### PR TITLE
Cancel superseded CI runs to cut wasted macOS minutes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,14 @@ on:
 permissions:
   contents: read
 
+# Cancel superseded CI runs on the same ref. A second push to a PR (or to
+# main) supersedes the first, so let the in-flight run stop instead of
+# burning macOS minutes on a diff that is already stale. Keyed by ref so
+# concurrent PRs never cancel each other.
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   coordinator:
     name: phase4-coordinator (go vet + test)


### PR DESCRIPTION
## What

Adds a top-level \`concurrency\` group to \`.github/workflows/ci.yml\` so that a superseded run on the same ref is cancelled instead of running to completion.

\`\`\`yaml
concurrency:
  group: ci-\${{ github.ref }}
  cancel-in-progress: true
\`\`\`

## Why

\`ci.yml\` was the only workflow without a concurrency block. Its heaviest jobs run on \`macos-15\` / \`macos-15-intel\` (10 + 4 jobs), which bill at ~10× Linux minutes and queue the slowest. Without cancellation, pushing twice to a PR left the first, macOS-heavy run grinding to completion against an already-stale diff — pure wasted minutes and latency.

Keyed by \`github.ref\` so concurrent PRs never cancel each other. CI is safe to cancel; the release and acceptance workflows keep \`cancel-in-progress: false\` on purpose (never interrupt a release mid-flight) and are untouched.

## Scope

- No money-path / coordinator / billing code touched.
- Single-file, additive change to CI orchestration only.

## Considered and rejected

An earlier pass flagged \`cache: false\` on a setup-go step as an accidental cache miss. On inspection it is the deliberate **Tier-2 signature verifier** sealing step (reviewed toolchain sealed into a protected path) — intentional, left unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)