### PR TITLE
Preserve signed catalog authentication in release builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -108,6 +108,18 @@ jobs:
             phase4-coordinator/go.sum
             phase5-gateway/go.sum
 
+      - name: Seal the Tier-2 verifier toolchain
+        shell: bash
+        run: |
+          set -euo pipefail
+          source_root="$(go env GOROOT)"
+          sudo test ! -e /usr/local/lib/macprovider-go-verifier
+          sudo install -d -o root -g wheel -m 0755 /usr/local/lib/macprovider-go-verifier
+          sudo cp -a "$source_root/." /usr/local/lib/macprovider-go-verifier/
+          sudo chown -R root:wheel /usr/local/lib/macprovider-go-verifier
+          sudo chmod -R go-w /usr/local/lib/macprovider-go-verifier
+          sudo test -x /usr/local/lib/macprovider-go-verifier/bin/go
+
       - name: Build Pearl linux-amd64 binaries
         shell: bash
         run: |
@@ -167,7 +179,8 @@ jobs:
         run: |
           set -euo pipefail
           cd phase3-binary/dist
-          MACPROVIDER_PROVIDER_ADMISSION_POLICY="$PROVIDER_ADMISSION_POLICY_INPUT" \
+          CATALOG_RELEASE_REQUIRE_SEALED_GO_VERIFIER=1 \
+            MACPROVIDER_PROVIDER_ADMISSION_POLICY="$PROVIDER_ADMISSION_POLICY_INPUT" \
             ./package.sh "${{ steps.release_source.outputs.tag }}"
 
       - name: Build Malibu.app

--- a/scripts/catalog-release.py
+++ b/scripts/catalog-release.py
@@ -56,6 +56,7 @@ FIXED_GO_EXECUTABLES = (
     "/usr/local/lib/macprovider-go-verifier/bin/go",
 )
 ALWAYS_ROOT_TRUSTED_GO_EXECUTABLES = frozenset({"/usr/local/lib/macprovider-go-verifier/bin/go"})
+REQUIRE_SEALED_GO_ENV = "CATALOG_RELEASE_REQUIRE_SEALED_GO_VERIFIER"
 
 
 class CatalogError(RuntimeError):
@@ -1128,6 +1129,11 @@ def go_executable() -> str:
     version probe before trusting the binary. Tier-2 authenticity must not
     depend on ambient process environment.
     """
+    sealed_requirement = os.environ.get(REQUIRE_SEALED_GO_ENV)
+    if sealed_requirement not in (None, "1"):
+        fail(f"{REQUIRE_SEALED_GO_ENV} must be unset or exactly 1")
+    require_sealed = sealed_requirement == "1"
+
     candidates = [
         candidate
         for candidate in FIXED_GO_EXECUTABLES
@@ -1146,6 +1152,8 @@ def go_executable() -> str:
         sealed_candidate = candidate in ALWAYS_ROOT_TRUSTED_GO_EXECUTABLES
         if sealed_candidate:
             if not os.path.lexists(candidate):
+                if require_sealed:
+                    fail(f"required sealed Go verifier toolchain is missing: {candidate}")
                 continue
             if not root_trusted_executable(candidate):
                 fail(f"sealed Go verifier toolchain is not root-trusted: {candidate}")

--- a/scripts/test-catalog-release.sh
+++ b/scripts/test-catalog-release.sh
@@ -691,6 +691,7 @@ unsealed_go.chmod(0o755)
 saved_fixed_go = module.FIXED_GO_EXECUTABLES
 saved_always_trusted = module.ALWAYS_ROOT_TRUSTED_GO_EXECUTABLES
 saved_root_trusted = module.root_trusted_executable
+saved_sealed_requirement = os.environ.get(module.REQUIRE_SEALED_GO_ENV)
 try:
     module.FIXED_GO_EXECUTABLES = (str(unsealed_go), str(sealed_go))
     module.ALWAYS_ROOT_TRUSTED_GO_EXECUTABLES = frozenset({str(sealed_go)})
@@ -699,12 +700,21 @@ try:
     module.root_trusted_executable = lambda candidate: pathlib.Path(candidate) == sealed_go
     if module.go_executable() != str(sealed_go):
         raise SystemExit("root-trusted sealed Go verifier toolchain did not take precedence")
+    sealed_go.unlink()
+    os.environ[module.REQUIRE_SEALED_GO_ENV] = "1"
+    rejected("required sealed Go verifier toolchain is missing", module.go_executable)
+    os.environ[module.REQUIRE_SEALED_GO_ENV] = "0"
+    rejected("invalid sealed Go verifier requirement", module.go_executable)
 finally:
     module.FIXED_GO_EXECUTABLES = saved_fixed_go
     module.ALWAYS_ROOT_TRUSTED_GO_EXECUTABLES = saved_always_trusted
     module.root_trusted_executable = saved_root_trusted
+    if saved_sealed_requirement is None:
+        os.environ.pop(module.REQUIRE_SEALED_GO_ENV, None)
+    else:
+        os.environ[module.REQUIRE_SEALED_GO_ENV] = saved_sealed_requirement
 
-print("sealed Go verifier toolchain requires root trust and wins candidate precedence")
+print("sealed Go verifier toolchain requires root trust and fails closed when required")
 
 # The trust root is the committed coordinator.yaml only. An ambient
 # environment variable set by anything other than a reviewed PR touching

--- a/scripts/test-release-security-posture.sh
+++ b/scripts/test-release-security-posture.sh
@@ -65,6 +65,30 @@ def unique_step(job, name):
 
 
 PEARL_SETUP_GO_SHA = "924ae3a1cded613372ab5595356fb5720e22ba16"
+PEARL_GO_SEAL_STEP = (
+    "        shell: bash\n"
+    "        run: |\n"
+    "          set -euo pipefail\n"
+    '          source_root="$(go env GOROOT)"\n'
+    "          sudo test ! -e /usr/local/lib/macprovider-go-verifier\n"
+    "          sudo install -d -o root -g wheel -m 0755 /usr/local/lib/macprovider-go-verifier\n"
+    '          sudo cp -a "$source_root/." /usr/local/lib/macprovider-go-verifier/\n'
+    "          sudo chown -R root:wheel /usr/local/lib/macprovider-go-verifier\n"
+    "          sudo chmod -R go-w /usr/local/lib/macprovider-go-verifier\n"
+    "          sudo test -x /usr/local/lib/macprovider-go-verifier/bin/go"
+)
+PEARL_SETUP_SEAL_BUILD_SEQUENCE = (
+    "\n      - name: Setup Go for Pearl binaries\n"
+    "{setup_go}\n"
+    "\n      - name: Seal the Tier-2 verifier toolchain\n"
+    f"{PEARL_GO_SEAL_STEP}\n"
+    "\n      - name: Build Pearl linux-amd64 binaries\n"
+)
+PEARL_SEALED_GO_REQUIREMENT = (
+    "          CATALOG_RELEASE_REQUIRE_SEALED_GO_VERIFIER=1 \\\n"
+    '            MACPROVIDER_PROVIDER_ADMISSION_POLICY="$PROVIDER_ADMISSION_POLICY_INPUT" \\\n'
+    '            ./package.sh "${{ steps.release_source.outputs.tag }}"'
+)
 PEARL_GO_VERIFY_STEP = (
     "        env:\n"
     '          EXPECTED_REVISION: ${{ steps.release_source.outputs.commit }}\n'
@@ -84,7 +108,9 @@ PEARL_VERIFY_UPLOAD_SEQUENCE = (
 
 def validate_pearl_toolchain(job):
     setup_go = unique_step(job, "Setup Go for Pearl binaries")
+    seal_go = unique_step(job, "Seal the Tier-2 verifier toolchain")
     pearl_build = unique_step(job, "Build Pearl linux-amd64 binaries")
+    package_build = unique_step(job, "Build package")
     verifier_step = unique_step(job, "Verify staged Pearl Go binaries")
     setup_go_uses = re.findall(
         r"(?m)^        uses: actions/setup-go@([0-9a-f]{40})$", job
@@ -100,6 +126,18 @@ def validate_pearl_toolchain(job):
         )
     if re.search(r"(?m)^          go-version:\s*", setup_go):
         raise SystemExit("Pearl Setup Go must not carry a second hardcoded Go version")
+    if seal_go.strip("\n") != PEARL_GO_SEAL_STEP:
+        raise SystemExit("Tier-2 verifier toolchain seal must contain only the exact root-owned copy")
+    sealed_go_path = "/usr/local/lib/macprovider-go-verifier"
+    if job.count(sealed_go_path) != PEARL_GO_SEAL_STEP.count(sealed_go_path):
+        raise SystemExit("sealed Go verifier path must appear only in the exact seal step")
+    expected_sequence = PEARL_SETUP_SEAL_BUILD_SEQUENCE.format(setup_go=setup_go.rstrip("\n"))
+    if job.count(expected_sequence) != 1:
+        raise SystemExit("Pearl Setup Go, verifier seal, and binary build must remain adjacent and ordered")
+    if package_build.count(PEARL_SEALED_GO_REQUIREMENT) != 1:
+        raise SystemExit("release package verification must require the sealed Go verifier")
+    if job.count("CATALOG_RELEASE_REQUIRE_SEALED_GO_VERIFIER") != 1:
+        raise SystemExit("release build must set the sealed Go verifier requirement exactly once")
     if verifier_step.strip("\n") != PEARL_GO_VERIFY_STEP:
         raise SystemExit("Pearl verifier step must contain only the exact binary verifier command")
     if job.count("scripts/verify-pearl-go-binaries.py") != 1:
@@ -275,6 +313,28 @@ setup_override_mutation = build.replace(
     "\n      - name: Build Pearl linux-amd64 binaries\n",
     1,
 )
+seal_replacement_mutation = build.replace(PEARL_GO_SEAL_STEP, "        run: true", 1)
+seal_failure_suppression_mutation = build.replace(
+    PEARL_GO_SEAL_STEP,
+    PEARL_GO_SEAL_STEP.replace(
+        "        run: |\n",
+        "        run: |\n          set +e\n",
+        1,
+    ),
+    1,
+)
+post_seal_override_mutation = build.replace(
+    "\n      - name: Build package\n",
+    "\n      - name: Override sealed Pearl Go\n"
+    "        run: sudo cp /bin/true /usr/local/lib/macprovider-go-verifier/bin/go\n"
+    "\n      - name: Build package\n",
+    1,
+)
+sealed_requirement_removal_mutation = build.replace(
+    "          CATALOG_RELEASE_REQUIRE_SEALED_GO_VERIFIER=1 \\\n",
+    "",
+    1,
+)
 verifier_replacement_mutation = build.replace(PEARL_GO_VERIFY_STEP, "        run: true", 1)
 verifier_suppression_mutation = build.replace(
     PEARL_GO_VERIFY_STEP,
@@ -312,6 +372,10 @@ gateway_role_substitution_mutation = build.replace(
 )
 for description, mutation in (
     ("case-folded setup-go override", setup_override_mutation),
+    ("toolchain seal replacement", seal_replacement_mutation),
+    ("toolchain seal failure suppression", seal_failure_suppression_mutation),
+    ("post-seal toolchain override", post_seal_override_mutation),
+    ("sealed verifier requirement removal", sealed_requirement_removal_mutation),
     ("binary verifier replacement", verifier_replacement_mutation),
     ("binary verifier failure suppression", verifier_suppression_mutation),
     ("compound setup-go/verifier replacement", compound_mutation),


### PR DESCRIPTION
Closes the macOS release-runner gap that prevented signed Tier-2 catalog authentication after the Go 1.26.5 toolchain update.

The release build now seals the reviewed setup-go GOROOT as root:wheel, requires that sealed verifier for catalog packaging, and fails closed on missing or invalid sealed state. Mutation tests lock exact ownership, ordering, path uniqueness, and the release-only requirement.

Audits at exact head e2d88de30fc0ff149f6624eb2abea066fd1aa8b7:
- code: 0 CRITICAL / 0 HIGH / 0 MEDIUM / 0 LOW
- security: 0 CRITICAL / 0 HIGH / 0 MEDIUM / 0 LOW
- architect: 0 CRITICAL / 0 HIGH / 0 MEDIUM / 0 LOW

Validation:
- bash scripts/test-catalog-release.sh
- bash scripts/test-release-security-posture.sh
- bash -n scripts/test-catalog-release.sh scripts/test-release-security-posture.sh
- python3 -m py_compile scripts/catalog-release.py
- PyYAML safe_load .github/workflows/release.yml
- git diff --check
- Darwin root group resolves to wheel

SPEC-GOVERNANCE-DECLARATION-BEGIN
{
  "schema_version": "spec-pr-governance-v1",
  "behavior_change": "yes",
  "contract_change": "none",
  "issue": "https://github.com/Augustas11/macprovider/issues/608",
  "specs": ["SPEC-010", "SPEC-008"],
  "requirements": ["SPEC-010-R004"],
  "authority_domains": ["model-catalog-identity", "tier2-trust-evidence"],
  "arbitration": ["CODE_BUG"],
  "tests": ["bash scripts/test-release-security-posture.sh", "bash scripts/test-catalog-release.sh"],
  "journeys": ["not-required"]
}
SPEC-GOVERNANCE-DECLARATION-END