### PR TITLE
Prepare v1.8.58 private PATH-repair acceptance identity

### DIFF
--- a/phase3-binary/Sources/macprovider-cli/CoordinatorClient.swift
+++ b/phase3-binary/Sources/macprovider-cli/CoordinatorClient.swift
@@ -146,7 +146,7 @@ actor CoordinatorClient {
     typealias InstalledCompatibilityManifest = @Sendable (URL, String) -> CompatibilitySetManifest?
     typealias ReloadHelperFence = @Sendable () throws -> Void
 
-    static let binaryVersion = "1.8.57"
+    static let binaryVersion = "1.8.58"
     private static let keepaliveDebugEnabled = ProcessInfo.processInfo.environment["MACPROVIDER_KEEPALIVE_DEBUG"] == "1"
 
     private let coordinatorURL: URL

--- a/phase4-coordinator/coordinator.yaml.example
+++ b/phase4-coordinator/coordinator.yaml.example
@@ -184,7 +184,7 @@ autotune:
 # legacy cohort (DECISION_CRITERIA Entry 161). `required_binary_version` is a
 # hard admission floor, not an autoupdate target, and is unaffected by the gate.
 coordinator_advertised_version:
-  latest_binary_version: "1.8.57"
+  latest_binary_version: "1.8.58"
   required_binary_version: ""
 
 auth:

--- a/phase4-coordinator/dist/coordinator.yaml
+++ b/phase4-coordinator/dist/coordinator.yaml
@@ -319,4 +319,4 @@ providers:
 # legacy cohort (DECISION_CRITERIA Entry 161). Setting this value does not, and
 # must not, re-arm the legacy binary-only updater.
 coordinator_advertised_version:
-  latest_binary_version: "1.8.57"
+  latest_binary_version: "1.8.58"

--- a/phase4-coordinator/dist/coordinator.yaml.example
+++ b/phase4-coordinator/dist/coordinator.yaml.example
@@ -358,7 +358,7 @@ malibu_emission:
 # Use for security fixes that must not be optional. Leave unset for advisory
 # releases.
 coordinator_advertised_version:
-  latest_binary_version: "1.8.57"
+  latest_binary_version: "1.8.58"
   # required_binary_version: "1.7.0"
 
 # Enumerated providers (SPEC-002 v1.0.4 Finding F-2: every provider_id that


### PR DESCRIPTION
## Intent

Give the merged #678 PATH regular-file repair, #677 onboarding work, and prior updater cluster one signed private acceptance identity for the blocked Shape A J1/J4 physical re-proof.

## Scope

- Provider CLI `binaryVersion`: 1.8.57 -> 1.8.58
- Three reviewed coordinator advertised-version templates: 1.8.57 -> 1.8.58
- Malibu remains independently versioned at 1.8.45 build 45
- Go remains pinned to 1.26.5 with `GOTOOLCHAIN=local`
- No billing/auth, Pearl overlay, public release publication, or production promotion changes

## Validation

- `bash scripts/test-coordinator-advertised-version.sh v1.8.58`
- `bash scripts/test-coordinator-advertised-version-test.sh`
- `bash scripts/test-acceptance-candidate-security.sh`
- `swift test --package-path phase3-binary --filter testBinaryVersion_AdvertisesSPEC020V17AcrossHandshakeFrames`
- `git diff --check`

The merged updater behavior already completed R3 audits at 0 Critical/High/Medium. This PR is a mechanical version-cohesion bump only. Required PR CI must be green before squash merge and protected acceptance signing.

SPEC-GOVERNANCE-DECLARATION-BEGIN
{
  "schema_version": "spec-pr-governance-v1",
  "behavior_change": "yes",
  "contract_change": "none",
  "issue": "https://github.com/Augustas11/macprovider/issues/610",
  "specs": ["SPEC-020"],
  "requirements": ["SPEC-020-R001", "SPEC-020-R002"],
  "authority_domains": ["provider-autoupdate"],
  "arbitration": ["CODE_BUG"],
  "tests": [
    "scripts/test-coordinator-advertised-version.sh",
    "scripts/test-coordinator-advertised-version-test.sh",
    "scripts/test-acceptance-candidate-security.sh",
    "CoordinatorClientTests.testBinaryVersion_AdvertisesSPEC020V17AcrossHandshakeFrames"
  ],
  "journeys": [
    "Shape A J1 #610 and J4 #616 physical re-proof from a stale regular-file PATH using signed private v1.8.58"
  ]
}
SPEC-GOVERNANCE-DECLARATION-END