### PR TITLE
fix(release): refresh reviewed openssl@3 formula pin after upstream recipe drift

### DIFF
--- a/scripts/install-sealed-release-openssl.sh
+++ b/scripts/install-sealed-release-openssl.sh
@@ -8,7 +8,7 @@ readonly expected_formula_revision="0"
 readonly expected_bottle_rebuild="1"
 readonly expected_bottle_tag="sequoia"
 readonly expected_bottle_sha256="5477285c4ebec45713873ae4002affece39e427c5f1b655c6a3df49c6b90f924"
-readonly expected_formula_sha256="773b90da6562a4018e1b5033b01432500002c4636cdfd35acf68d1a4b457590c"
+readonly expected_formula_sha256="00e19cdcb1b7d99058a8a15f316e5dce2e4b5cd2afee14b272e7f5448624801d"
 
 if [ "$#" -ne 1 ]; then
   echo "usage: $0 /private/var/macprovider-openssl-<name>" >&2

--- a/scripts/test-release-security-posture.sh
+++ b/scripts/test-release-security-posture.sh
@@ -727,7 +727,7 @@ def validate_sealed_openssl_installer(candidate):
         'readonly expected_openssl_version="3.6.3"',
         'readonly expected_bottle_tag="sequoia"',
         'readonly expected_bottle_sha256="5477285c4ebec45713873ae4002affece39e427c5f1b655c6a3df49c6b90f924"',
-        'readonly expected_formula_sha256="773b90da6562a4018e1b5033b01432500002c4636cdfd35acf68d1a4b457590c"',
+        'readonly expected_formula_sha256="00e19cdcb1b7d99058a8a15f316e5dce2e4b5cd2afee14b272e7f5448624801d"',
         "brew fetch --force",
         '--bottle-tag="$expected_bottle_tag"',
         'brew reinstall --force-bottle openssl@3',
@@ -783,7 +783,7 @@ for description, mutation in (
     (
         "reviewed formula digest removal",
         sealed_openssl_installer.replace(
-            'readonly expected_formula_sha256="773b90da6562a4018e1b5033b01432500002c4636cdfd35acf68d1a4b457590c"\n',
+            'readonly expected_formula_sha256="00e19cdcb1b7d99058a8a15f316e5dce2e4b5cd2afee14b272e7f5448624801d"\n',
             "",
             1,
         ),


### PR DESCRIPTION
## What & why

The v1.8.61 release candidate (for the merged #718 fix) failed closed at **"Preflight protected OpenSSL seal before tag creation"**:

```
reviewed OpenSSL formula sha256 drifted:
  expected '773b90da…6cdfd35acf68d1a4b457590c'
  got      '00e19cdc…afee14b272e7f5448624801d'
```

`install-sealed-release-openssl.sh` pins the Homebrew `openssl@3` **recipe file** sha256 (`ruby_source_checksum`) alongside the compiled **bottle** digest. Homebrew edited the recipe text upstream, drifting the recipe hash while leaving the actual OpenSSL build untouched.

## Verified safe — bottle digest unchanged

The seal check raises on the *first* mismatch and failed on the **last** field (formula sha256), so every earlier field passed. Confirmed against canonical `formulae.brew.sh`:

| field | pin | current | |
|---|---|---|---|
| version | 3.6.3 | 3.6.3 | ✅ |
| revision | 0 | 0 | ✅ |
| bottle rebuild | 1 | 1 | ✅ |
| **bottle sha256** (compiled binary) | `5477285c…` | `5477285c…` | ✅ byte-identical |
| formula sha256 (recipe text) | `773b90da…` | `00e19cdc…` | ← only this |

The compiled OpenSSL is byte-for-byte identical; only Homebrew's recipe *text* changed. This refreshes `expected_formula_sha256` in the installer and its guard test (`test-release-security-posture.sh`). The security-critical pin — the compiled bottle digest — is unchanged, and the release pipeline still re-verifies that digest at build time.

## Verification
- 3-line change (1 in installer, 2 in the guard test); no other drift.
- `test-release-security-posture.sh` (updated in lockstep) asserts the installer contains exactly the reviewed pin and rejects tamper mutations.
- Unblocks the v1.8.61 signed release.

SPEC-GOVERNANCE-DECLARATION-BEGIN
{
  "schema_version": "spec-pr-governance-v1",
  "behavior_change": "yes",
  "contract_change": "none",
  "specs": ["SPEC-020"],
  "requirements": ["SPEC-020-R001"],
  "authority_domains": ["provider-autoupdate"],
  "arbitration": ["CODE_BUG"],
  "tests": ["scripts/test-release-security-posture.sh"],
  "journeys": ["not-required"],
  "issue": "https://github.com/Augustas11/macprovider/issues/718"
}
SPEC-GOVERNANCE-DECLARATION-END

🤖 Generated with [Claude Code](https://claude.com/claude-code)
