### PR TITLE
fix(gateway): clamp over-cap provider usage instead of dropping the frame

### DIFF
--- a/phase5-gateway/internal/router/chat_proxy.go
+++ b/phase5-gateway/internal/router/chat_proxy.go
@@ -2255,11 +2255,37 @@ func usageFromJSON(body []byte, maxUsageTokens, maxCompletion int64, allowComple
 		return tokenUsage{}, true, fmt.Errorf("usage completion_tokens exceeds request max_tokens")
 	}
 	sum := usage.PromptTokens + usage.CompletionTokens
-	if sum > maxUsageTokens {
-		return tokenUsage{}, true, fmt.Errorf("usage token total exceeds request maximum")
-	}
+	// Validate provider self-consistency on the ORIGINAL reported values before
+	// any clamp.
 	if rawUsage.TotalTokens != nil && usage.TotalTokens != sum {
 		return tokenUsage{}, true, fmt.Errorf("usage total_tokens does not match prompt_tokens plus completion_tokens")
+	}
+	if sum > maxUsageTokens {
+		// The provider's honest token count exceeded the reservation-derived
+		// validation cap — common for token-dense prompts the byte heuristic
+		// under-counts. Clamp to the cap (reduce prompt tokens first, then
+		// completion) instead of rejecting: this mirrors the coordinator's
+		// "charge bounded prompt tokens" behavior so the buyer keeps a
+		// provider_reported usage frame and bounded billing, instead of losing
+		// usage visibility and being silently billed on gateway_estimated byte
+		// estimates. Never charges beyond the buyer's reservation hold. The
+		// buyer-facing usage frame still reports the provider's actual counts
+		// (only cached_prompt_tokens is rewritten downstream); this clamp bounds
+		// only the value settled against the reservation.
+		overage := sum - maxUsageTokens
+		if overage <= usage.PromptTokens {
+			usage.PromptTokens -= overage
+		} else {
+			usage.CompletionTokens -= overage - usage.PromptTokens
+			usage.PromptTokens = 0
+		}
+		if usage.CompletionTokens < 0 {
+			usage.CompletionTokens = 0
+		}
+		if usage.CachedPromptTokens > usage.PromptTokens {
+			usage.CachedPromptTokens = usage.PromptTokens
+		}
+		sum = usage.PromptTokens + usage.CompletionTokens
 	}
 	usage.TotalTokens = sum
 	return usage, true, nil
@@ -2425,6 +2451,12 @@ const promptHeadroomTokens = 64
 // cap=33; provider tokenized to prompt=30+completion=4=34 → falsely
 // rejected as invalid_provider_usage. Adding +64 to the cap (only)
 // fixes the false reject without inflating any billed quantity.
+//
+// NOTE: this cap equals the reservation hold (chat_proxy §"Validation
+// cap matches the reservation exposure"), so it cannot be widened
+// without widening every request's quota hold. Token-dense prompts
+// that still exceed it are handled by the clamp in usageFromJSON
+// (bounded provider_reported billing) rather than a wider cap.
 func promptCapTokens(body []byte) int64 {
 	return estimatePromptTokens(body) + promptHeadroomTokens
 }

--- a/phase5-gateway/internal/router/server_test.go
+++ b/phase5-gateway/internal/router/server_test.go
@@ -3503,6 +3503,38 @@ func TestNonStreamingSanitizesInvalidCachedPromptTokensWithoutRejectingUsage(t *
 	}
 }
 
+// TestNonStreamingOverCapUsageClampsInsteadOfRejecting is the non-streaming
+// analog of the over-cap clamp fix (2026-07-09 canary-probe finding): a prompt
+// whose provider-reported tokens exceed the reservation cap (completion within
+// max_tokens) settles provider_reported bounded to the cap, and the buyer still
+// receives the provider's actual usage counts — instead of a rejection.
+func TestNonStreamingOverCapUsageClampsInsteadOfRejecting(t *testing.T) {
+	body := `{"model":"llama","max_tokens":5,"messages":[{"role":"user","content":"ok"}]}`
+	client := &http.Client{Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+		responseBody := `{"id":"chatcmpl_overcap","usage":{"prompt_tokens":200,"completion_tokens":1,"total_tokens":201},"choices":[{"message":{"content":"ok"}}]}`
+		return responseWithBody(http.StatusOK, http.Header{"Content-Type": []string{"application/json"}}, responseBody), nil
+	})}
+	h, store, dbPath, cfg := newTestHarnessConfig(t, fakeOAuth{}, func(cfg *config.Config) {
+		cfg.Coordinator.BuyerURL = "http://coordinator.test"
+	}, WithHTTPClient(client))
+	fullKey := createAccountAndKey(t, store, cfg, "acct_overcap_nonstream")
+
+	resp := postChat(t, h, fullKey, body, nil)
+
+	if resp.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s", resp.Code, resp.Body.String())
+	}
+	// Visibility: buyer sees the provider's actual prompt count, not a rejection.
+	if !strings.Contains(resp.Body.String(), `"prompt_tokens":200`) {
+		t.Fatalf("over-cap usage was not forwarded to buyer: %s", resp.Body.String())
+	}
+	capTokens := promptCapTokens([]byte(body)) + 5
+	outcome, source, completion, prompt := usageEventOutcomeAndTokens(t, dbPath, "acct_overcap_nonstream")
+	if outcome != "ok" || source != "provider_reported" || completion != 1 || prompt != capTokens-1 {
+		t.Fatalf("usage event outcome/source/prompt/completion = %s/%s/%d/%d, want ok/provider_reported/%d/1 (bounded to cap=%d)", outcome, source, prompt, completion, capTokens-1, capTokens)
+	}
+}
+
 func TestNonStreamingSynthesizesCompleteUsageWhenProviderUsageAbsent(t *testing.T) {
 	body := `{"model":"llama","max_tokens":20,"messages":[{"role":"user","content":"legacy usage"}]}`
 	client := &http.Client{Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {

--- a/phase5-gateway/internal/router/server_test.go
+++ b/phase5-gateway/internal/router/server_test.go
@@ -3569,7 +3569,6 @@ func TestUsageFromJSONValidatesProviderReportedUsage(t *testing.T) {
 		{name: "overflow", body: `{"usage":{"prompt_tokens":9223372036854775807,"completion_tokens":1}}`},
 		{name: "inconsistent_total", body: `{"usage":{"prompt_tokens":1,"completion_tokens":2,"total_tokens":4}}`},
 		{name: "explicit_zero_total_mismatch", body: `{"usage":{"prompt_tokens":1,"completion_tokens":2,"total_tokens":0}}`},
-		{name: "exceeds_request_bound", body: `{"usage":{"prompt_tokens":1,"completion_tokens":10,"total_tokens":11}}`},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			if _, ok, err := usageFromJSON([]byte(tc.body), 10, 10); !ok || err == nil {
@@ -3608,6 +3607,17 @@ func TestUsageFromJSONValidatesProviderReportedUsage(t *testing.T) {
 	}
 	if _, ok, err := usageFromJSON([]byte(`{"usage":null}`), 10, 10); ok || err != nil {
 		t.Fatalf("usage null ok=%v err=%v, want absent usage", ok, err)
+	}
+	// Over-cap usage is CLAMPED to the reservation cap (mirrors the coordinator's
+	// bounded charge), not rejected — so the buyer keeps a provider_reported
+	// usage frame instead of losing usage and being billed on gateway_estimated.
+	// Regression for the 2026-07-09 canary-probe finding.
+	clamped, ok, err := usageFromJSON([]byte(`{"usage":{"prompt_tokens":1,"completion_tokens":10,"total_tokens":11}}`), 10, 10)
+	if err != nil || !ok {
+		t.Fatalf("over-cap usage ok=%v err=%v, want clamped accept", ok, err)
+	}
+	if clamped.PromptTokens != 0 || clamped.CompletionTokens != 10 || clamped.TotalTokens != 10 {
+		t.Fatalf("over-cap clamp = %#v, want prompt=0 completion=10 total=10 (bounded to cap=10)", clamped)
 	}
 }
 
@@ -3665,11 +3675,18 @@ func TestEstimatePromptTokensHeadroomCoversAir5(t *testing.T) {
 	}
 
 	// Sanity: a malicious provider reporting prompt=10000 for the same
-	// 115-byte body must STILL trip the cap. Headroom doesn't break
-	// the over-billing defense.
+	// body must STILL be bounded to the buyer's reservation. The clamp caps
+	// the settled total at maxUsageTokens (mirrors the coordinator's bounded
+	// charge) instead of dropping usage — the over-billing defense holds; the
+	// buyer just keeps a bounded provider_reported usage frame rather than
+	// losing usage and being billed on gateway_estimated.
 	abusiveUsage := []byte(`{"usage":{"prompt_tokens":10000,"completion_tokens":1,"total_tokens":10001}}`)
-	if _, _, err := usageFromJSON(abusiveUsage, maxUsageTokens, maxTokens); err == nil {
-		t.Fatalf("expected cap rejection for prompt=10000 on a 115-byte body (cap=%d)", maxUsageTokens)
+	clampedAbusive, ok, err := usageFromJSON(abusiveUsage, maxUsageTokens, maxTokens)
+	if err != nil || !ok {
+		t.Fatalf("abusive over-cap usage ok=%v err=%v, want clamped accept", ok, err)
+	}
+	if clampedAbusive.TotalTokens != maxUsageTokens || clampedAbusive.CompletionTokens != 1 || clampedAbusive.PromptTokens != maxUsageTokens-1 {
+		t.Fatalf("abusive clamp = %#v, want total=%d completion=1 prompt=%d (bounded to cap)", clampedAbusive, maxUsageTokens, maxUsageTokens-1)
 	}
 
 	// R1 CODE HIGH #1: a malicious provider must NOT be able to spend
@@ -5130,6 +5147,51 @@ func TestStreamingSanitizesInvalidCachedPromptTokensWithoutRejectingUsage(t *tes
 	outcome, source, completion, prompt := usageEventOutcomeAndTokens(t, dbPath, accountID)
 	if outcome != "unverified_streaming" || source != "provider_reported" || prompt != 3 || completion != 2 {
 		t.Fatalf("usage event outcome/source/prompt/completion = %s/%s/%d/%d, want unverified_streaming/provider_reported/3/2", outcome, source, prompt, completion)
+	}
+}
+
+// TestStreamingOverCapUsageClampsInsteadOfDroppingFrame regresses the
+// 2026-07-09 canary-probe finding: when a provider's honest token count
+// exceeds the reservation-derived validation cap (common for token-dense
+// prompts the byte heuristic under-counts), the gateway used to drop the
+// usage frame from the buyer stream and force settlement to gateway_estimated
+// byte estimates. It must instead forward the frame (buyer keeps usage
+// visibility) and settle provider_reported, clamped to the reservation cap.
+func TestStreamingOverCapUsageClampsInsteadOfDroppingFrame(t *testing.T) {
+	body := `{"model":"llama","stream":true,"max_tokens":5,"messages":[{"role":"user","content":"ok"}]}`
+	accountID := "acct_stream_overcap_usage"
+	client := &http.Client{Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+		payload := strings.Join([]string{
+			`data: {"id":"chatcmpl","choices":[{"delta":{"content":"ok"}}]}`,
+			`data: {"id":"chatcmpl","usage":{"prompt_tokens":200,"completion_tokens":1,"total_tokens":201},"choices":[{"delta":{},"finish_reason":"stop"}]}`,
+			`data: [DONE]`,
+			``,
+		}, "\n\n")
+		return responseWithBody(http.StatusOK, http.Header{"Content-Type": []string{"text/event-stream; charset=utf-8"}}, payload), nil
+	})}
+	h, store, dbPath, cfg := newTestHarnessConfig(t, fakeOAuth{}, func(cfg *config.Config) {
+		cfg.Coordinator.BuyerURL = "http://coordinator.test"
+	}, WithHTTPClient(client))
+	fullKey := createAccountAndKey(t, store, cfg, accountID)
+
+	resp := postChat(t, h, fullKey, body, nil)
+	if resp.Code != http.StatusOK {
+		t.Fatalf("stream response code=%d body=%s", resp.Code, resp.Body.String())
+	}
+	// Visibility fix: the usage frame is forwarded with the provider's ACTUAL
+	// prompt count, not dropped.
+	if !strings.Contains(resp.Body.String(), `"prompt_tokens":200`) {
+		t.Fatalf("over-cap usage frame was dropped from buyer stream: %s", resp.Body.String())
+	}
+	// Billing fix: settled provider_reported (not gateway_estimated), clamped to
+	// the reservation cap.
+	capTokens := promptCapTokens([]byte(body)) + 5
+	outcome, source, completion, prompt := usageEventOutcomeAndTokens(t, dbPath, accountID)
+	if source != "provider_reported" {
+		t.Fatalf("over-cap settlement source=%s outcome=%s, want provider_reported (not gateway_estimated)", source, outcome)
+	}
+	if completion != 1 || prompt != capTokens-1 {
+		t.Fatalf("over-cap clamped tokens prompt/completion = %d/%d, want %d/1 (bounded to cap=%d)", prompt, completion, capTokens-1, capTokens)
 	}
 }
 


### PR DESCRIPTION
## Summary

Fixes a confirmed prod billing + observability bug: **streaming (and non-streaming) requests whose prompt exceeds the gateway's usage-validation cap silently lost their `usage` frame and were billed on `gateway_estimated` byte estimates instead of provider-reported token counts.**

Discovered by the canary buyer probe (#507) against `api.streamvc.live`, model `qwen3-coder-30b-a3b-instruct`, and root-caused end-to-end (probe → gateway settlement code → Pearl coordinator logs + config).

## Root cause

The gateway's usage-validation cap `maxUsageTokens` is derived from a `ceil(bytes/4)` byte heuristic (`promptCapTokens`) and, by design invariant, **equals the buyer's reservation hold**. `ceil(bytes/4)` is prose-calibrated and under-counts token-dense prompts (code, JSON, CJK) — and prod serves a **coder** model. When the provider's honest `prompt_tokens + completion_tokens` exceeded the cap, [`usageFromJSON`](phase5-gateway/internal/router/chat_proxy.go) returned an error, and the streaming relay set the usage line to `nil` (dropping it from the buyer stream) and fell back to `gateway_estimated`.

Confirmed live:
- Probe: usage frame present ≤~302 prompt tokens, absent ≥~330 (deterministic); small prompt + long completion → present, large prompt + short completion → absent (isolates it to prefill/prompt size).
- Pearl coordinator log for a probe request: `provider reported prompt tokens exceeded independent bound ... provider_reported_prompt_tokens=502 charged_prompt_tokens=355`.
- Pearl config: no `verified_model_settlement_mode` set → prod runs the default `observe` mode, where the gateway's own stream-parsed usage is authoritative for billing. So this affects **billing**, not just buyer-visible usage.

## Fix (A)

On over-cap, `usageFromJSON` now **clamps** the reported usage to the reservation cap (reduce prompt first, then completion; floor at 0; clamp cached ≤ prompt) and returns it as valid — mirroring the coordinator's existing "charge bounded prompt tokens" behavior. Effect:
- The buyer keeps a `provider_reported` usage frame, forwarded with the provider's **actual** counts (only `cached_prompt_tokens` is normalized).
- Billing settles `provider_reported`, bounded to the reservation — **never over the hold** (over-billing defense preserved).
- Provider self-consistency (`total_tokens` mismatch) is still validated on the original values before any clamp; malformed / negative / overflow / completion-over-max still hard-reject.

## Deferred (B)

Widening the cap heuristic was intentionally **not** included: the validation cap equals the reservation hold by invariant, so widening it widens every request's quota hold (it 429'd a demo request in tests). A alone fully fixes the bug; token-dense prompts simply bill at the bounded cap (buyer-favorable, same as the coordinator already does). Any cap widening is a separate quota-behavior decision.

## Tests

- `usageFromJSON` clamp unit coverage; the Air5 abusive-usage case now asserts clamping (bounded), not rejection.
- New streaming regression `TestStreamingOverCapUsageClampsInsteadOfDroppingFrame` — usage frame forwarded + settled `provider_reported`.
- New non-streaming regression `TestNonStreamingOverCapUsageClampsInsteadOfRejecting`.
- Full gateway suite + `go vet` green.

## Audit

Three-lane codex audit (code / security / architect), money-path, **PASS 0 CRITICAL / 0 HIGH / 0 MEDIUM on the first round**. Security lane specifically verified a malicious provider cannot use the clamp to charge beyond the reservation hold.
