### PR TITLE
Stop CLI marketing-version bumps from invalidating recommendation evidence

### DIFF
--- a/phase3-binary/Sources/macprovider-cli/AutotuneRecommend.swift
+++ b/phase3-binary/Sources/macprovider-cli/AutotuneRecommend.swift
@@ -1703,8 +1703,11 @@ struct AutotuneRecommendEngine {
         } else {
             catalogEvidenceMatches = benchmark.candidateRowIdentity == request.candidateCatalog.rowIdentity(for: modelKey)
         }
+        // Evidence freshness binds to compatibility inputs (catalog row identity,
+        // model artifact, hardware identity) and an explicit evidence lifetime —
+        // never to the independently-versioned CLI marketing release number.
+        // A CLI version-only bump must not discard a known-good cached benchmark.
         guard catalogEvidenceMatches,
-              benchmark.binaryVersion == request.hardware.binaryVersion,
               benchmark.modelID == request.candidateCatalog.rows[modelKey]?.modelID,
               benchmark.artifactSHA256 == request.candidateCatalog.rows[modelKey]?.modelSHA256,
               benchmark.hardwareIdentityHash == request.hardware.hardwareIdentityHash,
@@ -2025,11 +2028,16 @@ enum RecommendationStateStore {
     }
 
     static func isStale(stored: LastRecommendationState, current: LastRecommendationState, now: Date) -> Bool {
+        // Staleness binds to compatibility inputs — rate card, demand rank, and
+        // candidate catalog identity/digest, plus hardware identity and evidence
+        // age. `binaryVersion` is the independently-versioned CLI marketing
+        // release number and intentionally does not participate here: a
+        // software-only version bump with unchanged compat inputs must not
+        // invalidate an otherwise-healthy recommendation.
         if stored.rateCardVersion != current.rateCardVersion { return true }
         if stored.demandRankVersion != current.demandRankVersion { return true }
         if stored.candidateCatalogVersion != current.candidateCatalogVersion { return true }
         if stored.candidateCatalogSHA256 != current.candidateCatalogSHA256 { return true }
-        if stored.binaryVersion != current.binaryVersion { return true }
         if stored.hardwareIdentityHash != current.hardwareIdentityHash { return true }
         guard let benchmarkGeneratedAt = stored.benchmarkGeneratedAt else { return true }
         return now.timeIntervalSince(benchmarkGeneratedAt) > AutotuneRecommendEngine.maxBenchmarkAge

--- a/phase3-binary/Tests/macprovider-cliTests/AutotuneRecommendTests.swift
+++ b/phase3-binary/Tests/macprovider-cliTests/AutotuneRecommendTests.swift
@@ -466,9 +466,12 @@ final class AutotuneRecommendTests: XCTestCase {
         catalogMismatch.candidateCatalogSHA256 = "mismatch"
         XCTAssertFalse(AutotuneRecommendEngine.cachedBenchmarkAdmitted(catalogMismatch, request: request, modelKey: modelKey))
 
-        var binaryMismatch = baseline
-        binaryMismatch.binaryVersion = "other"
-        XCTAssertFalse(AutotuneRecommendEngine.cachedBenchmarkAdmitted(binaryMismatch, request: request, modelKey: modelKey))
+        // binaryVersion is the independently-versioned CLI marketing release
+        // number, not a compatibility input — a version-only difference must
+        // not discard otherwise-valid cached benchmark evidence (#612).
+        var binaryVersionOnlyChange = baseline
+        binaryVersionOnlyChange.binaryVersion = "other"
+        XCTAssertTrue(AutotuneRecommendEngine.cachedBenchmarkAdmitted(binaryVersionOnlyChange, request: request, modelKey: modelKey))
 
         var modelMismatch = baseline
         modelMismatch.modelID = "other/model"
@@ -485,6 +488,72 @@ final class AutotuneRecommendTests: XCTestCase {
         var stale = baseline
         stale.generatedAt = request.generatedAt.addingTimeInterval(-(AutotuneRecommendEngine.maxBenchmarkAge + 1))
         XCTAssertFalse(AutotuneRecommendEngine.cachedBenchmarkAdmitted(stale, request: request, modelKey: modelKey))
+    }
+
+    func testCachedBenchmarkAdmittedAcrossCLIVersionOnlyBump() throws {
+        var request = try makeRequest()
+        let modelKey = "qwen3-coder-30b-a3b-instruct"
+        let benchmark = try XCTUnwrap(request.benchmarks[modelKey])
+        XCTAssertEqual(benchmark.binaryVersion, request.hardware.binaryVersion)
+
+        // Simulate a CLI update: the running binary's marketing version moves
+        // forward while every compatibility input (catalog, model artifact,
+        // hardware identity) stays the same as when the benchmark was recorded.
+        request.hardware = AutotuneRecommendHardware(
+            machine: request.hardware.machine,
+            chip: request.hardware.chip,
+            memoryGB: request.hardware.memoryGB,
+            bandwidthTier: request.hardware.bandwidthTier,
+            osVersion: request.hardware.osVersion,
+            binaryVersion: "1.8.57",
+            diversificationID: request.hardware.diversificationID,
+            hardwareIdentityHash: request.hardware.hardwareIdentityHash
+        )
+
+        XCTAssertNotEqual(benchmark.binaryVersion, request.hardware.binaryVersion)
+        XCTAssertTrue(AutotuneRecommendEngine.cachedBenchmarkAdmitted(benchmark, request: request, modelKey: modelKey))
+
+        let result = AutotuneRecommendEngine().recommend(request)
+        XCTAssertEqual(result.recommendedModel, modelKey)
+    }
+
+    func test8GBLlama32FeasibleFallbackSurvivesCLIVersionOnlyBump() throws {
+        let modelKey = "meta-llama/llama-3.2-3b-instruct"
+        var request = try makeRequest(modelKey: modelKey)
+        request.hardware = AutotuneRecommendHardware(
+            machine: request.hardware.machine,
+            chip: "Apple M1",
+            memoryGB: 8,
+            bandwidthTier: request.hardware.bandwidthTier,
+            osVersion: request.hardware.osVersion,
+            binaryVersion: request.hardware.binaryVersion,
+            diversificationID: request.hardware.diversificationID,
+            hardwareIdentityHash: request.hardware.hardwareIdentityHash
+        )
+        // The cached benchmark was recorded under the pre-update CLI version.
+        var benchmark = try XCTUnwrap(request.benchmarks[modelKey])
+        benchmark.swapDetected = true
+        request.benchmarks[modelKey] = benchmark
+
+        // A CLI update alone advances the marketing version with every
+        // compatibility input (catalog, model artifact, hardware) unchanged.
+        request.hardware = AutotuneRecommendHardware(
+            machine: request.hardware.machine,
+            chip: request.hardware.chip,
+            memoryGB: request.hardware.memoryGB,
+            bandwidthTier: request.hardware.bandwidthTier,
+            osVersion: request.hardware.osVersion,
+            binaryVersion: "1.8.57",
+            diversificationID: request.hardware.diversificationID,
+            hardwareIdentityHash: request.hardware.hardwareIdentityHash
+        )
+
+        let result = AutotuneRecommendEngine().recommend(request)
+
+        XCTAssertEqual(result.recommendedModel, modelKey)
+        XCTAssertNotEqual(result.recommendedModel, "none")
+        XCTAssertFalse(result.humanTranscript().contains("donor mode only"))
+        XCTAssertTrue(result.warnings.contains(.swapObservedUnderLoad))
     }
 
     func testRowIdentityPreservesEvidenceAcrossUnrelatedCatalogChange() throws {
@@ -2030,6 +2099,61 @@ final class AutotuneRecommendTests: XCTestCase {
         )
 
         XCTAssertEqual(staleSince, Optional(Self.date("2026-07-01T00:00:00Z")))
+    }
+
+    func testIsStaleIgnoresCLIVersionOnlyChange() throws {
+        let generatedAt = Self.date("2026-07-01T00:00:00Z")
+        let stored = LastRecommendationState(
+            generatedAt: generatedAt,
+            rateCardVersion: "rate-1",
+            demandRankVersion: "demand-1",
+            candidateCatalogVersion: "catalog-1",
+            candidateCatalogSHA256: "catalog-sha-1",
+            benchmarkID: "bench-1",
+            benchmarkGeneratedAt: generatedAt,
+            binaryVersion: "1.8.55",
+            hardwareIdentityHash: "hw-1",
+            recommendedModel: "meta-llama/llama-3.2-3b-instruct"
+        )
+        // Only the CLI marketing version advances; every compatibility input
+        // (rate card, demand rank, catalog identity/digest, hardware identity)
+        // and the cached benchmark stay the same.
+        var current = stored
+        current.binaryVersion = "1.8.56"
+
+        XCTAssertFalse(RecommendationStateStore.isStale(
+            stored: stored,
+            current: current,
+            now: generatedAt
+        ))
+    }
+
+    func testIsStaleDetectsCompatibilityInputChanges() throws {
+        let generatedAt = Self.date("2026-07-01T00:00:00Z")
+        let stored = LastRecommendationState(
+            generatedAt: generatedAt,
+            rateCardVersion: "rate-1",
+            demandRankVersion: "demand-1",
+            candidateCatalogVersion: "catalog-1",
+            candidateCatalogSHA256: "catalog-sha-1",
+            benchmarkID: "bench-1",
+            benchmarkGeneratedAt: generatedAt,
+            binaryVersion: "1.8.55",
+            hardwareIdentityHash: "hw-1",
+            recommendedModel: "meta-llama/llama-3.2-3b-instruct"
+        )
+
+        var catalogDigestChanged = stored
+        catalogDigestChanged.candidateCatalogSHA256 = "catalog-sha-2"
+        XCTAssertTrue(RecommendationStateStore.isStale(stored: stored, current: catalogDigestChanged, now: generatedAt))
+
+        var hardwareChanged = stored
+        hardwareChanged.hardwareIdentityHash = "hw-2"
+        XCTAssertTrue(RecommendationStateStore.isStale(stored: stored, current: hardwareChanged, now: generatedAt))
+
+        var catalogVersionChanged = stored
+        catalogVersionChanged.candidateCatalogVersion = "catalog-2"
+        XCTAssertTrue(RecommendationStateStore.isStale(stored: stored, current: catalogVersionChanged, now: generatedAt))
     }
 
     func testStatusStaleHelperMarksStoredStateStaleWhenSecretCannotBeReused() async throws {


### PR DESCRIPTION
Partial #612

<!-- SPEC-GOVERNANCE-DECLARATION-BEGIN
{
  "schema_version": "spec-pr-governance-v1",
  "behavior_change": "yes",
  "contract_change": "none",
  "specs": ["SPEC-023"],
  "requirements": ["SPEC-023-R001"],
  "authority_domains": ["installer-autotune-policy", "autotune-recommendation"],
  "arbitration": ["CODE_BUG"],
  "tests": [
    "phase3-binary/Tests/macprovider-cliTests/AutotuneRecommendTests.swift::testIsStaleIgnoresCLIVersionOnlyChange",
    "phase3-binary/Tests/macprovider-cliTests/AutotuneRecommendTests.swift::testIsStaleDetectsCompatibilityInputChanges",
    "phase3-binary/Tests/macprovider-cliTests/AutotuneRecommendTests.swift::testCachedBenchmarkAdmittedAcrossCLIVersionOnlyBump",
    "phase3-binary/Tests/macprovider-cliTests/AutotuneRecommendTests.swift::test8GBLlama32FeasibleFallbackSurvivesCLIVersionOnlyBump",
    "phase3-binary/Tests/macprovider-cliTests/AutotuneRecommendTests.swift::testCachedBenchmarkAdmissionRejectsEveryMismatch"
  ],
  "journeys": ["not-required"],
  "issue": "https://github.com/Augustas11/macprovider/issues/612"
}
SPEC-GOVERNANCE-DECLARATION-END -->

Note on SPEC-023 text: `specs/SPEC-023-installer-autotune-recommend.md` §9 / AC-25
currently documents `binary_version` as one of the inputs that should trigger a
stale-recommendation warning. This PR intentionally deviates from that specific
line per issue #612's required behavior (a CLI marketing-version-only change
must not invalidate evidence) and tracks under the existing `SPEC-023-R001`
gap (verdict `CODE_BUG`, owner `@Augustas11`, issue #612) already recorded in
`specs/CONFORMANCE.json`. The spec prose itself is not edited in this PR to
keep the diff minimal and scoped to the autotune/recommendation code + tests;
reconciling §9/AC-25 wording is left to the existing pending-reconciliation
tracking for SPEC-023.

## Summary

`RecommendationStateStore.isStale` and `cachedBenchmarkAdmitted` both keyed
evidence freshness on `binaryVersion` — the independently-versioned CLI
marketing release number. Any `macprovider-cli update` therefore:

- Discarded a healthy incumbent recommendation and its cached benchmark
  solely because the CLI version string changed.
- Forced a broad `autotune --recommend` nudge (surfaced from both `status`
  and `update`) on a pure software-only bump.
- Could collapse a feasible Llama 3.2 3B 8 GB fallback to `donor mode only`
  purely because the stale-cache check rejected the version string, even
  though hardware, model artifact, and catalog identity were unchanged.

## Fix

Bind both checks to the inputs that actually affect validity instead of the
CLI marketing version:

- `cachedBenchmarkAdmitted`: catalog row identity / digest, model ID +
  artifact SHA-256, hardware identity hash, and the existing evidence-age
  window (`maxBenchmarkAge`). `binaryVersion` no longer participates.
- `RecommendationStateStore.isStale`: rate card version, demand rank
  version, candidate catalog version + digest, hardware identity hash, and
  benchmark age. `binaryVersion` no longer participates.

Since the "Recommendation stale" nudge in both `status` and `update`
(`SelfUpdate.swift`, `MacProviderCLI.swift`) is derived entirely from
`RecommendationFreshnessChecker` → `RecommendationStateStore.isStale`, fixing
staleness at the source suppresses the spurious nudge on version-only bumps
without touching the messaging call sites directly.

Already-fixed items from the issue that this PR verifies but does not
re-touch: TPS/TTFT/swap remain advisory-only (thermal throttle is the sole
hard runtime gate), and the Llama 3.2 3B 8 GB catalog row is intact.

## Tests added (`AutotuneRecommendTests.swift`)

- `testIsStaleIgnoresCLIVersionOnlyChange` — a version-only bump with all
  compat inputs unchanged keeps `isStale` returning `false`.
- `testIsStaleDetectsCompatibilityInputChanges` — catalog digest, catalog
  version, and hardware identity changes still mark evidence stale.
- `testCachedBenchmarkAdmittedAcrossCLIVersionOnlyBump` — a cached benchmark
  recorded under an older CLI version is still admitted (and still drives
  `recommend()`) after a version-only bump.
- `test8GBLlama32FeasibleFallbackSurvivesCLIVersionOnlyBump` — an 8 GB Mac
  with a feasible (swap-flagged) Llama 3.2 3B benchmark from an older CLI
  version still recommends that model after a version bump, instead of
  collapsing to `donor mode only`.
- Updated `testCachedBenchmarkAdmissionRejectsEveryMismatch` — flipped the
  `binaryVersion`-mismatch case from reject to admit, since that dimension is
  intentionally no longer a compatibility input; all other mismatch
  dimensions (catalog digest, model ID, artifact SHA-256, hardware identity,
  evidence age) are unchanged and still reject.

I verified all four new/changed tests fail against the pre-fix source (by
temporarily stashing only the source change) and pass with it applied.

## Test results

```
swift test   # full phase3-binary suite
Executed 1519 tests, with 8 tests skipped and 0 failures (0 unexpected)
```

## Scope / out of scope

- Does not touch #616 (PATH/compat-set convergence) or #610/#658 (updater
  discovery) — no files under that scope were modified.
- Does not change TPS/TTFT/swap advisory behavior or the Llama 3.2 3B
  catalog row — verified intact, not re-implemented.
- Does not rename `spec-023`-labeled internal identifiers to
  "Model readiness check" user-facing language — out of scope for this
  minimal fix; `benchmarkID` prefix (`spec-023-…`) is not printed in normal
  (non-advanced/non-JSON) operator output today, so this is lower risk to
  leave for a follow-up.

## Remaining physical closure evidence (why this is "Partial", not "Closes")

Per the issue's closure criteria, this still needs physical proof on the
affected 8 GB Air:

1. Start the existing Llama 3.2 3B provider and prove it serves a request.
2. Run a signed CLI update.
3. Prove the same incumbent model remains selected and the provider remains
   available after restart.
4. Run recommendation diagnostics and prove swap/TPS/TTFT are reported
   without eliminating the feasible fallback.
5. Prove a second request is served after the update and diagnostics.

The code + unit test evidence in this PR is intended to unblock that
physical verification pass, not replace it.
