### PR TITLE
fix(malibu): show coordinator connection status, not just local ready

### DIFF
--- a/phase3-binary/app/Sources/Malibu/Agent/AgentSnapshot.swift
+++ b/phase3-binary/app/Sources/Malibu/Agent/AgentSnapshot.swift
@@ -60,6 +60,9 @@ struct AgentSnapshot: Equatable {
     var lastError: String?
 
     var cliVersion: String?
+    /// Whether macprovider-cli reports an active coordinator WebSocket session.
+    /// Distinct from local model readiness (`state == .serving` requires both).
+    var coordinatorConnected: Bool?
     var coordinatorRecommendedVersion: String?
     var latestReleaseVersion: String?
     var cliUpdateInProgress: Bool
@@ -105,6 +108,7 @@ struct AgentSnapshot: Equatable {
         thermalState: nil,
         lastError: nil,
         cliVersion: nil,
+        coordinatorConnected: nil,
         coordinatorRecommendedVersion: nil,
         latestReleaseVersion: nil,
         cliUpdateInProgress: false,
@@ -115,7 +119,15 @@ struct AgentSnapshot: Equatable {
 
 enum AgentSnapshotPresenter {
     private static func isActive(_ s: AgentSnapshot) -> Bool {
-        s.state == .serving || s.state == .paused
+        s.state == .serving || s.state == .paused || isLocalOnly(s)
+    }
+
+    private static func isNetworkReady(_ s: AgentSnapshot) -> Bool {
+        s.state == .serving && s.coordinatorConnected == true
+    }
+
+    private static func isLocalOnly(_ s: AgentSnapshot) -> Bool {
+        s.state == .reconnecting && s.currentModelID != nil
     }
 
     static func short(_ s: AgentSnapshot) -> String {
@@ -136,7 +148,8 @@ enum AgentSnapshotPresenter {
         case .starting:     return "Starting…"
         case .serving:      return "Serving"
         case .paused:       return "Paused"
-        case .reconnecting: return "Reconnecting…"
+        case .reconnecting:
+            return isLocalOnly(s) ? "Local only" : "Reconnecting…"
         case .error:        return "Error"
         }
     }
@@ -144,9 +157,11 @@ enum AgentSnapshotPresenter {
     static func dashboardSubtitle(_ s: AgentSnapshot) -> String? {
         switch s.state {
         case .serving where s.earningsUsdcToday == nil:
-            return "Provider connected · waiting for first paid job"
+            return "Connected to coordinator · waiting for first paid job"
         case .serving:
             return s.currentModelID
+        case .reconnecting where isLocalOnly(s):
+            return s.lastError ?? "Model loaded locally · reconnecting to coordinator"
         case .reconnecting:
             return s.lastError ?? "Checking background provider…"
         case .starting:
@@ -164,7 +179,11 @@ enum AgentSnapshotPresenter {
         case .starting:     return "Starting…"
         case .serving:      return "Serving " + (s.currentModelID ?? "model")
         case .paused:       return "Paused"
-        case .reconnecting: return "Reconnecting…"
+        case .reconnecting:
+            if isLocalOnly(s) {
+                return "Local only · " + (s.currentModelID ?? "model loaded")
+            }
+            return "Reconnecting…"
         case .error:        return s.lastError ?? "Error"
         }
     }
@@ -197,6 +216,8 @@ enum AgentSnapshotPresenter {
 
     static func modelLine(_ s: AgentSnapshot) -> String {
         if let model = s.currentModelID { return model }
+        if isNetworkReady(s) { return "Connected" }
+        if isLocalOnly(s) { return "Local only" }
         return isActive(s) ? "Connected" : "Not running"
     }
 

--- a/phase3-binary/app/Sources/Malibu/Agent/MalibuAgent.swift
+++ b/phase3-binary/app/Sources/Malibu/Agent/MalibuAgent.swift
@@ -203,11 +203,9 @@ final class MalibuAgent: ObservableObject {
                 monitorsLaunchdProvider = true
                 providerStartFailure = nil
                 await applyProviderSnapshot(port: port)
-                snapshot.state = .serving
-                snapshot.lastError = nil
                 startHealthPolling(port: port)
                 await refreshEarnings()
-                return true
+                return snapshot.state == .serving
             }
             if let failure = diagnosedProviderFailure() {
                 providerStartFailure = failure
@@ -248,8 +246,9 @@ final class MalibuAgent: ObservableObject {
     }
 
     private func applyProviderSnapshot(port: Int) async {
-        await applyHealthSnapshot(port: port)
+        let localReady = await applyHealthSnapshot(port: port)
         if let status = await InstalledProviderMonitor.fetchStatus(port: port) {
+            snapshot.coordinatorConnected = status.coordinatorConnected
             if let version = status.binaryVersion {
                 snapshot.cliVersion = ProviderCLIVersion.normalize(version)
             }
@@ -257,23 +256,14 @@ final class MalibuAgent: ObservableObject {
                 snapshot.coordinatorRecommendedVersion = ProviderCLIVersion.normalize(recommended)
             }
         }
+        reconcileNetworkState(localReady: localReady)
         await refreshLatestReleaseIfNeeded()
     }
 
-    private func refreshLatestReleaseIfNeeded() async {
-        if let fetchedAt = latestReleaseFetchedAt,
-           Date().timeIntervalSince(fetchedAt) < latestReleaseTTL,
-           snapshot.latestReleaseVersion != nil {
-            return
-        }
-        if let tag = await GitHubLatestReleaseClient.fetchTag() {
-            latestReleaseFetchedAt = Date()
-            snapshot.latestReleaseVersion = tag
-        }
-    }
-
-    private func applyHealthSnapshot(port: Int) async {
-        guard let health = await InstalledProviderMonitor.fetchHealth(port: port) else { return }
+    /// Local /v1/health readiness only — coordinator session is reconciled separately.
+    @discardableResult
+    private func applyHealthSnapshot(port: Int) async -> Bool {
+        guard let health = await InstalledProviderMonitor.fetchHealth(port: port) else { return false }
         if let model = health.model, !model.isEmpty {
             snapshot.currentModelID = model
         }
@@ -302,8 +292,44 @@ final class MalibuAgent: ObservableObject {
         if let restarts = health.restartCount {
             snapshot.restartCount = restarts
         }
-        if health.ready {
+        return health.ready
+    }
+
+    /// Serving requires both local model readiness and an active coordinator session.
+    private func reconcileNetworkState(localReady: Bool) {
+        guard snapshot.state != .paused else { return }
+        if localReady && snapshot.coordinatorConnected == true {
             snapshot.state = .serving
+            snapshot.lastError = nil
+            return
+        }
+        if localReady {
+            snapshot.state = .reconnecting
+            snapshot.lastError = coordinatorDisconnectMessage()
+            return
+        }
+    }
+
+    private func coordinatorDisconnectMessage() -> String {
+        switch snapshot.coordinatorConnected {
+        case false:
+            return "Model loaded locally · not connected to coordinator"
+        case nil:
+            return "Model loaded locally · checking coordinator connection…"
+        case true:
+            return "Checking background provider…"
+        }
+    }
+
+    private func refreshLatestReleaseIfNeeded() async {
+        if let fetchedAt = latestReleaseFetchedAt,
+           Date().timeIntervalSince(fetchedAt) < latestReleaseTTL,
+           snapshot.latestReleaseVersion != nil {
+            return
+        }
+        if let tag = await GitHubLatestReleaseClient.fetchTag() {
+            latestReleaseFetchedAt = Date()
+            snapshot.latestReleaseVersion = tag
         }
     }
 
@@ -328,11 +354,6 @@ final class MalibuAgent: ObservableObject {
                 guard let self else { return }
                 if await InstalledProviderMonitor.isHealthy(port: port) {
                     await self.applyProviderSnapshot(port: port)
-                    await MainActor.run {
-                        if self.snapshot.state != .serving && self.snapshot.state != .paused {
-                            self.snapshot.state = .serving
-                        }
-                    }
                     await self.refreshEarnings()
                 } else if self.monitorsLaunchdProvider {
                     await MainActor.run {
@@ -396,6 +417,9 @@ final class MalibuAgent: ObservableObject {
                 try? await Task.sleep(nanoseconds: 15_000_000_000)
                 try? await client.send(.metricsRequest)
                 try? await client.send(.statusRequest)
+                if let port = ProviderConfig.readHTTPPort() {
+                    await self?.applyProviderSnapshot(port: port)
+                }
                 await self?.refreshEarnings()
             }
         }
@@ -416,7 +440,9 @@ final class MalibuAgent: ObservableObject {
             // (`state:"ready"`) call the "serving" transition. Accept
             // either spelling so the state contract survives a rename on
             // either side.
-            if state == "ready" || state == "serving" { snapshot.state = .serving }
+            if state == "ready" || state == "serving" {
+                reconcileNetworkState(localReady: true)
+            }
         case let .metricsResponse(
             usdc,
             malibu,
@@ -476,7 +502,7 @@ final class MalibuAgent: ObservableObject {
             }
         case let .resumeAck(accepted, reason):
             if accepted {
-                snapshot.state = .serving
+                reconcileNetworkState(localReady: true)
                 snapshot.pauseAcknowledged = false
             } else {
                 snapshot.lastError = reason ?? "Resume was refused"

--- a/phase3-binary/app/Tests/MalibuTests/AgentSnapshotPresenterTests.swift
+++ b/phase3-binary/app/Tests/MalibuTests/AgentSnapshotPresenterTests.swift
@@ -15,7 +15,16 @@ final class AgentSnapshotPresenterTests: XCTestCase {
     func testShortShowsServingWhenNoEarningsYet() {
         var s = AgentSnapshot.empty
         s.state = .serving
+        s.coordinatorConnected = true
         XCTAssertEqual(AgentSnapshotPresenter.short(s), "Serving")
+    }
+
+    func testShortShowsSyncWhenLocalOnly() {
+        var s = AgentSnapshot.empty
+        s.state = .reconnecting
+        s.coordinatorConnected = false
+        s.currentModelID = "model-a"
+        XCTAssertEqual(AgentSnapshotPresenter.short(s), "Sync")
     }
 
     func testShortShowsSyncWhenReconnecting() {

--- a/phase3-binary/app/Tests/MalibuTests/DashboardViewTests.swift
+++ b/phase3-binary/app/Tests/MalibuTests/DashboardViewTests.swift
@@ -5,6 +5,7 @@ final class DashboardViewTests: XCTestCase {
     func testOptionalDashboardFieldsRenderFriendlyZerosWhenServing() {
         var snapshot = AgentSnapshot.empty
         snapshot.state = .serving
+        snapshot.coordinatorConnected = true
 
         XCTAssertEqual(AgentSnapshotPresenter.modelLine(snapshot), "Connected")
         XCTAssertTrue(AgentSnapshotPresenter.requestsLine(snapshot).contains("0 today"))
@@ -16,8 +17,27 @@ final class DashboardViewTests: XCTestCase {
         XCTAssertEqual(AgentSnapshotPresenter.dashboardHeadline(snapshot), "Serving")
         XCTAssertEqual(
             AgentSnapshotPresenter.dashboardSubtitle(snapshot),
-            "Provider connected · waiting for first paid job"
+            "Connected to coordinator · waiting for first paid job"
         )
+    }
+
+    func testLocalOnlyStateWhenCoordinatorDisconnected() {
+        var snapshot = AgentSnapshot.empty
+        snapshot.state = .reconnecting
+        snapshot.coordinatorConnected = false
+        snapshot.currentModelID = "qwen3-coder-30b-a3b-instruct"
+        snapshot.lastError = "Model loaded locally · not connected to coordinator"
+
+        XCTAssertEqual(AgentSnapshotPresenter.dashboardHeadline(snapshot), "Local only")
+        XCTAssertEqual(
+            AgentSnapshotPresenter.dashboardSubtitle(snapshot),
+            "Model loaded locally · not connected to coordinator"
+        )
+        XCTAssertEqual(
+            AgentSnapshotPresenter.stateLine(snapshot),
+            "Local only · qwen3-coder-30b-a3b-instruct"
+        )
+        XCTAssertEqual(AgentSnapshotPresenter.short(snapshot), "Sync")
     }
 
     func testPopulatedDashboardFieldsRenderValues() {


### PR DESCRIPTION
## Summary
- Malibu no longer shows **Serving** from local `/v1/health` alone when `macprovider-cli` reports `coordinator.connected=false`.
- Wire existing `/v1/status` coordinator session data into `AgentSnapshot` and reconcile UI state from both local readiness and coordinator connectivity.
- When the model is loaded locally but the coordinator session is down, the menu bar shows **Sync** and the dashboard shows **Local only** with explicit copy (`Model loaded locally · not connected to coordinator`).

## Test plan
- [x] `xcodebuild -project Malibu.xcodeproj -scheme Malibu test -only-testing:MalibuTests` (123 tests, 0 failures)
- [ ] Manual: provider with local `ready` but coordinator auth-reject loop shows **Local only / Sync**, not **Serving**
- [ ] Manual: fully connected provider still shows **Serving** and earnings subtitle


Made with [Cursor](https://cursor.com)