### PR TITLE
Record Entry 172 activation evidence

### DIFF
--- a/ops/exceptions/production-exceptions.json
+++ b/ops/exceptions/production-exceptions.json
@@ -1,8 +1,8 @@
 {
   "$schema": "./production-exceptions.schema.json",
   "schema_version": "macprovider-production-exceptions-v1",
-  "updated_at": "2026-07-21T10:35:43Z",
-  "updated_by": "codex-lane-c",
+  "updated_at": "2026-07-21T12:49:12Z",
+  "updated_by": "codex-lane-d",
   "environment": "pearl-production",
   "exceptions": [
     {
@@ -203,7 +203,7 @@
       "issue": "https://github.com/Augustas11/macprovider/issues/615",
       "created_at": "2026-07-19T00:00:00Z",
       "expires_at": "2026-07-26T23:59:59Z",
-      "scope": "Entry 172 private-prebeta referral campaign only; no broad stable release, no #613 closure, no fresh-provider redemption evidence claim.",
+      "scope": "Entry 172 private-prebeta referral campaign only; flags may remain live under the Air exception, with no broad stable release, no #613 closure, and no first fresh referred-provider redemption evidence claim.",
       "removal_condition": "Expires at deadline, terminal success/failure of the first fresh referred-provider journey, or any earlier controlled-sequence failure; keeping/re-enabling flags afterward requires complete #613 evidence or a new reviewed decision.",
       "rollback_command": "Restore the prior recorded Pearl referral flag values for `require_for_registration`, `enable_public_validation`, `enable_join_links`, and `enable_social_invite_bonus`; do not print HMAC secrets or referral codes.",
       "post_removal_validation": "Pearl flags match the recorded prior/off values, Vercel `/j` remains fragment-only/static, coordinator validation rejects disallowed origins, and no server logs contain invite code or challenge material.",
@@ -212,6 +212,7 @@
         "beta/DECISION_CRITERIA.md Entry 172",
         "specs/SPEC-034-referral-gated-prebeta.md#8-activation-rollback-and-acceptance",
         "ops/runbooks/entry-172-referral-activation.md",
+        "ops/runbooks/entry-172-activation-evidence-20260721.md",
         "https://github.com/Augustas11/macprovider/issues/615"
       ]
     }
@@ -263,8 +264,8 @@
       "id": "oq-entry172-live-flags",
       "question": "If Entry 172 activation has started, what exact prior/live referral flag values and campaign metadata were recorded without exposing HMAC secrets or referral codes?",
       "owner": "referral activation/security",
-      "status": "pending",
-      "evidence_target": "Update `exc-entry172-air-referral-activation.evidence` and removal status before expiry."
+      "status": "answered",
+      "evidence_target": "`ops/runbooks/entry-172-activation-evidence-20260721.md` records redacted PASS LIVE evidence; keep `exc-entry172-air-referral-activation` active until expiry, terminal fresh journey result, or earlier controlled-sequence failure."
     }
   ]
 }

--- a/ops/runbooks/entry-172-activation-evidence-20260721.md
+++ b/ops/runbooks/entry-172-activation-evidence-20260721.md
@@ -1,0 +1,79 @@
+# Entry 172 Activation Evidence - 2026-07-21
+
+Redacted checked-in summary of the controlled Entry 172 activation evidence.
+Codes, challenges, HMAC material, X bearer tokens, and provider bearers are
+intentionally omitted.
+
+## Result
+
+PASS LIVE. The reversible Entry 172 referral flags were left live after the
+controlled activation sequence completed.
+
+Final four Pearl referral flags:
+
+- `require_for_registration=true`
+- `enable_public_validation=true`
+- `enable_join_links=true`
+- `enable_social_invite_bonus=true`
+
+Campaign metadata:
+
+- Campaign: `prebeta_20260719`
+- Key id: `k1`
+- HMAC value: redacted
+- X bearer material: redacted
+- Seed: `launch_entry172_retry`
+- Seed operation id: `3bc003a4-6e0a-42e3-90d3-816ccd41a163`
+- Referral code: redacted and not committed
+
+## Executed Baseline
+
+- Public release tag: `v1.8.56`
+- CLI: `1.8.56`
+- Malibu asset: `Malibu-v1.8.56.dmg`
+- Malibu asset SHA-256:
+  `b5889de597363b2ecb1df823da93a5ecc555e91d75f8e5eb7208917071f1867b`
+- CLI darwin-arm64 SHA-256:
+  `55b642c3a600fac8a2dc170971c6c2f990d47dc9075e05cad001b9d596c2ffc8`
+- Vercel deploy: `dpl_9SPBC3yygAV9oWvaviAbgmsrB1TG`
+- Live join bundle: `/assets/join-D6XXjCu1.js`
+
+## Proof Gates
+
+- D1 hostile-origin CORS: PASS, redacted.
+- D2 allowed-origin validation: PASS, redacted.
+- D3 fragment-free edge path and log check: PASS, redacted.
+- D4 immutable live join download: PASS. The live `/j` target resolved to the
+  GitHub `v1.8.56` `Malibu-v1.8.56.dmg` asset and downloaded bytes matched the
+  SHA-256 above.
+- D5 Copy -> Download -> Paste journey: PASS by operator manual/headed-browser
+  confirmation under the resume #3 policy. Server-side code/challenge material
+  remained redacted and was not pasted into this file.
+- F X exactly-once reward: PASS, redacted. Evidence showed exactly one social
+  grant row for the provider/campaign and replay/no-op audit behavior for
+  response-loss recovery; X bearer and provider bearer material are omitted.
+
+## Boundaries
+
+- #613 NOT closed by Entry 172; Air exception only.
+- The first fresh referred-provider journey is still required.
+- The exception remains active until the earliest of
+  `2026-07-26T23:59:59Z`, terminal success/failure of the first fresh
+  referred-provider journey, or any earlier controlled-sequence failure.
+- #658 was not started or modified.
+- This evidence file records docs/register evidence only; it does not implement
+  #615 enforcement.
+
+## Backup Path Names
+
+Path names only are recorded here; backup contents and secrets are not included.
+
+- `/etc/macprovider/coordinator.pearl-overlays.yaml.entry172-failed-20260721T113322Z`
+- `/var/lib/macprovider/coordinator.db.entry172-pre-seed-replace-20260721T114506Z`
+- `/etc/macprovider/coordinator.pearl-overlays.yaml.entry172-C-pre-enable-20260721T114550Z`
+- `/etc/macprovider/coordinator.pearl-overlays.yaml.entry172-D-failed-20260721T115151Z`
+- `/etc/macprovider/coordinator.pearl-overlays.yaml.entry172-phase1-remove-download-url-20260721T120744Z`
+- `/etc/macprovider/coordinator.pearl-overlays.yaml.entry172-phase2-C-pre-enable-20260721T121019Z`
+- `/etc/macprovider/coordinator.pearl-overlays.yaml.entry172-D5-failed-20260721T121559Z`
+- `/etc/macprovider/coordinator.pearl-overlays.yaml.entry172-resume3-C-pre-enable-20260721T122613Z`
+- `/etc/macprovider/coordinator.pearl-overlays.yaml.entry172-resume3-E-pre-social-20260721T123103Z`

--- a/ops/runbooks/entry-172-referral-activation.md
+++ b/ops/runbooks/entry-172-referral-activation.md
@@ -12,15 +12,18 @@ Register row: [`exc-entry172-air-referral-activation`](../exceptions/production-
 
 Expiry: this exception expires at `2026-07-26T23:59:59Z`, on terminal success or failure of the first fresh referred-provider journey, or on any earlier controlled-sequence failure, whichever occurs first.
 
+Last successful activation evidence: [`entry-172-activation-evidence-20260721.md`](./entry-172-activation-evidence-20260721.md) records the redacted PASS LIVE result for the v1.8.56 execution baseline. Future re-runs must still re-confirm current release tags, asset hashes, deploy IDs, and live flag state before any operation.
+
 Fail closed if any checklist item below is unmet.
 
 ## 1. Preconditions
 
-- [ ] Base includes merge `87bc3fa2` / #660 or newer. #660 is a prerequisite note only: append-only release discovery transport is merged, but #658 remains open for the trust-preserving bridge and physical journey needed for continuous discovery.
+- [ ] Base includes merge `f91b7b6c` / #663 or newer. #663 is the #615 production exception register baseline; #658 remains open for the trust-preserving bridge and physical journey needed for continuous discovery.
 - [ ] Exact fragment-aware signed clients are public and verified before any flag change.
-  - Current `origin/main` evidence at `87bc3fa2`: CLI `CoordinatorClient.binaryVersion = "1.8.55"` and Malibu `MARKETING_VERSION = "1.8.44"`, build `44`.
-  - Current GitHub release evidence checked for this runbook: `macprovider-cli v1.8.55` published 2026-07-20T21:18:49Z and `Malibu 1.8.44` published 2026-07-21T07:41:13Z.
-  - Operator must re-confirm latest releases at execution time and record exact tags, asset names, SHA-256 values, notarization/signature evidence, and fixed Vercel download asset.
+  - Last executed public release tag: `v1.8.56`.
+  - Last executed CLI baseline: `1.8.56`; CLI darwin-arm64 SHA-256 `55b642c3a600fac8a2dc170971c6c2f990d47dc9075e05cad001b9d596c2ffc8`.
+  - Last executed Malibu asset: `Malibu-v1.8.56.dmg`; SHA-256 `b5889de597363b2ecb1df823da93a5ecc555e91d75f8e5eb7208917071f1867b`.
+  - Operator must re-confirm latest releases at future execution time and record exact tags, asset names, SHA-256 values, notarization/signature evidence, deploy IDs, and fixed Vercel download asset.
 - [ ] Coordinator route and nginx route are present: `location = /v1/referrals/validate` proxies to `127.0.0.1:8443`; historical `/j/` remains an access-log-off, `Cache-Control: no-store`, HTTP 404 tombstone.
 - [ ] Vercel `malibu.tech/j` is the only public download authority for the join landing page; invite material uses fragment-only URLs:
   - `https://malibu.tech/j#/<code>`
@@ -225,7 +228,7 @@ curl -I -sS '<FIXED_PUBLIC_MALIBU_DOWNLOAD_URL>'
 
 Expected: landing page is reachable; fixed download URL resolves to the reviewed signed/notarized Malibu asset.
 
-Copy -> Download -> Paste path:
+Copy -> Download -> Paste path (headed/manual proof, not headless CDP download-event proof):
 
 ```text
 1. Copy exactly: https://malibu.tech/j#/<REDACTED_TEST_CODE>


### PR DESCRIPTION
## Summary

- Docs/register only: adds redacted Entry 172 activation evidence, updates the active exception register row, and refreshes the Entry 172 runbook pins to the executed v1.8.56 baseline.
- Entry 172 PASS LIVE is evidenced with flags left live under the Air exception.
- #615 remains OPEN; enforcement is not implemented here.
- #613 is not closed by this PR; the first fresh referred-provider journey is still outstanding.

## Validation

- `python3` register schema validation with `jsonschema` in a temporary venv: PASS, duplicate exception IDs none.
- Dependency-free register validator from the runbook: PASS.
- `git diff --check`: PASS.
- Stale pin search for `1.8.55`, `1.8.44`, `87bc3fa2`, and "not yet executed": no matches in touched Entry 172 docs/register files.

## Out of Scope

- No Pearl SSH writes or live flag/overlay/DB/nginx/Vercel mutations.
- No Air5 work.
- No release cuts, binaryVersion bumps, MARKETING_VERSION bumps, Malibu/CLI code changes, #658 bridge work, or /host copy changes.

SPEC-GOVERNANCE-DECLARATION-BEGIN
{
  "schema_version": "spec-pr-governance-v1",
  "behavior_change": "yes",
  "contract_change": "none",
  "issue": "https://github.com/Augustas11/macprovider/issues/615",
  "specs": ["SPEC-034"],
  "requirements": ["SPEC-034-R001"],
  "authority_domains": ["referral-advocacy-policy"],
  "arbitration": ["UNKNOWN"],
  "tests": [
    "production exception register schema validation",
    "dependency-free production exception register validation",
    "git diff --check"
  ],
  "journeys": ["not-required"]
}
SPEC-GOVERNANCE-DECLARATION-END
