### PR TITLE
item 19: disaggregate settlement verdict counters by effective deadline (SPEC-022 B)

### DIFF
--- a/phase4-coordinator/internal/billing/endpoints.go
+++ b/phase4-coordinator/internal/billing/endpoints.go
@@ -171,7 +171,14 @@ type settlementReceiptDiagnostic struct {
 }
 
 type settlementVerdictCounter struct {
-	PolicyVersion           string `json:"policy_version"`
+	PolicyVersion string `json:"policy_version"`
+	// PendingDeadlineSeconds is the EFFECTIVE per-request settlement deadline
+	// (settlement.pending_deadline_seconds) captured on the route snapshot, not
+	// derivable from PolicyVersion — a runtime SIGHUP that changes the deadline
+	// keeps the same policy-version literal (SPEC-022 "Known limitations (B)"),
+	// so counters are disaggregated by this to avoid merging deadline regimes. 0
+	// when the verdict's route snapshot row is absent (LEFT JOIN miss).
+	PendingDeadlineSeconds  int64  `json:"pending_deadline_seconds"`
 	ModelID                 string `json:"model_id"`
 	Entrypoint              string `json:"entrypoint"`
 	ReasonCode              string `json:"reason_code"`
@@ -1071,36 +1078,51 @@ func diagnosticsWindowString(t time.Time, enabled bool) string {
 }
 
 func (h *handler) settlementVerdictCounters(ctx context.Context) ([]settlementVerdictCounter, error) {
+	// Item 19 / SPEC-022 (B): disaggregate by the EFFECTIVE deadline, not just
+	// the coarse route_snapshot_policy_version literal. The verdict row carries
+	// only the absolute pending_deadline_unix_ms, so the effective
+	// settlement.pending_deadline_seconds is pulled from the route snapshot the
+	// verdict was pinned to (joined by digest). The subquery collapses to one
+	// deadline per digest (the digest hashes the snapshot incl. the deadline, so
+	// this is a defensive dedup against any digest collision — never a fan-out).
+	// LEFT JOIN so a verdict whose snapshot row was pruned still reports (as
+	// deadline 0), rather than silently dropping from the counters.
 	rows, err := h.store.db.QueryContext(ctx, `
-SELECT route_snapshot_policy_version,
-       model_id,
-       paid_entrypoint,
-       reason,
-       COALESCE(SUM(CASE WHEN settlement_outcome='verified' THEN 1 ELSE 0 END), 0) AS verified_count,
-       COALESCE(SUM(CASE WHEN settlement_outcome='pending' THEN 1 ELSE 0 END), 0) AS pending_count,
-       COALESCE(SUM(CASE WHEN settlement_outcome='quarantined' THEN 1 ELSE 0 END), 0) AS quarantined_count,
-       COALESCE(SUM(CASE WHEN settlement_outcome='zero_settled' THEN 1 ELSE 0 END), 0) AS zero_settled_count,
+SELECT srv.route_snapshot_policy_version,
+       COALESCE(srs.pending_deadline_seconds, 0) AS pending_deadline_seconds,
+       srv.model_id,
+       srv.paid_entrypoint,
+       srv.reason,
+       COALESCE(SUM(CASE WHEN srv.settlement_outcome='verified' THEN 1 ELSE 0 END), 0) AS verified_count,
+       COALESCE(SUM(CASE WHEN srv.settlement_outcome='pending' THEN 1 ELSE 0 END), 0) AS pending_count,
+       COALESCE(SUM(CASE WHEN srv.settlement_outcome='quarantined' THEN 1 ELSE 0 END), 0) AS quarantined_count,
+       COALESCE(SUM(CASE WHEN srv.settlement_outcome='zero_settled' THEN 1 ELSE 0 END), 0) AS zero_settled_count,
        COALESCE(SUM(CASE
-           WHEN reason IN ('unknown_receipt_version', 'legacy_receipt_version')
-             OR (receipt_present=1 AND receipt_version IS NOT NULL AND receipt_version NOT IN ('4', 'spec015-v0.4', 'v0.4'))
+           WHEN srv.reason IN ('unknown_receipt_version', 'legacy_receipt_version')
+             OR (srv.receipt_present=1 AND srv.receipt_version IS NOT NULL AND srv.receipt_version NOT IN ('4', 'spec015-v0.4', 'v0.4'))
            THEN 1 ELSE 0 END), 0) AS legacy_receipt_count,
        COALESCE(SUM(CASE
-           WHEN receipt_present=0 OR reason IN ('missing_receipt', 'missing_receipt_deadline_elapsed')
+           WHEN srv.receipt_present=0 OR srv.reason IN ('missing_receipt', 'missing_receipt_deadline_elapsed')
            THEN 1 ELSE 0 END), 0) AS missing_receipt_count,
        COALESCE(SUM(CASE
-           WHEN reason IN ('catalog_snapshot_mismatch', 'expected_catalog_model_hash_mismatch')
-             OR reason LIKE 'catalog_%'
+           WHEN srv.reason IN ('catalog_snapshot_mismatch', 'expected_catalog_model_hash_mismatch')
+             OR srv.reason LIKE 'catalog_%'
            THEN 1 ELSE 0 END), 0) AS catalog_mismatch_count,
        COALESCE(SUM(CASE
-           WHEN reason IN ('model_hash_invalid', 'model_hash_null')
-             OR spec008_hash_status IN ('missing', 'null', 'unavailable')
+           WHEN srv.reason IN ('model_hash_invalid', 'model_hash_null')
+             OR srv.spec008_hash_status IN ('missing', 'null', 'unavailable')
            THEN 1 ELSE 0 END), 0) AS model_hash_null_count,
        COALESCE(SUM(CASE
-           WHEN reason IN ('provider_receipt_key_id_invalid', 'provider_receipt_key_id_mismatch', 'receipt_key_mismatch')
+           WHEN srv.reason IN ('provider_receipt_key_id_invalid', 'provider_receipt_key_id_mismatch', 'receipt_key_mismatch')
            THEN 1 ELSE 0 END), 0) AS receipt_key_mismatch_count
-  FROM settlement_receipt_verdicts
- GROUP BY route_snapshot_policy_version, model_id, paid_entrypoint, reason
- ORDER BY route_snapshot_policy_version, model_id, paid_entrypoint, reason`)
+  FROM settlement_receipt_verdicts srv
+  LEFT JOIN (
+      SELECT route_snapshot_digest, MIN(pending_deadline_seconds) AS pending_deadline_seconds
+        FROM settlement_route_snapshots
+       GROUP BY route_snapshot_digest
+  ) srs ON srs.route_snapshot_digest = srv.route_snapshot_digest
+ GROUP BY srv.route_snapshot_policy_version, pending_deadline_seconds, srv.model_id, srv.paid_entrypoint, srv.reason
+ ORDER BY srv.route_snapshot_policy_version, pending_deadline_seconds, srv.model_id, srv.paid_entrypoint, srv.reason`)
 	if err != nil {
 		return nil, err
 	}
@@ -1111,6 +1133,7 @@ SELECT route_snapshot_policy_version,
 		var counter settlementVerdictCounter
 		if err := rows.Scan(
 			&counter.PolicyVersion,
+			&counter.PendingDeadlineSeconds,
 			&counter.ModelID,
 			&counter.Entrypoint,
 			&counter.ReasonCode,

--- a/phase4-coordinator/internal/billing/endpoints_test.go
+++ b/phase4-coordinator/internal/billing/endpoints_test.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -158,6 +159,11 @@ func TestSummaryEndpointIncludesSettlementVerdictCounters(t *testing.T) {
 			counter.Entrypoint != input.RouteSnapshot.PaidEntrypoint {
 			t.Fatalf("counter grouping fields=%#v want route policy/model/entrypoint", counter)
 		}
+		// Item 19: the effective deadline is resolved from the route snapshot,
+		// not the policy-version literal.
+		if counter.PendingDeadlineSeconds != input.RouteSnapshot.PendingDeadlineSeconds {
+			t.Fatalf("counter pending_deadline_seconds=%d want %d (from route snapshot)", counter.PendingDeadlineSeconds, input.RouteSnapshot.PendingDeadlineSeconds)
+		}
 		byReason[counter.ReasonCode] = counter
 	}
 	for _, row := range counterRows {
@@ -200,6 +206,73 @@ func TestSummaryEndpointIncludesSettlementVerdictCounters(t *testing.T) {
 			}
 		default:
 			t.Fatalf("unhandled counter assertion %s", row.wantField)
+		}
+	}
+}
+
+// TestSettlementVerdictCountersDisaggregateByEffectiveDeadline is the item-19
+// regression: two verdicts that share the same route_snapshot_policy_version,
+// model, entrypoint and reason but were pinned to DIFFERENT effective
+// settlement.pending_deadline_seconds (a runtime SIGHUP does not bump the
+// policy-version literal — SPEC-022 (B)) must NOT be merged into one counter
+// row. Before the fix they collapsed under the coarse policy version
+// (verified_count=2); now they split by the effective deadline resolved from the
+// route snapshot.
+func TestSettlementVerdictCountersDisaggregateByEffectiveDeadline(t *testing.T) {
+	fixtures := loadSettlementVerifierFixtures(t)
+	pubkey := decodeSettlementVerifierPubkey(t, fixtures.ProviderReceiptPubkeyB64)
+	base := firstSettlementTupleWithTerminal(t, fixtures, "normal_done")
+	input := settlementVerifierInputFromFixture(t, fixtures, base, pubkey)
+	_, store := newRequestAndBillingStores(t)
+
+	// Same grouping keys, different effective deadline regimes.
+	for _, deadline := range []int64{300, 120} {
+		rowInput := input
+		rowInput.RequestID = fmt.Sprintf("%s-dl%d", input.RequestID, deadline)
+		rowInput.RouteSnapshot.RequestID = rowInput.RequestID
+		rowInput.RouteSnapshot.PendingDeadlineSeconds = deadline
+		seedSettlementVerdictCounterRow(t, store, rowInput, 1, "4", "valid",
+			SettlementOutcomeVerified, "verified_settlement",
+			rowInput.RouteSnapshot.Spec008HashStatus, 1)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/admin/ledger/summary", nil)
+	req.Header.Set("Authorization", "Bearer operator")
+	w := httptest.NewRecorder()
+	store.Handlers("operator", fakeTokens{}, true, 60).ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s", w.Code, w.Body.String())
+	}
+	var resp struct {
+		SettlementVerdictCounters []settlementVerdictCounter `json:"settlement_verdict_counters"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatal(err)
+	}
+
+	byDeadline := map[int64]settlementVerdictCounter{}
+	for _, c := range resp.SettlementVerdictCounters {
+		if c.ReasonCode != "verified_settlement" ||
+			c.PolicyVersion != input.RouteSnapshot.RouteSnapshotPolicyVersion ||
+			c.ModelID != input.RouteSnapshot.ModelID ||
+			c.Entrypoint != input.RouteSnapshot.PaidEntrypoint {
+			continue
+		}
+		if _, dup := byDeadline[c.PendingDeadlineSeconds]; dup {
+			t.Fatalf("duplicate counter row for deadline %d: %#v", c.PendingDeadlineSeconds, c)
+		}
+		byDeadline[c.PendingDeadlineSeconds] = c
+	}
+	if len(byDeadline) != 2 {
+		t.Fatalf("verified_settlement counters not disaggregated by effective deadline: got %d rows %#v", len(byDeadline), byDeadline)
+	}
+	for _, deadline := range []int64{300, 120} {
+		c, ok := byDeadline[deadline]
+		if !ok {
+			t.Fatalf("missing counter for effective deadline %d: %#v", deadline, byDeadline)
+		}
+		if c.VerifiedCount != 1 {
+			t.Fatalf("deadline %d verified_count=%d want 1 (rows merged across deadlines?)", deadline, c.VerifiedCount)
 		}
 	}
 }

--- a/specs/README.md
+++ b/specs/README.md
@@ -30,7 +30,7 @@ it can no longer drift. Do not hand-edit the table; edit each spec's
 | SPEC-019 | Structured output (`response_format: json_schema`) | 0.2.4 | [SPEC-019-structured-output.md](SPEC-019-structured-output.md) |
 | SPEC-020 | Provider autoupdate | v0.1.6 | [SPEC-020-provider-autoupdate.md](SPEC-020-provider-autoupdate.md) |
 | SPEC-021 | MALIBU bootstrap rewards emission ledger | 0.1.0 | [SPEC-021-malibu-emission-ledger.md](SPEC-021-malibu-emission-ledger.md) |
-| SPEC-022 | Verified model settlement | v0.1.4 | [SPEC-022-verified-model-settlement.md](SPEC-022-verified-model-settlement.md) |
+| SPEC-022 | Verified model settlement | v0.1.5 | [SPEC-022-verified-model-settlement.md](SPEC-022-verified-model-settlement.md) |
 | SPEC-023 | Installer-Integrated Autotune Recommend | v0.6 | [SPEC-023-installer-autotune-recommend.md](SPEC-023-installer-autotune-recommend.md) |
 | SPEC-024 | Prefix-cache billing and provider-local cache isolation | 0.2.1 | [SPEC-024-prefix-cache-billing.md](SPEC-024-prefix-cache-billing.md) |
 | SPEC-025 | Native Mac App (signed `.dmg` + menu bar wrapper) | v0.10 | [SPEC-025-native-mac-app.md](SPEC-025-native-mac-app.md) |

--- a/specs/SPEC-022-verified-model-settlement.md
+++ b/specs/SPEC-022-verified-model-settlement.md
@@ -1,11 +1,24 @@
 # SPEC-022 - Verified model settlement
 
-Version: v0.1.4
+Version: v0.1.5
 Status: Draft, lock-ready after round-4 closure
 Date drafted: 2026-06-30
 Depends on: SPEC-001, SPEC-002, SPEC-005, SPEC-006, SPEC-008, SPEC-010, SPEC-011, SPEC-015, SPEC-016
 
 ## Change log
+
+### v0.1.5
+
+Amends "Known limitations (B)" (runbook item 19): the effective per-request
+deadline is authoritatively recoverable from
+`settlement_route_snapshots.pending_deadline_seconds` (the coarse
+`route_snapshot_policy_version` literal does not track a runtime SIGHUP of
+`settlement.pending_deadline_seconds`). Reporting that needs the effective
+deadline MUST read/group by that column; the `settlement_verdict_counters`
+diagnostics now disaggregate by it (resolved via `route_snapshot_digest`) so
+counters are no longer merged across deadline regimes under one policy version.
+No settlement-correctness change; the SPEC-022 R-1.1 authoritative policy object
+remains the deferred follow-up.
 
 ### v0.1.4
 
@@ -1002,9 +1015,21 @@ as documented follow-ups rather than blocking it.
   `settlement.pending_deadline_seconds` keeps the same policy-version
   literal. Per-row settlement stays correct (each row pins and hashes its
   own deadline independent of the version string), so this only affects
-  report-by-policy-version aggregation, not settlement correctness. Fully
-  deriving the version from the effective policy object is the unimplemented
-  SPEC-022 R-1.1 policy object; carried as a follow-up.
+  report-by-policy-version aggregation, not settlement correctness. The
+  **effective per-request deadline is authoritatively captured per-row** in
+  `settlement_route_snapshots.pending_deadline_seconds` (set from the runtime
+  config at dispatch and included in the route-snapshot digest), so it is
+  always recoverable regardless of the coarse version literal. **Reporting that
+  needs the effective deadline MUST read/group by that column, not the version
+  string.** Accordingly, the `settlement_verdict_counters` diagnostics
+  (`/admin/ledger/summary`) now disaggregate by the effective
+  `pending_deadline_seconds` (resolved from the route snapshot via
+  `route_snapshot_digest`), so counters are no longer merged across deadline
+  regimes under one policy version (item 19). A verdict whose route-snapshot row
+  is absent reports deadline `0`. Fully deriving a single authoritative version
+  from the effective policy object (so the version literal *itself* tracks
+  runtime reconfiguration) remains the unimplemented SPEC-022 R-1.1 policy
+  object; carried as a follow-up.
 
 ## Open questions
 

--- a/specs/SPEC-022-verified-model-settlement.md
+++ b/specs/SPEC-022-verified-model-settlement.md
@@ -1019,21 +1019,25 @@ as documented follow-ups rather than blocking it.
   **effective per-request deadline is authoritatively captured per-row** in
   `settlement_route_snapshots.pending_deadline_seconds` (set from the runtime
   config at dispatch and included in the route-snapshot digest), so it is
-  always recoverable regardless of the coarse version literal. **Reporting that
-  needs the effective deadline MUST read/group by that column, not the version
-  string.** Accordingly, the `settlement_verdict_counters` diagnostics
+  recoverable — independent of the coarse version literal — as long as the pinned
+  route-snapshot row is retained (verdict and snapshot rows are co-retained; no
+  repository pruning path removes a snapshot ahead of its verdict). **Reporting
+  that needs the effective deadline MUST read/group by that column, not the
+  version string.** Accordingly, the `settlement_verdict_counters` diagnostics
   (`/admin/ledger/summary`) now disaggregate by the effective
   `pending_deadline_seconds` (resolved from the route snapshot via
   `route_snapshot_digest`), so counters are no longer merged across deadline
-  regimes under one policy version (item 19). A verdict whose route-snapshot row
-  is absent reports deadline `0`. Fully deriving a single authoritative version
+  regimes under one policy version (item 19). Deadline `0` is reserved as the
+  **unknown** sentinel: a verdict whose route-snapshot row is absent reports `0`
+  (which itself groups all unknown regimes together — an accepted degenerate case,
+  not a valid 1..900 deadline). Fully deriving a single authoritative version
   from the effective policy object (so the version literal *itself* tracks
   runtime reconfiguration) remains the unimplemented SPEC-022 R-1.1 policy
   object; carried as a follow-up.
 
 ## Open questions
 
-None for v0.1.4. Deferred implementation details belong in the receipt-profile
+None for v0.1.5. Deferred implementation details belong in the receipt-profile
 spec or the SPEC-022 implementation prompt, not in the locked settlement gate.
 
 ## Decision log

--- a/specs/design/spec-022/SPEC-022-IMPL-DELIVERABLE-7.md
+++ b/specs/design/spec-022/SPEC-022-IMPL-DELIVERABLE-7.md
@@ -22,10 +22,15 @@ raw account scope. Verdict events now include:
 - buyer debit, provider settlement, and payout exclusion outcomes.
 
 `/admin/ledger/summary` now exposes `settlement_verdict_counters`, grouped by
-policy version, model id, entrypoint, and reason code. Each grouped row includes
-counters for verified, pending, quarantined, zero-settled, legacy receipt,
-missing receipt, catalog mismatch, model-hash null, and receipt-key mismatch
-outcomes.
+policy version, effective `pending_deadline_seconds`, model id, entrypoint, and
+reason code (item 19 / SPEC-022 (B): the effective deadline is resolved from the
+route snapshot via `route_snapshot_digest`, so a runtime deadline reconfiguration
+that keeps the same policy-version literal is not merged into one row — consumers
+MUST NOT assume uniqueness on the original four dimensions; the deadline dimension
+multiplies rows accordingly, and `0` marks an unknown/absent snapshot). Each
+grouped row includes counters for verified, pending, quarantined, zero-settled,
+legacy receipt, missing receipt, catalog mismatch, model-hash null, and
+receipt-key mismatch outcomes.
 
 ## Validation
 


### PR DESCRIPTION
## Item 19 — settlement verdict counters merge different effective deadlines (SPEC-022 (B))

`route_snapshot_policy_version` is a coarse literal (`spec022-prereq-v0`=30s, `spec022-prereq-v1`=300s) marking when the *default* `settlement.pending_deadline_seconds` changed. It does **not** track a runtime SIGHUP that reconfigures the deadline (same literal). The `settlement_verdict_counters` diagnostics (`/admin/ledger/summary`) did `GROUP BY route_snapshot_policy_version, model_id, paid_entrypoint, reason` — so settlement outcomes (verified/pending/quarantined/…) with **different effective deadlines** were silently merged into one counter, misleading an operator reading pending→quarantine rates by deadline regime.

### Verify-before-design
The effective per-request deadline is **already captured authoritatively per-row** on `settlement_route_snapshots.pending_deadline_seconds` (set from runtime config at dispatch — `route_snapshot.go:62,102` — and hashed into `route_snapshot_digest`). It is *not* on `settlement_receipt_verdicts` (which has only the absolute `pending_deadline_unix_ms` + the coarse version). So no schema migration was needed — the report just wasn't using existing data.

### Fix (read-only diagnostics; no schema migration; no settlement-correctness change)
- `settlementVerdictCounters` now `LEFT JOIN`s the route snapshot by `route_snapshot_digest` (dedup subquery = one deadline per digest → no count fan-out) and adds `pending_deadline_seconds` to `SELECT`/`GROUP BY`/`ORDER BY`; verdict columns qualified `srv.`.
- A verdict whose snapshot row is absent reports deadline `0` (explicit **unknown** sentinel; LEFT JOIN keeps it counted rather than dropped).
- `settlementVerdictCounter` gains a `PendingDeadlineSeconds` field.

### Tests
- Existing `TestSummaryEndpointIncludesSettlementVerdictCounters` now asserts the effective deadline resolves from the route snapshot.
- New `TestSettlementVerdictCountersDisaggregateByEffectiveDeadline`: two verdicts sharing policy version/model/entrypoint/reason but pinned to different deadlines (300 vs 120) produce **two** rows (`verified_count=1` each), not one merged row — fails on the pre-fix query.

Full `phase4-coordinator` `go vet ./... && go test ./...` green.

### Audit
Codex 3-lane R1 converged: **code 0/0/0/0, security 0/0/0/0, architect 0/0/0/3L** — all lanes 0 C/H/M. The three architect LOWs (doc accuracy: deadline-0 unknown sentinel, stale "None for v0.1.4", deliverable-7 report contract) folded in.

### Specs
SPEC-022 → v0.1.5: (B) amended (effective deadline recoverable per-row + reporting guidance + the disaggregation behavior); the R-1.1 authoritative policy object (version literal that *itself* tracks runtime reconfig) remains the deferred follow-up. `SPEC-022-IMPL-DELIVERABLE-7` report contract updated. Spec index regenerated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
