### PR TITLE
Keep acceptance signing in an owned user keychain

### DIFF
--- a/scripts/acceptance-signing-keychain.sh
+++ b/scripts/acceptance-signing-keychain.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# Main-owned lifecycle helpers for the transient Developer ID signing keychain.
+# This file is sourced by sign-acceptance-candidate.sh.
+
+acceptance_previous_default_keychain=""
+acceptance_keychain_created=0
+acceptance_keychain_restore_required=0
+
+acceptance_keychain_capture_default() {
+  local raw_default
+  raw_default="$(security default-keychain -d user 2>/dev/null)" || return 1
+  [[ -n "$raw_default" && "$raw_default" != *$'\n'* ]] || return 1
+  raw_default="$(
+    printf '%s\n' "$raw_default" |
+      sed -e 's/^[[:space:]]*"//' -e 's/"[[:space:]]*$//'
+  )"
+  [[ -n "$raw_default" ]] || return 1
+  acceptance_previous_default_keychain="$raw_default"
+}
+
+acceptance_keychain_create_and_select() {
+  local keychain="$1"
+  local password="$2"
+
+  acceptance_keychain_created=0
+  acceptance_keychain_restore_required=0
+  security create-keychain -p "$password" "$keychain" || return 1
+  acceptance_keychain_created=1
+  # Set the restore flag before changing the default so even a partial failure
+  # attempts to restore the captured state.
+  acceptance_keychain_restore_required=1
+  security default-keychain -d user -s "$keychain" || return 1
+  security unlock-keychain -p "$password" "$keychain" || return 1
+  security set-keychain-settings -lut 3600 "$keychain" || return 1
+}
+
+acceptance_keychain_cleanup() {
+  local keychain="$1"
+  local failed=0
+
+  if [[ "$acceptance_keychain_restore_required" == 1 ]]; then
+    security default-keychain -d user -s "$acceptance_previous_default_keychain" \
+      >/dev/null 2>&1 || failed=1
+  fi
+  if [[ "$acceptance_keychain_created" == 1 ]]; then
+    security delete-keychain "$keychain" >/dev/null 2>&1 || failed=1
+  fi
+  return "$failed"
+}

--- a/scripts/sign-acceptance-candidate.sh
+++ b/scripts/sign-acceptance-candidate.sh
@@ -22,6 +22,7 @@ root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd -P)"
 metadata="$root/scripts/acceptance-candidate-metadata.py"
 compatibility="$root/scripts/compatibility-set-manifest.py"
 artifact_index="$root/scripts/compatibility-artifact-index.py"
+keychain_helper="$root/scripts/acceptance-signing-keychain.sh"
 acceptance_public_key="$root/security/acceptance-candidate-signing-public.pem"
 openssl_bin="${OPENSSL_BIN:-openssl}"
 
@@ -42,7 +43,7 @@ esac
 for command in python3 security codesign xcrun ditto hdiutil tar shasum spctl base64 "$openssl_bin"; do
   command -v "$command" >/dev/null 2>&1 || die "required command is unavailable: $command"
 done
-for path in "$metadata" "$compatibility" "$artifact_index" "$acceptance_public_key"; do
+for path in "$metadata" "$compatibility" "$artifact_index" "$keychain_helper" "$acceptance_public_key"; do
   [[ -f "$path" && ! -L "$path" ]] || die "trusted signer input is absent or unsafe: $path"
 done
 [[ -d "$unsigned_dir" && ! -L "$unsigned_dir" ]] || die "unsigned input directory is absent or unsafe"
@@ -85,12 +86,27 @@ python3 "$metadata" verify-unsigned \
   "${unsigned_assets[@]}"
 
 signing_tmp="$(mktemp -d "${RUNNER_TEMP:-${TMPDIR:-/tmp}}/acceptance-signer.XXXXXX")"
-keychain="$signing_tmp/acceptance-signing.keychain-db"
+# The trusted path is validated above before sourcing.
+# shellcheck disable=SC1090,SC1091
+source "$keychain_helper"
+keychain_nonce="$("$openssl_bin" rand -hex 8)"
+[[ "$keychain_nonce" =~ ^[0-9a-f]{16}$ ]] || die "could not generate a safe keychain nonce"
+keychain="acceptance-signing-${run_id}-${run_attempt}-${keychain_nonce}.keychain"
 cleanup() {
-  security delete-keychain "$keychain" >/dev/null 2>&1 || true
+  local status=$?
+  local cleanup_failed=0
+  if ! acceptance_keychain_cleanup "$keychain"; then
+    printf '[sign-acceptance-candidate] ERROR: could not restore and remove the signing keychain\n' >&2
+    cleanup_failed=1
+  fi
   rm -rf "$signing_tmp"
+  if [[ "$status" == 0 && "$cleanup_failed" == 1 ]]; then
+    status=1
+  fi
+  exit "$status"
 }
 trap cleanup EXIT
+acceptance_keychain_capture_default || die "could not capture the existing user default keychain"
 
 private_key="$signing_tmp/acceptance-private.pem"
 derived_public_key="$signing_tmp/acceptance-public.pem"
@@ -148,9 +164,8 @@ python3 "$compatibility" validate \
   --openssl "$openssl_bin"
 
 keychain_password="$("$openssl_bin" rand -hex 24)"
-security create-keychain -p "$keychain_password" "$keychain"
-security unlock-keychain -p "$keychain_password" "$keychain"
-security set-keychain-settings -lut 3600 "$keychain"
+acceptance_keychain_create_and_select "$keychain" "$keychain_password" ||
+  die "could not create and select the transient signing keychain"
 printf '%s' "$APPLE_DEVELOPER_ID_CERT_P12_BASE64" | base64 -d > "$signing_tmp/developer-id.p12"
 security import "$signing_tmp/developer-id.p12" \
   -k "$keychain" \

--- a/scripts/test-acceptance-candidate-security.sh
+++ b/scripts/test-acceptance-candidate-security.sh
@@ -5,13 +5,19 @@ root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd -P)"
 workflow="$root/.github/workflows/acceptance-candidate.yml"
 metadata="$root/scripts/acceptance-candidate-metadata.py"
 signer="$root/scripts/sign-acceptance-candidate.sh"
+keychain_helper="$root/scripts/acceptance-signing-keychain.sh"
 source_guard="$root/scripts/verify-acceptance-candidate-source.sh"
 remote_guard="$root/scripts/verify-acceptance-remote-state.sh"
 provisioner="$root/scripts/provision-acceptance-signing-key.sh"
 work="$(mktemp -d "${TMPDIR:-/tmp}/acceptance-security.XXXXXX")"
 trap 'rm -rf "$work"' EXIT
 
-python3 - "$workflow" "$metadata" "$signer" "$provisioner" "$root/schemas/acceptance-candidate-v1.schema.json" <<'PY'
+fail() {
+  printf '[test-acceptance-candidate-security] ERROR: %s\n' "$*" >&2
+  exit 1
+}
+
+python3 - "$workflow" "$metadata" "$signer" "$keychain_helper" "$provisioner" "$root/schemas/acceptance-candidate-v1.schema.json" <<'PY'
 import ast
 import pathlib
 import re
@@ -20,8 +26,9 @@ import sys
 workflow = pathlib.Path(sys.argv[1]).read_text(encoding="utf-8")
 metadata = pathlib.Path(sys.argv[2]).read_text(encoding="utf-8")
 signer = pathlib.Path(sys.argv[3]).read_text(encoding="utf-8")
-provisioner = pathlib.Path(sys.argv[4]).read_text(encoding="utf-8")
-schema = __import__("json").loads(pathlib.Path(sys.argv[5]).read_text(encoding="utf-8"))
+keychain_helper = pathlib.Path(sys.argv[4]).read_text(encoding="utf-8")
+provisioner = pathlib.Path(sys.argv[5]).read_text(encoding="utf-8")
+schema = __import__("json").loads(pathlib.Path(sys.argv[6]).read_text(encoding="utf-8"))
 
 if "\n  workflow_dispatch:\n" not in workflow or "\n  push:" in workflow:
     raise SystemExit("acceptance workflow must be manual dispatch only")
@@ -90,6 +97,29 @@ if "pearl-release.json.sig" not in signer or "-sign \"$private_key\"" not in sig
 if re.search(r'\$cli_work/macprovider-cli["}]?\s+--', signer):
     raise SystemExit("protected signer executes the candidate CLI")
 for value in (
+    'keychain="acceptance-signing-${run_id}-${run_attempt}-${keychain_nonce}.keychain"',
+    'acceptance_keychain_capture_default || die',
+    'acceptance_keychain_create_and_select "$keychain" "$keychain_password"',
+    'acceptance_keychain_cleanup "$keychain"',
+):
+    if value not in signer:
+        raise SystemExit(f"acceptance signer keychain contract is incomplete: {value}")
+if "$signing_tmp/acceptance-signing.keychain-db" in signer:
+    raise SystemExit("acceptance signer places its codesigning keychain outside the user keychain directory")
+for value in (
+    'acceptance_keychain_restore_required=1',
+    'security default-keychain -d user -s "$keychain"',
+    'security default-keychain -d user -s "$acceptance_previous_default_keychain"',
+    'if [[ "$acceptance_keychain_created" == 1 ]]',
+    'security delete-keychain "$keychain"',
+):
+    if value not in keychain_helper:
+        raise SystemExit(f"acceptance keychain helper contract is incomplete: {value}")
+if keychain_helper.find('acceptance_keychain_restore_required=1') > keychain_helper.find('security default-keychain -d user -s "$keychain"'):
+    raise SystemExit("acceptance keychain restore flag is set after default-keychain mutation")
+if keychain_helper.find('security default-keychain -d user -s "$acceptance_previous_default_keychain"') > keychain_helper.find('security delete-keychain "$keychain"'):
+    raise SystemExit("acceptance signer deletes the active keychain before restoring the prior default")
+for value in (
     'SIGNING_DOMAIN = b"macprovider.acceptance-candidate.v1\\n"',
     '"candidate_ref"',
     '"control_commit"',
@@ -130,6 +160,68 @@ for index, line in enumerate(lines):
     if any("${{" in row for row in block):
         raise SystemExit("GitHub expression is interpolated directly into a shell block")
 PY
+
+mkdir -p "$work/bin"
+cat > "$work/bin/security" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$*" >> "$SECURITY_LOG"
+case "$1" in
+  default-keychain)
+    if [[ "$*" == "default-keychain -d user" ]]; then
+      [[ "$SECURITY_SCENARIO" != query_failure ]] || exit 71
+      printf '    "/Users/fixture/Library/Keychains/login.keychain-db"\n'
+    fi
+    ;;
+  create-keychain)
+    [[ "$SECURITY_SCENARIO" != create_failure ]] || exit 72
+    ;;
+esac
+SH
+chmod 0755 "$work/bin/security"
+
+query_failure_log="$work/query-failure.log"
+if PATH="$work/bin:$PATH" SECURITY_LOG="$query_failure_log" SECURITY_SCENARIO=query_failure \
+  bash -c 'source "$1"; acceptance_keychain_capture_default' _ "$keychain_helper"; then
+  fail "keychain lifecycle accepted an unreadable prior default"
+fi
+printf '%s\n' 'default-keychain -d user' > "$work/query-failure.expected"
+cmp "$work/query-failure.expected" "$query_failure_log"
+
+create_failure_log="$work/create-failure.log"
+PATH="$work/bin:$PATH" SECURITY_LOG="$create_failure_log" SECURITY_SCENARIO=create_failure \
+  bash -c '
+    source "$1"
+    acceptance_keychain_capture_default
+    if acceptance_keychain_create_and_select collision.keychain fixture; then
+      exit 73
+    fi
+    acceptance_keychain_cleanup collision.keychain
+  ' _ "$keychain_helper"
+printf '%s\n' \
+  'default-keychain -d user' \
+  'create-keychain -p fixture collision.keychain' \
+  > "$work/create-failure.expected"
+cmp "$work/create-failure.expected" "$create_failure_log"
+
+downstream_failure_log="$work/downstream-failure.log"
+PATH="$work/bin:$PATH" SECURITY_LOG="$downstream_failure_log" SECURITY_SCENARIO=downstream_failure \
+  bash -c '
+    source "$1"
+    acceptance_keychain_capture_default
+    acceptance_keychain_create_and_select owned.keychain fixture
+    acceptance_keychain_cleanup owned.keychain
+  ' _ "$keychain_helper"
+printf '%s\n' \
+  'default-keychain -d user' \
+  'create-keychain -p fixture owned.keychain' \
+  'default-keychain -d user -s owned.keychain' \
+  'unlock-keychain -p fixture owned.keychain' \
+  'set-keychain-settings -lut 3600 owned.keychain' \
+  'default-keychain -d user -s /Users/fixture/Library/Keychains/login.keychain-db' \
+  'delete-keychain owned.keychain' \
+  > "$work/downstream-failure.expected"
+cmp "$work/downstream-failure.expected" "$downstream_failure_log"
 
 # macOS runners still invoke Bash 3.2, where expanding an initialized empty
 # array under `set -u` fails as an unbound variable. Keep the workflow's array


### PR DESCRIPTION
## Summary

- create the protected Developer ID keychain in the standard user keychain directory used by the proven release signer
- capture and restore the prior user default fail-closed
- delete only a keychain created by this invocation, using a run/attempt/random scoped name
- regression-test query failure, create collision/failure, and downstream restore-before-delete behavior

## Failure evidence

Acceptance run 29365725391 imported the Developer ID identity, then failed in `security set-key-partition-list` with `The specified item could not be found in the keychain`. The successful release signer uses a standard user/default keychain; the failed acceptance signer used an absolute keychain under `RUNNER_TEMP`.

## Validation

- `bash scripts/test-acceptance-candidate-security.sh`
- `bash scripts/test-release-security-posture.sh`
- ShellCheck and Bash syntax on all three changed files
- code, security, and architecture/operations audits: C0/H0/M0

Advances #585. This control PR publishes nothing and retains read-only workflow permissions.