### PR TITLE
fix(rewards): SEC-1 enforce distinct-credential dual-control on MALIBU trust promotion

### DIFF
--- a/phase4-coordinator/cmd/coordinator/main.go
+++ b/phase4-coordinator/cmd/coordinator/main.go
@@ -698,8 +698,8 @@ func main() {
 	providerMux.Handle("/admin/ledger/", billingHandler)
 	if rewardsDB != nil {
 		providerMux.Handle("/admin/trust-promotion/", rewards.TrustPromotionMux(rewards.TrustAdminDeps{
-			DB:          rewardsDB,
-			OperatorKey: cfg.Auth.OperatorKey,
+			DB:           rewardsDB,
+			OperatorKeys: cfg.Auth.OperatorKeys,
 		}))
 	}
 	if cfg.Auth.RequireProviderTokens {

--- a/phase4-coordinator/dist/coordinator.yaml.example
+++ b/phase4-coordinator/dist/coordinator.yaml.example
@@ -122,6 +122,15 @@ auth:
   # so operator_key can be rotated independently. Leave unset to preserve
   # pre-bridge behavior.
   #   gateway_service_token: env:GATEWAY_SERVICE_TOKEN
+  # Per-actor operator keys for TWO-PERSON control (SPEC-026 provider-auth-policy
+  # AND MALIBU trust-promotion /admin/trust-promotion/{request,approve}). The
+  # acting operator identity is bound to the MATCHED key, so dual-control requires
+  # at least TWO entries with DISTINCT, non-empty secrets; the trust-promotion
+  # route fails closed (503 dual_control_unavailable) otherwise. Do NOT rename an
+  # operator id while it has a pending promotion (the actor identity would change).
+  #   operator_keys:
+  #     spec026_a: env:OPERATOR_AUTH_POLICY_A
+  #     spec026_b: env:OPERATOR_AUTH_POLICY_B
   require_provider_tokens: true # Production/provider WS public exposure must require provider tokens.
   # Public onboarding escape hatch: permit a first tokenless provisional
   # provider to receive and persist its own provider_token. Tokenless reconnects

--- a/phase4-coordinator/internal/rewards/unlock_admin.go
+++ b/phase4-coordinator/internal/rewards/unlock_admin.go
@@ -7,13 +7,45 @@ import (
 	"strings"
 	"time"
 
+	"github.com/augstar/macprovider-coordinator/internal/auth"
 	"github.com/google/uuid"
 )
 
 // TrustAdminDeps wires operator dual-control trust promotion endpoints.
+//
+// Dual control is enforced by DISTINCT operator credentials, not by a
+// self-asserted actor header (SEC-1). The requester and approver must
+// present DIFFERENT bearer tokens drawn from OperatorKeys, and the acting
+// identity is derived from the matched key — never from a client-supplied
+// X-Operator-Actor header. OperatorKeys maps an operator actor id to its
+// secret; at least two entries with unique, non-empty secrets are required
+// or the route fails closed. This mirrors the provider-auth-policy operator
+// model in internal/ws/admin_endpoints.go.
 type TrustAdminDeps struct {
-	DB          *sql.DB
-	OperatorKey string
+	DB           *sql.DB
+	OperatorKeys map[string]string
+}
+
+// dualControlReady reports whether the configured operator keys can support
+// two-person control: at least two actors, every secret non-empty and
+// unique. With duplicate secrets a single credential could match more than
+// one actor id, which would defeat the requested_by != approved_by check.
+func dualControlReady(keys map[string]string) bool {
+	if len(keys) < 2 {
+		return false
+	}
+	seen := make(map[string]struct{}, len(keys))
+	for _, secret := range keys {
+		secret = strings.TrimSpace(secret)
+		if secret == "" {
+			return false
+		}
+		if _, dup := seen[secret]; dup {
+			return false
+		}
+		seen[secret] = struct{}{}
+	}
+	return true
 }
 
 // NewTrustPromotionRequestHandler serves POST /admin/trust-promotion/request.
@@ -24,7 +56,11 @@ func NewTrustPromotionRequestHandler(deps TrustAdminDeps) http.Handler {
 			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
 			return
 		}
-		actor, ok := authorizedTrustOperator(r, deps.OperatorKey)
+		if !dualControlReady(deps.OperatorKeys) {
+			writeTrustJSON(w, http.StatusServiceUnavailable, map[string]any{"error": "dual_control_unavailable"})
+			return
+		}
+		actor, ok := authorizedTrustOperator(r, deps.OperatorKeys)
 		if !ok {
 			writeTrustJSON(w, http.StatusUnauthorized, map[string]any{"error": "unauthorized"})
 			return
@@ -46,6 +82,9 @@ func NewTrustPromotionRequestHandler(deps TrustAdminDeps) http.Handler {
 		body.ProviderID = strings.TrimSpace(body.ProviderID)
 		body.Reason = strings.TrimSpace(body.Reason)
 		body.IncidentID = strings.TrimSpace(body.IncidentID)
+		// requested_by, when supplied, is advisory only and must match the
+		// credential-derived actor; the actor of record is always the one
+		// bound to the matched operator key.
 		if body.RequestedBy != "" && body.RequestedBy != actor {
 			writeTrustJSON(w, http.StatusForbidden, map[string]any{"error": "operator_actor_mismatch"})
 			return
@@ -72,7 +111,11 @@ func NewTrustPromotionApproveHandler(deps TrustAdminDeps) http.Handler {
 			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
 			return
 		}
-		actor, ok := authorizedTrustOperator(r, deps.OperatorKey)
+		if !dualControlReady(deps.OperatorKeys) {
+			writeTrustJSON(w, http.StatusServiceUnavailable, map[string]any{"error": "dual_control_unavailable"})
+			return
+		}
+		actor, ok := authorizedTrustOperator(r, deps.OperatorKeys)
 		if !ok {
 			writeTrustJSON(w, http.StatusUnauthorized, map[string]any{"error": "unauthorized"})
 			return
@@ -88,6 +131,9 @@ func NewTrustPromotionApproveHandler(deps TrustAdminDeps) http.Handler {
 			writeTrustJSON(w, http.StatusNotFound, map[string]any{"error": "not_found"})
 			return
 		}
+		// ApproveTrustPromotion rejects approved_by == requested_by. Because
+		// each actor is bound to a distinct operator key, that check now means
+		// a DIFFERENT credential must approve than the one that requested.
 		providerID, err := ApproveTrustPromotion(r.Context(), deps.DB, pendingID, actor)
 		if err != nil {
 			writeTrustJSON(w, http.StatusBadRequest, map[string]any{"error": err.Error()})
@@ -104,24 +150,34 @@ func NewTrustPromotionApproveHandler(deps TrustAdminDeps) http.Handler {
 	})
 }
 
-func authorizedTrustOperator(r *http.Request, operatorKey string) (actor string, ok bool) {
-	if operatorKey == "" {
+// authorizedTrustOperator matches the request bearer against the configured
+// operator keys using a constant-time comparison and returns the operator
+// identity bound to the MATCHED key. It never trusts a client-supplied
+// X-Operator-Actor header (SEC-1) and never short-circuits on a plain string
+// compare (SEC-2). Fails closed unless dual control is configured; because
+// dualControlReady guarantees unique secrets, at most one key can match, so
+// the returned actor is deterministic despite random map iteration.
+func authorizedTrustOperator(r *http.Request, keys map[string]string) (actor string, ok bool) {
+	if !dualControlReady(keys) {
 		return "", false
 	}
-	auth := strings.TrimSpace(r.Header.Get("Authorization"))
-	const prefix = "Bearer "
-	if !strings.HasPrefix(auth, prefix) {
-		return "", false
+	for actorID, secret := range keys {
+		if !auth.OperatorOnlyBearerMatches(r.Header, secret) {
+			continue
+		}
+		return normalizedTrustOperatorActor(actorID), true
 	}
-	token := strings.TrimSpace(strings.TrimPrefix(auth, prefix))
-	if token != operatorKey {
-		return "", false
+	return "", false
+}
+
+// normalizedTrustOperatorActor renders an operator map key as an
+// operator:<id> identity, matching internal/ws normalizedOperatorActor.
+func normalizedTrustOperatorActor(actorID string) string {
+	actorID = strings.TrimSpace(actorID)
+	if strings.HasPrefix(actorID, "operator:") {
+		return actorID
 	}
-	actor = strings.TrimSpace(r.Header.Get("X-Operator-Actor"))
-	if actor == "" {
-		actor = "operator:unknown"
-	}
-	return actor, true
+	return "operator:" + actorID
 }
 
 func writeTrustJSON(w http.ResponseWriter, status int, payload map[string]any) {

--- a/phase4-coordinator/internal/rewards/unlock_admin_test.go
+++ b/phase4-coordinator/internal/rewards/unlock_admin_test.go
@@ -1,0 +1,171 @@
+package rewards
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestDualControlReady(t *testing.T) {
+	cases := []struct {
+		name string
+		keys map[string]string
+		want bool
+	}{
+		{"nil", nil, false},
+		{"empty", map[string]string{}, false},
+		{"single", map[string]string{"alice": "alice-secret"}, false},
+		{"two_distinct", map[string]string{"alice": "alice-secret", "bob": "bob-secret"}, true},
+		{"shared_secret", map[string]string{"alice": "same", "bob": "same"}, false},
+		{"empty_secret", map[string]string{"alice": "alice-secret", "bob": ""}, false},
+		{"whitespace_secret", map[string]string{"alice": "alice-secret", "bob": "   "}, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := dualControlReady(tc.keys); got != tc.want {
+				t.Fatalf("dualControlReady(%v) = %v, want %v", tc.keys, got, tc.want)
+			}
+		})
+	}
+}
+
+func trustReq(t *testing.T, bearer, actorHeader string) *http.Request {
+	t.Helper()
+	r := httptest.NewRequest(http.MethodPost, "/admin/trust-promotion/request", nil)
+	if bearer != "" {
+		r.Header.Set("Authorization", "Bearer "+bearer)
+	}
+	if actorHeader != "" {
+		r.Header.Set("X-Operator-Actor", actorHeader)
+	}
+	return r
+}
+
+// TestAuthorizedTrustOperator_ActorIsCredentialDerived is the SEC-1 regression:
+// the acting identity must come from the MATCHED operator key, never from the
+// attacker-controllable X-Operator-Actor header. A single key holder therefore
+// cannot request as "alice" and approve as "bob".
+func TestAuthorizedTrustOperator_ActorIsCredentialDerived(t *testing.T) {
+	keys := map[string]string{"alice": "alice-secret", "bob": "bob-secret"}
+
+	// alice-secret always resolves to operator:alice, regardless of a spoofed
+	// X-Operator-Actor header claiming to be bob.
+	actor, ok := authorizedTrustOperator(trustReq(t, "alice-secret", "bob"), keys)
+	if !ok || actor != "operator:alice" {
+		t.Fatalf("alice-secret with spoofed X-Operator-Actor: got (%q,%v), want (operator:alice,true)", actor, ok)
+	}
+	// The only way to act as bob is to hold bob-secret.
+	actor, ok = authorizedTrustOperator(trustReq(t, "bob-secret", "alice"), keys)
+	if !ok || actor != "operator:bob" {
+		t.Fatalf("bob-secret: got (%q,%v), want (operator:bob,true)", actor, ok)
+	}
+}
+
+func TestAuthorizedTrustOperator_RejectsBadCredential(t *testing.T) {
+	keys := map[string]string{"alice": "alice-secret", "bob": "bob-secret"}
+	for _, bearer := range []string{"", "wrong-secret", "alice-secre"} {
+		if actor, ok := authorizedTrustOperator(trustReq(t, bearer, "alice"), keys); ok {
+			t.Fatalf("bearer %q: got (%q,true), want (\"\",false)", bearer, actor)
+		}
+	}
+}
+
+// TestAuthorizedTrustOperator_FailsClosed: without two distinct operator keys
+// the route cannot enforce two-person control and must reject everything.
+func TestAuthorizedTrustOperator_FailsClosed(t *testing.T) {
+	single := map[string]string{"alice": "alice-secret"}
+	if _, ok := authorizedTrustOperator(trustReq(t, "alice-secret", ""), single); ok {
+		t.Fatal("single-key map must fail closed even with a correct bearer")
+	}
+	shared := map[string]string{"alice": "same", "bob": "same"}
+	if _, ok := authorizedTrustOperator(trustReq(t, "same", ""), shared); ok {
+		t.Fatal("shared-secret map must fail closed")
+	}
+}
+
+func TestNormalizedTrustOperatorActor(t *testing.T) {
+	if got := normalizedTrustOperatorActor("alice"); got != "operator:alice" {
+		t.Fatalf("got %q", got)
+	}
+	if got := normalizedTrustOperatorActor("operator:bob"); got != "operator:bob" {
+		t.Fatalf("got %q", got)
+	}
+}
+
+func decodeErr(t *testing.T, rr *httptest.ResponseRecorder) string {
+	t.Helper()
+	var body struct {
+		Error string `json:"error"`
+	}
+	if err := json.NewDecoder(rr.Body).Decode(&body); err != nil {
+		t.Fatalf("decode body: %v", err)
+	}
+	return body.Error
+}
+
+// Handler-level fail-closed and auth-ordering checks (no DB required: the
+// dual-control gate and auth run before the DB-nil guard).
+func TestTrustPromotionHandlers_FailClosedAndAuth(t *testing.T) {
+	twoKeys := map[string]string{"alice": "alice-secret", "bob": "bob-secret"}
+
+	t.Run("request_dual_control_unavailable", func(t *testing.T) {
+		h := NewTrustPromotionRequestHandler(TrustAdminDeps{OperatorKeys: map[string]string{"alice": "alice-secret"}})
+		rr := httptest.NewRecorder()
+		h.ServeHTTP(rr, trustReq(t, "alice-secret", ""))
+		if rr.Code != http.StatusServiceUnavailable || decodeErr(t, rr) != "dual_control_unavailable" {
+			t.Fatalf("code=%d err=%q", rr.Code, rr.Body.String())
+		}
+	})
+
+	t.Run("request_unauthorized", func(t *testing.T) {
+		h := NewTrustPromotionRequestHandler(TrustAdminDeps{OperatorKeys: twoKeys})
+		rr := httptest.NewRecorder()
+		h.ServeHTTP(rr, trustReq(t, "nope", ""))
+		if rr.Code != http.StatusUnauthorized {
+			t.Fatalf("code=%d body=%q", rr.Code, rr.Body.String())
+		}
+	})
+
+	t.Run("request_valid_auth_reaches_db_guard", func(t *testing.T) {
+		// DB nil -> after successful auth the handler returns 503 "unavailable"
+		// (distinct from the dual-control 503), proving the credential passed.
+		h := NewTrustPromotionRequestHandler(TrustAdminDeps{OperatorKeys: twoKeys})
+		rr := httptest.NewRecorder()
+		h.ServeHTTP(rr, trustReq(t, "alice-secret", "bob"))
+		if rr.Code != http.StatusServiceUnavailable || decodeErr(t, rr) != "unavailable" {
+			t.Fatalf("code=%d err=%q", rr.Code, rr.Body.String())
+		}
+	})
+
+	t.Run("approve_dual_control_unavailable", func(t *testing.T) {
+		h := NewTrustPromotionApproveHandler(TrustAdminDeps{OperatorKeys: map[string]string{"alice": "alice-secret"}})
+		rr := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodPost, "/admin/trust-promotion/some-id/approve", nil)
+		req.Header.Set("Authorization", "Bearer alice-secret")
+		h.ServeHTTP(rr, req)
+		if rr.Code != http.StatusServiceUnavailable || decodeErr(t, rr) != "dual_control_unavailable" {
+			t.Fatalf("code=%d err=%q", rr.Code, rr.Body.String())
+		}
+	})
+
+	t.Run("approve_unauthorized", func(t *testing.T) {
+		h := NewTrustPromotionApproveHandler(TrustAdminDeps{OperatorKeys: twoKeys})
+		rr := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodPost, "/admin/trust-promotion/some-id/approve", nil)
+		req.Header.Set("Authorization", "Bearer nope")
+		h.ServeHTTP(rr, req)
+		if rr.Code != http.StatusUnauthorized {
+			t.Fatalf("code=%d body=%q", rr.Code, rr.Body.String())
+		}
+	})
+}
+
+func TestWriteTrustJSON_NoStore(t *testing.T) {
+	rr := httptest.NewRecorder()
+	writeTrustJSON(rr, http.StatusOK, map[string]any{"ok": true})
+	if got := rr.Header().Get("Cache-Control"); !strings.Contains(got, "no-store") {
+		t.Fatalf("Cache-Control=%q", got)
+	}
+}

--- a/specs/SPEC-MALIBU-EMISSION-LEDGER.md
+++ b/specs/SPEC-MALIBU-EMISSION-LEDGER.md
@@ -173,7 +173,13 @@ Coordinator job evaluates SPEC-026 §5.2 criteria on `unlock_eval_interval`:
 - At least **one economic** (E1/E2/E3) **and one distinct additional** criterion
 - E1: ≥100 verified receipts from `settlement_receipt_verdicts` (SQLite billing DB)
 - E2/A3: wallet bound + ≥100 USDC for 72h when `base_usdc_balance_rpc_urls` + checker configured
-- E3: dual-control operator promotion via `/admin/trust-promotion/request` + `.../approve`
+- E3: dual-control operator promotion via `/admin/trust-promotion/request` + `.../approve`.
+  Two-person control is enforced by **distinct operator credentials**: both endpoints
+  authenticate against `auth.operator_keys` (per-actor map) with a constant-time
+  compare, and the acting operator identity is bound to the **matched key** — the
+  `X-Operator-Actor` header is never trusted. The route **fails closed**
+  (`503 dual_control_unavailable`) unless `auth.operator_keys` holds ≥2 entries with
+  distinct, non-empty secrets, so one credential cannot both request and approve.
 - A1: 72h uptime with heartbeat gap &lt;5m (live pool snapshot)
 - A4: `provider_identities.attested = true`
 - On unlock: `trust_tier → trusted`; new accruals omit `trust_tier_provisional` hold


### PR DESCRIPTION
## Summary

Fixes **SEC-1 (HIGH)** — the MALIBU trust-promotion two-person control was defeatable by a **single** operator credential. Both `/admin/trust-promotion/request` and `.../approve` authenticated with one `operator_key` and derived the acting operator identity from a **client-supplied `X-Operator-Actor` header**. The only dual-control gate was `requested_by != approved_by` over those forgeable strings, so one key holder could POST request-as-`alice` then approve-as-`bob` and unilaterally promote a provider to `TierTrusted`, unlocking its accrued MALIBU for withdrawal.

Found by the 2026-07-08 comprehensive audit; **double-confirmed** by an independent codex security lane.

## Fix

- `authorizedTrustOperator` now matches the bearer against `auth.operator_keys` (per-actor map) with the **constant-time** `auth.OperatorOnlyBearerMatches`, and binds the actor to the **matched key**. `X-Operator-Actor` is no longer trusted. This mirrors the existing `internal/ws/admin_endpoints.go` `authorizedProviderAuthPolicyOperator` model.
- Constant-time compare also closes **SEC-2 (LOW)** — the previous `token != operatorKey` short-circuit timing oracle.
- The route **fails closed** (`503 dual_control_unavailable`) unless `operator_keys` holds **≥2 entries with distinct, non-empty secrets**, so two-person control cannot be satisfied by one credential. `ApproveTrustPromotion`'s `requested_by != approved_by` check now genuinely requires two distinct credentials.
- `main.go` wires `cfg.Auth.OperatorKeys` (was `cfg.Auth.OperatorKey`).

## Tests

New `unlock_admin_test.go` (no Postgres needed):
- **SEC-1 regression:** `alice-secret` always resolves to `operator:alice` **even with a spoofed `X-Operator-Actor: bob` header**; only `bob-secret` yields `operator:bob`.
- Fail-closed: single-key and shared-secret maps reject all requests; handler returns `503 dual_control_unavailable`.
- Bad-credential rejection; handler auth ordering (dual-control gate → auth → DB guard).

`go build ./...` clean; full `internal/rewards` suite green.

## Audit (three independent codex lanes, vs origin/main)

| Lane | Verdict |
|---|---|
| CODE | **PASS** — 0 C/H/M |
| SECURITY | **CONFIRMED-FIXED** — 0 C/H/M |
| ARCHITECT | **WATCH (no BLOCK)** — 0 C/H/M |

Carried (non-blocking):
- **LOW (security lane):** an unauthenticated caller can distinguish `503 dual_control_unavailable` from `401 unauthorized`. Config-state disclosure only, no auth/money impact.
- **Follow-up (architect lane):** fail-closed is enforced at *request time* (503), not at config load. Recommend a later change so `malibu_emission.enabled` requires `validateOperatorKeyMap(auth.operator_keys)` at startup (fail-loud). Deliberately **not** bundled here to keep a money-path config-load behavior change out of a security fix.

## Operational note (action required for operators)

Enabling MALIBU trusted-unlock now requires `auth.operator_keys` with **≥2 distinct operators**; a single `auth.operator_key` no longer authorizes this route. The tracked prod `dist/coordinator.yaml` already sets two (`spec026_a`, `spec026_b`). `coordinator.yaml.example` and `SPEC-MALIBU-EMISSION-LEDGER.md` are updated to document the requirement and the "don't rename an operator id with a pending promotion" caveat.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
