### PR TITLE
fix(proof-of-weights): grant hello-gate evidence columns to provider_onboarding

### DIFF
--- a/phase4-coordinator/dist/deploy-pearl-vps.sh
+++ b/phase4-coordinator/dist/deploy-pearl-vps.sh
@@ -785,8 +785,13 @@ PY
     }
     psql_preflight_service onboarding_preflight "$ONBOARDING_POSTGRES_DSN" <<SQL >/dev/null
 SELECT 1 FROM hardware_verification_jobs LIMIT 1;
+SELECT generated_at, evidence
+  FROM hardware_verification_jobs
+ WHERE provider_id = ''
+   AND status = 'verified'
+ LIMIT 0;
 SQL
-    echo "  ok: migration 008 hardware_verification_jobs is visible to provider_onboarding"
+    echo "  ok: migration 008+013 hardware_verification_jobs visible to provider_onboarding (hello gate read path)"
     psql_preflight_service auth_policy_request_preflight "$ONBOARDING_AUTH_POLICY_REQUEST_DSN" <<SQL >/dev/null
 DO \$\$
 BEGIN

--- a/phase4-coordinator/internal/onboarding/store_pg.go
+++ b/phase4-coordinator/internal/onboarding/store_pg.go
@@ -122,6 +122,14 @@ func (s *PGStore) Smoke(ctx context.Context) error {
 	if _, err := s.db.ExecContext(timeout, `SELECT id, evidence_sha256 FROM hardware_verification_jobs LIMIT 1`); err != nil {
 		return fmt.Errorf("provider_onboarding smoke hardware_verification_jobs read: %w", err)
 	}
+	if _, err := s.db.ExecContext(timeout, `
+SELECT generated_at, evidence
+  FROM hardware_verification_jobs
+ WHERE provider_id = ''
+   AND status = 'verified'
+ LIMIT 0`); err != nil {
+		return fmt.Errorf("provider_onboarding smoke autotune hello gate evidence read: %w", err)
+	}
 	if _, err := s.db.ExecContext(timeout, `SELECT 1 FROM provider_register_nonces LIMIT 1`); err != nil {
 		return fmt.Errorf("provider_onboarding smoke provider_register_nonces read: %w", err)
 	}

--- a/phase4-coordinator/internal/stats/migrations/013_pow_w2_hello_gate_grants.down.sql
+++ b/phase4-coordinator/internal/stats/migrations/013_pow_w2_hello_gate_grants.down.sql
@@ -1,0 +1,4 @@
+REVOKE SELECT (
+    generated_at,
+    evidence
+) ON hardware_verification_jobs FROM provider_onboarding;

--- a/phase4-coordinator/internal/stats/migrations/013_pow_w2_hello_gate_grants.up.sql
+++ b/phase4-coordinator/internal/stats/migrations/013_pow_w2_hello_gate_grants.up.sql
@@ -1,0 +1,7 @@
+-- W2 proof-of-weights hello gate: provider_onboarding must read verified
+-- autotune evidence (generated_at + evidence JSON) when evaluating WS hello.
+
+GRANT SELECT (
+    generated_at,
+    evidence
+) ON hardware_verification_jobs TO provider_onboarding;

--- a/phase4-coordinator/internal/stats/migrations/migrations_test.go
+++ b/phase4-coordinator/internal/stats/migrations/migrations_test.go
@@ -70,7 +70,7 @@ func TestEmbeddedSchemaShapesCorrect(t *testing.T) {
 	if err != nil {
 		t.Fatalf("All: %v", err)
 	}
-	var schema, bootstrap, spec026, hardware, hardwareJobs, authPolicyApproveFix, idlePrewarm string
+	var schema, bootstrap, spec026, hardware, hardwareJobs, authPolicyApproveFix, idlePrewarm, powW2HelloGateGrants string
 	for _, m := range all {
 		switch m.Name {
 		case "stats_tables":
@@ -87,6 +87,8 @@ func TestEmbeddedSchemaShapesCorrect(t *testing.T) {
 			authPolicyApproveFix = m.SQL
 		case "idle_prewarm_events":
 			idlePrewarm = m.SQL
+		case "pow_w2_hello_gate_grants":
+			powW2HelloGateGrants = m.SQL
 		}
 	}
 	if schema == "" {
@@ -422,6 +424,12 @@ func TestEmbeddedSchemaShapesCorrect(t *testing.T) {
 	} {
 		mustContain(t, hardwareJobsDownSQL, needle, "hardware verification rollback artifact")
 	}
+	if powW2HelloGateGrants == "" {
+		t.Fatal("pow_w2_hello_gate_grants migration body is empty")
+	}
+	mustContain(t, powW2HelloGateGrants,
+		"GRANT SELECT (\n    generated_at,\n    evidence\n) ON hardware_verification_jobs TO provider_onboarding",
+		"provider_onboarding hello gate read grants")
 }
 
 func mustContain(t *testing.T, body, needle, why string) {

--- a/phase4-coordinator/internal/stats/migrations/migrations_test.go
+++ b/phase4-coordinator/internal/stats/migrations/migrations_test.go
@@ -33,6 +33,7 @@ func TestEmbeddedMigrationsLoad(t *testing.T) {
 		{10, "partner_keys_provider_id"},
 		{11, "idle_prewarm_events"},
 		{12, "malibu_emission_ledger"},
+		{13, "pow_w2_hello_gate_grants"},
 	}
 	if len(all) != len(want) {
 		t.Fatalf("got %d migrations, want %d", len(all), len(want))


### PR DESCRIPTION
## Summary
- Add migration 013 granting `provider_onboarding` SELECT on `hardware_verification_jobs.generated_at` and `.evidence` for W2 autotune hello gate lookups.
- Discovered during Pearl W2 staging: gate enabled but hello failed with `permission denied` until grant applied manually.

## Test plan
- [x] `go test ./internal/stats/migrations/ -count=1`
- [x] Manual GRANT applied on Pearl Postgres during W2 staging


Made with [Cursor](https://cursor.com)