### PR TITLE
fix(ops): source coordinator.env before OPoI deploy validate-config

### DIFF
--- a/phase4-coordinator/dist/deploy-opoi-v0-pearl.sh
+++ b/phase4-coordinator/dist/deploy-opoi-v0-pearl.sh
@@ -118,10 +118,20 @@ fi
 
 log "step 4/6: validate merged config"
 if [ "$DRY_RUN" != "1" ]; then
-  "${SSH[@]}" '/opt/macprovider/coordinator \
-    --config /opt/macprovider/coordinator.yaml \
-    --config-overlay /etc/macprovider/coordinator.opoi-v0-staging.yaml \
-    --validate-config'
+  "${SSH[@]}" 'set -euo pipefail
+    env_file=/etc/macprovider/coordinator.env
+    if [ ! -f "$env_file" ]; then
+      echo "missing $env_file (required for --validate-config env expansion)" >&2
+      exit 1
+    fi
+    set -a
+    # shellcheck disable=SC1090
+    . "$env_file"
+    set +a
+    /opt/macprovider/coordinator \
+      --config /opt/macprovider/coordinator.yaml \
+      --config-overlay /etc/macprovider/coordinator.opoi-v0-staging.yaml \
+      --validate-config'
 fi
 
 log "step 5/6: restart coordinator"


### PR DESCRIPTION
## Summary
- Fix `deploy-opoi-v0-pearl.sh` step 4/6 to source `/etc/macprovider/coordinator.env` before running `--validate-config` on Pearl
- Matches the pattern used by `deploy-pearl-vps.sh` env preflight checks

## Test plan
- [x] Manual validate on Pearl during live deploy (sourced env → `config: ok`)
- [ ] CI green
- [ ] Re-run `SKIP_BUILD=1 DRY_RUN=1 bash dist/deploy-opoi-v0-pearl.sh` locally (dry run path unchanged)


Made with [Cursor](https://cursor.com)