### PR TITLE
test(autotune): repair fixtures stale after the 2026-07-10 candidate-catalog bump

### DIFF
--- a/phase3-binary/Tests/macprovider-cliTests/AutotuneRecommendSimulateTests.swift
+++ b/phase3-binary/Tests/macprovider-cliTests/AutotuneRecommendSimulateTests.swift
@@ -19,7 +19,7 @@ final class AutotuneRecommendSimulateTests: XCTestCase {
         XCTAssertEqual(request.donorMode, false)
         XCTAssertEqual(request.benchmarks["qwen3-coder-30b-a3b-instruct"]?.modelKey, "qwen3-coder-30b-a3b-instruct")
         XCTAssertEqual(request.rateCard.version, "baked-2026-07-07-p2-drift")
-        XCTAssertEqual(request.candidateCatalog.version, "published-2026-07-07-p2-qwen3-8b")
+        XCTAssertEqual(request.candidateCatalog.version, "published-2026-07-10-llama32-hash-repair")
         XCTAssertEqual(request.demandRank.version, "published-2026-07-07-p2-qwen3-8b")
     }
 
@@ -60,7 +60,7 @@ final class AutotuneRecommendSimulateTests: XCTestCase {
 
         XCTAssertEqual(fetchedURL, AutotuneRecommendSimulator.liveRateCardURL)
         XCTAssertEqual(result.rateCardVersion, "baked-2026-07-07-p2-drift")
-        XCTAssertEqual(result.candidateCatalogVersion, "published-2026-07-07-p2-qwen3-8b")
+        XCTAssertEqual(result.candidateCatalogVersion, "published-2026-07-10-llama32-hash-repair")
         XCTAssertEqual(result.demandRankVersion, "published-2026-07-07-p2-qwen3-8b")
     }
 

--- a/phase3-binary/Tests/macprovider-cliTests/ServeCommandTests.swift
+++ b/phase3-binary/Tests/macprovider-cliTests/ServeCommandTests.swift
@@ -303,10 +303,10 @@ final class ServeCommandTests: XCTestCase {
         try Data("{}".utf8).write(to: snapshot.appendingPathComponent("config.json"))
         let artifactSHA = try ModelArtifactVerifier.canonicalArtifactHash(directory: snapshot)
         let currentCatalogJSON = """
-        {"version":"current-catalog","generated_at":"2026-07-07T12:00:00Z","source":"operator_curated_autotune_candidate_catalog","rows":{"\(key)":{"model_id":"\(modelID)","model_revision":"\(revision)","model_sha256":"\(artifactSHA)","min_ram_gb":1,"min_bandwidth_tier":"C","bench_gate":{"min_sustained_tps":1,"max_4k_ttft_ms":1000},"runtime_status":"recommendable"}}}
+        {"version":"current-catalog","generated_at":"2026-07-10T12:00:00Z","source":"operator_curated_autotune_candidate_catalog","rows":{"\(key)":{"model_id":"\(modelID)","model_revision":"\(revision)","model_sha256":"\(artifactSHA)","min_ram_gb":1,"min_bandwidth_tier":"C","bench_gate":{"min_sustained_tps":1,"max_4k_ttft_ms":1000},"runtime_status":"recommendable"}}}
         """
         let rateCardJSON = """
-        {"version":"test-rate-card","generated_at":"2026-07-07T12:00:00Z","usd_per_million_credits":1.0,"rows":{"\(key)":{"prompt_rate_per_mtok":1,"completion_rate_per_mtok":1,"provider_share_bps":9000,"global_multiplier_ppm":1000000}}}
+        {"version":"test-rate-card","generated_at":"2026-07-10T12:00:00Z","usd_per_million_credits":1.0,"rows":{"\(key)":{"prompt_rate_per_mtok":1,"completion_rate_per_mtok":1,"provider_share_bps":9000,"global_multiplier_ppm":1000000}}}
         """
         let catalogBytes = Data(currentCatalogJSON.utf8)
         let rateCardBytes = Data(rateCardJSON.utf8)
@@ -326,7 +326,7 @@ final class ServeCommandTests: XCTestCase {
                 return catalogBytes
             },
             verifySignature: { _, _ in true },
-            now: { ISO8601DateFormatter.autotuneInternet.date(from: "2026-07-07T12:00:00Z")! }
+            now: { ISO8601DateFormatter.autotuneInternet.date(from: "2026-07-10T12:00:00Z")! }
         )
         var config = AppConfig.defaults()
         config.model = key
@@ -391,10 +391,10 @@ final class ServeCommandTests: XCTestCase {
         try Data("{}".utf8).write(to: snapshot.appendingPathComponent("config.json"))
         let artifactSHA = try ModelArtifactVerifier.canonicalArtifactHash(directory: snapshot)
         let catalogJSON = """
-        {"version":"test-catalog","generated_at":"2026-07-07T12:00:00Z","source":"operator_curated_autotune_candidate_catalog","rows":{"\(key)":{"model_id":"\(modelID)","model_revision":"\(revision)","model_sha256":"\(artifactSHA)","min_ram_gb":1,"min_bandwidth_tier":"C","bench_gate":{"min_sustained_tps":1,"max_4k_ttft_ms":1000},"runtime_status":"\(runtimeStatus)"}}}
+        {"version":"test-catalog","generated_at":"2026-07-10T12:00:00Z","source":"operator_curated_autotune_candidate_catalog","rows":{"\(key)":{"model_id":"\(modelID)","model_revision":"\(revision)","model_sha256":"\(artifactSHA)","min_ram_gb":1,"min_bandwidth_tier":"C","bench_gate":{"min_sustained_tps":1,"max_4k_ttft_ms":1000},"runtime_status":"\(runtimeStatus)"}}}
         """
         let rateCardJSON = """
-        {"version":"test-rate-card","generated_at":"2026-07-07T12:00:00Z","usd_per_million_credits":1.0,"rows":{"\(rateCardKey)":{"prompt_rate_per_mtok":1,"completion_rate_per_mtok":1,"provider_share_bps":9000,"global_multiplier_ppm":1000000}}}
+        {"version":"test-rate-card","generated_at":"2026-07-10T12:00:00Z","usd_per_million_credits":1.0,"rows":{"\(rateCardKey)":{"prompt_rate_per_mtok":1,"completion_rate_per_mtok":1,"provider_share_bps":9000,"global_multiplier_ppm":1000000}}}
         """
         let catalogBytes = Data(catalogJSON.utf8)
         let rateCardBytes = Data(rateCardJSON.utf8)
@@ -414,7 +414,7 @@ final class ServeCommandTests: XCTestCase {
                 return catalogBytes
             },
             verifySignature: { _, _ in true },
-            now: { ISO8601DateFormatter.autotuneInternet.date(from: "2026-07-07T12:00:00Z")! }
+            now: { ISO8601DateFormatter.autotuneInternet.date(from: "2026-07-10T12:00:00Z")! }
         )
         var config = AppConfig.defaults()
         config.donorMode = donorMode


### PR DESCRIPTION
## Problem

`swift test` (and the `phase3-binary (swift test)` CI job) has been **red on `main`** — unrelated to any single feature PR. The baked candidate catalog was bumped to `published-2026-07-10-llama32-hash-repair` (`generated_at: 2026-07-10T00:00:00Z`) by the 8GB-host / hash-repair work, but two test files still pinned the prior `2026-07-07` catalog:

1. **`AutotuneRecommendSimulateTests`** — asserted the *candidate-catalog* version as the old `published-2026-07-07-p2-qwen3-8b`. (The *demand-rank* version is a separate catalog and correctly stays `2026-07-07`.)
2. **`ServeCommandTests`** catalog-bound-snapshot preflights — used fixture `generated_at` / `now = 2026-07-07T12:00:00Z`. `loadSignedStatic`'s freshness gate requires `fetchedGeneratedAt >= bakedGeneratedAt` (now `2026-07-10`), so the fixture catalog was rejected → the loader fell back to the **baked** catalog (whose rows don't contain the test key) → preflight threw `ExitCode(2)` "model artifact is not admitted by the signed candidate catalog".

## Fix

Test-fixture drift repair only — **no production code change**:
- Update the two candidate-catalog version assertions → `published-2026-07-10-llama32-hash-repair`.
- Bump the six `ServeCommandTests` fixture timestamps → `2026-07-10T12:00:00Z` (fresh relative to the baked floor).

## Verified
`AutotuneRecommendSimulateTests` 4/4 and `ServeCommandTests` 29/29 pass locally.

Unblocks CI so **#533** (canary `temperature:0` fix) can merge on green.

> Note: these fixtures pin the baked catalog date, so a future catalog bump will re-drift them — a follow-up could derive the fixture date from the baked catalog's `generated_at` instead of hardcoding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
