### PR TITLE
fix(tools): render JSON-null tool-schema values as native Jinja nulls (#718); revert flawed #719

### DIFF
--- a/phase3-binary/Package.swift
+++ b/phase3-binary/Package.swift
@@ -25,6 +25,13 @@ let package = Package(
             url: "https://github.com/huggingface/swift-transformers.git",
             exact: "1.0.0"
         ),
+        // swift-transformers 1.0.0 resolves swift-jinja 2.3.6 transitively; pin
+        // it directly so `import Jinja` (native null tool-schema rendering,
+        // issue #718) binds to the same reviewed version.
+        .package(
+            url: "https://github.com/huggingface/swift-jinja.git",
+            exact: "2.3.6"
+        ),
         .package(
             url: "https://github.com/apple/swift-nio.git",
             exact: "2.101.2"
@@ -57,6 +64,7 @@ let package = Package(
                 .product(name: "MLXLMCommon", package: "mlx-swift-lm"),
                 .product(name: "MLXHuggingFace", package: "mlx-swift-lm"),
                 .product(name: "Tokenizers", package: "swift-transformers"),
+                .product(name: "Jinja", package: "swift-jinja"),
                 .product(name: "NIO", package: "swift-nio"),
                 .product(name: "NIOHTTP1", package: "swift-nio"),
                 .product(name: "ArgumentParser", package: "swift-argument-parser"),

--- a/phase3-binary/Sources/MacProviderCore/ChatCompletionRequest.swift
+++ b/phase3-binary/Sources/MacProviderCore/ChatCompletionRequest.swift
@@ -852,7 +852,56 @@ private func validateTools(_ raw: Any?) throws {
         guard function["parameters"] is [String: Any] else {
             throw APIError(status: 400, message: "Invalid tools[\(index)]: missing function.parameters", code: "invalid_tools")
         }
+        // The whole tool object is later walked recursively by `JSONValue.parse`
+        // and the chat-template converter, both otherwise depth-unbounded. Bound
+        // its container nesting here — at the untrusted-input boundary, before
+        // any recursive walk — so those walks cannot overflow the native stack.
+        //
+        // This is a RAW structural recursion bound (a stack-safety backstop),
+        // not a JSON-Schema logical-depth contract: it counts nested container
+        // levels, each schema position measured from itself as depth 1 so the
+        // tool/function wrapper does not consume budget. EVERY member is probed
+        // — the `function`'s members (`parameters`, `description`, …) AND any
+        // other key an over-permissive client may attach to the tool object —
+        // because `JSONValue.parse` traverses all of them; probing only
+        // `function` would leave a `tools[i].<other>` bypass. The limit reuses
+        // the repo-wide `JSONSchemaValidator.maxDepth`, far above any realistic
+        // tool schema (a handful of levels). The probe is iterative so it cannot
+        // overflow on the very input it guards against.
+        func rejectIfTooDeep(_ value: Any) throws {
+            guard !jsonContainerNestingExceeds(value, limit: JSONSchemaValidator.maxDepth) else {
+                throw APIError(status: 400, message: "Invalid tools[\(index)]: schema exceeds maximum nesting depth", code: "invalid_tools")
+            }
+        }
+        for (key, member) in tool {
+            if key == "function", let functionObject = member as? [String: Any] {
+                for functionMember in functionObject.values { try rejectIfTooDeep(functionMember) }
+            } else {
+                try rejectIfTooDeep(member)
+            }
+        }
     }
+}
+
+/// Iterative (heap-stack) container-nesting probe over a Foundation JSON graph.
+/// Depth counts nested container (object/array) levels only — scalar leaves do
+/// not add depth — with `root` at depth 1. Returns `true` as soon as a
+/// container is found deeper than `limit`, so native stack usage stays constant
+/// regardless of how deeply nested `root` is. Exact boundary: a root whose
+/// deepest container sits at level `limit` returns `false`; at `limit + 1`,
+/// `true`.
+func jsonContainerNestingExceeds(_ root: Any, limit: Int) -> Bool {
+    var stack: [(node: Any, depth: Int)] = [(root, 1)]
+    while let (node, depth) = stack.popLast() {
+        if let dict = node as? [String: Any] {
+            if depth > limit { return true }
+            for value in dict.values { stack.append((value, depth + 1)) }
+        } else if let array = node as? [Any] {
+            if depth > limit { return true }
+            for value in array { stack.append((value, depth + 1)) }
+        }
+    }
+    return false
 }
 
 private func validateToolChoice(_ raw: Any?) throws {

--- a/phase3-binary/Sources/macprovider-cli/HTTPServer.swift
+++ b/phase3-binary/Sources/macprovider-cli/HTTPServer.swift
@@ -640,11 +640,8 @@ final class RouterHandler: ChannelInboundHandler, @unchecked Sendable {
 	                    if providerRequestStarted {
 	                        await providerStatus.finishRequest(startedAt: startedAt, completion: nil, failed: true)
 	                    }
-	                    // Do not stamp every unexpected error as model_not_loaded.
-	                    // Once the request was admitted the model was loaded; a
-	                    // template/tools failure (e.g. historical NSNull→Jinja)
-	                    // is an inference/request problem, not a missing model.
-	                    let apiError = Self.unexpectedInferenceAPIError(error: error)
+	                    let apiError =
+                        APIError(status: 503, message: "Model inference failed", type: "server_error", code: "model_not_loaded")
                     do {
                         let receipt = try Self.errorReceiptHeaderResult(
                             providerID: providerID,
@@ -1000,15 +997,20 @@ final class RouterHandler: ChannelInboundHandler, @unchecked Sendable {
                 if providerRequestStarted {
                     await providerStatus.finishRequest(startedAt: startedAt, completion: nil, failed: true)
                 }
-                let apiError = Self.unexpectedInferenceAPIError(
-                    error: error,
-                    sseStarted: sseStarted
-                )
                 if sseStarted {
-                    writer.writeSSEJSON(apiError.envelope)
+                    writer.writeSSEJSON(
+                        APIError(
+                            status: 500,
+                            message: "Inference engine error",
+                            type: "server_error",
+                            code: "internal_error"
+                        ).envelope
+                    )
                     writer.writeSSEDone()
                 } else {
-                    writer.writeAPIError(apiError)
+                    writer.writeAPIError(
+                        APIError(status: 503, message: "Model inference failed", type: "server_error", code: "model_not_loaded")
+                    )
                 }
             }
         }
@@ -1025,52 +1027,6 @@ final class RouterHandler: ChannelInboundHandler, @unchecked Sendable {
                 "code": "swap_drain_timeout",
             ]
         ]
-    }
-
-    /// Maps unexpected non-APIError throws into a buyer-visible envelope.
-    ///
-    /// Residual catches historically stamped every failure as
-    /// `503 model_not_loaded`, which mislabeled chat-template / tools-schema
-    /// failures (e.g. `NSNull` in tool parameters → swift-jinja) as an unloaded
-    /// model. Detect those render failures and emit a 400 `chat_template_error`
-    /// instead. All other unexpected errors keep the historical envelope so
-    /// existing error-receipt eligibility (`model_not_loaded`) is unchanged.
-    static func unexpectedInferenceAPIError(
-        error: Error,
-        sseStarted: Bool = false
-    ) -> APIError {
-        if Self.looksLikeChatTemplateFailure(error) {
-            return APIError(
-                status: 400,
-                message: "Chat template rendering failed: \(error.localizedDescription)",
-                type: "invalid_request_error",
-                code: "chat_template_error",
-                retryable: false
-            )
-        }
-        if sseStarted {
-            return APIError(
-                status: 500,
-                message: "Inference engine error",
-                type: "server_error",
-                code: "internal_error"
-            )
-        }
-        return APIError(
-            status: 503,
-            message: "Model inference failed",
-            type: "server_error",
-            code: "model_not_loaded"
-        )
-    }
-
-    private static func looksLikeChatTemplateFailure(_ error: Error) -> Bool {
-        let text = "\(error) \(error.localizedDescription)".lowercased()
-        return text.contains("nsnull")
-            || text.contains("jinja")
-            || text.contains("chat template")
-            || text.contains("applychattemplate")
-            || text.contains("cannot convert value of type")
     }
 
     static let receiptHeaderName = "X-MacProvider-Receipt"

--- a/phase3-binary/Sources/macprovider-cli/HTTPServer.swift
+++ b/phase3-binary/Sources/macprovider-cli/HTTPServer.swift
@@ -640,8 +640,11 @@ final class RouterHandler: ChannelInboundHandler, @unchecked Sendable {
 	                    if providerRequestStarted {
 	                        await providerStatus.finishRequest(startedAt: startedAt, completion: nil, failed: true)
 	                    }
-	                    let apiError =
-                        APIError(status: 503, message: "Model inference failed", type: "server_error", code: "model_not_loaded")
+	                    // Do not stamp every unexpected error as model_not_loaded.
+	                    // Once the request was admitted the model was loaded; a
+	                    // template/tools failure (e.g. historical NSNull→Jinja)
+	                    // is an inference/request problem, not a missing model.
+	                    let apiError = Self.unexpectedInferenceAPIError(error: error)
                     do {
                         let receipt = try Self.errorReceiptHeaderResult(
                             providerID: providerID,
@@ -997,20 +1000,15 @@ final class RouterHandler: ChannelInboundHandler, @unchecked Sendable {
                 if providerRequestStarted {
                     await providerStatus.finishRequest(startedAt: startedAt, completion: nil, failed: true)
                 }
+                let apiError = Self.unexpectedInferenceAPIError(
+                    error: error,
+                    sseStarted: sseStarted
+                )
                 if sseStarted {
-                    writer.writeSSEJSON(
-                        APIError(
-                            status: 500,
-                            message: "Inference engine error",
-                            type: "server_error",
-                            code: "internal_error"
-                        ).envelope
-                    )
+                    writer.writeSSEJSON(apiError.envelope)
                     writer.writeSSEDone()
                 } else {
-                    writer.writeAPIError(
-                        APIError(status: 503, message: "Model inference failed", type: "server_error", code: "model_not_loaded")
-                    )
+                    writer.writeAPIError(apiError)
                 }
             }
         }
@@ -1027,6 +1025,42 @@ final class RouterHandler: ChannelInboundHandler, @unchecked Sendable {
                 "code": "swap_drain_timeout",
             ]
         ]
+    }
+
+    /// Maps unexpected non-APIError throws into a buyer-visible envelope.
+    ///
+    /// The specific #718 mislabel (tool-schema `NSNull` → swift-jinja throw) is
+    /// fixed at the source: tool nulls now render as native Jinja nulls in
+    /// `ModelRuntime.jsonAnyForTemplate`, so that failure no longer reaches this
+    /// residual catch. Pre-existing behavior is preserved here deliberately: a
+    /// pre-SSE failure keeps the long-standing `model_not_loaded` (503) envelope
+    /// so the buyer still receives the SPEC-015 §M.5 (AC-31) null-usage error
+    /// receipt — 0 tokens out, proof of no charge — while a post-SSE failure,
+    /// where headers are already committed, surfaces as `internal_error` (500).
+    ///
+    /// NOTE: whether an unexpected internal defect *should* keep sharing the
+    /// `model_not_loaded` code (an availability signal) with genuine
+    /// unavailability is a live taxonomy question raised in audit; changing it
+    /// alters AC-31 receipt economics and is intentionally left to a governed
+    /// SPEC decision rather than folded into the #718 null-handling fix.
+    static func unexpectedInferenceAPIError(
+        error: Error,
+        sseStarted: Bool = false
+    ) -> APIError {
+        if sseStarted {
+            return APIError(
+                status: 500,
+                message: "Inference engine error",
+                type: "server_error",
+                code: "internal_error"
+            )
+        }
+        return APIError(
+            status: 503,
+            message: "Model inference failed",
+            type: "server_error",
+            code: "model_not_loaded"
+        )
     }
 
     static let receiptHeaderName = "X-MacProvider-Receipt"

--- a/phase3-binary/Sources/macprovider-cli/ModelRuntime.swift
+++ b/phase3-binary/Sources/macprovider-cli/ModelRuntime.swift
@@ -1,5 +1,6 @@
 import Foundation
 import CryptoKit
+import Jinja
 import MLX
 import MLXLLM
 import MLXHuggingFace
@@ -2639,13 +2640,26 @@ actor ModelRuntime: ModelRuntimeServing {
             else {
                 return nil
             }
+            // Chat-template engines (swift-jinja via Tokenizers) reject
+            // Foundation `NSNull` (issue #718). Represent every JSON null as a
+            // native `Jinja.Value.null`, which `Value(any:)` passes through
+            // unchanged, so the rendered schema keeps its keys and array
+            // positions instead of silently dropping `enum:[null,…]`,
+            // `const:null`, or positional defaults.
+            // `description` is part of the receipt canonical tool subset, where
+            // an absent key and an explicit `null` both canonicalize to JCS null
+            // (PromptCanonicalizer.canonicalTool via jcsOrNull) — i.e. they share
+            // one signed prompt hash. Render both as a native Jinja null so the
+            // template the model actually sees cannot diverge from that hash.
+            let description = functionObject["description"].map { jsonAnyForTemplate($0) } ?? Jinja.Value.null
+            let function: [String: Any] = [
+                "name": name,
+                "description": description,
+                "parameters": jsonAnyForTemplate(parameters),
+            ]
             return [
                 "type": "function",
-                "function": [
-                    "name": name,
-                    "description": functionObject["description"].map(jsonAny) ?? NSNull(),
-                    "parameters": jsonAny(parameters),
-                ],
+                "function": function,
             ]
         }
         return converted.isEmpty ? nil : converted
@@ -2672,16 +2686,30 @@ actor ModelRuntime: ModelRuntimeServing {
         return names.isEmpty ? nil : Set(names)
     }
 
-    private static func jsonObject(_ object: [String: MacProviderCore.JSONValue]) -> [String: Any] {
-        object.mapValues(jsonAny)
-    }
-
-    private static func jsonAny(_ value: MacProviderCore.JSONValue) -> Any {
+    /// Converts a JSONValue subtree into the `Any` graph the chat template
+    /// consumes, preserving every key and array position. JSON null becomes a
+    /// native `Jinja.Value.null` (not `NSNull` and not an omission): swift-jinja
+    /// `Value(any:)` matches `case let value as Value` and passes it through,
+    /// so `default:null`, `const:null`, `enum:[null,…]`, and positional array
+    /// nulls survive round-trip with their original schema semantics (#718/#719).
+    ///
+    /// Recursion is bounded by the caller, not here: tool schemas are rejected
+    /// at `validateTools` (ChatCompletionRequest) when they exceed
+    /// `JSONSchemaValidator.maxDepth`, before `JSONValue.parse` builds the tree
+    /// this walk consumes. So every value reaching here is already depth-capped,
+    /// and the converter can stay a faithful shape-preserving pass with no
+    /// silent truncation of over-deep subtrees.
+    private static func jsonAnyForTemplate(_ value: MacProviderCore.JSONValue) -> Any {
         switch value {
         case .object(let object):
-            return jsonObject(object)
+            var result: [String: Any] = [:]
+            result.reserveCapacity(object.count)
+            for (key, member) in object {
+                result[key] = jsonAnyForTemplate(member)
+            }
+            return result
         case .array(let array):
-            return array.map(jsonAny)
+            return array.map { jsonAnyForTemplate($0) }
         case .string(let string):
             return string
         case .int(let int):
@@ -2691,7 +2719,7 @@ actor ModelRuntime: ModelRuntimeServing {
         case .bool(let bool):
             return bool
         case .null:
-            return NSNull()
+            return Jinja.Value.null
         }
     }
 

--- a/phase3-binary/Sources/macprovider-cli/ModelRuntime.swift
+++ b/phase3-binary/Sources/macprovider-cli/ModelRuntime.swift
@@ -2639,26 +2639,13 @@ actor ModelRuntime: ModelRuntimeServing {
             else {
                 return nil
             }
-            // Chat-template engines (swift-jinja via Tokenizers) cannot
-            // convert NSNull into a Jinja Value. Omit null object members
-            // and a missing description rather than materializing NSNull.
-            // `default: null` and similar schema nulls are irrelevant to
-            // Qwen tool-call prompt rendering.
-            guard let parametersAny = jsonAnyForTemplate(parameters) else {
-                return nil
-            }
-            var function: [String: Any] = [
-                "name": name,
-                "parameters": parametersAny,
-            ]
-            if let descriptionValue = functionObject["description"],
-               let description = jsonAnyForTemplate(descriptionValue)
-            {
-                function["description"] = description
-            }
             return [
                 "type": "function",
-                "function": function,
+                "function": [
+                    "name": name,
+                    "description": functionObject["description"].map(jsonAny) ?? NSNull(),
+                    "parameters": jsonAny(parameters),
+                ],
             ]
         }
         return converted.isEmpty ? nil : converted
@@ -2685,26 +2672,16 @@ actor ModelRuntime: ModelRuntimeServing {
         return names.isEmpty ? nil : Set(names)
     }
 
-    /// Converts JSONValue for chat-template tools dicts.
-    /// Object members (and array elements) that are JSON null are omitted so
-    /// the result never contains `NSNull`, which swift-jinja cannot convert.
-    private static func jsonObjectForTemplate(_ object: [String: MacProviderCore.JSONValue]) -> [String: Any] {
-        var result: [String: Any] = [:]
-        result.reserveCapacity(object.count)
-        for (key, value) in object {
-            if let converted = jsonAnyForTemplate(value) {
-                result[key] = converted
-            }
-        }
-        return result
+    private static func jsonObject(_ object: [String: MacProviderCore.JSONValue]) -> [String: Any] {
+        object.mapValues(jsonAny)
     }
 
-    private static func jsonAnyForTemplate(_ value: MacProviderCore.JSONValue) -> Any? {
+    private static func jsonAny(_ value: MacProviderCore.JSONValue) -> Any {
         switch value {
         case .object(let object):
-            return jsonObjectForTemplate(object)
+            return jsonObject(object)
         case .array(let array):
-            return array.compactMap(jsonAnyForTemplate)
+            return array.map(jsonAny)
         case .string(let string):
             return string
         case .int(let int):
@@ -2714,7 +2691,7 @@ actor ModelRuntime: ModelRuntimeServing {
         case .bool(let bool):
             return bool
         case .null:
-            return nil
+            return NSNull()
         }
     }
 

--- a/phase3-binary/Tests/macprovider-cliTests/HTTPServerReceiptTests.swift
+++ b/phase3-binary/Tests/macprovider-cliTests/HTTPServerReceiptTests.swift
@@ -731,6 +731,34 @@ final class HTTPServerReceiptTests: XCTestCase {
         XCTAssertNil(header)
     }
 
+    func testUnexpectedInferenceStaysOnEstablishedTaxonomy() {
+        // The #718 NSNull mislabel is fixed at the source (native Jinja null in
+        // ModelRuntime.jsonAnyForTemplate), so no new buyer-facing error code is
+        // introduced here. This residual catch keeps the PRE-EXISTING taxonomy:
+        // a pre-SSE failure stays `model_not_loaded` (503) so the SPEC-015 §M.5
+        // (AC-31) null-usage error receipt is still issued; a post-SSE failure
+        // uses `internal_error` (500). Whether internal defects should keep
+        // sharing `model_not_loaded` is a separate governed SPEC decision, not
+        // part of the #718 fix.
+        struct FakeJinjaError: Error, LocalizedError {
+            var errorDescription: String? {
+                "Cannot convert value of type NSNull to Jinja Value"
+            }
+        }
+        let preSSE = RouterHandler.unexpectedInferenceAPIError(error: FakeJinjaError())
+        XCTAssertEqual(preSSE.status, 503)
+        XCTAssertEqual(preSSE.code, "model_not_loaded")
+
+        struct GenericFailure: Error {}
+        let generic = RouterHandler.unexpectedInferenceAPIError(error: GenericFailure())
+        XCTAssertEqual(generic.status, 503)
+        XCTAssertEqual(generic.code, "model_not_loaded")
+
+        let postSSE = RouterHandler.unexpectedInferenceAPIError(error: GenericFailure(), sseStarted: true)
+        XCTAssertEqual(postSSE.status, 500)
+        XCTAssertEqual(postSSE.code, "internal_error")
+    }
+
     func testNullUsageModelNotLoadedErrorGetsReceiptHeader() throws {
         let key = try Curve25519.Signing.PrivateKey(rawRepresentation: Data(0..<32))
         let request = try parseRequest([

--- a/phase3-binary/Tests/macprovider-cliTests/HTTPServerReceiptTests.swift
+++ b/phase3-binary/Tests/macprovider-cliTests/HTTPServerReceiptTests.swift
@@ -731,26 +731,6 @@ final class HTTPServerReceiptTests: XCTestCase {
         XCTAssertNil(header)
     }
 
-    func testUnexpectedInferenceMapsJinjaNSNullToChatTemplateError() {
-        struct FakeJinjaError: Error, LocalizedError {
-            var errorDescription: String? {
-                "Cannot convert value of type NSNull to Jinja Value"
-            }
-        }
-        let apiError = RouterHandler.unexpectedInferenceAPIError(error: FakeJinjaError())
-        XCTAssertEqual(apiError.status, 400)
-        XCTAssertEqual(apiError.code, "chat_template_error")
-        XCTAssertEqual(apiError.type, "invalid_request_error")
-        XCTAssertFalse(apiError.retryableOverride ?? true)
-    }
-
-    func testUnexpectedInferenceKeepsModelNotLoadedForGenericFailures() {
-        struct GenericFailure: Error {}
-        let apiError = RouterHandler.unexpectedInferenceAPIError(error: GenericFailure())
-        XCTAssertEqual(apiError.status, 503)
-        XCTAssertEqual(apiError.code, "model_not_loaded")
-    }
-
     func testNullUsageModelNotLoadedErrorGetsReceiptHeader() throws {
         let key = try Curve25519.Signing.PrivateKey(rawRepresentation: Data(0..<32))
         let request = try parseRequest([

--- a/phase3-binary/Tests/macprovider-cliTests/ToolCallParserTests.swift
+++ b/phase3-binary/Tests/macprovider-cliTests/ToolCallParserTests.swift
@@ -536,103 +536,12 @@ I'll validate that.
         XCTAssertEqual(function["description"] as? String, "Find where a code symbol is defined")
         XCTAssertNotNil(function["parameters"])
         XCTAssertNil(function["x_function_extra"])
-        XCTAssertFalse(Self.containsNSNull(tool), "template tools must not materialize NSNull")
-    }
-
-    func testTemplateToolsOmitJSONNullsAndMissingDescription() {
-        // Regression for https://github.com/Augustas11/macprovider/issues/718:
-        // `"default": null` in tool parameters became NSNull, which swift-jinja
-        // cannot convert → 503 model_not_loaded mislabel.
-        let tools: JSONValue = .array([
-            .object([
-                "type": .string("function"),
-                "function": .object([
-                    "name": .string("f"),
-                    // description intentionally omitted
-                    "parameters": .object([
-                        "type": .string("object"),
-                        "properties": .object([
-                            "timeout": .object([
-                                "type": .string("integer"),
-                                "default": .null,
-                            ]),
-                            "optional_hint": .null,
-                        ]),
-                        "additionalProperties": .bool(false),
-                    ]),
-                ]),
-            ]),
-            .object([
-                "type": .string("function"),
-                "function": .object([
-                    "name": .string("g"),
-                    "description": .null,
-                    "parameters": .object([
-                        "type": .string("object"),
-                        "properties": .object([
-                            "tags": .object([
-                                "type": .string("array"),
-                                "items": .object([
-                                    "type": .array([.string("string"), .string("null")]),
-                                ]),
-                                "default": .array([.null, .string("x")]),
-                            ]),
-                        ]),
-                    ]),
-                ]),
-            ]),
-        ])
-
-        let converted = try! XCTUnwrap(ModelRuntime.mlxToolsForTemplate(from: tools))
-        XCTAssertEqual(converted.count, 2)
-
-        for tool in converted {
-            XCTAssertFalse(Self.containsNSNull(tool), "converted tool must not contain NSNull: \(tool)")
-        }
-
-        let first = try! XCTUnwrap(converted[0]["function"] as? [String: Any])
-        XCTAssertEqual(first["name"] as? String, "f")
-        XCTAssertNil(first["description"], "missing description must be omitted, not NSNull")
-        let firstParams = try! XCTUnwrap(first["parameters"] as? [String: Any])
-        let firstProps = try! XCTUnwrap(firstParams["properties"] as? [String: Any])
-        let timeout = try! XCTUnwrap(firstProps["timeout"] as? [String: Any])
-        XCTAssertEqual(timeout["type"] as? String, "integer")
-        XCTAssertNil(timeout["default"], "default:null must be omitted from template tools")
-        XCTAssertNil(firstProps["optional_hint"], "null-valued property entry must be omitted")
-
-        let second = try! XCTUnwrap(converted[1]["function"] as? [String: Any])
-        XCTAssertEqual(second["name"] as? String, "g")
-        XCTAssertNil(second["description"], "description:null must be omitted, not NSNull")
-        let secondParams = try! XCTUnwrap(second["parameters"] as? [String: Any])
-        let secondProps = try! XCTUnwrap(secondParams["properties"] as? [String: Any])
-        let tags = try! XCTUnwrap(secondProps["tags"] as? [String: Any])
-        // Array null elements are dropped so Jinja never sees NSNull.
-        let defaultTags = try! XCTUnwrap(tags["default"] as? [Any])
-        XCTAssertEqual(defaultTags.count, 1)
-        XCTAssertEqual(defaultTags.first as? String, "x")
-        // Union type ["string","null"] keeps the string "null" (not a JSON null).
-        let items = try! XCTUnwrap(tags["items"] as? [String: Any])
-        let typeUnion = try! XCTUnwrap(items["type"] as? [Any])
-        XCTAssertEqual(typeUnion as? [String], ["string", "null"])
     }
 
     func testNullAndEmptyToolsDoNotEnableTemplateTools() {
         XCTAssertNil(ModelRuntime.mlxToolsForTemplate(from: .null))
         XCTAssertNil(ModelRuntime.mlxToolsForTemplate(from: .array([])))
         XCTAssertNil(ModelRuntime.mlxToolsForTemplate(from: nil))
-    }
-
-    private static func containsNSNull(_ value: Any) -> Bool {
-        if value is NSNull {
-            return true
-        }
-        if let object = value as? [String: Any] {
-            return object.values.contains(where: containsNSNull)
-        }
-        if let array = value as? [Any] {
-            return array.contains(where: containsNSNull)
-        }
-        return false
     }
 
     private func argumentValue(_ arguments: String, key: String) throws -> Any? {

--- a/phase3-binary/Tests/macprovider-cliTests/ToolCallParserTests.swift
+++ b/phase3-binary/Tests/macprovider-cliTests/ToolCallParserTests.swift
@@ -1,5 +1,6 @@
 import Foundation
 import XCTest
+import Jinja
 import MacProviderCore
 @testable import macprovider_cli
 
@@ -536,12 +537,226 @@ I'll validate that.
         XCTAssertEqual(function["description"] as? String, "Find where a code symbol is defined")
         XCTAssertNotNil(function["parameters"])
         XCTAssertNil(function["x_function_extra"])
+        XCTAssertFalse(Self.containsNSNull(tool), "template tools must not materialize NSNull")
+    }
+
+    func testTemplateToolsRenderJSONNullsAsJinjaNullPreservingShape() throws {
+        // Regression for https://github.com/Augustas11/macprovider/issues/718
+        // and correctness follow-up: `"default": null` in tool parameters
+        // became NSNull, which swift-jinja cannot convert → 503 model_not_loaded
+        // mislabel. The fix renders JSON nulls as native `Jinja.Value.null`
+        // WITHOUT dropping keys or array positions (the earlier omit-based fix
+        // silently mutated `enum:[null,…]`, `const:null`, and positional
+        // defaults).
+        let tools: JSONValue = .array([
+            .object([
+                "type": .string("function"),
+                "function": .object([
+                    "name": .string("f"),
+                    // description intentionally omitted
+                    "parameters": .object([
+                        "type": .string("object"),
+                        "properties": .object([
+                            "timeout": .object([
+                                "type": .string("integer"),
+                                "default": .null,
+                            ]),
+                            "optional_hint": .null,
+                        ]),
+                        "additionalProperties": .bool(false),
+                    ]),
+                ]),
+            ]),
+            .object([
+                "type": .string("function"),
+                "function": .object([
+                    "name": .string("g"),
+                    "description": .null,
+                    "parameters": .object([
+                        "type": .string("object"),
+                        "properties": .object([
+                            "tags": .object([
+                                "type": .string("array"),
+                                "items": .object([
+                                    "type": .array([.string("string"), .string("null")]),
+                                ]),
+                                "default": .array([.null, .string("x")]),
+                            ]),
+                        ]),
+                    ]),
+                ]),
+            ]),
+        ])
+
+        let converted = try XCTUnwrap(ModelRuntime.mlxToolsForTemplate(from: tools))
+        XCTAssertEqual(converted.count, 2)
+
+        for tool in converted {
+            XCTAssertFalse(Self.containsNSNull(tool), "converted tool must not contain NSNull: \(tool)")
+        }
+
+        let first = try XCTUnwrap(converted[0]["function"] as? [String: Any])
+        XCTAssertEqual(first["name"] as? String, "f")
+        // An absent description renders as a native Jinja null, matching the
+        // receipt canonical form where absent and explicit-null both hash to
+        // JCS null (PromptCanonicalizer.canonicalTool). Render must not diverge
+        // from the signed prompt hash by treating absent as "undefined".
+        XCTAssertTrue(first.keys.contains("description"), "absent description is rendered as null (hash parity)")
+        XCTAssertEqual(first["description"] as? Jinja.Value, Jinja.Value.null)
+        let firstParams = try XCTUnwrap(first["parameters"] as? [String: Any])
+        let firstProps = try XCTUnwrap(firstParams["properties"] as? [String: Any])
+        let timeout = try XCTUnwrap(firstProps["timeout"] as? [String: Any])
+        XCTAssertEqual(timeout["type"] as? String, "integer")
+        // default:null is PRESERVED as a native Jinja null (key retained).
+        XCTAssertTrue(timeout.keys.contains("default"), "default key must be preserved")
+        XCTAssertEqual(timeout["default"] as? Jinja.Value, Jinja.Value.null)
+        XCTAssertTrue(firstProps.keys.contains("optional_hint"), "null-valued property key must be preserved")
+        XCTAssertEqual(firstProps["optional_hint"] as? Jinja.Value, Jinja.Value.null)
+
+        let second = try XCTUnwrap(converted[1]["function"] as? [String: Any])
+        XCTAssertEqual(second["name"] as? String, "g")
+        // description:null is PRESERVED as a native Jinja null.
+        XCTAssertTrue(second.keys.contains("description"), "present description key must be preserved")
+        XCTAssertEqual(second["description"] as? Jinja.Value, Jinja.Value.null)
+        let secondParams = try XCTUnwrap(second["parameters"] as? [String: Any])
+        let secondProps = try XCTUnwrap(secondParams["properties"] as? [String: Any])
+        let tags = try XCTUnwrap(secondProps["tags"] as? [String: Any])
+        // Array null elements keep their POSITION as a native Jinja null.
+        let defaultTags = try XCTUnwrap(tags["default"] as? [Any])
+        XCTAssertEqual(defaultTags.count, 2, "array null positions must be preserved, not dropped")
+        XCTAssertEqual(defaultTags[0] as? Jinja.Value, Jinja.Value.null)
+        XCTAssertEqual(defaultTags[1] as? String, "x")
+        // Union type ["string","null"] keeps the string "null" (not a JSON null).
+        let items = try XCTUnwrap(tags["items"] as? [String: Any])
+        let typeUnion = try XCTUnwrap(items["type"] as? [Any])
+        XCTAssertEqual(typeUnion as? [String], ["string", "null"])
+
+        // The failing #718 boundary itself: the converted tools must round-trip
+        // through swift-jinja's `Value(any:)` (what the tokenizer calls) WITHOUT
+        // throwing — the original crash was here, not in the model.
+        XCTAssertNoThrow(try Jinja.Value(any: converted))
+    }
+
+    func testTemplateToolConverterPreservesDeepShapeWithoutTruncation() throws {
+        // Depth is bounded upstream at request validation (see the request-level
+        // test below), so the converter is a faithful shape-preserving pass with
+        // NO silent truncation: a deep-but-legal schema must reach its leaf
+        // intact rather than being collapsed to null partway down.
+        let depth = 20
+        var node: JSONValue = .object(["leaf": .string("bottom")])
+        for _ in 0..<depth {
+            node = .object(["nested": node])
+        }
+        let tools: JSONValue = .array([
+            .object([
+                "type": .string("function"),
+                "function": .object([
+                    "name": .string("deep"),
+                    "parameters": .object(["type": .string("object"), "properties": node]),
+                ]),
+            ]),
+        ])
+        let converted = try XCTUnwrap(ModelRuntime.mlxToolsForTemplate(from: tools))
+        var cursor: [String: Any] = try XCTUnwrap(
+            (try XCTUnwrap(converted[0]["function"] as? [String: Any])["parameters"] as? [String: Any])?["properties"] as? [String: Any]
+        )
+        for _ in 0..<depth {
+            cursor = try XCTUnwrap(cursor["nested"] as? [String: Any], "shape truncated before reaching the leaf")
+        }
+        XCTAssertEqual(cursor["leaf"] as? String, "bottom", "leaf value must survive the full depth")
+        XCTAssertNoThrow(try Jinja.Value(any: converted))
+    }
+
+    func testOverDeepToolSchemaRejectedAtRequestValidation() throws {
+        // Buyer-controlled tool schemas must not drive unbounded native
+        // recursion in JSONValue.parse or the template converter. The guard
+        // lives at the untrusted-input boundary (validateTools): it bounds the
+        // container nesting of each function member, measured with the member
+        // (here `parameters`) as depth 1, against JSONSchemaValidator.maxDepth.
+        // A schema whose deepest container sits AT the limit is accepted; one
+        // level past it is rejected 400 invalid_tools BEFORE any recursive walk.
+
+        // Build a `parameters` value whose deepest container is at exactly
+        // `containerDepth` (linear nesting so the boundary is precise).
+        func parametersOfDepth(_ containerDepth: Int) -> Any {
+            var node: Any = ["type": "object"]
+            for _ in 1..<containerDepth { node = ["nested": node] }
+            return node
+        }
+        func toolBody(depth: Int) -> [String: Any] {
+            [
+                "model": "fixture-model",
+                "messages": [["role": "user", "content": "hi"]],
+                "tools": [[
+                    "type": "function",
+                    "function": ["name": "f", "parameters": parametersOfDepth(depth)],
+                ]],
+            ]
+        }
+
+        let limit = 32 // JSONSchemaValidator.maxDepth
+
+        // Exactly AT the limit: accepted.
+        XCTAssertNoThrow(try parseRequest(toolBody(depth: limit)))
+
+        // Exactly ONE past the limit: rejected with the established taxonomy code.
+        XCTAssertThrowsError(try parseRequest(toolBody(depth: limit + 1))) { error in
+            let apiError = error as? APIError
+            XCTAssertEqual(apiError?.status, 400)
+            XCTAssertEqual(apiError?.code, "invalid_tools")
+        }
+
+        // A deep `description` object (not just parameters) is also bounded.
+        let deepDescription: [String: Any] = [
+            "model": "fixture-model",
+            "messages": [["role": "user", "content": "hi"]],
+            "tools": [[
+                "type": "function",
+                "function": [
+                    "name": "f",
+                    "description": parametersOfDepth(limit + 1),
+                    "parameters": ["type": "object"],
+                ],
+            ]],
+        ]
+        XCTAssertThrowsError(try parseRequest(deepDescription)) { error in
+            XCTAssertEqual((error as? APIError)?.code, "invalid_tools")
+        }
+
+        // A deep member OUTSIDE `function` (an over-permissive client may attach
+        // extra keys to the tool object) must not bypass the guard — JSONValue
+        // .parse still recurses it.
+        let deepExtraToolMember: [String: Any] = [
+            "model": "fixture-model",
+            "messages": [["role": "user", "content": "hi"]],
+            "tools": [[
+                "type": "function",
+                "function": ["name": "f", "parameters": ["type": "object"]],
+                "x": parametersOfDepth(limit + 1),
+            ]],
+        ]
+        XCTAssertThrowsError(try parseRequest(deepExtraToolMember)) { error in
+            XCTAssertEqual((error as? APIError)?.code, "invalid_tools")
+        }
     }
 
     func testNullAndEmptyToolsDoNotEnableTemplateTools() {
         XCTAssertNil(ModelRuntime.mlxToolsForTemplate(from: .null))
         XCTAssertNil(ModelRuntime.mlxToolsForTemplate(from: .array([])))
         XCTAssertNil(ModelRuntime.mlxToolsForTemplate(from: nil))
+    }
+
+    private static func containsNSNull(_ value: Any) -> Bool {
+        if value is NSNull {
+            return true
+        }
+        if let object = value as? [String: Any] {
+            return object.values.contains(where: containsNSNull)
+        }
+        if let array = value as? [Any] {
+            return array.contains(where: containsNSNull)
+        }
+        return false
     }
 
     private func argumentValue(_ arguments: String, key: String) throws -> Any? {


### PR DESCRIPTION
## What & why

Reimplements the #718 tool-schema `null` fix **correctly**, after reverting the flawed **#719**.

**Root cause (#718):** a tool-schema value of JSON `null` became Foundation `NSNull`, which swift-jinja's `Value(any:)` rejects — surfacing to buyers as a mislabeled `503 model_not_loaded` instead of a template error.

**Why revert #719 rather than patch on top:** #719 was admin-merged without the standard 3-lane audit and took a shortcut that introduced collateral defects:
- It **deleted** the null-valued keys instead of preserving them — silently mutating the buyer's tool schema (dropping `enum:[null,…]`, `const:null`, positional defaults).
- It introduced an **ungoverned `chat_template_error`** code outside the SPEC-001 taxonomy.

This PR is `revert #719` + a clean correct implementation, so history and review see the whole fix rather than a slice-on-a-slice.

## The correct fix

- **Native Jinja nulls** — `ModelRuntime.jsonAnyForTemplate` renders every JSON `null` as `Jinja.Value.null`, preserving object keys and array positions (shape-faithful, no key deletion).
- **Signed-hash parity for `description`** — an absent `function.description` renders as a native Jinja null too, matching `PromptCanonicalizer.canonicalTool` (via `jcsOrNull`), which already collapses absent and explicit-null to the same JCS null. The rendered template can no longer diverge from the signed prompt hash.
- **Depth guard at the real boundary** — `ChatCompletionRequest.validateTools` rejects over-deep tool schemas `400 invalid_tools` via an **iterative** (non-recursive) per-member depth-1 probe against `JSONSchemaValidator.maxDepth`, **before** the recursive `JSONValue.parse`. It's a raw stack-safety backstop and covers **every** tool member (no `tools[i].<extra>` bypass). Exact 32/33 boundary is tested.
- **Taxonomy** — drops #719's `chat_template_error`; stays on the established SPEC-001 set.
- Pins `swift-jinja 2.3.6` (already resolved transitively) for the `import`.

## Deliberately deferred (not silently changed)

The residual `model_not_loaded` mapping for **post-load inference failures** is **preserved**. It's pre-existing behavior that **SPEC-015 §M.5 (AC-31)** relies on to issue a null-usage (0-token) error receipt = proof of no charge. An audit lane flagged the taxonomy as impure; changing it alters signed-receipt economics and is left to a governed SPEC decision, documented in-code — not folded into a null-handling fix.

## Verification

- **80 tests pass, 0 failures**; builds green.
- **3-lane codex audit (code / security / architect)** against the full combined fix diff, iterated to **0 Critical/High/Medium**.
- Pre-existing, unrelated failures (`SelfUpdateTests` version-string assertion; MLX `default.metallib` in headless env) fail identically on clean `main` — out of scope.

## Governance note — advisory `spec-index / check` is red BY DESIGN

`SPEC-018` / `agentic-tool-calling` (which governs tool-schema rendering) has **no requirements defined** in `specs/CONFORMANCE.json`, so the declaration below cites the real spec and domain but an **empty `requirements` array**. The advisory `spec-index / check` therefore fails on "requires at least one requirement" — an **honest** red reflecting the governance gap, tracked in #726. Unlike #719 (which invented a non-existent `SPEC-018-R001` and was admin-bypassed), this PR does not fake a requirement. The **required** gate `ci-required` is unaffected.

SPEC-GOVERNANCE-DECLARATION-BEGIN
{
  "schema_version": "spec-pr-governance-v1",
  "behavior_change": "yes",
  "contract_change": "none",
  "specs": ["SPEC-018"],
  "requirements": [],
  "authority_domains": ["agentic-tool-calling"],
  "arbitration": ["CODE_BUG"],
  "tests": [
    "phase3-binary/Tests/macprovider-cliTests/ToolCallParserTests.swift",
    "phase3-binary/Tests/macprovider-cliTests/HTTPServerReceiptTests.swift"
  ],
  "journeys": ["not-required"],
  "issue": "https://github.com/Augustas11/macprovider/issues/718"
}
SPEC-GOVERNANCE-DECLARATION-END
