### PR TITLE
Promote physically accepted release bytes without rebuilding

### DIFF
--- a/.github/workflows/acceptance-candidate.yml
+++ b/.github/workflows/acceptance-candidate.yml
@@ -23,6 +23,11 @@ on:
         options:
           - bridge_required
           - strict_post_migration
+      promotion_ready:
+        description: "Bind the exact candidate assets for stable production promotion after physical acceptance"
+        required: true
+        default: false
+        type: boolean
 
 permissions:
   contents: read
@@ -43,6 +48,7 @@ jobs:
       control_commit: ${{ steps.source.outputs.control_commit }}
       tag: ${{ steps.source.outputs.tag }}
       provider_admission_policy: ${{ steps.source.outputs.provider_admission_policy }}
+      promotion_ready: ${{ steps.source.outputs.promotion_ready }}
     steps:
       - name: Checkout main-owned workflow controls
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
@@ -69,6 +75,7 @@ jobs:
           CANDIDATE_SHA_INPUT: ${{ github.event.inputs.candidate_sha }}
           TAG_INPUT: ${{ github.event.inputs.tag }}
           PROVIDER_ADMISSION_POLICY_INPUT: ${{ github.event.inputs.provider_admission_policy }}
+          PROMOTION_READY_INPUT: ${{ github.event.inputs.promotion_ready || 'false' }}
         run: |
           set -euo pipefail
           bash control/scripts/verify-acceptance-candidate-source.sh \
@@ -78,11 +85,16 @@ jobs:
             bridge_required|strict_post_migration) ;;
             *) echo "::error::invalid provider admission policy" >&2; exit 1 ;;
           esac
+          case "$PROMOTION_READY_INPUT" in
+            true|false) ;;
+            *) echo "::error::invalid promotion-ready state" >&2; exit 1 ;;
+          esac
           printf 'candidate_ref=%s\n' "$CANDIDATE_REF_INPUT" >> "$GITHUB_OUTPUT"
           printf 'candidate_commit=%s\n' "$CANDIDATE_SHA_INPUT" >> "$GITHUB_OUTPUT"
           printf 'control_commit=%s\n' "$GITHUB_SHA" >> "$GITHUB_OUTPUT"
           printf 'tag=%s\n' "$TAG_INPUT" >> "$GITHUB_OUTPUT"
           printf 'provider_admission_policy=%s\n' "$PROVIDER_ADMISSION_POLICY_INPUT" >> "$GITHUB_OUTPUT"
+          printf 'promotion_ready=%s\n' "$PROMOTION_READY_INPUT" >> "$GITHUB_OUTPUT"
 
       - name: Select and verify main-reviewed release toolchain
         shell: bash
@@ -326,6 +338,7 @@ jobs:
           CONTROL_COMMIT: ${{ needs.build_candidate.outputs.control_commit }}
           TAG: ${{ needs.build_candidate.outputs.tag }}
           PROVIDER_ADMISSION_POLICY: ${{ needs.build_candidate.outputs.provider_admission_policy }}
+          PROMOTION_READY: ${{ needs.build_candidate.outputs.promotion_ready }}
         run: |
           set -euo pipefail
           bash scripts/sign-acceptance-candidate.sh \
@@ -338,7 +351,8 @@ jobs:
             "$CONTROL_COMMIT" \
             "$GITHUB_RUN_ID" \
             "$GITHUB_RUN_ATTEMPT" \
-            "$PROVIDER_ADMISSION_POLICY"
+            "$PROVIDER_ADMISSION_POLICY" \
+            "$PROMOTION_READY"
 
       - name: Reverify candidate ref and tag before private export
         shell: bash

--- a/.github/workflows/promote-acceptance-candidate.yml
+++ b/.github/workflows/promote-acceptance-candidate.yml
@@ -1,0 +1,432 @@
+name: Promote exact physically accepted candidate
+
+on:
+  workflow_dispatch:
+    inputs:
+      candidate_run_id:
+        description: "Successful acceptance-candidate workflow run ID"
+        required: true
+        type: string
+      candidate_sha:
+        description: "Exact accepted 40-character lowercase source SHA"
+        required: true
+        type: string
+      tag:
+        description: "Exact accepted semantic version tag"
+        required: true
+        type: string
+      expected_checksums_sha256:
+        description: "SHA-256 of checksums.txt recorded during physical acceptance"
+        required: true
+        type: string
+      physical_acceptance_confirmed:
+        description: "Confirm the exact checksums digest completed the physical acceptance journey"
+        required: true
+        default: false
+        type: boolean
+
+permissions:
+  actions: read
+  contents: write
+
+concurrency:
+  group: production-release
+  cancel-in-progress: false
+
+jobs:
+  promote:
+    name: Publish only the accepted bytes
+    runs-on: macos-15
+    environment: production-release
+    outputs:
+      tag: ${{ steps.request.outputs.tag }}
+    steps:
+      - name: Checkout reviewed promotion controls
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+        with:
+          ref: ${{ github.sha }}
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Validate immutable promotion request
+        id: request
+        shell: bash
+        env:
+          RUN_ID_INPUT: ${{ github.event.inputs.candidate_run_id }}
+          CANDIDATE_SHA_INPUT: ${{ github.event.inputs.candidate_sha }}
+          TAG_INPUT: ${{ github.event.inputs.tag }}
+          CHECKSUMS_SHA_INPUT: ${{ github.event.inputs.expected_checksums_sha256 }}
+          PHYSICAL_ACCEPTANCE_INPUT: ${{ github.event.inputs.physical_acceptance_confirmed || 'false' }}
+        run: |
+          set -euo pipefail
+          [[ "$RUN_ID_INPUT" =~ ^[1-9][0-9]*$ ]] || { echo "::error::invalid candidate run id" >&2; exit 1; }
+          [[ "$CANDIDATE_SHA_INPUT" =~ ^[0-9a-f]{40}$ ]] || { echo "::error::invalid candidate SHA" >&2; exit 1; }
+          [[ "$TAG_INPUT" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]] || { echo "::error::invalid tag" >&2; exit 1; }
+          [[ "$CHECKSUMS_SHA_INPUT" =~ ^[0-9a-f]{64}$ ]] || { echo "::error::invalid checksums digest" >&2; exit 1; }
+          [[ "$PHYSICAL_ACCEPTANCE_INPUT" == true ]] || {
+            echo "::error::exact physical acceptance must be explicitly confirmed" >&2
+            exit 1
+          }
+          printf 'run_id=%s\n' "$RUN_ID_INPUT" >> "$GITHUB_OUTPUT"
+          printf 'candidate_sha=%s\n' "$CANDIDATE_SHA_INPUT" >> "$GITHUB_OUTPUT"
+          printf 'tag=%s\n' "$TAG_INPUT" >> "$GITHUB_OUTPUT"
+          printf 'checksums_sha=%s\n' "$CHECKSUMS_SHA_INPUT" >> "$GITHUB_OUTPUT"
+
+      - name: Verify protected GitHub release posture
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_POSTURE_TOKEN }}
+        run: bash scripts/verify-github-release-posture.sh "$GITHUB_REPOSITORY" production-release 28995904
+
+      - name: Capture the exact successful acceptance run
+        id: run
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RUN_ID: ${{ steps.request.outputs.run_id }}
+        run: |
+          set -euo pipefail
+          gh api -H 'X-GitHub-Api-Version: 2026-03-10' \
+            "repos/$GITHUB_REPOSITORY/actions/runs/$RUN_ID" > "$RUNNER_TEMP/acceptance-run.json"
+          gh api -H 'X-GitHub-Api-Version: 2026-03-10' \
+            "repos/$GITHUB_REPOSITORY/actions/runs/$RUN_ID/artifacts?per_page=100" \
+            > "$RUNNER_TEMP/acceptance-artifacts.json"
+          python3 - "$RUNNER_TEMP/acceptance-run.json" "$GITHUB_OUTPUT" <<'PY'
+          import json
+          import pathlib
+          import sys
+
+          value = json.loads(pathlib.Path(sys.argv[1]).read_text(encoding="utf-8"))
+          attempt = value.get("run_attempt")
+          control = value.get("head_sha")
+          if type(attempt) is not int or attempt <= 0:
+              raise SystemExit("invalid acceptance run attempt")
+          if not isinstance(control, str) or len(control) != 40:
+              raise SystemExit("invalid acceptance control SHA")
+          with open(sys.argv[2], "a", encoding="ascii") as output:
+              output.write(f"run_attempt={attempt}\ncontrol_sha={control}\n")
+          PY
+
+      - name: Download only the exact private acceptance artifact
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
+        with:
+          github-token: ${{ github.token }}
+          repository: ${{ github.repository }}
+          run-id: ${{ steps.request.outputs.run_id }}
+          name: acceptance-candidate-${{ steps.request.outputs.candidate_sha }}
+          path: ${{ runner.temp }}/accepted
+
+      - name: Select OpenSSL 3
+        shell: bash
+        env:
+          HOMEBREW_NO_AUTO_UPDATE: "1"
+        run: |
+          set -euo pipefail
+          brew install openssl@3
+          openssl_bin="$(brew --prefix openssl@3)/bin/openssl"
+          "$openssl_bin" version | grep -E '^OpenSSL 3\.'
+          printf 'OPENSSL_BIN=%s\n' "$openssl_bin" >> "$GITHUB_ENV"
+
+      - name: Verify the signed acceptance set and production metadata
+        shell: bash
+        env:
+          RUN_ID: ${{ steps.request.outputs.run_id }}
+          RUN_ATTEMPT: ${{ steps.run.outputs.run_attempt }}
+          CANDIDATE_SHA: ${{ steps.request.outputs.candidate_sha }}
+          CONTROL_SHA: ${{ steps.run.outputs.control_sha }}
+          TAG: ${{ steps.request.outputs.tag }}
+          EXPECTED_CHECKSUMS_SHA: ${{ steps.request.outputs.checksums_sha }}
+        run: |
+          set -euo pipefail
+          accepted="$RUNNER_TEMP/accepted"
+          python3 scripts/verify-acceptance-promotion.py verify-run \
+            --run-json "$RUNNER_TEMP/acceptance-run.json" \
+            --artifacts-json "$RUNNER_TEMP/acceptance-artifacts.json" \
+            --repository "$GITHUB_REPOSITORY" \
+            --run-id "$RUN_ID" \
+            --run-attempt "$RUN_ATTEMPT" \
+            --candidate-sha "$CANDIDATE_SHA" \
+            --control-sha "$CONTROL_SHA"
+          python3 scripts/verify-acceptance-promotion.py verify-directory \
+            --directory "$accepted" \
+            --repository "$GITHUB_REPOSITORY" \
+            --run-id "$RUN_ID" \
+            --run-attempt "$RUN_ATTEMPT" \
+            --tag "$TAG" \
+            --candidate-sha "$CANDIDATE_SHA" \
+            --control-sha "$CONTROL_SHA" \
+            --expected-checksums-sha256 "$EXPECTED_CHECKSUMS_SHA" \
+            --release-public-key ops/pearl-updater/release-signing-public.pem \
+            --openssl "$OPENSSL_BIN"
+          release_assets=()
+          while IFS= read -r name; do
+            [[ -n "$name" ]] && release_assets+=("$accepted/$name")
+          done < "$accepted/release-assets.txt"
+          bash scripts/verify-release-checksums.sh \
+            --acceptance-candidate \
+            "$accepted/acceptance-candidate.json" \
+            "refs/heads/$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1]))[\"candidate_ref\"].removeprefix(\"refs/heads/\"))' "$accepted/acceptance-candidate.json")" \
+            "$RUN_ID" "$RUN_ATTEMPT" "$CONTROL_SHA" \
+            "$accepted/checksums.txt" \
+            "$accepted/acceptance-candidate.json.sig" \
+            "$accepted/release-provenance.json" \
+            "$GITHUB_REPOSITORY" "$TAG" "$CANDIDATE_SHA" \
+            "${release_assets[@]}"
+
+      - name: Verify accepted source is merged and reserve its exact tag
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_POSTURE_TOKEN }}
+          TAG: ${{ steps.request.outputs.tag }}
+          CANDIDATE_SHA: ${{ steps.request.outputs.candidate_sha }}
+          CONTROL_SHA: ${{ steps.run.outputs.control_sha }}
+        run: |
+          set -euo pipefail
+          tagger_id="$(gh api -H 'X-GitHub-Api-Version: 2026-03-10' user --jq .id)"
+          [[ "$tagger_id" == 28995904 ]] || {
+            echo "::error::protected tag credential is not the configured ruleset bypass actor" >&2
+            exit 1
+          }
+          git fetch --quiet --no-tags origin refs/heads/main:refs/remotes/origin/main
+          git cat-file -e "$CANDIDATE_SHA^{commit}"
+          git cat-file -e "$CONTROL_SHA^{commit}"
+          git merge-base --is-ancestor "$CANDIDATE_SHA" refs/remotes/origin/main || {
+            echo "::error::accepted candidate is not reachable from origin/main" >&2
+            exit 1
+          }
+          git merge-base --is-ancestor "$CONTROL_SHA" refs/remotes/origin/main || {
+            echo "::error::acceptance signer control commit is not reachable from origin/main" >&2
+            exit 1
+          }
+          gh api --paginate --slurp -H 'X-GitHub-Api-Version: 2026-03-10' \
+            "repos/$GITHUB_REPOSITORY/releases?per_page=100" > "$RUNNER_TEMP/release-pages.json"
+          python3 - "$RUNNER_TEMP/release-pages.json" "$TAG" <<'PY'
+          import json
+          import pathlib
+          import sys
+
+          pages = json.loads(pathlib.Path(sys.argv[1]).read_text(encoding="utf-8"))
+          tag = sys.argv[2]
+          matches = [
+              row
+              for page in pages
+              if isinstance(page, list)
+              for row in page
+              if isinstance(row, dict) and row.get("tag_name") == tag
+          ]
+          if matches:
+              raise SystemExit("a draft or public release already exists for the accepted tag")
+          PY
+          tag_rows="$(git ls-remote origin "refs/tags/$TAG" "refs/tags/$TAG^{}")"
+          if [[ -z "$tag_rows" ]]; then
+            gh api --method POST -H 'X-GitHub-Api-Version: 2026-03-10' \
+              "repos/$GITHUB_REPOSITORY/git/refs" \
+              -f ref="refs/tags/$TAG" -f sha="$CANDIDATE_SHA" >/dev/null
+          fi
+          bash scripts/verify-release-tag-target.sh "$TAG" "$CANDIDATE_SHA" origin --require-existing
+
+      - name: Generate only the production checksum signature
+        shell: bash
+        env:
+          MACPROVIDER_RELEASE_SIGNING_KEY_PEM: ${{ secrets.MACPROVIDER_RELEASE_SIGNING_KEY_PEM }}
+          TAG: ${{ steps.request.outputs.tag }}
+          CANDIDATE_SHA: ${{ steps.request.outputs.candidate_sha }}
+        run: |
+          set -euo pipefail
+          accepted="$RUNNER_TEMP/accepted"
+          key="$(mktemp "$RUNNER_TEMP/release-signing-private.XXXXXX.pem")"
+          trap 'rm -f "$key"' EXIT
+          printf '%s\n' "$MACPROVIDER_RELEASE_SIGNING_KEY_PEM" > "$key"
+          chmod 600 "$key"
+          "$OPENSSL_BIN" pkey -in "$key" -pubout -out "$RUNNER_TEMP/release-public.pem"
+          cmp "$RUNNER_TEMP/release-public.pem" ops/pearl-updater/release-signing-public.pem
+          "$OPENSSL_BIN" dgst -sha256 -sign "$key" \
+            -out "$accepted/checksums.txt.sig" "$accepted/checksums.txt"
+          release_assets=()
+          while IFS= read -r name; do
+            [[ -n "$name" ]] && release_assets+=("$accepted/$name")
+          done < "$accepted/release-assets.txt"
+          bash scripts/verify-release-checksums.sh \
+            "$accepted/checksums.txt" "$accepted/checksums.txt.sig" \
+            "$accepted/release-provenance.json" \
+            "$GITHUB_REPOSITORY" "$TAG" "$CANDIDATE_SHA" \
+            "${release_assets[@]}"
+
+      - name: Create and fully verify a numeric draft
+        id: draft
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ steps.request.outputs.tag }}
+          CANDIDATE_SHA: ${{ steps.request.outputs.candidate_sha }}
+        run: |
+          set -euo pipefail
+          accepted="$RUNNER_TEMP/accepted"
+          release_assets=()
+          while IFS= read -r name; do
+            [[ -n "$name" ]] && release_assets+=("$accepted/$name")
+          done < "$accepted/release-assets.txt"
+          notes="$RUNNER_TEMP/release-notes.md"
+          printf '# macprovider-cli %s\n\nExact bytes promoted after signed physical acceptance.\n' "$TAG" > "$notes"
+          gh release create "$TAG" \
+            "${release_assets[@]}" \
+            "$accepted/checksums.txt" \
+            "$accepted/checksums.txt.sig" \
+            --title "macprovider-cli $TAG" \
+            --notes-file "$notes" \
+            --target "$CANDIDATE_SHA" \
+            --verify-tag \
+            --draft
+          gh release view "$TAG" \
+            --json databaseId,isDraft,tagName,targetCommitish > "$RUNNER_TEMP/draft-cli.json"
+          release_id="$(python3 scripts/verify-release-draft-identity.py cli \
+            "$RUNNER_TEMP/draft-cli.json" "$TAG" "$CANDIDATE_SHA")"
+          gh api -H 'X-GitHub-Api-Version: 2026-03-10' \
+            "repos/$GITHUB_REPOSITORY/releases/$release_id" > "$RUNNER_TEMP/draft-api.json"
+          python3 scripts/verify-release-draft-identity.py api \
+            "$RUNNER_TEMP/draft-api.json" "$TAG" "$CANDIDATE_SHA" \
+            --release-id "$release_id" >/dev/null
+          python3 scripts/capture-release-publication.py --draft --notes-file "$notes" \
+            "$RUNNER_TEMP/draft-api.json" "$accepted/release-provenance.json" \
+            "$RUNNER_TEMP/draft-publication.json" \
+            "${release_assets[@]}" "$accepted/checksums.txt" "$accepted/checksums.txt.sig"
+          printf 'release_id=%s\n' "$release_id" >> "$GITHUB_OUTPUT"
+
+      - name: Reverify and publish only the captured numeric draft
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_POSTURE_TOKEN: ${{ secrets.RELEASE_POSTURE_TOKEN }}
+          TAG: ${{ steps.request.outputs.tag }}
+          CANDIDATE_SHA: ${{ steps.request.outputs.candidate_sha }}
+          RELEASE_ID: ${{ steps.draft.outputs.release_id }}
+        run: |
+          set -euo pipefail
+          accepted="$RUNNER_TEMP/accepted"
+          release_assets=()
+          while IFS= read -r name; do
+            [[ -n "$name" ]] && release_assets+=("$accepted/$name")
+          done < "$accepted/release-assets.txt"
+          notes="$RUNNER_TEMP/release-notes.md"
+          bash scripts/verify-release-tag-target.sh "$TAG" "$CANDIDATE_SHA" origin --require-existing
+          GH_TOKEN="$RELEASE_POSTURE_TOKEN" \
+            bash scripts/verify-github-release-posture.sh \
+              "$GITHUB_REPOSITORY" production-release 28995904
+          bash scripts/verify-release-checksums.sh \
+            "$accepted/checksums.txt" "$accepted/checksums.txt.sig" \
+            "$accepted/release-provenance.json" \
+            "$GITHUB_REPOSITORY" "$TAG" "$CANDIDATE_SHA" \
+            "${release_assets[@]}"
+          gh api -H 'X-GitHub-Api-Version: 2026-03-10' \
+            --include "repos/$GITHUB_REPOSITORY/releases/$RELEASE_ID" \
+            > "$RUNNER_TEMP/final-draft-response"
+          python3 - "$RUNNER_TEMP/final-draft-response" \
+            "$RUNNER_TEMP/final-draft.json" "$RUNNER_TEMP/final-draft-etag" <<'PY'
+          import pathlib
+          import sys
+
+          raw = pathlib.Path(sys.argv[1]).read_bytes()
+          separator = b"\r\n\r\n" if b"\r\n\r\n" in raw else b"\n\n"
+          headers, marker, body = raw.partition(separator)
+          if not marker:
+              raise SystemExit("GitHub draft response omitted headers")
+          etags = []
+          for line in headers.decode("latin-1").splitlines():
+              name, delimiter, value = line.partition(":")
+              if delimiter and name.lower() == "etag":
+                  etags.append(value.strip())
+          if len(etags) != 1 or not etags[0]:
+              raise SystemExit("GitHub draft response omitted a unique ETag")
+          pathlib.Path(sys.argv[2]).write_bytes(body)
+          pathlib.Path(sys.argv[3]).write_text(etags[0] + "\n", encoding="ascii")
+          PY
+          python3 scripts/verify-release-draft-identity.py api \
+            "$RUNNER_TEMP/final-draft.json" "$TAG" "$CANDIDATE_SHA" \
+            --release-id "$RELEASE_ID" >/dev/null
+          python3 scripts/capture-release-publication.py --draft --notes-file "$notes" \
+            "$RUNNER_TEMP/final-draft.json" "$accepted/release-provenance.json" \
+            "$RUNNER_TEMP/final-draft-publication.json" \
+            "${release_assets[@]}" "$accepted/checksums.txt" "$accepted/checksums.txt.sig"
+          bash scripts/verify-release-tag-target.sh "$TAG" "$CANDIDATE_SHA" origin --require-existing
+          draft_etag="$(cat "$RUNNER_TEMP/final-draft-etag")"
+          gh api --method PATCH -H 'X-GitHub-Api-Version: 2026-03-10' \
+            -H "If-Match: $draft_etag" \
+            "repos/$GITHUB_REPOSITORY/releases/$RELEASE_ID" \
+            -F draft=false -F prerelease=false -f make_latest=true \
+            > "$RUNNER_TEMP/published.json"
+          gh api -H 'X-GitHub-Api-Version: 2026-03-10' \
+            "repos/$GITHUB_REPOSITORY/releases/$RELEASE_ID" > "$RUNNER_TEMP/immutable-by-id.json"
+          gh api -H 'X-GitHub-Api-Version: 2026-03-10' \
+            "repos/$GITHUB_REPOSITORY/releases/tags/$TAG" > "$RUNNER_TEMP/immutable-by-tag.json"
+          gh api -H 'X-GitHub-Api-Version: 2026-03-10' \
+            "repos/$GITHUB_REPOSITORY/releases/latest" > "$RUNNER_TEMP/latest.json"
+          python3 scripts/verify-published-release.py \
+            "$RELEASE_ID" false "$RUNNER_TEMP/immutable-by-id.json" \
+            "$RUNNER_TEMP/immutable-by-tag.json" "$RUNNER_TEMP/latest.json"
+          python3 scripts/capture-release-publication.py --notes-file "$notes" \
+            "$RUNNER_TEMP/immutable-by-id.json" "$accepted/release-provenance.json" \
+            "$RUNNER_TEMP/publication.json" \
+            "${release_assets[@]}" "$accepted/checksums.txt" "$accepted/checksums.txt.sig"
+          cmp "$RUNNER_TEMP/final-draft-publication.json" "$RUNNER_TEMP/publication.json"
+
+      - name: Redownload and byte-compare every immutable asset
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_ID: ${{ steps.draft.outputs.release_id }}
+        run: |
+          set -euo pipefail
+          accepted="$RUNNER_TEMP/accepted"
+          download="$RUNNER_TEMP/redownload"
+          mkdir "$download"
+          python3 - "$RUNNER_TEMP/immutable-by-id.json" "$RUNNER_TEMP/assets.tsv" <<'PY'
+          import json
+          import pathlib
+          import re
+          import sys
+
+          value = json.loads(pathlib.Path(sys.argv[1]).read_text(encoding="utf-8"))
+          rows = []
+          for asset in value.get("assets", []):
+              name, asset_id = asset.get("name"), asset.get("id")
+              if not isinstance(name, str) or not re.fullmatch(r"[A-Za-z0-9][A-Za-z0-9._+-]{0,255}", name):
+                  raise SystemExit("unsafe release asset name")
+              if type(asset_id) is not int or asset_id <= 0:
+                  raise SystemExit("invalid release asset id")
+              rows.append((name, asset_id))
+          pathlib.Path(sys.argv[2]).write_text(
+              "".join(f"{name}\t{asset_id}\n" for name, asset_id in sorted(rows)),
+              encoding="ascii",
+          )
+          PY
+          while IFS=$'\t' read -r name asset_id; do
+            gh api -H 'Accept: application/octet-stream' \
+              -H 'X-GitHub-Api-Version: 2026-03-10' \
+              "repos/$GITHUB_REPOSITORY/releases/assets/$asset_id" > "$download/$name"
+            cmp "$accepted/$name" "$download/$name"
+          done < "$RUNNER_TEMP/assets.tsv"
+
+  verify_public:
+    name: Verify published bytes without protected credentials
+    needs: promote
+    runs-on: macos-15
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout reviewed public verifier
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+        with:
+          ref: ${{ github.sha }}
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Verify public Tier-2 release
+        shell: bash
+        env:
+          TAG: ${{ needs.promote.outputs.tag }}
+        run: |
+          set -euo pipefail
+          GITHUB_REPO="$GITHUB_REPOSITORY" \
+            DOWNLOAD_ATTEMPTS=6 \
+            DOWNLOAD_RETRY_SLEEP=5 \
+            scripts/verify-tier2-provider-release.sh --tag "$TAG"

--- a/.github/workflows/promote-acceptance-candidate.yml
+++ b/.github/workflows/promote-acceptance-candidate.yml
@@ -173,20 +173,15 @@ jobs:
             "$GITHUB_REPOSITORY" "$TAG" "$CANDIDATE_SHA" \
             "${release_assets[@]}"
 
-      - name: Verify accepted source is merged and reserve its exact tag
+      - name: Verify accepted source and owner-created protected tag
         shell: bash
         env:
-          GH_TOKEN: ${{ secrets.RELEASE_POSTURE_TOKEN }}
+          GH_TOKEN: ${{ github.token }}
           TAG: ${{ steps.request.outputs.tag }}
           CANDIDATE_SHA: ${{ steps.request.outputs.candidate_sha }}
           CONTROL_SHA: ${{ steps.run.outputs.control_sha }}
         run: |
           set -euo pipefail
-          tagger_id="$(gh api -H 'X-GitHub-Api-Version: 2026-03-10' user --jq .id)"
-          [[ "$tagger_id" == 28995904 ]] || {
-            echo "::error::protected tag credential is not the configured ruleset bypass actor" >&2
-            exit 1
-          }
           git fetch --quiet --no-tags origin refs/heads/main:refs/remotes/origin/main
           git cat-file -e "$CANDIDATE_SHA^{commit}"
           git cat-file -e "$CONTROL_SHA^{commit}"
@@ -217,12 +212,6 @@ jobs:
           if matches:
               raise SystemExit("a draft or public release already exists for the accepted tag")
           PY
-          tag_rows="$(git ls-remote origin "refs/tags/$TAG" "refs/tags/$TAG^{}")"
-          if [[ -z "$tag_rows" ]]; then
-            gh api --method POST -H 'X-GitHub-Api-Version: 2026-03-10' \
-              "repos/$GITHUB_REPOSITORY/git/refs" \
-              -f ref="refs/tags/$TAG" -f sha="$CANDIDATE_SHA" >/dev/null
-          fi
           bash scripts/verify-release-tag-target.sh "$TAG" "$CANDIDATE_SHA" origin --require-existing
 
       - name: Generate only the production checksum signature
@@ -318,28 +307,7 @@ jobs:
             "$GITHUB_REPOSITORY" "$TAG" "$CANDIDATE_SHA" \
             "${release_assets[@]}"
           gh api -H 'X-GitHub-Api-Version: 2026-03-10' \
-            --include "repos/$GITHUB_REPOSITORY/releases/$RELEASE_ID" \
-            > "$RUNNER_TEMP/final-draft-response"
-          python3 - "$RUNNER_TEMP/final-draft-response" \
-            "$RUNNER_TEMP/final-draft.json" "$RUNNER_TEMP/final-draft-etag" <<'PY'
-          import pathlib
-          import sys
-
-          raw = pathlib.Path(sys.argv[1]).read_bytes()
-          separator = b"\r\n\r\n" if b"\r\n\r\n" in raw else b"\n\n"
-          headers, marker, body = raw.partition(separator)
-          if not marker:
-              raise SystemExit("GitHub draft response omitted headers")
-          etags = []
-          for line in headers.decode("latin-1").splitlines():
-              name, delimiter, value = line.partition(":")
-              if delimiter and name.lower() == "etag":
-                  etags.append(value.strip())
-          if len(etags) != 1 or not etags[0]:
-              raise SystemExit("GitHub draft response omitted a unique ETag")
-          pathlib.Path(sys.argv[2]).write_bytes(body)
-          pathlib.Path(sys.argv[3]).write_text(etags[0] + "\n", encoding="ascii")
-          PY
+            "repos/$GITHUB_REPOSITORY/releases/$RELEASE_ID" > "$RUNNER_TEMP/final-draft.json"
           python3 scripts/verify-release-draft-identity.py api \
             "$RUNNER_TEMP/final-draft.json" "$TAG" "$CANDIDATE_SHA" \
             --release-id "$RELEASE_ID" >/dev/null
@@ -348,9 +316,10 @@ jobs:
             "$RUNNER_TEMP/final-draft-publication.json" \
             "${release_assets[@]}" "$accepted/checksums.txt" "$accepted/checksums.txt.sig"
           bash scripts/verify-release-tag-target.sh "$TAG" "$CANDIDATE_SHA" origin --require-existing
-          draft_etag="$(cat "$RUNNER_TEMP/final-draft-etag")"
+          # Repository rules and the production-release environment serialize
+          # the sole owner publication path. Re-fetch the exact numeric draft
+          # and tag immediately before this irreversible transition.
           gh api --method PATCH -H 'X-GitHub-Api-Version: 2026-03-10' \
-            -H "If-Match: $draft_etag" \
             "repos/$GITHUB_REPOSITORY/releases/$RELEASE_ID" \
             -F draft=false -F prerelease=false -f make_latest=true \
             > "$RUNNER_TEMP/published.json"

--- a/Makefile
+++ b/Makefile
@@ -59,6 +59,7 @@ test-dist:
 	bash scripts/test-recover-malibu-publication.sh
 	bash scripts/test-acceptance-candidate-security.sh
 	bash scripts/test-acceptance-candidate-metadata.sh
+	bash scripts/test-acceptance-promotion.sh
 	bash scripts/test-release-toolchain.sh
 	bash scripts/test-release-publication-provenance.sh
 	bash scripts/test-compatibility-set-manifest.sh

--- a/phase3-binary/dist/release-signing-runbook.md
+++ b/phase3-binary/dist/release-signing-runbook.md
@@ -327,12 +327,19 @@ test "${#ACCEPTED_CHECKSUMS_SHA256}" = 64
 ```
 
 Merge the candidate source to `main` without rebuilding or altering the
-accepted commit. Then dispatch the protected exact-byte promoter from current
-`main`:
+accepted commit. The configured owner/bypass actor must then create the
+protected tag at that exact accepted commit; the workflow token is
+intentionally unable to create, move, or delete protected tags:
 
 ```bash
 git fetch origin main
 git merge-base --is-ancestor "$ACCEPTANCE_COMMIT" origin/main
+test -z "$(git ls-remote origin "refs/tags/$TAG" "refs/tags/$TAG^{}")"
+git tag "$TAG" "$ACCEPTANCE_COMMIT"
+git push origin "refs/tags/$TAG"
+bash scripts/verify-release-tag-target.sh \
+  "$TAG" "$ACCEPTANCE_COMMIT" origin --require-existing
+
 gh workflow run promote-acceptance-candidate.yml \
   --repo Augustas11/macprovider \
   --ref main \
@@ -349,12 +356,18 @@ requires one successful, unexpired artifact from the exact
 `acceptance-candidate.yml` run; verifies the signed envelope, complete
 inventory, compatibility index, production Pearl signature/channel,
 provenance, and admission policy; and requires the accepted commit to be
-reachable from `origin/main`. It generates only the missing production
-`checksums.txt.sig`, tags the exact accepted SHA, uploads the exact accepted
-bytes to a numeric draft, verifies GitHub's asset digests, revalidates the
-draft immediately before publication, publishes it immutable, redownloads
-every public asset for byte comparison, and runs the existing Tier-2 public
-release verifier. It never checks out or executes candidate code.
+reachable from `origin/main` and the owner-created tag to target that exact
+commit. It generates only the missing production `checksums.txt.sig`, uploads
+the exact accepted bytes to a numeric draft, verifies GitHub's asset digests,
+revalidates the exact tag and numeric draft immediately before the sole-owner
+publication transition, publishes it immutable, and redownloads every public
+asset for byte comparison. A separate read-only, secretless job runs the
+existing Tier-2 public release verifier; the protected promoter never checks
+out or executes candidate code. GitHub does not expose a documented
+conditional release-PATCH revision contract, so repository rules, environment
+approval, the shared production-release concurrency group, immediate
+revalidation, and a single authorized owner remain the publication exclusion
+boundary.
 
 If the private artifact has expired, the accepted checksums digest differs,
 the source commit is not merged, or any tag/release identity is ambiguous, do

--- a/phase3-binary/dist/release-signing-runbook.md
+++ b/phase3-binary/dist/release-signing-runbook.md
@@ -234,7 +234,8 @@ gh workflow run acceptance-candidate.yml --repo Augustas11/macprovider \
   -f candidate_ref="$ACCEPTANCE_REF" \
   -f candidate_sha="$ACCEPTANCE_COMMIT" \
   -f tag="$TAG" \
-  -f provider_admission_policy=strict_post_migration
+  -f provider_admission_policy=strict_post_migration \
+  -f promotion_ready=true
 ```
 
 Approve the `production-release` job only after independently reviewing the
@@ -306,6 +307,58 @@ bash scripts/verify-release-checksums.sh \
   "${release_assets[@]}"
 test ! -e "$ACCEPTANCE_ASSET_DIR/checksums.txt.sig"
 ```
+
+Set `promotion_ready=true` only when the candidate may become the stable
+release after physical acceptance. That mode does not publish anything and
+does not extend the one-day private envelope. It binds
+`release-provenance.json` to `prerelease=false`, emits `pearl-release.json`
+for the `production` updater channel, and signs Pearl metadata with the
+production updater key. The private artifact still deliberately omits
+`checksums.txt.sig`.
+
+After the complete physical journey succeeds, record the SHA-256 of the exact
+accepted `checksums.txt`:
+
+```bash
+export ACCEPTED_CHECKSUMS_SHA256="$(
+  shasum -a 256 "$ACCEPTANCE_ASSET_DIR/checksums.txt" | awk '{print $1}'
+)"
+test "${#ACCEPTED_CHECKSUMS_SHA256}" = 64
+```
+
+Merge the candidate source to `main` without rebuilding or altering the
+accepted commit. Then dispatch the protected exact-byte promoter from current
+`main`:
+
+```bash
+git fetch origin main
+git merge-base --is-ancestor "$ACCEPTANCE_COMMIT" origin/main
+gh workflow run promote-acceptance-candidate.yml \
+  --repo Augustas11/macprovider \
+  --ref main \
+  -f candidate_run_id="$ACCEPTANCE_RUN_ID" \
+  -f candidate_sha="$ACCEPTANCE_COMMIT" \
+  -f tag="$TAG" \
+  -f expected_checksums_sha256="$ACCEPTED_CHECKSUMS_SHA256" \
+  -f physical_acceptance_confirmed=true
+```
+
+Approve the `production-release` environment only after comparing the run ID,
+source SHA, tag, and checksums digest with the physical evidence. The promoter
+requires one successful, unexpired artifact from the exact
+`acceptance-candidate.yml` run; verifies the signed envelope, complete
+inventory, compatibility index, production Pearl signature/channel,
+provenance, and admission policy; and requires the accepted commit to be
+reachable from `origin/main`. It generates only the missing production
+`checksums.txt.sig`, tags the exact accepted SHA, uploads the exact accepted
+bytes to a numeric draft, verifies GitHub's asset digests, revalidates the
+draft immediately before publication, publishes it immutable, redownloads
+every public asset for byte comparison, and runs the existing Tier-2 public
+release verifier. It never checks out or executes candidate code.
+
+If the private artifact has expired, the accepted checksums digest differs,
+the source commit is not merged, or any tag/release identity is ambiguous, do
+not recover around the gate. Dispatch and physically accept a new candidate.
 
 Run both acceptance paths on separate clean snapshots or hosts. First prove a
 clean bootstrap with no existing CLI or provider support directory:

--- a/scripts/acceptance-candidate-metadata.py
+++ b/scripts/acceptance-candidate-metadata.py
@@ -343,7 +343,7 @@ def build_pearl(args: argparse.Namespace) -> dict:
     return {
         "architecture": "linux-amd64",
         "catalog": {"files": files, "policy_version": policy_version, "release_id": release_id},
-        "channel": "private_acceptance",
+        "channel": args.channel,
         "commit": commit,
         "components": {
             "coordinator": {
@@ -656,6 +656,7 @@ def parser() -> argparse.ArgumentParser:
     pearl.add_argument("--commit", required=True)
     pearl.add_argument("--compatibility-manifest", required=True, type=pathlib.Path)
     pearl.add_argument("--provider-admission-policy", choices=("bridge_required", "strict_post_migration"), required=True)
+    pearl.add_argument("--channel", choices=("private_acceptance", "production"), default="private_acceptance")
     pearl.add_argument("--catalog-directory", required=True, type=pathlib.Path)
     pearl.add_argument("--coordinator", required=True, type=pathlib.Path)
     pearl.add_argument("--coordinator-cli", required=True, type=pathlib.Path)

--- a/scripts/sign-acceptance-candidate.sh
+++ b/scripts/sign-acceptance-candidate.sh
@@ -6,7 +6,7 @@ die() {
   exit 1
 }
 
-[[ "$#" == 10 ]] || die "usage: UNSIGNED_DIR OUTPUT_DIR REPOSITORY TAG CANDIDATE_REF CANDIDATE_COMMIT CONTROL_COMMIT RUN_ID RUN_ATTEMPT PROVIDER_ADMISSION_POLICY"
+[[ "$#" == 11 ]] || die "usage: UNSIGNED_DIR OUTPUT_DIR REPOSITORY TAG CANDIDATE_REF CANDIDATE_COMMIT CONTROL_COMMIT RUN_ID RUN_ATTEMPT PROVIDER_ADMISSION_POLICY PROMOTION_READY"
 unsigned_dir="$1"
 output_dir="$2"
 repository="$3"
@@ -17,6 +17,7 @@ control_commit="$7"
 run_id="$8"
 run_attempt="$9"
 provider_admission_policy="${10}"
+promotion_ready="${11}"
 
 root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd -P)"
 metadata="$root/scripts/acceptance-candidate-metadata.py"
@@ -39,6 +40,16 @@ case "$provider_admission_policy" in
   bridge_required|strict_post_migration) ;;
   *) die "invalid provider admission policy" ;;
 esac
+case "$promotion_ready" in
+  true|false) ;;
+  *) die "invalid promotion-ready state" ;;
+esac
+pearl_channel=private_acceptance
+release_prerelease=true
+if [[ "$promotion_ready" == true ]]; then
+  pearl_channel=production
+  release_prerelease=false
+fi
 
 for command in python3 security codesign xcrun ditto hdiutil tar shasum spctl base64 "$openssl_bin"; do
   command -v "$command" >/dev/null 2>&1 || die "required command is unavailable: $command"
@@ -272,14 +283,21 @@ python3 "$metadata" build-pearl \
   --commit "$candidate_commit" \
   --compatibility-manifest "$output_dir/compatibility-set.json" \
   --provider-admission-policy "$provider_admission_policy" \
+  --channel "$pearl_channel" \
   --catalog-directory "$output_dir" \
   --coordinator "$output_dir/coordinator-linux-amd64" \
   --coordinator-cli "$output_dir/coordinator-cli-linux-amd64" \
   --gateway "$output_dir/gateway-linux-amd64" \
   --output "$output_dir/pearl-release.json"
-"$openssl_bin" dgst -sha256 -sign "$private_key" \
+pearl_signing_key="$private_key"
+pearl_verification_key="$derived_public_key"
+if [[ "$promotion_ready" == true ]]; then
+  pearl_signing_key="$release_private_key"
+  pearl_verification_key="$release_public_key"
+fi
+"$openssl_bin" dgst -sha256 -sign "$pearl_signing_key" \
   -out "$output_dir/pearl-release.json.sig" "$output_dir/pearl-release.json"
-"$openssl_bin" dgst -sha256 -verify "$derived_public_key" \
+"$openssl_bin" dgst -sha256 -verify "$pearl_verification_key" \
   -signature "$output_dir/pearl-release.json.sig" "$output_dir/pearl-release.json"
 
 artifact_arguments=(
@@ -332,7 +350,7 @@ release_assets=(
   "$output_dir/compatibility-artifact-index.json"
 )
 python3 "$root/scripts/build-release-provenance.py" \
-  "$tag" "$candidate_commit" "$repository" true \
+  "$tag" "$candidate_commit" "$repository" "$release_prerelease" \
   "$output_dir/release-toolchain.json" \
   "$output_dir/release-provenance.json" \
   "${release_assets[@]}"

--- a/scripts/test-acceptance-candidate-security.sh
+++ b/scripts/test-acceptance-candidate-security.sh
@@ -95,8 +95,20 @@ for secret in (
         raise SystemExit(f"protected signer secret contract is incomplete: {secret}")
 if "--private-key \"$release_private_key\"" not in signer or "--public-key \"$release_public_key\"" not in signer:
     raise SystemExit("inner compatibility manifest is not main-owned and production-key verified")
-if "pearl-release.json.sig" not in signer or "-sign \"$private_key\"" not in signer:
-    raise SystemExit("acceptance-only Pearl metadata is not separately signed")
+if (
+    "pearl-release.json.sig" not in signer
+    or 'pearl_signing_key="$private_key"' not in signer
+    or 'pearl_signing_key="$release_private_key"' not in signer
+    or 'pearl_verification_key="$derived_public_key"' not in signer
+    or 'pearl_verification_key="$release_public_key"' not in signer
+):
+    raise SystemExit("Pearl metadata does not select the acceptance or production trust anchor explicitly")
+if (
+    '"$promotion_ready" == true' not in signer
+    or "pearl_channel=production" not in signer
+    or "release_prerelease=false" not in signer
+):
+    raise SystemExit("promotion-ready acceptance does not bind stable release provenance")
 if '--compatibility-manifest "$output_dir/compatibility-set.json"' not in signer:
     raise SystemExit("acceptance-only Pearl metadata is not bound to the signed compatibility manifest")
 if 'tar -czf "$provider_asset" -C "$cli_work" .' in signer:
@@ -374,6 +386,27 @@ if pearl.get("channel") != "private_acceptance":
     raise SystemExit("Pearl metadata did not declare the private acceptance channel")
 if pearl["provider_advertised_version"] != "1.8.31":
     raise SystemExit("Pearl metadata did not use the signed provider CLI component version")
+PY
+python3 "$metadata" build-pearl \
+  --repository Augustas11/macprovider \
+  --tag "$tag" \
+  --commit "$candidate_commit" \
+  --compatibility-manifest "$work/pearl-compatibility.json" \
+  --provider-admission-policy strict_post_migration \
+  --channel production \
+  --catalog-directory "$work/pearl-catalog" \
+  --coordinator "$work/assets/coordinator-linux-amd64" \
+  --coordinator-cli "$work/assets/coordinator-cli-linux-amd64" \
+  --gateway "$work/assets/gateway-linux-amd64" \
+  --output "$work/pearl-production.json"
+python3 - "$work/pearl-production.json" <<'PY'
+import json
+import pathlib
+import sys
+
+pearl = json.loads(pathlib.Path(sys.argv[1]).read_text())
+if pearl.get("channel") != "production":
+    raise SystemExit("promotion-ready Pearl metadata did not declare the production channel")
 PY
 python3 - "$work/pearl-catalog/release.json" <<'PY'
 import json

--- a/scripts/test-acceptance-promotion.sh
+++ b/scripts/test-acceptance-promotion.sh
@@ -1,0 +1,305 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd -P)"
+verifier="$root/scripts/verify-acceptance-promotion.py"
+workflow="$root/.github/workflows/promote-acceptance-candidate.yml"
+work="$(mktemp -d "${TMPDIR:-/tmp}/acceptance-promotion.XXXXXX")"
+trap 'rm -rf "$work"' EXIT
+
+fail() {
+  printf '[test-acceptance-promotion] ERROR: %s\n' "$*" >&2
+  exit 1
+}
+
+python3 - "$workflow" <<'PY'
+import pathlib
+import re
+import sys
+
+text = pathlib.Path(sys.argv[1]).read_text(encoding="utf-8")
+for required in (
+    "candidate_run_id:",
+    "candidate_sha:",
+    "tag:",
+    "expected_checksums_sha256:",
+    "physical_acceptance_confirmed:",
+    "environment: production-release",
+    "actions: read",
+    "contents: write",
+    "scripts/verify-acceptance-promotion.py verify-run",
+    "scripts/verify-acceptance-promotion.py verify-directory",
+    "scripts/verify-release-checksums.sh",
+    "scripts/verify-tier2-provider-release.sh",
+    'cmp "$accepted/$name" "$download/$name"',
+):
+    if required not in text:
+        raise SystemExit(f"promotion workflow omits required control: {required}")
+for forbidden in ("bash candidate/", "candidate/scripts/", "release.yml"):
+    if forbidden in text:
+        raise SystemExit(f"promotion workflow can execute or rebuild candidate code: {forbidden}")
+for match in re.finditer(r"^\s*uses:\s*(\S+)", text, re.MULTILINE):
+    value = match.group(1)
+    if not re.fullmatch(r"[^@\s]+@[0-9a-f]{40}", value):
+        raise SystemExit(f"promotion action is not commit-pinned: {value}")
+if text.count('out "$accepted/checksums.txt.sig"') != 1:
+    raise SystemExit("promoter must generate only one new release asset")
+if "go build" in text or "xcodebuild" in text or "./package.sh" in text:
+    raise SystemExit("protected promoter contains a build capability")
+protected, separator, public_verify = text.partition("\n  verify_public:\n")
+if not separator or "scripts/verify-tier2-provider-release.sh" in protected:
+    raise SystemExit("candidate executable verification must be isolated from the protected promoter")
+if "environment: production-release" in public_verify or "secrets." in public_verify:
+    raise SystemExit("public executable verifier gained protected credentials")
+if "GH_TOKEN: ${{ secrets.RELEASE_POSTURE_TOKEN }}" not in protected:
+    raise SystemExit("tag creation does not use the configured protected tagger identity")
+if '[[ "$tagger_id" == 28995904 ]]' not in protected:
+    raise SystemExit("protected tag credential is not verified against the ruleset actor")
+if 'git merge-base --is-ancestor "$CONTROL_SHA"' not in protected:
+    raise SystemExit("acceptance signer control commit need not remain reachable from main")
+if 'If-Match: $draft_etag' not in protected:
+    raise SystemExit("numeric draft publication lacks a conditional mutation guard")
+PY
+
+repository=Augustas11/macprovider
+run_id=29629457652
+run_attempt=1
+tag=v1.8.48
+candidate_sha=1111111111111111111111111111111111111111
+control_sha=2222222222222222222222222222222222222222
+accepted="$work/accepted"
+mkdir "$accepted"
+
+release_names=(
+  "Malibu-${tag}.dmg"
+  "autotune-candidates.json"
+  "autotune-candidates.json.sig"
+  "compatibility-artifact-index.json"
+  "compatibility-set.json"
+  "coordinator-cli-linux-amd64"
+  "coordinator-linux-amd64"
+  "demand-rank.json"
+  "demand-rank.json.sig"
+  "gateway-linux-amd64"
+  "macprovider-cli-${tag}-darwin-arm64.tar.gz"
+  "pearl-release.json"
+  "pearl-release.json.sig"
+  "release-provenance.json"
+  "release-toolchain.json"
+  "release.json"
+  "trusted-keys.json"
+)
+printf '%s\n' "${release_names[@]}" | LC_ALL=C sort > "$accepted/release-assets.txt"
+for name in "${release_names[@]}"; do
+  printf 'fixture:%s\n' "$name" > "$accepted/$name"
+done
+
+cat > "$accepted/acceptance-candidate.json" <<EOF
+{"candidate_commit":"$candidate_sha","candidate_ref":"refs/heads/release/referral-v1.8.48-candidate","channel":"acceptance","control_commit":"$control_sha","repository":"$repository","run_attempt":$run_attempt,"run_id":"$run_id","tag":"$tag"}
+EOF
+printf 'fixture-signature\n' > "$accepted/acceptance-candidate.json.sig"
+cat > "$accepted/release-provenance.json" <<EOF
+{"commit":"$candidate_sha","prerelease":false,"repository":"$repository","tag":"$tag"}
+EOF
+cat > "$accepted/compatibility-set.json" <<'EOF'
+{"signed":{"components":{"coordinator_admission":{"rollout":{"bridge_duration_s":0,"enforce_provider_admission":true,"mode":"strict_post_migration"}},"provider_cli":{"version":"1.8.48"}},"release":{"commit":"1111111111111111111111111111111111111111","repository":"Augustas11/macprovider","tag":"v1.8.48","version":"1.8.48"}}}
+EOF
+python3 - "$accepted" <<'PY'
+import hashlib
+import json
+import pathlib
+import sys
+
+root = pathlib.Path(sys.argv[1])
+digest = lambda name: hashlib.sha256((root / name).read_bytes()).hexdigest()
+catalog_names = (
+    "release.json",
+    "trusted-keys.json",
+    "autotune-candidates.json",
+    "autotune-candidates.json.sig",
+    "demand-rank.json",
+    "demand-rank.json.sig",
+)
+value = {
+    "architecture": "linux-amd64",
+    "catalog": {
+        "files": {name: digest(name) for name in catalog_names},
+        "policy_version": "fixture-policy",
+        "release_id": "fixture-release",
+    },
+    "channel": "production",
+    "commit": "1" * 40,
+    "components": {
+        "coordinator": {
+            "asset": "coordinator-linux-amd64",
+            "embedded_version": "v1.8.48",
+            "sha256": digest("coordinator-linux-amd64"),
+        },
+        "gateway": {
+            "asset": "gateway-linux-amd64",
+            "embedded_version": "v1.8.48",
+            "sha256": digest("gateway-linux-amd64"),
+        },
+    },
+    "operator_artifacts": {
+        "coordinator_cli": {
+            "asset": "coordinator-cli-linux-amd64",
+            "sha256": digest("coordinator-cli-linux-amd64"),
+        }
+    },
+    "provider_admission_rollout": {
+        "bridge_duration_s": 0,
+        "enforce_provider_admission": True,
+        "mode": "strict_post_migration",
+    },
+    "provider_advertised_version": "1.8.48",
+    "release_version": "1.8.48",
+    "repository": "Augustas11/macprovider",
+    "schema_version": 1,
+    "tag": "v1.8.48",
+}
+(root / "pearl-release.json").write_text(
+    json.dumps(value, sort_keys=True, separators=(",", ":")) + "\n",
+    encoding="utf-8",
+)
+PY
+openssl genpkey -algorithm EC -pkeyopt ec_paramgen_curve:P-256 -out "$work/release-private.pem" >/dev/null 2>&1
+openssl pkey -in "$work/release-private.pem" -pubout -out "$work/release-public.pem" >/dev/null 2>&1
+openssl dgst -sha256 -sign "$work/release-private.pem" \
+  -out "$accepted/pearl-release.json.sig" "$accepted/pearl-release.json"
+printf 'fixture checksums\n' > "$accepted/checksums.txt"
+checksums_sha="$(shasum -a 256 "$accepted/checksums.txt" | awk '{print $1}')"
+
+cat > "$work/run.json" <<EOF
+{"conclusion":"success","event":"workflow_dispatch","head_branch":"main","head_sha":"$control_sha","id":$run_id,"path":".github/workflows/acceptance-candidate.yml","repository":{"full_name":"$repository"},"run_attempt":$run_attempt,"status":"completed"}
+EOF
+cat > "$work/artifacts.json" <<EOF
+{"artifacts":[{"expired":false,"name":"unsigned-acceptance-$candidate_sha","workflow_run":{"id":$run_id}},{"expired":false,"name":"acceptance-candidate-$candidate_sha","workflow_run":{"id":$run_id}}],"total_count":2}
+EOF
+
+run_verify=(
+  python3 "$verifier" verify-run
+  --run-json "$work/run.json"
+  --artifacts-json "$work/artifacts.json"
+  --repository "$repository"
+  --run-id "$run_id"
+  --run-attempt "$run_attempt"
+  --candidate-sha "$candidate_sha"
+  --control-sha "$control_sha"
+)
+directory_verify=(
+  python3 "$verifier" verify-directory
+  --directory "$accepted"
+  --repository "$repository"
+  --run-id "$run_id"
+  --run-attempt "$run_attempt"
+  --tag "$tag"
+  --candidate-sha "$candidate_sha"
+  --control-sha "$control_sha"
+  --expected-checksums-sha256 "$checksums_sha"
+  --release-public-key "$work/release-public.pem"
+)
+"${run_verify[@]}"
+"${directory_verify[@]}"
+
+expect_reject() {
+  local label="$1"
+  shift
+  if "$@" >"$work/$label.out" 2>&1; then
+    fail "$label was accepted"
+  fi
+}
+
+python3 - "$work/run.json" <<'PY'
+import json, pathlib, sys
+p = pathlib.Path(sys.argv[1])
+v = json.loads(p.read_text())
+v["path"] = ".github/workflows/release.yml"
+p.write_text(json.dumps(v))
+PY
+expect_reject wrong-workflow "${run_verify[@]}"
+sed -i '' 's#\\.github/workflows/release.yml#.github/workflows/acceptance-candidate.yml#' "$work/run.json"
+
+cp "$work/artifacts.json" "$work/artifacts.valid"
+python3 - "$work/artifacts.json" <<'PY'
+import json, pathlib, sys
+p = pathlib.Path(sys.argv[1])
+v = json.loads(p.read_text())
+v["artifacts"].append(dict(v["artifacts"][-1]))
+v["total_count"] += 1
+p.write_text(json.dumps(v))
+PY
+expect_reject duplicate-artifact "${run_verify[@]}"
+mv "$work/artifacts.valid" "$work/artifacts.json"
+
+printf 'unexpected\n' > "$accepted/unexpected"
+expect_reject extra-file "${directory_verify[@]}"
+rm "$accepted/unexpected"
+
+mv "$accepted/gateway-linux-amd64" "$work/gateway"
+expect_reject missing-file "${directory_verify[@]}"
+mv "$work/gateway" "$accepted/gateway-linux-amd64"
+
+ln -s gateway-linux-amd64 "$accepted/unexpected"
+expect_reject symlink "${directory_verify[@]}"
+rm "$accepted/unexpected"
+
+ln "$accepted/gateway-linux-amd64" "$accepted/unexpected"
+expect_reject hardlink "${directory_verify[@]}"
+rm "$accepted/unexpected"
+
+cp "$accepted/release-provenance.json" "$work/provenance"
+python3 - "$accepted/release-provenance.json" <<'PY'
+import json, pathlib, sys
+p = pathlib.Path(sys.argv[1])
+v = json.loads(p.read_text())
+v["prerelease"] = True
+p.write_text(json.dumps(v) + "\n")
+PY
+expect_reject prerelease "${directory_verify[@]}"
+mv "$work/provenance" "$accepted/release-provenance.json"
+
+cp "$accepted/pearl-release.json" "$work/pearl"
+python3 - "$accepted/pearl-release.json" <<'PY'
+import json, pathlib, sys
+p = pathlib.Path(sys.argv[1])
+v = json.loads(p.read_text())
+v["channel"] = "private_acceptance"
+p.write_text(json.dumps(v) + "\n")
+PY
+expect_reject private-channel "${directory_verify[@]}"
+mv "$work/pearl" "$accepted/pearl-release.json"
+
+cp "$accepted/pearl-release.json.sig" "$work/pearl.sig"
+printf 'invalid\n' > "$accepted/pearl-release.json.sig"
+expect_reject wrong-pearl-signature "${directory_verify[@]}"
+mv "$work/pearl.sig" "$accepted/pearl-release.json.sig"
+
+cp "$accepted/pearl-release.json" "$work/pearl"
+python3 - "$accepted/pearl-release.json" <<'PY'
+import json, pathlib, sys
+p = pathlib.Path(sys.argv[1])
+v = json.loads(p.read_text())
+v["provider_admission_rollout"]["mode"] = "bridge_required"
+p.write_text(json.dumps(v) + "\n")
+PY
+expect_reject admission-mismatch "${directory_verify[@]}"
+mv "$work/pearl" "$accepted/pearl-release.json"
+
+expect_reject wrong-checksums-digest \
+  python3 "$verifier" verify-directory \
+  --directory "$accepted" \
+  --repository "$repository" \
+  --run-id "$run_id" \
+  --run-attempt "$run_attempt" \
+  --tag "$tag" \
+  --candidate-sha "$candidate_sha" \
+  --control-sha "$control_sha" \
+  --expected-checksums-sha256 0000000000000000000000000000000000000000000000000000000000000000 \
+  --release-public-key "$work/release-public.pem"
+
+printf '%s\n' "${release_names[@]}" "gateway-linux-amd64" | LC_ALL=C sort > "$accepted/release-assets.txt"
+expect_reject duplicate-basename "${directory_verify[@]}"
+printf '%s\n' "${release_names[@]}" | LC_ALL=C sort > "$accepted/release-assets.txt"
+
+printf '[test-acceptance-promotion] ok: exact accepted-byte promotion fails closed\n'

--- a/scripts/test-acceptance-promotion.sh
+++ b/scripts/test-acceptance-promotion.sh
@@ -51,14 +51,14 @@ if not separator or "scripts/verify-tier2-provider-release.sh" in protected:
     raise SystemExit("candidate executable verification must be isolated from the protected promoter")
 if "environment: production-release" in public_verify or "secrets." in public_verify:
     raise SystemExit("public executable verifier gained protected credentials")
-if "GH_TOKEN: ${{ secrets.RELEASE_POSTURE_TOKEN }}" not in protected:
-    raise SystemExit("tag creation does not use the configured protected tagger identity")
-if '[[ "$tagger_id" == 28995904 ]]' not in protected:
-    raise SystemExit("protected tag credential is not verified against the ruleset actor")
+if 'scripts/verify-release-tag-target.sh "$TAG" "$CANDIDATE_SHA" origin --require-existing' not in protected:
+    raise SystemExit("promoter does not require the owner-created exact protected tag")
+if "/git/refs" in protected or "-f ref=\"refs/tags/$TAG\"" in protected:
+    raise SystemExit("promoter gained protected tag creation or mutation capability")
 if 'git merge-base --is-ancestor "$CONTROL_SHA"' not in protected:
     raise SystemExit("acceptance signer control commit need not remain reachable from main")
-if 'If-Match: $draft_etag' not in protected:
-    raise SystemExit("numeric draft publication lacks a conditional mutation guard")
+if protected.count('scripts/verify-release-tag-target.sh "$TAG" "$CANDIDATE_SHA" origin --require-existing') < 2:
+    raise SystemExit("exact protected tag is not revalidated immediately before publication")
 PY
 
 repository=Augustas11/macprovider
@@ -218,7 +218,16 @@ v["path"] = ".github/workflows/release.yml"
 p.write_text(json.dumps(v))
 PY
 expect_reject wrong-workflow "${run_verify[@]}"
-sed -i '' 's#\\.github/workflows/release.yml#.github/workflows/acceptance-candidate.yml#' "$work/run.json"
+python3 - "$work/run.json" <<'PY'
+import json
+import pathlib
+import sys
+
+path = pathlib.Path(sys.argv[1])
+value = json.loads(path.read_text())
+value["path"] = ".github/workflows/acceptance-candidate.yml"
+path.write_text(json.dumps(value))
+PY
 
 cp "$work/artifacts.json" "$work/artifacts.valid"
 python3 - "$work/artifacts.json" <<'PY'

--- a/scripts/verify-acceptance-promotion.py
+++ b/scripts/verify-acceptance-promotion.py
@@ -1,0 +1,322 @@
+#!/usr/bin/env python3
+"""Fail-closed verification for promoting an exact private acceptance set."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import pathlib
+import re
+import stat
+import subprocess
+
+
+HEX40 = re.compile(r"^[0-9a-f]{40}$")
+HEX64 = re.compile(r"^[0-9a-f]{64}$")
+TAG = re.compile(r"^v[0-9]+\.[0-9]+\.[0-9]+$")
+SAFE_NAME = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._+-]{0,255}$")
+WORKFLOW_PATH = ".github/workflows/acceptance-candidate.yml"
+CONTROL_NAMES = {
+    "acceptance-candidate.json",
+    "acceptance-candidate.json.sig",
+    "checksums.txt",
+    "release-assets.txt",
+}
+
+
+def fail(message: str) -> None:
+    raise SystemExit(f"verify-acceptance-promotion: {message}")
+
+
+def load_json(path: pathlib.Path, label: str) -> dict:
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as exc:
+        fail(f"{label} is invalid: {exc}")
+    if not isinstance(value, dict):
+        fail(f"{label} must be an object")
+    return value
+
+
+def regular(path: pathlib.Path, label: str) -> None:
+    try:
+        info = path.lstat()
+    except OSError as exc:
+        fail(f"{label} cannot be inspected: {exc}")
+    if stat.S_ISLNK(info.st_mode) or not stat.S_ISREG(info.st_mode) or info.st_nlink != 1:
+        fail(f"{label} must be a regular non-symlink single-link file")
+
+
+def sha256(path: pathlib.Path) -> str:
+    regular(path, str(path))
+    digest = hashlib.sha256()
+    with path.open("rb") as source:
+        for chunk in iter(lambda: source.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def verify_run(args: argparse.Namespace) -> None:
+    run = load_json(args.run_json, "workflow run")
+    artifacts = load_json(args.artifacts_json, "workflow artifacts")
+    if run.get("id") != args.run_id:
+        fail("workflow run id differs from the requested run")
+    if run.get("event") != "workflow_dispatch" or run.get("status") != "completed" or run.get("conclusion") != "success":
+        fail("workflow run is not a successful completed manual dispatch")
+    if run.get("path") != WORKFLOW_PATH:
+        fail("workflow run path is not the reviewed acceptance workflow")
+    if run.get("head_branch") != "main" or run.get("head_sha") != args.control_sha:
+        fail("workflow control source differs from the reviewed main commit")
+    if run.get("run_attempt") != args.run_attempt or type(args.run_attempt) is not int or args.run_attempt <= 0:
+        fail("workflow run attempt differs from the signed acceptance envelope")
+    repository = run.get("repository")
+    if not isinstance(repository, dict) or repository.get("full_name") != args.repository:
+        fail("workflow repository differs from the requested repository")
+    rows = artifacts.get("artifacts")
+    if type(artifacts.get("total_count")) is not int or not isinstance(rows, list):
+        fail("workflow artifact response is malformed")
+    expected_name = f"acceptance-candidate-{args.candidate_sha}"
+    matches = [row for row in rows if isinstance(row, dict) and row.get("name") == expected_name]
+    if len(matches) != 1:
+        fail("workflow must expose exactly one matching acceptance artifact")
+    row = matches[0]
+    if (
+        not isinstance(row, dict)
+        or row.get("name") != expected_name
+        or row.get("expired") is not False
+        or row.get("workflow_run", {}).get("id") != args.run_id
+    ):
+        fail("workflow artifact identity is absent, expired, or ambiguous")
+
+
+def read_asset_names(path: pathlib.Path) -> list[str]:
+    regular(path, "release asset selector")
+    try:
+        raw = path.read_text(encoding="ascii")
+    except (OSError, UnicodeDecodeError) as exc:
+        fail(f"release asset selector is invalid: {exc}")
+    names = raw.splitlines()
+    if not names or raw != "".join(f"{name}\n" for name in names):
+        fail("release asset selector must contain newline-terminated names")
+    if names != sorted(names) or len(names) != len(set(names)):
+        fail("release asset selector must be sorted and unique")
+    if not all(SAFE_NAME.fullmatch(name) for name in names):
+        fail("release asset selector contains an unsafe name")
+    if any(name in CONTROL_NAMES or name == "checksums.txt.sig" for name in names):
+        fail("release asset selector crosses the acceptance control boundary")
+    return names
+
+
+def verify_directory(args: argparse.Namespace) -> None:
+    root = args.directory
+    if not root.is_dir() or root.is_symlink():
+        fail("candidate directory is absent or unsafe")
+    entries = list(root.iterdir())
+    if any(not path.is_file() for path in entries):
+        fail("candidate directory contains a nested or non-file entry")
+    names = [path.name for path in entries]
+    if len(names) != len(set(names)) or any(not SAFE_NAME.fullmatch(name) for name in names):
+        fail("candidate directory has duplicate or unsafe basenames")
+    release_names = read_asset_names(root / "release-assets.txt")
+    required_release_names = {
+        f"macprovider-cli-{args.tag}-darwin-arm64.tar.gz",
+        f"Malibu-{args.tag}.dmg",
+        "release-toolchain.json",
+        "coordinator-linux-amd64",
+        "coordinator-cli-linux-amd64",
+        "gateway-linux-amd64",
+        "compatibility-set.json",
+        "release.json",
+        "trusted-keys.json",
+        "autotune-candidates.json",
+        "autotune-candidates.json.sig",
+        "demand-rank.json",
+        "demand-rank.json.sig",
+        "pearl-release.json",
+        "pearl-release.json.sig",
+        "compatibility-artifact-index.json",
+        "release-provenance.json",
+    }
+    if set(release_names) != required_release_names:
+        fail("release asset selector differs from the production compatibility inventory")
+    expected = set(release_names) | CONTROL_NAMES
+    if set(names) != expected:
+        fail("candidate inventory has extra or missing files")
+    for path in entries:
+        regular(path, f"candidate asset {path.name}")
+    checksums_digest = sha256(root / "checksums.txt")
+    if checksums_digest != args.expected_checksums_sha256:
+        fail("checksums.txt differs from the physically accepted digest")
+
+    acceptance = load_json(root / "acceptance-candidate.json", "acceptance envelope")
+    expected_values = {
+        "repository": args.repository,
+        "tag": args.tag,
+        "candidate_commit": args.candidate_sha,
+        "control_commit": args.control_sha,
+        "run_id": str(args.run_id),
+        "run_attempt": args.run_attempt,
+        "channel": "acceptance",
+    }
+    for key, expected_value in expected_values.items():
+        if acceptance.get(key) != expected_value:
+            fail(f"acceptance envelope {key} differs from the promotion request")
+
+    provenance = load_json(root / "release-provenance.json", "release provenance")
+    if (
+        provenance.get("repository") != args.repository
+        or provenance.get("tag") != args.tag
+        or provenance.get("commit") != args.candidate_sha
+        or provenance.get("prerelease") is not False
+    ):
+        fail("release provenance is not bound to a stable production target")
+
+    pearl = load_json(root / "pearl-release.json", "Pearl metadata")
+    compatibility = load_json(root / "compatibility-set.json", "compatibility manifest")
+    try:
+        signed = compatibility["signed"]
+        rollout = signed["components"]["coordinator_admission"]["rollout"]
+        compatibility_release = signed["release"]
+        provider_cli_version = signed["components"]["provider_cli"]["version"]
+    except (KeyError, TypeError):
+        fail("compatibility manifest lacks production release identity")
+    if compatibility_release != {
+        "commit": args.candidate_sha,
+        "repository": args.repository,
+        "tag": args.tag,
+        "version": args.tag.removeprefix("v"),
+    }:
+        fail("compatibility manifest release identity differs from the promotion request")
+    if pearl.get("channel") != "production":
+        fail("Pearl metadata is not on the production updater channel")
+    expected_pearl_identity = {
+        "architecture": "linux-amd64",
+        "commit": args.candidate_sha,
+        "release_version": args.tag.removeprefix("v"),
+        "repository": args.repository,
+        "schema_version": 1,
+        "tag": args.tag,
+    }
+    for key, expected_value in expected_pearl_identity.items():
+        if pearl.get(key) != expected_value:
+            fail(f"Pearl metadata {key} differs from the promotion request")
+    if pearl.get("provider_advertised_version") != provider_cli_version:
+        fail("Pearl metadata does not advertise the signed provider CLI version")
+    if provider_cli_version != args.tag.removeprefix("v"):
+        fail("production provider CLI version differs from the stable release version")
+    if pearl.get("provider_admission_rollout") != rollout:
+        fail("Pearl and compatibility admission policies differ")
+    if rollout not in (
+        {"bridge_duration_s": 86400, "enforce_provider_admission": False, "mode": "bridge_required"},
+        {"bridge_duration_s": 0, "enforce_provider_admission": True, "mode": "strict_post_migration"},
+    ):
+        fail("provider admission policy is unsupported")
+    expected_components = {
+        "coordinator": ("coordinator-linux-amd64", args.tag),
+        "gateway": ("gateway-linux-amd64", args.tag),
+    }
+    components = pearl.get("components")
+    if not isinstance(components, dict) or set(components) != set(expected_components):
+        fail("Pearl component inventory differs from the production release")
+    for name, (asset_name, embedded_version) in expected_components.items():
+        row = components.get(name)
+        if row != {
+            "asset": asset_name,
+            "embedded_version": embedded_version,
+            "sha256": sha256(root / asset_name),
+        }:
+            fail(f"Pearl {name} binding differs from the accepted asset")
+    if pearl.get("operator_artifacts") != {
+        "coordinator_cli": {
+            "asset": "coordinator-cli-linux-amd64",
+            "sha256": sha256(root / "coordinator-cli-linux-amd64"),
+        }
+    }:
+        fail("Pearl operator artifact binding differs from the accepted asset")
+    catalog_names = {
+        "release.json",
+        "trusted-keys.json",
+        "autotune-candidates.json",
+        "autotune-candidates.json.sig",
+        "demand-rank.json",
+        "demand-rank.json.sig",
+    }
+    catalog = pearl.get("catalog")
+    if (
+        not isinstance(catalog, dict)
+        or set(catalog) != {"files", "policy_version", "release_id"}
+        or not isinstance(catalog.get("policy_version"), str)
+        or not catalog["policy_version"]
+        or not isinstance(catalog.get("release_id"), str)
+        or not catalog["release_id"]
+        or catalog.get("files") != {name: sha256(root / name) for name in catalog_names}
+    ):
+        fail("Pearl catalog binding differs from the accepted assets")
+
+    signature = root / "pearl-release.json.sig"
+    regular(signature, "Pearl production signature")
+    result = subprocess.run(
+        [
+            args.openssl,
+            "dgst",
+            "-sha256",
+            "-verify",
+            str(args.release_public_key),
+            "-signature",
+            str(signature),
+            str(root / "pearl-release.json"),
+        ],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=False,
+        timeout=20,
+    )
+    if result.returncode:
+        fail("Pearl metadata signature is not valid for the production updater key")
+
+
+def parser() -> argparse.ArgumentParser:
+    root = argparse.ArgumentParser(description=__doc__)
+    commands = root.add_subparsers(dest="command", required=True)
+    run = commands.add_parser("verify-run")
+    run.add_argument("--run-json", required=True, type=pathlib.Path)
+    run.add_argument("--artifacts-json", required=True, type=pathlib.Path)
+    run.add_argument("--repository", required=True)
+    run.add_argument("--run-id", required=True, type=int)
+    run.add_argument("--run-attempt", required=True, type=int)
+    run.add_argument("--candidate-sha", required=True)
+    run.add_argument("--control-sha", required=True)
+    run.set_defaults(handler=verify_run)
+
+    directory = commands.add_parser("verify-directory")
+    directory.add_argument("--directory", required=True, type=pathlib.Path)
+    directory.add_argument("--repository", required=True)
+    directory.add_argument("--run-id", required=True, type=int)
+    directory.add_argument("--run-attempt", required=True, type=int)
+    directory.add_argument("--tag", required=True)
+    directory.add_argument("--candidate-sha", required=True)
+    directory.add_argument("--control-sha", required=True)
+    directory.add_argument("--expected-checksums-sha256", required=True)
+    directory.add_argument("--release-public-key", required=True, type=pathlib.Path)
+    directory.add_argument("--openssl", default="openssl")
+    directory.set_defaults(handler=verify_directory)
+    return root
+
+
+def main() -> None:
+    args = parser().parse_args()
+    if not TAG.fullmatch(getattr(args, "tag", "v0.0.0")):
+        fail("invalid tag")
+    for name in ("candidate_sha", "control_sha"):
+        if not HEX40.fullmatch(getattr(args, name)):
+            fail(f"invalid {name.replace('_', ' ')}")
+    if hasattr(args, "expected_checksums_sha256") and not HEX64.fullmatch(args.expected_checksums_sha256):
+        fail("invalid expected checksums digest")
+    if not re.fullmatch(r"[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+", args.repository):
+        fail("invalid repository")
+    args.handler(args)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Outcome

Adds an optional promotion-ready acceptance candidate and a protected promoter that can publish the exact physically accepted bytes without rebuilding them.

## Trust boundary

- Private candidate remains one-day and omits `checksums.txt.sig`.
- Promotion-ready metadata binds stable provenance and production Pearl channel/signature.
- Promoter verifies exact run, attempt, workflow, source/control reachability, acceptance signature, physical checksum digest, inventory, compatibility index, admission policy, and production Pearl bindings.
- Only `checksums.txt.sig` is generated. Candidate executables run only in a separate secretless public-verifier job.
- The configured owner precreates the protected tag at the exact accepted SHA; the workflow cannot create, move, or delete protected tags.
- Numeric draft, GitHub digests, immediate tag/draft revalidation, immutable release identity, and redownloaded bytes are verified.

## Verification

Exact head: `f1b5e87c`.

- `make test-dist` passed: 125 Pearl updater tests plus deploy, installer, watchdog, catalog, release, and canary suites; expected Docker/Linux/live checks skipped locally.
- Focused acceptance, promotion, release-posture, provenance, and artifact-index tests passed after integrating referral client main `99ed4b7c`.
- ShellCheck, workflow YAML parse, Python compile, and `git diff --check` passed.
- One bounded combined adversarial review found 0 Critical, 2 High, 2 Medium, and 2 Low; the single remediation cycle resolved every Critical/High/Medium finding. No second audit was run.

No merge, deployment, candidate dispatch, protected tag, or release is performed by this PR.

SPEC-GOVERNANCE-DECLARATION-BEGIN
{
  "schema_version": "spec-pr-governance-v1",
  "behavior_change": "yes",
  "contract_change": "yes",
  "specs": ["SPEC-020", "SPEC-025"],
  "requirements": ["SPEC-020-R001"],
  "authority_domains": ["provider-autoupdate", "native-app-lifecycle"],
  "arbitration": ["CODE_BUG"],
  "tests": [
    "distribution release and acceptance security suites",
    "exact acceptance promotion negative-security fixtures",
    "Pearl updater production/private-channel suite",
    "release publication provenance and compatibility artifact-index suites"
  ],
  "journeys": ["Exact signed two-provider referral/X physical acceptance gates stable byte promotion"]
}
SPEC-GOVERNANCE-DECLARATION-END