### PR TITLE
Unblock protected recovery candidate signing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,6 +64,7 @@ test-dist:
 	bash scripts/test-release-publication-provenance.sh
 	bash scripts/test-compatibility-set-manifest.sh
 	bash scripts/test-compatibility-artifact-index.sh
+	bash scripts/test-release-discovery-head.sh
 	bash scripts/test-tier2-provider-artifact.sh
 	PYTHONDONTWRITEBYTECODE=1 python3 -m unittest -v ops/pearl-updater/test_pearl_updater.py
 	bash ops/pearl-updater/test_transaction_gate_systemd.sh

--- a/scripts/build-release-discovery-head.py
+++ b/scripts/build-release-discovery-head.py
@@ -1,0 +1,190 @@
+#!/usr/bin/env python3
+"""Build and sign the SPEC-020 release discovery head."""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import hashlib
+import json
+import pathlib
+import re
+import subprocess
+import tempfile
+
+
+ENVELOPE_SCHEMA = "macprovider.release-discovery-envelope.v1"
+PAYLOAD_SCHEMA = "macprovider.release-discovery.v1"
+COMPATIBILITY_SCHEMA = "macprovider.compatibility-set-envelope.v1"
+HEX64 = re.compile(r"[0-9a-f]{64}")
+SEMVER = re.compile(r"v?[0-9]+\.[0-9]+\.[0-9]+")
+SET_ID = re.compile(r"[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+:v[0-9]+\.[0-9]+\.[0-9]+@[0-9a-f]{40}")
+SEQUENCE_ATTEMPT_BITS = 16
+SEQUENCE_ATTEMPT_MAX = (1 << SEQUENCE_ATTEMPT_BITS) - 1
+UINT64_MAX = (1 << 64) - 1
+
+
+def fail(message: str) -> None:
+    raise SystemExit(f"[build-release-discovery-head] ERROR: {message}")
+
+
+def canonical_bytes(value: object) -> bytes:
+    return (json.dumps(value, sort_keys=True, separators=(",", ":")) + "\n").encode("utf-8")
+
+
+def load_canonical(path: pathlib.Path, label: str) -> dict:
+    data = path.read_bytes()
+    try:
+        value = json.loads(
+            data.decode("utf-8"),
+            object_pairs_hook=_reject_duplicate_keys(label),
+            parse_constant=lambda value: fail(f"{label}: invalid number {value}"),
+        )
+    except json.JSONDecodeError as exc:
+        fail(f"{label}: invalid JSON: {exc}")
+    if not isinstance(value, dict):
+        fail(f"{label}: top level must be an object")
+    if data != canonical_bytes(value):
+        fail(f"{label}: must be canonical sorted compact JSON with one trailing newline")
+    return value
+
+
+def _reject_duplicate_keys(label: str):
+    def hook(pairs: list[tuple[str, object]]) -> dict:
+        result: dict = {}
+        for key, value in pairs:
+            if key in result:
+                fail(f"{label}: duplicate key {key!r}")
+            result[key] = value
+        return result
+
+    return hook
+
+
+def compatibility_set_id(path: pathlib.Path) -> str:
+    envelope = load_canonical(path, "compatibility manifest")
+    if set(envelope) != {"schema_version", "signatures", "signed"}:
+        fail("compatibility manifest: unsupported envelope fields")
+    if envelope["schema_version"] != COMPATIBILITY_SCHEMA:
+        fail("compatibility manifest: unsupported schema")
+    signed = envelope["signed"]
+    if not isinstance(signed, dict):
+        fail("compatibility manifest: missing signed payload")
+    set_id = signed.get("compatibility_set_id")
+    if not isinstance(set_id, str) or not SET_ID.fullmatch(set_id):
+        fail("compatibility manifest: invalid compatibility_set_id")
+    return set_id
+
+
+def parse_time(value: str, label: str) -> dt.datetime:
+    if not value.endswith("Z"):
+        fail(f"{label}: must be UTC Z time")
+    try:
+        parsed = dt.datetime.strptime(value, "%Y-%m-%dT%H:%M:%SZ").replace(tzinfo=dt.timezone.utc)
+    except ValueError as exc:
+        fail(f"{label}: invalid RFC3339 second-precision time: {exc}")
+    return parsed
+
+
+def format_time(value: dt.datetime) -> str:
+    return value.astimezone(dt.timezone.utc).replace(microsecond=0).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def normalize_semver(value: str, label: str) -> str:
+    if not SEMVER.fullmatch(value):
+        fail(f"{label}: invalid semver")
+    return value[1:] if value.startswith("v") else value
+
+
+def sign_payload(
+    payload: bytes,
+    private_key: pathlib.Path,
+    public_key: pathlib.Path,
+    signature: pathlib.Path,
+    openssl: str,
+) -> None:
+    with tempfile.NamedTemporaryFile(prefix="release-discovery-signed.", suffix=".json") as handle:
+        handle.write(payload)
+        handle.flush()
+        subprocess.run(
+            [openssl, "dgst", "-sha256", "-sign", str(private_key), "-out", str(signature), handle.name],
+            check=True,
+        )
+        subprocess.run(
+            [
+                openssl,
+                "dgst",
+                "-sha256",
+                "-verify",
+                str(public_key),
+                "-signature",
+                str(signature),
+                handle.name,
+            ],
+            check=True,
+            stdout=subprocess.DEVNULL,
+        )
+
+
+def release_sequence(run_id: int, run_attempt: int) -> int:
+    if run_id <= 0:
+        fail("release run id must be positive")
+    if run_attempt <= 0 or run_attempt > SEQUENCE_ATTEMPT_MAX:
+        fail(f"release run attempt must be between 1 and {SEQUENCE_ATTEMPT_MAX}")
+    if run_id > (UINT64_MAX - run_attempt) >> SEQUENCE_ATTEMPT_BITS:
+        fail("release run id is too large for the composite sequence")
+    return (run_id << SEQUENCE_ATTEMPT_BITS) | run_attempt
+
+
+def build(args: argparse.Namespace) -> None:
+    sequence = release_sequence(args.sequence, args.attempt)
+    set_id = compatibility_set_id(args.compatibility_manifest)
+    artifact_index_sha = hashlib.sha256(args.target_artifact_index.read_bytes()).hexdigest()
+    if not HEX64.fullmatch(artifact_index_sha):
+        fail("artifact index digest invalid")
+    now = dt.datetime.now(dt.timezone.utc).replace(microsecond=0)
+    issued = parse_time(args.issued_at, "issued_at") if args.issued_at else now
+    expires = parse_time(args.expires_at, "expires_at") if args.expires_at else issued + dt.timedelta(hours=24)
+    if expires <= issued or expires - issued > dt.timedelta(days=7):
+        fail("expires_at must be after issued_at and no more than seven days later")
+    minimum = None if args.signed_policy_minimum is None else normalize_semver(args.signed_policy_minimum, "signed policy minimum")
+    revoked = sorted({normalize_semver(value, "signed policy revoked") for value in args.signed_policy_revoked})
+    signed = {
+        "expires_at": format_time(expires),
+        "issued_at": format_time(issued),
+        "release_sequence": sequence,
+        "schema_version": PAYLOAD_SCHEMA,
+        "signed_policy_minimum": minimum,
+        "signed_policy_revoked": revoked,
+        "target_artifact_index_sha256": artifact_index_sha,
+        "target_compatibility_set_id": set_id,
+    }
+    envelope = {
+        "schema_version": ENVELOPE_SCHEMA,
+        "signed": signed,
+    }
+    signed_bytes = canonical_bytes(signed)
+    args.output.write_bytes(canonical_bytes(envelope))
+    sign_payload(signed_bytes, args.private_key, args.public_key, args.signature, args.openssl)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--sequence", type=int, required=True)
+    parser.add_argument("--attempt", type=int, required=True)
+    parser.add_argument("--compatibility-manifest", type=pathlib.Path, required=True)
+    parser.add_argument("--target-artifact-index", type=pathlib.Path, required=True)
+    parser.add_argument("--signed-policy-minimum")
+    parser.add_argument("--signed-policy-revoked", action="append", default=[])
+    parser.add_argument("--issued-at")
+    parser.add_argument("--expires-at")
+    parser.add_argument("--private-key", type=pathlib.Path, required=True)
+    parser.add_argument("--public-key", type=pathlib.Path, required=True)
+    parser.add_argument("--openssl", default="openssl")
+    parser.add_argument("--output", type=pathlib.Path, required=True)
+    parser.add_argument("--signature", type=pathlib.Path, required=True)
+    build(parser.parse_args())
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/sign-acceptance-candidate.sh
+++ b/scripts/sign-acceptance-candidate.sh
@@ -23,6 +23,7 @@ root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd -P)"
 metadata="$root/scripts/acceptance-candidate-metadata.py"
 compatibility="$root/scripts/compatibility-set-manifest.py"
 artifact_index="$root/scripts/compatibility-artifact-index.py"
+release_discovery="$root/scripts/build-release-discovery-head.py"
 keychain_helper="$root/scripts/acceptance-signing-keychain.sh"
 acceptance_public_key="$root/security/acceptance-candidate-signing-public.pem"
 openssl_bin="${OPENSSL_BIN:-openssl}"
@@ -54,7 +55,7 @@ fi
 for command in python3 security codesign xcrun ditto hdiutil tar shasum spctl base64 "$openssl_bin"; do
   command -v "$command" >/dev/null 2>&1 || die "required command is unavailable: $command"
 done
-for path in "$metadata" "$compatibility" "$artifact_index" "$keychain_helper" "$acceptance_public_key"; do
+for path in "$metadata" "$compatibility" "$artifact_index" "$release_discovery" "$keychain_helper" "$acceptance_public_key"; do
   [[ -f "$path" && ! -L "$path" ]] || die "trusted signer input is absent or unsafe: $path"
 done
 [[ -d "$unsigned_dir" && ! -L "$unsigned_dir" ]] || die "unsigned input directory is absent or unsafe"
@@ -333,6 +334,16 @@ python3 "$artifact_index" validate \
   --tag "$tag" \
   --commit "$candidate_commit" \
   "${artifact_arguments[@]}"
+python3 "$release_discovery" \
+  --sequence "$run_id" \
+  --attempt "$run_attempt" \
+  --compatibility-manifest "$output_dir/compatibility-set.json" \
+  --target-artifact-index "$output_dir/compatibility-artifact-index.json" \
+  --private-key "$release_private_key" \
+  --public-key "$release_public_key" \
+  --openssl "$openssl_bin" \
+  --output "$output_dir/macprovider-release-discovery.json" \
+  --signature "$output_dir/macprovider-release-discovery.json.sig"
 
 release_assets=(
   "$provider_asset"
@@ -351,6 +362,8 @@ release_assets=(
   "$output_dir/pearl-release.json"
   "$output_dir/pearl-release.json.sig"
   "$output_dir/compatibility-artifact-index.json"
+  "$output_dir/macprovider-release-discovery.json"
+  "$output_dir/macprovider-release-discovery.json.sig"
 )
 python3 "$root/scripts/build-release-provenance.py" \
   "$tag" "$candidate_commit" "$repository" "$release_prerelease" \

--- a/scripts/test-acceptance-candidate-security.sh
+++ b/scripts/test-acceptance-candidate-security.sh
@@ -9,6 +9,7 @@ keychain_helper="$root/scripts/acceptance-signing-keychain.sh"
 source_guard="$root/scripts/verify-acceptance-candidate-source.sh"
 remote_guard="$root/scripts/verify-acceptance-remote-state.sh"
 provisioner="$root/scripts/provision-acceptance-signing-key.sh"
+release_discovery="$root/scripts/build-release-discovery-head.py"
 work="$(mktemp -d "${TMPDIR:-/tmp}/acceptance-security.XXXXXX")"
 trap 'rm -rf "$work"' EXIT
 
@@ -17,7 +18,7 @@ fail() {
   exit 1
 }
 
-python3 - "$workflow" "$metadata" "$signer" "$keychain_helper" "$provisioner" "$root/schemas/acceptance-candidate-v1.schema.json" <<'PY'
+python3 - "$workflow" "$metadata" "$signer" "$keychain_helper" "$provisioner" "$root/schemas/acceptance-candidate-v1.schema.json" "$release_discovery" <<'PY'
 import ast
 import pathlib
 import re
@@ -29,6 +30,7 @@ signer = pathlib.Path(sys.argv[3]).read_text(encoding="utf-8")
 keychain_helper = pathlib.Path(sys.argv[4]).read_text(encoding="utf-8")
 provisioner = pathlib.Path(sys.argv[5]).read_text(encoding="utf-8")
 schema = __import__("json").loads(pathlib.Path(sys.argv[6]).read_text(encoding="utf-8"))
+release_discovery = pathlib.Path(sys.argv[7])
 
 if "\n  workflow_dispatch:\n" not in workflow or "\n  push:" in workflow:
     raise SystemExit("acceptance workflow must be manual dispatch only")
@@ -111,6 +113,27 @@ if (
     raise SystemExit("promotion-ready acceptance does not bind stable release provenance")
 if '--compatibility-manifest "$output_dir/compatibility-set.json"' not in signer:
     raise SystemExit("acceptance-only Pearl metadata is not bound to the signed compatibility manifest")
+for value in (
+    'release_discovery="$root/scripts/build-release-discovery-head.py"',
+    '"$release_discovery"',
+    '--attempt "$run_attempt"',
+    '--target-artifact-index "$output_dir/compatibility-artifact-index.json"',
+    '--private-key "$release_private_key"',
+    '--public-key "$release_public_key"',
+    '--output "$output_dir/macprovider-release-discovery.json"',
+    '--signature "$output_dir/macprovider-release-discovery.json.sig"',
+):
+    if value not in signer:
+        raise SystemExit(f"acceptance signer release-discovery contract is incomplete: {value}")
+if not release_discovery.is_file() or release_discovery.is_symlink():
+    raise SystemExit("main-owned release-discovery builder is absent or unsafe")
+release_asset_block = signer.split("release_assets=(", 1)[1].split("\n)", 1)[0]
+for value in (
+    '"$output_dir/macprovider-release-discovery.json"',
+    '"$output_dir/macprovider-release-discovery.json.sig"',
+):
+    if value not in release_asset_block:
+        raise SystemExit(f"release-discovery asset is omitted from the signed checksum selector: {value}")
 if 'tar -czf "$provider_asset" -C "$cli_work" .' in signer:
     raise SystemExit("acceptance signer can emit an ambiguous provider archive root")
 for value in (

--- a/scripts/test-acceptance-promotion.sh
+++ b/scripts/test-acceptance-promotion.sh
@@ -85,6 +85,8 @@ release_names=(
   "demand-rank.json"
   "demand-rank.json.sig"
   "gateway-linux-amd64"
+  "macprovider-release-discovery.json"
+  "macprovider-release-discovery.json.sig"
   "macprovider-cli-${tag}-darwin-arm64.tar.gz"
   "pearl-release.json"
   "pearl-release.json.sig"

--- a/scripts/test-release-discovery-head.sh
+++ b/scripts/test-release-discovery-head.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd -P)"
+work="$(mktemp -d "${TMPDIR:-/tmp}/release-discovery-head.XXXXXX")"
+trap 'rm -rf "$work"' EXIT
+
+openssl genpkey -algorithm EC -pkeyopt ec_paramgen_curve:P-256 -out "$work/private.pem" >/dev/null 2>&1
+openssl pkey -in "$work/private.pem" -pubout -out "$work/public.pem" >/dev/null 2>&1
+cat > "$work/compatibility-set.json" <<'JSON'
+{"schema_version":"macprovider.compatibility-set-envelope.v1","signatures":[],"signed":{"compatibility_set_id":"Augustas11/macprovider:v1.8.41@0123456789abcdef0123456789abcdef01234567"}}
+JSON
+printf '{"schema_version":"macprovider.compatibility-artifact-index.v1"}\n' > "$work/compatibility-artifact-index.json"
+
+python3 "$root/scripts/build-release-discovery-head.py" \
+  --sequence 610 \
+  --attempt 2 \
+  --compatibility-manifest "$work/compatibility-set.json" \
+  --target-artifact-index "$work/compatibility-artifact-index.json" \
+  --signed-policy-minimum 1.8.40 \
+  --signed-policy-revoked v1.8.39 \
+  --issued-at 2026-07-17T00:00:00Z \
+  --expires-at 2026-07-18T00:00:00Z \
+  --private-key "$work/private.pem" \
+  --public-key "$work/public.pem" \
+  --output "$work/macprovider-release-discovery.json" \
+  --signature "$work/macprovider-release-discovery.json.sig"
+python3 "$root/scripts/build-release-discovery-head.py" \
+  --sequence 610 \
+  --attempt 3 \
+  --compatibility-manifest "$work/compatibility-set.json" \
+  --target-artifact-index "$work/compatibility-artifact-index.json" \
+  --signed-policy-minimum 1.8.40 \
+  --signed-policy-revoked v1.8.39 \
+  --issued-at 2026-07-17T00:00:00Z \
+  --expires-at 2026-07-18T00:00:00Z \
+  --private-key "$work/private.pem" \
+  --public-key "$work/public.pem" \
+  --output "$work/macprovider-release-discovery-rerun.json" \
+  --signature "$work/macprovider-release-discovery-rerun.json.sig"
+
+python3 - "$work" <<'PY'
+import hashlib
+import json
+import pathlib
+import sys
+
+work = pathlib.Path(sys.argv[1])
+data = work.joinpath("macprovider-release-discovery.json").read_bytes()
+head = json.loads(data)
+assert data == (json.dumps(head, sort_keys=True, separators=(",", ":")) + "\n").encode()
+assert set(head) == {"schema_version", "signed"}
+assert head["schema_version"] == "macprovider.release-discovery-envelope.v1"
+signed = head["signed"]
+assert signed == {
+    "expires_at": "2026-07-18T00:00:00Z",
+    "issued_at": "2026-07-17T00:00:00Z",
+    "release_sequence": 39976962,
+    "schema_version": "macprovider.release-discovery.v1",
+    "signed_policy_minimum": "1.8.40",
+    "signed_policy_revoked": ["1.8.39"],
+    "target_artifact_index_sha256": hashlib.sha256(work.joinpath("compatibility-artifact-index.json").read_bytes()).hexdigest(),
+    "target_compatibility_set_id": "Augustas11/macprovider:v1.8.41@0123456789abcdef0123456789abcdef01234567",
+}
+rerun = json.loads(work.joinpath("macprovider-release-discovery-rerun.json").read_bytes())
+assert rerun["signed"]["release_sequence"] == signed["release_sequence"] + 1
+assert rerun != head
+work.joinpath("signed-payload.json").write_bytes(
+    (json.dumps(signed, sort_keys=True, separators=(",", ":")) + "\n").encode()
+)
+PY
+
+openssl dgst -sha256 -verify "$work/public.pem" \
+  -signature "$work/macprovider-release-discovery.json.sig" \
+  "$work/signed-payload.json" >/dev/null
+
+printf '[test-release-discovery-head] PASS\n'

--- a/scripts/verify-acceptance-promotion.py
+++ b/scripts/verify-acceptance-promotion.py
@@ -136,6 +136,8 @@ def verify_directory(args: argparse.Namespace) -> None:
         "pearl-release.json",
         "pearl-release.json.sig",
         "compatibility-artifact-index.json",
+        "macprovider-release-discovery.json",
+        "macprovider-release-discovery.json.sig",
         "release-provenance.json",
     }
     if set(release_names) != required_release_names:


### PR DESCRIPTION
## What changed

- added the main-owned signed release-discovery head producer
- made the protected acceptance signer emit, verify, and checksum-bind `macprovider-release-discovery.json` and its signature
- encoded GitHub reruns into a bounded monotonic release sequence
- extended the exact promotion inventory to carry the two discovery assets
- added producer, signer-boundary, and promotion regression coverage

## Why

PR #631 cannot produce a physically testable private candidate before merge because its protected signer executes only code already reviewed on `main`. Landing this narrow prerequisite preserves that trust boundary while allowing the existing manual acceptance workflow to sign the discovery assets required by #610.

This PR changes no provider runtime, coordinator behavior, public release publication, or production activation.

## Validation

- `make test-dist`
- focused release-discovery producer test
- focused acceptance signer security test
- focused acceptance promotion test
- shell syntax, Python AST, and `git diff --check`
- code audit: 0 Critical / High / Medium / Low
- architecture audit: 0 Critical / High / Medium / Low
- security audit: 0 Critical / High / Medium; 1 contained Low for standalone path hardening outside the fresh-directory protected signer composition

## Integration sequence

After merge, merge updated `main` into #631, retain these main-owned signer/producer versions, update #631 public release call sites for `--attempt` and `--public-key`, rerun CI, and dispatch the protected physical-acceptance candidate.

Relates to #610.

SPEC-GOVERNANCE-DECLARATION-BEGIN
{
  "schema_version": "spec-pr-governance-v1",
  "behavior_change": "yes",
  "contract_change": "none",
  "specs": ["SPEC-020"],
  "requirements": ["SPEC-020-R001", "SPEC-020-R002", "SPEC-020-R003"],
  "authority_domains": ["provider-autoupdate"],
  "arbitration": ["CODE_BUG"],
  "tests": [
    "make test-dist",
    "bash scripts/test-release-discovery-head.sh",
    "bash scripts/test-acceptance-candidate-security.sh",
    "bash scripts/test-acceptance-promotion.sh",
    "git diff --check"
  ],
  "journeys": ["pending-protected-private-candidate"],
  "issue": "https://github.com/Augustas11/macprovider/issues/610"
}
SPEC-GOVERNANCE-DECLARATION-END
