### PR TITLE
spec(033): hardware-evidence verifier (hardware-verifier.v2) — reconstructed baseline (Wave C item 10)

### DIFF
--- a/specs/README.md
+++ b/specs/README.md
@@ -41,6 +41,7 @@ it can no longer drift. Do not hand-edit the table; edit each spec's
 | SPEC-030 | Losslessness Probe | v0.1 | [SPEC-030-losslessness-probe.md](SPEC-030-losslessness-probe.md) |
 | SPEC-031 | Canary Probe, Degrade & Sanction Lifecycle | v0.1 | [SPEC-031-canary-degrade-sanctions.md](SPEC-031-canary-degrade-sanctions.md) |
 | SPEC-032 | Autotune Hardware-Evidence Admission Gate, OPoI & Proof-of-Weights Boundary | v0.1 | [SPEC-032-proof-of-weights-hello-gate.md](SPEC-032-proof-of-weights-hello-gate.md) |
+| SPEC-033 | Hardware-Evidence Verifier (`hardware-verifier.v2`) | v0.1 | [SPEC-033-hardware-verifier.md](SPEC-033-hardware-verifier.md) |
 <!-- AUTOGEN:spec-index END -->
 
 **Version of record is each spec's own `**Version:**` header, not this table.**

--- a/specs/README.md
+++ b/specs/README.md
@@ -41,7 +41,7 @@ it can no longer drift. Do not hand-edit the table; edit each spec's
 | SPEC-030 | Losslessness Probe | v0.1 | [SPEC-030-losslessness-probe.md](SPEC-030-losslessness-probe.md) |
 | SPEC-031 | Canary Probe, Degrade & Sanction Lifecycle | v0.1 | [SPEC-031-canary-degrade-sanctions.md](SPEC-031-canary-degrade-sanctions.md) |
 | SPEC-032 | Autotune Hardware-Evidence Admission Gate, OPoI & Proof-of-Weights Boundary | v0.1 | [SPEC-032-proof-of-weights-hello-gate.md](SPEC-032-proof-of-weights-hello-gate.md) |
-| SPEC-033 | Hardware-Evidence Verifier (`hardware-verifier.v2`) | v0.2 | [SPEC-033-hardware-verifier.md](SPEC-033-hardware-verifier.md) |
+| SPEC-033 | Hardware-Evidence Verifier (`hardware-verifier.v2`) | v0.3 | [SPEC-033-hardware-verifier.md](SPEC-033-hardware-verifier.md) |
 <!-- AUTOGEN:spec-index END -->
 
 **Version of record is each spec's own `**Version:**` header, not this table.**

--- a/specs/README.md
+++ b/specs/README.md
@@ -41,7 +41,7 @@ it can no longer drift. Do not hand-edit the table; edit each spec's
 | SPEC-030 | Losslessness Probe | v0.1 | [SPEC-030-losslessness-probe.md](SPEC-030-losslessness-probe.md) |
 | SPEC-031 | Canary Probe, Degrade & Sanction Lifecycle | v0.1 | [SPEC-031-canary-degrade-sanctions.md](SPEC-031-canary-degrade-sanctions.md) |
 | SPEC-032 | Autotune Hardware-Evidence Admission Gate, OPoI & Proof-of-Weights Boundary | v0.1 | [SPEC-032-proof-of-weights-hello-gate.md](SPEC-032-proof-of-weights-hello-gate.md) |
-| SPEC-033 | Hardware-Evidence Verifier (`hardware-verifier.v2`) | v0.4 | [SPEC-033-hardware-verifier.md](SPEC-033-hardware-verifier.md) |
+| SPEC-033 | Hardware-Evidence Verifier (`hardware-verifier.v2`) | v0.5 | [SPEC-033-hardware-verifier.md](SPEC-033-hardware-verifier.md) |
 <!-- AUTOGEN:spec-index END -->
 
 **Version of record is each spec's own `**Version:**` header, not this table.**

--- a/specs/README.md
+++ b/specs/README.md
@@ -41,7 +41,7 @@ it can no longer drift. Do not hand-edit the table; edit each spec's
 | SPEC-030 | Losslessness Probe | v0.1 | [SPEC-030-losslessness-probe.md](SPEC-030-losslessness-probe.md) |
 | SPEC-031 | Canary Probe, Degrade & Sanction Lifecycle | v0.1 | [SPEC-031-canary-degrade-sanctions.md](SPEC-031-canary-degrade-sanctions.md) |
 | SPEC-032 | Autotune Hardware-Evidence Admission Gate, OPoI & Proof-of-Weights Boundary | v0.1 | [SPEC-032-proof-of-weights-hello-gate.md](SPEC-032-proof-of-weights-hello-gate.md) |
-| SPEC-033 | Hardware-Evidence Verifier (`hardware-verifier.v2`) | v0.5 | [SPEC-033-hardware-verifier.md](SPEC-033-hardware-verifier.md) |
+| SPEC-033 | Hardware-Evidence Verifier (`hardware-verifier.v2`) | v0.6 | [SPEC-033-hardware-verifier.md](SPEC-033-hardware-verifier.md) |
 <!-- AUTOGEN:spec-index END -->
 
 **Version of record is each spec's own `**Version:**` header, not this table.**

--- a/specs/README.md
+++ b/specs/README.md
@@ -41,7 +41,7 @@ it can no longer drift. Do not hand-edit the table; edit each spec's
 | SPEC-030 | Losslessness Probe | v0.1 | [SPEC-030-losslessness-probe.md](SPEC-030-losslessness-probe.md) |
 | SPEC-031 | Canary Probe, Degrade & Sanction Lifecycle | v0.1 | [SPEC-031-canary-degrade-sanctions.md](SPEC-031-canary-degrade-sanctions.md) |
 | SPEC-032 | Autotune Hardware-Evidence Admission Gate, OPoI & Proof-of-Weights Boundary | v0.1 | [SPEC-032-proof-of-weights-hello-gate.md](SPEC-032-proof-of-weights-hello-gate.md) |
-| SPEC-033 | Hardware-Evidence Verifier (`hardware-verifier.v2`) | v0.3 | [SPEC-033-hardware-verifier.md](SPEC-033-hardware-verifier.md) |
+| SPEC-033 | Hardware-Evidence Verifier (`hardware-verifier.v2`) | v0.4 | [SPEC-033-hardware-verifier.md](SPEC-033-hardware-verifier.md) |
 <!-- AUTOGEN:spec-index END -->
 
 **Version of record is each spec's own `**Version:**` header, not this table.**

--- a/specs/README.md
+++ b/specs/README.md
@@ -41,7 +41,7 @@ it can no longer drift. Do not hand-edit the table; edit each spec's
 | SPEC-030 | Losslessness Probe | v0.1 | [SPEC-030-losslessness-probe.md](SPEC-030-losslessness-probe.md) |
 | SPEC-031 | Canary Probe, Degrade & Sanction Lifecycle | v0.1 | [SPEC-031-canary-degrade-sanctions.md](SPEC-031-canary-degrade-sanctions.md) |
 | SPEC-032 | Autotune Hardware-Evidence Admission Gate, OPoI & Proof-of-Weights Boundary | v0.1 | [SPEC-032-proof-of-weights-hello-gate.md](SPEC-032-proof-of-weights-hello-gate.md) |
-| SPEC-033 | Hardware-Evidence Verifier (`hardware-verifier.v2`) | v0.1 | [SPEC-033-hardware-verifier.md](SPEC-033-hardware-verifier.md) |
+| SPEC-033 | Hardware-Evidence Verifier (`hardware-verifier.v2`) | v0.2 | [SPEC-033-hardware-verifier.md](SPEC-033-hardware-verifier.md) |
 <!-- AUTOGEN:spec-index END -->
 
 **Version of record is each spec's own `**Version:**` header, not this table.**

--- a/specs/SPEC-033-hardware-verifier.md
+++ b/specs/SPEC-033-hardware-verifier.md
@@ -1,6 +1,6 @@
 # SPEC-033 — Hardware-Evidence Verifier (`hardware-verifier.v2`)
 
-**Status:** v0.3-draft
+**Status:** v0.4-draft
 **Date:** 2026-07-12
 **Depends on:** SPEC-023 (autotune — produces the benchmark/recommendation inputs the evidence document carries). **Consumed by:** SPEC-032 (autotune hardware-evidence admission "hello-gate") reads this spec's verdict via an **exact-`hardware-verifier.v2`** lookup and cross-references it as "the item-10 hardware-verifier verdict spec". This spec owns the `hardware-verifier.v2` decision semantics and the job/profile lifecycle; SPEC-032 owns how a `verified` profile gates admission.
 
@@ -207,8 +207,10 @@ benchmarks []{
 ```
 
 A **lowercase hex SHA-256** is exactly 64 chars in `[0-9a-f]` (`isLowerSHA256`). The optional
-`candidate_row_identity` (emitted by the producer) is validated at the HTTP handler (§3.1) — 64
-lowercase hex if non-empty — but is not consumed by the `Evaluate` gate pipeline (§5).
+`candidate_row_identity` shown above is a field of the **HTTP handler's** request/benchmark struct
+only (validated there — 64 lowercase hex if non-empty); it is **not** a field of the verifier's
+`hardwareverify.Benchmark`, so `Evaluate` discards it during JSON decode. (The `hardware`/`benchmark`
+field names/types above otherwise match `hardwareverify.Evidence`/`Hardware`/`Benchmark` exactly.)
 
 ### 3.1 Submission and replay (enqueue path)
 
@@ -226,8 +228,10 @@ authenticated bearer identity; the handler (`HandleHardwareEvidence`) binds the 
   minutes (`hardware_evidence.go`), so a provider cannot flood the queue while one job is
   outstanding;
 - computes a **canonical** SHA-256 of the evidence (`canonicalEvidenceSHA`) → `evidence_sha256`;
-- in the **same transaction**, upserts a **`source='cli_hello'` profile row** (with `verified`
-  left to trigger A, i.e. `FALSE`) *before* inserting the job, then inserts a `pending` job
+- in the **same transaction**, upserts a **`source='cli_hello'` profile row** *before* inserting
+  the job (the upsert **omits `verified`**, so trigger A governs it: `FALSE` on an initial insert or
+  a chip/memory change, but **`OLD.verified` preserved** on an unchanged existing tuple — so a
+  re-submitting already-verified provider keeps `verified=TRUE`), then inserts a `pending` job
   (unique on `evidence_sha256`);
 - returns a **replay state machine** result (`hardwareEvidenceResponseStatus`), **fail-closed**: a
   duplicate is accepted (2xx) **only** while `pending`, while `waiting_trust`, or when already
@@ -258,9 +262,10 @@ row to convert.
 **two distinct consumer classes**:
 
 - **Exact-v2 (job-reason) consumers** require `decision_reason = VerifiedDecisionReason`: onboarding
-  replay (`hardware_evidence.go`; its test rejects `hardware-verifier.v1:verified`) and SPEC-032's
-  evidence lookup (`internal/autotune/evidence_pg.go`). A legacy `v1:verified` row is **not** a
-  current trusted verdict for these.
+  replay (`hardware_evidence.go`; its test rejects `hardware-verifier.v1:verified`), SPEC-032's
+  evidence lookup (`internal/autotune/evidence_pg.go` `LatestVerified`), and the same `LatestVerified`
+  feeding the config-gated telemetry-drift evaluator (`internal/pow/drift.go`). A legacy `v1:verified`
+  row is **not** a current trusted verdict for these.
 - **Verified-bit consumers** gate on `provider_hardware_profiles.verified = TRUE` **without**
   inspecting any job reason: the **SPEC-017 hardware cache** (`internal/stats/hardware/cache.go`
   selects `WHERE verified = TRUE`) and the demotion predicate's supporting-job clause (§7.3), which
@@ -366,20 +371,22 @@ matches **zero rows** — the existing (newer) profile is left intact — yet th
 `provider_hardware_profiles.verified` is not permanent, but demotion is **best-effort and has
 documented escape paths (§10.4)** — it is NOT a reliable revocation guarantee. The operator
 inventory sync (`cmd/stats-inventory-sync`, role `stats_inventory_writer`) runs
-`applyTrustDemotions`, which sets `verified = FALSE` only for a profile that satisfies **all** of:
-(i) `source = 'cli_hello'`; (ii) no matching **active** trust row (trust removed or `expires_at`
-passed); **and** (iii) a `status='verified'` job **exactly** matching the profile's chip, memory,
-`os_version→macos_version`, `binary_version→app_version`, and `generated_at→last_reported_at`.
-Consequences of that predicate:
+`applyTrustDemotions`. The exact predicate (`main.go`) sets `verified = FALSE` for every profile
+where `verified = TRUE` **AND** `source = 'cli_hello'` **AND `NOT EXISTS`** a **combined witness** —
+a `status='verified'` job that **both** exactly matches the profile's tuple (provider, chip, memory,
+`os_version→macos_version`, `binary_version→app_version`, `generated_at→last_reported_at`) **and**
+is joined to an **active** trust row (`expires_at IS NULL OR > now()`). In words: **retention
+requires that one combined (matching-verified-job ∧ active-trust) proof still exist; demotion fires
+when it does not** — so *either* trust loss/expiry *or* profile-tuple drift (no matching job) is
+independently sufficient. Consequences:
 
 - It only touches `source='cli_hello'` profiles — a profile converted to `app_register` (§10.4 R1)
-  is never demoted.
-- `applyTrustDemotions` (and the whole trust reconciliation) runs **only when the sync input
-  contains ≥ 1 trusted-hardware identity** (`validateInventory` rejects an empty `trusted_hardware`
-  section, and omitting it leaves trust roots untouched), so it cannot express "remove the last
-  root / zero trust" (§10.4 R2).
-- Because it also requires an exact tuple-matching verified job, tuple/profile drift can demote a
-  profile **even while its trust row remains** — trust removal is *sufficient but not exhaustive*.
+  is never demoted (the load-bearing escape).
+- Because the witness needs *both* the matching job and active trust, **tuple/profile drift can
+  demote even while a trust row remains** — trust removal is sufficient but not the only trigger.
+- `applyTrustDemotions` (and trust reconciliation) runs only when the sync input carries ≥ 1
+  trusted-hardware identity; an operator reaches **zero *active* trust** by supplying a placeholder
+  identity with a past `expires_at` (§10.4 R2) rather than an empty section.
 
 The same tool also directly upserts operator profiles (`source='operator'`, `verified` from an
 operator-authored YAML) — an operator-authority write path outside the evidence pipeline (§10.1).
@@ -486,12 +493,18 @@ them is code follow-up, not a spec change:
   removal/expiry** (SPEC-032 admission is then bounded only by the evidence-TTL freshness join, not
   by trust). MUST-close: demotion should not be `source='cli_hello'`-scoped, or admission should
   re-check current trust.
-- **R2 — last-trust-root / zero-trust non-removal.** `validateInventory` rejects an **empty**
-  `trusted_hardware` section (and omitting it means "leave roots untouched"), and trust
-  reconciliation + `applyTrustDemotions` run **only when ≥ 1 trust identity is present**. So the
-  inventory tool **cannot express removing the last root or operating at zero trust**, and in that
-  state no demotion runs at all — an active final root keeps authorizing promotions. MUST-close:
-  support an explicit zero-trust reconciliation that also demotes.
+- **R2 — no direct empty-trust reconciliation (ergonomics, NOT a revocation impossibility).**
+  `validateInventory` rejects an **empty** `trusted_hardware` section and omitting it leaves roots
+  untouched, so there is no *direct* "delete the last physical trust row" operation. **However,
+  zero *active* trust IS reachable** and DOES demote: an operator supplies a **placeholder identity
+  with a past `expires_at`** (validation accepts any parseable RFC3339, not requiring a future
+  time). That keeps the trust count > 0 (so reconciliation and `applyTrustDemotions` run and delete
+  all other roots), while the placeholder is **inactive** everywhere the code applies the
+  `expires_at > now()` predicate — both promotion (`verify.go`) and the demotion witness
+  (`main.go`). So revocation to zero-active-trust is achievable; the residual is only the missing
+  *ergonomic* empty-section path (and the final physical row cannot be deleted, only expired).
+  Minor MUST-close: accept an explicit empty/zero-trust reconciliation so operators need not use an
+  expired-placeholder workaround.
 
 ---
 
@@ -525,9 +538,13 @@ them is code follow-up, not a spec change:
   MUST roll the batch back if it does not hold (§2.5, §7.1).
 - **AC-HV-2 (ordered reasons).** For each gate in §5, a job failing exactly that gate first MUST
   persist `decision_reason='hardware-verifier.v2:<that reason>'`. Gate order is normative.
-- **AC-HV-3 (waiting is non-terminal).** A job missing only a trust row or chip profile MUST become
-  `waiting_trust` (not `rejected`) and MUST promote on a later run once the operator-curated row
-  exists — no re-submission.
+- **AC-HV-3 (waiting is non-terminal, subject to freshness).** A job missing only a trust row or
+  chip profile MUST become `waiting_trust` (not `rejected`). Once the operator-curated row exists it
+  MUST promote on a later run **provided the job still passes every preceding §5 gate** — in
+  particular, `Evaluate` re-runs the `stale_job`/`stale_evidence` gates against the *current* `now`
+  before the trust gates, so a `waiting_trust` job whose evidence has aged past `maxEvidenceAge` is
+  **rejected**, not promoted, and requires resubmission. No re-submission is needed only while the
+  evidence remains fresh.
 - **AC-HV-4 (no self-certification of the profile bit).** No `provider_onboarding` write may set
   `provider_hardware_profiles.verified=TRUE` (no grant + trigger A). This is a statement about the
   **profile verified bit**, independent of job `status` (a compromised onboarding role could insert
@@ -548,19 +565,40 @@ them is code follow-up, not a spec change:
   `hardware-verifier.v2:verified_trusted_hardware` reason. **Verified-bit consumers** (SPEC-017
   cache, the §7.3 demotion supporting-job clause) gate on `verified=TRUE` without a reason check
   (§4) — the spec MUST NOT claim exact-v2 is universal.
-- **AC-HV-10 (demotion is best-effort).** Removing/expiring a trust row demotes an affected profile
-  to `verified=FALSE` on the next sync **only** when all three §7.3 conditions hold (`source='cli_hello'`,
-  no active trust, exact tuple-matching verified job) **and** the sync input carries ≥ 1 trust
-  identity. Demotion is best-effort, not a guarantee (§10.4).
+- **AC-HV-10 (demotion is best-effort, correct predicate).** On the next sync, a `verified`,
+  `source='cli_hello'` profile is demoted to `verified=FALSE` **iff no combined witness exists** —
+  i.e. no `status='verified'` job that both exactly matches the profile tuple and is joined to an
+  **active** trust row (§7.3). So *either* trust loss/expiry *or* profile-tuple drift is sufficient
+  to demote; retention requires the combined proof. Demotion runs only when the sync input carries
+  ≥ 1 trust identity (zero *active* trust is reachable via an expired placeholder — §10.4 R2). It
+  does **not** touch `source='app_register'` profiles (§10.4 R1). Demotion is best-effort, not a
+  guarantee.
 - **AC-HV-11 (chip/memory re-verification).** A `provider_onboarding` update that changes
   `chip_normalized` or `unified_memory_gb` MUST clear `verified` (trigger A).
-- **AC-HV-12 (revocation gaps documented).** The spec MUST disclose the R1 (`app_register`
-  source-flip escape) and R2 (last-root/zero-trust non-removal) revocation gaps (§10.4) as known
-  shipped weaknesses rather than assert unconditional revocability.
+- **AC-HV-12 (revocation calibration documented).** The spec MUST disclose the R1 `app_register`
+  source-flip escape (a genuine revocation gap) and the R2 empty-trust *ergonomics* limitation
+  (zero *active* trust is reachable via an expired placeholder and does demote — §10.4) as known
+  shipped behavior, rather than assert unconditional revocability **or** overstate R2 as a hard
+  impossibility.
 
 ---
 
 ## Change log
+
+**v0.4-draft (2026-07-12) — audit reconciliation (SPEC-033 R3, 3-lane codex).**
+R3 confirmed every v0.3 scope/consumer/grant fix and narrowed to predicate-precision:
+- **§7.3 + AC-HV-10 demotion predicate corrected** (unanimous HIGH): the shipped SQL demotes a
+  `cli_hello` verified profile **iff no combined (exact-tuple verified job ∧ active trust) witness
+  exists** — so trust loss *or* tuple drift each suffice; the prior "all three conjunctive
+  conditions" wording was inverted.
+- **§10.4 R2 recalibrated** (unanimous HIGH): zero *active* trust is reachable (expired-placeholder
+  identity) and does demote, so R2 is an empty-section **ergonomics** limitation, not a hard
+  revocation impossibility (v0.3 overstated it). R1 `app_register` escape unchanged (confirmed real).
+- **§3.1** pre-job `cli_hello` upsert **preserves** `OLD.verified` on an unchanged existing tuple
+  (only insert/chip/memory-change forces FALSE) — reinforcing R1.
+- **AC-HV-3** qualified: `waiting_trust` promotes only if the job still passes the §5 freshness gates.
+- **§3** `candidate_row_identity` is an HTTP-handler field, not part of the `hardwareverify.Benchmark`
+  decode shape. **§4** adds the telemetry-drift (`internal/pow/drift.go`) exact-v2 consumer.
 
 **v0.3-draft (2026-07-12) — audit reconciliation (SPEC-033 R2, 3-lane codex).**
 R2 confirmed the §3/§5/§6/§8 core and the no-initial-self-certification property, and caught a

--- a/specs/SPEC-033-hardware-verifier.md
+++ b/specs/SPEC-033-hardware-verifier.md
@@ -1,6 +1,6 @@
 # SPEC-033 — Hardware-Evidence Verifier (`hardware-verifier.v2`)
 
-**Status:** v0.4-draft
+**Status:** v0.5-draft
 **Date:** 2026-07-12
 **Depends on:** SPEC-023 (autotune — produces the benchmark/recommendation inputs the evidence document carries). **Consumed by:** SPEC-032 (autotune hardware-evidence admission "hello-gate") reads this spec's verdict via an **exact-`hardware-verifier.v2`** lookup and cross-references it as "the item-10 hardware-verifier verdict spec". This spec owns the `hardware-verifier.v2` decision semantics and the job/profile lifecycle; SPEC-032 owns how a `verified` profile gates admission.
 
@@ -21,9 +21,10 @@ deployment/role SQL (`phase4-coordinator/dist/stats-inventory-writer.sql`,
 (`phase3-binary/.../AutotuneHardwareEvidence.swift`), the app-registration profile writer
 (`internal/onboarding/apptrack.go`, `store_pg.go`), the operator inventory writer/demotion
 (`cmd/stats-inventory-sync/main.go`), the runner (`cmd/stats-hardware-verifier/main.go`), and the
-downstream consumers — SPEC-032 admission (`internal/autotune/evidence_pg.go`) and the SPEC-017
-hardware cache (`internal/stats/hardware/cache.go`). **Where §2 summarizes DDL, the migration and
-`dist/*.sql` files are the byte-authoritative shape.**
+downstream consumers — SPEC-032 admission (`internal/autotune/evidence_pg.go`), the SPEC-017
+hardware cache (`internal/stats/hardware/cache.go`), and the config-gated telemetry-drift evaluator
+(`internal/pow/drift.go`, on the same exact-v2 `LatestVerified` lookup). **Where §2 summarizes DDL,
+the migration and `dist/*.sql` files are the byte-authoritative shape.**
 
 ---
 
@@ -43,9 +44,10 @@ ordered gate pipeline over each evidence document, and transitions the job to **
 ### 1.2 What `verified` means and who consumes it
 
 `provider_hardware_profiles.verified` is consumed by **SPEC-032's hardware-evidence admission
-lookup** (`internal/autotune/evidence_pg.go`), which requires a `verified = TRUE` profile joined
-to a `status='verified'` job carrying the **exact** `hardware-verifier.v2:verified_trusted_hardware`
-decision reason. It is **not** itself a SPEC-002 tier/routing input — SPEC-002 tiers derive from
+lookup** (`internal/autotune/evidence_pg.go` `LatestVerified`) — and the same lookup also feeds the
+config-gated **telemetry-drift** evaluator (`internal/pow/drift.go`) — which requires a
+`verified = TRUE` profile joined to a `status='verified'` job carrying the **exact**
+`hardware-verifier.v2:verified_trusted_hardware` decision reason. It is **not** itself a SPEC-002 tier/routing input — SPEC-002 tiers derive from
 pinned config / unknown-id / rejection state, and SPEC-032 explicitly treats the hardware-evidence
 signal as **orthogonal** to the SPEC-002/SPEC-003 tiers. This spec defines the verdict engine and
 lifecycle; it does not define admission or tier weighting.
@@ -161,10 +163,14 @@ DB-level counterpart of the application's terminal-safe `WHERE` (§6).
   `SELECT`** — `id, provider_id, status, submitted_at, evidence_sha256` (008), `decision_reason`
   (015), **`generated_at, evidence`** (013, for the SPEC-032 W2 hello gate — the §10.2 leakage
   boundary), and job `chip_normalized, unified_memory_gb` (017); on profiles, `last_reported_at`
-  (007) and `provider_id, chip_normalized, unified_memory_gb, verified` (017). It has **no
-  `verified` write grant** and trigger A forces `verified=FALSE` regardless: **onboarding can never
-  self-promote.** (A compromised onboarding SQL role could insert a job with a terminal `status`
-  and could *read* all evidence, but cannot set a profile's `verified` bit — §10.1, §10.2.)
+  (007) and `provider_id, chip_normalized, unified_memory_gb, verified` (017). It also has column
+  `INSERT`/`UPDATE` on profiles for `chip, chip_normalized, unified_memory_gb, macos_version,
+  app_version, source, last_reported_at` (007) — **but `verified` is NOT among them**, and trigger
+  A forces `verified=FALSE` on any insert and on any chip/memory change: **onboarding can never
+  self-promote.** (Precisely: trigger A forces FALSE on insert/chip/memory-change but **preserves**
+  `OLD.verified` on a same-tuple update — see §10.1; a compromised onboarding SQL role could insert
+  a terminal-`status` job, *read* all evidence, and flip `source` on already-verified rows to escape
+  demotion, but still cannot *set* the `verified` bit — §10.1, §10.2.)
 - **`stats_inventory_writer`** (operator inventory sync, §7.3; role/grants defined in
   `dist/stats-inventory-writer.sql`, not a migration): full `INSERT/UPDATE` on
   `provider_hardware_profiles` **including `verified`**, and **not** constrained by trigger A. This
@@ -208,9 +214,12 @@ benchmarks []{
 
 A **lowercase hex SHA-256** is exactly 64 chars in `[0-9a-f]` (`isLowerSHA256`). The optional
 `candidate_row_identity` shown above is a field of the **HTTP handler's** request/benchmark struct
-only (validated there — 64 lowercase hex if non-empty); it is **not** a field of the verifier's
-`hardwareverify.Benchmark`, so `Evaluate` discards it during JSON decode. (The `hardware`/`benchmark`
-field names/types above otherwise match `hardwareverify.Evidence`/`Hardware`/`Benchmark` exactly.)
+(validated there — 64 lowercase hex if non-empty). It is **not** a field of the *verifier's*
+`hardwareverify.Benchmark`, so the `Evaluate` gate pipeline (§5) discards it — **but** it is
+persisted in the raw `evidence` JSONB and **is** decoded and used by **downstream** SPEC-032
+admission (`internal/autotune/evidence_pg.go`, `gate.go`). So "not consumed by `Evaluate`" is
+correct; "handler-only" would be wrong. (The `hardware`/`benchmark` field names/types above
+otherwise match `hardwareverify.Evidence`/`Hardware`/`Benchmark` exactly.)
 
 ### 3.1 Submission and replay (enqueue path)
 
@@ -366,15 +375,16 @@ matches **zero rows** — the existing (newer) profile is left intact — yet th
 `verified`. So a `verified` verdict does **not** unconditionally rewrite the profile; it promotes
 **iff** no newer profile blocks it (§12 AC-HV-1).
 
-### 7.3 Post-verdict demotion (operator inventory sync) — best-effort, with known escapes
+### 7.3 Post-verdict demotion (operator inventory sync) — best-effort (one escape R1, one ergonomics gap R2)
 
 `provider_hardware_profiles.verified` is not permanent, but demotion is **best-effort and has
 documented escape paths (§10.4)** — it is NOT a reliable revocation guarantee. The operator
 inventory sync (`cmd/stats-inventory-sync`, role `stats_inventory_writer`) runs
 `applyTrustDemotions`. The exact predicate (`main.go`) sets `verified = FALSE` for every profile
 where `verified = TRUE` **AND** `source = 'cli_hello'` **AND `NOT EXISTS`** a **combined witness** —
-a `status='verified'` job that **both** exactly matches the profile's tuple (provider, chip, memory,
-`os_version→macos_version`, `binary_version→app_version`, `generated_at→last_reported_at`) **and**
+a `status='verified'` job that **both** exactly matches the profile's tuple (provider,
+`chip_normalized`, `unified_memory_gb`, `os_version→macos_version`, `binary_version→app_version`,
+`generated_at→last_reported_at`) **and**
 is joined to an **active** trust row (`expires_at IS NULL OR > now()`). In words: **retention
 requires that one combined (matching-verified-job ∧ active-trust) proof still exist; demotion fires
 when it does not** — so *either* trust loss/expiry *or* profile-tuple drift (no matching job) is
@@ -425,14 +435,21 @@ No provider-reachable path sets `provider_hardware_profiles.verified = TRUE`:
 - The provider-reachable profile-write paths (the enqueue upsert §3.1, **and** signed
   app-registration §10.4 R1) both run as `provider_onboarding` — a role with **no `verified` write
   grant**, and trigger A forces `verified=FALSE` on any insert and on any chip/memory change
-  (§2.5, §2.7). So **no provider path can create an initial `verified=TRUE`**; the worst a
-  compromised onboarding SQL role can do is insert a terminal-status job or read evidence (§10.2).
-  (What a provider *can* do is **retain** an already-granted `verified` bit past trust removal by
-  flipping `source` — that is the R1 revocation gap, §10.4, not an initial-promotion path.)
+  (§2.5, §2.7). So **no provider path can create an initial `verified=TRUE`**. A **compromised**
+  onboarding SQL role can, however, do more than insert terminal-status jobs and read all evidence
+  (§10.2): because it holds column `UPDATE` on profiles including **`source`** (007), and trigger A
+  **preserves** `OLD.verified` on a same-tuple update, it can run
+  `UPDATE provider_hardware_profiles SET source='app_register' WHERE verified=TRUE` to
+  **mass-convert** every verified row and escape demotion — the R1 gap (§10.4) at cross-provider
+  scale. It still **cannot set** the `verified` bit (not in its column grant; trigger forces FALSE
+  on insert). Initial self-certification therefore holds even under role compromise.
 - `verified=TRUE` is writable by exactly **two** roles, **neither provider-reachable**:
-  (1) `stats_hardware_verifier`, only via `promoteJob` **and** only if the trust join passes both
-  in `Evaluate` (§5.5) and in the DB trigger (§2.5); (2) `stats_inventory_writer`, an
-  **operator-authority** path syncing an operator-authored YAML (`source='operator'`), the same
+  (1) `stats_hardware_verifier` — the only shipped **application** writer is `promoteJob`, and the
+  trust join is enforced both in `Evaluate` (§5.5) and in the DB trigger (§2.5); the *role* also
+  has direct `INSERT/UPDATE` on `verified`, but trigger A trust-gates any such write (a direct
+  qualifying insert is possible only *with* a matching fresh job + active trust); (2)
+  `stats_inventory_writer`, an **operator-authority** path syncing an operator-authored YAML
+  (`source='operator'`), the same
   trust level as curating a trust row.
 
 So: **a provider without an operator-curated trust row can reach at best `waiting_trust`, never
@@ -478,17 +495,19 @@ from reopening finalized jobs.
 
 ### 10.4 Revocation gaps (known shipped weaknesses — MUST close, disclosed not papered over)
 
-Initial self-certification is impossible (§10.1, holds). **Revocation of an already-`verified`
-profile, however, has two shipped escape paths.** SPEC-033 documents them as known gaps; closing
-them is code follow-up, not a spec change:
+Initial self-certification is impossible (§10.1, holds). Revocation of an already-`verified`
+profile is weaker: there is **one genuine revocation *escape* (R1)** and, separately, **one
+operator-*ergonomics* gap (R2)** that is not itself an escape. SPEC-033 documents both as known
+issues; closing them is code follow-up, not a spec change:
 
 - **R1 — `app_register` source-flip escape.** A signed provider **app-registration**
   (`internal/onboarding/apptrack.go` → `store_pg.go` `UpsertProviderHardwareProfile`) upserts the
   profile with `source='app_register'`. For an unchanged (chip, memory) tuple, trigger A preserves
   `OLD.verified` but does **not** reset `source`. Demotion (§7.3) only touches `source='cli_hello'`,
-  and both downstream consumers — SPEC-032 admission (`evidence_pg.go`) and the SPEC-017 hardware
-  cache (`internal/stats/hardware/cache.go`, §4) — gate on the `verified` **bit** without
-  rechecking `source` or current trust. So a legitimately-verified provider can re-register the
+  and the downstream consumers — SPEC-032 admission (`evidence_pg.go`), the SPEC-017 hardware cache
+  (`internal/stats/hardware/cache.go`), and the telemetry-drift evaluator (`internal/pow/drift.go`)
+  (§4) — gate on the `verified` **bit** (or the exact-v2 job) without rechecking `source` or current
+  trust. So a legitimately-verified provider can re-register the
   same chip/memory, flip its row to `app_register`, and **retain `verified=TRUE` past a later trust
   removal/expiry** (SPEC-032 admission is then bounded only by the evidence-TTL freshness join, not
   by trust). MUST-close: demotion should not be `source='cli_hello'`-scoped, or admission should
@@ -561,10 +580,10 @@ them is code follow-up, not a spec change:
   any job.
 - **AC-HV-9 (legacy grandfathering + two consumer classes).** A `hardware-verifier.v1:verified` row
   MUST remain terminal and MUST NOT be re-evaluated by the verifier. **Exact-v2 job-reason
-  consumers** (onboarding replay, SPEC-032 admission) MUST accept only the exact
-  `hardware-verifier.v2:verified_trusted_hardware` reason. **Verified-bit consumers** (SPEC-017
-  cache, the §7.3 demotion supporting-job clause) gate on `verified=TRUE` without a reason check
-  (§4) — the spec MUST NOT claim exact-v2 is universal.
+  consumers** (onboarding replay, SPEC-032 admission, the telemetry-drift evaluator) MUST accept
+  only the exact `hardware-verifier.v2:verified_trusted_hardware` reason. **Verified-bit consumers**
+  (SPEC-017 cache, the §7.3 demotion supporting-job clause) gate on `verified=TRUE` without a reason
+  check (§4) — the spec MUST NOT claim exact-v2 is universal.
 - **AC-HV-10 (demotion is best-effort, correct predicate).** On the next sync, a `verified`,
   `source='cli_hello'` profile is demoted to `verified=FALSE` **iff no combined witness exists** —
   i.e. no `status='verified'` job that both exactly matches the profile tuple and is joined to an
@@ -584,6 +603,21 @@ them is code follow-up, not a spec change:
 ---
 
 ## Change log
+
+**v0.5-draft (2026-07-12) — audit reconciliation (SPEC-033 R4, 3-lane codex).**
+R4 verified all R3 fixes against code (0 HIGH on all three lanes); remaining items were
+internal-consistency/precision:
+- **§10.4/§7.3 framing** (shared MEDIUM): revocation has **one escape (R1)** + **one operator
+  ergonomics gap (R2)**, not "two escape paths".
+- **§10.1/§2.7** (security MEDIUM): a *compromised* `provider_onboarding` role holds column
+  `UPDATE` on profiles **including `source`** (007), so with trigger A preserving `OLD.verified` on
+  a same-tuple update it can mass-flip `source='app_register'` to escape demotion at cross-provider
+  scale — still cannot *set* `verified`. Also qualified "only via `promoteJob`" as the only
+  *application* path (the verifier role has trust-gated direct SQL).
+- **§7.3** (LOW): the exact-tuple field is `chip_normalized`, not raw `chip`.
+- **§3** (LOW): `candidate_row_identity` is discarded by `Evaluate` but IS decoded/used downstream
+  (`evidence_pg.go`/`gate.go`) — "handler-only" was wrong.
+- **Telemetry-drift consumer** (LOW): propagated to the header roster, §1.2, §10.4, and AC-HV-9.
 
 **v0.4-draft (2026-07-12) — audit reconciliation (SPEC-033 R3, 3-lane codex).**
 R3 confirmed every v0.3 scope/consumer/grant fix and narrowed to predicate-precision:

--- a/specs/SPEC-033-hardware-verifier.md
+++ b/specs/SPEC-033-hardware-verifier.md
@@ -1,20 +1,25 @@
 # SPEC-033 — Hardware-Evidence Verifier (`hardware-verifier.v2`)
 
-**Status:** v0.1-draft
+**Status:** v0.2-draft
 **Date:** 2026-07-12
-**Depends on:** SPEC-002 (coordinator provider state machine; `provider_hardware_profiles.verified` is a routing/tier input), SPEC-003 (open onboarding; the App/CLI hello that submits evidence), SPEC-023 (autotune — produces the `hardware_evidence.autotune.v1` evidence document this verifier consumes). SPEC-032 (autotune hardware-evidence admission "hello-gate") **consumes this spec's verdict as an input** and cross-references it as "the item-10 hardware-verifier verdict spec"; SPEC-033 owns the `hardware-verifier.v2` decision semantics, SPEC-032 owns how the resulting `verified` profile gates admission.
+**Depends on:** SPEC-023 (autotune — produces the benchmark/recommendation inputs the evidence document carries). **Consumed by:** SPEC-032 (autotune hardware-evidence admission "hello-gate") reads this spec's verdict via an **exact-`hardware-verifier.v2`** lookup and cross-references it as "the item-10 hardware-verifier verdict spec". This spec owns the `hardware-verifier.v2` decision semantics and the job/profile lifecycle; SPEC-032 owns how a `verified` profile gates admission.
+
+**Producer / enqueue boundary (see §3.1):** the provider **binary** builds the evidence envelope (`phase3-binary/Sources/macprovider-cli/AutotuneHardwareEvidence.swift`) and submits it over an **authenticated HTTP `POST /v1/providers/hardware-evidence`** (`phase4-coordinator/internal/onboarding/hardware_evidence.go` `HandleHardwareEvidence`), which enqueues a `hardware_verification_jobs` row. SPEC-023 owns the *content* (benchmarks, recommended model); the HTTP envelope + enqueue + replay state machine are owned here.
 
 **Numbering note.** Assigned canonical **SPEC-033** on 2026-07-12 (Wave C of the
 2026-07-10 SPEC-vs-code drift audit; runbook item 10). Highest prior canonical spec
 was SPEC-032. This document is the **reconstructed normative baseline** for a shipped,
-production-live coordinator trust signal that ships **unspecced**: the batch
-**hardware-evidence verifier** that promotes a provider's autotune hardware evidence to a
-`verified` hardware profile, emitting `hardware-verifier.v2:*` decision reasons. The shipped
-success constant is `hardware-verifier.v2:verified_trusted_hardware` (the code is at
-`phase4-coordinator/internal/stats/hardwareverify/verify.go`; the runner is
-`phase4-coordinator/cmd/stats-hardware-verifier/main.go`). **This spec is documentation of
-shipped behavior — it MUST NOT diverge from that code; the code is the source of truth and any
-disagreement is a spec bug.**
+production-live coordinator trust signal that ships **unspecced**.
+
+**Source-of-truth discipline.** This is documentation of shipped behavior. The **code and
+migrations are authoritative**; this spec MUST byte-match them and any disagreement is a spec
+bug. The contract spans: the verifier (`phase4-coordinator/internal/stats/hardwareverify/verify.go`),
+migrations **007, 008, 015, 016, 017** (`phase4-coordinator/internal/stats/migrations/`), the
+HTTP enqueue path (`internal/onboarding/hardware_evidence.go`), the operator inventory
+writer/demotion (`cmd/stats-inventory-sync/main.go`), the runner
+(`cmd/stats-hardware-verifier/main.go`), and the exact-v2 downstream consumers
+(`internal/onboarding/hardware_evidence.go`, `internal/autotune/evidence_pg.go`). **Where §2
+summarizes DDL, the migration files are the byte-authoritative shape.**
 
 ---
 
@@ -22,106 +27,138 @@ disagreement is a spec bug.**
 
 ### 1.1 Purpose
 
-A provider's autotune run (SPEC-023) produces a signed-shape **hardware-evidence document**
-(`hardware_evidence.autotune.v1`) describing the provider's Apple-silicon chip, unified memory,
-OS/binary versions, a stable `hardware_identity_hash`, and a set of local model benchmarks. The
-provider submits it during onboarding; a row lands in `hardware_verification_jobs`. The
-**hardware-evidence verifier** is a coordinator-side **batch job** that reads pending jobs,
-runs a deterministic ordered gate pipeline over each evidence document, and transitions the job
-to **`verified`**, **`rejected`**, or the non-terminal **`waiting_trust`** state — promoting a
+A provider's autotune run (SPEC-023) produces a **hardware-evidence document**
+(`hardware_evidence.autotune.v1`) describing its Apple-silicon chip, unified memory, OS/binary
+versions, a stable `hardware_identity_hash`, and local model benchmarks. The provider binary
+submits it (§3.1); a row lands in `hardware_verification_jobs`. The **hardware-evidence
+verifier** is a coordinator-side **batch job** that reads pending jobs, runs a deterministic
+ordered gate pipeline over each evidence document, and transitions the job to **`verified`**,
+**`rejected`**, or the non-terminal **`waiting_trust`** — promoting a
 `provider_hardware_profiles.verified = TRUE` row on success.
 
-`provider_hardware_profiles.verified` is a downstream routing/tier input (SPEC-002 provider
-state; SPEC-032 admission gate). This spec defines **only** the verdict engine: what makes
-evidence verifiable, the decision-reason taxonomy, the job/profile state machine, and the
-security model that prevents a provider from self-certifying.
+### 1.2 What `verified` means and who consumes it
 
-### 1.2 In scope
+`provider_hardware_profiles.verified` is consumed by **SPEC-032's hardware-evidence admission
+lookup** (`internal/autotune/evidence_pg.go`), which requires a `verified = TRUE` profile joined
+to a `status='verified'` job carrying the **exact** `hardware-verifier.v2:verified_trusted_hardware`
+decision reason. It is **not** itself a SPEC-002 tier/routing input — SPEC-002 tiers derive from
+pinned config / unknown-id / rejection state, and SPEC-032 explicitly treats the hardware-evidence
+signal as **orthogonal** to the SPEC-002/SPEC-003 tiers. This spec defines the verdict engine and
+lifecycle; it does not define admission or tier weighting.
+
+### 1.3 In scope
 
 - The `hardware-verifier.v2` decision-reason taxonomy and the shipped success constant.
-- The ordered verification algorithm (`Evaluate`) and every reject/wait reason it can emit.
-- The job lifecycle state machine (`pending` / `waiting_trust` / `verified` / `rejected`).
-- The verified-profile promotion (upsert) semantics and monotonicity guard.
-- Batch/concurrency semantics (`FOR UPDATE SKIP LOCKED`, batch limit, single transaction).
-- Idempotency / replay resistance (`evidence_sha256` uniqueness).
-- The database security model: least-privilege roles and the profile-verification trigger.
-- The runner and its preflight `Smoke` contract.
+- The ordered verification algorithm (`Evaluate`) and every reject/wait reason.
+- The submission/enqueue path and its replay state machine (§3.1).
+- The job lifecycle state machine (`pending`/`waiting_trust`/`verified`/`rejected`).
+- Verified-profile promotion, the DB-enforced re-verification, and the monotonicity guard.
+- Batch/concurrency semantics; replay resistance (`evidence_sha256`).
+- The full DB security model: least-privilege **column-level** grants and the **two** guard
+  triggers; the operator-authority inventory-writer path; the post-verdict demotion lifecycle.
+- The runner, its `Smoke` preflight, and systemd scheduling.
+- The **exact-v2** downstream-consumer contract and legacy-`v1` grandfathering nuance.
 
-### 1.3 Out of scope
+### 1.4 Out of scope
 
-- **How the evidence is produced.** Autotune benchmark generation, chip detection, and the
-  `hardware_identity_hash` derivation are SPEC-023 / provider-binary concerns. This spec treats
-  the evidence document as an untrusted input to validate.
-- **How `verified` gates admission or tiers.** SPEC-032 (hello-gate) and SPEC-002 own that.
-- **The trust-root curation policy.** *How* an operator decides to insert a
-  `hardware_verification_trust` row (attestation review, manual vetting) is an operational
-  policy; this spec defines only how a trust row is *matched*.
-- **Proof-of-weights / OPoI / model-hash attestation.** Those are SPEC-032 / SPEC-008.
+- **Evidence production** (autotune benchmark generation, chip detection, `hardware_identity_hash`
+  derivation) — SPEC-023 / provider-binary.
+- **How `verified` gates admission / tiers** — SPEC-032 / SPEC-002.
+- **Trust-root curation policy** — *how* an operator decides to insert a
+  `hardware_verification_trust` row is operational policy; this spec defines only how a row is
+  *matched*.
+- **Benchmark authenticity.** The verifier does **not** prove benchmarks were executed on the
+  claimed device (§10.2). Proof-of-weights / OPoI / attestation are SPEC-032 / SPEC-008.
 
 ---
 
 ## 2. Data model
 
-Four tables (migrations `007_hardware_profiles`, `008_hardware_verification_jobs`) plus a
-verification-guard trigger.
+Four tables plus **two** guard triggers and least-privilege **column-level** grants. Migrations
+**007, 008, 015, 016, 017** are the byte-authoritative DDL; the tables below are a load-bearing
+summary — a reimplementation MUST read the migrations for exact column lists, `NOT NULL`/`DEFAULT`
+clauses, `CHECK` constraints, indexes, and grants.
 
-### 2.1 `hardware_verification_jobs` — the work queue
+### 2.1 `hardware_verification_jobs` — the work queue (migration 008)
 
-Columns (normative shape; `phase4-coordinator/internal/stats/migrations/008_hardware_verification_jobs.up.sql`):
+Columns include `id BIGSERIAL PK`, `provider_id`, `source CHECK (source IN ('autotune'))`,
+`status CHECK (... 'pending','waiting_trust','verified','rejected') DEFAULT 'pending'`, `chip`,
+`chip_normalized`, `unified_memory_gb CHECK (0..4096)`, `bandwidth_tier`, `os_version`,
+`binary_version` (all `NOT NULL DEFAULT ''`), `benchmark_count CHECK (0..64)`,
+`max_sustained_tps CHECK (>= 0)`, `generated_at`, `submitted_at DEFAULT now()`, `processed_at NULL`,
+`decision_reason NOT NULL DEFAULT ''`, `evidence JSONB NOT NULL`, and
+**`evidence_sha256 TEXT NOT NULL UNIQUE`** (replay guard). Indexes: a partial index on
+`status IN ('pending','waiting_trust')` (batch scan) and `(provider_id, submitted_at DESC)`.
 
-| Column | Type / constraint | Meaning |
-| --- | --- | --- |
-| `id` | `BIGSERIAL` PK | job id; processing order |
-| `provider_id` | `TEXT NOT NULL` | provider the evidence claims to be from |
-| `source` | `TEXT CHECK (source IN ('autotune'))` | only autotune-sourced jobs exist |
-| `status` | `TEXT CHECK (... 'pending','waiting_trust','verified','rejected') DEFAULT 'pending'` | job state |
-| `chip`, `chip_normalized` | `TEXT NOT NULL` | claimed chip + normalized form |
-| `unified_memory_gb` | `INT CHECK (0..4096)` | claimed unified memory |
-| `bandwidth_tier`, `os_version`, `binary_version` | `TEXT NOT NULL DEFAULT ''` | claimed metadata |
-| `benchmark_count` | `INT CHECK (0..64) DEFAULT 0` | summary count |
-| `max_sustained_tps` | `DOUBLE PRECISION CHECK (>= 0)` | summary metric |
-| `generated_at` | `TIMESTAMPTZ NOT NULL` | when the provider generated the evidence |
-| `submitted_at` | `TIMESTAMPTZ DEFAULT now()` | when the job was enqueued |
-| `processed_at` | `TIMESTAMPTZ NULL` | when the verifier decided |
-| `decision_reason` | `TEXT NOT NULL DEFAULT ''` | the emitted `hardware-verifier.v2:*` (or legacy) reason |
-| `evidence` | `JSONB NOT NULL` | the full evidence document |
-| `evidence_sha256` | `TEXT NOT NULL UNIQUE` | **replay guard** — a duplicate evidence document cannot enqueue twice |
+Note `benchmark_count` and `max_sustained_tps` are **persisted summary columns** the onboarding
+enqueue path fills from the evidence; the migration-016 trigger re-checks them at promotion (§7).
 
-Partial index on `status IN ('pending','waiting_trust')` supports the batch scan.
-
-### 2.2 `hardware_verification_trust` — operator-curated trust roots
+### 2.2 `hardware_verification_trust` — operator-curated trust roots (migration 008)
 
 `(provider_id, hardware_identity_hash)` PK, plus `chip_normalized`, `unified_memory_gb`,
-`trusted_by`, `trusted_at`, `expires_at NULL`, `notes`. A row asserts "this operator vouches
-that `hardware_identity_hash` for this provider is a genuine device with this chip + memory."
-`expires_at IS NULL` (or in the future) means active. **Only an operator/trust-curation role
-writes this table; the verifier only reads it.** This is the human-in-the-loop trust anchor
-that makes self-certification impossible (§10).
+`trusted_by`, `trusted_at`, `expires_at NULL`, `notes`. A row asserts an operator vouches that
+`hardware_identity_hash` for this provider is a genuine device with this chip + memory.
+`expires_at IS NULL` or in the future ⇒ active. Written only by the operator trust-curation role
+(`stats_trust_inventory_writer`); the verifier only reads it.
 
-### 2.3 `provider_hardware_profiles` — the verified output
+### 2.3 `provider_hardware_profiles` — the verified output (migration 007)
 
-`provider_id` PK, `chip`, `chip_normalized`, `unified_memory_gb`, `macos_version`,
-`app_version`, `source TEXT CHECK (source IN ('app_register','cli_hello','operator'))`,
-`verified BOOLEAN DEFAULT FALSE`, `last_reported_at`. A successful verdict upserts this row
-with `verified = TRUE`, `source = 'cli_hello'` (§7).
+`provider_id PK`, `chip`, `chip_normalized`, `unified_memory_gb CHECK (0..4096)`, `macos_version`,
+`app_version`, `source CHECK (source IN ('app_register','cli_hello','operator'))`,
+`verified BOOLEAN DEFAULT FALSE`, `last_reported_at`. A successful verdict upserts this row with
+`verified=TRUE`, `source='cli_hello'` (§7). Index on `chip_normalized`.
 
-### 2.4 `chip_hardware_profiles` — the known-chip catalog
+### 2.4 `chip_hardware_profiles` — the known-chip catalog (migration 007)
 
-`chip_normalized` PK plus physical characteristics (`memory_bandwidth_gb_per_s`,
-`network_power_kw`, `gpu_cores`, `cpu_cores`). A job's `chip_normalized` MUST have a row here
-or the job goes to `waiting_trust` (§5.5). Operator-curated.
+`chip_normalized PK`, `display_chip NOT NULL`, `memory_bandwidth_gb_per_s BIGINT CHECK (>=0)`,
+`network_power_kw DOUBLE PRECISION CHECK (>=0)`, `gpu_cores CHECK (>=0)`, `cpu_cores CHECK (>=0)`,
+`updated_at DEFAULT now()`. Operator-curated. A job's `chip_normalized` MUST have a row here or
+the job goes to `waiting_trust` (§5.5).
 
-### 2.5 Verification guard trigger
+### 2.5 Guard trigger A — `provider_hardware_profiles_guard_verification` (migration 016, supersedes 007)
 
-`provider_hardware_profiles_guard_verification` (a `BEFORE INSERT/UPDATE` trigger) is a
-**defense-in-depth** DB guard, independent of application code:
+A `BEFORE INSERT/UPDATE` trigger on `provider_hardware_profiles`. **Migration 016 replaces the
+migration-007 function** — 016 is authoritative:
 
-- Under role `provider_onboarding`: `verified` is forced to `FALSE` on insert, and forced back
-  to `FALSE` whenever `chip_normalized` changes; otherwise preserved. **A provider-onboarding
-  writer can never set `verified = TRUE`.**
-- Under role `stats_hardware_verifier` (the verifier): an `UPDATE` that moves
-  `last_reported_at` **backward** RAISES — enforcing timestamp monotonicity at the DB layer,
-  matching the application-level guard in §7.
+- Under role `provider_onboarding`: `verified` is forced `FALSE` on insert, and forced `FALSE`
+  whenever **`chip_normalized` OR `unified_memory_gb`** changes; otherwise preserved. A verified
+  profile is thus **anchored to (chip, memory)** — it survives an `os/app/identity` change but is
+  cleared on a chip- or memory-tuple change.
+- Under role `stats_hardware_verifier` (the verifier): (a) an `UPDATE` moving `last_reported_at`
+  **backward** RAISES; (b) `NEW.verified` MUST be `TRUE` ("may only promote"); (c) the trigger
+  **independently RE-VERIFIES in the database** that a matching fresh job + active trust row +
+  chip-profile row exists — the same `(provider_id, hardware_identity_hash, chip_normalized,
+  unified_memory_gb)` trust join, a `chip_hardware_profiles` match, `generated_at >= now()-7d`,
+  `status IN ('pending','waiting_trust')`, `benchmark_count > 0`, `max_sustained_tps > 0`,
+  non-empty identity hash, and an **exact profile-tuple binding** (`os_version=macos_version`,
+  `binary_version=app_version`, `generated_at=last_reported_at`) — else it RAISES. **The trust
+  gate is enforced twice: in `Evaluate` (§5.5) and again in the DB at write time.**
+- Other roles (e.g. `stats_inventory_writer`, §2.7) fall through to `RETURN NEW` — **not**
+  trigger-constrained.
+
+### 2.6 Guard trigger B — `hardware_verification_jobs_guard_verifier_update` (migration 008)
+
+A `BEFORE UPDATE` trigger on `hardware_verification_jobs`: under `stats_hardware_verifier`, an
+update whose `OLD.status` is **not** `pending`/`waiting_trust` RAISES ("may not update finalized
+jobs"), and `NEW.status` MUST be one of `waiting_trust`/`verified`/`rejected`. This is the
+DB-level counterpart of the application's terminal-safe `WHERE` (§6).
+
+### 2.7 Least-privilege roles and grants
+
+- **`stats_hardware_verifier`** (the verifier): `SELECT` on the jobs/trust/chip/profile tables;
+  `UPDATE` on the job status/decision columns; the promotion `INSERT/UPDATE` on
+  `provider_hardware_profiles` — all gated by triggers A/B. `NOLOGIN`.
+- **`provider_onboarding`** (the enqueue path): **column-level** `INSERT` on the job columns
+  (including `status`, but the shipped enqueue always inserts `pending`) and **column-limited
+  `SELECT`** (`id, provider_id, status, submitted_at, evidence_sha256, decision_reason`, and —
+  migration 017 — `provider_id, chip_normalized, unified_memory_gb, verified` on profiles). It has
+  **no `verified` write grant** and trigger A forces `verified=FALSE` regardless: **onboarding can
+  never self-promote.** (A compromised onboarding SQL role could insert a job with a terminal
+  `status`, but that cannot set a profile's `verified` bit — §10.1.)
+- **`stats_inventory_writer`** (operator inventory sync, §7.3): full `INSERT/UPDATE` on
+  `provider_hardware_profiles` **including `verified`**, and **not** constrained by trigger A. This
+  is an **operator-authority** path, not a provider-reachable one (§10.1).
+- **`stats_trust_inventory_writer`**: writes `hardware_verification_trust` (the trust roots).
 
 ---
 
@@ -145,114 +182,113 @@ hardware {
 candidate_catalog_sha256 string    // lowercase hex SHA-256
 recommended_model        string
 benchmarks []{
-  model_key                 string
-  model_id                  string
-  sustained_tps             float64
-  ttft_ms                   int
-  swap_detected             bool
-  thermal_throttle_detected bool
-  artifact_sha256           string  // lowercase hex SHA-256
-  candidate_catalog_sha256  string
-  benchmark_id              string  // optional
-  generated_at              string  // RFC3339
-  binary_version            string
-  hardware_identity_hash    string
+  model_key, model_id                  string
+  sustained_tps                        float64
+  ttft_ms                              int
+  swap_detected, thermal_throttle_detected bool
+  artifact_sha256, candidate_catalog_sha256 string
+  benchmark_id                         string  // optional
+  generated_at                         string  // RFC3339
+  binary_version, hardware_identity_hash string
 }
 ```
 
-A **lowercase hex SHA-256** is exactly 64 characters, each in `[0-9a-f]` (`isLowerSHA256`).
-Uppercase, wrong length, or non-hex fails the relevant gate.
+A **lowercase hex SHA-256** is exactly 64 chars in `[0-9a-f]` (`isLowerSHA256`).
+
+### 3.1 Submission and replay (enqueue path)
+
+The provider binary POSTs the envelope to **`POST /v1/providers/hardware-evidence`** with its
+authenticated bearer identity; the handler (`HandleHardwareEvidence`) binds the job to the
+**authenticated** `provider_id` (a provider cannot enqueue for another provider). The handler:
+
+- computes a **canonical** SHA-256 of the evidence (`canonicalEvidenceSHA`) → `evidence_sha256`;
+- **rate-limits**: if a recent job for this provider exists within a 10-minute window, returns
+  HTTP `429` with `Retry-After: 600`;
+- inserts a `pending` job (unique on `evidence_sha256`);
+- returns a **replay state machine** result (`hardwareEvidenceResponseStatus`), which is
+  **fail-closed**: a duplicate is accepted (2xx) **only** while `pending`, while `waiting_trust`,
+  or when already `verified` **with `decision_reason == hardware-verifier.v2:verified_trusted_hardware`
+  exactly**. Every other finalized/unknown/legacy state (`rejected`, `v1:verified`, …) returns
+  HTTP `409` `evidence_replay_not_accepted` — a rejected or legacy decision cannot be laundered
+  through a 2xx replay; new evidence must be resubmitted.
 
 ---
 
-## 4. Decision constants and versioning
+## 4. Decision constants, versioning, and downstream acceptance
 
 - **Verifier version:** `hardware-verifier.v2` (`verifierDecisionVersion`).
 - **Evidence schema version:** `hardware_evidence.autotune.v1` (`evidenceSchemaVersion`).
-- **Success constant:** `hardware-verifier.v2:verified_trusted_hardware`
-  (`VerifiedDecisionReason`). This is the exported constant other components match on.
-- **Reject/wait reasons** are persisted as `hardware-verifier.v2:<reason>` — the verifier
-  prefixes the bare reason with the version at write time in `rejectJob` / `waitTrustJob`
-  (e.g. `hardware-verifier.v2:chip_mismatch`, `hardware-verifier.v2:trust_missing`). The
-  `Evaluate` function returns the bare reason; only the success path returns the
-  already-prefixed `VerifiedDecisionReason`.
-- **Legacy `hardware-verifier.v1:verified`** rows predate this version and MUST be treated as
-  terminal `verified` (grandfathered): the verifier only scans `pending`/`waiting_trust`, so a
-  legacy `verified` row is never re-evaluated, and downstream consumers treat any
-  `status = 'verified'` row as verified regardless of version prefix.
+- **Success constant:** `hardware-verifier.v2:verified_trusted_hardware` (`VerifiedDecisionReason`).
+- **Reject/wait reasons** are persisted as `hardware-verifier.v2:<bare reason>` —
+  `rejectJob`/`waitTrustJob` prefix the version at write time (e.g.
+  `hardware-verifier.v2:chip_mismatch`, `hardware-verifier.v2:missing_trusted_hardware_identity`,
+  `hardware-verifier.v2:missing_trusted_chip_profile`). `Evaluate` returns the bare reason; only
+  success returns the pre-prefixed `VerifiedDecisionReason`.
 
-> **Naming note (the drift this spec closes).** The shipped success constant is
-> `hardware-verifier.v2:verified_trusted_hardware`, **not** a `v1` reason. Earlier drift
-> assumed a `v1` verifier; the live constant is `v2`. This spec is authoritative on the `v2`
-> taxonomy.
+**Legacy `hardware-verifier.v1:verified` and downstream acceptance.** The *verifier* grandfathers
+legacy terminal rows only in the sense that it scans **only** `pending`/`waiting_trust`, so a
+legacy `verified` row is never re-evaluated. **Downstream consumers do NOT accept arbitrary
+`status='verified'` rows** — they require the **exact** current v2 reason:
+
+- onboarding replay accepts a `verified` job only when `decision_reason == VerifiedDecisionReason`
+  (`hardware_evidence.go`; its test rejects `hardware-verifier.v1:verified`);
+- SPEC-032's evidence lookup filters on `decision_reason = VerifiedDecisionReason`
+  (`internal/autotune/evidence_pg.go`).
+
+So a legacy `v1:verified` row is terminal and unscanned, but is **not** treated as a *current
+trusted verdict* by downstream consumers; only the exact v2 reason is.
+
+> **Naming drift closed.** The live success constant is `hardware-verifier.v2:verified_trusted_hardware`
+> (v2, not v1). Earlier drift assumed a `v1` verifier.
 
 ---
 
 ## 5. Verification algorithm (`Evaluate`)
 
 `Evaluate(job)` runs `evaluateAt(job, now)` with `now = time.Now().UTC()`. It is a
-**deterministic, ordered, short-circuit** gate pipeline: the **first** failing gate wins and
-its reason is returned; only a job that passes every gate returns
-`{Verified: true, Reason: VerifiedDecisionReason}`. The order below is normative — a
-reimplementation MUST emit the same reason for the same first-failing condition.
-
-Time bounds: `maxEvidenceAge = 7 * 24h`; `futureSkew = 5m`. A timestamp `t` is **stale** if
-`t < now - maxEvidenceAge`, and **future-skewed** if `t > now + futureSkew`; either is a
-failure on the relevant gate.
+**deterministic, ordered, short-circuit** gate pipeline: the **first** failing gate wins; only a
+job passing every gate returns `{Verified: true, Reason: VerifiedDecisionReason}`. Order is
+normative. Time bounds: `maxEvidenceAge = 7*24h`; `futureSkew = 5m`; `t` is **stale** if
+`t < now - maxEvidenceAge` and **future-skewed** if `t > now + futureSkew`.
 
 ### 5.1 Job-envelope gates (reject)
 
-In order: `missing_provider_id` (blank `provider_id`); `stale_job` (`job.generated_at`
-out of the age/skew window); `memory_out_of_range` (`job.unified_memory_gb < 8` or `> 4096`);
-`missing_evidence` (empty `evidence`); `invalid_evidence_json` (JSON decode fails).
-
-> Note the verifier's `>= 8` GB floor is stricter than the table's `>= 0` CHECK — the DB
-> accepts smaller values but the verifier rejects them.
+`missing_provider_id`; `stale_job` (`job.generated_at` out of window); `memory_out_of_range`
+(`job.unified_memory_gb < 8` or `> 4096` — the verifier's `>= 8` floor is **stricter** than the
+table's `>= 0` CHECK); `missing_evidence`; `invalid_evidence_json`.
 
 ### 5.2 Evidence-consistency gates (reject)
 
-`schema_version_mismatch` (`schema_version != hardware_evidence.autotune.v1`);
-`provider_id_mismatch` (`evidence.provider_id != job.provider_id`);
-`invalid_evidence_generated_at` (not RFC3339); `evidence_generated_at_mismatch`
-(`evidence.generated_at` not **exactly equal** to `job.generated_at`); `stale_evidence`
-(evidence timestamp out of window).
+`schema_version_mismatch`; `provider_id_mismatch`; `invalid_evidence_generated_at`;
+`evidence_generated_at_mismatch` (evidence timestamp not **exactly equal** to `job.generated_at`);
+`stale_evidence`.
 
 ### 5.3 Hardware-claim cross-check gates (reject)
 
-The evidence's self-described hardware MUST match the job columns the onboarding path already
-recorded: `chip_mismatch` (`normalizeChip(evidence.hardware.chip) != job.chip_normalized`,
-where `normalizeChip` lowercases, trims, and collapses internal whitespace);
-`memory_mismatch`; `bandwidth_tier_mismatch` (case-insensitive, trimmed);
-`os_version_mismatch` (trimmed, exact); `binary_version_mismatch` (trimmed, exact);
-`invalid_hardware_identity_hash` (not lowercase-hex SHA-256);
-`invalid_candidate_catalog_sha256`.
+`chip_mismatch` (`normalizeChip(evidence.hardware.chip) != job.chip_normalized`; `normalizeChip`
+lowercases, trims, collapses internal whitespace); `memory_mismatch`; `bandwidth_tier_mismatch`
+(case-insensitive, trimmed); `os_version_mismatch` (trimmed exact); `binary_version_mismatch`
+(trimmed exact); `invalid_hardware_identity_hash`; `invalid_candidate_catalog_sha256`.
 
 ### 5.4 Benchmark gates (reject)
 
-`missing_benchmarks` (empty list). Then, per benchmark, in list order:
-`missing_benchmark_model_binding` (blank `model_key` or `model_id`);
-`duplicate_benchmark_model_key` (a `model_key` seen earlier in the same document);
-`invalid_benchmark_artifact_sha256`; `benchmark_catalog_mismatch`
-(`benchmark.candidate_catalog_sha256 != evidence.candidate_catalog_sha256`);
-`benchmark_binary_version_mismatch` (`!= evidence.hardware.binary_version`);
-`benchmark_hardware_identity_mismatch` (`!= evidence.hardware.hardware_identity_hash`);
-`invalid_benchmark_generated_at`; `stale_benchmark`; `invalid_benchmark_tps` (NaN, ±Inf, or
-`<= 0`); `invalid_benchmark_ttft` (`<= 0`). After the loop: `missing_positive_benchmark` (no
-benchmark has a finite `sustained_tps > 0`) and `missing_chip_normalized` (blank
-`job.chip_normalized`).
+`missing_benchmarks`. Then per benchmark, in list order: `missing_benchmark_model_binding` (blank
+`model_key` or `model_id`); `duplicate_benchmark_model_key` (a `strings.TrimSpace(model_key)` seen
+earlier in the same document — so `"m"` and `" m "` collide); `invalid_benchmark_artifact_sha256`;
+`benchmark_catalog_mismatch`; `benchmark_binary_version_mismatch`;
+`benchmark_hardware_identity_mismatch`; `invalid_benchmark_generated_at`; `stale_benchmark`;
+`invalid_benchmark_tps` (NaN/±Inf/`<= 0`); `invalid_benchmark_ttft` (`<= 0`). After the loop:
+`missing_positive_benchmark`; `missing_chip_normalized`.
 
 ### 5.5 Trust gates (→ `waiting_trust`, NOT reject)
-
-The final two gates are **trust-anchor** checks. They do **not** reject; they return a reason
-the caller routes to the non-terminal `waiting_trust` state (§6):
 
 - `missing_trusted_hardware_identity` — no active `hardware_verification_trust` row matches
   `(provider_id, hardware_identity_hash, chip_normalized, unified_memory_gb)` with
   `expires_at IS NULL OR expires_at > now()`.
 - `missing_trusted_chip_profile` — no `chip_hardware_profiles` row for this `chip_normalized`.
 
-(The two `EXISTS` sub-queries are computed in the batch SELECT as `trust_matched` /
-`chip_profile_matched` and read by `Evaluate` as `job.TrustMatched` / `job.ChipProfileMatched`.)
+(Computed in the batch SELECT as `trust_matched`/`chip_profile_matched`, read as
+`job.TrustMatched`/`job.ChipProfileMatched`.)
 
 ### 5.6 Success
 
@@ -262,157 +298,208 @@ Passing every gate returns `hardware-verifier.v2:verified_trusted_hardware`.
 
 ## 6. Job lifecycle state machine
 
-```
-                submit (onboarding)
-                      │
-                      ▼
-                  ┌────────┐   trust/chip-profile absent    ┌───────────────┐
-                  │pending │ ─────────────────────────────▶ │ waiting_trust │
-                  └───┬────┘                                └──────┬────────┘
-        reject gate │  │ all gates pass          all gates pass /  │ trust/chip
-                    │  │                          reject gate hits  │ still absent
-                    ▼  ▼                                            │ (re-scanned)
-              ┌──────────┐        ┌──────────┐                      │
-              │ rejected │        │ verified │◀─────────────────────┘
-              └──────────┘        └──────────┘
-```
-
 - The batch scan selects `status IN ('pending','waiting_trust')`. **`waiting_trust` is
-  non-terminal**: a job parked there is re-evaluated on every subsequent run, so once an
-  operator later inserts the missing `hardware_verification_trust` or `chip_hardware_profiles`
-  row, the same job promotes to `verified` without re-submission.
-- `verified` and `rejected` are **terminal** (never re-scanned).
-- A `waiting_trust` job that later hits a **reject** gate (e.g. its evidence has since gone
-  stale) transitions to `rejected` — the age gates are evaluated against the *current* `now`.
-- All three transitions set `processed_at = now()` and `decision_reason`, and are guarded by
-  `WHERE id = $1 AND status IN ('pending','waiting_trust')` so a concurrently-terminalized job
-  is not overwritten.
+  non-terminal**: it is re-evaluated on every run, so once an operator later inserts the missing
+  trust or chip-profile row, the same job promotes without re-submission.
+- `verified` and `rejected` are terminal (never re-scanned). Trigger B (§2.6) forbids the verifier
+  from reopening them at the DB layer.
+- A `waiting_trust` job that later hits a **reject** gate (e.g. its evidence has since gone stale
+  — the age gates use the *current* `now`) transitions to `rejected`.
+- All transitions set `processed_at = now()` + `decision_reason`, guarded by
+  `WHERE id = $1 AND status IN ('pending','waiting_trust')` (terminal-safe; mirrored by trigger B).
 
 ---
 
-## 7. Verified-profile promotion
+## 7. Verified-profile promotion and demotion
 
-On a `verified` verdict, `promoteJob` upserts `provider_hardware_profiles`:
+### 7.1 Promotion (`promoteJob`)
 
-- `INSERT ... VALUES (provider_id, chip, chip_normalized, unified_memory_gb, os_version→macos_version, binary_version→app_version, source='cli_hello', verified=TRUE, generated_at→last_reported_at)`.
-- `ON CONFLICT (provider_id) DO UPDATE SET ... verified = TRUE, last_reported_at = EXCLUDED.last_reported_at` **only** `WHERE provider_hardware_profiles.last_reported_at <= EXCLUDED.last_reported_at` — a **monotonicity guard**: an older evidence document can never overwrite a newer verified profile (and the §2.5 trigger enforces the same invariant at the DB layer under the verifier role).
-- The job row is then set to `status='verified'`, guarded by the same terminal-safe `WHERE`.
+On a `verified` verdict, `promoteJob` upserts `provider_hardware_profiles` with `source='cli_hello'`,
+`verified=TRUE`, `last_reported_at = evidence.generated_at`, `ON CONFLICT (provider_id) DO UPDATE
+... verified=TRUE` **only** `WHERE provider_hardware_profiles.last_reported_at <= EXCLUDED.last_reported_at`
+(monotonicity guard). Trigger A (§2.5) independently re-verifies the trust join and RAISES if it
+does not hold — so a promotion that passed `Evaluate` but whose **persisted** `benchmark_count`/
+`max_sustained_tps`/tuple disagree with the trigger's checks **RAISES and rolls the whole batch
+back** rather than promoting. The job row is then set `status='verified'` in the **same
+transaction**.
 
-Both writes happen in the **same transaction** as the scan (§8), so a profile promotion and its
-job terminalization commit atomically.
+### 7.2 No-op upsert
+
+If a **newer** profile already exists (`last_reported_at > EXCLUDED`), the conflict `UPDATE`
+matches **zero rows** — the existing (newer) profile is left intact — yet the job is still marked
+`verified`. So a `verified` verdict does **not** unconditionally rewrite the profile; it promotes
+**iff** no newer profile blocks it (§12 AC-HV-1).
+
+### 7.3 Post-verdict demotion (operator inventory sync)
+
+`provider_hardware_profiles.verified` is not permanent. The operator inventory sync
+(`cmd/stats-inventory-sync`, role `stats_inventory_writer`) runs `applyTrustDemotions`, which sets
+`verified = FALSE` for every `source='cli_hello'` profile that **no longer** has a matching active
+trust row (trust removed or `expires_at` passed). So **removing/expiring a trust root demotes the
+previously-verified providers** on the next sync. The same tool also directly upserts operator
+profiles (`source='operator'`, `verified` from an operator-authored YAML) — an operator-authority
+write path outside the evidence pipeline (§10.1).
 
 ---
 
 ## 8. Concurrency and batching
 
-- `ProcessPending(ctx, limit)` opens **one transaction**, scans up to `limit` (default 100)
-  jobs `ORDER BY id` with **`FOR UPDATE SKIP LOCKED`**, decides each, applies the writes, and
-  commits once. `SKIP LOCKED` lets multiple verifier instances run concurrently without
-  contending on the same jobs.
-- The scan and all decision writes share the transaction; a failure at any job rolls the whole
-  batch back (`defer tx.Rollback()`), so a batch is all-or-nothing.
-- `Processed{Verified, Rejected, Waiting}` counts the batch outcome for the runner to log.
+`ProcessPending(ctx, limit)` opens **one transaction**, scans up to `limit` (default 100) jobs
+`ORDER BY id` with **`FOR UPDATE SKIP LOCKED`**, decides each, applies the writes, commits once.
+`SKIP LOCKED` lets multiple instances run concurrently without contending; a failure at any job
+rolls the whole batch back (`defer tx.Rollback()`). `Processed{Verified, Rejected, Waiting}` is
+the batch tally.
 
 ---
 
 ## 9. Idempotency and replay resistance
 
-- `hardware_verification_jobs.evidence_sha256` is `UNIQUE`. The onboarding submit path keys on
-  the evidence hash, so the **same evidence document cannot enqueue two jobs** — a replayed
-  submission collides on the unique constraint. Verification is therefore evaluated at most
-  once per distinct evidence document.
-- The verifier itself is naturally idempotent: terminal states are never re-scanned, and the
-  terminal-safe `WHERE status IN ('pending','waiting_trust')` on every write means a
-  double-processed job (e.g. across a crash/retry) cannot double-promote.
+- `evidence_sha256` is `UNIQUE` and computed by a **canonical** hash (`canonicalEvidenceSHA`); the
+  enqueue path keys on it, so the **same evidence document creates at most one queue row** — a
+  replay collides and is routed through the fail-closed replay state machine (§3.1).
+- **One queue row does NOT mean one evaluation.** A `waiting_trust` job is re-`Evaluate`d on every
+  batch run until it reaches a terminal state; this is by design (§6). Idempotency is preserved by
+  the terminal-safe write `WHERE` + trigger B: a job cannot double-promote or be reopened.
+- Net: **exactly one queue row per distinct document; exactly one *terminal verdict* committed;
+  possibly many interim `waiting_trust` evaluations.**
 
 ---
 
-## 10. Security model — why a provider cannot self-certify
+## 10. Security model — precise guarantees and non-guarantees
 
-Verification trust does **not** come from the evidence being well-formed; a provider fully
-controls its own evidence document. Trust comes from **operator-curated anchors** the provider
-cannot write:
+### 10.1 A provider cannot self-certify (holds)
 
-1. **Trust-root gate (§5.5).** `verified` requires a matching active
-   `hardware_verification_trust` row keyed on `(provider_id, hardware_identity_hash,
-   chip_normalized, unified_memory_gb)`. Only an operator/trust-curation role writes that
-   table. Absent a trust row, the best a provider can reach is `waiting_trust` — never
-   `verified`.
-2. **Known-chip gate (§5.5).** The `chip_normalized` must exist in the operator-curated
-   `chip_hardware_profiles` catalog.
-3. **DB least-privilege + trigger (§2.5).** The verifier runs as `stats_hardware_verifier`; the
-   onboarding submitter runs as `provider_onboarding`. The
-   `provider_hardware_profiles_guard_verification` trigger **forces `verified = FALSE`** for any
-   write by `provider_onboarding` and forbids the verifier from moving `last_reported_at`
-   backward. Even a SQL-injection or logic bug in the onboarding path cannot set
-   `verified = TRUE`; only the verifier role, going through `promoteJob`, can — and only after
-   the trust gates pass.
-4. **Evidence self-consistency (§5.2–5.4)** binds every benchmark to the same
-   `hardware_identity_hash`, `binary_version`, and `candidate_catalog_sha256`, so a provider
-   cannot splice a trusted device's identity onto another device's benchmarks within one
-   document.
+No provider-reachable path sets `provider_hardware_profiles.verified = TRUE`:
 
-The security property is: **`verified` ⟺ (well-formed self-consistent fresh evidence) ∧
-(operator-anchored trust for this exact identity+chip+memory)**. The provider supplies the
-former; only an operator supplies the latter.
+- The only provider-reachable write path is the authenticated enqueue (§3.1), which runs as
+  `provider_onboarding` — a role with **no `verified` write grant**, and trigger A forces
+  `verified=FALSE` for it regardless (§2.5, §2.7). The worst a compromised onboarding SQL role can
+  do is insert a job row with a terminal `status`; it still cannot flip a profile's `verified` bit.
+- `verified=TRUE` is writable by exactly **two** roles, **neither provider-reachable**:
+  (1) `stats_hardware_verifier`, only via `promoteJob` **and** only if the trust join passes both
+  in `Evaluate` (§5.5) and in the DB trigger (§2.5); (2) `stats_inventory_writer`, an
+  **operator-authority** path syncing an operator-authored YAML (`source='operator'`), the same
+  trust level as curating a trust row.
+
+So: **a provider without an operator-curated trust row can reach at best `waiting_trust`, never
+`verified`.** This is the load-bearing property and it holds.
+
+### 10.2 What `verified` does NOT prove (non-guarantees — do not overstate)
+
+- **Not benchmark authenticity / not anti-splicing.** The verifier does **no** signature,
+  proof-of-possession, or artifact verification: `artifact_sha256` is only *shape*-checked (64 hex),
+  and the per-benchmark identity/version/catalog checks are **string-equality** consistency checks
+  over provider-controlled fields. A provider that legitimately holds a trusted
+  `hardware_identity_hash` can attach that value **consistently** to fabricated or another-device
+  benchmark numbers; nothing binds the benchmarks to execution on the physical device. The
+  guarantee is **string-level self-consistency + an operator trust anchor**, not proof the
+  benchmarks ran on that hardware.
+- **Cross-provider borrow is blocked, self-fabrication is not.** The trust match keys on
+  `provider_id`, and the enqueue binds `provider_id` to the authenticated bearer, so a provider
+  cannot match **another** provider's trust row. It can, however, fabricate benchmark numbers for
+  **its own** trusted identity.
+- **`verified` is (chip, memory)-anchored, not identity-anchored, and not permanent.** Trigger A
+  clears `verified` only on a chip/memory change, so a previously-verified provider can change its
+  `hardware_identity_hash` (or move to another same-chip/same-memory device) and **retain**
+  `verified` until a chip/memory change or a §7.3 demotion. The verified bit is a
+  standing (chip, memory) capacity assertion, revocable by trust removal.
+
+### 10.3 Defense in depth (the trust gate is enforced twice)
+
+The trust/chip/freshness match is checked in **application code** (`Evaluate`, §5.5) **and again
+in the database** (trigger A re-runs the full join at write time, §2.5). A logic bug that let
+`Evaluate` pass a bad job would still be caught by the DB trigger, which RAISES and rolls back.
+Trigger B (§2.6) additionally prevents the verifier from reopening finalized jobs or moving them to
+an out-of-band status.
 
 ---
 
 ## 11. Runner and operations
 
-- **Binary:** `phase4-coordinator/cmd/stats-hardware-verifier/main.go` — opens the store with a
-  DSN, runs `Smoke`, then `ProcessPending`, and prints
-  `stats-hardware-verifier: verified=<n> rejected=<n> waiting=<n>`.
-- **`Smoke(ctx)` preflight** MUST pass before processing: it asserts `current_user =
-  'stats_hardware_verifier'` (fail-closed on a mis-provisioned DSN) and that the four tables
-  (`hardware_verification_jobs`, `hardware_verification_trust`, `provider_hardware_profiles`,
-  `chip_hardware_profiles`) are readable. A `Smoke` failure MUST abort the run before any job
-  is touched.
-- **Connection pool:** capped small (`MaxOpenConns=2`, `MaxIdleConns=1`) — this is a periodic
-  batch worker, not a hot-path service.
-- **Scheduling** is operational (a periodic invocation of the binary). Because `waiting_trust`
-  is non-terminal and re-scanned, a provider verified only after an operator adds a trust row
-  is promoted by the next scheduled run with no provider action.
+- **Binary:** `cmd/stats-hardware-verifier/main.go` — opens the store, runs `Smoke`, then
+  `ProcessPending`, prints `stats-hardware-verifier: verified=<n> rejected=<n> waiting=<n>`.
+- **`Smoke(ctx)` preflight** MUST pass before processing: asserts `current_user =
+  'stats_hardware_verifier'` (fail-closed on a mis-provisioned DSN) and that the four tables are
+  readable. A `Smoke` failure MUST abort before any job is touched.
+- **Pool:** `MaxOpenConns=2`, `MaxIdleConns=1` — a periodic batch worker, not a hot-path service.
+- **Scheduling (shipped):** a systemd **oneshot** service (`stats-hardware-verifier.service`,
+  `Type=oneshot`, `ConditionPathExists=/etc/macprovider-stats/stats-hardware-verifier.env`, hardened
+  with `ProtectSystem=strict`/`NoNewPrivileges`/`PrivateTmp`) driven by a **timer**
+  (`stats-hardware-verifier.timer`: `OnBootSec=2min`, `OnUnitActiveSec=1min`) — i.e. it runs ~1
+  minute after each prior activation. Because `waiting_trust` is non-terminal, a provider verified
+  only after an operator adds a trust row is promoted by the next timer firing with no provider
+  action.
 
 ---
 
 ## 12. Acceptance criteria
 
-- **AC-HV-1 (success constant).** A job with well-formed, self-consistent, fresh evidence whose
+- **AC-HV-1 (success + monotonic promotion).** A job whose evidence passes every §5 gate and whose
   `(provider_id, hardware_identity_hash, chip_normalized, unified_memory_gb)` matches an active
-  trust row and whose `chip_normalized` is in `chip_hardware_profiles` MUST become `verified`
-  with `decision_reason = 'hardware-verifier.v2:verified_trusted_hardware'` and MUST upsert
-  `provider_hardware_profiles.verified = TRUE`.
+  trust row (and a chip profile) MUST become `status='verified'` with
+  `decision_reason='hardware-verifier.v2:verified_trusted_hardware'`. It MUST upsert
+  `provider_hardware_profiles.verified=TRUE` **when no newer profile exists**; when a newer profile
+  exists the conflict update is a **no-op** (existing newer profile retained) and the job is still
+  marked verified (§7.2). The migration-016 trigger MUST independently re-verify the trust join and
+  MUST roll the batch back if it does not hold (§2.5, §7.1).
 - **AC-HV-2 (ordered reasons).** For each gate in §5, a job failing exactly that gate first MUST
-  persist `decision_reason = 'hardware-verifier.v2:<that reason>'`. Gate order is normative.
-- **AC-HV-3 (waiting is non-terminal).** A job missing only a trust row or chip profile MUST
-  become `waiting_trust` (not `rejected`), and MUST promote to `verified` on a later run once
-  the missing operator-curated row exists — with no re-submission.
-- **AC-HV-4 (no self-certification).** No write by `provider_onboarding` may set
-  `provider_hardware_profiles.verified = TRUE` (trigger-enforced); a provider without a trust
-  row MUST NOT reach `verified`.
-- **AC-HV-5 (monotonic promotion).** An older evidence document MUST NOT overwrite a newer
-  verified profile (`last_reported_at` guard, application + trigger).
-- **AC-HV-6 (replay).** Two submissions of the same evidence document MUST NOT create two jobs
-  (`evidence_sha256` UNIQUE); verification is evaluated at most once per distinct document.
+  persist `decision_reason='hardware-verifier.v2:<that reason>'`. Gate order is normative.
+- **AC-HV-3 (waiting is non-terminal).** A job missing only a trust row or chip profile MUST become
+  `waiting_trust` (not `rejected`) and MUST promote on a later run once the operator-curated row
+  exists — no re-submission.
+- **AC-HV-4 (no self-certification of the profile bit).** No `provider_onboarding` write may set
+  `provider_hardware_profiles.verified=TRUE` (no grant + trigger A). This is a statement about the
+  **profile verified bit**, independent of job `status` (a compromised onboarding role could insert
+  a terminal-status job but still cannot flip the profile bit).
+- **AC-HV-5 (monotonic timestamp).** An older evidence document MUST NOT overwrite a newer verified
+  profile (`last_reported_at` guard, application + trigger A).
+- **AC-HV-6 (replay = one row, one verdict).** Two submissions of the same document MUST NOT create
+  two jobs (`evidence_sha256` UNIQUE); a terminal **verdict** is committed at most once; a
+  `waiting_trust` job MAY be evaluated on many runs. HTTP replay MUST be fail-closed: only
+  `pending`/`waiting_trust`/exact-v2-`verified` yield a 2xx (§3.1).
 - **AC-HV-7 (batch isolation).** Concurrent verifier instances MUST NOT double-process a job
-  (`FOR UPDATE SKIP LOCKED` + terminal-safe write `WHERE`).
-- **AC-HV-8 (Smoke fail-closed).** A run whose `Smoke` preflight fails (wrong DB role or an
-  unreadable table) MUST abort before touching any job.
-- **AC-HV-9 (legacy grandfathering).** A `hardware-verifier.v1:verified` row MUST remain
-  terminal-`verified` and MUST NOT be re-evaluated.
+  (`FOR UPDATE SKIP LOCKED` + terminal-safe write `WHERE` + trigger B).
+- **AC-HV-8 (Smoke fail-closed).** A run whose `Smoke` preflight fails MUST abort before touching
+  any job.
+- **AC-HV-9 (legacy grandfathering + exact-v2 downstream).** A `hardware-verifier.v1:verified` row
+  MUST remain terminal and MUST NOT be re-evaluated by the verifier; **downstream consumers MUST
+  accept only the exact `hardware-verifier.v2:verified_trusted_hardware` reason** as a current
+  trusted verdict (§4), so a legacy row is not honored downstream.
+- **AC-HV-10 (demotion).** Removing or expiring a `hardware_verification_trust` row MUST demote the
+  affected `source='cli_hello'` profiles to `verified=FALSE` on the next inventory sync (§7.3).
+- **AC-HV-11 (chip/memory re-verification).** A `provider_onboarding` update that changes
+  `chip_normalized` or `unified_memory_gb` MUST clear `verified` (trigger A).
 
 ---
 
 ## Change log
 
-**v0.1-draft (2026-07-12) — reconstructed baseline (runbook item 10).**
-- First canonical spec for the shipped `hardware-verifier.v2` evidence verifier
-  (`phase4-coordinator/internal/stats/hardwareverify/verify.go`). Documents the decision-reason
-  taxonomy, the ordered gate pipeline, the `pending`/`waiting_trust`/`verified`/`rejected` state
-  machine, promotion + monotonicity, batch/concurrency, `evidence_sha256` replay resistance, and
-  the least-privilege + trigger security model that makes provider self-certification impossible.
-- Closes the naming drift: the live success constant is
-  `hardware-verifier.v2:verified_trusted_hardware` (v2, not v1); legacy `v1:verified` rows are
-  grandfathered.
-- Spec-only, no code change: the code is the source of truth and this document byte-matches it.
+**v0.2-draft (2026-07-12) — audit reconciliation (SPEC-033 R1, 3-lane codex).**
+Round-1 audit confirmed §3/§4-constants/§5-gate-orders/§6/§8/§11-runner accurate, and corrected an
+**under-scoping**: the reconstruction had followed `verify.go` + migrations 007/008 only. v0.2
+expands to the full shipped contract:
+- **§2 rewritten**: migration **016** trigger (supersedes 007) with in-DB trust re-verification and
+  chip-**or-memory** de-verification; the migration-**008** finalized-job guard trigger (previously
+  omitted); column-level grants; the `stats_inventory_writer` operator-authority role.
+- **§3.1 added**: the authenticated `POST /v1/providers/hardware-evidence` enqueue path, canonical
+  `evidence_sha256`, 10-minute rate limit, and the fail-closed replay state machine.
+- **§4 corrected**: downstream consumers require the **exact** v2 reason (onboarding replay +
+  SPEC-032 `evidence_pg.go`) — legacy `v1:verified` is terminal but not a current trusted verdict
+  downstream; fixed a non-existent `trust_missing` example to the real
+  `missing_trusted_hardware_identity` / `missing_trusted_chip_profile`.
+- **§7 expanded**: the no-op-upsert outcome, the DB re-verification raise-on-mismatch, and the
+  post-verdict **demotion** lifecycle (`applyTrustDemotions`).
+- **§9 corrected**: one queue row ≠ one evaluation (`waiting_trust` re-evaluated).
+- **§10 rewritten**: precise guarantees — a provider cannot self-certify (holds), but `verified` is
+  **not** benchmark-authenticity/anti-splice (string-consistency + operator anchor only), is
+  (chip, memory)-anchored (not identity-anchored) and revocable; two `verified` writers exist
+  (verifier + operator inventory); defense-in-depth (trust gate enforced twice).
+- **§1 boundary corrected**: `verified` is consumed by SPEC-032's admission lookup, not a direct
+  SPEC-002 tier input; producer is the HTTP endpoint, SPEC-023 owns evidence content.
+- **§11 scheduling**: systemd oneshot + timer (not "periodic invocation").
+- **§12**: fixed AC-HV-1 (no-op/monotonic + DB re-verify), AC-HV-4 (profile bit vs job status),
+  AC-HV-6 (one row/one verdict), AC-HV-9 (exact-v2 downstream); added AC-HV-10 (demotion) and
+  AC-HV-11 (chip/memory re-verification).
+
+**v0.1-draft (2026-07-12) — reconstructed baseline (runbook item 10).** First canonical spec for
+the shipped `hardware-verifier.v2` verifier; superseded by v0.2 above.

--- a/specs/SPEC-033-hardware-verifier.md
+++ b/specs/SPEC-033-hardware-verifier.md
@@ -1,6 +1,6 @@
 # SPEC-033 — Hardware-Evidence Verifier (`hardware-verifier.v2`)
 
-**Status:** v0.2-draft
+**Status:** v0.3-draft
 **Date:** 2026-07-12
 **Depends on:** SPEC-023 (autotune — produces the benchmark/recommendation inputs the evidence document carries). **Consumed by:** SPEC-032 (autotune hardware-evidence admission "hello-gate") reads this spec's verdict via an **exact-`hardware-verifier.v2`** lookup and cross-references it as "the item-10 hardware-verifier verdict spec". This spec owns the `hardware-verifier.v2` decision semantics and the job/profile lifecycle; SPEC-032 owns how a `verified` profile gates admission.
 
@@ -14,12 +14,16 @@ production-live coordinator trust signal that ships **unspecced**.
 **Source-of-truth discipline.** This is documentation of shipped behavior. The **code and
 migrations are authoritative**; this spec MUST byte-match them and any disagreement is a spec
 bug. The contract spans: the verifier (`phase4-coordinator/internal/stats/hardwareverify/verify.go`),
-migrations **007, 008, 015, 016, 017** (`phase4-coordinator/internal/stats/migrations/`), the
-HTTP enqueue path (`internal/onboarding/hardware_evidence.go`), the operator inventory
-writer/demotion (`cmd/stats-inventory-sync/main.go`), the runner
-(`cmd/stats-hardware-verifier/main.go`), and the exact-v2 downstream consumers
-(`internal/onboarding/hardware_evidence.go`, `internal/autotune/evidence_pg.go`). **Where §2
-summarizes DDL, the migration files are the byte-authoritative shape.**
+migrations **007, 008, 013, 015, 016, 017** (`phase4-coordinator/internal/stats/migrations/`), the
+deployment/role SQL (`phase4-coordinator/dist/stats-inventory-writer.sql`,
+`dist/stats-hardware-verifier-bootstrap.sql`), the HTTP enqueue path
+(`internal/onboarding/hardware_evidence.go`) and its producer
+(`phase3-binary/.../AutotuneHardwareEvidence.swift`), the app-registration profile writer
+(`internal/onboarding/apptrack.go`, `store_pg.go`), the operator inventory writer/demotion
+(`cmd/stats-inventory-sync/main.go`), the runner (`cmd/stats-hardware-verifier/main.go`), and the
+downstream consumers — SPEC-032 admission (`internal/autotune/evidence_pg.go`) and the SPEC-017
+hardware cache (`internal/stats/hardware/cache.go`). **Where §2 summarizes DDL, the migration and
+`dist/*.sql` files are the byte-authoritative shape.**
 
 ---
 
@@ -75,9 +79,10 @@ lifecycle; it does not define admission or tier weighting.
 ## 2. Data model
 
 Four tables plus **two** guard triggers and least-privilege **column-level** grants. Migrations
-**007, 008, 015, 016, 017** are the byte-authoritative DDL; the tables below are a load-bearing
-summary — a reimplementation MUST read the migrations for exact column lists, `NOT NULL`/`DEFAULT`
-clauses, `CHECK` constraints, indexes, and grants.
+**007, 008, 013, 015, 016, 017** plus the role SQL in `dist/stats-inventory-writer.sql` and
+`dist/stats-hardware-verifier-bootstrap.sql` are the byte-authoritative DDL; the tables below are a
+load-bearing summary — a reimplementation MUST read those files for exact column lists,
+`NOT NULL`/`DEFAULT` clauses, `CHECK` constraints, indexes, roles, and grants.
 
 ### 2.1 `hardware_verification_jobs` — the work queue (migration 008)
 
@@ -147,18 +152,25 @@ DB-level counterpart of the application's terminal-safe `WHERE` (§6).
 
 - **`stats_hardware_verifier`** (the verifier): `SELECT` on the jobs/trust/chip/profile tables;
   `UPDATE` on the job status/decision columns; the promotion `INSERT/UPDATE` on
-  `provider_hardware_profiles` — all gated by triggers A/B. `NOLOGIN`.
+  `provider_hardware_profiles` — all gated by triggers A/B. Created **`NOLOGIN`** by migration 008,
+  but the operator bootstrap (`dist/stats-hardware-verifier-bootstrap.sql`) `ALTER`s it to
+  **`LOGIN`** with a password so the runner can connect — so it is a login role in a real
+  deployment.
 - **`provider_onboarding`** (the enqueue path): **column-level** `INSERT` on the job columns
   (including `status`, but the shipped enqueue always inserts `pending`) and **column-limited
-  `SELECT`** (`id, provider_id, status, submitted_at, evidence_sha256, decision_reason`, and —
-  migration 017 — `provider_id, chip_normalized, unified_memory_gb, verified` on profiles). It has
-  **no `verified` write grant** and trigger A forces `verified=FALSE` regardless: **onboarding can
-  never self-promote.** (A compromised onboarding SQL role could insert a job with a terminal
-  `status`, but that cannot set a profile's `verified` bit — §10.1.)
-- **`stats_inventory_writer`** (operator inventory sync, §7.3): full `INSERT/UPDATE` on
+  `SELECT`** — `id, provider_id, status, submitted_at, evidence_sha256` (008), `decision_reason`
+  (015), **`generated_at, evidence`** (013, for the SPEC-032 W2 hello gate — the §10.2 leakage
+  boundary), and job `chip_normalized, unified_memory_gb` (017); on profiles, `last_reported_at`
+  (007) and `provider_id, chip_normalized, unified_memory_gb, verified` (017). It has **no
+  `verified` write grant** and trigger A forces `verified=FALSE` regardless: **onboarding can never
+  self-promote.** (A compromised onboarding SQL role could insert a job with a terminal `status`
+  and could *read* all evidence, but cannot set a profile's `verified` bit — §10.1, §10.2.)
+- **`stats_inventory_writer`** (operator inventory sync, §7.3; role/grants defined in
+  `dist/stats-inventory-writer.sql`, not a migration): full `INSERT/UPDATE` on
   `provider_hardware_profiles` **including `verified`**, and **not** constrained by trigger A. This
   is an **operator-authority** path, not a provider-reachable one (§10.1).
-- **`stats_trust_inventory_writer`**: writes `hardware_verification_trust` (the trust roots).
+- **`stats_trust_inventory_writer`** (also `dist/stats-inventory-writer.sql`): writes
+  `hardware_verification_trust` (the trust roots).
 
 ---
 
@@ -188,12 +200,15 @@ benchmarks []{
   swap_detected, thermal_throttle_detected bool
   artifact_sha256, candidate_catalog_sha256 string
   benchmark_id                         string  // optional
+  candidate_row_identity               string  // optional; if present MUST be 64 lowercase hex
   generated_at                         string  // RFC3339
   binary_version, hardware_identity_hash string
 }
 ```
 
-A **lowercase hex SHA-256** is exactly 64 chars in `[0-9a-f]` (`isLowerSHA256`).
+A **lowercase hex SHA-256** is exactly 64 chars in `[0-9a-f]` (`isLowerSHA256`). The optional
+`candidate_row_identity` (emitted by the producer) is validated at the HTTP handler (§3.1) — 64
+lowercase hex if non-empty — but is not consumed by the `Evaluate` gate pipeline (§5).
 
 ### 3.1 Submission and replay (enqueue path)
 
@@ -201,16 +216,28 @@ The provider binary POSTs the envelope to **`POST /v1/providers/hardware-evidenc
 authenticated bearer identity; the handler (`HandleHardwareEvidence`) binds the job to the
 **authenticated** `provider_id` (a provider cannot enqueue for another provider). The handler:
 
+- enforces **strict request validation**: `POST`-only; a bounded body; **unknown-field rejection**
+  (strict JSON); numeric precision/range checks; and field-binding checks (e.g. the optional
+  `candidate_row_identity` must be 64 lowercase hex);
+- applies **two rate limiters**: an **IP** limiter (`10/min`, HTTP `429` `Retry-After: 60`) and a
+  **per-provider** limiter (HTTP `429` `Retry-After: 600`). The per-provider limit is **broader
+  than a fixed window**: a new *distinct* evidence submission is rejected while the provider has
+  **any** non-terminal (`pending`/`waiting_trust`) job **OR** any job submitted within the last 10
+  minutes (`hardware_evidence.go`), so a provider cannot flood the queue while one job is
+  outstanding;
 - computes a **canonical** SHA-256 of the evidence (`canonicalEvidenceSHA`) → `evidence_sha256`;
-- **rate-limits**: if a recent job for this provider exists within a 10-minute window, returns
-  HTTP `429` with `Retry-After: 600`;
-- inserts a `pending` job (unique on `evidence_sha256`);
-- returns a **replay state machine** result (`hardwareEvidenceResponseStatus`), which is
-  **fail-closed**: a duplicate is accepted (2xx) **only** while `pending`, while `waiting_trust`,
-  or when already `verified` **with `decision_reason == hardware-verifier.v2:verified_trusted_hardware`
-  exactly**. Every other finalized/unknown/legacy state (`rejected`, `v1:verified`, …) returns
-  HTTP `409` `evidence_replay_not_accepted` — a rejected or legacy decision cannot be laundered
-  through a 2xx replay; new evidence must be resubmitted.
+- in the **same transaction**, upserts a **`source='cli_hello'` profile row** (with `verified`
+  left to trigger A, i.e. `FALSE`) *before* inserting the job, then inserts a `pending` job
+  (unique on `evidence_sha256`);
+- returns a **replay state machine** result (`hardwareEvidenceResponseStatus`), **fail-closed**: a
+  duplicate is accepted (2xx) **only** while `pending`, while `waiting_trust`, or when already
+  `verified` **with `decision_reason == hardware-verifier.v2:verified_trusted_hardware` exactly**.
+  Every other finalized/unknown/legacy state (`rejected`, `v1:verified`, …) returns HTTP `409`
+  `evidence_replay_not_accepted` — a rejected or legacy decision cannot be laundered through a 2xx
+  replay; new evidence must be resubmitted.
+
+The pre-job `cli_hello` profile upsert is why a later app-registration (§10.4 R1) finds an existing
+row to convert.
 
 ---
 
@@ -225,18 +252,22 @@ authenticated bearer identity; the handler (`HandleHardwareEvidence`) binds the 
   `hardware-verifier.v2:missing_trusted_chip_profile`). `Evaluate` returns the bare reason; only
   success returns the pre-prefixed `VerifiedDecisionReason`.
 
-**Legacy `hardware-verifier.v1:verified` and downstream acceptance.** The *verifier* grandfathers
-legacy terminal rows only in the sense that it scans **only** `pending`/`waiting_trust`, so a
-legacy `verified` row is never re-evaluated. **Downstream consumers do NOT accept arbitrary
-`status='verified'` rows** — they require the **exact** current v2 reason:
+**Legacy `hardware-verifier.v1:verified` and downstream acceptance (two consumer classes).** The
+*verifier* grandfathers legacy terminal rows only in the sense that it scans **only**
+`pending`/`waiting_trust`, so a legacy `verified` row is never re-evaluated. Downstream, there are
+**two distinct consumer classes**:
 
-- onboarding replay accepts a `verified` job only when `decision_reason == VerifiedDecisionReason`
-  (`hardware_evidence.go`; its test rejects `hardware-verifier.v1:verified`);
-- SPEC-032's evidence lookup filters on `decision_reason = VerifiedDecisionReason`
-  (`internal/autotune/evidence_pg.go`).
+- **Exact-v2 (job-reason) consumers** require `decision_reason = VerifiedDecisionReason`: onboarding
+  replay (`hardware_evidence.go`; its test rejects `hardware-verifier.v1:verified`) and SPEC-032's
+  evidence lookup (`internal/autotune/evidence_pg.go`). A legacy `v1:verified` row is **not** a
+  current trusted verdict for these.
+- **Verified-bit consumers** gate on `provider_hardware_profiles.verified = TRUE` **without**
+  inspecting any job reason: the **SPEC-017 hardware cache** (`internal/stats/hardware/cache.go`
+  selects `WHERE verified = TRUE`) and the demotion predicate's supporting-job clause (§7.3), which
+  accepts any `status='verified'` job. For these, the **bit**, not the v2 reason, is authoritative.
 
-So a legacy `v1:verified` row is terminal and unscanned, but is **not** treated as a *current
-trusted verdict* by downstream consumers; only the exact v2 reason is.
+So "downstream requires the exact v2 reason" is true for the *reason* consumers but **not**
+universal — the verified bit is a second, coarser signal.
 
 > **Naming drift closed.** The live success constant is `hardware-verifier.v2:verified_trusted_hardware`
 > (v2, not v1). Earlier drift assumed a `v1` verifier.
@@ -330,15 +361,28 @@ matches **zero rows** — the existing (newer) profile is left intact — yet th
 `verified`. So a `verified` verdict does **not** unconditionally rewrite the profile; it promotes
 **iff** no newer profile blocks it (§12 AC-HV-1).
 
-### 7.3 Post-verdict demotion (operator inventory sync)
+### 7.3 Post-verdict demotion (operator inventory sync) — best-effort, with known escapes
 
-`provider_hardware_profiles.verified` is not permanent. The operator inventory sync
-(`cmd/stats-inventory-sync`, role `stats_inventory_writer`) runs `applyTrustDemotions`, which sets
-`verified = FALSE` for every `source='cli_hello'` profile that **no longer** has a matching active
-trust row (trust removed or `expires_at` passed). So **removing/expiring a trust root demotes the
-previously-verified providers** on the next sync. The same tool also directly upserts operator
-profiles (`source='operator'`, `verified` from an operator-authored YAML) — an operator-authority
-write path outside the evidence pipeline (§10.1).
+`provider_hardware_profiles.verified` is not permanent, but demotion is **best-effort and has
+documented escape paths (§10.4)** — it is NOT a reliable revocation guarantee. The operator
+inventory sync (`cmd/stats-inventory-sync`, role `stats_inventory_writer`) runs
+`applyTrustDemotions`, which sets `verified = FALSE` only for a profile that satisfies **all** of:
+(i) `source = 'cli_hello'`; (ii) no matching **active** trust row (trust removed or `expires_at`
+passed); **and** (iii) a `status='verified'` job **exactly** matching the profile's chip, memory,
+`os_version→macos_version`, `binary_version→app_version`, and `generated_at→last_reported_at`.
+Consequences of that predicate:
+
+- It only touches `source='cli_hello'` profiles — a profile converted to `app_register` (§10.4 R1)
+  is never demoted.
+- `applyTrustDemotions` (and the whole trust reconciliation) runs **only when the sync input
+  contains ≥ 1 trusted-hardware identity** (`validateInventory` rejects an empty `trusted_hardware`
+  section, and omitting it leaves trust roots untouched), so it cannot express "remove the last
+  root / zero trust" (§10.4 R2).
+- Because it also requires an exact tuple-matching verified job, tuple/profile drift can demote a
+  profile **even while its trust row remains** — trust removal is *sufficient but not exhaustive*.
+
+The same tool also directly upserts operator profiles (`source='operator'`, `verified` from an
+operator-authored YAML) — an operator-authority write path outside the evidence pipeline (§10.1).
 
 ---
 
@@ -371,10 +415,13 @@ the batch tally.
 
 No provider-reachable path sets `provider_hardware_profiles.verified = TRUE`:
 
-- The only provider-reachable write path is the authenticated enqueue (§3.1), which runs as
-  `provider_onboarding` — a role with **no `verified` write grant**, and trigger A forces
-  `verified=FALSE` for it regardless (§2.5, §2.7). The worst a compromised onboarding SQL role can
-  do is insert a job row with a terminal `status`; it still cannot flip a profile's `verified` bit.
+- The provider-reachable profile-write paths (the enqueue upsert §3.1, **and** signed
+  app-registration §10.4 R1) both run as `provider_onboarding` — a role with **no `verified` write
+  grant**, and trigger A forces `verified=FALSE` on any insert and on any chip/memory change
+  (§2.5, §2.7). So **no provider path can create an initial `verified=TRUE`**; the worst a
+  compromised onboarding SQL role can do is insert a terminal-status job or read evidence (§10.2).
+  (What a provider *can* do is **retain** an already-granted `verified` bit past trust removal by
+  flipping `source` — that is the R1 revocation gap, §10.4, not an initial-promotion path.)
 - `verified=TRUE` is writable by exactly **two** roles, **neither provider-reachable**:
   (1) `stats_hardware_verifier`, only via `promoteJob` **and** only if the trust join passes both
   in `Evaluate` (§5.5) and in the DB trigger (§2.5); (2) `stats_inventory_writer`, an
@@ -402,15 +449,49 @@ So: **a provider without an operator-curated trust row can reach at best `waitin
   clears `verified` only on a chip/memory change, so a previously-verified provider can change its
   `hardware_identity_hash` (or move to another same-chip/same-memory device) and **retain**
   `verified` until a chip/memory change or a §7.3 demotion. The verified bit is a
-  standing (chip, memory) capacity assertion, revocable by trust removal.
+  standing (chip, memory) capacity assertion — and its revocation is **best-effort, not
+  guaranteed** (§10.4).
+- **Read-access leakage boundary.** Migration 013 grants `provider_onboarding` column `SELECT` on
+  `hardware_verification_jobs.(generated_at, evidence)` (needed by the SPEC-032 W2 hello gate).
+  There is no row-level policy, so a compromise of that **network-facing** onboarding SQL role can
+  read **every** provider's raw evidence JSON — hardware identity hashes, OS/binary metadata, and
+  benchmark values. This is a disclosed leakage boundary, not a promotion path (that role still
+  cannot set `verified`).
 
-### 10.3 Defense in depth (the trust gate is enforced twice)
+### 10.3 Defense in depth (the trust/promotion join is enforced twice — but only that join)
 
-The trust/chip/freshness match is checked in **application code** (`Evaluate`, §5.5) **and again
-in the database** (trigger A re-runs the full join at write time, §2.5). A logic bug that let
-`Evaluate` pass a bad job would still be caught by the DB trigger, which RAISES and rolls back.
-Trigger B (§2.6) additionally prevents the verifier from reopening finalized jobs or moving them to
-an out-of-band status.
+The **trust-row + chip-profile + summary-positivity + freshness + exact-profile-tuple** promotion
+check is enforced in **application code** (`Evaluate` §5.5 + `promoteJob`) **and again in the
+database** (trigger A re-runs that join at write time, §2.5), so a logic bug in the app layer that
+let a bad *trust match* through would still RAISE at the DB. **This duplication covers only the
+trust/promotion join, NOT the full §5 pipeline** — trigger A does **not** re-check schema/provider
+consistency, benchmark artifact/catalog/binary/identity binding, benchmark timestamps, or TTFT/TPS
+validity; those gates exist only in `Evaluate`. Trigger B (§2.6) separately prevents the verifier
+from reopening finalized jobs.
+
+### 10.4 Revocation gaps (known shipped weaknesses — MUST close, disclosed not papered over)
+
+Initial self-certification is impossible (§10.1, holds). **Revocation of an already-`verified`
+profile, however, has two shipped escape paths.** SPEC-033 documents them as known gaps; closing
+them is code follow-up, not a spec change:
+
+- **R1 — `app_register` source-flip escape.** A signed provider **app-registration**
+  (`internal/onboarding/apptrack.go` → `store_pg.go` `UpsertProviderHardwareProfile`) upserts the
+  profile with `source='app_register'`. For an unchanged (chip, memory) tuple, trigger A preserves
+  `OLD.verified` but does **not** reset `source`. Demotion (§7.3) only touches `source='cli_hello'`,
+  and both downstream consumers — SPEC-032 admission (`evidence_pg.go`) and the SPEC-017 hardware
+  cache (`internal/stats/hardware/cache.go`, §4) — gate on the `verified` **bit** without
+  rechecking `source` or current trust. So a legitimately-verified provider can re-register the
+  same chip/memory, flip its row to `app_register`, and **retain `verified=TRUE` past a later trust
+  removal/expiry** (SPEC-032 admission is then bounded only by the evidence-TTL freshness join, not
+  by trust). MUST-close: demotion should not be `source='cli_hello'`-scoped, or admission should
+  re-check current trust.
+- **R2 — last-trust-root / zero-trust non-removal.** `validateInventory` rejects an **empty**
+  `trusted_hardware` section (and omitting it means "leave roots untouched"), and trust
+  reconciliation + `applyTrustDemotions` run **only when ≥ 1 trust identity is present**. So the
+  inventory tool **cannot express removing the last root or operating at zero trust**, and in that
+  state no demotion runs at all — an active final root keeps authorizing promotions. MUST-close:
+  support an explicit zero-trust reconciliation that also demotes.
 
 ---
 
@@ -461,18 +542,49 @@ an out-of-band status.
   (`FOR UPDATE SKIP LOCKED` + terminal-safe write `WHERE` + trigger B).
 - **AC-HV-8 (Smoke fail-closed).** A run whose `Smoke` preflight fails MUST abort before touching
   any job.
-- **AC-HV-9 (legacy grandfathering + exact-v2 downstream).** A `hardware-verifier.v1:verified` row
-  MUST remain terminal and MUST NOT be re-evaluated by the verifier; **downstream consumers MUST
-  accept only the exact `hardware-verifier.v2:verified_trusted_hardware` reason** as a current
-  trusted verdict (§4), so a legacy row is not honored downstream.
-- **AC-HV-10 (demotion).** Removing or expiring a `hardware_verification_trust` row MUST demote the
-  affected `source='cli_hello'` profiles to `verified=FALSE` on the next inventory sync (§7.3).
+- **AC-HV-9 (legacy grandfathering + two consumer classes).** A `hardware-verifier.v1:verified` row
+  MUST remain terminal and MUST NOT be re-evaluated by the verifier. **Exact-v2 job-reason
+  consumers** (onboarding replay, SPEC-032 admission) MUST accept only the exact
+  `hardware-verifier.v2:verified_trusted_hardware` reason. **Verified-bit consumers** (SPEC-017
+  cache, the §7.3 demotion supporting-job clause) gate on `verified=TRUE` without a reason check
+  (§4) — the spec MUST NOT claim exact-v2 is universal.
+- **AC-HV-10 (demotion is best-effort).** Removing/expiring a trust row demotes an affected profile
+  to `verified=FALSE` on the next sync **only** when all three §7.3 conditions hold (`source='cli_hello'`,
+  no active trust, exact tuple-matching verified job) **and** the sync input carries ≥ 1 trust
+  identity. Demotion is best-effort, not a guarantee (§10.4).
 - **AC-HV-11 (chip/memory re-verification).** A `provider_onboarding` update that changes
   `chip_normalized` or `unified_memory_gb` MUST clear `verified` (trigger A).
+- **AC-HV-12 (revocation gaps documented).** The spec MUST disclose the R1 (`app_register`
+  source-flip escape) and R2 (last-root/zero-trust non-removal) revocation gaps (§10.4) as known
+  shipped weaknesses rather than assert unconditional revocability.
 
 ---
 
 ## Change log
+
+**v0.3-draft (2026-07-12) — audit reconciliation (SPEC-033 R2, 3-lane codex).**
+R2 confirmed the §3/§5/§6/§8 core and the no-initial-self-certification property, and caught a
+unanimous HIGH plus scope residuals — v0.2 overstated *revocation*:
+- **§10.4 added + §7.3/§10.1/§10.2 corrected**: revocation is best-effort with two documented
+  shipped escape paths — **R1** `app_register` source-flip (a verified provider re-registers the
+  same chip/memory, flips `source`, and evades the `cli_hello`-scoped demotion while SPEC-032/
+  SPEC-017 consumers ignore source/trust) and **R2** last-root/zero-trust non-removal (the
+  inventory tool rejects an empty `trusted_hardware` and skips demotion when no trust identity is
+  present). Both are MUST-close, disclosed not papered over.
+- **§10.3 narrowed**: the DB trigger re-verifies only the trust/promotion join, not the full §5
+  pipeline.
+- **§4 corrected**: two downstream consumer classes — exact-v2 job-reason consumers *and*
+  verified-**bit** consumers (SPEC-017 hardware cache; the demotion supporting-job clause); the
+  exact-v2 claim is not universal.
+- **§3/§3.1 expanded**: `candidate_row_identity`; strict body/unknown-field/precision/range/binding
+  validation; the real dual rate-limiters (IP `10/min` `Retry-After 60`; per-provider — any
+  non-terminal job or a job within 10 min — `Retry-After 600`); the pre-job `cli_hello` profile
+  upsert.
+- **§2.7/header expanded**: migration **013** grants (`generated_at, evidence` → the §10.2 leakage
+  boundary) + 017/007 grants; role/grant `dist/*.sql`; the verifier role is `NOLOGIN` by migration
+  but `ALTER`ed to `LOGIN` by the operator bootstrap.
+- **§12**: AC-HV-9 (two consumer classes), AC-HV-10 (best-effort demotion), new AC-HV-12
+  (revocation gaps disclosed).
 
 **v0.2-draft (2026-07-12) — audit reconciliation (SPEC-033 R1, 3-lane codex).**
 Round-1 audit confirmed §3/§4-constants/§5-gate-orders/§6/§8/§11-runner accurate, and corrected an

--- a/specs/SPEC-033-hardware-verifier.md
+++ b/specs/SPEC-033-hardware-verifier.md
@@ -1,0 +1,418 @@
+# SPEC-033 — Hardware-Evidence Verifier (`hardware-verifier.v2`)
+
+**Status:** v0.1-draft
+**Date:** 2026-07-12
+**Depends on:** SPEC-002 (coordinator provider state machine; `provider_hardware_profiles.verified` is a routing/tier input), SPEC-003 (open onboarding; the App/CLI hello that submits evidence), SPEC-023 (autotune — produces the `hardware_evidence.autotune.v1` evidence document this verifier consumes). SPEC-032 (autotune hardware-evidence admission "hello-gate") **consumes this spec's verdict as an input** and cross-references it as "the item-10 hardware-verifier verdict spec"; SPEC-033 owns the `hardware-verifier.v2` decision semantics, SPEC-032 owns how the resulting `verified` profile gates admission.
+
+**Numbering note.** Assigned canonical **SPEC-033** on 2026-07-12 (Wave C of the
+2026-07-10 SPEC-vs-code drift audit; runbook item 10). Highest prior canonical spec
+was SPEC-032. This document is the **reconstructed normative baseline** for a shipped,
+production-live coordinator trust signal that ships **unspecced**: the batch
+**hardware-evidence verifier** that promotes a provider's autotune hardware evidence to a
+`verified` hardware profile, emitting `hardware-verifier.v2:*` decision reasons. The shipped
+success constant is `hardware-verifier.v2:verified_trusted_hardware` (the code is at
+`phase4-coordinator/internal/stats/hardwareverify/verify.go`; the runner is
+`phase4-coordinator/cmd/stats-hardware-verifier/main.go`). **This spec is documentation of
+shipped behavior — it MUST NOT diverge from that code; the code is the source of truth and any
+disagreement is a spec bug.**
+
+---
+
+## 1. Purpose and scope
+
+### 1.1 Purpose
+
+A provider's autotune run (SPEC-023) produces a signed-shape **hardware-evidence document**
+(`hardware_evidence.autotune.v1`) describing the provider's Apple-silicon chip, unified memory,
+OS/binary versions, a stable `hardware_identity_hash`, and a set of local model benchmarks. The
+provider submits it during onboarding; a row lands in `hardware_verification_jobs`. The
+**hardware-evidence verifier** is a coordinator-side **batch job** that reads pending jobs,
+runs a deterministic ordered gate pipeline over each evidence document, and transitions the job
+to **`verified`**, **`rejected`**, or the non-terminal **`waiting_trust`** state — promoting a
+`provider_hardware_profiles.verified = TRUE` row on success.
+
+`provider_hardware_profiles.verified` is a downstream routing/tier input (SPEC-002 provider
+state; SPEC-032 admission gate). This spec defines **only** the verdict engine: what makes
+evidence verifiable, the decision-reason taxonomy, the job/profile state machine, and the
+security model that prevents a provider from self-certifying.
+
+### 1.2 In scope
+
+- The `hardware-verifier.v2` decision-reason taxonomy and the shipped success constant.
+- The ordered verification algorithm (`Evaluate`) and every reject/wait reason it can emit.
+- The job lifecycle state machine (`pending` / `waiting_trust` / `verified` / `rejected`).
+- The verified-profile promotion (upsert) semantics and monotonicity guard.
+- Batch/concurrency semantics (`FOR UPDATE SKIP LOCKED`, batch limit, single transaction).
+- Idempotency / replay resistance (`evidence_sha256` uniqueness).
+- The database security model: least-privilege roles and the profile-verification trigger.
+- The runner and its preflight `Smoke` contract.
+
+### 1.3 Out of scope
+
+- **How the evidence is produced.** Autotune benchmark generation, chip detection, and the
+  `hardware_identity_hash` derivation are SPEC-023 / provider-binary concerns. This spec treats
+  the evidence document as an untrusted input to validate.
+- **How `verified` gates admission or tiers.** SPEC-032 (hello-gate) and SPEC-002 own that.
+- **The trust-root curation policy.** *How* an operator decides to insert a
+  `hardware_verification_trust` row (attestation review, manual vetting) is an operational
+  policy; this spec defines only how a trust row is *matched*.
+- **Proof-of-weights / OPoI / model-hash attestation.** Those are SPEC-032 / SPEC-008.
+
+---
+
+## 2. Data model
+
+Four tables (migrations `007_hardware_profiles`, `008_hardware_verification_jobs`) plus a
+verification-guard trigger.
+
+### 2.1 `hardware_verification_jobs` — the work queue
+
+Columns (normative shape; `phase4-coordinator/internal/stats/migrations/008_hardware_verification_jobs.up.sql`):
+
+| Column | Type / constraint | Meaning |
+| --- | --- | --- |
+| `id` | `BIGSERIAL` PK | job id; processing order |
+| `provider_id` | `TEXT NOT NULL` | provider the evidence claims to be from |
+| `source` | `TEXT CHECK (source IN ('autotune'))` | only autotune-sourced jobs exist |
+| `status` | `TEXT CHECK (... 'pending','waiting_trust','verified','rejected') DEFAULT 'pending'` | job state |
+| `chip`, `chip_normalized` | `TEXT NOT NULL` | claimed chip + normalized form |
+| `unified_memory_gb` | `INT CHECK (0..4096)` | claimed unified memory |
+| `bandwidth_tier`, `os_version`, `binary_version` | `TEXT NOT NULL DEFAULT ''` | claimed metadata |
+| `benchmark_count` | `INT CHECK (0..64) DEFAULT 0` | summary count |
+| `max_sustained_tps` | `DOUBLE PRECISION CHECK (>= 0)` | summary metric |
+| `generated_at` | `TIMESTAMPTZ NOT NULL` | when the provider generated the evidence |
+| `submitted_at` | `TIMESTAMPTZ DEFAULT now()` | when the job was enqueued |
+| `processed_at` | `TIMESTAMPTZ NULL` | when the verifier decided |
+| `decision_reason` | `TEXT NOT NULL DEFAULT ''` | the emitted `hardware-verifier.v2:*` (or legacy) reason |
+| `evidence` | `JSONB NOT NULL` | the full evidence document |
+| `evidence_sha256` | `TEXT NOT NULL UNIQUE` | **replay guard** — a duplicate evidence document cannot enqueue twice |
+
+Partial index on `status IN ('pending','waiting_trust')` supports the batch scan.
+
+### 2.2 `hardware_verification_trust` — operator-curated trust roots
+
+`(provider_id, hardware_identity_hash)` PK, plus `chip_normalized`, `unified_memory_gb`,
+`trusted_by`, `trusted_at`, `expires_at NULL`, `notes`. A row asserts "this operator vouches
+that `hardware_identity_hash` for this provider is a genuine device with this chip + memory."
+`expires_at IS NULL` (or in the future) means active. **Only an operator/trust-curation role
+writes this table; the verifier only reads it.** This is the human-in-the-loop trust anchor
+that makes self-certification impossible (§10).
+
+### 2.3 `provider_hardware_profiles` — the verified output
+
+`provider_id` PK, `chip`, `chip_normalized`, `unified_memory_gb`, `macos_version`,
+`app_version`, `source TEXT CHECK (source IN ('app_register','cli_hello','operator'))`,
+`verified BOOLEAN DEFAULT FALSE`, `last_reported_at`. A successful verdict upserts this row
+with `verified = TRUE`, `source = 'cli_hello'` (§7).
+
+### 2.4 `chip_hardware_profiles` — the known-chip catalog
+
+`chip_normalized` PK plus physical characteristics (`memory_bandwidth_gb_per_s`,
+`network_power_kw`, `gpu_cores`, `cpu_cores`). A job's `chip_normalized` MUST have a row here
+or the job goes to `waiting_trust` (§5.5). Operator-curated.
+
+### 2.5 Verification guard trigger
+
+`provider_hardware_profiles_guard_verification` (a `BEFORE INSERT/UPDATE` trigger) is a
+**defense-in-depth** DB guard, independent of application code:
+
+- Under role `provider_onboarding`: `verified` is forced to `FALSE` on insert, and forced back
+  to `FALSE` whenever `chip_normalized` changes; otherwise preserved. **A provider-onboarding
+  writer can never set `verified = TRUE`.**
+- Under role `stats_hardware_verifier` (the verifier): an `UPDATE` that moves
+  `last_reported_at` **backward** RAISES — enforcing timestamp monotonicity at the DB layer,
+  matching the application-level guard in §7.
+
+---
+
+## 3. Evidence document schema (`hardware_evidence.autotune.v1`)
+
+The `evidence` JSONB decodes to (`hardwareverify.Evidence`):
+
+```
+schema_version           string   // MUST equal "hardware_evidence.autotune.v1"
+provider_id              string
+generated_at             string   // RFC3339
+hardware {
+  chip                   string
+  memory_gb              int
+  bandwidth_tier         string
+  detected               bool
+  os_version             string
+  binary_version         string
+  hardware_identity_hash string   // lowercase hex SHA-256 (64 chars)
+}
+candidate_catalog_sha256 string    // lowercase hex SHA-256
+recommended_model        string
+benchmarks []{
+  model_key                 string
+  model_id                  string
+  sustained_tps             float64
+  ttft_ms                   int
+  swap_detected             bool
+  thermal_throttle_detected bool
+  artifact_sha256           string  // lowercase hex SHA-256
+  candidate_catalog_sha256  string
+  benchmark_id              string  // optional
+  generated_at              string  // RFC3339
+  binary_version            string
+  hardware_identity_hash    string
+}
+```
+
+A **lowercase hex SHA-256** is exactly 64 characters, each in `[0-9a-f]` (`isLowerSHA256`).
+Uppercase, wrong length, or non-hex fails the relevant gate.
+
+---
+
+## 4. Decision constants and versioning
+
+- **Verifier version:** `hardware-verifier.v2` (`verifierDecisionVersion`).
+- **Evidence schema version:** `hardware_evidence.autotune.v1` (`evidenceSchemaVersion`).
+- **Success constant:** `hardware-verifier.v2:verified_trusted_hardware`
+  (`VerifiedDecisionReason`). This is the exported constant other components match on.
+- **Reject/wait reasons** are persisted as `hardware-verifier.v2:<reason>` — the verifier
+  prefixes the bare reason with the version at write time in `rejectJob` / `waitTrustJob`
+  (e.g. `hardware-verifier.v2:chip_mismatch`, `hardware-verifier.v2:trust_missing`). The
+  `Evaluate` function returns the bare reason; only the success path returns the
+  already-prefixed `VerifiedDecisionReason`.
+- **Legacy `hardware-verifier.v1:verified`** rows predate this version and MUST be treated as
+  terminal `verified` (grandfathered): the verifier only scans `pending`/`waiting_trust`, so a
+  legacy `verified` row is never re-evaluated, and downstream consumers treat any
+  `status = 'verified'` row as verified regardless of version prefix.
+
+> **Naming note (the drift this spec closes).** The shipped success constant is
+> `hardware-verifier.v2:verified_trusted_hardware`, **not** a `v1` reason. Earlier drift
+> assumed a `v1` verifier; the live constant is `v2`. This spec is authoritative on the `v2`
+> taxonomy.
+
+---
+
+## 5. Verification algorithm (`Evaluate`)
+
+`Evaluate(job)` runs `evaluateAt(job, now)` with `now = time.Now().UTC()`. It is a
+**deterministic, ordered, short-circuit** gate pipeline: the **first** failing gate wins and
+its reason is returned; only a job that passes every gate returns
+`{Verified: true, Reason: VerifiedDecisionReason}`. The order below is normative — a
+reimplementation MUST emit the same reason for the same first-failing condition.
+
+Time bounds: `maxEvidenceAge = 7 * 24h`; `futureSkew = 5m`. A timestamp `t` is **stale** if
+`t < now - maxEvidenceAge`, and **future-skewed** if `t > now + futureSkew`; either is a
+failure on the relevant gate.
+
+### 5.1 Job-envelope gates (reject)
+
+In order: `missing_provider_id` (blank `provider_id`); `stale_job` (`job.generated_at`
+out of the age/skew window); `memory_out_of_range` (`job.unified_memory_gb < 8` or `> 4096`);
+`missing_evidence` (empty `evidence`); `invalid_evidence_json` (JSON decode fails).
+
+> Note the verifier's `>= 8` GB floor is stricter than the table's `>= 0` CHECK — the DB
+> accepts smaller values but the verifier rejects them.
+
+### 5.2 Evidence-consistency gates (reject)
+
+`schema_version_mismatch` (`schema_version != hardware_evidence.autotune.v1`);
+`provider_id_mismatch` (`evidence.provider_id != job.provider_id`);
+`invalid_evidence_generated_at` (not RFC3339); `evidence_generated_at_mismatch`
+(`evidence.generated_at` not **exactly equal** to `job.generated_at`); `stale_evidence`
+(evidence timestamp out of window).
+
+### 5.3 Hardware-claim cross-check gates (reject)
+
+The evidence's self-described hardware MUST match the job columns the onboarding path already
+recorded: `chip_mismatch` (`normalizeChip(evidence.hardware.chip) != job.chip_normalized`,
+where `normalizeChip` lowercases, trims, and collapses internal whitespace);
+`memory_mismatch`; `bandwidth_tier_mismatch` (case-insensitive, trimmed);
+`os_version_mismatch` (trimmed, exact); `binary_version_mismatch` (trimmed, exact);
+`invalid_hardware_identity_hash` (not lowercase-hex SHA-256);
+`invalid_candidate_catalog_sha256`.
+
+### 5.4 Benchmark gates (reject)
+
+`missing_benchmarks` (empty list). Then, per benchmark, in list order:
+`missing_benchmark_model_binding` (blank `model_key` or `model_id`);
+`duplicate_benchmark_model_key` (a `model_key` seen earlier in the same document);
+`invalid_benchmark_artifact_sha256`; `benchmark_catalog_mismatch`
+(`benchmark.candidate_catalog_sha256 != evidence.candidate_catalog_sha256`);
+`benchmark_binary_version_mismatch` (`!= evidence.hardware.binary_version`);
+`benchmark_hardware_identity_mismatch` (`!= evidence.hardware.hardware_identity_hash`);
+`invalid_benchmark_generated_at`; `stale_benchmark`; `invalid_benchmark_tps` (NaN, ±Inf, or
+`<= 0`); `invalid_benchmark_ttft` (`<= 0`). After the loop: `missing_positive_benchmark` (no
+benchmark has a finite `sustained_tps > 0`) and `missing_chip_normalized` (blank
+`job.chip_normalized`).
+
+### 5.5 Trust gates (→ `waiting_trust`, NOT reject)
+
+The final two gates are **trust-anchor** checks. They do **not** reject; they return a reason
+the caller routes to the non-terminal `waiting_trust` state (§6):
+
+- `missing_trusted_hardware_identity` — no active `hardware_verification_trust` row matches
+  `(provider_id, hardware_identity_hash, chip_normalized, unified_memory_gb)` with
+  `expires_at IS NULL OR expires_at > now()`.
+- `missing_trusted_chip_profile` — no `chip_hardware_profiles` row for this `chip_normalized`.
+
+(The two `EXISTS` sub-queries are computed in the batch SELECT as `trust_matched` /
+`chip_profile_matched` and read by `Evaluate` as `job.TrustMatched` / `job.ChipProfileMatched`.)
+
+### 5.6 Success
+
+Passing every gate returns `hardware-verifier.v2:verified_trusted_hardware`.
+
+---
+
+## 6. Job lifecycle state machine
+
+```
+                submit (onboarding)
+                      │
+                      ▼
+                  ┌────────┐   trust/chip-profile absent    ┌───────────────┐
+                  │pending │ ─────────────────────────────▶ │ waiting_trust │
+                  └───┬────┘                                └──────┬────────┘
+        reject gate │  │ all gates pass          all gates pass /  │ trust/chip
+                    │  │                          reject gate hits  │ still absent
+                    ▼  ▼                                            │ (re-scanned)
+              ┌──────────┐        ┌──────────┐                      │
+              │ rejected │        │ verified │◀─────────────────────┘
+              └──────────┘        └──────────┘
+```
+
+- The batch scan selects `status IN ('pending','waiting_trust')`. **`waiting_trust` is
+  non-terminal**: a job parked there is re-evaluated on every subsequent run, so once an
+  operator later inserts the missing `hardware_verification_trust` or `chip_hardware_profiles`
+  row, the same job promotes to `verified` without re-submission.
+- `verified` and `rejected` are **terminal** (never re-scanned).
+- A `waiting_trust` job that later hits a **reject** gate (e.g. its evidence has since gone
+  stale) transitions to `rejected` — the age gates are evaluated against the *current* `now`.
+- All three transitions set `processed_at = now()` and `decision_reason`, and are guarded by
+  `WHERE id = $1 AND status IN ('pending','waiting_trust')` so a concurrently-terminalized job
+  is not overwritten.
+
+---
+
+## 7. Verified-profile promotion
+
+On a `verified` verdict, `promoteJob` upserts `provider_hardware_profiles`:
+
+- `INSERT ... VALUES (provider_id, chip, chip_normalized, unified_memory_gb, os_version→macos_version, binary_version→app_version, source='cli_hello', verified=TRUE, generated_at→last_reported_at)`.
+- `ON CONFLICT (provider_id) DO UPDATE SET ... verified = TRUE, last_reported_at = EXCLUDED.last_reported_at` **only** `WHERE provider_hardware_profiles.last_reported_at <= EXCLUDED.last_reported_at` — a **monotonicity guard**: an older evidence document can never overwrite a newer verified profile (and the §2.5 trigger enforces the same invariant at the DB layer under the verifier role).
+- The job row is then set to `status='verified'`, guarded by the same terminal-safe `WHERE`.
+
+Both writes happen in the **same transaction** as the scan (§8), so a profile promotion and its
+job terminalization commit atomically.
+
+---
+
+## 8. Concurrency and batching
+
+- `ProcessPending(ctx, limit)` opens **one transaction**, scans up to `limit` (default 100)
+  jobs `ORDER BY id` with **`FOR UPDATE SKIP LOCKED`**, decides each, applies the writes, and
+  commits once. `SKIP LOCKED` lets multiple verifier instances run concurrently without
+  contending on the same jobs.
+- The scan and all decision writes share the transaction; a failure at any job rolls the whole
+  batch back (`defer tx.Rollback()`), so a batch is all-or-nothing.
+- `Processed{Verified, Rejected, Waiting}` counts the batch outcome for the runner to log.
+
+---
+
+## 9. Idempotency and replay resistance
+
+- `hardware_verification_jobs.evidence_sha256` is `UNIQUE`. The onboarding submit path keys on
+  the evidence hash, so the **same evidence document cannot enqueue two jobs** — a replayed
+  submission collides on the unique constraint. Verification is therefore evaluated at most
+  once per distinct evidence document.
+- The verifier itself is naturally idempotent: terminal states are never re-scanned, and the
+  terminal-safe `WHERE status IN ('pending','waiting_trust')` on every write means a
+  double-processed job (e.g. across a crash/retry) cannot double-promote.
+
+---
+
+## 10. Security model — why a provider cannot self-certify
+
+Verification trust does **not** come from the evidence being well-formed; a provider fully
+controls its own evidence document. Trust comes from **operator-curated anchors** the provider
+cannot write:
+
+1. **Trust-root gate (§5.5).** `verified` requires a matching active
+   `hardware_verification_trust` row keyed on `(provider_id, hardware_identity_hash,
+   chip_normalized, unified_memory_gb)`. Only an operator/trust-curation role writes that
+   table. Absent a trust row, the best a provider can reach is `waiting_trust` — never
+   `verified`.
+2. **Known-chip gate (§5.5).** The `chip_normalized` must exist in the operator-curated
+   `chip_hardware_profiles` catalog.
+3. **DB least-privilege + trigger (§2.5).** The verifier runs as `stats_hardware_verifier`; the
+   onboarding submitter runs as `provider_onboarding`. The
+   `provider_hardware_profiles_guard_verification` trigger **forces `verified = FALSE`** for any
+   write by `provider_onboarding` and forbids the verifier from moving `last_reported_at`
+   backward. Even a SQL-injection or logic bug in the onboarding path cannot set
+   `verified = TRUE`; only the verifier role, going through `promoteJob`, can — and only after
+   the trust gates pass.
+4. **Evidence self-consistency (§5.2–5.4)** binds every benchmark to the same
+   `hardware_identity_hash`, `binary_version`, and `candidate_catalog_sha256`, so a provider
+   cannot splice a trusted device's identity onto another device's benchmarks within one
+   document.
+
+The security property is: **`verified` ⟺ (well-formed self-consistent fresh evidence) ∧
+(operator-anchored trust for this exact identity+chip+memory)**. The provider supplies the
+former; only an operator supplies the latter.
+
+---
+
+## 11. Runner and operations
+
+- **Binary:** `phase4-coordinator/cmd/stats-hardware-verifier/main.go` — opens the store with a
+  DSN, runs `Smoke`, then `ProcessPending`, and prints
+  `stats-hardware-verifier: verified=<n> rejected=<n> waiting=<n>`.
+- **`Smoke(ctx)` preflight** MUST pass before processing: it asserts `current_user =
+  'stats_hardware_verifier'` (fail-closed on a mis-provisioned DSN) and that the four tables
+  (`hardware_verification_jobs`, `hardware_verification_trust`, `provider_hardware_profiles`,
+  `chip_hardware_profiles`) are readable. A `Smoke` failure MUST abort the run before any job
+  is touched.
+- **Connection pool:** capped small (`MaxOpenConns=2`, `MaxIdleConns=1`) — this is a periodic
+  batch worker, not a hot-path service.
+- **Scheduling** is operational (a periodic invocation of the binary). Because `waiting_trust`
+  is non-terminal and re-scanned, a provider verified only after an operator adds a trust row
+  is promoted by the next scheduled run with no provider action.
+
+---
+
+## 12. Acceptance criteria
+
+- **AC-HV-1 (success constant).** A job with well-formed, self-consistent, fresh evidence whose
+  `(provider_id, hardware_identity_hash, chip_normalized, unified_memory_gb)` matches an active
+  trust row and whose `chip_normalized` is in `chip_hardware_profiles` MUST become `verified`
+  with `decision_reason = 'hardware-verifier.v2:verified_trusted_hardware'` and MUST upsert
+  `provider_hardware_profiles.verified = TRUE`.
+- **AC-HV-2 (ordered reasons).** For each gate in §5, a job failing exactly that gate first MUST
+  persist `decision_reason = 'hardware-verifier.v2:<that reason>'`. Gate order is normative.
+- **AC-HV-3 (waiting is non-terminal).** A job missing only a trust row or chip profile MUST
+  become `waiting_trust` (not `rejected`), and MUST promote to `verified` on a later run once
+  the missing operator-curated row exists — with no re-submission.
+- **AC-HV-4 (no self-certification).** No write by `provider_onboarding` may set
+  `provider_hardware_profiles.verified = TRUE` (trigger-enforced); a provider without a trust
+  row MUST NOT reach `verified`.
+- **AC-HV-5 (monotonic promotion).** An older evidence document MUST NOT overwrite a newer
+  verified profile (`last_reported_at` guard, application + trigger).
+- **AC-HV-6 (replay).** Two submissions of the same evidence document MUST NOT create two jobs
+  (`evidence_sha256` UNIQUE); verification is evaluated at most once per distinct document.
+- **AC-HV-7 (batch isolation).** Concurrent verifier instances MUST NOT double-process a job
+  (`FOR UPDATE SKIP LOCKED` + terminal-safe write `WHERE`).
+- **AC-HV-8 (Smoke fail-closed).** A run whose `Smoke` preflight fails (wrong DB role or an
+  unreadable table) MUST abort before touching any job.
+- **AC-HV-9 (legacy grandfathering).** A `hardware-verifier.v1:verified` row MUST remain
+  terminal-`verified` and MUST NOT be re-evaluated.
+
+---
+
+## Change log
+
+**v0.1-draft (2026-07-12) — reconstructed baseline (runbook item 10).**
+- First canonical spec for the shipped `hardware-verifier.v2` evidence verifier
+  (`phase4-coordinator/internal/stats/hardwareverify/verify.go`). Documents the decision-reason
+  taxonomy, the ordered gate pipeline, the `pending`/`waiting_trust`/`verified`/`rejected` state
+  machine, promotion + monotonicity, batch/concurrency, `evidence_sha256` replay resistance, and
+  the least-privilege + trigger security model that makes provider self-certification impossible.
+- Closes the naming drift: the live success constant is
+  `hardware-verifier.v2:verified_trusted_hardware` (v2, not v1); legacy `v1:verified` rows are
+  grandfathered.
+- Spec-only, no code change: the code is the source of truth and this document byte-matches it.

--- a/specs/SPEC-033-hardware-verifier.md
+++ b/specs/SPEC-033-hardware-verifier.md
@@ -1,6 +1,6 @@
 # SPEC-033 — Hardware-Evidence Verifier (`hardware-verifier.v2`)
 
-**Status:** v0.5-draft
+**Status:** v0.6-draft
 **Date:** 2026-07-12
 **Depends on:** SPEC-023 (autotune — produces the benchmark/recommendation inputs the evidence document carries). **Consumed by:** SPEC-032 (autotune hardware-evidence admission "hello-gate") reads this spec's verdict via an **exact-`hardware-verifier.v2`** lookup and cross-references it as "the item-10 hardware-verifier verdict spec". This spec owns the `hardware-verifier.v2` decision semantics and the job/profile lifecycle; SPEC-032 owns how a `verified` profile gates admission.
 
@@ -377,8 +377,9 @@ matches **zero rows** — the existing (newer) profile is left intact — yet th
 
 ### 7.3 Post-verdict demotion (operator inventory sync) — best-effort (one escape R1, one ergonomics gap R2)
 
-`provider_hardware_profiles.verified` is not permanent, but demotion is **best-effort and has
-documented escape paths (§10.4)** — it is NOT a reliable revocation guarantee. The operator
+`provider_hardware_profiles.verified` is not permanent, but demotion is **best-effort — it has one
+documented escape (R1) and one operator-ergonomics gap (R2) (§10.4)** — it is NOT a reliable
+revocation guarantee. The operator
 inventory sync (`cmd/stats-inventory-sync`, role `stats_inventory_writer`) runs
 `applyTrustDemotions`. The exact predicate (`main.go`) sets `verified = FALSE` for every profile
 where `verified = TRUE` **AND** `source = 'cli_hello'` **AND `NOT EXISTS`** a **combined witness** —
@@ -603,6 +604,12 @@ issues; closing them is code follow-up, not a spec change:
 ---
 
 ## Change log
+
+**v0.6-draft (2026-07-12) — audit reconciliation (SPEC-033 R5, 3-lane codex).**
+R5 confirmed the entire spec against code — all three lanes returned **0 C/H/M** except one shared
+MEDIUM: a leftover §7.3 lead phrase ("has documented escape paths", plural) contradicting the
+heading and §10.4 (R2 is not an escape). Fixed to "one documented escape (R1) and one
+operator-ergonomics gap (R2)". No other change.
 
 **v0.5-draft (2026-07-12) — audit reconciliation (SPEC-033 R4, 3-lane codex).**
 R4 verified all R3 fixes against code (0 HIGH on all three lanes); remaining items were


### PR DESCRIPTION
## What

Wave C **item 10** — **SPEC-033**: the reconstructed normative baseline for the shipped,
production-live coordinator **hardware-evidence verifier** (`hardware-verifier.v2`), which ships
**unspecced**. It documents the batch job that promotes a provider's autotune hardware evidence to
a `verified` hardware profile (or rejects/parks it), consumed downstream by SPEC-032's admission
gate.

**Spec-only. No code change** — the code (`phase4-coordinator/internal/stats/hardwareverify/verify.go`
+ migrations 007/008/013/015/016/017 + the HTTP enqueue path + the operator inventory
writer/demotion + the runner) is the source of truth; this spec byte-matches it. Closes the naming
drift: the live success constant is `hardware-verifier.v2:verified_trusted_hardware` (v2, not v1);
legacy `v1:verified` rows are grandfathered.

## What it pins

- The ordered `Evaluate` gate pipeline and every reject/wait decision reason (§5).
- The `pending`/`waiting_trust`/`verified`/`rejected` state machine; `waiting_trust` is
  non-terminal and re-evaluated (subject to freshness) (§6, §9).
- The two DB guard triggers — a profile-verification trigger (migration 016) that **re-verifies the
  full trust join inside the database** on every verifier promotion, and a job-state guard
  (migration 008) — plus the least-privilege **column-level** grants (§2).
- The authenticated `POST /v1/providers/hardware-evidence` enqueue path with its canonical
  `evidence_sha256` replay guard, dual rate-limiters, and fail-closed replay state machine (§3.1).
- Promotion + monotonicity + the operator-authority inventory writer and the post-verdict demotion
  lifecycle (§7).
- The two downstream consumer classes — exact-v2 job-reason (SPEC-032 admission, onboarding replay,
  telemetry-drift) and verified-**bit** (SPEC-017 hardware cache) (§4).

## Security model — precise guarantees AND honest non-guarantees (§10)

- **A provider cannot self-certify** (holds; DB grants + triggers enforce it, even under
  onboarding-role compromise).
- **But `verified` is not benchmark authenticity** — the verifier does no signature /
  proof-of-possession / artifact verification; it is string-consistency + an operator trust anchor.
- **`verified` is (chip, memory)-anchored, not identity-anchored, and revocation is best-effort**,
  with one documented **escape (R1)** — a verified provider can re-register via the `app_register`
  path to flip `source` away from `cli_hello` and dodge trust-removal demotion (a compromised
  onboarding role can do this at cross-provider scale) — and one operator-**ergonomics gap (R2)**.
  Both are recorded as **MUST-close** forward items, disclosed not papered over.

## Audit

6-round codex 3-lane loop (code / security / architect via `omc ask codex`), converged to
**0 CRITICAL / 0 HIGH / 0 MEDIUM on all three lanes**. The loop surfaced genuine, previously-unspecced
findings in the shipped verifier — most notably the R1 `app_register` revocation escape and the
in-DB trust re-verification trigger — and corrected several over/under-statements (an overstated
"only the verifier writes `verified`", an inverted demotion predicate, an overstated zero-trust
gap) until the spec byte-matched shipped reality. SPEC-032 already references this as the item-10
verdict spec, so the ownership boundary is clean.
