### PR TITLE
fix(#608): stage-tier2-republish for Llama Tier-2 align

### DIFF
--- a/ops/runbooks/608-llama-tier2-republish.md
+++ b/ops/runbooks/608-llama-tier2-republish.md
@@ -1,0 +1,169 @@
+# #608 Llama-3.2 Tier-2 vs autotune CONFLICT — reviewed republish
+
+**Status:** tooling ready; Pearl apply steps in §3 are **DO NOT EXECUTE YET**
+**Scope:** resolves the single live `mlx-community/Llama-3.2-3B-Instruct-4bit`
+hash CONFLICT between Pearl's autotune release and Pearl's Tier-2 dual file.
+**Not in scope:** ledger/compatibility-set Tier-2 feed membership, explicit
+`macprovider.snapshot-manifest.v1` `hash_scope`, physical dual-file removal,
+`exc-catalog-compatibility-bridges` clearance, or any `#609`
+`require_hash_verified` flip. See
+`audits/2026-07-22/PEARL_608_DUAL_CATALOG_CUTOVER_PREP.md` for the full gap
+list; this runbook only closes gap item 1 of 5 (the Llama CONFLICT).
+
+## 0. Read-only facts this runbook is built from
+
+Recorded by the 2026-07-22 read-only Pearl inventory
+(`audits/2026-07-22/PEARL_608_DUAL_CATALOG_CUTOVER_PREP.md`). Re-verify these
+before acting — do not assume they are still current.
+
+| Field | Value |
+| --- | --- |
+| Active autotune release | `published-2026-07-10-catalog-recovery-v1` |
+| `autotune-candidates.json` sha256 | `776182f6230eff098345b188322dba0c7fce47a6da46447432991ffdc37eabda` |
+| Repo `tier2-identity-binding.json` `autotune_candidates_sha256` | `776182f6230eff098345b188322dba0c7fce47a6da46447432991ffdc37eabda` (matches) |
+| Live Pearl `/opt/macprovider/tier2-catalog.json` sha256 | `309f67affe840974d04b571db86f343933e3a5785a388d4a39d61c3da0fe1874` |
+| Live Pearl Tier-2 `catalog_id` | `macprovider-tier2-model-catalog-2026-07-07-p2-qwen3-8b` |
+| Live Pearl Tier-2 model count | 9 |
+| `tier2.require_hash_verified` | `false` (must stay `false` for this runbook) |
+| CONFLICT | `mlx-community/Llama-3.2-3B-Instruct-4bit`: autotune `e7e5bff4248768b4db7a53afb3b514ba5867b800f63d1abd0330eaf08e54aa90` vs Tier-2 `3975387f249977e5e8bfb7ed0d352f8258ac3d630f961ce1dd952f428ee7216a` |
+| AGREE | remaining 8 overlapping `model_id`s (includes live Qwen3-Coder `10adb5da…`) |
+
+Expected post-republish state: the same 9 `model_id`s, the same 8 unchanged
+hashes, and Llama-3.2-3B updated to `e7e5bff4248768b4db7a53afb3b514ba5867b800f63d1abd0330eaf08e54aa90`.
+`scripts/catalog-release.py check-tier2-binding` must report zero conflicts
+against `published-2026-07-10-catalog-recovery-v1` afterward.
+
+## 1. Local, no-production-credentials staging (safe to run now)
+
+All commands run from the repository root in this worktree. Nothing in this
+section touches Pearl.
+
+```bash
+# 1a. Reproduce the live CONFLICT locally against the fixture that encodes
+#     the exact stale/current Llama hash pair (proves fail-closed detection
+#     before touching any real file).
+python3 scripts/catalog-release.py check-tier2-binding \
+  --candidate phase3-binary/catalog/autotune/autotune-candidates.json \
+  --tier2 phase3-binary/catalog/autotune/testdata/tier2-llama-conflict-template.json
+# Expected: exits non-zero, prints an "autotune/tier2 identity conflict"
+# error naming mlx-community/Llama-3.2-3B-Instruct-4bit and both hashes.
+
+# 1b. Stage an unsigned republish body from the SAME fixture shape (in a
+#     real run, --template is a copy of the operator-pulled live
+#     /opt/macprovider/tier2-catalog.json, not the test fixture).
+python3 scripts/catalog-release.py stage-tier2-republish \
+  --candidate phase3-binary/catalog/autotune/autotune-candidates.json \
+  --binding phase3-binary/catalog/autotune/tier2-identity-binding.json \
+  --template phase3-binary/catalog/autotune/testdata/tier2-llama-conflict-template.json \
+  --output /tmp/tier2-catalog.staged.json
+# Expected: prints the single changed row
+# ("mlx-community/Llama-3.2-3B-Instruct-4bit: 3975387f... -> e7e5bff4...")
+# and confirms check-tier2-binding already passed on the staged body.
+
+# 1c. Confirm the staged body now agrees on all 9 model_ids.
+python3 scripts/catalog-release.py check-tier2-binding \
+  --candidate phase3-binary/catalog/autotune/autotune-candidates.json \
+  --tier2 /tmp/tier2-catalog.staged.json
+# Expected: "tier2 binding ok: ... agrees with ..." (exit 0).
+
+diff <(python3 -m json.tool /tmp/tier2-catalog.staged.json 2>/dev/null || cat /tmp/tier2-catalog.staged.json) \
+     phase3-binary/catalog/autotune/testdata/tier2-llama-conflict-template.json || true
+# Manually review: the diff must show exactly one changed field
+# (Llama-3.2 sha256) and zero changes to hash_scope, artifact_kind,
+# min_ram_gb, notes, or source for any row.
+```
+
+`stage-tier2-republish` never invents `hash_scope`; it only copies the
+autotune sha256 for overlapping `model_id`s onto whatever operator-reviewed
+template it is given, and it refuses to write output unless the staged body
+already passes `check-tier2-binding`. It is not a second identity authority —
+see the function docstring in `scripts/catalog-release.py`.
+
+## 2. Get the real template and sign it (still no Pearl mutation)
+
+```bash
+# 2a. Pull the CURRENT live Tier-2 file read-only (no write, no restart).
+ssh <pearl-operator-target> \
+  'cat /opt/macprovider/tier2-catalog.json' > /tmp/tier2-catalog.live.json
+sha256sum /tmp/tier2-catalog.live.json
+# Expected: 309f67affe840974d04b571db86f343933e3a5785a388d4a39d61c3da0fe1874
+# (re-verify — do not proceed if this drifted from §0).
+
+# 2b. Strip the live signature block before using it as a stage-tier2-
+#     republish template (the tool accepts a signed body and ignores
+#     `signature`, but keep the diff obviously unsigned for review).
+python3 -c '
+import json, sys
+body = json.load(open("/tmp/tier2-catalog.live.json"))
+body.pop("signature", None)
+json.dump(body, open("/tmp/tier2-catalog.live.unsigned.json", "w"), indent=2, sort_keys=True)
+'
+
+python3 scripts/catalog-release.py stage-tier2-republish \
+  --candidate phase3-binary/catalog/autotune/autotune-candidates.json \
+  --binding phase3-binary/catalog/autotune/tier2-identity-binding.json \
+  --template /tmp/tier2-catalog.live.unsigned.json \
+  --output /tmp/tier2-catalog.republish.json
+
+# 2c. Operator review: confirm only Llama-3.2 sha256 changed, then sign with
+#     the existing production Tier-2 private key (already escrowed; never
+#     generate a new keypair for this).
+go run scripts/sign-catalog.go sign \
+  -key <path-to-existing-tier2-private-key> \
+  -key-id <existing-tier2-key-id> \
+  -out /tmp/tier2-catalog.republish.signed.json \
+  /tmp/tier2-catalog.republish.json
+
+go run scripts/sign-catalog.go verify \
+  -public-key <path-to-existing-tier2-public-key> \
+  /tmp/tier2-catalog.republish.signed.json
+
+python3 scripts/catalog-release.py check-tier2-binding \
+  --candidate phase3-binary/catalog/autotune/autotune-candidates.json \
+  --tier2 /tmp/tier2-catalog.republish.signed.json
+```
+
+## 3. Pearl apply — **DO NOT EXECUTE YET**
+
+Everything below mutates production and requires an explicit operator go/no-go
+plus the pre-flight in `ops/runbooks/catalog-release-provider-upgrade.md`
+§6.3 (direct deploy) — including the deploy mutex, canary proof, and rollback
+snapshot. This runbook does not authorize running it.
+
+```text
+DO NOT EXECUTE YET:
+1. Snapshot /opt/macprovider/tier2-catalog.json and its signature per the
+   direct-deploy recovery procedure (catalog-release-provider-upgrade.md
+   §6.3 step 3) before any write.
+2. Upload /tmp/tier2-catalog.republish.signed.json to Pearl through
+   phase4-coordinator/dist/deploy-pearl-vps.sh (never scp the file directly
+   onto the live path — the deploy script owns the mutex, verification, and
+   rollback).
+3. Confirm the deployed sha256 differs from 309f67affe840974d04b571db86f343933e3a5785a388d4a39d61c3da0fe1874
+   (the stale Llama file) and that check-tier2-binding against the active
+   autotune release passes on Pearl.
+4. Re-run the 2026-07-22 drift matrix read-only probe: expect CONFLICT=0,
+   AGREE=9.
+5. Confirm tier2.require_hash_verified is still false and
+   exc-tier2-hash-mismatch-containment / exc-catalog-compatibility-bridges
+   are unchanged (this runbook does not clear either exception).
+```
+
+## 4. What this closes vs what remains open on #608
+
+Closes: the Llama-3.2 CONFLICT align path (tooling + fail-closed fixture
+proof) described in
+`audits/2026-07-22/PEARL_608_DUAL_CATALOG_CUTOVER_PREP.md` §5 item 1.
+
+Still open (unchanged by this runbook):
+
+1. Ledger / compatibility-set membership for signed Tier-2 bytes (§5 item 2).
+2. Explicit Tier-2 `macprovider.snapshot-manifest.v1` `hash_scope`; keep
+   `derive-tier2` disabled until then (§5 item 3).
+3. Promote a Pearl coordinator binary carrying #682 `catalogbind` + #688
+   deploy-only mutate gate — the live binary predates both (§5 item 4).
+4. Physical `/opt/macprovider/tier2-catalog.json` dual-file removal + Pearl
+   journey proof, then `exc-catalog-compatibility-bridges` clearance (§5
+   item 5).
+5. `#609` `require_hash_verified` enforce flip — explicitly out of scope for
+   #608 and for this runbook.

--- a/ops/runbooks/README.md
+++ b/ops/runbooks/README.md
@@ -8,6 +8,7 @@
 | **C — $MALIBU bootstrap** | [`malibu-bootstrap-emission.md`](./malibu-bootstrap-emission.md) | Emission ledger, caps, Trusted unlock, Malibu UI |
 | **C — MALIBU Pearl** | [`malibu-pearl-deploy.md`](./malibu-pearl-deploy.md) | Session C4 Pearl migration + overlay |
 | **Catalog release + provider upgrade** | [`catalog-release-provider-upgrade.md`](./catalog-release-provider-upgrade.md) | Signed publication, coordinator activation, provider transaction, rollback |
+| **#608 Llama Tier-2 republish** | [`608-llama-tier2-republish.md`](./608-llama-tier2-republish.md) | Reviewed `stage-tier2-republish` staging for the live Llama-3.2 autotune/Tier-2 CONFLICT; Pearl apply steps not yet executed |
 | **B — Entry 172 referrals** | [`entry-172-referral-activation.md`](./entry-172-referral-activation.md) | Reversible private-prebeta referral activation checklist |
 | **#615 production exceptions** | [`production-exception-register.md`](./production-exception-register.md) | Machine-readable production exception register maintenance |
 | **#582 stranger onboarding** | [`582-stranger-hardware-trust-onboarding.md`](./582-stranger-hardware-trust-onboarding.md) | No-exception install → evidence → durable trust approve → admit → ready |

--- a/ops/runbooks/catalog-release-provider-upgrade.md
+++ b/ops/runbooks/catalog-release-provider-upgrade.md
@@ -46,6 +46,15 @@ Until then the interim rule is **derived-only mutate**:
    author/sign Tier-2 with `scripts/sign-catalog.go` after review, using
    `tier2-identity-binding.json` + `check-tier2-binding` as the drift gate.
    Signing alone does **not** authorize a live catalog.
+   `scripts/catalog-release.py stage-tier2-republish` helps close a detected
+   conflict: it projects autotune-derived hashes from
+   `tier2-identity-binding.json` onto an operator-supplied template (e.g. the
+   current live Tier-2 file) for overlapping `model_id`s only, leaving every
+   other reviewed field (`hash_scope`, `artifact_kind`, `min_ram_gb`, `notes`,
+   `source`) untouched, and refuses to write output unless the staged body
+   already passes `check-tier2-binding`. It is a staging aid for
+   `sign-catalog.go`, not a second identity authority. See
+   `ops/runbooks/608-llama-tier2-republish.md` for a worked example.
 3. `scripts/catalog-release.py check-tier2-binding` and Pearl
    `deploy-pearl-vps.sh` fail closed when an overlapping `model_id` has a
    Tier-2 `sha256` that disagrees with the autotune `model_sha256`. Deploy

--- a/phase3-binary/catalog/autotune/testdata/tier2-llama-conflict-template.json
+++ b/phase3-binary/catalog/autotune/testdata/tier2-llama-conflict-template.json
@@ -1,0 +1,81 @@
+{
+  "catalog_id": "test-fixture-tier2-llama-conflict-2026-07-22",
+  "issued_at": "2026-07-20T15:58:00Z",
+  "expires_at": "2099-01-01T00:00:00Z",
+  "version": 1,
+  "models": [
+    {
+      "artifact_kind": "mlx_weight_file",
+      "hash_scope": "artifact_manifest",
+      "model_id": "mlx-community/gemma-4-26b-a4b-it-4bit",
+      "min_ram_gb": 28,
+      "source": "operator_reviewed_tier2_catalog",
+      "sha256": "436ce68d2ac5a27dde3b54569736fb7a69dc3b7a175d2f633147c7802b3bc88a"
+    },
+    {
+      "artifact_kind": "mlx_weight_file",
+      "hash_scope": "artifact_manifest",
+      "model_id": "mlx-community/gpt-oss-20b-MXFP4-Q8",
+      "min_ram_gb": 24,
+      "source": "operator_reviewed_tier2_catalog",
+      "sha256": "f25592861e0b7f4eb8489d9103214f3f0dc4f798bb0e4e0cd817ff2f4191f1b1"
+    },
+    {
+      "artifact_kind": "mlx_weight_file",
+      "hash_scope": "artifact_manifest",
+      "model_id": "mlx-community/Llama-3.2-3B-Instruct-4bit",
+      "min_ram_gb": 4,
+      "notes": "STALE 2026-07-07 hash fixture for #608 fail-closed proof; do not use as a real catalog",
+      "source": "operator_reviewed_tier2_catalog",
+      "sha256": "3975387f249977e5e8bfb7ed0d352f8258ac3d630f961ce1dd952f428ee7216a"
+    },
+    {
+      "artifact_kind": "mlx_weight_file",
+      "hash_scope": "artifact_manifest",
+      "model_id": "mlx-community/Meta-Llama-3.1-8B-Instruct-4bit",
+      "min_ram_gb": 12,
+      "source": "operator_reviewed_tier2_catalog",
+      "sha256": "67b26d6b1c50dc8836ab3705b06276a43c74c8f66247f9b112e232b58abbd99f"
+    },
+    {
+      "artifact_kind": "mlx_weight_file",
+      "hash_scope": "artifact_manifest",
+      "model_id": "mlx-community/NVIDIA-Nemotron-3-Nano-30B-A3B-4bit",
+      "min_ram_gb": 32,
+      "source": "operator_reviewed_tier2_catalog",
+      "sha256": "1bc78f214f9a042eaeb290b1fa4cb29915df1028f79d8479266349166c40a71f"
+    },
+    {
+      "artifact_kind": "mlx_weight_file",
+      "hash_scope": "artifact_manifest",
+      "model_id": "mlx-community/Qwen2.5-Coder-32B-Instruct-4bit",
+      "min_ram_gb": 48,
+      "source": "operator_reviewed_tier2_catalog",
+      "sha256": "b7749cc57f37f7e9239d0f9b091bcffe6d7629e48af75e8cb84c1cdca1780973"
+    },
+    {
+      "artifact_kind": "mlx_weight_file",
+      "hash_scope": "artifact_manifest",
+      "model_id": "mlx-community/Qwen3-32B-4bit",
+      "min_ram_gb": 48,
+      "source": "operator_reviewed_tier2_catalog",
+      "sha256": "69169cceb643f108755f96dba26d8647862e38a7f82cb1b5b25aff8f204967aa"
+    },
+    {
+      "artifact_kind": "mlx_weight_file",
+      "hash_scope": "artifact_manifest",
+      "model_id": "mlx-community/Qwen3-8B-4bit",
+      "min_ram_gb": 12,
+      "source": "operator_reviewed_tier2_catalog",
+      "sha256": "1f591f9c4fb38d05ea2d879d89a6eeab485c23a04eb75e3e0a289db9d95ec877"
+    },
+    {
+      "artifact_kind": "mlx_weight_file",
+      "hash_scope": "artifact_manifest",
+      "model_id": "mlx-community/Qwen3-Coder-30B-A3B-Instruct-4bit",
+      "min_ram_gb": 28,
+      "source": "operator_reviewed_tier2_catalog",
+      "sha256": "10adb5da9840c8fe0e3036b10f6e2f8f34b41c615f3925b4132302e9cdbab9c0"
+    }
+  ]
+}

--- a/scripts/catalog-release.py
+++ b/scripts/catalog-release.py
@@ -32,6 +32,7 @@ TIER2_BINDING_PATH = CATALOG_DIR / "tier2-identity-binding.json"
 TIER2_BINDING_SCHEMA = "macprovider.tier2-identity-binding.v1"
 HEX64 = re.compile(r"^[0-9a-f]{64}$")
 HEX40 = re.compile(r"^[0-9a-f]{40}$")
+TIER2_HASH_SCOPES = {"primary_weight_file", "artifact_manifest", "coordinator_endorsed_incremental"}
 MODEL_KEY = re.compile(r"^[a-z0-9][a-z0-9._/-]{0,127}$")
 MODEL_ID = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]*/[A-Za-z0-9][A-Za-z0-9._-]*$")
 RFC3339 = re.compile(r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:\d{2})$")
@@ -874,6 +875,97 @@ def check_tier2_binding(candidate_data: bytes, tier2_data: bytes) -> None:
         fail(f"autotune/tier2 identity conflict on {len(conflicts)} model(s): " + "; ".join(conflicts))
 
 
+def load_tier2_republish_template(data: bytes) -> dict:
+    """Parse an operator-reviewed Tier-2 catalog body used as a republish
+    template for `stage-tier2-republish` (#608). Accepts either the unsigned
+    body shape or the full signed shape (an optional `signature` object is
+    ignored; the staged output is always unsigned)."""
+    value = strict_json(data, "tier2 republish template")
+    allowed = {"catalog_id", "expires_at", "issued_at", "models", "version", "signature"}
+    required = {"catalog_id", "expires_at", "issued_at", "models", "version"}
+    exact_keys(value, allowed, required, "tier2 republish template")
+    if value["version"] != 1:
+        fail("tier2 republish template: version must be 1")
+    if not isinstance(value["catalog_id"], str) or not value["catalog_id"].strip():
+        fail("tier2 republish template: catalog_id must be a non-empty string")
+    if not isinstance(value["issued_at"], str) or not value["issued_at"].strip():
+        fail("tier2 republish template: issued_at must be a non-empty string")
+    if not isinstance(value["expires_at"], str) or not value["expires_at"].strip():
+        fail("tier2 republish template: expires_at must be a non-empty string")
+    models = value["models"]
+    if not isinstance(models, list) or not models:
+        fail("tier2 republish template: models must be a non-empty array")
+    allowed_entry = {"artifact_kind", "hash_scope", "model_id", "min_ram_gb", "notes", "sha256", "source"}
+    required_entry = {"artifact_kind", "hash_scope", "model_id", "sha256", "source"}
+    seen: set[str] = set()
+    for idx, entry in enumerate(models):
+        label = f"tier2 republish template models[{idx}]"
+        if not isinstance(entry, dict):
+            fail(f"{label}: must be an object")
+        exact_keys(entry, allowed_entry, required_entry, label)
+        if entry["artifact_kind"] != "mlx_weight_file":
+            fail(f"{label}: artifact_kind must be mlx_weight_file")
+        if entry["hash_scope"] not in TIER2_HASH_SCOPES:
+            fail(f"{label}: unsupported hash_scope")
+        if not isinstance(entry["model_id"], str) or not entry["model_id"].strip():
+            fail(f"{label}: model_id must be a non-empty string")
+        if not isinstance(entry["sha256"], str) or not HEX64.fullmatch(entry["sha256"]):
+            fail(f"{label}: sha256 must be lowercase 64-hex")
+        if not isinstance(entry["source"], str) or not entry["source"].strip():
+            fail(f"{label}: source must be a non-empty string")
+        if "min_ram_gb" in entry and entry["min_ram_gb"] is not None and (
+            not isinstance(entry["min_ram_gb"], int)
+            or isinstance(entry["min_ram_gb"], bool)
+            or entry["min_ram_gb"] < 1
+        ):
+            fail(f"{label}: min_ram_gb must be a positive integer")
+        if "notes" in entry and entry["notes"] is not None and not isinstance(entry["notes"], str):
+            fail(f"{label}: notes must be a string")
+        normalized = entry["model_id"].strip().lower()
+        if normalized in seen:
+            fail(f"{label}: duplicate model_id {entry['model_id']!r}")
+        seen.add(normalized)
+    return value
+
+
+def stage_tier2_republish(template_obj: dict, binding_obj: dict) -> tuple[bytes, list[str]]:
+    """Project autotune-derived hashes from a validated
+    `tier2-identity-binding.json` object onto an operator-reviewed Tier-2
+    republish template, changing only `sha256` for model_ids that overlap.
+
+    This is deliberately NOT `derive_tier2_unsigned_body`: it never invents
+    `hash_scope`, `artifact_kind`, `min_ram_gb`, `notes`, or `source` — those
+    stay exactly as the operator wrote them in the template. It only closes
+    autotune/Tier-2 identity drift (#608) so the result can be reviewed and
+    handed to `scripts/sign-catalog.go sign`. It is not a second identity
+    authority: the caller must still run `check-tier2-binding` (this
+    function calls it internally) before treating the output as republish-
+    ready, and Pearl upload still goes through the reviewed sign + deploy
+    path, never this script alone.
+    """
+    binding_by_model: dict[str, str] = {}
+    for entry in binding_obj["models"]:
+        binding_by_model[entry["model_id"].strip().lower()] = entry["sha256"]
+    changed: list[str] = []
+    updated_models = []
+    for entry in template_obj["models"]:
+        normalized = entry["model_id"].strip().lower()
+        autotune_hash = binding_by_model.get(normalized)
+        new_entry = dict(entry)
+        if autotune_hash is not None and autotune_hash != entry["sha256"]:
+            changed.append(f"{entry['model_id']}: {entry['sha256']} -> {autotune_hash}")
+            new_entry["sha256"] = autotune_hash
+        updated_models.append(new_entry)
+    body = {
+        "catalog_id": template_obj["catalog_id"],
+        "expires_at": template_obj["expires_at"],
+        "issued_at": template_obj["issued_at"],
+        "models": updated_models,
+        "version": template_obj["version"],
+    }
+    return json.dumps(body, indent=2, sort_keys=True).encode("utf-8") + b"\n", changed
+
+
 def derive_tier2_unsigned_body(
     candidate_obj: dict,
     *,
@@ -1102,6 +1194,40 @@ def cmd_derive_tier2(
     del output_path
 
 
+def cmd_stage_tier2_republish(
+    candidate_path: pathlib.Path,
+    binding_path: pathlib.Path,
+    template_path: pathlib.Path,
+    output_path: pathlib.Path,
+) -> None:
+    """Stage an UNSIGNED Tier-2 republish body that resolves autotune/Tier-2
+    identity drift (#608) for a reviewed `template_path` catalog, using the
+    already-generated `tier2-identity-binding.json` as the autotune hash
+    source. Fails closed (does not write `output_path`) unless the staged
+    result agrees with `candidate_path` on every overlapping model_id, so a
+    caller cannot accidentally ship a body that still conflicts."""
+    candidate = candidate_path.read_bytes()
+    candidate_obj = validate_candidate(candidate)
+    binding_data = binding_path.read_bytes()
+    validate_tier2_identity_binding(binding_data, candidate, candidate_obj)
+    binding_obj = strict_json(binding_data, "tier2 identity binding")
+    template_obj = load_tier2_republish_template(template_path.read_bytes())
+    staged, changed = stage_tier2_republish(template_obj, binding_obj)
+    check_tier2_binding(candidate, staged)
+    output_path.write_bytes(staged)
+    if changed:
+        print("stage-tier2-republish: updated sha256 for " + "; ".join(changed))
+    else:
+        print("stage-tier2-republish: template already agrees with autotune; no sha256 changes")
+    print(
+        f"stage-tier2-republish: wrote unsigned body to {output_path} "
+        f"(autotune release={candidate_obj['version']!r}, models={len(template_obj['models'])}). "
+        "Review the diff, then sign with scripts/sign-catalog.go and republish "
+        "through the reviewed deploy path. This output is not a second identity "
+        "authority; check-tier2-binding already passed against the pinned candidate."
+    )
+
+
 def main() -> int:
     parser = argparse.ArgumentParser()
     sub = parser.add_subparsers(dest="command", required=True)
@@ -1133,6 +1259,26 @@ def main() -> int:
     derive_parser.add_argument("--catalog-id", required=True)
     derive_parser.add_argument("--issued-at", required=True)
     derive_parser.add_argument("--expires-at", required=True)
+    stage_parser = sub.add_parser("stage-tier2-republish")
+    stage_parser.add_argument(
+        "--candidate",
+        type=pathlib.Path,
+        default=CATALOG_DIR / "autotune-candidates.json",
+        help="autotune-candidates.json path",
+    )
+    stage_parser.add_argument(
+        "--binding",
+        type=pathlib.Path,
+        default=TIER2_BINDING_PATH,
+        help="tier2-identity-binding.json path (must match --candidate)",
+    )
+    stage_parser.add_argument(
+        "--template",
+        required=True,
+        type=pathlib.Path,
+        help="operator-reviewed Tier-2 catalog (signed or unsigned) to project autotune hashes into",
+    )
+    stage_parser.add_argument("--output", required=True, type=pathlib.Path)
     args = parser.parse_args()
     try:
         if args.command == "bootstrap":
@@ -1153,6 +1299,8 @@ def main() -> int:
                 issued_at=args.issued_at,
                 expires_at=args.expires_at,
             )
+        elif args.command == "stage-tier2-republish":
+            cmd_stage_tier2_republish(args.candidate, args.binding, args.template, args.output)
         else:
             fail(f"unknown command {args.command!r}")
     except (CatalogError, OSError, subprocess.SubprocessError) as exc:

--- a/scripts/test-catalog-release.sh
+++ b/scripts/test-catalog-release.sh
@@ -395,4 +395,89 @@ conflict = {
 PY
 expect_rejected "conflicting tier2 catalog in release directory"
 
+# #608 Partial: Llama-3.2 live-CONFLICT fixture proves check-tier2-binding
+# fails closed on the exact stale-vs-current hash pair observed on Pearl, and
+# that scripts/catalog-release.py stage-tier2-republish resolves it into an
+# agreeing unsigned body without touching derive-tier2's disabled path.
+python3 - "$VERIFY" "$CANONICAL" <<'PY'
+import importlib.util
+import json
+import pathlib
+import sys
+import tempfile
+
+spec = importlib.util.spec_from_file_location("catalog_release", sys.argv[1])
+module = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(module)
+canonical = pathlib.Path(sys.argv[2])
+candidate = (canonical / "autotune-candidates.json").read_bytes()
+candidate_obj = module.validate_candidate(candidate)
+binding_data = (canonical / "tier2-identity-binding.json").read_bytes()
+module.validate_tier2_identity_binding(binding_data, candidate, candidate_obj)
+binding_obj = module.strict_json(binding_data, "tier2-identity-binding")
+
+conflict_template = json.loads(
+    (canonical / "testdata" / "tier2-llama-conflict-template.json").read_bytes()
+)
+llama_row = next(
+    m for m in conflict_template["models"]
+    if m["model_id"] == "mlx-community/Llama-3.2-3B-Instruct-4bit"
+)
+STALE_LLAMA_SHA256 = "3975387f249977e5e8bfb7ed0d352f8258ac3d630f961ce1dd952f428ee7216a"
+CURRENT_LLAMA_SHA256 = "e7e5bff4248768b4db7a53afb3b514ba5867b800f63d1abd0330eaf08e54aa90"
+assert llama_row["sha256"] == STALE_LLAMA_SHA256, "fixture must encode the live Pearl stale hash"
+assert candidate_obj["rows"]["meta-llama/llama-3.2-3b-instruct"]["model_sha256"] == CURRENT_LLAMA_SHA256
+
+template_bytes = module.canonical_bytes(conflict_template)
+
+try:
+    module.check_tier2_binding(candidate, template_bytes)
+except module.CatalogError as exc:
+    message = str(exc)
+    if "Llama-3.2-3B-Instruct-4bit" not in message or STALE_LLAMA_SHA256 not in message or CURRENT_LLAMA_SHA256 not in message:
+        raise SystemExit(f"Llama conflict error missing expected hashes: {exc}")
+else:
+    raise SystemExit("stale Llama-3.2 tier2 fixture was accepted (must fail closed)")
+
+with tempfile.TemporaryDirectory() as directory:
+    staged_path = pathlib.Path(directory) / "tier2-staged.json"
+    staged_bytes, changed = module.stage_tier2_republish(
+        module.load_tier2_republish_template(json.dumps(conflict_template).encode()),
+        binding_obj,
+    )
+    if len(changed) != 1 or "Llama-3.2-3B-Instruct-4bit" not in changed[0]:
+        raise SystemExit(f"stage_tier2_republish changed unexpected rows: {changed!r}")
+    # Every overlapping model_id (all 9 in this fixture) must now agree with
+    # the current autotune release, not just Llama.
+    module.check_tier2_binding(candidate, staged_bytes)
+    staged_path.write_bytes(staged_bytes)
+
+    module.cmd_stage_tier2_republish(
+        canonical / "autotune-candidates.json",
+        canonical / "tier2-identity-binding.json",
+        canonical / "testdata" / "tier2-llama-conflict-template.json",
+        staged_path,
+    )
+    module.check_tier2_binding(candidate, staged_path.read_bytes())
+    staged_obj = json.loads(staged_path.read_bytes())
+    staged_models = {m["model_id"]: m["sha256"] for m in staged_obj["models"]}
+    if staged_models["mlx-community/Llama-3.2-3B-Instruct-4bit"] != CURRENT_LLAMA_SHA256:
+        raise SystemExit("staged republish body did not adopt the current autotune Llama hash")
+    for entry in staged_obj["models"]:
+        if entry["model_id"] == "mlx-community/Llama-3.2-3B-Instruct-4bit":
+            continue
+        original = next(m for m in conflict_template["models"] if m["model_id"] == entry["model_id"])
+        if entry != original:
+            raise SystemExit(f"stage-tier2-republish changed an already-agreeing row: {entry['model_id']}")
+
+    # Re-staging an already-agreeing body is a no-op (idempotent).
+    _, second_pass_changed = module.stage_tier2_republish(
+        module.load_tier2_republish_template(staged_path.read_bytes()),
+        binding_obj,
+    )
+    if second_pass_changed:
+        raise SystemExit(f"re-staging an agreeing body should be a no-op, got: {second_pass_changed!r}")
+print("llama tier2 conflict fixture + stage-tier2-republish checks locked")
+PY
+
 echo "PASS: catalog release generation and trust failures are locked"


### PR DESCRIPTION
## Summary
- Adds `scripts/catalog-release.py stage-tier2-republish` to rewrite Tier-2 `sha256` rows from autotune via `tier2-identity-binding.json` (staging aid only; not a second identity authority).
- Locks the live Pearl Llama-3.2 CONFLICT fixture (`3975387f…` → `e7e5bff4…`) and hermetic checks in `scripts/test-catalog-release.sh`.
- Documents the reviewed republish path in `ops/runbooks/608-llama-tier2-republish.md`. **Does not execute Pearl cutover/apply steps.**

Refs #608 (Partial: tooling + fixture + runbook). Leave #608 open — Pearl dual-catalog apply remains a separate explicit operator step.

## Test plan
- [x] `python3 scripts/catalog-release.py verify`
- [x] `check-tier2-binding` against conflict fixture fails with Llama-3.2 stale/current hashes
- [x] `stage-tier2-republish` + `check-tier2-binding` on staged output passes
- [x] `bash scripts/test-catalog-release.sh`
- [x] `go test ./internal/catalogbind/ ./internal/tier2/` in `phase4-coordinator`
- [ ] CI green on this PR

## Remaining on #608 (do not execute from this PR)
- Operator-reviewed sign + Pearl deploy / dual-catalog cutover
- Physical `/opt/macprovider/tier2-catalog.json` authority removal
- Exception clearance / journey proof

SPEC-GOVERNANCE-DECLARATION-BEGIN
{
  "schema_version": "spec-pr-governance-v1",
  "behavior_change": "yes",
  "contract_change": "none",
  "issue": "https://github.com/Augustas11/macprovider/issues/608",
  "specs": ["SPEC-010", "SPEC-008"],
  "requirements": ["SPEC-010-R004"],
  "authority_domains": ["model-catalog-identity", "tier2-trust-evidence"],
  "arbitration": ["CODE_BUG"],
  "tests": [
    "python3 scripts/catalog-release.py verify",
    "bash scripts/test-catalog-release.sh",
    "go test ./internal/catalogbind/ ./internal/tier2/ (phase4-coordinator)"
  ],
  "journeys": ["not-required"]
}
SPEC-GOVERNANCE-DECLARATION-END