### PR TITLE
Release v1.8.20: Malibu coordinator-aware Serving status

### DIFF
--- a/phase3-binary/Sources/macprovider-cli/CoordinatorClient.swift
+++ b/phase3-binary/Sources/macprovider-cli/CoordinatorClient.swift
@@ -165,7 +165,7 @@ final class CaffeinateSleepAssertion: ProviderSleepAssertion, @unchecked Sendabl
 actor CoordinatorClient {
     typealias SendOverride = @Sendable (sending [String: Any]) async throws -> Void
 
-    static let binaryVersion = "1.8.19"
+    static let binaryVersion = "1.8.20"
     private static let keepaliveDebugEnabled = ProcessInfo.processInfo.environment["MACPROVIDER_KEEPALIVE_DEBUG"] == "1"
 
     private let coordinatorURL: URL

--- a/phase3-binary/Tests/macprovider-cliTests/CoordinatorClientTests.swift
+++ b/phase3-binary/Tests/macprovider-cliTests/CoordinatorClientTests.swift
@@ -1862,10 +1862,10 @@ final class CoordinatorClientTests: XCTestCase {
         let hello = await client.helloMessage()
         let auth = await client.authInitialMessage(attempt: attempt)
 
-        XCTAssertEqual(CoordinatorClient.binaryVersion, "1.8.19")
-        XCTAssertEqual(MacProviderCLI.configuration.version, "1.8.19")
-        XCTAssertEqual(hello["binary_version"] as? String, "1.8.19")
-        XCTAssertEqual(auth["binary_version"] as? String, "1.8.19")
+        XCTAssertEqual(CoordinatorClient.binaryVersion, "1.8.20")
+        XCTAssertEqual(MacProviderCLI.configuration.version, "1.8.20")
+        XCTAssertEqual(hello["binary_version"] as? String, "1.8.20")
+        XCTAssertEqual(auth["binary_version"] as? String, "1.8.20")
     }
 
     func testAuthInitialDefaultsToSingleEntryCatalog() async throws {

--- a/phase3-binary/app/Tests/MalibuTests/MalibuUpdateConfigurationTests.swift
+++ b/phase3-binary/app/Tests/MalibuTests/MalibuUpdateConfigurationTests.swift
@@ -18,15 +18,15 @@ final class MalibuUpdateConfigurationTests: XCTestCase {
     }
 
     func testVersionedDownloadURLUsesTagSuffix() {
-        let url = MalibuUpdateConfiguration.releaseDownloadURL(tag: "v1.8.19")
-        XCTAssertEqual(url.absoluteString, "https://download.malibu.tech/Malibu-v1.8.19.dmg")
+        let url = MalibuUpdateConfiguration.releaseDownloadURL(tag: "v1.8.20")
+        XCTAssertEqual(url.absoluteString, "https://download.malibu.tech/Malibu-v1.8.20.dmg")
     }
 
     func testReleaseNotesURLPointsAtGitHubTag() {
-        let url = MalibuUpdateConfiguration.releaseNotesURL(tag: "v1.8.19")
+        let url = MalibuUpdateConfiguration.releaseNotesURL(tag: "v1.8.20")
         XCTAssertEqual(
             url.absoluteString,
-            "https://github.com/Augustas11/macprovider/releases/tag/v1.8.19"
+            "https://github.com/Augustas11/macprovider/releases/tag/v1.8.20"
         )
     }
 }

--- a/phase3-binary/app/project.yml
+++ b/phase3-binary/app/project.yml
@@ -27,8 +27,8 @@ settings:
     SWIFT_VERSION: "5.9"
     ENABLE_HARDENED_RUNTIME: YES
     CODE_SIGN_STYLE: Manual
-    MARKETING_VERSION: "1.8.19"
-    CURRENT_PROJECT_VERSION: "18"
+    MARKETING_VERSION: "1.8.20"
+    CURRENT_PROJECT_VERSION: "19"
     OTHER_SWIFT_FLAGS: "-strict-concurrency=complete"
 
 targets:

--- a/phase4-coordinator/dist/coordinator.yaml
+++ b/phase4-coordinator/dist/coordinator.yaml
@@ -238,4 +238,4 @@ providers: []
 
 # Auto-update recommendation surface (2026-07-03 — added post-#332 to unblock air5 v1.7.0 -> v1.7.9)
 coordinator_advertised_version:
-  latest_binary_version: "1.8.19"
+  latest_binary_version: "1.8.20"


### PR DESCRIPTION
## Summary
- Bump `macprovider-cli` and Malibu.app to **v1.8.20**.
- Ships the merged Malibu fix (#515): UI shows **Local only / Sync** when the provider is locally ready but `coordinator.connected=false`, instead of misleading **Serving**.
- Updates Pearl `latest_binary_version` advertisement to `1.8.20`.

## Release plan
- [ ] Merge this PR
- [ ] Tag `v1.8.20` on `main` to trigger `.github/workflows/release.yml`
- [ ] Verify GitHub Release includes `Malibu-v1.8.20.dmg` + `appcast.xml`
- [ ] Confirm `scripts/publish-malibu-latest-dmg.sh` ran in CI (or run manually)
- [ ] Smoke: `bash scripts/verify-malibu-download.sh`

## Test plan
- [x] Malibu update configuration tests pass locally
- [ ] CI green on PR


Made with [Cursor](https://cursor.com)