### PR TITLE
Expose failed first-auth message family

### DIFF
--- a/phase4-coordinator/internal/ws/messages.go
+++ b/phase4-coordinator/internal/ws/messages.go
@@ -428,7 +428,7 @@ func parseFirstAuthMessageWithField(payload []byte) (string, int, string, error)
 	}
 	var version int
 	if err := requireAuthVersion(raw, &version); err != nil {
-		return "", 0, err.Field, err
+		return typ, 0, err.Field, err
 	}
 	return typ, version, "", nil
 }

--- a/phase4-coordinator/internal/ws/messages_test.go
+++ b/phase4-coordinator/internal/ws/messages_test.go
@@ -394,12 +394,31 @@ func TestParseFirstAuthMessageWithFieldReportsVersion(t *testing.T) {
 	payload := validAuthRequestInitial()
 	payload["version"] = "v2"
 
-	_, _, field, err := parseFirstAuthMessageWithField(mustAuthJSON(t, payload))
+	typ, _, field, err := parseFirstAuthMessageWithField(mustAuthJSON(t, payload))
 	if err == nil {
 		t.Fatal("ParseFirstAuthMessageWithField err = nil, want error")
 	}
+	if typ != "auth_request" {
+		t.Fatalf("type = %q, want auth_request", typ)
+	}
 	if field != "version" {
 		t.Fatalf("field = %q, want version", field)
+	}
+}
+
+func TestParseFirstAuthMessageWithFieldReportsMissingVersionType(t *testing.T) {
+	payload := validAuthRequestInitial()
+	delete(payload, "version")
+
+	typ, _, field, err := parseFirstAuthMessageWithField(mustAuthJSON(t, payload))
+	if err == nil {
+		t.Fatal("ParseFirstAuthMessageWithField err = nil, want error")
+	}
+	if typ != "auth_request" {
+		t.Fatalf("type = %q, want auth_request", typ)
+	}
+	if field != "missing version" {
+		t.Fatalf("field = %q, want missing version", field)
 	}
 }
 

--- a/phase4-coordinator/internal/ws/server.go
+++ b/phase4-coordinator/internal/ws/server.go
@@ -622,7 +622,10 @@ func (s *Server) handleConn(conn net.Conn, auth providerAuth, releaseUnauthentic
 		if badField == "" {
 			badField = "unknown"
 		}
-		s.log.Warn().Str("bad_field", badField).Msg("provider first auth message rejected")
+		s.log.Warn().
+			Str("bad_field", badField).
+			Str("message_type", firstAuthMessageTypeForLog(typ)).
+			Msg("provider first auth message rejected")
 		s.close(conn, CloseUnrecognizedAuthMessage, "unrecognized auth message")
 		return
 	}
@@ -639,8 +642,22 @@ func (s *Server) handleConn(conn net.Conn, auth providerAuth, releaseUnauthentic
 		default:
 			badField = "type"
 		}
-		s.log.Warn().Str("bad_field", badField).Msg("provider first auth message rejected")
+		s.log.Warn().
+			Str("bad_field", badField).
+			Str("message_type", firstAuthMessageTypeForLog(typ)).
+			Msg("provider first auth message rejected")
 		s.close(conn, CloseUnrecognizedAuthMessage, "unrecognized auth message")
+	}
+}
+
+func firstAuthMessageTypeForLog(typ string) string {
+	switch typ {
+	case "hello", "auth_request":
+		return typ
+	case "":
+		return "missing"
+	default:
+		return "other"
 	}
 }
 

--- a/phase4-coordinator/internal/ws/server_test.go
+++ b/phase4-coordinator/internal/ws/server_test.go
@@ -777,6 +777,31 @@ func TestProviderAuthV2InitialEmptyCatalogRejectedOnTheWire(t *testing.T) {
 	assertInitialCatalogRejectedWithLockedSubstring(t, initial, "supported_models cannot be empty")
 }
 
+func TestProviderFirstAuthMissingVersionLogsBoundedMessageType(t *testing.T) {
+	var logBuffer lockedBuffer
+	h := newProviderHarnessWithServerOptionsAndLogger(t, nil, nil, zerolog.New(&logBuffer), func(cfg *config.Config) {
+		cfg.Providers[0].EndpointURL = ""
+	})
+	defer h.HTTP.Close()
+
+	initial := validAuthInitialWithFreshKey(t, "m4-anon")
+	delete(initial, "version")
+
+	code, reason := sendHelloExpectClose(t, h.HTTP.URL, initial)
+	if code != providerws.CloseUnrecognizedAuthMessage {
+		t.Fatalf("close code = %d, want %d", code, providerws.CloseUnrecognizedAuthMessage)
+	}
+	if reason != "unrecognized auth message" {
+		t.Fatalf("close reason = %q, want %q", reason, "unrecognized auth message")
+	}
+
+	logText := logBuffer.String()
+	if !strings.Contains(logText, `"bad_field":"missing version"`) ||
+		!strings.Contains(logText, `"message_type":"auth_request"`) {
+		t.Fatalf("missing bounded first-auth rejection log fields: %s", logText)
+	}
+}
+
 // TestProviderAuthV2ProofStageFirstWithMalformedCatalogTakesEnvelopePath
 // regression-pins the [r2:1.1] R2V closure: a first-frame
 // auth_request with stage:"proof" whose supported_models field is a


### PR DESCRIPTION
## Summary
- preserve the validated first-auth `type` when version parsing fails
- log a bounded `message_type` bucket for first-auth parse/dispatch rejections
- add parser and server-level tests for missing-version `auth_request` diagnostics

## Validation
- `go test ./internal/ws`
- `go test ./...` from `phase4-coordinator`
- `go vet ./...` from `phase4-coordinator`
- `git diff --check`
- 3 audit lanes: code/security/architecture all 0 Critical / High / Medium

## Live rollout context
This is a narrow diagnostic needed for the issue #379 live capacity rollout. Pearl currently reports provider first-auth rejection with `bad_field=missing version`; this PR adds the bounded message family needed to choose the actual compatibility fix without logging raw provider input.