### PR TITLE
Keep Pearl release builds aligned with the coordinator toolchain

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -103,7 +103,7 @@ jobs:
         # without CGO and carried as unsigned inputs into the protected signer.
         uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16
         with:
-          go-version: "1.26.4"
+          go-version-file: phase4-coordinator/go.mod
           cache-dependency-path: |
             phase4-coordinator/go.sum
             phase5-gateway/go.sum
@@ -116,18 +116,18 @@ jobs:
           (
             cd phase4-coordinator
             GOTOOLCHAIN=local CGO_ENABLED=0 GOOS=linux GOARCH=amd64 \
-              go build -mod=readonly -trimpath \
+              go build -mod=readonly -trimpath -buildvcs=true \
               -ldflags "-s -w -X main.version=$tag" \
               -o "$RUNNER_TEMP/coordinator-linux-amd64" ./cmd/coordinator
             GOTOOLCHAIN=local CGO_ENABLED=0 GOOS=linux GOARCH=amd64 \
-              go build -mod=readonly -trimpath \
+              go build -mod=readonly -trimpath -buildvcs=true \
               -ldflags "-s -w" \
               -o "$RUNNER_TEMP/coordinator-cli-linux-amd64" ./cmd/coordinator-cli
           )
           (
             cd phase5-gateway
             GOTOOLCHAIN=local CGO_ENABLED=0 GOOS=linux GOARCH=amd64 \
-              go build -mod=readonly -trimpath \
+              go build -mod=readonly -trimpath -buildvcs=true \
               -ldflags "-s -w -X main.version=$tag" \
               -o "$RUNNER_TEMP/gateway-linux-amd64" ./cmd/gateway
           )
@@ -138,11 +138,6 @@ jobs:
           grep -Eq "coordinator-linux-amd64:[[:space:]]+ELF 64-bit.*x86-64" pearl-file.txt
           grep -Eq "coordinator-cli-linux-amd64:[[:space:]]+ELF 64-bit.*x86-64" pearl-file.txt
           grep -Eq "gateway-linux-amd64:[[:space:]]+ELF 64-bit.*x86-64" pearl-file.txt
-          for binary in coordinator-linux-amd64 coordinator-cli-linux-amd64 gateway-linux-amd64; do
-            go version -m "$RUNNER_TEMP/$binary" > "$RUNNER_TEMP/$binary.buildinfo"
-            grep -Fq 'GOOS=linux' "$RUNNER_TEMP/$binary.buildinfo"
-            grep -Fq 'GOARCH=amd64' "$RUNNER_TEMP/$binary.buildinfo"
-          done
           strings "$RUNNER_TEMP/coordinator-linux-amd64" > "$RUNNER_TEMP/coordinator-linux-amd64.strings"
           strings "$RUNNER_TEMP/gateway-linux-amd64" > "$RUNNER_TEMP/gateway-linux-amd64.strings"
           grep -Fq "$tag" "$RUNNER_TEMP/coordinator-linux-amd64.strings"
@@ -219,6 +214,16 @@ jobs:
             unsigned-release-inputs/release-toolchain.json \
             unsigned-release-inputs/unsigned-release-manifest.json \
             "${unsigned_assets[@]}"
+
+      - name: Verify staged Pearl Go binaries
+        env:
+          EXPECTED_REVISION: ${{ steps.release_source.outputs.commit }}
+        shell: bash
+        run: |
+          python3 scripts/verify-pearl-go-binaries.py \
+            unsigned-release-inputs/coordinator-linux-amd64 \
+            unsigned-release-inputs/coordinator-cli-linux-amd64 \
+            unsigned-release-inputs/gateway-linux-amd64
 
       - name: Upload unsigned build artifact
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02

--- a/scripts/test-release-security-posture.sh
+++ b/scripts/test-release-security-posture.sh
@@ -11,6 +11,8 @@ sparkle_generator="$root/scripts/generate-malibu-appcast.sh"
 legacy_sparkle_key="$root/scripts/dist/malibu-v1.8.32-sparkle-public-key"
 trust_anchor_helper="$root/scripts/prepare-malibu-bootstrap-trust-anchor.py"
 malibu_artifact_verifier="$root/scripts/verify-malibu-release-artifacts.sh"
+coordinator_go_mod="$root/phase4-coordinator/go.mod"
+pearl_go_verifier="$root/scripts/verify-pearl-go-binaries.py"
 release_runbook="$root/phase3-binary/dist/release-signing-runbook.md"
 decision_log="$root/beta/DECISION_CRITERIA.md"
 ci_workflow="$root/.github/workflows/ci.yml"
@@ -21,7 +23,7 @@ trap 'rm -rf "$work"' EXIT
 
 python3 - "$workflow" "$root/phase3-binary/app/project.yml" \
   "$root/phase3-binary/app/Sources/Malibu/Info.plist" \
-  "$trust_anchor_helper" "$malibu_artifact_verifier" <<'PY'
+  "$trust_anchor_helper" "$malibu_artifact_verifier" "$coordinator_go_mod" <<'PY'
 import pathlib
 import re
 import sys
@@ -32,6 +34,12 @@ current_app = "\n".join(
 )
 trust_anchor_helper = pathlib.Path(sys.argv[4]).read_text(encoding="utf-8")
 malibu_artifact_verifier = pathlib.Path(sys.argv[5]).read_text(encoding="utf-8")
+coordinator_go_mod = pathlib.Path(sys.argv[6]).read_text(encoding="utf-8")
+go_directive = re.search(
+    r"(?m)^go ([0-9]+\.[0-9]+(?:\.[0-9]+)?)$", coordinator_go_mod
+)
+if go_directive is None:
+    raise SystemExit("phase4-coordinator go.mod lacks a valid Go directive")
 if "\n  push:" in text or "refs/tags/" in text:
     raise SystemExit("release workflow must not execute from a tag-push ref")
 if "\n  workflow_dispatch:" not in text:
@@ -47,6 +55,69 @@ if candidate_input is None:
     raise SystemExit("candidate dispatch input must be a boolean defaulting to false")
 build = text.split("\n  build:\n", 1)[1].split("\n  sign_publish:\n", 1)[0]
 publish = text.split("\n  sign_publish:\n", 1)[1]
+
+
+def unique_step(job, name):
+    marker = f"\n      - name: {name}\n"
+    if job.count(marker) != 1:
+        raise SystemExit(f"release build must contain exactly one {name} step")
+    return job.split(marker, 1)[1].split("\n      - name:", 1)[0]
+
+
+PEARL_SETUP_GO_SHA = "924ae3a1cded613372ab5595356fb5720e22ba16"
+PEARL_GO_VERIFY_STEP = (
+    "        env:\n"
+    '          EXPECTED_REVISION: ${{ steps.release_source.outputs.commit }}\n'
+    "        shell: bash\n"
+    "        run: |\n"
+    "          python3 scripts/verify-pearl-go-binaries.py \\\n"
+    "            unsigned-release-inputs/coordinator-linux-amd64 \\\n"
+    "            unsigned-release-inputs/coordinator-cli-linux-amd64 \\\n"
+    "            unsigned-release-inputs/gateway-linux-amd64"
+)
+PEARL_VERIFY_UPLOAD_SEQUENCE = (
+    "\n      - name: Verify staged Pearl Go binaries\n"
+    f"{PEARL_GO_VERIFY_STEP}\n"
+    "\n      - name: Upload unsigned build artifact\n"
+)
+
+
+def validate_pearl_toolchain(job):
+    setup_go = unique_step(job, "Setup Go for Pearl binaries")
+    pearl_build = unique_step(job, "Build Pearl linux-amd64 binaries")
+    verifier_step = unique_step(job, "Verify staged Pearl Go binaries")
+    setup_go_uses = re.findall(
+        r"(?m)^        uses: actions/setup-go@([0-9a-f]{40})$", job
+    )
+    if job.lower().count("actions/setup-go@") != 1 or setup_go_uses != [PEARL_SETUP_GO_SHA]:
+        raise SystemExit("release build must contain exactly one pinned setup-go action")
+    go_version_files = re.findall(
+        r"(?m)^          go-version-file:\s*(\S+)\s*$", setup_go
+    )
+    if go_version_files != ["phase4-coordinator/go.mod"]:
+        raise SystemExit(
+            "Pearl Setup Go must use phase4-coordinator/go.mod as its sole version source"
+        )
+    if re.search(r"(?m)^          go-version:\s*", setup_go):
+        raise SystemExit("Pearl Setup Go must not carry a second hardcoded Go version")
+    if verifier_step.strip("\n") != PEARL_GO_VERIFY_STEP:
+        raise SystemExit("Pearl verifier step must contain only the exact binary verifier command")
+    if job.count("scripts/verify-pearl-go-binaries.py") != 1:
+        raise SystemExit("Pearl build must invoke the binary verifier exactly once")
+    if job.count(PEARL_VERIFY_UPLOAD_SEQUENCE) != 1:
+        raise SystemExit("staged Pearl binary verification must immediately precede upload")
+    for build_target in (
+        '-o "$RUNNER_TEMP/coordinator-linux-amd64" ./cmd/coordinator',
+        '-o "$RUNNER_TEMP/coordinator-cli-linux-amd64" ./cmd/coordinator-cli',
+        '-o "$RUNNER_TEMP/gateway-linux-amd64" ./cmd/gateway',
+    ):
+        if len(re.findall(rf"(?m)^\s*{re.escape(build_target)}\s*$", pearl_build)) != 1:
+            raise SystemExit(f"Pearl build target is missing or duplicated: {build_target}")
+    if pearl_build.count("go build -mod=readonly -trimpath -buildvcs=true") != 3:
+        raise SystemExit("all Pearl binaries must use explicit reviewed VCS stamping")
+    return pearl_build
+
+
 if "secrets." in build or "contents: write" in build:
     raise SystemExit("unprivileged build job contains a secret or write permission")
 if "environment: production-release" not in publish:
@@ -184,8 +255,8 @@ if "gh release download" in text:
     raise SystemExit("release workflow must publish the captured workflow files")
 if "actions/upload-artifact@v" in text or "actions/download-artifact@v" in text:
     raise SystemExit("artifact actions must be pinned by commit")
+pearl_build = validate_pearl_toolchain(build)
 for requirement in (
-    'go-version: "1.26.4"',
     "GOTOOLCHAIN=local",
     "CGO_ENABLED=0 GOOS=linux GOARCH=amd64",
     "go build -mod=readonly -trimpath",
@@ -193,8 +264,67 @@ for requirement in (
     "coordinator-cli-linux-amd64",
     "gateway-linux-amd64",
 ):
-    if requirement not in build:
+    if requirement not in pearl_build:
         raise SystemExit(f"reviewed Pearl build contract is missing: {requirement}")
+setup_override_mutation = build.replace(
+    "\n      - name: Build Pearl linux-amd64 binaries\n",
+    "\n      - name: Override Pearl Go version\n"
+    f'        uses: "ACTIONS/setup-go@{PEARL_SETUP_GO_SHA}"\n'
+    "        with:\n"
+    '          go-version: "1.26.4"\n'
+    "\n      - name: Build Pearl linux-amd64 binaries\n",
+    1,
+)
+verifier_replacement_mutation = build.replace(PEARL_GO_VERIFY_STEP, "        run: true", 1)
+verifier_suppression_mutation = build.replace(
+    PEARL_GO_VERIFY_STEP,
+    PEARL_GO_VERIFY_STEP.replace(
+        "        run: |\n",
+        "        run: |\n          set +e\n",
+        1,
+    ),
+    1,
+)
+compound_mutation = setup_override_mutation.replace(PEARL_GO_VERIFY_STEP, "        run: true", 1)
+post_verify_overwrite_mutation = build.replace(
+    PEARL_VERIFY_UPLOAD_SEQUENCE,
+    "\n      - name: Verify staged Pearl Go binaries\n"
+    f"{PEARL_GO_VERIFY_STEP}\n"
+    "\n      - name: Replace verified Pearl binary\n"
+    "        run: cp /bin/true unsigned-release-inputs/coordinator-linux-amd64\n"
+    "\n      - name: Upload unsigned build artifact\n",
+    1,
+)
+build_role_substitution_mutation = build.replace(
+    '-o "$RUNNER_TEMP/coordinator-cli-linux-amd64" ./cmd/coordinator-cli',
+    '-o "$RUNNER_TEMP/coordinator-cli-linux-amd64" ./cmd/coordinator',
+    1,
+)
+coordinator_role_substitution_mutation = build.replace(
+    '-o "$RUNNER_TEMP/coordinator-linux-amd64" ./cmd/coordinator',
+    '-o "$RUNNER_TEMP/coordinator-linux-amd64" ./cmd/coordinator-cli',
+    1,
+)
+gateway_role_substitution_mutation = build.replace(
+    '-o "$RUNNER_TEMP/gateway-linux-amd64" ./cmd/gateway',
+    '-o "$RUNNER_TEMP/gateway-linux-amd64" ./cmd/coordinator',
+    1,
+)
+for description, mutation in (
+    ("case-folded setup-go override", setup_override_mutation),
+    ("binary verifier replacement", verifier_replacement_mutation),
+    ("binary verifier failure suppression", verifier_suppression_mutation),
+    ("compound setup-go/verifier replacement", compound_mutation),
+    ("post-verification binary overwrite", post_verify_overwrite_mutation),
+    ("Pearl build role substitution", build_role_substitution_mutation),
+    ("coordinator build role substitution", coordinator_role_substitution_mutation),
+    ("gateway build role substitution", gateway_role_substitution_mutation),
+):
+    try:
+        validate_pearl_toolchain(mutation)
+    except SystemExit:
+        continue
+    raise SystemExit(f"{description} mutation unexpectedly passed")
 for requirement in (
     'grep -Eq "coordinator-linux-amd64:[[:space:]]+ELF 64-bit.*x86-64"',
     'grep -Eq "coordinator-cli-linux-amd64:[[:space:]]+ELF 64-bit.*x86-64"',
@@ -414,6 +544,8 @@ anonymous = publish.find("- name: Verify anonymous signed discovery for stable r
 if anonymous < transport_position or '"$(cat discovery-transport-tag.txt)"' not in publish[anonymous:]:
     raise SystemExit("anonymous client proof is not bound to the published append-only transport")
 PY
+
+python3 "$pearl_go_verifier" --self-test
 
 for requirement in \
   '### 8.1 Frozen v1.8.39 pre-publication tag recovery' \

--- a/scripts/verify-pearl-go-binaries.py
+++ b/scripts/verify-pearl-go-binaries.py
@@ -1,0 +1,189 @@
+#!/usr/bin/env python3
+"""Verify Pearl Go binaries against the coordinator module toolchain contract."""
+
+from __future__ import annotations
+
+import os
+import pathlib
+import re
+import subprocess
+import sys
+
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+COORDINATOR_GO_MOD = ROOT / "phase4-coordinator" / "go.mod"
+GO_DIRECTIVE_RE = re.compile(r"(?m)^go ([0-9]+\.[0-9]+(?:\.[0-9]+)?)$")
+EXPECTED_MAIN_PACKAGES = {
+    "coordinator-linux-amd64": "github.com/augstar/macprovider-coordinator/cmd/coordinator",
+    "coordinator-cli-linux-amd64": "github.com/augstar/macprovider-coordinator/cmd/coordinator-cli",
+    "gateway-linux-amd64": "github.com/augstar/macprovider-gateway/cmd/gateway",
+}
+
+
+def expected_go_version() -> str:
+    match = GO_DIRECTIVE_RE.search(COORDINATOR_GO_MOD.read_text(encoding="utf-8"))
+    if match is None:
+        raise ValueError("phase4-coordinator/go.mod lacks a valid Go directive")
+    return f"go{match.group(1)}"
+
+
+def repository_head() -> str:
+    try:
+        result = subprocess.run(
+            ["git", "-C", str(ROOT), "rev-parse", "HEAD"],
+            check=True,
+            capture_output=True,
+            text=True,
+            timeout=15,
+        )
+    except (OSError, subprocess.CalledProcessError, subprocess.TimeoutExpired) as exc:
+        raise ValueError("cannot resolve reviewed repository HEAD") from exc
+    head = result.stdout.strip()
+    if re.fullmatch(r"[0-9a-f]{40}", head) is None:
+        raise ValueError("reviewed repository HEAD is not a full lowercase commit hash")
+    return head
+
+
+def expected_revision() -> str:
+    revision = os.environ.get("EXPECTED_REVISION", "")
+    if re.fullmatch(r"[0-9a-f]{40}", revision) is None:
+        raise ValueError("EXPECTED_REVISION must be a full lowercase commit hash")
+    head = repository_head()
+    if head != revision:
+        raise ValueError(f"reviewed repository HEAD {head} does not match {revision}")
+    return revision
+
+
+def verify_build_info(
+    binary: pathlib.Path, output: str, expected: str, revision: str
+) -> None:
+    expected_package = EXPECTED_MAIN_PACKAGES.get(binary.name)
+    if expected_package is None:
+        raise ValueError(f"{binary}: unexpected Pearl binary role")
+    lines = output.splitlines()
+    if not lines or lines[0].rsplit(": ", 1)[-1] != expected:
+        actual = lines[0].rsplit(": ", 1)[-1] if lines else "missing"
+        raise ValueError(f"{binary}: compiler version {actual!r}, expected {expected!r}")
+
+    packages = [
+        line.strip().split("\t", 1)[1]
+        for line in lines[1:]
+        if line.strip().startswith("path\t")
+    ]
+    if packages != [expected_package]:
+        raise ValueError(f"{binary}: main package {packages!r}, expected {expected_package!r}")
+    required_settings = {
+        "GOOS": "linux",
+        "GOARCH": "amd64",
+        "vcs": "git",
+        "vcs.revision": revision,
+        "vcs.modified": "false",
+    }
+    for key, expected_value in required_settings.items():
+        values = [
+            line.strip().split("=", 1)[1]
+            for line in lines[1:]
+            if line.strip().startswith(f"build\t{key}=")
+        ]
+        if values != [expected_value]:
+            raise ValueError(
+                f"{binary}: build setting {key} is {values!r}, expected {[expected_value]!r}"
+            )
+
+
+def verify_binary(binary: pathlib.Path, expected: str, revision: str) -> None:
+    if not binary.is_file():
+        raise ValueError(f"{binary}: binary is missing")
+    try:
+        result = subprocess.run(
+            ["go", "version", "-m", str(binary)],
+            check=True,
+            capture_output=True,
+            text=True,
+            timeout=15,
+        )
+    except (OSError, subprocess.CalledProcessError, subprocess.TimeoutExpired) as exc:
+        raise ValueError(f"{binary}: cannot read Go build information") from exc
+    verify_build_info(binary, result.stdout, expected, revision)
+
+
+def self_test() -> None:
+    expected = expected_go_version()
+    revision = repository_head()
+    previous_revision = os.environ.get("EXPECTED_REVISION")
+    try:
+        os.environ["EXPECTED_REVISION"] = revision
+        if expected_revision() != revision:
+            raise AssertionError("reviewed revision binding changed unexpectedly")
+        os.environ["EXPECTED_REVISION"] = "0" * 40
+        try:
+            expected_revision()
+        except ValueError:
+            pass
+        else:
+            raise AssertionError("mismatched reviewed revision was accepted")
+    finally:
+        if previous_revision is None:
+            os.environ.pop("EXPECTED_REVISION", None)
+        else:
+            os.environ["EXPECTED_REVISION"] = previous_revision
+    binary = pathlib.Path("coordinator-linux-amd64")
+    valid = (
+        f"{binary}: {expected}\n"
+        f"\tpath\t{EXPECTED_MAIN_PACKAGES[binary.name]}\n"
+        "\tbuild\tGOOS=linux\n"
+        "\tbuild\tGOARCH=amd64\n"
+        "\tbuild\tvcs=git\n"
+        f"\tbuild\tvcs.revision={revision}\n"
+        "\tbuild\tvcs.modified=false\n"
+    )
+    verify_build_info(binary, valid, expected, revision)
+    for invalid in (
+        valid.replace(expected, "go0.0.0", 1),
+        valid.replace("\tbuild\tGOOS=linux\n", "", 1),
+        valid.replace("\tbuild\tGOARCH=amd64\n", "", 1),
+        valid.replace("/cmd/coordinator\n", "/cmd/coordinator-cli\n", 1),
+        valid.replace(revision, "0" * 40, 1),
+        valid.replace("vcs.modified=false", "vcs.modified=true", 1),
+        valid + f"\tbuild\tvcs.revision={revision}\n",
+        valid + "\tbuild\tvcs.modified=true\n",
+    ):
+        try:
+            verify_build_info(binary, invalid, expected, revision)
+        except ValueError:
+            continue
+        raise AssertionError("invalid Pearl Go build information was accepted")
+
+
+def main(argv: list[str]) -> int:
+    if argv == ["--self-test"]:
+        self_test()
+        print("Pearl Go binary verifier self-test passed")
+        return 0
+    if not argv:
+        print("usage: verify-pearl-go-binaries.py BINARY [BINARY ...]", file=sys.stderr)
+        return 2
+
+    basenames = [pathlib.Path(value).name for value in argv]
+    if basenames != list(EXPECTED_MAIN_PACKAGES):
+        print(
+            "verify-pearl-go-binaries: expected coordinator, coordinator-cli, and gateway in order",
+            file=sys.stderr,
+        )
+        return 2
+
+    try:
+        expected = expected_go_version()
+        revision = expected_revision()
+        for value in argv:
+            verify_binary(pathlib.Path(value), expected, revision)
+    except ValueError as exc:
+        print(f"verify-pearl-go-binaries: {exc}", file=sys.stderr)
+        return 1
+
+    print(f"verified {len(argv)} Pearl Go binaries with {expected} at {revision}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))


### PR DESCRIPTION
Closes the v1.8.58 release blocker exposed during issue #608 Step B.

The Pearl release build now derives Go from phase4-coordinator/go.mod, stamps and verifies exact clean VCS provenance, binds each staged binary to its filename/package role, and verifies the exact staged upload bytes immediately before upload.

Local validation:
- python3 scripts/verify-pearl-go-binaries.py --self-test
- python3 -m py_compile scripts/verify-pearl-go-binaries.py
- bash -n scripts/test-release-security-posture.sh
- bash scripts/test-release-security-posture.sh
- git diff --check

Independent exact-head audits: code 0 C/H/M, security 0 C/H/M, architecture 0 C/H/M.

SPEC-GOVERNANCE-DECLARATION-BEGIN
{
  "schema_version": "spec-pr-governance-v1",
  "behavior_change": "yes",
  "contract_change": "none",
  "issue": "https://github.com/Augustas11/macprovider/issues/608",
  "specs": ["SPEC-010", "SPEC-008"],
  "requirements": ["SPEC-010-R004"],
  "authority_domains": ["model-catalog-identity", "tier2-trust-evidence"],
  "arbitration": ["CODE_BUG"],
  "tests": ["bash scripts/test-release-security-posture.sh"],
  "journeys": ["not-required"]
}
SPEC-GOVERNANCE-DECLARATION-END