### PR TITLE
Fix Step D buyer model handoff

### DIFF
--- a/ops/pearl-updater/catalog-canary-proof.py
+++ b/ops/pearl-updater/catalog-canary-proof.py
@@ -256,7 +256,8 @@ def main() -> int:
         print(json.dumps({
             "provider_id": installed_provider_id,
             "assigned_id": assigned_id,
-            "model_id": model_id,
+            "catalog_key": model_id,
+            "model_id": catalog_model_id,
             "launchd_pid": pid,
             "executable_path": process_path,
             "local_status": local_status,

--- a/ops/pearl-updater/macprovider-pearl-update
+++ b/ops/pearl-updater/macprovider-pearl-update
@@ -271,6 +271,7 @@ class CatalogRelease:
 class CatalogCanaryEvidence:
     row_identity: str
     assigned_id: str
+    catalog_key: str
     model_id: str
 
 
@@ -4231,6 +4232,7 @@ class Updater:
         except (ValueError, KeyError, TypeError) as exc:
             raise UpdateError("trusted catalog canary Mac proof is invalid") from exc
         row_identity = local_catalog.get("row_identity") if isinstance(local_catalog, dict) else None
+        catalog_key = proof.get("catalog_key") if isinstance(proof, dict) else None
         model_id = proof.get("model_id") if isinstance(proof, dict) else None
         assigned_id = proof.get("assigned_id") if isinstance(proof, dict) else None
         if (
@@ -4242,7 +4244,7 @@ class Updater:
             or local_status.get("provider_id") != provider_id
             or local_status.get("network_state") != "buyer_serving"
             or local_status.get("model_loaded") is not True
-            or local_status.get("model") != model_id
+            or local_status.get("model") != catalog_key
             or not isinstance(local_coordinator, dict)
             or local_coordinator.get("connected") is not True
             or local_coordinator.get("session") != assigned_id
@@ -4255,21 +4257,23 @@ class Updater:
             or local_catalog.get("signer_key_id") != candidate_signer
             or not isinstance(row_identity, str)
             or not SHA256_RE.fullmatch(row_identity.lower())
+            or not isinstance(catalog_key, str)
+            or not catalog_key
+            or len(catalog_key) > 512
+            or catalog_key.strip() != catalog_key
             or not isinstance(model_id, str)
             or not model_id
             or len(model_id) > 512
             or model_id.strip() != model_id
-            or local_catalog.get("catalog_key") != model_id
-            or not isinstance(local_catalog.get("model_id"), str)
-            or not local_catalog["model_id"]
-            or len(local_catalog["model_id"]) > 512
-            or local_catalog["model_id"].strip() != local_catalog["model_id"]
+            or local_catalog.get("catalog_key") != catalog_key
+            or local_catalog.get("model_id") != model_id
             or files != release.catalog.files
         ):
             raise UpdateError("trusted catalog canary Mac proof does not match the candidate release")
         return CatalogCanaryEvidence(
             row_identity=row_identity.lower(),
             assigned_id=assigned_id,
+            catalog_key=catalog_key,
             model_id=model_id,
         )
 
@@ -4365,6 +4369,7 @@ class Updater:
             catalog_signer_key_id=candidate_signer,
             catalog_row_identity=evidence.row_identity,
             assigned_id=evidence.assigned_id,
+            catalog_key=evidence.catalog_key,
             model=evidence.model_id,
         )
         return evidence

--- a/ops/pearl-updater/test_pearl_updater.py
+++ b/ops/pearl-updater/test_pearl_updater.py
@@ -1625,7 +1625,8 @@ class PearlUpdaterTests(unittest.TestCase):
         proof = {
             "provider_id": "catalog-canary",
             "assigned_id": "session-canary",
-            "model_id": "llama-3.2-3b-instruct",
+            "catalog_key": "llama-3.2-3b-instruct",
+            "model_id": "mlx-community/Llama-3.2-3B-Instruct-4bit",
             "launchd_pid": 123,
             "local_status": {
                 "provider_id": "catalog-canary",
@@ -1669,7 +1670,8 @@ class PearlUpdaterTests(unittest.TestCase):
                 updater_module.CatalogCanaryEvidence(
                     row_identity=row_identity,
                     assigned_id="session-canary",
-                    model_id="llama-3.2-3b-instruct",
+                    catalog_key="llama-3.2-3b-instruct",
+                    model_id="mlx-community/Llama-3.2-3B-Instruct-4bit",
                 ),
             )
         args, kwargs = self.updater.run_command.call_args
@@ -1702,7 +1704,8 @@ class PearlUpdaterTests(unittest.TestCase):
             "runtime model not loaded": {"local_status.model_loaded": False},
             "catalog key mismatch": {"local_status.catalog.catalog_key": "different-key"},
             "catalog model ID missing": {"local_status.catalog.model_id": None},
-            "emitted model key mismatch": {"model_id": "different-key"},
+            "emitted catalog key mismatch": {"catalog_key": "different-key"},
+            "emitted model ID mismatch": {"model_id": "different-model"},
         }
         for label, mutations in invalid_model_proofs.items():
             with self.subTest(label=label):
@@ -1749,6 +1752,7 @@ class PearlUpdaterTests(unittest.TestCase):
             or updater_module.CatalogCanaryEvidence(
                 row_identity="b" * 64,
                 assigned_id="session-canary",
+                catalog_key="llama-3.2-3b-instruct",
                 model_id="mlx-community/Llama-3.2-3B-Instruct-4bit",
             )
         )
@@ -1766,6 +1770,7 @@ class PearlUpdaterTests(unittest.TestCase):
             updater_module.CatalogCanaryEvidence(
                 row_identity="b" * 64,
                 assigned_id="session-canary",
+                catalog_key="llama-3.2-3b-instruct",
                 model_id="mlx-community/Llama-3.2-3B-Instruct-4bit",
             ),
         )
@@ -1799,11 +1804,13 @@ class PearlUpdaterTests(unittest.TestCase):
                 updater_module.CatalogCanaryEvidence(
                     row_identity=row_identity,
                     assigned_id="session-before-reconnect",
+                    catalog_key="llama-3.2-3b-instruct",
                     model_id="mlx-community/Llama-3.2-3B-Instruct-4bit",
                 ),
                 updater_module.CatalogCanaryEvidence(
                     row_identity=row_identity,
                     assigned_id="session-after-reconnect",
+                    catalog_key="llama-3.2-3b-instruct",
                     model_id="mlx-community/Llama-3.2-3B-Instruct-4bit",
                 ),
             ]
@@ -1835,6 +1842,7 @@ class PearlUpdaterTests(unittest.TestCase):
             catalog_signer_key_id=self.updater.catalog_candidate_identity(release)[1],
             catalog_row_identity=row_identity,
             assigned_id="session-after-reconnect",
+            catalog_key="llama-3.2-3b-instruct",
             model="mlx-community/Llama-3.2-3B-Instruct-4bit",
         )
 
@@ -3580,6 +3588,7 @@ class PearlUpdaterTests(unittest.TestCase):
         provider_evidence = updater_module.CatalogCanaryEvidence(
             row_identity="b" * 64,
             assigned_id="session-canary",
+            catalog_key="llama-3.2-3b-instruct",
             model_id="mlx-community/Llama-3.2-3B-Instruct-4bit",
         )
         self.updater.verify_exact_provider_canary = mock.Mock(
@@ -4814,6 +4823,7 @@ class PearlUpdaterTests(unittest.TestCase):
             return_value=updater_module.CatalogCanaryEvidence(
                 row_identity=expected_row_identity,
                 assigned_id="session-canary",
+                catalog_key="llama-3.2-3b-instruct",
                 model_id="mlx-community/Llama-3.2-3B-Instruct-4bit",
             )
         )


### PR DESCRIPTION
## What changed

- emit and validate the provider runtime `catalog_key` separately from the canonical catalog `model_id`
- freeze both identities in the physical-provider evidence
- submit only the canonical `model_id` to the public buyer API during all three Step D journeys
- add fail-closed coverage for independently mismatched emitted keys and model IDs

## Root cause

The physical provider status uses the short signed catalog key (`qwen3-coder-30b-a3b-instruct`) for its loaded runtime, while the coordinator and public buyer API route the canonical catalog model ID (`mlx-community/Qwen3-Coder-30B-A3B-Instruct-4bit`). The prior proof repair validated both namespaces but stored the runtime key in the evidence field consumed by the buyer journey, producing a correct gateway `404 model_not_found` before any journey could be credited.

## Impact

This repairs only the Step D proof-controller handoff. It does not change the signed release, active Tier-2 authority, coordinator/gateway binaries, enforcement, or canary posture. The proof remains bound to the exact physical provider, session, signed catalog row, release/policy/digest/signer, runtime catalog key, canonical buyer model ID, and exact catalog files. `tier2.require_hash_verified` remains false and buyer canary remains hard-disabled.

Closes no issue; advances #608.

## Validation

- Python compilation passed
- updater suite: 162 passed, 1 expected platform skip
- full `make test-dist` passed
- exact-head audits: code 0 C/H/M/L; security 0 C/H/M/L; architecture 0 C/H/M/L
- read-only Pearl gateway evidence confirmed the rejected request used the short catalog key while canonical model requests were serving successfully
- `git diff --check` passed

Production buyer journeys remain intentionally pending until this exact head is reviewed, merged, and installed.

SPEC-GOVERNANCE-DECLARATION-BEGIN
{
  "schema_version": "spec-pr-governance-v1",
  "behavior_change": "yes",
  "contract_change": "none",
  "specs": ["SPEC-010"],
  "requirements": ["SPEC-010-R004"],
  "authority_domains": ["model-catalog-identity"],
  "arbitration": ["CODE_BUG"],
  "tests": [
    "ops/pearl-updater/test_pearl_updater.py::test_exact_provider_canary_mac_proof_is_pinned_and_matches_catalog_files",
    "ops/pearl-updater/test_pearl_updater.py::test_prove_current_runs_three_single_authority_cycles",
    "make test-dist"
  ],
  "journeys": ["issue-608-step-d-single-authority-buyer-serving"],
  "issue": "https://github.com/Augustas11/macprovider/issues/608"
}
SPEC-GOVERNANCE-DECLARATION-END
