### PR TITLE
Fix Malibu Team ID lookup for signed CLI handoff (#611)

### DIFF
--- a/phase3-binary/app/Sources/Malibu/System/ProviderCredentialHandoffRunner.swift
+++ b/phase3-binary/app/Sources/Malibu/System/ProviderCredentialHandoffRunner.swift
@@ -356,6 +356,29 @@ enum ProviderCredentialHandoffRunner {
 
     typealias CommandRunner = @Sendable (URL, [String]) async throws -> Int32
     typealias CapturedCommandRunner = @Sendable (URL, [String]) async throws -> CapturedCommandResult
+    typealias SigningInformationCopier = (
+        SecStaticCode,
+        SecCSFlags,
+        UnsafeMutablePointer<CFDictionary?>
+    ) -> OSStatus
+
+    /// One production seam owns every signing-information read. Team ID and
+    /// code-directory hash are extended signing metadata, so requesting them
+    /// with an empty flag set does not reliably return them on macOS.
+    static func signingInformation(
+        for staticCode: SecStaticCode,
+        copy: SigningInformationCopier = { code, flags, information in
+            SecCodeCopySigningInformation(code, flags, information)
+        }
+    ) throws -> [String: Any] {
+        var information: CFDictionary?
+        let flags = SecCSFlags(rawValue: kSecCSSigningInformation)
+        guard copy(staticCode, flags, &information) == errSecSuccess,
+              let dictionary = information as? [String: Any] else {
+            throw Error.invalidCLI("code signing metadata is unavailable")
+        }
+        return dictionary
+    }
 
     static func credentialStatus(configURL: URL, expectedProviderID: String) async throws -> CredentialSnapshot {
         try await runCredentialCommand(
@@ -884,11 +907,9 @@ enum ProviderCredentialHandoffRunner {
               let currentStaticCode else {
             throw Error.invalidCLI("Malibu static signing identity is unavailable")
         }
-        var signingInfo: CFDictionary?
-        guard SecCodeCopySigningInformation(currentStaticCode, [], &signingInfo) == errSecSuccess,
-              let infoDictionary = signingInfo as? [String: Any],
-              let teamID = infoDictionary[kSecCodeInfoTeamIdentifier as String] as? String,
-              teamID.range(of: #"^[A-Z0-9]+$"#, options: .regularExpression) != nil else {
+        let infoDictionary = try signingInformation(for: currentStaticCode)
+        guard let teamID = infoDictionary[kSecCodeInfoTeamIdentifier as String] as? String,
+              teamID == "YF7XNRJUG4" else {
             throw Error.invalidCLI("Malibu Team ID is unavailable")
         }
 
@@ -908,10 +929,8 @@ enum ProviderCredentialHandoffRunner {
               ) == errSecSuccess else {
             throw Error.invalidCLI("signature, Team ID, or designated identifier mismatch")
         }
-        var installedSigningInfo: CFDictionary?
-        guard SecCodeCopySigningInformation(staticCode, [], &installedSigningInfo) == errSecSuccess,
-              let installedInfo = installedSigningInfo as? [String: Any],
-              let codeDirectoryHash = installedInfo[kSecCodeInfoUnique as String] as? Data,
+        let installedInfo = try signingInformation(for: staticCode)
+        guard let codeDirectoryHash = installedInfo[kSecCodeInfoUnique as String] as? Data,
               !codeDirectoryHash.isEmpty else {
             throw Error.invalidCLI("CLI code-directory identity is unavailable")
         }
@@ -938,10 +957,8 @@ enum ProviderCredentialHandoffRunner {
               let runningStaticCode else {
             throw Error.invalidCLI("running CLI static code identity is unavailable")
         }
-        var signingInfo: CFDictionary?
-        guard SecCodeCopySigningInformation(runningStaticCode, [], &signingInfo) == errSecSuccess,
-              let info = signingInfo as? [String: Any],
-              let codeDirectoryHash = info[kSecCodeInfoUnique as String] as? Data,
+        let info = try signingInformation(for: runningStaticCode)
+        guard let codeDirectoryHash = info[kSecCodeInfoUnique as String] as? Data,
               codeDirectoryHash == expectedIdentity.codeDirectoryHash else {
             throw Error.invalidCLI("running CLI does not match the validated executable")
         }

--- a/phase3-binary/app/Tests/MalibuTests/CLIUpdateRunnerTests.swift
+++ b/phase3-binary/app/Tests/MalibuTests/CLIUpdateRunnerTests.swift
@@ -33,6 +33,17 @@ final class CLIUpdateRunnerTests: XCTestCase {
         )
     }
 
+    func testSupportedCLIIsAcceptedIndependentlyOfMalibuMarketingVersion() throws {
+        XCTAssertEqual(
+            try CLIUpdateRunner.strategy(
+                installedVersion: "1.8.40",
+                compatibilitySetID: "Augustas11/macprovider:v1.8.40@abc123",
+                bundledAppVersion: "1.8.41"
+            ),
+            .installedCompatibilityCLI
+        )
+    }
+
     func testMissingCompatibilityIdentityRepairsThroughPinnedInstaller() throws {
         XCTAssertEqual(
             try CLIUpdateRunner.strategy(

--- a/phase3-binary/app/Tests/MalibuTests/ProviderCredentialHandoffRunnerTests.swift
+++ b/phase3-binary/app/Tests/MalibuTests/ProviderCredentialHandoffRunnerTests.swift
@@ -1,7 +1,66 @@
+import Security
 import XCTest
 @testable import Malibu
 
 final class ProviderCredentialHandoffRunnerTests: XCTestCase {
+    func testSigningInformationRequestsExtendedSigningMetadata() throws {
+        var staticCode: SecStaticCode?
+        XCTAssertEqual(
+            SecStaticCodeCreateWithPath(
+                URL(fileURLWithPath: "/usr/bin/true") as CFURL,
+                [],
+                &staticCode
+            ),
+            errSecSuccess
+        )
+        let code = try XCTUnwrap(staticCode)
+        var observedFlags: SecCSFlags?
+        let expected = [
+            kSecCodeInfoTeamIdentifier as String: "YF7XNRJUG4",
+            kSecCodeInfoUnique as String: Data([0x01, 0x02]),
+        ] as CFDictionary
+
+        let result = try ProviderCredentialHandoffRunner.signingInformation(
+            for: code,
+            copy: { _, flags, information in
+                observedFlags = flags
+                information.pointee = expected
+                return errSecSuccess
+            }
+        )
+
+        XCTAssertEqual(
+            observedFlags?.rawValue,
+            SecCSFlags(rawValue: kSecCSSigningInformation).rawValue
+        )
+        XCTAssertEqual(result[kSecCodeInfoTeamIdentifier as String] as? String, "YF7XNRJUG4")
+        XCTAssertEqual(result[kSecCodeInfoUnique as String] as? Data, Data([0x01, 0x02]))
+    }
+
+    func testSigningInformationFailsClosedWhenSecurityReadFails() throws {
+        var staticCode: SecStaticCode?
+        XCTAssertEqual(
+            SecStaticCodeCreateWithPath(
+                URL(fileURLWithPath: "/usr/bin/true") as CFURL,
+                [],
+                &staticCode
+            ),
+            errSecSuccess
+        )
+
+        XCTAssertThrowsError(
+            try ProviderCredentialHandoffRunner.signingInformation(
+                for: try XCTUnwrap(staticCode),
+                copy: { _, _, _ in errSecCSUnsigned }
+            )
+        ) { error in
+            XCTAssertEqual(
+                error as? ProviderCredentialHandoffRunner.Error,
+                .invalidCLI("code signing metadata is unavailable")
+            )
+        }
+    }
+
     func testHandoffImportsThenVerifiesWithFreshInvocation() async throws {
         let recorder = HandoffInvocationRecorder(exitCodes: [0, 0])
         let executable = URL(fileURLWithPath: "/tmp/macprovider-cli")


### PR DESCRIPTION
## Outcome

Fixes the source defect that makes signed Malibu builds report `Malibu Team ID is unavailable` while validating the correctly signed `macprovider-cli` 1.8.40.

This PR is intentionally narrow and is part of #611. It does not close #611 by itself: the exact Developer ID-signed, notarized, stapled downloadable artifact still needs physical install/launch/provider-monitoring and buyer-serving evidence.

## Root cause

Malibu requested `SecCodeCopySigningInformation` with an empty flag set for its own Team ID and for installed/running CLI code-directory metadata. Those extended values are not reliably returned without `kSecCSSigningInformation`.

## Changes

- Adds one injectable signing-information seam that always requests `kSecCSSigningInformation` and fails closed.
- Routes Malibu Team ID, installed CLI code-directory identity, and running CLI code-directory identity through that seam.
- Requires the production Malibu Team ID `YF7XNRJUG4`.
- Preserves the CLI designated requirement, strict signature validation, installed/running code-directory equality, launchd lifecycle authority, and CLI credential custody.
- Adds regression coverage for the Security.framework flags, fail-closed lookup failure, and CLI 1.8.40 acceptance with independently versioned Malibu 1.8.41.
- Does not modify or rebuild `macprovider-cli` 1.8.40 and adds no app/CLI version-equality gate.

## Verification

```text
xcodegen 2.45.4 generate
Created project at phase3-binary/app/Malibu.xcodeproj

Focused suites:
Executed 36 tests, with 0 failures (0 unexpected)
** TEST SUCCEEDED **

Complete Malibu suite:
Executed 174 tests, with 0 failures (0 unexpected)
** TEST SUCCEEDED **

Release configuration:
** BUILD SUCCEEDED **

release security posture regression checks passed
[verify-app-build-inputs] ok: reviewed SwiftPM and app generator inputs match 95e30a792e124a27aa619c932c9d1dcdc1dcbd4a
git diff --check: clean

Code audit: 0 CRITICAL / 0 HIGH / 0 MEDIUM
Security audit: 0 CRITICAL / 0 HIGH / 0 MEDIUM; 1 carried LOW test-hardening suggestion
Architecture audit: 0 CRITICAL / 0 HIGH / 0 MEDIUM
```

The only environmental warning was an out-of-date CoreSimulator framework. It did not block the native macOS destination, tests, or Release build.

## Artifact and physical-machine evidence

- Machine inspected: `Augustas Air`.
- Installed CLI: `1.8.40`.
- CLI SHA-256 before any app installation: `4392cfff14abc7c4ee4e8992e2f264b465f754594397bfd4f92d5859f4d77ff1`.
- CLI identity: `live.streamvc.macprovider.cli`, Team ID `YF7XNRJUG4`, Developer ID Application signed, hardened runtime, launchd service running.
- Existing installed Malibu: Developer ID-signed `1.8.39` build `39`, Team ID `YF7XNRJUG4`.
- Local Release executable SHA-256: `a89f22102e56d49048f2af464a11849b438d17fc147ad1efaf0f33b4221bf408`.
- The local Release product is ad-hoc signed (`TeamIdentifier=not set`) and is **not** a release candidate or downloadable artifact.
- `security find-identity -v -p codesigning` reports `0 valid identities found` on this Air. Developer ID signing, notarization, stapling, packaged-artifact verification, installation, operational-dashboard evidence, CLI after-digest, and buyer-serving proof remain blocked until a signing-capable release environment and physical main Mac are available.

No release is published by this PR, and existing Malibu v1.8.40 release assets do not contain this fix.

## Release handoff

Copy this into a new session:

```text
P0 TASK: Ship a working independently versioned Malibu app release for issue #611.

Business outcome:
A user must be able to download Malibu today, launch it on a Mac with the signed macprovider-cli 1.8.40 installed, and reach the normal
operational/provider-monitoring screen. The existing CLI must remain unchanged and buyer-serving.

This is a narrow release-recovery task. Do not work on referral PRs, catalogs, autotune, #613 automation, or the full #616 convergence project
unless they directly block this exact Malibu release.

Repository:
- /Users/augstar/macprovider-poc
- GitHub: Augustas11/macprovider
- Issue: https://github.com/Augustas11/macprovider/issues/611

Mandatory setup:
1. Read AGENTS.md and CLAUDE.md completely.
2. Inspect:
   - git status -sb
   - git worktree list
   - git fetch origin
3. Create a fresh isolated worktree and branch from origin/main, for example:
   - /Users/augstar/macprovider-611-malibu-team-id-release
   - fix/611-malibu-team-id-release
4. Do not edit the canonical checkout.
5. Do not reuse or modify /Users/augstar/macprovider-585-version-independent. It is a dirty reference worktree only.

Ground truth:
- CLI 1.8.40 is correctly Developer-ID signed with Team ID YF7XNRJUG4.
- Malibu 1.8.39 fails because its signing-information lookup calls SecCodeCopySigningInformation with empty flags.
- origin/main still contains empty signing-information flags in:
  phase3-binary/app/Sources/Malibu/System/ProviderCredentialHandoffRunner.swift
- The required fix exists only as uncommitted reference work in:
  /Users/augstar/macprovider-585-version-independent/phase3-binary/app/Sources/Malibu/System/ProviderCredentialHandoffRunner.swift
  /Users/augstar/macprovider-585-version-independent/phase3-binary/app/Tests/MalibuTests/ProviderCredentialHandoffRunnerTests.swift
- Do not copy any unrelated changes from that worktree.

Implementation:
1. Extract only the signing-information correction:
   - introduce one testable signing-information helper;
   - request kSecCSSigningInformation;
   - use it for Malibu, installed CLI, and running CLI signing metadata;
   - require Malibu Team ID YF7XNRJUG4;
   - preserve fail-closed behavior.
2. Add focused regression tests proving:
   - kSecCSSigningInformation is requested;
   - a Security.framework lookup failure fails closed;
   - Malibu and CLI marketing versions are not required to match.
3. Confirm Malibu remains a monitor for the launchd-managed CLI:
   - Malibu must not own the provider bearer;
   - Malibu must not launch a second managed provider child;
   - CLI/launchd remains lifecycle and credential authority.
4. Select Malibu’s release version from Malibu’s own release history. Do not derive it from CLI 1.8.40 and do not introduce any version-equality
gate.
5. Do not modify or rebuild the CLI unless verification reveals an unavoidable blocker. Record CLI SHA-256 before and after.

Verification:
1. Run the focused Malibu tests.
2. Run the complete relevant Malibu test suite and build.
3. Build the exact release candidate.
4. Verify Developer ID, hardened runtime, notarization, stapling, bundle identity, and Team ID YF7XNRJUG4.
5. Install and test that exact artifact on the physical main Mac from its real current state.
6. If accessible, repeat the relevant launch/install check on the Air.
7. Confirm:
   - Malibu launches without “Malibu Team ID is unavailable”;
   - existing-provider import/monitoring succeeds;
   - Malibu reaches its normal operational screen;
   - no duplicate provider process is started;
   - the installed CLI version and SHA-256 remain unchanged;
   - the provider remains coordinator-connected and buyer-serving;
   - one bounded buyer request succeeds.
8. Test the packaged/downloaded artifact, not merely a local debug .app.

Delivery:
- Commit using the repository Lore commit protocol.
- Push the branch and open a focused PR linked to #611.
- Include exact test output, artifact digest, signing/notarization evidence, CLI before/after digest, screenshots or logs of operational Malibu,
and buyer-serving evidence.
- Update #611 to correct any statement implying the fix was already merged.
- Do not mix broad release-framework work into this PR.
- Do not publicly publish or merge an irreversible stable release without presenting the complete candidate evidence first. If credentials or
required external authority are unavailable, report the exact blocker after completing every local and PR step.

Stop condition:
Do not call this complete because source tests pass. Completion means the exact signed Malibu artifact has been physically demonstrated to
download/install, launch, accept CLI 1.8.40, show the provider operational, preserve the CLI bytes, and keep buyer traffic working.
```
