### PR TITLE
Keep Pearl catalog proof aligned through provider recovery

### DIFF
--- a/phase4-coordinator/dist/deploy-pearl-vps.sh
+++ b/phase4-coordinator/dist/deploy-pearl-vps.sh
@@ -2822,13 +2822,14 @@ CANARY_SSH=(
   -o ServerAliveCountMax=3
   "$CATALOG_CANARY_SSH_TARGET"
 )
-if ! "${CANARY_SSH[@]}" python3 - \
+run_catalog_canary_mac_proof() {
+  "${CANARY_SSH[@]}" python3 - \
   "$CATALOG_CANARY_INSTALL_DIR" \
   "$CATALOG_CANARY_PROVIDER_ID" \
   "$AUTOTUNE_RELEASE_ID" \
   "$AUTOTUNE_POLICY_VERSION" \
   "$AUTOTUNE_CANDIDATE_SHA256" \
-  "$AUTOTUNE_CANDIDATE_SIGNER_KEY_ID" > "$CANARY_INSTALLED_BODY" <<'PY'
+  "$AUTOTUNE_CANDIDATE_SIGNER_KEY_ID" <<'PY'
 import hashlib, json, os, plistlib, re, stat, subprocess, sys, urllib.request
 
 (
@@ -3052,13 +3053,25 @@ finally:
         if fd is not None:
             os.close(fd)
 PY
-then
-  echo "SPEC-023 canary failed: could not read exact installed catalog bytes from $CATALOG_CANARY_SSH_TARGET" >&2
-  exit 1
-fi
+}
 
-# Bind coordinator admission to the exact session observed on the proved Mac.
-read -r CANARY_ASSIGNED_ID CANARY_CATALOG_ROW_IDENTITY < <(python3 - "$CANARY_INSTALLED_BODY" <<'PY'
+# A coordinator restart can make a healthy provider rotate its PID and assigned
+# session while its recovery watchdog drains in-flight work. Retry the complete
+# Mac proof and bind each admission query to the session from that same attempt;
+# never carry an assigned_id across retries. This mirrors the signed updater's
+# full-proof retry and keeps every success predicate fail-closed.
+CANARY_PROVIDER_QUERY=$(python3 -c 'import sys, urllib.parse; print(urllib.parse.quote(sys.argv[1], safe=""))' "$CATALOG_CANARY_PROVIDER_ID")
+(umask 077 && printf 'header = "Authorization: Bearer %s"\n' "$CATALOG_CANARY_AUTH_TOKEN" > "$CANARY_CURL_CONFIG")
+CANARY_OK=0
+CANARY_LAST_ERROR="canary proof did not start"
+CANARY_STATUS="000"
+CANARY_ATTEMPT=1
+CANARY_MAX_ATTEMPTS=36
+while [ "$CANARY_ATTEMPT" -le "$CANARY_MAX_ATTEMPTS" ]; do
+  rm -f "$CANARY_INSTALLED_BODY" "$CANARY_POOL_BODY"
+  CANARY_PROOF_ERROR="$STATIC_SMOKE_DIR/catalog-canary-proof.err"
+  if run_catalog_canary_mac_proof > "$CANARY_INSTALLED_BODY" 2> "$CANARY_PROOF_ERROR"; then
+    CANARY_BINDING=$(python3 - "$CANARY_INSTALLED_BODY" <<'PY'
 import json, pathlib, re, sys
 proof = json.loads(pathlib.Path(sys.argv[1]).read_text(encoding="utf-8"))
 assigned_id = proof.get("assigned_id")
@@ -3069,21 +3082,16 @@ if re.fullmatch(r"[0-9a-f]{64}", str(row_identity).lower()) is None:
     raise SystemExit("canary proof has no exact catalog row identity")
 print(assigned_id, str(row_identity).lower())
 PY
-) || {
-  echo "SPEC-023 canary failed: could not bind the live Mac session and catalog row" >&2
-  exit 1
-}
-CANARY_PROVIDER_QUERY=$(python3 -c 'import sys, urllib.parse; print(urllib.parse.quote(sys.argv[1], safe=""))' "$CATALOG_CANARY_PROVIDER_ID")
-CANARY_ASSIGNED_QUERY=$(python3 -c 'import sys, urllib.parse; print(urllib.parse.quote(sys.argv[1], safe=""))' "$CANARY_ASSIGNED_ID")
-(umask 077 && printf 'header = "Authorization: Bearer %s"\n' "$CATALOG_CANARY_AUTH_TOKEN" > "$CANARY_CURL_CONFIG")
-CANARY_OK=0
-for CANARY_ATTEMPT in 1 2 3 4 5 6 7 8 9 10 11 12; do
-  STATUS=$(curl --config "$CANARY_CURL_CONFIG" -sS -o "$CANARY_POOL_BODY" -w '%{http_code}' --max-time 10 --max-filesize 65536 \
-    "https://$DOMAIN/v1/pool/check?provider_id=$CANARY_PROVIDER_QUERY&assigned_id=$CANARY_ASSIGNED_QUERY&details=deployment" || true)
-  if [ "$STATUS" = "200" ] && python3 - \
-    "$CANARY_POOL_BODY" "$CATALOG_CANARY_PROVIDER_ID" "$CANARY_ASSIGNED_ID" \
-    "$AUTOTUNE_RELEASE_ID" "$AUTOTUNE_POLICY_VERSION" "$AUTOTUNE_CANDIDATE_SHA256" \
-    "$AUTOTUNE_CANDIDATE_SIGNER_KEY_ID" "$CANARY_CATALOG_ROW_IDENTITY" <<'PY'
+) || CANARY_BINDING=""
+    if [ -n "$CANARY_BINDING" ]; then
+      read -r CANARY_ASSIGNED_ID CANARY_CATALOG_ROW_IDENTITY <<< "$CANARY_BINDING"
+      CANARY_ASSIGNED_QUERY=$(python3 -c 'import sys, urllib.parse; print(urllib.parse.quote(sys.argv[1], safe=""))' "$CANARY_ASSIGNED_ID")
+      CANARY_STATUS=$(curl --config "$CANARY_CURL_CONFIG" -sS -o "$CANARY_POOL_BODY" -w '%{http_code}' --max-time 10 --max-filesize 65536 \
+        "https://$DOMAIN/v1/pool/check?provider_id=$CANARY_PROVIDER_QUERY&assigned_id=$CANARY_ASSIGNED_QUERY&details=deployment" || true)
+      if [ "$CANARY_STATUS" = "200" ] && python3 - \
+        "$CANARY_POOL_BODY" "$CATALOG_CANARY_PROVIDER_ID" "$CANARY_ASSIGNED_ID" \
+        "$AUTOTUNE_RELEASE_ID" "$AUTOTUNE_POLICY_VERSION" "$AUTOTUNE_CANDIDATE_SHA256" \
+        "$AUTOTUNE_CANDIDATE_SIGNER_KEY_ID" "$CANARY_CATALOG_ROW_IDENTITY" <<'PY'
 import json, sys
 value = json.load(open(sys.argv[1], encoding="utf-8"))
 if (
@@ -3100,16 +3108,28 @@ if (
 ):
     raise SystemExit(1)
 PY
-  then
-    CANARY_OK=1
-    break
+      then
+        CANARY_OK=1
+        break
+      fi
+      CANARY_LAST_ERROR="exact session $CANARY_ASSIGNED_ID was not buyer-serving (status=$CANARY_STATUS)"
+    else
+      CANARY_LAST_ERROR="could not bind the live Mac session and catalog row"
+    fi
+  else
+    CANARY_LAST_ERROR=$(tail -n 1 "$CANARY_PROOF_ERROR" 2>/dev/null || true)
+    [ -n "$CANARY_LAST_ERROR" ] || CANARY_LAST_ERROR="trusted Mac proof failed without diagnostics"
   fi
-  sleep 5
+  if [ "$CANARY_ATTEMPT" -lt "$CANARY_MAX_ATTEMPTS" ]; then
+    echo "  waiting for exact catalog canary recovery ($CANARY_ATTEMPT/$CANARY_MAX_ATTEMPTS): $CANARY_LAST_ERROR" >&2
+    sleep 5
+  fi
+  CANARY_ATTEMPT=$((CANARY_ATTEMPT + 1))
 done
 rm -f "$CANARY_CURL_CONFIG"
 if [ "$CANARY_OK" != "1" ]; then
-  echo "SPEC-023 canary failed: exact session $CANARY_ASSIGNED_ID did not return buyer-serving admission" >&2
-  echo "  last status=$STATUS body=$(head -c 300 "$CANARY_POOL_BODY" 2>/dev/null || true)" >&2
+  echo "SPEC-023 canary failed after $CANARY_MAX_ATTEMPTS full proof attempts: $CANARY_LAST_ERROR" >&2
+  echo "  last status=$CANARY_STATUS body=$(head -c 300 "$CANARY_POOL_BODY" 2>/dev/null || true)" >&2
   exit 1
 fi
 

--- a/phase4-coordinator/dist/deploy-pearl-vps.sh
+++ b/phase4-coordinator/dist/deploy-pearl-vps.sh
@@ -140,6 +140,22 @@ _validate_catalog_canary_auth_token() {
   esac
 }
 
+_run_with_deadline_alarm() {
+  local timeout_s="$1"
+  shift
+  python3 -c '
+import os
+import signal
+import sys
+
+timeout_s = int(sys.argv[1])
+if timeout_s < 1:
+    raise SystemExit("deadline must be at least one second")
+signal.alarm(timeout_s)
+os.execvp(sys.argv[2], sys.argv[2:])
+' "$timeout_s" "$@"
+}
+
 _parse_model_hash_legacy_until() {
   python3 -c '
 import shlex
@@ -2823,7 +2839,8 @@ CANARY_SSH=(
   "$CATALOG_CANARY_SSH_TARGET"
 )
 run_catalog_canary_mac_proof() {
-  "${CANARY_SSH[@]}" python3 - \
+  local timeout_s="$1"
+  _run_with_deadline_alarm "$timeout_s" "${CANARY_SSH[@]}" python3 - \
   "$CATALOG_CANARY_INSTALL_DIR" \
   "$CATALOG_CANARY_PROVIDER_ID" \
   "$AUTOTUNE_RELEASE_ID" \
@@ -2842,6 +2859,7 @@ import hashlib, json, os, plistlib, re, stat, subprocess, sys, urllib.request
 ) = sys.argv[1:]
 home = os.path.expanduser("~")
 nofollow = getattr(os, "O_NOFOLLOW", 0)
+nonblock = getattr(os, "O_NONBLOCK", 0)
 directory_flags = os.O_RDONLY | os.O_DIRECTORY | nofollow
 
 def open_dir(path):
@@ -2864,7 +2882,7 @@ def open_dir(path):
         raise
 
 def read_regular_at(directory_fd, name, limit, require_owner=True):
-    fd = os.open(name, os.O_RDONLY | nofollow, dir_fd=directory_fd)
+    fd = os.open(name, os.O_RDONLY | nofollow | nonblock, dir_fd=directory_fd)
     try:
         info = os.fstat(fd)
         if not stat.S_ISREG(info.st_mode):
@@ -2958,7 +2976,9 @@ try:
     if not isinstance(arguments, list) or len(arguments) < 4 or arguments[1:3] != ["serve", "--config"]:
         raise SystemExit("canary provider LaunchAgent has unexpected ProgramArguments")
 
-    binary_fd = os.open("macprovider-cli", os.O_RDONLY | nofollow, dir_fd=install_fd)
+    binary_fd = os.open(
+        "macprovider-cli", os.O_RDONLY | nofollow | nonblock, dir_fd=install_fd
+    )
     binary_info = os.fstat(binary_fd)
     if not stat.S_ISREG(binary_info.st_mode) or binary_info.st_uid != os.getuid() or binary_info.st_mode & 0o111 == 0:
         raise SystemExit("canary installation binary is not a safe executable")
@@ -3067,10 +3087,17 @@ CANARY_LAST_ERROR="canary proof did not start"
 CANARY_STATUS="000"
 CANARY_ATTEMPT=1
 CANARY_MAX_ATTEMPTS=36
-while [ "$CANARY_ATTEMPT" -le "$CANARY_MAX_ATTEMPTS" ]; do
+CANARY_RECOVERY_TIMEOUT_S=180
+CANARY_RECOVERY_DEADLINE=$((SECONDS + CANARY_RECOVERY_TIMEOUT_S))
+while [ "$CANARY_ATTEMPT" -le "$CANARY_MAX_ATTEMPTS" ] && [ "$SECONDS" -lt "$CANARY_RECOVERY_DEADLINE" ]; do
   rm -f "$CANARY_INSTALLED_BODY" "$CANARY_POOL_BODY"
   CANARY_PROOF_ERROR="$STATIC_SMOKE_DIR/catalog-canary-proof.err"
-  if run_catalog_canary_mac_proof > "$CANARY_INSTALLED_BODY" 2> "$CANARY_PROOF_ERROR"; then
+  CANARY_REMAINING_S=$((CANARY_RECOVERY_DEADLINE - SECONDS))
+  CANARY_PROOF_TIMEOUT_S=45
+  if [ "$CANARY_REMAINING_S" -lt "$CANARY_PROOF_TIMEOUT_S" ]; then
+    CANARY_PROOF_TIMEOUT_S="$CANARY_REMAINING_S"
+  fi
+  if run_catalog_canary_mac_proof "$CANARY_PROOF_TIMEOUT_S" > "$CANARY_INSTALLED_BODY" 2> "$CANARY_PROOF_ERROR"; then
     CANARY_BINDING=$(python3 - "$CANARY_INSTALLED_BODY" <<'PY'
 import json, pathlib, re, sys
 proof = json.loads(pathlib.Path(sys.argv[1]).read_text(encoding="utf-8"))
@@ -3117,18 +3144,23 @@ PY
       CANARY_LAST_ERROR="could not bind the live Mac session and catalog row"
     fi
   else
-    CANARY_LAST_ERROR=$(tail -n 1 "$CANARY_PROOF_ERROR" 2>/dev/null || true)
-    [ -n "$CANARY_LAST_ERROR" ] || CANARY_LAST_ERROR="trusted Mac proof failed without diagnostics"
+    CANARY_PROOF_RC=$?
+    CANARY_LAST_ERROR="trusted Mac proof failed (exit=$CANARY_PROOF_RC)"
   fi
-  if [ "$CANARY_ATTEMPT" -lt "$CANARY_MAX_ATTEMPTS" ]; then
+  CANARY_REMAINING_S=$((CANARY_RECOVERY_DEADLINE - SECONDS))
+  if [ "$CANARY_ATTEMPT" -lt "$CANARY_MAX_ATTEMPTS" ] && [ "$CANARY_REMAINING_S" -gt 0 ]; then
     echo "  waiting for exact catalog canary recovery ($CANARY_ATTEMPT/$CANARY_MAX_ATTEMPTS): $CANARY_LAST_ERROR" >&2
-    sleep 5
+    CANARY_SLEEP_S=5
+    if [ "$CANARY_REMAINING_S" -lt "$CANARY_SLEEP_S" ]; then
+      CANARY_SLEEP_S="$CANARY_REMAINING_S"
+    fi
+    sleep "$CANARY_SLEEP_S"
   fi
   CANARY_ATTEMPT=$((CANARY_ATTEMPT + 1))
 done
 rm -f "$CANARY_CURL_CONFIG"
 if [ "$CANARY_OK" != "1" ]; then
-  echo "SPEC-023 canary failed after $CANARY_MAX_ATTEMPTS full proof attempts: $CANARY_LAST_ERROR" >&2
+  echo "SPEC-023 canary failed after $((CANARY_ATTEMPT - 1)) full proof attempts within ${CANARY_RECOVERY_TIMEOUT_S}s: $CANARY_LAST_ERROR" >&2
   echo "  last status=$CANARY_STATUS body=$(head -c 300 "$CANARY_POOL_BODY" 2>/dev/null || true)" >&2
   exit 1
 fi

--- a/phase4-coordinator/dist/test/canary_text_vnode_proof_test.py
+++ b/phase4-coordinator/dist/test/canary_text_vnode_proof_test.py
@@ -31,7 +31,7 @@ def load_vnode_function(path: pathlib.Path, source: str):
 
 deploy_text = deploy.read_text(encoding="utf-8")
 start = deploy_text.index("import hashlib, json, os, plistlib, re, stat, subprocess, sys, urllib.request")
-end = deploy_text.index("\nPY\nthen", start)
+end = deploy_text.index("\nPY\n}", start)
 implementations = (
     load_vnode_function(deploy, deploy_text[start:end]),
     load_vnode_function(pearl_proof, pearl_proof.read_text(encoding="utf-8")),

--- a/phase4-coordinator/dist/test/check_deploy_static_feed_access.test.sh
+++ b/phase4-coordinator/dist/test/check_deploy_static_feed_access.test.sh
@@ -211,8 +211,24 @@ _validate_catalog_canary_auth_token "$token_512" ||
 ! _validate_catalog_canary_auth_token "${token_32}"$'\r''header = "X-Injected: yes"' ||
   fail "canary token validator must reject carriage-return curl-config injection"
 
+deadline_alarm_tmp="$(mktemp)"
+trap 'rm -f "$token_validator_tmp" "$deadline_alarm_tmp"' EXIT
+awk '/^_run_with_deadline_alarm\(\) \{/{f=1} f{print} f&&/^\}$/{exit}' "$DEPLOY_SH" > "$deadline_alarm_tmp"
+grep -qF '_run_with_deadline_alarm()' "$deadline_alarm_tmp" ||
+  fail "deploy must keep an extractable subprocess deadline helper"
+# shellcheck disable=SC1090
+. "$deadline_alarm_tmp"
+deadline_start="$SECONDS"
+if _run_with_deadline_alarm 1 sh -c 'sleep 30'; then
+  fail "subprocess deadline helper must terminate a hung command"
+fi
+[ "$((SECONDS - deadline_start))" -lt 5 ] ||
+  fail "subprocess deadline helper did not enforce its wall-clock bound"
+_run_with_deadline_alarm 2 sh -c 'exit 0' ||
+  fail "subprocess deadline helper must preserve successful commands"
+
 deadline_parser_tmp="$(mktemp)"
-trap 'rm -f "$token_validator_tmp" "$deadline_parser_tmp"' EXIT
+trap 'rm -f "$token_validator_tmp" "$deadline_alarm_tmp" "$deadline_parser_tmp"' EXIT
 awk '/^_parse_model_hash_legacy_until\(\) \{/{f=1} f{print} f&&/^\}$/{exit}' "$DEPLOY_SH" > "$deadline_parser_tmp"
 grep -qF '_parse_model_hash_legacy_until()' "$deadline_parser_tmp" ||
   fail "deploy must keep an extractable MODEL_HASH_LEGACY_UNTIL parser"
@@ -243,17 +259,21 @@ grep -q 'StrictHostKeyChecking=yes' "$DEPLOY_SH" ||
 grep -q 'assigned_id=\$CANARY_ASSIGNED_QUERY&details=deployment' "$DEPLOY_SH" ||
   fail "deploy must gate completion on the exact proved provider session"
 
-proof_retry_line=$(grep -nF 'if run_catalog_canary_mac_proof > "$CANARY_INSTALLED_BODY"' "$DEPLOY_SH" | head -n1 | cut -d: -f1)
+proof_retry_line=$(grep -nF 'if run_catalog_canary_mac_proof "$CANARY_PROOF_TIMEOUT_S" > "$CANARY_INSTALLED_BODY"' "$DEPLOY_SH" | head -n1 | cut -d: -f1)
 session_rebind_line=$(grep -nF 'read -r CANARY_ASSIGNED_ID CANARY_CATALOG_ROW_IDENTITY <<< "$CANARY_BINDING"' "$DEPLOY_SH" | head -n1 | cut -d: -f1)
 session_query_line=$(grep -nF 'CANARY_STATUS=$(curl --config "$CANARY_CURL_CONFIG"' "$DEPLOY_SH" | head -n1 | cut -d: -f1)
 [ -n "$proof_retry_line" ] && [ -n "$session_rebind_line" ] && [ -n "$session_query_line" ] &&
   [ "$proof_retry_line" -lt "$session_rebind_line" ] && [ "$session_rebind_line" -lt "$session_query_line" ] ||
   fail "each canary recovery attempt must re-prove the Mac and bind the query to that attempt's session"
 
-grep -q 'CANARY_MAX_ATTEMPTS=36' "$DEPLOY_SH" &&
+grep -q 'CANARY_RECOVERY_DEADLINE=' "$DEPLOY_SH" &&
+  grep -q '_run_with_deadline_alarm "$timeout_s" "${CANARY_SSH\[@\]}"' "$DEPLOY_SH" &&
   grep -q 'rm -f "$CANARY_INSTALLED_BODY" "$CANARY_POOL_BODY"' "$DEPLOY_SH" &&
   grep -q 'waiting for exact catalog canary recovery' "$DEPLOY_SH" ||
-  fail "deploy must retry full canary proof with a bounded window and discard stale attempt output"
+  fail "deploy must retry full canary proof within a wall-clock deadline and discard stale attempt output"
+
+grep -q 'os.O_RDONLY | nofollow | nonblock' "$DEPLOY_SH" ||
+  fail "Mac proof must open untrusted file entries without blocking on special files"
 
 grep -q 'value.get("assigned_id") != sys.argv\[3\]' "$DEPLOY_SH" ||
   fail "deploy must reject coordinator evidence for a different assigned session"

--- a/phase4-coordinator/dist/test/check_deploy_static_feed_access.test.sh
+++ b/phase4-coordinator/dist/test/check_deploy_static_feed_access.test.sh
@@ -243,6 +243,18 @@ grep -q 'StrictHostKeyChecking=yes' "$DEPLOY_SH" ||
 grep -q 'assigned_id=\$CANARY_ASSIGNED_QUERY&details=deployment' "$DEPLOY_SH" ||
   fail "deploy must gate completion on the exact proved provider session"
 
+proof_retry_line=$(grep -nF 'if run_catalog_canary_mac_proof > "$CANARY_INSTALLED_BODY"' "$DEPLOY_SH" | head -n1 | cut -d: -f1)
+session_rebind_line=$(grep -nF 'read -r CANARY_ASSIGNED_ID CANARY_CATALOG_ROW_IDENTITY <<< "$CANARY_BINDING"' "$DEPLOY_SH" | head -n1 | cut -d: -f1)
+session_query_line=$(grep -nF 'CANARY_STATUS=$(curl --config "$CANARY_CURL_CONFIG"' "$DEPLOY_SH" | head -n1 | cut -d: -f1)
+[ -n "$proof_retry_line" ] && [ -n "$session_rebind_line" ] && [ -n "$session_query_line" ] &&
+  [ "$proof_retry_line" -lt "$session_rebind_line" ] && [ "$session_rebind_line" -lt "$session_query_line" ] ||
+  fail "each canary recovery attempt must re-prove the Mac and bind the query to that attempt's session"
+
+grep -q 'CANARY_MAX_ATTEMPTS=36' "$DEPLOY_SH" &&
+  grep -q 'rm -f "$CANARY_INSTALLED_BODY" "$CANARY_POOL_BODY"' "$DEPLOY_SH" &&
+  grep -q 'waiting for exact catalog canary recovery' "$DEPLOY_SH" ||
+  fail "deploy must retry full canary proof with a bounded window and discard stale attempt output"
+
 grep -q 'value.get("assigned_id") != sys.argv\[3\]' "$DEPLOY_SH" ||
   fail "deploy must reject coordinator evidence for a different assigned session"
 


### PR DESCRIPTION
Part of #608.

Pearl Step B production activation twice proved the three-feed release and started cleanly, then correctly rolled back because the selected Mac canary entered its restart-driven watchdog drain before the one-shot local proof. This patch retries the complete Mac proof and coordinator admission query together. Every attempt discards stale output and rebinds the current PID/listener/assigned session/catalog row/exact seven-file hash set. The retry is bounded by a 180-second wall-clock deadline, each SSH proof is hard-terminated at its remaining budget, and untrusted remote file opens are nonblocking before regular-file validation.

Scope guards:
- no Tier-2 enforcement flip (tier2.require_hash_verified remains false)
- no canary timer/service enablement
- no dual-file removal or exception clearance
- no weakening of PID, text-vnode, buyer-serving, signature, row identity, or exact-byte predicates

Validation:
- bash syntax
- targeted deploy/static canary regressions
- Mac text-vnode proof
- make test-dist

Independent audits on exact commit b6e6be27738de28a52178504b3a6eac2d70325a2:
- code: 0 CRITICAL / 0 HIGH / 0 MEDIUM / 0 LOW
- security: 0 CRITICAL / 0 HIGH / 0 MEDIUM / 0 LOW
- architecture: 0 CRITICAL / 0 HIGH / 0 MEDIUM / 0 LOW

Governance: production deploy tooling change; requires green required CI, antfleet-ops approval on exact head, and Augustas11 squash merge.

SPEC-GOVERNANCE-DECLARATION-BEGIN
{
  "schema_version": "spec-pr-governance-v1",
  "behavior_change": "yes",
  "contract_change": "none",
  "issue": "https://github.com/Augustas11/macprovider/issues/608",
  "specs": ["SPEC-010", "SPEC-008"],
  "requirements": ["SPEC-010-R004"],
  "authority_domains": ["model-catalog-identity", "tier2-trust-evidence"],
  "arbitration": ["CODE_BUG"],
  "tests": ["make test-dist", "bash phase4-coordinator/dist/test/check_deploy_static_feed_access.test.sh", "python3 phase4-coordinator/dist/test/canary_text_vnode_proof_test.py"],
  "journeys": ["not-required"]
}
SPEC-GOVERNANCE-DECLARATION-END