### PR TITLE
Gate fresh provider admission with a durable referral saga

### DIFF
--- a/phase4-coordinator/cmd/coordinator/main.go
+++ b/phase4-coordinator/cmd/coordinator/main.go
@@ -528,13 +528,19 @@ func main() {
 		catalogLog.Msg("provider catalog compatibility enabled")
 	}
 	var onboardingStore *onboarding.PGStore
-	if cfg.Onboarding.AppTrackRegisterEnabled {
-		onboardingStore, err = onboarding.OpenPGStoreWithAuthPolicyDSNs(
-			cfg.Onboarding.PostgresDSN,
-			cfg.Onboarding.AuthPolicyRequestDSN,
-			cfg.Onboarding.AuthPolicyApproveDSN,
-			cfg.Onboarding.AuthPolicyCutoverDSN,
-		)
+	if shouldOpenOnboardingStore(cfg.Onboarding) {
+		if cfg.Onboarding.AppTrackRegisterEnabled {
+			onboardingStore, err = onboarding.OpenPGStoreWithAuthPolicyDSNs(
+				cfg.Onboarding.PostgresDSN,
+				cfg.Onboarding.AuthPolicyRequestDSN,
+				cfg.Onboarding.AuthPolicyApproveDSN,
+				cfg.Onboarding.AuthPolicyCutoverDSN,
+			)
+		} else {
+			// Keep the primary authority available to reconcile referral mints
+			// created before an operator disabled the public registration route.
+			onboardingStore, err = onboarding.OpenPGStore(cfg.Onboarding.PostgresDSN)
+		}
 		if err != nil {
 			logger.Fatal().Err(err).Msg("open onboarding postgres store")
 		}
@@ -542,8 +548,10 @@ func main() {
 		if err := onboardingStore.Smoke(context.Background()); err != nil {
 			logger.Fatal().Err(err).Msg("onboarding postgres smoke failed")
 		}
-		wsOpts = append(wsOpts, providerws.WithIdentitySignatureStore(onboardingStore))
-		wsOpts = append(wsOpts, providerws.WithProviderAuthPolicyAdminStore(onboardingStore))
+		if cfg.Onboarding.AppTrackRegisterEnabled {
+			wsOpts = append(wsOpts, providerws.WithIdentitySignatureStore(onboardingStore))
+			wsOpts = append(wsOpts, providerws.WithProviderAuthPolicyAdminStore(onboardingStore))
+		}
 	}
 	if cfg.ProofOfWeights.RequireAutotuneHelloGate {
 		if autotuneCatalog == nil {
@@ -865,41 +873,46 @@ func main() {
 
 	var register http.HandlerFunc
 	var hardwareEvidence http.HandlerFunc
+	registerHandler := &onboarding.Handler{
+		StatsDB:                             onboardingStore,
+		AuthTokenStore:                      tokenStore,
+		ReferralStore:                       tokenStore,
+		ReferralPolicy:                      referralPolicy,
+		CoordinatorDomain:                   cfg.Onboarding.CoordinatorDomain,
+		CoordinatorWSURL:                    "wss://" + cfg.Onboarding.CoordinatorDomain + "/v2/provider",
+		TrustedProxies:                      mustParseTrustedProxies(cfg, logger),
+		IPRateLimiter:                       onboarding.NewMemoryRateLimiter(5, time.Minute),
+		CommittedRetryRateLimiter:           onboarding.NewMemoryRateLimiter(5, time.Minute),
+		CommittedRetryGlobalRateLimiter:     onboarding.NewMemoryRateLimiter(60, time.Minute),
+		CommittedRetrySlots:                 make(chan struct{}, 4),
+		ASNRateLimiter:                      onboarding.NewMemoryRateLimiter(30, time.Minute),
+		HardwareEvidenceIPRateLimiter:       onboarding.NewMemoryRateLimiter(10, time.Minute),
+		HardwareEvidenceProviderRateLimiter: onboarding.NewMemoryRateLimiter(1, 10*time.Minute),
+		AppAttestVerifier: onboarding.AppleAppAttestVerifier{
+			Config: onboarding.AppAttestConfig{
+				CoordinatorDomain: cfg.Onboarding.CoordinatorDomain,
+				BundleID:          cfg.Onboarding.BundleID,
+				TeamID:            cfg.Onboarding.AppleTeamID,
+			},
+		},
+		Metrics: metricsHandle,
+		AppAttestConfig: onboarding.AppAttestConfig{
+			CoordinatorDomain: cfg.Onboarding.CoordinatorDomain,
+			BundleID:          cfg.Onboarding.BundleID,
+			TeamID:            cfg.Onboarding.AppleTeamID,
+		},
+	}
+	// Pending cross-store referral mints must converge even when operators
+	// disable the admission route or referral enforcement after a crash.
+	startAppTrackReferralMintReconciler(shutdownCtx, registerHandler, logger)
 	if cfg.Onboarding.AppTrackRegisterEnabled {
 		asnResolver, err := onboarding.NewStaticASNResolver(cfg.Onboarding.ASNPrefixes)
 		if err != nil {
 			logger.Fatal().Err(err).Msg("onboarding ASN resolver config invalid")
 		}
-		registerHandler := &onboarding.Handler{
-			StatsDB:                             onboardingStore,
-			AuthTokenStore:                      tokenStore,
-			ReferralStore:                       tokenStore,
-			ReferralPolicy:                      referralPolicy,
-			CoordinatorDomain:                   cfg.Onboarding.CoordinatorDomain,
-			CoordinatorWSURL:                    "wss://" + cfg.Onboarding.CoordinatorDomain + "/v2/provider",
-			TrustedProxies:                      mustParseTrustedProxies(cfg, logger),
-			IPRateLimiter:                       onboarding.NewMemoryRateLimiter(5, time.Minute),
-			ASNRateLimiter:                      onboarding.NewMemoryRateLimiter(30, time.Minute),
-			ASNResolver:                         asnResolver,
-			HardwareEvidenceIPRateLimiter:       onboarding.NewMemoryRateLimiter(10, time.Minute),
-			HardwareEvidenceProviderRateLimiter: onboarding.NewMemoryRateLimiter(1, 10*time.Minute),
-			AppAttestVerifier: onboarding.AppleAppAttestVerifier{
-				Config: onboarding.AppAttestConfig{
-					CoordinatorDomain: cfg.Onboarding.CoordinatorDomain,
-					BundleID:          cfg.Onboarding.BundleID,
-					TeamID:            cfg.Onboarding.AppleTeamID,
-				},
-			},
-			Metrics: metricsHandle,
-			AppAttestConfig: onboarding.AppAttestConfig{
-				CoordinatorDomain: cfg.Onboarding.CoordinatorDomain,
-				BundleID:          cfg.Onboarding.BundleID,
-				TeamID:            cfg.Onboarding.AppleTeamID,
-			},
-		}
+		registerHandler.ASNResolver = asnResolver
 		register = registerHandler.HandleAppTrackRegister
 		hardwareEvidence = registerHandler.HandleHardwareEvidence
-		startAppTrackReferralMintReconciler(shutdownCtx, registerHandler, logger)
 		logger.Info().Msg("SPEC-026 app-track register route mounted on buyer port")
 	}
 	// Phase 2 Track P2-A: MDM enrollment profile endpoint.
@@ -1212,8 +1225,16 @@ func startGitHubAuthStatePruner(ctx context.Context, store githubAuthStatePruner
 	}()
 }
 
-func startAppTrackReferralMintReconciler(ctx context.Context, handler *onboarding.Handler, logger zerolog.Logger) {
-	if handler == nil || !handler.ReferralPolicy.RequireForRegistration {
+type appTrackReferralMintReconciler interface {
+	ReconcilePendingAppTrackReferralMints(context.Context) error
+}
+
+func shouldOpenOnboardingStore(cfg config.OnboardingConfig) bool {
+	return cfg.AppTrackRegisterEnabled || strings.TrimSpace(cfg.PostgresDSN) != ""
+}
+
+func startAppTrackReferralMintReconciler(ctx context.Context, handler appTrackReferralMintReconciler, logger zerolog.Logger) {
+	if handler == nil {
 		return
 	}
 	go func() {

--- a/phase4-coordinator/cmd/coordinator/main.go
+++ b/phase4-coordinator/cmd/coordinator/main.go
@@ -29,6 +29,7 @@ import (
 	"github.com/augstar/macprovider-coordinator/internal/pool"
 	"github.com/augstar/macprovider-coordinator/internal/pow"
 	"github.com/augstar/macprovider-coordinator/internal/providerhttp"
+	"github.com/augstar/macprovider-coordinator/internal/referralapi"
 	"github.com/augstar/macprovider-coordinator/internal/requestlog"
 	"github.com/augstar/macprovider-coordinator/internal/rewards"
 	"github.com/augstar/macprovider-coordinator/internal/stats"
@@ -453,7 +454,28 @@ func main() {
 		}
 	}()
 	wsOpts := []providerws.Option{}
+	var grandfatherBefore *time.Time
+	if raw := strings.TrimSpace(cfg.Referrals.GrandfatherBefore); raw != "" && cfg.Referrals.RequireForRegistration {
+		parsed, err := time.Parse(time.RFC3339, raw)
+		if err != nil {
+			logger.Fatal().Err(err).Msg("parse referral grandfather cutoff")
+		}
+		grandfatherBefore = &parsed
+	}
+	referralPolicy := auth.ReferralPolicy{
+		RequireForRegistration: cfg.Referrals.RequireForRegistration,
+		EnableSocialBonus:      cfg.Referrals.EnableSocialInviteBonus,
+		Campaign:               cfg.Referrals.Campaign,
+		PolicyVersion:          cfg.Referrals.PolicyVersion,
+		GrandfatherBefore:      grandfatherBefore,
+		CurrentKeyID:           cfg.Referrals.CurrentKeyID,
+		HMACKeys:               cfg.Referrals.HMACKeys,
+		ProviderBaseUses:       cfg.Referrals.ProviderBaseUses,
+		SocialBonusUses:        cfg.Referrals.SocialBonusUses,
+		ChallengeTTL:           time.Duration(cfg.Referrals.ChallengeTTLS) * time.Second,
+	}
 	wsOpts = append(wsOpts, providerws.WithVersion(version))
+	wsOpts = append(wsOpts, providerws.WithReferralPolicy(referralPolicy))
 	wsOpts = append(wsOpts, providerws.WithAdmissionStore(admissionStore))
 	if canaryStore != nil {
 		wsOpts = append(wsOpts, providerws.WithCanarySanctionStore(canaryStore))
@@ -851,6 +873,8 @@ func main() {
 		registerHandler := &onboarding.Handler{
 			StatsDB:                             onboardingStore,
 			AuthTokenStore:                      tokenStore,
+			ReferralStore:                       tokenStore,
+			ReferralPolicy:                      referralPolicy,
 			CoordinatorDomain:                   cfg.Onboarding.CoordinatorDomain,
 			CoordinatorWSURL:                    "wss://" + cfg.Onboarding.CoordinatorDomain + "/v2/provider",
 			TrustedProxies:                      mustParseTrustedProxies(cfg, logger),
@@ -875,6 +899,7 @@ func main() {
 		}
 		register = registerHandler.HandleAppTrackRegister
 		hardwareEvidence = registerHandler.HandleHardwareEvidence
+		startAppTrackReferralMintReconciler(shutdownCtx, registerHandler, logger)
 		logger.Info().Msg("SPEC-026 app-track register route mounted on buyer port")
 	}
 	// Phase 2 Track P2-A: MDM enrollment profile endpoint.
@@ -887,7 +912,7 @@ func main() {
 			Str("base_url", cfg.Tier2.MDM.EnrollmentBaseURL).
 			Msg("MDM enrollment profile route mounted on buyer port (/v1/enroll)")
 	}
-	buyerHandler := buyerHandlerWithOptionalProviderEndpoints(
+	var buyerHandler http.Handler = buyerHandlerWithOptionalProviderEndpoints(
 		buyerServer.Handler(),
 		cfg.Onboarding.AppTrackRegisterEnabled,
 		register,
@@ -895,6 +920,17 @@ func main() {
 		enrollHandler,
 		malibuAccrualHandler(cfg, tokenStore, rewardsDB, rewards.NewPoolHeartbeatBridge(wsServer.PoolSnapshot)),
 	)
+	trustedReferralProxies := mustParseTrustedProxies(cfg, logger)
+	referralValidation := &referralapi.ValidationHandler{
+		Store:         tokenStore,
+		Policy:        referralPolicy,
+		PublicLimiter: referralapi.NewBoundedLimiter(30, time.Minute, 4096),
+		ValidateSlots: make(chan struct{}, 4),
+		SourceIP: func(r *http.Request) string {
+			return onboarding.ClientIP(r, trustedReferralProxies)
+		},
+	}
+	buyerHandler = withReferralValidation(buyerHandler, referralValidation.ServeHTTP)
 
 	providerHTTP := newHTTPServer(providerAddr, providerMux)
 	buyerHTTP := newHTTPServer(buyerAddr, buyerHandler)
@@ -1172,6 +1208,32 @@ func startGitHubAuthStatePruner(ctx context.Context, store githubAuthStatePruner
 	}()
 }
 
+func startAppTrackReferralMintReconciler(ctx context.Context, handler *onboarding.Handler, logger zerolog.Logger) {
+	if handler == nil || !handler.ReferralPolicy.RequireForRegistration {
+		return
+	}
+	go func() {
+		reconcile := func() {
+			reconcileCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+			defer cancel()
+			if err := handler.ReconcilePendingAppTrackReferralMints(reconcileCtx); err != nil && ctx.Err() == nil {
+				logger.Error().Err(err).Msg("App-track referral mint reconciliation failed")
+			}
+		}
+		reconcile()
+		ticker := time.NewTicker(time.Minute)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				reconcile()
+			}
+		}
+	}()
+}
+
 func startAuditLogRetentionPruner(ctx context.Context, store requestLogPruner, retentionDays int, logger zerolog.Logger) {
 	if store == nil || retentionDays <= 0 {
 		return
@@ -1242,6 +1304,16 @@ func buyerHandlerWithOptionalProviderEndpoints(base http.Handler, enabled bool, 
 	if malibuAccrual != nil {
 		mux.Handle("/v1/provider/malibu-accrual", malibuAccrual)
 	}
+	mux.Handle("/", base)
+	return mux
+}
+
+func withReferralValidation(base http.Handler, validate http.HandlerFunc) http.Handler {
+	if validate == nil {
+		return base
+	}
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v1/referrals/validate", validate)
 	mux.Handle("/", base)
 	return mux
 }

--- a/phase4-coordinator/cmd/coordinator/main.go
+++ b/phase4-coordinator/cmd/coordinator/main.go
@@ -920,17 +920,21 @@ func main() {
 		enrollHandler,
 		malibuAccrualHandler(cfg, tokenStore, rewardsDB, rewards.NewPoolHeartbeatBridge(wsServer.PoolSnapshot)),
 	)
-	trustedReferralProxies := mustParseTrustedProxies(cfg, logger)
-	referralValidation := &referralapi.ValidationHandler{
-		Store:         tokenStore,
-		Policy:        referralPolicy,
-		PublicLimiter: referralapi.NewBoundedLimiter(30, time.Minute, 4096),
-		ValidateSlots: make(chan struct{}, 4),
-		SourceIP: func(r *http.Request) string {
-			return onboarding.ClientIP(r, trustedReferralProxies)
-		},
+	var referralValidationHandler http.HandlerFunc
+	if cfg.Referrals.EnablePublicValidation {
+		trustedReferralProxies := mustParseTrustedProxies(cfg, logger)
+		referralValidation := &referralapi.ValidationHandler{
+			Store:         tokenStore,
+			Policy:        referralPolicy,
+			PublicLimiter: referralapi.NewBoundedLimiter(30, time.Minute, 4096),
+			ValidateSlots: make(chan struct{}, 4),
+			SourceIP: func(r *http.Request) string {
+				return onboarding.ClientIP(r, trustedReferralProxies)
+			},
+		}
+		referralValidationHandler = referralValidation.ServeHTTP
 	}
-	buyerHandler = withReferralValidation(buyerHandler, referralValidation.ServeHTTP)
+	buyerHandler = withReferralValidation(buyerHandler, referralValidationHandler)
 
 	providerHTTP := newHTTPServer(providerAddr, providerMux)
 	buyerHTTP := newHTTPServer(buyerAddr, buyerHandler)

--- a/phase4-coordinator/cmd/coordinator/main_test.go
+++ b/phase4-coordinator/cmd/coordinator/main_test.go
@@ -46,6 +46,13 @@ func TestNewHTTPServerAppliesTimeouts(t *testing.T) {
 
 func TestWithReferralValidationMountsOnlyValidationRoute(t *testing.T) {
 	base := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(http.StatusNoContent) })
+	disabled := withReferralValidation(base, nil)
+	disabledResponse := httptest.NewRecorder()
+	disabled.ServeHTTP(disabledResponse, httptest.NewRequest(http.MethodPost, "/v1/referrals/validate", nil))
+	if disabledResponse.Code != http.StatusNoContent {
+		t.Fatalf("disabled validation route unexpectedly mounted: status=%d", disabledResponse.Code)
+	}
+
 	handler := withReferralValidation(base, func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(http.StatusOK) })
 
 	response := httptest.NewRecorder()

--- a/phase4-coordinator/cmd/coordinator/main_test.go
+++ b/phase4-coordinator/cmd/coordinator/main_test.go
@@ -67,6 +67,41 @@ func TestWithReferralValidationMountsOnlyValidationRoute(t *testing.T) {
 	}
 }
 
+func TestAppTrackReferralMintReconcilerRunsAfterEnforcementRollback(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	called := make(chan struct{}, 1)
+	startAppTrackReferralMintReconciler(ctx, appTrackReferralMintReconcilerFunc(func(context.Context) error {
+		called <- struct{}{}
+		return nil
+	}), zerolog.Nop())
+
+	select {
+	case <-called:
+	case <-time.After(time.Second):
+		t.Fatal("referral mint reconciler did not run with enforcement disabled")
+	}
+}
+
+func TestOnboardingStoreRemainsOpenAfterRouteRollback(t *testing.T) {
+	cfg := config.Default().Onboarding
+	cfg.AppTrackRegisterEnabled = false
+	cfg.PostgresDSN = "postgres://provider_onboarding@postgres/onboarding"
+	if !shouldOpenOnboardingStore(cfg) {
+		t.Fatal("configured onboarding authority closed when registration route was disabled")
+	}
+	cfg.PostgresDSN = ""
+	if shouldOpenOnboardingStore(cfg) {
+		t.Fatal("unconfigured disabled onboarding store unexpectedly opened")
+	}
+}
+
+type appTrackReferralMintReconcilerFunc func(context.Context) error
+
+func (f appTrackReferralMintReconcilerFunc) ReconcilePendingAppTrackReferralMints(ctx context.Context) error {
+	return f(ctx)
+}
+
 func TestListenAddressParsesIPv4AndIPv6(t *testing.T) {
 	for _, host := range []string{"127.0.0.1", "::1", "::"} {
 		t.Run(host, func(t *testing.T) {

--- a/phase4-coordinator/cmd/coordinator/main_test.go
+++ b/phase4-coordinator/cmd/coordinator/main_test.go
@@ -44,6 +44,22 @@ func TestNewHTTPServerAppliesTimeouts(t *testing.T) {
 	}
 }
 
+func TestWithReferralValidationMountsOnlyValidationRoute(t *testing.T) {
+	base := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(http.StatusNoContent) })
+	handler := withReferralValidation(base, func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(http.StatusOK) })
+
+	response := httptest.NewRecorder()
+	handler.ServeHTTP(response, httptest.NewRequest(http.MethodPost, "/v1/referrals/validate", nil))
+	if response.Code != http.StatusOK {
+		t.Fatalf("validation status=%d", response.Code)
+	}
+	response = httptest.NewRecorder()
+	handler.ServeHTTP(response, httptest.NewRequest(http.MethodPost, "/v1/referrals/reserve", nil))
+	if response.Code != http.StatusNoContent {
+		t.Fatalf("reservation route unexpectedly mounted: status=%d", response.Code)
+	}
+}
+
 func TestListenAddressParsesIPv4AndIPv6(t *testing.T) {
 	for _, host := range []string{"127.0.0.1", "::1", "::"} {
 		t.Run(host, func(t *testing.T) {

--- a/phase4-coordinator/dist/coordinator.yaml
+++ b/phase4-coordinator/dist/coordinator.yaml
@@ -86,10 +86,12 @@ auth:
     spec026_a: env:OPERATOR_AUTH_POLICY_A
     spec026_b: env:OPERATOR_AUTH_POLICY_B
 
-# Pre-beta referral admission. Both switches remain off in checked-in config;
-# enabling either requires an explicit campaign, key id, and 32+ byte HMAC key.
+# Pre-beta referral admission. All public/enforcement switches remain off in
+# checked-in config; enabling one requires an explicit campaign, key id, and
+# 32+ byte HMAC key.
 referrals:
   require_for_registration: false
+  enable_public_validation: false
   enable_social_invite_bonus: false
   campaign: ""
   policy_version: "v1"

--- a/phase4-coordinator/dist/coordinator.yaml
+++ b/phase4-coordinator/dist/coordinator.yaml
@@ -86,6 +86,23 @@ auth:
     spec026_a: env:OPERATOR_AUTH_POLICY_A
     spec026_b: env:OPERATOR_AUTH_POLICY_B
 
+# Pre-beta referral admission. Both switches remain off in checked-in config;
+# enabling either requires an explicit campaign, key id, and 32+ byte HMAC key.
+referrals:
+  require_for_registration: false
+  enable_social_invite_bonus: false
+  campaign: ""
+  policy_version: "v1"
+  grandfather_before: ""
+  current_key_id: ""
+  hmac_keys: {}
+  provider_base_uses: 1
+  social_bonus_uses: 2
+  challenge_ttl_s: 900
+  join_base_url: "https://coordinator.streamvc.live/j"
+  x_api_bearer_token: ""
+  request_access_url: ""
+
 # SPEC-007 v0.2 — internal read-only operator explorer.
 # Reuses auth.operator_key (D15). Disable by setting enabled: false.
 # Mounted at /admin/explorer/ on provider_port (8444); already proxied by nginx.

--- a/phase4-coordinator/internal/auth/apptrack_referral_mints.go
+++ b/phase4-coordinator/internal/auth/apptrack_referral_mints.go
@@ -28,19 +28,24 @@ type PendingAppTrackReferralMint struct {
 }
 
 // MintProviderTokenAppTrackWithReferralAttempt validates and redeems the
-// referral, creates an undisclosed credential, and records an exact pending
-// saga in one SQLite transaction. It never rotates an existing credential.
+// referral, commits the client's signed credential candidate, and records an
+// exact pending saga in one SQLite transaction. It never rotates an existing
+// credential; the client already has custody if the HTTP response is lost.
 func (s *Store) MintProviderTokenAppTrackWithReferralAttempt(
 	ctx context.Context,
-	providerID, referralCode string,
+	providerID, referralCode, tokenCandidate string,
 	policy ReferralPolicy,
 	attempt AppTrackRegistrationAttempt,
 ) (string, error) {
 	if err := config.ValidateProviderID(providerID); err != nil {
 		return "", err
 	}
+	tokenCandidate = strings.TrimSpace(tokenCandidate)
 	if !policy.RequireForRegistration || strings.TrimSpace(attempt.SourceIP) == "" ||
 		strings.TrimSpace(attempt.Nonce) == "" || attempt.AttemptTS.IsZero() {
+		return "", ErrReferralConflict
+	}
+	if len(tokenCandidate) != 64 || !isLowerHexToken(tokenCandidate) {
 		return "", ErrReferralConflict
 	}
 
@@ -61,16 +66,12 @@ SELECT COUNT(1) FROM provider_tokens
 		if err != nil {
 			return err
 		}
-		newToken, err := randomHex(32)
-		if err != nil {
-			return err
-		}
-		hash := tokenHash(newToken)
+		hash := tokenHash(tokenCandidate)
 		if _, err := conn.ExecContext(ctx, `
 INSERT INTO provider_tokens
     (token_hash, token_prefix, provider_id, provider_name, created_at)
 VALUES (?, ?, ?, 'malibu-app', ?)`,
-			hash, newToken[:tokenDisplayPrefixLength], providerID, timeText(now),
+			hash, tokenCandidate[:tokenDisplayPrefixLength], providerID, timeText(now),
 		); err != nil {
 			if isActiveProviderTokenConstraintFailure(err) {
 				return ErrActiveTokenAlreadyExists
@@ -88,13 +89,22 @@ INSERT INTO apptrack_pending_referral_mints (
 		); err != nil {
 			return err
 		}
-		token = newToken
+		token = tokenCandidate
 		return nil
 	})
 	if err != nil {
 		return "", err
 	}
 	return token, nil
+}
+
+func isLowerHexToken(value string) bool {
+	for _, r := range value {
+		if (r < '0' || r > '9') && (r < 'a' || r > 'f') {
+			return false
+		}
+	}
+	return true
 }
 
 // AcknowledgeAppTrackReferralMint removes the saga only after PostgreSQL has

--- a/phase4-coordinator/internal/auth/apptrack_referral_mints.go
+++ b/phase4-coordinator/internal/auth/apptrack_referral_mints.go
@@ -1,0 +1,225 @@
+package auth
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/augstar/macprovider-coordinator/internal/config"
+	"github.com/augstar/macprovider-coordinator/internal/sqliteutil"
+)
+
+// AppTrackRegistrationAttempt identifies the PostgreSQL half of a gated
+// registration. AttemptTS is the signed request timestamp and therefore stable
+// across transport retries; SourceIP is retained only as diagnostic metadata.
+type AppTrackRegistrationAttempt struct {
+	SourceIP  string
+	Nonce     string
+	AttemptTS time.Time
+}
+
+type PendingAppTrackReferralMint struct {
+	ProviderID string
+	TokenHash  string
+	Attempt    AppTrackRegistrationAttempt
+}
+
+// MintProviderTokenAppTrackWithReferralAttempt validates and redeems the
+// referral, creates an undisclosed credential, and records an exact pending
+// saga in one SQLite transaction. It never rotates an existing credential.
+func (s *Store) MintProviderTokenAppTrackWithReferralAttempt(
+	ctx context.Context,
+	providerID, referralCode string,
+	policy ReferralPolicy,
+	attempt AppTrackRegistrationAttempt,
+) (string, error) {
+	if err := config.ValidateProviderID(providerID); err != nil {
+		return "", err
+	}
+	if !policy.RequireForRegistration || strings.TrimSpace(attempt.SourceIP) == "" ||
+		strings.TrimSpace(attempt.Nonce) == "" || attempt.AttemptTS.IsZero() {
+		return "", ErrReferralConflict
+	}
+
+	var token string
+	err := sqliteutil.Transact(ctx, s.db, func(ctx context.Context, conn *sql.Conn) error {
+		var active int
+		if err := conn.QueryRowContext(ctx, `
+SELECT COUNT(1) FROM provider_tokens
+ WHERE provider_id = ? AND revoked_at IS NULL`, providerID).Scan(&active); err != nil {
+			return err
+		}
+		if active != 0 {
+			return ErrAppTrackExistingTokenNoProof
+		}
+
+		now := time.Now().UTC()
+		createdRedemption, err := redeemReferralTx(ctx, conn, policy, referralCode, providerID, now)
+		if err != nil {
+			return err
+		}
+		newToken, err := randomHex(32)
+		if err != nil {
+			return err
+		}
+		hash := tokenHash(newToken)
+		if _, err := conn.ExecContext(ctx, `
+INSERT INTO provider_tokens
+    (token_hash, token_prefix, provider_id, provider_name, created_at)
+VALUES (?, ?, ?, 'malibu-app', ?)`,
+			hash, newToken[:tokenDisplayPrefixLength], providerID, timeText(now),
+		); err != nil {
+			if isActiveProviderTokenConstraintFailure(err) {
+				return ErrActiveTokenAlreadyExists
+			}
+			return err
+		}
+		if _, err := conn.ExecContext(ctx, `
+INSERT INTO apptrack_pending_referral_mints (
+    provider_id, token_hash, campaign, registration_source_ip,
+    registration_nonce, registration_attempt_ts, created_redemption, created_at
+) VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+			providerID, hash, policy.Campaign, strings.TrimSpace(attempt.SourceIP),
+			strings.TrimSpace(attempt.Nonce), attempt.AttemptTS.UTC().Format(time.RFC3339Nano),
+			createdRedemption, timeText(now),
+		); err != nil {
+			return err
+		}
+		token = newToken
+		return nil
+	})
+	if err != nil {
+		return "", err
+	}
+	return token, nil
+}
+
+// AcknowledgeAppTrackReferralMint removes the saga only after PostgreSQL has
+// durably recorded the exact attempt. The token and redemption remain.
+func (s *Store) AcknowledgeAppTrackReferralMint(ctx context.Context, providerID, cleartextToken string) error {
+	if err := config.ValidateProviderID(providerID); err != nil {
+		return err
+	}
+	cleartextToken = strings.TrimSpace(cleartextToken)
+	if cleartextToken == "" {
+		return ErrReferralConflict
+	}
+	result, err := s.db.ExecContext(ctx, `
+DELETE FROM apptrack_pending_referral_mints
+ WHERE provider_id = ? AND token_hash = ?`, providerID, tokenHash(cleartextToken))
+	if err != nil {
+		return err
+	}
+	if changed, err := result.RowsAffected(); err != nil || changed != 1 {
+		return ErrReferralConflict
+	}
+	return nil
+}
+
+func (s *Store) RollbackAppTrackReferralMint(ctx context.Context, providerID, cleartextToken string) error {
+	if err := config.ValidateProviderID(providerID); err != nil {
+		return err
+	}
+	cleartextToken = strings.TrimSpace(cleartextToken)
+	if cleartextToken == "" {
+		return ErrReferralConflict
+	}
+	return s.resolvePendingAppTrackReferralMint(ctx, providerID, tokenHash(cleartextToken), false)
+}
+
+func (s *Store) ListPendingAppTrackReferralMints(ctx context.Context, createdBefore time.Time) ([]PendingAppTrackReferralMint, error) {
+	rows, err := s.db.QueryContext(ctx, `
+SELECT provider_id, token_hash, registration_source_ip, registration_nonce, registration_attempt_ts
+  FROM apptrack_pending_referral_mints
+ WHERE created_at <= ?
+ ORDER BY created_at, provider_id`, timeText(createdBefore.UTC()))
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var pending []PendingAppTrackReferralMint
+	for rows.Next() {
+		var item PendingAppTrackReferralMint
+		var attemptTS string
+		if err := rows.Scan(
+			&item.ProviderID, &item.TokenHash, &item.Attempt.SourceIP,
+			&item.Attempt.Nonce, &attemptTS,
+		); err != nil {
+			return nil, err
+		}
+		item.Attempt.AttemptTS, err = time.Parse(time.RFC3339Nano, attemptTS)
+		if err != nil {
+			return nil, fmt.Errorf("parse pending App-track attempt timestamp: %w", err)
+		}
+		pending = append(pending, item)
+	}
+	return pending, rows.Err()
+}
+
+func (s *Store) ResolvePendingAppTrackReferralMint(ctx context.Context, pending PendingAppTrackReferralMint, registrationPrepared bool) error {
+	if err := config.ValidateProviderID(pending.ProviderID); err != nil {
+		return err
+	}
+	if strings.TrimSpace(pending.TokenHash) == "" {
+		return ErrReferralConflict
+	}
+	return s.resolvePendingAppTrackReferralMint(ctx, pending.ProviderID, pending.TokenHash, registrationPrepared)
+}
+
+func (s *Store) resolvePendingAppTrackReferralMint(ctx context.Context, providerID, expectedTokenHash string, registrationPrepared bool) error {
+	return sqliteutil.Transact(ctx, s.db, func(ctx context.Context, conn *sql.Conn) error {
+		var campaign string
+		var createdRedemption bool
+		if err := conn.QueryRowContext(ctx, `
+SELECT campaign, created_redemption
+  FROM apptrack_pending_referral_mints
+ WHERE provider_id = ? AND token_hash = ?`, providerID, expectedTokenHash,
+		).Scan(&campaign, &createdRedemption); err != nil {
+			if errors.Is(err, sql.ErrNoRows) {
+				return ErrReferralConflict
+			}
+			return err
+		}
+		if registrationPrepared {
+			_, err := conn.ExecContext(ctx, `
+DELETE FROM apptrack_pending_referral_mints
+ WHERE provider_id = ? AND token_hash = ?`, providerID, expectedTokenHash)
+			return err
+		}
+
+		result, err := conn.ExecContext(ctx, `
+DELETE FROM provider_tokens
+ WHERE provider_id = ? AND token_hash = ?
+   AND provider_name = 'malibu-app'
+   AND revoked_at IS NULL AND last_used_at IS NULL`, providerID, expectedTokenHash)
+		if err != nil {
+			return err
+		}
+		if changed, err := result.RowsAffected(); err != nil || changed != 1 {
+			return ErrReferralConflict
+		}
+		if createdRedemption {
+			result, err = conn.ExecContext(ctx, `
+DELETE FROM referral_redemptions
+ WHERE campaign = ? AND provider_id = ?`, campaign, providerID)
+			if err != nil {
+				return err
+			}
+			if changed, err := result.RowsAffected(); err != nil || changed != 1 {
+				return ErrReferralConflict
+			}
+			if _, err := conn.ExecContext(ctx, `
+DELETE FROM provider_referral_admissions
+ WHERE campaign = ? AND provider_id = ? AND decision = 'referred'`, campaign, providerID); err != nil {
+				return err
+			}
+		}
+		_, err = conn.ExecContext(ctx, `
+DELETE FROM apptrack_pending_referral_mints
+ WHERE provider_id = ? AND token_hash = ?`, providerID, expectedTokenHash)
+		return err
+	})
+}

--- a/phase4-coordinator/internal/auth/referrals_core.go
+++ b/phase4-coordinator/internal/auth/referrals_core.go
@@ -1,0 +1,306 @@
+package auth
+
+import (
+	"context"
+	"crypto/hmac"
+	"crypto/sha256"
+	"database/sql"
+	"encoding/base32"
+	"errors"
+	"fmt"
+	"regexp"
+	"strings"
+	"time"
+)
+
+var (
+	ErrReferralRequired  = errors.New("referral code required")
+	ErrReferralInvalid   = errors.New("referral code invalid")
+	ErrReferralExpired   = errors.New("referral code expired")
+	ErrReferralRevoked   = errors.New("referral code revoked")
+	ErrReferralExhausted = errors.New("referral code exhausted")
+	ErrReferralConflict  = errors.New("provider already attributed to another referral")
+)
+
+const (
+	ReferralTypeSeed     = "S"
+	ReferralTypeProvider = "P"
+	referralTagBytes     = 16
+)
+
+var referralPartPattern = regexp.MustCompile(`^[A-Za-z0-9_]{1,32}$`)
+var referralEncoder = base32.StdEncoding.WithPadding(base32.NoPadding)
+
+// ReferralPolicy is a caller-owned immutable snapshot. Secrets remain in
+// memory; issuer rows persist only the key id needed for explicit rotation.
+type ReferralPolicy struct {
+	RequireForRegistration bool
+	EnableSocialBonus      bool
+	Campaign               string
+	PolicyVersion          string
+	GrandfatherBefore      *time.Time
+	GrandfatherProof       bool
+	CurrentKeyID           string
+	HMACKeys               map[string]string
+	ProviderBaseUses       int
+	SocialBonusUses        int
+	ChallengeTTL           time.Duration
+}
+
+func (p ReferralPolicy) Validate() error {
+	if !p.RequireForRegistration && !p.EnableSocialBonus && strings.TrimSpace(p.Campaign) == "" {
+		return nil
+	}
+	if !referralPartPattern.MatchString(p.Campaign) {
+		return fmt.Errorf("referral campaign must match %s", referralPartPattern)
+	}
+	if !referralPartPattern.MatchString(p.PolicyVersion) {
+		return fmt.Errorf("referral policy version must match %s", referralPartPattern)
+	}
+	if !referralPartPattern.MatchString(p.CurrentKeyID) {
+		return fmt.Errorf("referral current key id must match %s", referralPartPattern)
+	}
+	secret := p.HMACKeys[p.CurrentKeyID]
+	if len(secret) < 32 {
+		return fmt.Errorf("referral current HMAC secret must be at least 32 bytes")
+	}
+	for keyID, value := range p.HMACKeys {
+		if !referralPartPattern.MatchString(keyID) || len(value) < 32 {
+			return fmt.Errorf("referral HMAC key %q is invalid or shorter than 32 bytes", keyID)
+		}
+	}
+	if p.ProviderBaseUses <= 0 {
+		return fmt.Errorf("referral provider capacity must be positive")
+	}
+	if p.EnableSocialBonus && (p.SocialBonusUses <= 0 || p.ChallengeTTL <= 0) {
+		return fmt.Errorf("referral social capacity and challenge ttl must be positive")
+	}
+	return nil
+}
+
+type ReferralValidation struct {
+	Valid         bool
+	Reason        string
+	Type          string
+	IssuerID      string
+	Campaign      string
+	RemainingUses int
+}
+
+type parsedReferralCode struct {
+	Type     string
+	KeyID    string
+	IssuerID string
+	Tag      []byte
+}
+
+func parseReferralCode(raw string) (parsedReferralCode, error) {
+	parts := strings.Split(strings.TrimSpace(raw), "-")
+	if len(parts) != 5 || parts[0] != "MAL1" ||
+		(parts[1] != ReferralTypeSeed && parts[1] != ReferralTypeProvider) ||
+		!referralPartPattern.MatchString(parts[2]) || !referralPartPattern.MatchString(parts[3]) {
+		return parsedReferralCode{}, ErrReferralInvalid
+	}
+	tag, err := referralEncoder.DecodeString(strings.ToUpper(parts[4]))
+	if err != nil || len(tag) != referralTagBytes {
+		return parsedReferralCode{}, ErrReferralInvalid
+	}
+	return parsedReferralCode{Type: parts[1], KeyID: parts[2], IssuerID: parts[3], Tag: tag}, nil
+}
+
+func referralMAC(policy ReferralPolicy, typ, keyID, issuerID string) ([]byte, error) {
+	secret, ok := policy.HMACKeys[keyID]
+	if !ok || len(secret) < 32 {
+		return nil, ErrReferralInvalid
+	}
+	mac := hmac.New(sha256.New, []byte(secret))
+	_, _ = mac.Write([]byte("malibu-referral/v1\x00"))
+	_, _ = mac.Write([]byte(typ))
+	_, _ = mac.Write([]byte("\x00" + keyID + "\x00" + policy.Campaign + "\x00" + issuerID))
+	return mac.Sum(nil)[:referralTagBytes], nil
+}
+
+func EncodeReferralCode(policy ReferralPolicy, typ, keyID, issuerID string) (string, error) {
+	if err := policy.Validate(); err != nil {
+		return "", err
+	}
+	if (typ != ReferralTypeSeed && typ != ReferralTypeProvider) ||
+		!referralPartPattern.MatchString(keyID) || !referralPartPattern.MatchString(issuerID) {
+		return "", ErrReferralInvalid
+	}
+	tag, err := referralMAC(policy, typ, keyID, issuerID)
+	if err != nil {
+		return "", err
+	}
+	return strings.Join([]string{"MAL1", typ, keyID, issuerID, referralEncoder.EncodeToString(tag)}, "-"), nil
+}
+
+func (s *Store) ValidateReferral(ctx context.Context, policy ReferralPolicy, code string, now time.Time) (ReferralValidation, error) {
+	if err := policy.Validate(); err != nil {
+		return ReferralValidation{}, err
+	}
+	return validateReferralTx(ctx, s.db, policy, code, now)
+}
+
+type referralQueryRower interface {
+	QueryRowContext(context.Context, string, ...any) *sql.Row
+}
+
+func validateReferralTx(ctx context.Context, conn referralQueryRower, policy ReferralPolicy, code string, now time.Time) (ReferralValidation, error) {
+	parsed, err := parseReferralCode(code)
+	if err != nil {
+		return ReferralValidation{Reason: "invalid"}, ErrReferralInvalid
+	}
+	want, err := referralMAC(policy, parsed.Type, parsed.KeyID, parsed.IssuerID)
+	if err != nil || !hmac.Equal(want, parsed.Tag) {
+		return ReferralValidation{Reason: "invalid"}, ErrReferralInvalid
+	}
+	var issuer struct {
+		Type      string
+		KeyID     string
+		Campaign  string
+		Base      int
+		Bonus     int
+		ExpiresAt sql.NullString
+		RevokedAt sql.NullString
+	}
+	err = conn.QueryRowContext(ctx, `
+SELECT code_type, key_id, campaign, base_capacity, bonus_capacity, expires_at, revoked_at
+  FROM referral_issuers
+ WHERE issuer_id = ?`, parsed.IssuerID).Scan(
+		&issuer.Type, &issuer.KeyID, &issuer.Campaign, &issuer.Base, &issuer.Bonus,
+		&issuer.ExpiresAt, &issuer.RevokedAt,
+	)
+	if errors.Is(err, sql.ErrNoRows) {
+		return ReferralValidation{Reason: "invalid"}, ErrReferralInvalid
+	}
+	if err != nil {
+		return ReferralValidation{}, err
+	}
+	if issuer.Type != parsed.Type || issuer.KeyID != parsed.KeyID || issuer.Campaign != policy.Campaign {
+		return ReferralValidation{Reason: "invalid"}, ErrReferralInvalid
+	}
+	if issuer.RevokedAt.Valid {
+		return ReferralValidation{Reason: "revoked"}, ErrReferralRevoked
+	}
+	if issuer.ExpiresAt.Valid {
+		expires, parseErr := time.Parse(time.RFC3339, issuer.ExpiresAt.String)
+		if parseErr != nil || !expires.After(now.UTC()) {
+			return ReferralValidation{Reason: "expired"}, ErrReferralExpired
+		}
+	}
+	var used int
+	if err := conn.QueryRowContext(ctx,
+		`SELECT COUNT(1) FROM referral_redemptions WHERE issuer_id = ?`,
+		parsed.IssuerID,
+	).Scan(&used); err != nil {
+		return ReferralValidation{}, err
+	}
+	remaining := issuer.Base + issuer.Bonus - used
+	if remaining <= 0 {
+		return ReferralValidation{
+			Reason: "exhausted", Type: parsed.Type, IssuerID: parsed.IssuerID, Campaign: issuer.Campaign,
+		}, ErrReferralExhausted
+	}
+	return ReferralValidation{
+		Valid: true, Reason: "valid", Type: parsed.Type, IssuerID: parsed.IssuerID,
+		Campaign: issuer.Campaign, RemainingUses: remaining,
+	}, nil
+}
+
+// redeemReferralTx is called from the same SQLite transaction that creates a
+// credential. Capacity therefore cannot be consumed without a corresponding
+// token, and two concurrent consumers cannot overdraw an issuer.
+func redeemReferralTx(ctx context.Context, conn *sql.Conn, policy ReferralPolicy, code, providerID string, now time.Time) (bool, error) {
+	if !policy.RequireForRegistration {
+		return false, nil
+	}
+	code = strings.TrimSpace(code)
+	if code == "" {
+		if policy.GrandfatherProof {
+			var decision string
+			err := conn.QueryRowContext(ctx,
+				`SELECT decision FROM provider_referral_admissions WHERE provider_id = ? AND campaign = ?`,
+				providerID, policy.Campaign,
+			).Scan(&decision)
+			if err == nil && decision == "grandfathered" {
+				return false, nil
+			}
+			if err != nil && !errors.Is(err, sql.ErrNoRows) {
+				return false, err
+			}
+		}
+		if policy.GrandfatherProof && policy.GrandfatherBefore != nil {
+			var firstCreated sql.NullString
+			if err := conn.QueryRowContext(ctx,
+				`SELECT MIN(created_at) FROM provider_tokens WHERE provider_id = ?`, providerID,
+			).Scan(&firstCreated); err != nil {
+				return false, err
+			}
+			if firstCreated.Valid {
+				first, err := time.Parse(time.RFC3339, firstCreated.String)
+				if err == nil && first.Before(policy.GrandfatherBefore.UTC()) {
+					_, err = conn.ExecContext(ctx, `
+INSERT INTO provider_referral_admissions (provider_id, campaign, policy_version, decision, applied_at)
+VALUES (?, ?, ?, 'grandfathered', ?)
+ON CONFLICT(provider_id, campaign) DO NOTHING`,
+						providerID, policy.Campaign, policy.PolicyVersion, timeText(now.UTC()),
+					)
+					return false, err
+				}
+			}
+		}
+		return false, ErrReferralRequired
+	}
+
+	var existingIssuer, existingDigest string
+	err := conn.QueryRowContext(ctx, `
+SELECT issuer_id, code_digest FROM referral_redemptions
+ WHERE campaign = ? AND provider_id = ?`, policy.Campaign, providerID,
+	).Scan(&existingIssuer, &existingDigest)
+	if err != nil && !errors.Is(err, sql.ErrNoRows) {
+		return false, err
+	}
+	parsed, parseErr := parseReferralCode(code)
+	if parseErr != nil {
+		return false, ErrReferralInvalid
+	}
+	digest := sha256.Sum256([]byte(code))
+	presentedDigest := fmt.Sprintf("%x", digest[:])
+	if err == nil {
+		if existingIssuer == parsed.IssuerID && hmac.Equal([]byte(existingDigest), []byte(presentedDigest)) {
+			wantMAC, macErr := referralMAC(policy, parsed.Type, parsed.KeyID, parsed.IssuerID)
+			if macErr != nil || !hmac.Equal(wantMAC, parsed.Tag) {
+				return false, ErrReferralInvalid
+			}
+			return false, nil
+		}
+		return false, ErrReferralConflict
+	}
+
+	validated, err := validateReferralTx(ctx, conn, policy, code, now)
+	if err != nil {
+		return false, err
+	}
+	_, err = conn.ExecContext(ctx, `
+INSERT INTO referral_redemptions
+    (campaign, provider_id, issuer_id, code_digest, policy_version, redeemed_at)
+VALUES (?, ?, ?, ?, ?, ?)`,
+		policy.Campaign, providerID, validated.IssuerID, presentedDigest,
+		policy.PolicyVersion, timeText(now.UTC()),
+	)
+	if isConstraintFailure(err) {
+		return false, ErrReferralExhausted
+	}
+	if err != nil {
+		return false, err
+	}
+	_, err = conn.ExecContext(ctx, `
+INSERT INTO provider_referral_admissions
+    (provider_id, campaign, policy_version, decision, applied_at)
+VALUES (?, ?, ?, 'referred', ?)
+ON CONFLICT(provider_id, campaign) DO NOTHING`,
+		providerID, policy.Campaign, policy.PolicyVersion, timeText(now.UTC()),
+	)
+	return true, err
+}

--- a/phase4-coordinator/internal/auth/referrals_core.go
+++ b/phase4-coordinator/internal/auth/referrals_core.go
@@ -223,7 +223,13 @@ func redeemReferralTx(ctx context.Context, conn *sql.Conn, policy ReferralPolicy
 				`SELECT decision FROM provider_referral_admissions WHERE provider_id = ? AND campaign = ?`,
 				providerID, policy.Campaign,
 			).Scan(&decision)
-			if err == nil && decision == "grandfathered" {
+			// Exact bootstrap-key custody may recover a response lost after a
+			// referral was already committed. The campaign-scoped admission row
+			// proves policy was satisfied; accepting no code here avoids storing
+			// the plaintext invite in the CLI restart journal. GrandfatherProof is
+			// set only after MintBootstrapToken byte-matches the retained key and
+			// rejects confirmed, ordinary, or operator-revoked ownership.
+			if err == nil && (decision == "grandfathered" || decision == "referred") {
 				return false, nil
 			}
 			if err != nil && !errors.Is(err, sql.ErrNoRows) {

--- a/phase4-coordinator/internal/auth/referrals_core_test.go
+++ b/phase4-coordinator/internal/auth/referrals_core_test.go
@@ -1,6 +1,7 @@
 package auth
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"path/filepath"
@@ -181,6 +182,134 @@ func TestReferralReplayForSameProviderDoesNotConsumeCapacityTwice(t *testing.T) 
 	if redemptions != 1 || activeTokens != 1 {
 		t.Fatalf("redemptions=%d active_tokens=%d, want 1/1", redemptions, activeTokens)
 	}
+}
+
+func TestCredentialBootstrapResponseLossKeepsOneReferralRedemption(t *testing.T) {
+	ctx := context.Background()
+	store, err := OpenStore(filepath.Join(t.TempDir(), "coordinator.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+	policy := coreReferralPolicy()
+	code := seedCoreReferral(t, store, policy, "seedbootstrapretry")
+	now := time.Now().UTC().Truncate(time.Second)
+	request := BootstrapMintRequest{
+		ProviderID:          "mp-0123456789abcdef0123456789abcdef",
+		ProviderName:        "bootstrap provider",
+		SourceIP:            "192.0.2.80",
+		ReceiptPubkey:       bytes.Repeat([]byte{0x81}, 32),
+		Now:                 now,
+		TTL:                 10 * time.Minute,
+		PerIPLimitPerHour:   8,
+		PerProviderPerHour:  3,
+		GlobalLimitPerHour:  128,
+		UnconfirmedIDMax:    64,
+		OutstandingTokenMax: 64,
+		IdentityRetention:   7 * 24 * time.Hour,
+		ReferralCode:        code,
+		ReferralPolicy:      policy,
+	}
+
+	first, err := store.MintBootstrapToken(ctx, request)
+	if err != nil || first.Replaced || first.ProviderToken == "" {
+		t.Fatalf("first mint=%+v err=%v", first, err)
+	}
+	request.Now = now.Add(time.Second)
+	request.ReferralCode = ""
+	recovered, err := store.MintBootstrapToken(ctx, request)
+	if err != nil || !recovered.Replaced || recovered.ProviderToken == "" || recovered.ProviderToken == first.ProviderToken {
+		t.Fatalf("recovered mint=%+v err=%v", recovered, err)
+	}
+	if _, valid, err := store.ValidateToken(ctx, first.ProviderToken); err != nil || valid {
+		t.Fatalf("lost-response token valid=%v err=%v, want revoked", valid, err)
+	}
+	providerID, valid, err := store.ValidateToken(ctx, recovered.ProviderToken)
+	if err != nil || !valid || providerID != request.ProviderID {
+		t.Fatalf("recovered provider_id=%q valid=%v err=%v", providerID, valid, err)
+	}
+
+	var redemptions, activeTokens int
+	if err := store.db.QueryRow(`SELECT COUNT(1) FROM referral_redemptions WHERE provider_id = ?`, request.ProviderID).Scan(&redemptions); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.db.QueryRow(`SELECT COUNT(1) FROM provider_tokens WHERE provider_id = ? AND revoked_at IS NULL`, request.ProviderID).Scan(&activeTokens); err != nil {
+		t.Fatal(err)
+	}
+	if redemptions != 1 || activeTokens != 1 {
+		t.Fatalf("redemptions=%d active_tokens=%d, want 1/1", redemptions, activeTokens)
+	}
+}
+
+func TestCredentialBootstrapReferralRecoveryCannotChangeCodeOrCampaign(t *testing.T) {
+	newRequest := func(providerID string, keyByte byte, now time.Time, code string, policy ReferralPolicy) BootstrapMintRequest {
+		return BootstrapMintRequest{
+			ProviderID: providerID, ProviderName: "bootstrap provider", SourceIP: "192.0.2.81",
+			ReceiptPubkey: bytes.Repeat([]byte{keyByte}, 32), Now: now, TTL: 10 * time.Minute,
+			PerIPLimitPerHour: 8, PerProviderPerHour: 3, GlobalLimitPerHour: 128,
+			UnconfirmedIDMax: 64, OutstandingTokenMax: 64, IdentityRetention: 7 * 24 * time.Hour,
+			ReferralCode: code, ReferralPolicy: policy,
+		}
+	}
+
+	t.Run("different code", func(t *testing.T) {
+		ctx := context.Background()
+		store, err := OpenStore(filepath.Join(t.TempDir(), "coordinator.db"))
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer store.Close()
+		policy := coreReferralPolicy()
+		firstCode := seedCoreReferral(t, store, policy, "seedbootstrapfirst")
+		secondCode := seedCoreReferral(t, store, policy, "seedbootstrapsecond")
+		now := time.Now().UTC().Truncate(time.Second)
+		request := newRequest("mp-1123456789abcdef0123456789abcdef", 0x82, now, firstCode, policy)
+		first, err := store.MintBootstrapToken(ctx, request)
+		if err != nil {
+			t.Fatal(err)
+		}
+		request.Now = now.Add(time.Second)
+		request.ReferralCode = secondCode
+		if _, err := store.MintBootstrapToken(ctx, request); !errors.Is(err, ErrReferralConflict) {
+			t.Fatalf("different-code recovery err=%v, want conflict", err)
+		}
+		if _, valid, err := store.ValidateToken(ctx, first.ProviderToken); err != nil || !valid {
+			t.Fatalf("original token valid=%v err=%v", valid, err)
+		}
+		var redemptions int
+		if err := store.db.QueryRow(`SELECT COUNT(1) FROM referral_redemptions WHERE provider_id = ?`, request.ProviderID).Scan(&redemptions); err != nil {
+			t.Fatal(err)
+		}
+		if redemptions != 1 {
+			t.Fatalf("redemptions=%d, want 1", redemptions)
+		}
+	})
+
+	t.Run("different campaign", func(t *testing.T) {
+		ctx := context.Background()
+		store, err := OpenStore(filepath.Join(t.TempDir(), "coordinator.db"))
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer store.Close()
+		policy := coreReferralPolicy()
+		code := seedCoreReferral(t, store, policy, "seedbootstrapcampaign")
+		now := time.Now().UTC().Truncate(time.Second)
+		request := newRequest("mp-2123456789abcdef0123456789abcdef", 0x83, now, code, policy)
+		first, err := store.MintBootstrapToken(ctx, request)
+		if err != nil {
+			t.Fatal(err)
+		}
+		request.Now = now.Add(time.Second)
+		request.ReferralCode = ""
+		request.ReferralPolicy.Campaign = "other_campaign"
+		if _, err := store.MintBootstrapToken(ctx, request); !errors.Is(err, ErrReferralRequired) {
+			t.Fatalf("different-campaign recovery err=%v, want required", err)
+		}
+		if _, valid, err := store.ValidateToken(ctx, first.ProviderToken); err != nil || !valid {
+			t.Fatalf("original token valid=%v err=%v", valid, err)
+		}
+	})
 }
 
 func TestConcurrentReferralRedemptionHasOneTokenAndRedemptionWinner(t *testing.T) {

--- a/phase4-coordinator/internal/auth/referrals_core_test.go
+++ b/phase4-coordinator/internal/auth/referrals_core_test.go
@@ -80,7 +80,8 @@ func TestAppTrackReferralSagaPreservesCommittedAndCompensatesAbsent(t *testing.T
 		AttemptTS: time.Date(2026, 7, 13, 10, 0, 0, 0, time.UTC),
 	}
 
-	token, err := store.MintProviderTokenAppTrackWithReferralAttempt(context.Background(), "provider-a", code, policy, attempt)
+	tokenCandidate := strings.Repeat("c", 64)
+	token, err := store.MintProviderTokenAppTrackWithReferralAttempt(context.Background(), "provider-a", code, tokenCandidate, policy, attempt)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -95,7 +96,7 @@ func TestAppTrackReferralSagaPreservesCommittedAndCompensatesAbsent(t *testing.T
 		t.Fatalf("rolled-back token ok=%v err=%v", ok, err)
 	}
 
-	committedToken, err := store.MintProviderTokenAppTrackWithReferralAttempt(context.Background(), "provider-b", code, policy, AppTrackRegistrationAttempt{
+	committedToken, err := store.MintProviderTokenAppTrackWithReferralAttempt(context.Background(), "provider-b", code, strings.Repeat("d", 64), policy, AppTrackRegistrationAttempt{
 		SourceIP: "203.0.113.11", Nonce: strings.Repeat("b", 64), AttemptTS: attempt.AttemptTS.Add(time.Second),
 	})
 	if err != nil {

--- a/phase4-coordinator/internal/auth/referrals_core_test.go
+++ b/phase4-coordinator/internal/auth/referrals_core_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 )
@@ -63,6 +64,217 @@ func TestReferralRedemptionAndTokenInsertAreAtomic(t *testing.T) {
 	}
 	if tokens != 1 || redemptions != 1 {
 		t.Fatalf("tokens=%d redemptions=%d, want 1/1", tokens, redemptions)
+	}
+}
+
+func TestReferralValidationRejectsInvalidExpiredRevokedAndExhausted(t *testing.T) {
+	now := time.Date(2026, 7, 13, 12, 0, 0, 0, time.UTC)
+
+	t.Run("invalid", func(t *testing.T) {
+		store, err := OpenStore(filepath.Join(t.TempDir(), "coordinator.db"))
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer store.Close()
+		policy := coreReferralPolicy()
+		code := seedCoreReferral(t, store, policy, "seedinvalid")
+		tagStart := strings.LastIndex(code, "-") + 1
+		replacement := "A"
+		if code[tagStart] == replacement[0] {
+			replacement = "B"
+		}
+		code = code[:tagStart] + replacement + code[tagStart+1:]
+
+		validation, err := store.ValidateReferral(context.Background(), policy, code, now)
+		if !errors.Is(err, ErrReferralInvalid) || validation.Reason != "invalid" {
+			t.Fatalf("validation=%+v err=%v, want invalid", validation, err)
+		}
+	})
+
+	t.Run("expired", func(t *testing.T) {
+		store, err := OpenStore(filepath.Join(t.TempDir(), "coordinator.db"))
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer store.Close()
+		policy := coreReferralPolicy()
+		code := seedCoreReferral(t, store, policy, "seedexpired")
+		if _, err := store.db.Exec(`UPDATE referral_issuers SET expires_at = ? WHERE issuer_id = ?`, timeText(now.Add(-time.Second)), "seedexpired"); err != nil {
+			t.Fatal(err)
+		}
+
+		validation, err := store.ValidateReferral(context.Background(), policy, code, now)
+		if !errors.Is(err, ErrReferralExpired) || validation.Reason != "expired" {
+			t.Fatalf("validation=%+v err=%v, want expired", validation, err)
+		}
+	})
+
+	t.Run("revoked", func(t *testing.T) {
+		store, err := OpenStore(filepath.Join(t.TempDir(), "coordinator.db"))
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer store.Close()
+		policy := coreReferralPolicy()
+		code := seedCoreReferral(t, store, policy, "seedrevoked")
+		if _, err := store.db.Exec(`UPDATE referral_issuers SET revoked_at = ? WHERE issuer_id = ?`, timeText(now.Add(-time.Second)), "seedrevoked"); err != nil {
+			t.Fatal(err)
+		}
+
+		validation, err := store.ValidateReferral(context.Background(), policy, code, now)
+		if !errors.Is(err, ErrReferralRevoked) || validation.Reason != "revoked" {
+			t.Fatalf("validation=%+v err=%v, want revoked", validation, err)
+		}
+	})
+
+	t.Run("exhausted", func(t *testing.T) {
+		store, err := OpenStore(filepath.Join(t.TempDir(), "coordinator.db"))
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer store.Close()
+		policy := coreReferralPolicy()
+		code := seedCoreReferral(t, store, policy, "seedexhausted")
+		if _, _, err := store.IssueTokenWithReferral(context.Background(), "provider-a", "host-a", code, policy); err != nil {
+			t.Fatal(err)
+		}
+
+		validation, err := store.ValidateReferral(context.Background(), policy, code, now)
+		if !errors.Is(err, ErrReferralExhausted) || validation.Reason != "exhausted" {
+			t.Fatalf("validation=%+v err=%v, want exhausted", validation, err)
+		}
+	})
+}
+
+func TestReferralReplayForSameProviderDoesNotConsumeCapacityTwice(t *testing.T) {
+	ctx := context.Background()
+	store, err := OpenStore(filepath.Join(t.TempDir(), "coordinator.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+	policy := coreReferralPolicy()
+	code := seedCoreReferral(t, store, policy, "seedreplay")
+
+	first, firstToken, err := store.IssueTokenWithReferral(ctx, "provider-a", "host-a", code, policy)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.RevokeToken(ctx, first.TokenPrefix); err != nil {
+		t.Fatal(err)
+	}
+	_, secondToken, err := store.IssueTokenWithReferral(ctx, "provider-a", "host-a", code, policy)
+	if err != nil {
+		t.Fatalf("idempotent replay mint: %v", err)
+	}
+	if secondToken == firstToken {
+		t.Fatal("replay returned the revoked credential")
+	}
+
+	var redemptions, activeTokens int
+	if err := store.db.QueryRow(`SELECT COUNT(1) FROM referral_redemptions WHERE provider_id = ?`, "provider-a").Scan(&redemptions); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.db.QueryRow(`SELECT COUNT(1) FROM provider_tokens WHERE provider_id = ? AND revoked_at IS NULL`, "provider-a").Scan(&activeTokens); err != nil {
+		t.Fatal(err)
+	}
+	if redemptions != 1 || activeTokens != 1 {
+		t.Fatalf("redemptions=%d active_tokens=%d, want 1/1", redemptions, activeTokens)
+	}
+}
+
+func TestConcurrentReferralRedemptionHasOneTokenAndRedemptionWinner(t *testing.T) {
+	store, err := OpenStore(filepath.Join(t.TempDir(), "coordinator.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+	policy := coreReferralPolicy()
+	code := seedCoreReferral(t, store, policy, "seedconcurrent")
+
+	type result struct {
+		providerID string
+		err        error
+	}
+	start := make(chan struct{})
+	results := make(chan result, 2)
+	var wg sync.WaitGroup
+	for _, providerID := range []string{"provider-a", "provider-b"} {
+		providerID := providerID
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			_, _, err := store.IssueTokenWithReferral(context.Background(), providerID, "host-"+providerID, code, policy)
+			results <- result{providerID: providerID, err: err}
+		}()
+	}
+	close(start)
+	wg.Wait()
+	close(results)
+
+	winner := ""
+	for result := range results {
+		switch {
+		case result.err == nil:
+			if winner != "" {
+				t.Fatalf("multiple winners: %q and %q", winner, result.providerID)
+			}
+			winner = result.providerID
+		case errors.Is(result.err, ErrReferralExhausted):
+		default:
+			t.Fatalf("provider %q error=%v, want exhausted", result.providerID, result.err)
+		}
+	}
+	if winner == "" {
+		t.Fatal("no redemption winner")
+	}
+
+	var tokens, redemptions int
+	if err := store.db.QueryRow(`SELECT COUNT(1) FROM provider_tokens WHERE revoked_at IS NULL`).Scan(&tokens); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.db.QueryRow(`SELECT COUNT(1) FROM referral_redemptions`).Scan(&redemptions); err != nil {
+		t.Fatal(err)
+	}
+	if tokens != 1 || redemptions != 1 {
+		t.Fatalf("tokens=%d redemptions=%d, want 1/1", tokens, redemptions)
+	}
+
+	var tokenProvider, redemptionProvider string
+	if err := store.db.QueryRow(`SELECT provider_id FROM provider_tokens WHERE revoked_at IS NULL`).Scan(&tokenProvider); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.db.QueryRow(`SELECT provider_id FROM referral_redemptions`).Scan(&redemptionProvider); err != nil {
+		t.Fatal(err)
+	}
+	if tokenProvider != winner || redemptionProvider != winner {
+		t.Fatalf("winner=%q token_provider=%q redemption_provider=%q", winner, tokenProvider, redemptionProvider)
+	}
+}
+
+func TestReferralFeatureOffAllowsFreshProviderWithoutRedemption(t *testing.T) {
+	ctx := context.Background()
+	store, err := OpenStore(filepath.Join(t.TempDir(), "coordinator.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+
+	_, token, err := store.IssueTokenWithReferral(ctx, "provider-fresh", "host-fresh", "", ReferralPolicy{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	providerID, ok, err := store.ValidateToken(ctx, token)
+	if err != nil || !ok || providerID != "provider-fresh" {
+		t.Fatalf("provider_id=%q ok=%v err=%v", providerID, ok, err)
+	}
+	var redemptions int
+	if err := store.db.QueryRow(`SELECT COUNT(1) FROM referral_redemptions`).Scan(&redemptions); err != nil {
+		t.Fatal(err)
+	}
+	if redemptions != 0 {
+		t.Fatalf("redemptions=%d, want 0", redemptions)
 	}
 }
 

--- a/phase4-coordinator/internal/auth/referrals_core_test.go
+++ b/phase4-coordinator/internal/auth/referrals_core_test.go
@@ -1,0 +1,131 @@
+package auth
+
+import (
+	"context"
+	"errors"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func coreReferralPolicy() ReferralPolicy {
+	return ReferralPolicy{
+		RequireForRegistration: true,
+		Campaign:               "prebeta_test",
+		PolicyVersion:          "v1",
+		CurrentKeyID:           "k1",
+		HMACKeys:               map[string]string{"k1": strings.Repeat("s", 32)},
+		ProviderBaseUses:       1,
+	}
+}
+
+func seedCoreReferral(t *testing.T, store *Store, policy ReferralPolicy, issuerID string) string {
+	t.Helper()
+	_, err := store.db.Exec(`
+INSERT INTO referral_issuers (
+    issuer_id, code_type, key_id, campaign, provider_id,
+    base_capacity, bonus_capacity, created_at, first_serving_at
+) VALUES (?, 'S', ?, ?, NULL, 1, 0, ?, ?)`,
+		issuerID, policy.CurrentKeyID, policy.Campaign, nowString(), nowString(),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	code, err := EncodeReferralCode(policy, ReferralTypeSeed, policy.CurrentKeyID, issuerID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return code
+}
+
+func TestReferralRedemptionAndTokenInsertAreAtomic(t *testing.T) {
+	store, err := OpenStore(filepath.Join(t.TempDir(), "coordinator.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+	policy := coreReferralPolicy()
+	code := seedCoreReferral(t, store, policy, "seed1")
+
+	if _, _, err := store.IssueTokenWithReferral(context.Background(), "provider-a", "host-a", code, policy); err != nil {
+		t.Fatalf("first mint: %v", err)
+	}
+	if _, _, err := store.IssueTokenWithReferral(context.Background(), "provider-b", "host-b", code, policy); !errors.Is(err, ErrReferralExhausted) {
+		t.Fatalf("second mint error=%v, want exhausted", err)
+	}
+	var tokens, redemptions int
+	if err := store.db.QueryRow(`SELECT COUNT(1) FROM provider_tokens WHERE revoked_at IS NULL`).Scan(&tokens); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.db.QueryRow(`SELECT COUNT(1) FROM referral_redemptions`).Scan(&redemptions); err != nil {
+		t.Fatal(err)
+	}
+	if tokens != 1 || redemptions != 1 {
+		t.Fatalf("tokens=%d redemptions=%d, want 1/1", tokens, redemptions)
+	}
+}
+
+func TestAppTrackReferralSagaPreservesCommittedAndCompensatesAbsent(t *testing.T) {
+	store, err := OpenStore(filepath.Join(t.TempDir(), "coordinator.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+	policy := coreReferralPolicy()
+	code := seedCoreReferral(t, store, policy, "seed1")
+	attempt := AppTrackRegistrationAttempt{
+		SourceIP:  "203.0.113.10",
+		Nonce:     strings.Repeat("a", 64),
+		AttemptTS: time.Date(2026, 7, 13, 10, 0, 0, 0, time.UTC),
+	}
+
+	token, err := store.MintProviderTokenAppTrackWithReferralAttempt(context.Background(), "provider-a", code, policy, attempt)
+	if err != nil {
+		t.Fatal(err)
+	}
+	pending, err := store.ListPendingAppTrackReferralMints(context.Background(), time.Now().UTC().Add(time.Hour))
+	if err != nil || len(pending) != 1 {
+		t.Fatalf("pending=%+v err=%v", pending, err)
+	}
+	if err := store.ResolvePendingAppTrackReferralMint(context.Background(), pending[0], false); err != nil {
+		t.Fatal(err)
+	}
+	if _, ok, err := store.ValidateToken(context.Background(), token); err != nil || ok {
+		t.Fatalf("rolled-back token ok=%v err=%v", ok, err)
+	}
+
+	committedToken, err := store.MintProviderTokenAppTrackWithReferralAttempt(context.Background(), "provider-b", code, policy, AppTrackRegistrationAttempt{
+		SourceIP: "203.0.113.11", Nonce: strings.Repeat("b", 64), AttemptTS: attempt.AttemptTS.Add(time.Second),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	pending, err = store.ListPendingAppTrackReferralMints(context.Background(), time.Now().UTC().Add(time.Hour))
+	if err != nil || len(pending) != 1 {
+		t.Fatalf("pending=%+v err=%v", pending, err)
+	}
+	if err := store.ResolvePendingAppTrackReferralMint(context.Background(), pending[0], true); err != nil {
+		t.Fatal(err)
+	}
+	if providerID, ok, err := store.ValidateToken(context.Background(), committedToken); err != nil || !ok || providerID != "provider-b" {
+		t.Fatalf("committed token provider=%q ok=%v err=%v", providerID, ok, err)
+	}
+}
+
+func TestCoreSchemaHasNoPublicReferralReservationTables(t *testing.T) {
+	store, err := OpenStore(filepath.Join(t.TempDir(), "coordinator.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+	var count int
+	if err := store.db.QueryRow(`
+SELECT COUNT(1) FROM sqlite_master
+ WHERE type = 'table' AND name LIKE 'referral_reservation%'`).Scan(&count); err != nil {
+		t.Fatal(err)
+	}
+	if count != 0 {
+		t.Fatalf("reservation table count=%d, want 0", count)
+	}
+}

--- a/phase4-coordinator/internal/auth/tokens.go
+++ b/phase4-coordinator/internal/auth/tokens.go
@@ -1081,7 +1081,7 @@ func deleteRows(ctx context.Context, conn *sql.Conn, query string, args ...any) 
 	return res.RowsAffected()
 }
 
-func (s *Store) MintProviderTokenAppTrack(ctx context.Context, providerID string, currentBearer *string) (string, error) {
+func (s *Store) MintProviderTokenAppTrack(ctx context.Context, providerID string, currentBearer, freshTokenCandidate *string) (string, error) {
 	if err := config.ValidateProviderID(providerID); err != nil {
 		return "", err
 	}
@@ -1129,9 +1129,18 @@ UPDATE provider_tokens
 			}
 		}
 
-		newToken, err := randomHex(32)
-		if err != nil {
-			return err
+		var newToken string
+		if !requiresProof && freshTokenCandidate != nil {
+			newToken = strings.TrimSpace(*freshTokenCandidate)
+			if len(newToken) != 64 || !isLowerHexToken(newToken) {
+				return ErrReferralConflict
+			}
+		} else {
+			var err error
+			newToken, err = randomHex(32)
+			if err != nil {
+				return err
+			}
 		}
 		prefix := newToken[:tokenDisplayPrefixLength]
 		if _, err := conn.ExecContext(ctx, `

--- a/phase4-coordinator/internal/auth/tokens.go
+++ b/phase4-coordinator/internal/auth/tokens.go
@@ -123,6 +123,8 @@ type BootstrapMintRequest struct {
 	UnconfirmedIDMax    int
 	OutstandingTokenMax int
 	IdentityRetention   time.Duration
+	ReferralCode        string
+	ReferralPolicy      ReferralPolicy
 }
 
 type BootstrapMint struct {
@@ -450,6 +452,50 @@ func (s *Store) ensureGitHubAuthSchema(ctx context.Context) error {
 		)`,
 		`CREATE INDEX IF NOT EXISTS idx_bootstrap_mint_log_provider_ts ON bootstrap_mint_log(provider_id, ts)`,
 		`CREATE INDEX IF NOT EXISTS idx_bootstrap_mint_log_ip_ts ON bootstrap_mint_log(source_ip, ts)`,
+		`CREATE TABLE IF NOT EXISTS referral_issuers (
+			issuer_id TEXT PRIMARY KEY,
+			code_type TEXT NOT NULL CHECK(code_type IN ('S','P')),
+			key_id TEXT NOT NULL,
+			campaign TEXT NOT NULL,
+			provider_id TEXT,
+			base_capacity INTEGER NOT NULL CHECK(base_capacity >= 0),
+			bonus_capacity INTEGER NOT NULL DEFAULT 0 CHECK(bonus_capacity >= 0),
+			expires_at TEXT,
+			revoked_at TEXT,
+			created_at TEXT NOT NULL,
+			first_serving_at TEXT,
+			UNIQUE(provider_id, campaign)
+		)`,
+		`CREATE INDEX IF NOT EXISTS idx_referral_issuers_provider_campaign ON referral_issuers(provider_id, campaign)`,
+		`CREATE TABLE IF NOT EXISTS referral_redemptions (
+			campaign TEXT NOT NULL,
+			provider_id TEXT NOT NULL,
+			issuer_id TEXT NOT NULL REFERENCES referral_issuers(issuer_id),
+			code_digest TEXT NOT NULL,
+			policy_version TEXT NOT NULL DEFAULT 'v1',
+			redeemed_at TEXT NOT NULL,
+			PRIMARY KEY(campaign, provider_id)
+		)`,
+		`CREATE INDEX IF NOT EXISTS idx_referral_redemptions_issuer ON referral_redemptions(issuer_id)`,
+		`CREATE TABLE IF NOT EXISTS provider_referral_admissions (
+			provider_id TEXT NOT NULL,
+			campaign TEXT NOT NULL,
+			policy_version TEXT NOT NULL,
+			decision TEXT NOT NULL CHECK(decision IN ('referred','grandfathered')),
+			applied_at TEXT NOT NULL,
+			PRIMARY KEY(provider_id, campaign)
+		)`,
+		`CREATE TABLE IF NOT EXISTS apptrack_pending_referral_mints (
+			provider_id TEXT PRIMARY KEY,
+			token_hash TEXT NOT NULL UNIQUE,
+			campaign TEXT NOT NULL,
+			registration_source_ip TEXT NOT NULL,
+			registration_nonce TEXT NOT NULL,
+			registration_attempt_ts TEXT NOT NULL,
+			created_redemption INTEGER NOT NULL CHECK(created_redemption IN (0, 1)),
+			created_at TEXT NOT NULL
+		)`,
+		`CREATE INDEX IF NOT EXISTS idx_apptrack_pending_referral_mints_created_at ON apptrack_pending_referral_mints(created_at)`,
 		`CREATE TABLE IF NOT EXISTS bootstrap_gc_audit (
 			id INTEGER PRIMARY KEY CHECK (id = 1),
 			last_run_at TEXT NOT NULL,
@@ -631,6 +677,16 @@ func (s *Store) ensureProviderIDColumn(ctx context.Context) error {
 }
 
 func (s *Store) IssueToken(ctx context.Context, providerID, providerName string) (TokenRecord, string, error) {
+	return s.issueToken(ctx, providerID, providerName, "", ReferralPolicy{})
+}
+
+// IssueTokenWithReferral redeems referral capacity in the same SQLite
+// transaction as the token insert.
+func (s *Store) IssueTokenWithReferral(ctx context.Context, providerID, providerName, referralCode string, policy ReferralPolicy) (TokenRecord, string, error) {
+	return s.issueToken(ctx, providerID, providerName, referralCode, policy)
+}
+
+func (s *Store) issueToken(ctx context.Context, providerID, providerName, referralCode string, policy ReferralPolicy) (TokenRecord, string, error) {
 	// Issue #274 R1 CODE LOW-1: validate the RAW provider_id before any
 	// normalization so admission paths apply the same gate semantics as WS
 	// paths (which validate as-received). Leading/trailing whitespace is
@@ -650,7 +706,8 @@ func (s *Store) IssueToken(ctx context.Context, providerID, providerName string)
 	token := hex.EncodeToString(raw[:])
 	hash := tokenHash(token)
 	prefix := token[:tokenDisplayPrefixLength]
-	createdAt := nowString()
+	now := time.Now().UTC()
+	createdAt := timeText(now)
 	var record TokenRecord
 	err := sqliteutil.Transact(ctx, s.db, func(ctx context.Context, conn *sql.Conn) error {
 		if IsCredentialBootstrapPrincipal(providerID) {
@@ -664,6 +721,9 @@ SELECT EXISTS(
 			if bootstrapIdentityExists == 1 {
 				return ErrBootstrapIdentityExists
 			}
+		}
+		if _, err := redeemReferralTx(ctx, conn, policy, referralCode, providerID, now); err != nil {
+			return err
 		}
 		res, err := conn.ExecContext(ctx, `INSERT INTO provider_tokens (token_hash, token_prefix, provider_id, provider_name, created_at) VALUES (?, ?, ?, ?, ?)`, hash, prefix, providerID, providerName, createdAt)
 		if err != nil {
@@ -902,6 +962,14 @@ SELECT COUNT(1)
 				decisionErr = ErrBootstrapOutstandingLimit
 				return nil
 			}
+		}
+
+		referralPolicy := req.ReferralPolicy
+		// Grandfathering is available only after exact receipt-key custody of an
+		// existing bootstrap identity has been proven above.
+		referralPolicy.GrandfatherProof = identityExists
+		if _, err := redeemReferralTx(ctx, conn, referralPolicy, req.ReferralCode, req.ProviderID, req.Now); err != nil {
+			return err
 		}
 
 		if activeExists {
@@ -2581,6 +2649,14 @@ func (s *Store) HasOwnership(ctx context.Context, providerID string) (bool, erro
 }
 
 func (s *Store) MintAdmissionTokenAndPairOT(ctx context.Context, providerID, providerName string, now time.Time) (AdmissionPairMint, error) {
+	return s.mintAdmissionTokenAndPairOT(ctx, providerID, providerName, now, "", ReferralPolicy{})
+}
+
+func (s *Store) MintAdmissionTokenAndPairOTWithReferral(ctx context.Context, providerID, providerName string, now time.Time, referralCode string, policy ReferralPolicy) (AdmissionPairMint, error) {
+	return s.mintAdmissionTokenAndPairOT(ctx, providerID, providerName, now, referralCode, policy)
+}
+
+func (s *Store) mintAdmissionTokenAndPairOT(ctx context.Context, providerID, providerName string, now time.Time, referralCode string, policy ReferralPolicy) (AdmissionPairMint, error) {
 	// Issue #274 R1 CODE LOW-1: validate the RAW provider_id before any
 	// normalization so admission paths apply the same gate semantics as WS
 	// paths.
@@ -2615,6 +2691,9 @@ SELECT EXISTS(
 			if bootstrapIdentityExists == 1 {
 				return ErrBootstrapIdentityExists
 			}
+		}
+		if _, err := redeemReferralTx(ctx, conn, policy, referralCode, providerID, now); err != nil {
+			return err
 		}
 		res, err := conn.ExecContext(ctx, `INSERT INTO provider_tokens (token_hash, token_prefix, provider_id, provider_name, created_at) VALUES (?, ?, ?, ?, ?)`, hash, prefix, providerID, providerName, nowText)
 		if err != nil {

--- a/phase4-coordinator/internal/auth/tokens_test.go
+++ b/phase4-coordinator/internal/auth/tokens_test.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"net/http"
 	"path/filepath"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -1239,7 +1240,7 @@ func TestMintProviderTokenAppTrackRequiresProofForAnyActiveToken(t *testing.T) {
 	ctx := context.Background()
 	const providerID = "p_apptrackprovider"
 
-	first, err := store.MintProviderTokenAppTrack(ctx, providerID, nil)
+	first, err := store.MintProviderTokenAppTrack(ctx, providerID, nil, nil)
 	if err != nil {
 		t.Fatalf("first app-track mint: %v", err)
 	}
@@ -1247,18 +1248,18 @@ func TestMintProviderTokenAppTrackRequiresProofForAnyActiveToken(t *testing.T) {
 		t.Fatalf("first token len=%d want 64", len(first))
 	}
 
-	if _, err := store.MintProviderTokenAppTrack(ctx, providerID, nil); !errors.Is(err, auth.ErrAppTrackExistingTokenNoProof) {
+	if _, err := store.MintProviderTokenAppTrack(ctx, providerID, nil, nil); !errors.Is(err, auth.ErrAppTrackExistingTokenNoProof) {
 		t.Fatalf("unused active without proof err=%v want ErrAppTrackExistingTokenNoProof", err)
 	}
 	if provider, ok, err := store.ValidateToken(ctx, first); err != nil || !ok || provider != providerID {
 		t.Fatalf("first token should remain active provider=%q ok=%v err=%v", provider, ok, err)
 	}
 	wrong := "wrong-token"
-	if _, err := store.MintProviderTokenAppTrack(ctx, providerID, &wrong); !errors.Is(err, auth.ErrAppTrackExistingTokenNoProof) {
+	if _, err := store.MintProviderTokenAppTrack(ctx, providerID, &wrong, nil); !errors.Is(err, auth.ErrAppTrackExistingTokenNoProof) {
 		t.Fatalf("active token with wrong proof err=%v want ErrAppTrackExistingTokenNoProof", err)
 	}
 
-	second, err := store.MintProviderTokenAppTrack(ctx, providerID, &first)
+	second, err := store.MintProviderTokenAppTrack(ctx, providerID, &first, nil)
 	if err != nil {
 		t.Fatalf("active token with current proof should reissue: %v", err)
 	}
@@ -1268,8 +1269,24 @@ func TestMintProviderTokenAppTrackRequiresProofForAnyActiveToken(t *testing.T) {
 	if err := store.MarkTokenUsed(ctx, second); err != nil {
 		t.Fatalf("mark second used: %v", err)
 	}
-	if _, err := store.MintProviderTokenAppTrack(ctx, providerID, &second); !errors.Is(err, auth.ErrAppTrackReissueCooldown) {
+	if _, err := store.MintProviderTokenAppTrack(ctx, providerID, &second, nil); !errors.Is(err, auth.ErrAppTrackReissueCooldown) {
 		t.Fatalf("cooldown reissue err=%v want ErrAppTrackReissueCooldown", err)
+	}
+}
+
+func TestMintProviderTokenAppTrackUsesFreshClientCandidate(t *testing.T) {
+	store, err := auth.OpenStore(filepath.Join(t.TempDir(), "coordinator.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+	candidate := strings.Repeat("c", 64)
+	got, err := store.MintProviderTokenAppTrack(context.Background(), "p_apptrackcandidate", nil, &candidate)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != candidate {
+		t.Fatalf("token=%q want client candidate", got)
 	}
 }
 

--- a/phase4-coordinator/internal/config/config.go
+++ b/phase4-coordinator/internal/config/config.go
@@ -70,6 +70,7 @@ type Config struct {
 	Tier2                        Tier2Config                  `yaml:"tier2"`
 	CoordinatorAdvertisedVersion CoordinatorAdvertisedVersion `yaml:"coordinator_advertised_version"`
 	Auth                         AuthConfig                   `yaml:"auth"`
+	Referrals                    ReferralConfig               `yaml:"referrals"`
 	Storage                      StorageConfig                `yaml:"storage"`
 	Logging                      LoggingConfig                `yaml:"logging"`
 	Rewards                      RewardsConfig                `yaml:"rewards"`
@@ -702,6 +703,25 @@ type AuthConfig struct {
 	GitHubOAuth                           GitHubOAuthConfig `yaml:"github_oauth"`
 }
 
+// ReferralConfig owns pre-beta admission policy. Both launch flags default
+// off; HMAC material supports env:NAME indirection and never needs to be
+// written to the credential database.
+type ReferralConfig struct {
+	RequireForRegistration  bool              `yaml:"require_for_registration"`
+	EnableSocialInviteBonus bool              `yaml:"enable_social_invite_bonus"`
+	Campaign                string            `yaml:"campaign"`
+	PolicyVersion           string            `yaml:"policy_version"`
+	GrandfatherBefore       string            `yaml:"grandfather_before"`
+	CurrentKeyID            string            `yaml:"current_key_id"`
+	HMACKeys                map[string]string `yaml:"hmac_keys"`
+	ProviderBaseUses        int               `yaml:"provider_base_uses"`
+	SocialBonusUses         int               `yaml:"social_bonus_uses"`
+	ChallengeTTLS           int               `yaml:"challenge_ttl_s"`
+	JoinBaseURL             string            `yaml:"join_base_url"`
+	XAPIBearerToken         string            `yaml:"x_api_bearer_token"`
+	RequestAccessURL        string            `yaml:"request_access_url"`
+}
+
 type GitHubOAuthConfig struct {
 	Enabled             bool   `yaml:"enabled"`
 	ClientID            string `yaml:"client_id"`
@@ -1124,6 +1144,14 @@ func Default() Config {
 			CredentialBootstrapTokenTTLS:          600,
 			CredentialBootstrapIdentityRetentionS: 604800,
 		},
+		Referrals: ReferralConfig{
+			ProviderBaseUses: 1,
+			SocialBonusUses:  2,
+			ChallengeTTLS:    900,
+			JoinBaseURL:      "https://coordinator.streamvc.live/j",
+			PolicyVersion:    "v1",
+			HMACKeys:         map[string]string{},
+		},
 		Proxy: ProxyConfig{
 			// Default trusts loopback only. Production sits behind nginx on
 			// localhost, so the default keys rate-limit buckets on the
@@ -1212,6 +1240,18 @@ func (c *Config) resolveEnv() error {
 			return err
 		}
 		c.Auth.OperatorKeys[name] = v
+	}
+	for keyID, raw := range c.Referrals.HMACKeys {
+		v, err := resolveEnvValue("referrals.hmac_keys."+keyID, raw)
+		if err != nil {
+			return err
+		}
+		c.Referrals.HMACKeys[keyID] = v
+	}
+	if v, err := resolveEnvValue("referrals.x_api_bearer_token", c.Referrals.XAPIBearerToken); err != nil {
+		return err
+	} else {
+		c.Referrals.XAPIBearerToken = v
 	}
 	// Round-1 SECURITY r1 MEDIUM 1: stats DSN fields go through
 	// the same env-indirection resolver. Operators inject DSNs
@@ -1516,6 +1556,9 @@ func (c Config) Validate() error {
 	if c.Auth.CredentialBootstrapIdentityRetentionS <= c.Auth.CredentialBootstrapTokenTTLS {
 		return fmt.Errorf("auth.credential_bootstrap_identity_retention_s must exceed auth.credential_bootstrap_token_ttl_s")
 	}
+	if err := c.validateReferrals(); err != nil {
+		return err
+	}
 	if c.WS.WriteBufferSize <= 0 {
 		return fmt.Errorf("ws.write_buffer_size must be > 0")
 	}
@@ -1801,6 +1844,60 @@ func (c Config) validateCompatibilitySet() error {
 	}
 	if _, ok := seen[policy.TargetID]; !ok {
 		return fmt.Errorf("coordinator.compatibility_set.accepted_ids must contain target_id")
+	}
+	return nil
+}
+
+var referralConfigPartPattern = regexp.MustCompile(`^[A-Za-z0-9_]{1,32}$`)
+
+func (c Config) validateReferrals() error {
+	r := c.Referrals
+	if !r.RequireForRegistration && !r.EnableSocialInviteBonus {
+		return nil
+	}
+	if !referralConfigPartPattern.MatchString(r.Campaign) {
+		return fmt.Errorf("referrals.campaign must contain 1-32 letters, digits, or underscores")
+	}
+	if !referralConfigPartPattern.MatchString(r.PolicyVersion) {
+		return fmt.Errorf("referrals.policy_version must contain 1-32 letters, digits, or underscores")
+	}
+	if raw := strings.TrimSpace(r.GrandfatherBefore); raw != "" {
+		if _, err := time.Parse(time.RFC3339, raw); err != nil {
+			return fmt.Errorf("referrals.grandfather_before must be RFC3339: %w", err)
+		}
+	}
+	if !referralConfigPartPattern.MatchString(r.CurrentKeyID) {
+		return fmt.Errorf("referrals.current_key_id must contain 1-32 letters, digits, or underscores")
+	}
+	secret := r.HMACKeys[r.CurrentKeyID]
+	if len(secret) < 32 {
+		return fmt.Errorf("referrals.hmac_keys.%s must be at least 32 bytes", r.CurrentKeyID)
+	}
+	for keyID, value := range r.HMACKeys {
+		if !referralConfigPartPattern.MatchString(keyID) || len(value) < 32 {
+			return fmt.Errorf("referrals.hmac_keys.%s is invalid or shorter than 32 bytes", keyID)
+		}
+	}
+	if r.ProviderBaseUses <= 0 {
+		return fmt.Errorf("referrals.provider_base_uses must be > 0")
+	}
+	if r.EnableSocialInviteBonus {
+		if r.SocialBonusUses <= 0 || r.ChallengeTTLS <= 0 {
+			return fmt.Errorf("referrals social_bonus_uses and challenge_ttl_s must be > 0")
+		}
+		if strings.TrimSpace(r.XAPIBearerToken) == "" {
+			return fmt.Errorf("referrals.x_api_bearer_token must be set when social invite bonus is enabled")
+		}
+	}
+	joinURL, err := url.Parse(strings.TrimSpace(r.JoinBaseURL))
+	if err != nil || joinURL.Scheme != "https" || joinURL.Host == "" || joinURL.RawQuery != "" || joinURL.Fragment != "" || !strings.HasSuffix(strings.TrimRight(joinURL.Path, "/"), "/j") {
+		return fmt.Errorf("referrals.join_base_url must be an absolute https URL ending in /j")
+	}
+	if raw := strings.TrimSpace(r.RequestAccessURL); raw != "" {
+		reqURL, err := url.Parse(raw)
+		if err != nil || reqURL.Scheme != "https" || reqURL.Host == "" {
+			return fmt.Errorf("referrals.request_access_url must be an absolute https URL when set")
+		}
 	}
 	return nil
 }

--- a/phase4-coordinator/internal/config/config.go
+++ b/phase4-coordinator/internal/config/config.go
@@ -708,6 +708,7 @@ type AuthConfig struct {
 // written to the credential database.
 type ReferralConfig struct {
 	RequireForRegistration  bool              `yaml:"require_for_registration"`
+	EnablePublicValidation  bool              `yaml:"enable_public_validation"`
 	EnableSocialInviteBonus bool              `yaml:"enable_social_invite_bonus"`
 	Campaign                string            `yaml:"campaign"`
 	PolicyVersion           string            `yaml:"policy_version"`
@@ -1852,7 +1853,7 @@ var referralConfigPartPattern = regexp.MustCompile(`^[A-Za-z0-9_]{1,32}$`)
 
 func (c Config) validateReferrals() error {
 	r := c.Referrals
-	if !r.RequireForRegistration && !r.EnableSocialInviteBonus {
+	if !r.RequireForRegistration && !r.EnablePublicValidation && !r.EnableSocialInviteBonus {
 		return nil
 	}
 	if !referralConfigPartPattern.MatchString(r.Campaign) {

--- a/phase4-coordinator/internal/config/config_test.go
+++ b/phase4-coordinator/internal/config/config_test.go
@@ -33,6 +33,28 @@ func TestAutotuneFeedsRequirePublicKeyringWhenConfigured(t *testing.T) {
 	}
 }
 
+func TestReferralLaunchPolicyDefaultsOffAndRejectsUnsafeEnablement(t *testing.T) {
+	cfg := Default()
+	if cfg.Referrals.RequireForRegistration || cfg.Referrals.EnableSocialInviteBonus {
+		t.Fatal("referral launch policy must default off")
+	}
+	cfg.Auth.OperatorKey = "operator-key"
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("disabled referral defaults should validate: %v", err)
+	}
+
+	cfg.Referrals.RequireForRegistration = true
+	cfg.Referrals.Campaign = "prebeta_2026"
+	cfg.Referrals.CurrentKeyID = "k1"
+	if err := cfg.Validate(); err == nil || !strings.Contains(err.Error(), "hmac_keys") {
+		t.Fatalf("unsafe enablement error=%v", err)
+	}
+	cfg.Referrals.HMACKeys = map[string]string{"k1": strings.Repeat("s", 32)}
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("valid referral gate: %v", err)
+	}
+}
+
 func TestAutotuneFeedsRejectInvalidPublicKeys(t *testing.T) {
 	tests := []struct {
 		name    string

--- a/phase4-coordinator/internal/config/config_test.go
+++ b/phase4-coordinator/internal/config/config_test.go
@@ -35,7 +35,7 @@ func TestAutotuneFeedsRequirePublicKeyringWhenConfigured(t *testing.T) {
 
 func TestReferralLaunchPolicyDefaultsOffAndRejectsUnsafeEnablement(t *testing.T) {
 	cfg := Default()
-	if cfg.Referrals.RequireForRegistration || cfg.Referrals.EnableSocialInviteBonus {
+	if cfg.Referrals.RequireForRegistration || cfg.Referrals.EnablePublicValidation || cfg.Referrals.EnableSocialInviteBonus {
 		t.Fatal("referral launch policy must default off")
 	}
 	cfg.Auth.OperatorKey = "operator-key"

--- a/phase4-coordinator/internal/onboarding/apptrack.go
+++ b/phase4-coordinator/internal/onboarding/apptrack.go
@@ -26,6 +26,8 @@ import (
 	"github.com/augstar/macprovider-coordinator/internal/billing"
 )
 
+const appTrackPendingMintReconcileAge = 2 * time.Minute
+
 // RegisterRequest is the JSON body of POST /v1/providers/register.
 // SPEC-026 §4.1. All fields required except AppAttestObject / AppAttestKeyID.
 type RegisterRequest struct {
@@ -34,9 +36,10 @@ type RegisterRequest struct {
 	HardwareSummary HardwareSummary `json:"hardware_summary"`
 	AppAttestObject *string         `json:"app_attest_object,omitempty"` // base64 CBOR
 	AppAttestKeyID  *string         `json:"app_attest_key_id,omitempty"` // base64 32-byte
-	Nonce           string          `json:"nonce"`                       // 64-hex = 32 random bytes
-	TSUTC           string          `json:"ts_utc"`                      // RFC3339
-	Signature       string          `json:"signature"`                   // base64 64-byte Ed25519 over JCS(body\signature)
+	ReferralCode    string          `json:"referral_code,omitempty"`
+	Nonce           string          `json:"nonce"`     // 64-hex = 32 random bytes
+	TSUTC           string          `json:"ts_utc"`    // RFC3339
+	Signature       string          `json:"signature"` // base64 64-byte Ed25519 over JCS(body\signature)
 }
 
 type HardwareSummary struct {
@@ -109,6 +112,8 @@ type Handler struct {
 	// SQLite auth DB — for provider_tokens mint. Reuses existing
 	// phase4-coordinator/internal/auth store.
 	AuthTokenStore AuthTokenStore
+	ReferralStore  ReferralStore
+	ReferralPolicy auth.ReferralPolicy
 
 	// Coordinator config
 	CoordinatorDomain string
@@ -162,6 +167,14 @@ type StatsDB interface {
 	CheckAppAttestKeyIDUnique(ctx context.Context, keyID []byte, providerID string) error
 }
 
+// RegistrationPrepareStore is the durable PostgreSQL half of a gated
+// App-track registration. It is a separate optional interface so open-beta
+// test seams and non-gated deployments retain the existing StatsDB contract.
+type RegistrationPrepareStore interface {
+	PrepareProviderRegistration(ctx context.Context, providerID, sourceIP, nonce string, observedAt, attemptTS time.Time, identityPubkey []byte, attested bool, appAttestKeyID []byte) error
+	ProviderRegistrationPrepared(ctx context.Context, providerID, nonce string, attemptTS time.Time) (bool, error)
+}
+
 // AuthTokenStore is the SQLite-side dependency (existing
 // phase4-coordinator/internal/auth/tokens.go).
 type AuthTokenStore interface {
@@ -175,6 +188,14 @@ type AuthTokenStore interface {
 	// bound provider_id. Evidence submission is read-only with respect to the
 	// SQLite token store, so it does not mark the token used.
 	ValidateToken(ctx context.Context, token string) (providerID string, ok bool, err error)
+}
+
+type ReferralStore interface {
+	MintProviderTokenAppTrackWithReferralAttempt(ctx context.Context, providerID, referralCode string, policy auth.ReferralPolicy, attempt auth.AppTrackRegistrationAttempt) (cleartext string, err error)
+	AcknowledgeAppTrackReferralMint(ctx context.Context, providerID, cleartextToken string) error
+	RollbackAppTrackReferralMint(ctx context.Context, providerID, cleartextToken string) error
+	ListPendingAppTrackReferralMints(ctx context.Context, createdBefore time.Time) ([]auth.PendingAppTrackReferralMint, error)
+	ResolvePendingAppTrackReferralMint(ctx context.Context, pending auth.PendingAppTrackReferralMint, registrationPrepared bool) error
 }
 
 // IPRateLimiter and ASNRateLimiter both wrap the coordinator's existing
@@ -261,6 +282,10 @@ func (h *Handler) HandleAppTrackRegister(w http.ResponseWriter, r *http.Request)
 		writeJSONError(w, http.StatusBadRequest, "bad_request", "invalid request body")
 		return
 	}
+	if len([]byte(req.ReferralCode)) > 256 || strings.IndexFunc(req.ReferralCode, func(r rune) bool { return r < 0x20 || r == 0x7f }) >= 0 {
+		writeJSONError(w, http.StatusBadRequest, "bad_request", "referral_code is invalid")
+		return
+	}
 
 	pubkey, err := DecodeIdentityPubkey(req.IdentityPubkey)
 	if err != nil {
@@ -284,10 +309,6 @@ func (h *Handler) HandleAppTrackRegister(w http.ResponseWriter, r *http.Request)
 	if h.Now != nil {
 		now = h.Now().UTC()
 	}
-	if delta := now.Sub(tsUTC); delta > time.Minute || delta < -time.Minute {
-		writeJSONError(w, http.StatusBadRequest, "timestamp_skew", "ts_utc outside allowed skew")
-		return
-	}
 	signature, err := base64.StdEncoding.DecodeString(req.Signature)
 	if err != nil || len(signature) != ed25519.SignatureSize {
 		writeJSONError(w, http.StatusBadRequest, "bad_request", "invalid signature encoding")
@@ -305,6 +326,40 @@ func (h *Handler) HandleAppTrackRegister(w http.ResponseWriter, r *http.Request)
 	}
 
 	sourceIP := clientIP(r, h.TrustedProxies)
+	currentBearer := bearerFromRequest(r)
+	bearerExempt := false
+	if h.ReferralPolicy.RequireForRegistration && currentBearer != nil {
+		boundProviderID, ok, validateErr := h.AuthTokenStore.ValidateToken(r.Context(), *currentBearer)
+		if validateErr != nil {
+			writeJSONError(w, http.StatusServiceUnavailable, "unavailable", "credential authority unavailable")
+			return
+		}
+		bearerExempt = ok && boundProviderID == req.ProviderID
+	}
+	prepareStore, prepareStoreOK := h.StatsDB.(RegistrationPrepareStore)
+	if h.ReferralPolicy.RequireForRegistration && !bearerExempt {
+		if h.ReferralStore == nil || !prepareStoreOK {
+			writeJSONError(w, http.StatusServiceUnavailable, "unavailable", "referral authority unavailable")
+			return
+		}
+		// A retry of an already committed signed attempt never rotates or
+		// re-discloses credentials. Return a stable support state instead.
+		checkCtx, cancelCheck := context.WithTimeout(r.Context(), 2*time.Second)
+		prepared, checkErr := prepareStore.ProviderRegistrationPrepared(checkCtx, req.ProviderID, req.Nonce, tsUTC)
+		cancelCheck()
+		if checkErr != nil {
+			writeJSONError(w, http.StatusServiceUnavailable, "unavailable", "provider registration outcome unavailable")
+			return
+		}
+		if prepared {
+			writeJSONError(w, http.StatusConflict, "existing_active_token_no_proof", "registration already committed; existing credential proof or support is required")
+			return
+		}
+	}
+	if delta := now.Sub(tsUTC); delta > time.Minute || delta < -time.Minute {
+		writeJSONError(w, http.StatusBadRequest, "timestamp_skew", "ts_utc outside allowed skew")
+		return
+	}
 	if h.IPRateLimiter != nil && !h.IPRateLimiter.Allow(sourceIP) {
 		if h.Metrics != nil {
 			h.Metrics.IncRegisterRateLimitHit("ip")
@@ -332,15 +387,6 @@ func (h *Handler) HandleAppTrackRegister(w http.ResponseWriter, r *http.Request)
 			return
 		}
 	}
-	if err := h.StatsDB.InsertRegisterNonce(r.Context(), req.ProviderID, sourceIP, req.Nonce, now); err != nil {
-		if errors.Is(err, ErrNonceReplay) {
-			writeJSONError(w, http.StatusConflict, "nonce_replay", "register nonce replay")
-			return
-		}
-		writeJSONError(w, http.StatusInternalServerError, "internal_error", "nonce replay check failed")
-		return
-	}
-
 	attested := false
 	var appAttestKeyID []byte
 	if req.AppAttestObject != nil {
@@ -398,30 +444,80 @@ func (h *Handler) HandleAppTrackRegister(w http.ResponseWriter, r *http.Request)
 			return
 		}
 	}
-	if err := h.StatsDB.UpsertProviderIdentity(r.Context(), req.ProviderID, pubkey, attested, appAttestKeyID); err != nil {
-		switch {
-		case errors.Is(err, ErrTOFUConflict):
-			writeJSONError(w, http.StatusConflict, "provider_id_pubkey_mismatch", "provider_id already registered with a different identity_pubkey")
-		case errors.Is(err, ErrAttestKeyReused):
-			writeJSONError(w, http.StatusConflict, "app_attest_key_reused", "app_attest_key_id already bound")
-		default:
-			writeJSONError(w, http.StatusInternalServerError, "internal_error", "provider identity upsert failed")
+	var token string
+	if h.ReferralPolicy.RequireForRegistration && !bearerExempt {
+		attempt := auth.AppTrackRegistrationAttempt{SourceIP: sourceIP, Nonce: req.Nonce, AttemptTS: tsUTC}
+		mintCtx, cancelMint := context.WithTimeout(r.Context(), 2*time.Second)
+		token, err = h.ReferralStore.MintProviderTokenAppTrackWithReferralAttempt(
+			mintCtx, req.ProviderID, req.ReferralCode, h.ReferralPolicy, attempt,
+		)
+		cancelMint()
+		if err != nil {
+			writeAppTrackMintError(w, err)
+			return
 		}
-		return
-	}
-	currentBearer := bearerFromRequest(r)
-	token, err := h.AuthTokenStore.MintProviderTokenAppTrack(r.Context(), req.ProviderID, currentBearer)
-	if err != nil {
-		switch {
-		case errors.Is(err, auth.ErrAppTrackExistingTokenNoProof):
-			writeJSONError(w, http.StatusConflict, "existing_active_token_no_proof", "existing active token requires proof")
-		case errors.Is(err, auth.ErrAppTrackReissueCooldown):
-			w.Header().Set("Retry-After", "300")
-			writeJSONError(w, http.StatusTooManyRequests, "reissue_cooldown", "provider token reissue cooldown active")
-		default:
-			writeJSONError(w, http.StatusInternalServerError, "internal_error", "provider token mint failed")
+
+		prepareCtx, cancelPrepare := context.WithTimeout(r.Context(), 2*time.Second)
+		prepareErr := prepareStore.PrepareProviderRegistration(
+			prepareCtx, req.ProviderID, sourceIP, req.Nonce, now, tsUTC,
+			pubkey, attested, appAttestKeyID,
+		)
+		cancelPrepare()
+		if prepareErr != nil {
+			// PostgreSQL commit errors can be ambiguous. Compensate only after the
+			// exact durable marker proves this attempt did not commit.
+			checkCtx, cancelCheck := context.WithTimeout(context.Background(), 2*time.Second)
+			prepared, checkErr := prepareStore.ProviderRegistrationPrepared(checkCtx, req.ProviderID, req.Nonce, tsUTC)
+			cancelCheck()
+			if checkErr != nil {
+				writeJSONError(w, http.StatusInternalServerError, "internal_error", "provider registration outcome pending reconciliation")
+				return
+			}
+			if !prepared {
+				rollbackCtx, cancelRollback := context.WithTimeout(context.Background(), 2*time.Second)
+				rollbackErr := h.ReferralStore.RollbackAppTrackReferralMint(rollbackCtx, req.ProviderID, token)
+				cancelRollback()
+				if rollbackErr != nil {
+					writeJSONError(w, http.StatusInternalServerError, "internal_error", "provider registration compensation pending reconciliation")
+					return
+				}
+				writeAppTrackPrepareError(w, prepareErr)
+				return
+			}
 		}
-		return
+
+		ackCtx, cancelAck := context.WithTimeout(context.Background(), 2*time.Second)
+		ackErr := h.ReferralStore.AcknowledgeAppTrackReferralMint(ackCtx, req.ProviderID, token)
+		cancelAck()
+		if ackErr != nil {
+			if metrics, ok := h.Metrics.(interface{ IncRegisterReconcileDeferred() }); ok {
+				metrics.IncRegisterReconcileDeferred()
+			}
+		}
+		if !h.appTrackTokenStillActive(req.ProviderID, token) {
+			writeJSONError(w, http.StatusConflict, "existing_active_token_no_proof", "credential was superseded before disclosure")
+			return
+		}
+	} else {
+		// Open registration and custody-proven reissues retain the established
+		// PostgreSQL-first path; they do not consume referral capacity.
+		if err := h.StatsDB.InsertRegisterNonce(r.Context(), req.ProviderID, sourceIP, req.Nonce, now); err != nil {
+			if errors.Is(err, ErrNonceReplay) {
+				writeJSONError(w, http.StatusConflict, "nonce_replay", "register nonce replay")
+				return
+			}
+			writeJSONError(w, http.StatusInternalServerError, "internal_error", "nonce replay check failed")
+			return
+		}
+		if err := h.StatsDB.UpsertProviderIdentity(r.Context(), req.ProviderID, pubkey, attested, appAttestKeyID); err != nil {
+			writeAppTrackPrepareError(w, err)
+			return
+		}
+		token, err = h.AuthTokenStore.MintProviderTokenAppTrack(r.Context(), req.ProviderID, currentBearer)
+		if err != nil {
+			writeAppTrackMintError(w, err)
+			return
+		}
 	}
 	h.persistHardwareProfileAsync(req.ProviderID, req.HardwareSummary, now)
 	if h.Metrics != nil {
@@ -434,6 +530,80 @@ func (h *Handler) HandleAppTrackRegister(w http.ResponseWriter, r *http.Request)
 		Trust:            TrustState{Attested: attested, RateLimitBucket: "new_ip"},
 		CoordinatorWSURL: h.CoordinatorWSURL,
 	})
+}
+
+// ReconcilePendingAppTrackReferralMints resolves only sagas old enough not to
+// belong to a live request. A committed marker preserves the token; an absent
+// marker compensates the undisclosed token and its exact new redemption.
+func (h *Handler) ReconcilePendingAppTrackReferralMints(ctx context.Context) error {
+	if h == nil || h.ReferralStore == nil || h.StatsDB == nil {
+		return nil
+	}
+	prepareStore, ok := h.StatsDB.(RegistrationPrepareStore)
+	if !ok {
+		return errors.New("registration prepare store unavailable")
+	}
+	now := time.Now().UTC()
+	if h.Now != nil {
+		now = h.Now().UTC()
+	}
+	pending, err := h.ReferralStore.ListPendingAppTrackReferralMints(ctx, now.Add(-appTrackPendingMintReconcileAge))
+	if err != nil {
+		return fmt.Errorf("list pending App-track referral mints: %w", err)
+	}
+	var reconcileErrs []error
+	for _, item := range pending {
+		prepared, err := prepareStore.ProviderRegistrationPrepared(
+			ctx, item.ProviderID, item.Attempt.Nonce, item.Attempt.AttemptTS,
+		)
+		if err != nil {
+			reconcileErrs = append(reconcileErrs, fmt.Errorf("check pending App-track mint %s: %w", item.ProviderID, err))
+			continue
+		}
+		if err := h.ReferralStore.ResolvePendingAppTrackReferralMint(ctx, item, prepared); err != nil {
+			reconcileErrs = append(reconcileErrs, fmt.Errorf("resolve pending App-track mint %s: %w", item.ProviderID, err))
+		}
+	}
+	return errors.Join(reconcileErrs...)
+}
+
+func writeAppTrackPrepareError(w http.ResponseWriter, err error) {
+	switch {
+	case errors.Is(err, ErrNonceReplay):
+		writeJSONError(w, http.StatusConflict, "nonce_replay", "register nonce replay")
+	case errors.Is(err, ErrTOFUConflict):
+		writeJSONError(w, http.StatusConflict, "provider_id_pubkey_mismatch", "provider_id already registered with a different identity_pubkey")
+	case errors.Is(err, ErrAttestKeyReused):
+		writeJSONError(w, http.StatusConflict, "app_attest_key_reused", "app_attest_key_id already bound")
+	default:
+		writeJSONError(w, http.StatusInternalServerError, "internal_error", "provider registration prepare failed")
+	}
+}
+
+func writeAppTrackMintError(w http.ResponseWriter, err error) {
+	switch {
+	case errors.Is(err, auth.ErrReferralRequired), errors.Is(err, auth.ErrReferralInvalid),
+		errors.Is(err, auth.ErrReferralExpired), errors.Is(err, auth.ErrReferralRevoked),
+		errors.Is(err, auth.ErrReferralExhausted), errors.Is(err, auth.ErrReferralConflict):
+		writeReferralError(w, err)
+	case errors.Is(err, auth.ErrAppTrackExistingTokenNoProof):
+		writeJSONError(w, http.StatusConflict, "existing_active_token_no_proof", "existing active token requires proof")
+	case errors.Is(err, auth.ErrAppTrackReissueCooldown):
+		w.Header().Set("Retry-After", "300")
+		writeJSONError(w, http.StatusTooManyRequests, "reissue_cooldown", "provider token reissue cooldown active")
+	default:
+		writeJSONError(w, http.StatusInternalServerError, "internal_error", "provider token mint failed")
+	}
+}
+
+func (h *Handler) appTrackTokenStillActive(providerID, cleartext string) bool {
+	if h.AuthTokenStore == nil {
+		return false
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	bound, ok, err := h.AuthTokenStore.ValidateToken(ctx, cleartext)
+	return err == nil && ok && bound == providerID
 }
 
 func (h *Handler) persistHardwareProfileAsync(providerID string, summary HardwareSummary, observedAt time.Time) {
@@ -528,6 +698,7 @@ func (h *Handler) clientDataHash(req RegisterRequest) [32]byte {
 		"provider_id":        req.ProviderID,
 		"identity_pubkey":    req.IdentityPubkey,
 		"register_nonce":     req.Nonce,
+		"referral_code":      req.ReferralCode,
 		"coordinator_domain": domain,
 		"bundle_id":          h.AppAttestConfig.BundleID,
 		"team_id":            h.AppAttestConfig.TeamID,
@@ -551,6 +722,30 @@ func bearerFromRequest(r *http.Request) *string {
 		return nil
 	}
 	return &token
+}
+
+func writeReferralError(w http.ResponseWriter, err error) {
+	switch {
+	case errors.Is(err, auth.ErrReferralRequired):
+		writeReferralJSONError(w, http.StatusBadRequest, "referral_required", "missing", "a valid pre-beta referral is required")
+	case errors.Is(err, auth.ErrReferralExpired):
+		writeReferralJSONError(w, http.StatusGone, "referral_expired", "expired", "referral code expired")
+	case errors.Is(err, auth.ErrReferralRevoked):
+		writeReferralJSONError(w, http.StatusGone, "referral_revoked", "revoked", "referral code revoked")
+	case errors.Is(err, auth.ErrReferralExhausted):
+		writeReferralJSONError(w, http.StatusConflict, "referral_exhausted", "exhausted", "all spots on this referral are taken")
+	case errors.Is(err, auth.ErrReferralConflict):
+		writeReferralJSONError(w, http.StatusConflict, "referral_conflict", "invalid", "provider is already attributed to another referral")
+	default:
+		writeReferralJSONError(w, http.StatusBadRequest, "referral_invalid", "invalid", "referral code is invalid")
+	}
+}
+
+func writeReferralJSONError(w http.ResponseWriter, status int, code, reason, message string) {
+	writeJSON(w, status, map[string]any{
+		"error":  map[string]any{"code": code, "message": message},
+		"reason": reason,
+	})
 }
 
 func writeJSON(w http.ResponseWriter, status int, v any) {
@@ -590,6 +785,12 @@ func clientIP(r *http.Request, trusted []netip.Prefix) string {
 		}
 	}
 	return host
+}
+
+// ClientIP exposes the audited trusted-proxy walk to adjacent public
+// onboarding endpoints without duplicating proxy-boundary logic.
+func ClientIP(r *http.Request, trusted []netip.Prefix) string {
+	return clientIP(r, trusted)
 }
 
 func parseIPAddr(s string) (netip.Addr, bool) {

--- a/phase4-coordinator/internal/onboarding/apptrack.go
+++ b/phase4-coordinator/internal/onboarding/apptrack.go
@@ -37,9 +37,13 @@ type RegisterRequest struct {
 	AppAttestObject *string         `json:"app_attest_object,omitempty"` // base64 CBOR
 	AppAttestKeyID  *string         `json:"app_attest_key_id,omitempty"` // base64 32-byte
 	ReferralCode    string          `json:"referral_code,omitempty"`
-	Nonce           string          `json:"nonce"`     // 64-hex = 32 random bytes
-	TSUTC           string          `json:"ts_utc"`    // RFC3339
-	Signature       string          `json:"signature"` // base64 64-byte Ed25519 over JCS(body\signature)
+	// ProviderTokenCandidate is generated and durably held by the client
+	// before transport. Binding it into the signed request makes a committed
+	// registration idempotently recoverable after a lost HTTP response.
+	ProviderTokenCandidate string `json:"provider_token_candidate,omitempty"`
+	Nonce                  string `json:"nonce"`     // 64-hex = 32 random bytes
+	TSUTC                  string `json:"ts_utc"`    // RFC3339
+	Signature              string `json:"signature"` // base64 64-byte Ed25519 over JCS(body\signature)
 }
 
 type HardwareSummary struct {
@@ -180,9 +184,10 @@ type RegistrationPrepareStore interface {
 type AuthTokenStore interface {
 	// MintProviderTokenAppTrack mints per SPEC-026 §4.1 step 7 semantics.
 	// Duplicate registration with any active token requires bearer proof from
-	// the Authorization header; request bodies must never carry bearer material.
-	// provider_name is the tenant literal "malibu-app" for App-track.
-	MintProviderTokenAppTrack(ctx context.Context, providerID string, currentBearer *string) (cleartext string, err error)
+	// the Authorization header; request bodies must never carry the current
+	// bearer. A fresh client-held candidate is not authoritative until this
+	// transaction commits. provider_name is the tenant literal "malibu-app".
+	MintProviderTokenAppTrack(ctx context.Context, providerID string, currentBearer, freshTokenCandidate *string) (cleartext string, err error)
 
 	// ValidateToken validates an existing provider bearer token and returns the
 	// bound provider_id. Evidence submission is read-only with respect to the
@@ -191,7 +196,7 @@ type AuthTokenStore interface {
 }
 
 type ReferralStore interface {
-	MintProviderTokenAppTrackWithReferralAttempt(ctx context.Context, providerID, referralCode string, policy auth.ReferralPolicy, attempt auth.AppTrackRegistrationAttempt) (cleartext string, err error)
+	MintProviderTokenAppTrackWithReferralAttempt(ctx context.Context, providerID, referralCode, tokenCandidate string, policy auth.ReferralPolicy, attempt auth.AppTrackRegistrationAttempt) (cleartext string, err error)
 	AcknowledgeAppTrackReferralMint(ctx context.Context, providerID, cleartextToken string) error
 	RollbackAppTrackReferralMint(ctx context.Context, providerID, cleartextToken string) error
 	ListPendingAppTrackReferralMints(ctx context.Context, createdBefore time.Time) ([]auth.PendingAppTrackReferralMint, error)
@@ -286,6 +291,10 @@ func (h *Handler) HandleAppTrackRegister(w http.ResponseWriter, r *http.Request)
 		writeJSONError(w, http.StatusBadRequest, "bad_request", "referral_code is invalid")
 		return
 	}
+	if req.ProviderTokenCandidate != "" && (len(req.ProviderTokenCandidate) != 64 || !isLowerHex(req.ProviderTokenCandidate)) {
+		writeJSONError(w, http.StatusBadRequest, "bad_request", "provider_token_candidate must be 64 lowercase hex chars")
+		return
+	}
 
 	pubkey, err := DecodeIdentityPubkey(req.IdentityPubkey)
 	if err != nil {
@@ -326,36 +335,6 @@ func (h *Handler) HandleAppTrackRegister(w http.ResponseWriter, r *http.Request)
 	}
 
 	sourceIP := clientIP(r, h.TrustedProxies)
-	currentBearer := bearerFromRequest(r)
-	bearerExempt := false
-	if h.ReferralPolicy.RequireForRegistration && currentBearer != nil {
-		boundProviderID, ok, validateErr := h.AuthTokenStore.ValidateToken(r.Context(), *currentBearer)
-		if validateErr != nil {
-			writeJSONError(w, http.StatusServiceUnavailable, "unavailable", "credential authority unavailable")
-			return
-		}
-		bearerExempt = ok && boundProviderID == req.ProviderID
-	}
-	prepareStore, prepareStoreOK := h.StatsDB.(RegistrationPrepareStore)
-	if h.ReferralPolicy.RequireForRegistration && !bearerExempt {
-		if h.ReferralStore == nil || !prepareStoreOK {
-			writeJSONError(w, http.StatusServiceUnavailable, "unavailable", "referral authority unavailable")
-			return
-		}
-		// A retry of an already committed signed attempt never rotates or
-		// re-discloses credentials. Return a stable support state instead.
-		checkCtx, cancelCheck := context.WithTimeout(r.Context(), 2*time.Second)
-		prepared, checkErr := prepareStore.ProviderRegistrationPrepared(checkCtx, req.ProviderID, req.Nonce, tsUTC)
-		cancelCheck()
-		if checkErr != nil {
-			writeJSONError(w, http.StatusServiceUnavailable, "unavailable", "provider registration outcome unavailable")
-			return
-		}
-		if prepared {
-			writeJSONError(w, http.StatusConflict, "existing_active_token_no_proof", "registration already committed; existing credential proof or support is required")
-			return
-		}
-	}
 	if delta := now.Sub(tsUTC); delta > time.Minute || delta < -time.Minute {
 		writeJSONError(w, http.StatusBadRequest, "timestamp_skew", "ts_utc outside allowed skew")
 		return
@@ -384,6 +363,49 @@ func (h *Handler) HandleAppTrackRegister(w http.ResponseWriter, r *http.Request)
 			}
 			w.Header().Set("Retry-After", "60")
 			writeJSONError(w, http.StatusTooManyRequests, "rate_limited", "asn rate limit exceeded")
+			return
+		}
+	}
+	currentBearer := bearerFromRequest(r)
+	bearerExempt := false
+	if h.ReferralPolicy.RequireForRegistration && currentBearer != nil {
+		boundProviderID, ok, validateErr := h.AuthTokenStore.ValidateToken(r.Context(), *currentBearer)
+		if validateErr != nil {
+			writeJSONError(w, http.StatusServiceUnavailable, "unavailable", "credential authority unavailable")
+			return
+		}
+		bearerExempt = ok && boundProviderID == req.ProviderID
+	}
+	prepareStore, prepareStoreOK := h.StatsDB.(RegistrationPrepareStore)
+	if h.ReferralPolicy.RequireForRegistration && !bearerExempt {
+		if h.ReferralStore == nil || !prepareStoreOK {
+			writeJSONError(w, http.StatusServiceUnavailable, "unavailable", "referral authority unavailable")
+			return
+		}
+		if req.ProviderTokenCandidate == "" {
+			writeJSONError(w, http.StatusBadRequest, "provider_token_candidate_required", "a client-held provider token candidate is required for gated registration")
+			return
+		}
+		// A retry of an already committed signed attempt never rotates or
+		// re-discloses credentials. Return a stable support state instead.
+		checkCtx, cancelCheck := context.WithTimeout(r.Context(), 2*time.Second)
+		prepared, checkErr := prepareStore.ProviderRegistrationPrepared(checkCtx, req.ProviderID, req.Nonce, tsUTC)
+		cancelCheck()
+		if checkErr != nil {
+			writeJSONError(w, http.StatusServiceUnavailable, "unavailable", "provider registration outcome unavailable")
+			return
+		}
+		if prepared {
+			boundProviderID, ok, validateErr := h.AuthTokenStore.ValidateToken(r.Context(), req.ProviderTokenCandidate)
+			if validateErr != nil {
+				writeJSONError(w, http.StatusServiceUnavailable, "unavailable", "credential authority unavailable")
+				return
+			}
+			if !ok || boundProviderID != req.ProviderID {
+				writeJSONError(w, http.StatusConflict, "committed_credential_mismatch", "registration committed with a different credential candidate")
+				return
+			}
+			writeAppTrackRegisterSuccess(w, req.ProviderID, req.ProviderTokenCandidate, false, h.CoordinatorWSURL)
 			return
 		}
 	}
@@ -449,7 +471,7 @@ func (h *Handler) HandleAppTrackRegister(w http.ResponseWriter, r *http.Request)
 		attempt := auth.AppTrackRegistrationAttempt{SourceIP: sourceIP, Nonce: req.Nonce, AttemptTS: tsUTC}
 		mintCtx, cancelMint := context.WithTimeout(r.Context(), 2*time.Second)
 		token, err = h.ReferralStore.MintProviderTokenAppTrackWithReferralAttempt(
-			mintCtx, req.ProviderID, req.ReferralCode, h.ReferralPolicy, attempt,
+			mintCtx, req.ProviderID, req.ReferralCode, req.ProviderTokenCandidate, h.ReferralPolicy, attempt,
 		)
 		cancelMint()
 		if err != nil {
@@ -513,7 +535,11 @@ func (h *Handler) HandleAppTrackRegister(w http.ResponseWriter, r *http.Request)
 			writeAppTrackPrepareError(w, err)
 			return
 		}
-		token, err = h.AuthTokenStore.MintProviderTokenAppTrack(r.Context(), req.ProviderID, currentBearer)
+		var freshTokenCandidate *string
+		if currentBearer == nil && req.ProviderTokenCandidate != "" {
+			freshTokenCandidate = &req.ProviderTokenCandidate
+		}
+		token, err = h.AuthTokenStore.MintProviderTokenAppTrack(r.Context(), req.ProviderID, currentBearer, freshTokenCandidate)
 		if err != nil {
 			writeAppTrackMintError(w, err)
 			return
@@ -523,12 +549,16 @@ func (h *Handler) HandleAppTrackRegister(w http.ResponseWriter, r *http.Request)
 	if h.Metrics != nil {
 		h.Metrics.IncRegisterSource("app")
 	}
+	writeAppTrackRegisterSuccess(w, req.ProviderID, token, attested, h.CoordinatorWSURL)
+}
+
+func writeAppTrackRegisterSuccess(w http.ResponseWriter, providerID, token string, attested bool, coordinatorWSURL string) {
 	writeJSON(w, http.StatusOK, RegisterResponse{
-		ProviderID:       req.ProviderID,
+		ProviderID:       providerID,
 		ProviderToken:    token,
 		TrustTier:        "provisional",
 		Trust:            TrustState{Attested: attested, RateLimitBucket: "new_ip"},
-		CoordinatorWSURL: h.CoordinatorWSURL,
+		CoordinatorWSURL: coordinatorWSURL,
 	})
 }
 

--- a/phase4-coordinator/internal/onboarding/apptrack.go
+++ b/phase4-coordinator/internal/onboarding/apptrack.go
@@ -106,8 +106,9 @@ type TrustState struct {
 	RateLimitBucket string `json:"rate_limit_bucket"`
 }
 
-// Handler wires SPEC-026 §4.1 dependencies. Fields are populated at
-// coordinator boot when onboarding.app_track_register_enabled is true.
+// Handler wires SPEC-026 §4.1 dependencies. The coordinator keeps the durable
+// store and referral recovery dependencies populated even when the public
+// App-track registration route is disabled.
 type Handler struct {
 	// Postgres stats DB — for provider_identities, provider_auth_policy,
 	// nonce replay cache, App Attest key uniqueness.
@@ -124,10 +125,15 @@ type Handler struct {
 	CoordinatorWSURL  string
 	TrustedProxies    []netip.Prefix
 
-	// Rate limiter (SPEC-026 §4.1 step 4)
-	IPRateLimiter  IPRateLimiter
-	ASNRateLimiter ASNRateLimiter
-	ASNResolver    ASNResolver
+	// Rate limiters (SPEC-026 §4.1 step 4). CommittedRetryRateLimiter is
+	// independent so a throttled admission can still recover later without
+	// exposing the SQLite credential authority to unbounded stale requests.
+	IPRateLimiter                   IPRateLimiter
+	CommittedRetryRateLimiter       IPRateLimiter
+	CommittedRetryGlobalRateLimiter IPRateLimiter
+	CommittedRetrySlots             chan struct{}
+	ASNRateLimiter                  ASNRateLimiter
+	ASNResolver                     ASNResolver
 
 	// Hardware evidence has separate limits from app registration so autotune
 	// telemetry cannot consume the register budget or buyer DB capacity.
@@ -253,8 +259,10 @@ var (
 
 const hardwareProfilePersistTimeout = 2 * time.Second
 const hardwareProfilePersistConcurrency = 2
+const committedRetryConcurrency = 4
 
 var defaultHardwareProfilePersistSlots = make(chan struct{}, hardwareProfilePersistConcurrency)
+var defaultCommittedRetrySlots = make(chan struct{}, committedRetryConcurrency)
 
 // HandleAppTrackRegister is the SPEC-026 §4.1 endpoint. Full contract:
 // specs/BUILD_SPEC_026_IMPL_STEP_1_COORD_REGISTER_PROMPT.md.
@@ -334,8 +342,65 @@ func (h *Handler) HandleAppTrackRegister(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
+	timestampOutsideSkew := now.Sub(tsUTC) > time.Minute || now.Sub(tsUTC) < -time.Minute
+	prepareStore, prepareStoreOK := h.StatsDB.(RegistrationPrepareStore)
 	sourceIP := clientIP(r, h.TrustedProxies)
-	if delta := now.Sub(tsUTC); delta > time.Minute || delta < -time.Minute {
+	// A response-lost retry must be able to recover the exact committed
+	// credential even after clock skew, admission throttling, or an operator
+	// rollback of referral enforcement. Only take this pre-admission path once
+	// the original request is stale; fresh attempts retain rate-limit ordering,
+	// and a throttled committed retry converges here after its backoff.
+	if timestampOutsideSkew && req.ProviderTokenCandidate != "" && prepareStoreOK {
+		rateLimited := h.CommittedRetryGlobalRateLimiter != nil && !h.CommittedRetryGlobalRateLimiter.Allow("global")
+		if !rateLimited && h.CommittedRetryRateLimiter != nil {
+			providerAllowed := h.CommittedRetryRateLimiter.Allow("provider|" + req.ProviderID)
+			ipAllowed := providerAllowed && h.CommittedRetryRateLimiter.Allow("ip|"+sourceIP)
+			rateLimited = !providerAllowed || !ipAllowed
+		}
+		if rateLimited {
+			if h.Metrics != nil {
+				h.Metrics.IncRegisterRateLimitHit("ip")
+			}
+			w.Header().Set("Retry-After", "60")
+			writeJSONError(w, http.StatusTooManyRequests, "rate_limited", "committed retry rate limit exceeded")
+			return
+		}
+		retrySlots := h.CommittedRetrySlots
+		if retrySlots == nil {
+			retrySlots = defaultCommittedRetrySlots
+		}
+		select {
+		case retrySlots <- struct{}{}:
+			defer func() { <-retrySlots }()
+		default:
+			if h.Metrics != nil {
+				h.Metrics.IncRegisterRateLimitHit("ip")
+			}
+			w.Header().Set("Retry-After", "1")
+			writeJSONError(w, http.StatusTooManyRequests, "rate_limited", "committed retry capacity exceeded")
+			return
+		}
+		boundProviderID, active, validateErr := h.AuthTokenStore.ValidateToken(r.Context(), req.ProviderTokenCandidate)
+		if validateErr != nil {
+			writeJSONError(w, http.StatusServiceUnavailable, "unavailable", "credential authority unavailable")
+			return
+		}
+		if active && boundProviderID == req.ProviderID {
+			checkCtx, cancelCheck := context.WithTimeout(r.Context(), 2*time.Second)
+			prepared, checkErr := prepareStore.ProviderRegistrationPrepared(checkCtx, req.ProviderID, req.Nonce, tsUTC)
+			cancelCheck()
+			if checkErr != nil {
+				writeJSONError(w, http.StatusServiceUnavailable, "unavailable", "provider registration outcome unavailable")
+				return
+			}
+			if prepared {
+				writeAppTrackRegisterSuccess(w, req.ProviderID, req.ProviderTokenCandidate, false, h.CoordinatorWSURL)
+				return
+			}
+		}
+	}
+
+	if timestampOutsideSkew {
 		writeJSONError(w, http.StatusBadRequest, "timestamp_skew", "ts_utc outside allowed skew")
 		return
 	}
@@ -376,7 +441,6 @@ func (h *Handler) HandleAppTrackRegister(w http.ResponseWriter, r *http.Request)
 		}
 		bearerExempt = ok && boundProviderID == req.ProviderID
 	}
-	prepareStore, prepareStoreOK := h.StatsDB.(RegistrationPrepareStore)
 	if h.ReferralPolicy.RequireForRegistration && !bearerExempt {
 		if h.ReferralStore == nil || !prepareStoreOK {
 			writeJSONError(w, http.StatusServiceUnavailable, "unavailable", "referral authority unavailable")
@@ -566,12 +630,8 @@ func writeAppTrackRegisterSuccess(w http.ResponseWriter, providerID, token strin
 // belong to a live request. A committed marker preserves the token; an absent
 // marker compensates the undisclosed token and its exact new redemption.
 func (h *Handler) ReconcilePendingAppTrackReferralMints(ctx context.Context) error {
-	if h == nil || h.ReferralStore == nil || h.StatsDB == nil {
+	if h == nil || h.ReferralStore == nil {
 		return nil
-	}
-	prepareStore, ok := h.StatsDB.(RegistrationPrepareStore)
-	if !ok {
-		return errors.New("registration prepare store unavailable")
 	}
 	now := time.Now().UTC()
 	if h.Now != nil {
@@ -580,6 +640,13 @@ func (h *Handler) ReconcilePendingAppTrackReferralMints(ctx context.Context) err
 	pending, err := h.ReferralStore.ListPendingAppTrackReferralMints(ctx, now.Add(-appTrackPendingMintReconcileAge))
 	if err != nil {
 		return fmt.Errorf("list pending App-track referral mints: %w", err)
+	}
+	if len(pending) == 0 {
+		return nil
+	}
+	prepareStore, ok := h.StatsDB.(RegistrationPrepareStore)
+	if !ok {
+		return errors.New("registration prepare store unavailable with pending App-track referral mints")
 	}
 	var reconcileErrs []error
 	for _, item := range pending {

--- a/phase4-coordinator/internal/onboarding/apptrack_test.go
+++ b/phase4-coordinator/internal/onboarding/apptrack_test.go
@@ -160,6 +160,145 @@ func TestHandleAppTrackRegisterCommittedRetryNeverRotatesCredential(t *testing.T
 	}
 }
 
+func TestHandleAppTrackRegisterCommittedRetrySurvivesRollbackSkewAndRateLimit(t *testing.T) {
+	body, providerID := signedRegisterBody(t, func(body map[string]any) { body["referral_code"] = "invite" })
+	stats := &fakeStatsDB{prepared: true}
+	authStore := &fakeAuthStore{
+		validateOK:         true,
+		validateProviderID: providerID,
+	}
+	metrics := &fakeMetrics{}
+	handler := testRegisterHandler(stats, authStore, metrics, denyLimiter{})
+	handler.ReferralStore = authStore
+	handler.Now = func() time.Time {
+		return time.Date(2026, 7, 3, 12, 2, 0, 0, time.UTC)
+	}
+	response := httptest.NewRecorder()
+
+	handler.HandleAppTrackRegister(response, httptest.NewRequest(http.MethodPost, "/v1/providers/register", bytes.NewReader(body)))
+
+	if response.Code != http.StatusOK || !strings.Contains(response.Body.String(), strings.Repeat("c", 64)) {
+		t.Fatalf("status=%d body=%s", response.Code, response.Body.String())
+	}
+	if authStore.referralMintCalls != 0 || stats.prepareCalls != 0 || stats.nonceCalls != 0 {
+		t.Fatalf("committed retry mutated state: mint=%d prepare=%d nonce=%d", authStore.referralMintCalls, stats.prepareCalls, stats.nonceCalls)
+	}
+	if metrics.limitIP != 0 {
+		t.Fatalf("committed retry reached IP limiter: hits=%d", metrics.limitIP)
+	}
+}
+
+func TestHandleAppTrackRegisterCommittedRetryIsBoundedBeforeCredentialLookup(t *testing.T) {
+	body, providerID := signedRegisterBody(t, func(body map[string]any) { body["referral_code"] = "invite" })
+	stats := &fakeStatsDB{prepared: true}
+	authStore := &fakeAuthStore{validateOK: true, validateProviderID: providerID}
+	handler := testRegisterHandler(stats, authStore, nil)
+	handler.ReferralStore = authStore
+	limiter := newPerKeyLimiter(1)
+	handler.CommittedRetryRateLimiter = limiter
+	handler.Now = func() time.Time {
+		return time.Date(2026, 7, 3, 12, 2, 0, 0, time.UTC)
+	}
+
+	first := httptest.NewRecorder()
+	firstRequest := httptest.NewRequest(http.MethodPost, "/v1/providers/register", bytes.NewReader(body))
+	firstRequest.RemoteAddr = "198.51.100.10:4444"
+	handler.HandleAppTrackRegister(first, firstRequest)
+	if first.Code != http.StatusOK {
+		t.Fatalf("first status=%d body=%s", first.Code, first.Body.String())
+	}
+
+	second := httptest.NewRecorder()
+	secondRequest := httptest.NewRequest(http.MethodPost, "/v1/providers/register", bytes.NewReader(body))
+	secondRequest.RemoteAddr = "198.51.100.10:4444"
+	handler.HandleAppTrackRegister(second, secondRequest)
+	if second.Code != http.StatusTooManyRequests || !strings.Contains(second.Body.String(), "rate_limited") {
+		t.Fatalf("second status=%d body=%s", second.Code, second.Body.String())
+	}
+	if authStore.validateCalls != 1 || stats.preparedChecks != 1 {
+		t.Fatalf("bounded retry authority calls: validates=%d prepared=%d", authStore.validateCalls, stats.preparedChecks)
+	}
+	if len(limiter.keys) != 3 ||
+		limiter.keys[0] != "provider|"+providerID ||
+		limiter.keys[1] != "ip|198.51.100.10" {
+		t.Fatalf("recovery limiter keys=%q", limiter.keys)
+	}
+}
+
+func TestHandleAppTrackRegisterAbsentCommittedRetryIsBounded(t *testing.T) {
+	body, providerID := signedRegisterBody(t, func(body map[string]any) { body["referral_code"] = "invite" })
+	stats := &fakeStatsDB{prepared: false}
+	authStore := &fakeAuthStore{validateOK: true, validateProviderID: providerID}
+	handler := testRegisterHandler(stats, authStore, nil)
+	handler.ReferralStore = authStore
+	limiter := newPerKeyLimiter(1)
+	handler.CommittedRetryRateLimiter = limiter
+	handler.Now = func() time.Time {
+		return time.Date(2026, 7, 3, 12, 2, 0, 0, time.UTC)
+	}
+
+	first := httptest.NewRecorder()
+	handler.HandleAppTrackRegister(first, httptest.NewRequest(http.MethodPost, "/v1/providers/register", bytes.NewReader(body)))
+	if first.Code != http.StatusBadRequest || !strings.Contains(first.Body.String(), "timestamp_skew") {
+		t.Fatalf("first status=%d body=%s", first.Code, first.Body.String())
+	}
+	second := httptest.NewRecorder()
+	handler.HandleAppTrackRegister(second, httptest.NewRequest(http.MethodPost, "/v1/providers/register", bytes.NewReader(body)))
+	if second.Code != http.StatusTooManyRequests || !strings.Contains(second.Body.String(), "rate_limited") {
+		t.Fatalf("second status=%d body=%s", second.Code, second.Body.String())
+	}
+	if authStore.validateCalls != 1 || stats.preparedChecks != 1 {
+		t.Fatalf("bounded absent retry authority calls: validates=%d prepared=%d", authStore.validateCalls, stats.preparedChecks)
+	}
+}
+
+func TestHandleAppTrackRegisterCommittedRetryGlobalCapacityPrecedesAuthorities(t *testing.T) {
+	body, _ := signedRegisterBody(t, func(body map[string]any) { body["referral_code"] = "invite" })
+	stats := &fakeStatsDB{prepared: true}
+	authStore := &fakeAuthStore{validateOK: true}
+	handler := testRegisterHandler(stats, authStore, nil)
+	handler.ReferralStore = authStore
+	handler.CommittedRetrySlots = make(chan struct{}, 1)
+	handler.CommittedRetrySlots <- struct{}{}
+	handler.Now = func() time.Time {
+		return time.Date(2026, 7, 3, 12, 2, 0, 0, time.UTC)
+	}
+	response := httptest.NewRecorder()
+
+	handler.HandleAppTrackRegister(response, httptest.NewRequest(http.MethodPost, "/v1/providers/register", bytes.NewReader(body)))
+
+	if response.Code != http.StatusTooManyRequests || !strings.Contains(response.Body.String(), "rate_limited") {
+		t.Fatalf("status=%d body=%s", response.Code, response.Body.String())
+	}
+	if authStore.validateCalls != 0 || stats.preparedChecks != 0 {
+		t.Fatalf("capacity-bound retry reached authorities: validates=%d prepared=%d", authStore.validateCalls, stats.preparedChecks)
+	}
+}
+
+func TestHandleAppTrackRegisterCommittedRetryGlobalRatePrecedesPerKeyState(t *testing.T) {
+	body, _ := signedRegisterBody(t, func(body map[string]any) { body["referral_code"] = "invite" })
+	stats := &fakeStatsDB{prepared: true}
+	authStore := &fakeAuthStore{validateOK: true}
+	perKey := newPerKeyLimiter(1)
+	handler := testRegisterHandler(stats, authStore, nil)
+	handler.ReferralStore = authStore
+	handler.CommittedRetryGlobalRateLimiter = denyLimiter{}
+	handler.CommittedRetryRateLimiter = perKey
+	handler.Now = func() time.Time {
+		return time.Date(2026, 7, 3, 12, 2, 0, 0, time.UTC)
+	}
+	response := httptest.NewRecorder()
+
+	handler.HandleAppTrackRegister(response, httptest.NewRequest(http.MethodPost, "/v1/providers/register", bytes.NewReader(body)))
+
+	if response.Code != http.StatusTooManyRequests || !strings.Contains(response.Body.String(), "rate_limited") {
+		t.Fatalf("status=%d body=%s", response.Code, response.Body.String())
+	}
+	if len(perKey.keys) != 0 || authStore.validateCalls != 0 || stats.preparedChecks != 0 {
+		t.Fatalf("global-bound retry reached lower authorities: keys=%q validates=%d prepared=%d", perKey.keys, authStore.validateCalls, stats.preparedChecks)
+	}
+}
+
 func TestHandleAppTrackRegisterCommittedRetryRejectsDifferentCandidate(t *testing.T) {
 	body, _ := signedRegisterBody(t, func(body map[string]any) { body["referral_code"] = "invite" })
 	stats := &fakeStatsDB{prepared: true}
@@ -219,7 +358,7 @@ func TestHandleAppTrackRegisterCompensatesOnlyProvenAbsentPrepare(t *testing.T) 
 	}
 }
 
-func TestReconcilePendingAppTrackReferralMintUsesExactSignedAttempt(t *testing.T) {
+func TestReconcilePendingAppTrackReferralMintUsesExactSignedAttemptWithEnforcementOff(t *testing.T) {
 	attemptTS := time.Date(2026, 7, 3, 11, 59, 30, 0, time.UTC)
 	pending := auth.PendingAppTrackReferralMint{
 		ProviderID: "provider-a",
@@ -231,7 +370,6 @@ func TestReconcilePendingAppTrackReferralMintUsesExactSignedAttempt(t *testing.T
 	stats := &fakeStatsDB{prepared: true}
 	authStore := &fakeAuthStore{pendingMints: []auth.PendingAppTrackReferralMint{pending}}
 	handler := testRegisterHandler(stats, authStore, nil)
-	handler.ReferralPolicy = auth.ReferralPolicy{RequireForRegistration: true}
 	handler.ReferralStore = authStore
 
 	if err := handler.ReconcilePendingAppTrackReferralMints(context.Background()); err != nil {
@@ -242,6 +380,30 @@ func TestReconcilePendingAppTrackReferralMintUsesExactSignedAttempt(t *testing.T
 	}
 	if len(authStore.resolvedMints) != 1 || !authStore.resolvedPrepared[0] {
 		t.Fatalf("resolved=%+v prepared=%+v", authStore.resolvedMints, authStore.resolvedPrepared)
+	}
+}
+
+func TestReconcilePendingAppTrackReferralMintReportsMissingPostgresAuthority(t *testing.T) {
+	authStore := &fakeAuthStore{pendingMints: []auth.PendingAppTrackReferralMint{{
+		ProviderID: "provider-a",
+		Attempt: auth.AppTrackRegistrationAttempt{
+			Nonce:     strings.Repeat("b", 64),
+			AttemptTS: time.Date(2026, 7, 3, 11, 59, 30, 0, time.UTC),
+		},
+	}}}
+	handler := &Handler{
+		ReferralStore: authStore,
+		Now: func() time.Time {
+			return time.Date(2026, 7, 3, 12, 2, 0, 0, time.UTC)
+		},
+	}
+
+	err := handler.ReconcilePendingAppTrackReferralMints(context.Background())
+	if err == nil || !strings.Contains(err.Error(), "registration prepare store unavailable") {
+		t.Fatalf("error=%v, want missing registration prepare authority", err)
+	}
+	if len(authStore.resolvedMints) != 0 {
+		t.Fatalf("resolved without PostgreSQL authority: %+v", authStore.resolvedMints)
 	}
 }
 
@@ -1166,12 +1328,14 @@ func testRegisterHandler(stats *fakeStatsDB, authStore *fakeAuthStore, metrics *
 		limiter = limiters[0]
 	}
 	return &Handler{
-		StatsDB:           stats,
-		AuthTokenStore:    authStore,
-		CoordinatorDomain: "coordinator.streamvc.live",
-		CoordinatorWSURL:  "wss://coordinator.streamvc.live/v2/provider",
-		IPRateLimiter:     limiter,
-		ASNRateLimiter:    allowLimiter{},
+		StatsDB:                         stats,
+		AuthTokenStore:                  authStore,
+		CoordinatorDomain:               "coordinator.streamvc.live",
+		CoordinatorWSURL:                "wss://coordinator.streamvc.live/v2/provider",
+		IPRateLimiter:                   limiter,
+		CommittedRetryRateLimiter:       allowLimiter{},
+		CommittedRetryGlobalRateLimiter: allowLimiter{},
+		ASNRateLimiter:                  allowLimiter{},
 		AppAttestConfig: AppAttestConfig{
 			BundleID: "live.streamvc.Malibu",
 			TeamID:   "MALIBU1234",
@@ -1506,6 +1670,25 @@ func (allowLimiter) Allow(string) bool { return true }
 type denyLimiter struct{}
 
 func (denyLimiter) Allow(string) bool { return false }
+
+type perKeyLimiter struct {
+	limit int
+	hits  map[string]int
+	keys  []string
+}
+
+func newPerKeyLimiter(limit int) *perKeyLimiter {
+	return &perKeyLimiter{limit: limit, hits: make(map[string]int)}
+}
+
+func (l *perKeyLimiter) Allow(key string) bool {
+	l.keys = append(l.keys, key)
+	if l.hits[key] >= l.limit {
+		return false
+	}
+	l.hits[key]++
+	return true
+}
 
 func stringPtr(s string) *string {
 	return &s

--- a/phase4-coordinator/internal/onboarding/apptrack_test.go
+++ b/phase4-coordinator/internal/onboarding/apptrack_test.go
@@ -137,9 +137,13 @@ func TestHandleAppTrackRegisterFreshGateUsesSagaThenDiscloses(t *testing.T) {
 }
 
 func TestHandleAppTrackRegisterCommittedRetryNeverRotatesCredential(t *testing.T) {
-	body, _ := signedRegisterBody(t, func(body map[string]any) { body["referral_code"] = "invite" })
+	body, providerID := signedRegisterBody(t, func(body map[string]any) { body["referral_code"] = "invite" })
 	stats := &fakeStatsDB{prepared: true}
-	authStore := &fakeAuthStore{referralToken: "must-not-mint"}
+	authStore := &fakeAuthStore{
+		referralToken:      "must-not-mint",
+		validateOK:         true,
+		validateProviderID: providerID,
+	}
 	handler := testRegisterHandler(stats, authStore, nil)
 	handler.ReferralPolicy = auth.ReferralPolicy{RequireForRegistration: true}
 	handler.ReferralStore = authStore
@@ -148,11 +152,49 @@ func TestHandleAppTrackRegisterCommittedRetryNeverRotatesCredential(t *testing.T
 
 	handler.HandleAppTrackRegister(response, req)
 
-	if response.Code != http.StatusConflict || !strings.Contains(response.Body.String(), "existing_active_token_no_proof") {
+	if response.Code != http.StatusOK || !strings.Contains(response.Body.String(), strings.Repeat("c", 64)) {
 		t.Fatalf("status=%d body=%s", response.Code, response.Body.String())
 	}
 	if authStore.referralMintCalls != 0 || stats.prepareCalls != 0 {
 		t.Fatalf("committed retry mutated state: mint=%d prepare=%d", authStore.referralMintCalls, stats.prepareCalls)
+	}
+}
+
+func TestHandleAppTrackRegisterCommittedRetryRejectsDifferentCandidate(t *testing.T) {
+	body, _ := signedRegisterBody(t, func(body map[string]any) { body["referral_code"] = "invite" })
+	stats := &fakeStatsDB{prepared: true}
+	authStore := &fakeAuthStore{}
+	handler := testRegisterHandler(stats, authStore, nil)
+	handler.ReferralPolicy = auth.ReferralPolicy{RequireForRegistration: true}
+	handler.ReferralStore = authStore
+	response := httptest.NewRecorder()
+
+	handler.HandleAppTrackRegister(response, httptest.NewRequest(http.MethodPost, "/v1/providers/register", bytes.NewReader(body)))
+
+	if response.Code != http.StatusConflict || !strings.Contains(response.Body.String(), "committed_credential_mismatch") {
+		t.Fatalf("status=%d body=%s", response.Code, response.Body.String())
+	}
+	if authStore.referralMintCalls != 0 || stats.prepareCalls != 0 {
+		t.Fatalf("committed retry mutated state: mint=%d prepare=%d", authStore.referralMintCalls, stats.prepareCalls)
+	}
+}
+
+func TestHandleAppTrackRegisterGateRequiresClientHeldCandidate(t *testing.T) {
+	body, _ := signedRegisterBody(t, func(body map[string]any) {
+		body["referral_code"] = "invite"
+		delete(body, "provider_token_candidate")
+	})
+	stats := &fakeStatsDB{}
+	authStore := &fakeAuthStore{}
+	handler := testRegisterHandler(stats, authStore, nil)
+	handler.ReferralPolicy = auth.ReferralPolicy{RequireForRegistration: true}
+	handler.ReferralStore = authStore
+	response := httptest.NewRecorder()
+
+	handler.HandleAppTrackRegister(response, httptest.NewRequest(http.MethodPost, "/v1/providers/register", bytes.NewReader(body)))
+
+	if response.Code != http.StatusBadRequest || !strings.Contains(response.Body.String(), "provider_token_candidate_required") {
+		t.Fatalf("status=%d body=%s", response.Code, response.Body.String())
 	}
 }
 
@@ -686,10 +728,12 @@ func TestHandleAppTrackRegisterMapsRateLimitAndCooldown(t *testing.T) {
 func TestHandleAppTrackRegisterRateLimitDoesNotWriteReplayNonce(t *testing.T) {
 	body, _ := signedRegisterBody(t, nil)
 	stats := &fakeStatsDB{}
-	handler := testRegisterHandler(stats, &fakeAuthStore{token: "provider-token"}, &fakeMetrics{}, denyLimiter{})
+	authStore := &fakeAuthStore{token: "provider-token", validateOK: true}
+	handler := testRegisterHandler(stats, authStore, &fakeMetrics{}, denyLimiter{})
 
 	req := httptest.NewRequest(http.MethodPost, "/v1/providers/register", bytes.NewReader(body))
 	req.RemoteAddr = "198.51.100.10:4444"
+	req.Header.Set("Authorization", "Bearer existing-token")
 	rr := httptest.NewRecorder()
 	handler.HandleAppTrackRegister(rr, req)
 
@@ -698,6 +742,12 @@ func TestHandleAppTrackRegisterRateLimitDoesNotWriteReplayNonce(t *testing.T) {
 	}
 	if stats.nonceCalls != 0 {
 		t.Fatalf("nonce calls=%d, want 0 before rate-limit rejection", stats.nonceCalls)
+	}
+	if stats.preparedChecks != 0 {
+		t.Fatalf("prepared checks=%d, want 0 before rate-limit rejection", stats.preparedChecks)
+	}
+	if authStore.validateCalls != 0 {
+		t.Fatalf("credential validations=%d, want 0 before rate-limit rejection", authStore.validateCalls)
 	}
 	if calls := stats.hardwareCallsCount(); calls != 0 {
 		t.Fatalf("hardware calls=%d, want 0 before rate-limit rejection", calls)
@@ -1083,8 +1133,9 @@ func signedRegisterBody(t *testing.T, mutate func(map[string]any)) ([]byte, stri
 			"macos_version":     "15.5",
 			"app_version":       "1.0.0",
 		},
-		"nonce":  strings.Repeat("a", 64),
-		"ts_utc": "2026-07-03T12:00:00Z",
+		"nonce":                    strings.Repeat("a", 64),
+		"ts_utc":                   "2026-07-03T12:00:00Z",
+		"provider_token_candidate": strings.Repeat("c", 64),
 	}
 	normalized, err := json.Marshal(body)
 	if err != nil {
@@ -1285,6 +1336,7 @@ type fakeAuthStore struct {
 	validateProviderID string
 	validateOK         bool
 	validateErr        error
+	validateCalls      int
 	referralToken      string
 	referralMintErr    error
 	referralMintCalls  int
@@ -1297,16 +1349,20 @@ type fakeAuthStore struct {
 	resolvedPrepared   []bool
 }
 
-func (f *fakeAuthStore) MintProviderTokenAppTrack(ctx context.Context, providerID string, currentBearer *string) (string, error) {
+func (f *fakeAuthStore) MintProviderTokenAppTrack(ctx context.Context, providerID string, currentBearer, freshTokenCandidate *string) (string, error) {
 	f.providerID = providerID
 	f.bearer = currentBearer
 	if f.err != nil {
 		return "", f.err
 	}
+	if currentBearer == nil && freshTokenCandidate != nil && f.token == "" {
+		return *freshTokenCandidate, nil
+	}
 	return f.token, nil
 }
 
 func (f *fakeAuthStore) ValidateToken(ctx context.Context, token string) (string, bool, error) {
+	f.validateCalls++
 	if f.validateErr != nil {
 		return "", false, f.validateErr
 	}
@@ -1319,13 +1375,16 @@ func (f *fakeAuthStore) ValidateToken(ctx context.Context, token string) (string
 	return f.providerID, true, nil
 }
 
-func (f *fakeAuthStore) MintProviderTokenAppTrackWithReferralAttempt(_ context.Context, providerID, referralCode string, policy auth.ReferralPolicy, attempt auth.AppTrackRegistrationAttempt) (string, error) {
+func (f *fakeAuthStore) MintProviderTokenAppTrackWithReferralAttempt(_ context.Context, providerID, referralCode, tokenCandidate string, policy auth.ReferralPolicy, attempt auth.AppTrackRegistrationAttempt) (string, error) {
 	f.referralMintCalls++
 	f.providerID = providerID
 	if f.referralMintErr != nil {
 		return "", f.referralMintErr
 	}
-	return f.referralToken, nil
+	if f.referralToken != "" {
+		return f.referralToken, nil
+	}
+	return tokenCandidate, nil
 }
 
 func (f *fakeAuthStore) AcknowledgeAppTrackReferralMint(context.Context, string, string) error {

--- a/phase4-coordinator/internal/onboarding/apptrack_test.go
+++ b/phase4-coordinator/internal/onboarding/apptrack_test.go
@@ -62,6 +62,147 @@ func TestHandleAppTrackRegisterSuccess(t *testing.T) {
 	}
 }
 
+func TestHandleAppTrackRegisterBogusBearerDoesNotBypassReferralGate(t *testing.T) {
+	body, _ := signedRegisterBody(t, nil)
+	stats := &fakeStatsDB{}
+	authStore := &fakeAuthStore{referralMintErr: auth.ErrReferralRequired}
+	handler := testRegisterHandler(stats, authStore, nil)
+	handler.ReferralPolicy = auth.ReferralPolicy{RequireForRegistration: true}
+	handler.ReferralStore = authStore
+	req := httptest.NewRequest(http.MethodPost, "/v1/providers/register", bytes.NewReader(body))
+	req.Header.Set("Authorization", "Bearer bogus")
+	response := httptest.NewRecorder()
+
+	handler.HandleAppTrackRegister(response, req)
+
+	if response.Code != http.StatusBadRequest || !strings.Contains(response.Body.String(), "referral_required") {
+		t.Fatalf("status=%d body=%s", response.Code, response.Body.String())
+	}
+	if authStore.referralMintCalls != 1 || stats.prepareCalls != 0 || stats.upsertProviderID != "" {
+		t.Fatalf("mintCalls=%d prepareCalls=%d upsert=%q", authStore.referralMintCalls, stats.prepareCalls, stats.upsertProviderID)
+	}
+}
+
+func TestHandleAppTrackRegisterValidBearerBypassesReferralConsumption(t *testing.T) {
+	body, providerID := signedRegisterBody(t, nil)
+	stats := &fakeStatsDB{}
+	authStore := &fakeAuthStore{
+		token:              "replacement-token",
+		validateOK:         true,
+		validateProviderID: providerID,
+		referralMintErr:    auth.ErrReferralRequired,
+	}
+	handler := testRegisterHandler(stats, authStore, nil)
+	handler.ReferralPolicy = auth.ReferralPolicy{RequireForRegistration: true}
+	handler.ReferralStore = authStore
+	req := httptest.NewRequest(http.MethodPost, "/v1/providers/register", bytes.NewReader(body))
+	req.Header.Set("Authorization", "Bearer current-token")
+	response := httptest.NewRecorder()
+
+	handler.HandleAppTrackRegister(response, req)
+
+	if response.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s", response.Code, response.Body.String())
+	}
+	if authStore.referralMintCalls != 0 || stats.nonceCalls != 1 || stats.upsertProviderID != providerID {
+		t.Fatalf("referralMints=%d nonceCalls=%d upsert=%q", authStore.referralMintCalls, stats.nonceCalls, stats.upsertProviderID)
+	}
+}
+
+func TestHandleAppTrackRegisterFreshGateUsesSagaThenDiscloses(t *testing.T) {
+	body, providerID := signedRegisterBody(t, func(body map[string]any) { body["referral_code"] = "invite" })
+	stats := &fakeStatsDB{}
+	authStore := &fakeAuthStore{
+		referralToken:      "fresh-token",
+		validateOK:         true,
+		validateProviderID: providerID,
+	}
+	handler := testRegisterHandler(stats, authStore, nil)
+	handler.ReferralPolicy = auth.ReferralPolicy{RequireForRegistration: true}
+	handler.ReferralStore = authStore
+	req := httptest.NewRequest(http.MethodPost, "/v1/providers/register", bytes.NewReader(body))
+	response := httptest.NewRecorder()
+
+	handler.HandleAppTrackRegister(response, req)
+
+	if response.Code != http.StatusOK || !strings.Contains(response.Body.String(), "fresh-token") {
+		t.Fatalf("status=%d body=%s", response.Code, response.Body.String())
+	}
+	if authStore.referralMintCalls != 1 || stats.prepareCalls != 1 || authStore.ackCalls != 1 || authStore.rollbackCalls != 0 {
+		t.Fatalf("mint=%d prepare=%d ack=%d rollback=%d", authStore.referralMintCalls, stats.prepareCalls, authStore.ackCalls, authStore.rollbackCalls)
+	}
+	if stats.nonceCalls != 0 || stats.upsertProviderID != "" {
+		t.Fatalf("fresh gate used non-atomic legacy PG path: nonce=%d upsert=%q", stats.nonceCalls, stats.upsertProviderID)
+	}
+}
+
+func TestHandleAppTrackRegisterCommittedRetryNeverRotatesCredential(t *testing.T) {
+	body, _ := signedRegisterBody(t, func(body map[string]any) { body["referral_code"] = "invite" })
+	stats := &fakeStatsDB{prepared: true}
+	authStore := &fakeAuthStore{referralToken: "must-not-mint"}
+	handler := testRegisterHandler(stats, authStore, nil)
+	handler.ReferralPolicy = auth.ReferralPolicy{RequireForRegistration: true}
+	handler.ReferralStore = authStore
+	req := httptest.NewRequest(http.MethodPost, "/v1/providers/register", bytes.NewReader(body))
+	response := httptest.NewRecorder()
+
+	handler.HandleAppTrackRegister(response, req)
+
+	if response.Code != http.StatusConflict || !strings.Contains(response.Body.String(), "existing_active_token_no_proof") {
+		t.Fatalf("status=%d body=%s", response.Code, response.Body.String())
+	}
+	if authStore.referralMintCalls != 0 || stats.prepareCalls != 0 {
+		t.Fatalf("committed retry mutated state: mint=%d prepare=%d", authStore.referralMintCalls, stats.prepareCalls)
+	}
+}
+
+func TestHandleAppTrackRegisterCompensatesOnlyProvenAbsentPrepare(t *testing.T) {
+	body, providerID := signedRegisterBody(t, func(body map[string]any) { body["referral_code"] = "invite" })
+	stats := &fakeStatsDB{prepareErr: ErrTOFUConflict, prepared: false}
+	authStore := &fakeAuthStore{
+		referralToken:      "undisclosed-token",
+		validateOK:         true,
+		validateProviderID: providerID,
+	}
+	handler := testRegisterHandler(stats, authStore, nil)
+	handler.ReferralPolicy = auth.ReferralPolicy{RequireForRegistration: true}
+	handler.ReferralStore = authStore
+	req := httptest.NewRequest(http.MethodPost, "/v1/providers/register", bytes.NewReader(body))
+	response := httptest.NewRecorder()
+
+	handler.HandleAppTrackRegister(response, req)
+
+	if response.Code != http.StatusConflict || authStore.rollbackCalls != 1 || authStore.ackCalls != 0 {
+		t.Fatalf("status=%d rollback=%d ack=%d body=%s", response.Code, authStore.rollbackCalls, authStore.ackCalls, response.Body.String())
+	}
+}
+
+func TestReconcilePendingAppTrackReferralMintUsesExactSignedAttempt(t *testing.T) {
+	attemptTS := time.Date(2026, 7, 3, 11, 59, 30, 0, time.UTC)
+	pending := auth.PendingAppTrackReferralMint{
+		ProviderID: "provider-a",
+		TokenHash:  strings.Repeat("a", 64),
+		Attempt: auth.AppTrackRegistrationAttempt{
+			SourceIP: "203.0.113.10", Nonce: strings.Repeat("b", 64), AttemptTS: attemptTS,
+		},
+	}
+	stats := &fakeStatsDB{prepared: true}
+	authStore := &fakeAuthStore{pendingMints: []auth.PendingAppTrackReferralMint{pending}}
+	handler := testRegisterHandler(stats, authStore, nil)
+	handler.ReferralPolicy = auth.ReferralPolicy{RequireForRegistration: true}
+	handler.ReferralStore = authStore
+
+	if err := handler.ReconcilePendingAppTrackReferralMints(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if stats.preparedProviderID != pending.ProviderID || stats.preparedNonce != pending.Attempt.Nonce || !stats.preparedAttemptTS.Equal(attemptTS) {
+		t.Fatalf("prepared lookup provider=%q nonce=%q ts=%s", stats.preparedProviderID, stats.preparedNonce, stats.preparedAttemptTS)
+	}
+	if len(authStore.resolvedMints) != 1 || !authStore.resolvedPrepared[0] {
+		t.Fatalf("resolved=%+v prepared=%+v", authStore.resolvedMints, authStore.resolvedPrepared)
+	}
+}
+
 func TestHandleHardwareEvidenceQueuesAuthenticatedAutotuneEvidence(t *testing.T) {
 	now := time.Date(2026, 7, 3, 12, 0, 0, 0, time.UTC)
 	stats := &fakeStatsDB{}
@@ -1021,6 +1162,30 @@ type fakeStatsDB struct {
 	existingEvidenceRecord     HardwareEvidenceJobRecord
 	existingEvidenceFound      bool
 	existingEvidenceErr        error
+	prepareErr                 error
+	prepared                   bool
+	preparedErr                error
+	prepareCalls               int
+	preparedChecks             int
+	preparedProviderID         string
+	preparedNonce              string
+	preparedAttemptTS          time.Time
+}
+
+func (f *fakeStatsDB) PrepareProviderRegistration(_ context.Context, providerID, sourceIP, nonce string, observedAt, attemptTS time.Time, identityPubkey []byte, attested bool, appAttestKeyID []byte) error {
+	f.prepareCalls++
+	f.preparedProviderID = providerID
+	f.preparedNonce = nonce
+	f.preparedAttemptTS = attemptTS
+	return f.prepareErr
+}
+
+func (f *fakeStatsDB) ProviderRegistrationPrepared(_ context.Context, providerID, nonce string, attemptTS time.Time) (bool, error) {
+	f.preparedChecks++
+	f.preparedProviderID = providerID
+	f.preparedNonce = nonce
+	f.preparedAttemptTS = attemptTS
+	return f.prepared, f.preparedErr
 }
 
 func (f *fakeStatsDB) UpsertProviderIdentity(ctx context.Context, providerID string, identityPubkey []byte, attested bool, appAttestKeyID []byte) error {
@@ -1120,6 +1285,16 @@ type fakeAuthStore struct {
 	validateProviderID string
 	validateOK         bool
 	validateErr        error
+	referralToken      string
+	referralMintErr    error
+	referralMintCalls  int
+	ackErr             error
+	ackCalls           int
+	rollbackErr        error
+	rollbackCalls      int
+	pendingMints       []auth.PendingAppTrackReferralMint
+	resolvedMints      []auth.PendingAppTrackReferralMint
+	resolvedPrepared   []bool
 }
 
 func (f *fakeAuthStore) MintProviderTokenAppTrack(ctx context.Context, providerID string, currentBearer *string) (string, error) {
@@ -1142,6 +1317,35 @@ func (f *fakeAuthStore) ValidateToken(ctx context.Context, token string) (string
 		return f.validateProviderID, true, nil
 	}
 	return f.providerID, true, nil
+}
+
+func (f *fakeAuthStore) MintProviderTokenAppTrackWithReferralAttempt(_ context.Context, providerID, referralCode string, policy auth.ReferralPolicy, attempt auth.AppTrackRegistrationAttempt) (string, error) {
+	f.referralMintCalls++
+	f.providerID = providerID
+	if f.referralMintErr != nil {
+		return "", f.referralMintErr
+	}
+	return f.referralToken, nil
+}
+
+func (f *fakeAuthStore) AcknowledgeAppTrackReferralMint(context.Context, string, string) error {
+	f.ackCalls++
+	return f.ackErr
+}
+
+func (f *fakeAuthStore) RollbackAppTrackReferralMint(context.Context, string, string) error {
+	f.rollbackCalls++
+	return f.rollbackErr
+}
+
+func (f *fakeAuthStore) ListPendingAppTrackReferralMints(context.Context, time.Time) ([]auth.PendingAppTrackReferralMint, error) {
+	return append([]auth.PendingAppTrackReferralMint(nil), f.pendingMints...), nil
+}
+
+func (f *fakeAuthStore) ResolvePendingAppTrackReferralMint(_ context.Context, pending auth.PendingAppTrackReferralMint, prepared bool) error {
+	f.resolvedMints = append(f.resolvedMints, pending)
+	f.resolvedPrepared = append(f.resolvedPrepared, prepared)
+	return nil
 }
 
 type fakeMetrics struct {

--- a/phase4-coordinator/internal/onboarding/ratelimit.go
+++ b/phase4-coordinator/internal/onboarding/ratelimit.go
@@ -9,11 +9,12 @@ import (
 // register surface. Production has one process per coordinator on Pearl, so
 // process-local limiting is sufficient for Step 1's deploy-disabled path.
 type MemoryRateLimiter struct {
-	mu     sync.Mutex
-	limit  int
-	window time.Duration
-	now    func() time.Time
-	hits   map[string][]time.Time
+	mu        sync.Mutex
+	limit     int
+	window    time.Duration
+	now       func() time.Time
+	hits      map[string][]time.Time
+	lastSweep time.Time
 }
 
 func NewMemoryRateLimiter(limit int, window time.Duration) *MemoryRateLimiter {
@@ -34,6 +35,23 @@ func (l *MemoryRateLimiter) Allow(key string) bool {
 
 	l.mu.Lock()
 	defer l.mu.Unlock()
+
+	if l.lastSweep.IsZero() || !now.Before(l.lastSweep.Add(l.window)) {
+		for key, timestamps := range l.hits {
+			kept := timestamps[:0]
+			for _, ts := range timestamps {
+				if ts.After(cutoff) {
+					kept = append(kept, ts)
+				}
+			}
+			if len(kept) == 0 {
+				delete(l.hits, key)
+			} else {
+				l.hits[key] = kept
+			}
+		}
+		l.lastSweep = now
+	}
 
 	existing := l.hits[key]
 	kept := existing[:0]

--- a/phase4-coordinator/internal/onboarding/ratelimit_test.go
+++ b/phase4-coordinator/internal/onboarding/ratelimit_test.go
@@ -1,0 +1,30 @@
+package onboarding
+
+import (
+	"fmt"
+	"testing"
+	"time"
+)
+
+func TestMemoryRateLimiterSweepsExpiredOneShotKeys(t *testing.T) {
+	now := time.Date(2026, 7, 17, 12, 0, 0, 0, time.UTC)
+	limiter := NewMemoryRateLimiter(5, time.Minute)
+	limiter.now = func() time.Time { return now }
+
+	for i := range 100 {
+		if !limiter.Allow(fmt.Sprintf("provider-%d", i)) {
+			t.Fatalf("one-shot key %d unexpectedly denied", i)
+		}
+	}
+	if got := len(limiter.hits); got != 100 {
+		t.Fatalf("tracked keys=%d want 100 before expiry", got)
+	}
+
+	now = now.Add(time.Minute + time.Second)
+	if !limiter.Allow("current-provider") {
+		t.Fatal("current key unexpectedly denied after sweep")
+	}
+	if got := len(limiter.hits); got != 1 {
+		t.Fatalf("tracked keys=%d want 1 after expired-key sweep", got)
+	}
+}

--- a/phase4-coordinator/internal/onboarding/store_pg.go
+++ b/phase4-coordinator/internal/onboarding/store_pg.go
@@ -138,6 +138,9 @@ SELECT j.generated_at, j.evidence
 	if _, err := s.db.ExecContext(timeout, `SELECT 1 FROM provider_register_nonces LIMIT 1`); err != nil {
 		return fmt.Errorf("provider_onboarding smoke provider_register_nonces read: %w", err)
 	}
+	if _, err := s.db.ExecContext(timeout, `SELECT 1 FROM provider_register_attempts LIMIT 1`); err != nil {
+		return fmt.Errorf("provider_onboarding smoke provider_register_attempts read: %w", err)
+	}
 	if _, err := s.db.ExecContext(timeout, `SELECT 1 FROM provider_auth_policy LIMIT 1`); err != nil {
 		return fmt.Errorf("provider_onboarding smoke provider_auth_policy read: %w", err)
 	}
@@ -362,6 +365,103 @@ VALUES ($1, $2, $3, $4)`, providerID, sourceIP, nonce, observedAt); err != nil {
 		return err
 	}
 	return nil
+}
+
+// PrepareProviderRegistration atomically records replay protection, provider
+// identity, and an exact durable attempt marker. App-track referral minting
+// happens first in SQLite but remains undisclosed behind a pending saga until
+// this transaction is known to have committed.
+func (s *PGStore) PrepareProviderRegistration(ctx context.Context, providerID, sourceIP, nonce string, observedAt, attemptTS time.Time, identityPubkey []byte, attested bool, appAttestKeyID []byte) error {
+	if s == nil || s.db == nil {
+		return errors.New("onboarding postgres store is nil")
+	}
+	tx, err := s.db.BeginTx(ctx, &sql.TxOptions{Isolation: sql.LevelSerializable})
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback()
+
+	observedAt = observedAt.UTC()
+	attemptTS = attemptTS.UTC()
+	cutoffStart := observedAt.Add(-registerNonceWindow)
+	cutoffEnd := observedAt.Add(registerNonceWindow)
+	var exists bool
+	if err := tx.QueryRowContext(ctx, `
+SELECT EXISTS (
+    SELECT 1 FROM provider_register_nonces
+     WHERE provider_id = $1 AND nonce = $2 AND ts_utc BETWEEN $3 AND $4
+)`, providerID, nonce, cutoffStart, cutoffEnd).Scan(&exists); err != nil {
+		return err
+	}
+	if exists {
+		return ErrNonceReplay
+	}
+	if err := tx.QueryRowContext(ctx, `
+SELECT EXISTS (
+    SELECT 1 FROM provider_register_nonces
+     WHERE source_ip = $1 AND nonce = $2 AND ts_utc BETWEEN $3 AND $4
+)`, sourceIP, nonce, cutoffStart, cutoffEnd).Scan(&exists); err != nil {
+		return err
+	}
+	if exists {
+		return ErrNonceReplay
+	}
+
+	var key any
+	if len(appAttestKeyID) > 0 {
+		key = appAttestKeyID
+	}
+	var out string
+	err = tx.QueryRowContext(ctx, `
+INSERT INTO provider_identities (provider_id, identity_pubkey, attested, app_attest_key_id)
+VALUES ($1, $2, $3, $4)
+ON CONFLICT (provider_id) DO UPDATE
+   SET attested = provider_identities.attested OR EXCLUDED.attested,
+       app_attest_key_id = COALESCE(provider_identities.app_attest_key_id, EXCLUDED.app_attest_key_id)
+ WHERE provider_identities.identity_pubkey = EXCLUDED.identity_pubkey
+RETURNING provider_id`, providerID, identityPubkey, attested, key).Scan(&out)
+	if errors.Is(err, sql.ErrNoRows) {
+		return ErrTOFUConflict
+	}
+	if err != nil {
+		if isUniqueViolation(err) {
+			return ErrAttestKeyReused
+		}
+		return err
+	}
+	if _, err := tx.ExecContext(ctx, `
+INSERT INTO provider_register_nonces (provider_id, source_ip, nonce, ts_utc)
+VALUES ($1, $2, $3, $4)`, providerID, sourceIP, nonce, observedAt); err != nil {
+		return err
+	}
+	if _, err := tx.ExecContext(ctx, `
+INSERT INTO provider_register_attempts (provider_id, nonce, ts_utc, source_ip)
+VALUES ($1, $2, $3, $4)
+ON CONFLICT (provider_id, nonce, ts_utc) DO NOTHING`, providerID, nonce, attemptTS, sourceIP); err != nil {
+		return err
+	}
+	if err := tx.Commit(); err != nil {
+		if isSerializationFailure(err) {
+			return ErrNonceReplay
+		}
+		return err
+	}
+	return nil
+}
+
+// ProviderRegistrationPrepared checks only replay-stable, signed fields. The
+// source IP is diagnostic and deliberately excluded from the commitment key.
+func (s *PGStore) ProviderRegistrationPrepared(ctx context.Context, providerID, nonce string, attemptTS time.Time) (bool, error) {
+	if s == nil || s.db == nil {
+		return false, errors.New("onboarding postgres store is nil")
+	}
+	var prepared bool
+	err := s.db.QueryRowContext(ctx, `
+SELECT EXISTS (
+    SELECT 1 FROM provider_register_attempts
+     WHERE provider_id = $1 AND nonce = $2 AND ts_utc = $3
+)`, providerID, nonce, attemptTS.UTC()).Scan(&prepared)
+	return prepared, err
 }
 
 func normalizeChip(chip string) string {

--- a/phase4-coordinator/internal/onboarding/store_pg_attempt_integration_test.go
+++ b/phase4-coordinator/internal/onboarding/store_pg_attempt_integration_test.go
@@ -1,0 +1,82 @@
+//go:build integration
+
+package onboarding
+
+import (
+	"context"
+	"crypto/ed25519"
+	"crypto/rand"
+	"database/sql"
+	"testing"
+	"time"
+
+	_ "github.com/lib/pq"
+	tc "github.com/testcontainers/testcontainers-go"
+	tcpg "github.com/testcontainers/testcontainers-go/modules/postgres"
+	"github.com/testcontainers/testcontainers-go/wait"
+
+	statsmigrations "github.com/augstar/macprovider-coordinator/internal/stats/migrations"
+)
+
+const (
+	referralAttemptPGImage = "postgres:16.4-alpine3.20@sha256:5660c2cbfea50c7a9127d17dc4e48543eedd3d7a41a595a2dfa572471e37e64c"
+	referralAttemptPGPass  = "referral-attempt-test-password"
+)
+
+func TestProviderRegistrationPreparedSurvivesNoncePrune(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 90*time.Second)
+	defer cancel()
+	container, err := tcpg.Run(ctx, referralAttemptPGImage,
+		tcpg.WithDatabase("referral_attempt"),
+		tcpg.WithUsername("postgres"),
+		tcpg.WithPassword(referralAttemptPGPass),
+		tc.WithWaitStrategy(wait.ForLog("database system is ready to accept connections").WithOccurrence(2).WithStartupTimeout(60*time.Second)),
+	)
+	if err != nil {
+		t.Fatalf("start postgres: %v", err)
+	}
+	t.Cleanup(func() {
+		cleanup, cleanupCancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cleanupCancel()
+		_ = container.Terminate(cleanup)
+	})
+	dsn, err := container.ConnectionString(ctx, "sslmode=disable")
+	if err != nil {
+		t.Fatal(err)
+	}
+	db, err := sql.Open("postgres", dsn)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	if err := statsmigrations.Apply(ctx, db); err != nil {
+		t.Fatalf("apply migrations: %v", err)
+	}
+
+	store := &PGStore{db: db}
+	publicKey, _, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	observedAt := time.Now().UTC().Truncate(time.Second)
+	attemptTS := observedAt.Add(-30 * time.Second)
+	if err := store.PrepareProviderRegistration(
+		ctx, "provider-a", "203.0.113.7", "nonce-a", observedAt, attemptTS,
+		publicKey, false, nil,
+	); err != nil {
+		t.Fatalf("prepare: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `DELETE FROM provider_register_nonces`); err != nil {
+		t.Fatalf("prune nonces: %v", err)
+	}
+	prepared, err := store.ProviderRegistrationPrepared(ctx, "provider-a", "nonce-a", attemptTS)
+	if err != nil || !prepared {
+		t.Fatalf("prepared=%v err=%v after nonce prune", prepared, err)
+	}
+	if wrong, err := store.ProviderRegistrationPrepared(ctx, "provider-a", "nonce-a", observedAt); err != nil || wrong {
+		t.Fatalf("server observed timestamp matched signed marker: prepared=%v err=%v", wrong, err)
+	}
+	if missing, err := store.ProviderRegistrationPrepared(ctx, "provider-missing", "nonce-z", attemptTS); err != nil || missing {
+		t.Fatalf("missing attempt prepared=%v err=%v", missing, err)
+	}
+}

--- a/phase4-coordinator/internal/referralapi/validate.go
+++ b/phase4-coordinator/internal/referralapi/validate.go
@@ -1,0 +1,192 @@
+package referralapi
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"sync"
+	"time"
+
+	"github.com/augstar/macprovider-coordinator/internal/auth"
+)
+
+type ValidationStore interface {
+	ValidateReferral(context.Context, auth.ReferralPolicy, string, time.Time) (auth.ReferralValidation, error)
+}
+
+// ValidationHandler is intentionally read-only. It exposes invite state for
+// onboarding UX but does not reserve capacity; registration remains the sole
+// authority that consumes a referral.
+type ValidationHandler struct {
+	Store         ValidationStore
+	Policy        auth.ReferralPolicy
+	PublicLimiter *BoundedLimiter
+	ValidateSlots chan struct{}
+	SourceIP      func(*http.Request) string
+	Now           func() time.Time
+}
+
+func (h *ValidationHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		w.Header().Set("Allow", http.MethodPost)
+		writeError(w, http.StatusMethodNotAllowed, "method_not_allowed", "POST required")
+		return
+	}
+	w.Header().Set("Cache-Control", "no-store")
+	if !h.Policy.RequireForRegistration {
+		writeJSON(w, http.StatusOK, map[string]any{"valid": true, "required": false, "reason": "disabled"})
+		return
+	}
+	key := r.RemoteAddr
+	if h.SourceIP != nil {
+		key = h.SourceIP(r)
+	}
+	if h.PublicLimiter == nil || !h.PublicLimiter.Allow(key) {
+		w.Header().Set("Retry-After", "60")
+		writeError(w, http.StatusTooManyRequests, "rate_limited", "too many referral checks")
+		return
+	}
+	if h.ValidateSlots != nil {
+		select {
+		case h.ValidateSlots <- struct{}{}:
+			defer func() { <-h.ValidateSlots }()
+		default:
+			w.Header().Set("Retry-After", "5")
+			writeError(w, http.StatusServiceUnavailable, "busy", "invite validation is temporarily busy")
+			return
+		}
+	}
+	if h.Store == nil {
+		writeError(w, http.StatusServiceUnavailable, "unavailable", "referral authority unavailable")
+		return
+	}
+	var request struct {
+		Code string `json:"code"`
+	}
+	if err := decodeBoundedJSON(r, &request, 1024); err != nil || len([]byte(request.Code)) > 256 {
+		writeError(w, http.StatusBadRequest, "bad_request", "invalid request")
+		return
+	}
+	validation, err := h.Store.ValidateReferral(r.Context(), h.Policy, request.Code, h.now())
+	if err != nil {
+		writeJSON(w, http.StatusOK, map[string]any{
+			"valid": false, "required": true, "reason": referralReason(err),
+		})
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{
+		"valid": validation.Valid, "required": true, "reason": validation.Reason,
+	})
+}
+
+func (h *ValidationHandler) now() time.Time {
+	if h.Now != nil {
+		return h.Now().UTC()
+	}
+	return time.Now().UTC()
+}
+
+func referralReason(err error) string {
+	switch {
+	case errors.Is(err, auth.ErrReferralRequired):
+		return "missing"
+	case errors.Is(err, auth.ErrReferralExpired):
+		return "expired"
+	case errors.Is(err, auth.ErrReferralRevoked):
+		return "revoked"
+	case errors.Is(err, auth.ErrReferralExhausted):
+		return "exhausted"
+	case errors.Is(err, auth.ErrReferralConflict):
+		return "conflict"
+	default:
+		return "invalid"
+	}
+}
+
+func decodeBoundedJSON(r *http.Request, dst any, max int64) error {
+	defer r.Body.Close()
+	body, err := io.ReadAll(io.LimitReader(r.Body, max+1))
+	if err != nil || int64(len(body)) > max {
+		return fmt.Errorf("body too large")
+	}
+	decoder := json.NewDecoder(bytes.NewReader(body))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(dst); err != nil {
+		return err
+	}
+	if err := decoder.Decode(&struct{}{}); err != io.EOF {
+		return fmt.Errorf("request must contain exactly one JSON value")
+	}
+	return nil
+}
+
+func writeError(w http.ResponseWriter, status int, code, message string) {
+	writeJSON(w, status, map[string]any{"error": map[string]string{"code": code, "message": message}})
+}
+
+func writeJSON(w http.ResponseWriter, status int, value any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("Cache-Control", "no-store")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(value)
+}
+
+type limiterEntry struct {
+	windowStart time.Time
+	count       int
+}
+
+type BoundedLimiter struct {
+	mu         sync.Mutex
+	limit      int
+	window     time.Duration
+	maxEntries int
+	now        func() time.Time
+	entries    map[string]limiterEntry
+}
+
+func NewBoundedLimiter(limit int, window time.Duration, maxEntries int) *BoundedLimiter {
+	return &BoundedLimiter{
+		limit: limit, window: window, maxEntries: maxEntries,
+		now: time.Now, entries: map[string]limiterEntry{},
+	}
+}
+
+func (l *BoundedLimiter) Allow(key string) bool {
+	if l == nil || l.limit <= 0 || l.window <= 0 || l.maxEntries <= 0 {
+		return false
+	}
+	now := l.now().UTC()
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	for k, entry := range l.entries {
+		if now.Sub(entry.windowStart) >= l.window {
+			delete(l.entries, k)
+		}
+	}
+	entry, ok := l.entries[key]
+	if !ok {
+		if len(l.entries) >= l.maxEntries {
+			var oldestKey string
+			var oldest time.Time
+			for k, candidate := range l.entries {
+				if oldestKey == "" || candidate.windowStart.Before(oldest) {
+					oldestKey, oldest = k, candidate.windowStart
+				}
+			}
+			delete(l.entries, oldestKey)
+		}
+		l.entries[key] = limiterEntry{windowStart: now, count: 1}
+		return true
+	}
+	if entry.count >= l.limit {
+		return false
+	}
+	entry.count++
+	l.entries[key] = entry
+	return true
+}

--- a/phase4-coordinator/internal/referralapi/validate.go
+++ b/phase4-coordinator/internal/referralapi/validate.go
@@ -2,6 +2,7 @@ package referralapi
 
 import (
 	"bytes"
+	"container/list"
 	"context"
 	"encoding/json"
 	"errors"
@@ -45,11 +46,6 @@ func (h *ValidationHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	if h.SourceIP != nil {
 		key = h.SourceIP(r)
 	}
-	if h.PublicLimiter == nil || !h.PublicLimiter.Allow(key) {
-		w.Header().Set("Retry-After", "60")
-		writeError(w, http.StatusTooManyRequests, "rate_limited", "too many referral checks")
-		return
-	}
 	if h.ValidateSlots != nil {
 		select {
 		case h.ValidateSlots <- struct{}{}:
@@ -59,6 +55,11 @@ func (h *ValidationHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			writeError(w, http.StatusServiceUnavailable, "busy", "invite validation is temporarily busy")
 			return
 		}
+	}
+	if h.PublicLimiter == nil || !h.PublicLimiter.Allow(key) {
+		w.Header().Set("Retry-After", "60")
+		writeError(w, http.StatusTooManyRequests, "rate_limited", "too many referral checks")
+		return
 	}
 	if h.Store == nil {
 		writeError(w, http.StatusServiceUnavailable, "unavailable", "referral authority unavailable")
@@ -138,6 +139,7 @@ func writeJSON(w http.ResponseWriter, status int, value any) {
 type limiterEntry struct {
 	windowStart time.Time
 	count       int
+	element     *list.Element
 }
 
 type BoundedLimiter struct {
@@ -147,12 +149,13 @@ type BoundedLimiter struct {
 	maxEntries int
 	now        func() time.Time
 	entries    map[string]limiterEntry
+	oldest     *list.List
 }
 
 func NewBoundedLimiter(limit int, window time.Duration, maxEntries int) *BoundedLimiter {
 	return &BoundedLimiter{
 		limit: limit, window: window, maxEntries: maxEntries,
-		now: time.Now, entries: map[string]limiterEntry{},
+		now: time.Now, entries: map[string]limiterEntry{}, oldest: list.New(),
 	}
 }
 
@@ -163,24 +166,41 @@ func (l *BoundedLimiter) Allow(key string) bool {
 	now := l.now().UTC()
 	l.mu.Lock()
 	defer l.mu.Unlock()
-	for k, entry := range l.entries {
-		if now.Sub(entry.windowStart) >= l.window {
-			delete(l.entries, k)
+	// Expiration is ordered by window start and bounded per call. This keeps a
+	// distributed-key flood from turning every request into a full-map scan.
+	for removed := 0; removed < 16; removed++ {
+		front := l.oldest.Front()
+		if front == nil {
+			break
 		}
+		key := front.Value.(string)
+		entry, ok := l.entries[key]
+		if !ok || entry.element != front {
+			l.oldest.Remove(front)
+			continue
+		}
+		if now.Sub(entry.windowStart) < l.window {
+			break
+		}
+		delete(l.entries, key)
+		l.oldest.Remove(front)
 	}
 	entry, ok := l.entries[key]
 	if !ok {
 		if len(l.entries) >= l.maxEntries {
-			var oldestKey string
-			var oldest time.Time
-			for k, candidate := range l.entries {
-				if oldestKey == "" || candidate.windowStart.Before(oldest) {
-					oldestKey, oldest = k, candidate.windowStart
-				}
-			}
-			delete(l.entries, oldestKey)
+			// Never reset an active caller's budget merely to admit a new key.
+			return false
 		}
-		l.entries[key] = limiterEntry{windowStart: now, count: 1}
+		element := l.oldest.PushBack(key)
+		l.entries[key] = limiterEntry{windowStart: now, count: 1, element: element}
+		return true
+	}
+	if now.Sub(entry.windowStart) >= l.window {
+		l.oldest.Remove(entry.element)
+		entry.windowStart = now
+		entry.count = 1
+		entry.element = l.oldest.PushBack(key)
+		l.entries[key] = entry
 		return true
 	}
 	if entry.count >= l.limit {

--- a/phase4-coordinator/internal/referralapi/validate_test.go
+++ b/phase4-coordinator/internal/referralapi/validate_test.go
@@ -86,3 +86,19 @@ func TestReferralReasonDoesNotCollapseLifecycleFailures(t *testing.T) {
 		}
 	}
 }
+
+func TestBoundedLimiterNeverEvictsAnActiveBucketForANewKey(t *testing.T) {
+	limiter := NewBoundedLimiter(2, time.Minute, 1)
+	now := time.Date(2026, 7, 13, 12, 0, 0, 0, time.UTC)
+	limiter.now = func() time.Time { return now }
+	if !limiter.Allow("active") || limiter.Allow("unseen") {
+		t.Fatal("full limiter admitted an unseen key")
+	}
+	if !limiter.Allow("active") || limiter.Allow("active") {
+		t.Fatal("active bucket was reset or its budget was not preserved")
+	}
+	now = now.Add(time.Minute)
+	if !limiter.Allow("unseen") {
+		t.Fatal("expired bucket was not reclaimed")
+	}
+}

--- a/phase4-coordinator/internal/referralapi/validate_test.go
+++ b/phase4-coordinator/internal/referralapi/validate_test.go
@@ -1,0 +1,88 @@
+package referralapi
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/augstar/macprovider-coordinator/internal/auth"
+)
+
+type validationStoreFunc func(string) (auth.ReferralValidation, error)
+
+func (f validationStoreFunc) ValidateReferral(_ context.Context, _ auth.ReferralPolicy, code string, _ time.Time) (auth.ReferralValidation, error) {
+	return f(code)
+}
+
+func validationPolicy() auth.ReferralPolicy {
+	return auth.ReferralPolicy{
+		RequireForRegistration: true,
+		Campaign:               "prebeta_test",
+		PolicyVersion:          "v1",
+		CurrentKeyID:           "k1",
+		HMACKeys:               map[string]string{"k1": strings.Repeat("s", 32)},
+		ProviderBaseUses:       1,
+	}
+}
+
+func TestValidationHandlerReturnsStableReasonWithoutReserving(t *testing.T) {
+	h := &ValidationHandler{
+		Store: validationStoreFunc(func(code string) (auth.ReferralValidation, error) {
+			if code == "expired" {
+				return auth.ReferralValidation{}, auth.ErrReferralExpired
+			}
+			return auth.ReferralValidation{Valid: true, Reason: "valid"}, nil
+		}),
+		Policy:        validationPolicy(),
+		PublicLimiter: NewBoundedLimiter(10, time.Minute, 10),
+		ValidateSlots: make(chan struct{}, 1),
+		SourceIP:      func(*http.Request) string { return "203.0.113.10" },
+	}
+
+	for _, tc := range []struct {
+		body string
+		want string
+	}{
+		{`{"code":"good"}`, `"valid":true`},
+		{`{"code":"expired"}`, `"reason":"expired"`},
+	} {
+		req := httptest.NewRequest(http.MethodPost, "/v1/referrals/validate", strings.NewReader(tc.body))
+		response := httptest.NewRecorder()
+		h.ServeHTTP(response, req)
+		if response.Code != http.StatusOK || !strings.Contains(response.Body.String(), tc.want) {
+			t.Fatalf("status=%d body=%s want %s", response.Code, response.Body.String(), tc.want)
+		}
+	}
+}
+
+func TestValidationHandlerFailsClosedWhenAuthorityMissing(t *testing.T) {
+	h := &ValidationHandler{
+		Policy:        validationPolicy(),
+		PublicLimiter: NewBoundedLimiter(1, time.Minute, 1),
+	}
+	request := httptest.NewRequest(http.MethodPost, "/v1/referrals/validate", strings.NewReader(`{"code":"x"}`))
+	response := httptest.NewRecorder()
+	h.ServeHTTP(response, request)
+	if response.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status=%d body=%s", response.Code, response.Body.String())
+	}
+}
+
+func TestReferralReasonDoesNotCollapseLifecycleFailures(t *testing.T) {
+	cases := map[error]string{
+		auth.ErrReferralRequired:  "missing",
+		auth.ErrReferralInvalid:   "invalid",
+		auth.ErrReferralExpired:   "expired",
+		auth.ErrReferralRevoked:   "revoked",
+		auth.ErrReferralExhausted: "exhausted",
+	}
+	for err, want := range cases {
+		if got := referralReason(errors.Join(err)); got != want {
+			t.Fatalf("reason(%v)=%q want=%q", err, got, want)
+		}
+	}
+}

--- a/phase4-coordinator/internal/ws/admission.go
+++ b/phase4-coordinator/internal/ws/admission.go
@@ -94,6 +94,32 @@ func (a *AdmissionManager) CheckAdmit(hello Hello, pinned bool, connectedProvisi
 	return a.evaluateAdmissionLocked(hello, connectedProvisional, false)
 }
 
+// ReserveAdmission holds in-memory pool capacity without creating durable
+// admission history. A failed referral/token transaction therefore leaves no
+// hourly admission record behind.
+func (a *AdmissionManager) ReserveAdmission(hello Hello, pinned bool, connectedProvisional int) (pool.Tier, gobwas.StatusCode, string) {
+	if pinned {
+		return pool.TierPinned, 0, ""
+	}
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	tier, code, reason := a.evaluateAdmissionLocked(hello, connectedProvisional, false)
+	if code == 0 {
+		a.pending++
+	}
+	return tier, code, reason
+}
+
+func (a *AdmissionManager) CommitReservedAdmission(hello Hello, pinned bool) pool.Tier {
+	if pinned {
+		return pool.TierPinned
+	}
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	a.recordAdmissionLocked(hello, a.now())
+	return pool.TierProvisional
+}
+
 func (a *AdmissionManager) evaluateAdmissionLocked(hello Hello, connectedProvisional int, record bool) (pool.Tier, gobwas.StatusCode, string) {
 	if _, ok := a.rejected[hello.ProviderID]; ok {
 		return pool.TierRejected, CloseBanned, "banned: provider " + hello.ProviderID + " has been rejected by operator"
@@ -114,6 +140,11 @@ func (a *AdmissionManager) evaluateAdmissionLocked(hello Hello, connectedProvisi
 		return pool.TierProvisional, 0, ""
 	}
 	a.pending++
+	a.recordAdmissionLocked(hello, now)
+	return pool.TierProvisional, 0, ""
+}
+
+func (a *AdmissionManager) recordAdmissionLocked(hello Hello, now time.Time) {
 	rec := a.records[hello.ProviderID]
 	if rec == nil {
 		rec = &ProvisionalRecord{
@@ -129,7 +160,6 @@ func (a *AdmissionManager) evaluateAdmissionLocked(hello Hello, connectedProvisi
 	rec.ModelID = hello.ModelID
 	rec.BinaryVersion = hello.BinaryVersion
 	a.persistLocked()
-	return pool.TierProvisional, 0, ""
 }
 
 func (a *AdmissionManager) ReleasePendingProvisional() {

--- a/phase4-coordinator/internal/ws/messages.go
+++ b/phase4-coordinator/internal/ws/messages.go
@@ -39,6 +39,7 @@ type Hello struct {
 	CandidateRowIdentity   string          `json:"catalog_row_identity,omitempty"`
 	CompatibilitySetID     string          `json:"compatibility_set_id,omitempty"`
 	CredentialBootstrap    bool            `json:"credential_bootstrap,omitempty"`
+	ReferralCode           string          `json:"referral_code,omitempty"`
 }
 
 const (
@@ -46,6 +47,7 @@ const (
 	maxHandshakeModelIDBytes       = 256
 	maxHandshakeBinaryVersionBytes = 32
 	maxHandshakeMetadataBytes      = 1024
+	maxReferralCodeBytes           = 256
 )
 
 type HelloAck struct {
@@ -62,9 +64,9 @@ type HelloAck struct {
 	// the top-level `provider_token` YAML key (FR-C9.3) so the next
 	// reconnect carries Bearer. Note: top-level, NOT nested under
 	// `auth:` — codex audit on PR #44 caught the prior spec/code drift.
-	AssignedProviderToken         string `json:"assigned_provider_token,omitempty"`
-	PairOT                        string `json:"pair_ot,omitempty"`
-	ClaimURL                      string `json:"claim_url,omitempty"`
+	AssignedProviderToken string `json:"assigned_provider_token,omitempty"`
+	PairOT                string `json:"pair_ot,omitempty"`
+	ClaimURL              string `json:"claim_url,omitempty"`
 	// The coordinator's admission verdict on this ACCEPT ack — one of
 	// bearer_validated / self_minted / bearerless_duplicate (pool.AuthState).
 	// mint_failed and the reject paths CLOSE the connection, so they never ride
@@ -123,6 +125,7 @@ type AuthRequest struct {
 	CandidateRowIdentity           string          `json:"catalog_row_identity,omitempty"`
 	CompatibilitySetID             string          `json:"compatibility_set_id,omitempty"`
 	CredentialBootstrap            bool            `json:"credential_bootstrap,omitempty"`
+	ReferralCode                   string          `json:"referral_code,omitempty"`
 }
 
 type Spec010Presence struct {
@@ -170,9 +173,9 @@ type AuthResponse struct {
 	// SPEC-003 v0.8 FR-C9.2 — populated only on proof-stage acceptance
 	// when a tokenless provisional provider was just self-minted on this
 	// connect. Never present on rejection-shaped responses.
-	AssignedProviderToken               string `json:"assigned_provider_token,omitempty"`
-	PairOT                              string `json:"pair_ot,omitempty"`
-	ClaimURL                            string `json:"claim_url,omitempty"`
+	AssignedProviderToken string `json:"assigned_provider_token,omitempty"`
+	PairOT                string `json:"pair_ot,omitempty"`
+	ClaimURL              string `json:"claim_url,omitempty"`
 	// Coordinator admission verdict on this ACCEPT ack; see the
 	// HelloAck.AuthState note (emission SPEC-003 FR-C9.2a, shape SPEC-001 §6.5.1,
 	// interpretation SPEC-020 v0.1.7). mint_failed / rejects close the
@@ -555,6 +558,11 @@ func ParseHello(payload []byte) (Hello, string, error) {
 			return Hello{}, "credential_bootstrap", fmt.Errorf("credential_bootstrap must be a bool")
 		}
 	}
+	if v, ok := raw["referral_code"]; ok && string(v) != "null" {
+		if err := json.Unmarshal(v, &h.ReferralCode); err != nil || len([]byte(h.ReferralCode)) > maxReferralCodeBytes || containsControlChar(h.ReferralCode) {
+			return Hello{}, "referral_code", fmt.Errorf("referral_code must be a string of at most %d bytes", maxReferralCodeBytes)
+		}
+	}
 	if field, err := parseCatalogAdmissionMetadata(raw, &h.CatalogReleaseID, &h.CatalogPolicyVersion, &h.CandidateCatalogSHA256, &h.CatalogSignerKeyID, &h.CandidateRowIdentity); err != nil {
 		return Hello{}, field, err
 	}
@@ -686,6 +694,11 @@ func parseAuthInitial(raw map[string]json.RawMessage, req AuthRequest) (AuthRequ
 	if v, ok := raw["provider_admission_recovery"]; ok {
 		if string(v) == "null" || json.Unmarshal(v, &req.ProviderAdmissionRecovery) != nil {
 			return AuthRequest{}, Spec010Presence{}, "provider_admission_recovery", fmt.Errorf("provider_admission_recovery must be a bool")
+		}
+	}
+	if v, ok := raw["referral_code"]; ok && string(v) != "null" {
+		if err := json.Unmarshal(v, &req.ReferralCode); err != nil || len([]byte(req.ReferralCode)) > maxReferralCodeBytes || containsControlChar(req.ReferralCode) {
+			return AuthRequest{}, Spec010Presence{}, "referral_code", fmt.Errorf("referral_code must be a string of at most %d bytes", maxReferralCodeBytes)
 		}
 	}
 	if err := requireString(raw, "provider_ecdh_public_key", &req.ProviderECDHPublicKey); err != nil {
@@ -830,6 +843,11 @@ func parseAuthProof(raw map[string]json.RawMessage, req AuthRequest) (AuthReques
 			return AuthRequest{}, Spec010Presence{}, "credential_bootstrap", fmt.Errorf("credential_bootstrap must be a bool")
 		}
 	}
+	if v, ok := raw["referral_code"]; ok && string(v) != "null" {
+		if err := json.Unmarshal(v, &req.ReferralCode); err != nil || len([]byte(req.ReferralCode)) > maxReferralCodeBytes || containsControlChar(req.ReferralCode) {
+			return AuthRequest{}, Spec010Presence{}, "referral_code", fmt.Errorf("referral_code must be a string of at most %d bytes", maxReferralCodeBytes)
+		}
+	}
 	// Proof-stage MUST keep the bare "supported_models" badField (NOT
 	// the locked initial-stage substring) — AC-K.15's surfacing
 	// contract is initial-stage-only, and the R2V regression test
@@ -885,6 +903,7 @@ func (r AuthRequest) Hello() Hello {
 		CandidateRowIdentity:   r.CandidateRowIdentity,
 		CompatibilitySetID:     r.CompatibilitySetID,
 		CredentialBootstrap:    r.CredentialBootstrap,
+		ReferralCode:           r.ReferralCode,
 	}
 }
 

--- a/phase4-coordinator/internal/ws/referral_core_test.go
+++ b/phase4-coordinator/internal/ws/referral_core_test.go
@@ -42,17 +42,29 @@ func TestAdmissionReservationIsNotDurableUntilCredentialCommit(t *testing.T) {
 		ProvisionalPoolMax:              1,
 	}, func() time.Time { return now })
 	manager.SetPersistence(store, func(err error) { t.Fatalf("persist admission: %v", err) })
-	hello := Hello{ProviderID: "provider-a", Hostname: "host", ModelID: "model", BinaryVersion: "1.2.0"}
-	if tier, code, reason := manager.ReserveAdmission(hello, false, 0); tier != pool.TierProvisional || code != 0 || reason != "" {
+	failedHello := Hello{ProviderID: "provider-a", Hostname: "host-a", ModelID: "model", BinaryVersion: "1.2.0"}
+	if tier, code, reason := manager.ReserveAdmission(failedHello, false, 0); tier != pool.TierProvisional || code != 0 || reason != "" {
 		t.Fatalf("reserve tier=%s code=%d reason=%q", tier, code, reason)
 	}
 	if records := manager.Records(nil); len(records) != 0 {
 		t.Fatalf("reservation created durable records: %+v", records)
 	}
-	if tier := manager.CommitReservedAdmission(hello, false); tier != pool.TierProvisional {
+
+	committedHello := Hello{ProviderID: "provider-b", Hostname: "host-b", ModelID: "model", BinaryVersion: "1.2.0"}
+	if _, code, _ := manager.ReserveAdmission(committedHello, false, 0); code != CloseProvisionalPoolFull {
+		t.Fatalf("reserve while credential pending code=%d, want %d", code, CloseProvisionalPoolFull)
+	}
+	manager.ReleasePendingProvisional()
+	if records := manager.Records(nil); len(records) != 0 {
+		t.Fatalf("failed credential reservation created durable records: %+v", records)
+	}
+	if tier, code, reason := manager.ReserveAdmission(committedHello, false, 0); tier != pool.TierProvisional || code != 0 || reason != "" {
+		t.Fatalf("reserve after failure release tier=%s code=%d reason=%q", tier, code, reason)
+	}
+	if tier := manager.CommitReservedAdmission(committedHello, false); tier != pool.TierProvisional {
 		t.Fatalf("commit tier=%s", tier)
 	}
-	if records := manager.Records(nil); len(records) != 1 || records[0].ProviderID != hello.ProviderID {
+	if records := manager.Records(nil); len(records) != 1 || records[0].ProviderID != committedHello.ProviderID {
 		t.Fatalf("committed records=%+v", records)
 	}
 	manager.ReleasePendingProvisional()

--- a/phase4-coordinator/internal/ws/referral_core_test.go
+++ b/phase4-coordinator/internal/ws/referral_core_test.go
@@ -17,7 +17,7 @@ func TestReferralCloseReasonPreservesLifecycleToken(t *testing.T) {
 		auth.ErrReferralExpired:   "referral_expired",
 		auth.ErrReferralRevoked:   "referral_revoked",
 		auth.ErrReferralExhausted: "referral_exhausted",
-		auth.ErrReferralConflict:  "referral_invalid",
+		auth.ErrReferralConflict:  "referral_conflict",
 	}
 	for err, want := range cases {
 		if got := referralCloseReason(err); got != want {

--- a/phase4-coordinator/internal/ws/referral_core_test.go
+++ b/phase4-coordinator/internal/ws/referral_core_test.go
@@ -1,0 +1,59 @@
+package ws
+
+import (
+	"database/sql"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/augstar/macprovider-coordinator/internal/auth"
+	"github.com/augstar/macprovider-coordinator/internal/config"
+	"github.com/augstar/macprovider-coordinator/internal/pool"
+)
+
+func TestReferralCloseReasonPreservesLifecycleToken(t *testing.T) {
+	cases := map[error]string{
+		auth.ErrReferralInvalid:   "referral_invalid",
+		auth.ErrReferralExpired:   "referral_expired",
+		auth.ErrReferralRevoked:   "referral_revoked",
+		auth.ErrReferralExhausted: "referral_exhausted",
+		auth.ErrReferralConflict:  "referral_invalid",
+	}
+	for err, want := range cases {
+		if got := referralCloseReason(err); got != want {
+			t.Fatalf("referralCloseReason(%v)=%q want=%q", err, got, want)
+		}
+	}
+}
+
+func TestAdmissionReservationIsNotDurableUntilCredentialCommit(t *testing.T) {
+	now := time.Date(2026, 7, 13, 12, 0, 0, 0, time.UTC)
+	db, err := sql.Open("sqlite", filepath.Join(t.TempDir(), "coordinator.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+	store, err := NewSQLiteAdmissionStore(db)
+	if err != nil {
+		t.Fatal(err)
+	}
+	manager := NewAdmissionManager(config.AdmissionConfig{
+		ProvisionalAdmissionRatePerHour: 1,
+		ProvisionalPoolMax:              1,
+	}, func() time.Time { return now })
+	manager.SetPersistence(store, func(err error) { t.Fatalf("persist admission: %v", err) })
+	hello := Hello{ProviderID: "provider-a", Hostname: "host", ModelID: "model", BinaryVersion: "1.2.0"}
+	if tier, code, reason := manager.ReserveAdmission(hello, false, 0); tier != pool.TierProvisional || code != 0 || reason != "" {
+		t.Fatalf("reserve tier=%s code=%d reason=%q", tier, code, reason)
+	}
+	if records := manager.Records(nil); len(records) != 0 {
+		t.Fatalf("reservation created durable records: %+v", records)
+	}
+	if tier := manager.CommitReservedAdmission(hello, false); tier != pool.TierProvisional {
+		t.Fatalf("commit tier=%s", tier)
+	}
+	if records := manager.Records(nil); len(records) != 1 || records[0].ProviderID != hello.ProviderID {
+		t.Fatalf("committed records=%+v", records)
+	}
+	manager.ReleasePendingProvisional()
+}

--- a/phase4-coordinator/internal/ws/server.go
+++ b/phase4-coordinator/internal/ws/server.go
@@ -1724,6 +1724,8 @@ func referralCloseReason(err error) string {
 		return "referral_revoked"
 	case errors.Is(err, auth.ErrReferralExhausted):
 		return "referral_exhausted"
+	case errors.Is(err, auth.ErrReferralConflict):
+		return "referral_conflict"
 	default:
 		return "referral_invalid"
 	}

--- a/phase4-coordinator/internal/ws/server.go
+++ b/phase4-coordinator/internal/ws/server.go
@@ -92,6 +92,7 @@ type Server struct {
 	// interface-segregation regression of mixing both on TokenValidator.
 	issuer          TokenIssuer
 	bootstrapTokens BootstrapTokenStore
+	referralPolicy  auth.ReferralPolicy
 	authStore       *auth.Store
 	githubOAuth     githubOAuthClient
 	admission       *AdmissionManager
@@ -339,6 +340,12 @@ func WithTokenIssuer(issuer TokenIssuer) Option {
 func WithBootstrapTokenStore(store BootstrapTokenStore) Option {
 	return func(s *Server) {
 		s.bootstrapTokens = store
+	}
+}
+
+func WithReferralPolicy(policy auth.ReferralPolicy) Option {
+	return func(s *Server) {
+		s.referralPolicy = policy
 	}
 }
 
@@ -902,7 +909,7 @@ const (
 // bearer; race-losers are quarantined as AuthBearerlessDuplicate.
 //
 // authParam is renamed to disambiguate from the auth package import.
-func (s *Server) resolveProvisionalToken(authParam providerAuth, providerID, providerName string) (provisionalTokenOutcome, string, string, string, pool.AuthState) {
+func (s *Server) resolveProvisionalToken(authParam providerAuth, providerID, providerName, referralCode string) (provisionalTokenOutcome, string, string, string, pool.AuthState) {
 	if s.issuer == nil {
 		return provisionalTokenSkip, "", "", "", ""
 	}
@@ -920,7 +927,7 @@ func (s *Server) resolveProvisionalToken(authParam providerAuth, providerID, pro
 		return provisionalTokenRejectTOFU, "", "", "", ""
 	}
 	if s.cfg.Auth.GitHubOAuth.Enabled && s.authStore != nil {
-		mint, err := s.authStore.MintAdmissionTokenAndPairOT(ctx, providerID, providerName, s.now())
+		mint, err := s.authStore.MintAdmissionTokenAndPairOTWithReferral(ctx, providerID, providerName, s.now(), referralCode, s.referralPolicy)
 		if err == nil {
 			claimURL := ""
 			if mint.Paired {
@@ -935,7 +942,19 @@ func (s *Server) resolveProvisionalToken(authParam providerAuth, providerID, pro
 		}
 		s.log.Warn().Err(err).Str("provider_id", providerID).Msg("FR-C10 pair_ot compound mint failed; falling back to plain FR-C9 provider token mint")
 	}
-	_, token, err := s.issuer.IssueToken(ctx, providerID, providerName)
+	var token string
+	if s.referralPolicy.RequireForRegistration {
+		referralIssuer, ok := s.issuer.(interface {
+			IssueTokenWithReferral(context.Context, string, string, string, auth.ReferralPolicy) (auth.TokenRecord, string, error)
+		})
+		if !ok {
+			err = errors.New("referral-aware token issuer unavailable")
+		} else {
+			_, token, err = referralIssuer.IssueTokenWithReferral(ctx, providerID, providerName, referralCode, s.referralPolicy)
+		}
+	} else {
+		_, token, err = s.issuer.IssueToken(ctx, providerID, providerName)
+	}
 	if err != nil {
 		if errors.Is(err, auth.ErrActiveTokenAlreadyExists) {
 			// SPEC-003 v0.8.4 race-loss path: a concurrent tokenless
@@ -1004,9 +1023,14 @@ func (s *Server) handleV1Conn(conn net.Conn, connectionAuth providerAuth, payloa
 		s.close(conn, CloseIdentitySignatureRequired, "durable_identity_requires_v2")
 		return "", ""
 	}
-	entry, ok := s.prepareProviderAdmission(conn, connectionAuth, hello, true)
+	entry, ok := s.prepareProviderAdmission(conn, connectionAuth, hello)
 	if !ok {
 		return "", ""
+	}
+	if tier, ok := s.reserveProviderAdmission(conn, hello, entry.Tier == pool.TierPinned); !ok {
+		return "", ""
+	} else {
+		entry.Tier = tier
 	}
 	registered := false
 	defer func() {
@@ -1022,7 +1046,7 @@ func (s *Server) handleV1Conn(conn net.Conn, connectionAuth providerAuth, payloa
 	// the provided AuthState (BearerValidated / BearerlessDuplicate /
 	// empty) and let the registry eviction defense + RoutingEligible
 	// gates take over.
-	outcome, assignedProviderToken, pairOT, claimURL, authState := s.resolveProvisionalToken(connectionAuth, entry.ProviderID, hello.Hostname)
+	outcome, assignedProviderToken, pairOT, claimURL, authState := s.resolveProvisionalToken(connectionAuth, entry.ProviderID, hello.Hostname, hello.ReferralCode)
 	if outcome == provisionalTokenRejectTOFU {
 		s.close(conn, CloseInvalidToken, "invalid_token")
 		return "", ""
@@ -1030,6 +1054,7 @@ func (s *Server) handleV1Conn(conn net.Conn, connectionAuth providerAuth, payloa
 	if !s.confirmAdmittedProviderToken(conn, connectionAuth) {
 		return "", ""
 	}
+	entry.Tier = s.commitProviderAdmission(hello, entry.Tier == pool.TierPinned)
 	entry.AuthState = authState
 	session, _ := s.registerProviderSession(conn, entry)
 	if session == nil {
@@ -1121,7 +1146,7 @@ func (s *Server) handleV2Conn(conn net.Conn, connectionAuth providerAuth, payloa
 	if initial.CredentialBootstrap {
 		entry, ok = s.prepareCredentialBootstrap(conn, connectionAuth, initial)
 	} else {
-		entry, ok = s.prepareProviderAdmission(conn, connectionAuth, initial.Hello(), false)
+		entry, ok = s.prepareProviderAdmission(conn, connectionAuth, initial.Hello())
 	}
 	if !ok {
 		return "", ""
@@ -1260,7 +1285,8 @@ func (s *Server) handleV2Conn(conn net.Conn, connectionAuth providerAuth, payloa
 		return "", ""
 	}
 	if proof.AuthAttemptID != authAttemptID || proof.ProviderID != initial.ProviderID ||
-		proof.CredentialBootstrap != initial.CredentialBootstrap || s.now().After(challengeExpiresAt) {
+		proof.CredentialBootstrap != initial.CredentialBootstrap || proof.ReferralCode != initial.ReferralCode ||
+		s.now().After(challengeExpiresAt) {
 		s.sendAuthRejection(conn, "attestation_failed", "attestation failed")
 		s.close(conn, CloseTier2AttestationFailed, "tier2_attestation_failed")
 		return "", ""
@@ -1338,6 +1364,8 @@ func (s *Server) handleV2Conn(conn net.Conn, connectionAuth providerAuth, payloa
 			UnconfirmedIDMax:    s.cfg.Auth.CredentialBootstrapUnconfirmedMax,
 			OutstandingTokenMax: s.cfg.Auth.CredentialBootstrapOutstandingMax,
 			IdentityRetention:   time.Duration(s.cfg.Auth.CredentialBootstrapIdentityRetentionS) * time.Second,
+			ReferralCode:        initial.ReferralCode,
+			ReferralPolicy:      s.referralPolicy,
 		})
 		if err != nil {
 			s.rejectCredentialBootstrap(conn, err)
@@ -1435,11 +1463,9 @@ func (s *Server) handleV2Conn(conn net.Conn, connectionAuth providerAuth, payloa
 	}
 	entry.MaxAdmittedModelKey = maxAdmittedModelKey
 	entry.MaxAdmittedModelID = maxAdmittedModelID
-	// This is the first durable admission mutation in the v2 path. Keep it
-	// after the post-challenge evidence recheck so a provider whose evidence
-	// disappears during authentication cannot consume an hourly admission or
-	// leave a provisional record behind.
-	if tier, ok := s.recordProviderAdmission(conn, initial.Hello(), entry.Tier == pool.TierPinned); !ok {
+	// Reserve after the post-challenge evidence recheck, but defer the durable
+	// admission record until credential minting succeeds.
+	if tier, ok := s.reserveProviderAdmission(conn, initial.Hello(), entry.Tier == pool.TierPinned); !ok {
 		return "", ""
 	} else {
 		entry.Tier = tier
@@ -1450,7 +1476,7 @@ func (s *Server) handleV2Conn(conn net.Conn, connectionAuth providerAuth, payloa
 			s.admission.ReleasePendingProvisional()
 		}
 	}()
-	outcome, assignedProviderToken, pairOT, claimURL, authState := s.resolveProvisionalToken(connectionAuth, entry.ProviderID, initial.Hostname)
+	outcome, assignedProviderToken, pairOT, claimURL, authState := s.resolveProvisionalToken(connectionAuth, entry.ProviderID, initial.Hostname, initial.ReferralCode)
 	if outcome == provisionalTokenRejectTOFU {
 		s.close(conn, CloseInvalidToken, "invalid_token")
 		return "", ""
@@ -1529,6 +1555,7 @@ func (s *Server) handleV2Conn(conn net.Conn, connectionAuth providerAuth, payloa
 			Int("identity_generation", state.Generation).
 			Msg("durable admission identity recovered under operator authorization")
 	}
+	entry.Tier = s.commitProviderAdmission(initial.Hello(), entry.Tier == pool.TierPinned)
 	entry.AuthState = authState
 	session, refusal := s.registerProviderSession(conn, entry)
 	if session == nil {
@@ -1674,10 +1701,31 @@ func (s *Server) rejectCredentialBootstrap(conn net.Conn, err error) {
 	case errors.Is(err, auth.ErrBootstrapOutstandingLimit):
 		s.observeCredentialBootstrap("rejected_outstanding")
 		s.close(conn, CloseProvisionalPoolFull, "credential_bootstrap_outstanding_full")
+	case errors.Is(err, auth.ErrReferralRequired):
+		s.observeCredentialBootstrap("rejected_referral_required")
+		s.close(conn, CloseInvalidToken, "referral_required")
+	case errors.Is(err, auth.ErrReferralInvalid), errors.Is(err, auth.ErrReferralExpired),
+		errors.Is(err, auth.ErrReferralRevoked), errors.Is(err, auth.ErrReferralExhausted),
+		errors.Is(err, auth.ErrReferralConflict):
+		s.observeCredentialBootstrap("rejected_referral")
+		s.close(conn, CloseInvalidToken, referralCloseReason(err))
 	default:
 		s.observeCredentialBootstrap("store_error")
 		s.log.Warn().Err(err).Msg("credential bootstrap token transaction failed")
 		s.close(conn, CloseInvalidToken, "invalid_token")
+	}
+}
+
+func referralCloseReason(err error) string {
+	switch {
+	case errors.Is(err, auth.ErrReferralExpired):
+		return "referral_expired"
+	case errors.Is(err, auth.ErrReferralRevoked):
+		return "referral_revoked"
+	case errors.Is(err, auth.ErrReferralExhausted):
+		return "referral_exhausted"
+	default:
+		return "referral_invalid"
 	}
 }
 
@@ -1687,7 +1735,7 @@ func (s *Server) observeCredentialBootstrap(outcome string) {
 	}
 }
 
-func (s *Server) prepareProviderAdmission(conn net.Conn, auth providerAuth, hello Hello, recordAdmission bool) (*pool.Provider, bool) {
+func (s *Server) prepareProviderAdmission(conn net.Conn, auth providerAuth, hello Hello) (*pool.Provider, bool) {
 	if required := strings.TrimSpace(s.cfg.CoordinatorAdvertisedVersion.RequiredBinaryVersion); required != "" {
 		cmp, ok := compareSemver(hello.BinaryVersion, required)
 		if !ok || cmp < 0 {
@@ -1765,13 +1813,6 @@ func (s *Server) prepareProviderAdmission(conn net.Conn, auth providerAuth, hell
 	maxAdmittedModelKey, maxAdmittedModelID, gateOK := s.checkAutotuneHelloGate(conn, hello)
 	if !gateOK {
 		return nil, false
-	}
-	if recordAdmission {
-		tier, closeCode, closeReason = s.checkOrRecordAdmission(hello, pinned, true)
-		if closeCode != 0 {
-			s.close(conn, closeCode, closeReason)
-			return nil, false
-		}
 	}
 	initialState := pool.StateReady
 	if s.cfg.Pool.WarmupGateEnabled {
@@ -2024,13 +2065,17 @@ func (s *Server) gatedRecommendedBinaryVersion(compatibilitySetID string) string
 	return s.cfg.CoordinatorAdvertisedVersion.LatestBinaryVersion
 }
 
-func (s *Server) recordProviderAdmission(conn net.Conn, hello Hello, pinned bool) (pool.Tier, bool) {
-	tier, closeCode, closeReason := s.checkOrRecordAdmission(hello, pinned, true)
+func (s *Server) reserveProviderAdmission(conn net.Conn, hello Hello, pinned bool) (pool.Tier, bool) {
+	tier, closeCode, closeReason := s.admission.ReserveAdmission(hello, pinned, s.connectedProvisional())
 	if closeCode != 0 {
 		s.close(conn, closeCode, closeReason)
 		return "", false
 	}
 	return tier, true
+}
+
+func (s *Server) commitProviderAdmission(hello Hello, pinned bool) pool.Tier {
+	return s.admission.CommitReservedAdmission(hello, pinned)
 }
 
 func (s *Server) checkOrRecordAdmission(hello Hello, pinned bool, record bool) (pool.Tier, gobwas.StatusCode, string) {


### PR DESCRIPTION
## Outcome

Restacks coordinator referral admission directly onto the recovered ledger now merged as `645ff030` on `main`. The branch contains only the five admission commits plus audited recovery hardening; the pre-squash #573 commit cannot reappear.

The launchd-managed CLI remains registration, provider identity, bearer custody, and lifecycle authority. Malibu is not a caller of this server surface. Coordinator referral enforcement, public validation, and social bonus flags remain off by default.

## Admission and recovery safety

- Fresh CLI credential bootstrap may carry a referral code. Incumbent valid bearers, pinned/operator issuance, admission-identity enrollment, rotation, recovery, and compatibility behavior remain intact.
- Referral redemption, provider/campaign attribution, exact receipt-key binding, and unused-token minting commit atomically in the auth SQLite store.
- Same-provider replay is idempotent; a different code or campaign conflicts. Concurrent redemption for one remaining use produces one token/redemption winner.
- App-track lost-response recovery remains bound to the exact signed `(provider_id, nonce, ts_utc)` attempt and active client-held credential candidate.
- Delayed retries can recover after skew/backoff without rotation, but only behind a 60/min process budget, 5/min provider and trusted-IP budgets, and a four-request concurrency bulkhead before credential/PostgreSQL authority access.
- Expired rate-limit keys are swept, bounding retained state.
- Cross-store saga reconciliation stays active when referral enforcement or the public App-track route is disabled. Route-off mode opens only the configured primary onboarding PostgreSQL authority; auth-policy role handles and admin/public surfaces remain disabled.
- Missing PostgreSQL recovery authority is reported only when pending saga work exists; ambiguous state is never compensated blindly.

## Rollout and rollback

1. #573 ledger is merged and migration 018 is canonical.
2. Merge this security-sensitive auth/admission PR with all production referral flags disabled.
3. Restack #576 onto the resulting `main`; do not squash-merge it from this feature branch.
4. Keep production disabled through #623, #625, #626, and signed physical acceptance.

Disabling admission or its route is a supported rollback. The dormant reconciler must remain available until all pending cross-store mints converge.

## Verification on head `8d36fd79`

- `go test ./...`
- `go vet ./...`
- `go test -race -count=1 ./internal/auth ./internal/onboarding ./internal/referralapi ./internal/ws`
- integration-tag PostgreSQL test compilation
- invalid, expired, revoked, exhausted, replayed, disabled-policy, concurrent redemption, response-loss, route/enforcement rollback, exact-candidate, bounded stale-retry, and missing-authority regressions
- independent code, architecture, and security audits: PASS, 0 Critical/High/Medium
- Docker is unavailable locally; fresh GitHub PostgreSQL CI must execute the live integration lane before merge.

## Real dependency sequence

1. #621 — lifecycle/spec baseline — merged
2. #573 — durable ledger — merged
3. this PR — coordinator referral admission
4. #576 — join links/operator controls, to be rebased onto `main`
5. #623 — coordinator advocacy/X rewards, then rebased onto `main`
6. #625 — CLI/Malibu onboarding, revalidated against merged server/spec baseline
7. #626 — Malibu referral/advocacy UI, rebased after #625
8. signed/notarized two-provider real-X acceptance and activation PR only after evidence passes

Production flags remain disabled.