### PR TITLE
fix(updater): permit one-way bootstrap from clean legacy builds

### DIFF
--- a/ops/pearl-updater/macprovider-pearl-update
+++ b/ops/pearl-updater/macprovider-pearl-update
@@ -73,6 +73,9 @@ CONTROL_ASSETS = (
     "checksums.txt.sig",
 )
 SEMVER_RE = re.compile(r"^(?:v)?(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$")
+LEGACY_GIT_DESCRIBE_RE = re.compile(
+    r"^v?(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)-([1-9][0-9]*)-g([0-9a-f]{7,40})$"
+)
 SHA256_RE = re.compile(r"^[0-9a-f]{64}$")
 COMMIT_RE = re.compile(r"^[0-9a-f]{40}$")
 ASSET_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$")
@@ -200,6 +203,12 @@ class InstalledRelease:
     coordinator_sha256: str
     gateway_sha256: str
     durable: dict[str, Any] | None
+    coordinator_legacy: bool = False
+    gateway_legacy: bool = False
+
+    @property
+    def requires_legacy_bootstrap(self) -> bool:
+        return self.coordinator_legacy or self.gateway_legacy
 
     @property
     def downgrade_floor(self) -> SemVer:
@@ -209,6 +218,8 @@ class InstalledRelease:
         return max(versions)
 
     def is_coherent_with(self, release: Release) -> bool:
+        if self.requires_legacy_bootstrap:
+            return False
         if self.coordinator != release.version or self.gateway != release.version:
             return False
         if self.coordinator_sha256 != release.coordinator.sha256 or self.gateway_sha256 != release.gateway.sha256:
@@ -1203,21 +1214,35 @@ class Updater:
             except (KeyError, TypeError, ValueError, OSError, UpdateError) as exc:
                 raise UpdateError(f"installed release state is invalid: {state}") from exc
         binaries: dict[str, SemVer] = {}
+        legacy: dict[str, bool] = {}
         hashes: dict[str, str] = {}
         for name in ("coordinator", "gateway"):
             binary = self.install_root / name
             self._trusted_regular_file(binary, f"installed {name} binary")
             result = self.run_command([str(binary), "--version"], check=False, timeout=10)
-            if result.returncode != 0 or not SEMVER_RE.fullmatch(result.stdout.strip()):
+            value = result.stdout.strip()
+            if result.returncode != 0:
                 raise UpdateError(f"installed {name} does not report a semantic version")
-            binaries[name] = SemVer.parse(result.stdout.strip())
+            if SEMVER_RE.fullmatch(value):
+                binaries[name] = SemVer.parse(value)
+                legacy[name] = False
+            else:
+                match = LEGACY_GIT_DESCRIBE_RE.fullmatch(value)
+                if match is None:
+                    raise UpdateError(f"installed {name} does not report a semantic version")
+                binaries[name] = SemVer(*(int(part) for part in match.groups()[:3]))
+                legacy[name] = True
             hashes[name] = sha256_file(binary)
+        if durable is not None and any(legacy.values()):
+            raise UpdateError("durable release state cannot coexist with legacy git-describe binaries")
         return InstalledRelease(
             binaries["coordinator"],
             binaries["gateway"],
             hashes["coordinator"],
             hashes["gateway"],
             durable,
+            legacy["coordinator"],
+            legacy["gateway"],
         )
 
     def eligibility(self, release: Release) -> tuple[SemVer, str]:
@@ -1232,6 +1257,20 @@ class Updater:
         if release.version < current:
             self.audit("release_eligibility", "rejected_downgrade", candidate=release.tag, current=str(current))
             raise UpdateError(f"downgrade rejected: installed={current} candidate={release.version}")
+        if installed.requires_legacy_bootstrap:
+            if release.version == current:
+                raise UpdateError(
+                    f"legacy bootstrap requires a signed release newer than the installed base: installed={current} candidate={release.version}"
+                )
+            self.audit(
+                "release_eligibility",
+                "legacy_bootstrap",
+                candidate=release.tag,
+                current=str(current),
+                coordinator=str(installed.coordinator),
+                gateway=str(installed.gateway),
+            )
+            return current, "upgrade"
         if release.version == current:
             if installed.is_coherent_with(release):
                 self.audit("release_eligibility", "already_current", candidate=release.tag, current=str(current))

--- a/ops/pearl-updater/test_pearl_updater.py
+++ b/ops/pearl-updater/test_pearl_updater.py
@@ -247,7 +247,9 @@ class PearlUpdaterTests(unittest.TestCase):
 
     def test_signature_failure_rejected_before_artifact_execution(self):
         signature = self.bundle / "pearl-release.json.sig"
-        signature.write_bytes(signature.read_bytes()[:-1] + b"x")
+        corrupted = bytearray(signature.read_bytes())
+        corrupted[-1] ^= 0x01
+        signature.write_bytes(corrupted)
         with self.assertRaisesRegex(updater_module.UpdateError, "signature verification failed"):
             self.verify()
 
@@ -326,6 +328,44 @@ class PearlUpdaterTests(unittest.TestCase):
 
         self.assertEqual(str(current), "1.8.25")
         self.assertEqual(decision, "upgrade")
+
+    def test_clean_legacy_git_describe_pair_can_bootstrap_to_newer_signed_release(self):
+        self.install_pair("v1.8.26-4-g64083ef", "v1.8.20-4-ga5e12c2")
+        self.make_bundle("1.8.30")
+        self.updater.candidate_version = "v1.8.30"
+        release = self.stage(self.updater.verify_release(self.bundle, "v1.8.30"))
+
+        current, decision = self.updater.assess_candidate(release)
+
+        self.assertEqual(str(current), "1.8.26")
+        self.assertEqual(decision, "upgrade")
+
+    def test_legacy_git_describe_bootstrap_requires_strictly_newer_release(self):
+        self.install_pair("v1.8.26-4-g64083ef", "v1.8.20-4-ga5e12c2")
+        self.make_bundle("1.8.26")
+        release = self.updater.verify_release(self.bundle, "v1.8.26")
+
+        with self.assertRaisesRegex(updater_module.UpdateError, "requires a signed release newer"):
+            self.updater.eligibility(release)
+
+    def test_legacy_bootstrap_rejects_dirty_or_ambiguous_build_versions(self):
+        for value in (
+            "v1.8.26-4-g64083ef-dirty",
+            "v1.8.26-4-g64083ef-dirty-forced",
+            "64083ef",
+            "v1.8.26-0-g64083ef",
+            "v1.8.26-4-gNOTHEX",
+        ):
+            with self.subTest(value=value):
+                self.install_pair(value, "v1.8.20-4-ga5e12c2")
+                with self.assertRaisesRegex(updater_module.UpdateError, "does not report a semantic version"):
+                    self.updater.installed_release()
+
+    def test_legacy_bootstrap_rejects_conflicting_durable_release_state(self):
+        self.install_pair("v1.8.26-4-g64083ef", "v1.8.20-4-ga5e12c2", "1.8.26")
+
+        with self.assertRaisesRegex(updater_module.UpdateError, "cannot coexist"):
+            self.updater.installed_release()
 
     def test_mismatched_installed_pair_is_repaired_not_skipped(self):
         self.install_pair("1.8.27", "1.8.26", "1.8.27")
@@ -1732,6 +1772,10 @@ class PearlUpdaterTests(unittest.TestCase):
         self.assertIn("/etc/macprovider/canary-buyer.token", text)
         self.assertIn("/etc/macprovider/canary-buyer.heartbeat", text)
         self.assertIn("test ! -e /etc/macprovider/canary-buyer.env", text)
+        self.assertIn(
+            "sudo -u macprovider -g macprovider /usr/local/sbin/macprovider-pearl-updater-alert",
+            text,
+        )
         self.assertNotIn("test -s /etc/macprovider/canary-buyer.env", text)
 
     def test_every_subprocess_invocation_has_an_explicit_timeout(self):

--- a/ops/runbooks/pearl-release-updater.md
+++ b/ops/runbooks/pearl-release-updater.md
@@ -55,6 +55,15 @@ and the durable signed tag, commit, version, and component hashes match the
 candidate. A same-version binary or state-file mismatch triggers transactional
 pair repair instead of a skip.
 
+The first adoption may start from older deployment-script binaries whose
+embedded versions are clean `git describe` identities such as
+`v1.8.26-4-g64083ef`. The updater accepts that exact, non-dirty shape only when
+no durable updater release state exists, derives the downgrade floor from the
+base tag, and requires the signed candidate to be strictly newer than that
+floor. Commit-only, dirty, ambiguous, same-base, and downgrade identities fail
+closed. After the first successful transaction persists signed release state,
+legacy git-describe bootstrap is no longer accepted.
+
 ## One-time installation
 
 First deploy #524's canary buyer exactly as reviewed, including its root-only
@@ -103,9 +112,9 @@ non-symlink directory and upgrades SMTP with Python's verified default TLS
 context:
 
 ```bash
-sudo /usr/local/sbin/macprovider-pearl-updater-alert \
+sudo -u macprovider -g macprovider /usr/local/sbin/macprovider-pearl-updater-alert \
   --check-config macprovider-pearl-updater.service
-sudo -u macprovider /usr/local/sbin/macprovider-pearl-updater-alert \
+sudo -u macprovider -g macprovider /usr/local/sbin/macprovider-pearl-updater-alert \
   macprovider-pearl-updater-preflight.service
 ```
 


### PR DESCRIPTION
## Outcome

Allows Pearl to perform its first signed transactional updater rollout from the two clean pre-updater git-describe binaries, without seeding false durable provenance or replacing daemons manually.

## Safety contract

- Accepts only clean `vX.Y.Z-N-g<lowercase hex>` identities when durable updater state is absent.
- Uses the highest installed base tag as the downgrade floor.
- Requires a strictly newer signed, checksummed, revocation-gated release.
- Rejects dirty, ambiguous, commit-only, same-base, downgrade, and durable-state conflict cases.
- Keeps legacy identities permanently ineligible for already-current reconciliation.
- Corrects manual alert preflight to use the same named user and group as systemd.
- Makes the negative signature test deterministic.

## Verification

- Pearl updater: 69 tests passed; 1 environment-only root UID-drop test skipped.
- `make test-dist`: passed.
- Python compile, Bash syntax, and `git diff --check`: passed.
- Exact-head independent audits: CODE C0/H0/M0/L0; ARCHITECTURE C0/H0/M0/L0; SECURITY C0/H0/M0/L1.
- Security low residual is limited to generic clean legacy shape admission for root-owned trusted binaries; Pearl exact lineage was verified safe.

Operational follow-up for #536; enables completing the production updater rollout after #524 monitoring activation.
