### PR TITLE
Report catalog model IDs to coordinator

### DIFF
--- a/phase3-binary/Sources/macprovider-cli/CoordinatorClient.swift
+++ b/phase3-binary/Sources/macprovider-cli/CoordinatorClient.swift
@@ -180,6 +180,7 @@ actor CoordinatorClient {
     private let maxBodyBytes: Int
     private let maxActiveRequests: Int
     private let supportedModels: [String]?
+    private let catalogModelIDForCoordinator: String?
     private let publishesSupportedModels: Bool
     private let warmSwapEnabled: Bool
     private let hardwareSummary: [String: Any]?
@@ -229,6 +230,7 @@ actor CoordinatorClient {
     private var autoupdateDrainExtensions = false
     private var autoupdateAttemptedTargets = Set<String>()
     private var webSocket: ProviderWebSocketTask?
+    private var coordinatorSessionAccepted = false
     private var runTask: Task<Void, Never>?
     private var heartbeatTask: Task<Void, Never>?
     // Issue #189: separate watchdog task observing heartbeat liveness.
@@ -307,6 +309,10 @@ actor CoordinatorClient {
         self.maxBodyBytes = config.maxRequestBodyBytes
         self.maxActiveRequests = 1
         self.supportedModels = config.supportedModels
+        self.catalogModelIDForCoordinator = config.modelCatalogModelID.flatMap { value in
+            let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+            return trimmed.isEmpty ? nil : trimmed
+        }
         self.publishesSupportedModels = config.publishesSupportedModels
         self.warmSwapEnabled = config.enableWarmSwap
         self.hardwareSummary = ProviderHardwareSummary.liveWireObject()
@@ -352,6 +358,7 @@ actor CoordinatorClient {
         inferenceRelay = nil
         tier2Session = nil
         webSocket?.cancel(with: .goingAway, reason: nil)
+        coordinatorSessionAccepted = false
         autoupdateCoordinatorPayload = [:]
         autoupdateCoordinatorPayloadIsV2 = false
         autoupdateAssignedProviderTokenAdopted = false
@@ -377,6 +384,9 @@ actor CoordinatorClient {
     }
 
     func sendIdlePrewarmEvent(event rawEvent: String, reason: String?) async {
+        guard coordinatorSessionAccepted else {
+            return
+        }
         var payload: [String: Any] = [
             "type": "idle_prewarm_event",
             "event": rawEvent,
@@ -402,6 +412,9 @@ actor CoordinatorClient {
             case .loadFinished:
                 continue
             case .completed:
+                guard coordinatorSessionAccepted || webSocket == nil else {
+                    continue
+                }
                 // Issue #189 R1 architect MEDIUM: the warm-swap completion
                 // path is the second hot heartbeat callsite. A wedged
                 // URLSession.send() here would park swapHeartbeatTask
@@ -1034,6 +1047,7 @@ actor CoordinatorClient {
         tier2Session = nil
         webSocket?.cancel(with: .goingAway, reason: nil)
         webSocket = nil
+        coordinatorSessionAccepted = false
         autoupdateCoordinatorPayload = [:]
         autoupdateCoordinatorPayloadIsV2 = false
         autoupdateAssignedProviderTokenAdopted = false
@@ -1474,6 +1488,7 @@ actor CoordinatorClient {
             tier: payload["tier"] as? String,
             recommendedBinaryVersion: payload["recommended_binary_version"] as? String
         )
+        coordinatorSessionAccepted = true
         if let tier = payload["tier"] as? String {
             print("Coordinator tier: \(tier)")
         }
@@ -2210,13 +2225,28 @@ actor CoordinatorClient {
     // sub-interval tick to keep the connection alive) pass resetWindow=false so
     // the since-last window stays aligned to the full coordinator interval and
     // metrics are unchanged from the prior single-heartbeat-per-interval cadence.
+    private func coordinatorWireModelID(for servedModelID: String?) -> String {
+        guard let servedModelID, !servedModelID.isEmpty else {
+            return ""
+        }
+        guard let catalogModelIDForCoordinator,
+              let loadedModelID,
+              !loadedModelID.isEmpty,
+              servedModelID == loadedModelID
+        else {
+            return servedModelID
+        }
+        return catalogModelIDForCoordinator
+    }
+
     private func sendHeartbeat(resetWindow: Bool = true) async throws {
         let snapshot = await providerStatus.snapshot(resetWindow: resetWindow)
+        let snapshotWireModelID = coordinatorWireModelID(for: snapshot.modelID)
         var payload: [String: Any] = [
             "type": "heartbeat",
             "status": snapshot.status.rawValue,
-            "model_id": snapshot.modelID ?? "",
-            "model_params_b": snapshot.capacity.modelParamsB(modelID: snapshot.modelID),
+            "model_id": snapshotWireModelID,
+            "model_params_b": snapshot.capacity.modelParamsB(modelID: snapshotWireModelID),
             "ram_gb": snapshot.capacity.ramGB,
             "max_context_tokens": snapshot.capacity.maxContextTokens,
             "max_concurrency": snapshot.capacity.maxConcurrency,
@@ -2235,8 +2265,9 @@ actor CoordinatorClient {
         if warmSwapEnabled {
             let runtimeSnapshot = await modelRuntime.currentSnapshot()
             let runtimeModelID = runtimeSnapshot.modelID
-            payload["model_id"] = runtimeModelID ?? ""
-            payload["model_params_b"] = snapshot.capacity.modelParamsB(modelID: runtimeModelID)
+            let runtimeWireModelID = coordinatorWireModelID(for: runtimeModelID)
+            payload["model_id"] = runtimeWireModelID
+            payload["model_params_b"] = snapshot.capacity.modelParamsB(modelID: runtimeWireModelID)
             if let modelHash = runtimeSnapshot.modelHash {
                 payload["model_hash"] = modelHash
             }
@@ -2328,14 +2359,14 @@ actor CoordinatorClient {
         // routing decisions in that window used the wrong metadata.
         // Fix: source modelID + modelHash from the same place
         // helloMessage does.
-        let resolvedModelID: String
+        let wireModelID: String
         let resolvedModelHash: String?
         if warmSwapEnabled {
             let runtimeSnapshot = await modelRuntime.currentSnapshot()
-            resolvedModelID = runtimeSnapshot.modelID ?? ""
+            wireModelID = coordinatorWireModelID(for: runtimeSnapshot.modelID)
             resolvedModelHash = runtimeSnapshot.modelHash
         } else {
-            resolvedModelID = snapshot.modelID ?? ""
+            wireModelID = coordinatorWireModelID(for: snapshot.modelID)
             resolvedModelHash = snapshot.modelHash
         }
         var message: [String: Any] = [
@@ -2344,8 +2375,8 @@ actor CoordinatorClient {
             "stage": "initial",
             "provider_id": providerID,
             "hostname": Host.current().localizedName ?? "unknown",
-            "model_id": resolvedModelID,
-            "model_params_b": snapshot.capacity.modelParamsB(modelID: resolvedModelID),
+            "model_id": wireModelID,
+            "model_params_b": snapshot.capacity.modelParamsB(modelID: wireModelID),
             "ram_gb": snapshot.capacity.ramGB,
             "max_context_tokens": snapshot.capacity.maxContextTokens,
             "max_concurrency": snapshot.capacity.maxConcurrency,
@@ -2362,11 +2393,11 @@ actor CoordinatorClient {
         let resolvedCatalog: [String]
         do {
             resolvedCatalog = try SupportedModels.validate(
-                model: resolvedModelID,
+                model: wireModelID,
                 supportedModels: supportedModels
             )
         } catch {
-            resolvedCatalog = [resolvedModelID]
+            resolvedCatalog = [wireModelID]
         }
         message["supported_models"] = resolvedCatalog
         if publishesSupportedModels {
@@ -2405,17 +2436,18 @@ actor CoordinatorClient {
         if let endpointURL {
             message["endpoint_url"] = endpointURL
         }
-        let modelIDForHello: String
+        let wireModelIDForHello: String
         let hashForHello: String?
         if warmSwapEnabled {
             let runtimeSnapshot = await modelRuntime.currentSnapshot()
-            modelIDForHello = runtimeSnapshot.modelID ?? ""
+            wireModelIDForHello = coordinatorWireModelID(for: runtimeSnapshot.modelID)
             hashForHello = runtimeSnapshot.modelHash
         } else {
-            modelIDForHello = snapshot.modelID ?? ""
+            wireModelIDForHello = coordinatorWireModelID(for: snapshot.modelID)
             hashForHello = snapshot.modelHash
         }
-        message["model_id"] = modelIDForHello
+        message["model_id"] = wireModelIDForHello
+        message["model_params_b"] = snapshot.capacity.modelParamsB(modelID: wireModelIDForHello)
         if let hashForHello {
             message["model_hash"] = hashForHello
         }

--- a/phase3-binary/Tests/macprovider-cliTests/CoordinatorClientTests.swift
+++ b/phase3-binary/Tests/macprovider-cliTests/CoordinatorClientTests.swift
@@ -4,6 +4,64 @@ import XCTest
 @testable import macprovider_cli
 
 final class CoordinatorClientTests: XCTestCase {
+    func testIdlePrewarmEventIsNotSentBeforeCoordinatorAcceptsSession() async throws {
+        let recorder = CoordinatorFrameRecorder()
+        let status = ProviderStatus(
+            modelID: "model-a",
+            modelLoaded: true,
+            capacity: ProviderCapacity(maxContextOverride: 20_000, maxConcurrencyOverride: 1)
+        )
+        let client = try await makeClient(status: status, recorder: recorder)
+
+        await client.sendIdlePrewarmEvent(event: "idle_prewarm_skipped", reason: "idle_prewarmer_disabled")
+
+        let frames = await recorder.frames
+        XCTAssertTrue(frames.isEmpty, "pre-auth idle prewarm event must not race ahead of auth: \(frames)")
+    }
+
+    func testWarmSwapCompletionDoesNotSendHeartbeatBeforeCoordinatorAcceptsSession() async throws {
+        var config = AppConfig.defaults(configPath: "/tmp/macprovider-test.yaml")
+        config.coordinatorURL = "wss://127.0.0.1:8444/ws/provider"
+        config.providerID = "provider-test"
+        config.model = "model-a"
+        config.enableWarmSwap = true
+        config.wsTunneledMode = true
+        let runtime = makeRuntime(modelID: "model-a", warmSwapEnabled: true)
+        let status = ProviderStatus(
+            modelID: "model-a",
+            modelLoaded: true,
+            capacity: ProviderCapacity(maxContextOverride: 20_000, maxConcurrencyOverride: 1)
+        )
+        let socket = FakeProviderWebSocketTask(
+            receiveResults: [],
+            receiveOverride: { _ in
+                try await Task.sleep(nanoseconds: 1_000_000_000)
+                throw CancellationError()
+            }
+        )
+        let factory = FakeProviderWebSocketFactory(sockets: [socket])
+        let client = try XCTUnwrap(CoordinatorClient(
+            config: config,
+            modelRuntime: runtime,
+            providerStatus: status,
+            reconnectGraceNanoseconds: 1_000_000,
+            attestationGenerator: StaticAttestationGenerator(token: nil),
+            webSocketFactory: { factory.makeSocket(for: $0) },
+            sleepAssertionFactory: { nil }
+        ))
+
+        await client.start()
+        try await Task.sleep(nanoseconds: 10_000_000)
+        let swapTask = try await runtime.beginSwap(targetModelID: "model-b")
+        try await swapTask.value
+        try await Task.sleep(nanoseconds: 50_000_000)
+        await client.stop()
+
+        let frames = socket.sentFrames()
+        XCTAssertFalse(frames.contains { $0["type"] as? String == "heartbeat" },
+                       "pre-auth warm-swap completion must not race a heartbeat ahead of auth: \(frames)")
+    }
+
     func testPreflightAckKeepsRequestIDCorrelation() async throws {
         let recorder = CoordinatorFrameRecorder()
         let status = ProviderStatus(
@@ -811,6 +869,63 @@ final class CoordinatorClientTests: XCTestCase {
 
         XCTAssertEqual(heartbeat["model_id"] as? String, "model-a")
         XCTAssertNil(heartbeat["loading"])
+    }
+
+    func testCoordinatorFramesUseCatalogModelIDForConfiguredModelKey() async throws {
+        let recorder = CoordinatorFrameRecorder()
+        let catalogModelID = "mlx-community/Qwen3-Coder-30B-A3B-Instruct-4bit"
+        let status = ProviderStatus(
+            modelID: "model-a",
+            modelLoaded: true,
+            capacity: ProviderCapacity(maxContextOverride: 20_000, maxConcurrencyOverride: 1),
+            modelHash: String(repeating: "a", count: 64)
+        )
+        let client = try await makeClient(
+            status: status,
+            recorder: recorder,
+            enableWarmSwap: false,
+            modelCatalogModelID: catalogModelID
+        )
+
+        let auth = await client.authInitialMessage(attempt: Tier2AuthAttempt())
+        let hello = await client.helloMessage()
+        try await client.sendHeartbeatForTest()
+        let frames = await recorder.frames
+        let heartbeat = try XCTUnwrap(frames.first)
+        let supportedModels = try XCTUnwrap(auth["supported_models"] as? [String])
+
+        XCTAssertEqual(auth["model_id"] as? String, catalogModelID)
+        XCTAssertEqual(hello["model_id"] as? String, catalogModelID)
+        XCTAssertEqual(heartbeat["model_id"] as? String, catalogModelID)
+        XCTAssertEqual(supportedModels, [catalogModelID])
+    }
+
+    func testCatalogModelIDDoesNotMaskCompletedWarmSwapRuntimeModelID() async throws {
+        let recorder = CoordinatorFrameRecorder()
+        let runtime = makeRuntime(modelID: "model-b", modelHash: "runtime-hash", warmSwapEnabled: true)
+        let status = ProviderStatus(
+            modelID: "model-a",
+            modelLoaded: true,
+            capacity: ProviderCapacity(maxContextOverride: 20_000, maxConcurrencyOverride: 1),
+            modelHash: "boot-hash"
+        )
+        let client = try await makeClient(
+            status: status,
+            recorder: recorder,
+            enableWarmSwap: true,
+            modelRuntime: runtime,
+            modelCatalogModelID: "mlx-community/Qwen3-Coder-30B-A3B-Instruct-4bit"
+        )
+
+        let auth = await client.authInitialMessage(attempt: Tier2AuthAttempt())
+        let hello = await client.helloMessage()
+        try await client.sendHeartbeatForTest()
+        let frames = await recorder.frames
+        let heartbeat = try XCTUnwrap(frames.first)
+
+        XCTAssertEqual(auth["model_id"] as? String, "model-b")
+        XCTAssertEqual(hello["model_id"] as? String, "model-b")
+        XCTAssertEqual(heartbeat["model_id"] as? String, "model-b")
     }
 
     func testHelloDisabledModeKeepsProviderStatusModelIDWhenRuntimeDiffers() async throws {
@@ -2124,12 +2239,14 @@ final class CoordinatorClientTests: XCTestCase {
         providerReceiptPublicKey: String? = nil,
         sendOverride: CoordinatorClient.SendOverride? = nil,
         watchdogExitHook: (@Sendable (String) -> Void)? = nil,
-        publishesSpecDecodeTelemetry: Bool = false
+        publishesSpecDecodeTelemetry: Bool = false,
+        modelCatalogModelID: String? = nil
     ) async throws -> CoordinatorClient {
         var config = AppConfig.defaults(configPath: "/tmp/macprovider-test.yaml")
         config.coordinatorURL = "wss://127.0.0.1:8444/ws/provider"
         config.providerID = "provider-test"
         config.model = "model-a"
+        config.modelCatalogModelID = modelCatalogModelID
         config.drainTimeoutSeconds = drainTimeoutSeconds
         config.enableWarmSwap = enableWarmSwap
         config.publishesSpecDecodeTelemetry = publishesSpecDecodeTelemetry


### PR DESCRIPTION
## Summary
- report `model_catalog_model_id` to the coordinator for auth, hello, heartbeat, and supported-model validation when the served local model key is the configured boot model
- keep local serve/preflight model keys unchanged so live `--model qwen3-coder-30b-a3b-instruct` still passes catalog-key validation
- suppress idle-prewarm events and warm-swap completion heartbeats before coordinator session acceptance to avoid pre-auth non-auth frame races

## Root Cause
Live provider preflight requires the local model/rate-card key, while coordinator admission validates the catalog model ID. Using the local alias on the wire caused the coordinator to reject the provider as uncatalogued/autotune-evidence-invalid; changing the serve model to the full catalog ID broke local preflight.

## Validation
- `swift test --package-path phase3-binary --filter CoordinatorClientTests`
- `swift test --package-path phase3-binary`
- `swift build -c release --package-path phase3-binary`
- `git diff --check`
- Three local audit lanes after implementation: correctness/runtime, protocol/security, regression/test adequacy; 0 Critical/High/Medium findings. Native subagent spawn was unavailable due the existing thread limit, so the lanes were run locally.

## Live Follow-up
After merge, install the release binary on the live provider, keep the alias model in launchd/config with `model_catalog_model_id` present, restart launchd, and verify coordinator registration plus the live HTTP/2 chat benchmark.