### PR TITLE
Record Entry 172 fresh invite-earn PASS

### DIFF
--- a/ops/exceptions/production-exceptions.json
+++ b/ops/exceptions/production-exceptions.json
@@ -1,8 +1,8 @@
 {
   "$schema": "./production-exceptions.schema.json",
   "schema_version": "macprovider-production-exceptions-v1",
-  "updated_at": "2026-07-21T12:49:12Z",
-  "updated_by": "codex-lane-d",
+  "updated_at": "2026-07-21T14:30:02Z",
+  "updated_by": "cursor-entry172-journey-pass",
   "environment": "pearl-production",
   "exceptions": [
     {
@@ -193,18 +193,18 @@
     },
     {
       "id": "exc-entry172-air-referral-activation",
-      "status": "active",
+      "status": "expired",
       "environment": "pearl-production",
       "component": "edge",
-      "policy_delta": "Entry 172 allows one controlled private-prebeta referral activation while the Air exception is not #613-complete, rather than requiring complete two-Mac physical journey evidence before reversible referral flags can remain live.",
+      "policy_delta": "Entry 172 allowed one controlled private-prebeta referral activation while the Air exception was not #613-complete; the first fresh referred-provider invite-earn journey has now PASSed, so the exception expiry condition is met while Pearl referral flags still need operator roll-off cleanup.",
       "authority_surface": "Pearl referral overlay keys `referrals.require_for_registration`, `referrals.enable_public_validation`, `referrals.enable_join_links`, `referrals.enable_social_invite_bonus`, `referrals.campaign`, `referrals.current_key_id`, and Vercel product-origin `/j` landing page.",
-      "reason": "Decision Entry 172 and SPEC-034 §8 define a one-time limited Air / fragment-link activation exception for private-prebeta referrals, with strict order, rollback, and expiry.",
+      "reason": "Decision Entry 172 and SPEC-034 §8 define a one-time limited Air / fragment-link activation exception for private-prebeta referrals, with strict order, rollback, and expiry on terminal success/failure of the first fresh referred-provider journey.",
       "owner": "referral activation/security",
       "issue": "https://github.com/Augustas11/macprovider/issues/615",
       "created_at": "2026-07-19T00:00:00Z",
       "expires_at": "2026-07-26T23:59:59Z",
-      "scope": "Entry 172 private-prebeta referral campaign only; flags may remain live under the Air exception, with no broad stable release, no #613 closure, and no first fresh referred-provider redemption evidence claim.",
-      "removal_condition": "Expires at deadline, terminal success/failure of the first fresh referred-provider journey, or any earlier controlled-sequence failure; keeping/re-enabling flags afterward requires complete #613 evidence or a new reviewed decision.",
+      "scope": "Entry 172 private-prebeta referral campaign only; Air5 fresh referred journey PASS for `mp-90542c0bcf7c4d303795cd10bda3830d` closed invite-earn under campaign `prebeta_20260719` with issuer `tn6skbiu4cfeiffs`. No broad stable release and no claim of complete #613 two-Mac conformance.",
+      "removal_condition": "Terminal success of the first fresh referred-provider journey is recorded; mark `removed` only after Pearl referral flags are rolled back to recorded prior/off values and `post_removal_validation` passes. Keeping or re-enabling flags afterward requires complete #613 evidence or a new reviewed decision.",
       "rollback_command": "Restore the prior recorded Pearl referral flag values for `require_for_registration`, `enable_public_validation`, `enable_join_links`, and `enable_social_invite_bonus`; do not print HMAC secrets or referral codes.",
       "post_removal_validation": "Pearl flags match the recorded prior/off values, Vercel `/j` remains fragment-only/static, coordinator validation rejects disallowed origins, and no server logs contain invite code or challenge material.",
       "blocks_stable_promotion": true,
@@ -213,6 +213,7 @@
         "specs/SPEC-034-referral-gated-prebeta.md#8-activation-rollback-and-acceptance",
         "ops/runbooks/entry-172-referral-activation.md",
         "ops/runbooks/entry-172-activation-evidence-20260721.md",
+        "ops/runbooks/entry-172-activation-evidence-20260721.md#fresh-referred-provider-invite-earn-pass-2026-07-21",
         "https://github.com/Augustas11/macprovider/issues/615"
       ]
     }
@@ -265,7 +266,7 @@
       "question": "If Entry 172 activation has started, what exact prior/live referral flag values and campaign metadata were recorded without exposing HMAC secrets or referral codes?",
       "owner": "referral activation/security",
       "status": "answered",
-      "evidence_target": "`ops/runbooks/entry-172-activation-evidence-20260721.md` records redacted PASS LIVE evidence; keep `exc-entry172-air-referral-activation` active until expiry, terminal fresh journey result, or earlier controlled-sequence failure."
+      "evidence_target": "`ops/runbooks/entry-172-activation-evidence-20260721.md` records redacted PASS LIVE activation plus Air5 fresh invite-earn PASS; `exc-entry172-air-referral-activation` is `expired` on terminal journey success and stays `expired` until flag roll-off + `post_removal_validation` allow `removed`."
     }
   ]
 }

--- a/ops/runbooks/entry-172-activation-evidence-20260721.md
+++ b/ops/runbooks/entry-172-activation-evidence-20260721.md
@@ -55,14 +55,70 @@ Campaign metadata:
 
 ## Boundaries
 
-- #613 NOT closed by Entry 172; Air exception only.
-- The first fresh referred-provider journey is still required.
-- The exception remains active until the earliest of
-  `2026-07-26T23:59:59Z`, terminal success/failure of the first fresh
-  referred-provider journey, or any earlier controlled-sequence failure.
+- #613 NOT closed by Entry 172; Air exception only. This file does not claim
+  complete two-Mac physical-journey conformance.
+- First fresh referred-provider invite-earn journey: PASS (see section below).
+- Exception register row `exc-entry172-air-referral-activation` is `expired` on
+  that terminal journey success per SPEC-034 §8 / Entry 172. Status is not
+  `removed` until Pearl referral flags are rolled back and
+  `post_removal_validation` passes.
+- Pearl flags were still live at the time of the journey PASS evidence below;
+  flag roll-off remains an operator follow-up.
 - #658 was not started or modified.
 - This evidence file records docs/register evidence only; it does not implement
   #615 enforcement.
+
+## Fresh referred-provider invite-earn PASS (2026-07-21)
+
+Result: PASS for the Entry 172 first fresh referred-provider journey on Air5.
+Invite earn closed. Secrets, invite codes, challenges, HMAC material, and
+provider bearers are omitted.
+
+Provider and model:
+
+- Host: Air5 (`MacBook-Air-5.local`)
+- `provider_id`: `mp-90542c0bcf7c4d303795cd10bda3830d`
+- Model: `mlx-community/Qwen3-8B-4bit`
+- Model hash:
+  `1f591f9c4fb38d05ea2d879d89a6eeab485c23a04eb75e3e0a289db9d95ec877`
+- Campaign: `prebeta_20260719`
+- Issuer: `tn6skbiu4cfeiffs` (`base_capacity=1`)
+
+Buyer / settlement evidence (Pearl):
+
+- Buyer hit: HTTP 200
+- `request_log.id=19241`
+- `settlement_attempt_outputs.id=6020` (`terminal_state=normal_done`)
+- `settlement_route_snapshots.id=458` (`spec008_hash_status=hash_verified`,
+  hash `1f591f9c…`)
+- `settlement_receipt_verdicts.id=458` (`settlement_outcome=verified`,
+  `receipt_result=valid`, `closed=1`)
+
+454 → 458 nuance (honest):
+
+- Serving qualification and issuer rows for this fresh provider already existed
+  from an earlier Qwen verified verdict `454`
+  (`evidence_id=settlement-verdict:454`, `issuer_id=tn6skbiu4cfeiffs`,
+  `qualified_at=2026-07-21T14:13:04Z`).
+- Those tables are one row per `(campaign, provider_id)`, so buyer hit
+  `request_log.id=19241` / verdict `458` did not create duplicate
+  qualification or issuer rows.
+- The issuer remained valid after verdict `458`; invite earn for this fresh
+  journey is closed on issuer `tn6skbiu4cfeiffs`.
+
+Operator-local evidence pointers (path names only; not committed):
+
+- Scratchpad:
+  `/Users/augstar/macprovider-entry172-ops/scratchpad/air5-fresh-referred-journey-20260721.md`
+- Buyer-proof artifact dir:
+  `/Users/augstar/macprovider-entry172-ops/scratchpad/air5-buyer-proof-qwen-20260721T142102Z`
+
+Register follow-up:
+
+- Exception id: `exc-entry172-air-referral-activation` (#615 register).
+- Status transition: `active` → `expired` on terminal journey PASS.
+- Do not mark `removed` until flag roll-off + post-removal validation.
+- Do not treat this PASS as #613 two-Mac conformance.
 
 ## Backup Path Names
 

--- a/ops/runbooks/entry-172-referral-activation.md
+++ b/ops/runbooks/entry-172-referral-activation.md
@@ -6,13 +6,17 @@ Docs-only activation checklist for Decision Entry 172 and [SPEC-034 §8](../../s
 
 This runbook does not flip production flags, deploy services, create seed codes, write live databases, or cut a release. It describes the operator path for a later controlled private-prebeta activation.
 
-Air exception is not #613 complete. It does not close #613, mark the two-Mac journey conformant, or claim fresh-provider redemption evidence.
+Air exception is not #613 complete. It does not close #613 or mark the two-Mac
+journey conformant. The first fresh referred-provider invite-earn journey has
+PASSed; see the evidence file below.
 
-Register row: [`exc-entry172-air-referral-activation`](../exceptions/production-exceptions.json) in the #615 production exception register.
+Register row: [`exc-entry172-air-referral-activation`](../exceptions/production-exceptions.json) in the #615 production exception register (`status: expired` on terminal journey PASS; remains `expired` until flag roll-off + post-removal validation allow `removed`).
 
-Expiry: this exception expires at `2026-07-26T23:59:59Z`, on terminal success or failure of the first fresh referred-provider journey, or on any earlier controlled-sequence failure, whichever occurs first.
+Expiry condition met by terminal journey PASS (calendar expiry was
+`2026-07-26T23:59:59Z`). Keeping or re-enabling referral flags afterward
+requires complete #613 evidence or a new reviewed decision.
 
-Last successful activation evidence: [`entry-172-activation-evidence-20260721.md`](./entry-172-activation-evidence-20260721.md) records the redacted PASS LIVE result for the v1.8.56 execution baseline. Future re-runs must still re-confirm current release tags, asset hashes, deploy IDs, and live flag state before any operation.
+Last successful activation evidence: [`entry-172-activation-evidence-20260721.md`](./entry-172-activation-evidence-20260721.md) records the redacted PASS LIVE activation result for the v1.8.56 baseline plus the Air5 fresh invite-earn PASS. Future re-runs must still re-confirm current release tags, asset hashes, deploy IDs, and live flag state before any operation.
 
 Fail closed if any checklist item below is unmet.
 
@@ -354,7 +358,7 @@ durable-state preservation check:
 
 - This runbook does not close #613, #658, #582, #617, #661, or any Lane C work.
 - #658 still needs the trust-preserving bridge plus physical update, rollback, buyer-serving, and renewal evidence for continuous discovery.
-- The first available fresh referred provider must still complete the missing redemption journey.
+- The first available fresh referred-provider invite-earn journey PASSed on Air5 (`mp-90542c0bcf7c4d303795cd10bda3830d`); see [`entry-172-activation-evidence-20260721.md`](./entry-172-activation-evidence-20260721.md#fresh-referred-provider-invite-earn-pass-2026-07-21). That PASS expires `exc-entry172-air-referral-activation` but does not claim #613 two-Mac conformance; Pearl flag roll-off remains an operator follow-up before `removed`.
 - Lane C / #615 owns exception inventory. Do not implement #615 from this runbook.
 - This runbook does not implement the #658 discovery bridge.
 - This runbook does not deploy, tag, publish, change nginx, change checked-in flag defaults, write live DB rows, create real HMAC secrets, or create real seed codes.


### PR DESCRIPTION
## Summary

- Docs/register only: records the Air5 fresh referred-provider invite-earn PASS and marks `exc-entry172-air-referral-activation` `expired` on terminal journey success.
- Evidence includes Pearl ids (`request_log` 19241, attempt output 6020, route snapshot/verdict 458), issuer `tn6skbiu4cfeiffs`, and the honest 454→458 qualification/issuer nuance.
- Does **not** claim #613 two-Mac conformance. Status is `expired` (schema enum), not `removed`, because Pearl referral flags still need operator roll-off + `post_removal_validation`.
- #615 remains OPEN; enforcement is not implemented here.

## Test plan

- [x] `python3` register schema validation with `jsonschema` in a temporary venv
- [x] Dependency-free register validator from the runbook
- [x] `git diff --check`

## Out of Scope

- No Pearl SSH writes or live flag/overlay/DB/nginx/Vercel mutations.
- No Air5 wipe/reinstall.
- No release cuts, binaryVersion bumps, Malibu/CLI code changes, or money-path code.

SPEC-GOVERNANCE-DECLARATION-BEGIN
{
  "schema_version": "spec-pr-governance-v1",
  "behavior_change": "yes",
  "contract_change": "none",
  "issue": "https://github.com/Augustas11/macprovider/issues/615",
  "specs": ["SPEC-034"],
  "requirements": ["SPEC-034-R001"],
  "authority_domains": ["referral-advocacy-policy"],
  "arbitration": ["UNKNOWN"],
  "tests": [
    "production exception register schema validation",
    "dependency-free production exception register validation",
    "git diff --check"
  ],
  "journeys": ["not-required"]
}
SPEC-GOVERNANCE-DECLARATION-END


Made with [Cursor](https://cursor.com)