### PR TITLE
Keep draft release publication recoverable

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -995,6 +995,10 @@ jobs:
             --target "$release_commit" \
             --verify-tag \
             --draft
+          gh release view "$tag" \
+            --json databaseId,isDraft,tagName,targetCommitish > draft-release-cli.json
+          python3 scripts/verify-release-draft-identity.py cli \
+            draft-release-cli.json "$tag" "$release_commit" > draft-release-id.txt
 
       - name: Verify draft release assets by numeric ID
         env:
@@ -1003,47 +1007,23 @@ jobs:
         run: |
           set -euo pipefail
           tag="${{ needs.build.outputs.tag }}"
-          gh api -H 'X-GitHub-Api-Version: 2026-03-10' \
-            "repos/$GITHUB_REPOSITORY/releases/tags/$tag" > release-by-tag-api.json
-          release_id="$(python3 - <<'PY'
-          import json
-          release = json.load(open("release-by-tag-api.json", encoding="utf-8"))
-          value = release.get("id")
-          if type(value) is not int or value <= 0:
-              raise SystemExit("tag lookup did not return a numeric release id")
-          print(value)
-          PY
-          )"
+          release_commit="${{ needs.build.outputs.commit }}"
+          release_id="$(cat draft-release-id.txt)"
+          [[ "$release_id" =~ ^[1-9][0-9]*$ ]] || {
+            echo "::error::captured draft release id is invalid" >&2
+            exit 1
+          }
           gh api -H 'X-GitHub-Api-Version: 2026-03-10' \
             "repos/$GITHUB_REPOSITORY/releases/$release_id" > draft-release-api.json
-          python3 - "$release_id" <<'PY'
-          import json
-          import sys
-          by_tag = json.load(open("release-by-tag-api.json", encoding="utf-8"))
-          by_id = json.load(open("draft-release-api.json", encoding="utf-8"))
-          def identity(release):
-              return {
-                  "id": release.get("id"),
-                  "tag_name": release.get("tag_name"),
-                  "target_commitish": release.get("target_commitish"),
-                  "draft": release.get("draft"),
-                  "immutable": release.get("immutable"),
-                  "assets": sorted(
-                      (asset.get("id"), asset.get("name"), asset.get("digest"))
-                      for asset in release.get("assets", [])
-                  ),
-              }
-          if identity(by_tag) != identity(by_id) or by_id.get("id") != int(sys.argv[1]):
-              raise SystemExit("tag and numeric release lookups disagree")
-          PY
+          python3 scripts/verify-release-draft-identity.py api \
+            draft-release-api.json "$tag" "$release_commit" --release-id "$release_id" >/dev/null
           release_assets=()
           while IFS= read -r release_asset; do
             [ -n "$release_asset" ] && release_assets+=("$release_asset")
           done < release-assets.txt
-          python3 scripts/capture-release-publication.py --draft \
+          python3 scripts/capture-release-publication.py --draft --notes-file release-notes.md \
             draft-release-api.json release-provenance.json draft-publication-manifest.json \
             "${release_assets[@]}" checksums.txt checksums.txt.sig
-          printf '%s\n' "$release_id" > draft-release-id.txt
 
       - name: Publish only the revalidated numeric draft
         env:
@@ -1089,31 +1069,15 @@ jobs:
             checksums.txt checksums.txt.sig release-provenance.json \
             "$GITHUB_REPOSITORY" "$tag" "$commit" \
             "${release_assets[@]}"
-          gh api -H 'X-GitHub-Api-Version: 2026-03-10' \
-            "repos/$GITHUB_REPOSITORY/releases/tags/$tag" > final-draft-by-tag.json
+          gh release view "$tag" \
+            --json databaseId,isDraft,tagName,targetCommitish > final-draft-cli.json
+          python3 scripts/verify-release-draft-identity.py cli \
+            final-draft-cli.json "$tag" "$commit" --release-id "$release_id" >/dev/null
           gh api -H 'X-GitHub-Api-Version: 2026-03-10' \
             "repos/$GITHUB_REPOSITORY/releases/$release_id" > final-draft-by-id.json
-          python3 - "$release_id" <<'PY'
-          import json
-          import sys
-          by_tag = json.load(open("final-draft-by-tag.json", encoding="utf-8"))
-          by_id = json.load(open("final-draft-by-id.json", encoding="utf-8"))
-          def identity(release):
-              return {
-                  "id": release.get("id"),
-                  "tag_name": release.get("tag_name"),
-                  "target_commitish": release.get("target_commitish"),
-                  "draft": release.get("draft"),
-                  "immutable": release.get("immutable"),
-                  "assets": sorted(
-                      (asset.get("id"), asset.get("name"), asset.get("digest"))
-                      for asset in release.get("assets", [])
-                  ),
-              }
-          if identity(by_tag) != identity(by_id) or by_id.get("id") != int(sys.argv[1]):
-              raise SystemExit("final tag and numeric draft lookups disagree")
-          PY
-          python3 scripts/capture-release-publication.py --draft \
+          python3 scripts/verify-release-draft-identity.py api \
+            final-draft-by-id.json "$tag" "$commit" --release-id "$release_id" >/dev/null
+          python3 scripts/capture-release-publication.py --draft --notes-file release-notes.md \
             final-draft-by-id.json release-provenance.json final-draft-manifest.json \
             "${release_assets[@]}" checksums.txt checksums.txt.sig
 
@@ -1139,9 +1103,10 @@ jobs:
             "$release_id" "$PRERELEASE_INPUT" \
             immutable-release-by-id.json immutable-release-by-tag.json \
             stable-latest-release.json
-          python3 scripts/capture-release-publication.py \
+          python3 scripts/capture-release-publication.py --notes-file release-notes.md \
             immutable-release-by-id.json release-provenance.json publication-manifest.json \
             "${release_assets[@]}" checksums.txt checksums.txt.sig
+          cmp final-draft-manifest.json publication-manifest.json
 
       - name: Publish Malibu latest.dmg
         if: needs.build.outputs.prerelease == 'false'

--- a/scripts/capture-release-publication.py
+++ b/scripts/capture-release-publication.py
@@ -14,8 +14,14 @@ arguments = sys.argv[1:]
 draft_mode = bool(arguments and arguments[0] == "--draft")
 if draft_mode:
     arguments = arguments[1:]
+notes_path = None
+if arguments[:1] == ["--notes-file"]:
+    if len(arguments) < 2:
+        fail("--notes-file requires a path")
+    notes_path = pathlib.Path(arguments[1])
+    arguments = arguments[2:]
 if len(arguments) < 4:
-    fail("usage: [--draft] RELEASE_JSON PROVENANCE_JSON OUTPUT RELEASE_ASSET...")
+    fail("usage: [--draft] [--notes-file PATH] RELEASE_JSON PROVENANCE_JSON OUTPUT RELEASE_ASSET...")
 
 release_path, provenance_path, output_path, *local_asset_names = arguments
 release = json.loads(pathlib.Path(release_path).read_text(encoding="utf-8"))
@@ -44,6 +50,17 @@ if release.get("tag_name") != tag:
     fail("numeric release tag differs from signed provenance")
 if release.get("target_commitish") != commit:
     fail("numeric release target differs from signed provenance")
+expected_title = f"macprovider-cli {tag}"
+body_sha256 = None
+if notes_path is not None:
+    if not notes_path.is_file() or notes_path.is_symlink():
+        fail(f"release notes are not regular: {notes_path}")
+    expected_body = notes_path.read_text(encoding="utf-8")
+    if release.get("name") != expected_title:
+        fail("numeric release title differs from the reviewed release")
+    if release.get("body") != expected_body:
+        fail("numeric release body differs from the reviewed release notes")
+    body_sha256 = hashlib.sha256(expected_body.encode()).hexdigest()
 if draft_mode:
     if release.get("draft") is not True:
         fail("numeric release is not the expected draft")
@@ -128,6 +145,9 @@ manifest = {
     "publication_id": publication_id,
     "assets": manifest_assets,
 }
+if body_sha256 is not None:
+    manifest["title"] = expected_title
+    manifest["body_sha256"] = body_sha256
 pathlib.Path(output_path).write_text(
     json.dumps(manifest, sort_keys=True, separators=(",", ":")) + "\n",
     encoding="utf-8",

--- a/scripts/test-malibu-download-publish.sh
+++ b/scripts/test-malibu-download-publish.sh
@@ -20,6 +20,13 @@ for file in "$SETUP" "$PUBLISH" "$INSTALL_PUBLICATION" "$VERIFY_SET" "$VERIFY" "
   [[ -f "$file" ]] || fail "missing $file"
   bash -n "$file" || fail "bash -n $file"
 done
+if grep -qE 'read -r .*< <\(python3 .*<<' "$VERIFY_SET"; then
+  fail 'publication verifier must not combine a heredoc with process substitution on Bash 3.2'
+fi
+grep -q 'expected_identity="[$](python3' "$VERIFY_SET" ||
+  fail 'publication verifier must capture signed provenance identity portably'
+grep -q 'publication_identity="[$](python3' "$VERIFY_SET" ||
+  fail 'publication verifier must capture publication identity portably'
 [[ -f "$KNOWN_HOSTS" ]] || fail "missing $KNOWN_HOSTS"
 [[ -f "$NGINX" ]] || fail "missing $NGINX"
 

--- a/scripts/test-release-publication-provenance.sh
+++ b/scripts/test-release-publication-provenance.sh
@@ -4,6 +4,7 @@ set -euo pipefail
 root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 build="$root/scripts/build-release-provenance.py"
 capture="$root/scripts/capture-release-publication.py"
+draft_identity="$root/scripts/verify-release-draft-identity.py"
 verify_published="$root/scripts/verify-published-release.py"
 sparkle="$root/scripts/verify-malibu-sparkle-signature.py"
 recovery="$root/scripts/recover-malibu-publication.sh"
@@ -20,6 +21,7 @@ printf 'coordinator cli payload\n' > "$work/coordinator-cli-linux-amd64"
 printf 'gateway payload\n' > "$work/gateway-linux-amd64"
 printf 'pearl metadata\n' > "$work/pearl-release.json"
 printf 'pearl metadata signature\n' > "$work/pearl-release.json.sig"
+printf 'reviewed release notes\n' > "$work/release-notes.md"
 cat >"$work/release-toolchain.json" <<'EOF'
 {"macos_sdk":{"path":"/Applications/Xcode_16.4.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX15.5.sdk","version":"15.5"},"swift":{"driver_version":"1.120.5","version":"Apple Swift version 6.1.2 (swiftlang-6.1.2.1.2 clang-1700.0.13.5)"},"xcode":{"build":"16F6","developer_dir":"/Applications/Xcode_16.4.app/Contents/Developer","version":"16.4"}}
 EOF
@@ -70,6 +72,8 @@ release = {
     "draft": False,
     "immutable": True,
     "prerelease": False,
+    "name": f"macprovider-cli {tag}",
+    "body": "reviewed release notes\n",
     "assets": assets,
 }
 (root / "release.json").write_text(json.dumps(release), encoding="utf-8")
@@ -88,7 +92,8 @@ local_assets=(
   "$work/checksums.txt"
   "$work/checksums.txt.sig"
 )
-python3 "$capture" "$work/release.json" "$work/release-provenance.json" \
+python3 "$capture" --notes-file "$work/release-notes.md" \
+  "$work/release.json" "$work/release-provenance.json" \
   "$work/publication-manifest.json" "${local_assets[@]}"
 
 python3 - "$work/release.json" "$work/release-draft.json" <<'PY'
@@ -98,8 +103,54 @@ data["draft"] = True
 data["immutable"] = False
 pathlib.Path(sys.argv[2]).write_text(json.dumps(data))
 PY
-python3 "$capture" --draft "$work/release-draft.json" "$work/release-provenance.json" \
+python3 "$capture" --draft --notes-file "$work/release-notes.md" \
+  "$work/release-draft.json" "$work/release-provenance.json" \
   "$work/draft-publication-manifest.json" "${local_assets[@]}"
+cmp "$work/publication-manifest.json" "$work/draft-publication-manifest.json"
+
+cat > "$work/release-draft-cli.json" <<EOF
+{"databaseId":401,"isDraft":true,"tagName":"$tag","targetCommitish":"$commit"}
+EOF
+[[ "$(python3 "$draft_identity" cli "$work/release-draft-cli.json" "$tag" "$commit")" == 401 ]]
+[[ "$(python3 "$draft_identity" api "$work/release-draft.json" "$tag" "$commit" --release-id 401)" == 401 ]]
+python3 - "$work/release-draft-cli.json" "$work/release-draft.json" "$work" <<'PY'
+import json
+import pathlib
+import sys
+
+cli_path, api_path, root = map(pathlib.Path, sys.argv[1:])
+cli = json.loads(cli_path.read_text())
+api = json.loads(api_path.read_text())
+cli_mutations = {
+    "id": {**cli, "databaseId": 402},
+    "draft": {**cli, "isDraft": False},
+    "tag": {**cli, "tagName": "v9.9.9"},
+    "commit": {**cli, "targetCommitish": "b" * 40},
+}
+api_mutations = {
+    "id": {**api, "id": 402},
+    "draft": {**api, "draft": False},
+    "immutable": {**api, "immutable": True},
+    "tag": {**api, "tag_name": "v9.9.9"},
+    "commit": {**api, "target_commitish": "b" * 40},
+}
+for name, value in cli_mutations.items():
+    (root / f"draft-cli-{name}.json").write_text(json.dumps(value))
+for name, value in api_mutations.items():
+    (root / f"draft-api-{name}.json").write_text(json.dumps(value))
+PY
+for fixture in "$work"/draft-cli-*.json; do
+  if python3 "$draft_identity" cli "$fixture" "$tag" "$commit" --release-id 401 >"$work/draft-identity.out" 2>&1; then
+    echo "draft identity guard accepted invalid CLI fixture: $fixture" >&2
+    exit 1
+  fi
+done
+for fixture in "$work"/draft-api-*.json; do
+  if python3 "$draft_identity" api "$fixture" "$tag" "$commit" --release-id 401 >"$work/draft-identity.out" 2>&1; then
+    echo "draft identity guard accepted invalid API fixture: $fixture" >&2
+    exit 1
+  fi
+done
 if python3 "$capture" "$work/release-draft.json" "$work/release-provenance.json" \
   "$work/premature-publication-manifest.json" "${local_assets[@]}" >"$work/draft.out" 2>&1; then
   echo "final publication capture accepted a draft release" >&2
@@ -116,12 +167,44 @@ import sys
 manifest = json.loads(pathlib.Path(sys.argv[1]).read_text())
 assert manifest["release_id"] == 401
 assert manifest["prerelease"] is False
+assert manifest["title"] == "macprovider-cli v1.2.3"
+assert re.fullmatch(r"[0-9a-f]{64}", manifest["body_sha256"])
 assert re.fullmatch(r"[0-9a-f]{64}", manifest["publication_id"])
 assert manifest["assets"]["Malibu-v1.2.3.dmg"]["id"] == 502
 assert manifest["assets"]["appcast.xml"]["id"] == 503
 assert manifest["assets"]["coordinator-linux-amd64"]["id"] == 504
 assert manifest["assets"]["pearl-release.json.sig"]["id"] == 508
 PY
+
+for field in name body; do
+  python3 - "$work/release.json" "$work/release-presentation-drift.json" "$field" <<'PY'
+import json, pathlib, sys
+data = json.loads(pathlib.Path(sys.argv[1]).read_text())
+data[sys.argv[3]] = "unreviewed presentation"
+pathlib.Path(sys.argv[2]).write_text(json.dumps(data))
+PY
+  if python3 "$capture" --notes-file "$work/release-notes.md" \
+    "$work/release-presentation-drift.json" "$work/release-provenance.json" \
+    "$work/presentation-drift-manifest.json" "${local_assets[@]}" \
+    >"$work/presentation-drift.out" 2>&1; then
+    echo "publication capture accepted release $field drift" >&2
+    exit 1
+  fi
+done
+
+python3 - "$work/release.json" "$work/release-asset-id-drift.json" <<'PY'
+import json, pathlib, sys
+data = json.loads(pathlib.Path(sys.argv[1]).read_text())
+data["assets"][0]["id"] += 1000
+pathlib.Path(sys.argv[2]).write_text(json.dumps(data))
+PY
+python3 "$capture" --notes-file "$work/release-notes.md" \
+  "$work/release-asset-id-drift.json" "$work/release-provenance.json" \
+  "$work/asset-id-drift-manifest.json" "${local_assets[@]}"
+if cmp -s "$work/publication-manifest.json" "$work/asset-id-drift-manifest.json"; then
+  echo "publication manifest did not bind numeric asset identity" >&2
+  exit 1
+fi
 
 python3 - "$work/release.json" "$work/release-mutable.json" <<'PY'
 import json, pathlib, sys

--- a/scripts/test-release-security-posture.sh
+++ b/scripts/test-release-security-posture.sh
@@ -135,8 +135,16 @@ verify_draft = publish.split("- name: Verify draft release assets by numeric ID"
 make_public = publish.split("- name: Publish only the revalidated numeric draft", 1)[1].split("\n      - name:", 1)[0]
 if "--draft" not in create or create.find("scripts/verify-release-checksums.sh") > create.find("gh release create"):
     raise SystemExit("GitHub publication must verify canonical checksums before creating a draft")
-if "capture-release-publication.py --draft" not in verify_draft or "draft-release-id.txt" not in verify_draft:
+if (
+    "gh release view \"$tag\"" not in create
+    or "verify-release-draft-identity.py cli" not in create
+    or "draft-release-id.txt" not in create
+    or "capture-release-publication.py --draft --notes-file release-notes.md" not in verify_draft
+    or "draft-release-id.txt" not in verify_draft
+):
     raise SystemExit("draft assets and numeric release ID must be captured before publication")
+if 'releases/tags/$tag' in verify_draft:
+    raise SystemExit("REST tag lookup cannot discover a draft release")
 patch_position = make_public.find("gh api --method PATCH")
 if patch_position < 0:
     raise SystemExit("verified draft must be made public by numeric-ID PATCH")
@@ -144,18 +152,29 @@ for requirement in (
     "scripts/verify-release-source.sh",
     "scripts/verify-github-release-posture.sh",
     "scripts/verify-release-checksums.sh",
-    "final-draft-by-tag.json",
+    "gh release view \"$tag\"",
+    "final-draft-cli.json",
     "final-draft-by-id.json",
+    "verify-release-draft-identity.py cli",
+    "verify-release-draft-identity.py api",
     "capture-release-publication.py --draft",
 ):
     if make_public.find(requirement) < 0 or make_public.find(requirement) > patch_position:
         raise SystemExit(f"final public-transition gate is missing or late: {requirement}")
+if 'releases/tags/$tag' in make_public[:patch_position]:
+    raise SystemExit("final draft verification cannot use the public-only REST tag lookup")
 if "--require-existing" not in make_public[make_public.find("scripts/verify-release-source.sh"):patch_position]:
     raise SystemExit("final public-transition source gate must explicitly require the tag")
 if make_public.find("immutable-release-by-id.json", patch_position) < 0 or make_public.find(
     "capture-release-publication.py", patch_position
 ) < 0:
     raise SystemExit("published numeric release must be re-fetched and required immutable")
+if "cmp final-draft-manifest.json publication-manifest.json" not in make_public[patch_position:]:
+    raise SystemExit("published release must exactly preserve the verified draft manifest")
+if "capture-release-publication.py --draft --notes-file release-notes.md" not in make_public[:patch_position]:
+    raise SystemExit("final draft capture must bind the reviewed release notes")
+if "capture-release-publication.py --notes-file release-notes.md" not in make_public[patch_position:]:
+    raise SystemExit("published release capture must bind the reviewed release notes")
 for requirement in (
     "verify-published-release.py",
     "stable-latest-release.json",

--- a/scripts/verify-malibu-publication-set.sh
+++ b/scripts/verify-malibu-publication-set.sh
@@ -19,7 +19,7 @@ for path in "$manifest" "$dmg" "$appcast" "$checksums" "$signature" "$provenance
   [[ -f "$path" && ! -L "$path" ]] || die "publication input is not a regular file: $path"
 done
 
-read -r expected_repository expected_tag expected_commit < <(python3 - "$provenance" <<'PY'
+expected_identity="$(python3 - "$provenance" <<'PY'
 import json
 import pathlib
 import sys
@@ -27,13 +27,14 @@ import sys
 value = json.loads(pathlib.Path(sys.argv[1]).read_text(encoding="utf-8"))
 print(value.get("repository", ""), value.get("tag", ""), value.get("commit", ""))
 PY
-)
+)"
+read -r expected_repository expected_tag expected_commit <<< "$expected_identity"
 bash "$repo_root/scripts/verify-release-checksums.sh" --allow-partial \
   "$checksums" "$signature" "$provenance" \
   "$expected_repository" "$expected_tag" "$expected_commit" \
   "$dmg" "$appcast" "$provenance" >/dev/null
 
-read -r tag commit < <(python3 - "$manifest" "$dmg" "$appcast" "$checksums" "$signature" "$provenance" <<'PY'
+publication_identity="$(python3 - "$manifest" "$dmg" "$appcast" "$checksums" "$signature" "$provenance" <<'PY'
 import hashlib
 import json
 import pathlib
@@ -90,7 +91,8 @@ if manifest.get("publication_id") != hashlib.sha256(content).hexdigest():
 
 print(tag, commit)
 PY
-)
+)"
+read -r tag commit <<< "$publication_identity"
 [[ "$tag" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ && "$commit" =~ ^[0-9a-f]{40}$ ]] ||
   die "publication identity verification failed"
 

--- a/scripts/verify-release-draft-identity.py
+++ b/scripts/verify-release-draft-identity.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+import argparse
+import json
+import pathlib
+import re
+
+
+def fail(message: str) -> None:
+    raise SystemExit(f"verify-release-draft-identity: {message}")
+
+
+parser = argparse.ArgumentParser(
+    description="Bind a GitHub draft lookup to the reviewed tag and commit."
+)
+parser.add_argument("mode", choices=("cli", "api"))
+parser.add_argument("release_json")
+parser.add_argument("tag")
+parser.add_argument("commit")
+parser.add_argument("--release-id", type=int)
+args = parser.parse_args()
+
+if not re.fullmatch(r"v\d+\.\d+\.\d+", args.tag):
+    fail("invalid tag")
+if not re.fullmatch(r"[0-9a-f]{40}", args.commit):
+    fail("invalid commit")
+if args.release_id is not None and args.release_id <= 0:
+    fail("invalid expected release id")
+
+release = json.loads(pathlib.Path(args.release_json).read_text(encoding="utf-8"))
+if not isinstance(release, dict):
+    fail("release lookup is not an object")
+
+if args.mode == "cli":
+    release_id = release.get("databaseId")
+    valid = (
+        type(release_id) is int
+        and release_id > 0
+        and release.get("isDraft") is True
+        and release.get("tagName") == args.tag
+        and release.get("targetCommitish") == args.commit
+    )
+else:
+    release_id = release.get("id")
+    valid = (
+        type(release_id) is int
+        and release_id > 0
+        and release.get("draft") is True
+        and release.get("immutable") is not True
+        and release.get("tag_name") == args.tag
+        and release.get("target_commitish") == args.commit
+    )
+
+if args.release_id is not None:
+    valid = valid and release_id == args.release_id
+if not valid:
+    fail(f"{args.mode} lookup did not return the expected draft identity")
+
+print(release_id)


### PR DESCRIPTION
## Why

The v1.8.30 release proved two production gaps: GitHub REST lookup by tag does not return a draft release, and the Malibu publication verifier used a construct incompatible with macOS Bash 3.2. The release artifacts were valid, but the workflow stopped before public transition and required an exact numeric-release recovery.

## What changed

- discover drafts through `gh release view`, then bind the numeric release ID, tag, target commit, and draft state independently
- bind exact release title, reviewed notes, numeric asset IDs, and asset digests into the draft publication manifest
- re-fetch the immutable public release and require byte-identical draft/public manifests before Malibu publication
- make the Malibu publication-set verifier portable to Bash 3.2
- add mutation regressions for release identity, presentation, asset IDs, workflow ordering, and the portable verifier path

## Validation

- `make test-dist` passed at exact head `8c215ecb3b1a6baba45f8c2a493b23fca618ac71`
- targeted publication, security-posture, and Malibu tests passed under `/bin/bash` 3.2
- ShellCheck, Bash/Python syntax, workflow YAML parse, and `git diff --check` passed
- three independent audits: code C0/H0/M0/L0 APPROVE; security C0/H0/M0/L1 COMMENT; architecture C0/H0/M0/L1 APPROVE

## Residual risk

GitHub does not offer an atomic verified-draft GET-to-PATCH transition. A concurrent mutation can still burn the public release, but the immutable post-publication re-fetch and manifest-equality gate detect it before Malibu publication, limiting impact to availability/recovery rather than undetected downstream publication.