### PR TITLE
fix(cli): CS-3 stop control-socket metrics poll draining the coordinator heartbeat window

### DIFF
--- a/phase3-binary/Sources/macprovider-cli/ControlMetricsSnapshot.swift
+++ b/phase3-binary/Sources/macprovider-cli/ControlMetricsSnapshot.swift
@@ -80,7 +80,13 @@ enum ControlMetricsBuilder {
         guard let providerStatus else {
             return ControlMetricsSnapshot()
         }
-        let snapshot = await providerStatus.snapshot(resetWindow: true)
+        // CS-3: the control-socket metrics poll (Malibu.app UI cadence) must NOT
+        // reset the since-last window. That window is owned by the coordinator
+        // heartbeat (CoordinatorClient.sendHeartbeat), whose since-last deltas feed
+        // autotune demand ranking and SPEC-023 payout-first scoring. Draining it
+        // here — the two share one ProviderStatus instance — truncated the next
+        // heartbeat's window to the post-poll sliver. Read without resetting.
+        let snapshot = await providerStatus.snapshot(resetWindow: false)
         var malibu = 0.0
         if let malibuAccrualClient,
            let token = providerToken?.trimmingCharacters(in: .whitespacesAndNewlines),

--- a/phase3-binary/Tests/macprovider-cliTests/ControlMetricsBuilderTests.swift
+++ b/phase3-binary/Tests/macprovider-cliTests/ControlMetricsBuilderTests.swift
@@ -1,0 +1,34 @@
+import Foundation
+import XCTest
+@testable import macprovider_cli
+
+final class ControlMetricsBuilderTests: XCTestCase {
+    private func makeCapacity() -> ProviderCapacity {
+        ProviderCapacity(maxContextOverride: 50_000, maxConcurrencyOverride: 4)
+    }
+
+    // CS-3 regression: the control-socket metrics poll shares one ProviderStatus
+    // instance with the coordinator heartbeat. The poll must READ the since-last
+    // window without RESETTING it, so the next heartbeat still reports the full
+    // window. Before the fix, build() reset the window and the heartbeat saw 0.
+    func testMetricsBuildDoesNotDrainHeartbeatWindow() async {
+        let status = ProviderStatus(modelID: "m", modelLoaded: true, capacity: makeCapacity())
+        await status.finishRequest(startedAt: Date(), completion: nil, failed: false)
+
+        // A Malibu.app metrics poll lands between two heartbeats.
+        _ = await ControlMetricsBuilder.build(
+            providerStatus: status,
+            malibuAccrualClient: nil,
+            providerToken: nil
+        )
+
+        // The heartbeat (resetWindow: true) must still observe the request the
+        // poll read — the poll did not steal it from the since-last window.
+        let heartbeat = await status.snapshot(resetWindow: true)
+        XCTAssertEqual(heartbeat.requestsServedSinceLast, 1)
+
+        // And the heartbeat, which owns rollover, has now cleared the window.
+        let afterHeartbeat = await status.snapshot(resetWindow: false)
+        XCTAssertEqual(afterHeartbeat.requestsServedSinceLast, 0)
+    }
+}


### PR DESCRIPTION
## Summary

Fixes **CS-3 (MEDIUM, payout-adjacent)** from the 2026-07-08 audit. `ControlMetricsBuilder.build` read the shared `ProviderStatus` since-last window with `resetWindow: true`. That window is owned by the coordinator heartbeat (`CoordinatorClient.sendHeartbeat`), whose since-last deltas feed autotune demand ranking and **SPEC-023 payout-first scoring**. Because the control socket and the heartbeat share one `ProviderStatus` instance (injected in `MacProviderCLI`), a Malibu.app metrics poll (UI cadence) landing between heartbeats **drained the window**, truncating the next heartbeat's since-last figures to the post-poll sliver and under-reporting served requests to the coordinator.

## Fix

- The metrics poll now reads with `resetWindow: false`. The coordinator heartbeat remains the **sole** `resetWindow: true` caller and the sole owner of window rollover. All-time cumulative counters were never affected.
- Malibu.app consumes `metrics_response` as display state (verified), so cumulative-since-last-heartbeat window values are correct for the UI — no consumer relied on per-poll deltas.

## Test

`ControlMetricsBuilderTests.testMetricsBuildDoesNotDrainHeartbeatWindow`: record one finished request → poll metrics → assert the next heartbeat (`resetWindow: true`) still observes that request (would be 0 before the fix), then clears it. Existing `ProviderStatusTests` (21) green.

## Audit

Independent codex review (code + concurrency lane): **PASS, 0 Critical/High/Medium**. Confirmed the heartbeat is the only production `resetWindow: true` caller, the actor-isolated reset introduces no double-reset/leak, and Malibu.app display semantics are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
