### PR TITLE
Make acceptance verification main-owned

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,6 +55,7 @@ test-dist:
 	bash scripts/test-release-tag-target.sh
 	bash scripts/test-release-security-posture.sh
 	bash scripts/test-acceptance-candidate-security.sh
+	bash scripts/test-acceptance-candidate-metadata.sh
 	bash scripts/test-compatibility-artifact-index.sh
 	bash scripts/test-release-toolchain.sh
 	bash scripts/test-release-publication-provenance.sh

--- a/scripts/sign-acceptance-candidate.sh
+++ b/scripts/sign-acceptance-candidate.sh
@@ -319,6 +319,34 @@ python3 "$root/scripts/build-release-provenance.py" \
   "$output_dir/release-provenance.json" \
   "${release_assets[@]}"
 release_assets+=("$output_dir/release-provenance.json")
+python3 - "$output_dir" "$output_dir/release-assets.txt" "${release_assets[@]}" <<'PY'
+import os
+import pathlib
+import re
+import stat
+import sys
+
+root = pathlib.Path(sys.argv[1]).resolve()
+output = pathlib.Path(sys.argv[2])
+paths = [pathlib.Path(value) for value in sys.argv[3:]]
+names = []
+for path in paths:
+    info = path.lstat()
+    if path.parent.resolve() != root or not stat.S_ISREG(info.st_mode) or info.st_nlink != 1:
+        raise SystemExit(f"unsafe acceptance release asset: {path}")
+    if not re.fullmatch(r"[A-Za-z0-9._-]+", path.name) or path.name in names:
+        raise SystemExit(f"invalid or duplicate acceptance release asset name: {path.name}")
+    names.append(path.name)
+descriptor = os.open(output, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o644)
+try:
+    with os.fdopen(descriptor, "w", encoding="ascii") as handle:
+        handle.write("".join(f"{name}\n" for name in sorted(names)))
+        handle.flush()
+        os.fsync(handle.fileno())
+except Exception:
+    output.unlink(missing_ok=True)
+    raise
+PY
 
 checksum_arguments=()
 for release_asset in "${release_assets[@]}"; do

--- a/scripts/test-acceptance-candidate-metadata.sh
+++ b/scripts/test-acceptance-candidate-metadata.sh
@@ -1,0 +1,396 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "$0")/.." && pwd -P)"
+work="$(mktemp -d "${TMPDIR:-/tmp}/acceptance-candidate-metadata.XXXXXX")"
+trap 'rm -rf "$work"' EXIT
+
+fail() {
+  printf '[acceptance-candidate-metadata-test] ERROR: %s\n' "$*" >&2
+  exit 1
+}
+
+canonical_public_key="$repo_root/security/acceptance-candidate-signing-public.pem"
+python3 - "$canonical_public_key" <<'PY'
+import hashlib
+import pathlib
+import sys
+
+path = pathlib.Path(sys.argv[1])
+if path.is_symlink() or not path.is_file():
+    raise SystemExit("committed acceptance public key is not a regular file")
+if hashlib.sha256(path.read_bytes()).hexdigest() != "849e9c9bc53db1fb8e28d3b46ab431089b12cb50b398c5317ced682d39bdbd38":
+    raise SystemExit("committed acceptance public key digest drifted")
+PY
+openssl pkey -pubin -in "$canonical_public_key" -noout >/dev/null
+
+# Exercise the immutable verifier path with an ephemeral test key by copying
+# the reviewed scripts into an isolated mirror. Production has no key override.
+mirror="$work/repo"
+mkdir -p "$mirror/scripts" "$mirror/phase3-binary/dist" "$mirror/security" "$work/assets"
+cp "$repo_root/scripts/verify-release-checksums.sh" "$mirror/scripts/"
+cp "$repo_root/scripts/acceptance-candidate-metadata.py" "$mirror/scripts/"
+cp "$repo_root/scripts/compatibility-artifact-index.py" "$mirror/scripts/"
+
+openssl ecparam -name prime256v1 -genkey -noout -out "$work/acceptance-private.pem"
+openssl ec -in "$work/acceptance-private.pem" -pubout \
+  -out "$mirror/security/acceptance-candidate-signing-public.pem" >/dev/null 2>&1
+openssl ecparam -name prime256v1 -genkey -noout -out "$work/production-private.pem"
+openssl ec -in "$work/production-private.pem" -pubout -out "$work/production-public.pem" >/dev/null 2>&1
+{
+  printf 'write_checksum_public_key() {\n'
+  printf "  cat <<'EOF'\n"
+  cat "$work/production-public.pem"
+  printf 'EOF\n}\n'
+} > "$mirror/phase3-binary/dist/install.sh"
+
+repository="Augustas11/macprovider"
+tag="v1.8.35"
+candidate_ref="refs/heads/fix/585-provider-lifecycle-option2"
+candidate_commit="$(printf 'a%.0s' {1..40})"
+control_commit="$(printf 'b%.0s' {1..40})"
+run_id="123456789"
+run_attempt="2"
+artifact_index="$work/assets/compatibility-artifact-index.json"
+payload="$work/assets/macprovider-cli-${tag}-darwin-arm64.tar.gz"
+provenance="$work/assets/release-provenance.json"
+checksums="$work/assets/checksums.txt"
+compatibility_manifest="$work/assets/compatibility-set.json"
+release_asset_list="$work/release-assets.list"
+
+python3 - "$work/assets" "$artifact_index" "$provenance" "$checksums" \
+  "$compatibility_manifest" "$release_asset_list" "$repository" "$tag" "$candidate_commit" <<'PY'
+import hashlib
+import json
+import pathlib
+import sys
+
+asset_dir, index_path, provenance_path, checksums_path, manifest_path, list_path = map(pathlib.Path, sys.argv[1:7])
+repository, tag, commit = sys.argv[7:]
+canonical = lambda value: (json.dumps(value, sort_keys=True, separators=(",", ":")) + "\n").encode()
+set_id = f"{repository}:{tag}@{commit}"
+manifest = {
+    "schema_version": "macprovider.compatibility-set-envelope.v1",
+    "signatures": [],
+    "signed": {
+        "compatibility_set_id": set_id,
+        "release": {"commit": commit, "repository": repository, "tag": tag, "version": tag.removeprefix("v")},
+    },
+}
+manifest_path.write_bytes(canonical(manifest))
+role_names = {
+    "catalog_candidates": "autotune-candidates.json",
+    "catalog_candidates_signature": "autotune-candidates.json.sig",
+    "catalog_demand": "demand-rank.json",
+    "catalog_demand_signature": "demand-rank.json.sig",
+    "catalog_manifest": "release.json",
+    "catalog_trusted_keys": "trusted-keys.json",
+    "compatibility_manifest": manifest_path.name,
+    "coordinator": "coordinator-linux-amd64",
+    "coordinator_cli": "coordinator-cli-linux-amd64",
+    "gateway": "gateway-linux-amd64",
+    "malibu_app": f"Malibu-{tag}.dmg",
+    "pearl_metadata": "pearl-release.json",
+    "pearl_metadata_signature": "pearl-release.json.sig",
+    "provider_cli": f"macprovider-cli-{tag}-darwin-arm64.tar.gz",
+}
+role_paths = {}
+for role, name in role_names.items():
+    path = asset_dir / name
+    if path != manifest_path:
+        path.write_text(f"fixture:{role}\n", encoding="ascii")
+    role_paths[role] = path
+index = {
+    "artifacts": {
+        role: {"name": path.name, "sha256": hashlib.sha256(path.read_bytes()).hexdigest()}
+        for role, path in role_paths.items()
+    },
+    "commit": commit,
+    "compatibility_manifest_sha256": hashlib.sha256(manifest_path.read_bytes()).hexdigest(),
+    "compatibility_set_id": set_id,
+    "repository": repository,
+    "schema_version": "macprovider.compatibility-artifact-index.v1",
+    "tag": tag,
+}
+index_path.write_bytes(canonical(index))
+assets = {
+    **{path.name: hashlib.sha256(path.read_bytes()).hexdigest() for path in role_paths.values()},
+    index_path.name: hashlib.sha256(index_path.read_bytes()).hexdigest(),
+}
+provenance = {
+    "assets": assets,
+    "commit": commit,
+    "repository": repository,
+    "schema_version": 1,
+    "tag": tag,
+}
+provenance_path.write_bytes(canonical(provenance))
+rows = dict(assets)
+rows[provenance_path.name] = hashlib.sha256(provenance_path.read_bytes()).hexdigest()
+checksums_path.write_text(
+    "".join(f"{digest}  {name}\n" for name, digest in sorted(rows.items())),
+    encoding="ascii",
+)
+list_path.write_text("".join(f"{name}\n" for name in sorted([*assets, provenance_path.name])), encoding="ascii")
+PY
+
+python3 - "$work/timestamps" <<'PY'
+import datetime as dt
+import pathlib
+import sys
+
+now = dt.datetime.now(dt.timezone.utc).replace(microsecond=0)
+render = lambda value: value.strftime("%Y-%m-%dT%H:%M:%SZ")
+pathlib.Path(sys.argv[1]).write_text(f"{render(now)}\n{render(now + dt.timedelta(minutes=10))}\n")
+PY
+issued_at="$(sed -n '1p' "$work/timestamps")"
+expires_at="$(sed -n '2p' "$work/timestamps")"
+metadata="$work/assets/acceptance-candidate.json"
+signature="$work/assets/acceptance-candidate.json.sig"
+python3 "$mirror/scripts/acceptance-candidate-metadata.py" sign \
+  --repository "$repository" \
+  --tag "$tag" \
+  --candidate-ref "$candidate_ref" \
+  --candidate-commit "$candidate_commit" \
+  --control-commit "$control_commit" \
+  --run-id "$run_id" \
+  --run-attempt "$run_attempt" \
+  --compatibility-manifest "$compatibility_manifest" \
+  --checksums "$checksums" \
+  --issued-at "$issued_at" \
+  --expires-at "$expires_at" \
+  --private-key "$work/acceptance-private.pem" \
+  --output "$metadata" \
+  --signature "$signature"
+
+assets=()
+while IFS= read -r release_asset; do
+  test -n "$release_asset" && assets+=("$work/assets/$release_asset")
+done < "$release_asset_list"
+verify=(
+  bash "$mirror/scripts/verify-release-checksums.sh"
+  --acceptance-candidate "$metadata" "$candidate_ref" "$run_id" "$run_attempt" "$control_commit"
+  "$checksums" "$signature" "$provenance" "$repository" "$tag" "$candidate_commit"
+  "${assets[@]}"
+)
+"${verify[@]}" >/dev/null
+
+verify_with_index() {
+  local replacement_index="$1"
+  local adjusted_assets=()
+  local release_asset
+  for release_asset in "${assets[@]}"; do
+    if [[ "$(basename "$release_asset")" == compatibility-artifact-index.json ]]; then
+      adjusted_assets+=("$replacement_index")
+    else
+      adjusted_assets+=("$release_asset")
+    fi
+  done
+  bash "$mirror/scripts/verify-release-checksums.sh" \
+    --acceptance-candidate "$metadata" "$candidate_ref" "$run_id" "$run_attempt" "$control_commit" \
+    "$checksums" "$signature" "$provenance" "$repository" "$tag" "$candidate_commit" \
+    "${adjusted_assets[@]}"
+}
+
+python3 - "$artifact_index" "$work/index-variants" <<'PY'
+import json
+import pathlib
+import sys
+
+source = pathlib.Path(sys.argv[1])
+root = pathlib.Path(sys.argv[2])
+value = json.loads(source.read_text(encoding="utf-8"))
+canonical = lambda item: (json.dumps(item, sort_keys=True, separators=(",", ":")) + "\n").encode()
+
+def write(name, item, *, canonical_form=True):
+    directory = root / name
+    directory.mkdir(parents=True)
+    output = directory / source.name
+    output.write_bytes(canonical(item) if canonical_form else (json.dumps(item, indent=2) + "\n").encode())
+
+changed = json.loads(json.dumps(value))
+changed["schema_version"] = "macprovider.compatibility-artifact-index.v2"
+write("wrong-schema", changed)
+
+changed = json.loads(json.dumps(value))
+changed["compatibility_manifest_sha256"] = "0" * 64
+write("wrong-manifest-digest", changed)
+
+changed = json.loads(json.dumps(value))
+changed["artifacts"].pop("provider_cli")
+write("missing-role", changed)
+
+changed = json.loads(json.dumps(value))
+changed["artifacts"]["provider_binary"] = changed["artifacts"].pop("provider_cli")
+write("relabelled-role", changed)
+
+write("noncanonical", value, canonical_form=False)
+
+directory = root / "duplicate-key"
+directory.mkdir(parents=True)
+raw = source.read_bytes()
+(directory / source.name).write_bytes(raw.replace(b'{"artifacts":', b'{"artifacts":{},"artifacts":', 1))
+PY
+
+if verify_with_index "$work/index-variants/wrong-schema/compatibility-artifact-index.json" \
+  >"$work/wrong-index-schema.out" 2>&1; then
+  fail "acceptance verifier accepted an unsupported artifact-index schema"
+fi
+grep -q 'unsupported schema' "$work/wrong-index-schema.out"
+
+if verify_with_index "$work/index-variants/wrong-manifest-digest/compatibility-artifact-index.json" \
+  >"$work/wrong-manifest-digest.out" 2>&1; then
+  fail "acceptance verifier accepted a false compatibility-manifest digest"
+fi
+grep -q 'compatibility manifest digest differs' "$work/wrong-manifest-digest.out"
+
+if verify_with_index "$work/index-variants/missing-role/compatibility-artifact-index.json" \
+  >"$work/missing-role.out" 2>&1; then
+  fail "acceptance verifier accepted an artifact index with a missing role"
+fi
+grep -q 'exact required roles' "$work/missing-role.out"
+
+if verify_with_index "$work/index-variants/relabelled-role/compatibility-artifact-index.json" \
+  >"$work/relabelled-role.out" 2>&1; then
+  fail "acceptance verifier accepted a relabelled artifact role"
+fi
+grep -q 'invalid or duplicate artifact mapping' "$work/relabelled-role.out"
+
+if verify_with_index "$work/index-variants/noncanonical/compatibility-artifact-index.json" \
+  >"$work/noncanonical-index.out" 2>&1; then
+  fail "acceptance verifier accepted a noncanonical artifact index"
+fi
+grep -q 'canonical sorted compact JSON' "$work/noncanonical-index.out"
+
+if verify_with_index "$work/index-variants/duplicate-key/compatibility-artifact-index.json" \
+  >"$work/duplicate-index-key.out" 2>&1; then
+  fail "acceptance verifier accepted a duplicate artifact-index key"
+fi
+grep -q 'duplicate key' "$work/duplicate-index-key.out"
+
+ln "$payload" "$work/hard-linked-provider-cli"
+if "${verify[@]}" >"$work/hard-link.out" 2>&1; then
+  fail "acceptance verifier accepted a hard-linked release input"
+fi
+grep -q 'single-link file' "$work/hard-link.out"
+rm "$work/hard-linked-provider-cli"
+
+production_signature="$work/assets/checksums.txt.sig"
+openssl dgst -sha256 -sign "$work/production-private.pem" \
+  -out "$production_signature" "$checksums"
+bash "$mirror/scripts/verify-release-checksums.sh" \
+  "$checksums" "$production_signature" "$provenance" "$repository" "$tag" "$candidate_commit" \
+  "${assets[@]}" >/dev/null
+
+cp "$signature" "$work/canonical-acceptance-signature"
+printf '\n' >> "$signature"
+if "${verify[@]}" >"$work/noncanonical-signature.out" 2>&1; then
+  fail "acceptance verifier accepted a noncanonical signature encoding"
+fi
+mv "$work/canonical-acceptance-signature" "$signature"
+
+if bash "$mirror/scripts/verify-release-checksums.sh" \
+  "$checksums" "$signature" "$provenance" "$repository" "$tag" "$candidate_commit" \
+  "${assets[@]}" >"$work/production-domain.out" 2>&1; then
+  fail "production verifier accepted an acceptance signature"
+fi
+
+if bash "$mirror/scripts/verify-release-checksums.sh" \
+  --acceptance-candidate "$metadata" refs/heads/fix/different "$run_id" "$run_attempt" "$control_commit" \
+  "$checksums" "$signature" "$provenance" "$repository" "$tag" "$candidate_commit" \
+  "${assets[@]}" >"$work/wrong-ref.out" 2>&1; then
+  fail "acceptance verifier accepted replay under a different candidate ref"
+fi
+grep -q 'candidate ref differs' "$work/wrong-ref.out"
+
+if bash "$mirror/scripts/verify-release-checksums.sh" \
+  --acceptance-candidate "$metadata" "$candidate_ref" 987654321 "$run_attempt" "$control_commit" \
+  "$checksums" "$signature" "$provenance" "$repository" "$tag" "$candidate_commit" \
+  "${assets[@]}" >"$work/wrong-run.out" 2>&1; then
+  fail "acceptance verifier accepted replay under a different run id"
+fi
+grep -q 'run id differs' "$work/wrong-run.out"
+
+if bash "$mirror/scripts/verify-release-checksums.sh" \
+  --acceptance-candidate "$metadata" "$candidate_ref" "$run_id" 3 "$control_commit" \
+  "$checksums" "$signature" "$provenance" "$repository" "$tag" "$candidate_commit" \
+  "${assets[@]}" >"$work/wrong-attempt.out" 2>&1; then
+  fail "acceptance verifier accepted replay under a different run attempt"
+fi
+grep -q 'run attempt differs' "$work/wrong-attempt.out"
+
+wrong_control_commit="$(printf 'c%.0s' {1..40})"
+if bash "$mirror/scripts/verify-release-checksums.sh" \
+  --acceptance-candidate "$metadata" "$candidate_ref" "$run_id" "$run_attempt" "$wrong_control_commit" \
+  "$checksums" "$signature" "$provenance" "$repository" "$tag" "$candidate_commit" \
+  "${assets[@]}" >"$work/wrong-control.out" 2>&1; then
+  fail "acceptance verifier accepted replay under a different control commit"
+fi
+grep -q 'control commit differs' "$work/wrong-control.out"
+
+if bash "$mirror/scripts/verify-release-checksums.sh" \
+  --allow-partial \
+  --acceptance-candidate "$metadata" "$candidate_ref" "$run_id" "$run_attempt" "$control_commit" \
+  "$checksums" "$signature" "$provenance" "$repository" "$tag" "$candidate_commit" \
+  "$artifact_index" "$provenance" >"$work/partial.out" 2>&1; then
+  fail "acceptance verifier allowed a partial signed release set"
+fi
+grep -q 'must cover the complete release set' "$work/partial.out"
+
+if bash "$mirror/scripts/verify-release-checksums.sh" \
+  --acceptance-candidate "$metadata" "$candidate_ref" "$run_id" "$run_attempt" "$control_commit" \
+  "$checksums" "$signature" "$provenance" "$repository" "$tag" "$candidate_commit" \
+  "$payload" "$provenance" >"$work/missing-index.out" 2>&1; then
+  fail "acceptance verifier accepted a release without its artifact index"
+fi
+grep -q 'requires compatibility-artifact-index.json' "$work/missing-index.out"
+
+wrong_domain_signature="$work/wrong-domain/acceptance-candidate.json.sig"
+mkdir -p "$(dirname "$wrong_domain_signature")"
+{
+  printf 'macprovider.production-release.v1\n'
+  cat "$metadata"
+} > "$work/wrong-domain-payload"
+openssl dgst -sha256 -sign "$work/acceptance-private.pem" \
+  -out "$work/wrong-domain.der" "$work/wrong-domain-payload"
+python3 - "$work/wrong-domain.der" "$wrong_domain_signature" <<'PY'
+import base64
+import pathlib
+import sys
+
+pathlib.Path(sys.argv[2]).write_bytes(base64.b64encode(pathlib.Path(sys.argv[1]).read_bytes()) + b"\n")
+PY
+if bash "$mirror/scripts/verify-release-checksums.sh" \
+  --acceptance-candidate "$metadata" "$candidate_ref" "$run_id" "$run_attempt" "$control_commit" \
+  "$checksums" "$wrong_domain_signature" "$provenance" "$repository" "$tag" "$candidate_commit" \
+  "${assets[@]}" >"$work/wrong-domain.out" 2>&1; then
+  fail "acceptance verifier accepted a signature from the production domain"
+fi
+
+expired_dir="$work/expired"
+mkdir -p "$expired_dir"
+python3 "$mirror/scripts/acceptance-candidate-metadata.py" sign \
+  --repository "$repository" \
+  --tag "$tag" \
+  --candidate-ref "$candidate_ref" \
+  --candidate-commit "$candidate_commit" \
+  --control-commit "$control_commit" \
+  --run-id "$run_id" \
+  --run-attempt "$run_attempt" \
+  --compatibility-manifest "$compatibility_manifest" \
+  --checksums "$checksums" \
+  --issued-at 2020-01-01T00:00:00Z \
+  --expires-at 2020-01-01T00:05:00Z \
+  --private-key "$work/acceptance-private.pem" \
+  --output "$expired_dir/acceptance-candidate.json" \
+  --signature "$expired_dir/acceptance-candidate.json.sig"
+if bash "$mirror/scripts/verify-release-checksums.sh" \
+  --acceptance-candidate "$expired_dir/acceptance-candidate.json" "$candidate_ref" "$run_id" "$run_attempt" "$control_commit" \
+  "$checksums" "$expired_dir/acceptance-candidate.json.sig" "$provenance" "$repository" "$tag" "$candidate_commit" \
+  "${assets[@]}" >"$work/expired.out" 2>&1; then
+  fail "acceptance verifier accepted expired metadata"
+fi
+grep -q 'candidate has expired' "$work/expired.out"
+
+bash -n "$repo_root/scripts/verify-release-checksums.sh" "$0"
+printf '[acceptance-candidate-metadata-test] passed\n'

--- a/scripts/test-acceptance-candidate-security.sh
+++ b/scripts/test-acceptance-candidate-security.sh
@@ -94,6 +94,12 @@ if "--private-key \"$release_private_key\"" not in signer or "--public-key \"$re
     raise SystemExit("inner compatibility manifest is not main-owned and production-key verified")
 if "pearl-release.json.sig" not in signer or "-sign \"$private_key\"" not in signer:
     raise SystemExit("acceptance-only Pearl metadata is not separately signed")
+if '"$output_dir/release-assets.txt"' not in signer:
+    raise SystemExit("acceptance signer does not export the verifier asset selector")
+if signer.find('release_assets+=("$output_dir/release-provenance.json")') > signer.find('"$output_dir/release-assets.txt"'):
+    raise SystemExit("acceptance asset selector is emitted before the provenance asset is included")
+if signer.find('"$output_dir/release-assets.txt"') > signer.find('build-checksums'):
+    raise SystemExit("acceptance asset selector is emitted after signed checksum construction")
 if re.search(r'\$cli_work/macprovider-cli["}]?\s+--', signer):
     raise SystemExit("protected signer executes the candidate CLI")
 for value in (

--- a/scripts/verify-release-checksums.sh
+++ b/scripts/verify-release-checksums.sh
@@ -7,11 +7,35 @@ die() {
 }
 
 allow_partial=false
-if [[ "${1:-}" == "--allow-partial" ]]; then
-  allow_partial=true
-  shift
-fi
-[[ "$#" -ge 7 ]] || die "usage: [--allow-partial] CHECKSUMS SIGNATURE PROVENANCE REPOSITORY TAG COMMIT ASSET..."
+acceptance_candidate=false
+acceptance_metadata=""
+acceptance_candidate_ref=""
+acceptance_run_id=""
+acceptance_run_attempt=""
+acceptance_control_commit=""
+while [[ "${1:-}" == --* ]]; do
+  case "$1" in
+    --allow-partial)
+      allow_partial=true
+      shift
+      ;;
+    --acceptance-candidate)
+      [[ "$#" -ge 6 ]] ||
+        die "--acceptance-candidate requires METADATA CANDIDATE_REF RUN_ID RUN_ATTEMPT CONTROL_COMMIT"
+      acceptance_candidate=true
+      acceptance_metadata="$2"
+      acceptance_candidate_ref="$3"
+      acceptance_run_id="$4"
+      acceptance_run_attempt="$5"
+      acceptance_control_commit="$6"
+      shift 6
+      ;;
+    *) die "unknown option: $1" ;;
+  esac
+done
+[[ "$#" -ge 7 ]] || die "usage: [--allow-partial] [--acceptance-candidate METADATA CANDIDATE_REF RUN_ID RUN_ATTEMPT CONTROL_COMMIT] CHECKSUMS SIGNATURE PROVENANCE REPOSITORY TAG COMMIT ASSET..."
+[[ "$acceptance_candidate" == false || "$allow_partial" == false ]] ||
+  die "acceptance candidate verification must cover the complete release set"
 checksums="$1"
 signature="$2"
 provenance="$3"
@@ -25,29 +49,219 @@ repo_root="$(cd "$(dirname "$0")/.." && pwd)"
 [[ "$repository" =~ ^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$ ]] || die "invalid repository"
 [[ "$tag" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]] || die "invalid tag"
 [[ "$commit" =~ ^[0-9a-f]{40}$ ]] || die "invalid commit"
-for path in "$checksums" "$signature" "$provenance" "${assets[@]}"; do
+[[ "$acceptance_candidate" == false || "$acceptance_candidate_ref" =~ ^refs/heads/[A-Za-z0-9._/-]+$ ]] ||
+  die "invalid acceptance candidate ref"
+[[ "$acceptance_candidate" == false || "$acceptance_run_id" =~ ^[1-9][0-9]{0,19}$ ]] ||
+  die "invalid acceptance run id"
+[[ "$acceptance_candidate" == false || "$acceptance_run_attempt" =~ ^[1-9][0-9]{0,9}$ ]] ||
+  die "invalid acceptance run attempt"
+[[ "$acceptance_candidate" == false || "$acceptance_control_commit" =~ ^[0-9a-f]{40}$ ]] ||
+  die "invalid acceptance control commit"
+inputs=("$checksums" "$signature" "$provenance" "${assets[@]}")
+if [[ "$acceptance_candidate" == true ]]; then
+  inputs+=("$acceptance_metadata")
+  [[ "$(basename "$acceptance_metadata")" == "acceptance-candidate.json" ]] ||
+    die "acceptance metadata must be named acceptance-candidate.json"
+  [[ "$(basename "$signature")" == "acceptance-candidate.json.sig" ]] ||
+    die "acceptance signature must be named acceptance-candidate.json.sig"
+  for path in "${assets[@]}"; do
+    [[ "$(basename "$path")" != "checksums.txt.sig" ]] ||
+      die "acceptance candidate must not contain production checksums.txt.sig"
+  done
+fi
+for path in "${inputs[@]}"; do
   [[ -f "$path" && ! -L "$path" ]] || die "release input is not a regular file: $path"
 done
 
-public_key="$(mktemp "${RUNNER_TEMP:-${TMPDIR:-/tmp}}/release-public-key.XXXXXX.pem")"
-trap 'rm -f "$public_key"' EXIT
+snapshot_root="$(mktemp -d "${RUNNER_TEMP:-${TMPDIR:-/tmp}}/release-verification.XXXXXX")"
+chmod 700 "$snapshot_root"
+public_key="$snapshot_root/release-public-key.pem"
+cleanup() {
+  rm -rf "$snapshot_root"
+}
+trap cleanup EXIT
+
+snapshot_input() {
+  local label="$1"
+  local source="$2"
+  python3 - "$snapshot_root" "$label" "$source" <<'PY'
+import os
+import pathlib
+import stat
+import sys
+
+root, label, source = pathlib.Path(sys.argv[1]), sys.argv[2], pathlib.Path(sys.argv[3])
+destination_directory = root / label
+destination_directory.mkdir(mode=0o700)
+destination = destination_directory / source.name
+flags = os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0)
+try:
+    source_fd = os.open(source, flags)
+except OSError as exc:
+    raise SystemExit(f"cannot open release input safely: {source}: {exc}")
+try:
+    info = os.fstat(source_fd)
+    if not stat.S_ISREG(info.st_mode) or info.st_nlink != 1:
+        raise SystemExit(f"release input must be a regular non-symlink single-link file: {source}")
+    destination_fd = os.open(destination, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o400)
+    try:
+        while True:
+            chunk = os.read(source_fd, 1024 * 1024)
+            if not chunk:
+                break
+            view = memoryview(chunk)
+            while view:
+                written = os.write(destination_fd, view)
+                view = view[written:]
+        os.fsync(destination_fd)
+    finally:
+        os.close(destination_fd)
+finally:
+    os.close(source_fd)
+print(destination)
+PY
+}
+
+checksums="$(snapshot_input checksums "$checksums")"
+signature="$(snapshot_input signature "$signature")"
+provenance="$(snapshot_input provenance "$provenance")"
+if [[ "$acceptance_candidate" == true ]]; then
+  acceptance_metadata="$(snapshot_input acceptance-metadata "$acceptance_metadata")"
+fi
+snapshot_assets=()
+asset_number=0
+for path in "${assets[@]}"; do
+  snapshot_assets+=("$(snapshot_input "asset-$asset_number" "$path")")
+  asset_number=$((asset_number + 1))
+done
+assets=("${snapshot_assets[@]}")
+
+if [[ "$acceptance_candidate" == true ]]; then
+  acceptance_public_key="$repo_root/security/acceptance-candidate-signing-public.pem"
+  [[ -f "$acceptance_public_key" && ! -L "$acceptance_public_key" ]] ||
+    die "canonical acceptance-candidate signing public key is missing"
+  cp "$acceptance_public_key" "$public_key"
+else
 python3 - "$repo_root/phase3-binary/dist/install.sh" "$public_key" <<'PY'
 import pathlib
 import re
 import sys
 
 source = pathlib.Path(sys.argv[1]).read_text(encoding="utf-8")
+function = re.search(
+    r"write_checksum_public_key\(\) \{(.+?)\n\}",
+    source,
+    flags=re.DOTALL,
+)
 blocks = re.findall(
     r"-----BEGIN PUBLIC KEY-----\n.+?\n-----END PUBLIC KEY-----",
-    source,
+    function.group(1) if function else "",
     flags=re.DOTALL,
 )
 if len(blocks) != 1:
     raise SystemExit("install.sh must embed exactly one canonical release public key")
 pathlib.Path(sys.argv[2]).write_text(blocks[0] + "\n", encoding="ascii")
 PY
-openssl dgst -sha256 -verify "$public_key" -signature "$signature" "$checksums" >/dev/null ||
-  die "checksums signature verification failed against the canonical installer key"
+fi
+if [[ "$acceptance_candidate" == true ]]; then
+  artifact_index=""
+  for path in "${assets[@]}"; do
+    if [[ "$(basename "$path")" == "compatibility-artifact-index.json" ]]; then
+      [[ -z "$artifact_index" ]] || die "duplicate compatibility artifact index"
+      artifact_index="$path"
+    fi
+  done
+  [[ -n "$artifact_index" ]] || die "acceptance verification requires compatibility-artifact-index.json"
+  artifact_mapping_file="$snapshot_root/artifact-mappings.tsv"
+  python3 - "$artifact_index" "$artifact_mapping_file" <<'PY'
+import json
+import pathlib
+import re
+import sys
+
+source, output = map(pathlib.Path, sys.argv[1:])
+data = source.read_bytes()
+
+def reject_pairs(pairs):
+    result = {}
+    for key, value in pairs:
+        if key in result:
+            raise SystemExit(f"artifact index contains duplicate key: {key!r}")
+        result[key] = value
+    return result
+
+try:
+    value = json.loads(data.decode("utf-8"), object_pairs_hook=reject_pairs)
+except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+    raise SystemExit(f"invalid artifact index JSON: {exc}")
+rows = value.get("artifacts") if isinstance(value, dict) else None
+if not isinstance(rows, dict):
+    raise SystemExit("artifact index is missing artifact role mappings")
+safe = re.compile(r"[A-Za-z0-9][A-Za-z0-9._+-]{0,255}")
+lines = []
+for role, row in sorted(rows.items()):
+    name = row.get("name") if isinstance(row, dict) else None
+    if not isinstance(role, str) or not safe.fullmatch(role) or not isinstance(name, str) or not safe.fullmatch(name):
+        raise SystemExit("artifact index contains an unsafe role mapping")
+    lines.append(f"{role}\t{name}\n")
+output.write_text("".join(lines), encoding="ascii")
+PY
+  artifact_arguments=()
+  compatibility_manifest=""
+  while IFS=$'\t' read -r role asset_name; do
+    matched_asset=""
+    for path in "${assets[@]}"; do
+      if [[ "$(basename "$path")" == "$asset_name" ]]; then
+        [[ -z "$matched_asset" ]] || die "duplicate release asset basename: $asset_name"
+        matched_asset="$path"
+      fi
+    done
+    [[ -n "$matched_asset" ]] || die "artifact index references an absent release asset: $asset_name"
+    artifact_arguments+=(--artifact "$role=$matched_asset")
+    if [[ "$role" == compatibility_manifest ]]; then
+      compatibility_manifest="$matched_asset"
+    fi
+  done < "$artifact_mapping_file"
+  [[ -n "$compatibility_manifest" ]] || die "artifact index lacks the compatibility manifest role"
+  python3 - "$signature" <<'PY' || die "acceptance signature must be canonical base64 DER with one trailing newline"
+import base64
+import pathlib
+import sys
+
+encoded_with_newline = pathlib.Path(sys.argv[1]).read_bytes()
+if not encoded_with_newline.endswith(b"\n") or b"\n" in encoded_with_newline[:-1]:
+    raise SystemExit(1)
+encoded = encoded_with_newline[:-1]
+try:
+    signature = base64.b64decode(encoded, validate=True)
+except ValueError:
+    raise SystemExit(1)
+if base64.b64encode(signature) != encoded or not 64 <= len(signature) <= 80:
+    raise SystemExit(1)
+PY
+  python3 "$repo_root/scripts/acceptance-candidate-metadata.py" verify \
+    --input "$acceptance_metadata" \
+    --signature "$signature" \
+    --public-key "$public_key" \
+    --checksums "$checksums" \
+    --repository "$repository" \
+    --tag "$tag" \
+    --candidate-ref "$acceptance_candidate_ref" \
+    --candidate-commit "$commit" \
+    --control-commit "$acceptance_control_commit" \
+    --run-id "$acceptance_run_id" \
+    --run-attempt "$acceptance_run_attempt"
+  python3 "$repo_root/scripts/compatibility-artifact-index.py" validate \
+    --input "$artifact_index" \
+    --compatibility-manifest "$compatibility_manifest" \
+    --repository "$repository" \
+    --tag "$tag" \
+    --commit "$commit" \
+    "${artifact_arguments[@]}"
+else
+  openssl dgst -sha256 -verify "$public_key" -signature "$signature" "$checksums" >/dev/null ||
+    die "checksums signature verification failed against the canonical installer key"
+fi
 
 python3 - "$allow_partial" "$checksums" "$provenance" "$repository" "$tag" "$commit" "${assets[@]}" <<'PY'
 import hashlib
@@ -115,4 +329,9 @@ if rows != expected_rows:
     raise SystemExit("signed checksums do not exactly cover the reviewed release assets")
 PY
 
-printf '[verify-release-checksums] ok: canonical signature and release set verified for %s\n' "$tag"
+if [[ "$acceptance_candidate" == true ]]; then
+  printf '[verify-release-checksums] ok: domain-separated acceptance candidate verified for %s at %s (ref %s; run %s/%s; control %s)\n' \
+    "$tag" "$commit" "$acceptance_candidate_ref" "$acceptance_run_id" "$acceptance_run_attempt" "$acceptance_control_commit"
+else
+  printf '[verify-release-checksums] ok: canonical production signature and release set verified for %s\n' "$tag"
+fi


### PR DESCRIPTION
Closes the final trust gap found while executing Issue #585 hardware acceptance.

- adds main-owned acceptance verification with exact candidate-ref, run, attempt, and control-commit pins
- snapshots all inputs before verification and rejects linked inputs
- validates the complete compatibility artifact index and exact signed release set
- exports the deterministic release-assets selector used by the operator runbook
- preserves the production checksum-verification path

Validation:
- make test-dist
- shellcheck and bash syntax
- real protected artifact from Actions run 29371332634 verified successfully
- code/security/architecture audits: C0 H0 M0