### PR TITLE
fix(integration): harden spec-014 healthz wait under parallel CI

### DIFF
--- a/test/integration/spec_014_v0_2_pairing/harness_test.go
+++ b/test/integration/spec_014_v0_2_pairing/harness_test.go
@@ -461,7 +461,10 @@ func postBind(t *testing.T, c *http.Client, baseURL, body string) (int, []byte) 
 
 func waitForHTTP(t *testing.T, rawURL string) {
 	t.Helper()
-	deadline := time.Now().Add(10 * time.Second)
+	// 30s: the cross-service integration job runs this package in parallel
+	// with the root harness (each builds coordinator binaries). Under CI
+	// load 10s was too tight for /healthz to come up reliably.
+	deadline := time.Now().Add(30 * time.Second)
 	for time.Now().Before(deadline) {
 		resp, err := http.Get(rawURL)
 		if err == nil {


### PR DESCRIPTION
## Summary
- Increase `waitForHTTP` deadline in `spec_014_v0_2_pairing` from 10s to 30s
- The cross-service `integration` job runs `./...` in parallel; spec_014 and the root harness each build coordinator binaries, so `/healthz` startup can exceed 10s under CI load
- `TestSpec014V02FullPairingHandoff` passes reliably in the isolated `spec-014-v0-2-gate` job but flaked in the parallel `./...` run

## Test plan
- [x] `go test -race -count=1 -timeout 5m ./spec_014_v0_2_pairing -run TestSpec014V02FullPairingHandoff`
- [x] `go test -race -count=1 -timeout 5m ./...` (full cross-service integration suite)


Made with [Cursor](https://cursor.com)