### PR TITLE
feat(rewards): MALIBU bootstrap emission ledger (Session C / Phase C1)

### DIFF
--- a/phase4-coordinator/cmd/coordinator/main.go
+++ b/phase4-coordinator/cmd/coordinator/main.go
@@ -26,6 +26,7 @@ import (
 	"github.com/augstar/macprovider-coordinator/internal/pool"
 	"github.com/augstar/macprovider-coordinator/internal/providerhttp"
 	"github.com/augstar/macprovider-coordinator/internal/requestlog"
+	"github.com/augstar/macprovider-coordinator/internal/rewards"
 	"github.com/augstar/macprovider-coordinator/internal/stats"
 	statshardware "github.com/augstar/macprovider-coordinator/internal/stats/hardware"
 	statsmetrics "github.com/augstar/macprovider-coordinator/internal/stats/metrics"
@@ -344,6 +345,46 @@ func main() {
 		}
 		statsRollup.Start(shutdownCtx)
 		logger.Info().Str("backfill_mode", mode).Int64("partial_history_since_unix", partialUnix).Msg("SPEC-017 stats rollup started (overview/timeseries/leaderboards/rewards_populated/nightly_rebuild)")
+	}
+
+	// SPEC-MALIBU-EMISSION-LEDGER — bootstrap accrual worker (default-off).
+	var rewardsRunner *rewards.Runner
+	var rewardsDB *sql.DB
+	if cfg.MalibuEmission.Enabled {
+		var err error
+		rewardsDB, err = sql.Open("postgres", cfg.MalibuEmission.WriterDSN)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "malibu_emission: open writer pool: %v\n", err)
+			os.Exit(1)
+		}
+		rewardsDB.SetMaxOpenConns(4)
+		rewardsDB.SetMaxIdleConns(2)
+		rewardsDB.SetConnMaxLifetime(5 * time.Minute)
+		sqlitePath := strings.TrimSpace(cfg.MalibuEmission.SQLitePayoutDBPath)
+		if sqlitePath == "" {
+			sqlitePath = cfg.Storage.DBPath
+		}
+		rewardsCfg := rewards.Config{
+			Enabled:                true,
+			WriterDSN:              cfg.MalibuEmission.WriterDSN,
+			TickInterval:           time.Duration(cfg.MalibuEmission.TickIntervalSeconds) * time.Second,
+			ProviderDailyCapMALIBU: cfg.MalibuEmission.ProviderDailyCapMALIBU,
+			WalletDailyCapMALIBU:   cfg.MalibuEmission.WalletDailyCapMALIBU,
+			SQLitePayoutDBPath:     sqlitePath,
+			WalletMirrorInterval:   time.Duration(cfg.MalibuEmission.WalletMirrorIntervalSeconds) * time.Second,
+			UnlockEvalInterval:     time.Duration(cfg.MalibuEmission.UnlockEvalIntervalSeconds) * time.Second,
+			MaxSerializableRetries: cfg.MalibuEmission.MaxSerializableRetries,
+		}
+		rewardsRunner, err = rewards.New(rewardsDB, rewardsCfg, logger.With().Str("subsystem", "malibu_emission").Logger())
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "malibu_emission: %v\n", err)
+			os.Exit(1)
+		}
+		rewardsRunner.Start(shutdownCtx)
+		logger.Info().Msg("SPEC-MALIBU-EMISSION-LEDGER accrual runner started")
+		defer rewardsDB.Close()
+	} else {
+		logger.Info().Msg("malibu_emission DISABLED via config (default)")
 	}
 	// Round-3 ARCH r3 LOW 2 fix: defers run LIFO, so a non-signal
 	// return path would call `Wait()` BEFORE the
@@ -703,6 +744,7 @@ func main() {
 		cfg.Onboarding.AppTrackRegisterEnabled,
 		register,
 		hardwareEvidence,
+		malibuAccrualHandler(cfg, tokenStore, rewardsDB),
 	)
 
 	providerHTTP := newHTTPServer(providerAddr, providerMux)
@@ -983,15 +1025,34 @@ func operatorMetricsHandler(operatorKey string, registry *prom.Registry) http.Ha
 	})
 }
 
-func buyerHandlerWithOptionalProviderEndpoints(base http.Handler, enabled bool, register, hardwareEvidence http.HandlerFunc) http.Handler {
+func buyerHandlerWithOptionalProviderEndpoints(base http.Handler, enabled bool, register, hardwareEvidence http.HandlerFunc, malibuAccrual http.Handler) http.Handler {
 	mux := http.NewServeMux()
 	if enabled {
 		mux.HandleFunc("/v1/providers/register", register)
 		mux.HandleFunc("/v1/providers/hardware-evidence", hardwareEvidence)
 	}
 	mux.HandleFunc("/v1/provider/wallet", appTrackWalletNotImplementedHandler)
+	if malibuAccrual != nil {
+		mux.Handle("/v1/provider/malibu-accrual", malibuAccrual)
+	}
 	mux.Handle("/", base)
 	return mux
+}
+
+func malibuAccrualHandler(cfg config.Config, tokenStore *auth.Store, rewardsDB *sql.DB) http.Handler {
+	if rewardsDB == nil || !cfg.MalibuEmission.Enabled {
+		return nil
+	}
+	rewardsCfg := rewards.Config{
+		ProviderDailyCapMALIBU: cfg.MalibuEmission.ProviderDailyCapMALIBU,
+		WalletDailyCapMALIBU:   cfg.MalibuEmission.WalletDailyCapMALIBU,
+	}
+	return rewards.NewAccrualHandler(rewards.AccrualHandlerDeps{
+		DB:                    rewardsDB,
+		TokenStore:            tokenStore,
+		RequireProviderTokens: cfg.Auth.RequireProviderTokens,
+		Config:                rewardsCfg,
+	})
 }
 
 func appTrackWalletNotImplementedHandler(w http.ResponseWriter, r *http.Request) {

--- a/phase4-coordinator/cmd/coordinator/main_test.go
+++ b/phase4-coordinator/cmd/coordinator/main_test.go
@@ -102,7 +102,7 @@ func TestBuyerRegisterRouteFeatureGate(t *testing.T) {
 		w.WriteHeader(http.StatusAccepted)
 	})
 
-	disabled := buyerHandlerWithOptionalProviderEndpoints(base, false, register, hardwareEvidence)
+	disabled := buyerHandlerWithOptionalProviderEndpoints(base, false, register, hardwareEvidence, nil)
 	req := httptest.NewRequest(http.MethodPost, "/v1/providers/register", nil)
 	rr := httptest.NewRecorder()
 	disabled.ServeHTTP(rr, req)
@@ -123,7 +123,7 @@ func TestBuyerRegisterRouteFeatureGate(t *testing.T) {
 		t.Fatalf("disabled wallet route status=%d body=%s, want 501 wallet_change_requires_spec_027", rr.Code, rr.Body.String())
 	}
 
-	enabled := buyerHandlerWithOptionalProviderEndpoints(base, true, register, hardwareEvidence)
+	enabled := buyerHandlerWithOptionalProviderEndpoints(base, true, register, hardwareEvidence, nil)
 	rr = httptest.NewRecorder()
 	enabled.ServeHTTP(rr, req)
 	if rr.Code != http.StatusNoContent {

--- a/phase4-coordinator/dist/coordinator.yaml.example
+++ b/phase4-coordinator/dist/coordinator.yaml.example
@@ -272,6 +272,20 @@ stats:
     - "127.0.0.0/8"
     - "::1/128"
 
+# SPEC-MALIBU-EMISSION-LEDGER — bootstrap $MALIBU accrual (default-off).
+# Requires migration 012 on the stats/rewards Postgres DB before enable.
+malibu_emission:
+  enabled: false
+  # writer_dsn: env:MALIBU_EMISSION_WRITER_DSN
+  tick_interval_seconds: 900
+  provider_daily_cap_malibu: 25
+  wallet_daily_cap_malibu: 100
+  # Defaults to storage.db_path when unset (SPEC-016 payout address mirror source).
+  # sqlite_payout_db_path: "/var/lib/macprovider/coordinator.db"
+  wallet_mirror_interval_seconds: 300
+  unlock_eval_interval_seconds: 3600
+  max_serializable_retries: 5
+
 # Auto-update recommendation surface. The coordinator forwards
 # `latest_binary_version` to every connected provider in its
 # `auth_response` / `state_update` frame as `recommended_binary_version`.

--- a/phase4-coordinator/internal/config/config.go
+++ b/phase4-coordinator/internal/config/config.go
@@ -58,6 +58,7 @@ type Config struct {
 	Explorer                     ExplorerConfig               `yaml:"explorer"`
 	Stats                        StatsConfig                  `yaml:"stats"`
 	Onboarding                   OnboardingConfig             `yaml:"onboarding"`
+	MalibuEmission               MalibuEmissionConfig         `yaml:"malibu_emission"`
 	AutotuneFeeds                AutotuneFeedsConfig          `yaml:"autotune"`
 	Proxy                        ProxyConfig                  `yaml:"proxy"`
 	Providers                    []ProviderConfig             `yaml:"providers"`
@@ -80,6 +81,20 @@ type OnboardingConfig struct {
 	AppleTeamID             string            `yaml:"apple_team_id"`
 	CoordinatorDomain       string            `yaml:"coordinator_domain"`
 	ASNPrefixes             map[string]string `yaml:"asn_prefixes"`
+}
+
+// MalibuEmissionConfig gates SPEC-MALIBU-EMISSION-LEDGER bootstrap accrual.
+// Default-off; money-path changes require PR + audit.
+type MalibuEmissionConfig struct {
+	Enabled                    bool    `yaml:"enabled"`
+	WriterDSN                  string  `yaml:"writer_dsn"`
+	TickIntervalSeconds        int     `yaml:"tick_interval_seconds"`
+	ProviderDailyCapMALIBU     float64 `yaml:"provider_daily_cap_malibu"`
+	WalletDailyCapMALIBU       float64 `yaml:"wallet_daily_cap_malibu"`
+	SQLitePayoutDBPath         string  `yaml:"sqlite_payout_db_path"`
+	WalletMirrorIntervalSeconds int    `yaml:"wallet_mirror_interval_seconds"`
+	UnlockEvalIntervalSeconds  int     `yaml:"unlock_eval_interval_seconds"`
+	MaxSerializableRetries     int     `yaml:"max_serializable_retries"`
 }
 
 // AutotuneFeedsConfig points at the signed SPEC-023 recommendation feeds
@@ -767,6 +782,15 @@ func Default() Config {
 			BundleID:                "tech.malibu.app",
 			CoordinatorDomain:       "coordinator.streamvc.live",
 		},
+		MalibuEmission: MalibuEmissionConfig{
+			Enabled:                     false,
+			TickIntervalSeconds:         900,
+			ProviderDailyCapMALIBU:      25,
+			WalletDailyCapMALIBU:        100,
+			WalletMirrorIntervalSeconds: 300,
+			UnlockEvalIntervalSeconds:   3600,
+			MaxSerializableRetries:      5,
+		},
 		Explorer: ExplorerConfig{
 			Enabled:                       false,
 			BindPath:                      "/admin/explorer/",
@@ -867,6 +891,7 @@ func (c *Config) resolveEnv() error {
 		{"stats.provider_portal_dsn", &c.Stats.ProviderPortalDSN},
 		{"stats.partner_keys.writer_dsn", &c.Stats.PartnerKeys.WriterDSN},
 		{"stats.partner_keys_admin_dsn", &c.Stats.PartnerKeysAdminDSN},
+		{"malibu_emission.writer_dsn", &c.MalibuEmission.WriterDSN},
 	}
 	for _, f := range statsDSNs {
 		v, err := resolveEnvValue(f.field, *f.dst)
@@ -1337,6 +1362,9 @@ func (c Config) Validate() error {
 	if err := c.validateOnboarding(); err != nil {
 		return err
 	}
+	if err := c.validateMalibuEmission(); err != nil {
+		return err
+	}
 	if err := c.validateAutotuneFeeds(); err != nil {
 		return err
 	}
@@ -1441,6 +1469,35 @@ func (c Config) validateOnboarding() error {
 	}
 	if err := validateOperatorKeyMap(c.Auth.OperatorKeys); err != nil {
 		return err
+	}
+	return nil
+}
+
+func (c Config) validateMalibuEmission() error {
+	m := c.MalibuEmission
+	if !m.Enabled {
+		return nil
+	}
+	if strings.TrimSpace(m.WriterDSN) == "" {
+		return fmt.Errorf("malibu_emission.writer_dsn must be set when malibu_emission.enabled is true")
+	}
+	if m.TickIntervalSeconds <= 0 {
+		return fmt.Errorf("malibu_emission.tick_interval_seconds must be > 0")
+	}
+	if m.ProviderDailyCapMALIBU <= 0 {
+		return fmt.Errorf("malibu_emission.provider_daily_cap_malibu must be > 0")
+	}
+	if m.WalletDailyCapMALIBU <= 0 {
+		return fmt.Errorf("malibu_emission.wallet_daily_cap_malibu must be > 0")
+	}
+	if m.WalletMirrorIntervalSeconds <= 0 {
+		return fmt.Errorf("malibu_emission.wallet_mirror_interval_seconds must be > 0")
+	}
+	if m.UnlockEvalIntervalSeconds <= 0 {
+		return fmt.Errorf("malibu_emission.unlock_eval_interval_seconds must be > 0")
+	}
+	if m.MaxSerializableRetries <= 0 {
+		return fmt.Errorf("malibu_emission.max_serializable_retries must be > 0")
 	}
 	return nil
 }

--- a/phase4-coordinator/internal/rewards/emission.go
+++ b/phase4-coordinator/internal/rewards/emission.go
@@ -1,0 +1,375 @@
+package rewards
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"math"
+	"strings"
+	"time"
+
+	"github.com/lib/pq"
+)
+
+// RunEmissionTickOnce runs a single accrual tick (test/export hook).
+func (r *Runner) RunEmissionTickOnce(ctx context.Context) error {
+	return r.runEmissionTick(ctx)
+}
+
+// RunWalletMirrorOnce runs a single wallet projection sync.
+func (r *Runner) RunWalletMirrorOnce(ctx context.Context) error {
+	return r.runWalletMirror(ctx)
+}
+
+func (r *Runner) runEmissionTick(ctx context.Context) error {
+	providers, err := r.listEligibleProviders(ctx)
+	if err != nil {
+		return err
+	}
+	tickAmount := r.cfg.ProviderDailyCapMALIBU / r.ticksPerDay()
+	for _, pid := range providers {
+		if err := r.accrueProvider(ctx, pid, tickAmount); err != nil {
+			r.logger.Warn().Err(err).Str("provider_id", pid).Msg("accrual failed")
+		}
+	}
+	return nil
+}
+
+func (r *Runner) ticksPerDay() float64 {
+	secs := r.cfg.TickInterval.Seconds()
+	if secs <= 0 {
+		return 96 // 15m default
+	}
+	return 86400 / secs
+}
+
+func (r *Runner) listEligibleProviders(ctx context.Context) ([]string, error) {
+	// Seed emission state for App-track identities not yet seen.
+	if _, err := r.db.ExecContext(ctx, `
+        INSERT INTO provider_emission_state (provider_id, trust_tier)
+        SELECT i.provider_id, $1
+          FROM provider_identities i
+         WHERE NOT EXISTS (
+            SELECT 1 FROM provider_emission_state s WHERE s.provider_id = i.provider_id
+         )
+    `, TierProvisional); err != nil {
+		return nil, err
+	}
+	rows, err := r.db.QueryContext(ctx, `
+        SELECT provider_id FROM provider_emission_state
+    `)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var out []string
+	for rows.Next() {
+		var pid string
+		if err := rows.Scan(&pid); err != nil {
+			return nil, err
+		}
+		out = append(out, pid)
+	}
+	return out, rows.Err()
+}
+
+type providerState struct {
+	TrustTier             string
+	BoundWallet           sql.NullString
+	CapReplayPending      bool
+	ProviderDayMALIBU     float64
+	EmissionDay           sql.NullTime
+	DemotionCooldownUntil sql.NullTime
+}
+
+func (r *Runner) accrueProvider(ctx context.Context, providerID string, tickAmount float64) error {
+	if tickAmount <= 0 {
+		return nil
+	}
+	return r.withSerializableRetry(ctx, func(tx *sql.Tx) error {
+		if _, err := tx.ExecContext(ctx, `
+            INSERT INTO provider_emission_state (provider_id, trust_tier)
+            VALUES ($1, $2)
+            ON CONFLICT (provider_id) DO NOTHING
+        `, providerID, TierProvisional); err != nil {
+			return err
+		}
+		st, err := loadProviderState(ctx, tx, providerID)
+		if err != nil {
+			return err
+		}
+		today := utcDay(time.Now().UTC())
+		if !st.EmissionDay.Valid || !sameUTCDay(st.EmissionDay.Time, today) {
+			st.ProviderDayMALIBU = 0
+		}
+		remaining := r.cfg.ProviderDailyCapMALIBU - st.ProviderDayMALIBU
+		if remaining <= 0 {
+			return nil
+		}
+		accrue := math.Min(tickAmount, remaining)
+		if accrue <= 0 {
+			return nil
+		}
+
+		hold := holdReasonForState(st)
+		wallet := strings.ToLower(st.BoundWallet.String)
+		if wallet != "" && strings.HasPrefix(wallet, "0x") {
+			walletHeld, walletAccrue, err := applyWalletCap(ctx, tx, wallet, today, accrue, r.cfg.WalletDailyCapMALIBU, st.TrustTier)
+			if err != nil {
+				return err
+			}
+			if walletAccrue <= 0 {
+				return nil
+			}
+			accrue = walletAccrue
+			if walletHeld {
+				if hold == "" {
+					hold = HoldPerWalletDailyCap
+				}
+			}
+		}
+
+		var holdArg sql.NullString
+		if hold != "" {
+			holdArg = sql.NullString{String: hold, Valid: true}
+		}
+
+		now := time.Now().UTC()
+		if _, err := tx.ExecContext(ctx, `
+            INSERT INTO provider_rewards_ledger
+                (provider_id, unix_ts, amount_malibu, withdrawal_hold_reason, reason)
+            VALUES ($1, $2, $3, $4, 'malibu_bootstrap_tick')
+        `, providerID, now.Unix(), formatMALIBU(accrue), holdArg); err != nil {
+			return err
+		}
+
+		newDayTotal := st.ProviderDayMALIBU + accrue
+		if _, err := tx.ExecContext(ctx, `
+            INSERT INTO provider_emission_state
+                (provider_id, trust_tier, bound_wallet, provider_day_malibu, emission_day, updated_at)
+            VALUES ($1, $2, $3, $4, $5, $6)
+            ON CONFLICT (provider_id) DO UPDATE SET
+                provider_day_malibu = $4,
+                emission_day = $5,
+                updated_at = $6
+        `, providerID, st.TrustTier, nullString(st.BoundWallet), newDayTotal, today, now); err != nil {
+			return err
+		}
+
+		if wallet != "" && strings.HasPrefix(wallet, "0x") {
+			if err := bumpWalletDaily(ctx, tx, wallet, today, accrue); err != nil {
+				return err
+			}
+		}
+
+		if st.CapReplayPending && wallet != "" {
+			return replayCapPending(ctx, tx, wallet, r.cfg.WalletDailyCapMALIBU)
+		}
+		return nil
+	})
+}
+
+func holdReasonForState(st providerState) string {
+	if st.DemotionCooldownUntil.Valid && time.Now().UTC().Before(st.DemotionCooldownUntil.Time) {
+		return HoldDemotionCooldown
+	}
+	if st.TrustTier != TierTrusted {
+		return HoldTrustTierProvisional
+	}
+	return ""
+}
+
+func loadProviderState(ctx context.Context, tx *sql.Tx, providerID string) (providerState, error) {
+	var st providerState
+	err := tx.QueryRowContext(ctx, `
+        SELECT trust_tier, bound_wallet, cap_replay_pending,
+               provider_day_malibu::FLOAT8, emission_day, demotion_cooldown_until
+          FROM provider_emission_state
+         WHERE provider_id = $1
+         FOR UPDATE
+    `, providerID).Scan(
+		&st.TrustTier, &st.BoundWallet, &st.CapReplayPending,
+		&st.ProviderDayMALIBU, &st.EmissionDay, &st.DemotionCooldownUntil,
+	)
+	if err == sql.ErrNoRows {
+		return providerState{TrustTier: TierProvisional}, nil
+	}
+	return st, err
+}
+
+func applyWalletCap(ctx context.Context, tx *sql.Tx, wallet string, day time.Time, want float64, cap float64, tier string) (held bool, accrue float64, err error) {
+	sum, err := walletDaySum(ctx, tx, wallet, day)
+	if err != nil {
+		return false, 0, err
+	}
+	remaining := cap - sum
+	if remaining <= 0 {
+		// Still accrue at zero? Spec says accrue with hold when cap hit.
+		// Accrue the requested amount but mark held — caller sets hold.
+		return true, want, nil
+	}
+	if want > remaining {
+		return true, remaining, nil
+	}
+	_ = tier
+	return false, want, nil
+}
+
+func walletDaySum(ctx context.Context, tx *sql.Tx, wallet string, day time.Time) (float64, error) {
+	var sum sql.NullFloat64
+	err := tx.QueryRowContext(ctx, `
+        SELECT sum_malibu::FLOAT8
+          FROM wallet_daily_malibu_emission
+         WHERE bound_wallet = $1 AND emission_day = $2
+         FOR UPDATE
+    `, wallet, day).Scan(&sum)
+	if err == sql.ErrNoRows {
+		return 0, nil
+	}
+	if err != nil {
+		return 0, err
+	}
+	if !sum.Valid {
+		return 0, nil
+	}
+	return sum.Float64, nil
+}
+
+func bumpWalletDaily(ctx context.Context, tx *sql.Tx, wallet string, day time.Time, delta float64) error {
+	now := time.Now().UTC()
+	_, err := tx.ExecContext(ctx, `
+        INSERT INTO wallet_daily_malibu_emission (bound_wallet, emission_day, sum_malibu, updated_at)
+        VALUES ($1, $2, $3, $4)
+        ON CONFLICT (bound_wallet, emission_day) DO UPDATE SET
+            sum_malibu = wallet_daily_malibu_emission.sum_malibu + EXCLUDED.sum_malibu,
+            updated_at = EXCLUDED.updated_at
+    `, wallet, day, formatMALIBU(delta), now)
+	return err
+}
+
+func replayCapPending(ctx context.Context, tx *sql.Tx, wallet string, walletCap float64) error {
+	// Oldest-first replay: for trusted providers, clear per_wallet_daily_cap
+	// holds where aggregate now permits withdrawal.
+	rows, err := tx.QueryContext(ctx, `
+        SELECT prl.id, prl.amount_malibu::FLOAT8, pes.trust_tier
+          FROM provider_rewards_ledger prl
+          JOIN provider_emission_state pes ON pes.provider_id = prl.provider_id
+         WHERE pes.bound_wallet = $1
+           AND prl.withdrawal_hold_reason = $2
+           AND pes.trust_tier = $3
+         ORDER BY prl.unix_ts ASC, prl.id ASC
+         FOR UPDATE OF prl
+    `, wallet, HoldPerWalletDailyCap, TierTrusted)
+	if err != nil {
+		return err
+	}
+	defer rows.Close()
+
+	day := utcDay(time.Now().UTC())
+	var running float64
+	if s, err := walletDaySum(ctx, tx, wallet, day); err != nil {
+		return err
+	} else {
+		running = s
+	}
+
+	for rows.Next() {
+		var id int64
+		var amt float64
+		var tier string
+		if err := rows.Scan(&id, &amt, &tier); err != nil {
+			return err
+		}
+		if tier != TierTrusted {
+			continue
+		}
+		if running+amt <= walletCap {
+			if _, err := tx.ExecContext(ctx, `
+                UPDATE provider_rewards_ledger
+                   SET withdrawal_hold_reason = NULL
+                 WHERE id = $1
+            `, id); err != nil {
+				return err
+			}
+		}
+		running += amt
+	}
+	if err := rows.Err(); err != nil {
+		return err
+	}
+
+	_, err = tx.ExecContext(ctx, `
+        UPDATE provider_emission_state
+           SET cap_replay_pending = FALSE, updated_at = $2
+         WHERE bound_wallet = $1 AND cap_replay_pending = TRUE
+    `, wallet, time.Now().UTC())
+	return err
+}
+
+func (r *Runner) withSerializableRetry(ctx context.Context, fn func(*sql.Tx) error) error {
+	var lastErr error
+	for attempt := 0; attempt < r.cfg.MaxSerializableRetries; attempt++ {
+		if attempt > 0 {
+			backoff := time.Duration(10*(1<<attempt)) * time.Millisecond
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			case <-time.After(backoff):
+			}
+		}
+		tx, err := r.db.BeginTx(ctx, &sql.TxOptions{Isolation: sql.LevelSerializable})
+		if err != nil {
+			return err
+		}
+		err = fn(tx)
+		if err == nil {
+			if commitErr := tx.Commit(); commitErr != nil {
+				if isSerializationFailure(commitErr) {
+					lastErr = commitErr
+					continue
+				}
+				return commitErr
+			}
+			return nil
+		}
+		_ = tx.Rollback()
+		if isSerializationFailure(err) {
+			lastErr = err
+			continue
+		}
+		return err
+	}
+	if lastErr != nil {
+		return fmt.Errorf("serializable retries exhausted: %w", lastErr)
+	}
+	return errors.New("serializable retries exhausted")
+}
+
+func isSerializationFailure(err error) bool {
+	var pqErr *pq.Error
+	if errors.As(err, &pqErr) {
+		return pqErr.Code == "40001"
+	}
+	return false
+}
+
+func utcDay(t time.Time) time.Time {
+	y, m, d := t.Date()
+	return time.Date(y, m, d, 0, 0, 0, 0, time.UTC)
+}
+
+func sameUTCDay(a, b time.Time) bool {
+	return utcDay(a).Equal(utcDay(b))
+}
+
+func formatMALIBU(v float64) string {
+	return fmt.Sprintf("%.8f", v)
+}
+
+func nullString(ns sql.NullString) interface{} {
+	if ns.Valid {
+		return ns.String
+	}
+	return nil
+}

--- a/phase4-coordinator/internal/rewards/emission_integration_test.go
+++ b/phase4-coordinator/internal/rewards/emission_integration_test.go
@@ -1,0 +1,191 @@
+//go:build integration
+
+package rewards_test
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"testing"
+	"time"
+
+	_ "github.com/lib/pq"
+	tc "github.com/testcontainers/testcontainers-go"
+	tcpg "github.com/testcontainers/testcontainers-go/modules/postgres"
+	"github.com/testcontainers/testcontainers-go/wait"
+
+	"github.com/augstar/macprovider-coordinator/internal/rewards"
+	statsmigrations "github.com/augstar/macprovider-coordinator/internal/stats/migrations"
+	"github.com/rs/zerolog"
+)
+
+const (
+	pgImage             = "postgres:16.4-alpine3.20@sha256:5660c2cbfea50c7a9127d17dc4e48543eedd3d7a41a595a2dfa572471e37e64c"
+	roleRuntimePassword = "rewards-test-runtime-pw"
+	roleAdminPassword   = "rewards-test-admin-pw"
+)
+
+type pgFixture struct {
+	container tc.Container
+	host      string
+	port      string
+	dbName    string
+}
+
+func (f *pgFixture) adminDSN() string {
+	return fmt.Sprintf("postgres://postgres:%s@%s:%s/%s?sslmode=disable", roleAdminPassword, f.host, f.port, f.dbName)
+}
+
+func (f *pgFixture) roleDSN(role string) string {
+	return fmt.Sprintf("postgres://%s:%s@%s:%s/%s?sslmode=disable", role, roleRuntimePassword, f.host, f.port, f.dbName)
+}
+
+func startPostgres(t *testing.T) (*pgFixture, *sql.DB) {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 90*time.Second)
+	defer cancel()
+
+	c, err := tcpg.Run(ctx, pgImage,
+		tcpg.WithDatabase("rewards_test"),
+		tcpg.WithUsername("postgres"),
+		tcpg.WithPassword(roleAdminPassword),
+		tc.WithWaitStrategy(wait.ForLog("database system is ready to accept connections").WithOccurrence(2)),
+	)
+	if err != nil {
+		t.Fatalf("start postgres: %v", err)
+	}
+	host, err := c.Host(ctx)
+	if err != nil {
+		t.Fatalf("host: %v", err)
+	}
+	port, err := c.MappedPort(ctx, "5432/tcp")
+	if err != nil {
+		t.Fatalf("port: %v", err)
+	}
+	fx := &pgFixture{container: c, host: host, port: port.Port(), dbName: "rewards_test"}
+	adminDB, err := sql.Open("postgres", fx.adminDSN())
+	if err != nil {
+		t.Fatalf("open admin: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = adminDB.Close()
+		_ = c.Terminate(context.Background())
+	})
+	if err := statsmigrations.Apply(ctx, adminDB); err != nil {
+		t.Fatalf("apply migrations: %v", err)
+	}
+	if _, err := adminDB.ExecContext(ctx, fmt.Sprintf(
+		`ALTER ROLE rewards_writer WITH LOGIN PASSWORD '%s'`, roleRuntimePassword,
+	)); err != nil {
+		t.Fatalf("rotate rewards_writer: %v", err)
+	}
+	return fx, adminDB
+}
+
+func openRewardsWriter(t *testing.T, fx *pgFixture) *sql.DB {
+	t.Helper()
+	db, err := sql.Open("postgres", fx.roleDSN("rewards_writer"))
+	if err != nil {
+		t.Fatalf("open rewards_writer: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	return db
+}
+
+func TestProvisionalAccrualSetsWithdrawalHold(t *testing.T) {
+	fx, adminDB := startPostgres(t)
+	writerDB := openRewardsWriter(t, fx)
+	ctx := context.Background()
+
+	if _, err := writerDB.ExecContext(ctx, `
+        INSERT INTO provider_emission_state (provider_id, trust_tier)
+        VALUES ('p_test', 'provisional')
+    `); err != nil {
+		t.Fatalf("seed state: %v", err)
+	}
+
+	cfg := rewards.Config{
+		Enabled:                true,
+		TickInterval:           time.Hour,
+		ProviderDailyCapMALIBU: 25,
+		WalletDailyCapMALIBU:   100,
+		MaxSerializableRetries: 5,
+	}
+	runner, err := rewards.New(writerDB, cfg, zerolog.Nop())
+	if err != nil {
+		t.Fatalf("new runner: %v", err)
+	}
+	if err := runner.RunEmissionTickOnce(ctx); err != nil {
+		t.Fatalf("emission tick: %v", err)
+	}
+
+	var hold string
+	var amt string
+	if err := adminDB.QueryRowContext(ctx, `
+        SELECT withdrawal_hold_reason, amount_malibu::TEXT
+          FROM provider_rewards_ledger
+         WHERE provider_id = 'p_test'
+         ORDER BY id DESC LIMIT 1
+    `).Scan(&hold, &amt); err != nil {
+		t.Fatalf("query ledger: %v", err)
+	}
+	if hold != rewards.HoldTrustTierProvisional {
+		t.Fatalf("hold=%q want %q", hold, rewards.HoldTrustTierProvisional)
+	}
+	if amt == "" || amt == "0.00000000" {
+		t.Fatalf("expected positive accrual, got %q", amt)
+	}
+
+	rows, err := rewards.SelectWithdrawableMALIBU(ctx, writerDB, "p_test", 10)
+	if err != nil {
+		t.Fatalf("withdrawable select: %v", err)
+	}
+	if len(rows) != 0 {
+		t.Fatalf("provisional rows must not be withdrawable, got %d", len(rows))
+	}
+}
+
+func TestWalletDailyCapAcrossProviders(t *testing.T) {
+	fx, adminDB := startPostgres(t)
+	writerDB := openRewardsWriter(t, fx)
+	ctx := context.Background()
+
+	wallet := "0xabc123"
+	for _, pid := range []string{"p_a", "p_b"} {
+		if _, err := writerDB.ExecContext(ctx, `
+            INSERT INTO provider_emission_state (provider_id, trust_tier, bound_wallet)
+            VALUES ($1, 'provisional', $2)
+        `, pid, wallet); err != nil {
+			t.Fatalf("seed %s: %v", pid, err)
+		}
+	}
+
+	cfg := rewards.Config{
+		Enabled:                true,
+		TickInterval:           time.Minute,
+		ProviderDailyCapMALIBU: 1000,
+		WalletDailyCapMALIBU:   100,
+		MaxSerializableRetries: 5,
+	}
+	runner, err := rewards.New(writerDB, cfg, zerolog.Nop())
+	if err != nil {
+		t.Fatalf("new runner: %v", err)
+	}
+	for i := 0; i < 12; i++ {
+		if err := runner.RunEmissionTickOnce(ctx); err != nil {
+			t.Fatalf("tick %d: %v", i, err)
+		}
+	}
+
+	var sum float64
+	if err := adminDB.QueryRowContext(ctx, `
+        SELECT COALESCE(sum_malibu, 0)::FLOAT8
+          FROM wallet_daily_malibu_emission
+         WHERE bound_wallet = $1 AND emission_day = CURRENT_DATE
+    `, wallet).Scan(&sum); err != nil {
+		t.Fatalf("wallet sum: %v", err)
+	}
+	if sum > 100.0001 {
+		t.Fatalf("wallet aggregate %v exceeds cap 100", sum)
+	}
+}

--- a/phase4-coordinator/internal/rewards/emission_test.go
+++ b/phase4-coordinator/internal/rewards/emission_test.go
@@ -1,0 +1,41 @@
+package rewards_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/augstar/macprovider-coordinator/internal/rewards"
+)
+
+func TestConfigDefaultsAndValidate(t *testing.T) {
+	cfg := rewards.Config{Enabled: true, WriterDSN: "postgres://x", SQLitePayoutDBPath: "/tmp/x.db"}
+	applied := cfg.DefaultsApplied()
+	if applied.TickInterval != 15*time.Minute {
+		t.Fatalf("tick interval = %v", applied.TickInterval)
+	}
+	if applied.ProviderDailyCapMALIBU != 25 {
+		t.Fatalf("provider cap = %v", applied.ProviderDailyCapMALIBU)
+	}
+	if applied.WalletDailyCapMALIBU != 100 {
+		t.Fatalf("wallet cap = %v", applied.WalletDailyCapMALIBU)
+	}
+	if err := applied.Validate(); err != nil {
+		t.Fatalf("validate: %v", err)
+	}
+
+	disabled := rewards.Config{Enabled: false}
+	if err := disabled.Validate(); err != nil {
+		t.Fatalf("disabled validate: %v", err)
+	}
+
+	missing := rewards.Config{Enabled: true}
+	if err := missing.Validate(); err == nil {
+		t.Fatal("expected error for missing writer dsn")
+	}
+}
+
+func TestHoldReasonConstants(t *testing.T) {
+	if rewards.HoldTrustTierProvisional == "" {
+		t.Fatal("hold constant must be set")
+	}
+}

--- a/phase4-coordinator/internal/rewards/endpoints.go
+++ b/phase4-coordinator/internal/rewards/endpoints.go
@@ -1,0 +1,82 @@
+package rewards
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"net/http"
+	"strings"
+)
+
+type tokenValidator interface {
+	ValidateAndMarkTokenUsed(ctx context.Context, raw string) (subject string, ok bool, err error)
+}
+
+// AccrualHandlerDeps wires the provider MALIBU accrual endpoint.
+type AccrualHandlerDeps struct {
+	DB                    *sql.DB
+	TokenStore            tokenValidator
+	RequireProviderTokens bool
+	Config                Config
+}
+
+// NewAccrualHandler serves GET /v1/provider/malibu-accrual.
+func NewAccrualHandler(deps AccrualHandlerDeps) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			w.Header().Set("Allow", http.MethodGet)
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			_, _ = w.Write([]byte(`{"error":"method_not_allowed"}` + "\n"))
+			return
+		}
+		if !deps.RequireProviderTokens {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusServiceUnavailable)
+			_, _ = w.Write([]byte(`{"error":"unavailable"}` + "\n"))
+			return
+		}
+		raw := bearerToken(r.Header.Get("Authorization"))
+		if raw == "" || deps.TokenStore == nil {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusUnauthorized)
+			_, _ = w.Write([]byte(`{"error":"unauthorized"}` + "\n"))
+			return
+		}
+		providerID, ok, err := deps.TokenStore.ValidateAndMarkTokenUsed(r.Context(), raw)
+		if err != nil || !ok || providerID == "" {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusUnauthorized)
+			_, _ = w.Write([]byte(`{"error":"unauthorized"}` + "\n"))
+			return
+		}
+
+		bal, err := QueryAccrualBalance(r.Context(), deps.DB, providerID, deps.Config)
+		if err != nil {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusInternalServerError)
+			_, _ = w.Write([]byte(`{"error":"internal_error"}` + "\n"))
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("Cache-Control", "no-store")
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"provider_id":             providerID,
+			"accrued_malibu":          bal.AccruedMALIBU,
+			"withdrawable_malibu":     bal.WithdrawableMALIBU,
+			"held_malibu":             bal.HeldMALIBU,
+			"trust_tier":              bal.TrustTier,
+			"daily_cap_malibu":        bal.ProviderDailyCap,
+			"wallet_daily_cap_malibu": bal.WalletDailyCap,
+			"withdrawal_hold_reasons": bal.HoldReasons,
+		})
+	})
+}
+
+func bearerToken(header string) string {
+	const prefix = "Bearer "
+	if !strings.HasPrefix(header, prefix) {
+		return ""
+	}
+	return strings.TrimSpace(strings.TrimPrefix(header, prefix))
+}

--- a/phase4-coordinator/internal/rewards/rewards.go
+++ b/phase4-coordinator/internal/rewards/rewards.go
@@ -1,0 +1,227 @@
+// Package rewards implements SPEC-MALIBU-EMISSION-LEDGER bootstrap
+// accrual: periodic MALIBU emission, per-wallet caps, and withdrawal
+// hold enforcement. Money-path code — changes require PR + audit.
+package rewards
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/rs/zerolog"
+)
+
+// Hold reasons — closed vocabulary per spec §2.1.
+const (
+	HoldTrustTierProvisional = "trust_tier_provisional"
+	HoldPerWalletDailyCap    = "per_wallet_daily_cap"
+	HoldDemotionCooldown     = "demotion_cooldown"
+)
+
+// Trust tiers.
+const (
+	TierProvisional = "provisional"
+	TierTrusted     = "trusted"
+)
+
+// Config is the operator-tunable malibu_emission block.
+type Config struct {
+	Enabled                 bool
+	WriterDSN               string
+	TickInterval            time.Duration
+	ProviderDailyCapMALIBU  float64
+	WalletDailyCapMALIBU    float64
+	SQLitePayoutDBPath      string
+	WalletMirrorInterval    time.Duration
+	UnlockEvalInterval      time.Duration
+	MaxSerializableRetries  int
+}
+
+// DefaultsApplied fills zero values with spec defaults.
+func (c Config) DefaultsApplied() Config {
+	out := c
+	if out.TickInterval <= 0 {
+		out.TickInterval = 15 * time.Minute
+	}
+	if out.ProviderDailyCapMALIBU <= 0 {
+		out.ProviderDailyCapMALIBU = 25
+	}
+	if out.WalletDailyCapMALIBU <= 0 {
+		out.WalletDailyCapMALIBU = 100
+	}
+	if out.WalletMirrorInterval <= 0 {
+		out.WalletMirrorInterval = 5 * time.Minute
+	}
+	if out.UnlockEvalInterval <= 0 {
+		out.UnlockEvalInterval = time.Hour
+	}
+	if out.MaxSerializableRetries <= 0 {
+		out.MaxSerializableRetries = 5
+	}
+	return out
+}
+
+func (c Config) Validate() error {
+	if !c.Enabled {
+		return nil
+	}
+	if c.WriterDSN == "" {
+		return errors.New("malibu_emission.writer_dsn is required when enabled")
+	}
+	if c.SQLitePayoutDBPath == "" {
+		return errors.New("malibu_emission.sqlite_payout_db_path is required when enabled")
+	}
+	return nil
+}
+
+// Runner orchestrates emission tick, wallet mirror, and unlock evaluation.
+type Runner struct {
+	db     *sql.DB
+	cfg    Config
+	logger zerolog.Logger
+}
+
+// New constructs a Runner. db MUST be authenticated as rewards_writer.
+func New(db *sql.DB, cfg Config, logger zerolog.Logger) (*Runner, error) {
+	if db == nil {
+		return nil, errors.New("rewards: db is required")
+	}
+	applied := cfg.DefaultsApplied()
+	if err := applied.Validate(); err != nil {
+		return nil, err
+	}
+	return &Runner{db: db, cfg: applied, logger: logger}, nil
+}
+
+// Start launches background goroutines until ctx is cancelled.
+func (r *Runner) Start(ctx context.Context) {
+	go r.loop(ctx, r.cfg.TickInterval, "emission_tick", r.runEmissionTick)
+	go r.loop(ctx, r.cfg.WalletMirrorInterval, "wallet_mirror", r.runWalletMirror)
+	go r.loop(ctx, r.cfg.UnlockEvalInterval, "unlock_eval", r.runUnlockEval)
+}
+
+func (r *Runner) loop(ctx context.Context, interval time.Duration, name string, fn func(context.Context) error) {
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+	log := r.logger.With().Str("job", name).Logger()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			if err := fn(ctx); err != nil {
+				log.Warn().Err(err).Msg("rewards job failed")
+			}
+		}
+	}
+}
+
+// EnsureProviderState seeds emission state for a provider (idempotent).
+func EnsureProviderState(ctx context.Context, db *sql.DB, providerID string) error {
+	if providerID == "" {
+		return errors.New("provider_id is required")
+	}
+	_, err := db.ExecContext(ctx, `
+        INSERT INTO provider_emission_state (provider_id, trust_tier)
+        VALUES ($1, $2)
+        ON CONFLICT (provider_id) DO NOTHING
+    `, providerID, TierProvisional)
+	return err
+}
+
+// AccrualBalance returns total and withdrawable MALIBU for a provider.
+type AccrualBalance struct {
+	AccruedMALIBU       string
+	WithdrawableMALIBU  string
+	HeldMALIBU          string
+	TrustTier           string
+	HoldReasons         []string
+	ProviderDailyCap    float64
+	WalletDailyCap      float64
+}
+
+// QueryAccrualBalance reads ledger aggregates for the provider read API.
+func QueryAccrualBalance(ctx context.Context, db *sql.DB, providerID string, cfg Config) (AccrualBalance, error) {
+	cfg = cfg.DefaultsApplied()
+	var tier string
+	err := db.QueryRowContext(ctx, `
+        SELECT COALESCE(trust_tier, $2)
+          FROM provider_emission_state
+         WHERE provider_id = $1
+    `, providerID, TierProvisional).Scan(&tier)
+	if err == sql.ErrNoRows {
+		tier = TierProvisional
+	} else if err != nil {
+		return AccrualBalance{}, fmt.Errorf("trust tier: %w", err)
+	}
+
+	var accrued, withdrawable string
+	if err := db.QueryRowContext(ctx, `
+        SELECT COALESCE(SUM(amount_malibu), 0)::TEXT,
+               COALESCE(SUM(amount_malibu) FILTER (WHERE withdrawal_hold_reason IS NULL), 0)::TEXT
+          FROM provider_rewards_ledger
+         WHERE provider_id = $1 AND amount_malibu IS NOT NULL
+    `, providerID).Scan(&accrued, &withdrawable); err != nil {
+		return AccrualBalance{}, fmt.Errorf("ledger sum: %w", err)
+	}
+
+	rows, err := db.QueryContext(ctx, `
+        SELECT DISTINCT withdrawal_hold_reason
+          FROM provider_rewards_ledger
+         WHERE provider_id = $1
+           AND amount_malibu IS NOT NULL
+           AND withdrawal_hold_reason IS NOT NULL
+    `, providerID)
+	if err != nil {
+		return AccrualBalance{}, fmt.Errorf("hold reasons: %w", err)
+	}
+	defer rows.Close()
+	var holds []string
+	for rows.Next() {
+		var h string
+		if err := rows.Scan(&h); err != nil {
+			return AccrualBalance{}, err
+		}
+		holds = append(holds, h)
+	}
+	if err := rows.Err(); err != nil {
+		return AccrualBalance{}, err
+	}
+
+	held := subtractDecimalStrings(accrued, withdrawable)
+	return AccrualBalance{
+		AccruedMALIBU:      accrued,
+		WithdrawableMALIBU: withdrawable,
+		HeldMALIBU:         held,
+		TrustTier:          tier,
+		HoldReasons:        holds,
+		ProviderDailyCap:   cfg.ProviderDailyCapMALIBU,
+		WalletDailyCap:     cfg.WalletDailyCapMALIBU,
+	}, nil
+}
+
+func subtractDecimalStrings(a, b string) string {
+	// Simple numeric subtraction via Postgres-compatible formatting in caller tests;
+	// for display we use a lightweight approach when b <= a.
+	if a == "" || a == "0" {
+		return "0"
+	}
+	if b == "" || b == "0" {
+		return a
+	}
+	// Delegate to SQL in production path when needed; inline for read API is fine
+	// since both values come from the same SUM query above.
+	var held string
+	_ = held
+	// Use fmt for common case
+	var af, bf float64
+	fmt.Sscanf(a, "%f", &af)
+	fmt.Sscanf(b, "%f", &bf)
+	diff := af - bf
+	if diff < 0 {
+		diff = 0
+	}
+	return fmt.Sprintf("%.8f", diff)
+}

--- a/phase4-coordinator/internal/rewards/wallet_mirror.go
+++ b/phase4-coordinator/internal/rewards/wallet_mirror.go
@@ -1,0 +1,114 @@
+package rewards
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/augstar/macprovider-coordinator/internal/sqliteutil"
+	_ "modernc.org/sqlite"
+)
+
+// PayoutAddress row mirrored from SPEC-016 SQLite.
+type PayoutAddress struct {
+	ProviderID      string
+	Chain           string
+	Address         string
+	PayoutAllowed   int
+	RegisteredAtUTC time.Time
+}
+
+func (r *Runner) runWalletMirror(ctx context.Context) error {
+	source, err := sql.Open("sqlite", sqliteutil.ReadOnlyDSN(r.cfg.SQLitePayoutDBPath))
+	if err != nil {
+		return fmt.Errorf("open payout sqlite: %w", err)
+	}
+	defer source.Close()
+	source.SetMaxOpenConns(1)
+
+	if !tableExists(ctx, source, "provider_payout_addresses") {
+		// SPEC-016 payout table not deployed yet — mirror is a no-op.
+		return nil
+	}
+
+	rows, err := source.QueryContext(ctx, `
+        SELECT provider_id, chain, address, payout_allowed, registered_at_utc
+          FROM provider_payout_addresses
+    `)
+	if err != nil {
+		return fmt.Errorf("read payout addresses: %w", err)
+	}
+	defer rows.Close()
+
+	now := time.Now().UTC()
+	for rows.Next() {
+		var addr PayoutAddress
+		var registeredRaw string
+		if err := rows.Scan(&addr.ProviderID, &addr.Chain, &addr.Address, &addr.PayoutAllowed, &registeredRaw); err != nil {
+			return err
+		}
+		addr.Address = normalizeAddress(addr.Address)
+		reg, err := time.Parse(time.RFC3339, registeredRaw)
+		if err != nil {
+			reg = now
+		}
+		addr.RegisteredAtUTC = reg
+		if err := r.upsertProjection(ctx, addr, now); err != nil {
+			return err
+		}
+	}
+	return rows.Err()
+}
+
+func (r *Runner) upsertProjection(ctx context.Context, addr PayoutAddress, now time.Time) error {
+	return r.withSerializableRetry(ctx, func(tx *sql.Tx) error {
+		var prevAddr sql.NullString
+		err := tx.QueryRowContext(ctx, `
+            SELECT address FROM provider_payout_addresses_proj
+             WHERE provider_id = $1 AND chain = $2
+        `, addr.ProviderID, addr.Chain).Scan(&prevAddr)
+		firstBind := err == sql.ErrNoRows
+
+		_, err = tx.ExecContext(ctx, `
+            INSERT INTO provider_payout_addresses_proj
+                (provider_id, chain, address, payout_allowed, registered_at_utc, source_updated_at)
+            VALUES ($1, $2, $3, $4, $5, $6)
+            ON CONFLICT (provider_id, chain) DO UPDATE SET
+                address = EXCLUDED.address,
+                payout_allowed = EXCLUDED.payout_allowed,
+                registered_at_utc = EXCLUDED.registered_at_utc,
+                source_updated_at = EXCLUDED.source_updated_at
+        `, addr.ProviderID, addr.Chain, addr.Address, addr.PayoutAllowed, addr.RegisteredAtUTC, now)
+		if err != nil {
+			return err
+		}
+
+		replay := firstBind || (prevAddr.Valid && !strings.EqualFold(prevAddr.String, addr.Address))
+		_, err = tx.ExecContext(ctx, `
+            INSERT INTO provider_emission_state (provider_id, trust_tier, bound_wallet, cap_replay_pending)
+            VALUES ($1, $2, $3, $4)
+            ON CONFLICT (provider_id) DO UPDATE SET
+                bound_wallet = EXCLUDED.bound_wallet,
+                cap_replay_pending = CASE
+                    WHEN $4 THEN TRUE
+                    ELSE provider_emission_state.cap_replay_pending
+                END,
+                updated_at = $5
+        `, addr.ProviderID, TierProvisional, addr.Address, replay, now)
+		return err
+	})
+}
+
+func normalizeAddress(addr string) string {
+	return strings.ToLower(strings.TrimSpace(addr))
+}
+
+func tableExists(ctx context.Context, db *sql.DB, name string) bool {
+	var n string
+	err := db.QueryRowContext(ctx, `
+        SELECT name FROM sqlite_master WHERE type='table' AND name = ?
+    `, name).Scan(&n)
+	return err == nil && n == name
+}

--- a/phase4-coordinator/internal/rewards/withdrawal.go
+++ b/phase4-coordinator/internal/rewards/withdrawal.go
@@ -1,0 +1,72 @@
+package rewards
+
+import (
+	"context"
+	"database/sql"
+	"time"
+)
+
+// WithdrawableRow is a MALIBU ledger row eligible for withdrawal.
+type WithdrawableRow struct {
+	ID           int64
+	ProviderID   string
+	UnixTS       int64
+	AmountMALIBU string
+}
+
+// SelectWithdrawableMALIBU returns ledger rows with no withdrawal hold.
+// Used by the future MALIBU withdrawal runner per spec §4.5.
+func SelectWithdrawableMALIBU(ctx context.Context, db *sql.DB, providerID string, limit int) ([]WithdrawableRow, error) {
+	if limit <= 0 {
+		limit = 100
+	}
+	rows, err := db.QueryContext(ctx, `
+        SELECT id, provider_id, unix_ts, amount_malibu::TEXT
+          FROM provider_rewards_ledger
+         WHERE provider_id = $1
+           AND amount_malibu IS NOT NULL
+           AND amount_malibu > 0
+           AND withdrawal_hold_reason IS NULL
+         ORDER BY id ASC
+         LIMIT $2
+    `, providerID, limit)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var out []WithdrawableRow
+	for rows.Next() {
+		var row WithdrawableRow
+		if err := rows.Scan(&row.ID, &row.ProviderID, &row.UnixTS, &row.AmountMALIBU); err != nil {
+			return nil, err
+		}
+		out = append(out, row)
+	}
+	return out, rows.Err()
+}
+
+// SetTrustTier updates provider trust tier (unlock/demotion path).
+func SetTrustTier(ctx context.Context, db *sql.DB, providerID, tier string) error {
+	now := time.Now().UTC()
+	var cooldown interface{}
+	if tier == TierProvisional {
+		cooldown = now.Add(72 * time.Hour)
+	}
+	_, err := db.ExecContext(ctx, `
+        INSERT INTO provider_emission_state (provider_id, trust_tier, demotion_cooldown_until, updated_at)
+        VALUES ($1, $2, $3, $4)
+        ON CONFLICT (provider_id) DO UPDATE SET
+            trust_tier = EXCLUDED.trust_tier,
+            demotion_cooldown_until = EXCLUDED.demotion_cooldown_until,
+            updated_at = EXCLUDED.updated_at
+    `, providerID, tier, cooldown, now)
+	return err
+}
+
+// runUnlockEval is the Phase C2 skeleton — full E1/E2 automation deferred.
+func (r *Runner) runUnlockEval(ctx context.Context) error {
+	// v0.1: no-op evaluator; operators promote via admin SetTrustTier.
+	// Hook point for SPEC-026 §5.2 criteria evaluation.
+	_ = ctx
+	return nil
+}

--- a/phase4-coordinator/internal/stats/migrations/012_malibu_emission_ledger.up.sql
+++ b/phase4-coordinator/internal/stats/migrations/012_malibu_emission_ledger.up.sql
@@ -1,0 +1,122 @@
+-- SPEC-MALIBU-EMISSION-LEDGER v0.1.0 — MALIBU bootstrap emission schema.
+-- Extends provider_rewards_ledger; adds cap aggregate, per-provider state,
+-- payout-address projection, and rewards_writer role.
+
+-- ===== provider_rewards_ledger MALIBU extension =====
+ALTER TABLE provider_rewards_ledger
+    ALTER COLUMN amount_usd DROP NOT NULL;
+
+ALTER TABLE provider_rewards_ledger
+    ADD COLUMN IF NOT EXISTS amount_malibu NUMERIC(24,8) NULL,
+    ADD COLUMN IF NOT EXISTS withdrawal_hold_reason TEXT NULL;
+
+ALTER TABLE provider_rewards_ledger
+    DROP CONSTRAINT IF EXISTS provider_rewards_ledger_amount_check;
+
+ALTER TABLE provider_rewards_ledger
+    ADD CONSTRAINT provider_rewards_ledger_amount_check
+    CHECK (amount_usd IS NOT NULL OR amount_malibu IS NOT NULL);
+
+ALTER TABLE provider_rewards_ledger
+    DROP CONSTRAINT IF EXISTS provider_rewards_ledger_hold_reason_check;
+
+ALTER TABLE provider_rewards_ledger
+    ADD CONSTRAINT provider_rewards_ledger_hold_reason_check
+    CHECK (
+        withdrawal_hold_reason IS NULL
+        OR withdrawal_hold_reason IN (
+            'trust_tier_provisional',
+            'per_wallet_daily_cap',
+            'demotion_cooldown'
+        )
+    );
+
+CREATE INDEX IF NOT EXISTS provider_rewards_ledger_malibu_pid_ts_idx
+    ON provider_rewards_ledger (provider_id, unix_ts)
+    WHERE amount_malibu IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS provider_rewards_ledger_withdrawable_malibu_idx
+    ON provider_rewards_ledger (provider_id)
+    WHERE amount_malibu IS NOT NULL AND withdrawal_hold_reason IS NULL;
+
+-- ===== wallet_daily_malibu_emission aggregate =====
+CREATE TABLE IF NOT EXISTS wallet_daily_malibu_emission (
+    bound_wallet  TEXT NOT NULL,
+    emission_day  DATE NOT NULL,
+    sum_malibu    NUMERIC(24,8) NOT NULL DEFAULT 0 CHECK (sum_malibu >= 0),
+    updated_at    TIMESTAMPTZ NOT NULL DEFAULT now(),
+    PRIMARY KEY (bound_wallet, emission_day)
+);
+
+-- ===== provider_emission_state cross-track =====
+CREATE TABLE IF NOT EXISTS provider_emission_state (
+    provider_id             TEXT PRIMARY KEY,
+    trust_tier              TEXT NOT NULL DEFAULT 'provisional'
+                            CHECK (trust_tier IN ('provisional', 'trusted')),
+    bound_wallet            TEXT NULL,
+    cap_replay_pending      BOOLEAN NOT NULL DEFAULT FALSE,
+    provider_day_malibu     NUMERIC(24,8) NOT NULL DEFAULT 0 CHECK (provider_day_malibu >= 0),
+    emission_day            DATE NULL,
+    demotion_cooldown_until TIMESTAMPTZ NULL,
+    updated_at              TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS provider_emission_state_wallet_idx
+    ON provider_emission_state (bound_wallet)
+    WHERE bound_wallet IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS provider_emission_state_cap_replay_idx
+    ON provider_emission_state (cap_replay_pending)
+    WHERE cap_replay_pending = TRUE;
+
+-- ===== SPEC-016 payout address Postgres projection =====
+CREATE TABLE IF NOT EXISTS provider_payout_addresses_proj (
+    provider_id       TEXT NOT NULL,
+    chain             TEXT NOT NULL CHECK (chain = 'base-mainnet'),
+    address           TEXT NOT NULL,
+    payout_allowed    INTEGER NOT NULL DEFAULT 1 CHECK (payout_allowed IN (0, 1)),
+    registered_at_utc TIMESTAMPTZ NOT NULL,
+    source_updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    PRIMARY KEY (provider_id, chain)
+);
+
+CREATE INDEX IF NOT EXISTS provider_payout_addresses_proj_address_idx
+    ON provider_payout_addresses_proj (address);
+
+-- ===== rewards_writer role =====
+DO $$
+BEGIN
+    IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'rewards_writer') THEN
+        CREATE ROLE rewards_writer NOLOGIN;
+    END IF;
+END
+$$;
+
+GRANT USAGE ON SCHEMA public TO rewards_writer;
+
+GRANT SELECT, INSERT ON provider_rewards_ledger TO rewards_writer;
+GRANT USAGE, SELECT ON SEQUENCE provider_rewards_ledger_id_seq TO rewards_writer;
+
+GRANT SELECT, INSERT, UPDATE ON wallet_daily_malibu_emission TO rewards_writer;
+GRANT SELECT, INSERT, UPDATE ON provider_emission_state TO rewards_writer;
+GRANT SELECT, INSERT, UPDATE ON provider_payout_addresses_proj TO rewards_writer;
+GRANT SELECT ON provider_identities TO rewards_writer;
+
+-- Explicit denies: rewards_writer must not touch rollup internals or partner keys.
+REVOKE ALL ON
+    stats_overview_current,
+    stats_timeseries_rpm_30m,
+    stats_timeseries_tpm_30m,
+    stats_leaderboard_24h,
+    stats_leaderboard_7d,
+    stats_leaderboard_30d,
+    stats_leaderboard_all,
+    stats_components_health,
+    stats_late_events,
+    stats_rewards_populated,
+    partner_keys,
+    provider_visibility,
+    provider_visibility_audit
+FROM rewards_writer;
+
+-- stats_rollup keeps SELECT-only on provider_rewards_ledger (unchanged from 004).

--- a/phase4-coordinator/internal/stats/migrations/migrations_test.go
+++ b/phase4-coordinator/internal/stats/migrations/migrations_test.go
@@ -32,6 +32,7 @@ func TestEmbeddedMigrationsLoad(t *testing.T) {
 		{9, "provider_auth_policy_approve_fix"},
 		{10, "partner_keys_provider_id"},
 		{11, "idle_prewarm_events"},
+		{12, "malibu_emission_ledger"},
 	}
 	if len(all) != len(want) {
 		t.Fatalf("got %d migrations, want %d", len(all), len(want))

--- a/specs/SPEC-MALIBU-EMISSION-LEDGER.md
+++ b/specs/SPEC-MALIBU-EMISSION-LEDGER.md
@@ -1,0 +1,260 @@
+# SPEC-MALIBU-EMISSION-LEDGER — $MALIBU bootstrap rewards emission
+
+**Version:** 0.1.0 (2026-07-08)  
+**Status:** DRAFT — implementation target for Session C (`ops/runbooks/malibu-bootstrap-emission.md`)  
+**Depends on:** SPEC-026 v0.13 §5.1–§5.2, §5.5, §10 step 8; SPEC-017 v0.1.8 (`provider_rewards_ledger`); SPEC-016 v0.1.19 (`provider_payout_addresses` projection); SPEC-022 (verified-receipt-only USDC earnings)
+
+**Note on numbering:** SPEC-026 prose references "SPEC-028 (MALIBU rewards emission ledger)". The repo's `SPEC-028-mlx-speculative-decoding.md` is unrelated MLX work. This document is the authoritative emission-ledger spec under the name `SPEC-MALIBU-EMISSION-LEDGER`.
+
+---
+
+## 1. Purpose
+
+Accrue **$MALIBU** for early Malibu providers to bootstrap network growth, with **enforceable** sybil defenses:
+
+- Provisional tier accrual is **non-withdrawable** until Trusted.
+- Per-wallet daily cap applies across all `provider_id`s sharing a bound payout address.
+- Withdrawal runners MUST filter on `withdrawal_hold_reason IS NULL`.
+
+USDC payout semantics remain in SPEC-016; this spec owns MALIBU accrual only.
+
+---
+
+## 2. Schema (Postgres stats / rewards DB)
+
+All objects live on the same Postgres database as SPEC-017 stats tables (`provider_rewards_ledger`).
+
+### 2.1 `provider_rewards_ledger` extension
+
+Migration extends the existing table:
+
+| Column | Type | Semantics |
+|--------|------|-----------|
+| `amount_usd` | `NUMERIC(18,2) NULL` | Legacy operator USD rewards; nullable after migration |
+| `amount_malibu` | `NUMERIC(24,8) NULL` | MALIBU accrual for this row; NULL for USD-only rows |
+| `withdrawal_hold_reason` | `TEXT NULL` | When non-NULL, row is accrual-visible but **not** withdrawable |
+
+Constraint: at least one of `amount_usd`, `amount_malibu` MUST be non-NULL.
+
+**Hold reason vocabulary (closed set):**
+
+| Value | Meaning |
+|-------|---------|
+| `trust_tier_provisional` | Provider is Provisional; accrues but cannot withdraw MALIBU |
+| `per_wallet_daily_cap` | Wallet aggregate cap reached; accrual continues for visibility but is held |
+| `demotion_cooldown` | Provider demoted from Trusted; 72h requalification window (SPEC-026 §5.5) |
+
+Withdrawal selection: `WHERE withdrawal_hold_reason IS NULL AND amount_malibu IS NOT NULL AND amount_malibu > 0`.
+
+### 2.2 `wallet_daily_malibu_emission`
+
+Aggregate cap enforcement table:
+
+```sql
+CREATE TABLE wallet_daily_malibu_emission (
+    bound_wallet  TEXT NOT NULL,          -- EIP-55 lowercase hex, 0x-prefixed
+    emission_day  DATE NOT NULL,          -- UTC calendar day
+    sum_malibu    NUMERIC(24,8) NOT NULL DEFAULT 0,
+    updated_at    TIMESTAMPTZ NOT NULL DEFAULT now(),
+    PRIMARY KEY (bound_wallet, emission_day)
+);
+```
+
+Cap value is **config-backed** (default **100 MALIBU / bound wallet / UTC day**).
+
+### 2.3 `provider_emission_state`
+
+Per-provider cross-track state:
+
+```sql
+CREATE TABLE provider_emission_state (
+    provider_id           TEXT PRIMARY KEY,
+    trust_tier            TEXT NOT NULL DEFAULT 'provisional'
+                          CHECK (trust_tier IN ('provisional', 'trusted')),
+    bound_wallet          TEXT NULL,      -- canonical payout address projection
+    cap_replay_pending    BOOLEAN NOT NULL DEFAULT FALSE,
+    provider_day_malibu   NUMERIC(24,8) NOT NULL DEFAULT 0,  -- today's accrual for per-provider cap
+    emission_day          DATE NULL,      -- UTC day provider_day_malibu applies to
+    demotion_cooldown_until TIMESTAMPTZ NULL,
+    updated_at            TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+```
+
+`cap_replay_pending` is set TRUE on first wallet bind; cleared after oldest-first replay through the wallet cap under the aggregate lock (§4.3).
+
+### 2.4 `provider_payout_addresses_proj`
+
+Postgres projection of SPEC-016 SQLite `provider_payout_addresses`:
+
+```sql
+CREATE TABLE provider_payout_addresses_proj (
+    provider_id      TEXT NOT NULL,
+    chain            TEXT NOT NULL CHECK (chain = 'base-mainnet'),
+    address          TEXT NOT NULL,       -- EIP-55 normalized lowercase
+    payout_allowed   INTEGER NOT NULL DEFAULT 1,
+    registered_at_utc TIMESTAMPTZ NOT NULL,
+    source_updated_at TIMESTAMPTZ NOT NULL,
+    PRIMARY KEY (provider_id, chain)
+);
+```
+
+Maintained by the wallet-mirror worker (§4.2). Staleness is monitored via mirror heartbeat, not row age alone.
+
+### 2.5 `rewards_writer` Postgres role
+
+Dedicated runtime role for emission writes:
+
+- `INSERT` on `provider_rewards_ledger`, `wallet_daily_malibu_emission`, `provider_emission_state`
+- `UPDATE` on `wallet_daily_malibu_emission`, `provider_emission_state`
+- `SELECT` on projection + ledger + state tables
+- **No** `DELETE`, `TRUNCATE`, or DDL
+- Emission transactions run at **`SERIALIZABLE`** isolation with **retry-on-40001** (max 5 attempts, exponential backoff 10–160ms)
+
+`stats_rollup` retains `SELECT` on `provider_rewards_ledger` only; it MUST NOT write MALIBU rows.
+
+---
+
+## 3. Emission rules (provisional tier)
+
+| Rule | Default (config-backed) |
+|------|-------------------------|
+| Per-provider daily accrual cap | **25 MALIBU / provider_id / UTC day** |
+| Per-wallet daily aggregate cap | **100 MALIBU / bound wallet / UTC day** |
+| Withdrawable | **No** until `trust_tier = trusted` |
+| Hold reason (provisional accrual) | `trust_tier_provisional` |
+| Hold reason (wallet cap exceeded) | `per_wallet_daily_cap` (accrue but non-withdrawable) |
+
+Trusted providers accrue with `withdrawal_hold_reason IS NULL` unless wallet cap applies (`per_wallet_daily_cap`).
+
+**Retroactive unlock rule:** Tier transition to Trusted clears holds on **new** accrual rows only. Existing ledger rows retain their original `withdrawal_hold_reason`; operators MAY run a one-shot reconciliation job to clear holds on pre-unlock rows (out of v0.1 scope).
+
+---
+
+## 4. Workers
+
+### 4.1 Emission tick (periodic)
+
+- Default interval: **15 minutes** (`malibu_emission.tick_interval`)
+- Gated by `malibu_emission.enabled` (default `false`)
+- Per tick, per eligible `provider_id`:
+  1. Resolve `bound_wallet` from `provider_payout_addresses_proj` (NULL if unbound — per-provider cap still applies; wallet cap skipped)
+  2. Compute tick accrual: `provider_daily_cap / ticks_per_day`
+  3. Under SERIALIZABLE txn + wallet/provider day counters:
+     - If `provider_day_malibu + tick > provider_daily_cap`, accrue remainder only
+     - If bound wallet set and `wallet sum + accrual > wallet_daily_cap`, accrue remainder with `per_wallet_daily_cap` hold on overflow portion
+     - Insert `provider_rewards_ledger` row
+     - Upsert aggregates
+
+Eligibility: provider MUST exist in `provider_emission_state` (seeded at App-track register and lazily on first tick for legacy CLI providers).
+
+Optional gate (hook only, v0.1): when `opoi_liveness_ok = false` for a canary cohort, skip accrual for that provider (Session A integration point).
+
+### 4.2 Wallet-bind mirror
+
+Periodic poll of SQLite `provider_payout_addresses` (same DB as `ledger_payout_ready` per SPEC-016 §3.1) into `provider_payout_addresses_proj`.
+
+On first bind for a `provider_id`:
+
+1. Set `provider_emission_state.bound_wallet`
+2. Set `cap_replay_pending = TRUE`
+
+### 4.3 Cap replay at wallet bind
+
+When `cap_replay_pending = TRUE`, under the same SERIALIZABLE lock as live emissions:
+
+1. Select held accrual rows for all `provider_id`s sharing the wallet, oldest `unix_ts` first
+2. Re-evaluate against wallet cap; clear `per_wallet_daily_cap` hold where cap now permits withdrawal (Trusted tier only)
+3. Clear `cap_replay_pending`
+
+### 4.4 Trusted unlock evaluator (Phase C2)
+
+Coordinator job evaluates SPEC-026 §5.2 criteria:
+
+- At least **one economic** (E1/E2/E3) **and one distinct additional** criterion
+- On unlock: `trust_tier → trusted`; new accruals omit `trust_tier_provisional` hold
+- On demotion (§5.5): `trust_tier → provisional`, set `demotion_cooldown_until = now() + 72h`, new rows get `demotion_cooldown` hold until cooldown elapses
+
+v0.1 ships unlock evaluator skeleton with manual `trust_tier` override admin path; full E1/E2 automation is follow-up within C2.
+
+### 4.5 Withdrawal runner filter
+
+Any MALIBU withdrawal query (future SPEC-016 extension or dedicated runner) MUST include:
+
+```sql
+WHERE withdrawal_hold_reason IS NULL
+```
+
+USDC `ledger_payout_ready` runner is unchanged.
+
+---
+
+## 5. Provider read API
+
+`GET /v1/provider/malibu-accrual` (provider-token auth):
+
+```json
+{
+  "accrued_malibu": "12.50000000",
+  "withdrawable_malibu": "0",
+  "held_malibu": "12.50000000",
+  "trust_tier": "provisional",
+  "daily_cap_malibu": "25",
+  "wallet_daily_cap_malibu": "100",
+  "withdrawal_hold_reasons": ["trust_tier_provisional"]
+}
+```
+
+`withdrawable_malibu` sums ledger rows where `withdrawal_hold_reason IS NULL`.
+
+---
+
+## 6. Config (`coordinator.yaml`)
+
+```yaml
+malibu_emission:
+  enabled: false
+  writer_dsn: ""                    # rewards_writer role; env override MALIBU_EMISSION_WRITER_DSN
+  tick_interval: 15m
+  provider_daily_cap_malibu: 25
+  wallet_daily_cap_malibu: 100
+  sqlite_payout_db_path: ""         # defaults to storage.db_path; SPEC-016 payout table source
+  wallet_mirror_interval: 5m
+  unlock_eval_interval: 1h
+  max_serializable_retries: 5
+```
+
+Rollback: set `malibu_emission.enabled: false`; accrual rows freeze, tier transitions stop.
+
+---
+
+## 7. Malibu app integration (Phase C3 — contract only)
+
+| Surface | Field / copy |
+|---------|----------------|
+| Control socket | `metricsResponse.malibuAccrued` |
+| Success card | "Provisional — earn up to 25 MALIBU/day (non-withdrawable until Trusted)" |
+| Lock icon | All MALIBU displays when `trust_tier != trusted` |
+
+Coordinator → CLI metrics wiring is C3; this spec defines the read API in §5.
+
+---
+
+## 8. Acceptance criteria (Phase C1)
+
+- [ ] Provisional provider accrues MALIBU with `withdrawal_hold_reason = trust_tier_provisional`
+- [ ] Second `provider_id` on same wallet cannot exceed 100 MALIBU/day wallet aggregate
+- [ ] Withdrawal helper returns zero rows for held accrual
+- [ ] `rewards_writer` cannot SELECT from `partner_keys` or write `stats_*` rollup tables
+- [ ] Migration is idempotent; existing `amount_usd` leaderboard rollup continues to work
+
+---
+
+## 9. Open questions
+
+1. Cohort telemetry may adjust 100 MALIBU/day wallet cap (SPEC-026 §13).
+2. Event-driven accrual (per verified receipt) vs periodic tick — v0.1 uses tick; receipt-gated accrual is v0.2 candidate.
+3. On-chain MALIBU withdrawal rail — out of scope; this spec is ledger-only.
+
+---
+
+*End of SPEC-MALIBU-EMISSION-LEDGER v0.1.0.*


### PR DESCRIPTION
## Summary
- Adds normative `specs/SPEC-MALIBU-EMISSION-LEDGER.md` implementing SPEC-026 §5.1 enforcement primitives (ledger extension, wallet daily cap, emission state, payout-address projection, `rewards_writer` role).
- Ships Postgres migration `012_malibu_emission_ledger` and `internal/rewards` worker: periodic accrual with `withdrawal_hold_reason`, SERIALIZABLE cap enforcement, wallet-bind mirror/replay hooks, and withdrawable-row filter helper.
- Wires `malibu_emission` config (default-off), coordinator runner startup, and `GET /v1/provider/malibu-accrual` provider read API.

## Test plan
- [x] `go test ./internal/rewards/... ./internal/stats/migrations/... ./cmd/coordinator/...`
- [ ] Integration: `go test -tags=integration ./internal/rewards/...` (Postgres testcontainers)
- [ ] Operator: apply migration 012 on Pearl rewards DB, set `malibu_emission.enabled: false` until C2 unlock verified
- [ ] Audit loop (code + security + architect) before production accrual enable

## Out of scope (follow-up PRs)
- Phase C2: full SPEC-026 §5.2 trusted unlock automation
- Phase C3: Malibu app `malibuAccrued` control-socket wiring
- Phase C4: production rollout with `malibu_emission.enabled: true`


Made with [Cursor](https://cursor.com)