### PR TITLE
fix(ops): nginx route for GET /v1/provider/malibu-accrual

### DIFF
--- a/ops/runbooks/malibu-pearl-deploy.md
+++ b/ops/runbooks/malibu-pearl-deploy.md
@@ -15,7 +15,7 @@
 | Applies Postgres migrations `012_malibu_emission_ledger` + `014_malibu_trust_unlock` | `malibu_emission.enabled` (stays `false`) |
 | Installs coordinator binary with `writer_dsn` wired | Withdrawable MALIBU flow |
 | Merges MALIBU overlay into Pearl `coordinator.pearl-overlays.yaml` | Base `/opt/macprovider/coordinator.yaml` |
-| Mounts `GET /v1/provider/malibu-accrual` read API | nginx / TLS / gateway |
+| Mounts `GET /v1/provider/malibu-accrual` read API | Base nginx vhost (add `location = /v1/provider/malibu-accrual` per §4.4) |
 
 **Operator stance (C4 staging):** accrual **read path** on, accrual **ticks** off until promotion.
 
@@ -143,6 +143,23 @@ Expect `200` with `accrued_malibu`, `trust_tier`, `trust_criteria_*`, `wallet_bo
 ssh pearl 'set -a && . /etc/macprovider/coordinator.env && set +a \
   && psql "$COORDINATOR_PARTNER_KEYS_ADMIN_DSN" -c \
   "SELECT version, name FROM schema_migrations_spec017 WHERE version IN (12, 14) ORDER BY version"'
+```
+
+### 4.4 Nginx allow-through (one-time)
+
+`GET /v1/provider/malibu-accrual` lives on buyer port **8443**. Without an exact-match nginx location, the public URL returns **404**.
+
+Install from repo template (or copy the `location = /v1/provider/malibu-accrual` block from `phase4-coordinator/dist/nginx-coordinator.streamvc.live.conf`):
+
+```bash
+# On Pearl — merge block after /v1/provider/wallet, then:
+nginx -t && systemctl reload nginx
+```
+
+Unauthenticated probe should return **401** (not 404):
+
+```bash
+curl -sS -o /dev/null -w "%{http_code}\n" https://coordinator.streamvc.live/v1/provider/malibu-accrual
 ```
 
 ---

--- a/phase4-coordinator/cmd/coordinator/main_test.go
+++ b/phase4-coordinator/cmd/coordinator/main_test.go
@@ -216,6 +216,34 @@ func TestNginxWalletRouteBeforeV1CatchAll(t *testing.T) {
 	}
 }
 
+func TestNginxMalibuAccrualRouteBeforeV1CatchAll(t *testing.T) {
+	body, err := os.ReadFile("../../dist/nginx-coordinator.streamvc.live.conf")
+	if err != nil {
+		t.Fatalf("read nginx config: %v", err)
+	}
+	cfg := string(body)
+	route := strings.Index(cfg, "location = /v1/provider/malibu-accrual")
+	catchAll := strings.Index(cfg, "location /v1/ {\n        return 404;")
+	if route < 0 {
+		t.Fatal("missing exact /v1/provider/malibu-accrual route")
+	}
+	if catchAll < 0 {
+		t.Fatal("missing /v1/ catch-all route")
+	}
+	if route > catchAll {
+		t.Fatal("/v1/provider/malibu-accrual route must appear before /v1/ catch-all")
+	}
+	for _, needle := range []string{
+		"proxy_pass http://127.0.0.1:8443/v1/provider/malibu-accrual;",
+		"proxy_set_header Authorization $http_authorization;",
+		"add_header Cache-Control \"no-store\" always;",
+	} {
+		if !strings.Contains(cfg[route:catchAll], needle) {
+			t.Fatalf("malibu-accrual route missing %q", needle)
+		}
+	}
+}
+
 func TestNginxV2ProviderAliasesExistingWSHandler(t *testing.T) {
 	body, err := os.ReadFile("../../dist/nginx-coordinator.streamvc.live.conf")
 	if err != nil {

--- a/phase4-coordinator/dist/nginx-coordinator.streamvc.live.conf
+++ b/phase4-coordinator/dist/nginx-coordinator.streamvc.live.conf
@@ -341,6 +341,23 @@ server {
     }
 
     # ---------------------------------------------------------------------
+    # /v1/provider/malibu-accrual — MALIBU accrual read API (Session C3/C4).
+    # Lives on buyer_port (8443). Provider bearer auth.
+    # ---------------------------------------------------------------------
+    location = /v1/provider/malibu-accrual {
+        proxy_pass http://127.0.0.1:8443/v1/provider/malibu-accrual;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header Authorization $http_authorization;
+        proxy_read_timeout 10s;
+        proxy_no_cache 1;
+        proxy_cache_bypass 1;
+        add_header Cache-Control "no-store" always;
+    }
+
+    # ---------------------------------------------------------------------
     # SPEC-017 v0.1.8 Step 4.B — /v1/stats/* allow-through. Public
     # Network Stats API endpoints, mounted on the coordinator's
     # provider port (8444) per main.go:525. The dedicated vhost


### PR DESCRIPTION
## Summary
- Adds `location = /v1/provider/malibu-accrual` to `nginx-coordinator.streamvc.live.conf` (buyer mux 8443).
- Documents one-time Pearl nginx step in `malibu-pearl-deploy.md` §4.4.
- Unit test guards route ordering before `/v1/` catch-all.

## Context
C4 Pearl deploy mounted the accrual handler, but public URL returned 404 until nginx allow-through was added live.

## Test plan
- [x] `go test ./cmd/coordinator -run TestNginxMalibuAccrual -count=1`
- [x] Pearl live: `curl -w "%{http_code}" https://coordinator.streamvc.live/v1/provider/malibu-accrual` → 401


Made with [Cursor](https://cursor.com)