### PR TITLE
Add durable App-track registration commitment ledger

### DIFF
--- a/phase4-coordinator/internal/stats/integration_test.go
+++ b/phase4-coordinator/internal/stats/integration_test.go
@@ -900,6 +900,85 @@ func TestMigrationsIdempotent(t *testing.T) {
 	}
 }
 
+func TestApptrackRegisterAttemptsUpgradeDowngradeAndReapply(t *testing.T) {
+	fx := startPostgres(t)
+	adminDB := applyMigrationsAndStubOLTP(t, fx)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	assertTableExists := func(want bool) {
+		t.Helper()
+		var exists bool
+		if err := adminDB.QueryRowContext(ctx, `
+SELECT to_regclass('public.provider_register_attempts') IS NOT NULL
+`).Scan(&exists); err != nil {
+			t.Fatalf("lookup provider_register_attempts: %v", err)
+		}
+		if exists != want {
+			t.Fatalf("provider_register_attempts exists=%v, want %v", exists, want)
+		}
+	}
+
+	assertTableExists(true)
+
+	onboardingDB, err := sql.Open("postgres", fx.roleDSN(roleProviderOnboard))
+	if err != nil {
+		t.Fatalf("open provider_onboarding: %v", err)
+	}
+	defer onboardingDB.Close()
+
+	providerID := "p_migration_roundtrip"
+	nonce := "nonce-roundtrip"
+	if _, err := onboardingDB.ExecContext(ctx, `
+INSERT INTO provider_register_attempts (provider_id, nonce, ts_utc, source_ip)
+VALUES ($1, $2, '2026-07-16T00:00:00Z', '127.0.0.1')
+`, providerID, nonce); err != nil {
+		t.Fatalf("provider_onboarding insert: %v", err)
+	}
+	var count int
+	if err := onboardingDB.QueryRowContext(ctx, `
+SELECT COUNT(*) FROM provider_register_attempts
+WHERE provider_id = $1 AND nonce = $2
+`, providerID, nonce).Scan(&count); err != nil {
+		t.Fatalf("provider_onboarding select: %v", err)
+	}
+	if count != 1 {
+		t.Fatalf("provider_onboarding selected %d attempt rows, want 1", count)
+	}
+	for operation, query := range map[string]string{
+		"update": `UPDATE provider_register_attempts SET source_ip = '127.0.0.2' WHERE provider_id = 'p_migration_roundtrip'`,
+		"delete": `DELETE FROM provider_register_attempts WHERE provider_id = 'p_migration_roundtrip'`,
+		"prune":  `SELECT prune_provider_register_attempts(INTERVAL '30 days')`,
+	} {
+		if _, err := onboardingDB.ExecContext(ctx, query); err == nil || !strings.Contains(strings.ToLower(err.Error()), "permission denied") {
+			t.Fatalf("provider_onboarding %s error=%v, want permission denied", operation, err)
+		}
+	}
+
+	if err := statsmigrations.Apply(ctx, adminDB); err != nil {
+		t.Fatalf("idempotent re-apply with migration 018 present: %v", err)
+	}
+	assertTableExists(true)
+
+	downSQL, err := os.ReadFile("migrations/018_apptrack_register_attempts.down.sql")
+	if err != nil {
+		t.Fatalf("read migration 018 rollback artifact: %v", err)
+	}
+	if _, err := adminDB.ExecContext(ctx, string(downSQL)); err != nil {
+		t.Fatalf("apply migration 018 rollback: %v", err)
+	}
+	if _, err := adminDB.ExecContext(ctx, `DELETE FROM schema_migrations_spec017 WHERE version = 18`); err != nil {
+		t.Fatalf("remove rolled-back migration 018 ledger row: %v", err)
+	}
+	assertTableExists(false)
+
+	if err := statsmigrations.Apply(ctx, adminDB); err != nil {
+		t.Fatalf("re-apply migration 018 after rollback: %v", err)
+	}
+	assertTableExists(true)
+}
+
 // TestMigrationsConcurrent — round-1 CODE r1 CRITICAL C1 fix.
 // Two parallel Apply calls must both succeed without leaving
 // duplicate rows in schema_migrations_spec017 or double-applying

--- a/phase4-coordinator/internal/stats/integration_test.go
+++ b/phase4-coordinator/internal/stats/integration_test.go
@@ -946,6 +946,16 @@ WHERE provider_id = $1 AND nonce = $2
 	if count != 1 {
 		t.Fatalf("provider_onboarding selected %d attempt rows, want 1", count)
 	}
+	if _, err := onboardingDB.ExecContext(ctx, `
+INSERT INTO provider_register_attempts (
+    provider_id, nonce, ts_utc, source_ip, committed_at
+) VALUES (
+    'p_forged_commit_time', 'nonce-forged', '2026-07-16T00:00:00Z',
+    '127.0.0.1', '2000-01-01T00:00:00Z'
+)
+`); err == nil || !strings.Contains(strings.ToLower(err.Error()), "permission denied") {
+		t.Fatalf("provider_onboarding committed_at override error=%v, want permission denied", err)
+	}
 	for operation, query := range map[string]string{
 		"update": `UPDATE provider_register_attempts SET source_ip = '127.0.0.2' WHERE provider_id = 'p_migration_roundtrip'`,
 		"delete": `DELETE FROM provider_register_attempts WHERE provider_id = 'p_migration_roundtrip'`,

--- a/phase4-coordinator/internal/stats/migrations/018_apptrack_register_attempts.down.sql
+++ b/phase4-coordinator/internal/stats/migrations/018_apptrack_register_attempts.down.sql
@@ -1,0 +1,6 @@
+-- Operator rollback artifact. The embedded runner applies only *.up.sql.
+REVOKE ALL ON provider_register_attempts FROM provider_onboarding;
+REVOKE ALL ON FUNCTION prune_provider_register_attempts(INTERVAL) FROM PUBLIC;
+
+DROP FUNCTION IF EXISTS prune_provider_register_attempts(INTERVAL);
+DROP TABLE IF EXISTS provider_register_attempts;

--- a/phase4-coordinator/internal/stats/migrations/018_apptrack_register_attempts.up.sql
+++ b/phase4-coordinator/internal/stats/migrations/018_apptrack_register_attempts.up.sql
@@ -41,8 +41,12 @@ BEGIN
 END;
 $$;
 
--- The runtime role can record and verify commitments but cannot mutate them.
-GRANT SELECT, INSERT ON provider_register_attempts TO provider_onboarding;
+-- The runtime role can record and verify commitments but cannot mutate them or
+-- choose the database-owned commitment timestamp used by retention.
+REVOKE INSERT ON provider_register_attempts FROM provider_onboarding;
+GRANT SELECT ON provider_register_attempts TO provider_onboarding;
+GRANT INSERT (provider_id, nonce, ts_utc, source_ip)
+    ON provider_register_attempts TO provider_onboarding;
 
 REVOKE ALL ON FUNCTION prune_provider_register_attempts(INTERVAL) FROM PUBLIC;
 REVOKE ALL ON FUNCTION prune_provider_register_attempts(INTERVAL) FROM provider_onboarding;

--- a/phase4-coordinator/internal/stats/migrations/018_apptrack_register_attempts.up.sql
+++ b/phase4-coordinator/internal/stats/migrations/018_apptrack_register_attempts.up.sql
@@ -1,0 +1,48 @@
+-- Durable commitment marker for App-track provider registration.
+--
+-- The replay nonce table is intentionally short-lived and therefore cannot
+-- prove that the PostgreSQL half of a cross-store referral mint committed.
+-- This table is written in the same transaction as provider identity prepare
+-- and survives well beyond the SQLite saga reconciliation horizon.
+--
+-- The primary key contains signed, replay-stable fields only. source_ip is
+-- connection-dependent diagnostic metadata and is never authoritative.
+CREATE TABLE IF NOT EXISTS provider_register_attempts (
+    provider_id  TEXT NOT NULL,
+    nonce        TEXT NOT NULL,
+    ts_utc       TIMESTAMPTZ NOT NULL,
+    source_ip    TEXT,
+    committed_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    PRIMARY KEY (provider_id, nonce, ts_utc)
+);
+
+CREATE INDEX IF NOT EXISTS idx_provider_register_attempts_committed_at
+    ON provider_register_attempts(committed_at);
+
+-- Keep attempt evidence for at least seven days. This is deliberately much
+-- longer than the registration reconciliation horizon.
+CREATE OR REPLACE FUNCTION prune_provider_register_attempts(retain_for INTERVAL DEFAULT INTERVAL '30 days')
+RETURNS BIGINT
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = pg_catalog, public, pg_temp
+AS $$
+DECLARE
+    deleted_count BIGINT;
+BEGIN
+    IF retain_for < INTERVAL '7 days' THEN
+        RAISE EXCEPTION 'retain_for must be at least 7 days';
+    END IF;
+
+    DELETE FROM provider_register_attempts
+     WHERE committed_at < NOW() - retain_for;
+    GET DIAGNOSTICS deleted_count = ROW_COUNT;
+    RETURN deleted_count;
+END;
+$$;
+
+-- The runtime role can record and verify commitments but cannot mutate them.
+GRANT SELECT, INSERT ON provider_register_attempts TO provider_onboarding;
+
+REVOKE ALL ON FUNCTION prune_provider_register_attempts(INTERVAL) FROM PUBLIC;
+REVOKE ALL ON FUNCTION prune_provider_register_attempts(INTERVAL) FROM provider_onboarding;

--- a/phase4-coordinator/internal/stats/migrations/migrations_test.go
+++ b/phase4-coordinator/internal/stats/migrations/migrations_test.go
@@ -580,7 +580,9 @@ func TestApptrackRegisterAttemptsMigrationShape(t *testing.T) {
 		"CREATE OR REPLACE FUNCTION prune_provider_register_attempts",
 		"retain_for must be at least 7 days",
 		"SET search_path = pg_catalog, public, pg_temp",
-		"GRANT SELECT, INSERT ON provider_register_attempts TO provider_onboarding",
+		"REVOKE INSERT ON provider_register_attempts FROM provider_onboarding",
+		"GRANT SELECT ON provider_register_attempts TO provider_onboarding",
+		"GRANT INSERT (provider_id, nonce, ts_utc, source_ip)",
 		"REVOKE ALL ON FUNCTION prune_provider_register_attempts(INTERVAL) FROM PUBLIC",
 		"REVOKE ALL ON FUNCTION prune_provider_register_attempts(INTERVAL) FROM provider_onboarding",
 	} {
@@ -588,6 +590,8 @@ func TestApptrackRegisterAttemptsMigrationShape(t *testing.T) {
 	}
 	mustNotContain(t, body, "GRANT DELETE ON provider_register_attempts",
 		"runtime onboarding role must not delete durable attempt markers")
+	mustNotContain(t, body, "GRANT SELECT, INSERT ON provider_register_attempts",
+		"runtime onboarding role must not receive table-level insert")
 	mustNotContain(t, body, "PRIMARY KEY (provider_id, nonce, ts_utc, source_ip)",
 		"connection metadata must not participate in commitment identity")
 

--- a/phase4-coordinator/internal/stats/migrations/migrations_test.go
+++ b/phase4-coordinator/internal/stats/migrations/migrations_test.go
@@ -38,6 +38,7 @@ func TestEmbeddedMigrationsLoad(t *testing.T) {
 		{15, "provider_onboarding_hardware_decision_reason"},
 		{16, "hardware_profile_memory_reverification"},
 		{17, "autotune_current_hardware_gate_grants"},
+		{18, "apptrack_register_attempts"},
 	}
 	if len(all) != len(want) {
 		t.Fatalf("got %d migrations, want %d", len(all), len(want))
@@ -557,4 +558,49 @@ func extractBetween(body, start, end string) string {
 		return rest
 	}
 	return rest[:j+len(end)]
+}
+
+func TestApptrackRegisterAttemptsMigrationShape(t *testing.T) {
+	all, err := All()
+	if err != nil {
+		t.Fatalf("All: %v", err)
+	}
+	var body string
+	for _, m := range all {
+		if m.Name == "apptrack_register_attempts" {
+			body = m.SQL
+		}
+	}
+	if body == "" {
+		t.Fatal("apptrack_register_attempts migration body is empty")
+	}
+	for _, needle := range []string{
+		"CREATE TABLE IF NOT EXISTS provider_register_attempts",
+		"PRIMARY KEY (provider_id, nonce, ts_utc)",
+		"CREATE OR REPLACE FUNCTION prune_provider_register_attempts",
+		"retain_for must be at least 7 days",
+		"SET search_path = pg_catalog, public, pg_temp",
+		"GRANT SELECT, INSERT ON provider_register_attempts TO provider_onboarding",
+		"REVOKE ALL ON FUNCTION prune_provider_register_attempts(INTERVAL) FROM PUBLIC",
+		"REVOKE ALL ON FUNCTION prune_provider_register_attempts(INTERVAL) FROM provider_onboarding",
+	} {
+		mustContain(t, body, needle, "durable registration attempt marker migration")
+	}
+	mustNotContain(t, body, "GRANT DELETE ON provider_register_attempts",
+		"runtime onboarding role must not delete durable attempt markers")
+	mustNotContain(t, body, "PRIMARY KEY (provider_id, nonce, ts_utc, source_ip)",
+		"connection metadata must not participate in commitment identity")
+
+	down, err := os.ReadFile("018_apptrack_register_attempts.down.sql")
+	if err != nil {
+		t.Fatalf("read rollback artifact: %v", err)
+	}
+	downSQL := string(down)
+	for _, needle := range []string{
+		"REVOKE ALL ON provider_register_attempts FROM provider_onboarding",
+		"DROP FUNCTION IF EXISTS prune_provider_register_attempts(INTERVAL)",
+		"DROP TABLE IF EXISTS provider_register_attempts",
+	} {
+		mustContain(t, downSQL, needle, "registration attempt rollback artifact")
+	}
 }


### PR DESCRIPTION
## Outcome

Restacks the durable PostgreSQL registration-commitment ledger onto the #621 integration baseline now merged as `a3859d6b` on `main`.

This remains a schema-only base. It adds no coordinator consumer, Malibu credential flow, provider-process ownership, serving qualification, social reward logic, or production activation.

## Authority and safety

- The launchd-managed `macprovider-cli` remains provider lifecycle, registration, identity, credential, update, and process authority.
- Malibu remains a non-secret UI/monitor and does not participate in this migration.
- The ledger key is the signed replay-stable tuple `(provider_id, nonce, ts_utc)`; `source_ip` is diagnostic only.
- `committed_at` is database-owned. `provider_onboarding` receives table `SELECT` and column-scoped `INSERT` only for `(provider_id, nonce, ts_utc, source_ip)`.
- The runtime role cannot forge the retention clock, update/delete evidence, or execute the security-definer prune function.

## Deployment and rollback

1. Apply migration `018_apptrack_register_attempts` before the dependent coordinator admission PR.
2. Keep all referral production flags disabled.
3. Remove or disable dependent consumers before applying the explicit down migration.

Migration 018 is unique and remains the next migration after 017 on the merged baseline.

## Verification on head `dfcb8c1e`

- `go test -count=1 ./internal/stats/migrations`
- `go test -count=1 ./internal/stats`
- `go test ./...`
- `go vet ./...`
- `git diff --check`
- Independent code, architecture, and security re-audits: PASS, 0 Critical/High/Medium
- Docker is unavailable locally, so the fresh GitHub PostgreSQL lane must prove upgrade, no-op reapply, downgrade, re-upgrade, least privilege, and forged-`committed_at` denial before merge.

## Real dependency sequence

1. #621 — lifecycle/spec integration baseline — merged
2. this PR — ledger/migration
3. #574 — coordinator referral admission, to be rebased onto the resulting `main`
4. #576 — join links/operator controls, then rebased onto `main`
5. #623 — coordinator advocacy/X rewards, then rebased onto `main`
6. #625 — CLI/Malibu onboarding, revalidated against the merged server/spec baseline
7. #626 — Malibu referral/advocacy UI, rebased after #625
8. signed/notarized physical acceptance candidate and activation PR only after the two-provider real-X exactly-once journey passes

No child PR will be squash-merged from a feature-branch base. Production flags remain disabled through physical acceptance.