### PR TITLE
Advance the #651 updater fix to v1.8.55

### DIFF
--- a/phase3-binary/Sources/macprovider-cli/CoordinatorClient.swift
+++ b/phase3-binary/Sources/macprovider-cli/CoordinatorClient.swift
@@ -146,7 +146,7 @@ actor CoordinatorClient {
     typealias InstalledCompatibilityManifest = @Sendable (URL, String) -> CompatibilitySetManifest?
     typealias ReloadHelperFence = @Sendable () throws -> Void
 
-    static let binaryVersion = "1.8.54"
+    static let binaryVersion = "1.8.55"
     private static let keepaliveDebugEnabled = ProcessInfo.processInfo.environment["MACPROVIDER_KEEPALIVE_DEBUG"] == "1"
 
     private let coordinatorURL: URL

--- a/phase3-binary/Tests/macprovider-cliTests/CoordinatorClientTests.swift
+++ b/phase3-binary/Tests/macprovider-cliTests/CoordinatorClientTests.swift
@@ -4004,10 +4004,10 @@ final class CoordinatorClientTests: XCTestCase {
         let hello = await client.helloMessage()
         let auth = await client.authInitialMessage(attempt: attempt)
 
-        XCTAssertEqual(CoordinatorClient.binaryVersion, "1.8.54")
-        XCTAssertEqual(MacProviderCLI.configuration.version, "1.8.54")
-        XCTAssertEqual(hello["binary_version"] as? String, "1.8.54")
-        XCTAssertEqual(auth["binary_version"] as? String, "1.8.54")
+        XCTAssertEqual(CoordinatorClient.binaryVersion, "1.8.55")
+        XCTAssertEqual(MacProviderCLI.configuration.version, "1.8.55")
+        XCTAssertEqual(hello["binary_version"] as? String, "1.8.55")
+        XCTAssertEqual(auth["binary_version"] as? String, "1.8.55")
     }
 
     func testCatalogProviderRejectsCoordinatorWithoutAdmissionAcknowledgement() async throws {

--- a/phase4-coordinator/coordinator.yaml.example
+++ b/phase4-coordinator/coordinator.yaml.example
@@ -184,7 +184,7 @@ autotune:
 # legacy cohort (DECISION_CRITERIA Entry 161). `required_binary_version` is a
 # hard admission floor, not an autoupdate target, and is unaffected by the gate.
 coordinator_advertised_version:
-  latest_binary_version: "1.8.54"
+  latest_binary_version: "1.8.55"
   required_binary_version: ""
 
 auth:

--- a/phase4-coordinator/dist/coordinator.yaml
+++ b/phase4-coordinator/dist/coordinator.yaml
@@ -303,4 +303,4 @@ providers:
 # legacy cohort (DECISION_CRITERIA Entry 161). Setting this value does not, and
 # must not, re-arm the legacy binary-only updater.
 coordinator_advertised_version:
-  latest_binary_version: "1.8.54"
+  latest_binary_version: "1.8.55"

--- a/phase4-coordinator/dist/coordinator.yaml.example
+++ b/phase4-coordinator/dist/coordinator.yaml.example
@@ -358,7 +358,7 @@ malibu_emission:
 # Use for security fixes that must not be optional. Leave unset for advisory
 # releases.
 coordinator_advertised_version:
-  latest_binary_version: "1.8.54"
+  latest_binary_version: "1.8.55"
   # required_binary_version: "1.7.0"
 
 # Enumerated providers (SPEC-002 v1.0.4 Finding F-2: every provider_id that

--- a/scripts/test-malibu-independent-release.sh
+++ b/scripts/test-malibu-independent-release.sh
@@ -124,8 +124,13 @@ PY
 validator="$root/scripts/validate-malibu-release-cli-inputs.sh"
 valid_sha="$(printf 'a%.0s' {1..64})"
 valid_archive_sha="$(printf 'b%.0s' {1..64})"
+valid_cli_version="$(
+  sed -nE 's/^[[:space:]]*static let binaryVersion = "([^"]+)".*$/\1/p' \
+    "$root/phase3-binary/Sources/macprovider-cli/CoordinatorClient.swift"
+)"
+valid_cli_tag="v$valid_cli_version"
 
-"$validator" v1.8.54 1.8.54 "$valid_sha" "$valid_archive_sha" >/dev/null
+"$validator" "$valid_cli_tag" "$valid_cli_version" "$valid_sha" "$valid_archive_sha" >/dev/null
 
 expect_failure() {
   if "$validator" "$@" >/dev/null 2>&1; then
@@ -134,11 +139,11 @@ expect_failure() {
   fi
 }
 
-expect_failure 1.8.54 1.8.54 "$valid_sha" "$valid_archive_sha"
-expect_failure v1.8.53 1.8.54 "$valid_sha" "$valid_archive_sha"
-expect_failure v1.8.54 1.8.53 "$valid_sha" "$valid_archive_sha"
-expect_failure v1.8.54 1.8.54 "$(printf 'A%.0s' {1..64})" "$valid_archive_sha"
-expect_failure v1.8.54 1.8.54 "${valid_sha%?}" "$valid_archive_sha"
-expect_failure v1.8.54 1.8.54 "$valid_sha" "${valid_archive_sha}0"
+expect_failure "$valid_cli_version" "$valid_cli_version" "$valid_sha" "$valid_archive_sha"
+expect_failure v0.0.1 "$valid_cli_version" "$valid_sha" "$valid_archive_sha"
+expect_failure "$valid_cli_tag" 0.0.1 "$valid_sha" "$valid_archive_sha"
+expect_failure "$valid_cli_tag" "$valid_cli_version" "$(printf 'A%.0s' {1..64})" "$valid_archive_sha"
+expect_failure "$valid_cli_tag" "$valid_cli_version" "${valid_sha%?}" "$valid_archive_sha"
+expect_failure "$valid_cli_tag" "$valid_cli_version" "$valid_sha" "${valid_archive_sha}0"
 
 echo "independent Malibu release CLI input validation checks passed"


### PR DESCRIPTION
## Outcome

Creates a release-only forward identity for the already-merged #651 updater fix so the exact merged bytes can be physically installed and proven without downgrading or bypassing the same-version guard.

## Scope

- Advances the provider CLI version from 1.8.54 to 1.8.55.
- Keeps the three coordinator example/default advertised-version surfaces aligned.
- Updates the focused handshake version assertions.
- Makes the independent Malibu release fixture derive the authoritative CLI version instead of hardcoding a past release.
- Does not change Malibu versioning or runtime behavior.

## Why

The private v1.8.54 artifact that proved #651 was built before GitHub squash-merged the source. The merged v1.8.54 candidate therefore has a different embedded signed commit identity, while the installed private candidate correctly refuses a same-version replacement. A forward v1.8.55 identity permits the exact merged source to pass the normal signed update path.

## Validation

- `scripts/test-coordinator-advertised-version.sh v1.8.55`
- Focused `CoordinatorClientTests/testBinaryVersion_AdvertisesSPEC020V17AcrossHandshakeFrames`
- Complete `make test-dist` (125 Pearl updater tests plus installer/watchdog/release suites; one expected Linux-root skip)
- `git diff --check`

## Physical stop condition

After merge: build the protected signed v1.8.55 candidate, update the live v1.8.54 provider through `macprovider-cli update`, prove exactly one provider process, no reload helper, exact compatibility identity, coordinator reconnection and a real buyer HTTP 200, then promote the exact tested bytes.

SPEC-GOVERNANCE-DECLARATION-BEGIN
{
  "schema_version": "spec-pr-governance-v1",
  "behavior_change": "yes",
  "contract_change": "none",
  "issue": "https://github.com/Augustas11/macprovider/issues/651",
  "specs": ["SPEC-020"],
  "requirements": ["SPEC-020-R004"],
  "authority_domains": ["provider-autoupdate"],
  "arbitration": ["CODE_BUG"],
  "tests": ["scripts/test-coordinator-advertised-version.sh", "CoordinatorClientTests.testBinaryVersion_AdvertisesSPEC020V17AcrossHandshakeFrames", "make test-dist"],
  "journeys": ["Post-merge signed v1.8.54-to-v1.8.55 physical updater acceptance"]
}
SPEC-GOVERNANCE-DECLARATION-END