### PR TITLE
Fix Step D proof model identity boundary

### DIFF
--- a/ops/pearl-updater/catalog-canary-proof.py
+++ b/ops/pearl-updater/catalog-canary-proof.py
@@ -220,6 +220,7 @@ def main() -> int:
         coordinator = local_status.get("coordinator") if isinstance(local_status, dict) else None
         assigned_id = coordinator.get("session") if isinstance(coordinator, dict) else None
         model_id = local_status.get("model") if isinstance(local_status, dict) else None
+        catalog_key = catalog.get("catalog_key") if isinstance(catalog, dict) else None
         catalog_model_id = catalog.get("model_id") if isinstance(catalog, dict) else None
         if (
             not isinstance(local_status, dict)
@@ -240,7 +241,11 @@ def main() -> int:
             or catalog.get("digest") != digest
             or catalog.get("signer_key_id") != signer
             or re.fullmatch(r"[0-9a-f]{64}", str(catalog.get("row_identity", "")).lower()) is None
-            or catalog_model_id != model_id
+            or catalog_key != model_id
+            or not isinstance(catalog_model_id, str)
+            or not catalog_model_id
+            or len(catalog_model_id) > 512
+            or catalog_model_id.strip() != catalog_model_id
         ):
             fail("live canary status does not match the expected provider and catalog")
 

--- a/ops/pearl-updater/macprovider-pearl-update
+++ b/ops/pearl-updater/macprovider-pearl-update
@@ -4259,7 +4259,11 @@ class Updater:
             or not model_id
             or len(model_id) > 512
             or model_id.strip() != model_id
-            or local_catalog.get("model_id") != model_id
+            or local_catalog.get("catalog_key") != model_id
+            or not isinstance(local_catalog.get("model_id"), str)
+            or not local_catalog["model_id"]
+            or len(local_catalog["model_id"]) > 512
+            or local_catalog["model_id"].strip() != local_catalog["model_id"]
             or files != release.catalog.files
         ):
             raise UpdateError("trusted catalog canary Mac proof does not match the candidate release")

--- a/ops/pearl-updater/test_pearl_updater.py
+++ b/ops/pearl-updater/test_pearl_updater.py
@@ -1625,12 +1625,12 @@ class PearlUpdaterTests(unittest.TestCase):
         proof = {
             "provider_id": "catalog-canary",
             "assigned_id": "session-canary",
-            "model_id": "mlx-community/Llama-3.2-3B-Instruct-4bit",
+            "model_id": "llama-3.2-3b-instruct",
             "launchd_pid": 123,
             "local_status": {
                 "provider_id": "catalog-canary",
                 "network_state": "buyer_serving",
-                "model": "mlx-community/Llama-3.2-3B-Instruct-4bit",
+                "model": "llama-3.2-3b-instruct",
                 "model_loaded": True,
                 "coordinator": {"connected": True, "session": "session-canary"},
                 "catalog": {
@@ -1639,6 +1639,7 @@ class PearlUpdaterTests(unittest.TestCase):
                     "digest": digest,
                     "signer_key_id": signer,
                     "row_identity": row_identity,
+                    "catalog_key": "llama-3.2-3b-instruct",
                     "model_id": "mlx-community/Llama-3.2-3B-Instruct-4bit",
                 },
             },
@@ -1668,7 +1669,7 @@ class PearlUpdaterTests(unittest.TestCase):
                 updater_module.CatalogCanaryEvidence(
                     row_identity=row_identity,
                     assigned_id="session-canary",
-                    model_id="mlx-community/Llama-3.2-3B-Instruct-4bit",
+                    model_id="llama-3.2-3b-instruct",
                 ),
             )
         args, kwargs = self.updater.run_command.call_args
@@ -1680,7 +1681,7 @@ class PearlUpdaterTests(unittest.TestCase):
         self.assertIn("catalog-canary", args[0][-1])
         self.assertIn("running_text_vnode", kwargs["input_text"])
         self.assertIn('local_status.get("model_loaded") is not True', kwargs["input_text"])
-        self.assertIn("catalog_model_id != model_id", kwargs["input_text"])
+        self.assertIn("catalog_key != model_id", kwargs["input_text"])
         self.assertEqual(kwargs["timeout"], 25.0)
 
         proof["files"]["release.json"] = "0" * 64
@@ -1699,10 +1700,9 @@ class PearlUpdaterTests(unittest.TestCase):
         invalid_model_proofs = {
             "runtime model missing": {"local_status.model": None},
             "runtime model not loaded": {"local_status.model_loaded": False},
-            "catalog model mismatch": {
-                "local_status.catalog.model_id": "different/model"
-            },
-            "emitted model mismatch": {"model_id": "different/model"},
+            "catalog key mismatch": {"local_status.catalog.catalog_key": "different-key"},
+            "catalog model ID missing": {"local_status.catalog.model_id": None},
+            "emitted model key mismatch": {"model_id": "different-key"},
         }
         for label, mutations in invalid_model_proofs.items():
             with self.subTest(label=label):


### PR DESCRIPTION
## What changed

- bind the physical Mac runtime model to the signed catalog `catalog_key`
- validate canonical `catalog.model_id` independently instead of conflating the two namespaces
- preserve the routed catalog key through the frozen provider evidence and three buyer-journey checks
- add fail-closed regression coverage for key mismatch and missing canonical model ID

## Root cause

The provider and buyer API intentionally use `model_catalog_key` (`qwen3-coder-30b-a3b-instruct`), while `catalog.model_id` identifies the canonical model artifact (`mlx-community/Qwen3-Coder-30B-A3B-Instruct-4bit`). PR #728 incorrectly required them to be equal, so the production Step D proof stopped before buyer traffic even though the provider, release binding, session, and signed row were healthy.

## Impact

This unblocks issue #608 Step D journey proof without weakening catalog authority. The proof still binds the physical provider, executable/PID/listener, loaded runtime key, coordinator session, release/policy/digest/signer/row identity, canonical model ID presence, and exact signed catalog files. `tier2.require_hash_verified` remains false and buyer canary remains hard-disabled.

Closes no issue; advances #608.

## Validation

- Python compilation passed
- updater suite: 162 passed, 1 expected platform skip
- full `make test-dist` passed
- patched proof executed read-only against the live Pearl-selected Mac and returned the expected routed key plus canonical model ID
- exact-head audits: code 0 C/H/M/L; security 0 C/H/M/L; architecture 0 C/H/M/L
- `git diff --check` passed

Production buyer journeys remain intentionally pending until this exact head is reviewed, merged, and installed.

SPEC-GOVERNANCE-DECLARATION-BEGIN
{
  "schema_version": "spec-pr-governance-v1",
  "behavior_change": "yes",
  "contract_change": "none",
  "specs": ["SPEC-010"],
  "requirements": ["SPEC-010-R004"],
  "authority_domains": ["model-catalog-identity"],
  "arbitration": ["CODE_BUG"],
  "tests": [
    "ops/pearl-updater/test_pearl_updater.py::test_exact_provider_canary_mac_proof_is_pinned_and_matches_catalog_files",
    "make test-dist"
  ],
  "journeys": ["issue-608-step-d-single-authority-buyer-serving"],
  "issue": "https://github.com/Augustas11/macprovider/issues/608"
}
SPEC-GOVERNANCE-DECLARATION-END
