### PR TITLE
Keep installer readiness aligned with provider model identity

### DIFF
--- a/phase3-binary/Tests/macprovider-cliTests/ProviderStatusTests.swift
+++ b/phase3-binary/Tests/macprovider-cliTests/ProviderStatusTests.swift
@@ -436,7 +436,7 @@ final class ProviderStatusTests: XCTestCase {
     }
 
     func testStatusSeparatesLiveCatalogTrustFromBuyerServing() async {
-        let status = ProviderStatus(modelID: "m", modelLoaded: true, capacity: makeCapacity())
+        let status = ProviderStatus(modelID: "model-key", modelLoaded: true, capacity: makeCapacity())
         await status.setCoordinatorSession(connected: true, assignedID: "session-a")
         let trust = ServeCommand.CatalogRuntimeTrust(
             state: "live_verified",
@@ -467,9 +467,12 @@ final class ProviderStatusTests: XCTestCase {
         )
         let catalog = body["catalog"] as? [String: Any]
 
+        XCTAssertEqual(body["model"] as? String, "model-key")
         XCTAssertEqual(body["network_state"] as? String, "buyer_serving")
         XCTAssertEqual(body["buyer_serving_authority"] as? String, "coordinator")
         XCTAssertEqual(catalog?["state"] as? String, "live_verified")
+        XCTAssertEqual(catalog?["catalog_key"] as? String, "model-key")
+        XCTAssertEqual(catalog?["model_id"] as? String, "org/model")
         XCTAssertEqual(catalog?["signer_key_id"] as? String, "streamvc-autotune-static-v5")
         XCTAssertEqual(catalog?["policy_version"] as? String, "autotune-policy-v1")
         XCTAssertEqual(catalog?["row_identity"] as? String, String(repeating: "e", count: 64))

--- a/phase3-binary/dist/install.sh
+++ b/phase3-binary/dist/install.sh
@@ -7733,10 +7733,15 @@ if not isinstance(catalog, dict):
     raise SystemExit(1)
 model = local.get("model")
 key = catalog.get("catalog_key")
+catalog_model_id = catalog.get("model_id")
 rows = candidates.get("rows")
 if not isinstance(rows, dict):
     raise SystemExit(1)
-if not isinstance(key, str) or key not in rows or rows[key].get("model_id") != model:
+if not isinstance(key, str) or key not in rows:
+    raise SystemExit(1)
+if not isinstance(model, str) or model != key:
+    raise SystemExit(1)
+if not isinstance(catalog_model_id, str) or catalog_model_id != rows[key].get("model_id"):
     raise SystemExit(1)
 row_identity = catalog.get("row_identity")
 if re.fullmatch(r"[0-9a-f]{64}", row_identity or "") is None:

--- a/phase3-binary/dist/test/install_coordinator_admission.test.sh
+++ b/phase3-binary/dist/test/install_coordinator_admission.test.sh
@@ -53,11 +53,12 @@ digest = hashlib.sha256(candidate_bytes).hexdigest()
 signer = release["feeds"]["autotune-candidates.json"]["signer_key_id"]
 local = {
     "provider_id": "provider-test",
-    "model": row["model_id"],
+    "model": key,
     "network_state": "buyer_serving",
     "coordinator": {"connected": True, "session": "session-test"},
     "catalog": {
         "catalog_key": key,
+        "model_id": row["model_id"],
         "release_id": release["release_id"],
         "digest": digest,
         "signer_key_id": signer,
@@ -130,6 +131,65 @@ run_wait() {
 run_wait "$TMP/coordinator.json"
 grep -F 'details=readiness' "$TMP/curl.log" >/dev/null
 grep -F 'assigned_id=session-test' "$TMP/curl.log" >/dev/null
+
+python3 - "$TMP/local.json" "$TMP/wrong-local-model.json" <<'PY'
+import json
+import sys
+source, destination = sys.argv[1:]
+payload = json.load(open(source, encoding="utf-8"))
+payload["model"] = "different-catalog-key"
+json.dump(payload, open(destination, "w", encoding="utf-8"), separators=(",", ":"))
+PY
+if run_wait "$TMP/coordinator.json" "$TMP/wrong-local-model.json"; then
+  echo "mismatched local model and catalog key passed admission" >&2
+  exit 1
+fi
+
+python3 - "$TMP/local.json" "$TMP/wrong-catalog-model-id.json" <<'PY'
+import json
+import sys
+source, destination = sys.argv[1:]
+payload = json.load(open(source, encoding="utf-8"))
+payload["catalog"]["model_id"] = "different/model-id"
+json.dump(payload, open(destination, "w", encoding="utf-8"), separators=(",", ":"))
+PY
+if run_wait "$TMP/coordinator.json" "$TMP/wrong-catalog-model-id.json"; then
+  echo "mismatched catalog model ID and signed row passed admission" >&2
+  exit 1
+fi
+
+python3 - "$TMP/local.json" "$TMP" <<'PY'
+import copy
+import json
+import os
+import sys
+
+source, destination = sys.argv[1:]
+baseline = json.load(open(source, encoding="utf-8"))
+fields = {
+    "local-model": ("model",),
+    "catalog-key": ("catalog", "catalog_key"),
+    "catalog-model-id": ("catalog", "model_id"),
+}
+for label, path in fields.items():
+    for mutation, value in (("missing", None), ("null", None), ("wrong-type", [])):
+        payload = copy.deepcopy(baseline)
+        target = payload
+        for component in path[:-1]:
+            target = target[component]
+        if mutation == "missing":
+            target.pop(path[-1])
+        else:
+            target[path[-1]] = value
+        output = os.path.join(destination, f"invalid-status-{label}-{mutation}.json")
+        json.dump(payload, open(output, "w", encoding="utf-8"), separators=(",", ":"))
+PY
+for invalid_status in "$TMP"/invalid-status-*.json; do
+  if run_wait "$TMP/coordinator.json" "$invalid_status"; then
+    echo "$(basename "$invalid_status") passed admission" >&2
+    exit 1
+  fi
+done
 
 python3 - "$TMP/coordinator.json" "$TMP/wrong-session.json" <<'PY'
 import json
@@ -239,6 +299,10 @@ if 'catalog_admission_mode") != "legacy_bridge"' not in text:
     raise SystemExit("emergency rollback is not gated on legacy_bridge buyer admission")
 if 'response.get("assigned_id") != assigned_id' not in text or 'response.get("buyer_serving") is not True' not in text:
     raise SystemExit("emergency rollback is not bound to the exact buyer-serving coordinator session")
+if 'model != key' not in text:
+    raise SystemExit("normal admission does not bind the local served model to the catalog key")
+if 'catalog_model_id != rows[key].get("model_id")' not in text:
+    raise SystemExit("normal admission does not bind the status catalog model ID to the signed row")
 
 commit_start = text.index("commit_install_transaction() {")
 commit_end = text.index("\n}\n\nrun()", commit_start)


### PR DESCRIPTION
## Outcome

Fixes the exact signed-installer readiness blocker found during private physical
referral acceptance. The installer now validates provider status using the two
model identities that the typed lifecycle contract actually publishes.

The existing private candidate from
`2aeab7d7aa3abb79e4efadf9eb706e1cf74785c7` remains quarantined and must not
be published or activated.

## Root cause

`/v1/status` publishes the served public model slug in top-level `model` and
publishes the full Hugging Face identity in `catalog.model_id`. The installer
incorrectly compared top-level `model` directly with the signed candidate
row's full `model_id`.

On the physical 30B sponsor, every other readiness assertion passed—exact
provider/session, coordinator connection, buyer-serving admission, catalog
release/digest/signer/policy/row identity—but this structurally impossible
comparison forced rollback.

The test fixture masked the defect by putting the full Hugging Face ID in
top-level `model` instead of using the real status shape.

## Changes

- Bind top-level status `model` to `catalog.catalog_key`.
- Independently bind `catalog.model_id` to the signed candidate row's full
  `model_id`.
- Correct the installer fixture to use the real typed status shape.
- Add rejection coverage for wrong, missing, null, and wrong-type
  model/key/model-ID values.
- Lock the separated slug/full-ID contract in `ProviderStatusTests`.

## Architecture and security

- CLI remains provider lifecycle, credential, identity, model, and process
  authority.
- Coordinator remains buyer-serving authority; exact provider/session and
  `buyer_serving=true` are still required.
- Signed release digest, signer, policy, catalog row identity, and admission
  mode checks remain unchanged and fail closed.
- Emergency rollback remains isolated to exact session-bound `legacy_bridge`
  admission.
- No bearer moves into Malibu and no second provider process is introduced.
- Production flags remain disabled.

## Validation

- `swift test --parallel`: 1,430 tests passed, 0 failures.
- `make test-dist`: passed; environment-gated Docker/Linux/live smokes skipped
  by their existing local guards.
- `phase3-binary/dist/test/install_coordinator_admission.test.sh`: passed with
  positive, mismatch, missing, null, and wrong-type coverage.
- Signed candidate security, metadata, and tier-2 provider artifact tests:
  passed.
- Shell syntax and `git diff --check`: passed.
- ShellCheck: only three pre-existing findings outside this diff.
- Independent code audit: 0 CRITICAL / HIGH / MEDIUM / LOW.
- Independent security audit after coverage fix: 0 CRITICAL / HIGH / MEDIUM /
  LOW.
- Independent architecture audit: 0 CRITICAL / HIGH / MEDIUM / LOW.

## Required follow-up

After review and squash merge, generate a new private signed/notarized v1.8.42
candidate from the exact merged commit. Then rerun the complete
two-physical-provider referral → buyer-serving → invite → real-X exactly-once
acceptance gate. Do not publish, deploy, activate, or open the activation PR
based on CI/signing alone.

SPEC-GOVERNANCE-DECLARATION-BEGIN
{
  "schema_version": "spec-pr-governance-v1",
  "behavior_change": "yes",
  "contract_change": "none",
  "issue": "https://github.com/Augustas11/macprovider/issues/613",
  "specs": [
    "SPEC-001",
    "SPEC-023"
  ],
  "requirements": [
    "SPEC-033-R001"
  ],
  "authority_domains": [
    "model-catalog-identity",
    "installer-autotune-policy",
    "coordinator-admission-routing"
  ],
  "arbitration": [
    "CODE_BUG"
  ],
  "tests": [
    "swift test --package-path phase3-binary --parallel",
    "make test-dist",
    "bash phase3-binary/dist/test/install_coordinator_admission.test.sh"
  ],
  "journeys": [
    "pending: regenerated signed two-provider referral acceptance for issue #613"
  ]
}
SPEC-GOVERNANCE-DECLARATION-END
