### PR TITLE
feat: add durable referral links and operator controls

### DIFF
--- a/phase4-coordinator/cmd/coordinator-cli/main.go
+++ b/phase4-coordinator/cmd/coordinator-cli/main.go
@@ -41,6 +41,12 @@ func main() {
 		err = listPairOTMints(os.Args[2:])
 	case "pre-flip-audit":
 		err = preFlipAudit(os.Args[2:])
+	case "create-seed-referral":
+		err = createSeedReferral(os.Args[2:], os.Getenv, os.Stdout)
+	case "adjust-seed-referral":
+		err = adjustSeedReferral(os.Args[2:], os.Getenv, os.Stdout)
+	case "revoke-referral":
+		err = revokeReferral(os.Args[2:], os.Stdout)
 	default:
 		usage()
 		os.Exit(2)
@@ -613,5 +619,5 @@ func preFlipAuditRun(args []string, stdout io.Writer) (stale bool, err error) {
 }
 
 func usage() {
-	fmt.Fprintln(os.Stderr, "usage: coordinator-cli <issue-token|revoke-token|revoke-bootstrap-identity|list-bootstrap-identities|list-tokens|revoke-and-kick|prune-tokens|list-pair-ot-mints|pre-flip-audit> [flags]")
+	fmt.Fprintln(os.Stderr, "usage: coordinator-cli <issue-token|revoke-token|revoke-bootstrap-identity|list-bootstrap-identities|list-tokens|revoke-and-kick|prune-tokens|list-pair-ot-mints|pre-flip-audit|create-seed-referral|adjust-seed-referral|revoke-referral> [flags]")
 }

--- a/phase4-coordinator/cmd/coordinator-cli/main.go
+++ b/phase4-coordinator/cmd/coordinator-cli/main.go
@@ -45,6 +45,8 @@ func main() {
 		err = createSeedReferral(os.Args[2:], os.Getenv, os.Stdout)
 	case "adjust-seed-referral":
 		err = adjustSeedReferral(os.Args[2:], os.Getenv, os.Stdout)
+	case "replace-seed-referral":
+		err = replaceSeedReferral(os.Args[2:], os.Getenv, os.Stdout)
 	case "revoke-referral":
 		err = revokeReferral(os.Args[2:], os.Stdout)
 	default:
@@ -619,5 +621,5 @@ func preFlipAuditRun(args []string, stdout io.Writer) (stale bool, err error) {
 }
 
 func usage() {
-	fmt.Fprintln(os.Stderr, "usage: coordinator-cli <issue-token|revoke-token|revoke-bootstrap-identity|list-bootstrap-identities|list-tokens|revoke-and-kick|prune-tokens|list-pair-ot-mints|pre-flip-audit|create-seed-referral|adjust-seed-referral|revoke-referral> [flags]")
+	fmt.Fprintln(os.Stderr, "usage: coordinator-cli <issue-token|revoke-token|revoke-bootstrap-identity|list-bootstrap-identities|list-tokens|revoke-and-kick|prune-tokens|list-pair-ot-mints|pre-flip-audit|create-seed-referral|adjust-seed-referral|replace-seed-referral|revoke-referral> [flags]")
 }

--- a/phase4-coordinator/cmd/coordinator-cli/referrals.go
+++ b/phase4-coordinator/cmd/coordinator-cli/referrals.go
@@ -22,7 +22,10 @@ func createSeedReferral(args []string, getenv func(string) string, stdout io.Wri
 	seedID := fs.String("seed-id", "", "opaque seed issuer identifier")
 	maxUses := fs.Int("max-uses", 1, "maximum successful registrations")
 	expiresAt := fs.String("expires-at", "", "optional RFC3339 expiry")
-	setReferralUsage(fs, "create-seed-referral", "coordinator-cli create-seed-referral --db coordinator.db --campaign prebeta --key-id k1 --secret-env MAL_REFERRAL_SECRET --seed-id launch --max-uses 100")
+	apply := fs.Bool("apply", false, "create the seed (default is dry-run preview)")
+	actor := fs.String("actor", "", "operator identity recorded in the audit log (required with --apply)")
+	reason := fs.String("reason", "", "reason recorded in the audit log (required with --apply)")
+	setReferralUsage(fs, "create-seed-referral", "coordinator-cli create-seed-referral --db coordinator.db --campaign prebeta --key-id k1 --secret-env MAL_REFERRAL_SECRET --seed-id launch --max-uses 100 --apply --actor ops@malibu --reason 'open cohort'")
 	if err := fs.Parse(args); err != nil {
 		return referralParseError(err)
 	}
@@ -47,14 +50,25 @@ func createSeedReferral(args []string, getenv func(string) string, stdout io.Wri
 		return err
 	}
 	defer store.Close()
-	code, err := store.CreateSeedReferral(context.Background(), policy, strings.TrimSpace(*seedID), *maxUses, expiry)
+	result, err := store.CreateSeedReferralAudited(context.Background(), policy, strings.TrimSpace(*seedID), *maxUses, expiry, *apply, strings.TrimSpace(*actor), strings.TrimSpace(*reason), time.Now().UTC())
 	if errors.Is(err, auth.ErrReferralSeedExists) {
 		return fmt.Errorf("seed %s already exists; use adjust-seed-referral to change its capacity", strings.TrimSpace(*seedID))
 	}
 	if err != nil {
 		return err
 	}
-	_, err = fmt.Fprintf(stdout, "referral_code=%s\ncampaign=%s\nseed_id=%s\nmax_uses=%d\nstatus=created\n", code, policy.Campaign, strings.TrimSpace(*seedID), *maxUses)
+	mode := "dry-run"
+	if result.Applied {
+		mode = "applied"
+	} else if result.Recovered {
+		mode = "recovered"
+	}
+	if _, err = fmt.Fprintf(stdout, "mode=%s\ncampaign=%s\nseed_id=%s\nmax_uses=%d\n", mode, policy.Campaign, result.SeedID, result.MaxUses); err != nil {
+		return err
+	}
+	if result.Applied || result.Recovered {
+		_, err = fmt.Fprintf(stdout, "referral_code=%s\n", result.Code)
+	}
 	return err
 }
 

--- a/phase4-coordinator/cmd/coordinator-cli/referrals.go
+++ b/phase4-coordinator/cmd/coordinator-cli/referrals.go
@@ -1,0 +1,195 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/augstar/macprovider-coordinator/internal/auth"
+)
+
+func createSeedReferral(args []string, getenv func(string) string, stdout io.Writer) error {
+	fs := newReferralFlagSet("create-seed-referral")
+	dbPath := fs.String("db", "coordinator.db", "path to coordinator SQLite database")
+	campaign := fs.String("campaign", "", "referral campaign identifier")
+	keyID := fs.String("key-id", "", "HMAC key identifier")
+	secretEnv := fs.String("secret-env", "", "environment variable containing the HMAC secret")
+	seedID := fs.String("seed-id", "", "opaque seed issuer identifier")
+	maxUses := fs.Int("max-uses", 1, "maximum successful registrations")
+	expiresAt := fs.String("expires-at", "", "optional RFC3339 expiry")
+	setReferralUsage(fs, "create-seed-referral", "coordinator-cli create-seed-referral --db coordinator.db --campaign prebeta --key-id k1 --secret-env MAL_REFERRAL_SECRET --seed-id launch --max-uses 100")
+	if err := fs.Parse(args); err != nil {
+		return referralParseError(err)
+	}
+	if fs.NArg() != 0 {
+		return fmt.Errorf("unexpected positional arguments")
+	}
+	policy, err := referralCLIPolicy(*campaign, *keyID, *secretEnv, getenv)
+	if err != nil {
+		return err
+	}
+	var expiry *time.Time
+	if raw := strings.TrimSpace(*expiresAt); raw != "" {
+		parsed, err := time.Parse(time.RFC3339, raw)
+		if err != nil {
+			return fmt.Errorf("--expires-at must be RFC3339: %w", err)
+		}
+		parsed = parsed.UTC()
+		expiry = &parsed
+	}
+	store, err := auth.OpenStore(*dbPath)
+	if err != nil {
+		return err
+	}
+	defer store.Close()
+	code, err := store.CreateSeedReferral(context.Background(), policy, strings.TrimSpace(*seedID), *maxUses, expiry)
+	if errors.Is(err, auth.ErrReferralSeedExists) {
+		return fmt.Errorf("seed %s already exists; use adjust-seed-referral to change its capacity", strings.TrimSpace(*seedID))
+	}
+	if err != nil {
+		return err
+	}
+	_, err = fmt.Fprintf(stdout, "referral_code=%s\ncampaign=%s\nseed_id=%s\nmax_uses=%d\nstatus=created\n", code, policy.Campaign, strings.TrimSpace(*seedID), *maxUses)
+	return err
+}
+
+func adjustSeedReferral(args []string, getenv func(string) string, stdout io.Writer) error {
+	fs := newReferralFlagSet("adjust-seed-referral")
+	dbPath := fs.String("db", "coordinator.db", "path to coordinator SQLite database")
+	campaign := fs.String("campaign", "", "referral campaign identifier")
+	keyID := fs.String("key-id", "", "HMAC key identifier")
+	secretEnv := fs.String("secret-env", "", "environment variable containing the HMAC secret")
+	seedID := fs.String("seed-id", "", "opaque seed issuer identifier")
+	maxUses := fs.Int("max-uses", -1, "new maximum successful registrations")
+	apply := fs.Bool("apply", false, "apply the change (default is dry-run preview)")
+	actor := fs.String("actor", "", "operator identity recorded in the audit log (required with --apply)")
+	reason := fs.String("reason", "", "reason recorded in the audit log (required with --apply)")
+	setReferralUsage(fs, "adjust-seed-referral", "coordinator-cli adjust-seed-referral --db coordinator.db --campaign prebeta --key-id k1 --secret-env MAL_REFERRAL_SECRET --seed-id launch --max-uses 250 --apply --actor ops@malibu --reason 'expand cohort'")
+	if err := fs.Parse(args); err != nil {
+		return referralParseError(err)
+	}
+	if fs.NArg() != 0 {
+		return fmt.Errorf("unexpected positional arguments")
+	}
+	if *maxUses < 0 {
+		return fmt.Errorf("--max-uses is required and must be >= 0")
+	}
+	policy, err := referralCLIPolicy(*campaign, *keyID, *secretEnv, getenv)
+	if err != nil {
+		return err
+	}
+	store, err := auth.OpenStore(*dbPath)
+	if err != nil {
+		return err
+	}
+	defer store.Close()
+	result, err := store.AdjustSeedReferral(context.Background(), policy, strings.TrimSpace(*seedID), *maxUses, *apply, strings.TrimSpace(*actor), strings.TrimSpace(*reason), time.Now().UTC())
+	if errors.Is(err, auth.ErrReferralCapacityBelowUsed) {
+		return fmt.Errorf("refusing to set capacity below redeemed uses for seed %s", strings.TrimSpace(*seedID))
+	}
+	if err != nil {
+		return err
+	}
+	mode := "dry-run"
+	if result.Applied {
+		mode = "applied"
+	}
+	_, err = fmt.Fprintf(stdout, "mode=%s\ncampaign=%s\nseed_id=%s\ncurrent_capacity=%d\nnew_capacity=%d\nredeemed=%d\nresulting_remaining=%d\n",
+		mode, policy.Campaign, result.SeedID, result.CurrentCapacity, result.NewCapacity, result.Redeemed, result.ResultingRemaining)
+	return err
+}
+
+func revokeReferral(args []string, stdout io.Writer) error {
+	fs := newReferralFlagSet("revoke-referral")
+	dbPath := fs.String("db", "coordinator.db", "path to coordinator SQLite database")
+	campaign := fs.String("campaign", "", "referral campaign identifier")
+	issuerID := fs.String("issuer-id", "", "seed or provider invite issuer identifier")
+	apply := fs.Bool("apply", false, "apply the revocation (default is a dry-run preview)")
+	actor := fs.String("actor", "", "operator identity recorded in the audit log (required with --apply)")
+	reason := fs.String("reason", "", "reason recorded in the audit log (required with --apply)")
+	expectRedeemed := fs.Int("expect-redeemed", -1, "expected redemption count from the dry-run (required with --apply)")
+	setReferralUsage(fs, "revoke-referral", "coordinator-cli revoke-referral --db coordinator.db --campaign prebeta --issuer-id launch --apply --actor ops@malibu --reason 'abuse report' --expect-redeemed 3")
+	if err := fs.Parse(args); err != nil {
+		return referralParseError(err)
+	}
+	if fs.NArg() != 0 {
+		return fmt.Errorf("unexpected positional arguments")
+	}
+	if *apply && (strings.TrimSpace(*actor) == "" || strings.TrimSpace(*reason) == "") {
+		return fmt.Errorf("--actor and --reason are required with --apply")
+	}
+	var expect *auth.ReferralRevokeExpectation
+	if *apply {
+		if *expectRedeemed < 0 {
+			return fmt.Errorf("--expect-redeemed is required with --apply (run the dry-run first)")
+		}
+		expect = &auth.ReferralRevokeExpectation{Redeemed: *expectRedeemed}
+	}
+	store, err := auth.OpenStore(*dbPath)
+	if err != nil {
+		return err
+	}
+	defer store.Close()
+	result, err := store.RevokeReferralIssuerAudited(context.Background(), *campaign, *issuerID, *apply, strings.TrimSpace(*actor), strings.TrimSpace(*reason), expect, time.Now().UTC())
+	if err != nil {
+		return err
+	}
+	mode := "dry-run"
+	if result.Applied {
+		mode = "applied"
+	}
+	_, err = fmt.Fprintf(stdout, "mode=%s\ncampaign=%s\nissuer_id=%s\ncode_type=%s\nprovider_id=%s\nredeemed=%d\nremaining_capacity=%d\n",
+		mode, result.Campaign, result.IssuerID, result.CodeType, result.ProviderID, result.Redeemed, result.RemainingCapacity)
+	return err
+}
+
+func referralCLIPolicy(campaign, keyID, secretEnv string, getenv func(string) string) (auth.ReferralPolicy, error) {
+	secretEnv = strings.TrimSpace(secretEnv)
+	if secretEnv == "" {
+		return auth.ReferralPolicy{}, fmt.Errorf("--secret-env is required; referral HMAC secrets are not accepted on argv")
+	}
+	secret := getenv(secretEnv)
+	if len(secret) < 32 {
+		return auth.ReferralPolicy{}, fmt.Errorf("referral HMAC secret from %s must be at least 32 bytes", secretEnv)
+	}
+	keyID = strings.TrimSpace(keyID)
+	policy := auth.ReferralPolicy{
+		Campaign:         strings.TrimSpace(campaign),
+		PolicyVersion:    "v1",
+		CurrentKeyID:     keyID,
+		HMACKeys:         map[string]string{keyID: secret},
+		ProviderBaseUses: 1,
+	}
+	if err := policy.Validate(); err != nil {
+		return auth.ReferralPolicy{}, err
+	}
+	return policy, nil
+}
+
+func newReferralFlagSet(name string) *flag.FlagSet {
+	fs := flag.NewFlagSet(name, flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	return fs
+}
+
+func setReferralUsage(fs *flag.FlagSet, name, example string) {
+	fs.Usage = func() {
+		fmt.Fprintf(os.Stderr, "usage: coordinator-cli %s [flags]\n\nflags:\n", name)
+		fs.SetOutput(os.Stderr)
+		fs.PrintDefaults()
+		fs.SetOutput(io.Discard)
+		fmt.Fprintf(os.Stderr, "\nexample:\n  %s\n", example)
+	}
+}
+
+func referralParseError(err error) error {
+	if errors.Is(err, flag.ErrHelp) {
+		return nil
+	}
+	return err
+}

--- a/phase4-coordinator/cmd/coordinator-cli/referrals.go
+++ b/phase4-coordinator/cmd/coordinator-cli/referrals.go
@@ -23,9 +23,10 @@ func createSeedReferral(args []string, getenv func(string) string, stdout io.Wri
 	maxUses := fs.Int("max-uses", 1, "maximum successful registrations")
 	expiresAt := fs.String("expires-at", "", "optional RFC3339 expiry")
 	apply := fs.Bool("apply", false, "create the seed (default is dry-run preview)")
+	operationID := fs.String("operation-id", "", "caller-generated UUID idempotency key (required with --apply)")
 	actor := fs.String("actor", "", "operator identity recorded in the audit log (required with --apply)")
 	reason := fs.String("reason", "", "reason recorded in the audit log (required with --apply)")
-	setReferralUsage(fs, "create-seed-referral", "coordinator-cli create-seed-referral --db coordinator.db --campaign prebeta --key-id k1 --secret-env MAL_REFERRAL_SECRET --seed-id launch --max-uses 100 --apply --actor ops@malibu --reason 'open cohort'")
+	setReferralUsage(fs, "create-seed-referral", "coordinator-cli create-seed-referral --db coordinator.db --campaign prebeta --key-id k1 --secret-env MAL_REFERRAL_SECRET --seed-id launch --max-uses 100 --apply --operation-id 11111111-1111-4111-8111-111111111111 --actor ops@malibu --reason 'open cohort'")
 	if err := fs.Parse(args); err != nil {
 		return referralParseError(err)
 	}
@@ -36,21 +37,19 @@ func createSeedReferral(args []string, getenv func(string) string, stdout io.Wri
 	if err != nil {
 		return err
 	}
-	var expiry *time.Time
-	if raw := strings.TrimSpace(*expiresAt); raw != "" {
-		parsed, err := time.Parse(time.RFC3339, raw)
-		if err != nil {
-			return fmt.Errorf("--expires-at must be RFC3339: %w", err)
-		}
-		parsed = parsed.UTC()
-		expiry = &parsed
+	expiry, err := parseReferralExpiry(*expiresAt)
+	if err != nil {
+		return err
 	}
 	store, err := auth.OpenStore(*dbPath)
 	if err != nil {
 		return err
 	}
 	defer store.Close()
-	result, err := store.CreateSeedReferralAudited(context.Background(), policy, strings.TrimSpace(*seedID), *maxUses, expiry, *apply, strings.TrimSpace(*actor), strings.TrimSpace(*reason), time.Now().UTC())
+	result, err := store.CreateSeedReferralAudited(
+		context.Background(), policy, strings.TrimSpace(*seedID), *maxUses, expiry,
+		*apply, referralAdminOperation(*operationID, *actor, *reason, ""), time.Now().UTC(),
+	)
 	if errors.Is(err, auth.ErrReferralSeedExists) {
 		return fmt.Errorf("seed %s already exists; use adjust-seed-referral to change its capacity", strings.TrimSpace(*seedID))
 	}
@@ -65,6 +64,11 @@ func createSeedReferral(args []string, getenv func(string) string, stdout io.Wri
 	}
 	if _, err = fmt.Fprintf(stdout, "mode=%s\ncampaign=%s\nseed_id=%s\nmax_uses=%d\n", mode, policy.Campaign, result.SeedID, result.MaxUses); err != nil {
 		return err
+	}
+	if result.ExpectedState != "" {
+		if _, err = fmt.Fprintf(stdout, "expected_state=%s\n", result.ExpectedState); err != nil {
+			return err
+		}
 	}
 	if result.Applied || result.Recovered {
 		_, err = fmt.Fprintf(stdout, "referral_code=%s\n", result.Code)
@@ -81,9 +85,11 @@ func adjustSeedReferral(args []string, getenv func(string) string, stdout io.Wri
 	seedID := fs.String("seed-id", "", "opaque seed issuer identifier")
 	maxUses := fs.Int("max-uses", -1, "new maximum successful registrations")
 	apply := fs.Bool("apply", false, "apply the change (default is dry-run preview)")
+	operationID := fs.String("operation-id", "", "caller-generated UUID idempotency key (required with --apply)")
+	expectState := fs.String("expect-state", "", "opaque expected-state digest from dry-run (required with --apply)")
 	actor := fs.String("actor", "", "operator identity recorded in the audit log (required with --apply)")
 	reason := fs.String("reason", "", "reason recorded in the audit log (required with --apply)")
-	setReferralUsage(fs, "adjust-seed-referral", "coordinator-cli adjust-seed-referral --db coordinator.db --campaign prebeta --key-id k1 --secret-env MAL_REFERRAL_SECRET --seed-id launch --max-uses 250 --apply --actor ops@malibu --reason 'expand cohort'")
+	setReferralUsage(fs, "adjust-seed-referral", "coordinator-cli adjust-seed-referral --db coordinator.db --campaign prebeta --key-id k1 --secret-env MAL_REFERRAL_SECRET --seed-id launch --max-uses 250 --apply --operation-id 22222222-2222-4222-8222-222222222222 --expect-state <dry-run-digest> --actor ops@malibu --reason 'expand cohort'")
 	if err := fs.Parse(args); err != nil {
 		return referralParseError(err)
 	}
@@ -102,7 +108,10 @@ func adjustSeedReferral(args []string, getenv func(string) string, stdout io.Wri
 		return err
 	}
 	defer store.Close()
-	result, err := store.AdjustSeedReferral(context.Background(), policy, strings.TrimSpace(*seedID), *maxUses, *apply, strings.TrimSpace(*actor), strings.TrimSpace(*reason), time.Now().UTC())
+	result, err := store.AdjustSeedReferral(
+		context.Background(), policy, strings.TrimSpace(*seedID), *maxUses, *apply,
+		referralAdminOperation(*operationID, *actor, *reason, *expectState), time.Now().UTC(),
+	)
 	if errors.Is(err, auth.ErrReferralCapacityBelowUsed) {
 		return fmt.Errorf("refusing to set capacity below redeemed uses for seed %s", strings.TrimSpace(*seedID))
 	}
@@ -112,9 +121,12 @@ func adjustSeedReferral(args []string, getenv func(string) string, stdout io.Wri
 	mode := "dry-run"
 	if result.Applied {
 		mode = "applied"
+	} else if result.Recovered {
+		mode = "recovered"
 	}
-	_, err = fmt.Fprintf(stdout, "mode=%s\ncampaign=%s\nseed_id=%s\ncurrent_capacity=%d\nnew_capacity=%d\nredeemed=%d\nresulting_remaining=%d\n",
-		mode, policy.Campaign, result.SeedID, result.CurrentCapacity, result.NewCapacity, result.Redeemed, result.ResultingRemaining)
+	_, err = fmt.Fprintf(stdout, "mode=%s\ncampaign=%s\nseed_id=%s\ncurrent_capacity=%d\ncurrent_bonus_capacity=%d\nnew_capacity=%d\nredeemed=%d\nresulting_remaining=%d\nexpected_state=%s\n",
+		mode, policy.Campaign, result.SeedID, result.CurrentCapacity, result.CurrentBonusCapacity,
+		result.NewCapacity, result.Redeemed, result.ResultingRemaining, result.ExpectedState)
 	return err
 }
 
@@ -124,10 +136,11 @@ func revokeReferral(args []string, stdout io.Writer) error {
 	campaign := fs.String("campaign", "", "referral campaign identifier")
 	issuerID := fs.String("issuer-id", "", "seed or provider invite issuer identifier")
 	apply := fs.Bool("apply", false, "apply the revocation (default is a dry-run preview)")
+	operationID := fs.String("operation-id", "", "caller-generated UUID idempotency key (required with --apply)")
 	actor := fs.String("actor", "", "operator identity recorded in the audit log (required with --apply)")
 	reason := fs.String("reason", "", "reason recorded in the audit log (required with --apply)")
-	expectRedeemed := fs.Int("expect-redeemed", -1, "expected redemption count from the dry-run (required with --apply)")
-	setReferralUsage(fs, "revoke-referral", "coordinator-cli revoke-referral --db coordinator.db --campaign prebeta --issuer-id launch --apply --actor ops@malibu --reason 'abuse report' --expect-redeemed 3")
+	expectState := fs.String("expect-state", "", "opaque expected-state digest from dry-run (required with --apply)")
+	setReferralUsage(fs, "revoke-referral", "coordinator-cli revoke-referral --db coordinator.db --campaign prebeta --issuer-id launch --apply --operation-id 33333333-3333-4333-8333-333333333333 --expect-state <dry-run-digest> --actor ops@malibu --reason 'abuse report'")
 	if err := fs.Parse(args); err != nil {
 		return referralParseError(err)
 	}
@@ -137,28 +150,88 @@ func revokeReferral(args []string, stdout io.Writer) error {
 	if *apply && (strings.TrimSpace(*actor) == "" || strings.TrimSpace(*reason) == "") {
 		return fmt.Errorf("--actor and --reason are required with --apply")
 	}
-	var expect *auth.ReferralRevokeExpectation
-	if *apply {
-		if *expectRedeemed < 0 {
-			return fmt.Errorf("--expect-redeemed is required with --apply (run the dry-run first)")
-		}
-		expect = &auth.ReferralRevokeExpectation{Redeemed: *expectRedeemed}
-	}
 	store, err := auth.OpenStore(*dbPath)
 	if err != nil {
 		return err
 	}
 	defer store.Close()
-	result, err := store.RevokeReferralIssuerAudited(context.Background(), *campaign, *issuerID, *apply, strings.TrimSpace(*actor), strings.TrimSpace(*reason), expect, time.Now().UTC())
+	result, err := store.RevokeReferralIssuerAudited(
+		context.Background(), *campaign, *issuerID, *apply,
+		referralAdminOperation(*operationID, *actor, *reason, *expectState), time.Now().UTC(),
+	)
 	if err != nil {
 		return err
 	}
 	mode := "dry-run"
 	if result.Applied {
 		mode = "applied"
+	} else if result.Recovered {
+		mode = "recovered"
 	}
-	_, err = fmt.Fprintf(stdout, "mode=%s\ncampaign=%s\nissuer_id=%s\ncode_type=%s\nprovider_id=%s\nredeemed=%d\nremaining_capacity=%d\n",
-		mode, result.Campaign, result.IssuerID, result.CodeType, result.ProviderID, result.Redeemed, result.RemainingCapacity)
+	_, err = fmt.Fprintf(stdout, "mode=%s\ncampaign=%s\nissuer_id=%s\ncode_type=%s\nprovider_id=%s\nbase_capacity=%d\nbonus_capacity=%d\nredeemed=%d\nremaining_capacity=%d\nexpected_state=%s\n",
+		mode, result.Campaign, result.IssuerID, result.CodeType, result.ProviderID,
+		result.BaseCapacity, result.BonusCapacity, result.Redeemed,
+		result.RemainingCapacity, result.ExpectedState)
+	return err
+}
+
+func replaceSeedReferral(args []string, getenv func(string) string, stdout io.Writer) error {
+	fs := newReferralFlagSet("replace-seed-referral")
+	dbPath := fs.String("db", "coordinator.db", "path to coordinator SQLite database")
+	campaign := fs.String("campaign", "", "referral campaign identifier")
+	keyID := fs.String("key-id", "", "HMAC key identifier")
+	secretEnv := fs.String("secret-env", "", "environment variable containing the HMAC secret")
+	oldSeedID := fs.String("old-seed-id", "", "active seed issuer to retire")
+	newSeedID := fs.String("new-seed-id", "", "new seed issuer identifier")
+	maxUses := fs.Int("max-uses", 1, "maximum successful registrations for the replacement")
+	expiresAt := fs.String("expires-at", "", "optional RFC3339 expiry for the replacement")
+	apply := fs.Bool("apply", false, "apply the atomic replacement (default is dry-run preview)")
+	operationID := fs.String("operation-id", "", "caller-generated UUID idempotency key (required with --apply)")
+	expectState := fs.String("expect-state", "", "opaque expected-state digest from dry-run (required with --apply)")
+	actor := fs.String("actor", "", "operator identity recorded in the audit log (required with --apply)")
+	reason := fs.String("reason", "", "reason recorded in the audit log (required with --apply)")
+	setReferralUsage(fs, "replace-seed-referral", "coordinator-cli replace-seed-referral --db coordinator.db --campaign prebeta --key-id k1 --secret-env MAL_REFERRAL_SECRET --old-seed-id launch --new-seed-id launch2 --max-uses 100 --apply --operation-id 44444444-4444-4444-8444-444444444444 --expect-state <dry-run-digest> --actor ops@malibu --reason 'rotate invite'")
+	if err := fs.Parse(args); err != nil {
+		return referralParseError(err)
+	}
+	if fs.NArg() != 0 {
+		return fmt.Errorf("unexpected positional arguments")
+	}
+	policy, err := referralCLIPolicy(*campaign, *keyID, *secretEnv, getenv)
+	if err != nil {
+		return err
+	}
+	expiry, err := parseReferralExpiry(*expiresAt)
+	if err != nil {
+		return err
+	}
+	store, err := auth.OpenStore(*dbPath)
+	if err != nil {
+		return err
+	}
+	defer store.Close()
+	result, err := store.ReplaceSeedReferralAudited(
+		context.Background(), policy, *oldSeedID, *newSeedID, *maxUses, expiry,
+		*apply, referralAdminOperation(*operationID, *actor, *reason, *expectState), time.Now().UTC(),
+	)
+	if err != nil {
+		return err
+	}
+	mode := "dry-run"
+	if result.Applied {
+		mode = "applied"
+	} else if result.Recovered {
+		mode = "recovered"
+	}
+	if _, err := fmt.Fprintf(stdout, "mode=%s\ncampaign=%s\nold_seed_id=%s\nnew_seed_id=%s\nold_base_capacity=%d\nold_bonus_capacity=%d\nold_redeemed=%d\nold_remaining_capacity=%d\nnew_max_uses=%d\nexpected_state=%s\n",
+		mode, result.Campaign, result.OldSeedID, result.NewSeedID,
+		result.OldBaseCapacity, result.OldBonusCapacity, result.OldRedeemed,
+		result.OldRemainingCapacity, result.NewMaxUses, result.ExpectedState); err != nil {
+		return err
+	}
+	if result.Applied || result.Recovered {
+		_, err = fmt.Fprintf(stdout, "referral_code=%s\n", result.Code)
+	}
 	return err
 }
 
@@ -183,6 +256,29 @@ func referralCLIPolicy(campaign, keyID, secretEnv string, getenv func(string) st
 		return auth.ReferralPolicy{}, err
 	}
 	return policy, nil
+}
+
+func referralAdminOperation(operationID, actor, reason, expectedState string) auth.ReferralAdminOperation {
+	return auth.ReferralAdminOperation{
+		OperationID:   strings.TrimSpace(operationID),
+		Actor:         strings.TrimSpace(actor),
+		UnixUID:       os.Geteuid(),
+		Reason:        strings.TrimSpace(reason),
+		ExpectedState: strings.TrimSpace(expectedState),
+	}
+}
+
+func parseReferralExpiry(raw string) (*time.Time, error) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return nil, nil
+	}
+	parsed, err := time.Parse(time.RFC3339, raw)
+	if err != nil {
+		return nil, fmt.Errorf("--expires-at must be RFC3339: %w", err)
+	}
+	parsed = parsed.UTC()
+	return &parsed, nil
 }
 
 func newReferralFlagSet(name string) *flag.FlagSet {

--- a/phase4-coordinator/cmd/coordinator-cli/referrals_test.go
+++ b/phase4-coordinator/cmd/coordinator-cli/referrals_test.go
@@ -20,11 +20,19 @@ func TestReferralCommandsCreateAdjustAndRevoke(t *testing.T) {
 	}
 	base := []string{"--db", dbPath, "--campaign", "prebeta_test", "--key-id", "k1", "--secret-env", "REFERRAL_SECRET", "--seed-id", "launch"}
 	var created bytes.Buffer
-	if err := createSeedReferral(append(append([]string{}, base...), "--max-uses", "2"), getenv, &created); err != nil {
+	createArgs := append(append([]string{}, base...), "--max-uses", "2", "--apply", "--actor", "release", "--reason", "open cohort")
+	if err := createSeedReferral(createArgs, getenv, &created); err != nil {
 		t.Fatal(err)
 	}
 	if !strings.Contains(created.String(), "referral_code=MAL1-S-k1-launch-") {
 		t.Fatalf("create output=%s", created.String())
+	}
+	var recovered bytes.Buffer
+	if err := createSeedReferral(createArgs, getenv, &recovered); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(recovered.String(), "mode=recovered") || !strings.Contains(recovered.String(), "referral_code=MAL1-S-k1-launch-") {
+		t.Fatalf("response-loss recovery output=%s", recovered.String())
 	}
 	if err := createSeedReferral(base, getenv, &bytes.Buffer{}); err == nil || !strings.Contains(err.Error(), "adjust-seed-referral") {
 		t.Fatalf("duplicate create error=%v", err)

--- a/phase4-coordinator/cmd/coordinator-cli/referrals_test.go
+++ b/phase4-coordinator/cmd/coordinator-cli/referrals_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bytes"
 	"context"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -20,7 +21,7 @@ func TestReferralCommandsCreateAdjustAndRevoke(t *testing.T) {
 	}
 	base := []string{"--db", dbPath, "--campaign", "prebeta_test", "--key-id", "k1", "--secret-env", "REFERRAL_SECRET", "--seed-id", "launch"}
 	var created bytes.Buffer
-	createArgs := append(append([]string{}, base...), "--max-uses", "2", "--apply", "--actor", "release", "--reason", "open cohort")
+	createArgs := append(append([]string{}, base...), "--max-uses", "2", "--apply", "--operation-id", "11111111-1111-4111-8111-111111111111", "--actor", "release", "--reason", "open cohort")
 	if err := createSeedReferral(createArgs, getenv, &created); err != nil {
 		t.Fatal(err)
 	}
@@ -38,13 +39,26 @@ func TestReferralCommandsCreateAdjustAndRevoke(t *testing.T) {
 		t.Fatalf("duplicate create error=%v", err)
 	}
 
+	var adjustPreview bytes.Buffer
+	adjustPreviewArgs := append(append([]string{}, base...), "--max-uses", "4")
+	if err := adjustSeedReferral(adjustPreviewArgs, getenv, &adjustPreview); err != nil {
+		t.Fatal(err)
+	}
+	adjustExpected := referralOutputValue(t, adjustPreview.String(), "expected_state")
 	var adjusted bytes.Buffer
-	adjustArgs := append(append([]string{}, base...), "--max-uses", "4", "--apply", "--actor", "ops", "--reason", "expand")
+	adjustArgs := append(append([]string{}, adjustPreviewArgs...), "--apply", "--operation-id", "22222222-2222-4222-8222-222222222222", "--expect-state", adjustExpected, "--actor", "ops", "--reason", "expand")
 	if err := adjustSeedReferral(adjustArgs, getenv, &adjusted); err != nil {
 		t.Fatal(err)
 	}
 	if !strings.Contains(adjusted.String(), "mode=applied") || strings.Contains(adjusted.String(), "reserved=") {
 		t.Fatalf("adjust output=%s", adjusted.String())
+	}
+	var adjustRecovered bytes.Buffer
+	if err := adjustSeedReferral(adjustArgs, getenv, &adjustRecovered); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(adjustRecovered.String(), "mode=recovered") {
+		t.Fatalf("adjust recovery output=%s", adjustRecovered.String())
 	}
 
 	store, err := auth.OpenStore(dbPath)
@@ -52,7 +66,7 @@ func TestReferralCommandsCreateAdjustAndRevoke(t *testing.T) {
 		t.Fatal(err)
 	}
 	var auditRows int
-	if err := store.DB().QueryRowContext(context.Background(), `SELECT COUNT(1) FROM referral_admin_audit WHERE actor = 'ops'`).Scan(&auditRows); err != nil {
+	if err := store.DB().QueryRowContext(context.Background(), `SELECT COUNT(1) FROM referral_admin_audit WHERE actor = 'ops' AND unix_uid = ?`, os.Geteuid()).Scan(&auditRows); err != nil {
 		t.Fatal(err)
 	}
 	store.Close()
@@ -67,8 +81,47 @@ func TestReferralCommandsCreateAdjustAndRevoke(t *testing.T) {
 	if !strings.Contains(preview.String(), "redeemed=0") || strings.Contains(preview.String(), "reservation") {
 		t.Fatalf("revoke preview=%s", preview.String())
 	}
-	if err := revokeReferral([]string{"--db", dbPath, "--campaign", "prebeta_test", "--issuer-id", "launch", "--apply", "--actor", "ops", "--reason", "retire", "--expect-redeemed", "0"}, &bytes.Buffer{}); err != nil {
+	revokeExpected := referralOutputValue(t, preview.String(), "expected_state")
+	revokeArgs := []string{"--db", dbPath, "--campaign", "prebeta_test", "--issuer-id", "launch", "--apply", "--operation-id", "33333333-3333-4333-8333-333333333333", "--expect-state", revokeExpected, "--actor", "ops", "--reason", "retire"}
+	if err := revokeReferral(revokeArgs, &bytes.Buffer{}); err != nil {
 		t.Fatal(err)
+	}
+	var revokeRecovered bytes.Buffer
+	if err := revokeReferral(revokeArgs, &revokeRecovered); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(revokeRecovered.String(), "mode=recovered") {
+		t.Fatalf("revoke recovery output=%s", revokeRecovered.String())
+	}
+}
+
+func TestReferralCommandReplacesSeedAtomicallyAndRecovers(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "coordinator.db")
+	getenv := func(string) string { return strings.Repeat("s", 32) }
+	policyArgs := []string{"--db", dbPath, "--campaign", "prebeta_test", "--key-id", "k1", "--secret-env", "REFERRAL_SECRET"}
+	if err := createSeedReferral(append(append([]string{}, policyArgs...), "--seed-id", "launch", "--max-uses", "2", "--apply", "--operation-id", "44444444-4444-4444-8444-444444444444", "--actor", "release", "--reason", "open"), getenv, &bytes.Buffer{}); err != nil {
+		t.Fatal(err)
+	}
+	replaceBase := append(append([]string{}, policyArgs...), "--old-seed-id", "launch", "--new-seed-id", "launch2", "--max-uses", "3")
+	var preview bytes.Buffer
+	if err := replaceSeedReferral(replaceBase, getenv, &preview); err != nil {
+		t.Fatal(err)
+	}
+	expected := referralOutputValue(t, preview.String(), "expected_state")
+	applyArgs := append(append([]string{}, replaceBase...), "--apply", "--operation-id", "55555555-5555-4555-8555-555555555555", "--expect-state", expected, "--actor", "ops", "--reason", "rotate")
+	var applied bytes.Buffer
+	if err := replaceSeedReferral(applyArgs, getenv, &applied); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(applied.String(), "mode=applied") || !strings.Contains(applied.String(), "referral_code=MAL1-S-k1-launch2-") {
+		t.Fatalf("replace output=%s", applied.String())
+	}
+	var recovered bytes.Buffer
+	if err := replaceSeedReferral(applyArgs, getenv, &recovered); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(recovered.String(), "mode=recovered") || !strings.Contains(recovered.String(), "referral_code=MAL1-S-k1-launch2-") {
+		t.Fatalf("replace recovery output=%s", recovered.String())
 	}
 }
 
@@ -77,4 +130,20 @@ func TestReferralCommandsNeverAcceptSecretOnArgv(t *testing.T) {
 	if err == nil || !strings.Contains(err.Error(), "--secret-env is required") {
 		t.Fatalf("error=%v", err)
 	}
+}
+
+func referralOutputValue(t *testing.T, output, key string) string {
+	t.Helper()
+	prefix := key + "="
+	for _, line := range strings.Split(output, "\n") {
+		if strings.HasPrefix(line, prefix) {
+			value := strings.TrimPrefix(line, prefix)
+			if value == "" {
+				t.Fatalf("%s is empty in output %q", key, output)
+			}
+			return value
+		}
+	}
+	t.Fatalf("%s missing from output %q", key, output)
+	return ""
 }

--- a/phase4-coordinator/cmd/coordinator-cli/referrals_test.go
+++ b/phase4-coordinator/cmd/coordinator-cli/referrals_test.go
@@ -1,0 +1,72 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/augstar/macprovider-coordinator/internal/auth"
+)
+
+func TestReferralCommandsCreateAdjustAndRevoke(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "coordinator.db")
+	getenv := func(key string) string {
+		if key == "REFERRAL_SECRET" {
+			return strings.Repeat("s", 32)
+		}
+		return ""
+	}
+	base := []string{"--db", dbPath, "--campaign", "prebeta_test", "--key-id", "k1", "--secret-env", "REFERRAL_SECRET", "--seed-id", "launch"}
+	var created bytes.Buffer
+	if err := createSeedReferral(append(append([]string{}, base...), "--max-uses", "2"), getenv, &created); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(created.String(), "referral_code=MAL1-S-k1-launch-") {
+		t.Fatalf("create output=%s", created.String())
+	}
+	if err := createSeedReferral(base, getenv, &bytes.Buffer{}); err == nil || !strings.Contains(err.Error(), "adjust-seed-referral") {
+		t.Fatalf("duplicate create error=%v", err)
+	}
+
+	var adjusted bytes.Buffer
+	adjustArgs := append(append([]string{}, base...), "--max-uses", "4", "--apply", "--actor", "ops", "--reason", "expand")
+	if err := adjustSeedReferral(adjustArgs, getenv, &adjusted); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(adjusted.String(), "mode=applied") || strings.Contains(adjusted.String(), "reserved=") {
+		t.Fatalf("adjust output=%s", adjusted.String())
+	}
+
+	store, err := auth.OpenStore(dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var auditRows int
+	if err := store.DB().QueryRowContext(context.Background(), `SELECT COUNT(1) FROM referral_admin_audit WHERE actor = 'ops'`).Scan(&auditRows); err != nil {
+		t.Fatal(err)
+	}
+	store.Close()
+	if auditRows != 1 {
+		t.Fatalf("audit rows=%d", auditRows)
+	}
+
+	var preview bytes.Buffer
+	if err := revokeReferral([]string{"--db", dbPath, "--campaign", "prebeta_test", "--issuer-id", "launch"}, &preview); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(preview.String(), "redeemed=0") || strings.Contains(preview.String(), "reservation") {
+		t.Fatalf("revoke preview=%s", preview.String())
+	}
+	if err := revokeReferral([]string{"--db", dbPath, "--campaign", "prebeta_test", "--issuer-id", "launch", "--apply", "--actor", "ops", "--reason", "retire", "--expect-redeemed", "0"}, &bytes.Buffer{}); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestReferralCommandsNeverAcceptSecretOnArgv(t *testing.T) {
+	err := createSeedReferral([]string{"--campaign", "prebeta_test", "--key-id", "k1", "--seed-id", "launch"}, func(string) string { return "" }, &bytes.Buffer{})
+	if err == nil || !strings.Contains(err.Error(), "--secret-env is required") {
+		t.Fatalf("error=%v", err)
+	}
+}

--- a/phase4-coordinator/cmd/coordinator/main.go
+++ b/phase4-coordinator/cmd/coordinator/main.go
@@ -933,9 +933,9 @@ func main() {
 		enrollHandler,
 		malibuAccrualHandler(cfg, tokenStore, rewardsDB, rewards.NewPoolHeartbeatBridge(wsServer.PoolSnapshot)),
 	)
+	trustedReferralProxies := mustParseTrustedProxies(cfg, logger)
 	var referralValidationHandler http.HandlerFunc
 	if cfg.Referrals.EnablePublicValidation {
-		trustedReferralProxies := mustParseTrustedProxies(cfg, logger)
 		referralValidation := &referralapi.ValidationHandler{
 			Store:         tokenStore,
 			Policy:        referralPolicy,
@@ -947,7 +947,20 @@ func main() {
 		}
 		referralValidationHandler = referralValidation.ServeHTTP
 	}
-	buyerHandler = withReferralValidation(buyerHandler, referralValidationHandler)
+	referralJoin := &referralapi.JoinHandler{
+		Store:            tokenStore,
+		Policy:           referralPolicy,
+		PublicLimiter:    referralapi.NewBoundedLimiter(30, time.Minute, 4096),
+		ValidateSlots:    make(chan struct{}, 4),
+		RequestAccessURL: cfg.Referrals.RequestAccessURL,
+		SourceIP: func(r *http.Request) string {
+			return onboarding.ClientIP(r, trustedReferralProxies)
+		},
+		ErrorLogger: func(op string, err error) {
+			logger.Error().Err(err).Str("op", op).Msg("referral join failed")
+		},
+	}
+	buyerHandler = withReferralValidation(buyerHandler, referralValidationHandler, referralJoin.ServeHTTP)
 
 	providerHTTP := newHTTPServer(providerAddr, providerMux)
 	buyerHTTP := newHTTPServer(buyerAddr, buyerHandler)
@@ -1333,12 +1346,18 @@ func buyerHandlerWithOptionalProviderEndpoints(base http.Handler, enabled bool, 
 	return mux
 }
 
-func withReferralValidation(base http.Handler, validate http.HandlerFunc) http.Handler {
-	if validate == nil {
+func withReferralValidation(base http.Handler, validate http.HandlerFunc, join ...http.HandlerFunc) http.Handler {
+	hasJoin := len(join) > 0 && join[0] != nil
+	if validate == nil && !hasJoin {
 		return base
 	}
 	mux := http.NewServeMux()
-	mux.HandleFunc("/v1/referrals/validate", validate)
+	if validate != nil {
+		mux.HandleFunc("/v1/referrals/validate", validate)
+	}
+	if hasJoin {
+		mux.HandleFunc("/j/", join[0])
+	}
 	mux.Handle("/", base)
 	return mux
 }

--- a/phase4-coordinator/cmd/coordinator/main.go
+++ b/phase4-coordinator/cmd/coordinator/main.go
@@ -939,7 +939,7 @@ func main() {
 	}
 	var referralValidationHandler http.HandlerFunc
 	if cfg.Referrals.EnablePublicValidation {
-		referralValidation := newReferralValidationHandler(tokenStore, referralPolicy, trustedReferralProxies, cfg.Referrals.RequestAccessURL)
+		referralValidation := newReferralValidationHandler(tokenStore, referralPolicy, trustedReferralProxies, cfg.Referrals.RequestAccessURL, metricsHandle)
 		referralValidationHandler = referralValidation.ServeHTTP
 	}
 	var referralJoinHandler http.HandlerFunc
@@ -1361,13 +1361,14 @@ func withReferralValidation(base http.Handler, validate, join http.HandlerFunc) 
 	return mux
 }
 
-func newReferralValidationHandler(store referralapi.ValidationStore, policy auth.ReferralPolicy, trustedProxies []netip.Prefix, requestAccessURL string) *referralapi.ValidationHandler {
+func newReferralValidationHandler(store referralapi.ValidationStore, policy auth.ReferralPolicy, trustedProxies []netip.Prefix, requestAccessURL string, metrics referralapi.ReferralMetrics) *referralapi.ValidationHandler {
 	return &referralapi.ValidationHandler{
 		Store:            store,
 		Policy:           policy,
 		PublicLimiter:    referralapi.NewBoundedLimiter(30, time.Minute, 4096),
 		ValidateSlots:    make(chan struct{}, 4),
 		RequestAccessURL: strings.TrimSpace(requestAccessURL),
+		Metrics:          metrics,
 		SourceIP: func(r *http.Request) string {
 			return onboarding.ClientIP(r, trustedProxies)
 		},

--- a/phase4-coordinator/cmd/coordinator/main.go
+++ b/phase4-coordinator/cmd/coordinator/main.go
@@ -933,34 +933,34 @@ func main() {
 		enrollHandler,
 		malibuAccrualHandler(cfg, tokenStore, rewardsDB, rewards.NewPoolHeartbeatBridge(wsServer.PoolSnapshot)),
 	)
-	trustedReferralProxies := mustParseTrustedProxies(cfg, logger)
+	var trustedReferralProxies []netip.Prefix
+	if cfg.Referrals.EnablePublicValidation || cfg.Referrals.EnableJoinLinks {
+		trustedReferralProxies = mustParseTrustedProxies(cfg, logger)
+	}
 	var referralValidationHandler http.HandlerFunc
 	if cfg.Referrals.EnablePublicValidation {
-		referralValidation := &referralapi.ValidationHandler{
-			Store:         tokenStore,
-			Policy:        referralPolicy,
-			PublicLimiter: referralapi.NewBoundedLimiter(30, time.Minute, 4096),
-			ValidateSlots: make(chan struct{}, 4),
+		referralValidation := newReferralValidationHandler(tokenStore, referralPolicy, trustedReferralProxies, cfg.Referrals.RequestAccessURL)
+		referralValidationHandler = referralValidation.ServeHTTP
+	}
+	var referralJoinHandler http.HandlerFunc
+	if cfg.Referrals.EnableJoinLinks {
+		referralJoin := &referralapi.JoinHandler{
+			Store:            tokenStore,
+			Policy:           referralPolicy,
+			PublicLimiter:    referralapi.NewBoundedLimiter(30, time.Minute, 4096),
+			ValidateSlots:    make(chan struct{}, 4),
+			RequestAccessURL: cfg.Referrals.RequestAccessURL,
+			DownloadURL:      cfg.Referrals.JoinDownloadURL,
 			SourceIP: func(r *http.Request) string {
 				return onboarding.ClientIP(r, trustedReferralProxies)
 			},
+			ErrorLogger: func(op string, err error) {
+				logger.Error().Err(err).Str("op", op).Msg("referral join failed")
+			},
 		}
-		referralValidationHandler = referralValidation.ServeHTTP
+		referralJoinHandler = referralJoin.ServeHTTP
 	}
-	referralJoin := &referralapi.JoinHandler{
-		Store:            tokenStore,
-		Policy:           referralPolicy,
-		PublicLimiter:    referralapi.NewBoundedLimiter(30, time.Minute, 4096),
-		ValidateSlots:    make(chan struct{}, 4),
-		RequestAccessURL: cfg.Referrals.RequestAccessURL,
-		SourceIP: func(r *http.Request) string {
-			return onboarding.ClientIP(r, trustedReferralProxies)
-		},
-		ErrorLogger: func(op string, err error) {
-			logger.Error().Err(err).Str("op", op).Msg("referral join failed")
-		},
-	}
-	buyerHandler = withReferralValidation(buyerHandler, referralValidationHandler, referralJoin.ServeHTTP)
+	buyerHandler = withReferralValidation(buyerHandler, referralValidationHandler, referralJoinHandler)
 
 	providerHTTP := newHTTPServer(providerAddr, providerMux)
 	buyerHTTP := newHTTPServer(buyerAddr, buyerHandler)
@@ -1346,20 +1346,32 @@ func buyerHandlerWithOptionalProviderEndpoints(base http.Handler, enabled bool, 
 	return mux
 }
 
-func withReferralValidation(base http.Handler, validate http.HandlerFunc, join ...http.HandlerFunc) http.Handler {
-	hasJoin := len(join) > 0 && join[0] != nil
-	if validate == nil && !hasJoin {
+func withReferralValidation(base http.Handler, validate, join http.HandlerFunc) http.Handler {
+	if validate == nil && join == nil {
 		return base
 	}
 	mux := http.NewServeMux()
 	if validate != nil {
 		mux.HandleFunc("/v1/referrals/validate", validate)
 	}
-	if hasJoin {
-		mux.HandleFunc("/j/", join[0])
+	if join != nil {
+		mux.HandleFunc("/j/", join)
 	}
 	mux.Handle("/", base)
 	return mux
+}
+
+func newReferralValidationHandler(store referralapi.ValidationStore, policy auth.ReferralPolicy, trustedProxies []netip.Prefix, requestAccessURL string) *referralapi.ValidationHandler {
+	return &referralapi.ValidationHandler{
+		Store:            store,
+		Policy:           policy,
+		PublicLimiter:    referralapi.NewBoundedLimiter(30, time.Minute, 4096),
+		ValidateSlots:    make(chan struct{}, 4),
+		RequestAccessURL: strings.TrimSpace(requestAccessURL),
+		SourceIP: func(r *http.Request) string {
+			return onboarding.ClientIP(r, trustedProxies)
+		},
+	}
 }
 
 // buildEnrollHandler constructs the MDM enrollment handler for POST /v1/enroll.

--- a/phase4-coordinator/cmd/coordinator/main_test.go
+++ b/phase4-coordinator/cmd/coordinator/main_test.go
@@ -126,7 +126,7 @@ func TestWithReferralValidationMountsJoinRouteOnlyWhenEnabled(t *testing.T) {
 }
 
 func TestNewReferralValidationHandlerWiresOperatorRecoveryURL(t *testing.T) {
-	handler := newReferralValidationHandler(nil, auth.ReferralPolicy{}, nil, "  https://access.example.test/waitlist  ")
+	handler := newReferralValidationHandler(nil, auth.ReferralPolicy{}, nil, "  https://access.example.test/waitlist  ", nil)
 	if handler.RequestAccessURL != "https://access.example.test/waitlist" {
 		t.Fatalf("request access URL=%q", handler.RequestAccessURL)
 	}

--- a/phase4-coordinator/cmd/coordinator/main_test.go
+++ b/phase4-coordinator/cmd/coordinator/main_test.go
@@ -16,6 +16,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/augstar/macprovider-coordinator/internal/auth"
 	"github.com/augstar/macprovider-coordinator/internal/buyer"
 	"github.com/augstar/macprovider-coordinator/internal/config"
 	"github.com/augstar/macprovider-coordinator/internal/pool"
@@ -46,14 +47,14 @@ func TestNewHTTPServerAppliesTimeouts(t *testing.T) {
 
 func TestWithReferralValidationMountsOnlyValidationRoute(t *testing.T) {
 	base := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(http.StatusNoContent) })
-	disabled := withReferralValidation(base, nil)
+	disabled := withReferralValidation(base, nil, nil)
 	disabledResponse := httptest.NewRecorder()
 	disabled.ServeHTTP(disabledResponse, httptest.NewRequest(http.MethodPost, "/v1/referrals/validate", nil))
 	if disabledResponse.Code != http.StatusNoContent {
 		t.Fatalf("disabled validation route unexpectedly mounted: status=%d", disabledResponse.Code)
 	}
 
-	handler := withReferralValidation(base, func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(http.StatusOK) })
+	handler := withReferralValidation(base, func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(http.StatusOK) }, nil)
 
 	response := httptest.NewRecorder()
 	handler.ServeHTTP(response, httptest.NewRequest(http.MethodPost, "/v1/referrals/validate", nil))
@@ -102,8 +103,15 @@ func (f appTrackReferralMintReconcilerFunc) ReconcilePendingAppTrackReferralMint
 	return f(ctx)
 }
 
-func TestWithReferralValidationMountsPermanentJoinRoute(t *testing.T) {
+func TestWithReferralValidationMountsJoinRouteOnlyWhenEnabled(t *testing.T) {
 	base := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(http.StatusNoContent) })
+	disabled := withReferralValidation(base, nil, nil)
+	disabledResponse := httptest.NewRecorder()
+	disabled.ServeHTTP(disabledResponse, httptest.NewRequest(http.MethodGet, "/j/invite", nil))
+	if disabledResponse.Code != http.StatusNoContent {
+		t.Fatalf("disabled join route unexpectedly mounted: status=%d", disabledResponse.Code)
+	}
+
 	handler := withReferralValidation(
 		base,
 		nil,
@@ -114,6 +122,16 @@ func TestWithReferralValidationMountsPermanentJoinRoute(t *testing.T) {
 	handler.ServeHTTP(response, httptest.NewRequest(http.MethodGet, "/j/invite", nil))
 	if response.Code != http.StatusAccepted {
 		t.Fatalf("join status=%d", response.Code)
+	}
+}
+
+func TestNewReferralValidationHandlerWiresOperatorRecoveryURL(t *testing.T) {
+	handler := newReferralValidationHandler(nil, auth.ReferralPolicy{}, nil, "  https://access.example.test/waitlist  ")
+	if handler.RequestAccessURL != "https://access.example.test/waitlist" {
+		t.Fatalf("request access URL=%q", handler.RequestAccessURL)
+	}
+	if handler.PublicLimiter == nil || handler.ValidateSlots == nil || handler.SourceIP == nil {
+		t.Fatal("production validation safeguards were not wired")
 	}
 }
 

--- a/phase4-coordinator/cmd/coordinator/main_test.go
+++ b/phase4-coordinator/cmd/coordinator/main_test.go
@@ -102,6 +102,21 @@ func (f appTrackReferralMintReconcilerFunc) ReconcilePendingAppTrackReferralMint
 	return f(ctx)
 }
 
+func TestWithReferralValidationMountsPermanentJoinRoute(t *testing.T) {
+	base := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(http.StatusNoContent) })
+	handler := withReferralValidation(
+		base,
+		nil,
+		func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(http.StatusAccepted) },
+	)
+
+	response := httptest.NewRecorder()
+	handler.ServeHTTP(response, httptest.NewRequest(http.MethodGet, "/j/invite", nil))
+	if response.Code != http.StatusAccepted {
+		t.Fatalf("join status=%d", response.Code)
+	}
+}
+
 func TestListenAddressParsesIPv4AndIPv6(t *testing.T) {
 	for _, host := range []string{"127.0.0.1", "::1", "::"} {
 		t.Run(host, func(t *testing.T) {

--- a/phase4-coordinator/dist/coordinator.yaml
+++ b/phase4-coordinator/dist/coordinator.yaml
@@ -92,6 +92,7 @@ auth:
 referrals:
   require_for_registration: false
   enable_public_validation: false
+  enable_join_links: false
   enable_social_invite_bonus: false
   campaign: ""
   policy_version: "v1"
@@ -102,6 +103,7 @@ referrals:
   social_bonus_uses: 2
   challenge_ttl_s: 900
   join_base_url: "https://coordinator.streamvc.live/j"
+  join_download_url: ""
   x_api_bearer_token: ""
   request_access_url: ""
 

--- a/phase4-coordinator/dist/nginx-coordinator.streamvc.live.conf
+++ b/phase4-coordinator/dist/nginx-coordinator.streamvc.live.conf
@@ -41,7 +41,8 @@ server {
     # the path or any query parameter in the nginx access log.
     location ^~ /j/ {
         access_log off;
-        return 301 https://$host$request_uri;
+        add_header Cache-Control "no-store" always;
+        return 307 https://coordinator.streamvc.live$request_uri;
     }
 
     location / {

--- a/phase4-coordinator/dist/nginx-coordinator.streamvc.live.conf
+++ b/phase4-coordinator/dist/nginx-coordinator.streamvc.live.conf
@@ -315,6 +315,25 @@ server {
         add_header Cache-Control "no-store" always;
     }
 
+    # Public invite preflight is an exact, read-only coordinator route. Keep it
+    # separately bounded at the edge and never cache request or response data.
+    # The referral_validate_rate zone is declared in the coordinator-deployed
+    # nginx-snippets/stats-shared.conf HTTP-context snippet.
+    location = /v1/referrals/validate {
+        limit_req zone=referral_validate_rate burst=10 nodelay;
+        limit_req_status 429;
+        proxy_pass http://127.0.0.1:8443/v1/referrals/validate;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_read_timeout 10s;
+        proxy_no_cache 1;
+        proxy_cache_bypass 1;
+        client_max_body_size 1k;
+        add_header Cache-Control "no-store" always;
+    }
+
     # ---------------------------------------------------------------------
     # /v1/providers/hardware-evidence — provider-token authenticated autotune
     # hardware evidence queue. Lives on buyer_port (8443), not the provider

--- a/phase4-coordinator/dist/nginx-coordinator.streamvc.live.conf
+++ b/phase4-coordinator/dist/nginx-coordinator.streamvc.live.conf
@@ -37,6 +37,13 @@ server {
         root /var/www/html;
     }
 
+    # Invite URLs are reusable credentials. Redirect to TLS without recording
+    # the path or any query parameter in the nginx access log.
+    location ^~ /j/ {
+        access_log off;
+        return 301 https://$host$request_uri;
+    }
+
     location / {
         return 301 https://$host$request_uri;
     }
@@ -360,6 +367,21 @@ server {
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
         proxy_set_header Authorization $http_authorization;
+        proxy_read_timeout 10s;
+        proxy_no_cache 1;
+        proxy_cache_bypass 1;
+        add_header Cache-Control "no-store" always;
+    }
+
+    # Durable invite landing links live on the buyer mux. The path contains a
+    # referral credential, so neither nginx access logs nor caches may retain it.
+    location ^~ /j/ {
+        access_log off;
+        proxy_pass http://127.0.0.1:8443;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
         proxy_read_timeout 10s;
         proxy_no_cache 1;
         proxy_cache_bypass 1;

--- a/phase4-coordinator/dist/nginx-snippets/stats-shared.conf
+++ b/phase4-coordinator/dist/nginx-snippets/stats-shared.conf
@@ -33,6 +33,11 @@ limit_req_zone $public_rl_key zone=stats_leaderboard:10m rate=60r/m;
 limit_req_zone $public_rl_key zone=stats_provider:10m    rate=60r/m;
 limit_req_zone $public_rl_key zone=stats_health:10m      rate=60r/m;
 
+# Coordinator-owned public referral validation. This declaration lives in the
+# same deploy-managed http-context snippet as the coordinator's other shared
+# zones so the vhost has no dependency on a separately deployed gateway site.
+limit_req_zone $binary_remote_addr zone=referral_validate_rate:10m rate=30r/m;
+
 # Cache for the public projection only. SECURITY r5 C1: paired
 # `proxy_no_cache $http_authorization` + `proxy_cache_bypass
 # $http_authorization` directives in every stats location keep the

--- a/phase4-coordinator/dist/test/check_nginx_referral_routes_test.sh
+++ b/phase4-coordinator/dist/test/check_nginx_referral_routes_test.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+config="$root/dist/nginx-coordinator.streamvc.live.conf"
+
+count="$(grep -c 'location \^~ /j/' "$config")"
+test "$count" -eq 2
+grep -A12 'location \^~ /j/' "$config" | grep -q 'access_log off;'
+grep -A12 'location \^~ /j/' "$config" | grep -q 'proxy_pass http://127.0.0.1:8443;'
+grep -A12 'location \^~ /j/' "$config" | grep -q 'return 301 https://\$host\$request_uri;'
+
+echo "nginx referral route checks passed"

--- a/phase4-coordinator/dist/test/check_nginx_referral_routes_test.sh
+++ b/phase4-coordinator/dist/test/check_nginx_referral_routes_test.sh
@@ -3,6 +3,8 @@ set -euo pipefail
 
 root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 config="$root/dist/nginx-coordinator.streamvc.live.conf"
+shared_config="$root/dist/nginx-snippets/stats-shared.conf"
+deploy="$root/dist/deploy-pearl-vps.sh"
 
 count="$(grep -c 'location \^~ /j/' "$config")"
 test "$count" -eq 2
@@ -18,5 +20,20 @@ if grep -A5 'location \^~ /j/' "$config" | grep -q 'return 301 '; then
   echo "invite redirect must not be permanent" >&2
   exit 1
 fi
+
+grep -q 'zone=referral_validate_rate:10m rate=30r/m;' "$shared_config"
+grep -q 'NGINX_STATS_SHARED=.*nginx-snippets/stats-shared.conf' "$deploy"
+grep -q 'install .*nginx-stats-shared.conf /etc/nginx/conf.d/stats-shared.conf' "$deploy"
+test "$(grep -c 'location = /v1/referrals/validate' "$config")" -eq 1
+validate_block="$(grep -A18 'location = /v1/referrals/validate' "$config")"
+grep -q 'limit_req zone=referral_validate_rate burst=10 nodelay;' <<<"$validate_block"
+grep -q 'proxy_pass http://127.0.0.1:8443/v1/referrals/validate;' <<<"$validate_block"
+grep -q 'proxy_no_cache 1;' <<<"$validate_block"
+grep -q 'proxy_cache_bypass 1;' <<<"$validate_block"
+grep -q 'client_max_body_size 1k;' <<<"$validate_block"
+grep -q 'add_header Cache-Control "no-store" always;' <<<"$validate_block"
+validate_line="$(grep -nE '^[[:space:]]*location = /v1/referrals/validate' "$config" | cut -d: -f1)"
+catchall_line="$(grep -nE '^[[:space:]]*location[[:space:]]+/v1/[[:space:]]*[{]' "$config" | cut -d: -f1)"
+test "$validate_line" -lt "$catchall_line"
 
 echo "nginx referral route checks passed"

--- a/phase4-coordinator/dist/test/check_nginx_referral_routes_test.sh
+++ b/phase4-coordinator/dist/test/check_nginx_referral_routes_test.sh
@@ -8,6 +8,15 @@ count="$(grep -c 'location \^~ /j/' "$config")"
 test "$count" -eq 2
 grep -A12 'location \^~ /j/' "$config" | grep -q 'access_log off;'
 grep -A12 'location \^~ /j/' "$config" | grep -q 'proxy_pass http://127.0.0.1:8443;'
-grep -A12 'location \^~ /j/' "$config" | grep -q 'return 301 https://\$host\$request_uri;'
+grep -A5 'location \^~ /j/' "$config" | grep -q 'add_header Cache-Control "no-store" always;'
+grep -A5 'location \^~ /j/' "$config" | grep -q 'return 307 https://coordinator\.streamvc\.live\$request_uri;'
+if grep -A5 'location \^~ /j/' "$config" | grep -q 'https://\$host'; then
+  echo "invite redirect must pin the trusted coordinator origin" >&2
+  exit 1
+fi
+if grep -A5 'location \^~ /j/' "$config" | grep -q 'return 301 '; then
+  echo "invite redirect must not be permanent" >&2
+  exit 1
+fi
 
 echo "nginx referral route checks passed"

--- a/phase4-coordinator/internal/auth/referrals_admin.go
+++ b/phase4-coordinator/internal/auth/referrals_admin.go
@@ -2,19 +2,39 @@ package auth
 
 import (
 	"context"
+	"crypto/sha256"
 	"database/sql"
+	"encoding/hex"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"strings"
 	"time"
 
 	"github.com/augstar/macprovider-coordinator/internal/sqliteutil"
+	"github.com/google/uuid"
 )
 
 var (
-	ErrReferralSeedExists        = errors.New("seed referral already exists")
-	ErrReferralCapacityBelowUsed = errors.New("referral capacity cannot be set below redeemed uses")
+	ErrReferralSeedExists         = errors.New("seed referral already exists")
+	ErrReferralCapacityBelowUsed  = errors.New("referral capacity cannot be set below redeemed uses")
+	ErrReferralAdminStateChanged  = errors.New("referral admin expected state changed")
+	ErrReferralOperationIDReused  = errors.New("referral admin operation id was reused for a different request")
+	ErrReferralReplacementInvalid = errors.New("referral seed replacement is invalid")
 )
+
+// ReferralAdminOperation is supplied only for an applied mutation. OperationID
+// is a caller-generated UUID and is the durable idempotency key. Actor is the
+// operator's claimed identity; UnixUID is the effective OS identity observed by
+// the local CLI. ExpectedState is the opaque full-state digest printed by the
+// corresponding dry-run.
+type ReferralAdminOperation struct {
+	OperationID   string
+	Actor         string
+	UnixUID       int
+	Reason        string
+	ExpectedState string
+}
 
 // referralAdminSchemaStatements is kept with the privileged referral
 // operations so the admin surface can be reviewed independently from referral
@@ -24,10 +44,15 @@ func referralAdminSchemaStatements() []string {
 	return []string{
 		`CREATE TABLE IF NOT EXISTS referral_admin_audit (
 			id INTEGER PRIMARY KEY AUTOINCREMENT,
+			operation_id TEXT NOT NULL UNIQUE,
 			actor TEXT NOT NULL,
+			unix_uid INTEGER NOT NULL CHECK(unix_uid >= 0),
 			reason TEXT NOT NULL,
 			action TEXT NOT NULL,
 			target TEXT NOT NULL,
+			expected_state TEXT NOT NULL,
+			request_fingerprint TEXT NOT NULL,
+			result TEXT NOT NULL,
 			detail TEXT NOT NULL DEFAULT '',
 			ts TEXT NOT NULL
 		)`,
@@ -44,83 +69,112 @@ func referralAdminSchemaStatements() []string {
 // SeedReferralCreation is returned for both dry-run and applied creation. The
 // signed code is disclosed only after the issuer and audit event commit.
 type SeedReferralCreation struct {
-	SeedID    string
-	Code      string
-	MaxUses   int
-	ExpiresAt *time.Time
-	Applied   bool
-	Recovered bool
+	SeedID        string
+	Code          string
+	MaxUses       int
+	ExpiresAt     *time.Time
+	ExpectedState string
+	Applied       bool
+	Recovered     bool
 }
 
 // CreateSeedReferralAudited previews or atomically creates a seed issuer and
-// its append-only operator audit record. Seed identifiers are immutable;
-// operators use AdjustSeedReferral for later capacity changes.
-func (s *Store) CreateSeedReferralAudited(ctx context.Context, policy ReferralPolicy, seedID string, maxUses int, expiresAt *time.Time, apply bool, actor, reason string, now time.Time) (SeedReferralCreation, error) {
+// its append-only operator audit record. A retry with the exact same operation
+// UUID recovers the original response without a second issuer or audit row.
+func (s *Store) CreateSeedReferralAudited(
+	ctx context.Context,
+	policy ReferralPolicy,
+	seedID string,
+	maxUses int,
+	expiresAt *time.Time,
+	apply bool,
+	operation ReferralAdminOperation,
+	now time.Time,
+) (SeedReferralCreation, error) {
 	if err := policy.Validate(); err != nil {
 		return SeedReferralCreation{}, err
 	}
 	seedID = strings.TrimSpace(seedID)
-	actor = strings.TrimSpace(actor)
-	reason = strings.TrimSpace(reason)
 	if !referralPartPattern.MatchString(seedID) || maxUses <= 0 {
 		return SeedReferralCreation{}, fmt.Errorf("seed id and max uses are invalid")
 	}
-	if apply && (actor == "" || reason == "") {
-		return SeedReferralCreation{}, fmt.Errorf("actor and reason are required to create a seed")
+	if apply {
+		var err error
+		operation, err = normalizeReferralAdminOperation(operation, false)
+		if err != nil {
+			return SeedReferralCreation{}, err
+		}
 	}
-	out := SeedReferralCreation{SeedID: seedID, MaxUses: maxUses, ExpiresAt: expiresAt}
+
+	expiryText, expiryValue := referralAdminExpiry(expiresAt)
+	target := policy.Campaign + "/" + seedID
+	expectedState := referralAdminAbsentExpectation(policy.Campaign, seedID)
+	requestFingerprint := referralAdminRequestFingerprint(struct {
+		Policy        string `json:"policy"`
+		SeedID        string `json:"seed_id"`
+		MaxUses       int    `json:"max_uses"`
+		ExpiresAt     string `json:"expires_at"`
+		ExpectedState string `json:"expected_state"`
+	}{
+		Policy: referralAdminPolicyFingerprint(policy), SeedID: seedID,
+		MaxUses: maxUses, ExpiresAt: expiryText, ExpectedState: expectedState,
+	})
+	out := SeedReferralCreation{
+		SeedID: seedID, MaxUses: maxUses, ExpiresAt: cloneReferralAdminTime(expiresAt),
+		ExpectedState: expectedState,
+	}
 	code, err := EncodeReferralCode(policy, ReferralTypeSeed, policy.CurrentKeyID, seedID)
 	if err != nil {
 		return SeedReferralCreation{}, err
 	}
-	var expiry any
-	if expiresAt != nil {
-		expiry = timeText(expiresAt.UTC())
-	}
+
 	err = sqliteutil.Transact(ctx, s.db, func(ctx context.Context, conn *sql.Conn) error {
-		var codeType, keyID string
-		var existingCapacity, existingBonus int
-		var existingExpiry, providerID, revokedAt sql.NullString
-		err := conn.QueryRowContext(ctx, `
-SELECT code_type, key_id, base_capacity, bonus_capacity, expires_at, provider_id, revoked_at
-  FROM referral_issuers
- WHERE issuer_id = ? AND campaign = ?`,
-			seedID, policy.Campaign,
-		).Scan(&codeType, &keyID, &existingCapacity, &existingBonus, &existingExpiry, &providerID, &revokedAt)
-		switch {
-		case err == nil:
-			expectedExpiry, hasExpiry := expiry.(string)
-			expiryMatches := (!hasExpiry && !existingExpiry.Valid) || (hasExpiry && existingExpiry.Valid && existingExpiry.String == expectedExpiry)
-			if apply && codeType == ReferralTypeSeed && keyID == policy.CurrentKeyID && existingCapacity == maxUses && existingBonus == 0 && expiryMatches && !providerID.Valid && !revokedAt.Valid {
+		if apply {
+			recovered, err := recoverReferralAdminResultTx(
+				ctx, conn, operation, "create_seed", target, expectedState, requestFingerprint, &out,
+			)
+			if err != nil {
+				return err
+			}
+			if recovered {
+				out.Applied = false
 				out.Recovered = true
 				return nil
 			}
-			return ErrReferralSeedExists
-		case !errors.Is(err, sql.ErrNoRows):
+		}
+
+		_, found, err := loadReferralIssuerAdminStateTx(ctx, conn, policy.Campaign, seedID)
+		if err != nil {
 			return err
+		}
+		if found {
+			return ErrReferralSeedExists
 		}
 		if !apply {
 			return nil
 		}
+
 		timestamp := timeText(now.UTC())
 		_, err = conn.ExecContext(ctx, `
 INSERT INTO referral_issuers (
     issuer_id, code_type, key_id, campaign, provider_id,
     base_capacity, bonus_capacity, expires_at, created_at, first_serving_at
 ) VALUES (?, 'S', ?, ?, NULL, ?, 0, ?, ?, ?)`,
-			seedID, policy.CurrentKeyID, policy.Campaign, maxUses, expiry, timestamp, timestamp)
+			seedID, policy.CurrentKeyID, policy.Campaign, maxUses, expiryValue, timestamp, timestamp)
 		if isConstraintFailure(err) {
 			return ErrReferralSeedExists
 		}
 		if err != nil {
 			return err
 		}
-		detail := fmt.Sprintf("code_type=S base_capacity=%d expires_at=%v", maxUses, expiry)
-		if err := recordReferralAdminAuditTx(ctx, conn, actor, reason, "create_seed", policy.Campaign+"/"+seedID, detail, now); err != nil {
-			return err
-		}
 		out.Applied = true
-		return nil
+		persisted := out
+		persisted.Code = ""
+		detail := fmt.Sprintf("code_type=S base_capacity=%d expires_at=%s", maxUses, expiryText)
+		return recordReferralAdminAuditTx(
+			ctx, conn, operation, "create_seed", target, expectedState,
+			requestFingerprint, detail, persisted, now,
+		)
 	})
 	if err != nil {
 		return SeedReferralCreation{}, err
@@ -132,79 +186,120 @@ INSERT INTO referral_issuers (
 }
 
 // SeedReferralAdjustment is returned for both dry-run and applied changes.
-// Used capacity is based only on durable redemptions; PR-B deliberately has no
-// public reservation model.
+// ExpectedState binds every issuer field plus the durable redemption count.
 type SeedReferralAdjustment struct {
-	SeedID             string
-	CurrentCapacity    int
-	NewCapacity        int
-	Redeemed           int
-	ResultingRemaining int
-	Applied            bool
+	SeedID               string
+	CurrentCapacity      int
+	CurrentBonusCapacity int
+	NewCapacity          int
+	Redeemed             int
+	ResultingRemaining   int
+	ExpectedState        string
+	Applied              bool
+	Recovered            bool
 }
 
-// AdjustSeedReferral previews or applies a seed capacity change. Applying is
-// attributable and transactional with its append-only audit record.
-func (s *Store) AdjustSeedReferral(ctx context.Context, policy ReferralPolicy, seedID string, newCapacity int, apply bool, actor, reason string, now time.Time) (SeedReferralAdjustment, error) {
+// AdjustSeedReferral previews or applies a seed capacity change. Applied
+// requests require the exact state digest returned by a dry-run.
+func (s *Store) AdjustSeedReferral(
+	ctx context.Context,
+	policy ReferralPolicy,
+	seedID string,
+	newCapacity int,
+	apply bool,
+	operation ReferralAdminOperation,
+	now time.Time,
+) (SeedReferralAdjustment, error) {
 	if err := policy.Validate(); err != nil {
 		return SeedReferralAdjustment{}, err
 	}
 	seedID = strings.TrimSpace(seedID)
-	actor = strings.TrimSpace(actor)
-	reason = strings.TrimSpace(reason)
 	if !referralPartPattern.MatchString(seedID) || newCapacity < 0 {
 		return SeedReferralAdjustment{}, ErrReferralInvalid
 	}
-	if apply && (actor == "" || reason == "") {
-		return SeedReferralAdjustment{}, fmt.Errorf("actor and reason are required to apply a seed adjustment")
+	if apply {
+		var err error
+		operation, err = normalizeReferralAdminOperation(operation, true)
+		if err != nil {
+			return SeedReferralAdjustment{}, err
+		}
 	}
 
+	target := policy.Campaign + "/" + seedID
+	requestFingerprint := referralAdminRequestFingerprint(struct {
+		Policy        string `json:"policy"`
+		SeedID        string `json:"seed_id"`
+		NewCapacity   int    `json:"new_capacity"`
+		ExpectedState string `json:"expected_state"`
+	}{
+		Policy: referralAdminPolicyFingerprint(policy), SeedID: seedID,
+		NewCapacity: newCapacity, ExpectedState: operation.ExpectedState,
+	})
 	out := SeedReferralAdjustment{SeedID: seedID, NewCapacity: newCapacity}
 	err := sqliteutil.Transact(ctx, s.db, func(ctx context.Context, conn *sql.Conn) error {
-		var codeType string
-		if err := conn.QueryRowContext(ctx, `
-SELECT code_type, base_capacity
-  FROM referral_issuers
- WHERE issuer_id = ? AND campaign = ?`, seedID, policy.Campaign).Scan(&codeType, &out.CurrentCapacity); err != nil {
-			if errors.Is(err, sql.ErrNoRows) {
-				return ErrReferralInvalid
+		if apply {
+			recovered, err := recoverReferralAdminResultTx(
+				ctx, conn, operation, "adjust_seed", target, operation.ExpectedState, requestFingerprint, &out,
+			)
+			if err != nil {
+				return err
 			}
+			if recovered {
+				out.Applied = false
+				out.Recovered = true
+				return nil
+			}
+		}
+
+		state, found, err := loadReferralIssuerAdminStateTx(ctx, conn, policy.Campaign, seedID)
+		if err != nil {
 			return err
 		}
-		if codeType != ReferralTypeSeed {
+		if !found || state.CodeType != ReferralTypeSeed || state.RevokedAt != "" {
 			return ErrReferralInvalid
 		}
-		if err := conn.QueryRowContext(ctx,
-			`SELECT COUNT(1) FROM referral_redemptions WHERE issuer_id = ?`, seedID,
-		).Scan(&out.Redeemed); err != nil {
-			return err
-		}
-		out.ResultingRemaining = newCapacity - out.Redeemed
+		out.CurrentCapacity = state.BaseCapacity
+		out.CurrentBonusCapacity = state.BonusCapacity
+		out.Redeemed = state.Redeemed
+		out.ResultingRemaining = newCapacity + state.BonusCapacity - state.Redeemed
 		if out.ResultingRemaining < 0 {
 			out.ResultingRemaining = 0
 		}
+		out.ExpectedState = referralAdminStateExpectation(state)
 		if !apply {
 			return nil
 		}
-		if newCapacity < out.Redeemed {
+		if operation.ExpectedState != out.ExpectedState {
+			return fmt.Errorf("%w: re-run the dry-run", ErrReferralAdminStateChanged)
+		}
+		if newCapacity+state.BonusCapacity < state.Redeemed {
 			return ErrReferralCapacityBelowUsed
 		}
 		result, err := conn.ExecContext(ctx, `
 UPDATE referral_issuers
    SET base_capacity = ?
- WHERE issuer_id = ? AND campaign = ? AND code_type = 'S'`, newCapacity, seedID, policy.Campaign)
+ WHERE issuer_id = ?
+   AND campaign = ?
+   AND code_type = 'S'
+   AND base_capacity = ?
+   AND bonus_capacity = ?
+   AND revoked_at IS NULL`,
+			newCapacity, seedID, policy.Campaign, state.BaseCapacity, state.BonusCapacity)
 		if err != nil {
 			return err
 		}
 		if changed, err := result.RowsAffected(); err != nil || changed != 1 {
-			return ErrReferralInvalid
-		}
-		detail := fmt.Sprintf("base_capacity %d->%d redeemed=%d", out.CurrentCapacity, newCapacity, out.Redeemed)
-		if err := recordReferralAdminAuditTx(ctx, conn, actor, reason, "adjust_seed", policy.Campaign+"/"+seedID, detail, now); err != nil {
-			return err
+			return ErrReferralAdminStateChanged
 		}
 		out.Applied = true
-		return nil
+		detail := fmt.Sprintf(
+			"base_capacity %d->%d bonus_capacity=%d redeemed=%d",
+			state.BaseCapacity, newCapacity, state.BonusCapacity, state.Redeemed,
+		)
+		return recordReferralAdminAuditTx(
+			ctx, conn, operation, "adjust_seed", target, operation.ExpectedState,
+			requestFingerprint, detail, out, now,
+		)
 	})
 	if err != nil {
 		return SeedReferralAdjustment{}, err
@@ -213,92 +308,114 @@ UPDATE referral_issuers
 }
 
 // ReferralRevocation is the blast-radius preview or result of an issuer revoke.
-// Capacity accounting is redemption-only in the reservation-neutral launch.
 type ReferralRevocation struct {
 	Campaign          string
 	IssuerID          string
 	CodeType          string
 	ProviderID        string
+	BaseCapacity      int
+	BonusCapacity     int
 	Redeemed          int
 	RemainingCapacity int
+	ExpectedState     string
 	Applied           bool
-}
-
-// ReferralRevokeExpectation is required when applying a previewed revoke. It
-// prevents an operator from acting on a stale redemption count.
-type ReferralRevokeExpectation struct {
-	Redeemed int
+	Recovered         bool
 }
 
 // RevokeReferralIssuerAudited previews or transactionally revokes an issuer and
-// records the operator actor and reason. Replacement issuance is intentionally
-// deferred to a later issuer-lifecycle change.
-func (s *Store) RevokeReferralIssuerAudited(ctx context.Context, campaign, issuerID string, apply bool, actor, reason string, expect *ReferralRevokeExpectation, now time.Time) (ReferralRevocation, error) {
+// records the operator's claimed actor, effective UID, reason, expected full
+// state, and exact result. An exact operation retry recovers that result.
+func (s *Store) RevokeReferralIssuerAudited(
+	ctx context.Context,
+	campaign string,
+	issuerID string,
+	apply bool,
+	operation ReferralAdminOperation,
+	now time.Time,
+) (ReferralRevocation, error) {
 	campaign = strings.TrimSpace(campaign)
 	issuerID = strings.TrimSpace(issuerID)
-	actor = strings.TrimSpace(actor)
-	reason = strings.TrimSpace(reason)
 	if !referralPartPattern.MatchString(campaign) || !referralPartPattern.MatchString(issuerID) {
 		return ReferralRevocation{}, ErrReferralInvalid
 	}
-	if apply && (actor == "" || reason == "") {
-		return ReferralRevocation{}, fmt.Errorf("actor and reason are required to apply a revocation")
-	}
-	if apply && expect == nil {
-		return ReferralRevocation{}, fmt.Errorf("an expected redemption count is required to apply a revocation")
+	if apply {
+		var err error
+		operation, err = normalizeReferralAdminOperation(operation, true)
+		if err != nil {
+			return ReferralRevocation{}, err
+		}
 	}
 
+	target := campaign + "/" + issuerID
+	requestFingerprint := referralAdminRequestFingerprint(struct {
+		Campaign      string `json:"campaign"`
+		IssuerID      string `json:"issuer_id"`
+		ExpectedState string `json:"expected_state"`
+	}{Campaign: campaign, IssuerID: issuerID, ExpectedState: operation.ExpectedState})
 	out := ReferralRevocation{Campaign: campaign, IssuerID: issuerID}
 	err := sqliteutil.Transact(ctx, s.db, func(ctx context.Context, conn *sql.Conn) error {
-		var providerID, revokedAt sql.NullString
-		var baseCapacity, bonusCapacity int
-		if err := conn.QueryRowContext(ctx, `
-SELECT code_type, provider_id, revoked_at, base_capacity, bonus_capacity
-  FROM referral_issuers
- WHERE campaign = ? AND issuer_id = ?`, campaign, issuerID).Scan(
-			&out.CodeType, &providerID, &revokedAt, &baseCapacity, &bonusCapacity,
-		); err != nil {
-			if errors.Is(err, sql.ErrNoRows) {
-				return ErrReferralInvalid
+		if apply {
+			recovered, err := recoverReferralAdminResultTx(
+				ctx, conn, operation, "revoke_issuer", target, operation.ExpectedState, requestFingerprint, &out,
+			)
+			if err != nil {
+				return err
 			}
+			if recovered {
+				out.Applied = false
+				out.Recovered = true
+				return nil
+			}
+		}
+
+		state, found, err := loadReferralIssuerAdminStateTx(ctx, conn, campaign, issuerID)
+		if err != nil {
 			return err
 		}
-		out.ProviderID = strings.TrimSpace(providerID.String)
-		if revokedAt.Valid {
-			return fmt.Errorf("issuer %s is already revoked", issuerID)
+		if !found || state.RevokedAt != "" {
+			return ErrReferralInvalid
 		}
-		if err := conn.QueryRowContext(ctx,
-			`SELECT COUNT(1) FROM referral_redemptions WHERE issuer_id = ?`, issuerID,
-		).Scan(&out.Redeemed); err != nil {
-			return err
-		}
-		out.RemainingCapacity = baseCapacity + bonusCapacity - out.Redeemed
+		out.CodeType = state.CodeType
+		out.ProviderID = state.ProviderID
+		out.BaseCapacity = state.BaseCapacity
+		out.BonusCapacity = state.BonusCapacity
+		out.Redeemed = state.Redeemed
+		out.RemainingCapacity = state.BaseCapacity + state.BonusCapacity - state.Redeemed
 		if out.RemainingCapacity < 0 {
 			out.RemainingCapacity = 0
 		}
+		out.ExpectedState = referralAdminStateExpectation(state)
 		if !apply {
 			return nil
 		}
-		if expect.Redeemed != out.Redeemed {
-			return fmt.Errorf("revocation snapshot drift: expected redeemed=%d but live redeemed=%d; re-run the dry-run", expect.Redeemed, out.Redeemed)
+		if operation.ExpectedState != out.ExpectedState {
+			return fmt.Errorf("%w: re-run the dry-run", ErrReferralAdminStateChanged)
 		}
 		result, err := conn.ExecContext(ctx, `
 UPDATE referral_issuers
    SET revoked_at = ?
- WHERE campaign = ? AND issuer_id = ? AND revoked_at IS NULL`,
-			timeText(now.UTC()), campaign, issuerID)
+ WHERE campaign = ?
+   AND issuer_id = ?
+   AND base_capacity = ?
+   AND bonus_capacity = ?
+   AND revoked_at IS NULL`,
+			timeText(now.UTC()), campaign, issuerID, state.BaseCapacity, state.BonusCapacity)
 		if err != nil {
 			return err
 		}
 		if changed, err := result.RowsAffected(); err != nil || changed != 1 {
-			return ErrReferralInvalid
-		}
-		detail := fmt.Sprintf("code_type=%s provider=%s redeemed=%d remaining_capacity=%d", out.CodeType, out.ProviderID, out.Redeemed, out.RemainingCapacity)
-		if err := recordReferralAdminAuditTx(ctx, conn, actor, reason, "revoke_issuer", campaign+"/"+issuerID, detail, now); err != nil {
-			return err
+			return ErrReferralAdminStateChanged
 		}
 		out.Applied = true
-		return nil
+		detail := fmt.Sprintf(
+			"code_type=%s provider=%s base_capacity=%d bonus_capacity=%d redeemed=%d remaining_capacity=%d",
+			out.CodeType, out.ProviderID, out.BaseCapacity, out.BonusCapacity,
+			out.Redeemed, out.RemainingCapacity,
+		)
+		return recordReferralAdminAuditTx(
+			ctx, conn, operation, "revoke_issuer", target, operation.ExpectedState,
+			requestFingerprint, detail, out, now,
+		)
 	})
 	if err != nil {
 		return ReferralRevocation{}, err
@@ -306,9 +423,376 @@ UPDATE referral_issuers
 	return out, nil
 }
 
-func recordReferralAdminAuditTx(ctx context.Context, conn *sql.Conn, actor, reason, action, target, detail string, now time.Time) error {
-	_, err := conn.ExecContext(ctx, `
-INSERT INTO referral_admin_audit (actor, reason, action, target, detail, ts)
-VALUES (?, ?, ?, ?, ?, ?)`, actor, reason, action, target, detail, timeText(now.UTC()))
+// SeedReferralReplacement is the preview or result of atomically retiring one
+// seed issuer and creating its successor.
+type SeedReferralReplacement struct {
+	Campaign             string
+	OldSeedID            string
+	NewSeedID            string
+	OldBaseCapacity      int
+	OldBonusCapacity     int
+	OldRedeemed          int
+	OldRemainingCapacity int
+	NewMaxUses           int
+	NewExpiresAt         *time.Time
+	Code                 string
+	ExpectedState        string
+	Applied              bool
+	Recovered            bool
+}
+
+// ReplaceSeedReferralAudited atomically revokes an active seed and creates its
+// successor with one append-only audit event. The dry-run digest binds the full
+// old issuer state and the absence of the requested successor.
+func (s *Store) ReplaceSeedReferralAudited(
+	ctx context.Context,
+	policy ReferralPolicy,
+	oldSeedID string,
+	newSeedID string,
+	newMaxUses int,
+	newExpiresAt *time.Time,
+	apply bool,
+	operation ReferralAdminOperation,
+	now time.Time,
+) (SeedReferralReplacement, error) {
+	if err := policy.Validate(); err != nil {
+		return SeedReferralReplacement{}, err
+	}
+	oldSeedID = strings.TrimSpace(oldSeedID)
+	newSeedID = strings.TrimSpace(newSeedID)
+	if !referralPartPattern.MatchString(oldSeedID) ||
+		!referralPartPattern.MatchString(newSeedID) ||
+		oldSeedID == newSeedID || newMaxUses <= 0 {
+		return SeedReferralReplacement{}, ErrReferralReplacementInvalid
+	}
+	if apply {
+		var err error
+		operation, err = normalizeReferralAdminOperation(operation, true)
+		if err != nil {
+			return SeedReferralReplacement{}, err
+		}
+	}
+
+	expiryText, expiryValue := referralAdminExpiry(newExpiresAt)
+	target := policy.Campaign + "/" + oldSeedID + "->" + newSeedID
+	requestFingerprint := referralAdminRequestFingerprint(struct {
+		Policy        string `json:"policy"`
+		OldSeedID     string `json:"old_seed_id"`
+		NewSeedID     string `json:"new_seed_id"`
+		NewMaxUses    int    `json:"new_max_uses"`
+		NewExpiresAt  string `json:"new_expires_at"`
+		ExpectedState string `json:"expected_state"`
+	}{
+		Policy: referralAdminPolicyFingerprint(policy), OldSeedID: oldSeedID,
+		NewSeedID: newSeedID, NewMaxUses: newMaxUses, NewExpiresAt: expiryText,
+		ExpectedState: operation.ExpectedState,
+	})
+	out := SeedReferralReplacement{
+		Campaign: policy.Campaign, OldSeedID: oldSeedID, NewSeedID: newSeedID,
+		NewMaxUses: newMaxUses, NewExpiresAt: cloneReferralAdminTime(newExpiresAt),
+	}
+	code, err := EncodeReferralCode(policy, ReferralTypeSeed, policy.CurrentKeyID, newSeedID)
+	if err != nil {
+		return SeedReferralReplacement{}, err
+	}
+
+	err = sqliteutil.Transact(ctx, s.db, func(ctx context.Context, conn *sql.Conn) error {
+		if apply {
+			recovered, err := recoverReferralAdminResultTx(
+				ctx, conn, operation, "replace_seed", target, operation.ExpectedState, requestFingerprint, &out,
+			)
+			if err != nil {
+				return err
+			}
+			if recovered {
+				out.Applied = false
+				out.Recovered = true
+				return nil
+			}
+		}
+
+		oldState, found, err := loadReferralIssuerAdminStateTx(ctx, conn, policy.Campaign, oldSeedID)
+		if err != nil {
+			return err
+		}
+		if !found || oldState.CodeType != ReferralTypeSeed || oldState.RevokedAt != "" {
+			return ErrReferralReplacementInvalid
+		}
+		if _, successorFound, err := loadReferralIssuerAdminStateTx(ctx, conn, policy.Campaign, newSeedID); err != nil {
+			return err
+		} else if successorFound {
+			return ErrReferralSeedExists
+		}
+
+		out.OldBaseCapacity = oldState.BaseCapacity
+		out.OldBonusCapacity = oldState.BonusCapacity
+		out.OldRedeemed = oldState.Redeemed
+		out.OldRemainingCapacity = oldState.BaseCapacity + oldState.BonusCapacity - oldState.Redeemed
+		if out.OldRemainingCapacity < 0 {
+			out.OldRemainingCapacity = 0
+		}
+		out.ExpectedState = referralAdminReplacementExpectation(oldState, newSeedID)
+		if !apply {
+			return nil
+		}
+		if operation.ExpectedState != out.ExpectedState {
+			return fmt.Errorf("%w: re-run the dry-run", ErrReferralAdminStateChanged)
+		}
+
+		timestamp := timeText(now.UTC())
+		result, err := conn.ExecContext(ctx, `
+UPDATE referral_issuers
+   SET revoked_at = ?
+ WHERE campaign = ?
+   AND issuer_id = ?
+   AND base_capacity = ?
+   AND bonus_capacity = ?
+   AND revoked_at IS NULL`,
+			timestamp, policy.Campaign, oldSeedID, oldState.BaseCapacity, oldState.BonusCapacity)
+		if err != nil {
+			return err
+		}
+		if changed, err := result.RowsAffected(); err != nil || changed != 1 {
+			return ErrReferralAdminStateChanged
+		}
+		_, err = conn.ExecContext(ctx, `
+INSERT INTO referral_issuers (
+    issuer_id, code_type, key_id, campaign, provider_id,
+    base_capacity, bonus_capacity, expires_at, created_at, first_serving_at
+) VALUES (?, 'S', ?, ?, NULL, ?, 0, ?, ?, ?)`,
+			newSeedID, policy.CurrentKeyID, policy.Campaign, newMaxUses,
+			expiryValue, timestamp, timestamp)
+		if isConstraintFailure(err) {
+			return ErrReferralSeedExists
+		}
+		if err != nil {
+			return err
+		}
+		out.Applied = true
+		persisted := out
+		persisted.Code = ""
+		detail := fmt.Sprintf(
+			"old_seed=%s old_base_capacity=%d old_bonus_capacity=%d old_redeemed=%d new_seed=%s new_base_capacity=%d new_expires_at=%s",
+			oldSeedID, oldState.BaseCapacity, oldState.BonusCapacity, oldState.Redeemed,
+			newSeedID, newMaxUses, expiryText,
+		)
+		return recordReferralAdminAuditTx(
+			ctx, conn, operation, "replace_seed", target, operation.ExpectedState,
+			requestFingerprint, detail, persisted, now,
+		)
+	})
+	if err != nil {
+		return SeedReferralReplacement{}, err
+	}
+	if out.Applied || out.Recovered {
+		out.Code = code
+	}
+	return out, nil
+}
+
+type referralIssuerAdminState struct {
+	Campaign      string `json:"campaign"`
+	IssuerID      string `json:"issuer_id"`
+	CodeType      string `json:"code_type"`
+	KeyID         string `json:"key_id"`
+	ProviderID    string `json:"provider_id"`
+	BaseCapacity  int    `json:"base_capacity"`
+	BonusCapacity int    `json:"bonus_capacity"`
+	ExpiresAt     string `json:"expires_at"`
+	RevokedAt     string `json:"revoked_at"`
+	Redeemed      int    `json:"redeemed"`
+}
+
+func loadReferralIssuerAdminStateTx(
+	ctx context.Context,
+	conn *sql.Conn,
+	campaign string,
+	issuerID string,
+) (referralIssuerAdminState, bool, error) {
+	state := referralIssuerAdminState{Campaign: campaign, IssuerID: issuerID}
+	var providerID, expiresAt, revokedAt sql.NullString
+	err := conn.QueryRowContext(ctx, `
+SELECT code_type, key_id, provider_id, base_capacity, bonus_capacity, expires_at, revoked_at
+  FROM referral_issuers
+ WHERE campaign = ? AND issuer_id = ?`,
+		campaign, issuerID,
+	).Scan(
+		&state.CodeType, &state.KeyID, &providerID, &state.BaseCapacity,
+		&state.BonusCapacity, &expiresAt, &revokedAt,
+	)
+	if errors.Is(err, sql.ErrNoRows) {
+		return referralIssuerAdminState{}, false, nil
+	}
+	if err != nil {
+		return referralIssuerAdminState{}, false, err
+	}
+	state.ProviderID = providerID.String
+	state.ExpiresAt = expiresAt.String
+	state.RevokedAt = revokedAt.String
+	if err := conn.QueryRowContext(ctx,
+		`SELECT COUNT(1) FROM referral_redemptions WHERE issuer_id = ?`,
+		issuerID,
+	).Scan(&state.Redeemed); err != nil {
+		return referralIssuerAdminState{}, false, err
+	}
+	return state, true, nil
+}
+
+func normalizeReferralAdminOperation(operation ReferralAdminOperation, requireExpectedState bool) (ReferralAdminOperation, error) {
+	parsed, err := uuid.Parse(strings.TrimSpace(operation.OperationID))
+	if err != nil || parsed == uuid.Nil {
+		return ReferralAdminOperation{}, fmt.Errorf("operation id must be a non-nil UUID")
+	}
+	operation.OperationID = parsed.String()
+	operation.Actor = strings.TrimSpace(operation.Actor)
+	operation.Reason = strings.TrimSpace(operation.Reason)
+	operation.ExpectedState = strings.TrimSpace(operation.ExpectedState)
+	if operation.Actor == "" || operation.Reason == "" {
+		return ReferralAdminOperation{}, fmt.Errorf("actor and reason are required to apply a referral admin operation")
+	}
+	if operation.UnixUID < 0 {
+		return ReferralAdminOperation{}, fmt.Errorf("effective unix uid must be non-negative")
+	}
+	if requireExpectedState && !isReferralAdminStateDigest(operation.ExpectedState) {
+		return ReferralAdminOperation{}, fmt.Errorf("expected state must be the 64-character digest from the dry-run")
+	}
+	return operation, nil
+}
+
+func isReferralAdminStateDigest(value string) bool {
+	if len(value) != sha256.Size*2 || value != strings.ToLower(value) {
+		return false
+	}
+	_, err := hex.DecodeString(value)
+	return err == nil
+}
+
+func referralAdminStateExpectation(state referralIssuerAdminState) string {
+	return referralAdminRequestFingerprint(state)
+}
+
+func referralAdminReplacementExpectation(state referralIssuerAdminState, newSeedID string) string {
+	return referralAdminRequestFingerprint(struct {
+		OldState  referralIssuerAdminState `json:"old_state"`
+		NewSeedID string                   `json:"new_seed_id"`
+		NewAbsent bool                     `json:"new_absent"`
+	}{OldState: state, NewSeedID: newSeedID, NewAbsent: true})
+}
+
+func referralAdminAbsentExpectation(campaign, issuerID string) string {
+	return referralAdminRequestFingerprint(struct {
+		Campaign string `json:"campaign"`
+		IssuerID string `json:"issuer_id"`
+		Absent   bool   `json:"absent"`
+	}{Campaign: campaign, IssuerID: issuerID, Absent: true})
+}
+
+func referralAdminPolicyFingerprint(policy ReferralPolicy) string {
+	return referralAdminRequestFingerprint(struct {
+		Campaign      string `json:"campaign"`
+		PolicyVersion string `json:"policy_version"`
+		CurrentKeyID  string `json:"current_key_id"`
+		CurrentSecret string `json:"current_secret"`
+	}{
+		Campaign: policy.Campaign, PolicyVersion: policy.PolicyVersion,
+		CurrentKeyID: policy.CurrentKeyID, CurrentSecret: policy.HMACKeys[policy.CurrentKeyID],
+	})
+}
+
+func referralAdminRequestFingerprint(value any) string {
+	encoded, err := json.Marshal(value)
+	if err != nil {
+		panic(fmt.Sprintf("marshal referral admin fingerprint: %v", err))
+	}
+	sum := sha256.Sum256(encoded)
+	return hex.EncodeToString(sum[:])
+}
+
+func referralAdminExpiry(value *time.Time) (string, any) {
+	if value == nil {
+		return "", nil
+	}
+	text := timeText(value.UTC())
+	return text, text
+}
+
+func cloneReferralAdminTime(value *time.Time) *time.Time {
+	if value == nil {
+		return nil
+	}
+	cloned := value.UTC()
+	return &cloned
+}
+
+func recoverReferralAdminResultTx(
+	ctx context.Context,
+	conn *sql.Conn,
+	operation ReferralAdminOperation,
+	action string,
+	target string,
+	expectedState string,
+	requestFingerprint string,
+	out any,
+) (bool, error) {
+	var actor, reason, storedAction, storedTarget, storedExpected, storedFingerprint, result string
+	var unixUID int
+	err := conn.QueryRowContext(ctx, `
+SELECT actor, unix_uid, reason, action, target, expected_state, request_fingerprint, result
+  FROM referral_admin_audit
+ WHERE operation_id = ?`,
+		operation.OperationID,
+	).Scan(
+		&actor, &unixUID, &reason, &storedAction, &storedTarget,
+		&storedExpected, &storedFingerprint, &result,
+	)
+	if errors.Is(err, sql.ErrNoRows) {
+		return false, nil
+	}
+	if err != nil {
+		return false, err
+	}
+	if actor != operation.Actor ||
+		unixUID != operation.UnixUID ||
+		reason != operation.Reason ||
+		storedAction != action ||
+		storedTarget != target ||
+		storedExpected != expectedState ||
+		storedFingerprint != requestFingerprint {
+		return false, ErrReferralOperationIDReused
+	}
+	if err := json.Unmarshal([]byte(result), out); err != nil {
+		return false, fmt.Errorf("decode referral admin replay result: %w", err)
+	}
+	return true, nil
+}
+
+func recordReferralAdminAuditTx(
+	ctx context.Context,
+	conn *sql.Conn,
+	operation ReferralAdminOperation,
+	action string,
+	target string,
+	expectedState string,
+	requestFingerprint string,
+	detail string,
+	result any,
+	now time.Time,
+) error {
+	encodedResult, err := json.Marshal(result)
+	if err != nil {
+		return fmt.Errorf("encode referral admin result: %w", err)
+	}
+	_, err = conn.ExecContext(ctx, `
+INSERT INTO referral_admin_audit (
+    operation_id, actor, unix_uid, reason, action, target,
+    expected_state, request_fingerprint, result, detail, ts
+) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		operation.OperationID, operation.Actor, operation.UnixUID, operation.Reason,
+		action, target, expectedState, requestFingerprint, string(encodedResult),
+		detail, timeText(now.UTC()),
+	)
+	if isConstraintFailure(err) {
+		return ErrReferralOperationIDReused
+	}
 	return err
 }

--- a/phase4-coordinator/internal/auth/referrals_admin.go
+++ b/phase4-coordinator/internal/auth/referrals_admin.go
@@ -1,0 +1,255 @@
+package auth
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/augstar/macprovider-coordinator/internal/sqliteutil"
+)
+
+var (
+	ErrReferralSeedExists        = errors.New("seed referral already exists")
+	ErrReferralCapacityBelowUsed = errors.New("referral capacity cannot be set below redeemed uses")
+)
+
+// referralAdminSchemaStatements is kept with the privileged referral
+// operations so the admin surface can be reviewed independently from referral
+// admission. The audit log is append-only by API contract: this package never
+// exposes update or delete operations for it.
+func referralAdminSchemaStatements() []string {
+	return []string{
+		`CREATE TABLE IF NOT EXISTS referral_admin_audit (
+			id INTEGER PRIMARY KEY AUTOINCREMENT,
+			actor TEXT NOT NULL,
+			reason TEXT NOT NULL,
+			action TEXT NOT NULL,
+			target TEXT NOT NULL,
+			detail TEXT NOT NULL DEFAULT '',
+			ts TEXT NOT NULL
+		)`,
+		`CREATE INDEX IF NOT EXISTS idx_referral_admin_audit_ts ON referral_admin_audit(ts)`,
+		`CREATE TRIGGER IF NOT EXISTS referral_admin_audit_no_update
+			BEFORE UPDATE ON referral_admin_audit
+			BEGIN SELECT RAISE(ABORT, 'referral_admin_audit is append-only'); END`,
+		`CREATE TRIGGER IF NOT EXISTS referral_admin_audit_no_delete
+			BEFORE DELETE ON referral_admin_audit
+			BEGIN SELECT RAISE(ABORT, 'referral_admin_audit is append-only'); END`,
+	}
+}
+
+// CreateSeedReferral inserts a new seed issuer and returns the signed invite
+// code. Seed identifiers are immutable; operators must use AdjustSeedReferral
+// for an audited capacity change rather than silently replacing a live seed.
+func (s *Store) CreateSeedReferral(ctx context.Context, policy ReferralPolicy, seedID string, maxUses int, expiresAt *time.Time) (string, error) {
+	if err := policy.Validate(); err != nil {
+		return "", err
+	}
+	seedID = strings.TrimSpace(seedID)
+	if !referralPartPattern.MatchString(seedID) || maxUses <= 0 {
+		return "", fmt.Errorf("seed id and max uses are invalid")
+	}
+	var expiry any
+	if expiresAt != nil {
+		expiry = timeText(expiresAt.UTC())
+	}
+	now := nowString()
+	_, err := s.db.ExecContext(ctx, `
+INSERT INTO referral_issuers (
+    issuer_id, code_type, key_id, campaign, provider_id,
+    base_capacity, bonus_capacity, expires_at, created_at, first_serving_at
+) VALUES (?, 'S', ?, ?, NULL, ?, 0, ?, ?, ?)`,
+		seedID, policy.CurrentKeyID, policy.Campaign, maxUses, expiry, now, now)
+	if isConstraintFailure(err) {
+		return "", ErrReferralSeedExists
+	}
+	if err != nil {
+		return "", err
+	}
+	return EncodeReferralCode(policy, ReferralTypeSeed, policy.CurrentKeyID, seedID)
+}
+
+// SeedReferralAdjustment is returned for both dry-run and applied changes.
+// Used capacity is based only on durable redemptions; PR-B deliberately has no
+// public reservation model.
+type SeedReferralAdjustment struct {
+	SeedID             string
+	CurrentCapacity    int
+	NewCapacity        int
+	Redeemed           int
+	ResultingRemaining int
+	Applied            bool
+}
+
+// AdjustSeedReferral previews or applies a seed capacity change. Applying is
+// attributable and transactional with its append-only audit record.
+func (s *Store) AdjustSeedReferral(ctx context.Context, policy ReferralPolicy, seedID string, newCapacity int, apply bool, actor, reason string, now time.Time) (SeedReferralAdjustment, error) {
+	if err := policy.Validate(); err != nil {
+		return SeedReferralAdjustment{}, err
+	}
+	seedID = strings.TrimSpace(seedID)
+	actor = strings.TrimSpace(actor)
+	reason = strings.TrimSpace(reason)
+	if !referralPartPattern.MatchString(seedID) || newCapacity < 0 {
+		return SeedReferralAdjustment{}, ErrReferralInvalid
+	}
+	if apply && (actor == "" || reason == "") {
+		return SeedReferralAdjustment{}, fmt.Errorf("actor and reason are required to apply a seed adjustment")
+	}
+
+	out := SeedReferralAdjustment{SeedID: seedID, NewCapacity: newCapacity}
+	err := sqliteutil.Transact(ctx, s.db, func(ctx context.Context, conn *sql.Conn) error {
+		var codeType string
+		if err := conn.QueryRowContext(ctx, `
+SELECT code_type, base_capacity
+  FROM referral_issuers
+ WHERE issuer_id = ? AND campaign = ?`, seedID, policy.Campaign).Scan(&codeType, &out.CurrentCapacity); err != nil {
+			if errors.Is(err, sql.ErrNoRows) {
+				return ErrReferralInvalid
+			}
+			return err
+		}
+		if codeType != ReferralTypeSeed {
+			return ErrReferralInvalid
+		}
+		if err := conn.QueryRowContext(ctx,
+			`SELECT COUNT(1) FROM referral_redemptions WHERE issuer_id = ?`, seedID,
+		).Scan(&out.Redeemed); err != nil {
+			return err
+		}
+		out.ResultingRemaining = newCapacity - out.Redeemed
+		if out.ResultingRemaining < 0 {
+			out.ResultingRemaining = 0
+		}
+		if !apply {
+			return nil
+		}
+		if newCapacity < out.Redeemed {
+			return ErrReferralCapacityBelowUsed
+		}
+		result, err := conn.ExecContext(ctx, `
+UPDATE referral_issuers
+   SET base_capacity = ?
+ WHERE issuer_id = ? AND campaign = ? AND code_type = 'S'`, newCapacity, seedID, policy.Campaign)
+		if err != nil {
+			return err
+		}
+		if changed, err := result.RowsAffected(); err != nil || changed != 1 {
+			return ErrReferralInvalid
+		}
+		detail := fmt.Sprintf("base_capacity %d->%d redeemed=%d", out.CurrentCapacity, newCapacity, out.Redeemed)
+		if err := recordReferralAdminAuditTx(ctx, conn, actor, reason, "adjust_seed", policy.Campaign+"/"+seedID, detail, now); err != nil {
+			return err
+		}
+		out.Applied = true
+		return nil
+	})
+	if err != nil {
+		return SeedReferralAdjustment{}, err
+	}
+	return out, nil
+}
+
+// ReferralRevocation is the blast-radius preview or result of an issuer revoke.
+// Capacity accounting is redemption-only in the reservation-neutral launch.
+type ReferralRevocation struct {
+	Campaign          string
+	IssuerID          string
+	CodeType          string
+	ProviderID        string
+	Redeemed          int
+	RemainingCapacity int
+	Applied           bool
+}
+
+// ReferralRevokeExpectation is required when applying a previewed revoke. It
+// prevents an operator from acting on a stale redemption count.
+type ReferralRevokeExpectation struct {
+	Redeemed int
+}
+
+// RevokeReferralIssuerAudited previews or transactionally revokes an issuer and
+// records the operator actor and reason. Replacement issuance is intentionally
+// deferred to a later issuer-lifecycle change.
+func (s *Store) RevokeReferralIssuerAudited(ctx context.Context, campaign, issuerID string, apply bool, actor, reason string, expect *ReferralRevokeExpectation, now time.Time) (ReferralRevocation, error) {
+	campaign = strings.TrimSpace(campaign)
+	issuerID = strings.TrimSpace(issuerID)
+	actor = strings.TrimSpace(actor)
+	reason = strings.TrimSpace(reason)
+	if !referralPartPattern.MatchString(campaign) || !referralPartPattern.MatchString(issuerID) {
+		return ReferralRevocation{}, ErrReferralInvalid
+	}
+	if apply && (actor == "" || reason == "") {
+		return ReferralRevocation{}, fmt.Errorf("actor and reason are required to apply a revocation")
+	}
+	if apply && expect == nil {
+		return ReferralRevocation{}, fmt.Errorf("an expected redemption count is required to apply a revocation")
+	}
+
+	out := ReferralRevocation{Campaign: campaign, IssuerID: issuerID}
+	err := sqliteutil.Transact(ctx, s.db, func(ctx context.Context, conn *sql.Conn) error {
+		var providerID, revokedAt sql.NullString
+		var baseCapacity, bonusCapacity int
+		if err := conn.QueryRowContext(ctx, `
+SELECT code_type, provider_id, revoked_at, base_capacity, bonus_capacity
+  FROM referral_issuers
+ WHERE campaign = ? AND issuer_id = ?`, campaign, issuerID).Scan(
+			&out.CodeType, &providerID, &revokedAt, &baseCapacity, &bonusCapacity,
+		); err != nil {
+			if errors.Is(err, sql.ErrNoRows) {
+				return ErrReferralInvalid
+			}
+			return err
+		}
+		out.ProviderID = strings.TrimSpace(providerID.String)
+		if revokedAt.Valid {
+			return fmt.Errorf("issuer %s is already revoked", issuerID)
+		}
+		if err := conn.QueryRowContext(ctx,
+			`SELECT COUNT(1) FROM referral_redemptions WHERE issuer_id = ?`, issuerID,
+		).Scan(&out.Redeemed); err != nil {
+			return err
+		}
+		out.RemainingCapacity = baseCapacity + bonusCapacity - out.Redeemed
+		if out.RemainingCapacity < 0 {
+			out.RemainingCapacity = 0
+		}
+		if !apply {
+			return nil
+		}
+		if expect.Redeemed != out.Redeemed {
+			return fmt.Errorf("revocation snapshot drift: expected redeemed=%d but live redeemed=%d; re-run the dry-run", expect.Redeemed, out.Redeemed)
+		}
+		result, err := conn.ExecContext(ctx, `
+UPDATE referral_issuers
+   SET revoked_at = ?
+ WHERE campaign = ? AND issuer_id = ? AND revoked_at IS NULL`,
+			timeText(now.UTC()), campaign, issuerID)
+		if err != nil {
+			return err
+		}
+		if changed, err := result.RowsAffected(); err != nil || changed != 1 {
+			return ErrReferralInvalid
+		}
+		detail := fmt.Sprintf("code_type=%s provider=%s redeemed=%d remaining_capacity=%d", out.CodeType, out.ProviderID, out.Redeemed, out.RemainingCapacity)
+		if err := recordReferralAdminAuditTx(ctx, conn, actor, reason, "revoke_issuer", campaign+"/"+issuerID, detail, now); err != nil {
+			return err
+		}
+		out.Applied = true
+		return nil
+	})
+	if err != nil {
+		return ReferralRevocation{}, err
+	}
+	return out, nil
+}
+
+func recordReferralAdminAuditTx(ctx context.Context, conn *sql.Conn, actor, reason, action, target, detail string, now time.Time) error {
+	_, err := conn.ExecContext(ctx, `
+INSERT INTO referral_admin_audit (actor, reason, action, target, detail, ts)
+VALUES (?, ?, ?, ?, ?, ?)`, actor, reason, action, target, detail, timeText(now.UTC()))
+	return err
+}

--- a/phase4-coordinator/internal/auth/referrals_admin.go
+++ b/phase4-coordinator/internal/auth/referrals_admin.go
@@ -41,35 +41,94 @@ func referralAdminSchemaStatements() []string {
 	}
 }
 
-// CreateSeedReferral inserts a new seed issuer and returns the signed invite
-// code. Seed identifiers are immutable; operators must use AdjustSeedReferral
-// for an audited capacity change rather than silently replacing a live seed.
-func (s *Store) CreateSeedReferral(ctx context.Context, policy ReferralPolicy, seedID string, maxUses int, expiresAt *time.Time) (string, error) {
+// SeedReferralCreation is returned for both dry-run and applied creation. The
+// signed code is disclosed only after the issuer and audit event commit.
+type SeedReferralCreation struct {
+	SeedID    string
+	Code      string
+	MaxUses   int
+	ExpiresAt *time.Time
+	Applied   bool
+	Recovered bool
+}
+
+// CreateSeedReferralAudited previews or atomically creates a seed issuer and
+// its append-only operator audit record. Seed identifiers are immutable;
+// operators use AdjustSeedReferral for later capacity changes.
+func (s *Store) CreateSeedReferralAudited(ctx context.Context, policy ReferralPolicy, seedID string, maxUses int, expiresAt *time.Time, apply bool, actor, reason string, now time.Time) (SeedReferralCreation, error) {
 	if err := policy.Validate(); err != nil {
-		return "", err
+		return SeedReferralCreation{}, err
 	}
 	seedID = strings.TrimSpace(seedID)
+	actor = strings.TrimSpace(actor)
+	reason = strings.TrimSpace(reason)
 	if !referralPartPattern.MatchString(seedID) || maxUses <= 0 {
-		return "", fmt.Errorf("seed id and max uses are invalid")
+		return SeedReferralCreation{}, fmt.Errorf("seed id and max uses are invalid")
+	}
+	if apply && (actor == "" || reason == "") {
+		return SeedReferralCreation{}, fmt.Errorf("actor and reason are required to create a seed")
+	}
+	out := SeedReferralCreation{SeedID: seedID, MaxUses: maxUses, ExpiresAt: expiresAt}
+	code, err := EncodeReferralCode(policy, ReferralTypeSeed, policy.CurrentKeyID, seedID)
+	if err != nil {
+		return SeedReferralCreation{}, err
 	}
 	var expiry any
 	if expiresAt != nil {
 		expiry = timeText(expiresAt.UTC())
 	}
-	now := nowString()
-	_, err := s.db.ExecContext(ctx, `
+	err = sqliteutil.Transact(ctx, s.db, func(ctx context.Context, conn *sql.Conn) error {
+		var codeType, keyID string
+		var existingCapacity, existingBonus int
+		var existingExpiry, providerID, revokedAt sql.NullString
+		err := conn.QueryRowContext(ctx, `
+SELECT code_type, key_id, base_capacity, bonus_capacity, expires_at, provider_id, revoked_at
+  FROM referral_issuers
+ WHERE issuer_id = ? AND campaign = ?`,
+			seedID, policy.Campaign,
+		).Scan(&codeType, &keyID, &existingCapacity, &existingBonus, &existingExpiry, &providerID, &revokedAt)
+		switch {
+		case err == nil:
+			expectedExpiry, hasExpiry := expiry.(string)
+			expiryMatches := (!hasExpiry && !existingExpiry.Valid) || (hasExpiry && existingExpiry.Valid && existingExpiry.String == expectedExpiry)
+			if apply && codeType == ReferralTypeSeed && keyID == policy.CurrentKeyID && existingCapacity == maxUses && existingBonus == 0 && expiryMatches && !providerID.Valid && !revokedAt.Valid {
+				out.Recovered = true
+				return nil
+			}
+			return ErrReferralSeedExists
+		case !errors.Is(err, sql.ErrNoRows):
+			return err
+		}
+		if !apply {
+			return nil
+		}
+		timestamp := timeText(now.UTC())
+		_, err = conn.ExecContext(ctx, `
 INSERT INTO referral_issuers (
     issuer_id, code_type, key_id, campaign, provider_id,
     base_capacity, bonus_capacity, expires_at, created_at, first_serving_at
 ) VALUES (?, 'S', ?, ?, NULL, ?, 0, ?, ?, ?)`,
-		seedID, policy.CurrentKeyID, policy.Campaign, maxUses, expiry, now, now)
-	if isConstraintFailure(err) {
-		return "", ErrReferralSeedExists
-	}
+			seedID, policy.CurrentKeyID, policy.Campaign, maxUses, expiry, timestamp, timestamp)
+		if isConstraintFailure(err) {
+			return ErrReferralSeedExists
+		}
+		if err != nil {
+			return err
+		}
+		detail := fmt.Sprintf("code_type=S base_capacity=%d expires_at=%v", maxUses, expiry)
+		if err := recordReferralAdminAuditTx(ctx, conn, actor, reason, "create_seed", policy.Campaign+"/"+seedID, detail, now); err != nil {
+			return err
+		}
+		out.Applied = true
+		return nil
+	})
 	if err != nil {
-		return "", err
+		return SeedReferralCreation{}, err
 	}
-	return EncodeReferralCode(policy, ReferralTypeSeed, policy.CurrentKeyID, seedID)
+	if out.Applied || out.Recovered {
+		out.Code = code
+	}
+	return out, nil
 }
 
 // SeedReferralAdjustment is returned for both dry-run and applied changes.

--- a/phase4-coordinator/internal/auth/referrals_admin_test.go
+++ b/phase4-coordinator/internal/auth/referrals_admin_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 )
@@ -18,12 +19,40 @@ func TestReferralAdminSeedLifecycleIsAuditedAndRedemptionOnly(t *testing.T) {
 	policy := coreReferralPolicy()
 	now := time.Date(2026, 7, 13, 12, 0, 0, 0, time.UTC)
 
-	code, err := store.CreateSeedReferral(ctx, policy, "launch", 3, nil)
+	creationPreview, err := store.CreateSeedReferralAudited(ctx, policy, "launch", 3, nil, false, "", "", now)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if _, err := store.CreateSeedReferral(ctx, policy, "launch", 9, nil); !errors.Is(err, ErrReferralSeedExists) {
+	if creationPreview.Applied || creationPreview.Code != "" {
+		t.Fatalf("creation preview=%+v", creationPreview)
+	}
+	var previewRows int
+	if err := store.db.QueryRow(`SELECT COUNT(1) FROM referral_issuers WHERE issuer_id = 'launch'`).Scan(&previewRows); err != nil || previewRows != 0 {
+		t.Fatalf("dry-run issuer rows=%d err=%v", previewRows, err)
+	}
+	created, err := store.CreateSeedReferralAudited(ctx, policy, "launch", 3, nil, true, "ops", "open cohort", now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	code := created.Code
+	if !created.Applied || code == "" {
+		t.Fatalf("creation result=%+v", created)
+	}
+	recovered, err := store.CreateSeedReferralAudited(ctx, policy, "launch", 3, nil, true, "ops", "retry after response loss", now.Add(time.Second))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if recovered.Applied || !recovered.Recovered || recovered.Code != code {
+		t.Fatalf("response-loss recovery=%+v want code %q", recovered, code)
+	}
+	if _, err := store.CreateSeedReferralAudited(ctx, policy, "launch", 9, nil, true, "ops", "duplicate", now); !errors.Is(err, ErrReferralSeedExists) {
 		t.Fatalf("duplicate seed error=%v, want ErrReferralSeedExists", err)
+	}
+	otherKeyPolicy := policy
+	otherKeyPolicy.CurrentKeyID = "k2"
+	otherKeyPolicy.HMACKeys = map[string]string{"k2": strings.Repeat("k", 32)}
+	if _, err := store.CreateSeedReferralAudited(ctx, otherKeyPolicy, "launch", 3, nil, true, "ops", "wrong key", now); !errors.Is(err, ErrReferralSeedExists) {
+		t.Fatalf("mismatched-key seed error=%v, want ErrReferralSeedExists", err)
 	}
 	if _, _, err := store.IssueTokenWithReferral(ctx, "provider-a", "host-a", code, policy); err != nil {
 		t.Fatal(err)
@@ -52,6 +81,12 @@ func TestReferralAdminSeedLifecycleIsAuditedAndRedemptionOnly(t *testing.T) {
 	}
 	if capacity != 5 || auditRows != 1 {
 		t.Fatalf("capacity=%d audit_rows=%d, want 5/1", capacity, auditRows)
+	}
+	if err := store.db.QueryRow(`SELECT COUNT(1) FROM referral_admin_audit WHERE action = 'create_seed' AND actor = 'ops' AND reason = 'open cohort'`).Scan(&auditRows); err != nil {
+		t.Fatal(err)
+	}
+	if auditRows != 1 {
+		t.Fatalf("create audit rows=%d, want 1", auditRows)
 	}
 	if _, err := store.db.Exec(`UPDATE referral_admin_audit SET reason = 'rewritten'`); err == nil {
 		t.Fatal("append-only referral audit accepted an update")
@@ -95,7 +130,10 @@ func TestReferralAdminApplyRequiresAttributionAndPreviewConfirmation(t *testing.
 	}
 	defer store.Close()
 	policy := coreReferralPolicy()
-	if _, err := store.CreateSeedReferral(context.Background(), policy, "launch", 1, nil); err != nil {
+	if _, err := store.CreateSeedReferralAudited(context.Background(), policy, "launch", 1, nil, true, "", "", time.Now().UTC()); err == nil {
+		t.Fatal("unattributed seed creation unexpectedly applied")
+	}
+	if _, err := store.CreateSeedReferralAudited(context.Background(), policy, "launch", 1, nil, true, "ops", "test", time.Now().UTC()); err != nil {
 		t.Fatal(err)
 	}
 	now := time.Now().UTC()

--- a/phase4-coordinator/internal/auth/referrals_admin_test.go
+++ b/phase4-coordinator/internal/auth/referrals_admin_test.go
@@ -9,84 +9,152 @@ import (
 	"time"
 )
 
-func TestReferralAdminSeedLifecycleIsAuditedAndRedemptionOnly(t *testing.T) {
+const (
+	adminCreateOperation  = "11111111-1111-4111-8111-111111111111"
+	adminAdjustOperation  = "22222222-2222-4222-8222-222222222222"
+	adminRevokeOperation  = "33333333-3333-4333-8333-333333333333"
+	adminReplaceOperation = "44444444-4444-4444-8444-444444444444"
+)
+
+func referralAdminTestOperation(id, actor, reason, expectedState string) ReferralAdminOperation {
+	return ReferralAdminOperation{
+		OperationID: id, Actor: actor, UnixUID: 501,
+		Reason: reason, ExpectedState: expectedState,
+	}
+}
+
+func openReferralAdminTestStore(t *testing.T) *Store {
+	t.Helper()
 	store, err := OpenStore(filepath.Join(t.TempDir(), "coordinator.db"))
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer store.Close()
+	t.Cleanup(func() { _ = store.Close() })
+	return store
+}
+
+func createReferralAdminSeed(t *testing.T, store *Store, policy ReferralPolicy, seedID string, capacity int, operationID string, now time.Time) SeedReferralCreation {
+	t.Helper()
+	result, err := store.CreateSeedReferralAudited(
+		context.Background(), policy, seedID, capacity, nil, true,
+		referralAdminTestOperation(operationID, "ops", "create "+seedID, ""), now,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return result
+}
+
+func TestReferralAdminMutationsAreAuditedAndExactlyRecoverable(t *testing.T) {
+	store := openReferralAdminTestStore(t)
 	ctx := context.Background()
 	policy := coreReferralPolicy()
 	now := time.Date(2026, 7, 13, 12, 0, 0, 0, time.UTC)
 
-	creationPreview, err := store.CreateSeedReferralAudited(ctx, policy, "launch", 3, nil, false, "", "", now)
+	creationPreview, err := store.CreateSeedReferralAudited(
+		ctx, policy, "launch", 3, nil, false, ReferralAdminOperation{}, now,
+	)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if creationPreview.Applied || creationPreview.Code != "" {
+	if creationPreview.Applied || creationPreview.Code != "" || creationPreview.ExpectedState == "" {
 		t.Fatalf("creation preview=%+v", creationPreview)
 	}
-	var previewRows int
-	if err := store.db.QueryRow(`SELECT COUNT(1) FROM referral_issuers WHERE issuer_id = 'launch'`).Scan(&previewRows); err != nil || previewRows != 0 {
-		t.Fatalf("dry-run issuer rows=%d err=%v", previewRows, err)
-	}
-	created, err := store.CreateSeedReferralAudited(ctx, policy, "launch", 3, nil, true, "ops", "open cohort", now)
+	createOp := referralAdminTestOperation(adminCreateOperation, "release", "open cohort", "")
+	created, err := store.CreateSeedReferralAudited(ctx, policy, "launch", 3, nil, true, createOp, now)
 	if err != nil {
 		t.Fatal(err)
 	}
-	code := created.Code
-	if !created.Applied || code == "" {
+	if !created.Applied || created.Recovered || created.Code == "" {
 		t.Fatalf("creation result=%+v", created)
 	}
-	recovered, err := store.CreateSeedReferralAudited(ctx, policy, "launch", 3, nil, true, "ops", "retry after response loss", now.Add(time.Second))
+	recovered, err := store.CreateSeedReferralAudited(ctx, policy, "launch", 3, nil, true, createOp, now.Add(time.Second))
 	if err != nil {
 		t.Fatal(err)
 	}
-	if recovered.Applied || !recovered.Recovered || recovered.Code != code {
-		t.Fatalf("response-loss recovery=%+v want code %q", recovered, code)
-	}
-	if _, err := store.CreateSeedReferralAudited(ctx, policy, "launch", 9, nil, true, "ops", "duplicate", now); !errors.Is(err, ErrReferralSeedExists) {
-		t.Fatalf("duplicate seed error=%v, want ErrReferralSeedExists", err)
-	}
-	otherKeyPolicy := policy
-	otherKeyPolicy.CurrentKeyID = "k2"
-	otherKeyPolicy.HMACKeys = map[string]string{"k2": strings.Repeat("k", 32)}
-	if _, err := store.CreateSeedReferralAudited(ctx, otherKeyPolicy, "launch", 3, nil, true, "ops", "wrong key", now); !errors.Is(err, ErrReferralSeedExists) {
-		t.Fatalf("mismatched-key seed error=%v, want ErrReferralSeedExists", err)
-	}
-	if _, _, err := store.IssueTokenWithReferral(ctx, "provider-a", "host-a", code, policy); err != nil {
-		t.Fatal(err)
+	if recovered.Applied || !recovered.Recovered || recovered.Code != created.Code {
+		t.Fatalf("creation recovery=%+v want code %q", recovered, created.Code)
 	}
 
-	preview, err := store.AdjustSeedReferral(ctx, policy, "launch", 0, false, "", "", now)
+	var auditRows, unixUID int
+	if err := store.db.QueryRow(`
+SELECT COUNT(1), MIN(unix_uid)
+  FROM referral_admin_audit
+ WHERE operation_id = ?`, adminCreateOperation).Scan(&auditRows, &unixUID); err != nil {
+		t.Fatal(err)
+	}
+	if auditRows != 1 || unixUID != 501 {
+		t.Fatalf("create audit rows=%d uid=%d", auditRows, unixUID)
+	}
+	reusedOp := createOp
+	reusedOp.Reason = "different request"
+	if _, err := store.CreateSeedReferralAudited(ctx, policy, "launch", 3, nil, true, reusedOp, now); !errors.Is(err, ErrReferralOperationIDReused) {
+		t.Fatalf("operation-id reuse error=%v", err)
+	}
+
+	if _, _, err := store.IssueTokenWithReferral(ctx, "provider-a", "host-a", created.Code, policy); err != nil {
+		t.Fatal(err)
+	}
+	adjustPreview, err := store.AdjustSeedReferral(ctx, policy, "launch", 5, false, ReferralAdminOperation{}, now)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if preview.Redeemed != 1 || preview.CurrentCapacity != 3 || preview.ResultingRemaining != 0 || preview.Applied {
-		t.Fatalf("unexpected preview: %+v", preview)
+	if adjustPreview.Redeemed != 1 || adjustPreview.CurrentCapacity != 3 || adjustPreview.ExpectedState == "" {
+		t.Fatalf("adjust preview=%+v", adjustPreview)
 	}
-	if _, err := store.AdjustSeedReferral(ctx, policy, "launch", 0, true, "ops", "shrink", now); !errors.Is(err, ErrReferralCapacityBelowUsed) {
-		t.Fatalf("below-used adjustment error=%v", err)
-	}
-	if _, err := store.AdjustSeedReferral(ctx, policy, "launch", 5, true, "ops", "expand cohort", now); err != nil {
+	adjustOp := referralAdminTestOperation(adminAdjustOperation, "ops", "expand cohort", adjustPreview.ExpectedState)
+	adjusted, err := store.AdjustSeedReferral(ctx, policy, "launch", 5, true, adjustOp, now)
+	if err != nil {
 		t.Fatal(err)
+	}
+	if !adjusted.Applied || adjusted.Recovered {
+		t.Fatalf("adjust result=%+v", adjusted)
+	}
+	adjustRecovered, err := store.AdjustSeedReferral(ctx, policy, "launch", 5, true, adjustOp, now.Add(time.Second))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if adjustRecovered.Applied || !adjustRecovered.Recovered ||
+		adjustRecovered.CurrentCapacity != adjusted.CurrentCapacity ||
+		adjustRecovered.ResultingRemaining != adjusted.ResultingRemaining {
+		t.Fatalf("adjust recovery=%+v original=%+v", adjustRecovered, adjusted)
 	}
 
-	var capacity, auditRows int
-	if err := store.db.QueryRow(`SELECT base_capacity FROM referral_issuers WHERE issuer_id = 'launch'`).Scan(&capacity); err != nil {
+	revokePreview, err := store.RevokeReferralIssuerAudited(
+		ctx, policy.Campaign, "launch", false, ReferralAdminOperation{}, now,
+	)
+	if err != nil {
 		t.Fatal(err)
 	}
-	if err := store.db.QueryRow(`SELECT COUNT(1) FROM referral_admin_audit WHERE action = 'adjust_seed' AND actor = 'ops' AND reason = 'expand cohort'`).Scan(&auditRows); err != nil {
+	revokeOp := referralAdminTestOperation(adminRevokeOperation, "ops", "abuse", revokePreview.ExpectedState)
+	revoked, err := store.RevokeReferralIssuerAudited(ctx, policy.Campaign, "launch", true, revokeOp, now)
+	if err != nil {
 		t.Fatal(err)
 	}
-	if capacity != 5 || auditRows != 1 {
-		t.Fatalf("capacity=%d audit_rows=%d, want 5/1", capacity, auditRows)
+	if !revoked.Applied || revoked.Recovered {
+		t.Fatalf("revoke result=%+v", revoked)
 	}
-	if err := store.db.QueryRow(`SELECT COUNT(1) FROM referral_admin_audit WHERE action = 'create_seed' AND actor = 'ops' AND reason = 'open cohort'`).Scan(&auditRows); err != nil {
+	revokeRecovered, err := store.RevokeReferralIssuerAudited(
+		ctx, policy.Campaign, "launch", true, revokeOp, now.Add(time.Second),
+	)
+	if err != nil {
 		t.Fatal(err)
 	}
-	if auditRows != 1 {
-		t.Fatalf("create audit rows=%d, want 1", auditRows)
+	if revokeRecovered.Applied || !revokeRecovered.Recovered ||
+		revokeRecovered.RemainingCapacity != revoked.RemainingCapacity {
+		t.Fatalf("revoke recovery=%+v original=%+v", revokeRecovered, revoked)
+	}
+
+	for _, operationID := range []string{adminCreateOperation, adminAdjustOperation, adminRevokeOperation} {
+		if err := store.db.QueryRow(
+			`SELECT COUNT(1) FROM referral_admin_audit WHERE operation_id = ?`,
+			operationID,
+		).Scan(&auditRows); err != nil {
+			t.Fatal(err)
+		}
+		if auditRows != 1 {
+			t.Fatalf("operation %s audit rows=%d", operationID, auditRows)
+		}
 	}
 	if _, err := store.db.Exec(`UPDATE referral_admin_audit SET reason = 'rewritten'`); err == nil {
 		t.Fatal("append-only referral audit accepted an update")
@@ -94,53 +162,191 @@ func TestReferralAdminSeedLifecycleIsAuditedAndRedemptionOnly(t *testing.T) {
 	if _, err := store.db.Exec(`DELETE FROM referral_admin_audit`); err == nil {
 		t.Fatal("append-only referral audit accepted a delete")
 	}
-
-	revokePreview, err := store.RevokeReferralIssuerAudited(ctx, policy.Campaign, "launch", false, "", "", nil, now)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if revokePreview.Redeemed != 1 || revokePreview.RemainingCapacity != 4 {
-		t.Fatalf("unexpected revoke preview: %+v", revokePreview)
-	}
-	if _, err := store.RevokeReferralIssuerAudited(ctx, policy.Campaign, "launch", true, "ops", "abuse", &ReferralRevokeExpectation{Redeemed: 0}, now); err == nil {
-		t.Fatal("stale revoke expectation unexpectedly applied")
-	}
-	result, err := store.RevokeReferralIssuerAudited(ctx, policy.Campaign, "launch", true, "ops", "abuse", &ReferralRevokeExpectation{Redeemed: 1}, now)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !result.Applied {
-		t.Fatalf("revoke result=%+v", result)
-	}
-	if err := store.db.QueryRow(`SELECT COUNT(1) FROM referral_admin_audit WHERE action = 'revoke_issuer' AND actor = 'ops' AND reason = 'abuse'`).Scan(&auditRows); err != nil {
-		t.Fatal(err)
-	}
-	if auditRows != 1 {
-		t.Fatalf("revoke audit rows=%d, want 1", auditRows)
-	}
-	if _, err := store.ValidateReferral(ctx, policy, code, now); !errors.Is(err, ErrReferralRevoked) {
-		t.Fatalf("validation after revoke error=%v, want revoked", err)
+	if _, err := store.ValidateReferral(ctx, policy, created.Code, now); !errors.Is(err, ErrReferralRevoked) {
+		t.Fatalf("validation after revoke error=%v", err)
 	}
 }
 
-func TestReferralAdminApplyRequiresAttributionAndPreviewConfirmation(t *testing.T) {
-	store, err := OpenStore(filepath.Join(t.TempDir(), "coordinator.db"))
+func TestReferralAdminFullStateCASRejectsRacedAdjustAndRevoke(t *testing.T) {
+	store := openReferralAdminTestStore(t)
+	ctx := context.Background()
+	policy := coreReferralPolicy()
+	now := time.Date(2026, 7, 13, 12, 0, 0, 0, time.UTC)
+	createReferralAdminSeed(t, store, policy, "launch", 3, adminCreateOperation, now)
+
+	adjustPreview, err := store.AdjustSeedReferral(ctx, policy, "launch", 6, false, ReferralAdminOperation{}, now)
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer store.Close()
-	policy := coreReferralPolicy()
-	if _, err := store.CreateSeedReferralAudited(context.Background(), policy, "launch", 1, nil, true, "", "", time.Now().UTC()); err == nil {
-		t.Fatal("unattributed seed creation unexpectedly applied")
-	}
-	if _, err := store.CreateSeedReferralAudited(context.Background(), policy, "launch", 1, nil, true, "ops", "test", time.Now().UTC()); err != nil {
+	if _, err := store.db.Exec(`UPDATE referral_issuers SET bonus_capacity = 1 WHERE issuer_id = 'launch'`); err != nil {
 		t.Fatal(err)
 	}
-	now := time.Now().UTC()
-	if _, err := store.AdjustSeedReferral(context.Background(), policy, "launch", 2, true, "", "", now); err == nil {
-		t.Fatal("unattributed adjustment unexpectedly applied")
+	adjustOp := referralAdminTestOperation(adminAdjustOperation, "ops", "expand", adjustPreview.ExpectedState)
+	if _, err := store.AdjustSeedReferral(ctx, policy, "launch", 6, true, adjustOp, now); !errors.Is(err, ErrReferralAdminStateChanged) {
+		t.Fatalf("raced adjustment error=%v", err)
 	}
-	if _, err := store.RevokeReferralIssuerAudited(context.Background(), policy.Campaign, "launch", true, "ops", "reason", nil, now); err == nil {
-		t.Fatal("revoke without confirmed preview unexpectedly applied")
+	var baseCapacity int
+	if err := store.db.QueryRow(`SELECT base_capacity FROM referral_issuers WHERE issuer_id = 'launch'`).Scan(&baseCapacity); err != nil {
+		t.Fatal(err)
+	}
+	if baseCapacity != 3 {
+		t.Fatalf("stale adjustment overwrote capacity: %d", baseCapacity)
+	}
+
+	revokePreview, err := store.RevokeReferralIssuerAudited(
+		ctx, policy.Campaign, "launch", false, ReferralAdminOperation{}, now,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.db.Exec(`UPDATE referral_issuers SET base_capacity = 4 WHERE issuer_id = 'launch'`); err != nil {
+		t.Fatal(err)
+	}
+	revokeOp := referralAdminTestOperation(adminRevokeOperation, "ops", "retire", revokePreview.ExpectedState)
+	if _, err := store.RevokeReferralIssuerAudited(ctx, policy.Campaign, "launch", true, revokeOp, now); !errors.Is(err, ErrReferralAdminStateChanged) {
+		t.Fatalf("raced revoke error=%v", err)
+	}
+	var revokedAt *string
+	if err := store.db.QueryRow(`SELECT revoked_at FROM referral_issuers WHERE issuer_id = 'launch'`).Scan(&revokedAt); err != nil {
+		t.Fatal(err)
+	}
+	if revokedAt != nil {
+		t.Fatalf("stale revoke applied: revoked_at=%v", revokedAt)
+	}
+}
+
+func TestReferralAdminReplacementIsAtomicCASAndRecoverable(t *testing.T) {
+	store := openReferralAdminTestStore(t)
+	ctx := context.Background()
+	policy := coreReferralPolicy()
+	now := time.Date(2026, 7, 13, 12, 0, 0, 0, time.UTC)
+	createReferralAdminSeed(t, store, policy, "launch", 3, adminCreateOperation, now)
+
+	preview, err := store.ReplaceSeedReferralAudited(
+		ctx, policy, "launch", "launch2", 5, nil, false, ReferralAdminOperation{}, now,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if preview.ExpectedState == "" || preview.Code != "" || preview.Applied {
+		t.Fatalf("replacement preview=%+v", preview)
+	}
+
+	if _, err := store.db.Exec(`
+INSERT INTO referral_issuers (
+    issuer_id, code_type, key_id, campaign, provider_id,
+    base_capacity, bonus_capacity, created_at, first_serving_at
+) VALUES ('launch2', 'S', 'k1', ?, NULL, 1, 0, ?, ?)`,
+		policy.Campaign, timeText(now), timeText(now),
+	); err != nil {
+		t.Fatal(err)
+	}
+	racedOp := referralAdminTestOperation(adminReplaceOperation, "ops", "rotate", preview.ExpectedState)
+	if _, err := store.ReplaceSeedReferralAudited(
+		ctx, policy, "launch", "launch2", 5, nil, true, racedOp, now,
+	); !errors.Is(err, ErrReferralSeedExists) {
+		t.Fatalf("successor race error=%v", err)
+	}
+	var oldRevokedAt *string
+	if err := store.db.QueryRow(`SELECT revoked_at FROM referral_issuers WHERE issuer_id = 'launch'`).Scan(&oldRevokedAt); err != nil {
+		t.Fatal(err)
+	}
+	if oldRevokedAt != nil {
+		t.Fatalf("failed replacement revoked old seed: %v", oldRevokedAt)
+	}
+	if _, err := store.db.Exec(`DELETE FROM referral_issuers WHERE issuer_id = 'launch2'`); err != nil {
+		t.Fatal(err)
+	}
+
+	preview, err = store.ReplaceSeedReferralAudited(
+		ctx, policy, "launch", "launch2", 5, nil, false, ReferralAdminOperation{}, now,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	replaceOp := referralAdminTestOperation(adminReplaceOperation, "ops", "rotate", preview.ExpectedState)
+	replaced, err := store.ReplaceSeedReferralAudited(
+		ctx, policy, "launch", "launch2", 5, nil, true, replaceOp, now,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !replaced.Applied || replaced.Recovered || replaced.Code == "" {
+		t.Fatalf("replacement=%+v", replaced)
+	}
+	recovered, err := store.ReplaceSeedReferralAudited(
+		ctx, policy, "launch", "launch2", 5, nil, true, replaceOp, now.Add(time.Second),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if recovered.Applied || !recovered.Recovered || recovered.Code != replaced.Code {
+		t.Fatalf("replacement recovery=%+v original=%+v", recovered, replaced)
+	}
+
+	var activeNew, revokedOld, auditRows int
+	if err := store.db.QueryRow(`
+SELECT
+    COUNT(1) FILTER (WHERE issuer_id = 'launch2' AND revoked_at IS NULL),
+    COUNT(1) FILTER (WHERE issuer_id = 'launch' AND revoked_at IS NOT NULL)
+  FROM referral_issuers`).Scan(&activeNew, &revokedOld); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.db.QueryRow(
+		`SELECT COUNT(1) FROM referral_admin_audit WHERE operation_id = ?`,
+		adminReplaceOperation,
+	).Scan(&auditRows); err != nil {
+		t.Fatal(err)
+	}
+	if activeNew != 1 || revokedOld != 1 || auditRows != 1 {
+		t.Fatalf("active_new=%d revoked_old=%d audit_rows=%d", activeNew, revokedOld, auditRows)
+	}
+	var auditResult, auditDetail string
+	if err := store.db.QueryRow(`
+SELECT result, detail FROM referral_admin_audit WHERE operation_id = ?`,
+		adminReplaceOperation,
+	).Scan(&auditResult, &auditDetail); err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(auditResult, replaced.Code) || strings.Contains(auditDetail, replaced.Code) ||
+		strings.Contains(auditResult, policy.HMACKeys[policy.CurrentKeyID]) ||
+		strings.Contains(auditDetail, policy.HMACKeys[policy.CurrentKeyID]) {
+		t.Fatal("replacement audit persisted a raw code or HMAC secret")
+	}
+}
+
+func TestReferralAdminApplyRequiresUUIDAttributionUIDAndExpectedState(t *testing.T) {
+	store := openReferralAdminTestStore(t)
+	policy := coreReferralPolicy()
+	now := time.Now().UTC()
+
+	for name, operation := range map[string]ReferralAdminOperation{
+		"missing uuid": {Actor: "ops", UnixUID: 501, Reason: "test"},
+		"bad uuid": {OperationID: "not-a-uuid", Actor: "ops", UnixUID: 501, Reason: "test"},
+		"missing actor": {OperationID: adminCreateOperation, UnixUID: 501, Reason: "test"},
+		"missing reason": {OperationID: adminCreateOperation, Actor: "ops", UnixUID: 501},
+		"invalid uid": {OperationID: adminCreateOperation, Actor: "ops", UnixUID: -1, Reason: "test"},
+	} {
+		t.Run(name, func(t *testing.T) {
+			if _, err := store.CreateSeedReferralAudited(
+				context.Background(), policy, "launch", 1, nil, true, operation, now,
+			); err == nil {
+				t.Fatal("invalid attributed create unexpectedly applied")
+			}
+		})
+	}
+
+	createReferralAdminSeed(t, store, policy, "launch", 1, adminCreateOperation, now)
+	if _, err := store.AdjustSeedReferral(
+		context.Background(), policy, "launch", 2, true,
+		referralAdminTestOperation(adminAdjustOperation, "ops", "expand", ""), now,
+	); err == nil {
+		t.Fatal("adjustment without expected state unexpectedly applied")
+	}
+	if _, err := store.RevokeReferralIssuerAudited(
+		context.Background(), policy.Campaign, "launch", true,
+		referralAdminTestOperation(adminRevokeOperation, "ops", "retire", ""), now,
+	); err == nil {
+		t.Fatal("revocation without expected state unexpectedly applied")
 	}
 }

--- a/phase4-coordinator/internal/auth/referrals_admin_test.go
+++ b/phase4-coordinator/internal/auth/referrals_admin_test.go
@@ -1,0 +1,108 @@
+package auth
+
+import (
+	"context"
+	"errors"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestReferralAdminSeedLifecycleIsAuditedAndRedemptionOnly(t *testing.T) {
+	store, err := OpenStore(filepath.Join(t.TempDir(), "coordinator.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+	ctx := context.Background()
+	policy := coreReferralPolicy()
+	now := time.Date(2026, 7, 13, 12, 0, 0, 0, time.UTC)
+
+	code, err := store.CreateSeedReferral(ctx, policy, "launch", 3, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.CreateSeedReferral(ctx, policy, "launch", 9, nil); !errors.Is(err, ErrReferralSeedExists) {
+		t.Fatalf("duplicate seed error=%v, want ErrReferralSeedExists", err)
+	}
+	if _, _, err := store.IssueTokenWithReferral(ctx, "provider-a", "host-a", code, policy); err != nil {
+		t.Fatal(err)
+	}
+
+	preview, err := store.AdjustSeedReferral(ctx, policy, "launch", 0, false, "", "", now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if preview.Redeemed != 1 || preview.CurrentCapacity != 3 || preview.ResultingRemaining != 0 || preview.Applied {
+		t.Fatalf("unexpected preview: %+v", preview)
+	}
+	if _, err := store.AdjustSeedReferral(ctx, policy, "launch", 0, true, "ops", "shrink", now); !errors.Is(err, ErrReferralCapacityBelowUsed) {
+		t.Fatalf("below-used adjustment error=%v", err)
+	}
+	if _, err := store.AdjustSeedReferral(ctx, policy, "launch", 5, true, "ops", "expand cohort", now); err != nil {
+		t.Fatal(err)
+	}
+
+	var capacity, auditRows int
+	if err := store.db.QueryRow(`SELECT base_capacity FROM referral_issuers WHERE issuer_id = 'launch'`).Scan(&capacity); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.db.QueryRow(`SELECT COUNT(1) FROM referral_admin_audit WHERE action = 'adjust_seed' AND actor = 'ops' AND reason = 'expand cohort'`).Scan(&auditRows); err != nil {
+		t.Fatal(err)
+	}
+	if capacity != 5 || auditRows != 1 {
+		t.Fatalf("capacity=%d audit_rows=%d, want 5/1", capacity, auditRows)
+	}
+	if _, err := store.db.Exec(`UPDATE referral_admin_audit SET reason = 'rewritten'`); err == nil {
+		t.Fatal("append-only referral audit accepted an update")
+	}
+	if _, err := store.db.Exec(`DELETE FROM referral_admin_audit`); err == nil {
+		t.Fatal("append-only referral audit accepted a delete")
+	}
+
+	revokePreview, err := store.RevokeReferralIssuerAudited(ctx, policy.Campaign, "launch", false, "", "", nil, now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if revokePreview.Redeemed != 1 || revokePreview.RemainingCapacity != 4 {
+		t.Fatalf("unexpected revoke preview: %+v", revokePreview)
+	}
+	if _, err := store.RevokeReferralIssuerAudited(ctx, policy.Campaign, "launch", true, "ops", "abuse", &ReferralRevokeExpectation{Redeemed: 0}, now); err == nil {
+		t.Fatal("stale revoke expectation unexpectedly applied")
+	}
+	result, err := store.RevokeReferralIssuerAudited(ctx, policy.Campaign, "launch", true, "ops", "abuse", &ReferralRevokeExpectation{Redeemed: 1}, now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !result.Applied {
+		t.Fatalf("revoke result=%+v", result)
+	}
+	if err := store.db.QueryRow(`SELECT COUNT(1) FROM referral_admin_audit WHERE action = 'revoke_issuer' AND actor = 'ops' AND reason = 'abuse'`).Scan(&auditRows); err != nil {
+		t.Fatal(err)
+	}
+	if auditRows != 1 {
+		t.Fatalf("revoke audit rows=%d, want 1", auditRows)
+	}
+	if _, err := store.ValidateReferral(ctx, policy, code, now); !errors.Is(err, ErrReferralRevoked) {
+		t.Fatalf("validation after revoke error=%v, want revoked", err)
+	}
+}
+
+func TestReferralAdminApplyRequiresAttributionAndPreviewConfirmation(t *testing.T) {
+	store, err := OpenStore(filepath.Join(t.TempDir(), "coordinator.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+	policy := coreReferralPolicy()
+	if _, err := store.CreateSeedReferral(context.Background(), policy, "launch", 1, nil); err != nil {
+		t.Fatal(err)
+	}
+	now := time.Now().UTC()
+	if _, err := store.AdjustSeedReferral(context.Background(), policy, "launch", 2, true, "", "", now); err == nil {
+		t.Fatal("unattributed adjustment unexpectedly applied")
+	}
+	if _, err := store.RevokeReferralIssuerAudited(context.Background(), policy.Campaign, "launch", true, "ops", "reason", nil, now); err == nil {
+		t.Fatal("revoke without confirmed preview unexpectedly applied")
+	}
+}

--- a/phase4-coordinator/internal/auth/tokens.go
+++ b/phase4-coordinator/internal/auth/tokens.go
@@ -507,6 +507,7 @@ func (s *Store) ensureGitHubAuthSchema(ctx context.Context) error {
 			total_removed_logs INTEGER NOT NULL
 		)`,
 	}
+	stmts = append(stmts, referralAdminSchemaStatements()...)
 	for _, stmt := range stmts {
 		if _, err := tx.ExecContext(ctx, stmt); err != nil {
 			return err

--- a/phase4-coordinator/internal/config/config.go
+++ b/phase4-coordinator/internal/config/config.go
@@ -709,6 +709,7 @@ type AuthConfig struct {
 type ReferralConfig struct {
 	RequireForRegistration  bool              `yaml:"require_for_registration"`
 	EnablePublicValidation  bool              `yaml:"enable_public_validation"`
+	EnableJoinLinks         bool              `yaml:"enable_join_links"`
 	EnableSocialInviteBonus bool              `yaml:"enable_social_invite_bonus"`
 	Campaign                string            `yaml:"campaign"`
 	PolicyVersion           string            `yaml:"policy_version"`
@@ -719,6 +720,7 @@ type ReferralConfig struct {
 	SocialBonusUses         int               `yaml:"social_bonus_uses"`
 	ChallengeTTLS           int               `yaml:"challenge_ttl_s"`
 	JoinBaseURL             string            `yaml:"join_base_url"`
+	JoinDownloadURL         string            `yaml:"join_download_url"`
 	XAPIBearerToken         string            `yaml:"x_api_bearer_token"`
 	RequestAccessURL        string            `yaml:"request_access_url"`
 }
@@ -1849,7 +1851,10 @@ func (c Config) validateCompatibilitySet() error {
 	return nil
 }
 
-var referralConfigPartPattern = regexp.MustCompile(`^[A-Za-z0-9_]{1,32}$`)
+var (
+	referralConfigPartPattern      = regexp.MustCompile(`^[A-Za-z0-9_]{1,32}$`)
+	referralDownloadVersionPattern = regexp.MustCompile(`(^|[-_/])v?[0-9]+[.][0-9]+[.][0-9]+([-_.]|$)`)
+)
 
 func (c Config) validateReferrals() error {
 	r := c.Referrals
@@ -1861,7 +1866,25 @@ func (c Config) validateReferrals() error {
 			return fmt.Errorf("referrals.request_access_url must be an absolute https URL without credentials when set")
 		}
 	}
-	if !r.RequireForRegistration && !r.EnablePublicValidation && !r.EnableSocialInviteBonus {
+	if raw := strings.TrimSpace(r.JoinDownloadURL); raw != "" {
+		downloadURL, err := url.Parse(raw)
+		if err != nil || downloadURL == nil {
+			return fmt.Errorf("referrals.join_download_url must be a fixed absolute https URL without credentials, query, fragment, trailing slash, or a moving latest path")
+		}
+		lowerPath := strings.ToLower(downloadURL.Path)
+		if downloadURL.Scheme != "https" || downloadURL.Host == "" || downloadURL.User != nil || downloadURL.RawQuery != "" || downloadURL.Fragment != "" || strings.HasSuffix(downloadURL.Path, "/") || strings.Contains(lowerPath, "latest") || !referralDownloadVersionPattern.MatchString(downloadURL.Path) {
+			return fmt.Errorf("referrals.join_download_url must be a fixed, versioned absolute https URL without credentials, query, fragment, trailing slash, or a moving latest path")
+		}
+	}
+	if r.EnableJoinLinks {
+		if !r.RequireForRegistration {
+			return fmt.Errorf("referrals.enable_join_links requires require_for_registration=true")
+		}
+		if strings.TrimSpace(r.JoinDownloadURL) == "" {
+			return fmt.Errorf("referrals.join_download_url must be set when join links are enabled")
+		}
+	}
+	if !r.RequireForRegistration && !r.EnablePublicValidation && !r.EnableJoinLinks && !r.EnableSocialInviteBonus {
 		return nil
 	}
 	if !referralConfigPartPattern.MatchString(r.Campaign) {

--- a/phase4-coordinator/internal/config/config.go
+++ b/phase4-coordinator/internal/config/config.go
@@ -1853,6 +1853,14 @@ var referralConfigPartPattern = regexp.MustCompile(`^[A-Za-z0-9_]{1,32}$`)
 
 func (c Config) validateReferrals() error {
 	r := c.Referrals
+	// The read-only validation response may advertise this URL even while the
+	// referral gate is disabled, so validate it independently of launch flags.
+	if raw := strings.TrimSpace(r.RequestAccessURL); raw != "" {
+		reqURL, err := url.Parse(raw)
+		if err != nil || reqURL.Scheme != "https" || reqURL.Host == "" || reqURL.User != nil {
+			return fmt.Errorf("referrals.request_access_url must be an absolute https URL without credentials when set")
+		}
+	}
 	if !r.RequireForRegistration && !r.EnablePublicValidation && !r.EnableSocialInviteBonus {
 		return nil
 	}
@@ -1893,12 +1901,6 @@ func (c Config) validateReferrals() error {
 	joinURL, err := url.Parse(strings.TrimSpace(r.JoinBaseURL))
 	if err != nil || joinURL.Scheme != "https" || joinURL.Host == "" || joinURL.RawQuery != "" || joinURL.Fragment != "" || !strings.HasSuffix(strings.TrimRight(joinURL.Path, "/"), "/j") {
 		return fmt.Errorf("referrals.join_base_url must be an absolute https URL ending in /j")
-	}
-	if raw := strings.TrimSpace(r.RequestAccessURL); raw != "" {
-		reqURL, err := url.Parse(raw)
-		if err != nil || reqURL.Scheme != "https" || reqURL.Host == "" {
-			return fmt.Errorf("referrals.request_access_url must be an absolute https URL when set")
-		}
 	}
 	return nil
 }

--- a/phase4-coordinator/internal/config/config_test.go
+++ b/phase4-coordinator/internal/config/config_test.go
@@ -55,6 +55,28 @@ func TestReferralLaunchPolicyDefaultsOffAndRejectsUnsafeEnablement(t *testing.T)
 	}
 }
 
+func TestReferralRequestAccessURLMustBeCredentialFreeHTTPSEvenWhenGateIsOff(t *testing.T) {
+	for _, raw := range []string{
+		"http://access.example.test/waitlist",
+		"/relative-access",
+		"https://user:secret@access.example.test/waitlist",
+	} {
+		cfg := Default()
+		cfg.Auth.OperatorKey = "operator-key"
+		cfg.Referrals.RequestAccessURL = raw
+		if err := cfg.Validate(); err == nil || !strings.Contains(err.Error(), "request_access_url") {
+			t.Fatalf("request_access_url=%q error=%v", raw, err)
+		}
+	}
+
+	cfg := Default()
+	cfg.Auth.OperatorKey = "operator-key"
+	cfg.Referrals.RequestAccessURL = "https://access.example.test/waitlist?campaign=prebeta"
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("valid request access URL: %v", err)
+	}
+}
+
 func TestAutotuneFeedsRejectInvalidPublicKeys(t *testing.T) {
 	tests := []struct {
 		name    string

--- a/phase4-coordinator/internal/config/config_test.go
+++ b/phase4-coordinator/internal/config/config_test.go
@@ -35,7 +35,7 @@ func TestAutotuneFeedsRequirePublicKeyringWhenConfigured(t *testing.T) {
 
 func TestReferralLaunchPolicyDefaultsOffAndRejectsUnsafeEnablement(t *testing.T) {
 	cfg := Default()
-	if cfg.Referrals.RequireForRegistration || cfg.Referrals.EnablePublicValidation || cfg.Referrals.EnableSocialInviteBonus {
+	if cfg.Referrals.RequireForRegistration || cfg.Referrals.EnablePublicValidation || cfg.Referrals.EnableJoinLinks || cfg.Referrals.EnableSocialInviteBonus {
 		t.Fatal("referral launch policy must default off")
 	}
 	cfg.Auth.OperatorKey = "operator-key"
@@ -52,6 +52,41 @@ func TestReferralLaunchPolicyDefaultsOffAndRejectsUnsafeEnablement(t *testing.T)
 	cfg.Referrals.HMACKeys = map[string]string{"k1": strings.Repeat("s", 32)}
 	if err := cfg.Validate(); err != nil {
 		t.Fatalf("valid referral gate: %v", err)
+	}
+}
+
+func TestReferralJoinLinksRequireAdmissionAndFixedDownload(t *testing.T) {
+	cfg := Default()
+	cfg.Auth.OperatorKey = "operator-key"
+	cfg.Referrals.EnableJoinLinks = true
+	if err := cfg.Validate(); err == nil || !strings.Contains(err.Error(), "requires require_for_registration") {
+		t.Fatalf("join without admission error=%v", err)
+	}
+
+	cfg.Referrals.RequireForRegistration = true
+	cfg.Referrals.Campaign = "prebeta_2026"
+	cfg.Referrals.CurrentKeyID = "k1"
+	cfg.Referrals.HMACKeys = map[string]string{"k1": strings.Repeat("s", 32)}
+	if err := cfg.Validate(); err == nil || !strings.Contains(err.Error(), "join_download_url must be set") {
+		t.Fatalf("join without download error=%v", err)
+	}
+
+	cfg.Referrals.JoinDownloadURL = "https://download.malibu.tech/releases/Malibu-1.9.0.dmg"
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("fixed join download URL: %v", err)
+	}
+
+	cfg.Referrals.EnableJoinLinks = false
+	cfg.Referrals.RequireForRegistration = false
+	for _, raw := range []string{
+		"https://download.malibu.tech/latest.dmg",
+		"https://download.malibu.tech/releases/Malibu-latest.dmg",
+		"https://download.malibu.tech/releases/Malibu.dmg",
+	} {
+		cfg.Referrals.JoinDownloadURL = raw
+		if err := cfg.Validate(); err == nil || !strings.Contains(err.Error(), "fixed, versioned") {
+			t.Fatalf("moving join download %q error=%v", raw, err)
+		}
 	}
 }
 

--- a/phase4-coordinator/internal/referralapi/join.go
+++ b/phase4-coordinator/internal/referralapi/join.go
@@ -10,8 +10,8 @@ import (
 	"github.com/augstar/macprovider-coordinator/internal/auth"
 )
 
-// JoinHandler serves durable invite links. It remains mounted after the gate is
-// disabled so links already in circulation resolve to the open-access page.
+// JoinHandler serves durable invite links only while the independent public
+// join flag is enabled by the router. Disabling exposure removes the route.
 type JoinHandler struct {
 	Store            ValidationStore
 	Policy           auth.ReferralPolicy
@@ -20,12 +20,14 @@ type JoinHandler struct {
 	SourceIP         func(*http.Request) string
 	Now              func() time.Time
 	RequestAccessURL string
+	DownloadURL      string
 	ErrorLogger      func(op string, err error)
 }
 
 type joinView struct {
 	Code             string
 	RequestAccessURL string
+	DownloadURL      string
 }
 
 const joinCSS = `body{margin:0;background:#101116;color:#f7f3ee;font:17px system-ui,sans-serif}main{max-width:620px;margin:10vh auto;padding:32px}h1{font-size:42px;margin:.2em 0}.card{background:#1b1d25;border-radius:18px;padding:26px}code{display:block;overflow-wrap:anywhere;background:#0b0c10;padding:12px;border-radius:8px}.actions{display:flex;gap:10px;flex-wrap:wrap;margin-top:20px}a,button{border:0;border-radius:9px;padding:12px 16px;font:inherit;font-weight:650;cursor:pointer}a{display:inline-block;background:#ff765f;color:#171717;text-decoration:none}a.secondary,button{background:#343744;color:#fff}`
@@ -34,7 +36,7 @@ var joinValidPage = template.Must(template.New("join-valid").Parse(`<!doctype ht
 <html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
 <meta name="robots" content="noindex,nofollow"><title>You're invited to Malibu</title><style>` + joinCSS + `</style></head>
 <body><main><p>Malibu pre-beta</p><h1>Put your Mac to work.</h1><div class="card"><p>You've been invited to join Malibu's private pre-beta compute network.</p>
-<p>Invite code</p><code id="invite">{{.Code}}</code><div class="actions"><a href="https://download.malibu.tech/latest.dmg">Download Malibu</a><button id="copy" type="button">Copy invite code</button></div>
+<p>Invite code</p><code id="invite">{{.Code}}</code><div class="actions"><a href="{{.DownloadURL}}">Download Malibu</a><button id="copy" type="button">Copy invite code</button></div>
 <p id="copied" aria-live="polite"></p><p>You choose when to launch the provider after installing Malibu.</p></div></main>
 <script>document.getElementById('copy').addEventListener('click',async()=>{await navigator.clipboard.writeText(document.getElementById('invite').textContent);document.getElementById('copied').textContent='Invite code copied.'})</script></body></html>`))
 
@@ -61,10 +63,6 @@ var joinUnavailablePage = template.Must(template.New("join-unavailable").Parse(`
 <html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1"><meta name="robots" content="noindex,nofollow"><title>Malibu pre-beta invite</title><style>` + joinCSS + `</style></head>
 <body><main><p>Malibu pre-beta</p><h1>We couldn't check this invite.</h1><div class="card"><p>Something went wrong on our side. Please try again in a moment.</p><div class="actions"><a href="https://malibu.tech">Learn more about Malibu</a></div></div></main></body></html>`))
 
-var joinOpenBetaPage = template.Must(template.New("join-open").Parse(`<!doctype html>
-<html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1"><meta name="robots" content="noindex,nofollow"><title>Malibu</title><style>` + joinCSS + `</style></head>
-<body><main><p>Malibu</p><h1>Put your Mac to work.</h1><div class="card"><p>Malibu is open. You don't need an invite code.</p><div class="actions"><a href="https://download.malibu.tech/latest.dmg">Download Malibu</a><a class="secondary" href="https://malibu.tech">Learn more about Malibu</a></div></div></main></body></html>`))
-
 func (h *JoinHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	h.setHeaders(w)
 	if r.Method != http.MethodGet && r.Method != http.MethodHead {
@@ -78,7 +76,7 @@ func (h *JoinHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if !h.Policy.RequireForRegistration {
-		h.render(w, r, http.StatusOK, joinOpenBetaPage, joinView{})
+		http.NotFound(w, r)
 		return
 	}
 	if h.Store == nil {
@@ -101,7 +99,10 @@ func (h *JoinHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	_, err := h.Store.ValidateReferral(r.Context(), h.Policy, code, h.now())
-	view := joinView{RequestAccessURL: strings.TrimSpace(h.RequestAccessURL)}
+	view := joinView{
+		RequestAccessURL: strings.TrimSpace(h.RequestAccessURL),
+		DownloadURL:      strings.TrimSpace(h.DownloadURL),
+	}
 	switch {
 	case errors.Is(err, auth.ErrReferralExhausted):
 		h.render(w, r, http.StatusOK, joinFullPage, view)

--- a/phase4-coordinator/internal/referralapi/join.go
+++ b/phase4-coordinator/internal/referralapi/join.go
@@ -1,0 +1,168 @@
+package referralapi
+
+import (
+	"errors"
+	"html/template"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/augstar/macprovider-coordinator/internal/auth"
+)
+
+// JoinHandler serves durable invite links. It remains mounted after the gate is
+// disabled so links already in circulation resolve to the open-access page.
+type JoinHandler struct {
+	Store            ValidationStore
+	Policy           auth.ReferralPolicy
+	PublicLimiter    *BoundedLimiter
+	ValidateSlots    chan struct{}
+	SourceIP         func(*http.Request) string
+	Now              func() time.Time
+	RequestAccessURL string
+	ErrorLogger      func(op string, err error)
+}
+
+type joinView struct {
+	Code             string
+	RequestAccessURL string
+}
+
+const joinCSS = `body{margin:0;background:#101116;color:#f7f3ee;font:17px system-ui,sans-serif}main{max-width:620px;margin:10vh auto;padding:32px}h1{font-size:42px;margin:.2em 0}.card{background:#1b1d25;border-radius:18px;padding:26px}code{display:block;overflow-wrap:anywhere;background:#0b0c10;padding:12px;border-radius:8px}.actions{display:flex;gap:10px;flex-wrap:wrap;margin-top:20px}a,button{border:0;border-radius:9px;padding:12px 16px;font:inherit;font-weight:650;cursor:pointer}a{display:inline-block;background:#ff765f;color:#171717;text-decoration:none}a.secondary,button{background:#343744;color:#fff}`
+
+var joinValidPage = template.Must(template.New("join-valid").Parse(`<!doctype html>
+<html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
+<meta name="robots" content="noindex,nofollow"><title>You're invited to Malibu</title><style>` + joinCSS + `</style></head>
+<body><main><p>Malibu pre-beta</p><h1>Put your Mac to work.</h1><div class="card"><p>You've been invited to join Malibu's private pre-beta compute network.</p>
+<p>Invite code</p><code id="invite">{{.Code}}</code><div class="actions"><a href="https://download.malibu.tech/latest.dmg">Download Malibu</a><button id="copy" type="button">Copy invite code</button></div>
+<p id="copied" aria-live="polite"></p><p>You choose when to launch the provider after installing Malibu.</p></div></main>
+<script>document.getElementById('copy').addEventListener('click',async()=>{await navigator.clipboard.writeText(document.getElementById('invite').textContent);document.getElementById('copied').textContent='Invite code copied.'})</script></body></html>`))
+
+var joinFullPage = template.Must(template.New("join-full").Parse(joinUnavailableDocument(
+	"This invite filled up.",
+	"All early-access spots on this invite have been claimed. Ask your inviter for another invite, or request access.",
+)))
+
+var joinExpiredPage = template.Must(template.New("join-expired").Parse(joinUnavailableDocument(
+	"This invite is no longer available.",
+	"This invite has expired. Ask your inviter for another invite, or request access.",
+)))
+
+var joinRevokedPage = template.Must(template.New("join-revoked").Parse(joinUnavailableDocument(
+	"This invite is no longer available.",
+	"This invite is no longer active. Ask your inviter for another invite, or request access.",
+)))
+
+func joinUnavailableDocument(title, message string) string {
+	return `<!doctype html><html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1"><meta name="robots" content="noindex,nofollow"><title>Malibu pre-beta invite</title><style>` + joinCSS + `</style></head><body><main><p>Malibu pre-beta</p><h1>` + title + `</h1><div class="card"><p>` + message + `</p><div class="actions">{{if .RequestAccessURL}}<a href="{{.RequestAccessURL}}">Request access</a>{{end}}<a class="secondary" href="https://malibu.tech">Learn more about Malibu</a></div></div></main></body></html>`
+}
+
+var joinUnavailablePage = template.Must(template.New("join-unavailable").Parse(`<!doctype html>
+<html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1"><meta name="robots" content="noindex,nofollow"><title>Malibu pre-beta invite</title><style>` + joinCSS + `</style></head>
+<body><main><p>Malibu pre-beta</p><h1>We couldn't check this invite.</h1><div class="card"><p>Something went wrong on our side. Please try again in a moment.</p><div class="actions"><a href="https://malibu.tech">Learn more about Malibu</a></div></div></main></body></html>`))
+
+var joinOpenBetaPage = template.Must(template.New("join-open").Parse(`<!doctype html>
+<html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1"><meta name="robots" content="noindex,nofollow"><title>Malibu</title><style>` + joinCSS + `</style></head>
+<body><main><p>Malibu</p><h1>Put your Mac to work.</h1><div class="card"><p>Malibu is open. You don't need an invite code.</p><div class="actions"><a href="https://download.malibu.tech/latest.dmg">Download Malibu</a><a class="secondary" href="https://malibu.tech">Learn more about Malibu</a></div></div></main></body></html>`))
+
+func (h *JoinHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	h.setHeaders(w)
+	if r.Method != http.MethodGet && r.Method != http.MethodHead {
+		w.Header().Set("Allow", "GET, HEAD")
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	if !h.allow(r) {
+		w.Header().Set("Retry-After", "60")
+		http.Error(w, "too many invite checks", http.StatusTooManyRequests)
+		return
+	}
+	code, ok := joinCode(r.URL.Path)
+	if !ok {
+		http.NotFound(w, r)
+		return
+	}
+	if !h.Policy.RequireForRegistration {
+		h.render(w, r, http.StatusOK, joinOpenBetaPage, joinView{})
+		return
+	}
+	if h.Store == nil {
+		h.renderOperationalFailure(w, r, errors.New("referral authority unavailable"))
+		return
+	}
+	if h.ValidateSlots != nil {
+		select {
+		case h.ValidateSlots <- struct{}{}:
+			defer func() { <-h.ValidateSlots }()
+		default:
+			h.renderOperationalFailure(w, r, errors.New("referral authority busy"))
+			return
+		}
+	}
+
+	_, err := h.Store.ValidateReferral(r.Context(), h.Policy, code, h.now())
+	view := joinView{RequestAccessURL: strings.TrimSpace(h.RequestAccessURL)}
+	switch {
+	case errors.Is(err, auth.ErrReferralExhausted):
+		h.render(w, r, http.StatusOK, joinFullPage, view)
+	case errors.Is(err, auth.ErrReferralExpired):
+		h.render(w, r, http.StatusOK, joinExpiredPage, view)
+	case errors.Is(err, auth.ErrReferralRevoked):
+		h.render(w, r, http.StatusOK, joinRevokedPage, view)
+	case errors.Is(err, auth.ErrReferralInvalid), errors.Is(err, auth.ErrReferralRequired):
+		http.NotFound(w, r)
+	case err != nil:
+		h.renderOperationalFailure(w, r, err)
+	default:
+		view.Code = code
+		h.render(w, r, http.StatusOK, joinValidPage, view)
+	}
+}
+
+func (h *JoinHandler) setHeaders(w http.ResponseWriter) {
+	w.Header().Set("Cache-Control", "no-store")
+	w.Header().Set("Content-Security-Policy", "default-src 'none'; style-src 'unsafe-inline'; script-src 'unsafe-inline'; connect-src 'none'; img-src 'none'; base-uri 'none'; frame-ancestors 'none'; form-action 'none'")
+	w.Header().Set("Referrer-Policy", "no-referrer")
+	w.Header().Set("X-Content-Type-Options", "nosniff")
+	w.Header().Set("X-Frame-Options", "DENY")
+}
+
+func (h *JoinHandler) allow(r *http.Request) bool {
+	key := r.RemoteAddr
+	if h.SourceIP != nil {
+		key = h.SourceIP(r)
+	}
+	return h.PublicLimiter != nil && h.PublicLimiter.Allow("join:"+key)
+}
+
+func joinCode(path string) (string, bool) {
+	if !strings.HasPrefix(path, "/j/") {
+		return "", false
+	}
+	code := strings.TrimPrefix(path, "/j/")
+	return code, code != "" && len(code) <= 256 && !strings.Contains(code, "/")
+}
+
+func (h *JoinHandler) renderOperationalFailure(w http.ResponseWriter, r *http.Request, err error) {
+	if h.ErrorLogger != nil {
+		h.ErrorLogger("join_validate", err)
+	}
+	w.Header().Set("Retry-After", "5")
+	h.render(w, r, http.StatusServiceUnavailable, joinUnavailablePage, joinView{})
+}
+
+func (h *JoinHandler) render(w http.ResponseWriter, r *http.Request, status int, page *template.Template, view joinView) {
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	w.WriteHeader(status)
+	if r.Method == http.MethodHead {
+		return
+	}
+	_ = page.Execute(w, view)
+}
+
+func (h *JoinHandler) now() time.Time {
+	if h.Now != nil {
+		return h.Now().UTC()
+	}
+	return time.Now().UTC()
+}

--- a/phase4-coordinator/internal/referralapi/join.go
+++ b/phase4-coordinator/internal/referralapi/join.go
@@ -40,17 +40,17 @@ var joinValidPage = template.Must(template.New("join-valid").Parse(`<!doctype ht
 
 var joinFullPage = template.Must(template.New("join-full").Parse(joinUnavailableDocument(
 	"This invite filled up.",
-	"All early-access spots on this invite have been claimed. Ask your inviter for another invite, or request access.",
+	"All early-access spots on this invite have been claimed. Ask your inviter for another invite.",
 )))
 
 var joinExpiredPage = template.Must(template.New("join-expired").Parse(joinUnavailableDocument(
 	"This invite is no longer available.",
-	"This invite has expired. Ask your inviter for another invite, or request access.",
+	"This invite has expired. Ask your inviter for another invite.",
 )))
 
 var joinRevokedPage = template.Must(template.New("join-revoked").Parse(joinUnavailableDocument(
 	"This invite is no longer available.",
-	"This invite is no longer active. Ask your inviter for another invite, or request access.",
+	"This invite is no longer active. Ask your inviter for another invite.",
 )))
 
 func joinUnavailableDocument(title, message string) string {

--- a/phase4-coordinator/internal/referralapi/join.go
+++ b/phase4-coordinator/internal/referralapi/join.go
@@ -72,11 +72,6 @@ func (h *JoinHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
 		return
 	}
-	if !h.allow(r) {
-		w.Header().Set("Retry-After", "60")
-		http.Error(w, "too many invite checks", http.StatusTooManyRequests)
-		return
-	}
 	code, ok := joinCode(r.URL.Path)
 	if !ok {
 		http.NotFound(w, r)
@@ -98,6 +93,11 @@ func (h *JoinHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			h.renderOperationalFailure(w, r, errors.New("referral authority busy"))
 			return
 		}
+	}
+	if !h.allow(r) {
+		w.Header().Set("Retry-After", "60")
+		http.Error(w, "too many invite checks", http.StatusTooManyRequests)
+		return
 	}
 
 	_, err := h.Store.ValidateReferral(r.Context(), h.Policy, code, h.now())

--- a/phase4-coordinator/internal/referralapi/join_test.go
+++ b/phase4-coordinator/internal/referralapi/join_test.go
@@ -23,6 +23,7 @@ func joinHandlerFor(result error) *JoinHandler {
 		PublicLimiter:    NewBoundedLimiter(20, time.Minute, 20),
 		ValidateSlots:    make(chan struct{}, 1),
 		RequestAccessURL: "https://access.example.test/waitlist",
+		DownloadURL:      "https://download.example.test/releases/Malibu-1.9.0.dmg",
 	}
 }
 
@@ -46,6 +47,11 @@ func TestJoinHandlerRendersLifecycleStates(t *testing.T) {
 			joinHandlerFor(tc.err).ServeHTTP(response, httptest.NewRequest(http.MethodGet, "/j/MAL1-S-k1-seed-AAAAAAAAAAAAAAAAAAAAAAAAAA", nil))
 			if response.Code != tc.wantStatus || !strings.Contains(response.Body.String(), tc.wantBody) {
 				t.Fatalf("status=%d body=%q", response.Code, response.Body.String())
+			}
+			if tc.name == "valid" {
+				if !strings.Contains(response.Body.String(), "https://download.example.test/releases/Malibu-1.9.0.dmg") || strings.Contains(response.Body.String(), "latest.dmg") {
+					t.Fatalf("valid download target is not fixed: %s", response.Body.String())
+				}
 			}
 			if got := response.Header().Get("Cache-Control"); got != "no-store" {
 				t.Fatalf("Cache-Control=%q", got)
@@ -73,13 +79,13 @@ func TestJoinHandlerOmitsAccessCTAWhenNotConfigured(t *testing.T) {
 	}
 }
 
-func TestJoinHandlerRemainsMountedForOpenAccess(t *testing.T) {
+func TestJoinHandlerFailsClosedWhenAdmissionPolicyIsOff(t *testing.T) {
 	h := joinHandlerFor(nil)
 	h.Policy.RequireForRegistration = false
 	h.Store = nil
 	response := httptest.NewRecorder()
 	h.ServeHTTP(response, httptest.NewRequest(http.MethodGet, "/j/old-invite", nil))
-	if response.Code != http.StatusOK || !strings.Contains(response.Body.String(), "don't need an invite") {
+	if response.Code != http.StatusNotFound || strings.Contains(response.Body.String(), "latest.dmg") || strings.Contains(response.Body.String(), "don't need an invite") {
 		t.Fatalf("status=%d body=%s", response.Code, response.Body.String())
 	}
 }

--- a/phase4-coordinator/internal/referralapi/join_test.go
+++ b/phase4-coordinator/internal/referralapi/join_test.go
@@ -22,7 +22,7 @@ func joinHandlerFor(result error) *JoinHandler {
 		Policy:           validationPolicy(),
 		PublicLimiter:    NewBoundedLimiter(20, time.Minute, 20),
 		ValidateSlots:    make(chan struct{}, 1),
-		RequestAccessURL: "https://malibu.tech/request-access",
+		RequestAccessURL: "https://access.example.test/waitlist",
 	}
 }
 
@@ -50,13 +50,26 @@ func TestJoinHandlerRendersLifecycleStates(t *testing.T) {
 			if got := response.Header().Get("Cache-Control"); got != "no-store" {
 				t.Fatalf("Cache-Control=%q", got)
 			}
-			if tc.err == auth.ErrReferralExpired && !strings.Contains(response.Body.String(), "https://malibu.tech/request-access") {
+			if tc.err == auth.ErrReferralExpired && !strings.Contains(response.Body.String(), "https://access.example.test/waitlist") {
 				t.Fatal("request-access CTA missing")
 			}
 			if tc.name == "operational" && response.Header().Get("Retry-After") != "5" {
 				t.Fatal("operational failure missing Retry-After")
 			}
 		})
+	}
+}
+
+func TestJoinHandlerOmitsAccessCTAWhenNotConfigured(t *testing.T) {
+	h := joinHandlerFor(auth.ErrReferralExpired)
+	h.RequestAccessURL = ""
+	response := httptest.NewRecorder()
+	h.ServeHTTP(response, httptest.NewRequest(http.MethodGet, "/j/invite", nil))
+	if response.Code != http.StatusOK || !strings.Contains(response.Body.String(), "Ask your inviter for another invite.") {
+		t.Fatalf("status=%d body=%s", response.Code, response.Body.String())
+	}
+	if strings.Contains(response.Body.String(), "Request access") || strings.Contains(response.Body.String(), "access.example.test") {
+		t.Fatalf("unconfigured request-access CTA rendered: %s", response.Body.String())
 	}
 }
 

--- a/phase4-coordinator/internal/referralapi/join_test.go
+++ b/phase4-coordinator/internal/referralapi/join_test.go
@@ -1,0 +1,102 @@
+package referralapi
+
+import (
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/augstar/macprovider-coordinator/internal/auth"
+)
+
+func joinHandlerFor(result error) *JoinHandler {
+	return &JoinHandler{
+		Store: validationStoreFunc(func(string) (auth.ReferralValidation, error) {
+			if result != nil {
+				return auth.ReferralValidation{}, result
+			}
+			return auth.ReferralValidation{Valid: true, Reason: "valid"}, nil
+		}),
+		Policy:           validationPolicy(),
+		PublicLimiter:    NewBoundedLimiter(20, time.Minute, 20),
+		ValidateSlots:    make(chan struct{}, 1),
+		RequestAccessURL: "https://malibu.tech/request-access",
+	}
+}
+
+func TestJoinHandlerRendersLifecycleStates(t *testing.T) {
+	cases := []struct {
+		name       string
+		err        error
+		wantStatus int
+		wantBody   string
+	}{
+		{name: "valid", wantStatus: http.StatusOK, wantBody: "Copy invite code"},
+		{name: "exhausted", err: auth.ErrReferralExhausted, wantStatus: http.StatusOK, wantBody: "invite filled up"},
+		{name: "expired", err: auth.ErrReferralExpired, wantStatus: http.StatusOK, wantBody: "invite has expired"},
+		{name: "revoked", err: auth.ErrReferralRevoked, wantStatus: http.StatusOK, wantBody: "no longer active"},
+		{name: "invalid", err: auth.ErrReferralInvalid, wantStatus: http.StatusNotFound, wantBody: "404 page not found"},
+		{name: "operational", err: errors.New("database is locked"), wantStatus: http.StatusServiceUnavailable, wantBody: "try again"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			response := httptest.NewRecorder()
+			joinHandlerFor(tc.err).ServeHTTP(response, httptest.NewRequest(http.MethodGet, "/j/MAL1-S-k1-seed-AAAAAAAAAAAAAAAAAAAAAAAAAA", nil))
+			if response.Code != tc.wantStatus || !strings.Contains(response.Body.String(), tc.wantBody) {
+				t.Fatalf("status=%d body=%q", response.Code, response.Body.String())
+			}
+			if got := response.Header().Get("Cache-Control"); got != "no-store" {
+				t.Fatalf("Cache-Control=%q", got)
+			}
+			if tc.err == auth.ErrReferralExpired && !strings.Contains(response.Body.String(), "https://malibu.tech/request-access") {
+				t.Fatal("request-access CTA missing")
+			}
+			if tc.name == "operational" && response.Header().Get("Retry-After") != "5" {
+				t.Fatal("operational failure missing Retry-After")
+			}
+		})
+	}
+}
+
+func TestJoinHandlerRemainsMountedForOpenAccess(t *testing.T) {
+	h := joinHandlerFor(nil)
+	h.Policy.RequireForRegistration = false
+	h.Store = nil
+	response := httptest.NewRecorder()
+	h.ServeHTTP(response, httptest.NewRequest(http.MethodGet, "/j/old-invite", nil))
+	if response.Code != http.StatusOK || !strings.Contains(response.Body.String(), "don't need an invite") {
+		t.Fatalf("status=%d body=%s", response.Code, response.Body.String())
+	}
+}
+
+func TestJoinHandlerRejectsMalformedPathsAndBoundsConcurrency(t *testing.T) {
+	h := joinHandlerFor(nil)
+	for _, path := range []string{"/j/", "/j/a/b", "/j/" + strings.Repeat("a", 257)} {
+		response := httptest.NewRecorder()
+		h.ServeHTTP(response, httptest.NewRequest(http.MethodGet, path, nil))
+		if response.Code != http.StatusNotFound {
+			t.Fatalf("path=%q status=%d", path, response.Code)
+		}
+	}
+	h.ValidateSlots <- struct{}{}
+	response := httptest.NewRecorder()
+	h.ServeHTTP(response, httptest.NewRequest(http.MethodGet, "/j/code", nil))
+	<-h.ValidateSlots
+	if response.Code != http.StatusServiceUnavailable {
+		t.Fatalf("busy status=%d", response.Code)
+	}
+}
+
+func TestJoinHandlerHEADHasNoBodyAndMissingAuthorityIs503(t *testing.T) {
+	h := joinHandlerFor(nil)
+	h.Store = nil
+	var logged error
+	h.ErrorLogger = func(_ string, err error) { logged = err }
+	response := httptest.NewRecorder()
+	h.ServeHTTP(response, httptest.NewRequest(http.MethodHead, "/j/code", nil))
+	if response.Code != http.StatusServiceUnavailable || response.Body.Len() != 0 || logged == nil {
+		t.Fatalf("status=%d body=%q logged=%v", response.Code, response.Body.String(), logged)
+	}
+}

--- a/phase4-coordinator/internal/referralapi/validate.go
+++ b/phase4-coordinator/internal/referralapi/validate.go
@@ -56,11 +56,6 @@ func (h *ValidationHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	w.Header().Set("Cache-Control", "no-store")
-	if !h.Policy.RequireForRegistration {
-		h.observe("disabled")
-		h.writeValidation(w, true, false, "disabled")
-		return
-	}
 	key := r.RemoteAddr
 	if h.SourceIP != nil {
 		key = h.SourceIP(r)
@@ -82,17 +77,24 @@ func (h *ValidationHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusTooManyRequests, "rate_limited", "too many referral checks")
 		return
 	}
-	if h.Store == nil {
-		h.observe("unavailable")
-		writeError(w, http.StatusServiceUnavailable, "unavailable", "referral authority unavailable")
-		return
-	}
+	// Decode and bound the request before consulting policy or authority so a
+	// temporarily disabled public route retains the same abuse posture.
 	var request struct {
 		Code string `json:"code"`
 	}
 	if err := decodeBoundedJSON(r, &request, 1024); err != nil || len([]byte(request.Code)) > 256 {
 		h.observe("bad_request")
 		writeError(w, http.StatusBadRequest, "bad_request", "invalid request")
+		return
+	}
+	if !h.Policy.RequireForRegistration {
+		h.observe("disabled")
+		h.writeValidation(w, true, false, "disabled")
+		return
+	}
+	if h.Store == nil {
+		h.observe("unavailable")
+		writeError(w, http.StatusServiceUnavailable, "unavailable", "referral authority unavailable")
 		return
 	}
 	validation, err := h.Store.ValidateReferral(r.Context(), h.Policy, request.Code, h.now())

--- a/phase4-coordinator/internal/referralapi/validate.go
+++ b/phase4-coordinator/internal/referralapi/validate.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"strings"
 	"sync"
 	"time"
 
@@ -17,6 +18,12 @@ import (
 
 type ValidationStore interface {
 	ValidateReferral(context.Context, auth.ReferralPolicy, string, time.Time) (auth.ReferralValidation, error)
+}
+
+// ReferralMetrics accepts only the closed event/outcome vocabulary enforced
+// by the coordinator metrics implementation.
+type ReferralMetrics interface {
+	IncReferralEvent(event, outcome string)
 }
 
 // ValidationHandler is intentionally read-only. It exposes invite state for
@@ -29,6 +36,17 @@ type ValidationHandler struct {
 	ValidateSlots chan struct{}
 	SourceIP      func(*http.Request) string
 	Now           func() time.Time
+	Metrics       ReferralMetrics
+	// RequestAccessURL is optional operator configuration shared with the
+	// durable /j/ page. It is informational only and never grants admission.
+	RequestAccessURL string
+}
+
+type validationResponse struct {
+	Valid            bool   `json:"valid"`
+	Required         bool   `json:"required"`
+	Reason           string `json:"reason"`
+	RequestAccessURL string `json:"request_access_url,omitempty"`
 }
 
 func (h *ValidationHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
@@ -39,7 +57,8 @@ func (h *ValidationHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 	w.Header().Set("Cache-Control", "no-store")
 	if !h.Policy.RequireForRegistration {
-		writeJSON(w, http.StatusOK, map[string]any{"valid": true, "required": false, "reason": "disabled"})
+		h.observe("disabled")
+		h.writeValidation(w, true, false, "disabled")
 		return
 	}
 	key := r.RemoteAddr
@@ -51,17 +70,20 @@ func (h *ValidationHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		case h.ValidateSlots <- struct{}{}:
 			defer func() { <-h.ValidateSlots }()
 		default:
+			h.observe("busy")
 			w.Header().Set("Retry-After", "5")
 			writeError(w, http.StatusServiceUnavailable, "busy", "invite validation is temporarily busy")
 			return
 		}
 	}
 	if h.PublicLimiter == nil || !h.PublicLimiter.Allow(key) {
+		h.observe("rate_limited")
 		w.Header().Set("Retry-After", "60")
 		writeError(w, http.StatusTooManyRequests, "rate_limited", "too many referral checks")
 		return
 	}
 	if h.Store == nil {
+		h.observe("unavailable")
 		writeError(w, http.StatusServiceUnavailable, "unavailable", "referral authority unavailable")
 		return
 	}
@@ -69,18 +91,38 @@ func (h *ValidationHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		Code string `json:"code"`
 	}
 	if err := decodeBoundedJSON(r, &request, 1024); err != nil || len([]byte(request.Code)) > 256 {
+		h.observe("bad_request")
 		writeError(w, http.StatusBadRequest, "bad_request", "invalid request")
 		return
 	}
 	validation, err := h.Store.ValidateReferral(r.Context(), h.Policy, request.Code, h.now())
 	if err != nil {
-		writeJSON(w, http.StatusOK, map[string]any{
-			"valid": false, "required": true, "reason": referralReason(err),
-		})
+		reason := referralReason(err)
+		if reason == "invalid" && !errors.Is(err, auth.ErrReferralInvalid) {
+			h.observe("unavailable")
+			writeError(w, http.StatusServiceUnavailable, "unavailable", "referral authority unavailable")
+			return
+		}
+		h.observe(reason)
+		h.writeValidation(w, false, true, reason)
 		return
 	}
-	writeJSON(w, http.StatusOK, map[string]any{
-		"valid": validation.Valid, "required": true, "reason": validation.Reason,
+	h.observe("valid")
+	h.writeValidation(w, validation.Valid, true, validation.Reason)
+}
+
+func (h *ValidationHandler) observe(outcome string) {
+	if h.Metrics != nil {
+		h.Metrics.IncReferralEvent("validate", outcome)
+	}
+}
+
+func (h *ValidationHandler) writeValidation(w http.ResponseWriter, valid, required bool, reason string) {
+	writeJSON(w, http.StatusOK, validationResponse{
+		Valid:            valid,
+		Required:         required,
+		Reason:           reason,
+		RequestAccessURL: strings.TrimSpace(h.RequestAccessURL),
 	})
 }
 

--- a/phase4-coordinator/internal/referralapi/validate_test.go
+++ b/phase4-coordinator/internal/referralapi/validate_test.go
@@ -89,6 +89,7 @@ func TestValidationHandlerOptionalAccessURLCoversDisabledAndCanBeOmitted(t *test
 	t.Run("disabled includes configured URL", func(t *testing.T) {
 		h := &ValidationHandler{
 			Policy:           auth.ReferralPolicy{RequireForRegistration: false},
+			PublicLimiter:    NewBoundedLimiter(10, time.Minute, 10),
 			RequestAccessURL: " https://access.example.test/waitlist ",
 		}
 		response := httptest.NewRecorder()
@@ -117,6 +118,23 @@ func TestValidationHandlerOptionalAccessURLCoversDisabledAndCanBeOmitted(t *test
 			t.Fatalf("absent access URL was serialized: %s", response.Body.String())
 		}
 	})
+}
+
+func TestValidationHandlerKeepsDisabledRouteBounded(t *testing.T) {
+	h := &ValidationHandler{
+		Policy:        auth.ReferralPolicy{RequireForRegistration: false},
+		PublicLimiter: NewBoundedLimiter(1, time.Minute, 1),
+	}
+	first := httptest.NewRecorder()
+	h.ServeHTTP(first, httptest.NewRequest(http.MethodPost, "/v1/referrals/validate", strings.NewReader(`{"code":""}`)))
+	if first.Code != http.StatusOK || !strings.Contains(first.Body.String(), `"reason":"disabled"`) {
+		t.Fatalf("first status=%d body=%s", first.Code, first.Body.String())
+	}
+	second := httptest.NewRecorder()
+	h.ServeHTTP(second, httptest.NewRequest(http.MethodPost, "/v1/referrals/validate", strings.NewReader(`{"code":""}`)))
+	if second.Code != http.StatusTooManyRequests {
+		t.Fatalf("second status=%d body=%s", second.Code, second.Body.String())
+	}
 }
 
 func TestValidationHandlerFailsClosedWhenAuthorityMissing(t *testing.T) {

--- a/phase4-coordinator/internal/referralapi/validate_test.go
+++ b/phase4-coordinator/internal/referralapi/validate_test.go
@@ -14,6 +14,23 @@ import (
 
 type validationStoreFunc func(string) (auth.ReferralValidation, error)
 
+type validationMetrics struct {
+	events []string
+}
+
+func (m *validationMetrics) IncReferralEvent(event, outcome string) {
+	m.events = append(m.events, event+"/"+outcome)
+}
+
+func containsValidationEvent(events []string, want string) bool {
+	for _, event := range events {
+		if event == want {
+			return true
+		}
+	}
+	return false
+}
+
 func (f validationStoreFunc) ValidateReferral(_ context.Context, _ auth.ReferralPolicy, code string, _ time.Time) (auth.ReferralValidation, error) {
 	return f(code)
 }
@@ -30,7 +47,7 @@ func validationPolicy() auth.ReferralPolicy {
 }
 
 func TestValidationHandlerReturnsStableReasonWithoutReserving(t *testing.T) {
-	metrics := &advocacyMetrics{}
+	metrics := &validationMetrics{}
 	h := &ValidationHandler{
 		Store: validationStoreFunc(func(code string) (auth.ReferralValidation, error) {
 			if code == "expired" {
@@ -63,7 +80,7 @@ func TestValidationHandlerReturnsStableReasonWithoutReserving(t *testing.T) {
 			t.Fatalf("configured access URL missing from status=%d body=%s", response.Code, response.Body.String())
 		}
 	}
-	if !containsEvent(metrics.events, "validate/valid") || !containsEvent(metrics.events, "validate/expired") {
+	if !containsValidationEvent(metrics.events, "validate/valid") || !containsValidationEvent(metrics.events, "validate/expired") {
 		t.Fatalf("metrics=%v", metrics.events)
 	}
 }
@@ -116,7 +133,7 @@ func TestValidationHandlerFailsClosedWhenAuthorityMissing(t *testing.T) {
 }
 
 func TestValidationHandlerDoesNotMisreportOperationalFailureAsInvalidCode(t *testing.T) {
-	metrics := &advocacyMetrics{}
+	metrics := &validationMetrics{}
 	h := &ValidationHandler{
 		Store: validationStoreFunc(func(string) (auth.ReferralValidation, error) {
 			return auth.ReferralValidation{}, errors.New("database busy")
@@ -130,7 +147,7 @@ func TestValidationHandlerDoesNotMisreportOperationalFailureAsInvalidCode(t *tes
 	if response.Code != http.StatusServiceUnavailable || strings.Contains(response.Body.String(), `"reason":"invalid"`) {
 		t.Fatalf("status=%d body=%s", response.Code, response.Body.String())
 	}
-	if !containsEvent(metrics.events, "validate/unavailable") {
+	if !containsValidationEvent(metrics.events, "validate/unavailable") {
 		t.Fatalf("metrics=%v", metrics.events)
 	}
 }

--- a/phase4-coordinator/internal/referralapi/validate_test.go
+++ b/phase4-coordinator/internal/referralapi/validate_test.go
@@ -30,6 +30,7 @@ func validationPolicy() auth.ReferralPolicy {
 }
 
 func TestValidationHandlerReturnsStableReasonWithoutReserving(t *testing.T) {
+	metrics := &advocacyMetrics{}
 	h := &ValidationHandler{
 		Store: validationStoreFunc(func(code string) (auth.ReferralValidation, error) {
 			if code == "expired" {
@@ -37,10 +38,12 @@ func TestValidationHandlerReturnsStableReasonWithoutReserving(t *testing.T) {
 			}
 			return auth.ReferralValidation{Valid: true, Reason: "valid"}, nil
 		}),
-		Policy:        validationPolicy(),
-		PublicLimiter: NewBoundedLimiter(10, time.Minute, 10),
-		ValidateSlots: make(chan struct{}, 1),
-		SourceIP:      func(*http.Request) string { return "203.0.113.10" },
+		Policy:           validationPolicy(),
+		PublicLimiter:    NewBoundedLimiter(10, time.Minute, 10),
+		ValidateSlots:    make(chan struct{}, 1),
+		SourceIP:         func(*http.Request) string { return "203.0.113.10" },
+		RequestAccessURL: "https://access.example.test/waitlist",
+		Metrics:          metrics,
 	}
 
 	for _, tc := range []struct {
@@ -56,7 +59,47 @@ func TestValidationHandlerReturnsStableReasonWithoutReserving(t *testing.T) {
 		if response.Code != http.StatusOK || !strings.Contains(response.Body.String(), tc.want) {
 			t.Fatalf("status=%d body=%s want %s", response.Code, response.Body.String(), tc.want)
 		}
+		if !strings.Contains(response.Body.String(), `"request_access_url":"https://access.example.test/waitlist"`) {
+			t.Fatalf("configured access URL missing from status=%d body=%s", response.Code, response.Body.String())
+		}
 	}
+	if !containsEvent(metrics.events, "validate/valid") || !containsEvent(metrics.events, "validate/expired") {
+		t.Fatalf("metrics=%v", metrics.events)
+	}
+}
+
+func TestValidationHandlerOptionalAccessURLCoversDisabledAndCanBeOmitted(t *testing.T) {
+	t.Run("disabled includes configured URL", func(t *testing.T) {
+		h := &ValidationHandler{
+			Policy:           auth.ReferralPolicy{RequireForRegistration: false},
+			RequestAccessURL: " https://access.example.test/waitlist ",
+		}
+		response := httptest.NewRecorder()
+		h.ServeHTTP(response, httptest.NewRequest(http.MethodPost, "/v1/referrals/validate", strings.NewReader(`{"code":""}`)))
+		if response.Code != http.StatusOK ||
+			!strings.Contains(response.Body.String(), `"reason":"disabled"`) ||
+			!strings.Contains(response.Body.String(), `"request_access_url":"https://access.example.test/waitlist"`) {
+			t.Fatalf("status=%d body=%s", response.Code, response.Body.String())
+		}
+	})
+
+	t.Run("invalid omits absent URL", func(t *testing.T) {
+		h := &ValidationHandler{
+			Store: validationStoreFunc(func(string) (auth.ReferralValidation, error) {
+				return auth.ReferralValidation{}, auth.ErrReferralInvalid
+			}),
+			Policy:        validationPolicy(),
+			PublicLimiter: NewBoundedLimiter(10, time.Minute, 10),
+		}
+		response := httptest.NewRecorder()
+		h.ServeHTTP(response, httptest.NewRequest(http.MethodPost, "/v1/referrals/validate", strings.NewReader(`{"code":"bad"}`)))
+		if response.Code != http.StatusOK || !strings.Contains(response.Body.String(), `"reason":"invalid"`) {
+			t.Fatalf("status=%d body=%s", response.Code, response.Body.String())
+		}
+		if strings.Contains(response.Body.String(), "request_access_url") {
+			t.Fatalf("absent access URL was serialized: %s", response.Body.String())
+		}
+	})
 }
 
 func TestValidationHandlerFailsClosedWhenAuthorityMissing(t *testing.T) {
@@ -69,6 +112,26 @@ func TestValidationHandlerFailsClosedWhenAuthorityMissing(t *testing.T) {
 	h.ServeHTTP(response, request)
 	if response.Code != http.StatusServiceUnavailable {
 		t.Fatalf("status=%d body=%s", response.Code, response.Body.String())
+	}
+}
+
+func TestValidationHandlerDoesNotMisreportOperationalFailureAsInvalidCode(t *testing.T) {
+	metrics := &advocacyMetrics{}
+	h := &ValidationHandler{
+		Store: validationStoreFunc(func(string) (auth.ReferralValidation, error) {
+			return auth.ReferralValidation{}, errors.New("database busy")
+		}),
+		Policy:        validationPolicy(),
+		PublicLimiter: NewBoundedLimiter(1, time.Minute, 1),
+		Metrics:       metrics,
+	}
+	response := httptest.NewRecorder()
+	h.ServeHTTP(response, httptest.NewRequest(http.MethodPost, "/v1/referrals/validate", strings.NewReader(`{"code":"well-formed"}`)))
+	if response.Code != http.StatusServiceUnavailable || strings.Contains(response.Body.String(), `"reason":"invalid"`) {
+		t.Fatalf("status=%d body=%s", response.Code, response.Body.String())
+	}
+	if !containsEvent(metrics.events, "validate/unavailable") {
+		t.Fatalf("metrics=%v", metrics.events)
 	}
 }
 

--- a/phase4-coordinator/internal/stats/metrics/metrics.go
+++ b/phase4-coordinator/internal/stats/metrics/metrics.go
@@ -69,6 +69,7 @@ type Metrics struct {
 	IdlePrewarmEventTotal    *prometheus.CounterVec
 	ModelHashMismatchTotal   prometheus.Counter
 	CredentialBootstrapTotal *prometheus.CounterVec
+	ReferralEventTotal       *prometheus.CounterVec
 }
 
 // New registers all five metrics against reg and returns the
@@ -162,6 +163,13 @@ func New(reg prometheus.Registerer) *Metrics {
 			},
 			[]string{"outcome"},
 		),
+		ReferralEventTotal: f.NewCounterVec(
+			prometheus.CounterOpts{
+				Name: "referral_event_total",
+				Help: "Count of public referral validation outcomes using closed-set event and outcome labels.",
+			},
+			[]string{"event", "outcome"},
+		),
 	}
 }
 
@@ -239,4 +247,17 @@ func (m *Metrics) IncCredentialBootstrap(outcome string) {
 		return
 	}
 	m.CredentialBootstrapTotal.WithLabelValues(outcome).Inc()
+}
+
+func (m *Metrics) IncReferralEvent(event, outcome string) {
+	if m == nil || m.ReferralEventTotal == nil || event != "validate" {
+		return
+	}
+	switch outcome {
+	case "disabled", "busy", "rate_limited", "unavailable", "bad_request",
+		"missing", "expired", "revoked", "exhausted", "conflict", "invalid", "valid":
+	default:
+		return
+	}
+	m.ReferralEventTotal.WithLabelValues(event, outcome).Inc()
 }

--- a/phase4-coordinator/internal/stats/metrics/metrics_test.go
+++ b/phase4-coordinator/internal/stats/metrics/metrics_test.go
@@ -47,6 +47,12 @@ var (
 		"rejected_identity": true, "rejected_used": true, "rejected_expired": true,
 		"rejected_rate": true, "rejected_outstanding": true, "store_error": true,
 	}
+	allowReferralOutcome = map[string]bool{
+		"disabled": true, "busy": true, "rate_limited": true,
+		"unavailable": true, "bad_request": true, "missing": true,
+		"expired": true, "revoked": true, "exhausted": true,
+		"conflict": true, "invalid": true, "valid": true,
+	}
 	// Round-1 ARCH M1 / CODE M1 fix: also scan for an
 	// Origin-fragment to prove no attacker-controlled string
 	// from the request `Origin` header lands in a label value.
@@ -87,6 +93,11 @@ func TestLabelHygiene(t *testing.T) {
 		m.IncCredentialBootstrap(outcome)
 	}
 	m.IncCredentialBootstrap("raw-attacker-value")
+	for outcome := range allowReferralOutcome {
+		m.IncReferralEvent("validate", outcome)
+	}
+	m.IncReferralEvent("validate", "raw-attacker-value")
+	m.IncReferralEvent("raw-attacker-value", "valid")
 
 	families, err := reg.Gather()
 	if err != nil {
@@ -143,7 +154,11 @@ func TestLabelHygiene(t *testing.T) {
 						t.Errorf("metric %s track=%q not in allowed set", mf.GetName(), val)
 					}
 				case "event":
-					if !allowIdlePrewarmEvent[val] {
+					if mf.GetName() == "referral_event_total" {
+						if val != "validate" {
+							t.Errorf("metric %s event=%q not in referral allowed set", mf.GetName(), val)
+						}
+					} else if !allowIdlePrewarmEvent[val] {
 						t.Errorf("metric %s event=%q not in allowed set", mf.GetName(), val)
 					}
 				case "reason":
@@ -151,7 +166,11 @@ func TestLabelHygiene(t *testing.T) {
 						t.Errorf("metric %s reason=%q not in allowed set", mf.GetName(), val)
 					}
 				case "outcome":
-					if !allowCredentialBootstrapOutcome[val] {
+					if mf.GetName() == "referral_event_total" {
+						if !allowReferralOutcome[val] {
+							t.Errorf("metric %s outcome=%q not in referral allowed set", mf.GetName(), val)
+						}
+					} else if !allowCredentialBootstrapOutcome[val] {
 						t.Errorf("metric %s outcome=%q not in allowed set", mf.GetName(), val)
 					}
 				}


### PR DESCRIPTION
## Outcome

Restacks only the coordinator join-link and operator-control layer directly on merged referral admission core #574 (`1781cfdf`). The obsolete #575 client dependency and all stale parent commits are absent.

## Current architecture

- Coordinator remains authoritative for code validity, redemption state, invite capacity, and operator audit.
- `referrals.enable_join_links` remains independent and false in checked-in config; disabling it removes `/j/` without deleting durable state.
- `referrals.enable_public_validation` remains false. When reviewed and enabled, nginx exposes only the exact validation route with coordinator-owned edge rate limiting, a 1 KiB body cap, and no-cache controls.
- Join pages validate coordinator state without reservations and use a separately reviewed fixed HTTPS download artifact.
- Seed create/adjust/replace/revoke are local coordinator CLI operations. Applied mutations require actor/reason, effective Unix UID attribution, a caller UUID, and preview-derived full-state CAS where applicable.
- Exact response-loss retries recover the stored result without a second mutation or audit row. Seed replacement revokes the old issuer and creates its successor atomically.
- No Malibu code, provider bearer custody, provider-process management, serving qualification, or social-reward behavior is included.

## Dependency and rollout

Depends only on merged #574. Merge is not activation. Referral admission, validation, join, and social flags remain disabled until the complete signed physical journey passes and a separate activation PR is reviewed.

Next dependency: #623 must be restacked onto `main` only after this PR squash-merges.

## Fresh verification on `fa5923f4`

- `go test ./...`
- targeted `go test -count=1`
- targeted `go test -race -count=1`
- `go vet ./...`
- integration-tag compile across `./...`
- nginx referral route/deployment contract
- deploy/recovery contract
- `git diff --check`
- independent code audit: C0/H0/M0/L0
- independent architecture audit: C0/H0/M0/L0
- independent security audit: C0/H0/M0/L0

Docker was unavailable locally for the stock-nginx composition test; GitHub CI is the required fresh execution surface for that check.

## Recovered stack

1. #573 — merged ledger/migrations
2. #574 — merged coordinator referral admission
3. this PR — join links/operator controls
4. #623 — coordinator advocacy/X rewards, to be restacked after this merge
5. #625 — current-architecture CLI/Malibu onboarding baseline
6. #626 — Malibu referral/advocacy UI, to be restacked after #625
7. signed physical acceptance evidence and separate activation PR
