### PR TITLE
fix(malibu): Release archive switch exhaustiveness

### DIFF
--- a/phase3-binary/app/Sources/Malibu/Agent/MalibuAgent.swift
+++ b/phase3-binary/app/Sources/Malibu/Agent/MalibuAgent.swift
@@ -312,11 +312,11 @@ final class MalibuAgent: ObservableObject {
 
     private func coordinatorDisconnectMessage() -> String {
         switch snapshot.coordinatorConnected {
-        case false:
+        case .some(false):
             return "Model loaded locally · not connected to coordinator"
-        case nil:
+        case .none:
             return "Model loaded locally · checking coordinator connection…"
-        case true:
+        case .some(true):
             return "Checking background provider…"
         }
     }


### PR DESCRIPTION
## Summary
- Fix Release Malibu archive failure on v1.8.20 tag (`switch must be exhaustive` on `Bool?` in `coordinatorDisconnectMessage()`).
- Use explicit `.some(true|false)` / `.none` patterns so Xcode 16.4 Release builds succeed.

## Test plan
- [x] `xcodebuild -configuration Release archive` succeeds locally
- [ ] Re-tag `v1.8.20` after merge and rerun release workflow


Made with [Cursor](https://cursor.com)