### PR TITLE
Finish public provider recovery language across Malibu and CLI

### DIFF
--- a/phase3-binary/Sources/macprovider-cli/AutotuneCommand.swift
+++ b/phase3-binary/Sources/macprovider-cli/AutotuneCommand.swift
@@ -829,7 +829,7 @@ struct AutotuneCommand: AsyncParsableCommand {
         request.benchmarks = outcomes.benchmarks
         for modelKey in outcomes.diagnostics.keys.sorted() {
             let reason = outcomes.diagnostics[modelKey]!
-            FileHandle.standardError.write(Data("[warn] spec-023 probe: \(modelKey): \(reason)\n".utf8))
+            FileHandle.standardError.write(Data("[warn] Model readiness check: \(modelKey): \(reason)\n".utf8))
         }
         var result = AutotuneRecommendEngine().recommend(request)
         result.probeDiagnostics = outcomes.diagnostics

--- a/phase3-binary/Sources/macprovider-cli/BootstrapAuthCommand.swift
+++ b/phase3-binary/Sources/macprovider-cli/BootstrapAuthCommand.swift
@@ -8,7 +8,8 @@ import MacProviderCore
 struct BootstrapAuthCommand: AsyncParsableCommand {
     static let configuration = CommandConfiguration(
         commandName: "bootstrap-auth",
-        abstract: "Acquire and persist a first-install provider credential."
+        abstract: "Acquire and persist a first-install provider credential.",
+        shouldDisplay: false
     )
 
     @Option(help: "YAML config path. Defaults to ~/.config/macprovider/config.yaml.")

--- a/phase3-binary/Sources/macprovider-cli/CredentialsCommand.swift
+++ b/phase3-binary/Sources/macprovider-cli/CredentialsCommand.swift
@@ -7,6 +7,7 @@ struct CredentialsCommand: ParsableCommand {
     static let configuration = CommandConfiguration(
         commandName: "credentials",
         abstract: "Manage CLI-owned provider credentials.",
+        shouldDisplay: false,
         subcommands: [
             CredentialsImportCommand.self,
             CredentialsVerifyCommand.self,

--- a/phase3-binary/Sources/macprovider-cli/DecodeBenchCommand.swift
+++ b/phase3-binary/Sources/macprovider-cli/DecodeBenchCommand.swift
@@ -31,7 +31,8 @@ struct DecodeBenchCommand: AsyncParsableCommand {
 
             TPS semantics: generation-only (excludes TTFT), matching Stage1Iterator
             v1.7.8 Track A4 semantics.
-            """
+            """,
+        shouldDisplay: false
     )
 
     @Option(help: "HuggingFace model ID or local path. Falls back to MACPROVIDER_MODEL.")

--- a/phase3-binary/Sources/macprovider-cli/EnrollCommand.swift
+++ b/phase3-binary/Sources/macprovider-cli/EnrollCommand.swift
@@ -8,6 +8,7 @@ struct EnrollCommand: AsyncParsableCommand {
     static let configuration = CommandConfiguration(
         commandName: "enroll",
         abstract: "Enroll this Mac in the macprovider MDM for hardware attestation.",
+        shouldDisplay: false,
         subcommands: [EnrollRunCommand.self, EnrollStatusCommand.self],
         defaultSubcommand: EnrollRunCommand.self
     )

--- a/phase3-binary/Sources/macprovider-cli/MacProviderCLI.swift
+++ b/phase3-binary/Sources/macprovider-cli/MacProviderCLI.swift
@@ -40,7 +40,7 @@ struct MacProviderCLI: AsyncParsableCommand {
         commandName: "macprovider-cli",
         abstract: "OpenAI-compatible Mac Provider inference CLI.",
         version: CoordinatorClient.binaryVersion,
-        subcommands: [ServeCommand.self, SelfTestCommand.self, StatusCommand.self, ClaimCommand.self, UpdateCommand.self, UninstallCommand.self, ModelsCommand.self, AutotuneCommand.self, BootstrapAuthCommand.self, RotateKeyCommand.self, CredentialsCommand.self, LifecycleStateCommand.self, LifecycleLeaseCommand.self, Spec028CanaryCommand.self, Spec028BenchmarkCommand.self, DecodeBenchCommand.self, EnrollCommand.self, ReleasePayloadPreflightCommand.self],
+        subcommands: [ServeCommand.self, SelfTestCommand.self, StatusCommand.self, ClaimCommand.self, UpdateCommand.self, UninstallCommand.self, ModelsCommand.self, AutotuneCommand.self, BootstrapAuthCommand.self, RotateKeyCommand.self, CredentialsCommand.self, LifecycleStateCommand.self, LifecycleLeaseCommand.self, Spec028CanaryCommand.self, Spec028BenchmarkCommand.self, LegacySpec028CanaryCommand.self, LegacySpec028BenchmarkCommand.self, DecodeBenchCommand.self, EnrollCommand.self, ReleasePayloadPreflightCommand.self],
         defaultSubcommand: ServeCommand.self
     )
 }
@@ -49,6 +49,7 @@ struct LifecycleStateCommand: ParsableCommand {
     static let configuration = CommandConfiguration(
         commandName: "lifecycle-state",
         abstract: "Read or transition the CLI-owned persisted provider lifecycle state.",
+        shouldDisplay: false,
         subcommands: [LifecycleStateStatusCommand.self, LifecycleStateTransitionCommand.self]
     )
 }
@@ -137,6 +138,7 @@ struct LifecycleLeaseCommand: ParsableCommand {
     static let configuration = CommandConfiguration(
         commandName: "lifecycle-lease",
         abstract: "Inspect the CLI-owned provider lifecycle lease.",
+        shouldDisplay: false,
         subcommands: [LifecycleLeaseStatusCommand.self]
     )
 }
@@ -217,7 +219,7 @@ struct ServeCommand: AsyncParsableCommand {
     @Option(help: "Speculative decoding draft tokens per verification round. Default 3 when --draft-model is set; valid range 1...16.")
     var numDraftTokens: Int?
 
-    @Flag(name: .customLong("publish-spec-decode-telemetry"), inversion: .prefixedNo, help: "Opt into publishing SPEC-028 speculative decoding telemetry on coordinator heartbeats after compatibility is verified. Default off.")
+    @Flag(name: .customLong("publish-spec-decode-telemetry"), inversion: .prefixedNo, help: "Opt into publishing speculative-decoding performance telemetry after provider software is verified. Default off.")
     var publishSpecDecodeTelemetry: Bool?
 
     @Option(help: "Coordinator WebSocket URL. Overrides MACPROVIDER_COORDINATOR_URL and config file coordinator_url.")
@@ -235,19 +237,19 @@ struct ServeCommand: AsyncParsableCommand {
     @Option(help: "Log level: trace, debug, info, notice, warning, error, critical.")
     var logLevel: String?
 
-    @Option(help: "Comma-separated list of HuggingFace model IDs (or local paths) this provider can serve. Overrides MACPROVIDER_SUPPORTED_MODELS and config key supported_models. When unset, the binary publishes supported_models: [model_id] (single-entry, per SPEC-010 v1.5 R-3.6.2).")
+    @Option(help: "Comma-separated list of HuggingFace model IDs (or local paths) this provider can serve. Overrides MACPROVIDER_SUPPORTED_MODELS and config key supported_models. When unset, only the configured model is advertised.")
     var supportedModels: String?
 
-    @Flag(name: .customLong("publish-supported-models"), inversion: .prefixedNo, help: "Opt into publishing the supported_models catalog to the coordinator's /v1/status echo (SPEC-010 v1.5 R-3.6.4). Default off.")
+    @Flag(name: .customLong("publish-supported-models"), inversion: .prefixedNo, help: "Opt into publishing the supported model list to the network status service. Default off.")
     var publishSupportedModels: Bool?
 
-    @Flag(name: .customLong("enable-warm-swap"), inversion: .prefixedNo, help: "Opt into the operator-pushed warm model swap workflow (SPEC-011 v0.5). Default off. When off, the binary follows the SPEC-001 v1.2.4 synchronous-load path; no control socket is opened.")
+    @Flag(name: .customLong("enable-warm-swap"), inversion: .prefixedNo, help: "Opt into switching models without a full provider restart. Default off. When off, no model-control socket is opened.")
     var enableWarmSwap: Bool?
 
-    @Flag(name: .customLong("enable-receipts"), inversion: .prefixedNo, help: "Opt into SPEC-015 non-streaming receipt emission. Default off for v0.1.x rollout.")
+    @Flag(name: .customLong("enable-receipts"), inversion: .prefixedNo, help: "Opt into signed non-streaming request receipts. Default off for staged rollout.")
     var enableReceipts: Bool?
 
-    @Option(help: "Drain timeout in seconds for an in-flight warm swap (SPEC-011 v0.5 §3.4 / §3.9). Default 30. Only meaningful when --enable-warm-swap is set.")
+    @Option(help: "Drain timeout in seconds for an in-flight model switch. Default 30. Only meaningful when --enable-warm-swap is set.")
     var swapDrainTimeoutSeconds: Int?
 
     @Option(help: "Control socket path. Overrides MACPROVIDER_CTL_SOCKET_PATH and config ctl_socket_path. Default $TMPDIR/macprovider-cli/ctl.sock. Only meaningful when --enable-warm-swap is set.")
@@ -1964,6 +1966,9 @@ struct StatusCommand: AsyncParsableCommand {
     @Option(help: "Local HTTP port to query. Overrides MACPROVIDER_PORT and config file port.")
     var port: Int?
 
+    @Flag(help: "Show exact technical fields for diagnostics and support.")
+    var advanced = false
+
     func run() async throws {
         let resolved = try ConfigLoader.load(
             cli: CLIOverrides(port: port, configPath: config)
@@ -1971,7 +1976,15 @@ struct StatusCommand: AsyncParsableCommand {
         let status = try await LocalStatusClient.fetch(port: resolved.port)
         let latest = try? await SelfUpdate(currentVersion: CoordinatorClient.binaryVersion, releasesAPIURL: nil).latestVersionCached()
         let staleSince = await Self.staleRecommendationSince(providerID: resolved.providerID)
-        print(LocalStatusFormatter.format(status, latestVersion: latest, ownerLogin: OwnerFileReader.githubLogin(configPath: resolved.configPath), donorMode: resolved.donorMode, staleRecommendationSince: staleSince, configPath: resolved.configPath))
+        print(LocalStatusFormatter.format(
+            status,
+            latestVersion: latest,
+            ownerLogin: OwnerFileReader.githubLogin(configPath: resolved.configPath),
+            donorMode: resolved.donorMode,
+            staleRecommendationSince: staleSince,
+            configPath: resolved.configPath,
+            advanced: advanced
+        ))
     }
 
     static func staleRecommendationSince(

--- a/phase3-binary/Sources/macprovider-cli/ModelsSubcommand.swift
+++ b/phase3-binary/Sources/macprovider-cli/ModelsSubcommand.swift
@@ -64,7 +64,7 @@ struct ModelsSwitchCommand: AsyncParsableCommand {
     @Argument(help: "Target HuggingFace model ID or local path.")
     var targetModelID: String
 
-    @Flag(help: "Bypass the CLI-side cooldown soft guard AND the local RAM fit guard (SPEC-001 v1.4 R-6.13.2): wontFit becomes a warning, tight is silenced, and HF-shape unknown fail-closed is overridden. Does NOT bypass --supported-models membership or server-side concurrency rejection.")
+    @Flag(help: "Bypass local cooldown and RAM-fit checks. This does not allow unsupported models or override network concurrency limits.")
     var force = false
 
     @Option(help: "YAML config path. Overrides MACPROVIDER_CONFIG.")

--- a/phase3-binary/Sources/macprovider-cli/RotateKeyCommand.swift
+++ b/phase3-binary/Sources/macprovider-cli/RotateKeyCommand.swift
@@ -29,7 +29,8 @@ enum ReceiptKeyRotationError: Error, CustomStringConvertible, Equatable {
 struct RotateKeyCommand: AsyncParsableCommand {
     static let configuration = CommandConfiguration(
         commandName: "rotate-key",
-        abstract: "Ask the running provider process to rotate its receipt signing key."
+        abstract: "Ask the running provider process to rotate its receipt signing key.",
+        shouldDisplay: false
     )
 
     @Option(help: "YAML config path. Overrides MACPROVIDER_CONFIG. Defaults to ~/.config/macprovider/config.yaml.")

--- a/phase3-binary/Sources/macprovider-cli/SelfUpdate.swift
+++ b/phase3-binary/Sources/macprovider-cli/SelfUpdate.swift
@@ -2438,7 +2438,112 @@ struct LocalStatusClient {
 }
 
 struct LocalStatusFormatter {
-    static func format(_ status: [String: Any], latestVersion: String? = nil, ownerLogin: String? = nil, donorMode: Bool = false, staleRecommendationSince: Date? = nil, configPath: String? = nil) -> String {
+    static func format(
+        _ status: [String: Any],
+        latestVersion: String? = nil,
+        ownerLogin: String? = nil,
+        donorMode: Bool = false,
+        staleRecommendationSince: Date? = nil,
+        configPath: String? = nil,
+        advanced: Bool = false
+    ) -> String {
+        guard advanced else {
+            return publicFormat(
+                status,
+                latestVersion: latestVersion,
+                ownerLogin: ownerLogin,
+                donorMode: donorMode,
+                staleRecommendationSince: staleRecommendationSince
+            )
+        }
+        return advancedFormat(
+            status,
+            latestVersion: latestVersion,
+            ownerLogin: ownerLogin,
+            donorMode: donorMode,
+            staleRecommendationSince: staleRecommendationSince,
+            configPath: configPath
+        )
+    }
+
+    private static func publicFormat(
+        _ status: [String: Any],
+        latestVersion: String?,
+        ownerLogin: String?,
+        donorMode: Bool,
+        staleRecommendationSince: Date?
+    ) -> String {
+        let coordinator = status["coordinator"] as? [String: Any] ?? [:]
+        let version = status["binary_version"] as? String ?? CoordinatorClient.binaryVersion
+        let providerID = string(status["provider_id"])
+        let model = string(status["model"])
+        let localState = string(status["status"])
+        let networkState = string(status["network_state"])
+        let connected = (coordinator["connected"] as? Bool) == true
+        let modelLoaded = (status["model_loaded"] as? Bool) ?? ["ready", "busy", "degraded"].contains(localState)
+        let title: String
+        let nextStep: String?
+
+        if donorMode || networkState == "local_donor" {
+            title = "Provider is running locally"
+            nextStep = "Open Malibu when you are ready to join the network."
+        } else if networkState == "buyer_serving" && connected && modelLoaded && !["draining", "unavailable"].contains(localState) {
+            title = "Provider is ready"
+            nextStep = nil
+        } else if networkState == "not_buyer_serving" {
+            title = "This Mac is not currently eligible"
+            nextStep = "Open Malibu to review the recommended next step."
+        } else if ["catalog_update_required", "compatibility_update_required"].contains(networkState) {
+            title = "This Mac is not currently eligible"
+            nextStep = "Run `macprovider-cli update`."
+        } else if !modelLoaded || ["draining", "unavailable"].contains(localState) {
+            title = "Model is preparing"
+            nextStep = "Keep this Mac awake while preparation completes."
+        } else if !connected {
+            title = "Provider is connecting"
+            nextStep = "Check this Mac's internet connection."
+        } else {
+            title = "Waiting for network approval"
+            nextStep = "No action is needed while approval completes."
+        }
+
+        let owner = ownerLogin.map { "@\($0)" } ?? "Not linked"
+        let update: String
+        if let latestVersion,
+           SelfUpdate.compareSemver(version, latestVersion) == .orderedAscending {
+            update = "v\(version) · v\(latestVersion) available"
+        } else if latestVersion != nil {
+            update = "v\(version) · up to date"
+        } else {
+            update = "v\(version) · update status unavailable"
+        }
+        let recommendation = staleRecommendationSince == nil
+            ? ""
+            : "\nRecommendation: Refresh with `macprovider-cli autotune --recommend`."
+        let action = nextStep.map { "\nNext step: \($0)" } ?? ""
+
+        return """
+        macprovider-cli v\(version)
+
+        \(title)
+        Provider: \(providerID)
+        Owner: \(owner)
+        Model: \(model)
+        Provider software: \(update)
+        Requests: \(status["requests_total"] ?? 0) served, \(status["errors_total"] ?? 0) errors\(recommendation)\(action)
+
+        Advanced diagnostics: macprovider-cli status --advanced
+        """
+    }
+
+    private static func advancedFormat(
+        _ status: [String: Any],
+        latestVersion: String?,
+        ownerLogin: String?,
+        donorMode: Bool,
+        staleRecommendationSince: Date?,
+        configPath: String?
+    ) -> String {
         let capacity = status["capacity"] as? [String: Any] ?? [:]
         let coordinator = status["coordinator"] as? [String: Any] ?? [:]
         let catalog = status["catalog"] as? [String: Any] ?? [:]

--- a/phase3-binary/Sources/macprovider-cli/Spec028BenchmarkCommand.swift
+++ b/phase3-binary/Sources/macprovider-cli/Spec028BenchmarkCommand.swift
@@ -4,11 +4,11 @@ import MacProviderCore
 
 struct Spec028BenchmarkCommand: AsyncParsableCommand {
     static let configuration = CommandConfiguration(
-        commandName: "spec028-benchmark",
-        abstract: "Measure SPEC-028 speculative decoding impact against the baseline path."
+        commandName: "performance-check",
+        abstract: "Compare speculative-decoding performance with the baseline path."
     )
 
-    @Option(name: .customLong("fixture"), help: "Fixture JSON path. May be repeated. Defaults to the AC-10 fixture.")
+    @Option(name: .customLong("fixture"), help: "Test fixture JSON path. May be repeated. Defaults to the supported 16 GB profile.")
     var fixturePaths: [String] = []
 
     @Option(help: "Target model local snapshot path. Overrides each fixture target model load path.")
@@ -233,6 +233,25 @@ struct Spec028BenchmarkCommand: AsyncParsableCommand {
 
     private static func evidenceModelRef(_ value: String) -> String {
         ProviderStatus.publicSpecDecodeDraftModelID(value) ?? "unknown"
+    }
+}
+
+/// Compatibility entry point for existing automation. Hidden from routine help so
+/// provider-facing surfaces use the public `performance-check` name.
+struct LegacySpec028BenchmarkCommand: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "spec028-benchmark",
+        shouldDisplay: false
+    )
+
+    @OptionGroup var command: Spec028BenchmarkCommand
+
+    mutating func validate() throws {
+        try command.validate()
+    }
+
+    mutating func run() async throws {
+        try await command.run()
     }
 }
 

--- a/phase3-binary/Sources/macprovider-cli/Spec028CanaryCommand.swift
+++ b/phase3-binary/Sources/macprovider-cli/Spec028CanaryCommand.swift
@@ -5,58 +5,66 @@ import MacProviderCore
 
 struct Spec028CanaryCommand: AsyncParsableCommand {
     static let configuration = CommandConfiguration(
-        commandName: "spec028-canary",
-        abstract: "Run SPEC-028 hardware acceptance canaries."
+        commandName: "hardware-check",
+        abstract: "Run the supported-Mac model readiness checks."
     )
 
-    enum CanaryKind: String, ExpressibleByArgument {
-        case ac10
-        case ac11
+    enum HardwareProfile: String, CaseIterable, ExpressibleByArgument {
+        case supported16GB = "supported-16gb"
+        case supported8GB = "supported-8gb"
+
+        init?(argument: String) {
+            switch argument {
+            case Self.supported16GB.rawValue, "ac10": self = .supported16GB
+            case Self.supported8GB.rawValue, "ac11": self = .supported8GB
+            default: return nil
+            }
+        }
     }
 
-    @Argument(help: "Canary to run. Currently: ac10, ac11.")
-    var kind: CanaryKind = .ac10
+    @Argument(help: "Hardware profile to check: supported-16gb or supported-8gb.")
+    var kind: HardwareProfile = .supported16GB
 
-    @Option(help: "Target model ID or local snapshot path. Defaults to the AC-10 fixture target.")
+    @Option(help: "Target model ID or local snapshot path. Defaults to the 16 GB test target.")
     var target: String?
 
-    @Option(help: "Draft model ID or local snapshot path. Defaults to the AC-10 fixture draft.")
+    @Option(help: "Draft model ID or local snapshot path. Defaults to the 16 GB test draft.")
     var draft: String?
 
-    @Option(help: "Speculative draft tokens. AC-10 default: 3.")
+    @Option(help: "Speculative draft tokens. Default: 3.")
     var numDraftTokens: Int = 3
 
     @Option(help: "Maximum prompt context tokens. Defaults to the 16 GB draft cap.")
     var maxContextTokens: Int = ProviderCapacity.draftContextCap(forPhysicalMemoryGB: 16)
 
-    @Option(help: "Number of warm baseline runs. AC-10 default: 5.")
+    @Option(help: "Number of warm baseline runs. Default: 5.")
     var baselineRuns: Int = 5
 
-    @Option(help: "Number of warm speculative runs. AC-10 default: 5.")
+    @Option(help: "Number of warm speculative runs. Default: 5.")
     var specRuns: Int = 5
 
-    @Option(help: "Sustained speculative window in seconds. AC-10 default: 300.")
+    @Option(help: "Sustained speculative window in seconds. Default: 300.")
     var sustainedSeconds: Double = 300
 
-    @Option(help: "Trailing sustained window in seconds. AC-10 default: 60.")
+    @Option(help: "Trailing sustained window in seconds. Default: 60.")
     var lastWindowSeconds: Double = 60
 
-    @Option(help: "Median speculative TPS / baseline TPS floor. AC-10 default: 1.4.")
+    @Option(help: "Median speculative TPS / baseline TPS floor. Default: 1.4.")
     var ratioFloor: Double = 1.4
 
-    @Option(help: "Trailing sustained TPS / baseline TPS floor. AC-10 default: 1.2.")
+    @Option(help: "Trailing sustained TPS / baseline TPS floor. Default: 1.2.")
     var sustainedRatioFloor: Double = 1.2
 
-    @Option(help: "Speculative accepted/drafted token floor. AC-10 default: 0.30.")
+    @Option(help: "Speculative accepted/drafted token floor. Default: 0.30.")
     var acceptanceFloor: Double = 0.30
 
-    @Option(help: "Override AC-10 fixture path.")
+    @Option(help: "Override the test fixture path.")
     var fixturePath: String?
 
-    @Flag(help: "Allow running on non-16 GB Apple Silicon for diagnostics. Evidence does not satisfy AC-10.")
+    @Flag(help: "Allow running the 16 GB profile on other Apple Silicon for diagnostics only.")
     var allowNon16GBHost = false
 
-    @Flag(help: "Allow running AC-11 on non-8 GB Apple Silicon for diagnostics. Evidence does not satisfy AC-11.")
+    @Flag(help: "Allow running the 8 GB profile on other Apple Silicon for diagnostics only.")
     var allowNon8GBHost = false
 
     mutating func validate() throws {
@@ -79,9 +87,9 @@ struct Spec028CanaryCommand: AsyncParsableCommand {
 
     mutating func run() async throws {
         switch kind {
-        case .ac10:
+        case .supported16GB:
             try await runAC10()
-        case .ac11:
+        case .supported8GB:
             try await runAC11()
         }
     }
@@ -90,7 +98,7 @@ struct Spec028CanaryCommand: AsyncParsableCommand {
         let host = HostEvidence.current()
         if !allowNon16GBHost {
             guard host.isAppleSilicon16GB else {
-                throw ValidationError("AC-10 requires M4 16 GB Apple Silicon; host=\(host.machine) chip=\(host.chip) memory_gb=\(host.memoryGB). Re-run on M4 16 GB hardware, or pass --allow-non16-gb-host for non-acceptance diagnostics.")
+                throw ValidationError("The 16 GB hardware check requires an M4 Mac with 16 GB memory. Re-run on supported hardware, or pass --allow-non16-gb-host for diagnostics only.")
             }
         }
 
@@ -160,7 +168,7 @@ struct Spec028CanaryCommand: AsyncParsableCommand {
         )
         try Self.emit(result)
         guard finalEvaluation.passed else {
-            throw ValidationError("AC-10 failed: \(finalEvaluation.failureReasons.joined(separator: "; "))")
+            throw ValidationError("The 16 GB hardware check failed. See the generated diagnostic report for details.")
         }
     }
 
@@ -168,7 +176,7 @@ struct Spec028CanaryCommand: AsyncParsableCommand {
         let host = HostEvidence.current()
         if !allowNon8GBHost {
             guard host.isAppleSilicon8GB else {
-                throw ValidationError("AC-11 requires M1 8 GB Apple Silicon; host=\(host.machine) chip=\(host.chip) memory_gb=\(host.memoryGB). Re-run on an 8 GB M1 Air, or pass --allow-non8-gb-host for non-acceptance diagnostics.")
+                throw ValidationError("The 8 GB hardware check requires an M1 Mac with 8 GB memory. Re-run on supported hardware, or pass --allow-non8-gb-host for diagnostics only.")
             }
         }
 
@@ -337,6 +345,25 @@ struct Spec028CanaryCommand: AsyncParsableCommand {
 
     private static func evidenceModelRef(_ value: String) -> String {
         ProviderStatus.publicSpecDecodeDraftModelID(value) ?? "unknown"
+    }
+}
+
+/// Compatibility entry point for existing automation. Hidden from routine help so
+/// provider-facing surfaces use the public `hardware-check` name.
+struct LegacySpec028CanaryCommand: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "spec028-canary",
+        shouldDisplay: false
+    )
+
+    @OptionGroup var command: Spec028CanaryCommand
+
+    mutating func validate() throws {
+        try command.validate()
+    }
+
+    mutating func run() async throws {
+        try await command.run()
     }
 }
 

--- a/phase3-binary/Tests/macprovider-cliTests/StatusCommandTests.swift
+++ b/phase3-binary/Tests/macprovider-cliTests/StatusCommandTests.swift
@@ -11,7 +11,8 @@ final class StatusCommandTests: XCTestCase {
         let output = LocalStatusFormatter.format(
             status(providerID: "provider-a"),
             latestVersion: nil,
-            ownerLogin: OwnerFileReader.githubLogin(configPath: fixture.configPath)
+            ownerLogin: OwnerFileReader.githubLogin(configPath: fixture.configPath),
+            advanced: true
         )
 
         XCTAssertTrue(output.contains("Provider ID:  provider-a"), output)
@@ -28,7 +29,8 @@ final class StatusCommandTests: XCTestCase {
         let output = LocalStatusFormatter.format(
             status(providerID: "provider-a"),
             latestVersion: nil,
-            ownerLogin: OwnerFileReader.githubLogin(configPath: fixture.configPath)
+            ownerLogin: OwnerFileReader.githubLogin(configPath: fixture.configPath),
+            advanced: true
         )
 
         XCTAssertTrue(output.contains("Owner: (unclaimed — run `macprovider-cli claim`)"), output)
@@ -42,7 +44,8 @@ final class StatusCommandTests: XCTestCase {
         let output = LocalStatusFormatter.format(
             status(providerID: "provider-a"),
             latestVersion: nil,
-            ownerLogin: OwnerFileReader.githubLogin(configPath: fixture.configPath)
+            ownerLogin: OwnerFileReader.githubLogin(configPath: fixture.configPath),
+            advanced: true
         )
 
         XCTAssertTrue(output.contains("Owner: (unclaimed — run `macprovider-cli claim`)"), output)
@@ -56,7 +59,8 @@ final class StatusCommandTests: XCTestCase {
         let output = LocalStatusFormatter.format(
             status(providerID: "provider-a"),
             latestVersion: nil,
-            ownerLogin: OwnerFileReader.githubLogin(configPath: fixture.configPath)
+            ownerLogin: OwnerFileReader.githubLogin(configPath: fixture.configPath),
+            advanced: true
         )
 
         XCTAssertTrue(output.contains("Owner: (unclaimed — run `macprovider-cli claim`)"), output)
@@ -66,7 +70,8 @@ final class StatusCommandTests: XCTestCase {
         let output = LocalStatusFormatter.format(
             status(providerID: "provider-a"),
             latestVersion: nil,
-            donorMode: true
+            donorMode: true,
+            advanced: true
         )
 
         XCTAssertTrue(output.contains("Model:       model-a DONOR MODE"), output)
@@ -78,7 +83,8 @@ final class StatusCommandTests: XCTestCase {
         let output = LocalStatusFormatter.format(
             status(providerID: "provider-a"),
             latestVersion: nil,
-            staleRecommendationSince: staleSince
+            staleRecommendationSince: staleSince,
+            advanced: true
         )
 
         XCTAssertTrue(output.contains("Recommendation stale: recommendation inputs changed since 2026-07-01T00:00:00Z."), output)
@@ -102,7 +108,8 @@ final class StatusCommandTests: XCTestCase {
 
         let output = LocalStatusFormatter.format(
             payload,
-            configPath: "/tmp/provider config.yaml"
+            configPath: "/tmp/provider config.yaml",
+            advanced: true
         )
 
         XCTAssertTrue(output.contains("State:       recovery_pending"), output)
@@ -110,6 +117,109 @@ final class StatusCommandTests: XCTestCase {
         XCTAssertTrue(output.contains("Previous until: 2026-07-21T12:00:00Z"), output)
         XCTAssertTrue(output.contains("POST /admin/provider-admission-identity/recover"), output)
         XCTAssertTrue(output.contains("--config '/tmp/provider config.yaml' --expected-provider-id 'provider-a' --activate"), output)
+    }
+
+    func testDefaultStatusUsesPublicLifecycleLanguage() {
+        let policy = try! publicLanguagePolicy()
+        let prohibited = policy.terms.map(\.internalTerm)
+        let cases: [(String, String, Bool, Bool, String)] = [
+            ("buyer_serving", "ready", true, true, "Provider is ready"),
+            ("not_buyer_serving", "ready", true, true, "This Mac is not currently eligible"),
+            ("buyer_serving_unknown", "ready", true, true, "Waiting for network approval"),
+            ("catalog_update_required", "ready", true, true, "This Mac is not currently eligible"),
+            ("live_verified", "unavailable", true, false, "Model is preparing"),
+            ("live_verified", "ready", false, true, "Provider is connecting"),
+            ("buyer_serving", "ready", false, true, "Provider is connecting"),
+        ]
+
+        for (networkState, localState, connected, modelLoaded, expectedTitle) in cases {
+            var payload = status(providerID: "provider-a")
+            payload["network_state"] = networkState
+            payload["status"] = localState
+            payload["model_loaded"] = modelLoaded
+            var coordinator = payload["coordinator"] as! [String: Any]
+            coordinator["connected"] = connected
+            payload["coordinator"] = coordinator
+
+            let output = LocalStatusFormatter.format(payload, latestVersion: "1.5.0")
+
+            XCTAssertTrue(output.contains(expectedTitle), output)
+            XCTAssertTrue(output.contains("Advanced diagnostics: macprovider-cli status --advanced"), output)
+            for term in prohibited {
+                XCTAssertFalse(output.lowercased().contains(term), "\(term) leaked in:\n\(output)")
+            }
+            XCTAssertNil(output.range(of: policy.specificationIdentifierPattern, options: [.regularExpression, .caseInsensitive]), output)
+        }
+    }
+
+    func testDefaultBlockedStatusShowsOneSafeNextStep() {
+        var payload = status(providerID: "provider-a")
+        payload["network_state"] = "not_buyer_serving"
+
+        let output = LocalStatusFormatter.format(payload)
+
+        XCTAssertEqual(output.components(separatedBy: "Next step:").count - 1, 1, output)
+        XCTAssertTrue(output.contains("Open Malibu to review the recommended next step."), output)
+    }
+
+    func testRoutineCLIHelpUsesCanonicalPublicLanguage() {
+        let policy = try! publicLanguagePolicy()
+        let helpMessages = [
+            MacProviderCLI.helpMessage(),
+            ServeCommand.helpMessage(),
+            StatusCommand.helpMessage(),
+            ModelsSwitchCommand.helpMessage(),
+            AutotuneCommand.helpMessage(),
+            Spec028CanaryCommand.helpMessage(),
+            Spec028BenchmarkCommand.helpMessage(),
+        ]
+
+        for help in helpMessages {
+            XCTAssertNil(help.range(of: policy.specificationIdentifierPattern, options: [.regularExpression, .caseInsensitive]), help)
+            XCTAssertNil(help.range(of: #"\bAC-[0-9]+\b"#, options: [.regularExpression, .caseInsensitive]), help)
+            for term in policy.terms.map(\.internalTerm) {
+                XCTAssertFalse(help.lowercased().contains(term), "\(term) leaked in:\n\(help)")
+            }
+        }
+        XCTAssertTrue(MacProviderCLI.helpMessage().contains("hardware-check"))
+        XCTAssertTrue(MacProviderCLI.helpMessage().contains("performance-check"))
+        XCTAssertFalse(MacProviderCLI.helpMessage().contains("spec028"))
+        XCTAssertTrue(Spec028CanaryCommand.helpMessage().contains("supported-16gb"))
+        XCTAssertFalse(Spec028CanaryCommand.helpMessage().contains("ac10"))
+        for hiddenCommand in ["bootstrap-auth", "credentials", "decode-bench", "enroll", "lifecycle-state", "lifecycle-lease", "rotate-key"] {
+            XCTAssertFalse(MacProviderCLI.helpMessage().contains(hiddenCommand), MacProviderCLI.helpMessage())
+        }
+    }
+
+    func testHardwareCheckKeepsLegacyAutomationProfileAliases() {
+        XCTAssertEqual(Spec028CanaryCommand.HardwareProfile(argument: "ac10"), .supported16GB)
+        XCTAssertEqual(Spec028CanaryCommand.HardwareProfile(argument: "ac11"), .supported8GB)
+        XCTAssertEqual(Spec028CanaryCommand.HardwareProfile(argument: "supported-16gb"), .supported16GB)
+        XCTAssertEqual(Spec028CanaryCommand.HardwareProfile(argument: "supported-8gb"), .supported8GB)
+    }
+
+    func testLegacyHardwareCommandsRemainParseableButHidden() throws {
+        let canary = try MacProviderCLI.parseAsRoot([
+            "spec028-canary", "ac10", "--baseline-runs", "1", "--spec-runs", "1",
+        ])
+        let benchmark = try MacProviderCLI.parseAsRoot([
+            "spec028-benchmark", "--baseline-runs", "1", "--spec-runs", "1",
+        ])
+
+        XCTAssertTrue(canary is LegacySpec028CanaryCommand)
+        XCTAssertTrue(benchmark is LegacySpec028BenchmarkCommand)
+        XCTAssertFalse(MacProviderCLI.helpMessage().contains("spec028-canary"))
+        XCTAssertFalse(MacProviderCLI.helpMessage().contains("spec028-benchmark"))
+    }
+
+    private func publicLanguagePolicy() throws -> PublicLanguagePolicy {
+        let testFile = URL(fileURLWithPath: #filePath)
+        let policyURL = testFile
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .appendingPathComponent("public-language.json")
+        return try JSONDecoder().decode(PublicLanguagePolicy.self, from: Data(contentsOf: policyURL))
     }
 
     private func makeFixture(prefix: String) throws -> StatusFixture {
@@ -142,6 +252,24 @@ final class StatusCommandTests: XCTestCase {
                 "recommended_binary_version": "1.5.0",
             ],
         ]
+    }
+}
+
+private struct PublicLanguagePolicy: Decodable {
+    struct Term: Decodable {
+        let internalTerm: String
+
+        enum CodingKeys: String, CodingKey {
+            case internalTerm = "internal"
+        }
+    }
+
+    let terms: [Term]
+    let specificationIdentifierPattern: String
+
+    enum CodingKeys: String, CodingKey {
+        case terms
+        case specificationIdentifierPattern = "specification_identifier_pattern"
     }
 }
 

--- a/phase3-binary/app/Sources/Malibu/MalibuApp.swift
+++ b/phase3-binary/app/Sources/Malibu/MalibuApp.swift
@@ -143,15 +143,24 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         case .quit:
             NSApp.terminate(nil)
         case .showImportDialog:
-            let decision = presentMigrationDialog()
-            do {
-                let result = try await StartupState.applyMigrationDecision(decision)
-                if let backupPath = result.backupPath {
-                    presentStartFreshBackup(path: backupPath)
+            while true {
+                let decision = presentMigrationDialog()
+                if decision == .startFresh, !presentStartFreshConfirmation() {
+                    continue
                 }
-                await handleStartupRoute(result.route)
-            } catch {
-                presentMigrationError(error)
+                do {
+                    let result = try await StartupState.applyMigrationDecision(decision)
+                    if let backupPath = result.backupPath {
+                        presentStartFreshBackup(path: backupPath)
+                    }
+                    await handleStartupRoute(result.route)
+                    return
+                } catch {
+                    guard presentMigrationError(error) else {
+                        NSApp.terminate(nil)
+                        return
+                    }
+                }
             }
         }
     }
@@ -179,12 +188,24 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         alert.runModal()
     }
 
-    private func presentMigrationError(_ error: Error) {
+    private func presentStartFreshConfirmation() -> Bool {
+        let alert = NSAlert()
+        alert.messageText = StartFreshConfirmationCopy.title
+        alert.informativeText = StartFreshConfirmationCopy.message
+        alert.alertStyle = .warning
+        alert.addButton(withTitle: StartFreshConfirmationCopy.cancelButton)
+        alert.addButton(withTitle: StartFreshConfirmationCopy.startFreshButton)
+        return StartFreshConfirmationCopy.confirms(alert.runModal())
+    }
+
+    private func presentMigrationError(_ error: Error) -> Bool {
         let alert = NSAlert()
         alert.messageText = MigrationErrorCopy.title
         alert.informativeText = MigrationErrorCopy.message(error)
         alert.alertStyle = .warning
-        alert.runModal()
+        alert.addButton(withTitle: MigrationErrorCopy.cancelButton)
+        alert.addButton(withTitle: MigrationErrorCopy.retryButton)
+        return alert.runModal() == .alertSecondButtonReturn
     }
 
     private func presentDashboard() {
@@ -304,10 +325,46 @@ enum StartFreshBackupCopy {
     }
 }
 
+enum StartFreshConfirmationCopy {
+    static let title = "Create a new provider instead?"
+    static let message = """
+    This moves the existing setup to a reversible backup before Malibu creates a new provider.
+
+    The new provider will have a different identity and will not include the previous payment history, saved access, or local model setup unless you restore the backup.
+    """
+    static let cancelButton = "Keep Existing Provider"
+    static let startFreshButton = "Create New Provider"
+
+    static func confirms(_ response: NSApplication.ModalResponse) -> Bool {
+        response == .alertSecondButtonReturn
+    }
+}
+
 enum MigrationErrorCopy {
     static let title = "Could not use existing provider"
+    static let cancelButton = "Cancel"
+    static let retryButton = "Try Again"
 
-    static func message(_: Error) -> String {
-        "Malibu could not use the existing provider. Your current setup was not changed. Try again, or choose Start Fresh only if you want Malibu to create a new provider."
+    static func message(_ error: Error) -> String {
+        let reason: String
+        if let handoffError = error as? ProviderCredentialHandoffRunner.Error {
+            reason = publicHandoffReason(handoffError)
+        } else {
+            reason = AgentSnapshotPresenter.publicErrorDetail(error.localizedDescription)
+                ?? "Technical details are available in Advanced diagnostics."
+        }
+        return "\(reason)\n\nYour current setup was not changed."
+    }
+
+    private static func publicHandoffReason(_ error: ProviderCredentialHandoffRunner.Error) -> String {
+        switch error {
+        case .cliNotFound, .invalidCLI, .importFailed, .freshProcessVerificationFailed,
+             .statusFailed, .repairFailed, .admissionRecoveryFailed, .timedOut:
+            return error.localizedDescription
+        case .invalidOutput:
+            return "The installed provider returned an incompatible import result. Update the provider and retry."
+        case .launchFailed:
+            return "Could not start provider import. Update the provider and retry."
+        }
     }
 }

--- a/phase3-binary/app/Tests/MalibuTests/StartupRouteTests.swift
+++ b/phase3-binary/app/Tests/MalibuTests/StartupRouteTests.swift
@@ -138,6 +138,29 @@ final class StartupRouteTests: XCTestCase {
         }
     }
 
+    func testStartFreshRequiresASeparateDestructiveConfirmation() {
+        XCTAssertEqual(StartFreshConfirmationCopy.cancelButton, "Keep Existing Provider")
+        XCTAssertEqual(StartFreshConfirmationCopy.startFreshButton, "Create New Provider")
+        XCTAssertFalse(StartFreshConfirmationCopy.confirms(.alertFirstButtonReturn))
+        XCTAssertTrue(StartFreshConfirmationCopy.confirms(.alertSecondButtonReturn))
+        XCTAssertFalse(StartFreshConfirmationCopy.confirms(.abort))
+
+        let copy = [
+            StartFreshConfirmationCopy.title,
+            StartFreshConfirmationCopy.message,
+            StartFreshConfirmationCopy.cancelButton,
+            StartFreshConfirmationCopy.startFreshButton,
+        ].joined(separator: "\n").lowercased()
+        XCTAssertTrue(copy.contains("reversible backup"), copy)
+        XCTAssertTrue(copy.contains("different identity"), copy)
+        XCTAssertTrue(copy.contains("payment history"), copy)
+        XCTAssertTrue(copy.contains("saved access"), copy)
+        XCTAssertTrue(copy.contains("local model setup"), copy)
+        for term in prohibitedPublicTerms {
+            XCTAssertFalse(copy.contains(term), "\(term) leaked in:\n\(copy)")
+        }
+    }
+
     func testMigrationErrorCopyUsesOrdinaryLanguage() {
         let error = NSError(
             domain: "coordinator.admission",
@@ -150,11 +173,70 @@ final class StartupRouteTests: XCTestCase {
         ].joined(separator: "\n").lowercased()
 
         XCTAssertTrue(copy.contains("current setup was not changed"))
-        XCTAssertTrue(copy.contains("create a new provider"))
+        XCTAssertTrue(copy.contains("advanced diagnostics"))
+        XCTAssertEqual(MigrationErrorCopy.cancelButton, "Cancel")
+        XCTAssertEqual(MigrationErrorCopy.retryButton, "Try Again")
         XCTAssertFalse(copy.contains("coordinator"), copy)
         XCTAssertFalse(copy.contains("/tmp"), copy)
         for term in prohibitedPublicTerms {
             XCTAssertFalse(copy.contains(term), "\(term) leaked in:\n\(copy)")
+        }
+    }
+
+    func testMigrationErrorCopyShowsASanitizedActualReason() {
+        let error = ProviderCredentialHandoffRunner.Error.importFailed(7)
+
+        let copy = MigrationErrorCopy.message(error)
+
+        XCTAssertTrue(copy.contains("could not prepare the saved access"), copy)
+        XCTAssertTrue(copy.contains("exit 7"), copy)
+        XCTAssertTrue(copy.contains("original setup was preserved"), copy)
+        XCTAssertTrue(copy.contains("current setup was not changed"), copy)
+    }
+
+    func testMigrationErrorCopyRedactsEveryUnboundedHandoffReason() {
+        let secret = "provider_token=secret /Users/name/config.yaml?token=secret"
+        let cases: [ProviderCredentialHandoffRunner.Error] = [
+            .invalidCLI(secret),
+            .invalidOutput(secret),
+            .launchFailed(secret),
+        ]
+
+        for error in cases {
+            let copy = MigrationErrorCopy.message(error).lowercased()
+            XCTAssertFalse(copy.contains("secret"), copy)
+            XCTAssertFalse(copy.contains("/users/"), copy)
+            XCTAssertFalse(copy.contains("provider_token"), copy)
+            XCTAssertTrue(copy.contains("retry"), copy)
+            XCTAssertTrue(copy.contains("current setup was not changed"), copy)
+        }
+    }
+
+    func testCanonicalPublicLanguagePolicyContainsTheMalibuCoreTerms() throws {
+        let testFile = URL(fileURLWithPath: #filePath)
+        let policyURL = testFile
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .appendingPathComponent("public-language.json")
+        let object = try XCTUnwrap(
+            try JSONSerialization.jsonObject(with: Data(contentsOf: policyURL)) as? [String: Any]
+        )
+        let terms = try XCTUnwrap(object["terms"] as? [[String: String]])
+        let internalTerms = Set(terms.compactMap { $0["internal"] })
+
+        for term in [
+            "compatibility set",
+            "admission identity",
+            "watchdog",
+            "buyer-serving",
+            "spec-023 probe",
+            "coordinator admission",
+            "credential custody",
+            "migration token",
+        ] {
+            XCTAssertTrue(internalTerms.contains(term), "missing canonical mapping for \(term)")
         }
     }
 

--- a/phase3-binary/public-language.json
+++ b/phase3-binary/public-language.json
@@ -1,0 +1,39 @@
+{
+  "version": 1,
+  "terms": [
+    {
+      "internal": "compatibility set",
+      "public": "provider software"
+    },
+    {
+      "internal": "admission identity",
+      "public": "network verification"
+    },
+    {
+      "internal": "watchdog",
+      "public": "provider health monitor"
+    },
+    {
+      "internal": "buyer-serving",
+      "public": "available to customers"
+    },
+    {
+      "internal": "spec-023 probe",
+      "public": "Model readiness check"
+    },
+    {
+      "internal": "coordinator admission",
+      "public": "network approval"
+    },
+    {
+      "internal": "credential custody",
+      "public": "saved provider access"
+    },
+    {
+      "internal": "migration token",
+      "public": "saved provider access"
+    }
+  ],
+  "specification_identifier_pattern": "spec-?[0-9]+",
+  "advanced_boundary": "Internal protocol, storage, and lifecycle values may appear only in explicitly labeled Advanced diagnostics or machine-readable JSON."
+}


### PR DESCRIPTION
## Outcome

Completes the remaining source work for #617 across Malibu and the provider CLI:

- makes routine `macprovider-cli status` use the same public lifecycle states as Malibu, with exact fields available only through `status --advanced`;
- removes specification and internal recovery terminology from routine help, and renames the visible model checks to `hardware-check` and `performance-check` while retaining hidden legacy command and profile compatibility for automation;
- hides operator/internal commands from root help without removing their machine interfaces;
- defines one reviewed public terminology map consumed by regression tests;
- makes existing-provider import primary and retryable, adds a separate safe-default confirmation before Fresh Start, preserves the reversible backup, and shows a sanitized real failure reason.

This PR does not change coordinator, referral/X, catalog, model, updater, or production configuration behavior.

Closes the remaining source slice of #617. The issue stays open until the exact signed candidate passes import, relaunch, provider restart, logout/login, reboot, and buyer-serving verification.

SPEC-GOVERNANCE-DECLARATION-BEGIN
{
  "schema_version": "spec-pr-governance-v1",
  "behavior_change": "yes",
  "contract_change": "none",
  "issue": "https://github.com/Augustas11/macprovider/issues/617",
  "specs": ["SPEC-034"],
  "requirements": ["SPEC-034-R001"],
  "authority_domains": ["native-app-lifecycle", "browserless-onboarding", "provider-onboarding-identity", "provider-console"],
  "arbitration": ["CODE_BUG"],
  "tests": [
    "swift test --filter StatusCommandTests",
    "swift build -c release",
    "xcodebuild -project Malibu.xcodeproj -scheme Malibu -destination 'platform=macOS' test",
    "xcodebuild -project Malibu.xcodeproj -scheme Malibu -configuration Release -destination 'platform=macOS' analyze"
  ],
  "journeys": ["pending exact signed #617 physical import-relaunch-restart-login-reboot-buyer-serving gate"]
}
SPEC-GOVERNANCE-DECLARATION-END

## Validation

- Malibu full suite: 236 passed, 0 failed.
- CLI public-language suite: 12 passed, 0 failed.
- Swift release build: passed.
- Malibu Release analyzer: passed.
- Full CLI suite: 1,498 passed and 8 skipped; five assertions across two unrelated coordinator timing tests failed in the combined local run. One passed alone and the other timed out alone; no changed file touches those tests or their implementation, so exact-head CI is the merge authority.
- Bounded code and security reviews: 0 Critical, 0 High, 0 Medium after fixes.
- `git diff --check`: passed.

## Physical gate

Not claimed by this source PR. After merge, the independently signed/notarized Malibu candidate must be installed from its packaged bytes and pass the existing-provider import journey without changing provider identity, config, model, credential, process count, or buyer-serving behavior.
