### PR TITLE
docs(ops): OPoI v0 Pearl deploy runbook and script

### DIFF
--- a/ops/runbooks/opoi-challenge-implementation.md
+++ b/ops/runbooks/opoi-challenge-implementation.md
@@ -81,6 +81,8 @@ Maintain per-model challenge entries if templates differ (tokenizer quirks). Sta
 
 ### 2.4 Rollout
 
+**Full Pearl procedure:** [`opoi-pearl-deploy.md`](./opoi-pearl-deploy.md) (build, systemd drop-in, scripted deploy).
+
 1. Enable on **staging** coordinator with 1–2 lab providers.
 2. Watch logs: `provider canary passed` / `provider canary failed`.
 3. Confirm degraded provider drops out of `/poolz` routing (`RoutingEligible` false).

--- a/ops/runbooks/opoi-pearl-deploy.md
+++ b/ops/runbooks/opoi-pearl-deploy.md
@@ -1,0 +1,227 @@
+# Runbook: OPoI v0 Pearl deploy (Session A)
+
+**Version:** 0.1  
+**Date:** 2026-07-08  
+**Audience:** Operator  
+**Prerequisite:** PR [#478](https://github.com/Augustas11/macprovider/pull/478) merged to `main` (`--config-overlay`, `--validate-config`)  
+**Parent:** [`opoi-challenge-implementation.md`](./opoi-challenge-implementation.md) §2.4–2.6
+
+---
+
+## 0. What this deploy does
+
+| Changes | Does NOT change |
+|---------|-----------------|
+| `/opt/macprovider/coordinator` binary (linux/amd64) | `/opt/macprovider/coordinator.yaml` base file |
+| `/etc/macprovider/coordinator.opoi-v0-staging.yaml` overlay | nginx / TLS / gateway |
+| systemd drop-in with `--config-overlay` | Full `deploy-pearl-vps.sh` path |
+
+Canaries enable via overlay only — rollback removes drop-in without editing production YAML.
+
+---
+
+## 1. Preconditions
+
+- [ ] `main` includes `LoadWithOverlay` + CLI flags (merged #478)
+- [ ] Pearl SSH key: `~/.ssh/pearl_operator_ed25519` (or set `SSH_KEY`)
+- [ ] Pearl host: `159.223.165.194` (`coordinator.streamvc.live`)
+- [ ] `/etc/macprovider/coordinator.env` present on Pearl (secrets)
+- [ ] **1–2 lab providers** ready to observe (Malibu on your Mac counts)
+- [ ] Prefer **zero connected providers** at restart, or set `FORCE_RESTART=1`
+
+---
+
+## 2. Quick deploy (scripted)
+
+From a clean checkout of `origin/main`:
+
+```bash
+cd phase4-coordinator
+bash scripts/build-linux.sh
+bash dist/deploy-opoi-v0-pearl.sh
+```
+
+Dry run:
+
+```bash
+DRY_RUN=1 bash dist/deploy-opoi-v0-pearl.sh
+```
+
+With providers connected (drain will run):
+
+```bash
+FORCE_RESTART=1 bash dist/deploy-opoi-v0-pearl.sh
+```
+
+---
+
+## 3. Manual deploy (step-by-step)
+
+### 3.1 Build binary (operator Mac)
+
+```bash
+cd phase4-coordinator
+bash scripts/build-linux.sh
+# → dist/coordinator-linux-amd64 @ <git describe>
+```
+
+Cross-compile only (no sidecars required for OPoI):
+
+```bash
+cd phase4-coordinator
+VERSION="$(git describe --always --dirty --tags)"
+GOOS=linux GOARCH=amd64 go build \
+  -ldflags "-X main.version=${VERSION}" \
+  -o dist/coordinator-linux-amd64 ./cmd/coordinator
+```
+
+### 3.2 Upload artifacts
+
+```bash
+SSH_KEY=~/.ssh/pearl_operator_ed25519
+PEARL=root@159.223.165.194
+
+scp -i "$SSH_KEY" dist/coordinator-linux-amd64 "$PEARL:/tmp/coordinator-linux-amd64"
+scp -i "$SSH_KEY" coordinator.opoi-v0-staging.yaml "$PEARL:/etc/macprovider/"
+scp -i "$SSH_KEY" dist/systemd/opoi-v0.conf.example "$PEARL:/tmp/opoi-v0.conf"
+```
+
+### 3.3 Install on Pearl
+
+```bash
+ssh -i "$SSH_KEY" "$PEARL" 'set -e
+  # Binary snapshot for rollback
+  if [ -x /opt/macprovider/coordinator ]; then
+    install -o root -g macprovider -m 0750 \
+      /opt/macprovider/coordinator /opt/macprovider/coordinator.prev
+  fi
+  install -o root -g macprovider -m 0750 \
+    /tmp/coordinator-linux-amd64 /opt/macprovider/coordinator
+  install -o root -g macprovider -m 0640 \
+    /etc/macprovider/coordinator.opoi-v0-staging.yaml \
+    /etc/macprovider/coordinator.opoi-v0-staging.yaml
+  install -d -m 0755 /etc/systemd/system/macprovider-coordinator.service.d
+  install -m 0644 /tmp/opoi-v0.conf \
+    /etc/systemd/system/macprovider-coordinator.service.d/opoi-v0.conf
+'
+```
+
+### 3.4 Validate config (no daemon start)
+
+```bash
+ssh -i "$SSH_KEY" "$PEARL" \
+  '/opt/macprovider/coordinator \
+    --config /opt/macprovider/coordinator.yaml \
+    --config-overlay /etc/macprovider/coordinator.opoi-v0-staging.yaml \
+    --validate-config'
+# expect: config: ok
+```
+
+### 3.5 Restart
+
+```bash
+ssh -i "$SSH_KEY" "$PEARL" \
+  'systemctl daemon-reload && systemctl restart macprovider-coordinator && systemctl is-active macprovider-coordinator'
+```
+
+---
+
+## 4. systemd drop-in reference
+
+File: `/etc/systemd/system/macprovider-coordinator.service.d/opoi-v0.conf`
+
+```ini
+[Service]
+ExecStart=
+ExecStart=/opt/macprovider/coordinator \
+  --config /opt/macprovider/coordinator.yaml \
+  --config-overlay /etc/macprovider/coordinator.opoi-v0-staging.yaml
+```
+
+Source template: `phase4-coordinator/dist/systemd/opoi-v0.conf.example`
+
+Base unit (unchanged): `phase4-coordinator/dist/macprovider-coordinator.service`
+
+---
+
+## 5. Verification (§2.5–2.6)
+
+### 5.1 Health + version
+
+```bash
+curl -sS https://coordinator.streamvc.live/healthz | jq '{version, pool_size}'
+```
+
+Version should match local `git describe` from the build tree.
+
+### 5.2 Canary logs (wait up to `canary_interval_s` = 300s)
+
+```bash
+ssh -i ~/.ssh/pearl_operator_ed25519 root@159.223.165.194 \
+  'journalctl -u macprovider-coordinator --since "10 min ago" --no-pager' \
+  | grep -E 'canary (passed|failed|skipped)'
+```
+
+### 5.3 Pool state (operator bearer)
+
+```bash
+# OPERATOR_KEY from /etc/macprovider/coordinator.env on Pearl
+curl -sS -H "Authorization: Bearer $OPERATOR_KEY" \
+  http://127.0.0.1:8444/admin/poolz \
+  | jq '.providers[] | {id: .provider_id, state: .state}'
+```
+
+Pass criteria:
+
+- [ ] Canary runs on interval for WS providers with free slots
+- [ ] Log shows nonce embedded in probe (coordinator-side)
+- [ ] 3 consecutive fails → degrade/ban; provider drops from routing
+- [ ] Recovery pass clears sanction
+
+### 5.4 Promote to production tuning
+
+After 24–48h staging observation, edit overlay on Pearl:
+
+```yaml
+pool:
+  canary_interval_s: 600   # 10 min production cadence
+```
+
+Then `systemctl restart macprovider-coordinator` (no binary change needed).
+
+---
+
+## 6. Rollback
+
+### 6.1 Disable canaries (keep new binary)
+
+```bash
+ssh pearl 'sudo rm /etc/systemd/system/macprovider-coordinator.service.d/opoi-v0.conf \
+  && sudo systemctl daemon-reload && sudo systemctl restart macprovider-coordinator'
+```
+
+### 6.2 Binary rollback
+
+```bash
+ssh pearl 'sudo install -o root -g macprovider -m 0750 \
+  /opt/macprovider/coordinator.prev /opt/macprovider/coordinator \
+  && sudo systemctl restart macprovider-coordinator'
+```
+
+See `OPS.md` §2 and `audits/2026-06-10/ROLLBACK_PROCEDURE.md`.
+
+---
+
+## 7. Troubleshooting
+
+| Symptom | Check |
+|---------|-------|
+| `config: unknown flag --config-overlay` | Binary predates #478 — rebuild and redeploy |
+| `config: pool canary_challenges must not be empty` | Overlay missing or not loaded — check drop-in |
+| No canary logs | Provider `SlotsFree==0` (skipped) or not `RoutingEligible` |
+| False fails | MLX output drift — widen template or normalize match (§7 parent runbook) |
+| Deploy refused exit 4 | Providers connected — use `FORCE_RESTART=1` or wait for idle window |
+
+---
+
+*End of runbook.*

--- a/phase4-coordinator/dist/deploy-opoi-v0-pearl.sh
+++ b/phase4-coordinator/dist/deploy-opoi-v0-pearl.sh
@@ -1,0 +1,149 @@
+#!/usr/bin/env bash
+# deploy-opoi-v0-pearl.sh — OPoI v0 only: coordinator binary + canary overlay.
+#
+# Does NOT run the full deploy-pearl-vps.sh (no nginx/certbot/coordinator.yaml
+# overwrite). Use after merging PR #478+ to main.
+#
+# Usage (from operator Mac, repo checkout at origin/main or later):
+#   cd phase4-coordinator
+#   bash scripts/build-linux.sh          # builds dist/coordinator-linux-amd64
+#   bash dist/deploy-opoi-v0-pearl.sh
+#
+# Environment:
+#   SSH_KEY          default ~/.ssh/pearl_operator_ed25519
+#   VPS_HOST         default 159.223.165.194
+#   VPS_USER         default root
+#   DOMAIN           default coordinator.streamvc.live (healthz + pool_size check)
+#   FORCE_RESTART    default 0 — set 1 to restart with connected providers
+#   SKIP_BUILD       default 0 — set 1 if dist/coordinator-linux-amd64 already built
+#   DRY_RUN          default 0 — set 1 to print actions only
+#
+# Rollback:
+#   ssh pearl 'sudo rm /etc/systemd/system/macprovider-coordinator.service.d/opoi-v0.conf \
+#     && sudo systemctl daemon-reload && sudo systemctl restart macprovider-coordinator'
+#   # Binary rollback: /opt/macprovider/coordinator.prev → coordinator (see OPS.md)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+DIST_DIR="$SCRIPT_DIR"
+MODULE_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+BINARY="$DIST_DIR/coordinator-linux-amd64"
+OVERLAY="$MODULE_DIR/coordinator.opoi-v0-staging.yaml"
+DROPIN="$DIST_DIR/systemd/opoi-v0.conf.example"
+
+SSH_KEY="${SSH_KEY:-$HOME/.ssh/pearl_operator_ed25519}"
+VPS_HOST="${VPS_HOST:-159.223.165.194}"
+VPS_USER="${VPS_USER:-root}"
+DOMAIN="${DOMAIN:-coordinator.streamvc.live}"
+FORCE_RESTART="${FORCE_RESTART:-0}"
+SKIP_BUILD="${SKIP_BUILD:-0}"
+DRY_RUN="${DRY_RUN:-0}"
+
+log() { printf '[opoi-deploy] %s\n' "$*"; }
+run() {
+  if [ "$DRY_RUN" = "1" ]; then
+    log "DRY_RUN: $*"
+  else
+    "$@"
+  fi
+}
+
+for f in "$OVERLAY" "$DROPIN"; do
+  [ -f "$f" ] || { echo "missing required file: $f" >&2; exit 1; }
+done
+if [ "$DRY_RUN" != "1" ] && [ ! -f "$BINARY" ]; then
+  echo "missing required file: $BINARY (run scripts/build-linux.sh first)" >&2
+  exit 1
+fi
+
+if [ "$SKIP_BUILD" != "1" ]; then
+  log "building coordinator linux/amd64 (scripts/build-linux.sh)"
+  if [ "$DRY_RUN" = "1" ]; then
+    log "DRY_RUN: would run bash $MODULE_DIR/scripts/build-linux.sh"
+  else
+    bash "$MODULE_DIR/scripts/build-linux.sh"
+  fi
+fi
+
+SSH=(ssh -i "$SSH_KEY" -o ConnectTimeout=10 -p 22 "$VPS_USER@$VPS_HOST")
+SCP=(scp -i "$SSH_KEY" -P 22)
+
+log "step 1/6: SSH + connected-provider guard"
+if [ "$DRY_RUN" != "1" ]; then
+  "${SSH[@]}" 'hostname && uptime' >/dev/null
+fi
+CONNECTED_COUNT=0
+if [ "$DRY_RUN" != "1" ]; then
+  CONNECTED_COUNT=$(curl -fsS --max-time 5 --max-filesize 65536 "https://$DOMAIN/healthz" 2>/dev/null \
+    | python3 -c "import sys,json; print(json.load(sys.stdin).get('pool_size', 0))" 2>/dev/null \
+    || echo 0)
+fi
+if [ "${CONNECTED_COUNT:-0}" -gt 0 ] && [ "$FORCE_RESTART" != "1" ]; then
+  log "REFUSING — $CONNECTED_COUNT provider(s) connected. Restart triggers drain."
+  log "Proceed with: FORCE_RESTART=1 bash dist/deploy-opoi-v0-pearl.sh"
+  exit 4
+fi
+log "ok: connected providers=$CONNECTED_COUNT (or FORCE_RESTART=1)"
+
+log "step 2/6: stage artifacts on Pearl"
+if [ "$DRY_RUN" = "1" ]; then
+  DEPLOY_TMP="/tmp/macprovider-opoi-deploy.XXXXXXXX"
+  log "DRY_RUN: would mktemp on Pearl"
+else
+  DEPLOY_TMP=$("${SSH[@]}" 'umask 077 && mktemp -d -t macprovider-opoi-deploy.XXXXXXXX')
+  case "$DEPLOY_TMP" in
+    /tmp/macprovider-opoi-deploy.*) ;;
+    *) echo "unexpected mktemp path: $DEPLOY_TMP" >&2; exit 1 ;;
+  esac
+  trap "${SSH[@]} rm -rf $DEPLOY_TMP" EXIT
+  "${SCP[@]}" "$BINARY" "$VPS_USER@$VPS_HOST:$DEPLOY_TMP/coordinator-linux-amd64"
+  "${SCP[@]}" "$OVERLAY" "$VPS_USER@$VPS_HOST:$DEPLOY_TMP/coordinator.opoi-v0-staging.yaml"
+  "${SCP[@]}" "$DROPIN" "$VPS_USER@$VPS_HOST:$DEPLOY_TMP/opoi-v0.conf"
+fi
+
+log "step 3/6: install binary + overlay + systemd drop-in"
+if [ "$DRY_RUN" != "1" ]; then
+  "${SSH[@]}" "set -e
+    if [ -x /opt/macprovider/coordinator ]; then
+      install -o root -g macprovider -m 0750 /opt/macprovider/coordinator /opt/macprovider/coordinator.prev
+      echo '  binary snapshot: /opt/macprovider/coordinator.prev'
+    fi
+    install -o root -g macprovider -m 0750 $DEPLOY_TMP/coordinator-linux-amd64 /opt/macprovider/coordinator
+    install -o root -g macprovider -m 0640 $DEPLOY_TMP/coordinator.opoi-v0-staging.yaml /etc/macprovider/coordinator.opoi-v0-staging.yaml
+    install -d -o root -g root -m 0755 /etc/systemd/system/macprovider-coordinator.service.d
+    install -o root -g root -m 0644 $DEPLOY_TMP/opoi-v0.conf /etc/systemd/system/macprovider-coordinator.service.d/opoi-v0.conf
+  "
+fi
+
+log "step 4/6: validate merged config"
+if [ "$DRY_RUN" != "1" ]; then
+  "${SSH[@]}" '/opt/macprovider/coordinator \
+    --config /opt/macprovider/coordinator.yaml \
+    --config-overlay /etc/macprovider/coordinator.opoi-v0-staging.yaml \
+    --validate-config'
+fi
+
+log "step 5/6: restart coordinator"
+if [ "$DRY_RUN" != "1" ]; then
+  "${SSH[@]}" 'set -e
+    systemctl daemon-reload
+    systemctl restart macprovider-coordinator
+    sleep 3
+    systemctl is-active macprovider-coordinator
+  '
+fi
+
+log "step 6/6: verify /healthz + version"
+if [ "$DRY_RUN" != "1" ]; then
+  HEALTHZ=$(curl -fsS --max-time 10 --max-filesize 65536 "https://$DOMAIN/healthz")
+  printf '%s\n' "$HEALTHZ" | python3 -m json.tool
+  DEPLOYED_VERSION=$(printf '%s' "$HEALTHZ" | python3 -c "import sys,json; print(json.load(sys.stdin).get('version','?'))")
+  EXPECTED_VERSION=$(git -C "$MODULE_DIR" describe --always --dirty --tags 2>/dev/null || git -C "$MODULE_DIR" rev-parse --short HEAD)
+  log "provenance: deployed=$DEPLOYED_VERSION expected=$EXPECTED_VERSION"
+fi
+
+log "DONE. Watch canaries:"
+log "  ssh -i $SSH_KEY $VPS_USER@$VPS_HOST journalctl -fu macprovider-coordinator | grep -E 'canary (passed|failed|skipped)'"
+log "Rollback overlay:"
+log "  ssh -i $SSH_KEY $VPS_USER@$VPS_HOST 'sudo rm /etc/systemd/system/macprovider-coordinator.service.d/opoi-v0.conf && sudo systemctl daemon-reload && sudo systemctl restart macprovider-coordinator'"

--- a/phase4-coordinator/dist/systemd/opoi-v0.conf.example
+++ b/phase4-coordinator/dist/systemd/opoi-v0.conf.example
@@ -1,0 +1,19 @@
+# systemd drop-in — OPoI v0 canary overlay (Session A)
+#
+# Install on Pearl:
+#   sudo install -d -m 0755 /etc/systemd/system/macprovider-coordinator.service.d
+#   sudo install -m 0644 opoi-v0.conf.example \
+#     /etc/systemd/system/macprovider-coordinator.service.d/opoi-v0.conf
+#   sudo systemctl daemon-reload
+#   sudo systemctl restart macprovider-coordinator
+#
+# Requires coordinator binary built from main @ PR #478+ (--config-overlay support).
+# Rollback: sudo rm /etc/systemd/system/macprovider-coordinator.service.d/opoi-v0.conf
+#           && sudo systemctl daemon-reload && sudo systemctl restart macprovider-coordinator
+
+[Service]
+# Clear the base unit ExecStart, then set overlay-aware command.
+ExecStart=
+ExecStart=/opt/macprovider/coordinator \
+  --config /opt/macprovider/coordinator.yaml \
+  --config-overlay /etc/macprovider/coordinator.opoi-v0-staging.yaml


### PR DESCRIPTION
## Summary
- Add `ops/runbooks/opoi-pearl-deploy.md` — operator steps for Session A Pearl staging (build, validate, verify, rollback).
- Add `phase4-coordinator/dist/deploy-opoi-v0-pearl.sh` — minimal deploy: binary + overlay + systemd drop-in (no full `deploy-pearl-vps.sh`).
- Add `phase4-coordinator/dist/systemd/opoi-v0.conf.example` — `--config-overlay` drop-in for `macprovider-coordinator.service`.
- Link from `opoi-challenge-implementation.md` §2.4.

## Test plan
- [x] `bash -n dist/deploy-opoi-v0-pearl.sh`
- [ ] Merge + run on Pearl: `bash dist/deploy-opoi-v0-pearl.sh` (operator)
- [ ] Confirm `config: ok` via `--validate-config` on Pearl
- [ ] Canary logs within 300s interval


Made with [Cursor](https://cursor.com)