### PR TITLE
Prepare one v1.8.57 updater-cluster acceptance identity

### DIFF
--- a/.github/workflows/acceptance-candidate.yml
+++ b/.github/workflows/acceptance-candidate.yml
@@ -112,7 +112,7 @@ jobs:
       - name: Setup Go for candidate Pearl binaries
         uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16
         with:
-          go-version: "1.26.4"
+          go-version: "1.26.5"
           cache-dependency-path: |
             candidate/phase4-coordinator/go.sum
             candidate/phase5-gateway/go.sum

--- a/phase3-binary/Sources/macprovider-cli/CoordinatorClient.swift
+++ b/phase3-binary/Sources/macprovider-cli/CoordinatorClient.swift
@@ -146,7 +146,7 @@ actor CoordinatorClient {
     typealias InstalledCompatibilityManifest = @Sendable (URL, String) -> CompatibilitySetManifest?
     typealias ReloadHelperFence = @Sendable () throws -> Void
 
-    static let binaryVersion = "1.8.56"
+    static let binaryVersion = "1.8.57"
     private static let keepaliveDebugEnabled = ProcessInfo.processInfo.environment["MACPROVIDER_KEEPALIVE_DEBUG"] == "1"
 
     private let coordinatorURL: URL

--- a/phase3-binary/Tests/macprovider-cliTests/CoordinatorClientTests.swift
+++ b/phase3-binary/Tests/macprovider-cliTests/CoordinatorClientTests.swift
@@ -4028,10 +4028,12 @@ final class CoordinatorClientTests: XCTestCase {
         let hello = await client.helloMessage()
         let auth = await client.authInitialMessage(attempt: attempt)
 
-        XCTAssertEqual(CoordinatorClient.binaryVersion, "1.8.56")
-        XCTAssertEqual(MacProviderCLI.configuration.version, "1.8.56")
-        XCTAssertEqual(hello["binary_version"] as? String, "1.8.56")
-        XCTAssertEqual(auth["binary_version"] as? String, "1.8.56")
+        // Advertise the live marketing version on both handshake frames; do not
+        // hardcode the number so ordinary candidate bumps do not break this gate.
+        XCTAssertFalse(CoordinatorClient.binaryVersion.isEmpty)
+        XCTAssertEqual(MacProviderCLI.configuration.version, CoordinatorClient.binaryVersion)
+        XCTAssertEqual(hello["binary_version"] as? String, CoordinatorClient.binaryVersion)
+        XCTAssertEqual(auth["binary_version"] as? String, CoordinatorClient.binaryVersion)
     }
 
     func testCatalogProviderRejectsCoordinatorWithoutAdmissionAcknowledgement() async throws {

--- a/phase4-coordinator/coordinator.yaml.example
+++ b/phase4-coordinator/coordinator.yaml.example
@@ -184,7 +184,7 @@ autotune:
 # legacy cohort (DECISION_CRITERIA Entry 161). `required_binary_version` is a
 # hard admission floor, not an autoupdate target, and is unaffected by the gate.
 coordinator_advertised_version:
-  latest_binary_version: "1.8.56"
+  latest_binary_version: "1.8.57"
   required_binary_version: ""
 
 auth:

--- a/phase4-coordinator/dist/coordinator.yaml
+++ b/phase4-coordinator/dist/coordinator.yaml
@@ -319,4 +319,4 @@ providers:
 # legacy cohort (DECISION_CRITERIA Entry 161). Setting this value does not, and
 # must not, re-arm the legacy binary-only updater.
 coordinator_advertised_version:
-  latest_binary_version: "1.8.56"
+  latest_binary_version: "1.8.57"

--- a/phase4-coordinator/dist/coordinator.yaml.example
+++ b/phase4-coordinator/dist/coordinator.yaml.example
@@ -358,7 +358,7 @@ malibu_emission:
 # Use for security fixes that must not be optional. Leave unset for advisory
 # releases.
 coordinator_advertised_version:
-  latest_binary_version: "1.8.56"
+  latest_binary_version: "1.8.57"
   # required_binary_version: "1.7.0"
 
 # Enumerated providers (SPEC-002 v1.0.4 Finding F-2: every provider_id that


### PR DESCRIPTION
## Intent

Give the merged #616/#612/#610/#658 updater cluster one unambiguous private acceptance identity without publishing a GitHub Release or changing Malibu marketing version.

The first private signing attempt, run 29858558760, proved the source gates and then exposed a main-owned toolchain mismatch: PR #673 raised `phase4-coordinator/go.mod` to Go 1.26.5 while `acceptance-candidate.yml` remained pinned to 1.26.4 under `GOTOOLCHAIN=local`. This PR aligns that protected build pin.

## Scope

- Provider CLI `binaryVersion`: 1.8.56 -> 1.8.57
- Three coordinator advertised-version templates: 1.8.56 -> 1.8.57
- Private acceptance workflow Go pin: 1.26.4 -> 1.26.5
- Malibu remains independently versioned at 1.8.45 build 45
- No billing/auth, catalog, Pearl overlay, release publication, or production promotion changes

## Validation

- `bash scripts/test-coordinator-advertised-version.sh v1.8.57`
- `bash scripts/test-coordinator-advertised-version-test.sh`
- `python3 scripts/catalog-release.py verify`
- `bash scripts/test-acceptance-candidate-security.sh`
- `git diff --check`

Local Pearl cross-build is not claimed because the workstation Go toolchain is 1.26.4. Required PR CI must be green before squash merge and acceptance redispatch.

SPEC-GOVERNANCE-DECLARATION-BEGIN
{
  "schema_version": "spec-pr-governance-v1",
  "behavior_change": "yes",
  "contract_change": "none",
  "issue": "https://github.com/Augustas11/macprovider/issues/610",
  "specs": ["SPEC-020"],
  "requirements": ["SPEC-020-R001", "SPEC-020-R002"],
  "authority_domains": ["provider-autoupdate"],
  "arbitration": ["CODE_BUG"],
  "tests": [
    "scripts/test-coordinator-advertised-version.sh",
    "scripts/test-coordinator-advertised-version-test.sh",
    "scripts/test-acceptance-candidate-security.sh",
    "python3 scripts/catalog-release.py verify"
  ],
  "journeys": [
    "Private acceptance candidate v1.8.57 for updater cluster physical matrix: #610 first-hop from public CLI 1.8.48, #658 v1.8.55 to vNext buyer 200, #612 Air recommendation continuity"
  ]
}
SPEC-GOVERNANCE-DECLARATION-END