### PR TITLE
test(harness): P3 thermal-soak instrument — B10 sustained-TPS retention (RESEARCH_235)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -75,7 +75,11 @@ phase4-coordinator/stats.test
 .deepsec-local/
 test/network-harness/artifacts/
 test/network-harness/harness
+test/network-harness/out-soak-30b/
 test/e2e/aead-rekey-oneshot/artifacts/
+# RESEARCH_235 thermal soak: raw device telemetry + correlation output.
+test/e2e/thermal-soak/out/
+test/e2e/thermal-soak/*.ndjson
 
 # Local #615 audit artifacts (reports/diffs; keep out of PRs)
 scratchpad/615-audit/

--- a/audits/2026-07-22/AUDIT_235_R2_ADDENDUM.md
+++ b/audits/2026-07-22/AUDIT_235_R2_ADDENDUM.md
@@ -1,0 +1,59 @@
+# AUDIT_235 R2 — re-audit after R1 fixes (thermal-soak instrument)
+
+Branch `research/235-thermal-soak` (macprovider). R1 three-lane codex audit
+returned findings; all were fixed. RE-VERIFY, in your lane, that each finding
+below is resolved AND that the fix introduced no regression. Report severity
+CRITICAL / HIGH / MEDIUM / LOW / INFO with file:line. Merge bar: 0 C / 0 H /
+0 M. Read the CURRENT files (not the R1 diff). `go build/test/vet` are green in
+`test/network-harness`.
+
+## What changed since R1 (verify each)
+
+### Code / architect lane (benchmark.go, benchmark_test.go)
+- **B10 final-window anchoring (was code-MEDIUM / architect-HIGH).**
+  `computeBuyerMetrics` now derives `runStart`/`runEnd` from the earliest/latest
+  timestamp over **ALL** results (including failed/disconnected ones, whose
+  StartUTC/EndUTC are set at dispatch). `computeSustainedTPS(samples, runStart,
+  runEnd)` windows `[runStart, runStart+300s)` and `(runEnd-300s, runEnd]`,
+  anchored to the true run span — NOT the last successful sample. Verify:
+  - A near-end provider disconnect (healthy early samples, then only failures to
+    run end) → empty final window → B10 **SKIP**, never a false ~1.0 PASS.
+    (test `TestB10_Retention_Skip_ProviderStopsBeforeEnd`.)
+  - Run span < 2×window (600s) → zero-count windows → **SKIP**, no overlapping
+    windows. (test `TestB10_Retention_Skip_ShortRunOverlappingWindows`.)
+  - Final-window lower bound is now **exclusive** (`s.start.After(finalCutoff)`).
+  - No new div-by-zero / NaN / boundary regression; existing PASS/WARN/FAIL/
+    unarmed-downgrade tests still hold.
+
+### Security lane
+- **Prod-host reachability (was HIGH).** `rejectProdHost` in
+  `internal/scenario/schema.go` now hard-fails validation for any scenario
+  declaring `B10` whose `gateway_url` or `coordinator_url` host is
+  `streamvc.live` or a subdomain. Verify a B10 scenario cannot be pointed at
+  prod by any URL/env value, subdomain/apex/case variations are covered, and a
+  non-B10 scenario is unaffected (test `TestB10_LabOnly_RejectsProdHost`). The
+  README prod-stack exception was removed.
+- **Bash arithmetic injection (was MEDIUM).** `thermal-collector.sh` now
+  strictly validates `--interval` (`^[1-9][0-9]{0,3}$`, ≤3600) and `--duration`
+  (`^(0|[1-9][0-9]{0,6})$`, ≤604800) BEFORE any `$((...))`, runs unprivileged
+  (sudo scoped to the internal `powermetrics` call), and sets `umask 077`.
+  Verify no remaining unvalidated-operand path and that raw device text→`python3
+  -c json.dumps` still can't inject.
+- **LOW carried/fixed:** `.gitignore` now covers `test/e2e/thermal-soak/out/`,
+  `*.ndjson`, and `test/network-harness/out-soak-30b/`. Joiner memory is still
+  load-all (documented LOW, local operator tool on own files).
+
+### Architect lane (scenario + README + SPEC + joiner)
+- **Scenario duration cap (was MEDIUM):** `requests_per_buyer` 1000→5000 so
+  `duration` is the terminating condition even on a fast provider.
+- **Thermal-join channel loss (was HIGH):** `join-thermal.py` now matches
+  `pmset` and `powermetrics` **independently** (per-source nearest), emits each
+  channel's timestamp + `*_skew_s`, and returns null beyond `--max-skew-seconds`
+  (default 30). Verify both channels attach and stale samples are dropped.
+- **Broken operator recipe (was MEDIUM):** README uses path-stable absolute
+  paths, points the window fields to `benchmark_summary.json`
+  (`buyer_metrics.sustained_tps`), drops top-level `sudo`, and reframes the
+  "safe sustained-load envelope" as a D3 **sweep** (scenario 15 = one stress
+  point). SPEC §5 artifact example gained the `sustained_tps` object.
+
+Focus your lane on: are these resolved, and did any fix create a NEW C/H/M?

--- a/audits/2026-07-22/AUDIT_235_R3_ADDENDUM.md
+++ b/audits/2026-07-22/AUDIT_235_R3_ADDENDUM.md
@@ -1,0 +1,55 @@
+# AUDIT_235 R3 — re-audit after R2 fixes (thermal-soak instrument)
+
+Branch `research/235-thermal-soak` (macprovider). R2 findings were all fixed.
+RE-VERIFY, in your lane, that each is resolved AND introduced no regression.
+Report CRITICAL / HIGH / MEDIUM / LOW / INFO with file:line. Merge bar: 0 C /
+0 H / 0 M. Read CURRENT files. `go build/test/vet` green in `test/network-harness`.
+
+## R2 fixes to verify
+
+### Security / code / architect — prod-reachability (was the R2 HIGH on all lanes)
+The R1 streamvc.live DENYLIST was bypassable (trailing root dot, IDNA/full-width
+separators, uppercase, and it was skipped when `benchmark.enabled=false`). R2
+replaces it with a POSITIVE lab-host ALLOWLIST:
+- `LabHostAllowed(host)` in `internal/scenario/schema.go` accepts ONLY loopback /
+  RFC1918-private / link-local IPs or `"localhost"` (host canonicalized:
+  lowercased, trailing dot trimmed). Every public host — prod, subdomain, apex,
+  trailing-dot, full-width/ideographic-dot, arbitrary FQDN — is rejected.
+- The guard runs whenever the scenario declares `B10`, **regardless of
+  `benchmark.enabled`** (`BenchmarkHasB10()`), because the sustained buyer load
+  runs even when scoring is off.
+- `loadgen.go` sets `CheckRedirect` for B10 scenarios so a lab gateway cannot
+  3xx-redirect the soak to a non-lab host.
+- Regression test `TestB10_LabOnly_RejectsProdHost` covers loopback/localhost/
+  private/ipv6 ok; prod apex/subdomain/uppercase/trailing-dot/full-width/
+  ideographic-dot and arbitrary public host rejected; disabled-benchmark still
+  guarded; non-B10 still allowed to target prod.
+  Verify: is there ANY remaining value (URL form, env expansion, redirect,
+  userinfo, IP-encoding trick like decimal/hex/IPv4-mapped-IPv6) by which a B10
+  scenario reaches a public host? Confirm the allowlist has no false-negative
+  that would reject a legitimate loopback/LAN lab, and no new regression.
+
+### Architect / code — thermal join B10 parity + stale skew
+- `join-thermal.py` `streaming_tps()` now mirrors B10's success filter
+  (`outcome == "ok"` and `http_status < 400`), so a failed stream with partial
+  usage no longer contributes a TPS point (overlay matches the scored
+  population). Verify field names match `per_request.jsonl` (`outcome`,
+  `http_status`, `stream`, `start_utc`, `ttft_ms`, `completion_tokens_received`,
+  `last_byte_utc`).
+- `nearest_thermal` now returns `(None, None)` beyond `--max-skew-seconds` (null
+  skew), matching the docstring + README. pmset/powermetrics still matched
+  independently with per-channel skew.
+
+### Architect — envelope wording + SPEC example
+- README and `15_thermal_soak.yaml` now say scenario 15 is ONE stress point and
+  the safe-load envelope needs a D3 sweep (was: "produces the envelope").
+- SPEC §5 artifact example now shows `scenario: 15_thermal_soak`,
+  `duration_seconds: 3600` (a <600s run SKIPs with zero windows, so the old
+  07/300s example with nonzero `sustained_tps` was impossible).
+
+## Carried LOW (documented, not blocking)
+- `join-thermal.py` loads both inputs fully into memory / rescans each channel
+  per bin — a local operator post-processing tool run on the operator's own
+  files; acceptable for the parked campaign.
+
+Focus your lane: are the R2 fixes resolved, and did any create a NEW C/H/M?

--- a/audits/2026-07-22/AUDIT_235_THERMAL_SOAK_ARCHITECT_PROMPT.md
+++ b/audits/2026-07-22/AUDIT_235_THERMAL_SOAK_ARCHITECT_PROMPT.md
@@ -1,0 +1,73 @@
+# AUDIT_235 — thermal-soak instrument — ARCHITECT lane
+
+You are auditing a **test-harness change** on branch `research/235-thermal-soak`
+in the macprovider repo. Review for ARCHITECTURE / DESIGN-COHERENCE issues
+(this lane). Report findings CRITICAL / HIGH / MEDIUM / LOW / INFO with
+file:line and a concrete recommendation. Bar for merge: 0 CRITICAL, 0 HIGH,
+0 MEDIUM.
+
+## What the change is
+
+RESEARCH_235 builds the *instrument* for a thermal/sustained-load soak (issue
+#584: sustained synthetic load collapsed a healthy provider ~30 → 8.9 → 5.3
+tok/s and disconnected it — a thermal/sustained-throughput degradation no test
+in the repo characterizes). The soak *run* is the real deliverable but is
+PARKED until a dedicated lab Mac exists; this session ships only the instrument
+so it's ready the moment hardware is. Parts:
+
+1. Benchmark invariant **B10** "sustained streaming-TPS retention"
+   (`internal/benchmark/benchmark.go`): windows streaming decode-TPS p50 into a
+   first-5min and last-5min window; retention = final/first; PASS ≥0.85 / WARN
+   ≥0.70 / FAIL <0.70 (**provisional** — calibrated later from a real run), SKIP
+   <8 samples/window. Gated behind a scenario `sustained_gate_armed` flag
+   (default false → would-be FAIL downgraded to WARN) so the uncalibrated gate
+   never blocks.
+2. Scenario `scenarios/15_thermal_soak.yaml`: 45–60 min, 2 buyers, stream,
+   max_tokens=64, 30B model, targets a LAB stack.
+3. `test/e2e/thermal-soak/`: `thermal-collector.sh` (pmset + powermetrics →
+   NDJSON) and `join-thermal.py` (correlate TPS decay to thermal), + README.
+
+## Focus for THIS lane (design coherence)
+
+- **Invariant-ID choice.** The forcing prompt said "B8", but B8/B9 are claimed
+  by RESEARCH_236 (open PR #696, unmerged). This change uses **B10** to avoid a
+  collision regardless of merge order, and documents the B8/B9 gap. Is B10 the
+  right call, and is the gap documented coherently in benchmark.go, schema.go,
+  and SPEC §3.5? Any residual place that still says B8?
+- **Metric basis.** B10 uses *streaming* decode-TPS (post-TTFT tokens / decode
+  duration), NOT the non-streaming `sustained_tps` field (which is
+  structurally unreliable — reads 17k–33k tok/s for a warm 30B). Confirm the
+  chosen basis is consistent with B2 and that the code doesn't accidentally mix
+  in the unreliable field.
+- **Pacing / scenario design.** Scenario 15 uses 2 buyers + a 1s inter-request
+  floor to keep the provider continuously busy while capping concurrency at ≤2
+  (within Pearl N_eff=2.5). Reuses scenario 07's pacing model. Is this a
+  faithful "sustained load" characterization, or will it under/over-drive the
+  provider vs the #584 incident's load? Is 5-min windows × ≥8-sample floor
+  well-matched to the 45–60 min duration and expected request rate?
+- **Provisional/unarmed posture.** The task explicitly wants B10 shipped
+  provisional and the gate left UNARMED until a lab soak calibrates it (mirrors
+  RESEARCH_236's CacheGateArmed). Verify the `sustained_gate_armed` mechanism
+  actually delivers "measures + reports but never blocks" until armed, and that
+  the SPEC/scenario/README consistently say so. Flag any place that reads as
+  final-calibrated.
+- **Fit with the existing suite.** Does B10 slot cleanly next to B1-B7 (verdict
+  shape, SKIP semantics, WARN-doesn't-block convention)? Does the new
+  `SustainedTPSMetrics` on `BuyerMetrics` and the `SustainedGateArmed` scenario
+  field fit the established patterns (cf. ColdWarm/B7, ProviderSlots)?
+- **Deliverable completeness for an INSTRUMENT-ONLY session.** Given the run is
+  parked, is what ships self-sufficient — will a fresh operator with a lab Mac
+  be able to run the soak, get a B10 verdict, and correlate thermal from the
+  README + scripts alone? Is the parked D3 (report + safe-load envelope +
+  #463 recommendation) clearly flagged as pending, not silently dropped?
+- **Scope discipline.** Did the change avoid touching scenario 07/08 or the
+  money path? Any scope creep?
+
+## How to review
+
+Branch checked out at repo root. Read the full files listed above plus
+`docs/notes/SPEC-NETWORK-BENCHMARK-v0.1.md` §3.5/§4.15 and
+`test/e2e/thermal-soak/README.md`. This is a research/test-harness change, not
+money-path — judge design coherence and whether the instrument is fit to be run
+later, not production-deployment concerns. Do NOT flag the provisional
+threshold *values* (calibrated later by design).

--- a/audits/2026-07-22/AUDIT_235_THERMAL_SOAK_CODE_PROMPT.md
+++ b/audits/2026-07-22/AUDIT_235_THERMAL_SOAK_CODE_PROMPT.md
@@ -1,0 +1,74 @@
+# AUDIT_235 — thermal-soak instrument — CODE-CORRECTNESS lane
+
+You are auditing a **test-harness change** on branch `research/235-thermal-soak`
+in the macprovider repo. Review the diff vs `origin/main` for CODE-CORRECTNESS
+issues only (this lane). Do NOT rewrite; report findings with severity
+CRITICAL / HIGH / MEDIUM / LOW / INFO, each with file:line and a concrete fix.
+Bar for merge: 0 CRITICAL, 0 HIGH, 0 MEDIUM.
+
+## What the change is
+
+RESEARCH_235 builds the *instrument* for a thermal/sustained-load soak test
+(issue #584: a sustained synthetic load collapsed a healthy provider's
+throughput ~30 → 8.9 → 5.3 tok/s and disconnected it). NO soak has been run;
+the campaign is parked pending a lab Mac. Three parts:
+
+1. **New benchmark invariant `B10` "sustained streaming-TPS retention"** in
+   `test/network-harness/internal/benchmark/benchmark.go`. It windows the
+   per-request *streaming* decode-TPS distribution (tokens / (last_byte −
+   (start + ttft)) — the same basis as B2, NOT the non-streaming sustained_tps
+   field) by wall-clock StartUTC into a first window ([t0, t0+300s)) and a
+   final window ((tEnd−300s, tEnd]), computes `retention = final_p50 /
+   first_p50`, and scores it PASS ≥0.85 / WARN ≥0.70 / FAIL <0.70. SKIP if
+   either window has <8 samples. A scenario flag `sustained_gate_armed`
+   (default false) downgrades a would-be FAIL to WARN so the uncalibrated gate
+   can't block. New: `SustainedTPSMetrics` struct, `computeSustainedTPS`,
+   `evalB10`, case dispatch, constants, unit tests.
+2. **B10 added to the scenario invariant allow-list** in
+   `test/network-harness/internal/scenario/schema.go` (was B1-B7), plus a new
+   `SustainedGateArmed bool` field on the `Benchmark` struct.
+3. Scenario YAML + provider-side shell/python capture scripts (audited in the
+   architect/security lanes; this lane focuses on the Go).
+
+## Focus for THIS lane (correctness)
+
+- Is the windowing math correct? t0/tEnd derivation, the `Before`/`!Before`
+  boundary conditions on `firstCutoff`/`finalCutoff`, off-by-one/edge cases
+  (single sample, all-same-timestamp, empty). Could a sample be double-counted
+  or dropped at a boundary in a way that biases retention?
+- Overlapping windows on short runs: the code documents that first/final can
+  overlap when the run is <10 min and relies on the ≥8-sample floor as the
+  guard, not disjointness. Is that reasoning sound, or can it produce a
+  misleading retention (e.g. retention ≈ 1.0 that hides decay) on a real
+  45–60 min soak? Is there any way the two windows silently coincide on a
+  long run?
+- `retention = final_p50 / first_p50` guards `first_p50 > 0`. Any div-by-zero,
+  NaN, or Inf path? What if all TPS samples are equal / zero?
+- `percentile` reuse: `computeSustainedTPS` calls the package `percentile`
+  helper on unsorted slices — confirm that's safe (the helper sorts if
+  needed) and that passing the same backing array isn't mutated unexpectedly.
+- `evalB10` status logic: verify the armed vs unarmed branch. Unarmed must
+  NEVER emit FAIL (the test `TestB10_Retention_Unarmed_DowngradesFailToWarn`
+  asserts `!res.AnyFailed()`); confirm no path violates that.
+- The unit-test fixture `makeTPSResult` sets TTFT=200ms, tokens=64 and derives
+  LastByteUTC so TPS is exact. Confirm the fixtures actually exercise the
+  PASS/WARN/FAIL/SKIP boundaries they claim (0.933/0.80/0.60), and that
+  `soakResults` produces disjoint 5-min windows with 10 samples each.
+- Any Go correctness smell: unused vars, shadowing, integer/float division,
+  slice aliasing, time-zone assumptions on StartUTC.
+- Back-compat: does adding the `SustainedTPS` field (json:"sustained_tps") to
+  `BuyerMetrics` or the allow-list change break any existing artifact
+  consumer or existing B1-B7 behavior?
+
+## How to review
+
+The branch is checked out at the repo root you're invoked in. Read the full
+files, not just the diff:
+- `test/network-harness/internal/benchmark/benchmark.go`
+- `test/network-harness/internal/benchmark/benchmark_test.go`
+- `test/network-harness/internal/scenario/schema.go`
+
+`go build ./... && go test ./... && go vet ./...` are GREEN in
+`test/network-harness`. Report only real defects; provisional thresholds are
+intentional (they're calibrated later from a lab run) — do NOT flag the
+threshold *values* as wrong, but DO flag any logic that mis-applies them.

--- a/audits/2026-07-22/AUDIT_235_THERMAL_SOAK_SECURITY_PROMPT.md
+++ b/audits/2026-07-22/AUDIT_235_THERMAL_SOAK_SECURITY_PROMPT.md
@@ -1,0 +1,66 @@
+# AUDIT_235 — thermal-soak instrument — SECURITY lane
+
+You are auditing a **test-harness change** on branch `research/235-thermal-soak`
+in the macprovider repo. Review the diff vs `origin/main` for SECURITY issues
+only (this lane). Report findings CRITICAL / HIGH / MEDIUM / LOW / INFO with
+file:line and a concrete fix. Bar for merge: 0 CRITICAL, 0 HIGH, 0 MEDIUM.
+
+## What the change is
+
+RESEARCH_235 builds the *instrument* for a thermal/sustained-load soak (issue
+#584). It adds a Go benchmark invariant (B10), a scenario YAML, and two
+provider-side capture scripts that run on a LAB Mac. No soak has run.
+
+## Focus for THIS lane (security)
+
+1. **Prod-safety / blast radius** — the single most important property. The
+   soak MUST NOT be runnable against production, because a sustained load
+   degrades and disconnects the prod mac (that IS #584). Verify:
+   - `test/network-harness/scenarios/15_thermal_soak.yaml` targets
+     `${LAB_GATEWAY_URL}` / `${LAB_COORDINATOR_URL}`, which are unset by
+     default. Confirm the harness env-expansion + `Validate()` behavior means
+     an unset lab URL → empty gateway_url → validation ERROR (fail-closed), so
+     you cannot accidentally fire at a baked-in prod default. Is there ANY
+     path (default value, fallback, other scenario field) by which this
+     scenario could hit `streamvc.live`?
+   - The committed-scenarios test (`schema_test.go`) seeds
+     `LAB_GATEWAY_URL`/`LAB_COORDINATOR_URL` placeholders so the structural
+     test passes. Confirm that seeding is test-scoped (`t.Setenv`) and does
+     NOT leak a usable default into the runtime path.
+
+2. **Secret handling** — the buyer token (`~/.config/macprovider/buyer-api-key`)
+   must never be committed or echoed. Check the scripts and YAML:
+   - `test/e2e/thermal-soak/thermal-collector.sh`
+   - `test/e2e/thermal-soak/join-thermal.py`
+   - `test/e2e/thermal-soak/README.md`
+   - scenario 15 YAML (uses `${BUYER_TOKEN}`).
+   Any place a token, DSN, or credential could be logged, embedded, or written
+   to the NDJSON output?
+
+3. **Shell-injection / command-exec in `thermal-collector.sh`** — it runs
+   `sudo powermetrics ...`, `pmset -g therm`, pipes tool output through
+   `awk`/`python3 -c` (`json_str`), and writes to a `--out` path. Check:
+   - Are any argument values (`--out`, `--interval`, `--duration`) used
+     unsafely (unquoted expansion, path traversal, arithmetic injection in
+     `$((...))`)?
+   - `powermetrics` raw output is passed to `python3 -c 'json.dumps(...)'` via
+     stdin — confirm the raw device text can't break out of JSON or inject
+     into the shell. Is the `sudo` usage minimal and scoped?
+   - Does the script fail safely on a non-macOS host (it checks `uname`)?
+
+4. **`join-thermal.py`** — parses two untrusted-ish NDJSON/JSONL files. Any
+   unsafe eval, path handling, or resource-exhaustion (unbounded memory on a
+   huge file)? It's stdlib-only; confirm no `eval`/`exec`/`pickle`/`os.system`.
+
+5. **Data exposure in artifacts** — the NDJSON thermal log preserves raw tool
+   output under a `"raw"` field. Could that raw text contain anything sensitive
+   (hostnames, serials, user paths) that shouldn't land in a committed or
+   shared artifact? Flag if the README implies committing raw logs.
+
+## How to review
+
+The branch is checked out at the repo root. Read the full files. The threat
+model is: an operator runs these on a lab Mac they control; the main risk is
+(a) accidentally hitting prod, (b) leaking the buyer token, (c) shell/JSON
+injection from device tool output. Do NOT flag the provisional B10 thresholds
+(that's a calibration matter, not security).

--- a/docs/notes/SPEC-NETWORK-BENCHMARK-v0.1.md
+++ b/docs/notes/SPEC-NETWORK-BENCHMARK-v0.1.md
@@ -199,7 +199,8 @@ FAIL + supporting evidence). Unlike I1-I4, WARN does not block the run.
     "tail_ratio_p99_p50": 2.7,
     "error_rate_per_1k": 3.0,
     "total_requests": 150,
-    "non_2xx_breakdown": {"429": 2, "503": 1, "502": 0}
+    "non_2xx_breakdown": {"429": 2, "503": 1, "502": 0},
+    "sustained_tps": {"first_window_tps_p50": 30.4, "final_window_tps_p50": 27.9, "retention": 0.92, "first_window_samples": 61, "final_window_samples": 58}
   },
   "provider_metrics": {
     "per_provider": [

--- a/docs/notes/SPEC-NETWORK-BENCHMARK-v0.1.md
+++ b/docs/notes/SPEC-NETWORK-BENCHMARK-v0.1.md
@@ -124,6 +124,11 @@ single bad run doesn't trip the alert).
 | B5 | Slot util reasonable | ≥ 15% over 5-min window |
 | B6 | Earnings/hr viable | ≥ $0.30/hr at current pricing |
 | B7 | Cold/warm TTFT ratio bounded | cold p50 / warm p50 ≤ 2.0 (scenario 08) |
+| B10 | Sustained streaming-TPS retention | final-5min TPS p50 / first-5min TPS p50 over a 45–60 min soak (scenario 15): PASS ≥ 0.85, WARN ≥ 0.70, FAIL < 0.70. **PROVISIONAL / UNARMED** — thresholds are pre-run guesses; scenario 15 sets `sustained_gate_armed: false` so a would-be FAIL downgrades to WARN until a lab soak calibrates them (#584). SKIP if either window has < 8 streaming samples. |
+
+(B8/B9 — sticky cache-reuse retention + cached-turn latency — are added by
+RESEARCH_236; B10 skips that range so the two tests never collide on an ID
+regardless of merge order.)
 
 Like I1-I4, each invariant produces a structured verdict (PASS / WARN /
 FAIL + supporting evidence). Unlike I1-I4, WARN does not block the run.
@@ -159,6 +164,25 @@ FAIL + supporting evidence). Unlike I1-I4, WARN does not block the run.
   tier-2 pricing, session_duration.
 - **Invariants**: B5, B6 (B7 session-mean deferred — needs >>10-min
   windows).
+
+### 4.15 `15_thermal_soak` (RESEARCH_235, #584)
+- **What**: 45–60 min (`duration: 3600s`) sustained-decode soak at N=2
+  concurrent buyers, streaming, `max_tokens=64`, one model per run (start
+  with the 30B — the prod model class that collapsed on 2026-07-13). Short
+  (1s) inter-request floor keeps the provider continuously busy while the
+  2-buyer cap holds concurrency ≤ 2 (within Pearl N_eff=2.5).
+- **Measures**: how much streaming decode-TPS the provider RETAINS from the
+  first 5 min to the last 5 min under constant load, correlated with a
+  provider-side thermal log (`test/e2e/thermal-soak/`).
+- **Invariants**: B1, B2, B3, B4, B5, **B10** (sustained-TPS retention).
+- **LAB PROVIDER ONLY.** Targets `${LAB_GATEWAY_URL}`/`${LAB_COORDINATOR_URL}`
+  (unset by default → validation fails rather than firing at a default).
+  Never run against `streamvc.live` — a soak degrades and disconnects the
+  single prod mac (that IS #584). Parked at the campaign step until a
+  dedicated lab Mac exists; the instrument (scenario + B10 + thermal
+  capture) ships now, calibration follows the first lab run.
+- **B10 is provisional/unarmed** until that first run recalibrates the
+  thresholds; see §3.5.
 
 ## 5. Artifact schema (`benchmark_summary.json`)
 

--- a/docs/notes/SPEC-NETWORK-BENCHMARK-v0.1.md
+++ b/docs/notes/SPEC-NETWORK-BENCHMARK-v0.1.md
@@ -188,7 +188,7 @@ FAIL + supporting evidence). Unlike I1-I4, WARN does not block the run.
 
 ```json
 {
-  "scenario": "15_thermal_soak",
+  "scenario": "thermal_soak",
   "scenario_version": "v0.1",
   "run_id": "20260628T180000Z",
   "duration_seconds": 3600,

--- a/docs/notes/SPEC-NETWORK-BENCHMARK-v0.1.md
+++ b/docs/notes/SPEC-NETWORK-BENCHMARK-v0.1.md
@@ -188,10 +188,10 @@ FAIL + supporting evidence). Unlike I1-I4, WARN does not block the run.
 
 ```json
 {
-  "scenario": "07_sustained_throughput",
+  "scenario": "15_thermal_soak",
   "scenario_version": "v0.1",
   "run_id": "20260628T180000Z",
-  "duration_seconds": 300,
+  "duration_seconds": 3600,
   "buyer_metrics": {
     "ttft_ms": {"p50": 612, "p95": 1840, "p99": 3210},
     "streaming_tps": {"p50": 42, "p95": 18},

--- a/scratchpad/235-audit-architect-r2.log
+++ b/scratchpad/235-audit-architect-r2.log
@@ -1,0 +1,1 @@
+/Users/augstar/macprovider-235/.omc/artifacts/ask/codex-audit-235-thermal-soak-instrument-architect-lane-you-are-aud-2026-07-22T16-48-45-517Z.md

--- a/scratchpad/235-audit-architect-r3.log
+++ b/scratchpad/235-audit-architect-r3.log
@@ -1,0 +1,1 @@
+/Users/augstar/macprovider-235/.omc/artifacts/ask/codex-audit-235-thermal-soak-instrument-architect-lane-you-are-aud-2026-07-22T17-03-02-449Z.md

--- a/scratchpad/235-audit-architect.log
+++ b/scratchpad/235-audit-architect.log
@@ -1,0 +1,1 @@
+/Users/augstar/macprovider-235/.omc/artifacts/ask/codex-audit-235-thermal-soak-instrument-architect-lane-you-are-aud-2026-07-22T16-31-53-536Z.md

--- a/scratchpad/235-audit-code-r2.log
+++ b/scratchpad/235-audit-code-r2.log
@@ -1,0 +1,1 @@
+/Users/augstar/macprovider-235/.omc/artifacts/ask/codex-audit-235-thermal-soak-instrument-code-correctness-lane-you--2026-07-22T16-46-35-563Z.md

--- a/scratchpad/235-audit-code-r3.log
+++ b/scratchpad/235-audit-code-r3.log
@@ -1,0 +1,1 @@
+/Users/augstar/macprovider-235/.omc/artifacts/ask/codex-audit-235-thermal-soak-instrument-code-correctness-lane-you--2026-07-22T17-00-36-988Z.md

--- a/scratchpad/235-audit-code.log
+++ b/scratchpad/235-audit-code.log
@@ -1,0 +1,1 @@
+/Users/augstar/macprovider-235/.omc/artifacts/ask/codex-audit-235-thermal-soak-instrument-code-correctness-lane-you--2026-07-22T16-31-10-211Z.md

--- a/scratchpad/235-audit-security-r2.log
+++ b/scratchpad/235-audit-security-r2.log
@@ -1,0 +1,1 @@
+/Users/augstar/macprovider-235/.omc/artifacts/ask/codex-audit-235-thermal-soak-instrument-security-lane-you-are-audi-2026-07-22T16-48-50-232Z.md

--- a/scratchpad/235-audit-security-r3.log
+++ b/scratchpad/235-audit-security-r3.log
@@ -1,0 +1,1 @@
+/Users/augstar/macprovider-235/.omc/artifacts/ask/codex-audit-235-thermal-soak-instrument-security-lane-you-are-audi-2026-07-22T17-01-43-726Z.md

--- a/scratchpad/235-audit-security.log
+++ b/scratchpad/235-audit-security.log
@@ -1,0 +1,1 @@
+/Users/augstar/macprovider-235/.omc/artifacts/ask/codex-audit-235-thermal-soak-instrument-security-lane-you-are-audi-2026-07-22T16-31-30-929Z.md

--- a/scratchpad/235-pr-body.md
+++ b/scratchpad/235-pr-body.md
@@ -1,0 +1,84 @@
+## RESEARCH_235 — P3 thermal / sustained-load soak instrument (B10)
+
+Builds the **instrument** for a thermal/sustained-load soak that characterizes
+issue #584 (2026-07-13: sustained synthetic load collapsed a healthy provider
+~30 → 8.9 → 5.3 tok/s, then stale heartbeats → WS EOF → removed from pool — a
+thermal/sustained-throughput degradation no test in the repo captured). Same
+instrument-now / campaign-later split as RESEARCH_234's cold cell.
+
+**The soak run is PARKED** — it needs a dedicated lab Mac (running it against
+prod reproduces the #584 outage). This PR ships only the instrument so it is
+ready the moment hardware exists.
+
+### What's in this PR
+
+1. **Benchmark invariant `B10` "sustained streaming-TPS retention"**
+   (`test/network-harness/internal/benchmark/benchmark.go`). Windows the
+   per-request *streaming* decode-TPS distribution (tokens / (last_byte −
+   (start + ttft)) — same basis as B2, **not** the structurally-unreliable
+   non-streaming `sustained_tps` field) by wall-clock start into a first-5min
+   and last-5min window; `retention = final_p50 / first_p50`. Bands **PASS ≥
+   0.85 / WARN ≥ 0.70 / FAIL < 0.70**, SKIP if either window has < 8 samples.
+   Emits `first_window_tps_p50`, `final_window_tps_p50`, `retention`, and
+   per-window sample counts.
+   - **Invariant ID is B10, not B8.** B8/B9 are claimed by RESEARCH_236 (open
+     PR #696). main has through B7; B10 skips that range so the two never
+     collide regardless of merge order.
+   - **Thresholds are PROVISIONAL and the gate is UNARMED.** A new scenario flag
+     `sustained_gate_armed` (default false) downgrades a would-be FAIL to WARN
+     so the uncalibrated gate can never block a run. Arm it only after the first
+     lab soak recalibrates the thresholds (mirrors RESEARCH_236's
+     `cache_gate_armed`).
+2. **Scenario `scenarios/15_thermal_soak.yaml`** — 45–60 min (3600s), 2 buyers,
+   streaming, `max_tokens=64`, 30B model, 1s inter-request floor (continuous
+   busy, ≤ 2 concurrent within Pearl N_eff=2.5). Targets `${LAB_GATEWAY_URL}` /
+   `${LAB_COORDINATOR_URL}`, **unset by default so a bare run fails validation
+   rather than hitting `streamvc.live`** (LAB PROVIDER ONLY). Invariants
+   B1-B5,B10. B10 added to the scenario invariant allow-list + a
+   `SustainedGateArmed` field on the scenario `Benchmark` struct.
+3. **Provider-side thermal capture** `test/e2e/thermal-soak/` (sibling to
+   `coldwarm-ttft/`): `thermal-collector.sh` (samples `pmset -g therm` +
+   `sudo powermetrics --samplers smc,cpu_power,gpu_power` → timestamped NDJSON),
+   `join-thermal.py` (correlates `per_request.jsonl` streaming-TPS to the
+   thermal log by timestamp, stdlib-only), and a README with the LAB-only run
+   recipe.
+4. SPEC `docs/notes/SPEC-NETWORK-BENCHMARK-v0.1.md` §3.5 row + §4.15 scenario
+   section.
+
+### Parked for the lab-Mac campaign (Deliverable 3)
+
+The actual 45–60 min soak run — the real deliverable — needs a lab Mac. It
+produces the "safe sustained-load envelope" the #584 canary redesign consumes,
+recalibrates B10's thresholds (then arms the gate), and answers the #463 (waived
+G3 48 h soak) recommendation. Run recipe + open questions in
+`test/e2e/thermal-soak/README.md`.
+
+### Verification
+
+- `go build ./...`, `go test ./...`, `go vet ./...` — GREEN in
+  `test/network-harness` (7 new B10 unit tests: PASS/WARN/FAIL-armed/
+  FAIL-downgrade-unarmed/SKIP×2/window-math).
+- `harness run scenarios/15_thermal_soak.yaml --dry-run` validates; fails safely
+  (validation error) without `LAB_*` env — cannot hit prod.
+- Three-lane codex audit (code / security / architect) to 0 CRITICAL / 0 HIGH /
+  0 MEDIUM; prompts + results under `audits/2026-07-22/`.
+- Does not touch scenario 07/08 or the money path.
+
+Closes nothing (instrument only); advances #584.
+
+<!-- SPEC-GOVERNANCE-DECLARATION-BEGIN
+{
+  "schema_version": "spec-pr-governance-v1",
+  "behavior_change": "yes",
+  "contract_change": "none",
+  "issue": "https://github.com/Augustas11/macprovider/issues/584",
+  "specs": ["SPEC-031"],
+  "requirements": ["SPEC-023-R001"],
+  "authority_domains": ["canary-sanction-lifecycle"],
+  "arbitration": ["UNKNOWN"],
+  "tests": ["go test ./... (test/network-harness)", "go vet ./... (test/network-harness)", "harness run scenarios/15_thermal_soak.yaml --dry-run"],
+  "journeys": ["not-required"]
+}
+SPEC-GOVERNANCE-DECLARATION-END -->
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)

--- a/scratchpad/235-pr-body.md
+++ b/scratchpad/235-pr-body.md
@@ -53,15 +53,35 @@ recalibrates B10's thresholds (then arms the gate), and answers the #463 (waived
 G3 48 h soak) recommendation. Run recipe + open questions in
 `test/e2e/thermal-soak/README.md`.
 
+### Prod-safety (LAB-ONLY, enforced in code)
+
+Any scenario declaring `B10` must have `gateway_url` and `coordinator_url`
+resolve to a **loopback / private / link-local IP or `localhost`** (positive
+allowlist `LabHostAllowed`) — every public host is rejected, including
+trailing-dot and Unicode-separator variants; the check runs even when
+`benchmark.enabled=false`; and a `CheckRedirect` guard blocks a lab gateway from
+redirecting the soak to a non-lab host. A soak physically cannot reach
+`streamvc.live`.
+
 ### Verification
 
 - `go build ./...`, `go test ./...`, `go vet ./...` — GREEN in
-  `test/network-harness` (7 new B10 unit tests: PASS/WARN/FAIL-armed/
-  FAIL-downgrade-unarmed/SKIP×2/window-math).
-- `harness run scenarios/15_thermal_soak.yaml --dry-run` validates; fails safely
-  (validation error) without `LAB_*` env — cannot hit prod.
-- Three-lane codex audit (code / security / architect) to 0 CRITICAL / 0 HIGH /
-  0 MEDIUM; prompts + results under `audits/2026-07-22/`.
+  `test/network-harness`. New tests: B10 PASS/WARN/FAIL-armed/FAIL-downgrade-
+  unarmed/SKIP-too-few/SKIP-provider-stops-before-end/SKIP-short-run/window-math;
+  lab-only host allow/reject matrix (loopback/localhost/private/ipv6 ok; prod
+  apex/subdomain/uppercase/trailing-dot/full-width/ideographic-dot/arbitrary-
+  public rejected; disabled-benchmark still guarded; non-B10 still allows prod).
+- `harness run scenarios/15_thermal_soak.yaml --dry-run` validates on a lab URL;
+  fails safely without `LAB_*` env and on any prod host.
+- **Three-lane codex audit (code / security / architect), 3 rounds** — R3 is
+  **0 CRITICAL / 0 HIGH / 0 MEDIUM on all three lanes** (code APPROVE, security
+  APPROVE, architect WATCH). Prompts + results under `audits/2026-07-22/`.
+  Carried LOWs (documented, non-blocking): (1) scoped IPv6 link-local
+  `[fe80::1%25en0]` is rejected by `net.ParseIP` — a legitimate-lab
+  false-negative that **fails safe** (never allows prod); (2) `join-thermal.py`
+  loads its inputs fully into memory (a local operator post-processing tool);
+  (3) the redirect barrier has no dedicated regression test yet (its logic was
+  read and verified correct by all three lanes).
 - Does not touch scenario 07/08 or the money path.
 
 Closes nothing (instrument only); advances #584.

--- a/scratchpad/RESEARCH_235_RESUME.md
+++ b/scratchpad/RESEARCH_235_RESUME.md
@@ -64,10 +64,24 @@ Scenario 15 `--dry-run` validates; fails safely without LAB_* env.
   - README recipe (arch M): path-stable abs paths, points to
     benchmark_summary.json (buyer_metrics.sustained_tps), no top-level sudo.
   - LOW: .gitignore thermal artifacts; SPEC §5 example gains sustained_tps.
-- R2: RE-AUDIT the touched lanes (all 3 touched) → need 0 C/H/M to PR.
+- R2 (3 lanes): code 2H/1L, security 1H/1L, architect 1H/2M/2L — ALL from the
+  R1 prod-host DENYLIST being bypassable + skipped when benchmark.enabled=false.
+  R2-fix: replaced denylist with POSITIVE lab-host allowlist (LabHostAllowed:
+  loopback/private/link-local/localhost only), applied regardless of
+  benchmark.enabled, + CheckRedirect guard in loadgen; joiner mirrors B10
+  success filter; stale skew→null; wording/SPEC-example fixes.
+- R3 (3 lanes): **ALL 0 CRITICAL / 0 HIGH / 0 MEDIUM** — code APPROVE,
+  security APPROVE, architect WATCH. Merge bar MET. Remaining LOWs carried
+  documented: (1) scoped IPv6 link-local `[fe80::1%25en0]` rejected by
+  net.ParseIP — FALSE-NEGATIVE, fails safe (never allows prod); (2) join-thermal
+  loads inputs fully into memory (local operator tool); (3) redirect barrier
+  lacks a dedicated regression test (impl verified correct by all 3 lanes).
+  Post-R3 doc-only fixes applied (no audited logic touched): README stale
+  rejectProdHost→LabHostAllowed; SPEC §5 example scenario name thermal_soak.
 
 ## Next steps (this session)
-1. [ ] R2 three-lane codex re-audit (code/security/architect) via `omc ask codex
+1. [x] R2/R3 three-lane codex re-audit — R3 all 0 C/H/M. DONE.
+1b. [ ] (superseded) via `omc ask codex
    --prompt "$(cat <promptfile>)"`. Prompts under `audits/_prompts/` or
    `audits/<date>/`. Bar 0 C/H/M. Loop→fix→re-audit.
 2. [ ] Rebase on origin/main.

--- a/scratchpad/RESEARCH_235_RESUME.md
+++ b/scratchpad/RESEARCH_235_RESUME.md
@@ -45,8 +45,29 @@ use B10.
 `go build ./...` OK. `go test ./...` GREEN (whole harness). `go vet ./...` clean.
 Scenario 15 `--dry-run` validates; fails safely without LAB_* env.
 
+## Audit status
+- R1 (3 lanes) DONE: code 0C/0H/1M/1L, security 0C/1H/1M/2L, architect 0C/2H/2M.
+  All findings FIXED in R1-fix commit:
+  - B10 final-window anchoring (code M / arch H): now anchors to TRUE run
+    start/end over ALL results (incl failures); near-end disconnect → empty
+    final window → SKIP (not false PASS). Span <2W → SKIP. + LOW boundary fix
+    (exclusive finalCutoff). 2 new tests (provider-stops-before-end, short-run).
+  - Prod-host reachable (security H): rejectProdHost() in schema.go hard-fails
+    any B10 scenario whose gateway/coordinator resolves to streamvc.live(+subs).
+    New regression test. README prod-stack exception removed.
+  - Thermal-join channel loss (arch H): join-thermal.py matches pmset +
+    powermetrics INDEPENDENTLY, emits per-channel skew, bounds max skew.
+  - Bash arithmetic injection (security M): strict digit+bound validation of
+    --interval/--duration before $((...)); run unprivileged, umask 077.
+  - Scenario duration cap (arch M): requests_per_buyer 1000→5000 so duration
+    terminates. README reframes envelope as a D3 sweep, scenario 15 = 1 point.
+  - README recipe (arch M): path-stable abs paths, points to
+    benchmark_summary.json (buyer_metrics.sustained_tps), no top-level sudo.
+  - LOW: .gitignore thermal artifacts; SPEC §5 example gains sustained_tps.
+- R2: RE-AUDIT the touched lanes (all 3 touched) → need 0 C/H/M to PR.
+
 ## Next steps (this session)
-1. [ ] Three-lane codex audit (code/security/architect) via `omc ask codex
+1. [ ] R2 three-lane codex re-audit (code/security/architect) via `omc ask codex
    --prompt "$(cat <promptfile>)"`. Prompts under `audits/_prompts/` or
    `audits/<date>/`. Bar 0 C/H/M. Loop→fix→re-audit.
 2. [ ] Rebase on origin/main.

--- a/scratchpad/RESEARCH_235_RESUME.md
+++ b/scratchpad/RESEARCH_235_RESUME.md
@@ -1,0 +1,71 @@
+# RESEARCH_235 — resume state (thermal/sustained-load soak instrument)
+
+**Branch:** `research/235-thermal-soak` (off origin/main). Fresh worktree
+`/Users/augstar/macprovider-235`. Serves issue #584 (canary redesign) + #463
+(waived G3 soak).
+
+**Scope this session: INSTRUMENT ONLY.** The soak campaign (Deliverable 3's
+actual run) is PARKED — it needs a dedicated lab Mac, unavailable now. Do NOT
+soak the prod provider (reproduces the #584 outage). Same instrument-now /
+campaign-later split as RESEARCH_234's cold cell.
+
+## Invariant ID used: **B10** (NOT B8)
+
+Prompt said "B8", but B8+B9 are taken by RESEARCH_236 (PR #696, OPEN, not
+merged — sticky cache-reuse). main has through B7. Used **B10** to avoid
+collision regardless of merge order. Scenario allow-list + SPEC + dispatch all
+use B10.
+
+## Deliverables — status
+
+- [x] **D1a scenario** `test/network-harness/scenarios/15_thermal_soak.yaml`
+  — 3600s (45–60 min), 2 buyers, stream:true, interval floor 1s (continuous
+  busy, ≤2 concurrent within N_eff=2.5), 30B model, max_tokens=64. Targets
+  `${LAB_GATEWAY_URL}`/`${LAB_COORDINATOR_URL}` (unset by default → validation
+  fails rather than hitting prod). Invariants B1-B5,B10. Dry-run validates.
+- [x] **D1b invariant B10** in `internal/benchmark/benchmark.go` — windows
+  streaming decode-TPS p50 (same basis as B2, NOT non-streaming sustained_tps)
+  into first-5min / last-5min windows; retention = final/first. Bands PASS
+  ≥0.85 / WARN ≥0.70 / FAIL <0.70 (PROVISIONAL). SKIP if <8 samples/window.
+  Emits first_window_tps_p50, final_window_tps_p50, retention, sample counts.
+  **Gate UNARMED**: scenario flag `sustained_gate_armed` (default false) →
+  would-be FAIL downgraded to WARN until a lab run calibrates. Case dispatch +
+  evalB10 + computeSustainedTPS + 7 unit tests in benchmark_test.go
+  (PASS/WARN/FAIL-armed/FAIL-downgrade-unarmed/SKIP×2/window-math). SPEC §3.5
+  row + §4.15 scenario section. Also added B10 to scenario invariant allow-list
+  (schema.go) + committed-scenarios test seeds LAB_* placeholders.
+- [x] **D2 thermal capture** `test/e2e/thermal-soak/` (sibling to coldwarm-ttft):
+  `thermal-collector.sh` (pmset + powermetrics → timestamped NDJSON),
+  `join-thermal.py` (joins per_request.jsonl streaming-TPS to thermal by ts,
+  binned; pure stdlib), `README.md`. Scripts syntax-checked + joiner smoke-tested.
+- [ ] **D3 soak report + envelope** — PARKED (needs lab Mac). README documents
+  the run recipe + the 4 questions a run must answer.
+
+## Build/test status
+`go build ./...` OK. `go test ./...` GREEN (whole harness). `go vet ./...` clean.
+Scenario 15 `--dry-run` validates; fails safely without LAB_* env.
+
+## Next steps (this session)
+1. [ ] Three-lane codex audit (code/security/architect) via `omc ask codex
+   --prompt "$(cat <promptfile>)"`. Prompts under `audits/_prompts/` or
+   `audits/<date>/`. Bar 0 C/H/M. Loop→fix→re-audit.
+2. [ ] Rebase on origin/main.
+3. [ ] Open PR as Augustas11 (`GH_TOKEN=$(gh auth token -u Augustas11) gh pr
+   create`), request antfleet-ops review. Do NOT merge (user lands it).
+   **PR body MUST have SPEC-GOVERNANCE-DECLARATION-BEGIN/END block** (model on
+   PR #696) or the `check` gate fails. behavior_change yes, contract_change
+   none, issue #584, specs SPEC-031 (+SPEC-023 if autotune touched — it's NOT),
+   requirements SPEC-023-R001 (verify in specs/CONFORMANCE.json), authority
+   ["canary-sanction-lifecycle"] (verify specs/AUTHORITY.json), arbitration
+   ["UNKNOWN"], tests [go test/vet cmds], journeys ["not-required"].
+
+## Commits pushed so far
+- B10 invariant + tests (benchmark.go, benchmark_test.go)
+- scenario 15 + allow-list + SPEC §3.5/§4.15
+- thermal-soak collector/joiner/README + this resume file
+
+## Parked for lab-Mac campaign
+The actual 45–60 min soak run (D3). First run = the real deliverable: produces
+the safe-sustained-load envelope for the #584 canary redesign, recalibrates B10
+thresholds, and answers the #463 (48h soak waiver) recommendation. Run recipe
+in `test/e2e/thermal-soak/README.md`.

--- a/test/e2e/thermal-soak/README.md
+++ b/test/e2e/thermal-soak/README.md
@@ -37,11 +37,16 @@ disconnects the single prod mac** (~30 → 8.9 → 5.3 tok/s, then stale
 heartbeats → WS EOF → removed from pool). Running this soak against
 `streamvc.live` with the prod provider in the pool reproduces the outage.
 
-This is enforced in code: scenario 15 declares `B10`, and the harness rejects
-any `B10` scenario whose `gateway_url` or `coordinator_url` resolves to
-`streamvc.live` (or a subdomain) — see `rejectProdHost` in
-`test/network-harness/internal/scenario/schema.go`. A soak **cannot** be pointed
-at prod even by setting `LAB_GATEWAY_URL` to the prod host.
+This is enforced in code by a **positive lab-host allowlist**: any scenario
+declaring `B10` must have both `gateway_url` and `coordinator_url` resolve to a
+loopback / private (RFC1918) / link-local IP or `localhost` — see
+`LabHostAllowed` / `validateLabOnlyHost` in
+`test/network-harness/internal/scenario/schema.go`. Every public host (prod, any
+subdomain, trailing-dot or Unicode-separator variants, or any other FQDN) is
+rejected, the check runs even when `benchmark.enabled=false`, and a
+`CheckRedirect` guard (`loadgen.go`) refuses a lab gateway that tries to
+3xx-redirect the soak to a non-lab host. A soak **cannot** be pointed at prod
+even by setting `LAB_GATEWAY_URL` to the prod host.
 
 Requirements for a valid run:
 - A Mac you **fully control** (you will run `powermetrics`/`pmset` on it and

--- a/test/e2e/thermal-soak/README.md
+++ b/test/e2e/thermal-soak/README.md
@@ -17,8 +17,11 @@ lines up with the machine throttling.
 The scenario, the `B10` invariant, and these scripts are **built and tested**,
 but **no soak has been run yet**. The run needs a **dedicated lab Mac** (see
 below); it must NOT run against production. The first lab run is the actual
-deliverable — it produces the "safe sustained load" envelope the #584 canary
-redesign consumes, and recalibrates B10's provisional thresholds. Until then:
+deliverable — it provides the **initial calibration** and the first stress
+point, and recalibrates B10's provisional thresholds. The full "safe sustained
+load" envelope the #584 canary redesign consumes comes from a **D3 sweep**
+across concurrency / duty-cycle cells (see the parked-work section below), not
+from a single scenario-15 run. Until then:
 
 - `B10` thresholds (PASS ≥ 0.85 / WARN ≥ 0.70 / FAIL < 0.70) are **provisional
   guesses**, and scenario 15 leaves the gate **unarmed** (`sustained_gate_armed:

--- a/test/e2e/thermal-soak/README.md
+++ b/test/e2e/thermal-soak/README.md
@@ -1,0 +1,95 @@
+# thermal-soak — provider-side thermal capture for the RESEARCH_235 soak
+
+This directory holds the **provider-side** half of the RESEARCH_235
+thermal/sustained-load soak (issue [#584](https://github.com/Augustas11/macprovider/issues/584)).
+The **buyer-side** half is the harness scenario
+[`test/network-harness/scenarios/15_thermal_soak.yaml`](../../network-harness/scenarios/15_thermal_soak.yaml)
+and its `B10` "sustained streaming-TPS retention" invariant.
+
+It is a **sibling of `test/e2e/coldwarm-ttft/`**: same posture (a probe/collector
+that runs against a live stack), different question. Cold/warm measures the
+cold-start TTFT penalty; this measures how much streaming decode throughput a
+provider **retains** under 45–60 min of constant load, and whether the decay
+lines up with the machine throttling.
+
+## Status — INSTRUMENT ONLY (campaign parked)
+
+The scenario, the `B10` invariant, and these scripts are **built and tested**,
+but **no soak has been run yet**. The run needs a **dedicated lab Mac** (see
+below); it must NOT run against production. The first lab run is the actual
+deliverable — it produces the "safe sustained load" envelope the #584 canary
+redesign consumes, and recalibrates B10's provisional thresholds. Until then:
+
+- `B10` thresholds (PASS ≥ 0.85 / WARN ≥ 0.70 / FAIL < 0.70) are **provisional
+  guesses**, and scenario 15 leaves the gate **unarmed** (`sustained_gate_armed:
+  false`), so a would-be FAIL is reported as WARN and can never block a run.
+- Arm B10 (set `sustained_gate_armed: true`) only after the first lab run
+  recalibrates the thresholds in `benchmark.go` and `SPEC-NETWORK-BENCHMARK-v0.1.md`
+  §3.5.
+
+## LAB MAC ONLY — do not soak prod
+
+The whole point of #584 is that a sustained synthetic load **degrades and
+disconnects the single prod mac** (~30 → 8.9 → 5.3 tok/s, then stale
+heartbeats → WS EOF → removed from pool). Running this soak against
+`streamvc.live` with the prod provider in the pool reproduces the outage.
+
+Requirements for a valid run:
+- A Mac you **fully control** (you will run `powermetrics`/`pmset` on it and
+  deliberately push it toward thermal throttle).
+- It is the **only** pool member of a **lab** coordinator+gateway stack (or the
+  prod stack with prod buyers routed away and this the sole provider).
+- Record the machine's **model, chip, RAM, and cooling** (fan vs fanless — an
+  M1 Air is fanless and throttles hard; that is *signal*, not a defect).
+- Stand the lab stack up **once** and leave it. Rapid coordinator restarts
+  wedge the provider CLI's v2 proof-auth (`auth_request proof rejected: type`,
+  pool → 0); recover with `pkill -9 -f macprovider-cli` and let launchd
+  respawn one.
+
+## Files
+
+| File | Role |
+|---|---|
+| `thermal-collector.sh` | Runs on the lab provider Mac for the soak window. Samples `pmset -g therm` (CPU speed-limit %) and `sudo powermetrics --samplers smc,cpu_power,gpu_power` (SMC temps, CPU/GPU power), writing a timestamped **NDJSON** thermal log. |
+| `join-thermal.py` | Post-processes a completed run: joins the harness `per_request.jsonl` (buyer-side streaming TPS) to `thermal.ndjson` by timestamp and bins them, so the TPS decay can be overlaid on the thermal signal. Pure stdlib. |
+
+## Run recipe (once a lab Mac exists)
+
+```bash
+# ── on the LAB PROVIDER mac ─────────────────────────────────────────────
+# 1. Start the thermal collector JUST BEFORE the soak (own terminal / tmux):
+sudo ./thermal-collector.sh --out ./thermal-$(date -u +%Y%m%dT%H%M%SZ).ndjson --interval 5
+
+# ── on the machine running the harness (can be the same mac) ────────────
+# 2. Point at the LAB stack and fire the soak:
+export LAB_GATEWAY_URL=http://127.0.0.1:<lab-gw-port>
+export LAB_COORDINATOR_URL=http://127.0.0.1:<lab-coord-port>
+export BUYER_TOKEN="$(cat ~/.config/macprovider/buyer-api-key)"   # never echo it
+cd ../../network-harness
+go build -o harness ./cmd/harness
+./harness run scenarios/15_thermal_soak.yaml --out ./out-soak-30b
+
+# 3. Stop the collector (Ctrl-C) when the soak finishes.
+
+# 4. Correlate TPS decay vs thermal state:
+./join-thermal.py ./out-soak-30b/per_request.jsonl ./thermal-*.ndjson --bin-seconds 60 > overlay.ndjson
+```
+
+`benchmark_verdict.json` in the `--out` dir carries the `B10` verdict
+(`first_window_tps_p50`, `final_window_tps_p50`, `retention`, per-window
+sample counts). `overlay.ndjson` is the thermal correlation.
+
+## What a run must answer (Deliverable 3, parked)
+
+1. The **TPS-retention curve** per model class + chip, with the thermal overlay
+   — does the decay coincide with a rising thermal-pressure / falling
+   clock-speed signal (thermal throttle), or is it memory pressure / something
+   else? #584 speculates thermal but never proved it.
+2. The **safe sustained-load envelope**: the concurrency / duty-cycle at which a
+   given provider class holds ≥ 0.85 retention. This tells the redesigned #584
+   canary how much load it may apply, and for how long, before it becomes the
+   cause of the degradation it is trying to detect.
+3. A recommendation on [#463](https://github.com/Augustas11/macprovider/issues/463):
+   can the waived G3 48 h soak be replaced by this characterized shorter soak as
+   a release gate, or is a longer burn still needed before the beta cohort?
+4. Whether slot-tuning (`466853e`) overheats capable machines under this load.

--- a/test/e2e/thermal-soak/README.md
+++ b/test/e2e/thermal-soak/README.md
@@ -34,11 +34,18 @@ disconnects the single prod mac** (~30 → 8.9 → 5.3 tok/s, then stale
 heartbeats → WS EOF → removed from pool). Running this soak against
 `streamvc.live` with the prod provider in the pool reproduces the outage.
 
+This is enforced in code: scenario 15 declares `B10`, and the harness rejects
+any `B10` scenario whose `gateway_url` or `coordinator_url` resolves to
+`streamvc.live` (or a subdomain) — see `rejectProdHost` in
+`test/network-harness/internal/scenario/schema.go`. A soak **cannot** be pointed
+at prod even by setting `LAB_GATEWAY_URL` to the prod host.
+
 Requirements for a valid run:
 - A Mac you **fully control** (you will run `powermetrics`/`pmset` on it and
   deliberately push it toward thermal throttle).
-- It is the **only** pool member of a **lab** coordinator+gateway stack (or the
-  prod stack with prod buyers routed away and this the sole provider).
+- It is the **only** pool member of a **lab** coordinator+gateway stack. (Do
+  NOT use the prod stack — the code-level guard above forbids a prod host for a
+  B10 scenario.)
 - Record the machine's **model, chip, RAM, and cooling** (fan vs fanless — an
   M1 Air is fanless and throttles hard; that is *signal*, not a defect).
 - Stand the lab stack up **once** and leave it. Rapid coordinator restarts
@@ -55,29 +62,44 @@ Requirements for a valid run:
 
 ## Run recipe (once a lab Mac exists)
 
+Use absolute paths so the commands work from any directory. Let
+`THERMAL_DIR=/abs/path/to/test/e2e/thermal-soak` and
+`HARNESS_DIR=/abs/path/to/test/network-harness`.
+
 ```bash
 # ── on the LAB PROVIDER mac ─────────────────────────────────────────────
-# 1. Start the thermal collector JUST BEFORE the soak (own terminal / tmux):
-sudo ./thermal-collector.sh --out ./thermal-$(date -u +%Y%m%dT%H%M%SZ).ndjson --interval 5
+# 1. Start the thermal collector JUST BEFORE the soak (own terminal / tmux).
+#    Run it UNPRIVILEGED — it escalates only the internal `powermetrics` call.
+"$THERMAL_DIR/thermal-collector.sh" \
+  --out "$THERMAL_DIR/out/thermal-$(date -u +%Y%m%dT%H%M%SZ).ndjson" --interval 5
 
 # ── on the machine running the harness (can be the same mac) ────────────
-# 2. Point at the LAB stack and fire the soak:
+# 2. Point at the LAB stack and fire the soak (a prod host is rejected):
 export LAB_GATEWAY_URL=http://127.0.0.1:<lab-gw-port>
 export LAB_COORDINATOR_URL=http://127.0.0.1:<lab-coord-port>
 export BUYER_TOKEN="$(cat ~/.config/macprovider/buyer-api-key)"   # never echo it
-cd ../../network-harness
-go build -o harness ./cmd/harness
-./harness run scenarios/15_thermal_soak.yaml --out ./out-soak-30b
+( cd "$HARNESS_DIR" && go build -o harness ./cmd/harness \
+  && ./harness run scenarios/15_thermal_soak.yaml --out "$HARNESS_DIR/out-soak-30b" )
 
 # 3. Stop the collector (Ctrl-C) when the soak finishes.
 
 # 4. Correlate TPS decay vs thermal state:
-./join-thermal.py ./out-soak-30b/per_request.jsonl ./thermal-*.ndjson --bin-seconds 60 > overlay.ndjson
+"$THERMAL_DIR/join-thermal.py" \
+  "$HARNESS_DIR/out-soak-30b/per_request.jsonl" \
+  "$THERMAL_DIR"/out/thermal-*.ndjson --bin-seconds 60 --max-skew-seconds 30 \
+  > "$THERMAL_DIR/out/overlay.ndjson"
 ```
 
-`benchmark_verdict.json` in the `--out` dir carries the `B10` verdict
-(`first_window_tps_p50`, `final_window_tps_p50`, `retention`, per-window
-sample counts). `overlay.ndjson` is the thermal correlation.
+The `B10` window fields (`first_window_tps_p50`, `final_window_tps_p50`,
+`retention`, per-window sample counts) live in **`benchmark_summary.json`**
+(under `buyer_metrics.sustained_tps`) in the `--out` dir; `benchmark_verdict.json`
+carries the human-readable `B10` verdict line. `overlay.ndjson` is the thermal
+correlation — each bin has both the pmset channel (`cpu_speed_limit_pct`) and
+the powermetrics channel (`cpu_power_mw`/`gpu_power_mw`/`cpu_die_temp_c`), each
+with its own `*_skew_s` (null when no thermal sample was within `--max-skew-seconds`).
+
+The thermal log preserves raw device output under a `"raw"` field — **review /
+redact before sharing**, and keep `out/` local (it is gitignored).
 
 ## What a run must answer (Deliverable 3, parked)
 
@@ -88,7 +110,12 @@ sample counts). `overlay.ndjson` is the thermal correlation.
 2. The **safe sustained-load envelope**: the concurrency / duty-cycle at which a
    given provider class holds ≥ 0.85 retention. This tells the redesigned #584
    canary how much load it may apply, and for how long, before it becomes the
-   cause of the degradation it is trying to detect.
+   cause of the degradation it is trying to detect. **Scenario 15 is a single
+   stress point** (N=2, 1s floor) — deliberately heavier than #584's sequential
+   canary, not an incident-faithful reproduction. Building the envelope needs a
+   **D3 sweep** across several concurrency / duty-cycle cells (e.g. N∈{1,2,3},
+   floors {1s,5s,15s}), with a cool-down between cells so each starts thermally
+   neutral. Copy scenario 15 per cell (swap `count` / `interval_ms`).
 3. A recommendation on [#463](https://github.com/Augustas11/macprovider/issues/463):
    can the waived G3 48 h soak be replaced by this characterized shorter soak as
    a release gate, or is a longer burn still needed before the beta cohort?

--- a/test/e2e/thermal-soak/join-thermal.py
+++ b/test/e2e/thermal-soak/join-thermal.py
@@ -68,8 +68,12 @@ def streaming_tps(rec):
 
 
 def load_thermal(path):
-    """Load thermal samples as a time-sorted list of (epoch, dict)."""
-    out = []
+    """Load thermal samples, split BY SOURCE into two time-sorted lists of
+    (epoch, dict). pmset and powermetrics are emitted as separate records with
+    disjoint fields (pmset has cpu_speed_limit_pct; powermetrics has power +
+    temp), so they must be matched independently — merging them and picking one
+    nearest record would null out whichever channel wasn't selected."""
+    by_source = {"pmset": [], "powermetrics": []}
     with open(path) as f:
         for line in f:
             line = line.strip()
@@ -82,17 +86,27 @@ def load_thermal(path):
             ts = parse_ts(rec.get("ts"))
             if ts is None:
                 continue
-            out.append((ts.timestamp(), rec))
-    out.sort(key=lambda x: x[0])
-    return out
+            src = rec.get("source")
+            if src not in by_source:
+                continue
+            by_source[src].append((ts.timestamp(), rec))
+    for lst in by_source.values():
+        lst.sort(key=lambda x: x[0])
+    return by_source
 
 
-def nearest_thermal(thermal, epoch):
-    """Nearest thermal sample to `epoch` by absolute time distance."""
+def nearest_thermal(thermal, epoch, max_skew_s):
+    """Nearest thermal sample to `epoch`, but only if within `max_skew_s`.
+    Returns (record, skew_seconds) or (None, None) when the list is empty or the
+    nearest sample is too stale — a bounded skew keeps a far-away thermal
+    reading from being silently attached to a TPS bin."""
     if not thermal:
-        return {}
-    best = min(thermal, key=lambda x: abs(x[0] - epoch))
-    return best[1]
+        return None, None
+    epoch_ts, rec = min(thermal, key=lambda x: abs(x[0] - epoch))
+    skew = epoch_ts - epoch
+    if abs(skew) > max_skew_s:
+        return None, round(skew, 1)
+    return rec, round(skew, 1)
 
 
 def main():
@@ -100,6 +114,9 @@ def main():
     ap.add_argument("per_request")
     ap.add_argument("thermal")
     ap.add_argument("--bin-seconds", type=int, default=60)
+    ap.add_argument("--max-skew-seconds", type=int, default=30,
+                    help="drop a thermal reading if the nearest sample is more "
+                         "than this many seconds from the bin (default 30)")
     args = ap.parse_args()
 
     thermal = load_thermal(args.thermal)
@@ -135,7 +152,10 @@ def main():
         pts = bins[b]
         tpss = [t for _, t in pts]
         mid_epoch = statistics.median([e for e, _ in pts])
-        th = nearest_thermal(thermal, mid_epoch)
+        # Match each thermal SOURCE independently so pmset (speed limit) and
+        # powermetrics (power/temp) both attach, each with its own skew.
+        pm, pm_skew = nearest_thermal(thermal["pmset"], mid_epoch, args.max_skew_seconds)
+        pw, pw_skew = nearest_thermal(thermal["powermetrics"], mid_epoch, args.max_skew_seconds)
         out = {
             "bin": b,
             "bin_start_offset_s": b * args.bin_seconds,
@@ -143,10 +163,16 @@ def main():
             "tps_p50": round(statistics.median(tpss), 2),
             "tps_min": round(min(tpss), 2),
             "tps_max": round(max(tpss), 2),
-            "cpu_speed_limit_pct": th.get("cpu_speed_limit_pct"),
-            "cpu_power_mw": th.get("cpu_power_mw"),
-            "gpu_power_mw": th.get("gpu_power_mw"),
-            "cpu_die_temp_c": th.get("cpu_die_temp_c"),
+            # pmset channel
+            "cpu_speed_limit_pct": pm.get("cpu_speed_limit_pct") if pm else None,
+            "pmset_ts": pm.get("ts") if pm else None,
+            "pmset_skew_s": pm_skew,
+            # powermetrics channel
+            "cpu_power_mw": pw.get("cpu_power_mw") if pw else None,
+            "gpu_power_mw": pw.get("gpu_power_mw") if pw else None,
+            "cpu_die_temp_c": pw.get("cpu_die_temp_c") if pw else None,
+            "powermetrics_ts": pw.get("ts") if pw else None,
+            "powermetrics_skew_s": pw_skew,
         }
         print(json.dumps(out))
     return 0

--- a/test/e2e/thermal-soak/join-thermal.py
+++ b/test/e2e/thermal-soak/join-thermal.py
@@ -49,7 +49,16 @@ def parse_ts(s):
 def streaming_tps(rec):
     """Derive per-request streaming decode TPS, mirroring benchmark.go's B2/B10
     basis: tokens / (last_byte - (start + ttft)). Returns (start_dt, tps) or
-    None if the record is not a usable streaming success."""
+    None if the record is not a usable streaming success.
+
+    Mirrors B10's success filter exactly (benchmark.go: HTTPStatus >= 400 or
+    Outcome != "ok" are excluded) so the thermal overlay reflects the same
+    population B10 scores — a failed stream that received some usage before a
+    transport error must NOT contribute a TPS point."""
+    if rec.get("outcome") != "ok":
+        return None
+    if (rec.get("http_status") or 0) >= 400:
+        return None
     if not rec.get("stream"):
         return None
     tokens = rec.get("completion_tokens_received") or 0
@@ -105,7 +114,9 @@ def nearest_thermal(thermal, epoch, max_skew_s):
     epoch_ts, rec = min(thermal, key=lambda x: abs(x[0] - epoch))
     skew = epoch_ts - epoch
     if abs(skew) > max_skew_s:
-        return None, round(skew, 1)
+        # Too stale — drop both the record and its skew so the output field is
+        # null (matches the documented contract and the README).
+        return None, None
     return rec, round(skew, 1)
 
 

--- a/test/e2e/thermal-soak/join-thermal.py
+++ b/test/e2e/thermal-soak/join-thermal.py
@@ -1,0 +1,156 @@
+#!/usr/bin/env python3
+"""join-thermal.py — correlate the soak's buyer-side streaming TPS with the
+provider-side thermal log, for RESEARCH_235 (scenario 15, issue #584).
+
+Answers #584's open question: does the streaming-TPS decay (B10) coincide
+with rising thermal pressure / a falling CPU speed-limit? It does NOT run the
+soak — it post-processes two files produced by a completed lab run:
+
+  1. per_request.jsonl  — the harness buyer-side log (one JSON obj/request,
+     with start_utc, ttft_ms, completion_tokens_received, last_byte_utc,
+     stream). Streaming TPS is derived the same way benchmark.go does:
+     tokens / (last_byte_utc - (start_utc + ttft_ms)).
+  2. thermal.ndjson     — thermal-collector.sh output (pmset + powermetrics
+     records tagged with "ts").
+
+Output (stdout, NDJSON): one record per time bin with the bin's median
+streaming TPS and the nearest thermal sample's cpu_speed_limit_pct /
+cpu_power_mw / gpu_power_mw / cpu_die_temp_c, so the pair can be plotted or
+eyeballed for a throttle correlation.
+
+Usage:
+  ./join-thermal.py per_request.jsonl thermal.ndjson [--bin-seconds 60] > overlay.ndjson
+
+Pure stdlib — no third-party deps, so it runs anywhere python3 does.
+"""
+import argparse
+import json
+import statistics
+import sys
+from datetime import datetime, timezone
+
+
+def parse_ts(s):
+    """Parse an RFC3339/ISO-8601 UTC timestamp to an aware datetime."""
+    if s is None:
+        return None
+    s = s.strip()
+    if s.endswith("Z"):
+        s = s[:-1] + "+00:00"
+    try:
+        dt = datetime.fromisoformat(s)
+    except ValueError:
+        return None
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return dt.astimezone(timezone.utc)
+
+
+def streaming_tps(rec):
+    """Derive per-request streaming decode TPS, mirroring benchmark.go's B2/B10
+    basis: tokens / (last_byte - (start + ttft)). Returns (start_dt, tps) or
+    None if the record is not a usable streaming success."""
+    if not rec.get("stream"):
+        return None
+    tokens = rec.get("completion_tokens_received") or 0
+    ttft_ms = rec.get("ttft_ms") or 0
+    if tokens <= 0 or ttft_ms <= 0:
+        return None
+    start = parse_ts(rec.get("start_utc"))
+    last = parse_ts(rec.get("last_byte_utc"))
+    if start is None or last is None:
+        return None
+    first_byte = start.timestamp() + ttft_ms / 1000.0
+    dur = last.timestamp() - first_byte
+    if dur <= 0:
+        return None
+    return start, tokens / dur
+
+
+def load_thermal(path):
+    """Load thermal samples as a time-sorted list of (epoch, dict)."""
+    out = []
+    with open(path) as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                rec = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            ts = parse_ts(rec.get("ts"))
+            if ts is None:
+                continue
+            out.append((ts.timestamp(), rec))
+    out.sort(key=lambda x: x[0])
+    return out
+
+
+def nearest_thermal(thermal, epoch):
+    """Nearest thermal sample to `epoch` by absolute time distance."""
+    if not thermal:
+        return {}
+    best = min(thermal, key=lambda x: abs(x[0] - epoch))
+    return best[1]
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("per_request")
+    ap.add_argument("thermal")
+    ap.add_argument("--bin-seconds", type=int, default=60)
+    args = ap.parse_args()
+
+    thermal = load_thermal(args.thermal)
+
+    samples = []  # (epoch, tps)
+    with open(args.per_request) as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                rec = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            r = streaming_tps(rec)
+            if r is None:
+                continue
+            start, tps = r
+            samples.append((start.timestamp(), tps))
+
+    if not samples:
+        print("join-thermal: no usable streaming samples", file=sys.stderr)
+        return 1
+
+    samples.sort(key=lambda x: x[0])
+    t0 = samples[0][0]
+    bins = {}
+    for epoch, tps in samples:
+        b = int((epoch - t0) // args.bin_seconds)
+        bins.setdefault(b, []).append((epoch, tps))
+
+    for b in sorted(bins):
+        pts = bins[b]
+        tpss = [t for _, t in pts]
+        mid_epoch = statistics.median([e for e, _ in pts])
+        th = nearest_thermal(thermal, mid_epoch)
+        out = {
+            "bin": b,
+            "bin_start_offset_s": b * args.bin_seconds,
+            "n": len(tpss),
+            "tps_p50": round(statistics.median(tpss), 2),
+            "tps_min": round(min(tpss), 2),
+            "tps_max": round(max(tpss), 2),
+            "cpu_speed_limit_pct": th.get("cpu_speed_limit_pct"),
+            "cpu_power_mw": th.get("cpu_power_mw"),
+            "gpu_power_mw": th.get("gpu_power_mw"),
+            "cpu_die_temp_c": th.get("cpu_die_temp_c"),
+        }
+        print(json.dumps(out))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/test/e2e/thermal-soak/thermal-collector.sh
+++ b/test/e2e/thermal-soak/thermal-collector.sh
@@ -29,12 +29,19 @@
 # tool text is preserved under "raw" so nothing is lost if parsing drifts
 # across macOS versions.
 #
+# Run this UNPRIVILEGED — do NOT `sudo` the whole script. It escalates only the
+# single `powermetrics` call internally (via `sudo powermetrics`), so `pmset`,
+# `mkdir`, and the log writes stay as your user. For an unattended run, grant
+# passwordless powermetrics once (e.g. a sudoers line:
+# `<you> ALL=(root) NOPASSWD: /usr/bin/powermetrics`) so the loop doesn't stall
+# on a password prompt.
+#
 # Usage:
-#   sudo ./thermal-collector.sh --out ./thermal-<runid>.ndjson --interval 5
-#   sudo ./thermal-collector.sh --out ./thermal.ndjson --duration 3600
+#   ./thermal-collector.sh --out ./thermal-<runid>.ndjson --interval 5
+#   ./thermal-collector.sh --out ./thermal.ndjson --duration 3600
 #   # Start this JUST BEFORE launching the harness soak; stop with the soak
-#   # (Ctrl-C, SIGTERM, or --duration). Then join:
-#   #   ./join-thermal.py per_request.jsonl thermal.ndjson > overlay.ndjson
+#   # (Ctrl-C, SIGTERM, or --duration). Then join (from this directory):
+#   #   ./join-thermal.py /path/to/per_request.jsonl ./thermal.ndjson > overlay.ndjson
 #
 # Env overrides: THERMAL_INTERVAL_S (default 5), THERMAL_DURATION_S (0 = until
 # signalled), THERMAL_OUT.
@@ -65,6 +72,23 @@ if [[ -z "$THERMAL_OUT" ]]; then
   echo "thermal-collector: --out <path.ndjson> is required" >&2
   exit 2
 fi
+
+# Strictly validate the numeric inputs BEFORE they are ever used in Bash
+# arithmetic ($((...))). Unvalidated arithmetic operands can smuggle command
+# substitution via array subscripts, so accept only plain base-10 digits with
+# sane bounds. (interval: 1..3600s, duration: 0..604800s / 7 days.)
+if ! [[ "$THERMAL_INTERVAL_S" =~ ^[1-9][0-9]{0,3}$ ]] || (( THERMAL_INTERVAL_S > 3600 )); then
+  echo "thermal-collector: --interval must be an integer 1..3600 (got '$THERMAL_INTERVAL_S')" >&2
+  exit 2
+fi
+if ! [[ "$THERMAL_DURATION_S" =~ ^(0|[1-9][0-9]{0,6})$ ]] || (( THERMAL_DURATION_S > 604800 )); then
+  echo "thermal-collector: --duration must be an integer 0..604800 (got '$THERMAL_DURATION_S')" >&2
+  exit 2
+fi
+
+# Restrict permissions on any file we create — the thermal log preserves raw
+# device output and should not be world-readable by default.
+umask 077
 
 case "$(uname -s)" in
   Darwin) : ;;

--- a/test/e2e/thermal-soak/thermal-collector.sh
+++ b/test/e2e/thermal-soak/thermal-collector.sh
@@ -1,0 +1,132 @@
+#!/usr/bin/env bash
+# thermal-collector.sh — provider-side thermal sampler for the RESEARCH_235
+# thermal/sustained-load soak (scenario 15, issue #584).
+#
+# Runs ON THE LAB PROVIDER MAC (not the coordinator, not prod) for the full
+# soak window. Samples on-device thermal state and writes a timestamped
+# NDJSON log that the analysis joins to the harness `per_request.jsonl` by
+# UTC timestamp, so a streaming-TPS decay curve (B10) can be overlaid on the
+# thermal-pressure / clock-speed signal to answer #584's open question:
+# is the sustained-load collapse thermal throttling, memory pressure, or
+# something else?
+#
+# ############################################################################
+# ## LAB MAC ONLY. This deliberately pushes a machine toward thermal        ##
+# ## throttle and runs `powermetrics`/`pmset`. Run it only on a Mac you     ##
+# ## fully control that is serving as the SOLE lab pool member. Never on the ##
+# ## single prod provider — a soak degrades and disconnects it (that IS     ##
+# ## #584). See scenario 15 header and test/e2e/thermal-soak/README.md.     ##
+# ############################################################################
+#
+# Two sample sources, each emitted as its own NDJSON record:
+#   - powermetrics --samplers smc,cpu_power,gpu_power : SMC temps, CPU/GPU
+#     power (W), package/GPU/CPU frequency residencies. Needs sudo.
+#   - pmset -g therm : thermal pressure + CPU speed-limit % (the OS's own
+#     "I am throttling" signal). No sudo needed on most macOS builds.
+#
+# Each line is one JSON object with a top-level "ts" (UTC RFC3339, ms) and a
+# "source" tag ("powermetrics" | "pmset"), plus the parsed fields. The raw
+# tool text is preserved under "raw" so nothing is lost if parsing drifts
+# across macOS versions.
+#
+# Usage:
+#   sudo ./thermal-collector.sh --out ./thermal-<runid>.ndjson --interval 5
+#   sudo ./thermal-collector.sh --out ./thermal.ndjson --duration 3600
+#   # Start this JUST BEFORE launching the harness soak; stop with the soak
+#   # (Ctrl-C, SIGTERM, or --duration). Then join:
+#   #   ./join-thermal.py per_request.jsonl thermal.ndjson > overlay.ndjson
+#
+# Env overrides: THERMAL_INTERVAL_S (default 5), THERMAL_DURATION_S (0 = until
+# signalled), THERMAL_OUT.
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+: "${THERMAL_INTERVAL_S:=5}"
+: "${THERMAL_DURATION_S:=0}"
+: "${THERMAL_OUT:=}"
+
+usage() {
+  sed -n '2,40p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
+  exit "${1:-0}"
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --out)       THERMAL_OUT="$2"; shift 2 ;;
+    --interval)  THERMAL_INTERVAL_S="$2"; shift 2 ;;
+    --duration)  THERMAL_DURATION_S="$2"; shift 2 ;;
+    -h|--help)   usage 0 ;;
+    *) echo "thermal-collector: unknown arg: $1" >&2; usage 2 ;;
+  esac
+done
+
+if [[ -z "$THERMAL_OUT" ]]; then
+  echo "thermal-collector: --out <path.ndjson> is required" >&2
+  exit 2
+fi
+
+case "$(uname -s)" in
+  Darwin) : ;;
+  *) echo "thermal-collector: macOS only (uname=$(uname -s)) — run on the lab Mac" >&2; exit 1 ;;
+esac
+
+mkdir -p "$(dirname "$THERMAL_OUT")"
+
+# ts_now: UTC RFC3339 with millis. `date` on macOS lacks %N, so use a portable
+# fallback (whole-second precision is enough to join against per_request.jsonl,
+# whose records span seconds).
+ts_now() { date -u +%Y-%m-%dT%H:%M:%SZ; }
+
+# json_str: minimal JSON string escaper for the "raw" field (escapes backslash,
+# double-quote, and control chars → spaces).
+json_str() {
+  python3 -c 'import json,sys; print(json.dumps(sys.stdin.read()))'
+}
+
+emit_pmset() {
+  local ts raw speed_limit
+  ts="$(ts_now)"
+  raw="$(pmset -g therm 2>/dev/null || true)"
+  # "CPU_Speed_Limit = 100" → 100 means no throttle; < 100 means throttling.
+  speed_limit="$(printf '%s\n' "$raw" | awk -F'= ' '/CPU_Speed_Limit/{gsub(/[^0-9]/,"",$2); print $2; exit}')"
+  [[ -z "$speed_limit" ]] && speed_limit="null"
+  printf '{"ts":"%s","source":"pmset","cpu_speed_limit_pct":%s,"raw":%s}\n' \
+    "$ts" "$speed_limit" "$(printf '%s' "$raw" | json_str)" >> "$THERMAL_OUT"
+}
+
+emit_powermetrics() {
+  local ts raw cpu_w gpu_w die_temp
+  ts="$(ts_now)"
+  # Single-shot sample (-n 1). -i is the sample window in ms.
+  raw="$(sudo powermetrics --samplers smc,cpu_power,gpu_power -n 1 -i "$((THERMAL_INTERVAL_S*1000))" 2>/dev/null || true)"
+  if [[ -z "$raw" ]]; then
+    printf '{"ts":"%s","source":"powermetrics","error":"no sample (needs sudo / unsupported on this Mac)"}\n' "$ts" >> "$THERMAL_OUT"
+    return
+  fi
+  cpu_w="$(printf '%s\n' "$raw"  | awk -F': ' '/CPU Power/{gsub(/[^0-9.]/,"",$2); print $2; exit}')"
+  gpu_w="$(printf '%s\n' "$raw"  | awk -F': ' '/GPU Power/{gsub(/[^0-9.]/,"",$2); print $2; exit}')"
+  die_temp="$(printf '%s\n' "$raw" | awk -F': ' '/die temperature|CPU die temperature/{gsub(/[^0-9.]/,"",$2); print $2; exit}')"
+  [[ -z "$cpu_w" ]] && cpu_w="null"
+  [[ -z "$gpu_w" ]] && gpu_w="null"
+  [[ -z "$die_temp" ]] && die_temp="null"
+  printf '{"ts":"%s","source":"powermetrics","cpu_power_mw":%s,"gpu_power_mw":%s,"cpu_die_temp_c":%s,"raw":%s}\n' \
+    "$ts" "$cpu_w" "$gpu_w" "$die_temp" "$(printf '%s' "$raw" | json_str)" >> "$THERMAL_OUT"
+}
+
+echo "thermal-collector: sampling every ${THERMAL_INTERVAL_S}s → $THERMAL_OUT (duration=${THERMAL_DURATION_S}s, 0=until signalled)" >&2
+
+start_epoch="$(date -u +%s)"
+trap 'echo "thermal-collector: stopping" >&2; exit 0' INT TERM
+
+while :; do
+  emit_pmset
+  emit_powermetrics   # this call itself consumes ~THERMAL_INTERVAL_S (its -i window)
+  if [[ "$THERMAL_DURATION_S" != "0" ]]; then
+    now_epoch="$(date -u +%s)"
+    if (( now_epoch - start_epoch >= THERMAL_DURATION_S )); then
+      echo "thermal-collector: duration reached, exiting" >&2
+      break
+    fi
+  fi
+done

--- a/test/network-harness/internal/benchmark/benchmark.go
+++ b/test/network-harness/internal/benchmark/benchmark.go
@@ -96,13 +96,14 @@ type BuyerMetrics struct {
 // SustainedTPSMetrics is the sustained-load retention cross-section for
 // B10. It windows the per-request *streaming* decode-TPS distribution
 // (post-TTFT tokens / decode duration — the same basis as B2, NOT the
-// structurally-unreliable non-streaming sustained_tps field) by
-// wall-clock StartUTC into a first window (the first SustainedTPSWindowSeconds
-// of observed samples) and a final window (the last SustainedTPSWindowSeconds),
-// then reports retention = final_p50 / first_p50. On a short run the two
-// windows can overlap; the ≥ SustainedTPSMinWindowSamples floor is the
-// guard against a meaningless verdict, not window disjointness (a real
-// 45–60 min soak has fully disjoint windows).
+// structurally-unreliable non-streaming sustained_tps field) by wall-clock
+// start into a first window [runStart, runStart+W) and a final window
+// (runEnd-W, runEnd], where runStart/runEnd are the TRUE run bounds (over
+// ALL results, including failures) and W = SustainedTPSWindowSeconds, then
+// reports retention = final_p50 / first_p50. Anchoring to the real run end
+// (not the last successful sample) is what makes a near-end provider
+// disconnect SKIP rather than falsely PASS. Runs whose span is < 2W (windows
+// would overlap) yield zero-count windows → B10 SKIPs.
 type SustainedTPSMetrics struct {
 	FirstWindowTPSP50  float64 `json:"first_window_tps_p50"`
 	FinalWindowTPSP50  float64 `json:"final_window_tps_p50"`
@@ -312,7 +313,26 @@ func computeBuyerMetrics(results []buyer.Result) BuyerMetrics {
 	non2xx := map[string]int{}
 	success := 0
 	non2xxCount := 0
+	// Run temporal bounds are tracked over ALL results (including failed /
+	// disconnected ones — their StartUTC/EndUTC are still recorded at
+	// dispatch). B10 anchors its first/final windows to this true run span,
+	// NOT to the last successful streaming sample. That way a provider that
+	// disconnects near the end of a soak (the #584 signature) leaves an empty
+	// final window → B10 SKIPs, instead of the window sliding back onto early
+	// healthy samples and falsely reporting ~1.0 retention.
+	var runStart, runEnd time.Time
 	for _, r := range results {
+		if !r.StartUTC.IsZero() {
+			if runStart.IsZero() || r.StartUTC.Before(runStart) {
+				runStart = r.StartUTC
+			}
+			if r.StartUTC.After(runEnd) {
+				runEnd = r.StartUTC
+			}
+		}
+		if !r.EndUTC.IsZero() && r.EndUTC.After(runEnd) {
+			runEnd = r.EndUTC
+		}
 		if r.HTTPStatus >= 400 || r.Outcome != "ok" {
 			non2xxCount++
 			key := fmt.Sprintf("%d", r.HTTPStatus)
@@ -374,39 +394,44 @@ func computeBuyerMetrics(results []buyer.Result) BuyerMetrics {
 			bm.ColdWarm.RatioP50 = bm.ColdWarm.ColdTTFTMs.P50 / bm.ColdWarm.WarmTTFTMs.P50
 		}
 	}
-	bm.SustainedTPS = computeSustainedTPS(tpsSamples)
+	bm.SustainedTPS = computeSustainedTPS(tpsSamples, runStart, runEnd)
 	return bm
 }
 
-// computeSustainedTPS windows the timestamped streaming-TPS samples into
-// a first window ([t0, t0+W)) and a final window ((tEnd-W, tEnd]) by
-// wall-clock start, where t0/tEnd are the earliest/latest observed sample
-// starts and W = SustainedTPSWindowSeconds. It reports the p50 of each
-// window and retention = final_p50 / first_p50. Sample counts are 0 when
-// no streaming samples exist; B10 SKIPs below the per-window floor.
-func computeSustainedTPS(samples []tpsSample) SustainedTPSMetrics {
+// computeSustainedTPS windows the timestamped streaming-TPS samples into a
+// first window [runStart, runStart+W) and a final window (runEnd-W, runEnd]
+// by wall-clock start, where W = SustainedTPSWindowSeconds and runStart /
+// runEnd are the TRUE run bounds (earliest/latest timestamp over ALL results,
+// including failures) — NOT the last successful sample. This is the fix for
+// the #584 failure mode: if the provider disconnects near run end, the final
+// window has no usable streaming samples and B10 SKIPs, rather than sliding
+// back onto early healthy samples and falsely PASSing.
+//
+// The run span must be at least 2W (disjoint windows). A shorter run yields
+// zero-count windows, so B10 SKIPs — a run that can't hold a distinct first
+// and final 5-min window cannot produce a meaningful retention verdict.
+// retention = final_p50 / first_p50. B10 SKIPs below the per-window floor.
+func computeSustainedTPS(samples []tpsSample, runStart, runEnd time.Time) SustainedTPSMetrics {
 	var st SustainedTPSMetrics
-	if len(samples) == 0 {
+	if len(samples) == 0 || runStart.IsZero() || !runEnd.After(runStart) {
 		return st
 	}
-	t0 := samples[0].start
-	tEnd := samples[0].start
-	for _, s := range samples {
-		if s.start.Before(t0) {
-			t0 = s.start
-		}
-		if s.start.After(tEnd) {
-			tEnd = s.start
-		}
+	w := time.Duration(SustainedTPSWindowSeconds) * time.Second
+	// Require disjoint first/final windows: span >= 2W. Otherwise leave both
+	// counts 0 so evalB10 SKIPs (can't distinguish first vs final).
+	if runEnd.Sub(runStart) < 2*w {
+		return st
 	}
-	firstCutoff := t0.Add(time.Duration(SustainedTPSWindowSeconds) * time.Second)
-	finalCutoff := tEnd.Add(-time.Duration(SustainedTPSWindowSeconds) * time.Second)
+	firstCutoff := runStart.Add(w)  // first window: [runStart, firstCutoff)
+	finalCutoff := runEnd.Add(-w)   // final window: (finalCutoff, runEnd]
 	var first, final []float64
 	for _, s := range samples {
-		if s.start.Before(firstCutoff) {
+		if !s.start.Before(runStart) && s.start.Before(firstCutoff) {
 			first = append(first, s.tps)
 		}
-		if !s.start.Before(finalCutoff) {
+		// Final window lower bound is EXCLUSIVE (finalCutoff, runEnd]; a
+		// sample exactly at the cutoff belongs to neither window.
+		if s.start.After(finalCutoff) && !s.start.After(runEnd) {
 			final = append(final, s.tps)
 		}
 	}

--- a/test/network-harness/internal/benchmark/benchmark.go
+++ b/test/network-harness/internal/benchmark/benchmark.go
@@ -11,6 +11,11 @@
 //   B4  Error rate per 1000 requests bounded
 //   B5  Provider slot utilization reasonable
 //   B6  Earnings/hr viable at current tier-2 pricing
+//   B7  Cold/warm TTFT ratio bounded (scenario 08)
+//   B10 Sustained streaming-TPS retention over a long soak (scenario 15)
+//
+// (B8/B9 — sticky cache-reuse — are added by RESEARCH_236; B10 skips
+// that range to avoid colliding regardless of merge order.)
 //
 // Each verdict carries a Status (PASS / WARN / FAIL / SKIP), the
 // measured value, the target and bare-min thresholds, and a one-line
@@ -81,6 +86,29 @@ type BuyerMetrics struct {
 	// distributions used by B7. Both Count fields are 0 when phase
 	// data is absent.
 	ColdWarm ColdWarmMetrics `json:"cold_warm,omitempty"`
+
+	// SustainedTPS — the windowed streaming-TPS retention cross-section
+	// used by B10. Always computed; the window sample counts are 0 on
+	// runs too short/sparse to fill either window, in which case B10 SKIPs.
+	SustainedTPS SustainedTPSMetrics `json:"sustained_tps"`
+}
+
+// SustainedTPSMetrics is the sustained-load retention cross-section for
+// B10. It windows the per-request *streaming* decode-TPS distribution
+// (post-TTFT tokens / decode duration — the same basis as B2, NOT the
+// structurally-unreliable non-streaming sustained_tps field) by
+// wall-clock StartUTC into a first window (the first SustainedTPSWindowSeconds
+// of observed samples) and a final window (the last SustainedTPSWindowSeconds),
+// then reports retention = final_p50 / first_p50. On a short run the two
+// windows can overlap; the ≥ SustainedTPSMinWindowSamples floor is the
+// guard against a meaningless verdict, not window disjointness (a real
+// 45–60 min soak has fully disjoint windows).
+type SustainedTPSMetrics struct {
+	FirstWindowTPSP50  float64 `json:"first_window_tps_p50"`
+	FinalWindowTPSP50  float64 `json:"final_window_tps_p50"`
+	Retention          float64 `json:"retention"`
+	FirstWindowSamples int     `json:"first_window_samples"`
+	FinalWindowSamples int     `json:"final_window_samples"`
 }
 
 // ColdWarmMetrics is the cold-vs-warm TTFT cross-section. Cold = first
@@ -178,6 +206,26 @@ const (
 	// hurts buyer-perceived p50 on bursty workloads.
 	ColdWarmRatioTarget  = 2.0
 	ColdWarmRatioBareMin = 5.0
+
+	// B10 (sustained streaming-TPS retention) thresholds for scenario 15
+	// (thermal soak). retention = final-window TPS p50 / first-window TPS
+	// p50 over a 45–60 min constant-decode soak. A provider that thermally
+	// throttles under sustained load sheds decode throughput; retention
+	// captures how much it keeps. These bands are PROVISIONAL — they were
+	// chosen before any real soak run and MUST be recalibrated from the
+	// first lab-Mac campaign (issue #584) before B10 is armed as a gate.
+	// Until then scenario 15 leaves sustained_gate_armed=false, which
+	// downgrades a would-be FAIL to WARN (see evalB10).
+	SustainedTPSRetentionTarget  = 0.85 // PASS ≥ 0.85
+	SustainedTPSRetentionBareMin = 0.70 // WARN ≥ 0.70, FAIL < 0.70
+
+	// SustainedTPSWindowSeconds is the width of the first/final comparison
+	// windows (5 min each).
+	SustainedTPSWindowSeconds = 300.0
+
+	// SustainedTPSMinWindowSamples is the per-window sample floor below
+	// which B10 SKIPs rather than emit a low-confidence retention verdict.
+	SustainedTPSMinWindowSamples = 8
 )
 
 // Evaluate computes the benchmark summary and per-invariant verdicts.
@@ -233,6 +281,8 @@ func Evaluate(
 			verdicts = append(verdicts, evalB6(providerMetrics, pricing, windowSeconds))
 		case "B7":
 			verdicts = append(verdicts, evalB7(buyerMetrics))
+		case "B10":
+			verdicts = append(verdicts, evalB10(buyerMetrics, sc.Benchmark.SustainedGateArmed))
 		default:
 			verdicts = append(verdicts, Verdict{
 				ID:     id,
@@ -248,9 +298,17 @@ func Evaluate(
 
 // --- buyer-side compute -----------------------------------------------------
 
+// tpsSample is one streaming-TPS observation tagged with the request's
+// wall-clock start, used to window the decode-TPS distribution for B10.
+type tpsSample struct {
+	start time.Time
+	tps   float64
+}
+
 func computeBuyerMetrics(results []buyer.Result) BuyerMetrics {
 	var ttfts, walls, tps []float64
 	var coldTTFTs, warmTTFTs []float64
+	var tpsSamples []tpsSample
 	non2xx := map[string]int{}
 	success := 0
 	non2xxCount := 0
@@ -288,7 +346,9 @@ func computeBuyerMetrics(results []buyer.Result) BuyerMetrics {
 			firstByte := r.StartUTC.Add(time.Duration(r.TTFTMillis) * time.Millisecond)
 			streamDur := r.LastByteUTC.Sub(firstByte).Seconds()
 			if streamDur > 0 {
-				tps = append(tps, float64(r.CompletionTokensReceived)/streamDur)
+				v := float64(r.CompletionTokensReceived) / streamDur
+				tps = append(tps, v)
+				tpsSamples = append(tpsSamples, tpsSample{start: r.StartUTC, tps: v})
 			}
 		}
 	}
@@ -314,7 +374,54 @@ func computeBuyerMetrics(results []buyer.Result) BuyerMetrics {
 			bm.ColdWarm.RatioP50 = bm.ColdWarm.ColdTTFTMs.P50 / bm.ColdWarm.WarmTTFTMs.P50
 		}
 	}
+	bm.SustainedTPS = computeSustainedTPS(tpsSamples)
 	return bm
+}
+
+// computeSustainedTPS windows the timestamped streaming-TPS samples into
+// a first window ([t0, t0+W)) and a final window ((tEnd-W, tEnd]) by
+// wall-clock start, where t0/tEnd are the earliest/latest observed sample
+// starts and W = SustainedTPSWindowSeconds. It reports the p50 of each
+// window and retention = final_p50 / first_p50. Sample counts are 0 when
+// no streaming samples exist; B10 SKIPs below the per-window floor.
+func computeSustainedTPS(samples []tpsSample) SustainedTPSMetrics {
+	var st SustainedTPSMetrics
+	if len(samples) == 0 {
+		return st
+	}
+	t0 := samples[0].start
+	tEnd := samples[0].start
+	for _, s := range samples {
+		if s.start.Before(t0) {
+			t0 = s.start
+		}
+		if s.start.After(tEnd) {
+			tEnd = s.start
+		}
+	}
+	firstCutoff := t0.Add(time.Duration(SustainedTPSWindowSeconds) * time.Second)
+	finalCutoff := tEnd.Add(-time.Duration(SustainedTPSWindowSeconds) * time.Second)
+	var first, final []float64
+	for _, s := range samples {
+		if s.start.Before(firstCutoff) {
+			first = append(first, s.tps)
+		}
+		if !s.start.Before(finalCutoff) {
+			final = append(final, s.tps)
+		}
+	}
+	st.FirstWindowSamples = len(first)
+	st.FinalWindowSamples = len(final)
+	if len(first) > 0 {
+		st.FirstWindowTPSP50 = percentile(first, 0.50)
+	}
+	if len(final) > 0 {
+		st.FinalWindowTPSP50 = percentile(final, 0.50)
+	}
+	if st.FirstWindowTPSP50 > 0 {
+		st.Retention = st.FinalWindowTPSP50 / st.FirstWindowTPSP50
+	}
+	return st
 }
 
 // --- provider-side compute --------------------------------------------------
@@ -630,6 +737,60 @@ func evalB7(bm BuyerMetrics) Verdict {
 	default:
 		v.Status = StatusFail
 		v.Detail = fmt.Sprintf("cold/warm p50 ratio %.2f exceeds bare-min %.1f — cold-start penalty hurts buyer-perceived latency", v.Value, v.BareMin)
+	}
+	return v
+}
+
+// evalB10 scores sustained streaming-TPS retention over a long soak
+// (scenario 15). retention = final-window TPS p50 / first-window TPS p50.
+// A provider that thermally throttles under constant decode load sheds
+// throughput, driving retention below 1.0. SKIP when either window has
+// fewer than SustainedTPSMinWindowSamples samples (run too short/sparse).
+//
+// gateArmed gates blocking: the B10 thresholds are provisional until a
+// real lab soak calibrates them (issue #584), so when gateArmed is false
+// a would-be FAIL is reported as WARN with a "[provisional/unarmed]"
+// marker — the retention is still measured and surfaced, it just cannot
+// block a run. When gateArmed is true B10 fails hard below the bare-min.
+func evalB10(bm BuyerMetrics, gateArmed bool) Verdict {
+	v := Verdict{ID: "B10", Title: "sustained streaming-TPS retention", Unit: "ratio",
+		Target: SustainedTPSRetentionTarget, BareMin: SustainedTPSRetentionBareMin}
+	st := bm.SustainedTPS
+	if st.FirstWindowSamples < SustainedTPSMinWindowSamples || st.FinalWindowSamples < SustainedTPSMinWindowSamples {
+		v.Status = StatusSkip
+		v.Detail = fmt.Sprintf("insufficient windowed streaming samples (first=%d final=%d, need >=%d each) — soak too short or too sparse for a retention verdict",
+			st.FirstWindowSamples, st.FinalWindowSamples, SustainedTPSMinWindowSamples)
+		return v
+	}
+	if st.FirstWindowTPSP50 <= 0 {
+		v.Status = StatusSkip
+		v.Detail = "first-window streaming TPS p50 is zero — cannot compute retention"
+		return v
+	}
+	v.Value = st.Retention
+	armSuffix := ""
+	if !gateArmed {
+		armSuffix = " [provisional/unarmed — thresholds not yet lab-calibrated, #584]"
+	}
+	switch {
+	case v.Value >= SustainedTPSRetentionTarget:
+		v.Status = StatusPass
+		v.Detail = fmt.Sprintf("retention %.2f >= target %.2f (first p50=%.1f tok/s n=%d, final p50=%.1f tok/s n=%d)%s",
+			v.Value, v.Target, st.FirstWindowTPSP50, st.FirstWindowSamples, st.FinalWindowTPSP50, st.FinalWindowSamples, armSuffix)
+	case v.Value >= SustainedTPSRetentionBareMin:
+		v.Status = StatusWarn
+		v.Detail = fmt.Sprintf("retention %.2f under target %.2f but >= bare-min %.2f — throughput sagging under sustained load (first p50=%.1f final p50=%.1f)%s",
+			v.Value, v.Target, v.BareMin, st.FirstWindowTPSP50, st.FinalWindowTPSP50, armSuffix)
+	default:
+		if gateArmed {
+			v.Status = StatusFail
+			v.Detail = fmt.Sprintf("retention %.2f under bare-min %.2f — sustained-load throughput collapse (first p50=%.1f tok/s, final p50=%.1f tok/s); this is the #584 degradation signature",
+				v.Value, v.BareMin, st.FirstWindowTPSP50, st.FinalWindowTPSP50)
+		} else {
+			v.Status = StatusWarn
+			v.Detail = fmt.Sprintf("retention %.2f below bare-min %.2f (would FAIL if gate armed) — sustained-load throughput collapse (first p50=%.1f tok/s, final p50=%.1f tok/s)%s",
+				v.Value, v.BareMin, st.FirstWindowTPSP50, st.FinalWindowTPSP50, armSuffix)
+		}
 	}
 	return v
 }

--- a/test/network-harness/internal/benchmark/benchmark_test.go
+++ b/test/network-harness/internal/benchmark/benchmark_test.go
@@ -1,6 +1,7 @@
 package benchmark
 
 import (
+	"math"
 	"os"
 	"path/filepath"
 	"testing"
@@ -558,5 +559,124 @@ func TestSchema_ColdWarmPairs_Validate(t *testing.T) {
 				t.Fatalf("Validate err=%v, wantErr=%v", err, tc.wantErr)
 			}
 		})
+	}
+}
+
+// B10 (sustained streaming-TPS retention) tests ------------------------
+
+// makeTPSResult builds one streaming-OK result starting at `start` whose
+// derived decode TPS is exactly `tps` (tokens / post-TTFT duration), so a
+// fixture can dial retention deterministically.
+func makeTPSResult(start time.Time, tps float64) buyer.Result {
+	const tokens = 64
+	const ttftMs = 200
+	streamDur := float64(tokens) / tps // seconds
+	firstByte := start.Add(ttftMs * time.Millisecond)
+	last := firstByte.Add(time.Duration(streamDur * float64(time.Second)))
+	return buyer.Result{
+		StartUTC:                 start,
+		EndUTC:                   last,
+		TTFTMillis:               ttftMs,
+		TotalMillis:              last.Sub(start).Milliseconds(),
+		CompletionTokensReceived: tokens,
+		HTTPStatus:               200,
+		Stream:                   true,
+		RouteProviderID:          "p1",
+		Model:                    "m",
+		Outcome:                  "ok",
+		LastByteUTC:              last,
+	}
+}
+
+// soakResults spreads nEach first-window samples over the opening ~3 min
+// and nEach final-window samples over the closing ~3 min of a ~60 min
+// span, so the two 5-min windows are fully disjoint.
+func soakResults(firstTPS, finalTPS float64, nEach int) []buyer.Result {
+	base := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	var rs []buyer.Result
+	for i := 0; i < nEach; i++ {
+		rs = append(rs, makeTPSResult(base.Add(time.Duration(i*20)*time.Second), firstTPS))
+	}
+	for i := 0; i < nEach; i++ {
+		rs = append(rs, makeTPSResult(base.Add(time.Duration(3400+i*20)*time.Second), finalTPS))
+	}
+	return rs
+}
+
+func scArmed(armed bool, invs ...string) *scenario.Scenario {
+	s := sc(invs...)
+	s.Benchmark.SustainedGateArmed = armed
+	return s
+}
+
+func TestB10_Retention_Pass(t *testing.T) {
+	// 30 → 28 tok/s → retention 0.933 ≥ 0.85 → PASS
+	res := Evaluate(scArmed(false, "B10"), soakResults(30, 28, 10), nil, nil, nil, "test", 3600)
+	if got := res.Verdicts[0].Status; got != StatusPass {
+		t.Fatalf("B10 expected PASS at retention 0.93, got %s: %s", got, res.Verdicts[0].Detail)
+	}
+}
+
+func TestB10_Retention_Warn(t *testing.T) {
+	// 30 → 24 tok/s → retention 0.80 → WARN (≥0.70, <0.85)
+	res := Evaluate(scArmed(false, "B10"), soakResults(30, 24, 10), nil, nil, nil, "test", 3600)
+	if got := res.Verdicts[0].Status; got != StatusWarn {
+		t.Fatalf("B10 expected WARN at retention 0.80, got %s: %s", got, res.Verdicts[0].Detail)
+	}
+}
+
+func TestB10_Retention_Fail_WhenArmed(t *testing.T) {
+	// 30 → 18 tok/s → retention 0.60 < 0.70; armed → FAIL
+	res := Evaluate(scArmed(true, "B10"), soakResults(30, 18, 10), nil, nil, nil, "test", 3600)
+	if got := res.Verdicts[0].Status; got != StatusFail {
+		t.Fatalf("B10 expected FAIL at retention 0.60 (armed), got %s: %s", got, res.Verdicts[0].Detail)
+	}
+}
+
+func TestB10_Retention_Unarmed_DowngradesFailToWarn(t *testing.T) {
+	// Same 0.60 retention, but gate UNARMED → downgraded to WARN, never FAIL.
+	res := Evaluate(scArmed(false, "B10"), soakResults(30, 18, 10), nil, nil, nil, "test", 3600)
+	if got := res.Verdicts[0].Status; got != StatusWarn {
+		t.Fatalf("B10 expected WARN at retention 0.60 (unarmed), got %s: %s", got, res.Verdicts[0].Detail)
+	}
+	if res.AnyFailed() {
+		t.Fatalf("unarmed B10 must never contribute a FAIL: %s", res.Verdicts[0].Detail)
+	}
+}
+
+func TestB10_Retention_Skip_TooFewSamples(t *testing.T) {
+	// Only 4 samples per window (< floor of 8) → SKIP.
+	res := Evaluate(scArmed(false, "B10"), soakResults(30, 28, 4), nil, nil, nil, "test", 3600)
+	if got := res.Verdicts[0].Status; got != StatusSkip {
+		t.Fatalf("B10 expected SKIP with 4 samples/window, got %s: %s", got, res.Verdicts[0].Detail)
+	}
+}
+
+func TestB10_Retention_Skip_NoStreamingSamples(t *testing.T) {
+	// Non-streaming results carry no windowed TPS → SKIP.
+	var results []buyer.Result
+	for i := 0; i < 20; i++ {
+		results = append(results, makeResult(300, 1000, 64, false, "p1", "m", 200))
+	}
+	res := Evaluate(scArmed(false, "B10"), results, nil, nil, nil, "test", 3600)
+	if got := res.Verdicts[0].Status; got != StatusSkip {
+		t.Fatalf("B10 expected SKIP with no streaming samples, got %s: %s", got, res.Verdicts[0].Detail)
+	}
+}
+
+func TestComputeSustainedTPS_Windows(t *testing.T) {
+	bm := computeBuyerMetrics(soakResults(30, 24, 10))
+	st := bm.SustainedTPS
+	if st.FirstWindowSamples != 10 || st.FinalWindowSamples != 10 {
+		t.Fatalf("want 10/10 window samples, got %d/%d", st.FirstWindowSamples, st.FinalWindowSamples)
+	}
+	if math.Abs(st.FirstWindowTPSP50-30) > 0.5 {
+		t.Fatalf("want first p50 ≈30, got %.2f", st.FirstWindowTPSP50)
+	}
+	if math.Abs(st.FinalWindowTPSP50-24) > 0.5 {
+		t.Fatalf("want final p50 ≈24, got %.2f", st.FinalWindowTPSP50)
+	}
+	if math.Abs(st.Retention-0.80) > 0.02 {
+		t.Fatalf("want retention ≈0.80, got %.3f", st.Retention)
 	}
 }

--- a/test/network-harness/internal/benchmark/benchmark_test.go
+++ b/test/network-harness/internal/benchmark/benchmark_test.go
@@ -664,6 +664,45 @@ func TestB10_Retention_Skip_NoStreamingSamples(t *testing.T) {
 	}
 }
 
+func TestB10_Retention_Skip_ProviderStopsBeforeEnd(t *testing.T) {
+	// The #584 signature: 10 healthy streaming samples in the first 5 min,
+	// then the provider disconnects — the buyer keeps firing but every later
+	// request FAILS (503), extending the run to ~60 min with NO usable
+	// streaming sample in the final window. B10 must SKIP (empty final
+	// window), NOT slide the window back and falsely PASS at ~1.0 retention.
+	base := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	var results []buyer.Result
+	for i := 0; i < 10; i++ {
+		results = append(results, makeTPSResult(base.Add(time.Duration(i*20)*time.Second), 30))
+	}
+	// Failed requests spanning the rest of the hour (these carry StartUTC/
+	// EndUTC, so they extend the true run bounds).
+	for i := 0; i < 30; i++ {
+		r := makeResult(0, 500, 0, true, "p1", "m", 503)
+		r.StartUTC = base.Add(time.Duration(300+i*100) * time.Second)
+		r.EndUTC = r.StartUTC.Add(500 * time.Millisecond)
+		results = append(results, r)
+	}
+	res := Evaluate(scArmed(true, "B10"), results, nil, nil, nil, "test", 3600)
+	if got := res.Verdicts[0].Status; got != StatusSkip {
+		t.Fatalf("B10 must SKIP when the provider stops before run end, got %s: %s", got, res.Verdicts[0].Detail)
+	}
+}
+
+func TestB10_Retention_Skip_ShortRunOverlappingWindows(t *testing.T) {
+	// A run whose full span is < 2×window (600s) cannot hold disjoint first
+	// and final windows → SKIP, never a false PASS from overlapping windows.
+	base := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	var results []buyer.Result
+	for i := 0; i < 20; i++ {
+		results = append(results, makeTPSResult(base.Add(time.Duration(i*20)*time.Second), 30)) // spans ~380s
+	}
+	res := Evaluate(scArmed(true, "B10"), results, nil, nil, nil, "test", 400)
+	if got := res.Verdicts[0].Status; got != StatusSkip {
+		t.Fatalf("B10 must SKIP on a run too short for disjoint windows, got %s: %s", got, res.Verdicts[0].Detail)
+	}
+}
+
 func TestComputeSustainedTPS_Windows(t *testing.T) {
 	bm := computeBuyerMetrics(soakResults(30, 24, 10))
 	st := bm.SustainedTPS

--- a/test/network-harness/internal/buyer/loadgen.go
+++ b/test/network-harness/internal/buyer/loadgen.go
@@ -85,6 +85,23 @@ func Run(ctx context.Context, sc *scenario.Scenario) ([]Result, error) {
 				Transport: transport,
 				Timeout:   sc.RequestTimeout,
 			}
+			// LAB-ONLY redirect guard for B10 soaks: even though the
+			// configured URLs are validated as lab addresses, a lab gateway
+			// that 3xx-redirects could otherwise send the sustained load to a
+			// public host (e.g. prod). Refuse any redirect whose destination
+			// is not itself a lab address, so the soak can never reach prod
+			// via a redirect (#584).
+			if sc.BenchmarkHasB10() {
+				client.CheckRedirect = func(req *http.Request, via []*http.Request) error {
+					if !scenario.LabHostAllowed(req.URL.Hostname()) {
+						return fmt.Errorf("B10 soak refused redirect to non-lab host %q (#584)", req.URL.Hostname())
+					}
+					if len(via) >= 10 {
+						return fmt.Errorf("stopped after 10 redirects")
+					}
+					return nil
+				}
+			}
 
 			for reqIdx := 0; reqIdx < sc.Buyers.RequestsPerBuyer; reqIdx++ {
 				if ctx.Err() != nil {

--- a/test/network-harness/internal/scenario/schema.go
+++ b/test/network-harness/internal/scenario/schema.go
@@ -129,6 +129,15 @@ type Benchmark struct {
 	// B5 (slot utilization). Defaults to 3 — the Pearl coordinator's
 	// AccountConcurrency at the time this spec landed (PR #205).
 	ProviderSlots int `yaml:"provider_slots"`
+
+	// SustainedGateArmed arms B10 (sustained streaming-TPS retention) as a
+	// blocking gate. When false (the default), B10 still measures and
+	// reports retention, but a would-be FAIL is downgraded to WARN so an
+	// UNCALIBRATED gate can never block a run. The B10 thresholds are
+	// provisional (PASS >= 0.85 / WARN >= 0.70 / FAIL < 0.70) and must be
+	// calibrated against a real lab soak before this flag is set true —
+	// see docs/notes/SPEC-NETWORK-BENCHMARK-v0.1.md §3.5 and issue #584.
+	SustainedGateArmed bool `yaml:"sustained_gate_armed"`
 }
 
 // ChaosEvent is one scheduled shell action. `At` is measured from

--- a/test/network-harness/internal/scenario/schema.go
+++ b/test/network-harness/internal/scenario/schema.go
@@ -537,13 +537,61 @@ func (s *Scenario) validateBuyerFleet() error {
 		// RESEARCH_235's sustained-TPS retention. B10 skips that range to
 		// avoid colliding regardless of PR merge order.
 		known := map[string]bool{"B1": true, "B2": true, "B3": true, "B4": true, "B5": true, "B6": true, "B7": true, "B10": true}
+		hasB10 := false
 		for _, id := range s.Benchmark.Invariants {
 			if !known[id] {
 				return fmt.Errorf("benchmark.invariants: unknown id %q (known: B1-B7, B10)", id)
 			}
+			if id == "B10" {
+				hasB10 = true
+			}
 		}
 		if s.Benchmark.ProviderSlots < 1 {
 			return fmt.Errorf("benchmark.provider_slots must be >= 1")
+		}
+		// LAB-ONLY enforcement for B10 (sustained-load soak). A 45–60 min
+		// soak degrades and disconnects the single prod mac — that IS #584.
+		// Leaving the lab URLs unset already fails the empty-gateway check,
+		// but an operator could still point ${LAB_GATEWAY_URL} at prod. Hard
+		// fail if either target resolves to the production host, so a B10
+		// scenario physically cannot fire at streamvc.live.
+		if hasB10 {
+			for _, pair := range []struct{ field, raw string }{
+				{"target.gateway_url", s.Target.GatewayURL},
+				{"target.coordinator_url", s.Target.CoordinatorURL},
+			} {
+				if err := rejectProdHost(pair.field, pair.raw); err != nil {
+					return err
+				}
+			}
+		}
+	}
+	return nil
+}
+
+// prodHostSuffixes are the production hosts a lab-only (B10) scenario must
+// never target. Matches the exact host and any subdomain of it.
+var prodHostSuffixes = []string{"streamvc.live"}
+
+// rejectProdHost fails validation if raw is a URL whose host is (or is a
+// subdomain of) a production host. Empty raw is allowed here — the caller's
+// separate empty-gateway check governs that. This is the LAB-ONLY guard for
+// the thermal soak (#584): a B10 scenario physically cannot fire at prod.
+func rejectProdHost(field, raw string) error {
+	if raw == "" {
+		return nil
+	}
+	u, err := url.Parse(raw)
+	if err != nil {
+		return fmt.Errorf("%s is not a valid URL: %w", field, err)
+	}
+	host := strings.ToLower(u.Hostname())
+	if host == "" {
+		return nil
+	}
+	for _, suffix := range prodHostSuffixes {
+		if host == suffix || strings.HasSuffix(host, "."+suffix) {
+			return fmt.Errorf("%s points at production host %q — B10 (thermal soak) is LAB-ONLY; a sustained soak degrades and disconnects the prod provider (#584). Use a lab stack", field, host)
 		}
 	}
 	return nil

--- a/test/network-harness/internal/scenario/schema.go
+++ b/test/network-harness/internal/scenario/schema.go
@@ -7,6 +7,7 @@ package scenario
 
 import (
 	"fmt"
+	"net"
 	"net/url"
 	"os"
 	"regexp"
@@ -537,47 +538,76 @@ func (s *Scenario) validateBuyerFleet() error {
 		// RESEARCH_235's sustained-TPS retention. B10 skips that range to
 		// avoid colliding regardless of PR merge order.
 		known := map[string]bool{"B1": true, "B2": true, "B3": true, "B4": true, "B5": true, "B6": true, "B7": true, "B10": true}
-		hasB10 := false
 		for _, id := range s.Benchmark.Invariants {
 			if !known[id] {
 				return fmt.Errorf("benchmark.invariants: unknown id %q (known: B1-B7, B10)", id)
-			}
-			if id == "B10" {
-				hasB10 = true
 			}
 		}
 		if s.Benchmark.ProviderSlots < 1 {
 			return fmt.Errorf("benchmark.provider_slots must be >= 1")
 		}
-		// LAB-ONLY enforcement for B10 (sustained-load soak). A 45–60 min
-		// soak degrades and disconnects the single prod mac — that IS #584.
-		// Leaving the lab URLs unset already fails the empty-gateway check,
-		// but an operator could still point ${LAB_GATEWAY_URL} at prod. Hard
-		// fail if either target resolves to the production host, so a B10
-		// scenario physically cannot fire at streamvc.live.
-		if hasB10 {
-			for _, pair := range []struct{ field, raw string }{
-				{"target.gateway_url", s.Target.GatewayURL},
-				{"target.coordinator_url", s.Target.CoordinatorURL},
-			} {
-				if err := rejectProdHost(pair.field, pair.raw); err != nil {
-					return err
-				}
+	}
+	// LAB-ONLY enforcement for B10 (sustained-load soak) — applied regardless
+	// of Benchmark.Enabled, because the sustained buyer load still runs even
+	// when benchmark scoring is off. A 45–60 min soak degrades and disconnects
+	// the single prod mac — that IS #584. Both targets must be lab addresses
+	// (loopback/private/localhost); a public host such as prod is rejected, and
+	// hostname-normalization tricks cannot slip past a positive allowlist.
+	if s.BenchmarkHasB10() {
+		for _, pair := range []struct{ field, raw string }{
+			{"target.gateway_url", s.Target.GatewayURL},
+			{"target.coordinator_url", s.Target.CoordinatorURL},
+		} {
+			if err := validateLabOnlyHost(pair.field, pair.raw); err != nil {
+				return err
 			}
 		}
 	}
 	return nil
 }
 
-// prodHostSuffixes are the production hosts a lab-only (B10) scenario must
-// never target. Matches the exact host and any subdomain of it.
-var prodHostSuffixes = []string{"streamvc.live"}
+// benchmarkHasB10 reports whether the scenario declares the B10 sustained-load
+// soak invariant. Checked regardless of Benchmark.Enabled — the sustained buyer
+// load hits gateway_url even when benchmark scoring is turned off.
+func (s *Scenario) BenchmarkHasB10() bool {
+	for _, id := range s.Benchmark.Invariants {
+		if id == "B10" {
+			return true
+		}
+	}
+	return false
+}
 
-// rejectProdHost fails validation if raw is a URL whose host is (or is a
-// subdomain of) a production host. Empty raw is allowed here — the caller's
-// separate empty-gateway check governs that. This is the LAB-ONLY guard for
-// the thermal soak (#584): a B10 scenario physically cannot fire at prod.
-func rejectProdHost(field, raw string) error {
+// LabHostAllowed reports whether host is an acceptable LAB target for a B10
+// soak. This is a POSITIVE allowlist (loopback / private / link-local /
+// "localhost") rather than a production denylist — a denylist of prod hostnames
+// is inherently bypassable by trailing-root-dot FQDNs, IDNA/full-width Unicode
+// separators, or case tricks, all of which Go's network stack still resolves to
+// the same public host. Only addresses the operator physically controls on a
+// private network can pass, so a soak can never reach prod (#584). host is a
+// bare hostname (url.Hostname()); it is canonicalized (lowercased, trailing dot
+// trimmed) before the check.
+func LabHostAllowed(host string) bool {
+	host = strings.TrimSuffix(strings.ToLower(host), ".")
+	if host == "" {
+		return false
+	}
+	if host == "localhost" {
+		return true
+	}
+	ip := net.ParseIP(host)
+	if ip == nil {
+		// Any non-IP hostname (prod, a cloud host, a public FQDN) is rejected:
+		// a lab stack is reached by loopback/LAN IP or "localhost".
+		return false
+	}
+	return ip.IsLoopback() || ip.IsPrivate() || ip.IsLinkLocalUnicast()
+}
+
+// validateLabOnlyHost fails validation unless raw is empty or targets a lab
+// address (see LabHostAllowed). Empty raw is allowed here — the caller's
+// separate empty-gateway check governs that.
+func validateLabOnlyHost(field, raw string) error {
 	if raw == "" {
 		return nil
 	}
@@ -585,14 +615,8 @@ func rejectProdHost(field, raw string) error {
 	if err != nil {
 		return fmt.Errorf("%s is not a valid URL: %w", field, err)
 	}
-	host := strings.ToLower(u.Hostname())
-	if host == "" {
-		return nil
-	}
-	for _, suffix := range prodHostSuffixes {
-		if host == suffix || strings.HasSuffix(host, "."+suffix) {
-			return fmt.Errorf("%s points at production host %q — B10 (thermal soak) is LAB-ONLY; a sustained soak degrades and disconnects the prod provider (#584). Use a lab stack", field, host)
-		}
+	if !LabHostAllowed(u.Hostname()) {
+		return fmt.Errorf("%s host %q is not a lab address — B10 (thermal soak) is LAB-ONLY; only loopback/private/link-local IPs or \"localhost\" are allowed, because a sustained soak degrades and disconnects a real provider (#584). Use a lab stack (a public host such as prod is rejected)", field, u.Hostname())
 	}
 	return nil
 }

--- a/test/network-harness/internal/scenario/schema.go
+++ b/test/network-harness/internal/scenario/schema.go
@@ -533,10 +533,13 @@ func (s *Scenario) validateBuyerFleet() error {
 		if len(s.Benchmark.Invariants) == 0 {
 			return fmt.Errorf("benchmark.invariants must list at least one B-ID when benchmark.enabled=true")
 		}
-		known := map[string]bool{"B1": true, "B2": true, "B3": true, "B4": true, "B5": true, "B6": true, "B7": true}
+		// B8/B9 are reserved by RESEARCH_236 (sticky cache-reuse); B10 is
+		// RESEARCH_235's sustained-TPS retention. B10 skips that range to
+		// avoid colliding regardless of PR merge order.
+		known := map[string]bool{"B1": true, "B2": true, "B3": true, "B4": true, "B5": true, "B6": true, "B7": true, "B10": true}
 		for _, id := range s.Benchmark.Invariants {
 			if !known[id] {
-				return fmt.Errorf("benchmark.invariants: unknown id %q (known: B1-B7)", id)
+				return fmt.Errorf("benchmark.invariants: unknown id %q (known: B1-B7, B10)", id)
 			}
 		}
 		if s.Benchmark.ProviderSlots < 1 {

--- a/test/network-harness/internal/scenario/schema_test.go
+++ b/test/network-harness/internal/scenario/schema_test.go
@@ -464,11 +464,21 @@ func TestB10_LabOnly_RejectsProdHost(t *testing.T) {
 		coord   string
 		wantErr bool
 	}{
-		{"lab localhost ok", "http://127.0.0.1:18080", "http://127.0.0.1:19090", false},
+		{"loopback ok", "http://127.0.0.1:18080", "http://127.0.0.1:19090", false},
+		{"localhost ok", "http://localhost:18080", "http://localhost:19090", false},
+		{"private LAN ok", "http://192.168.1.20:18080", "http://10.0.0.5:19090", false},
+		{"ipv6 loopback ok", "http://[::1]:18080", "http://[::1]:19090", false},
 		{"prod gateway rejected", "https://api.streamvc.live", "http://127.0.0.1:19090", true},
 		{"prod coordinator rejected", "http://127.0.0.1:18080", "https://coordinator.streamvc.live", true},
 		{"prod subdomain rejected", "https://foo.streamvc.live", "http://127.0.0.1:19090", true},
 		{"apex prod rejected", "https://streamvc.live", "http://127.0.0.1:19090", true},
+		// Bypass variants the R1 denylist missed (R2 HIGH):
+		{"trailing-dot prod rejected", "https://api.streamvc.live./", "http://127.0.0.1:19090", true},
+		{"uppercase prod rejected", "https://API.STREAMVC.LIVE", "http://127.0.0.1:19090", true},
+		{"fullwidth-dot prod rejected", "https://api．streamvc．live", "http://127.0.0.1:19090", true},
+		{"ideographic-dot prod rejected", "https://api。streamvc。live", "http://127.0.0.1:19090", true},
+		// Any public host (not just prod) is rejected — positive allowlist.
+		{"arbitrary public host rejected", "https://example.com", "http://127.0.0.1:19090", true},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -478,13 +488,24 @@ func TestB10_LabOnly_RejectsProdHost(t *testing.T) {
 			}
 		})
 	}
+	// The guard applies even when benchmark.enabled=false — the sustained
+	// buyer load runs regardless of scoring (R2 HIGH).
+	t.Run("disabled benchmark still guards B10", func(t *testing.T) {
+		s := mk("https://api.streamvc.live", "http://127.0.0.1:19090")
+		s.Benchmark.Enabled = false
+		if err := s.Validate(); err == nil {
+			t.Fatal("B10 + benchmark.enabled=false + prod host must still be rejected")
+		}
+	})
 	// A non-B10 scenario may still target prod (the other scenarios do).
-	s := validTestScenario()
-	s.Target.GatewayURL = "https://api.streamvc.live"
-	s.Benchmark = Benchmark{Enabled: true, Invariants: []string{"B1", "B2"}, ProviderSlots: 3}
-	if err := s.Validate(); err != nil {
-		t.Fatalf("non-B10 scenario must still allow prod host, got %v", err)
-	}
+	t.Run("non-B10 may target prod", func(t *testing.T) {
+		s := validTestScenario()
+		s.Target.GatewayURL = "https://api.streamvc.live"
+		s.Benchmark = Benchmark{Enabled: true, Invariants: []string{"B1", "B2"}, ProviderSlots: 3}
+		if err := s.Validate(); err != nil {
+			t.Fatalf("non-B10 scenario must still allow prod host, got %v", err)
+		}
+	})
 }
 
 func validTestScenario() Scenario {

--- a/test/network-harness/internal/scenario/schema_test.go
+++ b/test/network-harness/internal/scenario/schema_test.go
@@ -450,6 +450,43 @@ func TestCommittedScenariosValidate(t *testing.T) {
 	}
 }
 
+func TestB10_LabOnly_RejectsProdHost(t *testing.T) {
+	mk := func(gw, coord string) *Scenario {
+		s := validTestScenario()
+		s.Target.GatewayURL = gw
+		s.Target.CoordinatorURL = coord
+		s.Benchmark = Benchmark{Enabled: true, Invariants: []string{"B1", "B10"}, ProviderSlots: 3}
+		return &s
+	}
+	cases := []struct {
+		name    string
+		gw      string
+		coord   string
+		wantErr bool
+	}{
+		{"lab localhost ok", "http://127.0.0.1:18080", "http://127.0.0.1:19090", false},
+		{"prod gateway rejected", "https://api.streamvc.live", "http://127.0.0.1:19090", true},
+		{"prod coordinator rejected", "http://127.0.0.1:18080", "https://coordinator.streamvc.live", true},
+		{"prod subdomain rejected", "https://foo.streamvc.live", "http://127.0.0.1:19090", true},
+		{"apex prod rejected", "https://streamvc.live", "http://127.0.0.1:19090", true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := mk(tc.gw, tc.coord).Validate()
+			if (err != nil) != tc.wantErr {
+				t.Fatalf("Validate err=%v, wantErr=%v", err, tc.wantErr)
+			}
+		})
+	}
+	// A non-B10 scenario may still target prod (the other scenarios do).
+	s := validTestScenario()
+	s.Target.GatewayURL = "https://api.streamvc.live"
+	s.Benchmark = Benchmark{Enabled: true, Invariants: []string{"B1", "B2"}, ProviderSlots: 3}
+	if err := s.Validate(); err != nil {
+		t.Fatalf("non-B10 scenario must still allow prod host, got %v", err)
+	}
+}
+
 func validTestScenario() Scenario {
 	return Scenario{
 		Name:                "test",

--- a/test/network-harness/internal/scenario/schema_test.go
+++ b/test/network-harness/internal/scenario/schema_test.go
@@ -412,6 +412,12 @@ duration: 1s
 
 func TestCommittedScenariosValidate(t *testing.T) {
 	t.Setenv("BUYER_TOKEN", "test-buyer-token")
+	// 15_thermal_soak.yaml targets ${LAB_GATEWAY_URL}/${LAB_COORDINATOR_URL},
+	// intentionally unset at runtime so a bare soak run fails validation
+	// rather than firing at a default (LAB PROVIDER ONLY — #584). Supply
+	// placeholders here so the structural-validity check still covers it.
+	t.Setenv("LAB_GATEWAY_URL", "http://127.0.0.1:18080")
+	t.Setenv("LAB_COORDINATOR_URL", "http://127.0.0.1:19090")
 
 	paths, err := filepath.Glob(filepath.Join("..", "..", "scenarios", "*.yaml"))
 	if err != nil {

--- a/test/network-harness/scenarios/15_thermal_soak.yaml
+++ b/test/network-harness/scenarios/15_thermal_soak.yaml
@@ -1,0 +1,100 @@
+# 15_thermal_soak.yaml — benchmark scenario, phase B, LONG-DURATION SOAK.
+#
+# Goal: drive a single provider under constant streaming-decode load for
+# 45–60 min and measure how much streaming TPS it RETAINS from the first
+# 5 min to the last 5 min (invariant B10). A provider that thermally
+# throttles under sustained load sheds decode throughput; B10 quantifies
+# the decay. This characterizes the 2026-07-13 production incident (#584)
+# where the canary collapsed a healthy provider under sustained synthetic
+# load (~30 → 8.9 → 5.3 tok/s), and restores the G3 soak coverage waived
+# pre-beta in #463 with a characterized shorter burn.
+#
+# ############################################################################
+# ## LAB PROVIDER ONLY — NEVER RUN THIS AGAINST streamvc.live / prod.       ##
+# ## #584 is the receipt: a 45–60 min soak DEGRADES AND DISCONNECTS the     ##
+# ## single prod mac. This scenario targets ${LAB_GATEWAY_URL} /            ##
+# ## ${LAB_COORDINATOR_URL}, which are intentionally UNSET by default so a  ##
+# ## bare run fails validation rather than firing at a default. Export them ##
+# ## to your lab stack (a machine you fully control) before running:        ##
+# ##   export LAB_GATEWAY_URL=http://127.0.0.1:<gw-port>                     ##
+# ##   export LAB_COORDINATOR_URL=http://127.0.0.1:<coord-port>             ##
+# ## The lab provider must be the ONLY pool member and prod buyers routed   ##
+# ## away. Stand the lab stack up ONCE and leave it — rapid coordinator     ##
+# ## restarts wedge the provider CLI's v2 proof-auth (pool → 0); recover    ##
+# ## with `pkill -9 -f macprovider-cli` and let launchd respawn one.        ##
+# ############################################################################
+#
+# Pacing math (reuses 07_sustained_throughput's model):
+#   The load is bounded by buyer COUNT: with 2 buyers, at most 2 requests
+#   are ever in flight, so the provider never sees > 2 concurrent — safely
+#   within Pearl N_eff=2.5 (AccountConcurrency N=3, margin 0.5). Unlike 07
+#   (a light 10s-floor baseline that keeps mean_active < 1), a soak wants
+#   the provider CONTINUOUSLY busy, so the inter-request floor is short
+#   (1s): each buyer re-fires ~1s after its previous completion, keeping
+#   decode active nearly the whole window while staying at ≤ 2 concurrent.
+#     30B cycle ≈ TTFT(~0.5–2s) + decode(64 tok / ~30 tok/s ≈ 2.1s) + 1s
+#              ≈ 4–5s → ~720–900 requests/buyer over 3600s, ~1500–1800 total.
+#   duration is the real cap; requests_per_buyer is a generous ceiling.
+#
+# One model per soak run — start with the 30B (the prod model class that
+# collapsed). Run smaller classes as SEPARATE runs (copy this file, swap the
+# model). max_tokens=64 keeps decode the dominant cost so B10 measures
+# sustained decode throughput, not TTFT.
+#
+# B10 is PROVISIONAL and UNARMED (sustained_gate_armed: false): its bands
+# (PASS ≥ 0.85 / WARN ≥ 0.70 / FAIL < 0.70) were chosen before any real
+# soak. Until a lab campaign calibrates them, a would-be FAIL is reported
+# as WARN so the uncalibrated gate can never block. Arm it (set true) only
+# after recalibrating the thresholds in benchmark.go + SPEC §3.5 §4.15 from
+# the first run. See docs/notes/SPEC-NETWORK-BENCHMARK-v0.1.md §4.15.
+#
+# Cost estimate (~1500–1800 requests × 64 max_tokens): order of $1–2.
+#
+# See docs/notes/SPEC-NETWORK-BENCHMARK-v0.1.md for thresholds + invariants.
+name: thermal_soak
+description: |
+  2 concurrent buyers, streaming, max_tokens=64, 45–60 min sustained-decode
+  soak against a LAB provider. Measures streaming-TPS retention (first 5-min
+  vs last 5-min window) via B10, plus B1-B5 over the long window. Serves the
+  #584 canary redesign — produces the "safe sustained load" envelope.
+
+expected_shape: |
+  Phase B long soak (descriptive, B-invariants asserted):
+   - ~1500–1800 requests over ~60 min, ideally all 200.
+   - Single lab provider serving continuously (2 concurrent max).
+   - B10 retention ≥ 0.85 (PASS) means the provider held throughput; a
+     decaying curve (WARN/would-FAIL) is the #584 thermal-throttle signature
+     and is the SIGNAL this test exists to capture, not a harness defect.
+   - Correlate the B10 decay with the provider-side thermal log captured by
+     test/e2e/thermal-soak/thermal-collector.sh (join by timestamp).
+
+target:
+  gateway_url: ${LAB_GATEWAY_URL}
+  coordinator_url: ${LAB_COORDINATOR_URL}
+  buyer_token: ${BUYER_TOKEN}
+  # DB reconcile (I1) is optional for a soak — B10/B1-B5 are buyer-side and
+  # provider-header-side. Set these to your lab DB paths to also run I1:
+  # coordinator_db_path: /path/to/lab/coordinator.db
+  # gateway_db_path: /path/to/lab/gateway.db
+
+buyers:
+  count: 2
+  stream: true
+  pattern: interval
+  interval_ms: 1000
+  requests_per_buyer: 1000
+
+duration: 3600s
+request_timeout: 30s
+silent_hang_threshold: 15s
+
+benchmark:
+  enabled: true
+  invariants: [B1, B2, B3, B4, B5, B10]
+  # sustained_gate_armed: false is the DEFAULT and is left unset on purpose.
+  # Do NOT set it true until the B10 thresholds are lab-calibrated (#584).
+
+prompts:
+  - model: mlx-community/Qwen3-Coder-30B-A3B-Instruct-4bit
+    user: "Write a single concise paragraph about a yellow finch."
+    max_tokens: 64

--- a/test/network-harness/scenarios/15_thermal_soak.yaml
+++ b/test/network-harness/scenarios/15_thermal_soak.yaml
@@ -56,7 +56,8 @@ description: |
   2 concurrent buyers, streaming, max_tokens=64, 45–60 min sustained-decode
   soak against a LAB provider. Measures streaming-TPS retention (first 5-min
   vs last 5-min window) via B10, plus B1-B5 over the long window. Serves the
-  #584 canary redesign — produces the "safe sustained load" envelope.
+  #584 canary redesign — one stress point (N=2, 1s floor); the full "safe
+  sustained load" envelope needs a D3 sweep across concurrency/duty-cycle cells.
 
 expected_shape: |
   Phase B long soak (descriptive, B-invariants asserted):

--- a/test/network-harness/scenarios/15_thermal_soak.yaml
+++ b/test/network-harness/scenarios/15_thermal_soak.yaml
@@ -82,7 +82,11 @@ buyers:
   stream: true
   pattern: interval
   interval_ms: 1000
-  requests_per_buyer: 1000
+  # High ceiling on purpose: DURATION must be the terminating condition, not
+  # the request count (the load generator stops at whichever comes first). At
+  # the fastest plausible cycle (~1.2s) a buyer fires ~3000 reqs in 3600s, so
+  # 5000 guarantees the full 45-60 min window runs even on a fast provider.
+  requests_per_buyer: 5000
 
 duration: 3600s
 request_timeout: 30s


### PR DESCRIPTION
## RESEARCH_235 — P3 thermal / sustained-load soak instrument (B10)

Builds the **instrument** for a thermal/sustained-load soak that characterizes
issue #584 (2026-07-13: sustained synthetic load collapsed a healthy provider
~30 → 8.9 → 5.3 tok/s, then stale heartbeats → WS EOF → removed from pool — a
thermal/sustained-throughput degradation no test in the repo captured). Same
instrument-now / campaign-later split as RESEARCH_234's cold cell.

**The soak run is PARKED** — it needs a dedicated lab Mac (running it against
prod reproduces the #584 outage). This PR ships only the instrument so it is
ready the moment hardware exists.

### What's in this PR

1. **Benchmark invariant `B10` "sustained streaming-TPS retention"**
   (`test/network-harness/internal/benchmark/benchmark.go`). Windows the
   per-request *streaming* decode-TPS distribution (tokens / (last_byte −
   (start + ttft)) — same basis as B2, **not** the structurally-unreliable
   non-streaming `sustained_tps` field) by wall-clock start into a first-5min
   and last-5min window; `retention = final_p50 / first_p50`. Bands **PASS ≥
   0.85 / WARN ≥ 0.70 / FAIL < 0.70**, SKIP if either window has < 8 samples.
   Emits `first_window_tps_p50`, `final_window_tps_p50`, `retention`, and
   per-window sample counts.
   - **Invariant ID is B10, not B8.** B8/B9 are claimed by RESEARCH_236 (open
     PR #696). main has through B7; B10 skips that range so the two never
     collide regardless of merge order.
   - **Thresholds are PROVISIONAL and the gate is UNARMED.** A new scenario flag
     `sustained_gate_armed` (default false) downgrades a would-be FAIL to WARN
     so the uncalibrated gate can never block a run. Arm it only after the first
     lab soak recalibrates the thresholds (mirrors RESEARCH_236's
     `cache_gate_armed`).
2. **Scenario `scenarios/15_thermal_soak.yaml`** — 45–60 min (3600s), 2 buyers,
   streaming, `max_tokens=64`, 30B model, 1s inter-request floor (continuous
   busy, ≤ 2 concurrent within Pearl N_eff=2.5). Targets `${LAB_GATEWAY_URL}` /
   `${LAB_COORDINATOR_URL}`, **unset by default so a bare run fails validation
   rather than hitting `streamvc.live`** (LAB PROVIDER ONLY). Invariants
   B1-B5,B10. B10 added to the scenario invariant allow-list + a
   `SustainedGateArmed` field on the scenario `Benchmark` struct.
3. **Provider-side thermal capture** `test/e2e/thermal-soak/` (sibling to
   `coldwarm-ttft/`): `thermal-collector.sh` (samples `pmset -g therm` +
   `sudo powermetrics --samplers smc,cpu_power,gpu_power` → timestamped NDJSON),
   `join-thermal.py` (correlates `per_request.jsonl` streaming-TPS to the
   thermal log by timestamp, stdlib-only), and a README with the LAB-only run
   recipe.
4. SPEC `docs/notes/SPEC-NETWORK-BENCHMARK-v0.1.md` §3.5 row + §4.15 scenario
   section.

### Parked for the lab-Mac campaign (Deliverable 3)

The actual 45–60 min soak run — the real deliverable — needs a lab Mac. It
produces the "safe sustained-load envelope" the #584 canary redesign consumes,
recalibrates B10's thresholds (then arms the gate), and answers the #463 (waived
G3 48 h soak) recommendation. Run recipe + open questions in
`test/e2e/thermal-soak/README.md`.

### Prod-safety (LAB-ONLY, enforced in code)

Any scenario declaring `B10` must have `gateway_url` and `coordinator_url`
resolve to a **loopback / private / link-local IP or `localhost`** (positive
allowlist `LabHostAllowed`) — every public host is rejected, including
trailing-dot and Unicode-separator variants; the check runs even when
`benchmark.enabled=false`; and a `CheckRedirect` guard blocks a lab gateway from
redirecting the soak to a non-lab host. A soak physically cannot reach
`streamvc.live`.

### Verification

- `go build ./...`, `go test ./...`, `go vet ./...` — GREEN in
  `test/network-harness`. New tests: B10 PASS/WARN/FAIL-armed/FAIL-downgrade-
  unarmed/SKIP-too-few/SKIP-provider-stops-before-end/SKIP-short-run/window-math;
  lab-only host allow/reject matrix (loopback/localhost/private/ipv6 ok; prod
  apex/subdomain/uppercase/trailing-dot/full-width/ideographic-dot/arbitrary-
  public rejected; disabled-benchmark still guarded; non-B10 still allows prod).
- `harness run scenarios/15_thermal_soak.yaml --dry-run` validates on a lab URL;
  fails safely without `LAB_*` env and on any prod host.
- **Three-lane codex audit (code / security / architect), 3 rounds** — R3 is
  **0 CRITICAL / 0 HIGH / 0 MEDIUM on all three lanes** (code APPROVE, security
  APPROVE, architect WATCH). Prompts + results under `audits/2026-07-22/`.
  Carried LOWs (documented, non-blocking): (1) scoped IPv6 link-local
  `[fe80::1%25en0]` is rejected by `net.ParseIP` — a legitimate-lab
  false-negative that **fails safe** (never allows prod); (2) `join-thermal.py`
  loads its inputs fully into memory (a local operator post-processing tool);
  (3) the redirect barrier has no dedicated regression test yet (its logic was
  read and verified correct by all three lanes).
- Does not touch scenario 07/08 or the money path.

Closes nothing (instrument only); advances #584.

<!-- SPEC-GOVERNANCE-DECLARATION-BEGIN
{
  "schema_version": "spec-pr-governance-v1",
  "behavior_change": "yes",
  "contract_change": "none",
  "issue": "https://github.com/Augustas11/macprovider/issues/584",
  "specs": ["SPEC-031"],
  "requirements": ["SPEC-023-R001"],
  "authority_domains": ["canary-sanction-lifecycle"],
  "arbitration": ["UNKNOWN"],
  "tests": ["go test ./... (test/network-harness)", "go vet ./... (test/network-harness)", "harness run scenarios/15_thermal_soak.yaml --dry-run"],
  "journeys": ["not-required"]
}
SPEC-GOVERNANCE-DECLARATION-END -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)
