### PR TITLE
fix(ops): pin Pearl host key for Malibu CI publish

### DIFF
--- a/scripts/dist/malibu-download-known_hosts
+++ b/scripts/dist/malibu-download-known_hosts
@@ -1,0 +1,3 @@
+# Pearl VPS host key for download.malibu.tech (159.223.165.194).
+# Refresh with: ssh-keyscan -t ed25519 159.223.165.194
+159.223.165.194 ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIH6BDJCMyc+Jw2+U3D+i4clQCGMgBRYri++4jUE3mY+p

--- a/scripts/malibu-download-ssh.sh
+++ b/scripts/malibu-download-ssh.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# Shared OpenSSH options for Malibu download.malibu.tech Pearl uploads.
+# Source after SSH_KEY, VPS_USER, VPS_HOST, and SCRIPT_DIR are set.
+#
+# Optional overrides:
+#   MALIBU_DOWNLOAD_KNOWN_HOSTS — path to pinned known_hosts file
+#   MALIBU_DOWNLOAD_SSH_CONNECT_TIMEOUT — seconds (default 15)
+
+: "${SCRIPT_DIR:?SCRIPT_DIR must be set before sourcing malibu-download-ssh.sh}"
+: "${SSH_KEY:?SSH_KEY must be set before sourcing malibu-download-ssh.sh}"
+: "${VPS_USER:?VPS_USER must be set before sourcing malibu-download-ssh.sh}"
+: "${VPS_HOST:?VPS_HOST must be set before sourcing malibu-download-ssh.sh}"
+
+MALIBU_DOWNLOAD_KNOWN_HOSTS="${MALIBU_DOWNLOAD_KNOWN_HOSTS:-$SCRIPT_DIR/dist/malibu-download-known_hosts}"
+MALIBU_DOWNLOAD_SSH_CONNECT_TIMEOUT="${MALIBU_DOWNLOAD_SSH_CONNECT_TIMEOUT:-15}"
+
+if [[ ! -f "$MALIBU_DOWNLOAD_KNOWN_HOSTS" ]]; then
+  printf '[malibu-download-ssh] ERROR: missing known_hosts: %s\n' "$MALIBU_DOWNLOAD_KNOWN_HOSTS" >&2
+  return 1 2>/dev/null || exit 1
+fi
+
+malibu_download_ssh() {
+  ssh \
+    -i "$SSH_KEY" \
+    -o "ConnectTimeout=$MALIBU_DOWNLOAD_SSH_CONNECT_TIMEOUT" \
+    -o "UserKnownHostsFile=$MALIBU_DOWNLOAD_KNOWN_HOSTS" \
+    -o StrictHostKeyChecking=yes \
+    -p 22 \
+    "$VPS_USER@$VPS_HOST" \
+    "$@"
+}
+
+malibu_download_scp() {
+  scp \
+    -i "$SSH_KEY" \
+    -o "ConnectTimeout=$MALIBU_DOWNLOAD_SSH_CONNECT_TIMEOUT" \
+    -o "UserKnownHostsFile=$MALIBU_DOWNLOAD_KNOWN_HOSTS" \
+    -o StrictHostKeyChecking=yes \
+    -P 22 \
+    "$@"
+}

--- a/scripts/publish-malibu-latest-dmg.sh
+++ b/scripts/publish-malibu-latest-dmg.sh
@@ -12,6 +12,7 @@
 #   MALIBU_DOWNLOAD_SSH_KEY   default ~/.ssh/pearl_operator_ed25519
 #   MALIBU_DOWNLOAD_VPS_USER  default root
 #   MALIBU_DOWNLOAD_WEBROOT   default /var/www/malibu-download
+#   MALIBU_DOWNLOAD_KNOWN_HOSTS  pinned Pearl host key (see scripts/dist/)
 #   VERIFY_MALIBU_DOWNLOAD=1   run verify-malibu-download.sh after upload
 
 set -euo pipefail
@@ -20,6 +21,8 @@ die() {
   printf '[publish-malibu-latest-dmg] ERROR: %s\n' "$*" >&2
   exit 1
 }
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 
 tag="${1:-}"
 [[ "$tag" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]] || die "usage: $0 vX.Y.Z"
@@ -68,20 +71,20 @@ EOF
   exit 0
 fi
 
-SSH="ssh -i $SSH_KEY -o ConnectTimeout=15 -p 22 $VPS_USER@$VPS_HOST"
-SCP="scp -i $SSH_KEY -P 22"
+# shellcheck source=malibu-download-ssh.sh
+source "$SCRIPT_DIR/malibu-download-ssh.sh"
 
-$SSH "install -d -o www-data -g www-data -m 0755 $WEBROOT"
-$SCP "$asset" "$VPS_USER@$VPS_HOST:/tmp/malibu-${versioned_key}" >/dev/null
-$SCP "$work/${dmg_name}.sha256" "$VPS_USER@$VPS_HOST:/tmp/malibu-${dmg_name}.sha256" >/dev/null
+malibu_download_ssh "install -d -o www-data -g www-data -m 0755 $WEBROOT"
+malibu_download_scp "$asset" "$VPS_USER@$VPS_HOST:/tmp/malibu-${versioned_key}" >/dev/null
+malibu_download_scp "$work/${dmg_name}.sha256" "$VPS_USER@$VPS_HOST:/tmp/malibu-${dmg_name}.sha256" >/dev/null
 appcast="$work/appcast.xml"
 if [[ -f "$appcast" ]]; then
-  $SCP "$appcast" "$VPS_USER@$VPS_HOST:/tmp/malibu-appcast.xml" >/dev/null
+  malibu_download_scp "$appcast" "$VPS_USER@$VPS_HOST:/tmp/malibu-appcast.xml" >/dev/null
 else
   printf '[publish-malibu-latest-dmg] WARN: appcast.xml missing from release %s\n' "$tag" >&2
 fi
 
-$SSH "set -e
+malibu_download_ssh "set -e
   install -o www-data -g www-data -m 0644 /tmp/malibu-${versioned_key} ${WEBROOT}/${versioned_key}
   install -o www-data -g www-data -m 0644 /tmp/malibu-${versioned_key} ${WEBROOT}/${latest_key}
   install -o www-data -g www-data -m 0644 /tmp/malibu-${dmg_name}.sha256 ${WEBROOT}/${dmg_name}.sha256
@@ -96,6 +99,5 @@ printf '[publish-malibu-latest-dmg] ok: %s/%s + latest.dmg on Pearl (sha256=%s)\
   "$WEBROOT" "$versioned_key" "$sha256"
 
 if [[ "${VERIFY_MALIBU_DOWNLOAD:-0}" == "1" ]]; then
-  script_dir="$(cd "$(dirname "$0")" && pwd)"
-  bash "$script_dir/verify-malibu-download.sh"
+  bash "$SCRIPT_DIR/verify-malibu-download.sh"
 fi

--- a/scripts/setup-malibu-download-pearl.sh
+++ b/scripts/setup-malibu-download-pearl.sh
@@ -34,8 +34,9 @@ NGINX_SITE="$SCRIPT_DIR/dist/nginx-download.malibu.tech.conf"
 [[ -f "$NGINX_SITE" ]] || { echo "missing $NGINX_SITE" >&2; exit 1; }
 [[ -f "$SSH_KEY" ]] || { echo "missing SSH key: $SSH_KEY" >&2; exit 1; }
 
-SSH="ssh -i $SSH_KEY -o ConnectTimeout=10 -p 22 $VPS_USER@$VPS_HOST"
-SCP="scp -i $SSH_KEY -P 22"
+MALIBU_DOWNLOAD_SSH_CONNECT_TIMEOUT=10
+# shellcheck source=malibu-download-ssh.sh
+source "$SCRIPT_DIR/malibu-download-ssh.sh"
 
 log() { printf '[setup-malibu-download-pearl] %s\n' "$*"; }
 
@@ -68,7 +69,7 @@ EOF
 }
 
 log "step 1/7: confirm SSH"
-$SSH 'hostname >/dev/null && echo ok' >/dev/null
+malibu_download_ssh 'hostname >/dev/null && echo ok' >/dev/null
 
 log "step 2/7: DNS check"
 if dns_ready; then
@@ -96,7 +97,7 @@ else
 fi
 
 log "step 3/7: ensure certbot + docroot on Pearl"
-$SSH "set -e
+malibu_download_ssh "set -e
   DEBIAN_FRONTEND=noninteractive apt-get update -qq
   DEBIAN_FRONTEND=noninteractive apt-get install -qq -y certbot python3-certbot-nginx nginx >/dev/null || true
   install -d -o www-data -g www-data -m 0755 /var/www/html
@@ -104,8 +105,8 @@ $SSH "set -e
 "
 
 log "step 4/7: upload nginx site + install port-80 stub"
-$SCP "$NGINX_SITE" "$VPS_USER@$VPS_HOST:/tmp/nginx-malibu-download.conf" >/dev/null
-$SSH "set -e
+malibu_download_scp "$NGINX_SITE" "$VPS_USER@$VPS_HOST:/tmp/nginx-malibu-download.conf" >/dev/null
+malibu_download_ssh "set -e
   if [ ! -f /etc/letsencrypt/live/$DOMAIN/fullchain.pem ]; then
     cat > /etc/nginx/sites-available/$DOMAIN <<'NGINX_STUB'
 server {
@@ -136,7 +137,7 @@ NGINX_STUB
 
 if [[ "${SKIP_CERT:-0}" != "1" ]] && dns_ready; then
   log "step 5/7: obtain Let's Encrypt cert (webroot)"
-  $SSH "set -e
+  malibu_download_ssh "set -e
     if [ -f /etc/letsencrypt/live/$DOMAIN/fullchain.pem ]; then
       echo '  cert already present'
     else
@@ -145,7 +146,7 @@ if [[ "${SKIP_CERT:-0}" != "1" ]] && dns_ready; then
   "
 
   log "step 6/7: install full TLS vhost"
-  $SSH "set -e
+  malibu_download_ssh "set -e
     install -o root -g root -m 0644 /tmp/nginx-malibu-download.conf /etc/nginx/sites-available/$DOMAIN
     rm -f /tmp/nginx-malibu-download.conf
     ln -sf /etc/nginx/sites-available/$DOMAIN /etc/nginx/sites-enabled/$DOMAIN
@@ -153,7 +154,7 @@ if [[ "${SKIP_CERT:-0}" != "1" ]] && dns_ready; then
   "
 else
   log "step 5-6/7: skipped TLS (add name.com A record, then re-run without SKIP_DNS_WAIT)"
-  $SSH "rm -f /tmp/nginx-malibu-download.conf" || true
+  malibu_download_ssh "rm -f /tmp/nginx-malibu-download.conf" || true
 fi
 
 log "step 7/7: verify Pearl endpoint"

--- a/scripts/test-malibu-download-publish.sh
+++ b/scripts/test-malibu-download-publish.sh
@@ -5,6 +5,8 @@ ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 SETUP="$ROOT/scripts/setup-malibu-download-pearl.sh"
 PUBLISH="$ROOT/scripts/publish-malibu-latest-dmg.sh"
 VERIFY="$ROOT/scripts/verify-malibu-download.sh"
+SSH_HELPER="$ROOT/scripts/malibu-download-ssh.sh"
+KNOWN_HOSTS="$ROOT/scripts/dist/malibu-download-known_hosts"
 NGINX="$ROOT/scripts/dist/nginx-download.malibu.tech.conf"
 
 fail() {
@@ -12,11 +14,18 @@ fail() {
   exit 1
 }
 
-for f in "$SETUP" "$PUBLISH" "$VERIFY"; do
+for f in "$SETUP" "$PUBLISH" "$VERIFY" "$SSH_HELPER"; do
   [[ -f "$f" ]] || fail "missing $f"
   bash -n "$f" || fail "bash -n $f"
 done
+[[ -f "$KNOWN_HOSTS" ]] || fail "missing $KNOWN_HOSTS"
 [[ -f "$NGINX" ]] || fail "missing $NGINX"
+
+grep -q 'malibu-download-known_hosts' "$SSH_HELPER" ||
+  fail 'ssh helper should pin Pearl host key via known_hosts'
+
+grep -q 'StrictHostKeyChecking=yes' "$SSH_HELPER" ||
+  fail 'ssh helper should enforce StrictHostKeyChecking=yes'
 
 grep -q 'setup-malibu-download-pearl.sh' "$PUBLISH" ||
   grep -q 'Pearl' "$PUBLISH" ||


### PR DESCRIPTION
## Summary
- Add pinned Pearl ed25519 host key at `scripts/dist/malibu-download-known_hosts`.
- Add `scripts/malibu-download-ssh.sh` helper (`StrictHostKeyChecking=yes`, `UserKnownHostsFile=...`).
- Wire publish + setup scripts through the helper so release CI can upload `latest.dmg` / `appcast.xml` without manual Pearl publish.

## Context
v1.8.20 release built and published to GitHub successfully, but the **Publish Malibu latest.dmg** step failed with `Host key verification failed` on the ephemeral Actions runner.

## Test plan
- [x] `bash scripts/test-malibu-download-publish.sh`
- [x] `bash -n` on publish/setup/ssh helper scripts
- [ ] Next tag release: confirm CI Pearl publish step passes


Made with [Cursor](https://cursor.com)