### PR TITLE
Restore referral validation CORS at the production edge

### DIFF
--- a/phase4-coordinator/dist/nginx-coordinator.streamvc.live.conf
+++ b/phase4-coordinator/dist/nginx-coordinator.streamvc.live.conf
@@ -328,6 +328,10 @@ server {
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
+        # stats-proxy-public.conf hides upstream ACAO at the shared http
+        # scope. This route's Go handler emits the exact Malibu origin, so
+        # explicitly pass that header through instead of replacing it.
+        proxy_pass_header Access-Control-Allow-Origin;
         proxy_read_timeout 10s;
         proxy_no_cache 1;
         proxy_cache_bypass 1;

--- a/phase4-coordinator/dist/test/check_nginx_referral_routes_test.sh
+++ b/phase4-coordinator/dist/test/check_nginx_referral_routes_test.sh
@@ -24,6 +24,7 @@ test "$(grep -c 'location = /v1/referrals/validate' "$config")" -eq 1
 validate_block="$(grep -A18 'location = /v1/referrals/validate' "$config")"
 grep -q 'limit_req zone=referral_validate_rate burst=10 nodelay;' <<<"$validate_block"
 grep -q 'proxy_pass http://127.0.0.1:8443/v1/referrals/validate;' <<<"$validate_block"
+grep -q 'proxy_pass_header Access-Control-Allow-Origin;' <<<"$validate_block"
 grep -q 'proxy_no_cache 1;' <<<"$validate_block"
 grep -q 'proxy_cache_bypass 1;' <<<"$validate_block"
 grep -q 'client_max_body_size 1k;' <<<"$validate_block"


### PR DESCRIPTION
## Outcome

Restores the browser validation path for the live https://malibu.tech/j referral landing page. The coordinator already returns the exact allowed origin, but the shared nginx stats policy hides upstream ACAO at HTTP scope. This exact route now passes the handler-authorized header through.

## Scope

- one nginx directive on /v1/referrals/validate
- one regression assertion
- no wildcard CORS, credentials, referral policy, CLI, Malibu, or unrelated lifecycle changes

## Verification

- nginx referral route check
- full distribution suite
- git diff check
- narrow code, security, and architecture reviews: 0 Critical / 0 High / 0 Medium
- live failure reproduced before fix: exact preflight returned 204 without ACAO while direct coordinator response included Access-Control-Allow-Origin: https://malibu.tech

SPEC-GOVERNANCE-DECLARATION-BEGIN
{
  "schema_version": "spec-pr-governance-v1",
  "behavior_change": "yes",
  "contract_change": "none",
  "issue": "https://github.com/Augustas11/macprovider/issues/613",
  "specs": ["SPEC-034"],
  "requirements": ["SPEC-034-R001"],
  "authority_domains": ["referral-advocacy-policy"],
  "arbitration": ["CODE_BUG"],
  "tests": ["nginx referral route check", "full distribution suite", "live preflight reproduction"],
  "journeys": ["Vercel Malibu referral landing validates an invite through the exact production coordinator origin"]
}
SPEC-GOVERNANCE-DECLARATION-END

