### PR TITLE
fix(coordinator): implement SPEC-010 R-3.3.4 seenModels union of supported_models (404->503 for declared-but-cold)

### DIFF
--- a/phase4-coordinator/internal/buyer/server_test.go
+++ b/phase4-coordinator/internal/buyer/server_test.go
@@ -5556,6 +5556,56 @@ func TestChatCompletionsColdStartRaceReturnsNoProviderAvailable(t *testing.T) {
 	assertOpenAIErrorEnvelope(t, unseen, "model_not_found", "invalid_request_error")
 }
 
+// TestChatCompletionsDeclaredButColdModelReturns503 pins the buyer-
+// visible half of SPEC-010 v1.5 R-3.3.4: a request for a model that a
+// connected provider DECLARES supporting (supported_models) but is not
+// currently serving (cold) must return 503 no_provider_available
+// (transient/retryable — the provider may warm it), NOT 404
+// model_not_found. A model that no provider declares still returns 404.
+func TestChatCompletionsDeclaredButColdModelReturns503(t *testing.T) {
+	registry := pool.NewRegistry([]config.ProviderConfig{{ProviderID: "p1", EndpointURL: "http://p1.example"}})
+	// Provider serves model-served but declares support for
+	// model-declared-cold (it is warm-capable but not currently loaded).
+	registry.Register(&pool.Provider{
+		ProviderID:            "p1",
+		AssignedID:            "s1",
+		Hostname:              "p1.local",
+		ModelID:               "model-served",
+		SupportedModels:       []string{"model-declared-cold"},
+		ModelParamsB:          7,
+		RAMGB:                 16,
+		MaxContextTokens:      20000,
+		MaxConcurrency:        1,
+		SlotsFree:             1,
+		SlotsTotal:            1,
+		ThroughputTPSEstimate: 20,
+		EndpointURL:           "http://p1.example",
+		Tier:                  pool.TierPinned,
+		InferencePath:         pool.InferencePathHTTPForwarding,
+		State:                 pool.StateReady,
+		LastHeartbeatAt:       time.Now().UTC(),
+		ConnectedAt:           time.Now().UTC(),
+		BinaryVersion:         "0.1.0",
+	}, nil)
+	server := buyer.NewServer(registry, zerolog.Nop(), time.Unix(1716768000, 0))
+
+	// (b) Declared-but-cold model: no provider currently serves it, but
+	// it is in the seen-model union (R-3.3.4) → 503, not 404.
+	cold := postChat(t, server, []byte(`{"model":"model-declared-cold","messages":[{"role":"user","content":"hello"}]}`), nil)
+	if cold.Code != http.StatusServiceUnavailable {
+		t.Fatalf("declared-but-cold model status = %d, want 503; body=%s", cold.Code, cold.Body.String())
+	}
+	assertOpenAIErrorEnvelope(t, cold, "no_provider_available", "service_unavailable")
+
+	// (c) A model no provider declares stays 404 model_not_found — the
+	// union must not turn genuinely-unknown models into 503.
+	unknown := postChat(t, server, []byte(`{"model":"model-nobody-declares-9000","messages":[{"role":"user","content":"hi"}]}`), nil)
+	if unknown.Code != http.StatusNotFound {
+		t.Fatalf("undeclared model status = %d, want 404; body=%s", unknown.Code, unknown.Body.String())
+	}
+	assertOpenAIErrorEnvelope(t, unknown, "model_not_found", "invalid_request_error")
+}
+
 // assertOpenAIErrorEnvelope decodes the response body and verifies
 // the full OpenAI error envelope shape (error.code, error.type,
 // error.message non-empty, error.param is null). Used by the cold-

--- a/phase4-coordinator/internal/buyer/server_test.go
+++ b/phase4-coordinator/internal/buyer/server_test.go
@@ -5565,13 +5565,16 @@ func TestChatCompletionsColdStartRaceReturnsNoProviderAvailable(t *testing.T) {
 func TestChatCompletionsDeclaredButColdModelReturns503(t *testing.T) {
 	registry := pool.NewRegistry([]config.ProviderConfig{{ProviderID: "p1", EndpointURL: "http://p1.example"}})
 	// Provider serves model-served but declares support for
-	// model-declared-cold (it is warm-capable but not currently loaded).
+	// model-declared-cold (it is warm-capable but not currently
+	// loaded). R-3.1.4: the served model_id MUST appear in
+	// supported_models, so model-served is listed too (codex code-lane
+	// audit of PR #555).
 	registry.Register(&pool.Provider{
 		ProviderID:            "p1",
 		AssignedID:            "s1",
 		Hostname:              "p1.local",
 		ModelID:               "model-served",
-		SupportedModels:       []string{"model-declared-cold"},
+		SupportedModels:       []string{"model-served", "model-declared-cold"},
 		ModelParamsB:          7,
 		RAMGB:                 16,
 		MaxContextTokens:      20000,
@@ -5596,6 +5599,7 @@ func TestChatCompletionsDeclaredButColdModelReturns503(t *testing.T) {
 		t.Fatalf("declared-but-cold model status = %d, want 503; body=%s", cold.Code, cold.Body.String())
 	}
 	assertOpenAIErrorEnvelope(t, cold, "no_provider_available", "service_unavailable")
+	assertRetryableAndNoProviderBodyForwarded(t, cold, true)
 
 	// (c) A model no provider declares stays 404 model_not_found — the
 	// union must not turn genuinely-unknown models into 503.
@@ -5604,6 +5608,93 @@ func TestChatCompletionsDeclaredButColdModelReturns503(t *testing.T) {
 		t.Fatalf("undeclared model status = %d, want 404; body=%s", unknown.Code, unknown.Body.String())
 	}
 	assertOpenAIErrorEnvelope(t, unknown, "model_not_found", "invalid_request_error")
+	assertRetryableAndNoProviderBodyForwarded(t, unknown, false)
+}
+
+// TestChatCompletionsDeclaredModelBeyondSeenIndexCapsReturns503 pins
+// the buyer-visible half of the codex code-lane HIGH finding on PR
+// #555: a provider whose declared catalog is wider than the seen-index
+// caps (maxSeenModelsPerProvider=32 per-session,
+// maxLifetimeContribPerProvider=128 per-provider lifetime) still gets
+// 503 no_provider_available for a declared-but-cold model beyond those
+// caps, because ModelKnown falls back to scanning the live, currently-
+// connected provider's SupportedModels directly.
+func TestChatCompletionsDeclaredModelBeyondSeenIndexCapsReturns503(t *testing.T) {
+	registry := pool.NewRegistry([]config.ProviderConfig{{ProviderID: "p1", EndpointURL: "http://p1.example"}})
+
+	const totalSupported = 200
+	supported := make([]string, totalSupported)
+	// R-3.1.4: served model_id must appear in supported_models; this
+	// duplicate entry consumes no extra seen-index budget.
+	supported[0] = "model-served"
+	for i := 1; i < totalSupported; i++ {
+		supported[i] = fmt.Sprintf("declared-model-%03d", i)
+	}
+	// supported[150] is well past both the 32-entry per-session cap
+	// and the 128-entry per-provider lifetime cap (see the pool-level
+	// TestModelKnownFindsDeclaredModelBeyondSeenIndexCaps for the exact
+	// slot accounting).
+	beyondCapsModel := supported[150]
+
+	registry.Register(&pool.Provider{
+		ProviderID:            "p1",
+		AssignedID:            "s1",
+		Hostname:              "p1.local",
+		ModelID:               "model-served",
+		SupportedModels:       supported,
+		ModelParamsB:          7,
+		RAMGB:                 16,
+		MaxContextTokens:      20000,
+		MaxConcurrency:        1,
+		SlotsFree:             1,
+		SlotsTotal:            1,
+		ThroughputTPSEstimate: 20,
+		EndpointURL:           "http://p1.example",
+		Tier:                  pool.TierPinned,
+		InferencePath:         pool.InferencePathHTTPForwarding,
+		State:                 pool.StateReady,
+		LastHeartbeatAt:       time.Now().UTC(),
+		ConnectedAt:           time.Now().UTC(),
+		BinaryVersion:         "0.1.0",
+	}, nil)
+	server := buyer.NewServer(registry, zerolog.Nop(), time.Unix(1716768000, 0))
+
+	rr := postChat(t, server, []byte(`{"model":"`+beyondCapsModel+`","messages":[{"role":"user","content":"hello"}]}`), nil)
+	if rr.Code != http.StatusServiceUnavailable {
+		t.Fatalf("declared model beyond seen-index caps status = %d, want 503; body=%s", rr.Code, rr.Body.String())
+	}
+	assertOpenAIErrorEnvelope(t, rr, "no_provider_available", "service_unavailable")
+	assertRetryableAndNoProviderBodyForwarded(t, rr, true)
+}
+
+// assertRetryableAndNoProviderBodyForwarded asserts error.retryable
+// matches wantRetryable and that the response body is EXACTLY the
+// OpenAI error envelope shape — a single top-level "error" key — so a
+// provider's partial/forwarded completion payload cannot have leaked
+// into the 503/404 response. Codex code-lane audit of PR #555.
+func assertRetryableAndNoProviderBodyForwarded(t *testing.T, rr *httptest.ResponseRecorder, wantRetryable bool) {
+	t.Helper()
+	var body struct {
+		Error struct {
+			Retryable bool `json:"retryable"`
+		} `json:"error"`
+	}
+	if err := json.Unmarshal(rr.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode envelope: %v; body=%s", err, rr.Body.String())
+	}
+	if body.Error.Retryable != wantRetryable {
+		t.Fatalf("error.retryable = %v, want %v; body=%s", body.Error.Retryable, wantRetryable, rr.Body.String())
+	}
+	var topLevel map[string]json.RawMessage
+	if err := json.Unmarshal(rr.Body.Bytes(), &topLevel); err != nil {
+		t.Fatalf("decode top-level body: %v; body=%s", err, rr.Body.String())
+	}
+	if len(topLevel) != 1 {
+		t.Fatalf("response body has %d top-level keys, want exactly 1 (\"error\"); a provider body may have been forwarded: %s", len(topLevel), rr.Body.String())
+	}
+	if _, ok := topLevel["error"]; !ok {
+		t.Fatalf("response body missing top-level \"error\" key: %s", rr.Body.String())
+	}
 }
 
 // assertOpenAIErrorEnvelope decodes the response body and verifies

--- a/phase4-coordinator/internal/pool/provider.go
+++ b/phase4-coordinator/internal/pool/provider.go
@@ -1617,6 +1617,25 @@ func (r *Registry) ModelKnown(modelID string) bool {
 			return true
 		}
 	}
+	// 1b. SPEC-010 v1.5 R-3.3.4 correctness core: live providers'
+	// declared SupportedModels. recordSeenModelsUnionLocked's seen-index
+	// union (per-session cap maxSeenModelsPerProvider=32, per-provider
+	// lifetime cap maxLifetimeContribPerProvider=128, global lifetime
+	// cap maxSeenModelsLifetime=4096) is a best-effort accumulator that
+	// can silently drop a declared model under cap pressure — e.g. a
+	// provider with a catalog wider than 32 entries. Without this scan,
+	// a model beyond those caps would 404 forever even though a
+	// CURRENTLY-CONNECTED provider is declaring it right now. A served
+	// ModelID never has this gap (step 1 above always covers it
+	// regardless of cap state); declared-but-cold models need the same
+	// unconditional guarantee while the declaring provider is live.
+	for _, p := range r.providers {
+		for _, supported := range p.SupportedModels {
+			if strings.EqualFold(supported, modelID) {
+				return true
+			}
+		}
+	}
 	// 2. Per-session attribution map. ISS-185 R2 code-lane MAJOR: a
 	// provider may have previously advertised this model id via
 	// heartbeat (it's in their per-session set) while their CURRENT

--- a/phase4-coordinator/internal/pool/provider.go
+++ b/phase4-coordinator/internal/pool/provider.go
@@ -718,7 +718,9 @@ func (r *Registry) RegisterAtDetailed(p *Provider, conn net.Conn, now time.Time)
 	}
 	r.providers[p.ProviderID] = p
 	r.sessions[p.AssignedID] = p
-	r.recordSeenModelLocked(p.ProviderID, p.ModelID)
+	// SPEC-010 v1.5 R-3.3.4: seed the seen-model index with the union of
+	// the served model_id AND every declared supported_models entry.
+	r.recordSeenModelsUnionLocked(p.ProviderID, p.ModelID, p.SupportedModels)
 	delete(r.breakerFaults, p.ProviderID)
 	delete(r.recoveryHolds, p.ProviderID)
 	delete(r.lastBreakerRecoveries, p.ProviderID)
@@ -901,6 +903,37 @@ func (r *Registry) recordSeenModelLocked(providerID, modelID string) {
 	}
 	r.seenModelsLifetime[canonical] = struct{}{}
 	r.lifetimeContribByProvider[providerID]++
+}
+
+// recordSeenModelsUnionLocked records the SPEC-010 v1.5 R-3.3.4 union of
+// the currently-served modelID and every entry the provider declared in
+// supportedModels into the seen-model indexes. It makes ModelKnown()
+// return true for a model that some provider DECLARES supporting but is
+// not currently serving (cold), so a buyer request for such a model falls
+// through to the existing 503 no_provider_available (transient/retryable)
+// path instead of 404 model_not_found (see buyer/server.go's ModelKnown
+// gate).
+//
+// Each entry flows through recordSeenModelLocked, so:
+//   - supported-model entries share EXACTLY the same normalization
+//     (strings.ToLower canonical key for the lifetime accumulator, raw
+//     id for the per-session attribution set) as the served model_id;
+//   - they share the same lifecycle: dropped from seenModelsByProvider
+//     on disconnect / session-replacement (M2-5 / PERF-5), and retained
+//     append-only in seenModelsLifetime for the coordinator process
+//     lifetime (SPEC-002 § 7.2 cold-start-race survival). No separate
+//     removal path is introduced — a declared-cold model ages exactly as
+//     the served model_id does.
+//
+// Per R-3.1.5 a legacy provider carries supportedModels == [modelID]
+// (synthesized in ws/server.go), so the union collapses to {modelID} and
+// this is byte-identical to pre-SPEC-010 for any provider that did not
+// declare models beyond its served one (R-4.1 / R-3.5.1 guarantee).
+func (r *Registry) recordSeenModelsUnionLocked(providerID, modelID string, supportedModels []string) {
+	r.recordSeenModelLocked(providerID, modelID)
+	for _, supported := range supportedModels {
+		r.recordSeenModelLocked(providerID, supported)
+	}
 }
 
 // LifetimeCapStats returns the current size of the pool-lifetime
@@ -1461,7 +1494,11 @@ func (r *Registry) applyHeartbeatLocked(providerID, assignedID string, hb Heartb
 	if hb.HardwareCapacity != nil {
 		p.HardwareCapacity = sanitizeProviderHardwareCapacity(hb.HardwareCapacity)
 	}
-	r.recordSeenModelLocked(p.ProviderID, hb.ModelID)
+	// SPEC-010 v1.5 R-3.3.4: union the heartbeat's served model_id with
+	// the provider's declared supported_models. Heartbeat frames do not
+	// carry supported_models, so p.SupportedModels (populated at
+	// registration) is the authoritative declared set.
+	r.recordSeenModelsUnionLocked(p.ProviderID, hb.ModelID, p.SupportedModels)
 	if hb.Status != "" && hb.Status != p.State {
 		if r.canApplyProviderStateLocked(p, hb.Status) {
 			r.setStateLocked(p, hb.Status)

--- a/phase4-coordinator/internal/pool/provider_test.go
+++ b/phase4-coordinator/internal/pool/provider_test.go
@@ -1262,6 +1262,117 @@ func TestModelKnownPersistsInLifetimeAccumulator(t *testing.T) {
 	}
 }
 
+// TestModelKnownUnionsDeclaredSupportedModels pins SPEC-010 v1.5
+// R-3.3.4: the seen-model index is the UNION of a provider's served
+// ModelID and every entry in its SupportedModels, so ModelKnown()
+// returns true for a model that a provider DECLARES supporting but is
+// not currently serving (cold). This is what makes a buyer request for
+// such a model fall through to 503 no_provider_available (retryable)
+// instead of 404 model_not_found.
+func TestModelKnownUnionsDeclaredSupportedModels(t *testing.T) {
+	registry := NewRegistry(nil)
+	start := time.Unix(1716768000, 0).UTC()
+
+	// Provider serves model-y but declares support for model-x (cold)
+	// and Model-X-CASE (mixed case, to exercise the case-folding the
+	// registration path already applies to model ids).
+	registry.Register(&Provider{
+		ProviderID:       "p1",
+		AssignedID:       "s1",
+		ModelID:          "model-y",
+		SupportedModels:  []string{"model-x", "Model-X-CASE"},
+		State:            StateReady,
+		SlotsFree:        1,
+		SlotsTotal:       1,
+		LastHeartbeatAt:  start,
+		LastActivityAt:   start,
+		MaxConcurrency:   1,
+		MaxContextTokens: 20000,
+	}, nil)
+
+	// (a) The served model is known.
+	if !registry.ModelKnown("model-y") {
+		t.Fatal("ModelKnown(model-y) = false; served model_id not in seen index")
+	}
+	// (a) A declared-but-cold model is known via the R-3.3.4 union.
+	if !registry.ModelKnown("model-x") {
+		t.Fatal("ModelKnown(model-x) = false; declared supported_models entry not unioned into seen index (SPEC-010 R-3.3.4)")
+	}
+	// Case-folding: the union entry is matched regardless of case, the
+	// same as the served model_id path (ModelKnown lowercases + EqualFold).
+	if !registry.ModelKnown("model-x-case") {
+		t.Fatal("ModelKnown(model-x-case) = false; declared supported model not case-folded like model_id")
+	}
+	// (c) A model no provider declares is NOT known — union must not
+	// turn unknown models into false positives (would wrongly 503).
+	if registry.ModelKnown("model-z-undeclared") {
+		t.Fatal("ModelKnown(model-z-undeclared) = true; undeclared model must stay unknown (404), not 503")
+	}
+
+	// (d) Lifecycle: the per-session attribution index carries the
+	// declared supported models while connected, and is dropped on
+	// disconnect EXACTLY as the served model_id is (M2-5 / PERF-5). The
+	// pool-lifetime accumulator (SPEC-002 § 7.2) retains them append-only
+	// so the cold-start race still answers 503 — identical to model_id.
+	registry.mu.RLock()
+	sessionSet := registry.seenModelsByProvider["p1"]
+	_, xInSession := sessionSet["model-x"]
+	_, yInSession := sessionSet["model-y"]
+	registry.mu.RUnlock()
+	if !xInSession || !yInSession {
+		t.Fatalf("seenModelsByProvider[p1] = %v; want served model_id AND declared supported models while connected", sessionSet)
+	}
+
+	if !registry.RemoveIfSession("p1", "s1") {
+		t.Fatal("RemoveIfSession returned false")
+	}
+	// Per-session attribution for the declared model is gone on
+	// disconnect — no leak, same lifecycle as model_id.
+	registry.mu.RLock()
+	_, sessionStillPresent := registry.seenModelsByProvider["p1"]
+	registry.mu.RUnlock()
+	if sessionStillPresent {
+		t.Fatal("seenModelsByProvider[p1] still present after RemoveIfSession; supported-model union leaked into per-session index")
+	}
+	// Lifetime survival (intended, matches model_id / issue #185): a
+	// declared-cold model stays known across a disconnect so the buyer
+	// port keeps answering 503 for the cold-start race window.
+	if !registry.ModelKnown("model-x") {
+		t.Fatal("ModelKnown(model-x) = false after disconnect; declared-cold model should survive in lifetime accumulator like model_id (SPEC-002 § 7.2)")
+	}
+}
+
+// TestModelKnownUnionsSupportedModelsOnHeartbeat pins that the R-3.3.4
+// union is re-applied on the heartbeat path too (provider.go heartbeat
+// site), not only at registration. Heartbeat frames do not carry
+// supported_models, so the stored Provider.SupportedModels remains the
+// authoritative declared set across heartbeats.
+func TestModelKnownUnionsSupportedModelsOnHeartbeat(t *testing.T) {
+	registry := NewRegistry(nil)
+	start := time.Unix(1716768000, 0).UTC()
+
+	registry.Register(&Provider{
+		ProviderID:       "p1",
+		AssignedID:       "s1",
+		ModelID:          "model-y",
+		SupportedModels:  []string{"model-x"},
+		State:            StateReady,
+		SlotsFree:        1,
+		SlotsTotal:       1,
+		LastHeartbeatAt:  start,
+		LastActivityAt:   start,
+		MaxConcurrency:   1,
+		MaxContextTokens: 20000,
+	}, nil)
+
+	// A heartbeat still serving model-y must keep the declared-cold
+	// model-x known (union re-applied from p.SupportedModels).
+	registry.ApplyHeartbeat("p1", "s1", heartbeatUpdateAt("model-y", start.Add(time.Minute)))
+	if !registry.ModelKnown("model-x") {
+		t.Fatal("ModelKnown(model-x) = false after heartbeat; heartbeat path did not union declared supported_models (SPEC-010 R-3.3.4)")
+	}
+}
+
 // TestSeenModelsLifetimeCap pins the PERF-5 reconciliation in issue
 // #185: the lifetime accumulator is bounded at maxSeenModelsLifetime.
 // Beyond the cap, further inserts drop (with a warn-once log + a

--- a/phase4-coordinator/internal/pool/provider_test.go
+++ b/phase4-coordinator/internal/pool/provider_test.go
@@ -1275,12 +1275,15 @@ func TestModelKnownUnionsDeclaredSupportedModels(t *testing.T) {
 
 	// Provider serves model-y but declares support for model-x (cold)
 	// and Model-X-CASE (mixed case, to exercise the case-folding the
-	// registration path already applies to model ids).
+	// registration path already applies to model ids). R-3.1.4: the
+	// served model_id MUST appear in supported_models, so model-y is
+	// listed too (a duplicate of the modelID argument; it's a no-op
+	// on the seen-index, already recorded via modelID).
 	registry.Register(&Provider{
 		ProviderID:       "p1",
 		AssignedID:       "s1",
 		ModelID:          "model-y",
-		SupportedModels:  []string{"model-x", "Model-X-CASE"},
+		SupportedModels:  []string{"model-y", "model-x", "Model-X-CASE"},
 		State:            StateReady,
 		SlotsFree:        1,
 		SlotsTotal:       1,
@@ -1344,9 +1347,26 @@ func TestModelKnownUnionsDeclaredSupportedModels(t *testing.T) {
 
 // TestModelKnownUnionsSupportedModelsOnHeartbeat pins that the R-3.3.4
 // union is re-applied on the heartbeat path too (provider.go heartbeat
-// site), not only at registration. Heartbeat frames do not carry
-// supported_models, so the stored Provider.SupportedModels remains the
-// authoritative declared set across heartbeats.
+// site), not only at registration.
+//
+// Codex code-lane audit of PR #555 flagged the original version of this
+// test as ineffective: it declared model-x at REGISTRATION time, so the
+// registration-time union alone (not the heartbeat call) already made
+// ModelKnown(model-x) true -- the assertion stayed green even if the
+// heartbeat call were reverted to recordSeenModelLocked(p.ProviderID,
+// hb.ModelID) (dropping SupportedModels).
+//
+// This version exercises a supported-model entry the registration-time
+// union never saw: model-x is appended to the live Provider's
+// SupportedModels (white-box mutation, same package -- the real wire
+// has no post-registration supported_models update path; heartbeat
+// frames don't carry the field) strictly BETWEEN registration and the
+// heartbeat call. The assertion runs AFTER RemoveIfSession disconnects
+// the provider, so ModelKnown's live-provider SupportedModels scan
+// (fallback 1b, the HIGH-severity fix for cap-exhausted entries) no
+// longer applies either -- the only way model-x can still be known is
+// if the heartbeat's recordSeenModelsUnionLocked call recorded it into
+// the seen index while the provider was live.
 func TestModelKnownUnionsSupportedModelsOnHeartbeat(t *testing.T) {
 	registry := NewRegistry(nil)
 	start := time.Unix(1716768000, 0).UTC()
@@ -1355,7 +1375,7 @@ func TestModelKnownUnionsSupportedModelsOnHeartbeat(t *testing.T) {
 		ProviderID:       "p1",
 		AssignedID:       "s1",
 		ModelID:          "model-y",
-		SupportedModels:  []string{"model-x"},
+		SupportedModels:  []string{"model-y"},
 		State:            StateReady,
 		SlotsFree:        1,
 		SlotsTotal:       1,
@@ -1365,11 +1385,94 @@ func TestModelKnownUnionsSupportedModelsOnHeartbeat(t *testing.T) {
 		MaxContextTokens: 20000,
 	}, nil)
 
-	// A heartbeat still serving model-y must keep the declared-cold
-	// model-x known (union re-applied from p.SupportedModels).
+	if registry.ModelKnown("model-x") {
+		t.Fatal("ModelKnown(model-x) = true before it was ever declared; fixture bug")
+	}
+
+	// Simulate the provider's declared catalog gaining model-x between
+	// registration and the next heartbeat.
+	registry.mu.Lock()
+	registry.providers["p1"].SupportedModels = append(registry.providers["p1"].SupportedModels, "model-x")
+	registry.mu.Unlock()
+
 	registry.ApplyHeartbeat("p1", "s1", heartbeatUpdateAt("model-y", start.Add(time.Minute)))
+
+	if !registry.RemoveIfSession("p1", "s1") {
+		t.Fatal("RemoveIfSession returned false")
+	}
+	// Provider is disconnected: ModelKnown's live-provider scans no
+	// longer see it. model-x can only still be known via the seen
+	// index the heartbeat call populated.
 	if !registry.ModelKnown("model-x") {
-		t.Fatal("ModelKnown(model-x) = false after heartbeat; heartbeat path did not union declared supported_models (SPEC-010 R-3.3.4)")
+		t.Fatal("ModelKnown(model-x) = false after disconnect; heartbeat path did not union declared supported_models into the seen index (SPEC-010 R-3.3.4)")
+	}
+}
+
+// TestModelKnownFindsDeclaredModelBeyondSeenIndexCaps pins the HIGH-
+// severity fix from the codex code-lane audit of PR #555: the seen-
+// index union (recordSeenModelsUnionLocked) is a best-effort
+// accumulator bounded by maxSeenModelsPerProvider (per-session, 32),
+// maxLifetimeContribPerProvider (per-provider lifetime, 128), and
+// maxSeenModelsLifetime (global lifetime, 4096). A provider with a
+// declared catalog wider than those caps has entries silently dropped
+// from the seen index -- but ModelKnown's live-provider SupportedModels
+// scan (fallback 1b) must still find them while the declaring provider
+// is CURRENTLY CONNECTED, regardless of cap state. A served model_id
+// never had this gap (the live ModelID scan always covers it); this
+// test pins the equivalent unconditional guarantee for declared models.
+func TestModelKnownFindsDeclaredModelBeyondSeenIndexCaps(t *testing.T) {
+	registry := NewRegistry(nil)
+	start := time.Unix(1716768000, 0).UTC()
+
+	const totalSupported = 200
+	supported := make([]string, totalSupported)
+	// R-3.1.4: the served model_id MUST appear in supported_models.
+	// This first entry duplicates the modelID argument, so it consumes
+	// no additional seen-index budget (already recorded via modelID).
+	supported[0] = "model-served"
+	for i := 1; i < totalSupported; i++ {
+		supported[i] = fmt.Sprintf("declared-model-%03d", i)
+	}
+	// supported[150] is the 151st DISTINCT entry attempted for this
+	// provider (model-served consumes slot 1; supported[0] is a
+	// no-op duplicate; supported[1..150] consume slots 2..151) --
+	// well past both the 32-entry per-session cap and the 128-entry
+	// per-provider lifetime cap.
+	beyondCapsModel := supported[150]
+
+	registry.Register(&Provider{
+		ProviderID:       "p1",
+		AssignedID:       "s1",
+		ModelID:          "model-served",
+		SupportedModels:  supported,
+		State:            StateReady,
+		SlotsFree:        1,
+		SlotsTotal:       1,
+		LastHeartbeatAt:  start,
+		LastActivityAt:   start,
+		MaxConcurrency:   1,
+		MaxContextTokens: 20000,
+	}, nil)
+
+	// Confirm the fixture actually exhausts both seen-index caps for
+	// this entry -- guards the test itself against a future cap bump
+	// silently un-testing this scenario.
+	registry.mu.RLock()
+	_, inSession := registry.seenModelsByProvider["p1"][beyondCapsModel]
+	_, inLifetime := registry.seenModelsLifetime[strings.ToLower(beyondCapsModel)]
+	registry.mu.RUnlock()
+	if inSession {
+		t.Fatalf("fixture bug: %q unexpectedly fit within the %d-entry per-session cap; adjust the index", beyondCapsModel, maxSeenModelsPerProvider)
+	}
+	if inLifetime {
+		t.Fatalf("fixture bug: %q unexpectedly fit within the %d-entry per-provider lifetime cap; adjust the index", beyondCapsModel, maxLifetimeContribPerProvider)
+	}
+
+	// The seen-index caps dropped it, but the provider is still
+	// connected and declares it right now -- ModelKnown must catch it
+	// via the live-provider SupportedModels scan.
+	if !registry.ModelKnown(beyondCapsModel) {
+		t.Fatalf("ModelKnown(%q) = false; live provider declares it in SupportedModels but seen-index caps dropped it (SPEC-010 R-3.3.4 correctness core, codex HIGH fix)", beyondCapsModel)
 	}
 }
 

--- a/specs/SPEC-010-model-catalog.md
+++ b/specs/SPEC-010-model-catalog.md
@@ -842,6 +842,41 @@ default serializations. §3.3 specifies the one place
 > (`internal/pool/provider_test.go`) and
 > `TestChatCompletionsDeclaredButColdModelReturns503`
 > (`internal/buyer/server_test.go`).
+>
+> **Follow-up (2026-07-11, codex code-lane audit of PR #555, no
+> normative change):** the seen-index union above
+> (`recordSeenModelsUnionLocked`) is a best-effort accumulator bounded
+> by `maxSeenModelsPerProvider` (32, per-session),
+> `maxLifetimeContribPerProvider` (128, per-provider lifetime), and
+> `maxSeenModelsLifetime` (4096, global lifetime) — a provider whose
+> declared catalog exceeds those caps could have entries silently
+> dropped from the seen index, 404ing a declared model even though a
+> currently-connected provider declares it. Fixed by adding a live-
+> provider `SupportedModels` scan to `ModelKnown()` (alongside the
+> pre-existing live `ModelID` scan), so a declared model on a
+> CURRENTLY-CONNECTED provider is always known regardless of seen-
+> index cap state — this is the correctness core of R-3.3.4, not an
+> optional hardening. Covered by
+> `TestModelKnownFindsDeclaredModelBeyondSeenIndexCaps`
+> (`internal/pool/provider_test.go`) and
+> `TestChatCompletionsDeclaredModelBeyondSeenIndexCapsReturns503`
+> (`internal/buyer/server_test.go`).
+>
+> **Cross-spec inconsistency, carried (not resolved here):** R-3.3.4
+> above is `MUST`; SPEC-002 v1.3.5 R-3.X.6 (`specs/SPEC-002-coordinator.md:819`)
+> calls the identical `seenModels` union `MAY` (optional); SPEC-006
+> §17.2 (`specs/SPEC-006-buyer-api.md:2807`) defines the 404 condition
+> as "not in any provider's served or recently seen model list"
+> without an explicit reference to declared-but-cold models. This
+> implementation follows SPEC-010 v1.5 R-3.3.4's `MUST` (the more
+> specific, later-locked rule on this exact question), and does not
+> change any dispatch outcome — R-3.4.1 and SPEC-002 R-3.X.6's "MUST
+> NOT change dispatch outcomes" both still hold; only the buyer error
+> code for declared-but-cold requests changes (404→503). SPEC-002 and
+> SPEC-006 are both large LOCKED specs and are intentionally NOT
+> amended by this change; a future pass should reconcile SPEC-002
+> R-3.X.6's `MAY` and SPEC-006 §17.2's "served or recently seen"
+> wording to cross-reference SPEC-010 R-3.3.4 explicitly.
 
 ### 3.4 Router: candidate filter (semantically unchanged in v1.0)
 

--- a/specs/SPEC-010-model-catalog.md
+++ b/specs/SPEC-010-model-catalog.md
@@ -5,10 +5,13 @@
 codex round-6 returned 0 CRITICAL / 0 MAJOR / 0 MINOR). Implemented on
 both sides (provider `supported_models[]` advertisement, coordinator
 `Provider` extension, opt-in `/v1/status` echo). The former "pre round-6"
-status predated the lock and was never flipped. (Known open gap: the
-R-3.3.4 `seenModels` union of `supported_models` is not implemented, so
-declared-but-cold models 404 instead of the spec'd 503 — implement or
-strike in a v1.6 pass.)
+status predated the lock and was never flipped. (Former open gap NOW
+CLOSED, 2026-07-11: the R-3.3.4 `seenModels` union of `supported_models`
+is implemented — the seen-model index is seeded with the union of
+`ModelID` and every `SupportedModels[]` entry at BOTH the registration
+and heartbeat sites, so a declared-but-cold model now returns 503
+`no_provider_available` (retryable) instead of 404 `model_not_found`. No
+normative text changed; see the R-3.3.4 implementation note in §3.3.)
 **Date drafted:** 2026-06-06
 **Companion to (LOCKED):** SPEC-001 v1.2.4, SPEC-002 v1.3.4,
 SPEC-004 v0.3.1, SPEC-008 v0.3, SPEC-006 v0.8.1.
@@ -816,6 +819,29 @@ default serializations. §3.3 specifies the one place
   providers on the legacy auth shape (single `model_id`, no
   `supported_models`) until SPEC-012 ships a complete
   cold-supported handling story.
+
+> **Implementation note (2026-07-11, no normative change):** R-3.3.4
+> is implemented in `phase4-coordinator/internal/pool/provider.go` via
+> `recordSeenModelsUnionLocked`, called at BOTH the registration site
+> (`RegisterAtDetailed`) and the heartbeat site (`ApplyHeartbeat`).
+> Each `SupportedModels[]` entry flows through the same
+> `recordSeenModelLocked` path as `ModelID`, so it shares the served
+> model_id's normalization (lowercase canonical key for the
+> pool-lifetime accumulator, raw id for the per-session attribution
+> set) and its lifecycle: dropped from the per-session index on
+> disconnect / session-replacement (M2-5 / PERF-5) and retained
+> append-only in the SPEC-002 § 7.2 lifetime accumulator for the
+> coordinator process lifetime. Legacy providers carry
+> `SupportedModels == [model_id]` (R-3.1.5 synthesis), so the union
+> collapses to `{model_id}` and the L-1 / R-3.5.1 byte-identical
+> default path is preserved. The buyer-side 404→503 flip is driven
+> entirely by the existing `ModelKnown()` gate in
+> `internal/buyer/server.go`. Covered by
+> `TestModelKnownUnionsDeclaredSupportedModels`,
+> `TestModelKnownUnionsSupportedModelsOnHeartbeat`
+> (`internal/pool/provider_test.go`) and
+> `TestChatCompletionsDeclaredButColdModelReturns503`
+> (`internal/buyer/server_test.go`).
 
 ### 3.4 Router: candidate filter (semantically unchanged in v1.0)
 


### PR DESCRIPTION
## What & why

Implements **SPEC-010 v1.5 R-3.3.4** (audit finding: never implemented). R-3.3.4 requires the coordinator's `seenModels` index to be the **UNION** of each provider's served `ModelID` **and** every entry in its `SupportedModels[]`, so `ModelKnown()` returns `true` for a model that some provider **declares** supporting but is not currently serving (cold).

Before this change, only `ModelID` was recorded into the seen index at registration and heartbeat, so `SupportedModels` never fed `ModelKnown()`. A buyer request for a declared-but-cold model returned **404 `model_not_found`** instead of the spec'd **503 `no_provider_available`** (transient/retryable — a provider may warm it).

This is **buyer-visible**: the 404→503 substitution appears only when at least one provider explicitly opts in by sending `supported_models` with more than its `model_id` (R-3.3.4). Legacy providers carry `SupportedModels == [model_id]` (R-3.1.5 synthesis), so the union collapses to `{model_id}` and behavior is byte-identical (L-1 / R-3.5.1).

## The change

`phase4-coordinator/internal/pool/provider.go`
- New `recordSeenModelsUnionLocked(providerID, modelID, supportedModels)` records the served `model_id` and then each `SupportedModels[]` entry.
- Called at **both** seed sites:
  - **Registration** — `RegisterAtDetailed` (was `recordSeenModelLocked(p.ProviderID, p.ModelID)`).
  - **Heartbeat** — `applyHeartbeatLocked` (was `recordSeenModelLocked(p.ProviderID, hb.ModelID)`). Heartbeat frames don't carry `supported_models`, so `p.SupportedModels` (populated at registration) is the authoritative declared set.

Each `SupportedModels[]` entry flows through the existing `recordSeenModelLocked`, so it shares the served `model_id`'s **normalization** (`strings.ToLower` canonical key for the pool-lifetime accumulator; raw id for the per-session attribution set) — the same case-folding the registration path already applies.

## 404 vs 503

The buyer branch in `internal/buyer/server.go` keys the distinction entirely off `ModelKnown()`:

```
if !s.pool.ModelKnown(req.Model) && s.resolveModelClass(req.Model) == nil {
    // 404 model_not_found
}
```

- **Declared, cold** → `ModelKnown()` now true → 404 branch skipped → routing finds no candidate serving that `model_id` → **503 `no_provider_available`**.
- **Undeclared by any provider** → `ModelKnown()` still false → **404 `model_not_found`** (unchanged). The union does **not** turn genuinely-unknown models into 503.

No buyer-side code change was needed.

## Lifecycle / removal handling

Union entries age **exactly as `model_id`** because they reuse `recordSeenModelLocked`:
- **Per-session attribution** (`seenModelsByProvider`): dropped on disconnect (`RemoveIfSession`/`RemoveIfSessionState`) and on session-replacement — M2-5 / PERF-5. No leak into the per-session index.
- **Pool-lifetime accumulator** (`seenModelsLifetime`): append-only, retained for the coordinator process lifetime — SPEC-002 § 7.2 cold-start-race survival, identical to `model_id`. This is intentional (declared-cold stays 503 across the cold-start window), not a stale-forever bug.

No separate removal path is introduced.

## Tests

- `TestModelKnownUnionsDeclaredSupportedModels` (pool) — declared-but-cold model is `ModelKnown`-true (incl. case-folding); undeclared model stays false; per-session index carries then drops the entry on disconnect while the lifetime accumulator survives.
- `TestModelKnownUnionsSupportedModelsOnHeartbeat` (pool) — union re-applied on the heartbeat path.
- `TestChatCompletionsDeclaredButColdModelReturns503` (buyer) — 503 for the declared-cold model, 404 for an undeclared model.

All three fail against the pre-fix behavior (buyer test returned 404) and pass after.

```
go build ./... && go vet ./... && go test ./internal/pool/... ./internal/buyer/... ./internal/routing/...
ok  internal/pool
ok  internal/buyer
ok  internal/routing
ok  internal/routing/sticky
```
Full `go test ./...` for the module is green; `gofmt -l` clean.

## SPEC

SPEC-010 is **LOCKED v1.5**: no normative text changed. The status "known open gap" note is marked **CLOSED (2026-07-11)** and a non-normative R-3.3.4 implementation note added in §3.3.

---

## Round 2: codex 3-lane audit findings addressed (1 HIGH, 1 MEDIUM; security lane all-LOW/bounded, no blocker)

**HIGH — fixed.** `ModelKnown()`'s live-provider fallback scanned only each connected provider's current `ModelID`, never its declared `SupportedModels`. The seen-index union above (`recordSeenModelsUnionLocked`) is a best-effort accumulator bounded by `maxSeenModelsPerProvider` (32, per-session), `maxLifetimeContribPerProvider` (128, per-provider lifetime), and `maxSeenModelsLifetime` (4096, global lifetime) — a provider whose declared catalog exceeds those caps could have entries silently dropped from the seen index, so a declared model beyond the cap returned a **permanent 404** even though a live provider currently declares it. A served `model_id` never had this gap (the live `ModelID` scan always covers it); declared models needed the same unconditional guarantee. Fix: `internal/pool/provider.go`'s `ModelKnown()` gains a new fallback (1b) that scans every live provider's `SupportedModels` (same `EqualFold` normalization as the `ModelID` scan), independent of seen-index cap state. This is the correctness core of R-3.3.4, not optional hardening.

**MEDIUM — carried, not resolved in this PR.** Cross-spec inconsistency: SPEC-006 §17.2 defines the 404 condition as "not in any provider's served or recently seen model list" without an explicit reference to declared-but-cold models, and SPEC-002 v1.3.5 R-3.X.6 calls the identical `seenModels` union `MAY` (optional) while SPEC-010 v1.5 R-3.3.4 says `MUST`. The code correctly follows the more specific, LOCKED SPEC-010 `MUST`, and changes no dispatch outcome (R-3.4.1 / SPEC-002 R-3.X.6's "MUST NOT change dispatch outcomes" both still hold — only the buyer error code for declared-but-cold requests changes, 404→503). SPEC-002 and SPEC-006 are large LOCKED specs and are intentionally **not** amended by this PR. `specs/SPEC-010-model-catalog.md` §3.3 now carries an explicit follow-up note flagging this cross-reference reconciliation for a future pass (operator: track as a runbook follow-up item).

**LOW — test adequacy fixes, guarding the HIGH:**
- `TestModelKnownUnionsSupportedModelsOnHeartbeat` was ineffective: it declared the supported model at *registration* time, so the assertion stayed green even with the heartbeat-site union reverted. Rewritten to append the supported-model entry to the live `Provider` *after* registration (white-box, same package) and assert *after* disconnect — at that point the live-scan fallback (the HIGH fix above) no longer applies, so the assertion can only pass if the heartbeat call itself recorded the entry into the seen index.
- Added `TestModelKnownFindsDeclaredModelBeyondSeenIndexCaps` (pool) and `TestChatCompletionsDeclaredModelBeyondSeenIndexCapsReturns503` (buyer): a provider declaring 200 supported models, with an entry deliberately placed past both the 32-entry per-session cap and the 128-entry per-provider lifetime cap, asserting it is still `ModelKnown` and still returns 503.
- Buyer test now asserts `error.retryable == true` for the 503 case (and `false` for the 404 case) and that the response body is *exactly* the OpenAI error envelope shape (a single top-level `"error"` key) — ruling out any forwarded provider body.
- Fixed fixtures so the served `ModelID` is included in `SupportedModels`, per R-3.1.4 (the original PR's pool and buyer fixtures violated this).

Every new/changed assertion above was manually verified to **fail** when its corresponding fix is reverted (not just written as a positive check).

```
go build ./... && go vet ./... && go test ./internal/pool/... ./internal/buyer/... ./internal/routing/...
ok  internal/pool
ok  internal/buyer
ok  internal/routing
ok  internal/routing/sticky
```
Full `go test ./...` for the module remains green; `gofmt -l` clean.
