### PR TITLE
Enforce one provider runtime owner

### DIFF
--- a/ops/macprovider-watchdog/README.md
+++ b/ops/macprovider-watchdog/README.md
@@ -1,18 +1,26 @@
 # macprovider-watchdog
 
-External LaunchAgent that verifies the installed Mac provider process
-is alive and locally healthy. It ships alongside every install of
-`macprovider-cli` via the public `get.streamvc.live/install.sh` flow.
+External LaunchAgent that observes the installed Mac provider process
+and runs auto-update rollback recovery. It ships alongside every
+install of `macprovider-cli` via the public
+`get.streamvc.live/install.sh` flow.
 
 ## What it does
 
 Every 60 seconds, `watchdog.sh` checks that exactly one installed
 `macprovider-cli` process is running and that the provider's local
-`/v1/health` endpoint responds successfully. If either check fails,
-it issues `launchctl kickstart -k gui/$UID/live.streamvc.macprovider`
-so launchd restarts the provider. Coordinator TCP state is logged as
-advisory only; another process reaching the coordinator is not treated
-as proof that the provider is healthy.
+`/v1/health` endpoint responds successfully. If either check fails, it
+logs the condition and leaves restart ownership to the main
+`live.streamvc.macprovider` LaunchAgent's `KeepAlive` policy. This is
+intentional: #520 made the companion watchdog observer-only so there is
+one routine runtime manager for the provider singleton. Coordinator TCP
+state is logged as advisory only; another process reaching the
+coordinator is not treated as proof that the provider is healthy.
+
+The watchdog still runs auto-update rollback recovery. A rollback may
+bootstrap/kick the main provider label after restoring the prior binary
+so the restored executable takes effect; that is a bounded recovery
+action, not routine liveness ownership.
 
 It reads the provider identity from
 `~/.config/macprovider/config.yaml` (the file
@@ -46,7 +54,7 @@ LaunchAgent before bootstrapping the new one.
 ### Inspect
 
 The watchdog logs to `~/Library/Logs/macprovider/watchdog.log` (only
-when it detects an issue or kicks the provider — healthy ticks are
+when it detects an issue or performs rollback work — healthy ticks are
 silent so the log does not bloat). To see whether the LaunchAgent is
 loaded:
 
@@ -70,14 +78,13 @@ The main provider uninstaller (`phase3-binary/dist/uninstall.sh`)
 removes the watchdog too — operators only need this when they want to
 remove the watchdog without removing the provider.
 
-## Why this is operator-visibility insurance, not the fix
+## Why this is observer visibility, not runtime ownership
 
-The underlying bug is in the Swift WebSocket reconnect loop. PR #204
-landed the in-process bounded send + Darwin.exit(1) liveness watchdog
-that prevents the wedge from happening at all on new builds. This
-external LaunchAgent is the belt-and-suspenders safety net for
-operators still on older builds, and a long-tail catch for any future
-regression in the in-process protection.
+The provider process owns in-process liveness checks, and the main
+`live.streamvc.macprovider` LaunchAgent owns routine restarts through
+`KeepAlive`. This external LaunchAgent records local-health evidence for
+operators and performs bounded auto-update rollback recovery, but it does
+not kickstart the provider for normal liveness failures.
 
 ## Environment overrides (advanced)
 

--- a/ops/macprovider-watchdog/watchdog.sh
+++ b/ops/macprovider-watchdog/watchdog.sh
@@ -30,8 +30,8 @@ LOG_PATH="$LOG_DIR/watchdog.log"
 # cold-cache model load — re-disarms the watchdog and prevents the
 # stale-arming restart loop the R1 fix did not cover (R2 ARCH HIGH).
 #
-# Grace rule: after we DO kick, we wait at least KICK_GRACE_SECONDS
-# before kicking again. This covers the post-kick model-reload
+# Grace rule: after we observe a restart-worthy failure, we wait at least KICK_GRACE_SECONDS
+# before logging another restart request. This covers the post-restart model-reload
 # window without re-triggering on the gap between launchd respawn
 # and re-establishing the coordinator socket.
 STATE_DIR="${MACPROVIDER_WATCHDOG_STATE_DIR:-$HOME/.local/share/macprovider-watchdog/state}"
@@ -157,10 +157,8 @@ local_provider_health_ok() {
   "$curl_bin" -fsS --max-time 2 "http://127.0.0.1:${port}/v1/health" >/dev/null 2>&1
 }
 
-kick_provider() {
-  log "kicking $LABEL via launchctl kickstart -k gui/$UID/$LABEL"
-  launchctl kickstart -k "gui/$UID/$LABEL" >> "$LOG_PATH" 2>&1 || \
-    log "launchctl kickstart returned non-zero (likely benign — process may already be restarting)"
+note_provider_restart_request() {
+  log "provider restart requested for $LABEL but skipped: launchd KeepAlive is the sole runtime manager"
 }
 
 now_epoch() { date -u +%s; }
@@ -588,7 +586,7 @@ main() {
   if [ -z "$provider_pid" ]; then
     log "provider process unhealthy: expected exactly one macprovider-cli at $BINARY_PATH"
     now_epoch > "$LAST_KICK_FILE"
-    kick_provider
+    note_provider_restart_request
     exit 0
   fi
   boot_id="$(current_boot_id)"
@@ -608,9 +606,9 @@ main() {
         exit 0
       fi
     fi
-    log "provider process $provider_pid failed local /v1/health after arming; kicking $LABEL"
+    log "provider process $provider_pid failed local /v1/health after arming; leaving restart ownership to launchd KeepAlive for $LABEL"
     now_epoch > "$LAST_KICK_FILE"
-    kick_provider
+    note_provider_restart_request
     exit 0
   fi
   armed_boot=""

--- a/phase3-binary/Sources/macprovider-cli/MacProviderCLI.swift
+++ b/phase3-binary/Sources/macprovider-cli/MacProviderCLI.swift
@@ -470,16 +470,10 @@ struct ServeCommand: AsyncParsableCommand {
         // downstream.
         unsetenv("MACPROVIDER_PROVIDER_TOKEN")
 
-        try Self.runSupportedModelsPreflight(&resolved)
-        try Self.runDrainTimeoutPreflight(resolved)
-        try Self.runServingKnobsPreflight(resolved)
-        try Self.runSpecDecodeHeartbeatCompatibilityPreflight(
-            resolved,
-            coordinatorAcceptsSpecDecodeTelemetry: Self.bundledCoordinatorAcceptsSpecDecodeTelemetry
-        )
-        try Self.runSpecDecodeCapacityPreflight(&resolved)
-        try await Self.runModelArtifactPreflight(resolved, joiningCoordinator: !noJoin)
-        let verifiedDraftModelLoadPath = try Self.runDraftModelArtifactPreflight(resolved, joiningCoordinator: !noJoin)
+        let startupPreflight = try await Self.runServeStartupPreflights(&resolved, joiningCoordinator: !noJoin)
+        let serveLock = startupPreflight.serveLock
+        defer { serveLock.release() }
+        let verifiedDraftModelLoadPath = startupPreflight.verifiedDraftModelLoadPath
 
         printResolvedConfiguration(resolved)
 
@@ -651,6 +645,95 @@ struct ServeCommand: AsyncParsableCommand {
         }
         try withExtendedLifetime(terminationHandlers) {
             try server.run()
+        }
+    }
+
+    static func acquireProviderServeLock(_ config: AppConfig) throws -> ProviderServeLock {
+        do {
+            return try ProviderServeLock.acquire(providerID: config.providerID, port: config.port)
+        } catch let error as ProviderServeLockError {
+            FileHandle.standardError.write(Data((
+                "provider singleton conflict: \(error.description)\n"
+            ).utf8))
+            throw ExitCode(1)
+        }
+    }
+
+    struct ServeStartupPreflightResult {
+        let serveLock: ProviderServeLock
+        let verifiedDraftModelLoadPath: String?
+    }
+
+    static func runServeStartupPreflights(
+        _ resolved: inout AppConfig,
+        joiningCoordinator: Bool,
+        coordinatorAcceptsSpecDecodeTelemetry: Bool = Self.bundledCoordinatorAcceptsSpecDecodeTelemetry,
+        portIsOpen: (Int) -> Bool = MacProviderPortProbe.isOpen,
+        acquireServeLock: (AppConfig) throws -> ProviderServeLock = Self.acquireProviderServeLock,
+        staticInputs: AutotuneStaticInputs = AutotuneStaticInputs(),
+        artifactResolver: CachedModelArtifactResolver = CachedModelArtifactResolver()
+    ) async throws -> ServeStartupPreflightResult {
+        let serveLock = try Self.runPreModelStartupPreflights(
+            &resolved,
+            coordinatorAcceptsSpecDecodeTelemetry: coordinatorAcceptsSpecDecodeTelemetry,
+            portIsOpen: portIsOpen,
+            acquireServeLock: acquireServeLock
+        )
+        do {
+            try await Self.runModelArtifactPreflight(
+                resolved,
+                joiningCoordinator: joiningCoordinator,
+                staticInputs: staticInputs,
+                artifactResolver: artifactResolver
+            )
+            let verifiedDraftModelLoadPath = try Self.runDraftModelArtifactPreflight(
+                resolved,
+                joiningCoordinator: joiningCoordinator
+            )
+            return ServeStartupPreflightResult(
+                serveLock: serveLock,
+                verifiedDraftModelLoadPath: verifiedDraftModelLoadPath
+            )
+        } catch {
+            serveLock.release()
+            throw error
+        }
+    }
+
+    static func runPreModelStartupPreflights(
+        _ resolved: inout AppConfig,
+        coordinatorAcceptsSpecDecodeTelemetry: Bool = Self.bundledCoordinatorAcceptsSpecDecodeTelemetry,
+        portIsOpen: (Int) -> Bool = MacProviderPortProbe.isOpen,
+        acquireServeLock: (AppConfig) throws -> ProviderServeLock = Self.acquireProviderServeLock
+    ) throws -> ProviderServeLock {
+        try Self.runSupportedModelsPreflight(&resolved)
+        try Self.runDrainTimeoutPreflight(resolved)
+        try Self.runServingKnobsPreflight(resolved)
+        try Self.runSpecDecodeHeartbeatCompatibilityPreflight(
+            resolved,
+            coordinatorAcceptsSpecDecodeTelemetry: coordinatorAcceptsSpecDecodeTelemetry
+        )
+        try Self.runSpecDecodeCapacityPreflight(&resolved)
+
+        let serveLock = try acquireServeLock(resolved)
+        do {
+            try Self.assertServePortAvailable(resolved, portIsOpen: portIsOpen)
+        } catch {
+            serveLock.release()
+            throw error
+        }
+        return serveLock
+    }
+
+    static func assertServePortAvailable(
+        _ config: AppConfig,
+        portIsOpen: (Int) -> Bool = MacProviderPortProbe.isOpen
+    ) throws {
+        guard !portIsOpen(config.port) else {
+            FileHandle.standardError.write(Data((
+                "provider singleton conflict: 127.0.0.1:\(config.port) already has a listener\n"
+            ).utf8))
+            throw ExitCode(1)
         }
     }
 

--- a/phase3-binary/Sources/macprovider-cli/ProviderServeLock.swift
+++ b/phase3-binary/Sources/macprovider-cli/ProviderServeLock.swift
@@ -1,0 +1,141 @@
+import Darwin
+import Foundation
+
+enum ProviderServeLockError: Error, Equatable, CustomStringConvertible, LocalizedError {
+    case alreadyRunning(providerID: String?, port: Int, lockPath: String)
+    case directoryCreateFailed(path: String, message: String)
+    case openFailed(path: String, errnoCode: Int32)
+    case lockFailed(path: String, errnoCode: Int32)
+
+    var description: String {
+        switch self {
+        case .alreadyRunning(let providerID, let port, let lockPath):
+            let provider = providerID?.trimmingCharacters(in: .whitespacesAndNewlines)
+            let providerText = provider.flatMap { $0.isEmpty ? nil : "provider_id \($0)" } ?? "this provider"
+            return "\(providerText) is already starting or serving on port \(port) (lock: \(lockPath))"
+        case .directoryCreateFailed(let path, let message):
+            return "could not create provider singleton lock directory \(path): \(message)"
+        case .openFailed(let path, let errnoCode):
+            return "could not open provider singleton lock \(path): \(String(cString: strerror(errnoCode)))"
+        case .lockFailed(let path, let errnoCode):
+            return "could not acquire provider singleton lock \(path): \(String(cString: strerror(errnoCode)))"
+        }
+    }
+
+    var errorDescription: String? { description }
+}
+
+final class ProviderServeLock {
+    let url: URL
+    private var fd: Int32?
+
+    private init(url: URL, fd: Int32) {
+        self.url = url
+        self.fd = fd
+    }
+
+    deinit {
+        release()
+    }
+
+    static func defaultDirectory() -> URL {
+        FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent("Library/Application Support/macprovider/locks", isDirectory: true)
+    }
+
+    static func lockURL(port: Int, directory: URL = defaultDirectory()) -> URL {
+        directory.appendingPathComponent(lockFileName(port: port))
+    }
+
+    static func lockFileName(port: Int) -> String {
+        let raw = "port-\(port)"
+        let readable = sanitizedFileComponent(raw, maxLength: 56)
+        return "serve-\(readable)-\(stableDigest(raw)).lock"
+    }
+
+    static func acquire(
+        providerID: String?,
+        port: Int,
+        directory: URL = defaultDirectory(),
+        fileManager: FileManager = .default
+    ) throws -> ProviderServeLock {
+        do {
+            try fileManager.createDirectory(at: directory, withIntermediateDirectories: true)
+        } catch {
+            throw ProviderServeLockError.directoryCreateFailed(
+                path: directory.path,
+                message: String(describing: error)
+            )
+        }
+
+        let url = lockURL(port: port, directory: directory)
+        let fd = Darwin.open(url.path, O_CREAT | O_RDWR | O_CLOEXEC, mode_t(S_IRUSR | S_IWUSR))
+        guard fd >= 0 else {
+            throw ProviderServeLockError.openFailed(path: url.path, errnoCode: errno)
+        }
+
+        var lockResult: Int32
+        repeat {
+            lockResult = flock(fd, LOCK_EX | LOCK_NB)
+        } while lockResult == -1 && errno == EINTR
+
+        guard lockResult == 0 else {
+            let lockErrno = errno
+            Darwin.close(fd)
+            if lockErrno == EWOULDBLOCK || lockErrno == EAGAIN {
+                throw ProviderServeLockError.alreadyRunning(
+                    providerID: providerID,
+                    port: port,
+                    lockPath: url.path
+                )
+            }
+            throw ProviderServeLockError.lockFailed(path: url.path, errnoCode: lockErrno)
+        }
+
+        writeLockMetadata(fd: fd, providerID: providerID, port: port)
+        return ProviderServeLock(url: url, fd: fd)
+    }
+
+    func release() {
+        guard let fd else { return }
+        _ = flock(fd, LOCK_UN)
+        _ = Darwin.close(fd)
+        self.fd = nil
+    }
+
+    private static func writeLockMetadata(fd: Int32, providerID: String?, port: Int) {
+        _ = Darwin.ftruncate(fd, 0)
+        _ = Darwin.lseek(fd, 0, SEEK_SET)
+        let provider = providerID?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        let payload = "pid=\(getpid())\nprovider_id=\(provider)\nport=\(port)\n"
+        payload.withCString { pointer in
+            _ = Darwin.write(fd, pointer, strlen(pointer))
+        }
+    }
+
+    private static func sanitizedFileComponent(_ value: String, maxLength: Int) -> String {
+        var output = ""
+        output.reserveCapacity(min(value.count, maxLength))
+        for scalar in value.unicodeScalars {
+            guard output.count < maxLength else { break }
+            switch scalar.value {
+            case 48...57, 65...90, 97...122:
+                output.unicodeScalars.append(scalar)
+            case 45, 46, 95:
+                output.unicodeScalars.append(scalar)
+            default:
+                output.append("_")
+            }
+        }
+        return output.isEmpty ? "provider" : output
+    }
+
+    private static func stableDigest(_ value: String) -> String {
+        var hash: UInt64 = 0xcbf29ce484222325
+        for byte in value.utf8 {
+            hash ^= UInt64(byte)
+            hash &*= 0x100000001b3
+        }
+        return String(format: "%016llx", hash)
+    }
+}

--- a/phase3-binary/Tests/macprovider-cliTests/ProviderServeLockTests.swift
+++ b/phase3-binary/Tests/macprovider-cliTests/ProviderServeLockTests.swift
@@ -1,0 +1,86 @@
+import Foundation
+import XCTest
+@testable import macprovider_cli
+
+final class ProviderServeLockTests: XCTestCase {
+    func testLockFileNameIsStableAndFilesystemSafe() {
+        let first = ProviderServeLock.lockFileName(port: 61_919)
+        let second = ProviderServeLock.lockFileName(port: 61_919)
+
+        XCTAssertEqual(first, second)
+        XCTAssertTrue(first.hasPrefix("serve-port-61919-"), first)
+        XCTAssertTrue(first.hasSuffix(".lock"), first)
+        XCTAssertNil(first.range(of: #"[^A-Za-z0-9._-]"#, options: .regularExpression), first)
+    }
+
+    func testSecondAcquireFailsWhileFirstLockIsHeld() throws {
+        let directory = try makeTemporaryDirectory()
+        let first = try ProviderServeLock.acquire(providerID: "mac", port: 61_919, directory: directory)
+        defer { first.release() }
+
+        do {
+            _ = try ProviderServeLock.acquire(providerID: "mac", port: 61_919, directory: directory)
+            XCTFail("second same-provider same-port lock should fail")
+        } catch let error as ProviderServeLockError {
+            guard case .alreadyRunning(let providerID, let port, let lockPath) = error else {
+                XCTFail("unexpected lock error: \(error)")
+                return
+            }
+            XCTAssertEqual(providerID, "mac")
+            XCTAssertEqual(port, 61_919)
+            XCTAssertEqual(lockPath, first.url.path)
+        }
+    }
+
+    func testReleaseAllowsReacquire() throws {
+        let directory = try makeTemporaryDirectory()
+        let first = try ProviderServeLock.acquire(providerID: "mac", port: 61_919, directory: directory)
+        let lockPath = first.url.path
+        first.release()
+
+        let second = try ProviderServeLock.acquire(providerID: "mac", port: 61_919, directory: directory)
+        defer { second.release() }
+
+        XCTAssertEqual(second.url.path, lockPath)
+    }
+
+    func testDifferentPortsCanRunConcurrently() throws {
+        let directory = try makeTemporaryDirectory()
+        let first = try ProviderServeLock.acquire(providerID: "mac", port: 61_919, directory: directory)
+        defer { first.release() }
+
+        let second = try ProviderServeLock.acquire(providerID: "mac", port: 61_920, directory: directory)
+        defer { second.release() }
+
+        XCTAssertNotEqual(first.url.path, second.url.path)
+    }
+
+    func testSamePortDifferentProviderFailsBeforeBind() throws {
+        let directory = try makeTemporaryDirectory()
+        let first = try ProviderServeLock.acquire(providerID: "mac", port: 61_919, directory: directory)
+        defer { first.release() }
+
+        do {
+            _ = try ProviderServeLock.acquire(providerID: "other-provider", port: 61_919, directory: directory)
+            XCTFail("second same-port lock should fail even for a different provider ID")
+        } catch let error as ProviderServeLockError {
+            guard case .alreadyRunning(let providerID, let port, let lockPath) = error else {
+                XCTFail("unexpected lock error: \(error)")
+                return
+            }
+            XCTAssertEqual(providerID, "other-provider")
+            XCTAssertEqual(port, 61_919)
+            XCTAssertEqual(lockPath, first.url.path)
+        }
+    }
+
+    private func makeTemporaryDirectory() throws -> URL {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("ProviderServeLockTests-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+        addTeardownBlock {
+            try? FileManager.default.removeItem(at: url)
+        }
+        return url
+    }
+}

--- a/phase3-binary/Tests/macprovider-cliTests/ServeCommandTests.swift
+++ b/phase3-binary/Tests/macprovider-cliTests/ServeCommandTests.swift
@@ -93,6 +93,61 @@ final class ServeCommandTests: XCTestCase {
         XCTAssertFalse(factoryInvoked)
     }
 
+    func testServeStartupPreflightsAcquireSingletonBeforeModelArtifactPreflight() async throws {
+        let lockDirectory = try tempDir()
+        let heldLock = try ProviderServeLock.acquire(providerID: "mac", port: 61_919, directory: lockDirectory)
+        defer { heldLock.release() }
+        var config = configWithInvalidArtifact(port: 61_919)
+
+        do {
+            _ = try await ServeCommand.runServeStartupPreflights(
+                &config,
+                joiningCoordinator: false,
+                portIsOpen: { _ in false },
+                acquireServeLock: { config in
+                    do {
+                        return try ProviderServeLock.acquire(
+                            providerID: config.providerID,
+                            port: config.port,
+                            directory: lockDirectory
+                        )
+                    } catch is ProviderServeLockError {
+                        throw ExitCode(1)
+                    }
+                }
+            )
+            XCTFail("duplicate serve startup must fail before model artifact preflight")
+        } catch {
+            XCTAssertEqual(error as? ExitCode, ExitCode(1))
+        }
+    }
+
+    func testServeStartupPreflightsRejectOpenPortBeforeModelArtifactPreflightAndReleaseLock() async throws {
+        let lockDirectory = try tempDir()
+        var config = configWithInvalidArtifact(port: 61_920)
+
+        do {
+            _ = try await ServeCommand.runServeStartupPreflights(
+                &config,
+                joiningCoordinator: false,
+                portIsOpen: { port in port == 61_920 },
+                acquireServeLock: { config in
+                    try ProviderServeLock.acquire(
+                        providerID: config.providerID,
+                        port: config.port,
+                        directory: lockDirectory
+                    )
+                }
+            )
+            XCTFail("legacy listener on serve port must fail before model artifact preflight")
+        } catch {
+            XCTAssertEqual(error as? ExitCode, ExitCode(1))
+        }
+
+        let retryLock = try ProviderServeLock.acquire(providerID: "retry", port: 61_920, directory: lockDirectory)
+        retryLock.release()
+    }
+
     func testReceiptBuilderDisabledByDefault() throws {
         var config = AppConfig.defaults()
         config.providerID = "provider-a"
@@ -427,6 +482,16 @@ final class ServeCommandTests: XCTestCase {
         try Data("weights".utf8).write(to: root.appendingPathComponent("model.safetensors"))
         try Data("{}".utf8).write(to: root.appendingPathComponent("config.json"))
         return root
+    }
+
+    private func configWithInvalidArtifact(port: Int) -> AppConfig {
+        var config = AppConfig.defaults()
+        config.providerID = "mac"
+        config.port = port
+        config.model = "test-public-model"
+        config.modelArtifactPath = "/tmp/macprovider-missing-\(UUID().uuidString)"
+        config.modelArtifactSHA256 = String(repeating: "a", count: 64)
+        return config
     }
 
     private func tempDir() throws -> URL {

--- a/phase3-binary/dist/install.sh
+++ b/phase3-binary/dist/install.sh
@@ -1568,8 +1568,8 @@ LOG_PATH="$LOG_DIR/watchdog.log"
 # cold-cache model load — re-disarms the watchdog and prevents the
 # stale-arming restart loop the R1 fix did not cover (R2 ARCH HIGH).
 #
-# Grace rule: after we DO kick, we wait at least KICK_GRACE_SECONDS
-# before kicking again. This covers the post-kick model-reload
+# Grace rule: after we observe a restart-worthy failure, we wait at least KICK_GRACE_SECONDS
+# before logging another restart request. This covers the post-restart model-reload
 # window without re-triggering on the gap between launchd respawn
 # and re-establishing the coordinator socket.
 STATE_DIR="${MACPROVIDER_WATCHDOG_STATE_DIR:-$HOME/.local/share/macprovider-watchdog/state}"
@@ -1695,10 +1695,8 @@ local_provider_health_ok() {
   "$curl_bin" -fsS --max-time 2 "http://127.0.0.1:${port}/v1/health" >/dev/null 2>&1
 }
 
-kick_provider() {
-  log "kicking $LABEL via launchctl kickstart -k gui/$UID/$LABEL"
-  launchctl kickstart -k "gui/$UID/$LABEL" >> "$LOG_PATH" 2>&1 || \
-    log "launchctl kickstart returned non-zero (likely benign — process may already be restarting)"
+note_provider_restart_request() {
+  log "provider restart requested for $LABEL but skipped: launchd KeepAlive is the sole runtime manager"
 }
 
 now_epoch() { date -u +%s; }
@@ -2126,7 +2124,7 @@ main() {
   if [ -z "$provider_pid" ]; then
     log "provider process unhealthy: expected exactly one macprovider-cli at $BINARY_PATH"
     now_epoch > "$LAST_KICK_FILE"
-    kick_provider
+    note_provider_restart_request
     exit 0
   fi
   boot_id="$(current_boot_id)"
@@ -2146,9 +2144,9 @@ main() {
         exit 0
       fi
     fi
-    log "provider process $provider_pid failed local /v1/health after arming; kicking $LABEL"
+    log "provider process $provider_pid failed local /v1/health after arming; leaving restart ownership to launchd KeepAlive for $LABEL"
     now_epoch > "$LAST_KICK_FILE"
-    kick_provider
+    note_provider_restart_request
     exit 0
   fi
   armed_boot=""

--- a/phase3-binary/dist/test/watchdog_health_scope.test.sh
+++ b/phase3-binary/dist/test/watchdog_health_scope.test.sh
@@ -42,7 +42,11 @@ EOF
 chmod +x "$TMP/bin/pgrep"
 : > "$TMP/launchctl.log"
 run_watchdog
-grep -F 'kickstart -k' "$TMP/launchctl.log" >/dev/null
+if grep -F 'kickstart -k' "$TMP/launchctl.log" >/dev/null; then
+  echo "companion watchdog must not kickstart the provider singleton" >&2
+  exit 1
+fi
+grep -F 'launchd KeepAlive is the sole runtime manager' "$TMP/logs/watchdog.log" >/dev/null
 
 rm -rf "$TMP/bin" "$TMP/logs" "$TMP/launchctl.log" "$TMP/home/.local/share/macprovider-watchdog/state"
 make_fake_common
@@ -109,6 +113,11 @@ mkdir -p "$TMP/home/.local/share/macprovider-watchdog/state"
 printf "boot-a" > "$TMP/home/.local/share/macprovider-watchdog/state/armed"
 : > "$TMP/launchctl.log"
 run_watchdog
-grep -F 'kickstart -k' "$TMP/launchctl.log" >/dev/null
+if grep -F 'kickstart -k' "$TMP/launchctl.log" >/dev/null; then
+  echo "companion watchdog must observe unhealthy providers without becoming a second runtime manager" >&2
+  exit 1
+fi
+grep -F 'provider process 4242 failed local /v1/health after arming; leaving restart ownership to launchd KeepAlive' "$TMP/logs/watchdog.log" >/dev/null
+grep -F 'launchd KeepAlive is the sole runtime manager' "$TMP/logs/watchdog.log" >/dev/null
 
 echo "watchdog health scope ok"

--- a/phase3-binary/dist/test/watchdog_rollback_paths.test.sh
+++ b/phase3-binary/dist/test/watchdog_rollback_paths.test.sh
@@ -30,6 +30,15 @@ make_fixture() {
   cat > "$root/home/.local/share/macprovider/autoupdate/pending.json" <<EOF
 {"update_id":"123e4567-e89b-42d3-a456-426614174000","target_version":"1.8.10","target_path":"$root/bin/macprovider-cli","backup_path":"$root/bin/.macprovider-cli.rollback-123e4567-e89b-42d3-a456-426614174000","size":10,"mode":493,"sha256":"$hash","marker_deadline":"2000-01-01T00:00:00Z"}
 EOF
+  : > "$root/launchctl.log"
+  cat > "$root/bin/launchctl" <<'EOF'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >> "$MACPROVIDER_FAKE_LAUNCHCTL_LOG"
+if [ "${1:-}" = "print" ]; then
+  printf 'pid = 123\nlast exit status = 0\n'
+fi
+EOF
+  chmod +x "$root/bin/launchctl"
 }
 
 run_reconcile() {
@@ -38,9 +47,13 @@ run_reconcile() {
   HOME="$root/home" \
   MACPROVIDER_BINARY_PATH="$root/bin/macprovider-cli" \
   MACPROVIDER_LOG_DIR="$root/logs" \
+  MACPROVIDER_FAKE_LAUNCHCTL_LOG="$root/launchctl.log" \
+  PATH="$root/bin:$PATH" \
   bash "$script" --reconcile-autoupdate
   cmp -s "$root/bin/macprovider-cli" <(printf "old-binary")
   [ ! -e "$root/home/.local/share/macprovider/autoupdate/pending.json" ]
+  grep -F "bootstrap gui/" "$root/launchctl.log" >/dev/null
+  grep -F "kickstart -k gui/" "$root/launchctl.log" >/dev/null
 }
 
 make_fixture "$TMP/standalone"


### PR DESCRIPTION
## Summary

Fixes #520 by making the main `live.streamvc.macprovider` LaunchAgent the sole routine runtime manager for the local provider singleton.

- Add a port-scoped `ProviderServeLock` so duplicate `serve` startups fail before model artifact preflight or model load.
- Add an early `127.0.0.1:<port>` listener probe after the lock so legacy or foreign listeners also fail before heavy startup work.
- Change the companion watchdog normal liveness path to observe and log only; bounded rollback recovery still bootstraps/kickstarts after restoring the prior binary.
- Update standalone and inlined installer watchdog copies, docs, and tests.

## Root Cause

The install flow could leave two launchd-side managers influencing one `macprovider-cli` singleton. Both could try to run the provider on the same local port, causing duplicate `--provider-id mac` processes to fight over `--port 61919`.

## Validation

- `swift test --filter ServeCommandTests` - 29 tests, 0 failures
- `swift test --filter ProviderServeLockTests` - 5 tests, 0 failures
- `swift test --filter ProviderConflictDetectorTests` - 8 tests, 1 expected env-gated skip, 0 failures
- `bash phase3-binary/dist/test/watchdog_health_scope.test.sh`
- `bash phase3-binary/dist/test/watchdog_rollback_paths.test.sh`
- `bash scripts/test-watchdog-inline-drift.sh`
- `bash scripts/test-install-launchd-enable.sh`
- `git diff --check`
- Three audit lanes re-run after fixes: implementation, architecture, and verification all reported 0 Critical / High / Medium / Low findings.

## Not Run

- `MACPROVIDER_INTEGRATION_TEST=1` real `launchctl` integration test.
