### PR TITLE
Preserve no-provider 5xx audit rows

### DIFF
--- a/phase5-gateway/internal/router/chat_proxy.go
+++ b/phase5-gateway/internal/router/chat_proxy.go
@@ -402,7 +402,7 @@ func (s *Server) handleChatCompletions(w http.ResponseWriter, r *http.Request) {
 		s.forwardStreamingChat(w, r, resp, subject, promptEstimate, maxUsageTokens, maxTokens, retryExhausted, cancelUpstream, upCtx, structuredStreaming, window, timing)
 		return
 	}
-	s.forwardNonStreamingChat(w, r, resp, subject, promptEstimate, maxUsageTokens, maxTokens, retryExhausted)
+	s.forwardNonStreamingChat(w, r, resp, subject, promptEstimate, maxUsageTokens, maxTokens, retryExhausted, window)
 }
 
 func (s *Server) doCoordinatorChatWithRetry(upCtx context.Context, r *http.Request, accountID string, buildUpReq func() (*http.Request, error)) (*http.Response, bool, error) {
@@ -563,7 +563,7 @@ func (b *coord503PrefixErrBody) Read(p []byte) (int, error) {
 
 func (b *coord503PrefixErrBody) Close() error { return nil }
 
-func (s *Server) forwardNonStreamingChat(w http.ResponseWriter, r *http.Request, resp *http.Response, subject usageSubject, promptEstimate, maxUsageTokens, maxTokens int64, retryExhausted bool) {
+func (s *Server) forwardNonStreamingChat(w http.ResponseWriter, r *http.Request, resp *http.Response, subject usageSubject, promptEstimate, maxUsageTokens, maxTokens int64, retryExhausted bool, window string) {
 	body, err := readLimitedBody(resp.Body, maxUpstreamResponseBodyBytes)
 	if err != nil {
 		_ = s.store.RefundReservation(context.Background(), subject.AccountID, requestID(r), s.now().Unix())
@@ -576,10 +576,10 @@ func (s *Server) forwardNonStreamingChat(w http.ResponseWriter, r *http.Request,
 			return
 		}
 		if coordinatorTier2PolicyError(resp.StatusCode, body) {
-			s.passThroughNoProviderCoordinatorError(w, r, resp, subject, body, promptEstimate, maxUsageTokens, retryExhausted)
+			s.passThroughNoProviderCoordinatorError(w, r, resp, subject, body, promptEstimate, maxUsageTokens, retryExhausted, window)
 			return
 		}
-		s.passThroughNoProviderCoordinatorError(w, r, resp, subject, body, promptEstimate, maxUsageTokens, retryExhausted)
+		s.passThroughNoProviderCoordinatorError(w, r, resp, subject, body, promptEstimate, maxUsageTokens, retryExhausted, window)
 		return
 	}
 	if resp.StatusCode == http.StatusGatewayTimeout {
@@ -595,20 +595,20 @@ func (s *Server) forwardNonStreamingChat(w http.ResponseWriter, r *http.Request,
 	// reservation and pass the OpenAI-shaped error body through verbatim so
 	// the buyer sees an actionable 404 instead of an opaque 502.
 	if resp.StatusCode == http.StatusNotFound {
-		s.passThroughNoProviderCoordinatorError(w, r, resp, subject, body, promptEstimate, maxUsageTokens, retryExhausted)
+		s.passThroughNoProviderCoordinatorError(w, r, resp, subject, body, promptEstimate, maxUsageTokens, retryExhausted, window)
 		return
 	}
 	if coordinatorTier2PolicyError(resp.StatusCode, body) {
-		s.passThroughNoProviderCoordinatorError(w, r, resp, subject, body, promptEstimate, maxUsageTokens, retryExhausted)
+		s.passThroughNoProviderCoordinatorError(w, r, resp, subject, body, promptEstimate, maxUsageTokens, retryExhausted, window)
 		return
 	}
 	if coordinatorIdempotencyError(resp.StatusCode, body) {
-		s.passThroughNoProviderCoordinatorError(w, r, resp, subject, body, promptEstimate, maxUsageTokens, retryExhausted)
+		s.passThroughNoProviderCoordinatorError(w, r, resp, subject, body, promptEstimate, maxUsageTokens, retryExhausted, window)
 		return
 	}
 	if resp.StatusCode != http.StatusOK {
 		if coordinatorValidationError(resp.StatusCode, body) {
-			s.passThroughNoProviderCoordinatorError(w, r, resp, subject, body, promptEstimate, maxUsageTokens, retryExhausted)
+			s.passThroughNoProviderCoordinatorError(w, r, resp, subject, body, promptEstimate, maxUsageTokens, retryExhausted, window)
 			return
 		}
 		if isNullUsageProviderError(body) {
@@ -676,10 +676,10 @@ func (s *Server) forwardStreamingChat(w http.ResponseWriter, r *http.Request, re
 	if resp.StatusCode == http.StatusServiceUnavailable {
 		body, _ := io.ReadAll(resp.Body)
 		if coordinatorTier2PolicyError(resp.StatusCode, body) {
-			s.passThroughNoProviderCoordinatorError(w, r, resp, subject, body, promptEstimate, maxUsageTokens, retryExhausted)
+			s.passThroughNoProviderCoordinatorError(w, r, resp, subject, body, promptEstimate, maxUsageTokens, retryExhausted, reservationWindow)
 			return
 		}
-		s.passThroughNoProviderCoordinatorError(w, r, resp, subject, body, promptEstimate, maxUsageTokens, retryExhausted)
+		s.passThroughNoProviderCoordinatorError(w, r, resp, subject, body, promptEstimate, maxUsageTokens, retryExhausted, reservationWindow)
 		return
 	}
 	if resp.StatusCode != http.StatusOK {
@@ -696,20 +696,20 @@ func (s *Server) forwardStreamingChat(w http.ResponseWriter, r *http.Request, re
 		// See forwardNonStreamingChat for the matching non-stream branch.
 		if resp.StatusCode == http.StatusNotFound {
 			body, _ := io.ReadAll(resp.Body)
-			s.passThroughNoProviderCoordinatorError(w, r, resp, subject, body, promptEstimate, maxUsageTokens, retryExhausted)
+			s.passThroughNoProviderCoordinatorError(w, r, resp, subject, body, promptEstimate, maxUsageTokens, retryExhausted, reservationWindow)
 			return
 		}
 		body, _ := io.ReadAll(resp.Body)
 		if coordinatorValidationError(resp.StatusCode, body) {
-			s.passThroughNoProviderCoordinatorError(w, r, resp, subject, body, promptEstimate, maxUsageTokens, retryExhausted)
+			s.passThroughNoProviderCoordinatorError(w, r, resp, subject, body, promptEstimate, maxUsageTokens, retryExhausted, reservationWindow)
 			return
 		}
 		if coordinatorIdempotencyError(resp.StatusCode, body) {
-			s.passThroughNoProviderCoordinatorError(w, r, resp, subject, body, promptEstimate, maxUsageTokens, retryExhausted)
+			s.passThroughNoProviderCoordinatorError(w, r, resp, subject, body, promptEstimate, maxUsageTokens, retryExhausted, reservationWindow)
 			return
 		}
 		if coordinatorTier2PolicyError(resp.StatusCode, body) {
-			s.passThroughNoProviderCoordinatorError(w, r, resp, subject, body, promptEstimate, maxUsageTokens, retryExhausted)
+			s.passThroughNoProviderCoordinatorError(w, r, resp, subject, body, promptEstimate, maxUsageTokens, retryExhausted, reservationWindow)
 			return
 		}
 		if !s.settleBeforeStreamingResponseWithCoordinatorFinality(w, r, subject, promptEstimate, completionFromHeaderCapped(resp.Header, maxTokens), maxUsageTokens, "gateway_estimated", "upstream_error", resp.Header) {
@@ -1064,15 +1064,20 @@ func (s *Server) forwardStreamingChat(w http.ResponseWriter, r *http.Request, re
 	s.settleStreamingAfterCommitWithCoordinatorFinality(r, subject, promptEstimate, completion, maxUsageTokens, "gateway_estimated", outcome, reservationWindow, resp)
 }
 
-func (s *Server) passThroughNoProviderCoordinatorError(w http.ResponseWriter, r *http.Request, resp *http.Response, subject usageSubject, body []byte, promptEstimate, maxUsageTokens int64, retryExhausted bool) {
-	if retryExhausted &&
-		len(bytes.TrimSpace(body)) > 0 &&
-		isCoordNoProviderAvailable503(resp.StatusCode, body) {
-		if !s.settleBeforeResponse(w, r, subject, promptEstimate, 0, maxUsageTokens, "gateway_estimated", "no_provider_available") {
+func (s *Server) passThroughNoProviderCoordinatorError(w http.ResponseWriter, r *http.Request, resp *http.Response, subject usageSubject, body []byte, promptEstimate, maxUsageTokens int64, retryExhausted bool, window string) {
+	if (resp.StatusCode >= 500 && resp.StatusCode < 600) || coordinatorTier2PolicyError(resp.StatusCode, body) {
+		if !s.recordRefundedCoordinatorAudit(w, r, subject, window, refundedCoordinatorAuditOutcome(resp.StatusCode, body)) {
 			return
 		}
-	} else {
-		_ = s.store.RefundReservation(context.Background(), subject.AccountID, requestID(r), s.now().Unix())
+	}
+	if err := s.store.RefundReservation(context.Background(), subject.AccountID, requestID(r), s.now().Unix()); err != nil && !errors.Is(err, storage.ErrReservationNotFound) {
+		slog.Error("gateway no-provider refund failed after audit row",
+			"request_id", requestID(r),
+			"account_id", subject.AccountID,
+			"error", err,
+		)
+		writeError(w, http.StatusInternalServerError, "server_error", "settlement_failed", "Could not settle usage")
+		return
 	}
 	if len(bytes.TrimSpace(body)) == 0 && resp.StatusCode == http.StatusServiceUnavailable {
 		writeError(w, http.StatusServiceUnavailable, "service_unavailable", "no_provider_available", "No provider available")
@@ -1083,6 +1088,48 @@ func (s *Server) passThroughNoProviderCoordinatorError(w http.ResponseWriter, r 
 	w.Header().Set("Content-Type", contentTypeOrJSON(resp.Header))
 	w.WriteHeader(resp.StatusCode)
 	_, _ = w.Write(body)
+}
+
+func refundedCoordinatorAuditOutcome(status int, body []byte) string {
+	if isCoordNoProviderAvailable503(status, body) {
+		return "no_provider_available"
+	}
+	if code := openAIErrorCode(body); code != "" {
+		return code
+	}
+	return "upstream_error"
+}
+
+func (s *Server) recordRefundedCoordinatorAudit(w http.ResponseWriter, r *http.Request, subject usageSubject, window, outcome string) bool {
+	if window == "" {
+		window = s.now().UTC().Format("2006-01-02")
+	}
+	if outcome == "" {
+		outcome = "upstream_error"
+	}
+	if err := s.store.EnsureUsageEvent(context.Background(), storage.UsageEvent{
+		RequestID:        requestID(r),
+		AccountID:        subject.AccountID,
+		DemoIdentity:     subject.DemoIdentity,
+		WindowDate:       window,
+		PromptTokens:     0,
+		CompletionTokens: 0,
+		TotalTokens:      0,
+		TokenSource:      "gateway_estimated",
+		Outcome:          outcome,
+		CreatedAt:        s.now(),
+	}); err != nil {
+		slog.Error("gateway refunded coordinator audit row failed",
+			"request_id", requestID(r),
+			"account_id", subject.AccountID,
+			"outcome", outcome,
+			"error", err,
+		)
+		_ = s.store.RefundReservation(context.Background(), subject.AccountID, requestID(r), s.now().Unix())
+		writeError(w, http.StatusInternalServerError, "server_error", "settlement_failed", "Could not settle usage")
+		return false
+	}
+	return true
 }
 
 func (s *Server) passThroughReceiptEligibleProviderError(w http.ResponseWriter, r *http.Request, resp *http.Response, subject usageSubject, body []byte, promptEstimate, maxUsageTokens, maxTokens int64) {

--- a/phase5-gateway/internal/router/chat_proxy_retry_test.go
+++ b/phase5-gateway/internal/router/chat_proxy_retry_test.go
@@ -3,6 +3,7 @@ package router
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -84,7 +85,7 @@ func TestGatewayCoord503RetryExhaustsNoProviderResponses(t *testing.T) {
 	)
 }
 
-func TestCapacityRejection503EchoesRequestIDAndSettlesAfterRetryExhaustion(t *testing.T) {
+func TestCapacityRejection503EchoesRequestIDAndRefundsAfterRetryExhaustion(t *testing.T) {
 	var calls int
 	client := &http.Client{Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
 		calls++
@@ -94,7 +95,7 @@ func TestCapacityRejection503EchoesRequestIDAndSettlesAfterRetryExhaustion(t *te
 		}, noProviderBody()), nil
 	})}
 	h, store, dbPath, cfg := newRetryHarness(t, client, nil)
-	accountID := "acct_retry_exhausted_settled"
+	accountID := "acct_retry_exhausted_refunded"
 	fullKey := createAccountAndKey(t, store, cfg, accountID)
 
 	requestID := "33333333-3333-4333-8333-333333333333"
@@ -110,13 +111,10 @@ func TestCapacityRejection503EchoesRequestIDAndSettlesAfterRetryExhaustion(t *te
 	if len(values) != 1 || values[0] != requestID {
 		t.Fatalf("response X-Request-ID values=%q, want only gateway request id %q", values, requestID)
 	}
-	outcome, source, completion, prompt := usageEventOutcomeAndTokens(t, dbPath, accountID)
-	if outcome != "no_provider_available" || source != "gateway_estimated" || completion != 0 || prompt <= 0 {
-		t.Fatalf("usage row outcome/source/completion/prompt = %s/%s/%d/%d, want no_provider_available/gateway_estimated/0/>0", outcome, source, completion, prompt)
-	}
+	assertRefundedNoProviderAudit(t, dbPath, accountID)
 }
 
-func TestCoordinatorSuppliedRetryExhaustedHeaderDoesNotSettle(t *testing.T) {
+func TestCoordinatorSuppliedRetryExhaustedHeaderDoesNotCharge(t *testing.T) {
 	client := &http.Client{Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
 		return responseWithBody(http.StatusServiceUnavailable, http.Header{
 			"Content-Type":                          []string{"application/json"},
@@ -134,7 +132,7 @@ func TestCoordinatorSuppliedRetryExhaustedHeaderDoesNotSettle(t *testing.T) {
 	if resp.Code != http.StatusServiceUnavailable {
 		t.Fatalf("status=%d body=%s", resp.Code, resp.Body.String())
 	}
-	assertNoUsageEventsForAccount(t, dbPath, accountID)
+	assertRefundedNoProviderAudit(t, dbPath, accountID)
 }
 
 func TestGatewayCoord503RetryExhaustedEmptyBodyRefunds(t *testing.T) {
@@ -156,7 +154,60 @@ func TestGatewayCoord503RetryExhaustedEmptyBodyRefunds(t *testing.T) {
 		t.Fatalf("coordinator calls=%d want 3", calls)
 	}
 	assertErrorCode(t, resp.Body.String(), "no_provider_available")
-	assertNoUsageEventsForAccount(t, dbPath, accountID)
+	assertRefundedNoProviderAudit(t, dbPath, accountID)
+}
+
+func TestGatewayCoord503RetryExhaustedStreamingRefunds(t *testing.T) {
+	var calls int
+	client := &http.Client{Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+		calls++
+		return responseWithBody(http.StatusServiceUnavailable, http.Header{"Content-Type": []string{"application/json"}}, noProviderBody()), nil
+	})}
+	h, store, dbPath, cfg := newRetryHarness(t, client, nil)
+	accountID := "acct_retry_exhausted_stream_refunded"
+	fullKey := createAccountAndKey(t, store, cfg, accountID)
+
+	resp := postChat(t, h, fullKey, chatBody(true), nil)
+
+	if resp.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status=%d body=%s", resp.Code, resp.Body.String())
+	}
+	if calls != 3 {
+		t.Fatalf("coordinator calls=%d want 3", calls)
+	}
+	assertErrorCode(t, resp.Body.String(), "no_provider_available")
+	assertRefundedNoProviderAudit(t, dbPath, accountID)
+}
+
+func TestNoProviderAuditRefundFailureReturnsSettlementFailed(t *testing.T) {
+	for _, stream := range []bool{false, true} {
+		t.Run(fmt.Sprintf("stream_%v", stream), func(t *testing.T) {
+			client := &http.Client{Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+				return responseWithBody(http.StatusServiceUnavailable, http.Header{"Content-Type": []string{"application/json"}}, noProviderBody()), nil
+			})}
+			_, store, dbPath, cfg := newRetryHarness(t, client, func(cfg *config.Config) {
+				cfg.Retry503.Enabled = false
+			})
+			accountID := fmt.Sprintf("acct_no_provider_refund_failure_%v", stream)
+			fullKey := createAccountAndKey(t, store, cfg, accountID)
+			spy := &retryReservationSpyStore{Store: store, refundErr: errors.New("refund write failed")}
+			h := New(cfg, spy, fakeOAuth{}, WithNow(fixedNow), WithHTTPClient(client)).Handler()
+
+			resp := postChat(t, h, fullKey, chatBody(stream), nil)
+
+			if resp.Code != http.StatusInternalServerError {
+				t.Fatalf("status=%d body=%s, want settlement_failed 500", resp.Code, resp.Body.String())
+			}
+			assertErrorCode(t, resp.Body.String(), "settlement_failed")
+			if spy.refundCalls != 1 {
+				t.Fatalf("RefundReservation calls=%d, want 1", spy.refundCalls)
+			}
+			outcome, source, completion, prompt := usageEventOutcomeAndTokens(t, dbPath, accountID)
+			if outcome != "no_provider_available" || source != "gateway_estimated" || completion != 0 || prompt != 0 {
+				t.Fatalf("usage row outcome/source/completion/prompt = %s/%s/%d/%d, want no_provider_available/gateway_estimated/0/0", outcome, source, completion, prompt)
+			}
+		})
+	}
 }
 
 func TestGatewayCoord503RetryMetricsUsesGatewayGeneratedRequestIDClass(t *testing.T) {
@@ -198,27 +249,72 @@ func TestGatewayRetryMetricsBypassAllPublicKillSwitch(t *testing.T) {
 
 func TestGatewayCoord503RetrySkipsTier2PolicyError(t *testing.T) {
 	logs := captureRetryLogs(t)
-	var calls int
-	body := `{"error":{"code":"tier2_hash_verified_required","message":"tier2 policy rejected request","param":null,"type":"service_unavailable"}}`
-	client := &http.Client{Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
-		calls++
-		return responseWithBody(http.StatusServiceUnavailable, http.Header{"Content-Type": []string{"application/json"}}, body), nil
-	})}
-	h, store, _, cfg := newRetryHarness(t, client, nil)
-	fullKey := createAccountAndKey(t, store, cfg, "acct_retry_tier2")
-
-	resp := postChat(t, h, fullKey, chatBody(false), nil)
-
-	if resp.Code != http.StatusServiceUnavailable {
-		t.Fatalf("status=%d body=%s", resp.Code, resp.Body.String())
+	codes := []string{
+		"tier2_hash_verified_required",
+		"tier2_hash_mismatch",
+		"tier2_encrypted_leg_required",
+		"tier2_attestation_required",
 	}
-	if calls != 1 {
-		t.Fatalf("coordinator calls=%d want 1", calls)
-	}
-	if !strings.Contains(resp.Body.String(), `"code":"tier2_hash_verified_required"`) {
-		t.Fatalf("coordinator tier2 body not preserved: %s", resp.Body.String())
+	for _, code := range codes {
+		t.Run(code, func(t *testing.T) {
+			body := fmt.Sprintf(`{"error":{"code":%q,"message":"tier2 policy rejected request","param":null,"type":"service_unavailable"}}`, code)
+			for _, stream := range []bool{false, true} {
+				t.Run(fmt.Sprintf("stream_%v", stream), func(t *testing.T) {
+					var calls int
+					client := &http.Client{Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+						calls++
+						return responseWithBody(http.StatusServiceUnavailable, http.Header{"Content-Type": []string{"application/json"}}, body), nil
+					})}
+					h, store, dbPath, cfg := newRetryHarness(t, client, nil)
+					accountID := fmt.Sprintf("acct_retry_%s_%v", code, stream)
+					fullKey := createAccountAndKey(t, store, cfg, accountID)
+
+					resp := postChat(t, h, fullKey, chatBody(stream), nil)
+
+					if resp.Code != http.StatusServiceUnavailable {
+						t.Fatalf("status=%d body=%s", resp.Code, resp.Body.String())
+					}
+					if calls != 1 {
+						t.Fatalf("coordinator calls=%d want 1", calls)
+					}
+					if !strings.Contains(resp.Body.String(), fmt.Sprintf(`"code":%q`, code)) {
+						t.Fatalf("coordinator tier2 body not preserved: %s", resp.Body.String())
+					}
+					assertRefundedAuditOutcome(t, dbPath, accountID, code)
+				})
+			}
+		})
 	}
 	assertRetryLogCounts(t, logs.String(), 0, 0, 0)
+}
+
+func TestGatewayTier2HardPin400WritesRefundedAudit(t *testing.T) {
+	body := `{"error":{"code":"tier2_hard_pin_predicate_failed","message":"tier2 hard pin predicate failed","param":null,"type":"invalid_request_error"}}`
+	for _, stream := range []bool{false, true} {
+		t.Run(fmt.Sprintf("stream_%v", stream), func(t *testing.T) {
+			var calls int
+			client := &http.Client{Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+				calls++
+				return responseWithBody(http.StatusBadRequest, http.Header{"Content-Type": []string{"application/json"}}, body), nil
+			})}
+			h, store, dbPath, cfg := newRetryHarness(t, client, nil)
+			accountID := fmt.Sprintf("acct_retry_tier2_hard_pin_%v", stream)
+			fullKey := createAccountAndKey(t, store, cfg, accountID)
+
+			resp := postChat(t, h, fullKey, chatBody(stream), nil)
+
+			if resp.Code != http.StatusBadRequest {
+				t.Fatalf("status=%d body=%s", resp.Code, resp.Body.String())
+			}
+			if calls != 1 {
+				t.Fatalf("coordinator calls=%d want 1", calls)
+			}
+			if !strings.Contains(resp.Body.String(), `"code":"tier2_hard_pin_predicate_failed"`) {
+				t.Fatalf("coordinator tier2 body not preserved: %s", resp.Body.String())
+			}
+			assertRefundedAuditOutcome(t, dbPath, accountID, "tier2_hard_pin_predicate_failed")
+		})
+	}
 }
 
 func TestGatewayCoord502RetryRecoversAfterTransientProviderError(t *testing.T) {
@@ -627,6 +723,23 @@ func noProviderBody() string {
 	return `{"error":{"code":"no_provider_available","message":"No provider available","param":null,"type":"service_unavailable"}}`
 }
 
+func assertRefundedNoProviderAudit(t *testing.T, dbPath, accountID string) {
+	t.Helper()
+	assertRefundedAuditOutcome(t, dbPath, accountID, "no_provider_available")
+}
+
+func assertRefundedAuditOutcome(t *testing.T, dbPath, accountID, wantOutcome string) {
+	t.Helper()
+	outcome, source, completion, prompt := usageEventOutcomeAndTokens(t, dbPath, accountID)
+	if outcome != wantOutcome || source != "gateway_estimated" || completion != 0 || prompt != 0 {
+		t.Fatalf("usage row outcome/source/completion/prompt = %s/%s/%d/%d, want %s/gateway_estimated/0/0", outcome, source, completion, prompt, wantOutcome)
+	}
+	got := gatewaySettlementSnapshot(t, dbPath, accountID)
+	if got.usageRows != 1 || got.settledRows != 0 || got.refundedRows != 1 || got.activeRows != 0 || got.activeReserved != 0 {
+		t.Fatalf("settlement snapshot = %+v, want one zero-token usage audit row plus refunded reservation", got)
+	}
+}
+
 func chatBody(stream bool) string {
 	if stream {
 		return `{"model":"llama","stream":true,"max_tokens":20,"messages":[{"role":"user","content":"hi"}]}`
@@ -640,6 +753,7 @@ type retryReservationSpyStore struct {
 	acquireCalls int
 	refundCalls  int
 	releaseCalls int
+	refundErr    error
 }
 
 func (s *retryReservationSpyStore) ReserveQuota(ctx context.Context, req storage.ReservationRequest) (storage.QuotaDecision, error) {
@@ -654,6 +768,9 @@ func (s *retryReservationSpyStore) AcquireConcurrency(ctx context.Context, req s
 
 func (s *retryReservationSpyStore) RefundReservation(ctx context.Context, accountID, requestID string, refundedAt int64) error {
 	s.refundCalls++
+	if s.refundErr != nil {
+		return s.refundErr
+	}
 	return s.Store.RefundReservation(ctx, accountID, requestID, refundedAt)
 }
 

--- a/test/network-harness/internal/invariants/hard.go
+++ b/test/network-harness/internal/invariants/hard.go
@@ -311,17 +311,25 @@ func checkI2(results []buyer.Result, ledger *reconcile.Result) Check {
 		c.Detail = fmt.Sprintf("%d 5xx responses observed but settlement DB not configured", fiveXX)
 		return c
 	}
-	settled := map[string]bool{}
+	settled := map[string]reconcile.SettlementRequestIdentity{}
 	if ledger.GatewayHasAccountID {
 		for _, row := range ledger.GatewaySettlementRequests {
 			if row.AccountID == "" || row.RequestID == "" {
 				continue
 			}
-			settled[row.AccountID+"|"+row.RequestID] = true
+			settled[row.AccountID+"|"+row.RequestID] = row
 		}
 	} else {
+		for _, row := range ledger.GatewaySettlementRequests {
+			if row.RequestID == "" {
+				continue
+			}
+			settled[row.RequestID] = row
+		}
 		for _, id := range ledger.GatewaySettlementRequestIDs {
-			settled[id] = true
+			if _, ok := settled[id]; !ok {
+				settled[id] = reconcile.SettlementRequestIdentity{RequestID: id}
+			}
 		}
 	}
 	for _, r := range results {
@@ -338,30 +346,81 @@ func checkI2(results []buyer.Result, ledger *reconcile.Result) Check {
 				orphans = append(orphans, r.RequestID)
 				continue
 			}
-			if !settled[ledger.HarnessAccountID+"|"+r.RequestID] {
+			row, ok := settled[ledger.HarnessAccountID+"|"+r.RequestID]
+			if !ok || !valid5xxSettlementEvidence(row) {
 				orphans = append(orphans, r.RequestID)
 			}
 			continue
 		}
-		if !settled[r.RequestID] {
+		row, ok := settled[r.RequestID]
+		if !ok || !valid5xxSettlementEvidence(row) {
 			orphans = append(orphans, r.RequestID)
 		}
 	}
-	if fiveXX == 0 {
+	invalidAuditRows := invalidGatewayAuditEvidenceIDs(results, ledger)
+	if fiveXX == 0 && len(invalidAuditRows) == 0 {
 		c.Passed = true
 		c.Detail = "no 5xx responses observed"
 		return c
 	}
-	if len(orphans) == 0 {
+	if len(orphans) == 0 && len(invalidAuditRows) == 0 {
 		c.Passed = true
-		c.Detail = fmt.Sprintf("%d 5xx responses, all have gateway settlement rows", fiveXX)
+		c.Detail = fmt.Sprintf("%d 5xx responses, all have valid gateway settlement/audit rows", fiveXX)
 		return c
 	}
 	c.Passed = false
-	c.OffendingIDs = orphans
-	c.EvidenceCount = len(orphans)
-	c.Detail = fmt.Sprintf("%d 5xx responses without a request id — billing-bypass risk", len(orphans))
+	c.OffendingIDs = append(append([]string{}, orphans...), invalidAuditRows...)
+	c.EvidenceCount = len(c.OffendingIDs)
+	c.Detail = fmt.Sprintf("%d 5xx responses without valid gateway settlement/audit evidence; %d invalid gateway audit rows — billing-bypass risk", len(orphans), len(invalidAuditRows))
 	return c
+}
+
+func valid5xxSettlementEvidence(row reconcile.SettlementRequestIdentity) bool {
+	if isRefundedAuditOnlyOutcome(row.Outcome) {
+		return row.TotalTokens == 0 && row.ReservationStatus == "refunded"
+	}
+	if row.ReservationStatus != "" {
+		if row.TotalTokens == 0 {
+			return row.ReservationStatus == "refunded"
+		}
+		return row.ReservationStatus == "settled"
+	}
+	return true
+}
+
+func invalidGatewayAuditEvidenceIDs(results []buyer.Result, ledger *reconcile.Result) []string {
+	invalid := []string{}
+	owned := harnessOwnedRequestIDs(results)
+	for _, row := range ledger.GatewaySettlementRequests {
+		if row.RequestID == "" || !owned[row.RequestID] || !isRefundedAuditOnlyOutcome(row.Outcome) {
+			continue
+		}
+		if ledger.GatewayHasAccountID {
+			if ledger.HarnessAccountID == "" || row.AccountID != ledger.HarnessAccountID {
+				continue
+			}
+		}
+		if valid5xxSettlementEvidence(row) {
+			continue
+		}
+		invalid = append(invalid, row.RequestID)
+	}
+	return invalid
+}
+
+func harnessOwnedRequestIDs(results []buyer.Result) map[string]bool {
+	owned := map[string]bool{}
+	for _, r := range results {
+		if r.RequestID == "" {
+			continue
+		}
+		owned[r.RequestID] = true
+	}
+	return owned
+}
+
+func isRefundedAuditOnlyOutcome(outcome string) bool {
+	return outcome == "no_provider_available" || strings.HasPrefix(outcome, "tier2_")
 }
 
 // I3 — no charged-tokens > delivered-tokens. This consumes the

--- a/test/network-harness/internal/invariants/hard_test.go
+++ b/test/network-harness/internal/invariants/hard_test.go
@@ -272,6 +272,265 @@ func TestCheckI2_FailsWhen5xxSettlementBelongsToForeignAccount(t *testing.T) {
 	}
 }
 
+func TestCheckI2_PassesNoProviderOnlyWhenZeroTokenRefunded(t *testing.T) {
+	results := []buyer.Result{{HTTPStatus: 503, RequestID: "req-5xx"}}
+	ledger := &reconcile.Result{
+		GatewayHasAccountID: true,
+		HarnessAccountID:    "acct-harness",
+		GatewaySettlementRequests: []reconcile.SettlementRequestIdentity{{
+			AccountID:         "acct-harness",
+			RequestID:         "req-5xx",
+			Outcome:           "no_provider_available",
+			TotalTokens:       0,
+			ReservationStatus: "refunded",
+		}},
+	}
+
+	c := checkI2(results, ledger)
+
+	if !c.Passed || c.Skipped {
+		t.Fatalf("I2 should pass zero-token refunded no-provider evidence: %+v", c)
+	}
+}
+
+func TestCheckI2_FailsNoProviderEvidenceWhenNotRefunded(t *testing.T) {
+	results := []buyer.Result{{HTTPStatus: 503, RequestID: "req-5xx"}}
+	ledger := &reconcile.Result{
+		GatewaySettlementRequests: []reconcile.SettlementRequestIdentity{{
+			RequestID:         "req-5xx",
+			Outcome:           "no_provider_available",
+			TotalTokens:       0,
+			ReservationStatus: "active",
+		}},
+	}
+
+	c := checkI2(results, ledger)
+
+	if c.Passed || c.Skipped {
+		t.Fatalf("I2 should fail active no-provider reservation evidence: %+v", c)
+	}
+	if !contains(c.OffendingIDs, "req-5xx") {
+		t.Fatalf("offending IDs=%v want req-5xx", c.OffendingIDs)
+	}
+}
+
+func TestCheckI2_PassesTier2OnlyWhenZeroTokenRefunded(t *testing.T) {
+	results := []buyer.Result{{HTTPStatus: 503, RequestID: "req-tier2"}}
+	ledger := &reconcile.Result{
+		GatewaySettlementRequests: []reconcile.SettlementRequestIdentity{{
+			RequestID:         "req-tier2",
+			Outcome:           "tier2_hash_verified_required",
+			TotalTokens:       0,
+			ReservationStatus: "refunded",
+		}},
+	}
+
+	c := checkI2(results, ledger)
+
+	if !c.Passed || c.Skipped {
+		t.Fatalf("I2 should pass zero-token refunded tier2 evidence: %+v", c)
+	}
+}
+
+func TestCheckI2_FailsTier2EvidenceWhenChargedOrActive(t *testing.T) {
+	cases := []struct {
+		name              string
+		totalTokens       int64
+		reservationStatus string
+	}{
+		{name: "nonzero_tokens", totalTokens: 1, reservationStatus: "refunded"},
+		{name: "active_reservation", totalTokens: 0, reservationStatus: "active"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			results := []buyer.Result{{HTTPStatus: 503, RequestID: "req-tier2"}}
+			ledger := &reconcile.Result{
+				GatewaySettlementRequests: []reconcile.SettlementRequestIdentity{{
+					RequestID:         "req-tier2",
+					Outcome:           "tier2_hash_verified_required",
+					TotalTokens:       tc.totalTokens,
+					ReservationStatus: tc.reservationStatus,
+				}},
+			}
+
+			c := checkI2(results, ledger)
+
+			if c.Passed || c.Skipped {
+				t.Fatalf("I2 should fail invalid tier2 evidence: %+v", c)
+			}
+			if !contains(c.OffendingIDs, "req-tier2") {
+				t.Fatalf("offending IDs=%v want req-tier2", c.OffendingIDs)
+			}
+		})
+	}
+}
+
+func TestCheckI2_PassesGenericZeroToken5xxAuditOnlyWhenRefunded(t *testing.T) {
+	results := []buyer.Result{{HTTPStatus: 503, RequestID: "req-upstream"}}
+	ledger := &reconcile.Result{
+		GatewaySettlementRequests: []reconcile.SettlementRequestIdentity{{
+			RequestID:         "req-upstream",
+			Outcome:           "upstream_error",
+			TotalTokens:       0,
+			ReservationStatus: "refunded",
+		}},
+	}
+
+	c := checkI2(results, ledger)
+
+	if !c.Passed || c.Skipped {
+		t.Fatalf("I2 should pass zero-token refunded generic 5xx audit evidence: %+v", c)
+	}
+}
+
+func TestCheckI2_FailsGenericZeroToken5xxAuditWhenNotRefunded(t *testing.T) {
+	results := []buyer.Result{{HTTPStatus: 503, RequestID: "req-upstream"}}
+	ledger := &reconcile.Result{
+		GatewaySettlementRequests: []reconcile.SettlementRequestIdentity{{
+			RequestID:         "req-upstream",
+			Outcome:           "upstream_error",
+			TotalTokens:       0,
+			ReservationStatus: "active",
+		}},
+	}
+
+	c := checkI2(results, ledger)
+
+	if c.Passed || c.Skipped {
+		t.Fatalf("I2 should fail zero-token active generic 5xx audit evidence: %+v", c)
+	}
+	if !contains(c.OffendingIDs, "req-upstream") {
+		t.Fatalf("offending IDs=%v want req-upstream", c.OffendingIDs)
+	}
+}
+
+func TestCheckI2_FailsGeneric5xxAuditWithNonzeroTokens(t *testing.T) {
+	results := []buyer.Result{{HTTPStatus: 503, RequestID: "req-upstream"}}
+	ledger := &reconcile.Result{
+		GatewaySettlementRequests: []reconcile.SettlementRequestIdentity{{
+			RequestID:         "req-upstream",
+			Outcome:           "upstream_error",
+			TotalTokens:       7,
+			ReservationStatus: "active",
+		}},
+	}
+
+	c := checkI2(results, ledger)
+
+	if c.Passed || c.Skipped {
+		t.Fatalf("I2 should fail generic 5xx settlement evidence with active reservation: %+v", c)
+	}
+	if !contains(c.OffendingIDs, "req-upstream") {
+		t.Fatalf("offending IDs=%v want req-upstream", c.OffendingIDs)
+	}
+}
+
+func TestCheckI2_PassesGeneric5xxSettlementWithNonzeroTokens(t *testing.T) {
+	results := []buyer.Result{{HTTPStatus: 502, RequestID: "req-upstream"}}
+	ledger := &reconcile.Result{
+		GatewaySettlementRequests: []reconcile.SettlementRequestIdentity{{
+			RequestID:         "req-upstream",
+			Outcome:           "upstream_error",
+			TotalTokens:       7,
+			ReservationStatus: "settled",
+		}},
+	}
+
+	c := checkI2(results, ledger)
+
+	if !c.Passed || c.Skipped {
+		t.Fatalf("I2 should pass prompt-billed generic 5xx settlement evidence: %+v", c)
+	}
+}
+
+func TestCheckI2_PassesValidAuditEvidenceWithout5xx(t *testing.T) {
+	results := []buyer.Result{{HTTPStatus: 400, RequestID: "req-tier2-400"}}
+	ledger := &reconcile.Result{
+		GatewaySettlementRequests: []reconcile.SettlementRequestIdentity{{
+			RequestID:         "req-tier2-400",
+			Outcome:           "tier2_hard_pin_predicate_failed",
+			TotalTokens:       0,
+			ReservationStatus: "refunded",
+		}},
+	}
+
+	c := checkI2(results, ledger)
+
+	if !c.Passed || c.Skipped {
+		t.Fatalf("I2 should pass valid refunded audit evidence without 5xx responses: %+v", c)
+	}
+}
+
+func TestCheckI2_FailsInvalidAuditEvidenceWithout5xx(t *testing.T) {
+	cases := []struct {
+		name              string
+		requestID         string
+		outcome           string
+		totalTokens       int64
+		reservationStatus string
+	}{
+		{
+			name:              "tier2_400_active",
+			requestID:         "req-tier2-400",
+			outcome:           "tier2_hard_pin_predicate_failed",
+			totalTokens:       0,
+			reservationStatus: "active",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			results := []buyer.Result{{HTTPStatus: 400, RequestID: tc.requestID}}
+			ledger := &reconcile.Result{
+				GatewaySettlementRequests: []reconcile.SettlementRequestIdentity{{
+					RequestID:         tc.requestID,
+					Outcome:           tc.outcome,
+					TotalTokens:       tc.totalTokens,
+					ReservationStatus: tc.reservationStatus,
+				}},
+			}
+
+			c := checkI2(results, ledger)
+
+			if c.Passed || c.Skipped {
+				t.Fatalf("I2 should fail invalid audit evidence without 5xx responses: %+v", c)
+			}
+			if !contains(c.OffendingIDs, tc.requestID) {
+				t.Fatalf("offending IDs=%v want %s", c.OffendingIDs, tc.requestID)
+			}
+		})
+	}
+}
+
+func TestCheckI2_IgnoresUnownedInvalidAuditEvidenceWithout5xx(t *testing.T) {
+	results := []buyer.Result{{HTTPStatus: 200, RequestID: "owned-ok"}}
+	ledger := &reconcile.Result{
+		GatewayHasAccountID: true,
+		HarnessAccountID:    "acct-harness",
+		GatewaySettlementRequests: []reconcile.SettlementRequestIdentity{
+			{
+				AccountID:         "acct-harness",
+				RequestID:         "owned-ok",
+				Outcome:           "ok",
+				TotalTokens:       7,
+				ReservationStatus: "settled",
+			},
+			{
+				AccountID:         "acct-other",
+				RequestID:         "other-tier2-400",
+				Outcome:           "tier2_hard_pin_predicate_failed",
+				TotalTokens:       0,
+				ReservationStatus: "active",
+			},
+		},
+	}
+
+	c := checkI2(results, ledger)
+
+	if !c.Passed || c.Skipped {
+		t.Fatalf("I2 should ignore unowned invalid audit evidence in live window: %+v", c)
+	}
+}
+
 func TestCheckI2_PassesWhen5xxSettlementMatchesHarnessAccount(t *testing.T) {
 	results := []buyer.Result{{HTTPStatus: 502, RequestID: "req-5xx"}}
 	ledger := &reconcile.Result{

--- a/test/network-harness/internal/reconcile/ledger.go
+++ b/test/network-harness/internal/reconcile/ledger.go
@@ -296,8 +296,11 @@ type MatchedPair struct {
 }
 
 type SettlementRequestIdentity struct {
-	AccountID string `json:"account_id,omitempty"`
-	RequestID string `json:"request_id"`
+	AccountID         string `json:"account_id,omitempty"`
+	RequestID         string `json:"request_id"`
+	Outcome           string `json:"outcome,omitempty"`
+	TotalTokens       int64  `json:"total_tokens,omitempty"`
+	ReservationStatus string `json:"reservation_status,omitempty"`
 }
 
 // snapshotWindow returns the SQL query bounds for a reconcile run.
@@ -406,11 +409,14 @@ func Run(sc *scenario.Scenario, results []buyer.Result, startUTC, endUTC time.Ti
 	}
 	r.GatewayRows = len(gwRows)
 	for _, g := range gwRows {
-		if isSettlementComplete(g.Outcome) {
+		if isGatewayAuditCompleteOutcome(g.Outcome) {
 			r.GatewaySettlementRequestIDs = append(r.GatewaySettlementRequestIDs, g.RequestID)
 			r.GatewaySettlementRequests = append(r.GatewaySettlementRequests, SettlementRequestIdentity{
-				AccountID: g.AccountID,
-				RequestID: g.RequestID,
+				AccountID:         g.AccountID,
+				RequestID:         g.RequestID,
+				Outcome:           g.Outcome,
+				TotalTokens:       g.TotalTokens,
+				ReservationStatus: g.ReservationStatus,
 			})
 		}
 		switch {
@@ -772,7 +778,7 @@ func seedHarnessAccountIDFromGatewaySettlements(r *Result, results []buyer.Resul
 	}
 	accounts := map[string]bool{}
 	for _, g := range gwRows {
-		if !ids[g.RequestID] || !isSettlementComplete(g.Outcome) || g.AccountID == "" {
+		if !ids[g.RequestID] || !isGatewayAuditCompleteOutcome(g.Outcome) || g.AccountID == "" {
 			continue
 		}
 		accounts[g.AccountID] = true
@@ -1132,13 +1138,13 @@ func isGatewayOKOutcome(outcome string) bool {
 }
 
 // isSettlementComplete returns true for any gateway outcome value that
-// represents a complete settlement event from a money-path perspective.
-// "ok" is the canonical happy-path value; the rest are SPEC-006 § 17.7
-// streaming-fallback outcomes — the gateway still writes a usage_events
-// row with bytes emitted so far, so the audit trail is complete. From
-// the reconciler's point of view, any of these rows is a valid match
-// for a harness-success result (the harness saw a 200 + a terminator
-// signal, the gateway recorded the settlement row).
+// represents a complete, matchable settlement event from a money-path
+// perspective. "ok" is the canonical happy-path value; the rest are
+// SPEC-006 § 17.7 streaming-fallback outcomes — the gateway still writes
+// a usage_events row with bytes emitted so far, so the audit trail is
+// complete. From the reconciler's point of view, any of these rows is a
+// valid match for a harness-success result (the harness saw a 200 + a
+// terminator signal, the gateway recorded the settlement row).
 //
 // Source enumeration: phase5-gateway/internal/router/chat_proxy.go
 // settleAfterCommit() / settleBeforeResponse() call sites.
@@ -1167,6 +1173,10 @@ func isSettlementComplete(outcome string) bool {
 		return true
 	}
 	return false
+}
+
+func isGatewayAuditCompleteOutcome(outcome string) bool {
+	return isSettlementComplete(outcome) || outcome == "no_provider_available" || strings.HasPrefix(outcome, "tier2_")
 }
 
 type coordRow struct {
@@ -1200,13 +1210,14 @@ type gwRow struct {
 	// alone can hit a cross-account row on a shared gateway. Empty
 	// string means the snapshot pre-dates the column (legacy / partial
 	// migration), in which case the matcher treats it as a noop.
-	AccountID        string
-	PromptTokens     int64
-	CompletionTokens int64
-	TotalTokens      int64
-	TokenSource      string
-	Outcome          string
-	CreatedAt        time.Time
+	AccountID         string
+	PromptTokens      int64
+	CompletionTokens  int64
+	TotalTokens       int64
+	TokenSource       string
+	Outcome           string
+	ReservationStatus string
+	CreatedAt         time.Time
 }
 
 // queryCoordinator returns coordinator rows + a schema flag reporting
@@ -1457,6 +1468,36 @@ func gatewayTokenExprs(db *sql.DB) (string, string, string, error) {
 	return promptExpr, completionExpr, totalExpr, nil
 }
 
+func gatewayReservationStatusExpr(db *sql.DB, hasUsageAccountID bool) (string, error) {
+	hasQuota, err := tableExists(db, "quota_reservations")
+	if err != nil {
+		return "", fmt.Errorf("probe quota_reservations: %w", err)
+	}
+	if !hasQuota {
+		return "''", nil
+	}
+	hasRequestID, err := columnExists(db, "quota_reservations", "request_id")
+	if err != nil {
+		return "", fmt.Errorf("probe quota_reservations.request_id: %w", err)
+	}
+	hasStatus, err := columnExists(db, "quota_reservations", "status")
+	if err != nil {
+		return "", fmt.Errorf("probe quota_reservations.status: %w", err)
+	}
+	if !hasRequestID || !hasStatus {
+		return "''", nil
+	}
+	where := "qr.request_id = usage_events.request_id"
+	hasQuotaAccountID, err := columnExists(db, "quota_reservations", "account_id")
+	if err != nil {
+		return "", fmt.Errorf("probe quota_reservations.account_id: %w", err)
+	}
+	if hasUsageAccountID && hasQuotaAccountID {
+		where += " AND qr.account_id = usage_events.account_id"
+	}
+	return fmt.Sprintf("COALESCE((SELECT qr.status FROM quota_reservations qr WHERE %s ORDER BY qr.rowid DESC LIMIT 1), '')", where), nil
+}
+
 // queryGateway returns gateway usage_events rows + a schema flag
 // reporting whether the usage_events.account_id column exists in the
 // snapshot. Same shape as queryCoordinator.
@@ -1490,10 +1531,14 @@ func queryGateway(path string, start, end time.Time) ([]gwRow, bool, error) {
 	if err != nil {
 		return nil, false, err
 	}
+	reservationStatusExpr, err := gatewayReservationStatusExpr(db, hasAcct)
+	if err != nil {
+		return nil, false, err
+	}
 	rows, err := db.Query(fmt.Sprintf(`
-				SELECT request_id, %s, %s, %s, %s, %s, outcome, created_at
-				FROM usage_events
-			`, acctExpr, promptExpr, completionExpr, totalExpr, tokenSourceExpr))
+					SELECT request_id, %s, %s, %s, %s, %s, outcome, %s, created_at
+					FROM usage_events
+				`, acctExpr, promptExpr, completionExpr, totalExpr, tokenSourceExpr, reservationStatusExpr))
 	if err != nil {
 		return nil, false, err
 	}
@@ -1502,7 +1547,7 @@ func queryGateway(path string, start, end time.Time) ([]gwRow, bool, error) {
 	for rows.Next() {
 		var g gwRow
 		var ts string
-		if err := rows.Scan(&g.RequestID, &g.AccountID, &g.PromptTokens, &g.CompletionTokens, &g.TotalTokens, &g.TokenSource, &g.Outcome, &ts); err != nil {
+		if err := rows.Scan(&g.RequestID, &g.AccountID, &g.PromptTokens, &g.CompletionTokens, &g.TotalTokens, &g.TokenSource, &g.Outcome, &g.ReservationStatus, &ts); err != nil {
 			return nil, false, err
 		}
 		g.CreatedAt, _ = time.Parse(time.RFC3339Nano, ts)
@@ -1566,12 +1611,16 @@ func queryGatewayByIDs(path string, ids []string) ([]gwRow, error) {
 	if err != nil {
 		return nil, err
 	}
+	reservationStatusExpr, err := gatewayReservationStatusExpr(db, hasAcct)
+	if err != nil {
+		return nil, err
+	}
 	placeholders, args := inClause(ids)
 	rows, err := db.Query(fmt.Sprintf(`
-				SELECT request_id, %s, %s, %s, %s, %s, outcome, created_at
-				FROM usage_events
-			WHERE request_id IN (%s)
-		`, acctExpr, promptExpr, completionExpr, totalExpr, tokenSourceExpr, placeholders), args...)
+					SELECT request_id, %s, %s, %s, %s, %s, outcome, %s, created_at
+					FROM usage_events
+				WHERE request_id IN (%s)
+			`, acctExpr, promptExpr, completionExpr, totalExpr, tokenSourceExpr, reservationStatusExpr, placeholders), args...)
 	if err != nil {
 		return nil, err
 	}
@@ -1580,7 +1629,7 @@ func queryGatewayByIDs(path string, ids []string) ([]gwRow, error) {
 	for rows.Next() {
 		var g gwRow
 		var ts string
-		if err := rows.Scan(&g.RequestID, &g.AccountID, &g.PromptTokens, &g.CompletionTokens, &g.TotalTokens, &g.TokenSource, &g.Outcome, &ts); err != nil {
+		if err := rows.Scan(&g.RequestID, &g.AccountID, &g.PromptTokens, &g.CompletionTokens, &g.TotalTokens, &g.TokenSource, &g.Outcome, &g.ReservationStatus, &ts); err != nil {
 			return nil, err
 		}
 		g.CreatedAt, _ = time.Parse(time.RFC3339Nano, ts)

--- a/test/network-harness/internal/reconcile/ledger_test.go
+++ b/test/network-harness/internal/reconcile/ledger_test.go
@@ -13,6 +13,7 @@ package reconcile
 import (
 	"database/sql"
 	"fmt"
+	"net/http"
 	"path/filepath"
 	"testing"
 	"time"
@@ -419,6 +420,194 @@ func TestSseErrorCorroboratesOutcome_232_R6(t *testing.T) {
 			got := sseErrorCorroboratesOutcome(tc.code, tc.outcome)
 			if got != tc.want {
 				t.Errorf("sseErrorCorroboratesOutcome(%q, %q) = %v, want %v", tc.code, tc.outcome, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestNoProviderAuditOutcomeSupportsI2ButNotI1SuccessMatching(t *testing.T) {
+	if isSettlementComplete("no_provider_available") {
+		t.Fatal("no_provider_available must not be matchable as a harness-success settlement")
+	}
+	if !isGatewayAuditCompleteOutcome("no_provider_available") {
+		t.Fatal("no_provider_available should count as terminal gateway audit evidence for I2 reconciliation")
+	}
+
+	now := time.Now()
+	results := []buyer.Result{
+		{RequestID: "h_503", Outcome: "http_error", StartUTC: now, EndUTC: now},
+	}
+	gwRows := []gwRow{
+		{RequestID: "h_503", Outcome: "no_provider_available", CompletionTokens: 0, CreatedAt: now},
+	}
+	r := &Result{}
+	leftoverGw, _ := matchPairs(r, results, gwRows, nil)
+	if len(r.MatchedSuccesses) != 0 {
+		t.Fatalf("failed harness 503 must not produce matched success pairs, got %d", len(r.MatchedSuccesses))
+	}
+	collectUnmatchedGatewayOK(r, leftoverGw)
+	if len(r.UnmatchedGatewayOKRows) != 0 {
+		t.Fatalf("refunded no-provider audit row must not be reported as I1 gateway orphan, got %v", r.UnmatchedGatewayOKRows)
+	}
+	for _, g := range gwRows {
+		if isGatewayAuditCompleteOutcome(g.Outcome) {
+			r.GatewaySettlementRequestIDs = append(r.GatewaySettlementRequestIDs, g.RequestID)
+		}
+	}
+	if len(r.GatewaySettlementRequestIDs) != 1 || r.GatewaySettlementRequestIDs[0] != "h_503" {
+		t.Fatalf("I2 audit evidence request IDs = %v, want [h_503]", r.GatewaySettlementRequestIDs)
+	}
+}
+
+func TestTier2AuditOutcomesSupportI2ButNotI1SuccessMatching(t *testing.T) {
+	cases := []struct {
+		name   string
+		status int
+		code   string
+	}{
+		{name: "503_hash_verified_required", status: http.StatusServiceUnavailable, code: "tier2_hash_verified_required"},
+		{name: "503_hash_mismatch", status: http.StatusServiceUnavailable, code: "tier2_hash_mismatch"},
+		{name: "503_encrypted_leg_required", status: http.StatusServiceUnavailable, code: "tier2_encrypted_leg_required"},
+		{name: "503_attestation_required", status: http.StatusServiceUnavailable, code: "tier2_attestation_required"},
+		{name: "400_hard_pin_predicate_failed", status: http.StatusBadRequest, code: "tier2_hard_pin_predicate_failed"},
+	}
+	now := time.Now()
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if isSettlementComplete(tc.code) {
+				t.Fatalf("%s must not be matchable as a harness-success settlement", tc.code)
+			}
+			if !isGatewayAuditCompleteOutcome(tc.code) {
+				t.Fatalf("%s should count as terminal gateway audit evidence for I2 reconciliation", tc.code)
+			}
+
+			results := []buyer.Result{{
+				RequestID:  "h_" + tc.name,
+				Outcome:    "http_error",
+				HTTPStatus: tc.status,
+				StartUTC:   now,
+				EndUTC:     now,
+			}}
+			gwRows := []gwRow{{
+				RequestID:        "h_" + tc.name,
+				Outcome:          tc.code,
+				CompletionTokens: 0,
+				TotalTokens:      0,
+				CreatedAt:        now,
+			}}
+			r := &Result{}
+			leftoverGw, _ := matchPairs(r, results, gwRows, nil)
+			if len(r.MatchedSuccesses) != 0 {
+				t.Fatalf("failed harness tier2 response must not produce matched success pairs, got %d", len(r.MatchedSuccesses))
+			}
+			collectUnmatchedGatewayOK(r, leftoverGw)
+			if len(r.UnmatchedGatewayOKRows) != 0 {
+				t.Fatalf("refunded tier2 audit row must not be reported as I1 gateway orphan, got %v", r.UnmatchedGatewayOKRows)
+			}
+			for _, g := range gwRows {
+				if isGatewayAuditCompleteOutcome(g.Outcome) {
+					r.GatewaySettlementRequests = append(r.GatewaySettlementRequests, SettlementRequestIdentity{
+						RequestID:         g.RequestID,
+						Outcome:           g.Outcome,
+						TotalTokens:       g.TotalTokens,
+						ReservationStatus: "refunded",
+					})
+				}
+			}
+			if len(r.GatewaySettlementRequests) != 1 {
+				t.Fatalf("GatewaySettlementRequests=%v, want one tier2 audit evidence row", r.GatewaySettlementRequests)
+			}
+			evidence := r.GatewaySettlementRequests[0]
+			if evidence.RequestID != "h_"+tc.name || evidence.Outcome != tc.code || evidence.TotalTokens != 0 || evidence.ReservationStatus != "refunded" {
+				t.Fatalf("gateway audit evidence = %+v, want request %s zero-token refunded", evidence, tc.code)
+			}
+		})
+	}
+}
+
+func TestRunNoProviderAuditEvidenceDoesNotBecomeI1Orphan(t *testing.T) {
+	gwPath := newTestGatewayDB(t)
+	coordPath := newTestCoordDB(t)
+	startUTC := time.Date(2026, 7, 9, 15, 0, 0, 0, time.UTC)
+	endUTC := startUTC.Add(10 * time.Second)
+	insertGwRow(t, gwPath, "h_503_run", "acct-A", 0, "no_provider_available", startUTC.Add(time.Second))
+	insertQuotaReservation(t, gwPath, "h_503_run", "acct-A", "refunded", startUTC.Add(time.Second))
+
+	results := []buyer.Result{{
+		RequestID:  "h_503_run",
+		Model:      "test-model",
+		Outcome:    "http_error",
+		HTTPStatus: http.StatusServiceUnavailable,
+		StartUTC:   startUTC.Add(time.Second),
+		EndUTC:     startUTC.Add(2 * time.Second),
+	}}
+
+	r, err := Run(makeScenario(coordPath, gwPath), results, startUTC, endUTC)
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if len(r.MatchedSuccesses) != 0 {
+		t.Fatalf("failed harness 503 must not produce matched success pairs, got %d", len(r.MatchedSuccesses))
+	}
+	if len(r.UnmatchedGatewayOKRows) != 0 {
+		t.Fatalf("refunded no-provider audit row must not be reported as I1 gateway orphan, got %v", r.UnmatchedGatewayOKRows)
+	}
+	if len(r.GatewaySettlementRequests) != 1 {
+		t.Fatalf("GatewaySettlementRequests=%v, want one no-provider audit evidence row", r.GatewaySettlementRequests)
+	}
+	evidence := r.GatewaySettlementRequests[0]
+	if evidence.RequestID != "h_503_run" || evidence.AccountID != "acct-A" || evidence.Outcome != "no_provider_available" || evidence.TotalTokens != 0 || evidence.ReservationStatus != "refunded" {
+		t.Fatalf("gateway audit evidence = %+v, want acct/request no_provider zero-token refunded", evidence)
+	}
+}
+
+func TestRunTier2AuditEvidenceDoesNotBecomeI1Orphan(t *testing.T) {
+	cases := []struct {
+		name   string
+		status int
+		code   string
+	}{
+		{name: "503_hash_verified_required", status: http.StatusServiceUnavailable, code: "tier2_hash_verified_required"},
+		{name: "503_hash_mismatch", status: http.StatusServiceUnavailable, code: "tier2_hash_mismatch"},
+		{name: "503_encrypted_leg_required", status: http.StatusServiceUnavailable, code: "tier2_encrypted_leg_required"},
+		{name: "503_attestation_required", status: http.StatusServiceUnavailable, code: "tier2_attestation_required"},
+		{name: "400_hard_pin_predicate_failed", status: http.StatusBadRequest, code: "tier2_hard_pin_predicate_failed"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			gwPath := newTestGatewayDB(t)
+			coordPath := newTestCoordDB(t)
+			startUTC := time.Date(2026, 7, 9, 15, 0, 0, 0, time.UTC)
+			endUTC := startUTC.Add(10 * time.Second)
+			requestID := "h_tier2_" + tc.name
+			insertGwRow(t, gwPath, requestID, "acct-A", 0, tc.code, startUTC.Add(time.Second))
+			insertQuotaReservation(t, gwPath, requestID, "acct-A", "refunded", startUTC.Add(time.Second))
+
+			results := []buyer.Result{{
+				RequestID:  requestID,
+				Model:      "test-model",
+				Outcome:    "http_error",
+				HTTPStatus: tc.status,
+				StartUTC:   startUTC.Add(time.Second),
+				EndUTC:     startUTC.Add(2 * time.Second),
+			}}
+
+			r, err := Run(makeScenario(coordPath, gwPath), results, startUTC, endUTC)
+			if err != nil {
+				t.Fatalf("Run: %v", err)
+			}
+			if len(r.MatchedSuccesses) != 0 {
+				t.Fatalf("failed harness tier2 response must not produce matched success pairs, got %d", len(r.MatchedSuccesses))
+			}
+			if len(r.UnmatchedGatewayOKRows) != 0 {
+				t.Fatalf("refunded tier2 audit row must not be reported as I1 gateway orphan, got %v", r.UnmatchedGatewayOKRows)
+			}
+			if len(r.GatewaySettlementRequests) != 1 {
+				t.Fatalf("GatewaySettlementRequests=%v, want one tier2 audit evidence row", r.GatewaySettlementRequests)
+			}
+			evidence := r.GatewaySettlementRequests[0]
+			if evidence.RequestID != requestID || evidence.AccountID != "acct-A" || evidence.Outcome != tc.code || evidence.TotalTokens != 0 || evidence.ReservationStatus != "refunded" {
+				t.Fatalf("gateway audit evidence = %+v, want acct/request %s zero-token refunded", evidence, tc.code)
 			}
 		})
 	}
@@ -1337,11 +1526,21 @@ func newTestGatewayDB(t *testing.T) string {
 	if _, err := db.Exec(`CREATE TABLE usage_events (
 		request_id        TEXT NOT NULL,
 		account_id        TEXT NOT NULL DEFAULT '',
+		prompt_tokens     INTEGER NOT NULL DEFAULT 0,
 		completion_tokens INTEGER NOT NULL DEFAULT 0,
+		total_tokens      INTEGER NOT NULL DEFAULT 0,
 		outcome           TEXT NOT NULL,
 		created_at        TEXT NOT NULL
 	)`); err != nil {
 		t.Fatalf("create usage_events: %v", err)
+	}
+	if _, err := db.Exec(`CREATE TABLE quota_reservations (
+		request_id TEXT NOT NULL,
+		account_id TEXT NOT NULL DEFAULT '',
+		status     TEXT NOT NULL,
+		created_at TEXT NOT NULL
+	)`); err != nil {
+		t.Fatalf("create quota_reservations: %v", err)
 	}
 	return path
 }
@@ -1354,10 +1553,25 @@ func insertGwRow(t *testing.T, path, requestID, accountID string, completionToke
 	}
 	defer db.Close()
 	if _, err := db.Exec(
-		`INSERT INTO usage_events(request_id, account_id, completion_tokens, outcome, created_at) VALUES (?, ?, ?, ?, ?)`,
-		requestID, accountID, completionTokens, outcome, createdAt.UTC().Format(time.RFC3339Nano),
+		`INSERT INTO usage_events(request_id, account_id, completion_tokens, total_tokens, outcome, created_at) VALUES (?, ?, ?, ?, ?, ?)`,
+		requestID, accountID, completionTokens, completionTokens, outcome, createdAt.UTC().Format(time.RFC3339Nano),
 	); err != nil {
 		t.Fatalf("insert gw row: %v", err)
+	}
+}
+
+func insertQuotaReservation(t *testing.T, path, requestID, accountID, status string, createdAt time.Time) {
+	t.Helper()
+	db, err := sql.Open("sqlite", path)
+	if err != nil {
+		t.Fatalf("open gateway db: %v", err)
+	}
+	defer db.Close()
+	if _, err := db.Exec(
+		`INSERT INTO quota_reservations(request_id, account_id, status, created_at) VALUES (?, ?, ?, ?)`,
+		requestID, accountID, status, createdAt.UTC().Format(time.RFC3339Nano),
+	); err != nil {
+		t.Fatalf("insert quota reservation: %v", err)
 	}
 }
 


### PR DESCRIPTION
## Summary

Live SPEC-029 e2e on 2026-07-09 against `https://api.streamvc.live` showed that successful requests reconciled cleanly, but buyer-visible HTTP 503 no-provider responses did not have matching gateway `usage_events` rows. The harness captured `X-Request-ID`; the I2 failure was the missing durable settlement/audit row, not missing request-id propagation.

This PR makes admitted, refunded no-provider 5xx paths write a zero-token `usage_events` audit row before refunding the quota reservation, and teaches the network harness reconciler that `no_provider_available` is a terminal gateway outcome.

## Live evidence

- `spec029-live-alias-smoke-20260709T131850Z`: 2/2 successful, I1-I4 passed
- `spec029-live-alias-sustained-throughput-20260709T132104Z`: 32 success / 28 HTTP 503; I2 failed for 28 5xx responses missing gateway settlement rows
- `spec029-live-alias-ttft-small-20260709T132922Z`: 19 success / 1 HTTP 503; I2 failed for 1 5xx response missing gateway settlement row

Local artifact root: `/Users/augstar/macprovider-live-e2e-spec029/test/network-harness/artifacts/`

## Changes

- Gateway: record zero-token `no_provider_available` audit rows for refunded no-provider 5xx pass-throughs.
- Gateway tests: assert these 503 paths do not charge buyer quota, do refund the reservation, and do retain a usage audit row.
- Harness reconciler: accept `no_provider_available` as settlement-complete for I2 reconciliation.

## Validation

- `go test ./internal/router -run 'TestGatewayCoord503Retry|TestCapacityRejection503|TestCoordinatorSuppliedRetryExhaustedHeader|TestCoordinatorSuppliedRetryExhaustedHeaderDoesNotCharge|TestCoordinator404|TestCoordinatorGenericValidation|TestCoordinatorTier2Policy' -count=1` from `phase5-gateway/`
- `go test ./internal/reconcile -run 'TestIsSettlementCompleteIncludesRefundedNoProviderAudit|TestSseErrorCorroboratesOutcome' -count=1` from `test/network-harness/`
- `go test ./...` from `phase5-gateway/`
- `go test ./...` from `test/network-harness/`
- `git diff --check`

## Not tested

- Live network rerun after deploy. This branch is not deployed yet.
