### PR TITLE
fix(updater): recover legacy health without advertised field

### DIFF
--- a/ops/pearl-updater/macprovider-pearl-update
+++ b/ops/pearl-updater/macprovider-pearl-update
@@ -2471,11 +2471,17 @@ class Updater:
             advertised_version=self.config_update.next_version,
         )
 
-    def local_coordinator_identity_ready(self, identity: RuntimeIdentity, require_pool: bool) -> bool:
-        health = self.get_json("http://127.0.0.1:8444/healthz")
+    @staticmethod
+    def coordinator_identity_ready(health: dict[str, Any], identity: RuntimeIdentity) -> bool:
         if health.get("status") != "ok" or health.get("version") != identity.coordinator_version:
             return False
-        if health.get("recommended_binary_version") != identity.advertised_version:
+        if "recommended_binary_version" not in health:
+            return LEGACY_GIT_DESCRIBE_RE.fullmatch(identity.coordinator_version) is not None
+        return health["recommended_binary_version"] == identity.advertised_version
+
+    def local_coordinator_identity_ready(self, identity: RuntimeIdentity, require_pool: bool) -> bool:
+        health = self.get_json("http://127.0.0.1:8444/healthz")
+        if not self.coordinator_identity_ready(health, identity):
             return False
         return not require_pool or (
             type(health.get("pool_ready")) is int
@@ -2512,9 +2518,7 @@ class Updater:
         coordinator = self.get_json("https://coordinator.streamvc.live/healthz")
         gateway = self.get_json("https://api.streamvc.live/healthz")
         return (
-            coordinator.get("status") == "ok"
-            and coordinator.get("version") == identity.coordinator_version
-            and coordinator.get("recommended_binary_version") == identity.advertised_version
+            self.coordinator_identity_ready(coordinator, identity)
             and gateway.get("status") == "ok"
             and gateway.get("version") == identity.gateway_version
         )

--- a/ops/pearl-updater/test_pearl_updater.py
+++ b/ops/pearl-updater/test_pearl_updater.py
@@ -421,6 +421,52 @@ class PearlUpdaterTests(unittest.TestCase):
         self.updater.get_json.return_value["recommended_binary_version"] = "1.8.26"
         self.assertFalse(self.updater.local_coordinator_ready(release, False))
 
+    def test_legacy_rollback_accepts_only_an_absent_advertised_version_field(self):
+        legacy = updater_module.RuntimeIdentity(
+            "v1.8.26-4-g64083ef",
+            "v1.8.20-4-ga5e12c2",
+            "1.8.26",
+        )
+        release = updater_module.RuntimeIdentity("v1.8.30", "v1.8.30", "1.8.30")
+        self.updater.get_json = mock.Mock(
+            return_value={
+                "status": "ok",
+                "version": legacy.coordinator_version,
+            }
+        )
+
+        self.assertTrue(self.updater.local_coordinator_identity_ready(legacy, False))
+        self.updater.get_json.return_value["recommended_binary_version"] = "1.8.25"
+        self.assertFalse(self.updater.local_coordinator_identity_ready(legacy, False))
+        self.updater.get_json.return_value["recommended_binary_version"] = None
+        self.assertFalse(self.updater.local_coordinator_identity_ready(legacy, False))
+        self.updater.get_json.return_value = {
+            "status": "ok",
+            "version": release.coordinator_version,
+        }
+        self.assertFalse(self.updater.local_coordinator_identity_ready(release, False))
+
+    def test_legacy_rollback_public_health_accepts_the_same_omission(self):
+        legacy = updater_module.RuntimeIdentity(
+            "v1.8.26-4-g64083ef",
+            "v1.8.20-4-ga5e12c2",
+            "1.8.26",
+        )
+        coordinator = {
+            "status": "ok",
+            "version": legacy.coordinator_version,
+        }
+        gateway = {
+            "status": "ok",
+            "version": legacy.gateway_version,
+        }
+        self.updater.get_json = mock.Mock(side_effect=[coordinator, gateway])
+
+        self.assertTrue(self.updater.public_identity_ready(legacy))
+        coordinator["recommended_binary_version"] = None
+        self.updater.get_json = mock.Mock(side_effect=[coordinator, gateway])
+        self.assertFalse(self.updater.public_identity_ready(legacy))
+
     def test_advertised_version_update_targets_effective_overlay(self):
         install = self.updater.install_root
         install.mkdir(parents=True)


### PR DESCRIPTION
## Outcome

Allows an interrupted updater rollback to prove the exact legacy coordinator identity when that older health schema genuinely omits `recommended_binary_version`.

## Safety boundaries

- The exception applies only to anchored legacy git-describe coordinator identities.
- A present `recommended_binary_version` must still match exactly; explicit `null` fails.
- Signed release candidates remain strict semantic-version identities.
- Local/public gateway identity checks remain exact.
- Full serving recovery still requires coordinator pool readiness, gateway readiness, public identity, and the external canary.

## Production root cause

The signed v1.8.30 candidate correctly failed because database migrations 15-17 had not yet been applied. Rollback restored v1.8.26, whose older health response omits the advertised-version field; the updater then could not finish its otherwise valid serving proof.

## Validation

- 74 updater tests passed; 1 environment-dependent root/UID-drop test skipped.
- `make test-dist` passed, including canary wrapper E2E.
- `git diff --check` passed.
- Exact-head code, architecture, and security audits: C0/H0/M0/L0.