### PR TITLE
Bind acceptance CLI bytes to a post-public version

### DIFF
--- a/phase3-binary/Sources/macprovider-cli/CoordinatorClient.swift
+++ b/phase3-binary/Sources/macprovider-cli/CoordinatorClient.swift
@@ -145,7 +145,7 @@ actor CoordinatorClient {
     typealias CatalogArtifactIdentity = @Sendable (String?) async -> String?
     typealias InstalledCompatibilityManifest = @Sendable (URL, String) -> CompatibilitySetManifest?
 
-    static let binaryVersion = "1.8.40"
+    static let binaryVersion = "1.8.45"
     private static let keepaliveDebugEnabled = ProcessInfo.processInfo.environment["MACPROVIDER_KEEPALIVE_DEBUG"] == "1"
 
     private let coordinatorURL: URL

--- a/phase3-binary/Tests/macprovider-cliTests/CoordinatorClientTests.swift
+++ b/phase3-binary/Tests/macprovider-cliTests/CoordinatorClientTests.swift
@@ -3612,10 +3612,10 @@ final class CoordinatorClientTests: XCTestCase {
         let hello = await client.helloMessage()
         let auth = await client.authInitialMessage(attempt: attempt)
 
-        XCTAssertEqual(CoordinatorClient.binaryVersion, "1.8.40")
-        XCTAssertEqual(MacProviderCLI.configuration.version, "1.8.40")
-        XCTAssertEqual(hello["binary_version"] as? String, "1.8.40")
-        XCTAssertEqual(auth["binary_version"] as? String, "1.8.40")
+        XCTAssertEqual(CoordinatorClient.binaryVersion, "1.8.45")
+        XCTAssertEqual(MacProviderCLI.configuration.version, "1.8.45")
+        XCTAssertEqual(hello["binary_version"] as? String, "1.8.45")
+        XCTAssertEqual(auth["binary_version"] as? String, "1.8.45")
     }
 
     func testCatalogProviderRejectsCoordinatorWithoutAdmissionAcknowledgement() async throws {

--- a/phase4-coordinator/coordinator.yaml.example
+++ b/phase4-coordinator/coordinator.yaml.example
@@ -179,7 +179,7 @@ autotune:
 # legacy cohort (DECISION_CRITERIA Entry 161). `required_binary_version` is a
 # hard admission floor, not an autoupdate target, and is unaffected by the gate.
 coordinator_advertised_version:
-  latest_binary_version: "1.8.40"
+  latest_binary_version: "1.8.45"
   required_binary_version: ""
 
 auth:

--- a/phase4-coordinator/dist/coordinator.yaml
+++ b/phase4-coordinator/dist/coordinator.yaml
@@ -297,4 +297,4 @@ providers:
 # legacy cohort (DECISION_CRITERIA Entry 161). Setting this value does not, and
 # must not, re-arm the legacy binary-only updater.
 coordinator_advertised_version:
-  latest_binary_version: "1.8.40"
+  latest_binary_version: "1.8.45"

--- a/phase4-coordinator/dist/coordinator.yaml.example
+++ b/phase4-coordinator/dist/coordinator.yaml.example
@@ -352,7 +352,7 @@ malibu_emission:
 # Use for security fixes that must not be optional. Leave unset for advisory
 # releases.
 coordinator_advertised_version:
-  latest_binary_version: "1.8.40"
+  latest_binary_version: "1.8.45"
   # required_binary_version: "1.7.0"
 
 # Enumerated providers (SPEC-002 v1.0.4 Finding F-2: every provider_id that


### PR DESCRIPTION
## Summary
- Bumps `CoordinatorClient.binaryVersion` from `1.8.40` to `1.8.45` so new signed acceptance CLI bytes no longer advertise the public 1.8.40 component version.
- Aligns coordinator advertised latest version fixtures/config with the CLI component version.
- Keeps Malibu independently versioned at `1.8.41`.

## Why
The private `v1.8.45` acceptance candidate built from `9ce15f21df15dce1f945e4bac4fcfae31eef4765` was rejected before installation because the actual signed CLI binary reported `1.8.40`. The referral/X physical gate requires new CLI bytes to advertise a version above public `1.8.40`.

## Validation
- `bash scripts/test-coordinator-advertised-version.sh v1.8.45`
- `swift test --package-path phase3-binary --filter CoordinatorClientTests/testBinaryVersion_AdvertisesSPEC020V17AcrossHandshakeFrames`
- `git diff --check`

## Review
Required reviewer: `antfleet-ops`.

SPEC-GOVERNANCE-DECLARATION-BEGIN
{
  "schema_version": "spec-pr-governance-v1",
  "behavior_change": "yes",
  "contract_change": "none",
  "specs": ["SPEC-020"],
  "requirements": ["SPEC-020-R001"],
  "authority_domains": ["provider-autoupdate"],
  "arbitration": ["CODE_BUG"],
  "tests": [
    "scripts/test-coordinator-advertised-version.sh v1.8.45",
    "phase3-binary/Tests/macprovider-cliTests/CoordinatorClientTests.swift::testBinaryVersion_AdvertisesSPEC020V17AcrossHandshakeFrames"
  ],
  "journeys": ["pending: rebuilt signed two-provider referral/X acceptance candidate"]
}
SPEC-GOVERNANCE-DECLARATION-END
