### PR TITLE
feat(opoi): W3 canary cold-start grace for the TTFT/TPS wall-time gates

### DIFF
--- a/ops/runbooks/proof-of-weights-implementation.md
+++ b/ops/runbooks/proof-of-weights-implementation.md
@@ -81,6 +81,16 @@ pool:
 
 Full downgrade cheat smoke (30B claim + 8B serve) requires a dedicated lab provider loading the wrong weights; latency gates exercise the same sanction path.
 
+**Cold-start grace (2026-07-09):** a cold 30B load produces ~8s TTFT on
+reconnect, which false-fails a static `max_ttft_ms` (the reason the live tune
+had bumped 3500→7000). The real fix is `pool.canary_cold_start_grace_s` (default
+0): for that many seconds after a provider connects, ONLY the `max_ttft_ms` gate
+is waived — nonce-correctness and `min_sustained_tps` stay enforced, so the
+anti-cheat guarantee is unchanged. Staging overlay sets `300`, so `max_ttft_ms`
+can stay at the real production target (3500) instead of a padded value. A waived
+probe logs `provider canary TTFT gate waived during cold-start grace window` with
+`canary_ttft_ms` + `connected_age` so a genuinely-slow provider stays visible.
+
 ---
 
 ## §6 — W4 telemetry drift alerts

--- a/ops/runbooks/proof-of-weights-implementation.md
+++ b/ops/runbooks/proof-of-weights-implementation.md
@@ -83,13 +83,22 @@ Full downgrade cheat smoke (30B claim + 8B serve) requires a dedicated lab provi
 
 **Cold-start grace (2026-07-09):** a cold 30B load produces ~8s TTFT on
 reconnect, which false-fails a static `max_ttft_ms` (the reason the live tune
-had bumped 3500→7000). The real fix is `pool.canary_cold_start_grace_s` (default
-0): for that many seconds after a provider connects, ONLY the `max_ttft_ms` gate
-is waived — nonce-correctness and `min_sustained_tps` stay enforced, so the
-anti-cheat guarantee is unchanged. Staging overlay sets `300`, so `max_ttft_ms`
-can stay at the real production target (3500) instead of a padded value. A waived
+had bumped 3500→7000). The fix is `pool.canary_cold_start_grace_s` (default 0):
+for that many seconds after a provider connects, the wall-time latency gates
+(`max_ttft_ms` AND `min_sustained_tps` — canary probes are non-streaming, so
+both are measured over wall time and cold-contaminated) are waived. The
+nonce-correctness gate is NEVER relaxed, so anti-downgrade is unchanged. Staging
+overlay sets `300`, so `max_ttft_ms` can stay at the real production target
+(3500) instead of a padded value.
+
+The grace is sanction-safe (three codex audit rounds hardened it): a graced
+probe is NEUTRAL for the failure counter (it neither counts as a fail nor clears
+enforced-window fails), and it FORCES the next probe to be enforced (the
+`enforce-next` flag is cleared only after a *current, recorded* enforced probe,
+so a reconnect mid-probe cannot re-open grace). A chronically-slow provider
+therefore still fails the interleaved enforced probes and is sanctioned. A waived
 probe logs `provider canary TTFT gate waived during cold-start grace window` with
-`canary_ttft_ms` + `connected_age` so a genuinely-slow provider stays visible.
+`canary_ttft_ms` + `connected_age`.
 
 ---
 

--- a/phase4-coordinator/coordinator.opoi-v0-staging.yaml
+++ b/phase4-coordinator/coordinator.opoi-v0-staging.yaml
@@ -24,6 +24,12 @@ pool:
   canary_timeout_s: 120
   canary_max_tokens: 16
   canary_failure_threshold: 3   # 3 consecutive fails → provisional ban
+  # Relax ONLY the max_ttft_ms gate for the first 300s after a provider
+  # connects: a cold large-model load (observed ~8s TTFT for a cold 30B)
+  # must not false-fail the latency gate on reconnect. Correctness +
+  # min_sustained_tps still enforced. The real fix for the 3500→7000
+  # cold-30B false-fail (see proof-of-weights-implementation.md §5).
+  canary_cold_start_grace_s: 300
   # Challenge bank — both entries embed {nonce} (hex, 4 bytes, upper-case).
   # Rotate periodically; keep this file deployment-specific.
   canary_challenges:

--- a/phase4-coordinator/coordinator.opoi-v0-staging.yaml
+++ b/phase4-coordinator/coordinator.opoi-v0-staging.yaml
@@ -24,10 +24,11 @@ pool:
   canary_timeout_s: 120
   canary_max_tokens: 16
   canary_failure_threshold: 3   # 3 consecutive fails → provisional ban
-  # Relax ONLY the max_ttft_ms gate for the first 300s after a provider
-  # connects: a cold large-model load (observed ~8s TTFT for a cold 30B)
-  # must not false-fail the latency gate on reconnect. Correctness +
-  # min_sustained_tps still enforced. The real fix for the 3500→7000
+  # Waive the wall-time latency gates (max_ttft_ms + min_sustained_tps; canary
+  # probes are non-streaming) for the first 300s after a provider connects: a
+  # cold large-model load (observed ~8s TTFT for a cold 30B) must not false-fail
+  # on reconnect. Nonce-correctness is still enforced, a graced probe is neutral
+  # and forces the next probe to be enforced. The real fix for the 3500→7000
   # cold-30B false-fail (see proof-of-weights-implementation.md §5).
   canary_cold_start_grace_s: 300
   # Challenge bank — both entries embed {nonce} (hex, 4 bytes, upper-case).

--- a/phase4-coordinator/coordinator.yaml.example
+++ b/phase4-coordinator/coordinator.yaml.example
@@ -47,6 +47,8 @@ pool:
   canary_timeout_s: 120
   canary_max_tokens: 16
   canary_failure_threshold: 3   # provisional ban; pinned → degrade at 2
+  canary_cold_start_grace_s: 300 # waive ONLY max_ttft_ms for 300s after connect
+                                 # (cold large-model load); correctness + TPS enforced
   # OPoI v0 challenge bank — every entry must contain {nonce} in both prompt and expected.
   # Rotate or extend periodically; keep deployment-specific for model security.
   canary_challenges:

--- a/phase4-coordinator/coordinator.yaml.example
+++ b/phase4-coordinator/coordinator.yaml.example
@@ -47,8 +47,9 @@ pool:
   canary_timeout_s: 120
   canary_max_tokens: 16
   canary_failure_threshold: 3   # provisional ban; pinned → degrade at 2
-  canary_cold_start_grace_s: 300 # waive ONLY max_ttft_ms for 300s after connect
-                                 # (cold large-model load); correctness + TPS enforced
+  canary_cold_start_grace_s: 300 # waive wall-time latency gates (max_ttft_ms +
+                                 # min_sustained_tps) 300s after connect; nonce
+                                 # always enforced, graced probe neutral+enforced-next
   # OPoI v0 challenge bank — every entry must contain {nonce} in both prompt and expected.
   # Rotate or extend periodically; keep deployment-specific for model security.
   canary_challenges:

--- a/phase4-coordinator/dist/coordinator.yaml.example
+++ b/phase4-coordinator/dist/coordinator.yaml.example
@@ -62,10 +62,12 @@ pool:
   canary_timeout_s: 120
   canary_max_tokens: 16
   canary_failure_threshold: 3   # provisional ban; pinned → degrade at 2
-  canary_cold_start_grace_s: 0  # >0 waives ONLY max_ttft_ms for that many
-                                # seconds after a provider connects (cold
-                                # large-model load). Correctness + sustained
-                                # TPS always enforced. Set ~300 with latency gates.
+  canary_cold_start_grace_s: 0  # >0 waives the wall-time latency gates
+                                # (max_ttft_ms + min_sustained_tps; probes are
+                                # non-streaming) for N s after connect (cold
+                                # load). Nonce-correctness always enforced; a
+                                # graced probe is neutral + forces the next
+                                # probe enforced. Set ~300 with latency gates.
   # OPoI v0 challenge bank reference (enable in staging overlay, not here).
   # Every entry must contain {nonce} in both prompt and expected.
   # canary_challenges:

--- a/phase4-coordinator/dist/coordinator.yaml.example
+++ b/phase4-coordinator/dist/coordinator.yaml.example
@@ -62,6 +62,10 @@ pool:
   canary_timeout_s: 120
   canary_max_tokens: 16
   canary_failure_threshold: 3   # provisional ban; pinned → degrade at 2
+  canary_cold_start_grace_s: 0  # >0 waives ONLY max_ttft_ms for that many
+                                # seconds after a provider connects (cold
+                                # large-model load). Correctness + sustained
+                                # TPS always enforced. Set ~300 with latency gates.
   # OPoI v0 challenge bank reference (enable in staging overlay, not here).
   # Every entry must contain {nonce} in both prompt and expected.
   # canary_challenges:

--- a/phase4-coordinator/internal/config/config.go
+++ b/phase4-coordinator/internal/config/config.go
@@ -327,13 +327,16 @@ type PoolConfig struct {
 	CanaryTimeoutS          int                                `yaml:"canary_timeout_s"`
 	CanaryMaxTokens         int                                `yaml:"canary_max_tokens"`
 	CanaryFailureThreshold  int                                `yaml:"canary_failure_threshold"`
-	// CanaryColdStartGraceS relaxes ONLY the max_ttft_ms latency gate for the
-	// first grace-window seconds after a provider connects. A freshly
-	// (re)connected provider may still be cold-loading a large model, so a
-	// correct-but-slow answer must not trip a latency sanction. 0 (default)
-	// disables it; the nonce-correctness and min_sustained_tps gates are never
-	// relaxed. Size it to cover a cold large-model TTFT (observed ~8s for a
-	// cold 30B; a full model load can take tens of seconds).
+	// CanaryColdStartGraceS relaxes the WALL-TIME latency gates (max_ttft_ms and
+	// min_sustained_tps) for the first grace-window seconds after a provider
+	// connects. Canary probes are non-streaming, so both metrics are measured
+	// over wall time and are dominated by a cold large-model load; a
+	// correct-but-slow answer must not trip a latency sanction on (re)connect.
+	// 0 (default) disables it. The nonce-correctness gate is NEVER relaxed, a
+	// graced probe is neutral for the sanction counter, and it forces the next
+	// probe to be enforced — so this cannot be used to evade sanctions. Size it
+	// to cover a cold large-model load (observed ~8s TTFT for a cold 30B; a full
+	// load can take tens of seconds).
 	CanaryColdStartGraceS   int                                `yaml:"canary_cold_start_grace_s"`
 	CanaryChallenges        []CanaryChallengeConfig            `yaml:"canary_challenges"`
 	ModelClassChallenges    map[string][]CanaryChallengeConfig `yaml:"model_class_challenges"`

--- a/phase4-coordinator/internal/config/config.go
+++ b/phase4-coordinator/internal/config/config.go
@@ -327,6 +327,14 @@ type PoolConfig struct {
 	CanaryTimeoutS          int                                `yaml:"canary_timeout_s"`
 	CanaryMaxTokens         int                                `yaml:"canary_max_tokens"`
 	CanaryFailureThreshold  int                                `yaml:"canary_failure_threshold"`
+	// CanaryColdStartGraceS relaxes ONLY the max_ttft_ms latency gate for the
+	// first grace-window seconds after a provider connects. A freshly
+	// (re)connected provider may still be cold-loading a large model, so a
+	// correct-but-slow answer must not trip a latency sanction. 0 (default)
+	// disables it; the nonce-correctness and min_sustained_tps gates are never
+	// relaxed. Size it to cover a cold large-model TTFT (observed ~8s for a
+	// cold 30B; a full model load can take tens of seconds).
+	CanaryColdStartGraceS   int                                `yaml:"canary_cold_start_grace_s"`
 	CanaryChallenges        []CanaryChallengeConfig            `yaml:"canary_challenges"`
 	ModelClassChallenges    map[string][]CanaryChallengeConfig `yaml:"model_class_challenges"`
 }
@@ -1396,6 +1404,9 @@ func (c Config) Validate() error {
 	}
 	if c.Pool.CanaryEnabled && (c.Pool.CanaryIntervalS <= 0 || c.Pool.CanaryTimeoutS <= 0 || c.Pool.CanaryMaxTokens <= 0 || c.Pool.CanaryFailureThreshold <= 0) {
 		return fmt.Errorf("pool canary settings must be > 0 when enabled")
+	}
+	if c.Pool.CanaryColdStartGraceS < 0 {
+		return fmt.Errorf("pool canary_cold_start_grace_s must be >= 0")
 	}
 	if c.Pool.CanaryEnabled {
 		if len(c.Pool.CanaryChallenges) == 0 && len(c.Pool.ModelClassChallenges) == 0 {

--- a/phase4-coordinator/internal/config/config_test.go
+++ b/phase4-coordinator/internal/config/config_test.go
@@ -133,6 +133,23 @@ func TestCanaryValidationRequiresPrivateChallengeBankWhenEnabled(t *testing.T) {
 	}
 }
 
+func TestCanaryColdStartGraceValidation(t *testing.T) {
+	cfg := Default()
+	cfg.Auth.OperatorKey = "operator-key"
+	cfg.Pool.CanaryColdStartGraceS = -1
+	if err := cfg.Validate(); err == nil || !strings.Contains(err.Error(), "canary_cold_start_grace_s") {
+		t.Fatalf("negative cold-start grace validation err=%v", err)
+	}
+	cfg.Pool.CanaryColdStartGraceS = 300
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("valid cold-start grace should validate: %v", err)
+	}
+	cfg.Pool.CanaryColdStartGraceS = 0
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("zero cold-start grace (disabled) should validate: %v", err)
+	}
+}
+
 func TestProviderWebSocketBoundsDefaultAndValidate(t *testing.T) {
 	cfg := Default()
 	cfg.Auth.OperatorKey = "operator-key"

--- a/phase4-coordinator/internal/ws/canary_probe.go
+++ b/phase4-coordinator/internal/ws/canary_probe.go
@@ -29,6 +29,10 @@ type canaryProbeMetrics struct {
 	TTFTMS       int
 	SustainedTPS float64
 	LatencyGated bool
+	// LatencyGraced is set when the TTFT gate WOULD have failed but was waived
+	// because the provider was inside its cold-start grace window. Surfaced in
+	// logs so a genuinely-slow provider hiding behind grace stays visible.
+	LatencyGraced bool
 }
 
 type canaryAttemptResult struct {
@@ -97,14 +101,18 @@ func challengeHasLatencyGates(challenge config.CanaryChallengeConfig) bool {
 	return challenge.MaxTTFTMS > 0 || challenge.MinSustainedTPS > 0
 }
 
-func evaluateCanaryProbe(challenge config.CanaryChallengeConfig, output string, expected string, metrics canaryProbeMetrics) canaryProbeOutcome {
+// evaluateCanaryProbe returns the probe outcome. When coldStartGrace is true the
+// max_ttft_ms latency gate is waived (the provider may still be cold-loading a
+// large model after connecting) — but the nonce-correctness and min_sustained_tps
+// gates are ALWAYS enforced, so this never weakens the anti-cheat guarantee.
+func evaluateCanaryProbe(challenge config.CanaryChallengeConfig, output string, expected string, metrics canaryProbeMetrics, coldStartGrace bool) canaryProbeOutcome {
 	if !canaryAnswerMatches(output, expected) {
 		return canaryProbeFail
 	}
 	if !challengeHasLatencyGates(challenge) {
 		return canaryProbePass
 	}
-	if challenge.MaxTTFTMS > 0 && metrics.TTFTMS > challenge.MaxTTFTMS {
+	if !coldStartGrace && challenge.MaxTTFTMS > 0 && metrics.TTFTMS > challenge.MaxTTFTMS {
 		return canaryProbeFail
 	}
 	if challenge.MinSustainedTPS > 0 && (math.IsNaN(metrics.SustainedTPS) || math.IsInf(metrics.SustainedTPS, 0) || metrics.SustainedTPS < challenge.MinSustainedTPS) {

--- a/phase4-coordinator/internal/ws/canary_probe.go
+++ b/phase4-coordinator/internal/ws/canary_probe.go
@@ -29,16 +29,11 @@ type canaryProbeMetrics struct {
 	TTFTMS       int
 	SustainedTPS float64
 	LatencyGated bool
-	// LatencyGraced is set when the TTFT gate WOULD have failed but was waived
-	// because the provider was inside its cold-start grace window. Surfaced in
-	// logs so a genuinely-slow provider hiding behind grace stays visible.
+	// LatencyGraced is set when a latency gate (max_ttft_ms or min_sustained_tps)
+	// WOULD have failed but was waived because the provider was inside its
+	// cold-start grace window. Surfaced in logs so a genuinely-slow provider
+	// hiding behind grace stays visible.
 	LatencyGraced bool
-	// DecodeWindowReliable is true when a real first-token timestamp was
-	// observed (streaming WS probes), so SustainedTPS reflects decode rate and
-	// is NOT contaminated by cold prefill. HTTP/non-stream probes have no
-	// first-token split, so their SustainedTPS is over full wall time and the
-	// TPS gate must be waived under cold-start grace (see evaluateCanaryProbe).
-	DecodeWindowReliable bool
 }
 
 type canaryAttemptResult struct {
@@ -107,25 +102,34 @@ func challengeHasLatencyGates(challenge config.CanaryChallengeConfig) bool {
 	return challenge.MaxTTFTMS > 0 || challenge.MinSustainedTPS > 0
 }
 
-// evaluateCanaryProbe returns the probe outcome. When coldStartGrace is true the
-// max_ttft_ms latency gate is waived (the provider may still be cold-loading a
-// large model after connecting). The nonce-correctness gate is ALWAYS enforced.
-// min_sustained_tps is also always enforced when the probe has a real decode
-// window (streaming WS probes, DecodeWindowReliable); it is waived under grace
-// only for HTTP/non-stream probes whose SustainedTPS is measured over full wall
-// time and would therefore be contaminated by cold prefill.
+// challengeLatencyBreach reports whether the probe metrics violate a configured
+// latency gate (max_ttft_ms or min_sustained_tps).
+func challengeLatencyBreach(challenge config.CanaryChallengeConfig, metrics canaryProbeMetrics) bool {
+	if challenge.MaxTTFTMS > 0 && metrics.TTFTMS > challenge.MaxTTFTMS {
+		return true
+	}
+	if challenge.MinSustainedTPS > 0 && (math.IsNaN(metrics.SustainedTPS) || math.IsInf(metrics.SustainedTPS, 0) || metrics.SustainedTPS < challenge.MinSustainedTPS) {
+		return true
+	}
+	return false
+}
+
+// evaluateCanaryProbe returns the probe outcome. The nonce-correctness gate
+// (model identity / anti-downgrade) is ALWAYS enforced. When coldStartGrace is
+// true, BOTH latency gates are waived: canary probes are non-streaming
+// (stream:false), so max_ttft_ms and min_sustained_tps are both measured over
+// wall time (no reliable first-token/decode split) and are dominated by a cold
+// model load. A graced probe is additionally NEUTRAL for the sanction counter
+// (see runCanaryProbe), so waiving the latency gates here cannot be abused to
+// clear enforced-window failures.
 func evaluateCanaryProbe(challenge config.CanaryChallengeConfig, output string, expected string, metrics canaryProbeMetrics, coldStartGrace bool) canaryProbeOutcome {
 	if !canaryAnswerMatches(output, expected) {
 		return canaryProbeFail
 	}
-	if !challengeHasLatencyGates(challenge) {
+	if coldStartGrace {
 		return canaryProbePass
 	}
-	if !coldStartGrace && challenge.MaxTTFTMS > 0 && metrics.TTFTMS > challenge.MaxTTFTMS {
-		return canaryProbeFail
-	}
-	tpsWaived := coldStartGrace && !metrics.DecodeWindowReliable
-	if !tpsWaived && challenge.MinSustainedTPS > 0 && (math.IsNaN(metrics.SustainedTPS) || math.IsInf(metrics.SustainedTPS, 0) || metrics.SustainedTPS < challenge.MinSustainedTPS) {
+	if challengeLatencyBreach(challenge, metrics) {
 		return canaryProbeFail
 	}
 	return canaryProbePass
@@ -148,10 +152,9 @@ func canaryMetricsFromTiming(start time.Time, firstTokenAt time.Time, completedA
 	}
 	tps := float64(completionTokens) / decode.Seconds()
 	return canaryProbeMetrics{
-		TTFTMS:               int(ttft.Round(time.Millisecond) / time.Millisecond),
-		SustainedTPS:         tps,
-		LatencyGated:         true,
-		DecodeWindowReliable: !firstTokenAt.IsZero(),
+		TTFTMS:       int(ttft.Round(time.Millisecond) / time.Millisecond),
+		SustainedTPS: tps,
+		LatencyGated: true,
 	}
 }
 

--- a/phase4-coordinator/internal/ws/canary_probe.go
+++ b/phase4-coordinator/internal/ws/canary_probe.go
@@ -33,6 +33,12 @@ type canaryProbeMetrics struct {
 	// because the provider was inside its cold-start grace window. Surfaced in
 	// logs so a genuinely-slow provider hiding behind grace stays visible.
 	LatencyGraced bool
+	// DecodeWindowReliable is true when a real first-token timestamp was
+	// observed (streaming WS probes), so SustainedTPS reflects decode rate and
+	// is NOT contaminated by cold prefill. HTTP/non-stream probes have no
+	// first-token split, so their SustainedTPS is over full wall time and the
+	// TPS gate must be waived under cold-start grace (see evaluateCanaryProbe).
+	DecodeWindowReliable bool
 }
 
 type canaryAttemptResult struct {
@@ -103,8 +109,11 @@ func challengeHasLatencyGates(challenge config.CanaryChallengeConfig) bool {
 
 // evaluateCanaryProbe returns the probe outcome. When coldStartGrace is true the
 // max_ttft_ms latency gate is waived (the provider may still be cold-loading a
-// large model after connecting) — but the nonce-correctness and min_sustained_tps
-// gates are ALWAYS enforced, so this never weakens the anti-cheat guarantee.
+// large model after connecting). The nonce-correctness gate is ALWAYS enforced.
+// min_sustained_tps is also always enforced when the probe has a real decode
+// window (streaming WS probes, DecodeWindowReliable); it is waived under grace
+// only for HTTP/non-stream probes whose SustainedTPS is measured over full wall
+// time and would therefore be contaminated by cold prefill.
 func evaluateCanaryProbe(challenge config.CanaryChallengeConfig, output string, expected string, metrics canaryProbeMetrics, coldStartGrace bool) canaryProbeOutcome {
 	if !canaryAnswerMatches(output, expected) {
 		return canaryProbeFail
@@ -115,7 +124,8 @@ func evaluateCanaryProbe(challenge config.CanaryChallengeConfig, output string, 
 	if !coldStartGrace && challenge.MaxTTFTMS > 0 && metrics.TTFTMS > challenge.MaxTTFTMS {
 		return canaryProbeFail
 	}
-	if challenge.MinSustainedTPS > 0 && (math.IsNaN(metrics.SustainedTPS) || math.IsInf(metrics.SustainedTPS, 0) || metrics.SustainedTPS < challenge.MinSustainedTPS) {
+	tpsWaived := coldStartGrace && !metrics.DecodeWindowReliable
+	if !tpsWaived && challenge.MinSustainedTPS > 0 && (math.IsNaN(metrics.SustainedTPS) || math.IsInf(metrics.SustainedTPS, 0) || metrics.SustainedTPS < challenge.MinSustainedTPS) {
 		return canaryProbeFail
 	}
 	return canaryProbePass
@@ -138,9 +148,10 @@ func canaryMetricsFromTiming(start time.Time, firstTokenAt time.Time, completedA
 	}
 	tps := float64(completionTokens) / decode.Seconds()
 	return canaryProbeMetrics{
-		TTFTMS:       int(ttft.Round(time.Millisecond) / time.Millisecond),
-		SustainedTPS: tps,
-		LatencyGated: true,
+		TTFTMS:               int(ttft.Round(time.Millisecond) / time.Millisecond),
+		SustainedTPS:         tps,
+		LatencyGated:         true,
+		DecodeWindowReliable: !firstTokenAt.IsZero(),
 	}
 }
 

--- a/phase4-coordinator/internal/ws/canary_probe_test.go
+++ b/phase4-coordinator/internal/ws/canary_probe_test.go
@@ -54,29 +54,31 @@ func TestCanaryColdStartActiveIsChurnSafe(t *testing.T) {
 		return pool.Provider{ProviderID: "p1", ConnectedAt: connectedAt}
 	}
 
-	// Fresh connect → grace armed and active.
+	// Fresh connect within the window → graced.
 	if !s.canaryColdStartActive(p(base)) {
-		t.Fatal("fresh connect should be graced")
+		t.Fatal("fresh connect within window should be graced")
 	}
-	// Still within the original window → active.
-	now = base.Add(200 * time.Second)
-	if !s.canaryColdStartActive(p(base)) {
-		t.Fatal("within window should stay graced")
+	// Past the window → not graced, even with a stale ConnectedAt.
+	now = base.Add(400 * time.Second)
+	if s.canaryColdStartActive(p(base)) {
+		t.Fatal("past the cold-start window should not be graced")
 	}
-	// Reconnect-churn AFTER the original expiry with a fresh ConnectedAt must NOT
-	// re-arm grace while inside the cooldown — the TTFT gate is enforced again.
-	now = base.Add(310 * time.Second)
-	if s.canaryColdStartActive(p(now)) {
-		t.Fatal("reconnect-churn within cooldown must NOT re-arm grace")
-	}
-	// Future / negative-age connect is never graced (clock skew guard).
-	if s.canaryColdStartActive(p(now.Add(time.Hour))) {
+	now = base
+	// Future / negative-age connect is never graced (clock-skew guard).
+	if s.canaryColdStartActive(p(base.Add(time.Hour))) {
 		t.Fatal("future ConnectedAt must not be graced")
 	}
-	// A genuinely new cold start past the cooldown re-arms grace.
-	now = base.Add(601 * time.Second)
+	// Alternation guard: once the previous probe was graced (enforceNextCanary
+	// set), the next probe is enforced even with a fresh reconnect ConnectedAt —
+	// so churn cannot arrange to only ever be probed under grace.
+	s.enforceNextCanary.Store("p1", struct{}{})
+	if s.canaryColdStartActive(p(now)) {
+		t.Fatal("must enforce the probe following a graced one, despite fresh connect")
+	}
+	// After an enforced probe clears the flag, a genuine cold start is graced again.
+	s.enforceNextCanary.Delete("p1")
 	if !s.canaryColdStartActive(p(now)) {
-		t.Fatal("a new cold start past cooldown should re-arm grace")
+		t.Fatal("grace should re-arm after an enforced probe clears the flag")
 	}
 	// Disabled when grace <= 0.
 	s.cfg.Pool.CanaryColdStartGraceS = 0

--- a/phase4-coordinator/internal/ws/canary_probe_test.go
+++ b/phase4-coordinator/internal/ws/canary_probe_test.go
@@ -2,8 +2,10 @@ package ws
 
 import (
 	"testing"
+	"time"
 
 	"github.com/augstar/macprovider-coordinator/internal/config"
+	"github.com/augstar/macprovider-coordinator/internal/pool"
 )
 
 func TestEvaluateCanaryProbeLatencyGates(t *testing.T) {
@@ -27,16 +29,68 @@ func TestEvaluateCanaryProbeLatencyGates(t *testing.T) {
 	if evaluateCanaryProbe(challenge, "wrong", "ABCD", canaryProbeMetrics{TTFTMS: 700, SustainedTPS: 15}, false) != canaryProbeFail {
 		t.Fatal("expected answer fail")
 	}
-	// Cold-start grace waives ONLY the TTFT gate: a slow-but-correct answer
-	// passes, while a wrong answer or low sustained TPS still fails.
-	if evaluateCanaryProbe(challenge, "ABCD", "ABCD", canaryProbeMetrics{TTFTMS: 9000, SustainedTPS: 15}, true) != canaryProbePass {
+	// Cold-start grace waives the TTFT gate: a slow-but-correct answer passes.
+	// DecodeWindowReliable=true models a streaming WS probe.
+	if evaluateCanaryProbe(challenge, "ABCD", "ABCD", canaryProbeMetrics{TTFTMS: 9000, SustainedTPS: 15, DecodeWindowReliable: true}, true) != canaryProbePass {
 		t.Fatal("expected cold-start grace to waive the ttft gate")
 	}
-	if evaluateCanaryProbe(challenge, "wrong", "ABCD", canaryProbeMetrics{TTFTMS: 9000, SustainedTPS: 15}, true) != canaryProbeFail {
+	// Grace never waives the answer-correctness gate.
+	if evaluateCanaryProbe(challenge, "wrong", "ABCD", canaryProbeMetrics{TTFTMS: 9000, SustainedTPS: 15, DecodeWindowReliable: true}, true) != canaryProbeFail {
 		t.Fatal("cold-start grace must NOT waive the answer-correctness gate")
 	}
-	if evaluateCanaryProbe(challenge, "ABCD", "ABCD", canaryProbeMetrics{TTFTMS: 9000, SustainedTPS: 8}, true) != canaryProbeFail {
-		t.Fatal("cold-start grace must NOT waive the sustained-tps gate")
+	// For a WS probe with a real decode window, sustained-TPS is STILL enforced
+	// under grace (cold load does not depress decode rate).
+	if evaluateCanaryProbe(challenge, "ABCD", "ABCD", canaryProbeMetrics{TTFTMS: 9000, SustainedTPS: 8, DecodeWindowReliable: true}, true) != canaryProbeFail {
+		t.Fatal("cold-start grace must NOT waive sustained-tps for a WS decode-window probe")
+	}
+	// For an HTTP probe with NO decode window, SustainedTPS is over full wall
+	// time and is cold-contaminated, so it is waived under grace.
+	if evaluateCanaryProbe(challenge, "ABCD", "ABCD", canaryProbeMetrics{TTFTMS: 9000, SustainedTPS: 8, DecodeWindowReliable: false}, true) != canaryProbePass {
+		t.Fatal("cold-start grace should waive sustained-tps for an HTTP no-decode-window probe")
+	}
+	// Without grace, TPS is enforced regardless of decode window.
+	if evaluateCanaryProbe(challenge, "ABCD", "ABCD", canaryProbeMetrics{TTFTMS: 700, SustainedTPS: 8, DecodeWindowReliable: false}, false) != canaryProbeFail {
+		t.Fatal("without grace the sustained-tps gate must still fail")
+	}
+}
+
+func TestCanaryColdStartActiveIsChurnSafe(t *testing.T) {
+	base := time.Date(2026, 7, 9, 12, 0, 0, 0, time.UTC)
+	now := base
+	s := &Server{now: func() time.Time { return now }}
+	s.cfg.Pool.CanaryColdStartGraceS = 300 // 300s window
+	p := func(connectedAt time.Time) pool.Provider {
+		return pool.Provider{ProviderID: "p1", ConnectedAt: connectedAt}
+	}
+
+	// Fresh connect → grace armed and active.
+	if !s.canaryColdStartActive(p(base)) {
+		t.Fatal("fresh connect should be graced")
+	}
+	// Still within the original window → active.
+	now = base.Add(200 * time.Second)
+	if !s.canaryColdStartActive(p(base)) {
+		t.Fatal("within window should stay graced")
+	}
+	// Reconnect-churn AFTER the original expiry with a fresh ConnectedAt must NOT
+	// re-arm grace while inside the cooldown — the TTFT gate is enforced again.
+	now = base.Add(310 * time.Second)
+	if s.canaryColdStartActive(p(now)) {
+		t.Fatal("reconnect-churn within cooldown must NOT re-arm grace")
+	}
+	// Future / negative-age connect is never graced (clock skew guard).
+	if s.canaryColdStartActive(p(now.Add(time.Hour))) {
+		t.Fatal("future ConnectedAt must not be graced")
+	}
+	// A genuinely new cold start past the cooldown re-arms grace.
+	now = base.Add(601 * time.Second)
+	if !s.canaryColdStartActive(p(now)) {
+		t.Fatal("a new cold start past cooldown should re-arm grace")
+	}
+	// Disabled when grace <= 0.
+	s.cfg.Pool.CanaryColdStartGraceS = 0
+	if s.canaryColdStartActive(p(now)) {
+		t.Fatal("grace disabled (0) must be inactive")
 	}
 }
 

--- a/phase4-coordinator/internal/ws/canary_probe_test.go
+++ b/phase4-coordinator/internal/ws/canary_probe_test.go
@@ -29,27 +29,18 @@ func TestEvaluateCanaryProbeLatencyGates(t *testing.T) {
 	if evaluateCanaryProbe(challenge, "wrong", "ABCD", canaryProbeMetrics{TTFTMS: 700, SustainedTPS: 15}, false) != canaryProbeFail {
 		t.Fatal("expected answer fail")
 	}
-	// Cold-start grace waives the TTFT gate: a slow-but-correct answer passes.
-	// DecodeWindowReliable=true models a streaming WS probe.
-	if evaluateCanaryProbe(challenge, "ABCD", "ABCD", canaryProbeMetrics{TTFTMS: 9000, SustainedTPS: 15, DecodeWindowReliable: true}, true) != canaryProbePass {
-		t.Fatal("expected cold-start grace to waive the ttft gate")
+	// Cold-start grace waives BOTH wall-time latency gates (canary probes are
+	// non-streaming, so max_ttft_ms and min_sustained_tps are both cold-
+	// contaminated): a slow-but-correct answer passes.
+	if evaluateCanaryProbe(challenge, "ABCD", "ABCD", canaryProbeMetrics{TTFTMS: 9000, SustainedTPS: 8}, true) != canaryProbePass {
+		t.Fatal("expected cold-start grace to waive both latency gates for a correct answer")
 	}
 	// Grace never waives the answer-correctness gate.
-	if evaluateCanaryProbe(challenge, "wrong", "ABCD", canaryProbeMetrics{TTFTMS: 9000, SustainedTPS: 15, DecodeWindowReliable: true}, true) != canaryProbeFail {
+	if evaluateCanaryProbe(challenge, "wrong", "ABCD", canaryProbeMetrics{TTFTMS: 9000, SustainedTPS: 15}, true) != canaryProbeFail {
 		t.Fatal("cold-start grace must NOT waive the answer-correctness gate")
 	}
-	// For a WS probe with a real decode window, sustained-TPS is STILL enforced
-	// under grace (cold load does not depress decode rate).
-	if evaluateCanaryProbe(challenge, "ABCD", "ABCD", canaryProbeMetrics{TTFTMS: 9000, SustainedTPS: 8, DecodeWindowReliable: true}, true) != canaryProbeFail {
-		t.Fatal("cold-start grace must NOT waive sustained-tps for a WS decode-window probe")
-	}
-	// For an HTTP probe with NO decode window, SustainedTPS is over full wall
-	// time and is cold-contaminated, so it is waived under grace.
-	if evaluateCanaryProbe(challenge, "ABCD", "ABCD", canaryProbeMetrics{TTFTMS: 9000, SustainedTPS: 8, DecodeWindowReliable: false}, true) != canaryProbePass {
-		t.Fatal("cold-start grace should waive sustained-tps for an HTTP no-decode-window probe")
-	}
-	// Without grace, TPS is enforced regardless of decode window.
-	if evaluateCanaryProbe(challenge, "ABCD", "ABCD", canaryProbeMetrics{TTFTMS: 700, SustainedTPS: 8, DecodeWindowReliable: false}, false) != canaryProbeFail {
+	// Without grace, both latency gates are still enforced.
+	if evaluateCanaryProbe(challenge, "ABCD", "ABCD", canaryProbeMetrics{TTFTMS: 700, SustainedTPS: 8}, false) != canaryProbeFail {
 		t.Fatal("without grace the sustained-tps gate must still fail")
 	}
 }

--- a/phase4-coordinator/internal/ws/canary_probe_test.go
+++ b/phase4-coordinator/internal/ws/canary_probe_test.go
@@ -14,18 +14,29 @@ func TestEvaluateCanaryProbeLatencyGates(t *testing.T) {
 		MaxTTFTMS:       800,
 		MinSustainedTPS: 12,
 	}
-	pass := evaluateCanaryProbe(challenge, "ABCD", "ABCD", canaryProbeMetrics{TTFTMS: 700, SustainedTPS: 15})
+	pass := evaluateCanaryProbe(challenge, "ABCD", "ABCD", canaryProbeMetrics{TTFTMS: 700, SustainedTPS: 15}, false)
 	if pass != canaryProbePass {
 		t.Fatalf("latency pass = %q", pass)
 	}
-	if evaluateCanaryProbe(challenge, "ABCD", "ABCD", canaryProbeMetrics{TTFTMS: 900, SustainedTPS: 15}) != canaryProbeFail {
+	if evaluateCanaryProbe(challenge, "ABCD", "ABCD", canaryProbeMetrics{TTFTMS: 900, SustainedTPS: 15}, false) != canaryProbeFail {
 		t.Fatal("expected ttft fail")
 	}
-	if evaluateCanaryProbe(challenge, "ABCD", "ABCD", canaryProbeMetrics{TTFTMS: 700, SustainedTPS: 8}) != canaryProbeFail {
+	if evaluateCanaryProbe(challenge, "ABCD", "ABCD", canaryProbeMetrics{TTFTMS: 700, SustainedTPS: 8}, false) != canaryProbeFail {
 		t.Fatal("expected tps fail")
 	}
-	if evaluateCanaryProbe(challenge, "wrong", "ABCD", canaryProbeMetrics{TTFTMS: 700, SustainedTPS: 15}) != canaryProbeFail {
+	if evaluateCanaryProbe(challenge, "wrong", "ABCD", canaryProbeMetrics{TTFTMS: 700, SustainedTPS: 15}, false) != canaryProbeFail {
 		t.Fatal("expected answer fail")
+	}
+	// Cold-start grace waives ONLY the TTFT gate: a slow-but-correct answer
+	// passes, while a wrong answer or low sustained TPS still fails.
+	if evaluateCanaryProbe(challenge, "ABCD", "ABCD", canaryProbeMetrics{TTFTMS: 9000, SustainedTPS: 15}, true) != canaryProbePass {
+		t.Fatal("expected cold-start grace to waive the ttft gate")
+	}
+	if evaluateCanaryProbe(challenge, "wrong", "ABCD", canaryProbeMetrics{TTFTMS: 9000, SustainedTPS: 15}, true) != canaryProbeFail {
+		t.Fatal("cold-start grace must NOT waive the answer-correctness gate")
+	}
+	if evaluateCanaryProbe(challenge, "ABCD", "ABCD", canaryProbeMetrics{TTFTMS: 9000, SustainedTPS: 8}, true) != canaryProbeFail {
+		t.Fatal("cold-start grace must NOT waive the sustained-tps gate")
 	}
 }
 

--- a/phase4-coordinator/internal/ws/server.go
+++ b/phase4-coordinator/internal/ws/server.go
@@ -59,6 +59,11 @@ type Server struct {
 	warmups         sync.Map
 	canaries        sync.Map
 	canaryDue       sync.Map
+	// canaryGrace maps provider ID -> cold-start grace expiry (time.Time).
+	// Keyed by PROVIDER ID (not session) so reconnect-churn cannot keep
+	// resetting ConnectedAt to stay perpetually inside grace. See
+	// canaryColdStartActive.
+	canaryGrace     sync.Map
 	canarySanctions CanarySanctionStore
 	tokens          TokenValidator
 	// SPEC-003 v0.8 FR-C9.1 — separate issuer field so validator and
@@ -2418,14 +2423,41 @@ func (s *Server) runHTTPCanaryProbeAttempt(ctx context.Context, provider pool.Pr
 
 // canaryColdStartActive reports whether the provider is within its cold-start
 // grace window since connecting, during which the max_ttft_ms latency gate is
-// relaxed (see PoolConfig.CanaryColdStartGraceS). The nonce-correctness and
-// min_sustained_tps gates are never relaxed.
+// relaxed (see PoolConfig.CanaryColdStartGraceS). The nonce-correctness gate is
+// never relaxed (and min_sustained_tps is relaxed only for HTTP probes that
+// lack a real decode window — see evaluateCanaryProbe).
+//
+// Grace is anchored to the PROVIDER ID, not the session: the first cold-start
+// arms an expiry (ConnectedAt + window) that is reused, never extended, across
+// reconnects, and only re-arms after a cooldown of one full window past that
+// expiry. This bounds a reconnect-churn attacker to at most a ~50% duty cycle
+// of waived TTFT — during the enforced windows a chronically-slow provider still
+// accrues canary failures and is sanctioned. Waived breaches are also logged.
 func (s *Server) canaryColdStartActive(provider pool.Provider) bool {
 	grace := s.cfg.Pool.CanaryColdStartGraceS
-	if grace <= 0 || provider.ConnectedAt.IsZero() {
+	if grace <= 0 || provider.ConnectedAt.IsZero() || strings.TrimSpace(provider.ProviderID) == "" {
 		return false
 	}
-	return s.now().Sub(provider.ConnectedAt) < time.Duration(grace)*time.Second
+	window := time.Duration(grace) * time.Second
+	now := s.now()
+	age := now.Sub(provider.ConnectedAt)
+	// Only a genuinely recent, non-future connect can trigger cold-start grace.
+	if age < 0 || age >= window {
+		return false
+	}
+	if v, ok := s.canaryGrace.Load(provider.ProviderID); ok {
+		exp := v.(time.Time)
+		if now.Before(exp) {
+			return true // grace already armed for this provider and still active
+		}
+		if now.Sub(exp) < window {
+			return false // recently expired — within cooldown, block reconnect-churn re-arm
+		}
+	}
+	// Arm (first cold-start, or a genuinely new one past the cooldown), anchored
+	// to this connect so grace never outlasts ConnectedAt + window.
+	s.canaryGrace.Store(provider.ProviderID, provider.ConnectedAt.Add(window))
+	return true
 }
 
 func (s *Server) buildCanaryBody(modelID string, maxTokens int) ([]byte, string, error) {

--- a/phase4-coordinator/internal/ws/server.go
+++ b/phase4-coordinator/internal/ws/server.go
@@ -2225,6 +2225,15 @@ func (s *Server) runCanaryProbe(provider pool.Provider) bool {
 			Int("max_ttft_ms", attempt.challenge.MaxTTFTMS).
 			Dur("connected_age", s.now().Sub(provider.ConnectedAt)).
 			Msg("provider canary TTFT gate waived during cold-start grace window")
+		// A graced (correct-but-TTFT-slow) probe is NEUTRAL for the canary
+		// sanction counter: it is not recorded, so it neither counts as a
+		// failure nor CLEARS failures accrued during enforced (non-grace)
+		// windows. Recording it as a pass would let a chronically-slow provider
+		// cycling at the grace/cooldown boundary reset the counter before it
+		// reaches the failure threshold and evade the TTFT sanction indefinitely
+		// (R2 SECURITY HIGH). Correctness + model-class OPoI identity were
+		// already recorded above; only the latency sanction is neutralized.
+		return true
 	}
 	passed := outcome == canaryProbePass
 	checkedAt := s.now()
@@ -2366,7 +2375,7 @@ func (s *Server) runWSCanaryProbeAttempt(ctx context.Context, provider pool.Prov
 				return canaryProbeFail, metrics
 			}
 			grace := s.canaryColdStartActive(provider)
-			if grace && probe.Challenge.MaxTTFTMS > 0 && metrics.TTFTMS > probe.Challenge.MaxTTFTMS {
+			if grace && challengeLatencyBreach(probe.Challenge, metrics) {
 				metrics.LatencyGraced = true
 			}
 			return evaluateCanaryProbe(probe.Challenge, output.String(), probe.Expected, metrics, grace), metrics
@@ -2415,7 +2424,7 @@ func (s *Server) runHTTPCanaryProbeAttempt(ctx context.Context, provider pool.Pr
 		metrics = canaryMetricsFromTiming(start, time.Time{}, completedAt, tokens)
 	}
 	grace := s.canaryColdStartActive(provider)
-	if grace && probe.Challenge.MaxTTFTMS > 0 && metrics.TTFTMS > probe.Challenge.MaxTTFTMS {
+	if grace && challengeLatencyBreach(probe.Challenge, metrics) {
 		metrics.LatencyGraced = true
 	}
 	return evaluateCanaryProbe(probe.Challenge, output, probe.Expected, metrics, grace), metrics

--- a/phase4-coordinator/internal/ws/server.go
+++ b/phase4-coordinator/internal/ws/server.go
@@ -59,11 +59,13 @@ type Server struct {
 	warmups         sync.Map
 	canaries        sync.Map
 	canaryDue       sync.Map
-	// canaryGrace maps provider ID -> cold-start grace expiry (time.Time).
-	// Keyed by PROVIDER ID (not session) so reconnect-churn cannot keep
-	// resetting ConnectedAt to stay perpetually inside grace. See
-	// canaryColdStartActive.
-	canaryGrace     sync.Map
+	// enforceNextCanary marks provider IDs (presence = true) whose NEXT canary
+	// probe must be enforced (no cold-start grace). Set after a graced-neutral
+	// probe and cleared after any recorded (enforced) probe, so a graced probe
+	// is always followed by an enforced one — a provider cannot arrange (via
+	// reconnect / due-timing churn) to only ever be probed under grace and evade
+	// the TTFT sanction. Keyed by PROVIDER ID so it survives reconnects.
+	enforceNextCanary sync.Map
 	canarySanctions CanarySanctionStore
 	tokens          TokenValidator
 	// SPEC-003 v0.8 FR-C9.1 — separate issuer field so validator and
@@ -2218,7 +2220,12 @@ func (s *Server) runCanaryProbe(provider pool.Provider) bool {
 		s.log.Debug().Str("provider_id", provider.ProviderID).Msg("provider canary skipped")
 		return false
 	}
-	if attempt.metrics.LatencyGraced {
+	// Neutral only when the probe PASSED because of grace. LatencyGraced is set
+	// on a latency breach before the correctness check, so a wrong-nonce answer
+	// that is also latency-breaching would otherwise be neutralized here and
+	// partially waive the correctness gate (R3 SECURITY/ARCHITECT HIGH). A
+	// failing (wrong-nonce) probe must fall through and be recorded as a failure.
+	if outcome == canaryProbePass && attempt.metrics.LatencyGraced {
 		s.log.Info().
 			Str("provider_id", provider.ProviderID).
 			Int("canary_ttft_ms", attempt.metrics.TTFTMS).
@@ -2227,14 +2234,17 @@ func (s *Server) runCanaryProbe(provider pool.Provider) bool {
 			Msg("provider canary TTFT gate waived during cold-start grace window")
 		// A graced (correct-but-TTFT-slow) probe is NEUTRAL for the canary
 		// sanction counter: it is not recorded, so it neither counts as a
-		// failure nor CLEARS failures accrued during enforced (non-grace)
-		// windows. Recording it as a pass would let a chronically-slow provider
-		// cycling at the grace/cooldown boundary reset the counter before it
-		// reaches the failure threshold and evade the TTFT sanction indefinitely
-		// (R2 SECURITY HIGH). Correctness + model-class OPoI identity were
-		// already recorded above; only the latency sanction is neutralized.
+		// failure nor CLEARS failures accrued on enforced probes (R2 SECURITY
+		// HIGH). It also FORCES the next probe to be enforced, so a
+		// chronically-slow provider cannot arrange (via reconnect / due-timing
+		// churn) to only ever be probed under grace (R3 SECURITY HIGH).
+		// Correctness + model-class OPoI identity were already recorded above.
+		s.enforceNextCanary.Store(provider.ProviderID, struct{}{})
 		return true
 	}
+	// This is an enforced (recorded) probe — clear any pending enforcement flag
+	// so a future genuine cold start can be graced again.
+	s.enforceNextCanary.Delete(provider.ProviderID)
 	passed := outcome == canaryProbePass
 	checkedAt := s.now()
 	result := s.pool.RecordCanaryResult(provider.ProviderID, provider.AssignedID, passed, checkedAt, s.canaryFailureThreshold())
@@ -2430,42 +2440,29 @@ func (s *Server) runHTTPCanaryProbeAttempt(ctx context.Context, provider pool.Pr
 	return evaluateCanaryProbe(probe.Challenge, output, probe.Expected, metrics, grace), metrics
 }
 
-// canaryColdStartActive reports whether the provider is within its cold-start
-// grace window since connecting, during which the max_ttft_ms latency gate is
-// relaxed (see PoolConfig.CanaryColdStartGraceS). The nonce-correctness gate is
-// never relaxed (and min_sustained_tps is relaxed only for HTTP probes that
-// lack a real decode window — see evaluateCanaryProbe).
-//
-// Grace is anchored to the PROVIDER ID, not the session: the first cold-start
-// arms an expiry (ConnectedAt + window) that is reused, never extended, across
-// reconnects, and only re-arms after a cooldown of one full window past that
-// expiry. This bounds a reconnect-churn attacker to at most a ~50% duty cycle
-// of waived TTFT — during the enforced windows a chronically-slow provider still
-// accrues canary failures and is sanctioned. Waived breaches are also logged.
+// canaryColdStartActive reports whether the next canary probe for this provider
+// should waive the wall-time latency gates (a freshly (re)connected provider may
+// still be cold-loading a large model). Grace applies only while the provider is
+// within the configured window since ConnectedAt AND its NEXT probe is not
+// flagged for enforcement. The nonce-correctness gate is never relaxed (see
+// evaluateCanaryProbe), and a graced probe is neutral for sanctions and forces
+// the following probe to be enforced (see runCanaryProbe), so a chronically-slow
+// provider cannot evade the TTFT sanction via reconnect / due-timing churn — it
+// still fails the interleaved enforced probes and accrues canary failures.
 func (s *Server) canaryColdStartActive(provider pool.Provider) bool {
 	grace := s.cfg.Pool.CanaryColdStartGraceS
 	if grace <= 0 || provider.ConnectedAt.IsZero() || strings.TrimSpace(provider.ProviderID) == "" {
 		return false
 	}
-	window := time.Duration(grace) * time.Second
-	now := s.now()
-	age := now.Sub(provider.ConnectedAt)
-	// Only a genuinely recent, non-future connect can trigger cold-start grace.
-	if age < 0 || age >= window {
+	age := s.now().Sub(provider.ConnectedAt)
+	// Only a genuinely recent, non-future connect is within the cold-start window.
+	if age < 0 || age >= time.Duration(grace)*time.Second {
 		return false
 	}
-	if v, ok := s.canaryGrace.Load(provider.ProviderID); ok {
-		exp := v.(time.Time)
-		if now.Before(exp) {
-			return true // grace already armed for this provider and still active
-		}
-		if now.Sub(exp) < window {
-			return false // recently expired — within cooldown, block reconnect-churn re-arm
-		}
+	// A graced probe must be followed by an enforced one before grace re-arms.
+	if _, mustEnforce := s.enforceNextCanary.Load(provider.ProviderID); mustEnforce {
+		return false
 	}
-	// Arm (first cold-start, or a genuinely new one past the cooldown), anchored
-	// to this connect so grace never outlasts ConnectedAt + window.
-	s.canaryGrace.Store(provider.ProviderID, provider.ConnectedAt.Add(window))
 	return true
 }
 

--- a/phase4-coordinator/internal/ws/server.go
+++ b/phase4-coordinator/internal/ws/server.go
@@ -2213,6 +2213,14 @@ func (s *Server) runCanaryProbe(provider pool.Provider) bool {
 		s.log.Debug().Str("provider_id", provider.ProviderID).Msg("provider canary skipped")
 		return false
 	}
+	if attempt.metrics.LatencyGraced {
+		s.log.Info().
+			Str("provider_id", provider.ProviderID).
+			Int("canary_ttft_ms", attempt.metrics.TTFTMS).
+			Int("max_ttft_ms", attempt.challenge.MaxTTFTMS).
+			Dur("connected_age", s.now().Sub(provider.ConnectedAt)).
+			Msg("provider canary TTFT gate waived during cold-start grace window")
+	}
 	passed := outcome == canaryProbePass
 	checkedAt := s.now()
 	result := s.pool.RecordCanaryResult(provider.ProviderID, provider.AssignedID, passed, checkedAt, s.canaryFailureThreshold())
@@ -2352,7 +2360,11 @@ func (s *Server) runWSCanaryProbeAttempt(ctx context.Context, provider pool.Prov
 			if end.Status != "complete" {
 				return canaryProbeFail, metrics
 			}
-			return evaluateCanaryProbe(probe.Challenge, output.String(), probe.Expected, metrics), metrics
+			grace := s.canaryColdStartActive(provider)
+			if grace && probe.Challenge.MaxTTFTMS > 0 && metrics.TTFTMS > probe.Challenge.MaxTTFTMS {
+				metrics.LatencyGraced = true
+			}
+			return evaluateCanaryProbe(probe.Challenge, output.String(), probe.Expected, metrics, grace), metrics
 		case <-relay.Errors:
 			return canaryProbeFail, canaryProbeMetrics{}
 		case <-ctx.Done():
@@ -2397,7 +2409,23 @@ func (s *Server) runHTTPCanaryProbeAttempt(ctx context.Context, provider pool.Pr
 		}
 		metrics = canaryMetricsFromTiming(start, time.Time{}, completedAt, tokens)
 	}
-	return evaluateCanaryProbe(probe.Challenge, output, probe.Expected, metrics), metrics
+	grace := s.canaryColdStartActive(provider)
+	if grace && probe.Challenge.MaxTTFTMS > 0 && metrics.TTFTMS > probe.Challenge.MaxTTFTMS {
+		metrics.LatencyGraced = true
+	}
+	return evaluateCanaryProbe(probe.Challenge, output, probe.Expected, metrics, grace), metrics
+}
+
+// canaryColdStartActive reports whether the provider is within its cold-start
+// grace window since connecting, during which the max_ttft_ms latency gate is
+// relaxed (see PoolConfig.CanaryColdStartGraceS). The nonce-correctness and
+// min_sustained_tps gates are never relaxed.
+func (s *Server) canaryColdStartActive(provider pool.Provider) bool {
+	grace := s.cfg.Pool.CanaryColdStartGraceS
+	if grace <= 0 || provider.ConnectedAt.IsZero() {
+		return false
+	}
+	return s.now().Sub(provider.ConnectedAt) < time.Duration(grace)*time.Second
 }
 
 func (s *Server) buildCanaryBody(modelID string, maxTokens int) ([]byte, string, error) {

--- a/phase4-coordinator/internal/ws/server.go
+++ b/phase4-coordinator/internal/ws/server.go
@@ -2242,15 +2242,20 @@ func (s *Server) runCanaryProbe(provider pool.Provider) bool {
 		s.enforceNextCanary.Store(provider.ProviderID, struct{}{})
 		return true
 	}
-	// This is an enforced (recorded) probe — clear any pending enforcement flag
-	// so a future genuine cold start can be graced again.
-	s.enforceNextCanary.Delete(provider.ProviderID)
 	passed := outcome == canaryProbePass
 	checkedAt := s.now()
 	result := s.pool.RecordCanaryResult(provider.ProviderID, provider.AssignedID, passed, checkedAt, s.canaryFailureThreshold())
 	if !result.Current {
+		// Stale session (the provider reconnected during this enforced probe):
+		// the result did NOT apply, so DO NOT clear enforceNextCanary — the next
+		// probe must still be enforced. Clearing it here would let a slow provider
+		// reconnect during every forced enforced probe and be graced again on the
+		// fresh session, re-opening the all-graced evasion (R4 SECURITY HIGH).
 		return false
 	}
+	// A current, enforced probe was recorded — clear the pending-enforcement flag
+	// so a future genuine cold start can be graced again.
+	s.enforceNextCanary.Delete(provider.ProviderID)
 	if passed {
 		if result.SanctionCleared {
 			s.deleteCanarySanction(provider.ProviderID)


### PR DESCRIPTION
## W3 canary cold-start grace — waive wall-time latency gates within the connect window

### Problem
A cold 30B model load produces ~8s TTFT on the first canary probe after a
provider (re)connects. That false-fails a static `max_ttft_ms` — the reason the
live Pearl tune had been forced to pad `max_ttft_ms` from 3500 up to 7000. The
padded value weakens the steady-state latency gate for every subsequent probe
just to survive one cold probe.

### Fix
New `pool.canary_cold_start_grace_s` (default `0` = off). For that many seconds
after a provider connects, the **wall-time** latency gates (`max_ttft_ms` **and**
`min_sustained_tps` — canary probes are non-streaming, so both are measured over
wall clock and are cold-contaminated) are **waived**. This lets `max_ttft_ms`
stay at the real production target (3500) instead of a padded 7000. Staging
overlay sets `300`.

The **nonce-correctness gate is never relaxed**, so anti-downgrade is unchanged.

### Sanction-safety model (hardened across 4 audit rounds)
The grace is on a security-sensitive sanction gate, so the model is deliberately
conservative:

- **Correctness first**: a wrong-nonce answer is recorded as a failure even
  inside the grace window — grace only ever waives *latency*, never correctness.
- **Graced probe is NEUTRAL**: a correct-but-slow graced probe is not recorded —
  it neither counts as a failure nor **clears** failures accrued on enforced
  probes.
- **Graced probe FORCES the next probe enforced**: `enforceNextCanary` is keyed
  by `ProviderID` and **persists across reconnect**; it is cleared only after a
  *current, recorded* enforced probe. So a chronically-slow provider cannot
  arrange (via reconnect / due-timing churn) to only ever be probed under grace —
  the interleaved enforced probes still sanction it.
- **Grace is connect-window bounded**: `canaryColdStartActive` returns false once
  `ConnectedAt` age ≥ window, on zero/empty `ConnectedAt`/`ProviderID`, or when
  `enforceNextCanary` is set. A provider connected longer than the window gets no
  grace at all.

A waived probe logs `provider canary TTFT gate waived during cold-start grace
window` with `canary_ttft_ms` + `connected_age`.

### Audit convergence (three-lane codex, bar 0 C/H/M)
| Round | Lane | Finding | Resolution |
|---|---|---|---|
| R1 | security | reconnect-churn resets grace; HTTP TPS gap | provider-ID anchoring |
| R2 | security | graced pass clears failure counter; false decode-window flag | graced-neutral; honest non-streaming metrics |
| R3 | security/architect | all-graced via due-timing; wrong-nonce neutralized | enforced-probe alternation; correctness-gated neutrality |
| R4 | security/architect | flag cleared before `Current=true` | clear enforce-next only after a current recorded probe |
| R5 | architect | — | **LANE PASS 0/0/0** |
| R5 | security | reconnect-mid-enforced-probe drops result | see below → R6 |
| R6 | security (attribution) | — | **PRE-EXISTING BASELINE**, not introduced/worsened by this diff |

### Carried finding (pre-existing baseline — NOT introduced by this change)
R5 security raised: a provider can reconnect mid-enforced-probe so
`RecordCanaryResult` returns `Current=false`, dropping the result without
recording a failure. R6 attribution audit confirmed this is **pre-existing
baseline** behavior of the canary session-currency model:
`origin/main` already contains the identical `if !result.Current { return false }`
drop (server.go 2218-2221) and the non-current return in `RecordCanaryResult`
(provider.go 1027-1029). This diff does **not** make the evasion easier, cheaper,
or more powerful — grace is connect-window bounded, wrong nonce still fails, and
`enforceNextCanary` survives reconnect so the forced enforced probe cannot be
re-armed into grace. A future subsystem-wide hardening (strike-on-stale-disconnect
during an in-flight enforced probe) would need careful false-positive handling
(honest Mac-sleep / WiFi-blip mid-probe disconnects) and is out of scope for W3.

### Config
```yaml
pool:
  canary_cold_start_grace_s: 300  # 0 = off (default)
```
Validation rejects negative values. Examples updated:
`coordinator.yaml.example`, `dist/coordinator.yaml.example`,
`coordinator.opoi-v0-staging.yaml` (staging → 300), runbook §5.

### Tests
- `canary_probe_test.go`: `evaluateCanaryProbe` grace cases;
  `TestCanaryColdStartActiveIsChurnSafe` (reconnect-alternation model).
- `config_test.go`: `TestCanaryColdStartGraceValidation`.
- `go build ./...`, `go vet`, `go test ./internal/ws ./internal/config` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
