### PR TITLE
Recover coordinator referral advocacy and X rewards

### DIFF
--- a/phase4-coordinator/cmd/coordinator-cli/main.go
+++ b/phase4-coordinator/cmd/coordinator-cli/main.go
@@ -47,6 +47,8 @@ func main() {
 		err = adjustSeedReferral(os.Args[2:], os.Getenv, os.Stdout)
 	case "revoke-referral":
 		err = revokeReferral(os.Args[2:], os.Stdout)
+	case "replace-provider-referral":
+		err = replaceProviderReferral(os.Args[2:], os.Getenv, os.Stdout)
 	default:
 		usage()
 		os.Exit(2)
@@ -619,5 +621,5 @@ func preFlipAuditRun(args []string, stdout io.Writer) (stale bool, err error) {
 }
 
 func usage() {
-	fmt.Fprintln(os.Stderr, "usage: coordinator-cli <issue-token|revoke-token|revoke-bootstrap-identity|list-bootstrap-identities|list-tokens|revoke-and-kick|prune-tokens|list-pair-ot-mints|pre-flip-audit|create-seed-referral|adjust-seed-referral|revoke-referral> [flags]")
+	fmt.Fprintln(os.Stderr, "usage: coordinator-cli <issue-token|revoke-token|revoke-bootstrap-identity|list-bootstrap-identities|list-tokens|revoke-and-kick|prune-tokens|list-pair-ot-mints|pre-flip-audit|create-seed-referral|adjust-seed-referral|revoke-referral|replace-provider-referral> [flags]")
 }

--- a/phase4-coordinator/cmd/coordinator-cli/main.go
+++ b/phase4-coordinator/cmd/coordinator-cli/main.go
@@ -41,6 +41,12 @@ func main() {
 		err = listPairOTMints(os.Args[2:])
 	case "pre-flip-audit":
 		err = preFlipAudit(os.Args[2:])
+	case "create-seed-referral":
+		err = createSeedReferral(os.Args[2:], os.Getenv, os.Stdout)
+	case "adjust-seed-referral":
+		err = adjustSeedReferral(os.Args[2:], os.Getenv, os.Stdout)
+	case "revoke-referral":
+		err = revokeReferral(os.Args[2:], os.Stdout)
 	default:
 		usage()
 		os.Exit(2)
@@ -613,5 +619,5 @@ func preFlipAuditRun(args []string, stdout io.Writer) (stale bool, err error) {
 }
 
 func usage() {
-	fmt.Fprintln(os.Stderr, "usage: coordinator-cli <issue-token|revoke-token|revoke-bootstrap-identity|list-bootstrap-identities|list-tokens|revoke-and-kick|prune-tokens|list-pair-ot-mints|pre-flip-audit> [flags]")
+	fmt.Fprintln(os.Stderr, "usage: coordinator-cli <issue-token|revoke-token|revoke-bootstrap-identity|list-bootstrap-identities|list-tokens|revoke-and-kick|prune-tokens|list-pair-ot-mints|pre-flip-audit|create-seed-referral|adjust-seed-referral|revoke-referral> [flags]")
 }

--- a/phase4-coordinator/cmd/coordinator-cli/referrals.go
+++ b/phase4-coordinator/cmd/coordinator-cli/referrals.go
@@ -162,6 +162,106 @@ func revokeReferral(args []string, stdout io.Writer) error {
 	return err
 }
 
+func replaceProviderReferral(args []string, getenv func(string) string, stdout io.Writer) error {
+	fs := newReferralFlagSet("replace-provider-referral")
+	dbPath := fs.String("db", "coordinator.db", "path to coordinator SQLite database")
+	campaign := fs.String("campaign", "", "referral campaign identifier")
+	keyID := fs.String("key-id", "", "HMAC key identifier for the replacement code")
+	secretEnv := fs.String("secret-env", "", "environment variable containing the HMAC secret")
+	issuerID := fs.String("issuer-id", "", "revoked provider invite issuer identifier")
+	apply := fs.Bool("apply", false, "replace the issuer (default is a dry-run preview)")
+	actor := fs.String("actor", "", "operator identity recorded in the audit log (required with --apply)")
+	reason := fs.String("reason", "", "reason recorded in the audit log (required with --apply)")
+	expectProviderID := fs.String("expect-provider-id", "", "provider ID from the dry-run (required with --apply)")
+	expectBaseCapacity := fs.Int("expect-base-capacity", -1, "current base capacity from the dry-run (required with --apply)")
+	expectBonusCapacity := fs.Int("expect-bonus-capacity", -1, "current bonus capacity from the dry-run (required with --apply)")
+	expectRedeemed := fs.Int("expect-redeemed", -1, "carried and current redemptions from the dry-run (required with --apply)")
+	expectPendingSocial := fs.String("expect-pending-social-review", "", "pending social review state from the dry-run: true or false (required with --apply)")
+	setReferralUsage(fs, "replace-provider-referral", "coordinator-cli replace-provider-referral --db coordinator.db --campaign prebeta --key-id k1 --secret-env MAL_REFERRAL_SECRET --issuer-id oldissuer --apply --actor ops@malibu --reason 'rotate compromised link' --expect-provider-id provider-123 --expect-base-capacity 1 --expect-bonus-capacity 0 --expect-redeemed 0 --expect-pending-social-review=false")
+	if err := fs.Parse(args); err != nil {
+		return referralParseError(err)
+	}
+	if fs.NArg() != 0 {
+		return fmt.Errorf("unexpected positional arguments")
+	}
+	actorValue := strings.TrimSpace(*actor)
+	reasonValue := strings.TrimSpace(*reason)
+	providerExpectation := strings.TrimSpace(*expectProviderID)
+	var pendingExpectation bool
+	if *apply {
+		if actorValue == "" || reasonValue == "" {
+			return fmt.Errorf("--actor and --reason are required with --apply")
+		}
+		if providerExpectation == "" || *expectBaseCapacity < 0 || *expectBonusCapacity < 0 || *expectRedeemed < 0 || strings.TrimSpace(*expectPendingSocial) == "" {
+			return fmt.Errorf("--expect-provider-id, --expect-base-capacity, --expect-bonus-capacity, --expect-redeemed, and --expect-pending-social-review are required with --apply (run the dry-run first)")
+		}
+		parsed, err := parseExpectedBool("--expect-pending-social-review", *expectPendingSocial)
+		if err != nil {
+			return err
+		}
+		pendingExpectation = parsed
+	}
+
+	policy, err := referralCLIPolicy(*campaign, *keyID, *secretEnv, getenv)
+	if err != nil {
+		return err
+	}
+	store, err := auth.OpenStore(*dbPath)
+	if err != nil {
+		return err
+	}
+	defer store.Close()
+
+	// Always re-read the durable state immediately before an apply. The
+	// expectation flags bind the operator's earlier preview to this run; the
+	// store then performs its own revoked-issuer CAS inside the transaction.
+	preview, err := store.ReplaceReferralIssuer(context.Background(), policy, strings.TrimSpace(*issuerID), "", "", false, time.Now().UTC())
+	if err != nil {
+		return err
+	}
+	if !*apply {
+		_, err = fmt.Fprintf(stdout, "mode=dry-run\ncampaign=%s\nprovider_id=%s\nold_issuer_id=%s\ncurrent_base_capacity=%d\ncurrent_bonus_capacity=%d\nredeemed=%d\nremaining=%d\npending_social_review=%t\nreplacement_base_capacity=%d\n",
+			policy.Campaign, preview.ProviderID, preview.OldIssuerID, preview.OldBaseCapacity, preview.OldBonusCapacity, preview.Redeemed, preview.Remaining, preview.PendingSocialReview, preview.BaseCapacity)
+		return err
+	}
+	if providerExpectation != preview.ProviderID || *expectBaseCapacity != preview.OldBaseCapacity || *expectBonusCapacity != preview.OldBonusCapacity || *expectRedeemed != preview.Redeemed || pendingExpectation != preview.PendingSocialReview {
+		return fmt.Errorf("replacement snapshot drift: expected provider_id=%s base_capacity=%d bonus_capacity=%d redeemed=%d pending_social_review=%t but live provider_id=%s base_capacity=%d bonus_capacity=%d redeemed=%d pending_social_review=%t; re-run the dry-run",
+			providerExpectation, *expectBaseCapacity, *expectBonusCapacity, *expectRedeemed, pendingExpectation,
+			preview.ProviderID, preview.OldBaseCapacity, preview.OldBonusCapacity, preview.Redeemed, preview.PendingSocialReview)
+	}
+	result, err := store.ReplaceReferralIssuerExpected(
+		context.Background(), policy, preview.OldIssuerID, actorValue, reasonValue,
+		&auth.ReferralReplacementExpectation{
+			ProviderID:          providerExpectation,
+			OldBaseCapacity:     *expectBaseCapacity,
+			OldBonusCapacity:    *expectBonusCapacity,
+			Redeemed:            *expectRedeemed,
+			PendingSocialReview: pendingExpectation,
+		},
+		true, time.Now().UTC(),
+	)
+	if err != nil {
+		return err
+	}
+	if !result.Applied || result.NewIssuerID == "" || result.NewCode == "" {
+		return fmt.Errorf("replacement did not produce a new issuer and referral code")
+	}
+	_, err = fmt.Fprintf(stdout, "mode=applied\nprovider_id=%s\nold_issuer_id=%s\nnew_issuer_id=%s\nnew_referral_code=%s\n",
+		result.ProviderID, result.OldIssuerID, result.NewIssuerID, result.NewCode)
+	return err
+}
+
+func parseExpectedBool(name, value string) (bool, error) {
+	switch strings.ToLower(strings.TrimSpace(value)) {
+	case "true":
+		return true, nil
+	case "false":
+		return false, nil
+	default:
+		return false, fmt.Errorf("%s must be true or false", name)
+	}
+}
+
 func referralCLIPolicy(campaign, keyID, secretEnv string, getenv func(string) string) (auth.ReferralPolicy, error) {
 	secretEnv = strings.TrimSpace(secretEnv)
 	if secretEnv == "" {

--- a/phase4-coordinator/cmd/coordinator-cli/referrals.go
+++ b/phase4-coordinator/cmd/coordinator-cli/referrals.go
@@ -22,7 +22,10 @@ func createSeedReferral(args []string, getenv func(string) string, stdout io.Wri
 	seedID := fs.String("seed-id", "", "opaque seed issuer identifier")
 	maxUses := fs.Int("max-uses", 1, "maximum successful registrations")
 	expiresAt := fs.String("expires-at", "", "optional RFC3339 expiry")
-	setReferralUsage(fs, "create-seed-referral", "coordinator-cli create-seed-referral --db coordinator.db --campaign prebeta --key-id k1 --secret-env MAL_REFERRAL_SECRET --seed-id launch --max-uses 100")
+	apply := fs.Bool("apply", false, "create the seed (default is dry-run preview)")
+	actor := fs.String("actor", "", "operator identity recorded in the audit log (required with --apply)")
+	reason := fs.String("reason", "", "reason recorded in the audit log (required with --apply)")
+	setReferralUsage(fs, "create-seed-referral", "coordinator-cli create-seed-referral --db coordinator.db --campaign prebeta --key-id k1 --secret-env MAL_REFERRAL_SECRET --seed-id launch --max-uses 100 --apply --actor ops@malibu --reason 'open cohort'")
 	if err := fs.Parse(args); err != nil {
 		return referralParseError(err)
 	}
@@ -47,14 +50,25 @@ func createSeedReferral(args []string, getenv func(string) string, stdout io.Wri
 		return err
 	}
 	defer store.Close()
-	code, err := store.CreateSeedReferral(context.Background(), policy, strings.TrimSpace(*seedID), *maxUses, expiry)
+	result, err := store.CreateSeedReferralAudited(context.Background(), policy, strings.TrimSpace(*seedID), *maxUses, expiry, *apply, strings.TrimSpace(*actor), strings.TrimSpace(*reason), time.Now().UTC())
 	if errors.Is(err, auth.ErrReferralSeedExists) {
 		return fmt.Errorf("seed %s already exists; use adjust-seed-referral to change its capacity", strings.TrimSpace(*seedID))
 	}
 	if err != nil {
 		return err
 	}
-	_, err = fmt.Fprintf(stdout, "referral_code=%s\ncampaign=%s\nseed_id=%s\nmax_uses=%d\nstatus=created\n", code, policy.Campaign, strings.TrimSpace(*seedID), *maxUses)
+	mode := "dry-run"
+	if result.Applied {
+		mode = "applied"
+	} else if result.Recovered {
+		mode = "recovered"
+	}
+	if _, err = fmt.Fprintf(stdout, "mode=%s\ncampaign=%s\nseed_id=%s\nmax_uses=%d\n", mode, policy.Campaign, result.SeedID, result.MaxUses); err != nil {
+		return err
+	}
+	if result.Applied || result.Recovered {
+		_, err = fmt.Fprintf(stdout, "referral_code=%s\n", result.Code)
+	}
 	return err
 }
 

--- a/phase4-coordinator/cmd/coordinator-cli/referrals.go
+++ b/phase4-coordinator/cmd/coordinator-cli/referrals.go
@@ -1,0 +1,195 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/augstar/macprovider-coordinator/internal/auth"
+)
+
+func createSeedReferral(args []string, getenv func(string) string, stdout io.Writer) error {
+	fs := newReferralFlagSet("create-seed-referral")
+	dbPath := fs.String("db", "coordinator.db", "path to coordinator SQLite database")
+	campaign := fs.String("campaign", "", "referral campaign identifier")
+	keyID := fs.String("key-id", "", "HMAC key identifier")
+	secretEnv := fs.String("secret-env", "", "environment variable containing the HMAC secret")
+	seedID := fs.String("seed-id", "", "opaque seed issuer identifier")
+	maxUses := fs.Int("max-uses", 1, "maximum successful registrations")
+	expiresAt := fs.String("expires-at", "", "optional RFC3339 expiry")
+	setReferralUsage(fs, "create-seed-referral", "coordinator-cli create-seed-referral --db coordinator.db --campaign prebeta --key-id k1 --secret-env MAL_REFERRAL_SECRET --seed-id launch --max-uses 100")
+	if err := fs.Parse(args); err != nil {
+		return referralParseError(err)
+	}
+	if fs.NArg() != 0 {
+		return fmt.Errorf("unexpected positional arguments")
+	}
+	policy, err := referralCLIPolicy(*campaign, *keyID, *secretEnv, getenv)
+	if err != nil {
+		return err
+	}
+	var expiry *time.Time
+	if raw := strings.TrimSpace(*expiresAt); raw != "" {
+		parsed, err := time.Parse(time.RFC3339, raw)
+		if err != nil {
+			return fmt.Errorf("--expires-at must be RFC3339: %w", err)
+		}
+		parsed = parsed.UTC()
+		expiry = &parsed
+	}
+	store, err := auth.OpenStore(*dbPath)
+	if err != nil {
+		return err
+	}
+	defer store.Close()
+	code, err := store.CreateSeedReferral(context.Background(), policy, strings.TrimSpace(*seedID), *maxUses, expiry)
+	if errors.Is(err, auth.ErrReferralSeedExists) {
+		return fmt.Errorf("seed %s already exists; use adjust-seed-referral to change its capacity", strings.TrimSpace(*seedID))
+	}
+	if err != nil {
+		return err
+	}
+	_, err = fmt.Fprintf(stdout, "referral_code=%s\ncampaign=%s\nseed_id=%s\nmax_uses=%d\nstatus=created\n", code, policy.Campaign, strings.TrimSpace(*seedID), *maxUses)
+	return err
+}
+
+func adjustSeedReferral(args []string, getenv func(string) string, stdout io.Writer) error {
+	fs := newReferralFlagSet("adjust-seed-referral")
+	dbPath := fs.String("db", "coordinator.db", "path to coordinator SQLite database")
+	campaign := fs.String("campaign", "", "referral campaign identifier")
+	keyID := fs.String("key-id", "", "HMAC key identifier")
+	secretEnv := fs.String("secret-env", "", "environment variable containing the HMAC secret")
+	seedID := fs.String("seed-id", "", "opaque seed issuer identifier")
+	maxUses := fs.Int("max-uses", -1, "new maximum successful registrations")
+	apply := fs.Bool("apply", false, "apply the change (default is dry-run preview)")
+	actor := fs.String("actor", "", "operator identity recorded in the audit log (required with --apply)")
+	reason := fs.String("reason", "", "reason recorded in the audit log (required with --apply)")
+	setReferralUsage(fs, "adjust-seed-referral", "coordinator-cli adjust-seed-referral --db coordinator.db --campaign prebeta --key-id k1 --secret-env MAL_REFERRAL_SECRET --seed-id launch --max-uses 250 --apply --actor ops@malibu --reason 'expand cohort'")
+	if err := fs.Parse(args); err != nil {
+		return referralParseError(err)
+	}
+	if fs.NArg() != 0 {
+		return fmt.Errorf("unexpected positional arguments")
+	}
+	if *maxUses < 0 {
+		return fmt.Errorf("--max-uses is required and must be >= 0")
+	}
+	policy, err := referralCLIPolicy(*campaign, *keyID, *secretEnv, getenv)
+	if err != nil {
+		return err
+	}
+	store, err := auth.OpenStore(*dbPath)
+	if err != nil {
+		return err
+	}
+	defer store.Close()
+	result, err := store.AdjustSeedReferral(context.Background(), policy, strings.TrimSpace(*seedID), *maxUses, *apply, strings.TrimSpace(*actor), strings.TrimSpace(*reason), time.Now().UTC())
+	if errors.Is(err, auth.ErrReferralCapacityBelowUsed) {
+		return fmt.Errorf("refusing to set capacity below redeemed uses for seed %s", strings.TrimSpace(*seedID))
+	}
+	if err != nil {
+		return err
+	}
+	mode := "dry-run"
+	if result.Applied {
+		mode = "applied"
+	}
+	_, err = fmt.Fprintf(stdout, "mode=%s\ncampaign=%s\nseed_id=%s\ncurrent_capacity=%d\nnew_capacity=%d\nredeemed=%d\nresulting_remaining=%d\n",
+		mode, policy.Campaign, result.SeedID, result.CurrentCapacity, result.NewCapacity, result.Redeemed, result.ResultingRemaining)
+	return err
+}
+
+func revokeReferral(args []string, stdout io.Writer) error {
+	fs := newReferralFlagSet("revoke-referral")
+	dbPath := fs.String("db", "coordinator.db", "path to coordinator SQLite database")
+	campaign := fs.String("campaign", "", "referral campaign identifier")
+	issuerID := fs.String("issuer-id", "", "seed or provider invite issuer identifier")
+	apply := fs.Bool("apply", false, "apply the revocation (default is a dry-run preview)")
+	actor := fs.String("actor", "", "operator identity recorded in the audit log (required with --apply)")
+	reason := fs.String("reason", "", "reason recorded in the audit log (required with --apply)")
+	expectRedeemed := fs.Int("expect-redeemed", -1, "expected redemption count from the dry-run (required with --apply)")
+	setReferralUsage(fs, "revoke-referral", "coordinator-cli revoke-referral --db coordinator.db --campaign prebeta --issuer-id launch --apply --actor ops@malibu --reason 'abuse report' --expect-redeemed 3")
+	if err := fs.Parse(args); err != nil {
+		return referralParseError(err)
+	}
+	if fs.NArg() != 0 {
+		return fmt.Errorf("unexpected positional arguments")
+	}
+	if *apply && (strings.TrimSpace(*actor) == "" || strings.TrimSpace(*reason) == "") {
+		return fmt.Errorf("--actor and --reason are required with --apply")
+	}
+	var expect *auth.ReferralRevokeExpectation
+	if *apply {
+		if *expectRedeemed < 0 {
+			return fmt.Errorf("--expect-redeemed is required with --apply (run the dry-run first)")
+		}
+		expect = &auth.ReferralRevokeExpectation{Redeemed: *expectRedeemed}
+	}
+	store, err := auth.OpenStore(*dbPath)
+	if err != nil {
+		return err
+	}
+	defer store.Close()
+	result, err := store.RevokeReferralIssuerAudited(context.Background(), *campaign, *issuerID, *apply, strings.TrimSpace(*actor), strings.TrimSpace(*reason), expect, time.Now().UTC())
+	if err != nil {
+		return err
+	}
+	mode := "dry-run"
+	if result.Applied {
+		mode = "applied"
+	}
+	_, err = fmt.Fprintf(stdout, "mode=%s\ncampaign=%s\nissuer_id=%s\ncode_type=%s\nprovider_id=%s\nredeemed=%d\nremaining_capacity=%d\n",
+		mode, result.Campaign, result.IssuerID, result.CodeType, result.ProviderID, result.Redeemed, result.RemainingCapacity)
+	return err
+}
+
+func referralCLIPolicy(campaign, keyID, secretEnv string, getenv func(string) string) (auth.ReferralPolicy, error) {
+	secretEnv = strings.TrimSpace(secretEnv)
+	if secretEnv == "" {
+		return auth.ReferralPolicy{}, fmt.Errorf("--secret-env is required; referral HMAC secrets are not accepted on argv")
+	}
+	secret := getenv(secretEnv)
+	if len(secret) < 32 {
+		return auth.ReferralPolicy{}, fmt.Errorf("referral HMAC secret from %s must be at least 32 bytes", secretEnv)
+	}
+	keyID = strings.TrimSpace(keyID)
+	policy := auth.ReferralPolicy{
+		Campaign:         strings.TrimSpace(campaign),
+		PolicyVersion:    "v1",
+		CurrentKeyID:     keyID,
+		HMACKeys:         map[string]string{keyID: secret},
+		ProviderBaseUses: 1,
+	}
+	if err := policy.Validate(); err != nil {
+		return auth.ReferralPolicy{}, err
+	}
+	return policy, nil
+}
+
+func newReferralFlagSet(name string) *flag.FlagSet {
+	fs := flag.NewFlagSet(name, flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	return fs
+}
+
+func setReferralUsage(fs *flag.FlagSet, name, example string) {
+	fs.Usage = func() {
+		fmt.Fprintf(os.Stderr, "usage: coordinator-cli %s [flags]\n\nflags:\n", name)
+		fs.SetOutput(os.Stderr)
+		fs.PrintDefaults()
+		fs.SetOutput(io.Discard)
+		fmt.Fprintf(os.Stderr, "\nexample:\n  %s\n", example)
+	}
+}
+
+func referralParseError(err error) error {
+	if errors.Is(err, flag.ErrHelp) {
+		return nil
+	}
+	return err
+}

--- a/phase4-coordinator/cmd/coordinator-cli/referrals_test.go
+++ b/phase4-coordinator/cmd/coordinator-cli/referrals_test.go
@@ -20,11 +20,19 @@ func TestReferralCommandsCreateAdjustAndRevoke(t *testing.T) {
 	}
 	base := []string{"--db", dbPath, "--campaign", "prebeta_test", "--key-id", "k1", "--secret-env", "REFERRAL_SECRET", "--seed-id", "launch"}
 	var created bytes.Buffer
-	if err := createSeedReferral(append(append([]string{}, base...), "--max-uses", "2"), getenv, &created); err != nil {
+	createArgs := append(append([]string{}, base...), "--max-uses", "2", "--apply", "--actor", "release", "--reason", "open cohort")
+	if err := createSeedReferral(createArgs, getenv, &created); err != nil {
 		t.Fatal(err)
 	}
 	if !strings.Contains(created.String(), "referral_code=MAL1-S-k1-launch-") {
 		t.Fatalf("create output=%s", created.String())
+	}
+	var recovered bytes.Buffer
+	if err := createSeedReferral(createArgs, getenv, &recovered); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(recovered.String(), "mode=recovered") || !strings.Contains(recovered.String(), "referral_code=MAL1-S-k1-launch-") {
+		t.Fatalf("response-loss recovery output=%s", recovered.String())
 	}
 	if err := createSeedReferral(base, getenv, &bytes.Buffer{}); err == nil || !strings.Contains(err.Error(), "adjust-seed-referral") {
 		t.Fatalf("duplicate create error=%v", err)

--- a/phase4-coordinator/cmd/coordinator-cli/referrals_test.go
+++ b/phase4-coordinator/cmd/coordinator-cli/referrals_test.go
@@ -3,9 +3,11 @@ package main
 import (
 	"bytes"
 	"context"
+	"database/sql"
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/augstar/macprovider-coordinator/internal/auth"
 )
@@ -77,4 +79,184 @@ func TestReferralCommandsNeverAcceptSecretOnArgv(t *testing.T) {
 	if err == nil || !strings.Contains(err.Error(), "--secret-env is required") {
 		t.Fatalf("error=%v", err)
 	}
+}
+
+func TestReplaceProviderReferralDryRun(t *testing.T) {
+	dbPath, policy, issuerID, providerID, getenv := setupReplaceProviderReferral(t)
+	var stdout bytes.Buffer
+	if err := replaceProviderReferral(replaceProviderBaseArgs(dbPath, issuerID), getenv, &stdout); err != nil {
+		t.Fatal(err)
+	}
+	output := stdout.String()
+	for _, want := range []string{
+		"mode=dry-run",
+		"provider_id=" + providerID,
+		"old_issuer_id=" + issuerID,
+		"current_base_capacity=1",
+		"current_bonus_capacity=0",
+		"redeemed=0",
+		"remaining=1",
+		"pending_social_review=false",
+	} {
+		if !strings.Contains(output, want) {
+			t.Fatalf("dry-run output %q missing %q", output, want)
+		}
+	}
+	if strings.Contains(output, "new_referral_code=") || strings.Contains(output, "new_issuer_id=") {
+		t.Fatalf("dry-run disclosed apply-only output: %s", output)
+	}
+	store, err := auth.OpenStore(dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+	status, err := store.ProviderReferralStatus(context.Background(), policy, providerID)
+	if err != nil || status.IssuerID != issuerID || !status.Revoked {
+		t.Fatalf("status=%+v err=%v", status, err)
+	}
+}
+
+func TestReplaceProviderReferralApplyRequiresAllExpectations(t *testing.T) {
+	dbPath, _, issuerID, _, getenv := setupReplaceProviderReferral(t)
+	args := append(replaceProviderBaseArgs(dbPath, issuerID), "--apply", "--actor", "ops", "--reason", "rotate")
+	err := replaceProviderReferral(args, getenv, &bytes.Buffer{})
+	if err == nil || !strings.Contains(err.Error(), "--expect-provider-id") {
+		t.Fatalf("error=%v", err)
+	}
+}
+
+func TestReplaceProviderReferralRejectsPreviewMismatch(t *testing.T) {
+	dbPath, policy, issuerID, providerID, getenv := setupReplaceProviderReferral(t)
+	args := replaceProviderApplyArgs(dbPath, issuerID, "different-provider")
+	err := replaceProviderReferral(args, getenv, &bytes.Buffer{})
+	if err == nil || !strings.Contains(err.Error(), "replacement snapshot drift") {
+		t.Fatalf("error=%v", err)
+	}
+	store, err := auth.OpenStore(dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+	status, err := store.ProviderReferralStatus(context.Background(), policy, providerID)
+	if err != nil || status.IssuerID != issuerID || !status.Revoked {
+		t.Fatalf("status=%+v err=%v", status, err)
+	}
+}
+
+func TestReplaceProviderReferralApplied(t *testing.T) {
+	dbPath, policy, issuerID, providerID, getenv := setupReplaceProviderReferral(t)
+	var stdout bytes.Buffer
+	if err := replaceProviderReferral(replaceProviderApplyArgs(dbPath, issuerID, providerID), getenv, &stdout); err != nil {
+		t.Fatal(err)
+	}
+	output := stdout.String()
+	for _, want := range []string{"mode=applied", "provider_id=" + providerID, "old_issuer_id=" + issuerID, "new_issuer_id=", "new_referral_code=MAL1-P-k1-"} {
+		if !strings.Contains(output, want) {
+			t.Fatalf("apply output %q missing %q", output, want)
+		}
+	}
+	store, err := auth.OpenStore(dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+	status, err := store.ProviderReferralStatus(context.Background(), policy, providerID)
+	if err != nil || status.IssuerID == issuerID || status.Revoked {
+		t.Fatalf("status=%+v err=%v", status, err)
+	}
+	var oldProvider sql.NullString
+	var replacedBy sql.NullString
+	if err := store.DB().QueryRow(`SELECT provider_id, replaced_by FROM referral_issuers WHERE issuer_id = ?`, issuerID).Scan(&oldProvider, &replacedBy); err != nil {
+		t.Fatal(err)
+	}
+	if oldProvider.Valid || !replacedBy.Valid || replacedBy.String != status.IssuerID {
+		t.Fatalf("old provider=%+v replaced_by=%+v new issuer=%q", oldProvider, replacedBy, status.IssuerID)
+	}
+}
+
+func TestReplaceProviderReferralRequiresServingQualification(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "coordinator.db")
+	store, err := auth.OpenStore(dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	now := time.Date(2026, 7, 16, 9, 0, 0, 0, time.UTC).Format(time.RFC3339)
+	if _, err := store.DB().Exec(`
+INSERT INTO referral_issuers (
+    issuer_id, code_type, key_id, campaign, provider_id,
+    base_capacity, bonus_capacity, created_at, first_serving_at, revoked_at
+) VALUES ('unqualified', 'P', 'k1', 'prebeta_test', 'provider-unqualified', 1, 0, ?, ?, ?)`, now, now, now); err != nil {
+		store.Close()
+		t.Fatal(err)
+	}
+	store.Close()
+	getenv := func(key string) string {
+		if key == "REFERRAL_SECRET" {
+			return strings.Repeat("s", 32)
+		}
+		return ""
+	}
+	err = replaceProviderReferral(replaceProviderBaseArgs(dbPath, "unqualified"), getenv, &bytes.Buffer{})
+	if err == nil {
+		t.Fatal("replacement succeeded without serving qualification")
+	}
+	store, err = auth.OpenStore(dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+	var issuerRows int
+	if err := store.DB().QueryRow(`SELECT COUNT(1) FROM referral_issuers`).Scan(&issuerRows); err != nil {
+		t.Fatal(err)
+	}
+	if issuerRows != 1 {
+		t.Fatalf("issuer rows=%d", issuerRows)
+	}
+}
+
+func setupReplaceProviderReferral(t *testing.T) (string, auth.ReferralPolicy, string, string, func(string) string) {
+	t.Helper()
+	dbPath := filepath.Join(t.TempDir(), "coordinator.db")
+	getenv := func(key string) string {
+		if key == "REFERRAL_SECRET" {
+			return strings.Repeat("s", 32)
+		}
+		return ""
+	}
+	policy, err := referralCLIPolicy("prebeta_test", "k1", "REFERRAL_SECRET", getenv)
+	if err != nil {
+		t.Fatal(err)
+	}
+	store, err := auth.OpenStore(dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+	now := time.Date(2026, 7, 16, 9, 0, 0, 0, time.UTC)
+	providerID := "provider-replace"
+	status, created, err := store.QualifyProviderReferral(context.Background(), policy, providerID, "receipt-replace", now.Add(-time.Minute), now)
+	if err != nil || !created {
+		t.Fatalf("qualify status=%+v created=%t err=%v", status, created, err)
+	}
+	if _, err := store.RevokeReferralIssuerAudited(context.Background(), policy.Campaign, status.IssuerID, true, "ops", "rotate", &auth.ReferralRevokeExpectation{Redeemed: 0}, now.Add(time.Minute)); err != nil {
+		t.Fatal(err)
+	}
+	return dbPath, policy, status.IssuerID, providerID, getenv
+}
+
+func replaceProviderBaseArgs(dbPath, issuerID string) []string {
+	return []string{"--db", dbPath, "--campaign", "prebeta_test", "--key-id", "k1", "--secret-env", "REFERRAL_SECRET", "--issuer-id", issuerID}
+}
+
+func replaceProviderApplyArgs(dbPath, issuerID, providerID string) []string {
+	return append(replaceProviderBaseArgs(dbPath, issuerID),
+		"--apply",
+		"--actor", "ops",
+		"--reason", "rotate compromised link",
+		"--expect-provider-id", providerID,
+		"--expect-base-capacity", "1",
+		"--expect-bonus-capacity", "0",
+		"--expect-redeemed", "0",
+		"--expect-pending-social-review=false",
+	)
 }

--- a/phase4-coordinator/cmd/coordinator-cli/referrals_test.go
+++ b/phase4-coordinator/cmd/coordinator-cli/referrals_test.go
@@ -1,0 +1,72 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/augstar/macprovider-coordinator/internal/auth"
+)
+
+func TestReferralCommandsCreateAdjustAndRevoke(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "coordinator.db")
+	getenv := func(key string) string {
+		if key == "REFERRAL_SECRET" {
+			return strings.Repeat("s", 32)
+		}
+		return ""
+	}
+	base := []string{"--db", dbPath, "--campaign", "prebeta_test", "--key-id", "k1", "--secret-env", "REFERRAL_SECRET", "--seed-id", "launch"}
+	var created bytes.Buffer
+	if err := createSeedReferral(append(append([]string{}, base...), "--max-uses", "2"), getenv, &created); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(created.String(), "referral_code=MAL1-S-k1-launch-") {
+		t.Fatalf("create output=%s", created.String())
+	}
+	if err := createSeedReferral(base, getenv, &bytes.Buffer{}); err == nil || !strings.Contains(err.Error(), "adjust-seed-referral") {
+		t.Fatalf("duplicate create error=%v", err)
+	}
+
+	var adjusted bytes.Buffer
+	adjustArgs := append(append([]string{}, base...), "--max-uses", "4", "--apply", "--actor", "ops", "--reason", "expand")
+	if err := adjustSeedReferral(adjustArgs, getenv, &adjusted); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(adjusted.String(), "mode=applied") || strings.Contains(adjusted.String(), "reserved=") {
+		t.Fatalf("adjust output=%s", adjusted.String())
+	}
+
+	store, err := auth.OpenStore(dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var auditRows int
+	if err := store.DB().QueryRowContext(context.Background(), `SELECT COUNT(1) FROM referral_admin_audit WHERE actor = 'ops'`).Scan(&auditRows); err != nil {
+		t.Fatal(err)
+	}
+	store.Close()
+	if auditRows != 1 {
+		t.Fatalf("audit rows=%d", auditRows)
+	}
+
+	var preview bytes.Buffer
+	if err := revokeReferral([]string{"--db", dbPath, "--campaign", "prebeta_test", "--issuer-id", "launch"}, &preview); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(preview.String(), "redeemed=0") || strings.Contains(preview.String(), "reservation") {
+		t.Fatalf("revoke preview=%s", preview.String())
+	}
+	if err := revokeReferral([]string{"--db", dbPath, "--campaign", "prebeta_test", "--issuer-id", "launch", "--apply", "--actor", "ops", "--reason", "retire", "--expect-redeemed", "0"}, &bytes.Buffer{}); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestReferralCommandsNeverAcceptSecretOnArgv(t *testing.T) {
+	err := createSeedReferral([]string{"--campaign", "prebeta_test", "--key-id", "k1", "--seed-id", "launch"}, func(string) string { return "" }, &bytes.Buffer{})
+	if err == nil || !strings.Contains(err.Error(), "--secret-env is required") {
+		t.Fatalf("error=%v", err)
+	}
+}

--- a/phase4-coordinator/cmd/coordinator/main.go
+++ b/phase4-coordinator/cmd/coordinator/main.go
@@ -920,34 +920,34 @@ func main() {
 		enrollHandler,
 		malibuAccrualHandler(cfg, tokenStore, rewardsDB, rewards.NewPoolHeartbeatBridge(wsServer.PoolSnapshot)),
 	)
-	trustedReferralProxies := mustParseTrustedProxies(cfg, logger)
+	var trustedReferralProxies []netip.Prefix
+	if cfg.Referrals.EnablePublicValidation || cfg.Referrals.EnableJoinLinks {
+		trustedReferralProxies = mustParseTrustedProxies(cfg, logger)
+	}
 	var referralValidationHandler http.HandlerFunc
 	if cfg.Referrals.EnablePublicValidation {
-		referralValidation := &referralapi.ValidationHandler{
-			Store:         tokenStore,
-			Policy:        referralPolicy,
-			PublicLimiter: referralapi.NewBoundedLimiter(30, time.Minute, 4096),
-			ValidateSlots: make(chan struct{}, 4),
+		referralValidation := newReferralValidationHandler(tokenStore, referralPolicy, trustedReferralProxies, cfg.Referrals.RequestAccessURL)
+		referralValidationHandler = referralValidation.ServeHTTP
+	}
+	var referralJoinHandler http.HandlerFunc
+	if cfg.Referrals.EnableJoinLinks {
+		referralJoin := &referralapi.JoinHandler{
+			Store:            tokenStore,
+			Policy:           referralPolicy,
+			PublicLimiter:    referralapi.NewBoundedLimiter(30, time.Minute, 4096),
+			ValidateSlots:    make(chan struct{}, 4),
+			RequestAccessURL: cfg.Referrals.RequestAccessURL,
+			DownloadURL:      cfg.Referrals.JoinDownloadURL,
 			SourceIP: func(r *http.Request) string {
 				return onboarding.ClientIP(r, trustedReferralProxies)
 			},
+			ErrorLogger: func(op string, err error) {
+				logger.Error().Err(err).Str("op", op).Msg("referral join failed")
+			},
 		}
-		referralValidationHandler = referralValidation.ServeHTTP
+		referralJoinHandler = referralJoin.ServeHTTP
 	}
-	referralJoin := &referralapi.JoinHandler{
-		Store:            tokenStore,
-		Policy:           referralPolicy,
-		PublicLimiter:    referralapi.NewBoundedLimiter(30, time.Minute, 4096),
-		ValidateSlots:    make(chan struct{}, 4),
-		RequestAccessURL: cfg.Referrals.RequestAccessURL,
-		SourceIP: func(r *http.Request) string {
-			return onboarding.ClientIP(r, trustedReferralProxies)
-		},
-		ErrorLogger: func(op string, err error) {
-			logger.Error().Err(err).Str("op", op).Msg("referral join failed")
-		},
-	}
-	buyerHandler = withReferralValidation(buyerHandler, referralValidationHandler, referralJoin.ServeHTTP)
+	buyerHandler = withReferralValidation(buyerHandler, referralValidationHandler, referralJoinHandler)
 
 	providerHTTP := newHTTPServer(providerAddr, providerMux)
 	buyerHTTP := newHTTPServer(buyerAddr, buyerHandler)
@@ -1325,20 +1325,32 @@ func buyerHandlerWithOptionalProviderEndpoints(base http.Handler, enabled bool, 
 	return mux
 }
 
-func withReferralValidation(base http.Handler, validate http.HandlerFunc, join ...http.HandlerFunc) http.Handler {
-	hasJoin := len(join) > 0 && join[0] != nil
-	if validate == nil && !hasJoin {
+func withReferralValidation(base http.Handler, validate, join http.HandlerFunc) http.Handler {
+	if validate == nil && join == nil {
 		return base
 	}
 	mux := http.NewServeMux()
 	if validate != nil {
 		mux.HandleFunc("/v1/referrals/validate", validate)
 	}
-	if hasJoin {
-		mux.HandleFunc("/j/", join[0])
+	if join != nil {
+		mux.HandleFunc("/j/", join)
 	}
 	mux.Handle("/", base)
 	return mux
+}
+
+func newReferralValidationHandler(store referralapi.ValidationStore, policy auth.ReferralPolicy, trustedProxies []netip.Prefix, requestAccessURL string) *referralapi.ValidationHandler {
+	return &referralapi.ValidationHandler{
+		Store:            store,
+		Policy:           policy,
+		PublicLimiter:    referralapi.NewBoundedLimiter(30, time.Minute, 4096),
+		ValidateSlots:    make(chan struct{}, 4),
+		RequestAccessURL: strings.TrimSpace(requestAccessURL),
+		SourceIP: func(r *http.Request) string {
+			return onboarding.ClientIP(r, trustedProxies)
+		},
+	}
 }
 
 // buildEnrollHandler constructs the MDM enrollment handler for POST /v1/enroll.

--- a/phase4-coordinator/cmd/coordinator/main.go
+++ b/phase4-coordinator/cmd/coordinator/main.go
@@ -920,9 +920,9 @@ func main() {
 		enrollHandler,
 		malibuAccrualHandler(cfg, tokenStore, rewardsDB, rewards.NewPoolHeartbeatBridge(wsServer.PoolSnapshot)),
 	)
+	trustedReferralProxies := mustParseTrustedProxies(cfg, logger)
 	var referralValidationHandler http.HandlerFunc
 	if cfg.Referrals.EnablePublicValidation {
-		trustedReferralProxies := mustParseTrustedProxies(cfg, logger)
 		referralValidation := &referralapi.ValidationHandler{
 			Store:         tokenStore,
 			Policy:        referralPolicy,
@@ -934,7 +934,20 @@ func main() {
 		}
 		referralValidationHandler = referralValidation.ServeHTTP
 	}
-	buyerHandler = withReferralValidation(buyerHandler, referralValidationHandler)
+	referralJoin := &referralapi.JoinHandler{
+		Store:            tokenStore,
+		Policy:           referralPolicy,
+		PublicLimiter:    referralapi.NewBoundedLimiter(30, time.Minute, 4096),
+		ValidateSlots:    make(chan struct{}, 4),
+		RequestAccessURL: cfg.Referrals.RequestAccessURL,
+		SourceIP: func(r *http.Request) string {
+			return onboarding.ClientIP(r, trustedReferralProxies)
+		},
+		ErrorLogger: func(op string, err error) {
+			logger.Error().Err(err).Str("op", op).Msg("referral join failed")
+		},
+	}
+	buyerHandler = withReferralValidation(buyerHandler, referralValidationHandler, referralJoin.ServeHTTP)
 
 	providerHTTP := newHTTPServer(providerAddr, providerMux)
 	buyerHTTP := newHTTPServer(buyerAddr, buyerHandler)
@@ -1312,12 +1325,18 @@ func buyerHandlerWithOptionalProviderEndpoints(base http.Handler, enabled bool, 
 	return mux
 }
 
-func withReferralValidation(base http.Handler, validate http.HandlerFunc) http.Handler {
-	if validate == nil {
+func withReferralValidation(base http.Handler, validate http.HandlerFunc, join ...http.HandlerFunc) http.Handler {
+	hasJoin := len(join) > 0 && join[0] != nil
+	if validate == nil && !hasJoin {
 		return base
 	}
 	mux := http.NewServeMux()
-	mux.HandleFunc("/v1/referrals/validate", validate)
+	if validate != nil {
+		mux.HandleFunc("/v1/referrals/validate", validate)
+	}
+	if hasJoin {
+		mux.HandleFunc("/j/", join[0])
+	}
 	mux.Handle("/", base)
 	return mux
 }

--- a/phase4-coordinator/cmd/coordinator/main.go
+++ b/phase4-coordinator/cmd/coordinator/main.go
@@ -29,6 +29,7 @@ import (
 	"github.com/augstar/macprovider-coordinator/internal/pool"
 	"github.com/augstar/macprovider-coordinator/internal/pow"
 	"github.com/augstar/macprovider-coordinator/internal/providerhttp"
+	"github.com/augstar/macprovider-coordinator/internal/referralapi"
 	"github.com/augstar/macprovider-coordinator/internal/requestlog"
 	"github.com/augstar/macprovider-coordinator/internal/rewards"
 	"github.com/augstar/macprovider-coordinator/internal/stats"
@@ -453,7 +454,28 @@ func main() {
 		}
 	}()
 	wsOpts := []providerws.Option{}
+	var grandfatherBefore *time.Time
+	if raw := strings.TrimSpace(cfg.Referrals.GrandfatherBefore); raw != "" && cfg.Referrals.RequireForRegistration {
+		parsed, err := time.Parse(time.RFC3339, raw)
+		if err != nil {
+			logger.Fatal().Err(err).Msg("parse referral grandfather cutoff")
+		}
+		grandfatherBefore = &parsed
+	}
+	referralPolicy := auth.ReferralPolicy{
+		RequireForRegistration: cfg.Referrals.RequireForRegistration,
+		EnableSocialBonus:      cfg.Referrals.EnableSocialInviteBonus,
+		Campaign:               cfg.Referrals.Campaign,
+		PolicyVersion:          cfg.Referrals.PolicyVersion,
+		GrandfatherBefore:      grandfatherBefore,
+		CurrentKeyID:           cfg.Referrals.CurrentKeyID,
+		HMACKeys:               cfg.Referrals.HMACKeys,
+		ProviderBaseUses:       cfg.Referrals.ProviderBaseUses,
+		SocialBonusUses:        cfg.Referrals.SocialBonusUses,
+		ChallengeTTL:           time.Duration(cfg.Referrals.ChallengeTTLS) * time.Second,
+	}
 	wsOpts = append(wsOpts, providerws.WithVersion(version))
+	wsOpts = append(wsOpts, providerws.WithReferralPolicy(referralPolicy))
 	wsOpts = append(wsOpts, providerws.WithAdmissionStore(admissionStore))
 	if canaryStore != nil {
 		wsOpts = append(wsOpts, providerws.WithCanarySanctionStore(canaryStore))
@@ -851,6 +873,8 @@ func main() {
 		registerHandler := &onboarding.Handler{
 			StatsDB:                             onboardingStore,
 			AuthTokenStore:                      tokenStore,
+			ReferralStore:                       tokenStore,
+			ReferralPolicy:                      referralPolicy,
 			CoordinatorDomain:                   cfg.Onboarding.CoordinatorDomain,
 			CoordinatorWSURL:                    "wss://" + cfg.Onboarding.CoordinatorDomain + "/v2/provider",
 			TrustedProxies:                      mustParseTrustedProxies(cfg, logger),
@@ -875,6 +899,7 @@ func main() {
 		}
 		register = registerHandler.HandleAppTrackRegister
 		hardwareEvidence = registerHandler.HandleHardwareEvidence
+		startAppTrackReferralMintReconciler(shutdownCtx, registerHandler, logger)
 		logger.Info().Msg("SPEC-026 app-track register route mounted on buyer port")
 	}
 	// Phase 2 Track P2-A: MDM enrollment profile endpoint.
@@ -887,7 +912,7 @@ func main() {
 			Str("base_url", cfg.Tier2.MDM.EnrollmentBaseURL).
 			Msg("MDM enrollment profile route mounted on buyer port (/v1/enroll)")
 	}
-	buyerHandler := buyerHandlerWithOptionalProviderEndpoints(
+	var buyerHandler http.Handler = buyerHandlerWithOptionalProviderEndpoints(
 		buyerServer.Handler(),
 		cfg.Onboarding.AppTrackRegisterEnabled,
 		register,
@@ -895,6 +920,17 @@ func main() {
 		enrollHandler,
 		malibuAccrualHandler(cfg, tokenStore, rewardsDB, rewards.NewPoolHeartbeatBridge(wsServer.PoolSnapshot)),
 	)
+	trustedReferralProxies := mustParseTrustedProxies(cfg, logger)
+	referralValidation := &referralapi.ValidationHandler{
+		Store:         tokenStore,
+		Policy:        referralPolicy,
+		PublicLimiter: referralapi.NewBoundedLimiter(30, time.Minute, 4096),
+		ValidateSlots: make(chan struct{}, 4),
+		SourceIP: func(r *http.Request) string {
+			return onboarding.ClientIP(r, trustedReferralProxies)
+		},
+	}
+	buyerHandler = withReferralValidation(buyerHandler, referralValidation.ServeHTTP)
 
 	providerHTTP := newHTTPServer(providerAddr, providerMux)
 	buyerHTTP := newHTTPServer(buyerAddr, buyerHandler)
@@ -1172,6 +1208,32 @@ func startGitHubAuthStatePruner(ctx context.Context, store githubAuthStatePruner
 	}()
 }
 
+func startAppTrackReferralMintReconciler(ctx context.Context, handler *onboarding.Handler, logger zerolog.Logger) {
+	if handler == nil || !handler.ReferralPolicy.RequireForRegistration {
+		return
+	}
+	go func() {
+		reconcile := func() {
+			reconcileCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+			defer cancel()
+			if err := handler.ReconcilePendingAppTrackReferralMints(reconcileCtx); err != nil && ctx.Err() == nil {
+				logger.Error().Err(err).Msg("App-track referral mint reconciliation failed")
+			}
+		}
+		reconcile()
+		ticker := time.NewTicker(time.Minute)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				reconcile()
+			}
+		}
+	}()
+}
+
 func startAuditLogRetentionPruner(ctx context.Context, store requestLogPruner, retentionDays int, logger zerolog.Logger) {
 	if store == nil || retentionDays <= 0 {
 		return
@@ -1242,6 +1304,16 @@ func buyerHandlerWithOptionalProviderEndpoints(base http.Handler, enabled bool, 
 	if malibuAccrual != nil {
 		mux.Handle("/v1/provider/malibu-accrual", malibuAccrual)
 	}
+	mux.Handle("/", base)
+	return mux
+}
+
+func withReferralValidation(base http.Handler, validate http.HandlerFunc) http.Handler {
+	if validate == nil {
+		return base
+	}
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v1/referrals/validate", validate)
 	mux.Handle("/", base)
 	return mux
 }

--- a/phase4-coordinator/cmd/coordinator/main.go
+++ b/phase4-coordinator/cmd/coordinator/main.go
@@ -920,17 +920,21 @@ func main() {
 		enrollHandler,
 		malibuAccrualHandler(cfg, tokenStore, rewardsDB, rewards.NewPoolHeartbeatBridge(wsServer.PoolSnapshot)),
 	)
-	trustedReferralProxies := mustParseTrustedProxies(cfg, logger)
-	referralValidation := &referralapi.ValidationHandler{
-		Store:         tokenStore,
-		Policy:        referralPolicy,
-		PublicLimiter: referralapi.NewBoundedLimiter(30, time.Minute, 4096),
-		ValidateSlots: make(chan struct{}, 4),
-		SourceIP: func(r *http.Request) string {
-			return onboarding.ClientIP(r, trustedReferralProxies)
-		},
+	var referralValidationHandler http.HandlerFunc
+	if cfg.Referrals.EnablePublicValidation {
+		trustedReferralProxies := mustParseTrustedProxies(cfg, logger)
+		referralValidation := &referralapi.ValidationHandler{
+			Store:         tokenStore,
+			Policy:        referralPolicy,
+			PublicLimiter: referralapi.NewBoundedLimiter(30, time.Minute, 4096),
+			ValidateSlots: make(chan struct{}, 4),
+			SourceIP: func(r *http.Request) string {
+				return onboarding.ClientIP(r, trustedReferralProxies)
+			},
+		}
+		referralValidationHandler = referralValidation.ServeHTTP
 	}
-	buyerHandler = withReferralValidation(buyerHandler, referralValidation.ServeHTTP)
+	buyerHandler = withReferralValidation(buyerHandler, referralValidationHandler)
 
 	providerHTTP := newHTTPServer(providerAddr, providerMux)
 	buyerHTTP := newHTTPServer(buyerAddr, buyerHandler)

--- a/phase4-coordinator/cmd/coordinator/main.go
+++ b/phase4-coordinator/cmd/coordinator/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"flag"
 	"fmt"
 	"net"
@@ -463,16 +464,17 @@ func main() {
 		grandfatherBefore = &parsed
 	}
 	referralPolicy := auth.ReferralPolicy{
-		RequireForRegistration: cfg.Referrals.RequireForRegistration,
-		EnableSocialBonus:      cfg.Referrals.EnableSocialInviteBonus,
-		Campaign:               cfg.Referrals.Campaign,
-		PolicyVersion:          cfg.Referrals.PolicyVersion,
-		GrandfatherBefore:      grandfatherBefore,
-		CurrentKeyID:           cfg.Referrals.CurrentKeyID,
-		HMACKeys:               cfg.Referrals.HMACKeys,
-		ProviderBaseUses:       cfg.Referrals.ProviderBaseUses,
-		SocialBonusUses:        cfg.Referrals.SocialBonusUses,
-		ChallengeTTL:           time.Duration(cfg.Referrals.ChallengeTTLS) * time.Second,
+		RequireForRegistration:  cfg.Referrals.RequireForRegistration,
+		EnableSocialBonus:       cfg.Referrals.EnableSocialInviteBonus,
+		Campaign:                cfg.Referrals.Campaign,
+		PolicyVersion:           cfg.Referrals.PolicyVersion,
+		GrandfatherBefore:       grandfatherBefore,
+		CurrentKeyID:            cfg.Referrals.CurrentKeyID,
+		HMACKeys:                cfg.Referrals.HMACKeys,
+		ProviderBaseUses:        cfg.Referrals.ProviderBaseUses,
+		SocialBonusUses:         cfg.Referrals.SocialBonusUses,
+		ChallengeTTL:            time.Duration(cfg.Referrals.ChallengeTTLS) * time.Second,
+		SocialVerificationDwell: time.Duration(cfg.Referrals.SocialVerificationDwellS) * time.Second,
 	}
 	wsOpts = append(wsOpts, providerws.WithVersion(version))
 	wsOpts = append(wsOpts, providerws.WithReferralPolicy(referralPolicy))
@@ -948,6 +950,43 @@ func main() {
 		referralJoinHandler = referralJoin.ServeHTTP
 	}
 	buyerHandler = withReferralValidation(buyerHandler, referralValidationHandler, referralJoinHandler)
+	var referralStatus, referralChallenge, referralVerify http.HandlerFunc
+	if cfg.Referrals.RequireForRegistration {
+		advocacy := &referralapi.AdvocacyHandler{
+			Store:           tokenStore,
+			Tokens:          tokenStore,
+			Policy:          referralPolicy,
+			PublicLimiter:   referralapi.NewBoundedLimiter(60, time.Minute, 4096),
+			ProviderLimiter: referralapi.NewBoundedLimiter(10, time.Minute, 4096),
+			AuthSlots:       make(chan struct{}, 16),
+			VerifySlots:     make(chan struct{}, 8),
+			JoinBaseURL:     cfg.Referrals.JoinBaseURL,
+			SourceIP: func(r *http.Request) string {
+				return onboarding.ClientIP(r, trustedReferralProxies)
+			},
+		}
+		referralStatus = advocacy.HandleStatus
+		startReferralServingReconciler(shutdownCtx, referralapi.ServingReconciler{
+			Source: referralapi.SQLiteServingEvidence{Path: cfg.Storage.DBPath},
+			Store:  tokenStore,
+			Policy: referralPolicy,
+		}, logger)
+		if cfg.Referrals.EnableSocialInviteBonus {
+			xClient, err := referralapi.NewXAPIClient(cfg.Referrals.XAPIBearerToken, cfg.Referrals.JoinBaseURL)
+			if err != nil {
+				logger.Fatal().Err(err).Msg("invalid social verification configuration")
+			}
+			advocacy.PostVerifier = xClient
+			referralChallenge = advocacy.HandleChallenge
+			referralVerify = advocacy.HandleVerify
+			startSocialVerificationPromotionReconciler(shutdownCtx, tokenStore, referralPolicy, xClient, logger)
+		}
+		logger.Info().
+			Bool("social_invite_bonus", cfg.Referrals.EnableSocialInviteBonus).
+			Str("campaign", cfg.Referrals.Campaign).
+			Msg("provider referral status endpoint mounted; mutation routes remain feature-gated")
+	}
+	buyerHandler = withReferralAdvocacy(buyerHandler, referralStatus, referralChallenge, referralVerify)
 
 	providerHTTP := newHTTPServer(providerAddr, providerMux)
 	buyerHTTP := newHTTPServer(buyerAddr, buyerHandler)
@@ -1251,6 +1290,91 @@ func startAppTrackReferralMintReconciler(ctx context.Context, handler *onboardin
 	}()
 }
 
+func startReferralServingReconciler(ctx context.Context, reconciler referralapi.ServingReconciler, logger zerolog.Logger) {
+	if reconciler.Source == nil || reconciler.Store == nil || !reconciler.Policy.RequireForRegistration {
+		return
+	}
+	go func() {
+		reconcile := func() {
+			reconcileCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+			defer cancel()
+			qualified, err := reconciler.Reconcile(reconcileCtx)
+			if err != nil && ctx.Err() == nil {
+				logger.Error().Err(err).Msg("referral serving qualification reconciliation failed")
+				return
+			}
+			if qualified > 0 {
+				logger.Info().Int("qualified", qualified).Msg("provider referral invite capacity awarded from verified serving evidence")
+			}
+		}
+		reconcile()
+		ticker := time.NewTicker(time.Minute)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				reconcile()
+			}
+		}
+	}()
+}
+
+type socialAuthorLookup interface {
+	RecheckPost(context.Context, string, string) (string, error)
+}
+
+func startSocialVerificationPromotionReconciler(
+	ctx context.Context,
+	store *auth.Store,
+	policy auth.ReferralPolicy,
+	verifier socialAuthorLookup,
+	logger zerolog.Logger,
+) {
+	if store == nil || verifier == nil || !policy.EnableSocialBonus {
+		return
+	}
+	recheck := func(ctx context.Context, postID, boundAuthorID, shareURLHash string) error {
+		authorID, err := verifier.RecheckPost(ctx, postID, shareURLHash)
+		if err != nil {
+			if errors.Is(err, referralapi.ErrXPostTransient) {
+				return fmt.Errorf("%w: x lookup unavailable", auth.ErrSocialRecheckTransient)
+			}
+			return err
+		}
+		if boundAuthorID == "" || authorID != boundAuthorID {
+			return fmt.Errorf("x post author no longer matches")
+		}
+		return nil
+	}
+	go func() {
+		reconcile := func() {
+			reconcileCtx, cancel := context.WithTimeout(ctx, 45*time.Second)
+			defer cancel()
+			granted, err := store.PromoteMaturedSocialVerifications(reconcileCtx, policy, time.Now().UTC(), recheck)
+			if err != nil && ctx.Err() == nil {
+				logger.Error().Err(err).Msg("social verification promotion failed")
+				return
+			}
+			if granted > 0 {
+				logger.Info().Int("granted", granted).Msg("social invite bonus granted exactly once")
+			}
+		}
+		reconcile()
+		ticker := time.NewTicker(5 * time.Minute)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				reconcile()
+			}
+		}
+	}()
+}
+
 func startAuditLogRetentionPruner(ctx context.Context, store requestLogPruner, retentionDays int, logger zerolog.Logger) {
 	if store == nil || retentionDays <= 0 {
 		return
@@ -1335,6 +1459,24 @@ func withReferralValidation(base http.Handler, validate, join http.HandlerFunc) 
 	}
 	if join != nil {
 		mux.HandleFunc("/j/", join)
+	}
+	mux.Handle("/", base)
+	return mux
+}
+
+func withReferralAdvocacy(base http.Handler, status, challenge, verify http.HandlerFunc) http.Handler {
+	if status == nil && challenge == nil && verify == nil {
+		return base
+	}
+	mux := http.NewServeMux()
+	if status != nil {
+		mux.HandleFunc("/v1/provider/referrals", status)
+	}
+	if challenge != nil {
+		mux.HandleFunc("/v1/provider/referrals/x/challenge", challenge)
+	}
+	if verify != nil {
+		mux.HandleFunc("/v1/provider/referrals/x/verify", verify)
 	}
 	mux.Handle("/", base)
 	return mux

--- a/phase4-coordinator/cmd/coordinator/main_test.go
+++ b/phase4-coordinator/cmd/coordinator/main_test.go
@@ -46,6 +46,13 @@ func TestNewHTTPServerAppliesTimeouts(t *testing.T) {
 
 func TestWithReferralValidationMountsOnlyValidationRoute(t *testing.T) {
 	base := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(http.StatusNoContent) })
+	disabled := withReferralValidation(base, nil)
+	disabledResponse := httptest.NewRecorder()
+	disabled.ServeHTTP(disabledResponse, httptest.NewRequest(http.MethodPost, "/v1/referrals/validate", nil))
+	if disabledResponse.Code != http.StatusNoContent {
+		t.Fatalf("disabled validation route unexpectedly mounted: status=%d", disabledResponse.Code)
+	}
+
 	handler := withReferralValidation(base, func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(http.StatusOK) })
 
 	response := httptest.NewRecorder()

--- a/phase4-coordinator/cmd/coordinator/main_test.go
+++ b/phase4-coordinator/cmd/coordinator/main_test.go
@@ -67,6 +67,21 @@ func TestWithReferralValidationMountsOnlyValidationRoute(t *testing.T) {
 	}
 }
 
+func TestWithReferralValidationMountsPermanentJoinRoute(t *testing.T) {
+	base := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(http.StatusNoContent) })
+	handler := withReferralValidation(
+		base,
+		nil,
+		func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(http.StatusAccepted) },
+	)
+
+	response := httptest.NewRecorder()
+	handler.ServeHTTP(response, httptest.NewRequest(http.MethodGet, "/j/invite", nil))
+	if response.Code != http.StatusAccepted {
+		t.Fatalf("join status=%d", response.Code)
+	}
+}
+
 func TestListenAddressParsesIPv4AndIPv6(t *testing.T) {
 	for _, host := range []string{"127.0.0.1", "::1", "::"} {
 		t.Run(host, func(t *testing.T) {

--- a/phase4-coordinator/cmd/coordinator/main_test.go
+++ b/phase4-coordinator/cmd/coordinator/main_test.go
@@ -16,6 +16,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/augstar/macprovider-coordinator/internal/auth"
 	"github.com/augstar/macprovider-coordinator/internal/buyer"
 	"github.com/augstar/macprovider-coordinator/internal/config"
 	"github.com/augstar/macprovider-coordinator/internal/pool"
@@ -46,14 +47,14 @@ func TestNewHTTPServerAppliesTimeouts(t *testing.T) {
 
 func TestWithReferralValidationMountsOnlyValidationRoute(t *testing.T) {
 	base := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(http.StatusNoContent) })
-	disabled := withReferralValidation(base, nil)
+	disabled := withReferralValidation(base, nil, nil)
 	disabledResponse := httptest.NewRecorder()
 	disabled.ServeHTTP(disabledResponse, httptest.NewRequest(http.MethodPost, "/v1/referrals/validate", nil))
 	if disabledResponse.Code != http.StatusNoContent {
 		t.Fatalf("disabled validation route unexpectedly mounted: status=%d", disabledResponse.Code)
 	}
 
-	handler := withReferralValidation(base, func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(http.StatusOK) })
+	handler := withReferralValidation(base, func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(http.StatusOK) }, nil)
 
 	response := httptest.NewRecorder()
 	handler.ServeHTTP(response, httptest.NewRequest(http.MethodPost, "/v1/referrals/validate", nil))
@@ -67,8 +68,15 @@ func TestWithReferralValidationMountsOnlyValidationRoute(t *testing.T) {
 	}
 }
 
-func TestWithReferralValidationMountsPermanentJoinRoute(t *testing.T) {
+func TestWithReferralValidationMountsJoinRouteOnlyWhenEnabled(t *testing.T) {
 	base := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(http.StatusNoContent) })
+	disabled := withReferralValidation(base, nil, nil)
+	disabledResponse := httptest.NewRecorder()
+	disabled.ServeHTTP(disabledResponse, httptest.NewRequest(http.MethodGet, "/j/invite", nil))
+	if disabledResponse.Code != http.StatusNoContent {
+		t.Fatalf("disabled join route unexpectedly mounted: status=%d", disabledResponse.Code)
+	}
+
 	handler := withReferralValidation(
 		base,
 		nil,
@@ -79,6 +87,16 @@ func TestWithReferralValidationMountsPermanentJoinRoute(t *testing.T) {
 	handler.ServeHTTP(response, httptest.NewRequest(http.MethodGet, "/j/invite", nil))
 	if response.Code != http.StatusAccepted {
 		t.Fatalf("join status=%d", response.Code)
+	}
+}
+
+func TestNewReferralValidationHandlerWiresOperatorRecoveryURL(t *testing.T) {
+	handler := newReferralValidationHandler(nil, auth.ReferralPolicy{}, nil, "  https://access.example.test/waitlist  ")
+	if handler.RequestAccessURL != "https://access.example.test/waitlist" {
+		t.Fatalf("request access URL=%q", handler.RequestAccessURL)
+	}
+	if handler.PublicLimiter == nil || handler.ValidateSlots == nil || handler.SourceIP == nil {
+		t.Fatal("production validation safeguards were not wired")
 	}
 }
 

--- a/phase4-coordinator/cmd/coordinator/main_test.go
+++ b/phase4-coordinator/cmd/coordinator/main_test.go
@@ -44,6 +44,22 @@ func TestNewHTTPServerAppliesTimeouts(t *testing.T) {
 	}
 }
 
+func TestWithReferralValidationMountsOnlyValidationRoute(t *testing.T) {
+	base := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(http.StatusNoContent) })
+	handler := withReferralValidation(base, func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(http.StatusOK) })
+
+	response := httptest.NewRecorder()
+	handler.ServeHTTP(response, httptest.NewRequest(http.MethodPost, "/v1/referrals/validate", nil))
+	if response.Code != http.StatusOK {
+		t.Fatalf("validation status=%d", response.Code)
+	}
+	response = httptest.NewRecorder()
+	handler.ServeHTTP(response, httptest.NewRequest(http.MethodPost, "/v1/referrals/reserve", nil))
+	if response.Code != http.StatusNoContent {
+		t.Fatalf("reservation route unexpectedly mounted: status=%d", response.Code)
+	}
+}
+
 func TestListenAddressParsesIPv4AndIPv6(t *testing.T) {
 	for _, host := range []string{"127.0.0.1", "::1", "::"} {
 		t.Run(host, func(t *testing.T) {

--- a/phase4-coordinator/cmd/coordinator/main_test.go
+++ b/phase4-coordinator/cmd/coordinator/main_test.go
@@ -90,6 +90,42 @@ func TestWithReferralValidationMountsJoinRouteOnlyWhenEnabled(t *testing.T) {
 	}
 }
 
+func TestWithReferralAdvocacyKeepsMutationRoutesAbsentWhenDisabled(t *testing.T) {
+	base := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) { http.NotFound(w, nil) })
+	status := func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(http.StatusOK) }
+	challenge := func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(http.StatusCreated) }
+	verify := func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(http.StatusAccepted) }
+
+	statusOnly := withReferralAdvocacy(base, status, nil, nil)
+	for _, test := range []struct {
+		path string
+		want int
+	}{
+		{path: "/v1/provider/referrals", want: http.StatusOK},
+		{path: "/v1/provider/referrals/x/challenge", want: http.StatusNotFound},
+		{path: "/v1/provider/referrals/x/verify", want: http.StatusNotFound},
+	} {
+		response := httptest.NewRecorder()
+		statusOnly.ServeHTTP(response, httptest.NewRequest(http.MethodPost, test.path, nil))
+		if response.Code != test.want {
+			t.Fatalf("status-only path=%s status=%d want=%d", test.path, response.Code, test.want)
+		}
+	}
+
+	fullyEnabled := withReferralAdvocacy(base, status, challenge, verify)
+	for path, want := range map[string]int{
+		"/v1/provider/referrals":             http.StatusOK,
+		"/v1/provider/referrals/x/challenge": http.StatusCreated,
+		"/v1/provider/referrals/x/verify":    http.StatusAccepted,
+	} {
+		response := httptest.NewRecorder()
+		fullyEnabled.ServeHTTP(response, httptest.NewRequest(http.MethodPost, path, nil))
+		if response.Code != want {
+			t.Fatalf("enabled path=%s status=%d want=%d", path, response.Code, want)
+		}
+	}
+}
+
 func TestNewReferralValidationHandlerWiresOperatorRecoveryURL(t *testing.T) {
 	handler := newReferralValidationHandler(nil, auth.ReferralPolicy{}, nil, "  https://access.example.test/waitlist  ")
 	if handler.RequestAccessURL != "https://access.example.test/waitlist" {

--- a/phase4-coordinator/dist/coordinator.yaml
+++ b/phase4-coordinator/dist/coordinator.yaml
@@ -92,6 +92,7 @@ auth:
 referrals:
   require_for_registration: false
   enable_public_validation: false
+  enable_join_links: false
   enable_social_invite_bonus: false
   campaign: ""
   policy_version: "v1"
@@ -102,6 +103,7 @@ referrals:
   social_bonus_uses: 2
   challenge_ttl_s: 900
   join_base_url: "https://coordinator.streamvc.live/j"
+  join_download_url: ""
   x_api_bearer_token: ""
   request_access_url: ""
 

--- a/phase4-coordinator/dist/coordinator.yaml
+++ b/phase4-coordinator/dist/coordinator.yaml
@@ -86,10 +86,12 @@ auth:
     spec026_a: env:OPERATOR_AUTH_POLICY_A
     spec026_b: env:OPERATOR_AUTH_POLICY_B
 
-# Pre-beta referral admission. Both switches remain off in checked-in config;
-# enabling either requires an explicit campaign, key id, and 32+ byte HMAC key.
+# Pre-beta referral admission. All public/enforcement switches remain off in
+# checked-in config; enabling one requires an explicit campaign, key id, and
+# 32+ byte HMAC key.
 referrals:
   require_for_registration: false
+  enable_public_validation: false
   enable_social_invite_bonus: false
   campaign: ""
   policy_version: "v1"

--- a/phase4-coordinator/dist/coordinator.yaml
+++ b/phase4-coordinator/dist/coordinator.yaml
@@ -102,6 +102,7 @@ referrals:
   provider_base_uses: 1
   social_bonus_uses: 2
   challenge_ttl_s: 900
+  social_verification_dwell_s: 1800
   join_base_url: "https://coordinator.streamvc.live/j"
   join_download_url: ""
   x_api_bearer_token: ""

--- a/phase4-coordinator/dist/coordinator.yaml
+++ b/phase4-coordinator/dist/coordinator.yaml
@@ -86,6 +86,23 @@ auth:
     spec026_a: env:OPERATOR_AUTH_POLICY_A
     spec026_b: env:OPERATOR_AUTH_POLICY_B
 
+# Pre-beta referral admission. Both switches remain off in checked-in config;
+# enabling either requires an explicit campaign, key id, and 32+ byte HMAC key.
+referrals:
+  require_for_registration: false
+  enable_social_invite_bonus: false
+  campaign: ""
+  policy_version: "v1"
+  grandfather_before: ""
+  current_key_id: ""
+  hmac_keys: {}
+  provider_base_uses: 1
+  social_bonus_uses: 2
+  challenge_ttl_s: 900
+  join_base_url: "https://coordinator.streamvc.live/j"
+  x_api_bearer_token: ""
+  request_access_url: ""
+
 # SPEC-007 v0.2 — internal read-only operator explorer.
 # Reuses auth.operator_key (D15). Disable by setting enabled: false.
 # Mounted at /admin/explorer/ on provider_port (8444); already proxied by nginx.

--- a/phase4-coordinator/dist/nginx-coordinator.streamvc.live.conf
+++ b/phase4-coordinator/dist/nginx-coordinator.streamvc.live.conf
@@ -41,7 +41,8 @@ server {
     # the path or any query parameter in the nginx access log.
     location ^~ /j/ {
         access_log off;
-        return 301 https://$host$request_uri;
+        add_header Cache-Control "no-store" always;
+        return 307 https://coordinator.streamvc.live$request_uri;
     }
 
     location / {

--- a/phase4-coordinator/dist/nginx-coordinator.streamvc.live.conf
+++ b/phase4-coordinator/dist/nginx-coordinator.streamvc.live.conf
@@ -37,6 +37,13 @@ server {
         root /var/www/html;
     }
 
+    # Invite URLs are reusable credentials. Redirect to TLS without recording
+    # the path or any query parameter in the nginx access log.
+    location ^~ /j/ {
+        access_log off;
+        return 301 https://$host$request_uri;
+    }
+
     location / {
         return 301 https://$host$request_uri;
     }
@@ -360,6 +367,21 @@ server {
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
         proxy_set_header Authorization $http_authorization;
+        proxy_read_timeout 10s;
+        proxy_no_cache 1;
+        proxy_cache_bypass 1;
+        add_header Cache-Control "no-store" always;
+    }
+
+    # Durable invite landing links live on the buyer mux. The path contains a
+    # referral credential, so neither nginx access logs nor caches may retain it.
+    location ^~ /j/ {
+        access_log off;
+        proxy_pass http://127.0.0.1:8443;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
         proxy_read_timeout 10s;
         proxy_no_cache 1;
         proxy_cache_bypass 1;

--- a/phase4-coordinator/dist/test/check_nginx_referral_routes_test.sh
+++ b/phase4-coordinator/dist/test/check_nginx_referral_routes_test.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+config="$root/dist/nginx-coordinator.streamvc.live.conf"
+
+count="$(grep -c 'location \^~ /j/' "$config")"
+test "$count" -eq 2
+grep -A12 'location \^~ /j/' "$config" | grep -q 'access_log off;'
+grep -A12 'location \^~ /j/' "$config" | grep -q 'proxy_pass http://127.0.0.1:8443;'
+grep -A12 'location \^~ /j/' "$config" | grep -q 'return 301 https://\$host\$request_uri;'
+
+echo "nginx referral route checks passed"

--- a/phase4-coordinator/dist/test/check_nginx_referral_routes_test.sh
+++ b/phase4-coordinator/dist/test/check_nginx_referral_routes_test.sh
@@ -8,6 +8,15 @@ count="$(grep -c 'location \^~ /j/' "$config")"
 test "$count" -eq 2
 grep -A12 'location \^~ /j/' "$config" | grep -q 'access_log off;'
 grep -A12 'location \^~ /j/' "$config" | grep -q 'proxy_pass http://127.0.0.1:8443;'
-grep -A12 'location \^~ /j/' "$config" | grep -q 'return 301 https://\$host\$request_uri;'
+grep -A5 'location \^~ /j/' "$config" | grep -q 'add_header Cache-Control "no-store" always;'
+grep -A5 'location \^~ /j/' "$config" | grep -q 'return 307 https://coordinator\.streamvc\.live\$request_uri;'
+if grep -A5 'location \^~ /j/' "$config" | grep -q 'https://\$host'; then
+  echo "invite redirect must pin the trusted coordinator origin" >&2
+  exit 1
+fi
+if grep -A5 'location \^~ /j/' "$config" | grep -q 'return 301 '; then
+  echo "invite redirect must not be permanent" >&2
+  exit 1
+fi
 
 echo "nginx referral route checks passed"

--- a/phase4-coordinator/internal/auth/apptrack_referral_mints.go
+++ b/phase4-coordinator/internal/auth/apptrack_referral_mints.go
@@ -28,19 +28,24 @@ type PendingAppTrackReferralMint struct {
 }
 
 // MintProviderTokenAppTrackWithReferralAttempt validates and redeems the
-// referral, creates an undisclosed credential, and records an exact pending
-// saga in one SQLite transaction. It never rotates an existing credential.
+// referral, commits the client's signed credential candidate, and records an
+// exact pending saga in one SQLite transaction. It never rotates an existing
+// credential; the client already has custody if the HTTP response is lost.
 func (s *Store) MintProviderTokenAppTrackWithReferralAttempt(
 	ctx context.Context,
-	providerID, referralCode string,
+	providerID, referralCode, tokenCandidate string,
 	policy ReferralPolicy,
 	attempt AppTrackRegistrationAttempt,
 ) (string, error) {
 	if err := config.ValidateProviderID(providerID); err != nil {
 		return "", err
 	}
+	tokenCandidate = strings.TrimSpace(tokenCandidate)
 	if !policy.RequireForRegistration || strings.TrimSpace(attempt.SourceIP) == "" ||
 		strings.TrimSpace(attempt.Nonce) == "" || attempt.AttemptTS.IsZero() {
+		return "", ErrReferralConflict
+	}
+	if len(tokenCandidate) != 64 || !isLowerHexToken(tokenCandidate) {
 		return "", ErrReferralConflict
 	}
 
@@ -61,16 +66,12 @@ SELECT COUNT(1) FROM provider_tokens
 		if err != nil {
 			return err
 		}
-		newToken, err := randomHex(32)
-		if err != nil {
-			return err
-		}
-		hash := tokenHash(newToken)
+		hash := tokenHash(tokenCandidate)
 		if _, err := conn.ExecContext(ctx, `
 INSERT INTO provider_tokens
     (token_hash, token_prefix, provider_id, provider_name, created_at)
 VALUES (?, ?, ?, 'malibu-app', ?)`,
-			hash, newToken[:tokenDisplayPrefixLength], providerID, timeText(now),
+			hash, tokenCandidate[:tokenDisplayPrefixLength], providerID, timeText(now),
 		); err != nil {
 			if isActiveProviderTokenConstraintFailure(err) {
 				return ErrActiveTokenAlreadyExists
@@ -88,13 +89,22 @@ INSERT INTO apptrack_pending_referral_mints (
 		); err != nil {
 			return err
 		}
-		token = newToken
+		token = tokenCandidate
 		return nil
 	})
 	if err != nil {
 		return "", err
 	}
 	return token, nil
+}
+
+func isLowerHexToken(value string) bool {
+	for _, r := range value {
+		if (r < '0' || r > '9') && (r < 'a' || r > 'f') {
+			return false
+		}
+	}
+	return true
 }
 
 // AcknowledgeAppTrackReferralMint removes the saga only after PostgreSQL has

--- a/phase4-coordinator/internal/auth/apptrack_referral_mints.go
+++ b/phase4-coordinator/internal/auth/apptrack_referral_mints.go
@@ -1,0 +1,225 @@
+package auth
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/augstar/macprovider-coordinator/internal/config"
+	"github.com/augstar/macprovider-coordinator/internal/sqliteutil"
+)
+
+// AppTrackRegistrationAttempt identifies the PostgreSQL half of a gated
+// registration. AttemptTS is the signed request timestamp and therefore stable
+// across transport retries; SourceIP is retained only as diagnostic metadata.
+type AppTrackRegistrationAttempt struct {
+	SourceIP  string
+	Nonce     string
+	AttemptTS time.Time
+}
+
+type PendingAppTrackReferralMint struct {
+	ProviderID string
+	TokenHash  string
+	Attempt    AppTrackRegistrationAttempt
+}
+
+// MintProviderTokenAppTrackWithReferralAttempt validates and redeems the
+// referral, creates an undisclosed credential, and records an exact pending
+// saga in one SQLite transaction. It never rotates an existing credential.
+func (s *Store) MintProviderTokenAppTrackWithReferralAttempt(
+	ctx context.Context,
+	providerID, referralCode string,
+	policy ReferralPolicy,
+	attempt AppTrackRegistrationAttempt,
+) (string, error) {
+	if err := config.ValidateProviderID(providerID); err != nil {
+		return "", err
+	}
+	if !policy.RequireForRegistration || strings.TrimSpace(attempt.SourceIP) == "" ||
+		strings.TrimSpace(attempt.Nonce) == "" || attempt.AttemptTS.IsZero() {
+		return "", ErrReferralConflict
+	}
+
+	var token string
+	err := sqliteutil.Transact(ctx, s.db, func(ctx context.Context, conn *sql.Conn) error {
+		var active int
+		if err := conn.QueryRowContext(ctx, `
+SELECT COUNT(1) FROM provider_tokens
+ WHERE provider_id = ? AND revoked_at IS NULL`, providerID).Scan(&active); err != nil {
+			return err
+		}
+		if active != 0 {
+			return ErrAppTrackExistingTokenNoProof
+		}
+
+		now := time.Now().UTC()
+		createdRedemption, err := redeemReferralTx(ctx, conn, policy, referralCode, providerID, now)
+		if err != nil {
+			return err
+		}
+		newToken, err := randomHex(32)
+		if err != nil {
+			return err
+		}
+		hash := tokenHash(newToken)
+		if _, err := conn.ExecContext(ctx, `
+INSERT INTO provider_tokens
+    (token_hash, token_prefix, provider_id, provider_name, created_at)
+VALUES (?, ?, ?, 'malibu-app', ?)`,
+			hash, newToken[:tokenDisplayPrefixLength], providerID, timeText(now),
+		); err != nil {
+			if isActiveProviderTokenConstraintFailure(err) {
+				return ErrActiveTokenAlreadyExists
+			}
+			return err
+		}
+		if _, err := conn.ExecContext(ctx, `
+INSERT INTO apptrack_pending_referral_mints (
+    provider_id, token_hash, campaign, registration_source_ip,
+    registration_nonce, registration_attempt_ts, created_redemption, created_at
+) VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+			providerID, hash, policy.Campaign, strings.TrimSpace(attempt.SourceIP),
+			strings.TrimSpace(attempt.Nonce), attempt.AttemptTS.UTC().Format(time.RFC3339Nano),
+			createdRedemption, timeText(now),
+		); err != nil {
+			return err
+		}
+		token = newToken
+		return nil
+	})
+	if err != nil {
+		return "", err
+	}
+	return token, nil
+}
+
+// AcknowledgeAppTrackReferralMint removes the saga only after PostgreSQL has
+// durably recorded the exact attempt. The token and redemption remain.
+func (s *Store) AcknowledgeAppTrackReferralMint(ctx context.Context, providerID, cleartextToken string) error {
+	if err := config.ValidateProviderID(providerID); err != nil {
+		return err
+	}
+	cleartextToken = strings.TrimSpace(cleartextToken)
+	if cleartextToken == "" {
+		return ErrReferralConflict
+	}
+	result, err := s.db.ExecContext(ctx, `
+DELETE FROM apptrack_pending_referral_mints
+ WHERE provider_id = ? AND token_hash = ?`, providerID, tokenHash(cleartextToken))
+	if err != nil {
+		return err
+	}
+	if changed, err := result.RowsAffected(); err != nil || changed != 1 {
+		return ErrReferralConflict
+	}
+	return nil
+}
+
+func (s *Store) RollbackAppTrackReferralMint(ctx context.Context, providerID, cleartextToken string) error {
+	if err := config.ValidateProviderID(providerID); err != nil {
+		return err
+	}
+	cleartextToken = strings.TrimSpace(cleartextToken)
+	if cleartextToken == "" {
+		return ErrReferralConflict
+	}
+	return s.resolvePendingAppTrackReferralMint(ctx, providerID, tokenHash(cleartextToken), false)
+}
+
+func (s *Store) ListPendingAppTrackReferralMints(ctx context.Context, createdBefore time.Time) ([]PendingAppTrackReferralMint, error) {
+	rows, err := s.db.QueryContext(ctx, `
+SELECT provider_id, token_hash, registration_source_ip, registration_nonce, registration_attempt_ts
+  FROM apptrack_pending_referral_mints
+ WHERE created_at <= ?
+ ORDER BY created_at, provider_id`, timeText(createdBefore.UTC()))
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var pending []PendingAppTrackReferralMint
+	for rows.Next() {
+		var item PendingAppTrackReferralMint
+		var attemptTS string
+		if err := rows.Scan(
+			&item.ProviderID, &item.TokenHash, &item.Attempt.SourceIP,
+			&item.Attempt.Nonce, &attemptTS,
+		); err != nil {
+			return nil, err
+		}
+		item.Attempt.AttemptTS, err = time.Parse(time.RFC3339Nano, attemptTS)
+		if err != nil {
+			return nil, fmt.Errorf("parse pending App-track attempt timestamp: %w", err)
+		}
+		pending = append(pending, item)
+	}
+	return pending, rows.Err()
+}
+
+func (s *Store) ResolvePendingAppTrackReferralMint(ctx context.Context, pending PendingAppTrackReferralMint, registrationPrepared bool) error {
+	if err := config.ValidateProviderID(pending.ProviderID); err != nil {
+		return err
+	}
+	if strings.TrimSpace(pending.TokenHash) == "" {
+		return ErrReferralConflict
+	}
+	return s.resolvePendingAppTrackReferralMint(ctx, pending.ProviderID, pending.TokenHash, registrationPrepared)
+}
+
+func (s *Store) resolvePendingAppTrackReferralMint(ctx context.Context, providerID, expectedTokenHash string, registrationPrepared bool) error {
+	return sqliteutil.Transact(ctx, s.db, func(ctx context.Context, conn *sql.Conn) error {
+		var campaign string
+		var createdRedemption bool
+		if err := conn.QueryRowContext(ctx, `
+SELECT campaign, created_redemption
+  FROM apptrack_pending_referral_mints
+ WHERE provider_id = ? AND token_hash = ?`, providerID, expectedTokenHash,
+		).Scan(&campaign, &createdRedemption); err != nil {
+			if errors.Is(err, sql.ErrNoRows) {
+				return ErrReferralConflict
+			}
+			return err
+		}
+		if registrationPrepared {
+			_, err := conn.ExecContext(ctx, `
+DELETE FROM apptrack_pending_referral_mints
+ WHERE provider_id = ? AND token_hash = ?`, providerID, expectedTokenHash)
+			return err
+		}
+
+		result, err := conn.ExecContext(ctx, `
+DELETE FROM provider_tokens
+ WHERE provider_id = ? AND token_hash = ?
+   AND provider_name = 'malibu-app'
+   AND revoked_at IS NULL AND last_used_at IS NULL`, providerID, expectedTokenHash)
+		if err != nil {
+			return err
+		}
+		if changed, err := result.RowsAffected(); err != nil || changed != 1 {
+			return ErrReferralConflict
+		}
+		if createdRedemption {
+			result, err = conn.ExecContext(ctx, `
+DELETE FROM referral_redemptions
+ WHERE campaign = ? AND provider_id = ?`, campaign, providerID)
+			if err != nil {
+				return err
+			}
+			if changed, err := result.RowsAffected(); err != nil || changed != 1 {
+				return ErrReferralConflict
+			}
+			if _, err := conn.ExecContext(ctx, `
+DELETE FROM provider_referral_admissions
+ WHERE campaign = ? AND provider_id = ? AND decision = 'referred'`, campaign, providerID); err != nil {
+				return err
+			}
+		}
+		_, err = conn.ExecContext(ctx, `
+DELETE FROM apptrack_pending_referral_mints
+ WHERE provider_id = ? AND token_hash = ?`, providerID, expectedTokenHash)
+		return err
+	})
+}

--- a/phase4-coordinator/internal/auth/referrals_admin.go
+++ b/phase4-coordinator/internal/auth/referrals_admin.go
@@ -251,12 +251,12 @@ func (s *Store) RevokeReferralIssuerAudited(ctx context.Context, campaign, issue
 	out := ReferralRevocation{Campaign: campaign, IssuerID: issuerID}
 	err := sqliteutil.Transact(ctx, s.db, func(ctx context.Context, conn *sql.Conn) error {
 		var providerID, revokedAt sql.NullString
-		var baseCapacity, bonusCapacity int
+		var baseCapacity, bonusCapacity, carriedRedemptions int
 		if err := conn.QueryRowContext(ctx, `
-SELECT code_type, provider_id, revoked_at, base_capacity, bonus_capacity
+SELECT code_type, provider_id, revoked_at, base_capacity, bonus_capacity, carried_redemptions
   FROM referral_issuers
  WHERE campaign = ? AND issuer_id = ?`, campaign, issuerID).Scan(
-			&out.CodeType, &providerID, &revokedAt, &baseCapacity, &bonusCapacity,
+			&out.CodeType, &providerID, &revokedAt, &baseCapacity, &bonusCapacity, &carriedRedemptions,
 		); err != nil {
 			if errors.Is(err, sql.ErrNoRows) {
 				return ErrReferralInvalid
@@ -272,6 +272,7 @@ SELECT code_type, provider_id, revoked_at, base_capacity, bonus_capacity
 		).Scan(&out.Redeemed); err != nil {
 			return err
 		}
+		out.Redeemed += carriedRedemptions
 		out.RemainingCapacity = baseCapacity + bonusCapacity - out.Redeemed
 		if out.RemainingCapacity < 0 {
 			out.RemainingCapacity = 0

--- a/phase4-coordinator/internal/auth/referrals_admin.go
+++ b/phase4-coordinator/internal/auth/referrals_admin.go
@@ -1,0 +1,255 @@
+package auth
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/augstar/macprovider-coordinator/internal/sqliteutil"
+)
+
+var (
+	ErrReferralSeedExists        = errors.New("seed referral already exists")
+	ErrReferralCapacityBelowUsed = errors.New("referral capacity cannot be set below redeemed uses")
+)
+
+// referralAdminSchemaStatements is kept with the privileged referral
+// operations so the admin surface can be reviewed independently from referral
+// admission. The audit log is append-only by API contract: this package never
+// exposes update or delete operations for it.
+func referralAdminSchemaStatements() []string {
+	return []string{
+		`CREATE TABLE IF NOT EXISTS referral_admin_audit (
+			id INTEGER PRIMARY KEY AUTOINCREMENT,
+			actor TEXT NOT NULL,
+			reason TEXT NOT NULL,
+			action TEXT NOT NULL,
+			target TEXT NOT NULL,
+			detail TEXT NOT NULL DEFAULT '',
+			ts TEXT NOT NULL
+		)`,
+		`CREATE INDEX IF NOT EXISTS idx_referral_admin_audit_ts ON referral_admin_audit(ts)`,
+		`CREATE TRIGGER IF NOT EXISTS referral_admin_audit_no_update
+			BEFORE UPDATE ON referral_admin_audit
+			BEGIN SELECT RAISE(ABORT, 'referral_admin_audit is append-only'); END`,
+		`CREATE TRIGGER IF NOT EXISTS referral_admin_audit_no_delete
+			BEFORE DELETE ON referral_admin_audit
+			BEGIN SELECT RAISE(ABORT, 'referral_admin_audit is append-only'); END`,
+	}
+}
+
+// CreateSeedReferral inserts a new seed issuer and returns the signed invite
+// code. Seed identifiers are immutable; operators must use AdjustSeedReferral
+// for an audited capacity change rather than silently replacing a live seed.
+func (s *Store) CreateSeedReferral(ctx context.Context, policy ReferralPolicy, seedID string, maxUses int, expiresAt *time.Time) (string, error) {
+	if err := policy.Validate(); err != nil {
+		return "", err
+	}
+	seedID = strings.TrimSpace(seedID)
+	if !referralPartPattern.MatchString(seedID) || maxUses <= 0 {
+		return "", fmt.Errorf("seed id and max uses are invalid")
+	}
+	var expiry any
+	if expiresAt != nil {
+		expiry = timeText(expiresAt.UTC())
+	}
+	now := nowString()
+	_, err := s.db.ExecContext(ctx, `
+INSERT INTO referral_issuers (
+    issuer_id, code_type, key_id, campaign, provider_id,
+    base_capacity, bonus_capacity, expires_at, created_at, first_serving_at
+) VALUES (?, 'S', ?, ?, NULL, ?, 0, ?, ?, ?)`,
+		seedID, policy.CurrentKeyID, policy.Campaign, maxUses, expiry, now, now)
+	if isConstraintFailure(err) {
+		return "", ErrReferralSeedExists
+	}
+	if err != nil {
+		return "", err
+	}
+	return EncodeReferralCode(policy, ReferralTypeSeed, policy.CurrentKeyID, seedID)
+}
+
+// SeedReferralAdjustment is returned for both dry-run and applied changes.
+// Used capacity is based only on durable redemptions; PR-B deliberately has no
+// public reservation model.
+type SeedReferralAdjustment struct {
+	SeedID             string
+	CurrentCapacity    int
+	NewCapacity        int
+	Redeemed           int
+	ResultingRemaining int
+	Applied            bool
+}
+
+// AdjustSeedReferral previews or applies a seed capacity change. Applying is
+// attributable and transactional with its append-only audit record.
+func (s *Store) AdjustSeedReferral(ctx context.Context, policy ReferralPolicy, seedID string, newCapacity int, apply bool, actor, reason string, now time.Time) (SeedReferralAdjustment, error) {
+	if err := policy.Validate(); err != nil {
+		return SeedReferralAdjustment{}, err
+	}
+	seedID = strings.TrimSpace(seedID)
+	actor = strings.TrimSpace(actor)
+	reason = strings.TrimSpace(reason)
+	if !referralPartPattern.MatchString(seedID) || newCapacity < 0 {
+		return SeedReferralAdjustment{}, ErrReferralInvalid
+	}
+	if apply && (actor == "" || reason == "") {
+		return SeedReferralAdjustment{}, fmt.Errorf("actor and reason are required to apply a seed adjustment")
+	}
+
+	out := SeedReferralAdjustment{SeedID: seedID, NewCapacity: newCapacity}
+	err := sqliteutil.Transact(ctx, s.db, func(ctx context.Context, conn *sql.Conn) error {
+		var codeType string
+		if err := conn.QueryRowContext(ctx, `
+SELECT code_type, base_capacity
+  FROM referral_issuers
+ WHERE issuer_id = ? AND campaign = ?`, seedID, policy.Campaign).Scan(&codeType, &out.CurrentCapacity); err != nil {
+			if errors.Is(err, sql.ErrNoRows) {
+				return ErrReferralInvalid
+			}
+			return err
+		}
+		if codeType != ReferralTypeSeed {
+			return ErrReferralInvalid
+		}
+		if err := conn.QueryRowContext(ctx,
+			`SELECT COUNT(1) FROM referral_redemptions WHERE issuer_id = ?`, seedID,
+		).Scan(&out.Redeemed); err != nil {
+			return err
+		}
+		out.ResultingRemaining = newCapacity - out.Redeemed
+		if out.ResultingRemaining < 0 {
+			out.ResultingRemaining = 0
+		}
+		if !apply {
+			return nil
+		}
+		if newCapacity < out.Redeemed {
+			return ErrReferralCapacityBelowUsed
+		}
+		result, err := conn.ExecContext(ctx, `
+UPDATE referral_issuers
+   SET base_capacity = ?
+ WHERE issuer_id = ? AND campaign = ? AND code_type = 'S'`, newCapacity, seedID, policy.Campaign)
+		if err != nil {
+			return err
+		}
+		if changed, err := result.RowsAffected(); err != nil || changed != 1 {
+			return ErrReferralInvalid
+		}
+		detail := fmt.Sprintf("base_capacity %d->%d redeemed=%d", out.CurrentCapacity, newCapacity, out.Redeemed)
+		if err := recordReferralAdminAuditTx(ctx, conn, actor, reason, "adjust_seed", policy.Campaign+"/"+seedID, detail, now); err != nil {
+			return err
+		}
+		out.Applied = true
+		return nil
+	})
+	if err != nil {
+		return SeedReferralAdjustment{}, err
+	}
+	return out, nil
+}
+
+// ReferralRevocation is the blast-radius preview or result of an issuer revoke.
+// Capacity accounting is redemption-only in the reservation-neutral launch.
+type ReferralRevocation struct {
+	Campaign          string
+	IssuerID          string
+	CodeType          string
+	ProviderID        string
+	Redeemed          int
+	RemainingCapacity int
+	Applied           bool
+}
+
+// ReferralRevokeExpectation is required when applying a previewed revoke. It
+// prevents an operator from acting on a stale redemption count.
+type ReferralRevokeExpectation struct {
+	Redeemed int
+}
+
+// RevokeReferralIssuerAudited previews or transactionally revokes an issuer and
+// records the operator actor and reason. Replacement issuance is intentionally
+// deferred to a later issuer-lifecycle change.
+func (s *Store) RevokeReferralIssuerAudited(ctx context.Context, campaign, issuerID string, apply bool, actor, reason string, expect *ReferralRevokeExpectation, now time.Time) (ReferralRevocation, error) {
+	campaign = strings.TrimSpace(campaign)
+	issuerID = strings.TrimSpace(issuerID)
+	actor = strings.TrimSpace(actor)
+	reason = strings.TrimSpace(reason)
+	if !referralPartPattern.MatchString(campaign) || !referralPartPattern.MatchString(issuerID) {
+		return ReferralRevocation{}, ErrReferralInvalid
+	}
+	if apply && (actor == "" || reason == "") {
+		return ReferralRevocation{}, fmt.Errorf("actor and reason are required to apply a revocation")
+	}
+	if apply && expect == nil {
+		return ReferralRevocation{}, fmt.Errorf("an expected redemption count is required to apply a revocation")
+	}
+
+	out := ReferralRevocation{Campaign: campaign, IssuerID: issuerID}
+	err := sqliteutil.Transact(ctx, s.db, func(ctx context.Context, conn *sql.Conn) error {
+		var providerID, revokedAt sql.NullString
+		var baseCapacity, bonusCapacity int
+		if err := conn.QueryRowContext(ctx, `
+SELECT code_type, provider_id, revoked_at, base_capacity, bonus_capacity
+  FROM referral_issuers
+ WHERE campaign = ? AND issuer_id = ?`, campaign, issuerID).Scan(
+			&out.CodeType, &providerID, &revokedAt, &baseCapacity, &bonusCapacity,
+		); err != nil {
+			if errors.Is(err, sql.ErrNoRows) {
+				return ErrReferralInvalid
+			}
+			return err
+		}
+		out.ProviderID = strings.TrimSpace(providerID.String)
+		if revokedAt.Valid {
+			return fmt.Errorf("issuer %s is already revoked", issuerID)
+		}
+		if err := conn.QueryRowContext(ctx,
+			`SELECT COUNT(1) FROM referral_redemptions WHERE issuer_id = ?`, issuerID,
+		).Scan(&out.Redeemed); err != nil {
+			return err
+		}
+		out.RemainingCapacity = baseCapacity + bonusCapacity - out.Redeemed
+		if out.RemainingCapacity < 0 {
+			out.RemainingCapacity = 0
+		}
+		if !apply {
+			return nil
+		}
+		if expect.Redeemed != out.Redeemed {
+			return fmt.Errorf("revocation snapshot drift: expected redeemed=%d but live redeemed=%d; re-run the dry-run", expect.Redeemed, out.Redeemed)
+		}
+		result, err := conn.ExecContext(ctx, `
+UPDATE referral_issuers
+   SET revoked_at = ?
+ WHERE campaign = ? AND issuer_id = ? AND revoked_at IS NULL`,
+			timeText(now.UTC()), campaign, issuerID)
+		if err != nil {
+			return err
+		}
+		if changed, err := result.RowsAffected(); err != nil || changed != 1 {
+			return ErrReferralInvalid
+		}
+		detail := fmt.Sprintf("code_type=%s provider=%s redeemed=%d remaining_capacity=%d", out.CodeType, out.ProviderID, out.Redeemed, out.RemainingCapacity)
+		if err := recordReferralAdminAuditTx(ctx, conn, actor, reason, "revoke_issuer", campaign+"/"+issuerID, detail, now); err != nil {
+			return err
+		}
+		out.Applied = true
+		return nil
+	})
+	if err != nil {
+		return ReferralRevocation{}, err
+	}
+	return out, nil
+}
+
+func recordReferralAdminAuditTx(ctx context.Context, conn *sql.Conn, actor, reason, action, target, detail string, now time.Time) error {
+	_, err := conn.ExecContext(ctx, `
+INSERT INTO referral_admin_audit (actor, reason, action, target, detail, ts)
+VALUES (?, ?, ?, ?, ?, ?)`, actor, reason, action, target, detail, timeText(now.UTC()))
+	return err
+}

--- a/phase4-coordinator/internal/auth/referrals_admin.go
+++ b/phase4-coordinator/internal/auth/referrals_admin.go
@@ -41,35 +41,94 @@ func referralAdminSchemaStatements() []string {
 	}
 }
 
-// CreateSeedReferral inserts a new seed issuer and returns the signed invite
-// code. Seed identifiers are immutable; operators must use AdjustSeedReferral
-// for an audited capacity change rather than silently replacing a live seed.
-func (s *Store) CreateSeedReferral(ctx context.Context, policy ReferralPolicy, seedID string, maxUses int, expiresAt *time.Time) (string, error) {
+// SeedReferralCreation is returned for both dry-run and applied creation. The
+// signed code is disclosed only after the issuer and audit event commit.
+type SeedReferralCreation struct {
+	SeedID    string
+	Code      string
+	MaxUses   int
+	ExpiresAt *time.Time
+	Applied   bool
+	Recovered bool
+}
+
+// CreateSeedReferralAudited previews or atomically creates a seed issuer and
+// its append-only operator audit record. Seed identifiers are immutable;
+// operators use AdjustSeedReferral for later capacity changes.
+func (s *Store) CreateSeedReferralAudited(ctx context.Context, policy ReferralPolicy, seedID string, maxUses int, expiresAt *time.Time, apply bool, actor, reason string, now time.Time) (SeedReferralCreation, error) {
 	if err := policy.Validate(); err != nil {
-		return "", err
+		return SeedReferralCreation{}, err
 	}
 	seedID = strings.TrimSpace(seedID)
+	actor = strings.TrimSpace(actor)
+	reason = strings.TrimSpace(reason)
 	if !referralPartPattern.MatchString(seedID) || maxUses <= 0 {
-		return "", fmt.Errorf("seed id and max uses are invalid")
+		return SeedReferralCreation{}, fmt.Errorf("seed id and max uses are invalid")
+	}
+	if apply && (actor == "" || reason == "") {
+		return SeedReferralCreation{}, fmt.Errorf("actor and reason are required to create a seed")
+	}
+	out := SeedReferralCreation{SeedID: seedID, MaxUses: maxUses, ExpiresAt: expiresAt}
+	code, err := EncodeReferralCode(policy, ReferralTypeSeed, policy.CurrentKeyID, seedID)
+	if err != nil {
+		return SeedReferralCreation{}, err
 	}
 	var expiry any
 	if expiresAt != nil {
 		expiry = timeText(expiresAt.UTC())
 	}
-	now := nowString()
-	_, err := s.db.ExecContext(ctx, `
+	err = sqliteutil.Transact(ctx, s.db, func(ctx context.Context, conn *sql.Conn) error {
+		var codeType, keyID string
+		var existingCapacity, existingBonus int
+		var existingExpiry, providerID, revokedAt sql.NullString
+		err := conn.QueryRowContext(ctx, `
+SELECT code_type, key_id, base_capacity, bonus_capacity, expires_at, provider_id, revoked_at
+  FROM referral_issuers
+ WHERE issuer_id = ? AND campaign = ?`,
+			seedID, policy.Campaign,
+		).Scan(&codeType, &keyID, &existingCapacity, &existingBonus, &existingExpiry, &providerID, &revokedAt)
+		switch {
+		case err == nil:
+			expectedExpiry, hasExpiry := expiry.(string)
+			expiryMatches := (!hasExpiry && !existingExpiry.Valid) || (hasExpiry && existingExpiry.Valid && existingExpiry.String == expectedExpiry)
+			if apply && codeType == ReferralTypeSeed && keyID == policy.CurrentKeyID && existingCapacity == maxUses && existingBonus == 0 && expiryMatches && !providerID.Valid && !revokedAt.Valid {
+				out.Recovered = true
+				return nil
+			}
+			return ErrReferralSeedExists
+		case !errors.Is(err, sql.ErrNoRows):
+			return err
+		}
+		if !apply {
+			return nil
+		}
+		timestamp := timeText(now.UTC())
+		_, err = conn.ExecContext(ctx, `
 INSERT INTO referral_issuers (
     issuer_id, code_type, key_id, campaign, provider_id,
     base_capacity, bonus_capacity, expires_at, created_at, first_serving_at
 ) VALUES (?, 'S', ?, ?, NULL, ?, 0, ?, ?, ?)`,
-		seedID, policy.CurrentKeyID, policy.Campaign, maxUses, expiry, now, now)
-	if isConstraintFailure(err) {
-		return "", ErrReferralSeedExists
-	}
+			seedID, policy.CurrentKeyID, policy.Campaign, maxUses, expiry, timestamp, timestamp)
+		if isConstraintFailure(err) {
+			return ErrReferralSeedExists
+		}
+		if err != nil {
+			return err
+		}
+		detail := fmt.Sprintf("code_type=S base_capacity=%d expires_at=%v", maxUses, expiry)
+		if err := recordReferralAdminAuditTx(ctx, conn, actor, reason, "create_seed", policy.Campaign+"/"+seedID, detail, now); err != nil {
+			return err
+		}
+		out.Applied = true
+		return nil
+	})
 	if err != nil {
-		return "", err
+		return SeedReferralCreation{}, err
 	}
-	return EncodeReferralCode(policy, ReferralTypeSeed, policy.CurrentKeyID, seedID)
+	if out.Applied || out.Recovered {
+		out.Code = code
+	}
+	return out, nil
 }
 
 // SeedReferralAdjustment is returned for both dry-run and applied changes.

--- a/phase4-coordinator/internal/auth/referrals_admin_test.go
+++ b/phase4-coordinator/internal/auth/referrals_admin_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 )
@@ -18,12 +19,40 @@ func TestReferralAdminSeedLifecycleIsAuditedAndRedemptionOnly(t *testing.T) {
 	policy := coreReferralPolicy()
 	now := time.Date(2026, 7, 13, 12, 0, 0, 0, time.UTC)
 
-	code, err := store.CreateSeedReferral(ctx, policy, "launch", 3, nil)
+	creationPreview, err := store.CreateSeedReferralAudited(ctx, policy, "launch", 3, nil, false, "", "", now)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if _, err := store.CreateSeedReferral(ctx, policy, "launch", 9, nil); !errors.Is(err, ErrReferralSeedExists) {
+	if creationPreview.Applied || creationPreview.Code != "" {
+		t.Fatalf("creation preview=%+v", creationPreview)
+	}
+	var previewRows int
+	if err := store.db.QueryRow(`SELECT COUNT(1) FROM referral_issuers WHERE issuer_id = 'launch'`).Scan(&previewRows); err != nil || previewRows != 0 {
+		t.Fatalf("dry-run issuer rows=%d err=%v", previewRows, err)
+	}
+	created, err := store.CreateSeedReferralAudited(ctx, policy, "launch", 3, nil, true, "ops", "open cohort", now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	code := created.Code
+	if !created.Applied || code == "" {
+		t.Fatalf("creation result=%+v", created)
+	}
+	recovered, err := store.CreateSeedReferralAudited(ctx, policy, "launch", 3, nil, true, "ops", "retry after response loss", now.Add(time.Second))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if recovered.Applied || !recovered.Recovered || recovered.Code != code {
+		t.Fatalf("response-loss recovery=%+v want code %q", recovered, code)
+	}
+	if _, err := store.CreateSeedReferralAudited(ctx, policy, "launch", 9, nil, true, "ops", "duplicate", now); !errors.Is(err, ErrReferralSeedExists) {
 		t.Fatalf("duplicate seed error=%v, want ErrReferralSeedExists", err)
+	}
+	otherKeyPolicy := policy
+	otherKeyPolicy.CurrentKeyID = "k2"
+	otherKeyPolicy.HMACKeys = map[string]string{"k2": strings.Repeat("k", 32)}
+	if _, err := store.CreateSeedReferralAudited(ctx, otherKeyPolicy, "launch", 3, nil, true, "ops", "wrong key", now); !errors.Is(err, ErrReferralSeedExists) {
+		t.Fatalf("mismatched-key seed error=%v, want ErrReferralSeedExists", err)
 	}
 	if _, _, err := store.IssueTokenWithReferral(ctx, "provider-a", "host-a", code, policy); err != nil {
 		t.Fatal(err)
@@ -52,6 +81,12 @@ func TestReferralAdminSeedLifecycleIsAuditedAndRedemptionOnly(t *testing.T) {
 	}
 	if capacity != 5 || auditRows != 1 {
 		t.Fatalf("capacity=%d audit_rows=%d, want 5/1", capacity, auditRows)
+	}
+	if err := store.db.QueryRow(`SELECT COUNT(1) FROM referral_admin_audit WHERE action = 'create_seed' AND actor = 'ops' AND reason = 'open cohort'`).Scan(&auditRows); err != nil {
+		t.Fatal(err)
+	}
+	if auditRows != 1 {
+		t.Fatalf("create audit rows=%d, want 1", auditRows)
 	}
 	if _, err := store.db.Exec(`UPDATE referral_admin_audit SET reason = 'rewritten'`); err == nil {
 		t.Fatal("append-only referral audit accepted an update")
@@ -95,7 +130,10 @@ func TestReferralAdminApplyRequiresAttributionAndPreviewConfirmation(t *testing.
 	}
 	defer store.Close()
 	policy := coreReferralPolicy()
-	if _, err := store.CreateSeedReferral(context.Background(), policy, "launch", 1, nil); err != nil {
+	if _, err := store.CreateSeedReferralAudited(context.Background(), policy, "launch", 1, nil, true, "", "", time.Now().UTC()); err == nil {
+		t.Fatal("unattributed seed creation unexpectedly applied")
+	}
+	if _, err := store.CreateSeedReferralAudited(context.Background(), policy, "launch", 1, nil, true, "ops", "test", time.Now().UTC()); err != nil {
 		t.Fatal(err)
 	}
 	now := time.Now().UTC()

--- a/phase4-coordinator/internal/auth/referrals_admin_test.go
+++ b/phase4-coordinator/internal/auth/referrals_admin_test.go
@@ -1,0 +1,108 @@
+package auth
+
+import (
+	"context"
+	"errors"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestReferralAdminSeedLifecycleIsAuditedAndRedemptionOnly(t *testing.T) {
+	store, err := OpenStore(filepath.Join(t.TempDir(), "coordinator.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+	ctx := context.Background()
+	policy := coreReferralPolicy()
+	now := time.Date(2026, 7, 13, 12, 0, 0, 0, time.UTC)
+
+	code, err := store.CreateSeedReferral(ctx, policy, "launch", 3, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.CreateSeedReferral(ctx, policy, "launch", 9, nil); !errors.Is(err, ErrReferralSeedExists) {
+		t.Fatalf("duplicate seed error=%v, want ErrReferralSeedExists", err)
+	}
+	if _, _, err := store.IssueTokenWithReferral(ctx, "provider-a", "host-a", code, policy); err != nil {
+		t.Fatal(err)
+	}
+
+	preview, err := store.AdjustSeedReferral(ctx, policy, "launch", 0, false, "", "", now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if preview.Redeemed != 1 || preview.CurrentCapacity != 3 || preview.ResultingRemaining != 0 || preview.Applied {
+		t.Fatalf("unexpected preview: %+v", preview)
+	}
+	if _, err := store.AdjustSeedReferral(ctx, policy, "launch", 0, true, "ops", "shrink", now); !errors.Is(err, ErrReferralCapacityBelowUsed) {
+		t.Fatalf("below-used adjustment error=%v", err)
+	}
+	if _, err := store.AdjustSeedReferral(ctx, policy, "launch", 5, true, "ops", "expand cohort", now); err != nil {
+		t.Fatal(err)
+	}
+
+	var capacity, auditRows int
+	if err := store.db.QueryRow(`SELECT base_capacity FROM referral_issuers WHERE issuer_id = 'launch'`).Scan(&capacity); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.db.QueryRow(`SELECT COUNT(1) FROM referral_admin_audit WHERE action = 'adjust_seed' AND actor = 'ops' AND reason = 'expand cohort'`).Scan(&auditRows); err != nil {
+		t.Fatal(err)
+	}
+	if capacity != 5 || auditRows != 1 {
+		t.Fatalf("capacity=%d audit_rows=%d, want 5/1", capacity, auditRows)
+	}
+	if _, err := store.db.Exec(`UPDATE referral_admin_audit SET reason = 'rewritten'`); err == nil {
+		t.Fatal("append-only referral audit accepted an update")
+	}
+	if _, err := store.db.Exec(`DELETE FROM referral_admin_audit`); err == nil {
+		t.Fatal("append-only referral audit accepted a delete")
+	}
+
+	revokePreview, err := store.RevokeReferralIssuerAudited(ctx, policy.Campaign, "launch", false, "", "", nil, now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if revokePreview.Redeemed != 1 || revokePreview.RemainingCapacity != 4 {
+		t.Fatalf("unexpected revoke preview: %+v", revokePreview)
+	}
+	if _, err := store.RevokeReferralIssuerAudited(ctx, policy.Campaign, "launch", true, "ops", "abuse", &ReferralRevokeExpectation{Redeemed: 0}, now); err == nil {
+		t.Fatal("stale revoke expectation unexpectedly applied")
+	}
+	result, err := store.RevokeReferralIssuerAudited(ctx, policy.Campaign, "launch", true, "ops", "abuse", &ReferralRevokeExpectation{Redeemed: 1}, now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !result.Applied {
+		t.Fatalf("revoke result=%+v", result)
+	}
+	if err := store.db.QueryRow(`SELECT COUNT(1) FROM referral_admin_audit WHERE action = 'revoke_issuer' AND actor = 'ops' AND reason = 'abuse'`).Scan(&auditRows); err != nil {
+		t.Fatal(err)
+	}
+	if auditRows != 1 {
+		t.Fatalf("revoke audit rows=%d, want 1", auditRows)
+	}
+	if _, err := store.ValidateReferral(ctx, policy, code, now); !errors.Is(err, ErrReferralRevoked) {
+		t.Fatalf("validation after revoke error=%v, want revoked", err)
+	}
+}
+
+func TestReferralAdminApplyRequiresAttributionAndPreviewConfirmation(t *testing.T) {
+	store, err := OpenStore(filepath.Join(t.TempDir(), "coordinator.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+	policy := coreReferralPolicy()
+	if _, err := store.CreateSeedReferral(context.Background(), policy, "launch", 1, nil); err != nil {
+		t.Fatal(err)
+	}
+	now := time.Now().UTC()
+	if _, err := store.AdjustSeedReferral(context.Background(), policy, "launch", 2, true, "", "", now); err == nil {
+		t.Fatal("unattributed adjustment unexpectedly applied")
+	}
+	if _, err := store.RevokeReferralIssuerAudited(context.Background(), policy.Campaign, "launch", true, "ops", "reason", nil, now); err == nil {
+		t.Fatal("revoke without confirmed preview unexpectedly applied")
+	}
+}

--- a/phase4-coordinator/internal/auth/referrals_core.go
+++ b/phase4-coordinator/internal/auth/referrals_core.go
@@ -1,0 +1,306 @@
+package auth
+
+import (
+	"context"
+	"crypto/hmac"
+	"crypto/sha256"
+	"database/sql"
+	"encoding/base32"
+	"errors"
+	"fmt"
+	"regexp"
+	"strings"
+	"time"
+)
+
+var (
+	ErrReferralRequired  = errors.New("referral code required")
+	ErrReferralInvalid   = errors.New("referral code invalid")
+	ErrReferralExpired   = errors.New("referral code expired")
+	ErrReferralRevoked   = errors.New("referral code revoked")
+	ErrReferralExhausted = errors.New("referral code exhausted")
+	ErrReferralConflict  = errors.New("provider already attributed to another referral")
+)
+
+const (
+	ReferralTypeSeed     = "S"
+	ReferralTypeProvider = "P"
+	referralTagBytes     = 16
+)
+
+var referralPartPattern = regexp.MustCompile(`^[A-Za-z0-9_]{1,32}$`)
+var referralEncoder = base32.StdEncoding.WithPadding(base32.NoPadding)
+
+// ReferralPolicy is a caller-owned immutable snapshot. Secrets remain in
+// memory; issuer rows persist only the key id needed for explicit rotation.
+type ReferralPolicy struct {
+	RequireForRegistration bool
+	EnableSocialBonus      bool
+	Campaign               string
+	PolicyVersion          string
+	GrandfatherBefore      *time.Time
+	GrandfatherProof       bool
+	CurrentKeyID           string
+	HMACKeys               map[string]string
+	ProviderBaseUses       int
+	SocialBonusUses        int
+	ChallengeTTL           time.Duration
+}
+
+func (p ReferralPolicy) Validate() error {
+	if !p.RequireForRegistration && !p.EnableSocialBonus && strings.TrimSpace(p.Campaign) == "" {
+		return nil
+	}
+	if !referralPartPattern.MatchString(p.Campaign) {
+		return fmt.Errorf("referral campaign must match %s", referralPartPattern)
+	}
+	if !referralPartPattern.MatchString(p.PolicyVersion) {
+		return fmt.Errorf("referral policy version must match %s", referralPartPattern)
+	}
+	if !referralPartPattern.MatchString(p.CurrentKeyID) {
+		return fmt.Errorf("referral current key id must match %s", referralPartPattern)
+	}
+	secret := p.HMACKeys[p.CurrentKeyID]
+	if len(secret) < 32 {
+		return fmt.Errorf("referral current HMAC secret must be at least 32 bytes")
+	}
+	for keyID, value := range p.HMACKeys {
+		if !referralPartPattern.MatchString(keyID) || len(value) < 32 {
+			return fmt.Errorf("referral HMAC key %q is invalid or shorter than 32 bytes", keyID)
+		}
+	}
+	if p.ProviderBaseUses <= 0 {
+		return fmt.Errorf("referral provider capacity must be positive")
+	}
+	if p.EnableSocialBonus && (p.SocialBonusUses <= 0 || p.ChallengeTTL <= 0) {
+		return fmt.Errorf("referral social capacity and challenge ttl must be positive")
+	}
+	return nil
+}
+
+type ReferralValidation struct {
+	Valid         bool
+	Reason        string
+	Type          string
+	IssuerID      string
+	Campaign      string
+	RemainingUses int
+}
+
+type parsedReferralCode struct {
+	Type     string
+	KeyID    string
+	IssuerID string
+	Tag      []byte
+}
+
+func parseReferralCode(raw string) (parsedReferralCode, error) {
+	parts := strings.Split(strings.TrimSpace(raw), "-")
+	if len(parts) != 5 || parts[0] != "MAL1" ||
+		(parts[1] != ReferralTypeSeed && parts[1] != ReferralTypeProvider) ||
+		!referralPartPattern.MatchString(parts[2]) || !referralPartPattern.MatchString(parts[3]) {
+		return parsedReferralCode{}, ErrReferralInvalid
+	}
+	tag, err := referralEncoder.DecodeString(strings.ToUpper(parts[4]))
+	if err != nil || len(tag) != referralTagBytes {
+		return parsedReferralCode{}, ErrReferralInvalid
+	}
+	return parsedReferralCode{Type: parts[1], KeyID: parts[2], IssuerID: parts[3], Tag: tag}, nil
+}
+
+func referralMAC(policy ReferralPolicy, typ, keyID, issuerID string) ([]byte, error) {
+	secret, ok := policy.HMACKeys[keyID]
+	if !ok || len(secret) < 32 {
+		return nil, ErrReferralInvalid
+	}
+	mac := hmac.New(sha256.New, []byte(secret))
+	_, _ = mac.Write([]byte("malibu-referral/v1\x00"))
+	_, _ = mac.Write([]byte(typ))
+	_, _ = mac.Write([]byte("\x00" + keyID + "\x00" + policy.Campaign + "\x00" + issuerID))
+	return mac.Sum(nil)[:referralTagBytes], nil
+}
+
+func EncodeReferralCode(policy ReferralPolicy, typ, keyID, issuerID string) (string, error) {
+	if err := policy.Validate(); err != nil {
+		return "", err
+	}
+	if (typ != ReferralTypeSeed && typ != ReferralTypeProvider) ||
+		!referralPartPattern.MatchString(keyID) || !referralPartPattern.MatchString(issuerID) {
+		return "", ErrReferralInvalid
+	}
+	tag, err := referralMAC(policy, typ, keyID, issuerID)
+	if err != nil {
+		return "", err
+	}
+	return strings.Join([]string{"MAL1", typ, keyID, issuerID, referralEncoder.EncodeToString(tag)}, "-"), nil
+}
+
+func (s *Store) ValidateReferral(ctx context.Context, policy ReferralPolicy, code string, now time.Time) (ReferralValidation, error) {
+	if err := policy.Validate(); err != nil {
+		return ReferralValidation{}, err
+	}
+	return validateReferralTx(ctx, s.db, policy, code, now)
+}
+
+type referralQueryRower interface {
+	QueryRowContext(context.Context, string, ...any) *sql.Row
+}
+
+func validateReferralTx(ctx context.Context, conn referralQueryRower, policy ReferralPolicy, code string, now time.Time) (ReferralValidation, error) {
+	parsed, err := parseReferralCode(code)
+	if err != nil {
+		return ReferralValidation{Reason: "invalid"}, ErrReferralInvalid
+	}
+	want, err := referralMAC(policy, parsed.Type, parsed.KeyID, parsed.IssuerID)
+	if err != nil || !hmac.Equal(want, parsed.Tag) {
+		return ReferralValidation{Reason: "invalid"}, ErrReferralInvalid
+	}
+	var issuer struct {
+		Type      string
+		KeyID     string
+		Campaign  string
+		Base      int
+		Bonus     int
+		ExpiresAt sql.NullString
+		RevokedAt sql.NullString
+	}
+	err = conn.QueryRowContext(ctx, `
+SELECT code_type, key_id, campaign, base_capacity, bonus_capacity, expires_at, revoked_at
+  FROM referral_issuers
+ WHERE issuer_id = ?`, parsed.IssuerID).Scan(
+		&issuer.Type, &issuer.KeyID, &issuer.Campaign, &issuer.Base, &issuer.Bonus,
+		&issuer.ExpiresAt, &issuer.RevokedAt,
+	)
+	if errors.Is(err, sql.ErrNoRows) {
+		return ReferralValidation{Reason: "invalid"}, ErrReferralInvalid
+	}
+	if err != nil {
+		return ReferralValidation{}, err
+	}
+	if issuer.Type != parsed.Type || issuer.KeyID != parsed.KeyID || issuer.Campaign != policy.Campaign {
+		return ReferralValidation{Reason: "invalid"}, ErrReferralInvalid
+	}
+	if issuer.RevokedAt.Valid {
+		return ReferralValidation{Reason: "revoked"}, ErrReferralRevoked
+	}
+	if issuer.ExpiresAt.Valid {
+		expires, parseErr := time.Parse(time.RFC3339, issuer.ExpiresAt.String)
+		if parseErr != nil || !expires.After(now.UTC()) {
+			return ReferralValidation{Reason: "expired"}, ErrReferralExpired
+		}
+	}
+	var used int
+	if err := conn.QueryRowContext(ctx,
+		`SELECT COUNT(1) FROM referral_redemptions WHERE issuer_id = ?`,
+		parsed.IssuerID,
+	).Scan(&used); err != nil {
+		return ReferralValidation{}, err
+	}
+	remaining := issuer.Base + issuer.Bonus - used
+	if remaining <= 0 {
+		return ReferralValidation{
+			Reason: "exhausted", Type: parsed.Type, IssuerID: parsed.IssuerID, Campaign: issuer.Campaign,
+		}, ErrReferralExhausted
+	}
+	return ReferralValidation{
+		Valid: true, Reason: "valid", Type: parsed.Type, IssuerID: parsed.IssuerID,
+		Campaign: issuer.Campaign, RemainingUses: remaining,
+	}, nil
+}
+
+// redeemReferralTx is called from the same SQLite transaction that creates a
+// credential. Capacity therefore cannot be consumed without a corresponding
+// token, and two concurrent consumers cannot overdraw an issuer.
+func redeemReferralTx(ctx context.Context, conn *sql.Conn, policy ReferralPolicy, code, providerID string, now time.Time) (bool, error) {
+	if !policy.RequireForRegistration {
+		return false, nil
+	}
+	code = strings.TrimSpace(code)
+	if code == "" {
+		if policy.GrandfatherProof {
+			var decision string
+			err := conn.QueryRowContext(ctx,
+				`SELECT decision FROM provider_referral_admissions WHERE provider_id = ? AND campaign = ?`,
+				providerID, policy.Campaign,
+			).Scan(&decision)
+			if err == nil && decision == "grandfathered" {
+				return false, nil
+			}
+			if err != nil && !errors.Is(err, sql.ErrNoRows) {
+				return false, err
+			}
+		}
+		if policy.GrandfatherProof && policy.GrandfatherBefore != nil {
+			var firstCreated sql.NullString
+			if err := conn.QueryRowContext(ctx,
+				`SELECT MIN(created_at) FROM provider_tokens WHERE provider_id = ?`, providerID,
+			).Scan(&firstCreated); err != nil {
+				return false, err
+			}
+			if firstCreated.Valid {
+				first, err := time.Parse(time.RFC3339, firstCreated.String)
+				if err == nil && first.Before(policy.GrandfatherBefore.UTC()) {
+					_, err = conn.ExecContext(ctx, `
+INSERT INTO provider_referral_admissions (provider_id, campaign, policy_version, decision, applied_at)
+VALUES (?, ?, ?, 'grandfathered', ?)
+ON CONFLICT(provider_id, campaign) DO NOTHING`,
+						providerID, policy.Campaign, policy.PolicyVersion, timeText(now.UTC()),
+					)
+					return false, err
+				}
+			}
+		}
+		return false, ErrReferralRequired
+	}
+
+	var existingIssuer, existingDigest string
+	err := conn.QueryRowContext(ctx, `
+SELECT issuer_id, code_digest FROM referral_redemptions
+ WHERE campaign = ? AND provider_id = ?`, policy.Campaign, providerID,
+	).Scan(&existingIssuer, &existingDigest)
+	if err != nil && !errors.Is(err, sql.ErrNoRows) {
+		return false, err
+	}
+	parsed, parseErr := parseReferralCode(code)
+	if parseErr != nil {
+		return false, ErrReferralInvalid
+	}
+	digest := sha256.Sum256([]byte(code))
+	presentedDigest := fmt.Sprintf("%x", digest[:])
+	if err == nil {
+		if existingIssuer == parsed.IssuerID && hmac.Equal([]byte(existingDigest), []byte(presentedDigest)) {
+			wantMAC, macErr := referralMAC(policy, parsed.Type, parsed.KeyID, parsed.IssuerID)
+			if macErr != nil || !hmac.Equal(wantMAC, parsed.Tag) {
+				return false, ErrReferralInvalid
+			}
+			return false, nil
+		}
+		return false, ErrReferralConflict
+	}
+
+	validated, err := validateReferralTx(ctx, conn, policy, code, now)
+	if err != nil {
+		return false, err
+	}
+	_, err = conn.ExecContext(ctx, `
+INSERT INTO referral_redemptions
+    (campaign, provider_id, issuer_id, code_digest, policy_version, redeemed_at)
+VALUES (?, ?, ?, ?, ?, ?)`,
+		policy.Campaign, providerID, validated.IssuerID, presentedDigest,
+		policy.PolicyVersion, timeText(now.UTC()),
+	)
+	if isConstraintFailure(err) {
+		return false, ErrReferralExhausted
+	}
+	if err != nil {
+		return false, err
+	}
+	_, err = conn.ExecContext(ctx, `
+INSERT INTO provider_referral_admissions
+    (provider_id, campaign, policy_version, decision, applied_at)
+VALUES (?, ?, ?, 'referred', ?)
+ON CONFLICT(provider_id, campaign) DO NOTHING`,
+		providerID, policy.Campaign, policy.PolicyVersion, timeText(now.UTC()),
+	)
+	return true, err
+}

--- a/phase4-coordinator/internal/auth/referrals_core.go
+++ b/phase4-coordinator/internal/auth/referrals_core.go
@@ -223,7 +223,13 @@ func redeemReferralTx(ctx context.Context, conn *sql.Conn, policy ReferralPolicy
 				`SELECT decision FROM provider_referral_admissions WHERE provider_id = ? AND campaign = ?`,
 				providerID, policy.Campaign,
 			).Scan(&decision)
-			if err == nil && decision == "grandfathered" {
+			// Exact bootstrap-key custody may recover a response lost after a
+			// referral was already committed. The campaign-scoped admission row
+			// proves policy was satisfied; accepting no code here avoids storing
+			// the plaintext invite in the CLI restart journal. GrandfatherProof is
+			// set only after MintBootstrapToken byte-matches the retained key and
+			// rejects confirmed, ordinary, or operator-revoked ownership.
+			if err == nil && (decision == "grandfathered" || decision == "referred") {
 				return false, nil
 			}
 			if err != nil && !errors.Is(err, sql.ErrNoRows) {

--- a/phase4-coordinator/internal/auth/referrals_core.go
+++ b/phase4-coordinator/internal/auth/referrals_core.go
@@ -34,17 +34,18 @@ var referralEncoder = base32.StdEncoding.WithPadding(base32.NoPadding)
 // ReferralPolicy is a caller-owned immutable snapshot. Secrets remain in
 // memory; issuer rows persist only the key id needed for explicit rotation.
 type ReferralPolicy struct {
-	RequireForRegistration bool
-	EnableSocialBonus      bool
-	Campaign               string
-	PolicyVersion          string
-	GrandfatherBefore      *time.Time
-	GrandfatherProof       bool
-	CurrentKeyID           string
-	HMACKeys               map[string]string
-	ProviderBaseUses       int
-	SocialBonusUses        int
-	ChallengeTTL           time.Duration
+	RequireForRegistration  bool
+	EnableSocialBonus       bool
+	Campaign                string
+	PolicyVersion           string
+	GrandfatherBefore       *time.Time
+	GrandfatherProof        bool
+	CurrentKeyID            string
+	HMACKeys                map[string]string
+	ProviderBaseUses        int
+	SocialBonusUses         int
+	ChallengeTTL            time.Duration
+	SocialVerificationDwell time.Duration
 }
 
 func (p ReferralPolicy) Validate() error {
@@ -72,8 +73,8 @@ func (p ReferralPolicy) Validate() error {
 	if p.ProviderBaseUses <= 0 {
 		return fmt.Errorf("referral provider capacity must be positive")
 	}
-	if p.EnableSocialBonus && (p.SocialBonusUses <= 0 || p.ChallengeTTL <= 0) {
-		return fmt.Errorf("referral social capacity and challenge ttl must be positive")
+	if p.EnableSocialBonus && (p.SocialBonusUses <= 0 || p.ChallengeTTL <= 0 || p.SocialVerificationDwell <= 0) {
+		return fmt.Errorf("referral social capacity, challenge ttl, and verification dwell must be positive")
 	}
 	return nil
 }
@@ -161,14 +162,15 @@ func validateReferralTx(ctx context.Context, conn referralQueryRower, policy Ref
 		Campaign  string
 		Base      int
 		Bonus     int
+		Carried   int
 		ExpiresAt sql.NullString
 		RevokedAt sql.NullString
 	}
 	err = conn.QueryRowContext(ctx, `
-SELECT code_type, key_id, campaign, base_capacity, bonus_capacity, expires_at, revoked_at
+SELECT code_type, key_id, campaign, base_capacity, bonus_capacity, carried_redemptions, expires_at, revoked_at
   FROM referral_issuers
  WHERE issuer_id = ?`, parsed.IssuerID).Scan(
-		&issuer.Type, &issuer.KeyID, &issuer.Campaign, &issuer.Base, &issuer.Bonus,
+		&issuer.Type, &issuer.KeyID, &issuer.Campaign, &issuer.Base, &issuer.Bonus, &issuer.Carried,
 		&issuer.ExpiresAt, &issuer.RevokedAt,
 	)
 	if errors.Is(err, sql.ErrNoRows) {
@@ -196,7 +198,7 @@ SELECT code_type, key_id, campaign, base_capacity, bonus_capacity, expires_at, r
 	).Scan(&used); err != nil {
 		return ReferralValidation{}, err
 	}
-	remaining := issuer.Base + issuer.Bonus - used
+	remaining := issuer.Base + issuer.Bonus - issuer.Carried - used
 	if remaining <= 0 {
 		return ReferralValidation{
 			Reason: "exhausted", Type: parsed.Type, IssuerID: parsed.IssuerID, Campaign: issuer.Campaign,

--- a/phase4-coordinator/internal/auth/referrals_core_test.go
+++ b/phase4-coordinator/internal/auth/referrals_core_test.go
@@ -1,6 +1,7 @@
 package auth
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"path/filepath"
@@ -181,6 +182,134 @@ func TestReferralReplayForSameProviderDoesNotConsumeCapacityTwice(t *testing.T) 
 	if redemptions != 1 || activeTokens != 1 {
 		t.Fatalf("redemptions=%d active_tokens=%d, want 1/1", redemptions, activeTokens)
 	}
+}
+
+func TestCredentialBootstrapResponseLossKeepsOneReferralRedemption(t *testing.T) {
+	ctx := context.Background()
+	store, err := OpenStore(filepath.Join(t.TempDir(), "coordinator.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+	policy := coreReferralPolicy()
+	code := seedCoreReferral(t, store, policy, "seedbootstrapretry")
+	now := time.Now().UTC().Truncate(time.Second)
+	request := BootstrapMintRequest{
+		ProviderID:          "mp-0123456789abcdef0123456789abcdef",
+		ProviderName:        "bootstrap provider",
+		SourceIP:            "192.0.2.80",
+		ReceiptPubkey:       bytes.Repeat([]byte{0x81}, 32),
+		Now:                 now,
+		TTL:                 10 * time.Minute,
+		PerIPLimitPerHour:   8,
+		PerProviderPerHour:  3,
+		GlobalLimitPerHour:  128,
+		UnconfirmedIDMax:    64,
+		OutstandingTokenMax: 64,
+		IdentityRetention:   7 * 24 * time.Hour,
+		ReferralCode:        code,
+		ReferralPolicy:      policy,
+	}
+
+	first, err := store.MintBootstrapToken(ctx, request)
+	if err != nil || first.Replaced || first.ProviderToken == "" {
+		t.Fatalf("first mint=%+v err=%v", first, err)
+	}
+	request.Now = now.Add(time.Second)
+	request.ReferralCode = ""
+	recovered, err := store.MintBootstrapToken(ctx, request)
+	if err != nil || !recovered.Replaced || recovered.ProviderToken == "" || recovered.ProviderToken == first.ProviderToken {
+		t.Fatalf("recovered mint=%+v err=%v", recovered, err)
+	}
+	if _, valid, err := store.ValidateToken(ctx, first.ProviderToken); err != nil || valid {
+		t.Fatalf("lost-response token valid=%v err=%v, want revoked", valid, err)
+	}
+	providerID, valid, err := store.ValidateToken(ctx, recovered.ProviderToken)
+	if err != nil || !valid || providerID != request.ProviderID {
+		t.Fatalf("recovered provider_id=%q valid=%v err=%v", providerID, valid, err)
+	}
+
+	var redemptions, activeTokens int
+	if err := store.db.QueryRow(`SELECT COUNT(1) FROM referral_redemptions WHERE provider_id = ?`, request.ProviderID).Scan(&redemptions); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.db.QueryRow(`SELECT COUNT(1) FROM provider_tokens WHERE provider_id = ? AND revoked_at IS NULL`, request.ProviderID).Scan(&activeTokens); err != nil {
+		t.Fatal(err)
+	}
+	if redemptions != 1 || activeTokens != 1 {
+		t.Fatalf("redemptions=%d active_tokens=%d, want 1/1", redemptions, activeTokens)
+	}
+}
+
+func TestCredentialBootstrapReferralRecoveryCannotChangeCodeOrCampaign(t *testing.T) {
+	newRequest := func(providerID string, keyByte byte, now time.Time, code string, policy ReferralPolicy) BootstrapMintRequest {
+		return BootstrapMintRequest{
+			ProviderID: providerID, ProviderName: "bootstrap provider", SourceIP: "192.0.2.81",
+			ReceiptPubkey: bytes.Repeat([]byte{keyByte}, 32), Now: now, TTL: 10 * time.Minute,
+			PerIPLimitPerHour: 8, PerProviderPerHour: 3, GlobalLimitPerHour: 128,
+			UnconfirmedIDMax: 64, OutstandingTokenMax: 64, IdentityRetention: 7 * 24 * time.Hour,
+			ReferralCode: code, ReferralPolicy: policy,
+		}
+	}
+
+	t.Run("different code", func(t *testing.T) {
+		ctx := context.Background()
+		store, err := OpenStore(filepath.Join(t.TempDir(), "coordinator.db"))
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer store.Close()
+		policy := coreReferralPolicy()
+		firstCode := seedCoreReferral(t, store, policy, "seedbootstrapfirst")
+		secondCode := seedCoreReferral(t, store, policy, "seedbootstrapsecond")
+		now := time.Now().UTC().Truncate(time.Second)
+		request := newRequest("mp-1123456789abcdef0123456789abcdef", 0x82, now, firstCode, policy)
+		first, err := store.MintBootstrapToken(ctx, request)
+		if err != nil {
+			t.Fatal(err)
+		}
+		request.Now = now.Add(time.Second)
+		request.ReferralCode = secondCode
+		if _, err := store.MintBootstrapToken(ctx, request); !errors.Is(err, ErrReferralConflict) {
+			t.Fatalf("different-code recovery err=%v, want conflict", err)
+		}
+		if _, valid, err := store.ValidateToken(ctx, first.ProviderToken); err != nil || !valid {
+			t.Fatalf("original token valid=%v err=%v", valid, err)
+		}
+		var redemptions int
+		if err := store.db.QueryRow(`SELECT COUNT(1) FROM referral_redemptions WHERE provider_id = ?`, request.ProviderID).Scan(&redemptions); err != nil {
+			t.Fatal(err)
+		}
+		if redemptions != 1 {
+			t.Fatalf("redemptions=%d, want 1", redemptions)
+		}
+	})
+
+	t.Run("different campaign", func(t *testing.T) {
+		ctx := context.Background()
+		store, err := OpenStore(filepath.Join(t.TempDir(), "coordinator.db"))
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer store.Close()
+		policy := coreReferralPolicy()
+		code := seedCoreReferral(t, store, policy, "seedbootstrapcampaign")
+		now := time.Now().UTC().Truncate(time.Second)
+		request := newRequest("mp-2123456789abcdef0123456789abcdef", 0x83, now, code, policy)
+		first, err := store.MintBootstrapToken(ctx, request)
+		if err != nil {
+			t.Fatal(err)
+		}
+		request.Now = now.Add(time.Second)
+		request.ReferralCode = ""
+		request.ReferralPolicy.Campaign = "other_campaign"
+		if _, err := store.MintBootstrapToken(ctx, request); !errors.Is(err, ErrReferralRequired) {
+			t.Fatalf("different-campaign recovery err=%v, want required", err)
+		}
+		if _, valid, err := store.ValidateToken(ctx, first.ProviderToken); err != nil || !valid {
+			t.Fatalf("original token valid=%v err=%v", valid, err)
+		}
+	})
 }
 
 func TestConcurrentReferralRedemptionHasOneTokenAndRedemptionWinner(t *testing.T) {

--- a/phase4-coordinator/internal/auth/referrals_core_test.go
+++ b/phase4-coordinator/internal/auth/referrals_core_test.go
@@ -80,7 +80,8 @@ func TestAppTrackReferralSagaPreservesCommittedAndCompensatesAbsent(t *testing.T
 		AttemptTS: time.Date(2026, 7, 13, 10, 0, 0, 0, time.UTC),
 	}
 
-	token, err := store.MintProviderTokenAppTrackWithReferralAttempt(context.Background(), "provider-a", code, policy, attempt)
+	tokenCandidate := strings.Repeat("c", 64)
+	token, err := store.MintProviderTokenAppTrackWithReferralAttempt(context.Background(), "provider-a", code, tokenCandidate, policy, attempt)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -95,7 +96,7 @@ func TestAppTrackReferralSagaPreservesCommittedAndCompensatesAbsent(t *testing.T
 		t.Fatalf("rolled-back token ok=%v err=%v", ok, err)
 	}
 
-	committedToken, err := store.MintProviderTokenAppTrackWithReferralAttempt(context.Background(), "provider-b", code, policy, AppTrackRegistrationAttempt{
+	committedToken, err := store.MintProviderTokenAppTrackWithReferralAttempt(context.Background(), "provider-b", code, strings.Repeat("d", 64), policy, AppTrackRegistrationAttempt{
 		SourceIP: "203.0.113.11", Nonce: strings.Repeat("b", 64), AttemptTS: attempt.AttemptTS.Add(time.Second),
 	})
 	if err != nil {

--- a/phase4-coordinator/internal/auth/referrals_core_test.go
+++ b/phase4-coordinator/internal/auth/referrals_core_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 )
@@ -63,6 +64,217 @@ func TestReferralRedemptionAndTokenInsertAreAtomic(t *testing.T) {
 	}
 	if tokens != 1 || redemptions != 1 {
 		t.Fatalf("tokens=%d redemptions=%d, want 1/1", tokens, redemptions)
+	}
+}
+
+func TestReferralValidationRejectsInvalidExpiredRevokedAndExhausted(t *testing.T) {
+	now := time.Date(2026, 7, 13, 12, 0, 0, 0, time.UTC)
+
+	t.Run("invalid", func(t *testing.T) {
+		store, err := OpenStore(filepath.Join(t.TempDir(), "coordinator.db"))
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer store.Close()
+		policy := coreReferralPolicy()
+		code := seedCoreReferral(t, store, policy, "seedinvalid")
+		tagStart := strings.LastIndex(code, "-") + 1
+		replacement := "A"
+		if code[tagStart] == replacement[0] {
+			replacement = "B"
+		}
+		code = code[:tagStart] + replacement + code[tagStart+1:]
+
+		validation, err := store.ValidateReferral(context.Background(), policy, code, now)
+		if !errors.Is(err, ErrReferralInvalid) || validation.Reason != "invalid" {
+			t.Fatalf("validation=%+v err=%v, want invalid", validation, err)
+		}
+	})
+
+	t.Run("expired", func(t *testing.T) {
+		store, err := OpenStore(filepath.Join(t.TempDir(), "coordinator.db"))
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer store.Close()
+		policy := coreReferralPolicy()
+		code := seedCoreReferral(t, store, policy, "seedexpired")
+		if _, err := store.db.Exec(`UPDATE referral_issuers SET expires_at = ? WHERE issuer_id = ?`, timeText(now.Add(-time.Second)), "seedexpired"); err != nil {
+			t.Fatal(err)
+		}
+
+		validation, err := store.ValidateReferral(context.Background(), policy, code, now)
+		if !errors.Is(err, ErrReferralExpired) || validation.Reason != "expired" {
+			t.Fatalf("validation=%+v err=%v, want expired", validation, err)
+		}
+	})
+
+	t.Run("revoked", func(t *testing.T) {
+		store, err := OpenStore(filepath.Join(t.TempDir(), "coordinator.db"))
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer store.Close()
+		policy := coreReferralPolicy()
+		code := seedCoreReferral(t, store, policy, "seedrevoked")
+		if _, err := store.db.Exec(`UPDATE referral_issuers SET revoked_at = ? WHERE issuer_id = ?`, timeText(now.Add(-time.Second)), "seedrevoked"); err != nil {
+			t.Fatal(err)
+		}
+
+		validation, err := store.ValidateReferral(context.Background(), policy, code, now)
+		if !errors.Is(err, ErrReferralRevoked) || validation.Reason != "revoked" {
+			t.Fatalf("validation=%+v err=%v, want revoked", validation, err)
+		}
+	})
+
+	t.Run("exhausted", func(t *testing.T) {
+		store, err := OpenStore(filepath.Join(t.TempDir(), "coordinator.db"))
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer store.Close()
+		policy := coreReferralPolicy()
+		code := seedCoreReferral(t, store, policy, "seedexhausted")
+		if _, _, err := store.IssueTokenWithReferral(context.Background(), "provider-a", "host-a", code, policy); err != nil {
+			t.Fatal(err)
+		}
+
+		validation, err := store.ValidateReferral(context.Background(), policy, code, now)
+		if !errors.Is(err, ErrReferralExhausted) || validation.Reason != "exhausted" {
+			t.Fatalf("validation=%+v err=%v, want exhausted", validation, err)
+		}
+	})
+}
+
+func TestReferralReplayForSameProviderDoesNotConsumeCapacityTwice(t *testing.T) {
+	ctx := context.Background()
+	store, err := OpenStore(filepath.Join(t.TempDir(), "coordinator.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+	policy := coreReferralPolicy()
+	code := seedCoreReferral(t, store, policy, "seedreplay")
+
+	first, firstToken, err := store.IssueTokenWithReferral(ctx, "provider-a", "host-a", code, policy)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.RevokeToken(ctx, first.TokenPrefix); err != nil {
+		t.Fatal(err)
+	}
+	_, secondToken, err := store.IssueTokenWithReferral(ctx, "provider-a", "host-a", code, policy)
+	if err != nil {
+		t.Fatalf("idempotent replay mint: %v", err)
+	}
+	if secondToken == firstToken {
+		t.Fatal("replay returned the revoked credential")
+	}
+
+	var redemptions, activeTokens int
+	if err := store.db.QueryRow(`SELECT COUNT(1) FROM referral_redemptions WHERE provider_id = ?`, "provider-a").Scan(&redemptions); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.db.QueryRow(`SELECT COUNT(1) FROM provider_tokens WHERE provider_id = ? AND revoked_at IS NULL`, "provider-a").Scan(&activeTokens); err != nil {
+		t.Fatal(err)
+	}
+	if redemptions != 1 || activeTokens != 1 {
+		t.Fatalf("redemptions=%d active_tokens=%d, want 1/1", redemptions, activeTokens)
+	}
+}
+
+func TestConcurrentReferralRedemptionHasOneTokenAndRedemptionWinner(t *testing.T) {
+	store, err := OpenStore(filepath.Join(t.TempDir(), "coordinator.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+	policy := coreReferralPolicy()
+	code := seedCoreReferral(t, store, policy, "seedconcurrent")
+
+	type result struct {
+		providerID string
+		err        error
+	}
+	start := make(chan struct{})
+	results := make(chan result, 2)
+	var wg sync.WaitGroup
+	for _, providerID := range []string{"provider-a", "provider-b"} {
+		providerID := providerID
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			_, _, err := store.IssueTokenWithReferral(context.Background(), providerID, "host-"+providerID, code, policy)
+			results <- result{providerID: providerID, err: err}
+		}()
+	}
+	close(start)
+	wg.Wait()
+	close(results)
+
+	winner := ""
+	for result := range results {
+		switch {
+		case result.err == nil:
+			if winner != "" {
+				t.Fatalf("multiple winners: %q and %q", winner, result.providerID)
+			}
+			winner = result.providerID
+		case errors.Is(result.err, ErrReferralExhausted):
+		default:
+			t.Fatalf("provider %q error=%v, want exhausted", result.providerID, result.err)
+		}
+	}
+	if winner == "" {
+		t.Fatal("no redemption winner")
+	}
+
+	var tokens, redemptions int
+	if err := store.db.QueryRow(`SELECT COUNT(1) FROM provider_tokens WHERE revoked_at IS NULL`).Scan(&tokens); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.db.QueryRow(`SELECT COUNT(1) FROM referral_redemptions`).Scan(&redemptions); err != nil {
+		t.Fatal(err)
+	}
+	if tokens != 1 || redemptions != 1 {
+		t.Fatalf("tokens=%d redemptions=%d, want 1/1", tokens, redemptions)
+	}
+
+	var tokenProvider, redemptionProvider string
+	if err := store.db.QueryRow(`SELECT provider_id FROM provider_tokens WHERE revoked_at IS NULL`).Scan(&tokenProvider); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.db.QueryRow(`SELECT provider_id FROM referral_redemptions`).Scan(&redemptionProvider); err != nil {
+		t.Fatal(err)
+	}
+	if tokenProvider != winner || redemptionProvider != winner {
+		t.Fatalf("winner=%q token_provider=%q redemption_provider=%q", winner, tokenProvider, redemptionProvider)
+	}
+}
+
+func TestReferralFeatureOffAllowsFreshProviderWithoutRedemption(t *testing.T) {
+	ctx := context.Background()
+	store, err := OpenStore(filepath.Join(t.TempDir(), "coordinator.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+
+	_, token, err := store.IssueTokenWithReferral(ctx, "provider-fresh", "host-fresh", "", ReferralPolicy{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	providerID, ok, err := store.ValidateToken(ctx, token)
+	if err != nil || !ok || providerID != "provider-fresh" {
+		t.Fatalf("provider_id=%q ok=%v err=%v", providerID, ok, err)
+	}
+	var redemptions int
+	if err := store.db.QueryRow(`SELECT COUNT(1) FROM referral_redemptions`).Scan(&redemptions); err != nil {
+		t.Fatal(err)
+	}
+	if redemptions != 0 {
+		t.Fatalf("redemptions=%d, want 0", redemptions)
 	}
 }
 

--- a/phase4-coordinator/internal/auth/referrals_core_test.go
+++ b/phase4-coordinator/internal/auth/referrals_core_test.go
@@ -1,0 +1,131 @@
+package auth
+
+import (
+	"context"
+	"errors"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func coreReferralPolicy() ReferralPolicy {
+	return ReferralPolicy{
+		RequireForRegistration: true,
+		Campaign:               "prebeta_test",
+		PolicyVersion:          "v1",
+		CurrentKeyID:           "k1",
+		HMACKeys:               map[string]string{"k1": strings.Repeat("s", 32)},
+		ProviderBaseUses:       1,
+	}
+}
+
+func seedCoreReferral(t *testing.T, store *Store, policy ReferralPolicy, issuerID string) string {
+	t.Helper()
+	_, err := store.db.Exec(`
+INSERT INTO referral_issuers (
+    issuer_id, code_type, key_id, campaign, provider_id,
+    base_capacity, bonus_capacity, created_at, first_serving_at
+) VALUES (?, 'S', ?, ?, NULL, 1, 0, ?, ?)`,
+		issuerID, policy.CurrentKeyID, policy.Campaign, nowString(), nowString(),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	code, err := EncodeReferralCode(policy, ReferralTypeSeed, policy.CurrentKeyID, issuerID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return code
+}
+
+func TestReferralRedemptionAndTokenInsertAreAtomic(t *testing.T) {
+	store, err := OpenStore(filepath.Join(t.TempDir(), "coordinator.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+	policy := coreReferralPolicy()
+	code := seedCoreReferral(t, store, policy, "seed1")
+
+	if _, _, err := store.IssueTokenWithReferral(context.Background(), "provider-a", "host-a", code, policy); err != nil {
+		t.Fatalf("first mint: %v", err)
+	}
+	if _, _, err := store.IssueTokenWithReferral(context.Background(), "provider-b", "host-b", code, policy); !errors.Is(err, ErrReferralExhausted) {
+		t.Fatalf("second mint error=%v, want exhausted", err)
+	}
+	var tokens, redemptions int
+	if err := store.db.QueryRow(`SELECT COUNT(1) FROM provider_tokens WHERE revoked_at IS NULL`).Scan(&tokens); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.db.QueryRow(`SELECT COUNT(1) FROM referral_redemptions`).Scan(&redemptions); err != nil {
+		t.Fatal(err)
+	}
+	if tokens != 1 || redemptions != 1 {
+		t.Fatalf("tokens=%d redemptions=%d, want 1/1", tokens, redemptions)
+	}
+}
+
+func TestAppTrackReferralSagaPreservesCommittedAndCompensatesAbsent(t *testing.T) {
+	store, err := OpenStore(filepath.Join(t.TempDir(), "coordinator.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+	policy := coreReferralPolicy()
+	code := seedCoreReferral(t, store, policy, "seed1")
+	attempt := AppTrackRegistrationAttempt{
+		SourceIP:  "203.0.113.10",
+		Nonce:     strings.Repeat("a", 64),
+		AttemptTS: time.Date(2026, 7, 13, 10, 0, 0, 0, time.UTC),
+	}
+
+	token, err := store.MintProviderTokenAppTrackWithReferralAttempt(context.Background(), "provider-a", code, policy, attempt)
+	if err != nil {
+		t.Fatal(err)
+	}
+	pending, err := store.ListPendingAppTrackReferralMints(context.Background(), time.Now().UTC().Add(time.Hour))
+	if err != nil || len(pending) != 1 {
+		t.Fatalf("pending=%+v err=%v", pending, err)
+	}
+	if err := store.ResolvePendingAppTrackReferralMint(context.Background(), pending[0], false); err != nil {
+		t.Fatal(err)
+	}
+	if _, ok, err := store.ValidateToken(context.Background(), token); err != nil || ok {
+		t.Fatalf("rolled-back token ok=%v err=%v", ok, err)
+	}
+
+	committedToken, err := store.MintProviderTokenAppTrackWithReferralAttempt(context.Background(), "provider-b", code, policy, AppTrackRegistrationAttempt{
+		SourceIP: "203.0.113.11", Nonce: strings.Repeat("b", 64), AttemptTS: attempt.AttemptTS.Add(time.Second),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	pending, err = store.ListPendingAppTrackReferralMints(context.Background(), time.Now().UTC().Add(time.Hour))
+	if err != nil || len(pending) != 1 {
+		t.Fatalf("pending=%+v err=%v", pending, err)
+	}
+	if err := store.ResolvePendingAppTrackReferralMint(context.Background(), pending[0], true); err != nil {
+		t.Fatal(err)
+	}
+	if providerID, ok, err := store.ValidateToken(context.Background(), committedToken); err != nil || !ok || providerID != "provider-b" {
+		t.Fatalf("committed token provider=%q ok=%v err=%v", providerID, ok, err)
+	}
+}
+
+func TestCoreSchemaHasNoPublicReferralReservationTables(t *testing.T) {
+	store, err := OpenStore(filepath.Join(t.TempDir(), "coordinator.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+	var count int
+	if err := store.db.QueryRow(`
+SELECT COUNT(1) FROM sqlite_master
+ WHERE type = 'table' AND name LIKE 'referral_reservation%'`).Scan(&count); err != nil {
+		t.Fatal(err)
+	}
+	if count != 0 {
+		t.Fatalf("reservation table count=%d, want 0", count)
+	}
+}

--- a/phase4-coordinator/internal/auth/referrals_social.go
+++ b/phase4-coordinator/internal/auth/referrals_social.go
@@ -1,0 +1,1009 @@
+package auth
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/sha256"
+	"database/sql"
+	"errors"
+	"fmt"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/augstar/macprovider-coordinator/internal/config"
+	"github.com/augstar/macprovider-coordinator/internal/sqliteutil"
+)
+
+var (
+	ErrReferralLocked                = errors.New("provider referral locked until first verified serving")
+	ErrReferralQualificationConflict = errors.New("provider serving qualification conflicts with durable state")
+	ErrReferralReplacementConflict   = errors.New("provider referral replacement snapshot conflicts with durable state")
+	ErrSocialDisabled                = errors.New("social invite bonus disabled")
+	ErrSocialChallenge               = errors.New("social challenge invalid")
+	ErrSocialRateLimited             = errors.New("social action rate limited")
+	ErrSocialRecheckTransient        = errors.New("social recheck transient failure")
+)
+
+const (
+	SocialStateLocked   = "locked_until_first_serving"
+	SocialStateEligible = "eligible"
+	SocialStatePending  = "pending"
+	SocialStateMatured  = "matured"
+	SocialStateFailed   = "failed"
+	SocialStateRevoked  = "revoked"
+
+	socialGrantKind          = "x_verified_post"
+	socialRecheckLease       = 2 * time.Minute
+	socialRecheckBaseBackoff = time.Minute
+	socialRecheckMaxBackoff  = time.Hour
+)
+
+var socialPrincipalIDPattern = regexp.MustCompile(`^[0-9]{1,24}$`)
+var socialShareURLHashPattern = regexp.MustCompile(`^[0-9a-f]{64}$`)
+var socialEvidenceIDPattern = regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9._:/-]{0,191}$`)
+var socialActionPattern = regexp.MustCompile(`^[a-z][a-z0-9_]{0,31}$`)
+var socialAuditTokenPattern = regexp.MustCompile(`^[a-z][a-z0-9_]{0,47}$`)
+
+// ProviderReferral is the authoritative provider-invite snapshot. Capacity is
+// redemption-only: no public hold or reservation state is represented here.
+type ProviderReferral struct {
+	Code             string
+	Campaign         string
+	IssuerID         string
+	BaseCapacity     int
+	BonusCapacity    int
+	Redemptions      int
+	Remaining        int
+	SocialState      string
+	FirstServingSeen bool
+	Revoked          bool
+}
+
+type SocialChallenge struct {
+	Cleartext string
+	ExpiresAt time.Time
+	Code      string
+}
+
+func referralSocialSchemaStatements() []string {
+	return []string{
+		`CREATE TABLE IF NOT EXISTS referral_serving_qualifications (
+			campaign TEXT NOT NULL,
+			provider_id TEXT NOT NULL,
+			evidence_id TEXT NOT NULL,
+			evidence_at TEXT NOT NULL,
+			qualified_at TEXT NOT NULL,
+			issuer_id TEXT NOT NULL REFERENCES referral_issuers(issuer_id),
+			PRIMARY KEY(campaign, provider_id),
+			UNIQUE(campaign, evidence_id),
+			UNIQUE(issuer_id)
+		)`,
+		`CREATE TABLE IF NOT EXISTS referral_social_challenges (
+			challenge_hash TEXT PRIMARY KEY,
+			provider_id TEXT NOT NULL,
+			campaign TEXT NOT NULL,
+			issuer_id TEXT NOT NULL REFERENCES referral_issuers(issuer_id),
+			created_at TEXT NOT NULL,
+			expires_at TEXT NOT NULL,
+			consumed_at TEXT,
+			UNIQUE(provider_id, campaign)
+		)`,
+		`CREATE INDEX IF NOT EXISTS idx_referral_social_challenges_expiry
+			ON referral_social_challenges(expires_at)`,
+		`CREATE TABLE IF NOT EXISTS referral_social_verifications (
+			provider_id TEXT NOT NULL,
+			campaign TEXT NOT NULL,
+			issuer_id TEXT NOT NULL REFERENCES referral_issuers(issuer_id),
+			challenge_hash TEXT NOT NULL,
+			post_id TEXT NOT NULL UNIQUE,
+			author_id TEXT NOT NULL,
+			share_url_hash TEXT NOT NULL,
+			verification_method TEXT NOT NULL,
+			submitted_at TEXT NOT NULL,
+			pending_since TEXT NOT NULL,
+			next_check_at TEXT NOT NULL,
+			recheck_attempts INTEGER NOT NULL DEFAULT 0,
+			lease_token TEXT,
+			lease_until TEXT,
+			granted_at TEXT,
+			failed_at TEXT,
+			PRIMARY KEY(provider_id, campaign),
+			CHECK ((lease_token IS NULL) = (lease_until IS NULL))
+		)`,
+		`CREATE TABLE IF NOT EXISTS referral_social_verification_history (
+			archive_id INTEGER PRIMARY KEY AUTOINCREMENT,
+			provider_id TEXT NOT NULL,
+			campaign TEXT NOT NULL,
+			issuer_id TEXT NOT NULL,
+			challenge_hash TEXT NOT NULL,
+			post_id TEXT NOT NULL UNIQUE,
+			author_id TEXT NOT NULL,
+			share_url_hash TEXT NOT NULL,
+			verification_method TEXT NOT NULL,
+			submitted_at TEXT NOT NULL,
+			pending_since TEXT NOT NULL,
+			granted_at TEXT,
+			failed_at TEXT NOT NULL,
+			archived_at TEXT NOT NULL
+		)`,
+		`CREATE TABLE IF NOT EXISTS referral_social_grants (
+			campaign TEXT NOT NULL,
+			provider_id TEXT NOT NULL,
+			bonus_kind TEXT NOT NULL,
+			issuer_id TEXT NOT NULL,
+			verification_post_hash TEXT NOT NULL,
+			amount INTEGER NOT NULL CHECK(amount > 0),
+			granted_at TEXT NOT NULL,
+			PRIMARY KEY(campaign, provider_id, bonus_kind)
+		)`,
+		`CREATE TRIGGER IF NOT EXISTS referral_social_grants_no_update
+			BEFORE UPDATE ON referral_social_grants
+			BEGIN SELECT RAISE(ABORT, 'referral_social_grants is append-only'); END`,
+		`CREATE TRIGGER IF NOT EXISTS referral_social_grants_no_delete
+			BEFORE DELETE ON referral_social_grants
+			BEGIN SELECT RAISE(ABORT, 'referral_social_grants is append-only'); END`,
+		`CREATE TABLE IF NOT EXISTS referral_social_rate_windows (
+			campaign TEXT NOT NULL,
+			provider_id TEXT NOT NULL,
+			action TEXT NOT NULL,
+			window_started_at TEXT NOT NULL,
+			request_count INTEGER NOT NULL CHECK(request_count > 0),
+			PRIMARY KEY(campaign, provider_id, action, window_started_at)
+		)`,
+		`CREATE TABLE IF NOT EXISTS referral_social_audit (
+			id INTEGER PRIMARY KEY AUTOINCREMENT,
+			campaign TEXT NOT NULL,
+			provider_id TEXT NOT NULL,
+			issuer_id TEXT,
+			event_kind TEXT NOT NULL,
+			outcome TEXT NOT NULL,
+			subject_hash TEXT NOT NULL DEFAULT '',
+			reason TEXT NOT NULL DEFAULT '',
+			created_at TEXT NOT NULL
+		)`,
+		`CREATE INDEX IF NOT EXISTS idx_referral_social_audit_subject
+			ON referral_social_audit(campaign, provider_id, created_at)`,
+		`CREATE TRIGGER IF NOT EXISTS referral_social_audit_no_update
+			BEFORE UPDATE ON referral_social_audit
+			BEGIN SELECT RAISE(ABORT, 'referral_social_audit is append-only'); END`,
+		`CREATE TRIGGER IF NOT EXISTS referral_social_audit_no_delete
+			BEFORE DELETE ON referral_social_audit
+			BEGIN SELECT RAISE(ABORT, 'referral_social_audit is append-only'); END`,
+	}
+}
+
+// QualifyProviderReferral persists the coordinator-authoritative serving
+// evidence and creates the provider issuer in one transaction. Retries are
+// idempotent, while an out-of-order earlier authoritative verdict corrects the
+// durable evidence tuple without issuing capacity a second time.
+func (s *Store) QualifyProviderReferral(ctx context.Context, policy ReferralPolicy, providerID, evidenceID string, servedAt, qualifiedAt time.Time) (ProviderReferral, bool, error) {
+	if err := policy.Validate(); err != nil {
+		return ProviderReferral{}, false, err
+	}
+	evidenceID = strings.TrimSpace(evidenceID)
+	if err := config.ValidateProviderID(providerID); err != nil || !socialEvidenceIDPattern.MatchString(evidenceID) || servedAt.IsZero() || qualifiedAt.IsZero() {
+		return ProviderReferral{}, false, ErrReferralInvalid
+	}
+	servedAt = servedAt.UTC()
+	qualifiedAt = qualifiedAt.UTC()
+	if servedAt.After(qualifiedAt) {
+		return ProviderReferral{}, false, ErrReferralInvalid
+	}
+
+	created := false
+	err := sqliteutil.Transact(ctx, s.db, func(ctx context.Context, conn *sql.Conn) error {
+		var existingEvidence, existingAt, existingIssuer string
+		err := conn.QueryRowContext(ctx, `
+SELECT evidence_id, evidence_at, issuer_id
+  FROM referral_serving_qualifications
+ WHERE campaign = ? AND provider_id = ?`, policy.Campaign, providerID).Scan(&existingEvidence, &existingAt, &existingIssuer)
+		if err == nil {
+			if existingEvidence == evidenceID {
+				return nil
+			}
+			durableAt, parseErr := time.Parse(time.RFC3339, existingAt)
+			if parseErr != nil {
+				return parseErr
+			}
+			if servedAt.After(durableAt) || (servedAt.Equal(durableAt) && evidenceID >= existingEvidence) {
+				return nil
+			}
+			result, updateErr := conn.ExecContext(ctx, `
+UPDATE referral_serving_qualifications
+   SET evidence_id = ?, evidence_at = ?
+ WHERE campaign = ? AND provider_id = ? AND evidence_id = ? AND evidence_at = ?`,
+				evidenceID, timeText(servedAt), policy.Campaign, providerID, existingEvidence, existingAt)
+			if isConstraintFailure(updateErr) {
+				return ErrReferralQualificationConflict
+			}
+			if updateErr != nil {
+				return updateErr
+			}
+			changed, updateErr := result.RowsAffected()
+			if updateErr != nil || changed != 1 {
+				return ErrReferralQualificationConflict
+			}
+			if _, updateErr = conn.ExecContext(ctx, `UPDATE referral_issuers SET first_serving_at = ? WHERE issuer_id = ?`, timeText(servedAt), existingIssuer); updateErr != nil {
+				return updateErr
+			}
+			return recordSocialAuditTx(ctx, conn, policy.Campaign, providerID, existingIssuer, "serving_qualified", "corrected", hashSocialSubject(evidenceID), "earliest_authoritative_evidence", qualifiedAt)
+		}
+		if !errors.Is(err, sql.ErrNoRows) {
+			return err
+		}
+		var legacyIssuer string
+		err = conn.QueryRowContext(ctx, `SELECT issuer_id FROM referral_issuers WHERE campaign = ? AND provider_id = ?`, policy.Campaign, providerID).Scan(&legacyIssuer)
+		if err == nil {
+			return ErrReferralQualificationConflict
+		}
+		if !errors.Is(err, sql.ErrNoRows) {
+			return err
+		}
+		issuerID, err := randomReferralID()
+		if err != nil {
+			return err
+		}
+		_, err = conn.ExecContext(ctx, `
+INSERT INTO referral_issuers (
+    issuer_id, code_type, key_id, campaign, provider_id,
+    base_capacity, bonus_capacity, created_at, first_serving_at
+) VALUES (?, 'P', ?, ?, ?, ?, 0, ?, ?)`,
+			issuerID, policy.CurrentKeyID, policy.Campaign, providerID,
+			policy.ProviderBaseUses, timeText(qualifiedAt), timeText(servedAt))
+		if err != nil {
+			return err
+		}
+		_, err = conn.ExecContext(ctx, `
+INSERT INTO referral_serving_qualifications (
+    campaign, provider_id, evidence_id, evidence_at, qualified_at, issuer_id
+) VALUES (?, ?, ?, ?, ?, ?)`,
+			policy.Campaign, providerID, evidenceID, timeText(servedAt), timeText(qualifiedAt), issuerID)
+		if isConstraintFailure(err) {
+			return ErrReferralQualificationConflict
+		}
+		if err != nil {
+			return err
+		}
+		if err := recordSocialAuditTx(ctx, conn, policy.Campaign, providerID, issuerID, "serving_qualified", "accepted", hashSocialSubject(evidenceID), "authoritative_evidence", qualifiedAt); err != nil {
+			return err
+		}
+		created = true
+		return nil
+	})
+	if err != nil {
+		return ProviderReferral{}, false, err
+	}
+	status, err := s.ProviderReferralStatus(ctx, policy, providerID)
+	return status, created, err
+}
+
+func (s *Store) ProviderReferralStatus(ctx context.Context, policy ReferralPolicy, providerID string) (ProviderReferral, error) {
+	if err := policy.Validate(); err != nil {
+		return ProviderReferral{}, err
+	}
+	if err := config.ValidateProviderID(providerID); err != nil {
+		return ProviderReferral{}, ErrReferralInvalid
+	}
+
+	out := ProviderReferral{Campaign: policy.Campaign, SocialState: SocialStateLocked}
+	var keyID, evidenceAt string
+	var carriedRedemptions int
+	var revokedAt sql.NullString
+	err := s.db.QueryRowContext(ctx, `
+SELECT i.issuer_id, i.key_id, i.base_capacity, i.bonus_capacity, i.carried_redemptions, q.evidence_at, i.revoked_at
+  FROM referral_serving_qualifications q
+  JOIN referral_issuers i ON i.issuer_id = q.issuer_id
+ WHERE q.provider_id = ? AND q.campaign = ?`, providerID, policy.Campaign).Scan(
+		&out.IssuerID, &keyID, &out.BaseCapacity, &out.BonusCapacity, &carriedRedemptions, &evidenceAt, &revokedAt)
+	if errors.Is(err, sql.ErrNoRows) {
+		return out, ErrReferralLocked
+	}
+	if err != nil {
+		return ProviderReferral{}, err
+	}
+	out.FirstServingSeen = strings.TrimSpace(evidenceAt) != ""
+	if revokedAt.Valid {
+		out.SocialState = SocialStateRevoked
+		out.Revoked = true
+		return out, nil
+	}
+	if err := s.db.QueryRowContext(ctx, `SELECT COUNT(1) FROM referral_redemptions WHERE issuer_id = ?`, out.IssuerID).Scan(&out.Redemptions); err != nil {
+		return ProviderReferral{}, err
+	}
+	out.Redemptions += carriedRedemptions
+	out.Remaining = out.BaseCapacity + out.BonusCapacity - out.Redemptions
+	if out.Remaining < 0 {
+		out.Remaining = 0
+	}
+	out.Code, err = EncodeReferralCode(policy, ReferralTypeProvider, keyID, out.IssuerID)
+	if err != nil {
+		return ProviderReferral{}, err
+	}
+
+	var grantedAt, failedAt sql.NullString
+	err = s.db.QueryRowContext(ctx, `
+SELECT granted_at, failed_at FROM referral_social_verifications
+ WHERE provider_id = ? AND campaign = ?`, providerID, policy.Campaign).Scan(&grantedAt, &failedAt)
+	switch {
+	case errors.Is(err, sql.ErrNoRows):
+		out.SocialState = SocialStateEligible
+	case err != nil:
+		return ProviderReferral{}, err
+	case grantedAt.Valid:
+		out.SocialState = SocialStateMatured
+	case failedAt.Valid:
+		out.SocialState = SocialStateFailed
+	default:
+		out.SocialState = SocialStatePending
+	}
+	return out, nil
+}
+
+// ConsumeSocialRateLimit atomically consumes a provider/action slot in a
+// durable fixed window. Denials are committed and audited, so process restarts
+// and multiple coordinator instances cannot reset the provider limit.
+func (s *Store) ConsumeSocialRateLimit(ctx context.Context, policy ReferralPolicy, providerID, action string, now time.Time, window time.Duration, limit int) (bool, error) {
+	if err := policy.Validate(); err != nil {
+		return false, err
+	}
+	action = strings.TrimSpace(action)
+	if err := config.ValidateProviderID(providerID); err != nil || !socialActionPattern.MatchString(action) || now.IsZero() || window <= 0 || limit <= 0 {
+		return false, ErrReferralInvalid
+	}
+	windowSeconds := int64(window / time.Second)
+	if windowSeconds <= 0 {
+		return false, ErrReferralInvalid
+	}
+	startedAt := time.Unix((now.UTC().Unix()/windowSeconds)*windowSeconds, 0).UTC()
+	allowed := false
+	err := sqliteutil.Transact(ctx, s.db, func(ctx context.Context, conn *sql.Conn) error {
+		if _, err := conn.ExecContext(ctx, `
+DELETE FROM referral_social_rate_windows
+ WHERE campaign = ? AND provider_id = ? AND action = ? AND window_started_at < ?`,
+			policy.Campaign, providerID, action, timeText(now.UTC().Add(-24*time.Hour))); err != nil {
+			return err
+		}
+		var issuerID sql.NullString
+		_ = conn.QueryRowContext(ctx, `SELECT issuer_id FROM referral_serving_qualifications WHERE campaign = ? AND provider_id = ?`, policy.Campaign, providerID).Scan(&issuerID)
+		result, err := conn.ExecContext(ctx, `
+INSERT INTO referral_social_rate_windows (campaign, provider_id, action, window_started_at, request_count)
+VALUES (?, ?, ?, ?, 1)
+ON CONFLICT(campaign, provider_id, action, window_started_at) DO UPDATE
+   SET request_count = request_count + 1
+ WHERE request_count < ?`, policy.Campaign, providerID, action, timeText(startedAt), limit)
+		if err != nil {
+			return err
+		}
+		changed, err := result.RowsAffected()
+		if err != nil {
+			return err
+		}
+		allowed = changed == 1
+		if !allowed {
+			return recordSocialAuditTx(ctx, conn, policy.Campaign, providerID, issuerID.String, "rate_limit", "denied", hashSocialSubject(action+"|"+timeText(startedAt)), action, now)
+		}
+		return nil
+	})
+	return allowed, err
+}
+
+func (s *Store) CreateSocialChallenge(ctx context.Context, policy ReferralPolicy, providerID string, now time.Time) (SocialChallenge, error) {
+	if err := policy.Validate(); err != nil {
+		return SocialChallenge{}, err
+	}
+	if !policy.EnableSocialBonus {
+		return SocialChallenge{}, ErrSocialDisabled
+	}
+	if err := config.ValidateProviderID(providerID); err != nil || now.IsZero() {
+		return SocialChallenge{}, ErrSocialChallenge
+	}
+	cleartext, err := randomHex(32)
+	if err != nil {
+		return SocialChallenge{}, err
+	}
+	digest := sha256.Sum256([]byte(cleartext))
+	digestText := fmt.Sprintf("%x", digest[:])
+	expiresAt := now.UTC().Add(policy.ChallengeTTL)
+	var code string
+	err = sqliteutil.Transact(ctx, s.db, func(ctx context.Context, conn *sql.Conn) error {
+		var issuerID, keyID string
+		if err := conn.QueryRowContext(ctx, `
+SELECT i.issuer_id, i.key_id
+  FROM referral_serving_qualifications q
+  JOIN referral_issuers i ON i.issuer_id = q.issuer_id
+ WHERE q.provider_id = ? AND q.campaign = ? AND i.code_type = 'P' AND i.revoked_at IS NULL`, providerID, policy.Campaign).Scan(&issuerID, &keyID); err != nil {
+			if errors.Is(err, sql.ErrNoRows) {
+				return ErrReferralLocked
+			}
+			return err
+		}
+		var grantedAt, failedAt sql.NullString
+		err := conn.QueryRowContext(ctx, `SELECT granted_at, failed_at FROM referral_social_verifications WHERE provider_id = ? AND campaign = ?`, providerID, policy.Campaign).Scan(&grantedAt, &failedAt)
+		switch {
+		case errors.Is(err, sql.ErrNoRows):
+		case err != nil:
+			return err
+		case grantedAt.Valid || !failedAt.Valid:
+			return ErrSocialChallenge
+		default:
+			if err := archiveFailedVerificationTx(ctx, conn, providerID, policy.Campaign, now); err != nil {
+				return err
+			}
+		}
+		if _, err := conn.ExecContext(ctx, `DELETE FROM referral_social_challenges WHERE provider_id = ? AND campaign = ?`, providerID, policy.Campaign); err != nil {
+			return err
+		}
+		if _, err := conn.ExecContext(ctx, `
+INSERT INTO referral_social_challenges (challenge_hash, provider_id, campaign, issuer_id, created_at, expires_at)
+VALUES (?, ?, ?, ?, ?, ?)`, digestText, providerID, policy.Campaign, issuerID, timeText(now.UTC()), timeText(expiresAt)); err != nil {
+			return err
+		}
+		if err := recordSocialAuditTx(ctx, conn, policy.Campaign, providerID, issuerID, "challenge", "created", digestText, "", now); err != nil {
+			return err
+		}
+		code, err = EncodeReferralCode(policy, ReferralTypeProvider, keyID, issuerID)
+		return err
+	})
+	if err != nil {
+		return SocialChallenge{}, err
+	}
+	return SocialChallenge{Cleartext: cleartext, ExpiresAt: expiresAt, Code: code}, nil
+}
+
+func archiveFailedVerificationTx(ctx context.Context, conn *sql.Conn, providerID, campaign string, now time.Time) error {
+	result, err := conn.ExecContext(ctx, `
+INSERT INTO referral_social_verification_history (
+    provider_id, campaign, issuer_id, challenge_hash, post_id, author_id, share_url_hash,
+    verification_method, submitted_at, pending_since, granted_at, failed_at, archived_at
+)
+SELECT provider_id, campaign, issuer_id, challenge_hash, post_id, author_id, share_url_hash,
+       verification_method, submitted_at, pending_since, granted_at, failed_at, ?
+  FROM referral_social_verifications
+ WHERE provider_id = ? AND campaign = ? AND failed_at IS NOT NULL`, timeText(now.UTC()), providerID, campaign)
+	if err != nil {
+		return err
+	}
+	changed, err := result.RowsAffected()
+	if err != nil || changed != 1 {
+		return ErrSocialChallenge
+	}
+	result, err = conn.ExecContext(ctx, `DELETE FROM referral_social_verifications WHERE provider_id = ? AND campaign = ? AND failed_at IS NOT NULL`, providerID, campaign)
+	if err != nil {
+		return err
+	}
+	changed, err = result.RowsAffected()
+	if err != nil || changed != 1 {
+		return ErrSocialChallenge
+	}
+	return nil
+}
+
+func (s *Store) ValidateSocialChallenge(ctx context.Context, policy ReferralPolicy, providerID, challenge string, now time.Time) error {
+	if err := policy.Validate(); err != nil {
+		return err
+	}
+	if !policy.EnableSocialBonus {
+		return ErrSocialDisabled
+	}
+	digest := sha256.Sum256([]byte(strings.TrimSpace(challenge)))
+	var expiresAt string
+	var consumedAt sql.NullString
+	err := s.db.QueryRowContext(ctx, `
+SELECT c.expires_at, c.consumed_at
+  FROM referral_social_challenges c
+  JOIN referral_serving_qualifications q ON q.issuer_id = c.issuer_id AND q.provider_id = c.provider_id AND q.campaign = c.campaign
+  JOIN referral_issuers i ON i.issuer_id = q.issuer_id AND i.revoked_at IS NULL
+ WHERE c.challenge_hash = ? AND c.provider_id = ? AND c.campaign = ?`, fmt.Sprintf("%x", digest[:]), providerID, policy.Campaign).Scan(&expiresAt, &consumedAt)
+	if err != nil {
+		return ErrSocialChallenge
+	}
+	expires, err := time.Parse(time.RFC3339, expiresAt)
+	if err != nil || consumedAt.Valid || !expires.After(now.UTC()) {
+		return ErrSocialChallenge
+	}
+	return nil
+}
+
+// PreflightSocialVerification authorizes a challenge before any external X
+// request. An exact response-loss retry is recovered from durable state and
+// audited without spending external verifier quota.
+func (s *Store) PreflightSocialVerification(ctx context.Context, policy ReferralPolicy, providerID, challenge, postID string, now time.Time) (ProviderReferral, bool, error) {
+	if err := policy.Validate(); err != nil {
+		return ProviderReferral{}, false, err
+	}
+	if !policy.EnableSocialBonus {
+		return ProviderReferral{}, false, ErrSocialDisabled
+	}
+	challenge = strings.TrimSpace(challenge)
+	postID = strings.TrimSpace(postID)
+	if err := config.ValidateProviderID(providerID); err != nil || len(challenge) != 64 || !socialPrincipalIDPattern.MatchString(postID) || now.IsZero() {
+		return ProviderReferral{}, false, ErrSocialChallenge
+	}
+	digest := sha256.Sum256([]byte(challenge))
+	digestText := fmt.Sprintf("%x", digest[:])
+	replayed := false
+	err := sqliteutil.Transact(ctx, s.db, func(ctx context.Context, conn *sql.Conn) error {
+		var issuerID, expiresAt string
+		var consumedAt sql.NullString
+		if err := conn.QueryRowContext(ctx, `
+SELECT c.issuer_id, c.expires_at, c.consumed_at
+  FROM referral_social_challenges c
+  JOIN referral_serving_qualifications q ON q.issuer_id = c.issuer_id AND q.provider_id = c.provider_id AND q.campaign = c.campaign
+  JOIN referral_issuers i ON i.issuer_id = q.issuer_id AND i.revoked_at IS NULL
+ WHERE c.challenge_hash = ? AND c.provider_id = ? AND c.campaign = ?`, digestText, providerID, policy.Campaign).Scan(&issuerID, &expiresAt, &consumedAt); err != nil {
+			return ErrSocialChallenge
+		}
+		if consumedAt.Valid {
+			var storedIssuer, storedChallenge, storedPost string
+			err := conn.QueryRowContext(ctx, `
+SELECT issuer_id, challenge_hash, post_id
+  FROM referral_social_verifications
+ WHERE provider_id = ? AND campaign = ?`, providerID, policy.Campaign).Scan(&storedIssuer, &storedChallenge, &storedPost)
+			if err != nil || storedIssuer != issuerID || storedChallenge != digestText || storedPost != postID {
+				return ErrSocialChallenge
+			}
+			replayed = true
+			return recordSocialAuditTx(ctx, conn, policy.Campaign, providerID, issuerID, "submission", "replayed", hashSocialSubject(postID), "response_loss_recovery", now)
+		}
+		expires, err := time.Parse(time.RFC3339, expiresAt)
+		if err != nil || !expires.After(now.UTC()) {
+			return ErrSocialChallenge
+		}
+		return nil
+	})
+	if err != nil {
+		return ProviderReferral{}, false, err
+	}
+	if !replayed {
+		return ProviderReferral{}, false, nil
+	}
+	status, err := s.ProviderReferralStatus(ctx, policy, providerID)
+	return status, true, err
+}
+
+func (s *Store) CompleteSocialVerification(ctx context.Context, policy ReferralPolicy, providerID, challenge, postID, authorID, shareURLHash, method string, now time.Time) (ProviderReferral, error) {
+	if err := policy.Validate(); err != nil {
+		return ProviderReferral{}, err
+	}
+	if !policy.EnableSocialBonus {
+		return ProviderReferral{}, ErrSocialDisabled
+	}
+	postID = strings.TrimSpace(postID)
+	authorID = strings.TrimSpace(authorID)
+	shareURLHash = strings.TrimSpace(shareURLHash)
+	method = strings.TrimSpace(method)
+	if !socialPrincipalIDPattern.MatchString(postID) || !socialPrincipalIDPattern.MatchString(authorID) || !socialShareURLHashPattern.MatchString(shareURLHash) || method != "x_api" || now.IsZero() {
+		return ProviderReferral{}, ErrSocialChallenge
+	}
+	digest := sha256.Sum256([]byte(strings.TrimSpace(challenge)))
+	digestText := fmt.Sprintf("%x", digest[:])
+	err := sqliteutil.Transact(ctx, s.db, func(ctx context.Context, conn *sql.Conn) error {
+		var issuerID, expiresAt string
+		var consumedAt sql.NullString
+		if err := conn.QueryRowContext(ctx, `
+SELECT c.issuer_id, c.expires_at, c.consumed_at
+  FROM referral_social_challenges c
+  JOIN referral_serving_qualifications q ON q.issuer_id = c.issuer_id AND q.provider_id = c.provider_id AND q.campaign = c.campaign
+  JOIN referral_issuers i ON i.issuer_id = q.issuer_id AND i.revoked_at IS NULL
+ WHERE c.challenge_hash = ? AND c.provider_id = ? AND c.campaign = ?`, digestText, providerID, policy.Campaign).Scan(&issuerID, &expiresAt, &consumedAt); err != nil {
+			return ErrSocialChallenge
+		}
+		if consumedAt.Valid {
+			var storedIssuer, storedChallenge, storedPost, storedAuthor, storedShare, storedMethod string
+			err := conn.QueryRowContext(ctx, `
+SELECT issuer_id, challenge_hash, post_id, author_id, share_url_hash, verification_method
+  FROM referral_social_verifications WHERE provider_id = ? AND campaign = ?`, providerID, policy.Campaign).Scan(&storedIssuer, &storedChallenge, &storedPost, &storedAuthor, &storedShare, &storedMethod)
+			if err == nil && storedIssuer == issuerID && storedChallenge == digestText && storedPost == postID && storedAuthor == authorID && storedShare == shareURLHash && storedMethod == method {
+				return recordSocialAuditTx(ctx, conn, policy.Campaign, providerID, issuerID, "submission", "replayed", hashSocialSubject(postID), "response_loss_recovery", now)
+			}
+			return ErrSocialChallenge
+		}
+		expires, err := time.Parse(time.RFC3339, expiresAt)
+		if err != nil || !expires.After(now.UTC()) {
+			return ErrSocialChallenge
+		}
+		var archivedPost bool
+		if err := conn.QueryRowContext(ctx, `SELECT EXISTS(SELECT 1 FROM referral_social_verification_history WHERE post_id = ?)`, postID).Scan(&archivedPost); err != nil {
+			return err
+		}
+		if archivedPost {
+			return ErrSocialChallenge
+		}
+		if _, err := conn.ExecContext(ctx, `
+INSERT INTO referral_social_verifications (
+    provider_id, campaign, issuer_id, challenge_hash, post_id, author_id, share_url_hash,
+    verification_method, submitted_at, pending_since, next_check_at
+) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`, providerID, policy.Campaign, issuerID, digestText, postID, authorID, shareURLHash, method, timeText(now.UTC()), timeText(now.UTC()), timeText(now.UTC().Add(policy.SocialVerificationDwell))); err != nil {
+			if isConstraintFailure(err) {
+				return ErrSocialChallenge
+			}
+			return err
+		}
+		result, err := conn.ExecContext(ctx, `UPDATE referral_social_challenges SET consumed_at = ? WHERE challenge_hash = ? AND consumed_at IS NULL`, timeText(now.UTC()), digestText)
+		if err != nil {
+			return err
+		}
+		changed, err := result.RowsAffected()
+		if err != nil || changed != 1 {
+			return ErrSocialChallenge
+		}
+		return recordSocialAuditTx(ctx, conn, policy.Campaign, providerID, issuerID, "submission", "accepted", hashSocialSubject(postID), "x_api", now)
+	})
+	if err != nil {
+		return ProviderReferral{}, err
+	}
+	return s.ProviderReferralStatus(ctx, policy, providerID)
+}
+
+type socialRecheckClaim struct {
+	providerID, issuerID, postID, authorID, shareURLHash, leaseToken string
+	attempts                                                         int
+}
+
+func (s *Store) PromoteMaturedSocialVerifications(ctx context.Context, policy ReferralPolicy, now time.Time, recheck func(context.Context, string, string, string) error) (int, error) {
+	if err := policy.Validate(); err != nil {
+		return 0, err
+	}
+	if !policy.EnableSocialBonus || recheck == nil {
+		return 0, nil
+	}
+	granted := 0
+	for range 64 {
+		claim, ok, err := s.claimSocialRecheck(ctx, policy, now)
+		if err != nil {
+			return granted, err
+		}
+		if !ok {
+			break
+		}
+		checkErr := recheck(ctx, claim.postID, claim.authorID, claim.shareURLHash)
+		wasGranted, err := s.finishSocialRecheck(ctx, policy, now, claim, checkErr)
+		if err != nil {
+			return granted, err
+		}
+		if wasGranted {
+			granted++
+		}
+	}
+	return granted, nil
+}
+
+func (s *Store) claimSocialRecheck(ctx context.Context, policy ReferralPolicy, now time.Time) (socialRecheckClaim, bool, error) {
+	var claim socialRecheckClaim
+	claimed := false
+	err := sqliteutil.Transact(ctx, s.db, func(ctx context.Context, conn *sql.Conn) error {
+		err := conn.QueryRowContext(ctx, `
+SELECT v.provider_id, v.issuer_id, v.post_id, v.author_id, v.share_url_hash, v.recheck_attempts
+  FROM referral_social_verifications v
+  JOIN referral_serving_qualifications q ON q.provider_id = v.provider_id AND q.campaign = v.campaign AND q.issuer_id = v.issuer_id
+  JOIN referral_issuers i ON i.issuer_id = v.issuer_id AND i.revoked_at IS NULL
+ WHERE v.campaign = ? AND v.granted_at IS NULL AND v.failed_at IS NULL
+   AND v.pending_since <= ? AND v.next_check_at <= ?
+   AND (v.lease_until IS NULL OR v.lease_until <= ?)
+ ORDER BY v.next_check_at, v.pending_since, v.provider_id LIMIT 1`, policy.Campaign, timeText(now.UTC().Add(-policy.SocialVerificationDwell)), timeText(now.UTC()), timeText(now.UTC())).Scan(&claim.providerID, &claim.issuerID, &claim.postID, &claim.authorID, &claim.shareURLHash, &claim.attempts)
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil
+		}
+		if err != nil {
+			return err
+		}
+		claim.leaseToken, err = randomHex(16)
+		if err != nil {
+			return err
+		}
+		result, err := conn.ExecContext(ctx, `
+UPDATE referral_social_verifications SET lease_token = ?, lease_until = ?
+ WHERE provider_id = ? AND campaign = ? AND issuer_id = ?
+   AND granted_at IS NULL AND failed_at IS NULL AND (lease_until IS NULL OR lease_until <= ?)`, claim.leaseToken, timeText(now.UTC().Add(socialRecheckLease)), claim.providerID, policy.Campaign, claim.issuerID, timeText(now.UTC()))
+		if err != nil {
+			return err
+		}
+		changed, err := result.RowsAffected()
+		if err != nil {
+			return err
+		}
+		if changed != 1 {
+			return nil
+		}
+		claimed = true
+		return recordSocialAuditTx(ctx, conn, policy.Campaign, claim.providerID, claim.issuerID, "recheck", "claimed", hashSocialSubject(claim.postID), "", now)
+	})
+	return claim, claimed, err
+}
+
+func (s *Store) finishSocialRecheck(ctx context.Context, policy ReferralPolicy, now time.Time, claim socialRecheckClaim, checkErr error) (bool, error) {
+	granted := false
+	err := sqliteutil.Transact(ctx, s.db, func(ctx context.Context, conn *sql.Conn) error {
+		if errors.Is(checkErr, ErrSocialRecheckTransient) {
+			backoff := socialRecheckBackoff(claim.attempts + 1)
+			result, err := conn.ExecContext(ctx, `
+UPDATE referral_social_verifications
+   SET recheck_attempts = recheck_attempts + 1, next_check_at = ?, lease_token = NULL, lease_until = NULL
+ WHERE provider_id = ? AND campaign = ? AND issuer_id = ? AND lease_token = ?
+   AND granted_at IS NULL AND failed_at IS NULL`, timeText(now.UTC().Add(backoff)), claim.providerID, policy.Campaign, claim.issuerID, claim.leaseToken)
+			if err != nil {
+				return err
+			}
+			changed, err := result.RowsAffected()
+			if err != nil || changed == 0 {
+				return err
+			}
+			return recordSocialAuditTx(ctx, conn, policy.Campaign, claim.providerID, claim.issuerID, "recheck", "transient", hashSocialSubject(claim.postID), "backoff", now)
+		}
+		if checkErr != nil {
+			result, err := conn.ExecContext(ctx, `
+UPDATE referral_social_verifications SET failed_at = ?, lease_token = NULL, lease_until = NULL
+ WHERE provider_id = ? AND campaign = ? AND issuer_id = ? AND lease_token = ?
+   AND granted_at IS NULL AND failed_at IS NULL`, timeText(now.UTC()), claim.providerID, policy.Campaign, claim.issuerID, claim.leaseToken)
+			if err != nil {
+				return err
+			}
+			changed, err := result.RowsAffected()
+			if err != nil || changed == 0 {
+				return err
+			}
+			return recordSocialAuditTx(ctx, conn, policy.Campaign, claim.providerID, claim.issuerID, "recheck", "terminal", hashSocialSubject(claim.postID), "external_rejection", now)
+		}
+
+		result, err := conn.ExecContext(ctx, `
+INSERT INTO referral_social_grants (campaign, provider_id, bonus_kind, issuer_id, verification_post_hash, amount, granted_at)
+SELECT ?, ?, ?, ?, ?, ?, ?
+ WHERE EXISTS (
+       SELECT 1 FROM referral_social_verifications
+        WHERE provider_id = ? AND campaign = ? AND issuer_id = ? AND lease_token = ?
+          AND granted_at IS NULL AND failed_at IS NULL
+   )
+   AND EXISTS (
+       SELECT 1 FROM referral_serving_qualifications q
+       JOIN referral_issuers i ON i.issuer_id = q.issuer_id
+        WHERE q.provider_id = ? AND q.campaign = ? AND q.issuer_id = ? AND i.revoked_at IS NULL
+   )
+ON CONFLICT(campaign, provider_id, bonus_kind) DO NOTHING`, policy.Campaign, claim.providerID, socialGrantKind, claim.issuerID, hashSocialSubject(claim.postID), policy.SocialBonusUses, timeText(now.UTC()), claim.providerID, policy.Campaign, claim.issuerID, claim.leaseToken, claim.providerID, policy.Campaign, claim.issuerID)
+		if err != nil {
+			return err
+		}
+		inserted, err := result.RowsAffected()
+		if err != nil {
+			return err
+		}
+		if inserted == 0 {
+			return nil
+		}
+		result, err = conn.ExecContext(ctx, `UPDATE referral_issuers SET bonus_capacity = bonus_capacity + ? WHERE issuer_id = ? AND provider_id = ? AND campaign = ? AND revoked_at IS NULL`, policy.SocialBonusUses, claim.issuerID, claim.providerID, policy.Campaign)
+		if err != nil {
+			return err
+		}
+		changed, err := result.RowsAffected()
+		if err != nil || changed != 1 {
+			return fmt.Errorf("social issuer changed during grant")
+		}
+		result, err = conn.ExecContext(ctx, `
+UPDATE referral_social_verifications SET granted_at = ?, lease_token = NULL, lease_until = NULL
+ WHERE provider_id = ? AND campaign = ? AND issuer_id = ? AND lease_token = ?
+   AND granted_at IS NULL AND failed_at IS NULL`, timeText(now.UTC()), claim.providerID, policy.Campaign, claim.issuerID, claim.leaseToken)
+		if err != nil {
+			return err
+		}
+		changed, err = result.RowsAffected()
+		if err != nil || changed != 1 {
+			return fmt.Errorf("social verification changed during grant")
+		}
+		if err := recordSocialAuditTx(ctx, conn, policy.Campaign, claim.providerID, claim.issuerID, "bonus", "granted", hashSocialSubject(claim.postID), socialGrantKind, now); err != nil {
+			return err
+		}
+		granted = true
+		return nil
+	})
+	return granted, err
+}
+
+func socialRecheckBackoff(attempt int) time.Duration {
+	if attempt < 1 {
+		attempt = 1
+	}
+	d := socialRecheckBaseBackoff
+	for i := 1; i < attempt && d < socialRecheckMaxBackoff; i++ {
+		d *= 2
+		if d > socialRecheckMaxBackoff {
+			d = socialRecheckMaxBackoff
+		}
+	}
+	return d
+}
+
+// RecordSocialAudit records a redacted externally classified decision. Raw
+// challenge text, share URLs, bearers, and external response bodies are never
+// persisted; identifiers are reduced to a one-way subject digest.
+func (s *Store) RecordSocialAudit(ctx context.Context, policy ReferralPolicy, providerID, challenge, postID, authorID, eventKind, outcome, reason string, now time.Time) error {
+	if err := policy.Validate(); err != nil {
+		return err
+	}
+	eventKind = strings.TrimSpace(eventKind)
+	outcome = strings.TrimSpace(outcome)
+	reason = strings.TrimSpace(reason)
+	if err := config.ValidateProviderID(providerID); err != nil || !socialAuditTokenPattern.MatchString(eventKind) || !socialAuditTokenPattern.MatchString(outcome) || (reason != "" && !socialAuditTokenPattern.MatchString(reason)) || now.IsZero() {
+		return ErrSocialChallenge
+	}
+	subject := strings.Join([]string{strings.TrimSpace(challenge), strings.TrimSpace(postID), strings.TrimSpace(authorID)}, "|")
+	return sqliteutil.Transact(ctx, s.db, func(ctx context.Context, conn *sql.Conn) error {
+		var issuerID sql.NullString
+		if err := conn.QueryRowContext(ctx, `SELECT issuer_id FROM referral_serving_qualifications WHERE campaign = ? AND provider_id = ?`, policy.Campaign, providerID).Scan(&issuerID); err != nil && !errors.Is(err, sql.ErrNoRows) {
+			return err
+		}
+		return recordSocialAuditTx(ctx, conn, policy.Campaign, providerID, issuerID.String, eventKind, outcome, hashSocialSubject(subject), reason, now)
+	})
+}
+
+func recordSocialAuditTx(ctx context.Context, conn *sql.Conn, campaign, providerID, issuerID, eventKind, outcome, subjectHash, reason string, now time.Time) error {
+	_, err := conn.ExecContext(ctx, `
+INSERT INTO referral_social_audit (campaign, provider_id, issuer_id, event_kind, outcome, subject_hash, reason, created_at)
+VALUES (?, ?, NULLIF(?, ''), ?, ?, ?, ?, ?)`, campaign, providerID, issuerID, eventKind, outcome, subjectHash, reason, timeText(now.UTC()))
+	return err
+}
+
+func hashSocialSubject(value string) string {
+	digest := sha256.Sum256([]byte(value))
+	return fmt.Sprintf("%x", digest[:])
+}
+
+type ReferralReplacement struct {
+	ProviderID          string
+	OldIssuerID         string
+	OldBaseCapacity     int
+	OldBonusCapacity    int
+	Redeemed            int
+	Remaining           int
+	NewIssuerID         string
+	NewCode             string
+	KeyID               string
+	BaseCapacity        int
+	BonusCapacity       int
+	PendingSocialReview bool
+	Applied             bool
+}
+
+type ReferralReplacementExpectation struct {
+	ProviderID          string
+	OldBaseCapacity     int
+	OldBonusCapacity    int
+	Redeemed            int
+	PendingSocialReview bool
+}
+
+// ReplaceReferralIssuer replaces only an issuer backed by durable serving
+// qualification. The evidence timestamp is copied exactly; this operation can
+// never synthesize a provider's serving eligibility.
+func (s *Store) ReplaceReferralIssuer(ctx context.Context, policy ReferralPolicy, issuerID, actor, reason string, apply bool, now time.Time) (ReferralReplacement, error) {
+	if apply {
+		return ReferralReplacement{}, ErrReferralReplacementConflict
+	}
+	return s.ReplaceReferralIssuerExpected(ctx, policy, issuerID, actor, reason, nil, false, now)
+}
+
+// ReplaceReferralIssuerExpected binds an operator-approved preview to the same
+// transaction that replaces the issuer. No mutable capacity or pending-review
+// state can drift between the preview and the apply decision.
+func (s *Store) ReplaceReferralIssuerExpected(ctx context.Context, policy ReferralPolicy, issuerID, actor, reason string, expectation *ReferralReplacementExpectation, apply bool, now time.Time) (ReferralReplacement, error) {
+	if err := policy.Validate(); err != nil {
+		return ReferralReplacement{}, err
+	}
+	issuerID = strings.TrimSpace(issuerID)
+	actor = strings.TrimSpace(actor)
+	reason = strings.TrimSpace(reason)
+	if !referralPartPattern.MatchString(issuerID) {
+		return ReferralReplacement{}, ErrReferralInvalid
+	}
+	if apply && (actor == "" || reason == "") {
+		return ReferralReplacement{}, fmt.Errorf("actor and reason are required to replace an issuer")
+	}
+	if apply && expectation == nil {
+		return ReferralReplacement{}, ErrReferralReplacementConflict
+	}
+
+	var out ReferralReplacement
+	err := sqliteutil.Transact(ctx, s.db, func(ctx context.Context, conn *sql.Conn) error {
+		var codeType string
+		var providerID, revokedAt sql.NullString
+		var evidenceAt string
+		var carriedRedemptions int
+		if err := conn.QueryRowContext(ctx, `
+SELECT i.code_type, i.provider_id, i.revoked_at, i.base_capacity, i.bonus_capacity, i.carried_redemptions, q.evidence_at
+  FROM referral_issuers i
+  JOIN referral_serving_qualifications q ON q.issuer_id = i.issuer_id AND q.provider_id = i.provider_id AND q.campaign = i.campaign
+		 WHERE i.issuer_id = ? AND i.campaign = ?`, issuerID, policy.Campaign).Scan(&codeType, &providerID, &revokedAt, &out.OldBaseCapacity, &out.OldBonusCapacity, &carriedRedemptions, &evidenceAt); err != nil {
+			if errors.Is(err, sql.ErrNoRows) {
+				return ErrReferralInvalid
+			}
+			return err
+		}
+		if codeType != ReferralTypeProvider || !providerID.Valid || providerID.String == "" || !revokedAt.Valid || evidenceAt == "" {
+			return ErrReferralInvalid
+		}
+		if err := conn.QueryRowContext(ctx, `SELECT EXISTS(SELECT 1 FROM referral_social_verifications WHERE provider_id = ? AND campaign = ? AND granted_at IS NULL AND failed_at IS NULL)`, providerID.String, policy.Campaign).Scan(&out.PendingSocialReview); err != nil {
+			return err
+		}
+		out.ProviderID = providerID.String
+		out.OldIssuerID = issuerID
+		out.KeyID = policy.CurrentKeyID
+		out.BaseCapacity = out.OldBaseCapacity
+		out.BonusCapacity = out.OldBonusCapacity
+		if err := conn.QueryRowContext(ctx, `SELECT COUNT(1) FROM referral_redemptions WHERE issuer_id = ?`, issuerID).Scan(&out.Redeemed); err != nil {
+			return err
+		}
+		out.Redeemed += carriedRedemptions
+		out.Remaining = out.OldBaseCapacity + out.OldBonusCapacity - out.Redeemed
+		if out.Remaining < 0 {
+			return ErrReferralReplacementConflict
+		}
+		if apply && (expectation.ProviderID != out.ProviderID ||
+			expectation.OldBaseCapacity != out.OldBaseCapacity ||
+			expectation.OldBonusCapacity != out.OldBonusCapacity ||
+			expectation.Redeemed != out.Redeemed ||
+			expectation.PendingSocialReview != out.PendingSocialReview) {
+			return ErrReferralReplacementConflict
+		}
+		if !apply {
+			return nil
+		}
+
+		newIssuerID, err := randomReferralID()
+		if err != nil {
+			return err
+		}
+		result, err := conn.ExecContext(ctx, `UPDATE referral_issuers SET provider_id = NULL, replaced_by = ? WHERE issuer_id = ? AND campaign = ? AND revoked_at IS NOT NULL AND provider_id = ? AND replaced_by IS NULL`, newIssuerID, issuerID, policy.Campaign, providerID.String)
+		if err != nil {
+			return err
+		}
+		changed, err := result.RowsAffected()
+		if err != nil || changed != 1 {
+			return ErrReferralInvalid
+		}
+		if _, err := conn.ExecContext(ctx, `
+INSERT INTO referral_issuers (issuer_id, code_type, key_id, campaign, provider_id, base_capacity, bonus_capacity, carried_redemptions, created_at, first_serving_at)
+VALUES (?, 'P', ?, ?, ?, ?, ?, ?, ?, ?)`, newIssuerID, policy.CurrentKeyID, policy.Campaign, providerID.String, out.OldBaseCapacity, out.OldBonusCapacity, out.Redeemed, timeText(now.UTC()), evidenceAt); err != nil {
+			return err
+		}
+		result, err = conn.ExecContext(ctx, `UPDATE referral_serving_qualifications SET issuer_id = ? WHERE campaign = ? AND provider_id = ? AND issuer_id = ?`, newIssuerID, policy.Campaign, providerID.String, issuerID)
+		if err != nil {
+			return err
+		}
+		changed, err = result.RowsAffected()
+		if err != nil || changed != 1 {
+			return ErrReferralQualificationConflict
+		}
+		if _, err := conn.ExecContext(ctx, `UPDATE referral_social_verifications SET issuer_id = ?, lease_token = NULL, lease_until = NULL, next_check_at = ? WHERE provider_id = ? AND campaign = ? AND issuer_id = ?`, newIssuerID, timeText(now.UTC()), providerID.String, policy.Campaign, issuerID); err != nil {
+			return err
+		}
+		if _, err := conn.ExecContext(ctx, `UPDATE referral_social_challenges SET issuer_id = ? WHERE provider_id = ? AND campaign = ? AND issuer_id = ?`, newIssuerID, providerID.String, policy.Campaign, issuerID); err != nil {
+			return err
+		}
+		code, err := EncodeReferralCode(policy, ReferralTypeProvider, policy.CurrentKeyID, newIssuerID)
+		if err != nil {
+			return err
+		}
+		detail := fmt.Sprintf("provider=%s replaced_by=%s base_capacity=%d bonus_capacity=%d redeemed=%d remaining=%d pending_social=%t", providerID.String, newIssuerID, out.OldBaseCapacity, out.OldBonusCapacity, out.Redeemed, out.Remaining, out.PendingSocialReview)
+		if err := recordReferralAdminAuditTx(ctx, conn, actor, reason, "replace_issuer", policy.Campaign+"/"+issuerID, detail, now); err != nil {
+			return err
+		}
+		if err := recordSocialAuditTx(ctx, conn, policy.Campaign, providerID.String, newIssuerID, "issuer", "replaced", hashSocialSubject(issuerID), "operator_recovery", now); err != nil {
+			return err
+		}
+		out.NewIssuerID = newIssuerID
+		out.NewCode = code
+		out.Applied = true
+		return nil
+	})
+	if err != nil {
+		return ReferralReplacement{}, err
+	}
+	return out, nil
+}
+
+func randomReferralID() (string, error) {
+	var raw [10]byte
+	if _, err := rand.Read(raw[:]); err != nil {
+		return "", err
+	}
+	return strings.ToLower(referralEncoder.EncodeToString(raw[:])), nil
+}

--- a/phase4-coordinator/internal/auth/referrals_social_test.go
+++ b/phase4-coordinator/internal/auth/referrals_social_test.go
@@ -1,0 +1,464 @@
+package auth
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"path/filepath"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+var testSocialShareURLHash = strings.Repeat("a", 64)
+
+func socialReferralPolicy() ReferralPolicy {
+	policy := coreReferralPolicy()
+	policy.EnableSocialBonus = true
+	policy.SocialBonusUses = 2
+	policy.ChallengeTTL = 15 * time.Minute
+	policy.SocialVerificationDwell = 30 * time.Minute
+	return policy
+}
+
+func openSocialStoreAt(t *testing.T, path string) *Store {
+	t.Helper()
+	store, err := OpenStore(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+	return store
+}
+
+func openSocialStore(t *testing.T) *Store {
+	t.Helper()
+	return openSocialStoreAt(t, filepath.Join(t.TempDir(), "coordinator.db"))
+}
+
+func qualifyProvider(t *testing.T, store *Store, policy ReferralPolicy, providerID string, now time.Time) ProviderReferral {
+	t.Helper()
+	status, created, err := store.QualifyProviderReferral(context.Background(), policy, providerID, "settlement:"+providerID, now.Add(-time.Minute), now)
+	if err != nil || !created {
+		t.Fatalf("qualify status=%+v created=%t err=%v", status, created, err)
+	}
+	return status
+}
+
+func createPendingSocialVerification(t *testing.T, store *Store, policy ReferralPolicy, providerID, postID string, now time.Time) (ProviderReferral, SocialChallenge) {
+	t.Helper()
+	qualifyProvider(t, store, policy, providerID, now.Add(-time.Minute))
+	challenge, err := store.CreateSocialChallenge(context.Background(), policy, providerID, now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	status, err := store.CompleteSocialVerification(context.Background(), policy, providerID, challenge.Cleartext, postID, "456", testSocialShareURLHash, "x_api", now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return status, challenge
+}
+
+func TestQualificationIsAtomicIdempotentConcurrentAndDurable(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "coordinator.db")
+	first := openSocialStoreAt(t, path)
+	second := openSocialStoreAt(t, path)
+	policy := socialReferralPolicy()
+	now := time.Date(2026, 7, 13, 10, 0, 0, 0, time.UTC)
+	providerID := "provider-qualified"
+
+	locked, err := first.ProviderReferralStatus(context.Background(), policy, providerID)
+	if !errors.Is(err, ErrReferralLocked) || locked.Code != "" {
+		t.Fatalf("locked=%+v err=%v", locked, err)
+	}
+
+	type result struct {
+		status  ProviderReferral
+		created bool
+		err     error
+	}
+	start := make(chan struct{})
+	results := make(chan result, 2)
+	for i, store := range []*Store{first, second} {
+		i, store := i, store
+		go func() {
+			<-start
+			status, created, err := store.QualifyProviderReferral(context.Background(), policy, providerID, fmt.Sprintf("settlement-%d", i), now.Add(-time.Minute), now)
+			results <- result{status, created, err}
+		}()
+	}
+	close(start)
+	createdCount := 0
+	var issuerID string
+	for range 2 {
+		got := <-results
+		if got.err != nil {
+			t.Fatal(got.err)
+		}
+		if got.created {
+			createdCount++
+		}
+		if issuerID == "" {
+			issuerID = got.status.IssuerID
+		} else if got.status.IssuerID != issuerID {
+			t.Fatalf("issuer drift: %q != %q", got.status.IssuerID, issuerID)
+		}
+	}
+	if createdCount != 1 {
+		t.Fatalf("created count=%d, want 1", createdCount)
+	}
+	var qualificationRows, issuerRows, acceptedAudits, correctedAudits int
+	var winningEvidence string
+	if err := first.db.QueryRow(`SELECT COUNT(1), evidence_id FROM referral_serving_qualifications WHERE campaign = ? AND provider_id = ?`, policy.Campaign, providerID).Scan(&qualificationRows, &winningEvidence); err != nil {
+		t.Fatal(err)
+	}
+	if err := first.db.QueryRow(`SELECT COUNT(1) FROM referral_issuers WHERE campaign = ? AND issuer_id = ?`, policy.Campaign, issuerID).Scan(&issuerRows); err != nil {
+		t.Fatal(err)
+	}
+	if err := first.db.QueryRow(`SELECT COUNT(1) FROM referral_social_audit WHERE event_kind = 'serving_qualified' AND outcome = 'accepted' AND provider_id = ?`, providerID).Scan(&acceptedAudits); err != nil {
+		t.Fatal(err)
+	}
+	if err := first.db.QueryRow(`SELECT COUNT(1) FROM referral_social_audit WHERE event_kind = 'serving_qualified' AND outcome = 'corrected' AND provider_id = ?`, providerID).Scan(&correctedAudits); err != nil {
+		t.Fatal(err)
+	}
+	if qualificationRows != 1 || issuerRows != 1 || acceptedAudits != 1 || correctedAudits > 1 || winningEvidence != "settlement-0" {
+		t.Fatalf("qualification=%d issuer=%d accepted=%d corrected=%d evidence=%q", qualificationRows, issuerRows, acceptedAudits, correctedAudits, winningEvidence)
+	}
+
+	if err := first.Close(); err != nil {
+		t.Fatal(err)
+	}
+	reopened := openSocialStoreAt(t, path)
+	status, created, err := reopened.QualifyProviderReferral(context.Background(), policy, providerID, "later-settlement", now, now.Add(time.Hour))
+	if err != nil || created || status.IssuerID != issuerID {
+		t.Fatalf("reopen retry status=%+v created=%t err=%v", status, created, err)
+	}
+	if _, _, err := reopened.QualifyProviderReferral(context.Background(), policy, "other-provider", winningEvidence, now, now.Add(time.Hour)); !errors.Is(err, ErrReferralQualificationConflict) {
+		t.Fatalf("reused evidence err=%v", err)
+	}
+}
+
+func TestQualificationRejectsLegacyUnsourcedIssuer(t *testing.T) {
+	store := openSocialStore(t)
+	policy := socialReferralPolicy()
+	now := time.Date(2026, 7, 13, 10, 0, 0, 0, time.UTC)
+	_, err := store.db.Exec(`INSERT INTO referral_issuers (issuer_id, code_type, key_id, campaign, provider_id, base_capacity, bonus_capacity, created_at, first_serving_at) VALUES ('legacy', 'P', ?, ?, 'legacy-provider', 1, 0, ?, ?)`, policy.CurrentKeyID, policy.Campaign, timeText(now), timeText(now))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := store.QualifyProviderReferral(context.Background(), policy, "legacy-provider", "receipt-legacy", now, now); !errors.Is(err, ErrReferralQualificationConflict) {
+		t.Fatalf("legacy qualification err=%v", err)
+	}
+	if _, err := store.ProviderReferralStatus(context.Background(), policy, "legacy-provider"); !errors.Is(err, ErrReferralLocked) {
+		t.Fatalf("legacy status err=%v", err)
+	}
+}
+
+func TestSocialSubmissionReplayRecoversExactResponse(t *testing.T) {
+	store := openSocialStore(t)
+	policy := socialReferralPolicy()
+	now := time.Date(2026, 7, 13, 10, 0, 0, 0, time.UTC)
+	providerID := "provider-replay"
+	qualifyProvider(t, store, policy, providerID, now.Add(-time.Minute))
+	challenge, err := store.CreateSocialChallenge(context.Background(), policy, providerID, now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	first, err := store.CompleteSocialVerification(context.Background(), policy, providerID, challenge.Cleartext, "123", "456", testSocialShareURLHash, "x_api", now)
+	if err != nil || first.SocialState != SocialStatePending {
+		t.Fatalf("first=%+v err=%v", first, err)
+	}
+	replayed, err := store.CompleteSocialVerification(context.Background(), policy, providerID, challenge.Cleartext, "123", "456", testSocialShareURLHash, "x_api", now.Add(time.Second))
+	if err != nil || replayed.IssuerID != first.IssuerID || replayed.SocialState != SocialStatePending {
+		t.Fatalf("replayed=%+v err=%v", replayed, err)
+	}
+	if _, err := store.CompleteSocialVerification(context.Background(), policy, providerID, challenge.Cleartext, "124", "456", testSocialShareURLHash, "x_api", now.Add(time.Second)); !errors.Is(err, ErrSocialChallenge) {
+		t.Fatalf("mismatched replay err=%v", err)
+	}
+	var accepted, replayEvents int
+	if err := store.db.QueryRow(`SELECT COUNT(1) FROM referral_social_audit WHERE provider_id = ? AND event_kind = 'submission' AND outcome = 'accepted'`, providerID).Scan(&accepted); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.db.QueryRow(`SELECT COUNT(1) FROM referral_social_audit WHERE provider_id = ? AND event_kind = 'submission' AND outcome = 'replayed'`, providerID).Scan(&replayEvents); err != nil {
+		t.Fatal(err)
+	}
+	if accepted != 1 || replayEvents != 1 {
+		t.Fatalf("accepted=%d replayed=%d", accepted, replayEvents)
+	}
+}
+
+func TestDurableSocialRateLimitSurvivesReopen(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "coordinator.db")
+	store := openSocialStoreAt(t, path)
+	policy := socialReferralPolicy()
+	now := time.Date(2026, 7, 13, 10, 7, 0, 0, time.UTC)
+	for i := 0; i < 2; i++ {
+		allowed, err := store.ConsumeSocialRateLimit(context.Background(), policy, "provider-rate", "verify", now, 15*time.Minute, 2)
+		if err != nil || !allowed {
+			t.Fatalf("attempt %d allowed=%t err=%v", i, allowed, err)
+		}
+	}
+	if err := store.Close(); err != nil {
+		t.Fatal(err)
+	}
+	reopened := openSocialStoreAt(t, path)
+	allowed, err := reopened.ConsumeSocialRateLimit(context.Background(), policy, "provider-rate", "verify", now.Add(time.Minute), 15*time.Minute, 2)
+	if err != nil || allowed {
+		t.Fatalf("denial allowed=%t err=%v", allowed, err)
+	}
+	allowed, err = reopened.ConsumeSocialRateLimit(context.Background(), policy, "provider-rate", "verify", now.Add(15*time.Minute), 15*time.Minute, 2)
+	if err != nil || !allowed {
+		t.Fatalf("next window allowed=%t err=%v", allowed, err)
+	}
+	var denied int
+	if err := reopened.db.QueryRow(`SELECT COUNT(1) FROM referral_social_audit WHERE provider_id = 'provider-rate' AND event_kind = 'rate_limit' AND outcome = 'denied'`).Scan(&denied); err != nil {
+		t.Fatal(err)
+	}
+	if denied != 1 {
+		t.Fatalf("denied audit=%d", denied)
+	}
+}
+
+func TestSocialAuditIsRedactedAndImmutable(t *testing.T) {
+	store := openSocialStore(t)
+	policy := socialReferralPolicy()
+	now := time.Date(2026, 7, 13, 10, 0, 0, 0, time.UTC)
+	rawChallenge := "never-persist-this-challenge"
+	if err := store.RecordSocialAudit(context.Background(), policy, "provider-audit", rawChallenge, "123", "456", "external_check", "rejected", "author_mismatch", now); err != nil {
+		t.Fatal(err)
+	}
+	var subject, reason string
+	if err := store.db.QueryRow(`SELECT subject_hash, reason FROM referral_social_audit WHERE provider_id = 'provider-audit'`).Scan(&subject, &reason); err != nil {
+		t.Fatal(err)
+	}
+	if subject == "" || strings.Contains(subject, rawChallenge) || reason != "author_mismatch" {
+		t.Fatalf("subject=%q reason=%q", subject, reason)
+	}
+	if _, err := store.db.Exec(`UPDATE referral_social_audit SET outcome = 'forged'`); err == nil {
+		t.Fatal("audit update unexpectedly succeeded")
+	}
+	if _, err := store.db.Exec(`DELETE FROM referral_social_audit`); err == nil {
+		t.Fatal("audit delete unexpectedly succeeded")
+	}
+}
+
+func TestTransientRecheckUsesDurableBackoffAndLeaseRecovery(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "coordinator.db")
+	store := openSocialStoreAt(t, path)
+	policy := socialReferralPolicy()
+	now := time.Date(2026, 7, 13, 10, 0, 0, 0, time.UTC)
+	createPendingSocialVerification(t, store, policy, "provider-backoff", "111", now)
+	mature := now.Add(policy.SocialVerificationDwell)
+	var calls atomic.Int32
+	transient := func(context.Context, string, string, string) error {
+		calls.Add(1)
+		return ErrSocialRecheckTransient
+	}
+	if granted, err := store.PromoteMaturedSocialVerifications(context.Background(), policy, mature, transient); err != nil || granted != 0 {
+		t.Fatalf("transient granted=%d err=%v", granted, err)
+	}
+	if granted, err := store.PromoteMaturedSocialVerifications(context.Background(), policy, mature.Add(30*time.Second), transient); err != nil || granted != 0 || calls.Load() != 1 {
+		t.Fatalf("backoff granted=%d calls=%d err=%v", granted, calls.Load(), err)
+	}
+	if err := store.Close(); err != nil {
+		t.Fatal(err)
+	}
+	reopened := openSocialStoreAt(t, path)
+	if granted, err := reopened.PromoteMaturedSocialVerifications(context.Background(), policy, mature.Add(time.Minute), func(context.Context, string, string, string) error { calls.Add(1); return nil }); err != nil || granted != 1 {
+		t.Fatalf("reopen grant=%d calls=%d err=%v", granted, calls.Load(), err)
+	}
+
+	createPendingSocialVerification(t, reopened, policy, "provider-lease", "222", now)
+	claim, ok, err := reopened.claimSocialRecheck(context.Background(), policy, mature)
+	if err != nil || !ok {
+		t.Fatalf("claim=%+v ok=%t err=%v", claim, ok, err)
+	}
+	other := openSocialStoreAt(t, path)
+	var leaseCalls atomic.Int32
+	if granted, err := other.PromoteMaturedSocialVerifications(context.Background(), policy, mature.Add(time.Minute), func(context.Context, string, string, string) error { leaseCalls.Add(1); return nil }); err != nil || granted != 0 || leaseCalls.Load() != 0 {
+		t.Fatalf("leased grant=%d calls=%d err=%v", granted, leaseCalls.Load(), err)
+	}
+	if granted, err := other.PromoteMaturedSocialVerifications(context.Background(), policy, mature.Add(socialRecheckLease), func(context.Context, string, string, string) error { leaseCalls.Add(1); return nil }); err != nil || granted != 1 || leaseCalls.Load() != 1 {
+		t.Fatalf("lease recovery grant=%d calls=%d err=%v", granted, leaseCalls.Load(), err)
+	}
+}
+
+func TestParallelPromotersGrantBonusExactlyOnce(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "coordinator.db")
+	first := openSocialStoreAt(t, path)
+	second := openSocialStoreAt(t, path)
+	policy := socialReferralPolicy()
+	now := time.Date(2026, 7, 13, 10, 0, 0, 0, time.UTC)
+	providerID := "provider-parallel"
+	createPendingSocialVerification(t, first, policy, providerID, "333", now)
+	mature := now.Add(policy.SocialVerificationDwell)
+
+	entered := make(chan struct{})
+	release := make(chan struct{})
+	var once sync.Once
+	recheck := func(context.Context, string, string, string) error {
+		once.Do(func() { close(entered) })
+		<-release
+		return nil
+	}
+	type result struct {
+		granted int
+		err     error
+	}
+	results := make(chan result, 2)
+	go func() {
+		granted, err := first.PromoteMaturedSocialVerifications(context.Background(), policy, mature, recheck)
+		results <- result{granted, err}
+	}()
+	<-entered
+	go func() {
+		granted, err := second.PromoteMaturedSocialVerifications(context.Background(), policy, mature, func(context.Context, string, string, string) error { return nil })
+		results <- result{granted, err}
+	}()
+	close(release)
+	total := 0
+	for range 2 {
+		got := <-results
+		if got.err != nil {
+			t.Fatal(got.err)
+		}
+		total += got.granted
+	}
+	if total != 1 {
+		t.Fatalf("total grants=%d", total)
+	}
+	status, err := first.ProviderReferralStatus(context.Background(), policy, providerID)
+	if err != nil || status.BonusCapacity != policy.SocialBonusUses || status.SocialState != SocialStateMatured {
+		t.Fatalf("status=%+v err=%v", status, err)
+	}
+	var grants, grantAudits int
+	if err := first.db.QueryRow(`SELECT COUNT(1) FROM referral_social_grants WHERE campaign = ? AND provider_id = ?`, policy.Campaign, providerID).Scan(&grants); err != nil {
+		t.Fatal(err)
+	}
+	if err := first.db.QueryRow(`SELECT COUNT(1) FROM referral_social_audit WHERE campaign = ? AND provider_id = ? AND event_kind = 'bonus' AND outcome = 'granted'`, policy.Campaign, providerID).Scan(&grantAudits); err != nil {
+		t.Fatal(err)
+	}
+	if grants != 1 || grantAudits != 1 {
+		t.Fatalf("grant rows=%d grant audits=%d", grants, grantAudits)
+	}
+	if _, err := first.db.Exec(`UPDATE referral_social_grants SET amount = amount + 1`); err == nil {
+		t.Fatal("grant update unexpectedly succeeded")
+	}
+	if _, err := first.db.Exec(`DELETE FROM referral_social_grants`); err == nil {
+		t.Fatal("grant delete unexpectedly succeeded")
+	}
+}
+
+func TestReplacementRequiresQualificationAndPreservesEvidenceTime(t *testing.T) {
+	store := openSocialStore(t)
+	policy := socialReferralPolicy()
+	policy.ProviderBaseUses = 3
+	ctx := context.Background()
+	now := time.Date(2026, 7, 13, 10, 0, 0, 0, time.UTC)
+	providerID := "provider-replacement"
+	qualified := qualifyProvider(t, store, policy, providerID, now)
+	if _, _, err := store.IssueTokenWithReferral(ctx, "referred-before-replacement", "host-before", qualified.Code, policy); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.RevokeReferralIssuerAudited(ctx, policy.Campaign, qualified.IssuerID, true, "ops", "rotate", &ReferralRevokeExpectation{Redeemed: 1}, now.Add(time.Minute)); err != nil {
+		t.Fatal(err)
+	}
+	replacementPolicy := policy
+	replacementPolicy.ProviderBaseUses = 1
+	preview, err := store.ReplaceReferralIssuer(ctx, replacementPolicy, qualified.IssuerID, "", "", false, now.Add(2*time.Minute))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if preview.Redeemed != 1 || preview.Remaining != 2 {
+		t.Fatalf("preview redeemed=%d remaining=%d", preview.Redeemed, preview.Remaining)
+	}
+	if _, err := store.ReplaceReferralIssuerExpected(ctx, replacementPolicy, qualified.IssuerID, "ops", "stale preview", &ReferralReplacementExpectation{
+		ProviderID:          preview.ProviderID,
+		OldBaseCapacity:     preview.OldBaseCapacity,
+		OldBonusCapacity:    preview.OldBonusCapacity + 1,
+		Redeemed:            preview.Redeemed,
+		PendingSocialReview: preview.PendingSocialReview,
+	}, true, now.Add(2*time.Minute)); !errors.Is(err, ErrReferralReplacementConflict) {
+		t.Fatalf("stale replacement err=%v", err)
+	}
+	replacement, err := store.ReplaceReferralIssuerExpected(ctx, replacementPolicy, qualified.IssuerID, "ops", "rotate compromised link", &ReferralReplacementExpectation{
+		ProviderID:          preview.ProviderID,
+		OldBaseCapacity:     preview.OldBaseCapacity,
+		OldBonusCapacity:    preview.OldBonusCapacity,
+		Redeemed:            preview.Redeemed,
+		PendingSocialReview: preview.PendingSocialReview,
+	}, true, now.Add(2*time.Minute))
+	if err != nil || !replacement.Applied || replacement.NewIssuerID == qualified.IssuerID {
+		t.Fatalf("replacement=%+v err=%v", replacement, err)
+	}
+	var evidenceAt, firstServingAt string
+	var replacementBase int
+	if err := store.db.QueryRow(`SELECT evidence_at FROM referral_serving_qualifications WHERE campaign = ? AND provider_id = ?`, policy.Campaign, providerID).Scan(&evidenceAt); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.db.QueryRow(`SELECT first_serving_at, base_capacity FROM referral_issuers WHERE issuer_id = ?`, replacement.NewIssuerID).Scan(&firstServingAt, &replacementBase); err != nil {
+		t.Fatal(err)
+	}
+	if evidenceAt != firstServingAt || firstServingAt != timeText(now.Add(-time.Minute)) {
+		t.Fatalf("evidence=%q first serving=%q", evidenceAt, firstServingAt)
+	}
+	if replacementBase != 3 || replacement.BaseCapacity != 3 {
+		t.Fatalf("replacement base row=%d result=%d", replacementBase, replacement.BaseCapacity)
+	}
+	status, err := store.ProviderReferralStatus(ctx, replacementPolicy, providerID)
+	if err != nil || status.Redemptions != 1 || status.Remaining != 2 {
+		t.Fatalf("replacement status=%+v err=%v", status, err)
+	}
+	for i := 0; i < 2; i++ {
+		id := fmt.Sprintf("referred-after-replacement-%d", i)
+		if _, _, err := store.IssueTokenWithReferral(ctx, id, "host-"+id, replacement.NewCode, replacementPolicy); err != nil {
+			t.Fatalf("redemption %d: %v", i, err)
+		}
+	}
+	if _, _, err := store.IssueTokenWithReferral(ctx, "referred-over-capacity", "host-over-capacity", replacement.NewCode, replacementPolicy); !errors.Is(err, ErrReferralExhausted) {
+		t.Fatalf("replacement capacity reset err=%v", err)
+	}
+	status, err = store.ProviderReferralStatus(ctx, replacementPolicy, providerID)
+	if err != nil || status.Redemptions != 3 || status.Remaining != 0 {
+		t.Fatalf("exhausted replacement status=%+v err=%v", status, err)
+	}
+	if _, err := store.ReplaceReferralIssuerExpected(ctx, replacementPolicy, qualified.IssuerID, "ops", "duplicate", &ReferralReplacementExpectation{
+		ProviderID:          preview.ProviderID,
+		OldBaseCapacity:     preview.OldBaseCapacity,
+		OldBonusCapacity:    preview.OldBonusCapacity,
+		Redeemed:            preview.Redeemed,
+		PendingSocialReview: preview.PendingSocialReview,
+	}, true, now.Add(3*time.Minute)); !errors.Is(err, ErrReferralInvalid) {
+		t.Fatalf("repeat replacement err=%v", err)
+	}
+}
+
+func TestFailedVerificationArchivesAndCannotReusePost(t *testing.T) {
+	store := openSocialStore(t)
+	policy := socialReferralPolicy()
+	now := time.Date(2026, 7, 13, 10, 0, 0, 0, time.UTC)
+	providerID := "provider-retry"
+	_, firstChallenge := createPendingSocialVerification(t, store, policy, providerID, "444", now)
+	if granted, err := store.PromoteMaturedSocialVerifications(context.Background(), policy, now.Add(policy.SocialVerificationDwell), func(context.Context, string, string, string) error { return errors.New("post removed") }); err != nil || granted != 0 {
+		t.Fatalf("terminal grant=%d err=%v", granted, err)
+	}
+	retry, err := store.CreateSocialChallenge(context.Background(), policy, providerID, now.Add(policy.SocialVerificationDwell+time.Minute))
+	if err != nil || retry.Cleartext == firstChallenge.Cleartext {
+		t.Fatalf("retry=%+v err=%v", retry, err)
+	}
+	if _, err := store.CompleteSocialVerification(context.Background(), policy, providerID, retry.Cleartext, "444", "456", strings.Repeat("b", 64), "x_api", now.Add(policy.SocialVerificationDwell+2*time.Minute)); !errors.Is(err, ErrSocialChallenge) {
+		t.Fatalf("post reuse err=%v", err)
+	}
+	if _, err := store.CompleteSocialVerification(context.Background(), policy, providerID, retry.Cleartext, "555", "456", strings.Repeat("b", 64), "x_api", now.Add(policy.SocialVerificationDwell+2*time.Minute)); err != nil {
+		t.Fatal(err)
+	}
+	var history int
+	if err := store.db.QueryRow(`SELECT COUNT(1) FROM referral_social_verification_history WHERE provider_id = ?`, providerID).Scan(&history); err != nil {
+		t.Fatal(err)
+	}
+	if history != 1 {
+		t.Fatalf("history=%d", history)
+	}
+}

--- a/phase4-coordinator/internal/auth/tokens.go
+++ b/phase4-coordinator/internal/auth/tokens.go
@@ -507,6 +507,7 @@ func (s *Store) ensureGitHubAuthSchema(ctx context.Context) error {
 			total_removed_logs INTEGER NOT NULL
 		)`,
 	}
+	stmts = append(stmts, referralAdminSchemaStatements()...)
 	for _, stmt := range stmts {
 		if _, err := tx.ExecContext(ctx, stmt); err != nil {
 			return err

--- a/phase4-coordinator/internal/auth/tokens.go
+++ b/phase4-coordinator/internal/auth/tokens.go
@@ -1081,7 +1081,7 @@ func deleteRows(ctx context.Context, conn *sql.Conn, query string, args ...any) 
 	return res.RowsAffected()
 }
 
-func (s *Store) MintProviderTokenAppTrack(ctx context.Context, providerID string, currentBearer *string) (string, error) {
+func (s *Store) MintProviderTokenAppTrack(ctx context.Context, providerID string, currentBearer, freshTokenCandidate *string) (string, error) {
 	if err := config.ValidateProviderID(providerID); err != nil {
 		return "", err
 	}
@@ -1129,9 +1129,18 @@ UPDATE provider_tokens
 			}
 		}
 
-		newToken, err := randomHex(32)
-		if err != nil {
-			return err
+		var newToken string
+		if !requiresProof && freshTokenCandidate != nil {
+			newToken = strings.TrimSpace(*freshTokenCandidate)
+			if len(newToken) != 64 || !isLowerHexToken(newToken) {
+				return ErrReferralConflict
+			}
+		} else {
+			var err error
+			newToken, err = randomHex(32)
+			if err != nil {
+				return err
+			}
 		}
 		prefix := newToken[:tokenDisplayPrefixLength]
 		if _, err := conn.ExecContext(ctx, `

--- a/phase4-coordinator/internal/auth/tokens.go
+++ b/phase4-coordinator/internal/auth/tokens.go
@@ -123,6 +123,8 @@ type BootstrapMintRequest struct {
 	UnconfirmedIDMax    int
 	OutstandingTokenMax int
 	IdentityRetention   time.Duration
+	ReferralCode        string
+	ReferralPolicy      ReferralPolicy
 }
 
 type BootstrapMint struct {
@@ -450,6 +452,50 @@ func (s *Store) ensureGitHubAuthSchema(ctx context.Context) error {
 		)`,
 		`CREATE INDEX IF NOT EXISTS idx_bootstrap_mint_log_provider_ts ON bootstrap_mint_log(provider_id, ts)`,
 		`CREATE INDEX IF NOT EXISTS idx_bootstrap_mint_log_ip_ts ON bootstrap_mint_log(source_ip, ts)`,
+		`CREATE TABLE IF NOT EXISTS referral_issuers (
+			issuer_id TEXT PRIMARY KEY,
+			code_type TEXT NOT NULL CHECK(code_type IN ('S','P')),
+			key_id TEXT NOT NULL,
+			campaign TEXT NOT NULL,
+			provider_id TEXT,
+			base_capacity INTEGER NOT NULL CHECK(base_capacity >= 0),
+			bonus_capacity INTEGER NOT NULL DEFAULT 0 CHECK(bonus_capacity >= 0),
+			expires_at TEXT,
+			revoked_at TEXT,
+			created_at TEXT NOT NULL,
+			first_serving_at TEXT,
+			UNIQUE(provider_id, campaign)
+		)`,
+		`CREATE INDEX IF NOT EXISTS idx_referral_issuers_provider_campaign ON referral_issuers(provider_id, campaign)`,
+		`CREATE TABLE IF NOT EXISTS referral_redemptions (
+			campaign TEXT NOT NULL,
+			provider_id TEXT NOT NULL,
+			issuer_id TEXT NOT NULL REFERENCES referral_issuers(issuer_id),
+			code_digest TEXT NOT NULL,
+			policy_version TEXT NOT NULL DEFAULT 'v1',
+			redeemed_at TEXT NOT NULL,
+			PRIMARY KEY(campaign, provider_id)
+		)`,
+		`CREATE INDEX IF NOT EXISTS idx_referral_redemptions_issuer ON referral_redemptions(issuer_id)`,
+		`CREATE TABLE IF NOT EXISTS provider_referral_admissions (
+			provider_id TEXT NOT NULL,
+			campaign TEXT NOT NULL,
+			policy_version TEXT NOT NULL,
+			decision TEXT NOT NULL CHECK(decision IN ('referred','grandfathered')),
+			applied_at TEXT NOT NULL,
+			PRIMARY KEY(provider_id, campaign)
+		)`,
+		`CREATE TABLE IF NOT EXISTS apptrack_pending_referral_mints (
+			provider_id TEXT PRIMARY KEY,
+			token_hash TEXT NOT NULL UNIQUE,
+			campaign TEXT NOT NULL,
+			registration_source_ip TEXT NOT NULL,
+			registration_nonce TEXT NOT NULL,
+			registration_attempt_ts TEXT NOT NULL,
+			created_redemption INTEGER NOT NULL CHECK(created_redemption IN (0, 1)),
+			created_at TEXT NOT NULL
+		)`,
+		`CREATE INDEX IF NOT EXISTS idx_apptrack_pending_referral_mints_created_at ON apptrack_pending_referral_mints(created_at)`,
 		`CREATE TABLE IF NOT EXISTS bootstrap_gc_audit (
 			id INTEGER PRIMARY KEY CHECK (id = 1),
 			last_run_at TEXT NOT NULL,
@@ -631,6 +677,16 @@ func (s *Store) ensureProviderIDColumn(ctx context.Context) error {
 }
 
 func (s *Store) IssueToken(ctx context.Context, providerID, providerName string) (TokenRecord, string, error) {
+	return s.issueToken(ctx, providerID, providerName, "", ReferralPolicy{})
+}
+
+// IssueTokenWithReferral redeems referral capacity in the same SQLite
+// transaction as the token insert.
+func (s *Store) IssueTokenWithReferral(ctx context.Context, providerID, providerName, referralCode string, policy ReferralPolicy) (TokenRecord, string, error) {
+	return s.issueToken(ctx, providerID, providerName, referralCode, policy)
+}
+
+func (s *Store) issueToken(ctx context.Context, providerID, providerName, referralCode string, policy ReferralPolicy) (TokenRecord, string, error) {
 	// Issue #274 R1 CODE LOW-1: validate the RAW provider_id before any
 	// normalization so admission paths apply the same gate semantics as WS
 	// paths (which validate as-received). Leading/trailing whitespace is
@@ -650,7 +706,8 @@ func (s *Store) IssueToken(ctx context.Context, providerID, providerName string)
 	token := hex.EncodeToString(raw[:])
 	hash := tokenHash(token)
 	prefix := token[:tokenDisplayPrefixLength]
-	createdAt := nowString()
+	now := time.Now().UTC()
+	createdAt := timeText(now)
 	var record TokenRecord
 	err := sqliteutil.Transact(ctx, s.db, func(ctx context.Context, conn *sql.Conn) error {
 		if IsCredentialBootstrapPrincipal(providerID) {
@@ -664,6 +721,9 @@ SELECT EXISTS(
 			if bootstrapIdentityExists == 1 {
 				return ErrBootstrapIdentityExists
 			}
+		}
+		if _, err := redeemReferralTx(ctx, conn, policy, referralCode, providerID, now); err != nil {
+			return err
 		}
 		res, err := conn.ExecContext(ctx, `INSERT INTO provider_tokens (token_hash, token_prefix, provider_id, provider_name, created_at) VALUES (?, ?, ?, ?, ?)`, hash, prefix, providerID, providerName, createdAt)
 		if err != nil {
@@ -902,6 +962,14 @@ SELECT COUNT(1)
 				decisionErr = ErrBootstrapOutstandingLimit
 				return nil
 			}
+		}
+
+		referralPolicy := req.ReferralPolicy
+		// Grandfathering is available only after exact receipt-key custody of an
+		// existing bootstrap identity has been proven above.
+		referralPolicy.GrandfatherProof = identityExists
+		if _, err := redeemReferralTx(ctx, conn, referralPolicy, req.ReferralCode, req.ProviderID, req.Now); err != nil {
+			return err
 		}
 
 		if activeExists {
@@ -2581,6 +2649,14 @@ func (s *Store) HasOwnership(ctx context.Context, providerID string) (bool, erro
 }
 
 func (s *Store) MintAdmissionTokenAndPairOT(ctx context.Context, providerID, providerName string, now time.Time) (AdmissionPairMint, error) {
+	return s.mintAdmissionTokenAndPairOT(ctx, providerID, providerName, now, "", ReferralPolicy{})
+}
+
+func (s *Store) MintAdmissionTokenAndPairOTWithReferral(ctx context.Context, providerID, providerName string, now time.Time, referralCode string, policy ReferralPolicy) (AdmissionPairMint, error) {
+	return s.mintAdmissionTokenAndPairOT(ctx, providerID, providerName, now, referralCode, policy)
+}
+
+func (s *Store) mintAdmissionTokenAndPairOT(ctx context.Context, providerID, providerName string, now time.Time, referralCode string, policy ReferralPolicy) (AdmissionPairMint, error) {
 	// Issue #274 R1 CODE LOW-1: validate the RAW provider_id before any
 	// normalization so admission paths apply the same gate semantics as WS
 	// paths.
@@ -2615,6 +2691,9 @@ SELECT EXISTS(
 			if bootstrapIdentityExists == 1 {
 				return ErrBootstrapIdentityExists
 			}
+		}
+		if _, err := redeemReferralTx(ctx, conn, policy, referralCode, providerID, now); err != nil {
+			return err
 		}
 		res, err := conn.ExecContext(ctx, `INSERT INTO provider_tokens (token_hash, token_prefix, provider_id, provider_name, created_at) VALUES (?, ?, ?, ?, ?)`, hash, prefix, providerID, providerName, nowText)
 		if err != nil {

--- a/phase4-coordinator/internal/auth/tokens.go
+++ b/phase4-coordinator/internal/auth/tokens.go
@@ -460,6 +460,7 @@ func (s *Store) ensureGitHubAuthSchema(ctx context.Context) error {
 			provider_id TEXT,
 			base_capacity INTEGER NOT NULL CHECK(base_capacity >= 0),
 			bonus_capacity INTEGER NOT NULL DEFAULT 0 CHECK(bonus_capacity >= 0),
+			carried_redemptions INTEGER NOT NULL DEFAULT 0 CHECK(carried_redemptions >= 0),
 			expires_at TEXT,
 			revoked_at TEXT,
 			created_at TEXT NOT NULL,
@@ -508,6 +509,7 @@ func (s *Store) ensureGitHubAuthSchema(ctx context.Context) error {
 		)`,
 	}
 	stmts = append(stmts, referralAdminSchemaStatements()...)
+	stmts = append(stmts, referralSocialSchemaStatements()...)
 	for _, stmt := range stmts {
 		if _, err := tx.ExecContext(ctx, stmt); err != nil {
 			return err
@@ -520,6 +522,39 @@ func (s *Store) ensureGitHubAuthSchema(ctx context.Context) error {
 		return err
 	}
 	if err := ensureColumnTx(ctx, tx, "provider_tokens", "bootstrap_expires_at", `ALTER TABLE provider_tokens ADD COLUMN bootstrap_expires_at TEXT`); err != nil {
+		return err
+	}
+	if err := ensureColumnTx(ctx, tx, "referral_issuers", "replaced_by", `ALTER TABLE referral_issuers ADD COLUMN replaced_by TEXT`); err != nil {
+		return err
+	}
+	if err := ensureColumnTx(ctx, tx, "referral_issuers", "carried_redemptions", `ALTER TABLE referral_issuers ADD COLUMN carried_redemptions INTEGER NOT NULL DEFAULT 0`); err != nil {
+		return err
+	}
+	if err := ensureColumnTx(ctx, tx, "referral_social_verifications", "share_url_hash", `ALTER TABLE referral_social_verifications ADD COLUMN share_url_hash TEXT NOT NULL DEFAULT ''`); err != nil {
+		return err
+	}
+	if err := ensureColumnTx(ctx, tx, "referral_social_verifications", "challenge_hash", `ALTER TABLE referral_social_verifications ADD COLUMN challenge_hash TEXT NOT NULL DEFAULT ''`); err != nil {
+		return err
+	}
+	if err := ensureColumnTx(ctx, tx, "referral_social_verifications", "next_check_at", `ALTER TABLE referral_social_verifications ADD COLUMN next_check_at TEXT NOT NULL DEFAULT ''`); err != nil {
+		return err
+	}
+	if err := ensureColumnTx(ctx, tx, "referral_social_verifications", "recheck_attempts", `ALTER TABLE referral_social_verifications ADD COLUMN recheck_attempts INTEGER NOT NULL DEFAULT 0`); err != nil {
+		return err
+	}
+	if err := ensureColumnTx(ctx, tx, "referral_social_verifications", "lease_token", `ALTER TABLE referral_social_verifications ADD COLUMN lease_token TEXT`); err != nil {
+		return err
+	}
+	if err := ensureColumnTx(ctx, tx, "referral_social_verifications", "lease_until", `ALTER TABLE referral_social_verifications ADD COLUMN lease_until TEXT`); err != nil {
+		return err
+	}
+	if err := ensureColumnTx(ctx, tx, "referral_social_verification_history", "challenge_hash", `ALTER TABLE referral_social_verification_history ADD COLUMN challenge_hash TEXT NOT NULL DEFAULT ''`); err != nil {
+		return err
+	}
+	if _, err := tx.ExecContext(ctx, `
+CREATE INDEX IF NOT EXISTS idx_referral_social_recheck_pending
+    ON referral_social_verifications(campaign, next_check_at, pending_since)
+ WHERE granted_at IS NULL AND failed_at IS NULL`); err != nil {
 		return err
 	}
 	if err := ensureColumnTx(ctx, tx, "provider_bootstrap_identities", "confirmed_at", `ALTER TABLE provider_bootstrap_identities ADD COLUMN confirmed_at TEXT`); err != nil {
@@ -1390,6 +1425,36 @@ UPDATE provider_tokens
 	}
 	if providerID == "" {
 		return "", false, nil
+	}
+	return providerID, true, nil
+}
+
+// ValidateTokenReadOnly authenticates provider API reads without taking a
+// write transaction or refreshing last_used_at. Expired provisional bootstrap
+// credentials fail closed but remain for the normal auth retention path.
+func (s *Store) ValidateTokenReadOnly(ctx context.Context, token string) (string, bool, error) {
+	if token == "" {
+		return "", false, nil
+	}
+	var providerID string
+	var bootstrapIssued int
+	var bootstrapExpiresAt, lastUsedAt sql.NullString
+	err := s.db.QueryRowContext(ctx, `
+SELECT provider_id, bootstrap_issued, bootstrap_expires_at, last_used_at
+  FROM provider_tokens
+ WHERE token_hash = ? AND revoked_at IS NULL AND provider_id <> ''`, tokenHash(token)).Scan(
+		&providerID, &bootstrapIssued, &bootstrapExpiresAt, &lastUsedAt)
+	if errors.Is(err, sql.ErrNoRows) {
+		return "", false, nil
+	}
+	if err != nil {
+		return "", false, err
+	}
+	if bootstrapIssued == 1 && !lastUsedAt.Valid {
+		expiresAt, parseErr := time.Parse(time.RFC3339, bootstrapExpiresAt.String)
+		if !bootstrapExpiresAt.Valid || parseErr != nil || !expiresAt.After(time.Now().UTC()) {
+			return "", false, nil
+		}
 	}
 	return providerID, true, nil
 }

--- a/phase4-coordinator/internal/auth/tokens_test.go
+++ b/phase4-coordinator/internal/auth/tokens_test.go
@@ -33,6 +33,113 @@ func bootstrapPrincipal(label string) string {
 	return "mp-" + hex.EncodeToString(sum[:16])
 }
 
+func TestValidateTokenReadOnlyAuthenticatesWithoutRefreshingUsage(t *testing.T) {
+	ctx := context.Background()
+	store, err := auth.OpenStore(filepath.Join(t.TempDir(), "coordinator.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+	record, bearer, err := store.IssueToken(ctx, "provider-read-only", "dashboard polling")
+	if err != nil {
+		t.Fatal(err)
+	}
+	providerID, valid, err := store.ValidateTokenReadOnly(ctx, bearer)
+	if err != nil || !valid || providerID != "provider-read-only" {
+		t.Fatalf("provider=%q valid=%v err=%v", providerID, valid, err)
+	}
+	row, err := lookupTokenRow(ctx, t, store, record.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if row.LastUsedAt.Valid {
+		t.Fatalf("read-only validation refreshed last_used_at=%v", row.LastUsedAt)
+	}
+	if providerID, valid, err := store.ValidateTokenReadOnly(ctx, "not-a-token"); err != nil || valid || providerID != "" {
+		t.Fatalf("invalid provider=%q valid=%v err=%v", providerID, valid, err)
+	}
+}
+
+func TestOpenStoreUpgradesPreRecoverySocialTablesAdditively(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "coordinator.db")
+	db, err := sql.Open("sqlite", path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = db.Exec(`
+CREATE TABLE referral_social_verifications (
+    provider_id TEXT NOT NULL,
+    campaign TEXT NOT NULL,
+    issuer_id TEXT NOT NULL,
+    post_id TEXT NOT NULL UNIQUE,
+    author_id TEXT NOT NULL,
+    share_url_hash TEXT NOT NULL,
+    verification_method TEXT NOT NULL,
+    submitted_at TEXT NOT NULL,
+    pending_since TEXT NOT NULL,
+    granted_at TEXT,
+    failed_at TEXT,
+    PRIMARY KEY(provider_id, campaign)
+);
+CREATE TABLE referral_social_verification_history (
+    archive_id INTEGER PRIMARY KEY AUTOINCREMENT,
+    provider_id TEXT NOT NULL,
+    campaign TEXT NOT NULL,
+    issuer_id TEXT NOT NULL,
+    post_id TEXT NOT NULL UNIQUE,
+    author_id TEXT NOT NULL,
+    share_url_hash TEXT NOT NULL,
+    verification_method TEXT NOT NULL,
+    submitted_at TEXT NOT NULL,
+    pending_since TEXT NOT NULL,
+    granted_at TEXT,
+    failed_at TEXT NOT NULL,
+    archived_at TEXT NOT NULL
+)`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	store, err := auth.OpenStore(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+	for table, columns := range map[string][]string{
+		"referral_social_verifications":        {"challenge_hash", "next_check_at", "recheck_attempts", "lease_token", "lease_until"},
+		"referral_social_verification_history": {"challenge_hash"},
+	} {
+		rows, err := store.DB().Query(`PRAGMA table_info(` + table + `)`)
+		if err != nil {
+			t.Fatal(err)
+		}
+		got := map[string]bool{}
+		for rows.Next() {
+			var cid, notNull, primaryKey int
+			var name, kind string
+			var defaultValue sql.NullString
+			if err := rows.Scan(&cid, &name, &kind, &notNull, &defaultValue, &primaryKey); err != nil {
+				rows.Close()
+				t.Fatal(err)
+			}
+			got[name] = true
+		}
+		rows.Close()
+		for _, column := range columns {
+			if !got[column] {
+				t.Fatalf("%s missing upgraded column %s", table, column)
+			}
+		}
+	}
+	var indexCount int
+	if err := store.DB().QueryRow(`SELECT COUNT(1) FROM sqlite_master WHERE type = 'index' AND name = 'idx_referral_social_recheck_pending'`).Scan(&indexCount); err != nil || indexCount != 1 {
+		t.Fatalf("recheck index count=%d err=%v", indexCount, err)
+	}
+}
+
 func TestBindAdmissionIdentityPreservesLegacyProviderIDAcrossRestart(t *testing.T) {
 	ctx := context.Background()
 	dbPath := filepath.Join(t.TempDir(), "coordinator.db")

--- a/phase4-coordinator/internal/auth/tokens_test.go
+++ b/phase4-coordinator/internal/auth/tokens_test.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"net/http"
 	"path/filepath"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -1239,7 +1240,7 @@ func TestMintProviderTokenAppTrackRequiresProofForAnyActiveToken(t *testing.T) {
 	ctx := context.Background()
 	const providerID = "p_apptrackprovider"
 
-	first, err := store.MintProviderTokenAppTrack(ctx, providerID, nil)
+	first, err := store.MintProviderTokenAppTrack(ctx, providerID, nil, nil)
 	if err != nil {
 		t.Fatalf("first app-track mint: %v", err)
 	}
@@ -1247,18 +1248,18 @@ func TestMintProviderTokenAppTrackRequiresProofForAnyActiveToken(t *testing.T) {
 		t.Fatalf("first token len=%d want 64", len(first))
 	}
 
-	if _, err := store.MintProviderTokenAppTrack(ctx, providerID, nil); !errors.Is(err, auth.ErrAppTrackExistingTokenNoProof) {
+	if _, err := store.MintProviderTokenAppTrack(ctx, providerID, nil, nil); !errors.Is(err, auth.ErrAppTrackExistingTokenNoProof) {
 		t.Fatalf("unused active without proof err=%v want ErrAppTrackExistingTokenNoProof", err)
 	}
 	if provider, ok, err := store.ValidateToken(ctx, first); err != nil || !ok || provider != providerID {
 		t.Fatalf("first token should remain active provider=%q ok=%v err=%v", provider, ok, err)
 	}
 	wrong := "wrong-token"
-	if _, err := store.MintProviderTokenAppTrack(ctx, providerID, &wrong); !errors.Is(err, auth.ErrAppTrackExistingTokenNoProof) {
+	if _, err := store.MintProviderTokenAppTrack(ctx, providerID, &wrong, nil); !errors.Is(err, auth.ErrAppTrackExistingTokenNoProof) {
 		t.Fatalf("active token with wrong proof err=%v want ErrAppTrackExistingTokenNoProof", err)
 	}
 
-	second, err := store.MintProviderTokenAppTrack(ctx, providerID, &first)
+	second, err := store.MintProviderTokenAppTrack(ctx, providerID, &first, nil)
 	if err != nil {
 		t.Fatalf("active token with current proof should reissue: %v", err)
 	}
@@ -1268,8 +1269,24 @@ func TestMintProviderTokenAppTrackRequiresProofForAnyActiveToken(t *testing.T) {
 	if err := store.MarkTokenUsed(ctx, second); err != nil {
 		t.Fatalf("mark second used: %v", err)
 	}
-	if _, err := store.MintProviderTokenAppTrack(ctx, providerID, &second); !errors.Is(err, auth.ErrAppTrackReissueCooldown) {
+	if _, err := store.MintProviderTokenAppTrack(ctx, providerID, &second, nil); !errors.Is(err, auth.ErrAppTrackReissueCooldown) {
 		t.Fatalf("cooldown reissue err=%v want ErrAppTrackReissueCooldown", err)
+	}
+}
+
+func TestMintProviderTokenAppTrackUsesFreshClientCandidate(t *testing.T) {
+	store, err := auth.OpenStore(filepath.Join(t.TempDir(), "coordinator.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+	candidate := strings.Repeat("c", 64)
+	got, err := store.MintProviderTokenAppTrack(context.Background(), "p_apptrackcandidate", nil, &candidate)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != candidate {
+		t.Fatalf("token=%q want client candidate", got)
 	}
 }
 

--- a/phase4-coordinator/internal/config/config.go
+++ b/phase4-coordinator/internal/config/config.go
@@ -709,6 +709,7 @@ type AuthConfig struct {
 type ReferralConfig struct {
 	RequireForRegistration  bool              `yaml:"require_for_registration"`
 	EnablePublicValidation  bool              `yaml:"enable_public_validation"`
+	EnableJoinLinks         bool              `yaml:"enable_join_links"`
 	EnableSocialInviteBonus bool              `yaml:"enable_social_invite_bonus"`
 	Campaign                string            `yaml:"campaign"`
 	PolicyVersion           string            `yaml:"policy_version"`
@@ -719,6 +720,7 @@ type ReferralConfig struct {
 	SocialBonusUses         int               `yaml:"social_bonus_uses"`
 	ChallengeTTLS           int               `yaml:"challenge_ttl_s"`
 	JoinBaseURL             string            `yaml:"join_base_url"`
+	JoinDownloadURL         string            `yaml:"join_download_url"`
 	XAPIBearerToken         string            `yaml:"x_api_bearer_token"`
 	RequestAccessURL        string            `yaml:"request_access_url"`
 }
@@ -1849,7 +1851,10 @@ func (c Config) validateCompatibilitySet() error {
 	return nil
 }
 
-var referralConfigPartPattern = regexp.MustCompile(`^[A-Za-z0-9_]{1,32}$`)
+var (
+	referralConfigPartPattern      = regexp.MustCompile(`^[A-Za-z0-9_]{1,32}$`)
+	referralDownloadVersionPattern = regexp.MustCompile(`(^|[-_/])v?[0-9]+[.][0-9]+[.][0-9]+([-_.]|$)`)
+)
 
 func (c Config) validateReferrals() error {
 	r := c.Referrals
@@ -1861,7 +1866,25 @@ func (c Config) validateReferrals() error {
 			return fmt.Errorf("referrals.request_access_url must be an absolute https URL without credentials when set")
 		}
 	}
-	if !r.RequireForRegistration && !r.EnablePublicValidation && !r.EnableSocialInviteBonus {
+	if raw := strings.TrimSpace(r.JoinDownloadURL); raw != "" {
+		downloadURL, err := url.Parse(raw)
+		if err != nil || downloadURL == nil {
+			return fmt.Errorf("referrals.join_download_url must be a fixed absolute https URL without credentials, query, fragment, trailing slash, or a moving latest path")
+		}
+		lowerPath := strings.ToLower(downloadURL.Path)
+		if downloadURL.Scheme != "https" || downloadURL.Host == "" || downloadURL.User != nil || downloadURL.RawQuery != "" || downloadURL.Fragment != "" || strings.HasSuffix(downloadURL.Path, "/") || strings.Contains(lowerPath, "latest") || !referralDownloadVersionPattern.MatchString(downloadURL.Path) {
+			return fmt.Errorf("referrals.join_download_url must be a fixed, versioned absolute https URL without credentials, query, fragment, trailing slash, or a moving latest path")
+		}
+	}
+	if r.EnableJoinLinks {
+		if !r.RequireForRegistration {
+			return fmt.Errorf("referrals.enable_join_links requires require_for_registration=true")
+		}
+		if strings.TrimSpace(r.JoinDownloadURL) == "" {
+			return fmt.Errorf("referrals.join_download_url must be set when join links are enabled")
+		}
+	}
+	if !r.RequireForRegistration && !r.EnablePublicValidation && !r.EnableJoinLinks && !r.EnableSocialInviteBonus {
 		return nil
 	}
 	if !referralConfigPartPattern.MatchString(r.Campaign) {

--- a/phase4-coordinator/internal/config/config.go
+++ b/phase4-coordinator/internal/config/config.go
@@ -703,26 +703,27 @@ type AuthConfig struct {
 	GitHubOAuth                           GitHubOAuthConfig `yaml:"github_oauth"`
 }
 
-// ReferralConfig owns pre-beta admission policy. Both launch flags default
+// ReferralConfig owns pre-beta admission policy. All launch flags default
 // off; HMAC material supports env:NAME indirection and never needs to be
 // written to the credential database.
 type ReferralConfig struct {
-	RequireForRegistration  bool              `yaml:"require_for_registration"`
-	EnablePublicValidation  bool              `yaml:"enable_public_validation"`
-	EnableJoinLinks         bool              `yaml:"enable_join_links"`
-	EnableSocialInviteBonus bool              `yaml:"enable_social_invite_bonus"`
-	Campaign                string            `yaml:"campaign"`
-	PolicyVersion           string            `yaml:"policy_version"`
-	GrandfatherBefore       string            `yaml:"grandfather_before"`
-	CurrentKeyID            string            `yaml:"current_key_id"`
-	HMACKeys                map[string]string `yaml:"hmac_keys"`
-	ProviderBaseUses        int               `yaml:"provider_base_uses"`
-	SocialBonusUses         int               `yaml:"social_bonus_uses"`
-	ChallengeTTLS           int               `yaml:"challenge_ttl_s"`
-	JoinBaseURL             string            `yaml:"join_base_url"`
-	JoinDownloadURL         string            `yaml:"join_download_url"`
-	XAPIBearerToken         string            `yaml:"x_api_bearer_token"`
-	RequestAccessURL        string            `yaml:"request_access_url"`
+	RequireForRegistration   bool              `yaml:"require_for_registration"`
+	EnablePublicValidation   bool              `yaml:"enable_public_validation"`
+	EnableJoinLinks          bool              `yaml:"enable_join_links"`
+	EnableSocialInviteBonus  bool              `yaml:"enable_social_invite_bonus"`
+	Campaign                 string            `yaml:"campaign"`
+	PolicyVersion            string            `yaml:"policy_version"`
+	GrandfatherBefore        string            `yaml:"grandfather_before"`
+	CurrentKeyID             string            `yaml:"current_key_id"`
+	HMACKeys                 map[string]string `yaml:"hmac_keys"`
+	ProviderBaseUses         int               `yaml:"provider_base_uses"`
+	SocialBonusUses          int               `yaml:"social_bonus_uses"`
+	ChallengeTTLS            int               `yaml:"challenge_ttl_s"`
+	SocialVerificationDwellS int               `yaml:"social_verification_dwell_s"`
+	JoinBaseURL              string            `yaml:"join_base_url"`
+	JoinDownloadURL          string            `yaml:"join_download_url"`
+	XAPIBearerToken          string            `yaml:"x_api_bearer_token"`
+	RequestAccessURL         string            `yaml:"request_access_url"`
 }
 
 type GitHubOAuthConfig struct {
@@ -1148,12 +1149,13 @@ func Default() Config {
 			CredentialBootstrapIdentityRetentionS: 604800,
 		},
 		Referrals: ReferralConfig{
-			ProviderBaseUses: 1,
-			SocialBonusUses:  2,
-			ChallengeTTLS:    900,
-			JoinBaseURL:      "https://coordinator.streamvc.live/j",
-			PolicyVersion:    "v1",
-			HMACKeys:         map[string]string{},
+			ProviderBaseUses:         1,
+			SocialBonusUses:          2,
+			ChallengeTTLS:            900,
+			SocialVerificationDwellS: 1800,
+			JoinBaseURL:              "https://coordinator.streamvc.live/j",
+			PolicyVersion:            "v1",
+			HMACKeys:                 map[string]string{},
 		},
 		Proxy: ProxyConfig{
 			// Default trusts loopback only. Production sits behind nginx on
@@ -1884,6 +1886,9 @@ func (c Config) validateReferrals() error {
 			return fmt.Errorf("referrals.join_download_url must be set when join links are enabled")
 		}
 	}
+	if r.EnableSocialInviteBonus && (!r.RequireForRegistration || !r.EnableJoinLinks) {
+		return fmt.Errorf("referrals.enable_social_invite_bonus requires referral admission and join links")
+	}
 	if !r.RequireForRegistration && !r.EnablePublicValidation && !r.EnableJoinLinks && !r.EnableSocialInviteBonus {
 		return nil
 	}
@@ -1914,16 +1919,16 @@ func (c Config) validateReferrals() error {
 		return fmt.Errorf("referrals.provider_base_uses must be > 0")
 	}
 	if r.EnableSocialInviteBonus {
-		if r.SocialBonusUses <= 0 || r.ChallengeTTLS <= 0 {
-			return fmt.Errorf("referrals social_bonus_uses and challenge_ttl_s must be > 0")
+		if r.SocialBonusUses <= 0 || r.ChallengeTTLS <= 0 || r.SocialVerificationDwellS <= 0 {
+			return fmt.Errorf("referrals social_bonus_uses, challenge_ttl_s, and social_verification_dwell_s must be > 0")
 		}
 		if strings.TrimSpace(r.XAPIBearerToken) == "" {
 			return fmt.Errorf("referrals.x_api_bearer_token must be set when social invite bonus is enabled")
 		}
 	}
 	joinURL, err := url.Parse(strings.TrimSpace(r.JoinBaseURL))
-	if err != nil || joinURL.Scheme != "https" || joinURL.Host == "" || joinURL.RawQuery != "" || joinURL.Fragment != "" || !strings.HasSuffix(strings.TrimRight(joinURL.Path, "/"), "/j") {
-		return fmt.Errorf("referrals.join_base_url must be an absolute https URL ending in /j")
+	if err != nil || joinURL.Scheme != "https" || joinURL.Host == "" || joinURL.User != nil || joinURL.RawQuery != "" || joinURL.ForceQuery || joinURL.Fragment != "" || !strings.HasSuffix(strings.TrimRight(joinURL.Path, "/"), "/j") {
+		return fmt.Errorf("referrals.join_base_url must be a credential-free absolute https URL ending in /j")
 	}
 	return nil
 }

--- a/phase4-coordinator/internal/config/config.go
+++ b/phase4-coordinator/internal/config/config.go
@@ -70,6 +70,7 @@ type Config struct {
 	Tier2                        Tier2Config                  `yaml:"tier2"`
 	CoordinatorAdvertisedVersion CoordinatorAdvertisedVersion `yaml:"coordinator_advertised_version"`
 	Auth                         AuthConfig                   `yaml:"auth"`
+	Referrals                    ReferralConfig               `yaml:"referrals"`
 	Storage                      StorageConfig                `yaml:"storage"`
 	Logging                      LoggingConfig                `yaml:"logging"`
 	Rewards                      RewardsConfig                `yaml:"rewards"`
@@ -702,6 +703,25 @@ type AuthConfig struct {
 	GitHubOAuth                           GitHubOAuthConfig `yaml:"github_oauth"`
 }
 
+// ReferralConfig owns pre-beta admission policy. Both launch flags default
+// off; HMAC material supports env:NAME indirection and never needs to be
+// written to the credential database.
+type ReferralConfig struct {
+	RequireForRegistration  bool              `yaml:"require_for_registration"`
+	EnableSocialInviteBonus bool              `yaml:"enable_social_invite_bonus"`
+	Campaign                string            `yaml:"campaign"`
+	PolicyVersion           string            `yaml:"policy_version"`
+	GrandfatherBefore       string            `yaml:"grandfather_before"`
+	CurrentKeyID            string            `yaml:"current_key_id"`
+	HMACKeys                map[string]string `yaml:"hmac_keys"`
+	ProviderBaseUses        int               `yaml:"provider_base_uses"`
+	SocialBonusUses         int               `yaml:"social_bonus_uses"`
+	ChallengeTTLS           int               `yaml:"challenge_ttl_s"`
+	JoinBaseURL             string            `yaml:"join_base_url"`
+	XAPIBearerToken         string            `yaml:"x_api_bearer_token"`
+	RequestAccessURL        string            `yaml:"request_access_url"`
+}
+
 type GitHubOAuthConfig struct {
 	Enabled             bool   `yaml:"enabled"`
 	ClientID            string `yaml:"client_id"`
@@ -1124,6 +1144,14 @@ func Default() Config {
 			CredentialBootstrapTokenTTLS:          600,
 			CredentialBootstrapIdentityRetentionS: 604800,
 		},
+		Referrals: ReferralConfig{
+			ProviderBaseUses: 1,
+			SocialBonusUses:  2,
+			ChallengeTTLS:    900,
+			JoinBaseURL:      "https://coordinator.streamvc.live/j",
+			PolicyVersion:    "v1",
+			HMACKeys:         map[string]string{},
+		},
 		Proxy: ProxyConfig{
 			// Default trusts loopback only. Production sits behind nginx on
 			// localhost, so the default keys rate-limit buckets on the
@@ -1212,6 +1240,18 @@ func (c *Config) resolveEnv() error {
 			return err
 		}
 		c.Auth.OperatorKeys[name] = v
+	}
+	for keyID, raw := range c.Referrals.HMACKeys {
+		v, err := resolveEnvValue("referrals.hmac_keys."+keyID, raw)
+		if err != nil {
+			return err
+		}
+		c.Referrals.HMACKeys[keyID] = v
+	}
+	if v, err := resolveEnvValue("referrals.x_api_bearer_token", c.Referrals.XAPIBearerToken); err != nil {
+		return err
+	} else {
+		c.Referrals.XAPIBearerToken = v
 	}
 	// Round-1 SECURITY r1 MEDIUM 1: stats DSN fields go through
 	// the same env-indirection resolver. Operators inject DSNs
@@ -1516,6 +1556,9 @@ func (c Config) Validate() error {
 	if c.Auth.CredentialBootstrapIdentityRetentionS <= c.Auth.CredentialBootstrapTokenTTLS {
 		return fmt.Errorf("auth.credential_bootstrap_identity_retention_s must exceed auth.credential_bootstrap_token_ttl_s")
 	}
+	if err := c.validateReferrals(); err != nil {
+		return err
+	}
 	if c.WS.WriteBufferSize <= 0 {
 		return fmt.Errorf("ws.write_buffer_size must be > 0")
 	}
@@ -1801,6 +1844,60 @@ func (c Config) validateCompatibilitySet() error {
 	}
 	if _, ok := seen[policy.TargetID]; !ok {
 		return fmt.Errorf("coordinator.compatibility_set.accepted_ids must contain target_id")
+	}
+	return nil
+}
+
+var referralConfigPartPattern = regexp.MustCompile(`^[A-Za-z0-9_]{1,32}$`)
+
+func (c Config) validateReferrals() error {
+	r := c.Referrals
+	if !r.RequireForRegistration && !r.EnableSocialInviteBonus {
+		return nil
+	}
+	if !referralConfigPartPattern.MatchString(r.Campaign) {
+		return fmt.Errorf("referrals.campaign must contain 1-32 letters, digits, or underscores")
+	}
+	if !referralConfigPartPattern.MatchString(r.PolicyVersion) {
+		return fmt.Errorf("referrals.policy_version must contain 1-32 letters, digits, or underscores")
+	}
+	if raw := strings.TrimSpace(r.GrandfatherBefore); raw != "" {
+		if _, err := time.Parse(time.RFC3339, raw); err != nil {
+			return fmt.Errorf("referrals.grandfather_before must be RFC3339: %w", err)
+		}
+	}
+	if !referralConfigPartPattern.MatchString(r.CurrentKeyID) {
+		return fmt.Errorf("referrals.current_key_id must contain 1-32 letters, digits, or underscores")
+	}
+	secret := r.HMACKeys[r.CurrentKeyID]
+	if len(secret) < 32 {
+		return fmt.Errorf("referrals.hmac_keys.%s must be at least 32 bytes", r.CurrentKeyID)
+	}
+	for keyID, value := range r.HMACKeys {
+		if !referralConfigPartPattern.MatchString(keyID) || len(value) < 32 {
+			return fmt.Errorf("referrals.hmac_keys.%s is invalid or shorter than 32 bytes", keyID)
+		}
+	}
+	if r.ProviderBaseUses <= 0 {
+		return fmt.Errorf("referrals.provider_base_uses must be > 0")
+	}
+	if r.EnableSocialInviteBonus {
+		if r.SocialBonusUses <= 0 || r.ChallengeTTLS <= 0 {
+			return fmt.Errorf("referrals social_bonus_uses and challenge_ttl_s must be > 0")
+		}
+		if strings.TrimSpace(r.XAPIBearerToken) == "" {
+			return fmt.Errorf("referrals.x_api_bearer_token must be set when social invite bonus is enabled")
+		}
+	}
+	joinURL, err := url.Parse(strings.TrimSpace(r.JoinBaseURL))
+	if err != nil || joinURL.Scheme != "https" || joinURL.Host == "" || joinURL.RawQuery != "" || joinURL.Fragment != "" || !strings.HasSuffix(strings.TrimRight(joinURL.Path, "/"), "/j") {
+		return fmt.Errorf("referrals.join_base_url must be an absolute https URL ending in /j")
+	}
+	if raw := strings.TrimSpace(r.RequestAccessURL); raw != "" {
+		reqURL, err := url.Parse(raw)
+		if err != nil || reqURL.Scheme != "https" || reqURL.Host == "" {
+			return fmt.Errorf("referrals.request_access_url must be an absolute https URL when set")
+		}
 	}
 	return nil
 }

--- a/phase4-coordinator/internal/config/config.go
+++ b/phase4-coordinator/internal/config/config.go
@@ -708,6 +708,7 @@ type AuthConfig struct {
 // written to the credential database.
 type ReferralConfig struct {
 	RequireForRegistration  bool              `yaml:"require_for_registration"`
+	EnablePublicValidation  bool              `yaml:"enable_public_validation"`
 	EnableSocialInviteBonus bool              `yaml:"enable_social_invite_bonus"`
 	Campaign                string            `yaml:"campaign"`
 	PolicyVersion           string            `yaml:"policy_version"`
@@ -1852,7 +1853,7 @@ var referralConfigPartPattern = regexp.MustCompile(`^[A-Za-z0-9_]{1,32}$`)
 
 func (c Config) validateReferrals() error {
 	r := c.Referrals
-	if !r.RequireForRegistration && !r.EnableSocialInviteBonus {
+	if !r.RequireForRegistration && !r.EnablePublicValidation && !r.EnableSocialInviteBonus {
 		return nil
 	}
 	if !referralConfigPartPattern.MatchString(r.Campaign) {

--- a/phase4-coordinator/internal/config/config.go
+++ b/phase4-coordinator/internal/config/config.go
@@ -1853,6 +1853,14 @@ var referralConfigPartPattern = regexp.MustCompile(`^[A-Za-z0-9_]{1,32}$`)
 
 func (c Config) validateReferrals() error {
 	r := c.Referrals
+	// The read-only validation response may advertise this URL even while the
+	// referral gate is disabled, so validate it independently of launch flags.
+	if raw := strings.TrimSpace(r.RequestAccessURL); raw != "" {
+		reqURL, err := url.Parse(raw)
+		if err != nil || reqURL.Scheme != "https" || reqURL.Host == "" || reqURL.User != nil {
+			return fmt.Errorf("referrals.request_access_url must be an absolute https URL without credentials when set")
+		}
+	}
 	if !r.RequireForRegistration && !r.EnablePublicValidation && !r.EnableSocialInviteBonus {
 		return nil
 	}
@@ -1893,12 +1901,6 @@ func (c Config) validateReferrals() error {
 	joinURL, err := url.Parse(strings.TrimSpace(r.JoinBaseURL))
 	if err != nil || joinURL.Scheme != "https" || joinURL.Host == "" || joinURL.RawQuery != "" || joinURL.Fragment != "" || !strings.HasSuffix(strings.TrimRight(joinURL.Path, "/"), "/j") {
 		return fmt.Errorf("referrals.join_base_url must be an absolute https URL ending in /j")
-	}
-	if raw := strings.TrimSpace(r.RequestAccessURL); raw != "" {
-		reqURL, err := url.Parse(raw)
-		if err != nil || reqURL.Scheme != "https" || reqURL.Host == "" {
-			return fmt.Errorf("referrals.request_access_url must be an absolute https URL when set")
-		}
 	}
 	return nil
 }

--- a/phase4-coordinator/internal/config/config_test.go
+++ b/phase4-coordinator/internal/config/config_test.go
@@ -55,6 +55,28 @@ func TestReferralLaunchPolicyDefaultsOffAndRejectsUnsafeEnablement(t *testing.T)
 	}
 }
 
+func TestReferralRequestAccessURLMustBeCredentialFreeHTTPSEvenWhenGateIsOff(t *testing.T) {
+	for _, raw := range []string{
+		"http://access.example.test/waitlist",
+		"/relative-access",
+		"https://user:secret@access.example.test/waitlist",
+	} {
+		cfg := Default()
+		cfg.Auth.OperatorKey = "operator-key"
+		cfg.Referrals.RequestAccessURL = raw
+		if err := cfg.Validate(); err == nil || !strings.Contains(err.Error(), "request_access_url") {
+			t.Fatalf("request_access_url=%q error=%v", raw, err)
+		}
+	}
+
+	cfg := Default()
+	cfg.Auth.OperatorKey = "operator-key"
+	cfg.Referrals.RequestAccessURL = "https://access.example.test/waitlist?campaign=prebeta"
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("valid request access URL: %v", err)
+	}
+}
+
 func TestAutotuneFeedsRejectInvalidPublicKeys(t *testing.T) {
 	tests := []struct {
 		name    string

--- a/phase4-coordinator/internal/config/config_test.go
+++ b/phase4-coordinator/internal/config/config_test.go
@@ -33,6 +33,28 @@ func TestAutotuneFeedsRequirePublicKeyringWhenConfigured(t *testing.T) {
 	}
 }
 
+func TestReferralLaunchPolicyDefaultsOffAndRejectsUnsafeEnablement(t *testing.T) {
+	cfg := Default()
+	if cfg.Referrals.RequireForRegistration || cfg.Referrals.EnableSocialInviteBonus {
+		t.Fatal("referral launch policy must default off")
+	}
+	cfg.Auth.OperatorKey = "operator-key"
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("disabled referral defaults should validate: %v", err)
+	}
+
+	cfg.Referrals.RequireForRegistration = true
+	cfg.Referrals.Campaign = "prebeta_2026"
+	cfg.Referrals.CurrentKeyID = "k1"
+	if err := cfg.Validate(); err == nil || !strings.Contains(err.Error(), "hmac_keys") {
+		t.Fatalf("unsafe enablement error=%v", err)
+	}
+	cfg.Referrals.HMACKeys = map[string]string{"k1": strings.Repeat("s", 32)}
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("valid referral gate: %v", err)
+	}
+}
+
 func TestAutotuneFeedsRejectInvalidPublicKeys(t *testing.T) {
 	tests := []struct {
 		name    string

--- a/phase4-coordinator/internal/config/config_test.go
+++ b/phase4-coordinator/internal/config/config_test.go
@@ -35,7 +35,7 @@ func TestAutotuneFeedsRequirePublicKeyringWhenConfigured(t *testing.T) {
 
 func TestReferralLaunchPolicyDefaultsOffAndRejectsUnsafeEnablement(t *testing.T) {
 	cfg := Default()
-	if cfg.Referrals.RequireForRegistration || cfg.Referrals.EnableSocialInviteBonus {
+	if cfg.Referrals.RequireForRegistration || cfg.Referrals.EnablePublicValidation || cfg.Referrals.EnableSocialInviteBonus {
 		t.Fatal("referral launch policy must default off")
 	}
 	cfg.Auth.OperatorKey = "operator-key"

--- a/phase4-coordinator/internal/config/config_test.go
+++ b/phase4-coordinator/internal/config/config_test.go
@@ -35,7 +35,7 @@ func TestAutotuneFeedsRequirePublicKeyringWhenConfigured(t *testing.T) {
 
 func TestReferralLaunchPolicyDefaultsOffAndRejectsUnsafeEnablement(t *testing.T) {
 	cfg := Default()
-	if cfg.Referrals.RequireForRegistration || cfg.Referrals.EnablePublicValidation || cfg.Referrals.EnableSocialInviteBonus {
+	if cfg.Referrals.RequireForRegistration || cfg.Referrals.EnablePublicValidation || cfg.Referrals.EnableJoinLinks || cfg.Referrals.EnableSocialInviteBonus {
 		t.Fatal("referral launch policy must default off")
 	}
 	cfg.Auth.OperatorKey = "operator-key"
@@ -52,6 +52,41 @@ func TestReferralLaunchPolicyDefaultsOffAndRejectsUnsafeEnablement(t *testing.T)
 	cfg.Referrals.HMACKeys = map[string]string{"k1": strings.Repeat("s", 32)}
 	if err := cfg.Validate(); err != nil {
 		t.Fatalf("valid referral gate: %v", err)
+	}
+}
+
+func TestReferralJoinLinksRequireAdmissionAndFixedDownload(t *testing.T) {
+	cfg := Default()
+	cfg.Auth.OperatorKey = "operator-key"
+	cfg.Referrals.EnableJoinLinks = true
+	if err := cfg.Validate(); err == nil || !strings.Contains(err.Error(), "requires require_for_registration") {
+		t.Fatalf("join without admission error=%v", err)
+	}
+
+	cfg.Referrals.RequireForRegistration = true
+	cfg.Referrals.Campaign = "prebeta_2026"
+	cfg.Referrals.CurrentKeyID = "k1"
+	cfg.Referrals.HMACKeys = map[string]string{"k1": strings.Repeat("s", 32)}
+	if err := cfg.Validate(); err == nil || !strings.Contains(err.Error(), "join_download_url must be set") {
+		t.Fatalf("join without download error=%v", err)
+	}
+
+	cfg.Referrals.JoinDownloadURL = "https://download.malibu.tech/releases/Malibu-1.9.0.dmg"
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("fixed join download URL: %v", err)
+	}
+
+	cfg.Referrals.EnableJoinLinks = false
+	cfg.Referrals.RequireForRegistration = false
+	for _, raw := range []string{
+		"https://download.malibu.tech/latest.dmg",
+		"https://download.malibu.tech/releases/Malibu-latest.dmg",
+		"https://download.malibu.tech/releases/Malibu.dmg",
+	} {
+		cfg.Referrals.JoinDownloadURL = raw
+		if err := cfg.Validate(); err == nil || !strings.Contains(err.Error(), "fixed, versioned") {
+			t.Fatalf("moving join download %q error=%v", raw, err)
+		}
 	}
 }
 

--- a/phase4-coordinator/internal/config/config_test.go
+++ b/phase4-coordinator/internal/config/config_test.go
@@ -90,6 +90,38 @@ func TestReferralJoinLinksRequireAdmissionAndFixedDownload(t *testing.T) {
 	}
 }
 
+func TestReferralSocialBonusRequiresDarkStackAndConfiguredDwell(t *testing.T) {
+	cfg := Default()
+	cfg.Auth.OperatorKey = "operator-key"
+	cfg.Referrals.EnableSocialInviteBonus = true
+	if err := cfg.Validate(); err == nil || !strings.Contains(err.Error(), "requires referral admission and join links") {
+		t.Fatalf("social without server stack error=%v", err)
+	}
+
+	cfg.Referrals.RequireForRegistration = true
+	cfg.Referrals.EnableJoinLinks = true
+	cfg.Referrals.Campaign = "prebeta_2026"
+	cfg.Referrals.CurrentKeyID = "k1"
+	cfg.Referrals.HMACKeys = map[string]string{"k1": strings.Repeat("s", 32)}
+	cfg.Referrals.JoinDownloadURL = "https://download.malibu.tech/releases/Malibu-1.9.0.dmg"
+	cfg.Referrals.XAPIBearerToken = "secret"
+	cfg.Referrals.SocialBonusUses = 2
+	cfg.Referrals.ChallengeTTLS = 900
+	cfg.Referrals.SocialVerificationDwellS = 0
+	if err := cfg.Validate(); err == nil || !strings.Contains(err.Error(), "social_verification_dwell_s") {
+		t.Fatalf("social without dwell error=%v", err)
+	}
+	cfg.Referrals.SocialVerificationDwellS = 1800
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("valid dark social stack: %v", err)
+	}
+
+	cfg.Referrals.JoinBaseURL = "https://user:secret@coordinator.streamvc.live/j"
+	if err := cfg.Validate(); err == nil || !strings.Contains(err.Error(), "credential-free") {
+		t.Fatalf("credentialed join URL error=%v", err)
+	}
+}
+
 func TestReferralRequestAccessURLMustBeCredentialFreeHTTPSEvenWhenGateIsOff(t *testing.T) {
 	for _, raw := range []string{
 		"http://access.example.test/waitlist",

--- a/phase4-coordinator/internal/onboarding/apptrack.go
+++ b/phase4-coordinator/internal/onboarding/apptrack.go
@@ -26,6 +26,8 @@ import (
 	"github.com/augstar/macprovider-coordinator/internal/billing"
 )
 
+const appTrackPendingMintReconcileAge = 2 * time.Minute
+
 // RegisterRequest is the JSON body of POST /v1/providers/register.
 // SPEC-026 §4.1. All fields required except AppAttestObject / AppAttestKeyID.
 type RegisterRequest struct {
@@ -34,9 +36,10 @@ type RegisterRequest struct {
 	HardwareSummary HardwareSummary `json:"hardware_summary"`
 	AppAttestObject *string         `json:"app_attest_object,omitempty"` // base64 CBOR
 	AppAttestKeyID  *string         `json:"app_attest_key_id,omitempty"` // base64 32-byte
-	Nonce           string          `json:"nonce"`                       // 64-hex = 32 random bytes
-	TSUTC           string          `json:"ts_utc"`                      // RFC3339
-	Signature       string          `json:"signature"`                   // base64 64-byte Ed25519 over JCS(body\signature)
+	ReferralCode    string          `json:"referral_code,omitempty"`
+	Nonce           string          `json:"nonce"`     // 64-hex = 32 random bytes
+	TSUTC           string          `json:"ts_utc"`    // RFC3339
+	Signature       string          `json:"signature"` // base64 64-byte Ed25519 over JCS(body\signature)
 }
 
 type HardwareSummary struct {
@@ -109,6 +112,8 @@ type Handler struct {
 	// SQLite auth DB — for provider_tokens mint. Reuses existing
 	// phase4-coordinator/internal/auth store.
 	AuthTokenStore AuthTokenStore
+	ReferralStore  ReferralStore
+	ReferralPolicy auth.ReferralPolicy
 
 	// Coordinator config
 	CoordinatorDomain string
@@ -162,6 +167,14 @@ type StatsDB interface {
 	CheckAppAttestKeyIDUnique(ctx context.Context, keyID []byte, providerID string) error
 }
 
+// RegistrationPrepareStore is the durable PostgreSQL half of a gated
+// App-track registration. It is a separate optional interface so open-beta
+// test seams and non-gated deployments retain the existing StatsDB contract.
+type RegistrationPrepareStore interface {
+	PrepareProviderRegistration(ctx context.Context, providerID, sourceIP, nonce string, observedAt, attemptTS time.Time, identityPubkey []byte, attested bool, appAttestKeyID []byte) error
+	ProviderRegistrationPrepared(ctx context.Context, providerID, nonce string, attemptTS time.Time) (bool, error)
+}
+
 // AuthTokenStore is the SQLite-side dependency (existing
 // phase4-coordinator/internal/auth/tokens.go).
 type AuthTokenStore interface {
@@ -175,6 +188,14 @@ type AuthTokenStore interface {
 	// bound provider_id. Evidence submission is read-only with respect to the
 	// SQLite token store, so it does not mark the token used.
 	ValidateToken(ctx context.Context, token string) (providerID string, ok bool, err error)
+}
+
+type ReferralStore interface {
+	MintProviderTokenAppTrackWithReferralAttempt(ctx context.Context, providerID, referralCode string, policy auth.ReferralPolicy, attempt auth.AppTrackRegistrationAttempt) (cleartext string, err error)
+	AcknowledgeAppTrackReferralMint(ctx context.Context, providerID, cleartextToken string) error
+	RollbackAppTrackReferralMint(ctx context.Context, providerID, cleartextToken string) error
+	ListPendingAppTrackReferralMints(ctx context.Context, createdBefore time.Time) ([]auth.PendingAppTrackReferralMint, error)
+	ResolvePendingAppTrackReferralMint(ctx context.Context, pending auth.PendingAppTrackReferralMint, registrationPrepared bool) error
 }
 
 // IPRateLimiter and ASNRateLimiter both wrap the coordinator's existing
@@ -261,6 +282,10 @@ func (h *Handler) HandleAppTrackRegister(w http.ResponseWriter, r *http.Request)
 		writeJSONError(w, http.StatusBadRequest, "bad_request", "invalid request body")
 		return
 	}
+	if len([]byte(req.ReferralCode)) > 256 || strings.IndexFunc(req.ReferralCode, func(r rune) bool { return r < 0x20 || r == 0x7f }) >= 0 {
+		writeJSONError(w, http.StatusBadRequest, "bad_request", "referral_code is invalid")
+		return
+	}
 
 	pubkey, err := DecodeIdentityPubkey(req.IdentityPubkey)
 	if err != nil {
@@ -284,10 +309,6 @@ func (h *Handler) HandleAppTrackRegister(w http.ResponseWriter, r *http.Request)
 	if h.Now != nil {
 		now = h.Now().UTC()
 	}
-	if delta := now.Sub(tsUTC); delta > time.Minute || delta < -time.Minute {
-		writeJSONError(w, http.StatusBadRequest, "timestamp_skew", "ts_utc outside allowed skew")
-		return
-	}
 	signature, err := base64.StdEncoding.DecodeString(req.Signature)
 	if err != nil || len(signature) != ed25519.SignatureSize {
 		writeJSONError(w, http.StatusBadRequest, "bad_request", "invalid signature encoding")
@@ -305,6 +326,40 @@ func (h *Handler) HandleAppTrackRegister(w http.ResponseWriter, r *http.Request)
 	}
 
 	sourceIP := clientIP(r, h.TrustedProxies)
+	currentBearer := bearerFromRequest(r)
+	bearerExempt := false
+	if h.ReferralPolicy.RequireForRegistration && currentBearer != nil {
+		boundProviderID, ok, validateErr := h.AuthTokenStore.ValidateToken(r.Context(), *currentBearer)
+		if validateErr != nil {
+			writeJSONError(w, http.StatusServiceUnavailable, "unavailable", "credential authority unavailable")
+			return
+		}
+		bearerExempt = ok && boundProviderID == req.ProviderID
+	}
+	prepareStore, prepareStoreOK := h.StatsDB.(RegistrationPrepareStore)
+	if h.ReferralPolicy.RequireForRegistration && !bearerExempt {
+		if h.ReferralStore == nil || !prepareStoreOK {
+			writeJSONError(w, http.StatusServiceUnavailable, "unavailable", "referral authority unavailable")
+			return
+		}
+		// A retry of an already committed signed attempt never rotates or
+		// re-discloses credentials. Return a stable support state instead.
+		checkCtx, cancelCheck := context.WithTimeout(r.Context(), 2*time.Second)
+		prepared, checkErr := prepareStore.ProviderRegistrationPrepared(checkCtx, req.ProviderID, req.Nonce, tsUTC)
+		cancelCheck()
+		if checkErr != nil {
+			writeJSONError(w, http.StatusServiceUnavailable, "unavailable", "provider registration outcome unavailable")
+			return
+		}
+		if prepared {
+			writeJSONError(w, http.StatusConflict, "existing_active_token_no_proof", "registration already committed; existing credential proof or support is required")
+			return
+		}
+	}
+	if delta := now.Sub(tsUTC); delta > time.Minute || delta < -time.Minute {
+		writeJSONError(w, http.StatusBadRequest, "timestamp_skew", "ts_utc outside allowed skew")
+		return
+	}
 	if h.IPRateLimiter != nil && !h.IPRateLimiter.Allow(sourceIP) {
 		if h.Metrics != nil {
 			h.Metrics.IncRegisterRateLimitHit("ip")
@@ -332,15 +387,6 @@ func (h *Handler) HandleAppTrackRegister(w http.ResponseWriter, r *http.Request)
 			return
 		}
 	}
-	if err := h.StatsDB.InsertRegisterNonce(r.Context(), req.ProviderID, sourceIP, req.Nonce, now); err != nil {
-		if errors.Is(err, ErrNonceReplay) {
-			writeJSONError(w, http.StatusConflict, "nonce_replay", "register nonce replay")
-			return
-		}
-		writeJSONError(w, http.StatusInternalServerError, "internal_error", "nonce replay check failed")
-		return
-	}
-
 	attested := false
 	var appAttestKeyID []byte
 	if req.AppAttestObject != nil {
@@ -398,30 +444,80 @@ func (h *Handler) HandleAppTrackRegister(w http.ResponseWriter, r *http.Request)
 			return
 		}
 	}
-	if err := h.StatsDB.UpsertProviderIdentity(r.Context(), req.ProviderID, pubkey, attested, appAttestKeyID); err != nil {
-		switch {
-		case errors.Is(err, ErrTOFUConflict):
-			writeJSONError(w, http.StatusConflict, "provider_id_pubkey_mismatch", "provider_id already registered with a different identity_pubkey")
-		case errors.Is(err, ErrAttestKeyReused):
-			writeJSONError(w, http.StatusConflict, "app_attest_key_reused", "app_attest_key_id already bound")
-		default:
-			writeJSONError(w, http.StatusInternalServerError, "internal_error", "provider identity upsert failed")
+	var token string
+	if h.ReferralPolicy.RequireForRegistration && !bearerExempt {
+		attempt := auth.AppTrackRegistrationAttempt{SourceIP: sourceIP, Nonce: req.Nonce, AttemptTS: tsUTC}
+		mintCtx, cancelMint := context.WithTimeout(r.Context(), 2*time.Second)
+		token, err = h.ReferralStore.MintProviderTokenAppTrackWithReferralAttempt(
+			mintCtx, req.ProviderID, req.ReferralCode, h.ReferralPolicy, attempt,
+		)
+		cancelMint()
+		if err != nil {
+			writeAppTrackMintError(w, err)
+			return
 		}
-		return
-	}
-	currentBearer := bearerFromRequest(r)
-	token, err := h.AuthTokenStore.MintProviderTokenAppTrack(r.Context(), req.ProviderID, currentBearer)
-	if err != nil {
-		switch {
-		case errors.Is(err, auth.ErrAppTrackExistingTokenNoProof):
-			writeJSONError(w, http.StatusConflict, "existing_active_token_no_proof", "existing active token requires proof")
-		case errors.Is(err, auth.ErrAppTrackReissueCooldown):
-			w.Header().Set("Retry-After", "300")
-			writeJSONError(w, http.StatusTooManyRequests, "reissue_cooldown", "provider token reissue cooldown active")
-		default:
-			writeJSONError(w, http.StatusInternalServerError, "internal_error", "provider token mint failed")
+
+		prepareCtx, cancelPrepare := context.WithTimeout(r.Context(), 2*time.Second)
+		prepareErr := prepareStore.PrepareProviderRegistration(
+			prepareCtx, req.ProviderID, sourceIP, req.Nonce, now, tsUTC,
+			pubkey, attested, appAttestKeyID,
+		)
+		cancelPrepare()
+		if prepareErr != nil {
+			// PostgreSQL commit errors can be ambiguous. Compensate only after the
+			// exact durable marker proves this attempt did not commit.
+			checkCtx, cancelCheck := context.WithTimeout(context.Background(), 2*time.Second)
+			prepared, checkErr := prepareStore.ProviderRegistrationPrepared(checkCtx, req.ProviderID, req.Nonce, tsUTC)
+			cancelCheck()
+			if checkErr != nil {
+				writeJSONError(w, http.StatusInternalServerError, "internal_error", "provider registration outcome pending reconciliation")
+				return
+			}
+			if !prepared {
+				rollbackCtx, cancelRollback := context.WithTimeout(context.Background(), 2*time.Second)
+				rollbackErr := h.ReferralStore.RollbackAppTrackReferralMint(rollbackCtx, req.ProviderID, token)
+				cancelRollback()
+				if rollbackErr != nil {
+					writeJSONError(w, http.StatusInternalServerError, "internal_error", "provider registration compensation pending reconciliation")
+					return
+				}
+				writeAppTrackPrepareError(w, prepareErr)
+				return
+			}
 		}
-		return
+
+		ackCtx, cancelAck := context.WithTimeout(context.Background(), 2*time.Second)
+		ackErr := h.ReferralStore.AcknowledgeAppTrackReferralMint(ackCtx, req.ProviderID, token)
+		cancelAck()
+		if ackErr != nil {
+			if metrics, ok := h.Metrics.(interface{ IncRegisterReconcileDeferred() }); ok {
+				metrics.IncRegisterReconcileDeferred()
+			}
+		}
+		if !h.appTrackTokenStillActive(req.ProviderID, token) {
+			writeJSONError(w, http.StatusConflict, "existing_active_token_no_proof", "credential was superseded before disclosure")
+			return
+		}
+	} else {
+		// Open registration and custody-proven reissues retain the established
+		// PostgreSQL-first path; they do not consume referral capacity.
+		if err := h.StatsDB.InsertRegisterNonce(r.Context(), req.ProviderID, sourceIP, req.Nonce, now); err != nil {
+			if errors.Is(err, ErrNonceReplay) {
+				writeJSONError(w, http.StatusConflict, "nonce_replay", "register nonce replay")
+				return
+			}
+			writeJSONError(w, http.StatusInternalServerError, "internal_error", "nonce replay check failed")
+			return
+		}
+		if err := h.StatsDB.UpsertProviderIdentity(r.Context(), req.ProviderID, pubkey, attested, appAttestKeyID); err != nil {
+			writeAppTrackPrepareError(w, err)
+			return
+		}
+		token, err = h.AuthTokenStore.MintProviderTokenAppTrack(r.Context(), req.ProviderID, currentBearer)
+		if err != nil {
+			writeAppTrackMintError(w, err)
+			return
+		}
 	}
 	h.persistHardwareProfileAsync(req.ProviderID, req.HardwareSummary, now)
 	if h.Metrics != nil {
@@ -434,6 +530,80 @@ func (h *Handler) HandleAppTrackRegister(w http.ResponseWriter, r *http.Request)
 		Trust:            TrustState{Attested: attested, RateLimitBucket: "new_ip"},
 		CoordinatorWSURL: h.CoordinatorWSURL,
 	})
+}
+
+// ReconcilePendingAppTrackReferralMints resolves only sagas old enough not to
+// belong to a live request. A committed marker preserves the token; an absent
+// marker compensates the undisclosed token and its exact new redemption.
+func (h *Handler) ReconcilePendingAppTrackReferralMints(ctx context.Context) error {
+	if h == nil || h.ReferralStore == nil || h.StatsDB == nil {
+		return nil
+	}
+	prepareStore, ok := h.StatsDB.(RegistrationPrepareStore)
+	if !ok {
+		return errors.New("registration prepare store unavailable")
+	}
+	now := time.Now().UTC()
+	if h.Now != nil {
+		now = h.Now().UTC()
+	}
+	pending, err := h.ReferralStore.ListPendingAppTrackReferralMints(ctx, now.Add(-appTrackPendingMintReconcileAge))
+	if err != nil {
+		return fmt.Errorf("list pending App-track referral mints: %w", err)
+	}
+	var reconcileErrs []error
+	for _, item := range pending {
+		prepared, err := prepareStore.ProviderRegistrationPrepared(
+			ctx, item.ProviderID, item.Attempt.Nonce, item.Attempt.AttemptTS,
+		)
+		if err != nil {
+			reconcileErrs = append(reconcileErrs, fmt.Errorf("check pending App-track mint %s: %w", item.ProviderID, err))
+			continue
+		}
+		if err := h.ReferralStore.ResolvePendingAppTrackReferralMint(ctx, item, prepared); err != nil {
+			reconcileErrs = append(reconcileErrs, fmt.Errorf("resolve pending App-track mint %s: %w", item.ProviderID, err))
+		}
+	}
+	return errors.Join(reconcileErrs...)
+}
+
+func writeAppTrackPrepareError(w http.ResponseWriter, err error) {
+	switch {
+	case errors.Is(err, ErrNonceReplay):
+		writeJSONError(w, http.StatusConflict, "nonce_replay", "register nonce replay")
+	case errors.Is(err, ErrTOFUConflict):
+		writeJSONError(w, http.StatusConflict, "provider_id_pubkey_mismatch", "provider_id already registered with a different identity_pubkey")
+	case errors.Is(err, ErrAttestKeyReused):
+		writeJSONError(w, http.StatusConflict, "app_attest_key_reused", "app_attest_key_id already bound")
+	default:
+		writeJSONError(w, http.StatusInternalServerError, "internal_error", "provider registration prepare failed")
+	}
+}
+
+func writeAppTrackMintError(w http.ResponseWriter, err error) {
+	switch {
+	case errors.Is(err, auth.ErrReferralRequired), errors.Is(err, auth.ErrReferralInvalid),
+		errors.Is(err, auth.ErrReferralExpired), errors.Is(err, auth.ErrReferralRevoked),
+		errors.Is(err, auth.ErrReferralExhausted), errors.Is(err, auth.ErrReferralConflict):
+		writeReferralError(w, err)
+	case errors.Is(err, auth.ErrAppTrackExistingTokenNoProof):
+		writeJSONError(w, http.StatusConflict, "existing_active_token_no_proof", "existing active token requires proof")
+	case errors.Is(err, auth.ErrAppTrackReissueCooldown):
+		w.Header().Set("Retry-After", "300")
+		writeJSONError(w, http.StatusTooManyRequests, "reissue_cooldown", "provider token reissue cooldown active")
+	default:
+		writeJSONError(w, http.StatusInternalServerError, "internal_error", "provider token mint failed")
+	}
+}
+
+func (h *Handler) appTrackTokenStillActive(providerID, cleartext string) bool {
+	if h.AuthTokenStore == nil {
+		return false
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	bound, ok, err := h.AuthTokenStore.ValidateToken(ctx, cleartext)
+	return err == nil && ok && bound == providerID
 }
 
 func (h *Handler) persistHardwareProfileAsync(providerID string, summary HardwareSummary, observedAt time.Time) {
@@ -528,6 +698,7 @@ func (h *Handler) clientDataHash(req RegisterRequest) [32]byte {
 		"provider_id":        req.ProviderID,
 		"identity_pubkey":    req.IdentityPubkey,
 		"register_nonce":     req.Nonce,
+		"referral_code":      req.ReferralCode,
 		"coordinator_domain": domain,
 		"bundle_id":          h.AppAttestConfig.BundleID,
 		"team_id":            h.AppAttestConfig.TeamID,
@@ -551,6 +722,30 @@ func bearerFromRequest(r *http.Request) *string {
 		return nil
 	}
 	return &token
+}
+
+func writeReferralError(w http.ResponseWriter, err error) {
+	switch {
+	case errors.Is(err, auth.ErrReferralRequired):
+		writeReferralJSONError(w, http.StatusBadRequest, "referral_required", "missing", "a valid pre-beta referral is required")
+	case errors.Is(err, auth.ErrReferralExpired):
+		writeReferralJSONError(w, http.StatusGone, "referral_expired", "expired", "referral code expired")
+	case errors.Is(err, auth.ErrReferralRevoked):
+		writeReferralJSONError(w, http.StatusGone, "referral_revoked", "revoked", "referral code revoked")
+	case errors.Is(err, auth.ErrReferralExhausted):
+		writeReferralJSONError(w, http.StatusConflict, "referral_exhausted", "exhausted", "all spots on this referral are taken")
+	case errors.Is(err, auth.ErrReferralConflict):
+		writeReferralJSONError(w, http.StatusConflict, "referral_conflict", "invalid", "provider is already attributed to another referral")
+	default:
+		writeReferralJSONError(w, http.StatusBadRequest, "referral_invalid", "invalid", "referral code is invalid")
+	}
+}
+
+func writeReferralJSONError(w http.ResponseWriter, status int, code, reason, message string) {
+	writeJSON(w, status, map[string]any{
+		"error":  map[string]any{"code": code, "message": message},
+		"reason": reason,
+	})
 }
 
 func writeJSON(w http.ResponseWriter, status int, v any) {
@@ -590,6 +785,12 @@ func clientIP(r *http.Request, trusted []netip.Prefix) string {
 		}
 	}
 	return host
+}
+
+// ClientIP exposes the audited trusted-proxy walk to adjacent public
+// onboarding endpoints without duplicating proxy-boundary logic.
+func ClientIP(r *http.Request, trusted []netip.Prefix) string {
+	return clientIP(r, trusted)
 }
 
 func parseIPAddr(s string) (netip.Addr, bool) {

--- a/phase4-coordinator/internal/onboarding/apptrack.go
+++ b/phase4-coordinator/internal/onboarding/apptrack.go
@@ -37,9 +37,13 @@ type RegisterRequest struct {
 	AppAttestObject *string         `json:"app_attest_object,omitempty"` // base64 CBOR
 	AppAttestKeyID  *string         `json:"app_attest_key_id,omitempty"` // base64 32-byte
 	ReferralCode    string          `json:"referral_code,omitempty"`
-	Nonce           string          `json:"nonce"`     // 64-hex = 32 random bytes
-	TSUTC           string          `json:"ts_utc"`    // RFC3339
-	Signature       string          `json:"signature"` // base64 64-byte Ed25519 over JCS(body\signature)
+	// ProviderTokenCandidate is generated and durably held by the client
+	// before transport. Binding it into the signed request makes a committed
+	// registration idempotently recoverable after a lost HTTP response.
+	ProviderTokenCandidate string `json:"provider_token_candidate,omitempty"`
+	Nonce                  string `json:"nonce"`     // 64-hex = 32 random bytes
+	TSUTC                  string `json:"ts_utc"`    // RFC3339
+	Signature              string `json:"signature"` // base64 64-byte Ed25519 over JCS(body\signature)
 }
 
 type HardwareSummary struct {
@@ -180,9 +184,10 @@ type RegistrationPrepareStore interface {
 type AuthTokenStore interface {
 	// MintProviderTokenAppTrack mints per SPEC-026 §4.1 step 7 semantics.
 	// Duplicate registration with any active token requires bearer proof from
-	// the Authorization header; request bodies must never carry bearer material.
-	// provider_name is the tenant literal "malibu-app" for App-track.
-	MintProviderTokenAppTrack(ctx context.Context, providerID string, currentBearer *string) (cleartext string, err error)
+	// the Authorization header; request bodies must never carry the current
+	// bearer. A fresh client-held candidate is not authoritative until this
+	// transaction commits. provider_name is the tenant literal "malibu-app".
+	MintProviderTokenAppTrack(ctx context.Context, providerID string, currentBearer, freshTokenCandidate *string) (cleartext string, err error)
 
 	// ValidateToken validates an existing provider bearer token and returns the
 	// bound provider_id. Evidence submission is read-only with respect to the
@@ -191,7 +196,7 @@ type AuthTokenStore interface {
 }
 
 type ReferralStore interface {
-	MintProviderTokenAppTrackWithReferralAttempt(ctx context.Context, providerID, referralCode string, policy auth.ReferralPolicy, attempt auth.AppTrackRegistrationAttempt) (cleartext string, err error)
+	MintProviderTokenAppTrackWithReferralAttempt(ctx context.Context, providerID, referralCode, tokenCandidate string, policy auth.ReferralPolicy, attempt auth.AppTrackRegistrationAttempt) (cleartext string, err error)
 	AcknowledgeAppTrackReferralMint(ctx context.Context, providerID, cleartextToken string) error
 	RollbackAppTrackReferralMint(ctx context.Context, providerID, cleartextToken string) error
 	ListPendingAppTrackReferralMints(ctx context.Context, createdBefore time.Time) ([]auth.PendingAppTrackReferralMint, error)
@@ -286,6 +291,10 @@ func (h *Handler) HandleAppTrackRegister(w http.ResponseWriter, r *http.Request)
 		writeJSONError(w, http.StatusBadRequest, "bad_request", "referral_code is invalid")
 		return
 	}
+	if req.ProviderTokenCandidate != "" && (len(req.ProviderTokenCandidate) != 64 || !isLowerHex(req.ProviderTokenCandidate)) {
+		writeJSONError(w, http.StatusBadRequest, "bad_request", "provider_token_candidate must be 64 lowercase hex chars")
+		return
+	}
 
 	pubkey, err := DecodeIdentityPubkey(req.IdentityPubkey)
 	if err != nil {
@@ -326,36 +335,6 @@ func (h *Handler) HandleAppTrackRegister(w http.ResponseWriter, r *http.Request)
 	}
 
 	sourceIP := clientIP(r, h.TrustedProxies)
-	currentBearer := bearerFromRequest(r)
-	bearerExempt := false
-	if h.ReferralPolicy.RequireForRegistration && currentBearer != nil {
-		boundProviderID, ok, validateErr := h.AuthTokenStore.ValidateToken(r.Context(), *currentBearer)
-		if validateErr != nil {
-			writeJSONError(w, http.StatusServiceUnavailable, "unavailable", "credential authority unavailable")
-			return
-		}
-		bearerExempt = ok && boundProviderID == req.ProviderID
-	}
-	prepareStore, prepareStoreOK := h.StatsDB.(RegistrationPrepareStore)
-	if h.ReferralPolicy.RequireForRegistration && !bearerExempt {
-		if h.ReferralStore == nil || !prepareStoreOK {
-			writeJSONError(w, http.StatusServiceUnavailable, "unavailable", "referral authority unavailable")
-			return
-		}
-		// A retry of an already committed signed attempt never rotates or
-		// re-discloses credentials. Return a stable support state instead.
-		checkCtx, cancelCheck := context.WithTimeout(r.Context(), 2*time.Second)
-		prepared, checkErr := prepareStore.ProviderRegistrationPrepared(checkCtx, req.ProviderID, req.Nonce, tsUTC)
-		cancelCheck()
-		if checkErr != nil {
-			writeJSONError(w, http.StatusServiceUnavailable, "unavailable", "provider registration outcome unavailable")
-			return
-		}
-		if prepared {
-			writeJSONError(w, http.StatusConflict, "existing_active_token_no_proof", "registration already committed; existing credential proof or support is required")
-			return
-		}
-	}
 	if delta := now.Sub(tsUTC); delta > time.Minute || delta < -time.Minute {
 		writeJSONError(w, http.StatusBadRequest, "timestamp_skew", "ts_utc outside allowed skew")
 		return
@@ -384,6 +363,49 @@ func (h *Handler) HandleAppTrackRegister(w http.ResponseWriter, r *http.Request)
 			}
 			w.Header().Set("Retry-After", "60")
 			writeJSONError(w, http.StatusTooManyRequests, "rate_limited", "asn rate limit exceeded")
+			return
+		}
+	}
+	currentBearer := bearerFromRequest(r)
+	bearerExempt := false
+	if h.ReferralPolicy.RequireForRegistration && currentBearer != nil {
+		boundProviderID, ok, validateErr := h.AuthTokenStore.ValidateToken(r.Context(), *currentBearer)
+		if validateErr != nil {
+			writeJSONError(w, http.StatusServiceUnavailable, "unavailable", "credential authority unavailable")
+			return
+		}
+		bearerExempt = ok && boundProviderID == req.ProviderID
+	}
+	prepareStore, prepareStoreOK := h.StatsDB.(RegistrationPrepareStore)
+	if h.ReferralPolicy.RequireForRegistration && !bearerExempt {
+		if h.ReferralStore == nil || !prepareStoreOK {
+			writeJSONError(w, http.StatusServiceUnavailable, "unavailable", "referral authority unavailable")
+			return
+		}
+		if req.ProviderTokenCandidate == "" {
+			writeJSONError(w, http.StatusBadRequest, "provider_token_candidate_required", "a client-held provider token candidate is required for gated registration")
+			return
+		}
+		// A retry of an already committed signed attempt never rotates or
+		// re-discloses credentials. Return a stable support state instead.
+		checkCtx, cancelCheck := context.WithTimeout(r.Context(), 2*time.Second)
+		prepared, checkErr := prepareStore.ProviderRegistrationPrepared(checkCtx, req.ProviderID, req.Nonce, tsUTC)
+		cancelCheck()
+		if checkErr != nil {
+			writeJSONError(w, http.StatusServiceUnavailable, "unavailable", "provider registration outcome unavailable")
+			return
+		}
+		if prepared {
+			boundProviderID, ok, validateErr := h.AuthTokenStore.ValidateToken(r.Context(), req.ProviderTokenCandidate)
+			if validateErr != nil {
+				writeJSONError(w, http.StatusServiceUnavailable, "unavailable", "credential authority unavailable")
+				return
+			}
+			if !ok || boundProviderID != req.ProviderID {
+				writeJSONError(w, http.StatusConflict, "committed_credential_mismatch", "registration committed with a different credential candidate")
+				return
+			}
+			writeAppTrackRegisterSuccess(w, req.ProviderID, req.ProviderTokenCandidate, false, h.CoordinatorWSURL)
 			return
 		}
 	}
@@ -449,7 +471,7 @@ func (h *Handler) HandleAppTrackRegister(w http.ResponseWriter, r *http.Request)
 		attempt := auth.AppTrackRegistrationAttempt{SourceIP: sourceIP, Nonce: req.Nonce, AttemptTS: tsUTC}
 		mintCtx, cancelMint := context.WithTimeout(r.Context(), 2*time.Second)
 		token, err = h.ReferralStore.MintProviderTokenAppTrackWithReferralAttempt(
-			mintCtx, req.ProviderID, req.ReferralCode, h.ReferralPolicy, attempt,
+			mintCtx, req.ProviderID, req.ReferralCode, req.ProviderTokenCandidate, h.ReferralPolicy, attempt,
 		)
 		cancelMint()
 		if err != nil {
@@ -513,7 +535,11 @@ func (h *Handler) HandleAppTrackRegister(w http.ResponseWriter, r *http.Request)
 			writeAppTrackPrepareError(w, err)
 			return
 		}
-		token, err = h.AuthTokenStore.MintProviderTokenAppTrack(r.Context(), req.ProviderID, currentBearer)
+		var freshTokenCandidate *string
+		if currentBearer == nil && req.ProviderTokenCandidate != "" {
+			freshTokenCandidate = &req.ProviderTokenCandidate
+		}
+		token, err = h.AuthTokenStore.MintProviderTokenAppTrack(r.Context(), req.ProviderID, currentBearer, freshTokenCandidate)
 		if err != nil {
 			writeAppTrackMintError(w, err)
 			return
@@ -523,12 +549,16 @@ func (h *Handler) HandleAppTrackRegister(w http.ResponseWriter, r *http.Request)
 	if h.Metrics != nil {
 		h.Metrics.IncRegisterSource("app")
 	}
+	writeAppTrackRegisterSuccess(w, req.ProviderID, token, attested, h.CoordinatorWSURL)
+}
+
+func writeAppTrackRegisterSuccess(w http.ResponseWriter, providerID, token string, attested bool, coordinatorWSURL string) {
 	writeJSON(w, http.StatusOK, RegisterResponse{
-		ProviderID:       req.ProviderID,
+		ProviderID:       providerID,
 		ProviderToken:    token,
 		TrustTier:        "provisional",
 		Trust:            TrustState{Attested: attested, RateLimitBucket: "new_ip"},
-		CoordinatorWSURL: h.CoordinatorWSURL,
+		CoordinatorWSURL: coordinatorWSURL,
 	})
 }
 

--- a/phase4-coordinator/internal/onboarding/apptrack_test.go
+++ b/phase4-coordinator/internal/onboarding/apptrack_test.go
@@ -137,9 +137,13 @@ func TestHandleAppTrackRegisterFreshGateUsesSagaThenDiscloses(t *testing.T) {
 }
 
 func TestHandleAppTrackRegisterCommittedRetryNeverRotatesCredential(t *testing.T) {
-	body, _ := signedRegisterBody(t, func(body map[string]any) { body["referral_code"] = "invite" })
+	body, providerID := signedRegisterBody(t, func(body map[string]any) { body["referral_code"] = "invite" })
 	stats := &fakeStatsDB{prepared: true}
-	authStore := &fakeAuthStore{referralToken: "must-not-mint"}
+	authStore := &fakeAuthStore{
+		referralToken:      "must-not-mint",
+		validateOK:         true,
+		validateProviderID: providerID,
+	}
 	handler := testRegisterHandler(stats, authStore, nil)
 	handler.ReferralPolicy = auth.ReferralPolicy{RequireForRegistration: true}
 	handler.ReferralStore = authStore
@@ -148,11 +152,49 @@ func TestHandleAppTrackRegisterCommittedRetryNeverRotatesCredential(t *testing.T
 
 	handler.HandleAppTrackRegister(response, req)
 
-	if response.Code != http.StatusConflict || !strings.Contains(response.Body.String(), "existing_active_token_no_proof") {
+	if response.Code != http.StatusOK || !strings.Contains(response.Body.String(), strings.Repeat("c", 64)) {
 		t.Fatalf("status=%d body=%s", response.Code, response.Body.String())
 	}
 	if authStore.referralMintCalls != 0 || stats.prepareCalls != 0 {
 		t.Fatalf("committed retry mutated state: mint=%d prepare=%d", authStore.referralMintCalls, stats.prepareCalls)
+	}
+}
+
+func TestHandleAppTrackRegisterCommittedRetryRejectsDifferentCandidate(t *testing.T) {
+	body, _ := signedRegisterBody(t, func(body map[string]any) { body["referral_code"] = "invite" })
+	stats := &fakeStatsDB{prepared: true}
+	authStore := &fakeAuthStore{}
+	handler := testRegisterHandler(stats, authStore, nil)
+	handler.ReferralPolicy = auth.ReferralPolicy{RequireForRegistration: true}
+	handler.ReferralStore = authStore
+	response := httptest.NewRecorder()
+
+	handler.HandleAppTrackRegister(response, httptest.NewRequest(http.MethodPost, "/v1/providers/register", bytes.NewReader(body)))
+
+	if response.Code != http.StatusConflict || !strings.Contains(response.Body.String(), "committed_credential_mismatch") {
+		t.Fatalf("status=%d body=%s", response.Code, response.Body.String())
+	}
+	if authStore.referralMintCalls != 0 || stats.prepareCalls != 0 {
+		t.Fatalf("committed retry mutated state: mint=%d prepare=%d", authStore.referralMintCalls, stats.prepareCalls)
+	}
+}
+
+func TestHandleAppTrackRegisterGateRequiresClientHeldCandidate(t *testing.T) {
+	body, _ := signedRegisterBody(t, func(body map[string]any) {
+		body["referral_code"] = "invite"
+		delete(body, "provider_token_candidate")
+	})
+	stats := &fakeStatsDB{}
+	authStore := &fakeAuthStore{}
+	handler := testRegisterHandler(stats, authStore, nil)
+	handler.ReferralPolicy = auth.ReferralPolicy{RequireForRegistration: true}
+	handler.ReferralStore = authStore
+	response := httptest.NewRecorder()
+
+	handler.HandleAppTrackRegister(response, httptest.NewRequest(http.MethodPost, "/v1/providers/register", bytes.NewReader(body)))
+
+	if response.Code != http.StatusBadRequest || !strings.Contains(response.Body.String(), "provider_token_candidate_required") {
+		t.Fatalf("status=%d body=%s", response.Code, response.Body.String())
 	}
 }
 
@@ -686,10 +728,12 @@ func TestHandleAppTrackRegisterMapsRateLimitAndCooldown(t *testing.T) {
 func TestHandleAppTrackRegisterRateLimitDoesNotWriteReplayNonce(t *testing.T) {
 	body, _ := signedRegisterBody(t, nil)
 	stats := &fakeStatsDB{}
-	handler := testRegisterHandler(stats, &fakeAuthStore{token: "provider-token"}, &fakeMetrics{}, denyLimiter{})
+	authStore := &fakeAuthStore{token: "provider-token", validateOK: true}
+	handler := testRegisterHandler(stats, authStore, &fakeMetrics{}, denyLimiter{})
 
 	req := httptest.NewRequest(http.MethodPost, "/v1/providers/register", bytes.NewReader(body))
 	req.RemoteAddr = "198.51.100.10:4444"
+	req.Header.Set("Authorization", "Bearer existing-token")
 	rr := httptest.NewRecorder()
 	handler.HandleAppTrackRegister(rr, req)
 
@@ -698,6 +742,12 @@ func TestHandleAppTrackRegisterRateLimitDoesNotWriteReplayNonce(t *testing.T) {
 	}
 	if stats.nonceCalls != 0 {
 		t.Fatalf("nonce calls=%d, want 0 before rate-limit rejection", stats.nonceCalls)
+	}
+	if stats.preparedChecks != 0 {
+		t.Fatalf("prepared checks=%d, want 0 before rate-limit rejection", stats.preparedChecks)
+	}
+	if authStore.validateCalls != 0 {
+		t.Fatalf("credential validations=%d, want 0 before rate-limit rejection", authStore.validateCalls)
 	}
 	if calls := stats.hardwareCallsCount(); calls != 0 {
 		t.Fatalf("hardware calls=%d, want 0 before rate-limit rejection", calls)
@@ -1083,8 +1133,9 @@ func signedRegisterBody(t *testing.T, mutate func(map[string]any)) ([]byte, stri
 			"macos_version":     "15.5",
 			"app_version":       "1.0.0",
 		},
-		"nonce":  strings.Repeat("a", 64),
-		"ts_utc": "2026-07-03T12:00:00Z",
+		"nonce":                    strings.Repeat("a", 64),
+		"ts_utc":                   "2026-07-03T12:00:00Z",
+		"provider_token_candidate": strings.Repeat("c", 64),
 	}
 	normalized, err := json.Marshal(body)
 	if err != nil {
@@ -1285,6 +1336,7 @@ type fakeAuthStore struct {
 	validateProviderID string
 	validateOK         bool
 	validateErr        error
+	validateCalls      int
 	referralToken      string
 	referralMintErr    error
 	referralMintCalls  int
@@ -1297,16 +1349,20 @@ type fakeAuthStore struct {
 	resolvedPrepared   []bool
 }
 
-func (f *fakeAuthStore) MintProviderTokenAppTrack(ctx context.Context, providerID string, currentBearer *string) (string, error) {
+func (f *fakeAuthStore) MintProviderTokenAppTrack(ctx context.Context, providerID string, currentBearer, freshTokenCandidate *string) (string, error) {
 	f.providerID = providerID
 	f.bearer = currentBearer
 	if f.err != nil {
 		return "", f.err
 	}
+	if currentBearer == nil && freshTokenCandidate != nil && f.token == "" {
+		return *freshTokenCandidate, nil
+	}
 	return f.token, nil
 }
 
 func (f *fakeAuthStore) ValidateToken(ctx context.Context, token string) (string, bool, error) {
+	f.validateCalls++
 	if f.validateErr != nil {
 		return "", false, f.validateErr
 	}
@@ -1319,13 +1375,16 @@ func (f *fakeAuthStore) ValidateToken(ctx context.Context, token string) (string
 	return f.providerID, true, nil
 }
 
-func (f *fakeAuthStore) MintProviderTokenAppTrackWithReferralAttempt(_ context.Context, providerID, referralCode string, policy auth.ReferralPolicy, attempt auth.AppTrackRegistrationAttempt) (string, error) {
+func (f *fakeAuthStore) MintProviderTokenAppTrackWithReferralAttempt(_ context.Context, providerID, referralCode, tokenCandidate string, policy auth.ReferralPolicy, attempt auth.AppTrackRegistrationAttempt) (string, error) {
 	f.referralMintCalls++
 	f.providerID = providerID
 	if f.referralMintErr != nil {
 		return "", f.referralMintErr
 	}
-	return f.referralToken, nil
+	if f.referralToken != "" {
+		return f.referralToken, nil
+	}
+	return tokenCandidate, nil
 }
 
 func (f *fakeAuthStore) AcknowledgeAppTrackReferralMint(context.Context, string, string) error {

--- a/phase4-coordinator/internal/onboarding/apptrack_test.go
+++ b/phase4-coordinator/internal/onboarding/apptrack_test.go
@@ -62,6 +62,147 @@ func TestHandleAppTrackRegisterSuccess(t *testing.T) {
 	}
 }
 
+func TestHandleAppTrackRegisterBogusBearerDoesNotBypassReferralGate(t *testing.T) {
+	body, _ := signedRegisterBody(t, nil)
+	stats := &fakeStatsDB{}
+	authStore := &fakeAuthStore{referralMintErr: auth.ErrReferralRequired}
+	handler := testRegisterHandler(stats, authStore, nil)
+	handler.ReferralPolicy = auth.ReferralPolicy{RequireForRegistration: true}
+	handler.ReferralStore = authStore
+	req := httptest.NewRequest(http.MethodPost, "/v1/providers/register", bytes.NewReader(body))
+	req.Header.Set("Authorization", "Bearer bogus")
+	response := httptest.NewRecorder()
+
+	handler.HandleAppTrackRegister(response, req)
+
+	if response.Code != http.StatusBadRequest || !strings.Contains(response.Body.String(), "referral_required") {
+		t.Fatalf("status=%d body=%s", response.Code, response.Body.String())
+	}
+	if authStore.referralMintCalls != 1 || stats.prepareCalls != 0 || stats.upsertProviderID != "" {
+		t.Fatalf("mintCalls=%d prepareCalls=%d upsert=%q", authStore.referralMintCalls, stats.prepareCalls, stats.upsertProviderID)
+	}
+}
+
+func TestHandleAppTrackRegisterValidBearerBypassesReferralConsumption(t *testing.T) {
+	body, providerID := signedRegisterBody(t, nil)
+	stats := &fakeStatsDB{}
+	authStore := &fakeAuthStore{
+		token:              "replacement-token",
+		validateOK:         true,
+		validateProviderID: providerID,
+		referralMintErr:    auth.ErrReferralRequired,
+	}
+	handler := testRegisterHandler(stats, authStore, nil)
+	handler.ReferralPolicy = auth.ReferralPolicy{RequireForRegistration: true}
+	handler.ReferralStore = authStore
+	req := httptest.NewRequest(http.MethodPost, "/v1/providers/register", bytes.NewReader(body))
+	req.Header.Set("Authorization", "Bearer current-token")
+	response := httptest.NewRecorder()
+
+	handler.HandleAppTrackRegister(response, req)
+
+	if response.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s", response.Code, response.Body.String())
+	}
+	if authStore.referralMintCalls != 0 || stats.nonceCalls != 1 || stats.upsertProviderID != providerID {
+		t.Fatalf("referralMints=%d nonceCalls=%d upsert=%q", authStore.referralMintCalls, stats.nonceCalls, stats.upsertProviderID)
+	}
+}
+
+func TestHandleAppTrackRegisterFreshGateUsesSagaThenDiscloses(t *testing.T) {
+	body, providerID := signedRegisterBody(t, func(body map[string]any) { body["referral_code"] = "invite" })
+	stats := &fakeStatsDB{}
+	authStore := &fakeAuthStore{
+		referralToken:      "fresh-token",
+		validateOK:         true,
+		validateProviderID: providerID,
+	}
+	handler := testRegisterHandler(stats, authStore, nil)
+	handler.ReferralPolicy = auth.ReferralPolicy{RequireForRegistration: true}
+	handler.ReferralStore = authStore
+	req := httptest.NewRequest(http.MethodPost, "/v1/providers/register", bytes.NewReader(body))
+	response := httptest.NewRecorder()
+
+	handler.HandleAppTrackRegister(response, req)
+
+	if response.Code != http.StatusOK || !strings.Contains(response.Body.String(), "fresh-token") {
+		t.Fatalf("status=%d body=%s", response.Code, response.Body.String())
+	}
+	if authStore.referralMintCalls != 1 || stats.prepareCalls != 1 || authStore.ackCalls != 1 || authStore.rollbackCalls != 0 {
+		t.Fatalf("mint=%d prepare=%d ack=%d rollback=%d", authStore.referralMintCalls, stats.prepareCalls, authStore.ackCalls, authStore.rollbackCalls)
+	}
+	if stats.nonceCalls != 0 || stats.upsertProviderID != "" {
+		t.Fatalf("fresh gate used non-atomic legacy PG path: nonce=%d upsert=%q", stats.nonceCalls, stats.upsertProviderID)
+	}
+}
+
+func TestHandleAppTrackRegisterCommittedRetryNeverRotatesCredential(t *testing.T) {
+	body, _ := signedRegisterBody(t, func(body map[string]any) { body["referral_code"] = "invite" })
+	stats := &fakeStatsDB{prepared: true}
+	authStore := &fakeAuthStore{referralToken: "must-not-mint"}
+	handler := testRegisterHandler(stats, authStore, nil)
+	handler.ReferralPolicy = auth.ReferralPolicy{RequireForRegistration: true}
+	handler.ReferralStore = authStore
+	req := httptest.NewRequest(http.MethodPost, "/v1/providers/register", bytes.NewReader(body))
+	response := httptest.NewRecorder()
+
+	handler.HandleAppTrackRegister(response, req)
+
+	if response.Code != http.StatusConflict || !strings.Contains(response.Body.String(), "existing_active_token_no_proof") {
+		t.Fatalf("status=%d body=%s", response.Code, response.Body.String())
+	}
+	if authStore.referralMintCalls != 0 || stats.prepareCalls != 0 {
+		t.Fatalf("committed retry mutated state: mint=%d prepare=%d", authStore.referralMintCalls, stats.prepareCalls)
+	}
+}
+
+func TestHandleAppTrackRegisterCompensatesOnlyProvenAbsentPrepare(t *testing.T) {
+	body, providerID := signedRegisterBody(t, func(body map[string]any) { body["referral_code"] = "invite" })
+	stats := &fakeStatsDB{prepareErr: ErrTOFUConflict, prepared: false}
+	authStore := &fakeAuthStore{
+		referralToken:      "undisclosed-token",
+		validateOK:         true,
+		validateProviderID: providerID,
+	}
+	handler := testRegisterHandler(stats, authStore, nil)
+	handler.ReferralPolicy = auth.ReferralPolicy{RequireForRegistration: true}
+	handler.ReferralStore = authStore
+	req := httptest.NewRequest(http.MethodPost, "/v1/providers/register", bytes.NewReader(body))
+	response := httptest.NewRecorder()
+
+	handler.HandleAppTrackRegister(response, req)
+
+	if response.Code != http.StatusConflict || authStore.rollbackCalls != 1 || authStore.ackCalls != 0 {
+		t.Fatalf("status=%d rollback=%d ack=%d body=%s", response.Code, authStore.rollbackCalls, authStore.ackCalls, response.Body.String())
+	}
+}
+
+func TestReconcilePendingAppTrackReferralMintUsesExactSignedAttempt(t *testing.T) {
+	attemptTS := time.Date(2026, 7, 3, 11, 59, 30, 0, time.UTC)
+	pending := auth.PendingAppTrackReferralMint{
+		ProviderID: "provider-a",
+		TokenHash:  strings.Repeat("a", 64),
+		Attempt: auth.AppTrackRegistrationAttempt{
+			SourceIP: "203.0.113.10", Nonce: strings.Repeat("b", 64), AttemptTS: attemptTS,
+		},
+	}
+	stats := &fakeStatsDB{prepared: true}
+	authStore := &fakeAuthStore{pendingMints: []auth.PendingAppTrackReferralMint{pending}}
+	handler := testRegisterHandler(stats, authStore, nil)
+	handler.ReferralPolicy = auth.ReferralPolicy{RequireForRegistration: true}
+	handler.ReferralStore = authStore
+
+	if err := handler.ReconcilePendingAppTrackReferralMints(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if stats.preparedProviderID != pending.ProviderID || stats.preparedNonce != pending.Attempt.Nonce || !stats.preparedAttemptTS.Equal(attemptTS) {
+		t.Fatalf("prepared lookup provider=%q nonce=%q ts=%s", stats.preparedProviderID, stats.preparedNonce, stats.preparedAttemptTS)
+	}
+	if len(authStore.resolvedMints) != 1 || !authStore.resolvedPrepared[0] {
+		t.Fatalf("resolved=%+v prepared=%+v", authStore.resolvedMints, authStore.resolvedPrepared)
+	}
+}
+
 func TestHandleHardwareEvidenceQueuesAuthenticatedAutotuneEvidence(t *testing.T) {
 	now := time.Date(2026, 7, 3, 12, 0, 0, 0, time.UTC)
 	stats := &fakeStatsDB{}
@@ -1021,6 +1162,30 @@ type fakeStatsDB struct {
 	existingEvidenceRecord     HardwareEvidenceJobRecord
 	existingEvidenceFound      bool
 	existingEvidenceErr        error
+	prepareErr                 error
+	prepared                   bool
+	preparedErr                error
+	prepareCalls               int
+	preparedChecks             int
+	preparedProviderID         string
+	preparedNonce              string
+	preparedAttemptTS          time.Time
+}
+
+func (f *fakeStatsDB) PrepareProviderRegistration(_ context.Context, providerID, sourceIP, nonce string, observedAt, attemptTS time.Time, identityPubkey []byte, attested bool, appAttestKeyID []byte) error {
+	f.prepareCalls++
+	f.preparedProviderID = providerID
+	f.preparedNonce = nonce
+	f.preparedAttemptTS = attemptTS
+	return f.prepareErr
+}
+
+func (f *fakeStatsDB) ProviderRegistrationPrepared(_ context.Context, providerID, nonce string, attemptTS time.Time) (bool, error) {
+	f.preparedChecks++
+	f.preparedProviderID = providerID
+	f.preparedNonce = nonce
+	f.preparedAttemptTS = attemptTS
+	return f.prepared, f.preparedErr
 }
 
 func (f *fakeStatsDB) UpsertProviderIdentity(ctx context.Context, providerID string, identityPubkey []byte, attested bool, appAttestKeyID []byte) error {
@@ -1120,6 +1285,16 @@ type fakeAuthStore struct {
 	validateProviderID string
 	validateOK         bool
 	validateErr        error
+	referralToken      string
+	referralMintErr    error
+	referralMintCalls  int
+	ackErr             error
+	ackCalls           int
+	rollbackErr        error
+	rollbackCalls      int
+	pendingMints       []auth.PendingAppTrackReferralMint
+	resolvedMints      []auth.PendingAppTrackReferralMint
+	resolvedPrepared   []bool
 }
 
 func (f *fakeAuthStore) MintProviderTokenAppTrack(ctx context.Context, providerID string, currentBearer *string) (string, error) {
@@ -1142,6 +1317,35 @@ func (f *fakeAuthStore) ValidateToken(ctx context.Context, token string) (string
 		return f.validateProviderID, true, nil
 	}
 	return f.providerID, true, nil
+}
+
+func (f *fakeAuthStore) MintProviderTokenAppTrackWithReferralAttempt(_ context.Context, providerID, referralCode string, policy auth.ReferralPolicy, attempt auth.AppTrackRegistrationAttempt) (string, error) {
+	f.referralMintCalls++
+	f.providerID = providerID
+	if f.referralMintErr != nil {
+		return "", f.referralMintErr
+	}
+	return f.referralToken, nil
+}
+
+func (f *fakeAuthStore) AcknowledgeAppTrackReferralMint(context.Context, string, string) error {
+	f.ackCalls++
+	return f.ackErr
+}
+
+func (f *fakeAuthStore) RollbackAppTrackReferralMint(context.Context, string, string) error {
+	f.rollbackCalls++
+	return f.rollbackErr
+}
+
+func (f *fakeAuthStore) ListPendingAppTrackReferralMints(context.Context, time.Time) ([]auth.PendingAppTrackReferralMint, error) {
+	return append([]auth.PendingAppTrackReferralMint(nil), f.pendingMints...), nil
+}
+
+func (f *fakeAuthStore) ResolvePendingAppTrackReferralMint(_ context.Context, pending auth.PendingAppTrackReferralMint, prepared bool) error {
+	f.resolvedMints = append(f.resolvedMints, pending)
+	f.resolvedPrepared = append(f.resolvedPrepared, prepared)
+	return nil
 }
 
 type fakeMetrics struct {

--- a/phase4-coordinator/internal/onboarding/store_pg.go
+++ b/phase4-coordinator/internal/onboarding/store_pg.go
@@ -138,6 +138,9 @@ SELECT j.generated_at, j.evidence
 	if _, err := s.db.ExecContext(timeout, `SELECT 1 FROM provider_register_nonces LIMIT 1`); err != nil {
 		return fmt.Errorf("provider_onboarding smoke provider_register_nonces read: %w", err)
 	}
+	if _, err := s.db.ExecContext(timeout, `SELECT 1 FROM provider_register_attempts LIMIT 1`); err != nil {
+		return fmt.Errorf("provider_onboarding smoke provider_register_attempts read: %w", err)
+	}
 	if _, err := s.db.ExecContext(timeout, `SELECT 1 FROM provider_auth_policy LIMIT 1`); err != nil {
 		return fmt.Errorf("provider_onboarding smoke provider_auth_policy read: %w", err)
 	}
@@ -362,6 +365,103 @@ VALUES ($1, $2, $3, $4)`, providerID, sourceIP, nonce, observedAt); err != nil {
 		return err
 	}
 	return nil
+}
+
+// PrepareProviderRegistration atomically records replay protection, provider
+// identity, and an exact durable attempt marker. App-track referral minting
+// happens first in SQLite but remains undisclosed behind a pending saga until
+// this transaction is known to have committed.
+func (s *PGStore) PrepareProviderRegistration(ctx context.Context, providerID, sourceIP, nonce string, observedAt, attemptTS time.Time, identityPubkey []byte, attested bool, appAttestKeyID []byte) error {
+	if s == nil || s.db == nil {
+		return errors.New("onboarding postgres store is nil")
+	}
+	tx, err := s.db.BeginTx(ctx, &sql.TxOptions{Isolation: sql.LevelSerializable})
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback()
+
+	observedAt = observedAt.UTC()
+	attemptTS = attemptTS.UTC()
+	cutoffStart := observedAt.Add(-registerNonceWindow)
+	cutoffEnd := observedAt.Add(registerNonceWindow)
+	var exists bool
+	if err := tx.QueryRowContext(ctx, `
+SELECT EXISTS (
+    SELECT 1 FROM provider_register_nonces
+     WHERE provider_id = $1 AND nonce = $2 AND ts_utc BETWEEN $3 AND $4
+)`, providerID, nonce, cutoffStart, cutoffEnd).Scan(&exists); err != nil {
+		return err
+	}
+	if exists {
+		return ErrNonceReplay
+	}
+	if err := tx.QueryRowContext(ctx, `
+SELECT EXISTS (
+    SELECT 1 FROM provider_register_nonces
+     WHERE source_ip = $1 AND nonce = $2 AND ts_utc BETWEEN $3 AND $4
+)`, sourceIP, nonce, cutoffStart, cutoffEnd).Scan(&exists); err != nil {
+		return err
+	}
+	if exists {
+		return ErrNonceReplay
+	}
+
+	var key any
+	if len(appAttestKeyID) > 0 {
+		key = appAttestKeyID
+	}
+	var out string
+	err = tx.QueryRowContext(ctx, `
+INSERT INTO provider_identities (provider_id, identity_pubkey, attested, app_attest_key_id)
+VALUES ($1, $2, $3, $4)
+ON CONFLICT (provider_id) DO UPDATE
+   SET attested = provider_identities.attested OR EXCLUDED.attested,
+       app_attest_key_id = COALESCE(provider_identities.app_attest_key_id, EXCLUDED.app_attest_key_id)
+ WHERE provider_identities.identity_pubkey = EXCLUDED.identity_pubkey
+RETURNING provider_id`, providerID, identityPubkey, attested, key).Scan(&out)
+	if errors.Is(err, sql.ErrNoRows) {
+		return ErrTOFUConflict
+	}
+	if err != nil {
+		if isUniqueViolation(err) {
+			return ErrAttestKeyReused
+		}
+		return err
+	}
+	if _, err := tx.ExecContext(ctx, `
+INSERT INTO provider_register_nonces (provider_id, source_ip, nonce, ts_utc)
+VALUES ($1, $2, $3, $4)`, providerID, sourceIP, nonce, observedAt); err != nil {
+		return err
+	}
+	if _, err := tx.ExecContext(ctx, `
+INSERT INTO provider_register_attempts (provider_id, nonce, ts_utc, source_ip)
+VALUES ($1, $2, $3, $4)
+ON CONFLICT (provider_id, nonce, ts_utc) DO NOTHING`, providerID, nonce, attemptTS, sourceIP); err != nil {
+		return err
+	}
+	if err := tx.Commit(); err != nil {
+		if isSerializationFailure(err) {
+			return ErrNonceReplay
+		}
+		return err
+	}
+	return nil
+}
+
+// ProviderRegistrationPrepared checks only replay-stable, signed fields. The
+// source IP is diagnostic and deliberately excluded from the commitment key.
+func (s *PGStore) ProviderRegistrationPrepared(ctx context.Context, providerID, nonce string, attemptTS time.Time) (bool, error) {
+	if s == nil || s.db == nil {
+		return false, errors.New("onboarding postgres store is nil")
+	}
+	var prepared bool
+	err := s.db.QueryRowContext(ctx, `
+SELECT EXISTS (
+    SELECT 1 FROM provider_register_attempts
+     WHERE provider_id = $1 AND nonce = $2 AND ts_utc = $3
+)`, providerID, nonce, attemptTS.UTC()).Scan(&prepared)
+	return prepared, err
 }
 
 func normalizeChip(chip string) string {

--- a/phase4-coordinator/internal/onboarding/store_pg_attempt_integration_test.go
+++ b/phase4-coordinator/internal/onboarding/store_pg_attempt_integration_test.go
@@ -1,0 +1,82 @@
+//go:build integration
+
+package onboarding
+
+import (
+	"context"
+	"crypto/ed25519"
+	"crypto/rand"
+	"database/sql"
+	"testing"
+	"time"
+
+	_ "github.com/lib/pq"
+	tc "github.com/testcontainers/testcontainers-go"
+	tcpg "github.com/testcontainers/testcontainers-go/modules/postgres"
+	"github.com/testcontainers/testcontainers-go/wait"
+
+	statsmigrations "github.com/augstar/macprovider-coordinator/internal/stats/migrations"
+)
+
+const (
+	referralAttemptPGImage = "postgres:16.4-alpine3.20@sha256:5660c2cbfea50c7a9127d17dc4e48543eedd3d7a41a595a2dfa572471e37e64c"
+	referralAttemptPGPass  = "referral-attempt-test-password"
+)
+
+func TestProviderRegistrationPreparedSurvivesNoncePrune(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 90*time.Second)
+	defer cancel()
+	container, err := tcpg.Run(ctx, referralAttemptPGImage,
+		tcpg.WithDatabase("referral_attempt"),
+		tcpg.WithUsername("postgres"),
+		tcpg.WithPassword(referralAttemptPGPass),
+		tc.WithWaitStrategy(wait.ForLog("database system is ready to accept connections").WithOccurrence(2).WithStartupTimeout(60*time.Second)),
+	)
+	if err != nil {
+		t.Fatalf("start postgres: %v", err)
+	}
+	t.Cleanup(func() {
+		cleanup, cleanupCancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cleanupCancel()
+		_ = container.Terminate(cleanup)
+	})
+	dsn, err := container.ConnectionString(ctx, "sslmode=disable")
+	if err != nil {
+		t.Fatal(err)
+	}
+	db, err := sql.Open("postgres", dsn)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	if err := statsmigrations.Apply(ctx, db); err != nil {
+		t.Fatalf("apply migrations: %v", err)
+	}
+
+	store := &PGStore{db: db}
+	publicKey, _, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	observedAt := time.Now().UTC().Truncate(time.Second)
+	attemptTS := observedAt.Add(-30 * time.Second)
+	if err := store.PrepareProviderRegistration(
+		ctx, "provider-a", "203.0.113.7", "nonce-a", observedAt, attemptTS,
+		publicKey, false, nil,
+	); err != nil {
+		t.Fatalf("prepare: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `DELETE FROM provider_register_nonces`); err != nil {
+		t.Fatalf("prune nonces: %v", err)
+	}
+	prepared, err := store.ProviderRegistrationPrepared(ctx, "provider-a", "nonce-a", attemptTS)
+	if err != nil || !prepared {
+		t.Fatalf("prepared=%v err=%v after nonce prune", prepared, err)
+	}
+	if wrong, err := store.ProviderRegistrationPrepared(ctx, "provider-a", "nonce-a", observedAt); err != nil || wrong {
+		t.Fatalf("server observed timestamp matched signed marker: prepared=%v err=%v", wrong, err)
+	}
+	if missing, err := store.ProviderRegistrationPrepared(ctx, "provider-missing", "nonce-z", attemptTS); err != nil || missing {
+		t.Fatalf("missing attempt prepared=%v err=%v", missing, err)
+	}
+}

--- a/phase4-coordinator/internal/referralapi/advocacy.go
+++ b/phase4-coordinator/internal/referralapi/advocacy.go
@@ -1,0 +1,345 @@
+package referralapi
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/augstar/macprovider-coordinator/internal/auth"
+)
+
+type AdvocacyStore interface {
+	ProviderReferralStatus(context.Context, auth.ReferralPolicy, string) (auth.ProviderReferral, error)
+	CreateSocialChallenge(context.Context, auth.ReferralPolicy, string, time.Time) (auth.SocialChallenge, error)
+	PreflightSocialVerification(context.Context, auth.ReferralPolicy, string, string, string, time.Time) (auth.ProviderReferral, bool, error)
+	CompleteSocialVerification(context.Context, auth.ReferralPolicy, string, string, string, string, string, string, time.Time) (auth.ProviderReferral, error)
+	ConsumeSocialRateLimit(context.Context, auth.ReferralPolicy, string, string, time.Time, time.Duration, int) (bool, error)
+	RecordSocialAudit(context.Context, auth.ReferralPolicy, string, string, string, string, string, string, string, time.Time) error
+}
+
+type ProviderTokenValidator interface {
+	ValidateTokenReadOnly(context.Context, string) (string, bool, error)
+}
+
+type PostVerifier interface {
+	VerifyPost(context.Context, string, string) (string, error)
+}
+
+// AdvocacyHandler owns the provider-authenticated referral endpoints. It never
+// consumes invite capacity; only provider registration creates redemptions.
+type AdvocacyHandler struct {
+	Store           AdvocacyStore
+	Tokens          ProviderTokenValidator
+	PostVerifier    PostVerifier
+	Policy          auth.ReferralPolicy
+	PublicLimiter   *BoundedLimiter
+	ProviderLimiter *BoundedLimiter
+	AuthSlots       chan struct{}
+	VerifySlots     chan struct{}
+	SourceIP        func(*http.Request) string
+	Now             func() time.Time
+	JoinBaseURL     string
+	Metrics         ReferralMetrics
+}
+
+func (h *AdvocacyHandler) HandleStatus(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		w.Header().Set("Allow", http.MethodGet)
+		writeError(w, http.StatusMethodNotAllowed, "method_not_allowed", "GET required")
+		return
+	}
+	providerID, ok := h.authenticate(w, r)
+	if !ok {
+		return
+	}
+	status, err := h.Store.ProviderReferralStatus(r.Context(), h.Policy, providerID)
+	if errors.Is(err, auth.ErrReferralLocked) {
+		h.observe("status", "locked")
+		h.writeStatus(w, status)
+		return
+	}
+	if err != nil {
+		h.observe("status", "error")
+		writeError(w, http.StatusServiceUnavailable, "referral_state_unavailable", "provider referral state unavailable")
+		return
+	}
+	if status.SocialState != "" {
+		h.observe("status", status.SocialState)
+	}
+	h.writeStatus(w, status)
+}
+
+func (h *AdvocacyHandler) HandleChallenge(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		w.Header().Set("Allow", http.MethodPost)
+		writeError(w, http.StatusMethodNotAllowed, "method_not_allowed", "POST required")
+		return
+	}
+	providerID, ok := h.authenticate(w, r)
+	if !ok {
+		return
+	}
+	if !h.Policy.EnableSocialBonus {
+		h.observe("challenge", "disabled")
+		writeError(w, http.StatusNotFound, "social_bonus_disabled", "social invite bonus is disabled")
+		return
+	}
+	if h.ProviderLimiter == nil || !h.ProviderLimiter.Allow("challenge:"+providerID) {
+		w.Header().Set("Retry-After", "60")
+		h.observe("challenge", "rate_limited")
+		writeError(w, http.StatusTooManyRequests, "rate_limited", "too many social challenge requests")
+		return
+	}
+	allowed, err := h.Store.ConsumeSocialRateLimit(r.Context(), h.Policy, providerID, "challenge", h.now(), time.Minute, 5)
+	if err != nil {
+		h.observe("challenge", "error")
+		writeError(w, http.StatusServiceUnavailable, "rate_limit_unavailable", "social challenge is temporarily unavailable")
+		return
+	}
+	if !allowed {
+		w.Header().Set("Retry-After", "60")
+		h.observe("challenge", "rate_limited")
+		writeError(w, http.StatusTooManyRequests, "rate_limited", "too many social challenge requests")
+		return
+	}
+	challenge, err := h.Store.CreateSocialChallenge(r.Context(), h.Policy, providerID, h.now())
+	if err != nil {
+		if errors.Is(err, auth.ErrReferralLocked) {
+			h.observe("challenge", "locked")
+			writeError(w, http.StatusConflict, "first_serving_required", "complete one verified serving before sharing")
+			return
+		}
+		if errors.Is(err, auth.ErrSocialChallenge) {
+			h.observe("challenge", "conflict")
+			writeError(w, http.StatusConflict, "challenge_unavailable", "social challenge unavailable")
+			return
+		}
+		h.observe("challenge", "error")
+		writeError(w, http.StatusServiceUnavailable, "challenge_unavailable", "social challenge temporarily unavailable")
+		return
+	}
+	shareURL := strings.TrimRight(strings.TrimSpace(h.JoinBaseURL), "/") + "/" +
+		url.PathEscape(challenge.Code) + "?c=" + url.QueryEscape(challenge.Cleartext)
+	copy := "My Mac just joined Malibu's pre-beta compute network. If you have a Mac and want early access: " + shareURL
+	h.observe("challenge", "created")
+	writeJSON(w, http.StatusOK, map[string]any{
+		"intent_url": "https://twitter.com/intent/tweet?text=" + url.QueryEscape(copy),
+		"share_url":  shareURL,
+		"expires_at": challenge.ExpiresAt.UTC().Format(time.RFC3339),
+	})
+}
+
+func (h *AdvocacyHandler) HandleVerify(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		w.Header().Set("Allow", http.MethodPost)
+		writeError(w, http.StatusMethodNotAllowed, "method_not_allowed", "POST required")
+		return
+	}
+	providerID, ok := h.authenticate(w, r)
+	if !ok {
+		return
+	}
+	if !h.Policy.EnableSocialBonus || h.PostVerifier == nil {
+		h.observe("x_verify", "disabled")
+		writeError(w, http.StatusNotFound, "social_bonus_disabled", "social invite bonus is disabled")
+		return
+	}
+	if h.ProviderLimiter == nil || !h.ProviderLimiter.Allow("verify:"+providerID) {
+		w.Header().Set("Retry-After", "60")
+		h.observe("x_verify", "rate_limited")
+		writeError(w, http.StatusTooManyRequests, "rate_limited", "too many social verification requests")
+		return
+	}
+	allowed, err := h.Store.ConsumeSocialRateLimit(r.Context(), h.Policy, providerID, "submit", h.now(), time.Minute, 5)
+	if err != nil {
+		h.observe("x_verify", "error")
+		writeError(w, http.StatusServiceUnavailable, "rate_limit_unavailable", "social verification is temporarily unavailable")
+		return
+	}
+	if !allowed {
+		w.Header().Set("Retry-After", "60")
+		h.observe("x_verify", "rate_limited")
+		writeError(w, http.StatusTooManyRequests, "rate_limited", "too many social verification requests")
+		return
+	}
+	var request struct {
+		PostURL   string `json:"post_url"`
+		Challenge string `json:"challenge"`
+	}
+	if err := decodeBoundedJSON(r, &request, 2048); err != nil || len(request.Challenge) != 64 {
+		h.observe("x_verify", "bad_request")
+		writeError(w, http.StatusBadRequest, "bad_request", "invalid verification request")
+		return
+	}
+	postID, err := ParseXPostID(request.PostURL)
+	if err != nil {
+		h.observe("x_verify", "bad_request")
+		writeError(w, http.StatusBadRequest, "invalid_post_url", "use a public x.com post URL")
+		return
+	}
+	submittedAt := h.now()
+	status, replayed, err := h.Store.PreflightSocialVerification(r.Context(), h.Policy, providerID, request.Challenge, postID, submittedAt)
+	if err != nil {
+		if errors.Is(err, auth.ErrSocialChallenge) {
+			h.observe("x_verify", "conflict")
+			writeError(w, http.StatusConflict, "challenge_invalid", "challenge expired, reused, or belongs to another provider")
+			return
+		}
+		h.observe("x_verify", "error")
+		writeError(w, http.StatusServiceUnavailable, "verification_state_unavailable", "social verification is temporarily unavailable")
+		return
+	}
+	if replayed {
+		h.observe("x_verify", "replayed")
+		h.writeStatus(w, status)
+		return
+	}
+	status, err = h.Store.ProviderReferralStatus(r.Context(), h.Policy, providerID)
+	if err != nil || status.Code == "" {
+		h.observe("x_verify", "conflict")
+		writeError(w, http.StatusConflict, "referral_locked", "provider invite is not available")
+		return
+	}
+	expectedURL := strings.TrimRight(strings.TrimSpace(h.JoinBaseURL), "/") + "/" +
+		url.PathEscape(status.Code) + "?c=" + url.QueryEscape(request.Challenge)
+	if h.VerifySlots != nil {
+		select {
+		case h.VerifySlots <- struct{}{}:
+			defer func() { <-h.VerifySlots }()
+		default:
+			h.observe("x_verify", "busy")
+			writeError(w, http.StatusServiceUnavailable, "verification_busy", "social verification is temporarily busy")
+			return
+		}
+	}
+	authorID, err := h.PostVerifier.VerifyPost(r.Context(), postID, expectedURL)
+	if errors.Is(err, ErrXPostTransient) {
+		if auditErr := h.Store.RecordSocialAudit(
+			r.Context(), h.Policy, providerID, request.Challenge, postID, "",
+			"external_verify", "transient", "x_unavailable", h.now(),
+		); auditErr != nil {
+			h.observe("x_verify", "error")
+			writeError(w, http.StatusServiceUnavailable, "verification_audit_unavailable", "social verification is temporarily unavailable")
+			return
+		}
+		w.Header().Set("Retry-After", "30")
+		h.observe("x_verify", "unavailable")
+		writeError(w, http.StatusServiceUnavailable, "verification_unavailable", "social verification is temporarily unavailable")
+		return
+	}
+	if err != nil || strings.TrimSpace(authorID) == "" {
+		reason := "post_not_verified"
+		if err == nil {
+			reason = "author_missing"
+		}
+		if auditErr := h.Store.RecordSocialAudit(
+			r.Context(), h.Policy, providerID, request.Challenge, postID, authorID,
+			"external_verify", "terminal", reason, h.now(),
+		); auditErr != nil {
+			h.observe("x_verify", "error")
+			writeError(w, http.StatusServiceUnavailable, "verification_audit_unavailable", "social verification is temporarily unavailable")
+			return
+		}
+		h.observe("x_verify", "failed")
+		writeError(w, http.StatusUnprocessableEntity, "post_not_verified", "post is unavailable or does not contain the invite link")
+		return
+	}
+	shareURLHash, err := ShareURLDigest(expectedURL, h.JoinBaseURL)
+	if err != nil {
+		h.observe("x_verify", "error")
+		writeError(w, http.StatusInternalServerError, "verification_config_invalid", "social verification is unavailable")
+		return
+	}
+	status, err = h.Store.CompleteSocialVerification(
+		r.Context(), h.Policy, providerID, request.Challenge, postID, authorID, shareURLHash, "x_api", submittedAt,
+	)
+	if err != nil {
+		if errors.Is(err, auth.ErrSocialChallenge) {
+			h.observe("x_verify", "conflict")
+			writeError(w, http.StatusConflict, "challenge_invalid", "challenge expired, reused, or belongs to another provider")
+			return
+		}
+		h.observe("x_verify", "error")
+		writeError(w, http.StatusServiceUnavailable, "verification_state_unavailable", "social verification is temporarily unavailable")
+		return
+	}
+	h.observe("x_verify", "pending")
+	h.writeStatus(w, status)
+}
+
+func (h *AdvocacyHandler) authenticate(w http.ResponseWriter, r *http.Request) (string, bool) {
+	key := r.RemoteAddr
+	if h.SourceIP != nil {
+		key = h.SourceIP(r)
+	}
+	if h.PublicLimiter == nil || !h.PublicLimiter.Allow("advocacy:"+key) {
+		w.Header().Set("Retry-After", "60")
+		writeError(w, http.StatusTooManyRequests, "rate_limited", "too many provider referral requests")
+		return "", false
+	}
+	if h.AuthSlots != nil {
+		select {
+		case h.AuthSlots <- struct{}{}:
+			defer func() { <-h.AuthSlots }()
+		default:
+			w.Header().Set("Retry-After", "5")
+			writeError(w, http.StatusServiceUnavailable, "auth_busy", "provider authentication is temporarily busy")
+			return "", false
+		}
+	}
+	raw := strings.TrimSpace(r.Header.Get("Authorization"))
+	token, ok := strings.CutPrefix(raw, "Bearer ")
+	if !ok || strings.TrimSpace(token) == "" || h.Tokens == nil || h.Store == nil {
+		writeError(w, http.StatusUnauthorized, "unauthorized", "provider bearer token required")
+		return "", false
+	}
+	providerID, valid, err := h.Tokens.ValidateTokenReadOnly(r.Context(), strings.TrimSpace(token))
+	if err != nil {
+		writeError(w, http.StatusServiceUnavailable, "auth_unavailable", "provider authentication unavailable")
+		return "", false
+	}
+	if !valid {
+		writeError(w, http.StatusUnauthorized, "unauthorized", "provider bearer token invalid")
+		return "", false
+	}
+	return providerID, true
+}
+
+func (h *AdvocacyHandler) writeStatus(w http.ResponseWriter, status auth.ProviderReferral) {
+	configuredBonusCapacity := 0
+	if h.Policy.EnableSocialBonus {
+		configuredBonusCapacity = h.Policy.SocialBonusUses
+	}
+	body := map[string]any{
+		"campaign":                  status.Campaign,
+		"social_state":              status.SocialState,
+		"base_capacity":             status.BaseCapacity,
+		"configured_bonus_capacity": configuredBonusCapacity,
+		"bonus_capacity":            status.BonusCapacity,
+		"redemptions":               status.Redemptions,
+		"remaining":                 status.Remaining,
+		"first_serving_seen":        status.FirstServingSeen,
+		"social_bonus_enabled":      h.Policy.EnableSocialBonus,
+	}
+	if status.Code != "" {
+		body["invite_code"] = status.Code
+		body["invite_url"] = strings.TrimRight(strings.TrimSpace(h.JoinBaseURL), "/") + "/" + url.PathEscape(status.Code)
+	}
+	writeJSON(w, http.StatusOK, body)
+}
+
+func (h *AdvocacyHandler) now() time.Time {
+	if h.Now != nil {
+		return h.Now().UTC()
+	}
+	return time.Now().UTC()
+}
+
+func (h *AdvocacyHandler) observe(event, outcome string) {
+	if h.Metrics != nil {
+		h.Metrics.IncReferralEvent(event, outcome)
+	}
+}

--- a/phase4-coordinator/internal/referralapi/advocacy.go
+++ b/phase4-coordinator/internal/referralapi/advocacy.go
@@ -315,6 +315,7 @@ func (h *AdvocacyHandler) writeStatus(w http.ResponseWriter, status auth.Provide
 	}
 	body := map[string]any{
 		"campaign":                  status.Campaign,
+		"join_base_url":             strings.TrimRight(strings.TrimSpace(h.JoinBaseURL), "/"),
 		"social_state":              status.SocialState,
 		"base_capacity":             status.BaseCapacity,
 		"configured_bonus_capacity": configuredBonusCapacity,

--- a/phase4-coordinator/internal/referralapi/advocacy_test.go
+++ b/phase4-coordinator/internal/referralapi/advocacy_test.go
@@ -152,6 +152,7 @@ func TestAdvocacyStatusIsReadOnlyAndCannotQualifyProvider(t *testing.T) {
 	handler.HandleStatus(response, bearerRequest(http.MethodGet, "/v1/provider/referrals", ""))
 	if response.Code != http.StatusOK || !strings.Contains(response.Body.String(), `"social_state":"eligible"`) ||
 		!strings.Contains(response.Body.String(), `"base_capacity":1`) ||
+		!strings.Contains(response.Body.String(), `"join_base_url":"https://malibu.tech/j"`) ||
 		!strings.Contains(response.Body.String(), `"invite_url":"https://malibu.tech/j/`+qualified.Code+`"`) {
 		t.Fatalf("qualified status=%d body=%s", response.Code, response.Body.String())
 	}

--- a/phase4-coordinator/internal/referralapi/advocacy_test.go
+++ b/phase4-coordinator/internal/referralapi/advocacy_test.go
@@ -1,0 +1,405 @@
+package referralapi
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/augstar/macprovider-coordinator/internal/auth"
+)
+
+type advocacyTokens struct {
+	providerID string
+	err        error
+	calls      *int
+}
+
+func (s advocacyTokens) ValidateTokenReadOnly(_ context.Context, token string) (string, bool, error) {
+	if s.calls != nil {
+		(*s.calls)++
+	}
+	return s.providerID, token == "valid-token", s.err
+}
+
+type advocacyVerifier struct {
+	postID      string
+	expectedURL string
+	authorID    string
+	err         error
+	calls       int
+}
+
+func (v *advocacyVerifier) VerifyPost(_ context.Context, postID, expectedURL string) (string, error) {
+	v.calls++
+	v.postID = postID
+	v.expectedURL = expectedURL
+	return v.authorID, v.err
+}
+
+type advocacyMetrics struct {
+	events []string
+}
+
+func (m *advocacyMetrics) IncReferralEvent(event, outcome string) {
+	m.events = append(m.events, event+"/"+outcome)
+}
+
+func advocacyPolicy() auth.ReferralPolicy {
+	return auth.ReferralPolicy{
+		RequireForRegistration:  true,
+		EnableSocialBonus:       true,
+		Campaign:                "prebeta_test",
+		PolicyVersion:           "v1",
+		CurrentKeyID:            "k1",
+		HMACKeys:                map[string]string{"k1": strings.Repeat("s", 32)},
+		ProviderBaseUses:        1,
+		SocialBonusUses:         2,
+		ChallengeTTL:            15 * time.Minute,
+		SocialVerificationDwell: 30 * time.Minute,
+	}
+}
+
+func openAdvocacyStore(t *testing.T) *auth.Store {
+	t.Helper()
+	store, err := auth.OpenStore(filepath.Join(t.TempDir(), "coordinator.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+	return store
+}
+
+func qualifyAdvocacyProvider(t *testing.T, store *auth.Store, policy auth.ReferralPolicy, providerID string, now time.Time) auth.ProviderReferral {
+	t.Helper()
+	status, created, err := store.QualifyProviderReferral(
+		context.Background(), policy, providerID, "settlement-verdict:"+providerID,
+		now.Add(-time.Minute), now,
+	)
+	if err != nil || !created {
+		t.Fatalf("qualify provider status=%+v created=%v err=%v", status, created, err)
+	}
+	return status
+}
+
+func newAdvocacyHandler(store *auth.Store, providerID string, now time.Time) AdvocacyHandler {
+	return AdvocacyHandler{
+		Store:           store,
+		Tokens:          advocacyTokens{providerID: providerID},
+		Policy:          advocacyPolicy(),
+		PublicLimiter:   NewBoundedLimiter(1000, time.Minute, 128),
+		ProviderLimiter: NewBoundedLimiter(1000, time.Minute, 128),
+		AuthSlots:       make(chan struct{}, 1),
+		VerifySlots:     make(chan struct{}, 1),
+		Now:             func() time.Time { return now },
+		JoinBaseURL:     "https://malibu.tech/j",
+	}
+}
+
+func bearerRequest(method, target, body string) *http.Request {
+	request := httptest.NewRequest(method, target, strings.NewReader(body))
+	request.Header.Set("Authorization", "Bearer valid-token")
+	return request
+}
+
+func referralMutationCount(t *testing.T, store *auth.Store) int64 {
+	t.Helper()
+	var changes int64
+	if err := store.DB().QueryRow(`SELECT total_changes()`).Scan(&changes); err != nil {
+		t.Fatal(err)
+	}
+	return changes
+}
+
+func TestAdvocacyStatusIsReadOnlyAndCannotQualifyProvider(t *testing.T) {
+	store := openAdvocacyStore(t)
+	now := time.Date(2026, 7, 13, 10, 0, 0, 0, time.UTC)
+	metrics := &advocacyMetrics{}
+	handler := newAdvocacyHandler(store, "provider-status", now)
+	handler.Metrics = metrics
+
+	before := referralMutationCount(t, store)
+	for range 2 {
+		response := httptest.NewRecorder()
+		handler.HandleStatus(response, bearerRequest(http.MethodGet, "/v1/provider/referrals", ""))
+		if response.Code != http.StatusOK || !strings.Contains(response.Body.String(), `"social_state":"locked_until_first_serving"`) ||
+			strings.Contains(response.Body.String(), "invite_code") || strings.Contains(response.Body.String(), "invite_url") {
+			t.Fatalf("locked status=%d body=%s", response.Code, response.Body.String())
+		}
+	}
+	if after := referralMutationCount(t, store); after != before {
+		t.Fatalf("status GET mutated coordinator DB: before=%d after=%d", before, after)
+	}
+	for _, table := range []string{"referral_serving_qualifications", "referral_issuers", "referral_social_audit"} {
+		var rows int
+		if err := store.DB().QueryRow(`SELECT COUNT(1) FROM ` + table).Scan(&rows); err != nil {
+			t.Fatal(err)
+		}
+		if rows != 0 {
+			t.Fatalf("status GET created %d rows in %s", rows, table)
+		}
+	}
+
+	qualified := qualifyAdvocacyProvider(t, store, handler.Policy, "provider-status", now)
+	before = referralMutationCount(t, store)
+	response := httptest.NewRecorder()
+	handler.HandleStatus(response, bearerRequest(http.MethodGet, "/v1/provider/referrals", ""))
+	if response.Code != http.StatusOK || !strings.Contains(response.Body.String(), `"social_state":"eligible"`) ||
+		!strings.Contains(response.Body.String(), `"base_capacity":1`) ||
+		!strings.Contains(response.Body.String(), `"invite_url":"https://malibu.tech/j/`+qualified.Code+`"`) {
+		t.Fatalf("qualified status=%d body=%s", response.Code, response.Body.String())
+	}
+	if after := referralMutationCount(t, store); after != before {
+		t.Fatalf("qualified status GET mutated coordinator DB: before=%d after=%d", before, after)
+	}
+	if !containsEvent(metrics.events, "status/locked") || !containsEvent(metrics.events, "status/eligible") {
+		t.Fatalf("metrics=%v", metrics.events)
+	}
+}
+
+func createAdvocacyChallenge(t *testing.T, handler *AdvocacyHandler) (shareURL, challenge string) {
+	t.Helper()
+	response := httptest.NewRecorder()
+	handler.HandleChallenge(response, bearerRequest(http.MethodPost, "/v1/provider/referrals/x/challenge", ""))
+	if response.Code != http.StatusOK {
+		t.Fatalf("challenge status=%d body=%s", response.Code, response.Body.String())
+	}
+	var body struct {
+		ShareURL string `json:"share_url"`
+		Intent   string `json:"intent_url"`
+	}
+	if err := json.Unmarshal(response.Body.Bytes(), &body); err != nil {
+		t.Fatal(err)
+	}
+	parsed, err := url.Parse(body.ShareURL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	challenge = parsed.Query().Get("c")
+	if len(challenge) != 64 || !strings.HasPrefix(body.Intent, "https://twitter.com/intent/tweet?") {
+		t.Fatalf("challenge body=%+v", body)
+	}
+	return body.ShareURL, challenge
+}
+
+func TestAdvocacyXSubmissionIsExactReplaySafeAfterResponseLoss(t *testing.T) {
+	store := openAdvocacyStore(t)
+	now := time.Date(2026, 7, 13, 10, 0, 0, 0, time.UTC)
+	qualifyAdvocacyProvider(t, store, advocacyPolicy(), "provider-x", now)
+	verifier := &advocacyVerifier{authorID: "987654321"}
+	metrics := &advocacyMetrics{}
+	handler := newAdvocacyHandler(store, "provider-x", now)
+	handler.PostVerifier = verifier
+	handler.Metrics = metrics
+	shareURL, challenge := createAdvocacyChallenge(t, &handler)
+	verifyBody := `{"post_url":"https://x.com/malibu/status/123456789","challenge":"` + challenge + `"}`
+
+	for attempt := 1; attempt <= 2; attempt++ {
+		response := httptest.NewRecorder()
+		handler.HandleVerify(response, bearerRequest(http.MethodPost, "/v1/provider/referrals/x/verify", verifyBody))
+		if response.Code != http.StatusOK || !strings.Contains(response.Body.String(), `"social_state":"pending"`) ||
+			!strings.Contains(response.Body.String(), `"bonus_capacity":0`) {
+			t.Fatalf("attempt=%d status=%d body=%s", attempt, response.Code, response.Body.String())
+		}
+	}
+	if verifier.postID != "123456789" || verifier.expectedURL != shareURL {
+		t.Fatalf("verifier post=%q url=%q want=%q", verifier.postID, verifier.expectedURL, shareURL)
+	}
+	if verifier.calls != 1 {
+		t.Fatalf("external verifier calls=%d want=1", verifier.calls)
+	}
+	var verifications, accepted, replayed int
+	if err := store.DB().QueryRow(`SELECT COUNT(1) FROM referral_social_verifications WHERE provider_id = ?`, "provider-x").Scan(&verifications); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.DB().QueryRow(`SELECT COUNT(1) FROM referral_social_audit WHERE provider_id = ? AND event_kind = 'submission' AND outcome = 'accepted'`, "provider-x").Scan(&accepted); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.DB().QueryRow(`SELECT COUNT(1) FROM referral_social_audit WHERE provider_id = ? AND event_kind = 'submission' AND outcome = 'replayed'`, "provider-x").Scan(&replayed); err != nil {
+		t.Fatal(err)
+	}
+	if verifications != 1 || accepted != 1 || replayed != 1 {
+		t.Fatalf("verifications=%d accepted=%d replayed=%d", verifications, accepted, replayed)
+	}
+	if !containsEvent(metrics.events, "challenge/created") || !containsEvent(metrics.events, "x_verify/pending") {
+		t.Fatalf("metrics=%v", metrics.events)
+	}
+}
+
+func TestAdvocacyRejectsInvalidChallengeBeforeExternalVerification(t *testing.T) {
+	store := openAdvocacyStore(t)
+	now := time.Date(2026, 7, 13, 10, 0, 0, 0, time.UTC)
+	qualifyAdvocacyProvider(t, store, advocacyPolicy(), "provider-preflight", now)
+	verifier := &advocacyVerifier{authorID: "987654321"}
+	handler := newAdvocacyHandler(store, "provider-preflight", now)
+	handler.PostVerifier = verifier
+
+	response := httptest.NewRecorder()
+	body := `{"post_url":"https://x.com/malibu/status/123456789","challenge":"` + strings.Repeat("f", 64) + `"}`
+	handler.HandleVerify(response, bearerRequest(http.MethodPost, "/v1/provider/referrals/x/verify", body))
+	if response.Code != http.StatusConflict || !strings.Contains(response.Body.String(), `"code":"challenge_invalid"`) {
+		t.Fatalf("status=%d body=%s", response.Code, response.Body.String())
+	}
+	if verifier.calls != 0 {
+		t.Fatalf("external verifier called %d times for invalid challenge", verifier.calls)
+	}
+}
+
+func TestAdvocacyExternalDecisionsAreAuditedAndTransientRetryUsesSameChallenge(t *testing.T) {
+	store := openAdvocacyStore(t)
+	now := time.Date(2026, 7, 13, 10, 0, 0, 0, time.UTC)
+	qualifyAdvocacyProvider(t, store, advocacyPolicy(), "provider-retry", now)
+	verifier := &advocacyVerifier{err: ErrXPostTransient}
+	handler := newAdvocacyHandler(store, "provider-retry", now)
+	handler.PostVerifier = verifier
+	_, challenge := createAdvocacyChallenge(t, &handler)
+	body := `{"post_url":"https://x.com/malibu/status/123","challenge":"` + challenge + `"}`
+
+	transient := httptest.NewRecorder()
+	handler.HandleVerify(transient, bearerRequest(http.MethodPost, "/v1/provider/referrals/x/verify", body))
+	if transient.Code != http.StatusServiceUnavailable || transient.Header().Get("Retry-After") == "" {
+		t.Fatalf("transient status=%d headers=%v body=%s", transient.Code, transient.Header(), transient.Body.String())
+	}
+	var transientAudit int
+	if err := store.DB().QueryRow(`SELECT COUNT(1) FROM referral_social_audit WHERE provider_id = ? AND event_kind = 'external_verify' AND outcome = 'transient' AND reason = 'x_unavailable'`, "provider-retry").Scan(&transientAudit); err != nil {
+		t.Fatal(err)
+	}
+	if transientAudit != 1 {
+		t.Fatalf("transient audit rows=%d", transientAudit)
+	}
+
+	verifier.err = nil
+	verifier.authorID = "456"
+	retry := httptest.NewRecorder()
+	handler.HandleVerify(retry, bearerRequest(http.MethodPost, "/v1/provider/referrals/x/verify", body))
+	if retry.Code != http.StatusOK || !strings.Contains(retry.Body.String(), `"social_state":"pending"`) {
+		t.Fatalf("retry status=%d body=%s", retry.Code, retry.Body.String())
+	}
+
+	qualifyAdvocacyProvider(t, store, advocacyPolicy(), "provider-terminal", now)
+	terminalVerifier := &advocacyVerifier{err: ErrXPostTerminal}
+	terminalHandler := newAdvocacyHandler(store, "provider-terminal", now)
+	terminalHandler.PostVerifier = terminalVerifier
+	_, terminalChallenge := createAdvocacyChallenge(t, &terminalHandler)
+	terminalBody := `{"post_url":"https://x.com/malibu/status/456","challenge":"` + terminalChallenge + `"}`
+	terminal := httptest.NewRecorder()
+	terminalHandler.HandleVerify(terminal, bearerRequest(http.MethodPost, "/v1/provider/referrals/x/verify", terminalBody))
+	if terminal.Code != http.StatusUnprocessableEntity {
+		t.Fatalf("terminal status=%d body=%s", terminal.Code, terminal.Body.String())
+	}
+	var terminalAudit int
+	if err := store.DB().QueryRow(`SELECT COUNT(1) FROM referral_social_audit WHERE provider_id = ? AND event_kind = 'external_verify' AND outcome = 'terminal' AND reason = 'post_not_verified'`, "provider-terminal").Scan(&terminalAudit); err != nil {
+		t.Fatal(err)
+	}
+	if terminalAudit != 1 {
+		t.Fatalf("terminal audit rows=%d", terminalAudit)
+	}
+}
+
+func TestAdvocacyDurableProviderLimitsSurviveHandlerReplacement(t *testing.T) {
+	store := openAdvocacyStore(t)
+	now := time.Date(2026, 7, 13, 10, 0, 0, 0, time.UTC)
+	qualifyAdvocacyProvider(t, store, advocacyPolicy(), "provider-limited", now)
+
+	for attempt := 1; attempt <= 5; attempt++ {
+		handler := newAdvocacyHandler(store, "provider-limited", now)
+		response := httptest.NewRecorder()
+		handler.HandleChallenge(response, bearerRequest(http.MethodPost, "/v1/provider/referrals/x/challenge", ""))
+		if response.Code != http.StatusOK {
+			t.Fatalf("attempt=%d status=%d body=%s", attempt, response.Code, response.Body.String())
+		}
+	}
+	restarted := newAdvocacyHandler(store, "provider-limited", now)
+	denied := httptest.NewRecorder()
+	restarted.HandleChallenge(denied, bearerRequest(http.MethodPost, "/v1/provider/referrals/x/challenge", ""))
+	if denied.Code != http.StatusTooManyRequests || denied.Header().Get("Retry-After") == "" {
+		t.Fatalf("denied status=%d headers=%v body=%s", denied.Code, denied.Header(), denied.Body.String())
+	}
+	var count, deniedAudit int
+	if err := store.DB().QueryRow(`SELECT request_count FROM referral_social_rate_windows WHERE campaign = ? AND provider_id = ? AND action = 'challenge'`, advocacyPolicy().Campaign, "provider-limited").Scan(&count); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.DB().QueryRow(`SELECT COUNT(1) FROM referral_social_audit WHERE provider_id = ? AND event_kind = 'rate_limit' AND outcome = 'denied'`, "provider-limited").Scan(&deniedAudit); err != nil {
+		t.Fatal(err)
+	}
+	if count != 5 || deniedAudit != 1 {
+		t.Fatalf("durable count=%d denied audits=%d", count, deniedAudit)
+	}
+}
+
+func TestAdvocacyAuthenticationAndAdmissionLimitsFailClosed(t *testing.T) {
+	t.Run("auth storage unavailable", func(t *testing.T) {
+		handler := newAdvocacyHandler(openAdvocacyStore(t), "provider-auth", time.Now())
+		handler.Tokens = advocacyTokens{providerID: "provider-auth", err: errors.New("db unavailable")}
+		response := httptest.NewRecorder()
+		handler.HandleStatus(response, bearerRequest(http.MethodGet, "/v1/provider/referrals", ""))
+		if response.Code != http.StatusServiceUnavailable {
+			t.Fatalf("status=%d body=%s", response.Code, response.Body.String())
+		}
+	})
+
+	t.Run("public limit precedes token validation", func(t *testing.T) {
+		limiter := NewBoundedLimiter(1, time.Minute, 32)
+		if !limiter.Allow("advocacy:203.0.113.8") {
+			t.Fatal("failed to prime public limiter")
+		}
+		calls := 0
+		handler := newAdvocacyHandler(openAdvocacyStore(t), "provider-limited", time.Now())
+		handler.PublicLimiter = limiter
+		handler.Tokens = advocacyTokens{providerID: "provider-limited", calls: &calls}
+		handler.SourceIP = func(*http.Request) string { return "203.0.113.8" }
+		response := httptest.NewRecorder()
+		handler.HandleStatus(response, bearerRequest(http.MethodGet, "/v1/provider/referrals", ""))
+		if response.Code != http.StatusTooManyRequests || calls != 0 {
+			t.Fatalf("status=%d token calls=%d body=%s", response.Code, calls, response.Body.String())
+		}
+	})
+
+	t.Run("auth concurrency precedes token validation", func(t *testing.T) {
+		authSlots := make(chan struct{}, 1)
+		authSlots <- struct{}{}
+		calls := 0
+		handler := newAdvocacyHandler(openAdvocacyStore(t), "provider-busy", time.Now())
+		handler.AuthSlots = authSlots
+		handler.Tokens = advocacyTokens{providerID: "provider-busy", calls: &calls}
+		response := httptest.NewRecorder()
+		handler.HandleStatus(response, bearerRequest(http.MethodGet, "/v1/provider/referrals", ""))
+		if response.Code != http.StatusServiceUnavailable || calls != 0 {
+			t.Fatalf("status=%d token calls=%d body=%s", response.Code, calls, response.Body.String())
+		}
+	})
+}
+
+func TestAdvocacyRejectsDisabledSocialAndUnqualifiedChallenges(t *testing.T) {
+	store := openAdvocacyStore(t)
+	now := time.Date(2026, 7, 13, 10, 0, 0, 0, time.UTC)
+	handler := newAdvocacyHandler(store, "provider-locked", now)
+
+	locked := httptest.NewRecorder()
+	handler.HandleChallenge(locked, bearerRequest(http.MethodPost, "/v1/provider/referrals/x/challenge", ""))
+	if locked.Code != http.StatusConflict || !strings.Contains(locked.Body.String(), "first_serving_required") {
+		t.Fatalf("locked status=%d body=%s", locked.Code, locked.Body.String())
+	}
+
+	handler.Policy.EnableSocialBonus = false
+	disabled := httptest.NewRecorder()
+	handler.HandleChallenge(disabled, bearerRequest(http.MethodPost, "/v1/provider/referrals/x/challenge", ""))
+	if disabled.Code != http.StatusNotFound {
+		t.Fatalf("disabled status=%d body=%s", disabled.Code, disabled.Body.String())
+	}
+}
+
+func containsEvent(events []string, want string) bool {
+	for _, event := range events {
+		if event == want {
+			return true
+		}
+	}
+	return false
+}

--- a/phase4-coordinator/internal/referralapi/join.go
+++ b/phase4-coordinator/internal/referralapi/join.go
@@ -10,8 +10,8 @@ import (
 	"github.com/augstar/macprovider-coordinator/internal/auth"
 )
 
-// JoinHandler serves durable invite links. It remains mounted after the gate is
-// disabled so links already in circulation resolve to the open-access page.
+// JoinHandler serves durable invite links only while the independent public
+// join flag is enabled by the router. Disabling exposure removes the route.
 type JoinHandler struct {
 	Store            ValidationStore
 	Policy           auth.ReferralPolicy
@@ -20,12 +20,14 @@ type JoinHandler struct {
 	SourceIP         func(*http.Request) string
 	Now              func() time.Time
 	RequestAccessURL string
+	DownloadURL      string
 	ErrorLogger      func(op string, err error)
 }
 
 type joinView struct {
 	Code             string
 	RequestAccessURL string
+	DownloadURL      string
 }
 
 const joinCSS = `body{margin:0;background:#101116;color:#f7f3ee;font:17px system-ui,sans-serif}main{max-width:620px;margin:10vh auto;padding:32px}h1{font-size:42px;margin:.2em 0}.card{background:#1b1d25;border-radius:18px;padding:26px}code{display:block;overflow-wrap:anywhere;background:#0b0c10;padding:12px;border-radius:8px}.actions{display:flex;gap:10px;flex-wrap:wrap;margin-top:20px}a,button{border:0;border-radius:9px;padding:12px 16px;font:inherit;font-weight:650;cursor:pointer}a{display:inline-block;background:#ff765f;color:#171717;text-decoration:none}a.secondary,button{background:#343744;color:#fff}`
@@ -34,7 +36,7 @@ var joinValidPage = template.Must(template.New("join-valid").Parse(`<!doctype ht
 <html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
 <meta name="robots" content="noindex,nofollow"><title>You're invited to Malibu</title><style>` + joinCSS + `</style></head>
 <body><main><p>Malibu pre-beta</p><h1>Put your Mac to work.</h1><div class="card"><p>You've been invited to join Malibu's private pre-beta compute network.</p>
-<p>Invite code</p><code id="invite">{{.Code}}</code><div class="actions"><a href="https://download.malibu.tech/latest.dmg">Download Malibu</a><button id="copy" type="button">Copy invite code</button></div>
+<p>Invite code</p><code id="invite">{{.Code}}</code><div class="actions"><a href="{{.DownloadURL}}">Download Malibu</a><button id="copy" type="button">Copy invite code</button></div>
 <p id="copied" aria-live="polite"></p><p>You choose when to launch the provider after installing Malibu.</p></div></main>
 <script>document.getElementById('copy').addEventListener('click',async()=>{await navigator.clipboard.writeText(document.getElementById('invite').textContent);document.getElementById('copied').textContent='Invite code copied.'})</script></body></html>`))
 
@@ -61,10 +63,6 @@ var joinUnavailablePage = template.Must(template.New("join-unavailable").Parse(`
 <html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1"><meta name="robots" content="noindex,nofollow"><title>Malibu pre-beta invite</title><style>` + joinCSS + `</style></head>
 <body><main><p>Malibu pre-beta</p><h1>We couldn't check this invite.</h1><div class="card"><p>Something went wrong on our side. Please try again in a moment.</p><div class="actions"><a href="https://malibu.tech">Learn more about Malibu</a></div></div></main></body></html>`))
 
-var joinOpenBetaPage = template.Must(template.New("join-open").Parse(`<!doctype html>
-<html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1"><meta name="robots" content="noindex,nofollow"><title>Malibu</title><style>` + joinCSS + `</style></head>
-<body><main><p>Malibu</p><h1>Put your Mac to work.</h1><div class="card"><p>Malibu is open. You don't need an invite code.</p><div class="actions"><a href="https://download.malibu.tech/latest.dmg">Download Malibu</a><a class="secondary" href="https://malibu.tech">Learn more about Malibu</a></div></div></main></body></html>`))
-
 func (h *JoinHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	h.setHeaders(w)
 	if r.Method != http.MethodGet && r.Method != http.MethodHead {
@@ -78,7 +76,7 @@ func (h *JoinHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if !h.Policy.RequireForRegistration {
-		h.render(w, r, http.StatusOK, joinOpenBetaPage, joinView{})
+		http.NotFound(w, r)
 		return
 	}
 	if h.Store == nil {
@@ -101,7 +99,10 @@ func (h *JoinHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	_, err := h.Store.ValidateReferral(r.Context(), h.Policy, code, h.now())
-	view := joinView{RequestAccessURL: strings.TrimSpace(h.RequestAccessURL)}
+	view := joinView{
+		RequestAccessURL: strings.TrimSpace(h.RequestAccessURL),
+		DownloadURL:      strings.TrimSpace(h.DownloadURL),
+	}
 	switch {
 	case errors.Is(err, auth.ErrReferralExhausted):
 		h.render(w, r, http.StatusOK, joinFullPage, view)

--- a/phase4-coordinator/internal/referralapi/join.go
+++ b/phase4-coordinator/internal/referralapi/join.go
@@ -1,0 +1,168 @@
+package referralapi
+
+import (
+	"errors"
+	"html/template"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/augstar/macprovider-coordinator/internal/auth"
+)
+
+// JoinHandler serves durable invite links. It remains mounted after the gate is
+// disabled so links already in circulation resolve to the open-access page.
+type JoinHandler struct {
+	Store            ValidationStore
+	Policy           auth.ReferralPolicy
+	PublicLimiter    *BoundedLimiter
+	ValidateSlots    chan struct{}
+	SourceIP         func(*http.Request) string
+	Now              func() time.Time
+	RequestAccessURL string
+	ErrorLogger      func(op string, err error)
+}
+
+type joinView struct {
+	Code             string
+	RequestAccessURL string
+}
+
+const joinCSS = `body{margin:0;background:#101116;color:#f7f3ee;font:17px system-ui,sans-serif}main{max-width:620px;margin:10vh auto;padding:32px}h1{font-size:42px;margin:.2em 0}.card{background:#1b1d25;border-radius:18px;padding:26px}code{display:block;overflow-wrap:anywhere;background:#0b0c10;padding:12px;border-radius:8px}.actions{display:flex;gap:10px;flex-wrap:wrap;margin-top:20px}a,button{border:0;border-radius:9px;padding:12px 16px;font:inherit;font-weight:650;cursor:pointer}a{display:inline-block;background:#ff765f;color:#171717;text-decoration:none}a.secondary,button{background:#343744;color:#fff}`
+
+var joinValidPage = template.Must(template.New("join-valid").Parse(`<!doctype html>
+<html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
+<meta name="robots" content="noindex,nofollow"><title>You're invited to Malibu</title><style>` + joinCSS + `</style></head>
+<body><main><p>Malibu pre-beta</p><h1>Put your Mac to work.</h1><div class="card"><p>You've been invited to join Malibu's private pre-beta compute network.</p>
+<p>Invite code</p><code id="invite">{{.Code}}</code><div class="actions"><a href="https://download.malibu.tech/latest.dmg">Download Malibu</a><button id="copy" type="button">Copy invite code</button></div>
+<p id="copied" aria-live="polite"></p><p>You choose when to launch the provider after installing Malibu.</p></div></main>
+<script>document.getElementById('copy').addEventListener('click',async()=>{await navigator.clipboard.writeText(document.getElementById('invite').textContent);document.getElementById('copied').textContent='Invite code copied.'})</script></body></html>`))
+
+var joinFullPage = template.Must(template.New("join-full").Parse(joinUnavailableDocument(
+	"This invite filled up.",
+	"All early-access spots on this invite have been claimed. Ask your inviter for another invite, or request access.",
+)))
+
+var joinExpiredPage = template.Must(template.New("join-expired").Parse(joinUnavailableDocument(
+	"This invite is no longer available.",
+	"This invite has expired. Ask your inviter for another invite, or request access.",
+)))
+
+var joinRevokedPage = template.Must(template.New("join-revoked").Parse(joinUnavailableDocument(
+	"This invite is no longer available.",
+	"This invite is no longer active. Ask your inviter for another invite, or request access.",
+)))
+
+func joinUnavailableDocument(title, message string) string {
+	return `<!doctype html><html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1"><meta name="robots" content="noindex,nofollow"><title>Malibu pre-beta invite</title><style>` + joinCSS + `</style></head><body><main><p>Malibu pre-beta</p><h1>` + title + `</h1><div class="card"><p>` + message + `</p><div class="actions">{{if .RequestAccessURL}}<a href="{{.RequestAccessURL}}">Request access</a>{{end}}<a class="secondary" href="https://malibu.tech">Learn more about Malibu</a></div></div></main></body></html>`
+}
+
+var joinUnavailablePage = template.Must(template.New("join-unavailable").Parse(`<!doctype html>
+<html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1"><meta name="robots" content="noindex,nofollow"><title>Malibu pre-beta invite</title><style>` + joinCSS + `</style></head>
+<body><main><p>Malibu pre-beta</p><h1>We couldn't check this invite.</h1><div class="card"><p>Something went wrong on our side. Please try again in a moment.</p><div class="actions"><a href="https://malibu.tech">Learn more about Malibu</a></div></div></main></body></html>`))
+
+var joinOpenBetaPage = template.Must(template.New("join-open").Parse(`<!doctype html>
+<html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1"><meta name="robots" content="noindex,nofollow"><title>Malibu</title><style>` + joinCSS + `</style></head>
+<body><main><p>Malibu</p><h1>Put your Mac to work.</h1><div class="card"><p>Malibu is open. You don't need an invite code.</p><div class="actions"><a href="https://download.malibu.tech/latest.dmg">Download Malibu</a><a class="secondary" href="https://malibu.tech">Learn more about Malibu</a></div></div></main></body></html>`))
+
+func (h *JoinHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	h.setHeaders(w)
+	if r.Method != http.MethodGet && r.Method != http.MethodHead {
+		w.Header().Set("Allow", "GET, HEAD")
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	if !h.allow(r) {
+		w.Header().Set("Retry-After", "60")
+		http.Error(w, "too many invite checks", http.StatusTooManyRequests)
+		return
+	}
+	code, ok := joinCode(r.URL.Path)
+	if !ok {
+		http.NotFound(w, r)
+		return
+	}
+	if !h.Policy.RequireForRegistration {
+		h.render(w, r, http.StatusOK, joinOpenBetaPage, joinView{})
+		return
+	}
+	if h.Store == nil {
+		h.renderOperationalFailure(w, r, errors.New("referral authority unavailable"))
+		return
+	}
+	if h.ValidateSlots != nil {
+		select {
+		case h.ValidateSlots <- struct{}{}:
+			defer func() { <-h.ValidateSlots }()
+		default:
+			h.renderOperationalFailure(w, r, errors.New("referral authority busy"))
+			return
+		}
+	}
+
+	_, err := h.Store.ValidateReferral(r.Context(), h.Policy, code, h.now())
+	view := joinView{RequestAccessURL: strings.TrimSpace(h.RequestAccessURL)}
+	switch {
+	case errors.Is(err, auth.ErrReferralExhausted):
+		h.render(w, r, http.StatusOK, joinFullPage, view)
+	case errors.Is(err, auth.ErrReferralExpired):
+		h.render(w, r, http.StatusOK, joinExpiredPage, view)
+	case errors.Is(err, auth.ErrReferralRevoked):
+		h.render(w, r, http.StatusOK, joinRevokedPage, view)
+	case errors.Is(err, auth.ErrReferralInvalid), errors.Is(err, auth.ErrReferralRequired):
+		http.NotFound(w, r)
+	case err != nil:
+		h.renderOperationalFailure(w, r, err)
+	default:
+		view.Code = code
+		h.render(w, r, http.StatusOK, joinValidPage, view)
+	}
+}
+
+func (h *JoinHandler) setHeaders(w http.ResponseWriter) {
+	w.Header().Set("Cache-Control", "no-store")
+	w.Header().Set("Content-Security-Policy", "default-src 'none'; style-src 'unsafe-inline'; script-src 'unsafe-inline'; connect-src 'none'; img-src 'none'; base-uri 'none'; frame-ancestors 'none'; form-action 'none'")
+	w.Header().Set("Referrer-Policy", "no-referrer")
+	w.Header().Set("X-Content-Type-Options", "nosniff")
+	w.Header().Set("X-Frame-Options", "DENY")
+}
+
+func (h *JoinHandler) allow(r *http.Request) bool {
+	key := r.RemoteAddr
+	if h.SourceIP != nil {
+		key = h.SourceIP(r)
+	}
+	return h.PublicLimiter != nil && h.PublicLimiter.Allow("join:"+key)
+}
+
+func joinCode(path string) (string, bool) {
+	if !strings.HasPrefix(path, "/j/") {
+		return "", false
+	}
+	code := strings.TrimPrefix(path, "/j/")
+	return code, code != "" && len(code) <= 256 && !strings.Contains(code, "/")
+}
+
+func (h *JoinHandler) renderOperationalFailure(w http.ResponseWriter, r *http.Request, err error) {
+	if h.ErrorLogger != nil {
+		h.ErrorLogger("join_validate", err)
+	}
+	w.Header().Set("Retry-After", "5")
+	h.render(w, r, http.StatusServiceUnavailable, joinUnavailablePage, joinView{})
+}
+
+func (h *JoinHandler) render(w http.ResponseWriter, r *http.Request, status int, page *template.Template, view joinView) {
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	w.WriteHeader(status)
+	if r.Method == http.MethodHead {
+		return
+	}
+	_ = page.Execute(w, view)
+}
+
+func (h *JoinHandler) now() time.Time {
+	if h.Now != nil {
+		return h.Now().UTC()
+	}
+	return time.Now().UTC()
+}

--- a/phase4-coordinator/internal/referralapi/join.go
+++ b/phase4-coordinator/internal/referralapi/join.go
@@ -40,17 +40,17 @@ var joinValidPage = template.Must(template.New("join-valid").Parse(`<!doctype ht
 
 var joinFullPage = template.Must(template.New("join-full").Parse(joinUnavailableDocument(
 	"This invite filled up.",
-	"All early-access spots on this invite have been claimed. Ask your inviter for another invite, or request access.",
+	"All early-access spots on this invite have been claimed. Ask your inviter for another invite.",
 )))
 
 var joinExpiredPage = template.Must(template.New("join-expired").Parse(joinUnavailableDocument(
 	"This invite is no longer available.",
-	"This invite has expired. Ask your inviter for another invite, or request access.",
+	"This invite has expired. Ask your inviter for another invite.",
 )))
 
 var joinRevokedPage = template.Must(template.New("join-revoked").Parse(joinUnavailableDocument(
 	"This invite is no longer available.",
-	"This invite is no longer active. Ask your inviter for another invite, or request access.",
+	"This invite is no longer active. Ask your inviter for another invite.",
 )))
 
 func joinUnavailableDocument(title, message string) string {

--- a/phase4-coordinator/internal/referralapi/join.go
+++ b/phase4-coordinator/internal/referralapi/join.go
@@ -72,11 +72,6 @@ func (h *JoinHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
 		return
 	}
-	if !h.allow(r) {
-		w.Header().Set("Retry-After", "60")
-		http.Error(w, "too many invite checks", http.StatusTooManyRequests)
-		return
-	}
 	code, ok := joinCode(r.URL.Path)
 	if !ok {
 		http.NotFound(w, r)
@@ -98,6 +93,11 @@ func (h *JoinHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			h.renderOperationalFailure(w, r, errors.New("referral authority busy"))
 			return
 		}
+	}
+	if !h.allow(r) {
+		w.Header().Set("Retry-After", "60")
+		http.Error(w, "too many invite checks", http.StatusTooManyRequests)
+		return
 	}
 
 	_, err := h.Store.ValidateReferral(r.Context(), h.Policy, code, h.now())

--- a/phase4-coordinator/internal/referralapi/join_test.go
+++ b/phase4-coordinator/internal/referralapi/join_test.go
@@ -23,6 +23,7 @@ func joinHandlerFor(result error) *JoinHandler {
 		PublicLimiter:    NewBoundedLimiter(20, time.Minute, 20),
 		ValidateSlots:    make(chan struct{}, 1),
 		RequestAccessURL: "https://access.example.test/waitlist",
+		DownloadURL:      "https://download.example.test/releases/Malibu-1.9.0.dmg",
 	}
 }
 
@@ -46,6 +47,11 @@ func TestJoinHandlerRendersLifecycleStates(t *testing.T) {
 			joinHandlerFor(tc.err).ServeHTTP(response, httptest.NewRequest(http.MethodGet, "/j/MAL1-S-k1-seed-AAAAAAAAAAAAAAAAAAAAAAAAAA", nil))
 			if response.Code != tc.wantStatus || !strings.Contains(response.Body.String(), tc.wantBody) {
 				t.Fatalf("status=%d body=%q", response.Code, response.Body.String())
+			}
+			if tc.name == "valid" {
+				if !strings.Contains(response.Body.String(), "https://download.example.test/releases/Malibu-1.9.0.dmg") || strings.Contains(response.Body.String(), "latest.dmg") {
+					t.Fatalf("valid download target is not fixed: %s", response.Body.String())
+				}
 			}
 			if got := response.Header().Get("Cache-Control"); got != "no-store" {
 				t.Fatalf("Cache-Control=%q", got)
@@ -73,13 +79,13 @@ func TestJoinHandlerOmitsAccessCTAWhenNotConfigured(t *testing.T) {
 	}
 }
 
-func TestJoinHandlerRemainsMountedForOpenAccess(t *testing.T) {
+func TestJoinHandlerFailsClosedWhenAdmissionPolicyIsOff(t *testing.T) {
 	h := joinHandlerFor(nil)
 	h.Policy.RequireForRegistration = false
 	h.Store = nil
 	response := httptest.NewRecorder()
 	h.ServeHTTP(response, httptest.NewRequest(http.MethodGet, "/j/old-invite", nil))
-	if response.Code != http.StatusOK || !strings.Contains(response.Body.String(), "don't need an invite") {
+	if response.Code != http.StatusNotFound || strings.Contains(response.Body.String(), "latest.dmg") || strings.Contains(response.Body.String(), "don't need an invite") {
 		t.Fatalf("status=%d body=%s", response.Code, response.Body.String())
 	}
 }

--- a/phase4-coordinator/internal/referralapi/join_test.go
+++ b/phase4-coordinator/internal/referralapi/join_test.go
@@ -22,7 +22,7 @@ func joinHandlerFor(result error) *JoinHandler {
 		Policy:           validationPolicy(),
 		PublicLimiter:    NewBoundedLimiter(20, time.Minute, 20),
 		ValidateSlots:    make(chan struct{}, 1),
-		RequestAccessURL: "https://malibu.tech/request-access",
+		RequestAccessURL: "https://access.example.test/waitlist",
 	}
 }
 
@@ -50,13 +50,26 @@ func TestJoinHandlerRendersLifecycleStates(t *testing.T) {
 			if got := response.Header().Get("Cache-Control"); got != "no-store" {
 				t.Fatalf("Cache-Control=%q", got)
 			}
-			if tc.err == auth.ErrReferralExpired && !strings.Contains(response.Body.String(), "https://malibu.tech/request-access") {
+			if tc.err == auth.ErrReferralExpired && !strings.Contains(response.Body.String(), "https://access.example.test/waitlist") {
 				t.Fatal("request-access CTA missing")
 			}
 			if tc.name == "operational" && response.Header().Get("Retry-After") != "5" {
 				t.Fatal("operational failure missing Retry-After")
 			}
 		})
+	}
+}
+
+func TestJoinHandlerOmitsAccessCTAWhenNotConfigured(t *testing.T) {
+	h := joinHandlerFor(auth.ErrReferralExpired)
+	h.RequestAccessURL = ""
+	response := httptest.NewRecorder()
+	h.ServeHTTP(response, httptest.NewRequest(http.MethodGet, "/j/invite", nil))
+	if response.Code != http.StatusOK || !strings.Contains(response.Body.String(), "Ask your inviter for another invite.") {
+		t.Fatalf("status=%d body=%s", response.Code, response.Body.String())
+	}
+	if strings.Contains(response.Body.String(), "Request access") || strings.Contains(response.Body.String(), "access.example.test") {
+		t.Fatalf("unconfigured request-access CTA rendered: %s", response.Body.String())
 	}
 }
 

--- a/phase4-coordinator/internal/referralapi/join_test.go
+++ b/phase4-coordinator/internal/referralapi/join_test.go
@@ -1,0 +1,102 @@
+package referralapi
+
+import (
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/augstar/macprovider-coordinator/internal/auth"
+)
+
+func joinHandlerFor(result error) *JoinHandler {
+	return &JoinHandler{
+		Store: validationStoreFunc(func(string) (auth.ReferralValidation, error) {
+			if result != nil {
+				return auth.ReferralValidation{}, result
+			}
+			return auth.ReferralValidation{Valid: true, Reason: "valid"}, nil
+		}),
+		Policy:           validationPolicy(),
+		PublicLimiter:    NewBoundedLimiter(20, time.Minute, 20),
+		ValidateSlots:    make(chan struct{}, 1),
+		RequestAccessURL: "https://malibu.tech/request-access",
+	}
+}
+
+func TestJoinHandlerRendersLifecycleStates(t *testing.T) {
+	cases := []struct {
+		name       string
+		err        error
+		wantStatus int
+		wantBody   string
+	}{
+		{name: "valid", wantStatus: http.StatusOK, wantBody: "Copy invite code"},
+		{name: "exhausted", err: auth.ErrReferralExhausted, wantStatus: http.StatusOK, wantBody: "invite filled up"},
+		{name: "expired", err: auth.ErrReferralExpired, wantStatus: http.StatusOK, wantBody: "invite has expired"},
+		{name: "revoked", err: auth.ErrReferralRevoked, wantStatus: http.StatusOK, wantBody: "no longer active"},
+		{name: "invalid", err: auth.ErrReferralInvalid, wantStatus: http.StatusNotFound, wantBody: "404 page not found"},
+		{name: "operational", err: errors.New("database is locked"), wantStatus: http.StatusServiceUnavailable, wantBody: "try again"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			response := httptest.NewRecorder()
+			joinHandlerFor(tc.err).ServeHTTP(response, httptest.NewRequest(http.MethodGet, "/j/MAL1-S-k1-seed-AAAAAAAAAAAAAAAAAAAAAAAAAA", nil))
+			if response.Code != tc.wantStatus || !strings.Contains(response.Body.String(), tc.wantBody) {
+				t.Fatalf("status=%d body=%q", response.Code, response.Body.String())
+			}
+			if got := response.Header().Get("Cache-Control"); got != "no-store" {
+				t.Fatalf("Cache-Control=%q", got)
+			}
+			if tc.err == auth.ErrReferralExpired && !strings.Contains(response.Body.String(), "https://malibu.tech/request-access") {
+				t.Fatal("request-access CTA missing")
+			}
+			if tc.name == "operational" && response.Header().Get("Retry-After") != "5" {
+				t.Fatal("operational failure missing Retry-After")
+			}
+		})
+	}
+}
+
+func TestJoinHandlerRemainsMountedForOpenAccess(t *testing.T) {
+	h := joinHandlerFor(nil)
+	h.Policy.RequireForRegistration = false
+	h.Store = nil
+	response := httptest.NewRecorder()
+	h.ServeHTTP(response, httptest.NewRequest(http.MethodGet, "/j/old-invite", nil))
+	if response.Code != http.StatusOK || !strings.Contains(response.Body.String(), "don't need an invite") {
+		t.Fatalf("status=%d body=%s", response.Code, response.Body.String())
+	}
+}
+
+func TestJoinHandlerRejectsMalformedPathsAndBoundsConcurrency(t *testing.T) {
+	h := joinHandlerFor(nil)
+	for _, path := range []string{"/j/", "/j/a/b", "/j/" + strings.Repeat("a", 257)} {
+		response := httptest.NewRecorder()
+		h.ServeHTTP(response, httptest.NewRequest(http.MethodGet, path, nil))
+		if response.Code != http.StatusNotFound {
+			t.Fatalf("path=%q status=%d", path, response.Code)
+		}
+	}
+	h.ValidateSlots <- struct{}{}
+	response := httptest.NewRecorder()
+	h.ServeHTTP(response, httptest.NewRequest(http.MethodGet, "/j/code", nil))
+	<-h.ValidateSlots
+	if response.Code != http.StatusServiceUnavailable {
+		t.Fatalf("busy status=%d", response.Code)
+	}
+}
+
+func TestJoinHandlerHEADHasNoBodyAndMissingAuthorityIs503(t *testing.T) {
+	h := joinHandlerFor(nil)
+	h.Store = nil
+	var logged error
+	h.ErrorLogger = func(_ string, err error) { logged = err }
+	response := httptest.NewRecorder()
+	h.ServeHTTP(response, httptest.NewRequest(http.MethodHead, "/j/code", nil))
+	if response.Code != http.StatusServiceUnavailable || response.Body.Len() != 0 || logged == nil {
+		t.Fatalf("status=%d body=%q logged=%v", response.Code, response.Body.String(), logged)
+	}
+}

--- a/phase4-coordinator/internal/referralapi/serving.go
+++ b/phase4-coordinator/internal/referralapi/serving.go
@@ -1,0 +1,156 @@
+package referralapi
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/augstar/macprovider-coordinator/internal/auth"
+	"github.com/augstar/macprovider-coordinator/internal/sqliteutil"
+	_ "modernc.org/sqlite"
+)
+
+const defaultServingReconcileBatch = 128
+
+// VerifiedServing is coordinator/buyer evidence that one provider completed a
+// closed, verified settlement. EvidenceID is the durable settlement verdict
+// identity used to make qualification replay-safe.
+type VerifiedServing struct {
+	ProviderID string
+	EvidenceID string
+	ServedAt   time.Time
+}
+
+// ServingEvidenceSource is deliberately read-only. Referral state is written
+// only through ServingQualificationStore after buyer evidence has closed.
+type ServingEvidenceSource interface {
+	ListVerifiedServing(context.Context, string, int) ([]VerifiedServing, error)
+}
+
+type ServingQualificationStore interface {
+	QualifyProviderReferral(context.Context, auth.ReferralPolicy, string, string, time.Time, time.Time) (auth.ProviderReferral, bool, error)
+}
+
+// SQLiteServingEvidence reads the money-path verdict database without any
+// write capability. Pagination by provider ID ensures a complete bounded scan
+// even when already-qualified providers remain in the source database.
+type SQLiteServingEvidence struct {
+	Path string
+}
+
+func (s SQLiteServingEvidence) ListVerifiedServing(ctx context.Context, afterProviderID string, limit int) ([]VerifiedServing, error) {
+	if strings.TrimSpace(s.Path) == "" {
+		return nil, nil
+	}
+	if limit <= 0 || limit > 1024 {
+		limit = defaultServingReconcileBatch
+	}
+	db, err := sql.Open("sqlite", sqliteutil.ReadOnlyDSN(s.Path))
+	if err != nil {
+		return nil, err
+	}
+	defer db.Close()
+	db.SetMaxOpenConns(1)
+
+	rows, err := db.QueryContext(ctx, `
+SELECT v.id, v.provider_id, v.received_at_unix_ms
+  FROM settlement_receipt_verdicts v
+ WHERE v.provider_id > ?
+   AND v.provider_id <> ''
+   AND v.closed = 1
+   AND v.settlement_outcome = 'verified'
+   AND v.receipt_result = 'valid'
+   AND v.id = (
+       SELECT first.id
+         FROM settlement_receipt_verdicts first
+        WHERE first.provider_id = v.provider_id
+          AND first.closed = 1
+          AND first.settlement_outcome = 'verified'
+          AND first.receipt_result = 'valid'
+        ORDER BY first.received_at_unix_ms, first.id
+        LIMIT 1
+   )
+ ORDER BY v.provider_id
+ LIMIT ?`, strings.TrimSpace(afterProviderID), limit)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var out []VerifiedServing
+	for rows.Next() {
+		var id int64
+		var item VerifiedServing
+		var unixMillis int64
+		if err := rows.Scan(&id, &item.ProviderID, &unixMillis); err != nil {
+			return nil, err
+		}
+		if id <= 0 || unixMillis <= 0 {
+			continue
+		}
+		item.EvidenceID = fmt.Sprintf("settlement-verdict:%d", id)
+		item.ServedAt = time.UnixMilli(unixMillis).UTC()
+		out = append(out, item)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+// ServingReconciler is the sole bridge from authoritative buyer evidence to
+// referral invite qualification. It is safe to run at startup, on a ticker,
+// after response loss, and concurrently: the auth store owns the qualification
+// and issuer uniqueness transaction.
+type ServingReconciler struct {
+	Source    ServingEvidenceSource
+	Store     ServingQualificationStore
+	Policy    auth.ReferralPolicy
+	BatchSize int
+	Now       func() time.Time
+}
+
+func (r ServingReconciler) Reconcile(ctx context.Context) (int, error) {
+	if r.Source == nil || r.Store == nil {
+		return 0, nil
+	}
+	batchSize := r.BatchSize
+	if batchSize <= 0 || batchSize > 1024 {
+		batchSize = defaultServingReconcileBatch
+	}
+	now := time.Now().UTC()
+	if r.Now != nil {
+		now = r.Now().UTC()
+	}
+	after := ""
+	qualified := 0
+	for {
+		items, err := r.Source.ListVerifiedServing(ctx, after, batchSize)
+		if err != nil {
+			return qualified, err
+		}
+		if len(items) == 0 {
+			return qualified, nil
+		}
+		for _, item := range items {
+			if strings.TrimSpace(item.ProviderID) == "" {
+				continue
+			}
+			_, created, err := r.Store.QualifyProviderReferral(
+				ctx, r.Policy, item.ProviderID, item.EvidenceID, item.ServedAt, now,
+			)
+			if err != nil {
+				return qualified, err
+			}
+			if created {
+				qualified++
+			}
+			after = item.ProviderID
+		}
+		if len(items) < batchSize {
+			return qualified, nil
+		}
+	}
+}

--- a/phase4-coordinator/internal/referralapi/serving_test.go
+++ b/phase4-coordinator/internal/referralapi/serving_test.go
@@ -1,0 +1,241 @@
+package referralapi
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"path/filepath"
+	"strconv"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/augstar/macprovider-coordinator/internal/auth"
+	_ "modernc.org/sqlite"
+)
+
+func openServingEvidenceDB(t *testing.T) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "billing.db")
+	db, err := sql.Open("sqlite", path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+	if _, err := db.Exec(`
+CREATE TABLE settlement_receipt_verdicts (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    provider_id TEXT NOT NULL,
+    received_at_unix_ms INTEGER NOT NULL,
+    closed INTEGER NOT NULL,
+    settlement_outcome TEXT NOT NULL,
+    receipt_result TEXT NOT NULL
+)`); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+func insertServingVerdict(t *testing.T, path, providerID string, when time.Time, closed bool, outcome, result string) int64 {
+	t.Helper()
+	db, err := sql.Open("sqlite", path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+	closedValue := 0
+	if closed {
+		closedValue = 1
+	}
+	inserted, err := db.Exec(`INSERT INTO settlement_receipt_verdicts
+        (provider_id, received_at_unix_ms, closed, settlement_outcome, receipt_result)
+        VALUES (?, ?, ?, ?, ?)`, providerID, when.UnixMilli(), closedValue, outcome, result)
+	if err != nil {
+		t.Fatal(err)
+	}
+	id, err := inserted.LastInsertId()
+	if err != nil {
+		t.Fatal(err)
+	}
+	return id
+}
+
+type servingQualificationRecorder struct {
+	mu       sync.Mutex
+	seen     map[string]string
+	servedAt map[string]time.Time
+}
+
+func (s *servingQualificationRecorder) QualifyProviderReferral(_ context.Context, _ auth.ReferralPolicy, providerID, evidenceID string, servedAt, _ time.Time) (auth.ProviderReferral, bool, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.seen == nil {
+		s.seen = make(map[string]string)
+		s.servedAt = make(map[string]time.Time)
+	}
+	if _, ok := s.seen[providerID]; ok {
+		return auth.ProviderReferral{}, false, nil
+	}
+	s.seen[providerID] = evidenceID
+	s.servedAt[providerID] = servedAt
+	return auth.ProviderReferral{}, true, nil
+}
+
+func TestServingReconcilerIsOnlyPathFromBuyerEvidenceToInvite(t *testing.T) {
+	path := openServingEvidenceDB(t)
+	now := time.Date(2026, 7, 16, 9, 0, 0, 0, time.UTC)
+	insertServingVerdict(t, path, "provider-authoritative", now.Add(-time.Minute), true, "verified", "valid")
+	store := openAdvocacyStore(t)
+	policy := advocacyPolicy()
+
+	locked, err := store.ProviderReferralStatus(context.Background(), policy, "provider-authoritative")
+	if !errors.Is(err, auth.ErrReferralLocked) || locked.Code != "" || locked.FirstServingSeen {
+		t.Fatalf("evidence without reconcile unlocked invite: status=%+v err=%v", locked, err)
+	}
+	var qualifications int
+	if err := store.DB().QueryRow(`SELECT COUNT(1) FROM referral_serving_qualifications`).Scan(&qualifications); err != nil {
+		t.Fatal(err)
+	}
+	if qualifications != 0 {
+		t.Fatalf("pre-reconcile qualifications=%d", qualifications)
+	}
+
+	reconciler := ServingReconciler{
+		Source: SQLiteServingEvidence{Path: path},
+		Store:  store,
+		Policy: policy,
+		Now:    func() time.Time { return now },
+	}
+	created, err := reconciler.Reconcile(context.Background())
+	if err != nil || created != 1 {
+		t.Fatalf("created=%d err=%v", created, err)
+	}
+	status, err := store.ProviderReferralStatus(context.Background(), policy, "provider-authoritative")
+	if err != nil || !status.FirstServingSeen || status.SocialState != auth.SocialStateEligible || status.Code == "" || status.BaseCapacity != 1 {
+		t.Fatalf("qualified status=%+v err=%v", status, err)
+	}
+	if created, err := reconciler.Reconcile(context.Background()); err != nil || created != 0 {
+		t.Fatalf("duplicate reconcile created=%d err=%v", created, err)
+	}
+	var qualificationRows, issuerRows, auditRows int
+	if err := store.DB().QueryRow(`SELECT COUNT(1) FROM referral_serving_qualifications WHERE provider_id = ?`, "provider-authoritative").Scan(&qualificationRows); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.DB().QueryRow(`SELECT COUNT(1) FROM referral_issuers WHERE provider_id = ?`, "provider-authoritative").Scan(&issuerRows); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.DB().QueryRow(`SELECT COUNT(1) FROM referral_social_audit WHERE provider_id = ? AND event_kind = 'serving_qualified'`, "provider-authoritative").Scan(&auditRows); err != nil {
+		t.Fatal(err)
+	}
+	if qualificationRows != 1 || issuerRows != 1 || auditRows != 1 {
+		t.Fatalf("qualification=%d issuers=%d audit=%d", qualificationRows, issuerRows, auditRows)
+	}
+}
+
+func TestServingReconcilerAcceptsOnlyEarliestClosedVerifiedValidEvidence(t *testing.T) {
+	path := openServingEvidenceDB(t)
+	base := time.Date(2026, 7, 16, 9, 0, 0, 0, time.UTC)
+	insertServingVerdict(t, path, "provider-a", base.Add(5*time.Minute), true, "verified", "valid")
+	wantID := insertServingVerdict(t, path, "provider-a", base, true, "verified", "valid")
+	insertServingVerdict(t, path, "provider-pending", base, false, "verified", "valid")
+	insertServingVerdict(t, path, "provider-quarantined", base, true, "quarantined", "valid")
+	insertServingVerdict(t, path, "provider-invalid", base, true, "verified", "invalid")
+	insertServingVerdict(t, path, "", base, true, "verified", "valid")
+
+	store := &servingQualificationRecorder{}
+	reconciler := ServingReconciler{Source: SQLiteServingEvidence{Path: path}, Store: store, BatchSize: 1}
+	created, err := reconciler.Reconcile(context.Background())
+	if err != nil || created != 1 {
+		t.Fatalf("created=%d err=%v", created, err)
+	}
+	if got := store.servedAt["provider-a"]; !got.Equal(base) {
+		t.Fatalf("served_at=%v want=%v", got, base)
+	}
+	if got := store.seen["provider-a"]; got != "settlement-verdict:"+strconv.FormatInt(wantID, 10) {
+		t.Fatalf("evidence=%q", got)
+	}
+	if len(store.seen) != 1 {
+		t.Fatalf("qualified=%v", store.seen)
+	}
+}
+
+func TestServingReconcilerConcurrentDuplicateAndLateOutOfOrderEvidenceConverge(t *testing.T) {
+	path := openServingEvidenceDB(t)
+	base := time.Date(2026, 7, 16, 9, 0, 0, 0, time.UTC)
+	insertServingVerdict(t, path, "provider-race", base.Add(5*time.Minute), true, "verified", "valid")
+	winnerID := insertServingVerdict(t, path, "provider-race", base, true, "verified", "valid")
+	store := openAdvocacyStore(t)
+	reconciler := ServingReconciler{
+		Source: SQLiteServingEvidence{Path: path},
+		Store:  store,
+		Policy: advocacyPolicy(),
+		Now:    func() time.Time { return base.Add(10 * time.Minute) },
+	}
+
+	var wg sync.WaitGroup
+	results := make(chan int, 2)
+	errs := make(chan error, 2)
+	for range 2 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			created, err := reconciler.Reconcile(context.Background())
+			results <- created
+			errs <- err
+		}()
+	}
+	wg.Wait()
+	close(results)
+	close(errs)
+	for err := range errs {
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+	total := 0
+	for created := range results {
+		total += created
+	}
+	if total != 1 {
+		t.Fatalf("concurrent created total=%d", total)
+	}
+
+	var durableEvidence, durableAt string
+	if err := store.DB().QueryRow(`SELECT evidence_id, evidence_at FROM referral_serving_qualifications WHERE provider_id = ?`, "provider-race").Scan(&durableEvidence, &durableAt); err != nil {
+		t.Fatal(err)
+	}
+	wantEvidence := "settlement-verdict:" + strconv.FormatInt(winnerID, 10)
+	if durableEvidence != wantEvidence || durableAt != base.Format(time.RFC3339) {
+		t.Fatalf("durable evidence=%q at=%q want=%q at=%q", durableEvidence, durableAt, wantEvidence, base.Format(time.RFC3339))
+	}
+
+	// A receipt arriving late with an earlier timestamp corrects only the
+	// durable evidence tuple; it does not issue another invite allocation.
+	lateID := insertServingVerdict(t, path, "provider-race", base.Add(-time.Minute), true, "verified", "valid")
+	if created, err := reconciler.Reconcile(context.Background()); err != nil || created != 0 {
+		t.Fatalf("late evidence reconcile created=%d err=%v", created, err)
+	}
+	var afterEvidence, afterAt, firstServingAt string
+	if err := store.DB().QueryRow(`
+SELECT q.evidence_id, q.evidence_at, i.first_serving_at
+  FROM referral_serving_qualifications q
+  JOIN referral_issuers i ON i.issuer_id = q.issuer_id
+ WHERE q.provider_id = ?`, "provider-race").Scan(&afterEvidence, &afterAt, &firstServingAt); err != nil {
+		t.Fatal(err)
+	}
+	wantLateEvidence := "settlement-verdict:" + strconv.FormatInt(lateID, 10)
+	wantLateAt := base.Add(-time.Minute).Format(time.RFC3339)
+	if afterEvidence != wantLateEvidence || afterAt != wantLateAt || firstServingAt != wantLateAt {
+		t.Fatalf("corrected evidence=%q at=%q first=%q want=%q at=%q", afterEvidence, afterAt, firstServingAt, wantLateEvidence, wantLateAt)
+	}
+	var issuerRows, correctionAudits int
+	if err := store.DB().QueryRow(`SELECT COUNT(1) FROM referral_issuers WHERE provider_id = ?`, "provider-race").Scan(&issuerRows); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.DB().QueryRow(`SELECT COUNT(1) FROM referral_social_audit WHERE provider_id = ? AND event_kind = 'serving_qualified' AND outcome = 'corrected'`, "provider-race").Scan(&correctionAudits); err != nil {
+		t.Fatal(err)
+	}
+	if issuerRows != 1 || correctionAudits != 1 {
+		t.Fatalf("issuer rows=%d correction audits=%d", issuerRows, correctionAudits)
+	}
+}

--- a/phase4-coordinator/internal/referralapi/validate.go
+++ b/phase4-coordinator/internal/referralapi/validate.go
@@ -1,0 +1,192 @@
+package referralapi
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"sync"
+	"time"
+
+	"github.com/augstar/macprovider-coordinator/internal/auth"
+)
+
+type ValidationStore interface {
+	ValidateReferral(context.Context, auth.ReferralPolicy, string, time.Time) (auth.ReferralValidation, error)
+}
+
+// ValidationHandler is intentionally read-only. It exposes invite state for
+// onboarding UX but does not reserve capacity; registration remains the sole
+// authority that consumes a referral.
+type ValidationHandler struct {
+	Store         ValidationStore
+	Policy        auth.ReferralPolicy
+	PublicLimiter *BoundedLimiter
+	ValidateSlots chan struct{}
+	SourceIP      func(*http.Request) string
+	Now           func() time.Time
+}
+
+func (h *ValidationHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		w.Header().Set("Allow", http.MethodPost)
+		writeError(w, http.StatusMethodNotAllowed, "method_not_allowed", "POST required")
+		return
+	}
+	w.Header().Set("Cache-Control", "no-store")
+	if !h.Policy.RequireForRegistration {
+		writeJSON(w, http.StatusOK, map[string]any{"valid": true, "required": false, "reason": "disabled"})
+		return
+	}
+	key := r.RemoteAddr
+	if h.SourceIP != nil {
+		key = h.SourceIP(r)
+	}
+	if h.PublicLimiter == nil || !h.PublicLimiter.Allow(key) {
+		w.Header().Set("Retry-After", "60")
+		writeError(w, http.StatusTooManyRequests, "rate_limited", "too many referral checks")
+		return
+	}
+	if h.ValidateSlots != nil {
+		select {
+		case h.ValidateSlots <- struct{}{}:
+			defer func() { <-h.ValidateSlots }()
+		default:
+			w.Header().Set("Retry-After", "5")
+			writeError(w, http.StatusServiceUnavailable, "busy", "invite validation is temporarily busy")
+			return
+		}
+	}
+	if h.Store == nil {
+		writeError(w, http.StatusServiceUnavailable, "unavailable", "referral authority unavailable")
+		return
+	}
+	var request struct {
+		Code string `json:"code"`
+	}
+	if err := decodeBoundedJSON(r, &request, 1024); err != nil || len([]byte(request.Code)) > 256 {
+		writeError(w, http.StatusBadRequest, "bad_request", "invalid request")
+		return
+	}
+	validation, err := h.Store.ValidateReferral(r.Context(), h.Policy, request.Code, h.now())
+	if err != nil {
+		writeJSON(w, http.StatusOK, map[string]any{
+			"valid": false, "required": true, "reason": referralReason(err),
+		})
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{
+		"valid": validation.Valid, "required": true, "reason": validation.Reason,
+	})
+}
+
+func (h *ValidationHandler) now() time.Time {
+	if h.Now != nil {
+		return h.Now().UTC()
+	}
+	return time.Now().UTC()
+}
+
+func referralReason(err error) string {
+	switch {
+	case errors.Is(err, auth.ErrReferralRequired):
+		return "missing"
+	case errors.Is(err, auth.ErrReferralExpired):
+		return "expired"
+	case errors.Is(err, auth.ErrReferralRevoked):
+		return "revoked"
+	case errors.Is(err, auth.ErrReferralExhausted):
+		return "exhausted"
+	case errors.Is(err, auth.ErrReferralConflict):
+		return "conflict"
+	default:
+		return "invalid"
+	}
+}
+
+func decodeBoundedJSON(r *http.Request, dst any, max int64) error {
+	defer r.Body.Close()
+	body, err := io.ReadAll(io.LimitReader(r.Body, max+1))
+	if err != nil || int64(len(body)) > max {
+		return fmt.Errorf("body too large")
+	}
+	decoder := json.NewDecoder(bytes.NewReader(body))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(dst); err != nil {
+		return err
+	}
+	if err := decoder.Decode(&struct{}{}); err != io.EOF {
+		return fmt.Errorf("request must contain exactly one JSON value")
+	}
+	return nil
+}
+
+func writeError(w http.ResponseWriter, status int, code, message string) {
+	writeJSON(w, status, map[string]any{"error": map[string]string{"code": code, "message": message}})
+}
+
+func writeJSON(w http.ResponseWriter, status int, value any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("Cache-Control", "no-store")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(value)
+}
+
+type limiterEntry struct {
+	windowStart time.Time
+	count       int
+}
+
+type BoundedLimiter struct {
+	mu         sync.Mutex
+	limit      int
+	window     time.Duration
+	maxEntries int
+	now        func() time.Time
+	entries    map[string]limiterEntry
+}
+
+func NewBoundedLimiter(limit int, window time.Duration, maxEntries int) *BoundedLimiter {
+	return &BoundedLimiter{
+		limit: limit, window: window, maxEntries: maxEntries,
+		now: time.Now, entries: map[string]limiterEntry{},
+	}
+}
+
+func (l *BoundedLimiter) Allow(key string) bool {
+	if l == nil || l.limit <= 0 || l.window <= 0 || l.maxEntries <= 0 {
+		return false
+	}
+	now := l.now().UTC()
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	for k, entry := range l.entries {
+		if now.Sub(entry.windowStart) >= l.window {
+			delete(l.entries, k)
+		}
+	}
+	entry, ok := l.entries[key]
+	if !ok {
+		if len(l.entries) >= l.maxEntries {
+			var oldestKey string
+			var oldest time.Time
+			for k, candidate := range l.entries {
+				if oldestKey == "" || candidate.windowStart.Before(oldest) {
+					oldestKey, oldest = k, candidate.windowStart
+				}
+			}
+			delete(l.entries, oldestKey)
+		}
+		l.entries[key] = limiterEntry{windowStart: now, count: 1}
+		return true
+	}
+	if entry.count >= l.limit {
+		return false
+	}
+	entry.count++
+	l.entries[key] = entry
+	return true
+}

--- a/phase4-coordinator/internal/referralapi/validate.go
+++ b/phase4-coordinator/internal/referralapi/validate.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"strings"
 	"sync"
 	"time"
 
@@ -17,6 +18,12 @@ import (
 
 type ValidationStore interface {
 	ValidateReferral(context.Context, auth.ReferralPolicy, string, time.Time) (auth.ReferralValidation, error)
+}
+
+// ReferralMetrics accepts only the closed event/outcome vocabulary enforced
+// by the coordinator metrics implementation.
+type ReferralMetrics interface {
+	IncReferralEvent(event, outcome string)
 }
 
 // ValidationHandler is intentionally read-only. It exposes invite state for
@@ -29,6 +36,17 @@ type ValidationHandler struct {
 	ValidateSlots chan struct{}
 	SourceIP      func(*http.Request) string
 	Now           func() time.Time
+	Metrics       ReferralMetrics
+	// RequestAccessURL is optional operator configuration shared with the
+	// durable /j/ page. It is informational only and never grants admission.
+	RequestAccessURL string
+}
+
+type validationResponse struct {
+	Valid            bool   `json:"valid"`
+	Required         bool   `json:"required"`
+	Reason           string `json:"reason"`
+	RequestAccessURL string `json:"request_access_url,omitempty"`
 }
 
 func (h *ValidationHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
@@ -39,7 +57,8 @@ func (h *ValidationHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 	w.Header().Set("Cache-Control", "no-store")
 	if !h.Policy.RequireForRegistration {
-		writeJSON(w, http.StatusOK, map[string]any{"valid": true, "required": false, "reason": "disabled"})
+		h.observe("disabled")
+		h.writeValidation(w, true, false, "disabled")
 		return
 	}
 	key := r.RemoteAddr
@@ -51,17 +70,20 @@ func (h *ValidationHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		case h.ValidateSlots <- struct{}{}:
 			defer func() { <-h.ValidateSlots }()
 		default:
+			h.observe("busy")
 			w.Header().Set("Retry-After", "5")
 			writeError(w, http.StatusServiceUnavailable, "busy", "invite validation is temporarily busy")
 			return
 		}
 	}
 	if h.PublicLimiter == nil || !h.PublicLimiter.Allow(key) {
+		h.observe("rate_limited")
 		w.Header().Set("Retry-After", "60")
 		writeError(w, http.StatusTooManyRequests, "rate_limited", "too many referral checks")
 		return
 	}
 	if h.Store == nil {
+		h.observe("unavailable")
 		writeError(w, http.StatusServiceUnavailable, "unavailable", "referral authority unavailable")
 		return
 	}
@@ -69,18 +91,38 @@ func (h *ValidationHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		Code string `json:"code"`
 	}
 	if err := decodeBoundedJSON(r, &request, 1024); err != nil || len([]byte(request.Code)) > 256 {
+		h.observe("bad_request")
 		writeError(w, http.StatusBadRequest, "bad_request", "invalid request")
 		return
 	}
 	validation, err := h.Store.ValidateReferral(r.Context(), h.Policy, request.Code, h.now())
 	if err != nil {
-		writeJSON(w, http.StatusOK, map[string]any{
-			"valid": false, "required": true, "reason": referralReason(err),
-		})
+		reason := referralReason(err)
+		if reason == "invalid" && !errors.Is(err, auth.ErrReferralInvalid) {
+			h.observe("unavailable")
+			writeError(w, http.StatusServiceUnavailable, "unavailable", "referral authority unavailable")
+			return
+		}
+		h.observe(reason)
+		h.writeValidation(w, false, true, reason)
 		return
 	}
-	writeJSON(w, http.StatusOK, map[string]any{
-		"valid": validation.Valid, "required": true, "reason": validation.Reason,
+	h.observe("valid")
+	h.writeValidation(w, validation.Valid, true, validation.Reason)
+}
+
+func (h *ValidationHandler) observe(outcome string) {
+	if h.Metrics != nil {
+		h.Metrics.IncReferralEvent("validate", outcome)
+	}
+}
+
+func (h *ValidationHandler) writeValidation(w http.ResponseWriter, valid, required bool, reason string) {
+	writeJSON(w, http.StatusOK, validationResponse{
+		Valid:            valid,
+		Required:         required,
+		Reason:           reason,
+		RequestAccessURL: strings.TrimSpace(h.RequestAccessURL),
 	})
 }
 

--- a/phase4-coordinator/internal/referralapi/validate.go
+++ b/phase4-coordinator/internal/referralapi/validate.go
@@ -2,6 +2,7 @@ package referralapi
 
 import (
 	"bytes"
+	"container/list"
 	"context"
 	"encoding/json"
 	"errors"
@@ -45,11 +46,6 @@ func (h *ValidationHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	if h.SourceIP != nil {
 		key = h.SourceIP(r)
 	}
-	if h.PublicLimiter == nil || !h.PublicLimiter.Allow(key) {
-		w.Header().Set("Retry-After", "60")
-		writeError(w, http.StatusTooManyRequests, "rate_limited", "too many referral checks")
-		return
-	}
 	if h.ValidateSlots != nil {
 		select {
 		case h.ValidateSlots <- struct{}{}:
@@ -59,6 +55,11 @@ func (h *ValidationHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			writeError(w, http.StatusServiceUnavailable, "busy", "invite validation is temporarily busy")
 			return
 		}
+	}
+	if h.PublicLimiter == nil || !h.PublicLimiter.Allow(key) {
+		w.Header().Set("Retry-After", "60")
+		writeError(w, http.StatusTooManyRequests, "rate_limited", "too many referral checks")
+		return
 	}
 	if h.Store == nil {
 		writeError(w, http.StatusServiceUnavailable, "unavailable", "referral authority unavailable")
@@ -138,6 +139,7 @@ func writeJSON(w http.ResponseWriter, status int, value any) {
 type limiterEntry struct {
 	windowStart time.Time
 	count       int
+	element     *list.Element
 }
 
 type BoundedLimiter struct {
@@ -147,12 +149,13 @@ type BoundedLimiter struct {
 	maxEntries int
 	now        func() time.Time
 	entries    map[string]limiterEntry
+	oldest     *list.List
 }
 
 func NewBoundedLimiter(limit int, window time.Duration, maxEntries int) *BoundedLimiter {
 	return &BoundedLimiter{
 		limit: limit, window: window, maxEntries: maxEntries,
-		now: time.Now, entries: map[string]limiterEntry{},
+		now: time.Now, entries: map[string]limiterEntry{}, oldest: list.New(),
 	}
 }
 
@@ -163,24 +166,41 @@ func (l *BoundedLimiter) Allow(key string) bool {
 	now := l.now().UTC()
 	l.mu.Lock()
 	defer l.mu.Unlock()
-	for k, entry := range l.entries {
-		if now.Sub(entry.windowStart) >= l.window {
-			delete(l.entries, k)
+	// Expiration is ordered by window start and bounded per call. This keeps a
+	// distributed-key flood from turning every request into a full-map scan.
+	for removed := 0; removed < 16; removed++ {
+		front := l.oldest.Front()
+		if front == nil {
+			break
 		}
+		key := front.Value.(string)
+		entry, ok := l.entries[key]
+		if !ok || entry.element != front {
+			l.oldest.Remove(front)
+			continue
+		}
+		if now.Sub(entry.windowStart) < l.window {
+			break
+		}
+		delete(l.entries, key)
+		l.oldest.Remove(front)
 	}
 	entry, ok := l.entries[key]
 	if !ok {
 		if len(l.entries) >= l.maxEntries {
-			var oldestKey string
-			var oldest time.Time
-			for k, candidate := range l.entries {
-				if oldestKey == "" || candidate.windowStart.Before(oldest) {
-					oldestKey, oldest = k, candidate.windowStart
-				}
-			}
-			delete(l.entries, oldestKey)
+			// Never reset an active caller's budget merely to admit a new key.
+			return false
 		}
-		l.entries[key] = limiterEntry{windowStart: now, count: 1}
+		element := l.oldest.PushBack(key)
+		l.entries[key] = limiterEntry{windowStart: now, count: 1, element: element}
+		return true
+	}
+	if now.Sub(entry.windowStart) >= l.window {
+		l.oldest.Remove(entry.element)
+		entry.windowStart = now
+		entry.count = 1
+		entry.element = l.oldest.PushBack(key)
+		l.entries[key] = entry
 		return true
 	}
 	if entry.count >= l.limit {

--- a/phase4-coordinator/internal/referralapi/validate_test.go
+++ b/phase4-coordinator/internal/referralapi/validate_test.go
@@ -86,3 +86,19 @@ func TestReferralReasonDoesNotCollapseLifecycleFailures(t *testing.T) {
 		}
 	}
 }
+
+func TestBoundedLimiterNeverEvictsAnActiveBucketForANewKey(t *testing.T) {
+	limiter := NewBoundedLimiter(2, time.Minute, 1)
+	now := time.Date(2026, 7, 13, 12, 0, 0, 0, time.UTC)
+	limiter.now = func() time.Time { return now }
+	if !limiter.Allow("active") || limiter.Allow("unseen") {
+		t.Fatal("full limiter admitted an unseen key")
+	}
+	if !limiter.Allow("active") || limiter.Allow("active") {
+		t.Fatal("active bucket was reset or its budget was not preserved")
+	}
+	now = now.Add(time.Minute)
+	if !limiter.Allow("unseen") {
+		t.Fatal("expired bucket was not reclaimed")
+	}
+}

--- a/phase4-coordinator/internal/referralapi/validate_test.go
+++ b/phase4-coordinator/internal/referralapi/validate_test.go
@@ -14,6 +14,23 @@ import (
 
 type validationStoreFunc func(string) (auth.ReferralValidation, error)
 
+type validationMetrics struct {
+	events []string
+}
+
+func (m *validationMetrics) IncReferralEvent(event, outcome string) {
+	m.events = append(m.events, event+"/"+outcome)
+}
+
+func containsValidationEvent(events []string, want string) bool {
+	for _, event := range events {
+		if event == want {
+			return true
+		}
+	}
+	return false
+}
+
 func (f validationStoreFunc) ValidateReferral(_ context.Context, _ auth.ReferralPolicy, code string, _ time.Time) (auth.ReferralValidation, error) {
 	return f(code)
 }
@@ -30,7 +47,7 @@ func validationPolicy() auth.ReferralPolicy {
 }
 
 func TestValidationHandlerReturnsStableReasonWithoutReserving(t *testing.T) {
-	metrics := &advocacyMetrics{}
+	metrics := &validationMetrics{}
 	h := &ValidationHandler{
 		Store: validationStoreFunc(func(code string) (auth.ReferralValidation, error) {
 			if code == "expired" {
@@ -63,7 +80,7 @@ func TestValidationHandlerReturnsStableReasonWithoutReserving(t *testing.T) {
 			t.Fatalf("configured access URL missing from status=%d body=%s", response.Code, response.Body.String())
 		}
 	}
-	if !containsEvent(metrics.events, "validate/valid") || !containsEvent(metrics.events, "validate/expired") {
+	if !containsValidationEvent(metrics.events, "validate/valid") || !containsValidationEvent(metrics.events, "validate/expired") {
 		t.Fatalf("metrics=%v", metrics.events)
 	}
 }
@@ -116,7 +133,7 @@ func TestValidationHandlerFailsClosedWhenAuthorityMissing(t *testing.T) {
 }
 
 func TestValidationHandlerDoesNotMisreportOperationalFailureAsInvalidCode(t *testing.T) {
-	metrics := &advocacyMetrics{}
+	metrics := &validationMetrics{}
 	h := &ValidationHandler{
 		Store: validationStoreFunc(func(string) (auth.ReferralValidation, error) {
 			return auth.ReferralValidation{}, errors.New("database busy")
@@ -130,7 +147,7 @@ func TestValidationHandlerDoesNotMisreportOperationalFailureAsInvalidCode(t *tes
 	if response.Code != http.StatusServiceUnavailable || strings.Contains(response.Body.String(), `"reason":"invalid"`) {
 		t.Fatalf("status=%d body=%s", response.Code, response.Body.String())
 	}
-	if !containsEvent(metrics.events, "validate/unavailable") {
+	if !containsValidationEvent(metrics.events, "validate/unavailable") {
 		t.Fatalf("metrics=%v", metrics.events)
 	}
 }

--- a/phase4-coordinator/internal/referralapi/validate_test.go
+++ b/phase4-coordinator/internal/referralapi/validate_test.go
@@ -1,0 +1,88 @@
+package referralapi
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/augstar/macprovider-coordinator/internal/auth"
+)
+
+type validationStoreFunc func(string) (auth.ReferralValidation, error)
+
+func (f validationStoreFunc) ValidateReferral(_ context.Context, _ auth.ReferralPolicy, code string, _ time.Time) (auth.ReferralValidation, error) {
+	return f(code)
+}
+
+func validationPolicy() auth.ReferralPolicy {
+	return auth.ReferralPolicy{
+		RequireForRegistration: true,
+		Campaign:               "prebeta_test",
+		PolicyVersion:          "v1",
+		CurrentKeyID:           "k1",
+		HMACKeys:               map[string]string{"k1": strings.Repeat("s", 32)},
+		ProviderBaseUses:       1,
+	}
+}
+
+func TestValidationHandlerReturnsStableReasonWithoutReserving(t *testing.T) {
+	h := &ValidationHandler{
+		Store: validationStoreFunc(func(code string) (auth.ReferralValidation, error) {
+			if code == "expired" {
+				return auth.ReferralValidation{}, auth.ErrReferralExpired
+			}
+			return auth.ReferralValidation{Valid: true, Reason: "valid"}, nil
+		}),
+		Policy:        validationPolicy(),
+		PublicLimiter: NewBoundedLimiter(10, time.Minute, 10),
+		ValidateSlots: make(chan struct{}, 1),
+		SourceIP:      func(*http.Request) string { return "203.0.113.10" },
+	}
+
+	for _, tc := range []struct {
+		body string
+		want string
+	}{
+		{`{"code":"good"}`, `"valid":true`},
+		{`{"code":"expired"}`, `"reason":"expired"`},
+	} {
+		req := httptest.NewRequest(http.MethodPost, "/v1/referrals/validate", strings.NewReader(tc.body))
+		response := httptest.NewRecorder()
+		h.ServeHTTP(response, req)
+		if response.Code != http.StatusOK || !strings.Contains(response.Body.String(), tc.want) {
+			t.Fatalf("status=%d body=%s want %s", response.Code, response.Body.String(), tc.want)
+		}
+	}
+}
+
+func TestValidationHandlerFailsClosedWhenAuthorityMissing(t *testing.T) {
+	h := &ValidationHandler{
+		Policy:        validationPolicy(),
+		PublicLimiter: NewBoundedLimiter(1, time.Minute, 1),
+	}
+	request := httptest.NewRequest(http.MethodPost, "/v1/referrals/validate", strings.NewReader(`{"code":"x"}`))
+	response := httptest.NewRecorder()
+	h.ServeHTTP(response, request)
+	if response.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status=%d body=%s", response.Code, response.Body.String())
+	}
+}
+
+func TestReferralReasonDoesNotCollapseLifecycleFailures(t *testing.T) {
+	cases := map[error]string{
+		auth.ErrReferralRequired:  "missing",
+		auth.ErrReferralInvalid:   "invalid",
+		auth.ErrReferralExpired:   "expired",
+		auth.ErrReferralRevoked:   "revoked",
+		auth.ErrReferralExhausted: "exhausted",
+	}
+	for err, want := range cases {
+		if got := referralReason(errors.Join(err)); got != want {
+			t.Fatalf("reason(%v)=%q want=%q", err, got, want)
+		}
+	}
+}

--- a/phase4-coordinator/internal/referralapi/validate_test.go
+++ b/phase4-coordinator/internal/referralapi/validate_test.go
@@ -30,6 +30,7 @@ func validationPolicy() auth.ReferralPolicy {
 }
 
 func TestValidationHandlerReturnsStableReasonWithoutReserving(t *testing.T) {
+	metrics := &advocacyMetrics{}
 	h := &ValidationHandler{
 		Store: validationStoreFunc(func(code string) (auth.ReferralValidation, error) {
 			if code == "expired" {
@@ -37,10 +38,12 @@ func TestValidationHandlerReturnsStableReasonWithoutReserving(t *testing.T) {
 			}
 			return auth.ReferralValidation{Valid: true, Reason: "valid"}, nil
 		}),
-		Policy:        validationPolicy(),
-		PublicLimiter: NewBoundedLimiter(10, time.Minute, 10),
-		ValidateSlots: make(chan struct{}, 1),
-		SourceIP:      func(*http.Request) string { return "203.0.113.10" },
+		Policy:           validationPolicy(),
+		PublicLimiter:    NewBoundedLimiter(10, time.Minute, 10),
+		ValidateSlots:    make(chan struct{}, 1),
+		SourceIP:         func(*http.Request) string { return "203.0.113.10" },
+		RequestAccessURL: "https://access.example.test/waitlist",
+		Metrics:          metrics,
 	}
 
 	for _, tc := range []struct {
@@ -56,7 +59,47 @@ func TestValidationHandlerReturnsStableReasonWithoutReserving(t *testing.T) {
 		if response.Code != http.StatusOK || !strings.Contains(response.Body.String(), tc.want) {
 			t.Fatalf("status=%d body=%s want %s", response.Code, response.Body.String(), tc.want)
 		}
+		if !strings.Contains(response.Body.String(), `"request_access_url":"https://access.example.test/waitlist"`) {
+			t.Fatalf("configured access URL missing from status=%d body=%s", response.Code, response.Body.String())
+		}
 	}
+	if !containsEvent(metrics.events, "validate/valid") || !containsEvent(metrics.events, "validate/expired") {
+		t.Fatalf("metrics=%v", metrics.events)
+	}
+}
+
+func TestValidationHandlerOptionalAccessURLCoversDisabledAndCanBeOmitted(t *testing.T) {
+	t.Run("disabled includes configured URL", func(t *testing.T) {
+		h := &ValidationHandler{
+			Policy:           auth.ReferralPolicy{RequireForRegistration: false},
+			RequestAccessURL: " https://access.example.test/waitlist ",
+		}
+		response := httptest.NewRecorder()
+		h.ServeHTTP(response, httptest.NewRequest(http.MethodPost, "/v1/referrals/validate", strings.NewReader(`{"code":""}`)))
+		if response.Code != http.StatusOK ||
+			!strings.Contains(response.Body.String(), `"reason":"disabled"`) ||
+			!strings.Contains(response.Body.String(), `"request_access_url":"https://access.example.test/waitlist"`) {
+			t.Fatalf("status=%d body=%s", response.Code, response.Body.String())
+		}
+	})
+
+	t.Run("invalid omits absent URL", func(t *testing.T) {
+		h := &ValidationHandler{
+			Store: validationStoreFunc(func(string) (auth.ReferralValidation, error) {
+				return auth.ReferralValidation{}, auth.ErrReferralInvalid
+			}),
+			Policy:        validationPolicy(),
+			PublicLimiter: NewBoundedLimiter(10, time.Minute, 10),
+		}
+		response := httptest.NewRecorder()
+		h.ServeHTTP(response, httptest.NewRequest(http.MethodPost, "/v1/referrals/validate", strings.NewReader(`{"code":"bad"}`)))
+		if response.Code != http.StatusOK || !strings.Contains(response.Body.String(), `"reason":"invalid"`) {
+			t.Fatalf("status=%d body=%s", response.Code, response.Body.String())
+		}
+		if strings.Contains(response.Body.String(), "request_access_url") {
+			t.Fatalf("absent access URL was serialized: %s", response.Body.String())
+		}
+	})
 }
 
 func TestValidationHandlerFailsClosedWhenAuthorityMissing(t *testing.T) {
@@ -69,6 +112,26 @@ func TestValidationHandlerFailsClosedWhenAuthorityMissing(t *testing.T) {
 	h.ServeHTTP(response, request)
 	if response.Code != http.StatusServiceUnavailable {
 		t.Fatalf("status=%d body=%s", response.Code, response.Body.String())
+	}
+}
+
+func TestValidationHandlerDoesNotMisreportOperationalFailureAsInvalidCode(t *testing.T) {
+	metrics := &advocacyMetrics{}
+	h := &ValidationHandler{
+		Store: validationStoreFunc(func(string) (auth.ReferralValidation, error) {
+			return auth.ReferralValidation{}, errors.New("database busy")
+		}),
+		Policy:        validationPolicy(),
+		PublicLimiter: NewBoundedLimiter(1, time.Minute, 1),
+		Metrics:       metrics,
+	}
+	response := httptest.NewRecorder()
+	h.ServeHTTP(response, httptest.NewRequest(http.MethodPost, "/v1/referrals/validate", strings.NewReader(`{"code":"well-formed"}`)))
+	if response.Code != http.StatusServiceUnavailable || strings.Contains(response.Body.String(), `"reason":"invalid"`) {
+		t.Fatalf("status=%d body=%s", response.Code, response.Body.String())
+	}
+	if !containsEvent(metrics.events, "validate/unavailable") {
+		t.Fatalf("metrics=%v", metrics.events)
 	}
 }
 

--- a/phase4-coordinator/internal/referralapi/xapi.go
+++ b/phase4-coordinator/internal/referralapi/xapi.go
@@ -1,0 +1,232 @@
+package referralapi
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"mime"
+	"net/http"
+	"net/url"
+	"regexp"
+	"strings"
+	"time"
+)
+
+var xIDPattern = regexp.MustCompile(`^[0-9]{1,24}$`)
+var socialChallengePattern = regexp.MustCompile(`^[0-9a-f]{64}$`)
+
+var (
+	ErrXPostTerminal  = errors.New("x post terminally unavailable")
+	ErrXPostTransient = errors.New("x post lookup transient failure")
+)
+
+func ParseXPostID(raw string) (string, error) {
+	u, err := url.Parse(strings.TrimSpace(raw))
+	if err != nil || u.Scheme != "https" || !strings.EqualFold(u.Hostname(), "x.com") ||
+		u.Port() != "" || u.User != nil || u.RawQuery != "" || u.ForceQuery || u.Fragment != "" {
+		return "", errors.New("invalid x post url")
+	}
+	parts := strings.Split(strings.Trim(u.EscapedPath(), "/"), "/")
+	if len(parts) != 3 || parts[0] == "" || parts[1] != "status" || !xIDPattern.MatchString(parts[2]) {
+		return "", errors.New("invalid x post path")
+	}
+	return parts[2], nil
+}
+
+type XAPIClient struct {
+	bearer   string
+	client   *http.Client
+	joinBase *url.URL
+}
+
+func NewXAPIClient(bearer, joinBaseURL string) (*XAPIClient, error) {
+	transport := http.DefaultTransport.(*http.Transport).Clone()
+	transport.ResponseHeaderTimeout = 4 * time.Second
+	joinBase, err := parseJoinBaseURL(joinBaseURL)
+	if err != nil {
+		return nil, err
+	}
+	return &XAPIClient{
+		bearer:   strings.TrimSpace(bearer),
+		joinBase: joinBase,
+		client: &http.Client{
+			Timeout:   6 * time.Second,
+			Transport: transport,
+			CheckRedirect: func(*http.Request, []*http.Request) error {
+				return http.ErrUseLastResponse
+			},
+		},
+	}, nil
+}
+
+type xPostPayload struct {
+	Data struct {
+		ID       string `json:"id"`
+		AuthorID string `json:"author_id"`
+		Entities struct {
+			URLs []struct {
+				Expanded string `json:"expanded_url"`
+				Unwound  string `json:"unwound_url"`
+			} `json:"urls"`
+		} `json:"entities"`
+	} `json:"data"`
+}
+
+func (c *XAPIClient) fetchPost(ctx context.Context, postID string) (xPostPayload, error) {
+	var payload xPostPayload
+	if c == nil || c.bearer == "" || !xIDPattern.MatchString(postID) {
+		return payload, fmt.Errorf("x verifier unavailable: %w", ErrXPostTransient)
+	}
+	endpoint := "https://api.x.com/2/tweets/" + postID + "?tweet.fields=entities,author_id"
+	request, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+	if err != nil {
+		return payload, fmt.Errorf("build x lookup: %w", ErrXPostTransient)
+	}
+	request.Header.Set("Authorization", "Bearer "+c.bearer)
+	request.Header.Set("Accept", "application/json")
+	response, err := c.client.Do(request)
+	if err != nil {
+		return payload, fmt.Errorf("x lookup transport: %w", ErrXPostTransient)
+	}
+	defer response.Body.Close()
+	if response.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(io.LimitReader(response.Body, 4096))
+		switch response.StatusCode {
+		case http.StatusNotFound, http.StatusGone:
+			return payload, fmt.Errorf("x lookup status %d: %w", response.StatusCode, ErrXPostTerminal)
+		case http.StatusForbidden:
+			if describesProtectedOrPrivatePost(body) {
+				return payload, fmt.Errorf("x post is protected or private: %w", ErrXPostTerminal)
+			}
+			return payload, fmt.Errorf("x lookup status %d: %w", response.StatusCode, ErrXPostTransient)
+		default:
+			return payload, fmt.Errorf("x lookup status %d: %w", response.StatusCode, ErrXPostTransient)
+		}
+	}
+	mediaType, _, err := mime.ParseMediaType(response.Header.Get("Content-Type"))
+	if err != nil || mediaType != "application/json" {
+		return payload, fmt.Errorf("x lookup content type: %w", ErrXPostTransient)
+	}
+	body, err := io.ReadAll(io.LimitReader(response.Body, 64*1024+1))
+	if err != nil || len(body) > 64*1024 {
+		return payload, fmt.Errorf("x lookup response size: %w", ErrXPostTransient)
+	}
+	if err := json.Unmarshal(body, &payload); err != nil || payload.Data.ID != postID || !xIDPattern.MatchString(payload.Data.AuthorID) {
+		return payload, fmt.Errorf("x lookup response mismatch: %w", ErrXPostTransient)
+	}
+	return payload, nil
+}
+
+func (c *XAPIClient) VerifyPost(ctx context.Context, postID, expectedURL string) (string, error) {
+	payload, err := c.fetchPost(ctx, postID)
+	if err != nil {
+		return "", err
+	}
+	want, err := canonicalShareURL(expectedURL, c.joinBase)
+	if err != nil {
+		return "", err
+	}
+	for _, entity := range payload.Data.Entities.URLs {
+		for _, candidate := range []string{entity.Expanded, entity.Unwound} {
+			got, err := canonicalShareURL(candidate, c.joinBase)
+			if err == nil && got == want {
+				return payload.Data.AuthorID, nil
+			}
+		}
+	}
+	return "", errors.New("expected invite URL missing")
+}
+
+// RecheckPost proves that the same public post still contains the exact
+// canonical invite URL accepted during submission. The digest keeps the
+// challenge and invite code bound without retaining or logging the URL.
+func (c *XAPIClient) RecheckPost(ctx context.Context, postID, expectedURLHash string) (string, error) {
+	if !socialChallengePattern.MatchString(strings.TrimSpace(expectedURLHash)) {
+		return "", fmt.Errorf("invalid expected share URL digest: %w", ErrXPostTerminal)
+	}
+	payload, err := c.fetchPost(ctx, postID)
+	if err != nil {
+		return "", err
+	}
+	for _, entity := range payload.Data.Entities.URLs {
+		for _, candidate := range []string{entity.Expanded, entity.Unwound} {
+			canonical, err := canonicalShareURL(candidate, c.joinBase)
+			if err != nil {
+				continue
+			}
+			digest := sha256.Sum256([]byte(canonical))
+			if fmt.Sprintf("%x", digest[:]) == expectedURLHash {
+				return payload.Data.AuthorID, nil
+			}
+		}
+	}
+	return "", fmt.Errorf("exact invite URL no longer present: %w", ErrXPostTerminal)
+}
+
+func ShareURLDigest(raw, joinBaseURL string) (string, error) {
+	joinBase, err := parseJoinBaseURL(joinBaseURL)
+	if err != nil {
+		return "", err
+	}
+	canonical, err := canonicalShareURL(raw, joinBase)
+	if err != nil {
+		return "", err
+	}
+	digest := sha256.Sum256([]byte(canonical))
+	return fmt.Sprintf("%x", digest[:]), nil
+}
+
+func parseJoinBaseURL(raw string) (*url.URL, error) {
+	joinBase, err := url.Parse(strings.TrimRight(strings.TrimSpace(raw), "/"))
+	if err != nil || joinBase.Scheme != "https" || joinBase.Host == "" || joinBase.User != nil ||
+		joinBase.RawQuery != "" || joinBase.ForceQuery || joinBase.Fragment != "" || !strings.HasSuffix(strings.TrimRight(joinBase.Path, "/"), "/j") {
+		return nil, errors.New("join base URL must be a credential-free absolute https URL ending in /j")
+	}
+	return joinBase, nil
+}
+
+func describesProtectedOrPrivatePost(body []byte) bool {
+	var problem struct {
+		Type   string `json:"type"`
+		Errors []struct {
+			Type string `json:"type"`
+			Code int    `json:"code"`
+		} `json:"errors"`
+	}
+	if json.Unmarshal(body, &problem) != nil {
+		return false
+	}
+	if strings.HasSuffix(problem.Type, "/not-authorized-for-resource") {
+		return true
+	}
+	for _, item := range problem.Errors {
+		if strings.HasSuffix(item.Type, "/not-authorized-for-resource") || item.Code == 179 {
+			return true
+		}
+	}
+	return false
+}
+
+func canonicalShareURL(raw string, joinBase *url.URL) (string, error) {
+	u, err := url.Parse(strings.TrimSpace(raw))
+	if err != nil || joinBase == nil || joinBase.Scheme != "https" || joinBase.Host == "" ||
+		u.Scheme != joinBase.Scheme || !strings.EqualFold(u.Host, joinBase.Host) || u.User != nil || u.ForceQuery || u.Fragment != "" {
+		return "", errors.New("invalid share url")
+	}
+	wantPrefix := strings.TrimRight(joinBase.EscapedPath(), "/") + "/MAL1-"
+	if !strings.HasPrefix(u.EscapedPath(), wantPrefix) {
+		return "", errors.New("invalid share url")
+	}
+	query := u.Query()
+	challenges, ok := query["c"]
+	if !ok || len(query) != 1 || len(challenges) != 1 || !socialChallengePattern.MatchString(challenges[0]) {
+		return "", errors.New("invalid share url")
+	}
+	u.Scheme = joinBase.Scheme
+	u.Host = joinBase.Host
+	u.RawQuery = query.Encode()
+	return u.String(), nil
+}

--- a/phase4-coordinator/internal/referralapi/xapi_test.go
+++ b/phase4-coordinator/internal/referralapi/xapi_test.go
@@ -1,0 +1,219 @@
+package referralapi
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"testing"
+)
+
+func mustXClient(t *testing.T, bearer, joinBaseURL string) *XAPIClient {
+	t.Helper()
+	client, err := NewXAPIClient(bearer, joinBaseURL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return client
+}
+
+type xRoundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f xRoundTripFunc) RoundTrip(request *http.Request) (*http.Response, error) {
+	return f(request)
+}
+
+func TestParseXPostIDAcceptsOnlyCanonicalStatusURLs(t *testing.T) {
+	accepted := "https://x.com/malibu/status/123456789"
+	if got, err := ParseXPostID(accepted); err != nil || got != "123456789" {
+		t.Fatalf("ParseXPostID=%q err=%v", got, err)
+	}
+	for _, rejected := range []string{
+		"http://x.com/malibu/status/123",
+		"https://www.x.com/malibu/status/123",
+		"https://x.com/malibu/status/123?",
+		"https://x.com/malibu/status/123?ref=share",
+		"https://user@x.com/malibu/status/123",
+		"https://x.com:443/malibu/status/123",
+		"https://x.com.evil.test/malibu/status/123",
+		"https://x.com/malibu/status/not-numeric",
+		"https://x.com/malibu/status/1234567890123456789012345",
+		"https://x.com/status/123",
+		"https://x.com/malibu/status/123#fragment",
+	} {
+		if _, err := ParseXPostID(rejected); err == nil {
+			t.Fatalf("accepted %q", rejected)
+		}
+	}
+}
+
+func TestXAPIRefusesRedirectsAndOversizedResponses(t *testing.T) {
+	client := mustXClient(t, "secret", "https://malibu.tech/j")
+	redirect := &http.Request{URL: mustURL(t, "https://evil.test/steal")}
+	if err := client.client.CheckRedirect(redirect, []*http.Request{{URL: mustURL(t, "https://api.x.com/2/tweets/123")}}); !errors.Is(err, http.ErrUseLastResponse) {
+		t.Fatalf("redirect policy err=%v", err)
+	}
+
+	client.client = &http.Client{Transport: xRoundTripFunc(func(*http.Request) (*http.Response, error) {
+		body := strings.Repeat("x", 64*1024+1)
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     http.Header{"Content-Type": []string{"application/json"}},
+			Body:       io.NopCloser(strings.NewReader(body)),
+		}, nil
+	})}
+	if _, err := client.VerifyPost(context.Background(), "123", "https://malibu.tech/j/MAL1-P-k1-issuer-TAG?c="+strings.Repeat("a", 64)); !errors.Is(err, ErrXPostTransient) {
+		t.Fatalf("oversized response err=%v", err)
+	}
+
+	client.client = &http.Client{Transport: xRoundTripFunc(func(*http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     http.Header{"Content-Type": []string{"text/html"}},
+			Body:       io.NopCloser(strings.NewReader("{}")),
+		}, nil
+	})}
+	if _, err := client.VerifyPost(context.Background(), "123", "https://malibu.tech/j/MAL1-P-k1-issuer-TAG?c="+strings.Repeat("a", 64)); !errors.Is(err, ErrXPostTransient) {
+		t.Fatalf("content-type response err=%v", err)
+	}
+}
+
+func mustURL(t *testing.T, raw string) *url.URL {
+	t.Helper()
+	u, err := url.Parse(raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return u
+}
+
+func TestXAPIUsesFixedOriginAndRequiresAuthorAndExactInviteEntity(t *testing.T) {
+	challenge := strings.Repeat("a", 64)
+	wantShare := "https://malibu.tech/j/MAL1-P-k1-issuer-TAG?c=" + challenge
+	client := mustXClient(t, "secret", "https://malibu.tech/j")
+	client.client = &http.Client{Transport: xRoundTripFunc(func(request *http.Request) (*http.Response, error) {
+		if request.Method != http.MethodGet || request.URL.Scheme != "https" || request.URL.Host != "api.x.com" || request.Host != "api.x.com" {
+			t.Fatalf("request method=%s URL=%s host=%q", request.Method, request.URL, request.Host)
+		}
+		if request.URL.String() != "https://api.x.com/2/tweets/123?tweet.fields=entities,author_id" {
+			t.Fatalf("request URL=%s", request.URL)
+		}
+		if request.Header.Get("Authorization") != "Bearer secret" {
+			t.Fatalf("authorization=%q", request.Header.Get("Authorization"))
+		}
+		body := `{"data":{"id":"123","author_id":"456","entities":{"urls":[{"expanded_url":"` + wantShare + `"}]}}}`
+		return &http.Response{StatusCode: http.StatusOK, Header: http.Header{"Content-Type": []string{"application/json"}}, Body: io.NopCloser(strings.NewReader(body))}, nil
+	})}
+	authorID, err := client.VerifyPost(context.Background(), "123", wantShare)
+	if err != nil || authorID != "456" {
+		t.Fatalf("author=%q err=%v", authorID, err)
+	}
+
+	client.client = &http.Client{Transport: xRoundTripFunc(func(*http.Request) (*http.Response, error) {
+		body := `{"data":{"id":"123","author_id":"","entities":{"urls":[{"expanded_url":"` + wantShare + `"}]}}}`
+		return &http.Response{StatusCode: http.StatusOK, Header: http.Header{"Content-Type": []string{"application/json"}}, Body: io.NopCloser(strings.NewReader(body))}, nil
+	})}
+	if _, err := client.VerifyPost(context.Background(), "123", wantShare); !errors.Is(err, ErrXPostTransient) {
+		t.Fatalf("missing author error=%v", err)
+	}
+	if _, err := canonicalShareURL(wantShare+"&utm_source=x", client.joinBase); err == nil {
+		t.Fatal("canonical share URL accepted an extra query parameter")
+	}
+	if _, err := canonicalShareURL(wantShare+"?", client.joinBase); err == nil {
+		t.Fatal("canonical share URL accepted malformed duplicate query")
+	}
+	digest, err := ShareURLDigest(wantShare, "https://malibu.tech/j")
+	if err != nil || len(digest) != 64 {
+		t.Fatalf("share URL digest=%q err=%v", digest, err)
+	}
+}
+
+func TestXAPIRejectsResponseIdentityAndAuthorMismatch(t *testing.T) {
+	challenge := strings.Repeat("a", 64)
+	wantShare := "https://malibu.tech/j/MAL1-P-k1-issuer-TAG?c=" + challenge
+	client := mustXClient(t, "secret", "https://malibu.tech/j")
+	for _, payload := range []string{
+		`{"data":{"id":"999","author_id":"456","entities":{"urls":[{"expanded_url":"` + wantShare + `"}]}}}`,
+		`{"data":{"id":"123","author_id":"not-numeric","entities":{"urls":[{"expanded_url":"` + wantShare + `"}]}}}`,
+		`{"data":{"id":"123","author_id":"1234567890123456789012345","entities":{"urls":[{"expanded_url":"` + wantShare + `"}]}}}`,
+	} {
+		client.client = &http.Client{Transport: xRoundTripFunc(func(*http.Request) (*http.Response, error) {
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Header:     http.Header{"Content-Type": []string{"application/json; charset=utf-8"}},
+				Body:       io.NopCloser(strings.NewReader(payload)),
+			}, nil
+		})}
+		if _, err := client.VerifyPost(context.Background(), "123", wantShare); !errors.Is(err, ErrXPostTransient) {
+			t.Fatalf("payload=%s err=%v", payload, err)
+		}
+	}
+}
+
+func TestXAPIClassifiesOnlyConfirmedUnavailablePostsAsTerminal(t *testing.T) {
+	client := mustXClient(t, "secret", "https://malibu.tech/j")
+	for _, test := range []struct {
+		status int
+		body   string
+		want   error
+	}{
+		{status: http.StatusNotFound, body: `{"title":"not found"}`, want: ErrXPostTerminal},
+		{status: http.StatusGone, body: `{"title":"gone"}`, want: ErrXPostTerminal},
+		{status: http.StatusForbidden, body: `{"type":"https://api.x.com/2/problems/not-authorized-for-resource","detail":"This post is unavailable"}`, want: ErrXPostTerminal},
+		{status: http.StatusForbidden, body: `{"errors":[{"code":179,"message":"not visible"}]}`, want: ErrXPostTerminal},
+		{status: http.StatusForbidden, body: `{"detail":"client cannot access private metrics"}`, want: ErrXPostTransient},
+		{status: http.StatusForbidden, body: `{"title":"client forbidden"}`, want: ErrXPostTransient},
+		{status: http.StatusTooManyRequests, body: `{"title":"limited"}`, want: ErrXPostTransient},
+		{status: http.StatusInternalServerError, body: `{"title":"error"}`, want: ErrXPostTransient},
+	} {
+		client.client = &http.Client{Transport: xRoundTripFunc(func(*http.Request) (*http.Response, error) {
+			return &http.Response{StatusCode: test.status, Header: make(http.Header), Body: io.NopCloser(strings.NewReader(test.body))}, nil
+		})}
+		if _, err := client.RecheckPost(context.Background(), "123", strings.Repeat("a", 64)); !errors.Is(err, test.want) {
+			t.Fatalf("status=%d err=%v want=%v", test.status, err, test.want)
+		}
+	}
+}
+
+func TestXAPIRecheckRequiresOriginalExactInviteURL(t *testing.T) {
+	challenge := strings.Repeat("a", 64)
+	original := "https://malibu.tech/j/MAL1-P-k1-issuer-TAG?c=" + challenge
+	digest, err := ShareURLDigest(original, "https://malibu.tech/j")
+	if err != nil {
+		t.Fatal(err)
+	}
+	client := mustXClient(t, "secret", "https://malibu.tech/j")
+	postURL := original
+	client.client = &http.Client{Transport: xRoundTripFunc(func(*http.Request) (*http.Response, error) {
+		body := `{"data":{"id":"123","author_id":"456","entities":{"urls":[{"expanded_url":"` + postURL + `"}]}}}`
+		return &http.Response{StatusCode: http.StatusOK, Header: http.Header{"Content-Type": []string{"application/json"}}, Body: io.NopCloser(strings.NewReader(body))}, nil
+	})}
+	if author, err := client.RecheckPost(context.Background(), "123", digest); err != nil || author != "456" {
+		t.Fatalf("unchanged author=%q err=%v", author, err)
+	}
+	postURL = "https://malibu.tech/j/MAL1-P-k1-other-TAG?c=" + challenge
+	if _, err := client.RecheckPost(context.Background(), "123", digest); !errors.Is(err, ErrXPostTerminal) {
+		t.Fatalf("changed invite error=%v", err)
+	}
+	postURL = "https://example.test/no-malibu-link"
+	if _, err := client.RecheckPost(context.Background(), "123", digest); !errors.Is(err, ErrXPostTerminal) {
+		t.Fatalf("removed invite error=%v", err)
+	}
+}
+
+func TestNewXAPIClientRejectsUnsafeJoinBase(t *testing.T) {
+	for _, raw := range []string{
+		"http://malibu.tech/j",
+		"https://user:secret@malibu.tech/j",
+		"https://malibu.tech/j?next=evil",
+		"https://malibu.tech/j?",
+		"https://malibu.tech/j#fragment",
+		"https://malibu.tech/invite",
+	} {
+		if _, err := NewXAPIClient("secret", raw); err == nil {
+			t.Fatalf("accepted unsafe join base %q", raw)
+		}
+	}
+}

--- a/phase4-coordinator/internal/stats/integration_test.go
+++ b/phase4-coordinator/internal/stats/integration_test.go
@@ -900,6 +900,85 @@ func TestMigrationsIdempotent(t *testing.T) {
 	}
 }
 
+func TestApptrackRegisterAttemptsUpgradeDowngradeAndReapply(t *testing.T) {
+	fx := startPostgres(t)
+	adminDB := applyMigrationsAndStubOLTP(t, fx)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	assertTableExists := func(want bool) {
+		t.Helper()
+		var exists bool
+		if err := adminDB.QueryRowContext(ctx, `
+SELECT to_regclass('public.provider_register_attempts') IS NOT NULL
+`).Scan(&exists); err != nil {
+			t.Fatalf("lookup provider_register_attempts: %v", err)
+		}
+		if exists != want {
+			t.Fatalf("provider_register_attempts exists=%v, want %v", exists, want)
+		}
+	}
+
+	assertTableExists(true)
+
+	onboardingDB, err := sql.Open("postgres", fx.roleDSN(roleProviderOnboard))
+	if err != nil {
+		t.Fatalf("open provider_onboarding: %v", err)
+	}
+	defer onboardingDB.Close()
+
+	providerID := "p_migration_roundtrip"
+	nonce := "nonce-roundtrip"
+	if _, err := onboardingDB.ExecContext(ctx, `
+INSERT INTO provider_register_attempts (provider_id, nonce, ts_utc, source_ip)
+VALUES ($1, $2, '2026-07-16T00:00:00Z', '127.0.0.1')
+`, providerID, nonce); err != nil {
+		t.Fatalf("provider_onboarding insert: %v", err)
+	}
+	var count int
+	if err := onboardingDB.QueryRowContext(ctx, `
+SELECT COUNT(*) FROM provider_register_attempts
+WHERE provider_id = $1 AND nonce = $2
+`, providerID, nonce).Scan(&count); err != nil {
+		t.Fatalf("provider_onboarding select: %v", err)
+	}
+	if count != 1 {
+		t.Fatalf("provider_onboarding selected %d attempt rows, want 1", count)
+	}
+	for operation, query := range map[string]string{
+		"update": `UPDATE provider_register_attempts SET source_ip = '127.0.0.2' WHERE provider_id = 'p_migration_roundtrip'`,
+		"delete": `DELETE FROM provider_register_attempts WHERE provider_id = 'p_migration_roundtrip'`,
+		"prune":  `SELECT prune_provider_register_attempts(INTERVAL '30 days')`,
+	} {
+		if _, err := onboardingDB.ExecContext(ctx, query); err == nil || !strings.Contains(strings.ToLower(err.Error()), "permission denied") {
+			t.Fatalf("provider_onboarding %s error=%v, want permission denied", operation, err)
+		}
+	}
+
+	if err := statsmigrations.Apply(ctx, adminDB); err != nil {
+		t.Fatalf("idempotent re-apply with migration 018 present: %v", err)
+	}
+	assertTableExists(true)
+
+	downSQL, err := os.ReadFile("migrations/018_apptrack_register_attempts.down.sql")
+	if err != nil {
+		t.Fatalf("read migration 018 rollback artifact: %v", err)
+	}
+	if _, err := adminDB.ExecContext(ctx, string(downSQL)); err != nil {
+		t.Fatalf("apply migration 018 rollback: %v", err)
+	}
+	if _, err := adminDB.ExecContext(ctx, `DELETE FROM schema_migrations_spec017 WHERE version = 18`); err != nil {
+		t.Fatalf("remove rolled-back migration 018 ledger row: %v", err)
+	}
+	assertTableExists(false)
+
+	if err := statsmigrations.Apply(ctx, adminDB); err != nil {
+		t.Fatalf("re-apply migration 018 after rollback: %v", err)
+	}
+	assertTableExists(true)
+}
+
 // TestMigrationsConcurrent — round-1 CODE r1 CRITICAL C1 fix.
 // Two parallel Apply calls must both succeed without leaving
 // duplicate rows in schema_migrations_spec017 or double-applying

--- a/phase4-coordinator/internal/stats/migrations/018_apptrack_register_attempts.down.sql
+++ b/phase4-coordinator/internal/stats/migrations/018_apptrack_register_attempts.down.sql
@@ -1,0 +1,6 @@
+-- Operator rollback artifact. The embedded runner applies only *.up.sql.
+REVOKE ALL ON provider_register_attempts FROM provider_onboarding;
+REVOKE ALL ON FUNCTION prune_provider_register_attempts(INTERVAL) FROM PUBLIC;
+
+DROP FUNCTION IF EXISTS prune_provider_register_attempts(INTERVAL);
+DROP TABLE IF EXISTS provider_register_attempts;

--- a/phase4-coordinator/internal/stats/migrations/018_apptrack_register_attempts.up.sql
+++ b/phase4-coordinator/internal/stats/migrations/018_apptrack_register_attempts.up.sql
@@ -1,0 +1,48 @@
+-- Durable commitment marker for App-track provider registration.
+--
+-- The replay nonce table is intentionally short-lived and therefore cannot
+-- prove that the PostgreSQL half of a cross-store referral mint committed.
+-- This table is written in the same transaction as provider identity prepare
+-- and survives well beyond the SQLite saga reconciliation horizon.
+--
+-- The primary key contains signed, replay-stable fields only. source_ip is
+-- connection-dependent diagnostic metadata and is never authoritative.
+CREATE TABLE IF NOT EXISTS provider_register_attempts (
+    provider_id  TEXT NOT NULL,
+    nonce        TEXT NOT NULL,
+    ts_utc       TIMESTAMPTZ NOT NULL,
+    source_ip    TEXT,
+    committed_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    PRIMARY KEY (provider_id, nonce, ts_utc)
+);
+
+CREATE INDEX IF NOT EXISTS idx_provider_register_attempts_committed_at
+    ON provider_register_attempts(committed_at);
+
+-- Keep attempt evidence for at least seven days. This is deliberately much
+-- longer than the registration reconciliation horizon.
+CREATE OR REPLACE FUNCTION prune_provider_register_attempts(retain_for INTERVAL DEFAULT INTERVAL '30 days')
+RETURNS BIGINT
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = pg_catalog, public, pg_temp
+AS $$
+DECLARE
+    deleted_count BIGINT;
+BEGIN
+    IF retain_for < INTERVAL '7 days' THEN
+        RAISE EXCEPTION 'retain_for must be at least 7 days';
+    END IF;
+
+    DELETE FROM provider_register_attempts
+     WHERE committed_at < NOW() - retain_for;
+    GET DIAGNOSTICS deleted_count = ROW_COUNT;
+    RETURN deleted_count;
+END;
+$$;
+
+-- The runtime role can record and verify commitments but cannot mutate them.
+GRANT SELECT, INSERT ON provider_register_attempts TO provider_onboarding;
+
+REVOKE ALL ON FUNCTION prune_provider_register_attempts(INTERVAL) FROM PUBLIC;
+REVOKE ALL ON FUNCTION prune_provider_register_attempts(INTERVAL) FROM provider_onboarding;

--- a/phase4-coordinator/internal/stats/migrations/migrations_test.go
+++ b/phase4-coordinator/internal/stats/migrations/migrations_test.go
@@ -38,6 +38,7 @@ func TestEmbeddedMigrationsLoad(t *testing.T) {
 		{15, "provider_onboarding_hardware_decision_reason"},
 		{16, "hardware_profile_memory_reverification"},
 		{17, "autotune_current_hardware_gate_grants"},
+		{18, "apptrack_register_attempts"},
 	}
 	if len(all) != len(want) {
 		t.Fatalf("got %d migrations, want %d", len(all), len(want))
@@ -557,4 +558,49 @@ func extractBetween(body, start, end string) string {
 		return rest
 	}
 	return rest[:j+len(end)]
+}
+
+func TestApptrackRegisterAttemptsMigrationShape(t *testing.T) {
+	all, err := All()
+	if err != nil {
+		t.Fatalf("All: %v", err)
+	}
+	var body string
+	for _, m := range all {
+		if m.Name == "apptrack_register_attempts" {
+			body = m.SQL
+		}
+	}
+	if body == "" {
+		t.Fatal("apptrack_register_attempts migration body is empty")
+	}
+	for _, needle := range []string{
+		"CREATE TABLE IF NOT EXISTS provider_register_attempts",
+		"PRIMARY KEY (provider_id, nonce, ts_utc)",
+		"CREATE OR REPLACE FUNCTION prune_provider_register_attempts",
+		"retain_for must be at least 7 days",
+		"SET search_path = pg_catalog, public, pg_temp",
+		"GRANT SELECT, INSERT ON provider_register_attempts TO provider_onboarding",
+		"REVOKE ALL ON FUNCTION prune_provider_register_attempts(INTERVAL) FROM PUBLIC",
+		"REVOKE ALL ON FUNCTION prune_provider_register_attempts(INTERVAL) FROM provider_onboarding",
+	} {
+		mustContain(t, body, needle, "durable registration attempt marker migration")
+	}
+	mustNotContain(t, body, "GRANT DELETE ON provider_register_attempts",
+		"runtime onboarding role must not delete durable attempt markers")
+	mustNotContain(t, body, "PRIMARY KEY (provider_id, nonce, ts_utc, source_ip)",
+		"connection metadata must not participate in commitment identity")
+
+	down, err := os.ReadFile("018_apptrack_register_attempts.down.sql")
+	if err != nil {
+		t.Fatalf("read rollback artifact: %v", err)
+	}
+	downSQL := string(down)
+	for _, needle := range []string{
+		"REVOKE ALL ON provider_register_attempts FROM provider_onboarding",
+		"DROP FUNCTION IF EXISTS prune_provider_register_attempts(INTERVAL)",
+		"DROP TABLE IF EXISTS provider_register_attempts",
+	} {
+		mustContain(t, downSQL, needle, "registration attempt rollback artifact")
+	}
 }

--- a/phase4-coordinator/internal/ws/admission.go
+++ b/phase4-coordinator/internal/ws/admission.go
@@ -94,6 +94,32 @@ func (a *AdmissionManager) CheckAdmit(hello Hello, pinned bool, connectedProvisi
 	return a.evaluateAdmissionLocked(hello, connectedProvisional, false)
 }
 
+// ReserveAdmission holds in-memory pool capacity without creating durable
+// admission history. A failed referral/token transaction therefore leaves no
+// hourly admission record behind.
+func (a *AdmissionManager) ReserveAdmission(hello Hello, pinned bool, connectedProvisional int) (pool.Tier, gobwas.StatusCode, string) {
+	if pinned {
+		return pool.TierPinned, 0, ""
+	}
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	tier, code, reason := a.evaluateAdmissionLocked(hello, connectedProvisional, false)
+	if code == 0 {
+		a.pending++
+	}
+	return tier, code, reason
+}
+
+func (a *AdmissionManager) CommitReservedAdmission(hello Hello, pinned bool) pool.Tier {
+	if pinned {
+		return pool.TierPinned
+	}
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	a.recordAdmissionLocked(hello, a.now())
+	return pool.TierProvisional
+}
+
 func (a *AdmissionManager) evaluateAdmissionLocked(hello Hello, connectedProvisional int, record bool) (pool.Tier, gobwas.StatusCode, string) {
 	if _, ok := a.rejected[hello.ProviderID]; ok {
 		return pool.TierRejected, CloseBanned, "banned: provider " + hello.ProviderID + " has been rejected by operator"
@@ -114,6 +140,11 @@ func (a *AdmissionManager) evaluateAdmissionLocked(hello Hello, connectedProvisi
 		return pool.TierProvisional, 0, ""
 	}
 	a.pending++
+	a.recordAdmissionLocked(hello, now)
+	return pool.TierProvisional, 0, ""
+}
+
+func (a *AdmissionManager) recordAdmissionLocked(hello Hello, now time.Time) {
 	rec := a.records[hello.ProviderID]
 	if rec == nil {
 		rec = &ProvisionalRecord{
@@ -129,7 +160,6 @@ func (a *AdmissionManager) evaluateAdmissionLocked(hello Hello, connectedProvisi
 	rec.ModelID = hello.ModelID
 	rec.BinaryVersion = hello.BinaryVersion
 	a.persistLocked()
-	return pool.TierProvisional, 0, ""
 }
 
 func (a *AdmissionManager) ReleasePendingProvisional() {

--- a/phase4-coordinator/internal/ws/messages.go
+++ b/phase4-coordinator/internal/ws/messages.go
@@ -39,6 +39,7 @@ type Hello struct {
 	CandidateRowIdentity   string          `json:"catalog_row_identity,omitempty"`
 	CompatibilitySetID     string          `json:"compatibility_set_id,omitempty"`
 	CredentialBootstrap    bool            `json:"credential_bootstrap,omitempty"`
+	ReferralCode           string          `json:"referral_code,omitempty"`
 }
 
 const (
@@ -46,6 +47,7 @@ const (
 	maxHandshakeModelIDBytes       = 256
 	maxHandshakeBinaryVersionBytes = 32
 	maxHandshakeMetadataBytes      = 1024
+	maxReferralCodeBytes           = 256
 )
 
 type HelloAck struct {
@@ -62,9 +64,9 @@ type HelloAck struct {
 	// the top-level `provider_token` YAML key (FR-C9.3) so the next
 	// reconnect carries Bearer. Note: top-level, NOT nested under
 	// `auth:` — codex audit on PR #44 caught the prior spec/code drift.
-	AssignedProviderToken         string `json:"assigned_provider_token,omitempty"`
-	PairOT                        string `json:"pair_ot,omitempty"`
-	ClaimURL                      string `json:"claim_url,omitempty"`
+	AssignedProviderToken string `json:"assigned_provider_token,omitempty"`
+	PairOT                string `json:"pair_ot,omitempty"`
+	ClaimURL              string `json:"claim_url,omitempty"`
 	// The coordinator's admission verdict on this ACCEPT ack — one of
 	// bearer_validated / self_minted / bearerless_duplicate (pool.AuthState).
 	// mint_failed and the reject paths CLOSE the connection, so they never ride
@@ -123,6 +125,7 @@ type AuthRequest struct {
 	CandidateRowIdentity           string          `json:"catalog_row_identity,omitempty"`
 	CompatibilitySetID             string          `json:"compatibility_set_id,omitempty"`
 	CredentialBootstrap            bool            `json:"credential_bootstrap,omitempty"`
+	ReferralCode                   string          `json:"referral_code,omitempty"`
 }
 
 type Spec010Presence struct {
@@ -170,9 +173,9 @@ type AuthResponse struct {
 	// SPEC-003 v0.8 FR-C9.2 — populated only on proof-stage acceptance
 	// when a tokenless provisional provider was just self-minted on this
 	// connect. Never present on rejection-shaped responses.
-	AssignedProviderToken               string `json:"assigned_provider_token,omitempty"`
-	PairOT                              string `json:"pair_ot,omitempty"`
-	ClaimURL                            string `json:"claim_url,omitempty"`
+	AssignedProviderToken string `json:"assigned_provider_token,omitempty"`
+	PairOT                string `json:"pair_ot,omitempty"`
+	ClaimURL              string `json:"claim_url,omitempty"`
 	// Coordinator admission verdict on this ACCEPT ack; see the
 	// HelloAck.AuthState note (emission SPEC-003 FR-C9.2a, shape SPEC-001 §6.5.1,
 	// interpretation SPEC-020 v0.1.7). mint_failed / rejects close the
@@ -555,6 +558,11 @@ func ParseHello(payload []byte) (Hello, string, error) {
 			return Hello{}, "credential_bootstrap", fmt.Errorf("credential_bootstrap must be a bool")
 		}
 	}
+	if v, ok := raw["referral_code"]; ok && string(v) != "null" {
+		if err := json.Unmarshal(v, &h.ReferralCode); err != nil || len([]byte(h.ReferralCode)) > maxReferralCodeBytes || containsControlChar(h.ReferralCode) {
+			return Hello{}, "referral_code", fmt.Errorf("referral_code must be a string of at most %d bytes", maxReferralCodeBytes)
+		}
+	}
 	if field, err := parseCatalogAdmissionMetadata(raw, &h.CatalogReleaseID, &h.CatalogPolicyVersion, &h.CandidateCatalogSHA256, &h.CatalogSignerKeyID, &h.CandidateRowIdentity); err != nil {
 		return Hello{}, field, err
 	}
@@ -686,6 +694,11 @@ func parseAuthInitial(raw map[string]json.RawMessage, req AuthRequest) (AuthRequ
 	if v, ok := raw["provider_admission_recovery"]; ok {
 		if string(v) == "null" || json.Unmarshal(v, &req.ProviderAdmissionRecovery) != nil {
 			return AuthRequest{}, Spec010Presence{}, "provider_admission_recovery", fmt.Errorf("provider_admission_recovery must be a bool")
+		}
+	}
+	if v, ok := raw["referral_code"]; ok && string(v) != "null" {
+		if err := json.Unmarshal(v, &req.ReferralCode); err != nil || len([]byte(req.ReferralCode)) > maxReferralCodeBytes || containsControlChar(req.ReferralCode) {
+			return AuthRequest{}, Spec010Presence{}, "referral_code", fmt.Errorf("referral_code must be a string of at most %d bytes", maxReferralCodeBytes)
 		}
 	}
 	if err := requireString(raw, "provider_ecdh_public_key", &req.ProviderECDHPublicKey); err != nil {
@@ -830,6 +843,11 @@ func parseAuthProof(raw map[string]json.RawMessage, req AuthRequest) (AuthReques
 			return AuthRequest{}, Spec010Presence{}, "credential_bootstrap", fmt.Errorf("credential_bootstrap must be a bool")
 		}
 	}
+	if v, ok := raw["referral_code"]; ok && string(v) != "null" {
+		if err := json.Unmarshal(v, &req.ReferralCode); err != nil || len([]byte(req.ReferralCode)) > maxReferralCodeBytes || containsControlChar(req.ReferralCode) {
+			return AuthRequest{}, Spec010Presence{}, "referral_code", fmt.Errorf("referral_code must be a string of at most %d bytes", maxReferralCodeBytes)
+		}
+	}
 	// Proof-stage MUST keep the bare "supported_models" badField (NOT
 	// the locked initial-stage substring) — AC-K.15's surfacing
 	// contract is initial-stage-only, and the R2V regression test
@@ -885,6 +903,7 @@ func (r AuthRequest) Hello() Hello {
 		CandidateRowIdentity:   r.CandidateRowIdentity,
 		CompatibilitySetID:     r.CompatibilitySetID,
 		CredentialBootstrap:    r.CredentialBootstrap,
+		ReferralCode:           r.ReferralCode,
 	}
 }
 

--- a/phase4-coordinator/internal/ws/referral_core_test.go
+++ b/phase4-coordinator/internal/ws/referral_core_test.go
@@ -42,17 +42,29 @@ func TestAdmissionReservationIsNotDurableUntilCredentialCommit(t *testing.T) {
 		ProvisionalPoolMax:              1,
 	}, func() time.Time { return now })
 	manager.SetPersistence(store, func(err error) { t.Fatalf("persist admission: %v", err) })
-	hello := Hello{ProviderID: "provider-a", Hostname: "host", ModelID: "model", BinaryVersion: "1.2.0"}
-	if tier, code, reason := manager.ReserveAdmission(hello, false, 0); tier != pool.TierProvisional || code != 0 || reason != "" {
+	failedHello := Hello{ProviderID: "provider-a", Hostname: "host-a", ModelID: "model", BinaryVersion: "1.2.0"}
+	if tier, code, reason := manager.ReserveAdmission(failedHello, false, 0); tier != pool.TierProvisional || code != 0 || reason != "" {
 		t.Fatalf("reserve tier=%s code=%d reason=%q", tier, code, reason)
 	}
 	if records := manager.Records(nil); len(records) != 0 {
 		t.Fatalf("reservation created durable records: %+v", records)
 	}
-	if tier := manager.CommitReservedAdmission(hello, false); tier != pool.TierProvisional {
+
+	committedHello := Hello{ProviderID: "provider-b", Hostname: "host-b", ModelID: "model", BinaryVersion: "1.2.0"}
+	if _, code, _ := manager.ReserveAdmission(committedHello, false, 0); code != CloseProvisionalPoolFull {
+		t.Fatalf("reserve while credential pending code=%d, want %d", code, CloseProvisionalPoolFull)
+	}
+	manager.ReleasePendingProvisional()
+	if records := manager.Records(nil); len(records) != 0 {
+		t.Fatalf("failed credential reservation created durable records: %+v", records)
+	}
+	if tier, code, reason := manager.ReserveAdmission(committedHello, false, 0); tier != pool.TierProvisional || code != 0 || reason != "" {
+		t.Fatalf("reserve after failure release tier=%s code=%d reason=%q", tier, code, reason)
+	}
+	if tier := manager.CommitReservedAdmission(committedHello, false); tier != pool.TierProvisional {
 		t.Fatalf("commit tier=%s", tier)
 	}
-	if records := manager.Records(nil); len(records) != 1 || records[0].ProviderID != hello.ProviderID {
+	if records := manager.Records(nil); len(records) != 1 || records[0].ProviderID != committedHello.ProviderID {
 		t.Fatalf("committed records=%+v", records)
 	}
 	manager.ReleasePendingProvisional()

--- a/phase4-coordinator/internal/ws/referral_core_test.go
+++ b/phase4-coordinator/internal/ws/referral_core_test.go
@@ -1,0 +1,59 @@
+package ws
+
+import (
+	"database/sql"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/augstar/macprovider-coordinator/internal/auth"
+	"github.com/augstar/macprovider-coordinator/internal/config"
+	"github.com/augstar/macprovider-coordinator/internal/pool"
+)
+
+func TestReferralCloseReasonPreservesLifecycleToken(t *testing.T) {
+	cases := map[error]string{
+		auth.ErrReferralInvalid:   "referral_invalid",
+		auth.ErrReferralExpired:   "referral_expired",
+		auth.ErrReferralRevoked:   "referral_revoked",
+		auth.ErrReferralExhausted: "referral_exhausted",
+		auth.ErrReferralConflict:  "referral_invalid",
+	}
+	for err, want := range cases {
+		if got := referralCloseReason(err); got != want {
+			t.Fatalf("referralCloseReason(%v)=%q want=%q", err, got, want)
+		}
+	}
+}
+
+func TestAdmissionReservationIsNotDurableUntilCredentialCommit(t *testing.T) {
+	now := time.Date(2026, 7, 13, 12, 0, 0, 0, time.UTC)
+	db, err := sql.Open("sqlite", filepath.Join(t.TempDir(), "coordinator.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+	store, err := NewSQLiteAdmissionStore(db)
+	if err != nil {
+		t.Fatal(err)
+	}
+	manager := NewAdmissionManager(config.AdmissionConfig{
+		ProvisionalAdmissionRatePerHour: 1,
+		ProvisionalPoolMax:              1,
+	}, func() time.Time { return now })
+	manager.SetPersistence(store, func(err error) { t.Fatalf("persist admission: %v", err) })
+	hello := Hello{ProviderID: "provider-a", Hostname: "host", ModelID: "model", BinaryVersion: "1.2.0"}
+	if tier, code, reason := manager.ReserveAdmission(hello, false, 0); tier != pool.TierProvisional || code != 0 || reason != "" {
+		t.Fatalf("reserve tier=%s code=%d reason=%q", tier, code, reason)
+	}
+	if records := manager.Records(nil); len(records) != 0 {
+		t.Fatalf("reservation created durable records: %+v", records)
+	}
+	if tier := manager.CommitReservedAdmission(hello, false); tier != pool.TierProvisional {
+		t.Fatalf("commit tier=%s", tier)
+	}
+	if records := manager.Records(nil); len(records) != 1 || records[0].ProviderID != hello.ProviderID {
+		t.Fatalf("committed records=%+v", records)
+	}
+	manager.ReleasePendingProvisional()
+}

--- a/phase4-coordinator/internal/ws/server.go
+++ b/phase4-coordinator/internal/ws/server.go
@@ -92,6 +92,7 @@ type Server struct {
 	// interface-segregation regression of mixing both on TokenValidator.
 	issuer          TokenIssuer
 	bootstrapTokens BootstrapTokenStore
+	referralPolicy  auth.ReferralPolicy
 	authStore       *auth.Store
 	githubOAuth     githubOAuthClient
 	admission       *AdmissionManager
@@ -339,6 +340,12 @@ func WithTokenIssuer(issuer TokenIssuer) Option {
 func WithBootstrapTokenStore(store BootstrapTokenStore) Option {
 	return func(s *Server) {
 		s.bootstrapTokens = store
+	}
+}
+
+func WithReferralPolicy(policy auth.ReferralPolicy) Option {
+	return func(s *Server) {
+		s.referralPolicy = policy
 	}
 }
 
@@ -902,7 +909,7 @@ const (
 // bearer; race-losers are quarantined as AuthBearerlessDuplicate.
 //
 // authParam is renamed to disambiguate from the auth package import.
-func (s *Server) resolveProvisionalToken(authParam providerAuth, providerID, providerName string) (provisionalTokenOutcome, string, string, string, pool.AuthState) {
+func (s *Server) resolveProvisionalToken(authParam providerAuth, providerID, providerName, referralCode string) (provisionalTokenOutcome, string, string, string, pool.AuthState) {
 	if s.issuer == nil {
 		return provisionalTokenSkip, "", "", "", ""
 	}
@@ -920,7 +927,7 @@ func (s *Server) resolveProvisionalToken(authParam providerAuth, providerID, pro
 		return provisionalTokenRejectTOFU, "", "", "", ""
 	}
 	if s.cfg.Auth.GitHubOAuth.Enabled && s.authStore != nil {
-		mint, err := s.authStore.MintAdmissionTokenAndPairOT(ctx, providerID, providerName, s.now())
+		mint, err := s.authStore.MintAdmissionTokenAndPairOTWithReferral(ctx, providerID, providerName, s.now(), referralCode, s.referralPolicy)
 		if err == nil {
 			claimURL := ""
 			if mint.Paired {
@@ -935,7 +942,19 @@ func (s *Server) resolveProvisionalToken(authParam providerAuth, providerID, pro
 		}
 		s.log.Warn().Err(err).Str("provider_id", providerID).Msg("FR-C10 pair_ot compound mint failed; falling back to plain FR-C9 provider token mint")
 	}
-	_, token, err := s.issuer.IssueToken(ctx, providerID, providerName)
+	var token string
+	if s.referralPolicy.RequireForRegistration {
+		referralIssuer, ok := s.issuer.(interface {
+			IssueTokenWithReferral(context.Context, string, string, string, auth.ReferralPolicy) (auth.TokenRecord, string, error)
+		})
+		if !ok {
+			err = errors.New("referral-aware token issuer unavailable")
+		} else {
+			_, token, err = referralIssuer.IssueTokenWithReferral(ctx, providerID, providerName, referralCode, s.referralPolicy)
+		}
+	} else {
+		_, token, err = s.issuer.IssueToken(ctx, providerID, providerName)
+	}
 	if err != nil {
 		if errors.Is(err, auth.ErrActiveTokenAlreadyExists) {
 			// SPEC-003 v0.8.4 race-loss path: a concurrent tokenless
@@ -1004,9 +1023,14 @@ func (s *Server) handleV1Conn(conn net.Conn, connectionAuth providerAuth, payloa
 		s.close(conn, CloseIdentitySignatureRequired, "durable_identity_requires_v2")
 		return "", ""
 	}
-	entry, ok := s.prepareProviderAdmission(conn, connectionAuth, hello, true)
+	entry, ok := s.prepareProviderAdmission(conn, connectionAuth, hello)
 	if !ok {
 		return "", ""
+	}
+	if tier, ok := s.reserveProviderAdmission(conn, hello, entry.Tier == pool.TierPinned); !ok {
+		return "", ""
+	} else {
+		entry.Tier = tier
 	}
 	registered := false
 	defer func() {
@@ -1022,7 +1046,7 @@ func (s *Server) handleV1Conn(conn net.Conn, connectionAuth providerAuth, payloa
 	// the provided AuthState (BearerValidated / BearerlessDuplicate /
 	// empty) and let the registry eviction defense + RoutingEligible
 	// gates take over.
-	outcome, assignedProviderToken, pairOT, claimURL, authState := s.resolveProvisionalToken(connectionAuth, entry.ProviderID, hello.Hostname)
+	outcome, assignedProviderToken, pairOT, claimURL, authState := s.resolveProvisionalToken(connectionAuth, entry.ProviderID, hello.Hostname, hello.ReferralCode)
 	if outcome == provisionalTokenRejectTOFU {
 		s.close(conn, CloseInvalidToken, "invalid_token")
 		return "", ""
@@ -1030,6 +1054,7 @@ func (s *Server) handleV1Conn(conn net.Conn, connectionAuth providerAuth, payloa
 	if !s.confirmAdmittedProviderToken(conn, connectionAuth) {
 		return "", ""
 	}
+	entry.Tier = s.commitProviderAdmission(hello, entry.Tier == pool.TierPinned)
 	entry.AuthState = authState
 	session, _ := s.registerProviderSession(conn, entry)
 	if session == nil {
@@ -1121,7 +1146,7 @@ func (s *Server) handleV2Conn(conn net.Conn, connectionAuth providerAuth, payloa
 	if initial.CredentialBootstrap {
 		entry, ok = s.prepareCredentialBootstrap(conn, connectionAuth, initial)
 	} else {
-		entry, ok = s.prepareProviderAdmission(conn, connectionAuth, initial.Hello(), false)
+		entry, ok = s.prepareProviderAdmission(conn, connectionAuth, initial.Hello())
 	}
 	if !ok {
 		return "", ""
@@ -1260,7 +1285,8 @@ func (s *Server) handleV2Conn(conn net.Conn, connectionAuth providerAuth, payloa
 		return "", ""
 	}
 	if proof.AuthAttemptID != authAttemptID || proof.ProviderID != initial.ProviderID ||
-		proof.CredentialBootstrap != initial.CredentialBootstrap || s.now().After(challengeExpiresAt) {
+		proof.CredentialBootstrap != initial.CredentialBootstrap || proof.ReferralCode != initial.ReferralCode ||
+		s.now().After(challengeExpiresAt) {
 		s.sendAuthRejection(conn, "attestation_failed", "attestation failed")
 		s.close(conn, CloseTier2AttestationFailed, "tier2_attestation_failed")
 		return "", ""
@@ -1338,6 +1364,8 @@ func (s *Server) handleV2Conn(conn net.Conn, connectionAuth providerAuth, payloa
 			UnconfirmedIDMax:    s.cfg.Auth.CredentialBootstrapUnconfirmedMax,
 			OutstandingTokenMax: s.cfg.Auth.CredentialBootstrapOutstandingMax,
 			IdentityRetention:   time.Duration(s.cfg.Auth.CredentialBootstrapIdentityRetentionS) * time.Second,
+			ReferralCode:        initial.ReferralCode,
+			ReferralPolicy:      s.referralPolicy,
 		})
 		if err != nil {
 			s.rejectCredentialBootstrap(conn, err)
@@ -1435,11 +1463,9 @@ func (s *Server) handleV2Conn(conn net.Conn, connectionAuth providerAuth, payloa
 	}
 	entry.MaxAdmittedModelKey = maxAdmittedModelKey
 	entry.MaxAdmittedModelID = maxAdmittedModelID
-	// This is the first durable admission mutation in the v2 path. Keep it
-	// after the post-challenge evidence recheck so a provider whose evidence
-	// disappears during authentication cannot consume an hourly admission or
-	// leave a provisional record behind.
-	if tier, ok := s.recordProviderAdmission(conn, initial.Hello(), entry.Tier == pool.TierPinned); !ok {
+	// Reserve after the post-challenge evidence recheck, but defer the durable
+	// admission record until credential minting succeeds.
+	if tier, ok := s.reserveProviderAdmission(conn, initial.Hello(), entry.Tier == pool.TierPinned); !ok {
 		return "", ""
 	} else {
 		entry.Tier = tier
@@ -1450,7 +1476,7 @@ func (s *Server) handleV2Conn(conn net.Conn, connectionAuth providerAuth, payloa
 			s.admission.ReleasePendingProvisional()
 		}
 	}()
-	outcome, assignedProviderToken, pairOT, claimURL, authState := s.resolveProvisionalToken(connectionAuth, entry.ProviderID, initial.Hostname)
+	outcome, assignedProviderToken, pairOT, claimURL, authState := s.resolveProvisionalToken(connectionAuth, entry.ProviderID, initial.Hostname, initial.ReferralCode)
 	if outcome == provisionalTokenRejectTOFU {
 		s.close(conn, CloseInvalidToken, "invalid_token")
 		return "", ""
@@ -1529,6 +1555,7 @@ func (s *Server) handleV2Conn(conn net.Conn, connectionAuth providerAuth, payloa
 			Int("identity_generation", state.Generation).
 			Msg("durable admission identity recovered under operator authorization")
 	}
+	entry.Tier = s.commitProviderAdmission(initial.Hello(), entry.Tier == pool.TierPinned)
 	entry.AuthState = authState
 	session, refusal := s.registerProviderSession(conn, entry)
 	if session == nil {
@@ -1674,10 +1701,31 @@ func (s *Server) rejectCredentialBootstrap(conn net.Conn, err error) {
 	case errors.Is(err, auth.ErrBootstrapOutstandingLimit):
 		s.observeCredentialBootstrap("rejected_outstanding")
 		s.close(conn, CloseProvisionalPoolFull, "credential_bootstrap_outstanding_full")
+	case errors.Is(err, auth.ErrReferralRequired):
+		s.observeCredentialBootstrap("rejected_referral_required")
+		s.close(conn, CloseInvalidToken, "referral_required")
+	case errors.Is(err, auth.ErrReferralInvalid), errors.Is(err, auth.ErrReferralExpired),
+		errors.Is(err, auth.ErrReferralRevoked), errors.Is(err, auth.ErrReferralExhausted),
+		errors.Is(err, auth.ErrReferralConflict):
+		s.observeCredentialBootstrap("rejected_referral")
+		s.close(conn, CloseInvalidToken, referralCloseReason(err))
 	default:
 		s.observeCredentialBootstrap("store_error")
 		s.log.Warn().Err(err).Msg("credential bootstrap token transaction failed")
 		s.close(conn, CloseInvalidToken, "invalid_token")
+	}
+}
+
+func referralCloseReason(err error) string {
+	switch {
+	case errors.Is(err, auth.ErrReferralExpired):
+		return "referral_expired"
+	case errors.Is(err, auth.ErrReferralRevoked):
+		return "referral_revoked"
+	case errors.Is(err, auth.ErrReferralExhausted):
+		return "referral_exhausted"
+	default:
+		return "referral_invalid"
 	}
 }
 
@@ -1687,7 +1735,7 @@ func (s *Server) observeCredentialBootstrap(outcome string) {
 	}
 }
 
-func (s *Server) prepareProviderAdmission(conn net.Conn, auth providerAuth, hello Hello, recordAdmission bool) (*pool.Provider, bool) {
+func (s *Server) prepareProviderAdmission(conn net.Conn, auth providerAuth, hello Hello) (*pool.Provider, bool) {
 	if required := strings.TrimSpace(s.cfg.CoordinatorAdvertisedVersion.RequiredBinaryVersion); required != "" {
 		cmp, ok := compareSemver(hello.BinaryVersion, required)
 		if !ok || cmp < 0 {
@@ -1765,13 +1813,6 @@ func (s *Server) prepareProviderAdmission(conn net.Conn, auth providerAuth, hell
 	maxAdmittedModelKey, maxAdmittedModelID, gateOK := s.checkAutotuneHelloGate(conn, hello)
 	if !gateOK {
 		return nil, false
-	}
-	if recordAdmission {
-		tier, closeCode, closeReason = s.checkOrRecordAdmission(hello, pinned, true)
-		if closeCode != 0 {
-			s.close(conn, closeCode, closeReason)
-			return nil, false
-		}
 	}
 	initialState := pool.StateReady
 	if s.cfg.Pool.WarmupGateEnabled {
@@ -2024,13 +2065,17 @@ func (s *Server) gatedRecommendedBinaryVersion(compatibilitySetID string) string
 	return s.cfg.CoordinatorAdvertisedVersion.LatestBinaryVersion
 }
 
-func (s *Server) recordProviderAdmission(conn net.Conn, hello Hello, pinned bool) (pool.Tier, bool) {
-	tier, closeCode, closeReason := s.checkOrRecordAdmission(hello, pinned, true)
+func (s *Server) reserveProviderAdmission(conn net.Conn, hello Hello, pinned bool) (pool.Tier, bool) {
+	tier, closeCode, closeReason := s.admission.ReserveAdmission(hello, pinned, s.connectedProvisional())
 	if closeCode != 0 {
 		s.close(conn, closeCode, closeReason)
 		return "", false
 	}
 	return tier, true
+}
+
+func (s *Server) commitProviderAdmission(hello Hello, pinned bool) pool.Tier {
+	return s.admission.CommitReservedAdmission(hello, pinned)
 }
 
 func (s *Server) checkOrRecordAdmission(hello Hello, pinned bool, record bool) (pool.Tier, gobwas.StatusCode, string) {


### PR DESCRIPTION
## Outcome

Recovers only the coordinator-side advocacy/X reward functionality from #578 against the current referral server stack. This PR contains no Malibu code and has no dependency on obsolete #575 architecture.

## Dependency

- Base: #576 at 24440714 (join links/operator controls)
- Transitively depends on recovered #574 and #573
- Supersedes the server portion of #578
- Supplies the authenticated referral status contract consumed through the CLI by #626

## Architecture

- Coordinator/buyer settlement verdicts are the sole serving-qualification authority.
- Status reads are side-effect free and cannot issue invite capacity.
- Authenticated status returns configured credential-free join_base_url so clients do not infer a public join origin from the coordinator API host.
- Qualification converges to the earliest authoritative evidence tuple without duplicate allocation.
- X verification is server-side, fixed-origin, bounded, replay-safe, rate-limited, and audited.
- Invalid, expired, provider-mismatched, or replayed challenges are rejected safely.
- Exact response-loss replays return durable state without repeating the X lookup.
- Bonus capacity is transactionally awarded exactly once after dwell-time re-verification.
- Issuer replacement is dry-run/CAS guarded and preserves historical redemptions.
- All production activation flags remain disabled by default.

## Operator rollback

Routes are not mounted unless their flags are enabled. Social verification additionally requires admission and join-link flags, configured X credentials, and positive dwell. Operator replacement requires explicit snapshot expectations, actor, reason, and an environment-supplied HMAC secret.

## Verification

- go test ./...
- go vet ./...
- go test -race ./internal/auth ./internal/referralapi ./cmd/coordinator ./cmd/coordinator-cli
- golangci-lint run — 0 issues
- concurrent qualification/redemption/replay/replacement coverage
- independent code, architecture, and security reviews — PASS; 0 Critical/High/Medium

Earlier govulncheck found the same two inherited findings present on the #576 base (Go TLS GO-2026-5856 and x/net GO-2026-5026); this PR adds no dependency change.

## Activation gate

Do not enable production flags until the signed/notarized physical two-provider journey passes: CLI-owned referred registration, buyer-serving qualification, invite redemption by a second provider, and exactly-once X bonus.