### PR TITLE
Expose bounded first auth rejection diagnostics

### DIFF
--- a/phase4-coordinator/internal/ws/messages.go
+++ b/phase4-coordinator/internal/ws/messages.go
@@ -413,19 +413,24 @@ func ParseHello(payload []byte) (Hello, string, error) {
 }
 
 func ParseFirstAuthMessage(payload []byte) (string, int, error) {
+	typ, version, _, err := parseFirstAuthMessageWithField(payload)
+	return typ, version, err
+}
+
+func parseFirstAuthMessageWithField(payload []byte) (string, int, string, error) {
 	var raw map[string]json.RawMessage
 	if err := json.Unmarshal(payload, &raw); err != nil {
-		return "", 0, err
+		return "", 0, "json", err
 	}
 	var typ string
 	if err := requireString(raw, "type", &typ); err != nil {
-		return "", 0, err
+		return "", 0, err.Field, err
 	}
 	var version int
 	if err := requireAuthVersion(raw, &version); err != nil {
-		return "", 0, err
+		return "", 0, err.Field, err
 	}
-	return typ, version, nil
+	return typ, version, "", nil
 }
 
 func ParseAuthRequest(payload []byte) (AuthRequest, Spec010Presence, string, error) {

--- a/phase4-coordinator/internal/ws/messages_test.go
+++ b/phase4-coordinator/internal/ws/messages_test.go
@@ -390,6 +390,19 @@ func TestParseAuthInitialAcceptsNumericStringVersion(t *testing.T) {
 	}
 }
 
+func TestParseFirstAuthMessageWithFieldReportsVersion(t *testing.T) {
+	payload := validAuthRequestInitial()
+	payload["version"] = "v2"
+
+	_, _, field, err := parseFirstAuthMessageWithField(mustAuthJSON(t, payload))
+	if err == nil {
+		t.Fatal("ParseFirstAuthMessageWithField err = nil, want error")
+	}
+	if field != "version" {
+		t.Fatalf("field = %q, want version", field)
+	}
+}
+
 func TestParseAuthInitialAcceptsProviderReceiptPublicKey(t *testing.T) {
 	payload := validAuthRequestInitial()
 	pubkey := bytesOf(0x42, 32)

--- a/phase4-coordinator/internal/ws/server.go
+++ b/phase4-coordinator/internal/ws/server.go
@@ -612,12 +612,17 @@ func (s *Server) handleConn(conn net.Conn, auth providerAuth, releaseUnauthentic
 		return
 	}
 	if op != gobwas.OpText {
+		s.log.Warn().Str("bad_field", "opcode").Msg("provider first auth message rejected")
 		s.close(conn, CloseUnrecognizedAuthMessage, "unrecognized auth message")
 		return
 	}
 
-	typ, version, err := ParseFirstAuthMessage(payload)
+	typ, version, badField, err := parseFirstAuthMessageWithField(payload)
 	if err != nil {
+		if badField == "" {
+			badField = "unknown"
+		}
+		s.log.Warn().Str("bad_field", badField).Msg("provider first auth message rejected")
 		s.close(conn, CloseUnrecognizedAuthMessage, "unrecognized auth message")
 		return
 	}
@@ -627,6 +632,14 @@ func (s *Server) handleConn(conn net.Conn, auth providerAuth, releaseUnauthentic
 	case typ == "auth_request" && version == 2:
 		providerID, assignedID = s.handleV2Conn(conn, auth, payload, releaseUnauth)
 	default:
+		badField := "dispatch"
+		switch typ {
+		case "hello", "auth_request":
+			badField = "version"
+		default:
+			badField = "type"
+		}
+		s.log.Warn().Str("bad_field", badField).Msg("provider first auth message rejected")
 		s.close(conn, CloseUnrecognizedAuthMessage, "unrecognized auth message")
 	}
 }


### PR DESCRIPTION
## Summary
- add a package-local first-auth parser wrapper that returns a bounded bad-field label
- log fixed `bad_field` labels for first provider WS auth frame opcode, parse, and unsupported dispatch rejects
- preserve existing close codes/reasons and avoid raw payload / parse error logging

## Validation
- `go test ./internal/ws`
- `go test ./...` from `phase4-coordinator`
- `go vet ./...` from `phase4-coordinator`
- `git diff --check`
- Audit lanes: code 0 C/H/M, security 0 C/H/M (1 accepted Low log-noise note), architecture 0 C/H/M

## Live Context
The live provider is configured for 8-slot capacity and its recommendation provenance is fresh, but Pearl still reports a generic first-frame `unrecognized auth message`. This diagnostic is needed to expose whether the first-frame reject is `json`, `type`, `version`, `opcode`, or dispatch without leaking payload values.
