### PR TITLE
Fix Tier2 relay sequencing for encrypted concurrency

### DIFF
--- a/phase3-binary/Sources/macprovider-cli/CoordinatorClient.swift
+++ b/phase3-binary/Sources/macprovider-cli/CoordinatorClient.swift
@@ -1328,6 +1328,9 @@ actor CoordinatorClient {
         else {
             throw CoordinatorAuthError.invalidMessage("auth_response missing matching encrypted_leg session")
         }
+        if encryptedLeg["response_chunk_plaintext_envelope"] as? Bool == true {
+            session.enableResponseChunkPlaintextEnvelope()
+        }
     }
 
     /// SPEC-003 v0.8.2 FR-C9.3 — extract `assigned_provider_token` from
@@ -2353,6 +2356,7 @@ actor CoordinatorClient {
                 "encrypted_leg": true,
                 "attestation": true,
                 "aead_suites": [Tier2ProviderSession.aeadSuite],
+                "response_chunk_plaintext_envelope": true,
             ],
         ]
         let resolvedCatalog: [String]

--- a/phase3-binary/Sources/macprovider-cli/InferenceRelay.swift
+++ b/phase3-binary/Sources/macprovider-cli/InferenceRelay.swift
@@ -810,7 +810,7 @@ actor InferenceRelay {
     ) async throws {
         if let tier2Session {
             let sealStart = clockMonotonicMicros()
-            let sealed = try tier2Session.sealResponseChunk(requestID: requestID, stream: stream, plaintext: data)
+            let sealed = try tier2Session.sealResponseChunk(requestID: requestID, stream: stream, seq: seq, plaintext: data)
             EgressPerfTraceKey.current?.recordSeal(durationMicros: clockMonotonicMicros() &- sealStart)
             try await sendFrame(sealed)
             return

--- a/phase3-binary/Sources/macprovider-cli/Tier2ProviderSession.swift
+++ b/phase3-binary/Sources/macprovider-cli/Tier2ProviderSession.swift
@@ -31,6 +31,7 @@ final class Tier2ProviderSession: @unchecked Sendable {
     let p2cNonceBase: Data
 
     private let lock = NSLock()
+    private var responseChunkPlaintextEnvelope = false
     private var c2pCounter: UInt64 = 0
     private var p2cCounter: UInt64 = 0
 
@@ -100,6 +101,12 @@ final class Tier2ProviderSession: @unchecked Sendable {
         )
     }
 
+    func enableResponseChunkPlaintextEnvelope() {
+        lock.lock()
+        responseChunkPlaintextEnvelope = true
+        lock.unlock()
+    }
+
     var countersForTest: (c2p: UInt64, p2c: UInt64) {
         lock.lock()
         defer { lock.unlock() }
@@ -146,10 +153,21 @@ final class Tier2ProviderSession: @unchecked Sendable {
         )
     }
 
-    func sealResponseChunk(requestID: String, stream: Bool, plaintext: String) throws -> [String: Any] {
+    func sealResponseChunk(requestID: String, stream: Bool, seq: Int, plaintext: String) throws -> [String: Any] {
         lock.lock()
         defer { lock.unlock() }
-        let seq = p2cCounter
+        let plaintextData: Data
+        if responseChunkPlaintextEnvelope {
+            let plaintextEnvelope: [String: Any] = [
+                "type": "inference_response_chunk_plaintext",
+                "seq": seq,
+                "data": plaintext,
+            ]
+            plaintextData = try JSONSerialization.data(withJSONObject: plaintextEnvelope, options: [.sortedKeys])
+        } else {
+            plaintextData = Data(plaintext.utf8)
+        }
+        let aeadSeq = p2cCounter
         let aad = Tier2FrameAAD(
             type: "inference_response_chunk",
             direction: "p2c",
@@ -157,15 +175,15 @@ final class Tier2ProviderSession: @unchecked Sendable {
             stream: stream,
             providerID: providerID,
             assignedID: assignedID,
-            seq: seq
+            seq: aeadSeq
         )
         let enc = try Self.sealEnvelope(
-            Data(plaintext.utf8),
+            plaintextData,
             key: p2cKey,
             nonceBase: p2cNonceBase,
             keyID: keyID,
             aad: aad,
-            seq: seq
+            seq: aeadSeq
         )
         p2cCounter += 1
         return [
@@ -256,7 +274,9 @@ final class Tier2ProviderSession: @unchecked Sendable {
             seq: seq
         )
         let plaintext = try openEnvelope(enc, key: session.p2cKey, nonceBase: session.p2cNonceBase, keyID: session.keyID, expectedAAD: aad, expectedSeq: seq)
-        guard let data = String(data: plaintext, encoding: .utf8) else {
+        guard let object = try? JSONSerialization.jsonObject(with: plaintext) as? [String: Any],
+              object["type"] as? String == "inference_response_chunk_plaintext",
+              let data = object["data"] as? String else {
             throw Tier2ProviderError.invalidPlaintext
         }
         return data

--- a/phase3-binary/Tests/macprovider-cliTests/CoordinatorClientTests.swift
+++ b/phase3-binary/Tests/macprovider-cliTests/CoordinatorClientTests.swift
@@ -470,6 +470,7 @@ final class CoordinatorClientTests: XCTestCase {
                     "enabled": true,
                     "alg": Tier2ProviderSession.aeadSuite,
                     "kid": "kid-test",
+                    "response_chunk_plaintext_envelope": true,
                 ],
             ],
         ], session: session)
@@ -477,6 +478,13 @@ final class CoordinatorClientTests: XCTestCase {
         let record = try XCTUnwrap(claimFile.read())
         XCTAssertEqual(record.pairOT, "PAIRV2")
         XCTAssertEqual(record.claimURL, "https://portal.example/claim?ot=PAIRV2")
+        let response = try session.sealResponseChunk(requestID: "req-ack", stream: false, seq: 0, plaintext: "ack-body")
+        XCTAssertEqual(try Tier2ProviderSession.openResponseChunkForTest(
+            session: session,
+            frame: response,
+            requestID: "req-ack",
+            stream: false
+        ), "ack-body")
     }
 
     func testOwnershipStatusNeedsClaim_WritesStubWithoutOpeningBrowser() async throws {
@@ -1587,6 +1595,7 @@ final class CoordinatorClientTests: XCTestCase {
         XCTAssertEqual(caps["encrypted_leg"] as? Bool, true)
         XCTAssertEqual(caps["attestation"] as? Bool, true)
         XCTAssertEqual(caps["aead_suites"] as? [String], [Tier2ProviderSession.aeadSuite])
+        XCTAssertEqual(caps["response_chunk_plaintext_envelope"] as? Bool, true)
     }
 
     func testAuthInitialIncludesReceiptPublicKeyWhenConfigured() async throws {

--- a/phase3-binary/Tests/macprovider-cliTests/InferenceRelayTests.swift
+++ b/phase3-binary/Tests/macprovider-cliTests/InferenceRelayTests.swift
@@ -855,7 +855,7 @@ private actor FakeCompletionRuntime: ModelRuntimeServing {
 }
 
 private func testTier2Session() throws -> Tier2ProviderSession {
-    try Tier2ProviderSession(
+    let session = try Tier2ProviderSession(
         providerID: "provider-test",
         assignedID: "assigned-test",
         selectedAEAD: Tier2ProviderSession.aeadSuite,
@@ -865,6 +865,8 @@ private func testTier2Session() throws -> Tier2ProviderSession {
         c2pNonceBase: Data([0x01, 0x02, 0x03, 0x04]),
         p2cNonceBase: Data([0x05, 0x06, 0x07, 0x08])
     )
+    session.enableResponseChunkPlaintextEnvelope()
+    return session
 }
 
 private func waitUntil(

--- a/phase3-binary/Tests/macprovider-cliTests/Tier2ProviderSessionTests.swift
+++ b/phase3-binary/Tests/macprovider-cliTests/Tier2ProviderSessionTests.swift
@@ -29,7 +29,8 @@ final class Tier2ProviderSessionTests: XCTestCase {
         XCTAssertEqual(try session.openRequestBody(message: request, requestID: "req-roundtrip", stream: true), "request-body")
         XCTAssertThrowsError(try session.openRequestBody(message: request, requestID: "req-roundtrip", stream: true))
 
-        let response = try session.sealResponseChunk(requestID: "req-roundtrip", stream: true, plaintext: "response-body")
+        session.enableResponseChunkPlaintextEnvelope()
+        let response = try session.sealResponseChunk(requestID: "req-roundtrip", stream: true, seq: 0, plaintext: "response-body")
         XCTAssertEqual(response["encrypted"] as? Bool, true)
         XCTAssertNil(response["data"])
         let responseEnc = try XCTUnwrap(response["enc"] as? [String: Any])
@@ -46,6 +47,37 @@ final class Tier2ProviderSessionTests: XCTestCase {
             ),
             "response-body"
         )
+    }
+
+    func testResponseChunkEnvelopeRequiresCoordinatorAcknowledgement() throws {
+        let session = try Tier2ProviderSession(
+            providerID: "provider-test",
+            assignedID: "assigned-test",
+            selectedAEAD: Tier2ProviderSession.aeadSuite,
+            keyID: "kid-test",
+            c2pKey: Data(repeating: 0x31, count: 32),
+            p2cKey: Data(repeating: 0x42, count: 32),
+            c2pNonceBase: Data([0x01, 0x02, 0x03, 0x04]),
+            p2cNonceBase: Data([0x05, 0x06, 0x07, 0x08])
+        )
+
+        let rawResponse = try session.sealResponseChunk(requestID: "req-raw", stream: false, seq: 7, plaintext: "raw-body")
+        XCTAssertThrowsError(try Tier2ProviderSession.openResponseChunkForTest(
+            session: session,
+            frame: rawResponse,
+            requestID: "req-raw",
+            stream: false
+        ))
+
+        session.enableResponseChunkPlaintextEnvelope()
+        let wrappedResponse = try session.sealResponseChunk(requestID: "req-wrapped", stream: false, seq: 7, plaintext: "wrapped-body")
+        XCTAssertEqual(try Tier2ProviderSession.openResponseChunkForTest(
+            session: session,
+            frame: wrappedResponse,
+            requestID: "req-wrapped",
+            stream: false,
+            seq: 1
+        ), "wrapped-body")
     }
 
     func testAADEncodingIsVersionedBinary() throws {

--- a/phase4-coordinator/internal/pool/provider.go
+++ b/phase4-coordinator/internal/pool/provider.go
@@ -268,16 +268,18 @@ func truncateUTF8Bytes(s string, maxBytes int) string {
 }
 
 type Tier2Session struct {
-	AEADSuite          string
-	C2PKey             []byte
-	P2CKey             []byte
-	C2PNonceBase       []byte
-	P2CNonceBase       []byte
-	C2PCounter         uint64
-	P2CCounter         uint64
-	RequestsDispatched uint64
-	KeyID              string
-	StartedAt          time.Time
+	AEADSuite                      string
+	ResponseChunkPlaintextEnvelope bool
+	C2PKey                         []byte
+	P2CKey                         []byte
+	C2PNonceBase                   []byte
+	P2CNonceBase                   []byte
+	C2PCounter                     uint64
+	P2CCounter                     uint64
+	P2CSeen                        map[uint64]struct{}
+	RequestsDispatched             uint64
+	KeyID                          string
+	StartedAt                      time.Time
 }
 
 type ReceiptPubkeyPrevious struct {

--- a/phase4-coordinator/internal/ws/messages.go
+++ b/phase4-coordinator/internal/ws/messages.go
@@ -90,9 +90,10 @@ type Spec010Presence struct {
 }
 
 type Tier2Caps struct {
-	EncryptedLeg bool     `json:"encrypted_leg"`
-	Attestation  bool     `json:"attestation"`
-	AEADSuites   []string `json:"aead_suites"`
+	EncryptedLeg                   bool     `json:"encrypted_leg"`
+	Attestation                    bool     `json:"attestation"`
+	AEADSuites                     []string `json:"aead_suites"`
+	ResponseChunkPlaintextEnvelope bool     `json:"response_chunk_plaintext_envelope,omitempty"`
 }
 
 type AuthChallenge struct {
@@ -148,11 +149,12 @@ type AuthTier2Session struct {
 }
 
 type AuthEncryptedLegSession struct {
-	Enabled            bool   `json:"enabled"`
-	Alg                string `json:"alg"`
-	KID                string `json:"kid"`
-	RekeyAfterRequests int    `json:"rekey_after_requests"`
-	RekeyAfterSeconds  int    `json:"rekey_after_seconds"`
+	Enabled                        bool   `json:"enabled"`
+	Alg                            string `json:"alg"`
+	KID                            string `json:"kid"`
+	RekeyAfterRequests             int    `json:"rekey_after_requests"`
+	RekeyAfterSeconds              int    `json:"rekey_after_seconds"`
+	ResponseChunkPlaintextEnvelope bool   `json:"response_chunk_plaintext_envelope,omitempty"`
 }
 
 type AuthAttestationSession struct {

--- a/phase4-coordinator/internal/ws/relay.go
+++ b/phase4-coordinator/internal/ws/relay.go
@@ -30,6 +30,10 @@ var (
 const retiredRelayRequestTTL = 5 * time.Minute
 const providerDispatchWriteProbeTimeout = 500 * time.Millisecond
 
+// Bound sparse p2c sequence gaps so multiplexed responses can arrive out of
+// order without giving an admitted provider an unbounded replay-cache sink.
+const tier2MaxOutOfOrderP2CFrames = 4096
+
 var relayEndFrameAADMismatchTotal atomic.Uint64
 var relayBufferExceededTotal atomic.Uint64
 
@@ -197,6 +201,18 @@ type encryptedInferenceResponseChunk struct {
 	RequestID string                 `json:"request_id,omitempty"`
 	Encrypted bool                   `json:"encrypted"`
 	Enc       tier2.AEADEnvelopeBody `json:"enc"`
+}
+
+type encryptedInferenceChunkPlaintext struct {
+	Type string `json:"type"`
+	Seq  int    `json:"seq"`
+	Data string `json:"data"`
+}
+
+type encryptedInferenceChunkPlaintextDecode struct {
+	Type string  `json:"type"`
+	Seq  *int    `json:"seq"`
+	Data *string `json:"data"`
 }
 
 type encryptedInferenceResponseEnd struct {
@@ -431,10 +447,10 @@ func (ps *providerSession) failActiveOrAll(requestID string, err error) {
 	ps.failActive(requestID, err)
 }
 
-func (ps *providerSession) cancelActive(requestID string, reason string, err error) {
+func (ps *providerSession) cancelActive(requestID string, reason string, err error) bool {
 	active, ok := ps.removeActive(requestID)
 	if !ok {
-		return
+		return false
 	}
 	b, _ := json.Marshal(CancelRequest{Type: "cancel_request", RequestID: requestID, Reason: reason})
 	_ = ps.send(b)
@@ -445,6 +461,7 @@ func (ps *providerSession) cancelActive(requestID string, reason string, err err
 		}
 	}
 	close(active.chunks)
+	return true
 }
 
 func (ps *providerSession) activeFor(requestID string) (*relayActive, bool) {
@@ -546,16 +563,16 @@ func (ps *providerSession) sealInferenceRequest(provider pool.Provider, requestI
 	})
 }
 
-func (ps *providerSession) openInferenceChunk(providerID, assignedID string, active *relayActive, envelope tier2.AEADEnvelope) (InferenceResponseChunk, error) {
+func (ps *providerSession) openInferenceChunk(providerID, assignedID string, active *relayActive, aad tier2.AEADFrameAAD, envelope tier2.AEADEnvelope) (InferenceResponseChunk, error) {
 	ps.tier2Mu.Lock()
 	defer ps.tier2Mu.Unlock()
 	if ps.tier2 == nil {
 		return InferenceResponseChunk{}, errors.New("encrypted chunk for provider without tier2 session")
 	}
-	if ps.tier2.P2CCounter == ^uint64(0) {
+	seq := aad.Seq
+	if seq == ^uint64(0) {
 		return InferenceResponseChunk{}, errors.New("tier2 p2c frame counter exhausted")
 	}
-	seq := ps.tier2.P2CCounter
 	expectedAAD := tier2.AEADFrameAAD{
 		Type:       "inference_response_chunk",
 		Direction:  "p2c",
@@ -565,29 +582,92 @@ func (ps *providerSession) openInferenceChunk(providerID, assignedID string, act
 		AssignedID: assignedID,
 		Seq:        seq,
 	}
+	if ps.tier2P2CSequenceOutsideWindow(seq) {
+		return InferenceResponseChunk{}, errors.New("tier2 p2c frame sequence outside receive window")
+	}
+	if ps.tier2P2CSequenceSeen(seq) {
+		return InferenceResponseChunk{}, errors.New("tier2 p2c frame replayed")
+	}
 	plaintext, err := tier2.OpenPillarBFrame(ps.tier2.P2CKey, ps.tier2.P2CNonceBase, ps.tier2.KeyID, seq, expectedAAD, envelope)
 	if err != nil {
 		return InferenceResponseChunk{}, err
 	}
-	ps.tier2.P2CCounter++
+	responseChunkPlaintextEnvelope := ps.tier2.ResponseChunkPlaintextEnvelope
+	ps.markTier2P2CSequenceSeen(seq)
+	chunk, err := decodeEncryptedInferenceChunkPlaintext(active.requestID, seq, responseChunkPlaintextEnvelope, plaintext)
+	if err != nil {
+		return InferenceResponseChunk{}, err
+	}
 	return InferenceResponseChunk{
 		Type:      "inference_response_chunk",
 		RequestID: active.requestID,
-		Seq:       int(seq),
+		Seq:       chunk.Seq,
+		Data:      chunk.Data,
+	}, nil
+}
+
+func decodeEncryptedInferenceChunkPlaintext(requestID string, legacySeq uint64, responseChunkPlaintextEnvelope bool, plaintext []byte) (InferenceResponseChunk, error) {
+	if !responseChunkPlaintextEnvelope {
+		return legacyEncryptedInferenceChunk(requestID, legacySeq, plaintext)
+	}
+	var fields map[string]json.RawMessage
+	if err := json.Unmarshal(plaintext, &fields); err != nil {
+		return InferenceResponseChunk{}, errors.New("encrypted chunk plaintext envelope must be valid JSON")
+	}
+	var plaintextType string
+	rawType, ok := fields["type"]
+	if !ok {
+		return InferenceResponseChunk{}, errors.New("encrypted chunk plaintext type is required")
+	}
+	if err := json.Unmarshal(rawType, &plaintextType); err != nil {
+		return InferenceResponseChunk{}, errors.New("encrypted chunk plaintext type must be a string")
+	}
+	if plaintextType != "inference_response_chunk_plaintext" {
+		return InferenceResponseChunk{}, errors.New("encrypted chunk plaintext type mismatch")
+	}
+	var envelope encryptedInferenceChunkPlaintextDecode
+	if err := json.Unmarshal(plaintext, &envelope); err != nil {
+		return InferenceResponseChunk{}, err
+	}
+	if envelope.Seq == nil {
+		return InferenceResponseChunk{}, errors.New("encrypted chunk plaintext seq is required")
+	}
+	if *envelope.Seq < 0 {
+		return InferenceResponseChunk{}, errors.New("encrypted chunk plaintext seq must be >= 0")
+	}
+	if envelope.Data == nil {
+		return InferenceResponseChunk{}, errors.New("encrypted chunk plaintext data is required")
+	}
+	return InferenceResponseChunk{
+		Type:      "inference_response_chunk",
+		RequestID: requestID,
+		Seq:       *envelope.Seq,
+		Data:      *envelope.Data,
+	}, nil
+}
+
+func legacyEncryptedInferenceChunk(requestID string, legacySeq uint64, plaintext []byte) (InferenceResponseChunk, error) {
+	if legacySeq > uint64(^uint(0)>>1) {
+		return InferenceResponseChunk{}, errors.New("legacy encrypted chunk seq overflows int")
+	}
+	return InferenceResponseChunk{
+		Type:      "inference_response_chunk",
+		RequestID: requestID,
+		Seq:       int(legacySeq),
 		Data:      string(plaintext),
 	}, nil
 }
 
-func (ps *providerSession) openInferenceEnd(providerID, assignedID string, active *relayActive, envelope tier2.AEADEnvelope) (InferenceResponseEnd, error) {
+func (ps *providerSession) openInferenceEnd(providerID, assignedID string, active *relayActive, aad tier2.AEADFrameAAD, envelope tier2.AEADEnvelope) (InferenceResponseEnd, error) {
 	ps.tier2Mu.Lock()
 	defer ps.tier2Mu.Unlock()
 	if ps.tier2 == nil {
 		return InferenceResponseEnd{}, errors.New("encrypted end for provider without tier2 session")
 	}
-	if ps.tier2.P2CCounter == ^uint64(0) {
+	seq := aad.Seq
+	if seq == ^uint64(0) {
 		return InferenceResponseEnd{}, errors.New("tier2 p2c frame counter exhausted")
 	}
-	seq := ps.tier2.P2CCounter
 	expectedAAD := tier2.AEADFrameAAD{
 		Type:       "inference_response_end",
 		Direction:  "p2c",
@@ -597,11 +677,17 @@ func (ps *providerSession) openInferenceEnd(providerID, assignedID string, activ
 		AssignedID: assignedID,
 		Seq:        seq,
 	}
+	if ps.tier2P2CSequenceOutsideWindow(seq) {
+		return InferenceResponseEnd{}, errors.New("tier2 p2c frame sequence outside receive window")
+	}
+	if ps.tier2P2CSequenceSeen(seq) {
+		return InferenceResponseEnd{}, errors.New("tier2 p2c frame replayed")
+	}
 	plaintext, err := tier2.OpenPillarBFrame(ps.tier2.P2CKey, ps.tier2.P2CNonceBase, ps.tier2.KeyID, seq, expectedAAD, envelope)
 	if err != nil {
 		return InferenceResponseEnd{}, err
 	}
-	ps.tier2.P2CCounter++
+	ps.markTier2P2CSequenceSeen(seq)
 	var end InferenceResponseEnd
 	if err := json.Unmarshal(plaintext, &end); err != nil {
 		return InferenceResponseEnd{}, err
@@ -615,7 +701,8 @@ func (ps *providerSession) consumeRetiredEncryptedFrame(providerID, assignedID s
 	if ps.tier2 == nil {
 		return errors.New("encrypted frame for provider without tier2 session")
 	}
-	if ps.tier2.P2CCounter == ^uint64(0) {
+	seq := aad.Seq
+	if seq == ^uint64(0) {
 		return errors.New("tier2 p2c frame counter exhausted")
 	}
 	if aad.Type != expectedType {
@@ -630,7 +717,6 @@ func (ps *providerSession) consumeRetiredEncryptedFrame(providerID, assignedID s
 	if aad.Stream != retired.stream {
 		return errors.New("tier2 retired frame stream mismatch")
 	}
-	seq := ps.tier2.P2CCounter
 	expectedAAD := tier2.AEADFrameAAD{
 		Type:       expectedType,
 		Direction:  "p2c",
@@ -640,11 +726,64 @@ func (ps *providerSession) consumeRetiredEncryptedFrame(providerID, assignedID s
 		AssignedID: assignedID,
 		Seq:        seq,
 	}
+	if ps.tier2P2CSequenceOutsideWindow(seq) {
+		return errors.New("tier2 p2c frame sequence outside receive window")
+	}
+	if ps.tier2P2CSequenceSeen(seq) {
+		return errors.New("tier2 p2c frame replayed")
+	}
 	if _, err := tier2.OpenPillarBFrame(ps.tier2.P2CKey, ps.tier2.P2CNonceBase, ps.tier2.KeyID, seq, expectedAAD, envelope); err != nil {
 		return err
 	}
-	ps.tier2.P2CCounter++
+	ps.markTier2P2CSequenceSeen(seq)
 	return nil
+}
+
+func (ps *providerSession) tier2P2CSequenceOutsideWindow(seq uint64) bool {
+	if ps.tier2 == nil || seq <= ps.tier2.P2CCounter {
+		return false
+	}
+	return seq-ps.tier2.P2CCounter > tier2MaxOutOfOrderP2CFrames
+}
+
+func (ps *providerSession) tier2P2CSequenceSeen(seq uint64) bool {
+	if ps.tier2 == nil {
+		return false
+	}
+	if seq < ps.tier2.P2CCounter {
+		return true
+	}
+	if ps.tier2.P2CSeen == nil {
+		return false
+	}
+	_, ok := ps.tier2.P2CSeen[seq]
+	return ok
+}
+
+func (ps *providerSession) markTier2P2CSequenceSeen(seq uint64) {
+	if ps.tier2 == nil {
+		return
+	}
+	if seq == ps.tier2.P2CCounter {
+		ps.tier2.P2CCounter++
+		for {
+			if ps.tier2.P2CSeen == nil {
+				return
+			}
+			if _, ok := ps.tier2.P2CSeen[ps.tier2.P2CCounter]; !ok {
+				return
+			}
+			delete(ps.tier2.P2CSeen, ps.tier2.P2CCounter)
+			ps.tier2.P2CCounter++
+		}
+	}
+	if seq < ps.tier2.P2CCounter {
+		return
+	}
+	if ps.tier2.P2CSeen == nil {
+		ps.tier2.P2CSeen = make(map[uint64]struct{})
+	}
+	ps.tier2.P2CSeen[seq] = struct{}{}
 }
 
 func (ps *providerSession) markTier2RequestDispatched() {
@@ -679,6 +818,15 @@ func (s *Server) closeProviderForTier2Rekey(session *providerSession, providerID
 	s.sessions.Delete(sessionKey(providerID, assignedID))
 	_ = session.conn.Close()
 	session.close()
+}
+
+func (s *Server) closeProviderForTier2RekeyIfDrained(session *providerSession, providerID, assignedID, requestID string) {
+	if session.hasActive() {
+		return
+	}
+	if reason, ok := session.tier2RekeyReason(s.now(), s.tier2Config()); ok {
+		s.closeProviderForTier2Rekey(session, providerID, assignedID, requestID, reason)
+	}
 }
 
 func (s *Server) closeProviderForTier2AEADFailure(session *providerSession, providerID, assignedID, requestID, reason string) {
@@ -740,15 +888,21 @@ func (s *Server) dispatchInference(ctx context.Context, provider pool.Provider, 
 		if reason == "" {
 			reason = "buyer_disconnected"
 		}
-		session.cancelActive(requestID, reason, nil)
+		if session.cancelActive(requestID, reason, nil) {
+			s.closeProviderForTier2RekeyIfDrained(session, provider.ProviderID, provider.AssignedID, requestID)
+		}
 	}
 	go func() {
 		<-ctx.Done()
 		switch {
 		case errors.Is(ctx.Err(), context.DeadlineExceeded):
-			session.cancelActive(requestID, "timeout", ErrRelayTimeout)
+			if session.cancelActive(requestID, "timeout", ErrRelayTimeout) {
+				s.closeProviderForTier2RekeyIfDrained(session, provider.ProviderID, provider.AssignedID, requestID)
+			}
 		default:
-			session.cancelActive(requestID, "buyer_disconnected", ErrRelayClosed)
+			if session.cancelActive(requestID, "buyer_disconnected", ErrRelayClosed) {
+				s.closeProviderForTier2RekeyIfDrained(session, provider.ProviderID, provider.AssignedID, requestID)
+			}
 		}
 	}()
 	chunks, done := active.delivered(ctx)
@@ -812,7 +966,7 @@ func (s *Server) handleInferenceChunk(providerID, assignedID string, payload []b
 			s.closeProviderForTier2AEADFailure(session, providerID, assignedID, requestID, "unknown encrypted inference_response_chunk request_id")
 			return
 		}
-		chunk, err = session.openInferenceChunk(providerID, assignedID, active, tier2.AEADEnvelope{Encrypted: true, Enc: envelope.Enc})
+		chunk, err = session.openInferenceChunk(providerID, assignedID, active, aad, tier2.AEADEnvelope{Encrypted: true, Enc: envelope.Enc})
 		if err != nil {
 			s.closeProviderForTier2AEADFailure(session, providerID, assignedID, requestID, err.Error())
 			return
@@ -846,7 +1000,9 @@ func (s *Server) handleInferenceChunk(providerID, assignedID string, payload []b
 	if s.relayChunkWouldExceed(active, len([]byte(chunk.Data))) {
 		relayBufferExceededTotal.Add(1)
 		s.log.Warn().Str("provider_id", providerID).Str("assigned_id", assignedID).Str("request_id", chunk.RequestID).Msg("relay buffer cap exceeded")
-		session.cancelActive(chunk.RequestID, "relay_buffer_exceeded", ErrRelayBufferExceeded)
+		if session.cancelActive(chunk.RequestID, "relay_buffer_exceeded", ErrRelayBufferExceeded) {
+			s.closeProviderForTier2RekeyIfDrained(session, providerID, assignedID, chunk.RequestID)
+		}
 		return
 	}
 	select {
@@ -858,6 +1014,7 @@ func (s *Server) handleInferenceChunk(providerID, assignedID string, payload []b
 			default:
 			}
 			close(active.chunks)
+			s.closeProviderForTier2RekeyIfDrained(session, providerID, assignedID, chunk.RequestID)
 		}
 	}
 }
@@ -912,7 +1069,7 @@ func (s *Server) handleInferenceEnd(providerID, assignedID string, payload []byt
 			s.closeProviderForTier2AEADFailure(session, providerID, assignedID, requestID, "unknown encrypted inference_response_end request_id")
 			return
 		}
-		opened, err := session.openInferenceEnd(providerID, assignedID, active, tier2.AEADEnvelope{Encrypted: true, Enc: envelope.Enc})
+		opened, err := session.openInferenceEnd(providerID, assignedID, active, aad, tier2.AEADEnvelope{Encrypted: true, Enc: envelope.Enc})
 		if err != nil {
 			s.closeProviderForTier2AEADFailure(session, providerID, assignedID, requestID, err.Error())
 			return
@@ -950,9 +1107,7 @@ func (s *Server) handleInferenceEnd(providerID, assignedID string, payload []byt
 	}
 	active.done <- end
 	close(active.chunks)
-	if reason, ok := session.tier2RekeyReason(s.now(), s.tier2Config()); ok {
-		s.closeProviderForTier2Rekey(session, providerID, assignedID, end.RequestID, reason)
-	}
+	s.closeProviderForTier2RekeyIfDrained(session, providerID, assignedID, end.RequestID)
 }
 
 func (s *Server) handleNAK(providerID, assignedID string, payload []byte) {
@@ -983,6 +1138,7 @@ func (s *Server) handleNAK(providerID, assignedID string, payload []byte) {
 		if active, found := session.removeActive(nak.InReplyTo); found {
 			active.errs <- ErrRelayNAKFallback
 			close(active.chunks)
+			s.closeProviderForTier2RekeyIfDrained(session, providerID, assignedID, nak.InReplyTo)
 		}
 	}
 	s.log.Warn().Str("provider_id", providerID).Str("in_reply_to", nak.InReplyTo).Str("code", nak.Error.Code).Msg("provider nak processed")

--- a/phase4-coordinator/internal/ws/relay_test.go
+++ b/phase4-coordinator/internal/ws/relay_test.go
@@ -722,6 +722,269 @@ func TestEncryptedRelayDecryptsResponseEnd(t *testing.T) {
 	}
 }
 
+func TestEncryptedRelayAcceptsOutOfOrderConcurrentP2CSequences(t *testing.T) {
+	s, provider, providerConn := newEncryptedRelayHarness(t)
+	provider.MaxConcurrency = 2
+	provider.SlotsFree = 2
+	provider.SlotsTotal = 2
+
+	relayA, err := s.DispatchInference(context.Background(), *provider, "req-a", []byte(`{"model":"model-a"}`), false)
+	if err != nil {
+		t.Fatalf("dispatch a: %v", err)
+	}
+	if _, _, err := wsutil.ReadServerData(providerConn); err != nil {
+		t.Fatalf("read encrypted inference_request a: %v", err)
+	}
+	relayB, err := s.DispatchInference(context.Background(), *provider, "req-b", []byte(`{"model":"model-a"}`), false)
+	if err != nil {
+		t.Fatalf("dispatch b: %v", err)
+	}
+	if _, _, err := wsutil.ReadServerData(providerConn); err != nil {
+		t.Fatalf("read encrypted inference_request b: %v", err)
+	}
+
+	s.handleInferenceChunk("p1", "s1", encryptedResponseChunkWithAppSeq(t, provider, "req-b", false, 1, 0, []byte(`{"request":"b"}`)))
+	select {
+	case chunk := <-relayB.Chunks:
+		if chunk.RequestID != "req-b" || chunk.Seq != 0 || chunk.Data != `{"request":"b"}` {
+			t.Fatalf("decrypted out-of-order chunk b = %#v", chunk)
+		}
+	case err := <-relayB.Errors:
+		t.Fatalf("relay b unexpected error: %v", err)
+	case <-time.After(time.Second):
+		t.Fatal("decrypted out-of-order chunk b timeout")
+	}
+
+	s.handleInferenceChunk("p1", "s1", encryptedResponseChunk(t, provider, "req-a", false, 0, []byte(`{"request":"a"}`)))
+	select {
+	case chunk := <-relayA.Chunks:
+		if chunk.RequestID != "req-a" || chunk.Seq != 0 || chunk.Data != `{"request":"a"}` {
+			t.Fatalf("decrypted lower-sequence chunk a = %#v", chunk)
+		}
+	case err := <-relayA.Errors:
+		t.Fatalf("relay a unexpected error: %v", err)
+	case <-time.After(time.Second):
+		t.Fatal("decrypted lower-sequence chunk a timeout")
+	}
+	if provider.Tier2Session.P2CCounter != 2 {
+		t.Fatalf("p2c contiguous counter = %d, want 2", provider.Tier2Session.P2CCounter)
+	}
+	if len(provider.Tier2Session.P2CSeen) != 0 {
+		t.Fatalf("p2c out-of-order gap count = %d, want 0", len(provider.Tier2Session.P2CSeen))
+	}
+}
+
+func TestEncryptedRelayDecryptsLegacyRawDataChunksWithAEADSequence(t *testing.T) {
+	s, provider, providerConn := newEncryptedRelayHarness(t)
+	provider.Tier2Session.ResponseChunkPlaintextEnvelope = false
+	relay, err := s.DispatchInference(context.Background(), *provider, "req-legacy-raw-chunk", []byte(`{"model":"model-a"}`), false)
+	if err != nil {
+		t.Fatalf("dispatch: %v", err)
+	}
+	if _, _, err := wsutil.ReadServerData(providerConn); err != nil {
+		t.Fatalf("read encrypted inference_request: %v", err)
+	}
+
+	s.handleInferenceChunk("p1", "s1", encryptedLegacyRawResponseChunk(t, provider, "req-legacy-raw-chunk", false, 0, []byte(`{"legacy":true}`)))
+	select {
+	case chunk := <-relay.Chunks:
+		if chunk.RequestID != "req-legacy-raw-chunk" || chunk.Seq != 0 || chunk.Data != `{"legacy":true}` {
+			t.Fatalf("legacy raw encrypted chunk = %#v", chunk)
+		}
+	case err := <-relay.Errors:
+		t.Fatalf("legacy raw encrypted chunk error: %v", err)
+	case <-time.After(time.Second):
+		t.Fatal("legacy raw encrypted chunk timeout")
+	}
+
+	s.handleInferenceChunk("p1", "s1", encryptedLegacyRawResponseChunk(t, provider, "req-legacy-raw-chunk", false, 1, []byte(`{"legacy":2}`)))
+	select {
+	case chunk := <-relay.Chunks:
+		if chunk.RequestID != "req-legacy-raw-chunk" || chunk.Seq != 1 || chunk.Data != `{"legacy":2}` {
+			t.Fatalf("second legacy raw encrypted chunk = %#v", chunk)
+		}
+	case err := <-relay.Errors:
+		t.Fatalf("second legacy raw encrypted chunk error: %v", err)
+	case <-time.After(time.Second):
+		t.Fatal("second legacy raw encrypted chunk timeout")
+	}
+}
+
+func TestEncryptedRelayLegacyRawDataPreservesWrapperShapedOutput(t *testing.T) {
+	s, provider, providerConn := newEncryptedRelayHarness(t)
+	provider.Tier2Session.ResponseChunkPlaintextEnvelope = false
+	relay, err := s.DispatchInference(context.Background(), *provider, "req-legacy-wrapper-shaped-chunk", []byte(`{"model":"model-a"}`), false)
+	if err != nil {
+		t.Fatalf("dispatch: %v", err)
+	}
+	if _, _, err := wsutil.ReadServerData(providerConn); err != nil {
+		t.Fatalf("read encrypted inference_request: %v", err)
+	}
+
+	raw := []byte(`{"type":"inference_response_chunk_plaintext","seq":5,"data":"x"}`)
+	s.handleInferenceChunk("p1", "s1", encryptedLegacyRawResponseChunk(t, provider, "req-legacy-wrapper-shaped-chunk", false, 0, raw))
+	select {
+	case chunk := <-relay.Chunks:
+		if chunk.RequestID != "req-legacy-wrapper-shaped-chunk" || chunk.Seq != 0 || chunk.Data != string(raw) {
+			t.Fatalf("legacy wrapper-shaped raw chunk = %#v", chunk)
+		}
+	case err := <-relay.Errors:
+		t.Fatalf("legacy wrapper-shaped raw chunk error: %v", err)
+	case <-time.After(time.Second):
+		t.Fatal("legacy wrapper-shaped raw chunk timeout")
+	}
+}
+
+func TestEncryptedRelayRejectsMalformedTypedChunkPlaintext(t *testing.T) {
+	s, provider, providerConn := newEncryptedRelayHarness(t)
+	relay, err := s.DispatchInference(context.Background(), *provider, "req-malformed-typed-chunk", []byte(`{"model":"model-a"}`), false)
+	if err != nil {
+		t.Fatalf("dispatch: %v", err)
+	}
+	if _, _, err := wsutil.ReadServerData(providerConn); err != nil {
+		t.Fatalf("read encrypted inference_request: %v", err)
+	}
+
+	s.handleInferenceChunk("p1", "s1", encryptedLegacyRawResponseChunk(t, provider, "req-malformed-typed-chunk", false, 0, []byte(`{"type":"inference_response_chunk_plaintext","data":"missing seq"}`)))
+	select {
+	case err := <-relay.Errors:
+		if err != ErrRelayAEADFailed {
+			t.Fatalf("err = %v, want ErrRelayAEADFailed", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("malformed typed chunk error timeout")
+	}
+	if _, ok := s.storedSessionFor("p1", "s1"); ok {
+		t.Fatal("session remained stored after malformed typed chunk plaintext")
+	}
+}
+
+func TestEncryptedRelayRejectsCapabilityTrueRawChunkPlaintext(t *testing.T) {
+	s, provider, providerConn := newEncryptedRelayHarness(t)
+	relay, err := s.DispatchInference(context.Background(), *provider, "req-cap-true-raw-chunk", []byte(`{"model":"model-a"}`), false)
+	if err != nil {
+		t.Fatalf("dispatch: %v", err)
+	}
+	if _, _, err := wsutil.ReadServerData(providerConn); err != nil {
+		t.Fatalf("read encrypted inference_request: %v", err)
+	}
+
+	s.handleInferenceChunk("p1", "s1", encryptedLegacyRawResponseChunk(t, provider, "req-cap-true-raw-chunk", false, 0, []byte(`{"raw":true}`)))
+	select {
+	case err := <-relay.Errors:
+		if err != ErrRelayAEADFailed {
+			t.Fatalf("err = %v, want ErrRelayAEADFailed", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("capability-true raw chunk error timeout")
+	}
+	if _, ok := s.storedSessionFor("p1", "s1"); ok {
+		t.Fatal("session remained stored after capability-true raw chunk plaintext")
+	}
+}
+
+func TestDecodeEncryptedInferenceChunkPlaintextRejectsMalformedTypedEnvelope(t *testing.T) {
+	tests := []struct {
+		name      string
+		plaintext []byte
+	}{
+		{
+			name:      "missing_seq",
+			plaintext: []byte(`{"type":"inference_response_chunk_plaintext","data":"x"}`),
+		},
+		{
+			name:      "wrong_seq_type",
+			plaintext: []byte(`{"type":"inference_response_chunk_plaintext","seq":"0","data":"x"}`),
+		},
+		{
+			name:      "negative_seq",
+			plaintext: []byte(`{"type":"inference_response_chunk_plaintext","seq":-1,"data":"x"}`),
+		},
+		{
+			name:      "missing_data",
+			plaintext: []byte(`{"type":"inference_response_chunk_plaintext","seq":0}`),
+		},
+		{
+			name:      "wrong_data_type",
+			plaintext: []byte(`{"type":"inference_response_chunk_plaintext","seq":0,"data":{}}`),
+		},
+		{
+			name:      "raw_json",
+			plaintext: []byte(`{"raw":true}`),
+		},
+		{
+			name:      "non_json",
+			plaintext: []byte(`raw`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if _, err := decodeEncryptedInferenceChunkPlaintext("req-malformed", 9, true, tt.plaintext); err == nil {
+				t.Fatal("decode succeeded for malformed typed envelope")
+			}
+		})
+	}
+}
+
+func TestEncryptedRelayRejectsReplayedP2CSequence(t *testing.T) {
+	s, provider, providerConn := newEncryptedRelayHarness(t)
+	relay, err := s.DispatchInference(context.Background(), *provider, "req-replay", []byte(`{"model":"model-a"}`), false)
+	if err != nil {
+		t.Fatalf("dispatch: %v", err)
+	}
+	if _, _, err := wsutil.ReadServerData(providerConn); err != nil {
+		t.Fatalf("read encrypted inference_request: %v", err)
+	}
+
+	first := encryptedResponseChunk(t, provider, "req-replay", false, 0, []byte(`{"ok":true}`))
+	s.handleInferenceChunk("p1", "s1", first)
+	select {
+	case <-relay.Chunks:
+	case err := <-relay.Errors:
+		t.Fatalf("unexpected first-frame error: %v", err)
+	case <-time.After(time.Second):
+		t.Fatal("first chunk timeout")
+	}
+
+	s.handleInferenceChunk("p1", "s1", first)
+	select {
+	case err := <-relay.Errors:
+		if err != ErrRelayAEADFailed {
+			t.Fatalf("err = %v, want ErrRelayAEADFailed", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("replay error timeout")
+	}
+}
+
+func TestEncryptedRelayRejectsSparseP2CSequenceGap(t *testing.T) {
+	s, provider, providerConn := newEncryptedRelayHarness(t)
+	relay, err := s.DispatchInference(context.Background(), *provider, "req-sparse-gap", []byte(`{"model":"model-a"}`), false)
+	if err != nil {
+		t.Fatalf("dispatch: %v", err)
+	}
+	if _, _, err := wsutil.ReadServerData(providerConn); err != nil {
+		t.Fatalf("read encrypted inference_request: %v", err)
+	}
+
+	s.handleInferenceChunk("p1", "s1", encryptedResponseChunk(t, provider, "req-sparse-gap", false, tier2MaxOutOfOrderP2CFrames+1, []byte(`{"ok":true}`)))
+	select {
+	case err := <-relay.Errors:
+		if err != ErrRelayAEADFailed {
+			t.Fatalf("err = %v, want ErrRelayAEADFailed", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("sparse sequence gap error timeout")
+	}
+	if _, ok := s.storedSessionFor("p1", "s1"); ok {
+		t.Fatal("session remained stored after sparse sequence gap")
+	}
+	if len(provider.Tier2Session.P2CSeen) != 0 {
+		t.Fatalf("p2c seen count = %d, want 0 after rejected sparse gap", len(provider.Tier2Session.P2CSeen))
+	}
+}
+
 func TestEncryptedRelayRoutesEndByAADWhenPlaintextRequestIDDiffers(t *testing.T) {
 	s, provider, providerConn := newEncryptedRelayHarness(t)
 	relay, err := s.DispatchInference(context.Background(), *provider, "req-aad", []byte(`{"model":"model-a"}`), false)
@@ -937,6 +1200,35 @@ func TestEncryptedRelayDropsLateEndForRetiredRequest(t *testing.T) {
 	}
 }
 
+func TestEncryptedRelayRejectsSparseLateRetiredP2CSequenceGap(t *testing.T) {
+	s, provider, providerConn := newEncryptedRelayHarness(t)
+	relay, err := s.DispatchInference(context.Background(), *provider, "req-late-sparse-gap", []byte(`{"model":"model-a"}`), false)
+	if err != nil {
+		t.Fatalf("dispatch: %v", err)
+	}
+	if _, _, err := wsutil.ReadServerData(providerConn); err != nil {
+		t.Fatalf("read encrypted inference_request: %v", err)
+	}
+	relay.Cancel("buyer_disconnected")
+	if _, _, err := wsutil.ReadServerData(providerConn); err != nil {
+		t.Fatalf("read cancel_request: %v", err)
+	}
+
+	s.handleInferenceEnd("p1", "s1", encryptedResponseEnd(t, provider, "req-late-sparse-gap", false, tier2MaxOutOfOrderP2CFrames+1, InferenceResponseEnd{
+		Type:       "inference_response_end",
+		RequestID:  "req-late-sparse-gap",
+		Status:     "complete",
+		ChunksSent: 0,
+	}))
+
+	if _, ok := s.storedSessionFor("p1", "s1"); ok {
+		t.Fatal("session remained stored after sparse retired sequence gap")
+	}
+	if len(provider.Tier2Session.P2CSeen) != 0 {
+		t.Fatalf("p2c seen count = %d, want 0 after rejected retired sparse gap", len(provider.Tier2Session.P2CSeen))
+	}
+}
+
 func TestEncryptedRelayDropsLateChunkForRetiredRequest(t *testing.T) {
 	var logs bytes.Buffer
 	s, provider, providerConn := newEncryptedRelayHarnessWithConfig(t, config.Default(), zerolog.New(&logs), time.Now())
@@ -1053,42 +1345,119 @@ func TestEncryptedRelayRekeysAfterRequestThreshold(t *testing.T) {
 func TestEncryptedRelayDefersRekeyCloseUntilActiveCompletes(t *testing.T) {
 	var logs bytes.Buffer
 	cfg := config.Default()
-	cfg.Tier2.EncryptedLegRekeyAfterRequests = 1
+	cfg.Tier2.EncryptedLegRekeyAfterRequests = 2
 	s, provider, providerConn := newEncryptedRelayHarnessWithConfig(t, cfg, zerolog.New(&logs), time.Now())
 	provider.MaxConcurrency = 2
 
-	relay, err := s.DispatchInference(context.Background(), *provider, "req-rekey-active", []byte(`{"model":"model-a"}`), false)
+	relayA, err := s.DispatchInference(context.Background(), *provider, "req-rekey-active-a", []byte(`{"model":"model-a"}`), false)
 	if err != nil {
 		t.Fatalf("first dispatch: %v", err)
 	}
 	if _, _, err := wsutil.ReadServerData(providerConn); err != nil {
-		t.Fatalf("read encrypted inference_request: %v", err)
+		t.Fatalf("read encrypted inference_request a: %v", err)
 	}
-	if _, err := s.DispatchInference(context.Background(), *provider, "req-rekey-second", []byte(`{"model":"model-a"}`), false); err != ErrRelayBackpressure {
-		t.Fatalf("second dispatch = %v, want ErrRelayBackpressure while first request drains", err)
+	relayB, err := s.DispatchInference(context.Background(), *provider, "req-rekey-active-b", []byte(`{"model":"model-a"}`), false)
+	if err != nil {
+		t.Fatalf("second dispatch: %v", err)
+	}
+	if _, _, err := wsutil.ReadServerData(providerConn); err != nil {
+		t.Fatalf("read encrypted inference_request b: %v", err)
+	}
+	if _, err := s.DispatchInference(context.Background(), *provider, "req-rekey-third", []byte(`{"model":"model-a"}`), false); err != ErrRelayBackpressure {
+		t.Fatalf("third dispatch = %v, want ErrRelayBackpressure while active requests drain", err)
 	}
 	if _, ok := s.storedSessionFor("p1", "s1"); !ok {
-		t.Fatal("session closed before active request completed")
+		t.Fatal("session closed before active requests completed")
 	}
 
-	s.handleInferenceChunk("p1", "s1", encryptedResponseChunk(t, provider, "req-rekey-active", false, 0, []byte(`{"ok":true}`)))
+	s.handleInferenceChunk("p1", "s1", encryptedResponseChunk(t, provider, "req-rekey-active-a", false, 0, []byte(`{"a":true}`)))
 	select {
-	case <-relay.Chunks:
+	case <-relayA.Chunks:
 	case <-time.After(time.Second):
-		t.Fatal("chunk timeout")
+		t.Fatal("chunk a timeout")
 	}
-	s.handleInferenceEnd("p1", "s1", encryptedResponseEnd(t, provider, "req-rekey-active", false, 1, InferenceResponseEnd{Type: "inference_response_end", RequestID: "req-rekey-active", Status: "complete", ChunksSent: 1}))
+	s.handleInferenceEnd("p1", "s1", encryptedResponseEnd(t, provider, "req-rekey-active-a", false, 1, InferenceResponseEnd{Type: "inference_response_end", RequestID: "req-rekey-active-a", Status: "complete", ChunksSent: 1}))
 
 	select {
-	case end := <-relay.Done:
+	case end := <-relayA.Done:
 		if end.Status != "complete" {
 			t.Fatalf("end = %#v", end)
 		}
 	case <-time.After(time.Second):
-		t.Fatal("end timeout")
+		t.Fatal("end a timeout")
 	}
+	if _, ok := s.storedSessionFor("p1", "s1"); !ok {
+		t.Fatal("session closed before second active request completed")
+	}
+
+	s.handleInferenceChunk("p1", "s1", encryptedResponseChunk(t, provider, "req-rekey-active-b", false, 2, []byte(`{"b":true}`)))
+	select {
+	case <-relayB.Chunks:
+	case <-time.After(time.Second):
+		t.Fatal("chunk b timeout")
+	}
+	s.handleInferenceEnd("p1", "s1", encryptedResponseEnd(t, provider, "req-rekey-active-b", false, 3, InferenceResponseEnd{Type: "inference_response_end", RequestID: "req-rekey-active-b", Status: "complete", ChunksSent: 1}))
+
+	select {
+	case end := <-relayB.Done:
+		if end.Status != "complete" {
+			t.Fatalf("end = %#v", end)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("end b timeout")
+	}
+
 	if _, ok := s.storedSessionFor("p1", "s1"); ok {
 		t.Fatal("session still stored after drained rekey")
+	}
+	if !bytes.Contains(logs.Bytes(), []byte(`"event":"aead_rekey"`)) || !bytes.Contains(logs.Bytes(), []byte(`"reason":"request_threshold"`)) {
+		t.Fatalf("missing request-threshold rekey log: %s", logs.String())
+	}
+}
+
+func TestEncryptedRelayClosesDrainedRekeyAfterActiveCancel(t *testing.T) {
+	var logs bytes.Buffer
+	cfg := config.Default()
+	cfg.Tier2.EncryptedLegRekeyAfterRequests = 2
+	s, provider, providerConn := newEncryptedRelayHarnessWithConfig(t, cfg, zerolog.New(&logs), time.Now())
+	provider.MaxConcurrency = 2
+
+	relayA, err := s.DispatchInference(context.Background(), *provider, "req-rekey-cancel-a", []byte(`{"model":"model-a"}`), false)
+	if err != nil {
+		t.Fatalf("first dispatch: %v", err)
+	}
+	if _, _, err := wsutil.ReadServerData(providerConn); err != nil {
+		t.Fatalf("read encrypted inference_request a: %v", err)
+	}
+	relayB, err := s.DispatchInference(context.Background(), *provider, "req-rekey-cancel-b", []byte(`{"model":"model-a"}`), false)
+	if err != nil {
+		t.Fatalf("second dispatch: %v", err)
+	}
+	if _, _, err := wsutil.ReadServerData(providerConn); err != nil {
+		t.Fatalf("read encrypted inference_request b: %v", err)
+	}
+	if _, err := s.DispatchInference(context.Background(), *provider, "req-rekey-cancel-third", []byte(`{"model":"model-a"}`), false); err != ErrRelayBackpressure {
+		t.Fatalf("third dispatch = %v, want ErrRelayBackpressure while active requests drain", err)
+	}
+
+	relayA.Cancel("buyer_disconnected")
+	if _, _, err := wsutil.ReadServerData(providerConn); err != nil {
+		t.Fatalf("read cancel_request a: %v", err)
+	}
+	if _, ok := s.storedSessionFor("p1", "s1"); !ok {
+		t.Fatal("session closed before second active request canceled")
+	}
+
+	relayB.Cancel("buyer_disconnected")
+	if _, ok := s.storedSessionFor("p1", "s1"); ok {
+		t.Fatal("session still stored after drained rekey cancel")
+	}
+	got, ok := s.pool.Resolve("p1", "s1")
+	if !ok {
+		t.Fatal("provider not found")
+	}
+	if got.State != pool.StateUnavailable {
+		t.Fatalf("state = %s, want unavailable", got.State)
 	}
 	if !bytes.Contains(logs.Bytes(), []byte(`"event":"aead_rekey"`)) || !bytes.Contains(logs.Bytes(), []byte(`"reason":"request_threshold"`)) {
 		t.Fatalf("missing request-threshold rekey log: %s", logs.String())
@@ -1565,13 +1934,14 @@ func newEncryptedRelayHarnessWithConfig(t *testing.T, cfg config.Config, logger 
 		_ = serverConn.Close()
 	})
 	tier2Session := &pool.Tier2Session{
-		AEADSuite:    tier2.PillarBAEADA256GCM,
-		C2PKey:       bytes.Repeat([]byte{0x11}, 32),
-		P2CKey:       bytes.Repeat([]byte{0x22}, 32),
-		C2PNonceBase: []byte{0x01, 0x02, 0x03, 0x04},
-		P2CNonceBase: []byte{0x05, 0x06, 0x07, 0x08},
-		KeyID:        "test-kid",
-		StartedAt:    startedAt,
+		AEADSuite:                      tier2.PillarBAEADA256GCM,
+		ResponseChunkPlaintextEnvelope: true,
+		C2PKey:                         bytes.Repeat([]byte{0x11}, 32),
+		P2CKey:                         bytes.Repeat([]byte{0x22}, 32),
+		C2PNonceBase:                   []byte{0x01, 0x02, 0x03, 0x04},
+		P2CNonceBase:                   []byte{0x05, 0x06, 0x07, 0x08},
+		KeyID:                          "test-kid",
+		StartedAt:                      startedAt,
 	}
 	provider := &pool.Provider{
 		ProviderID:     "p1",
@@ -1597,6 +1967,21 @@ func newEncryptedRelayHarnessWithConfig(t *testing.T, cfg config.Config, logger 
 }
 
 func encryptedResponseChunk(t *testing.T, provider *pool.Provider, requestID string, stream bool, seq uint64, plaintext []byte) []byte {
+	t.Helper()
+	return encryptedResponseChunkWithAppSeq(t, provider, requestID, stream, seq, int(seq), plaintext)
+}
+
+func encryptedResponseChunkWithAppSeq(t *testing.T, provider *pool.Provider, requestID string, stream bool, seq uint64, appSeq int, plaintext []byte) []byte {
+	t.Helper()
+	wrapped := mustJSON(encryptedInferenceChunkPlaintext{
+		Type: "inference_response_chunk_plaintext",
+		Seq:  appSeq,
+		Data: string(plaintext),
+	})
+	return encryptedLegacyRawResponseChunk(t, provider, requestID, stream, seq, wrapped)
+}
+
+func encryptedLegacyRawResponseChunk(t *testing.T, provider *pool.Provider, requestID string, stream bool, seq uint64, plaintext []byte) []byte {
 	t.Helper()
 	aad := tier2.AEADFrameAAD{
 		Type:       "inference_response_chunk",

--- a/phase4-coordinator/internal/ws/server.go
+++ b/phase4-coordinator/internal/ws/server.go
@@ -86,17 +86,17 @@ type Server struct {
 	// catalog holds an explicitly-injected tier2.Catalog for tests that
 	// want isolation from the package-singleton; nil means "use
 	// tier2.Default()". M3-8d (audit TEST-4). See s.catalogRef().
-	catalog            *tier2.Catalog
-	autotuneCatalog    *autotune.Catalog
-	autotuneEvidence   autotune.EvidenceStore
-	telemetryDrift     *pow.Evaluator
-	identitySignatures IdentitySignatureStore
-	authPolicyAdmin    ProviderAuthPolicyAdminStore
-	idlePrewarm        IdlePrewarmRecorder
-	idlePrewarmMetrics IdlePrewarmMetrics
+	catalog                  *tier2.Catalog
+	autotuneCatalog          *autotune.Catalog
+	autotuneEvidence         autotune.EvidenceStore
+	telemetryDrift           *pow.Evaluator
+	identitySignatures       IdentitySignatureStore
+	authPolicyAdmin          ProviderAuthPolicyAdminStore
+	idlePrewarm              IdlePrewarmRecorder
+	idlePrewarmMetrics       IdlePrewarmMetrics
 	modelHashMismatchMetrics ModelHashMismatchMetrics
-	idlePrewarmLimits  sync.Map
-	idlePrewarmQueue   chan idlePrewarmRecord
+	idlePrewarmLimits        sync.Map
+	idlePrewarmQueue         chan idlePrewarmRecord
 }
 
 // TokenValidator handles inspection of a Bearer header on the WS connect.
@@ -1073,13 +1073,14 @@ func (s *Server) handleV2Conn(conn net.Conn, auth providerAuth, payload []byte, 
 	}
 	entry.PublishesSupportedModels = initial.PublishesSupportedModels
 	entry.Tier2Session = &pool.Tier2Session{
-		AEADSuite:    selectedAEAD,
-		C2PKey:       keys.C2PKey,
-		P2CKey:       keys.P2CKey,
-		C2PNonceBase: keys.C2PNonceBase,
-		P2CNonceBase: keys.P2CNonceBase,
-		KeyID:        keys.KeyID,
-		StartedAt:    s.now(),
+		AEADSuite:                      selectedAEAD,
+		ResponseChunkPlaintextEnvelope: initial.Tier2Capabilities.ResponseChunkPlaintextEnvelope,
+		C2PKey:                         keys.C2PKey,
+		P2CKey:                         keys.P2CKey,
+		C2PNonceBase:                   keys.C2PNonceBase,
+		P2CNonceBase:                   keys.P2CNonceBase,
+		KeyID:                          keys.KeyID,
+		StartedAt:                      s.now(),
 	}
 	if retainAuthAttempt {
 		// SPEC-002 v1.3.5 §7.9 — explicit early release so the
@@ -1130,11 +1131,12 @@ func (s *Server) handleV2Conn(conn net.Conn, auth providerAuth, payload []byte, 
 		ClaimURL:                  claimURL,
 		Tier2Session: &AuthTier2Session{
 			EncryptedLeg: AuthEncryptedLegSession{
-				Enabled:            true,
-				Alg:                selectedAEAD,
-				KID:                keys.KeyID,
-				RekeyAfterRequests: tier2Cfg.EncryptedLegRekeyAfterRequests,
-				RekeyAfterSeconds:  tier2Cfg.EncryptedLegRekeyAfterSeconds,
+				Enabled:                        true,
+				Alg:                            selectedAEAD,
+				KID:                            keys.KeyID,
+				RekeyAfterRequests:             tier2Cfg.EncryptedLegRekeyAfterRequests,
+				RekeyAfterSeconds:              tier2Cfg.EncryptedLegRekeyAfterSeconds,
+				ResponseChunkPlaintextEnvelope: initial.Tier2Capabilities.ResponseChunkPlaintextEnvelope,
 			},
 			Attestation: AuthAttestationSession{
 				Status:          string(attestationStatus),

--- a/phase4-coordinator/internal/ws/server_test.go
+++ b/phase4-coordinator/internal/ws/server_test.go
@@ -283,6 +283,9 @@ func TestProviderAuthV2RegistersEncryptedSession(t *testing.T) {
 	if response.Tier2Session == nil || !response.Tier2Session.EncryptedLeg.Enabled || response.Tier2Session.EncryptedLeg.KID != challenge.KeyID || response.Tier2Session.Attestation.Status != string(pool.AttestationStatusUnsupported) {
 		t.Fatalf("tier2 auth_response session = %+v", response.Tier2Session)
 	}
+	if !response.Tier2Session.EncryptedLeg.ResponseChunkPlaintextEnvelope {
+		t.Fatal("auth_response did not select response_chunk_plaintext_envelope")
+	}
 	eventually(t, func() bool {
 		provider, ok := h.Registry.Resolve("m4-anon", challenge.AssignedID)
 		return ok &&
@@ -290,6 +293,7 @@ func TestProviderAuthV2RegistersEncryptedSession(t *testing.T) {
 			provider.AttestationStatus == pool.AttestationStatusUnsupported &&
 			provider.ModelLoadTimeMs == 1234 &&
 			provider.Tier2Session != nil &&
+			provider.Tier2Session.ResponseChunkPlaintextEnvelope &&
 			provider.Tier2Session.KeyID == challenge.KeyID &&
 			len(provider.Tier2Session.C2PKey) == 32 &&
 			provider.InferencePath == pool.InferencePathWSTunneled
@@ -3606,9 +3610,10 @@ func validAuthInitial(providerID, providerPublic string) map[string]any {
 	delete(h, "attestation")
 	h["provider_ecdh_public_key"] = providerPublic
 	h["tier2_capabilities"] = map[string]any{
-		"encrypted_leg": true,
-		"attestation":   true,
-		"aead_suites":   []string{tier2.PillarBAEADA256GCM},
+		"encrypted_leg":                     true,
+		"attestation":                       true,
+		"aead_suites":                       []string{tier2.PillarBAEADA256GCM},
+		"response_chunk_plaintext_envelope": true,
 	}
 	return h
 }


### PR DESCRIPTION
## What changed

- Fixed Tier2 encrypted relay handling so session-global AEAD p2c frames can arrive out of order under concurrent provider responses.
- Added a bounded sparse replay window (`4096`) with replay rejection and gap cleanup after contiguous advancement.
- Negotiated `response_chunk_plaintext_envelope` through `auth_request`/`auth_response` so new providers carry per-request app chunk `seq` inside authenticated plaintext only after coordinator acknowledgement.
- Preserved cap-false legacy raw encrypted chunk behavior, including wrapper-shaped model output.
- Deferred request-threshold rekey close until all active requests drain, including cancel/error removal paths.

## Why

Issue #379 live capacity/config raised qwen3-coder capacity to eight slots, but concurrent encrypted responses could be sealed/sent in valid non-contiguous AEAD order. The coordinator previously expected strict arrival order, causing `tier2_aead_decrypt_failed`, provider disconnects, and failed concurrent live requests.

Closes #379.

## Validation

- `git diff --check`
- `go test ./... -count=1` in `phase4-coordinator`
- `go test -race ./internal/ws -run 'TestEncryptedRelay(...)|TestDecodeEncryptedInferenceChunkPlaintextRejectsMalformedTypedEnvelope|TestProviderAuth' -count=1`
- `go vet ./...` in `phase4-coordinator`
- `swift test --package-path phase3-binary --filter 'Tier2ProviderSessionTests|InferenceRelayTests|CoordinatorClientTests/testAuthInitialUsesV2EncryptedLegCapabilitiesAndModelHash|CoordinatorClientTests/testAcceptedAuthResponsePairingMaterial_WritesClaimURL'`
- `FORCE_DIRTY=1 ./scripts/build-linux.sh` in `phase4-coordinator`
- 3 audit lanes rerun to 0 Critical/High/Medium findings: code correctness, security, architecture
