### PR TITLE
Preserve exact CLI bytes in signed Malibu candidates

### DIFF
--- a/scripts/sign-acceptance-candidate.sh
+++ b/scripts/sign-acceptance-candidate.sh
@@ -213,13 +213,16 @@ rm -f "$cli_notary"
 install -m 0755 "$cli_work/macprovider-cli" "$app/Contents/MacOS/macprovider-cli"
 install -m 0644 "$cli_work/compatibility-set.json" "$app/Contents/Resources/compatibility-set.json"
 cmp "$cli_work/compatibility-set.json" "$app/Contents/Resources/compatibility-set.json"
-codesign --force --deep \
+embedded_cli_sha256="$(shasum -a 256 "$app/Contents/MacOS/macprovider-cli" | awk '{print $1}')"
+codesign --force \
   --options runtime \
   --timestamp \
   --entitlements "$root/phase3-binary/app/Malibu.entitlements" \
   --keychain "$keychain" \
   --sign "$signing_identity" \
   "$app"
+[[ "$(shasum -a 256 "$app/Contents/MacOS/macprovider-cli" | awk '{print $1}')" == "$embedded_cli_sha256" ]] ||
+  die "outer Malibu signing changed the already-signed embedded CLI"
 codesign --verify --strict --verbose=2 --deep "$app"
 app_notary="$signing_tmp/Malibu-notary.zip"
 /usr/bin/ditto -c -k --keepParent "$app" "$app_notary"

--- a/scripts/test-acceptance-candidate-security.sh
+++ b/scripts/test-acceptance-candidate-security.sh
@@ -128,6 +128,10 @@ if signer.find('"$output_dir/release-assets.txt"') > signer.find('build-checksum
     raise SystemExit("acceptance asset selector is emitted after signed checksum construction")
 if re.search(r'\$cli_work/macprovider-cli["}]?\s+--', signer):
     raise SystemExit("protected signer executes the candidate CLI")
+if "codesign --force --deep" in signer:
+    raise SystemExit("acceptance signer must preserve the already-signed embedded CLI bytes")
+if signer.count('shasum -a 256 "$app/Contents/MacOS/macprovider-cli"') != 2:
+    raise SystemExit("acceptance signer must prove embedded CLI bytes before and after outer app signing")
 for value in (
     'keychain="acceptance-signing-${run_id}-${run_attempt}-${keychain_nonce}.keychain"',
     'acceptance_keychain_capture_default || die',


### PR DESCRIPTION
## Outcome

Unblocks the exact signed referral/X release candidate by preserving the already-signed standalone CLI bytes when that CLI is embedded in Malibu.

The protected signer previously installed the signed CLI into Malibu and then used `codesign --deep`, which re-signed the nested executable. Both executables still reported 1.8.49, but their hashes differed, so the transactional updater correctly failed closed with `embedded_cli_mismatch` before cutover.

## Fix

- sign the nested CLI first, as before
- copy that exact binary into Malibu
- sign only the outer Malibu bundle
- verify the nested CLI hash is unchanged across outer signing
- continue to run deep signature verification after signing

No updater verification is relaxed.

## Verification

- `bash scripts/test-acceptance-candidate-security.sh`
- `bash scripts/test-malibu-independent-release.sh`
- signer/test Bash syntax
- `git diff --check`

SPEC-GOVERNANCE-DECLARATION-BEGIN
{
  "schema_version": "spec-pr-governance-v1",
  "behavior_change": "yes",
  "contract_change": "none",
  "issue": "https://github.com/Augustas11/macprovider/issues/613",
  "specs": ["SPEC-020", "SPEC-025"],
  "requirements": ["SPEC-020-R003"],
  "authority_domains": ["provider-autoupdate", "native-app-lifecycle"],
  "arbitration": ["CODE_BUG"],
  "tests": ["Acceptance-candidate security regression", "Independent Malibu release regression"],
  "journeys": ["Exact signed referral/X production activation tracked by #613"]
}
SPEC-GOVERNANCE-DECLARATION-END
