### PR TITLE
Fix accepted candidate ref extraction during promotion

### DIFF
--- a/.github/workflows/promote-acceptance-candidate.yml
+++ b/.github/workflows/promote-acceptance-candidate.yml
@@ -165,7 +165,7 @@ jobs:
           bash scripts/verify-release-checksums.sh \
             --acceptance-candidate \
             "$accepted/acceptance-candidate.json" \
-            "refs/heads/$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1]))[\"candidate_ref\"].removeprefix(\"refs/heads/\"))' "$accepted/acceptance-candidate.json")" \
+            "$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1]))["candidate_ref"])' "$accepted/acceptance-candidate.json")" \
             "$RUN_ID" "$RUN_ATTEMPT" "$CONTROL_SHA" \
             "$accepted/checksums.txt" \
             "$accepted/acceptance-candidate.json.sig" \

--- a/scripts/test-acceptance-promotion.sh
+++ b/scripts/test-acceptance-promotion.sh
@@ -59,6 +59,10 @@ if 'git merge-base --is-ancestor "$CONTROL_SHA"' not in protected:
     raise SystemExit("acceptance signer control commit need not remain reachable from main")
 if protected.count('scripts/verify-release-tag-target.sh "$TAG" "$CANDIDATE_SHA" origin --require-existing') < 2:
     raise SystemExit("exact protected tag is not revalidated immediately before publication")
+if '[\\"candidate_ref\\"]' in protected or '.removeprefix(\\"refs/heads/\\")' in protected:
+    raise SystemExit("candidate ref extraction contains shell-literal Python escapes")
+if 'print(json.load(open(sys.argv[1]))["candidate_ref"])' not in protected:
+    raise SystemExit("promoter does not pass the signed candidate ref directly to verification")
 PY
 
 repository=Augustas11/macprovider


### PR DESCRIPTION
## Outcome

Unblocks exact-byte promotion of the already physically accepted v1.8.48 candidate. The prior workflow passed Python backslash escapes literally, causing a SyntaxError before publication.

## Scope

- Pass the signed full candidate_ref directly to the existing fail-closed verifier.
- Add a regression assertion rejecting shell-literal Python escapes.
- No product bytes, runtime behavior, versioning, deployment, or release metadata changed.

## Verification

- bash scripts/test-acceptance-promotion.sh
- acceptance metadata/security tests
- exact cached candidate ref extraction
- git diff --check
- bounded code/security/architecture audits: 0 Critical / High / Medium

The v1.8.48 candidate remains run 29661372571, candidate b84b430a, control 6ccdae90, checksum digest abe836c8.

SPEC-GOVERNANCE-DECLARATION-BEGIN
{
  "schema_version": "spec-pr-governance-v1",
  "behavior_change": "yes",
  "contract_change": "none",
  "specs": ["SPEC-020"],
  "requirements": ["SPEC-020-R002"],
  "authority_domains": ["provider-autoupdate"],
  "arbitration": ["CODE_BUG"],
  "tests": [
    "bash scripts/test-acceptance-promotion.sh",
    "exact cached v1.8.48 candidate ref extraction"
  ],
  "journeys": ["not-required: release-control quoting repair; exact physical acceptance remains separately mandatory"]
}
SPEC-GOVERNANCE-DECLARATION-END