### PR TITLE
Keep acceptance Malibu builds compatible with dependency-free candidates

### DIFF
--- a/.github/workflows/acceptance-candidate.yml
+++ b/.github/workflows/acceptance-candidate.yml
@@ -161,9 +161,13 @@ jobs:
           set -euo pipefail
           cd candidate/phase3-binary/app
           "$RUNNER_TEMP/xcodegen-2.45.4/xcodegen/bin/xcodegen" generate
-          resolved_dir="Malibu.xcodeproj/project.xcworkspace/xcshareddata/swiftpm"
-          mkdir -p "$resolved_dir"
-          cp Package.resolved "$resolved_dir/Package.resolved"
+          package_resolution_args=()
+          if [ -f Package.resolved ]; then
+            resolved_dir="Malibu.xcodeproj/project.xcworkspace/xcshareddata/swiftpm"
+            mkdir -p "$resolved_dir"
+            cp Package.resolved "$resolved_dir/Package.resolved"
+            package_resolution_args=(-onlyUsePackageVersionsFromResolvedFile)
+          fi
           xcodebuild \
             -project Malibu.xcodeproj \
             -scheme Malibu \
@@ -171,7 +175,7 @@ jobs:
             -destination "generic/platform=macOS" \
             -archivePath "$RUNNER_TEMP/Malibu.xcarchive" \
             archive \
-            -onlyUsePackageVersionsFromResolvedFile \
+            "${package_resolution_args[@]}" \
             ARCHS=arm64 \
             CODE_SIGNING_ALLOWED=NO
           cp -R "$RUNNER_TEMP/Malibu.xcarchive/Products/Applications/Malibu.app" \

--- a/scripts/test-acceptance-candidate-security.sh
+++ b/scripts/test-acceptance-candidate-security.sh
@@ -61,6 +61,16 @@ for value in (
 ):
     if value not in build:
         raise SystemExit(f"candidate binary version check is incomplete: {value}")
+for value in (
+    'package_resolution_args=()',
+    'if [ -f Package.resolved ]; then',
+    'package_resolution_args=(-onlyUsePackageVersionsFromResolvedFile)',
+    '"${package_resolution_args[@]}"',
+):
+    if value not in build:
+        raise SystemExit(f"candidate Malibu dependency handling is incomplete: {value}")
+if re.search(r'^\s*cp Package\.resolved ', build, re.MULTILINE) and 'if [ -f Package.resolved ]; then' not in build:
+    raise SystemExit("candidate Malibu build requires a removed optional lockfile")
 if "retention-days: 1" not in protected or "actions/upload-artifact@ea165f8d" not in protected:
     raise SystemExit("private acceptance artifact is not short-lived and action-pinned")
 for secret in (


### PR DESCRIPTION
## Outcome

Allows the private Issue #585 acceptance workflow to archive both dependency-free Malibu candidates and older candidates that still carry an app SwiftPM lockfile.

## Root cause

Acceptance run `29359149492` completed the 14-minute CLI compatibility-set build, then failed immediately because PR #589 correctly removed Sparkle and `phase3-binary/app/Package.resolved`, while the main-owned workflow still copied that optional file unconditionally.

## Change

- Start with no package-resolution arguments.
- When the candidate supplies `Package.resolved`, copy it into the generated workspace and preserve `-onlyUsePackageVersionsFromResolvedFile`.
- When the dependency-free candidate omits it, archive without the inapplicable flag.
- Add workflow-contract assertions covering both paths.

No candidate code, protected secret, signing/notarization command, environment policy, ref/SHA guard, retention setting, or publication capability changes.

## Validation

- `bash scripts/test-acceptance-candidate-security.sh`
- `bash -n scripts/test-acceptance-candidate-security.sh`
- `git diff --check`
- `actionlint .github/workflows/acceptance-candidate.yml` when available

Refs #585
