### PR TITLE
Fix v2 provider auth version compatibility

### DIFF
--- a/phase4-coordinator/internal/ws/messages.go
+++ b/phase4-coordinator/internal/ws/messages.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"math"
+	"strconv"
 	"strings"
 
 	"github.com/augstar/macprovider-coordinator/internal/config"
@@ -421,7 +422,7 @@ func ParseFirstAuthMessage(payload []byte) (string, int, error) {
 		return "", 0, err
 	}
 	var version int
-	if err := requireInt(raw, "version", &version); err != nil {
+	if err := requireAuthVersion(raw, &version); err != nil {
 		return "", 0, err
 	}
 	return typ, version, nil
@@ -439,7 +440,7 @@ func ParseAuthRequest(payload []byte) (AuthRequest, Spec010Presence, string, err
 	if req.Type != "auth_request" {
 		return AuthRequest{}, Spec010Presence{}, "type", fmt.Errorf("expected auth_request, got %q", req.Type)
 	}
-	if err := requireInt(raw, "version", &req.Version); err != nil {
+	if err := requireAuthVersion(raw, &req.Version); err != nil {
 		return AuthRequest{}, Spec010Presence{}, err.Field, err
 	}
 	if req.Version != 2 {
@@ -726,6 +727,26 @@ func requireInt(raw map[string]json.RawMessage, field string, out *int) *fieldEr
 	if err := json.Unmarshal(v, out); err != nil {
 		return &fieldError{Field: field}
 	}
+	return nil
+}
+
+func requireAuthVersion(raw map[string]json.RawMessage, out *int) *fieldError {
+	v, ok := raw["version"]
+	if !ok {
+		return &fieldError{Field: "missing version"}
+	}
+	if err := json.Unmarshal(v, out); err == nil {
+		return nil
+	}
+	var s string
+	if err := json.Unmarshal(v, &s); err != nil || s == "" {
+		return &fieldError{Field: "version"}
+	}
+	parsed, err := strconv.Atoi(s)
+	if err != nil {
+		return &fieldError{Field: "version"}
+	}
+	*out = parsed
 	return nil
 }
 

--- a/phase4-coordinator/internal/ws/messages_test.go
+++ b/phase4-coordinator/internal/ws/messages_test.go
@@ -369,6 +369,27 @@ func TestParseAuthInitialAcceptsLegacyAbsentSpec010(t *testing.T) {
 	}
 }
 
+func TestParseAuthInitialAcceptsNumericStringVersion(t *testing.T) {
+	payload := validAuthRequestInitial()
+	payload["version"] = "2"
+
+	typ, version, err := ParseFirstAuthMessage(mustAuthJSON(t, payload))
+	if err != nil {
+		t.Fatalf("ParseFirstAuthMessage err=%v", err)
+	}
+	if typ != "auth_request" || version != 2 {
+		t.Fatalf("first auth = (%q, %d), want auth_request 2", typ, version)
+	}
+
+	req, _, field, err := ParseAuthRequest(mustAuthJSON(t, payload))
+	if err != nil {
+		t.Fatalf("ParseAuthRequest field=%q err=%v", field, err)
+	}
+	if req.Version != 2 {
+		t.Fatalf("Version = %d, want 2", req.Version)
+	}
+}
+
 func TestParseAuthInitialAcceptsProviderReceiptPublicKey(t *testing.T) {
 	payload := validAuthRequestInitial()
 	pubkey := bytesOf(0x42, 32)

--- a/phase4-coordinator/internal/ws/server.go
+++ b/phase4-coordinator/internal/ws/server.go
@@ -860,6 +860,7 @@ func (s *Server) handleV2Conn(conn net.Conn, auth providerAuth, payload []byte, 
 		if badField == "" {
 			badField = "stage"
 		}
+		s.log.Warn().Str("bad_field", badField).Msg("provider auth_request initial rejected")
 		// SPEC-002 v1.3.5 §11 AC-K.15 / SPEC-010 v1.5 R-3.1.9 — when
 		// initial-stage parse fails on a SPEC-010 catalog validation
 		// rule, surface the LOCKED reason substring on the wire so


### PR DESCRIPTION
## Summary
- accept numeric-string top-level auth_request.version values while still enforcing decoded v2
- keep normal capacity/heartbeat numeric fields strict
- add bounded bad_field logging for rejected v2 initial auth requests without logging raw unauthenticated parse errors

## Context
PR #500 deployed the Tier2 encrypted concurrency fix, but the live provider is rejected before joining the pool with unrecognized auth message. This hotfix restores compatibility for providers that encode the auth envelope version as a JSON string.

## Validation
- go test ./internal/ws targeted auth compatibility tests
- go test ./... -count=1 in phase4-coordinator
- go vet ./... in phase4-coordinator
- git diff --check
- three audit lanes: code 0 C/H/M, security 0 C/H/M after logging fix, architecture 0 C/H/M

Follow-up to #500 / #379 live deploy validation.