### PR TITLE
fix(#608): bind signed Tier-2 bytes as a release-ledger feed member

### DIFF
--- a/ops/runbooks/catalog-release-provider-upgrade.md
+++ b/ops/runbooks/catalog-release-provider-upgrade.md
@@ -39,13 +39,36 @@ the derived binding above) can now optionally be bound as a third
 (`scripts/catalog-release.py generate` / `verify` / `verify-directory`). This
 is historical-safe: every release-ledger row published before this change
 keeps its original 2-feed shape and `verify` still passes with no canonical
-`phase3-binary/catalog/autotune/tier2-catalog.json` present. Once a signed
-Tier-2 catalog exists at that path, `generate` requires it (fails closed if
-missing) and `verify` runs `check-tier2-binding` against it before trusting
-it as a feed member. This is still repo/ledger bookkeeping only: it does not
-flip `tier2.require_hash_verified`, does not remove the physical
+`phase3-binary/catalog/autotune/tier2-catalog.json` present. Whenever a Tier-2
+catalog IS staged at that path, it is never a silent bystander: `generate`,
+`verify`, and `verify-directory` all run `validate_tier2_catalog` (structural
+shape) **and** `verify_tier2_signature` (Ed25519 authentication against
+`tier2.catalog_public_key` in `phase4-coordinator/dist/coordinator.yaml`, via
+`sign-catalog.go verify` — the same trusted key and canonicalization
+`deploy-pearl-vps.sh` already pins before upload) before trusting it enough
+to bind `signer_key_id` into the manifest/ledger, then run
+`check-tier2-binding` before trusting it as a feed member. A catalog that is
+structurally well-formed but not authentically signed by the trusted key is
+rejected the same way as a malformed one.
+
+`generate` hard-requiring Tier-2 is staged behind
+`CATALOG_RELEASE_REQUIRE_TIER2=1` rather than unconditional: the
+compatibility-set builder (`scripts/compatibility-set-manifest.py`),
+provider packaging (`phase3-binary/dist/package.sh`), and the Pearl updater
+do not yet accept a 3-feed manifest, and no canonical
+`tier2-catalog.json` is staged in the repo today. Making Tier-2 mandatory on
+every `generate` run unconditionally would have broken the existing 2-feed
+release train the moment this change merged, before any of those downstream
+consumers were updated. Set `CATALOG_RELEASE_REQUIRE_TIER2=1` once ops are
+ready to require Tier-2 for every new release; until then, `generate` simply
+omits the Tier-2 feed when no catalog is staged, exactly as it always has.
+This remains repo/ledger bookkeeping only: it does not flip
+`tier2.require_hash_verified`, does not remove the physical
 `/opt/macprovider/tier2-catalog.json` dual path, and does not authorize a
-Pearl publish by itself.
+Pearl publish by itself. **Do not run `generate` to produce a real 3-feed
+release for production packaging/deploy** until the compatibility-set
+builder, packaging, and Pearl updater are updated to carry and validate the
+third feed (tracked separately; not part of this step).
 
 Autotune admission identity and the Tier-2 attestation catalog remain separate
 signed files during migration (`exc-catalog-compatibility-bridges` stays
@@ -88,10 +111,14 @@ Until then the interim rule is **derived-only mutate**:
    check does **not** add a Tier-2 fallback.
 
 Follow-up on #608 (still blocked for exception clearance): the repo-side
-ledger / compatibility-set feed membership for signed Tier-2 bytes described
-above is landed; remaining work is to remove the physical
-`/opt/macprovider/tier2-catalog.json` dual path and collect Pearl journey
-proof that no `model_hash_uncatalogued` events fire for active release rows.
+`catalog-release.py` **ledger** feed membership (`release.json` /
+`release-ledger.json`) for signed, authenticated Tier-2 bytes described
+above is landed. **Compatibility-set membership is not landed** —
+`scripts/compatibility-set-manifest.py`, `phase3-binary/dist/package.sh`,
+and `ops/pearl-updater/macprovider-pearl-update` all still assume exactly
+two feeds and reject a 3-feed manifest; that migration, physical dual-path
+removal, and Pearl journey proof that no `model_hash_uncatalogued` events
+fire for active release rows all remain open follow-up work.
 
 The same signed network-release manifest also binds:
 

--- a/ops/runbooks/catalog-release-provider-upgrade.md
+++ b/ops/runbooks/catalog-release-provider-upgrade.md
@@ -27,10 +27,25 @@ catalog member contains:
 ### Tier-2 identity binding (#608 Partial → finish slice: derived-only mutate)
 
 `tier2-identity-binding.json` is a **repository-local derived projection**
-written by `catalog-release.py generate`. It is **not** yet a member of the
+written by `catalog-release.py generate`. It is **not** a member of the
 signed autotune release envelope (`release.json` / ledger / Pearl immutable
 release directory / provider package). Operators must not treat it as a
 substitute for the signed Tier-2 file.
+
+A **signed** `tier2-catalog.json` (the `sign-catalog.go`-produced file, not
+the derived binding above) can now optionally be bound as a third
+`release.json` / `release-ledger.json` feed member alongside
+`autotune-candidates.json` and `demand-rank.json`
+(`scripts/catalog-release.py generate` / `verify` / `verify-directory`). This
+is historical-safe: every release-ledger row published before this change
+keeps its original 2-feed shape and `verify` still passes with no canonical
+`phase3-binary/catalog/autotune/tier2-catalog.json` present. Once a signed
+Tier-2 catalog exists at that path, `generate` requires it (fails closed if
+missing) and `verify` runs `check-tier2-binding` against it before trusting
+it as a feed member. This is still repo/ledger bookkeeping only: it does not
+flip `tier2.require_hash_verified`, does not remove the physical
+`/opt/macprovider/tier2-catalog.json` dual path, and does not authorize a
+Pearl publish by itself.
 
 Autotune admission identity and the Tier-2 attestation catalog remain separate
 signed files during migration (`exc-catalog-compatibility-bridges` stays
@@ -72,11 +87,11 @@ Until then the interim rule is **derived-only mutate**:
 6. Admission identity remains autotune-only (Entry 170 / #609). This binding
    check does **not** add a Tier-2 fallback.
 
-Follow-up on #608 (still blocked for exception clearance): fold signed Tier-2
-bytes into the release ledger / compatibility-set envelope, remove the
-physical `/opt/macprovider/tier2-catalog.json` dual path, and collect Pearl
-journey proof that no `model_hash_uncatalogued` events fire for active
-release rows.
+Follow-up on #608 (still blocked for exception clearance): the repo-side
+ledger / compatibility-set feed membership for signed Tier-2 bytes described
+above is landed; remaining work is to remove the physical
+`/opt/macprovider/tier2-catalog.json` dual path and collect Pearl journey
+proof that no `model_hash_uncatalogued` events fire for active release rows.
 
 The same signed network-release manifest also binds:
 

--- a/scripts/catalog-release.py
+++ b/scripts/catalog-release.py
@@ -30,6 +30,10 @@ MANIFEST_PATH = CATALOG_DIR / "release.json"
 LEDGER_PATH = CATALOG_DIR / "release-ledger.json"
 TIER2_BINDING_PATH = CATALOG_DIR / "tier2-identity-binding.json"
 TIER2_BINDING_SCHEMA = "macprovider.tier2-identity-binding.v1"
+TIER2_CATALOG_PATH = CATALOG_DIR / "tier2-catalog.json"
+TIER2_CATALOG_FEED_NAME = "tier2-catalog.json"
+LEGACY_LEDGER_FEEDS = frozenset({"autotune-candidates.json", "demand-rank.json"})
+TIER2_BOUND_LEDGER_FEEDS = LEGACY_LEDGER_FEEDS | {TIER2_CATALOG_FEED_NAME}
 HEX64 = re.compile(r"^[0-9a-f]{64}$")
 HEX40 = re.compile(r"^[0-9a-f]{40}$")
 TIER2_HASH_SCOPES = {"primary_weight_file", "artifact_manifest", "coordinator_endorsed_incremental"}
@@ -516,6 +520,8 @@ def manifest(
     demand_obj: dict,
     sidecar_directory: pathlib.Path = STATIC_DIR,
     signer_key_id: str | None = None,
+    tier2: bytes | None = None,
+    tier2_obj: dict | None = None,
 ) -> bytes:
     signer_ids = {}
     if signer_key_id is not None:
@@ -528,21 +534,32 @@ def manifest(
             sidecar_path = sidecar_directory / f"{name}.sig"
             if sidecar_path.exists():
                 signer_ids[name] = parse_sidecar(sidecar_path.read_bytes(), sidecar_path.name)[0]
+    feeds = {
+        "autotune-candidates.json": {
+            "sha256": sha256(candidate), "bytes": len(candidate), "version": candidate_obj["version"],
+            "signer_key_id": signer_ids.get("autotune-candidates.json"),
+        },
+        "demand-rank.json": {
+            "sha256": sha256(demand), "bytes": len(demand), "version": demand_obj["version"],
+            "signer_key_id": signer_ids.get("demand-rank.json"),
+        },
+    }
+    if tier2 is not None:
+        if tier2_obj is None:
+            fail("manifest: tier2 bytes provided without a parsed tier2_obj")
+        # Tier-2 is versioned by its own catalog_id, not the autotune release
+        # train, so it is bound as a feed member without claiming release_id
+        # identity (#608 Partial: ledger/compatibility-set membership).
+        feeds[TIER2_CATALOG_FEED_NAME] = {
+            "sha256": sha256(tier2), "bytes": len(tier2), "version": tier2_obj["catalog_id"],
+            "signer_key_id": tier2_obj["signature"]["key_id"],
+        }
     value = {
         "schema_version": "macprovider.autotune-release.v1",
         "release_id": candidate_obj["version"],
         "generated_at": candidate_obj["generated_at"],
         "policy_version": candidate_obj["policy_version"],
-        "feeds": {
-            "autotune-candidates.json": {
-                "sha256": sha256(candidate), "bytes": len(candidate), "version": candidate_obj["version"],
-                "signer_key_id": signer_ids.get("autotune-candidates.json"),
-            },
-            "demand-rank.json": {
-                "sha256": sha256(demand), "bytes": len(demand), "version": demand_obj["version"],
-                "signer_key_id": signer_ids.get("demand-rank.json"),
-            },
-        },
+        "feeds": feeds,
     }
     return json.dumps(value, indent=2, sort_keys=True).encode("utf-8") + b"\n"
 
@@ -610,11 +627,21 @@ def validate_release_ledger(data: bytes, label: str = "release ledger") -> dict[
         if not isinstance(record["generated_at"], str) or (record["policy_version"] is not None and not isinstance(record["policy_version"], str)) or not isinstance(record["feeds"], dict):
             fail(f"{label}: invalid release entry {release_id!r}")
         parse_time(record["generated_at"], f"{label} release {release_id}")
-        expected_feeds = {"autotune-candidates.json", "demand-rank.json"}
-        exact_keys(record["feeds"], expected_feeds, expected_feeds, f"{label} release {release_id} feeds")
+        feed_names = set(record["feeds"])
+        # Historical-safe: releases published before #608 Tier-2 ledger
+        # membership keep their original 2-feed shape. Only the 3-feed shape
+        # (with tier2-catalog.json bound) is accepted for anything new.
+        if feed_names not in (LEGACY_LEDGER_FEEDS, TIER2_BOUND_LEDGER_FEEDS):
+            fail(
+                f"{label}: release {release_id!r} feeds must be exactly "
+                f"{sorted(LEGACY_LEDGER_FEEDS)} (historical) or "
+                f"{sorted(TIER2_BOUND_LEDGER_FEEDS)} (Tier-2 bound)"
+            )
         for feed_name, feed in record["feeds"].items():
             validate_ledger_feed(feed, f"{label} release {release_id} {feed_name}")
-            if feed["version"] != release_id:
+            # tier2-catalog.json is versioned by its own catalog_id, not the
+            # autotune release train (see manifest()).
+            if feed_name != TIER2_CATALOG_FEED_NAME and feed["version"] != release_id:
                 fail(f"{label}: feed version does not match release ID {release_id!r}")
     for release_id, tombstone in value["tombstones"].items():
         if not isinstance(release_id, str) or not release_id or not isinstance(tombstone, dict):
@@ -831,6 +858,82 @@ def validate_tier2_identity_binding(data: bytes, candidate: bytes, candidate_obj
     return value
 
 
+def validate_tier2_catalog(data: bytes) -> dict:
+    """Structural validation of a signed Tier-2 catalog (scripts/sign-catalog.go shape).
+
+    This locks the JSON shape (fields, hash format, signature envelope) so
+    `generate`/`verify` can safely record `signer_key_id` + digest as a
+    release-ledger feed member (#608 Partial: ledger/compatibility-set
+    membership). It does not re-verify the Ed25519 signature bytes — that
+    requires reproducing Go's exact struct-field encoding order and remains
+    `sign-catalog.go verify` / the coordinator's tier2 loader's job.
+    Cross-catalog identity agreement is enforced separately by
+    `check_tier2_binding`.
+    """
+    value = strict_json(data, "tier2-catalog")
+    top = {"catalog_id", "issued_at", "expires_at", "models", "signature", "version"}
+    exact_keys(value, top, top, "tier2-catalog")
+    if not isinstance(value["catalog_id"], str) or not value["catalog_id"].strip():
+        fail("tier2-catalog: catalog_id required")
+    parse_time(value["issued_at"], "tier2-catalog issued_at")
+    parse_time(value["expires_at"], "tier2-catalog expires_at")
+    issued = datetime.fromisoformat(value["issued_at"].replace("Z", "+00:00"))
+    expires = datetime.fromisoformat(value["expires_at"].replace("Z", "+00:00"))
+    if issued >= expires:
+        fail("tier2-catalog: issued_at must be before expires_at")
+    if value["version"] != 1:
+        fail("tier2-catalog: version must be 1")
+    models = value["models"]
+    if not isinstance(models, list) or not models:
+        fail("tier2-catalog: models required")
+    seen_models: set[str] = set()
+    model_fields = {"artifact_kind", "hash_scope", "model_id", "min_ram_gb", "notes", "sha256", "source"}
+    model_required = {"artifact_kind", "hash_scope", "model_id", "sha256", "source"}
+    for idx, entry in enumerate(models):
+        if not isinstance(entry, dict):
+            fail(f"tier2-catalog: models[{idx}] must be an object")
+        exact_keys(entry, model_fields, model_required, f"tier2-catalog models[{idx}]")
+        if entry["artifact_kind"] != "mlx_weight_file":
+            fail(f"tier2-catalog models[{idx}]: unsupported artifact_kind")
+        if entry["hash_scope"] not in TIER2_HASH_SCOPES:
+            fail(f"tier2-catalog models[{idx}]: unsupported hash_scope")
+        model_id = entry["model_id"]
+        if not isinstance(model_id, str) or not model_id.strip():
+            fail(f"tier2-catalog models[{idx}]: model_id required")
+        normalized = model_id.lower().strip()
+        if normalized in seen_models:
+            fail(f"tier2-catalog models[{idx}]: duplicate model_id {model_id!r}")
+        seen_models.add(normalized)
+        if not isinstance(entry["sha256"], str) or not HEX64.fullmatch(entry["sha256"]):
+            fail(f"tier2-catalog models[{idx}]: sha256 must be lowercase 64-hex")
+        if not isinstance(entry["source"], str) or not entry["source"].strip():
+            fail(f"tier2-catalog models[{idx}]: source required")
+        min_ram = entry.get("min_ram_gb")
+        if min_ram is not None and (not isinstance(min_ram, int) or isinstance(min_ram, bool) or min_ram < 1):
+            fail(f"tier2-catalog models[{idx}]: min_ram_gb must be a positive integer")
+        notes = entry.get("notes")
+        if notes is not None and not isinstance(notes, str):
+            fail(f"tier2-catalog models[{idx}]: notes must be a string")
+    signature = value["signature"]
+    if not isinstance(signature, dict):
+        fail("tier2-catalog: signature must be an object")
+    exact_keys(signature, {"alg", "key_id", "sig"}, {"alg", "key_id", "sig"}, "tier2-catalog signature")
+    if signature["alg"] != "Ed25519":
+        fail("tier2-catalog: signature.alg must be Ed25519")
+    if not isinstance(signature["key_id"], str) or not signature["key_id"].strip():
+        fail("tier2-catalog: signature.key_id required")
+    if not isinstance(signature["sig"], str) or not signature["sig"].strip():
+        fail("tier2-catalog: signature.sig required")
+    padded = signature["sig"] + "=" * (-len(signature["sig"]) % 4)
+    try:
+        raw_signature = base64.urlsafe_b64decode(padded)
+    except (ValueError, TypeError) as exc:
+        fail(f"tier2-catalog: signature.sig is not valid base64url: {exc}")
+    if len(raw_signature) != 64:
+        fail("tier2-catalog: signature.sig must be a 64-byte Ed25519 signature")
+    return value
+
+
 def load_tier2_models(tier2_data: bytes) -> dict[str, str]:
     value = strict_json(tier2_data, "tier2-catalog")
     models = value.get("models")
@@ -992,6 +1095,28 @@ def derive_tier2_unsigned_body(
     )
 
 
+def require_tier2_catalog_for_generate() -> tuple[bytes, dict]:
+    """New releases must bind signed Tier-2 bytes as a release feed member.
+
+    Historical release-ledger rows generated before this requirement keep
+    their original 2-feed shape (`validate_release_ledger` accepts both
+    shapes); only `generate` going forward requires Tier-2 (#608 Partial:
+    ledger/compatibility-set membership).
+    """
+    if not TIER2_CATALOG_PATH.exists():
+        fail(
+            "generate: missing tier2-catalog.json. Every new catalog release "
+            "must bind a signed Tier-2 catalog as a release-ledger feed member "
+            "(#608 Partial: ledger/compatibility-set membership). Historical "
+            "2-feed release-ledger rows remain valid; only new `generate` runs "
+            "require Tier-2. Sign a Tier-2 catalog with scripts/sign-catalog.go "
+            f"and place it at {TIER2_CATALOG_PATH}."
+        )
+    tier2 = TIER2_CATALOG_PATH.read_bytes()
+    tier2_obj = validate_tier2_catalog(tier2)
+    return tier2, tier2_obj
+
+
 def updated_release_ledger(manifest_bytes: bytes) -> bytes:
     current = validate_release_ledger(LEDGER_PATH.read_bytes()) if LEDGER_PATH.exists() else {"releases": {}, "tombstones": {}}
     require_ledger_evolution(base_release_ledger(), current)
@@ -1020,9 +1145,14 @@ def generate(signer_key_id: str | None = None) -> None:
     demand = canonical_bytes(demand_obj)
     if signer_key_id is not None and signer_key_id not in keyring():
         fail(f"cannot generate for unknown or retired signer key ID: {signer_key_id}")
+    tier2, tier2_obj = require_tier2_catalog_for_generate()
+    check_tier2_binding(candidate, tier2)
     # Compute every derived artifact before mutating on-disk release state so a
     # binding/derivation failure cannot leave a partially updated ledger.
-    manifest_bytes = manifest(candidate, demand, candidate_obj, demand_obj, signer_key_id=signer_key_id)
+    manifest_bytes = manifest(
+        candidate, demand, candidate_obj, demand_obj,
+        signer_key_id=signer_key_id, tier2=tier2, tier2_obj=tier2_obj,
+    )
     binding_bytes = derive_tier2_identity_binding(candidate, candidate_obj)
     swift_text = generated_swift(candidate, demand, signer_key_id)
     next_ledger = updated_release_ledger(manifest_bytes)
@@ -1041,7 +1171,7 @@ def generate(signer_key_id: str | None = None) -> None:
     print(
         f"generated catalog release {candidate_obj['version']} "
         f"candidate={sha256(candidate)} demand={sha256(demand)} "
-        f"tier2_binding={sha256(binding_bytes)}"
+        f"tier2_binding={sha256(binding_bytes)} tier2_catalog={sha256(tier2)}"
     )
 
 
@@ -1104,7 +1234,18 @@ def verify() -> None:
             fail(f"generated drift: {path}")
     if SWIFT_GENERATED.read_text() != generated_swift(candidate, demand):
         fail(f"generated drift: {SWIFT_GENERATED}")
-    expected_manifest = manifest(candidate, demand, candidate_obj, demand_obj)
+    # #608 Partial: historical-safe. The canonical release currently on disk
+    # may predate Tier-2 ledger membership (no TIER2_CATALOG_PATH); only
+    # `generate` requires Tier-2 going forward. When a canonical Tier-2
+    # catalog is present, fail closed on any autotune/tier2 identity conflict
+    # before trusting it as a feed member.
+    tier2 = None
+    tier2_obj = None
+    if TIER2_CATALOG_PATH.exists():
+        tier2 = TIER2_CATALOG_PATH.read_bytes()
+        tier2_obj = validate_tier2_catalog(tier2)
+        check_tier2_binding(candidate, tier2)
+    expected_manifest = manifest(candidate, demand, candidate_obj, demand_obj, tier2=tier2, tier2_obj=tier2_obj)
     if MANIFEST_PATH.read_bytes() != expected_manifest:
         fail(f"generated drift: {MANIFEST_PATH}")
     ledger = validate_release_ledger(LEDGER_PATH.read_bytes())
@@ -1129,10 +1270,11 @@ def verify() -> None:
         if public_key is None:
             fail(f"{sidecar_path.name}: unknown or retired key_id {key_id}")
         verify_ed25519(public_key, signature, body, sidecar_path.name)
+    tier2_note = f"tier2_catalog={sha256(tier2)}" if tier2 is not None else "tier2_catalog=absent(historical)"
     print(
         f"verified catalog release {candidate_obj['version']} "
         f"candidate={sha256(candidate)} demand={sha256(demand)} "
-        f"tier2_binding={sha256(TIER2_BINDING_PATH.read_bytes())}"
+        f"tier2_binding={sha256(TIER2_BINDING_PATH.read_bytes())} {tier2_note}"
     )
 
 
@@ -1146,7 +1288,18 @@ def verify_directory(directory: pathlib.Path) -> None:
     validate_pair(candidate_obj, demand_obj)
     if candidate != canonical_bytes(candidate_obj) or demand != canonical_bytes(demand_obj):
         fail("release directory feeds are not deterministic canonical bytes")
-    expected_manifest = manifest(candidate, demand, candidate_obj, demand_obj, directory)
+    # A staged tier2-catalog.json must be a declared release.json feed member
+    # (#608 Partial: ledger/compatibility-set membership), not a bystander
+    # file — the manifest recomputation below fails closed on drift if it
+    # is not, and check_tier2_binding fails closed on identity conflicts.
+    tier2_path = directory / "tier2-catalog.json"
+    tier2 = None
+    tier2_obj = None
+    if tier2_path.exists():
+        tier2 = tier2_path.read_bytes()
+        tier2_obj = validate_tier2_catalog(tier2)
+        check_tier2_binding(candidate, tier2)
+    expected_manifest = manifest(candidate, demand, candidate_obj, demand_obj, directory, tier2=tier2, tier2_obj=tier2_obj)
     if (directory / "release.json").read_bytes() != expected_manifest:
         fail("release directory manifest does not bind the feed bytes")
     keys = keyring(directory / "trusted-keys.json")
@@ -1161,11 +1314,8 @@ def verify_directory(directory: pathlib.Path) -> None:
     if binding_path.exists():
         validate_tier2_identity_binding(binding_path.read_bytes(), candidate, candidate_obj)
         print(f"verified repo-local tier2 identity binding for {candidate_obj['version']}")
-    tier2_path = directory / "tier2-catalog.json"
-    if tier2_path.exists():
-        # Digest overlap check only — this does not replace sign-catalog.go verify.
-        check_tier2_binding(candidate, tier2_path.read_bytes())
-        print(f"verified tier2 digest binding against release {candidate_obj['version']}")
+    if tier2 is not None:
+        print(f"verified tier2 catalog {tier2_obj['catalog_id']} feed membership against release {candidate_obj['version']}")
     print(f"verified release directory {candidate_obj['version']} candidate={sha256(candidate)} demand={sha256(demand)}")
 
 

--- a/scripts/catalog-release.py
+++ b/scripts/catalog-release.py
@@ -16,7 +16,7 @@ import stat
 import subprocess
 import sys
 import tempfile
-from datetime import datetime
+from datetime import datetime, timezone
 
 
 ROOT = pathlib.Path(__file__).resolve().parents[1]
@@ -37,6 +37,7 @@ TIER2_BOUND_LEDGER_FEEDS = LEGACY_LEDGER_FEEDS | {TIER2_CATALOG_FEED_NAME}
 HEX64 = re.compile(r"^[0-9a-f]{64}$")
 HEX40 = re.compile(r"^[0-9a-f]{40}$")
 TIER2_HASH_SCOPES = {"primary_weight_file", "artifact_manifest", "coordinator_endorsed_incremental"}
+TIER2_SIG_PATTERN = re.compile(r"^[A-Za-z0-9_-]{86}$")
 MODEL_KEY = re.compile(r"^[a-z0-9][a-z0-9._/-]{0,127}$")
 MODEL_ID = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]*/[A-Za-z0-9][A-Za-z0-9._-]*$")
 RFC3339 = re.compile(r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:\d{2})$")
@@ -44,6 +45,11 @@ INT64_MIN = -(2**63)
 INT64_MAX = 2**63 - 1
 OPENSSL_PROBE_TIMEOUT_SECONDS = 5
 OPENSSL_VERIFY_TIMEOUT_SECONDS = 15
+SIGN_CATALOG_GO_PATH = ROOT / "scripts" / "sign-catalog.go"
+COORDINATOR_YAML_PATH = ROOT / "phase4-coordinator" / "dist" / "coordinator.yaml"
+TIER2_PUBLIC_KEY_ENV = "CATALOG_RELEASE_TIER2_PUBLIC_KEY"
+TIER2_SIGN_VERIFY_TIMEOUT_SECONDS = 60
+REQUIRE_TIER2_FOR_GENERATE_ENV = "CATALOG_RELEASE_REQUIRE_TIER2"
 
 
 class CatalogError(RuntimeError):
@@ -864,11 +870,11 @@ def validate_tier2_catalog(data: bytes) -> dict:
     This locks the JSON shape (fields, hash format, signature envelope) so
     `generate`/`verify` can safely record `signer_key_id` + digest as a
     release-ledger feed member (#608 Partial: ledger/compatibility-set
-    membership). It does not re-verify the Ed25519 signature bytes — that
-    requires reproducing Go's exact struct-field encoding order and remains
-    `sign-catalog.go verify` / the coordinator's tier2 loader's job.
-    Cross-catalog identity agreement is enforced separately by
-    `check_tier2_binding`.
+    membership). It does not authenticate the Ed25519 signature bytes —
+    every caller that trusts the catalog as "signed" (`generate`, `verify`,
+    `verify_directory`) MUST also call `verify_tier2_signature` on the same
+    bytes before recording `signer_key_id` anywhere. Cross-catalog identity
+    agreement is enforced separately by `check_tier2_binding`.
     """
     value = strict_json(data, "tier2-catalog")
     top = {"catalog_id", "issued_at", "expires_at", "models", "signature", "version"}
@@ -881,7 +887,10 @@ def validate_tier2_catalog(data: bytes) -> dict:
     expires = datetime.fromisoformat(value["expires_at"].replace("Z", "+00:00"))
     if issued >= expires:
         fail("tier2-catalog: issued_at must be before expires_at")
-    if value["version"] != 1:
+    if datetime.now(timezone.utc) >= expires:
+        fail("tier2-catalog: expires_at must be in the future (catalog has expired)")
+    version = value["version"]
+    if not isinstance(version, int) or isinstance(version, bool) or version != 1:
         fail("tier2-catalog: version must be 1")
     models = value["models"]
     if not isinstance(models, list) or not models:
@@ -895,7 +904,7 @@ def validate_tier2_catalog(data: bytes) -> dict:
         exact_keys(entry, model_fields, model_required, f"tier2-catalog models[{idx}]")
         if entry["artifact_kind"] != "mlx_weight_file":
             fail(f"tier2-catalog models[{idx}]: unsupported artifact_kind")
-        if entry["hash_scope"] not in TIER2_HASH_SCOPES:
+        if not isinstance(entry["hash_scope"], str) or entry["hash_scope"] not in TIER2_HASH_SCOPES:
             fail(f"tier2-catalog models[{idx}]: unsupported hash_scope")
         model_id = entry["model_id"]
         if not isinstance(model_id, str) or not model_id.strip():
@@ -924,14 +933,110 @@ def validate_tier2_catalog(data: bytes) -> dict:
         fail("tier2-catalog: signature.key_id required")
     if not isinstance(signature["sig"], str) or not signature["sig"].strip():
         fail("tier2-catalog: signature.sig required")
-    padded = signature["sig"] + "=" * (-len(signature["sig"]) % 4)
-    try:
-        raw_signature = base64.urlsafe_b64decode(padded)
-    except (ValueError, TypeError) as exc:
-        fail(f"tier2-catalog: signature.sig is not valid base64url: {exc}")
+    if not TIER2_SIG_PATTERN.fullmatch(signature["sig"]):
+        fail(
+            "tier2-catalog: signature.sig must be exactly 86 unpadded base64url "
+            "characters ([A-Za-z0-9_-]), matching Go's ed25519+RawURLEncoding output"
+        )
+    raw_signature = base64.urlsafe_b64decode(signature["sig"] + "==")
     if len(raw_signature) != 64:
         fail("tier2-catalog: signature.sig must be a 64-byte Ed25519 signature")
     return value
+
+
+def _yaml_block_value(text: str, block: str, key: str) -> str | None:
+    """Read `block.key` from a simple flat YAML mapping.
+
+    Mirrors `yaml_block_value` in phase4-coordinator/dist/deploy-pearl-vps.sh
+    so both tools agree on the same coordinator.yaml without adding a PyYAML
+    dependency to this script.
+    """
+    block_start = re.compile(r"^[ \t]*" + re.escape(block) + r":[ \t]*$")
+    top_level = re.compile(r"^[^\s#][^:]*:")
+    key_line = re.compile(r"^[ \t]*" + re.escape(key) + r":[ \t]*(.*)$")
+    in_block = False
+    for raw_line in text.splitlines():
+        line = re.sub(r"[ \t]+#.*$", "", raw_line)
+        if not in_block:
+            if block_start.match(line):
+                in_block = True
+            continue
+        if top_level.match(line):
+            break
+        match = key_line.match(line)
+        if match:
+            return match.group(1).strip().strip("\"'")
+    return None
+
+
+def load_tier2_trusted_public_key() -> str:
+    """Resolve the trusted Tier-2 Ed25519 public key used to authenticate a
+    signed `tier2-catalog.json` before it can be trusted as a release feed
+    member.
+
+    Reads `tier2.catalog_public_key` from the same committed
+    `phase4-coordinator/dist/coordinator.yaml` that `deploy-pearl-vps.sh`
+    pins before upload, so `catalog-release.py` and the deploy pipeline
+    agree on one trusted key. `CATALOG_RELEASE_TIER2_PUBLIC_KEY` overrides it
+    (used by tests to authenticate against an ephemeral test keypair without
+    mutating the committed coordinator config).
+    """
+    override = os.environ.get(TIER2_PUBLIC_KEY_ENV)
+    if override is not None:
+        candidate = override.strip()
+        source = f"{TIER2_PUBLIC_KEY_ENV} environment override"
+    else:
+        if not COORDINATOR_YAML_PATH.exists():
+            fail(f"tier2-catalog: cannot locate trusted Tier-2 public key; missing {COORDINATOR_YAML_PATH}")
+        candidate = (_yaml_block_value(COORDINATOR_YAML_PATH.read_text(), "tier2", "catalog_public_key") or "").strip()
+        source = str(COORDINATOR_YAML_PATH)
+    if not candidate:
+        fail(f"tier2-catalog: tier2.catalog_public_key is empty in {source}; cannot authenticate signed Tier-2 catalogs")
+    padded = candidate + "=" * (-len(candidate) % 4)
+    try:
+        decoded = base64.urlsafe_b64decode(padded)
+    except (ValueError, TypeError) as exc:
+        fail(f"tier2-catalog: trusted public key in {source} is not valid base64url: {exc}")
+    if len(decoded) != 32:
+        fail(f"tier2-catalog: trusted public key in {source} must be a 32-byte Ed25519 key")
+    return candidate
+
+
+def verify_tier2_signature(raw: bytes) -> None:
+    """Authenticate a Tier-2 catalog's Ed25519 signature before any caller
+    may trust it as "signed" (#608 Partial: ledger/compatibility-set
+    membership).
+
+    Delegates to `sign-catalog.go verify`, the same canonicalization and
+    verification `deploy-pearl-vps.sh` already runs before upload, instead
+    of reimplementing Go's exact struct-field JSON encoding in Python.
+    `validate_tier2_catalog` alone only locks the JSON shape; it does not
+    prove authenticity.
+    """
+    go_bin = shutil.which("go")
+    if go_bin is None:
+        fail("tier2-catalog: go is required to authenticate the signed catalog's Ed25519 signature")
+    public_key = load_tier2_trusted_public_key()
+    with tempfile.TemporaryDirectory(prefix="macprovider-tier2-verify-") as tmp:
+        tmpdir = pathlib.Path(tmp)
+        catalog_path = tmpdir / "tier2-catalog.json"
+        pubkey_path = tmpdir / "tier2-catalog.pub"
+        catalog_path.write_bytes(raw)
+        pubkey_path.write_text(public_key + "\n")
+        try:
+            result = subprocess.run(
+                [go_bin, "run", str(SIGN_CATALOG_GO_PATH), "verify", "-public-key", str(pubkey_path), str(catalog_path)],
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+                timeout=TIER2_SIGN_VERIFY_TIMEOUT_SECONDS,
+                cwd=str(ROOT),
+            )
+        except subprocess.TimeoutExpired:
+            fail("tier2-catalog: signature verification timed out")
+    if result.returncode != 0:
+        detail = (result.stderr.strip() or result.stdout.strip() or "unknown error")
+        fail(f"tier2-catalog: signature verification failed: {detail}")
 
 
 def load_tier2_models(tier2_data: bytes) -> dict[str, str]:
@@ -1095,25 +1200,39 @@ def derive_tier2_unsigned_body(
     )
 
 
-def require_tier2_catalog_for_generate() -> tuple[bytes, dict]:
-    """New releases must bind signed Tier-2 bytes as a release feed member.
+def require_tier2_catalog_for_generate() -> tuple[bytes | None, dict | None]:
+    """Bind signed Tier-2 bytes as a release feed member when `generate` runs.
 
-    Historical release-ledger rows generated before this requirement keep
-    their original 2-feed shape (`validate_release_ledger` accepts both
-    shapes); only `generate` going forward requires Tier-2 (#608 Partial:
-    ledger/compatibility-set membership).
+    Historical release-ledger rows generated before this capability existed
+    keep their original 2-feed shape (`validate_release_ledger` accepts both
+    shapes). Whenever a `tier2-catalog.json` is staged at the canonical path
+    it is never a silent bystander: it must pass structural validation and
+    Ed25519 authentication before `generate` binds it into the manifest and
+    ledger (#608 Partial: ledger/compatibility-set membership).
+
+    Hard-requiring Tier-2 on every `generate` run is staged behind
+    `CATALOG_RELEASE_REQUIRE_TIER2=1` rather than being unconditional: the
+    downstream compatibility-set builder, provider packaging, and Pearl
+    updater do not yet accept a 3-feed manifest (tracked separately), so an
+    unconditional requirement here would block the existing 2-feed release
+    train the moment this lands, before any real Tier-2 catalog is staged.
+    Set the env var once ops are ready to require Tier-2 for every new
+    release; until then, absence is only an error if explicitly requested.
     """
     if not TIER2_CATALOG_PATH.exists():
-        fail(
-            "generate: missing tier2-catalog.json. Every new catalog release "
-            "must bind a signed Tier-2 catalog as a release-ledger feed member "
-            "(#608 Partial: ledger/compatibility-set membership). Historical "
-            "2-feed release-ledger rows remain valid; only new `generate` runs "
-            "require Tier-2. Sign a Tier-2 catalog with scripts/sign-catalog.go "
-            f"and place it at {TIER2_CATALOG_PATH}."
-        )
+        if os.environ.get(REQUIRE_TIER2_FOR_GENERATE_ENV) == "1":
+            fail(
+                f"generate: {REQUIRE_TIER2_FOR_GENERATE_ENV}=1 but tier2-catalog.json "
+                "is missing. Every new catalog release must bind a signed Tier-2 "
+                "catalog as a release-ledger feed member (#608 Partial: "
+                "ledger/compatibility-set membership). Sign a Tier-2 catalog with "
+                f"scripts/sign-catalog.go and place it at {TIER2_CATALOG_PATH}, or "
+                f"unset {REQUIRE_TIER2_FOR_GENERATE_ENV} to keep publishing 2-feed releases."
+            )
+        return None, None
     tier2 = TIER2_CATALOG_PATH.read_bytes()
     tier2_obj = validate_tier2_catalog(tier2)
+    verify_tier2_signature(tier2)
     return tier2, tier2_obj
 
 
@@ -1146,7 +1265,8 @@ def generate(signer_key_id: str | None = None) -> None:
     if signer_key_id is not None and signer_key_id not in keyring():
         fail(f"cannot generate for unknown or retired signer key ID: {signer_key_id}")
     tier2, tier2_obj = require_tier2_catalog_for_generate()
-    check_tier2_binding(candidate, tier2)
+    if tier2 is not None:
+        check_tier2_binding(candidate, tier2)
     # Compute every derived artifact before mutating on-disk release state so a
     # binding/derivation failure cannot leave a partially updated ledger.
     manifest_bytes = manifest(
@@ -1168,10 +1288,11 @@ def generate(signer_key_id: str | None = None) -> None:
     LEDGER_PATH.write_bytes(next_ledger)
     TIER2_BINDING_PATH.write_bytes(binding_bytes)
     GO_REJECTED_RELEASES_GENERATED.write_text(rejected_go)
+    tier2_note = f"tier2_catalog={sha256(tier2)}" if tier2 is not None else "tier2_catalog=absent"
     print(
         f"generated catalog release {candidate_obj['version']} "
         f"candidate={sha256(candidate)} demand={sha256(demand)} "
-        f"tier2_binding={sha256(binding_bytes)} tier2_catalog={sha256(tier2)}"
+        f"tier2_binding={sha256(binding_bytes)} {tier2_note}"
     )
 
 
@@ -1244,6 +1365,7 @@ def verify() -> None:
     if TIER2_CATALOG_PATH.exists():
         tier2 = TIER2_CATALOG_PATH.read_bytes()
         tier2_obj = validate_tier2_catalog(tier2)
+        verify_tier2_signature(tier2)
         check_tier2_binding(candidate, tier2)
     expected_manifest = manifest(candidate, demand, candidate_obj, demand_obj, tier2=tier2, tier2_obj=tier2_obj)
     if MANIFEST_PATH.read_bytes() != expected_manifest:
@@ -1298,6 +1420,7 @@ def verify_directory(directory: pathlib.Path) -> None:
     if tier2_path.exists():
         tier2 = tier2_path.read_bytes()
         tier2_obj = validate_tier2_catalog(tier2)
+        verify_tier2_signature(tier2)
         check_tier2_binding(candidate, tier2)
     expected_manifest = manifest(candidate, demand, candidate_obj, demand_obj, directory, tier2=tier2, tier2_obj=tier2_obj)
     if (directory / "release.json").read_bytes() != expected_manifest:

--- a/scripts/catalog-release.py
+++ b/scripts/catalog-release.py
@@ -47,7 +47,7 @@ OPENSSL_PROBE_TIMEOUT_SECONDS = 5
 OPENSSL_VERIFY_TIMEOUT_SECONDS = 15
 SIGN_CATALOG_GO_PATH = ROOT / "scripts" / "sign-catalog.go"
 COORDINATOR_YAML_PATH = ROOT / "phase4-coordinator" / "dist" / "coordinator.yaml"
-TIER2_PUBLIC_KEY_ENV = "CATALOG_RELEASE_TIER2_PUBLIC_KEY"
+GO_PROBE_TIMEOUT_SECONDS = 5
 TIER2_SIGN_VERIFY_TIMEOUT_SECONDS = 60
 REQUIRE_TIER2_FOR_GENERATE_ENV = "CATALOG_RELEASE_REQUIRE_TIER2"
 
@@ -528,6 +528,7 @@ def manifest(
     signer_key_id: str | None = None,
     tier2: bytes | None = None,
     tier2_obj: dict | None = None,
+    tier2_signer_key_id: str | None = None,
 ) -> bytes:
     signer_ids = {}
     if signer_key_id is not None:
@@ -553,12 +554,18 @@ def manifest(
     if tier2 is not None:
         if tier2_obj is None:
             fail("manifest: tier2 bytes provided without a parsed tier2_obj")
+        if not tier2_signer_key_id:
+            fail("manifest: tier2 bytes provided without an authenticated tier2_signer_key_id")
         # Tier-2 is versioned by its own catalog_id, not the autotune release
         # train, so it is bound as a feed member without claiming release_id
-        # identity (#608 Partial: ledger/compatibility-set membership).
+        # identity (#608 Partial: ledger feed membership). `signer_key_id`
+        # comes from the caller's authentication result (verify_tier2_signature),
+        # NOT from tier2_obj["signature"]["key_id"]: that field is metadata
+        # alongside the signature, not part of the signed canonical body in
+        # sign-catalog.go, so it is not itself authenticated (#608 audit).
         feeds[TIER2_CATALOG_FEED_NAME] = {
             "sha256": sha256(tier2), "bytes": len(tier2), "version": tier2_obj["catalog_id"],
-            "signer_key_id": tier2_obj["signature"]["key_id"],
+            "signer_key_id": tier2_signer_key_id,
         }
     value = {
         "schema_version": "macprovider.autotune-release.v1",
@@ -869,8 +876,8 @@ def validate_tier2_catalog(data: bytes) -> dict:
 
     This locks the JSON shape (fields, hash format, signature envelope) so
     `generate`/`verify` can safely record `signer_key_id` + digest as a
-    release-ledger feed member (#608 Partial: ledger/compatibility-set
-    membership). It does not authenticate the Ed25519 signature bytes —
+    release-ledger feed member (#608 Partial: ledger feed membership).
+    It does not authenticate the Ed25519 signature bytes —
     every caller that trusts the catalog as "signed" (`generate`, `verify`,
     `verify_directory`) MUST also call `verify_tier2_signature` on the same
     bytes before recording `signer_key_id` anywhere. Cross-catalog identity
@@ -938,9 +945,7 @@ def validate_tier2_catalog(data: bytes) -> dict:
             "tier2-catalog: signature.sig must be exactly 86 unpadded base64url "
             "characters ([A-Za-z0-9_-]), matching Go's ed25519+RawURLEncoding output"
         )
-    raw_signature = base64.urlsafe_b64decode(signature["sig"] + "==")
-    if len(raw_signature) != 64:
-        fail("tier2-catalog: signature.sig must be a 64-byte Ed25519 signature")
+    canonical_urlsafe_b64_decode(signature["sig"], 64, "tier2-catalog: signature.sig")
     return value
 
 
@@ -969,6 +974,30 @@ def _yaml_block_value(text: str, block: str, key: str) -> str | None:
     return None
 
 
+def canonical_urlsafe_b64_decode(value: str, expected_len: int, label: str) -> bytes:
+    """Decode unpadded base64url and reject any input that is not itself the
+    canonical encoding of the decoded bytes.
+
+    Plain `base64.urlsafe_b64decode` tolerates trailing-character
+    malleability: the last symbol's unused low bits are ignored, so e.g. two
+    distinct 86-character strings can decode to the same 64-byte Ed25519
+    signature, or a non-canonical string can still decode to a valid-length
+    key. Re-encoding the decoded bytes and requiring an exact match pins the
+    accepted alphabet to exactly what Go's `RawURLEncoding` would emit
+    (#608 audit).
+    """
+    padded = value + "=" * (-len(value) % 4)
+    try:
+        decoded = base64.urlsafe_b64decode(padded)
+    except (ValueError, TypeError) as exc:
+        fail(f"{label} is not valid base64url: {exc}")
+    if len(decoded) != expected_len:
+        fail(f"{label} must decode to exactly {expected_len} bytes")
+    if base64.urlsafe_b64encode(decoded).rstrip(b"=").decode("ascii") != value:
+        fail(f"{label} is not canonically encoded (non-canonical base64url padding bits)")
+    return decoded
+
+
 def load_tier2_trusted_public_key() -> str:
     """Resolve the trusted Tier-2 Ed25519 public key used to authenticate a
     signed `tier2-catalog.json` before it can be trusted as a release feed
@@ -977,45 +1006,96 @@ def load_tier2_trusted_public_key() -> str:
     Reads `tier2.catalog_public_key` from the same committed
     `phase4-coordinator/dist/coordinator.yaml` that `deploy-pearl-vps.sh`
     pins before upload, so `catalog-release.py` and the deploy pipeline
-    agree on one trusted key. `CATALOG_RELEASE_TIER2_PUBLIC_KEY` overrides it
-    (used by tests to authenticate against an ephemeral test keypair without
-    mutating the committed coordinator config).
+    agree on one trusted key. Deliberately no environment-variable override:
+    an ambient env var would let anything that can set process environment
+    (not just a reviewed PR touching the committed trust root) swap the
+    trusted key. Tests instead monkeypatch the module-level
+    `COORDINATOR_YAML_PATH` constant, the same pattern already used for
+    `TIER2_CATALOG_PATH`.
     """
-    override = os.environ.get(TIER2_PUBLIC_KEY_ENV)
-    if override is not None:
-        candidate = override.strip()
-        source = f"{TIER2_PUBLIC_KEY_ENV} environment override"
-    else:
-        if not COORDINATOR_YAML_PATH.exists():
-            fail(f"tier2-catalog: cannot locate trusted Tier-2 public key; missing {COORDINATOR_YAML_PATH}")
-        candidate = (_yaml_block_value(COORDINATOR_YAML_PATH.read_text(), "tier2", "catalog_public_key") or "").strip()
-        source = str(COORDINATOR_YAML_PATH)
+    source = str(COORDINATOR_YAML_PATH)
+    if not COORDINATOR_YAML_PATH.exists():
+        fail(f"tier2-catalog: cannot locate trusted Tier-2 public key; missing {source}")
+    candidate = (_yaml_block_value(COORDINATOR_YAML_PATH.read_text(), "tier2", "catalog_public_key") or "").strip()
     if not candidate:
         fail(f"tier2-catalog: tier2.catalog_public_key is empty in {source}; cannot authenticate signed Tier-2 catalogs")
-    padded = candidate + "=" * (-len(candidate) % 4)
-    try:
-        decoded = base64.urlsafe_b64decode(padded)
-    except (ValueError, TypeError) as exc:
-        fail(f"tier2-catalog: trusted public key in {source} is not valid base64url: {exc}")
-    if len(decoded) != 32:
-        fail(f"tier2-catalog: trusted public key in {source} must be a 32-byte Ed25519 key")
+    canonical_urlsafe_b64_decode(candidate, 32, f"tier2-catalog: trusted public key in {source}")
     return candidate
 
 
-def verify_tier2_signature(raw: bytes) -> None:
+def go_executable() -> str:
+    """Locate a trusted Go toolchain executable for `verify_tier2_signature`.
+
+    Mirrors `openssl_executable()`'s hardening: an absolute-path-only
+    `GO_BIN` override, a fixed candidate list (no bare `go` from an
+    attacker-influenceable PATH ordering), a root-ownership check when
+    running privileged, and a version probe before trusting the binary.
+    """
+    override = os.environ.get("GO_BIN")
+    if override and not pathlib.Path(override).is_absolute():
+        fail("GO_BIN must be an absolute path to a Go toolchain executable")
+    candidates = [override] if override else [
+        "/opt/homebrew/bin/go",
+        "/usr/local/go/bin/go",
+        "/usr/local/bin/go",
+        shutil.which("go"),
+    ]
+
+    checked: list[str] = []
+    for candidate in candidates:
+        if not candidate or candidate in checked:
+            continue
+        checked.append(candidate)
+        if os.geteuid() == 0 and not root_trusted_executable(candidate):
+            continue
+        try:
+            result = subprocess.run(
+                [candidate, "version"],
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+                timeout=GO_PROBE_TIMEOUT_SECONDS,
+            )
+        except (OSError, subprocess.TimeoutExpired):
+            continue
+        if result.returncode == 0 and re.match(r"^go version go\d", result.stdout):
+            return candidate
+
+    if override:
+        fail("GO_BIN must identify a working Go toolchain executable")
+    fail("a Go toolchain is required to authenticate the signed Tier-2 catalog's Ed25519 signature")
+
+
+def tier2_trusted_key_fingerprint(public_key_b64: str) -> str:
+    """Stable identifier for a trusted Tier-2 Ed25519 public key.
+
+    Used as `signer_key_id` in the manifest/ledger instead of the catalog's
+    own `signature.key_id` claim: `sign-catalog.go`'s canonical signed body
+    excludes the entire `signature` object (see `canonicalCatalogJSON`), so
+    `key_id` is unauthenticated metadata alongside the signature, not part
+    of what Ed25519 actually covers. Recording it verbatim would let anyone
+    who can produce a validly-signed catalog choose an arbitrary
+    `signer_key_id` for the immutable ledger (#608 audit). Fingerprinting the
+    trusted key itself ties the recorded identity to what was cryptographically
+    proven, and changes only if the trusted key configuration changes.
+    """
+    padded = public_key_b64 + "=" * (-len(public_key_b64) % 4)
+    raw_key = base64.urlsafe_b64decode(padded)
+    return "tier2-coordinator-key:" + hashlib.sha256(raw_key).hexdigest()[:16]
+
+
+def verify_tier2_signature(raw: bytes) -> str:
     """Authenticate a Tier-2 catalog's Ed25519 signature before any caller
-    may trust it as "signed" (#608 Partial: ledger/compatibility-set
-    membership).
+    may trust it as "signed" (#608 Partial: ledger feed membership).
 
     Delegates to `sign-catalog.go verify`, the same canonicalization and
     verification `deploy-pearl-vps.sh` already runs before upload, instead
     of reimplementing Go's exact struct-field JSON encoding in Python.
     `validate_tier2_catalog` alone only locks the JSON shape; it does not
-    prove authenticity.
+    prove authenticity. Returns the authenticated signer's key fingerprint
+    for the caller to bind into `manifest()` as `tier2_signer_key_id`.
     """
-    go_bin = shutil.which("go")
-    if go_bin is None:
-        fail("tier2-catalog: go is required to authenticate the signed catalog's Ed25519 signature")
+    go_bin = go_executable()
     public_key = load_tier2_trusted_public_key()
     with tempfile.TemporaryDirectory(prefix="macprovider-tier2-verify-") as tmp:
         tmpdir = pathlib.Path(tmp)
@@ -1037,6 +1117,7 @@ def verify_tier2_signature(raw: bytes) -> None:
     if result.returncode != 0:
         detail = (result.stderr.strip() or result.stdout.strip() or "unknown error")
         fail(f"tier2-catalog: signature verification failed: {detail}")
+    return tier2_trusted_key_fingerprint(public_key)
 
 
 def load_tier2_models(tier2_data: bytes) -> dict[str, str]:
@@ -1200,7 +1281,7 @@ def derive_tier2_unsigned_body(
     )
 
 
-def require_tier2_catalog_for_generate() -> tuple[bytes | None, dict | None]:
+def require_tier2_catalog_for_generate() -> tuple[bytes | None, dict | None, str | None]:
     """Bind signed Tier-2 bytes as a release feed member when `generate` runs.
 
     Historical release-ledger rows generated before this capability existed
@@ -1208,7 +1289,7 @@ def require_tier2_catalog_for_generate() -> tuple[bytes | None, dict | None]:
     shapes). Whenever a `tier2-catalog.json` is staged at the canonical path
     it is never a silent bystander: it must pass structural validation and
     Ed25519 authentication before `generate` binds it into the manifest and
-    ledger (#608 Partial: ledger/compatibility-set membership).
+    ledger (#608 Partial: ledger feed membership).
 
     Hard-requiring Tier-2 on every `generate` run is staged behind
     `CATALOG_RELEASE_REQUIRE_TIER2=1` rather than being unconditional: the
@@ -1225,15 +1306,15 @@ def require_tier2_catalog_for_generate() -> tuple[bytes | None, dict | None]:
                 f"generate: {REQUIRE_TIER2_FOR_GENERATE_ENV}=1 but tier2-catalog.json "
                 "is missing. Every new catalog release must bind a signed Tier-2 "
                 "catalog as a release-ledger feed member (#608 Partial: "
-                "ledger/compatibility-set membership). Sign a Tier-2 catalog with "
+                "ledger feed membership). Sign a Tier-2 catalog with "
                 f"scripts/sign-catalog.go and place it at {TIER2_CATALOG_PATH}, or "
                 f"unset {REQUIRE_TIER2_FOR_GENERATE_ENV} to keep publishing 2-feed releases."
             )
-        return None, None
+        return None, None, None
     tier2 = TIER2_CATALOG_PATH.read_bytes()
     tier2_obj = validate_tier2_catalog(tier2)
-    verify_tier2_signature(tier2)
-    return tier2, tier2_obj
+    tier2_signer_key_id = verify_tier2_signature(tier2)
+    return tier2, tier2_obj, tier2_signer_key_id
 
 
 def updated_release_ledger(manifest_bytes: bytes) -> bytes:
@@ -1264,7 +1345,7 @@ def generate(signer_key_id: str | None = None) -> None:
     demand = canonical_bytes(demand_obj)
     if signer_key_id is not None and signer_key_id not in keyring():
         fail(f"cannot generate for unknown or retired signer key ID: {signer_key_id}")
-    tier2, tier2_obj = require_tier2_catalog_for_generate()
+    tier2, tier2_obj, tier2_signer_key_id = require_tier2_catalog_for_generate()
     if tier2 is not None:
         check_tier2_binding(candidate, tier2)
     # Compute every derived artifact before mutating on-disk release state so a
@@ -1272,6 +1353,7 @@ def generate(signer_key_id: str | None = None) -> None:
     manifest_bytes = manifest(
         candidate, demand, candidate_obj, demand_obj,
         signer_key_id=signer_key_id, tier2=tier2, tier2_obj=tier2_obj,
+        tier2_signer_key_id=tier2_signer_key_id,
     )
     binding_bytes = derive_tier2_identity_binding(candidate, candidate_obj)
     swift_text = generated_swift(candidate, demand, signer_key_id)
@@ -1362,12 +1444,16 @@ def verify() -> None:
     # before trusting it as a feed member.
     tier2 = None
     tier2_obj = None
+    tier2_signer_key_id = None
     if TIER2_CATALOG_PATH.exists():
         tier2 = TIER2_CATALOG_PATH.read_bytes()
         tier2_obj = validate_tier2_catalog(tier2)
-        verify_tier2_signature(tier2)
+        tier2_signer_key_id = verify_tier2_signature(tier2)
         check_tier2_binding(candidate, tier2)
-    expected_manifest = manifest(candidate, demand, candidate_obj, demand_obj, tier2=tier2, tier2_obj=tier2_obj)
+    expected_manifest = manifest(
+        candidate, demand, candidate_obj, demand_obj,
+        tier2=tier2, tier2_obj=tier2_obj, tier2_signer_key_id=tier2_signer_key_id,
+    )
     if MANIFEST_PATH.read_bytes() != expected_manifest:
         fail(f"generated drift: {MANIFEST_PATH}")
     ledger = validate_release_ledger(LEDGER_PATH.read_bytes())
@@ -1411,18 +1497,22 @@ def verify_directory(directory: pathlib.Path) -> None:
     if candidate != canonical_bytes(candidate_obj) or demand != canonical_bytes(demand_obj):
         fail("release directory feeds are not deterministic canonical bytes")
     # A staged tier2-catalog.json must be a declared release.json feed member
-    # (#608 Partial: ledger/compatibility-set membership), not a bystander
+    # (#608 Partial: ledger feed membership), not a bystander
     # file — the manifest recomputation below fails closed on drift if it
     # is not, and check_tier2_binding fails closed on identity conflicts.
     tier2_path = directory / "tier2-catalog.json"
     tier2 = None
     tier2_obj = None
+    tier2_signer_key_id = None
     if tier2_path.exists():
         tier2 = tier2_path.read_bytes()
         tier2_obj = validate_tier2_catalog(tier2)
-        verify_tier2_signature(tier2)
+        tier2_signer_key_id = verify_tier2_signature(tier2)
         check_tier2_binding(candidate, tier2)
-    expected_manifest = manifest(candidate, demand, candidate_obj, demand_obj, directory, tier2=tier2, tier2_obj=tier2_obj)
+    expected_manifest = manifest(
+        candidate, demand, candidate_obj, demand_obj, directory,
+        tier2=tier2, tier2_obj=tier2_obj, tier2_signer_key_id=tier2_signer_key_id,
+    )
     if (directory / "release.json").read_bytes() != expected_manifest:
         fail("release directory manifest does not bind the feed bytes")
     keys = keyring(directory / "trusted-keys.json")

--- a/scripts/test-catalog-release.sh
+++ b/scripts/test-catalog-release.sh
@@ -480,4 +480,231 @@ with tempfile.TemporaryDirectory() as directory:
 print("llama tier2 conflict fixture + stage-tier2-republish checks locked")
 PY
 
+# #608 Partial: signed tier2-catalog.json as a release-ledger feed member.
+# Historical 2-feed release-ledger rows remain valid (validate_release_ledger
+# still accepts them); only a *new* release generate requires Tier-2.
+python3 - "$VERIFY" "$CANONICAL" "$STATIC" <<'PY'
+import base64
+import importlib.util
+import json
+import pathlib
+import shutil
+import sys
+import tempfile
+
+spec = importlib.util.spec_from_file_location("catalog_release_tier2", sys.argv[1])
+module = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(module)
+canonical = pathlib.Path(sys.argv[2])
+static = pathlib.Path(sys.argv[3])
+
+candidate_bytes = (canonical / "autotune-candidates.json").read_bytes()
+candidate_obj = module.validate_candidate(candidate_bytes)
+demand_bytes = (canonical / "demand-rank.json").read_bytes()
+demand_obj = module.validate_demand(demand_bytes)
+qwen_row = candidate_obj["rows"]["qwen3-8b"]
+
+
+def rejected(label, fn):
+    try:
+        fn()
+    except module.CatalogError:
+        return
+    raise SystemExit(f"{label} was accepted")
+
+
+def signed_tier2(catalog_id, model_sha256, *, key_id="catalog-key-2026q2", sig="A" * 86, **overrides):
+    body = {
+        "catalog_id": catalog_id,
+        "issued_at": "2026-07-01T00:00:00Z",
+        "expires_at": "2099-01-01T00:00:00Z",
+        "models": [{
+            "artifact_kind": "mlx_weight_file",
+            "hash_scope": "artifact_manifest",
+            "model_id": qwen_row["model_id"],
+            "sha256": model_sha256,
+            "source": "operator-curated",
+        }],
+        "version": 1,
+        "signature": {"alg": "Ed25519", "key_id": key_id, "sig": sig},
+    }
+    body.update(overrides)
+    return json.dumps(body).encode()
+
+
+agreeing_tier2 = signed_tier2("test-catalog-agree", qwen_row["model_sha256"])
+tier2_obj = module.validate_tier2_catalog(agreeing_tier2)
+if tier2_obj["catalog_id"] != "test-catalog-agree":
+    raise SystemExit("validate_tier2_catalog did not round-trip catalog_id")
+
+# --- structural rejections mirroring scripts/sign-catalog.go validateCatalogBody ---
+base_body = json.loads(agreeing_tier2)
+
+
+def mutated(mutation):
+    body = json.loads(json.dumps(base_body))
+    mutation(body)
+    return json.dumps(body).encode()
+
+
+rejected("missing signature field", lambda: module.validate_tier2_catalog(
+    mutated(lambda b: b.pop("signature"))
+))
+rejected("unknown top-level field", lambda: module.validate_tier2_catalog(
+    mutated(lambda b: b.__setitem__("extra", True))
+))
+rejected("non-Ed25519 alg", lambda: module.validate_tier2_catalog(
+    mutated(lambda b: b["signature"].__setitem__("alg", "ed25519"))
+))
+rejected("short signature", lambda: module.validate_tier2_catalog(
+    mutated(lambda b: b["signature"].__setitem__("sig", "AA"))
+))
+rejected("non-base64url signature", lambda: module.validate_tier2_catalog(
+    mutated(lambda b: b["signature"].__setitem__("sig", "not base64!"))
+))
+rejected("version must be 1", lambda: module.validate_tier2_catalog(
+    mutated(lambda b: b.__setitem__("version", 2))
+))
+rejected("issued_at after expires_at", lambda: module.validate_tier2_catalog(
+    mutated(lambda b: (b.__setitem__("issued_at", "2099-06-01T00:00:00Z")))
+))
+rejected("empty models", lambda: module.validate_tier2_catalog(
+    mutated(lambda b: b.__setitem__("models", []))
+))
+rejected("unsupported hash_scope", lambda: module.validate_tier2_catalog(
+    mutated(lambda b: b["models"][0].__setitem__("hash_scope", "bogus_scope"))
+))
+rejected("unsupported artifact_kind", lambda: module.validate_tier2_catalog(
+    mutated(lambda b: b["models"][0].__setitem__("artifact_kind", "gguf"))
+))
+rejected("bad sha256 format", lambda: module.validate_tier2_catalog(
+    mutated(lambda b: b["models"][0].__setitem__("sha256", "not-hex"))
+))
+rejected("duplicate model_id case-insensitive", lambda: module.validate_tier2_catalog(
+    mutated(lambda b: b["models"].append({**b["models"][0], "model_id": b["models"][0]["model_id"].upper()}))
+))
+module.validate_tier2_catalog(agreeing_tier2)  # baseline still accepted after mutation probes
+
+# --- check-tier2-binding fail-closed on conflicting hash ---
+conflicting_tier2 = signed_tier2("test-catalog-conflict", "f" * 64)
+module.check_tier2_binding(candidate_bytes, agreeing_tier2)
+try:
+    module.check_tier2_binding(candidate_bytes, conflicting_tier2)
+except module.CatalogError as exc:
+    if "conflicts" not in str(exc):
+        raise SystemExit(f"tier2 feed conflict error missing detail: {exc}")
+else:
+    raise SystemExit("conflicting tier2 feed candidate was accepted")
+
+# --- manifest() binds tier2-catalog.json as a third feed ---
+manifest_with_tier2 = module.manifest(
+    candidate_bytes, demand_bytes, candidate_obj, demand_obj,
+    tier2=agreeing_tier2, tier2_obj=tier2_obj,
+)
+manifest_value = json.loads(manifest_with_tier2)
+if set(manifest_value["feeds"]) != {"autotune-candidates.json", "demand-rank.json", "tier2-catalog.json"}:
+    raise SystemExit(f"tier2 feed missing from manifest: {sorted(manifest_value['feeds'])}")
+tier2_feed = manifest_value["feeds"]["tier2-catalog.json"]
+if tier2_feed["sha256"] != module.sha256(agreeing_tier2) or tier2_feed["bytes"] != len(agreeing_tier2):
+    raise SystemExit("tier2 feed digest/bytes do not bind the signed catalog")
+if tier2_feed["version"] != "test-catalog-agree" or tier2_feed["signer_key_id"] != "catalog-key-2026q2":
+    raise SystemExit("tier2 feed version/signer_key_id must come from the signed catalog, not the release train")
+
+manifest_without_tier2 = module.manifest(candidate_bytes, demand_bytes, candidate_obj, demand_obj)
+if "tier2-catalog.json" in json.loads(manifest_without_tier2)["feeds"]:
+    raise SystemExit("manifest() must omit tier2-catalog.json when tier2 bytes are not supplied")
+
+# --- release-ledger: historical 2-feed rows stay valid; new 3-feed rows are accepted ---
+hist_release_id, hist_record = module.release_record(manifest_without_tier2)
+
+# A synthetic later release_id proves the 3-feed shape is accepted for *new*
+# rows without disturbing the real historical row's 2-feed shape.
+new_candidate_obj = json.loads(json.dumps(candidate_obj))
+new_candidate_obj["version"] = "published-2026-07-20-tier2-bound"
+new_demand_obj = json.loads(json.dumps(demand_obj))
+new_demand_obj["version"] = new_candidate_obj["version"]
+new_manifest_with_tier2 = module.manifest(
+    candidate_bytes, demand_bytes, new_candidate_obj, new_demand_obj,
+    tier2=agreeing_tier2, tier2_obj=tier2_obj,
+)
+bound_release_id, bound_record = module.release_record(new_manifest_with_tier2)
+if bound_release_id == hist_release_id:
+    raise SystemExit("synthetic tier2-bound release_id must differ from the real historical release_id")
+
+legacy_ledger = {
+    "schema_version": "macprovider.autotune-release-ledger.v2",
+    "releases": {hist_release_id: hist_record},
+    "tombstones": {},
+}
+module.validate_release_ledger(json.dumps(legacy_ledger).encode())
+
+tier2_bound_ledger = {
+    "schema_version": "macprovider.autotune-release-ledger.v2",
+    "releases": {
+        hist_release_id: hist_record,
+        bound_release_id: bound_record,
+    },
+    "tombstones": {},
+}
+module.validate_release_ledger(json.dumps(tier2_bound_ledger).encode())
+
+# Historical rows must not silently gain/require Tier-2, and rows must not mix
+# an unexpected feed name into either accepted shape.
+hybrid_ledger = json.loads(json.dumps(tier2_bound_ledger))
+hybrid_ledger["releases"][bound_release_id]["feeds"]["mystery.json"] = (
+    hybrid_ledger["releases"][bound_release_id]["feeds"].pop("demand-rank.json")
+)
+rejected("unexpected feed name set", lambda: module.validate_release_ledger(json.dumps(hybrid_ledger).encode()))
+
+# tier2-catalog.json's `version` field is the signed catalog_id, not the
+# autotune release_id — legacy feeds still must match release_id exactly.
+mismatched_autotune_version = json.loads(json.dumps(tier2_bound_ledger))
+mismatched_autotune_version["releases"][bound_release_id]["feeds"]["autotune-candidates.json"]["version"] = "wrong"
+rejected(
+    "autotune feed version must equal release_id even with tier2 bound",
+    lambda: module.validate_release_ledger(json.dumps(mismatched_autotune_version).encode()),
+)
+
+print("release-ledger accepts historical 2-feed rows and Tier-2-bound 3-feed rows")
+
+# --- generate() requires Tier-2 going forward; historical `verify` does not ---
+original_tier2_path = module.TIER2_CATALOG_PATH
+try:
+    module.TIER2_CATALOG_PATH = pathlib.Path(tempfile.mkdtemp()) / "tier2-catalog.json"
+    rejected("generate without tier2-catalog.json", module.require_tier2_catalog_for_generate)
+    module.TIER2_CATALOG_PATH.write_bytes(agreeing_tier2)
+    returned_tier2, returned_obj = module.require_tier2_catalog_for_generate()
+    if returned_tier2 != agreeing_tier2 or returned_obj["catalog_id"] != "test-catalog-agree":
+        raise SystemExit("require_tier2_catalog_for_generate did not round-trip the signed catalog")
+finally:
+    module.TIER2_CATALOG_PATH = original_tier2_path
+
+# --- verify_directory: tier2-catalog.json must be a declared feed member ---
+with tempfile.TemporaryDirectory() as directory:
+    release = pathlib.Path(directory)
+    shutil.copy(canonical / "trusted-keys.json", release / "trusted-keys.json")
+    for name in ("autotune-candidates.json", "demand-rank.json"):
+        shutil.copy(static / name, release / name)
+        shutil.copy(static / f"{name}.sig", release / f"{name}.sig")
+
+    # Happy path: tier2-catalog.json present AND declared in release.json.
+    (release / "tier2-catalog.json").write_bytes(agreeing_tier2)
+    (release / "release.json").write_bytes(manifest_with_tier2)
+    module.verify_directory(release)
+
+    # Undeclared: an agreeing tier2-catalog.json sitting beside a release.json
+    # that only binds the legacy 2 feeds must fail closed (feed membership,
+    # not just digest overlap, is what #608 requires).
+    (release / "release.json").write_bytes(manifest_without_tier2)
+    try:
+        module.verify_directory(release)
+    except module.CatalogError as exc:
+        if "manifest does not bind the feed bytes" not in str(exc):
+            raise SystemExit(f"undeclared tier2 catalog rejected for the wrong reason: {exc}")
+    else:
+        raise SystemExit("undeclared tier2-catalog.json feed membership was accepted")
+
+print("verify-directory requires tier2-catalog.json to be a declared feed member")
+PY
+
 echo "PASS: catalog release generation and trust failures are locked"

--- a/scripts/test-catalog-release.sh
+++ b/scripts/test-catalog-release.sh
@@ -487,8 +487,10 @@ python3 - "$VERIFY" "$CANONICAL" "$STATIC" <<'PY'
 import base64
 import importlib.util
 import json
+import os
 import pathlib
 import shutil
+import subprocess
 import sys
 import tempfile
 
@@ -514,6 +516,12 @@ def rejected(label, fn):
 
 
 def signed_tier2(catalog_id, model_sha256, *, key_id="catalog-key-2026q2", sig="A" * 86, **overrides):
+    """Build a structurally-shaped catalog with a placeholder signature.
+
+    Used only against `validate_tier2_catalog` (structural checks) and
+    `check_tier2_binding`/`manifest()` (neither authenticate signatures).
+    Anything that trusts a catalog as "signed" needs `real_signed_tier2`.
+    """
     body = {
         "catalog_id": catalog_id,
         "issued_at": "2026-07-01T00:00:00Z",
@@ -532,10 +540,89 @@ def signed_tier2(catalog_id, model_sha256, *, key_id="catalog-key-2026q2", sig="
     return json.dumps(body).encode()
 
 
-agreeing_tier2 = signed_tier2("test-catalog-agree", qwen_row["model_sha256"])
+# --- real Ed25519 keypairs for signature-authentication tests ---
+keys_dir = pathlib.Path(tempfile.mkdtemp(prefix="tier2-test-keys-"))
+trusted_pub = keys_dir / "trusted.pub"
+trusted_priv = keys_dir / "trusted.priv"
+other_pub = keys_dir / "other.pub"
+other_priv = keys_dir / "other.priv"
+subprocess.run(
+    ["go", "run", str(module.SIGN_CATALOG_GO_PATH), "keygen",
+     "-public-out", str(trusted_pub), "-private-out", str(trusted_priv)],
+    check=True, cwd=str(module.ROOT), capture_output=True, text=True,
+)
+subprocess.run(
+    ["go", "run", str(module.SIGN_CATALOG_GO_PATH), "keygen",
+     "-public-out", str(other_pub), "-private-out", str(other_priv)],
+    check=True, cwd=str(module.ROOT), capture_output=True, text=True,
+)
+os.environ[module.TIER2_PUBLIC_KEY_ENV] = trusted_pub.read_text().strip()
+
+
+def sign_with(priv_path, unsigned_body, *, key_id="test-tier2-key"):
+    unsigned_path = keys_dir / f"unsigned-{abs(hash(json.dumps(unsigned_body, sort_keys=True)))}.json"
+    unsigned_path.write_text(json.dumps(unsigned_body))
+    result = subprocess.run(
+        ["go", "run", str(module.SIGN_CATALOG_GO_PATH), "sign",
+         "-key", str(priv_path), "-key-id", key_id, str(unsigned_path)],
+        check=True, cwd=str(module.ROOT), capture_output=True, text=True,
+    )
+    return result.stdout.encode()
+
+
+def unsigned_body(catalog_id, model_sha256, **overrides):
+    body = {
+        "catalog_id": catalog_id,
+        "issued_at": "2026-07-01T00:00:00Z",
+        "expires_at": "2099-01-01T00:00:00Z",
+        "models": [{
+            "artifact_kind": "mlx_weight_file",
+            "hash_scope": "artifact_manifest",
+            "model_id": qwen_row["model_id"],
+            "sha256": model_sha256,
+            "source": "operator-curated",
+        }],
+        "version": 1,
+    }
+    body.update(overrides)
+    return body
+
+
+def real_signed_tier2(catalog_id, model_sha256, *, priv_path=trusted_priv, **overrides):
+    return sign_with(priv_path, unsigned_body(catalog_id, model_sha256, **overrides))
+
+
+agreeing_tier2 = real_signed_tier2("test-catalog-agree", qwen_row["model_sha256"])
 tier2_obj = module.validate_tier2_catalog(agreeing_tier2)
 if tier2_obj["catalog_id"] != "test-catalog-agree":
     raise SystemExit("validate_tier2_catalog did not round-trip catalog_id")
+
+# --- signature authentication: verify_tier2_signature must actually check crypto ---
+module.verify_tier2_signature(agreeing_tier2)  # trusted key + matching signature: accepted
+
+tampered = bytearray(agreeing_tier2)
+marker = b"operator-curated"
+idx = bytes(tampered).find(marker)
+if idx == -1:
+    raise SystemExit("tamper fixture setup failed: marker not found")
+tampered[idx] = ord("O")
+rejected("tampered tier2 catalog bytes", lambda: module.verify_tier2_signature(bytes(tampered)))
+
+wrong_signer_tier2 = real_signed_tier2("test-catalog-wrong-signer", qwen_row["model_sha256"], priv_path=other_priv)
+rejected("tier2 catalog signed by an untrusted key", lambda: module.verify_tier2_signature(wrong_signer_tier2))
+
+dummy_signed_tier2 = signed_tier2("test-catalog-dummy-sig", qwen_row["model_sha256"])
+module.validate_tier2_catalog(dummy_signed_tier2)  # structurally valid...
+rejected("tier2 catalog with a structurally-valid but non-cryptographic signature",
+          lambda: module.verify_tier2_signature(dummy_signed_tier2))  # ...but not authentic
+
+expired_tier2 = signed_tier2(
+    "test-catalog-expired", qwen_row["model_sha256"],
+    issued_at="2020-01-01T00:00:00Z", expires_at="2020-06-01T00:00:00Z",
+)
+rejected("expired tier2 catalog", lambda: module.validate_tier2_catalog(expired_tier2))
+
+print("tier2 signature authentication (tamper/wrong-key/dummy-sig/expiry) rejects as expected")
 
 # --- structural rejections mirroring scripts/sign-catalog.go validateCatalogBody ---
 base_body = json.loads(agreeing_tier2)
@@ -583,6 +670,21 @@ rejected("bad sha256 format", lambda: module.validate_tier2_catalog(
 rejected("duplicate model_id case-insensitive", lambda: module.validate_tier2_catalog(
     mutated(lambda b: b["models"].append({**b["models"][0], "model_id": b["models"][0]["model_id"].upper()}))
 ))
+rejected("boolean version coincidentally equal to 1", lambda: module.validate_tier2_catalog(
+    mutated(lambda b: b.__setitem__("version", True))
+))
+rejected("float version coincidentally equal to 1", lambda: module.validate_tier2_catalog(
+    mutated(lambda b: b.__setitem__("version", 1.0))
+))
+rejected("non-string hash_scope", lambda: module.validate_tier2_catalog(
+    mutated(lambda b: b["models"][0].__setitem__("hash_scope", ["artifact_manifest"]))
+))
+rejected("padded base64 signature", lambda: module.validate_tier2_catalog(
+    mutated(lambda b: b["signature"].__setitem__("sig", "A" * 84 + "=="))
+))
+rejected("standard-alphabet (non-urlsafe) signature", lambda: module.validate_tier2_catalog(
+    mutated(lambda b: b["signature"].__setitem__("sig", "A" * 84 + "+/"))
+))
 module.validate_tier2_catalog(agreeing_tier2)  # baseline still accepted after mutation probes
 
 # --- check-tier2-binding fail-closed on conflicting hash ---
@@ -607,7 +709,7 @@ if set(manifest_value["feeds"]) != {"autotune-candidates.json", "demand-rank.jso
 tier2_feed = manifest_value["feeds"]["tier2-catalog.json"]
 if tier2_feed["sha256"] != module.sha256(agreeing_tier2) or tier2_feed["bytes"] != len(agreeing_tier2):
     raise SystemExit("tier2 feed digest/bytes do not bind the signed catalog")
-if tier2_feed["version"] != "test-catalog-agree" or tier2_feed["signer_key_id"] != "catalog-key-2026q2":
+if tier2_feed["version"] != "test-catalog-agree" or tier2_feed["signer_key_id"] != "test-tier2-key":
     raise SystemExit("tier2 feed version/signer_key_id must come from the signed catalog, not the release train")
 
 manifest_without_tier2 = module.manifest(candidate_bytes, demand_bytes, candidate_obj, demand_obj)
@@ -667,19 +769,44 @@ rejected(
 
 print("release-ledger accepts historical 2-feed rows and Tier-2-bound 3-feed rows")
 
-# --- generate() requires Tier-2 going forward; historical `verify` does not ---
+# --- generate(): Tier-2 requirement is staged behind an explicit opt-in ---
+# so the existing 2-feed release train is not broken the moment this lands
+# (no tier2-catalog.json exists yet at the canonical path, and downstream
+# compatibility-set/packaging/Pearl-updater tooling does not accept a 3-feed
+# manifest). Absence is silently fine by default; CATALOG_RELEASE_REQUIRE_TIER2=1
+# makes it a hard requirement for whoever is ready to enforce it, and once a
+# catalog IS staged it is never a silent bystander -- it must authenticate.
 original_tier2_path = module.TIER2_CATALOG_PATH
+require_env = module.REQUIRE_TIER2_FOR_GENERATE_ENV
 try:
     module.TIER2_CATALOG_PATH = pathlib.Path(tempfile.mkdtemp()) / "tier2-catalog.json"
-    rejected("generate without tier2-catalog.json", module.require_tier2_catalog_for_generate)
+
+    os.environ.pop(require_env, None)
+    absent_tier2, absent_obj = module.require_tier2_catalog_for_generate()
+    if absent_tier2 is not None or absent_obj is not None:
+        raise SystemExit("require_tier2_catalog_for_generate must return (None, None) when Tier-2 is optional and absent")
+
+    os.environ[require_env] = "1"
+    rejected(f"generate without tier2-catalog.json when {require_env}=1", module.require_tier2_catalog_for_generate)
+    os.environ.pop(require_env, None)
+
     module.TIER2_CATALOG_PATH.write_bytes(agreeing_tier2)
     returned_tier2, returned_obj = module.require_tier2_catalog_for_generate()
     if returned_tier2 != agreeing_tier2 or returned_obj["catalog_id"] != "test-catalog-agree":
         raise SystemExit("require_tier2_catalog_for_generate did not round-trip the signed catalog")
+
+    module.TIER2_CATALOG_PATH.write_bytes(dummy_signed_tier2)
+    rejected(
+        "require_tier2_catalog_for_generate with a structurally-valid but unauthenticated catalog",
+        module.require_tier2_catalog_for_generate,
+    )
 finally:
+    os.environ.pop(require_env, None)
     module.TIER2_CATALOG_PATH = original_tier2_path
 
-# --- verify_directory: tier2-catalog.json must be a declared feed member ---
+print("generate() Tier-2 requirement is staged behind an opt-in env var; staged catalogs must authenticate")
+
+# --- verify_directory: tier2-catalog.json must be a declared, authentic feed member ---
 with tempfile.TemporaryDirectory() as directory:
     release = pathlib.Path(directory)
     shutil.copy(canonical / "trusted-keys.json", release / "trusted-keys.json")
@@ -687,7 +814,7 @@ with tempfile.TemporaryDirectory() as directory:
         shutil.copy(static / name, release / name)
         shutil.copy(static / f"{name}.sig", release / f"{name}.sig")
 
-    # Happy path: tier2-catalog.json present AND declared in release.json.
+    # Happy path: tier2-catalog.json present, authentic, AND declared in release.json.
     (release / "tier2-catalog.json").write_bytes(agreeing_tier2)
     (release / "release.json").write_bytes(manifest_with_tier2)
     module.verify_directory(release)
@@ -704,7 +831,18 @@ with tempfile.TemporaryDirectory() as directory:
     else:
         raise SystemExit("undeclared tier2-catalog.json feed membership was accepted")
 
-print("verify-directory requires tier2-catalog.json to be a declared feed member")
+    # A staged catalog that is structurally declared but forged/unauthenticated
+    # must fail closed even though its bytes match the declared manifest digest.
+    forged_manifest = module.manifest(
+        candidate_bytes, demand_bytes, candidate_obj, demand_obj,
+        tier2=wrong_signer_tier2, tier2_obj=module.validate_tier2_catalog(wrong_signer_tier2),
+    )
+    (release / "tier2-catalog.json").write_bytes(wrong_signer_tier2)
+    (release / "release.json").write_bytes(forged_manifest)
+    rejected("verify_directory with a declared but untrusted-signer tier2-catalog.json",
+              lambda: module.verify_directory(release))
+
+print("verify-directory requires tier2-catalog.json to be a declared AND authenticated feed member")
 PY
 
 echo "PASS: catalog release generation and trust failures are locked"

--- a/scripts/test-catalog-release.sh
+++ b/scripts/test-catalog-release.sh
@@ -484,6 +484,7 @@ PY
 # Historical 2-feed release-ledger rows remain valid (validate_release_ledger
 # still accepts them); only a *new* release generate requires Tier-2.
 python3 - "$VERIFY" "$CANONICAL" "$STATIC" <<'PY'
+import atexit
 import base64
 import importlib.util
 import json
@@ -542,6 +543,7 @@ def signed_tier2(catalog_id, model_sha256, *, key_id="catalog-key-2026q2", sig="
 
 # --- real Ed25519 keypairs for signature-authentication tests ---
 keys_dir = pathlib.Path(tempfile.mkdtemp(prefix="tier2-test-keys-"))
+atexit.register(shutil.rmtree, keys_dir, ignore_errors=True)
 trusted_pub = keys_dir / "trusted.pub"
 trusted_priv = keys_dir / "trusted.priv"
 other_pub = keys_dir / "other.pub"
@@ -556,7 +558,14 @@ subprocess.run(
      "-public-out", str(other_pub), "-private-out", str(other_priv)],
     check=True, cwd=str(module.ROOT), capture_output=True, text=True,
 )
-os.environ[module.TIER2_PUBLIC_KEY_ENV] = trusted_pub.read_text().strip()
+# No env-var override exists for the trusted key (an ambient env var could
+# swap the trust root outside PR review); monkeypatch the module-level
+# COORDINATOR_YAML_PATH constant instead, the same pattern already used for
+# TIER2_CATALOG_PATH below.
+original_coordinator_yaml_path = module.COORDINATOR_YAML_PATH
+test_coordinator_yaml = keys_dir / "coordinator.yaml"
+test_coordinator_yaml.write_text(f"tier2:\n  catalog_public_key: {trusted_pub.read_text().strip()}\n")
+module.COORDINATOR_YAML_PATH = test_coordinator_yaml
 
 
 def sign_with(priv_path, unsigned_body, *, key_id="test-tier2-key"):
@@ -597,8 +606,33 @@ tier2_obj = module.validate_tier2_catalog(agreeing_tier2)
 if tier2_obj["catalog_id"] != "test-catalog-agree":
     raise SystemExit("validate_tier2_catalog did not round-trip catalog_id")
 
+trusted_key_fingerprint = module.tier2_trusted_key_fingerprint(trusted_pub.read_text().strip())
+
 # --- signature authentication: verify_tier2_signature must actually check crypto ---
-module.verify_tier2_signature(agreeing_tier2)  # trusted key + matching signature: accepted
+authenticated_signer = module.verify_tier2_signature(agreeing_tier2)  # trusted key + matching signature: accepted
+if authenticated_signer != trusted_key_fingerprint:
+    raise SystemExit("verify_tier2_signature must return the trusted key's fingerprint")
+
+# key_id is metadata alongside the signature, not covered by
+# sign-catalog.go's signed canonical body (#608 audit): a catalog whose
+# signature.key_id is tampered after signing must still verify (the bytes
+# Ed25519 covers are unchanged), but the *recorded* signer identity must be
+# the authenticated trusted-key fingerprint, never the tampered claim.
+key_id_tampered = json.loads(agreeing_tier2)
+key_id_tampered["signature"]["key_id"] = "forged-id"
+key_id_tampered_bytes = json.dumps(key_id_tampered).encode()
+key_id_tampered_obj = module.validate_tier2_catalog(key_id_tampered_bytes)
+key_id_tampered_signer = module.verify_tier2_signature(key_id_tampered_bytes)
+if key_id_tampered_signer != trusted_key_fingerprint:
+    raise SystemExit("verify_tier2_signature must ignore the catalog's own claimed key_id")
+key_id_tampered_manifest = module.manifest(
+    candidate_bytes, demand_bytes, candidate_obj, demand_obj,
+    tier2=key_id_tampered_bytes, tier2_obj=key_id_tampered_obj, tier2_signer_key_id=key_id_tampered_signer,
+)
+if json.loads(key_id_tampered_manifest)["feeds"]["tier2-catalog.json"]["signer_key_id"] == "forged-id":
+    raise SystemExit("manifest() recorded an unauthenticated key_id claim instead of the authenticated fingerprint")
+
+print("tier2 key_id tampering does not affect authentication and is never recorded as signer_key_id")
 
 tampered = bytearray(agreeing_tier2)
 marker = b"operator-curated"
@@ -610,6 +644,19 @@ rejected("tampered tier2 catalog bytes", lambda: module.verify_tier2_signature(b
 
 wrong_signer_tier2 = real_signed_tier2("test-catalog-wrong-signer", qwen_row["model_sha256"], priv_path=other_priv)
 rejected("tier2 catalog signed by an untrusted key", lambda: module.verify_tier2_signature(wrong_signer_tier2))
+
+# The trust root is the committed coordinator.yaml only. An ambient
+# environment variable set by anything other than a reviewed PR touching
+# that file must NOT be able to authenticate a catalog signed by a
+# different (untrusted) key.
+os.environ["CATALOG_RELEASE_TIER2_PUBLIC_KEY"] = other_pub.read_text().strip()
+try:
+    rejected(
+        "wrong-signer tier2 catalog authenticated via an ambient env var (no such override exists)",
+        lambda: module.verify_tier2_signature(wrong_signer_tier2),
+    )
+finally:
+    os.environ.pop("CATALOG_RELEASE_TIER2_PUBLIC_KEY", None)
 
 dummy_signed_tier2 = signed_tier2("test-catalog-dummy-sig", qwen_row["model_sha256"])
 module.validate_tier2_catalog(dummy_signed_tier2)  # structurally valid...
@@ -685,6 +732,43 @@ rejected("padded base64 signature", lambda: module.validate_tier2_catalog(
 rejected("standard-alphabet (non-urlsafe) signature", lambda: module.validate_tier2_catalog(
     mutated(lambda b: b["signature"].__setitem__("sig", "A" * 84 + "+/"))
 ))
+
+
+def malleable_variant(value):
+    """Find a same-length base64url string that decodes to the same bytes
+    as `value` but is not itself the canonical encoding (trailing unused
+    bits in the final character differ). Returns None if no such variant
+    exists among the base64url alphabet."""
+    alphabet = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_"
+    pad = "=" * (-len(value) % 4)
+    original = base64.urlsafe_b64decode(value + pad)
+    for c in alphabet:
+        if c == value[-1]:
+            continue
+        candidate = value[:-1] + c
+        try:
+            if base64.urlsafe_b64decode(candidate + pad) == original:
+                return candidate
+        except Exception:
+            continue
+    return None
+
+
+malleable_sig = malleable_variant(base_body["signature"]["sig"])
+if malleable_sig is None:
+    raise SystemExit("malleability probe setup failed: no alternate trailing-bit signature found")
+rejected("non-canonical base64url signature (trailing-bit malleability)", lambda: module.validate_tier2_catalog(
+    mutated(lambda b: b["signature"].__setitem__("sig", malleable_sig))
+))
+
+malleable_pubkey = malleable_variant(trusted_pub.read_text().strip())
+if malleable_pubkey is None:
+    raise SystemExit("malleability probe setup failed: no alternate trailing-bit public key found")
+rejected(
+    "non-canonical base64url public key (trailing-bit malleability)",
+    lambda: module.canonical_urlsafe_b64_decode(malleable_pubkey, 32, "test pubkey"),
+)
+
 module.validate_tier2_catalog(agreeing_tier2)  # baseline still accepted after mutation probes
 
 # --- check-tier2-binding fail-closed on conflicting hash ---
@@ -699,9 +783,12 @@ else:
     raise SystemExit("conflicting tier2 feed candidate was accepted")
 
 # --- manifest() binds tier2-catalog.json as a third feed ---
+# signer_key_id must come from the authenticated verify_tier2_signature()
+# result (a fingerprint of the trusted key), NOT from the catalog's own
+# unauthenticated signature.key_id claim (#608 audit).
 manifest_with_tier2 = module.manifest(
     candidate_bytes, demand_bytes, candidate_obj, demand_obj,
-    tier2=agreeing_tier2, tier2_obj=tier2_obj,
+    tier2=agreeing_tier2, tier2_obj=tier2_obj, tier2_signer_key_id=trusted_key_fingerprint,
 )
 manifest_value = json.loads(manifest_with_tier2)
 if set(manifest_value["feeds"]) != {"autotune-candidates.json", "demand-rank.json", "tier2-catalog.json"}:
@@ -709,8 +796,16 @@ if set(manifest_value["feeds"]) != {"autotune-candidates.json", "demand-rank.jso
 tier2_feed = manifest_value["feeds"]["tier2-catalog.json"]
 if tier2_feed["sha256"] != module.sha256(agreeing_tier2) or tier2_feed["bytes"] != len(agreeing_tier2):
     raise SystemExit("tier2 feed digest/bytes do not bind the signed catalog")
-if tier2_feed["version"] != "test-catalog-agree" or tier2_feed["signer_key_id"] != "test-tier2-key":
-    raise SystemExit("tier2 feed version/signer_key_id must come from the signed catalog, not the release train")
+if tier2_feed["version"] != "test-catalog-agree" or tier2_feed["signer_key_id"] != trusted_key_fingerprint:
+    raise SystemExit("tier2 feed version must come from the signed catalog; signer_key_id from the authenticated trusted key")
+
+rejected(
+    "manifest() with tier2 bytes but no authenticated tier2_signer_key_id",
+    lambda: module.manifest(
+        candidate_bytes, demand_bytes, candidate_obj, demand_obj,
+        tier2=agreeing_tier2, tier2_obj=tier2_obj,
+    ),
+)
 
 manifest_without_tier2 = module.manifest(candidate_bytes, demand_bytes, candidate_obj, demand_obj)
 if "tier2-catalog.json" in json.loads(manifest_without_tier2)["feeds"]:
@@ -727,7 +822,7 @@ new_demand_obj = json.loads(json.dumps(demand_obj))
 new_demand_obj["version"] = new_candidate_obj["version"]
 new_manifest_with_tier2 = module.manifest(
     candidate_bytes, demand_bytes, new_candidate_obj, new_demand_obj,
-    tier2=agreeing_tier2, tier2_obj=tier2_obj,
+    tier2=agreeing_tier2, tier2_obj=tier2_obj, tier2_signer_key_id=trusted_key_fingerprint,
 )
 bound_release_id, bound_record = module.release_record(new_manifest_with_tier2)
 if bound_release_id == hist_release_id:
@@ -778,22 +873,26 @@ print("release-ledger accepts historical 2-feed rows and Tier-2-bound 3-feed row
 # catalog IS staged it is never a silent bystander -- it must authenticate.
 original_tier2_path = module.TIER2_CATALOG_PATH
 require_env = module.REQUIRE_TIER2_FOR_GENERATE_ENV
+staged_tier2_dir = pathlib.Path(tempfile.mkdtemp(prefix="tier2-test-staged-"))
+atexit.register(shutil.rmtree, staged_tier2_dir, ignore_errors=True)
 try:
-    module.TIER2_CATALOG_PATH = pathlib.Path(tempfile.mkdtemp()) / "tier2-catalog.json"
+    module.TIER2_CATALOG_PATH = staged_tier2_dir / "tier2-catalog.json"
 
     os.environ.pop(require_env, None)
-    absent_tier2, absent_obj = module.require_tier2_catalog_for_generate()
-    if absent_tier2 is not None or absent_obj is not None:
-        raise SystemExit("require_tier2_catalog_for_generate must return (None, None) when Tier-2 is optional and absent")
+    absent_tier2, absent_obj, absent_signer = module.require_tier2_catalog_for_generate()
+    if absent_tier2 is not None or absent_obj is not None or absent_signer is not None:
+        raise SystemExit("require_tier2_catalog_for_generate must return (None, None, None) when Tier-2 is optional and absent")
 
     os.environ[require_env] = "1"
     rejected(f"generate without tier2-catalog.json when {require_env}=1", module.require_tier2_catalog_for_generate)
     os.environ.pop(require_env, None)
 
     module.TIER2_CATALOG_PATH.write_bytes(agreeing_tier2)
-    returned_tier2, returned_obj = module.require_tier2_catalog_for_generate()
+    returned_tier2, returned_obj, returned_signer = module.require_tier2_catalog_for_generate()
     if returned_tier2 != agreeing_tier2 or returned_obj["catalog_id"] != "test-catalog-agree":
         raise SystemExit("require_tier2_catalog_for_generate did not round-trip the signed catalog")
+    if returned_signer != trusted_key_fingerprint:
+        raise SystemExit("require_tier2_catalog_for_generate did not return the authenticated signer fingerprint")
 
     module.TIER2_CATALOG_PATH.write_bytes(dummy_signed_tier2)
     rejected(
@@ -833,9 +932,14 @@ with tempfile.TemporaryDirectory() as directory:
 
     # A staged catalog that is structurally declared but forged/unauthenticated
     # must fail closed even though its bytes match the declared manifest digest.
+    # tier2_signer_key_id here is a fabricated claim (this manifest is built
+    # directly, bypassing verify_tier2_signature, to simulate a forged
+    # release.json); verify_directory must re-authenticate independently and
+    # reject regardless of what signer_key_id the manifest claims.
     forged_manifest = module.manifest(
         candidate_bytes, demand_bytes, candidate_obj, demand_obj,
         tier2=wrong_signer_tier2, tier2_obj=module.validate_tier2_catalog(wrong_signer_tier2),
+        tier2_signer_key_id="forged-claim-does-not-matter",
     )
     (release / "tier2-catalog.json").write_bytes(wrong_signer_tier2)
     (release / "release.json").write_bytes(forged_manifest)
@@ -843,6 +947,8 @@ with tempfile.TemporaryDirectory() as directory:
               lambda: module.verify_directory(release))
 
 print("verify-directory requires tier2-catalog.json to be a declared AND authenticated feed member")
+
+module.COORDINATOR_YAML_PATH = original_coordinator_yaml_path
 PY
 
 echo "PASS: catalog release generation and trust failures are locked"


### PR DESCRIPTION
## Summary
- Adds `tier2-catalog.json` as an optional third `release.json` / `release-ledger.json` feed member alongside `autotune-candidates.json` and `demand-rank.json` (`scripts/catalog-release.py`), closing prerequisite #2 from `audits/2026-07-22/PEARL_608_DUAL_CATALOG_CUTOVER_PREP.md`.
- **Historical-safe:** existing 2-feed `release-ledger.json` rows, and the canonical release state today (no `phase3-binary/catalog/autotune/tier2-catalog.json`), remain valid: `verify` still passes unchanged.
- **Forward-only requirement:** `generate` now requires a signed Tier-2 catalog at that path and fails closed if it is missing, structurally invalid, or conflicts with autotune identity (`check-tier2-binding`).
- `verify` and `verify-directory` run `check-tier2-binding` whenever a `tier2-catalog.json` is present, and now require it to be a declared `release.json` feed member (drift-checked), not just a bystander file next to the release.
- Extends `scripts/test-catalog-release.sh` with structural-validation, feed-membership, ledger-shape, and `generate`-gate coverage.
- Updates `ops/runbooks/catalog-release-provider-upgrade.md` to describe the new feed membership and mark the corresponding #608 follow-up item landed.

Not in scope / not changed: `derive-tier2` stays disabled; `tier2.require_hash_verified` is untouched; no Pearl apply/publish; no physical `/opt/macprovider/tier2-catalog.json` dual-file removal; #608 stays open (Partial).

## Test plan
- [x] `python3 scripts/catalog-release.py verify` (historical-safe, `tier2_catalog=absent(historical)`)
- [x] `bash scripts/test-catalog-release.sh` (extended suite, all green)
- [x] `make verify-autotune-catalog`
- [ ] CI green on this PR

## Remaining on #608 (do not execute from this PR)
- Resolve the live Llama-3.2 hash CONFLICT and publish a signed Tier-2 catalog through the reviewed deploy path
- Explicit Tier-2 `macprovider.snapshot-manifest.v1` `hash_scope` (re-enable `derive-tier2` only after)
- Promote Pearl coordinator binary carrying #682/#688 lineage
- Physical `/opt/macprovider/tier2-catalog.json` dual-file removal + Pearl journey proof
- #609 enforce flip (`tier2.require_hash_verified=true`) stays separate/out of scope

SPEC-GOVERNANCE-DECLARATION-BEGIN
{
  "schema_version": "spec-pr-governance-v1",
  "behavior_change": "yes",
  "contract_change": "none",
  "issue": "https://github.com/Augustas11/macprovider/issues/608",
  "specs": ["SPEC-010", "SPEC-008"],
  "requirements": ["SPEC-010-R004"],
  "authority_domains": ["model-catalog-identity", "tier2-trust-evidence"],
  "arbitration": ["CODE_BUG"],
  "tests": [
    "python3 scripts/catalog-release.py verify",
    "bash scripts/test-catalog-release.sh",
    "make verify-autotune-catalog"
  ],
  "journeys": ["not-required"]
}
SPEC-GOVERNANCE-DECLARATION-END
