### PR TITLE
Log proof-stage auth parser field for live diagnostics

### DIFF
--- a/phase4-coordinator/internal/ws/server.go
+++ b/phase4-coordinator/internal/ws/server.go
@@ -988,6 +988,7 @@ func (s *Server) handleV2Conn(conn net.Conn, auth providerAuth, payload []byte, 
 		if badField == "" {
 			badField = "stage"
 		}
+		s.log.Warn().Str("bad_field", badField).Msg("provider auth_request proof rejected")
 		s.sendAuthRejection(conn, "invalid_auth_request", "invalid auth_request")
 		s.close(conn, CloseInvalidHello, "invalid_auth_request: "+badField)
 		return "", ""


### PR DESCRIPTION
Adds bounded proof-stage auth_request parser diagnostics so live provider reconnect failures expose the rejected parser field without logging raw unauthenticated payloads.

Validation:
- go test ./internal/ws targeted auth/proof cases
- go test ./...
- go vet ./...
- git diff --check
- three audit lanes clear: code/security/architecture 0 C/H/M

Constraint: live provider reconnect still reports invalid_auth_request after initial-stage compatibility landed, but proof-stage parse failures did not emit bad_field evidence.
Rejected: logging raw parse errors or payloads | sensitive unauthenticated data must not reach logs.
Confidence: high
Scope-risk: narrow
Directive: Keep auth diagnostics bounded to parser-controlled field names.
Tested: targeted auth/proof cases, full coordinator tests, go vet, diff check, 3 audit lanes.
Not-tested: live reconnect until deploy.