### PR TITLE
Keep Malibu publication bound to discoverable drafts

### DIFF
--- a/.github/workflows/malibu-release.yml
+++ b/.github/workflows/malibu-release.yml
@@ -663,32 +663,38 @@ jobs:
               "$GITHUB_REPOSITORY" production-release 28995904
           gh api -H 'X-GitHub-Api-Version: 2026-03-10' \
             "repos/$GITHUB_REPOSITORY/releases/$RELEASE_ID" > "$RUNNER_TEMP/final-draft-by-id.json"
-          gh api -H 'X-GitHub-Api-Version: 2026-03-10' \
-            "repos/$GITHUB_REPOSITORY/releases/tags/$tag" > "$RUNNER_TEMP/final-draft-by-tag.json"
+          gh release view "$tag" --repo "$GITHUB_REPOSITORY" \
+            --json databaseId,isDraft,tagName,targetCommitish,assets > "$RUNNER_TEMP/final-draft-cli.json"
           python3 - "$RUNNER_TEMP/final-draft-by-id.json" \
-            "$RUNNER_TEMP/final-draft-by-tag.json" "$candidate" "$RELEASE_ID" \
+            "$RUNNER_TEMP/final-draft-cli.json" "$candidate" "$RELEASE_ID" \
             "$tag" "$SOURCE_COMMIT" "$APP_VERSION" <<'PY'
           import hashlib
           import json
           import pathlib
           import sys
 
-          by_id_path, by_tag_path, candidate_path, release_id, tag, commit, version = sys.argv[1:]
+          by_id_path, cli_path, candidate_path, release_id, tag, commit, version = sys.argv[1:]
           candidate = pathlib.Path(candidate_path)
           names = [f"Malibu-v{version}.dmg", f"Malibu-v{version}.dmg.sha256", "candidate-manifest.json"]
           expected_digests = {
               name: "sha256:" + hashlib.sha256((candidate / name).read_bytes()).hexdigest()
               for name in names
           }
-          for label, path in (("numeric", by_id_path), ("tag", by_tag_path)):
-              release = json.load(open(path, encoding="utf-8"))
-              if release.get("id") != int(release_id):
+          by_id = json.load(open(by_id_path, encoding="utf-8"))
+          by_cli = json.load(open(cli_path, encoding="utf-8"))
+          releases = (
+              ("numeric", by_id.get("id"), by_id.get("draft"), by_id.get("immutable"),
+               by_id.get("tag_name"), by_id.get("target_commitish"), by_id.get("assets", [])),
+              ("cli", by_cli.get("databaseId"), by_cli.get("isDraft"), None,
+               by_cli.get("tagName"), by_cli.get("targetCommitish"), by_cli.get("assets", [])),
+          )
+          for label, actual_id, draft, immutable, actual_tag, actual_commit, assets in releases:
+              if actual_id != int(release_id):
                   raise SystemExit(f"{label} draft release ID mismatch")
-              if release.get("draft") is not True or release.get("immutable") is True:
+              if draft is not True or immutable is True:
                   raise SystemExit(f"{label} release is not the mutable draft")
-              if release.get("tag_name") != tag or release.get("target_commitish") != commit:
+              if actual_tag != tag or actual_commit != commit:
                   raise SystemExit(f"{label} draft source identity mismatch")
-              assets = release.get("assets", [])
               if {asset.get("name") for asset in assets} != set(names):
                   raise SystemExit(f"{label} draft asset set mismatch")
               for asset in assets:

--- a/scripts/test-malibu-independent-release.sh
+++ b/scripts/test-malibu-independent-release.sh
@@ -42,6 +42,7 @@ required = (
     'identifier \\"tech.malibu.app\\"',
     'identifier \\"live.streamvc.macprovider.cli\\"',
     'git merge-base --is-ancestor "$SOURCE_COMMIT" refs/remotes/origin/main',
+    'final-draft-cli.json',
     'immutable-release-by-id.json',
     'immutable-release-by-tag.json',
     'release.get("immutable") is not True',
@@ -81,6 +82,12 @@ if 'test "$(git rev-parse refs/remotes/origin/main)" = "$SOURCE_COMMIT"' in publ
     raise SystemExit("publication must accept a tagged candidate still reachable from an advanced main")
 if publish.count('cmp -s "$candidate/$asset"') != 2:
     raise SystemExit("draft and public sidecar bytes must match the accepted candidate")
+make_public = publish.split("- name: Publish only the revalidated draft", 1)[1]
+patch_position = make_public.find("gh api --method PATCH")
+if patch_position < 0:
+    raise SystemExit("verified Malibu draft must be made public by numeric-ID PATCH")
+if 'releases/tags/$tag' in make_public[:patch_position]:
+    raise SystemExit("REST tag lookup cannot discover the Malibu draft release")
 if "actions/upload-artifact@v" in text or "actions/download-artifact@v" in text:
     raise SystemExit("artifact actions must remain commit-pinned")
 


### PR DESCRIPTION
## Summary

- replace the draft-invisible REST tag lookup with `gh release view`
- retain the authoritative numeric release API lookup and exact asset digest checks
- add a regression guard forbidding REST tag lookup before the numeric-ID publish transition

## Root cause

GitHub returns HTTP 404 from `releases/tags/{tag}` while a release is still a draft. The protected Malibu publish run therefore stopped after creating and verifying draft release 355304207, before `draft=false`.

## Release impact

This is a workflow-only recovery for #611. It does not change Malibu candidate bytes, source commit `a0b63e202824bef85b26ff6a0ee356d26bf3f1d9`, macprovider-cli 1.8.40, or the physical acceptance evidence. The protected job still fails closed on release ID, draft state, tag, source commit, exact asset set, and all candidate digests before publishing.

## Validation

- `git diff --check`
- `bash scripts/test-malibu-independent-release.sh`
- `bash scripts/test-release-security-posture.sh`
- `shellcheck scripts/test-malibu-independent-release.sh`
- live draft CLI/API identity and digest parity
- three Codex audit lanes: 0 CRITICAL / HIGH / MEDIUM findings

Closes no issue by itself; publication and public-download acceptance remain required for #611.