### PR TITLE
Recover referral onboarding on the CLI-owned lifecycle

### DIFF
--- a/.github/workflows/malibu-release.yml
+++ b/.github/workflows/malibu-release.yml
@@ -271,6 +271,30 @@ jobs:
             -exec cp -R {} "$app/Contents/MacOS"/ \;
           cp "$payload_dir/compatibility-set.json" \
             "$app/Contents/Resources/compatibility-set.json"
+          # The app must execute the exact installer authenticated by the
+          # signed compatibility set, never the source-tree post-build copy.
+          cp "$payload_dir/compatibility-set-local/install.sh" \
+            "$app/Contents/Resources/install.sh"
+          chmod 755 "$app/Contents/Resources/install.sh"
+          /usr/libexec/PlistBuddy -c \
+            'Set :MalibuBundledReferralBootstrapV1 false' \
+            "$app/Contents/Info.plist"
+          python3 - \
+            "$app/Contents/Resources/compatibility-set.json" \
+            "$app/Contents/Resources/install.sh" <<'PY'
+          import hashlib
+          import json
+          import pathlib
+          import sys
+
+          manifest_path = pathlib.Path(sys.argv[1])
+          installer_path = pathlib.Path(sys.argv[2])
+          envelope = json.loads(manifest_path.read_bytes())
+          expected = envelope["signed"]["components"]["launchd"]["install_contract"]["sha256"]
+          actual = hashlib.sha256(installer_path.read_bytes()).hexdigest()
+          if actual != expected:
+              raise SystemExit("embedded install.sh does not match the signed compatibility set")
+          PY
           embedded_cli="$app/Contents/MacOS/macprovider-cli"
           test "$(shasum -a 256 "$embedded_cli" | awk '{print $1}')" = "$CLI_SHA256"
 
@@ -577,6 +601,22 @@ jobs:
           codesign -dv --verbose=4 "$cli" 2>&1 | grep -qx "TeamIdentifier=$TEAM_ID"
           codesign -dv --verbose=4 "$cli" 2>&1 | grep -q '^Runtime Version='
           test -f "$app/Contents/Resources/compatibility-set.json"
+          test -x "$app/Contents/Resources/install.sh"
+          test "$(/usr/libexec/PlistBuddy -c 'Print :MalibuBundledReferralBootstrapV1' "$plist")" = false
+          python3 - \
+            "$app/Contents/Resources/compatibility-set.json" \
+            "$app/Contents/Resources/install.sh" <<'PY'
+          import hashlib
+          import json
+          import pathlib
+          import sys
+
+          envelope = json.loads(pathlib.Path(sys.argv[1]).read_bytes())
+          expected = envelope["signed"]["components"]["launchd"]["install_contract"]["sha256"]
+          actual = hashlib.sha256(pathlib.Path(sys.argv[2]).read_bytes()).hexdigest()
+          if actual != expected:
+              raise SystemExit("release artifact installer/manifest mismatch")
+          PY
           cleanup_mount
           trap - EXIT
 

--- a/phase3-binary/Sources/macprovider-cli/BootstrapAuthCommand.swift
+++ b/phase3-binary/Sources/macprovider-cli/BootstrapAuthCommand.swift
@@ -17,7 +17,19 @@ struct BootstrapAuthCommand: AsyncParsableCommand {
     @Option(help: "Maximum seconds to wait for credential persistence.")
     var timeoutSeconds: Int = 30
 
+    @Option(help: "Owner-only referral-code file used only for first credential bootstrap.")
+    var referralCodeFile: String?
+
     func run() async throws {
+        do {
+            try await runBootstrap()
+        } catch let failure as ReferralBootstrapFailure {
+            Self.emitReferralFailure(failure)
+            throw ExitCode(failure.exitCode)
+        }
+    }
+
+    private func runBootstrap() async throws {
         guard timeoutSeconds > 0 && timeoutSeconds <= 120 else {
             throw ValidationError("--timeout-seconds must be in 1...120")
         }
@@ -27,15 +39,39 @@ struct BootstrapAuthCommand: AsyncParsableCommand {
             throw ValidationError("provider_id is required before credential bootstrap")
         }
         let providerCredentialStore = KeychainProviderCredentialStore()
+        let referralInput = try referralCodeFile.map { try ReferralCodeFile.read(path: $0) }
+        let receiptKeyStore = KeychainReceiptKeyStore()
         if let configToken = resolved.providerToken?.trimmingCharacters(in: .whitespacesAndNewlines),
            !configToken.isEmpty {
             try providerCredentialStore.importIfAbsentOrMatches(
                 providerID: providerID,
                 token: configToken
             )
+            if let referralInput {
+                try Self.reconcilePersistedReferral(
+                    providerID: providerID,
+                    receiptPublicKey: try Self.persistedBootstrapReceiptPublicKey(
+                        providerID: providerID,
+                        store: receiptKeyStore
+                    ),
+                    input: referralInput,
+                    journal: ReferralBootstrapJournal(url: ReferralBootstrapJournal.defaultURL())
+                )
+            }
             return
         }
         if try Self.storedCredentialPresent(providerID: providerID, store: providerCredentialStore) {
+            if let referralInput {
+                try Self.reconcilePersistedReferral(
+                    providerID: providerID,
+                    receiptPublicKey: try Self.persistedBootstrapReceiptPublicKey(
+                        providerID: providerID,
+                        store: receiptKeyStore
+                    ),
+                    input: referralInput,
+                    journal: ReferralBootstrapJournal(url: ReferralBootstrapJournal.defaultURL())
+                )
+            }
             return
         }
         guard Self.isCredentialBootstrapPrincipal(providerID) else {
@@ -61,13 +97,25 @@ struct BootstrapAuthCommand: AsyncParsableCommand {
         // challenge under this exact same Keychain key and can replace only
         // its own unused bootstrap token, including after its initial TTL
         // while the coordinator's recovery-retention window remains open.
-        let receiptKeyStore = KeychainReceiptKeyStore()
         let currentReceiptKey = try receiptKeyStore.loadOrGenerate(providerId: providerID)
         let receiptKey = try receiptKeyStore.loadOrStoreBootstrapIdentity(
             providerId: providerID,
             candidate: currentReceiptKey
         )
         let receiptPublicKey = Data(receiptKey.publicKey.rawRepresentation).base64EncodedString()
+        let referralJournal = referralInput.map { _ in
+            ReferralBootstrapJournal(url: ReferralBootstrapJournal.defaultURL())
+        }
+        let referralAttempt: ReferralBootstrapAttempt?
+        if let referralInput, let referralJournal {
+            referralAttempt = try referralJournal.prepare(
+                providerID: providerID,
+                receiptPublicKey: receiptPublicKey,
+                input: referralInput
+            )
+        } else {
+            referralAttempt = nil
+        }
         guard let client = CoordinatorClient(
             config: resolved,
             modelRuntime: runtime,
@@ -75,6 +123,7 @@ struct BootstrapAuthCommand: AsyncParsableCommand {
             providerReceiptPublicKey: receiptPublicKey,
             credentialBootstrap: true,
             bootstrapReceiptSigningKey: receiptKey,
+            bootstrapReferralCode: referralInput?.code,
             providerCredentialStore: providerCredentialStore
         ) else {
             throw ValidationError("credential bootstrap requires a secure wss coordinator_url")
@@ -89,7 +138,25 @@ struct BootstrapAuthCommand: AsyncParsableCommand {
                     store: providerCredentialStore
                 ) {
                     await client.stop()
+                    if let referralInput, let referralJournal {
+                        try Self.reconcilePersistedReferral(
+                            providerID: providerID,
+                            receiptPublicKey: receiptPublicKey,
+                            input: referralInput,
+                            journal: referralJournal
+                        )
+                    }
                     return
+                }
+                if let failure = await client.credentialBootstrapTerminalReferralFailure() {
+                    await client.stop()
+                    if let referralJournal, let referralAttempt {
+                        try referralJournal.markTerminal(
+                            attemptID: referralAttempt.attemptID,
+                            failure: failure
+                        )
+                    }
+                    throw failure
                 }
                 try await Task.sleep(nanoseconds: 100_000_000)
             }
@@ -98,6 +165,9 @@ struct BootstrapAuthCommand: AsyncParsableCommand {
             throw error
         }
         await client.stop()
+        if referralInput != nil {
+            throw ReferralBootstrapFailure(kind: .unavailable)
+        }
         throw ValidationError("coordinator did not persist a provider token before the bootstrap timeout")
     }
 
@@ -115,6 +185,34 @@ struct BootstrapAuthCommand: AsyncParsableCommand {
         hasToken(try store.load(providerID: providerID))
     }
 
+    static func reconcilePersistedReferral(
+        providerID: String,
+        receiptPublicKey: String,
+        input: ReferralCodeInput,
+        journal: ReferralBootstrapJournal
+    ) throws {
+        guard try journal.reconcilePersistedCredential(
+            providerID: providerID,
+            receiptPublicKey: receiptPublicKey,
+            input: input
+        ) != nil else {
+            // A credential without the exact pending provider+code binding is
+            // an incumbent identity, not proof that this referral was redeemed.
+            throw ReferralBootstrapFailure(kind: .conflict)
+        }
+        try ReferralCodeFile.removeIfUnchanged(input)
+    }
+
+    private static func persistedBootstrapReceiptPublicKey(
+        providerID: String,
+        store: KeychainReceiptKeyStore
+    ) throws -> String {
+        guard let receiptKey = try store.loadBootstrapIdentity(providerId: providerID) else {
+            throw ReferralBootstrapFailure(kind: .conflict)
+        }
+        return Data(receiptKey.publicKey.rawRepresentation).base64EncodedString()
+    }
+
     static func isCredentialBootstrapPrincipal(_ providerID: String) -> Bool {
         let prefix = "mp-"
         guard providerID.hasPrefix(prefix), providerID.utf8.count == prefix.utf8.count + 32 else {
@@ -127,5 +225,11 @@ struct BootstrapAuthCommand: AsyncParsableCommand {
 
     private static func hasToken(_ value: String?) -> Bool {
         value?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == false
+    }
+
+    private static func emitReferralFailure(_ failure: ReferralBootstrapFailure) {
+        FileHandle.standardError.write(Data(
+            "referral_bootstrap_error=\(failure.kind.rawValue)\n".utf8
+        ))
     }
 }

--- a/phase3-binary/Sources/macprovider-cli/CoordinatorClient.swift
+++ b/phase3-binary/Sources/macprovider-cli/CoordinatorClient.swift
@@ -254,6 +254,8 @@ actor CoordinatorClient {
     private let streamInterval: Int
     private let credentialBootstrap: Bool
     private let bootstrapReceiptSigningKey: Curve25519.Signing.PrivateKey?
+    private let bootstrapReferralCode: String?
+    private var terminalBootstrapReferralFailure: ReferralBootstrapFailure?
     private let receiptIdentitySigningKeys: [Curve25519.Signing.PrivateKey]
     private let persistReceiptIdentitySigningKey: (@Sendable (Curve25519.Signing.PrivateKey) throws -> Void)?
 
@@ -318,6 +320,7 @@ actor CoordinatorClient {
         autoupdateMarkerStore: AutoUpdateMarkerStore = AutoUpdateMarkerStore(),
         credentialBootstrap: Bool = false,
         bootstrapReceiptSigningKey: Curve25519.Signing.PrivateKey? = nil,
+        bootstrapReferralCode: String? = nil,
         receiptIdentitySigningKey: Curve25519.Signing.PrivateKey? = nil,
         receiptIdentitySigningKeyCandidates: [Curve25519.Signing.PrivateKey] = [],
         persistReceiptIdentitySigningKey: (@Sendable (Curve25519.Signing.PrivateKey) throws -> Void)? = nil,
@@ -436,6 +439,7 @@ actor CoordinatorClient {
             }
         }
         self.bootstrapReceiptSigningKey = bootstrapReceiptSigningKey
+        self.bootstrapReferralCode = credentialBootstrap ? bootstrapReferralCode : nil
         self.receiptIdentitySigningKeys = receiptIdentitySigningKey.map { [$0] }
             ?? receiptIdentitySigningKeyCandidates
         self.persistReceiptIdentitySigningKey = persistReceiptIdentitySigningKey
@@ -633,6 +637,11 @@ actor CoordinatorClient {
                 consecutiveAuthProtocolFailures = 0
             } catch {
                 await cleanupConnection()
+                if credentialBootstrap,
+                   let terminalFailure = Self.terminalBootstrapReferralFailure(for: error) {
+                    terminalBootstrapReferralFailure = terminalFailure
+                    return
+                }
                 let classification = Self.lifecycleClassification(for: error)
                 recordConnectionFailureLifecycle(
                     state: classification.state,
@@ -697,6 +706,20 @@ actor CoordinatorClient {
                 lowered.contains("auth_challenge") ||
                 lowered.contains("unrecognized auth message")
         }
+    }
+
+    private static func terminalBootstrapReferralFailure(
+        for error: Error
+    ) -> ReferralBootstrapFailure? {
+        guard let authError = error as? CoordinatorAuthError,
+              case .rejected(let code, _) = authError else {
+            return nil
+        }
+        return ReferralBootstrapFailure.coordinatorCode(code)
+    }
+
+    func credentialBootstrapTerminalReferralFailure() -> ReferralBootstrapFailure? {
+        terminalBootstrapReferralFailure
     }
 
     struct ConnectionLifecycleClassification: Equatable, Sendable {
@@ -1383,7 +1406,15 @@ actor CoordinatorClient {
         case 4005 where reason == "invalid_token" ||
             reason == "bootstrap_identity_mismatch" ||
             reason == "bootstrap_token_used" ||
-            reason == "bootstrap_token_expired":
+            reason == "bootstrap_token_expired" ||
+            reason == "referral_required" ||
+            reason == "referral_invalid" ||
+            reason == "referral_expired" ||
+            reason == "referral_revoked" ||
+            reason == "referral_exhausted" ||
+            reason == "referral_conflict":
+            return .rejected(code: reason, message: reason)
+        case 4008 where reason == "credential_bootstrap_rate_limited":
             return .rejected(code: reason, message: reason)
         case 4000 where reason == "unrecognized auth message":
             return .invalidMessage(reason)
@@ -2003,6 +2034,9 @@ actor CoordinatorClient {
                 throw CoordinatorAuthError.invalidMessage("credential bootstrap receipt identity unavailable")
             }
             proof["credential_bootstrap"] = true
+            if let bootstrapReferralCode {
+                proof["referral_code"] = bootstrapReferralCode
+            }
             let transcriptSHA256 = try Self.initialAuthTranscriptHashBase64(initialMessage)
             let payload = try Self.credentialBootstrapIdentityPayload(
                 challenge: challenge,
@@ -3957,6 +3991,9 @@ actor CoordinatorClient {
         }
         if credentialBootstrap {
             message["credential_bootstrap"] = true
+            if let bootstrapReferralCode {
+                message["referral_code"] = bootstrapReferralCode
+            }
         }
         return message
     }

--- a/phase3-binary/Sources/macprovider-cli/HTTPServer.swift
+++ b/phase3-binary/Sources/macprovider-cli/HTTPServer.swift
@@ -228,6 +228,7 @@ final class RouterHandler: ChannelInboundHandler, @unchecked Sendable {
         "service_instance_v1",
         "status_observation_v1",
         "provider_safety_telemetry_v1",
+        "referral_bootstrap_v1",
         "provider_safety_telemetry_v2",
     ]
     static let serviceInstanceID = UUID().uuidString.lowercased()

--- a/phase3-binary/Sources/macprovider-cli/ReferralBootstrap.swift
+++ b/phase3-binary/Sources/macprovider-cli/ReferralBootstrap.swift
@@ -1,0 +1,484 @@
+import CryptoKit
+import Darwin
+import Foundation
+
+struct ReferralBootstrapFailure: Error, Equatable, Sendable {
+    enum Kind: String, Codable, Sendable {
+        case required = "referral_required"
+        case invalid = "referral_invalid"
+        case expired = "referral_expired"
+        case revoked = "referral_revoked"
+        case exhausted = "referral_exhausted"
+        case conflict = "referral_conflict"
+        case rateLimited = "referral_rate_limited"
+        case unavailable = "referral_unavailable"
+    }
+
+    let kind: Kind
+
+    var exitCode: Int32 {
+        switch kind {
+        case .required: 20
+        case .invalid: 21
+        case .expired: 22
+        case .revoked: 23
+        case .exhausted: 24
+        case .conflict: 25
+        case .rateLimited: 26
+        case .unavailable: 27
+        }
+    }
+
+    static func coordinatorCode(_ code: String) -> ReferralBootstrapFailure? {
+        switch code.lowercased() {
+        case "referral_required": ReferralBootstrapFailure(kind: .required)
+        case "referral_invalid": ReferralBootstrapFailure(kind: .invalid)
+        case "referral_expired": ReferralBootstrapFailure(kind: .expired)
+        case "referral_revoked": ReferralBootstrapFailure(kind: .revoked)
+        case "referral_exhausted": ReferralBootstrapFailure(kind: .exhausted)
+        case "referral_conflict": ReferralBootstrapFailure(kind: .conflict)
+        case "credential_bootstrap_rate_limited": ReferralBootstrapFailure(kind: .rateLimited)
+        default: nil
+        }
+    }
+}
+
+struct ReferralCodeInput: Equatable, Sendable {
+    let code: String
+    let digestSHA256: String
+    let path: String
+    let device: UInt64
+    let inode: UInt64
+}
+
+private struct ReferralFileIdentity: Equatable {
+    let device: dev_t
+    let inode: ino_t
+    let size: off_t
+    let modifiedSeconds: Int
+    let modifiedNanoseconds: Int
+    let changedSeconds: Int
+    let changedNanoseconds: Int
+
+    init(_ value: stat) {
+        device = value.st_dev
+        inode = value.st_ino
+        size = value.st_size
+        modifiedSeconds = Int(value.st_mtimespec.tv_sec)
+        modifiedNanoseconds = Int(value.st_mtimespec.tv_nsec)
+        changedSeconds = Int(value.st_ctimespec.tv_sec)
+        changedNanoseconds = Int(value.st_ctimespec.tv_nsec)
+    }
+}
+
+enum ReferralCodeFile {
+    static let maximumBytes = 256
+
+    static func read(path: String) throws -> ReferralCodeInput {
+        var pathStat = stat()
+        guard lstat(path, &pathStat) == 0 else {
+            throw ReferralBootstrapFailure(kind: errno == ENOENT ? .required : .unavailable)
+        }
+        try validate(pathStat)
+
+        let descriptor = open(path, O_RDONLY | O_CLOEXEC | O_NOFOLLOW)
+        guard descriptor >= 0 else {
+            throw ReferralBootstrapFailure(kind: errno == ELOOP ? .invalid : .unavailable)
+        }
+        defer { _ = close(descriptor) }
+
+        var openStat = stat()
+        guard fstat(descriptor, &openStat) == 0 else {
+            throw ReferralBootstrapFailure(kind: .unavailable)
+        }
+        try validate(openStat)
+        try validateNoExtendedACL(descriptor)
+        guard pathStat.st_dev == openStat.st_dev, pathStat.st_ino == openStat.st_ino else {
+            throw ReferralBootstrapFailure(kind: .invalid)
+        }
+        let initialIdentity = ReferralFileIdentity(openStat)
+
+        var bytes = [UInt8](repeating: 0, count: maximumBytes + 1)
+        var count = 0
+        while count < bytes.count {
+            let remaining = bytes.count - count
+            let received = bytes.withUnsafeMutableBytes { buffer -> Int in
+                guard let base = buffer.baseAddress else { return 0 }
+                return Darwin.read(descriptor, base.advanced(by: count), remaining)
+            }
+            if received < 0 {
+                if errno == EINTR { continue }
+                throw ReferralBootstrapFailure(kind: .unavailable)
+            }
+            if received == 0 { break }
+            count += received
+        }
+        guard count > 0, count <= maximumBytes else {
+            throw ReferralBootstrapFailure(kind: .invalid)
+        }
+        let raw = Data(bytes.prefix(count))
+        guard var code = String(data: raw, encoding: .utf8) else {
+            throw ReferralBootstrapFailure(kind: .invalid)
+        }
+        code = code.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !code.isEmpty,
+              code.utf8.count <= maximumBytes,
+              code.unicodeScalars.allSatisfy({ $0.value >= 0x21 && $0.value <= 0x7e }) else {
+            throw ReferralBootstrapFailure(kind: .invalid)
+        }
+        var finalStat = stat()
+        guard fstat(descriptor, &finalStat) == 0 else {
+            throw ReferralBootstrapFailure(kind: .unavailable)
+        }
+        try validate(finalStat)
+        try validateNoExtendedACL(descriptor)
+        guard ReferralFileIdentity(finalStat) == initialIdentity else {
+            throw ReferralBootstrapFailure(kind: .invalid)
+        }
+        return ReferralCodeInput(
+            code: code,
+            digestSHA256: sha256Hex(Data(code.utf8)),
+            path: path,
+            device: UInt64(openStat.st_dev),
+            inode: UInt64(openStat.st_ino)
+        )
+    }
+
+    static func removeIfUnchanged(_ input: ReferralCodeInput) throws {
+        var current = stat()
+        guard lstat(input.path, &current) == 0 else {
+            if errno == ENOENT { return }
+            throw ReferralBootstrapFailure(kind: .unavailable)
+        }
+        try validate(current)
+        guard UInt64(current.st_dev) == input.device, UInt64(current.st_ino) == input.inode else {
+            throw ReferralBootstrapFailure(kind: .unavailable)
+        }
+        guard unlink(input.path) == 0 else {
+            throw ReferralBootstrapFailure(kind: .unavailable)
+        }
+    }
+
+    private static func validate(_ value: stat) throws {
+        guard (value.st_mode & S_IFMT) == S_IFREG,
+              value.st_uid == geteuid(),
+              (value.st_mode & 0o777) == 0o600,
+              value.st_nlink == 1,
+              value.st_size >= 0,
+              value.st_size <= maximumBytes else {
+            throw ReferralBootstrapFailure(kind: .invalid)
+        }
+    }
+
+    fileprivate static func validateNoExtendedACL(_ descriptor: Int32) throws {
+        errno = 0
+        guard let acl = acl_get_fd_np(descriptor, ACL_TYPE_EXTENDED) else {
+            guard errno == 0 || errno == ENOENT else {
+                throw ReferralBootstrapFailure(kind: .unavailable)
+            }
+            return
+        }
+        defer { _ = acl_free(UnsafeMutableRawPointer(acl)) }
+        var entry: acl_entry_t?
+        let result = acl_get_entry(acl, ACL_FIRST_ENTRY.rawValue, &entry)
+        guard result == 0 else {
+            throw ReferralBootstrapFailure(kind: .unavailable)
+        }
+        guard entry == nil else { throw ReferralBootstrapFailure(kind: .invalid) }
+    }
+}
+
+struct ReferralBootstrapAttempt: Codable, Equatable, Sendable {
+    enum State: String, Codable, Sendable {
+        case pending
+        case terminal
+        case committed
+    }
+
+    let version: Int
+    let attemptID: String
+    let providerID: String
+    let receiptPublicKeySHA256: String
+    let referralCodeSHA256: String
+    let createdAt: String
+    var updatedAt: String
+    var state: State
+    var terminalCode: String?
+}
+
+enum ReferralBootstrapReconciliation: Equatable, Sendable {
+    case committedPendingAttempt
+    case alreadyCommitted
+}
+
+struct ReferralBootstrapJournal: Sendable {
+    let url: URL
+
+    static func defaultURL(
+        home: URL = FileManager.default.homeDirectoryForCurrentUser
+    ) -> URL {
+        home.appendingPathComponent(".config/macprovider/onboarding", isDirectory: true)
+            .appendingPathComponent("referral-attempt-v1.json", isDirectory: false)
+    }
+
+    func prepare(
+        providerID: String,
+        receiptPublicKey: String,
+        input: ReferralCodeInput,
+        now: Date = Date()
+    ) throws -> ReferralBootstrapAttempt {
+        try withLock {
+            let receiptDigest = sha256Hex(Data(receiptPublicKey.utf8))
+            let attemptID = sha256Hex(Data(
+                "referral-bootstrap/v1\0\(providerID)\0\(receiptDigest)\0\(input.digestSHA256)".utf8
+            ))
+            if var existing = try loadUnlocked() {
+                let sameBinding = existing.providerID == providerID
+                    && existing.receiptPublicKeySHA256 == receiptDigest
+                    && existing.referralCodeSHA256 == input.digestSHA256
+                if sameBinding {
+                    if existing.state == .committed {
+                        throw ReferralBootstrapFailure(kind: .conflict)
+                    }
+                    existing.state = .pending
+                    existing.terminalCode = nil
+                    existing.updatedAt = Self.timestamp(now)
+                    try persistUnlocked(existing)
+                    return existing
+                }
+                guard existing.state == .terminal else {
+                    throw ReferralBootstrapFailure(kind: .conflict)
+                }
+            }
+            let timestamp = Self.timestamp(now)
+            let attempt = ReferralBootstrapAttempt(
+                version: 1,
+                attemptID: attemptID,
+                providerID: providerID,
+                receiptPublicKeySHA256: receiptDigest,
+                referralCodeSHA256: input.digestSHA256,
+                createdAt: timestamp,
+                updatedAt: timestamp,
+                state: .pending,
+                terminalCode: nil
+            )
+            try persistUnlocked(attempt)
+            return attempt
+        }
+    }
+
+    func markTerminal(attemptID: String, failure: ReferralBootstrapFailure, now: Date = Date()) throws {
+        try update(attemptID: attemptID, state: .terminal, terminalCode: failure.kind.rawValue, now: now)
+    }
+
+    func markCommitted(attemptID: String, now: Date = Date()) throws {
+        try update(attemptID: attemptID, state: .committed, terminalCode: nil, now: now)
+    }
+
+    func reconcilePersistedCredential(
+        providerID: String,
+        receiptPublicKey: String,
+        input: ReferralCodeInput,
+        now: Date = Date()
+    ) throws -> ReferralBootstrapReconciliation? {
+        try withLock {
+            let receiptDigest = sha256Hex(Data(receiptPublicKey.utf8))
+            guard var attempt = try loadUnlocked(),
+                  attempt.providerID == providerID,
+                  attempt.receiptPublicKeySHA256 == receiptDigest,
+                  attempt.referralCodeSHA256 == input.digestSHA256,
+                  attempt.state == .pending || attempt.state == .committed else {
+                return nil
+            }
+            if attempt.state == .committed {
+                return .alreadyCommitted
+            }
+            attempt.state = .committed
+            attempt.terminalCode = nil
+            attempt.updatedAt = Self.timestamp(now)
+            try persistUnlocked(attempt)
+            return .committedPendingAttempt
+        }
+    }
+
+    func load() throws -> ReferralBootstrapAttempt? {
+        try withLock { try loadUnlocked() }
+    }
+
+    private func update(
+        attemptID: String,
+        state: ReferralBootstrapAttempt.State,
+        terminalCode: String?,
+        now: Date
+    ) throws {
+        try withLock {
+            guard var attempt = try loadUnlocked(), attempt.attemptID == attemptID else {
+                throw ReferralBootstrapFailure(kind: .conflict)
+            }
+            attempt.state = state
+            attempt.terminalCode = terminalCode
+            attempt.updatedAt = Self.timestamp(now)
+            try persistUnlocked(attempt)
+        }
+    }
+
+    private func withLock<T>(_ body: () throws -> T) throws -> T {
+        try ensureJournalDirectory()
+        let lockPath = url.path + ".lock"
+        let descriptor = open(lockPath, O_RDWR | O_CREAT | O_CLOEXEC | O_NOFOLLOW, 0o600)
+        guard descriptor >= 0 else {
+            throw ReferralBootstrapFailure(kind: .unavailable)
+        }
+        defer { _ = close(descriptor) }
+        var lockStat = stat()
+        guard fstat(descriptor, &lockStat) == 0,
+              (lockStat.st_mode & S_IFMT) == S_IFREG,
+              lockStat.st_uid == geteuid(),
+              (lockStat.st_mode & 0o777) == 0o600,
+              lockStat.st_nlink == 1,
+              flock(descriptor, LOCK_EX) == 0 else {
+            throw ReferralBootstrapFailure(kind: .unavailable)
+        }
+        try ReferralCodeFile.validateNoExtendedACL(descriptor)
+        defer { _ = flock(descriptor, LOCK_UN) }
+        return try body()
+    }
+
+    private func ensureJournalDirectory() throws {
+        let path = url.deletingLastPathComponent().path
+        if mkdir(path, 0o700) != 0, errno != EEXIST {
+            throw ReferralBootstrapFailure(kind: .unavailable)
+        }
+        let descriptor = open(path, O_RDONLY | O_DIRECTORY | O_CLOEXEC | O_NOFOLLOW)
+        guard descriptor >= 0 else {
+            throw ReferralBootstrapFailure(kind: .unavailable)
+        }
+        defer { _ = close(descriptor) }
+        var info = stat()
+        guard fstat(descriptor, &info) == 0,
+              (info.st_mode & S_IFMT) == S_IFDIR,
+              info.st_uid == geteuid(),
+              (info.st_mode & 0o077) == 0 else {
+            throw ReferralBootstrapFailure(kind: .unavailable)
+        }
+        try ReferralCodeFile.validateNoExtendedACL(descriptor)
+    }
+
+    private func loadUnlocked() throws -> ReferralBootstrapAttempt? {
+        var value = stat()
+        guard lstat(url.path, &value) == 0 else {
+            if errno == ENOENT { return nil }
+            throw ReferralBootstrapFailure(kind: .unavailable)
+        }
+        guard (value.st_mode & S_IFMT) == S_IFREG,
+              value.st_uid == geteuid(),
+              (value.st_mode & 0o777) == 0o600,
+              value.st_nlink == 1,
+              value.st_size >= 0,
+              value.st_size <= 16_384 else {
+            throw ReferralBootstrapFailure(kind: .unavailable)
+        }
+        let descriptor = open(url.path, O_RDONLY | O_CLOEXEC | O_NOFOLLOW)
+        guard descriptor >= 0 else {
+            throw ReferralBootstrapFailure(kind: .unavailable)
+        }
+        defer { _ = close(descriptor) }
+        var openValue = stat()
+        guard fstat(descriptor, &openValue) == 0,
+              (openValue.st_mode & S_IFMT) == S_IFREG,
+              openValue.st_uid == geteuid(),
+              (openValue.st_mode & 0o777) == 0o600,
+              openValue.st_size >= 0,
+              openValue.st_size <= 16_384,
+              ReferralFileIdentity(openValue) == ReferralFileIdentity(value) else {
+            throw ReferralBootstrapFailure(kind: .unavailable)
+        }
+        try ReferralCodeFile.validateNoExtendedACL(descriptor)
+        var data = Data()
+        var buffer = [UInt8](repeating: 0, count: 4096)
+        while data.count <= 16_384 {
+            let received = Darwin.read(descriptor, &buffer, buffer.count)
+            if received < 0 {
+                if errno == EINTR { continue }
+                throw ReferralBootstrapFailure(kind: .unavailable)
+            }
+            if received == 0 { break }
+            data.append(contentsOf: buffer.prefix(received))
+        }
+        guard !data.isEmpty, data.count <= 16_384,
+              let attempt = try? JSONDecoder().decode(ReferralBootstrapAttempt.self, from: data),
+              attempt.version == 1 else {
+            throw ReferralBootstrapFailure(kind: .unavailable)
+        }
+        return attempt
+    }
+
+    private func persistUnlocked(_ attempt: ReferralBootstrapAttempt) throws {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys]
+        guard let data = try? encoder.encode(attempt), data.count <= 16_384 else {
+            throw ReferralBootstrapFailure(kind: .unavailable)
+        }
+        let temporaryPath = url.path + ".tmp.\(getpid()).\(UUID().uuidString.lowercased())"
+        let descriptor = open(temporaryPath, O_WRONLY | O_CREAT | O_EXCL | O_CLOEXEC | O_NOFOLLOW, 0o600)
+        guard descriptor >= 0 else {
+            throw ReferralBootstrapFailure(kind: .unavailable)
+        }
+        var shouldRemove = true
+        defer {
+            _ = close(descriptor)
+            if shouldRemove { _ = unlink(temporaryPath) }
+        }
+        var temporaryInfo = stat()
+        guard fstat(descriptor, &temporaryInfo) == 0,
+              (temporaryInfo.st_mode & S_IFMT) == S_IFREG,
+              temporaryInfo.st_uid == geteuid(),
+              (temporaryInfo.st_mode & 0o777) == 0o600,
+              temporaryInfo.st_nlink == 1 else {
+            throw ReferralBootstrapFailure(kind: .unavailable)
+        }
+        try ReferralCodeFile.validateNoExtendedACL(descriptor)
+        var written = 0
+        try data.withUnsafeBytes { rawBuffer in
+            guard let base = rawBuffer.baseAddress else { return }
+            while written < data.count {
+                let result = Darwin.write(descriptor, base.advanced(by: written), data.count - written)
+                if result < 0 {
+                    if errno == EINTR { continue }
+                    throw ReferralBootstrapFailure(kind: .unavailable)
+                }
+                written += result
+            }
+        }
+        guard fsync(descriptor) == 0, rename(temporaryPath, url.path) == 0 else {
+            throw ReferralBootstrapFailure(kind: .unavailable)
+        }
+        let directoryDescriptor = open(
+            url.deletingLastPathComponent().path,
+            O_RDONLY | O_DIRECTORY | O_CLOEXEC | O_NOFOLLOW
+        )
+        guard directoryDescriptor >= 0 else {
+            throw ReferralBootstrapFailure(kind: .unavailable)
+        }
+        defer { _ = close(directoryDescriptor) }
+        var directoryInfo = stat()
+        guard fstat(directoryDescriptor, &directoryInfo) == 0,
+              (directoryInfo.st_mode & S_IFMT) == S_IFDIR,
+              directoryInfo.st_uid == geteuid(),
+              (directoryInfo.st_mode & 0o077) == 0,
+              fsync(directoryDescriptor) == 0 else {
+            throw ReferralBootstrapFailure(kind: .unavailable)
+        }
+        shouldRemove = false
+    }
+
+    private static func timestamp(_ date: Date) -> String {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        return formatter.string(from: date)
+    }
+}
+
+private func sha256Hex(_ data: Data) -> String {
+    SHA256.hash(data: data).map { String(format: "%02x", $0) }.joined()
+}

--- a/phase3-binary/Sources/macprovider-cli/ReferralBootstrap.swift
+++ b/phase3-binary/Sources/macprovider-cli/ReferralBootstrap.swift
@@ -46,12 +46,12 @@ struct ReferralBootstrapFailure: Error, Equatable, Sendable {
 struct ReferralCodeInput: Equatable, Sendable {
     let code: String
     let digestSHA256: String
+    let sourceFileSHA256: String
     let path: String
-    let device: UInt64
-    let inode: UInt64
+    let fileIdentity: ReferralFileIdentity
 }
 
-private struct ReferralFileIdentity: Equatable {
+struct ReferralFileIdentity: Equatable, Sendable {
     let device: dev_t
     let inode: ino_t
     let size: off_t
@@ -138,20 +138,60 @@ enum ReferralCodeFile {
         return ReferralCodeInput(
             code: code,
             digestSHA256: sha256Hex(Data(code.utf8)),
+            sourceFileSHA256: sha256Hex(raw),
             path: path,
-            device: UInt64(openStat.st_dev),
-            inode: UInt64(openStat.st_ino)
+            fileIdentity: ReferralFileIdentity(openStat)
         )
     }
 
     static func removeIfUnchanged(_ input: ReferralCodeInput) throws {
-        var current = stat()
-        guard lstat(input.path, &current) == 0 else {
+        var pathStat = stat()
+        guard lstat(input.path, &pathStat) == 0 else {
             if errno == ENOENT { return }
             throw ReferralBootstrapFailure(kind: .unavailable)
         }
-        try validate(current)
-        guard UInt64(current.st_dev) == input.device, UInt64(current.st_ino) == input.inode else {
+        try validate(pathStat)
+        guard ReferralFileIdentity(pathStat) == input.fileIdentity else {
+            throw ReferralBootstrapFailure(kind: .unavailable)
+        }
+
+        let descriptor = open(input.path, O_RDONLY | O_CLOEXEC | O_NOFOLLOW)
+        guard descriptor >= 0 else {
+            throw ReferralBootstrapFailure(kind: .unavailable)
+        }
+        defer { _ = close(descriptor) }
+        var openStat = stat()
+        guard fstat(descriptor, &openStat) == 0 else {
+            throw ReferralBootstrapFailure(kind: .unavailable)
+        }
+        try validate(openStat)
+        try validateNoExtendedACL(descriptor)
+        guard ReferralFileIdentity(openStat) == input.fileIdentity else {
+            throw ReferralBootstrapFailure(kind: .unavailable)
+        }
+
+        var data = Data()
+        var buffer = [UInt8](repeating: 0, count: maximumBytes + 1)
+        while data.count <= maximumBytes {
+            let received = Darwin.read(descriptor, &buffer, buffer.count)
+            if received < 0 {
+                if errno == EINTR { continue }
+                throw ReferralBootstrapFailure(kind: .unavailable)
+            }
+            if received == 0 { break }
+            data.append(contentsOf: buffer.prefix(received))
+        }
+        var finalOpenStat = stat()
+        guard !data.isEmpty,
+              data.count <= maximumBytes,
+              sha256Hex(data) == input.sourceFileSHA256,
+              fstat(descriptor, &finalOpenStat) == 0,
+              ReferralFileIdentity(finalOpenStat) == input.fileIdentity else {
+            throw ReferralBootstrapFailure(kind: .unavailable)
+        }
+        var finalPathStat = stat()
+        guard lstat(input.path, &finalPathStat) == 0,
+              ReferralFileIdentity(finalPathStat) == input.fileIdentity else {
             throw ReferralBootstrapFailure(kind: .unavailable)
         }
         guard unlink(input.path) == 0 else {

--- a/phase3-binary/Tests/macprovider-cliTests/BootstrapAuthCommandTests.swift
+++ b/phase3-binary/Tests/macprovider-cliTests/BootstrapAuthCommandTests.swift
@@ -97,6 +97,29 @@ final class BootstrapAuthCommandTests: XCTestCase {
         }
     }
 
+    func testReferralCodeFileDoesNotRetireInPlaceMutation() throws {
+        let directory = try temporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let source = directory.appendingPathComponent("source")
+        try Data("MAL1-S-key-original-tag".utf8).write(to: source)
+        XCTAssertEqual(chmod(source.path, 0o600), 0)
+        let input = try ReferralCodeFile.read(path: source.path)
+
+        let descriptor = open(source.path, O_WRONLY | O_TRUNC | O_CLOEXEC | O_NOFOLLOW)
+        XCTAssertGreaterThanOrEqual(descriptor, 0)
+        let replacement = Data("MAL1-S-key-revised-tag".utf8)
+        XCTAssertEqual(replacement.withUnsafeBytes {
+            Darwin.write(descriptor, $0.baseAddress, $0.count)
+        }, replacement.count)
+        XCTAssertEqual(close(descriptor), 0)
+
+        XCTAssertThrowsError(try ReferralCodeFile.removeIfUnchanged(input)) { error in
+            XCTAssertEqual(error as? ReferralBootstrapFailure, .init(kind: .unavailable))
+        }
+        XCTAssertTrue(FileManager.default.fileExists(atPath: source.path))
+        XCTAssertEqual(try String(contentsOf: source, encoding: .utf8), "MAL1-S-key-revised-tag")
+    }
+
     func testReferralJournalResumesSameBindingAndRejectsPendingCodeChange() throws {
         let directory = try temporaryDirectory()
         defer { try? FileManager.default.removeItem(at: directory) }

--- a/phase3-binary/Tests/macprovider-cliTests/BootstrapAuthCommandTests.swift
+++ b/phase3-binary/Tests/macprovider-cliTests/BootstrapAuthCommandTests.swift
@@ -1,4 +1,5 @@
 import XCTest
+import Darwin
 @testable import macprovider_cli
 
 final class BootstrapAuthCommandTests: XCTestCase {
@@ -35,5 +36,253 @@ final class BootstrapAuthCommandTests: XCTestCase {
             providerID: "mp-0123456789abcdef0123456789abcdef",
             store: store
         ))
+    }
+
+    func testReferralCodeFileRequiresOwnerOnlyRegularBoundedFile() throws {
+        let directory = try temporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let valid = directory.appendingPathComponent("referral-code")
+        try Data("  MAL1-S-key-issuer-tag\n".utf8).write(to: valid)
+        XCTAssertEqual(chmod(valid.path, 0o600), 0)
+
+        let input = try ReferralCodeFile.read(path: valid.path)
+        XCTAssertEqual(input.code, "MAL1-S-key-issuer-tag")
+        XCTAssertEqual(input.digestSHA256.count, 64)
+
+        XCTAssertEqual(chmod(valid.path, 0o644), 0)
+        XCTAssertThrowsError(try ReferralCodeFile.read(path: valid.path)) { error in
+            XCTAssertEqual(error as? ReferralBootstrapFailure, .init(kind: .invalid))
+        }
+    }
+
+    func testReferralCodeFileRejectsSymlinkAndOversizedInput() throws {
+        let directory = try temporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        XCTAssertThrowsError(try ReferralCodeFile.read(
+            path: directory.appendingPathComponent("missing").path
+        )) { error in
+            XCTAssertEqual(error as? ReferralBootstrapFailure, .init(kind: .required))
+        }
+        XCTAssertThrowsError(try ReferralCodeFile.read(path: directory.path)) { error in
+            XCTAssertEqual(error as? ReferralBootstrapFailure, .init(kind: .invalid))
+        }
+        let target = directory.appendingPathComponent("target")
+        try Data("MAL1-S-key-issuer-tag".utf8).write(to: target)
+        XCTAssertEqual(chmod(target.path, 0o600), 0)
+        let link = directory.appendingPathComponent("link")
+        try FileManager.default.createSymbolicLink(at: link, withDestinationURL: target)
+        XCTAssertThrowsError(try ReferralCodeFile.read(path: link.path)) { error in
+            XCTAssertEqual(error as? ReferralBootstrapFailure, .init(kind: .invalid))
+        }
+
+        let oversized = directory.appendingPathComponent("oversized")
+        try Data(repeating: 0x41, count: ReferralCodeFile.maximumBytes + 1).write(to: oversized)
+        XCTAssertEqual(chmod(oversized.path, 0o600), 0)
+        XCTAssertThrowsError(try ReferralCodeFile.read(path: oversized.path)) { error in
+            XCTAssertEqual(error as? ReferralBootstrapFailure, .init(kind: .invalid))
+        }
+    }
+
+    func testReferralCodeFileRejectsHardLinkedInput() throws {
+        let directory = try temporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let source = directory.appendingPathComponent("source")
+        let alias = directory.appendingPathComponent("alias")
+        try Data("MAL1-S-key-issuer-tag".utf8).write(to: source)
+        XCTAssertEqual(chmod(source.path, 0o600), 0)
+        XCTAssertEqual(link(source.path, alias.path), 0)
+
+        XCTAssertThrowsError(try ReferralCodeFile.read(path: source.path)) { error in
+            XCTAssertEqual(error as? ReferralBootstrapFailure, .init(kind: .invalid))
+        }
+    }
+
+    func testReferralJournalResumesSameBindingAndRejectsPendingCodeChange() throws {
+        let directory = try temporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let firstInput = try makeReferralInput(in: directory, name: "first", code: "MAL1-S-key-first-tag")
+        let secondInput = try makeReferralInput(in: directory, name: "second", code: "MAL1-S-key-second-tag")
+        let journal = ReferralBootstrapJournal(url: directory.appendingPathComponent("attempt.json"))
+
+        let first = try journal.prepare(
+            providerID: "mp-0123456789abcdef0123456789abcdef",
+            receiptPublicKey: "receipt-public-key",
+            input: firstInput,
+            now: Date(timeIntervalSince1970: 1)
+        )
+        let resumed = try journal.prepare(
+            providerID: first.providerID,
+            receiptPublicKey: "receipt-public-key",
+            input: firstInput,
+            now: Date(timeIntervalSince1970: 2)
+        )
+        XCTAssertEqual(resumed.attemptID, first.attemptID)
+        XCTAssertEqual(resumed.createdAt, first.createdAt)
+        XCTAssertEqual(resumed.state, .pending)
+        XCTAssertNil(resumed.terminalCode)
+        let persistedJournal = try String(contentsOf: journal.url, encoding: .utf8)
+        XCTAssertFalse(persistedJournal.contains(firstInput.code))
+        XCTAssertThrowsError(try journal.prepare(
+            providerID: first.providerID,
+            receiptPublicKey: "receipt-public-key",
+            input: secondInput
+        )) { error in
+            XCTAssertEqual(error as? ReferralBootstrapFailure, .init(kind: .conflict))
+        }
+    }
+
+    func testReferralJournalTerminalCorrectionAndCommittedCleanup() throws {
+        let directory = try temporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let firstInput = try makeReferralInput(in: directory, name: "first", code: "MAL1-S-key-first-tag")
+        let secondInput = try makeReferralInput(in: directory, name: "second", code: "MAL1-S-key-second-tag")
+        let journal = ReferralBootstrapJournal(url: directory.appendingPathComponent("attempt.json"))
+        let first = try journal.prepare(
+            providerID: "mp-0123456789abcdef0123456789abcdef",
+            receiptPublicKey: "receipt-public-key",
+            input: firstInput
+        )
+        try journal.markTerminal(attemptID: first.attemptID, failure: .init(kind: .invalid))
+        XCTAssertEqual(try journal.load()?.state, .terminal)
+        XCTAssertTrue(FileManager.default.fileExists(atPath: firstInput.path))
+
+        let corrected = try journal.prepare(
+            providerID: first.providerID,
+            receiptPublicKey: "receipt-public-key",
+            input: secondInput
+        )
+        XCTAssertNotEqual(corrected.attemptID, first.attemptID)
+        try journal.markCommitted(attemptID: corrected.attemptID)
+        try ReferralCodeFile.removeIfUnchanged(secondInput)
+        XCTAssertEqual(try journal.load()?.state, .committed)
+        XCTAssertFalse(FileManager.default.fileExists(atPath: secondInput.path))
+        XCTAssertTrue(FileManager.default.fileExists(atPath: firstInput.path))
+
+        let committedReplay = try makeReferralInput(
+            in: directory,
+            name: "committed-replay",
+            code: secondInput.code
+        )
+        try BootstrapAuthCommand.reconcilePersistedReferral(
+            providerID: corrected.providerID,
+            receiptPublicKey: "receipt-public-key",
+            input: committedReplay,
+            journal: journal
+        )
+        XCTAssertEqual(try journal.load()?.state, .committed)
+        XCTAssertFalse(FileManager.default.fileExists(atPath: committedReplay.path))
+    }
+
+    func testRetryAfterCredentialPersistenceCommitsPendingJournalAndRetiresExactSource() throws {
+        let directory = try temporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let input = try makeReferralInput(
+            in: directory,
+            name: "response-loss-referral",
+            code: "MAL1-S-key-response-loss-tag"
+        )
+        let journal = ReferralBootstrapJournal(url: directory.appendingPathComponent("attempt.json"))
+        let attempt = try journal.prepare(
+            providerID: "mp-0123456789abcdef0123456789abcdef",
+            receiptPublicKey: "receipt-public-key",
+            input: input
+        )
+        XCTAssertEqual(attempt.state, .pending)
+
+        // A retry reaches this path only after the CLI-owned Keychain already
+        // contains the coordinator-minted credential from the lost response.
+        try BootstrapAuthCommand.reconcilePersistedReferral(
+            providerID: attempt.providerID,
+            receiptPublicKey: "receipt-public-key",
+            input: input,
+            journal: journal
+        )
+
+        XCTAssertEqual(try journal.load()?.state, .committed)
+        XCTAssertFalse(FileManager.default.fileExists(atPath: input.path))
+    }
+
+    func testPersistedCredentialReconciliationRequiresExactReceiptKeyBinding() throws {
+        let directory = try temporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let input = try makeReferralInput(
+            in: directory,
+            name: "receipt-mismatch-referral",
+            code: "MAL1-S-key-receipt-mismatch-tag"
+        )
+        let journal = ReferralBootstrapJournal(url: directory.appendingPathComponent("attempt.json"))
+        let attempt = try journal.prepare(
+            providerID: "mp-0123456789abcdef0123456789abcdef",
+            receiptPublicKey: "expected-receipt-public-key",
+            input: input
+        )
+
+        XCTAssertThrowsError(try BootstrapAuthCommand.reconcilePersistedReferral(
+            providerID: attempt.providerID,
+            receiptPublicKey: "different-receipt-public-key",
+            input: input,
+            journal: journal
+        )) { error in
+            XCTAssertEqual(error as? ReferralBootstrapFailure, .init(kind: .conflict))
+        }
+        XCTAssertEqual(try journal.load()?.state, .pending)
+        XCTAssertTrue(FileManager.default.fileExists(atPath: input.path))
+    }
+
+    func testExistingCredentialCannotClaimReferralWithoutMatchingPendingAttempt() throws {
+        let directory = try temporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let input = try makeReferralInput(
+            in: directory,
+            name: "unbound-referral",
+            code: "MAL1-S-key-unbound-tag"
+        )
+        let journal = ReferralBootstrapJournal(url: directory.appendingPathComponent("attempt.json"))
+
+        XCTAssertThrowsError(try BootstrapAuthCommand.reconcilePersistedReferral(
+            providerID: "mp-0123456789abcdef0123456789abcdef",
+            receiptPublicKey: "receipt-public-key",
+            input: input,
+            journal: journal
+        )) { error in
+            XCTAssertEqual(error as? ReferralBootstrapFailure, .init(kind: .conflict))
+        }
+        XCTAssertTrue(FileManager.default.fileExists(atPath: input.path))
+    }
+
+    func testReferralFailureExitCodeContract() {
+        let expected: [(ReferralBootstrapFailure.Kind, Int32)] = [
+            (.required, 20), (.invalid, 21), (.expired, 22), (.revoked, 23),
+            (.exhausted, 24), (.conflict, 25), (.rateLimited, 26), (.unavailable, 27),
+        ]
+        for (kind, code) in expected {
+            XCTAssertEqual(ReferralBootstrapFailure(kind: kind).exitCode, code)
+        }
+        XCTAssertEqual(ReferralBootstrapFailure.coordinatorCode("referral_required")?.kind, .required)
+        XCTAssertEqual(ReferralBootstrapFailure.coordinatorCode("referral_invalid")?.kind, .invalid)
+        XCTAssertEqual(ReferralBootstrapFailure.coordinatorCode("referral_expired")?.kind, .expired)
+        XCTAssertEqual(ReferralBootstrapFailure.coordinatorCode("referral_revoked")?.kind, .revoked)
+        XCTAssertEqual(ReferralBootstrapFailure.coordinatorCode("referral_exhausted")?.kind, .exhausted)
+        XCTAssertEqual(ReferralBootstrapFailure.coordinatorCode("referral_conflict")?.kind, .conflict)
+        XCTAssertEqual(
+            ReferralBootstrapFailure.coordinatorCode("credential_bootstrap_rate_limited")?.kind,
+            .rateLimited
+        )
+        XCTAssertNil(ReferralBootstrapFailure.coordinatorCode("invalid_token"))
+    }
+
+    private func temporaryDirectory() throws -> URL {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("referral-bootstrap-tests-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: url, withIntermediateDirectories: false)
+        XCTAssertEqual(chmod(url.path, 0o700), 0)
+        return url
+    }
+
+    private func makeReferralInput(in directory: URL, name: String, code: String) throws -> ReferralCodeInput {
+        let url = directory.appendingPathComponent(name)
+        try Data(code.utf8).write(to: url)
+        XCTAssertEqual(chmod(url.path, 0o600), 0)
+        return try ReferralCodeFile.read(path: url.path)
     }
 }

--- a/phase3-binary/Tests/macprovider-cliTests/CoordinatorClientTests.swift
+++ b/phase3-binary/Tests/macprovider-cliTests/CoordinatorClientTests.swift
@@ -379,6 +379,50 @@ final class CoordinatorClientTests: XCTestCase {
         }
     }
 
+    func testTier2ReferralCloseIsTypedWithoutEchoingRawCode() async throws {
+        var config = AppConfig.defaults(configPath: "/tmp/macprovider-test.yaml")
+        config.coordinatorURL = "wss://127.0.0.1:8444/ws/provider"
+        config.providerID = "mp-0123456789abcdef0123456789abcdef"
+        config.model = "model-a"
+        let receiptKey = Curve25519.Signing.PrivateKey()
+        let receiptPublicKey = Data(receiptKey.publicKey.rawRepresentation).base64EncodedString()
+        let status = ProviderStatus(
+            modelID: "model-a",
+            modelLoaded: false,
+            capacity: ProviderCapacity(maxContextOverride: 20_000, maxConcurrencyOverride: 1)
+        )
+        let socket = FakeProviderWebSocketTask(
+            receiveResults: [.failure(CoordinatorClientTestError.closedByCoordinator)],
+            closeCodeRawValue: 4005,
+            closeReasonText: "referral_expired"
+        )
+        let factory = FakeProviderWebSocketFactory(sockets: [socket])
+        let runtime = try await ModelRuntime(modelID: nil)
+        let client = try XCTUnwrap(CoordinatorClient(
+            config: config,
+            modelRuntime: runtime,
+            providerStatus: status,
+            attestationGenerator: StaticAttestationGenerator(token: nil),
+            webSocketFactory: { factory.makeSocket(for: $0) },
+            sleepAssertionFactory: { nil },
+            providerReceiptPublicKey: receiptPublicKey,
+            credentialBootstrap: true,
+            bootstrapReceiptSigningKey: receiptKey,
+            bootstrapReferralCode: "MAL1-S-key-issuer-secret-tag"
+        ))
+
+        do {
+            try await client.connectAndRunOnceForTest()
+            XCTFail("terminal referral close should throw")
+        } catch let CoordinatorAuthError.rejected(code, message) {
+            XCTAssertEqual(code, "referral_expired")
+            XCTAssertEqual(message, "referral_expired")
+            XCTAssertFalse(message.contains("MAL1"))
+        } catch {
+            XCTFail("unexpected error: \(error)")
+        }
+    }
+
     func testRepeatedInvalidAuthRequestFailuresFireRecoveryHook() async throws {
         let recorder = CoordinatorFrameRecorder()
         let attempts = ReconnectAttemptRecorder()
@@ -2986,7 +3030,8 @@ final class CoordinatorClientTests: XCTestCase {
             recorder: recorder,
             providerReceiptPublicKey: receiptPublicKey,
             credentialBootstrap: true,
-            bootstrapReceiptSigningKey: receiptKey
+            bootstrapReceiptSigningKey: receiptKey,
+            bootstrapReferralCode: "MAL1-S-key-issuer-tag"
         )
         let attempt = Tier2AuthAttempt()
         let hello = await client.helloMessage()
@@ -3007,10 +3052,73 @@ final class CoordinatorClientTests: XCTestCase {
 
         XCTAssertNil(hello["credential_bootstrap"])
         XCTAssertEqual(initial["credential_bootstrap"] as? Bool, true)
+        XCTAssertEqual(initial["referral_code"] as? String, "MAL1-S-key-issuer-tag")
         XCTAssertEqual(initial["provider_receipt_public_key"] as? String, receiptPublicKey)
         XCTAssertEqual(proof["credential_bootstrap"] as? Bool, true)
+        XCTAssertEqual(proof["referral_code"] as? String, "MAL1-S-key-issuer-tag")
         XCTAssertNotNil(proof["identity_signature"] as? String)
         XCTAssertNotNil(proof["identity_signature_transcript_sha256"] as? String)
+    }
+
+    func testReferralCodeIsOmittedOutsideCredentialBootstrap() async throws {
+        let recorder = CoordinatorFrameRecorder()
+        let status = ProviderStatus(
+            modelID: "model-a",
+            modelLoaded: true,
+            capacity: ProviderCapacity(maxContextOverride: 20_000, maxConcurrencyOverride: 1)
+        )
+        let client = try await makeClient(
+            status: status,
+            recorder: recorder,
+            bootstrapReferralCode: "MAL1-S-key-issuer-tag"
+        )
+        let attempt = Tier2AuthAttempt()
+        let initial = await client.authInitialMessage(attempt: attempt)
+        let proof = try await client.authProofMessage(challenge: [
+            "type": "auth_challenge",
+            "version": 2,
+            "auth_attempt_id": "ordinary-no-referral",
+            "attestation_challenge": Data(repeating: 0x11, count: 32).base64URLUnpadded(),
+        ], attempt: attempt, initialMessage: initial)
+
+        XCTAssertNil(initial["referral_code"])
+        XCTAssertNil(proof["referral_code"])
+    }
+
+    func testTerminalReferralRejectionStopsBootstrapReconnectLoop() async throws {
+        let recorder = CoordinatorFrameRecorder()
+        let receiptKey = Curve25519.Signing.PrivateKey()
+        let receiptPublicKey = Data(receiptKey.publicKey.rawRepresentation).base64EncodedString()
+        let attempts = ReferralBootstrapConnectAttempts()
+        let status = ProviderStatus(
+            modelID: "model-a",
+            modelLoaded: false,
+            capacity: ProviderCapacity(maxContextOverride: 20_000, maxConcurrencyOverride: 1)
+        )
+        let client = try await makeClient(
+            status: status,
+            recorder: recorder,
+            reconnectInitialBackoffNanoseconds: 1_000_000,
+            connectAndRunOverride: {
+                await attempts.increment()
+                throw CoordinatorAuthError.rejected(code: "referral_expired", message: "redacted")
+            },
+            providerReceiptPublicKey: receiptPublicKey,
+            credentialBootstrap: true,
+            bootstrapReceiptSigningKey: receiptKey,
+            bootstrapReferralCode: "MAL1-S-key-issuer-tag"
+        )
+
+        await client.start()
+        try await Self.waitUntil {
+            await client.credentialBootstrapTerminalReferralFailure() != nil
+        }
+        let terminalFailure = await client.credentialBootstrapTerminalReferralFailure()
+        XCTAssertEqual(terminalFailure, ReferralBootstrapFailure(kind: .expired))
+        try await Task.sleep(nanoseconds: 10_000_000)
+        let attemptCount = await attempts.value()
+        XCTAssertEqual(attemptCount, 1)
+        await client.stop()
     }
 
     func testOrdinaryBearerV2PublishesAndSignsWithSeparateAdmissionIdentity() async throws {
@@ -4483,6 +4591,7 @@ final class CoordinatorClientTests: XCTestCase {
         losslessnessProbeEnabled: Bool = false,
         credentialBootstrap: Bool = false,
         bootstrapReceiptSigningKey: Curve25519.Signing.PrivateKey? = nil,
+        bootstrapReferralCode: String? = nil,
         receiptIdentitySigningKey: Curve25519.Signing.PrivateKey? = nil,
         receiptIdentitySigningKeyCandidates: [Curve25519.Signing.PrivateKey] = [],
         catalogReleaseID: String? = nil,
@@ -4557,6 +4666,7 @@ final class CoordinatorClientTests: XCTestCase {
             autoupdateMarkerStore: autoupdateMarkerStore,
             credentialBootstrap: credentialBootstrap,
             bootstrapReceiptSigningKey: bootstrapReceiptSigningKey,
+            bootstrapReferralCode: bootstrapReferralCode,
             receiptIdentitySigningKey: receiptIdentitySigningKey,
             receiptIdentitySigningKeyCandidates: receiptIdentitySigningKeyCandidates,
             providerCredentialStore: providerCredentialStore,
@@ -4855,6 +4965,18 @@ private struct StaticAttestationGenerator: Tier2AttestationTokenGenerating, @unc
         providerECDHPublicKey: String
     ) async -> [String: Any]? {
         token
+    }
+}
+
+private actor ReferralBootstrapConnectAttempts {
+    private var count = 0
+
+    func increment() {
+        count += 1
+    }
+
+    func value() -> Int {
+        count
     }
 }
 

--- a/phase3-binary/Tests/macprovider-cliTests/ProviderStatusTests.swift
+++ b/phase3-binary/Tests/macprovider-cliTests/ProviderStatusTests.swift
@@ -112,6 +112,7 @@ final class ProviderStatusTests: XCTestCase {
         XCTAssertTrue(capabilities.contains("status_observation_v1"))
         XCTAssertTrue(capabilities.contains("provider_safety_telemetry_v1"))
         XCTAssertTrue(capabilities.contains("provider_safety_telemetry_v2"))
+        XCTAssertTrue(capabilities.contains("referral_bootstrap_v1"))
 
         let observation = try XCTUnwrap(body["observation"] as? [String: Any])
         XCTAssertNotNil(observation["id"] as? String)

--- a/phase3-binary/app/Sources/Malibu/Info.plist
+++ b/phase3-binary/app/Sources/Malibu/Info.plist
@@ -24,6 +24,8 @@
 	<string>14.0</string>
 	<key>LSUIElement</key>
 	<true/>
+	<key>MalibuBundledReferralBootstrapV1</key>
+	<false/>
 	<key>NSAppTransportSecurity</key>
 	<dict>
 		<key>NSAllowsLocalNetworking</key>

--- a/phase3-binary/app/Sources/Malibu/Onboarding/CLIInstallRunner.swift
+++ b/phase3-binary/app/Sources/Malibu/Onboarding/CLIInstallRunner.swift
@@ -1,3 +1,4 @@
+import Darwin
 import Foundation
 
 /// Runs the public CLI-track `install.sh` non-interactively from Malibu.app.
@@ -5,16 +6,46 @@ import Foundation
 enum CLIInstallRunner {
     enum Error: Swift.Error, LocalizedError {
         case installScriptNotFound
+        case compatibilityManifestNotFound
         case invalidPinnedVersion(String)
+        case referralFailure(ReferralFailure)
         case nonZeroExit(Int32)
         case launchFailed(String)
+
+        enum ReferralFailure: Int32, Equatable {
+            case required = 20
+            case invalid = 21
+            case expired = 22
+            case revoked = 23
+            case exhausted = 24
+            case conflict = 25
+            case rateLimited = 26
+            case unavailable = 27
+
+            var message: String {
+                switch self {
+                case .required: return "A referral code is required to join right now. Enter an invite and retry."
+                case .invalid: return "This referral code is invalid. Check the code or invite link and retry."
+                case .expired: return "This referral code has expired. Ask the sender for a current invite."
+                case .revoked: return "This referral code was revoked. Ask the sender for a different invite."
+                case .exhausted: return "This referral code has no redemptions left. Ask the sender for a different invite."
+                case .conflict: return "This provider identity is already bound to a different referral attempt. Retry the original invite or contact support."
+                case .rateLimited: return "Too many referral attempts were submitted. Wait before retrying."
+                case .unavailable: return "Referral admission is temporarily unavailable. Your provider identity is preserved; retry later."
+                }
+            }
+        }
 
         var errorDescription: String? {
             switch self {
             case .installScriptNotFound:
                 return "The bundled macprovider installer script was not found."
+            case .compatibilityManifestNotFound:
+                return "The signed provider compatibility manifest was not found."
             case let .invalidPinnedVersion(version):
                 return "Provider install version pin is invalid: \(version)."
+            case let .referralFailure(failure):
+                return failure.message
             case let .nonZeroExit(code):
                 return "Provider install failed (exit \(code)). See the log above for details."
             case let .launchFailed(message):
@@ -27,16 +58,25 @@ enum CLIInstallRunner {
     /// lines to `onLogLine` on the main actor.
     static func run(
         pinnedVersion: String? = nil,
+        referralCode: String? = nil,
         onLogLine: @escaping @Sendable @MainActor (String) -> Void
     ) async throws {
         let scriptURL = try resolveInstallScriptURL()
-        let runnableURL = try materializeRunnableScript(from: scriptURL)
-        defer { try? FileManager.default.removeItem(at: runnableURL) }
+        let manifestURL = try resolveCompatibilityManifestURL()
+        let verifiedScript = try BundledInstallContractVerifier.verify(
+            scriptURL: scriptURL,
+            manifestURL: manifestURL
+        )
+        let referralFileURL = try referralCode.map { try ReferralCodeFile.create(code: $0) }
+        defer {
+            if let referralFileURL { try? FileManager.default.removeItem(at: referralFileURL) }
+        }
         let installPort = resolveInstallPort()
         let environment = try installerEnvironment(
             parentEnvironment: ProcessInfo.processInfo.environment,
             installPort: installPort,
-            pinnedVersion: pinnedVersion
+            pinnedVersion: pinnedVersion,
+            referralCodeFile: referralFileURL
         )
         if let installPort {
             await onLogLine("[macprovider-install] Using local HTTP port \(installPort) for provider install.")
@@ -44,10 +84,14 @@ enum CLIInstallRunner {
         let exitCode: Int32 = try await withCheckedThrowingContinuation { continuation in
             DispatchQueue.global(qos: .userInitiated).async {
                 let process = Process()
+                let stdin = Pipe()
                 let stdout = Pipe()
                 let stderr = Pipe()
                 process.executableURL = URL(fileURLWithPath: "/bin/bash")
-                process.arguments = [runnableURL.path]
+                // Execute the exact authenticated bytes without reopening an
+                // owner-writable path between verification and bash parsing.
+                process.arguments = ["-s", "--"]
+                process.standardInput = stdin
                 process.standardOutput = stdout
                 process.standardError = stderr
 
@@ -70,7 +114,11 @@ enum CLIInstallRunner {
 
                 do {
                     try process.run()
+                    try stdin.fileHandleForWriting.write(contentsOf: verifiedScript)
+                    try stdin.fileHandleForWriting.close()
                 } catch {
+                    try? stdin.fileHandleForWriting.close()
+                    if process.isRunning { process.terminate() }
                     continuation.resume(throwing: Error.launchFailed(error.localizedDescription))
                     return
                 }
@@ -83,6 +131,9 @@ enum CLIInstallRunner {
         if exitCode == 0 {
             return
         }
+        if let failure = Error.ReferralFailure(rawValue: exitCode) {
+            throw Error.referralFailure(failure)
+        }
         // Every non-zero installer exit leaves the durable transaction
         // uncommitted and triggers rollback. A healthy local process may be
         // the restored previous release, so it cannot prove this install won.
@@ -92,7 +143,8 @@ enum CLIInstallRunner {
     static func installerEnvironment(
         parentEnvironment: [String: String],
         installPort: Int?,
-        pinnedVersion: String?
+        pinnedVersion: String?,
+        referralCodeFile: URL? = nil
     ) throws -> [String: String] {
         // Deliberately do not inherit the parent environment. install.sh has
         // authority-changing knobs for repositories, public keys, acceptance
@@ -115,6 +167,9 @@ enum CLIInstallRunner {
                 throw Error.invalidPinnedVersion(pinnedVersion)
             }
             explicit["MACPROVIDER_VERSION"] = "v\(normalized)"
+        }
+        if let referralCodeFile {
+            explicit["MACPROVIDER_REFERRAL_CODE_FILE"] = referralCodeFile.path
         }
         return try ProcessEnvironmentSanitizer.sanitized(
             from: [:],
@@ -216,6 +271,13 @@ enum CLIInstallRunner {
         throw Error.installScriptNotFound
     }
 
+    static func resolveCompatibilityManifestURL() throws -> URL {
+        guard let bundled = Bundle.main.url(forResource: "compatibility-set", withExtension: "json") else {
+            throw Error.compatibilityManifestNotFound
+        }
+        return bundled
+    }
+
     /// Port for `install.sh`: explicit env override, existing config, else a probed free port.
     /// Avoids exit 6 when the default 8080 is occupied (common on dev Macs running Node).
     static func resolveInstallPort(
@@ -230,12 +292,4 @@ enum CLIInstallRunner {
         return try? FreePortProbe.probe()
     }
 
-    /// Bundle resources are not guaranteed executable; copy to a temp path with +x.
-    private static func materializeRunnableScript(from source: URL) throws -> URL {
-        let temp = FileManager.default.temporaryDirectory
-            .appendingPathComponent("macprovider-install-\(UUID().uuidString).sh")
-        try FileManager.default.copyItem(at: source, to: temp)
-        try FileManager.default.setAttributes([.posixPermissions: 0o700], ofItemAtPath: temp.path)
-        return temp
-    }
 }

--- a/phase3-binary/app/Sources/Malibu/Onboarding/LaunchProviderController.swift
+++ b/phase3-binary/app/Sources/Malibu/Onboarding/LaunchProviderController.swift
@@ -316,6 +316,15 @@ final class LaunchProviderController: ObservableObject {
     }
 
     private static func referralInputAvailableForCurrentInstall() async -> Bool {
+        let bundledHandoffEnabled = Bundle.main.object(
+            forInfoDictionaryKey: "MalibuBundledReferralBootstrapV1"
+        ) as? Bool == true
+        guard bundledHandoffEnabled else {
+            // Malibu always executes its separately bundled, signed installer.
+            // An independently updated installed CLI cannot make an older
+            // bundled handoff capable of forwarding referral input.
+            return false
+        }
         let paths = ProviderPaths.current
         let hasExistingInstall = FileManager.default.fileExists(atPath: paths.configFile.path)
             || StartupState.launchdInstallEvidenceExists(paths: paths)
@@ -324,9 +333,7 @@ final class LaunchProviderController: ObservableObject {
             // release assembly may enable this only after it embeds a signed,
             // referral-capable CLI/install contract. It remains off for older
             // independently versioned CLI payloads.
-            return Bundle.main.object(
-                forInfoDictionaryKey: "MalibuBundledReferralBootstrapV1"
-            ) as? Bool == true
+            return true
         }
         guard let port = InstalledProviderMonitor.readHTTPPort(paths: paths),
               let status = await InstalledProviderMonitor.fetchStatus(port: port),
@@ -342,7 +349,19 @@ final class LaunchProviderController: ObservableObject {
               ) else {
             return false
         }
-        return status.capabilities.contains("referral_bootstrap_v1")
+        return referralHandoffAvailable(
+            bundledHandoffEnabled: bundledHandoffEnabled,
+            installedCLIAdvertisesReferralBootstrapV1:
+                status.capabilities.contains("referral_bootstrap_v1")
+        )
+    }
+
+    static func referralHandoffAvailable(
+        bundledHandoffEnabled: Bool,
+        installedCLIAdvertisesReferralBootstrapV1: Bool?
+    ) -> Bool {
+        guard bundledHandoffEnabled else { return false }
+        return installedCLIAdvertisesReferralBootstrapV1 ?? true
     }
 
     private func beginInstallProgressWatch() {

--- a/phase3-binary/app/Sources/Malibu/Onboarding/LaunchProviderController.swift
+++ b/phase3-binary/app/Sources/Malibu/Onboarding/LaunchProviderController.swift
@@ -24,14 +24,19 @@ final class LaunchProviderController: ObservableObject {
     @Published private(set) var installLogLines: [String] = []
     @Published private(set) var installProgressHint: String?
     @Published private(set) var installStartedAt: Date?
+    @Published var referralInput = ""
+    @Published private(set) var referralInputAvailable = false
+    @Published private(set) var referralAvailabilityChecked = false
 
     private var installProgressTask: Task<Void, Never>?
     private let dependencies: Dependencies
 
     struct Dependencies {
         var localInstallSucceeded: @MainActor () async -> Bool
+        var referralInputAvailable: @MainActor () async -> Bool
         var registerLoginItem: @MainActor () async throws -> Void
         var runCLIInstall: @MainActor (
+            String?,
             @escaping @Sendable @MainActor (String) -> Void
         ) async throws -> Void
         var importCLIConfigAfterInstall: @MainActor () async throws -> Void
@@ -45,9 +50,12 @@ final class LaunchProviderController: ObservableObject {
         static func live(agent: MalibuAgent?) -> Dependencies {
             Dependencies(
                 localInstallSucceeded: { await CLIInstallRunner.localInstallSucceeded() },
+                referralInputAvailable: {
+                    await LaunchProviderController.referralInputAvailableForCurrentInstall()
+                },
                 registerLoginItem: { try AppLoginItem.register() },
-                runCLIInstall: { onLogLine in
-                    try await CLIInstallRunner.run(onLogLine: onLogLine)
+                runCLIInstall: { referralCode, onLogLine in
+                    try await CLIInstallRunner.run(referralCode: referralCode, onLogLine: onLogLine)
                 },
                 importCLIConfigAfterInstall: {
                     try await ProviderConfig.importExistingCLIConfig()
@@ -85,7 +93,27 @@ final class LaunchProviderController: ObservableObject {
             )
             return
         }
-        await launchViaCLIInstall()
+        let referralCode: String?
+        do {
+            referralCode = try ReferralOnboardingInput.normalize(referralInput)
+        } catch {
+            stage = .failed(stage: "referral", retryable: true, message: error.localizedDescription)
+            return
+        }
+        if referralCode != nil, !(await dependencies.referralInputAvailable()) {
+            stage = .failed(
+                stage: "referral",
+                retryable: true,
+                message: "Referral entry is unavailable until the installed provider CLI advertises referral_bootstrap_v1. Update the CLI, then retry."
+            )
+            return
+        }
+        await launchViaCLIInstall(referralCode: referralCode)
+    }
+
+    func refreshReferralInputAvailability() async {
+        referralInputAvailable = await dependencies.referralInputAvailable()
+        referralAvailabilityChecked = true
     }
 
     func retry() async {
@@ -112,13 +140,13 @@ final class LaunchProviderController: ObservableObject {
         await finalizeExistingInstall(logLine: "Background provider is already running locally.")
     }
 
-    private func launchViaCLIInstall() async {
+    private func launchViaCLIInstall(referralCode: String?) async {
         beginInstallProgressWatch()
         defer { endInstallProgressWatch() }
         do {
             stage = .runningCLIInstall
             installLogLines = []
-            try await dependencies.runCLIInstall { [weak self] line in
+            try await dependencies.runCLIInstall(referralCode) { [weak self] line in
                 guard let self else { return }
                 self.installLogLines.append(line)
                 if self.installLogLines.count > 200 {
@@ -138,6 +166,13 @@ final class LaunchProviderController: ObservableObject {
                 }
             }
             await finalizeInstall(pendingImportError: importError)
+        } catch let CLIInstallRunner.Error.referralFailure(failure) {
+            await refreshReferralInputAvailability()
+            stage = .failed(
+                stage: "referral",
+                retryable: true,
+                message: failure.message
+            )
         } catch {
             stage = .failed(stage: "cliInstall", retryable: true, message: error.localizedDescription)
         }
@@ -278,6 +313,36 @@ final class LaunchProviderController: ObservableObject {
             try? await Task.sleep(nanoseconds: 2_000_000_000)
         }
         return false
+    }
+
+    private static func referralInputAvailableForCurrentInstall() async -> Bool {
+        let paths = ProviderPaths.current
+        let hasExistingInstall = FileManager.default.fileExists(atPath: paths.configFile.path)
+            || StartupState.launchdInstallEvidenceExists(paths: paths)
+        guard hasExistingInstall else {
+            // Fresh onboarding has no installed CLI to negotiate with. The
+            // release assembly may enable this only after it embeds a signed,
+            // referral-capable CLI/install contract. It remains off for older
+            // independently versioned CLI payloads.
+            return Bundle.main.object(
+                forInfoDictionaryKey: "MalibuBundledReferralBootstrapV1"
+            ) as? Bool == true
+        }
+        guard let port = InstalledProviderMonitor.readHTTPPort(paths: paths),
+              let status = await InstalledProviderMonitor.fetchStatus(port: port),
+              status.contractCompatible == true,
+              status.lifecycleOwner == "macprovider_cli",
+              status.capabilities.contains("service_instance_v1"),
+              let expectedProviderID = ProviderConfig.readProviderID(paths: paths),
+              InstalledProviderMonitor.serviceIdentityMatches(
+                  status,
+                  expectedProviderID: expectedProviderID,
+                  launchdPID: InstalledProviderMonitor.launchdServicePID(),
+                  liveCodeMatches: ProviderCredentialHandoffRunner.validatedInstalledProcessMatches(pid:)
+              ) else {
+            return false
+        }
+        return status.capabilities.contains("referral_bootstrap_v1")
     }
 
     private func beginInstallProgressWatch() {

--- a/phase3-binary/app/Sources/Malibu/Onboarding/OnboardingWindow.swift
+++ b/phase3-binary/app/Sources/Malibu/Onboarding/OnboardingWindow.swift
@@ -56,6 +56,7 @@ private struct OnboardingRootView: View {
         .padding(28)
         .frame(minWidth: 460, minHeight: 560)
         .task {
+            await controller.refreshReferralInputAvailability()
             await controller.refreshFromExistingInstall()
         }
     }
@@ -66,6 +67,7 @@ private struct OnboardingRootView: View {
         case .idle:
             stageRow(title: "Ready", detail: "Installs the provider CLI, picks a model, and registers a background service.") {
                 VStack(alignment: .leading, spacing: 8) {
+                    referralAvailability
                     launchButton(title: "Launch Provider")
                     Text("No wallet needed to start — add one anytime after.")
                         .font(.callout)
@@ -121,8 +123,8 @@ private struct OnboardingRootView: View {
             }
         case .importingProviderCredential:
             stageRow(
-                title: "Importing provider identity",
-                detail: "Saving the provider identity to Keychain before connecting Malibu."
+                title: "Confirming provider identity",
+                detail: "Waiting for the CLI-owned provider identity to become restart-safe before Malibu attaches."
             ) {
                 ProgressView().controlSize(.small)
             }
@@ -142,10 +144,15 @@ private struct OnboardingRootView: View {
                     .buttonStyle(.borderedProminent)
                     .tint(MalibuBrand.coral)
             }
-        case let .failed(_, retryable, message):
+        case let .failed(stage, retryable, message):
             stageRow(title: retryable ? "Needs retry" : "Setup failed", detail: message) {
-                if retryable {
-                    launchButton(title: "Retry")
+                VStack(alignment: .leading, spacing: 8) {
+                    if stage == "referral" {
+                        referralAvailability
+                    }
+                    if retryable {
+                        launchButton(title: "Retry")
+                    }
                 }
             }
         }
@@ -189,6 +196,41 @@ private struct OnboardingRootView: View {
         }
         .buttonStyle(.borderedProminent)
         .tint(MalibuBrand.coral)
+    }
+
+    private var referralField: some View {
+        VStack(alignment: .leading, spacing: 5) {
+            Text("Invite code (optional)")
+                .font(.callout.weight(.medium))
+            TextField("MAL1-S-… or invite link", text: $controller.referralInput)
+                .textFieldStyle(.roundedBorder)
+                .textContentType(.oneTimeCode)
+                .disableAutocorrection(true)
+            Text("Malibu passes this once to the installed CLI. Malibu never receives or stores the provider credential.")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+        }
+    }
+
+    @ViewBuilder
+    private var referralAvailability: some View {
+        if !controller.referralAvailabilityChecked {
+            Text("Checking installed CLI capabilities…")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+        } else if controller.referralInputAvailable {
+            referralField
+        } else {
+            VStack(alignment: .leading, spacing: 5) {
+                Text("Invite entry is unavailable until the authenticated launchd CLI advertises referral_bootstrap_v1. Malibu and CLI versions are checked by capability, not by marketing version.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                Button("Check again") {
+                    Task { await controller.refreshReferralInputAvailability() }
+                }
+                .buttonStyle(.link)
+            }
+        }
     }
 
     private func formattedElapsed(since start: Date) -> String {

--- a/phase3-binary/app/Sources/Malibu/Onboarding/ReferralOnboarding.swift
+++ b/phase3-binary/app/Sources/Malibu/Onboarding/ReferralOnboarding.swift
@@ -1,0 +1,244 @@
+import CryptoKit
+import Darwin
+import Foundation
+
+enum ReferralOnboardingInput {
+    enum ValidationError: Swift.Error, LocalizedError, Equatable {
+        case invalidCodeOrLink
+
+        var errorDescription: String? {
+            "Enter a valid Malibu invite code or a https://coordinator.streamvc.live/j/ invite link."
+        }
+    }
+
+    private static let codePattern = #"^MAL1-[SP]-[A-Za-z0-9_]{1,32}-[A-Za-z0-9_]{1,32}-[A-Z2-7]{26}$"#
+
+    static func normalize(_ input: String) throws -> String? {
+        let trimmed = input.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return nil }
+        guard trimmed.utf8.count <= 512 else { throw ValidationError.invalidCodeOrLink }
+
+        if isValidCode(trimmed) {
+            return trimmed
+        }
+        guard let components = URLComponents(string: trimmed),
+              components.scheme == "https",
+              components.host?.lowercased() == "coordinator.streamvc.live",
+              components.user == nil,
+              components.password == nil,
+              components.port == nil,
+              components.query == nil,
+              components.fragment == nil else {
+            throw ValidationError.invalidCodeOrLink
+        }
+        let segments = components.percentEncodedPath.split(separator: "/", omittingEmptySubsequences: true)
+        guard segments.count == 2,
+              segments[0] == "j",
+              !segments[1].contains("%"),
+              isValidCode(String(segments[1])) else {
+            throw ValidationError.invalidCodeOrLink
+        }
+        return String(segments[1])
+    }
+
+    static func isValidCode(_ value: String) -> Bool {
+        value.range(of: codePattern, options: .regularExpression) != nil
+    }
+}
+
+enum BundledInstallContractVerifier {
+    enum VerificationError: Swift.Error, LocalizedError, Equatable {
+        case unavailable(String)
+
+        var errorDescription: String? {
+            switch self {
+            case let .unavailable(reason):
+                return "The signed provider installer is unavailable: \(reason)"
+            }
+        }
+    }
+
+    private static let maximumManifestBytes = 1_048_576
+    private static let maximumInstallScriptBytes = 8_388_608
+    private static let releasePublicKeyPEM = """
+    -----BEGIN PUBLIC KEY-----
+    MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEwwd0Vzj35OP8DlZU+0lUa8vI9gHK
+    09J48LDizWScsH6rutnZLkKnGQ4X5Q8lT9L5mglF8Ba0DDoUXKrFfSAX4Q==
+    -----END PUBLIC KEY-----
+    """
+
+    static func verify(
+        scriptURL: URL,
+        manifestURL: URL,
+        publicKeyPEM: String? = nil
+    ) throws -> Data {
+        let scriptData = try readRegularFile(
+            scriptURL,
+            label: "install.sh",
+            maximumBytes: maximumInstallScriptBytes
+        )
+        let manifestData = try readRegularFile(
+            manifestURL,
+            label: "compatibility-set.json",
+            maximumBytes: maximumManifestBytes
+        )
+        guard let object = try? JSONSerialization.jsonObject(with: manifestData),
+              let envelope = object as? [String: Any],
+              Set(envelope.keys) == ["schema_version", "signatures", "signed"],
+              envelope["schema_version"] as? String == "macprovider.compatibility-set-envelope.v1",
+              let signatures = envelope["signatures"] as? [[String: Any]],
+              signatures.count == 1,
+              let signature = signatures.first,
+              Set(signature.keys) == ["algorithm", "key_id", "signature"],
+              signature["algorithm"] as? String == "ecdsa-p256-sha256",
+              signature["key_id"] as? String == "macprovider-release-p256-v1",
+              let encodedSignature = signature["signature"] as? String,
+              let signatureData = Data(base64Encoded: encodedSignature),
+              signatureData.base64EncodedString() == encodedSignature,
+              (64...80).contains(signatureData.count),
+              let signed = envelope["signed"] as? [String: Any],
+              Set(signed.keys) == [
+                  "artifact_binding", "compatibility_set_id", "components",
+                  "release", "schema_version", "transaction",
+              ],
+              signed["schema_version"] as? String == "macprovider.compatibility-set.v1",
+              let components = signed["components"] as? [String: Any],
+              Set(components.keys) == [
+                  "catalog", "coordinator_admission", "launchd", "malibu_app",
+                  "provider_cli", "updater_rollback", "watchdog",
+              ],
+              let launchd = components["launchd"] as? [String: Any],
+              Set(launchd.keys) == ["activation", "contract", "install_contract", "label", "plist_template"],
+              launchd["activation"] as? String == "local",
+              launchd["contract"] as? String == "macprovider.launch-agent.v1",
+              launchd["label"] as? String == "live.streamvc.macprovider",
+              let contract = launchd["install_contract"] as? [String: Any],
+              Set(contract.keys) == ["path", "sha256"],
+              contract["path"] as? String == "compatibility-set-local/install.sh",
+              let expectedDigest = contract["sha256"] as? String,
+              expectedDigest.range(of: #"^[0-9a-f]{64}$"#, options: .regularExpression) != nil else {
+            throw VerificationError.unavailable("compatibility-set.json is not a canonical signed launchd contract")
+        }
+        guard var canonicalEnvelope = try? JSONSerialization.data(
+            withJSONObject: envelope,
+            options: [.sortedKeys, .withoutEscapingSlashes]
+        ) else {
+            throw VerificationError.unavailable("compatibility-set.json cannot be canonicalized")
+        }
+        canonicalEnvelope.append(0x0a)
+        guard canonicalEnvelope == manifestData else {
+            throw VerificationError.unavailable("compatibility-set.json is not canonically encoded")
+        }
+        guard var signedBytes = try? JSONSerialization.data(
+            withJSONObject: signed,
+            options: [.sortedKeys, .withoutEscapingSlashes]
+        ) else {
+            throw VerificationError.unavailable("compatibility-set.json signed payload is invalid")
+        }
+        signedBytes.append(0x0a)
+        do {
+            let publicKey = try P256.Signing.PublicKey(
+                pemRepresentation: publicKeyPEM ?? releasePublicKeyPEM
+            )
+            let ecdsa = try P256.Signing.ECDSASignature(derRepresentation: signatureData)
+            guard publicKey.isValidSignature(ecdsa, for: SHA256.hash(data: signedBytes)) else {
+                throw VerificationError.unavailable("compatibility-set.json signature is invalid")
+            }
+        } catch let error as VerificationError {
+            throw error
+        } catch {
+            throw VerificationError.unavailable("compatibility-set.json signature is invalid")
+        }
+
+        let actualDigest = SHA256.hash(data: scriptData).map { String(format: "%02x", $0) }.joined()
+        guard actualDigest == expectedDigest else {
+            throw VerificationError.unavailable("install.sh does not match its signed compatibility set")
+        }
+        return scriptData
+    }
+
+    private static func readRegularFile(
+        _ url: URL,
+        label: String,
+        maximumBytes: Int
+    ) throws -> Data {
+        let descriptor = open(url.path, O_RDONLY | O_CLOEXEC | O_NOFOLLOW)
+        guard descriptor >= 0 else {
+            throw VerificationError.unavailable("\(label) is missing or unreadable")
+        }
+        defer { close(descriptor) }
+        var info = stat()
+        guard fstat(descriptor, &info) == 0,
+              (info.st_mode & S_IFMT) == S_IFREG else {
+            throw VerificationError.unavailable("\(label) is not a regular file")
+        }
+        guard info.st_size > 0, info.st_size <= maximumBytes else {
+            throw VerificationError.unavailable("\(label) has an invalid size")
+        }
+        var data = Data()
+        var buffer = [UInt8](repeating: 0, count: 16_384)
+        while data.count <= maximumBytes {
+            let count = Darwin.read(descriptor, &buffer, buffer.count)
+            if count < 0 {
+                if errno == EINTR { continue }
+                throw VerificationError.unavailable("\(label) could not be read")
+            }
+            if count == 0 { break }
+            data.append(buffer, count: count)
+        }
+        guard !data.isEmpty, data.count <= maximumBytes else {
+            throw VerificationError.unavailable("\(label) has an invalid size")
+        }
+        return data
+    }
+}
+
+enum ReferralCodeFile {
+    enum WriteError: Swift.Error, LocalizedError {
+        case couldNotCreate
+
+        var errorDescription: String? {
+            "Could not securely prepare the referral code for the provider CLI."
+        }
+    }
+
+    static func create(code: String, directory: URL = FileManager.default.temporaryDirectory) throws -> URL {
+        let url = directory.appendingPathComponent("macprovider-referral-\(UUID().uuidString)")
+        let descriptor = open(url.path, O_WRONLY | O_CREAT | O_EXCL | O_NOFOLLOW, S_IRUSR | S_IWUSR)
+        guard descriptor >= 0 else { throw WriteError.couldNotCreate }
+        var succeeded = false
+        defer {
+            close(descriptor)
+            if !succeeded { unlink(url.path) }
+        }
+        var info = stat()
+        guard fstat(descriptor, &info) == 0,
+              (info.st_mode & S_IFMT) == S_IFREG,
+              info.st_uid == geteuid(),
+              (info.st_mode & 0o777) == 0o600,
+              info.st_nlink == 1,
+              hasNoExtendedACL(descriptor) else {
+            throw WriteError.couldNotCreate
+        }
+        let bytes = Array(code.utf8)
+        let written = bytes.withUnsafeBytes { buffer in
+            Darwin.write(descriptor, buffer.baseAddress, buffer.count)
+        }
+        guard written == bytes.count, fsync(descriptor) == 0 else {
+            throw WriteError.couldNotCreate
+        }
+        succeeded = true
+        return url
+    }
+
+    private static func hasNoExtendedACL(_ descriptor: Int32) -> Bool {
+        errno = 0
+        guard let acl = acl_get_fd_np(descriptor, ACL_TYPE_EXTENDED) else {
+            return errno == 0 || errno == ENOENT
+        }
+        defer { _ = acl_free(UnsafeMutableRawPointer(acl)) }
+        var entry: acl_entry_t?
+        guard acl_get_entry(acl, ACL_FIRST_ENTRY.rawValue, &entry) == 0 else { return false }
+        return entry == nil
+    }
+}

--- a/phase3-binary/app/Tests/MalibuTests/LaunchProviderControllerTests.swift
+++ b/phase3-binary/app/Tests/MalibuTests/LaunchProviderControllerTests.swift
@@ -141,6 +141,37 @@ final class LaunchProviderControllerTests: XCTestCase {
         XCTAssertFalse(controller.referralInputAvailable)
     }
 
+    func testReferralHandoffRequiresBundledArtifactAndInstalledCapability() {
+        XCTAssertFalse(LaunchProviderController.referralHandoffAvailable(
+            bundledHandoffEnabled: false,
+            installedCLIAdvertisesReferralBootstrapV1: true
+        ))
+        XCTAssertFalse(LaunchProviderController.referralHandoffAvailable(
+            bundledHandoffEnabled: true,
+            installedCLIAdvertisesReferralBootstrapV1: false
+        ))
+        XCTAssertTrue(LaunchProviderController.referralHandoffAvailable(
+            bundledHandoffEnabled: true,
+            installedCLIAdvertisesReferralBootstrapV1: true
+        ))
+        XCTAssertTrue(LaunchProviderController.referralHandoffAvailable(
+            bundledHandoffEnabled: true,
+            installedCLIAdvertisesReferralBootstrapV1: nil
+        ))
+    }
+
+    func testDefaultMalibuArtifactKeepsReferralHandoffDisabled() {
+        let bundledHandoffEnabled = Bundle.main.object(
+            forInfoDictionaryKey: "MalibuBundledReferralBootstrapV1"
+        ) as? Bool == true
+
+        XCTAssertFalse(bundledHandoffEnabled)
+        XCTAssertFalse(LaunchProviderController.referralHandoffAvailable(
+            bundledHandoffEnabled: bundledHandoffEnabled,
+            installedCLIAdvertisesReferralBootstrapV1: true
+        ))
+    }
+
     func testTypedReferralFailureDoesNotDestroyIdentityOrAttachProvider() async {
         let harness = Harness()
         harness.cliInstallError = CLIInstallRunner.Error.referralFailure(.expired)

--- a/phase3-binary/app/Tests/MalibuTests/LaunchProviderControllerTests.swift
+++ b/phase3-binary/app/Tests/MalibuTests/LaunchProviderControllerTests.swift
@@ -84,6 +84,82 @@ final class LaunchProviderControllerTests: XCTestCase {
         XCTAssertEqual(controller.stage, .live(model: harness.configModel, tier: .provisional))
     }
 
+    func testLaunchPassesNormalizedReferralLinkToCLIInstaller() async {
+        let harness = Harness()
+        let controller = LaunchProviderController(dependencies: harness.dependencies())
+        let code = "MAL1-S-key_1-issuer_1-" + String(repeating: "A", count: 26)
+        controller.referralInput = "https://coordinator.streamvc.live/j/\(code)"
+
+        await controller.launch()
+
+        XCTAssertEqual(harness.installedReferralCode, code)
+        XCTAssertEqual(controller.stage, .live(model: harness.configModel, tier: .provisional))
+    }
+
+    func testInvalidReferralInputDoesNotRunInstaller() async {
+        let harness = Harness()
+        let controller = LaunchProviderController(dependencies: harness.dependencies())
+        controller.referralInput = "https://evil.example/j/not-an-invite"
+
+        await controller.launch()
+
+        XCTAssertEqual(harness.cliInstallRuns, 0)
+        if case let .failed(stage, retryable, _) = controller.stage {
+            XCTAssertEqual(stage, "referral")
+            XCTAssertTrue(retryable)
+        } else {
+            XCTFail("expected referral correction state")
+        }
+    }
+
+    func testReferralInputRequiresNegotiatedCapability() async {
+        let harness = Harness()
+        harness.referralInputAvailable = false
+        let controller = LaunchProviderController(dependencies: harness.dependencies())
+        controller.referralInput = "MAL1-S-key_1-issuer_1-" + String(repeating: "A", count: 26)
+
+        await controller.launch()
+
+        XCTAssertEqual(harness.cliInstallRuns, 0)
+        if case let .failed(stage, retryable, message) = controller.stage {
+            XCTAssertEqual(stage, "referral")
+            XCTAssertTrue(retryable)
+            XCTAssertTrue(message.contains("referral_bootstrap_v1"))
+        } else {
+            XCTFail("expected unavailable referral correction state")
+        }
+    }
+
+    func testRefreshPublishesReferralCapabilityAvailability() async {
+        let harness = Harness()
+        harness.referralInputAvailable = false
+        let controller = LaunchProviderController(dependencies: harness.dependencies())
+
+        await controller.refreshReferralInputAvailability()
+
+        XCTAssertTrue(controller.referralAvailabilityChecked)
+        XCTAssertFalse(controller.referralInputAvailable)
+    }
+
+    func testTypedReferralFailureDoesNotDestroyIdentityOrAttachProvider() async {
+        let harness = Harness()
+        harness.cliInstallError = CLIInstallRunner.Error.referralFailure(.expired)
+        let controller = LaunchProviderController(dependencies: harness.dependencies())
+
+        await controller.launch()
+
+        XCTAssertEqual(harness.cliImportRuns, 0)
+        XCTAssertEqual(harness.monitorRuns, 0)
+        XCTAssertEqual(harness.startAgentRuns, 0)
+        if case let .failed(stage, retryable, message) = controller.stage {
+            XCTAssertEqual(stage, "referral")
+            XCTAssertTrue(retryable)
+            XCTAssertEqual(message, CLIInstallRunner.Error.ReferralFailure.expired.message)
+        } else {
+            XCTFail("expected typed referral failure")
+        }
+    }
+
     func testRefreshFromExistingInstallConnectsWithoutInstaller() async {
         let harness = Harness()
         harness.localInstallSucceeded = true
@@ -240,6 +316,7 @@ final class LaunchProviderControllerTests: XCTestCase {
 
     private final class Harness {
         var localInstallSucceeded = false
+        var referralInputAvailable = true
         var localInstallSucceededAfterInstall = false
         var markLocalInstallSucceededAfterInstall = true
         var cliInstallRuns = 0
@@ -256,17 +333,20 @@ final class LaunchProviderControllerTests: XCTestCase {
         var cliImportErrors: [Error] = []
         var configModel = "mlx-community/Qwen2.5-7B-Instruct-4bit"
         var installLogLines: [String] = []
+        var installedReferralCode: String?
 
         func dependencies() -> LaunchProviderController.Dependencies {
             LaunchProviderController.Dependencies(
                 localInstallSucceeded: {
                     self.localInstallSucceeded || self.localInstallSucceededAfterInstall
                 },
+                referralInputAvailable: { self.referralInputAvailable },
                 registerLoginItem: {
                     self.loginItemRegistrations += 1
                 },
-                runCLIInstall: { onLogLine in
+                runCLIInstall: { referralCode, onLogLine in
                     self.cliInstallRuns += 1
+                    self.installedReferralCode = referralCode
                     if let error = self.cliInstallError { throw error }
                     self.localInstallSucceededAfterInstall = self.markLocalInstallSucceededAfterInstall
                     onLogLine("install.sh finished")

--- a/phase3-binary/app/Tests/MalibuTests/ReferralOnboardingTests.swift
+++ b/phase3-binary/app/Tests/MalibuTests/ReferralOnboardingTests.swift
@@ -1,0 +1,191 @@
+import CryptoKit
+import Darwin
+import XCTest
+@testable import Malibu
+
+final class ReferralOnboardingTests: XCTestCase {
+    private let validCode = "MAL1-S-key_1-issuer_1-" + String(repeating: "A", count: 26)
+
+    func testNormalizesExactCodeAndCanonicalJoinLink() throws {
+        XCTAssertEqual(try ReferralOnboardingInput.normalize(validCode), validCode)
+        XCTAssertEqual(
+            try ReferralOnboardingInput.normalize("https://coordinator.streamvc.live/j/\(validCode)"),
+            validCode
+        )
+        XCTAssertNil(try ReferralOnboardingInput.normalize("  \n"))
+    }
+
+    func testRejectsNonCanonicalOrAuthorityChangingLinks() {
+        for input in [
+            "http://coordinator.streamvc.live/j/\(validCode)",
+            "https://evil.example/j/\(validCode)",
+            "https://user@coordinator.streamvc.live/j/\(validCode)",
+            "https://coordinator.streamvc.live:443/j/\(validCode)",
+            "https://coordinator.streamvc.live/j/\(validCode)?next=evil",
+            "https://coordinator.streamvc.live/j/%4D\(validCode.dropFirst())",
+            validCode.lowercased(),
+        ] {
+            XCTAssertThrowsError(try ReferralOnboardingInput.normalize(input), input)
+        }
+    }
+
+    func testInstallContractAcceptsExactRegularFiles() throws {
+        let fixture = try Fixture(script: Data("#!/bin/bash\nexit 0\n".utf8))
+        defer { fixture.remove() }
+
+        XCTAssertNoThrow(
+            try BundledInstallContractVerifier.verify(
+                scriptURL: fixture.script,
+                manifestURL: fixture.manifest,
+                publicKeyPEM: fixture.publicKeyPEM
+            )
+        )
+    }
+
+    func testInstallContractRejectsMismatchAndSymlink() throws {
+        let fixture = try Fixture(script: Data("#!/bin/bash\nexit 0\n".utf8))
+        defer { fixture.remove() }
+        try Data("tampered\n".utf8).write(to: fixture.script)
+        XCTAssertThrowsError(
+            try BundledInstallContractVerifier.verify(
+                scriptURL: fixture.script,
+                manifestURL: fixture.manifest,
+                publicKeyPEM: fixture.publicKeyPEM
+            )
+        )
+
+        let target = fixture.root.appendingPathComponent("target.sh")
+        try Data("#!/bin/bash\nexit 0\n".utf8).write(to: target)
+        let link = fixture.root.appendingPathComponent("linked.sh")
+        XCTAssertEqual(symlink(target.path, link.path), 0)
+        XCTAssertThrowsError(
+            try BundledInstallContractVerifier.verify(
+                scriptURL: link,
+                manifestURL: fixture.manifest,
+                publicKeyPEM: fixture.publicKeyPEM
+            )
+        )
+    }
+
+    func testInstallContractRejectsUnsignedOrNonCanonicalManifest() throws {
+        let fixture = try Fixture(script: Data("#!/bin/bash\nexit 0\n".utf8))
+        defer { fixture.remove() }
+        var envelope = try XCTUnwrap(
+            JSONSerialization.jsonObject(with: Data(contentsOf: fixture.manifest)) as? [String: Any]
+        )
+        envelope["signatures"] = []
+        let unsigned = try JSONSerialization.data(
+            withJSONObject: envelope,
+            options: [.sortedKeys, .withoutEscapingSlashes]
+        ) + Data([0x0a])
+        try unsigned.write(to: fixture.manifest)
+
+        XCTAssertThrowsError(
+            try BundledInstallContractVerifier.verify(
+                scriptURL: fixture.script,
+                manifestURL: fixture.manifest,
+                publicKeyPEM: fixture.publicKeyPEM
+            )
+        )
+    }
+
+    func testReferralCodeFileIsOwnerOnlyRegularAndContainsOnlyCode() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("referral-code-test-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: false)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let url = try ReferralCodeFile.create(code: validCode, directory: root)
+        var info = stat()
+        XCTAssertEqual(lstat(url.path, &info), 0)
+        XCTAssertEqual(info.st_mode & S_IFMT, S_IFREG)
+        XCTAssertEqual(info.st_mode & 0o777, 0o600)
+        XCTAssertEqual(try String(contentsOf: url, encoding: .utf8), validCode)
+    }
+
+    func testInstallerEnvironmentPassesOnlyReferralFilePath() throws {
+        let referralURL = URL(fileURLWithPath: "/tmp/referral-secret")
+        let environment = try CLIInstallRunner.installerEnvironment(
+            parentEnvironment: [
+                "MACPROVIDER_REFERRAL_CODE_FILE": "/tmp/attacker",
+                "MACPROVIDER_REFERRAL_CODE": validCode,
+            ],
+            installPort: nil,
+            pinnedVersion: nil,
+            referralCodeFile: referralURL
+        )
+
+        XCTAssertEqual(environment["MACPROVIDER_REFERRAL_CODE_FILE"], referralURL.path)
+        XCTAssertNil(environment["MACPROVIDER_REFERRAL_CODE"])
+        XCTAssertFalse(environment.values.contains(validCode))
+    }
+
+    private struct Fixture {
+        let root: URL
+        let script: URL
+        let manifest: URL
+        let publicKeyPEM: String
+
+        init(script data: Data) throws {
+            root = FileManager.default.temporaryDirectory
+                .appendingPathComponent("install-contract-test-\(UUID().uuidString)")
+            try FileManager.default.createDirectory(at: root, withIntermediateDirectories: false)
+            script = root.appendingPathComponent("install.sh")
+            manifest = root.appendingPathComponent("compatibility-set.json")
+            try data.write(to: script, options: .atomic)
+            let digest = SHA256.hash(data: data).map { String(format: "%02x", $0) }.joined()
+            let signingKey = P256.Signing.PrivateKey()
+            publicKeyPEM = signingKey.publicKey.pemRepresentation
+            let signed: [String: Any] = [
+                "artifact_binding": [:],
+                "compatibility_set_id": "Augustas11/macprovider:v1.8.41@" + String(repeating: "a", count: 40),
+                "components": [
+                    "catalog": [:],
+                    "coordinator_admission": [:],
+                    "launchd": [
+                        "activation": "local",
+                        "contract": "macprovider.launch-agent.v1",
+                        "install_contract": [
+                            "path": "compatibility-set-local/install.sh",
+                            "sha256": digest,
+                        ],
+                        "label": "live.streamvc.macprovider",
+                        "plist_template": [:],
+                    ],
+                    "malibu_app": [:],
+                    "provider_cli": [:],
+                    "updater_rollback": [:],
+                    "watchdog": [:],
+                ],
+                "release": [:],
+                "schema_version": "macprovider.compatibility-set.v1",
+                "transaction": [:],
+            ]
+            var signedBytes = try JSONSerialization.data(
+                withJSONObject: signed,
+                options: [.sortedKeys, .withoutEscapingSlashes]
+            )
+            signedBytes.append(0x0a)
+            let signature = try signingKey.signature(for: SHA256.hash(data: signedBytes))
+            let envelope: [String: Any] = [
+                "schema_version": "macprovider.compatibility-set-envelope.v1",
+                "signatures": [[
+                    "algorithm": "ecdsa-p256-sha256",
+                    "key_id": "macprovider-release-p256-v1",
+                    "signature": signature.derRepresentation.base64EncodedString(),
+                ]],
+                "signed": signed,
+            ]
+            var manifestData = try JSONSerialization.data(
+                withJSONObject: envelope,
+                options: [.sortedKeys, .withoutEscapingSlashes]
+            )
+            manifestData.append(0x0a)
+            try manifestData.write(to: manifest, options: .atomic)
+        }
+
+        func remove() {
+            try? FileManager.default.removeItem(at: root)
+        }
+    }
+}

--- a/phase3-binary/app/project.yml
+++ b/phase3-binary/app/project.yml
@@ -50,6 +50,7 @@ targets:
         CFBundleVersion: $(CURRENT_PROJECT_VERSION)
         LSMinimumSystemVersion: "14.0"
         LSUIElement: true                # menu bar only, no Dock icon
+        MalibuBundledReferralBootstrapV1: false
         NSHumanReadableCopyright: "Copyright © 2026 Malibu AI, Inc."
         NSAppTransportSecurity:
           NSAllowsLocalNetworking: true

--- a/phase3-binary/dist/install.sh
+++ b/phase3-binary/dist/install.sh
@@ -9,6 +9,13 @@
 
 set -euo pipefail
 
+# Malibu may provide a one-shot owner-only file containing a referral code.
+# Capture only the path, then remove it from the environment before any child
+# process is launched. The CLI validates and consumes the file; install.sh
+# never reads, logs, copies, or persists the code.
+REFERRAL_CODE_SOURCE_FILE="${MACPROVIDER_REFERRAL_CODE_FILE:-}"
+unset MACPROVIDER_REFERRAL_CODE_FILE
+
 GITHUB_REPO="${MACPROVIDER_GITHUB_REPO:-Augustas11/macprovider}"
 MACPROVIDER_MIN_SUPPORTED_VERSION="v1.7.11"
 MACPROVIDER_MIN_EMERGENCY_VERSION="v1.8.30"
@@ -5480,55 +5487,99 @@ read_config_donor_mode() {
   ' "$CONFIG_PATH"
 }
 
+publish_bootstrap_identity_for_rollback() {
+  [ -n "${STAGED_CONFIG_PATH:-}" ] && [ "$CONFIG_PATH" = "$STAGED_CONFIG_PATH" ] \
+    || return 0
+  [ -z "$(read_config_provider_token_line || true)" ] \
+    || die 70 "refusing to publish a bootstrap identity from a config that still contains a provider bearer"
+  # Publish only the tokenless provider principal. The CLI keeps the bearer in
+  # Keychain. Recovery moves this config aside and preserves its high-entropy
+  # principal, so an interrupted referral request retries against the same
+  # coordinator registration instead of generating a second identity.
+  assert_install_lock_ownership
+  mark_install_cutover_started
+  mkdir -p "$CONFIG_DIR"
+  bootstrap_config_temp="$LIVE_CONFIG_PATH.bootstrap.$$"
+  cp "$STAGED_CONFIG_PATH" "$bootstrap_config_temp" \
+    || die 70 "could not preserve the bootstrapped provider identity for rollback"
+  chmod 600 "$bootstrap_config_temp" 2>/dev/null || true
+  mv "$bootstrap_config_temp" "$LIVE_CONFIG_PATH" \
+    || die 70 "could not publish the bootstrapped provider identity for rollback"
+  if [ -f "$STAGED_PROVIDER_ID_PATH" ]; then
+    bootstrap_provider_id_temp="$LIVE_PROVIDER_ID_PATH.bootstrap.$$"
+    cp "$STAGED_PROVIDER_ID_PATH" "$bootstrap_provider_id_temp" \
+      || die 70 "could not preserve the bootstrapped provider identity for rollback"
+    chmod 600 "$bootstrap_provider_id_temp" 2>/dev/null || true
+    mv "$bootstrap_provider_id_temp" "$LIVE_PROVIDER_ID_PATH" \
+      || die 70 "could not publish the bootstrapped provider identity for rollback"
+  fi
+}
+
 ensure_provider_credentials() {
+  credential_already_present=0
   if [ -n "$(read_config_provider_token_line || true)" ]; then
     run_macprovider_cli_with_amfi_retry credentials import --config "$CONFIG_PATH" \
       || die 6 "provider credential migration into CLI Keychain failed"
     run_macprovider_cli_with_amfi_retry credentials verify --config "$CONFIG_PATH" \
       || die 6 "provider credential migration verification failed"
-    return 0
+    [ -n "${REFERRAL_CODE_SOURCE_FILE:-}" ] || return 0
+    credential_already_present=1
+  else
+    credential_verify_rc=0
+    run_macprovider_cli_with_amfi_retry credentials verify --config "$CONFIG_PATH" \
+      || credential_verify_rc=$?
+    case "$credential_verify_rc" in
+      0)
+        [ -n "${REFERRAL_CODE_SOURCE_FILE:-}" ] || return 0
+        credential_already_present=1
+        ;;
+      3) ;;
+      *) die 6 "existing CLI Keychain credential is unavailable or invalid; refusing unsafe bootstrap" ;;
+    esac
   fi
-  credential_verify_rc=0
-  run_macprovider_cli_with_amfi_retry credentials verify --config "$CONFIG_PATH" \
-    || credential_verify_rc=$?
-  case "$credential_verify_rc" in
-    0) return 0 ;;
-    3) ;;
-    *) die 6 "existing CLI Keychain credential is unavailable or invalid; refusing unsafe bootstrap" ;;
+  if [ "$credential_already_present" -eq 0 ]; then
+    provider_id="$(read_config_provider_id || true)"
+    case "$provider_id" in
+      mp-[0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f]) ;;
+      *) die 6 "tokenless credential bootstrap requires a fresh high-entropy mp-* provider ID; this existing predictable ID needs an operator-issued ownership credential" ;;
+    esac
+    log "Acquiring first-install provider credential before evidence admission."
+  else
+    log "Reconciling interrupted referral bootstrap with the existing CLI-owned credential."
+  fi
+  referral_onboarding_dir="$CONFIG_DIR/onboarding"
+  mkdir -p "$referral_onboarding_dir" \
+    || die 70 "could not create durable CLI onboarding state"
+  chmod 700 "$referral_onboarding_dir" \
+    || die 70 "could not protect durable CLI onboarding state"
+  bootstrap_auth_args=(bootstrap-auth --timeout-seconds 30 --config "$CONFIG_PATH")
+  if [ -n "${REFERRAL_CODE_SOURCE_FILE:-}" ]; then
+    bootstrap_auth_args+=(--referral-code-file "$REFERRAL_CODE_SOURCE_FILE")
+    # The journal and Keychain credential are bound to this provider ID. Make
+    # the tokenless identity rollback-durable before the request can redeem the
+    # referral and persist a bearer, including abrupt response-loss exits.
+    if [ "$credential_already_present" -eq 0 ]; then
+      publish_bootstrap_identity_for_rollback
+    fi
+  fi
+  bootstrap_auth_rc=0
+  run_macprovider_cli_with_amfi_retry "${bootstrap_auth_args[@]}" || bootstrap_auth_rc=$?
+  case "$bootstrap_auth_rc" in
+    0) ;;
+    20|21|22|23|24|25|26|27)
+      # Stable referral outcomes are part of the Malibu/installer/CLI
+      # capability contract. Preserve them through transaction rollback so
+      # Malibu can render a truthful, recoverable state without log scraping.
+      exit "$bootstrap_auth_rc"
+      ;;
+    *) die 6 "provider credential bootstrap failed before evidence admission" ;;
   esac
-  provider_id="$(read_config_provider_id || true)"
-  case "$provider_id" in
-    mp-[0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f]) ;;
-    *) die 6 "tokenless credential bootstrap requires a fresh high-entropy mp-* provider ID; this existing predictable ID needs an operator-issued ownership credential" ;;
-  esac
-  log "Acquiring first-install provider credential before evidence admission."
-  run_macprovider_cli_with_amfi_retry bootstrap-auth --timeout-seconds 30 --config "$CONFIG_PATH" \
-    || die 6 "provider credential bootstrap failed before evidence admission"
   run_macprovider_cli_with_amfi_retry credentials verify --config "$CONFIG_PATH" \
     || die 6 "provider credential bootstrap completed without restart-safe CLI custody"
-  if [ -n "${STAGED_CONFIG_PATH:-}" ] && [ "$CONFIG_PATH" = "$STAGED_CONFIG_PATH" ]; then
-    # Coordinator bootstrap creates a durable Keychain principal. Publish its
-    # provider ID and tokenless config into the protected live transaction
-    # immediately so #547's rollback helper preserves the identity even if
-    # later evidence or startup admission fails. The incumbent process remains
-    # running until cutover.
-    assert_install_lock_ownership
-    mark_install_cutover_started
-    mkdir -p "$CONFIG_DIR"
-    bootstrap_config_temp="$LIVE_CONFIG_PATH.bootstrap.$$"
-    cp "$STAGED_CONFIG_PATH" "$bootstrap_config_temp" \
-      || die 70 "could not preserve the bootstrapped provider identity for rollback"
-    chmod 600 "$bootstrap_config_temp" 2>/dev/null || true
-    mv "$bootstrap_config_temp" "$LIVE_CONFIG_PATH" \
-      || die 70 "could not publish the bootstrapped provider identity for rollback"
-    if [ -f "$STAGED_PROVIDER_ID_PATH" ]; then
-      bootstrap_provider_id_temp="$LIVE_PROVIDER_ID_PATH.bootstrap.$$"
-      cp "$STAGED_PROVIDER_ID_PATH" "$bootstrap_provider_id_temp" \
-        || die 70 "could not preserve the bootstrapped provider identity for rollback"
-      chmod 600 "$bootstrap_provider_id_temp" 2>/dev/null || true
-      mv "$bootstrap_provider_id_temp" "$LIVE_PROVIDER_ID_PATH" \
-        || die 70 "could not publish the bootstrapped provider identity for rollback"
-    fi
+  if [ -z "${REFERRAL_CODE_SOURCE_FILE:-}" ]; then
+    # Non-referral bootstrap cannot redeem admission before it returns, so keep
+    # the existing post-success publication boundary.
+    publish_bootstrap_identity_for_rollback
   fi
 }
 

--- a/phase3-binary/dist/test/install_fresh_evidence.test.sh
+++ b/phase3-binary/dist/test/install_fresh_evidence.test.sh
@@ -45,22 +45,36 @@ run_case() {
   if [ "$mode" = "receipt-probe-fails" ]; then
     : > "$root/prefetch-receipt.json"
   fi
+  case "$mode" in
+    referral-success|referral-expired|existing-referral-retry|existing-referral-import)
+      printf '%s' 'MAL1-S-key-issuer-AAAAAAAAAAAAAAAAAAAAAAAAAA' > "$root/referral-code"
+      chmod 600 "$root/referral-code"
+      ;;
+  esac
   cat > "$root/config/config.yaml" <<EOF
 model: "seed"
 provider_id: "$provider_id"
 coordinator_url: "wss://coordinator.example/ws/provider"
 EOF
+  if [ "$mode" = "existing-referral-import" ]; then
+    printf '%s\n' 'provider_token: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa' >> "$root/config/config.yaml"
+  fi
   case "$mode" in
-    existing-mp|existing-legacy) : > "$root/credential" ;;
+    existing-mp|existing-legacy|existing-referral-retry) : > "$root/credential" ;;
   esac
   set +e
   CASE_MODE="$mode" CASE_ROOT="$root" bash -c '
     set -euo pipefail
     INSTALL_DIR="$CASE_ROOT/install"
+    CONFIG_DIR="$CASE_ROOT/config"
     CONFIG_PATH="$CASE_ROOT/config/config.yaml"
     DRY_RUN=0
     SKIP_PROVIDER_START=0
     model="seed"
+    REFERRAL_CODE_SOURCE_FILE=""
+    case "$CASE_MODE" in
+      referral-success|referral-expired|existing-referral-retry|existing-referral-import) REFERRAL_CODE_SOURCE_FILE="$CASE_ROOT/referral-code" ;;
+    esac
     if [ "$CASE_MODE" = "receipt-probe-fails" ]; then
       AUTOTUNE_UPGRADE_CANDIDATE_MODEL_ID="namespace/seed"
       AUTOTUNE_PREFETCH_RECEIPT_PATH="$CASE_ROOT/prefetch-receipt.json"
@@ -68,14 +82,27 @@ EOF
     log() { :; }
     die() { exit "$1"; }
     prompt_yes_no() { return 0; }
+    publish_bootstrap_identity_for_rollback() {
+      printf "publish-bootstrap-identity\n" >> "$CASE_ROOT/calls"
+    }
     run_macprovider_cli_with_amfi_retry() {
       printf "%s\n" "$*" >> "$CASE_ROOT/calls"
       case "$1" in
         bootstrap-auth)
           [ "$CASE_MODE" != "bootstrap-fails" ] || return 9
+          [ "$CASE_MODE" != "referral-expired" ] || return 22
+          if [ "$CASE_MODE" = "existing-referral-retry" ] || [ "$CASE_MODE" = "existing-referral-import" ]; then
+            : > "$CASE_ROOT/reconciled"
+            rm -f "$CASE_ROOT/referral-code"
+          fi
           : > "$CASE_ROOT/credential"
           ;;
         credentials)
+          if [ "$2" = "import" ]; then
+            [ "$CASE_MODE" = "existing-referral-import" ] || return 12
+            : > "$CASE_ROOT/credential"
+            return 0
+          fi
           [ "$2" = "verify" ] || return 12
           [ "$CASE_MODE" != "store-unavailable" ] || return 17
           [ -f "$CASE_ROOT/credential" ] || return 3
@@ -101,7 +128,7 @@ EOF
   rc=$?
   set -e
   case "$mode" in
-    success)
+    success|referral-success)
       [ "$rc" -eq 0 ]
       awk '
         /--no-submit-hardware-evidence/ { tune=NR }
@@ -111,6 +138,22 @@ EOF
         /service-start/ { service=NR }
         END { exit !(tune < bootstrap && bootstrap < verify && verify < evidence && evidence < service) }
       ' "$root/calls"
+      if [ "$mode" = "referral-success" ]; then
+        grep -F -- "bootstrap-auth --timeout-seconds 30 --config $root/config/config.yaml --referral-code-file $root/referral-code" "$root/calls" >/dev/null
+        awk '
+          /publish-bootstrap-identity/ { publish=NR }
+          /bootstrap-auth/ { bootstrap=NR }
+          END { exit !(publish < bootstrap) }
+        ' "$root/calls"
+      fi
+      ;;
+    referral-expired)
+      [ "$rc" -eq 22 ]
+      grep -F -- "--referral-code-file $root/referral-code" "$root/calls" >/dev/null
+      if grep -F "service-start" "$root/calls" >/dev/null; then
+        echo "$mode started service after referral rejection" >&2
+        exit 1
+      fi
       ;;
     bootstrap-fails|evidence-fails|predictable-id)
       [ "$rc" -ne 0 ]
@@ -126,6 +169,29 @@ EOF
         echo "$mode bootstrapped over an existing CLI-Keychain credential" >&2
         exit 1
       fi
+      ;;
+    existing-referral-retry)
+      [ "$rc" -eq 0 ]
+      grep -F "credentials verify" "$root/calls" >/dev/null
+      grep -F -- "bootstrap-auth --timeout-seconds 30 --config $root/config/config.yaml --referral-code-file $root/referral-code" "$root/calls" >/dev/null
+      if grep -F "publish-bootstrap-identity" "$root/calls" >/dev/null; then
+        echo "$mode republished an identity that was already durable" >&2
+        exit 1
+      fi
+      [ -f "$root/reconciled" ]
+      [ ! -e "$root/referral-code" ]
+      ;;
+    existing-referral-import)
+      [ "$rc" -eq 0 ]
+      grep -F "credentials import" "$root/calls" >/dev/null
+      grep -F "credentials verify" "$root/calls" >/dev/null
+      grep -F -- "bootstrap-auth --timeout-seconds 30 --config $root/config/config.yaml --referral-code-file $root/referral-code" "$root/calls" >/dev/null
+      if grep -F "publish-bootstrap-identity" "$root/calls" >/dev/null; then
+        echo "$mode published a staged config that still contains a legacy bearer" >&2
+        exit 1
+      fi
+      [ -f "$root/reconciled" ]
+      [ ! -e "$root/referral-code" ]
       ;;
     store-unavailable)
       [ "$rc" -ne 0 ]
@@ -150,11 +216,15 @@ EOF
 }
 
 run_case success
+run_case referral-success
+run_case referral-expired
 run_case bootstrap-fails
 run_case evidence-fails
 run_case predictable-id
 run_case existing-mp
 run_case existing-legacy
+run_case existing-referral-retry
+run_case existing-referral-import
 run_case store-unavailable
 run_case receipt-probe-fails
 

--- a/phase3-binary/dist/test/install_referral_handoff.test.sh
+++ b/phase3-binary/dist/test/install_referral_handoff.test.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+installer="$root/phase3-binary/dist/install.sh"
+
+python3 - "$installer" <<'PY'
+import pathlib
+import sys
+
+source = pathlib.Path(sys.argv[1]).read_text(encoding="utf-8")
+
+capture = 'REFERRAL_CODE_SOURCE_FILE="${MACPROVIDER_REFERRAL_CODE_FILE:-}"'
+unset = "unset MACPROVIDER_REFERRAL_CODE_FILE"
+first_child = 'GITHUB_REPO="${MACPROVIDER_GITHUB_REPO:-Augustas11/macprovider}"'
+assert capture in source
+assert unset in source
+assert source.index(capture) < source.index(unset) < source.index(first_child)
+
+assert 'bootstrap_auth_args+=(--referral-code-file "$REFERRAL_CODE_SOURCE_FILE")' in source
+assert 'run_macprovider_cli_with_amfi_retry "${bootstrap_auth_args[@]}"' in source
+assert '20|21|22|23|24|25|26|27)' in source
+publish = "publish_bootstrap_identity_for_rollback"
+bootstrap = 'run_macprovider_cli_with_amfi_retry "${bootstrap_auth_args[@]}"'
+ensure_start = source.index("ensure_provider_credentials()")
+ensure_end = source.index("submit_required_hardware_evidence()", ensure_start)
+ensure_source = source[ensure_start:ensure_end]
+assert ensure_source.index(publish) < ensure_source.index(bootstrap)
+
+# The path may be passed to the CLI, but install.sh must never open, print,
+# copy, hash, or persist the referral file itself.
+for forbidden in (
+    'cat "$REFERRAL_CODE_SOURCE_FILE"',
+    'cp "$REFERRAL_CODE_SOURCE_FILE"',
+    'log "$REFERRAL_CODE_SOURCE_FILE"',
+    'printf "$REFERRAL_CODE_SOURCE_FILE"',
+):
+    assert forbidden not in source, forbidden
+PY
+
+echo "install_referral_handoff: PASS"

--- a/specs/SPEC-003-open-onboarding.md
+++ b/specs/SPEC-003-open-onboarding.md
@@ -684,9 +684,12 @@ Old binaries that cannot parse `assigned_provider_token` will silently drop the 
 The bootstrap pipe `curl https://get.streamvc.live/install.sh | bash` continues
 to work without a referral input and obtains a credential through the CLI-owned
 WS bootstrap. SPEC-034's optional referral integration may modify `install.sh`
-only to consume `MACPROVIDER_REFERRAL_CODE`, copy it into the owner-only 0600
-onboarding journal, unset the environment value, and pass the journal path to
-`bootstrap-auth --referral-code-file`. It MUST NOT write the code to
+only to capture and unset the path supplied as
+`MACPROVIDER_REFERRAL_CODE_FILE`, then pass that owner-only source path to
+`bootstrap-auth --referral-code-file`. The installer MUST NOT read, copy, log, or
+persist the code. The CLI's owner-only durable onboarding journal stores only the
+provider/receipt/code digests, attempt identity, and typed state; it never stores
+plaintext referral input. Neither installer nor CLI may write the code to
 `config.yaml`, logs, argv, lifecycle status, or Malibu storage. With the variable
 absent, installer behavior remains the ordinary single-shell-pipe flow.
 

--- a/specs/SPEC-025-native-mac-app.md
+++ b/specs/SPEC-025-native-mac-app.md
@@ -280,40 +280,53 @@ From reading `phase3-binary/`:
    register / autotune / spawn step. The stages are:
    - **Short-circuit:** if a local provider is already healthy, skip the installer
      and just attach (`:79-87,144-163`).
-   - **Run the bundled `install.sh`** (`runCLIInstall`, `:117-125`). The installer
+   - **Run the bundled `install.sh`** (`runCLIInstall`). The installer
      is bundled at `Contents/Resources/install.sh` (copied from
-     `phase3-binary/dist/install.sh` at build time, `project.yml:72-75`), run via
-     `/bin/bash <temp-copy 0700>` with **no CLI args**. Current
+     `phase3-binary/dist/install.sh` at build time). Malibu first authenticates
+     the exact regular-file bytes against the signed compatibility manifest,
+     then supplies those already-authenticated bytes to `/bin/bash -s --` over
+     stdin with **no script-path or installer CLI args**. Current
      `CLIInstallRunner.installerEnvironment` does **not** inherit the parent
      environment: it constructs a sanitized allowlist containing fixed
      `PATH`/`HOME`/`TMPDIR`/`LC_ALL`, `MACPROVIDER_NO_PROMPT=1`, and only its
-     validated port/version values (`CLIInstallRunner.swift:92-119`).
+     validated port/version values.
 
      Referral onboarding extends that exact boundary as
      `CLIInstallRunner.run(referralCode:)`. After bounded syntax validation it
-     adds one explicit `MACPROVIDER_REFERRAL_CODE` value to the sanitized install
-     environment. `install.sh` immediately writes the value to the CLI-owned 0600
-     journal `~/.config/macprovider/onboarding/referral-attempt-v1.json`, unsets
-     it, and invokes `macprovider-cli bootstrap-auth
-     --referral-code-file <journal>`. The code never appears in argv, config,
-     logs, lifecycle status, or Malibu persistence. The CLI sends it only on the
-     bootstrap initial/proof frames, persists the returned bearer to CLI Keychain,
-     then atomically retires the plaintext journal before exit 0. That exit is the
-     non-secret acknowledgement Malibu observes; the bearer never crosses back.
+     creates an owner-only 0600, single-link, no-ACL regular source file with an
+     unpredictable name and adds only its path as
+     `MACPROVIDER_REFERRAL_CODE_FILE` to the sanitized install environment.
+     `install.sh` captures and unsets that path before launching any child; it
+     never reads, logs, copies, or persists the code. It invokes
+     `macprovider-cli bootstrap-auth --referral-code-file <source>`, and the CLI
+     reopens the source with no-follow identity checks before reading it. The
+     durable CLI journal
+     `~/.config/macprovider/onboarding/referral-attempt-v1.json` stores only the
+     provider ID, receipt-key digest, referral-code digest, attempt ID, and typed
+     state; plaintext referral material is never journaled. The CLI sends the
+     code only on the bootstrap initial/proof frames, persists the returned bearer
+     to CLI Keychain, marks the digest journal committed, and removes the source
+     file only after reopening it no-follow and proving the full stat identity and
+     byte digest are unchanged. Malibu also best-effort removes its source file
+     after installer exit. Exit 0 is the non-secret acknowledgement Malibu
+     observes; the bearer never crosses back.
 
      Compatibility-set manifest v1 is exact-key and has no capability field; it
      MUST NOT be extended in place. For the fresh bundled path, the replacement
      Malibu build enables this UI only for its compiled-in v1 handoff. Before
      execution it hashes the exact `Contents/Resources/install.sh` regular-file
-     bytes it is about to copy/run and requires equality with the signed
+     bytes it is about to supply over stdin and requires equality with the signed
      manifest's `components.launchd.install_contract.sha256`, whose declared
      member is `compatibility-set-local/install.sh`. A missing, unreadable,
      symlinked, or mismatched top-level resource renders referral onboarding
-     unavailable and executes nothing. For an existing installation, Malibu
-     requires `referral_bootstrap_v1` in the installed CLI's versioned local
-     status contract. Otherwise it renders referral onboarding unavailable while
-     retaining ordinary attach/monitor behavior. No marketing-version equality
-     check substitutes for either gate.
+     unavailable and executes nothing. Because Malibu executes that bundled
+     installer for both fresh and existing-install onboarding, the compiled
+     `MalibuBundledReferralBootstrapV1` gate MUST be true on every referral path.
+     An existing installation additionally requires `referral_bootstrap_v1` in
+     the installed CLI's versioned local status contract. Either missing gate
+     renders referral onboarding unavailable while retaining ordinary
+     attach/monitor behavior. No marketing-version equality check substitutes for
+     either gate.
      `install.sh` performs the register + autotune (`autotune --recommend`) + model
      download + **launchd provider-service + watchdog install**; the app only surfaces a progress hint
      by scraping `ps` for the autotune stage (`:110-149`). A non-zero installer exit

--- a/specs/SPEC-026-browserless-provider-onboarding.md
+++ b/specs/SPEC-026-browserless-provider-onboarding.md
@@ -1283,31 +1283,40 @@ input. The concrete v1 handoff is:
    result with the signed
    `components.launchd.install_contract.sha256` value for
    `compatibility-set-local/install.sh`. Missing, symlinked, unreadable, or
-   mismatched resources fail to `unavailable` before execution. For an existing CLI, Malibu
-   requires `referral_bootstrap_v1` in the CLI-authored local status contract.
-   Otherwise it renders the input unavailable; it never infers support from a
+   mismatched resources fail to `unavailable` before execution. The compiled
+   `MalibuBundledReferralBootstrapV1` gate applies to every referral path because
+   Malibu executes the bundled installer even when a provider is already
+   installed. For an existing CLI, Malibu additionally requires
+   `referral_bootstrap_v1` in the CLI-authored local status contract. Either
+   missing gate renders the input unavailable; support is never inferred from a
    marketing version.
 2. `CLIInstallRunner.run(referralCode:)` validates at most 256 UTF-8 bytes with
-   no control characters and adds only `MACPROVIDER_REFERRAL_CODE` to its existing
-   sanitized allowlist. It does not inherit the App environment.
-3. `install.sh` writes the code to the CLI-owned 0600 journal
-   `~/.config/macprovider/onboarding/referral-attempt-v1.json`, unsets the
-   environment value, and calls the installed `macprovider-cli bootstrap-auth
-   --referral-code-file <journal>`.
-4. `bootstrap-auth` validates the owner/mode and bounded code, reuses the durable
-   provider/receipt identity, and sends the exact code in both signed bootstrap
-   stages. It persists the response bearer to CLI Keychain before atomically
-   retiring the plaintext journal and exiting 0.
+   no control characters, writes the code to an unpredictable owner-only 0600,
+   single-link, no-ACL regular source file, and adds only that file's path as
+   `MACPROVIDER_REFERRAL_CODE_FILE` to its existing sanitized allowlist. It does
+   not inherit the App environment.
+3. `install.sh` captures and unsets the source-file path before launching any
+   child. It never reads, logs, copies, or persists the code, and calls the
+   installed `macprovider-cli bootstrap-auth --referral-code-file <source>`.
+4. `bootstrap-auth` opens the source with no-follow owner/mode/link/ACL and
+   device/inode stability checks, reuses the durable provider/receipt identity,
+   and sends the exact code in both signed bootstrap stages. Its owner-only
+   `~/.config/macprovider/onboarding/referral-attempt-v1.json` journal contains
+   only provider/receipt/code digests, attempt ID, and typed state. It persists
+   the response bearer to CLI Keychain, marks that digest journal committed,
+   removes the source only after its full stat identity and byte digest still
+   match the original read, and exits 0.
 5. The installer exit and versioned local status are Malibu's acknowledgement;
    no response contains the bearer. Existing installs advertise
    `referral_bootstrap_v1` in local status before Malibu exposes referral input;
    `referral_status_v1` independently gates the sanitized referral dashboard.
 
-If the process or host restarts, the CLI reuses the journal and exact receipt
-key. If the coordinator committed but the journal was already retired, exact-key
-same-campaign recovery may omit the code and replace only its own unused
-bootstrap bearer. No raw code or bearer is written to Malibu storage, config,
-lifecycle state, or logs.
+If the process or host restarts, the CLI reuses the digest journal, exact receipt
+key, and a newly supplied source file containing the same code. If the
+coordinator committed but the response was lost, the same binding reconciles the
+persisted credential or the coordinator replaces only that exact bootstrap
+identity's unused bearer. No raw code or bearer is written to Malibu storage,
+config, the durable journal, lifecycle state, or logs.
 
 A coordinator rejection maps to a typed invalid, expired, revoked, exhausted,
 conflict, rate-limited, unavailable, or retryable result. The CLI reuses its
@@ -2148,15 +2157,17 @@ slower payout release. Not required for this spec to ship.
       id, a port, and readable launchd evidence (`install_manifest.json` /
       `live.streamvc.macprovider.plist`), skip the installer and attach
       (`CLIInstallRunner.swift:89-103`; `LaunchProviderController.swift:79-87`).
-   b. **Run the bundled `install.sh`** (`.runningCLIInstall`, `:117-125`) via
-      `/bin/bash <temp-copy 0700>` with **no CLI args**, one script-path arg.
+   b. **Run the bundled `install.sh`** (`.runningCLIInstall`) by authenticating
+      the exact bundled regular-file bytes and supplying those same bytes to
+      `/bin/bash -s --` over stdin with **no script-path or installer CLI args**.
       **Environment is sanitized (reconciled v0.25 to current source):**
       `CLIInstallRunner.installerEnvironment` constructs a new allowlist with
       fixed `PATH`, validated `HOME`/`TMPDIR`, `LC_ALL`,
       `MACPROVIDER_NO_PROMPT=1`, and its validated port/version inputs; it does
-      not inherit the parent process environment
-      (`CLIInstallRunner.swift:92-119`). SPEC-034 adds only the validated
-      one-shot `MACPROVIDER_REFERRAL_CODE` value to that allowlist. **`install.sh` runs the
+      not inherit the parent process environment. SPEC-034 adds only the path to
+      the validated one-shot owner-only referral source file as
+      `MACPROVIDER_REFERRAL_CODE_FILE`; the raw code is not an environment value.
+      **`install.sh` runs the
       CLI-track onboarding:** it generates a fresh `mp-<32hex>` principal and runs
       `bootstrap-auth`, which acquires the `provider_token` via the coordinator's
       **tokenless WS admission** handshake (NOT the App-track `/v1/providers/register`,

--- a/specs/SPEC-034-referral-gated-prebeta.md
+++ b/specs/SPEC-034-referral-gated-prebeta.md
@@ -216,16 +216,19 @@ grant and any number of idempotent observations.
 
 Malibu passes referral input only through SPEC-025/026's concrete
 `referral_bootstrap_v1` contract: sanitized one-shot install environment,
-CLI-owned 0600 attempt journal, and `bootstrap-auth --referral-code-file`. For a
-fresh bundled install, Malibu relies on its compiled-in v1 install handoff and
+CLI-owned 0600 digest-only attempt journal, and
+`bootstrap-auth --referral-code-file`. For a fresh bundled install, Malibu relies
+on its compiled-in v1 install handoff and
 hashes the exact regular-file `Contents/Resources/install.sh` bytes it is about
 to execute. Those bytes MUST equal the existing signed manifest's
 `components.launchd.install_contract.sha256` for
 `compatibility-set-local/install.sh`; missing, symlinked, unreadable, or
 mismatched resources fail unavailable before execution. Compatibility-set v1
-has no capability field and MUST NOT be extended in place. For an existing installed CLI, Malibu
-requires `referral_bootstrap_v1` in the CLI-authored local status contract before
-offering input. It invokes later typed referral actions over an owner-only local
+has no capability field and MUST NOT be extended in place. Because Malibu always
+executes that bundled installer, its compiled handoff gate applies to existing
+installs as well. An existing installed CLI additionally requires
+`referral_bootstrap_v1` in the CLI-authored local status contract before offering
+input. It invokes later typed referral actions over an owner-only local
 interface. The CLI owns all authenticated coordinator calls and exposes only a
 sanitized owner-only control-socket projection under `referral_status_v1`.
 Typed challenge/verify/cancel/reopen actions additionally require


### PR DESCRIPTION
## Outcome

Replaces #575 with referral-code onboarding on the post-#618 lifecycle: Malibu collects and validates input, the signed installer invokes macprovider-cli bootstrap-auth, the CLI owns registration, identity, Keychain credentials, and provider lifecycle, and Malibu attaches to the launchd-managed provider.

Production referral onboarding remains forced off until the signed referral-capable payload and physical two-provider journey pass.

## Why #575 cannot be rebased

The old branch restores deleted RegisterClient behavior, routes provider bearer material through Malibu/--token-fd, and lets Malibu launch or supervise a second provider child. Those are lifecycle regressions, not merge conflicts. This branch was rebuilt from current main after exact #618 source commit 90f4c713 was known.

## Architecture

- Malibu accepts a raw code or canonical HTTPS join link and passes only a one-shot owner-only referral file path to the installer.
- Malibu verifies the signed compatibility envelope and exact installer digest, then executes those verified bytes through bash stdin without reopening a mutable script path.
- Referral input is exposed only when the bundled signed handoff is enabled; existing installs additionally require authenticated referral_bootstrap_v1 from the launchd/live-code-validated CLI. Marketing versions remain independent.
- CLI sends the referral during tokenless bootstrap and persists the resulting bearer in CLI-owned Keychain storage before adoption.
- A durable digest-only attempt journal binds provider ID, bootstrap receipt key, and referral digest for idempotent response-loss/restart recovery.
- Installer preserves tokenless provider identity before redemption and never publishes a config containing a bearer.
- Malibu never receives a bearer or launches a provider process; it verifies and attaches to launchd.
- Source retirement reopens no-follow and requires the original full stat identity and raw SHA-256, preserving changed input.

## Exact dependency

- Base: main at e398b4cb8cbd090c6ba8aec20201e7cc369d7ebe (#628 merged after #621, #573, #574, and #576).
- Head: d413bf9cd9f196ca601608fdf1564c7e50e155f7.
- This PR is layer 5, the replacement #575 client foundation.
- #626 is layer 6 and must be restacked onto main only after this PR squash-merges.

No obsolete #575 or #578 client commits are included.

## Verification on the exact restacked head

- swift test --parallel: 1,398 tests passed.
- Malibu xcodebuild: 188 tests passed.
- All phase3-binary/dist/test installer, rollback, watchdog, and uninstall regressions passed.
- git diff --check passed; worktree clean.
- Independent code, architecture/spec, and security reviews: C0/H0/M0/L0.
- GitHub CI must pass again on exact head before merge.

## Activation gate

MalibuBundledReferralBootstrapV1 and coordinator production referral flags remain disabled. Not yet performed: signed/notarized candidate assembly and physical referral input through CLI registration, buyer-serving, authoritative invite award, second-provider redemption, and exactly-once X bonus. Activation remains a separate PR only after that evidence passes.

Supersedes #575.