### PR TITLE
fix(updater): snapshot shared stats database once

### DIFF
--- a/ops/pearl-updater/macprovider-pearl-update
+++ b/ops/pearl-updater/macprovider-pearl-update
@@ -1642,11 +1642,15 @@ class Updater:
             gateway = self._yaml_section_scalar(gateway_text, gateway_config, "storage", "db_path", required=True)
             assert gateway is not None
             stats_unit_inputs, stats_database = self.stats_mirror_runtime()
-            resolved = [
-                self._database_path(gateway, "gateway storage.db_path"),
-                self._database_path(storage, "coordinator storage.db_path"),
-                stats_database,
-            ]
+            gateway_database = self._database_path(gateway, "gateway storage.db_path")
+            coordinator_database = self._database_path(storage, "coordinator storage.db_path")
+            if gateway_database == coordinator_database:
+                raise UpdateError("gateway and coordinator database paths must be distinct")
+            if stats_database == gateway_database:
+                raise UpdateError("stats billing mirror cannot read the gateway database")
+            resolved = [gateway_database, coordinator_database]
+            if stats_database != coordinator_database:
+                resolved.append(stats_database)
             payout = effective.get(("malibu_emission", "sqlite_payout_db_path"))
             if payout:
                 resolved.append(self._database_path(payout, "coordinator malibu_emission.sqlite_payout_db_path"))

--- a/ops/pearl-updater/test_pearl_updater.py
+++ b/ops/pearl-updater/test_pearl_updater.py
@@ -1073,6 +1073,79 @@ class PearlUpdaterTests(unittest.TestCase):
         self.assertEqual(self.updater.gateway_reservations(), 0)
         self.assertEqual(self.updater.run_command.call_args.args[0][2], "/srv/macprovider/gateway.sqlite")
 
+    def test_stats_mirror_may_share_coordinator_database_once(self):
+        install = self.updater.install_root
+        install.mkdir(parents=True)
+        coordinator = install / "coordinator.yaml"
+        gateway = install / "gateway.yaml"
+        stats_fragment = self.root / "stats-billing-mirror.service"
+        stats_dropin = self.root / updater_module.TRANSACTION_GATE_DROPIN_NAME
+        coordinator_database = Path("/srv/macprovider/coordinator.sqlite")
+        coordinator.write_text(f"storage:\n  db_path: {coordinator_database}\n")
+        gateway.write_text("storage:\n  db_path: /srv/macprovider/gateway.sqlite\n")
+        stats_fragment.write_text(
+            "[Service]\nExecStart=/opt/macprovider-stats/stats-billing-mirror "
+            f"--sqlite {coordinator_database}\n"
+        )
+        stats_dropin.write_text(updater_module.TRANSACTION_GATE_DROPIN_TEXT)
+        self.updater.gateway_db = None
+        self.updater.databases = ()
+        self.updater.coordinator_runtime_state = updater_module.CoordinatorRuntime(coordinator, None, {})
+        self.updater.gateway_config_path = mock.Mock(return_value=gateway)
+        self.updater.stats_mirror_runtime = mock.Mock(
+            return_value=((stats_fragment, stats_dropin), coordinator_database)
+        )
+
+        self.updater.capture_database_paths()
+
+        self.assertEqual(
+            self.updater.databases,
+            (Path("/srv/macprovider/gateway.sqlite"), coordinator_database),
+        )
+        self.assertEqual(self.updater.gateway_db, Path("/srv/macprovider/gateway.sqlite"))
+        self.assertEqual(
+            set(self.updater.runtime_config_hashes),
+            {coordinator, gateway, stats_fragment, stats_dropin},
+        )
+
+    def test_stats_mirror_cannot_share_gateway_database(self):
+        install = self.updater.install_root
+        install.mkdir(parents=True)
+        coordinator = install / "coordinator.yaml"
+        gateway = install / "gateway.yaml"
+        gateway_database = Path("/srv/macprovider/gateway.sqlite")
+        coordinator.write_text("storage:\n  db_path: /srv/macprovider/coordinator.sqlite\n")
+        gateway.write_text(f"storage:\n  db_path: {gateway_database}\n")
+        self.updater.gateway_db = None
+        self.updater.databases = ()
+        self.updater.coordinator_runtime_state = updater_module.CoordinatorRuntime(coordinator, None, {})
+        self.updater.gateway_config_path = mock.Mock(return_value=gateway)
+        self.updater.stats_mirror_runtime = mock.Mock(
+            return_value=((self.root / "stats.service", self.root / "gate.conf"), gateway_database)
+        )
+
+        with self.assertRaisesRegex(updater_module.UpdateError, "cannot read the gateway database"):
+            self.updater.capture_database_paths()
+
+    def test_gateway_and_coordinator_databases_must_remain_distinct(self):
+        install = self.updater.install_root
+        install.mkdir(parents=True)
+        coordinator = install / "coordinator.yaml"
+        gateway = install / "gateway.yaml"
+        shared_database = Path("/srv/macprovider/shared.sqlite")
+        coordinator.write_text(f"storage:\n  db_path: {shared_database}\n")
+        gateway.write_text(f"storage:\n  db_path: {shared_database}\n")
+        self.updater.gateway_db = None
+        self.updater.databases = ()
+        self.updater.coordinator_runtime_state = updater_module.CoordinatorRuntime(coordinator, None, {})
+        self.updater.gateway_config_path = mock.Mock(return_value=gateway)
+        self.updater.stats_mirror_runtime = mock.Mock(
+            return_value=((self.root / "stats.service", self.root / "gate.conf"), Path("/srv/macprovider/stats.sqlite"))
+        )
+
+        with self.assertRaisesRegex(updater_module.UpdateError, "gateway and coordinator"):
+            self.updater.capture_database_paths()
+
     def test_runtime_database_parser_rejects_relative_or_duplicate_paths(self):
         with self.assertRaisesRegex(updater_module.UpdateError, "absolute path"):
             self.updater._database_path("gateway.db", "gateway storage.db_path")


### PR DESCRIPTION
## What changed

- allow only the production stats-mirror database to alias the coordinator database
- snapshot and journal that physical database once
- continue rejecting gateway/coordinator, stats/gateway, payout, and other duplicate database paths
- add focused production-shaped and rejection regressions

## Why

Pearl correctly configures the read-only stats mirror against the coordinator SQLite database. The updater preflight treated the two logical consumers as distinct physical databases and aborted before creating a transaction journal or mutating services.

## Validation

- updater suite: 72 passed, 1 expected root-only skip
- make test-dist: passed
- exact-head code audit: C0/H0/M0/L0
- exact-head architecture audit: C0/H0/M0/L0
- exact-head security audit: C0/H0/M0/L1; low residual is limited to root-controlled lexical path aliases and does not affect the production literal path
- Python compilation, Bash syntax, and git diff checks passed