### PR TITLE
test(e2e): re-land P2 cold/warm TTFT matrix harness (#526)

### DIFF
--- a/test/e2e/coldwarm-ttft/CALIBRATION.md
+++ b/test/e2e/coldwarm-ttft/CALIBRATION.md
@@ -1,0 +1,151 @@
+# Cold/warm TTFT — calibration methodology & the three P2 deliverables
+
+This document defines how the accumulated matrix (`--build-matrix`) becomes the
+three P2 outputs. It is the **method**; the actual numbers land once the store has
+enough samples (`sample_n >= COLDWARM_MIN_SAMPLES`, default 30, per cell). The
+harness computes the recommendations mechanically (`recommendations` / `slo` in
+the matrix JSON) so the calibration PR is a transcription, not a judgement call.
+
+## The regime rule (non-negotiable)
+
+- Calibrate `max_ttft_ms` against the **`canary_nonstream` warm** cell **only**.
+  That is the exact regime the coordinator gate is evaluated against
+  (`canary_probe.go` → `canaryMetricsFromTiming`, non-streaming → TTFT = full
+  round-trip). **Never** calibrate the gate off `buyer_stream` TTFT — doing that
+  is precisely what caused the 2026-07-09 ban-storm.
+- Use the **`buyer_stream` cold** cell for the buyer-UX SLO — that is the number a
+  real buyer feels on a cold first request.
+
+## Deliverable 1 — calibrated `max_ttft_ms` per model class
+
+**Formula (implemented in `recommendGates`):**
+
+```
+recommended_max_ttft_ms = ceil( canary_nonstream.warm.p99 × COLDWARM_HEADROOM / 500 ) × 500
+```
+
+with `COLDWARM_HEADROOM = 1.5` by default, rounded up to the nearest 500 ms.
+
+**Gate on sufficiency:** a recommendation is only marked `enforce_ready: true`
+when the warm `canary_nonstream` cell has `sample_n >= COLDWARM_MIN_SAMPLES`.
+Below that the harness explicitly says *keep `max_ttft_ms >= 7000` and
+`canary_latency_enforcement: observe`* — the current safe state.
+
+**Return-to-enforce decision, per class.** A class may flip to `enforce` only if
+**all** hold:
+1. `enforce_ready: true` (enough warm samples).
+2. The warm `canary_nonstream` p99 is **stable** across ≥ several days of the
+   store (compare `first_seen` vs `last_seen` windows; no widening tail).
+3. `canary_cold_start_grace_s` is sized to cover the worst cold load (Deliverable
+   2's grace number) — otherwise a legitimate cold (re)connect trips the gate
+   inside the grace window.
+
+If any fails, the class stays in `observe`. **This is per-class**: the 30B may
+stay observe (huge cold tail) while a small model with a tight warm envelope
+returns to enforce.
+
+**The PR this produces (audit-gated).** Editing `pool.model_class_challenges` /
+`canary_latency_enforcement` is a security sanction gate (money-path-adjacent).
+The change ships as a PR to:
+- `phase4-coordinator/coordinator.opoi-v0-staging.yaml` (staging overlay), and
+- the Pearl runtime overlay `coordinator.pearl-overlays.yaml` (the live source of
+  truth — currently `max_ttft_ms: 7000, min_sustained_tps: 20`, grace 300 s,
+  enforcement unset → `observe`),
+
+through a **three-lane codex audit** (code / security / architect via
+`omc ask codex`) to **0 CRITICAL / 0 HIGH / 0 MEDIUM** before merge, authored as
+Augustas11. **Do not** hand-edit gate values from intuition — transcribe the
+`enforce_ready` recommendation.
+
+> **`min_sustained_tps` caveat.** The non-streaming `sustained_tps` metric is
+> structurally unreliable (live: 17k–33k tok/s for a warm 30B, because it's
+> `completion_tokens / total_round_trip` on a 16-token response). The harness
+> records it but **does not** recommend a `min_sustained_tps` value. Leave it at
+> the current advisory floor (20) and rely on the buyer-side decode-TPS signal
+> from **P1** for real throughput regression detection.
+
+## Deliverable 2 — idle-prewarm policy (measured)
+
+The prod mac provider CLI runs with `--no-idle-prewarm`, so every (re)connect
+cold-loads the 30B (~30–60 s of buyer unavailability). Prewarm telemetry exists
+(commit `ed2f782`).
+
+**The measured case (from the matrix):**
+- `buyer_cold_minus_warm_p50_ms` = `buyer_stream.cold.p50 − buyer_stream.warm.p50`
+  — the latency a real first request pays for a cold load. This is the cost
+  idle-prewarm would hide.
+- `canary_nonstream.cold.p99` and `.post_reboot.p99` — the worst cold load, which
+  also sets the `canary_cold_start_grace_s` recommendation
+  (`recommended_cold_start_grace_s = ceil(worst_cold_s × 1.25 / 10) × 10`).
+
+**Recommendation framework** (fill from the accumulated deltas):
+- **Enable idle-prewarm** if the cold→warm buyer delta is large (order tens of
+  seconds — as observed) **and** connect/idle-evict churn is frequent enough that
+  buyers routinely hit cold. The delta is the buyer-unavailability window prewarm
+  removes.
+- **Idle threshold:** set the prewarm trigger below the model-unload threshold so
+  the model is re-warmed before the next buyer arrives, but high enough to avoid
+  needless reloads on a busy provider. Derive from the observed inter-request gap
+  distribution on the lab provider.
+- **Battery guard:** on laptop providers, gate idle-prewarm on AC power (or a
+  battery-level floor) so prewarm doesn't drain an unplugged Mac. Prewarm holding
+  a 30B resident is a real power/thermal cost — off-AC should skip it.
+
+## Deliverable 3 — buyer-UX cold-start SLO
+
+From `buyer_stream.cold`:
+- **`cold_start_ttft_p99_ms`** — the worst-case first-request TTFT a buyer sees.
+  This is the stated cold-start ceiling the product can publish and monitor.
+- Emitted as `macprovider_coldwarm_cold_start_ttft_p99_ms{model}`; alert when a
+  live cold-start (correlate P1's `macprovider_canary_ttft_ms` spikes on
+  provider reconnect) exceeds it.
+- `sufficient_samples` flags whether the p99 rests on ≥ `COLDWARM_MIN_SAMPLES`
+  cold cycles; don't publish an SLO off a thin sample.
+
+## Findings from carrying against prod (2026-07-10)
+
+First warm accumulation against live prod (`api.streamvc.live`, provider `mac`,
+20 samples/regime) surfaced three things worth recording:
+
+1. **The "warm 30B ≈ 6s" assumption baked into the gate config is wrong.** The
+   overlay comment justifies `max_ttft_ms >= 7000` with "a warm 30B measures
+   ~6s". Measured warm envelope is far tighter — `canary_nonstream` **p50 ≈ 1.6s,
+   p95 ≈ 2.3s, p99 ≈ 2.5s**; `buyer_stream` p50 ≈ 1.4s, p99 ≈ 2.6s. The 6-7s and
+   the 65-108s breach tail (observe-mode logs) are **cold-load / concurrent-load**
+   events, not warm steady state. Consequence: the warm calibration lands near
+   `p99 2.5s × 1.5 ≈ 4000ms` (close to autotune's streaming `max_4k_ttft_ms:
+   3500-4000`); the 2026-07-09 disaster was **not** that 3500 was too tight for
+   warm — it was that nothing sized the **cold-start grace** for the tail. The
+   return-to-enforce work is grace sizing, not gate loosening.
+2. **The two regimes converge when warm** (buyer 1444ms vs canary 1641ms p50) and
+   diverge only cold — the 125ms…7000ms canary swing the spec warns about is a
+   cold/relay-timing phenomenon. Both regimes must still be measured, because the
+   divergence is exactly in the cold tail the gate must tolerate.
+3. **`min_sustained_tps=20` is effectively a dead gate.** The non-streaming TPS
+   metric is garbage in *both* directions: the live coordinator reads 17k-33k
+   tok/s (its decode window collapses to ~1ms once it captures a relay
+   firstToken), while a naive buyer-side non-streaming read is ~0.7 tok/s (whole
+   round-trip as the window, on a 1-token answer). It can never detect a
+   throughput regression. Leave it advisory; use P1's buyer-side streaming decode
+   TPS (~40 tok/s warm here) for real throughput signal.
+
+## Current runtime baseline (Pearl, verified 2026-07-10)
+
+- Live gate (`coordinator.pearl-overlays.yaml`): 30B `max_ttft_ms: 7000`,
+  `min_sustained_tps: 20`; `canary_cold_start_grace_s: 300`; `canary_interval_s:
+  45`; `canary_latency_enforcement` **unset → observe** (safe default).
+- Observe-mode breach tail (24h, non-streaming regime): p50 ≈ 7.1 s, **p95 ≈ 65
+  s, p99 ≈ 93 s, max ≈ 108 s**; `sustained_tps` reads 17k–33k (garbage). The warm
+  *passing* envelope is not in the logs — the harness supplies it.
+- Autotune per-model bench gates to reconcile against (streaming-side targets,
+  `AutotuneRecommend.swift`): 30B `max_4k_ttft_ms: 3500`, gpt-oss-20b `2500`,
+  qwen3-32b `4000`. These are **streaming** TTFT ceilings — related to the
+  `buyer_stream` regime, **not** the `canary_nonstream` gate. Keep the two
+  regimes' numbers distinct.
+
+## Do-not-block rule
+
+Per the P2 operating model: **do not block on merging the harness PR while it is
+still accumulating data.** The harness (this directory) merges first as test-only
+tooling; the calibration PR (Deliverable 1) follows once cells reach
+`enforce_ready`, and it is the audit-gated one.

--- a/test/e2e/coldwarm-ttft/README.md
+++ b/test/e2e/coldwarm-ttft/README.md
@@ -1,0 +1,178 @@
+# Cold/warm TTFT matrix harness (P2)
+
+**P2** from the 2026-07-09 e2e-testing review. P1 (`test/e2e/canary-buyer/`)
+measures steady-state serving quality from the buyer vantage. P2 attacks the one
+thing P1 doesn't: **cold-start behavior and the latency gates that depend on it.**
+
+## Why this exists (the forcing function)
+
+On 2026-07-09 a cold 30B model load produced a **30,827 ms** canary TTFT in prod.
+The W3 canary `max_ttft_ms` gate had been hand-guessed (3500 → padded to 7000)
+with **no measured basis**. Tightening it to 3500 — calibrated off the *streaming
+buyer* TTFT (~1200 ms warm) — banned a healthy provider three-in-a-row and 503'd
+buyers. The fix shipped was to make the latency gates **observe-only**
+(`pool.canary_latency_enforcement: observe`, PR #513) — a safety valve, not a
+calibration. This harness produces the *real numbers* that let those gates be
+tightened back to `enforce` safely, per model class.
+
+### The critical subtlety (this is what bit us)
+
+The pool canary sends `stream:false` (**non-streaming**). Its measured "TTFT" is
+the **full non-streaming round-trip** and swings wildly. The **buyer path
+streams** and shows the true first-token latency (~1200 ms warm). **These two
+numbers are NOT interchangeable.** The `max_ttft_ms` gate is evaluated against
+the CANARY's non-streaming regime — so it must be calibrated against *that*.
+
+This harness measures **both regimes side by side**, cold and warm, per model
+class:
+
+| Regime | `stream` | What "TTFT" means | Whose number it is |
+|--------|----------|-------------------|--------------------|
+| `buyer_stream` | `true` | time to first **content token** | what a real buyer feels; the SLO |
+| `canary_nonstream` | `false` | **full round-trip** (mirrors coordinator `canaryMetricsFromTiming`: non-streaming → `firstTokenAt` is zero → `ttft = completedAt - start`) | what the `max_ttft_ms` gate sees; the calibration input |
+
+Live confirmation (Pearl, 2026-07-10, observe-mode breach logs over 24h): the
+`canary_nonstream` regime breaches even the padded 7000 ms gate on a ~5% tail
+with **p95 ≈ 65 s, p99 ≈ 93 s, max ≈ 108 s**, while reporting absurd
+`sustained_tps` (17k–33k tok/s). The coordinator logs **only breaches**, so the
+warm passing envelope (the `< 7000 ms` probes) is invisible from logs — **this
+harness is the instrument that measures it.**
+
+## States (why cold is one-sample-per-cycle)
+
+| State | Meaning | Samples per cycle |
+|-------|---------|-------------------|
+| `warm` | provider already loaded, steady state | N (batch) |
+| `cold` | the **first** request after the model was unloaded / idle-evicted | **1** (the first request warms the model) |
+| `post_reboot` | the first request after a full provider process restart | **1** |
+
+Because a cold cycle yields exactly **one** genuinely-cold sample, cold-start
+percentiles must be **accumulated over many real cold cycles**. The probe appends
+each sample to an append-only NDJSON store; `--build-matrix` aggregates the store
+into percentiles. Regimes are **balanced automatically** across cold cycles
+(`pickBalancedRegime`) so both fill up, or pin one with `--regime`.
+
+## Safety — read before inducing cold
+
+- **Cold-cycle a LAB provider you own, NEVER the prod `mac` provider.** Churning
+  prod caused an **hour-long outage on 2026-07-09**. `cold-cycle.sh` refuses a
+  prod `COLDWARM_BASE` unless `COLD_CYCLE_ALLOW_PROD=1` (don't).
+- **Do NOT stack coordinator restarts** — rapid coordinator restarts wedge the
+  provider CLI's v2 proof-auth (`auth_request proof rejected: type`) and empty
+  the pool (issue #519). This harness **never restarts the coordinator**; the
+  cold-cycle helper restarts the *provider CLI* at most once per cycle.
+- Warm accumulation against **prod read-only is fine** (it's just buyer traffic).
+  Only the cold *induction* is lab-only.
+
+## Run it by hand
+
+```bash
+export MACPROVIDER_BUYER_TOKEN=mp_...        # or MALIBU_API_KEY; never echoed
+cd test/e2e/coldwarm-ttft
+
+# 1. warm baseline — N samples per regime, appended to the store
+node coldwarm-probe.mjs --scenario warm --model qwen3-coder-30b-a3b-instruct \
+  --samples 20 --store ./matrix.ndjson
+
+# 2. one cold sample (induce cold on a LAB provider first — idle/restart/reboot)
+node coldwarm-probe.mjs --scenario cold --state cold \
+  --model qwen3-coder-30b-a3b-instruct --store ./matrix.ndjson
+
+# 3. after a provider process restart
+node coldwarm-probe.mjs --scenario cold --state post_reboot \
+  --model qwen3-coder-30b-a3b-instruct --store ./matrix.ndjson
+
+# 4. aggregate → matrix + advisory calibration + SLO (no token needed)
+node coldwarm-probe.mjs --build-matrix --store ./matrix.ndjson \
+  --metrics-out /tmp/coldwarm.prom --json-out ./artifacts
+```
+
+### Operator cold-cycle helper
+
+`cold-cycle.sh` induces cold out of band then captures the sample:
+
+```bash
+# idle lever — wait past the model-unload threshold (no restart)
+LAB_MODEL=qwen3-coder-30b-a3b-instruct COLDWARM_BASE=https://<lab-gateway> \
+  ./cold-cycle.sh --lever idle --idle-min 12 --state cold
+
+# restart lever — you supply the provider-CLI restart command
+PROVIDER_RESTART_CMD='ssh lab-mac launchctl kickstart -k gui/501/tech.malibu.provider' \
+COLDWARM_BASE=https://<lab-gateway> \
+  ./cold-cycle.sh --lever restart --state post_reboot
+```
+
+Loop it: induce cold → capture → repeat. Over many cycles the store accumulates
+enough cold samples for a real p99.
+
+## Model id — use the FULL catalog id (not the short rate-card key)
+
+Pass the **full** model id the provider advertises — the one `/v1/status` returns,
+e.g. `mlx-community/Qwen3-Coder-30B-A3B-Instruct-4bit` — or leave `--model` /
+`COLDWARM_MODEL` unset to auto-derive it from `/v1/status`. Do **not** use the
+short rate-card key `qwen3-coder-30b-a3b-instruct`: post-#510 the provider
+advertises the full catalog id, and a buyer request for the short id returns
+`404 model_not_found` (the coordinator's `ModelKnown` only knows the advertised
+full id; there's no `routing.model_classes` alias). This bit the harness on
+2026-07-10 — its default was the short id. Same convention as P1's canary-buyer
+probe, which derives models from `/v1/status`.
+
+## Schedule it (lab host)
+
+**systemd** (always-on lab Linux host): `coldwarm-warm.{service,timer}` accumulate
+the warm baseline every 30 min; `coldwarm-matrix.{service,timer}` rebuild the
+matrix every 15 min. See the service headers for install steps. **launchd** (lab
+Mac): `com.streamvc.coldwarm-warm.plist` for the warm baseline. Cold cycles stay
+operator-driven regardless.
+
+## Output — the matrix
+
+`--build-matrix` emits a Prometheus textfile and a JSON artifact:
+
+```
+macprovider_coldwarm_ttft_ms{model,regime,state,quantile}     # p50/p95/p99
+macprovider_coldwarm_ttft_samples{model,regime,state}         # accumulated n
+macprovider_coldwarm_decode_tps{model,regime,state,quantile}  # p50
+macprovider_coldwarm_recommended_max_ttft_ms{model}           # advisory (enforce_ready only)
+macprovider_coldwarm_recommended_cold_start_grace_s{model}    # advisory grace sizing
+macprovider_coldwarm_cold_start_ttft_p99_ms{model}            # buyer-UX SLO
+```
+
+The JSON `recommendations` / `slo` blocks carry the calibration; see
+`CALIBRATION.md` for how those numbers become the three P2 deliverables (the
+`max_ttft_ms` PR, the prewarm decision, the SLO).
+
+## Configuration
+
+| Var | Default | Meaning |
+|-----|---------|---------|
+| `MACPROVIDER_BUYER_TOKEN` / `MALIBU_API_KEY` | — | buyer bearer (required to probe) |
+| `COLDWARM_BASE` | `https://api.streamvc.live` | gateway base URL |
+| `COLDWARM_STORE` | `./coldwarm-samples.ndjson` | append-only NDJSON sample store |
+| `COLDWARM_SAMPLES` | `20` | warm samples per regime |
+| `COLDWARM_CANARY_MAX_TOKENS` | `16` | non-streaming `max_tokens` — keep == the coordinator's `canary_max_tokens` so the regime matches the gate |
+| `COLDWARM_TPS_MAX_TOKENS` | `128` | decode window for the warm TPS sample |
+| `COLDWARM_INTERVAL_MS` | `1500` | floor gap between warm samples |
+| `COLDWARM_REQ_TIMEOUT_MS` | `90000` | per-request timeout — a cold 30B load was ~30–58 s; must not abort a cold load |
+| `COLDWARM_HEADROOM` | `1.5` | calibration headroom multiplier over warm p99 |
+| `COLDWARM_MIN_SAMPLES` | `30` | min samples per cell before a gate is recommended (`enforce_ready`) |
+| `COLDWARM_ALLOW_INSECURE` | *(unset)* | `1` permits http/localhost/private targets (local mock only) |
+
+The buyer token is redacted from all logs, stdout, and the store even if a
+mispointed gateway echoes the `Authorization` header. Same SSRF guards as P1:
+`COLDWARM_BASE` must be https + non-private, `redirect: 'manual'` on
+token-bearing requests.
+
+## Local smoke test
+
+`mock-gateway.mjs` serves both regimes (and simulates a cold first request) so the
+probe logic can be exercised without a live network:
+
+```bash
+PORT=8799 node mock-gateway.mjs &
+export COLDWARM_ALLOW_INSECURE=1 COLDWARM_BASE=http://127.0.0.1:8799
+export MACPROVIDER_BUYER_TOKEN=mp_smoke COLDWARM_STORE=/tmp/cw.ndjson
+node coldwarm-probe.mjs --scenario warm --model qwen3-coder-30b-a3b-instruct --samples 5
+node coldwarm-probe.mjs --scenario cold --state cold --regime canary_nonstream
+node coldwarm-probe.mjs --build-matrix
+```

--- a/test/e2e/coldwarm-ttft/cold-cycle.sh
+++ b/test/e2e/coldwarm-ttft/cold-cycle.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+# Drive ONE cold cycle against a LAB provider and capture the first-after-cold
+# TTFT sample. This is the operator-run piece: it induces cold out of band, then
+# invokes the probe with the appropriate --state.
+#
+# SAFETY (hard-won 2026-07-09 lesson — an hour-long prod outage):
+#   - Run this ONLY against a LAB provider you own. NEVER the prod `mac` provider.
+#   - Do NOT stack coordinator restarts (wedges the CLI v2 proof-auth, issue #519).
+#     This script restarts the PROVIDER CLI at most once per cycle; it never
+#     touches the coordinator.
+#
+# Cold-induction levers (least invasive first), selected by --lever:
+#   idle    wait past the provider's model-unload threshold (no restart at all)
+#   restart restart just the provider CLI process (a full cold model load)
+#   reboot  you reboot the provider host yourself, then run with --state post_reboot
+#
+# Usage:
+#   LAB_MODEL=qwen3-coder-30b-a3b-instruct \
+#   COLDWARM_BASE=https://<lab-gateway> \
+#   ./cold-cycle.sh --lever idle --idle-min 12 --state cold
+#
+#   # provider-CLI restart lever (you supply the restart command):
+#   PROVIDER_RESTART_CMD='ssh lab-mac launchctl kickstart -k gui/501/tech.malibu.provider' \
+#   ./cold-cycle.sh --lever restart --state post_reboot
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+LEVER="idle"
+STATE="cold"
+IDLE_MIN="12"          # default idle wait; size to exceed the model-unload threshold
+REGIME=""              # empty → probe balances regimes across cycles
+MODEL="${LAB_MODEL:-}"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --lever) LEVER="$2"; shift 2;;
+    --state) STATE="$2"; shift 2;;
+    --idle-min) IDLE_MIN="$2"; shift 2;;
+    --regime) REGIME="$2"; shift 2;;
+    --model) MODEL="$2"; shift 2;;
+    *) echo "cold-cycle: unknown arg $1" >&2; exit 2;;
+  esac
+done
+
+# Guardrail: refuse to run against the production coordinator unless the operator
+# explicitly overrides. Cold-cycling churns the provider; prod is off-limits.
+: "${COLDWARM_BASE:=}"
+if [[ "$COLDWARM_BASE" == *"api.streamvc.live"* || "$COLDWARM_BASE" == *"coordinator.streamvc.live"* ]]; then
+  if [[ "${COLD_CYCLE_ALLOW_PROD:-}" != "1" ]]; then
+    echo "cold-cycle: REFUSING to cold-cycle against prod ($COLDWARM_BASE)." >&2
+    echo "            Cold-cycling churns the provider and caused an hour-long outage on 2026-07-09." >&2
+    echo "            Point COLDWARM_BASE at a LAB gateway. (COLD_CYCLE_ALLOW_PROD=1 overrides — do not.)" >&2
+    exit 3
+  fi
+  echo "cold-cycle: WARNING — running against prod because COLD_CYCLE_ALLOW_PROD=1. This is dangerous." >&2
+fi
+
+echo "cold-cycle: lever=$LEVER state=$STATE model=${MODEL:-<auto>} base=${COLDWARM_BASE:-<default>}" >&2
+
+case "$LEVER" in
+  idle)
+    echo "cold-cycle: idling ${IDLE_MIN} min to let the provider unload the model..." >&2
+    sleep "$(( IDLE_MIN * 60 ))"
+    ;;
+  restart)
+    if [[ -z "${PROVIDER_RESTART_CMD:-}" ]]; then
+      echo "cold-cycle: --lever restart needs \$PROVIDER_RESTART_CMD (the provider-CLI restart command)." >&2
+      exit 2
+    fi
+    echo "cold-cycle: restarting the provider CLI (single restart; coordinator untouched)..." >&2
+    eval "$PROVIDER_RESTART_CMD"
+    # Give the provider a moment to reconnect to the coordinator before probing.
+    sleep "${PROVIDER_RECONNECT_WAIT_S:-20}"
+    ;;
+  reboot)
+    echo "cold-cycle: --lever reboot assumes YOU already rebooted the provider host." >&2
+    echo "            Run with --state post_reboot once it has reconnected." >&2
+    ;;
+  *)
+    echo "cold-cycle: unknown --lever $LEVER (idle|restart|reboot)" >&2
+    exit 2
+    ;;
+esac
+
+ARGS=(--scenario cold --state "$STATE")
+[[ -n "$MODEL" ]] && ARGS+=(--model "$MODEL")
+[[ -n "$REGIME" ]] && ARGS+=(--regime "$REGIME")
+
+echo "cold-cycle: capturing first-after-cold sample..." >&2
+exec "$HERE/run-coldwarm.sh" "${ARGS[@]}"

--- a/test/e2e/coldwarm-ttft/coldwarm-matrix.service
+++ b/test/e2e/coldwarm-ttft/coldwarm-matrix.service
@@ -1,0 +1,31 @@
+# macprovider cold/warm TTFT — MATRIX rebuild (systemd oneshot).
+#
+# Reads the accumulated NDJSON store and rewrites the matrix (Prometheus textfile
+# + JSON artifact + advisory calibration recommendations). No token needed; reads
+# the local store only. Companion to coldwarm-warm.service. See that unit's
+# header for install steps.
+[Unit]
+Description=macprovider cold/warm TTFT — rebuild matrix + calibration from store
+
+[Service]
+Type=oneshot
+User=macprovider
+Group=macprovider
+EnvironmentFile=-/etc/macprovider/coldwarm-ttft.env
+Environment=COLDWARM_NODE_BIN=/usr/bin/node
+Environment=COLDWARM_STORE=/var/lib/macprovider/coldwarm-ttft/coldwarm-samples.ndjson
+Environment=COLDWARM_METRICS_OUT=/var/lib/macprovider/coldwarm-ttft/coldwarm.prom
+Environment=COLDWARM_JSON_OUT=/var/lib/macprovider/coldwarm-ttft/artifacts
+ExecStart=/bin/bash /opt/macprovider/coldwarm-ttft/run-coldwarm.sh --build-matrix
+TimeoutStartSec=120
+NoNewPrivileges=true
+ProtectSystem=strict
+ProtectHome=true
+PrivateTmp=true
+PrivateDevices=true
+ProtectKernelTunables=true
+ProtectControlGroups=true
+ReadWritePaths=/var/lib/macprovider/coldwarm-ttft
+StandardOutput=journal
+StandardError=journal
+SyslogIdentifier=coldwarm-ttft

--- a/test/e2e/coldwarm-ttft/coldwarm-matrix.timer
+++ b/test/e2e/coldwarm-ttft/coldwarm-matrix.timer
@@ -1,0 +1,12 @@
+# Rebuild the matrix + calibration every 15 min from the store. See coldwarm-matrix.service.
+[Unit]
+Description=Rebuild macprovider cold/warm TTFT matrix every 15 min
+
+[Timer]
+OnBootSec=8min
+OnUnitActiveSec=15min
+RandomizedDelaySec=60
+Persistent=true
+
+[Install]
+WantedBy=timers.target

--- a/test/e2e/coldwarm-ttft/coldwarm-probe.mjs
+++ b/test/e2e/coldwarm-ttft/coldwarm-probe.mjs
@@ -1,0 +1,945 @@
+#!/usr/bin/env node
+/**
+ * Cold/warm TTFT matrix probe — P2 of the 2026-07-09 e2e-testing review.
+ *
+ * P1 (test/e2e/canary-buyer/) measures steady-state serving quality from the
+ * buyer vantage. P2 attacks the one thing P1 doesn't: COLD-START behavior and
+ * the latency gates that depend on it.
+ *
+ * The forcing function (2026-07-09): a cold 30B model load produced a 30,827 ms
+ * canary TTFT in prod. The W3 canary `max_ttft_ms` gate had been hand-guessed
+ * (3500 → padded to 7000) with no measured basis; tightening it to 3500
+ * (calibrated off the *streaming buyer* ~1200 ms TTFT) banned a healthy provider
+ * three-in-a-row and 503'd buyers. The fix shipped was to make the latency gates
+ * observe-only (PR #513). This probe produces the *real numbers* that let those
+ * gates be tightened back to `enforce` safely, per model class.
+ *
+ * THE CRITICAL SUBTLETY (this is what bit us):
+ *   The pool canary sends stream:false (NON-streaming). Its measured "TTFT" is
+ *   the full non-streaming round-trip and swings wildly (observed 125 ms …
+ *   7000 ms for the SAME healthy provider, depending on relay chunk timing).
+ *   The buyer path STREAMS and shows the true first-token latency (~1200 ms
+ *   warm). These two numbers are NOT interchangeable. The `max_ttft_ms` gate is
+ *   evaluated against the CANARY's non-streaming regime — so it must be
+ *   calibrated against THAT, not against the buyer streaming TTFT.
+ *
+ * This probe measures BOTH regimes side by side, per model class, in three
+ * states (warm / cold / post_reboot), and accumulates the samples into an
+ * append-only NDJSON store so cold-start percentiles (inherently one sample per
+ * cold cycle) can be built up over many real cold/warm cycles. `--build-matrix`
+ * then aggregates the store into the matrix (Prometheus textfile + JSON), plus
+ * an advisory calibration recommendation for `max_ttft_ms` per model class.
+ *
+ * Regimes:
+ *   buyer_stream     stream:true  — TTFT = time to first CONTENT token (real
+ *                                   buyer first-token latency).
+ *   canary_nonstream stream:false — "TTFT" = full non-streaming round-trip,
+ *                                   faithfully mirroring the coordinator's
+ *                                   canaryMetricsFromTiming (canary_probe.go):
+ *                                   for a non-streaming response firstTokenAt is
+ *                                   zero, so ttft = completedAt - start. This is
+ *                                   the exact regime the max_ttft_ms gate sees.
+ *
+ * States:
+ *   warm        provider already loaded; steady-state samples.
+ *   cold        the FIRST request after the model was unloaded/idle-evicted.
+ *               A cold cycle yields exactly ONE genuinely-cold sample (the first
+ *               request warms the model), so this scenario fires a single request
+ *               and appends one sample; run it once per externally-induced cold
+ *               cycle. Regimes are balanced across cycles automatically.
+ *   post_reboot the first request after a full provider process restart (cold
+ *               load from disk). Same one-sample-per-cycle discipline.
+ *
+ * SAFETY (hard-won 2026-07-09 lesson): induce "cold" on a LAB provider, never the
+ * prod `mac` provider — churning prod caused an hour-long outage. Do NOT stack
+ * coordinator restarts (wedges the CLI's v2 proof-auth, issue #519). This probe
+ * NEVER restarts anything itself; the operator induces cold out of band (idle
+ * wait / restart the provider CLI / reboot) and then invokes the cold scenario.
+ *
+ * Zero dependencies (Node >= 18 built-in fetch), matching P1's probe.mjs. The
+ * security-critical helpers (redact, SSRF guards, atomic writes) are kept
+ * byte-identical to P1 so they can be diffed and share the same audit.
+ *
+ * Usage:
+ *   # warm baseline — N samples per regime, appended to the store
+ *   MACPROVIDER_BUYER_TOKEN=mp_... node coldwarm-probe.mjs --scenario warm \
+ *     --model qwen3-coder-30b-a3b-instruct --samples 20 --store ./matrix.ndjson
+ *
+ *   # one cold sample (operator induced cold out of band just before this)
+ *   node coldwarm-probe.mjs --scenario cold --state cold \
+ *     --model qwen3-coder-30b-a3b-instruct --store ./matrix.ndjson
+ *
+ *   # after a provider process restart
+ *   node coldwarm-probe.mjs --scenario cold --state post_reboot \
+ *     --model qwen3-coder-30b-a3b-instruct --store ./matrix.ndjson
+ *
+ *   # aggregate the accumulated store into the matrix + calibration advice
+ *   node coldwarm-probe.mjs --build-matrix --store ./matrix.ndjson \
+ *     --metrics-out /var/lib/node_exporter/textfile/coldwarm.prom \
+ *     --json-out ./artifacts
+ *
+ * Config (env, all optional except a token for probing scenarios):
+ *   MACPROVIDER_BUYER_TOKEN | MALIBU_API_KEY   buyer bearer token (required to probe)
+ *   COLDWARM_BASE          gateway base URL (default https://api.streamvc.live)
+ *   COLDWARM_STORE         NDJSON sample store (default ./coldwarm-samples.ndjson)
+ *   COLDWARM_SAMPLES       warm samples per regime (default 20)
+ *   COLDWARM_TPS_MAX_TOKENS decode window for the warm TPS sample (default 128)
+ *   COLDWARM_CANARY_MAX_TOKENS non-streaming canary max_tokens (default 16 — the
+ *                          coordinator's canary_max_tokens; keep in sync so the
+ *                          canary_nonstream regime matches the gate's regime)
+ *   COLDWARM_INTERVAL_MS   floor gap between warm samples (default 1500)
+ *   COLDWARM_REQ_TIMEOUT_MS per-request timeout (default 90000 — a cold 30B load
+ *                          was observed at ~30–58 s; must not abort a cold load)
+ *   COLDWARM_HEADROOM      calibration headroom multiplier over warm p99 (default 1.5)
+ *   COLDWARM_MIN_SAMPLES   min samples per cell before a gate is recommended (default 30)
+ */
+
+import net from 'node:net';
+import dns from 'node:dns/promises';
+import { webcrypto } from 'node:crypto';
+
+// `crypto` is a global on Node 20+ / browsers, but NOT on Node 18 (where it's
+// gated behind a flag). Fall back to node:crypto's webcrypto so the probe runs
+// on the systemd host's Node 18 as well as newer runtimes.
+const crypto = globalThis.crypto ?? webcrypto;
+
+const REGIMES = ['buyer_stream', 'canary_nonstream'];
+const STATES = ['warm', 'cold', 'post_reboot'];
+
+const args = parseArgs(process.argv.slice(2));
+
+const CONFIG = {
+  base: (env('COLDWARM_BASE') || 'https://api.streamvc.live').replace(/\/$/, ''),
+  token: env('MACPROVIDER_BUYER_TOKEN') || env('MALIBU_API_KEY') || '',
+  store: args['store'] || env('COLDWARM_STORE') || './coldwarm-samples.ndjson',
+  samples: intEnv('COLDWARM_SAMPLES', 20),
+  tpsMaxTokens: intEnv('COLDWARM_TPS_MAX_TOKENS', 128),
+  canaryMaxTokens: intEnv('COLDWARM_CANARY_MAX_TOKENS', 16),
+  intervalMs: intEnv('COLDWARM_INTERVAL_MS', 1500),
+  reqTimeoutMs: intEnv('COLDWARM_REQ_TIMEOUT_MS', 90000),
+  headroom: floatEnv('COLDWARM_HEADROOM', 1.5),
+  minSamples: intEnv('COLDWARM_MIN_SAMPLES', 30),
+  metricsOut: args['metrics-out'] || env('COLDWARM_METRICS_OUT') || '',
+  jsonOut: args['json-out'] || env('COLDWARM_JSON_OUT') || '',
+  // scenario / state / regime selection
+  scenario: (args['scenario'] || '').toString(),
+  state: (args['state'] || '').toString(),
+  regime: (args['regime'] || '').toString(),
+  model: (args['model'] || env('COLDWARM_MODEL') || '').toString(),
+  buildMatrix: 'build-matrix' in args,
+  warmFollowup: 'warm-followup' in args,
+};
+
+function env(k) {
+  return process.env[k] && process.env[k].length ? process.env[k] : '';
+}
+function intEnv(k, d) {
+  const v = parseInt(env(k), 10);
+  return Number.isFinite(v) && v > 0 ? v : d;
+}
+function floatEnv(k, d) {
+  const v = parseFloat(env(k));
+  return Number.isFinite(v) && v > 0 ? v : d;
+}
+function parseArgs(argv) {
+  const out = {};
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (!a.startsWith('--')) continue;
+    const key = a.slice(2);
+    const next = argv[i + 1];
+    if (next && !next.startsWith('--')) {
+      out[key] = next;
+      i++;
+    } else {
+      out[key] = true;
+    }
+  }
+  return out;
+}
+
+function authHeaders(extra = {}) {
+  return { Authorization: `Bearer ${CONFIG.token}`, ...extra };
+}
+
+// Redact the buyer token and any Bearer credential from any text before it
+// reaches a log, stdout, or an on-disk artifact. A mispointed or compromised
+// gateway that echoes the Authorization header must not persist the token.
+// (Kept byte-identical to test/e2e/canary-buyer/probe.mjs.)
+function redact(text) {
+  if (text == null) return text;
+  let s = String(text);
+  if (CONFIG.token && CONFIG.token.length >= 8) s = s.split(CONFIG.token).join('***');
+  return s.replace(/Bearer\s+[A-Za-z0-9._~+/=-]+/gi, 'Bearer ***');
+}
+
+// Validate a URL we are about to send the buyer token to. Require https and
+// reject private/loopback/link-local hosts so a bad env/plist/CLI value can't
+// exfiltrate the token or perform local-network SSRF. COLDWARM_ALLOW_INSECURE=1
+// opts into http/localhost for local testing against a mock gateway.
+function parseSafeUrl(raw, label) {
+  let u;
+  try {
+    u = new URL(raw);
+  } catch {
+    throw new Error(`${label} is not a valid URL`);
+  }
+  const insecure = env('COLDWARM_ALLOW_INSECURE') === '1';
+  if (u.protocol !== 'https:' && !(insecure && u.protocol === 'http:')) {
+    throw new Error(`${label} must be https (set COLDWARM_ALLOW_INSECURE=1 to allow http for local testing)`);
+  }
+  if (!insecure && isPrivateHostname(u.hostname)) {
+    throw new Error(`${label} points at a private/loopback host (set COLDWARM_ALLOW_INSECURE=1 to allow)`);
+  }
+  return u;
+}
+
+// Resolve the host and reject if it maps to a private address, closing the
+// static-misconfiguration / private-DNS SSRF case that a literal-hostname check
+// misses. Pure DNS-rebinding is an inherent limitation of dependency-free fetch
+// and is accepted as a residual risk for this operator-run internal tool;
+// redirect:'manual' on the token-bearing requests closes the redirect variant.
+async function assertResolvesPublic(u, label) {
+  if (env('COLDWARM_ALLOW_INSECURE') === '1') return;
+  const host = u.hostname.replace(/^\[|\]$/g, '');
+  if (net.isIP(host)) return; // literal IP already screened by isPrivateHostname
+  let addrs;
+  try {
+    addrs = await dns.lookup(host, { all: true });
+  } catch {
+    throw new Error(`${label} host ${host} does not resolve`);
+  }
+  for (const { address } of addrs) {
+    if (isPrivateIp(address)) {
+      throw new Error(`${label} host ${host} resolves to a private address`);
+    }
+  }
+}
+
+function isPrivateHostname(host) {
+  const h = host.toLowerCase().replace(/^\[|\]$/g, '').replace(/\.$/, '');
+  if (h === '' || h === 'localhost' || h.endsWith('.localhost')) return true;
+  if (net.isIP(h)) return isPrivateIp(h);
+  return false; // a real hostname is screened at resolve time by assertResolvesPublic
+}
+
+function isPrivateIp(ip) {
+  const fam = net.isIP(ip);
+  if (!fam) return false;
+  const addr = ip.toLowerCase();
+  if (fam === 6) {
+    const v4 = ipv4FromMapped(addr);
+    if (v4) return isPrivateIp4(v4);
+    if (addr === '::' || addr === '::1') return true; // unspecified + loopback
+    const first = addr.split(':')[0];
+    if (/^fe[89ab]/.test(first)) return true; // fe80::/10 link-local
+    if (/^f[cd]/.test(first)) return true; // fc00::/7 unique-local
+    return false;
+  }
+  return isPrivateIp4(addr);
+}
+function ipv4FromMapped(addr) {
+  const m = addr.match(/^(?:::ffff:|::)([0-9a-f.:]+)$/);
+  if (!m) return null;
+  const tail = m[1];
+  if (tail.includes('.')) return tail; // already dotted
+  const groups = tail.split(':').filter((g) => g.length);
+  if (groups.length !== 2) return null; // low 32 bits are exactly two hex groups
+  const [g1, g2] = groups.map((g) => parseInt(g, 16));
+  if (!Number.isInteger(g1) || !Number.isInteger(g2)) return null;
+  return `${(g1 >> 8) & 0xff}.${g1 & 0xff}.${(g2 >> 8) & 0xff}.${g2 & 0xff}`;
+}
+function isPrivateIp4(ip) {
+  const p = ip.split('.').map(Number);
+  if (p.length !== 4 || p.some((n) => !Number.isInteger(n) || n < 0 || n > 255)) return false;
+  const [a, b] = p;
+  if (a === 0 || a === 10 || a === 127) return true;
+  if (a === 169 && b === 254) return true;
+  if (a === 172 && b >= 16 && b <= 31) return true;
+  if (a === 192 && b === 168) return true;
+  return false;
+}
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+async function getStatus() {
+  const ctl = AbortSignal.timeout(CONFIG.reqTimeoutMs);
+  const r = await fetch(`${CONFIG.base}/v1/status`, {
+    headers: authHeaders({ Accept: 'application/json' }),
+    redirect: 'manual',
+    signal: ctl,
+  });
+  const text = await r.text();
+  if (!r.ok) throw new Error(redact(`/v1/status HTTP ${r.status}: ${text.slice(0, 200)}`));
+  return JSON.parse(text);
+}
+
+// ── regime: buyer_stream ──────────────────────────────────────────────────────
+// Streaming completion, TTFT = time to the first CONTENT token (the real buyer
+// first-token latency). Never throws — returns {ok:false,...} so failures are
+// recorded, not swallowed.
+async function measureBuyerStream({ model, messages, maxTokens }) {
+  const headers = authHeaders({
+    'Content-Type': 'application/json',
+    Accept: 'text/event-stream',
+  });
+  const start = now();
+  let firstTokenAt = 0;
+  let lastTokenAt = 0;
+  let usage = null;
+  let requestId = '';
+  let provider = '';
+  let streamError = null;
+
+  try {
+    const r = await fetch(`${CONFIG.base}/v1/chat/completions`, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify({
+        model,
+        messages,
+        stream: true,
+        max_tokens: maxTokens,
+        stream_options: { include_usage: true },
+      }),
+      redirect: 'manual',
+      signal: AbortSignal.timeout(CONFIG.reqTimeoutMs),
+    });
+    requestId = r.headers.get('x-request-id') || '';
+    provider = r.headers.get('x-provider-id') || r.headers.get('x-macprovider-provider') || '';
+    if (!r.ok) {
+      const text = await r.text().catch(() => '');
+      return fail(r.status, redact(text.slice(0, 300)), { requestId, provider });
+    }
+    const reader = r.body.getReader();
+    const decoder = new TextDecoder();
+    let buf = '';
+    const nextSep = (s) => {
+      const m = /\r?\n\r?\n/.exec(s);
+      return m ? { idx: m.index, len: m[0].length } : null;
+    };
+    try {
+      for (;;) {
+        const { value, done } = await reader.read();
+        if (done) break;
+        buf += decoder.decode(value, { stream: true });
+        let sep;
+        while ((sep = nextSep(buf))) {
+          const frame = buf.slice(0, sep.idx);
+          buf = buf.slice(sep.idx + sep.len);
+          for (const line of frame.split(/\r?\n/)) {
+            if (!line.startsWith('data:')) continue;
+            const payload = line.slice(5).trim();
+            if (!payload || payload === '[DONE]') continue;
+            let obj;
+            try {
+              obj = JSON.parse(payload);
+            } catch {
+              continue;
+            }
+            if (obj?.error) streamError = obj.error;
+            const delta = obj?.choices?.[0]?.delta?.content;
+            if (delta) {
+              if (!firstTokenAt) firstTokenAt = now();
+              lastTokenAt = now();
+            }
+            if (obj?.usage) usage = obj.usage;
+          }
+        }
+      }
+    } finally {
+      try {
+        reader.releaseLock();
+      } catch {
+        /* reader already released */
+      }
+    }
+  } catch (e) {
+    const kind = e && e.name === 'TimeoutError' ? 'timeout' : 'network_error';
+    return fail(0, redact(`${kind}: ${e.message || e}`), { kind, requestId, provider });
+  }
+
+  const end = now();
+  if (streamError) {
+    return fail(200, redact(`stream error frame: ${JSON.stringify(streamError).slice(0, 200)}`), {
+      kind: 'stream_error',
+      requestId,
+      provider,
+    });
+  }
+  if (!firstTokenAt) return fail(200, 'no content token', { kind: 'empty', requestId, provider });
+
+  const ttftMs = firstTokenAt - start;
+  const decodeMs = Math.max(0, lastTokenAt - firstTokenAt);
+  const completionTokens = usage?.completion_tokens ?? null;
+  let decodeTps = null;
+  if (completionTokens && completionTokens > 1 && decodeMs > 0) {
+    // Exclude the first token: TTFT already accounts for prefill + first token.
+    decodeTps = ((completionTokens - 1) / decodeMs) * 1000;
+  }
+  return {
+    ok: true,
+    status: 200,
+    ttftMs,
+    decodeTps,
+    totalMs: end - start,
+    completionTokens,
+    requestId,
+    provider,
+  };
+}
+
+// ── regime: canary_nonstream ──────────────────────────────────────────────────
+// Non-streaming completion, "TTFT" = full round-trip, mirroring the coordinator
+// canary's canaryMetricsFromTiming: for a non-streaming response firstTokenAt is
+// zero, so ttft = completedAt - start and decode = the same window. This is the
+// EXACT measurement regime the max_ttft_ms gate is evaluated against.
+async function measureCanaryNonstream({ model, messages, maxTokens }) {
+  const headers = authHeaders({
+    'Content-Type': 'application/json',
+    Accept: 'application/json',
+  });
+  const start = now();
+  let requestId = '';
+  let provider = '';
+  try {
+    const r = await fetch(`${CONFIG.base}/v1/chat/completions`, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify({ model, messages, stream: false, max_tokens: maxTokens }),
+      redirect: 'manual',
+      signal: AbortSignal.timeout(CONFIG.reqTimeoutMs),
+    });
+    requestId = r.headers.get('x-request-id') || '';
+    provider = r.headers.get('x-provider-id') || r.headers.get('x-macprovider-provider') || '';
+    const text = await r.text();
+    if (!r.ok) return fail(r.status, redact(text.slice(0, 300)), { requestId, provider });
+    const completedAt = now();
+    let obj;
+    try {
+      obj = JSON.parse(text);
+    } catch {
+      return fail(200, 'unparseable non-streaming body', { kind: 'empty', requestId, provider });
+    }
+    if (obj?.error) {
+      return fail(200, redact(`error body: ${JSON.stringify(obj.error).slice(0, 200)}`), {
+        kind: 'stream_error',
+        requestId,
+        provider,
+      });
+    }
+    const content = obj?.choices?.[0]?.message?.content ?? '';
+    if (!content) return fail(200, 'empty completion', { kind: 'empty', requestId, provider });
+    const completionTokens = numOrNull(obj?.usage?.completion_tokens);
+    // Mirror canaryMetricsFromTiming exactly: TTFT = whole round-trip, and the
+    // decode window is the same span, so TPS = completion_tokens / total_seconds.
+    const totalMs = completedAt - start;
+    let decodeTps = null;
+    if (completionTokens && completionTokens > 0 && totalMs > 0) {
+      decodeTps = (completionTokens / totalMs) * 1000;
+    }
+    return {
+      ok: true,
+      status: 200,
+      ttftMs: totalMs, // non-streaming: "TTFT" is the full round-trip
+      decodeTps,
+      totalMs,
+      completionTokens,
+      requestId,
+      provider,
+    };
+  } catch (e) {
+    const kind = e && e.name === 'TimeoutError' ? 'timeout' : 'network_error';
+    return fail(0, redact(`${kind}: ${e.message || e}`), { kind, requestId, provider });
+  }
+}
+
+function fail(status, error, extra = {}) {
+  return { ok: false, status, error, ...extra };
+}
+
+function measureRegime(regime, opts) {
+  return regime === 'buyer_stream' ? measureBuyerStream(opts) : measureCanaryNonstream(opts);
+}
+
+// Per-regime request shape. Short prompt / small decode window for TTFT; the
+// canary regime uses the coordinator's canary_max_tokens so it matches the gate.
+function regimeRequest(regime, model, { long = false } = {}) {
+  if (regime === 'canary_nonstream') {
+    return {
+      model,
+      messages: [{ role: 'user', content: 'Reply with exactly: READY' }],
+      maxTokens: long ? CONFIG.tpsMaxTokens : CONFIG.canaryMaxTokens,
+    };
+  }
+  return {
+    model,
+    messages: [
+      long
+        ? { role: 'user', content: 'Count from 1 to 100, one number per line.' }
+        : { role: 'user', content: 'Say: ready.' },
+    ],
+    maxTokens: long ? CONFIG.tpsMaxTokens : 8,
+  };
+}
+
+// role separates the two measurement classes, exactly as P1 does: a 'ttft'
+// sample is a short request that feeds ONLY the TTFT distribution; a 'tps' sample
+// is a longer request that feeds ONLY the sustained decode-TPS distribution.
+// Mixing them pollutes both — a short 8/16-token request has a decode window of a
+// couple ms, so its "TPS" is pure noise (observed 0.68 and 500 tok/s against
+// prod). decode_tps is therefore only retained on 'tps' samples.
+function toSample(regime, state, model, r, runUnix, role) {
+  const isTps = role === 'tps';
+  return {
+    ts: new Date(runUnix * 1000).toISOString(),
+    model,
+    regime,
+    state,
+    role,
+    ok: r.ok ? 1 : 0,
+    ttft_ms: r.ok ? round(r.ttftMs, 1) : null,
+    decode_tps: isTps && r.ok && r.decodeTps != null ? round(r.decodeTps, 3) : null,
+    completion_tokens: r.completionTokens ?? null,
+    total_ms: r.ok ? round(r.totalMs, 1) : null,
+    outcome: outcomeBucket(r),
+    provider: r.provider || '',
+    request_id: r.requestId || '',
+    first_error: r.ok ? null : `HTTP ${r.status}: ${r.error || ''}`.slice(0, 200),
+  };
+}
+
+function outcomeBucket(r) {
+  if (r.ok) return '2xx';
+  if (r.kind) return r.kind; // timeout | network_error | stream_error | empty
+  if (r.status === 0) return 'network_error';
+  if (r.status === 502) return '502';
+  if (r.status === 200) return 'empty';
+  if (r.status >= 500) return '5xx';
+  return 'other';
+}
+
+// ── scenarios ─────────────────────────────────────────────────────────────────
+
+// Warm baseline: N samples per regime, all tagged state=warm, plus one longer
+// sample per regime for a decode-TPS reading. Appended to the store.
+async function runWarm(model, runUnix) {
+  const out = [];
+  for (const regime of REGIMES) {
+    process.stderr.write(redact(`warm ${regime} × ${CONFIG.samples} → ${model}\n`));
+    for (let i = 0; i < CONFIG.samples; i++) {
+      const r = await measureRegime(regime, regimeRequest(regime, model));
+      const s = toSample(regime, 'warm', model, r, runUnix, 'ttft');
+      out.push(s);
+      logSample(s);
+      if (i < CONFIG.samples - 1) await sleep(CONFIG.intervalMs);
+    }
+    // one longer sample for sustained decode TPS (kept separate from the TTFT
+    // distribution — a short request's decode window is too small to time TPS).
+    await sleep(CONFIG.intervalMs);
+    const rl = await measureRegime(regime, regimeRequest(regime, model, { long: true }));
+    const sl = toSample(regime, 'warm', model, rl, runUnix, 'tps');
+    out.push(sl);
+    logSample(sl);
+  }
+  return out;
+}
+
+// Cold / post_reboot: a cold cycle yields exactly ONE genuinely-cold sample (the
+// first request warms the model). Fire a single request in the chosen regime
+// (explicit --regime, else balance across accumulated cold samples), append it.
+// With --warm-followup, also take a few warm samples afterwards (the model is
+// now loaded) so a cold cycle cheaply contributes to the warm baseline too.
+async function runCold(model, state, runUnix, store) {
+  const out = [];
+  const regime = CONFIG.regime || pickBalancedRegime(store, model, state);
+  process.stderr.write(redact(`${state} ${regime} (first-after-cold) → ${model}\n`));
+  const r = await measureRegime(regime, regimeRequest(regime, model));
+  // The cold first-request latency IS the point — a TTFT-class sample.
+  const s = toSample(regime, state, model, r, runUnix, 'ttft');
+  out.push(s);
+  logSample(s);
+
+  if (CONFIG.warmFollowup && r.ok) {
+    // Model is warm now — grab a small warm batch in BOTH regimes for free.
+    for (const wregime of REGIMES) {
+      for (let i = 0; i < 3; i++) {
+        await sleep(CONFIG.intervalMs);
+        const wr = await measureRegime(wregime, regimeRequest(wregime, model));
+        const ws = toSample(wregime, 'warm', model, wr, runUnix, 'ttft');
+        out.push(ws);
+        logSample(ws);
+      }
+    }
+  }
+  return out;
+}
+
+// Balance cold sampling across regimes: pick whichever regime has FEWER
+// accumulated ok cold samples for this (model,state), so both regimes fill up.
+function pickBalancedRegime(store, model, state) {
+  const counts = { buyer_stream: 0, canary_nonstream: 0 };
+  for (const s of store) {
+    if (s.model === model && s.state === state && s.ok && s.regime in counts) counts[s.regime]++;
+  }
+  return counts.buyer_stream <= counts.canary_nonstream ? 'buyer_stream' : 'canary_nonstream';
+}
+
+function logSample(s) {
+  const v = s.ok ? `ttft=${s.ttft_ms}ms${s.decode_tps != null ? ` tps=${s.decode_tps}` : ''}` : `FAIL ${s.outcome}`;
+  console.error(redact(`  [${s.state}/${s.regime}] ${v}${s.first_error ? ` err="${s.first_error}"` : ''}`));
+}
+
+// ── matrix aggregation ────────────────────────────────────────────────────────
+
+function buildMatrix(store, runUnix) {
+  // group by model|regime|state
+  const groups = new Map();
+  for (const s of store) {
+    if (!REGIMES.includes(s.regime) || !STATES.includes(s.state)) continue;
+    const key = `${s.model} ${s.regime} ${s.state}`;
+    if (!groups.has(key)) groups.set(key, []);
+    groups.get(key).push(s);
+  }
+  const cells = [];
+  for (const [key, samples] of groups) {
+    const [model, regime, state] = key.split(' ');
+    // TTFT distribution comes ONLY from 'ttft'-role (short) samples; sustained
+    // decode-TPS ONLY from 'tps'-role (long) samples. Samples predating the role
+    // field (none in practice) default to 'ttft' so a short request never leaks
+    // into the TPS series (a short decode window reads garbage TPS — 0.68 and
+    // 500 tok/s observed against prod).
+    const ttftOk = samples.filter((s) => s.ok && s.ttft_ms != null && (s.role || 'ttft') === 'ttft');
+    const tpsOk = samples.filter((s) => s.ok && s.decode_tps != null && s.role === 'tps');
+    const ttft = ttftOk.map((s) => s.ttft_ms);
+    const tps = tpsOk.map((s) => s.decode_tps);
+    cells.push({
+      model,
+      regime,
+      state,
+      sample_n: ttftOk.length,
+      tps_sample_n: tpsOk.length,
+      attempts: samples.length,
+      ttft_ms: {
+        p50: percentile(ttft, 50),
+        p95: percentile(ttft, 95),
+        p99: percentile(ttft, 99),
+        max: ttft.length ? Math.max(...ttft) : null,
+      },
+      decode_tps: { p50: percentile(tps, 50), min: tps.length ? Math.min(...tps) : null, n: tps.length },
+      first_seen: samples.reduce((a, s) => (a && a < s.ts ? a : s.ts), null),
+      last_seen: samples.reduce((a, s) => (a && a > s.ts ? a : s.ts), null),
+    });
+  }
+  cells.sort((a, b) =>
+    a.model.localeCompare(b.model) || a.regime.localeCompare(b.regime) || a.state.localeCompare(b.state)
+  );
+  return {
+    schema_version: 1,
+    probe: 'coldwarm_ttft',
+    run_at: new Date(runUnix * 1000).toISOString(),
+    base: CONFIG.base,
+    headroom: CONFIG.headroom,
+    min_samples: CONFIG.minSamples,
+    cells,
+    recommendations: recommendGates(cells),
+    slo: buildSLO(cells),
+  };
+}
+
+// Calibrated max_ttft_ms per model class, derived from the CANARY_NONSTREAM WARM
+// cell (the exact regime the gate is evaluated against), with headroom over p99.
+// Advisory only — the actual config change is a separate, audit-gated PR. We also
+// surface the cold p99 so the operator can size canary_cold_start_grace_s.
+function recommendGates(cells) {
+  const recs = [];
+  const byModel = new Map();
+  for (const c of cells) {
+    if (!byModel.has(c.model)) byModel.set(c.model, {});
+    byModel.get(c.model)[`${c.regime}/${c.state}`] = c;
+  }
+  for (const [model, m] of byModel) {
+    const warmCanary = m['canary_nonstream/warm'];
+    const coldCanary = m['canary_nonstream/cold'];
+    const rebootCanary = m['canary_nonstream/post_reboot'];
+    const warmBuyer = m['buyer_stream/warm'];
+    const coldBuyer = m['buyer_stream/cold'];
+    const rec = { model, regime: 'canary_nonstream' };
+    if (warmCanary && warmCanary.sample_n >= CONFIG.minSamples && warmCanary.ttft_ms.p99 != null) {
+      rec.warm_p95_ms = warmCanary.ttft_ms.p95;
+      rec.warm_p99_ms = warmCanary.ttft_ms.p99;
+      rec.recommended_max_ttft_ms = Math.ceil((warmCanary.ttft_ms.p99 * CONFIG.headroom) / 500) * 500;
+      rec.enforce_ready = true;
+      rec.basis = `warm canary_nonstream p99 ${warmCanary.ttft_ms.p99}ms × ${CONFIG.headroom} headroom, rounded up to 500ms`;
+    } else {
+      rec.enforce_ready = false;
+      rec.basis = `insufficient warm canary_nonstream samples (${warmCanary ? warmCanary.sample_n : 0} < ${CONFIG.minSamples}); keep max_ttft_ms >= 7000 and canary_latency_enforcement: observe`;
+    }
+    // Cold-start grace sizing: the grace window must cover the worst cold load.
+    const coldP99 = coldCanary?.ttft_ms?.p99 ?? null;
+    const rebootP99 = rebootCanary?.ttft_ms?.p99 ?? null;
+    rec.cold_canary_p99_ms = coldP99;
+    rec.post_reboot_canary_p99_ms = rebootP99;
+    const worstCold = Math.max(coldP99 || 0, rebootP99 || 0);
+    if (worstCold > 0) {
+      rec.recommended_cold_start_grace_s = Math.ceil((worstCold / 1000) * 1.25 / 10) * 10;
+    }
+    // Prewarm case: cold→warm delta on the buyer path (what a real first request costs).
+    if (warmBuyer?.ttft_ms?.p50 != null && coldBuyer?.ttft_ms?.p50 != null) {
+      rec.buyer_cold_minus_warm_p50_ms = round(coldBuyer.ttft_ms.p50 - warmBuyer.ttft_ms.p50, 0);
+    }
+    recs.push(rec);
+  }
+  return recs;
+}
+
+// Buyer-UX cold-start SLO: worst-case first-request latency (buyer_stream cold
+// p99), per model, the number the product can state/monitor.
+function buildSLO(cells) {
+  const slo = [];
+  for (const c of cells) {
+    if (c.regime === 'buyer_stream' && c.state === 'cold' && c.ttft_ms.p99 != null) {
+      slo.push({
+        model: c.model,
+        cold_start_ttft_p99_ms: c.ttft_ms.p99,
+        cold_start_ttft_max_ms: c.ttft_ms.max,
+        sample_n: c.sample_n,
+        sufficient_samples: c.sample_n >= CONFIG.minSamples,
+      });
+    }
+  }
+  return slo;
+}
+
+function numOrNull(v) {
+  return typeof v === 'number' && Number.isFinite(v) ? v : null;
+}
+function now() {
+  return Number(process.hrtime.bigint() / 1000000n);
+}
+function realUnix() {
+  return Date.now() / 1000;
+}
+function percentile(arr, p) {
+  if (!arr.length) return null;
+  const sorted = [...arr].sort((a, b) => a - b);
+  const rank = Math.ceil((p / 100) * sorted.length);
+  return sorted[Math.min(sorted.length - 1, Math.max(0, rank - 1))];
+}
+function round(v, d = 2) {
+  if (v == null || !Number.isFinite(v)) return v;
+  const f = Math.pow(10, d);
+  return Math.round(v * f) / f;
+}
+
+// ── Prometheus emission ───────────────────────────────────────────────────────
+
+function promEscape(v) {
+  return String(v).replace(/\\/g, '\\\\').replace(/"/g, '\\"').replace(/\n/g, ' ');
+}
+function toProm(matrix) {
+  const L = [];
+  const lbl = (o) =>
+    Object.entries(o)
+      .map(([k, v]) => `${k}="${promEscape(v)}"`)
+      .join(',');
+  const h = (name, help, type) => {
+    L.push(`# HELP ${name} ${help}`);
+    L.push(`# TYPE ${name} ${type}`);
+  };
+  h('macprovider_coldwarm_run_timestamp_seconds', 'Unix time of this matrix build.', 'gauge');
+  L.push(`macprovider_coldwarm_run_timestamp_seconds ${Math.floor(Date.parse(matrix.run_at) / 1000)}`);
+
+  h('macprovider_coldwarm_ttft_ms', 'TTFT by model/regime/state/quantile. regime=buyer_stream|canary_nonstream, state=warm|cold|post_reboot.', 'gauge');
+  h('macprovider_coldwarm_ttft_samples', 'Valid TTFT samples accumulated for the cell.', 'gauge');
+  h('macprovider_coldwarm_decode_tps', 'Decode tokens/sec by model/regime/state (p50).', 'gauge');
+  for (const c of matrix.cells) {
+    const base = { model: c.model, regime: c.regime, state: c.state };
+    for (const q of ['p50', 'p95', 'p99']) {
+      if (c.ttft_ms[q] != null) L.push(`macprovider_coldwarm_ttft_ms{${lbl({ ...base, quantile: q })}} ${c.ttft_ms[q]}`);
+    }
+    L.push(`macprovider_coldwarm_ttft_samples{${lbl(base)}} ${c.sample_n}`);
+    if (c.decode_tps.p50 != null) L.push(`macprovider_coldwarm_decode_tps{${lbl({ ...base, quantile: 'p50' })}} ${round(c.decode_tps.p50)}`);
+  }
+
+  h('macprovider_coldwarm_recommended_max_ttft_ms', 'Advisory calibrated max_ttft_ms for the canary_nonstream gate (warm p99 × headroom). Only emitted when enforce_ready.', 'gauge');
+  h('macprovider_coldwarm_recommended_cold_start_grace_s', 'Advisory canary_cold_start_grace_s sized to cover the worst cold canary load.', 'gauge');
+  for (const r of matrix.recommendations) {
+    if (r.enforce_ready && r.recommended_max_ttft_ms != null) {
+      L.push(`macprovider_coldwarm_recommended_max_ttft_ms{${lbl({ model: r.model })}} ${r.recommended_max_ttft_ms}`);
+    }
+    if (r.recommended_cold_start_grace_s != null) {
+      L.push(`macprovider_coldwarm_recommended_cold_start_grace_s{${lbl({ model: r.model })}} ${r.recommended_cold_start_grace_s}`);
+    }
+  }
+
+  h('macprovider_coldwarm_cold_start_ttft_p99_ms', 'Buyer-UX cold-start SLO: worst-case first-request TTFT (buyer_stream cold p99).', 'gauge');
+  for (const s of matrix.slo) {
+    L.push(`macprovider_coldwarm_cold_start_ttft_p99_ms{${lbl({ model: s.model })}} ${s.cold_start_ttft_p99_ms}`);
+  }
+  return L.join('\n') + '\n';
+}
+
+// ── store I/O ─────────────────────────────────────────────────────────────────
+
+async function appendSamples(path, samples) {
+  if (!samples.length) return;
+  const fs = await import('node:fs/promises');
+  await fs.mkdir(dirname(path), { recursive: true }).catch(() => {});
+  const lines = samples.map((s) => JSON.stringify(s)).join('\n') + '\n';
+  // Append-only NDJSON: a single appendFile of whole lines keeps concurrent runs
+  // from interleaving partial records at our cadence. redact() guards against a
+  // hostile gateway planting the token in a server-controlled field.
+  await fs.appendFile(path, redact(lines), { mode: 0o600 });
+}
+
+async function readStore(path) {
+  const fs = await import('node:fs/promises');
+  let text;
+  try {
+    text = await fs.readFile(path, 'utf8');
+  } catch {
+    return [];
+  }
+  const out = [];
+  for (const line of text.split('\n')) {
+    const t = line.trim();
+    if (!t) continue;
+    try {
+      out.push(JSON.parse(t));
+    } catch {
+      /* skip a corrupt/partial line rather than abort the whole aggregation */
+    }
+  }
+  return out;
+}
+
+async function writeAtomic(path, content) {
+  const fs = await import('node:fs/promises');
+  const tmp = `${path}.tmp-${process.pid}-${crypto.randomUUID()}`;
+  await fs.mkdir(dirname(path), { recursive: true }).catch(() => {});
+  await fs.writeFile(tmp, content, { flag: 'wx', mode: 0o600 });
+  try {
+    await fs.rename(tmp, path);
+  } catch (e) {
+    await fs.unlink(tmp).catch(() => {});
+    throw e;
+  }
+}
+async function joinPath(dir, file) {
+  const fs = await import('node:fs/promises');
+  await fs.mkdir(dir, { recursive: true }).catch(() => {});
+  return dir.replace(/\/$/, '') + '/' + file;
+}
+async function rotateArtifacts(dir, keep) {
+  const fs = await import('node:fs/promises');
+  let names;
+  try {
+    names = await fs.readdir(dir);
+  } catch {
+    return;
+  }
+  const files = names.filter((f) => /^coldwarm-.*\.json$/.test(f));
+  if (files.length <= keep) return;
+  const stated = [];
+  for (const f of files) {
+    try {
+      const st = await fs.stat(`${dir.replace(/\/$/, '')}/${f}`);
+      stated.push({ f, mtime: st.mtimeMs });
+    } catch {
+      /* skip unstatable entry */
+    }
+  }
+  stated.sort((a, b) => b.mtime - a.mtime);
+  for (const { f } of stated.slice(keep)) {
+    await fs.unlink(`${dir.replace(/\/$/, '')}/${f}`).catch(() => {});
+  }
+}
+function dirname(p) {
+  const i = p.lastIndexOf('/');
+  return i <= 0 ? '.' : p.slice(0, i);
+}
+
+// ── main ──────────────────────────────────────────────────────────────────────
+
+async function main() {
+  const runUnix = Math.floor(realUnix());
+
+  if (CONFIG.buildMatrix) {
+    const store = await readStore(CONFIG.store);
+    const matrix = buildMatrix(store, runUnix);
+    const prom = redact(toProm(matrix));
+    const json = redact(JSON.stringify(matrix, null, 2));
+    console.log(json);
+    if (CONFIG.metricsOut) {
+      await writeAtomic(CONFIG.metricsOut, prom);
+      console.error(redact(`wrote metrics → ${CONFIG.metricsOut}`));
+    }
+    if (CONFIG.jsonOut) {
+      const path = await joinPath(CONFIG.jsonOut, `coldwarm-${matrix.run_at.replace(/[:.]/g, '-')}.json`);
+      await writeAtomic(path, json + '\n');
+      await rotateArtifacts(CONFIG.jsonOut, 200);
+      console.error(redact(`wrote artifact → ${path}`));
+    }
+    return;
+  }
+
+  // Probing scenarios require a token and a validated, public https base.
+  if (!CONFIG.token) {
+    console.error('FAIL: set MACPROVIDER_BUYER_TOKEN or MALIBU_API_KEY');
+    process.exit(2);
+  }
+  if (!CONFIG.scenario) {
+    console.error('FAIL: --scenario warm|cold or --build-matrix required');
+    process.exit(2);
+  }
+  try {
+    const baseUrl = parseSafeUrl(`${CONFIG.base}/v1/status`, 'COLDWARM_BASE');
+    await assertResolvesPublic(baseUrl, 'COLDWARM_BASE');
+  } catch (e) {
+    console.error(`FAIL: ${redact(e.message)}`);
+    process.exit(2);
+  }
+
+  // Resolve the model: explicit --model, else the first served model from status.
+  let model = CONFIG.model;
+  if (!model) {
+    try {
+      const status = await getStatus();
+      model = (status?.models || []).map((m) => m.id).filter(Boolean)[0] || '';
+    } catch (e) {
+      console.error(`WARN: /v1/status failed: ${redact(e.message)}`);
+    }
+  }
+  if (!model) {
+    console.error('FAIL: no model to probe (pass --model or ensure /v1/status lists one)');
+    process.exit(2);
+  }
+
+  let samples = [];
+  if (CONFIG.scenario === 'warm') {
+    samples = await runWarm(model, runUnix);
+  } else if (CONFIG.scenario === 'cold') {
+    const state = CONFIG.state || 'cold';
+    if (state !== 'cold' && state !== 'post_reboot') {
+      console.error(`FAIL: --state must be cold or post_reboot (got "${state}")`);
+      process.exit(2);
+    }
+    const store = await readStore(CONFIG.store);
+    samples = await runCold(model, state, runUnix, store);
+  } else {
+    console.error(`FAIL: unknown --scenario "${CONFIG.scenario}" (warm|cold)`);
+    process.exit(2);
+  }
+
+  await appendSamples(CONFIG.store, samples);
+  const okN = samples.filter((s) => s.ok).length;
+  console.error(redact(`appended ${samples.length} samples (${okN} ok) → ${CONFIG.store}`));
+  // stdout: the samples just recorded (machine-readable).
+  console.log(redact(JSON.stringify({ appended: samples.length, ok: okN, store: CONFIG.store, samples }, null, 2)));
+}
+
+main().catch((e) => {
+  console.error('FATAL:', redact(e.message || String(e)));
+  process.exit(2);
+});

--- a/test/e2e/coldwarm-ttft/coldwarm-warm.service
+++ b/test/e2e/coldwarm-ttft/coldwarm-warm.service
@@ -1,0 +1,49 @@
+# macprovider cold/warm TTFT probe — WARM-baseline accumulation (systemd oneshot).
+#
+# Accumulates warm-state samples (both regimes) into the NDJSON store on a LAB
+# host running against a LAB provider. Cold samples are captured separately by
+# the operator (see cold-cycle.sh); this unit only does the warm baseline.
+#
+# Install (lab host):
+#   apt-get install -y nodejs            # >= 18
+#   install -d -o macprovider -g macprovider -m 0755 /opt/macprovider/coldwarm-ttft
+#   cp coldwarm-probe.mjs run-coldwarm.sh /opt/macprovider/coldwarm-ttft/
+#   install -d -o macprovider -g macprovider -m 0750 /var/lib/macprovider/coldwarm-ttft
+#   # buyer token via 0640 env file (NEVER inline in this unit):
+#   #   printf 'MACPROVIDER_BUYER_TOKEN=%s\n' "$TOKEN" > /etc/macprovider/coldwarm-ttft.env
+#   #   chown root:macprovider /etc/macprovider/coldwarm-ttft.env && chmod 0640 ...
+#   cp coldwarm-warm.{service,timer} coldwarm-matrix.{service,timer} /etc/systemd/system/
+#   systemctl daemon-reload && systemctl enable --now coldwarm-warm.timer coldwarm-matrix.timer
+[Unit]
+Description=macprovider cold/warm TTFT probe — warm baseline accumulation
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+User=macprovider
+Group=macprovider
+EnvironmentFile=-/etc/macprovider/coldwarm-ttft.env
+# Point at the LAB gateway, NOT prod — cold cycles churn the provider (see
+# cold-cycle.sh). Warm accumulation against prod read-only is fine, but keep the
+# store consistent by using one base per store.
+Environment=COLDWARM_BASE=https://api.streamvc.live
+Environment=COLDWARM_NODE_BIN=/usr/bin/node
+Environment=COLDWARM_STORE=/var/lib/macprovider/coldwarm-ttft/coldwarm-samples.ndjson
+Environment=COLDWARM_METRICS_OUT=/var/lib/macprovider/coldwarm-ttft/coldwarm.prom
+Environment=COLDWARM_JSON_OUT=/var/lib/macprovider/coldwarm-ttft/artifacts
+Environment=COLDWARM_SAMPLES=20
+ExecStart=/bin/bash /opt/macprovider/coldwarm-ttft/run-coldwarm.sh --scenario warm
+TimeoutStartSec=600
+# Hardening — outbound https + own state dir only.
+NoNewPrivileges=true
+ProtectSystem=strict
+ProtectHome=true
+PrivateTmp=true
+PrivateDevices=true
+ProtectKernelTunables=true
+ProtectControlGroups=true
+ReadWritePaths=/var/lib/macprovider/coldwarm-ttft
+StandardOutput=journal
+StandardError=journal
+SyslogIdentifier=coldwarm-ttft

--- a/test/e2e/coldwarm-ttft/coldwarm-warm.timer
+++ b/test/e2e/coldwarm-ttft/coldwarm-warm.timer
@@ -1,0 +1,12 @@
+# Accumulate a warm-baseline batch every 30 min. See coldwarm-warm.service.
+[Unit]
+Description=Run macprovider cold/warm warm-baseline accumulation every 30 min
+
+[Timer]
+OnBootSec=5min
+OnUnitActiveSec=30min
+RandomizedDelaySec=120
+Persistent=true
+
+[Install]
+WantedBy=timers.target

--- a/test/e2e/coldwarm-ttft/com.streamvc.coldwarm-warm.plist
+++ b/test/e2e/coldwarm-ttft/com.streamvc.coldwarm-warm.plist
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  launchd agent template — warm-baseline accumulation for the cold/warm TTFT
+  matrix, every 30 minutes on a lab Mac. Cold cycles are operator-driven
+  (see cold-cycle.sh); this agent only accumulates the warm baseline.
+
+  Install (per-user LaunchAgent):
+    1. Edit REPLACE_REPO_PATH below to the absolute checkout path.
+    2. Put the buyer token at ~/.config/macprovider/buyer-api-key (run-coldwarm.sh
+       resolves it) OR export MACPROVIDER_BUYER_TOKEN in EnvironmentVariables.
+    3. cp com.streamvc.coldwarm-warm.plist ~/Library/LaunchAgents/
+    4. launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/com.streamvc.coldwarm-warm.plist
+    5. launchctl kickstart -p gui/$(id -u)/com.streamvc.coldwarm-warm   # run once now
+
+  Uninstall:
+    launchctl bootout gui/$(id -u)/com.streamvc.coldwarm-warm
+    rm ~/Library/LaunchAgents/com.streamvc.coldwarm-warm.plist
+-->
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>com.streamvc.coldwarm-warm</string>
+
+  <key>ProgramArguments</key>
+  <array>
+    <string>/bin/bash</string>
+    <string>REPLACE_REPO_PATH/test/e2e/coldwarm-ttft/run-coldwarm.sh</string>
+    <string>--scenario</string>
+    <string>warm</string>
+  </array>
+
+  <key>EnvironmentVariables</key>
+  <dict>
+    <key>PATH</key>
+    <string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>
+    <key>COLDWARM_BASE</key>
+    <string>https://api.streamvc.live</string>
+    <!-- Pin the model explicitly to keep the store's matrix keys consistent.
+         Use the FULL catalog model id the provider advertises (what /v1/status
+         returns), NOT the short rate-card key: post-#510 the provider advertises
+         `mlx-community/…` and a buyer request for the short id
+         `qwen3-coder-30b-a3b-instruct` 404s `model_not_found`. Leave COLDWARM_MODEL
+         unset to auto-derive from /v1/status (also the full id) — either is fine,
+         but never hardcode the short id. (2026-07-10 incident learning.) -->
+    <key>COLDWARM_MODEL</key>
+    <string>mlx-community/Qwen3-Coder-30B-A3B-Instruct-4bit</string>
+  </dict>
+
+  <key>StartInterval</key>
+  <integer>1800</integer>
+
+  <key>RunAtLoad</key>
+  <true/>
+
+  <key>StandardOutPath</key>
+  <string>REPLACE_HOME/Library/Logs/coldwarm-warm.out.log</string>
+  <key>StandardErrorPath</key>
+  <string>REPLACE_HOME/Library/Logs/coldwarm-warm.err.log</string>
+
+  <key>ProcessType</key>
+  <string>Background</string>
+</dict>
+</plist>

--- a/test/e2e/coldwarm-ttft/mock-gateway.mjs
+++ b/test/e2e/coldwarm-ttft/mock-gateway.mjs
@@ -1,0 +1,50 @@
+#!/usr/bin/env node
+// Tiny local mock gateway for smoke-testing coldwarm-probe.mjs (dev only).
+// Serves /v1/status and /v1/chat/completions (both streaming and non-streaming).
+// COLDWARM_MOCK_DELAY_MS simulates a cold load on the first request.
+import http from 'node:http';
+
+const PORT = parseInt(process.env.PORT || '8799', 10);
+const MODEL = process.env.MOCK_MODEL || 'qwen3-coder-30b-a3b-instruct';
+let firstSeen = false;
+
+function coldDelay() {
+  // First request after boot is "cold": big delay. Subsequent are "warm".
+  if (!firstSeen) {
+    firstSeen = true;
+    return parseInt(process.env.MOCK_COLD_MS || '1200', 10);
+  }
+  return parseInt(process.env.MOCK_WARM_MS || '80', 10);
+}
+
+const server = http.createServer(async (req, res) => {
+  if (req.url === '/v1/status') {
+    res.writeHead(200, { 'content-type': 'application/json' });
+    res.end(JSON.stringify({ models: [{ id: MODEL }], pool: { ready: 1 } }));
+    return;
+  }
+  if (req.url === '/v1/chat/completions' && req.method === 'POST') {
+    let body = '';
+    for await (const c of req) body += c;
+    const stream = /"stream"\s*:\s*true/.test(body);
+    const delay = coldDelay();
+    await new Promise((r) => setTimeout(r, delay));
+    if (stream) {
+      res.writeHead(200, { 'content-type': 'text/event-stream', 'x-request-id': 'mock-req', 'x-provider-id': 'mock' });
+      for (const tok of ['re', 'ad', 'y']) {
+        res.write(`data: ${JSON.stringify({ choices: [{ delta: { content: tok } }] })}\n\n`);
+        await new Promise((r) => setTimeout(r, 20));
+      }
+      res.write(`data: ${JSON.stringify({ choices: [{ delta: {} }], usage: { completion_tokens: 3, prompt_tokens: 10 } })}\n\n`);
+      res.write('data: [DONE]\n\n');
+      res.end();
+    } else {
+      res.writeHead(200, { 'content-type': 'application/json', 'x-request-id': 'mock-req', 'x-provider-id': 'mock' });
+      res.end(JSON.stringify({ choices: [{ message: { content: 'READY' } }], usage: { completion_tokens: 3, prompt_tokens: 10 } }));
+    }
+    return;
+  }
+  res.writeHead(404);
+  res.end('nope');
+});
+server.listen(PORT, '127.0.0.1', () => console.error(`mock gateway on http://127.0.0.1:${PORT} model=${MODEL}`));

--- a/test/e2e/coldwarm-ttft/run-coldwarm.sh
+++ b/test/e2e/coldwarm-ttft/run-coldwarm.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# Wrapper for the cold/warm TTFT probe. Resolves the buyer token, then runs the
+# requested scenario (warm accumulation, a single cold sample, or a matrix
+# rebuild). Intended for launchd/systemd (warm + matrix) or by hand (cold cycles).
+#
+# Token resolution order (same as P1's run-canary.sh):
+#   1. $MACPROVIDER_BUYER_TOKEN (if already exported)
+#   2. $COLDWARM_TOKEN_FILE (default ~/.config/macprovider/buyer-api-key)
+# The token is never echoed. Diagnostics go to stderr / the service log.
+#
+# Usage:
+#   run-coldwarm.sh --scenario warm --model mlx-community/Qwen3-Coder-30B-A3B-Instruct-4bit
+#   (use the FULL id the provider advertises / that /v1/status returns — the short
+#    rate-card key qwen3-coder-30b-a3b-instruct 404s post-#510. Or omit --model to
+#    auto-derive from /v1/status.)
+#   run-coldwarm.sh --scenario cold --state cold      # after inducing cold
+#   run-coldwarm.sh --build-matrix
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+: "${COLDWARM_BASE:=https://api.streamvc.live}"
+: "${COLDWARM_TOKEN_FILE:=$HOME/.config/macprovider/buyer-api-key}"
+: "${COLDWARM_STORE:=$HOME/.local/state/coldwarm-ttft/coldwarm-samples.ndjson}"
+: "${COLDWARM_METRICS_OUT:=$HOME/.local/state/coldwarm-ttft/coldwarm.prom}"
+: "${COLDWARM_JSON_OUT:=$HOME/.local/state/coldwarm-ttft/artifacts}"
+
+# build-matrix does not need a token (it only reads the local store).
+needs_token=1
+for a in "$@"; do
+  [[ "$a" == "--build-matrix" ]] && needs_token=0
+done
+
+if [[ "$needs_token" == "1" && -z "${MACPROVIDER_BUYER_TOKEN:-}" ]]; then
+  if [[ -r "$COLDWARM_TOKEN_FILE" ]]; then
+    MACPROVIDER_BUYER_TOKEN="$(tr -d '[:space:]' < "$COLDWARM_TOKEN_FILE")"
+    export MACPROVIDER_BUYER_TOKEN
+  else
+    echo "coldwarm: no token in \$MACPROVIDER_BUYER_TOKEN and $COLDWARM_TOKEN_FILE not readable" >&2
+    exit 2
+  fi
+fi
+
+export COLDWARM_BASE COLDWARM_STORE COLDWARM_METRICS_OUT COLDWARM_JSON_OUT
+
+# launchd/systemd run with a minimal PATH that usually lacks Homebrew/node.
+export PATH="/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:$PATH"
+NODE_BIN="${COLDWARM_NODE_BIN:-$(command -v node || true)}"
+if [[ -z "$NODE_BIN" ]]; then
+  echo "coldwarm: node not found on PATH; set \$COLDWARM_NODE_BIN to the node binary" >&2
+  exit 2
+fi
+
+# --build-matrix writes the prom textfile + JSON artifact; probing scenarios only
+# append to the store (the matrix is rebuilt separately by the matrix unit).
+exec "$NODE_BIN" "$HERE/coldwarm-probe.mjs" \
+  --store "$COLDWARM_STORE" \
+  --metrics-out "$COLDWARM_METRICS_OUT" \
+  --json-out "$COLDWARM_JSON_OUT" \
+  "$@"


### PR DESCRIPTION
## Summary
- Re-lands the additive `test/e2e/coldwarm-ttft/` harness from stale PR #526 onto current `origin/main`.
- Same purpose: measure **buyer_stream** vs **canary_nonstream** TTFT cold/warm/post_reboot so `max_ttft_ms` can be calibrated without guessing.
- No coordinator/gateway/billing changes.

## Why not merge #526 as-is
- #526 was **3 ahead / 169 behind** `main` with red CI on a stale head.
- Files were new and applied cleanly; this PR is the clean replacement.

## Safety (from harness README)
- Cold induction is lab-only; refuses prod base unless explicit override.
- Never restarts the coordinator.

## Test plan
- [x] `node --check` on `coldwarm-probe.mjs` and `mock-gateway.mjs`
- [x] `bash -n` on shell helpers
- [ ] Optional: warm probe against lab buyer token (not required for merge of additive harness)

Closes #526

Made with [Cursor](https://cursor.com)