### PR TITLE
feat(attest): Phase 2 P2-C — provider MDM enrollment CLI

### DIFF
--- a/docs/runbooks/hardware-attestation-phases.md
+++ b/docs/runbooks/hardware-attestation-phases.md
@@ -287,6 +287,29 @@ Script auto-restores config backup on verification failure. Manual: set `require
 |------|-------|
 | 2026-07-08 | Runbook created; Phase 1 agents spawned (P1-A, P1-B, P1-C) |
 | 2026-07-08 | All three tracks landed in worktree; focused tests pass (Go SE+Liveness, Swift SEAttestation 12/12). Swift liveness unit tests still TODO. Entitlements blocker documented. |
+| 2026-07-09 | **Phase 1 merged** — PR #477 squash-merged to main (`001fb405`). Augustas11 approved (PR author was antfleet-ops). |
+| 2026-07-09 | **Phase 2 started** — worktree `/Users/augstar/macprovider-attest-phase2`, branch `fix/attestation-phase2`. Operator registering Apple MDM push cert in parallel. |
+
+## Phase 2 — IN PROGRESS
+
+**Goal:** macprovider-run MDM enrollment path (`POST /v1/enroll` + provider `enroll` CLI). APNs cert ops parallel (operator).
+
+### Phase 2 tracks
+
+| Track | Scope | Deliverables |
+|-------|-------|--------------|
+| **P2-A** | Coordinator enroll API | `POST /v1/enroll`, SCEP+MDM `.mobileconfig` generator, AccessRights=1041, config keys |
+| **P2-B** | Routing + nginx + config | `coordinator.yaml` MDM block, nginx exact route, tests |
+| **P2-C** | Provider CLI | `macprovider enroll`, `mdm-status`, serial via ioreg, open System Settings |
+
+### Phase 2 exit criteria
+
+- [ ] `POST /v1/enroll` returns valid `.mobileconfig` for a serial
+- [ ] Provider `enroll` command downloads and opens profile
+- [ ] `mdm-status` reports enrolled / not enrolled / foreign MDM
+- [ ] Config documented in `coordinator.yaml.example`
+- [ ] Tests (Go handler + Swift enroll parser)
+- [ ] **Ops (parallel):** APNs push cert at identity.apple.com/pushcert
 
 ### Phase 1 exit criteria status
 

--- a/phase3-binary/Sources/macprovider-cli/EnrollCommand.swift
+++ b/phase3-binary/Sources/macprovider-cli/EnrollCommand.swift
@@ -1,0 +1,241 @@
+import ArgumentParser
+import Foundation
+import MacProviderCore
+
+// MARK: - Enroll command
+
+struct EnrollCommand: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "enroll",
+        abstract: "Enroll this Mac in the macprovider MDM for hardware attestation.",
+        subcommands: [EnrollRunCommand.self, EnrollStatusCommand.self],
+        defaultSubcommand: EnrollRunCommand.self
+    )
+}
+
+// MARK: - enroll (default: request profile and open System Settings)
+
+struct EnrollRunCommand: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "run",
+        abstract: "Request an enrollment profile from the coordinator and open System Settings."
+    )
+
+    @Option(help: "YAML config path. Overrides MACPROVIDER_CONFIG. Defaults to ~/.config/macprovider/config.yaml.")
+    var config: String?
+
+    @Option(help: "Coordinator URL. Overrides coordinator_url in config.")
+    var coordinator: String?
+
+    @Flag(help: "Print profile path instead of opening System Settings (non-interactive / test mode).")
+    var noOpen = false
+
+    func run() async throws {
+        let resolved = try ConfigLoader.load(cli: CLIOverrides(coordinatorURL: coordinator, configPath: config))
+        let runner = EnrollCommandRunner(
+            config: resolved,
+            openSystemSettings: !noOpen,
+            checker: { coordinatorURL in checkMDMEnrollment(coordinatorURL: coordinatorURL) },
+            serialReader: { macHardwareSerialNumber() }
+        )
+        try await runner.run()
+    }
+}
+
+// MARK: - enroll status
+
+struct EnrollStatusCommand: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "status",
+        abstract: "Print current MDM enrollment state."
+    )
+
+    @Option(help: "YAML config path. Overrides MACPROVIDER_CONFIG. Defaults to ~/.config/macprovider/config.yaml.")
+    var config: String?
+
+    @Option(help: "Coordinator URL. Overrides coordinator_url in config.")
+    var coordinator: String?
+
+    func run() async throws {
+        let resolved = try ConfigLoader.load(cli: CLIOverrides(coordinatorURL: coordinator, configPath: config))
+        let state = checkMDMEnrollment(coordinatorURL: resolved.coordinatorURL)
+        switch state {
+        case .notEnrolled:
+            print("mdm_enrollment: not_enrolled")
+        case .enrolledMacprovider(let serverURL):
+            print("mdm_enrollment: macprovider server=\(serverURL)")
+        case .enrolledOtherMDM(let serverURL):
+            print("mdm_enrollment: other_mdm server=\(serverURL)")
+            FileHandle.standardError.write(Data(
+                "warning: Mac is managed by a foreign MDM; macprovider enrollment is unavailable.\n".utf8
+            ))
+        case .checkFailed:
+            print("mdm_enrollment: unknown (profiles check failed)")
+        }
+    }
+}
+
+// MARK: - Enroll errors
+
+enum EnrollError: Error, CustomStringConvertible {
+    case serialNumberUnavailable
+    case coordinatorURLMissing
+    case coordinatorURLInvalid(String)
+    case coordinatorRequestFailed(String)
+    case coordinatorHTTPError(Int, body: String)
+    case profileWriteFailed(String)
+    case managedByOtherMDM(serverURL: String)
+
+    var description: String {
+        switch self {
+        case .serialNumberUnavailable:
+            return "Could not read hardware serial number from ioreg."
+        case .coordinatorURLMissing:
+            return "coordinator_url is not set. Pass --coordinator or set it in config.yaml."
+        case .coordinatorURLInvalid(let raw):
+            return "Could not derive enroll endpoint from coordinator URL: \(raw)"
+        case .coordinatorRequestFailed(let detail):
+            return "Failed to reach coordinator: \(detail)"
+        case .coordinatorHTTPError(let status, let body):
+            return "Coordinator returned HTTP \(status): \(body)"
+        case .profileWriteFailed(let detail):
+            return "Failed to write enrollment profile: \(detail)"
+        case .managedByOtherMDM(let serverURL):
+            return "This Mac is already managed by another MDM (server: \(serverURL)). "
+                + "macOS allows only one MDM enrollment per device. "
+                + "Remove the existing profile in System Settings → General → Device Management, "
+                + "then re-run `macprovider-cli enroll`."
+        }
+    }
+}
+
+// MARK: - Enrollment result
+
+struct EnrollResult: Sendable {
+    let serialNumber: String
+    let profilePath: URL
+    let alreadyEnrolled: Bool
+}
+
+// MARK: - Runner (injectable for testing)
+
+struct EnrollCommandRunner: Sendable {
+    let config: AppConfig
+    let openSystemSettings: Bool
+    let checker: @Sendable (String?) -> MDMEnrollmentState
+    let serialReader: @Sendable () -> String?
+
+    init(
+        config: AppConfig,
+        openSystemSettings: Bool = true,
+        checker: @escaping @Sendable (String?) -> MDMEnrollmentState = { checkMDMEnrollment(coordinatorURL: $0) },
+        serialReader: @escaping @Sendable () -> String? = { macHardwareSerialNumber() }
+    ) {
+        self.config = config
+        self.openSystemSettings = openSystemSettings
+        self.checker = checker
+        self.serialReader = serialReader
+    }
+
+    func run() async throws {
+        let coordinatorURL = config.coordinatorURL
+
+        switch checker(coordinatorURL) {
+        case .enrolledMacprovider(let serverURL):
+            print("mdm_enrollment: already enrolled server=\(serverURL)")
+            return
+        case .enrolledOtherMDM(let serverURL):
+            let err = EnrollError.managedByOtherMDM(serverURL: serverURL)
+            FileHandle.standardError.write(Data("error: \(err.description)\n".utf8))
+            throw ExitCode(1)
+        case .notEnrolled, .checkFailed:
+            break
+        }
+
+        guard let rawCoordinatorURL = coordinatorURL, !rawCoordinatorURL.isEmpty else {
+            FileHandle.standardError.write(Data("error: \(EnrollError.coordinatorURLMissing.description)\n".utf8))
+            throw ExitCode(2)
+        }
+
+        let baseURL = coordinatorHTTPBase(rawCoordinatorURL)
+        guard let enrollURL = URL(string: "\(baseURL)/v1/enroll") else {
+            let err = EnrollError.coordinatorURLInvalid(rawCoordinatorURL)
+            FileHandle.standardError.write(Data("error: \(err.description)\n".utf8))
+            throw ExitCode(2)
+        }
+
+        guard let serial = serialReader(), !serial.isEmpty else {
+            let err = EnrollError.serialNumberUnavailable
+            FileHandle.standardError.write(Data("error: \(err.description)\n".utf8))
+            throw ExitCode(2)
+        }
+
+        print("Requesting enrollment profile for serial \(serial)…")
+
+        var request = URLRequest(url: enrollURL)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.timeoutInterval = 30
+        request.httpBody = try JSONSerialization.data(withJSONObject: ["serial_number": serial])
+
+        let data: Data
+        let response: URLResponse
+        do {
+            (data, response) = try await URLSession.shared.data(for: request)
+        } catch {
+            let err = EnrollError.coordinatorRequestFailed(error.localizedDescription)
+            FileHandle.standardError.write(Data("error: \(err.description)\n".utf8))
+            throw ExitCode(3)
+        }
+
+        if let http = response as? HTTPURLResponse, !(200..<300).contains(http.statusCode) {
+            let body = String(data: data, encoding: .utf8) ?? ""
+            let err = EnrollError.coordinatorHTTPError(http.statusCode, body: body)
+            FileHandle.standardError.write(Data("error: \(err.description)\n".utf8))
+            throw ExitCode(3)
+        }
+
+        let profilePath = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("macprovider-enroll-\(serial).mobileconfig")
+        do {
+            try data.write(to: profilePath, options: .atomic)
+        } catch {
+            let err = EnrollError.profileWriteFailed(error.localizedDescription)
+            FileHandle.standardError.write(Data("error: \(err.description)\n".utf8))
+            throw ExitCode(3)
+        }
+
+        print("Profile saved: \(profilePath.path)")
+
+        if openSystemSettings {
+            openProfile(profilePath)
+        }
+    }
+
+    private func openProfile(_ profilePath: URL) {
+        // Register the profile with System Settings.
+        let openProfile = Process()
+        openProfile.executableURL = URL(fileURLWithPath: "/usr/bin/open")
+        openProfile.arguments = [profilePath.path]
+        openProfile.standardOutput = FileHandle.nullDevice
+        openProfile.standardError = FileHandle.nullDevice
+        try? openProfile.run()
+        openProfile.waitUntilExit()
+
+        // Pause briefly so the profile registers before we surface the pane.
+        Thread.sleep(forTimeInterval: 1.0)
+
+        // Open System Settings → Profiles.
+        let openSettings = Process()
+        openSettings.executableURL = URL(fileURLWithPath: "/usr/bin/open")
+        openSettings.arguments = [
+            "x-apple.systempreferences:com.apple.Profiles-Settings.extension"
+        ]
+        openSettings.standardOutput = FileHandle.nullDevice
+        openSettings.standardError = FileHandle.nullDevice
+        try? openSettings.run()
+        openSettings.waitUntilExit()
+
+        print("Install the profile shown in System Settings to complete enrollment.")
+    }
+}

--- a/phase3-binary/Sources/macprovider-cli/MDMEnrollment.swift
+++ b/phase3-binary/Sources/macprovider-cli/MDMEnrollment.swift
@@ -1,0 +1,191 @@
+import Foundation
+
+// MARK: - MDM enrollment state
+
+/// MDM enrollment state of this Mac, as reported by
+/// `profiles status -type enrollment`.
+///
+/// macOS allows exactly one MDM enrollment per device: a Mac managed by a
+/// corporate MDM cannot also enroll in macprovider's MDM, and an unenrolled
+/// Mac must never be incorrectly told it is "already enrolled".
+enum MDMEnrollmentState: Equatable, Sendable {
+    case notEnrolled
+    case enrolledMacprovider(serverURL: String)
+    case enrolledOtherMDM(serverURL: String)
+    /// `profiles status` could not be run or produced no useful output.
+    /// Distinct from .notEnrolled — callers should proceed (not block) when
+    /// the check fails, since a redundant profile download is idempotent.
+    case checkFailed
+
+    var isMacprovider: Bool {
+        if case .enrolledMacprovider = self { return true }
+        return false
+    }
+}
+
+// MARK: - Recognised macprovider MDM host suffixes / known hosts
+
+/// Coordinator hosts that are always ours regardless of local config.
+let macproviderMDMHostSuffixes = [".streamvc.live", ".macprovider.xyz"]
+let macproviderMDMHosts = ["coordinator.streamvc.live"]
+
+// MARK: - Parser
+
+/// Parse `profiles status -type enrollment` output into an enrollment state.
+///
+/// Relevant output shapes (macOS 14+):
+///
+///     Enrolled via DEP: No
+///     MDM enrollment: Yes (User Approved)
+///     MDM server: https://coordinator.streamvc.live/mdm/connect
+///
+/// or when not enrolled:
+///
+///     Enrolled via DEP: No
+///     MDM enrollment: No
+///
+/// Only the `MDM enrollment:` line decides enrolled-vs-not. The
+/// `Enrolled via DEP:` line must NOT be used (it was a false-positive source
+/// in earlier heuristics that matched on a substring of "enrolled").
+///
+/// - Parameters:
+///   - output: Raw stdout from `profiles status -type enrollment`.
+///   - expectedHosts: Additional hosts that count as "ours" (e.g. the host
+///     extracted from the locally configured coordinator URL).
+/// - Returns: The computed enrollment state.
+func parseMDMEnrollmentStatus(
+    _ output: String,
+    expectedHosts: [String] = []
+) -> MDMEnrollmentState {
+    var enrolled = false
+    var serverURL: String?
+
+    for rawLine in output.split(separator: "\n") {
+        let line = rawLine.trimmingCharacters(in: .whitespaces)
+        let lower = line.lowercased()
+        if lower.hasPrefix("mdm enrollment:") {
+            let value = line.dropFirst("mdm enrollment:".count)
+                .trimmingCharacters(in: .whitespaces)
+                .lowercased()
+            enrolled = value.hasPrefix("yes")
+        } else if lower.hasPrefix("mdm server:") {
+            serverURL = line.dropFirst("mdm server:".count)
+                .trimmingCharacters(in: .whitespaces)
+        }
+    }
+
+    guard enrolled else { return .notEnrolled }
+
+    guard let serverURL, let host = URL(string: serverURL)?.host?.lowercased() else {
+        // Enrolled but the server URL is unreadable — report as foreign.
+        return .enrolledOtherMDM(serverURL: serverURL ?? "<unknown>")
+    }
+
+    let ours = macproviderMDMHosts.contains(host)
+        || macproviderMDMHostSuffixes.contains(where: { host.hasSuffix($0) })
+        || expectedHosts.contains(where: { !$0.isEmpty && $0.lowercased() == host })
+    return ours
+        ? .enrolledMacprovider(serverURL: serverURL)
+        : .enrolledOtherMDM(serverURL: serverURL)
+}
+
+// MARK: - Live check
+
+/// Query this Mac's MDM enrollment state by running
+/// `/usr/bin/profiles status -type enrollment` (works unprivileged).
+///
+/// `coordinatorURL` (http(s):// or ws(s)://) contributes its host to the set
+/// of accepted macprovider MDM hosts so that self-hosted coordinators are
+/// recognised without being listed in the static suffix table.
+///
+/// Returns `.checkFailed` (not `.notEnrolled`) when the tool itself fails,
+/// so callers can choose: enroll proceeds to download (idempotent),
+/// doctor says state is unknown rather than asserting non-enrollment.
+func checkMDMEnrollment(coordinatorURL: String? = nil) -> MDMEnrollmentState {
+    let process = Process()
+    process.executableURL = URL(fileURLWithPath: "/usr/bin/profiles")
+    process.arguments = ["status", "-type", "enrollment"]
+
+    let outPipe = Pipe()
+    process.standardOutput = outPipe
+    process.standardError = Pipe()
+
+    do {
+        try process.run()
+    } catch {
+        return .checkFailed
+    }
+    process.waitUntilExit()
+
+    let output = String(
+        data: outPipe.fileHandleForReading.readDataToEndOfFile(),
+        encoding: .utf8
+    ) ?? ""
+
+    if process.terminationStatus != 0
+        && output.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+        return .checkFailed
+    }
+
+    var expectedHosts: [String] = []
+    if let coordinatorURL, let host = URL(string: coordinatorURL)?.host {
+        expectedHosts.append(host)
+    }
+    return parseMDMEnrollmentStatus(output, expectedHosts: expectedHosts)
+}
+
+// MARK: - Hardware serial
+
+/// Read the Mac's hardware serial number via `ioreg -c IOPlatformExpertDevice`.
+/// Returns `nil` on parse failure (unlikely on real hardware; hits in test environments).
+func macHardwareSerialNumber() -> String? {
+    let process = Process()
+    process.executableURL = URL(fileURLWithPath: "/usr/sbin/ioreg")
+    process.arguments = ["-c", "IOPlatformExpertDevice", "-d", "2"]
+    let pipe = Pipe()
+    process.standardOutput = pipe
+    process.standardError = Pipe()
+    do {
+        try process.run()
+    } catch {
+        return nil
+    }
+    process.waitUntilExit()
+
+    let data = pipe.fileHandleForReading.readDataToEndOfFile()
+    guard let text = String(data: data, encoding: .utf8) else { return nil }
+
+    for line in text.split(separator: "\n") {
+        guard line.contains("IOPlatformSerialNumber") else { continue }
+        // ioreg format: "IOPlatformSerialNumber" = "C02XXXXX..."
+        // Splitting on " yields: [..., "IOPlatformSerialNumber", " = ", "C02...", ...]
+        let parts = line.split(separator: "\"", omittingEmptySubsequences: false)
+        if parts.count >= 4 {
+            let candidate = String(parts[3])
+            if !candidate.isEmpty { return candidate }
+        }
+    }
+    return nil
+}
+
+// MARK: - URL helpers
+
+/// Derive the HTTPS coordinator base URL from a coordinator URL that may use
+/// `wss://` or `https://`.  Path, query, and fragment are stripped.
+///
+///     coordinatorHTTPBase("wss://coordinator.streamvc.live/ws")
+///     // → "https://coordinator.streamvc.live"
+func coordinatorHTTPBase(_ rawURL: String) -> String {
+    guard var components = URLComponents(string: rawURL) else {
+        return rawURL
+    }
+    switch components.scheme {
+    case "wss":  components.scheme = "https"
+    case "ws":   components.scheme = "http"
+    default:     break
+    }
+    components.path = ""
+    components.query = nil
+    components.fragment = nil
+    return components.url?.absoluteString ?? rawURL
+}

--- a/phase3-binary/Sources/macprovider-cli/MacProviderCLI.swift
+++ b/phase3-binary/Sources/macprovider-cli/MacProviderCLI.swift
@@ -11,7 +11,7 @@ struct MacProviderCLI: AsyncParsableCommand {
         commandName: "macprovider-cli",
         abstract: "OpenAI-compatible Mac Provider inference CLI.",
         version: CoordinatorClient.binaryVersion,
-        subcommands: [ServeCommand.self, SelfTestCommand.self, StatusCommand.self, ClaimCommand.self, UpdateCommand.self, UninstallCommand.self, ModelsCommand.self, AutotuneCommand.self, RotateKeyCommand.self, Spec028CanaryCommand.self, DecodeBenchCommand.self],
+        subcommands: [ServeCommand.self, SelfTestCommand.self, StatusCommand.self, ClaimCommand.self, UpdateCommand.self, UninstallCommand.self, ModelsCommand.self, AutotuneCommand.self, RotateKeyCommand.self, Spec028CanaryCommand.self, DecodeBenchCommand.self, EnrollCommand.self],
         defaultSubcommand: ServeCommand.self
     )
 }

--- a/phase3-binary/Tests/macprovider-cliTests/MDMEnrollmentTests.swift
+++ b/phase3-binary/Tests/macprovider-cliTests/MDMEnrollmentTests.swift
@@ -1,0 +1,221 @@
+import Foundation
+import MacProviderCore
+import XCTest
+@testable import macprovider_cli
+
+final class MDMEnrollmentTests: XCTestCase {
+
+    // MARK: - parseMDMEnrollmentStatus
+
+    func testParse_NotEnrolled() {
+        let output = """
+        Enrolled via DEP: No
+        MDM enrollment: No
+        """
+        XCTAssertEqual(parseMDMEnrollmentStatus(output), .notEnrolled)
+    }
+
+    func testParse_EnrolledMacprovider_KnownHost() {
+        let output = """
+        Enrolled via DEP: No
+        MDM enrollment: Yes (User Approved)
+        MDM server: https://coordinator.streamvc.live/mdm/connect
+        """
+        XCTAssertEqual(
+            parseMDMEnrollmentStatus(output),
+            .enrolledMacprovider(serverURL: "https://coordinator.streamvc.live/mdm/connect")
+        )
+    }
+
+    func testParse_EnrolledMacprovider_KnownSuffix() {
+        let output = """
+        MDM enrollment: Yes
+        MDM server: https://custom.streamvc.live/mdm
+        """
+        XCTAssertEqual(
+            parseMDMEnrollmentStatus(output),
+            .enrolledMacprovider(serverURL: "https://custom.streamvc.live/mdm")
+        )
+    }
+
+    func testParse_EnrolledForeignMDM() {
+        let output = """
+        Enrolled via DEP: No
+        MDM enrollment: Yes (User Approved)
+        MDM server: https://mdm.corporate.example.com/enroll
+        """
+        XCTAssertEqual(
+            parseMDMEnrollmentStatus(output),
+            .enrolledOtherMDM(serverURL: "https://mdm.corporate.example.com/enroll")
+        )
+    }
+
+    func testParse_EnrolledMacprovider_ViaExpectedHost() {
+        let output = """
+        MDM enrollment: Yes
+        MDM server: https://my-self-hosted.example.com/mdm/connect
+        """
+        XCTAssertEqual(
+            parseMDMEnrollmentStatus(output, expectedHosts: ["my-self-hosted.example.com"]),
+            .enrolledMacprovider(serverURL: "https://my-self-hosted.example.com/mdm/connect")
+        )
+    }
+
+    func testParse_EnrolledForeignMDM_ExpectedHostDoesNotMatch() {
+        let output = """
+        MDM enrollment: Yes
+        MDM server: https://other.example.com/mdm
+        """
+        XCTAssertEqual(
+            parseMDMEnrollmentStatus(output, expectedHosts: ["mine.example.com"]),
+            .enrolledOtherMDM(serverURL: "https://other.example.com/mdm")
+        )
+    }
+
+    func testParse_DEPLineDoesNotTriggerEnrolled() {
+        // "Enrolled via DEP: Yes" must NOT cause enrolled=true.
+        let output = """
+        Enrolled via DEP: Yes
+        MDM enrollment: No
+        """
+        XCTAssertEqual(parseMDMEnrollmentStatus(output), .notEnrolled)
+    }
+
+    func testParse_EmptyOutput() {
+        XCTAssertEqual(parseMDMEnrollmentStatus(""), .notEnrolled)
+    }
+
+    func testParse_MissingServerURLWhileEnrolled() {
+        // Enrolled but no server line → report as foreign (unknown server).
+        let output = "MDM enrollment: Yes"
+        guard case .enrolledOtherMDM = parseMDMEnrollmentStatus(output) else {
+            XCTFail("Expected enrolledOtherMDM when server URL is absent")
+            return
+        }
+    }
+
+    func testParse_CaseInsensitiveMDMLine() {
+        let output = """
+        MDM Enrollment: YES
+        MDM Server: https://coordinator.streamvc.live/mdm
+        """
+        XCTAssertEqual(
+            parseMDMEnrollmentStatus(output),
+            .enrolledMacprovider(serverURL: "https://coordinator.streamvc.live/mdm")
+        )
+    }
+
+    func testParse_UserApprovedSuffix() {
+        // "Yes (User Approved)" must still be treated as enrolled.
+        let output = """
+        MDM enrollment: Yes (User Approved)
+        MDM server: https://coordinator.streamvc.live/mdm
+        """
+        XCTAssertEqual(
+            parseMDMEnrollmentStatus(output),
+            .enrolledMacprovider(serverURL: "https://coordinator.streamvc.live/mdm")
+        )
+    }
+
+    // MARK: - coordinatorHTTPBase (URL derivation)
+
+    func testCoordinatorHTTPBase_WSS_DropsPath() {
+        XCTAssertEqual(
+            coordinatorHTTPBase("wss://coordinator.streamvc.live/ws"),
+            "https://coordinator.streamvc.live"
+        )
+    }
+
+    func testCoordinatorHTTPBase_HTTPS_DropsPath() {
+        XCTAssertEqual(
+            coordinatorHTTPBase("https://coordinator.streamvc.live/api"),
+            "https://coordinator.streamvc.live"
+        )
+    }
+
+    func testCoordinatorHTTPBase_WS_ToHTTP() {
+        XCTAssertEqual(
+            coordinatorHTTPBase("ws://localhost:8080/ws"),
+            "http://localhost:8080"
+        )
+    }
+
+    func testCoordinatorHTTPBase_WithQueryAndFragment() {
+        XCTAssertEqual(
+            coordinatorHTTPBase("wss://host.example.com/path?foo=bar#section"),
+            "https://host.example.com"
+        )
+    }
+
+    func testCoordinatorHTTPBase_PreservesPort() {
+        XCTAssertEqual(
+            coordinatorHTTPBase("wss://host.example.com:9443/ws"),
+            "https://host.example.com:9443"
+        )
+    }
+
+    func testEnrollEndpoint_Derived() {
+        let base = coordinatorHTTPBase("wss://coordinator.streamvc.live/ws")
+        let endpoint = URL(string: "\(base)/v1/enroll")
+        XCTAssertEqual(endpoint?.absoluteString, "https://coordinator.streamvc.live/v1/enroll")
+    }
+
+    func testEnrollEndpoint_SelfHosted() {
+        let base = coordinatorHTTPBase("wss://my-node.example.com:9443/coordinator")
+        let endpoint = URL(string: "\(base)/v1/enroll")
+        XCTAssertEqual(endpoint?.absoluteString, "https://my-node.example.com:9443/v1/enroll")
+    }
+
+    // MARK: - EnrollCommandRunner (unit, no network)
+
+    private func makeConfig(coordinatorURL: String) throws -> AppConfig {
+        try ConfigLoader.load(
+            cli: CLIOverrides(coordinatorURL: coordinatorURL),
+            environment: [:]
+        )
+    }
+
+    func testEnrollRunner_AlreadyEnrolledMacprovider_PrintsStatusAndExits() async throws {
+        let config = try makeConfig(coordinatorURL: "wss://coordinator.streamvc.live/ws")
+        let runner = EnrollCommandRunner(
+            config: config,
+            openSystemSettings: false,
+            checker: { _ in .enrolledMacprovider(serverURL: "https://coordinator.streamvc.live/mdm") },
+            serialReader: { "C02TESTSERIAL" }
+        )
+        // Should not throw — already enrolled is an exit-0 idempotent case.
+        try await runner.run()
+    }
+
+    func testEnrollRunner_ForeignMDM_Throws() async throws {
+        let config = try makeConfig(coordinatorURL: "wss://coordinator.streamvc.live/ws")
+        let runner = EnrollCommandRunner(
+            config: config,
+            openSystemSettings: false,
+            checker: { _ in .enrolledOtherMDM(serverURL: "https://corporate.example.com") },
+            serialReader: { "C02TESTSERIAL" }
+        )
+        do {
+            try await runner.run()
+            XCTFail("Expected throw for foreign MDM")
+        } catch {
+            // ExitCode thrown — expected.
+        }
+    }
+
+    func testEnrollRunner_MissingSerial_Throws() async throws {
+        let config = try makeConfig(coordinatorURL: "wss://coordinator.streamvc.live/ws")
+        let runner = EnrollCommandRunner(
+            config: config,
+            openSystemSettings: false,
+            checker: { _ in .notEnrolled },
+            serialReader: { nil }
+        )
+        do {
+            try await runner.run()
+            XCTFail("Expected throw for missing serial")
+        } catch {
+            // ExitCode thrown — expected.
+        }
+    }
+}

--- a/phase4-coordinator/cmd/coordinator/main.go
+++ b/phase4-coordinator/cmd/coordinator/main.go
@@ -23,6 +23,7 @@ import (
 	"github.com/augstar/macprovider-coordinator/internal/buyer"
 	"github.com/augstar/macprovider-coordinator/internal/config"
 	"github.com/augstar/macprovider-coordinator/internal/explorer"
+	"github.com/augstar/macprovider-coordinator/internal/mdm"
 	"github.com/augstar/macprovider-coordinator/internal/onboarding"
 	"github.com/augstar/macprovider-coordinator/internal/pool"
 	"github.com/augstar/macprovider-coordinator/internal/pow"
@@ -827,11 +828,22 @@ func main() {
 		hardwareEvidence = registerHandler.HandleHardwareEvidence
 		logger.Info().Msg("SPEC-026 app-track register route mounted on buyer port")
 	}
+	// Phase 2 Track P2-A: MDM enrollment profile endpoint.
+	// Enabled when tier2.mdm.enrollment_base_url is configured.
+	var enrollHandler http.HandlerFunc
+	if cfg.Tier2.MDM.EnrollmentBaseURL != "" {
+		eh := buildEnrollHandler(cfg, logger)
+		enrollHandler = eh.HandleEnroll
+		logger.Info().
+			Str("base_url", cfg.Tier2.MDM.EnrollmentBaseURL).
+			Msg("MDM enrollment profile route mounted on buyer port (/v1/enroll)")
+	}
 	buyerHandler := buyerHandlerWithOptionalProviderEndpoints(
 		buyerServer.Handler(),
 		cfg.Onboarding.AppTrackRegisterEnabled,
 		register,
 		hardwareEvidence,
+		enrollHandler,
 		malibuAccrualHandler(cfg, tokenStore, rewardsDB, rewards.NewPoolHeartbeatBridge(wsServer.PoolSnapshot)),
 	)
 
@@ -1302,6 +1314,9 @@ var tier2ReloadFieldClasses = map[string]tier2ReloadFieldClass{
 	"ResponseTimeAnomalyEnabled":     tier2HotReloadable,
 	"ResponseTimeAnomalyFactor":      tier2HotReloadable,
 	"ResponseTimeAnomalyMinMS":       tier2HotReloadable,
+	// MDM enrollment config — startup-only: changing push cert or SCEP
+	// settings mid-flight would invalidate already-issued profiles.
+	"MDM": tier2StartupOnly,
 }
 
 func tier2ReloadFieldChanged(name string, startup, next reflect.Value) bool {

--- a/phase4-coordinator/cmd/coordinator/main.go
+++ b/phase4-coordinator/cmd/coordinator/main.go
@@ -1125,18 +1125,49 @@ func operatorMetricsHandler(operatorKey string, registry *prom.Registry) http.Ha
 	})
 }
 
-func buyerHandlerWithOptionalProviderEndpoints(base http.Handler, enabled bool, register, hardwareEvidence http.HandlerFunc, malibuAccrual http.Handler) http.Handler {
+func buyerHandlerWithOptionalProviderEndpoints(base http.Handler, enabled bool, register, hardwareEvidence, enroll http.HandlerFunc, malibuAccrual http.Handler) http.Handler {
 	mux := http.NewServeMux()
 	if enabled {
 		mux.HandleFunc("/v1/providers/register", register)
 		mux.HandleFunc("/v1/providers/hardware-evidence", hardwareEvidence)
 	}
 	mux.HandleFunc("/v1/provider/wallet", appTrackWalletNotImplementedHandler)
+	if enroll != nil {
+		mux.HandleFunc("/v1/enroll", enroll)
+	}
 	if malibuAccrual != nil {
 		mux.Handle("/v1/provider/malibu-accrual", malibuAccrual)
 	}
 	mux.Handle("/", base)
 	return mux
+}
+
+// buildEnrollHandler constructs the MDM enrollment handler for POST /v1/enroll.
+// Called only when tier2.mdm.enrollment_base_url is configured.
+func buildEnrollHandler(cfg config.Config, logger zerolog.Logger) *onboarding.EnrollHandler {
+	mdmCfg := cfg.Tier2.MDM
+	eh := &onboarding.EnrollHandler{
+		MDMConfig: mdm.Config{
+			EnrollmentBaseURL: mdmCfg.EnrollmentBaseURL,
+			MDMServerURL:      mdmCfg.MDMServerURL,
+			SCEPUrl:           mdmCfg.SCEPUrl,
+			PushTopic:         mdmCfg.PushTopic,
+		},
+		Logger: logger,
+	}
+	if mdmCfg.ProfileSignerCertPath != "" && mdmCfg.ProfileSignerKeyPath != "" {
+		signer, err := onboarding.NewFileProfileSigner(mdmCfg.ProfileSignerCertPath, mdmCfg.ProfileSignerKeyPath)
+		if err != nil {
+			logger.Error().Err(err).
+				Str("cert_path", mdmCfg.ProfileSignerCertPath).
+				Str("key_path", mdmCfg.ProfileSignerKeyPath).
+				Msg("MDM profile signer init failed — profiles will be served unsigned")
+		} else {
+			eh.Signer = signer
+			logger.Info().Msg("MDM enrollment profile CMS signer loaded")
+		}
+	}
+	return eh
 }
 
 func malibuAccrualHandler(cfg config.Config, tokenStore *auth.Store, rewardsDB *sql.DB, connectivity rewards.ProviderConnectivity) http.Handler {

--- a/phase4-coordinator/cmd/coordinator/main_test.go
+++ b/phase4-coordinator/cmd/coordinator/main_test.go
@@ -102,7 +102,7 @@ func TestBuyerRegisterRouteFeatureGate(t *testing.T) {
 		w.WriteHeader(http.StatusAccepted)
 	})
 
-	disabled := buyerHandlerWithOptionalProviderEndpoints(base, false, register, hardwareEvidence, nil)
+	disabled := buyerHandlerWithOptionalProviderEndpoints(base, false, register, hardwareEvidence, nil, nil)
 	req := httptest.NewRequest(http.MethodPost, "/v1/providers/register", nil)
 	rr := httptest.NewRecorder()
 	disabled.ServeHTTP(rr, req)
@@ -123,7 +123,7 @@ func TestBuyerRegisterRouteFeatureGate(t *testing.T) {
 		t.Fatalf("disabled wallet route status=%d body=%s, want 501 wallet_change_requires_spec_027", rr.Code, rr.Body.String())
 	}
 
-	enabled := buyerHandlerWithOptionalProviderEndpoints(base, true, register, hardwareEvidence, nil)
+	enabled := buyerHandlerWithOptionalProviderEndpoints(base, true, register, hardwareEvidence, nil, nil)
 	rr = httptest.NewRecorder()
 	enabled.ServeHTTP(rr, req)
 	if rr.Code != http.StatusNoContent {

--- a/phase4-coordinator/internal/config/config.go
+++ b/phase4-coordinator/internal/config/config.go
@@ -466,6 +466,10 @@ type Tier2Config struct {
 	SELivenessTimeoutS    int `yaml:"se_liveness_timeout_s"`
 	SELivenessMaxFailures int `yaml:"se_liveness_max_failures"`
 
+	// MDM enrollment profile generation (Phase 2, Track P2-A, Scenario B).
+	// Profile generation is enabled when MDM.EnrollmentBaseURL is non-empty.
+	MDM Tier2MDMConfig `yaml:"mdm"`
+
 	BehavioralSafetyEnabled    bool    `yaml:"behavioral_safety_enabled"`
 	OutputSizeCapBytes         int64   `yaml:"output_size_cap_bytes"`
 	OutputBytesPerTokenCeiling int     `yaml:"output_bytes_per_token_ceiling"`
@@ -474,6 +478,40 @@ type Tier2Config struct {
 	ResponseTimeAnomalyEnabled bool    `yaml:"response_time_anomaly_enabled"`
 	ResponseTimeAnomalyFactor  float64 `yaml:"response_time_anomaly_factor"`
 	ResponseTimeAnomalyMinMS   int64   `yaml:"response_time_anomaly_min_ms"`
+}
+
+// Tier2MDMConfig holds Phase 2 Track P2-A MDM enrollment profile settings.
+// All fields are optional — profile generation is disabled when
+// EnrollmentBaseURL is empty. Signer fields are optional; profiles are served
+// unsigned (with a loud error log) when signing is not configured or fails.
+type Tier2MDMConfig struct {
+	// EnrollmentBaseURL is the canonical HTTPS base URL used to build SCEP and
+	// MDM connect URLs inside the generated .mobileconfig. MUST be set
+	// explicitly; the coordinator never derives this from the inbound request's
+	// Host header — a client-controlled Host would let an attacker obtain a
+	// coordinator-signed profile pointing enrollment at their own server.
+	EnrollmentBaseURL string `yaml:"enrollment_base_url"`
+
+	// MDMServerURL is the full MicroMDM /mdm/connect URL. When empty, falls
+	// back to EnrollmentBaseURL + "/mdm/connect".
+	MDMServerURL string `yaml:"mdm_server_url"`
+
+	// SCEPUrl is the full SCEP endpoint URL. When empty, falls back to
+	// EnrollmentBaseURL + "/scep".
+	SCEPUrl string `yaml:"scep_url"`
+
+	// PushTopic is the APNs push topic tied to the MDM push certificate,
+	// e.g. "com.apple.mgmt.External.<uuid>". This is a placeholder until the
+	// macprovider APNs certificate is provisioned; the profile is syntactically
+	// valid without it but push-based MDM commands will not function.
+	PushTopic string `yaml:"push_topic"`
+
+	// ProfileSignerCertPath and ProfileSignerKeyPath point to PEM-encoded
+	// signing cert + private key for optional CMS signing of generated
+	// profiles. When empty, profiles are served unsigned (macOS will show
+	// "Unsigned" in the install prompt, which is acceptable for enrollment).
+	ProfileSignerCertPath string `yaml:"profile_signer_cert_path"`
+	ProfileSignerKeyPath  string `yaml:"profile_signer_key_path"`
 }
 
 type CoordinatorAdvertisedVersion struct {

--- a/phase4-coordinator/internal/mdm/cms.go
+++ b/phase4-coordinator/internal/mdm/cms.go
@@ -1,0 +1,320 @@
+package mdm
+
+// signMobileconfig creates a CMS SignedData (PKCS#7) envelope for a
+// .mobileconfig plist, enabling macOS to display the signer's identity at
+// install time. Signing is install-time trust only — it does not affect the
+// SCEP or MDM protocol trust chain inside the profile.
+//
+// Implements RFC 5652 §5 SignedData with:
+//   - SHA-256 digest algorithm
+//   - RSA or ECDSA (P-256) signature algorithm, inferred from the key type
+//   - Explicit signed attributes (content type + message digest)
+//   - The signing certificate embedded in the CertificateSet
+
+import (
+	"crypto"
+	"crypto/ecdsa"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/sha256"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/asn1"
+	"fmt"
+	"math/big"
+	"time"
+)
+
+// ASN.1 OIDs used in CMS/PKCS#7 SignedData.
+var (
+	oidPKCS7SignedData   = asn1.ObjectIdentifier{1, 2, 840, 113549, 1, 7, 2}
+	oidPKCS7Data         = asn1.ObjectIdentifier{1, 2, 840, 113549, 1, 7, 1}
+	oidSHA256            = asn1.ObjectIdentifier{2, 16, 840, 1, 101, 3, 4, 2, 1}
+	oidRSA               = asn1.ObjectIdentifier{1, 2, 840, 113549, 1, 1, 1}
+	oidECDSAWithSHA256   = asn1.ObjectIdentifier{1, 2, 840, 10045, 4, 3, 2}
+	oidAttrContentType   = asn1.ObjectIdentifier{1, 2, 840, 113549, 1, 9, 3}
+	oidAttrMessageDigest = asn1.ObjectIdentifier{1, 2, 840, 113549, 1, 9, 4}
+	oidAttrSigningTime   = asn1.ObjectIdentifier{1, 2, 840, 113549, 1, 9, 5}
+)
+
+// signedAttribute is a CMS SignedAttribute (RFC 5652 §5.3).
+type signedAttribute struct {
+	Type   asn1.ObjectIdentifier
+	Values asn1.RawValue `asn1:"set"`
+}
+
+// issuerAndSerialNumber identifies the signer by certificate issuer + serial.
+type issuerAndSerialNumber struct {
+	Issuer       pkix.RDNSequence
+	SerialNumber *big.Int
+}
+
+// signMobileconfig produces a DER-encoded CMS SignedData wrapping the given
+// plist bytes. The content is embedded (encapContentInfo.eContent present).
+func signMobileconfig(content []byte, cert *x509.Certificate, key crypto.Signer) ([]byte, error) {
+	// 1. Compute the message digest of the content.
+	digest := sha256.Sum256(content)
+
+	// 2. Build the signed attributes (content type, signing time, message digest).
+	//    Order matters: attributes must be in DER SET order (OID-sorted) for
+	//    correct signature verification, but encoding/asn1 does not auto-sort
+	//    SET OF — we order them by OID value manually.
+	//
+	//    OID ordering: 1.2.840.113549.1.9.3 (contentType) < 1.2.840.113549.1.9.4
+	//    (messageDigest) < 1.2.840.113549.1.9.5 (signingTime) by DER SET rules.
+	//    Actually, RFC 5652 says ordered SET is not required for SignedAttributes
+	//    (they are defined as IMPLICIT [0] SET OF Attribute, receiver must re-sort).
+	//    We build them in a deterministic order that produces a valid signature.
+
+	contentTypeVal, err := asn1.Marshal(oidPKCS7Data)
+	if err != nil {
+		return nil, fmt.Errorf("cms: marshal content type value: %w", err)
+	}
+	digestVal, err := asn1.Marshal(digest[:])
+	if err != nil {
+		return nil, fmt.Errorf("cms: marshal digest value: %w", err)
+	}
+	signingTimeVal, err := asn1.Marshal(time.Now().UTC())
+	if err != nil {
+		return nil, fmt.Errorf("cms: marshal signing time: %w", err)
+	}
+
+	// Each Attribute is SEQUENCE { OID, SET { value } }.
+	// Build as raw bytes so we control the SET encoding precisely.
+	attrContentType, err := marshalAttribute(oidAttrContentType, contentTypeVal)
+	if err != nil {
+		return nil, fmt.Errorf("cms: marshal contentType attr: %w", err)
+	}
+	attrSigningTime, err := marshalAttribute(oidAttrSigningTime, signingTimeVal)
+	if err != nil {
+		return nil, fmt.Errorf("cms: marshal signingTime attr: %w", err)
+	}
+	attrMessageDigest, err := marshalAttribute(oidAttrMessageDigest, digestVal)
+	if err != nil {
+		return nil, fmt.Errorf("cms: marshal messageDigest attr: %w", err)
+	}
+
+	// signedAttrsBytes is the concatenation of attribute DER encodings, which
+	// will be wrapped in an explicit SET tag for both storage and signing.
+	signedAttrsInner := append(attrContentType, attrSigningTime...)
+	signedAttrsInner = append(signedAttrsInner, attrMessageDigest...)
+
+	// 3. Compute the signature over the DER SET encoding of signedAttrs.
+	//    RFC 5652 §5.4: the message authentication code is computed over the
+	//    complete DER encoding of the SignedAttributes, re-tagged as a SET
+	//    (tag 0x31) — NOT as the IMPLICIT [0] tag used in the SignerInfo.
+	signedAttrsDER, err := marshalSET(signedAttrsInner)
+	if err != nil {
+		return nil, fmt.Errorf("cms: marshal signed attributes SET: %w", err)
+	}
+	signedAttrsHash := sha256.Sum256(signedAttrsDER)
+
+	var sigAlgOID asn1.ObjectIdentifier
+	var sigBytes []byte
+
+	switch k := key.(type) {
+	case *rsa.PrivateKey:
+		sigAlgOID = oidRSA
+		sigBytes, err = k.Sign(rand.Reader, signedAttrsHash[:], crypto.SHA256)
+		if err != nil {
+			return nil, fmt.Errorf("cms: RSA sign: %w", err)
+		}
+	case *ecdsa.PrivateKey:
+		sigAlgOID = oidECDSAWithSHA256
+		sigBytes, err = k.Sign(rand.Reader, signedAttrsHash[:], crypto.SHA256)
+		if err != nil {
+			return nil, fmt.Errorf("cms: ECDSA sign: %w", err)
+		}
+	default:
+		return nil, fmt.Errorf("cms: unsupported key type %T", key)
+	}
+
+	// 4. Build SignerInfo.
+	//    SignerInfo version is 1 when using issuerAndSerialNumber (RFC 5652 §5.3).
+	issuerRDN := pkix.RDNSequence{}
+	if err := issuerRDN.FillFromRDNSequence(&cert.Issuer); err != nil {
+		return nil, fmt.Errorf("cms: encode issuer: %w", err)
+	}
+	issuerDER, err := asn1.Marshal(issuerRDN)
+	if err != nil {
+		return nil, fmt.Errorf("cms: marshal issuer: %w", err)
+	}
+	issuerAndSN := issuerAndSerialNumber{
+		SerialNumber: cert.SerialNumber,
+	}
+	if rest, err2 := asn1.Unmarshal(issuerDER, &issuerAndSN.Issuer); err2 != nil || len(rest) != 0 {
+		return nil, fmt.Errorf("cms: unmarshal issuer RDN: %w", err2)
+	}
+	sidDER, err := asn1.Marshal(issuerAndSN)
+	if err != nil {
+		return nil, fmt.Errorf("cms: marshal issuerAndSN: %w", err)
+	}
+
+	signerInfoDER, err := buildSignerInfoDER(sidDER, signedAttrsInner, sigAlgOID, sigBytes)
+	if err != nil {
+		return nil, fmt.Errorf("cms: build signerInfo: %w", err)
+	}
+
+	// 5. Build EncapsulatedContentInfo with the plist bytes.
+	contentDER, err := asn1.Marshal(content) // OCTET STRING
+	if err != nil {
+		return nil, fmt.Errorf("cms: marshal content: %w", err)
+	}
+	eContentTagged := asn1.RawValue{Class: asn1.ClassContextSpecific, Tag: 0, IsCompound: true, Bytes: contentDER}
+	eContentDER, err := asn1.Marshal(eContentTagged)
+	if err != nil {
+		return nil, fmt.Errorf("cms: marshal eContent explicit: %w", err)
+	}
+	eciDER, err := marshalSEQUENCE(append(mustMarshalOID(oidPKCS7Data), eContentDER...))
+	if err != nil {
+		return nil, fmt.Errorf("cms: build encapContentInfo: %w", err)
+	}
+
+	// 6. DigestAlgorithmIdentifiers SET { AlgorithmIdentifier }.
+	digestAlgDER, err := asn1.Marshal(pkix.AlgorithmIdentifier{Algorithm: oidSHA256})
+	if err != nil {
+		return nil, fmt.Errorf("cms: marshal digestAlg: %w", err)
+	}
+	digestAlgSetDER, err := marshalSET(digestAlgDER)
+	if err != nil {
+		return nil, fmt.Errorf("cms: marshal digestAlg SET: %w", err)
+	}
+
+	// 7. Certificates [0] IMPLICIT — the raw certificate DER bytes.
+	certTagged := asn1.RawValue{Class: asn1.ClassContextSpecific, Tag: 0, IsCompound: true, Bytes: cert.Raw}
+	certsDER, err := asn1.Marshal(certTagged)
+	if err != nil {
+		return nil, fmt.Errorf("cms: marshal certificates: %w", err)
+	}
+
+	// 8. SignerInfos SET { SignerInfo }.
+	signerInfosSetDER, err := marshalSET(signerInfoDER)
+	if err != nil {
+		return nil, fmt.Errorf("cms: marshal signerInfos SET: %w", err)
+	}
+
+	// 9. SignedData SEQUENCE {version(1), digestAlgs, encapCI, certs[0], signerInfos}.
+	versionDER, err := asn1.Marshal(1) // version = 1
+	if err != nil {
+		return nil, fmt.Errorf("cms: marshal version: %w", err)
+	}
+	signedDataInner := make([]byte, 0,
+		len(versionDER)+len(digestAlgSetDER)+len(eciDER)+len(certsDER)+len(signerInfosSetDER))
+	signedDataInner = append(signedDataInner, versionDER...)
+	signedDataInner = append(signedDataInner, digestAlgSetDER...)
+	signedDataInner = append(signedDataInner, eciDER...)
+	signedDataInner = append(signedDataInner, certsDER...)
+	signedDataInner = append(signedDataInner, signerInfosSetDER...)
+	signedDataDER, err := marshalSEQUENCE(signedDataInner)
+	if err != nil {
+		return nil, fmt.Errorf("cms: build signedData: %w", err)
+	}
+
+	// 10. ContentInfo SEQUENCE { OID pkcs7SignedData, [0] EXPLICIT signedData }.
+	signedDataExplicit := asn1.RawValue{
+		Class:      asn1.ClassContextSpecific,
+		Tag:        0,
+		IsCompound: true,
+		Bytes:      signedDataDER,
+	}
+	signedDataExplicitDER, err := asn1.Marshal(signedDataExplicit)
+	if err != nil {
+		return nil, fmt.Errorf("cms: marshal signedData explicit: %w", err)
+	}
+	ciInner := append(mustMarshalOID(oidPKCS7SignedData), signedDataExplicitDER...)
+	return marshalSEQUENCE(ciInner)
+}
+
+// marshalAttribute encodes a CMS Attribute as:
+// SEQUENCE { OID, SET { preEncodedValue } }
+// where preEncodedValue is already DER-encoded.
+func marshalAttribute(oid asn1.ObjectIdentifier, valueDER []byte) ([]byte, error) {
+	oidDER, err := asn1.Marshal(oid)
+	if err != nil {
+		return nil, err
+	}
+	setDER, err := marshalSET(valueDER)
+	if err != nil {
+		return nil, err
+	}
+	return marshalSEQUENCE(append(oidDER, setDER...))
+}
+
+// buildSignerInfoDER assembles the raw DER bytes for a SignerInfo:
+//
+//	SignerInfo ::= SEQUENCE {
+//	  version              INTEGER (1),
+//	  sid                  IssuerAndSerialNumber,
+//	  digestAlgorithm      AlgorithmIdentifier,
+//	  signedAttrs     [0] IMPLICIT SET OF Attribute,
+//	  signatureAlgorithm   AlgorithmIdentifier,
+//	  signature            OCTET STRING
+//	}
+func buildSignerInfoDER(sidDER, signedAttrsInner []byte, sigAlgOID asn1.ObjectIdentifier, sigBytes []byte) ([]byte, error) {
+	vDER, err := asn1.Marshal(1)
+	if err != nil {
+		return nil, err
+	}
+	digestAlgDER, err := asn1.Marshal(pkix.AlgorithmIdentifier{Algorithm: oidSHA256})
+	if err != nil {
+		return nil, err
+	}
+	// signedAttrs is stored as IMPLICIT [0] SET (class context-specific, tag 0).
+	// We use the raw bytes of the inner attributes and wrap with the implicit tag.
+	signedAttrsImplicit := asn1.RawValue{
+		Class:      asn1.ClassContextSpecific,
+		Tag:        0,
+		IsCompound: true,
+		Bytes:      signedAttrsInner,
+	}
+	signedAttrsDER, err := asn1.Marshal(signedAttrsImplicit)
+	if err != nil {
+		return nil, err
+	}
+	sigAlgDER, err := asn1.Marshal(pkix.AlgorithmIdentifier{Algorithm: sigAlgOID})
+	if err != nil {
+		return nil, err
+	}
+	sigDER, err := asn1.Marshal(sigBytes)
+	if err != nil {
+		return nil, err
+	}
+	inner := make([]byte, 0, len(vDER)+len(sidDER)+len(digestAlgDER)+len(signedAttrsDER)+len(sigAlgDER)+len(sigDER))
+	inner = append(inner, vDER...)
+	inner = append(inner, sidDER...)
+	inner = append(inner, digestAlgDER...)
+	inner = append(inner, signedAttrsDER...)
+	inner = append(inner, sigAlgDER...)
+	inner = append(inner, sigDER...)
+	return marshalSEQUENCE(inner)
+}
+
+// marshalSEQUENCE wraps inner bytes in a DER SEQUENCE (tag 0x30).
+func marshalSEQUENCE(inner []byte) ([]byte, error) {
+	return asn1.Marshal(asn1.RawValue{
+		Class:      asn1.ClassUniversal,
+		Tag:        asn1.TagSequence,
+		IsCompound: true,
+		Bytes:      inner,
+	})
+}
+
+// marshalSET wraps inner bytes in a DER SET (tag 0x31).
+func marshalSET(inner []byte) ([]byte, error) {
+	return asn1.Marshal(asn1.RawValue{
+		Class:      asn1.ClassUniversal,
+		Tag:        asn1.TagSet,
+		IsCompound: true,
+		Bytes:      inner,
+	})
+}
+
+// mustMarshalOID marshals an OID to DER. Panics on error (OIDs are static
+// constants — failure is a programming error, not a runtime condition).
+func mustMarshalOID(oid asn1.ObjectIdentifier) []byte {
+	b, err := asn1.Marshal(oid)
+	if err != nil {
+		panic(fmt.Sprintf("cms: marshal OID %v: %v", oid, err))
+	}
+	return b
+}

--- a/phase4-coordinator/internal/mdm/cms.go
+++ b/phase4-coordinator/internal/mdm/cms.go
@@ -1,6 +1,6 @@
 package mdm
 
-// signMobileconfig creates a CMS SignedData (PKCS#7) envelope for a
+// SignMobileconfig creates a CMS SignedData (PKCS#7) envelope for a
 // .mobileconfig plist, enabling macOS to display the signer's identity at
 // install time. Signing is install-time trust only — it does not affect the
 // SCEP or MDM protocol trust chain inside the profile.
@@ -8,7 +8,7 @@ package mdm
 // Implements RFC 5652 §5 SignedData with:
 //   - SHA-256 digest algorithm
 //   - RSA or ECDSA (P-256) signature algorithm, inferred from the key type
-//   - Explicit signed attributes (content type + message digest)
+//   - Explicit signed attributes (content type, signing time, message digest)
 //   - The signing certificate embedded in the CertificateSet
 
 import (
@@ -37,35 +37,13 @@ var (
 	oidAttrSigningTime   = asn1.ObjectIdentifier{1, 2, 840, 113549, 1, 9, 5}
 )
 
-// signedAttribute is a CMS SignedAttribute (RFC 5652 §5.3).
-type signedAttribute struct {
-	Type   asn1.ObjectIdentifier
-	Values asn1.RawValue `asn1:"set"`
-}
-
-// issuerAndSerialNumber identifies the signer by certificate issuer + serial.
-type issuerAndSerialNumber struct {
-	Issuer       pkix.RDNSequence
-	SerialNumber *big.Int
-}
-
-// signMobileconfig produces a DER-encoded CMS SignedData wrapping the given
+// SignMobileconfig produces a DER-encoded CMS SignedData wrapping the given
 // plist bytes. The content is embedded (encapContentInfo.eContent present).
-func signMobileconfig(content []byte, cert *x509.Certificate, key crypto.Signer) ([]byte, error) {
+func SignMobileconfig(content []byte, cert *x509.Certificate, key crypto.Signer) ([]byte, error) {
 	// 1. Compute the message digest of the content.
 	digest := sha256.Sum256(content)
 
-	// 2. Build the signed attributes (content type, signing time, message digest).
-	//    Order matters: attributes must be in DER SET order (OID-sorted) for
-	//    correct signature verification, but encoding/asn1 does not auto-sort
-	//    SET OF — we order them by OID value manually.
-	//
-	//    OID ordering: 1.2.840.113549.1.9.3 (contentType) < 1.2.840.113549.1.9.4
-	//    (messageDigest) < 1.2.840.113549.1.9.5 (signingTime) by DER SET rules.
-	//    Actually, RFC 5652 says ordered SET is not required for SignedAttributes
-	//    (they are defined as IMPLICIT [0] SET OF Attribute, receiver must re-sort).
-	//    We build them in a deterministic order that produces a valid signature.
-
+	// 2. Build the signed attributes: contentType, signingTime, messageDigest.
 	contentTypeVal, err := asn1.Marshal(oidPKCS7Data)
 	if err != nil {
 		return nil, fmt.Errorf("cms: marshal content type value: %w", err)
@@ -79,8 +57,6 @@ func signMobileconfig(content []byte, cert *x509.Certificate, key crypto.Signer)
 		return nil, fmt.Errorf("cms: marshal signing time: %w", err)
 	}
 
-	// Each Attribute is SEQUENCE { OID, SET { value } }.
-	// Build as raw bytes so we control the SET encoding precisely.
 	attrContentType, err := marshalAttribute(oidAttrContentType, contentTypeVal)
 	if err != nil {
 		return nil, fmt.Errorf("cms: marshal contentType attr: %w", err)
@@ -94,15 +70,13 @@ func signMobileconfig(content []byte, cert *x509.Certificate, key crypto.Signer)
 		return nil, fmt.Errorf("cms: marshal messageDigest attr: %w", err)
 	}
 
-	// signedAttrsBytes is the concatenation of attribute DER encodings, which
-	// will be wrapped in an explicit SET tag for both storage and signing.
+	// signedAttrsInner is the concatenation of attribute DER encodings wrapped
+	// as an IMPLICIT [0] SET in the SignerInfo.
 	signedAttrsInner := append(attrContentType, attrSigningTime...)
 	signedAttrsInner = append(signedAttrsInner, attrMessageDigest...)
 
-	// 3. Compute the signature over the DER SET encoding of signedAttrs.
-	//    RFC 5652 §5.4: the message authentication code is computed over the
-	//    complete DER encoding of the SignedAttributes, re-tagged as a SET
-	//    (tag 0x31) — NOT as the IMPLICIT [0] tag used in the SignerInfo.
+	// 3. Signature is computed over the DER SET encoding of signedAttrs
+	//    (RFC 5652 §5.4 — re-tagged as universal SET 0x31).
 	signedAttrsDER, err := marshalSET(signedAttrsInner)
 	if err != nil {
 		return nil, fmt.Errorf("cms: marshal signed attributes SET: %w", err)
@@ -129,23 +103,9 @@ func signMobileconfig(content []byte, cert *x509.Certificate, key crypto.Signer)
 		return nil, fmt.Errorf("cms: unsupported key type %T", key)
 	}
 
-	// 4. Build SignerInfo.
-	//    SignerInfo version is 1 when using issuerAndSerialNumber (RFC 5652 §5.3).
-	issuerRDN := pkix.RDNSequence{}
-	if err := issuerRDN.FillFromRDNSequence(&cert.Issuer); err != nil {
-		return nil, fmt.Errorf("cms: encode issuer: %w", err)
-	}
-	issuerDER, err := asn1.Marshal(issuerRDN)
-	if err != nil {
-		return nil, fmt.Errorf("cms: marshal issuer: %w", err)
-	}
-	issuerAndSN := issuerAndSerialNumber{
-		SerialNumber: cert.SerialNumber,
-	}
-	if rest, err2 := asn1.Unmarshal(issuerDER, &issuerAndSN.Issuer); err2 != nil || len(rest) != 0 {
-		return nil, fmt.Errorf("cms: unmarshal issuer RDN: %w", err2)
-	}
-	sidDER, err := asn1.Marshal(issuerAndSN)
+	// 4. Build IssuerAndSerialNumber using the raw DER issuer from the cert.
+	//    cert.RawIssuer is the already-encoded Name (SEQUENCE of SETs).
+	sidDER, err := marshalIssuerAndSN(cert.RawIssuer, cert.SerialNumber)
 	if err != nil {
 		return nil, fmt.Errorf("cms: marshal issuerAndSN: %w", err)
 	}
@@ -155,7 +115,7 @@ func signMobileconfig(content []byte, cert *x509.Certificate, key crypto.Signer)
 		return nil, fmt.Errorf("cms: build signerInfo: %w", err)
 	}
 
-	// 5. Build EncapsulatedContentInfo with the plist bytes.
+	// 5. EncapsulatedContentInfo with the plist bytes.
 	contentDER, err := asn1.Marshal(content) // OCTET STRING
 	if err != nil {
 		return nil, fmt.Errorf("cms: marshal content: %w", err)
@@ -180,7 +140,7 @@ func signMobileconfig(content []byte, cert *x509.Certificate, key crypto.Signer)
 		return nil, fmt.Errorf("cms: marshal digestAlg SET: %w", err)
 	}
 
-	// 7. Certificates [0] IMPLICIT — the raw certificate DER bytes.
+	// 7. Certificates [0] IMPLICIT — raw certificate DER.
 	certTagged := asn1.RawValue{Class: asn1.ClassContextSpecific, Tag: 0, IsCompound: true, Bytes: cert.Raw}
 	certsDER, err := asn1.Marshal(certTagged)
 	if err != nil {
@@ -193,8 +153,8 @@ func signMobileconfig(content []byte, cert *x509.Certificate, key crypto.Signer)
 		return nil, fmt.Errorf("cms: marshal signerInfos SET: %w", err)
 	}
 
-	// 9. SignedData SEQUENCE {version(1), digestAlgs, encapCI, certs[0], signerInfos}.
-	versionDER, err := asn1.Marshal(1) // version = 1
+	// 9. SignedData SEQUENCE { version(1), digestAlgs, encapCI, certs[0], signerInfos }.
+	versionDER, err := asn1.Marshal(1)
 	if err != nil {
 		return nil, fmt.Errorf("cms: marshal version: %w", err)
 	}
@@ -225,9 +185,19 @@ func signMobileconfig(content []byte, cert *x509.Certificate, key crypto.Signer)
 	return marshalSEQUENCE(ciInner)
 }
 
+// marshalIssuerAndSN encodes IssuerAndSerialNumber by embedding raw DER issuer
+// bytes directly, avoiding round-trip issues with pkix.RDNSequence re-ordering.
+func marshalIssuerAndSN(rawIssuer []byte, serial *big.Int) ([]byte, error) {
+	serialDER, err := asn1.Marshal(serial)
+	if err != nil {
+		return nil, fmt.Errorf("cms: marshal serial: %w", err)
+	}
+	inner := append(rawIssuer, serialDER...)
+	return marshalSEQUENCE(inner)
+}
+
 // marshalAttribute encodes a CMS Attribute as:
 // SEQUENCE { OID, SET { preEncodedValue } }
-// where preEncodedValue is already DER-encoded.
 func marshalAttribute(oid asn1.ObjectIdentifier, valueDER []byte) ([]byte, error) {
 	oidDER, err := asn1.Marshal(oid)
 	if err != nil {
@@ -240,16 +210,7 @@ func marshalAttribute(oid asn1.ObjectIdentifier, valueDER []byte) ([]byte, error
 	return marshalSEQUENCE(append(oidDER, setDER...))
 }
 
-// buildSignerInfoDER assembles the raw DER bytes for a SignerInfo:
-//
-//	SignerInfo ::= SEQUENCE {
-//	  version              INTEGER (1),
-//	  sid                  IssuerAndSerialNumber,
-//	  digestAlgorithm      AlgorithmIdentifier,
-//	  signedAttrs     [0] IMPLICIT SET OF Attribute,
-//	  signatureAlgorithm   AlgorithmIdentifier,
-//	  signature            OCTET STRING
-//	}
+// buildSignerInfoDER assembles the raw DER bytes for a SignerInfo.
 func buildSignerInfoDER(sidDER, signedAttrsInner []byte, sigAlgOID asn1.ObjectIdentifier, sigBytes []byte) ([]byte, error) {
 	vDER, err := asn1.Marshal(1)
 	if err != nil {
@@ -259,8 +220,7 @@ func buildSignerInfoDER(sidDER, signedAttrsInner []byte, sigAlgOID asn1.ObjectId
 	if err != nil {
 		return nil, err
 	}
-	// signedAttrs is stored as IMPLICIT [0] SET (class context-specific, tag 0).
-	// We use the raw bytes of the inner attributes and wrap with the implicit tag.
+	// signedAttrs stored as IMPLICIT [0] SET (context-specific, tag 0).
 	signedAttrsImplicit := asn1.RawValue{
 		Class:      asn1.ClassContextSpecific,
 		Tag:        0,
@@ -309,8 +269,8 @@ func marshalSET(inner []byte) ([]byte, error) {
 	})
 }
 
-// mustMarshalOID marshals an OID to DER. Panics on error (OIDs are static
-// constants — failure is a programming error, not a runtime condition).
+// mustMarshalOID panics on error — OID constants are static and failure is a
+// programming error.
 func mustMarshalOID(oid asn1.ObjectIdentifier) []byte {
 	b, err := asn1.Marshal(oid)
 	if err != nil {

--- a/phase4-coordinator/internal/mdm/enroll.go
+++ b/phase4-coordinator/internal/mdm/enroll.go
@@ -1,0 +1,209 @@
+// Package mdm implements Phase 2 Track P2-A MDM enrollment profile generation
+// (Scenario B). It generates per-device .mobileconfig files containing SCEP
+// and MDM payloads for enrolling macprovider compute nodes into MicroMDM.
+//
+// No MicroMDM server deployment or APNs certificate is required for this
+// track — the package only handles profile generation.
+package mdm
+
+import (
+	"fmt"
+
+	"github.com/google/uuid"
+)
+
+// Stable payload UUIDs — macOS keys profile identity (and re-enrollment
+// update-in-place) on PayloadIdentifier strings and PayloadUUIDs. Using
+// fixed UUIDs means a re-enroll with this profile replaces the existing
+// macprovider enrollment rather than adding a duplicate.
+const (
+	scepPayloadUUID = "B3F7E8A1-2C9D-4F5E-8A6B-1E2D3C4B5A00"
+	mdmPayloadUUID  = "A1B2C3D4-E5F6-7A8B-9C0D-E1F2A3B4C501"
+)
+
+// mdmPayloadIdentifierNS is the payload identifier namespace for macprovider.
+// Using live.streamvc.macprovider.enroll.* (NOT io.darkbloom.*).
+const mdmPayloadIdentifierNS = "live.streamvc.macprovider.enroll"
+
+// Config carries the MDM enrollment parameters for profile generation.
+// Populated at coordinator boot from config.Tier2MDMConfig.
+type Config struct {
+	// EnrollmentBaseURL is the canonical HTTPS base URL (e.g.
+	// "https://coordinator.streamvc.live"). Used to derive SCEP and MDM
+	// connect URLs when MDMServerURL or SCEPUrl are not set explicitly.
+	EnrollmentBaseURL string
+
+	// MDMServerURL overrides the MicroMDM connect URL. When empty,
+	// EnrollmentBaseURL + "/mdm/connect" is used.
+	MDMServerURL string
+
+	// SCEPUrl overrides the SCEP endpoint URL. When empty,
+	// EnrollmentBaseURL + "/scep" is used.
+	SCEPUrl string
+
+	// PushTopic is the APNs push topic tied to the MDM push certificate.
+	// Placeholder until the macprovider APNs certificate is provisioned;
+	// omit for staging — the resulting profile is syntactically valid.
+	PushTopic string
+}
+
+// GenerateEnrollmentProfile creates a .mobileconfig plist with two payloads:
+//
+//  1. SCEP — obtains the MDM identity certificate from the coordinator's
+//     SCEP endpoint. Fixed PayloadUUID scepPayloadUUID for re-enrollment
+//     stability.
+//
+//  2. MDM — enrolls the device with MicroMDM via the ServerURL. References
+//     the SCEP payload by IdentityCertificateUUID.
+//
+// AccessRights=1041 (bits 0+4+10): profile inspection, device info queries,
+// and security-related queries (SIP, SecureBoot). Strictly read-only — no
+// device control or personal data access.
+//
+// Apple MDM AccessRights bitmask:
+//
+//	Bit 0  (1)    — Inspect installed config profiles          ✓ REQUESTED
+//	Bit 1  (2)    — Install/remove config profiles             ✗
+//	Bit 2  (4)    — Device lock and passcode removal           ✗
+//	Bit 3  (8)    — Device erase (remote wipe)                 ✗
+//	Bit 4  (16)   — Query device information (name, serial)    ✓ REQUESTED
+//	Bit 5  (32)   — Query network information                  ✗
+//	Bit 6  (64)   — Inspect installed provisioning profiles    ✗
+//	Bit 7  (128)  — Install/remove provisioning profiles       ✗
+//	Bit 8  (256)  — Inspect installed applications             ✗
+//	Bit 9  (512)  — Restriction-related queries                ✗
+//	Bit 10 (1024) — Security-related queries (SIP, SecureBoot) ✓ REQUESTED
+//	Bit 11 (2048) — Change device settings                     ✗
+//	Bit 12 (4096) — App management                             ✗
+func GenerateEnrollmentProfile(serialNumber string, cfg Config) string {
+	scepURL := cfg.SCEPUrl
+	if scepURL == "" {
+		scepURL = cfg.EnrollmentBaseURL + "/scep"
+	}
+	mdmServerURL := cfg.MDMServerURL
+	if mdmServerURL == "" {
+		mdmServerURL = cfg.EnrollmentBaseURL + "/mdm/connect"
+	}
+	mdmCheckInURL := cfg.EnrollmentBaseURL + "/mdm/checkin"
+	pushTopic := cfg.PushTopic
+
+	profileUUID := uuid.New().String()
+
+	return fmt.Sprintf(`<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>PayloadContent</key>
+  <array>
+    <!-- Payload 1: SCEP — MDM identity certificate -->
+    <dict>
+      <key>PayloadContent</key>
+      <dict>
+        <key>Challenge</key>
+        <string>micromdm</string>
+        <key>Key Type</key>
+        <string>RSA</string>
+        <key>Key Usage</key>
+        <integer>5</integer>
+        <key>Keysize</key>
+        <integer>2048</integer>
+        <key>Name</key>
+        <string>macprovider Device Management Identity Certificate</string>
+        <key>Subject</key>
+        <array>
+          <array>
+            <array>
+              <string>O</string>
+              <string>macprovider</string>
+            </array>
+          </array>
+          <array>
+            <array>
+              <string>CN</string>
+              <string>macprovider Device Identity</string>
+            </array>
+          </array>
+        </array>
+        <key>URL</key>
+        <string>%s</string>
+      </dict>
+      <key>PayloadDescription</key>
+      <string>Configures SCEP for MDM enrollment</string>
+      <key>PayloadDisplayName</key>
+      <string>SCEP</string>
+      <key>PayloadIdentifier</key>
+      <string>%s.scep</string>
+      <key>PayloadOrganization</key>
+      <string>macprovider</string>
+      <key>PayloadType</key>
+      <string>com.apple.security.scep</string>
+      <key>PayloadUUID</key>
+      <string>%s</string>
+      <key>PayloadVersion</key>
+      <integer>1</integer>
+    </dict>
+    <!-- Payload 2: MDM — enrollment with MicroMDM -->
+    <dict>
+      <key>AccessRights</key>
+      <integer>1041</integer>
+      <key>CheckInURL</key>
+      <string>%s</string>
+      <key>CheckOutWhenRemoved</key>
+      <true/>
+      <key>IdentityCertificateUUID</key>
+      <string>%s</string>
+      <key>PayloadDescription</key>
+      <string>Enrolls with the macprovider coordinator for security verification</string>
+      <key>PayloadIdentifier</key>
+      <string>%s.mdm</string>
+      <key>PayloadOrganization</key>
+      <string>macprovider</string>
+      <key>PayloadType</key>
+      <string>com.apple.mdm</string>
+      <key>PayloadUUID</key>
+      <string>%s</string>
+      <key>PayloadVersion</key>
+      <integer>1</integer>
+      <key>ServerCapabilities</key>
+      <array>
+        <string>com.apple.mdm.per-user-connections</string>
+        <string>com.apple.mdm.bootstraptoken</string>
+      </array>
+      <key>ServerURL</key>
+      <string>%s</string>
+      <key>SignMessage</key>
+      <true/>
+      <key>Topic</key>
+      <string>%s</string>
+    </dict>
+  </array>
+  <key>PayloadDescription</key>
+  <string>macprovider provider enrollment. Grants read-only security verification (SIP, SecureBoot) via MDM.</string>
+  <key>PayloadDisplayName</key>
+  <string>macprovider Provider Enrollment</string>
+  <key>PayloadIdentifier</key>
+  <string>%s.%s</string>
+  <key>PayloadOrganization</key>
+  <string>macprovider</string>
+  <key>PayloadType</key>
+  <string>Configuration</string>
+  <key>PayloadUUID</key>
+  <string>%s</string>
+  <key>PayloadVersion</key>
+  <integer>1</integer>
+</dict>
+</plist>`,
+		scepURL,                    // SCEP URL
+		mdmPayloadIdentifierNS,     // SCEP PayloadIdentifier prefix
+		scepPayloadUUID,            // SCEP PayloadUUID (stable)
+		mdmCheckInURL,              // MDM CheckInURL
+		scepPayloadUUID,            // MDM IdentityCertificateUUID (refs SCEP payload)
+		mdmPayloadIdentifierNS,     // MDM PayloadIdentifier prefix
+		mdmPayloadUUID,             // MDM PayloadUUID (stable)
+		mdmServerURL,               // MDM ServerURL
+		pushTopic,                  // MDM Topic
+		mdmPayloadIdentifierNS,     // outer PayloadIdentifier prefix
+		serialNumber,               // outer PayloadIdentifier serial suffix
+		profileUUID,                // outer PayloadUUID (fresh per request)
+	)
+}

--- a/phase4-coordinator/internal/mdm/enroll_test.go
+++ b/phase4-coordinator/internal/mdm/enroll_test.go
@@ -1,0 +1,135 @@
+package mdm_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/augstar/macprovider-coordinator/internal/mdm"
+)
+
+func TestGenerateEnrollmentProfile_ContainsSCEPAndMDMPayloads(t *testing.T) {
+	cfg := mdm.Config{
+		EnrollmentBaseURL: "https://coordinator.streamvc.live",
+		PushTopic:         "com.apple.mgmt.External.test-topic",
+	}
+	profile := mdm.GenerateEnrollmentProfile("C02XYZ1234AB", cfg)
+
+	// Must contain both payload types.
+	if !strings.Contains(profile, "com.apple.security.scep") {
+		t.Error("profile missing SCEP payload type")
+	}
+	if !strings.Contains(profile, "com.apple.mdm") {
+		t.Error("profile missing MDM payload type")
+	}
+}
+
+func TestGenerateEnrollmentProfile_SerialInProfile(t *testing.T) {
+	const serial = "C02XYZ1234AB"
+	cfg := mdm.Config{
+		EnrollmentBaseURL: "https://coordinator.streamvc.live",
+	}
+	profile := mdm.GenerateEnrollmentProfile(serial, cfg)
+
+	if !strings.Contains(profile, serial) {
+		t.Errorf("profile does not contain serial number %q", serial)
+	}
+}
+
+func TestGenerateEnrollmentProfile_ServerURLFromConfig(t *testing.T) {
+	cfg := mdm.Config{
+		EnrollmentBaseURL: "https://coordinator.streamvc.live",
+		MDMServerURL:      "https://mdm.streamvc.live/mdm/connect",
+		SCEPUrl:           "https://mdm.streamvc.live/scep",
+		PushTopic:         "com.apple.mgmt.External.abc",
+	}
+	profile := mdm.GenerateEnrollmentProfile("SERIALTEST1", cfg)
+
+	if !strings.Contains(profile, "https://mdm.streamvc.live/mdm/connect") {
+		t.Error("profile does not contain the configured MDM ServerURL")
+	}
+	if !strings.Contains(profile, "https://mdm.streamvc.live/scep") {
+		t.Error("profile does not contain the configured SCEP URL")
+	}
+}
+
+func TestGenerateEnrollmentProfile_FallbackURLs(t *testing.T) {
+	cfg := mdm.Config{
+		EnrollmentBaseURL: "https://coordinator.streamvc.live",
+	}
+	profile := mdm.GenerateEnrollmentProfile("SERIALTEST2", cfg)
+
+	// When MDMServerURL/SCEPUrl are empty, they should fall back to
+	// EnrollmentBaseURL + path suffixes.
+	if !strings.Contains(profile, "https://coordinator.streamvc.live/mdm/connect") {
+		t.Error("profile missing fallback MDM ServerURL")
+	}
+	if !strings.Contains(profile, "https://coordinator.streamvc.live/scep") {
+		t.Error("profile missing fallback SCEP URL")
+	}
+}
+
+func TestGenerateEnrollmentProfile_AccessRights1041(t *testing.T) {
+	cfg := mdm.Config{
+		EnrollmentBaseURL: "https://coordinator.streamvc.live",
+	}
+	profile := mdm.GenerateEnrollmentProfile("SERIALTEST3", cfg)
+
+	// AccessRights must be exactly 1041 (bits 0 + 4 + 10).
+	if !strings.Contains(profile, "<integer>1041</integer>") {
+		t.Error("profile AccessRights is not 1041")
+	}
+}
+
+func TestGenerateEnrollmentProfile_MacproviderNamespace(t *testing.T) {
+	cfg := mdm.Config{
+		EnrollmentBaseURL: "https://coordinator.streamvc.live",
+	}
+	profile := mdm.GenerateEnrollmentProfile("SERIALTEST4", cfg)
+
+	// Identifiers must use the macprovider namespace, not Darkbloom.
+	if strings.Contains(profile, "darkbloom") || strings.Contains(profile, "Darkbloom") {
+		t.Error("profile contains Darkbloom branding — must use macprovider namespace")
+	}
+	if !strings.Contains(profile, "live.streamvc.macprovider.enroll") {
+		t.Error("profile missing live.streamvc.macprovider.enroll namespace")
+	}
+}
+
+func TestGenerateEnrollmentProfile_CheckInURL(t *testing.T) {
+	cfg := mdm.Config{
+		EnrollmentBaseURL: "https://coordinator.streamvc.live",
+	}
+	profile := mdm.GenerateEnrollmentProfile("SERIALTEST5", cfg)
+
+	if !strings.Contains(profile, "https://coordinator.streamvc.live/mdm/checkin") {
+		t.Error("profile missing CheckInURL")
+	}
+}
+
+func TestGenerateEnrollmentProfile_IdentityCertUUIDMatchesSCEPPayloadUUID(t *testing.T) {
+	cfg := mdm.Config{
+		EnrollmentBaseURL: "https://coordinator.streamvc.live",
+	}
+	profile := mdm.GenerateEnrollmentProfile("SERIALTEST6", cfg)
+
+	// The stable SCEP PayloadUUID must appear at least twice: once as the SCEP
+	// payload's own PayloadUUID and once as the MDM IdentityCertificateUUID.
+	const scepUUID = "B3F7E8A1-2C9D-4F5E-8A6B-1E2D3C4B5A00"
+	count := strings.Count(profile, scepUUID)
+	if count < 2 {
+		t.Errorf("SCEP UUID %q appears %d time(s) in profile; expected >= 2 (PayloadUUID + IdentityCertificateUUID)", scepUUID, count)
+	}
+}
+
+func TestGenerateEnrollmentProfile_PushTopic(t *testing.T) {
+	const topic = "com.apple.mgmt.External.99999-test"
+	cfg := mdm.Config{
+		EnrollmentBaseURL: "https://coordinator.streamvc.live",
+		PushTopic:         topic,
+	}
+	profile := mdm.GenerateEnrollmentProfile("SERIALTEST7", cfg)
+
+	if !strings.Contains(profile, topic) {
+		t.Errorf("profile does not contain configured push topic %q", topic)
+	}
+}

--- a/phase4-coordinator/internal/onboarding/enroll_handler.go
+++ b/phase4-coordinator/internal/onboarding/enroll_handler.go
@@ -1,0 +1,190 @@
+package onboarding
+
+import (
+	"crypto"
+	"crypto/ecdsa"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/json"
+	"encoding/pem"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"regexp"
+
+	"github.com/augstar/macprovider-coordinator/internal/mdm"
+	"github.com/rs/zerolog"
+)
+
+// serialNumberRegexp matches valid device serial numbers: 8-14 alphanumeric
+// characters (case-insensitive). Apple serials are typically 12 chars but
+// range from 8-14 in practice.
+var serialNumberRegexp = regexp.MustCompile(`^[A-Za-z0-9]{8,14}$`)
+
+// maxEnrollBodyBytes caps the JSON body for POST /v1/enroll.
+const maxEnrollBodyBytes = 4 * 1024
+
+// ProfileSigner optionally CMS-signs a generated .mobileconfig before it is
+// served to the client. Signing is install-time trust only — it does not
+// affect the SCEP/MDM chain inside the profile. When the signer is nil or
+// returns an error the handler serves the unsigned profile with a loud log.
+type ProfileSigner interface {
+	Sign(profile []byte) ([]byte, error)
+}
+
+// EnrollHandler handles POST /v1/enroll and returns per-device
+// .mobileconfig files for MDM enrollment (Phase 2 Track P2-A, Scenario B).
+//
+// No authentication is required: the serial number is not secret. Trust is
+// established via MDM SecurityInfo verification after enrollment completes,
+// not from possession of the profile.
+type EnrollHandler struct {
+	// MDMConfig carries the profile generation parameters (base URL, SCEP URL,
+	// MDM connect URL, push topic). Populated from config.Tier2MDMConfig.
+	MDMConfig mdm.Config
+
+	// Signer optionally CMS-signs the profile. When nil the profile is served
+	// unsigned. Build via NewFileProfileSigner from config signer paths.
+	Signer ProfileSigner
+
+	// Logger is required; use zerolog.Nop() for tests.
+	Logger zerolog.Logger
+}
+
+// HandleEnroll is the HTTP handler for POST /v1/enroll.
+func (h *EnrollHandler) HandleEnroll(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		w.Header().Set("Allow", http.MethodPost)
+		writeJSONError(w, http.StatusMethodNotAllowed, "method_not_allowed", "method not allowed")
+		return
+	}
+
+	lr := io.LimitReader(r.Body, maxEnrollBodyBytes+1)
+	body, err := io.ReadAll(lr)
+	if err != nil {
+		writeJSONError(w, http.StatusBadRequest, "bad_request", "failed to read request body")
+		return
+	}
+	if int64(len(body)) > maxEnrollBodyBytes {
+		writeJSONError(w, http.StatusRequestEntityTooLarge, "request_too_large", "body exceeds 4 KiB")
+		return
+	}
+
+	var req struct {
+		SerialNumber string `json:"serial_number"`
+	}
+	if err := json.Unmarshal(body, &req); err != nil {
+		writeJSONError(w, http.StatusBadRequest, "bad_request", "invalid json body")
+		return
+	}
+
+	if req.SerialNumber == "" {
+		writeJSONError(w, http.StatusBadRequest, "invalid_request_error", "serial_number is required")
+		return
+	}
+	if !serialNumberRegexp.MatchString(req.SerialNumber) {
+		writeJSONError(w, http.StatusBadRequest, "invalid_request_error", "invalid serial number format")
+		return
+	}
+
+	h.Logger.Info().
+		Str("serial_number", req.SerialNumber).
+		Msg("generating MDM enrollment profile")
+
+	profileBody := []byte(mdm.GenerateEnrollmentProfile(req.SerialNumber, h.MDMConfig))
+
+	// Optionally CMS-sign the profile. When signing is not configured or
+	// fails, serve unsigned — enrollment is never blocked by signing.
+	// Failure is logged loudly so operators are alerted.
+	if h.Signer != nil {
+		signed, err := h.Signer.Sign(profileBody)
+		if err != nil {
+			h.Logger.Error().
+				Str("serial_number", req.SerialNumber).
+				Err(err).
+				Msg("profile CMS signing failed — serving unsigned profile")
+		} else {
+			profileBody = signed
+		}
+	}
+
+	w.Header().Set("Content-Type", "application/x-apple-aspen-config")
+	w.Header().Set("Content-Disposition",
+		fmt.Sprintf(`attachment; filename="macprovider-enroll-%s.mobileconfig"`, req.SerialNumber))
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write(profileBody)
+}
+
+// NewFileProfileSigner loads a PEM cert + key from disk and returns a
+// ProfileSigner that CMS-signs profiles using that identity. Supports RSA and
+// ECDSA private keys.
+//
+// Returns an error if either path is empty or the files cannot be loaded.
+// Callers should set EnrollHandler.Signer to nil when signer paths are not
+// configured.
+func NewFileProfileSigner(certPath, keyPath string) (ProfileSigner, error) {
+	if certPath == "" || keyPath == "" {
+		return nil, fmt.Errorf("mdm profile signer: cert_path and key_path must both be set")
+	}
+	certPEM, err := os.ReadFile(certPath)
+	if err != nil {
+		return nil, fmt.Errorf("mdm profile signer: read cert: %w", err)
+	}
+	keyPEM, err := os.ReadFile(keyPath)
+	if err != nil {
+		return nil, fmt.Errorf("mdm profile signer: read key: %w", err)
+	}
+	block, _ := pem.Decode(certPEM)
+	if block == nil || block.Type != "CERTIFICATE" {
+		return nil, fmt.Errorf("mdm profile signer: cert file does not contain a PEM CERTIFICATE block")
+	}
+	cert, err := x509.ParseCertificate(block.Bytes)
+	if err != nil {
+		return nil, fmt.Errorf("mdm profile signer: parse cert: %w", err)
+	}
+	keyBlock, _ := pem.Decode(keyPEM)
+	if keyBlock == nil {
+		return nil, fmt.Errorf("mdm profile signer: key file does not contain a PEM block")
+	}
+	var signer crypto.Signer
+	switch keyBlock.Type {
+	case "RSA PRIVATE KEY":
+		rsaKey, err := x509.ParsePKCS1PrivateKey(keyBlock.Bytes)
+		if err != nil {
+			return nil, fmt.Errorf("mdm profile signer: parse RSA key: %w", err)
+		}
+		signer = rsaKey
+	case "EC PRIVATE KEY":
+		ecKey, err := x509.ParseECPrivateKey(keyBlock.Bytes)
+		if err != nil {
+			return nil, fmt.Errorf("mdm profile signer: parse EC key: %w", err)
+		}
+		signer = ecKey
+	case "PRIVATE KEY":
+		key, err := x509.ParsePKCS8PrivateKey(keyBlock.Bytes)
+		if err != nil {
+			return nil, fmt.Errorf("mdm profile signer: parse PKCS8 key: %w", err)
+		}
+		switch k := key.(type) {
+		case *rsa.PrivateKey:
+			signer = k
+		case *ecdsa.PrivateKey:
+			signer = k
+		default:
+			return nil, fmt.Errorf("mdm profile signer: unsupported PKCS8 key type %T", key)
+		}
+	default:
+		return nil, fmt.Errorf("mdm profile signer: unsupported PEM key type %q", keyBlock.Type)
+	}
+	return &fileProfileSigner{cert: cert, key: signer}, nil
+}
+
+type fileProfileSigner struct {
+	cert *x509.Certificate
+	key  crypto.Signer
+}
+
+func (s *fileProfileSigner) Sign(profile []byte) ([]byte, error) {
+	return signMobileconfig(profile, s.cert, s.key)
+}

--- a/phase4-coordinator/internal/onboarding/enroll_handler.go
+++ b/phase4-coordinator/internal/onboarding/enroll_handler.go
@@ -186,5 +186,5 @@ type fileProfileSigner struct {
 }
 
 func (s *fileProfileSigner) Sign(profile []byte) ([]byte, error) {
-	return signMobileconfig(profile, s.cert, s.key)
+	return mdm.SignMobileconfig(profile, s.cert, s.key)
 }

--- a/phase4-coordinator/internal/onboarding/enroll_handler_test.go
+++ b/phase4-coordinator/internal/onboarding/enroll_handler_test.go
@@ -1,0 +1,148 @@
+package onboarding_test
+
+import (
+	"bytes"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/augstar/macprovider-coordinator/internal/mdm"
+	"github.com/augstar/macprovider-coordinator/internal/onboarding"
+	"github.com/rs/zerolog"
+)
+
+func newTestEnrollHandler() *onboarding.EnrollHandler {
+	return &onboarding.EnrollHandler{
+		MDMConfig: mdm.Config{
+			EnrollmentBaseURL: "https://coordinator.streamvc.live",
+			PushTopic:         "com.apple.mgmt.External.test",
+		},
+		Logger: zerolog.Nop(),
+	}
+}
+
+func TestHandleEnroll_ValidSerial(t *testing.T) {
+	h := newTestEnrollHandler()
+	body := bytes.NewBufferString(`{"serial_number":"C02XYZ1234AB"}`)
+	req := httptest.NewRequest(http.MethodPost, "/v1/enroll", body)
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	h.HandleEnroll(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	ct := w.Header().Get("Content-Type")
+	if ct != "application/x-apple-aspen-config" {
+		t.Errorf("expected Content-Type application/x-apple-aspen-config, got %q", ct)
+	}
+	if !strings.Contains(w.Body.String(), "com.apple.security.scep") {
+		t.Error("response body missing SCEP payload")
+	}
+	if !strings.Contains(w.Body.String(), "com.apple.mdm") {
+		t.Error("response body missing MDM payload")
+	}
+	if !strings.Contains(w.Body.String(), "C02XYZ1234AB") {
+		t.Error("response body missing serial number")
+	}
+}
+
+func TestHandleEnroll_ContentDispositionHeader(t *testing.T) {
+	h := newTestEnrollHandler()
+	body := bytes.NewBufferString(`{"serial_number":"C02XYZ1234AB"}`)
+	req := httptest.NewRequest(http.MethodPost, "/v1/enroll", body)
+	w := httptest.NewRecorder()
+
+	h.HandleEnroll(w, req)
+
+	cd := w.Header().Get("Content-Disposition")
+	if !strings.Contains(cd, "macprovider-enroll-C02XYZ1234AB.mobileconfig") {
+		t.Errorf("unexpected Content-Disposition: %q", cd)
+	}
+}
+
+func TestHandleEnroll_MissingSerial(t *testing.T) {
+	h := newTestEnrollHandler()
+	body := bytes.NewBufferString(`{}`)
+	req := httptest.NewRequest(http.MethodPost, "/v1/enroll", body)
+	w := httptest.NewRecorder()
+
+	h.HandleEnroll(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d", w.Code)
+	}
+}
+
+func TestHandleEnroll_InvalidSerialFormat(t *testing.T) {
+	cases := []string{
+		"short",          // too short (< 8 chars)
+		"C02XYZ1234ABCDE", // too long (> 14 chars)
+		"C02-XYZ-1234",  // contains non-alphanumeric
+		"",
+	}
+	h := newTestEnrollHandler()
+	for _, serial := range cases {
+		body := bytes.NewBufferString(`{"serial_number":"` + serial + `"}`)
+		req := httptest.NewRequest(http.MethodPost, "/v1/enroll", body)
+		w := httptest.NewRecorder()
+		h.HandleEnroll(w, req)
+		if w.Code != http.StatusBadRequest {
+			t.Errorf("serial %q: expected 400, got %d", serial, w.Code)
+		}
+	}
+}
+
+func TestHandleEnroll_WrongMethod(t *testing.T) {
+	h := newTestEnrollHandler()
+	req := httptest.NewRequest(http.MethodGet, "/v1/enroll", nil)
+	w := httptest.NewRecorder()
+
+	h.HandleEnroll(w, req)
+
+	if w.Code != http.StatusMethodNotAllowed {
+		t.Errorf("expected 405, got %d", w.Code)
+	}
+}
+
+func TestHandleEnroll_InvalidJSON(t *testing.T) {
+	h := newTestEnrollHandler()
+	body := bytes.NewBufferString(`not json`)
+	req := httptest.NewRequest(http.MethodPost, "/v1/enroll", body)
+	w := httptest.NewRecorder()
+
+	h.HandleEnroll(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d", w.Code)
+	}
+}
+
+func TestHandleEnroll_ServerURLFromConfig(t *testing.T) {
+	h := &onboarding.EnrollHandler{
+		MDMConfig: mdm.Config{
+			EnrollmentBaseURL: "https://coordinator.streamvc.live",
+			MDMServerURL:      "https://mdm.streamvc.live/mdm/connect",
+			SCEPUrl:           "https://mdm.streamvc.live/scep",
+		},
+		Logger: zerolog.Nop(),
+	}
+	body := bytes.NewBufferString(`{"serial_number":"SERIALTEST1"}`)
+	req := httptest.NewRequest(http.MethodPost, "/v1/enroll", body)
+	w := httptest.NewRecorder()
+
+	h.HandleEnroll(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+	resp := w.Body.String()
+	if !strings.Contains(resp, "https://mdm.streamvc.live/mdm/connect") {
+		t.Error("profile does not contain configured MDM ServerURL")
+	}
+	if !strings.Contains(resp, "https://mdm.streamvc.live/scep") {
+		t.Error("profile does not contain configured SCEP URL")
+	}
+}


### PR DESCRIPTION
## Summary

Provider-side MDM enrollment UX (Phase 2 Track P2-C) + coordinator P2-A enroll handler.

**phase3-binary CLI changes:**
- `MDMEnrollment.swift` — parse `profiles status -type enrollment` output; detect macprovider vs foreign MDM (accept coordinator host as additional MDM host); `coordinatorHTTPBase()` derives HTTPS base from `wss://` URL; `macHardwareSerialNumber()` via ioreg.
- `EnrollCommand.swift` — `macprovider-cli enroll` with two sub-subcommands:
  - `run` (default): reads serial, POSTs `{"serial_number"}` to `{coordinator_http_base}/v1/enroll`, saves `.mobileconfig` to `$TMPDIR`, opens System Settings Profiles pane; idempotent if already enrolled.
  - `status`: prints current MDM enrollment state.
- `MacProviderCLI.swift`: wire `EnrollCommand` into top-level subcommand list.
- `MDMEnrollmentTests.swift`: 21 unit tests (profile parsing, URL derivation, runner paths).

**phase4-coordinator changes (P2-A):**
- `internal/mdm/{enroll.go,cms.go}` — SCEP + MDM `.mobileconfig` generator.
- `internal/onboarding/enroll_handler.go` — `POST /v1/enroll` HTTP handler.
- `internal/config/config.go` — MDM config keys.

**Docs:** Phase 2 runbook section, exit-criteria checklist.

## Test plan

- [x] `swift test --filter MDMEnrollment` → 21 passed, 0 failed
- [ ] Manual smoke: `macprovider-cli enroll status` on unenrolled Mac
- [ ] Manual smoke: `macprovider-cli enroll run --no-open` against staging coordinator

Made with [Cursor](https://cursor.com)