### PR TITLE
Keep Pearl deploy preflight portable and fail-closed

### DIFF
--- a/phase4-coordinator/dist/deploy-pearl-vps.sh
+++ b/phase4-coordinator/dist/deploy-pearl-vps.sh
@@ -131,6 +131,33 @@ _validate_dns_name() {
 _validate_dns_name "$DOMAIN"        DOMAIN
 _validate_dns_name "${STATS_DOMAIN:-stats.streamvc.live}" STATS_DOMAIN
 
+_validate_catalog_canary_auth_token() {
+  local value="$1" length
+  length=${#value}
+  [ "$length" -ge 32 ] && [ "$length" -le 512 ] || return 1
+  case "$value" in
+    *[!A-Za-z0-9._~-]*) return 1 ;;
+  esac
+}
+
+_parse_model_hash_legacy_until() {
+  python3 -c '
+import shlex
+import sys
+
+raw = sys.argv[1].strip()
+if not raw:
+    sys.exit(0)
+try:
+    values = shlex.split(raw, comments=False, posix=True)
+except ValueError as exc:
+    raise SystemExit(f"invalid MODEL_HASH_LEGACY_UNTIL quoting: {exc}")
+if len(values) != 1:
+    raise SystemExit("MODEL_HASH_LEGACY_UNTIL must be a single scalar value")
+print(values[0], end="")
+' "$1"
+}
+
 # Email validator — RFC-conformant pre-validation is overkill; we just
 # need to reject metacharacters that would split a shell arg.
 if ! printf '%s' "$EMAIL" | grep -Eq '^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$'; then
@@ -143,7 +170,7 @@ if [ "$DRY_RUN_LOCAL" != "1" ]; then
     echo "  Select a provider expected to reconnect after restart; deployment commits only after pool admission." >&2
     exit 1
   fi
-  if ! printf '%s' "$CATALOG_CANARY_AUTH_TOKEN" | grep -Eq '^[A-Za-z0-9._~-]{32,512}$'; then
+  if ! _validate_catalog_canary_auth_token "$CATALOG_CANARY_AUTH_TOKEN"; then
     echo "aborting deploy: CATALOG_CANARY_AUTH_TOKEN is required and must be a safe 32-512 character bearer token" >&2
     exit 1
   fi
@@ -654,9 +681,13 @@ else
   # The deadline is not a secret, but it is operator-owned runtime state. Read
   # it as data from the same EnvironmentFile systemd uses; do not source the
   # file. The deploy gate validates syntax and freshness before any upload.
-  MODEL_HASH_LEGACY_UNTIL_FOR_GATE="$($SSH \
-    'if [ -r /etc/macprovider/coordinator.env ]; then sed -n "s/^[[:space:]]*MODEL_HASH_LEGACY_UNTIL=//p" /etc/macprovider/coordinator.env | tail -n 1 | sed "s/^[[:space:]]*[\"'\"']//; s/[\"'\"'][[:space:]]*$//"; fi')" || {
+  MODEL_HASH_LEGACY_UNTIL_RAW="$($SSH \
+    'if [ -r /etc/macprovider/coordinator.env ]; then sed -n "s/^[[:space:]]*MODEL_HASH_LEGACY_UNTIL=//p" /etc/macprovider/coordinator.env | tail -n 1; fi')" || {
     echo "aborting deploy: could not read MODEL_HASH_LEGACY_UNTIL from Pearl coordinator.env" >&2
+    exit 5
+  }
+  MODEL_HASH_LEGACY_UNTIL_FOR_GATE="$(_parse_model_hash_legacy_until "$MODEL_HASH_LEGACY_UNTIL_RAW")" || {
+    echo "aborting deploy: could not parse MODEL_HASH_LEGACY_UNTIL from Pearl coordinator.env" >&2
     exit 5
   }
   env MODEL_HASH_LEGACY_UNTIL="$MODEL_HASH_LEGACY_UNTIL_FOR_GATE" \
@@ -1798,7 +1829,7 @@ BEGIN
            FROM unnest(c.conkey) WITH ORDINALITY AS k(attnum, ord)
            JOIN pg_attribute a
              ON a.attrelid = c.conrelid AND a.attnum = k.attnum
-       ) = ARRAY['provider_id', 'hardware_identity_hash', 'source']
+       ) = ARRAY['provider_id', 'hardware_identity_hash', 'source']::name[]
   ) THEN
     RAISE EXCEPTION 'hardware_verification_trust PRIMARY KEY is not (provider_id, hardware_identity_hash, source) (migration 019 not applied)';
   END IF;

--- a/phase4-coordinator/dist/test/check_deploy_static_feed_access.test.sh
+++ b/phase4-coordinator/dist/test/check_deploy_static_feed_access.test.sh
@@ -171,6 +171,57 @@ grep -q 'CATALOG_CANARY_PROVIDER_ID is required' "$DEPLOY_SH" ||
 grep -q 'CATALOG_CANARY_AUTH_TOKEN is required' "$DEPLOY_SH" ||
   fail "deploy must require authenticated canary evidence"
 
+token_validator_tmp="$(mktemp)"
+trap 'rm -f "$token_validator_tmp"' EXIT
+awk '/^_validate_catalog_canary_auth_token\(\) \{/{f=1} f{print} f&&/^\}$/{exit}' "$DEPLOY_SH" > "$token_validator_tmp"
+grep -qF '_validate_catalog_canary_auth_token()' "$token_validator_tmp" ||
+  fail "deploy must keep an extractable portable canary token validator"
+# BSD grep rejects interval upper bounds greater than 255. Length checks belong
+# in Bash so the production deploy remains portable on the operator Mac.
+if grep -qF '{32,512}' "$DEPLOY_SH"; then
+  fail "deploy must not use a BSD-grep-incompatible {32,512} interval"
+fi
+# shellcheck disable=SC1090
+. "$token_validator_tmp"
+token_31="$(printf '%031d' 0)"
+token_32="$(printf '%032d' 0)"
+token_512="$(printf '%0512d' 0)"
+token_513="$(printf '%0513d' 0)"
+! _validate_catalog_canary_auth_token "$token_31" ||
+  fail "canary token validator must reject 31-byte tokens"
+_validate_catalog_canary_auth_token "$token_32" ||
+  fail "canary token validator must accept safe 32-byte tokens"
+_validate_catalog_canary_auth_token "$token_512" ||
+  fail "canary token validator must accept safe 512-byte tokens"
+! _validate_catalog_canary_auth_token "$token_513" ||
+  fail "canary token validator must reject 513-byte tokens"
+! _validate_catalog_canary_auth_token "${token_32}!" ||
+  fail "canary token validator must reject unsafe characters"
+! _validate_catalog_canary_auth_token "${token_32}"$'\n''url = "https://attacker.invalid/"' ||
+  fail "canary token validator must reject newline curl-config injection"
+! _validate_catalog_canary_auth_token "${token_32}"$'\r''header = "X-Injected: yes"' ||
+  fail "canary token validator must reject carriage-return curl-config injection"
+
+deadline_parser_tmp="$(mktemp)"
+trap 'rm -f "$token_validator_tmp" "$deadline_parser_tmp"' EXIT
+awk '/^_parse_model_hash_legacy_until\(\) \{/{f=1} f{print} f&&/^\}$/{exit}' "$DEPLOY_SH" > "$deadline_parser_tmp"
+grep -qF '_parse_model_hash_legacy_until()' "$deadline_parser_tmp" ||
+  fail "deploy must keep an extractable MODEL_HASH_LEGACY_UNTIL parser"
+# shellcheck disable=SC1090
+. "$deadline_parser_tmp"
+deadline='2030-01-02T03:04:05Z'
+[ "$(_parse_model_hash_legacy_until "  $deadline  ")" = "$deadline" ] ||
+  fail "legacy deadline parser must accept an unquoted scalar"
+[ "$(_parse_model_hash_legacy_until "  \"$deadline\"  ")" = "$deadline" ] ||
+  fail "legacy deadline parser must strip matching double quotes"
+[ "$(_parse_model_hash_legacy_until "  '$deadline'  ")" = "$deadline" ] ||
+  fail "legacy deadline parser must strip matching single quotes"
+[ -z "$(_parse_model_hash_legacy_until '   ')" ] ||
+  fail "legacy deadline parser must preserve an absent deadline as empty"
+if _parse_model_hash_legacy_until '2030-01-02T03:04:05Z trailing' >/dev/null 2>&1; then
+  fail "legacy deadline parser must reject multiple scalar tokens"
+fi
+
 grep -q 'CATALOG_CANARY_SSH_TARGET is required' "$DEPLOY_SH" ||
   fail "deploy must require a trusted canary host for exact installed-byte verification"
 

--- a/phase4-coordinator/dist/test/check_stats_inventory_deploy_test.sh
+++ b/phase4-coordinator/dist/test/check_stats_inventory_deploy_test.sh
@@ -526,8 +526,16 @@ gate_run_dir="$(mktemp -d)"
 gate_stub_bin="$gate_run_dir/bin"
 trap 'rm -rf "$remote_preflight_tmp" "$parser_tmp" "$env_parse_tmp" "$gate_heredoc_tmp" "$gate_parser_tmp" "$gate_env_tmp" "$gate_run_dir"' EXIT
 mkdir -p "$gate_stub_bin"
-# Stub psql: for the fixtures that reach it (declared + DSN present), 019 is "present".
-printf '%s\n' '#!/usr/bin/env bash' 'exit 0' > "$gate_stub_bin/psql"
+# Stub psql: for fixtures that reach it, verify the exact type-safe primary-key
+# assertion before treating migration 019 as present. PostgreSQL returns name[]
+# from array_agg(pg_attribute.attname); comparing it with an uncast text[]
+# literal aborts a healthy production deploy before the release snapshot.
+cat > "$gate_stub_bin/psql" <<'STUB_PSQL'
+#!/usr/bin/env bash
+set -euo pipefail
+sql="$(cat)"
+grep -qF ") = ARRAY['provider_id', 'hardware_identity_hash', 'source']::name[]" <<<"$sql"
+STUB_PSQL
 chmod +x "$gate_stub_bin/psql"
 
 run_gate_fixture() {


### PR DESCRIPTION
## Why

The sealed Pearl Step A catalog apply exposed three pre-mutation portability/type failures in the reviewed deploy path: BSD grep rejected the bearer-token interval, quoted systemd environment data was trimmed unsafely, and PostgreSQL compared `name[]` migration metadata to an uncast `text[]`.

## What

- validate the canary bearer token with whole-string Bash length/character checks, including CR/LF curl-config injection rejection
- parse `MODEL_HASH_LEGACY_UNTIL` as one shlex scalar without evaluating it
- cast the migration-019 expected primary-key array to `name[]`
- lock all three production failures with behavioral regressions

## Verification

- `bash -n` on changed shell files
- `check_deploy_static_feed_access.test.sh`
- `check_stats_inventory_deploy_test.sh`
- broader non-live dist deploy suite
- Codex code audit: 0 CRITICAL / 0 HIGH / 0 MEDIUM
- Codex security audit: 0 CRITICAL / 0 HIGH / 0 MEDIUM
- Codex architecture audit: 0 CRITICAL / 0 HIGH / 0 MEDIUM

Part of #608. No Pearl catalog bytes were mutated by the failed preflight attempts.

SPEC-GOVERNANCE-DECLARATION-BEGIN
{
  "schema_version": "spec-pr-governance-v1",
  "behavior_change": "yes",
  "contract_change": "none",
  "issue": "https://github.com/Augustas11/macprovider/issues/608",
  "specs": ["SPEC-010", "SPEC-008"],
  "requirements": ["SPEC-010-R004"],
  "authority_domains": ["model-catalog-identity", "tier2-trust-evidence"],
  "arbitration": ["CODE_BUG"],
  "tests": [
    "bash phase4-coordinator/dist/test/check_deploy_static_feed_access.test.sh",
    "bash phase4-coordinator/dist/test/check_stats_inventory_deploy_test.sh"
  ],
  "journeys": ["not-required"]
}
SPEC-GOVERNANCE-DECLARATION-END