### PR TITLE
Keep catalog verification portable across macOS release runners

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -154,6 +154,17 @@ jobs:
           set -euo pipefail
           bash scripts/install-pinned-xcodegen.sh "$RUNNER_TEMP/xcodegen-2.45.4"
 
+      - name: Select OpenSSL 3 for catalog verification
+        shell: bash
+        env:
+          HOMEBREW_NO_AUTO_UPDATE: "1"
+        run: |
+          set -euo pipefail
+          brew install openssl@3
+          openssl_bin="$(brew --prefix openssl@3)/bin/openssl"
+          "$openssl_bin" version | grep -E '^OpenSSL 3\.'
+          echo "OPENSSL_BIN=$openssl_bin" >> "$GITHUB_ENV"
+
       - name: Build package
         shell: bash
         run: |

--- a/scripts/catalog-release.py
+++ b/scripts/catalog-release.py
@@ -11,6 +11,8 @@ import math
 import os
 import pathlib
 import re
+import shutil
+import stat
 import subprocess
 import sys
 import tempfile
@@ -33,6 +35,8 @@ MODEL_ID = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]*/[A-Za-z0-9][A-Za-z0-9._-]*$"
 RFC3339 = re.compile(r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:\d{2})$")
 INT64_MIN = -(2**63)
 INT64_MAX = 2**63 - 1
+OPENSSL_PROBE_TIMEOUT_SECONDS = 5
+OPENSSL_VERIFY_TIMEOUT_SECONDS = 15
 
 
 class CatalogError(RuntimeError):
@@ -348,6 +352,73 @@ def parse_sidecar(data: bytes, label: str) -> tuple[str, bytes]:
     return value["key_id"], signature
 
 
+def root_trusted_executable(candidate: str) -> bool:
+    path = pathlib.Path(candidate)
+    if not path.is_absolute() or ".." in path.parts:
+        return False
+    try:
+        resolved = path.resolve(strict=True)
+    except OSError:
+        return False
+
+    for checked_path in {path, resolved}:
+        current = pathlib.Path(checked_path.anchor)
+        components = [current]
+        for component in checked_path.parts[1:]:
+            current /= component
+            components.append(current)
+        for component in components:
+            try:
+                metadata = component.lstat()
+            except OSError:
+                return False
+            if metadata.st_uid != 0:
+                return False
+            if not stat.S_ISLNK(metadata.st_mode) and metadata.st_mode & (stat.S_IWGRP | stat.S_IWOTH):
+                return False
+
+    try:
+        return resolved.is_file() and os.access(resolved, os.X_OK)
+    except OSError:
+        return False
+
+
+def openssl_executable() -> str:
+    override = os.environ.get("OPENSSL_BIN")
+    if override and not pathlib.Path(override).is_absolute():
+        fail("OPENSSL_BIN must be an absolute path to OpenSSL 3 or newer")
+    candidates = [override] if override else [
+        "/opt/homebrew/opt/openssl@3/bin/openssl",
+        "/usr/local/opt/openssl@3/bin/openssl",
+        shutil.which("openssl"),
+    ]
+
+    checked: list[str] = []
+    for candidate in candidates:
+        if not candidate or candidate in checked:
+            continue
+        checked.append(candidate)
+        if os.geteuid() == 0 and not root_trusted_executable(candidate):
+            continue
+        try:
+            result = subprocess.run(
+                [candidate, "version"],
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+                timeout=OPENSSL_PROBE_TIMEOUT_SECONDS,
+            )
+        except (OSError, subprocess.TimeoutExpired):
+            continue
+        version = re.match(r"^OpenSSL ([0-9]+)\.", result.stdout)
+        if result.returncode == 0 and version and int(version.group(1)) >= 3:
+            return candidate
+
+    if override:
+        fail("OPENSSL_BIN must identify a trusted OpenSSL 3 or newer executable; LibreSSL and OpenSSL 1.x are unsupported")
+    fail("OpenSSL 3 or newer is required for Ed25519 catalog verification; LibreSSL and OpenSSL 1.x are unsupported")
+
+
 def verify_ed25519(public_key: bytes, signature: bytes, message: bytes, label: str) -> None:
     # RFC 8410 SubjectPublicKeyInfo prefix for a raw Ed25519 public key.
     spki = bytes.fromhex("302a300506032b6570032100") + public_key
@@ -359,13 +430,17 @@ def verify_ed25519(public_key: bytes, signature: bytes, message: bytes, label: s
         pub_path.write_bytes(spki)
         sig_path.write_bytes(signature)
         msg_path.write_bytes(message)
-        result = subprocess.run(
-            ["openssl", "pkeyutl", "-verify", "-pubin", "-inkey", str(pub_path),
-             "-keyform", "DER", "-rawin", "-in", str(msg_path), "-sigfile", str(sig_path)],
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-            text=True,
-        )
+        try:
+            result = subprocess.run(
+                [openssl_executable(), "pkeyutl", "-verify", "-pubin", "-inkey", str(pub_path),
+                 "-keyform", "DER", "-rawin", "-in", str(msg_path), "-sigfile", str(sig_path)],
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+                timeout=OPENSSL_VERIFY_TIMEOUT_SECONDS,
+            )
+        except subprocess.TimeoutExpired:
+            fail(f"{label}: signature verification timed out")
     if result.returncode != 0:
         fail(f"{label}: signature verification failed")
 

--- a/scripts/test-catalog-release.sh
+++ b/scripts/test-catalog-release.sh
@@ -13,6 +13,37 @@ fail() {
   exit 1
 }
 
+cat >"$TMP/libressl" <<'EOF'
+#!/usr/bin/env bash
+echo 'LibreSSL 3.3.6'
+EOF
+chmod +x "$TMP/libressl"
+if OPENSSL_BIN="$TMP/libressl" python3 "$VERIFY" verify \
+  >"$TMP/libressl.out" 2>"$TMP/libressl.err"; then
+  fail "catalog verifier accepted LibreSSL for Ed25519 verification"
+fi
+grep -q 'OPENSSL_BIN must identify a trusted OpenSSL 3 or newer executable' \
+  "$TMP/libressl.err"
+
+cat >"$TMP/openssl-1" <<'EOF'
+#!/usr/bin/env bash
+echo 'OpenSSL 1.1.1w  11 Sep 2023'
+EOF
+chmod +x "$TMP/openssl-1"
+if OPENSSL_BIN="$TMP/openssl-1" python3 "$VERIFY" verify \
+  >"$TMP/openssl-1.out" 2>"$TMP/openssl-1.err"; then
+  fail "catalog verifier accepted OpenSSL 1.1 for Ed25519 verification"
+fi
+grep -q 'OPENSSL_BIN must identify a trusted OpenSSL 3 or newer executable' \
+  "$TMP/openssl-1.err"
+
+if OPENSSL_BIN=openssl python3 "$VERIFY" verify \
+  >"$TMP/relative.out" 2>"$TMP/relative.err"; then
+  fail "catalog verifier accepted a relative OPENSSL_BIN override"
+fi
+grep -q 'OPENSSL_BIN must be an absolute path to OpenSSL 3 or newer' \
+  "$TMP/relative.err"
+
 stage_release() {
   rm -rf "$TMP/release"
   mkdir -p "$TMP/release"
@@ -47,6 +78,13 @@ spec.loader.exec_module(module)
 canonical = pathlib.Path(sys.argv[2])
 static = pathlib.Path(sys.argv[3])
 coordinator_config = pathlib.Path(sys.argv[4])
+
+assert module.root_trusted_executable("/usr/bin/true")
+with tempfile.TemporaryDirectory() as directory:
+    user_owned = pathlib.Path(directory) / "openssl"
+    user_owned.write_text("#!/bin/sh\nexit 0\n")
+    user_owned.chmod(0o755)
+    assert not module.root_trusted_executable(str(user_owned))
 
 def rejected(label, operation):
     try:


### PR DESCRIPTION
## What changed

- require an absolute OpenSSL 3+ executable for catalog Ed25519 verification
- reject LibreSSL and OpenSSL 1.x with an actionable diagnostic
- enforce root-owned, non-group/world-writable executable ancestry during elevated verification
- bound version probes and signature verification with fail-closed timeouts
- provision and explicitly select OpenSSL 3 in the macOS release job
- lock LibreSSL, OpenSSL 1.1, relative override, and elevated ownership regressions

## Why

The v1.8.32 candidate failed before tagging because the macOS release runner selected an incompatible LibreSSL implementation for pkeyutl -rawin. The repair preserves the catalog signature gate instead of bypassing it and also protects root-run Pearl verification from user-owned executable substitution.

## Validation

- catalog release regression suite passed
- explicit OpenSSL 3 verification passed
- Python and shell syntax plus diff check passed
- full package.sh v1.8.32 build passed
- three independent audits report 0 Critical, 0 High, 0 Medium

## Rollout impact

No production state changes in this PR. Once merged, the v1.8.32 protected release candidate will be rerun from the exact reviewed main SHA.