### PR TITLE
Tag X challenge copy and restore advisory autotune gates

### DIFF
--- a/phase3-binary/Sources/macprovider-cli/AutotuneRecommend.swift
+++ b/phase3-binary/Sources/macprovider-cli/AutotuneRecommend.swift
@@ -46,18 +46,13 @@ enum AutotuneRecommendWarning: String, CaseIterable {
     /// warning surfaces the discovery-tier pricing to the operator.
     case rateCardDefaultTierUsed = "rate_card_default_tier_used"
     /// v1.7.6 Track A2a: at least one recommended candidate observed
-    /// swap pageouts during the Stage 1 probe. The candidate still
-    /// cleared TPS/TTFT gates so eligibility passes, but the operator
-    /// should be aware that heavy real-world context loads may push
-    /// this Mac into swap.
+    /// swap pageouts during the Stage 1 probe. Swap is advisory; the
+    /// operator should be aware that heavy real-world context loads may
+    /// push this Mac into swap.
     case swapObservedUnderLoad = "swap_observed_under_load"
-    /// Retained for decoding recommendation artifacts written by older
-    /// binaries. Current recommendations treat the signed catalog's
-    /// `min_sustained_tps` as a hard eligibility gate.
+    /// Advisory QoS warning when measured TPS misses the signed catalog target.
     case tpsBelowGate = "tps_below_gate"
-    /// Retained for decoding recommendation artifacts written by older
-    /// binaries. Current recommendations treat the signed catalog's
-    /// `max_4k_ttft_ms` as a hard eligibility gate.
+    /// Advisory QoS warning when measured TTFT exceeds the signed catalog target.
     case ttftAboveGate = "ttft_above_gate"
 }
 
@@ -1502,7 +1497,8 @@ struct AutotuneRecommendEngine {
                 benchmark: benchmark,
                 request: request
             )
-            let tps = benchmark?.sustainedTPS ?? 0
+            let measuredTPS = benchmark?.sustainedTPS ?? 0
+            let tps = measuredTPS.isFinite ? measuredTPS : 0
             let rateRow = rateMatch?.row
             let promptUSD = rateRow?.usdPerMillionPromptTokens(creditsPerMillion: request.rateCard.usdPerMillionCredits) ?? 0
             let completionUSD = rateRow?.usdPerMillionCompletionTokens(creditsPerMillion: request.rateCard.usdPerMillionCredits) ?? 0
@@ -1580,6 +1576,10 @@ struct AutotuneRecommendEngine {
             if rateMatch?.key == "default", target.catalogKey != "default" {
                 warnings.insert(.rateCardDefaultTierUsed)
             }
+            if let benchmark = request.benchmarks[target.catalogKey],
+               let candidate = request.candidateCatalog.rows[target.catalogKey] {
+                warnings.formUnion(Self.advisoryBenchmarkWarnings(benchmark, candidate: candidate))
+            }
             if request.benchmarks[target.catalogKey]?.swapDetected == true {
                 warnings.insert(.swapObservedUnderLoad)
             }
@@ -1625,13 +1625,9 @@ struct AutotuneRecommendEngine {
         guard candidate.minRAMGB <= request.hardware.memoryGB - Self.safetyMarginGB else { return false }
         guard request.hardware.bandwidthTier.satisfies(minimum: candidate.minBandwidthTier) else { return false }
         guard let benchmark else { return false }
-        // Keep provider-side recommendation admission identical to the
-        // coordinator's benchmark gate: TPS below the signed minimum and
-        // TTFT above the signed maximum are hard failures. Equality passes.
-        // Thermal throttling remains a separate hard block because throttled
-        // measurements are unreliable; swap remains an operator warning.
+        // SPEC-023 v0.2: signed TPS/TTFT gates are advisory QoS warnings, not
+        // eligibility vetoes. Thermal throttling remains the runtime hard block.
         return !benchmark.thermalThrottleDetected
-            && Self.benchmarkClearsSignedCatalogGates(benchmark, candidate: candidate)
             && Self.cachedBenchmarkAdmitted(benchmark, request: request, modelKey: modelKey)
     }
 
@@ -1648,9 +1644,6 @@ struct AutotuneRecommendEngine {
         candidate: CandidateCatalog.Row?,
         request: AutotuneRecommendRequest
     ) -> Bool {
-        // Donor recommendations use the same signed performance gates so a
-        // locally-applied fallback cannot later appear network-admissible with
-        // benchmark evidence the coordinator would reject.
         guard let candidate,
               ["candidate", "listed", "recommendable"].contains(candidate.runtimeStatus),
               candidate.modelRevision != nil,
@@ -1658,21 +1651,49 @@ struct AutotuneRecommendEngine {
               candidate.minRAMGB <= request.hardware.memoryGB - safetyMarginGB,
               request.hardware.bandwidthTier.satisfies(minimum: candidate.minBandwidthTier),
               let benchmark = request.benchmarks[modelKey],
-              !benchmark.thermalThrottleDetected,
-              benchmarkClearsSignedCatalogGates(benchmark, candidate: candidate)
+              !benchmark.thermalThrottleDetected
         else {
             return false
         }
         return cachedBenchmarkAdmitted(benchmark, request: request, modelKey: modelKey)
     }
 
-    static func benchmarkClearsSignedCatalogGates(
+    static func advisoryBenchmarkWarnings(
         _ benchmark: CandidateBenchmark,
         candidate: CandidateCatalog.Row
-    ) -> Bool {
-        benchmark.sustainedTPS.isFinite
-            && benchmark.sustainedTPS >= candidate.benchGate.minSustainedTPS
-            && benchmark.ttftMS <= candidate.benchGate.max4KTTFTMS
+    ) -> Set<AutotuneRecommendWarning> {
+        var warnings = Set<AutotuneRecommendWarning>()
+        if !benchmark.sustainedTPS.isFinite || benchmark.sustainedTPS < candidate.benchGate.minSustainedTPS {
+            warnings.insert(.tpsBelowGate)
+        }
+        if benchmark.ttftMS > candidate.benchGate.max4KTTFTMS {
+            warnings.insert(.ttftAboveGate)
+        }
+        return warnings
+    }
+
+    private static func advisoryBenchmarkWarningReasons(
+        _ benchmark: CandidateBenchmark,
+        candidate: CandidateCatalog.Row
+    ) -> [String] {
+        var reasons: [String] = []
+        if !benchmark.sustainedTPS.isFinite {
+            reasons.append("TPS evidence is non-finite")
+        } else if benchmark.sustainedTPS < candidate.benchGate.minSustainedTPS {
+            reasons.append(
+                String(
+                    format: "TPS %.3f is below advisory catalog target %.3f",
+                    benchmark.sustainedTPS,
+                    candidate.benchGate.minSustainedTPS
+                )
+            )
+        }
+        if benchmark.ttftMS > candidate.benchGate.max4KTTFTMS {
+            reasons.append(
+                "TTFT \(benchmark.ttftMS)ms exceeds advisory catalog target \(candidate.benchGate.max4KTTFTMS)ms"
+            )
+        }
+        return reasons
     }
 
     static func cachedBenchmarkAdmitted(_ benchmark: CandidateBenchmark, request: AutotuneRecommendRequest, modelKey: String) -> Bool {
@@ -1715,29 +1736,16 @@ struct AutotuneRecommendEngine {
         eligible: Bool
     ) -> String {
         if eligible {
+            if let benchmark {
+                let advisoryReasons = Self.advisoryBenchmarkWarningReasons(benchmark, candidate: candidate)
+                if !advisoryReasons.isEmpty {
+                    return ("\(modelKey) eligible with advisory QoS warning: " + advisoryReasons.joined(separator: "; ")).prefixString(140)
+                }
+            }
             return "\(modelKey) has the best expected provider earnings after measured throughput, buyer demand, and supply deficit.".prefixString(140)
         }
-        if let benchmark {
-            var signedGateFailures: [String] = []
-            if !benchmark.sustainedTPS.isFinite {
-                signedGateFailures.append("TPS evidence is non-finite")
-            } else if benchmark.sustainedTPS < candidate.benchGate.minSustainedTPS {
-                signedGateFailures.append(
-                    String(
-                        format: "TPS %.3f is below signed catalog minimum %.3f",
-                        benchmark.sustainedTPS,
-                        candidate.benchGate.minSustainedTPS
-                    )
-                )
-            }
-            if benchmark.ttftMS > candidate.benchGate.max4KTTFTMS {
-                signedGateFailures.append(
-                    "TTFT \(benchmark.ttftMS)ms exceeds signed catalog maximum \(candidate.benchGate.max4KTTFTMS)ms"
-                )
-            }
-            if !signedGateFailures.isEmpty {
-                return ("\(modelKey): " + signedGateFailures.joined(separator: "; ")).prefixString(140)
-            }
+        if benchmark?.thermalThrottleDetected == true {
+            return "\(modelKey) did not clear the thermal throttle recommendation gate.".prefixString(140)
         }
         return "\(modelKey) did not clear one or more recommendation gates.".prefixString(140)
     }

--- a/phase3-binary/Sources/macprovider-cli/CoordinatorClient.swift
+++ b/phase3-binary/Sources/macprovider-cli/CoordinatorClient.swift
@@ -145,7 +145,7 @@ actor CoordinatorClient {
     typealias CatalogArtifactIdentity = @Sendable (String?) async -> String?
     typealias InstalledCompatibilityManifest = @Sendable (URL, String) -> CompatibilitySetManifest?
 
-    static let binaryVersion = "1.8.45"
+    static let binaryVersion = "1.8.47"
     private static let keepaliveDebugEnabled = ProcessInfo.processInfo.environment["MACPROVIDER_KEEPALIVE_DEBUG"] == "1"
 
     private let coordinatorURL: URL

--- a/phase3-binary/Tests/macprovider-cliTests/AutotuneRecommendTests.swift
+++ b/phase3-binary/Tests/macprovider-cliTests/AutotuneRecommendTests.swift
@@ -2252,9 +2252,9 @@ final class AutotuneRecommendTests: XCTestCase {
         ))
     }
 
-    // MARK: - Signed catalog TPS + TTFT admission parity
+    // MARK: - Signed catalog TPS + TTFT advisory parity
 
-    func testTPSBelowSignedCatalogGateBlocksRecommendation() throws {
+    func testTPSBelowSignedCatalogGateWarnsWithoutBlockingRecommendation() throws {
         var request = try makeRequest()
         let modelKey = "qwen3-coder-30b-a3b-instruct"
         var benchmark = try XCTUnwrap(request.benchmarks[modelKey])
@@ -2264,15 +2264,16 @@ final class AutotuneRecommendTests: XCTestCase {
 
         let result = AutotuneRecommendEngine().recommend(request)
 
-        XCTAssertNil(result.recommendedModel)
-        XCTAssertTrue(result.warnings.contains(.noEligibleModel))
+        XCTAssertEqual(result.recommendedModel, modelKey)
+        XCTAssertTrue(result.warnings.contains(.tpsBelowGate))
+        XCTAssertFalse(result.warnings.contains(.noEligibleModel))
         XCTAssertTrue(
             try XCTUnwrap(result.allCandidates.first { $0.catalogKey == modelKey }).why
-                .contains("below signed catalog minimum")
+                .contains("below advisory catalog target")
         )
     }
 
-    func testTTFTAboveSignedCatalogGateBlocksRecommendation() throws {
+    func testTTFTAboveSignedCatalogGateWarnsWithoutBlockingRecommendation() throws {
         var request = try makeRequest()
         let modelKey = "qwen3-coder-30b-a3b-instruct"
         var benchmark = try XCTUnwrap(request.benchmarks[modelKey])
@@ -2282,12 +2283,31 @@ final class AutotuneRecommendTests: XCTestCase {
 
         let result = AutotuneRecommendEngine().recommend(request)
 
-        XCTAssertNil(result.recommendedModel)
-        XCTAssertTrue(result.warnings.contains(.noEligibleModel))
+        XCTAssertEqual(result.recommendedModel, modelKey)
+        XCTAssertTrue(result.warnings.contains(.ttftAboveGate))
+        XCTAssertFalse(result.warnings.contains(.noEligibleModel))
         XCTAssertTrue(
             try XCTUnwrap(result.allCandidates.first { $0.catalogKey == modelKey }).why
-                .contains("exceeds signed catalog maximum")
+                .contains("exceeds advisory catalog target")
         )
+    }
+
+    func testTPSAndTTFTSignedCatalogGateMissesWarnWithoutBlockingRecommendation() throws {
+        var request = try makeRequest()
+        let modelKey = "qwen3-coder-30b-a3b-instruct"
+        let candidate = try XCTUnwrap(request.candidateCatalog.rows[modelKey])
+        var benchmark = try XCTUnwrap(request.benchmarks[modelKey])
+        benchmark.sustainedTPS = candidate.benchGate.minSustainedTPS.nextDown
+        benchmark.ttftMS = candidate.benchGate.max4KTTFTMS + 1
+        request.benchmarks[modelKey] = benchmark
+
+        let result = AutotuneRecommendEngine().recommend(request)
+
+        XCTAssertEqual(result.recommendedModel, modelKey)
+        XCTAssertTrue(result.warnings.contains(.tpsBelowGate))
+        XCTAssertTrue(result.warnings.contains(.ttftAboveGate))
+        XCTAssertEqual(result.selectedCandidate?.tokensPerSecond, (benchmark.sustainedTPS * 1_000_000).rounded() / 1_000_000)
+        XCTAssertFalse(result.warnings.contains(.noEligibleModel))
     }
 
     func testSignedCatalogGateBoundariesAreInclusiveLikeCoordinator() throws {
@@ -2304,7 +2324,7 @@ final class AutotuneRecommendTests: XCTestCase {
         XCTAssertEqual(result.recommendedModel, modelKey)
     }
 
-    func testDonorModeAlsoRejectsSignedCatalogGateFailures() throws {
+    func testDonorModeAlsoTreatsSignedCatalogGateFailuresAsAdvisory() throws {
         var request = try makeRequest(modelKey: "qwen3-32b")
         request.donorMode = true
         request.hardware.bandwidthTier = .a
@@ -2314,7 +2334,7 @@ final class AutotuneRecommendTests: XCTestCase {
         benchmark.ttftMS = 100_000
         request.benchmarks["qwen3-32b"] = benchmark
 
-        XCTAssertFalse(AutotuneRecommendEngine.donorModeAdmitted(
+        XCTAssertTrue(AutotuneRecommendEngine.donorModeAdmitted(
             modelKey: "qwen3-32b",
             candidate: request.candidateCatalog.rows["qwen3-32b"],
             request: request

--- a/phase3-binary/Tests/macprovider-cliTests/CoordinatorClientTests.swift
+++ b/phase3-binary/Tests/macprovider-cliTests/CoordinatorClientTests.swift
@@ -3612,10 +3612,10 @@ final class CoordinatorClientTests: XCTestCase {
         let hello = await client.helloMessage()
         let auth = await client.authInitialMessage(attempt: attempt)
 
-        XCTAssertEqual(CoordinatorClient.binaryVersion, "1.8.45")
-        XCTAssertEqual(MacProviderCLI.configuration.version, "1.8.45")
-        XCTAssertEqual(hello["binary_version"] as? String, "1.8.45")
-        XCTAssertEqual(auth["binary_version"] as? String, "1.8.45")
+        XCTAssertEqual(CoordinatorClient.binaryVersion, "1.8.47")
+        XCTAssertEqual(MacProviderCLI.configuration.version, "1.8.47")
+        XCTAssertEqual(hello["binary_version"] as? String, "1.8.47")
+        XCTAssertEqual(auth["binary_version"] as? String, "1.8.47")
     }
 
     func testCatalogProviderRejectsCoordinatorWithoutAdmissionAcknowledgement() async throws {

--- a/phase4-coordinator/coordinator.yaml.example
+++ b/phase4-coordinator/coordinator.yaml.example
@@ -179,7 +179,7 @@ autotune:
 # legacy cohort (DECISION_CRITERIA Entry 161). `required_binary_version` is a
 # hard admission floor, not an autoupdate target, and is unaffected by the gate.
 coordinator_advertised_version:
-  latest_binary_version: "1.8.45"
+  latest_binary_version: "1.8.47"
   required_binary_version: ""
 
 auth:

--- a/phase4-coordinator/dist/coordinator.yaml
+++ b/phase4-coordinator/dist/coordinator.yaml
@@ -297,4 +297,4 @@ providers:
 # legacy cohort (DECISION_CRITERIA Entry 161). Setting this value does not, and
 # must not, re-arm the legacy binary-only updater.
 coordinator_advertised_version:
-  latest_binary_version: "1.8.45"
+  latest_binary_version: "1.8.47"

--- a/phase4-coordinator/dist/coordinator.yaml.example
+++ b/phase4-coordinator/dist/coordinator.yaml.example
@@ -352,7 +352,7 @@ malibu_emission:
 # Use for security fixes that must not be optional. Leave unset for advisory
 # releases.
 coordinator_advertised_version:
-  latest_binary_version: "1.8.45"
+  latest_binary_version: "1.8.47"
   # required_binary_version: "1.7.0"
 
 # Enumerated providers (SPEC-002 v1.0.4 Finding F-2: every provider_id that

--- a/phase4-coordinator/internal/autotune/gate.go
+++ b/phase4-coordinator/internal/autotune/gate.go
@@ -2,7 +2,6 @@ package autotune
 
 import (
 	"fmt"
-	"math"
 	"strings"
 )
 
@@ -102,11 +101,8 @@ func benchmarkPassesGate(benchmark VerifiedBenchmark, row Row, catalogSHA256, ro
 	if strings.TrimSpace(benchmark.ArtifactSHA256) == "" || !strings.EqualFold(strings.TrimSpace(benchmark.ArtifactSHA256), strings.TrimSpace(row.ModelSHA256)) {
 		return false
 	}
-	if math.IsNaN(benchmark.SustainedTPS) || math.IsInf(benchmark.SustainedTPS, 0) || benchmark.SustainedTPS < row.BenchGate.MinSustainedTPS {
-		return false
-	}
-	if benchmark.TTFTMS > row.BenchGate.Max4KTTFTMS {
-		return false
-	}
+	// SPEC-023 v0.2: min_sustained_tps and max_4k_ttft_ms are advisory QoS
+	// thresholds. The coordinator mirror must not reject an otherwise valid
+	// benchmark row for low TPS, high TTFT, or a missing/non-finite TPS value.
 	return true
 }

--- a/phase4-coordinator/internal/autotune/gate_test.go
+++ b/phase4-coordinator/internal/autotune/gate_test.go
@@ -124,6 +124,35 @@ func TestEvaluateHelloGateRejectsThermalThrottle(t *testing.T) {
 	}
 }
 
+func TestEvaluateHelloGateTreatsTPSAndTTFTMissesAsAdvisory(t *testing.T) {
+	t.Parallel()
+	catalog := mustCatalog(t, `{
+		"version":"test",
+		"generated_at":"2026-07-08T00:00:00Z",
+		"source":"operator_curated_autotune_candidate_catalog",
+		"rows":{
+			"small":{"model_id":"mlx-community/Llama-3.2-3B-Instruct-4bit","model_revision":"7f0dc925e0d0afb0322d96f9255cfddf2ba5636e","model_sha256":"3975387f249977e5e8bfb7ed0d352f8258ac3d630f961ce1dd952f428ee7216a","min_ram_gb":4,"min_bandwidth_tier":"C","bench_gate":{"min_sustained_tps":15,"max_4k_ttft_ms":2500},"runtime_status":"recommendable"}
+		}
+	}`)
+	evidence := autotune.VerifiedEvidence{
+		CandidateCatalogSHA256: catalog.SHA256,
+		Benchmarks: []autotune.VerifiedBenchmark{
+			{
+				ModelKey:               "small",
+				ModelID:                "mlx-community/Llama-3.2-3B-Instruct-4bit",
+				SustainedTPS:           1,
+				TTFTMS:                 12_000,
+				ArtifactSHA256:         "3975387f249977e5e8bfb7ed0d352f8258ac3d630f961ce1dd952f428ee7216a",
+				CandidateCatalogSHA256: catalog.SHA256,
+			},
+		},
+	}
+	decision := autotune.EvaluateHelloGate(catalog, evidence, "mlx-community/Llama-3.2-3B-Instruct-4bit")
+	if !decision.Allowed || decision.MaxAdmittedModelKey != "small" {
+		t.Fatalf("TPS/TTFT advisory miss rejected: %+v", decision)
+	}
+}
+
 func TestEvaluateHelloGateRejectsMissingModelOrArtifactBinding(t *testing.T) {
 	t.Parallel()
 	catalog := mustCatalog(t, `{

--- a/phase4-coordinator/internal/referralapi/advocacy.go
+++ b/phase4-coordinator/internal/referralapi/advocacy.go
@@ -125,7 +125,7 @@ func (h *AdvocacyHandler) HandleChallenge(w http.ResponseWriter, r *http.Request
 	}
 	shareURL := strings.TrimRight(strings.TrimSpace(h.JoinBaseURL), "/") + "/" +
 		url.PathEscape(challenge.Code) + "?c=" + url.QueryEscape(challenge.Cleartext)
-	copy := "My Mac just joined Malibu's pre-beta compute network. If you have a Mac and want early access: " + shareURL
+	copy := "My Mac just joined @malibuonbase’s pre-beta compute network. If you have a Mac and want early access: " + shareURL
 	h.observe("challenge", "created")
 	writeJSON(w, http.StatusOK, map[string]any{
 		"intent_url": "https://twitter.com/intent/tweet?text=" + url.QueryEscape(copy),

--- a/phase4-coordinator/internal/referralapi/advocacy_test.go
+++ b/phase4-coordinator/internal/referralapi/advocacy_test.go
@@ -190,6 +190,39 @@ func createAdvocacyChallenge(t *testing.T, handler *AdvocacyHandler) (shareURL, 
 	return body.ShareURL, challenge
 }
 
+func TestAdvocacyChallengeIntentUsesTaggedMalibuHandle(t *testing.T) {
+	store := openAdvocacyStore(t)
+	now := time.Date(2026, 7, 18, 9, 0, 0, 0, time.UTC)
+	qualifyAdvocacyProvider(t, store, advocacyPolicy(), "provider-copy", now)
+	handler := newAdvocacyHandler(store, "provider-copy", now)
+
+	response := httptest.NewRecorder()
+	handler.HandleChallenge(response, bearerRequest(http.MethodPost, "/v1/provider/referrals/x/challenge", ""))
+	if response.Code != http.StatusOK {
+		t.Fatalf("challenge status=%d body=%s", response.Code, response.Body.String())
+	}
+
+	var body struct {
+		ShareURL string `json:"share_url"`
+		Intent   string `json:"intent_url"`
+	}
+	if err := json.Unmarshal(response.Body.Bytes(), &body); err != nil {
+		t.Fatal(err)
+	}
+	parsedIntent, err := url.Parse(body.Intent)
+	if err != nil {
+		t.Fatal(err)
+	}
+	decodedText := parsedIntent.Query().Get("text")
+	want := "My Mac just joined @malibuonbase’s pre-beta compute network. If you have a Mac and want early access: " + body.ShareURL
+	if decodedText != want {
+		t.Fatalf("decoded intent text mismatch\nwant: %q\n got: %q", want, decodedText)
+	}
+	if strings.Contains(decodedText, "joined Malibu's") {
+		t.Fatalf("decoded intent text retained untagged legacy copy: %q", decodedText)
+	}
+}
+
 func TestAdvocacyXSubmissionIsExactReplaySafeAfterResponseLoss(t *testing.T) {
 	store := openAdvocacyStore(t)
 	now := time.Date(2026, 7, 13, 10, 0, 0, 0, time.UTC)

--- a/specs/CONFORMANCE.json
+++ b/specs/CONFORMANCE.json
@@ -1036,6 +1036,32 @@
       }
     },
     {
+      "requirement_id": "SPEC-023-R001",
+      "spec_id": "SPEC-023",
+      "state": "pending",
+      "implementation": [
+        "phase3-binary/Sources/macprovider-cli/AutotuneRecommend.swift:func isEligible(",
+        "phase3-binary/Sources/macprovider-cli/AutotuneRecommend.swift:static func advisoryBenchmarkWarnings(",
+        "phase4-coordinator/internal/autotune/gate.go:func benchmarkPassesGate("
+      ],
+      "tests": [
+        "phase3-binary/Tests/macprovider-cliTests/AutotuneRecommendTests.swift::testTPSBelowSignedCatalogGateWarnsWithoutBlockingRecommendation",
+        "phase3-binary/Tests/macprovider-cliTests/AutotuneRecommendTests.swift::testTTFTAboveSignedCatalogGateWarnsWithoutBlockingRecommendation",
+        "phase3-binary/Tests/macprovider-cliTests/AutotuneRecommendTests.swift::testTPSAndTTFTSignedCatalogGateMissesWarnWithoutBlockingRecommendation",
+        "phase3-binary/Tests/macprovider-cliTests/AutotuneRecommendTests.swift::testThermalThrottleStillHardBlocksEligibility",
+        "phase4-coordinator/internal/autotune/gate_test.go::TestEvaluateHelloGateTreatsTPSAndTTFTMissesAsAdvisory",
+        "phase4-coordinator/internal/autotune/gate_test.go::TestEvaluateHelloGateRejectsThermalThrottle"
+      ],
+      "journeys": [],
+      "evidence": [],
+      "gap": {
+        "verdict": "CODE_BUG",
+        "owner": "@Augustas11",
+        "issue": "https://github.com/Augustas11/macprovider/issues/612",
+        "rationale": "SPEC-023 advisory TPS/TTFT behavior is repaired here, but the requirement remains pending until a signed candidate completes the physical referral/X acceptance journey."
+      }
+    },
+    {
       "requirement_id": "SPEC-033-R001",
       "spec_id": "SPEC-033",
       "state": "pending",

--- a/specs/README.md
+++ b/specs/README.md
@@ -31,7 +31,7 @@ it can no longer drift. Do not hand-edit the table; edit each spec's
 | SPEC-020 | Provider autoupdate | v0.1.8 | normative | pending | nonconformant: 3 | [SPEC-020-provider-autoupdate.md](SPEC-020-provider-autoupdate.md) |
 | SPEC-021 | MALIBU bootstrap rewards emission ledger | 0.1.0 | draft | pending | pending corpus migration | [SPEC-021-malibu-emission-ledger.md](SPEC-021-malibu-emission-ledger.md) |
 | SPEC-022 | Verified model settlement | v0.1.5 | draft | pending | pending corpus migration | [SPEC-022-verified-model-settlement.md](SPEC-022-verified-model-settlement.md) |
-| SPEC-023 | Installer-Integrated Autotune Recommend | v0.6 | normative | pending | pending corpus migration | [SPEC-023-installer-autotune-recommend.md](SPEC-023-installer-autotune-recommend.md) |
+| SPEC-023 | Installer-Integrated Autotune Recommend | v0.6 | normative | pending | pending: 1 | [SPEC-023-installer-autotune-recommend.md](SPEC-023-installer-autotune-recommend.md) |
 | SPEC-024 | Prefix-cache billing and provider-local cache isolation | 0.2.1 | normative | pending | pending corpus migration | [SPEC-024-prefix-cache-billing.md](SPEC-024-prefix-cache-billing.md) |
 | SPEC-025 | Native Mac App (signed `.dmg` + menu bar wrapper) | v0.18 | draft | pending | pending corpus migration | [SPEC-025-native-mac-app.md](SPEC-025-native-mac-app.md) |
 | SPEC-026 | Browserless Provider Onboarding (one-click Launch Provider) | v0.25 | draft | pending | pending corpus migration | [SPEC-026-browserless-provider-onboarding.md](SPEC-026-browserless-provider-onboarding.md) |


### PR DESCRIPTION
## What changed

- Updates the coordinator-owned X challenge intent copy to tag `@malibuonbase` exactly.
- Adds a decoded-intent regression test for the generated public post text.
- Restores SPEC-023 advisory semantics for signed `min_sustained_tps` / `max_4k_ttft_ms` in the CLI recommendation path.
- Mirrors the advisory TPS/TTFT behavior in coordinator autotune admission while preserving thermal throttle, catalog/artifact binding, RAM, bandwidth, trust, and freshness gates.
- Bumps CLI/coordinator advertised version to `1.8.47`; Malibu remains independently versioned at `1.8.41`.
- Adds pending `SPEC-023-R001` conformance metadata for the advisory-gate contract; physical conformance remains pending until the signed Air referral/X journey passes.

SPEC-GOVERNANCE-DECLARATION-BEGIN
{
  "schema_version": "spec-pr-governance-v1",
  "behavior_change": "yes",
  "contract_change": "yes",
  "specs": ["SPEC-023", "SPEC-034"],
  "requirements": ["SPEC-023-R001"],
  "authority_domains": ["installer-autotune-policy", "referral-advocacy-policy"],
  "arbitration": ["CODE_BUG"],
  "tests": [
    "phase3-binary/Tests/macprovider-cliTests/AutotuneRecommendTests.swift::testTPSBelowSignedCatalogGateWarnsWithoutBlockingRecommendation",
    "phase3-binary/Tests/macprovider-cliTests/AutotuneRecommendTests.swift::testTTFTAboveSignedCatalogGateWarnsWithoutBlockingRecommendation",
    "phase3-binary/Tests/macprovider-cliTests/AutotuneRecommendTests.swift::testTPSAndTTFTSignedCatalogGateMissesWarnWithoutBlockingRecommendation",
    "phase3-binary/Tests/macprovider-cliTests/AutotuneRecommendTests.swift::testThermalThrottleStillHardBlocksEligibility",
    "phase4-coordinator/internal/autotune/gate_test.go::TestEvaluateHelloGateTreatsTPSAndTTFTMissesAsAdvisory",
    "phase4-coordinator/internal/referralapi/advocacy_test.go::TestAdvocacyChallengeIntentUsesTaggedMalibuHandle"
  ],
  "journeys": ["JOURNEY-PHYSICAL-REFERRAL-X-PENDING"],
  "issue": "https://github.com/Augustas11/macprovider/issues/612"
}
SPEC-GOVERNANCE-DECLARATION-END

## Validation

- `swift test --filter 'AutotuneRecommendTests/testTPSBelowSignedCatalogGateWarnsWithoutBlockingRecommendation|AutotuneRecommendTests/testTTFTAboveSignedCatalogGateWarnsWithoutBlockingRecommendation|AutotuneRecommendTests/testTPSAndTTFTSignedCatalogGateMissesWarnWithoutBlockingRecommendation|AutotuneRecommendTests/testThermalThrottleStillHardBlocksEligibility|AutotuneRecommendTests/testDonorModeAlsoTreatsSignedCatalogGateFailuresAsAdvisory|CoordinatorClientTests/testBinaryVersion_AdvertisesSPEC020V17AcrossHandshakeFrames'`
- `swift test`
- `swift build -c release`
- `cd phase4-coordinator && go test ./...`
- `cd phase4-coordinator && go vet ./...`
- `python3 scripts/check_spec_governance.py --base-ref origin/main`
- `python3 scripts/gen_spec_index.py --check`
- `python3 scripts/gen_spec_index.py --lint`
- `python3 -m unittest -v scripts.tests.test_spec_governance scripts.tests.test_spec_pr_declaration`
- `./scripts/test-coordinator-advertised-version.sh`
- `git diff --check`

## Notes

- No production flags changed.
- No referral ledger, redemption, credential, bearer, or social verification policy changed.
- Physical Air referral and fresh X challenge must resume only from the signed `1.8.47` candidate built after this merges.
- Bounded self-review performed; external advisor unavailable by instruction and not used.
