### PR TITLE
Keep acceptance version checks reliable under pipefail

### DIFF
--- a/.github/workflows/acceptance-candidate.yml
+++ b/.github/workflows/acceptance-candidate.yml
@@ -135,8 +135,10 @@ jobs:
           grep -Eq "coordinator-linux-amd64:[[:space:]]+ELF 64-bit.*x86-64" "$RUNNER_TEMP/pearl-file.txt"
           grep -Eq "coordinator-cli-linux-amd64:[[:space:]]+ELF 64-bit.*x86-64" "$RUNNER_TEMP/pearl-file.txt"
           grep -Eq "gateway-linux-amd64:[[:space:]]+ELF 64-bit.*x86-64" "$RUNNER_TEMP/pearl-file.txt"
-          strings "$RUNNER_TEMP/coordinator-linux-amd64" | grep -Fq "$TAG"
-          strings "$RUNNER_TEMP/gateway-linux-amd64" | grep -Fq "$TAG"
+          strings "$RUNNER_TEMP/coordinator-linux-amd64" > "$RUNNER_TEMP/coordinator-strings.txt"
+          strings "$RUNNER_TEMP/gateway-linux-amd64" > "$RUNNER_TEMP/gateway-strings.txt"
+          grep -Fq "$TAG" "$RUNNER_TEMP/coordinator-strings.txt"
+          grep -Fq "$TAG" "$RUNNER_TEMP/gateway-strings.txt"
 
       - name: Install main-reviewed XcodeGen artifact
         shell: bash

--- a/scripts/test-acceptance-candidate-security.sh
+++ b/scripts/test-acceptance-candidate-security.sh
@@ -51,6 +51,16 @@ if protected.find("verify-acceptance-remote-state.sh") > protected.find("RELEASE
     raise SystemExit("a protected token is imported before the post-approval candidate drift gate")
 if 'MACPROVIDER_PROVIDER_ADMISSION_POLICY="$PROVIDER_ADMISSION_POLICY"' not in build:
     raise SystemExit("candidate package does not receive the exact admission policy input")
+if re.search(r'^\s*strings\s+.*\|\s*grep\s+.*-q', build, re.MULTILINE):
+    raise SystemExit("candidate binary version checks can fail under pipefail when grep exits early")
+for value in (
+    'strings "$RUNNER_TEMP/coordinator-linux-amd64" > "$RUNNER_TEMP/coordinator-strings.txt"',
+    'strings "$RUNNER_TEMP/gateway-linux-amd64" > "$RUNNER_TEMP/gateway-strings.txt"',
+    'grep -Fq "$TAG" "$RUNNER_TEMP/coordinator-strings.txt"',
+    'grep -Fq "$TAG" "$RUNNER_TEMP/gateway-strings.txt"',
+):
+    if value not in build:
+        raise SystemExit(f"candidate binary version check is incomplete: {value}")
 if "retention-days: 1" not in protected or "actions/upload-artifact@ea165f8d" not in protected:
     raise SystemExit("private acceptance artifact is not short-lived and action-pinned")
 for secret in (


### PR DESCRIPTION
## Outcome

Keeps the private Issue #585 acceptance build reliable under macOS `set -o pipefail` while preserving the embedded-version assertion for the coordinator and gateway binaries.

## Root cause

Acceptance run `29357448110` built the binaries successfully, but Xcode 16.4's `strings` reported `failed to flush output` after `grep -q` exited on the first match. With `pipefail`, that expected early pipe close failed the job before any protected environment or secret was reached.

## Change

- Materialize each binary's `strings` output before checking for `v1.8.33`.
- Add a workflow-contract regression that rejects `strings | grep -q` under pipefail and requires both version checks to remain present.
- Leave the protected signer, secret boundary, ref/SHA checks, signing, notarization, and no-publication behavior unchanged.

## Validation

- `bash scripts/test-acceptance-candidate-security.sh`
- `bash -n scripts/test-acceptance-candidate-security.sh`
- `git diff --check`
- `actionlint .github/workflows/acceptance-candidate.yml` when available

Refs #585
