### PR TITLE
feat(proof-of-weights): W3 model-class canary probes + hello gate catalog-key fix

### DIFF
--- a/docs/research/proof-of-weights-w1-inventory.md
+++ b/docs/research/proof-of-weights-w1-inventory.md
@@ -68,4 +68,4 @@
 
 ## Handoff to W2
 
-W1 seams are wired; W2 adds **capacity ceiling** via verified autotune hardware-evidence at WS hello (`internal/autotune` hello gate). OPoI model-class probes remain Session A / W3.
+W1 seams are wired; W2 adds **capacity ceiling** via verified autotune hardware-evidence at WS hello (`internal/autotune` hello gate). W3 adds **runtime model-class probes** via `pool.model_class_challenges` with optional `max_ttft_ms` / `min_sustained_tps` gates on the existing canary path (`internal/ws/canary_probe.go`), exporting `model_class_opoi_pass` on `/poolz`.

--- a/ops/runbooks/opoi-challenge-implementation.md
+++ b/ops/runbooks/opoi-challenge-implementation.md
@@ -75,9 +75,23 @@ pool:
 - Expected answer must be **exact** after trim (`canaryAnswerMatches`).
 - Use **deterministic** short outputs (low `max_tokens`) to minimize MLX variance.
 
-### 2.3 Model-specific banks (recommended)
+### 2.3 Model-specific banks (Session B / W3)
 
-Maintain per-model challenge entries if templates differ (tokenizer quirks). Start with one bank for 3B/8B instruct models.
+Per-model challenge banks with optional latency gates live under `pool.model_class_challenges` (Proof of Weights W3). When a provider's active `model_id` matches a bank key, canaries use that bank instead of the global `canary_challenges` list. See `ops/runbooks/proof-of-weights-implementation.md` §5 (when committed) and `phase4-coordinator/internal/ws/canary_probe.go`.
+
+Example:
+
+```yaml
+pool:
+  model_class_challenges:
+    qwen3-coder-30b-a3b-instruct:
+      - prompt: "Reply with exactly: CANARY-{nonce}"
+        expected: "CANARY-{nonce}"
+        max_ttft_ms: 3500
+        min_sustained_tps: 20
+```
+
+Start with one bank per production model class before widening coverage.
 
 ### 2.4 Rollout
 

--- a/phase4-coordinator/coordinator.opoi-v0-staging.yaml
+++ b/phase4-coordinator/coordinator.opoi-v0-staging.yaml
@@ -31,3 +31,11 @@ pool:
       expected: "CANARY-{nonce}"
     - prompt: "What is the code {nonce}? Reply with only the code."
       expected: "{nonce}"
+  # W3 — per-model-class probes with latency gates (Session B).
+  # Keys match provider hello model_id / catalog row key.
+  model_class_challenges:
+    qwen3-coder-30b-a3b-instruct:
+      - prompt: "Reply with exactly: CANARY-{nonce}"
+        expected: "CANARY-{nonce}"
+        max_ttft_ms: 3500
+        min_sustained_tps: 20

--- a/phase4-coordinator/coordinator.yaml.example
+++ b/phase4-coordinator/coordinator.yaml.example
@@ -54,6 +54,14 @@ pool:
       expected: "CANARY-{nonce}"
     - prompt: "What is the code {nonce}? Reply with only the code."
       expected: "{nonce}"
+  # W3 optional — per-model challenge banks with latency gates. When a provider's
+  # active model_id matches a key, canaries use that bank instead of canary_challenges.
+  # model_class_challenges:
+  #   qwen3-coder-30b-a3b-instruct:
+  #     - prompt: "Reply with exactly: CANARY-{nonce}"
+  #       expected: "CANARY-{nonce}"
+  #       max_ttft_ms: 3500
+  #       min_sustained_tps: 20
 
 routing:
   preflight_threshold_tokens: 4096

--- a/phase4-coordinator/internal/autotune/catalog.go
+++ b/phase4-coordinator/internal/autotune/catalog.go
@@ -98,7 +98,11 @@ func (c *Catalog) HighestClaimedTier(modelID string) (key string, row Row, ok bo
 	if c == nil {
 		return "", Row{}, false
 	}
-	keys := c.keysByModel[normalizeModelID(modelID)]
+	normalized := normalizeModelID(modelID)
+	if row, ok := c.rowsByKey[normalized]; ok {
+		return normalized, row, true
+	}
+	keys := c.keysByModel[normalized]
 	if len(keys) == 0 {
 		return "", Row{}, false
 	}

--- a/phase4-coordinator/internal/autotune/gate_test.go
+++ b/phase4-coordinator/internal/autotune/gate_test.go
@@ -64,6 +64,35 @@ func TestEvaluateHelloGateUnderTierAllowedOverTierRejected(t *testing.T) {
 	}
 }
 
+func TestEvaluateHelloGateAcceptsCatalogRowKeyHelloModelID(t *testing.T) {
+	t.Parallel()
+	catalog := mustCatalog(t, `{
+		"version":"test",
+		"generated_at":"2026-07-08T00:00:00Z",
+		"source":"operator_curated_autotune_candidate_catalog",
+		"rows":{
+			"qwen3-coder-30b-a3b-instruct":{"model_id":"mlx-community/Qwen3-Coder-30B-A3B-Instruct-4bit","model_revision":"6e302ea604ad9ab206367e2c501d1571023e7b6d","model_sha256":"10adb5da9840c8fe0e3036b10f6e2f8f34b41c615f3925b4132302e9cdbab9c0","min_ram_gb":28,"min_bandwidth_tier":"C","bench_gate":{"min_sustained_tps":20,"max_4k_ttft_ms":3500},"runtime_status":"recommendable"}
+		}
+	}`)
+	evidence := autotune.VerifiedEvidence{
+		CandidateCatalogSHA256: catalog.SHA256,
+		Benchmarks: []autotune.VerifiedBenchmark{
+			{
+				ModelKey:               "qwen3-coder-30b-a3b-instruct",
+				ModelID:                "mlx-community/Qwen3-Coder-30B-A3B-Instruct-4bit",
+				SustainedTPS:           45.9,
+				TTFTMS:                 3064,
+				ArtifactSHA256:         "10adb5da9840c8fe0e3036b10f6e2f8f34b41c615f3925b4132302e9cdbab9c0",
+				CandidateCatalogSHA256: catalog.SHA256,
+			},
+		},
+	}
+	allowed := autotune.EvaluateHelloGate(catalog, evidence, "qwen3-coder-30b-a3b-instruct")
+	if !allowed.Allowed || allowed.ClaimedModelKey != "qwen3-coder-30b-a3b-instruct" {
+		t.Fatalf("catalog-key hello: %+v", allowed)
+	}
+}
+
 func TestEvaluateHelloGateRejectsThermalThrottle(t *testing.T) {
 	t.Parallel()
 	catalog := mustCatalog(t, `{

--- a/phase4-coordinator/internal/config/config.go
+++ b/phase4-coordinator/internal/config/config.go
@@ -310,13 +310,50 @@ type PoolConfig struct {
 	CanaryIntervalS         int                     `yaml:"canary_interval_s"`
 	CanaryTimeoutS          int                     `yaml:"canary_timeout_s"`
 	CanaryMaxTokens         int                     `yaml:"canary_max_tokens"`
-	CanaryFailureThreshold  int                     `yaml:"canary_failure_threshold"`
-	CanaryChallenges        []CanaryChallengeConfig `yaml:"canary_challenges"`
+	CanaryFailureThreshold  int                              `yaml:"canary_failure_threshold"`
+	CanaryChallenges        []CanaryChallengeConfig          `yaml:"canary_challenges"`
+	ModelClassChallenges    map[string][]CanaryChallengeConfig `yaml:"model_class_challenges"`
 }
 
 type CanaryChallengeConfig struct {
-	Prompt   string `yaml:"prompt"`
-	Expected string `yaml:"expected"`
+	Prompt          string  `yaml:"prompt"`
+	Expected        string  `yaml:"expected"`
+	MaxTTFTMS       int     `yaml:"max_ttft_ms,omitempty"`
+	MinSustainedTPS float64 `yaml:"min_sustained_tps,omitempty"`
+}
+
+func validateCanaryChallengeList(prefix string, challenges []CanaryChallengeConfig) error {
+	for i, challenge := range challenges {
+		if strings.TrimSpace(challenge.Prompt) == "" || strings.TrimSpace(challenge.Expected) == "" {
+			return fmt.Errorf("%s[%d] prompt and expected must not be empty", prefix, i)
+		}
+		if !strings.Contains(challenge.Prompt, "{nonce}") || !strings.Contains(challenge.Expected, "{nonce}") {
+			return fmt.Errorf("%s[%d] prompt and expected must contain {nonce}", prefix, i)
+		}
+		if challenge.MaxTTFTMS < 0 {
+			return fmt.Errorf("%s[%d] max_ttft_ms must be >= 0", prefix, i)
+		}
+		if math.IsNaN(challenge.MinSustainedTPS) || math.IsInf(challenge.MinSustainedTPS, 0) || challenge.MinSustainedTPS < 0 {
+			return fmt.Errorf("%s[%d] min_sustained_tps is invalid", prefix, i)
+		}
+	}
+	return nil
+}
+
+func (p PoolConfig) CanaryChallengesForModel(modelID string) ([]CanaryChallengeConfig, bool) {
+	modelID = strings.TrimSpace(modelID)
+	if modelID == "" {
+		return p.CanaryChallenges, false
+	}
+	if bank, ok := p.ModelClassChallenges[modelID]; ok && len(bank) > 0 {
+		return bank, true
+	}
+	for key, bank := range p.ModelClassChallenges {
+		if strings.EqualFold(strings.TrimSpace(key), modelID) && len(bank) > 0 {
+			return bank, true
+		}
+	}
+	return p.CanaryChallenges, false
 }
 
 type RoutingConfig struct {
@@ -1283,15 +1320,18 @@ func (c Config) Validate() error {
 		return fmt.Errorf("pool canary settings must be > 0 when enabled")
 	}
 	if c.Pool.CanaryEnabled {
-		if len(c.Pool.CanaryChallenges) == 0 {
-			return fmt.Errorf("pool canary_challenges must not be empty when enabled")
+		if len(c.Pool.CanaryChallenges) == 0 && len(c.Pool.ModelClassChallenges) == 0 {
+			return fmt.Errorf("pool canary_challenges or model_class_challenges must not be empty when enabled")
 		}
-		for i, challenge := range c.Pool.CanaryChallenges {
-			if strings.TrimSpace(challenge.Prompt) == "" || strings.TrimSpace(challenge.Expected) == "" {
-				return fmt.Errorf("pool canary_challenges[%d] prompt and expected must not be empty", i)
+		if err := validateCanaryChallengeList("pool.canary_challenges", c.Pool.CanaryChallenges); err != nil {
+			return err
+		}
+		for modelID, challenges := range c.Pool.ModelClassChallenges {
+			if strings.TrimSpace(modelID) == "" {
+				return fmt.Errorf("pool.model_class_challenges model id must not be empty")
 			}
-			if !strings.Contains(challenge.Prompt, "{nonce}") || !strings.Contains(challenge.Expected, "{nonce}") {
-				return fmt.Errorf("pool canary_challenges[%d] prompt and expected must contain {nonce}", i)
+			if err := validateCanaryChallengeList("pool.model_class_challenges."+modelID, challenges); err != nil {
+				return err
 			}
 		}
 	}

--- a/phase4-coordinator/internal/config/config_test.go
+++ b/phase4-coordinator/internal/config/config_test.go
@@ -105,6 +105,17 @@ func TestCanaryValidationRequiresPrivateChallengeBankWhenEnabled(t *testing.T) {
 		t.Fatalf("enabled canary without challenges validation err=%v", err)
 	}
 
+	cfg.Pool.ModelClassChallenges = map[string][]CanaryChallengeConfig{
+		"model-a": {{
+			Prompt:   "Reply with exactly: CANARY-{nonce}",
+			Expected: "CANARY-{nonce}",
+		}},
+	}
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("enabled canary with model_class_challenges only should validate: %v", err)
+	}
+	cfg.Pool.ModelClassChallenges = nil
+
 	cfg.Pool.CanaryChallenges = []CanaryChallengeConfig{{
 		Prompt:   "Which US state uses postal abbreviation VT?",
 		Expected: "Vermont-{nonce}",
@@ -582,6 +593,16 @@ func TestCanaryOPoIV0StagingOverlayParsesAndValidates(t *testing.T) {
 	for i, ch := range cfg.Pool.CanaryChallenges {
 		if !strings.Contains(ch.Prompt, "{nonce}") || !strings.Contains(ch.Expected, "{nonce}") {
 			t.Fatalf("canary_challenges[%d] missing {nonce} in prompt or expected", i)
+		}
+	}
+	if len(cfg.Pool.ModelClassChallenges) == 0 {
+		t.Fatal("staging overlay must include model_class_challenges for W3 lab smoke")
+	}
+	for modelID, bank := range cfg.Pool.ModelClassChallenges {
+		for i, ch := range bank {
+			if !strings.Contains(ch.Prompt, "{nonce}") || !strings.Contains(ch.Expected, "{nonce}") {
+				t.Fatalf("model_class_challenges.%s[%d] missing {nonce}", modelID, i)
+			}
 		}
 	}
 }

--- a/phase4-coordinator/internal/pool/provider.go
+++ b/phase4-coordinator/internal/pool/provider.go
@@ -166,6 +166,10 @@ type Provider struct {
 	// or provider admitted before W2 rollout.
 	MaxAdmittedModelKey string `json:"max_admitted_model_class,omitempty"`
 	MaxAdmittedModelID  string `json:"max_admitted_model_id,omitempty"`
+	// Proof of Weights W3 — latest model-class OPoI probe outcome when a
+	// per-model challenge bank with optional latency gates was used.
+	// Omitted when only the global canary bank applies.
+	ModelClassOPoIPass *bool `json:"model_class_opoi_pass,omitempty"`
 
 	// SPEC-002 v1.3.5 §3.X.1 — populated from v2 auth_request initial-stage
 	// supported_models[] per SPEC-010 v1.5 R-3.3.1; nil for the L-1 baseline.
@@ -1055,6 +1059,16 @@ func (r *Registry) RecordCanaryResult(providerID, assignedID string, passed bool
 	}
 	result.Tripped = CanaryTripDegraded
 	return result
+}
+
+func (r *Registry) SetModelClassOPoIPass(providerID, assignedID string, pass *bool) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	p := r.providers[providerID]
+	if p == nil || p.AssignedID != assignedID {
+		return
+	}
+	p.ModelClassOPoIPass = pass
 }
 
 func (r *Registry) applyCanarySanctionLocked(p *Provider) {

--- a/phase4-coordinator/internal/ws/canary_probe.go
+++ b/phase4-coordinator/internal/ws/canary_probe.go
@@ -1,0 +1,149 @@
+package ws
+
+import (
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"math"
+	"strings"
+	"time"
+
+	"github.com/augstar/macprovider-coordinator/internal/config"
+)
+
+var (
+	errCanaryChallengeBankEmpty   = errors.New("canary challenge bank is empty")
+	errCanaryRandomSeedTooShort   = errors.New("canary random seed too short")
+	errCanaryChallengePromptEmpty = errors.New("canary challenge prompt and expected must not be empty")
+	errCanaryChallengeMissingNonce = errors.New("canary challenge prompt and expected must contain {nonce}")
+)
+
+type canaryBuiltProbe struct {
+	Body           []byte
+	Expected       string
+	Challenge      config.CanaryChallengeConfig
+	ModelClassBank bool
+}
+
+type canaryProbeMetrics struct {
+	TTFTMS       int
+	SustainedTPS float64
+	LatencyGated bool
+}
+
+type canaryAttemptResult struct {
+	outcome        canaryProbeOutcome
+	metrics        canaryProbeMetrics
+	modelClassBank bool
+	challenge      config.CanaryChallengeConfig
+}
+
+func buildCanaryProbe(modelID string, maxTokens int, challenges []config.CanaryChallengeConfig, modelClassBank bool) (canaryBuiltProbe, error) {
+	body, expected, challenge, err := buildCanaryBodyFromBank(modelID, maxTokens, challenges)
+	if err != nil {
+		return canaryBuiltProbe{}, err
+	}
+	return canaryBuiltProbe{
+		Body:           body,
+		Expected:       expected,
+		Challenge:      challenge,
+		ModelClassBank: modelClassBank,
+	}, nil
+}
+
+func buildCanaryBodyFromBank(modelID string, maxTokens int, challenges []config.CanaryChallengeConfig) ([]byte, string, config.CanaryChallengeConfig, error) {
+	random, err := randomBytes(5)
+	if err != nil {
+		return nil, "", config.CanaryChallengeConfig{}, err
+	}
+	return buildCanaryBodyFromRandomWithChallenge(modelID, maxTokens, challenges, random)
+}
+
+func buildCanaryBodyFromRandomWithChallenge(modelID string, maxTokens int, challenges []config.CanaryChallengeConfig, random []byte) ([]byte, string, config.CanaryChallengeConfig, error) {
+	if len(challenges) == 0 {
+		return nil, "", config.CanaryChallengeConfig{}, errCanaryChallengeBankEmpty
+	}
+	if len(random) < 5 {
+		return nil, "", config.CanaryChallengeConfig{}, errCanaryRandomSeedTooShort
+	}
+	challenge := challenges[int(random[4])%len(challenges)]
+	promptTemplate := strings.TrimSpace(challenge.Prompt)
+	expectedTemplate := strings.TrimSpace(challenge.Expected)
+	if promptTemplate == "" || expectedTemplate == "" {
+		return nil, "", config.CanaryChallengeConfig{}, errCanaryChallengePromptEmpty
+	}
+	if !strings.Contains(promptTemplate, "{nonce}") || !strings.Contains(expectedTemplate, "{nonce}") {
+		return nil, "", config.CanaryChallengeConfig{}, errCanaryChallengeMissingNonce
+	}
+	nonce := strings.ToUpper(hex.EncodeToString(random[:4]))
+	content := strings.ReplaceAll(promptTemplate, "{nonce}", nonce)
+	expected := strings.ReplaceAll(expectedTemplate, "{nonce}", nonce)
+	body, err := json.Marshal(map[string]any{
+		"model": modelID,
+		"messages": []map[string]string{{
+			"role":    "user",
+			"content": content,
+		}},
+		"max_tokens": maxTokens,
+		"stream":     false,
+	})
+	if err != nil {
+		return nil, "", config.CanaryChallengeConfig{}, err
+	}
+	return body, expected, challenge, nil
+}
+
+func challengeHasLatencyGates(challenge config.CanaryChallengeConfig) bool {
+	return challenge.MaxTTFTMS > 0 || challenge.MinSustainedTPS > 0
+}
+
+func evaluateCanaryProbe(challenge config.CanaryChallengeConfig, output string, expected string, metrics canaryProbeMetrics) canaryProbeOutcome {
+	if !canaryAnswerMatches(output, expected) {
+		return canaryProbeFail
+	}
+	if !challengeHasLatencyGates(challenge) {
+		return canaryProbePass
+	}
+	if challenge.MaxTTFTMS > 0 && metrics.TTFTMS > challenge.MaxTTFTMS {
+		return canaryProbeFail
+	}
+	if challenge.MinSustainedTPS > 0 && (math.IsNaN(metrics.SustainedTPS) || math.IsInf(metrics.SustainedTPS, 0) || metrics.SustainedTPS < challenge.MinSustainedTPS) {
+		return canaryProbeFail
+	}
+	return canaryProbePass
+}
+
+func canaryMetricsFromTiming(start time.Time, firstTokenAt time.Time, completedAt time.Time, completionTokens int) canaryProbeMetrics {
+	if completionTokens <= 0 {
+		completionTokens = 1
+	}
+	ttft := completedAt.Sub(start)
+	if !firstTokenAt.IsZero() {
+		ttft = firstTokenAt.Sub(start)
+	}
+	decode := completedAt.Sub(start)
+	if !firstTokenAt.IsZero() {
+		decode = completedAt.Sub(firstTokenAt)
+	}
+	if decode <= 0 {
+		decode = time.Millisecond
+	}
+	tps := float64(completionTokens) / decode.Seconds()
+	return canaryProbeMetrics{
+		TTFTMS:       int(ttft.Round(time.Millisecond) / time.Millisecond),
+		SustainedTPS: tps,
+		LatencyGated: true,
+	}
+}
+
+func canaryCompletionTokens(raw []byte) int {
+	var resp struct {
+		Usage struct {
+			CompletionTokens int `json:"completion_tokens"`
+		} `json:"usage"`
+	}
+	if err := json.Unmarshal(raw, &resp); err != nil {
+		return 0
+	}
+	return resp.Usage.CompletionTokens
+}

--- a/phase4-coordinator/internal/ws/canary_probe_test.go
+++ b/phase4-coordinator/internal/ws/canary_probe_test.go
@@ -1,0 +1,46 @@
+package ws
+
+import (
+	"testing"
+
+	"github.com/augstar/macprovider-coordinator/internal/config"
+)
+
+func TestEvaluateCanaryProbeLatencyGates(t *testing.T) {
+	t.Parallel()
+	challenge := config.CanaryChallengeConfig{
+		Prompt:          "Reply {nonce}",
+		Expected:        "{nonce}",
+		MaxTTFTMS:       800,
+		MinSustainedTPS: 12,
+	}
+	pass := evaluateCanaryProbe(challenge, "ABCD", "ABCD", canaryProbeMetrics{TTFTMS: 700, SustainedTPS: 15})
+	if pass != canaryProbePass {
+		t.Fatalf("latency pass = %q", pass)
+	}
+	if evaluateCanaryProbe(challenge, "ABCD", "ABCD", canaryProbeMetrics{TTFTMS: 900, SustainedTPS: 15}) != canaryProbeFail {
+		t.Fatal("expected ttft fail")
+	}
+	if evaluateCanaryProbe(challenge, "ABCD", "ABCD", canaryProbeMetrics{TTFTMS: 700, SustainedTPS: 8}) != canaryProbeFail {
+		t.Fatal("expected tps fail")
+	}
+	if evaluateCanaryProbe(challenge, "wrong", "ABCD", canaryProbeMetrics{TTFTMS: 700, SustainedTPS: 15}) != canaryProbeFail {
+		t.Fatal("expected answer fail")
+	}
+}
+
+func TestPoolConfigCanaryChallengesForModel(t *testing.T) {
+	t.Parallel()
+	pool := config.PoolConfig{
+		CanaryChallenges: []config.CanaryChallengeConfig{{Prompt: "global {nonce}", Expected: "{nonce}"}},
+		ModelClassChallenges: map[string][]config.CanaryChallengeConfig{
+			"qwen3-coder-30b-a3b-instruct": {{Prompt: "tier {nonce}", Expected: "tier-{nonce}"}},
+		},
+	}
+	if bank, ok := pool.CanaryChallengesForModel("qwen3-coder-30b-a3b-instruct"); !ok || bank[0].Prompt != "tier {nonce}" {
+		t.Fatalf("model class bank = %+v ok=%v", bank, ok)
+	}
+	if bank, ok := pool.CanaryChallengesForModel("unknown-model"); ok || bank[0].Prompt != "global {nonce}" {
+		t.Fatalf("fallback bank = %+v ok=%v", bank, ok)
+	}
+}

--- a/phase4-coordinator/internal/ws/server.go
+++ b/phase4-coordinator/internal/ws/server.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"crypto/rand"
 	"encoding/base64"
-	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"io"
@@ -2108,7 +2107,12 @@ const (
 )
 
 func (s *Server) runCanaryProbe(provider pool.Provider) bool {
-	outcome := s.runCanaryProbeAttempt(provider)
+	attempt := s.runCanaryProbeAttempt(provider)
+	outcome := attempt.outcome
+	if attempt.modelClassBank {
+		pass := outcome == canaryProbePass
+		s.pool.SetModelClassOPoIPass(provider.ProviderID, provider.AssignedID, &pass)
+	}
 	if outcome == canaryProbeSkip {
 		s.log.Debug().Str("provider_id", provider.ProviderID).Msg("provider canary skipped")
 		return false
@@ -2134,6 +2138,11 @@ func (s *Server) runCanaryProbe(provider pool.Provider) bool {
 		Int("canary_failure_threshold", result.Threshold)
 	if result.Tripped != pool.CanaryTripNone {
 		event = event.Str("canary_trip", string(result.Tripped))
+	}
+	if attempt.modelClassBank && attempt.metrics.LatencyGated {
+		event = event.
+			Int("canary_ttft_ms", attempt.metrics.TTFTMS).
+			Float64("canary_sustained_tps", attempt.metrics.SustainedTPS)
 	}
 	event.Msg("provider canary failed")
 	switch result.Tripped {
@@ -2178,30 +2187,46 @@ func (s *Server) deleteCanarySanction(providerID string) {
 	}
 }
 
-func (s *Server) runCanaryProbeAttempt(provider pool.Provider) canaryProbeOutcome {
-	body, expected, err := s.buildCanaryBody(provider.ModelID, s.canaryMaxTokens())
+func (s *Server) runCanaryProbeAttempt(provider pool.Provider) canaryAttemptResult {
+	challenges, modelClassBank := s.cfg.Pool.CanaryChallengesForModel(provider.ModelID)
+	probe, err := buildCanaryProbe(provider.ModelID, s.canaryMaxTokens(), challenges, modelClassBank)
 	if err != nil {
-		return canaryProbeSkip
+		return canaryAttemptResult{outcome: canaryProbeSkip}
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), s.canaryTimeout())
 	defer cancel()
+	var outcome canaryProbeOutcome
+	var metrics canaryProbeMetrics
 	if !provider.IsWSTunneled() {
-		return s.runHTTPCanaryProbeAttempt(ctx, provider, body, expected)
+		outcome, metrics = s.runHTTPCanaryProbeAttempt(ctx, provider, probe)
+	} else {
+		outcome, metrics = s.runWSCanaryProbeAttempt(ctx, provider, probe)
 	}
-	return s.runWSCanaryProbeAttempt(ctx, provider, body, expected)
+	if challengeHasLatencyGates(probe.Challenge) {
+		metrics.LatencyGated = true
+	}
+	return canaryAttemptResult{
+		outcome:        outcome,
+		metrics:        metrics,
+		modelClassBank: probe.ModelClassBank,
+		challenge:      probe.Challenge,
+	}
 }
 
-func (s *Server) runWSCanaryProbeAttempt(ctx context.Context, provider pool.Provider, body []byte, expected string) canaryProbeOutcome {
+func (s *Server) runWSCanaryProbeAttempt(ctx context.Context, provider pool.Provider, probe canaryBuiltProbe) (canaryProbeOutcome, canaryProbeMetrics) {
 	if s.tier2WarmupExcluded(provider) {
-		return canaryProbeSkip
+		return canaryProbeSkip, canaryProbeMetrics{}
 	}
 	requestID := s.newUUID()
-	relay, err := s.DispatchInference(ctx, provider, requestID, body, false)
+	start := time.Now()
+	relay, err := s.DispatchInference(ctx, provider, requestID, probe.Body, false)
 	if err != nil {
-		return canaryProbeSkip
+		return canaryProbeSkip, canaryProbeMetrics{}
 	}
 	chunks := relay.Chunks
 	var output strings.Builder
+	var firstTokenAt time.Time
+	var rawResponse strings.Builder
 	for {
 		select {
 		case chunk, ok := <-chunks:
@@ -2209,95 +2234,89 @@ func (s *Server) runWSCanaryProbeAttempt(ctx context.Context, provider pool.Prov
 				chunks = nil
 				continue
 			}
+			if firstTokenAt.IsZero() {
+				firstTokenAt = time.Now()
+			}
+			rawResponse.WriteString(chunk.Data)
 			output.WriteString(canaryChunkContent(chunk.Data))
 		case end := <-relay.Done:
+			completedAt := time.Now()
+			metrics := canaryProbeMetrics{}
+			if challengeHasLatencyGates(probe.Challenge) {
+				tokens := canaryCompletionTokens([]byte(rawResponse.String()))
+				if tokens == 0 {
+					tokens = len(strings.Fields(output.String()))
+					if tokens == 0 {
+						tokens = 1
+					}
+				}
+				metrics = canaryMetricsFromTiming(start, firstTokenAt, completedAt, tokens)
+			}
 			if end.Status != "complete" {
-				return canaryProbeFail
+				return canaryProbeFail, metrics
 			}
-			if canaryAnswerMatches(output.String(), expected) {
-				return canaryProbePass
-			}
-			return canaryProbeFail
+			return evaluateCanaryProbe(probe.Challenge, output.String(), probe.Expected, metrics), metrics
 		case <-relay.Errors:
-			return canaryProbeFail
+			return canaryProbeFail, canaryProbeMetrics{}
 		case <-ctx.Done():
-			return canaryProbeFail
+			return canaryProbeFail, canaryProbeMetrics{}
 		}
 	}
 }
 
-func (s *Server) runHTTPCanaryProbeAttempt(ctx context.Context, provider pool.Provider, body []byte, expected string) canaryProbeOutcome {
+func (s *Server) runHTTPCanaryProbeAttempt(ctx context.Context, provider pool.Provider, probe canaryBuiltProbe) (canaryProbeOutcome, canaryProbeMetrics) {
 	endpoint := strings.TrimRight(strings.TrimSpace(provider.EndpointURL), "/")
 	if endpoint == "" {
-		return canaryProbeSkip
+		return canaryProbeSkip, canaryProbeMetrics{}
 	}
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint+"/v1/chat/completions", bytes.NewReader(body))
+	start := time.Now()
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint+"/v1/chat/completions", bytes.NewReader(probe.Body))
 	if err != nil {
-		return canaryProbeSkip
+		return canaryProbeSkip, canaryProbeMetrics{}
 	}
 	req.Header.Set("Content-Type", "application/json")
 	resp, err := providerhttp.Client.Do(req)
 	if err != nil {
-		return canaryProbeFail
+		return canaryProbeFail, canaryProbeMetrics{}
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
-		return canaryProbeFail
+		return canaryProbeFail, canaryProbeMetrics{}
 	}
 	raw, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
 	if err != nil {
-		return canaryProbeFail
+		return canaryProbeFail, canaryProbeMetrics{}
 	}
-	if canaryAnswerMatches(strings.Join(canaryPayloadContents(raw), ""), expected) {
-		return canaryProbePass
+	completedAt := time.Now()
+	output := strings.Join(canaryPayloadContents(raw), "")
+	metrics := canaryProbeMetrics{}
+	if challengeHasLatencyGates(probe.Challenge) {
+		tokens := canaryCompletionTokens(raw)
+		if tokens == 0 {
+			tokens = len(strings.Fields(output))
+			if tokens == 0 {
+				tokens = 1
+			}
+		}
+		metrics = canaryMetricsFromTiming(start, time.Time{}, completedAt, tokens)
 	}
-	return canaryProbeFail
+	return evaluateCanaryProbe(probe.Challenge, output, probe.Expected, metrics), metrics
 }
 
 func (s *Server) buildCanaryBody(modelID string, maxTokens int) ([]byte, string, error) {
-	return buildCanaryBody(modelID, maxTokens, s.cfg.Pool.CanaryChallenges)
+	challenges, _ := s.cfg.Pool.CanaryChallengesForModel(modelID)
+	body, expected, _, err := buildCanaryBodyFromBank(modelID, maxTokens, challenges)
+	return body, expected, err
 }
 
 func buildCanaryBody(modelID string, maxTokens int, challenges []config.CanaryChallengeConfig) ([]byte, string, error) {
-	random, err := randomBytes(5)
-	if err != nil {
-		return nil, "", err
-	}
-	return buildCanaryBodyFromRandom(modelID, maxTokens, challenges, random)
+	body, expected, _, err := buildCanaryBodyFromBank(modelID, maxTokens, challenges)
+	return body, expected, err
 }
 
 func buildCanaryBodyFromRandom(modelID string, maxTokens int, challenges []config.CanaryChallengeConfig, random []byte) ([]byte, string, error) {
-	if len(challenges) == 0 {
-		return nil, "", errors.New("canary challenge bank is empty")
-	}
-	if len(random) < 5 {
-		return nil, "", errors.New("canary random seed too short")
-	}
-	challenge := challenges[int(random[4])%len(challenges)]
-	promptTemplate := strings.TrimSpace(challenge.Prompt)
-	expectedTemplate := strings.TrimSpace(challenge.Expected)
-	if promptTemplate == "" || expectedTemplate == "" {
-		return nil, "", errors.New("canary challenge prompt and expected must not be empty")
-	}
-	if !strings.Contains(promptTemplate, "{nonce}") || !strings.Contains(expectedTemplate, "{nonce}") {
-		return nil, "", errors.New("canary challenge prompt and expected must contain {nonce}")
-	}
-	nonce := strings.ToUpper(hex.EncodeToString(random[:4]))
-	content := strings.ReplaceAll(promptTemplate, "{nonce}", nonce)
-	expected := strings.ReplaceAll(expectedTemplate, "{nonce}", nonce)
-	body, err := json.Marshal(map[string]any{
-		"model": modelID,
-		"messages": []map[string]string{{
-			"role":    "user",
-			"content": content,
-		}},
-		"max_tokens": maxTokens,
-		"stream":     false,
-	})
-	if err != nil {
-		return nil, "", err
-	}
-	return body, expected, nil
+	body, expected, _, err := buildCanaryBodyFromRandomWithChallenge(modelID, maxTokens, challenges, random)
+	return body, expected, err
 }
 
 func canaryAnswerMatches(output, expected string) bool {


### PR DESCRIPTION
## Summary
- **W2 fix:** `HighestClaimedTier` resolves catalog row keys (e.g. `qwen3-coder-30b-a3b-instruct`) in addition to HuggingFace `model_id` paths, fixing `autotune_model_uncatalogued` on Pearl with W2 enabled.
- **W3:** Per-model `pool.model_class_challenges` banks with optional `max_ttft_ms` / `min_sustained_tps` gates on the existing canary path; exports `model_class_opoi_pass` on `/poolz`.
- Staging overlay adds qwen3-coder-30b bank aligned to verified autotune bench (3500ms TTFT, 20 TPS).

## Test plan
- [x] `go test ./internal/ws/ ./internal/config/ ./internal/pool/`
- [ ] Pearl: deploy coordinator binary, merge overlay, confirm `model_class_opoi_pass` flips on canary pass for provider `mac`
- [ ] Lab downgrade: provider claiming 30B but serving 8B should fail latency or prompt bank within N probes


Made with [Cursor](https://cursor.com)