### PR TITLE
feat(malibu): wire accrual read path into CLI and Malibu app (Session C3)

### DIFF
--- a/phase3-binary/Sources/macprovider-cli/ControlMetricsSnapshot.swift
+++ b/phase3-binary/Sources/macprovider-cli/ControlMetricsSnapshot.swift
@@ -1,0 +1,98 @@
+import Foundation
+
+/// Wire payload for metrics_response (SPEC-025 §5.2 / Session C3).
+public struct ControlMetricsSnapshot: Equatable, Sendable {
+    public var earningsUsdc: Double = 0
+    public var malibuAccrued: Double = 0
+    public var gpuC: Double?
+    public var latencyP50Ms: Int?
+    public var uptimeSec: Int = 0
+    public var requestsServedToday: Int?
+    public var requestsServedAllTime: Int?
+    public var requestsPerMinute: Double?
+    public var inputTokensToday: Int64?
+    public var outputTokensToday: Int64?
+    public var inputTokensAllTime: Int64?
+    public var outputTokensAllTime: Int64?
+    public var queueDepth: Int?
+
+    public init(
+        earningsUsdc: Double = 0,
+        malibuAccrued: Double = 0,
+        gpuC: Double? = nil,
+        latencyP50Ms: Int? = nil,
+        uptimeSec: Int = 0,
+        requestsServedToday: Int? = nil,
+        requestsServedAllTime: Int? = nil,
+        requestsPerMinute: Double? = nil,
+        inputTokensToday: Int64? = nil,
+        outputTokensToday: Int64? = nil,
+        inputTokensAllTime: Int64? = nil,
+        outputTokensAllTime: Int64? = nil,
+        queueDepth: Int? = nil
+    ) {
+        self.earningsUsdc = earningsUsdc
+        self.malibuAccrued = malibuAccrued
+        self.gpuC = gpuC
+        self.latencyP50Ms = latencyP50Ms
+        self.uptimeSec = uptimeSec
+        self.requestsServedToday = requestsServedToday
+        self.requestsServedAllTime = requestsServedAllTime
+        self.requestsPerMinute = requestsPerMinute
+        self.inputTokensToday = inputTokensToday
+        self.outputTokensToday = outputTokensToday
+        self.inputTokensAllTime = inputTokensAllTime
+        self.outputTokensAllTime = outputTokensAllTime
+        self.queueDepth = queueDepth
+    }
+
+    static func from(provider snapshot: ProviderSnapshot, malibuAccrued: Double) -> ControlMetricsSnapshot {
+        let rpm: Double?
+        if let tps = snapshot.throughputTPSSinceLast, tps > 0 {
+            rpm = tps * 60
+        } else {
+            rpm = nil
+        }
+        return ControlMetricsSnapshot(
+            earningsUsdc: 0,
+            malibuAccrued: malibuAccrued,
+            gpuC: nil,
+            latencyP50Ms: snapshot.avgLatencyMSSinceLast.map { Int($0.rounded()) },
+            uptimeSec: snapshot.uptimeSeconds,
+            requestsServedToday: snapshot.requestsToday,
+            requestsServedAllTime: snapshot.requestsTotal,
+            requestsPerMinute: rpm,
+            inputTokensToday: snapshot.inputTokensToday,
+            outputTokensToday: snapshot.outputTokensToday,
+            inputTokensAllTime: snapshot.inputTokensAllTime,
+            outputTokensAllTime: snapshot.outputTokensAllTime,
+            queueDepth: snapshot.requestsQueued
+        )
+    }
+}
+
+enum ControlMetricsBuilder {
+    static func build(
+        providerStatus: ProviderStatus?,
+        malibuAccrualClient: MalibuAccrualClient?,
+        providerToken: String?
+    ) async -> ControlMetricsSnapshot {
+        guard let providerStatus else {
+            return ControlMetricsSnapshot()
+        }
+        let snapshot = await providerStatus.snapshot(resetWindow: true)
+        var malibu = 0.0
+        if let malibuAccrualClient,
+           let token = providerToken?.trimmingCharacters(in: .whitespacesAndNewlines),
+           !token.isEmpty {
+            malibu = (try? await malibuAccrualClient.fetch(bearerToken: token).accruedMALIBU) ?? 0
+        }
+        return .from(provider: snapshot, malibuAccrued: malibu)
+    }
+}
+
+extension ControlSocketCodec {
+    static func encodeMetrics(_ metrics: ControlMetricsSnapshot) throws -> Data {
+        try encode(.metricsResponse(metrics))
+    }
+}

--- a/phase3-binary/Sources/macprovider-cli/ControlSocket.swift
+++ b/phase3-binary/Sources/macprovider-cli/ControlSocket.swift
@@ -35,7 +35,7 @@ public enum ControlSocketFrame: Equatable, Sendable {
     // The stub server acks with accepted:false + reason "not_implemented" when the semantic
     // is not yet wired end-to-end; the wire format is stable so the app can integrate now.
     case metricsRequest
-    case metricsResponse(earningsUsdc: Double, malibuAccrued: Double, gpuC: Double?, latencyP50Ms: Int?, uptimeSec: Int)
+    case metricsResponse(ControlMetricsSnapshot)
     case pauseRequest
     case pauseAck(accepted: Bool, reason: String?)
     case resumeRequest
@@ -127,15 +127,23 @@ public enum ControlSocketCodec {
             ]
         case .metricsRequest:
             object = ["type": "metrics_request"]
-        case let .metricsResponse(earningsUsdc, malibuAccrued, gpuC, latencyP50Ms, uptimeSec):
+        case let .metricsResponse(metrics):
             var frame: [String: Any] = [
                 "type": "metrics_response",
-                "earnings_usdc": earningsUsdc,
-                "malibu_accrued": malibuAccrued,
-                "uptime_sec": uptimeSec,
+                "earnings_usdc": metrics.earningsUsdc,
+                "malibu_accrued": metrics.malibuAccrued,
+                "uptime_sec": metrics.uptimeSec,
             ]
-            if let gpuC { frame["gpu_c"] = gpuC }
-            if let latencyP50Ms { frame["latency_p50_ms"] = latencyP50Ms }
+            if let gpuC = metrics.gpuC { frame["gpu_c"] = gpuC }
+            if let latencyP50Ms = metrics.latencyP50Ms { frame["latency_p50_ms"] = latencyP50Ms }
+            if let requestsServedToday = metrics.requestsServedToday { frame["requests_served_today"] = requestsServedToday }
+            if let requestsServedAllTime = metrics.requestsServedAllTime { frame["requests_served_all_time"] = requestsServedAllTime }
+            if let requestsPerMinute = metrics.requestsPerMinute { frame["requests_per_minute"] = requestsPerMinute }
+            if let inputTokensToday = metrics.inputTokensToday { frame["input_tokens_today"] = inputTokensToday }
+            if let outputTokensToday = metrics.outputTokensToday { frame["output_tokens_today"] = outputTokensToday }
+            if let inputTokensAllTime = metrics.inputTokensAllTime { frame["input_tokens_all_time"] = inputTokensAllTime }
+            if let outputTokensAllTime = metrics.outputTokensAllTime { frame["output_tokens_all_time"] = outputTokensAllTime }
+            if let queueDepth = metrics.queueDepth { frame["queue_depth"] = queueDepth }
             object = frame
         case .pauseRequest:
             object = ["type": "pause_request"]
@@ -246,13 +254,21 @@ public enum ControlSocketCodec {
         case "metrics_request":
             return .metricsRequest
         case "metrics_response":
-            return .metricsResponse(
+            return .metricsResponse(ControlMetricsSnapshot(
                 earningsUsdc: try doubleField("earnings_usdc", in: object),
                 malibuAccrued: try doubleField("malibu_accrued", in: object),
                 gpuC: optionalDoubleField("gpu_c", in: object),
                 latencyP50Ms: optionalIntField("latency_p50_ms", in: object),
-                uptimeSec: try intField("uptime_sec", in: object)
-            )
+                uptimeSec: try intField("uptime_sec", in: object),
+                requestsServedToday: optionalIntField("requests_served_today", in: object),
+                requestsServedAllTime: optionalIntField("requests_served_all_time", in: object),
+                requestsPerMinute: optionalDoubleField("requests_per_minute", in: object),
+                inputTokensToday: optionalInt64Field("input_tokens_today", in: object),
+                outputTokensToday: optionalInt64Field("output_tokens_today", in: object),
+                inputTokensAllTime: optionalInt64Field("input_tokens_all_time", in: object),
+                outputTokensAllTime: optionalInt64Field("output_tokens_all_time", in: object),
+                queueDepth: optionalIntField("queue_depth", in: object)
+            ))
         case "pause_request":
             return .pauseRequest
         case "pause_ack":
@@ -306,6 +322,13 @@ public enum ControlSocketCodec {
     private static func optionalIntField(_ field: String, in object: [String: Any]) -> Int? {
         if let value = object[field] as? Int { return value }
         if let value = object[field] as? NSNumber { return value.intValue }
+        return nil
+    }
+
+    private static func optionalInt64Field(_ field: String, in object: [String: Any]) -> Int64? {
+        if let value = object[field] as? Int64 { return value }
+        if let value = object[field] as? Int { return Int64(value) }
+        if let value = object[field] as? NSNumber { return value.int64Value }
         return nil
     }
 
@@ -414,6 +437,9 @@ actor ControlSocketServer {
     private let receiptRotationProviderID: String?
     private let idleTimeoutSeconds: TimeInterval
     private let identityBridge: IdentitySignatureBridge?
+    private let providerStatus: ProviderStatus?
+    private let malibuAccrualClient: MalibuAccrualClient?
+    private let providerToken: String?
     private let tracker = ControlSocketSwitchTracker()
     private var listenerFD: Int32?
     private var acceptTask: Task<Void, Never>?
@@ -427,7 +453,10 @@ actor ControlSocketServer {
         receiptRotator: (@Sendable () async throws -> Void)? = nil,
         receiptRotationProviderID: String? = nil,
         idleTimeoutSeconds: TimeInterval = 30.0,
-        identityBridge: IdentitySignatureBridge? = nil
+        identityBridge: IdentitySignatureBridge? = nil,
+        providerStatus: ProviderStatus? = nil,
+        malibuAccrualClient: MalibuAccrualClient? = nil,
+        providerToken: String? = nil
     ) {
         self.socketPath = socketPath
         self.modelRuntime = modelRuntime
@@ -436,6 +465,9 @@ actor ControlSocketServer {
         self.receiptRotationProviderID = receiptRotationProviderID
         self.idleTimeoutSeconds = idleTimeoutSeconds
         self.identityBridge = identityBridge
+        self.providerStatus = providerStatus
+        self.malibuAccrualClient = malibuAccrualClient
+        self.providerToken = providerToken
     }
 
     func start() async throws {
@@ -482,6 +514,9 @@ actor ControlSocketServer {
         let receiptRotationProviderID = receiptRotationProviderID
         let idleTimeoutSeconds = idleTimeoutSeconds
         let identityBridge = identityBridge
+        let providerStatus = providerStatus
+        let malibuAccrualClient = malibuAccrualClient
+        let providerToken = providerToken
         acceptTask = Task.detached(priority: .userInitiated) {
             await Self.acceptLoop(
                 listenerFD: fd,
@@ -492,6 +527,9 @@ actor ControlSocketServer {
                 receiptRotationProviderID: receiptRotationProviderID,
                 idleTimeoutSeconds: idleTimeoutSeconds,
                 identityBridge: identityBridge,
+                providerStatus: providerStatus,
+                malibuAccrualClient: malibuAccrualClient,
+                providerToken: providerToken,
                 server: self
             )
         }
@@ -545,6 +583,9 @@ actor ControlSocketServer {
         receiptRotationProviderID: String?,
         idleTimeoutSeconds: TimeInterval,
         identityBridge: IdentitySignatureBridge?,
+        providerStatus: ProviderStatus?,
+        malibuAccrualClient: MalibuAccrualClient?,
+        providerToken: String?,
         server: ControlSocketServer
     ) async {
         while !Task.isCancelled {
@@ -573,7 +614,10 @@ actor ControlSocketServer {
                     receiptRotator: receiptRotator,
                     receiptRotationProviderID: receiptRotationProviderID,
                     idleTimeoutSeconds: idleTimeoutSeconds,
-                    identityBridge: identityBridge
+                    identityBridge: identityBridge,
+                    providerStatus: providerStatus,
+                    malibuAccrualClient: malibuAccrualClient,
+                    providerToken: providerToken
                 )
                 await server.removeClientFD(clientFD)
             }
@@ -611,7 +655,10 @@ actor ControlSocketServer {
         receiptRotator: (@Sendable () async throws -> Void)?,
         receiptRotationProviderID: String?,
         idleTimeoutSeconds: TimeInterval,
-        identityBridge: IdentitySignatureBridge? = nil
+        identityBridge: IdentitySignatureBridge? = nil,
+        providerStatus: ProviderStatus? = nil,
+        malibuAccrualClient: MalibuAccrualClient? = nil,
+        providerToken: String? = nil
     ) async {
         let connection = ControlSocketConnection(fd: fd)
 
@@ -691,15 +738,12 @@ actor ControlSocketServer {
                     await connection.close()
                     return
                 case .metricsRequest:
-                    // SPEC-025 §5.2 — real earnings/uptime source will land with the App track
-                    // rollout (see SPEC-025 §11 P1). Wire format is stable; semantic is stub.
-                    try? await connection.send(.metricsResponse(
-                        earningsUsdc: 0,
-                        malibuAccrued: 0,
-                        gpuC: nil,
-                        latencyP50Ms: nil,
-                        uptimeSec: 0
-                    ))
+                    let snapshot = await ControlMetricsBuilder.build(
+                        providerStatus: providerStatus,
+                        malibuAccrualClient: malibuAccrualClient,
+                        providerToken: providerToken
+                    )
+                    try? await connection.send(.metricsResponse(snapshot))
                 case .pauseRequest:
                     try? await connection.send(.pauseAck(accepted: false, reason: "not_implemented"))
                 case .resumeRequest:

--- a/phase3-binary/Sources/macprovider-cli/MacProviderCLI.swift
+++ b/phase3-binary/Sources/macprovider-cli/MacProviderCLI.swift
@@ -588,13 +588,17 @@ struct ServeCommand: AsyncParsableCommand {
         }
         if resolved.enableWarmSwap || receiptRotator != nil {
             let socketURL = ControlSocketPaths.resolve(ctlSocketPath: resolved.ctlSocketPath)
+            let malibuAccrualClient = try? MalibuAccrualClient(coordinatorURL: resolved.coordinatorURL)
             controlSocket = ControlSocketServer(
                 socketPath: socketURL,
                 modelRuntime: modelRuntime,
                 supportedModels: resolved.supportedModels,
                 receiptRotator: receiptRotator,
                 receiptRotationProviderID: resolved.providerID?.trimmingCharacters(in: .whitespacesAndNewlines),
-                identityBridge: identityBridge
+                identityBridge: identityBridge,
+                providerStatus: providerStatus,
+                malibuAccrualClient: malibuAccrualClient,
+                providerToken: resolved.providerToken
             )
             do {
                 try await controlSocket?.start()

--- a/phase3-binary/Sources/macprovider-cli/MalibuAccrualClient.swift
+++ b/phase3-binary/Sources/macprovider-cli/MalibuAccrualClient.swift
@@ -1,0 +1,109 @@
+import Foundation
+
+/// Provider-facing MALIBU accrual read model from GET /v1/provider/malibu-accrual.
+struct MalibuAccrualSummary: Decodable, Equatable, Sendable {
+    let accruedMALIBU: Double
+    let withdrawableMALIBU: Double
+    let heldMALIBU: Double
+    let trustTier: String
+    let trustCriteriaMet: Int?
+    let trustCriteriaRequired: Int?
+    let walletBound: Bool?
+
+    enum CodingKeys: String, CodingKey {
+        case accruedMALIBU = "accrued_malibu"
+        case withdrawableMALIBU = "withdrawable_malibu"
+        case heldMALIBU = "held_malibu"
+        case trustTier = "trust_tier"
+        case trustCriteriaMet = "trust_criteria_met"
+        case trustCriteriaRequired = "trust_criteria_required"
+        case walletBound = "wallet_bound"
+    }
+
+    init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        accruedMALIBU = try Self.decodeDecimal(c, key: .accruedMALIBU)
+        withdrawableMALIBU = try Self.decodeDecimal(c, key: .withdrawableMALIBU)
+        heldMALIBU = try Self.decodeDecimal(c, key: .heldMALIBU)
+        trustTier = try c.decodeIfPresent(String.self, forKey: .trustTier) ?? "provisional"
+        trustCriteriaMet = try c.decodeIfPresent(Int.self, forKey: .trustCriteriaMet)
+        trustCriteriaRequired = try c.decodeIfPresent(Int.self, forKey: .trustCriteriaRequired)
+        walletBound = try c.decodeIfPresent(Bool.self, forKey: .walletBound)
+    }
+
+    private static func decodeDecimal(_ c: KeyedDecodingContainer<CodingKeys>, key: CodingKeys) throws -> Double {
+        guard c.contains(key) else { return 0 }
+        if let value = try? c.decode(Double.self, forKey: key) {
+            return value
+        }
+        if let text = try? c.decode(String.self, forKey: key) {
+            return Double(text) ?? 0
+        }
+        return 0
+    }
+}
+
+enum MalibuAccrualClientError: Error, Equatable {
+    case invalidCoordinatorURL
+    case httpStatus(Int)
+    case unavailable
+}
+
+struct MalibuAccrualClient: Sendable {
+    let accrualURL: URL
+    private let session: URLSession?
+
+    init(coordinatorURL: String?, session: URLSession? = nil) throws {
+        guard let url = Self.accrualURL(from: coordinatorURL) else {
+            throw MalibuAccrualClientError.invalidCoordinatorURL
+        }
+        self.accrualURL = url
+        self.session = session
+    }
+
+    init(accrualURL: URL, session: URLSession? = nil) {
+        self.accrualURL = accrualURL
+        self.session = session
+    }
+
+    static func accrualURL(from coordinatorURL: String?) -> URL? {
+        guard let coordinatorURL,
+              var components = URLComponents(string: coordinatorURL) else {
+            return nil
+        }
+        switch components.scheme {
+        case "wss":
+            components.scheme = "https"
+        case "https":
+            break
+        default:
+            return nil
+        }
+        components.path = "/v1/provider/malibu-accrual"
+        components.query = nil
+        components.fragment = nil
+        return components.url
+    }
+
+    func fetch(bearerToken: String) async throws -> MalibuAccrualSummary {
+        var request = URLRequest(url: accrualURL)
+        request.httpMethod = "GET"
+        request.setValue("Bearer \(bearerToken)", forHTTPHeaderField: "Authorization")
+        let data: Data
+        let response: URLResponse
+        if let session {
+            (data, response) = try await session.data(for: request)
+        } else {
+            let ephemeral = URLSession(configuration: .ephemeral)
+            defer { ephemeral.finishTasksAndInvalidate() }
+            (data, response) = try await ephemeral.data(for: request)
+        }
+        guard let http = response as? HTTPURLResponse else {
+            throw MalibuAccrualClientError.unavailable
+        }
+        guard (200..<300).contains(http.statusCode) else {
+            throw MalibuAccrualClientError.httpStatus(http.statusCode)
+        }
+        return try JSONDecoder().decode(MalibuAccrualSummary.self, from: data)
+    }
+}

--- a/phase3-binary/Tests/macprovider-cliTests/ControlSocketTests.swift
+++ b/phase3-binary/Tests/macprovider-cliTests/ControlSocketTests.swift
@@ -127,29 +127,29 @@ final class ControlSocketTests: XCTestCase {
     }
 
     func testEncodeDecodeMetricsResponseFull() throws {
-        try assertRoundTrip(.metricsResponse(
+        try assertRoundTrip(.metricsResponse(ControlMetricsSnapshot(
             earningsUsdc: 0.42,
             malibuAccrued: 0.14,
             gpuC: 58.5,
             latencyP50Ms: 180,
             uptimeSec: 3600
-        ))
+        )))
     }
 
     func testEncodeDecodeMetricsResponseOptionalsOmitted() throws {
-        let data = try ControlSocketCodec.encode(.metricsResponse(
+        let data = try ControlSocketCodec.encode(.metricsResponse(ControlMetricsSnapshot(
             earningsUsdc: 0,
             malibuAccrued: 0,
             gpuC: nil,
             latencyP50Ms: nil,
             uptimeSec: 0
-        ))
+        )))
         let text = String(decoding: data, as: UTF8.self)
         XCTAssertFalse(text.contains("gpu_c"))
         XCTAssertFalse(text.contains("latency_p50_ms"))
-        XCTAssertEqual(try ControlSocketCodec.decode(data), .metricsResponse(
+        XCTAssertEqual(try ControlSocketCodec.decode(data), .metricsResponse(ControlMetricsSnapshot(
             earningsUsdc: 0, malibuAccrued: 0, gpuC: nil, latencyP50Ms: nil, uptimeSec: 0
-        ))
+        )))
     }
 
     func testEncodeDecodePauseAndResume() throws {

--- a/phase3-binary/Tests/macprovider-cliTests/MalibuAccrualClientTests.swift
+++ b/phase3-binary/Tests/macprovider-cliTests/MalibuAccrualClientTests.swift
@@ -1,0 +1,88 @@
+import Foundation
+import XCTest
+@testable import macprovider_cli
+
+final class MalibuAccrualClientTests: XCTestCase {
+    func testAccrualURLFromWSSCoordinator() {
+        let url = MalibuAccrualClient.accrualURL(from: "wss://coordinator.streamvc.live/v2/provider")
+        XCTAssertEqual(url?.absoluteString, "https://coordinator.streamvc.live/v1/provider/malibu-accrual")
+    }
+
+    func testAccrualURLFromHTTPSCoordinator() {
+        let url = MalibuAccrualClient.accrualURL(from: "https://coordinator.streamvc.live")
+        XCTAssertEqual(url?.absoluteString, "https://coordinator.streamvc.live/v1/provider/malibu-accrual")
+    }
+
+    func testDecodeAccrualSummaryStringDecimals() throws {
+        let json = """
+        {
+          "accrued_malibu": "12.5",
+          "withdrawable_malibu": "0",
+          "held_malibu": "12.5",
+          "trust_tier": "provisional",
+          "trust_criteria_met": 2,
+          "trust_criteria_required": 4,
+          "wallet_bound": true
+        }
+        """.data(using: .utf8)!
+        let summary = try JSONDecoder().decode(MalibuAccrualSummary.self, from: json)
+        XCTAssertEqual(summary.accruedMALIBU, 12.5)
+        XCTAssertEqual(summary.withdrawableMALIBU, 0)
+        XCTAssertEqual(summary.heldMALIBU, 12.5)
+        XCTAssertEqual(summary.trustTier, "provisional")
+        XCTAssertEqual(summary.trustCriteriaMet, 2)
+        XCTAssertEqual(summary.trustCriteriaRequired, 4)
+        XCTAssertEqual(summary.walletBound, true)
+    }
+
+    func testFetchUsesBearerToken() async throws {
+        let config = URLSessionConfiguration.ephemeral
+        config.protocolClasses = [MockURLProtocol.self]
+        let session = URLSession(configuration: config)
+        MockURLProtocol.requestHandler = { request in
+            XCTAssertEqual(request.value(forHTTPHeaderField: "Authorization"), "Bearer test-token")
+            let response = HTTPURLResponse(
+                url: request.url!,
+                statusCode: 200,
+                httpVersion: nil,
+                headerFields: ["Content-Type": "application/json"]
+            )!
+            let body = """
+            {"accrued_malibu":1.25,"withdrawable_malibu":0,"held_malibu":1.25,"trust_tier":"provisional"}
+            """.data(using: .utf8)!
+            return (response, body)
+        }
+        defer { MockURLProtocol.requestHandler = nil }
+
+        let client = MalibuAccrualClient(
+            accrualURL: URL(string: "https://coordinator.streamvc.live/v1/provider/malibu-accrual")!,
+            session: session
+        )
+        let summary = try await client.fetch(bearerToken: "test-token")
+        XCTAssertEqual(summary.accruedMALIBU, 1.25)
+    }
+}
+
+private final class MockURLProtocol: URLProtocol {
+    nonisolated(unsafe) static var requestHandler: ((URLRequest) throws -> (HTTPURLResponse, Data))?
+
+    override class func canInit(with request: URLRequest) -> Bool { true }
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+
+    override func startLoading() {
+        guard let handler = Self.requestHandler else {
+            client?.urlProtocol(self, didFailWithError: URLError(.badURL))
+            return
+        }
+        do {
+            let (response, data) = try handler(request)
+            client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+            client?.urlProtocol(self, didLoad: data)
+            client?.urlProtocolDidFinishLoading(self)
+        } catch {
+            client?.urlProtocol(self, didFailWithError: error)
+        }
+    }
+
+    override func stopLoading() {}
+}

--- a/phase3-binary/app/Sources/Malibu/Agent/MalibuAccrualClient.swift
+++ b/phase3-binary/app/Sources/Malibu/Agent/MalibuAccrualClient.swift
@@ -1,0 +1,81 @@
+import Foundation
+
+/// Provider-facing MALIBU accrual read model from GET /v1/provider/malibu-accrual (SPEC-MALIBU-EMISSION-LEDGER §5).
+struct MalibuAccrualSummary: Decodable, Equatable {
+    let accruedMALIBU: Double
+    let withdrawableMALIBU: Double
+    let heldMALIBU: Double
+    let trustTier: AgentSnapshot.TrustTier
+    let trustCriteriaMet: Int?
+    let trustCriteriaRequired: Int?
+    let walletBound: Bool?
+
+    enum CodingKeys: String, CodingKey {
+        case accruedMALIBU = "accrued_malibu"
+        case withdrawableMALIBU = "withdrawable_malibu"
+        case heldMALIBU = "held_malibu"
+        case trustTier = "trust_tier"
+        case trustCriteriaMet = "trust_criteria_met"
+        case trustCriteriaRequired = "trust_criteria_required"
+        case walletBound = "wallet_bound"
+    }
+
+    init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        accruedMALIBU = try Self.decodeDecimal(c, key: .accruedMALIBU)
+        withdrawableMALIBU = try Self.decodeDecimal(c, key: .withdrawableMALIBU)
+        heldMALIBU = try Self.decodeDecimal(c, key: .heldMALIBU)
+        trustTier = try c.decodeIfPresent(AgentSnapshot.TrustTier.self, forKey: .trustTier) ?? .provisional
+        trustCriteriaMet = try c.decodeIfPresent(Int.self, forKey: .trustCriteriaMet)
+        trustCriteriaRequired = try c.decodeIfPresent(Int.self, forKey: .trustCriteriaRequired)
+        walletBound = try c.decodeIfPresent(Bool.self, forKey: .walletBound)
+    }
+
+    private static func decodeDecimal(_ c: KeyedDecodingContainer<CodingKeys>, key: CodingKeys) throws -> Double {
+        guard c.contains(key) else { return 0 }
+        if let value = try? c.decode(Double.self, forKey: key) {
+            return value
+        }
+        if let text = try? c.decode(String.self, forKey: key) {
+            return Double(text) ?? 0
+        }
+        return 0
+    }
+}
+
+enum MalibuAccrualClientError: Error {
+    case httpStatus(Int)
+}
+
+struct MalibuAccrualClient {
+    let coordinatorBaseURL: URL
+    private let session: URLSession?
+
+    init(
+        coordinatorBaseURL: URL = URL(string: "https://coordinator.streamvc.live")!,
+        session: URLSession? = nil
+    ) {
+        self.coordinatorBaseURL = coordinatorBaseURL
+        self.session = session
+    }
+
+    func fetch(bearerToken: String) async throws -> MalibuAccrualSummary {
+        let url = coordinatorBaseURL.appendingPathComponent("v1/provider/malibu-accrual")
+        var request = URLRequest(url: url)
+        request.httpMethod = "GET"
+        request.setValue("Bearer \(bearerToken)", forHTTPHeaderField: "Authorization")
+        let data: Data
+        let response: URLResponse
+        if let session {
+            (data, response) = try await session.data(for: request)
+        } else {
+            let guarded = ProviderBearerURLSession.make()
+            defer { guarded.finishTasksAndInvalidate() }
+            (data, response) = try await guarded.data(for: request)
+        }
+        if let http = response as? HTTPURLResponse, !(200..<300).contains(http.statusCode) {
+            throw MalibuAccrualClientError.httpStatus(http.statusCode)
+        }
+        return try JSONDecoder().decode(MalibuAccrualSummary.self, from: data)
+    }
+}

--- a/phase3-binary/app/Sources/Malibu/Agent/MalibuAgent.swift
+++ b/phase3-binary/app/Sources/Malibu/Agent/MalibuAgent.swift
@@ -33,6 +33,7 @@ final class MalibuAgent: ObservableObject {
     private var providerLogTailCancellable: AnyCancellable?
     private var reconnect = ReconnectPolicy()
     private let earningsClient = EarningsClient()
+    private let malibuAccrualClient = MalibuAccrualClient()
     private let thermalMonitor = ThermalMonitor()
     private var cancellables: Set<AnyCancellable> = []
     // AUDIT R2 CODE H3 fix: once shutdown begins, refuse any subsequent start()
@@ -518,8 +519,7 @@ final class MalibuAgent: ObservableObject {
               let token = await KeychainStore.readProviderToken(providerID: providerID) else {
             return
         }
-        do {
-            let earnings = try await earningsClient.fetch(providerID: providerID, bearerToken: token)
+        if let earnings = try? await earningsClient.fetch(providerID: providerID, bearerToken: token) {
             snapshot.walletBound = earnings.walletBound
             snapshot.trustTier = earnings.trustTier
             snapshot.unpaidLedgerBacklogUSDC = earnings.unpaidLedgerBacklogUSDC
@@ -532,10 +532,15 @@ final class MalibuAgent: ObservableObject {
             snapshot.malibuAccruedAllTime = earnings.malibuAllTime
             snapshot.trustCriteriaMet = earnings.trustCriteriaMet
             snapshot.trustCriteriaRequired = earnings.trustCriteriaRequired
-        } catch {
-            // Earnings is not part of the daemon liveness path. Keep existing
-            // metrics visible and retry on the next poll without logging bearer
-            // material or the request payload.
+        }
+        if let accrual = try? await malibuAccrualClient.fetch(bearerToken: token) {
+            snapshot.malibuAccruedAllTime = accrual.accruedMALIBU
+            snapshot.trustTier = accrual.trustTier
+            snapshot.trustCriteriaMet = accrual.trustCriteriaMet
+            snapshot.trustCriteriaRequired = accrual.trustCriteriaRequired
+            if let walletBound = accrual.walletBound {
+                snapshot.walletBound = walletBound
+            }
         }
     }
 

--- a/phase3-binary/app/Tests/MalibuTests/MalibuAccrualClientTests.swift
+++ b/phase3-binary/app/Tests/MalibuTests/MalibuAccrualClientTests.swift
@@ -1,0 +1,24 @@
+import Foundation
+import XCTest
+@testable import Malibu
+
+final class MalibuAccrualClientTests: XCTestCase {
+    func testDecodeAccrualSummary() throws {
+        let json = """
+        {
+          "accrued_malibu": "3.75",
+          "withdrawable_malibu": "0",
+          "held_malibu": "3.75",
+          "trust_tier": "trusted",
+          "trust_criteria_met": 4,
+          "trust_criteria_required": 4,
+          "wallet_bound": true
+        }
+        """.data(using: .utf8)!
+        let summary = try JSONDecoder().decode(MalibuAccrualSummary.self, from: json)
+        XCTAssertEqual(summary.accruedMALIBU, 3.75)
+        XCTAssertEqual(summary.trustTier, .trusted)
+        XCTAssertEqual(summary.trustCriteriaMet, 4)
+        XCTAssertEqual(summary.walletBound, true)
+    }
+}

--- a/phase4-coordinator/cmd/coordinator/main.go
+++ b/phase4-coordinator/cmd/coordinator/main.go
@@ -1085,7 +1085,7 @@ func buyerHandlerWithOptionalProviderEndpoints(base http.Handler, enabled bool, 
 }
 
 func malibuAccrualHandler(cfg config.Config, tokenStore *auth.Store, rewardsDB *sql.DB, connectivity rewards.ProviderConnectivity) http.Handler {
-	if rewardsDB == nil || !cfg.MalibuEmission.Enabled {
+	if rewardsDB == nil {
 		return nil
 	}
 	rewardsCfg := rewards.Config{


### PR DESCRIPTION
## Summary
- Wire `GET /v1/provider/malibu-accrual` into the CLI control socket so `metrics_response` carries live uptime/token stats plus accrued MALIBU from the emission ledger.
- Add Malibu app accrual polling to overlay trust tier, criteria progress, wallet binding, and all-time accrued MALIBU on the existing earnings refresh path.
- Mount the coordinator accrual read API whenever `rewardsDB` is configured, even with `malibu_emission.enabled: false`, so Malibu can poll before C4 enables accrual.

## Test plan
- [x] `swift test --filter MalibuAccrualClientTests`
- [x] `swift test --filter ControlSocketTests`
- [x] `go test ./cmd/coordinator/...`
- [ ] CI green on PR


Made with [Cursor](https://cursor.com)