### PR TITLE
Keep resumed updater database capture idempotent

### DIFF
--- a/ops/pearl-updater/macprovider-pearl-update
+++ b/ops/pearl-updater/macprovider-pearl-update
@@ -1620,8 +1620,12 @@ class Updater:
 
     def capture_database_paths(self) -> None:
         if self.gateway_db is not None:
-            paths = (self.gateway_db, *self.databases)
-            config_hashes: dict[Path, str] = {}
+            paths = (
+                self.databases
+                if self.databases and self.databases[0] == self.gateway_db
+                else (self.gateway_db, *self.databases)
+            )
+            config_hashes = dict(self.runtime_config_hashes)
         else:
             runtime = self.coordinator_runtime_state or self.coordinator_runtime()
             coordinator_paths = [runtime.base_config]

--- a/ops/pearl-updater/test_pearl_updater.py
+++ b/ops/pearl-updater/test_pearl_updater.py
@@ -1154,6 +1154,52 @@ class PearlUpdaterTests(unittest.TestCase):
             {coordinator, gateway, stats_fragment, stats_dropin},
         )
 
+    def test_capture_database_paths_is_idempotent_after_runtime_capture(self):
+        install = self.updater.install_root
+        install.mkdir(parents=True)
+        coordinator = install / "coordinator.yaml"
+        gateway = install / "gateway.yaml"
+        stats_fragment = self.root / "stats-billing-mirror.service"
+        stats_dropin = self.root / updater_module.TRANSACTION_GATE_DROPIN_NAME
+        coordinator.write_text("storage:\n  db_path: /srv/macprovider/coordinator.sqlite\n")
+        gateway.write_text("storage:\n  db_path: /srv/macprovider/gateway.sqlite\n")
+        stats_fragment.write_text(
+            "[Service]\nExecStart=/opt/macprovider-stats/stats-billing-mirror "
+            "--sqlite /srv/macprovider/coordinator.sqlite\n"
+        )
+        stats_dropin.write_text(updater_module.TRANSACTION_GATE_DROPIN_TEXT)
+        self.updater.gateway_db = None
+        self.updater.databases = ()
+        self.updater.coordinator_runtime_state = updater_module.CoordinatorRuntime(coordinator, None, {})
+        self.updater.gateway_config_path = mock.Mock(return_value=gateway)
+        self.updater.stats_mirror_runtime = mock.Mock(
+            return_value=((stats_fragment, stats_dropin), Path("/srv/macprovider/coordinator.sqlite"))
+        )
+
+        self.updater.capture_database_paths()
+        captured_paths = self.updater.databases
+        captured_hashes = dict(self.updater.runtime_config_hashes)
+        self.updater.capture_database_paths()
+
+        self.assertEqual(self.updater.gateway_db, Path("/srv/macprovider/gateway.sqlite"))
+        self.assertEqual(self.updater.databases, captured_paths)
+        self.assertEqual(self.updater.runtime_config_hashes, captured_hashes)
+
+    def test_capture_database_paths_accepts_journal_restored_state(self):
+        gateway = Path("/srv/macprovider/gateway.sqlite")
+        coordinator = Path("/srv/macprovider/coordinator.sqlite")
+        config = Path("/opt/macprovider/coordinator.yaml")
+        config_hash = "a" * 64
+        self.updater.gateway_db = gateway
+        self.updater.databases = (gateway, coordinator)
+        self.updater.runtime_config_hashes = {config: config_hash}
+
+        self.updater.capture_database_paths()
+
+        self.assertEqual(self.updater.gateway_db, gateway)
+        self.assertEqual(self.updater.databases, (gateway, coordinator))
+        self.assertEqual(self.updater.runtime_config_hashes, {config: config_hash})
+
     def test_stats_mirror_cannot_share_gateway_database(self):
         install = self.updater.install_root
         install.mkdir(parents=True)
@@ -1196,7 +1242,7 @@ class PearlUpdaterTests(unittest.TestCase):
         with self.assertRaisesRegex(updater_module.UpdateError, "absolute path"):
             self.updater._database_path("gateway.db", "gateway storage.db_path")
         self.updater.gateway_db = self.root / "same.sqlite"
-        self.updater.databases = (self.root / "same.sqlite",)
+        self.updater.databases = (self.root / "other.sqlite", self.root / "other.sqlite")
         with self.assertRaisesRegex(updater_module.UpdateError, "distinct absolute"):
             self.updater.capture_database_paths()
 


### PR DESCRIPTION
## Outcome

Prevents a reconciled Pearl updater invocation from prepending the gateway database twice and aborting the next rollout with `effective database paths must be distinct absolute paths`.

## Root cause and correction

The durable journal restores `gateway_db` and a canonical `databases` tuple whose first entry is already that gateway path. A subsequent capture treated the tuple as uncaptured constructor input and prepended the gateway again. The updater now recognizes the canonical representation and preserves its journal-bound configuration hashes; malformed duplicate tuples still fail closed.

## Regression coverage

- repeated same-process runtime capture remains idempotent
- journal-restored capture retains paths and configuration hashes
- genuinely duplicated paths remain rejected

## Verification

- 76 updater unit tests passed; 1 macOS-inapplicable root/systemd test skipped
- transaction-gate shell integration skipped cleanly on non-Linux
- `git diff --check` passed
- exact-head CODE audit: C0/H0/M0/L0
- exact-head SECURITY audit: C0/H0/M0/L2
- exact-head ARCHITECTURE audit: C0/H0/M0/L1 (WATCH, mergeable)

The LOW notes concern malformed private-journal normalization/hash cross-field hardening and a rare committed-success-to-newer-release same-process retry; none affect this rollback-path fix or permit unsafe mutation.

Closes no issue directly: production rollout and verification must complete before #524 is closed.