### PR TITLE
Keep admission proofs bound to the coordinator wire transcript

### DIFF
--- a/phase3-binary/Sources/macprovider-cli/CanonicalJSON.swift
+++ b/phase3-binary/Sources/macprovider-cli/CanonicalJSON.swift
@@ -2,9 +2,10 @@ import Foundation
 
 // RFC 8785 JSON Canonicalization Scheme (JCS).
 //
-// Byte-identical mirror of the Malibu.app CanonicalJSON implementation at
-// phase3-binary/app/Sources/Malibu/System/RegisterClient.swift and of the
-// coordinator's Go implementation at phase4-coordinator/internal/billing/jcs.go.
+// CLI-side adapter for the coordinator's Go implementation at
+// phase4-coordinator/internal/billing/jcs.go. Numeric rendering delegates to
+// RFC8785JCS so the signed transcript matches the coordinator's canonical form
+// of the actual wire message.
 //
 // Used by the SPEC-026 identity_signature flow to build the canonical bytes
 // whose SHA-256 the coordinator retains from the initial `auth_request`
@@ -13,6 +14,7 @@ import Foundation
 
 enum CanonicalJSONError: Error {
     case nonFiniteNumber
+    case integerOutOfRange
     case invalidStringEncoding
 }
 
@@ -97,10 +99,6 @@ extension CanonicalJSON {
         switch any {
         case is NSNull:
             return .null
-        case let bool as Bool:
-            return .bool(bool)
-        case let string as String:
-            return .string(string)
         case let number as NSNumber:
             if CFGetTypeID(number) == CFBooleanGetTypeID() {
                 return .bool(number.boolValue)
@@ -109,7 +107,20 @@ extension CanonicalJSON {
             if raw == "q" || raw == "l" || raw == "i" || raw == "s" || raw == "c" {
                 return .number(String(number.int64Value))
             }
-            return .number(number.stringValue)
+            if raw == "Q" || raw == "L" || raw == "I" || raw == "S" || raw == "C" {
+                guard number.uint64Value <= UInt64(Int64.max) else {
+                    throw CanonicalJSONError.integerOutOfRange
+                }
+                return .number(String(number.uint64Value))
+            }
+            guard number.doubleValue.isFinite else {
+                throw CanonicalJSONError.nonFiniteNumber
+            }
+            return .number(try RFC8785JCS.canonicalString(.double(number.doubleValue)))
+        case let bool as Bool:
+            return .bool(bool)
+        case let string as String:
+            return .string(string)
         case let int as Int:
             return .number(String(int))
         case let int64 as Int64:
@@ -118,10 +129,7 @@ extension CanonicalJSON {
             guard double.isFinite else {
                 throw CanonicalJSONError.nonFiniteNumber
             }
-            if double == double.rounded() && abs(double) < Double(Int64.max) {
-                return .number(String(Int64(double)))
-            }
-            return .number(String(double))
+            return .number(try RFC8785JCS.canonicalString(.double(double)))
         case let array as [Any]:
             return try .array(array.map { try fromJSONLike($0) })
         case let dict as [String: Any]:

--- a/phase3-binary/Tests/macprovider-cliTests/CanonicalJSONTests.swift
+++ b/phase3-binary/Tests/macprovider-cliTests/CanonicalJSONTests.swift
@@ -1,0 +1,84 @@
+import CryptoKit
+import Foundation
+import XCTest
+@testable import macprovider_cli
+
+final class CanonicalJSONTests: XCTestCase {
+    func testCapturedStartupThroughputValuesUseRFC8785NumberFormatting() throws {
+        let cases: [(Double, String)] = [
+            (0.09774012272370747, "0.09774012272370747"),
+            (0.15710173308461284, "0.15710173308461284"),
+        ]
+
+        for (throughput, expected) in cases {
+            let message: [String: Any] = [
+                "throughput_tps_estimate": throughput,
+            ]
+            let canonical = try CanonicalJSON.encode(CanonicalJSON.fromJSONLike(message))
+
+            XCTAssertEqual(
+                String(decoding: canonical, as: UTF8.self),
+                #"{"throughput_tps_estimate":\#(expected)}"#
+            )
+        }
+    }
+
+    func testTranscriptHashMatchesRFC8785ForCapturedRejectedValue() throws {
+        let message: [String: Any] = [
+            "provider_id": "provider-test",
+            "throughput_tps_estimate": 0.15710173308461284,
+            "type": "auth_request",
+        ]
+        let expectedCanonical =
+            #"{"provider_id":"provider-test","throughput_tps_estimate":0.15710173308461284,"type":"auth_request"}"#
+        let expectedHash = Data(SHA256.hash(data: Data(expectedCanonical.utf8))).base64EncodedString()
+
+        XCTAssertEqual(
+            try CoordinatorClient.initialAuthTranscriptHashBase64(message),
+            expectedHash
+        )
+    }
+
+    func testUnsignedIntegerNSNumberPreservesValuesWithinSignedJSONRange() throws {
+        let message: [String: Any] = [
+            "value": NSNumber(value: UInt64(Int64.max)),
+        ]
+        let canonical = try CanonicalJSON.encode(CanonicalJSON.fromJSONLike(message))
+
+        XCTAssertEqual(
+            String(decoding: canonical, as: UTF8.self),
+            #"{"value":9223372036854775807}"#
+        )
+    }
+
+    func testUnsignedIntegerAboveCoordinatorExactRangeIsRejected() {
+        XCTAssertThrowsError(
+            try CanonicalJSON.fromJSONLike(NSNumber(value: UInt64.max))
+        ) { error in
+            XCTAssertEqual(error as? CanonicalJSONError, .integerOutOfRange)
+        }
+    }
+
+    func testNonFiniteNSNumberIsRejected() {
+        XCTAssertThrowsError(
+            try CanonicalJSON.fromJSONLike(NSNumber(value: Double.infinity))
+        ) { error in
+            XCTAssertTrue(error is CanonicalJSONError)
+        }
+    }
+
+    func testNSNumberZeroAndOneRemainNumbersWhileCFBooleansRemainBooleans() throws {
+        let value: [String: Any] = [
+            "false": false,
+            "one": NSNumber(value: 1),
+            "true": true,
+            "zero": NSNumber(value: 0),
+        ]
+        let canonical = try CanonicalJSON.encode(CanonicalJSON.fromJSONLike(value))
+
+        XCTAssertEqual(
+            String(decoding: canonical, as: UTF8.self),
+            #"{"false":false,"one":1,"true":true,"zero":0}"#
+        )
+    }
+}

--- a/phase7-verify/testdata/jcs_parity.json
+++ b/phase7-verify/testdata/jcs_parity.json
@@ -352,6 +352,16 @@
     "input" : 0.5
   },
   {
+    "expected_canonical_b64" : "MC4wOTc3NDAxMjI3MjM3MDc0Nw==",
+    "id" : "double_captured_acceptance_success",
+    "input" : 0.09774012272370747
+  },
+  {
+    "expected_canonical_b64" : "MC4xNTcxMDE3MzMwODQ2MTI4NA==",
+    "id" : "double_captured_acceptance_rejection",
+    "input" : 0.15710173308461284
+  },
+  {
     "expected_canonical_b64" : "eyJmcmVxdWVuY3lfcGVuYWx0eSI6MCwibWF4X3Rva2VucyI6MjU2LCJtZXNzYWdlcyI6W3siY29udGVudCI6IkNhZsOpIiwicm9sZSI6InVzZXIifV0sIm1vZGVsIjoibSIsInByZXNlbmNlX3BlbmFsdHkiOjAsInRlbXBlcmF0dXJlIjowLjcsInRvb2xfY2hvaWNlIjpudWxsLCJ0b29scyI6W10sInRvcF9wIjoxfQ==",
     "id" : "prompt_like",
     "input" : {


### PR DESCRIPTION
## Outcome

Fixes the CLI identity-signature transcript mismatch discovered during private
referral acceptance. The coordinator remains authoritative and continues
rejecting proofs whose transcript hash does not match the canonical form of
the received wire message.

## Root cause

`CanonicalJSON.fromJSONLike` formatted floating-point `NSNumber` values with
`NSNumber.stringValue`, while the same initial auth dictionary was sent with
`JSONSerialization`. Those two formatters can spell the same `Double`
differently. The coordinator canonicalizes the received JSON using RFC 8785,
so a valid measured startup throughput such as `0.15710173308461284` produced
a different client transcript hash and failed with
`identity_signature_required`.

The existing signed/notarized acceptance candidate at
`6cdd3da26d86a6282bc3ab19965137050dc733b5` is therefore quarantined and must
not be activated.

## Changes

- Delegate finite floating-point transcript rendering to the existing RFC
  8785/ECMAScript formatter.
- Reject unsigned integers above `Int64.max`, matching the coordinator's exact
  integer domain instead of silently creating a cross-language mismatch.
- Distinguish numeric `NSNumber(0/1)` from actual Core Foundation booleans.
- Add regression tests for both captured physical-acceptance throughput
  values, transcript hashing, integer bounds, non-finite values, and boolean
  bridging.
- Add both captured values to the shared Swift/Go JCS parity fixture.

## Architecture and security

- CLI remains the owner of provider identity and proof construction.
- Coordinator remains the authority for the wire-derived canonical transcript
  and signature decision.
- No verification bypass, downgrade, replay relaxation, or server-side
  acceptance weakening is introduced.
- Production flags remain disabled.

## Validation

- `swift test`: 1,430 passed, 8 environment-gated hardware/integration
  canaries skipped, 0 failures.
- Focused Swift JCS/auth suites: 17 passed, 0 failures.
- `go test -count=1 ./internal/jcs`: passed.
- `git diff --check`: clean.
- Independent code audit: 0 CRITICAL / HIGH / MEDIUM / LOW.
- Independent security audit: 0 CRITICAL / HIGH / MEDIUM / LOW.
- Independent architecture audit: 0 CRITICAL / HIGH / MEDIUM / LOW.

## Required follow-up

After review and squash merge, build a new private signed/notarized candidate
from the exact merged commit and rerun the complete two-physical-provider
referral → buyer-serving → invite → real-X exactly-once acceptance gate. Do
not publish or activate based on unit/CI success alone.

SPEC-GOVERNANCE-DECLARATION-BEGIN
{
  "schema_version": "spec-pr-governance-v1",
  "behavior_change": "yes",
  "contract_change": "none",
  "issue": "https://github.com/Augustas11/macprovider/issues/613",
  "specs": [
    "SPEC-001",
    "SPEC-033"
  ],
  "requirements": [
    "SPEC-033-R001"
  ],
  "authority_domains": [
    "provider-wire-protocol",
    "hardware-evidence-admission"
  ],
  "arbitration": [
    "CODE_BUG"
  ],
  "tests": [
    "swift test --package-path phase3-binary",
    "swift test --package-path phase3-binary --filter CanonicalJSONTests",
    "go test -count=1 ./internal/jcs"
  ],
  "journeys": [
    "pending: signed two-provider referral acceptance for issue #613"
  ]
}
SPEC-GOVERNANCE-DECLARATION-END
