### PR TITLE
ops(malibu): Pearl C4 deploy tooling and stats-migrate CLI

### DIFF
--- a/ops/runbooks/README.md
+++ b/ops/runbooks/README.md
@@ -1,0 +1,8 @@
+# Ops runbooks
+
+| Track | Runbook | Scope |
+|-------|---------|-------|
+| **A — OPoI** | [`opoi-challenge-implementation.md`](./opoi-challenge-implementation.md) | Liveness canaries |
+| **A — OPoI Pearl** | [`opoi-pearl-deploy.md`](./opoi-pearl-deploy.md) | Pearl canary overlay deploy |
+| **C — $MALIBU bootstrap** | [`malibu-bootstrap-emission.md`](./malibu-bootstrap-emission.md) | Emission ledger, caps, Trusted unlock, Malibu UI |
+| **C — MALIBU Pearl** | [`malibu-pearl-deploy.md`](./malibu-pearl-deploy.md) | Session C4 Pearl migration + overlay |

--- a/ops/runbooks/malibu-bootstrap-emission.md
+++ b/ops/runbooks/malibu-bootstrap-emission.md
@@ -1,0 +1,72 @@
+# Runbook: $MALIBU bootstrap emission (Session C)
+
+**Version:** 0.1  
+**Date:** 2026-07-08  
+**Audience:** Coordinator billing + Malibu app implementers  
+**Session:** **C** — new Cursor session; **money-path PR required** for all ledger changes.  
+**Spec:** `specs/SPEC-MALIBU-EMISSION-LEDGER.md`  
+**Related:** [`mining-program-bootstrap.md`](./mining-program-bootstrap.md) (Session D), [`opoi-challenge-implementation.md`](./opoi-challenge-implementation.md) (Session A)
+
+---
+
+## 0. Executive path
+
+**Goal:** Accrue **$MALIBU** for early Malibu providers with enforceable sybil defenses before any withdrawable flow.
+
+**Prerequisite narrative (SPEC-026):** Provisional $MALIBU is **non-withdrawable until Trusted**. Per-wallet cap applies across provider_ids.
+
+**Out of scope:** OPoI canary rollout (Session A), proof-of-weights probes (Session B), bootstrap rate policy (Session D).
+
+---
+
+## 1. Preconditions
+
+- [ ] Read SPEC-026 §5.1, §5.2, §10 step 8
+- [ ] Operator stance before accrual ticks:
+  - **(a) Safest:** no MALIBU flow until ledger ships
+  - **(b) Accrual-only:** emit with `withdrawal_hold_reason` on every provisional row
+- [ ] OPoI v0 recommended on Pearl before enabling accrual ticks
+
+---
+
+## 2. Phase C1 — Schema + ledger (merged #480)
+
+Ledger schema, emission worker, `rewards_writer` role, migration `012`.
+
+---
+
+## 3. Phase C2 — Trusted unlock (merged #486)
+
+Unlock evaluator, dual-control promotion, migration `014`.
+
+---
+
+## 4. Phase C3 — Malibu app integration (merged #487)
+
+CLI control socket + Malibu app poll `GET /v1/provider/malibu-accrual`.
+
+---
+
+## 5. Phase C4 — Production rollout (ops)
+
+**Runbook:** [`malibu-pearl-deploy.md`](./malibu-pearl-deploy.md)
+
+1. [ ] Operator stance documented (§1)
+2. [ ] Deploy migrations 012+014 to Pearl (`coordinator stats-migrate`)
+3. [ ] Wire `writer_dsn`; keep `malibu_emission.enabled: false` until §4 verification passes
+4. [ ] Promote accrual ticks (`enabled: true`) only after read API + hold enforcement verified
+5. [ ] Monitor: `wallet_daily_malibu_emission`, cap hits, unlock rate
+
+---
+
+## 6. Rollback
+
+| Phase | Rollback |
+|-------|----------|
+| C1 | Stop emission worker; accrual rows frozen |
+| C2 | Freeze tier transitions |
+| C4 | `malibu_emission.enabled: false` or remove overlay drop-in |
+
+---
+
+*End of runbook.*

--- a/ops/runbooks/malibu-pearl-deploy.md
+++ b/ops/runbooks/malibu-pearl-deploy.md
@@ -1,0 +1,197 @@
+# Runbook: MALIBU emission Pearl deploy (Session C4)
+
+**Version:** 0.1  
+**Date:** 2026-07-08  
+**Audience:** Operator  
+**Parent:** [`malibu-bootstrap-emission.md`](./malibu-bootstrap-emission.md) §5  
+**Prerequisite:** C1 (#480), C2 (#486), C3 (#487) merged to `main`
+
+---
+
+## 0. What this deploy does
+
+| Changes | Does NOT change |
+|---------|-----------------|
+| Applies Postgres migrations `012_malibu_emission_ledger` + `014_malibu_trust_unlock` | `malibu_emission.enabled` (stays `false`) |
+| Installs coordinator binary with `writer_dsn` wired | Withdrawable MALIBU flow |
+| Merges MALIBU overlay into Pearl `coordinator.pearl-overlays.yaml` | Base `/opt/macprovider/coordinator.yaml` |
+| Mounts `GET /v1/provider/malibu-accrual` read API | nginx / TLS / gateway |
+
+**Operator stance (C4 staging):** accrual **read path** on, accrual **ticks** off until promotion.
+
+---
+
+## 1. Preconditions
+
+- [ ] `main` includes `coordinator stats-migrate` + C3 accrual read mount
+- [ ] Pearl SSH: `~/.ssh/pearl_operator_ed25519` (or `SSH_KEY`)
+- [ ] Pearl host: `159.223.165.194` (`coordinator.streamvc.live`)
+- [ ] `/etc/macprovider/coordinator.env` on Pearl
+- [ ] OPoI canaries recommended (Session A) before enabling accrual ticks
+- [ ] Prefer zero connected providers at restart, or `FORCE_RESTART=1`
+
+### 1.1 Add Pearl env vars (one-time)
+
+Append to `/etc/macprovider/coordinator.env` on Pearl:
+
+```bash
+# Admin DSN for stats-migrate (existing partner-keys admin role).
+COORDINATOR_PARTNER_KEYS_ADMIN_DSN=postgres://...
+
+# Runtime rewards_writer DSN (read API now; accrual worker when enabled).
+MALIBU_EMISSION_WRITER_DSN=postgres://rewards_writer:...@127.0.0.1:5432/macprovider_stats?sslmode=disable
+
+# Optional first-time login password for rewards_writer role:
+MALIBU_EMISSION_WRITER_PASSWORD='generate-a-strong-password'
+```
+
+After first deploy with `MALIBU_EMISSION_WRITER_PASSWORD` set, rotate the password out of the env file (DSN already embeds the secret).
+
+---
+
+## 2. Quick deploy (scripted)
+
+```bash
+cd phase4-coordinator
+bash scripts/build-linux.sh
+bash dist/deploy-malibu-emission-pearl.sh
+```
+
+Dry run:
+
+```bash
+DRY_RUN=1 bash dist/deploy-malibu-emission-pearl.sh
+```
+
+With providers connected:
+
+```bash
+FORCE_RESTART=1 bash dist/deploy-malibu-emission-pearl.sh
+```
+
+Migrations already applied:
+
+```bash
+SKIP_MIGRATE=1 bash dist/deploy-malibu-emission-pearl.sh
+```
+
+---
+
+## 3. Manual steps (if not using script)
+
+### 3.1 Build + upload binary
+
+Same as [`opoi-pearl-deploy.md`](./opoi-pearl-deploy.md) §3.1–3.2.
+
+### 3.2 Apply migrations
+
+```bash
+ssh pearl 'set -a && . /etc/macprovider/coordinator.env && set +a \
+  && /opt/macprovider/coordinator stats-migrate --admin-dsn "$COORDINATOR_PARTNER_KEYS_ADMIN_DSN" --check \
+  && /opt/macprovider/coordinator stats-migrate --admin-dsn "$COORDINATOR_PARTNER_KEYS_ADMIN_DSN"'
+```
+
+Confirm `012_malibu_emission_ledger` and `014_malibu_trust_unlock` show `applied`.
+
+### 3.3 Install overlay
+
+Merge `coordinator.opoi-v0-staging.yaml` (or existing Pearl overlay) with `coordinator.malibu-emission-overlay.yaml`:
+
+```bash
+python3 dist/merge-yaml-overlay.py coordinator.opoi-v0-staging.yaml coordinator.malibu-emission-overlay.yaml \
+  > /tmp/coordinator.pearl-overlays.yaml
+scp /tmp/coordinator.pearl-overlays.yaml pearl:/etc/macprovider/
+```
+
+Install systemd drop-in from `dist/systemd/malibu-emission.conf.example`.
+
+### 3.4 Validate + restart
+
+```bash
+ssh pearl '/opt/macprovider/coordinator \
+  --config /opt/macprovider/coordinator.yaml \
+  --config-overlay /etc/macprovider/coordinator.pearl-overlays.yaml \
+  --validate-config'
+ssh pearl 'systemctl daemon-reload && systemctl restart macprovider-coordinator'
+```
+
+---
+
+## 4. Verification (C4 pass criteria)
+
+### 4.1 Coordinator logs
+
+```bash
+ssh pearl 'journalctl -u macprovider-coordinator --since "5 min ago" --no-pager' \
+  | grep -E 'malibu_emission|stats-migrate'
+```
+
+Expect: `malibu_emission DISABLED via config (default)` — read pool still opens when `writer_dsn` is set.
+
+### 4.2 Accrual read API (provider bearer)
+
+```bash
+curl -sS -H "Authorization: Bearer $PROVIDER_TOKEN" \
+  https://coordinator.streamvc.live/v1/provider/malibu-accrual | jq
+```
+
+Expect `200` with `accrued_malibu`, `trust_tier`, `trust_criteria_*`, `wallet_bound`.
+
+### 4.3 Migration versions on Pearl Postgres
+
+```bash
+ssh pearl 'set -a && . /etc/macprovider/coordinator.env && set +a \
+  && psql "$COORDINATOR_PARTNER_KEYS_ADMIN_DSN" -c \
+  "SELECT version, name FROM schema_migrations_spec017 WHERE version IN (12, 14) ORDER BY version"'
+```
+
+---
+
+## 5. Promotion — enable accrual ticks (post-C4)
+
+Only after §4 passes and operator accepts stance **(b) accrual-only**:
+
+1. Edit `/etc/macprovider/coordinator.pearl-overlays.yaml` on Pearl: `malibu_emission.enabled: true`
+2. `systemctl restart macprovider-coordinator`
+3. Watch logs for `malibu_emission` subsystem ticks
+4. Monitor `wallet_daily_malibu_emission` and provisional `withdrawal_hold_reason`
+
+**Do not** enable withdrawable MALIBU until C1+C2 lab verification is complete on production data.
+
+---
+
+## 6. Rollback
+
+### 6.1 Disable overlay (keep binary)
+
+```bash
+ssh pearl 'sudo rm /etc/systemd/system/macprovider-coordinator.service.d/malibu-emission.conf \
+  && sudo systemctl daemon-reload && sudo systemctl restart macprovider-coordinator'
+```
+
+### 6.2 Freeze accrual ticks (keep read API)
+
+Set `malibu_emission.enabled: false` in pearl overlay and restart.
+
+### 6.3 Binary rollback
+
+```bash
+ssh pearl 'sudo install -o root -g macprovider -m 0750 \
+  /opt/macprovider/coordinator.prev /opt/macprovider/coordinator \
+  && sudo systemctl restart macprovider-coordinator'
+```
+
+---
+
+## 7. Monitoring (post-promotion)
+
+| Signal | Query / log |
+|--------|-------------|
+| Cap hits | `withdrawal_hold_reason = per_wallet_daily_cap` in `provider_rewards_ledger` |
+| Wallet aggregate | `wallet_daily_malibu_emission` daily sums |
+| Unlock rate | `provider_emission_state.trust_tier` transitions |
+| Held accrual | `held_malibu` in accrual API vs withdrawable |
+
+---
+
+*End of runbook.*

--- a/phase4-coordinator/cmd/coordinator/dispatch_test.go
+++ b/phase4-coordinator/cmd/coordinator/dispatch_test.go
@@ -167,6 +167,25 @@ func TestDispatchJournalStreamFlagAccepted(t *testing.T) {
 	}
 }
 
+// TestDispatchStatsMigrateMissingAdminDSN — stats-migrate rejects missing DSN.
+func TestDispatchStatsMigrateMissingAdminDSN(t *testing.T) {
+	bin := locateCoordinatorBinary(t)
+	cmd := exec.Command(bin, "stats-migrate")
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	err := cmd.Run()
+	exitCode := exitCodeOf(err)
+	if exitCode != 2 {
+		t.Fatalf("stats-migrate without --admin-dsn exit=%d, want 2; stderr=%q", exitCode, stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "no admin DSN") {
+		t.Errorf("stderr should mention missing admin DSN; got %q", stderr.String())
+	}
+	if strings.Contains(stderr.String(), "open coordinator.yaml") {
+		t.Errorf("stats-migrate fell through to daemon config load: %q", stderr.String())
+	}
+}
+
 func exitCodeOf(err error) int {
 	if err == nil {
 		return 0

--- a/phase4-coordinator/cmd/coordinator/main.go
+++ b/phase4-coordinator/cmd/coordinator/main.go
@@ -88,6 +88,8 @@ func main() {
 			os.Exit(runMigrateIndexes(os.Args[2:]))
 		case "backfill-attempt-n":
 			os.Exit(runBackfillAttemptN(os.Args[2:]))
+		case "stats-migrate":
+			os.Exit(runStatsMigrate(os.Args[2:]))
 		}
 		// Round-1 CODE H1 fix: a non-flag first positional that
 		// is NEITHER a known daemon flag NOR a known CLI verb is
@@ -105,6 +107,7 @@ func main() {
 			fmt.Fprintln(os.Stderr, "  coordinator visibility revert --id <pid> --reason TEXT")
 			fmt.Fprintln(os.Stderr, "  coordinator migrate-indexes --config <path>  (one-shot operator migration)")
 			fmt.Fprintln(os.Stderr, "  coordinator backfill-attempt-n --config <path>  (one-shot attempt_n backfill)")
+			fmt.Fprintln(os.Stderr, "  coordinator stats-migrate [--admin-dsn DSN] [--check]  (SPEC-017 stats/rewards migrations)")
 			os.Exit(2)
 		}
 	}

--- a/phase4-coordinator/cmd/coordinator/stats_migrate.go
+++ b/phase4-coordinator/cmd/coordinator/stats_migrate.go
@@ -1,0 +1,130 @@
+package main
+
+// SPEC-017 / SPEC-MALIBU-EMISSION-LEDGER — operator migration CLI:
+//
+//	coordinator stats-migrate [--admin-dsn DSN] [--config path] [--check]
+//
+// Applies embedded stats/rewards Postgres migrations (schema_migrations_spec017)
+// using an admin-capable DSN. Not invoked from the daemon path.
+
+import (
+	"context"
+	"database/sql"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"time"
+
+	statsmigrations "github.com/augstar/macprovider-coordinator/internal/stats/migrations"
+
+	_ "github.com/lib/pq"
+)
+
+func runStatsMigrate(args []string) int {
+	return runStatsMigrateIO(args, os.Stdout, os.Stderr)
+}
+
+func runStatsMigrateIO(args []string, stdout, stderr io.Writer) int {
+	fs := flag.NewFlagSet("stats-migrate", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	adminDSNFlag := fs.String("admin-dsn", "", "operator admin DSN (overrides --config and "+adminDSNEnv+")")
+	configPath := fs.String("config", "", "optional coordinator YAML (reads stats.partner_keys_admin_dsn when --admin-dsn unset)")
+	check := fs.Bool("check", false, "report applied migration versions without mutating schema")
+	timeout := fs.Duration("timeout", 10*time.Minute, "max time for migration apply")
+	if err := fs.Parse(args); err != nil {
+		return 2
+	}
+
+	dsn, source, err := resolveAdminDSN(*adminDSNFlag, *configPath)
+	if err != nil {
+		fmt.Fprintf(stderr, "stats-migrate: %v\n", err)
+		return 2
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), *timeout)
+	defer cancel()
+
+	db, err := sql.Open("postgres", dsn)
+	if err != nil {
+		fmt.Fprintf(stderr, "stats-migrate: open db (%s): %v\n", source, err)
+		return 1
+	}
+	defer db.Close()
+	if err := db.PingContext(ctx); err != nil {
+		fmt.Fprintf(stderr, "stats-migrate: ping db (%s): %v\n", source, err)
+		return 1
+	}
+
+	all, err := statsmigrations.All()
+	if err != nil {
+		fmt.Fprintf(stderr, "stats-migrate: load migrations: %v\n", err)
+		return 1
+	}
+
+	applied, err := queryAppliedMigrationVersions(ctx, db)
+	if err != nil {
+		fmt.Fprintf(stderr, "stats-migrate: read applied versions: %v\n", err)
+		return 1
+	}
+
+	if *check {
+		fmt.Fprintf(stdout, "stats-migrate check (%s): %d embedded, %d applied\n", source, len(all), len(applied))
+		for _, m := range all {
+			state := "pending"
+			if applied[m.Version] {
+				state = "applied"
+			}
+			fmt.Fprintf(stdout, "  %03d_%s %s\n", m.Version, m.Name, state)
+		}
+		return 0
+	}
+
+	started := time.Now()
+	if err := statsmigrations.Apply(ctx, db); err != nil {
+		fmt.Fprintf(stderr, "stats-migrate: apply failed: %v\n", err)
+		return 1
+	}
+	appliedAfter, err := queryAppliedMigrationVersions(ctx, db)
+	if err != nil {
+		fmt.Fprintf(stderr, "stats-migrate: post-apply version read: %v\n", err)
+		return 1
+	}
+	var pending int
+	for _, m := range all {
+		if !appliedAfter[m.Version] {
+			pending++
+		}
+	}
+	if pending > 0 {
+		fmt.Fprintf(stderr, "stats-migrate: %d migration(s) still pending after apply\n", pending)
+		return 1
+	}
+	fmt.Fprintf(stdout, "stats-migrate ok (%s, %s)\n", source, time.Since(started).Round(time.Millisecond))
+	return 0
+}
+
+func queryAppliedMigrationVersions(ctx context.Context, db *sql.DB) (map[int]bool, error) {
+	rows, err := db.QueryContext(ctx, `SELECT version FROM schema_migrations_spec017`)
+	if err != nil {
+		// Table may not exist before first migration.
+		if strings.Contains(err.Error(), "does not exist") {
+			return map[int]bool{}, nil
+		}
+		return nil, err
+	}
+	defer rows.Close()
+	out := make(map[int]bool)
+	for rows.Next() {
+		var version int
+		if err := rows.Scan(&version); err != nil {
+			return nil, err
+		}
+		out[version] = true
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return out, nil
+}

--- a/phase4-coordinator/coordinator.malibu-emission-overlay.yaml
+++ b/phase4-coordinator/coordinator.malibu-emission-overlay.yaml
@@ -1,0 +1,18 @@
+# coordinator.malibu-emission-overlay.yaml — Session C4 Pearl overlay
+#
+# Mounts MALIBU accrual read API (writer_dsn) while keeping accrual ticks
+# disabled until operator promotion. Merge with any existing Pearl overlay
+# (e.g. OPoI canaries) before install — deploy script does this automatically.
+#
+# Promotion (after C4 verification): set enabled: true and restart coordinator.
+# Rollback: set enabled: false or remove this overlay block.
+
+malibu_emission:
+  enabled: false
+  writer_dsn: env:MALIBU_EMISSION_WRITER_DSN
+  tick_interval_seconds: 900
+  provider_daily_cap_malibu: 25
+  wallet_daily_cap_malibu: 100
+  wallet_mirror_interval_seconds: 300
+  unlock_eval_interval_seconds: 3600
+  max_serializable_retries: 5

--- a/phase4-coordinator/dist/deploy-malibu-emission-pearl.sh
+++ b/phase4-coordinator/dist/deploy-malibu-emission-pearl.sh
@@ -1,0 +1,238 @@
+#!/usr/bin/env bash
+# deploy-malibu-emission-pearl.sh — Session C4: MALIBU emission Pearl rollout.
+#
+# Applies stats migrations 012+014, installs coordinator binary with merged
+# overlay (preserves OPoI canary overlay when present), and keeps
+# malibu_emission.enabled=false until operator promotion.
+#
+# Usage (from operator Mac, repo at origin/main):
+#   cd phase4-coordinator
+#   bash scripts/build-linux.sh
+#   bash dist/deploy-malibu-emission-pearl.sh
+#
+# Environment:
+#   SSH_KEY                 default ~/.ssh/pearl_operator_ed25519
+#   VPS_HOST                default 159.223.165.194
+#   VPS_USER                default root
+#   DOMAIN                  default coordinator.streamvc.live
+#   FORCE_RESTART           default 0
+#   SKIP_BUILD              default 0
+#   SKIP_MIGRATE            default 0 — set 1 if migrations already applied
+#   DRY_RUN                 default 0
+#
+# Pearl /etc/macprovider/coordinator.env MUST contain (non-empty):
+#   COORDINATOR_PARTNER_KEYS_ADMIN_DSN  — admin-capable Postgres (stats-migrate)
+#   MALIBU_EMISSION_WRITER_DSN          — rewards_writer runtime DSN
+#
+# Optional (first-time rewards_writer login):
+#   MALIBU_EMISSION_WRITER_PASSWORD     — if set, deploy runs ALTER ROLE rewards_writer
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+DIST_DIR="$SCRIPT_DIR"
+MODULE_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+BINARY="$DIST_DIR/coordinator-linux-amd64"
+MALIBU_OVERLAY="$MODULE_DIR/coordinator.malibu-emission-overlay.yaml"
+OPIO_OVERLAY="$MODULE_DIR/coordinator.opoi-v0-staging.yaml"
+DROPIN="$DIST_DIR/systemd/malibu-emission.conf.example"
+MERGE_PY="$DIST_DIR/merge-yaml-overlay.py"
+
+SSH_KEY="${SSH_KEY:-$HOME/.ssh/pearl_operator_ed25519}"
+VPS_HOST="${VPS_HOST:-159.223.165.194}"
+VPS_USER="${VPS_USER:-root}"
+DOMAIN="${DOMAIN:-coordinator.streamvc.live}"
+FORCE_RESTART="${FORCE_RESTART:-0}"
+SKIP_BUILD="${SKIP_BUILD:-0}"
+SKIP_MIGRATE="${SKIP_MIGRATE:-0}"
+DRY_RUN="${DRY_RUN:-0}"
+
+log() { printf '[malibu-deploy] %s\n' "$*"; }
+run() {
+  if [ "$DRY_RUN" = "1" ]; then
+    log "DRY_RUN: $*"
+  else
+    "$@"
+  fi
+}
+
+for f in "$MALIBU_OVERLAY" "$DROPIN" "$MERGE_PY"; do
+  [ -f "$f" ] || { echo "missing required file: $f" >&2; exit 1; }
+done
+if [ "$DRY_RUN" != "1" ] && [ ! -f "$BINARY" ]; then
+  echo "missing required file: $BINARY (run scripts/build-linux.sh first)" >&2
+  exit 1
+fi
+
+if [ "$SKIP_BUILD" != "1" ]; then
+  log "building coordinator linux/amd64"
+  if [ "$DRY_RUN" = "1" ]; then
+    log "DRY_RUN: would run bash $MODULE_DIR/scripts/build-linux.sh"
+  else
+    bash "$MODULE_DIR/scripts/build-linux.sh"
+  fi
+fi
+
+SSH=(ssh -i "$SSH_KEY" -o ConnectTimeout=10 -p 22 "$VPS_USER@$VPS_HOST")
+SCP=(scp -i "$SSH_KEY" -P 22)
+
+log "step 1/8: SSH + connected-provider guard"
+if [ "$DRY_RUN" != "1" ]; then
+  "${SSH[@]}" 'hostname && uptime' >/dev/null
+fi
+CONNECTED_COUNT=0
+if [ "$DRY_RUN" != "1" ]; then
+  CONNECTED_COUNT=$(curl -fsS --max-time 5 --max-filesize 65536 "https://$DOMAIN/healthz" 2>/dev/null \
+    | python3 -c "import sys,json; print(json.load(sys.stdin).get('pool_size', 0))" 2>/dev/null \
+    || echo 0)
+fi
+if [ "${CONNECTED_COUNT:-0}" -gt 0 ] && [ "$FORCE_RESTART" != "1" ]; then
+  log "REFUSING — $CONNECTED_COUNT provider(s) connected. Use FORCE_RESTART=1 to proceed."
+  exit 4
+fi
+log "ok: connected providers=$CONNECTED_COUNT"
+
+log "step 2/8: Pearl env preflight (admin + writer DSNs)"
+if [ "$DRY_RUN" != "1" ]; then
+  "${SSH[@]}" 'set -euo pipefail
+    env_file=/etc/macprovider/coordinator.env
+    [ -r "$env_file" ] || { echo "missing $env_file" >&2; exit 12; }
+    require_var() {
+      name="$1"
+      if ! python3 - "$env_file" "$name" <<'"'"'PY'"'"'
+import re, shlex, sys
+path, want = sys.argv[1], sys.argv[2]
+found = False
+val = ""
+with open(path, "r", encoding="utf-8") as f:
+    for raw in f:
+        line = raw.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        key, value = line.split("=", 1)
+        if key.strip() != want:
+            continue
+        parts = shlex.split(value.strip(), posix=True)
+        if len(parts) != 1 or not parts[0]:
+            sys.exit(2)
+        found, val = True, parts[0]
+        break
+if not found or not val:
+    sys.exit(1)
+print(val)
+PY
+      then
+        echo "aborting: $env_file missing or empty required var: $name" >&2
+        exit 12
+      fi
+    }
+    require_var COORDINATOR_PARTNER_KEYS_ADMIN_DSN >/dev/null
+    require_var MALIBU_EMISSION_WRITER_DSN >/dev/null
+    echo "  ok: COORDINATOR_PARTNER_KEYS_ADMIN_DSN and MALIBU_EMISSION_WRITER_DSN present"
+  '
+fi
+
+log "step 3/8: merge Pearl overlay (OPoI + MALIBU)"
+WORKDIR=""
+if [ "$DRY_RUN" = "1" ]; then
+  log "DRY_RUN: would merge overlays into coordinator.pearl-overlays.yaml"
+else
+  WORKDIR=$(mktemp -d)
+  trap 'rm -rf "$WORKDIR"' EXIT
+  BASE_OVERLAY="$OPIO_OVERLAY"
+  if "${SSH[@]}" 'test -f /etc/macprovider/coordinator.pearl-overlays.yaml'; then
+    "${SCP[@]}" "$VPS_USER@$VPS_HOST:/etc/macprovider/coordinator.pearl-overlays.yaml" "$WORKDIR/base.yaml"
+    BASE_OVERLAY="$WORKDIR/base.yaml"
+    log "  using existing /etc/macprovider/coordinator.pearl-overlays.yaml as merge base"
+  elif "${SSH[@]}" 'test -f /etc/macprovider/coordinator.opoi-v0-staging.yaml'; then
+    "${SCP[@]}" "$VPS_USER@$VPS_HOST:/etc/macprovider/coordinator.opoi-v0-staging.yaml" "$WORKDIR/base.yaml"
+    BASE_OVERLAY="$WORKDIR/base.yaml"
+    log "  using existing OPoI overlay as merge base"
+  else
+    log "  no Pearl overlay found; merging repo OPoI staging defaults"
+  fi
+  python3 "$MERGE_PY" "$BASE_OVERLAY" "$MALIBU_OVERLAY" > "$WORKDIR/coordinator.pearl-overlays.yaml"
+fi
+
+log "step 4/8: stage artifacts on Pearl"
+if [ "$DRY_RUN" = "1" ]; then
+  DEPLOY_TMP="/tmp/macprovider-malibu-deploy.XXXXXXXX"
+else
+  DEPLOY_TMP=$("${SSH[@]}" 'umask 077 && mktemp -d -t macprovider-malibu-deploy.XXXXXXXX')
+  case "$DEPLOY_TMP" in
+    /tmp/macprovider-malibu-deploy.*) ;;
+    *) echo "unexpected mktemp path: $DEPLOY_TMP" >&2; exit 1 ;;
+  esac
+  trap "${SSH[@]} rm -rf $DEPLOY_TMP" EXIT
+  "${SCP[@]}" "$BINARY" "$VPS_USER@$VPS_HOST:$DEPLOY_TMP/coordinator-linux-amd64"
+  "${SCP[@]}" "$WORKDIR/coordinator.pearl-overlays.yaml" "$VPS_USER@$VPS_HOST:$DEPLOY_TMP/coordinator.pearl-overlays.yaml"
+  "${SCP[@]}" "$DROPIN" "$VPS_USER@$VPS_HOST:$DEPLOY_TMP/malibu-emission.conf"
+fi
+
+log "step 5/8: install binary + merged overlay + systemd drop-in"
+if [ "$DRY_RUN" != "1" ]; then
+  "${SSH[@]}" "set -e
+    if [ -x /opt/macprovider/coordinator ]; then
+      install -o root -g macprovider -m 0750 /opt/macprovider/coordinator /opt/macprovider/coordinator.prev
+    fi
+    install -o root -g macprovider -m 0750 $DEPLOY_TMP/coordinator-linux-amd64 /opt/macprovider/coordinator
+    install -o root -g macprovider -m 0640 $DEPLOY_TMP/coordinator.pearl-overlays.yaml /etc/macprovider/coordinator.pearl-overlays.yaml
+    install -d -o root -g root -m 0755 /etc/systemd/system/macprovider-coordinator.service.d
+    install -o root -g root -m 0644 $DEPLOY_TMP/malibu-emission.conf \
+      /etc/systemd/system/macprovider-coordinator.service.d/malibu-emission.conf
+  "
+fi
+
+log "step 6/8: stats-migrate (012 malibu_emission_ledger + 014 malibu_trust_unlock)"
+if [ "$SKIP_MIGRATE" != "1" ] && [ "$DRY_RUN" != "1" ]; then
+  "${SSH[@]}" 'set -euo pipefail
+    env_file=/etc/macprovider/coordinator.env
+    set -a
+    # shellcheck disable=SC1090
+    . "$env_file"
+    set +a
+    /opt/macprovider/coordinator stats-migrate --admin-dsn "$COORDINATOR_PARTNER_KEYS_ADMIN_DSN" --check
+    /opt/macprovider/coordinator stats-migrate --admin-dsn "$COORDINATOR_PARTNER_KEYS_ADMIN_DSN"
+    if [ -n "${MALIBU_EMISSION_WRITER_PASSWORD:-}" ]; then
+      psql "$COORDINATOR_PARTNER_KEYS_ADMIN_DSN" -v ON_ERROR_STOP=1 \
+        -c "ALTER ROLE rewards_writer WITH LOGIN PASSWORD '"'"'${MALIBU_EMISSION_WRITER_PASSWORD}'"'"'"
+      echo "  ok: rewards_writer login password rotated from MALIBU_EMISSION_WRITER_PASSWORD"
+    fi
+  '
+elif [ "$SKIP_MIGRATE" = "1" ]; then
+  log "  SKIP_MIGRATE=1 — skipping stats-migrate"
+fi
+
+log "step 7/8: validate merged config + restart"
+if [ "$DRY_RUN" != "1" ]; then
+  "${SSH[@]}" 'set -euo pipefail
+    env_file=/etc/macprovider/coordinator.env
+    set -a
+    # shellcheck disable=SC1090
+    . "$env_file"
+    set +a
+    /opt/macprovider/coordinator \
+      --config /opt/macprovider/coordinator.yaml \
+      --config-overlay /etc/macprovider/coordinator.pearl-overlays.yaml \
+      --validate-config
+    systemctl daemon-reload
+    systemctl restart macprovider-coordinator
+    sleep 3
+    systemctl is-active macprovider-coordinator
+  '
+fi
+
+log "step 8/8: verify healthz + malibu_emission disabled log line"
+if [ "$DRY_RUN" != "1" ]; then
+  HEALTHZ=$(curl -fsS --max-time 10 --max-filesize 65536 "https://$DOMAIN/healthz")
+  printf '%s\n' "$HEALTHZ" | python3 -m json.tool
+  "${SSH[@]}" 'journalctl -u macprovider-coordinator --since "2 min ago" --no-pager' \
+    | grep -E 'malibu_emission (DISABLED|started)' || true
+fi
+
+log "DONE. C4 staging complete with malibu_emission.enabled=false."
+log "Verify read API from a provider token:"
+log "  curl -sS -H \"Authorization: Bearer \$PROVIDER_TOKEN\" https://$DOMAIN/v1/provider/malibu-accrual | jq"
+log "Promotion (accrual ticks): set malibu_emission.enabled: true in pearl overlay and restart."
+log "Rollback:"
+log "  ssh -i $SSH_KEY $VPS_USER@$VPS_HOST 'sudo rm /etc/systemd/system/macprovider-coordinator.service.d/malibu-emission.conf && sudo systemctl daemon-reload && sudo systemctl restart macprovider-coordinator'"

--- a/phase4-coordinator/dist/merge-yaml-overlay.py
+++ b/phase4-coordinator/dist/merge-yaml-overlay.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python3
+"""Shallow-merge two YAML mapping documents (overlay keys win)."""
+from __future__ import annotations
+
+import sys
+
+try:
+    import yaml
+except ImportError as exc:  # pragma: no cover
+    print("merge-yaml-overlay.py requires PyYAML (pip install pyyaml)", file=sys.stderr)
+    raise SystemExit(2) from exc
+
+
+def merge(base: dict, overlay: dict) -> dict:
+    out = dict(base)
+    for key, value in overlay.items():
+        if isinstance(value, dict) and isinstance(out.get(key), dict):
+            out[key] = merge(out[key], value)
+        else:
+            out[key] = value
+    return out
+
+
+def main() -> int:
+    if len(sys.argv) != 3:
+        print("usage: merge-yaml-overlay.py <base.yaml> <overlay.yaml>", file=sys.stderr)
+        return 2
+    with open(sys.argv[1], "r", encoding="utf-8") as f:
+        base = yaml.safe_load(f) or {}
+    with open(sys.argv[2], "r", encoding="utf-8") as f:
+        overlay = yaml.safe_load(f) or {}
+    if not isinstance(base, dict) or not isinstance(overlay, dict):
+        print("both inputs must be YAML mappings", file=sys.stderr)
+        return 2
+    yaml.safe_dump(merge(base, overlay), sys.stdout, sort_keys=False, default_flow_style=False)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/phase4-coordinator/dist/systemd/malibu-emission.conf.example
+++ b/phase4-coordinator/dist/systemd/malibu-emission.conf.example
@@ -1,0 +1,14 @@
+# systemd drop-in — MALIBU emission overlay (Session C4)
+#
+# Install on Pearl (after deploy-malibu-emission-pearl.sh merges overlays):
+#   /etc/systemd/system/macprovider-coordinator.service.d/malibu-emission.conf
+#
+# Rollback overlay only:
+#   sudo rm /etc/systemd/system/macprovider-coordinator.service.d/malibu-emission.conf
+#   sudo systemctl daemon-reload && sudo systemctl restart macprovider-coordinator
+
+[Service]
+ExecStart=
+ExecStart=/opt/macprovider/coordinator \
+  --config /opt/macprovider/coordinator.yaml \
+  --config-overlay /etc/macprovider/coordinator.pearl-overlays.yaml

--- a/phase4-coordinator/internal/config/config_test.go
+++ b/phase4-coordinator/internal/config/config_test.go
@@ -614,3 +614,35 @@ pool:
 		t.Fatalf("canary challenges=%d want 1", len(cfg.Pool.CanaryChallenges))
 	}
 }
+
+func TestLoadWithOverlayMalibuEmissionBlock(t *testing.T) {
+	t.Setenv("MALIBU_EMISSION_WRITER_DSN", "postgres://rewards_writer:pw@127.0.0.1:5432/stats?sslmode=disable")
+	dir := t.TempDir()
+	basePath := filepath.Join(dir, "base.yaml")
+	overlayPath := filepath.Join(dir, "malibu.yaml")
+	if err := os.WriteFile(basePath, []byte("auth:\n  operator_key: test-operator-key-with-32-byte-minimum-length\n"), 0o644); err != nil {
+		t.Fatalf("write base: %v", err)
+	}
+	overlay := strings.TrimSpace(`
+malibu_emission:
+  enabled: false
+  writer_dsn: env:MALIBU_EMISSION_WRITER_DSN
+  provider_daily_cap_malibu: 25
+`)
+	if err := os.WriteFile(overlayPath, []byte(overlay), 0o644); err != nil {
+		t.Fatalf("write overlay: %v", err)
+	}
+	cfg, err := LoadWithOverlay(basePath, overlayPath)
+	if err != nil {
+		t.Fatalf("LoadWithOverlay: %v", err)
+	}
+	if cfg.MalibuEmission.Enabled {
+		t.Fatal("malibu overlay should keep enabled false for C4 staging")
+	}
+	if cfg.MalibuEmission.WriterDSN != "postgres://rewards_writer:pw@127.0.0.1:5432/stats?sslmode=disable" {
+		t.Fatalf("writer_dsn=%q", cfg.MalibuEmission.WriterDSN)
+	}
+	if cfg.MalibuEmission.ProviderDailyCapMALIBU != 25 {
+		t.Fatalf("provider cap=%v", cfg.MalibuEmission.ProviderDailyCapMALIBU)
+	}
+}


### PR DESCRIPTION
## Summary
- Add `coordinator stats-migrate` operator CLI to apply embedded stats/rewards migrations (012 + 014) with an admin DSN.
- Add Pearl deploy script, overlay merge helper, systemd drop-in, and Session C4 runbooks.
- Staging overlay wires `writer_dsn` for the accrual read API while keeping `malibu_emission.enabled: false` until operator promotion.

## Test plan
- [x] `go test ./cmd/coordinator/... -run DispatchStatsMigrate`
- [x] `go test ./internal/config/... -run LoadWithOverlayMalibu`
- [ ] CI green
- [ ] Pearl deploy dry-run: `DRY_RUN=1 bash dist/deploy-malibu-emission-pearl.sh`


Made with [Cursor](https://cursor.com)