### PR TITLE
Honor catalog canonical JSON in acceptance signing

### DIFF
--- a/phase4-coordinator/dist/test/check_deploy_config_test.sh
+++ b/phase4-coordinator/dist/test/check_deploy_config_test.sh
@@ -123,7 +123,7 @@ assert_exit() { # $1 expected rc, $2 test name
 }
 
 assert_contains() { # $1 substring, $2 test name
-  if printf '%s' "$OUT" | grep -qF "$1"; then
+  if grep -qF -- "$1" <<<"$OUT"; then
     PASS=$((PASS+1)); echo "  ok: $2 (found: $1)"
   else
     FAIL=$((FAIL+1)); FAIL_NAMES+=("$2"); echo "  FAIL: $2 — output missing: $1"
@@ -132,7 +132,7 @@ assert_contains() { # $1 substring, $2 test name
 }
 
 assert_absent() { # $1 substring that must NOT appear, $2 test name
-  if printf '%s' "$OUT" | grep -qF "$1"; then
+  if grep -qF -- "$1" <<<"$OUT"; then
     FAIL=$((FAIL+1)); FAIL_NAMES+=("$2"); echo "  FAIL: $2 — output should not contain: $1"
     printf '%s\n' "$OUT" | sed 's/^/      | /'
   else

--- a/scripts/acceptance-candidate-metadata.py
+++ b/scripts/acceptance-candidate-metadata.py
@@ -90,7 +90,7 @@ def read_regular(path: pathlib.Path, label: str, maximum: int | None = None) -> 
         fail(f"{label}: cannot read {path}: {exc}")
 
 
-def strict_json(path: pathlib.Path, label: str) -> dict:
+def strict_json(path: pathlib.Path, label: str, *, catalog_release: bool = False) -> dict:
     data = read_regular(path, label, MAX_JSON_BYTES)
 
     def reject_pairs(pairs: list[tuple[str, object]]) -> dict:
@@ -112,8 +112,14 @@ def strict_json(path: pathlib.Path, label: str) -> dict:
         fail(f"{label}: invalid JSON: {exc}")
     if not isinstance(value, dict):
         fail(f"{label}: top level must be an object")
-    if data != canonical_bytes(value):
-        fail(f"{label}: must be canonical sorted compact JSON with one trailing newline")
+    expected = (
+        json.dumps(value, indent=2, sort_keys=True).encode("utf-8") + b"\n"
+        if catalog_release
+        else canonical_bytes(value)
+    )
+    if data != expected:
+        json_style = "indented" if catalog_release else "compact"
+        fail(f"{label}: must be canonical sorted {json_style} JSON with one trailing newline")
     return value
 
 
@@ -297,7 +303,7 @@ def build_pearl(args: argparse.Namespace) -> dict:
     commit = require_string(args.commit, HEX40, "commit")
     catalog = args.catalog_directory
     files = {name: sha256(catalog / name, f"catalog {name}") for name in CATALOG_NAMES}
-    release = strict_json(catalog / "release.json", "catalog release")
+    release = strict_json(catalog / "release.json", "catalog release", catalog_release=True)
     release_id = release.get("release_id")
     policy_version = release.get("policy_version")
     if not isinstance(release_id, str) or not release_id or not isinstance(policy_version, str) or not policy_version:

--- a/scripts/test-acceptance-candidate-security.sh
+++ b/scripts/test-acceptance-candidate-security.sh
@@ -307,6 +307,61 @@ if python3 "$metadata" validate-provider-payload --directory "$work/provider" >"
 fi
 grep -q 'unexpected top-level members' "$work/extra-provider.out"
 
+# Catalog release manifests have their own deterministic pretty-JSON contract.
+# The acceptance signer must preserve and parse those exact bytes rather than
+# imposing the compact acceptance-envelope format on them.
+mkdir "$work/pearl-catalog"
+python3 "$root/scripts/catalog-release.py" verify
+cp "$root/phase3-binary/catalog/autotune/release.json" \
+  "$root/phase3-binary/catalog/autotune/trusted-keys.json" \
+  "$root/phase3-binary/dist/static/autotune-candidates.json" \
+  "$root/phase3-binary/dist/static/autotune-candidates.json.sig" \
+  "$root/phase3-binary/dist/static/demand-rank.json" \
+  "$root/phase3-binary/dist/static/demand-rank.json.sig" \
+  "$work/pearl-catalog/"
+python3 "$metadata" build-pearl \
+  --repository Augustas11/macprovider \
+  --tag "$tag" \
+  --commit "$candidate_commit" \
+  --provider-admission-policy strict_post_migration \
+  --catalog-directory "$work/pearl-catalog" \
+  --coordinator "$work/assets/coordinator-linux-amd64" \
+  --coordinator-cli "$work/assets/coordinator-cli-linux-amd64" \
+  --gateway "$work/assets/gateway-linux-amd64" \
+  --output "$work/pearl-release.json"
+python3 - "$work/pearl-catalog/release.json" "$work/pearl-release.json" <<'PY'
+import json
+import pathlib
+import sys
+
+catalog = json.loads(pathlib.Path(sys.argv[1]).read_text())
+pearl = json.loads(pathlib.Path(sys.argv[2]).read_text())
+if pearl["catalog"]["release_id"] != catalog["release_id"]:
+    raise SystemExit("Pearl metadata did not preserve the verified catalog release ID")
+PY
+python3 - "$work/pearl-catalog/release.json" <<'PY'
+import json
+import pathlib
+import sys
+
+path = pathlib.Path(sys.argv[1])
+path.write_text(json.dumps(json.loads(path.read_text()), sort_keys=True, separators=(",", ":")) + "\n")
+PY
+if python3 "$metadata" build-pearl \
+  --repository Augustas11/macprovider \
+  --tag "$tag" \
+  --commit "$candidate_commit" \
+  --provider-admission-policy strict_post_migration \
+  --catalog-directory "$work/pearl-catalog" \
+  --coordinator "$work/assets/coordinator-linux-amd64" \
+  --coordinator-cli "$work/assets/coordinator-cli-linux-amd64" \
+  --gateway "$work/assets/gateway-linux-amd64" \
+  --output "$work/noncanonical-pearl-release.json" >"$work/noncanonical-catalog.out" 2>&1; then
+  echo "Pearl metadata builder accepted a noncanonical catalog release" >&2
+  exit 1
+fi
+grep -q 'catalog release: must be canonical' "$work/noncanonical-catalog.out"
+
 cat > "$work/compatibility.json.tmp" <<EOF
 {"schema_version":"macprovider.compatibility-set-envelope.v1","signatures":[],"signed":{"compatibility_set_id":"Augustas11/macprovider:${tag}@${candidate_commit}","release":{"commit":"${candidate_commit}","repository":"Augustas11/macprovider","tag":"${tag}","version":"1.8.33"}}}
 EOF


### PR DESCRIPTION
## What changed

- parse catalog `release.json` using its producer-owned deterministic indented JSON contract
- keep compact canonical JSON mandatory for acceptance envelopes and other metadata
- exercise `build-pearl` against the repository's actual verified catalog artifacts
- reject a compact reserialization of the catalog manifest as noncanonical

## Why

Acceptance run `29368552584` completed CLI, app, and DMG notarization, then failed while building Pearl metadata because the acceptance reader incorrectly imposed the compact acceptance-envelope format on the catalog producer's canonical indented `release.json`.

## Validation

- `make test-dist`
- `bash scripts/test-acceptance-candidate-security.sh`
- Python compile and Bash syntax checks
- `git diff --check`
- code, security, and architecture/ops audits: 0 critical / 0 high / 0 medium