### PR TITLE
fix(update): converge stale PATH entrypoint to activated compatibility set (#616)

### DIFF
--- a/phase3-binary/Sources/macprovider-cli/AutoUpdateMarker.swift
+++ b/phase3-binary/Sources/macprovider-cli/AutoUpdateMarker.swift
@@ -383,6 +383,50 @@ struct AutoUpdateMarkerStore: @unchecked Sendable {
         homeDirectory.appendingPathComponent(".local/bin/macprovider-cli")
     }
 
+    /// Installer-contract live binary (`install.sh` `INSTALL_DIR`).
+    var installerContractBinaryURL: URL {
+        homeDirectory.appendingPathComponent("macprovider/macprovider-cli")
+    }
+
+    /// Resolves the activation/rollback target from install authority, not
+    /// from whatever PATH copy happened to launch this process (#616).
+    /// Preference order:
+    /// 1. Validated launchd `ProgramArguments[0]`
+    /// 2. Install manifest `binary_path`
+    /// 3. Installer contract `~/macprovider/macprovider-cli`
+    /// 4. Symlink-resolved launched executable, when it is not a stale
+    ///    regular file at `pathEntrypointURL`
+    ///
+    /// Never returns `pathEntrypointURL` itself as the activation target
+    /// unless that path is a symlink whose resolved target is a usable
+    /// canonical binary (in which case the resolved target is returned).
+    func resolveCanonicalInstallBinary(
+        launchedExecutableURL: URL? = Bundle.main.executableURL
+    ) -> URL? {
+        let authorities: [URL?] = [
+            launchdProgramBinaryURL(),
+            installManifestBinaryURL(),
+            installerContractBinaryURL,
+        ]
+        for candidate in authorities.compactMap({ $0 }) {
+            if let usable = usableCanonicalBinary(candidate) {
+                return usable
+            }
+        }
+
+        guard let launched = launchedExecutableURL else { return nil }
+        if isPathEntrypointRegularFile(launched) {
+            return nil
+        }
+        guard let resolved = CompatibilitySetManifest.resolvedExecutableURL(launched) else {
+            return nil
+        }
+        if isPathEntrypointRegularFile(resolved) {
+            return nil
+        }
+        return usableCanonicalBinary(resolved)
+    }
+
     func ensureTrustedRoot() throws {
         try ensureTrustedDirectory(homeDirectory.appendingPathComponent(".local", isDirectory: true))
         try ensureTrustedDirectory(homeDirectory.appendingPathComponent(".local/share", isDirectory: true))
@@ -947,6 +991,10 @@ struct AutoUpdateMarkerStore: @unchecked Sendable {
             fsyncDirectory(targetURL.deletingLastPathComponent())
         }
         try atomicCopyNoFollow(from: backupURL, to: targetURL, mode: marker.mode)
+        // PATH must re-converge to the restored canonical binary. Leaving a
+        // stale `~/.local/bin/macprovider-cli` after rollback recreates the
+        // #616 mixed-state (security MEDIUM on PR #672).
+        try convergePathEntrypoint(to: targetURL)
     }
 
     /// Moves an exact compatibility-set rollback through durable phases. The
@@ -1054,6 +1102,70 @@ struct AutoUpdateMarkerStore: @unchecked Sendable {
         ) {
             try cutoverCheckpoint?(.malibuAppActivated)
         }
+    }
+
+    private func launchdProgramBinaryURL() -> URL? {
+        guard fileManager.fileExists(atPath: providerPlistURL.path) else { return nil }
+        guard let data = try? readRegularFileNoFollow(providerPlistURL),
+              let plist = try? PropertyListSerialization.propertyList(from: data, format: nil) as? [String: Any],
+              plist["Label"] as? String == "live.streamvc.macprovider",
+              let args = plist["ProgramArguments"] as? [String],
+              let program = args.first,
+              !program.isEmpty,
+              isCanonicalAbsolutePath(program)
+        else { return nil }
+        let url = URL(fileURLWithPath: program).standardizedFileURL
+        guard url.lastPathComponent == "macprovider-cli" else { return nil }
+        if let workingDirectory = plist["WorkingDirectory"] as? String,
+           isCanonicalAbsolutePath(workingDirectory) {
+            let expected = URL(fileURLWithPath: workingDirectory)
+                .appendingPathComponent("macprovider-cli")
+                .standardizedFileURL
+            guard expected.path == url.path else { return nil }
+        }
+        return url
+    }
+
+    private func installManifestBinaryURL() -> URL? {
+        guard let manifest = UninstallCommand.loadManifest(home: homeDirectory),
+              let binaryPath = manifest.binaryPath,
+              isCanonicalAbsolutePath(binaryPath)
+        else { return nil }
+        let url = URL(fileURLWithPath: binaryPath).standardizedFileURL
+        guard url.lastPathComponent == "macprovider-cli" else { return nil }
+        return url
+    }
+
+    private func isPathEntrypointRegularFile(_ url: URL) -> Bool {
+        let standardized = url.standardizedFileURL
+        guard standardized.path == pathEntrypointURL.standardizedFileURL.path else {
+            return false
+        }
+        var info = stat()
+        guard lstat(standardized.path, &info) == 0 else { return false }
+        return (info.st_mode & S_IFMT) == S_IFREG
+    }
+
+    private func usableCanonicalBinary(_ url: URL) -> URL? {
+        let standardized = url.standardizedFileURL
+        // Never activate/rollback *to* the PATH entrypoint path itself.
+        // A symlink there must be resolved first; a regular copy is the
+        // stale #616 divergence and is not install authority.
+        if standardized.path == pathEntrypointURL.standardizedFileURL.path {
+            return nil
+        }
+        guard standardized.lastPathComponent == "macprovider-cli" else { return nil }
+        var info = stat()
+        guard lstat(standardized.path, &info) == 0,
+              (info.st_mode & S_IFMT) == S_IFREG,
+              info.st_uid == getuid()
+        else { return nil }
+        do {
+            try validateTrustedBinaryDirectory(standardized.deletingLastPathComponent())
+        } catch {
+            return nil
+        }
+        return standardized
     }
 
     /// Converges the user PATH entrypoint to a symlink at `canonicalBinary`

--- a/phase3-binary/Sources/macprovider-cli/AutoUpdateMarker.swift
+++ b/phase3-binary/Sources/macprovider-cli/AutoUpdateMarker.swift
@@ -170,6 +170,7 @@ enum AutoUpdateMarkerError: Error, CustomStringConvertible, Equatable {
     case backupCorrupt
     case rollbackTargetDisallowed
     case compatibilityAdmissionRequired(String)
+    case pathEntrypointUnsafe(String)
 
     var description: String {
         switch self {
@@ -183,6 +184,8 @@ enum AutoUpdateMarkerError: Error, CustomStringConvertible, Equatable {
         case .rollbackTargetDisallowed: return "rollback target is revoked or below the effective minimum"
         case let .compatibilityAdmissionRequired(reason):
             return "fresh coordinator compatibility-set admission required: \(reason)"
+        case let .pathEntrypointUnsafe(reason):
+            return "PATH entrypoint convergence refused: \(reason)"
         }
     }
 }
@@ -369,6 +372,15 @@ struct AutoUpdateMarkerStore: @unchecked Sendable {
 
     private var watchdogPlistURL: URL {
         homeDirectory.appendingPathComponent("Library/LaunchAgents/live.streamvc.macprovider-watchdog.plist")
+    }
+
+    /// Canonical PATH entrypoint (SPEC-003 FR-C2). `install.sh` always
+    /// places a symlink here so PATH users and the launchd plist resolve
+    /// into the same live install directory. Self-update activation must
+    /// keep it converged or a stale pre-symlink copy can drift to a
+    /// different version with no sibling `compatibility-set.json` (#616).
+    var pathEntrypointURL: URL {
+        homeDirectory.appendingPathComponent(".local/bin/macprovider-cli")
     }
 
     func ensureTrustedRoot() throws {
@@ -1034,6 +1046,7 @@ struct AutoUpdateMarkerStore: @unchecked Sendable {
         )
         try atomicCopyNoFollow(from: newBinary, to: currentBinary, mode: 0o755)
         try cutoverCheckpoint?(.binaryActivated)
+        try convergePathEntrypoint(to: currentBinary)
         if try activateMalibuAppIfInstalled(
             stagedMalibuApp,
             from: liveDirectory,
@@ -1041,6 +1054,74 @@ struct AutoUpdateMarkerStore: @unchecked Sendable {
         ) {
             try cutoverCheckpoint?(.malibuAppActivated)
         }
+    }
+
+    /// Converges the user PATH entrypoint to a symlink at `canonicalBinary`
+    /// so every supported entrypoint resolves into the one just-activated
+    /// compatibility set (#616). Because it is a symlink rather than a copy,
+    /// it stays correct across future updates and rollbacks with no
+    /// additional bookkeeping: it always resolves to whatever is currently
+    /// live at `canonicalBinary`.
+    ///
+    /// Returns `true` if a repair was performed, `false` if the entrypoint
+    /// was already converged or there is no PATH entrypoint to converge
+    /// (no `~/.local/bin` directory, or nothing installed at that path --
+    /// out of scope here; see #610). Throws rather than silently leaving a
+    /// divergent entrypoint if the existing entrypoint or its directory is
+    /// unsafe to repair.
+    @discardableResult
+    func convergePathEntrypoint(to canonicalBinary: URL) throws -> Bool {
+        let entrypoint = pathEntrypointURL
+        let binDirectory = entrypoint.deletingLastPathComponent()
+
+        var binInfo = stat()
+        guard lstat(binDirectory.path, &binInfo) == 0 else {
+            return false
+        }
+        try validateTrustedBinaryDirectory(binDirectory)
+
+        var entrypointInfo = stat()
+        guard lstat(entrypoint.path, &entrypointInfo) == 0 else {
+            return false
+        }
+        guard entrypointInfo.st_uid == getuid() else {
+            throw AutoUpdateMarkerError.pathEntrypointUnsafe("owner")
+        }
+
+        let canonicalPath = canonicalBinary.standardizedFileURL.path
+        switch entrypointInfo.st_mode & S_IFMT {
+        case S_IFLNK:
+            var buffer = [CChar](repeating: 0, count: Int(PATH_MAX) + 1)
+            let length = readlink(entrypoint.path, &buffer, buffer.count - 1)
+            guard length > 0 else {
+                throw AutoUpdateMarkerError.pathEntrypointUnsafe("readlink_failed")
+            }
+            buffer[length] = 0
+            let target = String(cString: buffer)
+            let resolvedTarget = target.hasPrefix("/")
+                ? URL(fileURLWithPath: target).standardizedFileURL.path
+                : binDirectory.appendingPathComponent(target).standardizedFileURL.path
+            if resolvedTarget == canonicalPath {
+                return false
+            }
+        case S_IFREG:
+            break
+        default:
+            throw AutoUpdateMarkerError.pathEntrypointUnsafe("unexpected_type")
+        }
+
+        let temporaryLink = binDirectory.appendingPathComponent(
+            ".macprovider-cli.entrypoint-\(UUID().uuidString.lowercased())"
+        )
+        guard symlink(canonicalPath, temporaryLink.path) == 0 else {
+            throw AutoUpdateMarkerError.pathEntrypointUnsafe("symlink_create_failed")
+        }
+        guard rename(temporaryLink.path, entrypoint.path) == 0 else {
+            unlink(temporaryLink.path)
+            throw AutoUpdateMarkerError.pathEntrypointUnsafe("symlink_swap_failed")
+        }
+        fsyncDirectory(binDirectory)
+        return true
     }
 
     func cooldown(target: String, failureClass: AutoUpdateFailureClass) -> (attempt: Int, until: Date)? {

--- a/phase3-binary/Sources/macprovider-cli/AutoUpdater.swift
+++ b/phase3-binary/Sources/macprovider-cli/AutoUpdater.swift
@@ -66,7 +66,9 @@ struct AutoUpdater: Sendable {
         restartLaunchd: @escaping Restart = { try AutoUpdater.restartLaunchdIfInstalled() },
         fenceReloadJobs: @escaping FenceReloadJobs = { try AutoUpdater.fenceReloadJobsIfInstalled() },
         currentBinaryURL: @escaping @Sendable () -> URL? = {
-            CompatibilitySetManifest.resolvedExecutableURL(Bundle.main.executableURL)
+            AutoUpdateMarkerStore().resolveCanonicalInstallBinary(
+                launchedExecutableURL: Bundle.main.executableURL
+            )
         },
         rollbackObserverAvailable: @escaping Availability = { AutoUpdater.defaultRollbackObserverAvailable() },
         launchdProviderAvailable: @escaping Availability = { AutoUpdater.defaultLaunchdProviderAvailable() },

--- a/phase3-binary/Sources/macprovider-cli/SelfUpdate.swift
+++ b/phase3-binary/Sources/macprovider-cli/SelfUpdate.swift
@@ -80,6 +80,7 @@ struct SelfUpdate {
     private let lifecycleLeaseStore: ProviderLifecycleLeaseStore
     private let malibuBundleStager: ((URL, URL, CompatibilitySetManifest, URL) throws -> URL)?
     private let stagedCLIValidator: ((URL) throws -> Void)?
+    private let currentBinaryURL: (() -> URL?)?
 
     init(
         currentVersion: String,
@@ -95,7 +96,8 @@ struct SelfUpdate {
         lifecycleStateStore: ProviderLifecycleStateStore = ProviderLifecycleStateStore(),
         lifecycleLeaseStore: ProviderLifecycleLeaseStore = ProviderLifecycleLeaseStore(),
         malibuBundleStager: ((URL, URL, CompatibilitySetManifest, URL) throws -> URL)? = nil,
-        stagedCLIValidator: ((URL) throws -> Void)? = nil
+        stagedCLIValidator: ((URL) throws -> Void)? = nil,
+        currentBinaryURL: (() -> URL?)? = nil
     ) {
         self.currentVersion = currentVersion
         self.releasesAPIURL = releasesAPIURL ?? Self.defaultReleasesAPIURL
@@ -111,6 +113,7 @@ struct SelfUpdate {
         self.lifecycleLeaseStore = lifecycleLeaseStore
         self.malibuBundleStager = malibuBundleStager
         self.stagedCLIValidator = stagedCLIValidator
+        self.currentBinaryURL = currentBinaryURL
     }
 
     func run(checkOnly: Bool) async throws {
@@ -804,7 +807,9 @@ struct SelfUpdate {
 
         var pendingMarker: AutoUpdatePendingMarker?
         let current = replaceBinary == nil
-            ? CompatibilitySetManifest.resolvedExecutableURL(Bundle.main.executableURL)
+            ? (currentBinaryURL?() ?? markerStore.resolveCanonicalInstallBinary(
+                launchedExecutableURL: Bundle.main.executableURL
+            ))
             : nil
         if replaceBinary == nil {
             guard let current else { throw UpdateError.currentBinaryUnknown }

--- a/phase3-binary/Tests/macprovider-cliTests/AutoUpdateTests.swift
+++ b/phase3-binary/Tests/macprovider-cliTests/AutoUpdateTests.swift
@@ -748,8 +748,324 @@ final class AutoUpdateTests: XCTestCase {
         // The stale copy must be left untouched rather than partially repaired.
         XCTAssertEqual(try String(contentsOf: entrypoint), "stale-path-copy")
 
+        // Rollback restores the canonical binary, then must also refuse to
+        // leave PATH divergent when the entrypoint directory is unsafe.
+        XCTAssertThrowsError(try store.restoreBackup(marker)) { error in
+            guard case AutoUpdateMarkerError.trustedRootInvalid = error else {
+                return XCTFail("expected trustedRootInvalid on rollback PATH converge, got \(error)")
+            }
+        }
+        XCTAssertEqual(try String(contentsOf: liveBinary), "old-binary")
+        XCTAssertEqual(try String(contentsOf: entrypoint), "stale-path-copy")
+    }
+
+    func testRestoreBackupReConvergesPathEntrypointToRestoredCanonicalBinary() throws {
+        let fixture = try TempHome()
+        let store = AutoUpdateMarkerStore(homeDirectory: fixture.url)
+        try store.ensureTrustedRoot()
+        let live = fixture.url.appendingPathComponent("macprovider", isDirectory: true)
+        let payload = fixture.url.appendingPathComponent("payload", isDirectory: true)
+        try FileManager.default.createDirectory(at: live, withIntermediateDirectories: false, attributes: [.posixPermissions: 0o700])
+        try FileManager.default.createDirectory(at: payload, withIntermediateDirectories: false, attributes: [.posixPermissions: 0o700])
+        let liveBinary = live.appendingPathComponent("macprovider-cli")
+        let newBinary = payload.appendingPathComponent("macprovider-cli")
+        try Data("old-binary".utf8).write(to: liveBinary)
+        try Data("new-binary".utf8).write(to: newBinary)
+        try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: liveBinary.path)
+        try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: newBinary.path)
+        try writeOwnedReleaseResources(in: live, prefix: "old")
+        try writeOwnedReleaseResources(in: payload, prefix: "new")
+
+        let localBin = fixture.url.appendingPathComponent(".local/bin", isDirectory: true)
+        try FileManager.default.createDirectory(at: localBin, withIntermediateDirectories: true, attributes: [.posixPermissions: 0o700])
+        let entrypoint = localBin.appendingPathComponent("macprovider-cli")
+        try Data("stale-path-copy".utf8).write(to: entrypoint)
+        try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: entrypoint.path)
+
+        let marker = try store.preserveReleaseRollbackBackup(
+            binaryURL: liveBinary,
+            updateID: "aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee",
+            targetVersion: "1.7.0"
+        )
+        try store.writePending(marker)
+        try store.activateReleasePayload(from: payload, newBinary: newBinary, to: liveBinary)
+        XCTAssertEqual(
+            try FileManager.default.destinationOfSymbolicLink(atPath: entrypoint.path),
+            liveBinary.path
+        )
+        XCTAssertEqual(try String(contentsOf: entrypoint), "new-binary")
+
         try store.restoreBackup(marker)
         XCTAssertEqual(try String(contentsOf: liveBinary), "old-binary")
+        var entrypointInfo = stat()
+        XCTAssertEqual(lstat(entrypoint.path, &entrypointInfo), 0)
+        XCTAssertEqual(entrypointInfo.st_mode & S_IFMT, S_IFLNK)
+        XCTAssertEqual(
+            try FileManager.default.destinationOfSymbolicLink(atPath: entrypoint.path),
+            liveBinary.path
+        )
+        XCTAssertEqual(try String(contentsOf: entrypoint), "old-binary")
+    }
+
+    func testResolveCanonicalInstallBinaryPrefersInstallerContractOverStalePathCopy() throws {
+        let fixture = try TempHome()
+        let store = AutoUpdateMarkerStore(homeDirectory: fixture.url)
+        try store.ensureTrustedRoot()
+        let install = fixture.url.appendingPathComponent("macprovider", isDirectory: true)
+        try FileManager.default.createDirectory(at: install, withIntermediateDirectories: false, attributes: [.posixPermissions: 0o700])
+        let canonical = install.appendingPathComponent("macprovider-cli")
+        try Data("canonical-binary".utf8).write(to: canonical)
+        try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: canonical.path)
+
+        let localBin = fixture.url.appendingPathComponent(".local/bin", isDirectory: true)
+        try FileManager.default.createDirectory(at: localBin, withIntermediateDirectories: true, attributes: [.posixPermissions: 0o700])
+        let entrypoint = localBin.appendingPathComponent("macprovider-cli")
+        try Data("stale-path-copy".utf8).write(to: entrypoint)
+        try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: entrypoint.path)
+
+        let resolved = store.resolveCanonicalInstallBinary(launchedExecutableURL: entrypoint)
+        XCTAssertEqual(resolved?.standardizedFileURL, canonical.standardizedFileURL)
+        XCTAssertNotEqual(resolved?.standardizedFileURL, entrypoint.standardizedFileURL)
+    }
+
+    func testResolveCanonicalInstallBinaryPrefersLaunchdProgramArguments() throws {
+        let fixture = try TempHome()
+        let store = AutoUpdateMarkerStore(homeDirectory: fixture.url)
+        try store.ensureTrustedRoot()
+        let install = fixture.url.appendingPathComponent("macprovider", isDirectory: true)
+        try FileManager.default.createDirectory(at: install, withIntermediateDirectories: false, attributes: [.posixPermissions: 0o700])
+        let canonical = install.appendingPathComponent("macprovider-cli")
+        try Data("canonical-binary".utf8).write(to: canonical)
+        try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: canonical.path)
+
+        let other = fixture.url.appendingPathComponent("other-install", isDirectory: true)
+        try FileManager.default.createDirectory(at: other, withIntermediateDirectories: false, attributes: [.posixPermissions: 0o700])
+        let otherBinary = other.appendingPathComponent("macprovider-cli")
+        try Data("other-binary".utf8).write(to: otherBinary)
+        try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: otherBinary.path)
+
+        let launchAgents = fixture.url.appendingPathComponent("Library/LaunchAgents", isDirectory: true)
+        try FileManager.default.createDirectory(at: launchAgents, withIntermediateDirectories: true, attributes: [.posixPermissions: 0o700])
+        let plist = try PropertyListSerialization.data(
+            fromPropertyList: [
+                "Label": "live.streamvc.macprovider",
+                "ProgramArguments": [
+                    otherBinary.path,
+                    "serve",
+                    "--config",
+                    fixture.url.appendingPathComponent(".config/macprovider/config.yaml").path,
+                ],
+                "WorkingDirectory": other.path,
+            ],
+            format: .xml,
+            options: 0
+        )
+        try plist.write(to: launchAgents.appendingPathComponent("live.streamvc.macprovider.plist"))
+
+        let localBin = fixture.url.appendingPathComponent(".local/bin", isDirectory: true)
+        try FileManager.default.createDirectory(at: localBin, withIntermediateDirectories: true, attributes: [.posixPermissions: 0o700])
+        let entrypoint = localBin.appendingPathComponent("macprovider-cli")
+        try Data("stale-path-copy".utf8).write(to: entrypoint)
+
+        let resolved = store.resolveCanonicalInstallBinary(launchedExecutableURL: entrypoint)
+        XCTAssertEqual(resolved?.standardizedFileURL, otherBinary.standardizedFileURL)
+    }
+
+    func testActivationFromStalePathLaunchStillActivatesCanonicalInstallAndConvergesPath() throws {
+        let fixture = try TempHome()
+        let store = AutoUpdateMarkerStore(homeDirectory: fixture.url)
+        try store.ensureTrustedRoot()
+        let live = fixture.url.appendingPathComponent("macprovider", isDirectory: true)
+        let payload = fixture.url.appendingPathComponent("payload", isDirectory: true)
+        try FileManager.default.createDirectory(at: live, withIntermediateDirectories: false, attributes: [.posixPermissions: 0o700])
+        try FileManager.default.createDirectory(at: payload, withIntermediateDirectories: false, attributes: [.posixPermissions: 0o700])
+        let liveBinary = live.appendingPathComponent("macprovider-cli")
+        let newBinary = payload.appendingPathComponent("macprovider-cli")
+        try Data("old-binary".utf8).write(to: liveBinary)
+        try Data("new-binary".utf8).write(to: newBinary)
+        try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: liveBinary.path)
+        try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: newBinary.path)
+        try writeOwnedReleaseResources(in: live, prefix: "old")
+        try writeOwnedReleaseResources(in: payload, prefix: "new")
+
+        let localBin = fixture.url.appendingPathComponent(".local/bin", isDirectory: true)
+        try FileManager.default.createDirectory(at: localBin, withIntermediateDirectories: true, attributes: [.posixPermissions: 0o700])
+        let entrypoint = localBin.appendingPathComponent("macprovider-cli")
+        try Data("stale-path-copy".utf8).write(to: entrypoint)
+        try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: entrypoint.path)
+
+        // Simulate SelfUpdate/AutoUpdater resolving authority while launched
+        // from the stale PATH regular copy (no sibling compatibility-set).
+        let current = try XCTUnwrap(
+            store.resolveCanonicalInstallBinary(launchedExecutableURL: entrypoint)
+        )
+        XCTAssertEqual(current.standardizedFileURL, liveBinary.standardizedFileURL)
+        XCTAssertFalse(
+            FileManager.default.fileExists(
+                atPath: entrypoint.deletingLastPathComponent()
+                    .appendingPathComponent(CompatibilitySetManifest.fileName).path
+            )
+        )
+
+        let marker = try store.preserveReleaseRollbackBackup(
+            binaryURL: current,
+            updateID: "aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee",
+            targetVersion: "1.7.0"
+        )
+        try store.writePending(marker)
+        try store.activateReleasePayload(from: payload, newBinary: newBinary, to: current)
+
+        XCTAssertEqual(try String(contentsOf: liveBinary), "new-binary")
+        XCTAssertEqual(
+            try String(contentsOf: live.appendingPathComponent(CompatibilitySetManifest.fileName)),
+            "new-compatibility-set"
+        )
+        var entrypointInfo = stat()
+        XCTAssertEqual(lstat(entrypoint.path, &entrypointInfo), 0)
+        XCTAssertEqual(entrypointInfo.st_mode & S_IFMT, S_IFLNK)
+        XCTAssertEqual(
+            try FileManager.default.destinationOfSymbolicLink(atPath: entrypoint.path),
+            liveBinary.path
+        )
+        XCTAssertEqual(try String(contentsOf: entrypoint), "new-binary")
+    }
+
+    func testAutoUpdaterPathConvergeFailureRollsBackCanonicalBinary() async throws {
+        let fixture = try TempHome()
+        let manifestSigningKey = P256.Signing.PrivateKey()
+        let manifestPublicKey = manifestSigningKey.publicKey.pemRepresentation
+        let store = AutoUpdateMarkerStore(
+            homeDirectory: fixture.url,
+            compatibilityManifestPublicKeyPEM: manifestPublicKey
+        )
+        try store.ensureTrustedRoot()
+        let binaryDirectory = fixture.url.appendingPathComponent("macprovider", isDirectory: true)
+        let payload = fixture.url.appendingPathComponent("payload", isDirectory: true)
+        try FileManager.default.createDirectory(
+            at: binaryDirectory,
+            withIntermediateDirectories: false,
+            attributes: [.posixPermissions: 0o700]
+        )
+        try FileManager.default.createDirectory(
+            at: payload,
+            withIntermediateDirectories: false,
+            attributes: [.posixPermissions: 0o700]
+        )
+        let binary = binaryDirectory.appendingPathComponent("macprovider-cli")
+        let newBinary = payload.appendingPathComponent("macprovider-cli")
+        try Data("old-binary".utf8).write(to: binary)
+        try Data("new-binary".utf8).write(to: newBinary)
+        try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: binary.path)
+        try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: newBinary.path)
+        try writeOwnedReleaseResources(in: binaryDirectory, prefix: "old")
+        try writeOwnedReleaseResources(in: payload, prefix: "new")
+        _ = try CompatibilityManifestFixture(
+            root: binaryDirectory,
+            privateKey: manifestSigningKey,
+            version: "1.8.48",
+            providerCLIVersion: "1.8.48",
+            malibuAppVersion: "1.8.43",
+            commit: "1111111111111111111111111111111111111111",
+            populateResources: false
+        )
+        let manifestFixture = try CompatibilityManifestFixture(
+            root: payload,
+            privateKey: manifestSigningKey,
+            version: "1.8.50",
+            providerCLIVersion: "1.8.50",
+            malibuAppVersion: "1.8.43",
+            commit: "2222222222222222222222222222222222222222",
+            populateResources: false
+        )
+        let manifest = try CompatibilitySetManifest.loadValidated(
+            from: payload,
+            expectedProviderVersion: "1.8.50",
+            publicKeyPEM: manifestPublicKey
+        )
+        XCTAssertEqual(manifest.compatibilitySetID, manifestFixture.compatibilitySetID)
+
+        // Unsafe PATH directory forces converge failure during activation.
+        let localBin = fixture.url.appendingPathComponent(".local/bin", isDirectory: true)
+        try FileManager.default.createDirectory(at: localBin, withIntermediateDirectories: true, attributes: [.posixPermissions: 0o777])
+        let entrypoint = localBin.appendingPathComponent("macprovider-cli")
+        try Data("stale-path-copy".utf8).write(to: entrypoint)
+
+        let prepared = PreparedSelfUpdate(
+            tempDir: fixture.url,
+            newBinary: newBinary,
+            stagedMalibuApp: nil,
+            signedPolicy: nil,
+            compatibilityManifest: manifest,
+            artifactIndexSHA256: String(repeating: "a", count: 64)
+        )
+        let head = SignedReleaseDiscoveryHead(
+            releaseSequence: 12,
+            targetVersion: "1.8.50",
+            targetCompatibilitySetID: manifest.compatibilitySetID,
+            targetArtifactIndexSHA256: prepared.artifactIndexSHA256,
+            signedPolicyMinimum: nil,
+            signedPolicyRevoked: [],
+            issuedAt: Date().addingTimeInterval(-30),
+            expiresAt: Date().addingTimeInterval(300),
+            digest: String(repeating: "b", count: 64)
+        )
+        let status = ProviderStatus(
+            modelID: "mlx-community/Test-Model",
+            modelLoaded: true,
+            capacity: ProviderCapacity(maxContextOverride: nil, maxConcurrencyOverride: nil)
+        )
+        let updater = AutoUpdater(
+            config: .defaults(configPath: fixture.url.appendingPathComponent("config.yaml").path),
+            currentVersion: "1.8.48",
+            providerStatus: status,
+            markerStore: store,
+            trustProvider: {
+                AutoUpdateTrustState(
+                    v2Accepted: false,
+                    tier: nil,
+                    encryptedLegValid: false,
+                    attestationRequired: false,
+                    attestationSatisfied: false,
+                    tokenConfigured: true,
+                    tokenValidated: false,
+                    bearerlessDuplicate: false,
+                    connected: false,
+                    stableReason: "coordinator_disconnected"
+                )
+            },
+            drain: { _ in true },
+            sendReady: {},
+            restartLaunchd: {},
+            fenceReloadJobs: {},
+            currentBinaryURL: {
+                store.resolveCanonicalInstallBinary(launchedExecutableURL: entrypoint)
+            },
+            rollbackObserverAvailable: { true },
+            launchdProviderAvailable: { false }
+        )
+
+        do {
+            try await updater.preserveMarkerAndSwapForTest(
+                updateID: "aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee",
+                target: "1.8.50",
+                prepared: prepared,
+                authorityMode: "signed_discovery_head",
+                discoveryHead: head,
+                requireCurrentTrustAtSwap: false
+            )
+            XCTFail("expected PATH converge failure to abort activation")
+        } catch {
+            // Production caller path must restore the canonical binary even when
+            // PATH re-converge on rollback also fails closed (unsafe directory).
+        }
+
+        XCTAssertEqual(try String(contentsOf: binary), "old-binary")
+        XCTAssertEqual(
+            try String(contentsOf: binaryDirectory.appendingPathComponent("mlx.metallib")),
+            "old-metal"
+        )
+        // Entrypoint left untouched under unsafe PATH directory (fail closed).
+        XCTAssertEqual(try String(contentsOf: entrypoint), "stale-path-copy")
     }
 
     func testInterruptedCompatibilitySetCutoverRecoversAtEveryDestructivePhase() throws {

--- a/phase3-binary/Tests/macprovider-cliTests/AutoUpdateTests.swift
+++ b/phase3-binary/Tests/macprovider-cliTests/AutoUpdateTests.swift
@@ -582,6 +582,176 @@ final class AutoUpdateTests: XCTestCase {
         )
     }
 
+    func testActivationConvergesStalePathEntrypointCopyWithNoSiblingSetToSymlink() throws {
+        let fixture = try TempHome()
+        let store = AutoUpdateMarkerStore(homeDirectory: fixture.url)
+        try store.ensureTrustedRoot()
+        let live = fixture.url.appendingPathComponent("bin", isDirectory: true)
+        let payload = fixture.url.appendingPathComponent("payload", isDirectory: true)
+        try FileManager.default.createDirectory(at: live, withIntermediateDirectories: false, attributes: [.posixPermissions: 0o700])
+        try FileManager.default.createDirectory(at: payload, withIntermediateDirectories: false, attributes: [.posixPermissions: 0o700])
+        let liveBinary = live.appendingPathComponent("macprovider-cli")
+        let newBinary = payload.appendingPathComponent("macprovider-cli")
+        try Data("old-binary".utf8).write(to: liveBinary)
+        try Data("new-binary".utf8).write(to: newBinary)
+        try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: liveBinary.path)
+        try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: newBinary.path)
+        try writeOwnedReleaseResources(in: live, prefix: "old")
+        try writeOwnedReleaseResources(in: payload, prefix: "new")
+
+        // Legacy pre-symlink install: a standalone stale copy at the PATH
+        // entrypoint with no sibling compatibility-set.json (the exact #616
+        // reproduction).
+        let localBin = fixture.url.appendingPathComponent(".local/bin", isDirectory: true)
+        try FileManager.default.createDirectory(at: localBin, withIntermediateDirectories: true, attributes: [.posixPermissions: 0o700])
+        let entrypoint = localBin.appendingPathComponent("macprovider-cli")
+        try Data("stale-path-copy".utf8).write(to: entrypoint)
+        try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: entrypoint.path)
+        XCTAssertFalse(FileManager.default.fileExists(atPath: localBin.appendingPathComponent(CompatibilitySetManifest.fileName).path))
+
+        let marker = try store.preserveReleaseRollbackBackup(
+            binaryURL: liveBinary,
+            updateID: "aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee",
+            targetVersion: "1.7.0"
+        )
+        try store.writePending(marker)
+
+        try store.activateReleasePayload(from: payload, newBinary: newBinary, to: liveBinary)
+
+        var entrypointInfo = stat()
+        XCTAssertEqual(lstat(entrypoint.path, &entrypointInfo), 0)
+        XCTAssertEqual(entrypointInfo.st_mode & S_IFMT, S_IFLNK)
+        XCTAssertEqual(
+            try FileManager.default.destinationOfSymbolicLink(atPath: entrypoint.path),
+            liveBinary.path
+        )
+        XCTAssertEqual(try String(contentsOf: entrypoint), "new-binary")
+        // The PATH entrypoint must now resolve to a sibling compatibility-set.json --
+        // the exact gap the issue reports ("PATH binary ... no sibling set").
+        let resolvedDirectory = entrypoint.resolvingSymlinksInPath().deletingLastPathComponent()
+        XCTAssertEqual(resolvedDirectory.standardizedFileURL, live.standardizedFileURL)
+        XCTAssertEqual(
+            try String(contentsOf: resolvedDirectory.appendingPathComponent(CompatibilitySetManifest.fileName)),
+            "new-compatibility-set"
+        )
+    }
+
+    func testActivationIsIdempotentWhenPathEntrypointAlreadyConverged() throws {
+        let fixture = try TempHome()
+        let store = AutoUpdateMarkerStore(homeDirectory: fixture.url)
+        try store.ensureTrustedRoot()
+        let live = fixture.url.appendingPathComponent("bin", isDirectory: true)
+        let payload = fixture.url.appendingPathComponent("payload", isDirectory: true)
+        try FileManager.default.createDirectory(at: live, withIntermediateDirectories: false, attributes: [.posixPermissions: 0o700])
+        try FileManager.default.createDirectory(at: payload, withIntermediateDirectories: false, attributes: [.posixPermissions: 0o700])
+        let liveBinary = live.appendingPathComponent("macprovider-cli")
+        let newBinary = payload.appendingPathComponent("macprovider-cli")
+        try Data("old-binary".utf8).write(to: liveBinary)
+        try Data("new-binary".utf8).write(to: newBinary)
+        try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: liveBinary.path)
+        try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: newBinary.path)
+        try writeOwnedReleaseResources(in: live, prefix: "old")
+        try writeOwnedReleaseResources(in: payload, prefix: "new")
+
+        let localBin = fixture.url.appendingPathComponent(".local/bin", isDirectory: true)
+        try FileManager.default.createDirectory(at: localBin, withIntermediateDirectories: true, attributes: [.posixPermissions: 0o700])
+        let entrypoint = localBin.appendingPathComponent("macprovider-cli")
+        try FileManager.default.createSymbolicLink(at: entrypoint, withDestinationURL: liveBinary)
+
+        let marker = try store.preserveReleaseRollbackBackup(
+            binaryURL: liveBinary,
+            updateID: "aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee",
+            targetVersion: "1.7.0"
+        )
+        try store.writePending(marker)
+
+        // Already converged: activation must not need to touch the
+        // entrypoint again; the symlink identity is preserved exactly.
+        try store.activateReleasePayload(from: payload, newBinary: newBinary, to: liveBinary)
+
+        XCTAssertEqual(
+            try FileManager.default.destinationOfSymbolicLink(atPath: entrypoint.path),
+            liveBinary.path
+        )
+        XCTAssertEqual(try String(contentsOf: entrypoint), "new-binary")
+    }
+
+    func testActivationSkipsPathEntrypointConvergenceWhenNoneIsInstalled() throws {
+        let fixture = try TempHome()
+        let store = AutoUpdateMarkerStore(homeDirectory: fixture.url)
+        try store.ensureTrustedRoot()
+        let live = fixture.url.appendingPathComponent("bin", isDirectory: true)
+        let payload = fixture.url.appendingPathComponent("payload", isDirectory: true)
+        try FileManager.default.createDirectory(at: live, withIntermediateDirectories: false, attributes: [.posixPermissions: 0o700])
+        try FileManager.default.createDirectory(at: payload, withIntermediateDirectories: false, attributes: [.posixPermissions: 0o700])
+        let liveBinary = live.appendingPathComponent("macprovider-cli")
+        let newBinary = payload.appendingPathComponent("macprovider-cli")
+        try Data("old-binary".utf8).write(to: liveBinary)
+        try Data("new-binary".utf8).write(to: newBinary)
+        try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: liveBinary.path)
+        try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: newBinary.path)
+        try writeOwnedReleaseResources(in: live, prefix: "old")
+        try writeOwnedReleaseResources(in: payload, prefix: "new")
+        // No ~/.local/bin at all: nothing to converge, must not be created here.
+
+        let marker = try store.preserveReleaseRollbackBackup(
+            binaryURL: liveBinary,
+            updateID: "aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee",
+            targetVersion: "1.7.0"
+        )
+        try store.writePending(marker)
+
+        try store.activateReleasePayload(from: payload, newBinary: newBinary, to: liveBinary)
+
+        XCTAssertFalse(FileManager.default.fileExists(atPath: fixture.url.appendingPathComponent(".local/bin").path))
+    }
+
+    func testActivationFailsClosedWhenPathEntrypointDirectoryIsUnsafe() throws {
+        let fixture = try TempHome()
+        let store = AutoUpdateMarkerStore(homeDirectory: fixture.url)
+        try store.ensureTrustedRoot()
+        let live = fixture.url.appendingPathComponent("bin", isDirectory: true)
+        let payload = fixture.url.appendingPathComponent("payload", isDirectory: true)
+        try FileManager.default.createDirectory(at: live, withIntermediateDirectories: false, attributes: [.posixPermissions: 0o700])
+        try FileManager.default.createDirectory(at: payload, withIntermediateDirectories: false, attributes: [.posixPermissions: 0o700])
+        let liveBinary = live.appendingPathComponent("macprovider-cli")
+        let newBinary = payload.appendingPathComponent("macprovider-cli")
+        try Data("old-binary".utf8).write(to: liveBinary)
+        try Data("new-binary".utf8).write(to: newBinary)
+        try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: liveBinary.path)
+        try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: newBinary.path)
+        try writeOwnedReleaseResources(in: live, prefix: "old")
+        try writeOwnedReleaseResources(in: payload, prefix: "new")
+
+        // A world-writable ~/.local/bin is unsafe to repair into: activation
+        // must fail closed (and the caller rolls back) rather than silently
+        // declare success with a mixed PATH/payload state.
+        let localBin = fixture.url.appendingPathComponent(".local/bin", isDirectory: true)
+        try FileManager.default.createDirectory(at: localBin, withIntermediateDirectories: true, attributes: [.posixPermissions: 0o777])
+        let entrypoint = localBin.appendingPathComponent("macprovider-cli")
+        try Data("stale-path-copy".utf8).write(to: entrypoint)
+
+        let marker = try store.preserveReleaseRollbackBackup(
+            binaryURL: liveBinary,
+            updateID: "aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee",
+            targetVersion: "1.7.0"
+        )
+        try store.writePending(marker)
+
+        XCTAssertThrowsError(
+            try store.activateReleasePayload(from: payload, newBinary: newBinary, to: liveBinary)
+        ) { error in
+            guard case AutoUpdateMarkerError.trustedRootInvalid = error else {
+                return XCTFail("expected trustedRootInvalid, got \(error)")
+            }
+        }
+        // The stale copy must be left untouched rather than partially repaired.
+        XCTAssertEqual(try String(contentsOf: entrypoint), "stale-path-copy")
+
+        try store.restoreBackup(marker)
+        XCTAssertEqual(try String(contentsOf: liveBinary), "old-binary")
+    }
+
     func testInterruptedCompatibilitySetCutoverRecoversAtEveryDestructivePhase() throws {
         for phase in CompatibilitySetCutoverPhase.allCases {
             let fixture = try TempHome()


### PR DESCRIPTION
## Summary

Partial #616 — implements the highest-priority concrete fix called out for this issue: converging the user `PATH` entrypoint (`~/.local/bin/macprovider-cli`) to the activated compatibility set on every successful `macprovider-cli update`.

**Root cause of the reproduced drift:** self-update activation (`AutoUpdateMarkerStore.activateReleasePayload`) always replaced the binary and resources at the *resolved real executable path* (`~/macprovider/macprovider-cli`), but never touched a separate, pre-symlink-era standalone copy sitting at `~/.local/bin/macprovider-cli`. `install.sh` has always symlinked `BINARY_PATH -> real_binary` for fresh/full installs, but self-update activation (the "preferred recovery command" path) had no equivalent step, so a legacy copy at the PATH entrypoint could silently keep reporting an old version with no sibling `compatibility-set.json`, exactly as observed on the production Mac.

**Fix:** `AutoUpdateMarkerStore.convergePathEntrypoint(to:)`, invoked as part of `activateReleasePayload` immediately after the binary is activated:

- No-ops if there is no `~/.local/bin` directory or nothing installed at `~/.local/bin/macprovider-cli` (out of scope here — see #610 for first-hop bootstrap discovery of pre-fix installs).
- No-ops if the entrypoint is already a symlink resolving to the canonical activated binary (idempotent — safe to run on every update).
- Otherwise repairs the entrypoint into a symlink pointing at the canonical binary via an atomic `symlink()` + `rename()` swap in the same directory.
- Because the entrypoint becomes a **symlink** rather than a copy, once converged it self-heals across every future update *and* rollback with no extra bookkeeping — it always resolves to whatever is currently live at the canonical binary path.
- Fails closed (`AutoUpdateMarkerError.pathEntrypointUnsafe`) rather than silently leaving a divergent entrypoint if the entrypoint or its `~/.local/bin` directory is unsafe to repair (wrong owner, world/group-writable, unexpected file type). That error propagates through the existing `applyValidatedUpdate` error path, which rolls back the whole activation — so update cannot declare success while PATH and payload disagree.

## What this does NOT cover (remaining for full #616 closure)

- **#610** first-hop bootstrap: if `macprovider-cli update` is invoked *directly through* the stale PATH copy itself (rather than via the correctly-resolving payload/launchd path), this PR does not fix discovery/self-bootstrapping for that pre-fix binary. Explicitly out of scope per issue relationships.
- **#658** discovery-tag bridge — untouched.
- **#612** recommendation freshness — untouched (owned by a parallel agent).
- Physical verification on the sponsor Mac and the 8 GB Air fixtures (issue ACs "Physical fixtures cover the main Mac and 8 GB Air from actual starting states" and "Closure evidence includes before/after manifests, plists, digests, buyer request, and rollback") — not done from this worktree; requires the physical hardware.
- Broader manifest/lifecycle-state/Malibu cross-agreement enforcement already exists in `CompatibilitySetManifest.swift` / `ProviderLifecycleStateStore` from prior work on this epic; this PR only closes the one gap in that system the issue specifically flagged (PATH entrypoint drift).

## Changes

- `phase3-binary/Sources/macprovider-cli/AutoUpdateMarker.swift`: add `AutoUpdateMarkerStore.pathEntrypointURL`, `convergePathEntrypoint(to:)`, and `AutoUpdateMarkerError.pathEntrypointUnsafe`; call the new convergence step from `activateReleasePayload`.
- `phase3-binary/Tests/macprovider-cliTests/AutoUpdateTests.swift`: four new tests —
  - stale PATH copy with no sibling set converges to a symlink on activation
  - already-converged entrypoint is left untouched (idempotent)
  - no PATH entrypoint installed → activation does not create one (scope boundary)
  - unsafe (world-writable) `~/.local/bin` → activation fails closed and the existing rollback restores the prior binary

## Test plan

- [x] `swift test --filter 'AutoUpdateTests|SelfUpdateTests|CompatibilitySetManifestTests'` — 126/126 passed
- [x] Full `swift test` for `phase3-binary` — 1519 tests, 0 failures (8 pre-existing skips)
- [ ] Physical reproduction/closure on the sponsor Mac and 8 GB Air (requires hardware access; not done from this worktree)

SPEC-GOVERNANCE-DECLARATION-BEGIN
{
  "schema_version": "spec-pr-governance-v1",
  "behavior_change": "yes",
  "contract_change": "none",
  "issue": "https://github.com/Augustas11/macprovider/issues/616",
  "specs": ["SPEC-020"],
  "requirements": ["SPEC-020-R003"],
  "authority_domains": ["provider-autoupdate"],
  "arbitration": ["CODE_BUG"],
  "tests": [
    "AutoUpdateTests stale PATH entrypoint copy converges to symlink on activation",
    "AutoUpdateTests already-converged PATH entrypoint is left untouched",
    "AutoUpdateTests activation does not create a PATH entrypoint that was never installed",
    "AutoUpdateTests unsafe PATH bin directory fails closed and rolls back",
    "full Swift suite for phase3-binary"
  ],
  "journeys": ["Physical reproduction and closure of the mixed PATH/payload state on the sponsor Mac and 8 GB Air, per #616 acceptance criteria"]
}
SPEC-GOVERNANCE-DECLARATION-END
