### PR TITLE
fix(tools): stop null tool-schema defaults from 503ing as model_not_loaded (#718)

### DIFF
--- a/phase3-binary/Sources/macprovider-cli/HTTPServer.swift
+++ b/phase3-binary/Sources/macprovider-cli/HTTPServer.swift
@@ -640,8 +640,11 @@ final class RouterHandler: ChannelInboundHandler, @unchecked Sendable {
 	                    if providerRequestStarted {
 	                        await providerStatus.finishRequest(startedAt: startedAt, completion: nil, failed: true)
 	                    }
-	                    let apiError =
-                        APIError(status: 503, message: "Model inference failed", type: "server_error", code: "model_not_loaded")
+	                    // Do not stamp every unexpected error as model_not_loaded.
+	                    // Once the request was admitted the model was loaded; a
+	                    // template/tools failure (e.g. historical NSNull→Jinja)
+	                    // is an inference/request problem, not a missing model.
+	                    let apiError = Self.unexpectedInferenceAPIError(error: error)
                     do {
                         let receipt = try Self.errorReceiptHeaderResult(
                             providerID: providerID,
@@ -997,20 +1000,15 @@ final class RouterHandler: ChannelInboundHandler, @unchecked Sendable {
                 if providerRequestStarted {
                     await providerStatus.finishRequest(startedAt: startedAt, completion: nil, failed: true)
                 }
+                let apiError = Self.unexpectedInferenceAPIError(
+                    error: error,
+                    sseStarted: sseStarted
+                )
                 if sseStarted {
-                    writer.writeSSEJSON(
-                        APIError(
-                            status: 500,
-                            message: "Inference engine error",
-                            type: "server_error",
-                            code: "internal_error"
-                        ).envelope
-                    )
+                    writer.writeSSEJSON(apiError.envelope)
                     writer.writeSSEDone()
                 } else {
-                    writer.writeAPIError(
-                        APIError(status: 503, message: "Model inference failed", type: "server_error", code: "model_not_loaded")
-                    )
+                    writer.writeAPIError(apiError)
                 }
             }
         }
@@ -1027,6 +1025,52 @@ final class RouterHandler: ChannelInboundHandler, @unchecked Sendable {
                 "code": "swap_drain_timeout",
             ]
         ]
+    }
+
+    /// Maps unexpected non-APIError throws into a buyer-visible envelope.
+    ///
+    /// Residual catches historically stamped every failure as
+    /// `503 model_not_loaded`, which mislabeled chat-template / tools-schema
+    /// failures (e.g. `NSNull` in tool parameters → swift-jinja) as an unloaded
+    /// model. Detect those render failures and emit a 400 `chat_template_error`
+    /// instead. All other unexpected errors keep the historical envelope so
+    /// existing error-receipt eligibility (`model_not_loaded`) is unchanged.
+    static func unexpectedInferenceAPIError(
+        error: Error,
+        sseStarted: Bool = false
+    ) -> APIError {
+        if Self.looksLikeChatTemplateFailure(error) {
+            return APIError(
+                status: 400,
+                message: "Chat template rendering failed: \(error.localizedDescription)",
+                type: "invalid_request_error",
+                code: "chat_template_error",
+                retryable: false
+            )
+        }
+        if sseStarted {
+            return APIError(
+                status: 500,
+                message: "Inference engine error",
+                type: "server_error",
+                code: "internal_error"
+            )
+        }
+        return APIError(
+            status: 503,
+            message: "Model inference failed",
+            type: "server_error",
+            code: "model_not_loaded"
+        )
+    }
+
+    private static func looksLikeChatTemplateFailure(_ error: Error) -> Bool {
+        let text = "\(error) \(error.localizedDescription)".lowercased()
+        return text.contains("nsnull")
+            || text.contains("jinja")
+            || text.contains("chat template")
+            || text.contains("applychattemplate")
+            || text.contains("cannot convert value of type")
     }
 
     static let receiptHeaderName = "X-MacProvider-Receipt"

--- a/phase3-binary/Sources/macprovider-cli/ModelRuntime.swift
+++ b/phase3-binary/Sources/macprovider-cli/ModelRuntime.swift
@@ -2639,13 +2639,26 @@ actor ModelRuntime: ModelRuntimeServing {
             else {
                 return nil
             }
+            // Chat-template engines (swift-jinja via Tokenizers) cannot
+            // convert NSNull into a Jinja Value. Omit null object members
+            // and a missing description rather than materializing NSNull.
+            // `default: null` and similar schema nulls are irrelevant to
+            // Qwen tool-call prompt rendering.
+            guard let parametersAny = jsonAnyForTemplate(parameters) else {
+                return nil
+            }
+            var function: [String: Any] = [
+                "name": name,
+                "parameters": parametersAny,
+            ]
+            if let descriptionValue = functionObject["description"],
+               let description = jsonAnyForTemplate(descriptionValue)
+            {
+                function["description"] = description
+            }
             return [
                 "type": "function",
-                "function": [
-                    "name": name,
-                    "description": functionObject["description"].map(jsonAny) ?? NSNull(),
-                    "parameters": jsonAny(parameters),
-                ],
+                "function": function,
             ]
         }
         return converted.isEmpty ? nil : converted
@@ -2672,16 +2685,26 @@ actor ModelRuntime: ModelRuntimeServing {
         return names.isEmpty ? nil : Set(names)
     }
 
-    private static func jsonObject(_ object: [String: MacProviderCore.JSONValue]) -> [String: Any] {
-        object.mapValues(jsonAny)
+    /// Converts JSONValue for chat-template tools dicts.
+    /// Object members (and array elements) that are JSON null are omitted so
+    /// the result never contains `NSNull`, which swift-jinja cannot convert.
+    private static func jsonObjectForTemplate(_ object: [String: MacProviderCore.JSONValue]) -> [String: Any] {
+        var result: [String: Any] = [:]
+        result.reserveCapacity(object.count)
+        for (key, value) in object {
+            if let converted = jsonAnyForTemplate(value) {
+                result[key] = converted
+            }
+        }
+        return result
     }
 
-    private static func jsonAny(_ value: MacProviderCore.JSONValue) -> Any {
+    private static func jsonAnyForTemplate(_ value: MacProviderCore.JSONValue) -> Any? {
         switch value {
         case .object(let object):
-            return jsonObject(object)
+            return jsonObjectForTemplate(object)
         case .array(let array):
-            return array.map(jsonAny)
+            return array.compactMap(jsonAnyForTemplate)
         case .string(let string):
             return string
         case .int(let int):
@@ -2691,7 +2714,7 @@ actor ModelRuntime: ModelRuntimeServing {
         case .bool(let bool):
             return bool
         case .null:
-            return NSNull()
+            return nil
         }
     }
 

--- a/phase3-binary/Tests/macprovider-cliTests/HTTPServerReceiptTests.swift
+++ b/phase3-binary/Tests/macprovider-cliTests/HTTPServerReceiptTests.swift
@@ -731,6 +731,26 @@ final class HTTPServerReceiptTests: XCTestCase {
         XCTAssertNil(header)
     }
 
+    func testUnexpectedInferenceMapsJinjaNSNullToChatTemplateError() {
+        struct FakeJinjaError: Error, LocalizedError {
+            var errorDescription: String? {
+                "Cannot convert value of type NSNull to Jinja Value"
+            }
+        }
+        let apiError = RouterHandler.unexpectedInferenceAPIError(error: FakeJinjaError())
+        XCTAssertEqual(apiError.status, 400)
+        XCTAssertEqual(apiError.code, "chat_template_error")
+        XCTAssertEqual(apiError.type, "invalid_request_error")
+        XCTAssertFalse(apiError.retryableOverride ?? true)
+    }
+
+    func testUnexpectedInferenceKeepsModelNotLoadedForGenericFailures() {
+        struct GenericFailure: Error {}
+        let apiError = RouterHandler.unexpectedInferenceAPIError(error: GenericFailure())
+        XCTAssertEqual(apiError.status, 503)
+        XCTAssertEqual(apiError.code, "model_not_loaded")
+    }
+
     func testNullUsageModelNotLoadedErrorGetsReceiptHeader() throws {
         let key = try Curve25519.Signing.PrivateKey(rawRepresentation: Data(0..<32))
         let request = try parseRequest([

--- a/phase3-binary/Tests/macprovider-cliTests/ToolCallParserTests.swift
+++ b/phase3-binary/Tests/macprovider-cliTests/ToolCallParserTests.swift
@@ -536,12 +536,103 @@ I'll validate that.
         XCTAssertEqual(function["description"] as? String, "Find where a code symbol is defined")
         XCTAssertNotNil(function["parameters"])
         XCTAssertNil(function["x_function_extra"])
+        XCTAssertFalse(Self.containsNSNull(tool), "template tools must not materialize NSNull")
+    }
+
+    func testTemplateToolsOmitJSONNullsAndMissingDescription() {
+        // Regression for https://github.com/Augustas11/macprovider/issues/718:
+        // `"default": null` in tool parameters became NSNull, which swift-jinja
+        // cannot convert → 503 model_not_loaded mislabel.
+        let tools: JSONValue = .array([
+            .object([
+                "type": .string("function"),
+                "function": .object([
+                    "name": .string("f"),
+                    // description intentionally omitted
+                    "parameters": .object([
+                        "type": .string("object"),
+                        "properties": .object([
+                            "timeout": .object([
+                                "type": .string("integer"),
+                                "default": .null,
+                            ]),
+                            "optional_hint": .null,
+                        ]),
+                        "additionalProperties": .bool(false),
+                    ]),
+                ]),
+            ]),
+            .object([
+                "type": .string("function"),
+                "function": .object([
+                    "name": .string("g"),
+                    "description": .null,
+                    "parameters": .object([
+                        "type": .string("object"),
+                        "properties": .object([
+                            "tags": .object([
+                                "type": .string("array"),
+                                "items": .object([
+                                    "type": .array([.string("string"), .string("null")]),
+                                ]),
+                                "default": .array([.null, .string("x")]),
+                            ]),
+                        ]),
+                    ]),
+                ]),
+            ]),
+        ])
+
+        let converted = try! XCTUnwrap(ModelRuntime.mlxToolsForTemplate(from: tools))
+        XCTAssertEqual(converted.count, 2)
+
+        for tool in converted {
+            XCTAssertFalse(Self.containsNSNull(tool), "converted tool must not contain NSNull: \(tool)")
+        }
+
+        let first = try! XCTUnwrap(converted[0]["function"] as? [String: Any])
+        XCTAssertEqual(first["name"] as? String, "f")
+        XCTAssertNil(first["description"], "missing description must be omitted, not NSNull")
+        let firstParams = try! XCTUnwrap(first["parameters"] as? [String: Any])
+        let firstProps = try! XCTUnwrap(firstParams["properties"] as? [String: Any])
+        let timeout = try! XCTUnwrap(firstProps["timeout"] as? [String: Any])
+        XCTAssertEqual(timeout["type"] as? String, "integer")
+        XCTAssertNil(timeout["default"], "default:null must be omitted from template tools")
+        XCTAssertNil(firstProps["optional_hint"], "null-valued property entry must be omitted")
+
+        let second = try! XCTUnwrap(converted[1]["function"] as? [String: Any])
+        XCTAssertEqual(second["name"] as? String, "g")
+        XCTAssertNil(second["description"], "description:null must be omitted, not NSNull")
+        let secondParams = try! XCTUnwrap(second["parameters"] as? [String: Any])
+        let secondProps = try! XCTUnwrap(secondParams["properties"] as? [String: Any])
+        let tags = try! XCTUnwrap(secondProps["tags"] as? [String: Any])
+        // Array null elements are dropped so Jinja never sees NSNull.
+        let defaultTags = try! XCTUnwrap(tags["default"] as? [Any])
+        XCTAssertEqual(defaultTags.count, 1)
+        XCTAssertEqual(defaultTags.first as? String, "x")
+        // Union type ["string","null"] keeps the string "null" (not a JSON null).
+        let items = try! XCTUnwrap(tags["items"] as? [String: Any])
+        let typeUnion = try! XCTUnwrap(items["type"] as? [Any])
+        XCTAssertEqual(typeUnion as? [String], ["string", "null"])
     }
 
     func testNullAndEmptyToolsDoNotEnableTemplateTools() {
         XCTAssertNil(ModelRuntime.mlxToolsForTemplate(from: .null))
         XCTAssertNil(ModelRuntime.mlxToolsForTemplate(from: .array([])))
         XCTAssertNil(ModelRuntime.mlxToolsForTemplate(from: nil))
+    }
+
+    private static func containsNSNull(_ value: Any) -> Bool {
+        if value is NSNull {
+            return true
+        }
+        if let object = value as? [String: Any] {
+            return object.values.contains(where: containsNSNull)
+        }
+        if let array = value as? [Any] {
+            return array.contains(where: containsNSNull)
+        }
+        return false
     }
 
     private func argumentValue(_ arguments: String, key: String) throws -> Any? {


### PR DESCRIPTION
## Summary

Fixes https://github.com/Augustas11/macprovider/issues/718.

OpenAI tool requests whose parameters schema contains a literal JSON `null` (commonly `"default": null`) failed with:

```json
HTTP 503 {"error":{"code":"model_not_loaded","message":"Model inference failed",...}}
```

even when the model was loaded and healthy. Root cause: `mlxToolsForTemplate` / `jsonAny` materialised `.null` as `NSNull()`, then swift-jinja's `Value(any:)` threw (no `NSNull` case). The HTTP residual catch stamped that throw as `model_not_loaded`.

### Changes

1. **Primary (correctness)** — `ModelRuntime.mlxToolsForTemplate`:
   - recursively **omit** JSON-null object members and array elements when building the chat-template tools dict (never emit `NSNull`)
   - omit `description` when missing or null (was `?? NSNull()`)
2. **Secondary (diagnosability)** — `HTTPServer` residual catch:
   - Jinja/NSNull/chat-template style failures → `400 chat_template_error`
   - other unexpected non-streaming failures keep historical `503 model_not_loaded` (error-receipt eligibility unchanged)
3. **Tests**
   - `testTemplateToolsOmitJSONNullsAndMissingDescription` (issue #718 regression)
   - mapper unit tests for Jinja/NSNull → `chat_template_error` and generic → `model_not_loaded`

### Line-number verification against `origin/main` (`7bc5ba87`)

Issue pointers matched current main closely:

| Site | Issue pointer | Actual on main |
|---|---|---|
| `mlxToolsForTemplate` | ~L2630 | L2630 |
| `description ?? NSNull()` | ~L2646 | L2646 |
| `jsonAny` `.null → NSNull()` | ~L2693–2694 | L2693–2694 |
| non-stream residual catch | ~L639–644 | L639–644 |
| stream residual catch | ~L1012 | L1012 |
| `validateTools` loose parse | ~L834–856 | L834–856 |

## Test plan

- [x] `swift test --filter ToolCallParserTests` (41 tests, including new null-strip case)
- [x] `swift test --filter HTTPServerReceiptTests/testUnexpectedInference*`
- [x] `swift test --filter HTTPServerReceiptTests/testHTTPGenericInferenceFailureGetsNullUsageReceipt`
- [x] `swift test --filter HTTPServerReceiptTests/testHTTPEarlyModelNotLoadedValidationGetsNullUsageReceipt`
- [ ] CI `ci-required` green
- [ ] Live repro from issue (provider serve + `default: null` tools curl) once a binary with this fix is installed

## Notes

- Provider binary fix only — no coordinator change.
- Ships with the next `macprovider-cli` release; not live until providers update.
- `spec-index / check` may be advisory-red: SPEC-018 `requirement_id_migration` is still `pending`, so no formal `SPEC-018-R###` IDs exist in `CONFORMANCE.json`. Declaration below is honest on domain/spec; requirement id is provisional. `ci-required` remains the merge gate.

SPEC-GOVERNANCE-DECLARATION-BEGIN
{
  "schema_version": "spec-pr-governance-v1",
  "behavior_change": "yes",
  "contract_change": "none",
  "specs": ["SPEC-018"],
  "requirements": ["SPEC-018-R001"],
  "authority_domains": ["agentic-tool-calling"],
  "arbitration": ["CODE_BUG"],
  "tests": [
    "phase3-binary/Tests/macprovider-cliTests/ToolCallParserTests.swift",
    "phase3-binary/Tests/macprovider-cliTests/HTTPServerReceiptTests.swift"
  ],
  "journeys": ["not-required"],
  "issue": "https://github.com/Augustas11/macprovider/issues/718"
}
SPEC-GOVERNANCE-DECLARATION-END
