### PR TITLE
fix(deploy): OPS-1 remove superseded opoi-v0 systemd drop-in on malibu emission deploy

### DIFF
--- a/phase4-coordinator/dist/deploy-malibu-emission-pearl.sh
+++ b/phase4-coordinator/dist/deploy-malibu-emission-pearl.sh
@@ -180,6 +180,14 @@ if [ "$DRY_RUN" != "1" ]; then
     install -d -o root -g root -m 0755 /etc/systemd/system/macprovider-coordinator.service.d
     install -o root -g root -m 0644 $DEPLOY_TMP/malibu-emission.conf \
       /etc/systemd/system/macprovider-coordinator.service.d/malibu-emission.conf
+    # OPS-1: remove the superseded OPoI drop-in. Its ExecStart points at
+    # coordinator.opoi-v0-staging.yaml and, because systemd applies .service.d
+    # drop-ins in lexicographic filename order, opoi-v0.conf sorts AFTER
+    # malibu-emission.conf and its ExecStart would WIN — the coordinator would
+    # then ignore the merged coordinator.pearl-overlays.yaml. The OPoI config is
+    # already folded into pearl-overlays.yaml by the step 3 merge, so removing
+    # this drop-in drops no configuration.
+    rm -f /etc/systemd/system/macprovider-coordinator.service.d/opoi-v0.conf
   "
 fi
 
@@ -216,6 +224,15 @@ if [ "$DRY_RUN" != "1" ]; then
       --config-overlay /etc/macprovider/coordinator.pearl-overlays.yaml \
       --validate-config
     systemctl daemon-reload
+    # OPS-1: assert the effective ExecStart uses the merged overlay we just
+    # validated. Guards against a lingering/again-added drop-in silently running
+    # the coordinator against a different --config-overlay than --validate-config
+    # checked (validate-vs-runtime divergence).
+    if ! systemctl show -p ExecStart macprovider-coordinator | grep -q "coordinator.pearl-overlays.yaml"; then
+      echo "ERROR: effective ExecStart does not reference coordinator.pearl-overlays.yaml" >&2
+      systemctl show -p ExecStart macprovider-coordinator >&2
+      exit 1
+    fi
     systemctl restart macprovider-coordinator
     sleep 3
     systemctl is-active macprovider-coordinator
@@ -234,5 +251,13 @@ log "DONE. C4 staging complete with malibu_emission.enabled=false."
 log "Verify read API from a provider token:"
 log "  curl -sS -H \"Authorization: Bearer \$PROVIDER_TOKEN\" https://$DOMAIN/v1/provider/malibu-accrual | jq"
 log "Promotion (accrual ticks): set malibu_emission.enabled: true in pearl overlay and restart."
-log "Rollback:"
-log "  ssh -i $SSH_KEY $VPS_USER@$VPS_HOST 'sudo rm /etc/systemd/system/macprovider-coordinator.service.d/malibu-emission.conf && sudo systemctl daemon-reload && sudo systemctl restart macprovider-coordinator'"
+log "Rollback (disable MALIBU emission, KEEP the OPoI overlay):"
+log "  1. Edit /etc/macprovider/coordinator.pearl-overlays.yaml and set the"
+log "     malibu_emission.enabled key to false (edit the YAML directly; do not"
+log "     sed it — a blind substitution can hit another 'enabled:' key or break"
+log "     indentation)."
+log "  2. Validate + restart (drop-in unchanged so the OPoI overlay is preserved):"
+log "     ssh -i $SSH_KEY $VPS_USER@$VPS_HOST 'sudo /opt/macprovider/coordinator --config /opt/macprovider/coordinator.yaml --config-overlay /etc/macprovider/coordinator.pearl-overlays.yaml --validate-config && sudo systemctl restart macprovider-coordinator'"
+log "  Do NOT remove the malibu-emission.conf drop-in: it loads pearl-overlays.yaml,"
+log "  which now also carries the merged OPoI overlay, so removing it would leave the"
+log "  base unit with no --config-overlay and drop the OPoI canary config."


### PR DESCRIPTION
## Summary

Fixes **OPS-1 (MEDIUM, deploy-safety)** from the 2026-07-08 audit. `deploy-malibu-emission-pearl.sh` installed `malibu-emission.conf` but left the earlier `opoi-v0.conf` systemd drop-in in place. systemd applies `.service.d` drop-ins in lexicographic filename order and the last `ExecStart=` reset+set wins; `opoi-v0.conf` sorts **after** `malibu-emission.conf`, so its `ExecStart` (`--config-overlay coordinator.opoi-v0-staging.yaml`) won and the coordinator ran against the OPoI-only overlay instead of the merged `coordinator.pearl-overlays.yaml` that step 7 `--validate-config` had just checked — a validate-vs-runtime divergence. Enabling `malibu_emission` in `pearl-overlays.yaml` then silently had no effect.

## Fix

- **Step 5:** `rm -f opoi-v0.conf` during install, so exactly one drop-in defines `ExecStart`. Its config is already folded into `pearl-overlays.yaml` by the step 3 merge (`merge-yaml-overlay.py` recursively merges `pool:` OPoI keys with `malibu_emission:`), so nothing is dropped. `rm -f` is idempotent and safe on fresh hosts / re-runs.
- **Step 7:** assert `systemctl show -p ExecStart` references `coordinator.pearl-overlays.yaml` after `daemon-reload` and **before** restart, failing closed (`exit 1`) — catches any future drop-in that would re-introduce the divergence.
- **Rollback guidance:** rewritten to disable `malibu_emission` in `pearl-overlays.yaml` while **keeping** the drop-in (it now loads the overlay carrying the merged OPoI config). Removing the drop-in would drop OPoI. Guidance is YAML-aware and explicitly warns against a blind `sed` (which could hit another `enabled:` key or break indentation).

## Verification

`bash -n` clean; no new shellcheck warnings (only the pre-existing line-166 `SC2145/SC2064`). Independent codex ops-deploy review: **PASS, 0 Critical/High/Medium** — confirmed OPoI preservation (rendered the merged overlay: `pool.canary_enabled=true` + `malibu_emission.enabled=false` both present), drop-in determinism, the fail-closed `ExecStart` assertion, and the corrected rollback. (A first review pass caught that the initial fix left the rollback guidance stale; that was fixed and re-verified.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
