### PR TITLE
fix(opoi): observe-only canary latency gates + fail-reason logging

### DIFF
--- a/ops/runbooks/proof-of-weights-implementation.md
+++ b/ops/runbooks/proof-of-weights-implementation.md
@@ -68,8 +68,9 @@ pool:
     qwen3-coder-30b-a3b-instruct:
       - prompt: What is the code {nonce}? Reply with only the code.
         expected: '{nonce}'
-        max_ttft_ms: 3500
+        max_ttft_ms: 7000        # non-streaming round-trip; keep generous
         min_sustained_tps: 20
+  canary_latency_enforcement: observe   # observe (default) | enforce
 ```
 
 **Export:** `model_class_opoi_pass` on `/poolz` when a model-class bank was used.
@@ -98,7 +99,34 @@ enforced-window fails), and it FORCES the next probe to be enforced (the
 so a reconnect mid-probe cannot re-open grace). A chronically-slow provider
 therefore still fails the interleaved enforced probes and is sanctioned. A waived
 probe logs `provider canary TTFT gate waived during cold-start grace window` with
-`canary_ttft_ms` + `connected_age`.
+`canary_ttft_ms` + `connected_age`. Grace only applies when
+`canary_latency_enforcement: enforce` (see below).
+
+**Latency enforcement mode (2026-07-09):** the wall-time latency gates
+(`max_ttft_ms` / `min_sustained_tps`) are **unreliable** on a non-streaming
+canary. The probe sends `stream:false`, so the coordinator has no real
+first-token boundary: measured `canary_ttft_ms` swings from ~125ms to ~7000ms and
+`canary_sustained_tps` from ~7 to ~27000 for the *same healthy provider*. During
+the W3 rollout, tightening Pearl `max_ttft_ms` to 3500 (matching the *streaming*
+buyer-probe TTFT of ~1200ms) made a warm provider fail the gate 3-in-a-row →
+sanctioned → intermittent buyer 503s. The buyer path is streaming and shows the
+true numbers; the non-streaming canary does not.
+
+`pool.canary_latency_enforcement` (default **`observe`**) governs whether a
+latency breach SANCTIONS:
+
+- **`observe`** (default): a nonce-correct probe that breaches a latency gate is
+  **not** failed; it logs `provider canary latency breach observed (not enforced)`
+  with `canary_latency_reason` + `canary_ttft_ms`/`canary_sustained_tps`. TPS is
+  also tracked by `proof_of_weights.telemetry_drift`. The nonce gate still
+  enforces (anti-downgrade unchanged).
+- **`enforce`**: latency breaches fail the probe (subject to
+  `canary_cold_start_grace_s`). Use ONLY after validating metric stability; keep
+  `max_ttft_ms >= 7000` to fit the non-streaming round-trip.
+
+The `provider canary failed` log now carries `canary_fail_reason`
+(`nonce_mismatch` | `ttft_breach` | `tps_breach` | `incomplete` | `relay_error`)
+so a prod failure is diagnosable.
 
 ---
 

--- a/ops/runbooks/proof-of-weights-implementation.md
+++ b/ops/runbooks/proof-of-weights-implementation.md
@@ -78,9 +78,17 @@ pool:
 **Pearl smoke (2026-07-08):**
 
 - Normal gates: `provider canary passed`, `model_class_opoi_pass: true`.
-- Induced fail: temporary `max_ttft_ms: 1` → `provider canary failed` with `canary_ttft_ms: 1124` (latency gate path). Overlay reverted to `max_ttft_ms: 3500`.
+- Induced-fail smoke exercises the latency SANCTION path only under
+  `canary_latency_enforcement: enforce`: temporarily set `enforce` +
+  `max_ttft_ms: 1` → `provider canary failed` with `canary_fail_reason:
+  ttft_breach`. Under the default `observe`, the same breach logs `provider
+  canary latency breach observed (not enforced)` and does NOT increment the
+  sanction counter. Restore `observe` (and `max_ttft_ms: 7000`) after.
+- **Restart-required:** `pool.canary_latency_enforcement` (and every `pool.*`
+  canary setting) is read at startup. SIGHUP reloads tier2 / billing config
+  only — flipping observe↔enforce needs a coordinator restart.
 
-Full downgrade cheat smoke (30B claim + 8B serve) requires a dedicated lab provider loading the wrong weights; latency gates exercise the same sanction path.
+Full downgrade cheat smoke (30B claim + 8B serve) requires a dedicated lab provider loading the wrong weights; the NONCE gate (always enforced) exercises the sanction path regardless of latency-enforcement mode.
 
 **Cold-start grace (2026-07-09):** a cold 30B load produces ~8s TTFT on
 reconnect, which false-fails a static `max_ttft_ms` (the reason the live tune

--- a/phase4-coordinator/coordinator.opoi-v0-staging.yaml
+++ b/phase4-coordinator/coordinator.opoi-v0-staging.yaml
@@ -31,6 +31,14 @@ pool:
   # and forces the next probe to be enforced. The real fix for the 3500→7000
   # cold-30B false-fail (see proof-of-weights-implementation.md §5).
   canary_cold_start_grace_s: 300
+  # Wall-time latency gates (max_ttft_ms / min_sustained_tps) are observe-only by
+  # default: the canary is non-streaming so those metrics are unreliable (real
+  # warm canary TTFT sits ~6s, TPS reads noisy). observe logs breaches without
+  # sanctioning; nonce-correctness always enforces. Flip to enforce ONLY after
+  # validating metric stability for the target providers (and keep max_ttft_ms
+  # generous — >= 7000 — to fit the non-streaming round-trip). See
+  # proof-of-weights-implementation.md §5.
+  canary_latency_enforcement: observe
   # Challenge bank — both entries embed {nonce} (hex, 4 bytes, upper-case).
   # Rotate periodically; keep this file deployment-specific.
   canary_challenges:
@@ -44,5 +52,7 @@ pool:
     qwen3-coder-30b-a3b-instruct:
       - prompt: "Reply with exactly: CANARY-{nonce}"
         expected: "CANARY-{nonce}"
-        max_ttft_ms: 3500
+        # Non-streaming canary round-trip for a warm 30B measures ~6s, so keep
+        # max_ttft_ms >= 7000 even in observe mode to avoid noisy breach logs.
+        max_ttft_ms: 7000
         min_sustained_tps: 20

--- a/phase4-coordinator/coordinator.yaml.example
+++ b/phase4-coordinator/coordinator.yaml.example
@@ -58,7 +58,10 @@ pool:
   # "observe": a latency breach on a nonce-correct probe is LOGGED
   # (provider canary latency breach observed) but does NOT fail the canary. Set
   # "enforce" only if you have validated the metric is stable for your providers.
-  # The nonce-correctness gate is ALWAYS enforced in both modes.
+  # The nonce-correctness gate is ALWAYS enforced in both modes. NOTE: like all
+  # pool.* canary settings this is read at startup only — SIGHUP reloads tier2 /
+  # billing config, NOT the pool block, so changing this requires a coordinator
+  # restart to take effect.
   canary_latency_enforcement: observe
   # OPoI v0 challenge bank — every entry must contain {nonce} in both prompt and expected.
   # Rotate or extend periodically; keep deployment-specific for model security.

--- a/phase4-coordinator/coordinator.yaml.example
+++ b/phase4-coordinator/coordinator.yaml.example
@@ -50,6 +50,16 @@ pool:
   canary_cold_start_grace_s: 300 # waive wall-time latency gates (max_ttft_ms +
                                  # min_sustained_tps) 300s after connect; nonce
                                  # always enforced, graced probe neutral+enforced-next
+                                 # (only meaningful when canary_latency_enforcement=enforce)
+  # canary_latency_enforcement controls whether the wall-time latency gates
+  # (max_ttft_ms / min_sustained_tps) SANCTION or are observe-only. Canary probes
+  # are non-streaming (stream:false), so these metrics are structurally unreliable
+  # (measured TTFT/TPS swing widely for the same healthy provider). Default
+  # "observe": a latency breach on a nonce-correct probe is LOGGED
+  # (provider canary latency breach observed) but does NOT fail the canary. Set
+  # "enforce" only if you have validated the metric is stable for your providers.
+  # The nonce-correctness gate is ALWAYS enforced in both modes.
+  canary_latency_enforcement: observe
   # OPoI v0 challenge bank — every entry must contain {nonce} in both prompt and expected.
   # Rotate or extend periodically; keep deployment-specific for model security.
   canary_challenges:

--- a/phase4-coordinator/dist/coordinator.yaml.example
+++ b/phase4-coordinator/dist/coordinator.yaml.example
@@ -73,6 +73,8 @@ pool:
                                 # wall-time latency gates are unreliable on a
                                 # non-streaming canary; observe logs breaches
                                 # without sanctioning. Nonce gate always enforced.
+                                # Startup-only (SIGHUP reloads tier2/billing, not
+                                # pool) — a restart is required to change it.
   # OPoI v0 challenge bank reference (enable in staging overlay, not here).
   # Every entry must contain {nonce} in both prompt and expected.
   # canary_challenges:

--- a/phase4-coordinator/dist/coordinator.yaml.example
+++ b/phase4-coordinator/dist/coordinator.yaml.example
@@ -67,7 +67,12 @@ pool:
                                 # non-streaming) for N s after connect (cold
                                 # load). Nonce-correctness always enforced; a
                                 # graced probe is neutral + forces the next
-                                # probe enforced. Set ~300 with latency gates.
+                                # probe enforced. Only meaningful with
+                                # canary_latency_enforcement=enforce.
+  canary_latency_enforcement: observe  # observe (default) | enforce. The
+                                # wall-time latency gates are unreliable on a
+                                # non-streaming canary; observe logs breaches
+                                # without sanctioning. Nonce gate always enforced.
   # OPoI v0 challenge bank reference (enable in staging overlay, not here).
   # Every entry must contain {nonce} in both prompt and expected.
   # canary_challenges:

--- a/phase4-coordinator/internal/config/config.go
+++ b/phase4-coordinator/internal/config/config.go
@@ -337,10 +337,35 @@ type PoolConfig struct {
 	// probe to be enforced — so this cannot be used to evade sanctions. Size it
 	// to cover a cold large-model load (observed ~8s TTFT for a cold 30B; a full
 	// load can take tens of seconds).
-	CanaryColdStartGraceS int                                `yaml:"canary_cold_start_grace_s"`
-	CanaryChallenges      []CanaryChallengeConfig            `yaml:"canary_challenges"`
-	ModelClassChallenges  map[string][]CanaryChallengeConfig `yaml:"model_class_challenges"`
-	LosslessnessProbe     LosslessnessProbeConfig            `yaml:"losslessness_probe"`
+	CanaryColdStartGraceS int `yaml:"canary_cold_start_grace_s"`
+	// CanaryLatencyEnforcement controls whether the WALL-TIME latency gates
+	// (max_ttft_ms / min_sustained_tps) SANCTION a provider or are observe-only.
+	// Canary probes are non-streaming (stream:false), so these wall-time metrics
+	// are structurally unreliable — measured TTFT/TPS swing widely for the same
+	// healthy provider depending on relay chunk timing. Default "observe": a
+	// latency breach on a nonce-correct probe is logged (canary_latency_observed)
+	// but does NOT count as a canary failure. "enforce": a latency breach fails
+	// the probe (subject to CanaryColdStartGraceS). The nonce-correctness gate is
+	// ALWAYS enforced in both modes. Empty = "observe".
+	CanaryLatencyEnforcement string                             `yaml:"canary_latency_enforcement"`
+	CanaryChallenges         []CanaryChallengeConfig            `yaml:"canary_challenges"`
+	ModelClassChallenges     map[string][]CanaryChallengeConfig `yaml:"model_class_challenges"`
+	LosslessnessProbe        LosslessnessProbeConfig            `yaml:"losslessness_probe"`
+}
+
+// CanaryLatencyMode normalizes CanaryLatencyEnforcement (empty defaults to
+// observe).
+func (p PoolConfig) CanaryLatencyMode() string {
+	if strings.EqualFold(strings.TrimSpace(p.CanaryLatencyEnforcement), "enforce") {
+		return "enforce"
+	}
+	return "observe"
+}
+
+// CanaryLatencyEnforced reports whether latency-gate breaches sanction the
+// provider (enforce mode) or are observe-only (default).
+func (p PoolConfig) CanaryLatencyEnforced() bool {
+	return p.CanaryLatencyMode() == "enforce"
 }
 
 type CanaryChallengeConfig struct {
@@ -1434,6 +1459,11 @@ func (c Config) Validate() error {
 	}
 	if c.Pool.CanaryColdStartGraceS < 0 {
 		return fmt.Errorf("pool canary_cold_start_grace_s must be >= 0")
+	}
+	switch strings.ToLower(strings.TrimSpace(c.Pool.CanaryLatencyEnforcement)) {
+	case "", "observe", "enforce":
+	default:
+		return fmt.Errorf("pool canary_latency_enforcement must be \"observe\" or \"enforce\"")
 	}
 	if c.Pool.CanaryEnabled {
 		if len(c.Pool.CanaryChallenges) == 0 && len(c.Pool.ModelClassChallenges) == 0 {

--- a/phase4-coordinator/internal/config/config_test.go
+++ b/phase4-coordinator/internal/config/config_test.go
@@ -150,6 +150,35 @@ func TestCanaryColdStartGraceValidation(t *testing.T) {
 	}
 }
 
+func TestCanaryLatencyEnforcementValidation(t *testing.T) {
+	cfg := Default()
+	cfg.Auth.OperatorKey = "operator-key"
+
+	// Default (empty) normalizes to observe and validates.
+	if cfg.Pool.CanaryLatencyEnforcement != "" {
+		t.Fatalf("default canary_latency_enforcement should be empty, got %q", cfg.Pool.CanaryLatencyEnforcement)
+	}
+	if cfg.Pool.CanaryLatencyMode() != "observe" || cfg.Pool.CanaryLatencyEnforced() {
+		t.Fatalf("empty enforcement must normalize to observe (not enforced)")
+	}
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("empty enforcement should validate: %v", err)
+	}
+	for _, mode := range []string{"observe", "enforce", "ENFORCE", "Observe"} {
+		cfg.Pool.CanaryLatencyEnforcement = mode
+		if err := cfg.Validate(); err != nil {
+			t.Fatalf("mode %q should validate: %v", mode, err)
+		}
+	}
+	if cfg.Pool.CanaryLatencyEnforcement = "enforce"; !cfg.Pool.CanaryLatencyEnforced() {
+		t.Fatal("enforce mode must report enforced")
+	}
+	cfg.Pool.CanaryLatencyEnforcement = "sanction"
+	if err := cfg.Validate(); err == nil || !strings.Contains(err.Error(), "canary_latency_enforcement") {
+		t.Fatalf("invalid enforcement should fail validation, got %v", err)
+	}
+}
+
 func TestProviderWebSocketBoundsDefaultAndValidate(t *testing.T) {
 	cfg := Default()
 	cfg.Auth.OperatorKey = "operator-key"

--- a/phase4-coordinator/internal/ws/canary_probe.go
+++ b/phase4-coordinator/internal/ws/canary_probe.go
@@ -34,7 +34,23 @@ type canaryProbeMetrics struct {
 	// cold-start grace window. Surfaced in logs so a genuinely-slow provider
 	// hiding behind grace stays visible.
 	LatencyGraced bool
+	// FailReason records WHY a probe failed (nonce_mismatch, ttft_breach,
+	// tps_breach, incomplete, relay_error) so prod canary-failure logs are
+	// diagnosable. Empty on a pass.
+	FailReason canaryFailReason
 }
+
+// canaryFailReason identifies why a canary probe failed. Empty on pass.
+type canaryFailReason string
+
+const (
+	canaryFailNone       canaryFailReason = ""
+	canaryFailNonce      canaryFailReason = "nonce_mismatch"
+	canaryFailTTFT       canaryFailReason = "ttft_breach"
+	canaryFailTPS        canaryFailReason = "tps_breach"
+	canaryFailIncomplete canaryFailReason = "incomplete"
+	canaryFailRelay      canaryFailReason = "relay_error"
+)
 
 type canaryAttemptResult struct {
 	outcome        canaryProbeOutcome
@@ -102,37 +118,47 @@ func challengeHasLatencyGates(challenge config.CanaryChallengeConfig) bool {
 	return challenge.MaxTTFTMS > 0 || challenge.MinSustainedTPS > 0
 }
 
+// latencyBreachReason returns the specific latency gate the metrics violate
+// (ttft_breach checked before tps_breach), or canaryFailNone if neither.
+func latencyBreachReason(challenge config.CanaryChallengeConfig, metrics canaryProbeMetrics) canaryFailReason {
+	if challenge.MaxTTFTMS > 0 && metrics.TTFTMS > challenge.MaxTTFTMS {
+		return canaryFailTTFT
+	}
+	if challenge.MinSustainedTPS > 0 && (math.IsNaN(metrics.SustainedTPS) || math.IsInf(metrics.SustainedTPS, 0) || metrics.SustainedTPS < challenge.MinSustainedTPS) {
+		return canaryFailTPS
+	}
+	return canaryFailNone
+}
+
 // challengeLatencyBreach reports whether the probe metrics violate a configured
 // latency gate (max_ttft_ms or min_sustained_tps).
 func challengeLatencyBreach(challenge config.CanaryChallengeConfig, metrics canaryProbeMetrics) bool {
-	if challenge.MaxTTFTMS > 0 && metrics.TTFTMS > challenge.MaxTTFTMS {
-		return true
-	}
-	if challenge.MinSustainedTPS > 0 && (math.IsNaN(metrics.SustainedTPS) || math.IsInf(metrics.SustainedTPS, 0) || metrics.SustainedTPS < challenge.MinSustainedTPS) {
-		return true
-	}
-	return false
+	return latencyBreachReason(challenge, metrics) != canaryFailNone
 }
 
-// evaluateCanaryProbe returns the probe outcome. The nonce-correctness gate
-// (model identity / anti-downgrade) is ALWAYS enforced. When coldStartGrace is
-// true, BOTH latency gates are waived: canary probes are non-streaming
-// (stream:false), so max_ttft_ms and min_sustained_tps are both measured over
-// wall time (no reliable first-token/decode split) and are dominated by a cold
-// model load. A graced probe is additionally NEUTRAL for the sanction counter
-// (see runCanaryProbe), so waiving the latency gates here cannot be abused to
-// clear enforced-window failures.
-func evaluateCanaryProbe(challenge config.CanaryChallengeConfig, output string, expected string, metrics canaryProbeMetrics, coldStartGrace bool) canaryProbeOutcome {
+// evaluateCanaryProbe returns the probe outcome and, on failure, the reason.
+// The nonce-correctness gate (model identity / anti-downgrade) is ALWAYS
+// enforced. The wall-time latency gates (max_ttft_ms / min_sustained_tps)
+// SANCTION only when enforceLatency is true — canary probes are non-streaming
+// (stream:false), so those metrics are structurally unreliable, and observe
+// mode (the default) never fails a nonce-correct probe on latency. When
+// enforceLatency is true, coldStartGrace additionally waives BOTH latency gates
+// for the cold-start window; a graced probe is NEUTRAL for the sanction counter
+// (see runCanaryProbe), so waiving cannot be abused to clear enforced-window
+// failures.
+func evaluateCanaryProbe(challenge config.CanaryChallengeConfig, output string, expected string, metrics canaryProbeMetrics, coldStartGrace bool, enforceLatency bool) (canaryProbeOutcome, canaryFailReason) {
 	if !canaryAnswerMatches(output, expected) {
-		return canaryProbeFail
+		return canaryProbeFail, canaryFailNonce
 	}
-	if coldStartGrace {
-		return canaryProbePass
+	// Nonce correct. Latency gates sanction only in enforce mode, and are waived
+	// during the cold-start grace window even then.
+	if !enforceLatency || coldStartGrace {
+		return canaryProbePass, canaryFailNone
 	}
-	if challengeLatencyBreach(challenge, metrics) {
-		return canaryProbeFail
+	if reason := latencyBreachReason(challenge, metrics); reason != canaryFailNone {
+		return canaryProbeFail, reason
 	}
-	return canaryProbePass
+	return canaryProbePass, canaryFailNone
 }
 
 func canaryMetricsFromTiming(start time.Time, firstTokenAt time.Time, completedAt time.Time, completionTokens int) canaryProbeMetrics {

--- a/phase4-coordinator/internal/ws/canary_probe_test.go
+++ b/phase4-coordinator/internal/ws/canary_probe_test.go
@@ -16,32 +16,38 @@ func TestEvaluateCanaryProbeLatencyGates(t *testing.T) {
 		MaxTTFTMS:       800,
 		MinSustainedTPS: 12,
 	}
-	pass := evaluateCanaryProbe(challenge, "ABCD", "ABCD", canaryProbeMetrics{TTFTMS: 700, SustainedTPS: 15}, false)
-	if pass != canaryProbePass {
-		t.Fatalf("latency pass = %q", pass)
+	// grace=false, enforce=true throughout this block (steady-state enforce mode).
+	eval := func(out string, m canaryProbeMetrics, grace bool) (canaryProbeOutcome, canaryFailReason) {
+		return evaluateCanaryProbe(challenge, out, "ABCD", m, grace, true)
 	}
-	if evaluateCanaryProbe(challenge, "ABCD", "ABCD", canaryProbeMetrics{TTFTMS: 900, SustainedTPS: 15}, false) != canaryProbeFail {
-		t.Fatal("expected ttft fail")
+	if o, r := eval("ABCD", canaryProbeMetrics{TTFTMS: 700, SustainedTPS: 15}, false); o != canaryProbePass || r != canaryFailNone {
+		t.Fatalf("enforce within gates = %q/%q", o, r)
 	}
-	if evaluateCanaryProbe(challenge, "ABCD", "ABCD", canaryProbeMetrics{TTFTMS: 700, SustainedTPS: 8}, false) != canaryProbeFail {
-		t.Fatal("expected tps fail")
+	if o, r := eval("ABCD", canaryProbeMetrics{TTFTMS: 900, SustainedTPS: 15}, false); o != canaryProbeFail || r != canaryFailTTFT {
+		t.Fatalf("expected ttft_breach, got %q/%q", o, r)
 	}
-	if evaluateCanaryProbe(challenge, "wrong", "ABCD", canaryProbeMetrics{TTFTMS: 700, SustainedTPS: 15}, false) != canaryProbeFail {
-		t.Fatal("expected answer fail")
+	if o, r := eval("ABCD", canaryProbeMetrics{TTFTMS: 700, SustainedTPS: 8}, false); o != canaryProbeFail || r != canaryFailTPS {
+		t.Fatalf("expected tps_breach, got %q/%q", o, r)
 	}
-	// Cold-start grace waives BOTH wall-time latency gates (canary probes are
-	// non-streaming, so max_ttft_ms and min_sustained_tps are both cold-
-	// contaminated): a slow-but-correct answer passes.
-	if evaluateCanaryProbe(challenge, "ABCD", "ABCD", canaryProbeMetrics{TTFTMS: 9000, SustainedTPS: 8}, true) != canaryProbePass {
-		t.Fatal("expected cold-start grace to waive both latency gates for a correct answer")
+	if o, r := eval("wrong", canaryProbeMetrics{TTFTMS: 700, SustainedTPS: 15}, false); o != canaryProbeFail || r != canaryFailNonce {
+		t.Fatalf("expected nonce_mismatch, got %q/%q", o, r)
+	}
+	// Cold-start grace waives BOTH wall-time latency gates (enforce mode).
+	if o, r := eval("ABCD", canaryProbeMetrics{TTFTMS: 9000, SustainedTPS: 8}, true); o != canaryProbePass || r != canaryFailNone {
+		t.Fatalf("expected grace to waive both latency gates, got %q/%q", o, r)
 	}
 	// Grace never waives the answer-correctness gate.
-	if evaluateCanaryProbe(challenge, "wrong", "ABCD", canaryProbeMetrics{TTFTMS: 9000, SustainedTPS: 15}, true) != canaryProbeFail {
-		t.Fatal("cold-start grace must NOT waive the answer-correctness gate")
+	if o, r := eval("wrong", canaryProbeMetrics{TTFTMS: 9000, SustainedTPS: 15}, true); o != canaryProbeFail || r != canaryFailNonce {
+		t.Fatalf("grace must NOT waive nonce gate, got %q/%q", o, r)
 	}
-	// Without grace, both latency gates are still enforced.
-	if evaluateCanaryProbe(challenge, "ABCD", "ABCD", canaryProbeMetrics{TTFTMS: 700, SustainedTPS: 8}, false) != canaryProbeFail {
-		t.Fatal("without grace the sustained-tps gate must still fail")
+
+	// Observe mode (default): a nonce-correct probe NEVER fails on latency, even
+	// with a hard breach and no grace. The nonce gate still enforces.
+	if o, r := evaluateCanaryProbe(challenge, "ABCD", "ABCD", canaryProbeMetrics{TTFTMS: 9000, SustainedTPS: 1}, false, false); o != canaryProbePass || r != canaryFailNone {
+		t.Fatalf("observe mode must not sanction latency, got %q/%q", o, r)
+	}
+	if o, r := evaluateCanaryProbe(challenge, "wrong", "ABCD", canaryProbeMetrics{TTFTMS: 700, SustainedTPS: 15}, false, false); o != canaryProbeFail || r != canaryFailNonce {
+		t.Fatalf("observe mode must still enforce nonce, got %q/%q", o, r)
 	}
 }
 

--- a/phase4-coordinator/internal/ws/server.go
+++ b/phase4-coordinator/internal/ws/server.go
@@ -2239,6 +2239,21 @@ func (s *Server) runCanaryProbe(provider pool.Provider) bool {
 		s.log.Debug().Str("provider_id", provider.ProviderID).Msg("provider canary skipped")
 		return false
 	}
+	// Observe mode (default): a nonce-correct probe that breaches a wall-time
+	// latency gate is NOT sanctioned (the non-streaming metric is unreliable),
+	// but the breach is logged so operators keep the signal. TPS drift is also
+	// tracked via proof_of_weights.telemetry_drift.
+	if outcome == canaryProbePass && attempt.modelClassBank && !s.cfg.Pool.CanaryLatencyEnforced() &&
+		challengeLatencyBreach(attempt.challenge, attempt.metrics) {
+		s.log.Info().
+			Str("provider_id", provider.ProviderID).
+			Str("canary_latency_reason", string(latencyBreachReason(attempt.challenge, attempt.metrics))).
+			Int("canary_ttft_ms", attempt.metrics.TTFTMS).
+			Int("max_ttft_ms", attempt.challenge.MaxTTFTMS).
+			Float64("canary_sustained_tps", attempt.metrics.SustainedTPS).
+			Float64("min_sustained_tps", attempt.challenge.MinSustainedTPS).
+			Msg("provider canary latency breach observed (not enforced)")
+	}
 	// Neutral only when the probe PASSED because of grace. LatencyGraced is set
 	// on a latency breach before the correctness check, so a wrong-nonce answer
 	// that is also latency-breaching would otherwise be neutralized here and
@@ -2288,6 +2303,9 @@ func (s *Server) runCanaryProbe(provider pool.Provider) bool {
 		Str("provider_id", provider.ProviderID).
 		Int("canary_fail_count", result.Count).
 		Int("canary_failure_threshold", result.Threshold)
+	if attempt.metrics.FailReason != canaryFailNone {
+		event = event.Str("canary_fail_reason", string(attempt.metrics.FailReason))
+	}
 	if result.Tripped != pool.CanaryTripNone {
 		event = event.Str("canary_trip", string(result.Tripped))
 	}
@@ -2406,17 +2424,21 @@ func (s *Server) runWSCanaryProbeAttempt(ctx context.Context, provider pool.Prov
 				metrics = canaryMetricsFromTiming(start, firstTokenAt, completedAt, tokens)
 			}
 			if end.Status != "complete" {
+				metrics.FailReason = canaryFailIncomplete
 				return canaryProbeFail, metrics
 			}
-			grace := s.canaryColdStartActive(provider)
+			enforceLatency := s.cfg.Pool.CanaryLatencyEnforced()
+			grace := enforceLatency && s.canaryColdStartActive(provider)
 			if grace && challengeLatencyBreach(probe.Challenge, metrics) {
 				metrics.LatencyGraced = true
 			}
-			return evaluateCanaryProbe(probe.Challenge, output.String(), probe.Expected, metrics, grace), metrics
+			outcome, reason := evaluateCanaryProbe(probe.Challenge, output.String(), probe.Expected, metrics, grace, enforceLatency)
+			metrics.FailReason = reason
+			return outcome, metrics
 		case <-relay.Errors:
-			return canaryProbeFail, canaryProbeMetrics{}
+			return canaryProbeFail, canaryProbeMetrics{FailReason: canaryFailRelay}
 		case <-ctx.Done():
-			return canaryProbeFail, canaryProbeMetrics{}
+			return canaryProbeFail, canaryProbeMetrics{FailReason: canaryFailRelay}
 		}
 	}
 }
@@ -2434,15 +2456,15 @@ func (s *Server) runHTTPCanaryProbeAttempt(ctx context.Context, provider pool.Pr
 	req.Header.Set("Content-Type", "application/json")
 	resp, err := providerhttp.Client.Do(req)
 	if err != nil {
-		return canaryProbeFail, canaryProbeMetrics{}
+		return canaryProbeFail, canaryProbeMetrics{FailReason: canaryFailRelay}
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
-		return canaryProbeFail, canaryProbeMetrics{}
+		return canaryProbeFail, canaryProbeMetrics{FailReason: canaryFailRelay}
 	}
 	raw, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
 	if err != nil {
-		return canaryProbeFail, canaryProbeMetrics{}
+		return canaryProbeFail, canaryProbeMetrics{FailReason: canaryFailRelay}
 	}
 	completedAt := time.Now()
 	output := strings.Join(canaryPayloadContents(raw), "")
@@ -2457,11 +2479,14 @@ func (s *Server) runHTTPCanaryProbeAttempt(ctx context.Context, provider pool.Pr
 		}
 		metrics = canaryMetricsFromTiming(start, time.Time{}, completedAt, tokens)
 	}
-	grace := s.canaryColdStartActive(provider)
+	enforceLatency := s.cfg.Pool.CanaryLatencyEnforced()
+	grace := enforceLatency && s.canaryColdStartActive(provider)
 	if grace && challengeLatencyBreach(probe.Challenge, metrics) {
 		metrics.LatencyGraced = true
 	}
-	return evaluateCanaryProbe(probe.Challenge, output, probe.Expected, metrics, grace), metrics
+	outcome, reason := evaluateCanaryProbe(probe.Challenge, output, probe.Expected, metrics, grace, enforceLatency)
+	metrics.FailReason = reason
+	return outcome, metrics
 }
 
 // canaryColdStartActive reports whether the next canary probe for this provider


### PR DESCRIPTION
## Canary latency gates → observe-only by default + fail-reason logging

### Why
The coordinator pool canary sends `stream:false` (non-streaming). Its wall-time
latency metrics are therefore **structurally unreliable** — measured
`canary_ttft_ms` swings ~125ms↔7000ms and `canary_sustained_tps` ~7↔27000 for the
**same healthy provider**, depending on relay chunk timing. The streaming buyer
path shows the true numbers (TTFT ~1200ms, ~30 TPS); the canary does not.

This bit us in prod on 2026-07-09: tightening Pearl `max_ttft_ms` to 3500 (to
match the buyer-probe TTFT) made a warm provider fail the latency gate 3-in-a-row
→ sanctioned → `pool_ready:0` → intermittent buyer 503s. Mitigated live by
reverting to 7000. This PR is the durable fix.

### What
- **`pool.canary_latency_enforcement`** (default **`observe`**): a nonce-correct
  probe that breaches a wall-time latency gate (`max_ttft_ms` / `min_sustained_tps`)
  is **logged** (`provider canary latency breach observed (not enforced)`) but
  **not failed**. `enforce` preserves the exact prior W3 cold-start-grace
  behavior. The **nonce-correctness gate is ALWAYS enforced** in both modes, so
  anti-downgrade is unchanged. TPS is also watched observe-only via
  `proof_of_weights.telemetry_drift`.
- **`canary_fail_reason`** on the `provider canary failed` log
  (`nonce_mismatch` | `ttft_breach` | `tps_breach` | `incomplete` | `relay_error`)
  — prod canary failures were previously undiagnosable (no reason field).
- Grace (`canaryColdStartActive` / `LatencyGraced`) is evaluated **only** in
  enforce mode.
- Config examples / staging overlay / runbook §5 updated: default observe, keep
  `max_ttft_ms >= 7000` for the non-streaming round-trip, and **startup-only**
  (SIGHUP reloads tier2/billing, not pool — a restart is required to flip).

### Security invariants preserved (enforce mode)
Nonce wrong → always fail; graced probe neutral for the sanction counter AND
forces the next probe enforced; enforce-next flag cleared only after a current
recorded probe; reconnect/churn cannot arrange all-graced. Observe mode only
relaxes the (unreliable) latency sanction — never nonce.

### Audit (three-lane codex, bar 0 C/H/M)
| Round | Code | Security | Architect |
|---|---|---|---|
| R1 | **PASS 0/0/0** | 2 MEDIUM (SIGHUP-reload doc gap; stale runbook smoke) | **PASS 0/0/0** |
| R2 | — (unchanged) | **PASS 0/0/0** (both fixed, docs-only) | — (unchanged) |

### Tests
`TestEvaluateCanaryProbeLatencyGates` (enforce + observe + all fail reasons),
`TestCanaryLatencyEnforcementValidation`. `go build ./...`, `go vet`,
`go test ./internal/ws ./internal/config` green.

### Follow-up for the operator
This ships `observe` as the default, so once deployed the Pearl latency gates
stop sanctioning (nonce still enforces). At that point `min_sustained_tps` can
stay configured for the observe signal without ban risk. Flipping to `enforce`
later requires validating metric stability first (and a restart).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
