### PR TITLE
Bind acceptance ledger checks to the reviewed main control

### DIFF
--- a/scripts/test-acceptance-candidate-security.sh
+++ b/scripts/test-acceptance-candidate-security.sh
@@ -308,16 +308,17 @@ candidate_sha="$(git -C "$work/source" rev-parse HEAD)"
 git -C "$work/source" push -q -u origin candidate
 git clone -q "file://$work/bare.git" "$work/candidate"
 git -C "$work/candidate" checkout -q "$candidate_sha"
-GITHUB_EVENT_NAME=workflow_dispatch \
-GITHUB_REF=refs/heads/main \
-GITHUB_SHA="$(git -C "$root" rev-parse HEAD)" \
-GITHUB_REPOSITORY=Augustas11/macprovider \
-  bash "$source_guard" "$root" "$work/candidate" "file://$work/bare.git" \
-    refs/heads/candidate "$candidate_sha" v9.9.9
-
 git clone -q "file://$work/bare.git" "$work/control"
 git -C "$work/control" checkout -q main
 control_sha="$(git -C "$work/control" rev-parse HEAD)"
+GITHUB_EVENT_NAME=workflow_dispatch \
+GITHUB_REF=refs/heads/main \
+GITHUB_SHA="$control_sha" \
+GITHUB_REPOSITORY=Augustas11/macprovider \
+  bash "$source_guard" "$work/control" "$work/candidate" "file://$work/bare.git" \
+    refs/heads/candidate "$candidate_sha" v9.9.9
+test "$(git -C "$work/candidate" rev-parse refs/remotes/origin/main)" = "$control_sha"
+
 (
   cd "$work/control"
   GITHUB_EVENT_NAME=workflow_dispatch \
@@ -329,14 +330,33 @@ git -C "$work/source" tag v9.9.9 "$candidate_sha"
 git -C "$work/source" push -q origin v9.9.9
 if GITHUB_EVENT_NAME=workflow_dispatch \
   GITHUB_REF=refs/heads/main \
-  GITHUB_SHA="$(git -C "$root" rev-parse HEAD)" \
+  GITHUB_SHA="$control_sha" \
   GITHUB_REPOSITORY=Augustas11/macprovider \
-    bash "$source_guard" "$root" "$work/candidate" "file://$work/bare.git" \
+    bash "$source_guard" "$work/control" "$work/candidate" "file://$work/bare.git" \
       refs/heads/candidate "$candidate_sha" v9.9.9 >"$work/existing-tag.out" 2>&1; then
   echo "source guard accepted an existing production tag" >&2
   exit 1
 fi
 grep -q 'candidate tag already exists' "$work/existing-tag.out"
+git -C "$work/source" tag -d v9.9.9 >/dev/null
+git -C "$work/source" push -q origin :refs/tags/v9.9.9
+
+git -C "$work/source" checkout -q main
+printf 'drift\n' >> "$work/source/value"
+git -C "$work/source" add value
+git -C "$work/source" commit -qm drift-main
+git -C "$work/source" push -q origin main
+if (
+  cd "$work/control"
+  GITHUB_EVENT_NAME=workflow_dispatch \
+  GITHUB_REF=refs/heads/main \
+  GITHUB_SHA="$control_sha" \
+    bash "$remote_guard" refs/heads/candidate "$candidate_sha" v9.9.9
+) >"$work/main-drift.out" 2>&1; then
+  echo "protected remote guard accepted a drifted main control branch" >&2
+  exit 1
+fi
+grep -q 'main control branch drifted after dispatch' "$work/main-drift.out"
 
 bash -n "$signer" "$source_guard" "$remote_guard" "$provisioner"
 printf '[test-acceptance-candidate-security] ok: read-only signer, exact source, expiry, domain separation, and no publication\n'

--- a/scripts/verify-acceptance-candidate-source.sh
+++ b/scripts/verify-acceptance-candidate-source.sh
@@ -48,6 +48,16 @@ read -r remote_sha remote_ref extra <<<"$remote_row"
 [[ "$remote_sha" == "$candidate_sha" ]] ||
   die "candidate ref tip is $remote_sha, not requested SHA $candidate_sha"
 
+# package.sh verifies the immutable catalog release ledger against origin/main.
+# Materialize that read-only ref from the same repository and bind it to the
+# exact main control commit that owns this workflow run.
+git -C "$candidate_dir" fetch --quiet --no-tags --depth=1 origin \
+  "+refs/heads/main:refs/remotes/origin/main" ||
+  die "could not refresh origin/main release-ledger base"
+ledger_base_sha="$(git -C "$candidate_dir" rev-parse refs/remotes/origin/main)"
+[[ "$ledger_base_sha" == "$GITHUB_SHA" ]] ||
+  die "origin/main release-ledger base is $ledger_base_sha, not control commit $GITHUB_SHA"
+
 tag_rows="$(git -C "$candidate_dir" ls-remote origin "refs/tags/$tag" "refs/tags/$tag^{}")" ||
   die "could not verify candidate tag absence"
 [[ -z "$tag_rows" ]] || die "candidate tag already exists on origin; acceptance signing is forbidden"

--- a/scripts/verify-acceptance-remote-state.sh
+++ b/scripts/verify-acceptance-remote-state.sh
@@ -20,6 +20,12 @@ git check-ref-format --branch "${candidate_ref#refs/heads/}" >/dev/null 2>&1 || 
 [[ "$candidate_sha" =~ ^[0-9a-f]{40}$ ]] || die "candidate SHA is invalid"
 [[ "$tag" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]] || die "candidate tag is invalid"
 
+main_row="$(git ls-remote --exit-code origin refs/heads/main)" || die "main control branch is unavailable"
+[[ "$(printf '%s\n' "$main_row" | wc -l | tr -d ' ')" == "1" ]] || die "main branch lookup was ambiguous"
+read -r main_sha main_ref main_extra <<<"$main_row"
+[[ -z "${main_extra:-}" && "$main_ref" == refs/heads/main && "$main_sha" == "$GITHUB_SHA" ]] ||
+  die "main control branch drifted after dispatch"
+
 remote_row="$(git ls-remote --exit-code origin "$candidate_ref")" || die "candidate branch is unavailable"
 [[ "$(printf '%s\n' "$remote_row" | wc -l | tr -d ' ')" == "1" ]] || die "candidate branch lookup was ambiguous"
 read -r remote_sha remote_ref extra <<<"$remote_row"


### PR DESCRIPTION
## Outcome

Makes the main-owned Issue #585 acceptance workflow provide the exact immutable catalog ledger base required by candidate packaging, while binding that base to the reviewed workflow control commit.

## Root cause

Acceptance run `29358216017` passed the corrected Pearl binary stage, then failed before secrets at `Build candidate CLI compatibility set` because the detached candidate checkout had no `origin/main`. `package.sh` correctly refuses to verify the signed catalog release without that immutable ledger base.

## Change

- Fetch `refs/heads/main` into the candidate checkout as read-only `refs/remotes/origin/main`.
- Require the fetched ledger base to equal the exact `GITHUB_SHA` control commit.
- Recheck remote `main` alongside the candidate branch and absent tag after environment approval and before private export.
- Extend the signer security test to prove ledger materialization and rejection of main drift.

No candidate code, protected secret, signing/notarization command, environment policy, retention setting, or publication capability changes.

## Validation

- `bash scripts/test-acceptance-candidate-security.sh`
- `bash -n scripts/verify-acceptance-candidate-source.sh scripts/verify-acceptance-remote-state.sh scripts/test-acceptance-candidate-security.sh`
- `git diff --check`

Refs #585
