### PR TITLE
fix(provider): accept coordinator-advertised catalog model id as serve alias

### DIFF
--- a/phase3-binary/Sources/MacProviderCore/ChatCompletionRequest.swift
+++ b/phase3-binary/Sources/MacProviderCore/ChatCompletionRequest.swift
@@ -180,13 +180,17 @@ public struct ChatCompletionRequest: Sendable {
         self.conversationKey = conversationKey
     }
 
-    public func validateModelMatches(_ loadedModel: String?) throws {
+    public func validateModelMatches(_ loadedModel: String?, aliases: [String] = []) throws {
         guard let loadedModel else {
             throw APIError(status: 503, message: "Model not loaded", type: "server_error", code: "model_not_loaded")
         }
-        guard Self.asciiCaseInsensitiveEquals(model, loadedModel) else {
-            throw APIError(status: 404, message: "Model not found", code: "model_not_found")
+        if Self.asciiCaseInsensitiveEquals(model, loadedModel) {
+            return
         }
+        for alias in aliases where !alias.isEmpty && Self.asciiCaseInsensitiveEquals(model, alias) {
+            return
+        }
+        throw APIError(status: 404, message: "Model not found", code: "model_not_found")
     }
 
     public var allowsSpeculativeDecoding: Bool {

--- a/phase3-binary/Sources/macprovider-cli/CoordinatorClient.swift
+++ b/phase3-binary/Sources/macprovider-cli/CoordinatorClient.swift
@@ -846,6 +846,7 @@ actor CoordinatorClient {
             modelRuntime: modelRuntime,
             providerStatus: providerStatus,
             loadedModelID: loadedModelID,
+            catalogModelIDAlias: catalogModelIDForCoordinator,
             warmSwapEnabled: warmSwapEnabled,
             maxActiveRequests: maxActiveRequests,
             maxBodyBytes: maxBodyBytes,

--- a/phase3-binary/Sources/macprovider-cli/HTTPServer.swift
+++ b/phase3-binary/Sources/macprovider-cli/HTTPServer.swift
@@ -9,19 +9,22 @@ struct HTTPServer: Sendable {
     let providerStatus: ProviderStatus
     let receiptBuilder: ReceiptBuilder?
     let idlePrewarmer: IdlePrewarmer?
+    let catalogModelIDAlias: String?
 
     init(
         config: AppConfig,
         modelRuntime: ModelRuntime,
         providerStatus: ProviderStatus,
         receiptBuilder: ReceiptBuilder?,
-        idlePrewarmer: IdlePrewarmer? = nil
+        idlePrewarmer: IdlePrewarmer? = nil,
+        catalogModelIDAlias: String? = nil
     ) {
         self.config = config
         self.modelRuntime = modelRuntime
         self.providerStatus = providerStatus
         self.receiptBuilder = receiptBuilder
         self.idlePrewarmer = idlePrewarmer
+        self.catalogModelIDAlias = catalogModelIDAlias
     }
 
     func run() throws {
@@ -45,7 +48,8 @@ struct HTTPServer: Sendable {
                             warmSwapEnabled: config.enableWarmSwap,
                             maxBodyBytes: config.maxRequestBodyBytes,
                             receiptBuilder: receiptBuilder,
-                            idlePrewarmer: idlePrewarmer
+                            idlePrewarmer: idlePrewarmer,
+                            catalogModelIDAlias: catalogModelIDAlias
                         )
                     )
                 }
@@ -71,6 +75,7 @@ final class RouterHandler: ChannelInboundHandler, @unchecked Sendable {
     private let maxBodyBytes: Int
     private let receiptBuilder: ReceiptBuilder?
     private let idlePrewarmer: IdlePrewarmer?
+    private let catalogModelIDAlias: String?
     private var requestHead: HTTPRequestHead?
     private var bodyBuffer: ByteBuffer?
     private var bodyTooLarge = false
@@ -84,7 +89,8 @@ final class RouterHandler: ChannelInboundHandler, @unchecked Sendable {
         warmSwapEnabled: Bool,
         maxBodyBytes: Int,
         receiptBuilder: ReceiptBuilder? = nil,
-        idlePrewarmer: IdlePrewarmer? = nil
+        idlePrewarmer: IdlePrewarmer? = nil,
+        catalogModelIDAlias: String? = nil
     ) {
         self.modelID = modelID
         self.providerID = providerID
@@ -95,6 +101,7 @@ final class RouterHandler: ChannelInboundHandler, @unchecked Sendable {
         self.maxBodyBytes = maxBodyBytes
         self.receiptBuilder = receiptBuilder
         self.idlePrewarmer = idlePrewarmer
+        self.catalogModelIDAlias = catalogModelIDAlias
     }
 
     func channelRead(context: ChannelHandlerContext, data: NIOAny) {
@@ -264,7 +271,7 @@ final class RouterHandler: ChannelInboundHandler, @unchecked Sendable {
                 .withConversationKey(requestHead?.headers.first(name: "X-MacProvider-Provider-Conversation"))
             parsedRequest = request
             if !warmSwapEnabled {
-                try request.validateModelMatches(modelID)
+                try request.validateModelMatches(modelID, aliases: modelIDAliasList(catalogModelIDAlias))
             }
 
             if request.stream {

--- a/phase3-binary/Sources/macprovider-cli/InferenceRelay.swift
+++ b/phase3-binary/Sources/macprovider-cli/InferenceRelay.swift
@@ -1,6 +1,17 @@
 import Foundation
 import MacProviderCore
 
+/// Normalizes an optional catalog-alias string into the `aliases:` array shape
+/// expected by `ChatCompletionRequest.validateModelMatches`. Trims whitespace
+/// and newlines to match the normalization applied to
+/// `catalogModelIDForCoordinator` in CoordinatorClient (see lines 324-327);
+/// returns `[]` for nil/empty so the default no-alias behavior is preserved.
+func modelIDAliasList(_ value: String?) -> [String] {
+    guard let value else { return [] }
+    let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+    return trimmed.isEmpty ? [] : [trimmed]
+}
+
 actor InferenceRelay {
     typealias SendFrame = @Sendable (sending [String: Any]) async throws -> Void
     typealias TrustDemotion = @Sendable (_ reason: String) async -> Void
@@ -13,6 +24,7 @@ actor InferenceRelay {
     private let modelRuntime: any ModelRuntimeServing
     private let providerStatus: ProviderStatus
     private let loadedModelID: String?
+    private let catalogModelIDAlias: String?
     private let warmSwapEnabled: Bool
     private let maxActiveRequests: Int
     private let maxBodyBytes: Int
@@ -30,6 +42,7 @@ actor InferenceRelay {
         modelRuntime: any ModelRuntimeServing,
         providerStatus: ProviderStatus,
         loadedModelID: String?,
+        catalogModelIDAlias: String? = nil,
         warmSwapEnabled: Bool = false,
         maxActiveRequests: Int,
         maxBodyBytes: Int,
@@ -43,6 +56,7 @@ actor InferenceRelay {
         self.modelRuntime = modelRuntime
         self.providerStatus = providerStatus
         self.loadedModelID = loadedModelID
+        self.catalogModelIDAlias = catalogModelIDAlias
         self.warmSwapEnabled = warmSwapEnabled
         self.maxActiveRequests = max(1, maxActiveRequests)
         self.maxBodyBytes = max(1, maxBodyBytes)
@@ -138,7 +152,7 @@ actor InferenceRelay {
         let state = RelayRequestState()
         let receiptBuilder = receiptBuilder
         let receiptProviderID = receiptProviderID
-        let task = Task { [weak self, modelRuntime, providerStatus, loadedModelID, warmSwapEnabled, sendFrame, tier2Session, state, settlementMetadata, streamInterval] in
+        let task = Task { [weak self, modelRuntime, providerStatus, loadedModelID, catalogModelIDAlias, warmSwapEnabled, sendFrame, tier2Session, state, settlementMetadata, streamInterval] in
             await Self.process(
                 requestID: requestID,
                 body: body,
@@ -147,6 +161,7 @@ actor InferenceRelay {
                 modelRuntime: modelRuntime,
                 providerStatus: providerStatus,
                 loadedModelID: loadedModelID,
+                catalogModelIDAlias: catalogModelIDAlias,
                 warmSwapEnabled: warmSwapEnabled,
                 tier2Session: tier2Session,
                 receiptBuilder: receiptBuilder,
@@ -230,6 +245,7 @@ actor InferenceRelay {
         modelRuntime: any ModelRuntimeServing,
         providerStatus: ProviderStatus,
         loadedModelID: String?,
+        catalogModelIDAlias: String?,
         warmSwapEnabled: Bool,
         tier2Session: Tier2ProviderSession?,
         receiptBuilder: ReceiptBuilder?,
@@ -251,7 +267,16 @@ actor InferenceRelay {
             let validationModelID = warmSwapEnabled
                 ? await modelRuntime.currentSnapshot().modelID
                 : loadedModelID
-            try request.validateModelMatches(validationModelID)
+            // Accept the coordinator-advertised catalog id as an alias only while
+            // the configured model is the one currently served — the exact predicate
+            // coordinatorWireModelID uses to decide whether to advertise it
+            // (servedModelID == loadedModelID). This holds even when warm-swap is
+            // enabled but the configured model is still loaded; after a swap to a
+            // different model the alias no longer applies.
+            let relayAliases = (validationModelID != nil && validationModelID == loadedModelID)
+                ? modelIDAliasList(catalogModelIDAlias)
+                : []
+            try request.validateModelMatches(validationModelID, aliases: relayAliases)
         if stream {
             let trace = EgressPerfTrace()
             completionResult = try await EgressPerfTraceKey.$current.withValue(trace) {

--- a/phase3-binary/Sources/macprovider-cli/MacProviderCLI.swift
+++ b/phase3-binary/Sources/macprovider-cli/MacProviderCLI.swift
@@ -487,6 +487,16 @@ struct ServeCommand: AsyncParsableCommand {
         // not set an explicit override. Explicit config/env/CLI always wins.
         let effectiveKVBits = resolved.kvBitsOverride
             ?? KVQuantRecommendation.recommendedKVBits(for: resolved.model ?? "")
+        // The coordinator advertises config.modelCatalogModelID as this
+        // provider's model_id while inference is served locally under
+        // config.model. Accept the advertised catalog id as a serve alias so
+        // relayed buyer requests carrying it are not 404'd. Trimmed here to
+        // match CoordinatorClient's catalogModelIDForCoordinator normalization;
+        // nil/empty → no alias.
+        let catalogModelIDAlias: String? = resolved.modelCatalogModelID.flatMap { value in
+            let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+            return trimmed.isEmpty ? nil : trimmed
+        }
         let modelRuntime = try await ModelRuntime(
             modelID: resolved.model,
             modelLoadPath: resolved.modelArtifactPath,
@@ -498,7 +508,8 @@ struct ServeCommand: AsyncParsableCommand {
             prefillStepSize: resolved.prefillStepSize,
             maxBatch: resolved.maxConcurrencyOverride ?? 1,
             warmSwapEnabled: resolved.enableWarmSwap,
-            swapDrainTimeoutSeconds: resolved.swapDrainTimeoutSeconds
+            swapDrainTimeoutSeconds: resolved.swapDrainTimeoutSeconds,
+            catalogModelIDAlias: catalogModelIDAlias
         )
         // The serve runtime defaults `--max-batch` to 1 (the prior
         // single-slot behavior). Operators opting in via --max-batch >1
@@ -626,7 +637,8 @@ struct ServeCommand: AsyncParsableCommand {
             modelRuntime: modelRuntime,
             providerStatus: providerStatus,
             receiptBuilder: receiptRuntime.builder,
-            idlePrewarmer: idlePrewarmer
+            idlePrewarmer: idlePrewarmer,
+            catalogModelIDAlias: catalogModelIDAlias
         )
         let terminationHandlers = installTerminationHandlers(coordinatorClient: coordinatorClient, controlSocket: controlSocket, idlePrewarmer: idlePrewarmer)
         defer {

--- a/phase3-binary/Sources/macprovider-cli/ModelRuntime.swift
+++ b/phase3-binary/Sources/macprovider-cli/ModelRuntime.swift
@@ -320,6 +320,14 @@ actor ModelRuntime: ModelRuntimeServing {
     private var state: SwapState = .ready
     private var targetModelID: String?
     private var currentModelID: String?
+    // The model id this runtime was configured to serve (constant across
+    // warm-swaps). Used to gate the catalog-id alias so the alias only applies
+    // while the configured model is the one currently loaded.
+    private let modelID: String?
+    // Coordinator-advertised catalog id (e.g. mlx-community/…) accepted as an
+    // alias for the configured served model. nil when unset. See BUILD_SPEC
+    // relay_serve_model_id_alias.
+    private let catalogModelIDAlias: String?
     private var currentContainer: ModelContainer?
     private var currentDraftModelID: String?
     private var currentDraftTargetModelID: String?
@@ -392,10 +400,13 @@ actor ModelRuntime: ModelRuntimeServing {
         prefillStepSize: Int = 512,
         maxBatch: Int = 1,
         warmSwapEnabled: Bool = false,
-        swapDrainTimeoutSeconds: Int = 30
+        swapDrainTimeoutSeconds: Int = 30,
+        catalogModelIDAlias: String? = nil
     ) async throws {
         let normalizedDraftModelID = Self.nonEmpty(draftModelID)
         let normalizedDraftModelLoadPath = Self.nonEmpty(draftModelLoadPath)
+        self.modelID = modelID
+        self.catalogModelIDAlias = catalogModelIDAlias
         self.currentModelID = modelID
         self.currentDraftModelID = nil
         self.currentDraftTargetModelID = nil
@@ -485,6 +496,7 @@ actor ModelRuntime: ModelRuntimeServing {
         warmSwapEnabled: Bool,
         swapDrainTimeoutSeconds: Int = 30,
         providerStatus: ProviderStatus? = nil,
+        catalogModelIDAlias: String? = nil,
         loader: @escaping @Sendable (String) async throws -> (ModelContainer, String, String?),
         testLoader: (@Sendable (String) async throws -> (String, String?))? = nil,
         testCompletion: (@Sendable (RuntimeSnapshot, ChatCompletionRequest) async throws -> CompletionResult)? = nil,
@@ -492,6 +504,8 @@ actor ModelRuntime: ModelRuntimeServing {
         testSpeculativeStream: (@Sendable (RuntimeSnapshot, ChatCompletionRequest) async throws -> CompletionResult)? = nil
     ) {
         let normalizedDraftModelID = Self.nonEmpty(draftModelID)
+        self.modelID = modelID
+        self.catalogModelIDAlias = catalogModelIDAlias
         self.currentModelID = modelID
         self.currentContainer = nil
         self.currentDraftModelID = normalizedDraftModelID
@@ -884,7 +898,14 @@ actor ModelRuntime: ModelRuntimeServing {
     func acquireRequestHandle(_ request: ChatCompletionRequest) throws -> RequestHandle {
         let snapshot = requestStartSnapshot()
         try Self.validateReady(snapshot.state)
-        try request.validateModelMatches(snapshot.modelID)
+        // Accept the coordinator-advertised catalog id as an alias only while the
+        // configured model is the one currently loaded (mirrors
+        // coordinatorWireModelID's servedModelID == loadedModelID guard). After a
+        // warm-swap to a different model the alias must not apply.
+        let aliases = (snapshot.modelID != nil && snapshot.modelID == self.modelID)
+            ? modelIDAliasList(catalogModelIDAlias)
+            : []
+        try request.validateModelMatches(snapshot.modelID, aliases: aliases)
         try Self.validateToolChoiceScope(request)
         let drainCancelled = DrainCancelToken()
         let registrationID = registerInFlight { drainCancelled.fire() }

--- a/phase3-binary/Tests/macprovider-cliTests/ChatCompletionRequestTests.swift
+++ b/phase3-binary/Tests/macprovider-cliTests/ChatCompletionRequestTests.swift
@@ -18,6 +18,67 @@ final class ChatCompletionRequestTests: XCTestCase {
         }
     }
 
+    // Default aliases: [] preserves prior behavior — a non-matching model still 404s.
+    func testDefaultEmptyAliasesStillReturnsNotFound() throws {
+        let request = try makeRequest(model: "mlx-community/Other-Model")
+
+        XCTAssertThrowsError(try request.validateModelMatches("qwen3-coder-30b-a3b-instruct", aliases: [])) { error in
+            let apiError = error as? APIError
+            XCTAssertEqual(apiError?.status, 404)
+            XCTAssertEqual(apiError?.code, "model_not_found")
+        }
+    }
+
+    // Request model equals the loaded id → passes even with aliases present.
+    func testLoadedIDMatchWithAliasesPresent() throws {
+        let request = try makeRequest(model: "qwen3-coder-30b-a3b-instruct")
+
+        XCTAssertNoThrow(try request.validateModelMatches(
+            "qwen3-coder-30b-a3b-instruct",
+            aliases: ["mlx-community/Qwen3-Coder-30B-A3B-Instruct-4bit"]
+        ))
+    }
+
+    // Request model equals an alias entry (ascii case-insensitive) → passes.
+    func testAliasMatchIsAsciiCaseInsensitive() throws {
+        let request = try makeRequest(model: "MLX-COMMUNITY/qwen3-coder-30b-a3b-instruct-4bit")
+
+        XCTAssertNoThrow(try request.validateModelMatches(
+            "qwen3-coder-30b-a3b-instruct",
+            aliases: ["mlx-community/Qwen3-Coder-30B-A3B-Instruct-4bit"]
+        ))
+    }
+
+    // Request model matches neither the loaded id nor any alias → 404.
+    func testNeitherLoadedNorAliasReturnsNotFound() throws {
+        let request = try makeRequest(model: "some-other-model")
+
+        XCTAssertThrowsError(try request.validateModelMatches(
+            "qwen3-coder-30b-a3b-instruct",
+            aliases: ["mlx-community/Qwen3-Coder-30B-A3B-Instruct-4bit"]
+        )) { error in
+            let apiError = error as? APIError
+            XCTAssertEqual(apiError?.status, 404)
+            XCTAssertEqual(apiError?.code, "model_not_found")
+        }
+    }
+
+    // Empty-string alias entries must never match (no accidental match on "").
+    // The request model is non-empty (parse rejects ""), and an all-empty alias
+    // list must be treated as no alias at all → 404.
+    func testEmptyStringAliasEntryIsIgnored() throws {
+        let request = try makeRequest(model: "unrelated-model")
+
+        XCTAssertThrowsError(try request.validateModelMatches(
+            "qwen3-coder-30b-a3b-instruct",
+            aliases: [""]
+        )) { error in
+            let apiError = error as? APIError
+            XCTAssertEqual(apiError?.status, 404)
+            XCTAssertEqual(apiError?.code, "model_not_found")
+        }
+    }
+
     func testFractionalMaxTokensIsRejected() throws {
         let body: [String: Any] = [
             "model": "m",

--- a/phase3-binary/Tests/macprovider-cliTests/HTTPServerSwapTests.swift
+++ b/phase3-binary/Tests/macprovider-cliTests/HTTPServerSwapTests.swift
@@ -172,6 +172,72 @@ final class HTTPServerSwapTests: XCTestCase {
         }
     }
 
+    // ModelRuntime gate (BUILD_SPEC relay_serve_model_id_alias): the
+    // coordinator-advertised catalog id is accepted as an alias by
+    // acquireRequestHandle while the configured model is the one loaded.
+    func testCatalogAliasAcceptedByAcquireHandleWhenConfiguredLoaded() async throws {
+        let runtime = ModelRuntime(
+            modelID: "qwen3-coder-30b-a3b-instruct",
+            modelHash: "hash-a",
+            warmSwapEnabled: false,
+            catalogModelIDAlias: "mlx-community/Qwen3-Coder-30B-A3B-Instruct-4bit",
+            loader: { _ in throw HTTPServerSwapTestError.unexpectedContainerLoader },
+            testLoader: { target in (target, "hash-a") },
+            testCompletion: { _, _ in
+                CompletionResult(content: "ok", finishReason: "stop", promptTokens: 1, completionTokens: 1)
+            }
+        )
+        let request = try makeRequest(model: "mlx-community/Qwen3-Coder-30B-A3B-Instruct-4bit")
+        let handle = try await runtime.acquireRequestHandle(request)
+        await runtime.unregisterInFlight(handle.registrationID)
+    }
+
+    // The configured served id itself is still accepted (unchanged behavior).
+    func testConfiguredModelIDStillAcceptedWithAliasConfigured() async throws {
+        let runtime = ModelRuntime(
+            modelID: "qwen3-coder-30b-a3b-instruct",
+            modelHash: "hash-a",
+            warmSwapEnabled: false,
+            catalogModelIDAlias: "mlx-community/Qwen3-Coder-30B-A3B-Instruct-4bit",
+            loader: { _ in throw HTTPServerSwapTestError.unexpectedContainerLoader },
+            testLoader: { target in (target, "hash-a") },
+            testCompletion: { _, _ in
+                CompletionResult(content: "ok", finishReason: "stop", promptTokens: 1, completionTokens: 1)
+            }
+        )
+        let request = try makeRequest(model: "qwen3-coder-30b-a3b-instruct")
+        let handle = try await runtime.acquireRequestHandle(request)
+        await runtime.unregisterInFlight(handle.registrationID)
+    }
+
+    // After a warm-swap loads a DIFFERENT model, the alias must NOT apply: the
+    // configured model is no longer the one loaded, so the catalog-id request is
+    // rejected 404 (mirrors coordinatorWireModelID's servedModelID == loadedModelID
+    // guard).
+    func testCatalogAliasRejectedByAcquireHandleAfterWarmSwap() async throws {
+        let runtime = ModelRuntime(
+            modelID: "qwen3-coder-30b-a3b-instruct",
+            modelHash: "hash-a",
+            warmSwapEnabled: true,
+            catalogModelIDAlias: "mlx-community/Qwen3-Coder-30B-A3B-Instruct-4bit",
+            loader: { _ in throw HTTPServerSwapTestError.unexpectedContainerLoader },
+            testLoader: { target in (target, "hash-b") }
+        )
+
+        let swapTask = try await runtime.beginSwap(targetModelID: "some-other-model")
+        try await swapTask.value
+
+        let request = try makeRequest(model: "mlx-community/Qwen3-Coder-30B-A3B-Instruct-4bit")
+        do {
+            let handle = try await runtime.acquireRequestHandle(request)
+            await runtime.unregisterInFlight(handle.registrationID)
+            XCTFail("catalog alias must not apply after warm-swap to a different model")
+        } catch let error as APIError {
+            XCTAssertEqual(error.status, 404)
+            XCTAssertEqual(error.code, "model_not_found")
+        }
+    }
+
     private func makeRequest(model: String) throws -> ChatCompletionRequest {
         let body: [String: Any] = [
             "model": model,

--- a/phase3-binary/Tests/macprovider-cliTests/InferenceRelayTests.swift
+++ b/phase3-binary/Tests/macprovider-cliTests/InferenceRelayTests.swift
@@ -75,6 +75,147 @@ final class InferenceRelayTests: XCTestCase {
         XCTAssertTrue(telemetry.records.isEmpty)
     }
 
+    // Money-path regression (BUILD_SPEC relay_serve_model_id_alias): the
+    // coordinator advertises config.modelCatalogModelID as this provider's
+    // model_id and relays buyer requests carrying it. With the served model
+    // configured (warm-swap off), a WS-relayed request whose `model` is the
+    // catalog alias must be accepted and served, not 404'd.
+    func testCatalogAliasAcceptedWhenConfiguredModelLoaded() async throws {
+        let runtime = FakeStreamingRuntime()
+        let status = ProviderStatus(
+            modelID: "qwen3-coder-30b-a3b-instruct",
+            modelLoaded: true,
+            capacity: ProviderCapacity(maxContextOverride: nil, maxConcurrencyOverride: nil)
+        )
+        let recorder = FrameRecorder()
+        let relay = InferenceRelay(
+            modelRuntime: runtime,
+            providerStatus: status,
+            loadedModelID: "qwen3-coder-30b-a3b-instruct",
+            catalogModelIDAlias: "mlx-community/Qwen3-Coder-30B-A3B-Instruct-4bit",
+            warmSwapEnabled: false,
+            maxActiveRequests: 1,
+            maxBodyBytes: 4096,
+            sendFrame: { frame in
+                await recorder.append(frame)
+            }
+        )
+
+        let body = #"{"model":"mlx-community/Qwen3-Coder-30B-A3B-Instruct-4bit","messages":[{"role":"user","content":"hello"}],"max_tokens":20,"stream":false}"#
+        try await relay.handleInferenceRequest([
+            "type": "inference_request",
+            "request_id": "req-alias-accept",
+            "stream": false,
+            "body": body,
+        ])
+
+        let frames = try await waitForFrames { frames in
+            frames.contains { $0["type"] as? String == "inference_response_end" }
+        } from: {
+            await recorder.frames
+        }
+        let end = try XCTUnwrap(frames.last { $0["type"] as? String == "inference_response_end" })
+        XCTAssertEqual(
+            end["status"] as? String,
+            "complete",
+            "catalog alias must be accepted and served when the configured model is loaded"
+        )
+    }
+
+    // Contrast: with no alias configured, the same catalog-id request is a
+    // genuine model mismatch and must be rejected 404 (surfaced by the relay as
+    // an error_model_not_loaded terminal frame).
+    func testCatalogAliasRequestRejectedWhenNoAliasConfigured() async throws {
+        let runtime = FakeStreamingRuntime()
+        let status = ProviderStatus(
+            modelID: "qwen3-coder-30b-a3b-instruct",
+            modelLoaded: true,
+            capacity: ProviderCapacity(maxContextOverride: nil, maxConcurrencyOverride: nil)
+        )
+        let recorder = FrameRecorder()
+        let relay = InferenceRelay(
+            modelRuntime: runtime,
+            providerStatus: status,
+            loadedModelID: "qwen3-coder-30b-a3b-instruct",
+            catalogModelIDAlias: nil,
+            warmSwapEnabled: false,
+            maxActiveRequests: 1,
+            maxBodyBytes: 4096,
+            sendFrame: { frame in
+                await recorder.append(frame)
+            }
+        )
+
+        let body = #"{"model":"mlx-community/Qwen3-Coder-30B-A3B-Instruct-4bit","messages":[{"role":"user","content":"hello"}],"max_tokens":20,"stream":false}"#
+        try await relay.handleInferenceRequest([
+            "type": "inference_request",
+            "request_id": "req-alias-reject",
+            "stream": false,
+            "body": body,
+        ])
+
+        let frames = try await waitForFrames { frames in
+            frames.contains { $0["type"] as? String == "inference_response_end" }
+        } from: {
+            await recorder.frames
+        }
+        let end = try XCTUnwrap(frames.last { $0["type"] as? String == "inference_response_end" })
+        XCTAssertEqual(end["status"] as? String, "error_model_not_loaded")
+    }
+
+    // Money-path regression (audit HIGH — relay warm-swap gate): coordinatorWireModelID
+    // advertises the catalog id whenever the *configured* model is the served snapshot,
+    // even when warm-swap is enabled. So with warmSwapEnabled == true but the current
+    // snapshot still the configured model, a relayed request for the catalog alias must
+    // still be accepted (the relay gate keys on validationModelID == loadedModelID, not
+    // on warmSwapEnabled). Before the fix this 404'd.
+    func testCatalogAliasAcceptedUnderWarmSwapWhenConfiguredModelStillLoaded() async throws {
+        let runtime = FakeReceiptCompletionRuntime(servedSnapshot: RuntimeSnapshot(
+            state: .ready,
+            container: nil,
+            modelID: "qwen3-coder-30b-a3b-instruct",
+            modelHash: nil
+        ))
+        let status = ProviderStatus(
+            modelID: "qwen3-coder-30b-a3b-instruct",
+            modelLoaded: true,
+            capacity: ProviderCapacity(maxContextOverride: nil, maxConcurrencyOverride: nil)
+        )
+        let recorder = FrameRecorder()
+        let relay = InferenceRelay(
+            modelRuntime: runtime,
+            providerStatus: status,
+            loadedModelID: "qwen3-coder-30b-a3b-instruct",
+            catalogModelIDAlias: "mlx-community/Qwen3-Coder-30B-A3B-Instruct-4bit",
+            warmSwapEnabled: true,
+            maxActiveRequests: 1,
+            maxBodyBytes: 4096,
+            sendFrame: { frame in
+                await recorder.append(frame)
+            }
+        )
+
+        let body = #"{"model":"mlx-community/Qwen3-Coder-30B-A3B-Instruct-4bit","messages":[{"role":"user","content":"hello"}],"max_tokens":20,"stream":false}"#
+        try await relay.handleInferenceRequest([
+            "type": "inference_request",
+            "request_id": "req-alias-warmswap",
+            "stream": false,
+            "body": body,
+        ])
+
+        let frames = try await waitForFrames { frames in
+            frames.contains { $0["type"] as? String == "inference_response_end" }
+        } from: {
+            await recorder.frames
+        }
+        let end = try XCTUnwrap(frames.last { $0["type"] as? String == "inference_response_end" })
+        XCTAssertEqual(
+            end["status"] as? String,
+            "complete",
+            "catalog alias must be accepted under warm-swap when the configured model is still the served snapshot"
+        )
+    }
+
     func testUnknownCancelIsIdempotent() async throws {
         let runtime = try await ModelRuntime(modelID: nil)
         let status = ProviderStatus(

--- a/specs/BUILD_SPEC_relay_serve_model_id_alias.md
+++ b/specs/BUILD_SPEC_relay_serve_model_id_alias.md
@@ -1,0 +1,112 @@
+# BUILD_SPEC — Provider accepts its advertised catalog model id as a serve alias
+
+## Problem (root cause, verified against prod 2026-07-09)
+
+The provider serves inference locally under `loadedModelID = config.model` (the
+autotune rate-card key, e.g. `qwen3-coder-30b-a3b-instruct`). But when it is
+serving that configured model, `CoordinatorClient.coordinatorWireModelID(for:)`
+advertises `catalogModelIDForCoordinator = config.modelCatalogModelID`
+(e.g. `mlx-community/Qwen3-Coder-30B-A3B-Instruct-4bit`) to the coordinator as
+its `model_id`. The coordinator stores that verbatim as `provider.ModelID`,
+advertises it to buyers (`/v1/status`, `/v1/models`), and relays buyer requests
+carrying that catalog id to the provider.
+
+The provider's request validation (`ChatCompletionRequest.validateModelMatches`)
+only accepts a request whose `model` equals the single loaded/served id. So the
+provider **advertises `mlx-community/…` but 404s every request for
+`mlx-community/…`** → relay NAK → coordinator returns 503 `no_provider_available`
+"Selected provider is not reachable" → 100% of billed buyer completions fail,
+while the pool still shows the provider `ready` (heartbeat/warmup use the
+served id path).
+
+## Fix (provider-side, symmetric): accept the advertised id as an alias
+
+The provider must accept, as a valid request model, the id it advertised for the
+currently-served model. Concretely: when serving the configured `loadedModelID`,
+also accept `config.modelCatalogModelID` (the `catalogModelIDForCoordinator`
+value) as an alias. Do NOT change what is echoed in responses/receipts, do NOT
+rewrite the request model — only relax validation. Same underlying weights (same
+model hash), so proof-of-weights / settlement are unaffected.
+
+### 1. `phase3-binary/Sources/MacProviderCore/ChatCompletionRequest.swift`
+
+Change `validateModelMatches` to accept optional aliases (default empty →
+no behavior change for existing callers/tests):
+
+```swift
+public func validateModelMatches(_ loadedModel: String?, aliases: [String] = []) throws {
+    guard let loadedModel else {
+        throw APIError(status: 503, message: "Model not loaded", type: "server_error", code: "model_not_loaded")
+    }
+    if Self.asciiCaseInsensitiveEquals(model, loadedModel) {
+        return
+    }
+    for alias in aliases where !alias.isEmpty && Self.asciiCaseInsensitiveEquals(model, alias) {
+        return
+    }
+    throw APIError(status: 404, message: "Model not found", code: "model_not_found")
+}
+```
+
+### 2. Thread the alias `config.modelCatalogModelID` (trimmed; nil/empty → no alias)
+
+The alias is the coordinator-advertised catalog id. It must be accepted ONLY
+when the currently-served model is the configured `loadedModelID` (mirrors
+`coordinatorWireModelID`'s `servedModelID == loadedModelID` guard) so warm-swap
+to a different model does not wrongly accept it.
+
+Add a stored optional `catalogModelIDAlias: String?` to each of the three
+validation owners, injected from config; pass a gated `aliases:` array:
+
+- **`HTTPServer`** (`Sources/macprovider-cli/HTTPServer.swift`): add init param
+  `catalogModelIDAlias: String?`, store it. At the `validateModelMatches(modelID)`
+  call (only runs when `!warmSwapEnabled`, so served == configured `modelID`),
+  pass `aliases: aliasList(catalogModelIDAlias)`.
+- **`InferenceRelay`** (`Sources/macprovider-cli/InferenceRelay.swift`): add init
+  param `catalogModelIDAlias: String?`, store it, and thread it into the static
+  `process(...)`. At `validateModelMatches(validationModelID)`, pass
+  `aliases: warmSwapEnabled ? [] : aliasList(catalogModelIDAlias)`.
+- **`ModelRuntime`** (`Sources/macprovider-cli/ModelRuntime.swift`): add init
+  param `catalogModelIDAlias: String? = nil` (default nil so benchmark/canary/
+  decode-bench constructors are unchanged), store it. In
+  `acquireRequestHandle`, at `validateModelMatches(snapshot.modelID)`, pass
+  `aliases: (snapshot.modelID != nil && snapshot.modelID == self.modelID) ? aliasList(catalogModelIDAlias) : []`
+  (only when the configured model is the one loaded).
+
+Where `aliasList(_ s: String?) -> [String]` is a tiny helper returning
+`[trimmed]` when non-empty else `[]` (inline or a small private func; trim
+whitespace/newlines to match `catalogModelIDForCoordinator` normalization in
+CoordinatorClient.swift:324-327).
+
+### 3. Wiring (pass `config.modelCatalogModelID`, trimmed, at construction)
+
+- `Sources/macprovider-cli/MacProviderCLI.swift:~624` — `HTTPServer(...)`: add
+  `catalogModelIDAlias: <trimmed config.modelCatalogModelID>`.
+- `Sources/macprovider-cli/MacProviderCLI.swift:~490` — the serve-path
+  `ModelRuntime(...)`: add `catalogModelIDAlias: <trimmed config.modelCatalogModelID>`.
+  Do NOT set it for decode-bench / canary / non-serve ModelRuntime constructions
+  (leave default nil).
+- `Sources/macprovider-cli/CoordinatorClient.swift:~845` — `InferenceRelay(...)`:
+  add `catalogModelIDAlias: catalogModelIDForCoordinator` (already trimmed there).
+
+## Tests (add, do not weaken existing)
+
+In the ChatCompletionRequest test target:
+- `validateModelMatches` with `aliases: []` still 404s a non-matching model
+  (regression guard for default behavior).
+- request model == loaded id → passes (unchanged).
+- request model == an alias entry (case-insensitive) → passes.
+- request model matches neither loaded nor any alias → 404 `model_not_found`.
+- empty-string alias entries are ignored (no accidental match on "").
+
+Add/adjust InferenceRelay + HTTPServer tests to cover: a WS-relayed / HTTP
+request whose `model` is the catalog alias is accepted and served when the
+configured model is loaded; and is rejected when warm-swap has loaded a
+different model (alias must NOT apply).
+
+## Acceptance
+
+- `swift build` succeeds in `phase3-binary/`.
+- `swift test` passes (new + existing).
+- No change to response/receipt model echoing or to `coordinatorWireModelID`.
+- Default `aliases: []` keeps every non-serve caller behavior-identical.


### PR DESCRIPTION
## Summary

Fixes a live production outage: **100% of billed buyer completions have 503'd since ~2026-07-08 19:18 UTC** while `/v1/status` showed the sole provider `ready`.

**Root cause (verified against prod):** the provider advertises `config.modelCatalogModelID` (a catalog id like `mlx-community/Qwen3-Coder-30B-A3B-Instruct-4bit`) to the coordinator via `CoordinatorClient.coordinatorWireModelID`, but serves inference locally under `config.model` (the autotune rate-card key, e.g. `qwen3-coder-30b-a3b-instruct`). Its request validation (`ChatCompletionRequest.validateModelMatches`) only accepted the single served id — so the provider **404'd every request for the very id it advertised**. The coordinator relays the buyer's (catalog) id verbatim → provider 404 → relay NAK → coordinator returns `503 no_provider_available` "Selected provider is not reachable". Heartbeat and warmup use the served-id path, so the pool kept showing the provider `ready` (the "admits a provider that can't serve" symptom).

## Fix

Accept the coordinator-advertised catalog id as a **serve alias** in all three `validateModelMatches` sites — HTTP (`HTTPServer`), WS relay (`InferenceRelay`), and runtime (`ModelRuntime.acquireRequestHandle`) — **gated so the alias applies only while the configured model is the one currently loaded**, exactly mirroring `coordinatorWireModelID`'s `servedModelID == loadedModelID` predicate. After a warm-swap to a different model the alias no longer applies.

- Validation is **only relaxed**; the request model is not rewritten and response/receipt model echoing is unchanged. Same weights ⇒ same model hash, so proof-of-weights / settlement are unaffected.
- Default `aliases: []` keeps every non-serve caller (decode-bench, canary, self-test) behavior-identical.
- Alias is sourced from trusted local operator config only; length/case/whitespace handling mirrors `catalogModelIDForCoordinator` normalization.

Design doc: `specs/BUILD_SPEC_relay_serve_model_id_alias.md`.

## Tests

Added regression coverage (all passing):
- `ChatCompletionRequestTests`: default-empty regression, loaded-id pass, alias pass (case-insensitive), neither → 404, empty-alias-ignored.
- `HTTPServerSwapTests`: runtime accepts alias when configured model loaded; **rejects alias after warm-swap to a different model → 404**.
- `InferenceRelayTests`: relay accepts catalog alias when configured model loaded; rejects when no alias configured; **accepts under `warmSwapEnabled` while the configured model is still the served snapshot** (the audit-caught warm-swap gate case).

`swift build` clean; targeted suites pass (`ChatCompletionRequestTests|HTTPServerSwapTests|InferenceRelayTests`).

## Audit (three independent codex lanes, money-path bar 0 C/H/M)

Converged to **0 CRITICAL / 0 HIGH / 0 MEDIUM** across code, security, and architect lanes. Round 1 surfaced one HIGH (code + architect): the relay gated the alias on `warmSwapEnabled ? []`, which would wrongly reject the alias for a warm-swap-enabled provider still serving its configured model. Fixed by gating on `validationModelID == loadedModelID` (+ regression test); round 2 re-audit is clean.

Deferred (non-blocking LOW/INFO, documented per convention):
- The acceptable-id predicate is owned independently at the three validation sites; if a 4th validation path is added, consider centralizing it (e.g. exposed from the runtime snapshot).
- No explicit "matched via alias" telemetry; existing request telemetry still records the buyer-provided model id. Consider a low-cardinality alias-match marker only if operators need future mismatch forensics.

## Deploy note

This is the durable fix. Restoring buyers requires shipping a new provider binary (notarization/AMFI), which is a separate follow-up — buyers remain down until that lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
