### PR TITLE
Keep Malibu candidate tests testable before Release archiving

### DIFF
--- a/.github/workflows/malibu-release.yml
+++ b/.github/workflows/malibu-release.yml
@@ -114,7 +114,7 @@ jobs:
           xcodebuild \
             -project Malibu.xcodeproj \
             -scheme Malibu \
-            -configuration Release \
+            -configuration Debug \
             -destination "platform=macOS" \
             test
           xcodebuild \


### PR DESCRIPTION
Follow-up to #620 after private candidate run 29522689125 failed before signing.

The failure was exact and configuration-specific: MalibuTests uses @testable import Malibu, while the production Release target intentionally disables testability. This changes only the pre-archive test invocation to Debug. The separate archive command remains explicitly Release, and only that Release archive is copied into the candidate.

Evidence:
- Failed candidate stopped in the unprotected build job with Module Malibu was not compiled for testing.
- The exact corrected xcodebuild invocation passes 174/174 tests locally.
- Workflow regression, YAML parse, embedded Bash syntax, and diff checks pass.
- Three Codex re-audit lanes: 0 CRITICAL, 0 HIGH, 0 MEDIUM.
- No signing secret was accessed and no candidate/release asset was produced by the failed run.

After merge, a fresh candidate will be built from the new exact origin/main commit. The failed run cannot be reused because the workflow binds run ID, head SHA, manifest, and artifact digest.