### PR TITLE
Close SPEC-005 quarantine credit arm

### DIFF
--- a/phase4-coordinator/cmd/coordinator/main.go
+++ b/phase4-coordinator/cmd/coordinator/main.go
@@ -208,6 +208,11 @@ func main() {
 		fmt.Fprintf(os.Stderr, "billing force-void flag init: %v\n", err)
 		os.Exit(1)
 	}
+	if err := billingStore.SetForceCreditEnabled(context.Background(), cfg.Billing.QuarantineResolutionForceCreditEnabled, "startup"); err != nil {
+		fmt.Fprintf(os.Stderr, "billing force-credit flag init: %v\n", err)
+		os.Exit(1)
+	}
+	billingStore.SetForceCreditSettlementHoldSeconds(int64(cfg.Billing.ForceCreditSettlementHoldSeconds))
 	snapshotID, err := billingStore.InsertConfigSnapshot(context.Background(), cfg.Rewards, time.Now().UTC())
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "billing config snapshot: %v\n", err)
@@ -391,16 +396,16 @@ func main() {
 			sqlitePath = cfg.Storage.DBPath
 		}
 		rewardsCfg := rewards.Config{
-			Enabled:                  true,
-			WriterDSN:                cfg.MalibuEmission.WriterDSN,
-			TickInterval:             time.Duration(cfg.MalibuEmission.TickIntervalSeconds) * time.Second,
-			ProviderDailyCapMALIBU:   cfg.MalibuEmission.ProviderDailyCapMALIBU,
-			WalletDailyCapMALIBU:     cfg.MalibuEmission.WalletDailyCapMALIBU,
-			SQLitePayoutDBPath:       sqlitePath,
-			WalletMirrorInterval:     time.Duration(cfg.MalibuEmission.WalletMirrorIntervalSeconds) * time.Second,
-			UnlockEvalInterval:       time.Duration(cfg.MalibuEmission.UnlockEvalIntervalSeconds) * time.Second,
-			MaxSerializableRetries:   cfg.MalibuEmission.MaxSerializableRetries,
-			BaseUSDCBalanceRPCURLs:   cfg.MalibuEmission.BaseUSDCBalanceRPCURLs,
+			Enabled:                true,
+			WriterDSN:              cfg.MalibuEmission.WriterDSN,
+			TickInterval:           time.Duration(cfg.MalibuEmission.TickIntervalSeconds) * time.Second,
+			ProviderDailyCapMALIBU: cfg.MalibuEmission.ProviderDailyCapMALIBU,
+			WalletDailyCapMALIBU:   cfg.MalibuEmission.WalletDailyCapMALIBU,
+			SQLitePayoutDBPath:     sqlitePath,
+			WalletMirrorInterval:   time.Duration(cfg.MalibuEmission.WalletMirrorIntervalSeconds) * time.Second,
+			UnlockEvalInterval:     time.Duration(cfg.MalibuEmission.UnlockEvalIntervalSeconds) * time.Second,
+			MaxSerializableRetries: cfg.MalibuEmission.MaxSerializableRetries,
+			BaseUSDCBalanceRPCURLs: cfg.MalibuEmission.BaseUSDCBalanceRPCURLs,
 		}
 		var err error
 		rewardsRunner, err = rewards.New(rewardsDB, rewardsCfg, logger.With().Str("subsystem", "malibu_emission").Logger(), rewards.RunnerDeps{})
@@ -711,17 +716,20 @@ func main() {
 	if statsPools != nil {
 		idlePrewarmReader = statsprewarm.NewReader(statsPools.Reader)
 	}
-	billingHandler := billingStore.HandlersWithQuarantineGateAndIdlePrewarm(
+	billingHandler := billingStore.HandlersWithQuarantineGatesAndIdlePrewarm(
 		cfg.Auth.OperatorKey,
 		tokenStore,
 		cfg.Auth.RequireProviderTokens,
 		cfg.Endpoints.ProviderEarnings.RateLimitPerMinute,
 		cfg.Billing.QuarantineResolutionForceVoidEnabled,
+		cfg.Billing.QuarantineResolutionForceCreditEnabled,
 		idlePrewarmReader,
 	)
 	// §11.5 launch-gate item 10 — operator-visible startup state.
 	logger.Info().
 		Bool("billing.quarantine_resolution_force_void_enabled", cfg.Billing.QuarantineResolutionForceVoidEnabled).
+		Bool("billing.quarantine_resolution_force_credit_enabled", cfg.Billing.QuarantineResolutionForceCreditEnabled).
+		Int("billing.force_credit_settlement_hold_seconds", cfg.Billing.ForceCreditSettlementHoldSeconds).
 		Str("event", "spec005_v0_4_route_layer_flag_init").
 		Msg("quarantine force-void route-layer flag initialized")
 	providerMux.Handle("/admin/ledger/", billingHandler)
@@ -1188,7 +1196,15 @@ func reloadTier2Config(configPath string, startupTier2 config.Tier2Config, logge
 		// written, and the force-void flag stays at its prior value.
 		// Only AFTER COMMIT do we publish the rewards / settlement
 		// in-memory configs that depend on the snapshot id.
-		snapshotID, err := billingStores[0].ReloadBillingConfig(context.Background(), cfg.Rewards, cfg.Billing.QuarantineResolutionForceVoidEnabled, "sighup", time.Now().UTC())
+		snapshotID, err := billingStores[0].ReloadBillingConfigV05(
+			context.Background(),
+			cfg.Rewards,
+			cfg.Billing.QuarantineResolutionForceVoidEnabled,
+			cfg.Billing.QuarantineResolutionForceCreditEnabled,
+			int64(cfg.Billing.ForceCreditSettlementHoldSeconds),
+			"sighup",
+			time.Now().UTC(),
+		)
 		if err != nil {
 			logger.Error().Err(err).Msg("billing config reload rejected (snapshot + flag audit atomic)")
 			return
@@ -1197,6 +1213,8 @@ func reloadTier2Config(configPath string, startupTier2 config.Tier2Config, logge
 		billingStores[0].SetSettlementConfig(cfg.Settlement)
 		logger.Info().
 			Bool("billing.quarantine_resolution_force_void_enabled", cfg.Billing.QuarantineResolutionForceVoidEnabled).
+			Bool("billing.quarantine_resolution_force_credit_enabled", cfg.Billing.QuarantineResolutionForceCreditEnabled).
+			Int("billing.force_credit_settlement_hold_seconds", cfg.Billing.ForceCreditSettlementHoldSeconds).
 			Str("event", "spec005_v0_4_route_layer_flag_reload").
 			Msg("quarantine force-void route-layer flag reloaded")
 	}

--- a/phase4-coordinator/internal/billing/endpoints.go
+++ b/phase4-coordinator/internal/billing/endpoints.go
@@ -3,6 +3,7 @@ package billing
 import (
 	"context"
 	"database/sql"
+	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"net/http"
@@ -49,11 +50,19 @@ func (s *Store) Handlers(operatorKey string, tokenStore tokenValidator, requireP
 // below) so it shares atomicity with the ledger_config_snapshots
 // row §13.2 already requires.
 func (s *Store) HandlersWithQuarantineGate(operatorKey string, tokenStore tokenValidator, requireProviderTokens bool, earningsRateLimitPerMin int, forceVoidEnabled bool) http.Handler {
-	return s.handlersInternal(operatorKey, "", tokenStore, requireProviderTokens, earningsRateLimitPerMin, forceVoidEnabled, nil)
+	return s.handlersInternal(operatorKey, "", tokenStore, requireProviderTokens, earningsRateLimitPerMin, forceVoidEnabled, false, nil)
 }
 
 func (s *Store) HandlersWithQuarantineGateAndIdlePrewarm(operatorKey string, tokenStore tokenValidator, requireProviderTokens bool, earningsRateLimitPerMin int, forceVoidEnabled bool, idlePrewarm idlePrewarmReader) http.Handler {
-	return s.handlersInternal(operatorKey, "", tokenStore, requireProviderTokens, earningsRateLimitPerMin, forceVoidEnabled, idlePrewarm)
+	return s.handlersInternal(operatorKey, "", tokenStore, requireProviderTokens, earningsRateLimitPerMin, forceVoidEnabled, false, idlePrewarm)
+}
+
+func (s *Store) HandlersWithQuarantineGates(operatorKey string, tokenStore tokenValidator, requireProviderTokens bool, earningsRateLimitPerMin int, forceVoidEnabled bool, forceCreditEnabled bool) http.Handler {
+	return s.handlersInternal(operatorKey, "", tokenStore, requireProviderTokens, earningsRateLimitPerMin, forceVoidEnabled, forceCreditEnabled, nil)
+}
+
+func (s *Store) HandlersWithQuarantineGatesAndIdlePrewarm(operatorKey string, tokenStore tokenValidator, requireProviderTokens bool, earningsRateLimitPerMin int, forceVoidEnabled bool, forceCreditEnabled bool, idlePrewarm idlePrewarmReader) http.Handler {
+	return s.handlersInternal(operatorKey, "", tokenStore, requireProviderTokens, earningsRateLimitPerMin, forceVoidEnabled, forceCreditEnabled, idlePrewarm)
 }
 
 // HandlersWithBridge mounts the admin/provider handlers. The
@@ -66,10 +75,10 @@ func (s *Store) HandlersWithQuarantineGateAndIdlePrewarm(operatorKey string, tok
 // accepted. Handlers (the legacy single-arg signature) is kept as a
 // thin shim so test fixtures and direct callers don't churn.
 func (s *Store) HandlersWithBridge(operatorKey, _gatewayServiceTokenIgnoredAdminOnly string, tokenStore tokenValidator, requireProviderTokens bool, earningsRateLimitPerMin int) http.Handler {
-	return s.handlersInternal(operatorKey, _gatewayServiceTokenIgnoredAdminOnly, tokenStore, requireProviderTokens, earningsRateLimitPerMin, false, nil)
+	return s.handlersInternal(operatorKey, _gatewayServiceTokenIgnoredAdminOnly, tokenStore, requireProviderTokens, earningsRateLimitPerMin, false, false, nil)
 }
 
-func (s *Store) handlersInternal(operatorKey, _gatewayServiceTokenIgnoredAdminOnly string, tokenStore tokenValidator, requireProviderTokens bool, earningsRateLimitPerMin int, forceVoidEnabled bool, idlePrewarm idlePrewarmReader) http.Handler {
+func (s *Store) handlersInternal(operatorKey, _gatewayServiceTokenIgnoredAdminOnly string, tokenStore tokenValidator, requireProviderTokens bool, earningsRateLimitPerMin int, forceVoidEnabled bool, forceCreditEnabled bool, idlePrewarm idlePrewarmReader) http.Handler {
 	// SPEC-005 v0.4 (issue #169) — handler CONSTRUCTION must not be
 	// able to silently flip the live route-layer flag. R8 fix
 	// (ARCH-M1) replaces the unconditional SetForceVoidEnabled call
@@ -88,6 +97,9 @@ func (s *Store) handlersInternal(operatorKey, _gatewayServiceTokenIgnoredAdminOn
 	// the first-construction init case.
 	if forceVoidEnabled {
 		s.forceVoidEnabled.CompareAndSwap(false, true)
+	}
+	if forceCreditEnabled {
+		s.forceCreditEnabled.CompareAndSwap(false, true)
 	}
 	h := &handler{
 		store:                   s,
@@ -175,6 +187,10 @@ type settlementVerdictCounter struct {
 }
 
 func (h *handler) serveHTTP(w http.ResponseWriter, r *http.Request) {
+	if r.URL.Path == "/admin/ledger/quarantine" {
+		h.quarantineListHandler(w, r)
+		return
+	}
 	// SPEC-005 v0.4 §11.6 quarantine surface (issue #169).
 	// matchQuarantinePath distinguishes "not this route" from
 	// "matched route + bad id" so we can emit 400 (not 404) per
@@ -186,7 +202,11 @@ func (h *handler) serveHTTP(w http.ResponseWriter, r *http.Request) {
 		// checks. Otherwise GET / PUT / bad-id requests leak route
 		// existence via 405 / 400 even when the operator has not
 		// turned the surface on.
-		if !h.store.ForceVoidEnabled() {
+		enabled := h.store.ForceVoidEnabled()
+		if m.kind == "force-credit" {
+			enabled = h.store.ForceCreditEnabled()
+		}
+		if !enabled {
 			if auth.OperatorOnlyBearerMatches(r.Header, h.operatorKey) {
 				if !h.allowAdminRequest(w) {
 					return
@@ -214,6 +234,9 @@ func (h *handler) serveHTTP(w http.ResponseWriter, r *http.Request) {
 		case "force-void":
 			h.forceVoidHandler(w, r, m.id)
 			return
+		case "force-credit":
+			h.forceCreditHandler(w, r, m.id)
+			return
 		}
 	}
 	switch {
@@ -230,6 +253,138 @@ func (h *handler) serveHTTP(w http.ResponseWriter, r *http.Request) {
 	default:
 		writeError(w, http.StatusNotFound, "not_found", "not found")
 	}
+}
+
+func (h *handler) quarantineListHandler(w http.ResponseWriter, r *http.Request) {
+	if !auth.OperatorOnlyBearerMatches(r.Header, h.operatorKey) {
+		writeError(w, http.StatusForbidden, "forbidden", "operator key required")
+		return
+	}
+	if !h.allowAdminRequest(w) {
+		return
+	}
+	if r.Method != http.MethodGet {
+		writeError(w, http.StatusMethodNotAllowed, "method_not_allowed", "method not allowed")
+		return
+	}
+	status := r.URL.Query().Get("status")
+	if status == "" {
+		status = "open"
+	}
+	if status != "open" {
+		writeError(w, http.StatusBadRequest, "bad_request", "status must be open")
+		return
+	}
+	limit := 500
+	if rawLimit := r.URL.Query().Get("limit"); rawLimit != "" {
+		parsed, err := strconv.Atoi(rawLimit)
+		if err != nil || parsed <= 0 || parsed > 500 {
+			writeError(w, http.StatusBadRequest, "bad_request", "limit must be between 1 and 500")
+			return
+		}
+		limit = parsed
+	}
+	cursorTS := ""
+	cursorID := int64(0)
+	if rawCursor := r.URL.Query().Get("cursor"); rawCursor != "" {
+		cursor, err := decodeQuarantineListCursor(rawCursor)
+		if err != nil {
+			writeError(w, http.StatusBadRequest, "bad_request", "bad cursor")
+			return
+		}
+		cursorTS = cursor.TS
+		cursorID = cursor.ID
+	}
+	ctx, cancel := context.WithTimeout(r.Context(), 5*time.Second)
+	defer cancel()
+	rows, err := h.store.db.QueryContext(ctx, `
+SELECT id, request_id, attempt_n, provider_id, ts_utc, quarantine_reason
+  FROM ledger_request_credits lrc
+ WHERE lrc.quarantined = 1
+   AND NOT EXISTS (
+       SELECT 1 FROM ledger_quarantine_resolutions lqr
+        WHERE lqr.request_credit_id = lrc.id
+   )
+   AND (? = '' OR lrc.ts_utc < ? OR (lrc.ts_utc = ? AND lrc.id < ?))
+ ORDER BY ts_utc DESC, id DESC
+ LIMIT ?`, cursorTS, cursorTS, cursorTS, cursorID, limit+1)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "internal_error", "query quarantine list: "+err.Error())
+		return
+	}
+	defer rows.Close()
+	items := []map[string]any{}
+	for rows.Next() {
+		var id int64
+		var requestID string
+		var attemptN int64
+		var providerID string
+		var tsUTC string
+		var quarantineReason sql.NullString
+		if err := rows.Scan(&id, &requestID, &attemptN, &providerID, &tsUTC, &quarantineReason); err != nil {
+			writeError(w, http.StatusInternalServerError, "internal_error", "scan quarantine list: "+err.Error())
+			return
+		}
+		items = append(items, map[string]any{
+			"request_credit_id": id,
+			"request_id":        requestID,
+			"attempt_n":         attemptN,
+			"provider_id":       providerID,
+			"ts_utc":            tsUTC,
+			"quarantine_reason": nullStringOrNil(quarantineReason),
+		})
+	}
+	if err := rows.Err(); err != nil {
+		writeError(w, http.StatusInternalServerError, "internal_error", "read quarantine list: "+err.Error())
+		return
+	}
+	var nextCursor any
+	if len(items) > limit {
+		last := items[limit-1]
+		if ts, _ := last["ts_utc"].(string); ts != "" {
+			if id, ok := last["request_credit_id"].(int64); ok {
+				nextCursor = encodeQuarantineListCursor(quarantineListCursor{TS: ts, ID: id})
+			}
+		}
+		items = items[:limit]
+	}
+	writeJSON(w, http.StatusOK, map[string]any{
+		"status":      status,
+		"count":       len(items),
+		"items":       items,
+		"next_cursor": nextCursor,
+	})
+}
+
+type quarantineListCursor struct {
+	TS string `json:"ts"`
+	ID int64  `json:"id"`
+}
+
+func decodeQuarantineListCursor(raw string) (quarantineListCursor, error) {
+	b, err := base64.RawURLEncoding.DecodeString(raw)
+	if err != nil {
+		return quarantineListCursor{}, err
+	}
+	var cursor quarantineListCursor
+	if err := json.Unmarshal(b, &cursor); err != nil {
+		return quarantineListCursor{}, err
+	}
+	if cursor.TS == "" || cursor.ID <= 0 {
+		return quarantineListCursor{}, errors.New("invalid cursor")
+	}
+	if _, err := time.Parse(time.RFC3339Nano, cursor.TS); err != nil {
+		return quarantineListCursor{}, err
+	}
+	return cursor, nil
+}
+
+func encodeQuarantineListCursor(cursor quarantineListCursor) string {
+	b, err := json.Marshal(cursor)
+	if err != nil {
+		return ""
+	}
+	return base64.RawURLEncoding.EncodeToString(b)
 }
 
 func (h *handler) admin(w http.ResponseWriter, r *http.Request, fn func(http.ResponseWriter, *http.Request)) {

--- a/phase4-coordinator/internal/billing/quarantine.go
+++ b/phase4-coordinator/internal/billing/quarantine.go
@@ -29,13 +29,16 @@ import (
 const (
 	quarantinePathPrefix   = "/admin/ledger/quarantine/"
 	forceVoidPathSuffix    = "/force-void"
+	forceCreditPathSuffix  = "/force-credit"
 	maxReasonLen           = 500
 	maxOperatorIDLen       = 64
 	maxBodyBytes           = 4 * 1024
 	operatorAttribution    = "operator_key_self_asserted"
 	eventForceVoid         = "ledger_quarantine_force_void"
+	eventForceCredit       = "ledger_quarantine_force_credit"
 	eventConfigFlagChanged = "billing_config_flag_changed"
 	resolutionKindVoid     = "force_void"
+	resolutionKindCredit   = "force_credit"
 )
 
 // quarantinePathMatch distinguishes three cases:
@@ -57,31 +60,48 @@ func matchQuarantinePath(path string) quarantinePathMatch {
 		return quarantinePathMatch{}
 	}
 	rest := path[len(quarantinePathPrefix):]
-	if !strings.HasSuffix(rest, forceVoidPathSuffix) {
+	suffix := ""
+	kind := ""
+	switch {
+	case strings.HasSuffix(rest, forceVoidPathSuffix):
+		suffix = forceVoidPathSuffix
+		kind = "force-void"
+	case strings.HasSuffix(rest, forceCreditPathSuffix):
+		suffix = forceCreditPathSuffix
+		kind = "force-credit"
+	default:
 		return quarantinePathMatch{}
 	}
-	idStr := rest[:len(rest)-len(forceVoidPathSuffix)]
+	idStr := rest[:len(rest)-len(suffix)]
 	// At this point the path SHAPE matches the force-void route.
 	// Anything wrong with the id field is now a §11.6.1.1 400, not a
 	// 404 fall-through.
 	if idStr == "" {
-		return quarantinePathMatch{matched: true, badID: true, kind: "force-void"}
+		return quarantinePathMatch{matched: true, badID: true, kind: kind}
 	}
 	for _, c := range idStr {
 		if c < '0' || c > '9' {
-			return quarantinePathMatch{matched: true, badID: true, kind: "force-void"}
+			return quarantinePathMatch{matched: true, badID: true, kind: kind}
 		}
 	}
 	id, err := strconv.ParseInt(idStr, 10, 64)
 	if err != nil {
-		return quarantinePathMatch{matched: true, badID: true, kind: "force-void"}
+		return quarantinePathMatch{matched: true, badID: true, kind: kind}
 	}
-	return quarantinePathMatch{matched: true, badID: false, id: id, kind: "force-void"}
+	return quarantinePathMatch{matched: true, badID: false, id: id, kind: kind}
 }
 
 // forceVoidHandler implements POST /admin/ledger/quarantine/{id}/force-void
 // per SPEC-005 v0.4 §11.6.1.
 func (h *handler) forceVoidHandler(w http.ResponseWriter, r *http.Request, requestCreditID int64) {
+	h.forceResolutionHandler(w, r, requestCreditID, resolutionKindVoid, eventForceVoid)
+}
+
+func (h *handler) forceCreditHandler(w http.ResponseWriter, r *http.Request, requestCreditID int64) {
+	h.forceResolutionHandler(w, r, requestCreditID, resolutionKindCredit, eventForceCredit)
+}
+
+func (h *handler) forceResolutionHandler(w http.ResponseWriter, r *http.Request, requestCreditID int64, resolutionKind, eventType string) {
 	// The dispatcher has already enforced the route launch gate,
 	// operator auth, admin rate limit, method, and id shape before
 	// entering this mutation handler.
@@ -172,13 +192,61 @@ SELECT 1, quarantined, request_id, attempt_n, provider_id, quarantine_reason
 		return
 	}
 
-	// Resolution INSERT. Race protection is the UNIQUE constraint
-	// (§11.6.6); we do NOT pre-check ledger_quarantine_resolutions.
-	now := time.Now().UTC().Format(time.RFC3339Nano)
+	// Resolution INSERT. v0.5 relaxes UNIQUE(request_credit_id) so
+	// the handler owns the corrective-resolution rule: first
+	// resolution wins, then one opposite-kind correction is allowed
+	// while the hold window is still open.
+	nowTime := h.store.now().UTC()
+	now := sqliteTimeText(nowTime)
+	var existingCount int
+	if err := conn.QueryRowContext(ctx, `
+SELECT COUNT(*) FROM ledger_quarantine_resolutions WHERE request_credit_id = ?`,
+		requestCreditID).Scan(&existingCount); err != nil {
+		writeError(w, http.StatusInternalServerError, "internal_error", "count resolutions: "+err.Error())
+		return
+	}
+	if existingCount > 0 {
+		var existingKind string
+		var existingCreated string
+		var existingMatures sql.NullString
+		var existingDeadline string
+		if err := conn.QueryRowContext(ctx, `
+SELECT resolution_kind, created_at_utc, force_credit_matures_at_utc, correction_deadline_at_utc
+  FROM ledger_quarantine_resolutions
+ WHERE request_credit_id = ?
+ ORDER BY created_at_utc DESC, id DESC
+ LIMIT 1`, requestCreditID).Scan(&existingKind, &existingCreated, &existingMatures, &existingDeadline); err != nil {
+			writeError(w, http.StatusInternalServerError, "internal_error", "read latest resolution: "+err.Error())
+			return
+		}
+		if existingKind == resolutionKind || existingCount >= 2 {
+			_, _ = conn.ExecContext(ctx, `ROLLBACK`)
+			committed = true
+			conn.Close()
+			h.respondAlreadyResolved(w, ctx, nil, requestCreditID)
+			return
+		}
+		correctionDeadline, ok := h.correctionDeadline(existingDeadline)
+		if !ok || !nowTime.Before(correctionDeadline) {
+			_, _ = conn.ExecContext(ctx, `ROLLBACK`)
+			committed = true
+			conn.Close()
+			h.respondResolutionLocked(w, ctx, requestCreditID)
+			return
+		}
+	}
+	var maturesAt sql.NullString
+	if resolutionKind == resolutionKindCredit {
+		maturesAt = sql.NullString{
+			String: sqliteTimeText(nowTime.Add(time.Duration(h.store.ForceCreditSettlementHoldSeconds()) * time.Second)),
+			Valid:  true,
+		}
+	}
+	correctionDeadlineAt := sqliteTimeText(nowTime.Add(time.Duration(h.store.ForceCreditSettlementHoldSeconds()) * time.Second))
 	_, err = conn.ExecContext(ctx, `
 INSERT INTO ledger_quarantine_resolutions
-    (request_credit_id, resolution_kind, operator_id, resolution_reason, created_at_utc)
-VALUES (?, ?, ?, ?, ?)`, requestCreditID, resolutionKindVoid, operatorID, reason, now)
+    (request_credit_id, resolution_kind, operator_id, resolution_reason, created_at_utc, force_credit_matures_at_utc, correction_deadline_at_utc)
+VALUES (?, ?, ?, ?, ?, ?, ?)`, requestCreditID, resolutionKind, operatorID, reason, now, maturesAt, correctionDeadlineAt)
 	if err != nil {
 		if isSQLiteUniqueConstraint(err) {
 			// ROLLBACK + release conn (MaxOpenConns(1) on the shared
@@ -199,16 +267,21 @@ VALUES (?, ?, ?, ?, ?)`, requestCreditID, resolutionKindVoid, operatorID, reason
 	// insertion-path requirement). Must use json.Marshal — no
 	// hand-rolled JSON.
 	payload := map[string]any{
-		"severity":             "WARN",
-		"operator_attribution": operatorAttribution,
-		"operator_id":          operatorID,
-		"request_credit_id":    requestCreditID,
-		"request_id":           requestID,
-		"attempt_n":            attemptN,
-		"provider_id":          providerID,
-		"quarantine_reason":    nullStringOrNil(quarantineReason),
-		"resolution_reason":    reason,
-		"ts_utc":               now,
+		"severity":                   "WARN",
+		"operator_attribution":       operatorAttribution,
+		"operator_id":                operatorID,
+		"request_credit_id":          requestCreditID,
+		"resolution_kind":            resolutionKind,
+		"request_id":                 requestID,
+		"attempt_n":                  attemptN,
+		"provider_id":                providerID,
+		"quarantine_reason":          nullStringOrNil(quarantineReason),
+		"resolution_reason":          reason,
+		"ts_utc":                     now,
+		"correction_deadline_at_utc": correctionDeadlineAt,
+	}
+	if maturesAt.Valid {
+		payload["force_credit_matures_at_utc"] = maturesAt.String
 	}
 	payloadJSON, err := json.Marshal(payload)
 	if err != nil {
@@ -217,7 +290,7 @@ VALUES (?, ?, ?, ?, ?)`, requestCreditID, resolutionKindVoid, operatorID, reason
 	}
 	if _, err := conn.ExecContext(ctx, `
 INSERT INTO audit_log (ts_utc, event_type, provider_id, payload_json)
-VALUES (?, ?, ?, ?)`, now, eventForceVoid, providerID, string(payloadJSON)); err != nil {
+VALUES (?, ?, ?, ?)`, now, eventType, providerID, string(payloadJSON)); err != nil {
 		writeError(w, http.StatusInternalServerError, "internal_error", "insert audit: "+err.Error())
 		return
 	}
@@ -229,12 +302,22 @@ VALUES (?, ?, ?, ?)`, now, eventForceVoid, providerID, string(payloadJSON)); err
 	committed = true
 
 	writeJSON(w, http.StatusOK, map[string]any{
-		"request_credit_id": requestCreditID,
-		"resolution_kind":   resolutionKindVoid,
-		"operator_id":       operatorID,
-		"resolution_reason": reason,
-		"created_at_utc":    now,
+		"request_credit_id":           requestCreditID,
+		"resolution_kind":             resolutionKind,
+		"operator_id":                 operatorID,
+		"resolution_reason":           reason,
+		"created_at_utc":              now,
+		"force_credit_matures_at_utc": nullStringOrNil(maturesAt),
+		"correction_deadline_at_utc":  correctionDeadlineAt,
 	})
+}
+
+func (h *handler) correctionDeadline(deadlineAt string) (time.Time, bool) {
+	deadline, err := time.Parse(time.RFC3339Nano, deadlineAt)
+	if err != nil {
+		return time.Time{}, false
+	}
+	return deadline, true
 }
 
 // respondAlreadyResolved reads the existing resolution row and emits
@@ -250,14 +333,20 @@ func (h *handler) respondAlreadyResolved(w http.ResponseWriter, ctx context.Cont
 		opID      string
 		reason    string
 		createdAt string
+		maturesAt sql.NullString
+		deadline  string
 	)
 	err := h.store.db.QueryRowContext(ctx, `
-SELECT resolution_kind, operator_id, resolution_reason, created_at_utc
-  FROM ledger_quarantine_resolutions WHERE request_credit_id = ?`,
-		requestCreditID).Scan(&kind, &opID, &reason, &createdAt)
+SELECT resolution_kind, operator_id, resolution_reason, created_at_utc, force_credit_matures_at_utc, correction_deadline_at_utc
+  FROM ledger_quarantine_resolutions
+ WHERE request_credit_id = ?
+ ORDER BY created_at_utc DESC, id DESC
+ LIMIT 1`,
+		requestCreditID).Scan(&kind, &opID, &reason, &createdAt, &maturesAt, &deadline)
 	if err != nil {
-		// UNIQUE fired but the row vanished? Treat as 500 — should
-		// never happen because the constraint precludes deletion.
+		// The caller observed an existing resolution but the re-read
+		// could not find it. Treat as 500; resolution rows are
+		// append-only and should not disappear.
 		writeError(w, http.StatusInternalServerError, "internal_error", "re-read existing resolution: "+err.Error())
 		return
 	}
@@ -266,15 +355,54 @@ SELECT resolution_kind, operator_id, resolution_reason, created_at_utc
 			"code":    "already_resolved",
 			"message": "row already resolved",
 			"existing_resolution": map[string]any{
-				"request_credit_id": requestCreditID,
-				"resolution_kind":   kind,
-				"operator_id":       opID,
-				"resolution_reason": reason,
-				"created_at_utc":    createdAt,
+				"request_credit_id":           requestCreditID,
+				"resolution_kind":             kind,
+				"operator_id":                 opID,
+				"resolution_reason":           reason,
+				"created_at_utc":              createdAt,
+				"force_credit_matures_at_utc": nullStringOrNil(maturesAt),
+				"correction_deadline_at_utc":  deadline,
 			},
 		},
 	}
 	writeJSON(w, http.StatusConflict, body)
+}
+
+func (h *handler) respondResolutionLocked(w http.ResponseWriter, ctx context.Context, requestCreditID int64) {
+	var (
+		kind      string
+		opID      string
+		reason    string
+		createdAt string
+		maturesAt sql.NullString
+		deadline  string
+	)
+	err := h.store.db.QueryRowContext(ctx, `
+SELECT resolution_kind, operator_id, resolution_reason, created_at_utc, force_credit_matures_at_utc, correction_deadline_at_utc
+  FROM ledger_quarantine_resolutions
+ WHERE request_credit_id = ?
+ ORDER BY created_at_utc DESC, id DESC
+ LIMIT 1`,
+		requestCreditID).Scan(&kind, &opID, &reason, &createdAt, &maturesAt, &deadline)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "internal_error", "re-read locked resolution: "+err.Error())
+		return
+	}
+	writeJSON(w, http.StatusConflict, map[string]any{
+		"error": map[string]any{
+			"code":    "resolution_locked",
+			"message": "resolution can no longer be corrected",
+			"existing_resolution": map[string]any{
+				"request_credit_id":           requestCreditID,
+				"resolution_kind":             kind,
+				"operator_id":                 opID,
+				"resolution_reason":           reason,
+				"created_at_utc":              createdAt,
+				"force_credit_matures_at_utc": nullStringOrNil(maturesAt),
+				"correction_deadline_at_utc":  deadline,
+			},
+		},
+	})
 }
 
 type forceVoidBody struct {

--- a/phase4-coordinator/internal/billing/quarantine_test.go
+++ b/phase4-coordinator/internal/billing/quarantine_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -71,6 +72,18 @@ func doForceVoid(t *testing.T, store *Store, gateEnabled bool, id int64, body st
 	return w
 }
 
+func doForceCredit(t *testing.T, store *Store, gateEnabled bool, id int64, body string, ct string) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodPost, "/admin/ledger/quarantine/"+itoa(id)+"/force-credit", strings.NewReader(body))
+	req.Header.Set("Authorization", "Bearer operator")
+	if ct != "" {
+		req.Header.Set("Content-Type", ct)
+	}
+	w := httptest.NewRecorder()
+	store.HandlersWithQuarantineGates("operator", fakeTokens{}, true, 60, true, gateEnabled).ServeHTTP(w, req)
+	return w
+}
+
 func itoa(i int64) string {
 	if i == 0 {
 		return "0"
@@ -94,9 +107,10 @@ func itoa(i int64) string {
 	return string(buf[n:])
 }
 
-// AC-Q040: schema shape — UNIQUE(request_credit_id),
-// CHECK(resolution_kind IN ('force_void')), idx_lqr_kind_created
-// present, no separate idx_lqr_request_credit index.
+// AC-Q040: schema shape — history-capable resolution table,
+// CHECK(resolution_kind IN ('force_void','force_credit')),
+// idx_lqr_kind_created and latest-projection index present, and no
+// UNIQUE(request_credit_id).
 func TestACQ040_SchemaShape(t *testing.T) {
 	store := quarantineFixture(t)
 	// Columns present?
@@ -116,30 +130,37 @@ func TestACQ040_SchemaShape(t *testing.T) {
 		}
 		cols[name] = typ
 	}
-	want := []string{"id", "request_credit_id", "resolution_kind", "operator_id", "resolution_reason", "created_at_utc"}
+	want := []string{"id", "request_credit_id", "resolution_kind", "operator_id", "resolution_reason", "created_at_utc", "force_credit_matures_at_utc", "correction_deadline_at_utc"}
 	for _, c := range want {
 		if _, ok := cols[c]; !ok {
 			t.Fatalf("missing column %q", c)
 		}
 	}
-	// UNIQUE auto-index present, idx_lqr_kind_created present.
 	if !indexExists(t, store.db, "ledger_quarantine_resolutions", "idx_lqr_kind_created") {
 		t.Fatal("idx_lqr_kind_created missing")
 	}
-	// No non-unique idx_lqr_request_credit (the UNIQUE auto-index
-	// covers the read path).
-	if indexExists(t, store.db, "ledger_quarantine_resolutions", "idx_lqr_request_credit") {
-		t.Fatal("idx_lqr_request_credit must not exist in v0.4")
+	if !indexExists(t, store.db, "ledger_quarantine_resolutions", "idx_lqr_request_latest") {
+		t.Fatal("idx_lqr_request_latest missing")
 	}
-	// UNIQUE constraint: try INSERT twice with same request_credit_id.
-	id := insertQuarantinedCredit(t, store, "p-q040")
-	now := time.Now().UTC().Format(time.RFC3339Nano)
-	if _, err := store.db.Exec(`INSERT INTO ledger_quarantine_resolutions(request_credit_id, resolution_kind, operator_id, resolution_reason, created_at_utc) VALUES (?, 'force_void', 'alice', 'reason', ?)`, id, now); err != nil {
+	hasUnique, err := store.hasUniqueIndexOnColumns(context.Background(), "ledger_quarantine_resolutions", []string{"request_credit_id"})
+	if err != nil {
 		t.Fatal(err)
 	}
-	_, err = store.db.Exec(`INSERT INTO ledger_quarantine_resolutions(request_credit_id, resolution_kind, operator_id, resolution_reason, created_at_utc) VALUES (?, 'force_void', 'alice', 'reason', ?)`, id, now)
-	if err == nil {
-		t.Fatal("second INSERT must hit UNIQUE constraint")
+	if hasUnique {
+		t.Fatal("UNIQUE(request_credit_id) must be relaxed in v0.5")
+	}
+	// History shape: direct INSERT may keep a prior decision and append
+	// a corrective opposite-kind row; API owns the one-correction rule.
+	id := insertQuarantinedCredit(t, store, "p-q040")
+	now := time.Now().UTC().Format(time.RFC3339Nano)
+	if _, err := store.db.Exec(`INSERT INTO ledger_quarantine_resolutions(request_credit_id, resolution_kind, operator_id, resolution_reason, created_at_utc, correction_deadline_at_utc) VALUES (?, 'force_void', 'alice', 'reason', ?, ?)`, id, now, now); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.db.Exec(`INSERT INTO ledger_quarantine_resolutions(request_credit_id, resolution_kind, operator_id, resolution_reason, created_at_utc, force_credit_matures_at_utc, correction_deadline_at_utc) VALUES (?, 'force_credit', 'alice', 'correction', ?, ?, ?)`, id, now, now, now); err != nil {
+		t.Fatal(err)
+	}
+	if got := scalar(t, store.db, `SELECT COUNT(*) FROM ledger_quarantine_resolutions WHERE request_credit_id=?`, id); got != 2 {
+		t.Fatalf("history rows=%d want 2", got)
 	}
 	// R6 fix (CODE-M2): pin the §4.10 length CHECK constraints on
 	// operator_id and resolution_reason. Empty values and over-cap
@@ -155,7 +176,7 @@ func TestACQ040_SchemaShape(t *testing.T) {
 	}
 	for _, c := range checkCases {
 		t.Run(c.name, func(t *testing.T) {
-			_, err := store.db.Exec(`INSERT INTO ledger_quarantine_resolutions(request_credit_id, resolution_kind, operator_id, resolution_reason, created_at_utc) VALUES (?, 'force_void', ?, ?, ?)`, id2, c.opID, c.reason, now)
+			_, err := store.db.Exec(`INSERT INTO ledger_quarantine_resolutions(request_credit_id, resolution_kind, operator_id, resolution_reason, created_at_utc, correction_deadline_at_utc) VALUES (?, 'force_void', ?, ?, ?, ?)`, id2, c.opID, c.reason, now, now)
 			if err == nil {
 				t.Fatalf("INSERT (%s) must hit length CHECK", c.name)
 			}
@@ -504,18 +525,246 @@ func TestACQ053_RouteLayerConfigFlagGate(t *testing.T) {
 	}
 }
 
-// AC-Q055: v0.4 force-credit schema rejection — direct INSERT with
-// resolution_kind='force_credit' must fail the CHECK constraint.
-func TestACQ055_ForceCreditSchemaRejection(t *testing.T) {
+// AC-Q055: v0.5 force-credit endpoint is held out of payable rows
+// until force_credit_matures_at_utc, then appears in the payable
+// projection without clearing the base quarantined flag.
+func TestACQ055_ForceCreditHoldThenPayable(t *testing.T) {
 	store := quarantineFixture(t)
+	now := time.Now().UTC().Add(time.Hour)
+	store.now = func() time.Time { return now }
 	id := insertQuarantinedCredit(t, store, "p-q055")
-	now := time.Now().UTC().Format(time.RFC3339Nano)
-	_, err := store.db.Exec(`INSERT INTO ledger_quarantine_resolutions(request_credit_id, resolution_kind, operator_id, resolution_reason, created_at_utc) VALUES (?, 'force_credit', 'alice', 'x', ?)`, id, now)
-	if err == nil {
-		t.Fatal("INSERT with resolution_kind=force_credit must hit CHECK constraint in v0.4")
+	w := doForceCredit(t, store, true, id, `{"operator_id":"alice","reason":"receipt verified manually"}`, "application/json")
+	if w.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s want 200", w.Code, w.Body.String())
 	}
-	if !strings.Contains(strings.ToLower(err.Error()), "check") {
-		t.Fatalf("error must mention CHECK constraint, got: %v", err)
+	var resp map[string]any
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatal(err)
+	}
+	if resp["resolution_kind"] != "force_credit" {
+		t.Fatalf("resolution_kind=%v want force_credit", resp["resolution_kind"])
+	}
+	wantMatures := sqliteTimeText(now.Add(24 * time.Hour))
+	if resp["force_credit_matures_at_utc"] != wantMatures {
+		t.Fatalf("force_credit_matures_at_utc=%v want %s", resp["force_credit_matures_at_utc"], wantMatures)
+	}
+	if got := scalar(t, store.db, `SELECT COUNT(*) FROM spec022_payable_request_credits WHERE id=?`, id); got != 0 {
+		t.Fatalf("held force-credit payable rows=%d want 0", got)
+	}
+	if _, err := store.db.Exec(`UPDATE ledger_quarantine_resolutions SET force_credit_matures_at_utc='2000-01-01T00:00:00.000000000Z' WHERE request_credit_id=?`, id); err != nil {
+		t.Fatal(err)
+	}
+	if got := scalar(t, store.db, `SELECT COUNT(*) FROM spec022_payable_request_credits WHERE id=?`, id); got != 1 {
+		t.Fatalf("matured force-credit payable rows=%d want 1", got)
+	}
+}
+
+func TestForceCreditCorrectiveVoidWithinHoldLatestWins(t *testing.T) {
+	store := quarantineFixture(t)
+	now := time.Date(2026, 7, 1, 12, 0, 0, 0, time.UTC)
+	store.now = func() time.Time { return now }
+	id := insertQuarantinedCredit(t, store, "p-correct")
+	if w := doForceCredit(t, store, true, id, `{"operator_id":"alice","reason":"manual credit"}`, "application/json"); w.Code != http.StatusOK {
+		t.Fatalf("force-credit status=%d body=%s", w.Code, w.Body.String())
+	}
+	if w := doForceVoid(t, store, true, id, `{"operator_id":"bob","reason":"mistake caught before hold"}`, "application/json"); w.Code != http.StatusOK {
+		t.Fatalf("force-void correction status=%d body=%s", w.Code, w.Body.String())
+	}
+	if got := scalar(t, store.db, `SELECT COUNT(*) FROM ledger_quarantine_resolutions WHERE request_credit_id=?`, id); got != 2 {
+		t.Fatalf("resolution history rows=%d want 2", got)
+	}
+	var latest string
+	if err := store.db.QueryRow(`SELECT resolution_kind FROM ledger_quarantine_resolutions WHERE request_credit_id=? ORDER BY created_at_utc DESC, id DESC LIMIT 1`, id).Scan(&latest); err != nil {
+		t.Fatal(err)
+	}
+	if latest != "force_void" {
+		t.Fatalf("latest resolution=%q want force_void", latest)
+	}
+	if got := scalar(t, store.db, `SELECT COUNT(*) FROM spec022_payable_request_credits WHERE id=?`, id); got != 0 {
+		t.Fatalf("corrected-to-void payable rows=%d want 0", got)
+	}
+	if w := doForceCredit(t, store, true, id, `{"operator_id":"carol","reason":"third try"}`, "application/json"); w.Code != http.StatusConflict {
+		t.Fatalf("third resolution status=%d body=%s want 409", w.Code, w.Body.String())
+	}
+}
+
+func TestForceCreditCorrectionAfterHoldLocked(t *testing.T) {
+	store := quarantineFixture(t)
+	now := time.Date(2026, 7, 1, 12, 0, 0, 0, time.UTC)
+	store.now = func() time.Time { return now }
+	id := insertQuarantinedCredit(t, store, "p-lock")
+	if w := doForceCredit(t, store, true, id, `{"operator_id":"alice","reason":"manual credit"}`, "application/json"); w.Code != http.StatusOK {
+		t.Fatalf("force-credit status=%d body=%s", w.Code, w.Body.String())
+	}
+	store.now = func() time.Time { return now.Add(25 * time.Hour) }
+	w := doForceVoid(t, store, true, id, `{"operator_id":"bob","reason":"too late"}`, "application/json")
+	if w.Code != http.StatusConflict {
+		t.Fatalf("late correction status=%d body=%s want 409", w.Code, w.Body.String())
+	}
+	if !strings.Contains(w.Body.String(), "resolution_locked") {
+		t.Fatalf("body=%s missing resolution_locked", w.Body.String())
+	}
+}
+
+func TestForceVoidCorrectionDeadlinePersistsAcrossHoldReload(t *testing.T) {
+	store := quarantineFixture(t)
+	now := time.Date(2026, 7, 1, 12, 0, 0, 0, time.UTC)
+	store.now = func() time.Time { return now }
+	store.SetForceCreditSettlementHoldSeconds(24 * 60 * 60)
+	id := insertQuarantinedCredit(t, store, "p-deadline")
+	if w := doForceVoid(t, store, true, id, `{"operator_id":"alice","reason":"initial void"}`, "application/json"); w.Code != http.StatusOK {
+		t.Fatalf("force-void status=%d body=%s", w.Code, w.Body.String())
+	}
+	// A later config reload shortens the current hold to one second,
+	// but the existing row's correction deadline remains the
+	// resolution-time 24h deadline.
+	store.SetForceCreditSettlementHoldSeconds(1)
+	store.now = func() time.Time { return now.Add(time.Hour) }
+	w := doForceCredit(t, store, true, id, `{"operator_id":"bob","reason":"correct within original deadline"}`, "application/json")
+	if w.Code != http.StatusOK {
+		t.Fatalf("force-credit correction status=%d body=%s want 200", w.Code, w.Body.String())
+	}
+}
+
+func TestSettlementForceCreditMaturedAfterExistingPayoutRollsForward(t *testing.T) {
+	_, store := newRequestAndBillingStores(t)
+	windowStart := time.Date(2026, 7, 1, 0, 0, 0, 0, time.UTC)
+	windowEnd := windowStart.AddDate(0, 0, 7)
+	cfg := SettlementConfig{CadenceDays: 7, MinPayoutCredits: 1}
+	insertCreditWithOperator(t, store.db, "existing-window-credit", "provider-a", windowStart.Add(time.Hour), 600)
+	if err := store.RunSettlement(context.Background(), cfg, windowStart, windowEnd); err != nil {
+		t.Fatal(err)
+	}
+	var payoutID int64
+	var payoutCreatedRaw string
+	if err := store.db.QueryRow(`SELECT id, created_at_utc FROM ledger_payout_ready WHERE provider_id='provider-a' AND window_start_utc=? AND window_end_utc=?`, sqliteTimeText(windowStart), sqliteTimeText(windowEnd)).Scan(&payoutID, &payoutCreatedRaw); err != nil {
+		t.Fatal(err)
+	}
+	payoutCreated, err := time.Parse(time.RFC3339Nano, payoutCreatedRaw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	insertCreditWithRequest(t, store.db, "force-credit-after-payout", "provider-a", windowStart.Add(2*time.Hour), 500)
+	id := scalar(t, store.db, `SELECT id FROM ledger_request_credits WHERE request_id='force-credit-after-payout'`)
+	if _, err := store.db.Exec(`UPDATE ledger_request_credits SET quarantined=1, quarantine_reason='manual review' WHERE id=?`, id); err != nil {
+		t.Fatal(err)
+	}
+	createdAt := sqliteTimeText(payoutCreated)
+	maturesAt := sqliteTimeText(payoutCreated.Add(time.Nanosecond))
+	if _, err := store.db.Exec(`
+INSERT INTO ledger_quarantine_resolutions (
+    request_credit_id, resolution_kind, operator_id, resolution_reason,
+    created_at_utc, force_credit_matures_at_utc, correction_deadline_at_utc
+) VALUES (?, 'force_credit', 'alice', 'late credit', ?, ?, ?)`,
+		id, createdAt, maturesAt, maturesAt); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.RunSettlement(context.Background(), cfg, windowStart, windowEnd); err != nil {
+		t.Fatal(err)
+	}
+	if got := scalar(t, store.db, `SELECT provider_credits FROM ledger_payout_ready WHERE id=?`, payoutID); got != 600 {
+		t.Fatalf("old payout provider_credits=%d want 600", got)
+	}
+	if got := scalar(t, store.db, `SELECT source_credit_count FROM ledger_payout_ready WHERE id=?`, payoutID); got != 1 {
+		t.Fatalf("old payout source count=%d want 1", got)
+	}
+	if got := scalar(t, store.db, `SELECT settled FROM ledger_request_credits WHERE id=?`, id); got != 0 {
+		t.Fatalf("force-credit row settled after old-window rerun=%d want 0", got)
+	}
+	nextEnd := windowEnd.AddDate(0, 0, 7)
+	if err := store.RunSettlement(context.Background(), cfg, windowEnd, nextEnd); err != nil {
+		t.Fatal(err)
+	}
+	if got := scalar(t, store.db, `SELECT provider_credits FROM ledger_payout_ready WHERE provider_id='provider-a' AND window_start_utc=? AND window_end_utc=?`, sqliteTimeText(windowEnd), sqliteTimeText(nextEnd)); got != 500 {
+		t.Fatalf("rolled-forward payout provider_credits=%d want 500", got)
+	}
+	if got := scalar(t, store.db, `SELECT settlement_id FROM ledger_request_credits WHERE id=?`, id); got == payoutID {
+		t.Fatalf("force-credit row linked to old payout id %d", payoutID)
+	}
+}
+
+func TestQuarantineListOpenEndpoint(t *testing.T) {
+	store := quarantineFixture(t)
+	openID := insertQuarantinedCredit(t, store, "p-list-open")
+	resolvedID := insertQuarantinedCredit(t, store, "p-list-resolved")
+	if w := doForceVoid(t, store, true, resolvedID, `{"operator_id":"alice","reason":"x"}`, "application/json"); w.Code != http.StatusOK {
+		t.Fatalf("force-void status=%d body=%s", w.Code, w.Body.String())
+	}
+	req := httptest.NewRequest(http.MethodGet, "/admin/ledger/quarantine?status=open", nil)
+	req.Header.Set("Authorization", "Bearer operator")
+	w := httptest.NewRecorder()
+	store.HandlersWithQuarantineGate("operator", fakeTokens{}, true, 60, true).ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s want 200", w.Code, w.Body.String())
+	}
+	var resp struct {
+		Count int `json:"count"`
+		Items []struct {
+			RequestCreditID int64 `json:"request_credit_id"`
+		} `json:"items"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatal(err)
+	}
+	if resp.Count != 1 || len(resp.Items) != 1 || resp.Items[0].RequestCreditID != openID {
+		t.Fatalf("open list=%+v want only id %d", resp, openID)
+	}
+}
+
+func TestQuarantineListOpenEndpointPaginates(t *testing.T) {
+	store := quarantineFixture(t)
+	base := time.Date(2026, 7, 1, 12, 0, 0, 0, time.UTC)
+	ids := make([]int64, 0, 3)
+	for i := 0; i < 3; i++ {
+		id := insertQuarantinedCredit(t, store, fmt.Sprintf("p-list-page-%d", i))
+		ts := sqliteTimeText(base.Add(time.Duration(i) * time.Minute))
+		if _, err := store.db.Exec(`UPDATE ledger_request_credits SET ts_utc=? WHERE id=?`, ts, id); err != nil {
+			t.Fatal(err)
+		}
+		ids = append(ids, id)
+	}
+	req := httptest.NewRequest(http.MethodGet, "/admin/ledger/quarantine?status=open&limit=2", nil)
+	req.Header.Set("Authorization", "Bearer operator")
+	w := httptest.NewRecorder()
+	store.HandlersWithQuarantineGate("operator", fakeTokens{}, true, 60, true).ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("first page status=%d body=%s want 200", w.Code, w.Body.String())
+	}
+	var first struct {
+		Count      int     `json:"count"`
+		NextCursor *string `json:"next_cursor"`
+		Items      []struct {
+			RequestCreditID int64 `json:"request_credit_id"`
+		} `json:"items"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &first); err != nil {
+		t.Fatal(err)
+	}
+	if first.Count != 2 || len(first.Items) != 2 || first.NextCursor == nil || *first.NextCursor == "" {
+		t.Fatalf("first page=%+v want 2 items and next cursor", first)
+	}
+	if first.Items[0].RequestCreditID != ids[2] || first.Items[1].RequestCreditID != ids[1] {
+		t.Fatalf("first page ids=%+v want [%d %d]", first.Items, ids[2], ids[1])
+	}
+	req = httptest.NewRequest(http.MethodGet, "/admin/ledger/quarantine?status=open&limit=2&cursor="+url.QueryEscape(*first.NextCursor), nil)
+	req.Header.Set("Authorization", "Bearer operator")
+	w = httptest.NewRecorder()
+	store.HandlersWithQuarantineGate("operator", fakeTokens{}, true, 60, true).ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("second page status=%d body=%s want 200", w.Code, w.Body.String())
+	}
+	var second struct {
+		Count      int     `json:"count"`
+		NextCursor *string `json:"next_cursor"`
+		Items      []struct {
+			RequestCreditID int64 `json:"request_credit_id"`
+		} `json:"items"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &second); err != nil {
+		t.Fatal(err)
+	}
+	if second.Count != 1 || len(second.Items) != 1 || second.Items[0].RequestCreditID != ids[0] || second.NextCursor != nil {
+		t.Fatalf("second page=%+v want only id %d and no cursor", second, ids[0])
 	}
 }
 
@@ -740,28 +989,37 @@ func TestACQ053_ReloadEmitsFlagChangedAuditAndFlipTakesEffect(t *testing.T) {
 	}
 }
 
-// AC-Q050: SPEC-007 explorer detail surface — LEFT JOIN to
-// ledger_quarantine_resolutions exposes resolution_kind /
-// resolution_operator_id / resolution_reason / resolution_at_utc as
-// aliased columns on the ledger row when a resolution exists.
+// AC-Q050: SPEC-007 explorer detail surface — after v0.5 UNIQUE
+// relaxation, explorer-style queries must separate latest current
+// projection from ordered resolution history.
 func TestACQ050_ExplorerAliasColumns(t *testing.T) {
 	store := quarantineFixture(t)
+	now := time.Date(2026, 7, 1, 12, 0, 0, 0, time.UTC)
+	store.now = func() time.Time { return now }
 	id := insertQuarantinedCredit(t, store, "p-q050")
-	// Force-void via the handler to land both the resolution + audit.
-	w := doForceVoid(t, store, true, id, `{"operator_id":"alice","reason":"audited"}`, "application/json")
-	if w.Code != http.StatusOK {
-		t.Fatalf("prep force-void status=%d body=%s", w.Code, w.Body.String())
+	if w := doForceCredit(t, store, true, id, `{"operator_id":"alice","reason":"audited credit"}`, "application/json"); w.Code != http.StatusOK {
+		t.Fatalf("prep force-credit status=%d body=%s", w.Code, w.Body.String())
 	}
-	// Read the request_id we used to seed the row.
+	store.now = func() time.Time { return now.Add(time.Hour) }
+	if w := doForceVoid(t, store, true, id, `{"operator_id":"bob","reason":"corrected to void"}`, "application/json"); w.Code != http.StatusOK {
+		t.Fatalf("prep force-void correction status=%d body=%s", w.Code, w.Body.String())
+	}
 	var requestID string
 	if err := store.db.QueryRow(`SELECT request_id FROM ledger_request_credits WHERE id = ?`, id).Scan(&requestID); err != nil {
 		t.Fatal(err)
 	}
-	// Mirror the explorer query against the same DB.
 	row := store.db.QueryRow(`
-SELECT lqr.resolution_kind, lqr.operator_id, lqr.resolution_reason, lqr.created_at_utc
+SELECT current.resolution_kind, current.operator_id, current.resolution_reason, current.created_at_utc
   FROM ledger_request_credits lrc
-  LEFT JOIN ledger_quarantine_resolutions lqr ON lqr.request_credit_id = lrc.id
+  LEFT JOIN ledger_quarantine_resolutions current
+    ON current.request_credit_id = lrc.id
+   AND current.id = (
+       SELECT latest.id
+         FROM ledger_quarantine_resolutions latest
+        WHERE latest.request_credit_id = lrc.id
+        ORDER BY latest.created_at_utc DESC, latest.id DESC
+        LIMIT 1
+   )
  WHERE lrc.request_id = ?`, requestID)
 	var kind, opID, reason, createdAt sql.NullString
 	if err := row.Scan(&kind, &opID, &reason, &createdAt); err != nil {
@@ -770,14 +1028,37 @@ SELECT lqr.resolution_kind, lqr.operator_id, lqr.resolution_reason, lqr.created_
 	if !kind.Valid || kind.String != "force_void" {
 		t.Fatalf("resolution_kind=%v want force_void", kind)
 	}
-	if !opID.Valid || opID.String != "alice" {
-		t.Fatalf("resolution_operator_id=%v want alice", opID)
+	if !opID.Valid || opID.String != "bob" {
+		t.Fatalf("resolution_operator_id=%v want bob", opID)
 	}
-	if !reason.Valid || reason.String != "audited" {
-		t.Fatalf("resolution_reason=%v want audited", reason)
+	if !reason.Valid || reason.String != "corrected to void" {
+		t.Fatalf("resolution_reason=%v want corrected to void", reason)
 	}
 	if !createdAt.Valid || createdAt.String == "" {
 		t.Fatal("resolution_at_utc unset")
+	}
+	rows, err := store.db.Query(`
+SELECT resolution_kind
+  FROM ledger_quarantine_resolutions
+ WHERE request_credit_id = ?
+ ORDER BY created_at_utc ASC, id ASC`, id)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer rows.Close()
+	var history []string
+	for rows.Next() {
+		var k string
+		if err := rows.Scan(&k); err != nil {
+			t.Fatal(err)
+		}
+		history = append(history, k)
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatal(err)
+	}
+	if len(history) != 2 || history[0] != "force_credit" || history[1] != "force_void" {
+		t.Fatalf("history=%v want [force_credit force_void]", history)
 	}
 }
 

--- a/phase4-coordinator/internal/billing/settlement.go
+++ b/phase4-coordinator/internal/billing/settlement.go
@@ -9,13 +9,26 @@ import (
 
 func (s *Store) RunSettlement(ctx context.Context, cfg SettlementConfig, windowStart, windowEnd time.Time) error {
 	s.SetSettlementConfig(cfg)
-	tx, err := s.db.BeginTx(ctx, nil)
+	conn, err := s.db.Conn(ctx)
 	if err != nil {
 		return err
 	}
-	defer func() { _ = tx.Rollback() }()
+	defer conn.Close()
+	if _, err := conn.ExecContext(ctx, `BEGIN IMMEDIATE`); err != nil {
+		return err
+	}
+	committed := false
+	defer func() {
+		if !committed {
+			_, _ = conn.ExecContext(context.Background(), `ROLLBACK`)
+		}
+	}()
 	now := sqliteTimeText(time.Now().UTC())
-	if _, err := tx.ExecContext(ctx, `
+	snapshotAtUTC := now
+	defer func() {
+		_, _ = conn.ExecContext(context.Background(), `DROP TABLE IF EXISTS temp.settlement_eligible_request_credits`)
+	}()
+	if _, err := conn.ExecContext(ctx, `
 UPDATE ledger_request_credits
    SET quarantined = 1,
        quarantine_reason = COALESCE(quarantine_reason, 'conflicting_settlement_id'),
@@ -29,7 +42,7 @@ UPDATE ledger_request_credits
 	); err != nil {
 		return err
 	}
-	if _, err := tx.ExecContext(ctx, `
+	if _, err := conn.ExecContext(ctx, `
 UPDATE ledger_request_credits
    SET quarantined = 1,
        quarantine_reason = COALESCE(quarantine_reason, 'operator_split_mismatch'),
@@ -55,13 +68,104 @@ UPDATE ledger_request_credits
 	); err != nil {
 		return err
 	}
-	rows, err := tx.QueryContext(ctx, `
-SELECT provider_id, COUNT(*), SUM(gross_credits), SUM(provider_credits), SUM(gross_credits - provider_credits)
-  FROM spec022_payable_request_credits
- WHERE `+sqliteTimeBefore("ts_utc")+` AND settled = 0 AND settlement_id IS NULL
- GROUP BY provider_id
-HAVING SUM(provider_credits) >= ?`,
+	if _, err := conn.ExecContext(ctx, `
+CREATE TEMP TABLE IF NOT EXISTS settlement_eligible_request_credits (
+    id INTEGER PRIMARY KEY,
+    provider_id TEXT NOT NULL
+);
+DELETE FROM settlement_eligible_request_credits;`); err != nil {
+		return err
+	}
+	if _, err := conn.ExecContext(ctx, `
+INSERT INTO settlement_eligible_request_credits (id, provider_id)
+SELECT lrc.id, lrc.provider_id
+  FROM ledger_request_credits lrc
+ WHERE `+sqliteTimeBefore("lrc.ts_utc")+`
+   AND lrc.settled = 0
+   AND lrc.settlement_id IS NULL
+   AND (
+       lrc.quarantined = 0
+       OR EXISTS (
+           SELECT 1
+             FROM ledger_quarantine_resolutions lqr
+            WHERE lqr.request_credit_id = lrc.id
+              AND lqr.id = (
+                  SELECT latest.id
+                    FROM ledger_quarantine_resolutions latest
+                   WHERE latest.request_credit_id = lrc.id
+                   ORDER BY latest.created_at_utc DESC, latest.id DESC
+                   LIMIT 1
+              )
+              AND lqr.resolution_kind = 'force_credit'
+              AND lqr.force_credit_matures_at_utc IS NOT NULL
+              AND lqr.force_credit_matures_at_utc <= ?
+       )
+   )
+   AND (
+       COALESCE(lrc.settlement_policy_mode, 'legacy') IN ('legacy', 'observe')
+       OR (
+           lrc.settlement_policy_mode = 'enforce'
+           AND lrc.settlement_account_scope_hash IS NOT NULL
+           AND lrc.settlement_policy_version IS NOT NULL
+           AND EXISTS (
+               SELECT 1
+                 FROM settlement_route_snapshots srs
+                 JOIN settlement_receipt_verdicts srv
+                   ON srv.account_scope_hash = lrc.settlement_account_scope_hash
+                  AND srv.request_id = srs.request_id
+                  AND srv.attempt_n = srs.attempt_n
+                  AND srv.provider_id = srs.provider_id
+                  AND srv.route_snapshot_digest = srs.route_snapshot_digest
+                 JOIN settlement_attempt_outputs sao
+                   ON sao.account_scope = srs.account_scope
+                  AND sao.request_id = srs.request_id
+                  AND sao.attempt_n = srs.attempt_n
+                  AND sao.provider_id = srs.provider_id
+                WHERE srs.request_id = lrc.request_id
+                  AND srs.attempt_n = lrc.attempt_n
+                  AND srs.provider_id = lrc.provider_id
+                  AND srs.route_snapshot_mode = 'enforce'
+                  AND srs.route_snapshot_policy_version = lrc.settlement_policy_version
+                  AND srv.route_snapshot_mode = 'enforce'
+                  AND srv.route_snapshot_policy_version = lrc.settlement_policy_version
+                  AND srv.closed = 1
+                  AND srv.settlement_outcome = 'verified'
+                  AND sao.overlapping_or_duplicate = 0
+           )
+       )
+   )
+   AND NOT EXISTS (
+       SELECT 1
+         FROM ledger_payout_ready lpr
+         JOIN ledger_quarantine_resolutions lqr
+           ON lqr.request_credit_id = lrc.id
+        WHERE lpr.provider_id = lrc.provider_id
+          AND lpr.window_start_utc = ?
+          AND lpr.window_end_utc = ?
+          AND lqr.id = (
+              SELECT latest.id
+                FROM ledger_quarantine_resolutions latest
+               WHERE latest.request_credit_id = lrc.id
+               ORDER BY latest.created_at_utc DESC, latest.id DESC
+               LIMIT 1
+          )
+          AND lqr.resolution_kind = 'force_credit'
+          AND lqr.force_credit_matures_at_utc IS NOT NULL
+          AND lqr.force_credit_matures_at_utc > lpr.created_at_utc
+   )`,
 		sqliteTimeText(windowEnd),
+		snapshotAtUTC,
+		sqliteTimeText(windowStart),
+		sqliteTimeText(windowEnd),
+	); err != nil {
+		return err
+	}
+	rows, err := conn.QueryContext(ctx, `
+SELECT lrc.provider_id, COUNT(*), SUM(lrc.gross_credits), SUM(lrc.provider_credits), SUM(lrc.gross_credits - lrc.provider_credits)
+  FROM ledger_request_credits lrc
+  JOIN settlement_eligible_request_credits eligible ON eligible.id = lrc.id
+ GROUP BY lrc.provider_id
+HAVING SUM(provider_credits) >= ?`,
 		cfg.MinPayoutCredits,
 	)
 	if err != nil {
@@ -75,7 +179,7 @@ HAVING SUM(provider_credits) >= ?`,
 			return err
 		}
 		key := providerID + "|" + sqliteTimeText(windowStart) + "|" + sqliteTimeText(windowEnd)
-		res, err := tx.ExecContext(ctx, `
+		res, err := conn.ExecContext(ctx, `
 INSERT INTO ledger_payout_ready (
     provider_id, window_start_utc, window_end_utc, cadence_days, source_credit_count,
     gross_credits, provider_credits, operator_credits, min_payout_credits,
@@ -104,7 +208,7 @@ WHERE ledger_payout_ready.status = 'ready'`,
 		}
 		var settlementID int64
 		var payoutStatus string
-		err = tx.QueryRowContext(ctx, `SELECT id, status FROM ledger_payout_ready WHERE idempotency_key = ?`, key).Scan(&settlementID, &payoutStatus)
+		err = conn.QueryRowContext(ctx, `SELECT id, status FROM ledger_payout_ready WHERE idempotency_key = ?`, key).Scan(&settlementID, &payoutStatus)
 		if err != nil {
 			return err
 		}
@@ -114,15 +218,15 @@ WHERE ledger_payout_ready.status = 'ready'`,
 		if affected, _ := res.RowsAffected(); affected == 0 {
 			continue
 		}
-		if _, err := tx.ExecContext(ctx, `
+		if _, err := conn.ExecContext(ctx, `
 UPDATE ledger_request_credits
    SET settled = 1, settlement_id = ?, updated_at_utc = ?
- WHERE provider_id = ? AND `+sqliteTimeBefore("ts_utc")+` AND settled = 0 AND settlement_id IS NULL AND quarantined = 0
-   AND id IN (SELECT id FROM spec022_payable_request_credits)`,
+ WHERE provider_id = ?
+   AND id IN (SELECT id FROM settlement_eligible_request_credits WHERE provider_id = ?)`,
 			settlementID,
 			now,
 			providerID,
-			sqliteTimeText(windowEnd),
+			providerID,
 		); err != nil {
 			return err
 		}
@@ -130,7 +234,11 @@ UPDATE ledger_request_credits
 	if err := rows.Err(); err != nil {
 		return err
 	}
-	return tx.Commit()
+	if _, err := conn.ExecContext(ctx, `COMMIT`); err != nil {
+		return err
+	}
+	committed = true
+	return nil
 }
 
 func (s *Store) StartWeeklySettlement(ctx context.Context, cfg SettlementConfig) {

--- a/phase4-coordinator/internal/billing/snapshot.go
+++ b/phase4-coordinator/internal/billing/snapshot.go
@@ -23,15 +23,19 @@ type canonicalConfig struct {
 	// `quarantine_resolution_force_void_enabled` value. Including
 	// the boolean in the canonical hash makes the snapshot a
 	// forensic record of the flag state at that reload.
-	QuarantineResolutionForceVoidEnabled bool `json:"quarantine_resolution_force_void_enabled"`
+	QuarantineResolutionForceVoidEnabled   bool  `json:"quarantine_resolution_force_void_enabled"`
+	QuarantineResolutionForceCreditEnabled bool  `json:"quarantine_resolution_force_credit_enabled"`
+	ForceCreditSettlementHoldSeconds       int64 `json:"force_credit_settlement_hold_seconds"`
 }
 
 func (s *Store) InsertConfigSnapshot(ctx context.Context, cfg RewardsConfig, now time.Time) (int64, error) {
 	canon := canonicalConfig{
-		ProviderShareBps:                     ParseShareBps(cfg.ProviderShare),
-		GlobalMultiplierPPM:                  ParseMultiplierPPM(cfg.GlobalMultiplier),
-		RateCard:                             cfg.RateCard,
-		QuarantineResolutionForceVoidEnabled: s.forceVoidEnabled.Load(),
+		ProviderShareBps:                       ParseShareBps(cfg.ProviderShare),
+		GlobalMultiplierPPM:                    ParseMultiplierPPM(cfg.GlobalMultiplier),
+		RateCard:                               cfg.RateCard,
+		QuarantineResolutionForceVoidEnabled:   s.forceVoidEnabled.Load(),
+		QuarantineResolutionForceCreditEnabled: s.forceCreditEnabled.Load(),
+		ForceCreditSettlementHoldSeconds:       s.ForceCreditSettlementHoldSeconds(),
 	}
 	rateJSON, err := json.Marshal(canon.RateCard)
 	if err != nil {
@@ -82,8 +86,15 @@ INSERT INTO ledger_config_snapshots (
 // audit) and HandlersWithQuarantineGate (which uses
 // SetForceVoidEnabled with reloadSource="startup").
 func (s *Store) ReloadBillingConfig(ctx context.Context, cfg RewardsConfig, forceVoidEnabled bool, reloadSource string, now time.Time) (int64, error) {
+	return s.ReloadBillingConfigV05(ctx, cfg, forceVoidEnabled, s.forceCreditEnabled.Load(), s.ForceCreditSettlementHoldSeconds(), reloadSource, now)
+}
+
+func (s *Store) ReloadBillingConfigV05(ctx context.Context, cfg RewardsConfig, forceVoidEnabled bool, forceCreditEnabled bool, forceCreditHoldSeconds int64, reloadSource string, now time.Time) (int64, error) {
 	if reloadSource != "sighup" && reloadSource != "http_reload" {
 		return 0, errors.New("ReloadBillingConfig: reloadSource must be sighup or http_reload")
+	}
+	if forceCreditHoldSeconds <= 0 {
+		forceCreditHoldSeconds = defaultForceCreditSettlementHoldSeconds
 	}
 	s.forceVoidReloadMu.Lock()
 	defer s.forceVoidReloadMu.Unlock()
@@ -92,10 +103,12 @@ func (s *Store) ReloadBillingConfig(ctx context.Context, cfg RewardsConfig, forc
 	// value so the ledger_config_snapshots row reflects what the
 	// next handler-request observes (not the pre-reload value).
 	canon := canonicalConfig{
-		ProviderShareBps:                     ParseShareBps(cfg.ProviderShare),
-		GlobalMultiplierPPM:                  ParseMultiplierPPM(cfg.GlobalMultiplier),
-		RateCard:                             cfg.RateCard,
-		QuarantineResolutionForceVoidEnabled: forceVoidEnabled,
+		ProviderShareBps:                       ParseShareBps(cfg.ProviderShare),
+		GlobalMultiplierPPM:                    ParseMultiplierPPM(cfg.GlobalMultiplier),
+		RateCard:                               cfg.RateCard,
+		QuarantineResolutionForceVoidEnabled:   forceVoidEnabled,
+		QuarantineResolutionForceCreditEnabled: forceCreditEnabled,
+		ForceCreditSettlementHoldSeconds:       forceCreditHoldSeconds,
 	}
 	rateJSON, err := json.Marshal(canon.RateCard)
 	if err != nil {
@@ -111,6 +124,8 @@ func (s *Store) ReloadBillingConfig(ctx context.Context, cfg RewardsConfig, forc
 
 	oldFlag := s.forceVoidEnabled.Load()
 	flagChanged := oldFlag != forceVoidEnabled
+	oldCreditFlag := s.forceCreditEnabled.Load()
+	creditFlagChanged := oldCreditFlag != forceCreditEnabled
 
 	var flagPayloadJSON []byte
 	if flagChanged {
@@ -122,6 +137,20 @@ func (s *Store) ReloadBillingConfig(ctx context.Context, cfg RewardsConfig, forc
 			"ts_utc":        ts,
 		}
 		flagPayloadJSON, err = json.Marshal(flagPayload)
+		if err != nil {
+			return 0, err
+		}
+	}
+	var creditFlagPayloadJSON []byte
+	if creditFlagChanged {
+		flagPayload := map[string]any{
+			"flag":          "quarantine_resolution_force_credit_enabled",
+			"old_value":     oldCreditFlag,
+			"new_value":     forceCreditEnabled,
+			"reload_source": reloadSource,
+			"ts_utc":        ts,
+		}
+		creditFlagPayloadJSON, err = json.Marshal(flagPayload)
 		if err != nil {
 			return 0, err
 		}
@@ -150,6 +179,13 @@ VALUES (?, 'billing_config_flag_changed', NULL, ?)`, ts, string(flagPayloadJSON)
 				return err
 			}
 		}
+		if creditFlagChanged {
+			if _, err := conn.ExecContext(ctx, `
+INSERT INTO audit_log (ts_utc, event_type, provider_id, payload_json)
+VALUES (?, 'billing_config_flag_changed', NULL, ?)`, ts, string(creditFlagPayloadJSON)); err != nil {
+				return err
+			}
+		}
 		snapshotID = id
 		return nil
 	}); err != nil {
@@ -162,6 +198,10 @@ VALUES (?, 'billing_config_flag_changed', NULL, ?)`, ts, string(flagPayloadJSON)
 	if flagChanged {
 		s.forceVoidEnabled.Store(forceVoidEnabled)
 	}
+	if creditFlagChanged {
+		s.forceCreditEnabled.Store(forceCreditEnabled)
+	}
+	s.forceCreditHoldSeconds.Store(forceCreditHoldSeconds)
 	return snapshotID, nil
 }
 

--- a/phase4-coordinator/internal/billing/store.go
+++ b/phase4-coordinator/internal/billing/store.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"strings"
 	"sync"
@@ -32,15 +33,20 @@ type Store struct {
 	// forceVoidReloadMu serializes writes so that the (audit, publish)
 	// pair is atomic and the published value is durable in audit_log
 	// before any handler can observe it (R2 fix for flag-flip race).
-	forceVoidReloadMu sync.Mutex
-	forceVoidEnabled  atomic.Bool
+	forceVoidReloadMu      sync.Mutex
+	forceVoidEnabled       atomic.Bool
+	forceCreditEnabled     atomic.Bool
+	forceCreditHoldSeconds atomic.Int64
 }
+
+const defaultForceCreditSettlementHoldSeconds int64 = 24 * 60 * 60
 
 func NewStore(db *sql.DB) (*Store, error) {
 	if db == nil {
 		return nil, fmt.Errorf("db is required")
 	}
 	s := &Store{db: db, now: time.Now}
+	s.forceCreditHoldSeconds.Store(defaultForceCreditSettlementHoldSeconds)
 	if err := s.migrate(context.Background()); err != nil {
 		return nil, err
 	}
@@ -303,25 +309,27 @@ CREATE INDEX IF NOT EXISTS idx_srv_provider_recent ON settlement_receipt_verdict
 CREATE INDEX IF NOT EXISTS idx_srv_provider_failed_recent ON settlement_receipt_verdicts(provider_id, received_at_unix_ms DESC, id DESC)
     WHERE closed=1 AND settlement_outcome='quarantined';
 
--- SPEC-005 v0.4 (issue #169) — MIG-005-010
--- ledger_quarantine_resolutions records the operator-issued force-void
--- decision for a quarantined ledger_request_credits row. v0.4 ships
--- force-void only; CHECK widens in v0.5 to include 'force_credit' once
--- the pre-payout hold primitive lands.
--- UNIQUE(request_credit_id) makes the resolution terminal; the implicit
--- sqlite_autoindex covers the LEFT JOIN read path (no separate
--- non-unique index is added).
+-- SPEC-005 v0.5 (issue #253) — MIG-005-011
+-- ledger_quarantine_resolutions records operator-issued quarantine
+-- decisions. v0.5 widens the enum to force-credit and keeps history:
+-- at most one corrective opposite-kind row may be appended by the
+-- handler during the hold window; readers project the latest row.
 CREATE TABLE IF NOT EXISTS ledger_quarantine_resolutions (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
     request_credit_id INTEGER NOT NULL REFERENCES ledger_request_credits(id),
-    resolution_kind TEXT NOT NULL CHECK(resolution_kind IN ('force_void')),
+    resolution_kind TEXT NOT NULL CHECK(resolution_kind IN ('force_void','force_credit')),
     operator_id TEXT NOT NULL CHECK(length(operator_id) BETWEEN 1 AND 64),
     resolution_reason TEXT NOT NULL CHECK(length(resolution_reason) BETWEEN 1 AND 500),
     created_at_utc TEXT NOT NULL,
-    UNIQUE(request_credit_id)
+    force_credit_matures_at_utc TEXT NULL,
+    correction_deadline_at_utc TEXT NOT NULL
 );
 CREATE INDEX IF NOT EXISTS idx_lqr_kind_created ON ledger_quarantine_resolutions(resolution_kind, created_at_utc);
+CREATE INDEX IF NOT EXISTS idx_lqr_request_latest ON ledger_quarantine_resolutions(request_credit_id, created_at_utc DESC, id DESC);
 `); err != nil {
+		return err
+	}
+	if err := s.ensureLedgerQuarantineResolutionsV05(ctx); err != nil {
 		return err
 	}
 	if err := s.ensureCachedPromptTokensColumn(ctx); err != nil {
@@ -388,6 +396,210 @@ func (s *Store) ensureLedgerRequestCreditSettlementColumns(ctx context.Context) 
 		}
 	}
 	return nil
+}
+
+func (s *Store) ensureLedgerQuarantineResolutionsV05(ctx context.Context) error {
+	if err := s.recoverLedgerQuarantineResolutionsV05(ctx); err != nil {
+		return err
+	}
+	tableSQL := ""
+	if err := s.db.QueryRowContext(ctx, `
+SELECT sql FROM sqlite_master WHERE type='table' AND name='ledger_quarantine_resolutions'`).Scan(&tableSQL); err != nil {
+		return err
+	}
+	hasMaturesColumn, err := s.columnExists(ctx, "ledger_quarantine_resolutions", "force_credit_matures_at_utc")
+	if err != nil {
+		return err
+	}
+	hasDeadlineColumn, err := s.columnExists(ctx, "ledger_quarantine_resolutions", "correction_deadline_at_utc")
+	if err != nil {
+		return err
+	}
+	hasForceCreditEnum := strings.Contains(tableSQL, "'force_credit'")
+	hasUniqueRequestCredit, err := s.hasUniqueIndexOnColumns(ctx, "ledger_quarantine_resolutions", []string{"request_credit_id"})
+	if err != nil {
+		return err
+	}
+	if hasMaturesColumn && hasDeadlineColumn && hasForceCreditEnum && !hasUniqueRequestCredit {
+		_, err := s.db.ExecContext(ctx, `
+CREATE INDEX IF NOT EXISTS idx_lqr_kind_created ON ledger_quarantine_resolutions(resolution_kind, created_at_utc);
+CREATE INDEX IF NOT EXISTS idx_lqr_request_latest ON ledger_quarantine_resolutions(request_credit_id, created_at_utc DESC, id DESC);
+`)
+		return err
+	}
+	return sqliteutil.Transact(ctx, s.db, func(ctx context.Context, conn *sql.Conn) error {
+		var oldCount int64
+		if err := conn.QueryRowContext(ctx, `SELECT COUNT(*) FROM ledger_quarantine_resolutions`).Scan(&oldCount); err != nil {
+			return err
+		}
+		if _, err := conn.ExecContext(ctx, `
+DROP VIEW IF EXISTS spec022_payable_request_credits;
+DROP INDEX IF EXISTS idx_lqr_kind_created;
+DROP INDEX IF EXISTS idx_lqr_request_latest;
+DROP TABLE IF EXISTS ledger_quarantine_resolutions_v05;
+CREATE TABLE ledger_quarantine_resolutions_v05 (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    request_credit_id INTEGER NOT NULL REFERENCES ledger_request_credits(id),
+    resolution_kind TEXT NOT NULL CHECK(resolution_kind IN ('force_void','force_credit')),
+    operator_id TEXT NOT NULL CHECK(length(operator_id) BETWEEN 1 AND 64),
+    resolution_reason TEXT NOT NULL CHECK(length(resolution_reason) BETWEEN 1 AND 500),
+    created_at_utc TEXT NOT NULL,
+    force_credit_matures_at_utc TEXT NULL,
+    correction_deadline_at_utc TEXT NOT NULL
+);
+INSERT INTO ledger_quarantine_resolutions_v05 (
+    id, request_credit_id, resolution_kind, operator_id, resolution_reason,
+    created_at_utc, force_credit_matures_at_utc, correction_deadline_at_utc
+)
+SELECT id, request_credit_id, resolution_kind, operator_id, resolution_reason,
+       created_at_utc,
+       CASE WHEN resolution_kind = 'force_credit'
+            THEN strftime('%Y-%m-%dT%H:%M:%fZ', created_at_utc, '+86400 seconds')
+            ELSE NULL
+       END,
+       strftime('%Y-%m-%dT%H:%M:%fZ', created_at_utc, '+86400 seconds')
+  FROM ledger_quarantine_resolutions;
+`); err != nil {
+			return err
+		}
+		var newCount int64
+		if err := conn.QueryRowContext(ctx, `SELECT COUNT(*) FROM ledger_quarantine_resolutions_v05`).Scan(&newCount); err != nil {
+			return err
+		}
+		if newCount != oldCount {
+			return fmt.Errorf("ledger_quarantine_resolutions v0.5 rebuild count mismatch: old=%d new=%d", oldCount, newCount)
+		}
+		_, err := conn.ExecContext(ctx, `
+DROP TABLE ledger_quarantine_resolutions;
+ALTER TABLE ledger_quarantine_resolutions_v05 RENAME TO ledger_quarantine_resolutions;
+CREATE INDEX IF NOT EXISTS idx_lqr_kind_created ON ledger_quarantine_resolutions(resolution_kind, created_at_utc);
+CREATE INDEX IF NOT EXISTS idx_lqr_request_latest ON ledger_quarantine_resolutions(request_credit_id, created_at_utc DESC, id DESC);
+`)
+		return err
+	})
+}
+
+func (s *Store) recoverLedgerQuarantineResolutionsV05(ctx context.Context) error {
+	leftover, err := s.tableExists(ctx, "ledger_quarantine_resolutions_v05")
+	if err != nil || !leftover {
+		return err
+	}
+	return sqliteutil.Transact(ctx, s.db, func(ctx context.Context, conn *sql.Conn) error {
+		var canonicalCount, leftoverCount int64
+		if err := conn.QueryRowContext(ctx, `SELECT COUNT(*) FROM ledger_quarantine_resolutions`).Scan(&canonicalCount); err != nil {
+			return err
+		}
+		if err := conn.QueryRowContext(ctx, `SELECT COUNT(*) FROM ledger_quarantine_resolutions_v05`).Scan(&leftoverCount); err != nil {
+			return err
+		}
+		switch {
+		case leftoverCount == 0:
+			_, err := conn.ExecContext(ctx, `DROP TABLE ledger_quarantine_resolutions_v05`)
+			return err
+		case canonicalCount == 0:
+			_, err := conn.ExecContext(ctx, `
+DROP VIEW IF EXISTS spec022_payable_request_credits;
+DROP TABLE ledger_quarantine_resolutions;
+ALTER TABLE ledger_quarantine_resolutions_v05 RENAME TO ledger_quarantine_resolutions;
+CREATE INDEX IF NOT EXISTS idx_lqr_kind_created ON ledger_quarantine_resolutions(resolution_kind, created_at_utc);
+CREATE INDEX IF NOT EXISTS idx_lqr_request_latest ON ledger_quarantine_resolutions(request_credit_id, created_at_utc DESC, id DESC);
+`)
+			return err
+		default:
+			return fmt.Errorf("ambiguous ledger_quarantine_resolutions_v05 recovery: canonical=%d leftover=%d", canonicalCount, leftoverCount)
+		}
+	})
+}
+
+func (s *Store) tableExists(ctx context.Context, table string) (bool, error) {
+	var name string
+	err := s.db.QueryRowContext(ctx, `SELECT name FROM sqlite_master WHERE type='table' AND name=?`, table).Scan(&name)
+	if errors.Is(err, sql.ErrNoRows) {
+		return false, nil
+	}
+	return err == nil, err
+}
+
+func (s *Store) hasUniqueIndexOnColumns(ctx context.Context, table string, want []string) (bool, error) {
+	rows, err := s.db.QueryContext(ctx, "PRAGMA index_list("+table+")")
+	if err != nil {
+		return false, err
+	}
+	var indexes []string
+	for rows.Next() {
+		var seq int
+		var name string
+		var unique int
+		var origin string
+		var partial int
+		if err := rows.Scan(&seq, &name, &unique, &origin, &partial); err != nil {
+			_ = rows.Close()
+			return false, err
+		}
+		if unique == 1 {
+			indexes = append(indexes, name)
+		}
+	}
+	if err := rows.Err(); err != nil {
+		_ = rows.Close()
+		return false, err
+	}
+	if err := rows.Close(); err != nil {
+		return false, err
+	}
+	for _, indexName := range indexes {
+		cols, err := s.indexColumns(ctx, indexName)
+		if err != nil {
+			return false, err
+		}
+		if sameStringSlice(cols, want) {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+func (s *Store) indexColumns(ctx context.Context, indexName string) ([]string, error) {
+	rows, err := s.db.QueryContext(ctx, "PRAGMA index_info("+indexName+")")
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	type indexColumn struct {
+		seq  int
+		name string
+	}
+	var cols []indexColumn
+	for rows.Next() {
+		var seqno, cid int
+		var name string
+		if err := rows.Scan(&seqno, &cid, &name); err != nil {
+			return nil, err
+		}
+		cols = append(cols, indexColumn{seq: seqno, name: name})
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	out := make([]string, len(cols))
+	for _, c := range cols {
+		if c.seq >= 0 && c.seq < len(out) {
+			out[c.seq] = c.name
+		}
+	}
+	return out, nil
+}
+
+func sameStringSlice(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
 }
 
 func (s *Store) ensureCachedPromptTokensColumn(ctx context.Context) error {
@@ -713,7 +925,24 @@ DROP VIEW IF EXISTS spec022_payable_request_credits;
 CREATE VIEW spec022_payable_request_credits AS
 SELECT lrc.*
   FROM ledger_request_credits lrc
- WHERE lrc.quarantined = 0
+ WHERE (
+       lrc.quarantined = 0
+       OR EXISTS (
+           SELECT 1
+             FROM ledger_quarantine_resolutions lqr
+            WHERE lqr.request_credit_id = lrc.id
+              AND lqr.id = (
+                  SELECT latest.id
+                    FROM ledger_quarantine_resolutions latest
+                   WHERE latest.request_credit_id = lrc.id
+                   ORDER BY latest.created_at_utc DESC, latest.id DESC
+                   LIMIT 1
+              )
+              AND lqr.resolution_kind = 'force_credit'
+              AND lqr.force_credit_matures_at_utc IS NOT NULL
+              AND lqr.force_credit_matures_at_utc <= strftime('%Y-%m-%dT%H:%M:%fZ', 'now')
+       )
+   )
    AND (
        COALESCE(lrc.settlement_policy_mode, 'legacy') IN ('legacy', 'observe')
        OR (
@@ -929,6 +1158,25 @@ func (s *Store) ForceVoidEnabled() bool {
 	return s.forceVoidEnabled.Load()
 }
 
+func (s *Store) ForceCreditEnabled() bool {
+	return s.forceCreditEnabled.Load()
+}
+
+func (s *Store) ForceCreditSettlementHoldSeconds() int64 {
+	hold := s.forceCreditHoldSeconds.Load()
+	if hold <= 0 {
+		return defaultForceCreditSettlementHoldSeconds
+	}
+	return hold
+}
+
+func (s *Store) SetForceCreditSettlementHoldSeconds(seconds int64) {
+	if seconds <= 0 {
+		seconds = defaultForceCreditSettlementHoldSeconds
+	}
+	s.forceCreditHoldSeconds.Store(seconds)
+}
+
 // SetForceVoidEnabled atomically updates the route-layer flag and,
 // on actual flips (old != new), emits the SPEC-005 v0.4 §11.6.4
 // `billing_config_flag_changed` audit-log row inside the billing
@@ -940,6 +1188,14 @@ func (s *Store) ForceVoidEnabled() bool {
 // "startup" callers MUST pass a zero-value old (we infer first-time
 // init from changed == false on the swap).
 func (s *Store) SetForceVoidEnabled(ctx context.Context, newValue bool, reloadSource string) error {
+	return s.setQuarantineFlagEnabled(ctx, "quarantine_resolution_force_void_enabled", &s.forceVoidEnabled, newValue, reloadSource)
+}
+
+func (s *Store) SetForceCreditEnabled(ctx context.Context, newValue bool, reloadSource string) error {
+	return s.setQuarantineFlagEnabled(ctx, "quarantine_resolution_force_credit_enabled", &s.forceCreditEnabled, newValue, reloadSource)
+}
+
+func (s *Store) setQuarantineFlagEnabled(ctx context.Context, flagName string, flag *atomic.Bool, newValue bool, reloadSource string) error {
 	// R6 fix (CODE-M1): reloadSource enum is documented as restricted
 	// to "startup" | "sighup" | "http_reload". Validate before doing
 	// any state mutation or DB write — otherwise a typo in a caller
@@ -956,7 +1212,7 @@ func (s *Store) SetForceVoidEnabled(ctx context.Context, newValue bool, reloadSo
 	s.forceVoidReloadMu.Lock()
 	defer s.forceVoidReloadMu.Unlock()
 
-	oldValue := s.forceVoidEnabled.Load()
+	oldValue := flag.Load()
 	if oldValue == newValue {
 		return nil
 	}
@@ -966,11 +1222,11 @@ func (s *Store) SetForceVoidEnabled(ctx context.Context, newValue bool, reloadSo
 	// `ledger_config_snapshots` row already captures the initial
 	// state."
 	if reloadSource == "startup" {
-		s.forceVoidEnabled.Store(newValue)
+		flag.Store(newValue)
 		return nil
 	}
 	payload := map[string]any{
-		"flag":          "quarantine_resolution_force_void_enabled",
+		"flag":          flagName,
 		"old_value":     oldValue,
 		"new_value":     newValue,
 		"reload_source": reloadSource,
@@ -993,7 +1249,7 @@ VALUES (?, 'billing_config_flag_changed', NULL, ?)`, now, string(payloadJSON)); 
 	}
 	// Audit is durable: publish the new value. No handler could
 	// observe newValue before this point because the only reader is
-	// h.store.ForceVoidEnabled() which reads s.forceVoidEnabled.
-	s.forceVoidEnabled.Store(newValue)
+	// h.store.Force*Enabled() which reads the corresponding atomic.
+	flag.Store(newValue)
 	return nil
 }

--- a/phase4-coordinator/internal/billing/store_test.go
+++ b/phase4-coordinator/internal/billing/store_test.go
@@ -59,6 +59,63 @@ func TestBillingMigration(t *testing.T) {
 	}
 }
 
+func TestBillingMigrationUpgradesQuarantineResolutionsV04ToV05(t *testing.T) {
+	_, store := newRequestAndBillingStores(t)
+	insertCreditWithRequest(t, store.db, "legacy-resolution-row", "provider-a", time.Now().UTC(), 100)
+	id := scalar(t, store.db, `SELECT id FROM ledger_request_credits WHERE request_id='legacy-resolution-row'`)
+	if _, err := store.db.Exec(`UPDATE ledger_request_credits SET quarantined=1, quarantine_reason='legacy' WHERE id=?`, id); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.db.Exec(`
+DROP VIEW IF EXISTS spec022_payable_request_credits;
+DROP TABLE ledger_quarantine_resolutions;
+CREATE TABLE ledger_quarantine_resolutions (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    request_credit_id INTEGER NOT NULL REFERENCES ledger_request_credits(id),
+    resolution_kind TEXT NOT NULL CHECK(resolution_kind IN ('force_void')),
+    operator_id TEXT NOT NULL CHECK(length(operator_id) BETWEEN 1 AND 64),
+    resolution_reason TEXT NOT NULL CHECK(length(resolution_reason) BETWEEN 1 AND 500),
+    created_at_utc TEXT NOT NULL,
+    UNIQUE(request_credit_id)
+);
+CREATE INDEX IF NOT EXISTS idx_lqr_kind_created ON ledger_quarantine_resolutions(resolution_kind, created_at_utc);
+INSERT INTO ledger_quarantine_resolutions (
+    request_credit_id, resolution_kind, operator_id, resolution_reason, created_at_utc
+) VALUES (?, 'force_void', 'alice', 'legacy void', '2026-07-01T00:00:00.000000000Z')`, id); err != nil {
+		t.Fatal(err)
+	}
+	upgraded, err := NewStore(store.db)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !columnExists(t, store.db, "ledger_quarantine_resolutions", "force_credit_matures_at_utc") {
+		t.Fatal("missing force_credit_matures_at_utc after v0.5 migration")
+	}
+	if !columnExists(t, store.db, "ledger_quarantine_resolutions", "correction_deadline_at_utc") {
+		t.Fatal("missing correction_deadline_at_utc after v0.5 migration")
+	}
+	hasUnique, err := upgraded.hasUniqueIndexOnColumns(context.Background(), "ledger_quarantine_resolutions", []string{"request_credit_id"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if hasUnique {
+		t.Fatal("UNIQUE(request_credit_id) survived v0.5 migration")
+	}
+	if !indexExists(t, store.db, "ledger_quarantine_resolutions", "idx_lqr_request_latest") {
+		t.Fatal("missing idx_lqr_request_latest after v0.5 migration")
+	}
+	if got := scalar(t, store.db, `SELECT COUNT(*) FROM ledger_quarantine_resolutions WHERE request_credit_id=? AND resolution_kind='force_void'`, id); got != 1 {
+		t.Fatalf("preserved legacy rows=%d want 1", got)
+	}
+	if _, err := store.db.Exec(`
+INSERT INTO ledger_quarantine_resolutions (
+    request_credit_id, resolution_kind, operator_id, resolution_reason,
+    created_at_utc, force_credit_matures_at_utc, correction_deadline_at_utc
+) VALUES (?, 'force_credit', 'bob', 'corrected', '2026-07-01T00:00:01.000000000Z', '2026-07-02T00:00:01.000000000Z', '2026-07-02T00:00:01.000000000Z')`, id); err != nil {
+		t.Fatalf("append force_credit after migration: %v", err)
+	}
+}
+
 func TestBillingMigration_ReplacesSettledMoneyTrigger(t *testing.T) {
 	_, store := newRequestAndBillingStores(t)
 	if _, err := store.db.Exec(`

--- a/phase4-coordinator/internal/config/config.go
+++ b/phase4-coordinator/internal/config/config.go
@@ -60,7 +60,7 @@ type Config struct {
 	Onboarding                   OnboardingConfig             `yaml:"onboarding"`
 	MalibuEmission               MalibuEmissionConfig         `yaml:"malibu_emission"`
 	AutotuneFeeds                AutotuneFeedsConfig          `yaml:"autotune"`
-	ProofOfWeights               ProofOfWeightsConfig       `yaml:"proof_of_weights"`
+	ProofOfWeights               ProofOfWeightsConfig         `yaml:"proof_of_weights"`
 	Proxy                        ProxyConfig                  `yaml:"proxy"`
 	Providers                    []ProviderConfig             `yaml:"providers"`
 }
@@ -110,16 +110,16 @@ type OnboardingConfig struct {
 // MalibuEmissionConfig gates SPEC-MALIBU-EMISSION-LEDGER bootstrap accrual.
 // Default-off; money-path changes require PR + audit.
 type MalibuEmissionConfig struct {
-	Enabled                    bool    `yaml:"enabled"`
-	WriterDSN                  string  `yaml:"writer_dsn"`
-	TickIntervalSeconds        int     `yaml:"tick_interval_seconds"`
-	ProviderDailyCapMALIBU     float64 `yaml:"provider_daily_cap_malibu"`
-	WalletDailyCapMALIBU       float64 `yaml:"wallet_daily_cap_malibu"`
-	SQLitePayoutDBPath         string  `yaml:"sqlite_payout_db_path"`
-	WalletMirrorIntervalSeconds int    `yaml:"wallet_mirror_interval_seconds"`
-	UnlockEvalIntervalSeconds  int      `yaml:"unlock_eval_interval_seconds"`
-	MaxSerializableRetries     int      `yaml:"max_serializable_retries"`
-	BaseUSDCBalanceRPCURLs     []string `yaml:"base_usdc_balance_rpc_urls"`
+	Enabled                     bool     `yaml:"enabled"`
+	WriterDSN                   string   `yaml:"writer_dsn"`
+	TickIntervalSeconds         int      `yaml:"tick_interval_seconds"`
+	ProviderDailyCapMALIBU      float64  `yaml:"provider_daily_cap_malibu"`
+	WalletDailyCapMALIBU        float64  `yaml:"wallet_daily_cap_malibu"`
+	SQLitePayoutDBPath          string   `yaml:"sqlite_payout_db_path"`
+	WalletMirrorIntervalSeconds int      `yaml:"wallet_mirror_interval_seconds"`
+	UnlockEvalIntervalSeconds   int      `yaml:"unlock_eval_interval_seconds"`
+	MaxSerializableRetries      int      `yaml:"max_serializable_retries"`
+	BaseUSDCBalanceRPCURLs      []string `yaml:"base_usdc_balance_rpc_urls"`
 }
 
 // AutotuneFeedsConfig points at the signed SPEC-023 recommendation feeds
@@ -311,22 +311,22 @@ type PoolConfig struct {
 	WakeGapThresholdS       int `yaml:"wake_gap_threshold_s"`
 	// WakeGapThresholdMs, when > 0, overrides WakeGapThresholdS for
 	// millisecond-precision test scenarios. Not for production use.
-	WakeGapThresholdMs      int                     `yaml:"wake_gap_threshold_ms"`
-	WarmupFallbackS         int                     `yaml:"warmup_fallback_s"`
-	WarmupGateEnabled       bool                    `yaml:"warmup_gate_enabled"`
-	WarmupGateTimeoutS      int                     `yaml:"warmup_gate_timeout_s"`
-	WarmupGateMaxTokens     int                     `yaml:"warmup_gate_max_tokens"`
-	DegradedBackoffS        int                     `yaml:"degraded_backoff_s"`
-	DegradedMaxRetries      int                     `yaml:"degraded_max_retries"`
-	DegradedProbeAfter502   bool                    `yaml:"degraded_probe_after_502"`
-	BreakerFailureThreshold int                     `yaml:"breaker_failure_threshold"`
-	BreakerWindowS          int                     `yaml:"breaker_window_s"`
-	CanaryEnabled           bool                    `yaml:"canary_enabled"`
-	CanaryIntervalS         int                     `yaml:"canary_interval_s"`
-	CanaryTimeoutS          int                     `yaml:"canary_timeout_s"`
-	CanaryMaxTokens         int                     `yaml:"canary_max_tokens"`
-	CanaryFailureThreshold  int                              `yaml:"canary_failure_threshold"`
-	CanaryChallenges        []CanaryChallengeConfig          `yaml:"canary_challenges"`
+	WakeGapThresholdMs      int                                `yaml:"wake_gap_threshold_ms"`
+	WarmupFallbackS         int                                `yaml:"warmup_fallback_s"`
+	WarmupGateEnabled       bool                               `yaml:"warmup_gate_enabled"`
+	WarmupGateTimeoutS      int                                `yaml:"warmup_gate_timeout_s"`
+	WarmupGateMaxTokens     int                                `yaml:"warmup_gate_max_tokens"`
+	DegradedBackoffS        int                                `yaml:"degraded_backoff_s"`
+	DegradedMaxRetries      int                                `yaml:"degraded_max_retries"`
+	DegradedProbeAfter502   bool                               `yaml:"degraded_probe_after_502"`
+	BreakerFailureThreshold int                                `yaml:"breaker_failure_threshold"`
+	BreakerWindowS          int                                `yaml:"breaker_window_s"`
+	CanaryEnabled           bool                               `yaml:"canary_enabled"`
+	CanaryIntervalS         int                                `yaml:"canary_interval_s"`
+	CanaryTimeoutS          int                                `yaml:"canary_timeout_s"`
+	CanaryMaxTokens         int                                `yaml:"canary_max_tokens"`
+	CanaryFailureThreshold  int                                `yaml:"canary_failure_threshold"`
+	CanaryChallenges        []CanaryChallengeConfig            `yaml:"canary_challenges"`
 	ModelClassChallenges    map[string][]CanaryChallengeConfig `yaml:"model_class_challenges"`
 }
 
@@ -638,10 +638,7 @@ type SettlementConfig struct {
 	JobEnabled                  bool   `yaml:"job_enabled"`
 }
 
-// BillingConfig is the SPEC-005 v0.4 (issue #169) billing-side
-// operator-toggleable surface. v0.4 ships one flag gating the
-// quarantine-VOID admin endpoint at the route layer; v0.5 will
-// add a force-credit flag alongside the pre-payout hold.
+// BillingConfig is the SPEC-005 billing-side operator-toggleable surface.
 type BillingConfig struct {
 	// QuarantineResolutionForceVoidEnabled gates POST
 	// /admin/ledger/quarantine/{id}/force-void (SPEC-005 v0.4
@@ -650,6 +647,13 @@ type BillingConfig struct {
 	// 10) until the operator explicitly flips this to true via
 	// the existing config-reload primitive.
 	QuarantineResolutionForceVoidEnabled bool `yaml:"quarantine_resolution_force_void_enabled"`
+	// QuarantineResolutionForceCreditEnabled gates POST
+	// /admin/ledger/quarantine/{id}/force-credit. Default false.
+	QuarantineResolutionForceCreditEnabled bool `yaml:"quarantine_resolution_force_credit_enabled"`
+	// ForceCreditSettlementHoldSeconds is the pre-payout hold for
+	// force-credit resolutions. Zero means the SPEC-005 v0.5 default
+	// of 24 hours.
+	ForceCreditSettlementHoldSeconds int `yaml:"force_credit_settlement_hold_seconds"`
 }
 
 type EndpointsConfig struct {

--- a/phase4-coordinator/internal/explorer/store.go
+++ b/phase4-coordinator/internal/explorer/store.go
@@ -69,12 +69,9 @@ func (Store) SessionDetail(ctx context.Context, q ReadDB, requestID string) (map
 	if err != nil {
 		return nil, err
 	}
-	// SPEC-005 v0.4 §11.6.5 — LEFT JOIN ledger_quarantine_resolutions
-	// and surface resolution_kind / resolution_operator_id /
-	// resolution_reason / resolution_at_utc as the contract aliases
-	// the explorer client reads. Force-voided rows have
-	// `lrc.quarantined=1` AND a matching resolution row; the alias
-	// columns are non-null only when a resolution exists.
+	// SPEC-005 v0.5 §11.6.5 — current resolution aliases must project
+	// only the latest history row after UNIQUE(request_credit_id) is
+	// relaxed for corrective resolutions.
 	ledger, err := queryMaps(ctx, q, `
 		SELECT lrc.id, lrc.request_id, lrc.attempt_n, lrc.provider_id, lrc.provider_assigned_id,
 		       lrc.ts_utc, lrc.model, lrc.status, lrc.stream, lrc.prompt_tokens,
@@ -88,9 +85,34 @@ func (Store) SessionDetail(ctx context.Context, q ReadDB, requestID string) (map
 		       lqr.created_at_utc    AS resolution_at_utc
 		FROM ledger_request_credits lrc
 		LEFT JOIN ledger_operator_credits loc ON loc.request_credit_id = lrc.id
-		LEFT JOIN ledger_quarantine_resolutions lqr ON lqr.request_credit_id = lrc.id
+		LEFT JOIN ledger_quarantine_resolutions lqr
+		  ON lqr.id = (
+		      SELECT latest.id
+		        FROM ledger_quarantine_resolutions latest
+		       WHERE latest.request_credit_id = lrc.id
+		       ORDER BY latest.created_at_utc DESC, latest.id DESC
+		       LIMIT 1
+		  )
 		WHERE lrc.request_id = ?
 		ORDER BY lrc.attempt_n ASC, lrc.id ASC`, requestID)
+	if err != nil {
+		return nil, err
+	}
+	resolutionHistory, err := queryMaps(ctx, q, `
+		SELECT lrc.id AS request_credit_id,
+		       lrc.request_id,
+		       lrc.attempt_n,
+		       lqr.id AS resolution_id,
+		       lqr.resolution_kind,
+		       lqr.operator_id AS resolution_operator_id,
+		       lqr.resolution_reason,
+		       lqr.created_at_utc AS resolution_at_utc,
+		       lqr.force_credit_matures_at_utc,
+		       lqr.correction_deadline_at_utc
+		FROM ledger_request_credits lrc
+		JOIN ledger_quarantine_resolutions lqr ON lqr.request_credit_id = lrc.id
+		WHERE lrc.request_id = ?
+		ORDER BY lrc.attempt_n ASC, lqr.created_at_utc ASC, lqr.id ASC`, requestID)
 	if err != nil {
 		return nil, err
 	}
@@ -107,12 +129,13 @@ func (Store) SessionDetail(ctx context.Context, q ReadDB, requestID string) (map
 		return nil, sql.ErrNoRows
 	}
 	return map[string]any{
-		"request_id":                  requestID,
-		"attempts":                    attempts,
-		"ledger_rows":                 ledger,
-		"provider_identity_snapshots": snapshots,
-		"partial":                     false,
-		"error":                       nil,
+		"request_id":                    requestID,
+		"attempts":                      attempts,
+		"ledger_rows":                   ledger,
+		"quarantine_resolution_history": resolutionHistory,
+		"provider_identity_snapshots":   snapshots,
+		"partial":                       false,
+		"error":                         nil,
 	}, nil
 }
 
@@ -159,8 +182,8 @@ func (Store) ProviderDetail(ctx context.Context, q ReadDB, p pool.Provider) (map
 }
 
 func (Store) Ledger(ctx context.Context, q ReadDB, from, to time.Time, limit int) ([]map[string]any, error) {
-	// SPEC-005 v0.4 §11.6.5 — LEFT JOIN ledger_quarantine_resolutions
-	// surfaces the resolution alias columns on the ledger list view.
+	// SPEC-005 v0.5 §11.6.5 — list view surfaces only the latest
+	// resolution aliases, not one row per resolution-history entry.
 	return queryMaps(ctx, q, `
 		SELECT lrc.id, lrc.request_id, lrc.attempt_n, lrc.provider_id, lrc.provider_assigned_id,
 		       lrc.ts_utc, lrc.model, lrc.status, lrc.stream, lrc.prompt_tokens,
@@ -174,7 +197,14 @@ func (Store) Ledger(ctx context.Context, q ReadDB, from, to time.Time, limit int
 		       lqr.created_at_utc    AS resolution_at_utc
 		FROM ledger_request_credits lrc
 		LEFT JOIN ledger_operator_credits loc ON loc.request_credit_id = lrc.id
-		LEFT JOIN ledger_quarantine_resolutions lqr ON lqr.request_credit_id = lrc.id
+		LEFT JOIN ledger_quarantine_resolutions lqr
+		  ON lqr.id = (
+		      SELECT latest.id
+		        FROM ledger_quarantine_resolutions latest
+		       WHERE latest.request_credit_id = lrc.id
+		       ORDER BY latest.created_at_utc DESC, latest.id DESC
+		       LIMIT 1
+		  )
 		WHERE lrc.ts_utc >= ? AND lrc.ts_utc < ?
 		ORDER BY lrc.ts_utc DESC, lrc.id DESC
 		LIMIT ?`, encodeTime(from), encodeTime(to), limit)
@@ -250,17 +280,14 @@ func (Store) Overview(ctx context.Context, q ReadDB, from, to time.Time) (map[st
 	if err != nil {
 		return nil, err
 	}
-	// R3 fix (SEC-M2): payable totals (current_window_provider_credits,
-	// total_gross_credits, total_provider_credits) must mirror the
-	// SPEC-005 v0.4 §11 payable predicate (lrc.quarantined=0). Without
-	// this filter, quarantined and force-voided rows inflate the
-	// explorer overview totals, which then disagree with the
-	// /admin/ledger/summary numbers operators read.
+	// SPEC-005 v0.5: payable totals use the shared projection so
+	// matured force-credit rows count while force-void and held
+	// force-credit rows remain excluded.
 	ledgerRows, err := queryMaps(ctx, q, `
-		SELECT COALESCE(SUM(CASE WHEN lrc.quarantined=0 AND lrc.ts_utc >= ? AND lrc.ts_utc < ? THEN lrc.provider_credits ELSE 0 END), 0) AS current_window_provider_credits,
-		       COALESCE(SUM(CASE WHEN lrc.quarantined=0 THEN lrc.gross_credits ELSE 0 END), 0) AS total_gross_credits,
-		       COALESCE(SUM(CASE WHEN lrc.quarantined=0 THEN lrc.provider_credits ELSE 0 END), 0) AS total_provider_credits,
-		       COALESCE(SUM(CASE WHEN lrc.quarantined=0 THEN loc.operator_credits ELSE 0 END), 0) AS total_operator_credits,
+		SELECT COALESCE((SELECT SUM(provider_credits) FROM spec022_payable_request_credits WHERE ts_utc >= ? AND ts_utc < ?), 0) AS current_window_provider_credits,
+		       COALESCE((SELECT SUM(gross_credits) FROM spec022_payable_request_credits), 0) AS total_gross_credits,
+		       COALESCE((SELECT SUM(provider_credits) FROM spec022_payable_request_credits), 0) AS total_provider_credits,
+		       COALESCE((SELECT SUM(gross_credits - provider_credits) FROM spec022_payable_request_credits), 0) AS total_operator_credits,
 		       COALESCE((SELECT COUNT(*) FROM ledger_payout_ready WHERE status = 'ready'), 0) AS pending_payout_count,
 		       COALESCE((SELECT SUM(provider_credits) FROM ledger_payout_ready WHERE status = 'ready'), 0) AS pending_payout_credits,
 		       -- SPEC-005 v0.4 §11.6.5 OPEN_PREDICATE: surface only
@@ -270,8 +297,7 @@ func (Store) Overview(ctx context.Context, q ReadDB, from, to time.Time) (map[st
 		             SELECT 1 FROM ledger_quarantine_resolutions r WHERE r.request_credit_id = lrc.id
 		       ) THEN 1 ELSE 0 END), 0) AS quarantined_count,
 		       COALESCE(SUM(CASE WHEN lrc.fault_flag != '' AND lrc.fault_flag != 'none' THEN 1 ELSE 0 END), 0) AS fault_count
-		FROM ledger_request_credits lrc
-		LEFT JOIN ledger_operator_credits loc ON loc.request_credit_id = lrc.id`, encodeTime(from), encodeTime(to))
+		FROM ledger_request_credits lrc`, encodeTime(from), encodeTime(to))
 	if err != nil {
 		return nil, err
 	}

--- a/phase4-coordinator/internal/explorer/store_test.go
+++ b/phase4-coordinator/internal/explorer/store_test.go
@@ -32,26 +32,33 @@ func TestStoreSessionDetailReturnsLedgerJoin(t *testing.T) {
 	}
 }
 
-// R4 fix (CODE-M4): SPEC-005 v0.4 §11.6.5 explorer LEFT JOIN must
-// surface the resolution_* alias columns. Earlier AC-Q050 (in
-// billing package) ran the expected SQL directly against store.db,
-// which could mask an explorer-layer regression. This test exercises
-// the REAL explorer API — Store{}.SessionDetail and Store{}.Ledger —
-// against a fixture that has a force-void resolution row.
+// SPEC-005 v0.5 §11.6.5 explorer reads must surface latest/current
+// resolution aliases without duplicating ledger rows, while preserving
+// ordered resolution history for detail views.
 func TestStoreSessionDetail_SurfacesQuarantineResolutionAliases(t *testing.T) {
 	_, db := newTestExplorer(t, nil)
 	now := fixedExplorerTime()
-	// Mark the seed ledger row as quarantined + force-voided.
 	if _, err := db.Exec(`UPDATE ledger_request_credits SET quarantined=1, quarantine_reason='test_quarantine' WHERE request_id='req_seed'`); err != nil {
 		t.Fatalf("mark seed quarantined: %v", err)
 	}
 	if _, err := db.Exec(`
 INSERT INTO ledger_quarantine_resolutions
-    (request_credit_id, resolution_kind, operator_id, resolution_reason, created_at_utc)
-SELECT id, 'force_void', 'alice', 'real-explorer-test', ?
+    (request_credit_id, resolution_kind, operator_id, resolution_reason, created_at_utc, force_credit_matures_at_utc, correction_deadline_at_utc)
+SELECT id, 'force_credit', 'alice', 'credit-first', ?, ?, ?
   FROM ledger_request_credits WHERE request_id='req_seed'`,
-		now.Format(time.RFC3339Nano)); err != nil {
-		t.Fatalf("insert quarantine resolution: %v", err)
+		now.Format(time.RFC3339Nano),
+		now.Add(24*time.Hour).Format(time.RFC3339Nano),
+		now.Add(24*time.Hour).Format(time.RFC3339Nano)); err != nil {
+		t.Fatalf("insert force-credit resolution: %v", err)
+	}
+	if _, err := db.Exec(`
+INSERT INTO ledger_quarantine_resolutions
+    (request_credit_id, resolution_kind, operator_id, resolution_reason, created_at_utc, correction_deadline_at_utc)
+SELECT id, 'force_void', 'bob', 'void-correction', ?, ?
+  FROM ledger_request_credits WHERE request_id='req_seed'`,
+		now.Add(time.Minute).Format(time.RFC3339Nano),
+		now.Add(24*time.Hour).Format(time.RFC3339Nano)); err != nil {
+		t.Fatalf("insert force-void resolution: %v", err)
 	}
 	detail, err := Store{}.SessionDetail(context.Background(), db, "req_seed")
 	if err != nil {
@@ -65,14 +72,24 @@ SELECT id, 'force_void', 'alice', 'real-explorer-test', ?
 	if got, _ := row["resolution_kind"].(string); got != "force_void" {
 		t.Fatalf("resolution_kind=%v want force_void", row["resolution_kind"])
 	}
-	if got, _ := row["resolution_operator_id"].(string); got != "alice" {
-		t.Fatalf("resolution_operator_id=%v want alice", row["resolution_operator_id"])
+	if got, _ := row["resolution_operator_id"].(string); got != "bob" {
+		t.Fatalf("resolution_operator_id=%v want bob", row["resolution_operator_id"])
 	}
-	if got, _ := row["resolution_reason"].(string); got != "real-explorer-test" {
-		t.Fatalf("resolution_reason=%v want real-explorer-test", row["resolution_reason"])
+	if got, _ := row["resolution_reason"].(string); got != "void-correction" {
+		t.Fatalf("resolution_reason=%v want void-correction", row["resolution_reason"])
 	}
 	if got, _ := row["resolution_at_utc"].(string); got == "" {
 		t.Fatalf("resolution_at_utc is empty")
+	}
+	history := detail["quarantine_resolution_history"].([]map[string]any)
+	if len(history) != 2 {
+		t.Fatalf("history len=%d want 2: %+v", len(history), history)
+	}
+	if got, _ := history[0]["resolution_kind"].(string); got != "force_credit" {
+		t.Fatalf("history[0] kind=%v want force_credit", history[0]["resolution_kind"])
+	}
+	if got, _ := history[1]["resolution_kind"].(string); got != "force_void" {
+		t.Fatalf("history[1] kind=%v want force_void", history[1]["resolution_kind"])
 	}
 	// Also verify the Ledger() list view surfaces the same aliases.
 	ledger, err := Store{}.Ledger(context.Background(), db, now.Add(-time.Hour), now.Add(time.Hour), 10)
@@ -94,6 +111,46 @@ SELECT id, 'force_void', 'alice', 'real-explorer-test', ?
 	}
 	if !found {
 		t.Fatalf("req_seed missing from ledger list")
+	}
+}
+
+func TestStoreOverviewIncludesMaturedForceCreditPayableRows(t *testing.T) {
+	_, db := newTestExplorer(t, nil)
+	now := fixedExplorerTime()
+	if _, err := db.Exec(`
+INSERT INTO ledger_request_credits (
+	request_id, attempt_n, provider_id, provider_assigned_id, ts_utc, model, status, stream,
+	prompt_tokens, completion_tokens, estimated_completion_tokens, usage_source,
+	prompt_rate_per_mtok, completion_rate_per_mtok, global_multiplier_ppm,
+	gross_credits, provider_share_bps, provider_credits, quarantined, quarantine_reason, created_at_utc
+) VALUES ('req_force_credit_payable', 0, 'provider_seed', 'assigned_seed', ?, 'llama', 200, 0, 10, 5, NULL, 'provider_reported', 1, 1, 1000000, 20, 9000, 18, 1, 'test_quarantine', ?)`,
+		now.Format(time.RFC3339Nano), now.Format(time.RFC3339Nano)); err != nil {
+		t.Fatalf("insert force-credit ledger row: %v", err)
+	}
+	if _, err := db.Exec(`
+INSERT INTO ledger_quarantine_resolutions
+    (request_credit_id, resolution_kind, operator_id, resolution_reason, created_at_utc, force_credit_matures_at_utc, correction_deadline_at_utc)
+SELECT id, 'force_credit', 'alice', 'matured credit', ?, '2000-01-01T00:00:00.000000000Z', ?
+  FROM ledger_request_credits WHERE request_id='req_force_credit_payable'`,
+		now.Format(time.RFC3339Nano), now.Add(24*time.Hour).Format(time.RFC3339Nano)); err != nil {
+		t.Fatalf("insert force-credit resolution: %v", err)
+	}
+	overview, err := Store{}.Overview(context.Background(), db, now.Add(-time.Hour), now.Add(time.Hour))
+	if err != nil {
+		t.Fatalf("Overview: %v", err)
+	}
+	ledger := overview["ledger"].(map[string]any)
+	if got := ledger["total_gross_credits"]; got != int64(35) {
+		t.Fatalf("total_gross_credits=%v want 35", got)
+	}
+	if got := ledger["total_provider_credits"]; got != int64(31) {
+		t.Fatalf("total_provider_credits=%v want 31", got)
+	}
+	if got := ledger["total_operator_credits"]; got != int64(4) {
+		t.Fatalf("total_operator_credits=%v want 4", got)
+	}
+	if got := ledger["current_window_provider_credits"]; got != int64(31) {
+		t.Fatalf("current_window_provider_credits=%v want 31", got)
 	}
 }
 

--- a/specs/SPEC-005-billing.md
+++ b/specs/SPEC-005-billing.md
@@ -1,7 +1,65 @@
 # SPEC-005 - Billing, Settlement, and Provider Rewards
 
-**Version:** 0.4 (2026-06-29, manual quarantine VOID admin surface — issue #169, partial §OQ-5 close; force-credit deferred to v0.5)
+**Version:** 0.5 (2026-07-08, force-credit + 24h pre-payout hold + corrective resolution — issue #253, closes §OQ-5 credit arm)
 **Depends on:** SPEC-001 v1.2.4, SPEC-002 v1.5.2, SPEC-003 v0.7, SPEC-004 v0.3.1, SPEC-006 v0.9.1
+
+**Change log v0.5 (2026-07-08, issue #253 — force-credit + pre-payout hold + corrective resolution):**
+
+v0.5 lands the force-credit arm that v0.4 deliberately deferred.
+The new surface is intentionally coupled to a pre-payout hold so an
+operator mistake can be corrected before SPEC-016 consumes a
+`ledger_payout_ready` row for real-money payout.
+
+- **New force-credit endpoint (§11.6.1).**
+  `POST /admin/ledger/quarantine/{request_credit_id}/force-credit`
+  uses the same operator-key, JSON validation, rate-limit bucket,
+  same-transaction audit, and route-layer invisibility posture as
+  force-void. It emits `ledger_quarantine_force_credit`.
+- **Pre-payout hold.** A successful force-credit writes
+  `force_credit_matures_at_utc = created_at_utc +
+  billing.force_credit_settlement_hold_seconds`. The default is
+  86400 seconds (24h). Until that timestamp has elapsed, the
+  quarantined row remains excluded from `spec022_payable_request_credits`
+  and therefore cannot enter §7 settlement or SPEC-016 payout.
+- **Persisted correction deadline.** Every resolution row also writes
+  `correction_deadline_at_utc`. Corrective eligibility is evaluated
+  against that persisted deadline, not against a later hot-reloaded
+  hold value.
+- **UNIQUE relaxation and latest-row projection (§4.10).**
+  `UNIQUE(request_credit_id)` is removed. Resolution rows are
+  append-only history. Readers that need the current state MUST use
+  the latest row by `(created_at_utc DESC, id DESC)`.
+- **Corrective-resolution rule.** The handler permits at most one
+  opposite-kind corrective resolution during the hold window
+  (`force_credit -> force_void` before `force_credit_matures_at_utc`,
+  or `force_void -> force_credit` before the prior row's persisted
+  `correction_deadline_at_utc`).
+  Same-kind repeats and third resolutions return HTTP 409
+  `already_resolved`; corrections after the window return HTTP 409
+  `resolution_locked`.
+- **Settlement snapshot ordering (§7).** The settlement sweep MUST
+  acquire a SQLite `BEGIN IMMEDIATE` transaction before computing the
+  payable-row snapshot, and MUST materialize one fixed eligible source
+  set before inserting or updating `ledger_payout_ready`. Force-credit
+  maturity and corrective mutations cannot interleave with
+  payout-ready materialization or mutate the already-computed source
+  set.
+- **Existing payout-ready interaction.** If a force-credit matures
+  after a prior settlement window has already produced a
+  `ledger_payout_ready` row, the row MUST NOT mutate that old payout.
+  It rolls forward as an unsettled payable row and can be captured by
+  the next settlement sweep whose `window_end_utc` is after the row's
+  original `ts_utc`.
+- **First-class open-quarantine list.**
+  `GET /admin/ledger/quarantine?status=open` returns unresolved
+  quarantined rows. A row with any resolution history is no longer
+  "open"; held force-credit rows are resolved-but-not-yet-payable.
+- **SPEC-007 explorer projection.** Explorer-style reads MUST separate
+  current state from history after UNIQUE relaxation: the current
+  resolution is the latest row; full history is an ordered collection.
+- **Acceptance.** AC-Q040 and AC-Q043 are updated for history-capable
+  resolution rows; AC-Q055 now verifies held force-credit exclusion
+  and post-maturity payable inclusion.
 
 **Change log v0.4 (2026-06-29, issue #169 — manual quarantine VOID admin surface, partial §OQ-5 close; force-credit + pre-payout hold deferred to v0.5):**
 
@@ -679,41 +737,50 @@ Recovery MUST use this snapshot when request_log lacks stable provider identity.
   quarantine row carries a resolution row, which is the intended
   v0.4 semantic (operator MUST issue the resolution explicitly per
   §11.6).
+- MIG-005-011 widens `ledger_quarantine_resolutions` for v0.5
+  (issue #253): `resolution_kind` permits `force_void` and
+  `force_credit`; `UNIQUE(request_credit_id)` is removed;
+  `force_credit_matures_at_utc` and `correction_deadline_at_utc` are
+  present; `idx_lqr_request_latest` exists. This migration MUST run
+  transactionally. On SQLite versions where altering CHECK/UNIQUE
+  constraints requires a rebuild, the implementation MUST rebuild via
+  create-copy-count-check-rename inside one transaction and recover
+  safely from an interrupted prior attempt before making further
+  schema changes.
 - No SPEC-005 migration alters request_log.
 
 ### 4.10 Table `ledger_quarantine_resolutions`
 
-Added by SPEC-005 v0.4 (issue #169) to record the operator-issued
-force-void resolution for a quarantined `ledger_request_credits`
-row. The base row's `quarantined=1` marker remains immutable —
-this table records the OUTCOME of operator review without
-violating the v0.3.3 monotonic-quarantine schema invariant. v0.4
-ships the `force_void` kind only; v0.5 widens the `resolution_kind`
-CHECK to include `force_credit` alongside the pre-payout hold
-primitive.
+Added by SPEC-005 v0.4 (issue #169) and widened by v0.5
+(issue #253) to record operator-issued resolutions for a
+quarantined `ledger_request_credits` row. The base row's
+`quarantined=1` marker remains immutable — this table records the
+OUTCOME of operator review without violating the v0.3.3
+monotonic-quarantine schema invariant. v0.5 supports `force_void`
+and `force_credit`; force-credit rows are held from settlement until
+`force_credit_matures_at_utc`.
 
 | Column | Type | Constraint | Meaning | Update rule |
 |---|---|---|---|---|
 | `id` | INTEGER | PRIMARY KEY AUTOINCREMENT | local row id | insert only |
 | `request_credit_id` | INTEGER | NOT NULL REFERENCES ledger_request_credits(id) | quarantined row being resolved | insert only |
-| `resolution_kind` | TEXT | NOT NULL CHECK(resolution_kind IN ('force_void')) in v0.4; v0.5 widens to include `'force_credit'` | operator's resolution; v0.4 ships force_void only | insert only |
+| `resolution_kind` | TEXT | NOT NULL CHECK(resolution_kind IN ('force_void','force_credit')) | operator's resolution | insert only |
 | `operator_id` | TEXT | NOT NULL CHECK(length(operator_id) BETWEEN 1 AND 64) | self-asserted operator identity; the SCHEMA enforces only length; endpoint-layer validation (§11.6.1, §11.6.4) is authoritative for charset, trim, and UTF-8 | insert only |
 | `resolution_reason` | TEXT | NOT NULL CHECK(length(resolution_reason) BETWEEN 1 AND 500) | operator-supplied justification; SCHEMA enforces only length; endpoint-layer validation (§11.6.4) is authoritative for sanitization | insert only |
 | `created_at_utc` | TEXT | NOT NULL | resolution time (RFC3339Nano) | insert only |
+| `force_credit_matures_at_utc` | TEXT NULL | populated for `force_credit`; NULL for `force_void` | earliest time the force-credited row may enter `spec022_payable_request_credits` / settlement | insert only |
+| `correction_deadline_at_utc` | TEXT | NOT NULL | final time an opposite-kind correction may be appended for this resolution | insert only |
 
 Indexes and uniqueness constraints:
-- `UNIQUE(request_credit_id)` — terminal: one resolution per
-  quarantined row, ever. SQLite creates an implicit index for the
-  UNIQUE clause (`sqlite_autoindex_ledger_quarantine_resolutions_1`)
-  that ALSO covers the LEFT JOIN read path used by §11.1 / §11.2 /
-  §11.4 / §7. No additional non-unique index on
-  `request_credit_id` is added because the UNIQUE auto-index is
-  sufficient. The second POST to `force-void` against an already-
-  resolved row MUST hit this UNIQUE constraint, surface as HTTP
-  409 per §11.6.2, and MUST
-  NOT insert a second resolution row.
+- v0.5 removes `UNIQUE(request_credit_id)`. The table is append-only
+  history. The handler enforces the current lifecycle rule: zero or
+  one initial resolution, plus at most one opposite-kind correction
+  within the hold window. Readers that need current state MUST use
+  the latest row ordered by `(created_at_utc DESC, id DESC)`.
 - `INDEX idx_lqr_kind_created(resolution_kind, created_at_utc)` —
   covers operator-facing audit-of-resolutions browsing.
+- `INDEX idx_lqr_request_latest(request_credit_id, created_at_utc DESC, id DESC)` —
+  covers latest-resolution projection and current-state joins.
 
 **Schema choice rationale (v0.4).** The separate
 `ledger_quarantine_resolutions` table — instead of adding a
@@ -730,26 +797,25 @@ hold + corrective-resolution) and any future operator-lifecycle
 extensions (defer, split, amend) require schema changes; until
 then the simpler two-table shape stays.
 
-**Schema invariants (v0.4).**
-- v0.4 does NOT introduce an update path. The columns are insert-only.
-  Mistakes are corrected by a separate audit-log entry, NOT by mutating
-  the resolution row. Future spec versions MAY add an amend mechanism;
-  v0.4 deliberately does not.
-- `resolution_kind` enum in v0.4 is constrained to `{'force_void'}`
-  via CHECK; v0.5 widens to `{'force_credit', 'force_void'}` when
-  force-credit ships with the pre-payout hold. Additional kinds
-  (e.g. `defer`, `split`) are not planned.
+**Schema invariants (v0.5).**
+- v0.5 does NOT introduce an update path. The columns are insert-only.
+  Mistakes are
+  corrected by appending one opposite-kind corrective row inside the
+  hold window, NOT by mutating prior history.
+- `correction_deadline_at_utc` is set at resolution INSERT time using
+  the then-effective hold duration. Later config reloads MUST NOT
+  shorten or extend an already-inserted row's correction window.
+- `resolution_kind` enum is constrained to
+  `{'force_credit', 'force_void'}`. Additional kinds (e.g. `defer`,
+  `split`) are not planned.
 - The base `ledger_request_credits` row referenced by
   `request_credit_id` MUST have `quarantined=1` at resolution time.
   The hot path MUST enforce this at the endpoint layer (§11.6.2)
   BEFORE the INSERT, because a foreign-key check alone would not
   catch a non-quarantined target.
-- The resolution does NOT modify the base row. Aggregation queries
-  (§11.1 / §11.2 / §11.3 / §11.4 / §7) MUST join through this
-  table only when narrowing `quarantined_count` (per
-  §11.6.5 `OPEN_PREDICATE`); the payable-row aggregations remain
-  on the v0.3.3 `quarantined=0` filter because force-void never
-  contributes a payable row.
+- The resolution does NOT modify the base row. Force-void remains
+  non-payable. Force-credit becomes payable only when it is the
+  latest resolution and its `force_credit_matures_at_utc` has elapsed.
 
 ## 5. Units and arithmetic
 
@@ -921,6 +987,22 @@ The idempotency key is provider_id plus window_start_utc plus window_end_utc.
 Re-running a window cannot create duplicate payout-ready rows.
 If payout-ready exists and source rows are unsettled, rerun may mark only matching source rows settled.
 Conflicting settlement_id values quarantine rows.
+
+### 7.4.1 Settlement source-set snapshot
+
+Each settlement run MUST acquire `BEGIN IMMEDIATE` before computing
+eligible source rows. Within that transaction it MUST materialize a
+fixed source set for the run before inserting or updating
+`ledger_payout_ready`, and subsequent source-row settlement updates
+MUST use only that materialized set. The eligibility timestamp for
+force-credit maturity is one run-local snapshot timestamp, not a
+fresh wall-clock evaluation per SQL statement.
+
+If a force-credit row matures after a provider/window already has a
+`ledger_payout_ready` row, rerunning that old window MUST NOT mutate
+the old payout-ready row. The matured source row remains unsettled
+and can roll forward into the next settlement run whose
+`window_end_utc` is after the row's original `ts_utc`.
 
 ### 7.5 Update exception
 
@@ -1158,13 +1240,12 @@ No HTML, chart markup, Slack payload, or email body is returned.
 }
 ```
 
-`delta_gross_credits` MUST be 0 for a clean H-005 range. v0.4
-computes it over the v0.3.3 `quarantined=0` predicate (UNCHANGED);
-force-void rows are excluded from the payable set just like
-quarantined-and-unresolved rows. The `rows_force_resolved_in_range`
-field is mandatory under v0.4 and counts `force_void` resolutions
-with `created_at_utc` inside the range (v0.5 widens the count when
-`force_credit` ships); see §11.6.5.
+`delta_gross_credits` MUST be 0 for a clean H-005 range. v0.5
+computes included rows through `spec022_payable_request_credits`:
+force-void rows stay excluded, while held force-credit rows enter
+only after maturity. The `rows_force_resolved_in_range` field is
+mandatory and counts `force_void` and `force_credit` resolutions
+with `created_at_utc` inside the range; see §11.6.5.
 `buyer_equivalent_credits` is computed by SPEC-005 from request_log and the section  6 D8 matrix; it is not read from SPEC-006 usage tables.
 Provider/operator split validation is reported separately with `split_delta_rows`.
 A non-zero `delta_gross_credits` MUST be returned in this JSON response and MUST fail AC-H005.
@@ -1239,13 +1320,16 @@ Missing token returns 401.
 Unknown provider_id returns 404 without enumerating valid providers.
 When SPEC-002 v1.5.0 `auth.require_provider_tokens` is `false`, the `/providers/{provider_id}/earnings` endpoint MUST be disabled at the route layer. SPEC-005 v0.3.1 does NOT specify a side-channel per-provider bearer-token provisioning scheme; provider economics in this deployment mode are available only via the operator-keyed `/admin/ledger/providers` endpoint. SPEC-005 v0.3.1 production launch gate adds this as item 9 alongside the SPEC-006 production launch gate.
 
-**Production launch gate item 10 (v0.4, issue #169).** v0.4
-introduces ONE new config key gating §11.6 at the route layer:
-`billing.quarantine_resolution_force_void_enabled` (default
-`false`). When the flag is `false`, the endpoint MUST return
-HTTP 404 `not_found` — the endpoint is invisible to clients. The
-flag is operator-toggleable via the existing config-reload
-primitive (no coordinator restart required); §13 lists it.
+**Production launch gate item 10 (v0.5, issue #253).** §11.6 is
+gated at the route layer by independent config keys:
+`billing.quarantine_resolution_force_void_enabled` and
+`billing.quarantine_resolution_force_credit_enabled` (both default
+`false`). When a flag is `false`, its endpoint MUST return HTTP
+404 `not_found` — the endpoint is invisible to clients. The flags
+are operator-toggleable via the existing config-reload primitive
+(no coordinator restart required); §13 lists them. Force-credit
+also reads `billing.force_credit_settlement_hold_seconds`, default
+86400.
 
 Before flipping the flag to `true` in production the operator
 MUST: (a) document the operator-key holder set (who can hit
@@ -1254,23 +1338,21 @@ limitation per §11.6.4; (b) verify the §13 config-table entry is
 present in the deployment's `coordinator.yaml`.
 
 The route-layer default-disabled posture is a MUST, not a SHOULD.
-v0.4 ships the SPEC text and IMPL with the flag FALSE; operator
-flip is a deliberate, runbook-gated event. v0.4 does NOT add a
-force-credit gate item — force-credit is deferred to v0.5 (see
-v0.4 changelog scope-cut rationale). The SPEC-006 production
-launch gate is NOT modified by SPEC-005 v0.4 — gate item 10 lives
+v0.5 ships the SPEC text and IMPL with both flags FALSE; operator
+flip is a deliberate, runbook-gated event. The SPEC-006 production
+launch gate is NOT modified by SPEC-005 v0.5 — gate item 10 lives
 in SPEC-005 alone.
 
-### 11.6 Quarantine VOID admin surface (v0.4, issue #169)
+### 11.6 Quarantine resolution admin surface (v0.5, issue #253)
 
 Added by SPEC-005 v0.4 to PARTIALLY close the §OQ-5 "Manual
 quarantine resolution" open question. The §OQ-1 closure in v0.3.3
 narrowed the quarantine creation class to `attempt_n=1` with
 `retried=0` (legitimate retry without explicit marker); v0.4 ships
 the operator action to clear false-positive quarantines from the
-open-quarantine count via a `force-void` resolution. Force-CREDIT
-is deferred to v0.5 (alongside the pre-payout hold primitive) per
-the v0.4 changelog scope-cut rationale.
+open-quarantine count via a `force-void` resolution. v0.5 adds the
+credit arm via `force-credit`, gated by a 24h default pre-payout
+hold.
 
 The endpoint is operator-only (same `/admin/ledger/*` posture as
 §11.1 / §11.2 / §11.3 — operator_key bearer, no gateway service
@@ -1279,7 +1361,7 @@ writes to the `ledger_quarantine_resolutions` table (§4.10) and
 emits an audit-log row (§11.6.4) on success, all inside the same
 SQLite `BEGIN IMMEDIATE` transaction.
 
-#### 11.6.1 `POST /admin/ledger/quarantine/{request_credit_id}/force-void`
+#### 11.6.1 `POST /admin/ledger/quarantine/{request_credit_id}/force-void` and `/force-credit`
 
 **Purpose:** mark the quarantined row as a non-credit (duplicate,
 over-count, fraud, or other reason the operator decided not to pay
@@ -1288,8 +1370,14 @@ it). After this resolution, the row remains excluded from §11.1 /
 unresolved row was excluded under v0.3.3 — but the row is no
 longer counted toward the open-quarantine surface (`quarantined_count`
 in §11.1 / §11.2). Force-void produces NO money-out; this is the
-v0.4 safety property that lets the endpoint ship without the v0.5
-pre-payout hold.
+v0.4 safety property.
+
+**Force-credit purpose:** mark the quarantined row as payable after
+operator review. The successful resolution remains out of
+`spec022_payable_request_credits`, §7 settlement, and SPEC-016
+payout until `force_credit_matures_at_utc`. The maturity timestamp
+is `created_at_utc + billing.force_credit_settlement_hold_seconds`
+and defaults to 24h.
 
 **Path parameter:** `request_credit_id` MUST be the integer
 primary key of a row in `ledger_request_credits`. Decimal digits
@@ -1323,9 +1411,10 @@ in §11.6.1.1 (no echo of submitted values to avoid log-injection).
 | 200 | (n/a — success body) | resolution row inserted; see §11.6.1 200 example |
 | 400 | `bad_request` | path `{request_credit_id}` not a base-10 integer, OR overflows int64, OR body not valid JSON, OR top-level not an object, OR contains duplicate keys, OR contains unknown keys |
 | 403 | `forbidden` | missing OR wrong operator key (per §11, §16.1 envelope) |
-| 404 | `not_found` | (a) the config flag `billing.quarantine_resolution_force_void_enabled` is `false` — endpoint is route-layer disabled per §11.5 launch-gate item 10; OR (b) the flag is true but no `ledger_request_credits` row exists with that `id`; the response body is identical in both cases (no leak of which) |
+| 404 | `not_found` | (a) the endpoint's config flag is `false` — endpoint is route-layer disabled per §11.5 launch-gate item 10; OR (b) the flag is true but no `ledger_request_credits` row exists with that `id`; the response body is identical in both cases (no leak of which) |
 | 405 | `method_not_allowed` | method is not POST |
-| 409 | `already_resolved` | UNIQUE(request_credit_id) constraint hit (per §11.6.2) |
+| 409 | `already_resolved` | same-kind repeat, third resolution attempt, or other already-resolved state that is not an allowed hold-window correction (per §11.6.2) |
+| 409 | `resolution_locked` | opposite-kind correction attempted after the hold window has elapsed |
 | 413 | `request_too_large` | body > 4 KiB |
 | 415 | `unsupported_media_type` | `Content-Type` not `application/json` |
 | 422 | `not_quarantined` | row exists but `quarantined=0` |
@@ -1347,7 +1436,9 @@ All error responses follow the §11 envelope shape.
   "resolution_kind": "force_void",
   "operator_id": "alice",
   "resolution_reason": "Duplicate row confirmed via gateway audit log",
-  "created_at_utc": "2026-07-12T18:23:51.000000000Z"
+  "created_at_utc": "2026-07-12T18:23:51.000000000Z",
+  "force_credit_matures_at_utc": null,
+  "correction_deadline_at_utc": "2026-07-13T18:23:51.000000000Z"
 }
 ```
 
@@ -1355,13 +1446,12 @@ The 200 body is a top-level resolution object mirroring the
 inserted row. The 409 body is the §11 error envelope with
 `existing_resolution` nested inside (§11.6.2) — different shape.
 
-#### 11.6.2 Idempotency and the immutable resolution rule
+#### 11.6.2 Idempotency and corrective resolution rule
 
-The `UNIQUE(request_credit_id)` constraint on
-`ledger_quarantine_resolutions` makes resolutions terminal in v0.4.
-A second POST against the same `request_credit_id` — even with a
-different `reason` — MUST return HTTP 409 `conflict` with this
-body:
+v0.5 removes `UNIQUE(request_credit_id)` but keeps idempotency at
+the handler layer. A second same-kind POST against the same
+`request_credit_id` — even with a different `reason` — MUST return
+HTTP 409 `conflict` with this body:
 
 ```json
 {
@@ -1373,17 +1463,22 @@ body:
       "resolution_kind": "force_void",
       "operator_id": "alice",
       "resolution_reason": "Duplicate row confirmed via gateway audit log",
-      "created_at_utc": "2026-07-12T18:23:51.000000000Z"
+      "created_at_utc": "2026-07-12T18:23:51.000000000Z",
+      "force_credit_matures_at_utc": null,
+      "correction_deadline_at_utc": "2026-07-13T18:23:51.000000000Z"
     }
   }
 }
 ```
 
-v0.5 will lift the UNIQUE constraint (when force-credit lands with
-the pre-payout hold) so a force-credit can be corrected by a
-force-void within the hold window. v0.4 takes the simpler
-immutable stance because the only resolution kind is force-void,
-which has no money-out risk.
+Exactly one opposite-kind correction is allowed while the hold
+window is open. A `force_credit` row can be corrected to
+`force_void` before `force_credit_matures_at_utc`. A `force_void`
+row can be corrected to `force_credit` before that row's persisted
+`correction_deadline_at_utc`. The latest row wins for current-state
+projection. A third resolution attempt returns 409
+`already_resolved`; an opposite-kind correction after the hold
+window returns 409 `resolution_locked`.
 
 The endpoint MUST also enforce, INSIDE the same `BEGIN IMMEDIATE`
 transaction that performs the resolution INSERT:
@@ -1395,21 +1490,23 @@ transaction that performs the resolution INSERT:
 
 Both checks happen on `ledger_request_credits` (the base ledger
 row); they are NOT a TOCTOU pre-check on
-`ledger_quarantine_resolutions`. The forbidden pre-check is on
-the resolution table itself — that introduces the race the UNIQUE
-constraint is designed to prevent.
+`ledger_quarantine_resolutions`. The current-state lookup,
+correction-window decision, resolution INSERT, and audit INSERT
+MUST happen inside one `BEGIN IMMEDIATE` transaction.
 
-**SQLite error-class mapping.** When the INSERT into
-`ledger_quarantine_resolutions` fails:
+**Conflict and SQLite error-class mapping.** When the lifecycle
+decision or INSERT into `ledger_quarantine_resolutions` fails:
 
-- `SQLITE_CONSTRAINT_UNIQUE` against the `UNIQUE(request_credit_id)`
-  constraint → HTTP 409 `already_resolved`; the handler MUST
-  re-read the existing row to populate `existing_resolution`.
-- `SQLITE_CONSTRAINT_CHECK` on the `resolution_kind` CHECK (e.g.,
-  an IMPL attempt to insert `force_credit` in v0.4) → HTTP 500
-  `internal_error`. The endpoint MUST never accept `force_credit`
-  in v0.4; if a 500 surfaces here it indicates an IMPL bug, not
-  silent corruption.
+- Same-kind repeat or third resolution → HTTP 409
+  `already_resolved`; the handler MUST re-read the latest row to
+  populate `existing_resolution`.
+- Opposite-kind correction after the hold window → HTTP 409
+  `resolution_locked`; the handler MUST re-read the latest row to
+  populate `existing_resolution`.
+- `SQLITE_CONSTRAINT_CHECK` on the `resolution_kind` CHECK → HTTP
+  500 `internal_error`. The endpoint MUST never insert any
+  resolution kind outside `force_void` / `force_credit`; if a 500
+  surfaces here it indicates an IMPL bug, not silent corruption.
 - `SQLITE_CONSTRAINT_FOREIGN_KEY` → unreachable after the 404
   precondition; HTTP 500 `internal_error` if it surfaces.
 - `SQLITE_CONSTRAINT_CHECK` on length checks → unreachable after
@@ -1544,30 +1641,35 @@ the payload makes this limitation visible to a forensic reader
 who sees only the audit row.
 
 **Config-flag flip auditing.** Every hot-reload-acknowledged
-CHANGE to `billing.quarantine_resolution_force_void_enabled` —
-i.e., the post-reload value differs from the pre-reload value —
+CHANGE to `billing.quarantine_resolution_force_void_enabled` or
+`billing.quarantine_resolution_force_credit_enabled` — i.e., the
+post-reload value differs from the pre-reload value —
 MUST emit a separate audit-log row with `event_type =
 "billing_config_flag_changed"`, payload `{"flag":
-"quarantine_resolution_force_void_enabled", "old_value": <bool>,
+"quarantine_resolution_force_void_enabled"|"quarantine_resolution_force_credit_enabled", "old_value": <bool>,
 "new_value": <bool>, "reload_source": "sighup"|"http_reload",
 "ts_utc": "<RFC3339Nano>"}`. The `reload_source` enum is
-restricted to actual reload mechanisms; v0.4 does NOT emit at
+restricted to actual reload mechanisms; v0.5 does NOT emit at
 startup, because "no prior acknowledged value" has no defined
 `old_value` and the startup `ledger_config_snapshots` row already
 captures the initial state. A reload that ACKNOWLEDGES the same
 value (no change) MUST NOT emit. This is in addition to the
 existing `ledger_config_snapshots` row §13.2 already requires;
 it surfaces the flip as a discrete WARN event so an audit-log
-scan can correlate force-void resolutions to the flag state at
+scan can correlate quarantine resolutions to the flag state at
 the time.
 
 #### 11.6.5 Reader-side composition (SPEC-007 explorer and §11 aggregates)
 
 v0.4's force-void resolution does NOT add a row to the payable
-set. The pre-v0.4 `quarantined=0` filter remains correct for
-INCLUDED aggregations. v0.4 changes ONLY the OPEN aggregation
-(narrows it to exclude voided rows) and the SPEC-007 explorer
-detail (adds resolution columns).
+set. v0.5's force-credit resolution adds a row to the payable set
+only after the hold matures and only while `force_credit` is the
+latest resolution. Included aggregations and §7 settlement MUST use
+the `spec022_payable_request_credits` projection rather than a raw
+`quarantined=0` filter. The OPEN aggregation remains a count of
+quarantined rows with no resolution history. SPEC-007 explorer
+detail MUST expose both the latest/current resolution and ordered
+history after v0.5 removes `UNIQUE(request_credit_id)`.
 
 Define one reusable SQL fragment:
 
@@ -1588,34 +1690,28 @@ the new `OPEN_PREDICATE`.
 
 Concrete touch-list:
 
-| Reader | v0.3.3 filter | v0.4 filter |
+| Reader | v0.3.3 filter | v0.5 filter |
 |---|---|---|
-| §11.1 `total_gross_credits`, `total_provider_credits`, `total_operator_credits`, `current_window_provider_credits` | `WHERE quarantined=0` | **UNCHANGED** — still `WHERE quarantined=0` |
+| §11.1 `total_gross_credits`, `total_provider_credits`, `total_operator_credits`, `current_window_provider_credits` | `WHERE quarantined=0` | use `spec022_payable_request_credits` |
 | §11.1 `quarantined_count` | `WHERE quarantined=1` | `WHERE OPEN_PREDICATE` — narrows to exclude voided rows |
-| §11.2 per-provider rollup credits | `WHERE quarantined=0` | **UNCHANGED** |
+| §11.2 per-provider rollup credits | `WHERE quarantined=0` | use `spec022_payable_request_credits` |
 | §11.2 per-provider `quarantined_count` | `WHERE quarantined=1` | `WHERE OPEN_PREDICATE` |
-| §11.3 reconcile `provider_gross_credits`, `buyer_equivalent_credits` | `WHERE quarantined=0` | **UNCHANGED** |
+| §11.3 reconcile `provider_gross_credits`, `buyer_equivalent_credits` | `WHERE quarantined=0` | use `spec022_payable_request_credits` |
 | §11.3 reconcile `rows_quarantined` | `WHERE quarantined=1` | `WHERE OPEN_PREDICATE` |
-| §11.4 `/providers/{id}/earnings` `total_credits`, `current_window_credits` | `WHERE quarantined=0` | **UNCHANGED** |
-| §7 settlement sweep | `WHERE quarantined=0` | **UNCHANGED** — force-void does not enter settlement |
-| SPEC-007 explorer quarantined-row detail view | `WHERE quarantined=1` (no resolution data) | `LEFT JOIN ledger_quarantine_resolutions r ON r.request_credit_id = ledger_request_credits.id` and SELECT `r.resolution_kind AS resolution_kind`, `r.operator_id AS resolution_operator_id`, `r.resolution_reason AS resolution_reason`, `r.created_at_utc AS resolution_at_utc` |
+| §11.4 `/providers/{id}/earnings` `total_credits`, `current_window_credits` | `WHERE quarantined=0` | use `spec022_payable_request_credits` |
+| §7 settlement sweep | `WHERE quarantined=0` | materialize one run-local eligible set equivalent to `spec022_payable_request_credits`, plus §7.4.1 old-window protection |
+| SPEC-007 explorer quarantined-row detail view | `WHERE quarantined=1` (no resolution data) | current projection uses the latest row by `(created_at_utc DESC, id DESC)`; history projection returns all rows ordered by `(created_at_utc ASC, id ASC)` |
 
 The §11.3 reconcile response also gains a new top-level field
 `rows_force_resolved_in_range` (integer, COUNT of
 `ledger_quarantine_resolutions` rows with `created_at_utc` in
-[from_utc, to_utc]). v0.4 only ever counts `force_void`
-resolutions; v0.5 widens the count to include `force_credit`.
+[from_utc, to_utc]). v0.5 counts both `force_void` and
+`force_credit` resolutions.
 
-The §10.3 AC-H005 `delta_gross_credits` contract is UNCHANGED by
-v0.4 — force-void does not affect `provider_gross_credits` because
-the row was not in `provider_gross_credits` BEFORE the resolution
-either. The only observable shift is in `quarantined_count`
-(narrows) and the new field `rows_force_resolved_in_range`.
-
-Note for v0.5: when force-credit lands, this section will need
-significant widening (the `INCLUDED_PREDICATE` becomes necessary,
-along with settlement-sweep snapshot ordering and reconcile
-amendment). v0.4 deliberately punts that complexity.
+The §10.3 AC-H005 `delta_gross_credits` contract remains clean-range
+zero. Force-void rows stay excluded from provider gross. Force-credit
+rows shift into provider gross only after maturity, through the same
+`spec022_payable_request_credits` projection used by §11 and §7.
 
 #### 11.6.6 Rate limit, concurrency, and threat-model notes
 
@@ -1648,11 +1744,11 @@ a bare INSERT) is the correct shape.
    proves operator-KEY use, not human identity. The
    `operator_attribution` constant in the payload makes the
    limitation forensically explicit.
-3. **No money-out risk.** v0.4 ships force-void only, which never
-   produces a payout. The R3 audit-discovered safety concerns
-   around mistaken `force_credit` resolutions DO NOT apply to
-   force-void; v0.5 will introduce the pre-payout hold primitive
-   alongside force-credit.
+3. **Money-out risk bounded by hold.** Force-credit can produce a
+   payable row only after the hold elapses. A mistaken force-credit
+   can be corrected to force-void during that window; settlement
+   snapshots acquire `BEGIN IMMEDIATE` so a correction cannot
+   interleave with payout-ready materialization.
 
 ## 12. Buyer-balance interaction (D7)
 
@@ -1685,6 +1781,9 @@ Config changes affect only new request-credit rows.
 | `settlement.nightly_reconcile_window_days` | integer | `7` | nightly scan window |
 | `settlement.recovery_grace_seconds` | integer | `30` | recovery scan grace cutoff |
 | `settlement.job_enabled` | boolean | `true` | test-disable switch for scheduler only |
+| `billing.quarantine_resolution_force_void_enabled` | boolean | `false` | route-layer gate for force-void |
+| `billing.quarantine_resolution_force_credit_enabled` | boolean | `false` | route-layer gate for force-credit |
+| `billing.force_credit_settlement_hold_seconds` | integer | `86400` | pre-payout hold for force-credit maturity; zero/missing uses the default |
 | `endpoints.provider_earnings.rate_limit_per_minute` | integer | `60` | per-provider read limit for earnings endpoint |
 
 The coordinator SQLite database MUST run in WAL mode (`journal_mode = WAL`). SPEC-005 behavior is undefined under `journal_mode = DELETE`.
@@ -1706,18 +1805,21 @@ Invalid reload keeps prior valid config.
 Cold start without default rate-card row fails.
 Recovery MUST use historical `ledger_config_snapshots`; it MUST NOT price old request_log rows from a newer acknowledged config.
 
-**v0.4 route-layer flag (issue #169).** The
-`billing.quarantine_resolution_force_void_enabled` boolean
-(default `false`; YAML: `billing.quarantine_resolution_force_void_enabled: true|false`)
-is a route-layer hot-reload setting: a flip applies on the next
-inbound HTTP request, NOT just to "new request-credit rows" as the
-pre-v0.4 hot-reload prose implied. The flip is recorded in
+**v0.5 route-layer flags and hold (issue #253).** The
+`billing.quarantine_resolution_force_void_enabled` and
+`billing.quarantine_resolution_force_credit_enabled` booleans are
+route-layer hot-reload settings: a flip applies on the next inbound
+HTTP request, NOT just to "new request-credit rows" as the
+pre-v0.4 hot-reload prose implied. Each flip is recorded in
 `ledger_config_snapshots` (existing §4.7 mechanism) AND emits an
 explicit WARN audit-log row per §11.6.4 "Config-flag flip
-auditing". The coordinator MUST treat the flag as
+auditing". The coordinator MUST treat the flags as
 strictly-additive: the GET-summary path (§11.1
-`quarantined_count`) reads the same database regardless of the
-flag's value; only the POST §11.6.1 endpoint observes the flag.
+`quarantined_count`) reads the same database regardless of flag
+values; only the POST §11.6.1 endpoints observe their flags.
+`billing.force_credit_settlement_hold_seconds` is snapshotted with
+the route flags and applies to subsequently inserted force-credit
+resolution rows.
 
 ## 14. Instrumentation and metrics
 
@@ -1834,10 +1936,10 @@ Endpoint failures MUST return the section  11 JSON error envelope and no ledger 
 | Orphan ledger row | startup/nightly | quarantine | quarantined=1 |
 | Missing default rate | config load | startup failure | unknown models cannot be priced |
 | Invalid multiplier | config reload | reload failure | keep prior valid config |
-| audit_log INSERT fails during quarantine-resolution POST (v0.4) | /admin/ledger/quarantine/{id}/force-void | 500 `internal_error` | the same `BEGIN IMMEDIATE` transaction MUST roll back; no resolution row inserted; no audit row written; client retry safe |
-| Already-resolved row hit by second POST (v0.4) | /admin/ledger/quarantine/{id}/force-void | 409 `already_resolved` | response includes `existing_resolution`; no second resolution row; no second audit row; rate-limit bucket charged |
-| Force-void attempt with route flag disabled (v0.4) | /admin/ledger/quarantine/{id}/force-void | 404 `not_found` | same body as row-not-found 404; no flag-leak; no resolution INSERT; no audit row |
-| IMPL bug attempts to insert `force_credit` in v0.4 | /admin/ledger/quarantine/{id}/force-void | 500 `internal_error` | CHECK(resolution_kind IN ('force_void')) constraint fails; transaction rolls back; tracking issue OR v0.5 land |
+| audit_log INSERT fails during quarantine-resolution POST (v0.5) | /admin/ledger/quarantine/{id}/force-void or /force-credit | 500 `internal_error` | the same `BEGIN IMMEDIATE` transaction MUST roll back; no resolution row inserted; no audit row written; client retry safe |
+| Same-kind already-resolved row hit by second POST (v0.5) | /admin/ledger/quarantine/{id}/force-void or /force-credit | 409 `already_resolved` | response includes latest `existing_resolution`; no second same-kind resolution row; no second audit row; rate-limit bucket charged |
+| Correction after hold expires (v0.5) | /admin/ledger/quarantine/{id}/force-void or /force-credit | 409 `resolution_locked` | response includes latest `existing_resolution`; no corrective row; no audit row |
+| Route flag disabled (v0.5) | /admin/ledger/quarantine/{id}/force-void or /force-credit | 404 `not_found` | same body as row-not-found 404; no flag-leak; no resolution INSERT; no audit row |
 
 ## 18. Acceptance criteria
 
@@ -2129,10 +2231,10 @@ Fixtures may use in-memory SQLite, temporary SQLite, or pure functions.
 **Network:** Not required.
 **State reset:** Fresh fixture database or pure-function input.
 
-### AC-Q040: Quarantine resolution table shape (v0.4 §4.10)
+### AC-Q040: Quarantine resolution table shape (v0.5 §4.10)
 
-**Verification:** Inspect SQLite schema after MIG-005-010.
-**Expected:** Table `ledger_quarantine_resolutions` exists with columns `id`, `request_credit_id`, `resolution_kind`, `operator_id`, `resolution_reason`, `created_at_utc`; `UNIQUE(request_credit_id)`; CHECK constraints per §4.10 including `CHECK(resolution_kind IN ('force_void'))` (v0.4-only — v0.5 widens); idx_lqr_kind_created present. No separate `idx_lqr_request_credit` index exists (the UNIQUE auto-index covers the read path).
+**Verification:** Inspect SQLite schema after MIG-005-011.
+**Expected:** Table `ledger_quarantine_resolutions` exists with columns `id`, `request_credit_id`, `resolution_kind`, `operator_id`, `resolution_reason`, `created_at_utc`, `force_credit_matures_at_utc`, `correction_deadline_at_utc`; no `UNIQUE(request_credit_id)`; CHECK constraints per §4.10 including `CHECK(resolution_kind IN ('force_void','force_credit'))`; `idx_lqr_kind_created` and `idx_lqr_request_latest` present.
 **Network:** Not required.
 **State reset:** Fresh fixture database.
 
@@ -2143,10 +2245,10 @@ Fixtures may use in-memory SQLite, temporary SQLite, or pure functions.
 **Network:** Not required.
 **State reset:** Fresh fixture database.
 
-### AC-Q043: Idempotent UNIQUE conflict (v0.4 §11.6.2)
+### AC-Q043: Idempotent conflict and corrective resolution (v0.5 §11.6.2)
 
-**Verification:** With the route flag enabled, issue two sequential POSTs against the same `request_credit_id`. Also drive two concurrent POSTs from separate clients against the same id.
-**Expected:** Exactly one row in `ledger_quarantine_resolutions`; the second / concurrent-loser POST returns HTTP 409 with `code: "already_resolved"` and the existing resolution body. No double `audit_log` row. The implementation MUST rely on the UNIQUE constraint for race protection, NOT a check-then-INSERT sequence.
+**Verification:** With route flags enabled, issue two sequential same-kind POSTs against the same `request_credit_id`; also drive two concurrent same-kind POSTs from separate clients against the same id. Separately, issue `force-credit` followed by `force-void` before maturity, then attempt a third resolution. Separately, attempt `force-credit` followed by `force-void` after maturity.
+**Expected:** Same-kind repeats produce exactly one current resolution and return HTTP 409 with `code: "already_resolved"` and the existing/latest resolution body. The hold-window opposite-kind correction appends exactly one second row; latest row wins for current projection. A third resolution returns 409 `already_resolved`. A correction after maturity returns 409 `resolution_locked`. No losing/conflict path writes an extra `audit_log` row.
 **Network:** Not required.
 **State reset:** Fresh fixture database.
 
@@ -2178,17 +2280,17 @@ Fixtures may use in-memory SQLite, temporary SQLite, or pure functions.
 **Network:** Not required.
 **State reset:** Fresh fixture database (row 12345 quarantined).
 
-### AC-Q049: Concurrent UNIQUE conflict mapping (v0.4 §11.6.2, §11.6.6)
+### AC-Q049: Concurrent same-kind conflict mapping (v0.5 §11.6.2, §11.6.6)
 
 **Verification:** With route flag enabled, seed a `quarantined=1` row. Fire 64 parallel POST `/force-void` requests against it from independent client goroutines, each with a distinct `reason` value.
-**Expected:** Exactly one 200 response. Exactly 63 × 409 `already_resolved` responses, each with `existing_resolution` populated with the winner's identity. SELECT on `ledger_quarantine_resolutions` returns exactly one row. SELECT on `audit_log` returns exactly one row of `event_type='ledger_quarantine_force_void'`. All 64 authenticated responses count against the `/admin/*` rate-limit bucket.
+**Expected:** Exactly one 200 response. Exactly 63 × 409 `already_resolved` responses, each with `existing_resolution` populated with the winner's identity. SELECT on `ledger_quarantine_resolutions` returns exactly one row. SELECT on `audit_log` returns exactly one row of `event_type='ledger_quarantine_force_void'`. The implementation MUST serialize the lifecycle decision and INSERT in one `BEGIN IMMEDIATE` transaction. All 64 authenticated responses count against the `/admin/*` rate-limit bucket.
 **Network:** Not required.
 **State reset:** Fresh fixture database.
 
-### AC-Q050: SPEC-007 explorer alias columns (v0.4 §11.6.5)
+### AC-Q050: SPEC-007 explorer current and history projection (v0.5 §11.6.5)
 
-**Verification:** Seed three rows: (a) `quarantined=0`, (b) `quarantined=1` with no resolution, (c) `quarantined=1` with a `force_void` resolution. Hit the SPEC-007 explorer detail view for each.
-**Expected:** (a) view returns base columns; resolution_kind/resolution_operator_id/resolution_reason/resolution_at_utc are absent or JSON null. (b) same as (a). (c) view returns base columns AND the four `resolution_*` fields with the exact column-to-alias mapping per §11.6.5 (resolution_kind=force_void; resolution_operator_id=row's operator_id; resolution_reason=row's resolution_reason; resolution_at_utc=row's created_at_utc).
+**Verification:** Seed three rows: (a) `quarantined=0`, (b) `quarantined=1` with no resolution, (c) `quarantined=1` with two resolution rows: first `force_credit`, then corrective `force_void`. Hit the SPEC-007 explorer detail view for each.
+**Expected:** (a) view returns base columns; current resolution fields are absent or JSON null and history is empty. (b) same as (a). (c) current projection returns the latest row (`force_void`) using the `resolution_*` aliases; history projection returns both rows in chronological order with the original `force_credit` before the corrective `force_void`.
 **Network:** Not required.
 **State reset:** Fresh fixture database.
 
@@ -2199,17 +2301,17 @@ Fixtures may use in-memory SQLite, temporary SQLite, or pure functions.
 **Network:** Not required.
 **State reset:** Fresh fixture database.
 
-### AC-Q053: Route-layer config flag gate (v0.4 §11.5 / §13.2)
+### AC-Q053: Route-layer config flag gates (v0.5 §11.5 / §13.2)
 
-**Verification:** With `billing.quarantine_resolution_force_void_enabled = false` (default), POST `/admin/ledger/quarantine/12345/force-void` against a valid quarantined row. Config-reload with the flag = `true` and POST again. Config-reload back to `false` and POST a third time against a DIFFERENT quarantined row.
-**Expected:** First POST returns HTTP 404 `not_found` with the §11.6.1.1 envelope; no resolution INSERT; no audit row. Second POST returns HTTP 200 with a fresh resolution row + audit row. Third POST returns HTTP 404 again. The 404 body for the disabled-flag case is byte-identical to the row-not-found 404 body — no leak of which case fired. After each flag flip, a separate `audit_log` row exists with `event_type='billing_config_flag_changed'` carrying the old/new values and reload-source per §11.6.4.
+**Verification:** With both route flags false by default, POST `/force-void` and `/force-credit` against valid quarantined rows. Config-reload either flag to true and POST that endpoint again. Config-reload back to false and POST a third time against a DIFFERENT quarantined row.
+**Expected:** Disabled endpoints return HTTP 404 `not_found` with the §11.6.1.1 envelope; no resolution INSERT; no audit row. Enabled endpoints return HTTP 200 with a fresh resolution row + audit row. Re-disabled endpoints return HTTP 404 again. The 404 body for the disabled-flag case is byte-identical to the row-not-found 404 body — no leak of which case fired. After each flag flip, a separate `audit_log` row exists with `event_type='billing_config_flag_changed'` carrying the flag name, old/new values, and reload-source per §11.6.4.
 **Network:** Not required.
 **State reset:** Fresh fixture database; config-reload primitive exercised between scenarios.
 
-### AC-Q055: v0.4 force-credit rejection (v0.4 §4.10 CHECK)
+### AC-Q055: Force-credit hold and payable inclusion (v0.5 §11.6.1)
 
-**Verification:** Direct-SQL test (no HTTP path; the §11.6 endpoint has no `/force-credit` route in v0.4): attempt an INSERT into `ledger_quarantine_resolutions` with `resolution_kind='force_credit'` from a separate test fixture.
-**Expected:** SQLite returns `SQLITE_CONSTRAINT_CHECK` (error code 19). No row inserted. This AC pins the v0.4 schema invariant that force-credit is unreachable; v0.5 will lift the CHECK constraint when force-credit ships.
+**Verification:** Seed a quarantined `ledger_request_credits` row, enable `billing.quarantine_resolution_force_credit_enabled`, POST `/admin/ledger/quarantine/{id}/force-credit`, and inspect `spec022_payable_request_credits` before and after `force_credit_matures_at_utc`.
+**Expected:** The POST returns HTTP 200, writes `resolution_kind='force_credit'`, sets `force_credit_matures_at_utc = created_at_utc + billing.force_credit_settlement_hold_seconds`, sets `correction_deadline_at_utc` at INSERT time, and emits `ledger_quarantine_force_credit`. Before maturity the row is absent from `spec022_payable_request_credits`. After maturity, if force-credit remains the latest resolution, the row appears in `spec022_payable_request_credits` while the base `ledger_request_credits.quarantined` marker remains 1.
 **Network:** Not required.
 **State reset:** Fresh fixture database.
 


### PR DESCRIPTION
## Summary
- implements SPEC-005 v0.5 force-credit with a 24h default pre-payout hold and corrective resolution history
- hardens settlement to use a fixed eligible source set under BEGIN IMMEDIATE
- updates explorer/admin projections for latest resolution, ordered history, payable totals, and open-quarantine pagination
- updates SPEC-005 and regression coverage for issue #253

Closes #253.

## Validation
- go test -count=1 ./internal/billing ./internal/explorer
- go test -count=1 ./...
- git diff --check
- three audit lanes rerun to PASS with zero Critical/High/Medium findings
