### PR TITLE
Issue v1.8.27 with Pearl backend recovery assets

### DIFF
--- a/phase3-binary/Sources/macprovider-cli/CoordinatorClient.swift
+++ b/phase3-binary/Sources/macprovider-cli/CoordinatorClient.swift
@@ -138,7 +138,7 @@ final class CaffeinateSleepAssertion: ProviderSleepAssertion, @unchecked Sendabl
 actor CoordinatorClient {
     typealias SendOverride = @Sendable (sending [String: Any]) async throws -> Void
 
-    static let binaryVersion = "1.8.26"
+    static let binaryVersion = "1.8.27"
     private static let keepaliveDebugEnabled = ProcessInfo.processInfo.environment["MACPROVIDER_KEEPALIVE_DEBUG"] == "1"
 
     private let coordinatorURL: URL

--- a/phase3-binary/Tests/macprovider-cliTests/CoordinatorClientTests.swift
+++ b/phase3-binary/Tests/macprovider-cliTests/CoordinatorClientTests.swift
@@ -2369,10 +2369,10 @@ final class CoordinatorClientTests: XCTestCase {
         let hello = await client.helloMessage()
         let auth = await client.authInitialMessage(attempt: attempt)
 
-        XCTAssertEqual(CoordinatorClient.binaryVersion, "1.8.26")
-        XCTAssertEqual(MacProviderCLI.configuration.version, "1.8.26")
-        XCTAssertEqual(hello["binary_version"] as? String, "1.8.26")
-        XCTAssertEqual(auth["binary_version"] as? String, "1.8.26")
+        XCTAssertEqual(CoordinatorClient.binaryVersion, "1.8.27")
+        XCTAssertEqual(MacProviderCLI.configuration.version, "1.8.27")
+        XCTAssertEqual(hello["binary_version"] as? String, "1.8.27")
+        XCTAssertEqual(auth["binary_version"] as? String, "1.8.27")
     }
 
     func testAuthInitialDefaultsToSingleEntryCatalog() async throws {

--- a/phase3-binary/app/project.yml
+++ b/phase3-binary/app/project.yml
@@ -28,8 +28,8 @@ settings:
     SWIFT_VERSION: "5.9"
     ENABLE_HARDENED_RUNTIME: YES
     CODE_SIGN_STYLE: Manual
-    MARKETING_VERSION: "1.8.26"
-    CURRENT_PROJECT_VERSION: "26"
+    MARKETING_VERSION: "1.8.27"
+    CURRENT_PROJECT_VERSION: "27"
     OTHER_SWIFT_FLAGS: "-strict-concurrency=complete"
 
 targets:

--- a/phase3-binary/app/release-builds.tsv
+++ b/phase3-binary/app/release-builds.tsv
@@ -6,3 +6,4 @@
 # represented as valid Malibu releases.
 1.8.21	20
 1.8.26	26
+1.8.27	27

--- a/phase4-coordinator/coordinator.yaml.example
+++ b/phase4-coordinator/coordinator.yaml.example
@@ -164,7 +164,7 @@ admission:
 #   response_time_anomaly_min_ms: 10000
 
 coordinator_advertised_version:
-  latest_binary_version: "1.8.26"
+  latest_binary_version: "1.8.27"
   required_binary_version: ""
 
 auth:

--- a/phase4-coordinator/dist/coordinator.yaml
+++ b/phase4-coordinator/dist/coordinator.yaml
@@ -253,4 +253,4 @@ providers: []
 
 # Auto-update recommendation surface (2026-07-03 — added post-#332 to unblock air5 v1.7.0 -> v1.7.9)
 coordinator_advertised_version:
-  latest_binary_version: "1.8.26"
+  latest_binary_version: "1.8.27"

--- a/phase4-coordinator/dist/coordinator.yaml.example
+++ b/phase4-coordinator/dist/coordinator.yaml.example
@@ -337,7 +337,7 @@ malibu_emission:
 # version, closing WS with CloseVersionTooOld. Use for security fixes
 # that must not be optional. Leave unset for advisory releases.
 coordinator_advertised_version:
-  latest_binary_version: "1.8.26"
+  latest_binary_version: "1.8.27"
   # required_binary_version: "1.7.0"
 
 # Enumerated providers (SPEC-002 v1.0.4 Finding F-2: every provider_id that

--- a/scripts/test-coordinator-advertised-version-test.sh
+++ b/scripts/test-coordinator-advertised-version-test.sh
@@ -58,7 +58,7 @@ printf '%s\n' '    CURRENT_PROJECT_VERSION: "999"' >> "$fixture/phase3-binary/ap
 expect_fixture_failure duplicate-build 'exactly one numeric CURRENT_PROJECT_VERSION definition (found 2)'
 
 # A future release must append a new, strictly larger build to the committed
-# ledger. Updating every SemVer source while retaining build 26 must fail.
+# ledger. Updating every SemVer source while retaining build 27 must fail.
 reset_fixture
 for path in \
   "$fixture/phase3-binary/Sources/macprovider-cli/CoordinatorClient.swift" \
@@ -66,25 +66,25 @@ for path in \
   "$fixture/phase4-coordinator/dist/coordinator.yaml" \
   "$fixture/phase4-coordinator/coordinator.yaml.example" \
   "$fixture/phase4-coordinator/dist/coordinator.yaml.example"; do
-  sed 's/1\.8\.26/1.8.27/g' "$path" > "$path.next"
+  sed 's/1\.8\.27/1.8.28/g' "$path" > "$path.next"
   mv "$path.next" "$path"
 done
-if bash "$fixture/scripts/test-coordinator-advertised-version.sh" v1.8.27 >"$work/future-missing-build.out" 2>&1; then
+if bash "$fixture/scripts/test-coordinator-advertised-version.sh" v1.8.28 >"$work/future-missing-build.out" 2>&1; then
   echo "version guard accepted a future release without a release-build ledger entry" >&2
   exit 1
 fi
-grep -q 'exactly one entry for 1.8.27' "$work/future-missing-build.out"
-printf '%s\t%s\n' '1.8.27' '26' >> "$fixture/phase3-binary/app/release-builds.tsv"
-if bash "$fixture/scripts/test-coordinator-advertised-version.sh" v1.8.27 >"$work/future-reused-build.out" 2>&1; then
-  echo "version guard accepted a future release that reused build 26" >&2
+grep -q 'exactly one entry for 1.8.28' "$work/future-missing-build.out"
+printf '%s\t%s\n' '1.8.28' '27' >> "$fixture/phase3-binary/app/release-builds.tsv"
+if bash "$fixture/scripts/test-coordinator-advertised-version.sh" v1.8.28 >"$work/future-reused-build.out" 2>&1; then
+  echo "version guard accepted a future release that reused build 27" >&2
   exit 1
 fi
 grep -q 'duplicate build' "$work/future-reused-build.out"
-sed 's/1\.8\.27[[:space:]]*26/1.8.27 27/' "$fixture/phase3-binary/app/release-builds.tsv" > "$fixture/phase3-binary/app/release-builds.tsv.next"
+sed 's/1\.8\.28[[:space:]]*27/1.8.28 28/' "$fixture/phase3-binary/app/release-builds.tsv" > "$fixture/phase3-binary/app/release-builds.tsv.next"
 mv "$fixture/phase3-binary/app/release-builds.tsv.next" "$fixture/phase3-binary/app/release-builds.tsv"
-sed 's/CURRENT_PROJECT_VERSION: "26"/CURRENT_PROJECT_VERSION: "27"/' "$fixture/phase3-binary/app/project.yml" > "$fixture/phase3-binary/app/project.yml.next"
+sed 's/CURRENT_PROJECT_VERSION: "27"/CURRENT_PROJECT_VERSION: "28"/' "$fixture/phase3-binary/app/project.yml" > "$fixture/phase3-binary/app/project.yml.next"
 mv "$fixture/phase3-binary/app/project.yml.next" "$fixture/phase3-binary/app/project.yml"
-bash "$fixture/scripts/test-coordinator-advertised-version.sh" v1.8.27
+bash "$fixture/scripts/test-coordinator-advertised-version.sh" v1.8.28
 
 cat >"$work/current-appcast.xml" <<EOF
 <?xml version="1.0" encoding="utf-8"?>


### PR DESCRIPTION
## Outcome

Issues the first immutable release containing the merged Pearl backend recovery path from #549. The existing v1.8.26 release predates those Linux assets and cannot be modified.

## Scope

- Align macprovider-cli and Malibu at 1.8.27 / build 27
- Append the immutable release-build ledger entry
- Advertise 1.8.27 from all coordinator distributions
- Advance the future-version regression fixture to 1.8.28

No tag has been created. After squash merge, v1.8.27 must be created only on the resulting fresh origin/main commit, then the protected release workflow may be dispatched.

## Verification

- make test-dist
- coordinator advertised-version check for v1.8.27
- focused Swift handshake version test
- code audit: APPROVE, C0/H0/M0/L0
- security audit: APPROVE, C0/H0/M0/L0
- architecture/operability audit: APPROVE, C0/H0/M0/L0

Relates to #536 and #549.