### PR TITLE
Prevent unowned provider runtime during Malibu recovery

### DIFF
--- a/phase3-binary/Sources/macprovider-cli/CoordinatorClient.swift
+++ b/phase3-binary/Sources/macprovider-cli/CoordinatorClient.swift
@@ -176,7 +176,7 @@ final class CaffeinateSleepAssertion: ProviderSleepAssertion, @unchecked Sendabl
 actor CoordinatorClient {
     typealias SendOverride = @Sendable (sending [String: Any]) async throws -> Void
 
-    static let binaryVersion = "1.8.20"
+    static let binaryVersion = "1.8.21"
     private static let keepaliveDebugEnabled = ProcessInfo.processInfo.environment["MACPROVIDER_KEEPALIVE_DEBUG"] == "1"
 
     private let coordinatorURL: URL

--- a/phase3-binary/Tests/macprovider-cliTests/CoordinatorClientTests.swift
+++ b/phase3-binary/Tests/macprovider-cliTests/CoordinatorClientTests.swift
@@ -1983,10 +1983,10 @@ final class CoordinatorClientTests: XCTestCase {
         let hello = await client.helloMessage()
         let auth = await client.authInitialMessage(attempt: attempt)
 
-        XCTAssertEqual(CoordinatorClient.binaryVersion, "1.8.20")
-        XCTAssertEqual(MacProviderCLI.configuration.version, "1.8.20")
-        XCTAssertEqual(hello["binary_version"] as? String, "1.8.20")
-        XCTAssertEqual(auth["binary_version"] as? String, "1.8.20")
+        XCTAssertEqual(CoordinatorClient.binaryVersion, "1.8.21")
+        XCTAssertEqual(MacProviderCLI.configuration.version, "1.8.21")
+        XCTAssertEqual(hello["binary_version"] as? String, "1.8.21")
+        XCTAssertEqual(auth["binary_version"] as? String, "1.8.21")
     }
 
     func testAuthInitialDefaultsToSingleEntryCatalog() async throws {

--- a/phase3-binary/app/Sources/Malibu/Agent/MalibuAgent.swift
+++ b/phase3-binary/app/Sources/Malibu/Agent/MalibuAgent.swift
@@ -61,6 +61,22 @@ final class MalibuAgent: ObservableObject {
     func start() async {
         guard !isShuttingDown else { return }
 
+        guard ProviderConfig.readProviderID() != nil else {
+            snapshot.state = .error
+            snapshot.lastError = "Not set up yet. Click Launch Provider to activate."
+            return
+        }
+        guard StartupState.launchdInstallEvidenceExists() else {
+            snapshot.state = .error
+            snapshot.lastError = "Not set up yet. Click Launch Provider to run the installer."
+            return
+        }
+        guard await ProviderConfig.isConfigured else {
+            snapshot.state = .error
+            snapshot.lastError = "Not set up yet. Click Launch Provider to activate."
+            return
+        }
+
         // Release any Malibu-spawned CLI from older builds before attaching to launchd.
         await releaseSpawnedChildForLaunchdMonitor()
 
@@ -73,22 +89,6 @@ final class MalibuAgent: ObservableObject {
         if let failure = providerStartFailure {
             snapshot.state = .error
             snapshot.lastError = failure
-            return
-        }
-
-        guard ProviderConfig.readProviderID() != nil else {
-            snapshot.state = .error
-            snapshot.lastError = "Not set up yet. Click Launch Provider to activate."
-            return
-        }
-        guard StartupState.launchdInstallEvidenceExists() else {
-            snapshot.state = .error
-            snapshot.lastError = "Not set up yet. Click Launch Provider to run the installer."
-            return
-        }
-        guard await ProviderConfig.isConfigured || ProviderConfig.readHTTPPort() != nil else {
-            snapshot.state = .error
-            snapshot.lastError = "Not set up yet. Click Launch Provider to activate."
             return
         }
         guard !isShuttingDown else { return }

--- a/phase3-binary/app/Sources/Malibu/Onboarding/LaunchProviderController.swift
+++ b/phase3-binary/app/Sources/Malibu/Onboarding/LaunchProviderController.swift
@@ -15,6 +15,7 @@ final class LaunchProviderController: ObservableObject {
         case idle
         case runningCLIInstall
         case startingAgent
+        case importingProviderIdentity
         case live(model: String, tier: TrustTier)
         case failed(stage: String, retryable: Bool, message: String)
     }
@@ -32,9 +33,12 @@ final class LaunchProviderController: ObservableObject {
         var registerLoginItem: @MainActor () async throws -> Void
         var runCLIInstall: @MainActor (@escaping @MainActor (String) -> Void) async throws -> Void
         var importCLIConfigAfterInstall: @MainActor () async throws -> Void
-        var monitorInstalledProvider: @MainActor () async -> Bool
+        var waitForInstalledProviderHealth: @MainActor () async -> Bool
+        var attachInstalledProviderAfterInstall: @MainActor () async -> Bool
         var readConfigModel: () -> String?
         var providerStartFailure: @MainActor () -> String?
+        var appIdentityConfigured: @MainActor () async -> Bool
+        var waitBeforeImportRetry: @MainActor () async throws -> Void
 
         static func live(agent: MalibuAgent?) -> Dependencies {
             Dependencies(
@@ -46,14 +50,24 @@ final class LaunchProviderController: ObservableObject {
                 importCLIConfigAfterInstall: {
                     try await ProviderConfig.importExistingCLIConfig()
                 },
-                monitorInstalledProvider: {
-                    guard let agent else { return false }
-                    return await agent.monitorInstalledProviderIfPresent(
+                waitForInstalledProviderHealth: {
+                    await LaunchProviderController.waitForInstalledProviderHealth(
                         timeout: MalibuOnboardingTimeouts.firstServingFrameSec
                     )
                 },
+                attachInstalledProviderAfterInstall: {
+                    await agent?.monitorInstalledProviderIfPresent(
+                        timeout: MalibuOnboardingTimeouts.firstServingFrameSec
+                    ) ?? false
+                },
                 readConfigModel: { ProviderConfig.readModel() },
-                providerStartFailure: { agent?.providerStartFailure }
+                providerStartFailure: { agent?.providerStartFailure },
+                appIdentityConfigured: { await ProviderConfig.isConfigured },
+                waitBeforeImportRetry: {
+                    try await Task.sleep(
+                        nanoseconds: UInt64(MalibuOnboardingTimeouts.providerTokenImportRetryIntervalSec * 1_000_000_000)
+                    )
+                }
             )
         }
     }
@@ -64,8 +78,9 @@ final class LaunchProviderController: ObservableObject {
 
     func launch() async {
         if await dependencies.localInstallSucceeded() {
-            installLogLines = ["Background provider is already running locally. Connecting Malibu to it."]
-            await finalizeInstall()
+            await finalizeExistingInstall(
+                logLine: "Background provider is already running locally. Connecting Malibu to it."
+            )
             return
         }
         await launchViaCLIInstall()
@@ -86,14 +101,13 @@ final class LaunchProviderController: ObservableObject {
 
     func refreshFromExistingInstall() async {
         switch stage {
-        case .idle, .failed(stage: "cliInstall", _, _):
+        case .idle, .failed(stage: "cliInstall", _, _), .failed(stage: "identityImport", _, _):
             break
         default:
             return
         }
         guard await dependencies.localInstallSucceeded() else { return }
-        installLogLines = ["Background provider is already running locally."]
-        await finalizeInstall()
+        await finalizeExistingInstall(logLine: "Background provider is already running locally.")
     }
 
     private func launchViaCLIInstall() async {
@@ -109,37 +123,103 @@ final class LaunchProviderController: ObservableObject {
                     self.installLogLines.removeFirst(self.installLogLines.count - 200)
                 }
             }
+            var importError: Error?
             do {
                 try await dependencies.importCLIConfigAfterInstall()
             } catch {
-                if await dependencies.localInstallSucceeded() {
-                    installLogLines.append(
-                        "Provider token not in config yet; Malibu will monitor the background provider without Keychain import."
-                    )
+                if isRetriableImportError(error) {
+                    importError = error
+                    installLogLines.append(deferredImportMessage(for: error))
                 } else {
-                    throw error
+                    stage = .failed(stage: "identityImport", retryable: true, message: error.localizedDescription)
+                    return
                 }
             }
-            await finalizeInstall()
+            await finalizeInstall(pendingImportError: importError)
         } catch {
             stage = .failed(stage: "cliInstall", retryable: true, message: error.localizedDescription)
         }
     }
 
-    private func finalizeInstall() async {
+    private func finalizeExistingInstall(logLine: String) async {
+        installLogLines = [logLine]
+        guard !Task.isCancelled else { return }
+        if await dependencies.appIdentityConfigured() {
+            await finalizeInstall()
+            return
+        }
+        var importError: Error?
         do {
-            try await dependencies.registerLoginItem()
+            try await dependencies.importCLIConfigAfterInstall()
+        } catch {
+            guard isRetriableImportError(error) else {
+                stage = .failed(stage: "identityImport", retryable: true, message: error.localizedDescription)
+                return
+            }
+            importError = error
+            installLogLines.append(deferredImportMessage(for: error))
+        }
+        await finalizeInstall(pendingImportError: importError)
+    }
+
+    private func finalizeInstall(pendingImportError: Error? = nil) async {
+        do {
             stage = .startingAgent
-            guard await dependencies.monitorInstalledProvider() else {
+            guard await dependencies.waitForInstalledProviderHealth() else {
                 let message = dependencies.providerStartFailure()
                     ?? ProviderLogDiagnostics.timeoutMessage(logHint: ProviderLogDiagnostics.logHint())
                 throw launchdMonitorUnavailableError(message: message)
             }
+            if let pendingImportError {
+                stage = .importingProviderIdentity
+                do {
+                    try await retryPendingImportAfterProviderStart(initialError: pendingImportError)
+                } catch {
+                    stage = .failed(stage: "identityImport", retryable: true, message: error.localizedDescription)
+                    return
+                }
+            }
+            guard await dependencies.appIdentityConfigured() else {
+                stage = .failed(
+                    stage: "identityImport",
+                    retryable: true,
+                    message: providerIdentityImportUnavailableError(
+                        underlying: ProviderConfig.SaveError.savedIdentityNotConfigured
+                    ).localizedDescription
+                )
+                return
+            }
+            guard await dependencies.attachInstalledProviderAfterInstall() else {
+                let message = dependencies.providerStartFailure()
+                    ?? ProviderLogDiagnostics.timeoutMessage(logHint: ProviderLogDiagnostics.logHint())
+                throw launchdMonitorUnavailableError(message: message)
+            }
+            try await dependencies.registerLoginItem()
             let model = dependencies.readConfigModel() ?? "installed"
             stage = .live(model: model, tier: .provisional)
         } catch {
             stage = .failed(stage: "cliInstall", retryable: true, message: error.localizedDescription)
         }
+    }
+
+    private func retryPendingImportAfterProviderStart(initialError: Error) async throws {
+        var lastError = initialError
+        for attempt in 1...MalibuOnboardingTimeouts.providerTokenImportRetryAttempts {
+            try Task.checkCancellation()
+            do {
+                try await dependencies.importCLIConfigAfterInstall()
+                return
+            } catch {
+                guard isRetriableImportError(error) else {
+                    throw error
+                }
+                lastError = error
+                if attempt < MalibuOnboardingTimeouts.providerTokenImportRetryAttempts {
+                    try await dependencies.waitBeforeImportRetry()
+                }
+            }
+        }
+        throw providerIdentityImportUnavailableError(underlying: lastError)
     }
 
     private func launchdMonitorUnavailableError(message: String) -> NSError {
@@ -148,6 +228,54 @@ final class LaunchProviderController: ObservableObject {
             code: 3,
             userInfo: [NSLocalizedDescriptionKey: message]
         )
+    }
+
+    private func isMissingProviderToken(_ error: Error) -> Bool {
+        if case ProviderConfig.SaveError.missingProviderToken = error {
+            return true
+        }
+        return false
+    }
+
+    private func isRetriableImportError(_ error: Error) -> Bool {
+        isMissingProviderToken(error)
+    }
+
+    private func providerIdentityImportUnavailableError(underlying: Error) -> NSError {
+        NSError(
+            domain: "Malibu.LaunchProviderController",
+            code: 4,
+            userInfo: [
+                NSLocalizedDescriptionKey: "Provider identity was not fully imported after the background provider became healthy. Retry setup once the provider token is available.",
+                NSUnderlyingErrorKey: underlying,
+            ]
+        )
+    }
+
+    private func deferredImportMessage(for error: Error) -> String {
+        if isMissingProviderToken(error) {
+            return "Provider token not in config yet; waiting for the background provider before Keychain import."
+        }
+        return "Provider identity import failed; waiting for the background provider before retrying Keychain import."
+    }
+
+    private static func waitForInstalledProviderHealth(timeout: TimeInterval) async -> Bool {
+        guard let port = ProviderConfig.readHTTPPort(),
+              ProviderConfig.readProviderID() != nil,
+              StartupState.launchdInstallEvidenceExists() else {
+            return false
+        }
+        let deadline = Date().addingTimeInterval(max(1, timeout))
+        while Date() < deadline {
+            if Task.isCancelled {
+                return false
+            }
+            if await InstalledProviderMonitor.isHealthy(port: port) {
+                return true
+            }
+            try? await Task.sleep(nanoseconds: 2_000_000_000)
+        }
+        return false
     }
 
     private func beginInstallProgressWatch() {
@@ -192,6 +320,7 @@ struct MigrationResult: Equatable {
 struct StartupState: Equatable {
     let configExists: Bool
     let appMarkerExists: Bool
+    let appIdentityConfigured: Bool
     let launchdInstallEvidenceExists: Bool
     let backgroundProviderHealthy: Bool
 
@@ -201,6 +330,7 @@ struct StartupState: Equatable {
         try? await ProviderConfig.recoverPendingImportIfNeeded(paths: paths)
         let configExists = fm.fileExists(atPath: paths.configFile.path)
         let markerExists = fm.fileExists(atPath: paths.appMarkerFile.path)
+        let identityConfigured = await ProviderConfig.isConfigured(paths: paths)
         let launchdInstallEvidenceExists = Self.launchdInstallEvidenceExists(paths: paths)
 
         var backgroundProviderHealthy = false
@@ -213,17 +343,21 @@ struct StartupState: Equatable {
         return StartupState(
             configExists: configExists,
             appMarkerExists: markerExists,
+            appIdentityConfigured: identityConfigured,
             launchdInstallEvidenceExists: launchdInstallEvidenceExists,
             backgroundProviderHealthy: backgroundProviderHealthy
         )
     }
 
     func route() -> StartupRoute {
-        if backgroundProviderHealthy {
-            return .startAgent
-        }
         if configExists && !appMarkerExists {
             return .showImportDialog
+        }
+        if configExists && appMarkerExists && !appIdentityConfigured {
+            return .showOnboarding
+        }
+        if backgroundProviderHealthy {
+            return .startAgent
         }
         // Launchd + config but provider still starting: attach and poll health.
         if launchdInstallEvidenceExists && configExists {

--- a/phase3-binary/app/Sources/Malibu/Onboarding/OnboardingWindow.swift
+++ b/phase3-binary/app/Sources/Malibu/Onboarding/OnboardingWindow.swift
@@ -119,6 +119,13 @@ private struct OnboardingRootView: View {
                     }
                 }
             }
+        case .importingProviderIdentity:
+            stageRow(
+                title: "Importing provider identity",
+                detail: "Saving the provider identity to Keychain before connecting Malibu."
+            ) {
+                ProgressView().controlSize(.small)
+            }
         case let .live(model, tier):
             VStack(alignment: .leading, spacing: 16) {
                 stageRow(title: "Provider live", detail: "Serving \(model). Trust tier: \(tier.rawValue).") {

--- a/phase3-binary/app/Sources/Malibu/System/MalibuOnboardingTimeouts.swift
+++ b/phase3-binary/app/Sources/Malibu/System/MalibuOnboardingTimeouts.swift
@@ -69,6 +69,14 @@ enum MalibuOnboardingTimeouts {
     /// frame." on 2026-07-05 v1.8.4 fresh-install smoke retry.
     static let firstServingFrameSec: TimeInterval = 600
 
+    /// Fresh CLI-track installs mint and persist `provider_token` after the
+    /// coordinator handshake, which can land just after `install.sh` exits.
+    /// Malibu retries the Keychain import briefly after the launchd provider is
+    /// healthy so this race does not bounce the user back to Retry. Total
+    /// post-health retry budget is roughly 30s: 15 attempts with 14 sleeps.
+    static let providerTokenImportRetryAttempts: Int = 15
+    static let providerTokenImportRetryIntervalSec: TimeInterval = 2
+
     /// Poll interval for `waitForFirstServing`. The controller polls
     /// `snapshot.state` because the state machine transitions there are
     /// event-driven inside MalibuAgent but the controller wants a

--- a/phase3-binary/app/Sources/Malibu/System/ProviderConfig.swift
+++ b/phase3-binary/app/Sources/Malibu/System/ProviderConfig.swift
@@ -21,14 +21,7 @@ enum ProviderConfig {
     // the CLI unauthenticated or trampling a config the CLI track owns.
     static var isConfigured: Bool {
         get async {
-            let paths = ProviderPaths.current
-            let fm = FileManager.default
-            guard fm.fileExists(atPath: paths.configFile.path),
-                  fm.fileExists(atPath: paths.appMarkerFile.path),
-                  let providerID = readProviderID() else {
-                return false
-            }
-            return await KeychainStore.readProviderToken(providerID: providerID) != nil
+            await isConfigured(paths: .current)
         }
     }
 

--- a/phase3-binary/app/Tests/MalibuTests/LaunchProviderControllerTests.swift
+++ b/phase3-binary/app/Tests/MalibuTests/LaunchProviderControllerTests.swift
@@ -14,12 +14,14 @@ final class LaunchProviderControllerTests: XCTestCase {
         XCTAssertEqual(harness.cliImportRuns, 1)
         XCTAssertEqual(harness.monitorRuns, 1)
         XCTAssertEqual(harness.loginItemRegistrations, 1)
+        XCTAssertEqual(harness.startAgentRuns, 1)
         XCTAssertEqual(controller.stage, .live(model: harness.configModel, tier: .provisional))
     }
 
     func testLaunchSkipsInstallerWhenLocalProviderAlreadyHealthy() async {
         let harness = Harness()
         harness.localInstallSucceeded = true
+        harness.appIdentityConfigured = true
         let controller = LaunchProviderController(dependencies: harness.dependencies())
 
         await controller.launch()
@@ -28,6 +30,7 @@ final class LaunchProviderControllerTests: XCTestCase {
         XCTAssertEqual(harness.cliImportRuns, 0)
         XCTAssertEqual(harness.monitorRuns, 1)
         XCTAssertEqual(harness.loginItemRegistrations, 1)
+        XCTAssertEqual(harness.startAgentRuns, 1)
         XCTAssertEqual(controller.stage, .live(model: harness.configModel, tier: .provisional))
     }
 
@@ -46,6 +49,7 @@ final class LaunchProviderControllerTests: XCTestCase {
             XCTFail("expected failed cliInstall stage")
         }
         XCTAssertEqual(harness.loginItemRegistrations, 0)
+        XCTAssertEqual(harness.startAgentRuns, 0)
         XCTAssertEqual(harness.monitorRuns, 0)
     }
 
@@ -62,7 +66,8 @@ final class LaunchProviderControllerTests: XCTestCase {
         } else {
             XCTFail("expected failed cliInstall stage after monitor timeout")
         }
-        XCTAssertEqual(harness.loginItemRegistrations, 1)
+        XCTAssertEqual(harness.loginItemRegistrations, 0)
+        XCTAssertEqual(harness.startAgentRuns, 0)
     }
 
     func testRetryRerunsInstallAfterFailure() async {
@@ -75,32 +80,121 @@ final class LaunchProviderControllerTests: XCTestCase {
         await controller.retry()
 
         XCTAssertEqual(harness.cliInstallRuns, 2)
+        XCTAssertEqual(harness.startAgentRuns, 1)
         XCTAssertEqual(controller.stage, .live(model: harness.configModel, tier: .provisional))
     }
 
     func testRefreshFromExistingInstallConnectsWithoutInstaller() async {
         let harness = Harness()
         harness.localInstallSucceeded = true
+        harness.appIdentityConfigured = true
         let controller = LaunchProviderController(dependencies: harness.dependencies())
 
         await controller.refreshFromExistingInstall()
 
         XCTAssertEqual(harness.cliInstallRuns, 0)
         XCTAssertEqual(harness.monitorRuns, 1)
+        XCTAssertEqual(harness.loginItemRegistrations, 1)
+        XCTAssertEqual(harness.startAgentRuns, 1)
         XCTAssertEqual(controller.stage, .live(model: harness.configModel, tier: .provisional))
     }
 
-    func testImportFailureToleratedWhenProviderAlreadyHealthy() async {
+    func testPermanentImportFailureDoesNotWaitForProviderStart() async {
         let harness = Harness()
-        harness.cliImportError = NSError(domain: "tests", code: 2, userInfo: [NSLocalizedDescriptionKey: "import failed"])
+        harness.cliImportErrors = [
+            NSError(domain: "tests", code: 2, userInfo: [NSLocalizedDescriptionKey: "import failed"])
+        ]
         let controller = LaunchProviderController(dependencies: harness.dependencies())
 
         await controller.launch()
 
         XCTAssertEqual(harness.cliInstallRuns, 1)
         XCTAssertEqual(harness.cliImportRuns, 1)
+        XCTAssertEqual(harness.monitorRuns, 0)
+        XCTAssertEqual(harness.importRetryWaits, 0)
+        XCTAssertEqual(harness.loginItemRegistrations, 0)
+        XCTAssertEqual(harness.startAgentRuns, 0)
+        if case let .failed(stage, retryable, message) = controller.stage {
+            XCTAssertEqual(stage, "identityImport")
+            XCTAssertTrue(retryable)
+            XCTAssertEqual(message, "import failed")
+        } else {
+            XCTFail("expected retryable failed stage after permanent import failure")
+        }
+    }
+
+    func testTokenlessFirstImportRetriesAfterProviderBecomesHealthy() async {
+        let harness = Harness()
+        harness.markLocalInstallSucceededAfterInstall = false
+        harness.cliImportErrors = [ProviderConfig.SaveError.missingProviderToken]
+        let controller = LaunchProviderController(dependencies: harness.dependencies())
+
+        await controller.launch()
+
+        XCTAssertEqual(harness.cliInstallRuns, 1)
+        XCTAssertEqual(harness.cliImportRuns, 2)
         XCTAssertEqual(harness.monitorRuns, 1)
+        XCTAssertEqual(harness.loginItemRegistrations, 1)
+        XCTAssertEqual(harness.startAgentRuns, 1)
+        XCTAssertEqual(harness.importRetryWaits, 0)
         XCTAssertEqual(controller.stage, .live(model: harness.configModel, tier: .provisional))
+    }
+
+    func testRetryAfterPersistentImportFailureDoesNotBypassIdentityImport() async {
+        let harness = Harness()
+        harness.cliImportErrors = Array(
+            repeating: ProviderConfig.SaveError.missingProviderToken,
+            count: 2 * (MalibuOnboardingTimeouts.providerTokenImportRetryAttempts + 1)
+        )
+        let controller = LaunchProviderController(dependencies: harness.dependencies())
+
+        await controller.launch()
+        await controller.retry()
+
+        XCTAssertEqual(harness.cliInstallRuns, 1)
+        XCTAssertEqual(
+            harness.cliImportRuns,
+            2 * (MalibuOnboardingTimeouts.providerTokenImportRetryAttempts + 1)
+        )
+        XCTAssertEqual(harness.monitorRuns, 2)
+        XCTAssertEqual(harness.loginItemRegistrations, 0)
+        XCTAssertEqual(harness.startAgentRuns, 0)
+        XCTAssertEqual(harness.importRetryWaits, 2 * (MalibuOnboardingTimeouts.providerTokenImportRetryAttempts - 1))
+        if case let .failed(stage, retryable, message) = controller.stage {
+            XCTAssertEqual(stage, "identityImport")
+            XCTAssertTrue(retryable)
+            XCTAssertEqual(
+                message,
+                "Provider identity was not fully imported after the background provider became healthy. Retry setup once the provider token is available."
+            )
+        } else {
+            XCTFail("expected retryable failed stage after retry exhausts identity import again")
+        }
+    }
+
+    func testExistingInstallPermanentImportFailureDoesNotBypassIdentityImport() async {
+        let harness = Harness()
+        harness.localInstallSucceeded = true
+        harness.cliImportErrors = [
+            ProviderConfig.SaveError.importKeychainVerificationFailed
+        ]
+        let controller = LaunchProviderController(dependencies: harness.dependencies())
+
+        await controller.launch()
+
+        XCTAssertEqual(harness.cliInstallRuns, 0)
+        XCTAssertEqual(harness.cliImportRuns, 1)
+        XCTAssertEqual(harness.monitorRuns, 0)
+        XCTAssertEqual(harness.loginItemRegistrations, 0)
+        XCTAssertEqual(harness.startAgentRuns, 0)
+        XCTAssertEqual(harness.importRetryWaits, 0)
+        if case let .failed(stage, retryable, message) = controller.stage {
+            XCTAssertEqual(stage, "identityImport")
+            XCTAssertTrue(retryable)
+            XCTAssertEqual(message, "The imported provider token could not be verified in Keychain.")
+        } else {
+            XCTFail("expected identityImport failure after permanent import error")
+        }
     }
 
     func testLaunchMonitorFailureSurfacesProviderStartFailure() async {
@@ -122,17 +216,44 @@ final class LaunchProviderControllerTests: XCTestCase {
         }
     }
 
+    func testAttachFailureDoesNotRegisterLoginItemOrMarkLive() async {
+        let harness = Harness()
+        harness.attachHealthy = false
+        harness.providerStartFailureMessage = "provider attach failed"
+        let controller = LaunchProviderController(dependencies: harness.dependencies())
+
+        await controller.launch()
+
+        XCTAssertEqual(harness.cliInstallRuns, 1)
+        XCTAssertEqual(harness.cliImportRuns, 1)
+        XCTAssertEqual(harness.monitorRuns, 1)
+        XCTAssertEqual(harness.startAgentRuns, 1)
+        XCTAssertEqual(harness.loginItemRegistrations, 0)
+        if case let .failed(stage, retryable, message) = controller.stage {
+            XCTAssertEqual(stage, "cliInstall")
+            XCTAssertTrue(retryable)
+            XCTAssertEqual(message, "provider attach failed")
+        } else {
+            XCTFail("expected failed cliInstall stage after attach failure")
+        }
+    }
+
     private final class Harness {
         var localInstallSucceeded = false
         var localInstallSucceededAfterInstall = false
+        var markLocalInstallSucceededAfterInstall = true
         var cliInstallRuns = 0
         var cliImportRuns = 0
         var monitorRuns = 0
         var loginItemRegistrations = 0
+        var startAgentRuns = 0
+        var importRetryWaits = 0
         var monitorHealthy = true
+        var attachHealthy = true
+        var appIdentityConfigured = false
         var providerStartFailureMessage: String?
         var cliInstallError: Error?
-        var cliImportError: Error?
+        var cliImportErrors: [Error] = []
         var configModel = "mlx-community/Qwen2.5-7B-Instruct-4bit"
         var installLogLines: [String] = []
 
@@ -147,19 +268,30 @@ final class LaunchProviderControllerTests: XCTestCase {
                 runCLIInstall: { onLogLine in
                     self.cliInstallRuns += 1
                     if let error = self.cliInstallError { throw error }
-                    self.localInstallSucceededAfterInstall = true
+                    self.localInstallSucceededAfterInstall = self.markLocalInstallSucceededAfterInstall
                     onLogLine("install.sh finished")
                 },
                 importCLIConfigAfterInstall: {
                     self.cliImportRuns += 1
-                    if let error = self.cliImportError { throw error }
+                    if !self.cliImportErrors.isEmpty {
+                        throw self.cliImportErrors.removeFirst()
+                    }
+                    self.appIdentityConfigured = true
                 },
-                monitorInstalledProvider: {
+                waitForInstalledProviderHealth: {
                     self.monitorRuns += 1
                     return self.monitorHealthy
                 },
+                attachInstalledProviderAfterInstall: {
+                    self.startAgentRuns += 1
+                    return self.attachHealthy
+                },
                 readConfigModel: { self.configModel },
-                providerStartFailure: { self.providerStartFailureMessage }
+                providerStartFailure: { self.providerStartFailureMessage },
+                appIdentityConfigured: { self.appIdentityConfigured },
+                waitBeforeImportRetry: {
+                    self.importRetryWaits += 1
+                }
             )
         }
     }

--- a/phase3-binary/app/Tests/MalibuTests/MalibuUpdateConfigurationTests.swift
+++ b/phase3-binary/app/Tests/MalibuTests/MalibuUpdateConfigurationTests.swift
@@ -18,15 +18,15 @@ final class MalibuUpdateConfigurationTests: XCTestCase {
     }
 
     func testVersionedDownloadURLUsesTagSuffix() {
-        let url = MalibuUpdateConfiguration.releaseDownloadURL(tag: "v1.8.20")
-        XCTAssertEqual(url.absoluteString, "https://download.malibu.tech/Malibu-v1.8.20.dmg")
+        let url = MalibuUpdateConfiguration.releaseDownloadURL(tag: "v1.8.21")
+        XCTAssertEqual(url.absoluteString, "https://download.malibu.tech/Malibu-v1.8.21.dmg")
     }
 
     func testReleaseNotesURLPointsAtGitHubTag() {
-        let url = MalibuUpdateConfiguration.releaseNotesURL(tag: "v1.8.20")
+        let url = MalibuUpdateConfiguration.releaseNotesURL(tag: "v1.8.21")
         XCTAssertEqual(
             url.absoluteString,
-            "https://github.com/Augustas11/macprovider/releases/tag/v1.8.20"
+            "https://github.com/Augustas11/macprovider/releases/tag/v1.8.21"
         )
     }
 }

--- a/phase3-binary/app/Tests/MalibuTests/StartupRouteTests.swift
+++ b/phase3-binary/app/Tests/MalibuTests/StartupRouteTests.swift
@@ -9,6 +9,10 @@ final class StartupRouteTests: XCTestCase {
             ("launchd-config-starting", state(config: true, marker: true, launchd: true, healthy: false), .startAgent),
             ("legacy-app-config", state(config: true, marker: true, launchd: false, healthy: false), .showOnboarding),
             ("cli-owned", state(config: true, marker: false, launchd: false, healthy: false), .showImportDialog),
+            ("launchd-cli-owned-healthy", state(config: true, marker: false, launchd: true, healthy: true), .showImportDialog),
+            ("launchd-cli-owned-starting", state(config: true, marker: false, launchd: true, healthy: false), .showImportDialog),
+            ("app-owned-missing-identity-healthy", state(config: true, marker: true, configured: false, launchd: true, healthy: true), .showOnboarding),
+            ("app-owned-missing-identity-starting", state(config: true, marker: true, configured: false, launchd: true, healthy: false), .showOnboarding),
             ("launchd-only", state(config: false, marker: false, launchd: true, healthy: false), .showOnboarding),
             ("fresh", state(config: false, marker: false, launchd: false, healthy: false), .showOnboarding)
         ]
@@ -80,12 +84,14 @@ final class StartupRouteTests: XCTestCase {
     private func state(
         config: Bool,
         marker: Bool,
+        configured: Bool? = nil,
         launchd: Bool,
         healthy: Bool
     ) -> StartupState {
         StartupState(
             configExists: config,
             appMarkerExists: marker,
+            appIdentityConfigured: configured ?? marker,
             launchdInstallEvidenceExists: launchd,
             backgroundProviderHealthy: healthy
         )

--- a/phase3-binary/app/project.yml
+++ b/phase3-binary/app/project.yml
@@ -27,8 +27,8 @@ settings:
     SWIFT_VERSION: "5.9"
     ENABLE_HARDENED_RUNTIME: YES
     CODE_SIGN_STYLE: Manual
-    MARKETING_VERSION: "1.8.20"
-    CURRENT_PROJECT_VERSION: "19"
+    MARKETING_VERSION: "1.8.21"
+    CURRENT_PROJECT_VERSION: "20"
     OTHER_SWIFT_FLAGS: "-strict-concurrency=complete"
 
 targets:

--- a/phase4-coordinator/dist/coordinator.yaml
+++ b/phase4-coordinator/dist/coordinator.yaml
@@ -238,4 +238,4 @@ providers: []
 
 # Auto-update recommendation surface (2026-07-03 — added post-#332 to unblock air5 v1.7.0 -> v1.7.9)
 coordinator_advertised_version:
-  latest_binary_version: "1.8.20"
+  latest_binary_version: "1.8.21"


### PR DESCRIPTION
## Summary

Fixes fresh-Mac Malibu installs that inherit an existing CLI config without a provider_token.

- Gate provider attach and live state on app-owned identity custody.
- Retry only the retriable missing-provider-token import path after provider health.
- Route incomplete app identity to onboarding repair and preserve markerless import routing.
- Align CLI, Malibu, test, and coordinator release metadata to v1.8.21.

## Validation

- 127 MalibuTests passed.
- 70 CoordinatorClientTests passed.
- Three audit lanes reported 0 C/H/M findings.
- git diff --check passed.

## Root cause

Malibu could observe a healthy background provider and attach its agent before the app had imported and verified provider identity. On a new Mac with an existing CLI config, that left the install in a wedge with missing provider_token.
