### PR TITLE
fix(ws): real wall clock for physical socket deadlines (unbreak date-deterministic CI flake)

### DIFF
--- a/phase4-coordinator/internal/ws/server.go
+++ b/phase4-coordinator/internal/ws/server.go
@@ -2080,7 +2080,14 @@ func isLoopbackHost(host string) bool {
 }
 
 func (s *Server) setReadDeadline(conn net.Conn, timeout time.Duration) {
-	_ = conn.SetReadDeadline(s.now().Add(timeout))
+	// Physical socket deadlines MUST use the real wall clock — the OS poller
+	// compares SetReadDeadline against time.Now(), not our injectable logical
+	// clock. In production s.now() == time.Now().UTC() so this is unchanged, but
+	// a test that injects a frozen/offset clock (WithNow) would otherwise hand
+	// the poller a deadline in the past, expiring the read immediately and
+	// closing the handshake ("read auth_challenge: EOF"). s.now() stays the
+	// source of truth for LOGICAL time (token/challenge expiry, epoch age).
+	_ = conn.SetReadDeadline(time.Now().Add(timeout))
 }
 
 func (s *Server) enableProviderTCPKeepAlive(conn net.Conn) {
@@ -2097,7 +2104,8 @@ func (s *Server) enableProviderTCPKeepAlive(conn net.Conn) {
 }
 
 func (s *Server) setWriteDeadline(conn net.Conn) {
-	_ = conn.SetWriteDeadline(s.now().Add(s.cfg.ProviderWSWriteTimeout()))
+	// Real wall clock for the physical socket deadline — see setReadDeadline.
+	_ = conn.SetWriteDeadline(time.Now().Add(s.cfg.ProviderWSWriteTimeout()))
 }
 
 func (s *Server) writeServerText(conn net.Conn, payload []byte) error {


### PR DESCRIPTION
## Problem
`phase4-coordinator (go vet + test)` reds **every** PR via a date-deterministic failure of `TestBuyerHTTPMaintainsOneProviderContinuityAcrossAgeThresholdRekey` (`internal/ws`) — `read auth_challenge: EOF`.

## Root cause
`setReadDeadline` / `setWriteDeadline` passed the server's **injectable logical clock** `s.now()` to `conn.SetReadDeadline` / `SetWriteDeadline`. The OS poller compares socket deadlines against the **real wall clock**, not our logical clock. In production `s.now() == time.Now().UTC()`, so behavior is identical — but the test injects a frozen clock (`providerws.WithNow`) locked to `2026-07-13`. Once real time advances past that date + the handshake timeout, the deadline handed to the poller is already in the past, so the handshake read expires immediately and the server closes the connection.

## Fix
Physical I/O deadlines use `time.Now()`; `s.now()` stays the source of truth for **logical** time (token/challenge expiry, epoch age, admission windows). **Zero production behavior change.**

## Verification
`go vet ./... && go test ./...` on `phase4-coordinator` is fully green, including the previously-failing test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
