### PR TITLE
ops(coordinator): pin the owned Pearl Mac provider

### DIFF
--- a/phase4-coordinator/dist/coordinator.yaml
+++ b/phase4-coordinator/dist/coordinator.yaml
@@ -247,9 +247,13 @@ tier2:
   public_catalog_base_url: "https://coordinator.streamvc.live"
 
 # Enumerated PINNED providers (SPEC-002 v1.0.4 Finding F-2: every pinned
-# provider_id MUST be listed here). M4 + M1 today; provisional providers
+# provider_id MUST be listed here). Pearl's owned Mac stays WS-tunneled by
+# leaving endpoint_url empty; unlisted providers remain provisional and are
 # admitted dynamically per `admission` config above.
-providers: []
+providers:
+  - provider_id: "mac"
+    endpoint_url: ""
+    display_name: "Pearl Mac provider"
 
 # Auto-update recommendation surface (2026-07-03 — added post-#332 to unblock air5 v1.7.0 -> v1.7.9)
 coordinator_advertised_version:


### PR DESCRIPTION
## Outcome

Persist the already-authorized runtime promotion of provider `mac` so coordinator restarts do not return the owned production provider to the rolling provisional quota.

## Safety boundaries

- Only exact provider ID `mac` is pinned.
- `endpoint_url` remains empty, preserving WS-tunneled inference and preventing provider-supplied HTTP forwarding.
- Provider bearer authentication remains required.
- All unlisted providers retain the existing provisional admission policy and quota.

## Production evidence

The strict rollback canary exhausted the 100-request/hour provisional quota after repeated recovery probes. Runtime promotion immediately restored public serving and allowed the rollback journal to clear. The provider hardware profile is verified; this change makes the intended operator promotion durable across the v1.8.30 restart.

## Validation

- Coordinator config drift gate passed.
- `go test ./internal/config ./internal/ws` passed.
- `make test-dist` passed.
- Exact-head code, security, and architecture audits: C0/H0/M0/L0.