### PR TITLE
fix(updater): validate alert config against named service group

### DIFF
--- a/ops/pearl-updater/macprovider-pearl-update
+++ b/ops/pearl-updater/macprovider-pearl-update
@@ -12,6 +12,7 @@ import contextlib
 import dataclasses
 import errno
 import fcntl
+import grp
 import hashlib
 import http.client
 import json
@@ -46,6 +47,8 @@ BOOT_ID_PATH = Path("/proc/sys/kernel/random/boot_id")
 SYSTEMD_ROOT = Path("/etc/systemd/system")
 INDEPENDENT_ALERT_ENV_PATH = Path("/etc/macprovider/monitor.env")
 VALIDATOR_ACCOUNT = "macprovider-updater-validate"
+INDEPENDENT_ALERT_ACCOUNT = "macprovider"
+INDEPENDENT_ALERT_GROUP = "macprovider"
 GATED_SERVICE_UNITS = (
     "macprovider-coordinator.service",
     "macprovider-gateway.service",
@@ -118,6 +121,22 @@ class CommandTimeout(UpdateError):
 
 class AssetNotFound(UpdateError):
     pass
+
+
+def resolve_service_group_gid(account_name: str, group_name: str) -> int:
+    try:
+        account = pwd.getpwnam(account_name)
+    except KeyError as exc:
+        raise UpdateError(f"{account_name} service account is missing") from exc
+    if account.pw_uid == 0:
+        raise UpdateError(f"{account_name} service account must not use the root uid")
+    try:
+        group = grp.getgrnam(group_name)
+    except KeyError as exc:
+        raise UpdateError(f"{group_name} service group is missing") from exc
+    if group.gr_gid == 0:
+        raise UpdateError(f"{group_name} service group must not use the root gid")
+    return group.gr_gid
 
 
 @dataclasses.dataclass(frozen=True, order=True)
@@ -561,6 +580,7 @@ class Updater:
         trusted_uid: int = 0,
         candidate_uid: int | None = None,
         candidate_gid: int | None = None,
+        independent_alert_gid: int | None = None,
         isolate_candidate_network: bool = False,
         sleep: Callable[[float], None] = time.sleep,
     ):
@@ -577,6 +597,9 @@ class Updater:
         self.trusted_uid = trusted_uid
         self.candidate_uid = trusted_uid if candidate_uid is None else candidate_uid
         self.candidate_gid = trusted_uid if candidate_gid is None else candidate_gid
+        self.independent_alert_gid = (
+            self.candidate_gid if independent_alert_gid is None else independent_alert_gid
+        )
         self.isolate_candidate_network = isolate_candidate_network
         self.sleep = sleep
         self.transaction: Path | None = None
@@ -1280,7 +1303,7 @@ class Updater:
         if (
             not stat.S_ISDIR(parent_stat.st_mode)
             or parent_stat.st_uid != self.trusted_uid
-            or parent_stat.st_gid != self.candidate_gid
+            or parent_stat.st_gid != self.independent_alert_gid
             or stat.S_IMODE(parent_stat.st_mode) != 0o750
         ):
             raise UpdateError("independent-alert config directory must have exact trusted ownership and mode 0750")
@@ -1301,7 +1324,7 @@ class Updater:
         if (
             not stat.S_ISREG(env_stat.st_mode)
             or env_stat.st_uid != self.trusted_uid
-            or env_stat.st_gid != self.candidate_gid
+            or env_stat.st_gid != self.independent_alert_gid
             or env_stat.st_nlink != 1
             or stat.S_IMODE(env_stat.st_mode) != 0o640
         ):
@@ -3148,6 +3171,7 @@ def main(argv: list[str]) -> int:
     if testing:
         candidate_uid = os.geteuid()
         candidate_gid = os.getegid()
+        independent_alert_gid = candidate_gid
     else:
         try:
             account = pwd.getpwnam(VALIDATOR_ACCOUNT)
@@ -3157,6 +3181,10 @@ def main(argv: list[str]) -> int:
             raise UpdateError(f"{VALIDATOR_ACCOUNT} service account must not use the root uid or gid")
         candidate_uid = account.pw_uid
         candidate_gid = account.pw_gid
+        independent_alert_gid = resolve_service_group_gid(
+            INDEPENDENT_ALERT_ACCOUNT,
+            INDEPENDENT_ALERT_GROUP,
+        )
     updater = Updater(
         config,
         public_key=test_path(PINNED_PUBLIC_KEY, "PEARL_UPDATER_TEST_PUBLIC_KEY", testing),
@@ -3172,6 +3200,7 @@ def main(argv: list[str]) -> int:
         trusted_uid=trusted_uid,
         candidate_uid=candidate_uid,
         candidate_gid=candidate_gid,
+        independent_alert_gid=independent_alert_gid,
         isolate_candidate_network=not testing,
     )
     lock_uid = trusted_uid

--- a/ops/pearl-updater/test_pearl_updater.py
+++ b/ops/pearl-updater/test_pearl_updater.py
@@ -1272,6 +1272,76 @@ class PearlUpdaterTests(unittest.TestCase):
             with self.assertRaisesRegex(updater_module.UpdateError, "mode 0640"):
                 self.updater.validate_independent_alert_configuration()
 
+    def test_independent_alert_policy_uses_alert_group_not_candidate_sandbox_group(self):
+        alert_directory = self.root / "alert-group-policy"
+        alert_directory.mkdir(mode=0o750)
+        alert_env = alert_directory / "monitor.env"
+        alert_env.write_text(
+            "ALERT_EMAIL=operator@example.invalid\n"
+            "GMAIL_USER=sender@example.invalid\n"
+            "GMAIL_APP_PASSWORD=app-password\n"
+        )
+        alert_env.chmod(0o640)
+
+        self.updater.candidate_gid = os.getegid() + 10000
+        self.updater.independent_alert_gid = os.getegid()
+        with mock.patch.object(updater_module, "INDEPENDENT_ALERT_ENV_PATH", alert_env):
+            self.updater.validate_independent_alert_configuration()
+
+            self.updater.independent_alert_gid = self.updater.candidate_gid
+            with self.assertRaisesRegex(updater_module.UpdateError, "config directory"):
+                self.updater.validate_independent_alert_configuration()
+
+    def test_independent_alert_group_resolution_uses_named_group(self):
+        account = mock.Mock(pw_uid=1234, pw_gid=2345)
+        group = mock.Mock(gr_gid=3456)
+        with (
+            mock.patch.object(updater_module.pwd, "getpwnam", return_value=account) as account_lookup,
+            mock.patch.object(updater_module.grp, "getgrnam", return_value=group) as group_lookup,
+        ):
+            self.assertEqual(
+                updater_module.resolve_service_group_gid("macprovider", "macprovider"),
+                group.gr_gid,
+            )
+        account_lookup.assert_called_once_with("macprovider")
+        group_lookup.assert_called_once_with("macprovider")
+        self.assertNotEqual(account.pw_gid, group.gr_gid)
+
+    def test_independent_alert_group_resolution_rejects_missing_or_root_identity(self):
+        with mock.patch.object(updater_module.pwd, "getpwnam", side_effect=KeyError):
+            with self.assertRaisesRegex(updater_module.UpdateError, "service account is missing"):
+                updater_module.resolve_service_group_gid("macprovider", "macprovider")
+
+        with mock.patch.object(
+            updater_module.pwd,
+            "getpwnam",
+            return_value=mock.Mock(pw_uid=0, pw_gid=1234),
+        ):
+            with self.assertRaisesRegex(updater_module.UpdateError, "must not use the root uid"):
+                updater_module.resolve_service_group_gid("macprovider", "macprovider")
+
+        with (
+            mock.patch.object(
+                updater_module.pwd,
+                "getpwnam",
+                return_value=mock.Mock(pw_uid=1234, pw_gid=2345),
+            ),
+            mock.patch.object(updater_module.grp, "getgrnam", side_effect=KeyError),
+        ):
+            with self.assertRaisesRegex(updater_module.UpdateError, "service group is missing"):
+                updater_module.resolve_service_group_gid("macprovider", "macprovider")
+
+        with (
+            mock.patch.object(
+                updater_module.pwd,
+                "getpwnam",
+                return_value=mock.Mock(pw_uid=1234, pw_gid=2345),
+            ),
+            mock.patch.object(updater_module.grp, "getgrnam", return_value=mock.Mock(gr_gid=0)),
+        ):
+            with self.assertRaisesRegex(updater_module.UpdateError, "must not use the root gid"):
+                updater_module.resolve_service_group_gid("macprovider", "macprovider")
+
     def test_independent_alert_sender_checks_monitor_gmail_configuration(self):
         sender = SCRIPT.with_name("macprovider-pearl-updater-alert")
         alert_directory = self.root / "alert-config"
@@ -1703,6 +1773,7 @@ class PearlUpdaterTests(unittest.TestCase):
         self.assertIn("WantedBy=multi-user.target", boot)
         alert = SCRIPT.with_name("macprovider-pearl-updater-alert@.service").read_text(encoding="utf-8")
         self.assertIn("User=macprovider", alert)
+        self.assertIn("Group=macprovider", alert)
         self.assertIn("ExecStart=/usr/local/sbin/macprovider-pearl-updater-alert %i", alert)
         for hardened in (unit, boot):
             self.assertIn("NoNewPrivileges=true", hardened)


### PR DESCRIPTION
## Outcome

Pearl updater preflight now validates the independent alert configuration against the explicitly named `macprovider` systemd/installer group, not the service user primary GID. Candidate validation remains isolated on `macprovider-updater-validate`.

## Regression coverage

- proves a divergent passwd primary GID cannot override the named group GID
- rejects missing or root service accounts/groups
- asserts the alert unit keeps `Group=macprovider`
- preserves exact root:macprovider 0750/0640 policy

## Verification

- 65 Pearl updater tests pass (1 root-only environment skip)
- `make test-dist` passes
- Python compile, Bash syntax, and `git diff --check` pass
- CODE audit: C0/H0/M0/L0
- SECURITY audit: C0/H0/M0/L0
- ARCHITECTURE audit: C0/H0/M0/L0

Operationally discovered while advancing the signed Pearl updater preflight from #536 toward the credential-gated #524 activation. This PR does not enable the updater or alter Pearl production state.