### PR TITLE
feat(proof-of-weights): W1 model_hash_mismatch_total counter

### DIFF
--- a/docs/research/proof-of-weights-w1-inventory.md
+++ b/docs/research/proof-of-weights-w1-inventory.md
@@ -31,7 +31,7 @@
 - `/poolz` tier2 eligibility uses the same predicate (`ws/server.go:3042`).
 - Tier2 audit log emits `decision=exclude` for mismatch (`catalog.go:705-706`).
 
-**Gap (LOW):** optional coordinator metric `model_hash_mismatch_total` from runbook §3.1 not yet present — routing exclusion works without it.
+**Gap (LOW):** optional coordinator metric `model_hash_mismatch_total` — increments on transition to `hash_mismatch` via WS server (`internal/ws/server.go` + `internal/stats/metrics`).
 
 ---
 
@@ -62,7 +62,7 @@
 |-----------|--------|
 | Mismatch provider never receives buyer traffic for pinned catalog row | ✅ Enforced via tier2 routing predicate |
 | Quarantined receipts visible in operator explorer | ✅ Settlement reason filters present |
-| Optional mismatch metric | ⬜ Not implemented (carry LOW) |
+| Optional mismatch metric | ✅ `model_hash_mismatch_total` on hash status transition to mismatch |
 
 ---
 

--- a/phase4-coordinator/cmd/coordinator/main.go
+++ b/phase4-coordinator/cmd/coordinator/main.go
@@ -453,6 +453,7 @@ func main() {
 	if statsPools != nil {
 		wsOpts = append(wsOpts, providerws.WithIdlePrewarmRecorder(statsprewarm.NewRecorder(statsPools.Rollup)))
 		wsOpts = append(wsOpts, providerws.WithIdlePrewarmMetrics(metricsHandle))
+		wsOpts = append(wsOpts, providerws.WithModelHashMismatchMetrics(metricsHandle))
 	}
 	var onboardingStore *onboarding.PGStore
 	if cfg.Onboarding.AppTrackRegisterEnabled {

--- a/phase4-coordinator/internal/stats/metrics/metrics.go
+++ b/phase4-coordinator/internal/stats/metrics/metrics.go
@@ -67,6 +67,7 @@ type Metrics struct {
 	RegisterSource         *prometheus.CounterVec
 	RegisterHardwareErrors prometheus.Counter
 	IdlePrewarmEventTotal  *prometheus.CounterVec
+	ModelHashMismatchTotal prometheus.Counter
 }
 
 // New registers all five metrics against reg and returns the
@@ -147,6 +148,12 @@ func New(reg prometheus.Registerer) *Metrics {
 			},
 			[]string{"event", "reason"},
 		),
+		ModelHashMismatchTotal: f.NewCounter(
+			prometheus.CounterOpts{
+				Name: "model_hash_mismatch_total",
+				Help: "Count of provider hash status transitions to hash_mismatch (Proof of Weights W1 observability).",
+			},
+		),
 	}
 }
 
@@ -204,4 +211,11 @@ func (m *Metrics) IncIdlePrewarmEvent(event, reason string) {
 		return
 	}
 	m.IdlePrewarmEventTotal.WithLabelValues(event, reason).Inc()
+}
+
+func (m *Metrics) IncModelHashMismatch() {
+	if m == nil || m.ModelHashMismatchTotal == nil {
+		return
+	}
+	m.ModelHashMismatchTotal.Inc()
 }

--- a/phase4-coordinator/internal/ws/hash_mismatch_metrics_test.go
+++ b/phase4-coordinator/internal/ws/hash_mismatch_metrics_test.go
@@ -1,0 +1,48 @@
+package ws
+
+import (
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/rs/zerolog"
+	statsmetrics "github.com/augstar/macprovider-coordinator/internal/stats/metrics"
+	"github.com/augstar/macprovider-coordinator/internal/config"
+	"github.com/augstar/macprovider-coordinator/internal/pool"
+)
+
+func TestObserveHashStatusTransitionIncrementsMismatchMetric(t *testing.T) {
+	t.Parallel()
+	reg := prometheus.NewRegistry()
+	metrics := statsmetrics.New(reg)
+	server := NewServer(config.Default(), pool.NewRegistry(nil), zerolog.Nop(), WithModelHashMismatchMetrics(metrics))
+
+	server.observeHashStatusTransition(pool.HashStatusVerified, pool.HashStatusVerified, "p", "a", "m", "h")
+	if got := modelHashMismatchMetricValue(t, reg); got != 0 {
+		t.Fatalf("verified->verified metric = %v, want 0", got)
+	}
+	server.observeHashStatusTransition(pool.HashStatusVerified, pool.HashStatusMismatch, "p", "a", "m", "h")
+	if got := modelHashMismatchMetricValue(t, reg); got != 1 {
+		t.Fatalf("verified->mismatch metric = %v, want 1", got)
+	}
+	server.observeHashStatusTransition(pool.HashStatusMismatch, pool.HashStatusMismatch, "p", "a", "m", "h")
+	if got := modelHashMismatchMetricValue(t, reg); got != 1 {
+		t.Fatalf("mismatch->mismatch metric = %v, want 1", got)
+	}
+}
+
+func modelHashMismatchMetricValue(t *testing.T, reg *prometheus.Registry) float64 {
+	t.Helper()
+	families, err := reg.Gather()
+	if err != nil {
+		t.Fatalf("gather: %v", err)
+	}
+	for _, mf := range families {
+		if mf.GetName() != "model_hash_mismatch_total" {
+			continue
+		}
+		for _, metric := range mf.GetMetric() {
+			return metric.GetCounter().GetValue()
+		}
+	}
+	return 0
+}

--- a/phase4-coordinator/internal/ws/server.go
+++ b/phase4-coordinator/internal/ws/server.go
@@ -94,6 +94,7 @@ type Server struct {
 	authPolicyAdmin    ProviderAuthPolicyAdminStore
 	idlePrewarm        IdlePrewarmRecorder
 	idlePrewarmMetrics IdlePrewarmMetrics
+	modelHashMismatchMetrics ModelHashMismatchMetrics
 	idlePrewarmLimits  sync.Map
 	idlePrewarmQueue   chan idlePrewarmRecord
 }
@@ -163,6 +164,10 @@ type IdlePrewarmRecorder interface {
 
 type IdlePrewarmMetrics interface {
 	IncIdlePrewarmEvent(event, reason string)
+}
+
+type ModelHashMismatchMetrics interface {
+	IncModelHashMismatch()
 }
 
 const (
@@ -257,6 +262,12 @@ func WithIdlePrewarmRecorder(recorder IdlePrewarmRecorder) Option {
 func WithIdlePrewarmMetrics(metrics IdlePrewarmMetrics) Option {
 	return func(s *Server) {
 		s.idlePrewarmMetrics = metrics
+	}
+}
+
+func WithModelHashMismatchMetrics(metrics ModelHashMismatchMetrics) Option {
+	return func(s *Server) {
+		s.modelHashMismatchMetrics = metrics
 	}
 }
 
@@ -433,14 +444,22 @@ func (s *Server) RefreshTier2HashStatuses() int {
 	}
 	return s.pool.UpdateHashStatuses(func(provider pool.Provider) pool.HashStatus {
 		next := s.catalogRef().VerifyProviderHash(provider.ModelID, provider.ModelHash)
-		if next != provider.HashStatus {
-			tier2.LogProviderHashStatus(s.log, provider.ProviderID, provider.AssignedID, provider.ModelID, provider.ModelHash, next)
-		}
+		s.observeHashStatusTransition(provider.HashStatus, next, provider.ProviderID, provider.AssignedID, provider.ModelID, provider.ModelHash)
 		if cfg.RequireHashVerified && (next == pool.HashStatusUncatalogued || next == pool.HashStatusCatalogUnavailable) {
 			tier2.LogHashRequiredProviderExcluded(s.log, provider.ProviderID, provider.AssignedID, provider.ModelID, provider.ModelHash, next)
 		}
 		return next
 	})
+}
+
+func (s *Server) observeHashStatusTransition(prev, next pool.HashStatus, providerID, assignedID, modelID, reportedHash string) {
+	if next == prev {
+		return
+	}
+	tier2.LogProviderHashStatus(s.log, providerID, assignedID, modelID, reportedHash, next)
+	if next == pool.HashStatusMismatch && s.modelHashMismatchMetrics != nil {
+		s.modelHashMismatchMetrics.IncModelHashMismatch()
+	}
 }
 
 func (s *Server) tier2Config() config.Tier2Config {
@@ -1202,7 +1221,7 @@ func (s *Server) prepareProviderAdmission(conn net.Conn, auth providerAuth, hell
 	tier2Cfg := s.tier2Config()
 	if tier2.ModelHashActive(tier2Cfg) {
 		hashStatus = s.catalogRef().VerifyProviderHash(hello.ModelID, hello.ModelHash)
-		tier2.LogProviderHashStatus(s.log, hello.ProviderID, assignedID, hello.ModelID, hello.ModelHash, hashStatus)
+		s.observeHashStatusTransition("", hashStatus, hello.ProviderID, assignedID, hello.ModelID, hello.ModelHash)
 		if tier2Cfg.RequireHashVerified && (hashStatus == pool.HashStatusUncatalogued || hashStatus == pool.HashStatusCatalogUnavailable) {
 			tier2.LogHashRequiredProviderExcluded(s.log, hello.ProviderID, assignedID, hello.ModelID, hello.ModelHash, hashStatus)
 		}


### PR DESCRIPTION
## Summary
- Add `model_hash_mismatch_total` Prometheus counter on coordinator.
- Increment when a provider hash status transitions to `hash_mismatch` (WS hello + tier2 catalog reload refresh path).
- Update W1 inventory doc to mark the optional metric delivered.

## Test plan
- [x] `go test ./internal/ws/ -run TestObserveHashStatusTransition`
- [x] `go test ./internal/stats/metrics/`

Made with [Cursor](https://cursor.com)