### PR TITLE
fix(canary): pin temperature 0 so providers echo the nonce exactly

### DIFF
--- a/phase4-coordinator/internal/ws/canary_probe.go
+++ b/phase4-coordinator/internal/ws/canary_probe.go
@@ -107,6 +107,14 @@ func buildCanaryBodyFromRandomWithChallenge(modelID string, maxTokens int, chall
 		}},
 		"max_tokens": maxTokens,
 		"stream":     false,
+		// Pin greedy decoding. The canary challenge requires the provider to echo
+		// a random nonce EXACTLY (anti-downgrade identity proof); without this the
+		// provider samples at its own default temperature and a model that serves
+		// fine otherwise (e.g. a 4-bit qwen3-coder-30b) hallucinates the nonce
+		// ("CANARY-A1B2C3" -> "CANARY-A1By2C3" -> garbage), producing spurious
+		// nonce_mismatch failures that bench a healthy provider. Measured
+		// 2026-07-10: temperature 0 -> 6/6 exact echo; default temp -> 0/8.
+		"temperature": 0,
 	})
 	if err != nil {
 		return nil, "", config.CanaryChallengeConfig{}, err

--- a/phase4-coordinator/internal/ws/canary_test.go
+++ b/phase4-coordinator/internal/ws/canary_test.go
@@ -38,6 +38,11 @@ func TestBuildCanaryBodyUsesPrivateChallengeTemplates(t *testing.T) {
 	if req.Model != "model-a" || req.MaxTokens != 8 || req.Stream {
 		t.Fatalf("canary request = %+v", req)
 	}
+	// Greedy decoding must be pinned so a healthy provider echoes the nonce
+	// exactly rather than sampling and hallucinating it (spurious nonce_mismatch).
+	if req.Temperature == nil || *req.Temperature != 0 {
+		t.Fatalf("canary request temperature = %v, want 0", req.Temperature)
+	}
 	if len(req.Messages) != 1 || req.Messages[0].Role != "user" {
 		t.Fatalf("messages = %+v", req.Messages)
 	}
@@ -591,10 +596,11 @@ func TestHTTPCanaryEndpointResetCountsAsFailure(t *testing.T) {
 }
 
 type decodedCanaryBody struct {
-	Model     string `json:"model"`
-	MaxTokens int    `json:"max_tokens"`
-	Stream    bool   `json:"stream"`
-	Messages  []struct {
+	Model       string   `json:"model"`
+	MaxTokens   int      `json:"max_tokens"`
+	Stream      bool     `json:"stream"`
+	Temperature *float64 `json:"temperature"`
+	Messages    []struct {
 		Role    string `json:"role"`
 		Content string `json:"content"`
 	} `json:"messages"`


### PR DESCRIPTION
## Problem

The OPoI canary asks each provider to **echo a random nonce exactly** — that's the anti-downgrade / model-identity proof. But the canary request body (`canary_probe.go`) set only `max_tokens` + `stream:false` and **never pinned `temperature`**. So providers sample the nonce-echo at their own default temperature, and a model that serves normal traffic perfectly hallucinates the random string:

```
Reply with exactly: CANARY-A1B2C3   ->  CANARY-A1By2C3
Reply with exactly: CANARY-DEADBEEF ->  CANARY-DEADBEOF\n\nWait, let me correct that...
```

→ `canary_fail_reason=nonce_mismatch` → trips the failure threshold → `canary_trip=degraded` → a **healthy** provider is benched and buyers get `503 no_provider_available` on a provider that is serving correctly.

## Evidence (live mac provider, qwen3-coder-30b-a3b-instruct, 4-bit, 2026-07-10)

| temperature | exact nonce echo |
|---|---|
| default (unset) | **0 / 8** |
| `0` | **6 / 6** |

At default temperature the provider flapped ~35% ready / 65% degraded purely from canary nonce hallucination, despite streaming real completions fine.

## Fix

Add `"temperature": 0` to the canary request body so decoding is greedy/deterministic and an honest provider reproduces the nonce exactly. The nonce-correctness gate is unchanged — this only removes the sampling noise that was failing honest providers. Test asserts the canary body pins `temperature: 0`.

## Scope / gates

- `phase4-coordinator/internal/ws/canary_probe.go` (+ test). `go vet` clean; full `internal/ws` suite passes.
- The canary is a security/anti-downgrade gate → this should go through the **three-lane codex audit** (code / security / architect) before merge, and the deploy is the usual gated coordinator rebuild + restart.

Surfaced by the P2 cold/warm TTFT harness carry (#526).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
