### PR TITLE
Bind Step D proof to the physical provider model

### DIFF
--- a/ops/pearl-updater/catalog-canary-proof.py
+++ b/ops/pearl-updater/catalog-canary-proof.py
@@ -219,10 +219,17 @@ def main() -> int:
         catalog = local_status.get("catalog") if isinstance(local_status, dict) else None
         coordinator = local_status.get("coordinator") if isinstance(local_status, dict) else None
         assigned_id = coordinator.get("session") if isinstance(coordinator, dict) else None
+        model_id = local_status.get("model") if isinstance(local_status, dict) else None
+        catalog_model_id = catalog.get("model_id") if isinstance(catalog, dict) else None
         if (
             not isinstance(local_status, dict)
             or local_status.get("provider_id") != provider_id
             or local_status.get("network_state") != "buyer_serving"
+            or local_status.get("model_loaded") is not True
+            or not isinstance(model_id, str)
+            or not model_id
+            or len(model_id) > 512
+            or model_id.strip() != model_id
             or not isinstance(coordinator, dict)
             or coordinator.get("connected") is not True
             or not isinstance(assigned_id, str)
@@ -233,6 +240,7 @@ def main() -> int:
             or catalog.get("digest") != digest
             or catalog.get("signer_key_id") != signer
             or re.fullmatch(r"[0-9a-f]{64}", str(catalog.get("row_identity", "")).lower()) is None
+            or catalog_model_id != model_id
         ):
             fail("live canary status does not match the expected provider and catalog")
 
@@ -243,6 +251,7 @@ def main() -> int:
         print(json.dumps({
             "provider_id": installed_provider_id,
             "assigned_id": assigned_id,
+            "model_id": model_id,
             "launchd_pid": pid,
             "executable_path": process_path,
             "local_status": local_status,

--- a/ops/pearl-updater/macprovider-pearl-update
+++ b/ops/pearl-updater/macprovider-pearl-update
@@ -4161,7 +4161,7 @@ class Updater:
         candidate_signer: str,
         *,
         deadline: float | None = None,
-    ) -> str:
+    ) -> tuple[str, str, str]:
         proof_program = _read_trusted_text(
             self.catalog_canary_proof,
             "catalog canary proof program",
@@ -4224,6 +4224,7 @@ class Updater:
         except (ValueError, KeyError, TypeError) as exc:
             raise UpdateError("trusted catalog canary Mac proof is invalid") from exc
         row_identity = local_catalog.get("row_identity") if isinstance(local_catalog, dict) else None
+        model_id = proof.get("model_id") if isinstance(proof, dict) else None
         assigned_id = proof.get("assigned_id") if isinstance(proof, dict) else None
         if (
             not isinstance(proof, dict)
@@ -4233,6 +4234,8 @@ class Updater:
             or not isinstance(local_status, dict)
             or local_status.get("provider_id") != provider_id
             or local_status.get("network_state") != "buyer_serving"
+            or local_status.get("model_loaded") is not True
+            or local_status.get("model") != model_id
             or not isinstance(local_coordinator, dict)
             or local_coordinator.get("connected") is not True
             or local_coordinator.get("session") != assigned_id
@@ -4245,10 +4248,15 @@ class Updater:
             or local_catalog.get("signer_key_id") != candidate_signer
             or not isinstance(row_identity, str)
             or not SHA256_RE.fullmatch(row_identity.lower())
+            or not isinstance(model_id, str)
+            or not model_id
+            or len(model_id) > 512
+            or model_id.strip() != model_id
+            or local_catalog.get("model_id") != model_id
             or files != release.catalog.files
         ):
             raise UpdateError("trusted catalog canary Mac proof does not match the candidate release")
-        return row_identity.lower(), assigned_id
+        return row_identity.lower(), assigned_id, model_id
 
     def catalog_provider_admission_ready(
         self,
@@ -4297,13 +4305,13 @@ class Updater:
             and str(status.get("catalog_row_identity", "")).lower() == row_identity
         )
 
-    def verify_exact_provider_canary(self, release: Release) -> None:
+    def verify_exact_provider_canary(self, release: Release) -> str:
         provider_id, token = self.validate_catalog_canary_configuration()
         candidate_digest, candidate_signer = self.catalog_candidate_identity(release)
         verified: dict[str, str] = {}
 
         def exact_canary_ready(deadline: float) -> bool:
-            row_identity, assigned_id = self.prove_catalog_canary_mac(
+            row_identity, assigned_id, model_id = self.prove_catalog_canary_mac(
                 release,
                 provider_id,
                 candidate_digest,
@@ -4323,6 +4331,7 @@ class Updater:
                 return False
             verified["row_identity"] = row_identity
             verified["assigned_id"] = assigned_id
+            verified["model_id"] = model_id
             return True
 
         self.wait_for_with_deadline(
@@ -4340,13 +4349,9 @@ class Updater:
             catalog_signer_key_id=candidate_signer,
             catalog_row_identity=verified["row_identity"],
             assigned_id=verified["assigned_id"],
+            model=verified["model_id"],
         )
-
-    def _catalog_canary_expected_model(self) -> str:
-        for row in self._canary_expected_fleet():
-            if row["provider_id"] == self.config.catalog_canary_provider_id:
-                return row["model_id"]
-        raise UpdateError("catalog canary provider is not bound in the expected fleet")
+        return verified["model_id"]
 
     def _buyer_token(self) -> str:
         token = _read_trusted_text(
@@ -4477,7 +4482,7 @@ class Updater:
             raise UpdateError("prove-current requires hard-disabled buyer canary configuration")
         self.verify_live_runtime_binding(release)
         provider_id = self.config.catalog_canary_provider_id
-        model_id = self._catalog_canary_expected_model()
+        model_id = self.verify_exact_provider_canary(release)
         seen_request_ids: set[str] = set()
         seen_timestamps: set[str] = set()
         for cycle in range(1, 4):
@@ -4487,7 +4492,8 @@ class Updater:
                 provider_id=provider_id,
                 model_id=model_id,
             )
-            self.verify_exact_provider_canary(release)
+            if self.verify_exact_provider_canary(release) != model_id:
+                raise UpdateError("catalog canary model changed during the buyer journey proof")
             if buyer_proof["response_request_id"] in seen_request_ids:
                 raise UpdateError("gateway buyer proof response request IDs are not unique")
             if buyer_proof["requested_at"] in seen_timestamps:

--- a/ops/pearl-updater/macprovider-pearl-update
+++ b/ops/pearl-updater/macprovider-pearl-update
@@ -268,6 +268,13 @@ class CatalogRelease:
 
 
 @dataclasses.dataclass(frozen=True)
+class CatalogCanaryEvidence:
+    row_identity: str
+    assigned_id: str
+    model_id: str
+
+
+@dataclasses.dataclass(frozen=True)
 class ProviderAdmissionRollout:
     mode: str
     enforce_provider_admission: bool
@@ -4161,7 +4168,7 @@ class Updater:
         candidate_signer: str,
         *,
         deadline: float | None = None,
-    ) -> tuple[str, str, str]:
+    ) -> CatalogCanaryEvidence:
         proof_program = _read_trusted_text(
             self.catalog_canary_proof,
             "catalog canary proof program",
@@ -4256,7 +4263,11 @@ class Updater:
             or files != release.catalog.files
         ):
             raise UpdateError("trusted catalog canary Mac proof does not match the candidate release")
-        return row_identity.lower(), assigned_id, model_id
+        return CatalogCanaryEvidence(
+            row_identity=row_identity.lower(),
+            assigned_id=assigned_id,
+            model_id=model_id,
+        )
 
     def catalog_provider_admission_ready(
         self,
@@ -4305,13 +4316,13 @@ class Updater:
             and str(status.get("catalog_row_identity", "")).lower() == row_identity
         )
 
-    def verify_exact_provider_canary(self, release: Release) -> str:
+    def verify_exact_provider_canary(self, release: Release) -> CatalogCanaryEvidence:
         provider_id, token = self.validate_catalog_canary_configuration()
         candidate_digest, candidate_signer = self.catalog_candidate_identity(release)
-        verified: dict[str, str] = {}
+        verified: dict[str, CatalogCanaryEvidence] = {}
 
         def exact_canary_ready(deadline: float) -> bool:
-            row_identity, assigned_id, model_id = self.prove_catalog_canary_mac(
+            evidence = self.prove_catalog_canary_mac(
                 release,
                 provider_id,
                 candidate_digest,
@@ -4324,14 +4335,12 @@ class Updater:
                 token,
                 candidate_digest,
                 candidate_signer,
-                row_identity,
-                assigned_id,
+                evidence.row_identity,
+                evidence.assigned_id,
                 deadline=deadline,
             ):
                 return False
-            verified["row_identity"] = row_identity
-            verified["assigned_id"] = assigned_id
-            verified["model_id"] = model_id
+            verified["evidence"] = evidence
             return True
 
         self.wait_for_with_deadline(
@@ -4339,6 +4348,9 @@ class Updater:
             self.config.provider_recovery_timeout_s,
             exact_canary_ready,
         )
+        evidence = verified.get("evidence")
+        if evidence is None:
+            raise UpdateError("exact catalog-aware provider proof returned no evidence")
         self.audit(
             "exact_catalog_provider_canary",
             "success",
@@ -4347,11 +4359,11 @@ class Updater:
             catalog_policy_version=release.catalog.policy_version,
             catalog_candidate_sha256=candidate_digest,
             catalog_signer_key_id=candidate_signer,
-            catalog_row_identity=verified["row_identity"],
-            assigned_id=verified["assigned_id"],
-            model=verified["model_id"],
+            catalog_row_identity=evidence.row_identity,
+            assigned_id=evidence.assigned_id,
+            model=evidence.model_id,
         )
-        return verified["model_id"]
+        return evidence
 
     def _buyer_token(self) -> str:
         token = _read_trusted_text(
@@ -4482,7 +4494,8 @@ class Updater:
             raise UpdateError("prove-current requires hard-disabled buyer canary configuration")
         self.verify_live_runtime_binding(release)
         provider_id = self.config.catalog_canary_provider_id
-        model_id = self.verify_exact_provider_canary(release)
+        provider_evidence = self.verify_exact_provider_canary(release)
+        model_id = provider_evidence.model_id
         seen_request_ids: set[str] = set()
         seen_timestamps: set[str] = set()
         for cycle in range(1, 4):
@@ -4492,8 +4505,8 @@ class Updater:
                 provider_id=provider_id,
                 model_id=model_id,
             )
-            if self.verify_exact_provider_canary(release) != model_id:
-                raise UpdateError("catalog canary model changed during the buyer journey proof")
+            if self.verify_exact_provider_canary(release) != provider_evidence:
+                raise UpdateError("catalog canary identity changed during the buyer journey proof")
             if buyer_proof["response_request_id"] in seen_request_ids:
                 raise UpdateError("gateway buyer proof response request IDs are not unique")
             if buyer_proof["requested_at"] in seen_timestamps:
@@ -4509,6 +4522,8 @@ class Updater:
                 catalog_policy_version=release.catalog.policy_version,
                 provider_id=provider_id,
                 model=model_id,
+                assigned_id=provider_evidence.assigned_id,
+                catalog_row_identity=provider_evidence.row_identity,
                 request_id=buyer_proof["request_id"],
                 response_request_id=buyer_proof["response_request_id"],
                 requested_at=buyer_proof["requested_at"],

--- a/ops/pearl-updater/test_pearl_updater.py
+++ b/ops/pearl-updater/test_pearl_updater.py
@@ -1665,10 +1665,10 @@ class PearlUpdaterTests(unittest.TestCase):
                     signer,
                     deadline=125.0,
                 ),
-                (
-                    row_identity,
-                    "session-canary",
-                    "mlx-community/Llama-3.2-3B-Instruct-4bit",
+                updater_module.CatalogCanaryEvidence(
+                    row_identity=row_identity,
+                    assigned_id="session-canary",
+                    model_id="mlx-community/Llama-3.2-3B-Instruct-4bit",
                 ),
             )
         args, kwargs = self.updater.run_command.call_args
@@ -1746,10 +1746,10 @@ class PearlUpdaterTests(unittest.TestCase):
         order = []
         self.updater.prove_catalog_canary_mac = mock.Mock(
             side_effect=lambda *_args, **_kwargs: order.append("mac")
-            or (
-                "b" * 64,
-                "session-canary",
-                "mlx-community/Llama-3.2-3B-Instruct-4bit",
+            or updater_module.CatalogCanaryEvidence(
+                row_identity="b" * 64,
+                assigned_id="session-canary",
+                model_id="mlx-community/Llama-3.2-3B-Instruct-4bit",
             )
         )
         self.updater.catalog_provider_admission_ready = mock.Mock(
@@ -1763,7 +1763,11 @@ class PearlUpdaterTests(unittest.TestCase):
 
         self.assertEqual(
             self.updater.verify_exact_provider_canary(release),
-            "mlx-community/Llama-3.2-3B-Instruct-4bit",
+            updater_module.CatalogCanaryEvidence(
+                row_identity="b" * 64,
+                assigned_id="session-canary",
+                model_id="mlx-community/Llama-3.2-3B-Instruct-4bit",
+            ),
         )
 
         self.assertEqual(order, ["mac", "pool"])
@@ -1792,15 +1796,15 @@ class PearlUpdaterTests(unittest.TestCase):
         self.updater.prove_catalog_canary_mac = mock.Mock(
             side_effect=[
                 updater_module.UpdateError("provider not installed yet"),
-                (
-                    row_identity,
-                    "session-before-reconnect",
-                    "mlx-community/Llama-3.2-3B-Instruct-4bit",
+                updater_module.CatalogCanaryEvidence(
+                    row_identity=row_identity,
+                    assigned_id="session-before-reconnect",
+                    model_id="mlx-community/Llama-3.2-3B-Instruct-4bit",
                 ),
-                (
-                    row_identity,
-                    "session-after-reconnect",
-                    "mlx-community/Llama-3.2-3B-Instruct-4bit",
+                updater_module.CatalogCanaryEvidence(
+                    row_identity=row_identity,
+                    assigned_id="session-after-reconnect",
+                    model_id="mlx-community/Llama-3.2-3B-Instruct-4bit",
                 ),
             ]
         )
@@ -3573,8 +3577,13 @@ class PearlUpdaterTests(unittest.TestCase):
             catalog_canary_provider_id="catalog-canary",
         )
         self.updater.verify_buyer_canary_rollout_posture = mock.Mock()
+        provider_evidence = updater_module.CatalogCanaryEvidence(
+            row_identity="b" * 64,
+            assigned_id="session-canary",
+            model_id="mlx-community/Llama-3.2-3B-Instruct-4bit",
+        )
         self.updater.verify_exact_provider_canary = mock.Mock(
-            return_value="mlx-community/Llama-3.2-3B-Instruct-4bit"
+            return_value=provider_evidence
         )
         self.updater.verify_live_runtime_binding = mock.Mock()
         self.updater.prove_gateway_buyer_stream = mock.Mock(
@@ -3625,6 +3634,13 @@ class PearlUpdaterTests(unittest.TestCase):
             if call.args[:2] == ("single_authority_buyer_serving_cycle", "success")
         ]
         self.assertEqual([call.kwargs["cycle"] for call in proof_events], [1, 2, 3])
+        self.assertTrue(
+            all(
+                call.kwargs["assigned_id"] == provider_evidence.assigned_id
+                and call.kwargs["catalog_row_identity"] == provider_evidence.row_identity
+                for call in proof_events
+            )
+        )
         self.updater.prepare_config_update.assert_not_called()
         self.updater.snapshot.assert_not_called()
         self.updater.install_release.assert_not_called()
@@ -3634,8 +3650,11 @@ class PearlUpdaterTests(unittest.TestCase):
             return_value=True,
         )
         self.updater.verify_exact_provider_canary.side_effect = [
-            "mlx-community/Llama-3.2-3B-Instruct-4bit",
-            "mlx-community/Qwen3-Coder-30B-A3B-Instruct-4bit",
+            provider_evidence,
+            updater_module.dataclasses.replace(
+                provider_evidence,
+                assigned_id="replacement-session",
+            ),
         ]
         self.updater.prove_gateway_buyer_stream.reset_mock(
             side_effect=True,
@@ -3652,7 +3671,7 @@ class PearlUpdaterTests(unittest.TestCase):
 
         with self.assertRaisesRegex(
             updater_module.UpdateError,
-            "catalog canary model changed",
+            "catalog canary identity changed",
         ):
             self.updater.prove_current_release(release)
 
@@ -4792,10 +4811,10 @@ class PearlUpdaterTests(unittest.TestCase):
             return_value=("catalog-canary", "t" * 32)
         )
         self.updater.prove_catalog_canary_mac = mock.Mock(
-            return_value=(
-                expected_row_identity,
-                "session-canary",
-                "mlx-community/Llama-3.2-3B-Instruct-4bit",
+            return_value=updater_module.CatalogCanaryEvidence(
+                row_identity=expected_row_identity,
+                assigned_id="session-canary",
+                model_id="mlx-community/Llama-3.2-3B-Instruct-4bit",
             )
         )
         self.updater.get_authorized_json = mock.Mock(

--- a/ops/pearl-updater/test_pearl_updater.py
+++ b/ops/pearl-updater/test_pearl_updater.py
@@ -1625,10 +1625,13 @@ class PearlUpdaterTests(unittest.TestCase):
         proof = {
             "provider_id": "catalog-canary",
             "assigned_id": "session-canary",
+            "model_id": "mlx-community/Llama-3.2-3B-Instruct-4bit",
             "launchd_pid": 123,
             "local_status": {
                 "provider_id": "catalog-canary",
                 "network_state": "buyer_serving",
+                "model": "mlx-community/Llama-3.2-3B-Instruct-4bit",
+                "model_loaded": True,
                 "coordinator": {"connected": True, "session": "session-canary"},
                 "catalog": {
                     "release_id": release.catalog.release_id,
@@ -1636,6 +1639,7 @@ class PearlUpdaterTests(unittest.TestCase):
                     "digest": digest,
                     "signer_key_id": signer,
                     "row_identity": row_identity,
+                    "model_id": "mlx-community/Llama-3.2-3B-Instruct-4bit",
                 },
             },
             "files": dict(release.catalog.files),
@@ -1661,7 +1665,11 @@ class PearlUpdaterTests(unittest.TestCase):
                     signer,
                     deadline=125.0,
                 ),
-                (row_identity, "session-canary"),
+                (
+                    row_identity,
+                    "session-canary",
+                    "mlx-community/Llama-3.2-3B-Instruct-4bit",
+                ),
             )
         args, kwargs = self.updater.run_command.call_args
         self.assertIn(
@@ -1671,6 +1679,8 @@ class PearlUpdaterTests(unittest.TestCase):
         self.assertEqual(args[0][-2], "operator@canary.example")
         self.assertIn("catalog-canary", args[0][-1])
         self.assertIn("running_text_vnode", kwargs["input_text"])
+        self.assertIn('local_status.get("model_loaded") is not True', kwargs["input_text"])
+        self.assertIn("catalog_model_id != model_id", kwargs["input_text"])
         self.assertEqual(kwargs["timeout"], 25.0)
 
         proof["files"]["release.json"] = "0" * 64
@@ -1684,6 +1694,35 @@ class PearlUpdaterTests(unittest.TestCase):
             self.updater.prove_catalog_canary_mac(
                 release, "catalog-canary", digest, signer
             )
+
+        proof["files"] = dict(release.catalog.files)
+        invalid_model_proofs = {
+            "runtime model missing": {"local_status.model": None},
+            "runtime model not loaded": {"local_status.model_loaded": False},
+            "catalog model mismatch": {
+                "local_status.catalog.model_id": "different/model"
+            },
+            "emitted model mismatch": {"model_id": "different/model"},
+        }
+        for label, mutations in invalid_model_proofs.items():
+            with self.subTest(label=label):
+                invalid_proof = json.loads(json.dumps(proof))
+                for path, value in mutations.items():
+                    target = invalid_proof
+                    parts = path.split(".")
+                    for part in parts[:-1]:
+                        target = target[part]
+                    target[parts[-1]] = value
+                self.updater.run_command.return_value = subprocess.CompletedProcess(
+                    ["ssh"], 0, stdout=json.dumps(invalid_proof), stderr=""
+                )
+                with self.assertRaisesRegex(
+                    updater_module.UpdateError,
+                    "does not match the candidate release",
+                ):
+                    self.updater.prove_catalog_canary_mac(
+                        release, "catalog-canary", digest, signer
+                    )
 
     def test_exact_provider_canary_runs_mac_proof_before_authoritative_pool_gate(self):
         release = self.verify()
@@ -1706,7 +1745,12 @@ class PearlUpdaterTests(unittest.TestCase):
         )
         order = []
         self.updater.prove_catalog_canary_mac = mock.Mock(
-            side_effect=lambda *_args, **_kwargs: order.append("mac") or ("b" * 64, "session-canary")
+            side_effect=lambda *_args, **_kwargs: order.append("mac")
+            or (
+                "b" * 64,
+                "session-canary",
+                "mlx-community/Llama-3.2-3B-Instruct-4bit",
+            )
         )
         self.updater.catalog_provider_admission_ready = mock.Mock(
             side_effect=lambda *_args, **_kwargs: order.append("pool") or True
@@ -1717,7 +1761,10 @@ class PearlUpdaterTests(unittest.TestCase):
             )
         )
 
-        self.updater.verify_exact_provider_canary(release)
+        self.assertEqual(
+            self.updater.verify_exact_provider_canary(release),
+            "mlx-community/Llama-3.2-3B-Instruct-4bit",
+        )
 
         self.assertEqual(order, ["mac", "pool"])
 
@@ -1745,8 +1792,16 @@ class PearlUpdaterTests(unittest.TestCase):
         self.updater.prove_catalog_canary_mac = mock.Mock(
             side_effect=[
                 updater_module.UpdateError("provider not installed yet"),
-                (row_identity, "session-before-reconnect"),
-                (row_identity, "session-after-reconnect"),
+                (
+                    row_identity,
+                    "session-before-reconnect",
+                    "mlx-community/Llama-3.2-3B-Instruct-4bit",
+                ),
+                (
+                    row_identity,
+                    "session-after-reconnect",
+                    "mlx-community/Llama-3.2-3B-Instruct-4bit",
+                ),
             ]
         )
         self.updater.catalog_provider_admission_ready = mock.Mock(
@@ -1776,6 +1831,7 @@ class PearlUpdaterTests(unittest.TestCase):
             catalog_signer_key_id=self.updater.catalog_candidate_identity(release)[1],
             catalog_row_identity=row_identity,
             assigned_id="session-after-reconnect",
+            model="mlx-community/Llama-3.2-3B-Instruct-4bit",
         )
 
     def test_gateway_buyer_stream_requires_provider_model_token_done_and_request_id(self):
@@ -3517,9 +3573,10 @@ class PearlUpdaterTests(unittest.TestCase):
             catalog_canary_provider_id="catalog-canary",
         )
         self.updater.verify_buyer_canary_rollout_posture = mock.Mock()
-        self.updater.verify_exact_provider_canary = mock.Mock()
+        self.updater.verify_exact_provider_canary = mock.Mock(
+            return_value="mlx-community/Llama-3.2-3B-Instruct-4bit"
+        )
         self.updater.verify_live_runtime_binding = mock.Mock()
-        self.updater._catalog_canary_expected_model = mock.Mock(return_value="mlx-community/Llama-3.2-3B-Instruct-4bit")
         self.updater.prove_gateway_buyer_stream = mock.Mock(
             side_effect=[
                 {
@@ -3546,7 +3603,7 @@ class PearlUpdaterTests(unittest.TestCase):
         self.assertEqual((str(current), decision), ("1.8.27", "already_current"))
         self.updater.verify_live_runtime_binding.assert_called_once_with(release)
         self.assertEqual(self.updater.verify_buyer_canary_rollout_posture.call_count, 3)
-        self.assertEqual(self.updater.verify_exact_provider_canary.call_args_list, [mock.call(release)] * 3)
+        self.assertEqual(self.updater.verify_exact_provider_canary.call_args_list, [mock.call(release)] * 4)
         self.assertEqual(
             self.updater.prove_gateway_buyer_stream.call_args_list,
             [
@@ -3560,7 +3617,7 @@ class PearlUpdaterTests(unittest.TestCase):
         )
         self.assertEqual(
             [call[0] for call in proof_order.mock_calls],
-            ["posture", "buyer", "provider"] * 3,
+            ["provider"] + ["posture", "buyer", "provider"] * 3,
         )
         proof_events = [
             call
@@ -3571,6 +3628,40 @@ class PearlUpdaterTests(unittest.TestCase):
         self.updater.prepare_config_update.assert_not_called()
         self.updater.snapshot.assert_not_called()
         self.updater.install_release.assert_not_called()
+
+        self.updater.verify_exact_provider_canary.reset_mock(
+            side_effect=True,
+            return_value=True,
+        )
+        self.updater.verify_exact_provider_canary.side_effect = [
+            "mlx-community/Llama-3.2-3B-Instruct-4bit",
+            "mlx-community/Qwen3-Coder-30B-A3B-Instruct-4bit",
+        ]
+        self.updater.prove_gateway_buyer_stream.reset_mock(
+            side_effect=True,
+            return_value=True,
+        )
+        self.updater.prove_gateway_buyer_stream.return_value = {
+            "request_id": "request-model-change",
+            "response_request_id": "gateway-request-model-change",
+            "requested_at": "2026-07-23T00:01:00Z",
+            "provider_id": "catalog-canary",
+            "model": "mlx-community/Llama-3.2-3B-Instruct-4bit",
+        }
+        self.updater.audit.reset_mock()
+
+        with self.assertRaisesRegex(
+            updater_module.UpdateError,
+            "catalog canary model changed",
+        ):
+            self.updater.prove_current_release(release)
+
+        self.assertFalse(
+            any(
+                call.args[:2] == ("single_authority_buyer_serving_cycle", "success")
+                for call in self.updater.audit.call_args_list
+            )
+        )
 
     def test_prove_current_rejects_preconditions_fail_closed(self):
         release = self.stage(self.verify())
@@ -4701,7 +4792,11 @@ class PearlUpdaterTests(unittest.TestCase):
             return_value=("catalog-canary", "t" * 32)
         )
         self.updater.prove_catalog_canary_mac = mock.Mock(
-            return_value=(expected_row_identity, "session-canary")
+            return_value=(
+                expected_row_identity,
+                "session-canary",
+                "mlx-community/Llama-3.2-3B-Instruct-4bit",
+            )
         )
         self.updater.get_authorized_json = mock.Mock(
             return_value={


### PR DESCRIPTION
## Outcome

Repairs issue #608 Step D journey proof so it derives the requested model from the exact physical canary Mac’s loaded runtime and signed catalog status instead of comparing the canonical `mp-*` provider ID with unrelated expected-fleet aliases.

## Safety boundary

- requires `model_loaded=true`
- requires the live runtime model to exactly equal the signed catalog row model
- resolves the model only after the existing pinned SSH host, live PID/text-vnode/listener, signed release, file-hash, provider-ID, session, and public admission checks pass
- carries immutable row identity, assigned session, and model evidence
- requires that exact evidence to remain unchanged before and after all three buyer journeys
- preserves hard-disabled buyer canary posture and `tier2.require_hash_verified=false`
- does not mutate Pearl in this PR; production proof rerun remains gated on squash merge and exact merged-byte installation

## Root cause

The initial Step D proof looked up the canonical catalog-canary provider ID in `/etc/macprovider/canary-buyer.expected-fleet.json`. Pearl’s protected fleet file uses operational aliases (`mac`, `augustass-macbook-air`), so a healthy canonical `mp-*` provider could never resolve a model. Review also found that retaining only provider/model across the buyer request could miss a same-provider session replacement; the final head retains and compares the exact assigned session and catalog row as well.

## Validation

- `make test-dist` — pass on exact head (expected platform skips only)
- Pearl updater suite — 162 passed, 1 Linux-root-only skip
- Python compile and `git diff --check` — pass
- adversarial coverage for missing/unloaded/mismatched runtime and catalog models, emitted-proof mismatch, and same-model session replacement
- Codex code audit — 0 CRITICAL / 0 HIGH / 0 MEDIUM / 0 LOW
- Codex security audit — 0 CRITICAL / 0 HIGH / 0 MEDIUM / 0 LOW
- Codex architecture audit — 0 CRITICAL / 0 HIGH / 0 MEDIUM / 0 LOW

SPEC-GOVERNANCE-DECLARATION-BEGIN
{
  "schema_version": "spec-pr-governance-v1",
  "behavior_change": "yes",
  "contract_change": "none",
  "specs": ["SPEC-010"],
  "requirements": ["SPEC-010-R004"],
  "authority_domains": ["model-catalog-identity"],
  "arbitration": ["CODE_BUG"],
  "tests": ["ops/pearl-updater/test_pearl_updater.py"],
  "journeys": ["not-required"],
  "issue": "https://github.com/Augustas11/macprovider/issues/608"
}
SPEC-GOVERNANCE-DECLARATION-END

Part of #608.
