### PR TITLE
Reclaim orphaned control sockets on serve startup instead of failing forever

### DIFF
--- a/phase3-binary/Sources/macprovider-cli/ControlSocket.swift
+++ b/phase3-binary/Sources/macprovider-cli/ControlSocket.swift
@@ -480,7 +480,7 @@ public enum ControlSocketPaths {
     }
 }
 
-private struct ControlSocketFileIdentity: Equatable, Sendable {
+struct ControlSocketFileIdentity: Equatable, Sendable {
     let device: dev_t
     let inode: ino_t
     let owner: uid_t
@@ -491,6 +491,177 @@ private struct ControlSocketFileIdentity: Equatable, Sendable {
         inode = info.st_ino
         owner = info.st_uid
         mode = info.st_mode
+    }
+}
+
+enum ControlSocketStaleSocketOutcome: Equatable {
+    /// No live listener was found at the path; the orphaned inode was
+    /// safely quarantined and unlinked (or was already gone). Safe to bind.
+    case reclaimed
+    /// A live peer accepted a connection attempt on the path. Must stay
+    /// fail-closed; some other serve process currently owns this socket.
+    case live
+    /// The path could not be verified as our own control socket (wrong
+    /// owner/type/mode, unsafe parent directory, or an ambiguous connect
+    /// failure). Never reclaimed; caller must stay fail-closed.
+    case unverified
+}
+
+/// Reclaims a control socket path left behind by a serve process that died
+/// without running its watchdog exit cleanup (e.g. SIGKILL, launchd
+/// KeepAlive restart racing a crash). Applies the same identity-verification
+/// and atomic quarantine-then-unlink discipline as
+/// `ControlSocketWatchdogCleanup` so an unknown or live path is never
+/// touched — this only clears sockets we can prove are both ours and dead.
+enum ControlSocketStaleSocketReclaimer {
+    static func reclaimIfOrphaned(socketPath: URL) -> ControlSocketStaleSocketOutcome {
+        let parentPath = socketPath.deletingLastPathComponent().path
+        let socketName = socketPath.lastPathComponent
+
+        let parentFD = Darwin.open(parentPath, O_RDONLY | O_DIRECTORY | O_NOFOLLOW)
+        guard parentFD >= 0 else {
+            log("could not open control socket directory", error: errno)
+            return .unverified
+        }
+        defer { Darwin.close(parentFD) }
+
+        var parentInfo = stat()
+        guard Darwin.fstat(parentFD, &parentInfo) == 0,
+              parentInfo.st_uid == geteuid(),
+              (parentInfo.st_mode & S_IFMT) == S_IFDIR,
+              (parentInfo.st_mode & 0o777) == 0o700
+        else {
+            log("refused unverified control socket directory")
+            return .unverified
+        }
+
+        var socketInfo = stat()
+        guard Darwin.fstatat(parentFD, socketName, &socketInfo, AT_SYMLINK_NOFOLLOW) == 0 else {
+            let error = errno
+            if error == ENOENT { return .reclaimed }
+            log("could not inspect control socket", error: error)
+            return .unverified
+        }
+        guard socketInfo.st_uid == geteuid(),
+              (socketInfo.st_mode & S_IFMT) == S_IFSOCK,
+              (socketInfo.st_mode & 0o777) == 0o600
+        else {
+            log("refused unverified control socket")
+            return .unverified
+        }
+
+        switch probeLiveness(socketPath: socketPath.path) {
+        case .live:
+            return .live
+        case .unknown:
+            return .unverified
+        case .orphaned:
+            break
+        }
+
+        let expectedIdentity = ControlSocketFileIdentity(socketInfo)
+        return quarantineAndUnlink(
+            parentFD: parentFD,
+            socketName: socketName,
+            expectedIdentity: expectedIdentity
+        ) ? .reclaimed : .unverified
+    }
+
+    /// Test-only seam exercising the exact quarantine-then-unlink step used
+    /// by `reclaimIfOrphaned`, so tests can assert the race-safety guarantee
+    /// (a mismatched identity — i.e. someone else's live replacement won the
+    /// race — is preserved untouched) without depending on real thread
+    /// timing.
+    static func quarantineAndUnlinkForTest(
+        parentFD: Int32,
+        socketName: String,
+        expectedIdentity: ControlSocketFileIdentity
+    ) -> Bool {
+        quarantineAndUnlink(parentFD: parentFD, socketName: socketName, expectedIdentity: expectedIdentity)
+    }
+
+    private enum LivenessProbe {
+        case live
+        case orphaned
+        case unknown
+    }
+
+    private static func probeLiveness(socketPath: String) -> LivenessProbe {
+        guard let address = try? unixAddress(path: socketPath) else { return .unknown }
+        var raw = address.sockaddr
+        let fd = Darwin.socket(AF_UNIX, SOCK_STREAM, 0)
+        guard fd >= 0 else { return .unknown }
+        defer { Darwin.close(fd) }
+        let result = withUnsafePointer(to: &raw) { pointer in
+            pointer.withMemoryRebound(to: sockaddr.self, capacity: 1) {
+                Darwin.connect(fd, $0, address.length)
+            }
+        }
+        if result == 0 { return .live }
+        switch errno {
+        case ECONNREFUSED, ENOTSOCK, EPROTOTYPE, ENOENT:
+            return .orphaned
+        default:
+            return .unknown
+        }
+    }
+
+    private static func quarantineAndUnlink(
+        parentFD: Int32,
+        socketName: String,
+        expectedIdentity: ControlSocketFileIdentity
+    ) -> Bool {
+        let quarantineName = ".\(socketName).stale-reclaim-\(getpid())-\(UUID().uuidString.lowercased())"
+        guard Darwin.renameatx_np(
+            parentFD, socketName,
+            parentFD, quarantineName,
+            UInt32(RENAME_EXCL)
+        ) == 0 else {
+            let error = errno
+            if error == ENOENT { return true }
+            log("could not quarantine control socket", error: error)
+            return false
+        }
+
+        var quarantinedInfo = stat()
+        guard Darwin.fstatat(parentFD, quarantineName, &quarantinedInfo, AT_SYMLINK_NOFOLLOW) == 0 else {
+            let error = errno
+            if Darwin.renameatx_np(
+                parentFD, quarantineName,
+                parentFD, socketName,
+                UInt32(RENAME_EXCL)
+            ) != 0 {
+                log("preserved mismatched control socket as \(quarantineName)", error: errno)
+            } else {
+                log("could not inspect quarantined control socket", error: error)
+            }
+            return false
+        }
+        guard ControlSocketFileIdentity(quarantinedInfo) == expectedIdentity else {
+            if Darwin.renameatx_np(
+                parentFD, quarantineName,
+                parentFD, socketName,
+                UInt32(RENAME_EXCL)
+            ) != 0 {
+                log("preserved mismatched control socket as \(quarantineName)", error: errno)
+            } else {
+                log("refused replacement control socket cleanup")
+            }
+            return false
+        }
+
+        guard Darwin.unlinkat(parentFD, quarantineName, 0) == 0 else {
+            let error = errno
+            if error == ENOENT { return true }
+            log("could not remove quarantined control socket", error: error)
+            return false
+        }
+        return true
+    }
+
+    private static func log(_ message: String, error: Int32? = nil) {
+        let detail = error.map { ": \(String(cString: strerror($0)))" } ?? ""
+        FileHandle.standardError.write(Data("control socket stale reclaim \(message)\(detail)\n".utf8))
     }
 }
 
@@ -739,9 +910,17 @@ actor ControlSocketServer {
         chmod(parent.path, S_IRWXU)
 
         if FileManager.default.fileExists(atPath: socketPath.path) {
-            let error = ControlSocketServerError.staleSocket(path: socketPath.path)
-            FileHandle.standardError.write(Data(("\(error.description)\n").utf8))
-            throw error
+            // launchd KeepAlive restarts a serve process whose predecessor
+            // may have died (SIGKILL, OOM, power loss) before its watchdog
+            // exit cleanup ran, leaving an orphaned control socket file with
+            // no listener. Reclaim only when we can prove the path is both
+            // ours and dead; otherwise stay fail-closed exactly as before.
+            let outcome = ControlSocketStaleSocketReclaimer.reclaimIfOrphaned(socketPath: socketPath)
+            if outcome != .reclaimed {
+                let error = ControlSocketServerError.staleSocket(path: socketPath.path)
+                FileHandle.standardError.write(Data(("\(error.description)\n").utf8))
+                throw error
+            }
         }
 
         let fd = Darwin.socket(AF_UNIX, SOCK_STREAM, 0)

--- a/phase3-binary/Tests/macprovider-cliTests/ControlSocketTests.swift
+++ b/phase3-binary/Tests/macprovider-cliTests/ControlSocketTests.swift
@@ -418,6 +418,86 @@ final class ControlSocketTests: XCTestCase {
         try? FileManager.default.removeItem(at: socketPath.deletingLastPathComponent())
     }
 
+    func testServerReclaimsOrphanedControlSocketOnStart() async throws {
+        let socketPath = try makeSocketPath()
+        try FileManager.default.createDirectory(at: socketPath.deletingLastPathComponent(), withIntermediateDirectories: true)
+        chmod(socketPath.deletingLastPathComponent().path, 0o700)
+        try createOrphanedSocket(at: socketPath)
+
+        let server = makeServer(socketPath: socketPath, modelRuntime: makeRuntime(modelID: "reclaimed-model"))
+        try await server.start()
+
+        let connection = try await ControlSocketClient.connect(socketPath: socketPath)
+        try await connection.send(.statusRequest)
+        let response = try await connection.receive(timeout: 1)
+        await connection.close()
+        await server.stop()
+
+        XCTAssertEqual(response, .statusResponse(currentModelID: "reclaimed-model", runtimeState: .ready))
+        try? FileManager.default.removeItem(at: socketPath.deletingLastPathComponent())
+    }
+
+    func testServerFailsClosedWhenControlSocketIsLive() async throws {
+        let socketPath = try makeSocketPath()
+        let liveServer = makeServer(socketPath: socketPath, modelRuntime: makeRuntime(modelID: "live-model"))
+        try await liveServer.start()
+
+        let contender = makeServer(socketPath: socketPath, modelRuntime: makeRuntime(modelID: "contender"))
+        do {
+            try await contender.start()
+            XCTFail("expected stale socket rejection while peer is live")
+        } catch let error as ControlSocketServerError {
+            XCTAssertEqual(error, .staleSocket(path: socketPath.path))
+        }
+
+        // The live peer must be completely unaffected by the failed reclaim attempt.
+        let connection = try await ControlSocketClient.connect(socketPath: socketPath)
+        try await connection.send(.statusRequest)
+        let response = try await connection.receive(timeout: 1)
+        await connection.close()
+        await liveServer.stop()
+
+        XCTAssertEqual(response, .statusResponse(currentModelID: "live-model", runtimeState: .ready))
+    }
+
+    func testStaleSocketReclaimPreservesLiveReplacementOnIdentityRace() async throws {
+        let socketPath = try makeSocketPath()
+        try FileManager.default.createDirectory(at: socketPath.deletingLastPathComponent(), withIntermediateDirectories: true)
+        chmod(socketPath.deletingLastPathComponent().path, 0o700)
+
+        // Capture the identity a reclaimer would have observed for a
+        // now-orphaned socket before it acted on it.
+        let staleIdentityPath = socketPath.deletingLastPathComponent().appendingPathComponent("stale-identity.sock")
+        try createOrphanedSocket(at: staleIdentityPath)
+        let staleIdentity = try socketIdentity(at: staleIdentityPath)
+        try FileManager.default.removeItem(at: staleIdentityPath)
+
+        // A live server now wins the race and legitimately owns socketPath.
+        let liveServer = makeServer(socketPath: socketPath, modelRuntime: makeRuntime(modelID: "winner"))
+        try await liveServer.start()
+
+        let parentFD = Darwin.open(socketPath.deletingLastPathComponent().path, O_RDONLY | O_DIRECTORY)
+        XCTAssertGreaterThanOrEqual(parentFD, 0)
+        defer { Darwin.close(parentFD) }
+
+        // Attempting to quarantine using the stale (pre-race) identity must
+        // fail and must not disturb the live replacement's socket file.
+        XCTAssertFalse(ControlSocketStaleSocketReclaimer.quarantineAndUnlinkForTest(
+            parentFD: parentFD,
+            socketName: socketPath.lastPathComponent,
+            expectedIdentity: staleIdentity
+        ))
+
+        let connection = try await ControlSocketClient.connect(socketPath: socketPath)
+        try await connection.send(.statusRequest)
+        let response = try await connection.receive(timeout: 1)
+        await connection.close()
+        await liveServer.stop()
+
+        XCTAssertEqual(response, .statusResponse(currentModelID: "winner", runtimeState: .ready))
+        try? FileManager.default.removeItem(at: socketPath.deletingLastPathComponent())
+    }
+
     func testWatchdogCleanupRemovesOwnedUnixSocket() async throws {
         let socketPath = try makeSocketPath()
         let cleanup = ControlSocketWatchdogCleanup(socketPath: socketPath)
@@ -653,6 +733,31 @@ final class ControlSocketTests: XCTestCase {
 
     private func makeServer(socketPath: URL, modelRuntime: ModelRuntime) -> ControlSocketServer {
         ControlSocketServer(socketPath: socketPath, modelRuntime: modelRuntime, idleTimeoutSeconds: 0.2)
+    }
+
+    /// Binds and listens on `path` like a real serve process would, then
+    /// closes the listener without unlinking the file — reproducing the
+    /// exact orphaned-inode state left behind when a process dies (SIGKILL,
+    /// OOM, power loss) before its watchdog exit cleanup can run.
+    private func createOrphanedSocket(at path: URL) throws {
+        let fd = Darwin.socket(AF_UNIX, SOCK_STREAM, 0)
+        XCTAssertGreaterThanOrEqual(fd, 0)
+        var address = try unixAddress(path: path.path)
+        let result = withUnsafePointer(to: &address.sockaddr) { pointer in
+            pointer.withMemoryRebound(to: sockaddr.self, capacity: 1) {
+                Darwin.bind(fd, $0, address.length)
+            }
+        }
+        XCTAssertEqual(result, 0)
+        chmod(path.path, 0o600)
+        XCTAssertEqual(Darwin.listen(fd, 128), 0)
+        Darwin.close(fd)
+    }
+
+    private func socketIdentity(at path: URL) throws -> ControlSocketFileIdentity {
+        var info = stat()
+        XCTAssertEqual(Darwin.lstat(path.path, &info), 0)
+        return ControlSocketFileIdentity(info)
     }
 
     private func rawConnect(socketPath: URL) throws -> Int32 {


### PR DESCRIPTION
## Summary

Fixes today's production wedge (2026-07-22): launchd `KeepAlive` restarts of `macprovider-cli serve` failed forever with

```
control socket .../T/macprovider-cli/ctl.sock already exists; remove the stale file and restart serve
```

Process stayed "running" under launchd but never bound HTTP (`:61920`), leaving Malibu stuck on Starting.

**Incident facts (this Mac):**
- After J1/J4 physical update re-proof (~07:35), the watchdog logged `no validated PID` from ~07:40 while `KeepAlive` skipped restarts.
- The stale `ctl.sock` (mtime ~09:34) then blocked every subsequent `serve` start.
- Manual recovery required `bootout` + `rm -f ctl.sock` + `bootstrap`.

**Root cause:** `ControlSocketServer.start()` treated *any* pre-existing socket path as fatal (`staleSocket`), with no way to distinguish "another live serve owns this" from "a dead serve process left this behind." A process that dies before its watchdog exit cleanup runs (SIGKILL, OOM, power loss) leaves an orphaned socket file that then wedges every future restart — exactly the failure mode `KeepAlive` is supposed to recover from.

**Fix:** `ControlSocketStaleSocketReclaimer` reuses the same identity-verification and atomic quarantine-then-unlink discipline already proven in `ControlSocketWatchdogCleanup` (the exit-side cleanup), but runs it at startup instead:

1. Verify the path is genuinely our own control socket — owned by our euid, `S_IFSOCK`, mode `0600`, with a `0700` euid-owned parent directory. Any mismatch (regular file, symlink, wrong owner/mode, unsafe parent) is never touched and stays fail-closed with the existing `staleSocket` error.
2. Probe liveness with a real `connect()`. If a listener accepts, the socket is live — stay fail-closed exactly as before; some other `serve` process currently owns it.
3. Only `ECONNREFUSED` / `ENOTSOCK` / `EPROTOTYPE` / `ENOENT` (no listener, or the file is already gone) is treated as an orphan. Reclaim it via the same rename-verify-unlink sequence as the watchdog path: atomically rename to a quarantine name, re-verify the quarantined file's device/inode/owner/mode against what was observed before reclaiming, then unlink. If a live replacement won a race and now owns the name, the identity check fails and the rename is reversed — the replacement is never clobbered.

Same security posture as the existing reclaim path throughout: never unlink an unknown or live path, only ever act on something proven to be both ours and dead.

## Scope

Only `phase3-binary/Sources/macprovider-cli/ControlSocket.swift` (+ its tests). No changes to serve's HTTP/model runtime, watchdog exit cleanup, launchd plist, or coordinator admission. No Pearl mutation, no canary change, no release/promote.

## Test plan

- [x] `swift build` — clean.
- [x] `swift test --filter ControlSocketTests` — **51/51 passing**, including 3 new cases:
  - `testServerReclaimsOrphanedControlSocketOnStart` — an orphaned socket (bound+listened, then closed without unlinking, simulating a crashed serve) is reclaimed and the new server binds and serves normally.
  - `testServerFailsClosedWhenControlSocketIsLive` — a second `serve` attempt against a path with a live listener still fails closed with `staleSocket`, and the live peer is unaffected.
  - `testStaleSocketReclaimPreservesLiveReplacementOnIdentityRace` — quarantining with a stale (pre-race) identity against a path now owned by a live replacement fails and leaves the replacement's socket completely untouched.
- [x] Full `swift test` suite run and compared against a clean `origin/main` baseline (via `git stash`) — the pre-existing 26 `CoordinatorClientTests` failures + 2 `SelfUpdateTests`/`EndToEndAcceptanceTests` failures are identical on both, confirming they're environment-dependent (local MDM enrollment, missing keychain-access-groups entitlement, version-drift fixtures) and unrelated to this change.

## Residual risk

- Reclaim only fires when the socket file exists at `start()`; a still-running healthy `serve` is unaffected since its own socket connect always succeeds.
- The liveness probe treats any *unexpected* `connect()` errno (not in the reclaim allowlist) as fail-closed/`unverified`, matching the existing conservative posture rather than guessing.
- Does not address the separate watchdog `no validated PID` gap noted in today's incident timeline (watchdog skipping restarts before the stale-socket wedge) — that is tracked separately and out of scope for this fix per the assigned task.

Incident reference: `ops/runbooks/pearl-exception-clearance-20260722.md`. Extends the lifecycle-reliability line of work tracked under #585.

<!--
SPEC-GOVERNANCE-DECLARATION-BEGIN
{
  "schema_version": "spec-pr-governance-v1",
  "behavior_change": "yes",
  "contract_change": "none",
  "issue": "https://github.com/Augustas11/macprovider/issues/585",
  "specs": ["SPEC-025", "SPEC-020"],
  "requirements": ["SPEC-020-R004"],
  "authority_domains": ["native-app-lifecycle", "provider-autoupdate"],
  "arbitration": ["CODE_BUG"],
  "tests": [
    "swift test --filter ControlSocketTests (phase3-binary)"
  ],
  "journeys": ["not-required"]
}
SPEC-GOVERNANCE-DECLARATION-END
-->

