### PR TITLE
Preserve hardware admission under least privilege

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,12 +18,12 @@ verify-autotune-catalog:
 test-coordinator:
 	cd phase4-coordinator && go test ./...
 
-# SPEC-017 Step 1 — Postgres-dependent integration tests
-# (AC-9 / AC-10 / AC-19 / AC-20). Tagged with `integration` so
+# SPEC-017 Step 1 and provider-onboarding Postgres integration tests.
+# Tagged with `integration` so
 # `make test-coordinator` does NOT require a Docker daemon.
 # CI runs this as a separate job that provides the daemon.
 test-coordinator-integration:
-	cd phase4-coordinator && go test -tags=integration -timeout 5m ./internal/stats/... ./cmd/coordinator/...
+	cd phase4-coordinator && go test -tags=integration -timeout 5m ./internal/stats/... ./internal/onboarding/... ./cmd/coordinator/...
 
 # SPEC-017 AC-16 — golangci-lint with depguard + forbidigo.
 # Pinned version so the target is hermetic on a fresh checkout.

--- a/phase4-coordinator/internal/onboarding/hardware_evidence.go
+++ b/phase4-coordinator/internal/onboarding/hardware_evidence.go
@@ -149,14 +149,14 @@ INSERT INTO provider_hardware_profiles (
     $1, $2, $3, $4, $5, $6, 'cli_hello', $7
 )
 ON CONFLICT (provider_id) DO UPDATE
-   SET chip = EXCLUDED.chip,
-       chip_normalized = EXCLUDED.chip_normalized,
-       unified_memory_gb = EXCLUDED.unified_memory_gb,
-       macos_version = EXCLUDED.macos_version,
-       app_version = EXCLUDED.app_version,
-       source = EXCLUDED.source,
-       last_reported_at = EXCLUDED.last_reported_at
- WHERE provider_hardware_profiles.last_reported_at <= EXCLUDED.last_reported_at`,
+   SET chip = $2,
+       chip_normalized = $3,
+       unified_memory_gb = $4,
+       macos_version = $5,
+       app_version = $6,
+       source = 'cli_hello',
+       last_reported_at = $7
+ WHERE provider_hardware_profiles.last_reported_at <= $7`,
 		providerID, chip, normalized, memoryGB, macosVersion, appVersion, generatedAt.UTC(),
 	); err != nil {
 		return HardwareEvidenceJobRecord{}, err

--- a/phase4-coordinator/internal/onboarding/store_pg.go
+++ b/phase4-coordinator/internal/onboarding/store_pg.go
@@ -452,14 +452,14 @@ INSERT INTO provider_hardware_profiles (
     $1, $2, $3, $4, $5, $6, 'app_register', $7
 )
 ON CONFLICT (provider_id) DO UPDATE
-   SET chip = EXCLUDED.chip,
-       chip_normalized = EXCLUDED.chip_normalized,
-       unified_memory_gb = EXCLUDED.unified_memory_gb,
-       macos_version = EXCLUDED.macos_version,
-       app_version = EXCLUDED.app_version,
-       source = EXCLUDED.source,
-       last_reported_at = EXCLUDED.last_reported_at
- WHERE provider_hardware_profiles.last_reported_at <= EXCLUDED.last_reported_at`,
+   SET chip = $2,
+       chip_normalized = $3,
+       unified_memory_gb = $4,
+       macos_version = $5,
+       app_version = $6,
+       source = 'app_register',
+       last_reported_at = $7
+ WHERE provider_hardware_profiles.last_reported_at <= $7`,
 		providerID, chip, normalized, memoryGB, macosVersion, appVersion, observedAt.UTC(),
 	)
 	return err

--- a/phase4-coordinator/internal/onboarding/store_pg_attempt_integration_test.go
+++ b/phase4-coordinator/internal/onboarding/store_pg_attempt_integration_test.go
@@ -7,6 +7,8 @@ import (
 	"crypto/ed25519"
 	"crypto/rand"
 	"database/sql"
+	"net/url"
+	"strings"
 	"testing"
 	"time"
 
@@ -78,5 +80,121 @@ func TestProviderRegistrationPreparedSurvivesNoncePrune(t *testing.T) {
 	}
 	if missing, err := store.ProviderRegistrationPrepared(ctx, "provider-missing", "nonce-z", attemptTS); err != nil || missing {
 		t.Fatalf("missing attempt prepared=%v err=%v", missing, err)
+	}
+}
+
+func TestProviderHardwareUpsertsRespectColumnLimitedGrants(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 90*time.Second)
+	defer cancel()
+	container, err := tcpg.Run(ctx, referralAttemptPGImage,
+		tcpg.WithDatabase("hardware_upsert"),
+		tcpg.WithUsername("postgres"),
+		tcpg.WithPassword(referralAttemptPGPass),
+		tc.WithWaitStrategy(wait.ForLog("database system is ready to accept connections").WithOccurrence(2).WithStartupTimeout(60*time.Second)),
+	)
+	if err != nil {
+		t.Fatalf("start postgres: %v", err)
+	}
+	t.Cleanup(func() {
+		cleanup, cleanupCancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cleanupCancel()
+		_ = container.Terminate(cleanup)
+	})
+	adminDSN, err := container.ConnectionString(ctx, "sslmode=disable")
+	if err != nil {
+		t.Fatal(err)
+	}
+	adminDB, err := sql.Open("postgres", adminDSN)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = adminDB.Close() })
+	if err := statsmigrations.Apply(ctx, adminDB); err != nil {
+		t.Fatalf("apply migrations: %v", err)
+	}
+
+	const onboardingPassword = "hardware-upsert-test-password"
+	if _, err := adminDB.ExecContext(ctx, `ALTER ROLE provider_onboarding PASSWORD '`+onboardingPassword+`'`); err != nil {
+		t.Fatalf("set provider_onboarding password: %v", err)
+	}
+	onboardingURL, err := url.Parse(adminDSN)
+	if err != nil {
+		t.Fatalf("parse admin DSN: %v", err)
+	}
+	onboardingURL.User = url.UserPassword("provider_onboarding", onboardingPassword)
+	onboardingDB, err := sql.Open("postgres", onboardingURL.String())
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = onboardingDB.Close() })
+	if err := onboardingDB.PingContext(ctx); err != nil {
+		t.Fatalf("connect as provider_onboarding: %v", err)
+	}
+	store := &PGStore{db: onboardingDB}
+
+	observedAt := time.Now().UTC().Truncate(time.Second)
+	if err := store.UpsertProviderHardwareProfile(ctx, "provider-app", HardwareSummary{
+		Chip:            "Apple M5",
+		UnifiedMemoryGB: 32,
+		MacOSVersion:    "26.5",
+		AppVersion:      "1.8.42",
+	}, observedAt); err != nil {
+		t.Fatalf("initial app-track hardware upsert: %v", err)
+	}
+	if err := store.UpsertProviderHardwareProfile(ctx, "provider-app", HardwareSummary{
+		Chip:            "Apple M5",
+		UnifiedMemoryGB: 32,
+		MacOSVersion:    "26.5.1",
+		AppVersion:      "1.8.43",
+	}, observedAt.Add(time.Second)); err != nil {
+		t.Fatalf("conflicting app-track hardware upsert: %v", err)
+	}
+
+	if err := store.UpsertProviderHardwareProfile(ctx, "provider-cli", HardwareSummary{
+		Chip:            "Apple M5",
+		UnifiedMemoryGB: 32,
+		MacOSVersion:    "26.5",
+		AppVersion:      "1.8.42",
+	}, observedAt.Add(-time.Second)); err != nil {
+		t.Fatalf("seed CLI hardware profile: %v", err)
+	}
+	evidence := HardwareEvidenceRequest{
+		SchemaVersion:          hardwareEvidenceSchemaVersion,
+		ProviderID:             "provider-cli",
+		GeneratedAt:            observedAt.Format(time.RFC3339),
+		CandidateCatalogSHA256: "catalog-sha",
+		RecommendedModel:       "model-a",
+		Hardware: HardwareEvidenceHardware{
+			Chip:                 "Apple M5",
+			MemoryGB:             32,
+			BandwidthTier:        "C",
+			Detected:             true,
+			OSVersion:            "26.5",
+			BinaryVersion:        "1.8.42",
+			HardwareIdentityHash: "hardware-hash",
+		},
+		Benchmarks: []HardwareEvidenceBenchmark{{
+			ModelKey:               "model-a",
+			ModelID:                "mlx-community/model-a",
+			SustainedTPS:           12.5,
+			ArtifactSHA256:         "artifact-sha",
+			CandidateCatalogSHA256: "catalog-sha",
+			GeneratedAt:            observedAt.Format(time.RFC3339),
+			BinaryVersion:          "1.8.42",
+			HardwareIdentityHash:   "hardware-hash",
+		}},
+	}
+	record, err := store.InsertHardwareVerificationJob(ctx, "provider-cli", evidence, observedAt)
+	if err != nil {
+		t.Fatalf("conflicting CLI hardware upsert: %v", err)
+	}
+	if record.JobID == 0 || record.Status != hardwareEvidenceJobPending {
+		t.Fatalf("hardware evidence record = %+v, want queued pending job", record)
+	}
+
+	if _, err := onboardingDB.QueryContext(ctx, `SELECT source FROM provider_hardware_profiles LIMIT 1`); err == nil {
+		t.Fatal("provider_onboarding unexpectedly gained direct source read")
+	} else if !strings.Contains(err.Error(), "permission denied") {
+		t.Fatalf("provider_onboarding source read error = %q, want permission denied", err)
 	}
 }

--- a/specs/CONFORMANCE.json
+++ b/specs/CONFORMANCE.json
@@ -1034,6 +1034,26 @@
         "issue": "https://github.com/Augustas11/macprovider/issues/610",
         "rationale": "The updater treats missing buyer-serving readiness as rollback-worthy even when signed activation, launch, and local health succeeded; success sentinels bind only the CLI version rather than the exact compatibility set; rollback does not fail closed when the prior set is revoked or below the effective minimum."
       }
+    },
+    {
+      "requirement_id": "SPEC-033-R001",
+      "spec_id": "SPEC-033",
+      "state": "pending",
+      "implementation": [
+        "phase4-coordinator/internal/onboarding/hardware_evidence.go:InsertHardwareVerificationJob",
+        "phase4-coordinator/internal/onboarding/store_pg.go:UpsertProviderHardwareProfile"
+      ],
+      "tests": [
+        "phase4-coordinator/internal/onboarding/store_pg_attempt_integration_test.go::TestProviderHardwareUpsertsRespectColumnLimitedGrants"
+      ],
+      "journeys": [],
+      "evidence": [],
+      "gap": {
+        "verdict": "CODE_BUG",
+        "owner": "@Augustas11",
+        "issue": "https://github.com/Augustas11/macprovider/issues/613",
+        "rationale": "The signed 42efce21 acceptance candidate proved that both authenticated provider hardware-profile UPSERT paths failed under the intended provider_onboarding column-limited grants. This PR repairs the SQL without widening authority; conformance remains pending until a replacement signed candidate completes the physical referral journey."
+      }
     }
   ]
 }

--- a/specs/CONFORMANCE.json
+++ b/specs/CONFORMANCE.json
@@ -916,7 +916,7 @@
     {
       "spec_id": "SPEC-033",
       "title": "Hardware-Evidence Verifier (`hardware-verifier.v2`)",
-      "version": "v0.6",
+      "version": "v0.6.1",
       "path": "specs/SPEC-033-hardware-verifier.md",
       "status": "draft",
       "owner": "@Augustas11",

--- a/specs/README.md
+++ b/specs/README.md
@@ -41,7 +41,7 @@ it can no longer drift. Do not hand-edit the table; edit each spec's
 | SPEC-030 | Losslessness Probe | v0.1 | draft | pending | pending corpus migration | [SPEC-030-losslessness-probe.md](SPEC-030-losslessness-probe.md) |
 | SPEC-031 | Canary Probe, Degrade & Sanction Lifecycle | v0.1 | draft | pending | pending corpus migration | [SPEC-031-canary-degrade-sanctions.md](SPEC-031-canary-degrade-sanctions.md) |
 | SPEC-032 | Autotune Hardware-Evidence Admission Gate, OPoI & Proof-of-Weights Boundary | v0.1 | draft | pending | pending corpus migration | [SPEC-032-proof-of-weights-hello-gate.md](SPEC-032-proof-of-weights-hello-gate.md) |
-| SPEC-033 | Hardware-Evidence Verifier (`hardware-verifier.v2`) | v0.6 | draft | pending | pending: 1 | [SPEC-033-hardware-verifier.md](SPEC-033-hardware-verifier.md) |
+| SPEC-033 | Hardware-Evidence Verifier (`hardware-verifier.v2`) | v0.6.1 | draft | pending | pending: 1 | [SPEC-033-hardware-verifier.md](SPEC-033-hardware-verifier.md) |
 | SPEC-034 | Referral admission, provider invites, and advocacy rewards | v0.4.1 | normative | pending | pending corpus migration | [SPEC-034-referral-gated-prebeta.md](SPEC-034-referral-gated-prebeta.md) |
 <!-- AUTOGEN:spec-index END -->
 

--- a/specs/README.md
+++ b/specs/README.md
@@ -41,7 +41,7 @@ it can no longer drift. Do not hand-edit the table; edit each spec's
 | SPEC-030 | Losslessness Probe | v0.1 | draft | pending | pending corpus migration | [SPEC-030-losslessness-probe.md](SPEC-030-losslessness-probe.md) |
 | SPEC-031 | Canary Probe, Degrade & Sanction Lifecycle | v0.1 | draft | pending | pending corpus migration | [SPEC-031-canary-degrade-sanctions.md](SPEC-031-canary-degrade-sanctions.md) |
 | SPEC-032 | Autotune Hardware-Evidence Admission Gate, OPoI & Proof-of-Weights Boundary | v0.1 | draft | pending | pending corpus migration | [SPEC-032-proof-of-weights-hello-gate.md](SPEC-032-proof-of-weights-hello-gate.md) |
-| SPEC-033 | Hardware-Evidence Verifier (`hardware-verifier.v2`) | v0.6 | draft | pending | pending corpus migration | [SPEC-033-hardware-verifier.md](SPEC-033-hardware-verifier.md) |
+| SPEC-033 | Hardware-Evidence Verifier (`hardware-verifier.v2`) | v0.6 | draft | pending | pending: 1 | [SPEC-033-hardware-verifier.md](SPEC-033-hardware-verifier.md) |
 | SPEC-034 | Referral admission, provider invites, and advocacy rewards | v0.4.1 | normative | pending | pending corpus migration | [SPEC-034-referral-gated-prebeta.md](SPEC-034-referral-gated-prebeta.md) |
 <!-- AUTOGEN:spec-index END -->
 

--- a/specs/SPEC-033-hardware-verifier.md
+++ b/specs/SPEC-033-hardware-verifier.md
@@ -1,7 +1,7 @@
 # SPEC-033 — Hardware-Evidence Verifier (`hardware-verifier.v2`)
 
-**Status:** v0.6-draft
-**Date:** 2026-07-12
+**Status:** v0.6.1-draft
+**Date:** 2026-07-17
 **Depends on:** SPEC-023 (autotune — produces the benchmark/recommendation inputs the evidence document carries). **Consumed by:** SPEC-032 (autotune hardware-evidence admission "hello-gate") reads this spec's verdict via an **exact-`hardware-verifier.v2`** lookup and cross-references it as "the item-10 hardware-verifier verdict spec". This spec owns the `hardware-verifier.v2` decision semantics and the job/profile lifecycle; SPEC-032 owns how a `verified` profile gates admission.
 
 **Producer / enqueue boundary (see §3.1):** the provider **binary** builds the evidence envelope (`phase3-binary/Sources/macprovider-cli/AutotuneHardwareEvidence.swift`) and submits it over an **authenticated HTTP `POST /v1/providers/hardware-evidence`** (`phase4-coordinator/internal/onboarding/hardware_evidence.go` `HandleHardwareEvidence`), which enqueues a `hardware_verification_jobs` row. SPEC-023 owns the *content* (benchmarks, recommended model); the HTTP envelope + enqueue + replay state machine are owned here.
@@ -251,6 +251,13 @@ authenticated bearer identity; the handler (`HandleHardwareEvidence`) binds the 
 
 The pre-job `cli_hello` profile upsert is why a later app-registration (§10.4 R1) finds an existing
 row to convert.
+
+**SPEC-033-R001 — Preserve provider hardware-profile writes under least privilege.** The
+authenticated CLI evidence-enqueue path and the signed app-registration profile path MUST execute
+under the column-limited `provider_onboarding` role without requiring `SELECT` on write-only
+profile payload columns. On conflict, each path MUST keep `source` coordinator-controlled, MUST
+NOT write `verified`, and MUST NOT replace a profile whose `last_reported_at` is newer than the
+incoming observation.
 
 ---
 
@@ -604,6 +611,12 @@ issues; closing them is code follow-up, not a spec change:
 ---
 
 ## Change log
+
+**v0.6.1-draft (2026-07-17) — stable requirement mapping for physical acceptance.**
+Defines SPEC-033-R001 for the existing §2.7/§3.1 least-privilege hardware-profile write contract.
+The requirement covers both coordinator-owned onboarding paths whose conflict updates share the
+same column-limited runtime role. No provider authority, verifier decision, or production state
+changes.
 
 **v0.6-draft (2026-07-12) — audit reconciliation (SPEC-033 R5, 3-lane codex).**
 R5 confirmed the entire spec against code — all three lanes returned **0 C/H/M** except one shared


### PR DESCRIPTION
## Outcome

Unblocks the physical referral acceptance gate without widening `provider_onboarding` database authority.

The signed `42efce21` acceptance candidate reached `POST /v1/providers/hardware-evidence`, but PostgreSQL returned a permission error and the coordinator failed closed with HTTP 503. The installer then restored the prior provider state as designed.

## Root cause

Both hardware-profile UPSERTs used `EXCLUDED.*` in `ON CONFLICT DO UPDATE`. PostgreSQL requires `SELECT` privilege for those referenced columns, while the migrations intentionally give `provider_onboarding` write-only access to the profile payload and read access only to admission-safe fields.

## Change

- Reuse the already-bound request parameters in the app-track hardware-profile UPSERT.
- Reuse the already-bound evidence parameters in the CLI hardware-evidence UPSERT.
- Keep `source` coordinator-controlled and preserve the monotonic `last_reported_at` predicate.
- Add an integration regression that authenticates as the real migrated `provider_onboarding` role, exercises both conflict paths, and proves direct `source` reads remain denied.

No migration grants, feature flags, provider credentials, or lifecycle ownership changed.

## Validation

- `go test ./...`
- `go vet ./...`
- `go test -tags=integration ./internal/onboarding -run '^$'` (integration-tag compile)
- Isolated Pearl PostgreSQL transactional role probe: corrected UPSERT succeeds and rolls back with zero retained probe rows; the candidate query failed under the same role
- Independent code review: 0 CRITICAL / 0 HIGH / 0 MEDIUM / 0 LOW
- Independent security review: 0 CRITICAL / 0 HIGH / 0 MEDIUM / 0 LOW
- Independent architecture review: 0 CRITICAL / 0 HIGH / 0 MEDIUM / 0 LOW

The Docker-backed integration test could not execute locally because rootless Docker is unavailable; CI must execute it before merge.

## Acceptance impact

The existing `42efce21` candidate must remain rejected. After this PR is reviewed and merged, build a new private signed/notarized candidate from the resulting exact main commit and rerun the complete two-physical-Mac referral and real-X gate. Production flags remain disabled.

SPEC-GOVERNANCE-DECLARATION-BEGIN
{
  "schema_version": "spec-pr-governance-v1",
  "behavior_change": "yes",
  "contract_change": "yes",
  "specs": [
    "SPEC-033"
  ],
  "requirements": [
    "SPEC-033-R001"
  ],
  "authority_domains": [
    "hardware-evidence-verifier"
  ],
  "arbitration": [
    "CODE_BUG"
  ],
  "tests": [
    "go test ./...",
    "go vet ./...",
    "make test-coordinator-integration"
  ],
  "journeys": [
    "not-required"
  ],
  "issue": "https://github.com/Augustas11/macprovider/issues/613"
}
SPEC-GOVERNANCE-DECLARATION-END
