### PR TITLE
test(e2e): canary buyer probe for continuous network/perf measurement

### DIFF
--- a/test/e2e/canary-buyer/README.md
+++ b/test/e2e/canary-buyer/README.md
@@ -22,7 +22,8 @@ scheduled, dependency-free probe.
 | TTFT | `macprovider_canary_ttft_ms{model,quantile}` | p50/p95/p99 time-to-first-token. Feeds real numbers into the W3 `max_ttft_ms` canary gate instead of guesses. |
 | Decode TPS | `macprovider_canary_decode_tps{model,quantile}` | Sustained tokens/sec (first token excluded). Catches metallib/thermal silent regressions. |
 | KV-cache reuse | `macprovider_canary_cached_prompt_ratio{model}` | Turn-2 `cached_prompt_tokens / prompt_tokens`. Locks in the measured ~45% sticky-affinity win. |
-| Outcomes | `macprovider_canary_requests{model,outcome}` | 2xx / 502 / 5xx / timeout / empty counts (per-run gauge) → 502-rate signal. |
+| Outcomes | `macprovider_canary_requests{model,outcome}` | Per-run gauge over buckets `2xx / 502 / 5xx / timeout / network_error / stream_error / empty / other` → 502-rate and mid-stream-failure signal. |
+| Sample counts | `macprovider_canary_ttft_samples{model}`, `macprovider_canary_decode_tps_samples{model}` | Valid samples collected — alert on `== 0 while serviceable == 1` to catch a signal going dark (e.g. gateway stops returning usage). |
 | Pool view | `macprovider_canary_pool_providers{state}`, `macprovider_canary_up` | What `/v1/status` claims, for divergence comparison. |
 
 Also writes a per-run JSON artifact (same shape as the network-harness
@@ -105,6 +106,9 @@ tokens**. At 30-minute cadence and one model that is ~24k tokens/day.
 
 # Silent throughput regression (tune the floor per model/tier from observed p50).
 macprovider_canary_decode_tps{quantile="p50"} < 15
+
+# Serviceable but a signal went dark (e.g. gateway stopped returning usage).
+macprovider_canary_model_serviceable == 1 and on(model) macprovider_canary_decode_tps_samples == 0
 
 # TTFT SLO breach.
 macprovider_canary_ttft_ms{quantile="p95"} > 7000

--- a/test/e2e/canary-buyer/README.md
+++ b/test/e2e/canary-buyer/README.md
@@ -67,6 +67,40 @@ By default it writes a `.prom` textfile to
 To push instead, set `CANARY_PUSHGATEWAY=http://host:9091` (in the plist
 `EnvironmentVariables` or the environment).
 
+## Schedule it (always-on Linux host, e.g. Pearl — every 30 min)
+
+Prefer this over a lab Mac when you have an always-on host: a sleeping Mac
+creates blind spots. Units ship next to this README (`canary-buyer.service`,
+`canary-buyer.timer`).
+
+```bash
+apt-get install -y nodejs            # Ubuntu 24.04 ships node 18 (probe-compatible)
+install -d -o macprovider -g macprovider -m 0755 /opt/macprovider/canary-buyer
+cp probe.mjs run-canary.sh /opt/macprovider/canary-buyer/
+install -d -o macprovider -g macprovider -m 0750 /var/lib/macprovider/canary-buyer
+# buyer token via a 0640 env file — never inline in the unit, never echoed:
+printf 'MACPROVIDER_BUYER_TOKEN=%s\n' "$TOKEN" > /etc/macprovider/canary-buyer.env
+chown root:macprovider /etc/macprovider/canary-buyer.env && chmod 0640 /etc/macprovider/canary-buyer.env
+cp canary-buyer.service canary-buyer.timer /etc/systemd/system/
+systemctl daemon-reload && systemctl enable --now canary-buyer.timer
+systemctl start canary-buyer.service   # run once now; check `journalctl -u canary-buyer`
+```
+
+### Alerting without Prometheus — dead-man's-switch heartbeat
+
+No Prometheus/pushgateway is required. The service runs with `--fail-on-degraded`,
+so a down gateway or unserviceable model makes the run **exit non-zero** (visible
+in `journalctl -u canary-buyer`) and the wrapper then **does not** ping the
+heartbeat. Point `CANARY_HEARTBEAT_URL` at a BetterStack "Heartbeat" (or
+healthchecks.io) monitor with an expected period ≥ the timer interval: a healthy
+run pings it; a degraded/failed/missed run leaves it stale and the monitor
+alerts. Add to `/etc/macprovider/canary-buyer.env`:
+
+```
+CANARY_HEARTBEAT_URL=https://uptime.betterstack.com/api/v1/heartbeat/<token>
+```
+(https required unless `CANARY_ALLOW_INSECURE=1`; the URL carries no buyer token.)
+
 ## Configuration
 
 All env, all optional except the token:
@@ -83,6 +117,7 @@ All env, all optional except the token:
 | `CANARY_REQ_TIMEOUT_MS` | `45000` | per-request timeout |
 | `CANARY_STICKY_PREFIX_LINES` | `80` | shared-prefix size (~10 tok/line) for the sticky KV-cache test; must exceed the provider's prefix-cache granularity or turn-2 `cached_prompt_tokens` is always 0 |
 | `CANARY_ALLOW_INSECURE` | *(unset)* | set `1` to permit `http`/localhost/private-host targets (local mock testing only). By default `CANARY_BASE`/`CANARY_PUSHGATEWAY` must be `https` and non-private, so the buyer token can't be sent to an arbitrary origin. |
+| `CANARY_HEARTBEAT_URL` | *(unset)* | https dead-man's-switch ping (BetterStack/healthchecks). Pinged by `run-canary.sh` only on a healthy (exit-0) run; a degraded run with `--fail-on-degraded` leaves it stale so the upstream monitor alerts. |
 
 The buyer token is redacted from all logs, stdout, and artifacts even if a
 mispointed gateway echoes the `Authorization` header.

--- a/test/e2e/canary-buyer/README.md
+++ b/test/e2e/canary-buyer/README.md
@@ -21,7 +21,7 @@ scheduled, dependency-free probe.
 | Serviceability | `macprovider_canary_model_serviceable{model}` | 1 iff a chat actually produced a token. Catches the status-vs-serviceable divergence (status says ready, completions 502). |
 | TTFT | `macprovider_canary_ttft_ms{model,quantile}` | p50/p95/p99 time-to-first-token. Feeds real numbers into the W3 `max_ttft_ms` canary gate instead of guesses. |
 | Decode TPS | `macprovider_canary_decode_tps{model,quantile}` | Sustained tokens/sec (first token excluded). Catches metallib/thermal silent regressions. |
-| KV-cache reuse | `macprovider_canary_cached_prompt_ratio{model}` | Turn-2 `cached_prompt_tokens / prompt_tokens`. Locks in the measured ~45% sticky-affinity win. |
+| KV-cache reuse | `macprovider_canary_cached_prompt_ratio{model}` | Turn-2 `cached_prompt_tokens / prompt_tokens` over a large shared prefix. Locks in the sticky-affinity win (measured ~64% live 2026-07-09). Requires the usage frame to survive large prompts (gateway PR #511). |
 | Outcomes | `macprovider_canary_requests{model,outcome}` | Per-run gauge over buckets `2xx / 502 / 5xx / timeout / network_error / stream_error / empty / other` → 502-rate and mid-stream-failure signal. |
 | Sample counts | `macprovider_canary_ttft_samples{model}`, `macprovider_canary_decode_tps_samples{model}` | Valid samples collected — alert on `== 0 while serviceable == 1` to catch a signal going dark (e.g. gateway stops returning usage). |
 | Pool view | `macprovider_canary_pool_providers{state}`, `macprovider_canary_up` | What `/v1/status` claims, for divergence comparison. |
@@ -81,6 +81,7 @@ All env, all optional except the token:
 | `CANARY_TPS_MAX_TOKENS` | `128` | decode window for TPS samples |
 | `CANARY_INTERVAL_MS` | `1500` | floor gap between samples (avoids self-induced queueing; see scenario 09 pacing math) |
 | `CANARY_REQ_TIMEOUT_MS` | `45000` | per-request timeout |
+| `CANARY_STICKY_PREFIX_LINES` | `80` | shared-prefix size (~10 tok/line) for the sticky KV-cache test; must exceed the provider's prefix-cache granularity or turn-2 `cached_prompt_tokens` is always 0 |
 | `CANARY_ALLOW_INSECURE` | *(unset)* | set `1` to permit `http`/localhost/private-host targets (local mock testing only). By default `CANARY_BASE`/`CANARY_PUSHGATEWAY` must be `https` and non-private, so the buyer token can't be sent to an arbitrary origin. |
 
 The buyer token is redacted from all logs, stdout, and artifacts even if a

--- a/test/e2e/canary-buyer/README.md
+++ b/test/e2e/canary-buyer/README.md
@@ -1,0 +1,124 @@
+# Canary buyer probe
+
+A continuous synthetic buyer that measures the live macprovider network the way
+a real buyer experiences it, and exports the result as Prometheus metrics.
+
+This is **P1** from the 2026-07-09 e2e-testing review. The month's pattern was
+that every serious finding came from live contact with prod (KV-cache verify,
+W3 canary TTFT false-fail), yet the network had **no continuous
+buyer-perspective measurement** — a metallib-class silent 2× TPS regression, or
+a provider that `/v1/status` calls "ready" but that 502s every completion, would
+be invisible until a buyer complained.
+
+It productionizes `test/e2e/malibu-console/smoke.mjs` and network-harness
+scenarios `07_sustained_throughput` / `09_streaming_ttft_distribution` into a
+scheduled, dependency-free probe.
+
+## What it measures (per model class, per run)
+
+| Signal | Metric | Why it matters |
+|--------|--------|----------------|
+| Serviceability | `macprovider_canary_model_serviceable{model}` | 1 iff a chat actually produced a token. Catches the status-vs-serviceable divergence (status says ready, completions 502). |
+| TTFT | `macprovider_canary_ttft_ms{model,quantile}` | p50/p95/p99 time-to-first-token. Feeds real numbers into the W3 `max_ttft_ms` canary gate instead of guesses. |
+| Decode TPS | `macprovider_canary_decode_tps{model,quantile}` | Sustained tokens/sec (first token excluded). Catches metallib/thermal silent regressions. |
+| KV-cache reuse | `macprovider_canary_cached_prompt_ratio{model}` | Turn-2 `cached_prompt_tokens / prompt_tokens`. Locks in the measured ~45% sticky-affinity win. |
+| Outcomes | `macprovider_canary_requests{model,outcome}` | 2xx / 502 / 5xx / timeout / empty counts (per-run gauge) → 502-rate signal. |
+| Pool view | `macprovider_canary_pool_providers{state}`, `macprovider_canary_up` | What `/v1/status` claims, for divergence comparison. |
+
+Also writes a per-run JSON artifact (same shape as the network-harness
+artifacts) for archival and offline analysis.
+
+> **Buyer-side scope.** From the buyer we can split latency into *TTFT*
+> (network + queue + prefill + first token) and *decode window* (sustained
+> rate). The finer server-side phase timing the gateway logs on completion is
+> not exposed in the buyer response, so this probe does not claim it — pair
+> gateway logs with these metrics by `x-request-id` when you need the split.
+
+## Run once (by hand)
+
+```bash
+export MACPROVIDER_BUYER_TOKEN=mp_...        # or MALIBU_API_KEY
+node test/e2e/canary-buyer/probe.mjs --metrics-out /tmp/canary.prom --json-out ./artifacts
+```
+
+Or via the wrapper, which resolves the token from the documented harness
+location (`~/.config/macprovider/buyer-api-key`) and rotates artifacts:
+
+```bash
+test/e2e/canary-buyer/run-canary.sh
+```
+
+The token is never echoed. Diagnostics go to stderr; the JSON run summary goes
+to stdout.
+
+## Schedule it (lab Mac, every 30 min)
+
+```bash
+# 1. Edit REPLACE_REPO_PATH / REPLACE_HOME in the plist to absolute paths.
+cp test/e2e/canary-buyer/com.streamvc.canary-buyer.plist ~/Library/LaunchAgents/
+launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/com.streamvc.canary-buyer.plist
+launchctl kickstart -p gui/$(id -u)/com.streamvc.canary-buyer   # run now
+```
+
+By default it writes a `.prom` textfile to
+`~/.local/state/canary-buyer/canary_buyer.prom` for the node_exporter
+[textfile collector](https://github.com/prometheus/node_exporter#textfile-collector).
+To push instead, set `CANARY_PUSHGATEWAY=http://host:9091` (in the plist
+`EnvironmentVariables` or the environment).
+
+## Configuration
+
+All env, all optional except the token:
+
+| Var | Default | Meaning |
+|-----|---------|---------|
+| `MACPROVIDER_BUYER_TOKEN` / `MALIBU_API_KEY` | — | buyer bearer (required) |
+| `CANARY_BASE` | `https://api.streamvc.live` | gateway base URL |
+| `CANARY_MODELS` | *(all from `/v1/status`)* | comma-separated model ids to probe |
+| `CANARY_TTFT_SAMPLES` | `12` | short requests/model for the TTFT histogram |
+| `CANARY_TPS_SAMPLES` | `3` | longer requests/model for sustained TPS |
+| `CANARY_TPS_MAX_TOKENS` | `128` | decode window for TPS samples |
+| `CANARY_INTERVAL_MS` | `1500` | floor gap between samples (avoids self-induced queueing; see scenario 09 pacing math) |
+| `CANARY_REQ_TIMEOUT_MS` | `45000` | per-request timeout |
+| `CANARY_ALLOW_INSECURE` | *(unset)* | set `1` to permit `http`/localhost/private-host targets (local mock testing only). By default `CANARY_BASE`/`CANARY_PUSHGATEWAY` must be `https` and non-private, so the buyer token can't be sent to an arbitrary origin. |
+
+The buyer token is redacted from all logs, stdout, and artifacts even if a
+mispointed gateway echoes the `Authorization` header.
+
+Flags: `--metrics-out <path>`, `--json-out <dir>`, `--pushgateway <url>`,
+`--fail-on-degraded` (exit 1 if the gateway is down or any model is
+unserviceable — for CI/alerting; default exit is 0 so launchd doesn't treat a
+bad-network run as a probe crash).
+
+## Cost
+
+Tiny. Default per model per run ≈ `12×8 + 3×128 + 2×16` ≈ **500 completion
+tokens**. At 30-minute cadence and one model that is ~24k tokens/day.
+
+## Suggested alerts
+
+```
+# Network says ready but can't actually serve. `on()` is required because
+# _up has no labels while _model_serviceable has {model} — a bare `and` matches
+# no series and the alert would silently never fire.
+(macprovider_canary_model_serviceable == 0) and on() (macprovider_canary_up == 1)
+
+# Silent throughput regression (tune the floor per model/tier from observed p50).
+macprovider_canary_decode_tps{quantile="p50"} < 15
+
+# TTFT SLO breach.
+macprovider_canary_ttft_ms{quantile="p95"} > 7000
+
+# Sticky affinity / KV-cache reuse collapsed.
+macprovider_canary_cached_prompt_ratio < 0.1
+
+# Probe stopped reporting.
+time() - macprovider_canary_run_timestamp_seconds > 5400
+```
+
+## Validation (2026-07-09)
+
+- Failure path verified against live prod during an active `upstream_provider_error`
+  incident: `up=1`, `serviceable=0`, outcomes `{502:4, 5xx:1}` recorded correctly.
+- Success path (TTFT percentiles, decode-TPS math, cache ratio, Prometheus
+  emission) verified against a local mock SSE gateway.

--- a/test/e2e/canary-buyer/canary-buyer.service
+++ b/test/e2e/canary-buyer/canary-buyer.service
@@ -1,0 +1,50 @@
+# macprovider canary buyer probe — systemd oneshot (Linux/always-on host).
+#
+# Companion to com.streamvc.canary-buyer.plist (the lab-Mac launchd variant).
+# Prefer this on an always-on host (VPS) so a sleeping Mac can't create blind
+# spots. Triggered by canary-buyer.timer.
+#
+# Install (Pearl):
+#   apt-get install -y nodejs            # >= 18 (ships probe-compatible ESM)
+#   install -d -o macprovider -g macprovider -m 0755 /opt/macprovider/canary-buyer
+#   cp probe.mjs run-canary.sh /opt/macprovider/canary-buyer/
+#   install -d -o macprovider -g macprovider -m 0750 /var/lib/macprovider/canary-buyer
+#   # buyer token via 0640 env file (NEVER inline in this unit):
+#   #   printf 'MACPROVIDER_BUYER_TOKEN=%s\n' "$TOKEN" > /etc/macprovider/canary-buyer.env
+#   #   chown root:macprovider /etc/macprovider/canary-buyer.env && chmod 0640 ...
+#   cp canary-buyer.service canary-buyer.timer /etc/systemd/system/
+#   systemctl daemon-reload && systemctl enable --now canary-buyer.timer
+[Unit]
+Description=macprovider canary buyer probe (e2e serving/perf harness)
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+User=macprovider
+Group=macprovider
+# Buyer token (MACPROVIDER_BUYER_TOKEN) and optional CANARY_HEARTBEAT_URL live
+# here, mode 0640 root:macprovider. The "-" tolerates a missing file so the unit
+# fails loud (no token) rather than refusing to load.
+EnvironmentFile=-/etc/macprovider/canary-buyer.env
+Environment=CANARY_BASE=https://api.streamvc.live
+Environment=CANARY_NODE_BIN=/usr/bin/node
+Environment=CANARY_METRICS_OUT=/var/lib/macprovider/canary-buyer/canary_buyer.prom
+Environment=CANARY_JSON_OUT=/var/lib/macprovider/canary-buyer/artifacts
+# --fail-on-degraded: exit non-zero when the gateway is down or any model is
+# unserviceable, so the run FAILS (visible in journald) and the heartbeat is not
+# pinged (dead-man switch fires upstream).
+ExecStart=/bin/bash /opt/macprovider/canary-buyer/run-canary.sh --fail-on-degraded
+TimeoutStartSec=180
+# Hardening — the probe only needs outbound https + its own state dir.
+NoNewPrivileges=true
+ProtectSystem=strict
+ProtectHome=true
+PrivateTmp=true
+PrivateDevices=true
+ProtectKernelTunables=true
+ProtectControlGroups=true
+ReadWritePaths=/var/lib/macprovider/canary-buyer
+StandardOutput=journal
+StandardError=journal
+SyslogIdentifier=canary-buyer

--- a/test/e2e/canary-buyer/canary-buyer.timer
+++ b/test/e2e/canary-buyer/canary-buyer.timer
@@ -1,0 +1,14 @@
+# Runs the canary buyer probe every 30 minutes. See canary-buyer.service.
+[Unit]
+Description=Run macprovider canary buyer probe every 30 min
+
+[Timer]
+OnBootSec=3min
+OnUnitActiveSec=30min
+# Jitter so the probe never lands on the same instant as other periodic jobs.
+RandomizedDelaySec=60
+# Catch up one missed run after downtime instead of waiting a full interval.
+Persistent=true
+
+[Install]
+WantedBy=timers.target

--- a/test/e2e/canary-buyer/com.streamvc.canary-buyer.plist
+++ b/test/e2e/canary-buyer/com.streamvc.canary-buyer.plist
@@ -31,9 +31,11 @@
     <key>CANARY_BASE</key>
     <string>https://api.streamvc.live</string>
     <!-- Uncomment to push to a Prometheus pushgateway instead of relying on the
-         node_exporter textfile collector:
+         node_exporter textfile collector. A localhost/http pushgateway also
+         requires CANARY_ALLOW_INSECURE=1 (URLs must be https + non-private by
+         default); prefer an https, non-private pushgateway address:
     <key>CANARY_PUSHGATEWAY</key>
-    <string>http://127.0.0.1:9091</string>
+    <string>https://pushgateway.internal.example:9091</string>
     -->
     <!-- Uncomment to pin an explicit model set instead of deriving from /v1/status:
     <key>CANARY_MODELS</key>

--- a/test/e2e/canary-buyer/com.streamvc.canary-buyer.plist
+++ b/test/e2e/canary-buyer/com.streamvc.canary-buyer.plist
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  launchd agent template — runs the canary buyer probe every 30 minutes on a lab Mac.
+
+  Install (per-user LaunchAgent):
+    1. Edit REPLACE_REPO_PATH below to the absolute checkout path.
+    2. Optionally set CANARY_PUSHGATEWAY / CANARY_MODELS in EnvironmentVariables.
+    3. cp com.streamvc.canary-buyer.plist ~/Library/LaunchAgents/
+    4. launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/com.streamvc.canary-buyer.plist
+    5. launchctl kickstart -p gui/$(id -u)/com.streamvc.canary-buyer   # run once now
+
+  Uninstall:
+    launchctl bootout gui/$(id -u)/com.streamvc.canary-buyer
+    rm ~/Library/LaunchAgents/com.streamvc.canary-buyer.plist
+-->
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>com.streamvc.canary-buyer</string>
+
+  <key>ProgramArguments</key>
+  <array>
+    <string>/bin/bash</string>
+    <string>REPLACE_REPO_PATH/test/e2e/canary-buyer/run-canary.sh</string>
+  </array>
+
+  <key>EnvironmentVariables</key>
+  <dict>
+    <key>PATH</key>
+    <string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>
+    <key>CANARY_BASE</key>
+    <string>https://api.streamvc.live</string>
+    <!-- Uncomment to push to a Prometheus pushgateway instead of relying on the
+         node_exporter textfile collector:
+    <key>CANARY_PUSHGATEWAY</key>
+    <string>http://127.0.0.1:9091</string>
+    -->
+    <!-- Uncomment to pin an explicit model set instead of deriving from /v1/status:
+    <key>CANARY_MODELS</key>
+    <string>mlx-community/Qwen3-Coder-30B-A3B-Instruct-4bit</string>
+    -->
+  </dict>
+
+  <key>StartInterval</key>
+  <integer>1800</integer>
+
+  <key>RunAtLoad</key>
+  <true/>
+
+  <key>StandardOutPath</key>
+  <string>REPLACE_HOME/Library/Logs/canary-buyer.out.log</string>
+  <key>StandardErrorPath</key>
+  <string>REPLACE_HOME/Library/Logs/canary-buyer.err.log</string>
+
+  <key>ProcessType</key>
+  <string>Background</string>
+</dict>
+</plist>

--- a/test/e2e/canary-buyer/probe.mjs
+++ b/test/e2e/canary-buyer/probe.mjs
@@ -53,6 +53,7 @@ const CONFIG = {
   tpsMaxTokens: intEnv('CANARY_TPS_MAX_TOKENS', 128),
   intervalMs: intEnv('CANARY_INTERVAL_MS', 1500),
   reqTimeoutMs: intEnv('CANARY_REQ_TIMEOUT_MS', 45000),
+  stickyPrefixLines: intEnv('CANARY_STICKY_PREFIX_LINES', 80),
   metricsOut: args['metrics-out'] || env('CANARY_METRICS_OUT') || '',
   jsonOut: args['json-out'] || env('CANARY_JSON_OUT') || '',
   pushgateway: args['pushgateway'] || env('CANARY_PUSHGATEWAY') || '',
@@ -405,13 +406,18 @@ async function sampleModel(model) {
     record(r, { tps: true });
   }
 
-  // 3. Sticky KV-cache reuse — two turns, same conversation tag.
+  // 3. Sticky KV-cache reuse — two turns, same conversation tag, sharing a
+  // large prefix. The prefix MUST be large enough to exceed the provider's
+  // prefix-cache granularity, otherwise turn-2 cached_prompt_tokens is always 0
+  // and the metric can't distinguish "working" from "reuse collapsed". A live
+  // measurement (2026-07-09, ~3.9k-token prefix) saw ~64% turn-2 reuse.
   await sleep(CONFIG.intervalMs);
   const conv = randUUID();
+  const prefix = stickyPrefix(CONFIG.stickyPrefixLines);
   const t1 = await streamOne({
     model,
     conversationId: conv,
-    messages: [{ role: 'user', content: 'Reply with exactly: pong' }],
+    messages: [{ role: 'user', content: `${prefix}\n\nReply with exactly: pong` }],
     maxTokens: 16,
   });
   record(t1);
@@ -421,7 +427,7 @@ async function sampleModel(model) {
       model,
       conversationId: conv,
       messages: [
-        { role: 'user', content: 'Reply with exactly: pong' },
+        { role: 'user', content: `${prefix}\n\nReply with exactly: pong` },
         { role: 'assistant', content: t1.content },
         { role: 'user', content: 'Reply with exactly: ping' },
       ],
@@ -459,6 +465,16 @@ function outcomeBucket(r) {
 
 function numOrNull(v) {
   return typeof v === 'number' && Number.isFinite(v) ? v : null;
+}
+// Deterministic shared prefix (~10 tokens/line) for the sticky KV-cache test.
+// Large enough to exceed the provider's prefix-cache granularity so turn-2
+// cached_prompt_tokens is a real reuse signal.
+function stickyPrefix(lines) {
+  const out = ['Reference facts to retain for this conversation:'];
+  for (let i = 0; i < lines; i++) {
+    out.push(`- item ${i}: key K${i} maps to value V${i * 7} under namespace N${i % 9}; invariant s${i} > ${i}.`);
+  }
+  return out.join('\n');
 }
 function randUUID() {
   return crypto.randomUUID();

--- a/test/e2e/canary-buyer/probe.mjs
+++ b/test/e2e/canary-buyer/probe.mjs
@@ -225,6 +225,7 @@ async function streamOne({ model, messages, conversationId, maxTokens }) {
   let usage = null;
   let requestId = '';
   let provider = '';
+  let streamError = null;
 
   try {
     const r = await fetch(`${CONFIG.base}/v1/chat/completions`, {
@@ -280,6 +281,9 @@ async function streamOne({ model, messages, conversationId, maxTokens }) {
             } catch {
               continue;
             }
+            // A terminal error frame means the completion failed even if content
+            // already streamed — don't count it as a healthy sample.
+            if (obj?.error) streamError = obj.error;
             const delta = obj?.choices?.[0]?.delta?.content;
             if (delta) {
               if (!firstTokenAt) firstTokenAt = now();
@@ -305,6 +309,17 @@ async function streamOne({ model, messages, conversationId, maxTokens }) {
   }
 
   const end = now();
+  if (streamError) {
+    return {
+      ok: false,
+      status: 200,
+      kind: 'stream_error',
+      error: redact(`stream error frame: ${JSON.stringify(streamError).slice(0, 200)}`),
+      requestId,
+      provider,
+      usage,
+    };
+  }
   if (!firstTokenAt) {
     // 2xx but no content token ever arrived (e.g. empty completion / mid-stream abort).
     return { ok: false, status: 200, error: 'no content token', requestId, provider, usage };
@@ -337,7 +352,7 @@ async function sampleModel(model) {
     model,
     ttftMs: [],
     decodeTps: [],
-    outcomes: {}, // "2xx" | "502" | "5xx" | "timeout" | "empty" | "other"
+    outcomes: {}, // 2xx | 502 | 5xx | timeout | network_error | stream_error | empty | other
     samples: 0,
     firstError: '',
     cachedRatio: null,
@@ -431,9 +446,11 @@ async function sampleModel(model) {
   return res;
 }
 
+// Buckets: 2xx | 502 | 5xx | timeout | network_error | stream_error | empty | other
 function outcomeBucket(r) {
   if (r.ok) return '2xx';
-  if (r.status === 0) return r.kind === 'timeout' ? 'timeout' : 'network_error';
+  if (r.kind) return r.kind; // timeout | network_error | stream_error
+  if (r.status === 0) return 'network_error';
   if (r.status === 502) return '502';
   if (r.status === 200) return 'empty';
   if (r.status >= 500) return '5xx';
@@ -527,7 +544,9 @@ function toProm(run) {
 
   h('macprovider_canary_model_serviceable', 'A chat completion actually produced a token (1) despite status. Catches status-vs-serviceable divergence.', 'gauge');
   h('macprovider_canary_ttft_ms', 'Time-to-first-token in ms by quantile.', 'gauge');
+  h('macprovider_canary_ttft_samples', 'Valid TTFT samples collected this run (0 while serviceable=1 means the signal went dark).', 'gauge');
   h('macprovider_canary_decode_tps', 'Sustained decode tokens/sec (excludes first token/prefill).', 'gauge');
+  h('macprovider_canary_decode_tps_samples', 'Valid decode-TPS samples this run (0 while serviceable=1 means usage stopped being reported).', 'gauge');
   h('macprovider_canary_cached_prompt_ratio', 'Sticky turn-2 cached_prompt_tokens / prompt_tokens (KV-cache reuse).', 'gauge');
   // Per-run gauges (reset each run), NOT cumulative counters — hence no _total
   // suffix, so consumers don't apply rate()/counter semantics to them.
@@ -544,6 +563,10 @@ function toProm(run) {
     for (const q of ['p50', 'p95', 'p99']) {
       if (m.ttft_ms[q] != null) L.push(`macprovider_canary_ttft_ms{${lbl({ ...base, quantile: q })}} ${m.ttft_ms[q]}`);
     }
+    // Explicit sample counts so alerts can catch "serviceable but signal dark"
+    // — Prometheus can't easily alert on an absent series.
+    L.push(`macprovider_canary_ttft_samples{${lbl(base)}} ${m.ttft_ms.n}`);
+    L.push(`macprovider_canary_decode_tps_samples{${lbl(base)}} ${m.decode_tps.n}`);
     // Only the p50 quantile is emitted to Prometheus; mean stays in the JSON
     // artifact (a mean under a quantile label misleads Prometheus consumers).
     if (m.decode_tps.p50 != null) L.push(`macprovider_canary_decode_tps{${lbl({ ...base, quantile: 'p50' })}} ${round(m.decode_tps.p50)}`);
@@ -632,19 +655,19 @@ async function main() {
 
   if (CONFIG.metricsOut) {
     await writeAtomic(CONFIG.metricsOut, prom);
-    console.error(`wrote metrics → ${CONFIG.metricsOut}`);
+    console.error(redact(`wrote metrics → ${CONFIG.metricsOut}`));
   }
   if (CONFIG.jsonOut) {
     const fname = `canary-${run.run_at.replace(/[:.]/g, '-')}.json`;
     const path = await joinPath(CONFIG.jsonOut, fname);
     await writeAtomic(path, runJson + '\n');
     await rotateArtifacts(CONFIG.jsonOut, 200);
-    console.error(`wrote artifact → ${path}`);
+    console.error(redact(`wrote artifact → ${path}`));
   }
   if (CONFIG.pushgateway) {
     try {
       await pushMetrics(prom);
-      console.error(`pushed metrics → ${CONFIG.pushgateway}`);
+      console.error(redact(`pushed metrics → ${CONFIG.pushgateway}`));
     } catch (e) {
       console.error(`WARN: pushgateway failed: ${redact(e.message)}`);
     }
@@ -675,7 +698,12 @@ async function writeAtomic(path, content) {
   const tmp = `${path}.tmp-${process.pid}-${randUUID()}`;
   await fs.mkdir(dirname(path), { recursive: true }).catch(() => {});
   await fs.writeFile(tmp, content, { flag: 'wx', mode: 0o600 });
-  await fs.rename(tmp, path);
+  try {
+    await fs.rename(tmp, path);
+  } catch (e) {
+    await fs.unlink(tmp).catch(() => {}); // don't leave a .tmp behind on failure
+    throw e;
+  }
 }
 async function joinPath(dir, file) {
   const fs = await import('node:fs/promises');

--- a/test/e2e/canary-buyer/probe.mjs
+++ b/test/e2e/canary-buyer/probe.mjs
@@ -36,6 +36,9 @@
  *   CANARY_REQ_TIMEOUT_MS per-request timeout (default 45000)
  */
 
+import net from 'node:net';
+import dns from 'node:dns/promises';
+
 const args = parseArgs(process.argv.slice(2));
 
 const CONFIG = {
@@ -91,7 +94,11 @@ function authHeaders(extra = {}) {
 function redact(text) {
   if (text == null) return text;
   let s = String(text);
-  if (CONFIG.token) s = s.split(CONFIG.token).join('***');
+  // Only scrub the literal token when it is long enough to be a real credential
+  // (harness buyer keys are mp_ + 20+ chars). A pathologically short token would
+  // otherwise corrupt legitimate output by matching common substrings. The
+  // Bearer-pattern scrub below still catches the credential regardless.
+  if (CONFIG.token && CONFIG.token.length >= 8) s = s.split(CONFIG.token).join('***');
   return s.replace(/Bearer\s+[A-Za-z0-9._~+/=-]+/gi, 'Bearer ***');
 }
 
@@ -110,24 +117,78 @@ function parseSafeUrl(raw, label) {
   if (u.protocol !== 'https:' && !(insecure && u.protocol === 'http:')) {
     throw new Error(`${label} must be https (set CANARY_ALLOW_INSECURE=1 to allow http for local testing)`);
   }
-  if (!insecure && isPrivateHost(u.hostname)) {
+  if (!insecure && isPrivateHostname(u.hostname)) {
     throw new Error(`${label} points at a private/loopback host (set CANARY_ALLOW_INSECURE=1 to allow)`);
   }
   return u;
 }
-function isPrivateHost(host) {
-  const h = host.toLowerCase().replace(/^\[|\]$/g, '');
-  if (h === 'localhost' || h.endsWith('.localhost') || h === '') return true;
-  if (h === '::1' || h.startsWith('fc') || h.startsWith('fd') || h.startsWith('fe80')) return true;
-  const m = h.match(/^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/);
-  if (m) {
-    const a = Number(m[1]);
-    const b = Number(m[2]);
-    if (a === 127 || a === 10 || a === 0) return true;
-    if (a === 169 && b === 254) return true;
-    if (a === 172 && b >= 16 && b <= 31) return true;
-    if (a === 192 && b === 168) return true;
+
+// Resolve the host and reject if it maps to a private address, closing the
+// static-misconfiguration / private-DNS SSRF case that a literal-hostname check
+// misses. Pure DNS-rebinding (a flip between this check and fetch's own resolve)
+// is an inherent limitation of dependency-free fetch and is accepted as a
+// residual risk for this operator-run internal tool; `redirect: 'manual'` on the
+// token-bearing requests closes the redirect-based variant.
+async function assertResolvesPublic(u, label) {
+  if (env('CANARY_ALLOW_INSECURE') === '1') return;
+  const host = u.hostname.replace(/^\[|\]$/g, '');
+  if (net.isIP(host)) return; // literal IP already screened by isPrivateHostname
+  let addrs;
+  try {
+    addrs = await dns.lookup(host, { all: true });
+  } catch {
+    throw new Error(`${label} host ${host} does not resolve`);
   }
+  for (const { address } of addrs) {
+    if (isPrivateIp(address)) {
+      throw new Error(`${label} host ${host} resolves to a private address`);
+    }
+  }
+}
+
+function isPrivateHostname(host) {
+  const h = host.toLowerCase().replace(/^\[|\]$/g, '').replace(/\.$/, '');
+  if (h === '' || h === 'localhost' || h.endsWith('.localhost')) return true;
+  if (net.isIP(h)) return isPrivateIp(h);
+  return false; // a real hostname is screened at resolve time by assertResolvesPublic
+}
+
+function isPrivateIp(ip) {
+  const fam = net.isIP(ip);
+  if (!fam) return false;
+  const addr = ip.toLowerCase();
+  if (fam === 6) {
+    // IPv4-mapped/compat, in dotted (::ffff:127.0.0.1) or hex (::ffff:7f00:1)
+    // form — URL parsing normalizes to the latter, so handle both.
+    const v4 = ipv4FromMapped(addr);
+    if (v4) return isPrivateIp4(v4);
+    if (addr === '::' || addr === '::1') return true; // unspecified + loopback
+    const first = addr.split(':')[0];
+    if (/^fe[89ab]/.test(first)) return true; // fe80::/10 link-local
+    if (/^f[cd]/.test(first)) return true; // fc00::/7 unique-local
+    return false;
+  }
+  return isPrivateIp4(addr);
+}
+function ipv4FromMapped(addr) {
+  const m = addr.match(/^(?:::ffff:|::)([0-9a-f.:]+)$/);
+  if (!m) return null;
+  const tail = m[1];
+  if (tail.includes('.')) return tail; // already dotted
+  const groups = tail.split(':').filter((g) => g.length);
+  if (groups.length !== 2) return null; // low 32 bits are exactly two hex groups
+  const [g1, g2] = groups.map((g) => parseInt(g, 16));
+  if (!Number.isInteger(g1) || !Number.isInteger(g2)) return null;
+  return `${(g1 >> 8) & 0xff}.${g1 & 0xff}.${(g2 >> 8) & 0xff}.${g2 & 0xff}`;
+}
+function isPrivateIp4(ip) {
+  const p = ip.split('.').map(Number);
+  if (p.length !== 4 || p.some((n) => !Number.isInteger(n) || n < 0 || n > 255)) return false;
+  const [a, b] = p;
+  if (a === 0 || a === 10 || a === 127) return true;
+  if (a === 169 && b === 254) return true;
+  if (a === 172 && b >= 16 && b <= 31) return true;
+  if (a === 192 && b === 168) return true;
   return false;
 }
 
@@ -137,6 +198,7 @@ async function getStatus() {
   const ctl = AbortSignal.timeout(CONFIG.reqTimeoutMs);
   const r = await fetch(`${CONFIG.base}/v1/status`, {
     headers: authHeaders({ Accept: 'application/json' }),
+    redirect: 'manual',
     signal: ctl,
   });
   const text = await r.text();
@@ -168,7 +230,17 @@ async function streamOne({ model, messages, conversationId, maxTokens }) {
     const r = await fetch(`${CONFIG.base}/v1/chat/completions`, {
       method: 'POST',
       headers,
-      body: JSON.stringify({ model, messages, stream: true, max_tokens: maxTokens }),
+      // include_usage requests the final usage chunk in the stream — without it
+      // a spec-strict gateway omits usage and decode-TPS/cache-ratio go silently
+      // null while the request still counts as serviceable.
+      body: JSON.stringify({
+        model,
+        messages,
+        stream: true,
+        max_tokens: maxTokens,
+        stream_options: { include_usage: true },
+      }),
+      redirect: 'manual',
       signal: AbortSignal.timeout(CONFIG.reqTimeoutMs),
     });
     requestId = r.headers.get('x-request-id') || '';
@@ -226,7 +298,10 @@ async function streamOne({ model, messages, conversationId, maxTokens }) {
       }
     }
   } catch (e) {
-    return { ok: false, status: 0, error: redact(`stream error: ${e.message || e}`), requestId, provider };
+    // Distinguish a request timeout (AbortError from AbortSignal.timeout) from
+    // other connect/DNS/TLS/reset failures so the outcome buckets stay honest.
+    const kind = e && e.name === 'TimeoutError' ? 'timeout' : 'network_error';
+    return { ok: false, status: 0, kind, error: redact(`${kind}: ${e.message || e}`), requestId, provider };
   }
 
   const end = now();
@@ -271,14 +346,19 @@ async function sampleModel(model) {
     provider: '',
   };
 
-  const record = (r) => {
+  // Metric collection is per sample class: only the short-request loop feeds the
+  // TTFT distribution, only the long-request loop feeds sustained TPS. Mixing
+  // them would contaminate TTFT percentiles with long-generation requests and
+  // TPS with 8-token noise. `collect` selects which array (if any) this request
+  // contributes to; every request still contributes to outcome counts.
+  const record = (r, collect = {}) => {
     res.samples++;
     if (r.provider && !res.provider) res.provider = r.provider;
     const bucket = outcomeBucket(r);
     res.outcomes[bucket] = (res.outcomes[bucket] || 0) + 1;
     if (r.ok) {
-      res.ttftMs.push(r.ttftMs);
-      if (r.decodeTps != null) res.decodeTps.push(r.decodeTps);
+      if (collect.ttft) res.ttftMs.push(r.ttftMs);
+      if (collect.tps && r.decodeTps != null) res.decodeTps.push(r.decodeTps);
     } else if (!res.firstError) {
       res.firstError = `HTTP ${r.status}: ${r.error || ''}`.slice(0, 200);
     }
@@ -292,7 +372,7 @@ async function sampleModel(model) {
       messages: [{ role: 'user', content: 'Say: ready.' }],
       maxTokens: 8,
     });
-    record(r);
+    record(r, { ttft: true });
     if (i < CONFIG.ttftSamples - 1) await sleep(CONFIG.intervalMs);
   }
 
@@ -307,7 +387,7 @@ async function sampleModel(model) {
       ],
       maxTokens: CONFIG.tpsMaxTokens,
     });
-    record(r);
+    record(r, { tps: true });
   }
 
   // 3. Sticky KV-cache reuse — two turns, same conversation tag.
@@ -344,13 +424,16 @@ async function sampleModel(model) {
     }
   }
 
-  res.serviceable = res.ttftMs.length > 0 ? 1 : 0;
+  // Serviceable iff any request across all classes produced a token (a 2xx
+  // outcome), not just the TTFT loop — a model that fails short probes but
+  // serves long ones is still serving.
+  res.serviceable = (res.outcomes['2xx'] || 0) > 0 ? 1 : 0;
   return res;
 }
 
 function outcomeBucket(r) {
   if (r.ok) return '2xx';
-  if (r.status === 0) return 'timeout';
+  if (r.status === 0) return r.kind === 'timeout' ? 'timeout' : 'network_error';
   if (r.status === 502) return '502';
   if (r.status === 200) return 'empty';
   if (r.status >= 500) return '5xx';
@@ -461,8 +544,9 @@ function toProm(run) {
     for (const q of ['p50', 'p95', 'p99']) {
       if (m.ttft_ms[q] != null) L.push(`macprovider_canary_ttft_ms{${lbl({ ...base, quantile: q })}} ${m.ttft_ms[q]}`);
     }
+    // Only the p50 quantile is emitted to Prometheus; mean stays in the JSON
+    // artifact (a mean under a quantile label misleads Prometheus consumers).
     if (m.decode_tps.p50 != null) L.push(`macprovider_canary_decode_tps{${lbl({ ...base, quantile: 'p50' })}} ${round(m.decode_tps.p50)}`);
-    if (m.decode_tps.mean != null) L.push(`macprovider_canary_decode_tps{${lbl({ ...base, quantile: 'mean' })}} ${round(m.decode_tps.mean)}`);
     if (m.cached_prompt_ratio != null) L.push(`macprovider_canary_cached_prompt_ratio{${lbl(base)}} ${round(m.cached_prompt_ratio, 4)}`);
   }
   return L.join('\n') + '\n';
@@ -479,6 +563,7 @@ async function pushMetrics(text) {
     method: 'POST',
     headers: { 'Content-Type': 'text/plain' },
     body: text,
+    redirect: 'manual',
     signal: AbortSignal.timeout(15000),
   });
   if (!r.ok) throw new Error(`pushgateway HTTP ${r.status}`);
@@ -492,10 +577,14 @@ async function main() {
     process.exit(2);
   }
   try {
-    parseSafeUrl(`${CONFIG.base}/v1/status`, 'CANARY_BASE');
-    if (CONFIG.pushgateway) parseSafeUrl(CONFIG.pushgateway, 'CANARY_PUSHGATEWAY');
+    const baseUrl = parseSafeUrl(`${CONFIG.base}/v1/status`, 'CANARY_BASE');
+    await assertResolvesPublic(baseUrl, 'CANARY_BASE');
+    if (CONFIG.pushgateway) {
+      const pgUrl = parseSafeUrl(CONFIG.pushgateway, 'CANARY_PUSHGATEWAY');
+      await assertResolvesPublic(pgUrl, 'CANARY_PUSHGATEWAY');
+    }
   } catch (e) {
-    console.error(`FAIL: ${e.message}`);
+    console.error(`FAIL: ${redact(e.message)}`);
     process.exit(2);
   }
   const runStartUnix = Math.floor(realUnix());
@@ -517,22 +606,29 @@ async function main() {
 
   const results = [];
   for (const model of models) {
-    process.stderr.write(`probing ${model} ...\n`);
+    process.stderr.write(redact(`probing ${model} ...\n`));
     const r = await sampleModel(model);
     results.push(r);
     const t = r.ttftMs.length ? `ttft_p50=${percentile(r.ttftMs, 50)}ms p95=${percentile(r.ttftMs, 95)}ms` : 'ttft=none';
     const tps = r.decodeTps.length ? `tps_p50=${round(percentile(r.decodeTps, 50))}` : 'tps=none';
     const cache = r.cachedRatio != null ? `cache=${round(r.cachedRatio, 3)}` : 'cache=n/a';
+    // redact: a hostile gateway could plant the token in a server-controlled
+    // field (model id, provider id, error) that lands in this progress line.
     console.error(
-      `  ${model}: serviceable=${r.serviceable} ${t} ${tps} ${cache} outcomes=${JSON.stringify(r.outcomes)}${r.firstError ? ` firstErr="${r.firstError}"` : ''}`
+      redact(
+        `  ${model}: serviceable=${r.serviceable} ${t} ${tps} ${cache} outcomes=${JSON.stringify(r.outcomes)}${r.firstError ? ` firstErr="${r.firstError}"` : ''}`
+      )
     );
   }
 
   const run = buildRun(status, results, runStartUnix);
-  const prom = toProm(run);
+  // Redact every serialized sink, not just error text: any server-controlled
+  // string (model/provider id, coordinator status) could carry the token.
+  const prom = redact(toProm(run));
+  const runJson = redact(JSON.stringify(run, null, 2));
 
   // stdout: the JSON run summary (machine-readable). Diagnostics go to stderr.
-  console.log(JSON.stringify(run, null, 2));
+  console.log(runJson);
 
   if (CONFIG.metricsOut) {
     await writeAtomic(CONFIG.metricsOut, prom);
@@ -541,7 +637,8 @@ async function main() {
   if (CONFIG.jsonOut) {
     const fname = `canary-${run.run_at.replace(/[:.]/g, '-')}.json`;
     const path = await joinPath(CONFIG.jsonOut, fname);
-    await writeAtomic(path, JSON.stringify(run, null, 2) + '\n');
+    await writeAtomic(path, runJson + '\n');
+    await rotateArtifacts(CONFIG.jsonOut, 200);
     console.error(`wrote artifact → ${path}`);
   }
   if (CONFIG.pushgateway) {
@@ -549,7 +646,7 @@ async function main() {
       await pushMetrics(prom);
       console.error(`pushed metrics → ${CONFIG.pushgateway}`);
     } catch (e) {
-      console.error(`WARN: pushgateway failed: ${e.message}`);
+      console.error(`WARN: pushgateway failed: ${redact(e.message)}`);
     }
   }
 
@@ -573,15 +670,44 @@ function realUnix() {
 
 async function writeAtomic(path, content) {
   const fs = await import('node:fs/promises');
-  const tmp = `${path}.tmp-${process.pid}`;
+  // Unpredictable temp name + exclusive create (wx) so a pre-planted symlink in
+  // a writable output dir can't redirect the write; restrictive mode on create.
+  const tmp = `${path}.tmp-${process.pid}-${randUUID()}`;
   await fs.mkdir(dirname(path), { recursive: true }).catch(() => {});
-  await fs.writeFile(tmp, content);
+  await fs.writeFile(tmp, content, { flag: 'wx', mode: 0o600 });
   await fs.rename(tmp, path);
 }
 async function joinPath(dir, file) {
   const fs = await import('node:fs/promises');
   await fs.mkdir(dir, { recursive: true }).catch(() => {});
   return dir.replace(/\/$/, '') + '/' + file;
+}
+
+// Keep only the newest `keep` canary artifacts. Done in Node (readdir/stat/
+// unlink) rather than shell so no filename can be misparsed into a bad delete.
+async function rotateArtifacts(dir, keep) {
+  const fs = await import('node:fs/promises');
+  let names;
+  try {
+    names = await fs.readdir(dir);
+  } catch {
+    return;
+  }
+  const files = names.filter((f) => /^canary-.*\.json$/.test(f));
+  if (files.length <= keep) return;
+  const stated = [];
+  for (const f of files) {
+    try {
+      const st = await fs.stat(`${dir.replace(/\/$/, '')}/${f}`);
+      stated.push({ f, mtime: st.mtimeMs });
+    } catch {
+      /* skip unstatable entry */
+    }
+  }
+  stated.sort((a, b) => b.mtime - a.mtime);
+  for (const { f } of stated.slice(keep)) {
+    await fs.unlink(`${dir.replace(/\/$/, '')}/${f}`).catch(() => {});
+  }
 }
 function dirname(p) {
   const i = p.lastIndexOf('/');

--- a/test/e2e/canary-buyer/probe.mjs
+++ b/test/e2e/canary-buyer/probe.mjs
@@ -1,0 +1,594 @@
+#!/usr/bin/env node
+/**
+ * Canary buyer probe — continuous synthetic-buyer measurement of the live
+ * macprovider network from the buyer's perspective.
+ *
+ * P1 from the 2026-07-09 e2e-testing review: productionizes
+ * test/e2e/malibu-console/smoke.mjs + network-harness scenarios 07/09 into a
+ * scheduled probe that records, per model class, the buyer-observable signals:
+ *
+ *   - TTFT (time to first content token) distribution: p50 / p95 / p99
+ *   - sustained decode TPS (completion_tokens / decode window)
+ *   - sticky KV-cache reuse ratio (cached_prompt_tokens / prompt_tokens on turn 2)
+ *   - serviceability: does a chat actually complete, vs /v1/status claiming ready
+ *   - request outcome counts (2xx / 502 / other) for a 502-rate signal
+ *
+ * Emits Prometheus text-exposition metrics (node_exporter textfile collector or
+ * pushgateway) plus a per-run JSON artifact. Designed to run every 30–60 min on
+ * a lab Mac via launchd (see com.streamvc.canary-buyer.plist).
+ *
+ * Zero dependencies (Node >= 18 built-in fetch), matching smoke.mjs.
+ *
+ * Usage:
+ *   MACPROVIDER_BUYER_TOKEN=mp_... node probe.mjs \
+ *     --metrics-out /var/lib/node_exporter/textfile/canary_buyer.prom \
+ *     --json-out ./artifacts \
+ *     --pushgateway http://localhost:9091
+ *
+ * Config (env, all optional except a token):
+ *   MACPROVIDER_BUYER_TOKEN | MALIBU_API_KEY   buyer bearer token (required)
+ *   CANARY_BASE            gateway base URL (default https://api.streamvc.live)
+ *   CANARY_MODELS         comma list of model ids (default: all from /v1/status)
+ *   CANARY_TTFT_SAMPLES   short-request samples per model (default 12)
+ *   CANARY_TPS_SAMPLES    longer-request samples per model (default 3)
+ *   CANARY_TPS_MAX_TOKENS decode window for TPS samples (default 128)
+ *   CANARY_INTERVAL_MS    floor gap between samples (default 1500)
+ *   CANARY_REQ_TIMEOUT_MS per-request timeout (default 45000)
+ */
+
+const args = parseArgs(process.argv.slice(2));
+
+const CONFIG = {
+  base: (env('CANARY_BASE') || 'https://api.streamvc.live').replace(/\/$/, ''),
+  token: env('MACPROVIDER_BUYER_TOKEN') || env('MALIBU_API_KEY') || '',
+  models: (env('CANARY_MODELS') || '')
+    .split(',')
+    .map((s) => s.trim())
+    .filter(Boolean),
+  ttftSamples: intEnv('CANARY_TTFT_SAMPLES', 12),
+  tpsSamples: intEnv('CANARY_TPS_SAMPLES', 3),
+  tpsMaxTokens: intEnv('CANARY_TPS_MAX_TOKENS', 128),
+  intervalMs: intEnv('CANARY_INTERVAL_MS', 1500),
+  reqTimeoutMs: intEnv('CANARY_REQ_TIMEOUT_MS', 45000),
+  metricsOut: args['metrics-out'] || env('CANARY_METRICS_OUT') || '',
+  jsonOut: args['json-out'] || env('CANARY_JSON_OUT') || '',
+  pushgateway: args['pushgateway'] || env('CANARY_PUSHGATEWAY') || '',
+  pushJob: args['push-job'] || env('CANARY_PUSH_JOB') || 'canary_buyer',
+  failOnDegraded: 'fail-on-degraded' in args,
+};
+
+function env(k) {
+  return process.env[k] && process.env[k].length ? process.env[k] : '';
+}
+function intEnv(k, d) {
+  const v = parseInt(env(k), 10);
+  return Number.isFinite(v) && v > 0 ? v : d;
+}
+function parseArgs(argv) {
+  const out = {};
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (!a.startsWith('--')) continue;
+    const key = a.slice(2);
+    const next = argv[i + 1];
+    if (next && !next.startsWith('--')) {
+      out[key] = next;
+      i++;
+    } else {
+      out[key] = true;
+    }
+  }
+  return out;
+}
+
+function authHeaders(extra = {}) {
+  return { Authorization: `Bearer ${CONFIG.token}`, ...extra };
+}
+
+// Redact the buyer token and any Bearer credential from any text before it
+// reaches a log, stdout, or an on-disk artifact. A mispointed or compromised
+// gateway that echoes the Authorization header must not persist the token.
+function redact(text) {
+  if (text == null) return text;
+  let s = String(text);
+  if (CONFIG.token) s = s.split(CONFIG.token).join('***');
+  return s.replace(/Bearer\s+[A-Za-z0-9._~+/=-]+/gi, 'Bearer ***');
+}
+
+// Validate a URL we are about to send the buyer token to. Require https and
+// reject private/loopback/link-local hosts so a bad env/plist/CLI value can't
+// exfiltrate the token or perform local-network SSRF. CANARY_ALLOW_INSECURE=1
+// opts into http/localhost for local testing against a mock gateway.
+function parseSafeUrl(raw, label) {
+  let u;
+  try {
+    u = new URL(raw);
+  } catch {
+    throw new Error(`${label} is not a valid URL`);
+  }
+  const insecure = env('CANARY_ALLOW_INSECURE') === '1';
+  if (u.protocol !== 'https:' && !(insecure && u.protocol === 'http:')) {
+    throw new Error(`${label} must be https (set CANARY_ALLOW_INSECURE=1 to allow http for local testing)`);
+  }
+  if (!insecure && isPrivateHost(u.hostname)) {
+    throw new Error(`${label} points at a private/loopback host (set CANARY_ALLOW_INSECURE=1 to allow)`);
+  }
+  return u;
+}
+function isPrivateHost(host) {
+  const h = host.toLowerCase().replace(/^\[|\]$/g, '');
+  if (h === 'localhost' || h.endsWith('.localhost') || h === '') return true;
+  if (h === '::1' || h.startsWith('fc') || h.startsWith('fd') || h.startsWith('fe80')) return true;
+  const m = h.match(/^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/);
+  if (m) {
+    const a = Number(m[1]);
+    const b = Number(m[2]);
+    if (a === 127 || a === 10 || a === 0) return true;
+    if (a === 169 && b === 254) return true;
+    if (a === 172 && b >= 16 && b <= 31) return true;
+    if (a === 192 && b === 168) return true;
+  }
+  return false;
+}
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+async function getStatus() {
+  const ctl = AbortSignal.timeout(CONFIG.reqTimeoutMs);
+  const r = await fetch(`${CONFIG.base}/v1/status`, {
+    headers: authHeaders({ Accept: 'application/json' }),
+    signal: ctl,
+  });
+  const text = await r.text();
+  if (!r.ok) throw new Error(redact(`/v1/status HTTP ${r.status}: ${text.slice(0, 200)}`));
+  return JSON.parse(text);
+}
+
+/**
+ * Stream one chat completion, measuring TTFT and decode-window timing.
+ * Never throws on HTTP/stream errors — returns {ok:false, status, error} so
+ * the caller can record failures as metrics (recording failures is the point).
+ */
+async function streamOne({ model, messages, conversationId, maxTokens }) {
+  const headers = authHeaders({
+    'Content-Type': 'application/json',
+    Accept: 'text/event-stream',
+  });
+  if (conversationId) headers['X-MacProvider-Conversation'] = conversationId;
+
+  const start = now();
+  let firstTokenAt = 0;
+  let lastTokenAt = 0;
+  let content = '';
+  let usage = null;
+  let requestId = '';
+  let provider = '';
+
+  try {
+    const r = await fetch(`${CONFIG.base}/v1/chat/completions`, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify({ model, messages, stream: true, max_tokens: maxTokens }),
+      signal: AbortSignal.timeout(CONFIG.reqTimeoutMs),
+    });
+    requestId = r.headers.get('x-request-id') || '';
+    provider = r.headers.get('x-provider-id') || r.headers.get('x-macprovider-provider') || '';
+
+    if (!r.ok) {
+      const text = await r.text().catch(() => '');
+      return { ok: false, status: r.status, error: redact(text.slice(0, 300)), requestId, provider };
+    }
+
+    const reader = r.body.getReader();
+    const decoder = new TextDecoder();
+    let buf = '';
+    // SSE events are separated by a blank line, which may be LF (\n\n) or CRLF
+    // (\r\n\r\n) depending on the server/proxy. Match either, else a CRLF stream
+    // buffers forever and the request is falsely recorded as "empty".
+    const nextSep = (s) => {
+      const m = /\r?\n\r?\n/.exec(s);
+      return m ? { idx: m.index, len: m[0].length } : null;
+    };
+    try {
+      for (;;) {
+        const { value, done } = await reader.read();
+        if (done) break;
+        buf += decoder.decode(value, { stream: true });
+        let sep;
+        while ((sep = nextSep(buf))) {
+          const frame = buf.slice(0, sep.idx);
+          buf = buf.slice(sep.idx + sep.len);
+          for (const line of frame.split(/\r?\n/)) {
+            if (!line.startsWith('data:')) continue;
+            const payload = line.slice(5).trim();
+            if (!payload || payload === '[DONE]') continue;
+            let obj;
+            try {
+              obj = JSON.parse(payload);
+            } catch {
+              continue;
+            }
+            const delta = obj?.choices?.[0]?.delta?.content;
+            if (delta) {
+              if (!firstTokenAt) firstTokenAt = now();
+              lastTokenAt = now();
+              content += delta;
+            }
+            if (obj?.usage) usage = obj.usage;
+          }
+        }
+      }
+    } finally {
+      try {
+        reader.releaseLock();
+      } catch {
+        /* reader already released */
+      }
+    }
+  } catch (e) {
+    return { ok: false, status: 0, error: redact(`stream error: ${e.message || e}`), requestId, provider };
+  }
+
+  const end = now();
+  if (!firstTokenAt) {
+    // 2xx but no content token ever arrived (e.g. empty completion / mid-stream abort).
+    return { ok: false, status: 200, error: 'no content token', requestId, provider, usage };
+  }
+  const ttftMs = firstTokenAt - start;
+  const decodeMs = Math.max(0, lastTokenAt - firstTokenAt);
+  const completionTokens = usage?.completion_tokens ?? null;
+  let decodeTps = null;
+  if (completionTokens && completionTokens > 1 && decodeMs > 0) {
+    // Exclude the first token from the decode-rate window: TTFT already accounts
+    // for prefill + first token; the sustained rate is the remaining tokens.
+    decodeTps = ((completionTokens - 1) / decodeMs) * 1000;
+  }
+  return {
+    ok: true,
+    status: 200,
+    ttftMs,
+    decodeMs,
+    totalMs: end - start,
+    decodeTps,
+    content,
+    usage,
+    requestId,
+    provider,
+  };
+}
+
+async function sampleModel(model) {
+  const res = {
+    model,
+    ttftMs: [],
+    decodeTps: [],
+    outcomes: {}, // "2xx" | "502" | "5xx" | "timeout" | "empty" | "other"
+    samples: 0,
+    firstError: '',
+    cachedRatio: null,
+    cachedPromptTokens: null,
+    promptTokens: null,
+    provider: '',
+  };
+
+  const record = (r) => {
+    res.samples++;
+    if (r.provider && !res.provider) res.provider = r.provider;
+    const bucket = outcomeBucket(r);
+    res.outcomes[bucket] = (res.outcomes[bucket] || 0) + 1;
+    if (r.ok) {
+      res.ttftMs.push(r.ttftMs);
+      if (r.decodeTps != null) res.decodeTps.push(r.decodeTps);
+    } else if (!res.firstError) {
+      res.firstError = `HTTP ${r.status}: ${r.error || ''}`.slice(0, 200);
+    }
+  };
+
+  // 1. TTFT distribution — many short requests, fresh conversation each.
+  for (let i = 0; i < CONFIG.ttftSamples; i++) {
+    const r = await streamOne({
+      model,
+      conversationId: randUUID(),
+      messages: [{ role: 'user', content: 'Say: ready.' }],
+      maxTokens: 8,
+    });
+    record(r);
+    if (i < CONFIG.ttftSamples - 1) await sleep(CONFIG.intervalMs);
+  }
+
+  // 2. Sustained decode TPS — fewer, longer requests.
+  for (let i = 0; i < CONFIG.tpsSamples; i++) {
+    await sleep(CONFIG.intervalMs);
+    const r = await streamOne({
+      model,
+      conversationId: randUUID(),
+      messages: [
+        { role: 'user', content: 'Count from 1 to 100, one number per line.' },
+      ],
+      maxTokens: CONFIG.tpsMaxTokens,
+    });
+    record(r);
+  }
+
+  // 3. Sticky KV-cache reuse — two turns, same conversation tag.
+  await sleep(CONFIG.intervalMs);
+  const conv = randUUID();
+  const t1 = await streamOne({
+    model,
+    conversationId: conv,
+    messages: [{ role: 'user', content: 'Reply with exactly: pong' }],
+    maxTokens: 16,
+  });
+  record(t1);
+  if (t1.ok) {
+    await sleep(CONFIG.intervalMs);
+    const t2 = await streamOne({
+      model,
+      conversationId: conv,
+      messages: [
+        { role: 'user', content: 'Reply with exactly: pong' },
+        { role: 'assistant', content: t1.content },
+        { role: 'user', content: 'Reply with exactly: ping' },
+      ],
+      maxTokens: 16,
+    });
+    record(t2);
+    if (t2.ok && t2.usage) {
+      const cached = numOrNull(t2.usage.cached_prompt_tokens);
+      const prompt = numOrNull(t2.usage.prompt_tokens);
+      res.cachedPromptTokens = cached;
+      res.promptTokens = prompt;
+      if (cached != null && prompt != null && prompt > 0) {
+        res.cachedRatio = cached / prompt;
+      }
+    }
+  }
+
+  res.serviceable = res.ttftMs.length > 0 ? 1 : 0;
+  return res;
+}
+
+function outcomeBucket(r) {
+  if (r.ok) return '2xx';
+  if (r.status === 0) return 'timeout';
+  if (r.status === 502) return '502';
+  if (r.status === 200) return 'empty';
+  if (r.status >= 500) return '5xx';
+  return 'other';
+}
+
+function numOrNull(v) {
+  return typeof v === 'number' && Number.isFinite(v) ? v : null;
+}
+function randUUID() {
+  return crypto.randomUUID();
+}
+function now() {
+  return Number(process.hrtime.bigint() / 1000000n);
+}
+
+function percentile(arr, p) {
+  if (!arr.length) return null;
+  const sorted = [...arr].sort((a, b) => a - b);
+  const rank = Math.ceil((p / 100) * sorted.length);
+  return sorted[Math.min(sorted.length - 1, Math.max(0, rank - 1))];
+}
+function mean(arr) {
+  return arr.length ? arr.reduce((a, b) => a + b, 0) / arr.length : null;
+}
+
+// ── metrics emission ────────────────────────────────────────────────────────
+
+function buildRun(status, modelResults, runStartUnix) {
+  return {
+    schema_version: 1,
+    probe: 'canary_buyer',
+    run_at: new Date(runStartUnix * 1000).toISOString(),
+    base: CONFIG.base,
+    up: status ? 1 : 0,
+    pool: status?.pool || null,
+    coordinator_status: status?.coordinator?.status || null,
+    models: modelResults.map((m) => ({
+      model: m.model,
+      serviceable: m.serviceable,
+      samples: m.samples,
+      outcomes: m.outcomes,
+      ttft_ms: {
+        p50: percentile(m.ttftMs, 50),
+        p95: percentile(m.ttftMs, 95),
+        p99: percentile(m.ttftMs, 99),
+        n: m.ttftMs.length,
+      },
+      decode_tps: {
+        p50: percentile(m.decodeTps, 50),
+        mean: mean(m.decodeTps),
+        n: m.decodeTps.length,
+      },
+      cached_prompt_ratio: m.cachedRatio,
+      cached_prompt_tokens: m.cachedPromptTokens,
+      prompt_tokens: m.promptTokens,
+      provider: m.provider,
+      first_error: m.firstError || null,
+    })),
+  };
+}
+
+function promEscape(v) {
+  return String(v).replace(/\\/g, '\\\\').replace(/"/g, '\\"').replace(/\n/g, ' ');
+}
+
+function toProm(run) {
+  const L = [];
+  const ts = Math.floor(Date.parse(run.run_at));
+  const h = (name, help, type) => {
+    L.push(`# HELP ${name} ${help}`);
+    L.push(`# TYPE ${name} ${type}`);
+  };
+  const lbl = (o) =>
+    Object.entries(o)
+      .map(([k, v]) => `${k}="${promEscape(v)}"`)
+      .join(',');
+
+  h('macprovider_canary_up', 'Gateway /v1/status reachable (1) or not (0).', 'gauge');
+  L.push(`macprovider_canary_up ${run.up}`);
+
+  h('macprovider_canary_run_timestamp_seconds', 'Unix time of this probe run.', 'gauge');
+  L.push(`macprovider_canary_run_timestamp_seconds ${Math.floor(ts / 1000)}`);
+
+  if (run.pool) {
+    h('macprovider_canary_pool_providers', 'Providers by pool state from /v1/status.', 'gauge');
+    for (const k of ['total_providers', 'ready', 'degraded', 'draining', 'unavailable']) {
+      if (run.pool[k] != null) L.push(`macprovider_canary_pool_providers{state="${k}"} ${run.pool[k]}`);
+    }
+  }
+
+  h('macprovider_canary_model_serviceable', 'A chat completion actually produced a token (1) despite status. Catches status-vs-serviceable divergence.', 'gauge');
+  h('macprovider_canary_ttft_ms', 'Time-to-first-token in ms by quantile.', 'gauge');
+  h('macprovider_canary_decode_tps', 'Sustained decode tokens/sec (excludes first token/prefill).', 'gauge');
+  h('macprovider_canary_cached_prompt_ratio', 'Sticky turn-2 cached_prompt_tokens / prompt_tokens (KV-cache reuse).', 'gauge');
+  // Per-run gauges (reset each run), NOT cumulative counters — hence no _total
+  // suffix, so consumers don't apply rate()/counter semantics to them.
+  h('macprovider_canary_requests', 'Probe requests this run by outcome bucket (per-run gauge).', 'gauge');
+  h('macprovider_canary_samples', 'Probe requests issued for the model this run (per-run gauge).', 'gauge');
+
+  for (const m of run.models) {
+    const base = { model: m.model };
+    L.push(`macprovider_canary_model_serviceable{${lbl(base)}} ${m.serviceable}`);
+    L.push(`macprovider_canary_samples{${lbl(base)}} ${m.samples}`);
+    for (const [outcome, n] of Object.entries(m.outcomes)) {
+      L.push(`macprovider_canary_requests{${lbl({ ...base, outcome })}} ${n}`);
+    }
+    for (const q of ['p50', 'p95', 'p99']) {
+      if (m.ttft_ms[q] != null) L.push(`macprovider_canary_ttft_ms{${lbl({ ...base, quantile: q })}} ${m.ttft_ms[q]}`);
+    }
+    if (m.decode_tps.p50 != null) L.push(`macprovider_canary_decode_tps{${lbl({ ...base, quantile: 'p50' })}} ${round(m.decode_tps.p50)}`);
+    if (m.decode_tps.mean != null) L.push(`macprovider_canary_decode_tps{${lbl({ ...base, quantile: 'mean' })}} ${round(m.decode_tps.mean)}`);
+    if (m.cached_prompt_ratio != null) L.push(`macprovider_canary_cached_prompt_ratio{${lbl(base)}} ${round(m.cached_prompt_ratio, 4)}`);
+  }
+  return L.join('\n') + '\n';
+}
+
+function round(v, d = 2) {
+  const f = Math.pow(10, d);
+  return Math.round(v * f) / f;
+}
+
+async function pushMetrics(text) {
+  const url = `${CONFIG.pushgateway.replace(/\/$/, '')}/metrics/job/${encodeURIComponent(CONFIG.pushJob)}`;
+  const r = await fetch(url, {
+    method: 'POST',
+    headers: { 'Content-Type': 'text/plain' },
+    body: text,
+    signal: AbortSignal.timeout(15000),
+  });
+  if (!r.ok) throw new Error(`pushgateway HTTP ${r.status}`);
+}
+
+// ── main ─────────────────────────────────────────────────────────────────────
+
+async function main() {
+  if (!CONFIG.token) {
+    console.error('FAIL: set MACPROVIDER_BUYER_TOKEN or MALIBU_API_KEY');
+    process.exit(2);
+  }
+  try {
+    parseSafeUrl(`${CONFIG.base}/v1/status`, 'CANARY_BASE');
+    if (CONFIG.pushgateway) parseSafeUrl(CONFIG.pushgateway, 'CANARY_PUSHGATEWAY');
+  } catch (e) {
+    console.error(`FAIL: ${e.message}`);
+    process.exit(2);
+  }
+  const runStartUnix = Math.floor(realUnix());
+
+  let status = null;
+  try {
+    status = await getStatus();
+  } catch (e) {
+    console.error(`WARN: /v1/status failed: ${redact(e.message)}`);
+  }
+
+  let models = CONFIG.models;
+  if (!models.length) {
+    models = (status?.models || []).map((m) => m.id).filter(Boolean);
+  }
+  if (!models.length) {
+    console.error('WARN: no models to probe (status unreachable and CANARY_MODELS unset)');
+  }
+
+  const results = [];
+  for (const model of models) {
+    process.stderr.write(`probing ${model} ...\n`);
+    const r = await sampleModel(model);
+    results.push(r);
+    const t = r.ttftMs.length ? `ttft_p50=${percentile(r.ttftMs, 50)}ms p95=${percentile(r.ttftMs, 95)}ms` : 'ttft=none';
+    const tps = r.decodeTps.length ? `tps_p50=${round(percentile(r.decodeTps, 50))}` : 'tps=none';
+    const cache = r.cachedRatio != null ? `cache=${round(r.cachedRatio, 3)}` : 'cache=n/a';
+    console.error(
+      `  ${model}: serviceable=${r.serviceable} ${t} ${tps} ${cache} outcomes=${JSON.stringify(r.outcomes)}${r.firstError ? ` firstErr="${r.firstError}"` : ''}`
+    );
+  }
+
+  const run = buildRun(status, results, runStartUnix);
+  const prom = toProm(run);
+
+  // stdout: the JSON run summary (machine-readable). Diagnostics go to stderr.
+  console.log(JSON.stringify(run, null, 2));
+
+  if (CONFIG.metricsOut) {
+    await writeAtomic(CONFIG.metricsOut, prom);
+    console.error(`wrote metrics → ${CONFIG.metricsOut}`);
+  }
+  if (CONFIG.jsonOut) {
+    const fname = `canary-${run.run_at.replace(/[:.]/g, '-')}.json`;
+    const path = await joinPath(CONFIG.jsonOut, fname);
+    await writeAtomic(path, JSON.stringify(run, null, 2) + '\n');
+    console.error(`wrote artifact → ${path}`);
+  }
+  if (CONFIG.pushgateway) {
+    try {
+      await pushMetrics(prom);
+      console.error(`pushed metrics → ${CONFIG.pushgateway}`);
+    } catch (e) {
+      console.error(`WARN: pushgateway failed: ${e.message}`);
+    }
+  }
+
+  // Exit code policy: 0 by default even on failures (recording is the job, and
+  // launchd should not treat a bad-network run as a probe crash). Opt into a
+  // non-zero exit for CI/alerting with --fail-on-degraded.
+  if (CONFIG.failOnDegraded) {
+    const anyUnserviceable = run.up === 0 || run.models.some((m) => !m.serviceable);
+    if (anyUnserviceable) {
+      console.error('DEGRADED: gateway down or a model unserviceable');
+      process.exit(1);
+    }
+  }
+}
+
+// realUnix uses Date.now via a tiny indirection so the timestamp is honest even
+// though hrtime powers the latency deltas.
+function realUnix() {
+  return Date.now() / 1000;
+}
+
+async function writeAtomic(path, content) {
+  const fs = await import('node:fs/promises');
+  const tmp = `${path}.tmp-${process.pid}`;
+  await fs.mkdir(dirname(path), { recursive: true }).catch(() => {});
+  await fs.writeFile(tmp, content);
+  await fs.rename(tmp, path);
+}
+async function joinPath(dir, file) {
+  const fs = await import('node:fs/promises');
+  await fs.mkdir(dir, { recursive: true }).catch(() => {});
+  return dir.replace(/\/$/, '') + '/' + file;
+}
+function dirname(p) {
+  const i = p.lastIndexOf('/');
+  return i <= 0 ? '.' : p.slice(0, i);
+}
+
+main().catch((e) => {
+  console.error('FATAL:', redact(e.message || String(e)));
+  process.exit(2);
+});

--- a/test/e2e/canary-buyer/probe.mjs
+++ b/test/e2e/canary-buyer/probe.mjs
@@ -38,6 +38,12 @@
 
 import net from 'node:net';
 import dns from 'node:dns/promises';
+import { webcrypto } from 'node:crypto';
+
+// `crypto` is a global on Node 20+ / browsers, but NOT on Node 18 (where it's
+// gated behind a flag). Fall back to node:crypto's webcrypto so the probe runs
+// on the systemd host's Node 18 as well as newer runtimes.
+const crypto = globalThis.crypto ?? webcrypto;
 
 const args = parseArgs(process.argv.slice(2));
 

--- a/test/e2e/canary-buyer/run-canary.sh
+++ b/test/e2e/canary-buyer/run-canary.sh
@@ -40,13 +40,8 @@ if [[ -z "$NODE_BIN" ]]; then
   exit 2
 fi
 
-# Keep only the most recent 200 JSON artifacts. Enumerate NUL-safe so odd
-# filenames can't cause unintended deletions.
-if [[ -d "$CANARY_JSON_OUT" ]]; then
-  ( cd "$CANARY_JSON_OUT" 2>/dev/null &&
-      ls -1t canary-*.json 2>/dev/null | tail -n +201 |
-      while IFS= read -r f; do [[ -f "$f" ]] && rm -f -- "$f"; done ) || true
-fi
+# Artifact rotation (keep newest 200) is handled inside probe.mjs in Node, so no
+# filename can be misparsed by the shell into an unintended delete.
 
 exec "$NODE_BIN" "$HERE/probe.mjs" \
   --metrics-out "$CANARY_METRICS_OUT" \

--- a/test/e2e/canary-buyer/run-canary.sh
+++ b/test/e2e/canary-buyer/run-canary.sh
@@ -43,6 +43,32 @@ fi
 # Artifact rotation (keep newest 200) is handled inside probe.mjs in Node, so no
 # filename can be misparsed by the shell into an unintended delete.
 
+# Optional dead-man's-switch heartbeat. When CANARY_HEARTBEAT_URL is set (an
+# https BetterStack / healthchecks-style ping URL), the wrapper pings it ONLY
+# when the probe exits 0 (healthy). A degraded run (with --fail-on-degraded) or a
+# probe that never runs leaves the heartbeat stale, so the upstream monitor
+# alerts. The heartbeat URL carries no buyer token, but we still require https so
+# a mispointed URL can't be reached over cleartext (CANARY_ALLOW_INSECURE=1
+# bypasses, for local testing only).
+if [[ -n "${CANARY_HEARTBEAT_URL:-}" ]]; then
+  if [[ "$CANARY_HEARTBEAT_URL" != https://* && "${CANARY_ALLOW_INSECURE:-}" != "1" ]]; then
+    echo "canary: CANARY_HEARTBEAT_URL must be https (set CANARY_ALLOW_INSECURE=1 to allow http)" >&2
+    exit 2
+  fi
+  if "$NODE_BIN" "$HERE/probe.mjs" \
+      --metrics-out "$CANARY_METRICS_OUT" \
+      --json-out "$CANARY_JSON_OUT" \
+      "$@"; then
+    curl -fsS -m 10 "$CANARY_HEARTBEAT_URL" >/dev/null 2>&1 \
+      || echo "canary: heartbeat ping failed (probe was healthy)" >&2
+    exit 0
+  else
+    rc=$?
+    echo "canary: probe exited $rc; heartbeat NOT pinged (dead-man switch will fire)" >&2
+    exit "$rc"
+  fi
+fi
+
 exec "$NODE_BIN" "$HERE/probe.mjs" \
   --metrics-out "$CANARY_METRICS_OUT" \
   --json-out "$CANARY_JSON_OUT" \

--- a/test/e2e/canary-buyer/run-canary.sh
+++ b/test/e2e/canary-buyer/run-canary.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# Wrapper for the canary buyer probe. Resolves the buyer token, runs the probe,
+# and writes a Prometheus textfile + a rotated JSON artifact. Intended to be
+# invoked by launchd (com.streamvc.canary-buyer.plist) on a lab Mac, or by hand.
+#
+# Token resolution order:
+#   1. $MACPROVIDER_BUYER_TOKEN (if already exported)
+#   2. ~/.config/macprovider/buyer-api-key  (the documented harness location)
+#
+# The token is never echoed. Diagnostics go to stderr / the launchd log.
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+: "${CANARY_BASE:=https://api.streamvc.live}"
+: "${CANARY_TOKEN_FILE:=$HOME/.config/macprovider/buyer-api-key}"
+: "${CANARY_METRICS_OUT:=$HOME/.local/state/canary-buyer/canary_buyer.prom}"
+: "${CANARY_JSON_OUT:=$HOME/.local/state/canary-buyer/artifacts}"
+# Optional: export CANARY_PUSHGATEWAY=http://host:9091 to push instead of/along
+# with the textfile.
+
+if [[ -z "${MACPROVIDER_BUYER_TOKEN:-}" ]]; then
+  if [[ -r "$CANARY_TOKEN_FILE" ]]; then
+    MACPROVIDER_BUYER_TOKEN="$(tr -d '[:space:]' < "$CANARY_TOKEN_FILE")"
+    export MACPROVIDER_BUYER_TOKEN
+  else
+    echo "canary: no token in \$MACPROVIDER_BUYER_TOKEN and $CANARY_TOKEN_FILE not readable" >&2
+    exit 2
+  fi
+fi
+
+export CANARY_BASE CANARY_METRICS_OUT CANARY_JSON_OUT
+
+# launchd runs with a minimal PATH that usually lacks Homebrew, so a bare `node`
+# would fail every scheduled run. Resolve it explicitly.
+export PATH="/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:$PATH"
+NODE_BIN="${CANARY_NODE_BIN:-$(command -v node || true)}"
+if [[ -z "$NODE_BIN" ]]; then
+  echo "canary: node not found on PATH; set \$CANARY_NODE_BIN to the node binary" >&2
+  exit 2
+fi
+
+# Keep only the most recent 200 JSON artifacts. Enumerate NUL-safe so odd
+# filenames can't cause unintended deletions.
+if [[ -d "$CANARY_JSON_OUT" ]]; then
+  ( cd "$CANARY_JSON_OUT" 2>/dev/null &&
+      ls -1t canary-*.json 2>/dev/null | tail -n +201 |
+      while IFS= read -r f; do [[ -f "$f" ]] && rm -f -- "$f"; done ) || true
+fi
+
+exec "$NODE_BIN" "$HERE/probe.mjs" \
+  --metrics-out "$CANARY_METRICS_OUT" \
+  --json-out "$CANARY_JSON_OUT" \
+  "$@"


### PR DESCRIPTION
## Summary

Adds a **canary buyer probe** — a continuous synthetic buyer that measures the
live macprovider network from the buyer's perspective and exports Prometheus
metrics. This is **P1** from the 2026-07-09 e2e-testing review.

The month's testing pattern was that every serious finding came from live
contact with prod (KV-cache verify, W3 canary TTFT false-fail), yet the network
had **zero continuous buyer-perspective measurement**. A metallib-class silent
2× TPS regression, a thermal-throttle degradation, or a provider that
`/v1/status` calls "ready" but that 502s every completion, would be invisible
until a buyer complained.

While building this, the probe caught exactly that last case live: `/v1/status`
reported the sole provider `ready`, verified, 8 free slots — while every
`/v1/chat/completions` returned `502 upstream_provider_error` (3/3 retries). The
probe recorded `up=1, serviceable=0, {502:4, 5xx:1}`, which is the signal.

## What it adds (all under `test/e2e/canary-buyer/`, no product-code changes)

- `probe.mjs` — zero-dependency Node probe. Per model class per run records:
  TTFT p50/p95/p99, sustained decode TPS, sticky turn-2 KV-cache reuse ratio,
  serviceability, and request-outcome counts. Emits Prometheus text-exposition
  metrics + a per-run JSON artifact.
- `run-canary.sh` — wrapper: resolves the buyer token from the documented
  harness location, rotates artifacts, runs the probe. Token never echoed.
- `com.streamvc.canary-buyer.plist` — launchd agent template (30-min cadence).
- `README.md` — usage, metric reference, suggested alert rules.

Productionizes `test/e2e/malibu-console/smoke.mjs` and network-harness scenarios
`07_sustained_throughput` / `09_streaming_ttft_distribution` into a scheduled,
monitorable form. Generates the baseline data that P2 (cold/warm matrix), P3
(soak), and P4 (cache-reuse gate) need for their thresholds.

## Verification

- **Failure path** verified against live prod during an active
  `upstream_provider_error` incident (recorded the divergence correctly).
- **Success path** (TTFT percentiles, decode-TPS math, cache ratio, Prometheus
  emission) verified against a local mock SSE gateway.
- `node --check` + `bash -n` clean.
- Three-lane codex audit (code / security / architect), converged over 4 rounds
  to **0 CRITICAL / 0 HIGH / 0 MEDIUM** on every lane. Each round surfaced new
  territory (not repeats) and every finding was reproduced + fixed + re-verified:
  - R1: SSRF/token-leak on error bodies, README alert label-mismatch, launchd node PATH
  - R2: TTFT/TPS sample conflation; **2 HIGH** — IPv6 SSRF bypasses + token leaking via server-controlled fields; missing `stream_options.include_usage`
  - R3: terminal SSE `{error}` frames counted as healthy; dark-signal sample-count gauges
  - R4: code + architect PASS (security already PASS at R3)

  Carried LOW: pure DNS-rebinding TOCTOU without a pinning agent (documented in code; mitigated by https-only + private-host reject + startup resolve-check + `redirect: 'manual'`).

## Notes

- Buyer-side scope: splits latency into TTFT vs decode window. Finer server-side
  phase timing is in gateway completion logs (join by `x-request-id`), not the
  buyer response, so the probe does not claim it.
- Default exit 0 even on network failure (launchd shouldn't treat a bad-network
  run as a crash); `--fail-on-degraded` opts into exit 1 for CI/alerting.
