### PR TITLE
Add secure invite-gated macOS onboarding

### DIFF
--- a/phase3-binary/Sources/MacProviderCore/Config.swift
+++ b/phase3-binary/Sources/MacProviderCore/Config.swift
@@ -32,6 +32,8 @@ public struct AppConfig: Equatable, Sendable {
     public var modelCatalogVersion: String?
     public var modelCatalogHash: String?
     public var coordinatorURL: String?
+    /// Pre-beta referral code used only while obtaining first credentials.
+    public var referralCode: String?
     public var providerID: String?
     public var endpointURL: String?
     public var wsTunneledMode: Bool?
@@ -129,6 +131,7 @@ public struct AppConfig: Equatable, Sendable {
             modelCatalogVersion: nil,
             modelCatalogHash: nil,
             coordinatorURL: nil,
+            referralCode: nil,
             providerID: nil,
             endpointURL: nil,
             wsTunneledMode: nil,
@@ -177,6 +180,7 @@ public struct CLIOverrides: Equatable, Sendable {
     public var numDraftTokens: Int?
     public var publishesSpecDecodeTelemetry: Bool?
     public var coordinatorURL: String?
+    public var referralCode: String?
     public var providerID: String?
     public var endpointURL: String?
     public var configPath: String?
@@ -214,6 +218,7 @@ public struct CLIOverrides: Equatable, Sendable {
         numDraftTokens: Int? = nil,
         publishesSpecDecodeTelemetry: Bool? = nil,
         coordinatorURL: String? = nil,
+        referralCode: String? = nil,
         providerID: String? = nil,
         endpointURL: String? = nil,
         configPath: String? = nil,
@@ -247,6 +252,7 @@ public struct CLIOverrides: Equatable, Sendable {
         self.numDraftTokens = numDraftTokens
         self.publishesSpecDecodeTelemetry = publishesSpecDecodeTelemetry
         self.coordinatorURL = coordinatorURL
+        self.referralCode = referralCode
         self.providerID = providerID
         self.endpointURL = endpointURL
         self.configPath = configPath
@@ -368,6 +374,7 @@ public enum ConfigLoader {
         try assign(&config.modelCatalogVersion, from: dict, key: "model_catalog_version", expected: "string")
         try assign(&config.modelCatalogHash, from: dict, key: "model_catalog_hash", expected: "string")
         try assign(&config.coordinatorURL, from: dict, key: "coordinator_url", expected: "string")
+        try assign(&config.referralCode, from: dict, key: "referral_code", expected: "string")
         try assign(&config.providerID, from: dict, key: "provider_id", expected: "string")
         try assign(&config.endpointURL, from: dict, key: "endpoint_url", expected: "string")
         try assign(&config.wsTunneledMode, from: dict, key: "ws_tunneled_mode", expected: "boolean")
@@ -423,6 +430,7 @@ public enum ConfigLoader {
         try assign(&config.numDraftTokens, from: environment, env: "MACPROVIDER_NUM_DRAFT_TOKENS", expected: "integer")
         try assign(&config.publishesSpecDecodeTelemetry, from: environment, env: "MACPROVIDER_PUBLISHES_SPEC_DECODE_TELEMETRY", expected: "boolean")
         try assign(&config.coordinatorURL, from: environment, env: "MACPROVIDER_COORDINATOR_URL", expected: "string")
+        try assign(&config.referralCode, from: environment, env: "MACPROVIDER_REFERRAL_CODE", expected: "string")
         try assign(&config.providerID, from: environment, env: "MACPROVIDER_PROVIDER_ID", expected: "string")
         try assign(&config.endpointURL, from: environment, env: "MACPROVIDER_ENDPOINT_URL", expected: "string")
         try assign(&config.wsTunneledMode, from: environment, env: "MACPROVIDER_WS_TUNNELED_MODE", expected: "boolean")
@@ -483,6 +491,9 @@ public enum ConfigLoader {
         }
         if let coordinatorURL = cli.coordinatorURL {
             config.coordinatorURL = coordinatorURL
+        }
+        if let referralCode = cli.referralCode {
+            config.referralCode = referralCode
         }
         if let providerID = cli.providerID {
             config.providerID = providerID

--- a/phase3-binary/Sources/macprovider-cli/AutotuneCommand.swift
+++ b/phase3-binary/Sources/macprovider-cli/AutotuneCommand.swift
@@ -60,6 +60,9 @@ struct AutotuneCommand: AsyncParsableCommand {
     @Option(help: "YAML config path for --apply. Defaults to ~/.config/macprovider/config.yaml.")
     var config: String?
 
+    @Option(help: "Read the provider authentication token from an inherited file descriptor (for example, --token-fd 0 for stdin). Used by Malibu.app repair so required hardware evidence can authenticate without putting the bearer in argv, the environment, or a file.")
+    var tokenFd: Int?
+
     @Option(help: "Number of recent autotune runs to retain.")
     var retainRuns = 50
 
@@ -690,6 +693,12 @@ struct AutotuneCommand: AsyncParsableCommand {
         if requireHardwareEvidence && !submitHardwareEvidence {
             throw ValidationError("--require-hardware-evidence cannot be combined with --no-submit-hardware-evidence")
         }
+        if tokenFd != nil && !recommend {
+            throw ValidationError("--token-fd requires --recommend")
+        }
+        if let tokenFd, tokenFd < 0 {
+            throw ValidationError("--token-fd must be a non-negative file descriptor")
+        }
         guard maxDuration > 0 else {
             throw ValidationError("--max-duration must be > 0")
         }
@@ -725,7 +734,7 @@ struct AutotuneCommand: AsyncParsableCommand {
         let rateCard = await staticInputs.loadRateCard()
 
         let fingerprint = MachineFingerprinter().sample()
-        let resolvedConfig = try? ConfigLoader.load(cli: CLIOverrides(configPath: config))
+        let resolvedConfig = try resolvedProviderConfig()
         let secret = try AutotuneHMACSecretStore(path: AutotuneHMACSecretStore.defaultPath).loadOrCreate()
         let identity = HMACIdentity.derive(secret: secret, fingerprint: fingerprint, providerID: resolvedConfig?.providerID)
         let hardware = AutotuneRecommendHardware(fingerprint: fingerprint, hmacIdentity: identity)
@@ -897,7 +906,7 @@ struct AutotuneCommand: AsyncParsableCommand {
     }
 
     private func runRecommendationFreshnessCheck() async throws {
-        let resolvedConfig = try? ConfigLoader.load(cli: CLIOverrides(configPath: config))
+        let resolvedConfig = try resolvedProviderConfig()
         let status = await RecommendationFreshnessChecker(providerID: resolvedConfig?.providerID).status()
         switch status {
         case .fresh:
@@ -951,6 +960,14 @@ struct AutotuneCommand: AsyncParsableCommand {
         case .failed(let reason):
             return .blocked(reason)
         }
+    }
+
+    private func resolvedProviderConfig() throws -> AppConfig? {
+        guard var resolved = try? ConfigLoader.load(cli: CLIOverrides(configPath: config)) else {
+            return nil
+        }
+        try ProviderTokenInput.apply(fileDescriptor: tokenFd, to: &resolved)
+        return resolved
     }
 
     static func requiredHardwareEvidenceBlockReason(

--- a/phase3-binary/Sources/macprovider-cli/BootstrapAuthCommand.swift
+++ b/phase3-binary/Sources/macprovider-cli/BootstrapAuthCommand.swift
@@ -78,6 +78,15 @@ struct BootstrapAuthCommand: AsyncParsableCommand {
                     await client.stop()
                     return
                 }
+                // PROD-M2: a referral-coded terminal rejection means retrying is
+                // pointless. Surface the specific reason on stderr as a
+                // machine-readable marker so install.sh can route the user back
+                // to the invite step instead of reporting a generic timeout.
+                if let reason = await client.terminalReferralRejection() {
+                    await client.stop()
+                    FileHandle.standardError.write(Data("MACPROVIDER_REFERRAL_REJECTED reason=\(reason)\n".utf8))
+                    throw ValidationError("provider credential bootstrap rejected the invite: \(reason)")
+                }
                 try await Task.sleep(nanoseconds: 100_000_000)
             }
         } catch {

--- a/phase3-binary/Sources/macprovider-cli/CoordinatorClient.swift
+++ b/phase3-binary/Sources/macprovider-cli/CoordinatorClient.swift
@@ -228,6 +228,11 @@ actor CoordinatorClient {
     private let sendOverride: SendOverride?
     private let streamInterval: Int
     private let credentialBootstrap: Bool
+    // PROD-M2: set when a credential-bootstrap attempt is terminally rejected
+    // for a referral reason (`referral_<token>`). BootstrapAuthCommand polls
+    // this so the installer can surface the specific reason instead of a
+    // generic timeout.
+    private var terminalReferralReason: String?
     private let bootstrapReceiptSigningKey: Curve25519.Signing.PrivateKey?
     private let receiptIdentitySigningKeys: [Curve25519.Signing.PrivateKey]
     private let persistReceiptIdentitySigningKey: (@Sendable (Curve25519.Signing.PrivateKey) throws -> Void)?
@@ -402,6 +407,13 @@ actor CoordinatorClient {
         self.persistReceiptIdentitySigningKey = persistReceiptIdentitySigningKey
     }
 
+    /// PROD-M2: the terminal referral rejection reason (`referral_<token>`)
+    /// observed on a credential-bootstrap attempt, if any. `nil` until a
+    /// referral-coded close terminates the reconnect loop.
+    func terminalReferralRejection() -> String? {
+        terminalReferralReason
+    }
+
     func start() async {
         await runStartupAutoupdateRecovery()
         startReconnectTask()
@@ -560,6 +572,16 @@ actor CoordinatorClient {
                 consecutiveAuthProtocolFailures = 0
             } catch {
                 await cleanupConnection()
+                // PROD-M2: a referral rejection during credential bootstrap is
+                // terminal. Record the specific reason and stop looping so the
+                // bootstrap command surfaces it immediately (no 30s timeout).
+                if credentialBootstrap,
+                   let authError = error as? CoordinatorAuthError,
+                   case .rejected(let code, _) = authError,
+                   code.hasPrefix("referral_") {
+                    terminalReferralReason = code
+                    return
+                }
                 failedAttempts += 1
                 if Self.isFatalAuthProtocolFailure(error) {
                     consecutiveAuthProtocolFailures += 1
@@ -611,7 +633,9 @@ actor CoordinatorClient {
         }
         switch authError {
         case .rejected(let code, _):
-            return code == "invalid_auth_request"
+            // A referral rejection is deterministic — retrying will not help,
+            // so it counts as a fatal auth-protocol failure (PROD-M2).
+            return code == "invalid_auth_request" || code.hasPrefix("referral_")
         case .invalidMessage(let message):
             let lowered = message.lowercased()
             return lowered.contains("auth_request") ||
@@ -1180,6 +1204,16 @@ actor CoordinatorClient {
         case 4000 where reason == "unrecognized auth message":
             return .invalidMessage(reason)
         default:
+            // PROD-M2 / C-1: the coordinator preserves the specific referral
+            // failure token in the WS close reason as `referral_<token>`
+            // (token ∈ missing|invalid|expired|revoked|exhausted). Surface it
+            // verbatim as a rejection so the installer/app can route the user
+            // back to the invite step with the right message instead of
+            // treating it as a generic auth/timeout failure. Accept it on any
+            // close code the coordinator chooses.
+            if reason.hasPrefix("referral_") {
+                return .rejected(code: reason, message: reason)
+            }
             return nil
         }
     }
@@ -1595,6 +1629,10 @@ actor CoordinatorClient {
                 throw CoordinatorAuthError.invalidMessage("credential bootstrap receipt identity unavailable")
             }
             proof["credential_bootstrap"] = true
+            if let referralCode = appConfig.referralCode?.trimmingCharacters(in: .whitespacesAndNewlines),
+               !referralCode.isEmpty {
+                proof["referral_code"] = referralCode
+            }
             let transcriptSHA256 = try Self.initialAuthTranscriptHashBase64(initialMessage)
             let payload = try Self.credentialBootstrapIdentityPayload(
                 challenge: challenge,
@@ -2950,6 +2988,10 @@ actor CoordinatorClient {
         }
         if credentialBootstrap {
             message["credential_bootstrap"] = true
+            if let referralCode = appConfig.referralCode?.trimmingCharacters(in: .whitespacesAndNewlines),
+               !referralCode.isEmpty {
+                message["referral_code"] = referralCode
+            }
         }
         return message
     }
@@ -3004,6 +3046,11 @@ actor CoordinatorClient {
             message["model_hash"] = hashForHello
         }
         appendCatalogAdmissionMetadata(to: &message, wireModelID: wireModelIDForHello)
+        if providerToken == nil,
+           let referralCode = appConfig.referralCode?.trimmingCharacters(in: .whitespacesAndNewlines),
+           !referralCode.isEmpty {
+            message["referral_code"] = referralCode
+        }
         return message
     }
 

--- a/phase3-binary/Sources/macprovider-cli/MacProviderCLI.swift
+++ b/phase3-binary/Sources/macprovider-cli/MacProviderCLI.swift
@@ -494,32 +494,6 @@ struct ServeCommand: AsyncParsableCommand {
         return factory()
     }
 
-    /// Read a provider bearer from an inherited file descriptor. The writer
-    /// (Malibu.app) sends the token bytes and closes its end; we read to EOF
-    /// and trim surrounding whitespace/newlines, mirroring --token-file. The
-    /// fd is never captured by KERN_PROCARGS2, so the bearer stays off both
-    /// argv and the process environment.
-    static func readProviderToken(fromFileDescriptor fd: Int32) throws -> String {
-        guard fd >= 0 else {
-            throw ValidationError("--token-fd must be a non-negative file descriptor")
-        }
-        let handle = FileHandle(fileDescriptor: fd, closeOnDealloc: false)
-        let data: Data
-        do {
-            data = try handle.readToEnd() ?? Data()
-        } catch {
-            throw ValidationError("could not read provider token from --token-fd \(fd): \(error)")
-        }
-        guard let raw = String(data: data, encoding: .utf8) else {
-            throw ValidationError("provider token on --token-fd \(fd) is not valid UTF-8")
-        }
-        let token = raw.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !token.isEmpty else {
-            throw ValidationError("provider token on --token-fd \(fd) was empty")
-        }
-        return token
-    }
-
     func run() async throws {
         var resolved = try ConfigLoader.load(
             cli: CLIOverrides(
@@ -566,9 +540,7 @@ struct ServeCommand: AsyncParsableCommand {
         // snapshot) can no longer read the token. Reading here — after config
         // load — lets the fd win over any env/config value, matching the
         // precedence of --token-file.
-        if let tokenFd {
-            resolved.providerToken = try Self.readProviderToken(fromFileDescriptor: Int32(tokenFd))
-        }
+        try ProviderTokenInput.apply(fileDescriptor: tokenFd, to: &resolved)
 
         // AUDIT R1 SECURITY S2 fix (PR #334): drop MACPROVIDER_PROVIDER_TOKEN
         // from the process env immediately after we've resolved it. Legacy

--- a/phase3-binary/Sources/macprovider-cli/MacProviderCLI.swift
+++ b/phase3-binary/Sources/macprovider-cli/MacProviderCLI.swift
@@ -50,6 +50,9 @@ struct ServeCommand: AsyncParsableCommand {
     @Option(help: "Coordinator WebSocket URL. Overrides MACPROVIDER_COORDINATOR_URL and config file coordinator_url.")
     var coordinator: String?
 
+    @Option(name: [.customLong("ref"), .customLong("referral-code")], help: "Pre-beta referral code used only to obtain the first provider credential. Overrides MACPROVIDER_REFERRAL_CODE and config key referral_code.")
+    var referralCode: String?
+
     @Option(help: "Stable provider identifier sent in the coordinator hello message. Must match the coordinator's config.providers[] entry. Overrides MACPROVIDER_PROVIDER_ID and config file provider_id. If unset, a per-instance UUID is generated (suitable for dev/test only).")
     var providerID: String?
 
@@ -89,6 +92,9 @@ struct ServeCommand: AsyncParsableCommand {
 
     @Option(help: "Read provider authentication token from a 0600 file. Overrides MACPROVIDER_PROVIDER_TOKEN and config key provider_token without exposing the token in process arguments.")
     var tokenFile: String?
+
+    @Option(help: "Read the provider authentication token from an already-open, inherited file descriptor (e.g. --token-fd 0 for stdin). Used by Malibu.app to hand the bearer to the managed CLI without exposing it in argv or the process environment, so it is invisible to KERN_PROCARGS2 inspection. Overrides MACPROVIDER_PROVIDER_TOKEN and config key provider_token.")
+    var tokenFd: Int?
 
     @Option(help: "Marks this binary as spawned by an outer manager (SPEC-025). Setting this to 'malibu-app' disables the CLI's own AutoUpdater so Sparkle in Malibu.app owns whole-bundle updates. Overrides MACPROVIDER_MANAGED_BY and config key managed_by. Unset for the standalone CLI track.")
     var managedBy: String?
@@ -488,6 +494,32 @@ struct ServeCommand: AsyncParsableCommand {
         return factory()
     }
 
+    /// Read a provider bearer from an inherited file descriptor. The writer
+    /// (Malibu.app) sends the token bytes and closes its end; we read to EOF
+    /// and trim surrounding whitespace/newlines, mirroring --token-file. The
+    /// fd is never captured by KERN_PROCARGS2, so the bearer stays off both
+    /// argv and the process environment.
+    static func readProviderToken(fromFileDescriptor fd: Int32) throws -> String {
+        guard fd >= 0 else {
+            throw ValidationError("--token-fd must be a non-negative file descriptor")
+        }
+        let handle = FileHandle(fileDescriptor: fd, closeOnDealloc: false)
+        let data: Data
+        do {
+            data = try handle.readToEnd() ?? Data()
+        } catch {
+            throw ValidationError("could not read provider token from --token-fd \(fd): \(error)")
+        }
+        guard let raw = String(data: data, encoding: .utf8) else {
+            throw ValidationError("provider token on --token-fd \(fd) is not valid UTF-8")
+        }
+        let token = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !token.isEmpty else {
+            throw ValidationError("provider token on --token-fd \(fd) was empty")
+        }
+        return token
+    }
+
     func run() async throws {
         var resolved = try ConfigLoader.load(
             cli: CLIOverrides(
@@ -498,6 +530,7 @@ struct ServeCommand: AsyncParsableCommand {
                 numDraftTokens: numDraftTokens,
                 publishesSpecDecodeTelemetry: publishSpecDecodeTelemetry,
                 coordinatorURL: coordinator,
+                referralCode: referralCode,
                 providerID: providerID,
                 endpointURL: endpointURL,
                 configPath: config,
@@ -526,10 +559,21 @@ struct ServeCommand: AsyncParsableCommand {
             )
         )
 
+        // ADV-C1 fix: when Malibu.app manages this CLI it hands the bearer
+        // through an inherited file descriptor (--token-fd) rather than the
+        // initial environment. Unlike the environment, an fd is never captured
+        // by KERN_PROCARGS2, so a same-user process (or an installer recovery
+        // snapshot) can no longer read the token. Reading here — after config
+        // load — lets the fd win over any env/config value, matching the
+        // precedence of --token-file.
+        if let tokenFd {
+            resolved.providerToken = try Self.readProviderToken(fromFileDescriptor: Int32(tokenFd))
+        }
+
         // AUDIT R1 SECURITY S2 fix (PR #334): drop MACPROVIDER_PROVIDER_TOKEN
-        // from the process env immediately after we've resolved it. Under
-        // Malibu.app the token arrives via env (see SPEC-025 §7 followup:
-        // eventually via Keychain read here). Same-user malware inspecting
+        // from the process env immediately after we've resolved it. Legacy
+        // callers may still pass the token via env; the fd path above is the
+        // supported app-managed transport. Same-user malware inspecting
         // `ps -E <cli-pid>` would otherwise see a payout-bearing bearer token
         // for the lifetime of the process. Config resolution has already
         // captured it into `resolved.providerToken`; the env slot is unused

--- a/phase3-binary/Sources/macprovider-cli/ProviderTokenInput.swift
+++ b/phase3-binary/Sources/macprovider-cli/ProviderTokenInput.swift
@@ -1,0 +1,34 @@
+import ArgumentParser
+import Foundation
+import MacProviderCore
+
+enum ProviderTokenInput {
+    /// Reads a provider bearer from an inherited descriptor. Callers write the
+    /// token bytes and close their end; the credential never enters argv, the
+    /// process environment, or a filesystem-backed token file.
+    static func read(fromFileDescriptor fd: Int32) throws -> String {
+        guard fd >= 0 else {
+            throw ValidationError("--token-fd must be a non-negative file descriptor")
+        }
+        let handle = FileHandle(fileDescriptor: fd, closeOnDealloc: false)
+        let data: Data
+        do {
+            data = try handle.readToEnd() ?? Data()
+        } catch {
+            throw ValidationError("could not read provider token from --token-fd \(fd): \(error)")
+        }
+        guard let raw = String(data: data, encoding: .utf8) else {
+            throw ValidationError("provider token on --token-fd \(fd) is not valid UTF-8")
+        }
+        let token = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !token.isEmpty else {
+            throw ValidationError("provider token on --token-fd \(fd) was empty")
+        }
+        return token
+    }
+
+    static func apply(fileDescriptor: Int?, to config: inout AppConfig) throws {
+        guard let fileDescriptor else { return }
+        config.providerToken = try read(fromFileDescriptor: Int32(fileDescriptor))
+    }
+}

--- a/phase3-binary/Tests/macprovider-cliTests/AutotuneCommandTests.swift
+++ b/phase3-binary/Tests/macprovider-cliTests/AutotuneCommandTests.swift
@@ -154,6 +154,7 @@ final class AutotuneCommandTests: XCTestCase {
             "--freshness-check",
             "--submit-hardware-evidence",
             "--require-hardware-evidence",
+            "--token-fd", "0",
             "--donor-mode",
         ])
 
@@ -161,6 +162,7 @@ final class AutotuneCommandTests: XCTestCase {
         XCTAssertTrue(command.freshnessCheck)
         XCTAssertTrue(command.submitHardwareEvidence)
         XCTAssertTrue(command.requireHardwareEvidence)
+        XCTAssertEqual(command.tokenFd, 0)
         XCTAssertTrue(command.donorMode)
     }
 
@@ -186,6 +188,13 @@ final class AutotuneCommandTests: XCTestCase {
             "--recommend",
             "--require-hardware-evidence",
             "--no-submit-hardware-evidence",
+        ]))
+    }
+
+    func testTokenFDRequiresRecommendation() {
+        XCTAssertThrowsError(try AutotuneCommand.parse([
+            "--token-fd", "0",
+            "--dry-run",
         ]))
     }
 

--- a/phase3-binary/Tests/macprovider-cliTests/CoordinatorClientTests.swift
+++ b/phase3-binary/Tests/macprovider-cliTests/CoordinatorClientTests.swift
@@ -2224,6 +2224,7 @@ final class CoordinatorClientTests: XCTestCase {
             status: status,
             recorder: recorder,
             providerReceiptPublicKey: receiptPublicKey,
+            referralCode: "MAL1-S-k1-seed-AAAAAAAAAAAAAAAAAAAAAAAAAA",
             credentialBootstrap: true,
             bootstrapReceiptSigningKey: receiptKey
         )
@@ -2246,8 +2247,10 @@ final class CoordinatorClientTests: XCTestCase {
 
         XCTAssertNil(hello["credential_bootstrap"])
         XCTAssertEqual(initial["credential_bootstrap"] as? Bool, true)
+        XCTAssertEqual(initial["referral_code"] as? String, "MAL1-S-k1-seed-AAAAAAAAAAAAAAAAAAAAAAAAAA")
         XCTAssertEqual(initial["provider_receipt_public_key"] as? String, receiptPublicKey)
         XCTAssertEqual(proof["credential_bootstrap"] as? Bool, true)
+        XCTAssertEqual(proof["referral_code"] as? String, initial["referral_code"] as? String)
         XCTAssertNotNil(proof["identity_signature"] as? String)
         XCTAssertNotNil(proof["identity_signature_transcript_sha256"] as? String)
     }
@@ -3069,6 +3072,7 @@ final class CoordinatorClientTests: XCTestCase {
         pairingController: PairingController? = nil,
         connectAndRunOverride: (@Sendable () async throws -> Void)? = nil,
         providerReceiptPublicKey: String? = nil,
+        referralCode: String? = nil,
         sendOverride: CoordinatorClient.SendOverride? = nil,
         watchdogExitHook: (@Sendable (String) -> Void)? = nil,
         publishesSpecDecodeTelemetry: Bool = false,
@@ -3092,6 +3096,7 @@ final class CoordinatorClientTests: XCTestCase {
         var config = AppConfig.defaults(configPath: "/tmp/macprovider-test.yaml")
         config.coordinatorURL = "wss://127.0.0.1:8444/ws/provider"
         config.providerID = "provider-test"
+        config.referralCode = referralCode
         config.model = "model-a"
         config.modelCatalogModelID = modelCatalogModelID
         config.drainTimeoutSeconds = drainTimeoutSeconds

--- a/phase3-binary/Tests/macprovider-cliTests/ServeCommandTests.swift
+++ b/phase3-binary/Tests/macprovider-cliTests/ServeCommandTests.swift
@@ -5,6 +5,27 @@ import XCTest
 @testable import macprovider_cli
 
 final class ServeCommandTests: XCTestCase {
+    func testReferralCodeAcceptsShortAndLongOptionNames() throws {
+        let short = try ServeCommand.parse(["--ref", "MAL1-S-k1-seed-AAAAAAAAAAAAAAAAAAAAAAAAAA"])
+        XCTAssertEqual(short.referralCode, "MAL1-S-k1-seed-AAAAAAAAAAAAAAAAAAAAAAAAAA")
+
+        let long = try ServeCommand.parse(["--referral-code", "MAL1-P-k1-issuer-BBBBBBBBBBBBBBBBBBBBBBBBBB"])
+        XCTAssertEqual(long.referralCode, "MAL1-P-k1-issuer-BBBBBBBBBBBBBBBBBBBBBBBBBB")
+    }
+
+    func testProviderTokenCanBeReadFromInheritedFileDescriptor() throws {
+        let pipe = Pipe()
+        try pipe.fileHandleForWriting.write(contentsOf: Data("fd-token\n".utf8))
+        try pipe.fileHandleForWriting.close()
+
+        let token = try ServeCommand.readProviderToken(
+            fromFileDescriptor: pipe.fileHandleForReading.fileDescriptor
+        )
+
+        XCTAssertEqual(token, "fd-token")
+        try pipe.fileHandleForReading.close()
+    }
+
     func testServeCommandRejectsInlineProviderTokenArguments() throws {
         let deprecated = try ServeCommand.parse(["--token", "secret"])
         XCTAssertThrowsError(try ConfigLoader.load(cli: CLIOverrides(providerToken: deprecated.providerToken), environment: [:])) { error in

--- a/phase3-binary/Tests/macprovider-cliTests/ServeCommandTests.swift
+++ b/phase3-binary/Tests/macprovider-cliTests/ServeCommandTests.swift
@@ -18,9 +18,7 @@ final class ServeCommandTests: XCTestCase {
         try pipe.fileHandleForWriting.write(contentsOf: Data("fd-token\n".utf8))
         try pipe.fileHandleForWriting.close()
 
-        let token = try ServeCommand.readProviderToken(
-            fromFileDescriptor: pipe.fileHandleForReading.fileDescriptor
-        )
+        let token = try ProviderTokenInput.read(fromFileDescriptor: pipe.fileHandleForReading.fileDescriptor)
 
         XCTAssertEqual(token, "fd-token")
         try pipe.fileHandleForReading.close()

--- a/phase3-binary/Tests/macprovider-cliTests/ServingKnobsConfigTests.swift
+++ b/phase3-binary/Tests/macprovider-cliTests/ServingKnobsConfigTests.swift
@@ -55,6 +55,24 @@ final class ServingKnobsConfigTests: XCTestCase {
         XCTAssertTrue(config.enableReceipts)
     }
 
+    func testReferralCodeResolutionUsesCLIThenEnvironmentThenYAML() throws {
+        let config = try ConfigLoader.load(
+            cli: CLIOverrides(referralCode: "cli-code"),
+            environment: ["MACPROVIDER_REFERRAL_CODE": "env-code"],
+            fileExists: { _ in true },
+            readFile: { _ in "referral_code: yaml-code\n" }
+        )
+        XCTAssertEqual(config.referralCode, "cli-code")
+
+        let environmentOnly = try ConfigLoader.load(
+            cli: CLIOverrides(),
+            environment: ["MACPROVIDER_REFERRAL_CODE": "env-code"],
+            fileExists: { _ in true },
+            readFile: { _ in "referral_code: yaml-code\n" }
+        )
+        XCTAssertEqual(environmentOnly.referralCode, "env-code")
+    }
+
     // MARK: - --kv-bits
 
     func testKvBitsCLIOverridesEnvironmentOverridesYAML() throws {

--- a/phase3-binary/app/Sources/Malibu/Agent/CLIChildProcess.swift
+++ b/phase3-binary/app/Sources/Malibu/Agent/CLIChildProcess.swift
@@ -11,9 +11,32 @@ final class CLIChildProcess {
         let controlSocketPath: URL
         let httpPort: Int?
         let logFileURL: URL
-        // Merged over an allowlisted parent env. MACPROVIDER_PROVIDER_TOKEN
-        // belongs here so the token never touches config.yaml or argv.
+        // Merged over an allowlisted parent env. The provider bearer is NOT
+        // carried here (see `providerToken`): the environment is captured by
+        // KERN_PROCARGS2 and could be serialized to disk by installer recovery.
         let extraEnvironment: [String: String]
+        // ADV-C1: the provider bearer, handed to the child over an anonymous
+        // stdin pipe (--token-fd 0) so it never appears in argv or the initial
+        // environment and is invisible to same-user KERN_PROCARGS2 inspection.
+        let providerToken: String?
+
+        init(
+            executable: URL,
+            configPath: URL,
+            controlSocketPath: URL,
+            httpPort: Int?,
+            logFileURL: URL,
+            extraEnvironment: [String: String] = [:],
+            providerToken: String? = nil
+        ) {
+            self.executable = executable
+            self.configPath = configPath
+            self.controlSocketPath = controlSocketPath
+            self.httpPort = httpPort
+            self.logFileURL = logFileURL
+            self.extraEnvironment = extraEnvironment
+            self.providerToken = providerToken
+        }
     }
 
     private let launch: Launch
@@ -49,23 +72,21 @@ final class CLIChildProcess {
 
         let proc = Process()
         proc.executableURL = launch.executable
-        // Flag names must match phase3-binary/Sources/macprovider-cli/MacProviderCLI.swift
-        // (ArgumentParser derives kebab-case from the camelCase @Option name).
-        //
-        // --enable-warm-swap is required: the CLI only opens the control socket when
-        // warm-swap is enabled (see ServeCommand comment on `enableWarmSwap`).
-        var args = [
-            "--config", launch.configPath.path,
-            "--ctl-socket-path", launch.controlSocketPath.path,
-            "--enable-warm-swap",
-            "--managed-by", "malibu-app"
-        ]
-        if let port = launch.httpPort {
-            args.append(contentsOf: ["--port", "\(port)"])
-        }
-        proc.arguments = args
+        proc.arguments = Self.buildArguments(launch: launch)
 
         proc.environment = try ProcessEnvironmentSanitizer.sanitized(extraEnvironment: launch.extraEnvironment)
+
+        // ADV-C1: deliver the bearer over an anonymous stdin pipe. The read end
+        // becomes the child's fd 0 (--token-fd 0); we write the token to the
+        // write end after launch and close it so the CLI reads it to EOF. The
+        // pipe is not part of argv or the environment, so KERN_PROCARGS2 (and
+        // therefore installer recovery snapshots) never see the token.
+        var tokenPipe: Pipe?
+        if let token = launch.providerToken, !token.isEmpty {
+            let pipe = Pipe()
+            proc.standardInput = pipe.fileHandleForReading
+            tokenPipe = pipe
+        }
 
         proc.standardOutput = handle
         proc.standardError = handle
@@ -85,6 +106,40 @@ final class CLIChildProcess {
 
         try proc.run()
         process = proc
+
+        // Write the bearer to the child's stdin and close our end so the CLI
+        // sees EOF. Done after run() so the read end is already dup'd into the
+        // child; closing the read end here (it lives on in the child) avoids
+        // leaking the fd into our own process.
+        if let tokenPipe, let token = launch.providerToken {
+            let writer = tokenPipe.fileHandleForWriting
+            try? writer.write(contentsOf: Data(token.utf8))
+            try? writer.close()
+            try? tokenPipe.fileHandleForReading.close()
+        }
+    }
+
+    /// Build the CLI argument vector. Flag names must match
+    /// phase3-binary/Sources/macprovider-cli/MacProviderCLI.swift (ArgumentParser
+    /// derives kebab-case from the camelCase @Option name).
+    ///
+    /// --enable-warm-swap is required: the CLI only opens the control socket when
+    /// warm-swap is enabled (see ServeCommand comment on `enableWarmSwap`).
+    /// --token-fd 0 is appended when a bearer is supplied over the stdin pipe.
+    static func buildArguments(launch: Launch) -> [String] {
+        var args = [
+            "--config", launch.configPath.path,
+            "--ctl-socket-path", launch.controlSocketPath.path,
+            "--enable-warm-swap",
+            "--managed-by", "malibu-app"
+        ]
+        if let port = launch.httpPort {
+            args.append(contentsOf: ["--port", "\(port)"])
+        }
+        if let token = launch.providerToken, !token.isEmpty {
+            args.append(contentsOf: ["--token-fd", "0"])
+        }
+        return args
     }
 
     func stop(gracePeriod: TimeInterval) async {

--- a/phase3-binary/app/Sources/Malibu/Agent/MalibuAgent.swift
+++ b/phase3-binary/app/Sources/Malibu/Agent/MalibuAgent.swift
@@ -42,6 +42,7 @@ final class MalibuAgent: ObservableObject {
     private var isShuttingDown: Bool = false
     private var healthPollTask: Task<Void, Never>?
     private var monitorsLaunchdProvider = false
+    private var managedStartFailureIsPermanent = false
     private var lastRequestsRateSample: (total: Int, date: Date)?
     private var latestReleaseFetchedAt: Date?
     private var cliUpdateTask: Task<Void, Never>?
@@ -77,16 +78,15 @@ final class MalibuAgent: ObservableObject {
             return
         }
 
-        // Release any Malibu-spawned CLI from older builds before attaching to launchd.
-        await releaseSpawnedChildForLaunchdMonitor()
-
-        snapshot.state = .starting
-        startProviderLogTail()
-        if await monitorInstalledProviderIfPresent() {
+        // App-owned identities keep their bearer in Keychain, never in config.yaml
+        // or a launchd plist. Run the provider as Malibu's child so the bearer is
+        // supplied over an anonymous stdin pipe (--token-fd 0) — never argv or the
+        // initial environment — so KERN_PROCARGS2 inspection cannot recover it.
+        if await startManagedProvider() {
             return
         }
 
-        if let failure = providerStartFailure {
+        if let failure = providerStartFailure, managedStartFailureIsPermanent {
             snapshot.state = .error
             snapshot.lastError = failure
             return
@@ -105,6 +105,106 @@ final class MalibuAgent: ObservableObject {
             logHint: ProviderLogDiagnostics.logHint()
         )
         await scheduleReconnect()
+    }
+
+    /// Start an app-owned provider with the Keychain bearer. This is also the
+    /// repair path after install.sh refreshes an existing app-managed install:
+    /// unlike launchd, this child receives the bearer without persisting it.
+    @discardableResult
+    func startManagedProvider(
+        timeout: TimeInterval = MalibuOnboardingTimeouts.firstServingFrameSec
+    ) async -> Bool {
+        managedStartFailureIsPermanent = false
+        guard !isShuttingDown,
+              let providerID = ProviderConfig.readProviderID(),
+              let port = ProviderConfig.readHTTPPort(),
+              await ProviderConfig.isConfigured,
+              let bearer = await KeychainStore.readProviderToken(providerID: providerID),
+              !bearer.isEmpty else {
+            managedStartFailureIsPermanent = true
+            providerStartFailure = "The app-managed provider credential is unavailable. Re-import the provider identity and try again."
+            snapshot.state = .error
+            snapshot.lastError = providerStartFailure
+            return false
+        }
+
+        providerStartFailure = nil
+        reconnectTask?.cancel()
+        reconnectTask = nil
+        healthPollTask?.cancel()
+        healthPollTask = nil
+        monitorsLaunchdProvider = false
+        await stopManagedChildForRestart()
+        guard await Self.bootoutLaunchdProvider(port: port) else {
+            providerStartFailure = "Could not release the background provider before app-managed startup. Malibu will retry."
+            snapshot.state = .reconnecting
+            snapshot.lastError = providerStartFailure
+            return false
+        }
+        guard !isShuttingDown else { return false }
+
+        let paths = ProviderPaths.current
+        do {
+            try paths.ensureDirectories()
+            try? FileManager.default.removeItem(at: paths.controlSocket)
+            let managed = CLIChildProcess(
+                launch: .init(
+                    executable: try CLIUpdateRunner.resolveExecutableURL(),
+                    configPath: paths.configFile,
+                    controlSocketPath: paths.controlSocket,
+                    httpPort: port,
+                    logFileURL: paths.cliLogFile,
+                    // ADV-C1: the bearer travels over an anonymous stdin pipe
+                    // (--token-fd 0), never the child's initial environment,
+                    // so it cannot be read from KERN_PROCARGS2 or captured by
+                    // an installer recovery snapshot.
+                    providerToken: bearer
+                )
+            )
+            managed.onUnexpectedExit = { [weak self] code in
+                Task { @MainActor in
+                    await self?.handleUnexpectedChildExit(code: code)
+                }
+            }
+            child = managed
+            snapshot.state = .starting
+            snapshot.lastError = nil
+            startProviderLogTail()
+            try managed.start()
+        } catch {
+            child = nil
+            providerStartFailure = "Could not start the app-managed provider: \(error.localizedDescription)"
+            snapshot.state = .error
+            snapshot.lastError = providerStartFailure
+            return false
+        }
+
+        let deadline = Date().addingTimeInterval(max(1, timeout))
+        while Date() < deadline, !isShuttingDown, child != nil {
+            if await InstalledProviderMonitor.isHealthy(port: port) {
+                await connectControl(socketPath: paths.controlSocket.path)
+                guard child != nil, !isShuttingDown else { return false }
+                await applyProviderSnapshot(port: port)
+                startHealthPolling(port: port)
+                await refreshEarnings()
+                providerStartFailure = nil
+                return snapshot.state == .serving
+            }
+            let remaining = deadline.timeIntervalSinceNow
+            guard remaining > 0 else { break }
+            try? await Task.sleep(
+                nanoseconds: UInt64(min(1, remaining) * 1_000_000_000)
+            )
+        }
+
+        guard !isShuttingDown else { return false }
+        let failure = diagnosedProviderFailure()
+            ?? ProviderLogDiagnostics.timeoutMessage(logHint: ProviderLogDiagnostics.logHint())
+        providerStartFailure = failure
+        snapshot.state = .error
+        snapshot.lastError = failure
+        await stopManagedChildForRestart()
+        return false
     }
 
     // AUDIT R1 ARCHITECT A1: don't flip state until the CLI acks. If the CLI
@@ -242,6 +342,83 @@ final class MalibuAgent: ObservableObject {
         await control?.close()
         child = nil
         control = nil
+    }
+
+    private func stopManagedChildForRestart() async {
+        guard child != nil || control != nil else { return }
+        child?.markStopping()
+        try? await control?.send(.shutdownRequest(graceSeconds: 5))
+        await child?.stop(gracePeriod: 5)
+        metricsPoller?.cancel()
+        metricsPoller = nil
+        eventStreamTask?.cancel()
+        eventStreamTask = nil
+        await control?.close()
+        child = nil
+        control = nil
+    }
+
+    private func handleUnexpectedChildExit(code: Int32) async {
+        guard !isShuttingDown else { return }
+        child = nil
+        metricsPoller?.cancel()
+        metricsPoller = nil
+        eventStreamTask?.cancel()
+        eventStreamTask = nil
+        await control?.close()
+        control = nil
+        snapshot.state = .reconnecting
+        snapshot.lastError = "Provider exited unexpectedly (status \(code)). Reconnecting…"
+        await scheduleReconnect()
+    }
+
+    private static func bootoutLaunchdProvider(port: Int) async -> Bool {
+        let plist = FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent("Library/LaunchAgents/live.streamvc.macprovider.plist")
+        let uid = getuid()
+        _ = await processStatus(
+            executable: "/bin/launchctl",
+            arguments: ["bootout", "gui/\(uid)/live.streamvc.macprovider"]
+        )
+        if FileManager.default.fileExists(atPath: plist.path) {
+            _ = await processStatus(
+                executable: "/bin/launchctl",
+                arguments: ["bootout", "gui/\(uid)", plist.path]
+            )
+        }
+        let deadline = Date().addingTimeInterval(10)
+        while Date() < deadline {
+            let jobLoaded = await processStatus(
+                executable: "/bin/launchctl",
+                arguments: ["print", "gui/\(uid)/live.streamvc.macprovider"]
+            ) == 0
+            let portOwned = await processStatus(
+                executable: "/usr/sbin/lsof",
+                arguments: ["-nP", "-iTCP:\(port)", "-sTCP:LISTEN", "-t"]
+            ) == 0
+            if !jobLoaded && !portOwned { return true }
+            try? await Task.sleep(nanoseconds: 250_000_000)
+        }
+        return false
+    }
+
+    private static func processStatus(executable: String, arguments: [String]) async -> Int32 {
+        await withCheckedContinuation { (continuation: CheckedContinuation<Int32, Never>) in
+            DispatchQueue.global(qos: .utility).async {
+                let process = Process()
+                process.executableURL = URL(fileURLWithPath: executable)
+                process.arguments = arguments
+                process.standardOutput = FileHandle.nullDevice
+                process.standardError = FileHandle.nullDevice
+                do {
+                    try process.run()
+                    process.waitUntilExit()
+                    continuation.resume(returning: process.terminationStatus)
+                } catch {
+                    continuation.resume(returning: -1)
+                }
+            }
+        }
     }
 
     private func applyProviderSnapshot(port: Int) async {
@@ -401,6 +578,15 @@ final class MalibuAgent: ObservableObject {
                             )
                         }
                     }
+                } else if self.child != nil {
+                    await MainActor.run {
+                        self.snapshot.state = .reconnecting
+                        self.snapshot.lastError = ProviderLogDiagnostics.timeoutMessage(
+                            logHint: ProviderLogDiagnostics.logHint()
+                        )
+                    }
+                    await self.stopManagedChildForRestart()
+                    await self.scheduleReconnect()
                 }
             }
         }

--- a/phase3-binary/app/Sources/Malibu/Onboarding/CLIInstallRunner.swift
+++ b/phase3-binary/app/Sources/Malibu/Onboarding/CLIInstallRunner.swift
@@ -22,10 +22,20 @@ enum CLIInstallRunner {
 
     /// Invokes `install.sh` with `MACPROVIDER_NO_PROMPT=1`. Delivers stdout/stderr
     /// lines to `onLogLine` on the main actor.
-    static func run(onLogLine: @escaping @MainActor (String) -> Void) async throws {
+    static func run(referralCode: String, onLogLine: @escaping @MainActor (String) -> Void) async throws {
         let scriptURL = try resolveInstallScriptURL()
         let runnableURL = try materializeRunnableScript(from: scriptURL)
         let installPort = resolveInstallPort()
+        let existingProviderToken: String?
+        if let providerID = ProviderConfig.readProviderID() {
+            existingProviderToken = await KeychainStore.readProviderToken(providerID: providerID)
+        } else {
+            existingProviderToken = nil
+        }
+        // Only a durable Keychain bearer authorizes app-managed repair. A
+        // marker/provider_id without that bearer is routed to the explicit
+        // missing-credential guard instead of attempting automatic recovery.
+        let appManagedRepair = existingProviderToken?.isEmpty == false
         if let installPort {
             await onLogLine("[macprovider-install] Using local HTTP port \(installPort) for provider install.")
         }
@@ -39,16 +49,13 @@ enum CLIInstallRunner {
                 process.standardOutput = stdout
                 process.standardError = stderr
 
-                var environment = ProcessInfo.processInfo.environment
-                environment["MACPROVIDER_NO_PROMPT"] = "1"
-                environment["HOME"] = NSHomeDirectory()
-                if let installPort {
-                    environment["MACPROVIDER_PORT"] = String(installPort)
-                }
-                if environment["PATH"]?.isEmpty != false {
-                    environment["PATH"] = "/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"
-                }
-                process.environment = environment
+                process.environment = installerEnvironment(
+                    base: ProcessInfo.processInfo.environment,
+                    referralCode: referralCode,
+                    appManagedRepair: appManagedRepair,
+                    installPort: installPort,
+                    home: NSHomeDirectory()
+                )
 
                 let emit: (Pipe) -> Void = { pipe in
                     pipe.fileHandleForReading.readabilityHandler = { handle in
@@ -84,6 +91,34 @@ enum CLIInstallRunner {
         // uncommitted and triggers rollback. A healthy local process may be
         // the restored previous release, so it cannot prove this install won.
         throw Error.nonZeroExit(exitCode)
+    }
+
+    static func installerEnvironment(
+        base: [String: String],
+        referralCode: String,
+        appManagedRepair: Bool,
+        installPort: Int?,
+        home: String
+    ) -> [String: String] {
+        var environment = base
+        environment["MACPROVIDER_NO_PROMPT"] = "1"
+        environment["MACPROVIDER_REFERRAL_CODE"] = referralCode
+        environment.removeValue(forKey: "MACPROVIDER_PROVIDER_TOKEN")
+        environment.removeValue(forKey: "MACPROVIDER_APP_MANAGED_REPAIR")
+        if appManagedRepair {
+            // Deliberately non-secret: the Keychain bearer is reserved for
+            // Malibu's sanitized serving child and never enters the installer
+            // or any of its subprocesses.
+            environment["MACPROVIDER_APP_MANAGED_REPAIR"] = "1"
+        }
+        environment["HOME"] = home
+        if let installPort {
+            environment["MACPROVIDER_PORT"] = String(installPort)
+        }
+        if environment["PATH"]?.isEmpty != false {
+            environment["PATH"] = "/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"
+        }
+        return environment
     }
 
     /// Reports whether an already-installed provider is locally healthy. This

--- a/phase3-binary/app/Sources/Malibu/Onboarding/CLIInstallRunner.swift
+++ b/phase3-binary/app/Sources/Malibu/Onboarding/CLIInstallRunner.swift
@@ -45,9 +45,19 @@ enum CLIInstallRunner {
                 let stdout = Pipe()
                 let stderr = Pipe()
                 process.executableURL = URL(fileURLWithPath: "/bin/bash")
-                process.arguments = [runnableURL.path]
+                process.arguments = installerArguments(
+                    scriptPath: runnableURL.path,
+                    appManagedRepair: appManagedRepair
+                )
                 process.standardOutput = stdout
                 process.standardError = stderr
+
+                var providerTokenPipe: Pipe?
+                if appManagedRepair, existingProviderToken?.isEmpty == false {
+                    let pipe = Pipe()
+                    process.standardInput = pipe.fileHandleForReading
+                    providerTokenPipe = pipe
+                }
 
                 process.environment = installerEnvironment(
                     base: ProcessInfo.processInfo.environment,
@@ -74,7 +84,19 @@ enum CLIInstallRunner {
 
                 do {
                     try process.run()
+                    if let providerTokenPipe, let existingProviderToken {
+                        try providerTokenPipe.fileHandleForWriting.write(contentsOf: Data(existingProviderToken.utf8))
+                        try providerTokenPipe.fileHandleForWriting.close()
+                        try providerTokenPipe.fileHandleForReading.close()
+                    }
                 } catch {
+                    try? providerTokenPipe?.fileHandleForWriting.close()
+                    try? providerTokenPipe?.fileHandleForReading.close()
+                    if process.isRunning {
+                        process.terminate()
+                    }
+                    stdout.fileHandleForReading.readabilityHandler = nil
+                    stderr.fileHandleForReading.readabilityHandler = nil
                     continuation.resume(throwing: Error.launchFailed(error.localizedDescription))
                     return
                 }
@@ -93,6 +115,16 @@ enum CLIInstallRunner {
         throw Error.nonZeroExit(exitCode)
     }
 
+    static func installerArguments(scriptPath: String, appManagedRepair: Bool) -> [String] {
+        var arguments = [scriptPath]
+        if appManagedRepair {
+            // The descriptor number is non-secret. The Keychain bearer itself
+            // is written through the anonymous stdin pipe after launch.
+            arguments.append(contentsOf: ["--provider-token-fd", "0"])
+        }
+        return arguments
+    }
+
     static func installerEnvironment(
         base: [String: String],
         referralCode: String,
@@ -106,9 +138,8 @@ enum CLIInstallRunner {
         environment.removeValue(forKey: "MACPROVIDER_PROVIDER_TOKEN")
         environment.removeValue(forKey: "MACPROVIDER_APP_MANAGED_REPAIR")
         if appManagedRepair {
-            // Deliberately non-secret: the Keychain bearer is reserved for
-            // Malibu's sanitized serving child and never enters the installer
-            // or any of its subprocesses.
+            // Deliberately non-secret. The Keychain bearer is delivered over
+            // the installer's inherited stdin descriptor, not its environment.
             environment["MACPROVIDER_APP_MANAGED_REPAIR"] = "1"
         }
         environment["HOME"] = home

--- a/phase3-binary/app/Sources/Malibu/Onboarding/LaunchProviderController.swift
+++ b/phase3-binary/app/Sources/Malibu/Onboarding/LaunchProviderController.swift
@@ -4,11 +4,42 @@ struct ReferralPreflightResult: Decodable, Equatable {
     let valid: Bool
     let reason: String
     let required: Bool
+    let requestAccessURL: URL?
 
-    init(valid: Bool, reason: String, required: Bool = true) {
+    private enum CodingKeys: String, CodingKey {
+        case valid
+        case reason
+        case required
+        case requestAccessURL = "request_access_url"
+    }
+
+    init(valid: Bool, reason: String, required: Bool = true, requestAccessURL: URL? = nil) {
         self.valid = valid
         self.reason = reason
         self.required = required
+        self.requestAccessURL = Self.validRequestAccessURL(requestAccessURL?.absoluteString)
+    }
+
+    init(from decoder: Decoder) throws {
+        let values = try decoder.container(keyedBy: CodingKeys.self)
+        valid = try values.decode(Bool.self, forKey: .valid)
+        reason = try values.decode(String.self, forKey: .reason)
+        required = try values.decode(Bool.self, forKey: .required)
+        requestAccessURL = Self.validRequestAccessURL(
+            try values.decodeIfPresent(String.self, forKey: .requestAccessURL)
+        )
+    }
+
+    private static func validRequestAccessURL(_ raw: String?) -> URL? {
+        guard let raw,
+              let components = URLComponents(string: raw),
+              components.scheme?.lowercased() == "https",
+              components.host?.isEmpty == false,
+              components.user == nil,
+              components.password == nil else {
+            return nil
+        }
+        return components.url
     }
 }
 
@@ -45,11 +76,10 @@ final class LaunchProviderController: ObservableObject {
         case existingIdentityMissingBearer(providerID: String)
     }
 
-    // PROD-M3: three-valued referral policy. `.unknown` (policy discovery
-    // failed) must NOT masquerade as `.required`: it lets the authoritative
-    // registration decide and only re-gates if the server rejects with
-    // `referral_required`. `.required` is the pre-discovery default so a fresh
-    // launch before discovery still fails closed.
+    // PROD-M3: three-valued referral policy. `.unknown` (policy discovery in
+    // flight or unavailable) must NOT masquerade as `.required`: it lets the
+    // authoritative registration decide and only re-gates if the server
+    // rejects with `referral_required`.
     enum ReferralPolicy: Equatable {
         case required
         case optional
@@ -57,7 +87,8 @@ final class LaunchProviderController: ObservableObject {
     }
 
     // PROD-M6: details of an identity just retired via "Start New", surfaced so
-    // the UI can name what was archived, where, and offer a session-scoped undo.
+    // the UI can name what was archived, where, and offer a session-scoped
+    // local-file restore without promising credential or serving recovery.
     struct RetiredIdentity: Equatable {
         let providerID: String
         let archiveURL: URL
@@ -70,7 +101,9 @@ final class LaunchProviderController: ObservableObject {
     @Published private(set) var installProgressHint: String?
     @Published private(set) var installStartedAt: Date?
     @Published var referralCode = ""
-    @Published private(set) var referralPolicy: ReferralPolicy = .required
+    @Published private(set) var referralPolicy: ReferralPolicy = .unknown
+    @Published private(set) var isDiscoveringReferralPolicy = false
+    @Published private(set) var requestAccessURL: URL?
     @Published private(set) var retiredIdentity: RetiredIdentity?
 
     /// True only when an invite is known to be mandatory. `.unknown` and
@@ -104,11 +137,11 @@ final class LaunchProviderController: ObservableObject {
         }
         var readProviderID: @MainActor () -> String? = { ProviderConfig.readProviderID() }
         // PROD-M6: returns the archive directory so the UI can show where the
-        // retired identity went and offer an undo.
+        // retired identity went and offer a local-file restore.
         var moveAppOwnedConfigAside: @MainActor () async throws -> URL? = {
             try ProviderConfig.startFreshMovingCLIConfigAside()
         }
-        var restoreArchivedIdentity: @MainActor (URL) async throws -> Void = { archive in
+        var restoreArchivedFiles: @MainActor (URL) async throws -> Void = { archive in
             try ProviderConfig.restoreArchivedIdentity(from: archive)
         }
 
@@ -126,8 +159,11 @@ final class LaunchProviderController: ObservableObject {
                     request.setValue("application/json", forHTTPHeaderField: "Accept")
                     request.httpBody = try JSONEncoder().encode(["code": code])
                     let configuration = URLSessionConfiguration.ephemeral
-                    configuration.timeoutIntervalForRequest = 6
-                    configuration.timeoutIntervalForResource = 8
+                    // Policy discovery is advisory and must never hold the
+                    // onboarding screen indefinitely. These URLSession bounds
+                    // cover connection establishment and the complete request.
+                    configuration.timeoutIntervalForRequest = LaunchProviderController.referralPolicyRequestTimeout
+                    configuration.timeoutIntervalForResource = LaunchProviderController.referralPolicyResourceTimeout
                     let session = URLSession(configuration: configuration)
                     defer { session.finishTasksAndInvalidate() }
                     let (data, response) = try await session.data(for: request)
@@ -183,19 +219,25 @@ final class LaunchProviderController: ObservableObject {
     // segment after "/j/") or a bare code.
     static func extractReferralCode(_ raw: String) -> String {
         let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard let marker = trimmed.range(of: "/j/") else {
+        guard let components = URLComponents(string: trimmed), components.scheme != nil else {
             return trimmed
         }
-        let tail = trimmed[marker.upperBound...]
-        let code = tail.prefix { $0 != "/" && $0 != "?" && $0 != "#" }
-        return String(code)
+        guard components.scheme?.lowercased() == "https",
+              components.host?.isEmpty == false,
+              components.user == nil,
+              components.password == nil,
+              !components.path.hasSuffix("//") else {
+            return trimmed
+        }
+        let path = components.path.split(separator: "/", omittingEmptySubsequences: true)
+        guard path.count >= 2, path[path.count - 2] == "j" else {
+            return trimmed
+        }
+        return String(path[path.count - 1])
     }
 
-    // PROD-M6: a lightweight, non-authorizing way for a user without a working
-    // inviter to ask for access. This does NOT grant registration — it is a
-    // waitlist/support entry point. The Go branded join pages (A6) link to the
-    // same destination; keep them in sync.
-    static let requestAccessURL = URL(string: "https://malibu.tech/request-access")!
+    static let referralPolicyRequestTimeout: TimeInterval = 6
+    static let referralPolicyResourceTimeout: TimeInterval = 8
 
     static func isValidReferralCode(_ raw: String) -> Bool {
         raw.range(
@@ -222,17 +264,22 @@ final class LaunchProviderController: ObservableObject {
     func refreshReferralPolicy() async {
         if await dependencies.appIdentityConfigured() {
             referralPolicy = .optional
+            requestAccessURL = nil
             return
         }
+        isDiscoveringReferralPolicy = true
+        defer { isDiscoveringReferralPolicy = false }
         do {
             let result = try await dependencies.validateReferralCode("")
             referralPolicy = result.required ? .required : .optional
+            requestAccessURL = result.requestAccessURL
         } catch {
             // PROD-M3: policy discovery failed → UNKNOWN, not required. Let the
             // authoritative registration decide; B8 re-gates only if the server
             // rejects with referral_required. Mirrors the installer's advisory
             // treatment of /v1/referrals/validate.
             referralPolicy = .unknown
+            requestAccessURL = nil
         }
     }
 
@@ -255,8 +302,8 @@ final class LaunchProviderController: ObservableObject {
     // PROD-H6 (b): explicit destructive escape hatch. Move the app-owned
     // config aside so a genuinely fresh provider can be created, then return to
     // the normal invite flow. PROD-M6: capture the archive location and provider
-    // id so the UI can name what was retired and offer an undo — the caller is
-    // expected to have confirmed the destructive action first.
+    // id so the UI can name what was retired and offer a local-file restore —
+    // the caller is expected to have confirmed the destructive action first.
     func startAsNewProvider() async {
         let providerID = dependencies.readProviderID() ?? ""
         do {
@@ -281,18 +328,19 @@ final class LaunchProviderController: ObservableObject {
         await refreshReferralPolicy()
     }
 
-    // PROD-M6: undo a just-performed "Start New" while the archive still exists,
-    // restoring the retired identity bundle in place. Refuses (surfaces the
-    // error) if a replacement identity was already created over it.
-    func undoStartAsNewProvider() async {
+    // PROD-M6: restore local files from a just-performed "Start New" while the
+    // archive still exists. This cannot recreate a missing Keychain bearer,
+    // restore coordinator authority, or resume serving. Refuses (surfaces the
+    // error) if a replacement identity was already created over the files.
+    func restoreRetiredProviderFiles() async {
         guard let retired = retiredIdentity else { return }
         do {
-            try await dependencies.restoreArchivedIdentity(retired.archiveURL)
+            try await dependencies.restoreArchivedFiles(retired.archiveURL)
         } catch {
             stage = .failed(
                 stage: "startFresh",
                 retryable: true,
-                message: "Could not restore the retired provider: \(error.localizedDescription)"
+                message: "Could not restore the archived provider files: \(error.localizedDescription)"
             )
             return
         }
@@ -345,6 +393,7 @@ final class LaunchProviderController: ObservableObject {
         if !existingIdentity && referralPolicy != .optional {
             do {
                 let result = try await dependencies.validateReferralCode(normalizedReferralCode)
+                requestAccessURL = result.requestAccessURL
                 if result.required {
                     referralPolicy = .required
                 }
@@ -426,12 +475,12 @@ final class LaunchProviderController: ObservableObject {
         // exists but cannot be used routes the user to swap it.
         case "expired": return "This invite has expired. Use a different invite."
         case "revoked": return "This invite is no longer available. Use a different invite."
-        case "exhausted": return "This invite has already been used. Use a different invite."
+        case "exhausted": return "All spots on this invite are taken. Use a different invite."
         // PROD-M4: `required` is normalized to `missing` upstream, but map it
         // here too so any direct preflight `required` reason renders the same
         // mandatory-invite copy rather than the generic fallback. There is no
         // code to swap, so the copy asks for one instead.
-        case "missing", "required": return "An invite code is required. Enter a new invite code."
+        case "missing", "required": return "An invite is required. Enter an invite code or link."
         default: return "This invite is not valid. Use a different invite."
         }
     }

--- a/phase3-binary/app/Sources/Malibu/Onboarding/LaunchProviderController.swift
+++ b/phase3-binary/app/Sources/Malibu/Onboarding/LaunchProviderController.swift
@@ -1,7 +1,28 @@
 import Foundation
 
-// Malibu is a CLI wrapper: onboarding runs install.sh, then Malibu monitors
-// the launchd-managed macprovider-cli. No in-app register/autotune/spawn path.
+struct ReferralPreflightResult: Decodable, Equatable {
+    let valid: Bool
+    let reason: String
+    let required: Bool
+
+    init(valid: Bool, reason: String, required: Bool = true) {
+        self.valid = valid
+        self.reason = reason
+        self.required = required
+    }
+}
+
+private enum ReferralPreflightError: LocalizedError {
+    case unavailable
+
+    var errorDescription: String? {
+        "Malibu could not check this invite. Check your connection and try again."
+    }
+}
+
+// Malibu is a CLI wrapper: onboarding runs install.sh. Fresh installs use the
+// launchd bootstrap long enough to import the issued identity; app-owned
+// identities then run as a Malibu child so their bearer remains in Keychain.
 
 @MainActor
 final class LaunchProviderController: ObservableObject {
@@ -18,20 +39,56 @@ final class LaunchProviderController: ObservableObject {
         case importingProviderIdentity
         case live(model: String, tier: TrustTier)
         case failed(stage: String, retryable: Bool, message: String)
+        // PROD-H6: an app-owned identity exists but its Keychain bearer is
+        // gone. Offer recovery or an explicit destructive "start fresh"
+        // instead of silently asking for a new invite.
+        case existingIdentityMissingBearer(providerID: String)
+    }
+
+    // PROD-M3: three-valued referral policy. `.unknown` (policy discovery
+    // failed) must NOT masquerade as `.required`: it lets the authoritative
+    // registration decide and only re-gates if the server rejects with
+    // `referral_required`. `.required` is the pre-discovery default so a fresh
+    // launch before discovery still fails closed.
+    enum ReferralPolicy: Equatable {
+        case required
+        case optional
+        case unknown
+    }
+
+    // PROD-M6: details of an identity just retired via "Start New", surfaced so
+    // the UI can name what was archived, where, and offer a session-scoped undo.
+    struct RetiredIdentity: Equatable {
+        let providerID: String
+        let archiveURL: URL
+        let retiredAt: Date
+        var archivePath: String { archiveURL.path }
     }
 
     @Published private(set) var stage: Stage = .idle
     @Published private(set) var installLogLines: [String] = []
     @Published private(set) var installProgressHint: String?
     @Published private(set) var installStartedAt: Date?
+    @Published var referralCode = ""
+    @Published private(set) var referralPolicy: ReferralPolicy = .required
+    @Published private(set) var retiredIdentity: RetiredIdentity?
+
+    /// True only when an invite is known to be mandatory. `.unknown` and
+    /// `.optional` are both non-blocking at the UI — the server enforces.
+    var referralRequired: Bool { referralPolicy == .required }
+
+    /// Show the invite field whenever an invite may still be needed, i.e. when
+    /// required or when policy discovery hasn't confirmed it is optional.
+    var showsReferralField: Bool { referralPolicy != .optional }
 
     private var installProgressTask: Task<Void, Never>?
     private let dependencies: Dependencies
 
     struct Dependencies {
         var localInstallSucceeded: @MainActor () async -> Bool
+        var validateReferralCode: @MainActor (String) async throws -> ReferralPreflightResult
         var registerLoginItem: @MainActor () async throws -> Void
-        var runCLIInstall: @MainActor (@escaping @MainActor (String) -> Void) async throws -> Void
+        var runCLIInstall: @MainActor (String, @escaping @MainActor (String) -> Void) async throws -> Void
         var importCLIConfigAfterInstall: @MainActor () async throws -> Void
         var waitForInstalledProviderHealth: @MainActor () async -> Bool
         var attachInstalledProviderAfterInstall: @MainActor () async -> Bool
@@ -39,13 +96,49 @@ final class LaunchProviderController: ObservableObject {
         var providerStartFailure: @MainActor () -> String?
         var appIdentityConfigured: @MainActor () async -> Bool
         var waitBeforeImportRetry: @MainActor () async throws -> Void
+        // PROD-H6: detect an app-owned identity whose Keychain bearer is gone,
+        // read its provider_id, and move the app-owned config aside for an
+        // explicit "start fresh". Defaulted so existing callers/tests compile.
+        var existingIdentityMissingBearer: @MainActor () async -> Bool = {
+            await ProviderConfig.existingIdentityMissingBearer()
+        }
+        var readProviderID: @MainActor () -> String? = { ProviderConfig.readProviderID() }
+        // PROD-M6: returns the archive directory so the UI can show where the
+        // retired identity went and offer an undo.
+        var moveAppOwnedConfigAside: @MainActor () async throws -> URL? = {
+            try ProviderConfig.startFreshMovingCLIConfigAside()
+        }
+        var restoreArchivedIdentity: @MainActor (URL) async throws -> Void = { archive in
+            try ProviderConfig.restoreArchivedIdentity(from: archive)
+        }
 
         static func live(agent: MalibuAgent?) -> Dependencies {
             Dependencies(
                 localInstallSucceeded: { await CLIInstallRunner.localInstallSucceeded() },
+                validateReferralCode: { code in
+                    guard let baseURL = ProviderConfig.readCoordinatorBaseURL()
+                        ?? URL(string: "https://coordinator.streamvc.live") else {
+                        throw ReferralPreflightError.unavailable
+                    }
+                    var request = URLRequest(url: baseURL.appendingPathComponent("v1/referrals/validate"))
+                    request.httpMethod = "POST"
+                    request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+                    request.setValue("application/json", forHTTPHeaderField: "Accept")
+                    request.httpBody = try JSONEncoder().encode(["code": code])
+                    let configuration = URLSessionConfiguration.ephemeral
+                    configuration.timeoutIntervalForRequest = 6
+                    configuration.timeoutIntervalForResource = 8
+                    let session = URLSession(configuration: configuration)
+                    defer { session.finishTasksAndInvalidate() }
+                    let (data, response) = try await session.data(for: request)
+                    guard let http = response as? HTTPURLResponse, http.statusCode == 200 else {
+                        throw ReferralPreflightError.unavailable
+                    }
+                    return try JSONDecoder().decode(ReferralPreflightResult.self, from: data)
+                },
                 registerLoginItem: { try AppLoginItem.register() },
-                runCLIInstall: { onLogLine in
-                    try await CLIInstallRunner.run(onLogLine: onLogLine)
+                runCLIInstall: { referralCode, onLogLine in
+                    try await CLIInstallRunner.run(referralCode: referralCode, onLogLine: onLogLine)
                 },
                 importCLIConfigAfterInstall: {
                     try await ProviderConfig.importExistingCLIConfig()
@@ -56,7 +149,7 @@ final class LaunchProviderController: ObservableObject {
                     )
                 },
                 attachInstalledProviderAfterInstall: {
-                    await agent?.monitorInstalledProviderIfPresent(
+                    await agent?.startManagedProvider(
                         timeout: MalibuOnboardingTimeouts.firstServingFrameSec
                     ) ?? false
                 },
@@ -76,19 +169,139 @@ final class LaunchProviderController: ObservableObject {
         self.dependencies = dependencies ?? .live(agent: agent)
     }
 
+    var normalizedReferralCode: String {
+        Self.extractReferralCode(referralCode)
+    }
+
+    var referralCodeIsValid: Bool {
+        Self.isValidReferralCode(normalizedReferralCode)
+    }
+
+    // PROD-M1: the dashboard "Copy private invite" puts a canonical
+    // https://…/j/<code> URL on the clipboard, so a recipient will often paste
+    // the whole URL here. Accept either a canonical invite URL (take the path
+    // segment after "/j/") or a bare code.
+    static func extractReferralCode(_ raw: String) -> String {
+        let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard let marker = trimmed.range(of: "/j/") else {
+            return trimmed
+        }
+        let tail = trimmed[marker.upperBound...]
+        let code = tail.prefix { $0 != "/" && $0 != "?" && $0 != "#" }
+        return String(code)
+    }
+
+    // PROD-M6: a lightweight, non-authorizing way for a user without a working
+    // inviter to ask for access. This does NOT grant registration — it is a
+    // waitlist/support entry point. The Go branded join pages (A6) link to the
+    // same destination; keep them in sync.
+    static let requestAccessURL = URL(string: "https://malibu.tech/request-access")!
+
+    static func isValidReferralCode(_ raw: String) -> Bool {
+        raw.range(
+            of: #"^MAL1-[SP]-[A-Za-z0-9_]{1,32}-[A-Za-z0-9_]{1,32}-[A-Z2-7]{26}$"#,
+            options: .regularExpression
+        ) != nil
+    }
+
     func launch() async {
+        if await dependencies.existingIdentityMissingBearer() {
+            stage = .existingIdentityMissingBearer(providerID: dependencies.readProviderID() ?? "")
+            return
+        }
         if await dependencies.localInstallSucceeded() {
             await finalizeExistingInstall(
                 logLine: "Background provider is already running locally. Connecting Malibu to it."
             )
             return
         }
-        await launchViaCLIInstall()
+        let existingIdentity = await dependencies.appIdentityConfigured()
+        await launchViaCLIInstall(existingIdentity: existingIdentity)
+    }
+
+    func refreshReferralPolicy() async {
+        if await dependencies.appIdentityConfigured() {
+            referralPolicy = .optional
+            return
+        }
+        do {
+            let result = try await dependencies.validateReferralCode("")
+            referralPolicy = result.required ? .required : .optional
+        } catch {
+            // PROD-M3: policy discovery failed → UNKNOWN, not required. Let the
+            // authoritative registration decide; B8 re-gates only if the server
+            // rejects with referral_required. Mirrors the installer's advisory
+            // treatment of /v1/referrals/validate.
+            referralPolicy = .unknown
+        }
     }
 
     func retry() async {
         guard case .failed(_, let retryable, _) = stage, retryable else { return }
         await launch()
+    }
+
+    // PROD-H6: if an app-owned identity exists without its Keychain bearer,
+    // claim the dedicated recovery/start-fresh stage instead of falling through
+    // to the invite flow. Returns true when it took over the stage.
+    @discardableResult
+    func evaluateExistingIdentityState() async -> Bool {
+        guard case .idle = stage else { return false }
+        guard await dependencies.existingIdentityMissingBearer() else { return false }
+        stage = .existingIdentityMissingBearer(providerID: dependencies.readProviderID() ?? "")
+        return true
+    }
+
+    // PROD-H6 (b): explicit destructive escape hatch. Move the app-owned
+    // config aside so a genuinely fresh provider can be created, then return to
+    // the normal invite flow. PROD-M6: capture the archive location and provider
+    // id so the UI can name what was retired and offer an undo — the caller is
+    // expected to have confirmed the destructive action first.
+    func startAsNewProvider() async {
+        let providerID = dependencies.readProviderID() ?? ""
+        do {
+            let archive = try await dependencies.moveAppOwnedConfigAside()
+            if let archive {
+                retiredIdentity = RetiredIdentity(
+                    providerID: providerID,
+                    archiveURL: archive,
+                    retiredAt: Date()
+                )
+            }
+        } catch {
+            stage = .failed(
+                stage: "startFresh",
+                retryable: true,
+                message: "Could not move the existing provider aside: \(error.localizedDescription)"
+            )
+            return
+        }
+        referralCode = ""
+        stage = .idle
+        await refreshReferralPolicy()
+    }
+
+    // PROD-M6: undo a just-performed "Start New" while the archive still exists,
+    // restoring the retired identity bundle in place. Refuses (surfaces the
+    // error) if a replacement identity was already created over it.
+    func undoStartAsNewProvider() async {
+        guard let retired = retiredIdentity else { return }
+        do {
+            try await dependencies.restoreArchivedIdentity(retired.archiveURL)
+        } catch {
+            stage = .failed(
+                stage: "startFresh",
+                retryable: true,
+                message: "Could not restore the retired provider: \(error.localizedDescription)"
+            )
+            return
+        }
+        retiredIdentity = nil
+        stage = .idle
+        // Re-detect the restored (missing-bearer) identity so the user lands
+        // back on the recover/start-new choice rather than a blank invite.
+        if await evaluateExistingIdentityState() { return }
+        await refreshReferralPolicy()
     }
 
     func setPayoutWallet(_ address: String) async throws {
@@ -110,13 +323,45 @@ final class LaunchProviderController: ObservableObject {
         await finalizeExistingInstall(logLine: "Background provider is already running locally.")
     }
 
-    private func launchViaCLIInstall() async {
+    private func launchViaCLIInstall(existingIdentity: Bool = false) async {
+        guard existingIdentity || !referralRequired || referralCodeIsValid else {
+            stage = .failed(
+                stage: "referral",
+                retryable: true,
+                message: "Enter a valid Malibu pre-beta invite code."
+            )
+            return
+        }
+        var preflightWarning: String?
+        // PROD-M1: validate the invite BEFORE any expensive install work
+        // whenever the policy is not known-optional — i.e. required OR still
+        // unknown (policy discovery failed). This stops a user from spending
+        // 10–30 min downloading and tuning only to discover at the mint that an
+        // invite was mandatory. An authoritative `required` + missing/invalid
+        // code re-gates to the EDITABLE invite step now with reason-specific
+        // copy; an unavailable pre-check degrades to a warning and lets the
+        // install-log rejection re-gate as before (mirrors install.sh's
+        // advisory /v1/referrals/validate treatment).
+        if !existingIdentity && referralPolicy != .optional {
+            do {
+                let result = try await dependencies.validateReferralCode(normalizedReferralCode)
+                if result.required {
+                    referralPolicy = .required
+                }
+                if result.required && !result.valid {
+                    stage = .failed(stage: "referral", retryable: true, message: Self.referralFailureMessage(result.reason))
+                    return
+                }
+            } catch {
+                preflightWarning = "Invite pre-check unavailable; final validation will happen securely during registration."
+            }
+        }
         beginInstallProgressWatch()
         defer { endInstallProgressWatch() }
         do {
             stage = .runningCLIInstall
-            installLogLines = []
-            try await dependencies.runCLIInstall { [weak self] line in
+            installLogLines = preflightWarning.map { [$0] } ?? []
+            try await dependencies.runCLIInstall(existingIdentity ? "" : normalizedReferralCode) { [weak self] line in
                 guard let self else { return }
                 self.installLogLines.append(line)
                 if self.installLogLines.count > 200 {
@@ -124,20 +369,70 @@ final class LaunchProviderController: ObservableObject {
                 }
             }
             var importError: Error?
-            do {
-                try await dependencies.importCLIConfigAfterInstall()
-            } catch {
-                if isRetriableImportError(error) {
-                    importError = error
-                    installLogLines.append(deferredImportMessage(for: error))
-                } else {
-                    stage = .failed(stage: "identityImport", retryable: true, message: error.localizedDescription)
-                    return
+            if !existingIdentity {
+                do {
+                    try await dependencies.importCLIConfigAfterInstall()
+                } catch {
+                    if isRetriableImportError(error) {
+                        importError = error
+                        installLogLines.append(deferredImportMessage(for: error))
+                    } else {
+                        stage = .failed(stage: "identityImport", retryable: true, message: error.localizedDescription)
+                        return
+                    }
                 }
             }
-            await finalizeInstall(pendingImportError: importError)
+            await finalizeInstall(
+                pendingImportError: importError,
+                startWithAppCredential: existingIdentity
+            )
         } catch {
+            // PROD-M2: if the authoritative registration rejected the invite,
+            // route back to the referral step (required) with the specific
+            // reason rather than a generic install failure.
+            if let reason = referralRejectionFromInstallLog() {
+                referralPolicy = .required
+                stage = .failed(stage: "referral", retryable: true, message: Self.referralFailureMessage(reason))
+                return
+            }
             stage = .failed(stage: "cliInstall", retryable: true, message: error.localizedDescription)
+        }
+    }
+
+    // PROD-M2: install.sh surfaces a referral rejection from the authoritative
+    // mint as `referral_<token>` (token ∈ missing|invalid|expired|revoked|
+    // exhausted|required), both as a MACPROVIDER_REFERRAL_REJECTED marker and in
+    // the fatal message. Scan the captured install log for it.
+    private func referralRejectionFromInstallLog() -> String? {
+        let pattern = #"referral_(missing|invalid|expired|revoked|exhausted|required)"#
+        for line in installLogLines.reversed() {
+            if let range = line.range(of: pattern, options: .regularExpression) {
+                let token = String(line[range].dropFirst("referral_".count))
+                // PROD-M4: the server's authoritative `referral_required`
+                // rejection means an invite is mandatory. Normalize it to the
+                // `missing` case so the failure copy and mandatory-invite routing
+                // match the other required-invite rejections.
+                return token == "required" ? "missing" : token
+            }
+        }
+        return nil
+    }
+
+    private static func referralFailureMessage(_ reason: String) -> String {
+        switch reason {
+        // PROD-M1: reason-specific copy that matches the installer's own wording
+        // ("use a different invite") so the same rejection reads identically
+        // whether it surfaces at preflight or from the install log. A code that
+        // exists but cannot be used routes the user to swap it.
+        case "expired": return "This invite has expired. Use a different invite."
+        case "revoked": return "This invite is no longer available. Use a different invite."
+        case "exhausted": return "This invite has already been used. Use a different invite."
+        // PROD-M4: `required` is normalized to `missing` upstream, but map it
+        // here too so any direct preflight `required` reason renders the same
+        // mandatory-invite copy rather than the generic fallback. There is no
+        // code to swap, so the copy asks for one instead.
+        case "missing", "required": return "An invite code is required. Enter a new invite code."
+        default: return "This invite is not valid. Use a different invite."
         }
     }
 
@@ -145,7 +440,7 @@ final class LaunchProviderController: ObservableObject {
         installLogLines = [logLine]
         guard !Task.isCancelled else { return }
         if await dependencies.appIdentityConfigured() {
-            await finalizeInstall()
+            await finalizeInstall(startWithAppCredential: true)
             return
         }
         var importError: Error?
@@ -162,21 +457,26 @@ final class LaunchProviderController: ObservableObject {
         await finalizeInstall(pendingImportError: importError)
     }
 
-    private func finalizeInstall(pendingImportError: Error? = nil) async {
+    private func finalizeInstall(
+        pendingImportError: Error? = nil,
+        startWithAppCredential: Bool = false
+    ) async {
         do {
             stage = .startingAgent
-            guard await dependencies.waitForInstalledProviderHealth() else {
-                let message = dependencies.providerStartFailure()
-                    ?? ProviderLogDiagnostics.timeoutMessage(logHint: ProviderLogDiagnostics.logHint())
-                throw launchdMonitorUnavailableError(message: message)
-            }
-            if let pendingImportError {
-                stage = .importingProviderIdentity
-                do {
-                    try await retryPendingImportAfterProviderStart(initialError: pendingImportError)
-                } catch {
-                    stage = .failed(stage: "identityImport", retryable: true, message: error.localizedDescription)
-                    return
+            if !startWithAppCredential {
+                guard await dependencies.waitForInstalledProviderHealth() else {
+                    let message = dependencies.providerStartFailure()
+                        ?? ProviderLogDiagnostics.timeoutMessage(logHint: ProviderLogDiagnostics.logHint())
+                    throw launchdMonitorUnavailableError(message: message)
+                }
+                if let pendingImportError {
+                    stage = .importingProviderIdentity
+                    do {
+                        try await retryPendingImportAfterProviderStart(initialError: pendingImportError)
+                    } catch {
+                        stage = .failed(stage: "identityImport", retryable: true, message: error.localizedDescription)
+                        return
+                    }
                 }
             }
             guard await dependencies.appIdentityConfigured() else {

--- a/phase3-binary/app/Sources/Malibu/Onboarding/OnboardingWindow.swift
+++ b/phase3-binary/app/Sources/Malibu/Onboarding/OnboardingWindow.swift
@@ -23,6 +23,8 @@ private struct OnboardingRootView: View {
     @ObservedObject var agent: MalibuAgent
     let onDone: () -> Void
     @StateObject private var controller: LaunchProviderController
+    // PROD-M6: gate the destructive "Start New" behind an explicit confirmation.
+    @State private var showStartFreshConfirm = false
 
     init(agent: MalibuAgent, onDone: @escaping () -> Void) {
         self.agent = agent
@@ -56,6 +58,10 @@ private struct OnboardingRootView: View {
         .padding(28)
         .frame(minWidth: 460, minHeight: 560)
         .task {
+            // PROD-H6: an app-owned identity with a missing bearer takes over
+            // the stage; skip the invite flow when it does.
+            if await controller.evaluateExistingIdentityState() { return }
+            await controller.refreshReferralPolicy()
             await controller.refreshFromExistingInstall()
         }
     }
@@ -64,9 +70,43 @@ private struct OnboardingRootView: View {
     private var content: some View {
         switch controller.stage {
         case .idle:
-            stageRow(title: "Ready", detail: "Installs the provider CLI, picks a model, and registers a background service.") {
-                VStack(alignment: .leading, spacing: 8) {
+            stageRow(
+                title: controller.referralRequired ? "Invite-only pre-beta" : "Set up Malibu",
+                detail: controller.referralRequired
+                    ? "Enter an invite to install the provider CLI and register this Mac."
+                    : "Install the provider CLI and register this Mac."
+            ) {
+                VStack(alignment: .leading, spacing: 10) {
+                    if let retired = controller.retiredIdentity {
+                        retiredIdentityBanner(retired)
+                    }
+                    if controller.showsReferralField {
+                        HStack(spacing: 8) {
+                            TextField("MAL1-… or invite link", text: $controller.referralCode)
+                                .textFieldStyle(.roundedBorder)
+                                .font(.system(.body, design: .monospaced))
+                                .accessibilityLabel("Malibu invite code")
+                            Button("Paste code") {
+                                if let value = NSPasteboard.general.string(forType: .string) {
+                                    controller.referralCode = value.trimmingCharacters(in: .whitespacesAndNewlines)
+                                }
+                            }
+                        }
+                        if !controller.referralRequired {
+                            // PROD-M3: policy is unknown/optional — the invite is
+                            // not blocking; registration decides.
+                            Text("Have an invite? Paste it here. Registration will confirm whether one is required.")
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                        }
+                        if !controller.normalizedReferralCode.isEmpty && !controller.referralCodeIsValid {
+                            Text("That invite code does not match Malibu's expected format.")
+                                .font(.caption)
+                                .foregroundStyle(.red)
+                        }
+                    }
                     launchButton(title: "Launch Provider")
+                        .disabled(controller.referralRequired && !controller.referralCodeIsValid)
                     Text("No wallet needed to start — add one anytime after.")
                         .font(.callout)
                         .foregroundStyle(.secondary)
@@ -126,6 +166,42 @@ private struct OnboardingRootView: View {
             ) {
                 ProgressView().controlSize(.small)
             }
+        case let .existingIdentityMissingBearer(providerID):
+            stageRow(
+                title: "Provider credential missing",
+                detail: "This Mac already has a Malibu provider identity"
+                    + (providerID.isEmpty ? "" : " (\(providerID))")
+                    + ", but its saved credential is gone. Malibu will not retry registration with that identity or ask for another invite in a loop."
+            ) {
+                VStack(alignment: .leading, spacing: 10) {
+                    Text("Contact Malibu support if you believe the credential can be restored from another trusted backup. Otherwise, start as a new provider below.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                    Link("Contact Malibu support", destination: LaunchProviderController.requestAccessURL)
+                        .font(.caption)
+                    Divider()
+                    Button("Start as a new provider") {
+                        showStartFreshConfirm = true
+                    }
+                    .prominentButton(true)
+                    .tint(MalibuBrand.coral)
+                    Text("Moves the existing provider aside and sets up a fresh one. This does not delete your earnings history, but the old provider identity is retired on this Mac.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+                .confirmationDialog(
+                    "Retire this provider and start new?",
+                    isPresented: $showStartFreshConfirm,
+                    titleVisibility: .visible
+                ) {
+                    Button("Retire and start new", role: .destructive) {
+                        Task { await controller.startAsNewProvider() }
+                    }
+                    Button("Cancel", role: .cancel) { }
+                } message: {
+                    Text(startFreshConfirmationMessage(providerID: providerID))
+                }
+            }
         case let .live(model, tier):
             VStack(alignment: .leading, spacing: 16) {
                 stageRow(title: "Provider live", detail: "Serving \(model). Trust tier: \(tier.rawValue).") {
@@ -142,13 +218,61 @@ private struct OnboardingRootView: View {
                     .buttonStyle(.borderedProminent)
                     .tint(MalibuBrand.coral)
             }
-        case let .failed(_, retryable, message):
+        case let .failed(stage, retryable, message):
             stageRow(title: retryable ? "Needs retry" : "Setup failed", detail: message) {
                 if retryable {
+                    if stage == "referral" || (stage == "cliInstall" && controller.referralRequired) {
+                        // PROD-M2: when the server demanded an invite, entering a
+                        // new invite code is required — not optional.
+                        Text(stage == "referral" ? "Enter a new invite code" : "Change invite code")
+                            .font(.caption.weight(.semibold))
+                        TextField("MAL1-… or invite link", text: $controller.referralCode)
+                            .textFieldStyle(.roundedBorder)
+                            .font(.system(.body, design: .monospaced))
+                        // PROD-M6: no working inviter? Offer a non-authorizing
+                        // request-access affordance.
+                        Link("No working invite? Request access", destination: LaunchProviderController.requestAccessURL)
+                            .font(.caption)
+                    }
                     launchButton(title: "Retry")
+                        .disabled(controller.referralRequired && (stage == "referral" || stage == "cliInstall") && !controller.referralCodeIsValid)
                 }
             }
         }
+    }
+
+    // PROD-M6: name the affected provider, the identity/earnings consequence,
+    // and where the bundle is archived so a destructive click is informed.
+    private func startFreshConfirmationMessage(providerID: String) -> String {
+        let subject = providerID.isEmpty ? "This Mac's provider identity" : "Provider \(providerID)"
+        return "\(subject) will be archived under ~/.config/macprovider and retired on this Mac. "
+            + "Your earnings history is not deleted, but this Mac stops serving under that identity until you restore it. "
+            + "You can undo this immediately afterward while the archive is still on disk."
+    }
+
+    // PROD-M6: session-scoped undo affordance after a "Start New". The archive
+    // stays on disk, so even after this session it can be restored manually from
+    // the shown path.
+    @ViewBuilder
+    private func retiredIdentityBanner(_ retired: LaunchProviderController.RetiredIdentity) -> some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text(retired.providerID.isEmpty
+                ? "Previous provider retired and archived."
+                : "Retired provider \(retired.providerID) and archived it.")
+                .font(.caption.weight(.semibold))
+            Text("Archive: \(retired.archivePath)")
+                .font(.caption2.monospaced())
+                .foregroundStyle(.secondary)
+                .textSelection(.enabled)
+                .lineLimit(2)
+            Button("Undo — restore the retired provider") {
+                Task { await controller.undoStartAsNewProvider() }
+            }
+            .buttonStyle(.bordered)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(10)
+        .background(RoundedRectangle(cornerRadius: 8).fill(MalibuBrand.sunnyYellow.opacity(0.15)))
     }
 
     @ViewBuilder
@@ -201,5 +325,18 @@ private struct OnboardingRootView: View {
             return String(format: "%d:%02d:%02d", hours, mins, remainder)
         }
         return String(format: "%d:%02d", minutes, remainder)
+    }
+}
+
+private extension View {
+    // A ternary over `.borderedProminent`/`.bordered` doesn't type-check
+    // (distinct ButtonStyle types), so branch on the concrete style instead.
+    @ViewBuilder
+    func prominentButton(_ prominent: Bool) -> some View {
+        if prominent {
+            buttonStyle(.borderedProminent)
+        } else {
+            buttonStyle(.bordered)
+        }
     }
 }

--- a/phase3-binary/app/Sources/Malibu/Onboarding/OnboardingWindow.swift
+++ b/phase3-binary/app/Sources/Malibu/Onboarding/OnboardingWindow.swift
@@ -71,8 +71,12 @@ private struct OnboardingRootView: View {
         switch controller.stage {
         case .idle:
             stageRow(
-                title: controller.referralRequired ? "Invite-only pre-beta" : "Set up Malibu",
-                detail: controller.referralRequired
+                title: controller.isDiscoveringReferralPolicy
+                    ? "Checking pre-beta access"
+                    : (controller.referralRequired ? "Invite-only pre-beta" : "Set up Malibu"),
+                detail: controller.isDiscoveringReferralPolicy
+                    ? "Checking whether this Mac needs an invite. You can enter one while Malibu checks."
+                    : controller.referralRequired
                     ? "Enter an invite to install the provider CLI and register this Mac."
                     : "Install the provider CLI and register this Mac."
             ) {
@@ -174,11 +178,9 @@ private struct OnboardingRootView: View {
                     + ", but its saved credential is gone. Malibu will not retry registration with that identity or ask for another invite in a loop."
             ) {
                 VStack(alignment: .leading, spacing: 10) {
-                    Text("Contact Malibu support if you believe the credential can be restored from another trusted backup. Otherwise, start as a new provider below.")
+                    Text("Restore the credential from a trusted backup if you have one. Otherwise, start as a new provider below. General troubleshooting cannot recreate this credential.")
                         .font(.caption)
                         .foregroundStyle(.secondary)
-                    Link("Contact Malibu support", destination: LaunchProviderController.requestAccessURL)
-                        .font(.caption)
                     Divider()
                     Button("Start as a new provider") {
                         showStartFreshConfirm = true
@@ -229,10 +231,17 @@ private struct OnboardingRootView: View {
                         TextField("MAL1-… or invite link", text: $controller.referralCode)
                             .textFieldStyle(.roundedBorder)
                             .font(.system(.body, design: .monospaced))
-                        // PROD-M6: no working inviter? Offer a non-authorizing
-                        // request-access affordance.
-                        Link("No working invite? Request access", destination: LaunchProviderController.requestAccessURL)
-                            .font(.caption)
+                        // Request-access is an operator-owned, optional URL
+                        // returned by the coordinator. Never invent a public
+                        // destination that cannot actually grant access.
+                        if let requestAccessURL = controller.requestAccessURL {
+                            Link("No working invite? Request access", destination: requestAccessURL)
+                                .font(.caption)
+                        } else {
+                            Text("Ask your inviter for another invite.")
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                        }
                     }
                     launchButton(title: "Retry")
                         .disabled(controller.referralRequired && (stage == "referral" || stage == "cliInstall") && !controller.referralCodeIsValid)
@@ -245,28 +254,30 @@ private struct OnboardingRootView: View {
     // and where the bundle is archived so a destructive click is informed.
     private func startFreshConfirmationMessage(providerID: String) -> String {
         let subject = providerID.isEmpty ? "This Mac's provider identity" : "Provider \(providerID)"
-        return "\(subject) will be archived under ~/.config/macprovider and retired on this Mac. "
-            + "Your earnings history is not deleted, but this Mac stops serving under that identity until you restore it. "
-            + "You can undo this immediately afterward while the archive is still on disk."
+        return "\(subject)'s identity files will be archived under ~/.config/macprovider. "
+            + "Your earnings history is not deleted. These local identity files remain unusable unless the missing credential is recovered separately."
     }
 
-    // PROD-M6: session-scoped undo affordance after a "Start New". The archive
-    // stays on disk, so even after this session it can be restored manually from
-    // the shown path.
+    // PROD-M6: session-scoped local-file restore after a "Start New". The
+    // archive stays on disk, so even after this session its files can be
+    // restored manually from the shown path. This is not credential recovery.
     @ViewBuilder
     private func retiredIdentityBanner(_ retired: LaunchProviderController.RetiredIdentity) -> some View {
         VStack(alignment: .leading, spacing: 6) {
             Text(retired.providerID.isEmpty
-                ? "Previous provider retired and archived."
-                : "Retired provider \(retired.providerID) and archived it.")
+                ? "Previous provider identity files archived."
+                : "Provider \(retired.providerID) identity files archived.")
                 .font(.caption.weight(.semibold))
             Text("Archive: \(retired.archivePath)")
                 .font(.caption2.monospaced())
                 .foregroundStyle(.secondary)
                 .textSelection(.enabled)
                 .lineLimit(2)
-            Button("Undo — restore the retired provider") {
-                Task { await controller.undoStartAsNewProvider() }
+            Text("Restoring these files does not recover the missing credential, reactivate this provider, or resume serving.")
+                .font(.caption2)
+                .foregroundStyle(.secondary)
+            Button("Restore archived files") {
+                Task { await controller.restoreRetiredProviderFiles() }
             }
             .buttonStyle(.bordered)
         }

--- a/phase3-binary/app/Sources/Malibu/System/ProcessEnvironmentSanitizer.swift
+++ b/phase3-binary/app/Sources/Malibu/System/ProcessEnvironmentSanitizer.swift
@@ -3,11 +3,14 @@ import Foundation
 enum ProcessEnvironmentSanitizer {
     enum Error: Swift.Error, CustomStringConvertible, Equatable {
         case unsafeValue(String)
+        case forbiddenSecretKey(String)
 
         var description: String {
             switch self {
             case let .unsafeValue(key):
                 return "unsafe environment value for \(key)"
+            case let .forbiddenSecretKey(key):
+                return "secret environment key is forbidden for managed child: \(key)"
             }
         }
     }
@@ -23,6 +26,9 @@ enum ProcessEnvironmentSanitizer {
             result[key] = value
         }
         for (key, value) in extraEnvironment {
+            guard key != "MACPROVIDER_PROVIDER_TOKEN" else {
+                throw Error.forbiddenSecretKey(key)
+            }
             guard isSafeValue(value) else { throw Error.unsafeValue(key) }
             result[key] = value
         }

--- a/phase3-binary/app/Sources/Malibu/System/ProviderConfig.swift
+++ b/phase3-binary/app/Sources/Malibu/System/ProviderConfig.swift
@@ -45,6 +45,26 @@ enum ProviderConfig {
         return port
     }
 
+    static func readCoordinatorBaseURL(paths: ProviderPaths = .current) -> URL? {
+        guard let contents = try? String(contentsOf: paths.configFile),
+              let raw = parseTopLevelValue(named: "coordinator_url", from: contents),
+              var components = URLComponents(string: raw) else {
+            return nil
+        }
+        let isLoopback = ["localhost", "127.0.0.1", "::1"].contains(components.host?.lowercased() ?? "")
+        switch components.scheme?.lowercased() {
+        case "wss": components.scheme = "https"
+        case "ws" where isLoopback: components.scheme = "http"
+        case "https": break
+        case "http" where isLoopback: break
+        default: return nil
+        }
+        components.path = ""
+        components.query = nil
+        components.fragment = nil
+        return components.url
+    }
+
     static func readLinkState(paths: ProviderPaths = .current) -> LinkState? {
         guard let contents = try? String(contentsOf: paths.configFile),
               let value = parseTopLevelValue(named: "link_state", from: contents)
@@ -156,6 +176,7 @@ enum ProviderConfig {
         case importRollbackFailed(importError: Error, rollbackError: Error)
         case appMarkerCreateFailed
         case savedIdentityNotConfigured
+        case restoreDestinationOccupied
         var errorDescription: String? {
             switch self {
             case .existingConfigNotOwnedByApp:
@@ -174,6 +195,8 @@ enum ProviderConfig {
                 return "The app ownership marker could not be written."
             case .savedIdentityNotConfigured:
                 return "The provider identity was not fully persisted."
+            case .restoreDestinationOccupied:
+                return "A provider identity already exists on this Mac, so the archived one cannot be restored over it."
             }
         }
     }
@@ -237,11 +260,9 @@ enum ProviderConfig {
         lines.append("provider_id: \(providerID)")
         lines.append("coordinator_url: \(coordinatorWSURL.absoluteString)")
         lines.append("link_state: \(LinkState.pendingLink.rawValue)")
-        // We deliberately do NOT write the token to disk. The CLI must be
-        // launched with the token in the environment (MACPROVIDER_PROVIDER_TOKEN),
-        // which MalibuAgent will set from Keychain before spawning the process.
-        // Followup: teach the CLI to read the token from Keychain directly so
-        // the environment-variable path can be removed.
+        // We deliberately do NOT write the token to disk. MalibuAgent hands the
+        // Keychain bearer to its managed CLI child over an anonymous pipe
+        // (`--token-fd 0`), keeping it out of argv and the process environment.
         let joined = lines.joined(separator: "\n") + "\n"
         do {
             try await saveToken(providerID, token)
@@ -440,9 +461,25 @@ enum ProviderConfig {
         try startFreshMovingCLIConfigAside(now: now, paths: .current)
     }
 
+    /// The durable provider_id file the installer's `choose_provider_id` reads
+    /// first (`~/.config/macprovider/provider_id`). It lives next to config.yaml
+    /// and is part of the app-owned identity bundle.
+    static func providerIDFile(paths: ProviderPaths = .current) -> URL {
+        paths.configFile.deletingLastPathComponent().appendingPathComponent("provider_id")
+    }
+
+    // PROD-H3: "Start as a new provider" must be truly destructive+clean. Moving
+    // only config.yaml aside left the durable provider_id file (and the app
+    // ownership marker) in place, so the installer's choose_provider_id reused
+    // the old bound provider_id and the fresh registration landed back in the
+    // bound-identity conflict. Archive the COMPLETE identity bundle — config.yaml,
+    // the provider_id file, and the app marker — into one timestamped directory
+    // so the next install generates a brand-new provider_id. Partial moves roll
+    // back so a failure never leaves the identity half-retired.
     static func startFreshMovingCLIConfigAside(now: Date = Date(), paths: ProviderPaths) throws -> URL? {
         let fm = FileManager.default
-        guard fm.fileExists(atPath: paths.configFile.path) else { return nil }
+        let bundle = [paths.configFile, providerIDFile(paths: paths), paths.appMarkerFile]
+        guard bundle.contains(where: { fm.fileExists(atPath: $0.path) }) else { return nil }
         try paths.ensureDirectories()
         let formatter = ISO8601DateFormatter()
         formatter.formatOptions = [.withInternetDateTime]
@@ -450,11 +487,66 @@ enum ProviderConfig {
         let suffix = formatter.string(from: now)
             .replacingOccurrences(of: ":", with: "")
             .replacingOccurrences(of: "-", with: "")
-        let backup = paths.configFile.deletingLastPathComponent()
-            .appendingPathComponent("config.yaml.cli-backup-\(suffix)")
-        try fm.moveItem(at: paths.configFile, to: backup)
-        try fm.setAttributes([.posixPermissions: 0o600], ofItemAtPath: backup.path)
-        return backup
+        let archive = paths.configFile.deletingLastPathComponent()
+            .appendingPathComponent("identity-archive-\(suffix)-\(UUID().uuidString.prefix(8))", isDirectory: true)
+        try fm.createDirectory(at: archive, withIntermediateDirectories: true)
+        try fm.setAttributes([.posixPermissions: 0o700], ofItemAtPath: archive.path)
+
+        var moved: [(from: URL, to: URL)] = []
+        do {
+            for artifact in bundle where fm.fileExists(atPath: artifact.path) {
+                let destination = archive.appendingPathComponent(artifact.lastPathComponent)
+                try fm.moveItem(at: artifact, to: destination)
+                try? fm.setAttributes([.posixPermissions: 0o600], ofItemAtPath: destination.path)
+                moved.append((artifact, destination))
+            }
+        } catch {
+            // Restore any already-archived artifacts so the identity stays whole.
+            for entry in moved.reversed() {
+                try? fm.moveItem(at: entry.to, to: entry.from)
+            }
+            try? fm.removeItem(at: archive)
+            throw error
+        }
+        return archive
+    }
+
+    // PROD-M6: reverse of startFreshMovingCLIConfigAside so an accidental
+    // "Start New" can be undone while the archive still exists. Each archived
+    // artifact is restored to its original location by filename (config.yaml
+    // and provider_id under the config dir; the app marker under Application
+    // Support). Refuses if any destination is already occupied so a
+    // freshly-created replacement identity is never clobbered. Partial moves
+    // roll back so a failure never leaves the identity half-restored.
+    static func restoreArchivedIdentity(from archive: URL, paths: ProviderPaths = .current) throws {
+        let fm = FileManager.default
+        let destinations: [String: URL] = [
+            paths.configFile.lastPathComponent: paths.configFile,
+            providerIDFile(paths: paths).lastPathComponent: providerIDFile(paths: paths),
+            paths.appMarkerFile.lastPathComponent: paths.appMarkerFile,
+        ]
+        let entries = (try? fm.contentsOfDirectory(at: archive, includingPropertiesForKeys: nil)) ?? []
+        for entry in entries {
+            if let destination = destinations[entry.lastPathComponent],
+               fm.fileExists(atPath: destination.path) {
+                throw SaveError.restoreDestinationOccupied
+            }
+        }
+        try paths.ensureDirectories()
+        var moved: [(from: URL, to: URL)] = []
+        do {
+            for entry in entries {
+                guard let destination = destinations[entry.lastPathComponent] else { continue }
+                try fm.moveItem(at: entry, to: destination)
+                moved.append((entry, destination))
+            }
+        } catch {
+            for entry in moved.reversed() {
+                try? fm.moveItem(at: entry.to, to: entry.from)
+            }
+            throw error
+        }
+        try? fm.removeItem(at: archive)
     }
 
     // AUDIT R1 CODE M2 / SECURITY S3 / ARCHITECT A6 fix: uninstall must complete
@@ -508,6 +600,22 @@ enum ProviderConfig {
             return false
         }
         return await KeychainStore.readProviderToken(providerID: providerID) != nil
+    }
+
+    // PROD-H6: an app-owned config (config + app marker + provider_id) whose
+    // Keychain bearer is gone. This is distinct from "unconfigured": reusing
+    // the existing provider_id for a fresh referral loops because the
+    // coordinator rejects the already-confirmed bootstrap identity. Callers
+    // must offer proven recovery or an explicit "start fresh", never silently
+    // ask for a new invite.
+    static func existingIdentityMissingBearer(paths: ProviderPaths = .current) async -> Bool {
+        let fm = FileManager.default
+        guard fm.fileExists(atPath: paths.configFile.path),
+              fm.fileExists(atPath: paths.appMarkerFile.path),
+              let providerID = readProviderID(paths: paths) else {
+            return false
+        }
+        return await KeychainStore.readProviderToken(providerID: providerID) == nil
     }
 
     private static func writeAppMarker(paths: ProviderPaths, fileManager fm: FileManager) throws {

--- a/phase3-binary/app/Sources/Malibu/System/RegisterClient.swift
+++ b/phase3-binary/app/Sources/Malibu/System/RegisterClient.swift
@@ -77,6 +77,7 @@ struct RegisterRequest: Equatable {
     let hardwareSummary: [String: String]
     let appAttestObject: String?
     let appAttestKeyID: String?
+    let referralCode: String?
     let nonce: String
     let timestampUTC: String
     let signature: String
@@ -88,6 +89,7 @@ struct RegisterRequest: Equatable {
             "hardware_summary": hardwareSummary,
             "app_attest_object": appAttestObject ?? NSNull(),
             "app_attest_key_id": appAttestKeyID ?? NSNull(),
+            "referral_code": referralCode ?? NSNull(),
             "nonce": nonce,
             "ts_utc": timestampUTC,
             "signature": signature
@@ -127,6 +129,7 @@ struct RegisterClient {
         hardwareSummary: [String: String] = Self.currentHardwareSummary(),
         appAttestObject: Data? = nil,
         appAttestKeyID: Data? = nil,
+        referralCode: String? = nil,
         nonce: String = Self.makeNonce(),
         timestamp: Date = Date()
     ) throws -> RegisterRequest {
@@ -138,6 +141,7 @@ struct RegisterClient {
             hardwareSummary: hardwareSummary,
             appAttestObject: appAttestObject?.base64EncodedString(),
             appAttestKeyID: appAttestKeyID?.base64EncodedString(),
+            referralCode: referralCode,
             nonce: nonce,
             timestampUTC: timestampUTC
         )
@@ -149,6 +153,7 @@ struct RegisterClient {
             hardwareSummary: hardwareSummary,
             appAttestObject: appAttestObject?.base64EncodedString(),
             appAttestKeyID: appAttestKeyID?.base64EncodedString(),
+            referralCode: referralCode,
             nonce: nonce,
             timestampUTC: timestampUTC,
             signature: signature
@@ -234,6 +239,7 @@ struct RegisterClient {
             hardwareSummary: request.hardwareSummary,
             appAttestObject: request.appAttestObject,
             appAttestKeyID: request.appAttestKeyID,
+            referralCode: request.referralCode,
             nonce: request.nonce,
             timestampUTC: request.timestampUTC
         ))
@@ -290,6 +296,7 @@ struct RegisterClient {
         hardwareSummary: [String: String],
         appAttestObject: String?,
         appAttestKeyID: String?,
+        referralCode: String?,
         nonce: String,
         timestampUTC: String
     ) -> CanonicalJSONValue {
@@ -299,6 +306,7 @@ struct RegisterClient {
             "hardware_summary": .object(hardwareSummary.mapValues { .string($0) }),
             "app_attest_object": appAttestObject.map(CanonicalJSONValue.string) ?? .null,
             "app_attest_key_id": appAttestKeyID.map(CanonicalJSONValue.string) ?? .null,
+            "referral_code": referralCode.map(CanonicalJSONValue.string) ?? .null,
             "nonce": .string(nonce),
             "ts_utc": .string(timestampUTC)
         ])

--- a/phase3-binary/app/Sources/Malibu/System/RegisterClient.swift
+++ b/phase3-binary/app/Sources/Malibu/System/RegisterClient.swift
@@ -78,6 +78,9 @@ struct RegisterRequest: Equatable {
     let appAttestObject: String?
     let appAttestKeyID: String?
     let referralCode: String?
+    /// Client-generated credential held before transport. The coordinator
+    /// commits this exact value so a lost response cannot orphan the bearer.
+    let providerTokenCandidate: String
     let nonce: String
     let timestampUTC: String
     let signature: String
@@ -90,6 +93,7 @@ struct RegisterRequest: Equatable {
             "app_attest_object": appAttestObject ?? NSNull(),
             "app_attest_key_id": appAttestKeyID ?? NSNull(),
             "referral_code": referralCode ?? NSNull(),
+            "provider_token_candidate": providerTokenCandidate,
             "nonce": nonce,
             "ts_utc": timestampUTC,
             "signature": signature
@@ -130,6 +134,7 @@ struct RegisterClient {
         appAttestObject: Data? = nil,
         appAttestKeyID: Data? = nil,
         referralCode: String? = nil,
+        providerTokenCandidate: String = Self.makeProviderTokenCandidate(),
         nonce: String = Self.makeNonce(),
         timestamp: Date = Date()
     ) throws -> RegisterRequest {
@@ -142,6 +147,7 @@ struct RegisterClient {
             appAttestObject: appAttestObject?.base64EncodedString(),
             appAttestKeyID: appAttestKeyID?.base64EncodedString(),
             referralCode: referralCode,
+            providerTokenCandidate: providerTokenCandidate,
             nonce: nonce,
             timestampUTC: timestampUTC
         )
@@ -154,6 +160,7 @@ struct RegisterClient {
             appAttestObject: appAttestObject?.base64EncodedString(),
             appAttestKeyID: appAttestKeyID?.base64EncodedString(),
             referralCode: referralCode,
+            providerTokenCandidate: providerTokenCandidate,
             nonce: nonce,
             timestampUTC: timestampUTC,
             signature: signature
@@ -161,6 +168,16 @@ struct RegisterClient {
     }
 
     func postRegister(_ requestBody: RegisterRequest, bearerProof: String? = nil) async throws -> RegisterResponse {
+        if bearerProof == nil {
+            if let existing = await KeychainStore.readProviderToken(providerID: requestBody.providerID),
+               existing != requestBody.providerTokenCandidate {
+                throw RegisterClientError.candidateConflictsWithKeychain
+            }
+            try await KeychainStore.saveProviderToken(
+                providerID: requestBody.providerID,
+                token: requestBody.providerTokenCandidate
+            )
+        }
         var request = URLRequest(url: coordinatorBaseURL.appendingPathComponent("v1/providers/register"))
         request.httpMethod = "POST"
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
@@ -183,6 +200,9 @@ struct RegisterClient {
 		}
         let decoded = try JSONDecoder().decode(RegisterResponse.self, from: data)
         try Self.validateCoordinatorWSURL(decoded.coordinatorWebSocketURL, expectedBase: coordinatorBaseURL)
+        if bearerProof == nil, decoded.providerToken != requestBody.providerTokenCandidate {
+            throw RegisterClientError.coordinatorChangedCandidate
+        }
         return decoded
     }
 
@@ -240,6 +260,7 @@ struct RegisterClient {
             appAttestObject: request.appAttestObject,
             appAttestKeyID: request.appAttestKeyID,
             referralCode: request.referralCode,
+            providerTokenCandidate: request.providerTokenCandidate,
             nonce: request.nonce,
             timestampUTC: request.timestampUTC
         ))
@@ -283,6 +304,10 @@ struct RegisterClient {
         return bytes.map { String(format: "%02x", $0) }.joined()
     }
 
+    static func makeProviderTokenCandidate() -> String {
+        makeNonce()
+    }
+
     static func rfc3339UTC(_ date: Date) -> String {
         let formatter = ISO8601DateFormatter()
         formatter.formatOptions = [.withInternetDateTime]
@@ -297,6 +322,7 @@ struct RegisterClient {
         appAttestObject: String?,
         appAttestKeyID: String?,
         referralCode: String?,
+        providerTokenCandidate: String,
         nonce: String,
         timestampUTC: String
     ) -> CanonicalJSONValue {
@@ -307,6 +333,7 @@ struct RegisterClient {
             "app_attest_object": appAttestObject.map(CanonicalJSONValue.string) ?? .null,
             "app_attest_key_id": appAttestKeyID.map(CanonicalJSONValue.string) ?? .null,
             "referral_code": referralCode.map(CanonicalJSONValue.string) ?? .null,
+            "provider_token_candidate": .string(providerTokenCandidate),
             "nonce": .string(nonce),
             "ts_utc": .string(timestampUTC)
         ])
@@ -316,6 +343,8 @@ struct RegisterClient {
 enum RegisterClientError: Error, Equatable {
     case httpStatus(Int)
     case invalidCoordinatorWSURL(reason: String)
+    case candidateConflictsWithKeychain
+    case coordinatorChangedCandidate
 }
 
 enum ProviderBearerURLSession {

--- a/phase3-binary/app/Tests/MalibuTests/CLIChildProcessTests.swift
+++ b/phase3-binary/app/Tests/MalibuTests/CLIChildProcessTests.swift
@@ -1,0 +1,24 @@
+import XCTest
+@testable import Malibu
+
+@MainActor
+final class CLIChildProcessTests: XCTestCase {
+    func testManagedBearerUsesTokenFDWithoutPuttingSecretInArgumentsOrEnvironment() throws {
+        let secret = "payout-bearing-secret"
+        let launch = CLIChildProcess.Launch(
+            executable: URL(fileURLWithPath: "/tmp/macprovider-cli"),
+            configPath: URL(fileURLWithPath: "/tmp/config.yaml"),
+            controlSocketPath: URL(fileURLWithPath: "/tmp/control.sock"),
+            httpPort: 18080,
+            logFileURL: URL(fileURLWithPath: "/tmp/provider.log"),
+            extraEnvironment: ["SAFE": "1"],
+            providerToken: secret
+        )
+
+        let arguments = CLIChildProcess.buildArguments(launch: launch)
+        XCTAssertTrue(arguments.contains("--token-fd"))
+        XCTAssertTrue(arguments.contains("0"))
+        XCTAssertFalse(arguments.contains(secret))
+        XCTAssertNil(launch.extraEnvironment["MACPROVIDER_PROVIDER_TOKEN"])
+    }
+}

--- a/phase3-binary/app/Tests/MalibuTests/LaunchProviderControllerTests.swift
+++ b/phase3-binary/app/Tests/MalibuTests/LaunchProviderControllerTests.swift
@@ -10,6 +10,55 @@ final class LaunchProviderControllerTests: XCTestCase {
         return controller
     }
 
+    func testReferralPolicyStartsUnknownAndUsesBoundedLiveDiscovery() {
+        let controller = LaunchProviderController(dependencies: Harness().dependencies())
+
+        XCTAssertEqual(controller.referralPolicy, .unknown)
+        XCTAssertFalse(controller.referralRequired)
+        XCTAssertTrue(controller.showsReferralField)
+        XCTAssertLessThanOrEqual(LaunchProviderController.referralPolicyRequestTimeout, 8)
+        XCTAssertLessThanOrEqual(LaunchProviderController.referralPolicyResourceTimeout, 10)
+    }
+
+    func testReferralPreflightDecodesOnlyConfiguredAbsoluteHTTPSAccessURL() throws {
+        let present = try JSONDecoder().decode(
+            ReferralPreflightResult.self,
+            from: Data(#"{"valid":false,"reason":"expired","required":true,"request_access_url":"https://access.example.test/waitlist"}"#.utf8)
+        )
+        XCTAssertEqual(present.requestAccessURL?.absoluteString, "https://access.example.test/waitlist")
+
+        let absent = try JSONDecoder().decode(
+            ReferralPreflightResult.self,
+            from: Data(#"{"valid":false,"reason":"expired","required":true}"#.utf8)
+        )
+        XCTAssertNil(absent.requestAccessURL)
+
+        for raw in ["http://access.example.test", "/relative", "https://user:secret@access.example.test"] {
+            let data = try JSONSerialization.data(withJSONObject: [
+                "valid": false,
+                "reason": "expired",
+                "required": true,
+                "request_access_url": raw,
+            ])
+            let decoded = try JSONDecoder().decode(ReferralPreflightResult.self, from: data)
+            XCTAssertNil(decoded.requestAccessURL, "unexpected access URL for \(raw)")
+        }
+    }
+
+    func testRefreshRetainsCoordinatorConfiguredAccessURL() async {
+        let harness = Harness()
+        harness.referralPreflight = ReferralPreflightResult(
+            valid: false,
+            reason: "missing",
+            requestAccessURL: URL(string: "https://access.example.test/waitlist")
+        )
+        let controller = LaunchProviderController(dependencies: harness.dependencies())
+
+        await controller.refreshReferralPolicy()
+
+        XCTAssertEqual(controller.requestAccessURL?.absoluteString, "https://access.example.test/waitlist")
+    }
+
     func testLaunchViaCLIInstallWhenNotAlreadyRunning() async {
         let harness = Harness()
         let controller = makeController(harness)
@@ -26,6 +75,7 @@ final class LaunchProviderControllerTests: XCTestCase {
 
     func testFreshInstallRequiresWellFormedReferral() async {
         let harness = Harness()
+        harness.referralPreflight = ReferralPreflightResult(valid: false, reason: "missing")
         let controller = LaunchProviderController(dependencies: harness.dependencies())
 
         await controller.launch()
@@ -33,8 +83,9 @@ final class LaunchProviderControllerTests: XCTestCase {
         XCTAssertEqual(harness.cliInstallRuns, 0)
         XCTAssertEqual(
             controller.stage,
-            .failed(stage: "referral", retryable: true, message: "Enter a valid Malibu pre-beta invite code.")
+            .failed(stage: "referral", retryable: true, message: "An invite is required. Enter an invite code or link.")
         )
+        XCTAssertNil(controller.requestAccessURL)
     }
 
     func testExistingIdentityRepairRunsWithoutReferral() async {
@@ -95,6 +146,15 @@ final class LaunchProviderControllerTests: XCTestCase {
         XCTAssertNil(repair["MACPROVIDER_PROVIDER_TOKEN"])
         XCTAssertEqual(repair["MACPROVIDER_APP_MANAGED_REPAIR"], "1")
         XCTAssertEqual(repair["MACPROVIDER_REFERRAL_CODE"], "")
+
+        XCTAssertEqual(
+            CLIInstallRunner.installerArguments(scriptPath: "/tmp/install.sh", appManagedRepair: false),
+            ["/tmp/install.sh"]
+        )
+        XCTAssertEqual(
+            CLIInstallRunner.installerArguments(scriptPath: "/tmp/install.sh", appManagedRepair: true),
+            ["/tmp/install.sh", "--provider-token-fd", "0"]
+        )
     }
 
     func testReferralFormatMatchesInstallerContract() {
@@ -103,9 +163,57 @@ final class LaunchProviderControllerTests: XCTestCase {
         XCTAssertFalse(LaunchProviderController.isValidReferralCode("MAL1-X-key-seed-AAAAAAAAAAAAAAAAAAAAAAAAAA"))
     }
 
+    func testCanonicalInviteURLIsNormalizedBeforeInstaller() async {
+        let harness = Harness()
+        let controller = LaunchProviderController(dependencies: harness.dependencies())
+        controller.referralCode = "https://coordinator.streamvc.live/j/\(Harness.validReferralCode)?c=x-post"
+
+        await controller.launch()
+
+        XCTAssertEqual(harness.cliInstallRuns, 1)
+        XCTAssertEqual(controller.normalizedReferralCode, Harness.validReferralCode)
+    }
+
+    func testNonCanonicalInviteURLIsNotExtracted() {
+        XCTAssertEqual(
+            LaunchProviderController.extractReferralCode(
+                "  https://coordinator.streamvc.live/j/\(Harness.validReferralCode)/?c=x-post#install  "
+            ),
+            Harness.validReferralCode
+        )
+        XCTAssertEqual(
+            LaunchProviderController.extractReferralCode(
+                "http://coordinator.streamvc.live/j/\(Harness.validReferralCode)"
+            ),
+            "http://coordinator.streamvc.live/j/\(Harness.validReferralCode)"
+        )
+        XCTAssertEqual(
+            LaunchProviderController.extractReferralCode(
+                "https://coordinator.streamvc.live/?next=/j/\(Harness.validReferralCode)"
+            ),
+            "https://coordinator.streamvc.live/?next=/j/\(Harness.validReferralCode)"
+        )
+        XCTAssertEqual(
+            LaunchProviderController.extractReferralCode(
+                "https://coordinator.streamvc.live/j/\(Harness.validReferralCode)/extra"
+            ),
+            "https://coordinator.streamvc.live/j/\(Harness.validReferralCode)/extra"
+        )
+        XCTAssertEqual(
+            LaunchProviderController.extractReferralCode(
+                "https://coordinator.streamvc.live/j/\(Harness.validReferralCode)//"
+            ),
+            "https://coordinator.streamvc.live/j/\(Harness.validReferralCode)//"
+        )
+    }
+
     func testFreshInstallRejectsExhaustedReferralBeforeInstaller() async {
         let harness = Harness()
-        harness.referralPreflight = ReferralPreflightResult(valid: false, reason: "exhausted")
+        harness.referralPreflight = ReferralPreflightResult(
+            valid: false,
+            reason: "exhausted",
+            requestAccessURL: URL(string: "https://access.example.test/waitlist")
+        )
         let controller = makeController(harness)
 
         await controller.launch()
@@ -113,8 +221,9 @@ final class LaunchProviderControllerTests: XCTestCase {
         XCTAssertEqual(harness.cliInstallRuns, 0)
         XCTAssertEqual(
             controller.stage,
-            .failed(stage: "referral", retryable: true, message: "This invite has already been used. Use a different invite.")
+            .failed(stage: "referral", retryable: true, message: "All spots on this invite are taken. Use a different invite.")
         )
+        XCTAssertEqual(controller.requestAccessURL?.absoluteString, "https://access.example.test/waitlist")
     }
 
     func testDefaultOffPolicyAllowsFreshInstallWithoutReferral() async {
@@ -351,7 +460,7 @@ final class LaunchProviderControllerTests: XCTestCase {
             .failed(
                 stage: "referral",
                 retryable: true,
-                message: "An invite code is required. Enter a new invite code."
+                message: "An invite is required. Enter an invite code or link."
             )
         )
     }
@@ -375,7 +484,7 @@ final class LaunchProviderControllerTests: XCTestCase {
         XCTAssertEqual(harness.cliInstallRuns, 0)
         XCTAssertEqual(
             controller.stage,
-            .failed(stage: "referral", retryable: true, message: "An invite code is required. Enter a new invite code.")
+            .failed(stage: "referral", retryable: true, message: "An invite is required. Enter an invite code or link.")
         )
     }
 
@@ -417,9 +526,9 @@ final class LaunchProviderControllerTests: XCTestCase {
     }
 
     // PROD-M6: "Start New" records the retired identity (id + archive path) so
-    // the UI can name it and offer an undo; the undo restores it and clears the
-    // banner.
-    func testStartAsNewProviderRecordsRetiredIdentityAndUndoRestores() async {
+    // the UI can name it and offer a local-file restore; restoring clears the
+    // archive banner without claiming credential or serving recovery.
+    func testStartAsNewProviderRecordsRetiredIdentityAndRestoresArchivedFiles() async {
         let harness = Harness()
         harness.providerID = "p_retire_me"
         let archive = URL(fileURLWithPath: "/tmp/malibu-archive-xyz")
@@ -432,21 +541,38 @@ final class LaunchProviderControllerTests: XCTestCase {
         XCTAssertEqual(controller.retiredIdentity?.archivePath, archive.path)
         XCTAssertEqual(controller.stage, .idle)
 
-        await controller.undoStartAsNewProvider()
+        await controller.restoreRetiredProviderFiles()
 
         XCTAssertEqual(harness.restoreRuns, 1)
         XCTAssertNil(controller.retiredIdentity)
         XCTAssertEqual(controller.stage, .idle)
     }
 
-    func testUndoStartAsNewProviderSurfacesRestoreFailure() async {
+    func testRestoreRetiredProviderFilesReturnsToMissingCredentialRecovery() async {
+        let harness = Harness()
+        harness.providerID = "p_still_missing"
+        harness.startFreshArchive = URL(fileURLWithPath: "/tmp/malibu-archive-xyz")
+        let controller = LaunchProviderController(dependencies: harness.dependencies())
+
+        await controller.startAsNewProvider()
+        harness.existingIdentityMissingBearer = true
+        await controller.restoreRetiredProviderFiles()
+
+        XCTAssertEqual(harness.restoreRuns, 1)
+        XCTAssertEqual(
+            controller.stage,
+            .existingIdentityMissingBearer(providerID: "p_still_missing")
+        )
+    }
+
+    func testRestoreRetiredProviderFilesSurfacesRestoreFailure() async {
         let harness = Harness()
         harness.startFreshArchive = URL(fileURLWithPath: "/tmp/malibu-archive-xyz")
         harness.restoreError = NSError(domain: "tests", code: 9, userInfo: [NSLocalizedDescriptionKey: "occupied"])
         let controller = LaunchProviderController(dependencies: harness.dependencies())
 
         await controller.startAsNewProvider()
-        await controller.undoStartAsNewProvider()
+        await controller.restoreRetiredProviderFiles()
 
         // The retired banner remains so the user can retry / restore manually.
         XCTAssertNotNil(controller.retiredIdentity)
@@ -542,7 +668,7 @@ final class LaunchProviderControllerTests: XCTestCase {
                     if let error = self.startFreshError { throw error }
                     return self.startFreshArchive
                 },
-                restoreArchivedIdentity: { _ in
+                restoreArchivedFiles: { _ in
                     self.restoreRuns += 1
                     if let error = self.restoreError { throw error }
                 }

--- a/phase3-binary/app/Tests/MalibuTests/LaunchProviderControllerTests.swift
+++ b/phase3-binary/app/Tests/MalibuTests/LaunchProviderControllerTests.swift
@@ -4,9 +4,15 @@ import XCTest
 @MainActor
 final class LaunchProviderControllerTests: XCTestCase {
 
+    private func makeController(_ harness: Harness) -> LaunchProviderController {
+        let controller = LaunchProviderController(dependencies: harness.dependencies())
+        controller.referralCode = Harness.validReferralCode
+        return controller
+    }
+
     func testLaunchViaCLIInstallWhenNotAlreadyRunning() async {
         let harness = Harness()
-        let controller = LaunchProviderController(dependencies: harness.dependencies())
+        let controller = makeController(harness)
 
         await controller.launch()
 
@@ -18,17 +24,123 @@ final class LaunchProviderControllerTests: XCTestCase {
         XCTAssertEqual(controller.stage, .live(model: harness.configModel, tier: .provisional))
     }
 
-    func testLaunchSkipsInstallerWhenLocalProviderAlreadyHealthy() async {
+    func testFreshInstallRequiresWellFormedReferral() async {
         let harness = Harness()
-        harness.localInstallSucceeded = true
-        harness.appIdentityConfigured = true
         let controller = LaunchProviderController(dependencies: harness.dependencies())
 
         await controller.launch()
 
         XCTAssertEqual(harness.cliInstallRuns, 0)
+        XCTAssertEqual(
+            controller.stage,
+            .failed(stage: "referral", retryable: true, message: "Enter a valid Malibu pre-beta invite code.")
+        )
+    }
+
+    func testExistingIdentityRepairRunsWithoutReferral() async {
+        let harness = Harness()
+        harness.appIdentityConfigured = true
+        harness.expectedReferralCode = ""
+        let controller = LaunchProviderController(dependencies: harness.dependencies())
+
+        await controller.refreshReferralPolicy()
+        await controller.launch()
+
+        XCTAssertFalse(controller.referralRequired)
+        XCTAssertEqual(harness.cliInstallRuns, 1)
         XCTAssertEqual(harness.cliImportRuns, 0)
-        XCTAssertEqual(harness.monitorRuns, 1)
+        XCTAssertEqual(harness.monitorRuns, 0)
+        XCTAssertEqual(harness.startAgentRuns, 1)
+        XCTAssertEqual(controller.stage, .live(model: harness.configModel, tier: .provisional))
+    }
+
+    func testMissingBearerStopsBeforeInviteOrInstallerAndRetryDoesNotLoop() async {
+        let harness = Harness()
+        harness.existingIdentityMissingBearer = true
+        harness.providerID = "p_missing_bearer"
+        let controller = LaunchProviderController(dependencies: harness.dependencies())
+
+        await controller.launch()
+
+        XCTAssertEqual(controller.stage, .existingIdentityMissingBearer(providerID: "p_missing_bearer"))
+        XCTAssertEqual(harness.cliInstallRuns, 0)
+
+        await controller.retry()
+        XCTAssertEqual(controller.stage, .existingIdentityMissingBearer(providerID: "p_missing_bearer"))
+        XCTAssertEqual(harness.cliInstallRuns, 0)
+    }
+
+    func testInstallerRepairModeIsBoundToExistingCredential() {
+        let fresh = CLIInstallRunner.installerEnvironment(
+            base: [
+                "MACPROVIDER_PROVIDER_TOKEN": "inherited-token",
+                "MACPROVIDER_APP_MANAGED_REPAIR": "1",
+            ],
+            referralCode: Harness.validReferralCode,
+            appManagedRepair: false,
+            installPort: 18080,
+            home: "/Users/test"
+        )
+        XCTAssertNil(fresh["MACPROVIDER_PROVIDER_TOKEN"])
+        XCTAssertNil(fresh["MACPROVIDER_APP_MANAGED_REPAIR"])
+        XCTAssertEqual(fresh["MACPROVIDER_REFERRAL_CODE"], Harness.validReferralCode)
+
+        let repair = CLIInstallRunner.installerEnvironment(
+            base: [:],
+            referralCode: "",
+            appManagedRepair: true,
+            installPort: 18080,
+            home: "/Users/test"
+        )
+        XCTAssertNil(repair["MACPROVIDER_PROVIDER_TOKEN"])
+        XCTAssertEqual(repair["MACPROVIDER_APP_MANAGED_REPAIR"], "1")
+        XCTAssertEqual(repair["MACPROVIDER_REFERRAL_CODE"], "")
+    }
+
+    func testReferralFormatMatchesInstallerContract() {
+        XCTAssertTrue(LaunchProviderController.isValidReferralCode(Harness.validReferralCode))
+        XCTAssertFalse(LaunchProviderController.isValidReferralCode("MAL1-S-key-seed-short"))
+        XCTAssertFalse(LaunchProviderController.isValidReferralCode("MAL1-X-key-seed-AAAAAAAAAAAAAAAAAAAAAAAAAA"))
+    }
+
+    func testFreshInstallRejectsExhaustedReferralBeforeInstaller() async {
+        let harness = Harness()
+        harness.referralPreflight = ReferralPreflightResult(valid: false, reason: "exhausted")
+        let controller = makeController(harness)
+
+        await controller.launch()
+
+        XCTAssertEqual(harness.cliInstallRuns, 0)
+        XCTAssertEqual(
+            controller.stage,
+            .failed(stage: "referral", retryable: true, message: "This invite has already been used. Use a different invite.")
+        )
+    }
+
+    func testDefaultOffPolicyAllowsFreshInstallWithoutReferral() async {
+        let harness = Harness()
+        harness.referralPreflight = ReferralPreflightResult(valid: true, reason: "disabled", required: false)
+        harness.expectedReferralCode = ""
+        let controller = LaunchProviderController(dependencies: harness.dependencies())
+
+        await controller.refreshReferralPolicy()
+        await controller.launch()
+
+        XCTAssertFalse(controller.referralRequired)
+        XCTAssertEqual(harness.cliInstallRuns, 1)
+    }
+
+    func testLaunchSkipsInstallerWhenLocalProviderAlreadyHealthy() async {
+        let harness = Harness()
+        harness.localInstallSucceeded = true
+        harness.appIdentityConfigured = true
+        let controller = makeController(harness)
+
+        await controller.launch()
+
+        XCTAssertEqual(harness.cliInstallRuns, 0)
+        XCTAssertEqual(harness.cliImportRuns, 0)
+        XCTAssertEqual(harness.monitorRuns, 0)
         XCTAssertEqual(harness.loginItemRegistrations, 1)
         XCTAssertEqual(harness.startAgentRuns, 1)
         XCTAssertEqual(controller.stage, .live(model: harness.configModel, tier: .provisional))
@@ -37,7 +149,7 @@ final class LaunchProviderControllerTests: XCTestCase {
     func testLaunchInstallFailureIsRetryable() async {
         let harness = Harness()
         harness.cliInstallError = NSError(domain: "tests", code: 1, userInfo: [NSLocalizedDescriptionKey: "install failed"])
-        let controller = LaunchProviderController(dependencies: harness.dependencies())
+        let controller = makeController(harness)
 
         await controller.launch()
 
@@ -56,7 +168,7 @@ final class LaunchProviderControllerTests: XCTestCase {
     func testLaunchMonitorFailureIsRetryable() async {
         let harness = Harness()
         harness.monitorHealthy = false
-        let controller = LaunchProviderController(dependencies: harness.dependencies())
+        let controller = makeController(harness)
 
         await controller.launch()
 
@@ -73,7 +185,7 @@ final class LaunchProviderControllerTests: XCTestCase {
     func testRetryRerunsInstallAfterFailure() async {
         let harness = Harness()
         harness.cliInstallError = NSError(domain: "tests", code: 1, userInfo: [NSLocalizedDescriptionKey: "install failed"])
-        let controller = LaunchProviderController(dependencies: harness.dependencies())
+        let controller = makeController(harness)
 
         await controller.launch()
         harness.cliInstallError = nil
@@ -88,12 +200,12 @@ final class LaunchProviderControllerTests: XCTestCase {
         let harness = Harness()
         harness.localInstallSucceeded = true
         harness.appIdentityConfigured = true
-        let controller = LaunchProviderController(dependencies: harness.dependencies())
+        let controller = makeController(harness)
 
         await controller.refreshFromExistingInstall()
 
         XCTAssertEqual(harness.cliInstallRuns, 0)
-        XCTAssertEqual(harness.monitorRuns, 1)
+        XCTAssertEqual(harness.monitorRuns, 0)
         XCTAssertEqual(harness.loginItemRegistrations, 1)
         XCTAssertEqual(harness.startAgentRuns, 1)
         XCTAssertEqual(controller.stage, .live(model: harness.configModel, tier: .provisional))
@@ -104,7 +216,7 @@ final class LaunchProviderControllerTests: XCTestCase {
         harness.cliImportErrors = [
             NSError(domain: "tests", code: 2, userInfo: [NSLocalizedDescriptionKey: "import failed"])
         ]
-        let controller = LaunchProviderController(dependencies: harness.dependencies())
+        let controller = makeController(harness)
 
         await controller.launch()
 
@@ -127,7 +239,7 @@ final class LaunchProviderControllerTests: XCTestCase {
         let harness = Harness()
         harness.markLocalInstallSucceededAfterInstall = false
         harness.cliImportErrors = [ProviderConfig.SaveError.missingProviderToken]
-        let controller = LaunchProviderController(dependencies: harness.dependencies())
+        let controller = makeController(harness)
 
         await controller.launch()
 
@@ -146,7 +258,7 @@ final class LaunchProviderControllerTests: XCTestCase {
             repeating: ProviderConfig.SaveError.missingProviderToken,
             count: 2 * (MalibuOnboardingTimeouts.providerTokenImportRetryAttempts + 1)
         )
-        let controller = LaunchProviderController(dependencies: harness.dependencies())
+        let controller = makeController(harness)
 
         await controller.launch()
         await controller.retry()
@@ -178,7 +290,7 @@ final class LaunchProviderControllerTests: XCTestCase {
         harness.cliImportErrors = [
             ProviderConfig.SaveError.importKeychainVerificationFailed
         ]
-        let controller = LaunchProviderController(dependencies: harness.dependencies())
+        let controller = makeController(harness)
 
         await controller.launch()
 
@@ -203,7 +315,7 @@ final class LaunchProviderControllerTests: XCTestCase {
         harness.providerStartFailureMessage =
             "Model catalog is out of date for this Mac. Update Malibu to the latest release, "
             + "or run: macprovider-cli autotune --recommend --apply"
-        let controller = LaunchProviderController(dependencies: harness.dependencies())
+        let controller = makeController(harness)
 
         await controller.launch()
 
@@ -216,11 +328,77 @@ final class LaunchProviderControllerTests: XCTestCase {
         }
     }
 
+    // PROD-M4: after policy discovery leaves the invite non-required, an
+    // authoritative `referral_required` rejection from the install log must
+    // re-gate to a mandatory invite (not a generic Retry with no invite field).
+    func testAuthoritativeReferralRequiredReGatesToMandatoryInvite() async {
+        let harness = Harness()
+        harness.referralPreflight = ReferralPreflightResult(valid: true, reason: "disabled", required: false)
+        harness.installLogLines = ["macprovider-install FATAL: MACPROVIDER_REFERRAL_REJECTED referral_required"]
+        harness.cliInstallError = NSError(
+            domain: "tests", code: 6, userInfo: [NSLocalizedDescriptionKey: "install failed"]
+        )
+        let controller = makeController(harness)
+
+        await controller.refreshReferralPolicy()
+        XCTAssertFalse(controller.referralRequired)
+
+        await controller.launch()
+
+        XCTAssertTrue(controller.referralRequired)
+        XCTAssertEqual(
+            controller.stage,
+            .failed(
+                stage: "referral",
+                retryable: true,
+                message: "An invite code is required. Enter a new invite code."
+            )
+        )
+    }
+
+    // PROD-M1: when policy discovery failed (.unknown) and no invite is
+    // supplied, an authoritative `required` preflight must re-gate to the
+    // editable invite step BEFORE the expensive installer runs — not after
+    // 10–30 min of downloads/tuning.
+    func testUnknownPolicyRejectsMissingInviteBeforeInstaller() async {
+        let harness = Harness()
+        harness.referralPreflightError = NSError(domain: "tests", code: 0)
+        harness.referralPreflight = ReferralPreflightResult(valid: false, reason: "missing", required: true)
+        harness.expectedReferralCode = ""
+        let controller = LaunchProviderController(dependencies: harness.dependencies())
+
+        await controller.refreshReferralPolicy()
+        XCTAssertFalse(controller.referralRequired)
+
+        await controller.launch()
+
+        XCTAssertEqual(harness.cliInstallRuns, 0)
+        XCTAssertEqual(
+            controller.stage,
+            .failed(stage: "referral", retryable: true, message: "An invite code is required. Enter a new invite code.")
+        )
+    }
+
+    // PROD-M1: an unknown policy with a valid supplied code validates the code
+    // at preflight and then proceeds to install (no false gate).
+    func testUnknownPolicyValidatesSuppliedCodeThenInstalls() async {
+        let harness = Harness()
+        harness.referralPreflightError = NSError(domain: "tests", code: 0)
+        harness.referralPreflight = ReferralPreflightResult(valid: true, reason: "valid", required: true)
+        let controller = makeController(harness)
+
+        await controller.refreshReferralPolicy()
+        await controller.launch()
+
+        XCTAssertEqual(harness.cliInstallRuns, 1)
+        XCTAssertEqual(controller.stage, .live(model: harness.configModel, tier: .provisional))
+    }
+
     func testAttachFailureDoesNotRegisterLoginItemOrMarkLive() async {
         let harness = Harness()
         harness.attachHealthy = false
         harness.providerStartFailureMessage = "provider attach failed"
-        let controller = LaunchProviderController(dependencies: harness.dependencies())
+        let controller = makeController(harness)
 
         await controller.launch()
 
@@ -238,7 +416,51 @@ final class LaunchProviderControllerTests: XCTestCase {
         }
     }
 
+    // PROD-M6: "Start New" records the retired identity (id + archive path) so
+    // the UI can name it and offer an undo; the undo restores it and clears the
+    // banner.
+    func testStartAsNewProviderRecordsRetiredIdentityAndUndoRestores() async {
+        let harness = Harness()
+        harness.providerID = "p_retire_me"
+        let archive = URL(fileURLWithPath: "/tmp/malibu-archive-xyz")
+        harness.startFreshArchive = archive
+        let controller = LaunchProviderController(dependencies: harness.dependencies())
+
+        await controller.startAsNewProvider()
+
+        XCTAssertEqual(controller.retiredIdentity?.providerID, "p_retire_me")
+        XCTAssertEqual(controller.retiredIdentity?.archivePath, archive.path)
+        XCTAssertEqual(controller.stage, .idle)
+
+        await controller.undoStartAsNewProvider()
+
+        XCTAssertEqual(harness.restoreRuns, 1)
+        XCTAssertNil(controller.retiredIdentity)
+        XCTAssertEqual(controller.stage, .idle)
+    }
+
+    func testUndoStartAsNewProviderSurfacesRestoreFailure() async {
+        let harness = Harness()
+        harness.startFreshArchive = URL(fileURLWithPath: "/tmp/malibu-archive-xyz")
+        harness.restoreError = NSError(domain: "tests", code: 9, userInfo: [NSLocalizedDescriptionKey: "occupied"])
+        let controller = LaunchProviderController(dependencies: harness.dependencies())
+
+        await controller.startAsNewProvider()
+        await controller.undoStartAsNewProvider()
+
+        // The retired banner remains so the user can retry / restore manually.
+        XCTAssertNotNil(controller.retiredIdentity)
+        if case let .failed(stage, retryable, message) = controller.stage {
+            XCTAssertEqual(stage, "startFresh")
+            XCTAssertTrue(retryable)
+            XCTAssertTrue(message.contains("occupied"))
+        } else {
+            XCTFail("expected failed startFresh stage after restore failure")
+        }
+    }
+
     private final class Harness {
+        static let validReferralCode = "MAL1-S-key-seed-AAAAAAAAAAAAAAAAAAAAAAAAAA"
         var localInstallSucceeded = false
         var localInstallSucceededAfterInstall = false
         var markLocalInstallSucceededAfterInstall = true
@@ -251,22 +473,44 @@ final class LaunchProviderControllerTests: XCTestCase {
         var monitorHealthy = true
         var attachHealthy = true
         var appIdentityConfigured = false
+        var existingIdentityMissingBearer = false
         var providerStartFailureMessage: String?
         var cliInstallError: Error?
         var cliImportErrors: [Error] = []
         var configModel = "mlx-community/Qwen2.5-7B-Instruct-4bit"
         var installLogLines: [String] = []
+        var referralPreflight = ReferralPreflightResult(valid: true, reason: "valid")
+        // PROD-M1: when set, validateReferralCode throws this on its FIRST call
+        // only — used to drive policy discovery into `.unknown` (refresh) while
+        // still returning a definitive result at the pre-install preflight.
+        var referralPreflightError: Error?
+        var expectedReferralCode = Harness.validReferralCode
+        // PROD-M6: start-fresh archive + undo injection.
+        var providerID = "p_existing"
+        var startFreshArchive: URL? = URL(fileURLWithPath: "/tmp/malibu-test-archive")
+        var startFreshError: Error?
+        var restoreError: Error?
+        var restoreRuns = 0
 
         func dependencies() -> LaunchProviderController.Dependencies {
             LaunchProviderController.Dependencies(
                 localInstallSucceeded: {
                     self.localInstallSucceeded || self.localInstallSucceededAfterInstall
                 },
+                validateReferralCode: { _ in
+                    if let error = self.referralPreflightError {
+                        self.referralPreflightError = nil
+                        throw error
+                    }
+                    return self.referralPreflight
+                },
                 registerLoginItem: {
                     self.loginItemRegistrations += 1
                 },
-                runCLIInstall: { onLogLine in
+                runCLIInstall: { referralCode, onLogLine in
+                    XCTAssertEqual(referralCode, self.expectedReferralCode)
                     self.cliInstallRuns += 1
+                    for line in self.installLogLines { onLogLine(line) }
                     if let error = self.cliInstallError { throw error }
                     self.localInstallSucceededAfterInstall = self.markLocalInstallSucceededAfterInstall
                     onLogLine("install.sh finished")
@@ -291,6 +535,16 @@ final class LaunchProviderControllerTests: XCTestCase {
                 appIdentityConfigured: { self.appIdentityConfigured },
                 waitBeforeImportRetry: {
                     self.importRetryWaits += 1
+                },
+                existingIdentityMissingBearer: { self.existingIdentityMissingBearer },
+                readProviderID: { self.providerID },
+                moveAppOwnedConfigAside: {
+                    if let error = self.startFreshError { throw error }
+                    return self.startFreshArchive
+                },
+                restoreArchivedIdentity: { _ in
+                    self.restoreRuns += 1
+                    if let error = self.restoreError { throw error }
                 }
             )
         }

--- a/phase3-binary/app/Tests/MalibuTests/ProcessEnvironmentSanitizerTests.swift
+++ b/phase3-binary/app/Tests/MalibuTests/ProcessEnvironmentSanitizerTests.swift
@@ -2,7 +2,7 @@ import XCTest
 @testable import Malibu
 
 final class ProcessEnvironmentSanitizerTests: XCTestCase {
-    func testChildEnvironmentKeepsOnlyAllowlistedInheritedValuesAndExplicitToken() throws {
+    func testChildEnvironmentKeepsOnlyAllowlistedInheritedValues() throws {
         let sanitized = try ProcessEnvironmentSanitizer.sanitized(
             from: [
                 "PATH": "/usr/bin:/bin",
@@ -11,16 +11,26 @@ final class ProcessEnvironmentSanitizerTests: XCTestCase {
                 "MACPROVIDER_EVIL": "1",
                 "MALIBU_CLI_PATH": "/tmp/fake"
             ],
-            extraEnvironment: [
-                "MACPROVIDER_PROVIDER_TOKEN": "provider-token"
-            ]
+            extraEnvironment: ["MACPROVIDER_SAFE_OVERRIDE": "enabled"]
         )
 
         XCTAssertEqual(sanitized["PATH"], "/usr/bin:/bin")
         XCTAssertEqual(sanitized["LC_CTYPE"], "UTF-8")
-        XCTAssertEqual(sanitized["MACPROVIDER_PROVIDER_TOKEN"], "provider-token")
+        XCTAssertEqual(sanitized["MACPROVIDER_SAFE_OVERRIDE"], "enabled")
         XCTAssertNil(sanitized["MACPROVIDER_EVIL"])
         XCTAssertNil(sanitized["MALIBU_CLI_PATH"])
+    }
+
+    func testChildEnvironmentRejectsProviderBearerEvenWhenExplicit() {
+        XCTAssertThrowsError(try ProcessEnvironmentSanitizer.sanitized(
+            from: [:],
+            extraEnvironment: ["MACPROVIDER_PROVIDER_TOKEN": "provider-token"]
+        )) { error in
+            XCTAssertEqual(
+                error as? ProcessEnvironmentSanitizer.Error,
+                .forbiddenSecretKey("MACPROVIDER_PROVIDER_TOKEN")
+            )
+        }
     }
 
     func testChildEnvironmentRejectsUnsafeInheritedValue() {

--- a/phase3-binary/app/Tests/MalibuTests/ProviderConfigTests.swift
+++ b/phase3-binary/app/Tests/MalibuTests/ProviderConfigTests.swift
@@ -524,6 +524,48 @@ final class ProviderConfigParserTests: XCTestCase {
         )
     }
 
+    // PROD-M6: "Start New" archives the identity bundle; the undo restores it
+    // in place, and a restore over a live identity is refused.
+    func testRestoreArchivedIdentityRoundTrip() throws {
+        let paths = try makeTempPaths()
+        try paths.ensureDirectories()
+        defer { try? FileManager.default.removeItem(at: paths.configFile.deletingLastPathComponent().deletingLastPathComponent()) }
+        try "provider_id: p_old\nprovider_token: old-token\n".write(to: paths.configFile, atomically: true, encoding: .utf8)
+        try Data().write(to: paths.appMarkerFile)
+        try "p_old".write(to: ProviderConfig.providerIDFile(paths: paths), atomically: true, encoding: .utf8)
+
+        let archive = try XCTUnwrap(ProviderConfig.startFreshMovingCLIConfigAside(paths: paths))
+        XCTAssertFalse(FileManager.default.fileExists(atPath: paths.configFile.path))
+        XCTAssertFalse(FileManager.default.fileExists(atPath: paths.appMarkerFile.path))
+
+        try ProviderConfig.restoreArchivedIdentity(from: archive, paths: paths)
+        XCTAssertTrue(FileManager.default.fileExists(atPath: paths.configFile.path))
+        XCTAssertTrue(FileManager.default.fileExists(atPath: paths.appMarkerFile.path))
+        XCTAssertEqual(ProviderConfig.readProviderID(paths: paths), "p_old")
+        XCTAssertFalse(FileManager.default.fileExists(atPath: archive.path))
+    }
+
+    func testRestoreArchivedIdentityRefusesWhenDestinationOccupied() throws {
+        let paths = try makeTempPaths()
+        try paths.ensureDirectories()
+        defer { try? FileManager.default.removeItem(at: paths.configFile.deletingLastPathComponent().deletingLastPathComponent()) }
+        try "provider_id: p_old\nprovider_token: old-token\n".write(to: paths.configFile, atomically: true, encoding: .utf8)
+        try Data().write(to: paths.appMarkerFile)
+
+        let archive = try XCTUnwrap(ProviderConfig.startFreshMovingCLIConfigAside(paths: paths))
+        // A replacement identity is created before the user tries to undo.
+        try "provider_id: p_new\nprovider_token: new-token\n".write(to: paths.configFile, atomically: true, encoding: .utf8)
+
+        XCTAssertThrowsError(try ProviderConfig.restoreArchivedIdentity(from: archive, paths: paths)) { error in
+            guard case ProviderConfig.SaveError.restoreDestinationOccupied = error else {
+                return XCTFail("expected restoreDestinationOccupied, got \(error)")
+            }
+        }
+        // The replacement identity is untouched and the archive is preserved.
+        XCTAssertEqual(ProviderConfig.readProviderID(paths: paths), "p_new")
+        XCTAssertTrue(FileManager.default.fileExists(atPath: archive.path))
+    }
+
     private func makeTempPaths() throws -> ProviderPaths {
         let root = FileManager.default.temporaryDirectory
             .appendingPathComponent("malibu-provider-config-tests-\(UUID().uuidString)", isDirectory: true)
@@ -584,5 +626,41 @@ final class ProviderConfigParserTests: XCTestCase {
         var st = stat()
         XCTAssertEqual(lstat(url.path, &st), 0)
         return st.st_mode
+    }
+
+    // PROD-H3: "Start as a new provider" must retire the COMPLETE identity
+    // bundle. Leaving the durable provider_id file (or the app marker) behind
+    // makes the installer's choose_provider_id reuse the old bound provider_id.
+    func testStartFreshArchivesCompleteIdentityBundle() throws {
+        let paths = try makeTempPaths()
+        let fm = FileManager.default
+        try paths.ensureDirectories()
+        let providerIDFile = ProviderConfig.providerIDFile(paths: paths)
+        try "provider_id: mp-old-bound-identity\nmodel: test\n"
+            .write(to: paths.configFile, atomically: true, encoding: .utf8)
+        try "mp-old-bound-identity\n"
+            .write(to: providerIDFile, atomically: true, encoding: .utf8)
+        XCTAssertTrue(fm.createFile(atPath: paths.appMarkerFile.path, contents: Data()))
+
+        let archive = try ProviderConfig.startFreshMovingCLIConfigAside(paths: paths)
+
+        // The whole bundle is moved out of the live locations, so the next
+        // install generates a brand-new provider_id.
+        XCTAssertFalse(fm.fileExists(atPath: paths.configFile.path))
+        XCTAssertFalse(fm.fileExists(atPath: providerIDFile.path))
+        XCTAssertFalse(fm.fileExists(atPath: paths.appMarkerFile.path))
+        XCTAssertNil(ProviderConfig.readProviderID(paths: paths))
+
+        // Every artifact is preserved in the returned archive directory.
+        let archiveDir = try XCTUnwrap(archive)
+        XCTAssertTrue(fm.fileExists(atPath: archiveDir.appendingPathComponent("config.yaml").path))
+        XCTAssertTrue(fm.fileExists(atPath: archiveDir.appendingPathComponent("provider_id").path))
+        XCTAssertTrue(fm.fileExists(atPath: archiveDir.appendingPathComponent(".installed-by-app").path))
+    }
+
+    func testStartFreshReturnsNilWhenNoIdentityPresent() throws {
+        let paths = try makeTempPaths()
+        try paths.ensureDirectories()
+        XCTAssertNil(try ProviderConfig.startFreshMovingCLIConfigAside(paths: paths))
     }
 }

--- a/phase3-binary/app/Tests/MalibuTests/RegisterClientTests.swift
+++ b/phase3-binary/app/Tests/MalibuTests/RegisterClientTests.swift
@@ -25,6 +25,7 @@ final class RegisterClientTests: XCTestCase {
                 "app_version": "1.0.3"
             ],
             referralCode: "MAL1-S-k1-seed-TEST",
+            providerTokenCandidate: String(repeating: "c", count: 64),
             nonce: String(repeating: "a", count: 64),
             timestamp: Date(timeIntervalSince1970: 1_783_082_460)
         )
@@ -36,6 +37,7 @@ final class RegisterClientTests: XCTestCase {
             "app_attest_object",
             "app_attest_key_id",
             "referral_code",
+            "provider_token_candidate",
             "nonce",
             "ts_utc",
             "signature"
@@ -44,6 +46,7 @@ final class RegisterClientTests: XCTestCase {
         XCTAssertFalse(request.fieldNames.contains("provider_name"))
         XCTAssertFalse(request.fieldNames.contains("signature_alg"))
         XCTAssertEqual(request.referralCode, "MAL1-S-k1-seed-TEST")
+        XCTAssertEqual(request.providerTokenCandidate, String(repeating: "c", count: 64))
 
         let canonical = try RegisterClient.canonicalRegisterPayloadWithoutSignature(request)
         let signature = Data(base64Encoded: request.signature)

--- a/phase3-binary/app/Tests/MalibuTests/RegisterClientTests.swift
+++ b/phase3-binary/app/Tests/MalibuTests/RegisterClientTests.swift
@@ -24,6 +24,7 @@ final class RegisterClientTests: XCTestCase {
                 "macos_version": "14.5",
                 "app_version": "1.0.3"
             ],
+            referralCode: "MAL1-S-k1-seed-TEST",
             nonce: String(repeating: "a", count: 64),
             timestamp: Date(timeIntervalSince1970: 1_783_082_460)
         )
@@ -34,6 +35,7 @@ final class RegisterClientTests: XCTestCase {
             "hardware_summary",
             "app_attest_object",
             "app_attest_key_id",
+            "referral_code",
             "nonce",
             "ts_utc",
             "signature"
@@ -41,6 +43,7 @@ final class RegisterClientTests: XCTestCase {
         XCTAssertFalse(request.fieldNames.contains("binary_version"))
         XCTAssertFalse(request.fieldNames.contains("provider_name"))
         XCTAssertFalse(request.fieldNames.contains("signature_alg"))
+        XCTAssertEqual(request.referralCode, "MAL1-S-k1-seed-TEST")
 
         let canonical = try RegisterClient.canonicalRegisterPayloadWithoutSignature(request)
         let signature = Data(base64Encoded: request.signature)

--- a/phase3-binary/app/Tests/MalibuTests/StartupRouteTests.swift
+++ b/phase3-binary/app/Tests/MalibuTests/StartupRouteTests.swift
@@ -60,8 +60,19 @@ final class StartupRouteTests: XCTestCase {
         XCTAssertNotNil(result.backupPath)
         XCTAssertFalse(FileManager.default.fileExists(atPath: paths.configFile.path))
         XCTAssertTrue(FileManager.default.fileExists(atPath: result.backupPath!))
-        let attrs = try FileManager.default.attributesOfItem(atPath: result.backupPath!)
-        XCTAssertEqual((attrs[.posixPermissions] as? NSNumber)?.intValue, 0o600)
+        // PROD-H3/M6: startFresh archives the whole identity bundle into a
+        // timestamped directory. The directory is 0o700; each archived artifact
+        // inside stays 0o600.
+        var isDirectory: ObjCBool = false
+        XCTAssertTrue(FileManager.default.fileExists(atPath: result.backupPath!, isDirectory: &isDirectory))
+        XCTAssertTrue(isDirectory.boolValue)
+        let dirAttrs = try FileManager.default.attributesOfItem(atPath: result.backupPath!)
+        XCTAssertEqual((dirAttrs[.posixPermissions] as? NSNumber)?.intValue, 0o700)
+        let archivedConfig = URL(fileURLWithPath: result.backupPath!)
+            .appendingPathComponent(paths.configFile.lastPathComponent)
+        XCTAssertTrue(FileManager.default.fileExists(atPath: archivedConfig.path))
+        let fileAttrs = try FileManager.default.attributesOfItem(atPath: archivedConfig.path)
+        XCTAssertEqual((fileAttrs[.posixPermissions] as? NSNumber)?.intValue, 0o600)
     }
 
     func testMigrationCancelTouchesNoFiles() async throws {

--- a/phase3-binary/dist/install.sh
+++ b/phase3-binary/dist/install.sh
@@ -53,6 +53,12 @@ NO_PROMPT="${MACPROVIDER_NO_PROMPT:-0}"
 NO_LAUNCHD="${MACPROVIDER_NO_LAUNCHD:-0}"
 EMERGENCY_ROLLBACK="${MACPROVIDER_EMERGENCY_ROLLBACK:-0}"
 APP_MANAGED_REPAIR="${MACPROVIDER_APP_MANAGED_REPAIR:-0}"
+APP_MANAGED_PROVIDER_TOKEN_FD=""
+# This variable is populated only from an inherited descriptor. Clear any
+# same-named environment entry first so the bearer can never become exported
+# to installer subprocesses by accident.
+unset APP_MANAGED_PROVIDER_TOKEN
+APP_MANAGED_PROVIDER_TOKEN=""
 EMERGENCY_CONFIG_BACKUP="${MACPROVIDER_EMERGENCY_CONFIG_BACKUP:-}"
 EMERGENCY_CONFIG_SHA256="${MACPROVIDER_EMERGENCY_CONFIG_SHA256:-}"
 EMERGENCY_STAGED_CONFIG_SHA256=""
@@ -203,14 +209,24 @@ validate_port_value() {
 run_macprovider_cli_with_amfi_retry() {
   local rc=0
   local cli_path="$MACPROVIDER_CLI_EXECUTABLE"
-  "$cli_path" "$@" || rc=$?
+  _run_macprovider_cli_once() {
+    if [ "${MACPROVIDER_CLI_USE_APP_TOKEN:-0}" -eq 1 ]; then
+      # The token lives only in a non-exported shell variable and this
+      # anonymous pipe. Append the non-secret descriptor flag to the CLI argv.
+      printf "%s" "$APP_MANAGED_PROVIDER_TOKEN" | "$cli_path" "$@" --token-fd 0
+      local cli_rc="${PIPESTATUS[1]}"
+      return "$cli_rc"
+    fi
+    "$cli_path" "$@"
+  }
+  _run_macprovider_cli_once "$@" || rc=$?
   if [ "$rc" -ne 137 ]; then
     return "$rc"
   fi
   log "macprovider-cli was SIGKILL'd on first invocation (rc=$rc); likely a transient AMFI code-signature race after pkg install. Retrying once after 2s." >&2
   sleep 2
   rc=0
-  "$cli_path" "$@" || rc=$?
+  _run_macprovider_cli_once "$@" || rc=$?
   if [ "$rc" -ne 137 ]; then
     return "$rc"
   fi
@@ -241,7 +257,7 @@ run_macprovider_cli_with_amfi_retry() {
   fi
   rm -f "$tmp"
   rc=0
-  "$cli_path" "$@" || rc=$?
+  _run_macprovider_cli_once "$@" || rc=$?
   if [ "$rc" -eq 137 ]; then
     log "macprovider-cli was SIGKILL'd after the inode refresh; this is likely a genuine signature failure rather than the AMFI cache." >&2
   fi
@@ -268,17 +284,17 @@ fi
 
 usage() {
   cat <<'USAGE'
-Usage: bash install.sh [--dry-run] [--ref CODE]
+Usage: bash install.sh [--dry-run] [--ref CODE_OR_INVITE_URL]
 
 Referral invite:
-  curl -fsSL https://get.streamvc.live/install.sh | bash -s -- --ref CODE
+  curl -fsSL https://get.streamvc.live/install.sh | bash -s -- --ref CODE_OR_INVITE_URL
 
 Environment overrides:
   MACPROVIDER_GITHUB_REPO        owner/repo for GitHub Releases
   MACPROVIDER_VERSION            pin installer to vMAJOR.MINOR.PATCH
                                  (pipe-side form: curl ... | MACPROVIDER_VERSION=v1.7.11 bash)
   MACPROVIDER_COORDINATOR_URL    coordinator WebSocket URL
-  MACPROVIDER_REFERRAL_CODE      pre-beta referral code (same as --ref)
+  MACPROVIDER_REFERRAL_CODE      pre-beta code or canonical invite URL (same as --ref)
   MACPROVIDER_PORT               local HTTP port
   MACPROVIDER_INSTALL_DIR        support dir for binary + bundles
   MACPROVIDER_RELEASE_FORMAT     auto, pkg, or tar (default: auto)
@@ -289,7 +305,8 @@ Environment overrides:
                                  launchd service but skip the watchdog
   MACPROVIDER_APP_MANAGED_REPAIR=1
                                  Malibu.app only: update an existing app-owned
-                                 install without starting credential-less launchd
+                                 install without starting credential-less launchd;
+                                 requires --provider-token-fd N
   MACPROVIDER_EMERGENCY_ROLLBACK=1
                                  operator-only signed rollback to an explicit
                                  MACPROVIDER_VERSION; commits only through an
@@ -302,16 +319,86 @@ while [ "$#" -gt 0 ]; do
   case "$1" in
     --dry-run) DRY_RUN=1 ;;
     --ref|--referral-code)
-      [ "$#" -ge 2 ] || die 7 "$1 requires a referral code"
+      [ "$#" -ge 2 ] || die 7 "$1 requires CODE_OR_INVITE_URL"
       REFERRAL_CODE="$2"
       shift
       ;;
     --ref=*|--referral-code=*) REFERRAL_CODE="${1#*=}" ;;
+    --provider-token-fd)
+      [ "$#" -ge 2 ] || die 7 "$1 requires a file descriptor"
+      APP_MANAGED_PROVIDER_TOKEN_FD="$2"
+      shift
+      ;;
+    --provider-token-fd=*) APP_MANAGED_PROVIDER_TOKEN_FD="${1#*=}" ;;
     -h|--help) usage; exit 0 ;;
     *) die 7 "unknown argument: $1" ;;
   esac
   shift
 done
+
+read_app_managed_provider_token() {
+  if [ "$APP_MANAGED_REPAIR" -ne 1 ]; then
+    [ -z "$APP_MANAGED_PROVIDER_TOKEN_FD" ] \
+      || die 7 "--provider-token-fd is reserved for app-managed repair"
+    return 0
+  fi
+  [ -n "$APP_MANAGED_PROVIDER_TOKEN_FD" ] \
+    || die 7 "app-managed repair requires --provider-token-fd"
+  case "$APP_MANAGED_PROVIDER_TOKEN_FD" in
+    *[!0-9]*) die 7 "--provider-token-fd must be a non-negative file descriptor" ;;
+  esac
+  APP_MANAGED_PROVIDER_TOKEN=""
+  if ! IFS= read -r APP_MANAGED_PROVIDER_TOKEN <&"$APP_MANAGED_PROVIDER_TOKEN_FD"; then
+    [ -n "$APP_MANAGED_PROVIDER_TOKEN" ] \
+      || die 7 "app-managed repair provider token descriptor was empty or unreadable"
+  fi
+  [ "${#APP_MANAGED_PROVIDER_TOKEN}" -eq 64 ] \
+    || die 7 "app-managed repair provider token must be 64 lowercase hex characters"
+  case "$APP_MANAGED_PROVIDER_TOKEN" in
+    *[!0-9a-f]*) die 7 "app-managed repair provider token must be 64 lowercase hex characters" ;;
+  esac
+}
+
+normalize_referral_code() {
+  local raw="$1"
+  local authority_and_path authority path code
+  # Match Malibu.app: accept harmless surrounding whitespace, then parse the
+  # value locally without fetching the invite URL.
+  raw="${raw#"${raw%%[![:space:]]*}"}"
+  raw="${raw%"${raw##*[![:space:]]}"}"
+  case "$raw" in
+    https://*)
+      authority_and_path="${raw#https://}"
+      authority="${authority_and_path%%/*}"
+      case "$authority" in
+        ''|*@*) return 1 ;;
+      esac
+      [ "$authority_and_path" != "$authority" ] || return 1
+      path="/${authority_and_path#*/}"
+      path="${path%%\?*}"
+      path="${path%%\#*}"
+      # Accept exactly one optional trailing slash, but no path segment after
+      # the invite code.
+      case "$path" in
+        */) path="${path%/}" ;;
+      esac
+      case "$path" in
+        */j/*) code="${path##*/j/}" ;;
+        *) return 1 ;;
+      esac
+      case "$code" in
+        ''|*/*) return 1 ;;
+      esac
+      printf '%s' "$code"
+      ;;
+    *://*) return 1 ;;
+    *) printf '%s' "$raw" ;;
+  esac
+}
+
+if ! REFERRAL_CODE="$(normalize_referral_code "$REFERRAL_CODE")"; then
+  die 7 "referral invite URL must use the canonical https://<host>/j/CODE form"
+fi
 
 if [ -n "$REFERRAL_CODE" ] && [[ ! "$REFERRAL_CODE" =~ ^MAL1-[SP]-[A-Za-z0-9_]{1,32}-[A-Za-z0-9_]{1,32}-[A-Z2-7]{26}$ ]]; then
   die 7 "referral code has an invalid format"
@@ -2154,15 +2241,29 @@ advisory_validate_referral() {
   fi
   result="$(printf "%s" "$response" | python3 -c 'import json,sys
 try:
- d=json.load(sys.stdin); print(("valid" if d.get("valid") else "invalid") + ":" + str(d.get("reason", "invalid")))
+ d=json.load(sys.stdin)
+ required=d["required"]; valid=d["valid"]; reason=d["reason"]
+ if type(required) is not bool or type(valid) is not bool or type(reason) is not str: raise ValueError()
+ rejected={"missing","invalid","expired","revoked","exhausted","conflict"}
+ if required is False and valid is True and reason == "disabled": print("valid:disabled")
+ elif required is True and valid is True and reason == "valid": print("valid:valid")
+ elif required is True and valid is False and reason in rejected: print("invalid:" + reason)
+ else: print("unavailable:invalid")
 except Exception: print("unavailable:invalid")')"
   case "$result" in
     valid:*) return 0 ;;
-    invalid:expired) die 7 "referral code has expired; use a different invite" ;;
-    invalid:revoked) die 7 "referral code is no longer available; use a different invite" ;;
-    invalid:exhausted) die 7 "referral code has already been used; use a different invite" ;;
-    invalid:*) die 7 "referral code is not valid; check it or use a different invite" ;;
+    invalid:*) die 7 "$(referral_rejection_message "${result#invalid:}")" ;;
     *) log "Invite pre-check response was unavailable; authoritative validation will run during credential registration." ;;
+  esac
+}
+
+referral_rejection_message() {
+  case "$1" in
+    missing|required) printf '%s' 'An invite is required; rerun with --ref CODE_OR_INVITE_URL' ;;
+    expired) printf '%s' "This invite has expired; use a different invite" ;;
+    revoked) printf '%s' "This invite is no longer available; use a different invite" ;;
+    exhausted) printf '%s' "All spots on this invite are taken; use a different invite" ;;
+    *) printf '%s' "This invite is not valid; check it or use a different invite" ;;
   esac
 }
 
@@ -3281,7 +3382,7 @@ ensure_provider_credentials() {
     referral_reason="$(sed -n 's/.*MACPROVIDER_REFERRAL_REJECTED reason=referral_\([a-z]*\).*/\1/p' "$bootstrap_err" | head -n1)"
     rm -f "$bootstrap_err"
     if [ -n "$referral_reason" ]; then
-      die 7 "provider registration rejected the invite (referral_$referral_reason); enter a new invite and try again"
+      die 7 "$(referral_rejection_message "$referral_reason") (referral_$referral_reason)"
     fi
     die 6 "provider credential bootstrap failed before evidence admission"
   fi
@@ -3318,6 +3419,12 @@ ensure_provider_credentials() {
 
 submit_required_hardware_evidence() {
   log "Submitting the exact stored autotune evidence before provider service start."
+  local MACPROVIDER_CLI_USE_APP_TOKEN=0
+  if [ "${APP_MANAGED_REPAIR:-0}" -eq 1 ]; then
+    [ -n "$APP_MANAGED_PROVIDER_TOKEN" ] \
+      || die 6 "app-managed repair lost provider credential custody before evidence admission"
+    MACPROVIDER_CLI_USE_APP_TOKEN=1
+  fi
   run_macprovider_cli_with_amfi_retry autotune --recommend --freshness-check \
     --submit-hardware-evidence --require-hardware-evidence --config "$CONFIG_PATH" >/dev/null \
     || die 6 "authenticated hardware evidence admission failed before service start"
@@ -5124,6 +5231,7 @@ main() {
     0|1) ;;
     *) die 7 "MACPROVIDER_APP_MANAGED_REPAIR must be 0 or 1" ;;
   esac
+  read_app_managed_provider_token
   acquire_install_lock
   recover_orphaned_install_transactions
 

--- a/phase3-binary/dist/install.sh
+++ b/phase3-binary/dist/install.sh
@@ -31,6 +31,7 @@ LIVE_CONFIG_PATH="$CONFIG_PATH"
 LIVE_PROVIDER_ID_PATH="$PROVIDER_ID_PATH"
 MANIFEST_DIR="$HOME/Library/Application Support/macprovider"
 MANIFEST_PATH="$MANIFEST_DIR/install_manifest.json"
+APP_MARKER_PATH="$HOME/Library/Application Support/Malibu/.installed-by-app"
 EXISTING_INSTALL_WAS_PRESENT=0
 PLIST_PATH="$HOME/Library/LaunchAgents/live.streamvc.macprovider.plist"
 LOG_DIR="$HOME/Library/Logs/macprovider"
@@ -47,9 +48,11 @@ WATCHDOG_PLIST_PATH="$HOME/Library/LaunchAgents/live.streamvc.macprovider-watchd
 WATCHDOG_LABEL="live.streamvc.macprovider-watchdog"
 NO_WATCHDOG="${MACPROVIDER_NO_WATCHDOG:-0}"
 DRY_RUN=0
+REFERRAL_CODE="${MACPROVIDER_REFERRAL_CODE:-}"
 NO_PROMPT="${MACPROVIDER_NO_PROMPT:-0}"
 NO_LAUNCHD="${MACPROVIDER_NO_LAUNCHD:-0}"
 EMERGENCY_ROLLBACK="${MACPROVIDER_EMERGENCY_ROLLBACK:-0}"
+APP_MANAGED_REPAIR="${MACPROVIDER_APP_MANAGED_REPAIR:-0}"
 EMERGENCY_CONFIG_BACKUP="${MACPROVIDER_EMERGENCY_CONFIG_BACKUP:-}"
 EMERGENCY_CONFIG_SHA256="${MACPROVIDER_EMERGENCY_CONFIG_SHA256:-}"
 EMERGENCY_STAGED_CONFIG_SHA256=""
@@ -265,13 +268,17 @@ fi
 
 usage() {
   cat <<'USAGE'
-Usage: bash install.sh [--dry-run]
+Usage: bash install.sh [--dry-run] [--ref CODE]
+
+Referral invite:
+  curl -fsSL https://get.streamvc.live/install.sh | bash -s -- --ref CODE
 
 Environment overrides:
   MACPROVIDER_GITHUB_REPO        owner/repo for GitHub Releases
   MACPROVIDER_VERSION            pin installer to vMAJOR.MINOR.PATCH
                                  (pipe-side form: curl ... | MACPROVIDER_VERSION=v1.7.11 bash)
   MACPROVIDER_COORDINATOR_URL    coordinator WebSocket URL
+  MACPROVIDER_REFERRAL_CODE      pre-beta referral code (same as --ref)
   MACPROVIDER_PORT               local HTTP port
   MACPROVIDER_INSTALL_DIR        support dir for binary + bundles
   MACPROVIDER_RELEASE_FORMAT     auto, pkg, or tar (default: auto)
@@ -280,6 +287,9 @@ Environment overrides:
                                  launchd service and its companion watchdog
   MACPROVIDER_NO_WATCHDOG=1      expert/debug only: install the provider
                                  launchd service but skip the watchdog
+  MACPROVIDER_APP_MANAGED_REPAIR=1
+                                 Malibu.app only: update an existing app-owned
+                                 install without starting credential-less launchd
   MACPROVIDER_EMERGENCY_ROLLBACK=1
                                  operator-only signed rollback to an explicit
                                  MACPROVIDER_VERSION; commits only through an
@@ -288,13 +298,24 @@ Environment overrides:
 USAGE
 }
 
-for arg in "$@"; do
-  case "$arg" in
+while [ "$#" -gt 0 ]; do
+  case "$1" in
     --dry-run) DRY_RUN=1 ;;
+    --ref|--referral-code)
+      [ "$#" -ge 2 ] || die 7 "$1 requires a referral code"
+      REFERRAL_CODE="$2"
+      shift
+      ;;
+    --ref=*|--referral-code=*) REFERRAL_CODE="${1#*=}" ;;
     -h|--help) usage; exit 0 ;;
-    *) die 7 "unknown argument: $arg" ;;
+    *) die 7 "unknown argument: $1" ;;
   esac
+  shift
 done
+
+if [ -n "$REFERRAL_CODE" ] && [[ ! "$REFERRAL_CODE" =~ ^MAL1-[SP]-[A-Za-z0-9_]{1,32}-[A-Za-z0-9_]{1,32}-[A-Z2-7]{26}$ ]]; then
+  die 7 "referral code has an invalid format"
+fi
 
 release_install_lock() {
   [ "$INSTALL_LOCK_HELD" -eq 1 ] || return 0
@@ -1297,6 +1318,19 @@ for encoded in encoded_arguments:
     arguments.append(argument)
 if sum(map(len, arguments)) > 65536:
     raise SystemExit("manual provider argument bounds exceeded")
+# ADV-H1: defense in depth for any pre-fix recovery snapshot. A `--token-fd`
+# provider cannot be relaunched with `stdin=DEVNULL` (the empty bearer would be
+# rejected). Do not replay it — write a `handoff` sentinel and exit cleanly so
+# the caller logs the app-managed handoff instead of relaunching or failing.
+def _references_token_fd(args):
+    for argument in args:
+        if argument == b"--token-fd" or argument.startswith(b"--token-fd="):
+            return True
+    return False
+if _references_token_fd(arguments):
+    with open(pid_path, "w", encoding="ascii") as handle:
+        handle.write("handoff\n")
+    raise SystemExit(0)
 try:
     working_directory = base64.b64decode(record["working_directory_b64"], validate=True)
 except Exception as error:
@@ -1419,10 +1453,17 @@ except BaseException as original_error:
     raise
 PY
   RESTORED_MANUAL_PID="$(cat "$RECOVERY_DIR/manual-restored.pid")"
-  case "$RESTORED_MANUAL_PID" in
-    ''|*[!0-9]*) recovery_failed "restored manual provider pid is invalid" ;;
-  esac
-  recovery_log "Restored prior manual provider pid=$RESTORED_MANUAL_PID with exact prior argv and port ownership."
+  if [ "$RESTORED_MANUAL_PID" = "handoff" ]; then
+    # ADV-H1: the prior manual provider received its bearer on an inherited
+    # token fd (app-managed). It is intentionally not relaunched here; Malibu
+    # restarts it with the Keychain bearer after the failed install rolls back.
+    recovery_log "Previous manual provider used an inherited token fd (app-managed); skipped installer replay and handed its restart to Malibu."
+  else
+    case "$RESTORED_MANUAL_PID" in
+      ''|*[!0-9]*) recovery_failed "restored manual provider pid is invalid" ;;
+    esac
+    recovery_log "Restored prior manual provider pid=$RESTORED_MANUAL_PID with exact prior argv and port ownership."
+  fi
 fi
 
 recovery_log "Previous provider, recommendation, watchdog, manifest, service, and manual-process states were restored and verified."
@@ -1630,6 +1671,24 @@ if len(arguments) > 128 or any(b"\x00" in argument or len(argument) > 4096 for a
     raise SystemExit("manual provider argument bounds exceeded")
 if sum(map(len, arguments)) > 65536:
     raise SystemExit("manual provider argument bounds exceeded")
+# ADV-H1: an app-managed provider receives its bearer on an inherited file
+# descriptor (`--token-fd N`), which is closed when we stop it and cannot be
+# reproduced by a rollback that relaunches with `stdin=DEVNULL`. Do NOT capture
+# a recovery snapshot for such a provider — a replay would feed `--token-fd` an
+# empty bearer and the provider would reject it. Skip capture cleanly (exit 0,
+# no snapshot file) so rollback leaves its restart to Malibu's app-managed start,
+# which owns the Keychain bearer.
+def _references_token_fd(args):
+    for argument in args:
+        if argument == b"--token-fd" or argument.startswith(b"--token-fd="):
+            return True
+    return False
+if _references_token_fd(arguments):
+    sys.stderr.write(
+        "manual provider uses an inherited token fd (app-managed); skipping recovery "
+        "capture so rollback will not relaunch it with an empty bearer\n"
+    )
+    raise SystemExit(0)
 environment = []
 while offset < len(data):
     entry_end = data.find(b"\x00", offset)
@@ -1647,6 +1706,34 @@ if len(environment) > 512 or any(len(entry) > 8192 for entry in environment) or 
 environment_keys = [entry.split(b"=", 1)[0] for entry in environment]
 if any(not key or b"=" in key for key in environment_keys) or len(set(environment_keys)) != len(environment_keys):
     raise SystemExit("manual provider environment is invalid")
+# ADV-C1: never serialize a secret to disk. Drop the provider bearer and any
+# token/secret/key/password/bearer-shaped env entry from the recovery snapshot.
+# The restored serving child obtains its bearer from Keychain (app-managed) or
+# its 0600 config/token-file (CLI track), not from this recovered environment.
+def _is_secret_env_key(key):
+    upper = key.upper()
+    if upper == b"MACPROVIDER_PROVIDER_TOKEN":
+        return True
+    for needle in (b"TOKEN", b"SECRET", b"PASSWORD", b"PASSWD", b"BEARER", b"APIKEY"):
+        if needle in upper:
+            return True
+    return upper.endswith(b"_KEY") or upper == b"KEY"
+# M1(adv): the secret-substring filter uses ASCII .upper()/substring checks, so
+# fullwidth/Cyrillic confusables (APIＴOKEN, secrе t, ＢEARER) would survive it.
+# Conservatively DROP every non-ASCII-keyed env entry from the recovery snapshot
+# in addition to the ASCII secret filter; a restored serving child never needs a
+# non-ASCII environment key and we must never risk serializing a disguised secret.
+def _is_ascii_key(key):
+    try:
+        key.decode("ascii")
+    except UnicodeDecodeError:
+        return False
+    return True
+environment = [
+    entry
+    for entry in environment
+    if _is_ascii_key(entry.split(b"=", 1)[0]) and not _is_secret_env_key(entry.split(b"=", 1)[0])
+]
 working_directory = os.path.realpath(observed_cwd)
 if not os.path.isabs(working_directory) or not os.path.isdir(working_directory):
     raise SystemExit("manual provider working directory is invalid")
@@ -2051,6 +2138,31 @@ coordinator_http_base() {
     wss://coordinator.streamvc.live/ws/provider) printf "%s" "$COORDINATOR_BASE_DEFAULT" ;;
     wss://*) printf "https://%s" "${coordinator_url#wss://}" | sed -E 's#/ws/provider/?$##' ;;
     *) die 7 "coordinator URL must start with wss://" ;;
+  esac
+}
+
+advisory_validate_referral() {
+  local coordinator_base="$1"
+  local payload response result
+  payload="$(MACPROVIDER_CONFIG_REFERRAL_CODE="$REFERRAL_CODE" python3 -c 'import json,os; print(json.dumps({"code": os.environ.pop("MACPROVIDER_CONFIG_REFERRAL_CODE", "")}))')" \
+    || return 0
+  if ! response="$(printf "%s" "$payload" | curl -fsS --max-time 8 \
+      -H 'Content-Type: application/json' -H 'Accept: application/json' \
+      --data-binary @- "$coordinator_base/v1/referrals/validate" 2>/dev/null)"; then
+    log "Invite pre-check unavailable; authoritative validation will run during credential registration."
+    return 0
+  fi
+  result="$(printf "%s" "$response" | python3 -c 'import json,sys
+try:
+ d=json.load(sys.stdin); print(("valid" if d.get("valid") else "invalid") + ":" + str(d.get("reason", "invalid")))
+except Exception: print("unavailable:invalid")')"
+  case "$result" in
+    valid:*) return 0 ;;
+    invalid:expired) die 7 "referral code has expired; use a different invite" ;;
+    invalid:revoked) die 7 "referral code is no longer available; use a different invite" ;;
+    invalid:exhausted) die 7 "referral code has already been used; use a different invite" ;;
+    invalid:*) die 7 "referral code is not valid; check it or use a different invite" ;;
+    *) log "Invite pre-check response was unavailable; authoritative validation will run during credential registration." ;;
   esac
 }
 
@@ -2958,7 +3070,9 @@ semantic_merge_config() {
   provider_id_value="$3"
   coordinator_url_value="$4"
   port_value="$5"
-  python3 - "$config_path" "$model_value" "$provider_id_value" "$coordinator_url_value" "$port_value" <<'PY'
+  referral_code_value="${6:-}"
+  MACPROVIDER_CONFIG_REFERRAL_CODE="$referral_code_value" \
+    python3 - "$config_path" "$model_value" "$provider_id_value" "$coordinator_url_value" "$port_value" <<'PY'
 import json
 import os
 import re
@@ -2966,6 +3080,7 @@ import sys
 import tempfile
 
 path, model, provider_id, coordinator_url, port = sys.argv[1:]
+referral_code = os.environ.pop("MACPROVIDER_CONFIG_REFERRAL_CODE", "")
 owned = {
     "coordinator_url": json.dumps(coordinator_url),
     "provider_id": json.dumps(provider_id),
@@ -2973,6 +3088,8 @@ owned = {
 }
 if model:
     owned["model"] = json.dumps(model)
+if referral_code:
+    owned["referral_code"] = json.dumps(referral_code)
 try:
     with open(path, "r", encoding="utf-8") as handle:
         lines = handle.read().splitlines()
@@ -2993,7 +3110,7 @@ for line in lines:
     merged.append(f"{key}: {owned[key]}")
     seen.add(key)
 
-for key in ("model", "coordinator_url", "provider_id", "port"):
+for key in ("model", "coordinator_url", "provider_id", "port", "referral_code"):
     if key not in owned:
         continue
     if key not in seen:
@@ -3030,7 +3147,7 @@ write_config() {
   printf "%s\n" "$provider_id" > "$provider_id_temp"
   chmod 600 "$provider_id_temp" 2>/dev/null || true
   mv "$provider_id_temp" "$PROVIDER_ID_PATH"
-  semantic_merge_config "$CONFIG_PATH" "$model" "$provider_id" "$coordinator_url" "$PORT"
+  semantic_merge_config "$CONFIG_PATH" "$model" "$provider_id" "$coordinator_url" "$PORT" "$REFERRAL_CODE"
   chmod 600 "$CONFIG_PATH" "$PROVIDER_ID_PATH" 2>/dev/null || true
 }
 
@@ -3047,14 +3164,42 @@ read_config_model() {
   ' "$CONFIG_PATH"
 }
 
-read_config_provider_token_line() {
+read_config_provider_token() {
   [ -f "$CONFIG_PATH" ] || return 1
-  awk '
+  awk -F: '
     /^provider_token[[:space:]]*:/ {
-      print
+	  value=$0
+	  sub(/^provider_token[[:space:]]*:[[:space:]]*/, "", value)
+	  gsub(/^[[:space:]]+|[[:space:]]+$/, "", value)
+	  gsub(/^"|"$/, "", value)
+	  print value
       exit
     }
   ' "$CONFIG_PATH"
+}
+
+clear_config_referral_code() {
+  [ -f "$CONFIG_PATH" ] || return 0
+  grep -Eq '^referral_code[[:space:]]*:' "$CONFIG_PATH" || return 0
+  referral_temp="$(mktemp "${CONFIG_PATH}.referral.XXXXXX")" \
+    || die 5 "could not prepare referral-code cleanup"
+  if ! awk '!/^referral_code[[:space:]]*:/' "$CONFIG_PATH" > "$referral_temp"; then
+    rm -f "$referral_temp"
+    die 5 "could not remove redeemed referral code from config"
+  fi
+  chmod 600 "$referral_temp" 2>/dev/null || true
+  mv "$referral_temp" "$CONFIG_PATH" \
+    || die 5 "could not finalize referral-code cleanup"
+}
+
+existing_provider_credential_configured() {
+  [ -n "$(read_config_provider_token || true)" ] && return 0
+  if [ "${APP_MANAGED_REPAIR:-0}" -eq 1 ] \
+    && [ -r "$APP_MARKER_PATH" ] \
+    && [ -n "$(read_config_provider_id || true)" ]; then
+    return 0
+  fi
+  return 1
 }
 
 read_config_provider_id() {
@@ -3110,7 +3255,8 @@ read_config_donor_mode() {
 }
 
 ensure_provider_credentials() {
-  if [ -n "$(read_config_provider_token_line || true)" ]; then
+  if existing_provider_credential_configured; then
+    clear_config_referral_code
     return 0
   fi
   provider_id="$(read_config_provider_id || true)"
@@ -3119,10 +3265,29 @@ ensure_provider_credentials() {
     *) die 6 "tokenless credential bootstrap requires a fresh high-entropy mp-* provider ID; this existing predictable ID needs an operator-issued ownership credential" ;;
   esac
   log "Acquiring first-install provider credential before evidence admission."
+  # PROD-M2: capture bootstrap-auth stderr so we can distinguish a referral
+  # rejection (machine-readable MACPROVIDER_REFERRAL_REJECTED marker) from a
+  # generic failure, and surface the specific reason so the app can route the
+  # user back to the invite step.
+  bootstrap_err="$(mktemp -t macprovider-bootstrap-err 2>/dev/null || mktemp)"
+  bootstrap_rc=0
   run_macprovider_cli_with_amfi_retry bootstrap-auth --timeout-seconds 30 --config "$CONFIG_PATH" \
-    || die 6 "provider credential bootstrap failed before evidence admission"
-  [ -n "$(read_config_provider_token_line || true)" ] \
+    2>"$bootstrap_err" || bootstrap_rc=$?
+  cat "$bootstrap_err" >&2
+  if [ "$bootstrap_rc" -ne 0 ]; then
+    referral_reason="$(sed -n 's/.*MACPROVIDER_REFERRAL_REJECTED reason=referral_\([a-z]*\).*/\1/p' "$bootstrap_err" | head -n1)"
+    rm -f "$bootstrap_err"
+    if [ -n "$referral_reason" ]; then
+      die 7 "provider registration rejected the invite (referral_$referral_reason); enter a new invite and try again"
+    fi
+    die 6 "provider credential bootstrap failed before evidence admission"
+  fi
+  rm -f "$bootstrap_err"
+  [ -n "$(read_config_provider_token || true)" ] \
     || die 6 "provider credential bootstrap completed without persisting provider_token"
+  # The invite is bootstrap-only. Remove it immediately after a credential is
+  # present so a redeemed multi-use code is not retained in long-lived config.
+  clear_config_referral_code
   if [ -n "${STAGED_CONFIG_PATH:-}" ] && [ "$CONFIG_PATH" = "$STAGED_CONFIG_PATH" ]; then
     # Coordinator bootstrap creates a durable principal. Publish its exact key
     # material into the protected live transaction immediately so #547's
@@ -4406,6 +4571,41 @@ start_manual_service() {
   fi
 }
 
+unload_app_managed_launchd_jobs() {
+  [ "${INSTALL_TX_ACTIVE:-0}" -eq 1 ] && assert_install_lock_ownership
+  # Address the launchd domain by label even when a crashing KeepAlive job has
+  # no listener. Port-based cutover detection cannot see that state.
+  launchctl bootout "gui/$UID/live.streamvc.macprovider" >/dev/null 2>&1 || true
+  launchctl bootout "gui/$UID/$WATCHDOG_LABEL" >/dev/null 2>&1 || true
+  # Older launchctl versions are more reliable with the plist form.
+  [ ! -f "$PLIST_PATH" ] \
+    || launchctl bootout "gui/$UID" "$PLIST_PATH" >/dev/null 2>&1 \
+    || true
+  [ ! -f "$WATCHDOG_PLIST_PATH" ] \
+    || launchctl bootout "gui/$UID" "$WATCHDOG_PLIST_PATH" >/dev/null 2>&1 \
+    || true
+  attempts=0
+  while [ "$attempts" -lt 40 ]; do
+    provider_loaded=0
+    watchdog_loaded=0
+    launchctl print "gui/$UID/live.streamvc.macprovider" >/dev/null 2>&1 \
+      && provider_loaded=1
+    launchctl print "gui/$UID/$WATCHDOG_LABEL" >/dev/null 2>&1 \
+      && watchdog_loaded=1
+    listener_present=0
+    lsof -nP -iTCP:"$PORT" -sTCP:LISTEN -t >/dev/null 2>&1 \
+      && listener_present=1
+    if [ "$provider_loaded" -eq 0 ] \
+      && [ "$watchdog_loaded" -eq 0 ] \
+      && [ "$listener_present" -eq 0 ]; then
+      return 0
+    fi
+    sleep 0.25
+    attempts=$((attempts + 1))
+  done
+  die 70 "could not confirm launchd ownership release for app-managed repair"
+}
+
 cache_size_kb() {
   path="$1"
   if [ -d "$path" ]; then
@@ -4917,6 +5117,10 @@ main() {
     require_tool "$tool"
   done
   validate_install_dir
+  case "$APP_MANAGED_REPAIR" in
+    0|1) ;;
+    *) die 7 "MACPROVIDER_APP_MANAGED_REPAIR must be 0 or 1" ;;
+  esac
   acquire_install_lock
   recover_orphaned_install_transactions
 
@@ -4926,6 +5130,19 @@ main() {
   coordinator_url="$(choose_coordinator_url)"
   coordinator_base="$(coordinator_http_base "$coordinator_url")"
   validate_inputs "$model" "$provider_id" "$coordinator_url"
+  if [ "$DRY_RUN" -eq 0 ]; then
+    if existing_provider_credential_configured; then
+      log "Existing provider credential found; referral pre-check is not required for repair or upgrade."
+    else
+      advisory_validate_referral "$coordinator_base"
+    fi
+  fi
+  if [ "$APP_MANAGED_REPAIR" -eq 1 ]; then
+    existing_provider_credential_configured \
+      || die 7 "app-managed repair requires an existing provider credential"
+    [ "$EMERGENCY_ROLLBACK" -eq 0 ] \
+      || die 7 "app-managed repair cannot perform an emergency rollback"
+  fi
   log "Model selection: signed catalog recommendation after release verification"
   log "Provider ID: $provider_id"
   log "Coordinator: $coordinator_url"
@@ -5037,6 +5254,18 @@ main() {
   install_binary
   activate_staged_config
   check_path_hint
+  if [ "$APP_MANAGED_REPAIR" -eq 1 ]; then
+    # The app-owned config intentionally contains no bearer. Do not start or
+    # health-gate a launchd job that cannot authenticate. The caller starts the
+    # verified binary as a Malibu child with its Keychain bearer immediately
+    # after this transaction commits.
+    unload_app_managed_launchd_jobs
+    rm -f "$PLIST_PATH" "$WATCHDOG_PLIST_PATH"
+    write_install_manifest "$tag"
+    commit_install_transaction
+    log "App-managed repair artifacts are ready; Malibu will start and verify the provider."
+    exit 0
+  fi
   install_plist "$model" "$provider_id" "$coordinator_url"
   install_watchdog "$coordinator_url"
   write_install_manifest "$tag"

--- a/phase3-binary/dist/install.sh
+++ b/phase3-binary/dist/install.sh
@@ -3147,7 +3147,10 @@ write_config() {
   printf "%s\n" "$provider_id" > "$provider_id_temp"
   chmod 600 "$provider_id_temp" 2>/dev/null || true
   mv "$provider_id_temp" "$PROVIDER_ID_PATH"
-  semantic_merge_config "$CONFIG_PATH" "$model" "$provider_id" "$coordinator_url" "$PORT" "$REFERRAL_CODE"
+  # Some hermetic deploy checks source this function without running the
+  # installer's argument-initialization prelude. Treat an unset referral as the
+  # open-beta/default empty value while preserving set -u for real mistakes.
+  semantic_merge_config "$CONFIG_PATH" "$model" "$provider_id" "$coordinator_url" "$PORT" "${REFERRAL_CODE:-}"
   chmod 600 "$CONFIG_PATH" "$PROVIDER_ID_PATH" 2>/dev/null || true
 }
 

--- a/phase3-binary/dist/test/app_managed_repair_evidence_token_fd.test.sh
+++ b/phase3-binary/dist/test/app_managed_repair_evidence_token_fd.test.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC2034 # Globals are consumed by extracted installer functions.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/../../.." && pwd)"
+INSTALL_SH="$REPO_ROOT/phase3-binary/dist/install.sh"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+extract_function() {
+  name="$1"
+  awk -v start="${name}() {" '
+    $0 == start { inside=1 }
+    inside { print }
+    inside && /^}$/ { exit }
+  ' "$INSTALL_SH"
+}
+
+for function_name in \
+  read_app_managed_provider_token run_macprovider_cli_with_amfi_retry \
+  submit_required_hardware_evidence; do
+  extract_function "$function_name" >> "$TMP/functions.sh"
+done
+
+# shellcheck source=/dev/null
+source "$TMP/functions.sh"
+
+die() {
+  printf 'unexpected installer failure: %s\n' "$*" >&2
+  exit "$1"
+}
+log() { :; }
+sleep() { :; }
+
+secret="$(printf 'ab%.0s' {1..32})"
+APP_MANAGED_REPAIR=1
+APP_MANAGED_PROVIDER_TOKEN_FD=3
+APP_MANAGED_PROVIDER_TOKEN=""
+exec 3<<<"$secret"
+read_app_managed_provider_token
+exec 3<&-
+[ "$APP_MANAGED_PROVIDER_TOKEN" = "$secret" ]
+if export -p | grep -F "$secret" >/dev/null; then
+  echo "app-managed token became exported" >&2
+  exit 1
+fi
+
+cat > "$TMP/macprovider-cli" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$*" > "$TOKEN_FD_TEST_ARGS"
+env > "$TOKEN_FD_TEST_ENV"
+attempt=1
+if [ -f "$TOKEN_FD_TEST_ATTEMPTS" ]; then
+  attempt=$(( $(cat "$TOKEN_FD_TEST_ATTEMPTS") + 1 ))
+fi
+printf '%s\n' "$attempt" > "$TOKEN_FD_TEST_ATTEMPTS"
+fd=""
+while [ "$#" -gt 0 ]; do
+  if [ "$1" = "--token-fd" ]; then
+    fd="${2:-}"
+    break
+  fi
+  shift
+done
+[ "$fd" = "0" ] || exit 21
+shasum -a 256 | awk '{print $1}' >> "$TOKEN_FD_TEST_DIGEST"
+if [ "${TOKEN_FD_TEST_RETRY_ONCE:-0}" -eq 1 ] && [ "$attempt" -eq 1 ]; then
+  exit 137
+fi
+SH
+chmod +x "$TMP/macprovider-cli"
+
+export TOKEN_FD_TEST_ARGS="$TMP/args"
+export TOKEN_FD_TEST_ENV="$TMP/env"
+export TOKEN_FD_TEST_DIGEST="$TMP/digest"
+export TOKEN_FD_TEST_ATTEMPTS="$TMP/attempts"
+export TOKEN_FD_TEST_RETRY_ONCE=1
+MACPROVIDER_CLI_EXECUTABLE="$TMP/macprovider-cli"
+CONFIG_PATH="$TMP/config.yaml"
+submit_required_hardware_evidence
+
+grep -F -- '--token-fd 0' "$TMP/args" >/dev/null
+if grep -F "$secret" "$TMP/args" "$TMP/env" >/dev/null; then
+  echo "app-managed token leaked through CLI argv or environment" >&2
+  exit 1
+fi
+expected_digest="$(printf '%s' "$secret" | shasum -a 256 | awk '{print $1}')"
+[ "$(cat "$TMP/attempts")" -eq 2 ]
+[ "$(wc -l < "$TMP/digest" | tr -d ' ')" -eq 2 ]
+awk -v expected="$expected_digest" '$0 != expected { exit 1 }' "$TMP/digest"
+
+if (APP_MANAGED_REPAIR=0 APP_MANAGED_PROVIDER_TOKEN_FD=0 read_app_managed_provider_token) 2>/dev/null; then
+  echo "standalone install accepted the app-only token descriptor" >&2
+  exit 1
+fi
+
+echo "app-managed repair evidence token fd transport ok"

--- a/phase3-binary/dist/test/install_fresh_evidence.test.sh
+++ b/phase3-binary/dist/test/install_fresh_evidence.test.sh
@@ -9,10 +9,10 @@ trap 'rm -rf "$TMP"' EXIT
 python3 - "$INSTALL_SH" > "$TMP/functions.sh" <<'PY'
 import sys
 names = {
-    "read_config_provider_token_line", "read_config_model",
+    "read_config_provider_token_line", "read_config_provider_token", "read_config_model",
     "read_config_provider_id", "read_config_artifact_path", "read_config_artifact_sha",
-    "is_bootstrap_principal",
-    "ensure_provider_credentials", "submit_required_hardware_evidence",
+    "is_bootstrap_principal", "existing_provider_credential_configured",
+    "clear_config_referral_code", "ensure_provider_credentials", "submit_required_hardware_evidence",
     "run_autotune_recommend_apply",
 }
 lines = open(sys.argv[1], encoding="utf-8").read().splitlines()

--- a/phase3-binary/dist/test/install_referral_input.test.sh
+++ b/phase3-binary/dist/test/install_referral_input.test.sh
@@ -1,0 +1,130 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/../../.." && pwd)"
+INSTALL_SH="$REPO_ROOT/phase3-binary/dist/install.sh"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+extract_function() {
+  local name="$1"
+  awk -v start="${name}() {" '
+    $0 == start { inside=1 }
+    inside { print }
+    inside && /^}$/ { exit }
+  ' "$INSTALL_SH"
+}
+
+extract_function normalize_referral_code > "$TMP/functions.sh"
+extract_function advisory_validate_referral >> "$TMP/functions.sh"
+extract_function referral_rejection_message >> "$TMP/functions.sh"
+# shellcheck source=/dev/null
+source "$TMP/functions.sh"
+
+code='MAL1-S-key-seed-AAAAAAAAAAAAAAAAAAAAAAAAAA'
+[ "$(normalize_referral_code "$code")" = "$code" ]
+[ "$(normalize_referral_code "  $code  ")" = "$code" ]
+[ "$(normalize_referral_code "https://coordinator.streamvc.live/j/$code")" = "$code" ]
+[ "$(normalize_referral_code " https://coordinator.streamvc.live/j/$code/ ")" = "$code" ]
+[ "$(normalize_referral_code "https://coordinator.streamvc.live/j/$code?c=x-post#install")" = "$code" ]
+[ "$(normalize_referral_code "https://coordinator.streamvc.live/j/$code/?c=x-post#install")" = "$code" ]
+[ "$(normalize_referral_code "")" = "" ]
+
+if normalize_referral_code "http://coordinator.streamvc.live/j/$code" >/dev/null; then
+  echo "non-HTTPS invite URL was accepted" >&2
+  exit 1
+fi
+if normalize_referral_code "https://coordinator.streamvc.live/?next=/j/$code" >/dev/null; then
+  echo "query-smuggled invite URL was accepted" >&2
+  exit 1
+fi
+if normalize_referral_code "https://coordinator.streamvc.live/j/" >/dev/null; then
+  echo "invite URL without a code was accepted" >&2
+  exit 1
+fi
+if normalize_referral_code "https://coordinator.streamvc.live/j/$code/extra" >/dev/null; then
+  echo "invite URL with an extra path segment was accepted" >&2
+  exit 1
+fi
+if normalize_referral_code "https://coordinator.streamvc.live/j/$code//" >/dev/null; then
+  echo "invite URL with multiple trailing slashes was accepted" >&2
+  exit 1
+fi
+if normalize_referral_code "https://user@coordinator.streamvc.live/j/$code" >/dev/null; then
+  echo "credential-bearing invite URL was accepted" >&2
+  exit 1
+fi
+
+[ "$(referral_rejection_message missing)" = 'An invite is required; rerun with --ref CODE_OR_INVITE_URL' ]
+[ "$(referral_rejection_message required)" = 'An invite is required; rerun with --ref CODE_OR_INVITE_URL' ]
+[ "$(referral_rejection_message expired)" = 'This invite has expired; use a different invite' ]
+[ "$(referral_rejection_message exhausted)" = 'All spots on this invite are taken; use a different invite' ]
+
+REFERRAL_CODE="$code"
+CURL_RESPONSE=""
+CURL_FAIL=0
+curl() {
+  if [ "$CURL_FAIL" -eq 1 ]; then
+    return 22
+  fi
+  printf '%s' "$CURL_RESPONSE"
+}
+log() { printf 'LOG:%s\n' "$*" >&2; }
+die() {
+  local status="$1"
+  shift
+  printf 'DIE:%s\n' "$*" >&2
+  exit "$status"
+}
+
+assert_advisory_allows() {
+  local response="$1"
+  local output
+  output="$(CURL_RESPONSE="$response" advisory_validate_referral "https://coordinator.example.test" 2>&1)"
+  case "$output" in
+    *DIE:*) echo "advisory response unexpectedly rejected: $output" >&2; exit 1 ;;
+  esac
+}
+
+assert_advisory_rejects() {
+  local response="$1" expected="$2" output status
+  set +e
+  output="$(CURL_RESPONSE="$response" advisory_validate_referral "https://coordinator.example.test" 2>&1)"
+  status=$?
+  set -e
+  [ "$status" -eq 7 ] || {
+    echo "advisory response status=$status, expected 7: $output" >&2
+    exit 1
+  }
+  case "$output" in
+    *"$expected"*) ;;
+    *) echo "advisory rejection missing '$expected': $output" >&2; exit 1 ;;
+  esac
+}
+
+assert_advisory_allows '{"required":false,"valid":true,"reason":"disabled"}'
+assert_advisory_allows '{not-json'
+assert_advisory_allows '{"required":"true","valid":false,"reason":"missing"}'
+assert_advisory_allows '{"required":true,"valid":"false","reason":"missing"}'
+assert_advisory_allows '{"required":true,"valid":false,"reason":"surprise"}'
+assert_advisory_rejects '{"required":true,"valid":false,"reason":"missing"}' 'rerun with --ref CODE_OR_INVITE_URL'
+assert_advisory_rejects '{"required":true,"valid":false,"reason":"invalid"}' 'not valid'
+assert_advisory_rejects '{"required":true,"valid":false,"reason":"expired"}' 'expired'
+assert_advisory_rejects '{"required":true,"valid":false,"reason":"revoked"}' 'no longer available'
+assert_advisory_rejects '{"required":true,"valid":false,"reason":"exhausted"}' 'All spots'
+
+for failure in timeout http_5xx; do
+  output="$(CURL_FAIL=1 advisory_validate_referral "https://coordinator.example.test" 2>&1)"
+  case "$output" in
+    *'Invite pre-check unavailable'*) ;;
+    *) echo "$failure did not remain advisory: $output" >&2; exit 1 ;;
+  esac
+done
+
+# Both `--ref` and MACPROVIDER_REFERRAL_CODE populate REFERRAL_CODE before this
+# shared normalization point.
+# shellcheck disable=SC2016 # Assert the installer's literal command substitution.
+grep -F 'REFERRAL_CODE="$(normalize_referral_code "$REFERRAL_CODE")"' "$INSTALL_SH" >/dev/null
+grep -F 'Usage: bash install.sh [--dry-run] [--ref CODE_OR_INVITE_URL]' "$INSTALL_SH" >/dev/null
+
+echo "installer referral input normalization ok"

--- a/phase3-binary/dist/test/manual_recovery_token_fd_and_env.test.sh
+++ b/phase3-binary/dist/test/manual_recovery_token_fd_and_env.test.sh
@@ -1,0 +1,177 @@
+#!/usr/bin/env bash
+# ADV-H1 + M1(adv): the recovery-capture snapshot must never (1) preserve a
+# manual provider that received its bearer on an inherited `--token-fd` (a
+# rollback replay with stdin=DEVNULL would feed it an empty bearer), nor
+# (2) serialize a secret env var — including one whose key uses non-ASCII
+# confusable characters that bypass the ASCII secret-substring filter.
+#
+# Exact process-argv/env capture uses Darwin's KERN_PROCARGS2 contract, so this
+# is a macOS-only lane (matching install_upgrade_evidence_rollback.test.sh).
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/../../.." && pwd)"
+INSTALL_SH="$REPO_ROOT/phase3-binary/dist/install.sh"
+
+if [ "$(uname -s)" != "Darwin" ]; then
+  echo "skipping Darwin-only manual recovery token-fd/env capture test"
+  exit 0
+fi
+
+TMP="$(mktemp -d)"
+FIXTURE_PID=""
+cleanup() {
+  [ -z "$FIXTURE_PID" ] || kill "$FIXTURE_PID" >/dev/null 2>&1 || true
+  rm -rf "$TMP"
+}
+trap cleanup EXIT
+
+# Extract capture_manual_provider_for_recovery from the installer verbatim.
+python3 - "$INSTALL_SH" > "$TMP/functions.sh" <<'PY'
+import sys
+names = {"capture_manual_provider_for_recovery"}
+lines = open(sys.argv[1], encoding="utf-8").read().splitlines()
+i = 0
+while i < len(lines):
+    name = lines[i].split("()", 1)[0] if "()" in lines[i] else ""
+    if name not in names:
+        i += 1
+        continue
+    depth = 0
+    while i < len(lines):
+        line = lines[i]
+        print(line)
+        depth += line.count("{") - line.count("}")
+        i += 1
+        if depth == 0:
+            break
+PY
+[ -s "$TMP/functions.sh" ] || { echo "failed to extract capture function" >&2; exit 1; }
+
+INSTALL_DIR="$TMP/install"
+mkdir -p "$INSTALL_DIR" "$TMP/cwd"
+BINARY_PATH="$INSTALL_DIR/macprovider-cli"
+
+cat > "$TMP/fixture.c" <<'EOF'
+#include <arpa/inet.h>
+#include <netinet/in.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/socket.h>
+#include <unistd.h>
+int main(int argc, char **argv) {
+  int port = 0;
+  for (int i = 1; i + 1 < argc; i++)
+    if (strcmp(argv[i], "--port") == 0) port = atoi(argv[i + 1]);
+  if (port <= 0) return 2;
+  int fd = socket(AF_INET, SOCK_STREAM, 0);
+  int yes = 1;
+  setsockopt(fd, SOL_SOCKET, SO_REUSEADDR, &yes, sizeof(yes));
+  struct sockaddr_in addr = {0};
+  addr.sin_family = AF_INET;
+  addr.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+  addr.sin_port = htons((unsigned short)port);
+  if (bind(fd, (struct sockaddr *)&addr, sizeof(addr)) != 0 || listen(fd, 4) != 0) return 3;
+  for (;;) pause();
+}
+EOF
+cc -O2 -o "$BINARY_PATH" "$TMP/fixture.c"
+
+PORT="$(python3 -c 'import socket
+s = socket.socket()
+s.bind(("127.0.0.1", 0))
+print(s.getsockname()[1])
+s.close()')"
+
+start_fixture() {
+  # start_fixture <output-var-unused> [env args...] -- [fixture args...]
+  local env_args=() cli_args=() seen_sep=0 arg
+  shift # drop the unused output-var placeholder
+  for arg in "$@"; do
+    if [ "$arg" = "--" ]; then seen_sep=1; continue; fi
+    if [ "$seen_sep" -eq 0 ]; then env_args+=("$arg"); else cli_args+=("$arg"); fi
+  done
+  (
+    cd "$TMP/cwd"
+    exec env ${env_args[@]+"${env_args[@]}"} "$BINARY_PATH" --port "$PORT" ${cli_args[@]+"${cli_args[@]}"}
+  ) &
+  FIXTURE_PID=$!
+  local i
+  for i in $(seq 1 40); do
+    if lsof -nP -iTCP:"$PORT" -sTCP:LISTEN -t 2>/dev/null | grep -Fxq "$FIXTURE_PID"; then
+      return 0
+    fi
+    sleep 0.1
+  done
+  echo "fixture did not bind port $PORT" >&2
+  return 1
+}
+
+run_capture() {
+  local json_out="$1"
+  ( set -euo pipefail
+    INSTALL_TX_ACTIVE=1
+    INSTALL_TX_SERVICE_WAS_ACTIVE=0
+    INSTALL_DIR="$INSTALL_DIR"
+    BINARY_PATH="$BINARY_PATH"
+    PORT="$PORT"
+    INSTALL_TX_BACKUP="$(dirname "$json_out")"
+    die() { echo "die $*" >&2; exit "${1:-1}"; }
+    log() { :; }
+    source "$TMP/functions.sh"
+    capture_manual_provider_for_recovery "$FIXTURE_PID"
+  )
+}
+
+stop_fixture() {
+  [ -z "$FIXTURE_PID" ] || kill "$FIXTURE_PID" >/dev/null 2>&1 || true
+  wait "$FIXTURE_PID" 2>/dev/null || true
+  FIXTURE_PID=""
+}
+
+# --- Case 1: a --token-fd provider is NOT captured (would replay empty bearer) ---
+start_fixture x -- --token-fd 0
+mkdir -p "$TMP/tx1"
+run_capture "$TMP/tx1/manual-provider.json"
+if [ -e "$TMP/tx1/manual-provider.json" ]; then
+  echo "FAIL: a --token-fd manual provider was captured for blind relaunch" >&2
+  exit 1
+fi
+stop_fixture
+echo "ok: token-fd manual provider skipped from recovery capture"
+
+# --- Case 2: secret env vars (ASCII and non-ASCII confusable) are not serialized ---
+# Fullwidth 'B' (U+FF22 = EF BC A2) + EARER bypasses the ASCII secret filter.
+NONASCII_KEY=$'\xef\xbc\xa2EARER'
+start_fixture x \
+  "MACPROVIDER_PROVIDER_TOKEN=ascii-bearer-secret" \
+  "${NONASCII_KEY}=confusable-bearer-secret" \
+  "SAFEVAR=keep-me" \
+  --
+mkdir -p "$TMP/tx2"
+run_capture "$TMP/tx2/manual-provider.json"
+[ -s "$TMP/tx2/manual-provider.json" ] || { echo "FAIL: expected a recovery snapshot" >&2; exit 1; }
+python3 - "$TMP/tx2/manual-provider.json" <<'PY'
+import base64
+import json
+import sys
+
+with open(sys.argv[1], "r", encoding="utf-8") as handle:
+    record = json.load(handle)
+keys = [base64.b64decode(entry).split(b"=", 1)[0] for entry in record["environment_b64"]]
+# The ASCII bearer must be dropped.
+if any(key == b"MACPROVIDER_PROVIDER_TOKEN" for key in keys):
+    raise SystemExit("FAIL: ASCII provider bearer was serialized")
+# Every serialized key must be ASCII (non-ASCII confusables are dropped wholesale).
+for key in keys:
+    try:
+        key.decode("ascii")
+    except UnicodeDecodeError:
+        raise SystemExit(f"FAIL: non-ASCII env key was serialized: {key!r}")
+# A benign ASCII var is still preserved so capture is not vacuous.
+if not any(key == b"SAFEVAR" for key in keys):
+    raise SystemExit("FAIL: benign env var SAFEVAR was not preserved")
+PY
+stop_fixture
+echo "ok: ASCII and non-ASCII confusable secrets dropped from recovery capture"
+
+echo "manual recovery token-fd + env capture ok"

--- a/phase3-binary/dist/test/provider_upgrade_transaction.test.sh
+++ b/phase3-binary/dist/test/provider_upgrade_transaction.test.sh
@@ -22,6 +22,7 @@ extract_function() {
 for function_name in \
   validate_install_dir validate_port_value \
   prepare_staged_config activate_staged_config select_autotune_benchmark_port \
+  read_config_provider_token read_config_provider_id existing_provider_credential_configured \
   semantic_merge_config restore_existing_provider_if_start_skipped \
   validate_staged_entries; do
   extract_function "$function_name" >> "$TMP/helpers.sh"
@@ -55,6 +56,33 @@ install = main.index("install_binary", recommend)
 activate = main.index("activate_staged_config", install)
 if not snapshot < stage < prepare < freshness < recommend_gate < stop < recommend < install < activate:
     raise SystemExit("benchmarks are not isolated from the live provider and staged cutover")
+repair_gate = main.index('if [ "$APP_MANAGED_REPAIR" -eq 1 ]', activate)
+plist = main.index('install_plist "$model" "$provider_id" "$coordinator_url"', repair_gate)
+local_health = main.index('if ! wait_for_local_model "$model"', plist)
+admission = main.index('if ! wait_for_coordinator "$provider_id" "$coordinator_base"', local_health)
+repair_body = main[repair_gate:plist]
+if not activate < repair_gate < plist < local_health < admission:
+    raise SystemExit("app-managed repair is not returned before launchd health/admission gates")
+for required in (
+    'unload_app_managed_launchd_jobs',
+    'rm -f "$PLIST_PATH" "$WATCHDOG_PLIST_PATH"',
+    'write_install_manifest "$tag"',
+    'commit_install_transaction',
+    'exit 0',
+):
+    if required not in repair_body:
+        raise SystemExit(f"app-managed repair is missing: {required}")
+if repair_body.index('unload_app_managed_launchd_jobs') > repair_body.index('rm -f "$PLIST_PATH" "$WATCHDOG_PLIST_PATH"'):
+    raise SystemExit("app-managed repair deletes plists before unloading launchd jobs")
+unload = source[source.index("unload_app_managed_launchd_jobs() {"):source.index("cache_size_kb() {")]
+for required in (
+    'launchctl print "gui/$UID/live.streamvc.macprovider"',
+    'launchctl print "gui/$UID/$WATCHDOG_LABEL"',
+    'lsof -nP -iTCP:"$PORT" -sTCP:LISTEN -t',
+    'die 70 "could not confirm launchd ownership release for app-managed repair"',
+):
+    if required not in unload:
+        raise SystemExit(f"app-managed launchd teardown is not verified: {required}")
 helper = source[source.index("run_macprovider_cli_with_amfi_retry() {"):source.index("detect_existing_port() {")]
 if 'local cli_path="$MACPROVIDER_CLI_EXECUTABLE"' not in helper:
     raise SystemExit("recommendation helper is not routed to the staged CLI")
@@ -126,10 +154,36 @@ LIVE_CONFIG_PATH="$CONFIG_PATH"
 PROVIDER_ID_PATH="$CONFIG_DIR/provider_id"
 LIVE_PROVIDER_ID_PATH="$PROVIDER_ID_PATH"
 mkdir -p "$CONFIG_DIR"
+APP_MARKER_PATH="$TMP/home/Library/Application Support/Malibu/.installed-by-app"
+
+printf 'provider_id: existing\n' > "$CONFIG_PATH"
+if existing_provider_credential_configured; then
+  echo "tokenless config unexpectedly bypassed referral preflight" >&2
+  exit 1
+fi
+printf 'provider_id: existing\nprovider_token: existing-secret\n' > "$CONFIG_PATH"
+existing_provider_credential_configured || {
+  echo "existing config credential did not bypass referral preflight" >&2
+  exit 1
+}
+printf 'provider_id: existing\n' > "$CONFIG_PATH"
+mkdir -p "$(dirname "$APP_MARKER_PATH")"
+: > "$APP_MARKER_PATH"
+APP_MANAGED_REPAIR=1 existing_provider_credential_configured || {
+  echo "app-owned identity marker did not bypass referral preflight" >&2
+  exit 1
+}
+rm -f "$APP_MARKER_PATH"
+if (APP_MANAGED_REPAIR=1; existing_provider_credential_configured); then
+  echo "unproven app-managed repair unexpectedly bypassed referral preflight" >&2
+  exit 1
+fi
+
 cat > "$CONFIG_PATH" <<'EOF'
 # operator-owned settings must survive installer upgrades
 model: "old/model"
 provider_token: "secret-token"
+referral_code: "MAL1-S-k1-existing-AAAAAAAAAAAAAAAAAAAAAAAAAA"
 receipt_log_path: "/private/receipts.jsonl"
 enable_warm_swap: true
 auto_update: false
@@ -150,6 +204,7 @@ grep -F 'provider_id: "provider-new"' "$CONFIG_PATH" >/dev/null
 grep -F 'coordinator_url: "wss://coordinator.example/ws/provider"' "$CONFIG_PATH" >/dev/null
 grep -F 'port: 19090' "$CONFIG_PATH" >/dev/null
 grep -F 'provider_token: "secret-token"' "$CONFIG_PATH" >/dev/null
+grep -F 'referral_code: "MAL1-S-k1-existing-AAAAAAAAAAAAAAAAAAAAAAAAAA"' "$CONFIG_PATH" >/dev/null
 grep -F 'receipt_log_path: "/private/receipts.jsonl"' "$CONFIG_PATH" >/dev/null
 grep -F 'enable_warm_swap: true' "$CONFIG_PATH" >/dev/null
 grep -F 'auto_update: false' "$CONFIG_PATH" >/dev/null
@@ -160,11 +215,12 @@ mkdir -p "$staging_dir"
 printf 'provider-old\n' > "$LIVE_PROVIDER_ID_PATH"
 prepare_staged_config
 grep -F 'model: "new/model"' "$STAGED_CONFIG_PATH" >/dev/null
-semantic_merge_config "$STAGED_CONFIG_PATH" "staged/model" "provider-staged" "wss://staged.example/ws/provider" "19090"
+semantic_merge_config "$STAGED_CONFIG_PATH" "staged/model" "provider-staged" "wss://staged.example/ws/provider" "19090" "MAL1-P-k1-newissuer-BBBBBBBBBBBBBBBBBBBBBBBBBB"
 printf 'provider-staged\n' > "$STAGED_PROVIDER_ID_PATH"
 grep -F 'model: "new/model"' "$LIVE_CONFIG_PATH" >/dev/null
 activate_staged_config
 grep -F 'model: "staged/model"' "$LIVE_CONFIG_PATH" >/dev/null
+grep -F 'referral_code: "MAL1-P-k1-newissuer-BBBBBBBBBBBBBBBBBBBBBBBBBB"' "$LIVE_CONFIG_PATH" >/dev/null
 grep -F 'provider-staged' "$LIVE_PROVIDER_ID_PATH" >/dev/null
 
 PORT=18080

--- a/phase4-coordinator/cmd/coordinator/main.go
+++ b/phase4-coordinator/cmd/coordinator/main.go
@@ -29,6 +29,7 @@ import (
 	"github.com/augstar/macprovider-coordinator/internal/pool"
 	"github.com/augstar/macprovider-coordinator/internal/pow"
 	"github.com/augstar/macprovider-coordinator/internal/providerhttp"
+	"github.com/augstar/macprovider-coordinator/internal/referralapi"
 	"github.com/augstar/macprovider-coordinator/internal/requestlog"
 	"github.com/augstar/macprovider-coordinator/internal/rewards"
 	"github.com/augstar/macprovider-coordinator/internal/stats"
@@ -444,7 +445,28 @@ func main() {
 		}
 	}()
 	wsOpts := []providerws.Option{}
+	var grandfatherBefore *time.Time
+	if raw := strings.TrimSpace(cfg.Referrals.GrandfatherBefore); raw != "" && cfg.Referrals.RequireForRegistration {
+		parsed, err := time.Parse(time.RFC3339, raw)
+		if err != nil {
+			logger.Fatal().Err(err).Msg("parse referral grandfather cutoff")
+		}
+		grandfatherBefore = &parsed
+	}
+	referralPolicy := auth.ReferralPolicy{
+		RequireForRegistration: cfg.Referrals.RequireForRegistration,
+		EnableSocialBonus:      cfg.Referrals.EnableSocialInviteBonus,
+		Campaign:               cfg.Referrals.Campaign,
+		PolicyVersion:          cfg.Referrals.PolicyVersion,
+		GrandfatherBefore:      grandfatherBefore,
+		CurrentKeyID:           cfg.Referrals.CurrentKeyID,
+		HMACKeys:               cfg.Referrals.HMACKeys,
+		ProviderBaseUses:       cfg.Referrals.ProviderBaseUses,
+		SocialBonusUses:        cfg.Referrals.SocialBonusUses,
+		ChallengeTTL:           time.Duration(cfg.Referrals.ChallengeTTLS) * time.Second,
+	}
 	wsOpts = append(wsOpts, providerws.WithVersion(version))
+	wsOpts = append(wsOpts, providerws.WithReferralPolicy(referralPolicy))
 	wsOpts = append(wsOpts, providerws.WithAdmissionStore(admissionStore))
 	if canaryStore != nil {
 		wsOpts = append(wsOpts, providerws.WithCanarySanctionStore(canaryStore))
@@ -837,6 +859,8 @@ func main() {
 		registerHandler := &onboarding.Handler{
 			StatsDB:                             onboardingStore,
 			AuthTokenStore:                      tokenStore,
+			ReferralStore:                       tokenStore,
+			ReferralPolicy:                      referralPolicy,
 			CoordinatorDomain:                   cfg.Onboarding.CoordinatorDomain,
 			CoordinatorWSURL:                    "wss://" + cfg.Onboarding.CoordinatorDomain + "/v2/provider",
 			TrustedProxies:                      mustParseTrustedProxies(cfg, logger),
@@ -861,6 +885,7 @@ func main() {
 		}
 		register = registerHandler.HandleAppTrackRegister
 		hardwareEvidence = registerHandler.HandleHardwareEvidence
+		startAppTrackReferralMintReconciler(shutdownCtx, registerHandler, logger)
 		logger.Info().Msg("SPEC-026 app-track register route mounted on buyer port")
 	}
 	// Phase 2 Track P2-A: MDM enrollment profile endpoint.
@@ -873,7 +898,7 @@ func main() {
 			Str("base_url", cfg.Tier2.MDM.EnrollmentBaseURL).
 			Msg("MDM enrollment profile route mounted on buyer port (/v1/enroll)")
 	}
-	buyerHandler := buyerHandlerWithOptionalProviderEndpoints(
+	var buyerHandler http.Handler = buyerHandlerWithOptionalProviderEndpoints(
 		buyerServer.Handler(),
 		cfg.Onboarding.AppTrackRegisterEnabled,
 		register,
@@ -881,6 +906,17 @@ func main() {
 		enrollHandler,
 		malibuAccrualHandler(cfg, tokenStore, rewardsDB, rewards.NewPoolHeartbeatBridge(wsServer.PoolSnapshot)),
 	)
+	trustedReferralProxies := mustParseTrustedProxies(cfg, logger)
+	referralValidation := &referralapi.ValidationHandler{
+		Store:         tokenStore,
+		Policy:        referralPolicy,
+		PublicLimiter: referralapi.NewBoundedLimiter(30, time.Minute, 4096),
+		ValidateSlots: make(chan struct{}, 4),
+		SourceIP: func(r *http.Request) string {
+			return onboarding.ClientIP(r, trustedReferralProxies)
+		},
+	}
+	buyerHandler = withReferralValidation(buyerHandler, referralValidation.ServeHTTP)
 
 	providerHTTP := newHTTPServer(providerAddr, providerMux)
 	buyerHTTP := newHTTPServer(buyerAddr, buyerHandler)
@@ -1158,6 +1194,32 @@ func startGitHubAuthStatePruner(ctx context.Context, store githubAuthStatePruner
 	}()
 }
 
+func startAppTrackReferralMintReconciler(ctx context.Context, handler *onboarding.Handler, logger zerolog.Logger) {
+	if handler == nil || !handler.ReferralPolicy.RequireForRegistration {
+		return
+	}
+	go func() {
+		reconcile := func() {
+			reconcileCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+			defer cancel()
+			if err := handler.ReconcilePendingAppTrackReferralMints(reconcileCtx); err != nil && ctx.Err() == nil {
+				logger.Error().Err(err).Msg("App-track referral mint reconciliation failed")
+			}
+		}
+		reconcile()
+		ticker := time.NewTicker(time.Minute)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				reconcile()
+			}
+		}
+	}()
+}
+
 func startAuditLogRetentionPruner(ctx context.Context, store requestLogPruner, retentionDays int, logger zerolog.Logger) {
 	if store == nil || retentionDays <= 0 {
 		return
@@ -1228,6 +1290,16 @@ func buyerHandlerWithOptionalProviderEndpoints(base http.Handler, enabled bool, 
 	if malibuAccrual != nil {
 		mux.Handle("/v1/provider/malibu-accrual", malibuAccrual)
 	}
+	mux.Handle("/", base)
+	return mux
+}
+
+func withReferralValidation(base http.Handler, validate http.HandlerFunc) http.Handler {
+	if validate == nil {
+		return base
+	}
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v1/referrals/validate", validate)
 	mux.Handle("/", base)
 	return mux
 }

--- a/phase4-coordinator/cmd/coordinator/main_test.go
+++ b/phase4-coordinator/cmd/coordinator/main_test.go
@@ -44,6 +44,22 @@ func TestNewHTTPServerAppliesTimeouts(t *testing.T) {
 	}
 }
 
+func TestWithReferralValidationMountsOnlyValidationRoute(t *testing.T) {
+	base := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(http.StatusNoContent) })
+	handler := withReferralValidation(base, func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(http.StatusOK) })
+
+	response := httptest.NewRecorder()
+	handler.ServeHTTP(response, httptest.NewRequest(http.MethodPost, "/v1/referrals/validate", nil))
+	if response.Code != http.StatusOK {
+		t.Fatalf("validation status=%d", response.Code)
+	}
+	response = httptest.NewRecorder()
+	handler.ServeHTTP(response, httptest.NewRequest(http.MethodPost, "/v1/referrals/reserve", nil))
+	if response.Code != http.StatusNoContent {
+		t.Fatalf("reservation route unexpectedly mounted: status=%d", response.Code)
+	}
+}
+
 func TestListenAddressParsesIPv4AndIPv6(t *testing.T) {
 	for _, host := range []string{"127.0.0.1", "::1", "::"} {
 		t.Run(host, func(t *testing.T) {

--- a/phase4-coordinator/dist/coordinator.yaml
+++ b/phase4-coordinator/dist/coordinator.yaml
@@ -86,6 +86,23 @@ auth:
     spec026_a: env:OPERATOR_AUTH_POLICY_A
     spec026_b: env:OPERATOR_AUTH_POLICY_B
 
+# Pre-beta referral admission. Both switches remain off in checked-in config;
+# enabling either requires an explicit campaign, key id, and 32+ byte HMAC key.
+referrals:
+  require_for_registration: false
+  enable_social_invite_bonus: false
+  campaign: ""
+  policy_version: "v1"
+  grandfather_before: ""
+  current_key_id: ""
+  hmac_keys: {}
+  provider_base_uses: 1
+  social_bonus_uses: 2
+  challenge_ttl_s: 900
+  join_base_url: "https://coordinator.streamvc.live/j"
+  x_api_bearer_token: ""
+  request_access_url: ""
+
 # SPEC-007 v0.2 — internal read-only operator explorer.
 # Reuses auth.operator_key (D15). Disable by setting enabled: false.
 # Mounted at /admin/explorer/ on provider_port (8444); already proxied by nginx.

--- a/phase4-coordinator/internal/auth/apptrack_referral_mints.go
+++ b/phase4-coordinator/internal/auth/apptrack_referral_mints.go
@@ -28,19 +28,24 @@ type PendingAppTrackReferralMint struct {
 }
 
 // MintProviderTokenAppTrackWithReferralAttempt validates and redeems the
-// referral, creates an undisclosed credential, and records an exact pending
-// saga in one SQLite transaction. It never rotates an existing credential.
+// referral, commits the client's signed credential candidate, and records an
+// exact pending saga in one SQLite transaction. It never rotates an existing
+// credential; the client already has custody if the HTTP response is lost.
 func (s *Store) MintProviderTokenAppTrackWithReferralAttempt(
 	ctx context.Context,
-	providerID, referralCode string,
+	providerID, referralCode, tokenCandidate string,
 	policy ReferralPolicy,
 	attempt AppTrackRegistrationAttempt,
 ) (string, error) {
 	if err := config.ValidateProviderID(providerID); err != nil {
 		return "", err
 	}
+	tokenCandidate = strings.TrimSpace(tokenCandidate)
 	if !policy.RequireForRegistration || strings.TrimSpace(attempt.SourceIP) == "" ||
 		strings.TrimSpace(attempt.Nonce) == "" || attempt.AttemptTS.IsZero() {
+		return "", ErrReferralConflict
+	}
+	if len(tokenCandidate) != 64 || !isLowerHexToken(tokenCandidate) {
 		return "", ErrReferralConflict
 	}
 
@@ -61,16 +66,12 @@ SELECT COUNT(1) FROM provider_tokens
 		if err != nil {
 			return err
 		}
-		newToken, err := randomHex(32)
-		if err != nil {
-			return err
-		}
-		hash := tokenHash(newToken)
+		hash := tokenHash(tokenCandidate)
 		if _, err := conn.ExecContext(ctx, `
 INSERT INTO provider_tokens
     (token_hash, token_prefix, provider_id, provider_name, created_at)
 VALUES (?, ?, ?, 'malibu-app', ?)`,
-			hash, newToken[:tokenDisplayPrefixLength], providerID, timeText(now),
+			hash, tokenCandidate[:tokenDisplayPrefixLength], providerID, timeText(now),
 		); err != nil {
 			if isActiveProviderTokenConstraintFailure(err) {
 				return ErrActiveTokenAlreadyExists
@@ -88,13 +89,22 @@ INSERT INTO apptrack_pending_referral_mints (
 		); err != nil {
 			return err
 		}
-		token = newToken
+		token = tokenCandidate
 		return nil
 	})
 	if err != nil {
 		return "", err
 	}
 	return token, nil
+}
+
+func isLowerHexToken(value string) bool {
+	for _, r := range value {
+		if (r < '0' || r > '9') && (r < 'a' || r > 'f') {
+			return false
+		}
+	}
+	return true
 }
 
 // AcknowledgeAppTrackReferralMint removes the saga only after PostgreSQL has

--- a/phase4-coordinator/internal/auth/apptrack_referral_mints.go
+++ b/phase4-coordinator/internal/auth/apptrack_referral_mints.go
@@ -1,0 +1,225 @@
+package auth
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/augstar/macprovider-coordinator/internal/config"
+	"github.com/augstar/macprovider-coordinator/internal/sqliteutil"
+)
+
+// AppTrackRegistrationAttempt identifies the PostgreSQL half of a gated
+// registration. AttemptTS is the signed request timestamp and therefore stable
+// across transport retries; SourceIP is retained only as diagnostic metadata.
+type AppTrackRegistrationAttempt struct {
+	SourceIP  string
+	Nonce     string
+	AttemptTS time.Time
+}
+
+type PendingAppTrackReferralMint struct {
+	ProviderID string
+	TokenHash  string
+	Attempt    AppTrackRegistrationAttempt
+}
+
+// MintProviderTokenAppTrackWithReferralAttempt validates and redeems the
+// referral, creates an undisclosed credential, and records an exact pending
+// saga in one SQLite transaction. It never rotates an existing credential.
+func (s *Store) MintProviderTokenAppTrackWithReferralAttempt(
+	ctx context.Context,
+	providerID, referralCode string,
+	policy ReferralPolicy,
+	attempt AppTrackRegistrationAttempt,
+) (string, error) {
+	if err := config.ValidateProviderID(providerID); err != nil {
+		return "", err
+	}
+	if !policy.RequireForRegistration || strings.TrimSpace(attempt.SourceIP) == "" ||
+		strings.TrimSpace(attempt.Nonce) == "" || attempt.AttemptTS.IsZero() {
+		return "", ErrReferralConflict
+	}
+
+	var token string
+	err := sqliteutil.Transact(ctx, s.db, func(ctx context.Context, conn *sql.Conn) error {
+		var active int
+		if err := conn.QueryRowContext(ctx, `
+SELECT COUNT(1) FROM provider_tokens
+ WHERE provider_id = ? AND revoked_at IS NULL`, providerID).Scan(&active); err != nil {
+			return err
+		}
+		if active != 0 {
+			return ErrAppTrackExistingTokenNoProof
+		}
+
+		now := time.Now().UTC()
+		createdRedemption, err := redeemReferralTx(ctx, conn, policy, referralCode, providerID, now)
+		if err != nil {
+			return err
+		}
+		newToken, err := randomHex(32)
+		if err != nil {
+			return err
+		}
+		hash := tokenHash(newToken)
+		if _, err := conn.ExecContext(ctx, `
+INSERT INTO provider_tokens
+    (token_hash, token_prefix, provider_id, provider_name, created_at)
+VALUES (?, ?, ?, 'malibu-app', ?)`,
+			hash, newToken[:tokenDisplayPrefixLength], providerID, timeText(now),
+		); err != nil {
+			if isActiveProviderTokenConstraintFailure(err) {
+				return ErrActiveTokenAlreadyExists
+			}
+			return err
+		}
+		if _, err := conn.ExecContext(ctx, `
+INSERT INTO apptrack_pending_referral_mints (
+    provider_id, token_hash, campaign, registration_source_ip,
+    registration_nonce, registration_attempt_ts, created_redemption, created_at
+) VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+			providerID, hash, policy.Campaign, strings.TrimSpace(attempt.SourceIP),
+			strings.TrimSpace(attempt.Nonce), attempt.AttemptTS.UTC().Format(time.RFC3339Nano),
+			createdRedemption, timeText(now),
+		); err != nil {
+			return err
+		}
+		token = newToken
+		return nil
+	})
+	if err != nil {
+		return "", err
+	}
+	return token, nil
+}
+
+// AcknowledgeAppTrackReferralMint removes the saga only after PostgreSQL has
+// durably recorded the exact attempt. The token and redemption remain.
+func (s *Store) AcknowledgeAppTrackReferralMint(ctx context.Context, providerID, cleartextToken string) error {
+	if err := config.ValidateProviderID(providerID); err != nil {
+		return err
+	}
+	cleartextToken = strings.TrimSpace(cleartextToken)
+	if cleartextToken == "" {
+		return ErrReferralConflict
+	}
+	result, err := s.db.ExecContext(ctx, `
+DELETE FROM apptrack_pending_referral_mints
+ WHERE provider_id = ? AND token_hash = ?`, providerID, tokenHash(cleartextToken))
+	if err != nil {
+		return err
+	}
+	if changed, err := result.RowsAffected(); err != nil || changed != 1 {
+		return ErrReferralConflict
+	}
+	return nil
+}
+
+func (s *Store) RollbackAppTrackReferralMint(ctx context.Context, providerID, cleartextToken string) error {
+	if err := config.ValidateProviderID(providerID); err != nil {
+		return err
+	}
+	cleartextToken = strings.TrimSpace(cleartextToken)
+	if cleartextToken == "" {
+		return ErrReferralConflict
+	}
+	return s.resolvePendingAppTrackReferralMint(ctx, providerID, tokenHash(cleartextToken), false)
+}
+
+func (s *Store) ListPendingAppTrackReferralMints(ctx context.Context, createdBefore time.Time) ([]PendingAppTrackReferralMint, error) {
+	rows, err := s.db.QueryContext(ctx, `
+SELECT provider_id, token_hash, registration_source_ip, registration_nonce, registration_attempt_ts
+  FROM apptrack_pending_referral_mints
+ WHERE created_at <= ?
+ ORDER BY created_at, provider_id`, timeText(createdBefore.UTC()))
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var pending []PendingAppTrackReferralMint
+	for rows.Next() {
+		var item PendingAppTrackReferralMint
+		var attemptTS string
+		if err := rows.Scan(
+			&item.ProviderID, &item.TokenHash, &item.Attempt.SourceIP,
+			&item.Attempt.Nonce, &attemptTS,
+		); err != nil {
+			return nil, err
+		}
+		item.Attempt.AttemptTS, err = time.Parse(time.RFC3339Nano, attemptTS)
+		if err != nil {
+			return nil, fmt.Errorf("parse pending App-track attempt timestamp: %w", err)
+		}
+		pending = append(pending, item)
+	}
+	return pending, rows.Err()
+}
+
+func (s *Store) ResolvePendingAppTrackReferralMint(ctx context.Context, pending PendingAppTrackReferralMint, registrationPrepared bool) error {
+	if err := config.ValidateProviderID(pending.ProviderID); err != nil {
+		return err
+	}
+	if strings.TrimSpace(pending.TokenHash) == "" {
+		return ErrReferralConflict
+	}
+	return s.resolvePendingAppTrackReferralMint(ctx, pending.ProviderID, pending.TokenHash, registrationPrepared)
+}
+
+func (s *Store) resolvePendingAppTrackReferralMint(ctx context.Context, providerID, expectedTokenHash string, registrationPrepared bool) error {
+	return sqliteutil.Transact(ctx, s.db, func(ctx context.Context, conn *sql.Conn) error {
+		var campaign string
+		var createdRedemption bool
+		if err := conn.QueryRowContext(ctx, `
+SELECT campaign, created_redemption
+  FROM apptrack_pending_referral_mints
+ WHERE provider_id = ? AND token_hash = ?`, providerID, expectedTokenHash,
+		).Scan(&campaign, &createdRedemption); err != nil {
+			if errors.Is(err, sql.ErrNoRows) {
+				return ErrReferralConflict
+			}
+			return err
+		}
+		if registrationPrepared {
+			_, err := conn.ExecContext(ctx, `
+DELETE FROM apptrack_pending_referral_mints
+ WHERE provider_id = ? AND token_hash = ?`, providerID, expectedTokenHash)
+			return err
+		}
+
+		result, err := conn.ExecContext(ctx, `
+DELETE FROM provider_tokens
+ WHERE provider_id = ? AND token_hash = ?
+   AND provider_name = 'malibu-app'
+   AND revoked_at IS NULL AND last_used_at IS NULL`, providerID, expectedTokenHash)
+		if err != nil {
+			return err
+		}
+		if changed, err := result.RowsAffected(); err != nil || changed != 1 {
+			return ErrReferralConflict
+		}
+		if createdRedemption {
+			result, err = conn.ExecContext(ctx, `
+DELETE FROM referral_redemptions
+ WHERE campaign = ? AND provider_id = ?`, campaign, providerID)
+			if err != nil {
+				return err
+			}
+			if changed, err := result.RowsAffected(); err != nil || changed != 1 {
+				return ErrReferralConflict
+			}
+			if _, err := conn.ExecContext(ctx, `
+DELETE FROM provider_referral_admissions
+ WHERE campaign = ? AND provider_id = ? AND decision = 'referred'`, campaign, providerID); err != nil {
+				return err
+			}
+		}
+		_, err = conn.ExecContext(ctx, `
+DELETE FROM apptrack_pending_referral_mints
+ WHERE provider_id = ? AND token_hash = ?`, providerID, expectedTokenHash)
+		return err
+	})
+}

--- a/phase4-coordinator/internal/auth/referrals_core.go
+++ b/phase4-coordinator/internal/auth/referrals_core.go
@@ -1,0 +1,306 @@
+package auth
+
+import (
+	"context"
+	"crypto/hmac"
+	"crypto/sha256"
+	"database/sql"
+	"encoding/base32"
+	"errors"
+	"fmt"
+	"regexp"
+	"strings"
+	"time"
+)
+
+var (
+	ErrReferralRequired  = errors.New("referral code required")
+	ErrReferralInvalid   = errors.New("referral code invalid")
+	ErrReferralExpired   = errors.New("referral code expired")
+	ErrReferralRevoked   = errors.New("referral code revoked")
+	ErrReferralExhausted = errors.New("referral code exhausted")
+	ErrReferralConflict  = errors.New("provider already attributed to another referral")
+)
+
+const (
+	ReferralTypeSeed     = "S"
+	ReferralTypeProvider = "P"
+	referralTagBytes     = 16
+)
+
+var referralPartPattern = regexp.MustCompile(`^[A-Za-z0-9_]{1,32}$`)
+var referralEncoder = base32.StdEncoding.WithPadding(base32.NoPadding)
+
+// ReferralPolicy is a caller-owned immutable snapshot. Secrets remain in
+// memory; issuer rows persist only the key id needed for explicit rotation.
+type ReferralPolicy struct {
+	RequireForRegistration bool
+	EnableSocialBonus      bool
+	Campaign               string
+	PolicyVersion          string
+	GrandfatherBefore      *time.Time
+	GrandfatherProof       bool
+	CurrentKeyID           string
+	HMACKeys               map[string]string
+	ProviderBaseUses       int
+	SocialBonusUses        int
+	ChallengeTTL           time.Duration
+}
+
+func (p ReferralPolicy) Validate() error {
+	if !p.RequireForRegistration && !p.EnableSocialBonus && strings.TrimSpace(p.Campaign) == "" {
+		return nil
+	}
+	if !referralPartPattern.MatchString(p.Campaign) {
+		return fmt.Errorf("referral campaign must match %s", referralPartPattern)
+	}
+	if !referralPartPattern.MatchString(p.PolicyVersion) {
+		return fmt.Errorf("referral policy version must match %s", referralPartPattern)
+	}
+	if !referralPartPattern.MatchString(p.CurrentKeyID) {
+		return fmt.Errorf("referral current key id must match %s", referralPartPattern)
+	}
+	secret := p.HMACKeys[p.CurrentKeyID]
+	if len(secret) < 32 {
+		return fmt.Errorf("referral current HMAC secret must be at least 32 bytes")
+	}
+	for keyID, value := range p.HMACKeys {
+		if !referralPartPattern.MatchString(keyID) || len(value) < 32 {
+			return fmt.Errorf("referral HMAC key %q is invalid or shorter than 32 bytes", keyID)
+		}
+	}
+	if p.ProviderBaseUses <= 0 {
+		return fmt.Errorf("referral provider capacity must be positive")
+	}
+	if p.EnableSocialBonus && (p.SocialBonusUses <= 0 || p.ChallengeTTL <= 0) {
+		return fmt.Errorf("referral social capacity and challenge ttl must be positive")
+	}
+	return nil
+}
+
+type ReferralValidation struct {
+	Valid         bool
+	Reason        string
+	Type          string
+	IssuerID      string
+	Campaign      string
+	RemainingUses int
+}
+
+type parsedReferralCode struct {
+	Type     string
+	KeyID    string
+	IssuerID string
+	Tag      []byte
+}
+
+func parseReferralCode(raw string) (parsedReferralCode, error) {
+	parts := strings.Split(strings.TrimSpace(raw), "-")
+	if len(parts) != 5 || parts[0] != "MAL1" ||
+		(parts[1] != ReferralTypeSeed && parts[1] != ReferralTypeProvider) ||
+		!referralPartPattern.MatchString(parts[2]) || !referralPartPattern.MatchString(parts[3]) {
+		return parsedReferralCode{}, ErrReferralInvalid
+	}
+	tag, err := referralEncoder.DecodeString(strings.ToUpper(parts[4]))
+	if err != nil || len(tag) != referralTagBytes {
+		return parsedReferralCode{}, ErrReferralInvalid
+	}
+	return parsedReferralCode{Type: parts[1], KeyID: parts[2], IssuerID: parts[3], Tag: tag}, nil
+}
+
+func referralMAC(policy ReferralPolicy, typ, keyID, issuerID string) ([]byte, error) {
+	secret, ok := policy.HMACKeys[keyID]
+	if !ok || len(secret) < 32 {
+		return nil, ErrReferralInvalid
+	}
+	mac := hmac.New(sha256.New, []byte(secret))
+	_, _ = mac.Write([]byte("malibu-referral/v1\x00"))
+	_, _ = mac.Write([]byte(typ))
+	_, _ = mac.Write([]byte("\x00" + keyID + "\x00" + policy.Campaign + "\x00" + issuerID))
+	return mac.Sum(nil)[:referralTagBytes], nil
+}
+
+func EncodeReferralCode(policy ReferralPolicy, typ, keyID, issuerID string) (string, error) {
+	if err := policy.Validate(); err != nil {
+		return "", err
+	}
+	if (typ != ReferralTypeSeed && typ != ReferralTypeProvider) ||
+		!referralPartPattern.MatchString(keyID) || !referralPartPattern.MatchString(issuerID) {
+		return "", ErrReferralInvalid
+	}
+	tag, err := referralMAC(policy, typ, keyID, issuerID)
+	if err != nil {
+		return "", err
+	}
+	return strings.Join([]string{"MAL1", typ, keyID, issuerID, referralEncoder.EncodeToString(tag)}, "-"), nil
+}
+
+func (s *Store) ValidateReferral(ctx context.Context, policy ReferralPolicy, code string, now time.Time) (ReferralValidation, error) {
+	if err := policy.Validate(); err != nil {
+		return ReferralValidation{}, err
+	}
+	return validateReferralTx(ctx, s.db, policy, code, now)
+}
+
+type referralQueryRower interface {
+	QueryRowContext(context.Context, string, ...any) *sql.Row
+}
+
+func validateReferralTx(ctx context.Context, conn referralQueryRower, policy ReferralPolicy, code string, now time.Time) (ReferralValidation, error) {
+	parsed, err := parseReferralCode(code)
+	if err != nil {
+		return ReferralValidation{Reason: "invalid"}, ErrReferralInvalid
+	}
+	want, err := referralMAC(policy, parsed.Type, parsed.KeyID, parsed.IssuerID)
+	if err != nil || !hmac.Equal(want, parsed.Tag) {
+		return ReferralValidation{Reason: "invalid"}, ErrReferralInvalid
+	}
+	var issuer struct {
+		Type      string
+		KeyID     string
+		Campaign  string
+		Base      int
+		Bonus     int
+		ExpiresAt sql.NullString
+		RevokedAt sql.NullString
+	}
+	err = conn.QueryRowContext(ctx, `
+SELECT code_type, key_id, campaign, base_capacity, bonus_capacity, expires_at, revoked_at
+  FROM referral_issuers
+ WHERE issuer_id = ?`, parsed.IssuerID).Scan(
+		&issuer.Type, &issuer.KeyID, &issuer.Campaign, &issuer.Base, &issuer.Bonus,
+		&issuer.ExpiresAt, &issuer.RevokedAt,
+	)
+	if errors.Is(err, sql.ErrNoRows) {
+		return ReferralValidation{Reason: "invalid"}, ErrReferralInvalid
+	}
+	if err != nil {
+		return ReferralValidation{}, err
+	}
+	if issuer.Type != parsed.Type || issuer.KeyID != parsed.KeyID || issuer.Campaign != policy.Campaign {
+		return ReferralValidation{Reason: "invalid"}, ErrReferralInvalid
+	}
+	if issuer.RevokedAt.Valid {
+		return ReferralValidation{Reason: "revoked"}, ErrReferralRevoked
+	}
+	if issuer.ExpiresAt.Valid {
+		expires, parseErr := time.Parse(time.RFC3339, issuer.ExpiresAt.String)
+		if parseErr != nil || !expires.After(now.UTC()) {
+			return ReferralValidation{Reason: "expired"}, ErrReferralExpired
+		}
+	}
+	var used int
+	if err := conn.QueryRowContext(ctx,
+		`SELECT COUNT(1) FROM referral_redemptions WHERE issuer_id = ?`,
+		parsed.IssuerID,
+	).Scan(&used); err != nil {
+		return ReferralValidation{}, err
+	}
+	remaining := issuer.Base + issuer.Bonus - used
+	if remaining <= 0 {
+		return ReferralValidation{
+			Reason: "exhausted", Type: parsed.Type, IssuerID: parsed.IssuerID, Campaign: issuer.Campaign,
+		}, ErrReferralExhausted
+	}
+	return ReferralValidation{
+		Valid: true, Reason: "valid", Type: parsed.Type, IssuerID: parsed.IssuerID,
+		Campaign: issuer.Campaign, RemainingUses: remaining,
+	}, nil
+}
+
+// redeemReferralTx is called from the same SQLite transaction that creates a
+// credential. Capacity therefore cannot be consumed without a corresponding
+// token, and two concurrent consumers cannot overdraw an issuer.
+func redeemReferralTx(ctx context.Context, conn *sql.Conn, policy ReferralPolicy, code, providerID string, now time.Time) (bool, error) {
+	if !policy.RequireForRegistration {
+		return false, nil
+	}
+	code = strings.TrimSpace(code)
+	if code == "" {
+		if policy.GrandfatherProof {
+			var decision string
+			err := conn.QueryRowContext(ctx,
+				`SELECT decision FROM provider_referral_admissions WHERE provider_id = ? AND campaign = ?`,
+				providerID, policy.Campaign,
+			).Scan(&decision)
+			if err == nil && decision == "grandfathered" {
+				return false, nil
+			}
+			if err != nil && !errors.Is(err, sql.ErrNoRows) {
+				return false, err
+			}
+		}
+		if policy.GrandfatherProof && policy.GrandfatherBefore != nil {
+			var firstCreated sql.NullString
+			if err := conn.QueryRowContext(ctx,
+				`SELECT MIN(created_at) FROM provider_tokens WHERE provider_id = ?`, providerID,
+			).Scan(&firstCreated); err != nil {
+				return false, err
+			}
+			if firstCreated.Valid {
+				first, err := time.Parse(time.RFC3339, firstCreated.String)
+				if err == nil && first.Before(policy.GrandfatherBefore.UTC()) {
+					_, err = conn.ExecContext(ctx, `
+INSERT INTO provider_referral_admissions (provider_id, campaign, policy_version, decision, applied_at)
+VALUES (?, ?, ?, 'grandfathered', ?)
+ON CONFLICT(provider_id, campaign) DO NOTHING`,
+						providerID, policy.Campaign, policy.PolicyVersion, timeText(now.UTC()),
+					)
+					return false, err
+				}
+			}
+		}
+		return false, ErrReferralRequired
+	}
+
+	var existingIssuer, existingDigest string
+	err := conn.QueryRowContext(ctx, `
+SELECT issuer_id, code_digest FROM referral_redemptions
+ WHERE campaign = ? AND provider_id = ?`, policy.Campaign, providerID,
+	).Scan(&existingIssuer, &existingDigest)
+	if err != nil && !errors.Is(err, sql.ErrNoRows) {
+		return false, err
+	}
+	parsed, parseErr := parseReferralCode(code)
+	if parseErr != nil {
+		return false, ErrReferralInvalid
+	}
+	digest := sha256.Sum256([]byte(code))
+	presentedDigest := fmt.Sprintf("%x", digest[:])
+	if err == nil {
+		if existingIssuer == parsed.IssuerID && hmac.Equal([]byte(existingDigest), []byte(presentedDigest)) {
+			wantMAC, macErr := referralMAC(policy, parsed.Type, parsed.KeyID, parsed.IssuerID)
+			if macErr != nil || !hmac.Equal(wantMAC, parsed.Tag) {
+				return false, ErrReferralInvalid
+			}
+			return false, nil
+		}
+		return false, ErrReferralConflict
+	}
+
+	validated, err := validateReferralTx(ctx, conn, policy, code, now)
+	if err != nil {
+		return false, err
+	}
+	_, err = conn.ExecContext(ctx, `
+INSERT INTO referral_redemptions
+    (campaign, provider_id, issuer_id, code_digest, policy_version, redeemed_at)
+VALUES (?, ?, ?, ?, ?, ?)`,
+		policy.Campaign, providerID, validated.IssuerID, presentedDigest,
+		policy.PolicyVersion, timeText(now.UTC()),
+	)
+	if isConstraintFailure(err) {
+		return false, ErrReferralExhausted
+	}
+	if err != nil {
+		return false, err
+	}
+	_, err = conn.ExecContext(ctx, `
+INSERT INTO provider_referral_admissions
+    (provider_id, campaign, policy_version, decision, applied_at)
+VALUES (?, ?, ?, 'referred', ?)
+ON CONFLICT(provider_id, campaign) DO NOTHING`,
+		providerID, policy.Campaign, policy.PolicyVersion, timeText(now.UTC()),
+	)
+	return true, err
+}

--- a/phase4-coordinator/internal/auth/referrals_core_test.go
+++ b/phase4-coordinator/internal/auth/referrals_core_test.go
@@ -80,7 +80,8 @@ func TestAppTrackReferralSagaPreservesCommittedAndCompensatesAbsent(t *testing.T
 		AttemptTS: time.Date(2026, 7, 13, 10, 0, 0, 0, time.UTC),
 	}
 
-	token, err := store.MintProviderTokenAppTrackWithReferralAttempt(context.Background(), "provider-a", code, policy, attempt)
+	tokenCandidate := strings.Repeat("c", 64)
+	token, err := store.MintProviderTokenAppTrackWithReferralAttempt(context.Background(), "provider-a", code, tokenCandidate, policy, attempt)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -95,7 +96,7 @@ func TestAppTrackReferralSagaPreservesCommittedAndCompensatesAbsent(t *testing.T
 		t.Fatalf("rolled-back token ok=%v err=%v", ok, err)
 	}
 
-	committedToken, err := store.MintProviderTokenAppTrackWithReferralAttempt(context.Background(), "provider-b", code, policy, AppTrackRegistrationAttempt{
+	committedToken, err := store.MintProviderTokenAppTrackWithReferralAttempt(context.Background(), "provider-b", code, strings.Repeat("d", 64), policy, AppTrackRegistrationAttempt{
 		SourceIP: "203.0.113.11", Nonce: strings.Repeat("b", 64), AttemptTS: attempt.AttemptTS.Add(time.Second),
 	})
 	if err != nil {

--- a/phase4-coordinator/internal/auth/referrals_core_test.go
+++ b/phase4-coordinator/internal/auth/referrals_core_test.go
@@ -1,0 +1,131 @@
+package auth
+
+import (
+	"context"
+	"errors"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func coreReferralPolicy() ReferralPolicy {
+	return ReferralPolicy{
+		RequireForRegistration: true,
+		Campaign:               "prebeta_test",
+		PolicyVersion:          "v1",
+		CurrentKeyID:           "k1",
+		HMACKeys:               map[string]string{"k1": strings.Repeat("s", 32)},
+		ProviderBaseUses:       1,
+	}
+}
+
+func seedCoreReferral(t *testing.T, store *Store, policy ReferralPolicy, issuerID string) string {
+	t.Helper()
+	_, err := store.db.Exec(`
+INSERT INTO referral_issuers (
+    issuer_id, code_type, key_id, campaign, provider_id,
+    base_capacity, bonus_capacity, created_at, first_serving_at
+) VALUES (?, 'S', ?, ?, NULL, 1, 0, ?, ?)`,
+		issuerID, policy.CurrentKeyID, policy.Campaign, nowString(), nowString(),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	code, err := EncodeReferralCode(policy, ReferralTypeSeed, policy.CurrentKeyID, issuerID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return code
+}
+
+func TestReferralRedemptionAndTokenInsertAreAtomic(t *testing.T) {
+	store, err := OpenStore(filepath.Join(t.TempDir(), "coordinator.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+	policy := coreReferralPolicy()
+	code := seedCoreReferral(t, store, policy, "seed1")
+
+	if _, _, err := store.IssueTokenWithReferral(context.Background(), "provider-a", "host-a", code, policy); err != nil {
+		t.Fatalf("first mint: %v", err)
+	}
+	if _, _, err := store.IssueTokenWithReferral(context.Background(), "provider-b", "host-b", code, policy); !errors.Is(err, ErrReferralExhausted) {
+		t.Fatalf("second mint error=%v, want exhausted", err)
+	}
+	var tokens, redemptions int
+	if err := store.db.QueryRow(`SELECT COUNT(1) FROM provider_tokens WHERE revoked_at IS NULL`).Scan(&tokens); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.db.QueryRow(`SELECT COUNT(1) FROM referral_redemptions`).Scan(&redemptions); err != nil {
+		t.Fatal(err)
+	}
+	if tokens != 1 || redemptions != 1 {
+		t.Fatalf("tokens=%d redemptions=%d, want 1/1", tokens, redemptions)
+	}
+}
+
+func TestAppTrackReferralSagaPreservesCommittedAndCompensatesAbsent(t *testing.T) {
+	store, err := OpenStore(filepath.Join(t.TempDir(), "coordinator.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+	policy := coreReferralPolicy()
+	code := seedCoreReferral(t, store, policy, "seed1")
+	attempt := AppTrackRegistrationAttempt{
+		SourceIP:  "203.0.113.10",
+		Nonce:     strings.Repeat("a", 64),
+		AttemptTS: time.Date(2026, 7, 13, 10, 0, 0, 0, time.UTC),
+	}
+
+	token, err := store.MintProviderTokenAppTrackWithReferralAttempt(context.Background(), "provider-a", code, policy, attempt)
+	if err != nil {
+		t.Fatal(err)
+	}
+	pending, err := store.ListPendingAppTrackReferralMints(context.Background(), time.Now().UTC().Add(time.Hour))
+	if err != nil || len(pending) != 1 {
+		t.Fatalf("pending=%+v err=%v", pending, err)
+	}
+	if err := store.ResolvePendingAppTrackReferralMint(context.Background(), pending[0], false); err != nil {
+		t.Fatal(err)
+	}
+	if _, ok, err := store.ValidateToken(context.Background(), token); err != nil || ok {
+		t.Fatalf("rolled-back token ok=%v err=%v", ok, err)
+	}
+
+	committedToken, err := store.MintProviderTokenAppTrackWithReferralAttempt(context.Background(), "provider-b", code, policy, AppTrackRegistrationAttempt{
+		SourceIP: "203.0.113.11", Nonce: strings.Repeat("b", 64), AttemptTS: attempt.AttemptTS.Add(time.Second),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	pending, err = store.ListPendingAppTrackReferralMints(context.Background(), time.Now().UTC().Add(time.Hour))
+	if err != nil || len(pending) != 1 {
+		t.Fatalf("pending=%+v err=%v", pending, err)
+	}
+	if err := store.ResolvePendingAppTrackReferralMint(context.Background(), pending[0], true); err != nil {
+		t.Fatal(err)
+	}
+	if providerID, ok, err := store.ValidateToken(context.Background(), committedToken); err != nil || !ok || providerID != "provider-b" {
+		t.Fatalf("committed token provider=%q ok=%v err=%v", providerID, ok, err)
+	}
+}
+
+func TestCoreSchemaHasNoPublicReferralReservationTables(t *testing.T) {
+	store, err := OpenStore(filepath.Join(t.TempDir(), "coordinator.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+	var count int
+	if err := store.db.QueryRow(`
+SELECT COUNT(1) FROM sqlite_master
+ WHERE type = 'table' AND name LIKE 'referral_reservation%'`).Scan(&count); err != nil {
+		t.Fatal(err)
+	}
+	if count != 0 {
+		t.Fatalf("reservation table count=%d, want 0", count)
+	}
+}

--- a/phase4-coordinator/internal/auth/tokens.go
+++ b/phase4-coordinator/internal/auth/tokens.go
@@ -104,6 +104,8 @@ type BootstrapMintRequest struct {
 	UnconfirmedIDMax    int
 	OutstandingTokenMax int
 	IdentityRetention   time.Duration
+	ReferralCode        string
+	ReferralPolicy      ReferralPolicy
 }
 
 type BootstrapMint struct {
@@ -386,6 +388,50 @@ func (s *Store) ensureGitHubAuthSchema(ctx context.Context) error {
 		)`,
 		`CREATE INDEX IF NOT EXISTS idx_bootstrap_mint_log_provider_ts ON bootstrap_mint_log(provider_id, ts)`,
 		`CREATE INDEX IF NOT EXISTS idx_bootstrap_mint_log_ip_ts ON bootstrap_mint_log(source_ip, ts)`,
+		`CREATE TABLE IF NOT EXISTS referral_issuers (
+			issuer_id TEXT PRIMARY KEY,
+			code_type TEXT NOT NULL CHECK(code_type IN ('S','P')),
+			key_id TEXT NOT NULL,
+			campaign TEXT NOT NULL,
+			provider_id TEXT,
+			base_capacity INTEGER NOT NULL CHECK(base_capacity >= 0),
+			bonus_capacity INTEGER NOT NULL DEFAULT 0 CHECK(bonus_capacity >= 0),
+			expires_at TEXT,
+			revoked_at TEXT,
+			created_at TEXT NOT NULL,
+			first_serving_at TEXT,
+			UNIQUE(provider_id, campaign)
+		)`,
+		`CREATE INDEX IF NOT EXISTS idx_referral_issuers_provider_campaign ON referral_issuers(provider_id, campaign)`,
+		`CREATE TABLE IF NOT EXISTS referral_redemptions (
+			campaign TEXT NOT NULL,
+			provider_id TEXT NOT NULL,
+			issuer_id TEXT NOT NULL REFERENCES referral_issuers(issuer_id),
+			code_digest TEXT NOT NULL,
+			policy_version TEXT NOT NULL DEFAULT 'v1',
+			redeemed_at TEXT NOT NULL,
+			PRIMARY KEY(campaign, provider_id)
+		)`,
+		`CREATE INDEX IF NOT EXISTS idx_referral_redemptions_issuer ON referral_redemptions(issuer_id)`,
+		`CREATE TABLE IF NOT EXISTS provider_referral_admissions (
+			provider_id TEXT NOT NULL,
+			campaign TEXT NOT NULL,
+			policy_version TEXT NOT NULL,
+			decision TEXT NOT NULL CHECK(decision IN ('referred','grandfathered')),
+			applied_at TEXT NOT NULL,
+			PRIMARY KEY(provider_id, campaign)
+		)`,
+		`CREATE TABLE IF NOT EXISTS apptrack_pending_referral_mints (
+			provider_id TEXT PRIMARY KEY,
+			token_hash TEXT NOT NULL UNIQUE,
+			campaign TEXT NOT NULL,
+			registration_source_ip TEXT NOT NULL,
+			registration_nonce TEXT NOT NULL,
+			registration_attempt_ts TEXT NOT NULL,
+			created_redemption INTEGER NOT NULL CHECK(created_redemption IN (0, 1)),
+			created_at TEXT NOT NULL
+		)`,
+		`CREATE INDEX IF NOT EXISTS idx_apptrack_pending_referral_mints_created_at ON apptrack_pending_referral_mints(created_at)`,
 		`CREATE TABLE IF NOT EXISTS bootstrap_gc_audit (
 			id INTEGER PRIMARY KEY CHECK (id = 1),
 			last_run_at TEXT NOT NULL,
@@ -549,6 +595,16 @@ func (s *Store) ensureProviderIDColumn(ctx context.Context) error {
 }
 
 func (s *Store) IssueToken(ctx context.Context, providerID, providerName string) (TokenRecord, string, error) {
+	return s.issueToken(ctx, providerID, providerName, "", ReferralPolicy{})
+}
+
+// IssueTokenWithReferral redeems referral capacity in the same SQLite
+// transaction as the token insert.
+func (s *Store) IssueTokenWithReferral(ctx context.Context, providerID, providerName, referralCode string, policy ReferralPolicy) (TokenRecord, string, error) {
+	return s.issueToken(ctx, providerID, providerName, referralCode, policy)
+}
+
+func (s *Store) issueToken(ctx context.Context, providerID, providerName, referralCode string, policy ReferralPolicy) (TokenRecord, string, error) {
 	// Issue #274 R1 CODE LOW-1: validate the RAW provider_id before any
 	// normalization so admission paths apply the same gate semantics as WS
 	// paths (which validate as-received). Leading/trailing whitespace is
@@ -568,7 +624,8 @@ func (s *Store) IssueToken(ctx context.Context, providerID, providerName string)
 	token := hex.EncodeToString(raw[:])
 	hash := tokenHash(token)
 	prefix := token[:tokenDisplayPrefixLength]
-	createdAt := nowString()
+	now := time.Now().UTC()
+	createdAt := timeText(now)
 	var record TokenRecord
 	err := sqliteutil.Transact(ctx, s.db, func(ctx context.Context, conn *sql.Conn) error {
 		if IsCredentialBootstrapPrincipal(providerID) {
@@ -582,6 +639,9 @@ SELECT EXISTS(
 			if bootstrapIdentityExists == 1 {
 				return ErrBootstrapIdentityExists
 			}
+		}
+		if _, err := redeemReferralTx(ctx, conn, policy, referralCode, providerID, now); err != nil {
+			return err
 		}
 		res, err := conn.ExecContext(ctx, `INSERT INTO provider_tokens (token_hash, token_prefix, provider_id, provider_name, created_at) VALUES (?, ?, ?, ?, ?)`, hash, prefix, providerID, providerName, createdAt)
 		if err != nil {
@@ -820,6 +880,14 @@ SELECT COUNT(1)
 				decisionErr = ErrBootstrapOutstandingLimit
 				return nil
 			}
+		}
+
+		referralPolicy := req.ReferralPolicy
+		// Grandfathering is available only after exact receipt-key custody of an
+		// existing bootstrap identity has been proven above.
+		referralPolicy.GrandfatherProof = identityExists
+		if _, err := redeemReferralTx(ctx, conn, referralPolicy, req.ReferralCode, req.ProviderID, req.Now); err != nil {
+			return err
 		}
 
 		if activeExists {
@@ -1762,6 +1830,14 @@ func (s *Store) HasOwnership(ctx context.Context, providerID string) (bool, erro
 }
 
 func (s *Store) MintAdmissionTokenAndPairOT(ctx context.Context, providerID, providerName string, now time.Time) (AdmissionPairMint, error) {
+	return s.mintAdmissionTokenAndPairOT(ctx, providerID, providerName, now, "", ReferralPolicy{})
+}
+
+func (s *Store) MintAdmissionTokenAndPairOTWithReferral(ctx context.Context, providerID, providerName string, now time.Time, referralCode string, policy ReferralPolicy) (AdmissionPairMint, error) {
+	return s.mintAdmissionTokenAndPairOT(ctx, providerID, providerName, now, referralCode, policy)
+}
+
+func (s *Store) mintAdmissionTokenAndPairOT(ctx context.Context, providerID, providerName string, now time.Time, referralCode string, policy ReferralPolicy) (AdmissionPairMint, error) {
 	// Issue #274 R1 CODE LOW-1: validate the RAW provider_id before any
 	// normalization so admission paths apply the same gate semantics as WS
 	// paths.
@@ -1796,6 +1872,9 @@ SELECT EXISTS(
 			if bootstrapIdentityExists == 1 {
 				return ErrBootstrapIdentityExists
 			}
+		}
+		if _, err := redeemReferralTx(ctx, conn, policy, referralCode, providerID, now); err != nil {
+			return err
 		}
 		res, err := conn.ExecContext(ctx, `INSERT INTO provider_tokens (token_hash, token_prefix, provider_id, provider_name, created_at) VALUES (?, ?, ?, ?, ?)`, hash, prefix, providerID, providerName, nowText)
 		if err != nil {

--- a/phase4-coordinator/internal/auth/tokens.go
+++ b/phase4-coordinator/internal/auth/tokens.go
@@ -999,7 +999,7 @@ func deleteRows(ctx context.Context, conn *sql.Conn, query string, args ...any) 
 	return res.RowsAffected()
 }
 
-func (s *Store) MintProviderTokenAppTrack(ctx context.Context, providerID string, currentBearer *string) (string, error) {
+func (s *Store) MintProviderTokenAppTrack(ctx context.Context, providerID string, currentBearer, freshTokenCandidate *string) (string, error) {
 	if err := config.ValidateProviderID(providerID); err != nil {
 		return "", err
 	}
@@ -1047,9 +1047,18 @@ UPDATE provider_tokens
 			}
 		}
 
-		newToken, err := randomHex(32)
-		if err != nil {
-			return err
+		var newToken string
+		if !requiresProof && freshTokenCandidate != nil {
+			newToken = strings.TrimSpace(*freshTokenCandidate)
+			if len(newToken) != 64 || !isLowerHexToken(newToken) {
+				return ErrReferralConflict
+			}
+		} else {
+			var err error
+			newToken, err = randomHex(32)
+			if err != nil {
+				return err
+			}
 		}
 		prefix := newToken[:tokenDisplayPrefixLength]
 		if _, err := conn.ExecContext(ctx, `

--- a/phase4-coordinator/internal/auth/tokens_test.go
+++ b/phase4-coordinator/internal/auth/tokens_test.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"net/http"
 	"path/filepath"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -962,7 +963,7 @@ func TestMintProviderTokenAppTrackRequiresProofForAnyActiveToken(t *testing.T) {
 	ctx := context.Background()
 	const providerID = "p_apptrackprovider"
 
-	first, err := store.MintProviderTokenAppTrack(ctx, providerID, nil)
+	first, err := store.MintProviderTokenAppTrack(ctx, providerID, nil, nil)
 	if err != nil {
 		t.Fatalf("first app-track mint: %v", err)
 	}
@@ -970,18 +971,18 @@ func TestMintProviderTokenAppTrackRequiresProofForAnyActiveToken(t *testing.T) {
 		t.Fatalf("first token len=%d want 64", len(first))
 	}
 
-	if _, err := store.MintProviderTokenAppTrack(ctx, providerID, nil); !errors.Is(err, auth.ErrAppTrackExistingTokenNoProof) {
+	if _, err := store.MintProviderTokenAppTrack(ctx, providerID, nil, nil); !errors.Is(err, auth.ErrAppTrackExistingTokenNoProof) {
 		t.Fatalf("unused active without proof err=%v want ErrAppTrackExistingTokenNoProof", err)
 	}
 	if provider, ok, err := store.ValidateToken(ctx, first); err != nil || !ok || provider != providerID {
 		t.Fatalf("first token should remain active provider=%q ok=%v err=%v", provider, ok, err)
 	}
 	wrong := "wrong-token"
-	if _, err := store.MintProviderTokenAppTrack(ctx, providerID, &wrong); !errors.Is(err, auth.ErrAppTrackExistingTokenNoProof) {
+	if _, err := store.MintProviderTokenAppTrack(ctx, providerID, &wrong, nil); !errors.Is(err, auth.ErrAppTrackExistingTokenNoProof) {
 		t.Fatalf("active token with wrong proof err=%v want ErrAppTrackExistingTokenNoProof", err)
 	}
 
-	second, err := store.MintProviderTokenAppTrack(ctx, providerID, &first)
+	second, err := store.MintProviderTokenAppTrack(ctx, providerID, &first, nil)
 	if err != nil {
 		t.Fatalf("active token with current proof should reissue: %v", err)
 	}
@@ -991,8 +992,24 @@ func TestMintProviderTokenAppTrackRequiresProofForAnyActiveToken(t *testing.T) {
 	if err := store.MarkTokenUsed(ctx, second); err != nil {
 		t.Fatalf("mark second used: %v", err)
 	}
-	if _, err := store.MintProviderTokenAppTrack(ctx, providerID, &second); !errors.Is(err, auth.ErrAppTrackReissueCooldown) {
+	if _, err := store.MintProviderTokenAppTrack(ctx, providerID, &second, nil); !errors.Is(err, auth.ErrAppTrackReissueCooldown) {
 		t.Fatalf("cooldown reissue err=%v want ErrAppTrackReissueCooldown", err)
+	}
+}
+
+func TestMintProviderTokenAppTrackUsesFreshClientCandidate(t *testing.T) {
+	store, err := auth.OpenStore(filepath.Join(t.TempDir(), "coordinator.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+	candidate := strings.Repeat("c", 64)
+	got, err := store.MintProviderTokenAppTrack(context.Background(), "p_apptrackcandidate", nil, &candidate)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != candidate {
+		t.Fatalf("token=%q want client candidate", got)
 	}
 }
 

--- a/phase4-coordinator/internal/config/config.go
+++ b/phase4-coordinator/internal/config/config.go
@@ -52,6 +52,7 @@ type Config struct {
 	Tier2                        Tier2Config                  `yaml:"tier2"`
 	CoordinatorAdvertisedVersion CoordinatorAdvertisedVersion `yaml:"coordinator_advertised_version"`
 	Auth                         AuthConfig                   `yaml:"auth"`
+	Referrals                    ReferralConfig               `yaml:"referrals"`
 	Storage                      StorageConfig                `yaml:"storage"`
 	Logging                      LoggingConfig                `yaml:"logging"`
 	Rewards                      RewardsConfig                `yaml:"rewards"`
@@ -655,6 +656,25 @@ type AuthConfig struct {
 	GitHubOAuth                           GitHubOAuthConfig `yaml:"github_oauth"`
 }
 
+// ReferralConfig owns pre-beta admission policy. Both launch flags default
+// off; HMAC material supports env:NAME indirection and never needs to be
+// written to the credential database.
+type ReferralConfig struct {
+	RequireForRegistration  bool              `yaml:"require_for_registration"`
+	EnableSocialInviteBonus bool              `yaml:"enable_social_invite_bonus"`
+	Campaign                string            `yaml:"campaign"`
+	PolicyVersion           string            `yaml:"policy_version"`
+	GrandfatherBefore       string            `yaml:"grandfather_before"`
+	CurrentKeyID            string            `yaml:"current_key_id"`
+	HMACKeys                map[string]string `yaml:"hmac_keys"`
+	ProviderBaseUses        int               `yaml:"provider_base_uses"`
+	SocialBonusUses         int               `yaml:"social_bonus_uses"`
+	ChallengeTTLS           int               `yaml:"challenge_ttl_s"`
+	JoinBaseURL             string            `yaml:"join_base_url"`
+	XAPIBearerToken         string            `yaml:"x_api_bearer_token"`
+	RequestAccessURL        string            `yaml:"request_access_url"`
+}
+
 type GitHubOAuthConfig struct {
 	Enabled             bool   `yaml:"enabled"`
 	ClientID            string `yaml:"client_id"`
@@ -1077,6 +1097,14 @@ func Default() Config {
 			CredentialBootstrapTokenTTLS:          600,
 			CredentialBootstrapIdentityRetentionS: 604800,
 		},
+		Referrals: ReferralConfig{
+			ProviderBaseUses: 1,
+			SocialBonusUses:  2,
+			ChallengeTTLS:    900,
+			JoinBaseURL:      "https://coordinator.streamvc.live/j",
+			PolicyVersion:    "v1",
+			HMACKeys:         map[string]string{},
+		},
 		Proxy: ProxyConfig{
 			// Default trusts loopback only. Production sits behind nginx on
 			// localhost, so the default keys rate-limit buckets on the
@@ -1165,6 +1193,18 @@ func (c *Config) resolveEnv() error {
 			return err
 		}
 		c.Auth.OperatorKeys[name] = v
+	}
+	for keyID, raw := range c.Referrals.HMACKeys {
+		v, err := resolveEnvValue("referrals.hmac_keys."+keyID, raw)
+		if err != nil {
+			return err
+		}
+		c.Referrals.HMACKeys[keyID] = v
+	}
+	if v, err := resolveEnvValue("referrals.x_api_bearer_token", c.Referrals.XAPIBearerToken); err != nil {
+		return err
+	} else {
+		c.Referrals.XAPIBearerToken = v
 	}
 	// Round-1 SECURITY r1 MEDIUM 1: stats DSN fields go through
 	// the same env-indirection resolver. Operators inject DSNs
@@ -1466,6 +1506,9 @@ func (c Config) Validate() error {
 	if c.Auth.CredentialBootstrapIdentityRetentionS <= c.Auth.CredentialBootstrapTokenTTLS {
 		return fmt.Errorf("auth.credential_bootstrap_identity_retention_s must exceed auth.credential_bootstrap_token_ttl_s")
 	}
+	if err := c.validateReferrals(); err != nil {
+		return err
+	}
 	if c.WS.WriteBufferSize <= 0 {
 		return fmt.Errorf("ws.write_buffer_size must be > 0")
 	}
@@ -1720,6 +1763,60 @@ func (c Config) Validate() error {
 			if err := ValidateEndpointURL(p.EndpointURL); err != nil {
 				return fmt.Errorf("provider %q endpoint_url must be a valid https URL (http allowed only for 127.0.0.1/localhost)", p.ProviderID)
 			}
+		}
+	}
+	return nil
+}
+
+var referralConfigPartPattern = regexp.MustCompile(`^[A-Za-z0-9_]{1,32}$`)
+
+func (c Config) validateReferrals() error {
+	r := c.Referrals
+	if !r.RequireForRegistration && !r.EnableSocialInviteBonus {
+		return nil
+	}
+	if !referralConfigPartPattern.MatchString(r.Campaign) {
+		return fmt.Errorf("referrals.campaign must contain 1-32 letters, digits, or underscores")
+	}
+	if !referralConfigPartPattern.MatchString(r.PolicyVersion) {
+		return fmt.Errorf("referrals.policy_version must contain 1-32 letters, digits, or underscores")
+	}
+	if raw := strings.TrimSpace(r.GrandfatherBefore); raw != "" {
+		if _, err := time.Parse(time.RFC3339, raw); err != nil {
+			return fmt.Errorf("referrals.grandfather_before must be RFC3339: %w", err)
+		}
+	}
+	if !referralConfigPartPattern.MatchString(r.CurrentKeyID) {
+		return fmt.Errorf("referrals.current_key_id must contain 1-32 letters, digits, or underscores")
+	}
+	secret := r.HMACKeys[r.CurrentKeyID]
+	if len(secret) < 32 {
+		return fmt.Errorf("referrals.hmac_keys.%s must be at least 32 bytes", r.CurrentKeyID)
+	}
+	for keyID, value := range r.HMACKeys {
+		if !referralConfigPartPattern.MatchString(keyID) || len(value) < 32 {
+			return fmt.Errorf("referrals.hmac_keys.%s is invalid or shorter than 32 bytes", keyID)
+		}
+	}
+	if r.ProviderBaseUses <= 0 {
+		return fmt.Errorf("referrals.provider_base_uses must be > 0")
+	}
+	if r.EnableSocialInviteBonus {
+		if r.SocialBonusUses <= 0 || r.ChallengeTTLS <= 0 {
+			return fmt.Errorf("referrals social_bonus_uses and challenge_ttl_s must be > 0")
+		}
+		if strings.TrimSpace(r.XAPIBearerToken) == "" {
+			return fmt.Errorf("referrals.x_api_bearer_token must be set when social invite bonus is enabled")
+		}
+	}
+	joinURL, err := url.Parse(strings.TrimSpace(r.JoinBaseURL))
+	if err != nil || joinURL.Scheme != "https" || joinURL.Host == "" || joinURL.RawQuery != "" || joinURL.Fragment != "" || !strings.HasSuffix(strings.TrimRight(joinURL.Path, "/"), "/j") {
+		return fmt.Errorf("referrals.join_base_url must be an absolute https URL ending in /j")
+	}
+	if raw := strings.TrimSpace(r.RequestAccessURL); raw != "" {
+		reqURL, err := url.Parse(raw)
+		if err != nil || reqURL.Scheme != "https" || reqURL.Host == "" {
+			return fmt.Errorf("referrals.request_access_url must be an absolute https URL when set")
 		}
 	}
 	return nil

--- a/phase4-coordinator/internal/config/config_test.go
+++ b/phase4-coordinator/internal/config/config_test.go
@@ -33,6 +33,28 @@ func TestAutotuneFeedsRequirePublicKeyringWhenConfigured(t *testing.T) {
 	}
 }
 
+func TestReferralLaunchPolicyDefaultsOffAndRejectsUnsafeEnablement(t *testing.T) {
+	cfg := Default()
+	if cfg.Referrals.RequireForRegistration || cfg.Referrals.EnableSocialInviteBonus {
+		t.Fatal("referral launch policy must default off")
+	}
+	cfg.Auth.OperatorKey = "operator-key"
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("disabled referral defaults should validate: %v", err)
+	}
+
+	cfg.Referrals.RequireForRegistration = true
+	cfg.Referrals.Campaign = "prebeta_2026"
+	cfg.Referrals.CurrentKeyID = "k1"
+	if err := cfg.Validate(); err == nil || !strings.Contains(err.Error(), "hmac_keys") {
+		t.Fatalf("unsafe enablement error=%v", err)
+	}
+	cfg.Referrals.HMACKeys = map[string]string{"k1": strings.Repeat("s", 32)}
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("valid referral gate: %v", err)
+	}
+}
+
 func TestAutotuneFeedsRejectInvalidPublicKeys(t *testing.T) {
 	tests := []struct {
 		name    string

--- a/phase4-coordinator/internal/onboarding/apptrack.go
+++ b/phase4-coordinator/internal/onboarding/apptrack.go
@@ -26,6 +26,8 @@ import (
 	"github.com/augstar/macprovider-coordinator/internal/billing"
 )
 
+const appTrackPendingMintReconcileAge = 2 * time.Minute
+
 // RegisterRequest is the JSON body of POST /v1/providers/register.
 // SPEC-026 §4.1. All fields required except AppAttestObject / AppAttestKeyID.
 type RegisterRequest struct {
@@ -34,9 +36,10 @@ type RegisterRequest struct {
 	HardwareSummary HardwareSummary `json:"hardware_summary"`
 	AppAttestObject *string         `json:"app_attest_object,omitempty"` // base64 CBOR
 	AppAttestKeyID  *string         `json:"app_attest_key_id,omitempty"` // base64 32-byte
-	Nonce           string          `json:"nonce"`                       // 64-hex = 32 random bytes
-	TSUTC           string          `json:"ts_utc"`                      // RFC3339
-	Signature       string          `json:"signature"`                   // base64 64-byte Ed25519 over JCS(body\signature)
+	ReferralCode    string          `json:"referral_code,omitempty"`
+	Nonce           string          `json:"nonce"`     // 64-hex = 32 random bytes
+	TSUTC           string          `json:"ts_utc"`    // RFC3339
+	Signature       string          `json:"signature"` // base64 64-byte Ed25519 over JCS(body\signature)
 }
 
 type HardwareSummary struct {
@@ -109,6 +112,8 @@ type Handler struct {
 	// SQLite auth DB — for provider_tokens mint. Reuses existing
 	// phase4-coordinator/internal/auth store.
 	AuthTokenStore AuthTokenStore
+	ReferralStore  ReferralStore
+	ReferralPolicy auth.ReferralPolicy
 
 	// Coordinator config
 	CoordinatorDomain string
@@ -162,6 +167,14 @@ type StatsDB interface {
 	CheckAppAttestKeyIDUnique(ctx context.Context, keyID []byte, providerID string) error
 }
 
+// RegistrationPrepareStore is the durable PostgreSQL half of a gated
+// App-track registration. It is a separate optional interface so open-beta
+// test seams and non-gated deployments retain the existing StatsDB contract.
+type RegistrationPrepareStore interface {
+	PrepareProviderRegistration(ctx context.Context, providerID, sourceIP, nonce string, observedAt, attemptTS time.Time, identityPubkey []byte, attested bool, appAttestKeyID []byte) error
+	ProviderRegistrationPrepared(ctx context.Context, providerID, nonce string, attemptTS time.Time) (bool, error)
+}
+
 // AuthTokenStore is the SQLite-side dependency (existing
 // phase4-coordinator/internal/auth/tokens.go).
 type AuthTokenStore interface {
@@ -175,6 +188,14 @@ type AuthTokenStore interface {
 	// bound provider_id. Evidence submission is read-only with respect to the
 	// SQLite token store, so it does not mark the token used.
 	ValidateToken(ctx context.Context, token string) (providerID string, ok bool, err error)
+}
+
+type ReferralStore interface {
+	MintProviderTokenAppTrackWithReferralAttempt(ctx context.Context, providerID, referralCode string, policy auth.ReferralPolicy, attempt auth.AppTrackRegistrationAttempt) (cleartext string, err error)
+	AcknowledgeAppTrackReferralMint(ctx context.Context, providerID, cleartextToken string) error
+	RollbackAppTrackReferralMint(ctx context.Context, providerID, cleartextToken string) error
+	ListPendingAppTrackReferralMints(ctx context.Context, createdBefore time.Time) ([]auth.PendingAppTrackReferralMint, error)
+	ResolvePendingAppTrackReferralMint(ctx context.Context, pending auth.PendingAppTrackReferralMint, registrationPrepared bool) error
 }
 
 // IPRateLimiter and ASNRateLimiter both wrap the coordinator's existing
@@ -261,6 +282,10 @@ func (h *Handler) HandleAppTrackRegister(w http.ResponseWriter, r *http.Request)
 		writeJSONError(w, http.StatusBadRequest, "bad_request", "invalid request body")
 		return
 	}
+	if len([]byte(req.ReferralCode)) > 256 || strings.IndexFunc(req.ReferralCode, func(r rune) bool { return r < 0x20 || r == 0x7f }) >= 0 {
+		writeJSONError(w, http.StatusBadRequest, "bad_request", "referral_code is invalid")
+		return
+	}
 
 	pubkey, err := DecodeIdentityPubkey(req.IdentityPubkey)
 	if err != nil {
@@ -284,10 +309,6 @@ func (h *Handler) HandleAppTrackRegister(w http.ResponseWriter, r *http.Request)
 	if h.Now != nil {
 		now = h.Now().UTC()
 	}
-	if delta := now.Sub(tsUTC); delta > time.Minute || delta < -time.Minute {
-		writeJSONError(w, http.StatusBadRequest, "timestamp_skew", "ts_utc outside allowed skew")
-		return
-	}
 	signature, err := base64.StdEncoding.DecodeString(req.Signature)
 	if err != nil || len(signature) != ed25519.SignatureSize {
 		writeJSONError(w, http.StatusBadRequest, "bad_request", "invalid signature encoding")
@@ -305,6 +326,40 @@ func (h *Handler) HandleAppTrackRegister(w http.ResponseWriter, r *http.Request)
 	}
 
 	sourceIP := clientIP(r, h.TrustedProxies)
+	currentBearer := bearerFromRequest(r)
+	bearerExempt := false
+	if h.ReferralPolicy.RequireForRegistration && currentBearer != nil {
+		boundProviderID, ok, validateErr := h.AuthTokenStore.ValidateToken(r.Context(), *currentBearer)
+		if validateErr != nil {
+			writeJSONError(w, http.StatusServiceUnavailable, "unavailable", "credential authority unavailable")
+			return
+		}
+		bearerExempt = ok && boundProviderID == req.ProviderID
+	}
+	prepareStore, prepareStoreOK := h.StatsDB.(RegistrationPrepareStore)
+	if h.ReferralPolicy.RequireForRegistration && !bearerExempt {
+		if h.ReferralStore == nil || !prepareStoreOK {
+			writeJSONError(w, http.StatusServiceUnavailable, "unavailable", "referral authority unavailable")
+			return
+		}
+		// A retry of an already committed signed attempt never rotates or
+		// re-discloses credentials. Return a stable support state instead.
+		checkCtx, cancelCheck := context.WithTimeout(r.Context(), 2*time.Second)
+		prepared, checkErr := prepareStore.ProviderRegistrationPrepared(checkCtx, req.ProviderID, req.Nonce, tsUTC)
+		cancelCheck()
+		if checkErr != nil {
+			writeJSONError(w, http.StatusServiceUnavailable, "unavailable", "provider registration outcome unavailable")
+			return
+		}
+		if prepared {
+			writeJSONError(w, http.StatusConflict, "existing_active_token_no_proof", "registration already committed; existing credential proof or support is required")
+			return
+		}
+	}
+	if delta := now.Sub(tsUTC); delta > time.Minute || delta < -time.Minute {
+		writeJSONError(w, http.StatusBadRequest, "timestamp_skew", "ts_utc outside allowed skew")
+		return
+	}
 	if h.IPRateLimiter != nil && !h.IPRateLimiter.Allow(sourceIP) {
 		if h.Metrics != nil {
 			h.Metrics.IncRegisterRateLimitHit("ip")
@@ -332,15 +387,6 @@ func (h *Handler) HandleAppTrackRegister(w http.ResponseWriter, r *http.Request)
 			return
 		}
 	}
-	if err := h.StatsDB.InsertRegisterNonce(r.Context(), req.ProviderID, sourceIP, req.Nonce, now); err != nil {
-		if errors.Is(err, ErrNonceReplay) {
-			writeJSONError(w, http.StatusConflict, "nonce_replay", "register nonce replay")
-			return
-		}
-		writeJSONError(w, http.StatusInternalServerError, "internal_error", "nonce replay check failed")
-		return
-	}
-
 	attested := false
 	var appAttestKeyID []byte
 	if req.AppAttestObject != nil {
@@ -398,30 +444,80 @@ func (h *Handler) HandleAppTrackRegister(w http.ResponseWriter, r *http.Request)
 			return
 		}
 	}
-	if err := h.StatsDB.UpsertProviderIdentity(r.Context(), req.ProviderID, pubkey, attested, appAttestKeyID); err != nil {
-		switch {
-		case errors.Is(err, ErrTOFUConflict):
-			writeJSONError(w, http.StatusConflict, "provider_id_pubkey_mismatch", "provider_id already registered with a different identity_pubkey")
-		case errors.Is(err, ErrAttestKeyReused):
-			writeJSONError(w, http.StatusConflict, "app_attest_key_reused", "app_attest_key_id already bound")
-		default:
-			writeJSONError(w, http.StatusInternalServerError, "internal_error", "provider identity upsert failed")
+	var token string
+	if h.ReferralPolicy.RequireForRegistration && !bearerExempt {
+		attempt := auth.AppTrackRegistrationAttempt{SourceIP: sourceIP, Nonce: req.Nonce, AttemptTS: tsUTC}
+		mintCtx, cancelMint := context.WithTimeout(r.Context(), 2*time.Second)
+		token, err = h.ReferralStore.MintProviderTokenAppTrackWithReferralAttempt(
+			mintCtx, req.ProviderID, req.ReferralCode, h.ReferralPolicy, attempt,
+		)
+		cancelMint()
+		if err != nil {
+			writeAppTrackMintError(w, err)
+			return
 		}
-		return
-	}
-	currentBearer := bearerFromRequest(r)
-	token, err := h.AuthTokenStore.MintProviderTokenAppTrack(r.Context(), req.ProviderID, currentBearer)
-	if err != nil {
-		switch {
-		case errors.Is(err, auth.ErrAppTrackExistingTokenNoProof):
-			writeJSONError(w, http.StatusConflict, "existing_active_token_no_proof", "existing active token requires proof")
-		case errors.Is(err, auth.ErrAppTrackReissueCooldown):
-			w.Header().Set("Retry-After", "300")
-			writeJSONError(w, http.StatusTooManyRequests, "reissue_cooldown", "provider token reissue cooldown active")
-		default:
-			writeJSONError(w, http.StatusInternalServerError, "internal_error", "provider token mint failed")
+
+		prepareCtx, cancelPrepare := context.WithTimeout(r.Context(), 2*time.Second)
+		prepareErr := prepareStore.PrepareProviderRegistration(
+			prepareCtx, req.ProviderID, sourceIP, req.Nonce, now, tsUTC,
+			pubkey, attested, appAttestKeyID,
+		)
+		cancelPrepare()
+		if prepareErr != nil {
+			// PostgreSQL commit errors can be ambiguous. Compensate only after the
+			// exact durable marker proves this attempt did not commit.
+			checkCtx, cancelCheck := context.WithTimeout(context.Background(), 2*time.Second)
+			prepared, checkErr := prepareStore.ProviderRegistrationPrepared(checkCtx, req.ProviderID, req.Nonce, tsUTC)
+			cancelCheck()
+			if checkErr != nil {
+				writeJSONError(w, http.StatusInternalServerError, "internal_error", "provider registration outcome pending reconciliation")
+				return
+			}
+			if !prepared {
+				rollbackCtx, cancelRollback := context.WithTimeout(context.Background(), 2*time.Second)
+				rollbackErr := h.ReferralStore.RollbackAppTrackReferralMint(rollbackCtx, req.ProviderID, token)
+				cancelRollback()
+				if rollbackErr != nil {
+					writeJSONError(w, http.StatusInternalServerError, "internal_error", "provider registration compensation pending reconciliation")
+					return
+				}
+				writeAppTrackPrepareError(w, prepareErr)
+				return
+			}
 		}
-		return
+
+		ackCtx, cancelAck := context.WithTimeout(context.Background(), 2*time.Second)
+		ackErr := h.ReferralStore.AcknowledgeAppTrackReferralMint(ackCtx, req.ProviderID, token)
+		cancelAck()
+		if ackErr != nil {
+			if metrics, ok := h.Metrics.(interface{ IncRegisterReconcileDeferred() }); ok {
+				metrics.IncRegisterReconcileDeferred()
+			}
+		}
+		if !h.appTrackTokenStillActive(req.ProviderID, token) {
+			writeJSONError(w, http.StatusConflict, "existing_active_token_no_proof", "credential was superseded before disclosure")
+			return
+		}
+	} else {
+		// Open registration and custody-proven reissues retain the established
+		// PostgreSQL-first path; they do not consume referral capacity.
+		if err := h.StatsDB.InsertRegisterNonce(r.Context(), req.ProviderID, sourceIP, req.Nonce, now); err != nil {
+			if errors.Is(err, ErrNonceReplay) {
+				writeJSONError(w, http.StatusConflict, "nonce_replay", "register nonce replay")
+				return
+			}
+			writeJSONError(w, http.StatusInternalServerError, "internal_error", "nonce replay check failed")
+			return
+		}
+		if err := h.StatsDB.UpsertProviderIdentity(r.Context(), req.ProviderID, pubkey, attested, appAttestKeyID); err != nil {
+			writeAppTrackPrepareError(w, err)
+			return
+		}
+		token, err = h.AuthTokenStore.MintProviderTokenAppTrack(r.Context(), req.ProviderID, currentBearer)
+		if err != nil {
+			writeAppTrackMintError(w, err)
+			return
+		}
 	}
 	h.persistHardwareProfileAsync(req.ProviderID, req.HardwareSummary, now)
 	if h.Metrics != nil {
@@ -434,6 +530,80 @@ func (h *Handler) HandleAppTrackRegister(w http.ResponseWriter, r *http.Request)
 		Trust:            TrustState{Attested: attested, RateLimitBucket: "new_ip"},
 		CoordinatorWSURL: h.CoordinatorWSURL,
 	})
+}
+
+// ReconcilePendingAppTrackReferralMints resolves only sagas old enough not to
+// belong to a live request. A committed marker preserves the token; an absent
+// marker compensates the undisclosed token and its exact new redemption.
+func (h *Handler) ReconcilePendingAppTrackReferralMints(ctx context.Context) error {
+	if h == nil || h.ReferralStore == nil || h.StatsDB == nil {
+		return nil
+	}
+	prepareStore, ok := h.StatsDB.(RegistrationPrepareStore)
+	if !ok {
+		return errors.New("registration prepare store unavailable")
+	}
+	now := time.Now().UTC()
+	if h.Now != nil {
+		now = h.Now().UTC()
+	}
+	pending, err := h.ReferralStore.ListPendingAppTrackReferralMints(ctx, now.Add(-appTrackPendingMintReconcileAge))
+	if err != nil {
+		return fmt.Errorf("list pending App-track referral mints: %w", err)
+	}
+	var reconcileErrs []error
+	for _, item := range pending {
+		prepared, err := prepareStore.ProviderRegistrationPrepared(
+			ctx, item.ProviderID, item.Attempt.Nonce, item.Attempt.AttemptTS,
+		)
+		if err != nil {
+			reconcileErrs = append(reconcileErrs, fmt.Errorf("check pending App-track mint %s: %w", item.ProviderID, err))
+			continue
+		}
+		if err := h.ReferralStore.ResolvePendingAppTrackReferralMint(ctx, item, prepared); err != nil {
+			reconcileErrs = append(reconcileErrs, fmt.Errorf("resolve pending App-track mint %s: %w", item.ProviderID, err))
+		}
+	}
+	return errors.Join(reconcileErrs...)
+}
+
+func writeAppTrackPrepareError(w http.ResponseWriter, err error) {
+	switch {
+	case errors.Is(err, ErrNonceReplay):
+		writeJSONError(w, http.StatusConflict, "nonce_replay", "register nonce replay")
+	case errors.Is(err, ErrTOFUConflict):
+		writeJSONError(w, http.StatusConflict, "provider_id_pubkey_mismatch", "provider_id already registered with a different identity_pubkey")
+	case errors.Is(err, ErrAttestKeyReused):
+		writeJSONError(w, http.StatusConflict, "app_attest_key_reused", "app_attest_key_id already bound")
+	default:
+		writeJSONError(w, http.StatusInternalServerError, "internal_error", "provider registration prepare failed")
+	}
+}
+
+func writeAppTrackMintError(w http.ResponseWriter, err error) {
+	switch {
+	case errors.Is(err, auth.ErrReferralRequired), errors.Is(err, auth.ErrReferralInvalid),
+		errors.Is(err, auth.ErrReferralExpired), errors.Is(err, auth.ErrReferralRevoked),
+		errors.Is(err, auth.ErrReferralExhausted), errors.Is(err, auth.ErrReferralConflict):
+		writeReferralError(w, err)
+	case errors.Is(err, auth.ErrAppTrackExistingTokenNoProof):
+		writeJSONError(w, http.StatusConflict, "existing_active_token_no_proof", "existing active token requires proof")
+	case errors.Is(err, auth.ErrAppTrackReissueCooldown):
+		w.Header().Set("Retry-After", "300")
+		writeJSONError(w, http.StatusTooManyRequests, "reissue_cooldown", "provider token reissue cooldown active")
+	default:
+		writeJSONError(w, http.StatusInternalServerError, "internal_error", "provider token mint failed")
+	}
+}
+
+func (h *Handler) appTrackTokenStillActive(providerID, cleartext string) bool {
+	if h.AuthTokenStore == nil {
+		return false
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	bound, ok, err := h.AuthTokenStore.ValidateToken(ctx, cleartext)
+	return err == nil && ok && bound == providerID
 }
 
 func (h *Handler) persistHardwareProfileAsync(providerID string, summary HardwareSummary, observedAt time.Time) {
@@ -528,6 +698,7 @@ func (h *Handler) clientDataHash(req RegisterRequest) [32]byte {
 		"provider_id":        req.ProviderID,
 		"identity_pubkey":    req.IdentityPubkey,
 		"register_nonce":     req.Nonce,
+		"referral_code":      req.ReferralCode,
 		"coordinator_domain": domain,
 		"bundle_id":          h.AppAttestConfig.BundleID,
 		"team_id":            h.AppAttestConfig.TeamID,
@@ -551,6 +722,30 @@ func bearerFromRequest(r *http.Request) *string {
 		return nil
 	}
 	return &token
+}
+
+func writeReferralError(w http.ResponseWriter, err error) {
+	switch {
+	case errors.Is(err, auth.ErrReferralRequired):
+		writeReferralJSONError(w, http.StatusBadRequest, "referral_required", "missing", "a valid pre-beta referral is required")
+	case errors.Is(err, auth.ErrReferralExpired):
+		writeReferralJSONError(w, http.StatusGone, "referral_expired", "expired", "referral code expired")
+	case errors.Is(err, auth.ErrReferralRevoked):
+		writeReferralJSONError(w, http.StatusGone, "referral_revoked", "revoked", "referral code revoked")
+	case errors.Is(err, auth.ErrReferralExhausted):
+		writeReferralJSONError(w, http.StatusConflict, "referral_exhausted", "exhausted", "all spots on this referral are taken")
+	case errors.Is(err, auth.ErrReferralConflict):
+		writeReferralJSONError(w, http.StatusConflict, "referral_conflict", "invalid", "provider is already attributed to another referral")
+	default:
+		writeReferralJSONError(w, http.StatusBadRequest, "referral_invalid", "invalid", "referral code is invalid")
+	}
+}
+
+func writeReferralJSONError(w http.ResponseWriter, status int, code, reason, message string) {
+	writeJSON(w, status, map[string]any{
+		"error":  map[string]any{"code": code, "message": message},
+		"reason": reason,
+	})
 }
 
 func writeJSON(w http.ResponseWriter, status int, v any) {
@@ -590,6 +785,12 @@ func clientIP(r *http.Request, trusted []netip.Prefix) string {
 		}
 	}
 	return host
+}
+
+// ClientIP exposes the audited trusted-proxy walk to adjacent public
+// onboarding endpoints without duplicating proxy-boundary logic.
+func ClientIP(r *http.Request, trusted []netip.Prefix) string {
+	return clientIP(r, trusted)
 }
 
 func parseIPAddr(s string) (netip.Addr, bool) {

--- a/phase4-coordinator/internal/onboarding/apptrack.go
+++ b/phase4-coordinator/internal/onboarding/apptrack.go
@@ -37,9 +37,13 @@ type RegisterRequest struct {
 	AppAttestObject *string         `json:"app_attest_object,omitempty"` // base64 CBOR
 	AppAttestKeyID  *string         `json:"app_attest_key_id,omitempty"` // base64 32-byte
 	ReferralCode    string          `json:"referral_code,omitempty"`
-	Nonce           string          `json:"nonce"`     // 64-hex = 32 random bytes
-	TSUTC           string          `json:"ts_utc"`    // RFC3339
-	Signature       string          `json:"signature"` // base64 64-byte Ed25519 over JCS(body\signature)
+	// ProviderTokenCandidate is generated and durably held by the client
+	// before transport. Binding it into the signed request makes a committed
+	// registration idempotently recoverable after a lost HTTP response.
+	ProviderTokenCandidate string `json:"provider_token_candidate,omitempty"`
+	Nonce                  string `json:"nonce"`     // 64-hex = 32 random bytes
+	TSUTC                  string `json:"ts_utc"`    // RFC3339
+	Signature              string `json:"signature"` // base64 64-byte Ed25519 over JCS(body\signature)
 }
 
 type HardwareSummary struct {
@@ -180,9 +184,10 @@ type RegistrationPrepareStore interface {
 type AuthTokenStore interface {
 	// MintProviderTokenAppTrack mints per SPEC-026 §4.1 step 7 semantics.
 	// Duplicate registration with any active token requires bearer proof from
-	// the Authorization header; request bodies must never carry bearer material.
-	// provider_name is the tenant literal "malibu-app" for App-track.
-	MintProviderTokenAppTrack(ctx context.Context, providerID string, currentBearer *string) (cleartext string, err error)
+	// the Authorization header; request bodies must never carry the current
+	// bearer. A fresh client-held candidate is not authoritative until this
+	// transaction commits. provider_name is the tenant literal "malibu-app".
+	MintProviderTokenAppTrack(ctx context.Context, providerID string, currentBearer, freshTokenCandidate *string) (cleartext string, err error)
 
 	// ValidateToken validates an existing provider bearer token and returns the
 	// bound provider_id. Evidence submission is read-only with respect to the
@@ -191,7 +196,7 @@ type AuthTokenStore interface {
 }
 
 type ReferralStore interface {
-	MintProviderTokenAppTrackWithReferralAttempt(ctx context.Context, providerID, referralCode string, policy auth.ReferralPolicy, attempt auth.AppTrackRegistrationAttempt) (cleartext string, err error)
+	MintProviderTokenAppTrackWithReferralAttempt(ctx context.Context, providerID, referralCode, tokenCandidate string, policy auth.ReferralPolicy, attempt auth.AppTrackRegistrationAttempt) (cleartext string, err error)
 	AcknowledgeAppTrackReferralMint(ctx context.Context, providerID, cleartextToken string) error
 	RollbackAppTrackReferralMint(ctx context.Context, providerID, cleartextToken string) error
 	ListPendingAppTrackReferralMints(ctx context.Context, createdBefore time.Time) ([]auth.PendingAppTrackReferralMint, error)
@@ -286,6 +291,10 @@ func (h *Handler) HandleAppTrackRegister(w http.ResponseWriter, r *http.Request)
 		writeJSONError(w, http.StatusBadRequest, "bad_request", "referral_code is invalid")
 		return
 	}
+	if req.ProviderTokenCandidate != "" && (len(req.ProviderTokenCandidate) != 64 || !isLowerHex(req.ProviderTokenCandidate)) {
+		writeJSONError(w, http.StatusBadRequest, "bad_request", "provider_token_candidate must be 64 lowercase hex chars")
+		return
+	}
 
 	pubkey, err := DecodeIdentityPubkey(req.IdentityPubkey)
 	if err != nil {
@@ -326,36 +335,6 @@ func (h *Handler) HandleAppTrackRegister(w http.ResponseWriter, r *http.Request)
 	}
 
 	sourceIP := clientIP(r, h.TrustedProxies)
-	currentBearer := bearerFromRequest(r)
-	bearerExempt := false
-	if h.ReferralPolicy.RequireForRegistration && currentBearer != nil {
-		boundProviderID, ok, validateErr := h.AuthTokenStore.ValidateToken(r.Context(), *currentBearer)
-		if validateErr != nil {
-			writeJSONError(w, http.StatusServiceUnavailable, "unavailable", "credential authority unavailable")
-			return
-		}
-		bearerExempt = ok && boundProviderID == req.ProviderID
-	}
-	prepareStore, prepareStoreOK := h.StatsDB.(RegistrationPrepareStore)
-	if h.ReferralPolicy.RequireForRegistration && !bearerExempt {
-		if h.ReferralStore == nil || !prepareStoreOK {
-			writeJSONError(w, http.StatusServiceUnavailable, "unavailable", "referral authority unavailable")
-			return
-		}
-		// A retry of an already committed signed attempt never rotates or
-		// re-discloses credentials. Return a stable support state instead.
-		checkCtx, cancelCheck := context.WithTimeout(r.Context(), 2*time.Second)
-		prepared, checkErr := prepareStore.ProviderRegistrationPrepared(checkCtx, req.ProviderID, req.Nonce, tsUTC)
-		cancelCheck()
-		if checkErr != nil {
-			writeJSONError(w, http.StatusServiceUnavailable, "unavailable", "provider registration outcome unavailable")
-			return
-		}
-		if prepared {
-			writeJSONError(w, http.StatusConflict, "existing_active_token_no_proof", "registration already committed; existing credential proof or support is required")
-			return
-		}
-	}
 	if delta := now.Sub(tsUTC); delta > time.Minute || delta < -time.Minute {
 		writeJSONError(w, http.StatusBadRequest, "timestamp_skew", "ts_utc outside allowed skew")
 		return
@@ -384,6 +363,49 @@ func (h *Handler) HandleAppTrackRegister(w http.ResponseWriter, r *http.Request)
 			}
 			w.Header().Set("Retry-After", "60")
 			writeJSONError(w, http.StatusTooManyRequests, "rate_limited", "asn rate limit exceeded")
+			return
+		}
+	}
+	currentBearer := bearerFromRequest(r)
+	bearerExempt := false
+	if h.ReferralPolicy.RequireForRegistration && currentBearer != nil {
+		boundProviderID, ok, validateErr := h.AuthTokenStore.ValidateToken(r.Context(), *currentBearer)
+		if validateErr != nil {
+			writeJSONError(w, http.StatusServiceUnavailable, "unavailable", "credential authority unavailable")
+			return
+		}
+		bearerExempt = ok && boundProviderID == req.ProviderID
+	}
+	prepareStore, prepareStoreOK := h.StatsDB.(RegistrationPrepareStore)
+	if h.ReferralPolicy.RequireForRegistration && !bearerExempt {
+		if h.ReferralStore == nil || !prepareStoreOK {
+			writeJSONError(w, http.StatusServiceUnavailable, "unavailable", "referral authority unavailable")
+			return
+		}
+		if req.ProviderTokenCandidate == "" {
+			writeJSONError(w, http.StatusBadRequest, "provider_token_candidate_required", "a client-held provider token candidate is required for gated registration")
+			return
+		}
+		// A retry of an already committed signed attempt never rotates or
+		// re-discloses credentials. Return a stable support state instead.
+		checkCtx, cancelCheck := context.WithTimeout(r.Context(), 2*time.Second)
+		prepared, checkErr := prepareStore.ProviderRegistrationPrepared(checkCtx, req.ProviderID, req.Nonce, tsUTC)
+		cancelCheck()
+		if checkErr != nil {
+			writeJSONError(w, http.StatusServiceUnavailable, "unavailable", "provider registration outcome unavailable")
+			return
+		}
+		if prepared {
+			boundProviderID, ok, validateErr := h.AuthTokenStore.ValidateToken(r.Context(), req.ProviderTokenCandidate)
+			if validateErr != nil {
+				writeJSONError(w, http.StatusServiceUnavailable, "unavailable", "credential authority unavailable")
+				return
+			}
+			if !ok || boundProviderID != req.ProviderID {
+				writeJSONError(w, http.StatusConflict, "committed_credential_mismatch", "registration committed with a different credential candidate")
+				return
+			}
+			writeAppTrackRegisterSuccess(w, req.ProviderID, req.ProviderTokenCandidate, false, h.CoordinatorWSURL)
 			return
 		}
 	}
@@ -449,7 +471,7 @@ func (h *Handler) HandleAppTrackRegister(w http.ResponseWriter, r *http.Request)
 		attempt := auth.AppTrackRegistrationAttempt{SourceIP: sourceIP, Nonce: req.Nonce, AttemptTS: tsUTC}
 		mintCtx, cancelMint := context.WithTimeout(r.Context(), 2*time.Second)
 		token, err = h.ReferralStore.MintProviderTokenAppTrackWithReferralAttempt(
-			mintCtx, req.ProviderID, req.ReferralCode, h.ReferralPolicy, attempt,
+			mintCtx, req.ProviderID, req.ReferralCode, req.ProviderTokenCandidate, h.ReferralPolicy, attempt,
 		)
 		cancelMint()
 		if err != nil {
@@ -513,7 +535,11 @@ func (h *Handler) HandleAppTrackRegister(w http.ResponseWriter, r *http.Request)
 			writeAppTrackPrepareError(w, err)
 			return
 		}
-		token, err = h.AuthTokenStore.MintProviderTokenAppTrack(r.Context(), req.ProviderID, currentBearer)
+		var freshTokenCandidate *string
+		if currentBearer == nil && req.ProviderTokenCandidate != "" {
+			freshTokenCandidate = &req.ProviderTokenCandidate
+		}
+		token, err = h.AuthTokenStore.MintProviderTokenAppTrack(r.Context(), req.ProviderID, currentBearer, freshTokenCandidate)
 		if err != nil {
 			writeAppTrackMintError(w, err)
 			return
@@ -523,12 +549,16 @@ func (h *Handler) HandleAppTrackRegister(w http.ResponseWriter, r *http.Request)
 	if h.Metrics != nil {
 		h.Metrics.IncRegisterSource("app")
 	}
+	writeAppTrackRegisterSuccess(w, req.ProviderID, token, attested, h.CoordinatorWSURL)
+}
+
+func writeAppTrackRegisterSuccess(w http.ResponseWriter, providerID, token string, attested bool, coordinatorWSURL string) {
 	writeJSON(w, http.StatusOK, RegisterResponse{
-		ProviderID:       req.ProviderID,
+		ProviderID:       providerID,
 		ProviderToken:    token,
 		TrustTier:        "provisional",
 		Trust:            TrustState{Attested: attested, RateLimitBucket: "new_ip"},
-		CoordinatorWSURL: h.CoordinatorWSURL,
+		CoordinatorWSURL: coordinatorWSURL,
 	})
 }
 

--- a/phase4-coordinator/internal/onboarding/apptrack_test.go
+++ b/phase4-coordinator/internal/onboarding/apptrack_test.go
@@ -137,9 +137,13 @@ func TestHandleAppTrackRegisterFreshGateUsesSagaThenDiscloses(t *testing.T) {
 }
 
 func TestHandleAppTrackRegisterCommittedRetryNeverRotatesCredential(t *testing.T) {
-	body, _ := signedRegisterBody(t, func(body map[string]any) { body["referral_code"] = "invite" })
+	body, providerID := signedRegisterBody(t, func(body map[string]any) { body["referral_code"] = "invite" })
 	stats := &fakeStatsDB{prepared: true}
-	authStore := &fakeAuthStore{referralToken: "must-not-mint"}
+	authStore := &fakeAuthStore{
+		referralToken:      "must-not-mint",
+		validateOK:         true,
+		validateProviderID: providerID,
+	}
 	handler := testRegisterHandler(stats, authStore, nil)
 	handler.ReferralPolicy = auth.ReferralPolicy{RequireForRegistration: true}
 	handler.ReferralStore = authStore
@@ -148,11 +152,49 @@ func TestHandleAppTrackRegisterCommittedRetryNeverRotatesCredential(t *testing.T
 
 	handler.HandleAppTrackRegister(response, req)
 
-	if response.Code != http.StatusConflict || !strings.Contains(response.Body.String(), "existing_active_token_no_proof") {
+	if response.Code != http.StatusOK || !strings.Contains(response.Body.String(), strings.Repeat("c", 64)) {
 		t.Fatalf("status=%d body=%s", response.Code, response.Body.String())
 	}
 	if authStore.referralMintCalls != 0 || stats.prepareCalls != 0 {
 		t.Fatalf("committed retry mutated state: mint=%d prepare=%d", authStore.referralMintCalls, stats.prepareCalls)
+	}
+}
+
+func TestHandleAppTrackRegisterCommittedRetryRejectsDifferentCandidate(t *testing.T) {
+	body, _ := signedRegisterBody(t, func(body map[string]any) { body["referral_code"] = "invite" })
+	stats := &fakeStatsDB{prepared: true}
+	authStore := &fakeAuthStore{}
+	handler := testRegisterHandler(stats, authStore, nil)
+	handler.ReferralPolicy = auth.ReferralPolicy{RequireForRegistration: true}
+	handler.ReferralStore = authStore
+	response := httptest.NewRecorder()
+
+	handler.HandleAppTrackRegister(response, httptest.NewRequest(http.MethodPost, "/v1/providers/register", bytes.NewReader(body)))
+
+	if response.Code != http.StatusConflict || !strings.Contains(response.Body.String(), "committed_credential_mismatch") {
+		t.Fatalf("status=%d body=%s", response.Code, response.Body.String())
+	}
+	if authStore.referralMintCalls != 0 || stats.prepareCalls != 0 {
+		t.Fatalf("committed retry mutated state: mint=%d prepare=%d", authStore.referralMintCalls, stats.prepareCalls)
+	}
+}
+
+func TestHandleAppTrackRegisterGateRequiresClientHeldCandidate(t *testing.T) {
+	body, _ := signedRegisterBody(t, func(body map[string]any) {
+		body["referral_code"] = "invite"
+		delete(body, "provider_token_candidate")
+	})
+	stats := &fakeStatsDB{}
+	authStore := &fakeAuthStore{}
+	handler := testRegisterHandler(stats, authStore, nil)
+	handler.ReferralPolicy = auth.ReferralPolicy{RequireForRegistration: true}
+	handler.ReferralStore = authStore
+	response := httptest.NewRecorder()
+
+	handler.HandleAppTrackRegister(response, httptest.NewRequest(http.MethodPost, "/v1/providers/register", bytes.NewReader(body)))
+
+	if response.Code != http.StatusBadRequest || !strings.Contains(response.Body.String(), "provider_token_candidate_required") {
+		t.Fatalf("status=%d body=%s", response.Code, response.Body.String())
 	}
 }
 
@@ -686,10 +728,12 @@ func TestHandleAppTrackRegisterMapsRateLimitAndCooldown(t *testing.T) {
 func TestHandleAppTrackRegisterRateLimitDoesNotWriteReplayNonce(t *testing.T) {
 	body, _ := signedRegisterBody(t, nil)
 	stats := &fakeStatsDB{}
-	handler := testRegisterHandler(stats, &fakeAuthStore{token: "provider-token"}, &fakeMetrics{}, denyLimiter{})
+	authStore := &fakeAuthStore{token: "provider-token", validateOK: true}
+	handler := testRegisterHandler(stats, authStore, &fakeMetrics{}, denyLimiter{})
 
 	req := httptest.NewRequest(http.MethodPost, "/v1/providers/register", bytes.NewReader(body))
 	req.RemoteAddr = "198.51.100.10:4444"
+	req.Header.Set("Authorization", "Bearer existing-token")
 	rr := httptest.NewRecorder()
 	handler.HandleAppTrackRegister(rr, req)
 
@@ -698,6 +742,12 @@ func TestHandleAppTrackRegisterRateLimitDoesNotWriteReplayNonce(t *testing.T) {
 	}
 	if stats.nonceCalls != 0 {
 		t.Fatalf("nonce calls=%d, want 0 before rate-limit rejection", stats.nonceCalls)
+	}
+	if stats.preparedChecks != 0 {
+		t.Fatalf("prepared checks=%d, want 0 before rate-limit rejection", stats.preparedChecks)
+	}
+	if authStore.validateCalls != 0 {
+		t.Fatalf("credential validations=%d, want 0 before rate-limit rejection", authStore.validateCalls)
 	}
 	if calls := stats.hardwareCallsCount(); calls != 0 {
 		t.Fatalf("hardware calls=%d, want 0 before rate-limit rejection", calls)
@@ -1083,8 +1133,9 @@ func signedRegisterBody(t *testing.T, mutate func(map[string]any)) ([]byte, stri
 			"macos_version":     "15.5",
 			"app_version":       "1.0.0",
 		},
-		"nonce":  strings.Repeat("a", 64),
-		"ts_utc": "2026-07-03T12:00:00Z",
+		"nonce":                    strings.Repeat("a", 64),
+		"ts_utc":                   "2026-07-03T12:00:00Z",
+		"provider_token_candidate": strings.Repeat("c", 64),
 	}
 	normalized, err := json.Marshal(body)
 	if err != nil {
@@ -1285,6 +1336,7 @@ type fakeAuthStore struct {
 	validateProviderID string
 	validateOK         bool
 	validateErr        error
+	validateCalls      int
 	referralToken      string
 	referralMintErr    error
 	referralMintCalls  int
@@ -1297,16 +1349,20 @@ type fakeAuthStore struct {
 	resolvedPrepared   []bool
 }
 
-func (f *fakeAuthStore) MintProviderTokenAppTrack(ctx context.Context, providerID string, currentBearer *string) (string, error) {
+func (f *fakeAuthStore) MintProviderTokenAppTrack(ctx context.Context, providerID string, currentBearer, freshTokenCandidate *string) (string, error) {
 	f.providerID = providerID
 	f.bearer = currentBearer
 	if f.err != nil {
 		return "", f.err
 	}
+	if currentBearer == nil && freshTokenCandidate != nil && f.token == "" {
+		return *freshTokenCandidate, nil
+	}
 	return f.token, nil
 }
 
 func (f *fakeAuthStore) ValidateToken(ctx context.Context, token string) (string, bool, error) {
+	f.validateCalls++
 	if f.validateErr != nil {
 		return "", false, f.validateErr
 	}
@@ -1319,13 +1375,16 @@ func (f *fakeAuthStore) ValidateToken(ctx context.Context, token string) (string
 	return f.providerID, true, nil
 }
 
-func (f *fakeAuthStore) MintProviderTokenAppTrackWithReferralAttempt(_ context.Context, providerID, referralCode string, policy auth.ReferralPolicy, attempt auth.AppTrackRegistrationAttempt) (string, error) {
+func (f *fakeAuthStore) MintProviderTokenAppTrackWithReferralAttempt(_ context.Context, providerID, referralCode, tokenCandidate string, policy auth.ReferralPolicy, attempt auth.AppTrackRegistrationAttempt) (string, error) {
 	f.referralMintCalls++
 	f.providerID = providerID
 	if f.referralMintErr != nil {
 		return "", f.referralMintErr
 	}
-	return f.referralToken, nil
+	if f.referralToken != "" {
+		return f.referralToken, nil
+	}
+	return tokenCandidate, nil
 }
 
 func (f *fakeAuthStore) AcknowledgeAppTrackReferralMint(context.Context, string, string) error {

--- a/phase4-coordinator/internal/onboarding/apptrack_test.go
+++ b/phase4-coordinator/internal/onboarding/apptrack_test.go
@@ -62,6 +62,147 @@ func TestHandleAppTrackRegisterSuccess(t *testing.T) {
 	}
 }
 
+func TestHandleAppTrackRegisterBogusBearerDoesNotBypassReferralGate(t *testing.T) {
+	body, _ := signedRegisterBody(t, nil)
+	stats := &fakeStatsDB{}
+	authStore := &fakeAuthStore{referralMintErr: auth.ErrReferralRequired}
+	handler := testRegisterHandler(stats, authStore, nil)
+	handler.ReferralPolicy = auth.ReferralPolicy{RequireForRegistration: true}
+	handler.ReferralStore = authStore
+	req := httptest.NewRequest(http.MethodPost, "/v1/providers/register", bytes.NewReader(body))
+	req.Header.Set("Authorization", "Bearer bogus")
+	response := httptest.NewRecorder()
+
+	handler.HandleAppTrackRegister(response, req)
+
+	if response.Code != http.StatusBadRequest || !strings.Contains(response.Body.String(), "referral_required") {
+		t.Fatalf("status=%d body=%s", response.Code, response.Body.String())
+	}
+	if authStore.referralMintCalls != 1 || stats.prepareCalls != 0 || stats.upsertProviderID != "" {
+		t.Fatalf("mintCalls=%d prepareCalls=%d upsert=%q", authStore.referralMintCalls, stats.prepareCalls, stats.upsertProviderID)
+	}
+}
+
+func TestHandleAppTrackRegisterValidBearerBypassesReferralConsumption(t *testing.T) {
+	body, providerID := signedRegisterBody(t, nil)
+	stats := &fakeStatsDB{}
+	authStore := &fakeAuthStore{
+		token:              "replacement-token",
+		validateOK:         true,
+		validateProviderID: providerID,
+		referralMintErr:    auth.ErrReferralRequired,
+	}
+	handler := testRegisterHandler(stats, authStore, nil)
+	handler.ReferralPolicy = auth.ReferralPolicy{RequireForRegistration: true}
+	handler.ReferralStore = authStore
+	req := httptest.NewRequest(http.MethodPost, "/v1/providers/register", bytes.NewReader(body))
+	req.Header.Set("Authorization", "Bearer current-token")
+	response := httptest.NewRecorder()
+
+	handler.HandleAppTrackRegister(response, req)
+
+	if response.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s", response.Code, response.Body.String())
+	}
+	if authStore.referralMintCalls != 0 || stats.nonceCalls != 1 || stats.upsertProviderID != providerID {
+		t.Fatalf("referralMints=%d nonceCalls=%d upsert=%q", authStore.referralMintCalls, stats.nonceCalls, stats.upsertProviderID)
+	}
+}
+
+func TestHandleAppTrackRegisterFreshGateUsesSagaThenDiscloses(t *testing.T) {
+	body, providerID := signedRegisterBody(t, func(body map[string]any) { body["referral_code"] = "invite" })
+	stats := &fakeStatsDB{}
+	authStore := &fakeAuthStore{
+		referralToken:      "fresh-token",
+		validateOK:         true,
+		validateProviderID: providerID,
+	}
+	handler := testRegisterHandler(stats, authStore, nil)
+	handler.ReferralPolicy = auth.ReferralPolicy{RequireForRegistration: true}
+	handler.ReferralStore = authStore
+	req := httptest.NewRequest(http.MethodPost, "/v1/providers/register", bytes.NewReader(body))
+	response := httptest.NewRecorder()
+
+	handler.HandleAppTrackRegister(response, req)
+
+	if response.Code != http.StatusOK || !strings.Contains(response.Body.String(), "fresh-token") {
+		t.Fatalf("status=%d body=%s", response.Code, response.Body.String())
+	}
+	if authStore.referralMintCalls != 1 || stats.prepareCalls != 1 || authStore.ackCalls != 1 || authStore.rollbackCalls != 0 {
+		t.Fatalf("mint=%d prepare=%d ack=%d rollback=%d", authStore.referralMintCalls, stats.prepareCalls, authStore.ackCalls, authStore.rollbackCalls)
+	}
+	if stats.nonceCalls != 0 || stats.upsertProviderID != "" {
+		t.Fatalf("fresh gate used non-atomic legacy PG path: nonce=%d upsert=%q", stats.nonceCalls, stats.upsertProviderID)
+	}
+}
+
+func TestHandleAppTrackRegisterCommittedRetryNeverRotatesCredential(t *testing.T) {
+	body, _ := signedRegisterBody(t, func(body map[string]any) { body["referral_code"] = "invite" })
+	stats := &fakeStatsDB{prepared: true}
+	authStore := &fakeAuthStore{referralToken: "must-not-mint"}
+	handler := testRegisterHandler(stats, authStore, nil)
+	handler.ReferralPolicy = auth.ReferralPolicy{RequireForRegistration: true}
+	handler.ReferralStore = authStore
+	req := httptest.NewRequest(http.MethodPost, "/v1/providers/register", bytes.NewReader(body))
+	response := httptest.NewRecorder()
+
+	handler.HandleAppTrackRegister(response, req)
+
+	if response.Code != http.StatusConflict || !strings.Contains(response.Body.String(), "existing_active_token_no_proof") {
+		t.Fatalf("status=%d body=%s", response.Code, response.Body.String())
+	}
+	if authStore.referralMintCalls != 0 || stats.prepareCalls != 0 {
+		t.Fatalf("committed retry mutated state: mint=%d prepare=%d", authStore.referralMintCalls, stats.prepareCalls)
+	}
+}
+
+func TestHandleAppTrackRegisterCompensatesOnlyProvenAbsentPrepare(t *testing.T) {
+	body, providerID := signedRegisterBody(t, func(body map[string]any) { body["referral_code"] = "invite" })
+	stats := &fakeStatsDB{prepareErr: ErrTOFUConflict, prepared: false}
+	authStore := &fakeAuthStore{
+		referralToken:      "undisclosed-token",
+		validateOK:         true,
+		validateProviderID: providerID,
+	}
+	handler := testRegisterHandler(stats, authStore, nil)
+	handler.ReferralPolicy = auth.ReferralPolicy{RequireForRegistration: true}
+	handler.ReferralStore = authStore
+	req := httptest.NewRequest(http.MethodPost, "/v1/providers/register", bytes.NewReader(body))
+	response := httptest.NewRecorder()
+
+	handler.HandleAppTrackRegister(response, req)
+
+	if response.Code != http.StatusConflict || authStore.rollbackCalls != 1 || authStore.ackCalls != 0 {
+		t.Fatalf("status=%d rollback=%d ack=%d body=%s", response.Code, authStore.rollbackCalls, authStore.ackCalls, response.Body.String())
+	}
+}
+
+func TestReconcilePendingAppTrackReferralMintUsesExactSignedAttempt(t *testing.T) {
+	attemptTS := time.Date(2026, 7, 3, 11, 59, 30, 0, time.UTC)
+	pending := auth.PendingAppTrackReferralMint{
+		ProviderID: "provider-a",
+		TokenHash:  strings.Repeat("a", 64),
+		Attempt: auth.AppTrackRegistrationAttempt{
+			SourceIP: "203.0.113.10", Nonce: strings.Repeat("b", 64), AttemptTS: attemptTS,
+		},
+	}
+	stats := &fakeStatsDB{prepared: true}
+	authStore := &fakeAuthStore{pendingMints: []auth.PendingAppTrackReferralMint{pending}}
+	handler := testRegisterHandler(stats, authStore, nil)
+	handler.ReferralPolicy = auth.ReferralPolicy{RequireForRegistration: true}
+	handler.ReferralStore = authStore
+
+	if err := handler.ReconcilePendingAppTrackReferralMints(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if stats.preparedProviderID != pending.ProviderID || stats.preparedNonce != pending.Attempt.Nonce || !stats.preparedAttemptTS.Equal(attemptTS) {
+		t.Fatalf("prepared lookup provider=%q nonce=%q ts=%s", stats.preparedProviderID, stats.preparedNonce, stats.preparedAttemptTS)
+	}
+	if len(authStore.resolvedMints) != 1 || !authStore.resolvedPrepared[0] {
+		t.Fatalf("resolved=%+v prepared=%+v", authStore.resolvedMints, authStore.resolvedPrepared)
+	}
+}
+
 func TestHandleHardwareEvidenceQueuesAuthenticatedAutotuneEvidence(t *testing.T) {
 	now := time.Date(2026, 7, 3, 12, 0, 0, 0, time.UTC)
 	stats := &fakeStatsDB{}
@@ -1021,6 +1162,30 @@ type fakeStatsDB struct {
 	existingEvidenceRecord     HardwareEvidenceJobRecord
 	existingEvidenceFound      bool
 	existingEvidenceErr        error
+	prepareErr                 error
+	prepared                   bool
+	preparedErr                error
+	prepareCalls               int
+	preparedChecks             int
+	preparedProviderID         string
+	preparedNonce              string
+	preparedAttemptTS          time.Time
+}
+
+func (f *fakeStatsDB) PrepareProviderRegistration(_ context.Context, providerID, sourceIP, nonce string, observedAt, attemptTS time.Time, identityPubkey []byte, attested bool, appAttestKeyID []byte) error {
+	f.prepareCalls++
+	f.preparedProviderID = providerID
+	f.preparedNonce = nonce
+	f.preparedAttemptTS = attemptTS
+	return f.prepareErr
+}
+
+func (f *fakeStatsDB) ProviderRegistrationPrepared(_ context.Context, providerID, nonce string, attemptTS time.Time) (bool, error) {
+	f.preparedChecks++
+	f.preparedProviderID = providerID
+	f.preparedNonce = nonce
+	f.preparedAttemptTS = attemptTS
+	return f.prepared, f.preparedErr
 }
 
 func (f *fakeStatsDB) UpsertProviderIdentity(ctx context.Context, providerID string, identityPubkey []byte, attested bool, appAttestKeyID []byte) error {
@@ -1120,6 +1285,16 @@ type fakeAuthStore struct {
 	validateProviderID string
 	validateOK         bool
 	validateErr        error
+	referralToken      string
+	referralMintErr    error
+	referralMintCalls  int
+	ackErr             error
+	ackCalls           int
+	rollbackErr        error
+	rollbackCalls      int
+	pendingMints       []auth.PendingAppTrackReferralMint
+	resolvedMints      []auth.PendingAppTrackReferralMint
+	resolvedPrepared   []bool
 }
 
 func (f *fakeAuthStore) MintProviderTokenAppTrack(ctx context.Context, providerID string, currentBearer *string) (string, error) {
@@ -1142,6 +1317,35 @@ func (f *fakeAuthStore) ValidateToken(ctx context.Context, token string) (string
 		return f.validateProviderID, true, nil
 	}
 	return f.providerID, true, nil
+}
+
+func (f *fakeAuthStore) MintProviderTokenAppTrackWithReferralAttempt(_ context.Context, providerID, referralCode string, policy auth.ReferralPolicy, attempt auth.AppTrackRegistrationAttempt) (string, error) {
+	f.referralMintCalls++
+	f.providerID = providerID
+	if f.referralMintErr != nil {
+		return "", f.referralMintErr
+	}
+	return f.referralToken, nil
+}
+
+func (f *fakeAuthStore) AcknowledgeAppTrackReferralMint(context.Context, string, string) error {
+	f.ackCalls++
+	return f.ackErr
+}
+
+func (f *fakeAuthStore) RollbackAppTrackReferralMint(context.Context, string, string) error {
+	f.rollbackCalls++
+	return f.rollbackErr
+}
+
+func (f *fakeAuthStore) ListPendingAppTrackReferralMints(context.Context, time.Time) ([]auth.PendingAppTrackReferralMint, error) {
+	return append([]auth.PendingAppTrackReferralMint(nil), f.pendingMints...), nil
+}
+
+func (f *fakeAuthStore) ResolvePendingAppTrackReferralMint(_ context.Context, pending auth.PendingAppTrackReferralMint, prepared bool) error {
+	f.resolvedMints = append(f.resolvedMints, pending)
+	f.resolvedPrepared = append(f.resolvedPrepared, prepared)
+	return nil
 }
 
 type fakeMetrics struct {

--- a/phase4-coordinator/internal/onboarding/store_pg.go
+++ b/phase4-coordinator/internal/onboarding/store_pg.go
@@ -138,6 +138,9 @@ SELECT j.generated_at, j.evidence
 	if _, err := s.db.ExecContext(timeout, `SELECT 1 FROM provider_register_nonces LIMIT 1`); err != nil {
 		return fmt.Errorf("provider_onboarding smoke provider_register_nonces read: %w", err)
 	}
+	if _, err := s.db.ExecContext(timeout, `SELECT 1 FROM provider_register_attempts LIMIT 1`); err != nil {
+		return fmt.Errorf("provider_onboarding smoke provider_register_attempts read: %w", err)
+	}
 	if _, err := s.db.ExecContext(timeout, `SELECT 1 FROM provider_auth_policy LIMIT 1`); err != nil {
 		return fmt.Errorf("provider_onboarding smoke provider_auth_policy read: %w", err)
 	}
@@ -362,6 +365,103 @@ VALUES ($1, $2, $3, $4)`, providerID, sourceIP, nonce, observedAt); err != nil {
 		return err
 	}
 	return nil
+}
+
+// PrepareProviderRegistration atomically records replay protection, provider
+// identity, and an exact durable attempt marker. App-track referral minting
+// happens first in SQLite but remains undisclosed behind a pending saga until
+// this transaction is known to have committed.
+func (s *PGStore) PrepareProviderRegistration(ctx context.Context, providerID, sourceIP, nonce string, observedAt, attemptTS time.Time, identityPubkey []byte, attested bool, appAttestKeyID []byte) error {
+	if s == nil || s.db == nil {
+		return errors.New("onboarding postgres store is nil")
+	}
+	tx, err := s.db.BeginTx(ctx, &sql.TxOptions{Isolation: sql.LevelSerializable})
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback()
+
+	observedAt = observedAt.UTC()
+	attemptTS = attemptTS.UTC()
+	cutoffStart := observedAt.Add(-registerNonceWindow)
+	cutoffEnd := observedAt.Add(registerNonceWindow)
+	var exists bool
+	if err := tx.QueryRowContext(ctx, `
+SELECT EXISTS (
+    SELECT 1 FROM provider_register_nonces
+     WHERE provider_id = $1 AND nonce = $2 AND ts_utc BETWEEN $3 AND $4
+)`, providerID, nonce, cutoffStart, cutoffEnd).Scan(&exists); err != nil {
+		return err
+	}
+	if exists {
+		return ErrNonceReplay
+	}
+	if err := tx.QueryRowContext(ctx, `
+SELECT EXISTS (
+    SELECT 1 FROM provider_register_nonces
+     WHERE source_ip = $1 AND nonce = $2 AND ts_utc BETWEEN $3 AND $4
+)`, sourceIP, nonce, cutoffStart, cutoffEnd).Scan(&exists); err != nil {
+		return err
+	}
+	if exists {
+		return ErrNonceReplay
+	}
+
+	var key any
+	if len(appAttestKeyID) > 0 {
+		key = appAttestKeyID
+	}
+	var out string
+	err = tx.QueryRowContext(ctx, `
+INSERT INTO provider_identities (provider_id, identity_pubkey, attested, app_attest_key_id)
+VALUES ($1, $2, $3, $4)
+ON CONFLICT (provider_id) DO UPDATE
+   SET attested = provider_identities.attested OR EXCLUDED.attested,
+       app_attest_key_id = COALESCE(provider_identities.app_attest_key_id, EXCLUDED.app_attest_key_id)
+ WHERE provider_identities.identity_pubkey = EXCLUDED.identity_pubkey
+RETURNING provider_id`, providerID, identityPubkey, attested, key).Scan(&out)
+	if errors.Is(err, sql.ErrNoRows) {
+		return ErrTOFUConflict
+	}
+	if err != nil {
+		if isUniqueViolation(err) {
+			return ErrAttestKeyReused
+		}
+		return err
+	}
+	if _, err := tx.ExecContext(ctx, `
+INSERT INTO provider_register_nonces (provider_id, source_ip, nonce, ts_utc)
+VALUES ($1, $2, $3, $4)`, providerID, sourceIP, nonce, observedAt); err != nil {
+		return err
+	}
+	if _, err := tx.ExecContext(ctx, `
+INSERT INTO provider_register_attempts (provider_id, nonce, ts_utc, source_ip)
+VALUES ($1, $2, $3, $4)
+ON CONFLICT (provider_id, nonce, ts_utc) DO NOTHING`, providerID, nonce, attemptTS, sourceIP); err != nil {
+		return err
+	}
+	if err := tx.Commit(); err != nil {
+		if isSerializationFailure(err) {
+			return ErrNonceReplay
+		}
+		return err
+	}
+	return nil
+}
+
+// ProviderRegistrationPrepared checks only replay-stable, signed fields. The
+// source IP is diagnostic and deliberately excluded from the commitment key.
+func (s *PGStore) ProviderRegistrationPrepared(ctx context.Context, providerID, nonce string, attemptTS time.Time) (bool, error) {
+	if s == nil || s.db == nil {
+		return false, errors.New("onboarding postgres store is nil")
+	}
+	var prepared bool
+	err := s.db.QueryRowContext(ctx, `
+SELECT EXISTS (
+    SELECT 1 FROM provider_register_attempts
+     WHERE provider_id = $1 AND nonce = $2 AND ts_utc = $3
+)`, providerID, nonce, attemptTS.UTC()).Scan(&prepared)
+	return prepared, err
 }
 
 func normalizeChip(chip string) string {

--- a/phase4-coordinator/internal/onboarding/store_pg_attempt_integration_test.go
+++ b/phase4-coordinator/internal/onboarding/store_pg_attempt_integration_test.go
@@ -1,0 +1,82 @@
+//go:build integration
+
+package onboarding
+
+import (
+	"context"
+	"crypto/ed25519"
+	"crypto/rand"
+	"database/sql"
+	"testing"
+	"time"
+
+	_ "github.com/lib/pq"
+	tc "github.com/testcontainers/testcontainers-go"
+	tcpg "github.com/testcontainers/testcontainers-go/modules/postgres"
+	"github.com/testcontainers/testcontainers-go/wait"
+
+	statsmigrations "github.com/augstar/macprovider-coordinator/internal/stats/migrations"
+)
+
+const (
+	referralAttemptPGImage = "postgres:16.4-alpine3.20@sha256:5660c2cbfea50c7a9127d17dc4e48543eedd3d7a41a595a2dfa572471e37e64c"
+	referralAttemptPGPass  = "referral-attempt-test-password"
+)
+
+func TestProviderRegistrationPreparedSurvivesNoncePrune(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 90*time.Second)
+	defer cancel()
+	container, err := tcpg.Run(ctx, referralAttemptPGImage,
+		tcpg.WithDatabase("referral_attempt"),
+		tcpg.WithUsername("postgres"),
+		tcpg.WithPassword(referralAttemptPGPass),
+		tc.WithWaitStrategy(wait.ForLog("database system is ready to accept connections").WithOccurrence(2).WithStartupTimeout(60*time.Second)),
+	)
+	if err != nil {
+		t.Fatalf("start postgres: %v", err)
+	}
+	t.Cleanup(func() {
+		cleanup, cleanupCancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cleanupCancel()
+		_ = container.Terminate(cleanup)
+	})
+	dsn, err := container.ConnectionString(ctx, "sslmode=disable")
+	if err != nil {
+		t.Fatal(err)
+	}
+	db, err := sql.Open("postgres", dsn)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	if err := statsmigrations.Apply(ctx, db); err != nil {
+		t.Fatalf("apply migrations: %v", err)
+	}
+
+	store := &PGStore{db: db}
+	publicKey, _, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	observedAt := time.Now().UTC().Truncate(time.Second)
+	attemptTS := observedAt.Add(-30 * time.Second)
+	if err := store.PrepareProviderRegistration(
+		ctx, "provider-a", "203.0.113.7", "nonce-a", observedAt, attemptTS,
+		publicKey, false, nil,
+	); err != nil {
+		t.Fatalf("prepare: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `DELETE FROM provider_register_nonces`); err != nil {
+		t.Fatalf("prune nonces: %v", err)
+	}
+	prepared, err := store.ProviderRegistrationPrepared(ctx, "provider-a", "nonce-a", attemptTS)
+	if err != nil || !prepared {
+		t.Fatalf("prepared=%v err=%v after nonce prune", prepared, err)
+	}
+	if wrong, err := store.ProviderRegistrationPrepared(ctx, "provider-a", "nonce-a", observedAt); err != nil || wrong {
+		t.Fatalf("server observed timestamp matched signed marker: prepared=%v err=%v", wrong, err)
+	}
+	if missing, err := store.ProviderRegistrationPrepared(ctx, "provider-missing", "nonce-z", attemptTS); err != nil || missing {
+		t.Fatalf("missing attempt prepared=%v err=%v", missing, err)
+	}
+}

--- a/phase4-coordinator/internal/referralapi/validate.go
+++ b/phase4-coordinator/internal/referralapi/validate.go
@@ -1,0 +1,192 @@
+package referralapi
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"sync"
+	"time"
+
+	"github.com/augstar/macprovider-coordinator/internal/auth"
+)
+
+type ValidationStore interface {
+	ValidateReferral(context.Context, auth.ReferralPolicy, string, time.Time) (auth.ReferralValidation, error)
+}
+
+// ValidationHandler is intentionally read-only. It exposes invite state for
+// onboarding UX but does not reserve capacity; registration remains the sole
+// authority that consumes a referral.
+type ValidationHandler struct {
+	Store         ValidationStore
+	Policy        auth.ReferralPolicy
+	PublicLimiter *BoundedLimiter
+	ValidateSlots chan struct{}
+	SourceIP      func(*http.Request) string
+	Now           func() time.Time
+}
+
+func (h *ValidationHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		w.Header().Set("Allow", http.MethodPost)
+		writeError(w, http.StatusMethodNotAllowed, "method_not_allowed", "POST required")
+		return
+	}
+	w.Header().Set("Cache-Control", "no-store")
+	if !h.Policy.RequireForRegistration {
+		writeJSON(w, http.StatusOK, map[string]any{"valid": true, "required": false, "reason": "disabled"})
+		return
+	}
+	key := r.RemoteAddr
+	if h.SourceIP != nil {
+		key = h.SourceIP(r)
+	}
+	if h.PublicLimiter == nil || !h.PublicLimiter.Allow(key) {
+		w.Header().Set("Retry-After", "60")
+		writeError(w, http.StatusTooManyRequests, "rate_limited", "too many referral checks")
+		return
+	}
+	if h.ValidateSlots != nil {
+		select {
+		case h.ValidateSlots <- struct{}{}:
+			defer func() { <-h.ValidateSlots }()
+		default:
+			w.Header().Set("Retry-After", "5")
+			writeError(w, http.StatusServiceUnavailable, "busy", "invite validation is temporarily busy")
+			return
+		}
+	}
+	if h.Store == nil {
+		writeError(w, http.StatusServiceUnavailable, "unavailable", "referral authority unavailable")
+		return
+	}
+	var request struct {
+		Code string `json:"code"`
+	}
+	if err := decodeBoundedJSON(r, &request, 1024); err != nil || len([]byte(request.Code)) > 256 {
+		writeError(w, http.StatusBadRequest, "bad_request", "invalid request")
+		return
+	}
+	validation, err := h.Store.ValidateReferral(r.Context(), h.Policy, request.Code, h.now())
+	if err != nil {
+		writeJSON(w, http.StatusOK, map[string]any{
+			"valid": false, "required": true, "reason": referralReason(err),
+		})
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{
+		"valid": validation.Valid, "required": true, "reason": validation.Reason,
+	})
+}
+
+func (h *ValidationHandler) now() time.Time {
+	if h.Now != nil {
+		return h.Now().UTC()
+	}
+	return time.Now().UTC()
+}
+
+func referralReason(err error) string {
+	switch {
+	case errors.Is(err, auth.ErrReferralRequired):
+		return "missing"
+	case errors.Is(err, auth.ErrReferralExpired):
+		return "expired"
+	case errors.Is(err, auth.ErrReferralRevoked):
+		return "revoked"
+	case errors.Is(err, auth.ErrReferralExhausted):
+		return "exhausted"
+	case errors.Is(err, auth.ErrReferralConflict):
+		return "conflict"
+	default:
+		return "invalid"
+	}
+}
+
+func decodeBoundedJSON(r *http.Request, dst any, max int64) error {
+	defer r.Body.Close()
+	body, err := io.ReadAll(io.LimitReader(r.Body, max+1))
+	if err != nil || int64(len(body)) > max {
+		return fmt.Errorf("body too large")
+	}
+	decoder := json.NewDecoder(bytes.NewReader(body))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(dst); err != nil {
+		return err
+	}
+	if err := decoder.Decode(&struct{}{}); err != io.EOF {
+		return fmt.Errorf("request must contain exactly one JSON value")
+	}
+	return nil
+}
+
+func writeError(w http.ResponseWriter, status int, code, message string) {
+	writeJSON(w, status, map[string]any{"error": map[string]string{"code": code, "message": message}})
+}
+
+func writeJSON(w http.ResponseWriter, status int, value any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("Cache-Control", "no-store")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(value)
+}
+
+type limiterEntry struct {
+	windowStart time.Time
+	count       int
+}
+
+type BoundedLimiter struct {
+	mu         sync.Mutex
+	limit      int
+	window     time.Duration
+	maxEntries int
+	now        func() time.Time
+	entries    map[string]limiterEntry
+}
+
+func NewBoundedLimiter(limit int, window time.Duration, maxEntries int) *BoundedLimiter {
+	return &BoundedLimiter{
+		limit: limit, window: window, maxEntries: maxEntries,
+		now: time.Now, entries: map[string]limiterEntry{},
+	}
+}
+
+func (l *BoundedLimiter) Allow(key string) bool {
+	if l == nil || l.limit <= 0 || l.window <= 0 || l.maxEntries <= 0 {
+		return false
+	}
+	now := l.now().UTC()
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	for k, entry := range l.entries {
+		if now.Sub(entry.windowStart) >= l.window {
+			delete(l.entries, k)
+		}
+	}
+	entry, ok := l.entries[key]
+	if !ok {
+		if len(l.entries) >= l.maxEntries {
+			var oldestKey string
+			var oldest time.Time
+			for k, candidate := range l.entries {
+				if oldestKey == "" || candidate.windowStart.Before(oldest) {
+					oldestKey, oldest = k, candidate.windowStart
+				}
+			}
+			delete(l.entries, oldestKey)
+		}
+		l.entries[key] = limiterEntry{windowStart: now, count: 1}
+		return true
+	}
+	if entry.count >= l.limit {
+		return false
+	}
+	entry.count++
+	l.entries[key] = entry
+	return true
+}

--- a/phase4-coordinator/internal/referralapi/validate.go
+++ b/phase4-coordinator/internal/referralapi/validate.go
@@ -2,6 +2,7 @@ package referralapi
 
 import (
 	"bytes"
+	"container/list"
 	"context"
 	"encoding/json"
 	"errors"
@@ -45,11 +46,6 @@ func (h *ValidationHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	if h.SourceIP != nil {
 		key = h.SourceIP(r)
 	}
-	if h.PublicLimiter == nil || !h.PublicLimiter.Allow(key) {
-		w.Header().Set("Retry-After", "60")
-		writeError(w, http.StatusTooManyRequests, "rate_limited", "too many referral checks")
-		return
-	}
 	if h.ValidateSlots != nil {
 		select {
 		case h.ValidateSlots <- struct{}{}:
@@ -59,6 +55,11 @@ func (h *ValidationHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			writeError(w, http.StatusServiceUnavailable, "busy", "invite validation is temporarily busy")
 			return
 		}
+	}
+	if h.PublicLimiter == nil || !h.PublicLimiter.Allow(key) {
+		w.Header().Set("Retry-After", "60")
+		writeError(w, http.StatusTooManyRequests, "rate_limited", "too many referral checks")
+		return
 	}
 	if h.Store == nil {
 		writeError(w, http.StatusServiceUnavailable, "unavailable", "referral authority unavailable")
@@ -138,6 +139,7 @@ func writeJSON(w http.ResponseWriter, status int, value any) {
 type limiterEntry struct {
 	windowStart time.Time
 	count       int
+	element     *list.Element
 }
 
 type BoundedLimiter struct {
@@ -147,12 +149,13 @@ type BoundedLimiter struct {
 	maxEntries int
 	now        func() time.Time
 	entries    map[string]limiterEntry
+	oldest     *list.List
 }
 
 func NewBoundedLimiter(limit int, window time.Duration, maxEntries int) *BoundedLimiter {
 	return &BoundedLimiter{
 		limit: limit, window: window, maxEntries: maxEntries,
-		now: time.Now, entries: map[string]limiterEntry{},
+		now: time.Now, entries: map[string]limiterEntry{}, oldest: list.New(),
 	}
 }
 
@@ -163,24 +166,41 @@ func (l *BoundedLimiter) Allow(key string) bool {
 	now := l.now().UTC()
 	l.mu.Lock()
 	defer l.mu.Unlock()
-	for k, entry := range l.entries {
-		if now.Sub(entry.windowStart) >= l.window {
-			delete(l.entries, k)
+	// Expiration is ordered by window start and bounded per call. This keeps a
+	// distributed-key flood from turning every request into a full-map scan.
+	for removed := 0; removed < 16; removed++ {
+		front := l.oldest.Front()
+		if front == nil {
+			break
 		}
+		key := front.Value.(string)
+		entry, ok := l.entries[key]
+		if !ok || entry.element != front {
+			l.oldest.Remove(front)
+			continue
+		}
+		if now.Sub(entry.windowStart) < l.window {
+			break
+		}
+		delete(l.entries, key)
+		l.oldest.Remove(front)
 	}
 	entry, ok := l.entries[key]
 	if !ok {
 		if len(l.entries) >= l.maxEntries {
-			var oldestKey string
-			var oldest time.Time
-			for k, candidate := range l.entries {
-				if oldestKey == "" || candidate.windowStart.Before(oldest) {
-					oldestKey, oldest = k, candidate.windowStart
-				}
-			}
-			delete(l.entries, oldestKey)
+			// Never reset an active caller's budget merely to admit a new key.
+			return false
 		}
-		l.entries[key] = limiterEntry{windowStart: now, count: 1}
+		element := l.oldest.PushBack(key)
+		l.entries[key] = limiterEntry{windowStart: now, count: 1, element: element}
+		return true
+	}
+	if now.Sub(entry.windowStart) >= l.window {
+		l.oldest.Remove(entry.element)
+		entry.windowStart = now
+		entry.count = 1
+		entry.element = l.oldest.PushBack(key)
+		l.entries[key] = entry
 		return true
 	}
 	if entry.count >= l.limit {

--- a/phase4-coordinator/internal/referralapi/validate_test.go
+++ b/phase4-coordinator/internal/referralapi/validate_test.go
@@ -86,3 +86,19 @@ func TestReferralReasonDoesNotCollapseLifecycleFailures(t *testing.T) {
 		}
 	}
 }
+
+func TestBoundedLimiterNeverEvictsAnActiveBucketForANewKey(t *testing.T) {
+	limiter := NewBoundedLimiter(2, time.Minute, 1)
+	now := time.Date(2026, 7, 13, 12, 0, 0, 0, time.UTC)
+	limiter.now = func() time.Time { return now }
+	if !limiter.Allow("active") || limiter.Allow("unseen") {
+		t.Fatal("full limiter admitted an unseen key")
+	}
+	if !limiter.Allow("active") || limiter.Allow("active") {
+		t.Fatal("active bucket was reset or its budget was not preserved")
+	}
+	now = now.Add(time.Minute)
+	if !limiter.Allow("unseen") {
+		t.Fatal("expired bucket was not reclaimed")
+	}
+}

--- a/phase4-coordinator/internal/referralapi/validate_test.go
+++ b/phase4-coordinator/internal/referralapi/validate_test.go
@@ -1,0 +1,88 @@
+package referralapi
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/augstar/macprovider-coordinator/internal/auth"
+)
+
+type validationStoreFunc func(string) (auth.ReferralValidation, error)
+
+func (f validationStoreFunc) ValidateReferral(_ context.Context, _ auth.ReferralPolicy, code string, _ time.Time) (auth.ReferralValidation, error) {
+	return f(code)
+}
+
+func validationPolicy() auth.ReferralPolicy {
+	return auth.ReferralPolicy{
+		RequireForRegistration: true,
+		Campaign:               "prebeta_test",
+		PolicyVersion:          "v1",
+		CurrentKeyID:           "k1",
+		HMACKeys:               map[string]string{"k1": strings.Repeat("s", 32)},
+		ProviderBaseUses:       1,
+	}
+}
+
+func TestValidationHandlerReturnsStableReasonWithoutReserving(t *testing.T) {
+	h := &ValidationHandler{
+		Store: validationStoreFunc(func(code string) (auth.ReferralValidation, error) {
+			if code == "expired" {
+				return auth.ReferralValidation{}, auth.ErrReferralExpired
+			}
+			return auth.ReferralValidation{Valid: true, Reason: "valid"}, nil
+		}),
+		Policy:        validationPolicy(),
+		PublicLimiter: NewBoundedLimiter(10, time.Minute, 10),
+		ValidateSlots: make(chan struct{}, 1),
+		SourceIP:      func(*http.Request) string { return "203.0.113.10" },
+	}
+
+	for _, tc := range []struct {
+		body string
+		want string
+	}{
+		{`{"code":"good"}`, `"valid":true`},
+		{`{"code":"expired"}`, `"reason":"expired"`},
+	} {
+		req := httptest.NewRequest(http.MethodPost, "/v1/referrals/validate", strings.NewReader(tc.body))
+		response := httptest.NewRecorder()
+		h.ServeHTTP(response, req)
+		if response.Code != http.StatusOK || !strings.Contains(response.Body.String(), tc.want) {
+			t.Fatalf("status=%d body=%s want %s", response.Code, response.Body.String(), tc.want)
+		}
+	}
+}
+
+func TestValidationHandlerFailsClosedWhenAuthorityMissing(t *testing.T) {
+	h := &ValidationHandler{
+		Policy:        validationPolicy(),
+		PublicLimiter: NewBoundedLimiter(1, time.Minute, 1),
+	}
+	request := httptest.NewRequest(http.MethodPost, "/v1/referrals/validate", strings.NewReader(`{"code":"x"}`))
+	response := httptest.NewRecorder()
+	h.ServeHTTP(response, request)
+	if response.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status=%d body=%s", response.Code, response.Body.String())
+	}
+}
+
+func TestReferralReasonDoesNotCollapseLifecycleFailures(t *testing.T) {
+	cases := map[error]string{
+		auth.ErrReferralRequired:  "missing",
+		auth.ErrReferralInvalid:   "invalid",
+		auth.ErrReferralExpired:   "expired",
+		auth.ErrReferralRevoked:   "revoked",
+		auth.ErrReferralExhausted: "exhausted",
+	}
+	for err, want := range cases {
+		if got := referralReason(errors.Join(err)); got != want {
+			t.Fatalf("reason(%v)=%q want=%q", err, got, want)
+		}
+	}
+}

--- a/phase4-coordinator/internal/stats/migrations/018_apptrack_register_attempts.down.sql
+++ b/phase4-coordinator/internal/stats/migrations/018_apptrack_register_attempts.down.sql
@@ -1,0 +1,6 @@
+-- Operator rollback artifact. The embedded runner applies only *.up.sql.
+REVOKE ALL ON provider_register_attempts FROM provider_onboarding;
+REVOKE ALL ON FUNCTION prune_provider_register_attempts(INTERVAL) FROM PUBLIC;
+
+DROP FUNCTION IF EXISTS prune_provider_register_attempts(INTERVAL);
+DROP TABLE IF EXISTS provider_register_attempts;

--- a/phase4-coordinator/internal/stats/migrations/018_apptrack_register_attempts.up.sql
+++ b/phase4-coordinator/internal/stats/migrations/018_apptrack_register_attempts.up.sql
@@ -1,0 +1,48 @@
+-- Durable commitment marker for App-track provider registration.
+--
+-- The replay nonce table is intentionally short-lived and therefore cannot
+-- prove that the PostgreSQL half of a cross-store referral mint committed.
+-- This table is written in the same transaction as provider identity prepare
+-- and survives well beyond the SQLite saga reconciliation horizon.
+--
+-- The primary key contains signed, replay-stable fields only. source_ip is
+-- connection-dependent diagnostic metadata and is never authoritative.
+CREATE TABLE IF NOT EXISTS provider_register_attempts (
+    provider_id  TEXT NOT NULL,
+    nonce        TEXT NOT NULL,
+    ts_utc       TIMESTAMPTZ NOT NULL,
+    source_ip    TEXT,
+    committed_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    PRIMARY KEY (provider_id, nonce, ts_utc)
+);
+
+CREATE INDEX IF NOT EXISTS idx_provider_register_attempts_committed_at
+    ON provider_register_attempts(committed_at);
+
+-- Keep attempt evidence for at least seven days. This is deliberately much
+-- longer than the registration reconciliation horizon.
+CREATE OR REPLACE FUNCTION prune_provider_register_attempts(retain_for INTERVAL DEFAULT INTERVAL '30 days')
+RETURNS BIGINT
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = pg_catalog, public, pg_temp
+AS $$
+DECLARE
+    deleted_count BIGINT;
+BEGIN
+    IF retain_for < INTERVAL '7 days' THEN
+        RAISE EXCEPTION 'retain_for must be at least 7 days';
+    END IF;
+
+    DELETE FROM provider_register_attempts
+     WHERE committed_at < NOW() - retain_for;
+    GET DIAGNOSTICS deleted_count = ROW_COUNT;
+    RETURN deleted_count;
+END;
+$$;
+
+-- The runtime role can record and verify commitments but cannot mutate them.
+GRANT SELECT, INSERT ON provider_register_attempts TO provider_onboarding;
+
+REVOKE ALL ON FUNCTION prune_provider_register_attempts(INTERVAL) FROM PUBLIC;
+REVOKE ALL ON FUNCTION prune_provider_register_attempts(INTERVAL) FROM provider_onboarding;

--- a/phase4-coordinator/internal/stats/migrations/migrations_test.go
+++ b/phase4-coordinator/internal/stats/migrations/migrations_test.go
@@ -38,6 +38,7 @@ func TestEmbeddedMigrationsLoad(t *testing.T) {
 		{15, "provider_onboarding_hardware_decision_reason"},
 		{16, "hardware_profile_memory_reverification"},
 		{17, "autotune_current_hardware_gate_grants"},
+		{18, "apptrack_register_attempts"},
 	}
 	if len(all) != len(want) {
 		t.Fatalf("got %d migrations, want %d", len(all), len(want))
@@ -557,4 +558,49 @@ func extractBetween(body, start, end string) string {
 		return rest
 	}
 	return rest[:j+len(end)]
+}
+
+func TestApptrackRegisterAttemptsMigrationShape(t *testing.T) {
+	all, err := All()
+	if err != nil {
+		t.Fatalf("All: %v", err)
+	}
+	var body string
+	for _, m := range all {
+		if m.Name == "apptrack_register_attempts" {
+			body = m.SQL
+		}
+	}
+	if body == "" {
+		t.Fatal("apptrack_register_attempts migration body is empty")
+	}
+	for _, needle := range []string{
+		"CREATE TABLE IF NOT EXISTS provider_register_attempts",
+		"PRIMARY KEY (provider_id, nonce, ts_utc)",
+		"CREATE OR REPLACE FUNCTION prune_provider_register_attempts",
+		"retain_for must be at least 7 days",
+		"SET search_path = pg_catalog, public, pg_temp",
+		"GRANT SELECT, INSERT ON provider_register_attempts TO provider_onboarding",
+		"REVOKE ALL ON FUNCTION prune_provider_register_attempts(INTERVAL) FROM PUBLIC",
+		"REVOKE ALL ON FUNCTION prune_provider_register_attempts(INTERVAL) FROM provider_onboarding",
+	} {
+		mustContain(t, body, needle, "durable registration attempt marker migration")
+	}
+	mustNotContain(t, body, "GRANT DELETE ON provider_register_attempts",
+		"runtime onboarding role must not delete durable attempt markers")
+	mustNotContain(t, body, "PRIMARY KEY (provider_id, nonce, ts_utc, source_ip)",
+		"connection metadata must not participate in commitment identity")
+
+	down, err := os.ReadFile("018_apptrack_register_attempts.down.sql")
+	if err != nil {
+		t.Fatalf("read rollback artifact: %v", err)
+	}
+	downSQL := string(down)
+	for _, needle := range []string{
+		"REVOKE ALL ON provider_register_attempts FROM provider_onboarding",
+		"DROP FUNCTION IF EXISTS prune_provider_register_attempts(INTERVAL)",
+		"DROP TABLE IF EXISTS provider_register_attempts",
+	} {
+		mustContain(t, downSQL, needle, "registration attempt rollback artifact")
+	}
 }

--- a/phase4-coordinator/internal/ws/admission.go
+++ b/phase4-coordinator/internal/ws/admission.go
@@ -94,6 +94,32 @@ func (a *AdmissionManager) CheckAdmit(hello Hello, pinned bool, connectedProvisi
 	return a.evaluateAdmissionLocked(hello, connectedProvisional, false)
 }
 
+// ReserveAdmission holds in-memory pool capacity without creating durable
+// admission history. A failed referral/token transaction therefore leaves no
+// hourly admission record behind.
+func (a *AdmissionManager) ReserveAdmission(hello Hello, pinned bool, connectedProvisional int) (pool.Tier, gobwas.StatusCode, string) {
+	if pinned {
+		return pool.TierPinned, 0, ""
+	}
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	tier, code, reason := a.evaluateAdmissionLocked(hello, connectedProvisional, false)
+	if code == 0 {
+		a.pending++
+	}
+	return tier, code, reason
+}
+
+func (a *AdmissionManager) CommitReservedAdmission(hello Hello, pinned bool) pool.Tier {
+	if pinned {
+		return pool.TierPinned
+	}
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	a.recordAdmissionLocked(hello, a.now())
+	return pool.TierProvisional
+}
+
 func (a *AdmissionManager) evaluateAdmissionLocked(hello Hello, connectedProvisional int, record bool) (pool.Tier, gobwas.StatusCode, string) {
 	if _, ok := a.rejected[hello.ProviderID]; ok {
 		return pool.TierRejected, CloseBanned, "banned: provider " + hello.ProviderID + " has been rejected by operator"
@@ -114,6 +140,11 @@ func (a *AdmissionManager) evaluateAdmissionLocked(hello Hello, connectedProvisi
 		return pool.TierProvisional, 0, ""
 	}
 	a.pending++
+	a.recordAdmissionLocked(hello, now)
+	return pool.TierProvisional, 0, ""
+}
+
+func (a *AdmissionManager) recordAdmissionLocked(hello Hello, now time.Time) {
 	rec := a.records[hello.ProviderID]
 	if rec == nil {
 		rec = &ProvisionalRecord{
@@ -129,7 +160,6 @@ func (a *AdmissionManager) evaluateAdmissionLocked(hello Hello, connectedProvisi
 	rec.ModelID = hello.ModelID
 	rec.BinaryVersion = hello.BinaryVersion
 	a.persistLocked()
-	return pool.TierProvisional, 0, ""
 }
 
 func (a *AdmissionManager) ReleasePendingProvisional() {

--- a/phase4-coordinator/internal/ws/messages.go
+++ b/phase4-coordinator/internal/ws/messages.go
@@ -35,6 +35,7 @@ type Hello struct {
 	CatalogSignerKeyID     string          `json:"catalog_signer_key_id,omitempty"`
 	CandidateRowIdentity   string          `json:"catalog_row_identity,omitempty"`
 	CredentialBootstrap    bool            `json:"credential_bootstrap,omitempty"`
+	ReferralCode           string          `json:"referral_code,omitempty"`
 }
 
 const (
@@ -42,6 +43,7 @@ const (
 	maxHandshakeModelIDBytes       = 256
 	maxHandshakeBinaryVersionBytes = 32
 	maxHandshakeMetadataBytes      = 1024
+	maxReferralCodeBytes           = 256
 )
 
 type HelloAck struct {
@@ -100,6 +102,7 @@ type AuthRequest struct {
 	CatalogSignerKeyID       string          `json:"catalog_signer_key_id,omitempty"`
 	CandidateRowIdentity     string          `json:"catalog_row_identity,omitempty"`
 	CredentialBootstrap      bool            `json:"credential_bootstrap,omitempty"`
+	ReferralCode             string          `json:"referral_code,omitempty"`
 }
 
 type Spec010Presence struct {
@@ -460,6 +463,11 @@ func ParseHello(payload []byte) (Hello, string, error) {
 			return Hello{}, "credential_bootstrap", fmt.Errorf("credential_bootstrap must be a bool")
 		}
 	}
+	if v, ok := raw["referral_code"]; ok && string(v) != "null" {
+		if err := json.Unmarshal(v, &h.ReferralCode); err != nil || len([]byte(h.ReferralCode)) > maxReferralCodeBytes || containsControlChar(h.ReferralCode) {
+			return Hello{}, "referral_code", fmt.Errorf("referral_code must be a string of at most %d bytes", maxReferralCodeBytes)
+		}
+	}
 	if field, err := parseCatalogAdmissionMetadata(raw, &h.CatalogReleaseID, &h.CatalogPolicyVersion, &h.CandidateCatalogSHA256, &h.CatalogSignerKeyID, &h.CandidateRowIdentity); err != nil {
 		return Hello{}, field, err
 	}
@@ -587,6 +595,11 @@ func parseAuthInitial(raw map[string]json.RawMessage, req AuthRequest) (AuthRequ
 			return AuthRequest{}, Spec010Presence{}, "credential_bootstrap", fmt.Errorf("credential_bootstrap must be a bool")
 		}
 	}
+	if v, ok := raw["referral_code"]; ok && string(v) != "null" {
+		if err := json.Unmarshal(v, &req.ReferralCode); err != nil || len([]byte(req.ReferralCode)) > maxReferralCodeBytes || containsControlChar(req.ReferralCode) {
+			return AuthRequest{}, Spec010Presence{}, "referral_code", fmt.Errorf("referral_code must be a string of at most %d bytes", maxReferralCodeBytes)
+		}
+	}
 	if err := requireString(raw, "provider_ecdh_public_key", &req.ProviderECDHPublicKey); err != nil {
 		return AuthRequest{}, Spec010Presence{}, err.Field, err
 	}
@@ -702,6 +715,11 @@ func parseAuthProof(raw map[string]json.RawMessage, req AuthRequest) (AuthReques
 			return AuthRequest{}, Spec010Presence{}, "credential_bootstrap", fmt.Errorf("credential_bootstrap must be a bool")
 		}
 	}
+	if v, ok := raw["referral_code"]; ok && string(v) != "null" {
+		if err := json.Unmarshal(v, &req.ReferralCode); err != nil || len([]byte(req.ReferralCode)) > maxReferralCodeBytes || containsControlChar(req.ReferralCode) {
+			return AuthRequest{}, Spec010Presence{}, "referral_code", fmt.Errorf("referral_code must be a string of at most %d bytes", maxReferralCodeBytes)
+		}
+	}
 	// Proof-stage MUST keep the bare "supported_models" badField (NOT
 	// the locked initial-stage substring) — AC-K.15's surfacing
 	// contract is initial-stage-only, and the R2V regression test
@@ -756,6 +774,7 @@ func (r AuthRequest) Hello() Hello {
 		CatalogSignerKeyID:     r.CatalogSignerKeyID,
 		CandidateRowIdentity:   r.CandidateRowIdentity,
 		CredentialBootstrap:    r.CredentialBootstrap,
+		ReferralCode:           r.ReferralCode,
 	}
 }
 

--- a/phase4-coordinator/internal/ws/referral_core_test.go
+++ b/phase4-coordinator/internal/ws/referral_core_test.go
@@ -1,0 +1,59 @@
+package ws
+
+import (
+	"database/sql"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/augstar/macprovider-coordinator/internal/auth"
+	"github.com/augstar/macprovider-coordinator/internal/config"
+	"github.com/augstar/macprovider-coordinator/internal/pool"
+)
+
+func TestReferralCloseReasonPreservesLifecycleToken(t *testing.T) {
+	cases := map[error]string{
+		auth.ErrReferralInvalid:   "referral_invalid",
+		auth.ErrReferralExpired:   "referral_expired",
+		auth.ErrReferralRevoked:   "referral_revoked",
+		auth.ErrReferralExhausted: "referral_exhausted",
+		auth.ErrReferralConflict:  "referral_invalid",
+	}
+	for err, want := range cases {
+		if got := referralCloseReason(err); got != want {
+			t.Fatalf("referralCloseReason(%v)=%q want=%q", err, got, want)
+		}
+	}
+}
+
+func TestAdmissionReservationIsNotDurableUntilCredentialCommit(t *testing.T) {
+	now := time.Date(2026, 7, 13, 12, 0, 0, 0, time.UTC)
+	db, err := sql.Open("sqlite", filepath.Join(t.TempDir(), "coordinator.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+	store, err := NewSQLiteAdmissionStore(db)
+	if err != nil {
+		t.Fatal(err)
+	}
+	manager := NewAdmissionManager(config.AdmissionConfig{
+		ProvisionalAdmissionRatePerHour: 1,
+		ProvisionalPoolMax:              1,
+	}, func() time.Time { return now })
+	manager.SetPersistence(store, func(err error) { t.Fatalf("persist admission: %v", err) })
+	hello := Hello{ProviderID: "provider-a", Hostname: "host", ModelID: "model", BinaryVersion: "1.2.0"}
+	if tier, code, reason := manager.ReserveAdmission(hello, false, 0); tier != pool.TierProvisional || code != 0 || reason != "" {
+		t.Fatalf("reserve tier=%s code=%d reason=%q", tier, code, reason)
+	}
+	if records := manager.Records(nil); len(records) != 0 {
+		t.Fatalf("reservation created durable records: %+v", records)
+	}
+	if tier := manager.CommitReservedAdmission(hello, false); tier != pool.TierProvisional {
+		t.Fatalf("commit tier=%s", tier)
+	}
+	if records := manager.Records(nil); len(records) != 1 || records[0].ProviderID != hello.ProviderID {
+		t.Fatalf("committed records=%+v", records)
+	}
+	manager.ReleasePendingProvisional()
+}

--- a/phase4-coordinator/internal/ws/server.go
+++ b/phase4-coordinator/internal/ws/server.go
@@ -92,6 +92,7 @@ type Server struct {
 	// interface-segregation regression of mixing both on TokenValidator.
 	issuer          TokenIssuer
 	bootstrapTokens BootstrapTokenStore
+	referralPolicy  auth.ReferralPolicy
 	authStore       *auth.Store
 	githubOAuth     githubOAuthClient
 	admission       *AdmissionManager
@@ -312,6 +313,12 @@ func WithTokenIssuer(issuer TokenIssuer) Option {
 func WithBootstrapTokenStore(store BootstrapTokenStore) Option {
 	return func(s *Server) {
 		s.bootstrapTokens = store
+	}
+}
+
+func WithReferralPolicy(policy auth.ReferralPolicy) Option {
+	return func(s *Server) {
+		s.referralPolicy = policy
 	}
 }
 
@@ -861,7 +868,7 @@ const (
 // bearer; race-losers are quarantined as AuthBearerlessDuplicate.
 //
 // authParam is renamed to disambiguate from the auth package import.
-func (s *Server) resolveProvisionalToken(authParam providerAuth, providerID, providerName string) (provisionalTokenOutcome, string, string, string, pool.AuthState) {
+func (s *Server) resolveProvisionalToken(authParam providerAuth, providerID, providerName, referralCode string) (provisionalTokenOutcome, string, string, string, pool.AuthState) {
 	if s.issuer == nil {
 		return provisionalTokenSkip, "", "", "", ""
 	}
@@ -879,7 +886,7 @@ func (s *Server) resolveProvisionalToken(authParam providerAuth, providerID, pro
 		return provisionalTokenRejectTOFU, "", "", "", ""
 	}
 	if s.cfg.Auth.GitHubOAuth.Enabled && s.authStore != nil {
-		mint, err := s.authStore.MintAdmissionTokenAndPairOT(ctx, providerID, providerName, s.now())
+		mint, err := s.authStore.MintAdmissionTokenAndPairOTWithReferral(ctx, providerID, providerName, s.now(), referralCode, s.referralPolicy)
 		if err == nil {
 			claimURL := ""
 			if mint.Paired {
@@ -894,7 +901,19 @@ func (s *Server) resolveProvisionalToken(authParam providerAuth, providerID, pro
 		}
 		s.log.Warn().Err(err).Str("provider_id", providerID).Msg("FR-C10 pair_ot compound mint failed; falling back to plain FR-C9 provider token mint")
 	}
-	_, token, err := s.issuer.IssueToken(ctx, providerID, providerName)
+	var token string
+	if s.referralPolicy.RequireForRegistration {
+		referralIssuer, ok := s.issuer.(interface {
+			IssueTokenWithReferral(context.Context, string, string, string, auth.ReferralPolicy) (auth.TokenRecord, string, error)
+		})
+		if !ok {
+			err = errors.New("referral-aware token issuer unavailable")
+		} else {
+			_, token, err = referralIssuer.IssueTokenWithReferral(ctx, providerID, providerName, referralCode, s.referralPolicy)
+		}
+	} else {
+		_, token, err = s.issuer.IssueToken(ctx, providerID, providerName)
+	}
 	if err != nil {
 		if errors.Is(err, auth.ErrActiveTokenAlreadyExists) {
 			// SPEC-003 v0.8.4 race-loss path: a concurrent tokenless
@@ -956,9 +975,14 @@ func (s *Server) handleV1Conn(conn net.Conn, connectionAuth providerAuth, payloa
 			return "", ""
 		}
 	}
-	entry, ok := s.prepareProviderAdmission(conn, connectionAuth, hello, true)
+	entry, ok := s.prepareProviderAdmission(conn, connectionAuth, hello)
 	if !ok {
 		return "", ""
+	}
+	if tier, ok := s.reserveProviderAdmission(conn, hello, entry.Tier == pool.TierPinned); !ok {
+		return "", ""
+	} else {
+		entry.Tier = tier
 	}
 	registered := false
 	defer func() {
@@ -974,7 +998,7 @@ func (s *Server) handleV1Conn(conn net.Conn, connectionAuth providerAuth, payloa
 	// the provided AuthState (BearerValidated / BearerlessDuplicate /
 	// empty) and let the registry eviction defense + RoutingEligible
 	// gates take over.
-	outcome, assignedProviderToken, pairOT, claimURL, authState := s.resolveProvisionalToken(connectionAuth, entry.ProviderID, hello.Hostname)
+	outcome, assignedProviderToken, pairOT, claimURL, authState := s.resolveProvisionalToken(connectionAuth, entry.ProviderID, hello.Hostname, hello.ReferralCode)
 	if outcome == provisionalTokenRejectTOFU {
 		s.close(conn, CloseInvalidToken, "invalid_token")
 		return "", ""
@@ -982,6 +1006,7 @@ func (s *Server) handleV1Conn(conn net.Conn, connectionAuth providerAuth, payloa
 	if !s.confirmAdmittedProviderToken(conn, connectionAuth) {
 		return "", ""
 	}
+	entry.Tier = s.commitProviderAdmission(hello, entry.Tier == pool.TierPinned)
 	entry.AuthState = authState
 	session, _ := s.registerProviderSession(conn, entry)
 	if session == nil {
@@ -1068,7 +1093,7 @@ func (s *Server) handleV2Conn(conn net.Conn, connectionAuth providerAuth, payloa
 	if initial.CredentialBootstrap {
 		entry, ok = s.prepareCredentialBootstrap(conn, connectionAuth, initial)
 	} else {
-		entry, ok = s.prepareProviderAdmission(conn, connectionAuth, initial.Hello(), false)
+		entry, ok = s.prepareProviderAdmission(conn, connectionAuth, initial.Hello())
 	}
 	if !ok {
 		return "", ""
@@ -1193,7 +1218,8 @@ func (s *Server) handleV2Conn(conn net.Conn, connectionAuth providerAuth, payloa
 		return "", ""
 	}
 	if proof.AuthAttemptID != authAttemptID || proof.ProviderID != initial.ProviderID ||
-		proof.CredentialBootstrap != initial.CredentialBootstrap || s.now().After(challengeExpiresAt) {
+		proof.CredentialBootstrap != initial.CredentialBootstrap || proof.ReferralCode != initial.ReferralCode ||
+		s.now().After(challengeExpiresAt) {
 		s.sendAuthRejection(conn, "attestation_failed", "attestation failed")
 		s.close(conn, CloseTier2AttestationFailed, "tier2_attestation_failed")
 		return "", ""
@@ -1267,6 +1293,8 @@ func (s *Server) handleV2Conn(conn net.Conn, connectionAuth providerAuth, payloa
 			UnconfirmedIDMax:    s.cfg.Auth.CredentialBootstrapUnconfirmedMax,
 			OutstandingTokenMax: s.cfg.Auth.CredentialBootstrapOutstandingMax,
 			IdentityRetention:   time.Duration(s.cfg.Auth.CredentialBootstrapIdentityRetentionS) * time.Second,
+			ReferralCode:        initial.ReferralCode,
+			ReferralPolicy:      s.referralPolicy,
 		})
 		if err != nil {
 			s.rejectCredentialBootstrap(conn, err)
@@ -1359,11 +1387,9 @@ func (s *Server) handleV2Conn(conn net.Conn, connectionAuth providerAuth, payloa
 	}
 	entry.MaxAdmittedModelKey = maxAdmittedModelKey
 	entry.MaxAdmittedModelID = maxAdmittedModelID
-	// This is the first durable admission mutation in the v2 path. Keep it
-	// after the post-challenge evidence recheck so a provider whose evidence
-	// disappears during authentication cannot consume an hourly admission or
-	// leave a provisional record behind.
-	if tier, ok := s.recordProviderAdmission(conn, initial.Hello(), entry.Tier == pool.TierPinned); !ok {
+	// Reserve after the post-challenge evidence recheck, but defer the durable
+	// admission record until credential minting succeeds.
+	if tier, ok := s.reserveProviderAdmission(conn, initial.Hello(), entry.Tier == pool.TierPinned); !ok {
 		return "", ""
 	} else {
 		entry.Tier = tier
@@ -1374,7 +1400,7 @@ func (s *Server) handleV2Conn(conn net.Conn, connectionAuth providerAuth, payloa
 			s.admission.ReleasePendingProvisional()
 		}
 	}()
-	outcome, assignedProviderToken, pairOT, claimURL, authState := s.resolveProvisionalToken(connectionAuth, entry.ProviderID, initial.Hostname)
+	outcome, assignedProviderToken, pairOT, claimURL, authState := s.resolveProvisionalToken(connectionAuth, entry.ProviderID, initial.Hostname, initial.ReferralCode)
 	if outcome == provisionalTokenRejectTOFU {
 		s.close(conn, CloseInvalidToken, "invalid_token")
 		return "", ""
@@ -1382,6 +1408,7 @@ func (s *Server) handleV2Conn(conn net.Conn, connectionAuth providerAuth, payloa
 	if !s.confirmAdmittedProviderToken(conn, connectionAuth) {
 		return "", ""
 	}
+	entry.Tier = s.commitProviderAdmission(initial.Hello(), entry.Tier == pool.TierPinned)
 	entry.AuthState = authState
 	session, refusal := s.registerProviderSession(conn, entry)
 	if session == nil {
@@ -1515,10 +1542,31 @@ func (s *Server) rejectCredentialBootstrap(conn net.Conn, err error) {
 	case errors.Is(err, auth.ErrBootstrapOutstandingLimit):
 		s.observeCredentialBootstrap("rejected_outstanding")
 		s.close(conn, CloseProvisionalPoolFull, "credential_bootstrap_outstanding_full")
+	case errors.Is(err, auth.ErrReferralRequired):
+		s.observeCredentialBootstrap("rejected_referral_required")
+		s.close(conn, CloseInvalidToken, "referral_required")
+	case errors.Is(err, auth.ErrReferralInvalid), errors.Is(err, auth.ErrReferralExpired),
+		errors.Is(err, auth.ErrReferralRevoked), errors.Is(err, auth.ErrReferralExhausted),
+		errors.Is(err, auth.ErrReferralConflict):
+		s.observeCredentialBootstrap("rejected_referral")
+		s.close(conn, CloseInvalidToken, referralCloseReason(err))
 	default:
 		s.observeCredentialBootstrap("store_error")
 		s.log.Warn().Err(err).Msg("credential bootstrap token transaction failed")
 		s.close(conn, CloseInvalidToken, "invalid_token")
+	}
+}
+
+func referralCloseReason(err error) string {
+	switch {
+	case errors.Is(err, auth.ErrReferralExpired):
+		return "referral_expired"
+	case errors.Is(err, auth.ErrReferralRevoked):
+		return "referral_revoked"
+	case errors.Is(err, auth.ErrReferralExhausted):
+		return "referral_exhausted"
+	default:
+		return "referral_invalid"
 	}
 }
 
@@ -1528,7 +1576,7 @@ func (s *Server) observeCredentialBootstrap(outcome string) {
 	}
 }
 
-func (s *Server) prepareProviderAdmission(conn net.Conn, auth providerAuth, hello Hello, recordAdmission bool) (*pool.Provider, bool) {
+func (s *Server) prepareProviderAdmission(conn net.Conn, auth providerAuth, hello Hello) (*pool.Provider, bool) {
 	if required := strings.TrimSpace(s.cfg.CoordinatorAdvertisedVersion.RequiredBinaryVersion); required != "" {
 		cmp, ok := compareSemver(hello.BinaryVersion, required)
 		if !ok || cmp < 0 {
@@ -1606,13 +1654,6 @@ func (s *Server) prepareProviderAdmission(conn net.Conn, auth providerAuth, hell
 	maxAdmittedModelKey, maxAdmittedModelID, gateOK := s.checkAutotuneHelloGate(conn, hello)
 	if !gateOK {
 		return nil, false
-	}
-	if recordAdmission {
-		tier, closeCode, closeReason = s.checkOrRecordAdmission(hello, pinned, true)
-		if closeCode != 0 {
-			s.close(conn, closeCode, closeReason)
-			return nil, false
-		}
 	}
 	initialState := pool.StateReady
 	if s.cfg.Pool.WarmupGateEnabled {
@@ -1787,13 +1828,17 @@ func (s *Server) populateCatalogAuthResponse(response *AuthResponse) {
 	response.CatalogSignerKeyID = s.autotuneCatalog.SignerKeyID
 }
 
-func (s *Server) recordProviderAdmission(conn net.Conn, hello Hello, pinned bool) (pool.Tier, bool) {
-	tier, closeCode, closeReason := s.checkOrRecordAdmission(hello, pinned, true)
+func (s *Server) reserveProviderAdmission(conn net.Conn, hello Hello, pinned bool) (pool.Tier, bool) {
+	tier, closeCode, closeReason := s.admission.ReserveAdmission(hello, pinned, s.connectedProvisional())
 	if closeCode != 0 {
 		s.close(conn, closeCode, closeReason)
 		return "", false
 	}
 	return tier, true
+}
+
+func (s *Server) commitProviderAdmission(hello Hello, pinned bool) pool.Tier {
+	return s.admission.CommitReservedAdmission(hello, pinned)
 }
 
 func (s *Server) checkOrRecordAdmission(hello Hello, pinned bool, record bool) (pool.Tier, gobwas.StatusCode, string) {


### PR DESCRIPTION
## Outcome

Adds the mandatory macOS onboarding and credential-transport slice required before the pre-beta referral gate can be enabled.

This PR contains no dashboard/X advocacy and no public referral reservation flow.

## Product behavior

- Fresh onboarding accepts a bare invite or canonical `/j/<code>` URL.
- Policy discovery and `/validate` are advisory; network failure does not falsely claim an invite is required.
- Authoritative registration rejection returns the user to the invite step with a lifecycle-specific message.
- Existing valid bearer custody is exempt from referral consumption.
- An app-owned identity with a missing bearer stops at an explicit support/start-new decision instead of looping or minting again.

## Credential boundary

- Malibu keeps the provider bearer in Keychain.
- Its managed CLI child receives the bearer through an inherited descriptor (`--token-fd 0`).
- The bearer is absent from argv, environment, config, launchd plist, and installer recovery snapshots.
- No persisted automatic registration replay exists.

## Verification

- Swift package tests: 1,183 executed, 8 skipped, 0 failures for this slice
- focused Malibu app suite: 48 tests, 0 failures
- installer fresh-evidence, upgrade-transaction, and manual-recovery token-FD tests
- `bash -n dist/install.sh`
- `swift build`
- `git diff --check`
- complete-stack exact-head reviews: adversarial 0C/0H/0M; product design 0C/0H/0M

## Draft stack

1. #573 — durable App-track attempt ledger
2. #574 — referral authority and registration gate
3. this PR — secure macOS onboarding and credential custody
4. #576 — permanent join links and operator controls
5. #578 — serving-earned advocacy and audit closure

Review and merge bottom-up. Both rollout flags remain off; merge is not activation.

Supersedes part of #570. Product parent: https://github.com/MalibuAI/malibu/issues/46