### PR TITLE
feat(proof-of-weights): W4 observe-only telemetry drift alerts

### DIFF
--- a/docs/research/proof-of-weights-w1-inventory.md
+++ b/docs/research/proof-of-weights-w1-inventory.md
@@ -66,6 +66,6 @@
 
 ---
 
-## Handoff to W2
+## Handoff to W2–W4
 
-W1 seams are wired; W2 adds **capacity ceiling** via verified autotune hardware-evidence at WS hello (`internal/autotune` hello gate). W3 adds **runtime model-class probes** via `pool.model_class_challenges` with optional `max_ttft_ms` / `min_sustained_tps` gates on the existing canary path (`internal/ws/canary_probe.go`), exporting `model_class_opoi_pass` on `/poolz`.
+W1 seams are wired; W2 adds **capacity ceiling** via verified autotune hardware-evidence at WS hello (`internal/autotune` hello gate). W3 adds **runtime model-class probes** via `pool.model_class_challenges` with optional `max_ttft_ms` / `min_sustained_tps` gates on the existing canary path (`internal/ws/canary_probe.go`), exporting `model_class_opoi_pass` on `/poolz`. W4 adds **observe-only telemetry drift alerts** (`internal/pow/drift.go`) comparing live heartbeat TPS/hash and rolling OPoI pass-rate against verified autotune evidence; emits `pow_telemetry_drift_detected` structured logs without changing routing or sanctions.

--- a/phase4-coordinator/cmd/coordinator/main.go
+++ b/phase4-coordinator/cmd/coordinator/main.go
@@ -25,6 +25,7 @@ import (
 	"github.com/augstar/macprovider-coordinator/internal/explorer"
 	"github.com/augstar/macprovider-coordinator/internal/onboarding"
 	"github.com/augstar/macprovider-coordinator/internal/pool"
+	"github.com/augstar/macprovider-coordinator/internal/pow"
 	"github.com/augstar/macprovider-coordinator/internal/providerhttp"
 	"github.com/augstar/macprovider-coordinator/internal/requestlog"
 	"github.com/augstar/macprovider-coordinator/internal/rewards"
@@ -478,6 +479,34 @@ func main() {
 			Int("autotune_evidence_ttl_days", cfg.ProofOfWeights.AutotuneEvidenceTTLDays).
 			Str("autotune_catalog_version", autotuneCatalog.Version).
 			Msg("proof-of-weights autotune hello gate enabled")
+	}
+	if cfg.ProofOfWeights.TelemetryDrift.Enabled {
+		if autotuneCatalog == nil {
+			logger.Fatal().Msg("proof_of_weights.telemetry_drift.enabled requires autotune candidate catalog feeds")
+		}
+		if onboardingStore == nil || onboardingStore.DB() == nil {
+			logger.Fatal().Msg("proof_of_weights.telemetry_drift.enabled requires onboarding postgres store")
+		}
+		driftCfg, err := pow.TelemetryDriftConfigFrom(
+			true,
+			cfg.ProofOfWeights.TelemetryDrift.TPSRatioThreshold,
+			cfg.ProofOfWeights.TelemetryDrift.TPSMinAbsolute,
+			cfg.ProofOfWeights.TelemetryDrift.HashAlertOnStatus,
+			cfg.ProofOfWeights.TelemetryDrift.HashAlertOnArtifactDrift,
+			cfg.ProofOfWeights.TelemetryDrift.OPoIPassRateWindow,
+			cfg.ProofOfWeights.TelemetryDrift.OPoIPassRateThreshold,
+			cfg.ProofOfWeights.TelemetryDrift.AlertCooldownSeconds,
+		)
+		if err != nil {
+			logger.Fatal().Err(err).Msg("proof_of_weights.telemetry_drift config invalid")
+		}
+		evidenceStore := autotune.NewPGEvidenceStore(onboardingStore.DB())
+		ttl := time.Duration(cfg.ProofOfWeights.AutotuneEvidenceTTLDays) * 24 * time.Hour
+		wsOpts = append(wsOpts, providerws.WithTelemetryDriftEvaluator(pow.NewEvaluator(driftCfg, autotuneCatalog, evidenceStore, ttl)))
+		logger.Info().
+			Float64("tps_ratio_threshold", driftCfg.TPSRatioThreshold).
+			Int("opoi_pass_rate_window", driftCfg.OPoIPassRateWindow).
+			Msg("proof-of-weights telemetry drift alerts enabled")
 	}
 	if cfg.Auth.RequireProviderTokens {
 		logger.Info().

--- a/phase4-coordinator/coordinator.pow-w4-staging.yaml
+++ b/phase4-coordinator/coordinator.pow-w4-staging.yaml
@@ -1,0 +1,14 @@
+# Proof of Weights W4 staging overlay — telemetry drift alerts (observe-only).
+# Merge with production coordinator.yaml + Pearl pearl-overlays.yaml.
+proof_of_weights:
+  telemetry_drift:
+    enabled: true
+    tps_ratio_threshold: 0.70
+    tps_min_absolute: 5.0
+    hash_alert_on_status:
+      - hash_mismatch
+      - hash_invalid
+    hash_alert_on_artifact_drift: true
+    opoi_pass_rate_window: 10
+    opoi_pass_rate_threshold: 0.80
+    alert_cooldown_s: 900

--- a/phase4-coordinator/internal/config/config.go
+++ b/phase4-coordinator/internal/config/config.go
@@ -69,8 +69,23 @@ type Config struct {
 // legacy self-declared hello model_id behavior until the operator enables
 // the autotune hello gate explicitly.
 type ProofOfWeightsConfig struct {
-	RequireAutotuneHelloGate bool `yaml:"require_autotune_hello_gate"`
-	AutotuneEvidenceTTLDays  int  `yaml:"autotune_evidence_ttl_days"`
+	RequireAutotuneHelloGate bool                     `yaml:"require_autotune_hello_gate"`
+	AutotuneEvidenceTTLDays  int                      `yaml:"autotune_evidence_ttl_days"`
+	TelemetryDrift           TelemetryDriftConfig     `yaml:"telemetry_drift"`
+}
+
+// TelemetryDriftConfig enables observe-only operator alerts when live
+// provider telemetry diverges from verified autotune evidence or W3 OPoI
+// pass-rate baselines. Default-off; does not change routing or sanctions.
+type TelemetryDriftConfig struct {
+	Enabled                  bool     `yaml:"enabled"`
+	TPSRatioThreshold        float64  `yaml:"tps_ratio_threshold"`
+	TPSMinAbsolute           float64  `yaml:"tps_min_absolute"`
+	HashAlertOnStatus        []string `yaml:"hash_alert_on_status"`
+	HashAlertOnArtifactDrift bool     `yaml:"hash_alert_on_artifact_drift"`
+	OPoIPassRateWindow       int      `yaml:"opoi_pass_rate_window"`
+	OPoIPassRateThreshold    float64  `yaml:"opoi_pass_rate_threshold"`
+	AlertCooldownSeconds     int      `yaml:"alert_cooldown_s"`
 }
 
 type CoordinatorConfig struct {
@@ -745,6 +760,16 @@ func Default() Config {
 		ProofOfWeights: ProofOfWeightsConfig{
 			RequireAutotuneHelloGate: false,
 			AutotuneEvidenceTTLDays:  30,
+			TelemetryDrift: TelemetryDriftConfig{
+				Enabled:                  false,
+				TPSRatioThreshold:        0.70,
+				TPSMinAbsolute:           5.0,
+				HashAlertOnStatus:        []string{"hash_mismatch", "hash_invalid"},
+				HashAlertOnArtifactDrift: true,
+				OPoIPassRateWindow:       10,
+				OPoIPassRateThreshold:    0.80,
+				AlertCooldownSeconds:     900,
+			},
 		},
 		Tier2: Tier2Config{
 			ObserveEnabled:                 false,
@@ -1483,18 +1508,59 @@ func (c Config) validateProofOfWeights() error {
 	if p.AutotuneEvidenceTTLDays < 0 {
 		return fmt.Errorf("proof_of_weights.autotune_evidence_ttl_days must be >= 0")
 	}
-	if !p.RequireAutotuneHelloGate {
+	if p.RequireAutotuneHelloGate {
+		if p.AutotuneEvidenceTTLDays <= 0 {
+			return fmt.Errorf("proof_of_weights.autotune_evidence_ttl_days must be > 0 when require_autotune_hello_gate is true")
+		}
+		if err := c.requireAutotuneEvidenceFeeds(); err != nil {
+			return err
+		}
+	}
+	if !p.TelemetryDrift.Enabled {
 		return nil
 	}
 	if p.AutotuneEvidenceTTLDays <= 0 {
-		return fmt.Errorf("proof_of_weights.autotune_evidence_ttl_days must be > 0 when require_autotune_hello_gate is true")
+		return fmt.Errorf("proof_of_weights.autotune_evidence_ttl_days must be > 0 when telemetry_drift.enabled is true")
 	}
+	if err := c.requireAutotuneEvidenceFeeds(); err != nil {
+		return err
+	}
+	d := p.TelemetryDrift
+	if d.TPSRatioThreshold <= 0 || d.TPSRatioThreshold > 1 || math.IsNaN(d.TPSRatioThreshold) || math.IsInf(d.TPSRatioThreshold, 0) {
+		return fmt.Errorf("proof_of_weights.telemetry_drift.tps_ratio_threshold must be in (0,1]")
+	}
+	if d.TPSMinAbsolute < 0 || math.IsNaN(d.TPSMinAbsolute) || math.IsInf(d.TPSMinAbsolute, 0) {
+		return fmt.Errorf("proof_of_weights.telemetry_drift.tps_min_absolute must be >= 0")
+	}
+	if d.OPoIPassRateWindow < 0 {
+		return fmt.Errorf("proof_of_weights.telemetry_drift.opoi_pass_rate_window must be >= 0")
+	}
+	if d.OPoIPassRateThreshold < 0 || d.OPoIPassRateThreshold > 1 || math.IsNaN(d.OPoIPassRateThreshold) || math.IsInf(d.OPoIPassRateThreshold, 0) {
+		return fmt.Errorf("proof_of_weights.telemetry_drift.opoi_pass_rate_threshold must be in [0,1]")
+	}
+	if d.AlertCooldownSeconds < 0 {
+		return fmt.Errorf("proof_of_weights.telemetry_drift.alert_cooldown_s must be >= 0")
+	}
+	for _, status := range d.HashAlertOnStatus {
+		switch strings.TrimSpace(status) {
+		case "hash_mismatch", "hash_invalid", "hash_verified", "uncatalogued", "catalog_unavailable":
+		default:
+			return fmt.Errorf("proof_of_weights.telemetry_drift.hash_alert_on_status contains unsupported value %q", status)
+		}
+	}
+	if !c.Pool.CanaryEnabled && d.OPoIPassRateWindow > 0 {
+		return fmt.Errorf("proof_of_weights.telemetry_drift.opoi_pass_rate_window requires pool.canary_enabled when > 0")
+	}
+	return nil
+}
+
+func (c Config) requireAutotuneEvidenceFeeds() error {
 	a := c.AutotuneFeeds
 	if strings.TrimSpace(a.AutotuneCandidatesPath) == "" || strings.TrimSpace(a.AutotuneCandidatesSigPath) == "" {
-		return fmt.Errorf("proof_of_weights.require_autotune_hello_gate requires autotune.autotune_candidates_path and autotune.autotune_candidates_sig_path")
+		return fmt.Errorf("proof_of_weights autotune evidence requires autotune.autotune_candidates_path and autotune.autotune_candidates_sig_path")
 	}
 	if !c.Onboarding.AppTrackRegisterEnabled || strings.TrimSpace(c.Onboarding.PostgresDSN) == "" {
-		return fmt.Errorf("proof_of_weights.require_autotune_hello_gate requires onboarding.app_track_register_enabled and onboarding.postgres_dsn")
+		return fmt.Errorf("proof_of_weights autotune evidence requires onboarding.app_track_register_enabled and onboarding.postgres_dsn")
 	}
 	return nil
 }

--- a/phase4-coordinator/internal/config/proof_of_weights_test.go
+++ b/phase4-coordinator/internal/config/proof_of_weights_test.go
@@ -22,3 +22,28 @@ func TestValidateProofOfWeightsRequiresFeedsAndOnboarding(t *testing.T) {
 		t.Fatalf("Validate() = %v, want onboarding requirement", err)
 	}
 }
+
+func proofOfWeightsOnboardingBaseline(cfg *config.Config) {
+	cfg.AutotuneFeeds.AutotuneCandidatesPath = "/tmp/autotune-candidates.json"
+	cfg.AutotuneFeeds.AutotuneCandidatesSigPath = "/tmp/autotune-candidates.json.sig"
+	cfg.Onboarding.AppTrackRegisterEnabled = true
+	cfg.Onboarding.PostgresDSN = "postgres://provider_onboarding@127.0.0.1/db?sslmode=disable"
+	cfg.Onboarding.AuthPolicyRequestDSN = "postgres://provider_auth_policy_requester@127.0.0.1/db?sslmode=disable"
+	cfg.Onboarding.AuthPolicyApproveDSN = "postgres://provider_auth_policy_approver@127.0.0.1/db?sslmode=disable"
+	cfg.Onboarding.AuthPolicyCutoverDSN = "postgres://provider_auth_policy_cutover@127.0.0.1/db?sslmode=disable"
+	cfg.Onboarding.AppleTeamID = "TEAM12345"
+	cfg.Onboarding.ASNPrefixes = map[string]string{"198.51.100.0/24": "AS64500"}
+	cfg.Auth.OperatorKeys = map[string]string{"alice": "alice-secret", "bob": "bob-secret"}
+}
+
+func TestValidateProofOfWeightsTelemetryDriftRequiresCanaryWhenWindowSet(t *testing.T) {
+	cfg := config.Default()
+	cfg.Auth.OperatorKey = "test-operator-key"
+	cfg.ProofOfWeights.AutotuneEvidenceTTLDays = 30
+	cfg.ProofOfWeights.TelemetryDrift.Enabled = true
+	cfg.ProofOfWeights.TelemetryDrift.OPoIPassRateWindow = 10
+	proofOfWeightsOnboardingBaseline(&cfg)
+	if err := cfg.Validate(); err == nil || !strings.Contains(err.Error(), "pool.canary_enabled") {
+		t.Fatalf("Validate() = %v, want canary requirement", err)
+	}
+}

--- a/phase4-coordinator/internal/pow/drift.go
+++ b/phase4-coordinator/internal/pow/drift.go
@@ -1,0 +1,297 @@
+package pow
+
+import (
+	"context"
+	"fmt"
+	"math"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/augstar/macprovider-coordinator/internal/autotune"
+	"github.com/augstar/macprovider-coordinator/internal/pool"
+)
+
+const EventTelemetryDriftDetected = "pow_telemetry_drift_detected"
+
+type TelemetryDriftConfig struct {
+	Enabled                  bool
+	TPSRatioThreshold        float64
+	TPSMinAbsolute           float64
+	HashAlertOnStatus        []pool.HashStatus
+	HashAlertOnArtifactDrift bool
+	OPoIPassRateWindow       int
+	OPoIPassRateThreshold    float64
+	AlertCooldown            time.Duration
+}
+
+type Alert struct {
+	Signal               string
+	ProviderID           string
+	AssignedID           string
+	ModelID              string
+	LiveTPS              float64
+	BaselineTPS          float64
+	TPSThreshold         float64
+	HashStatus           pool.HashStatus
+	LiveModelHash        string
+	ExpectedArtifactHash string
+	OPoIPassRate         float64
+	OPoIPassRateWindow   int
+	OPoIPassCount        int
+	SwapDetected         bool
+}
+
+type Evaluator struct {
+	cfg         TelemetryDriftConfig
+	catalog     *autotune.Catalog
+	evidence    autotune.EvidenceStore
+	evidenceTTL time.Duration
+	opoi        *rollingPassRate
+	lastAlert   map[string]time.Time
+	mu          sync.Mutex
+	now         func() time.Time
+}
+
+func NewEvaluator(cfg TelemetryDriftConfig, catalog *autotune.Catalog, evidence autotune.EvidenceStore, evidenceTTL time.Duration) *Evaluator {
+	if cfg.OPoIPassRateWindow <= 0 {
+		cfg.OPoIPassRateWindow = 10
+	}
+	if cfg.OPoIPassRateThreshold <= 0 {
+		cfg.OPoIPassRateThreshold = 0.80
+	}
+	if cfg.TPSRatioThreshold <= 0 {
+		cfg.TPSRatioThreshold = 0.70
+	}
+	if cfg.AlertCooldown <= 0 {
+		cfg.AlertCooldown = 15 * time.Minute
+	}
+	return &Evaluator{
+		cfg:         cfg,
+		catalog:     catalog,
+		evidence:    evidence,
+		evidenceTTL: evidenceTTL,
+		opoi:        newRollingPassRate(cfg.OPoIPassRateWindow),
+		lastAlert:   make(map[string]time.Time),
+		now:         time.Now,
+	}
+}
+
+func ResolveVerifiedBenchmark(catalog *autotune.Catalog, evidence autotune.VerifiedEvidence, modelID string) (autotune.VerifiedBenchmark, bool) {
+	if catalog == nil {
+		return autotune.VerifiedBenchmark{}, false
+	}
+	key, _, ok := catalog.HighestClaimedTier(modelID)
+	if !ok {
+		return autotune.VerifiedBenchmark{}, false
+	}
+	for _, benchmark := range evidence.Benchmarks {
+		if strings.EqualFold(strings.TrimSpace(benchmark.ModelKey), key) {
+			return benchmark, true
+		}
+	}
+	normalized := strings.ToLower(strings.TrimSpace(modelID))
+	for _, benchmark := range evidence.Benchmarks {
+		if strings.EqualFold(strings.TrimSpace(benchmark.ModelID), normalized) {
+			return benchmark, true
+		}
+	}
+	return autotune.VerifiedBenchmark{}, false
+}
+
+func (e *Evaluator) EvaluateHeartbeat(ctx context.Context, provider pool.Provider) []Alert {
+	if e == nil || !e.cfg.Enabled {
+		return nil
+	}
+	evidence, ok, err := e.evidence.LatestVerified(ctx, provider.ProviderID, e.evidenceTTL)
+	if err != nil || !ok {
+		return nil
+	}
+	benchmark, hasBenchmark := ResolveVerifiedBenchmark(e.catalog, evidence, provider.ModelID)
+	var alerts []Alert
+	if alert, ok := e.evaluateTPS(provider, benchmark, hasBenchmark); ok {
+		alerts = append(alerts, alert)
+	}
+	if alert, ok := e.evaluateHash(provider, benchmark, hasBenchmark); ok {
+		alerts = append(alerts, alert)
+	}
+	return e.filterCooldown(alerts)
+}
+
+func (e *Evaluator) RecordModelClassCanary(provider pool.Provider, passed bool) []Alert {
+	if e == nil || !e.cfg.Enabled || e.opoi == nil {
+		return nil
+	}
+	key := provider.ProviderID + "|" + provider.AssignedID
+	rate, count, window := e.opoi.record(key, passed)
+	if count < window {
+		return nil
+	}
+	if rate >= e.cfg.OPoIPassRateThreshold {
+		return nil
+	}
+	alert := Alert{
+		Signal:             "opoi_pass_rate",
+		ProviderID:         provider.ProviderID,
+		AssignedID:         provider.AssignedID,
+		ModelID:            provider.ModelID,
+		OPoIPassRate:       rate,
+		OPoIPassRateWindow: window,
+		OPoIPassCount:      count,
+	}
+	return e.filterCooldown([]Alert{alert})
+}
+
+func (e *Evaluator) evaluateTPS(provider pool.Provider, benchmark autotune.VerifiedBenchmark, hasBenchmark bool) (Alert, bool) {
+	if !hasBenchmark {
+		return Alert{}, false
+	}
+	baseline := benchmark.SustainedTPS
+	if baseline <= 0 || math.IsNaN(baseline) || math.IsInf(baseline, 0) {
+		return Alert{}, false
+	}
+	live := provider.ThroughputTPSEstimate
+	if live <= 0 || math.IsNaN(live) || math.IsInf(live, 0) {
+		return Alert{}, false
+	}
+	threshold := math.Max(e.cfg.TPSMinAbsolute, baseline*e.cfg.TPSRatioThreshold)
+	if live >= threshold {
+		return Alert{}, false
+	}
+	return Alert{
+		Signal:       "tps",
+		ProviderID:   provider.ProviderID,
+		AssignedID:   provider.AssignedID,
+		ModelID:      provider.ModelID,
+		LiveTPS:      live,
+		BaselineTPS:  baseline,
+		TPSThreshold: threshold,
+		SwapDetected: benchmark.SwapDetected,
+	}, true
+}
+
+func (e *Evaluator) evaluateHash(provider pool.Provider, benchmark autotune.VerifiedBenchmark, hasBenchmark bool) (Alert, bool) {
+	for _, status := range e.cfg.HashAlertOnStatus {
+		if provider.HashStatus == status {
+			return Alert{
+				Signal:     "hash_status",
+				ProviderID: provider.ProviderID,
+				AssignedID: provider.AssignedID,
+				ModelID:    provider.ModelID,
+				HashStatus: provider.HashStatus,
+				LiveModelHash: strings.TrimSpace(provider.ModelHash),
+			}, true
+		}
+	}
+	if !e.cfg.HashAlertOnArtifactDrift || !hasBenchmark {
+		return Alert{}, false
+	}
+	expected := strings.ToLower(strings.TrimSpace(benchmark.ArtifactSHA256))
+	live := strings.ToLower(strings.TrimSpace(provider.ModelHash))
+	if expected == "" || live == "" || expected == live {
+		return Alert{}, false
+	}
+	return Alert{
+		Signal:               "hash_artifact",
+		ProviderID:           provider.ProviderID,
+		AssignedID:           provider.AssignedID,
+		ModelID:              provider.ModelID,
+		HashStatus:           provider.HashStatus,
+		LiveModelHash:        live,
+		ExpectedArtifactHash: expected,
+		SwapDetected:         benchmark.SwapDetected,
+	}, true
+}
+
+func (e *Evaluator) filterCooldown(alerts []Alert) []Alert {
+	if len(alerts) == 0 {
+		return nil
+	}
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	now := e.now()
+	out := make([]Alert, 0, len(alerts))
+	for _, alert := range alerts {
+		key := alert.ProviderID + "|" + alert.Signal
+		if last, ok := e.lastAlert[key]; ok && now.Sub(last) < e.cfg.AlertCooldown {
+			continue
+		}
+		e.lastAlert[key] = now
+		out = append(out, alert)
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+type rollingPassRate struct {
+	window int
+	mu     sync.Mutex
+	byKey  map[string][]bool
+}
+
+func newRollingPassRate(window int) *rollingPassRate {
+	if window <= 0 {
+		window = 10
+	}
+	return &rollingPassRate{
+		window: window,
+		byKey:  make(map[string][]bool),
+	}
+}
+
+func (r *rollingPassRate) record(key string, passed bool) (rate float64, count int, window int) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	history := append(r.byKey[key], passed)
+	if len(history) > r.window {
+		history = history[len(history)-r.window:]
+	}
+	r.byKey[key] = history
+	passes := 0
+	for _, ok := range history {
+		if ok {
+			passes++
+		}
+	}
+	if len(history) == 0 {
+		return 0, 0, r.window
+	}
+	return float64(passes) / float64(len(history)), len(history), r.window
+}
+
+func ParseHashAlertStatuses(values []string) ([]pool.HashStatus, error) {
+	if len(values) == 0 {
+		return []pool.HashStatus{pool.HashStatusMismatch, pool.HashStatusInvalid}, nil
+	}
+	out := make([]pool.HashStatus, 0, len(values))
+	for _, raw := range values {
+		status := pool.HashStatus(strings.TrimSpace(raw))
+		switch status {
+		case pool.HashStatusMismatch, pool.HashStatusInvalid, pool.HashStatusUncatalogued, pool.HashStatusCatalogUnavailable, pool.HashStatusVerified:
+			out = append(out, status)
+		default:
+			return nil, fmt.Errorf("unsupported hash_alert_on_status value %q", raw)
+		}
+	}
+	return out, nil
+}
+
+func TelemetryDriftConfigFrom(enabled bool, tpsRatio, tpsMinAbsolute float64, hashStatuses []string, hashArtifactDrift bool, opoiWindow int, opoiThreshold float64, cooldownSeconds int) (TelemetryDriftConfig, error) {
+	statuses, err := ParseHashAlertStatuses(hashStatuses)
+	if err != nil {
+		return TelemetryDriftConfig{}, err
+	}
+	cooldown := time.Duration(cooldownSeconds) * time.Second
+	return TelemetryDriftConfig{
+		Enabled:                  enabled,
+		TPSRatioThreshold:        tpsRatio,
+		TPSMinAbsolute:           tpsMinAbsolute,
+		HashAlertOnStatus:        statuses,
+		HashAlertOnArtifactDrift: hashArtifactDrift,
+		OPoIPassRateWindow:       opoiWindow,
+		OPoIPassRateThreshold:    opoiThreshold,
+		AlertCooldown:            cooldown,
+	}, nil
+}

--- a/phase4-coordinator/internal/pow/drift_test.go
+++ b/phase4-coordinator/internal/pow/drift_test.go
@@ -1,0 +1,168 @@
+package pow
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/augstar/macprovider-coordinator/internal/autotune"
+	"github.com/augstar/macprovider-coordinator/internal/pool"
+)
+
+type stubEvidence struct {
+	evidence autotune.VerifiedEvidence
+	ok       bool
+}
+
+func (s stubEvidence) LatestVerified(context.Context, string, time.Duration) (autotune.VerifiedEvidence, bool, error) {
+	return s.evidence, s.ok, nil
+}
+
+func mustCatalog(t *testing.T, raw string) *autotune.Catalog {
+	t.Helper()
+	catalog, err := autotune.ParseCatalog([]byte(raw))
+	if err != nil {
+		t.Fatalf("ParseCatalog: %v", err)
+	}
+	return catalog
+}
+
+func TestEvaluateHeartbeatTPSDrift(t *testing.T) {
+	t.Parallel()
+	catalog := mustCatalog(t, `{
+		"version":"test","source":"operator_curated_autotune_candidate_catalog",
+		"rows":{"qwen3-coder-30b-a3b-instruct":{"model_id":"mlx-community/Qwen3-Coder-30B-A3B-Instruct-4bit","min_ram_gb":28,"bench_gate":{"min_sustained_tps":20,"max_4k_ttft_ms":3500}}}
+	}`)
+	evidence := autotune.VerifiedEvidence{
+		CandidateCatalogSHA256: catalog.SHA256,
+		Benchmarks: []autotune.VerifiedBenchmark{{
+			ModelKey:       "qwen3-coder-30b-a3b-instruct",
+			ModelID:        "mlx-community/Qwen3-Coder-30B-A3B-Instruct-4bit",
+			SustainedTPS:   20,
+			ArtifactSHA256: "abc123",
+		}},
+	}
+	evaluator := NewEvaluator(TelemetryDriftConfig{
+		Enabled:           true,
+		TPSRatioThreshold: 0.70,
+		TPSMinAbsolute:    5,
+		AlertCooldown:     time.Second,
+	}, catalog, stubEvidence{evidence: evidence, ok: true}, 30*24*time.Hour)
+	evaluator.now = func() time.Time { return time.Unix(0, 0) }
+
+	alerts := evaluator.EvaluateHeartbeat(context.Background(), pool.Provider{
+		ProviderID:            "mac",
+		AssignedID:            "sess-1",
+		ModelID:               "qwen3-coder-30b-a3b-instruct",
+		ThroughputTPSEstimate: 10,
+		HashStatus:            pool.HashStatusVerified,
+		ModelHash:             "abc123",
+	})
+	if len(alerts) != 1 || alerts[0].Signal != "tps" {
+		t.Fatalf("alerts = %#v, want single tps alert", alerts)
+	}
+
+	alerts = evaluator.EvaluateHeartbeat(context.Background(), pool.Provider{
+		ProviderID:            "mac",
+		AssignedID:            "sess-1",
+		ModelID:               "qwen3-coder-30b-a3b-instruct",
+		ThroughputTPSEstimate: 15,
+		HashStatus:            pool.HashStatusVerified,
+		ModelHash:             "abc123",
+	})
+	if len(alerts) != 0 {
+		t.Fatalf("expected no alert above threshold, got %#v", alerts)
+	}
+}
+
+func TestEvaluateHeartbeatHashArtifactDrift(t *testing.T) {
+	t.Parallel()
+	catalog := mustCatalog(t, `{
+		"version":"test","source":"operator_curated_autotune_candidate_catalog",
+		"rows":{"qwen3-coder-30b-a3b-instruct":{"model_id":"mlx-community/Qwen3-Coder-30B-A3B-Instruct-4bit","min_ram_gb":28,"bench_gate":{"min_sustained_tps":20,"max_4k_ttft_ms":3500}}}
+	}`)
+	evidence := autotune.VerifiedEvidence{
+		CandidateCatalogSHA256: catalog.SHA256,
+		Benchmarks: []autotune.VerifiedBenchmark{{
+			ModelKey:       "qwen3-coder-30b-a3b-instruct",
+			SustainedTPS:   20,
+			ArtifactSHA256: "deadbeef",
+		}},
+	}
+	evaluator := NewEvaluator(TelemetryDriftConfig{
+		Enabled:                  true,
+		HashAlertOnArtifactDrift: true,
+		AlertCooldown:            time.Second,
+	}, catalog, stubEvidence{evidence: evidence, ok: true}, 30*24*time.Hour)
+	evaluator.now = func() time.Time { return time.Unix(0, 0) }
+
+	alerts := evaluator.EvaluateHeartbeat(context.Background(), pool.Provider{
+		ProviderID:            "mac",
+		AssignedID:            "sess-1",
+		ModelID:               "qwen3-coder-30b-a3b-instruct",
+		ThroughputTPSEstimate: 20,
+		HashStatus:            pool.HashStatusVerified,
+		ModelHash:             "cafebabe",
+	})
+	if len(alerts) != 1 || alerts[0].Signal != "hash_artifact" {
+		t.Fatalf("alerts = %#v, want hash_artifact", alerts)
+	}
+}
+
+func TestRecordModelClassCanaryPassRateDrop(t *testing.T) {
+	t.Parallel()
+	evaluator := NewEvaluator(TelemetryDriftConfig{
+		Enabled:               true,
+		OPoIPassRateWindow:    5,
+		OPoIPassRateThreshold: 0.80,
+		AlertCooldown:         time.Second,
+	}, nil, stubEvidence{}, time.Hour)
+	evaluator.now = func() time.Time { return time.Unix(0, 0) }
+	provider := pool.Provider{ProviderID: "mac", AssignedID: "sess-1", ModelID: "qwen3-coder-30b-a3b-instruct"}
+
+	for i := 0; i < 4; i++ {
+		if alerts := evaluator.RecordModelClassCanary(provider, false); alerts != nil {
+			t.Fatalf("unexpected early alert at %d: %#v", i, alerts)
+		}
+	}
+	alerts := evaluator.RecordModelClassCanary(provider, false)
+	if len(alerts) != 1 || alerts[0].Signal != "opoi_pass_rate" {
+		t.Fatalf("alerts = %#v, want opoi_pass_rate", alerts)
+	}
+}
+
+func TestTelemetryDriftCooldownSuppressesRepeat(t *testing.T) {
+	t.Parallel()
+	catalog := mustCatalog(t, `{
+		"version":"test","source":"operator_curated_autotune_candidate_catalog",
+		"rows":{"qwen3-coder-30b-a3b-instruct":{"model_id":"mlx-community/Qwen3-Coder-30B-A3B-Instruct-4bit","min_ram_gb":28,"bench_gate":{"min_sustained_tps":20,"max_4k_ttft_ms":3500}}}
+	}`)
+	evidence := autotune.VerifiedEvidence{
+		CandidateCatalogSHA256: catalog.SHA256,
+		Benchmarks: []autotune.VerifiedBenchmark{{
+			ModelKey:     "qwen3-coder-30b-a3b-instruct",
+			SustainedTPS: 20,
+		}},
+	}
+	now := time.Unix(1000, 0)
+	evaluator := NewEvaluator(TelemetryDriftConfig{
+		Enabled:           true,
+		TPSRatioThreshold: 0.70,
+		TPSMinAbsolute:    5,
+		AlertCooldown:     15 * time.Minute,
+	}, catalog, stubEvidence{evidence: evidence, ok: true}, time.Hour)
+	evaluator.now = func() time.Time { return now }
+
+	provider := pool.Provider{
+		ProviderID:            "mac",
+		AssignedID:            "sess-1",
+		ModelID:               "qwen3-coder-30b-a3b-instruct",
+		ThroughputTPSEstimate: 1,
+	}
+	if alerts := evaluator.EvaluateHeartbeat(context.Background(), provider); len(alerts) != 1 {
+		t.Fatalf("first alert = %#v", alerts)
+	}
+	if alerts := evaluator.EvaluateHeartbeat(context.Background(), provider); len(alerts) != 0 {
+		t.Fatalf("expected cooldown suppression, got %#v", alerts)
+	}
+}

--- a/phase4-coordinator/internal/ws/server.go
+++ b/phase4-coordinator/internal/ws/server.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/augstar/macprovider-coordinator/internal/auth"
 	"github.com/augstar/macprovider-coordinator/internal/autotune"
+	"github.com/augstar/macprovider-coordinator/internal/pow"
 )
 
 const (
@@ -88,6 +89,7 @@ type Server struct {
 	catalog            *tier2.Catalog
 	autotuneCatalog    *autotune.Catalog
 	autotuneEvidence   autotune.EvidenceStore
+	telemetryDrift     *pow.Evaluator
 	identitySignatures IdentitySignatureStore
 	authPolicyAdmin    ProviderAuthPolicyAdminStore
 	idlePrewarm        IdlePrewarmRecorder
@@ -202,6 +204,12 @@ func WithAutotuneHelloGate(catalog *autotune.Catalog, store autotune.EvidenceSto
 	return func(s *Server) {
 		s.autotuneCatalog = catalog
 		s.autotuneEvidence = store
+	}
+}
+
+func WithTelemetryDriftEvaluator(evaluator *pow.Evaluator) Option {
+	return func(s *Server) {
+		s.telemetryDrift = evaluator
 	}
 }
 
@@ -2112,6 +2120,9 @@ func (s *Server) runCanaryProbe(provider pool.Provider) bool {
 	if attempt.modelClassBank {
 		pass := outcome == canaryProbePass
 		s.pool.SetModelClassOPoIPass(provider.ProviderID, provider.AssignedID, &pass)
+		if s.telemetryDrift != nil {
+			s.logTelemetryDriftAlerts(s.telemetryDrift.RecordModelClassCanary(provider, pass))
+		}
 	}
 	if outcome == canaryProbeSkip {
 		s.log.Debug().Str("provider_id", provider.ProviderID).Msg("provider canary skipped")
@@ -2664,6 +2675,53 @@ func (s *Server) handleHeartbeat(conn net.Conn, providerID, assignedID string, p
 			Int("slots_total", entry.SlotsTotal).
 			Msg("provider heartbeat")
 	}
+	if s.telemetryDrift != nil {
+		s.logTelemetryDriftAlerts(s.telemetryDrift.EvaluateHeartbeat(context.Background(), *entry))
+	}
+}
+
+func (s *Server) logTelemetryDriftAlerts(alerts []pow.Alert) {
+	for _, alert := range alerts {
+		event := s.log.Warn().
+			Str("event", pow.EventTelemetryDriftDetected).
+			Str("signal", alert.Signal).
+			Str("provider_id", alert.ProviderID).
+			Str("assigned_id", alert.AssignedID).
+			Str("model_id", alert.ModelID)
+		if alert.LiveTPS > 0 || alert.BaselineTPS > 0 {
+			event = event.
+				Float64("live_tps", alert.LiveTPS).
+				Float64("baseline_tps", alert.BaselineTPS).
+				Float64("tps_threshold", alert.TPSThreshold)
+		}
+		if alert.HashStatus != "" {
+			event = event.Str("hash_status", string(alert.HashStatus))
+		}
+		if alert.LiveModelHash != "" {
+			event = event.Str("live_model_hash_prefix", prefixHex(alert.LiveModelHash, 8))
+		}
+		if alert.ExpectedArtifactHash != "" {
+			event = event.Str("expected_artifact_hash_prefix", prefixHex(alert.ExpectedArtifactHash, 8))
+		}
+		if alert.OPoIPassRateWindow > 0 {
+			event = event.
+				Float64("opoi_pass_rate", alert.OPoIPassRate).
+				Int("opoi_pass_rate_window", alert.OPoIPassRateWindow).
+				Int("opoi_pass_count", alert.OPoIPassCount)
+		}
+		if alert.SwapDetected {
+			event = event.Bool("swap_detected", true)
+		}
+		event.Msg("proof-of-weights telemetry drift detected")
+	}
+}
+
+func prefixHex(value string, n int) string {
+	value = strings.TrimSpace(value)
+	if n <= 0 || len(value) <= n {
+		return value
+	}
+	return value[:n]
 }
 
 func poolHardwareCapacity(summary *HardwareSummary) *pool.ProviderHardwareCapacity {


### PR DESCRIPTION
## Summary
- Add `proof_of_weights.telemetry_drift` config (disabled by default) with TPS ratio/absolute thresholds, hash status + artifact drift alerts, and rolling OPoI pass-rate window.
- Wire `internal/pow` evaluator into WS heartbeat and model-class canary paths; emit structured `pow_telemetry_drift_detected` logs with per-signal cooldown dedupe.
- Observe-only: no routing, admission, or sanction changes. Includes staging overlay example and W1 inventory handoff note.

## Test plan
- [x] `go test ./...` in `phase4-coordinator`
- [ ] Pearl staging: merge `coordinator.pow-w4-staging.yaml` into pearl overlay, restart coordinator, induce TPS/hash drift and confirm alert logs

Made with [Cursor](https://cursor.com)