### PR TITLE
revert(release): restore openssl@3 formula pin to fleet-majority 773b90da (unblock v1.8.61)

### DIFF
--- a/scripts/install-sealed-release-openssl.sh
+++ b/scripts/install-sealed-release-openssl.sh
@@ -8,7 +8,7 @@ readonly expected_formula_revision="0"
 readonly expected_bottle_rebuild="1"
 readonly expected_bottle_tag="sequoia"
 readonly expected_bottle_sha256="5477285c4ebec45713873ae4002affece39e427c5f1b655c6a3df49c6b90f924"
-readonly expected_formula_sha256="00e19cdcb1b7d99058a8a15f316e5dce2e4b5cd2afee14b272e7f5448624801d"
+readonly expected_formula_sha256="773b90da6562a4018e1b5033b01432500002c4636cdfd35acf68d1a4b457590c"
 
 if [ "$#" -ne 1 ]; then
   echo "usage: $0 /private/var/macprovider-openssl-<name>" >&2

--- a/scripts/test-release-security-posture.sh
+++ b/scripts/test-release-security-posture.sh
@@ -727,7 +727,7 @@ def validate_sealed_openssl_installer(candidate):
         'readonly expected_openssl_version="3.6.3"',
         'readonly expected_bottle_tag="sequoia"',
         'readonly expected_bottle_sha256="5477285c4ebec45713873ae4002affece39e427c5f1b655c6a3df49c6b90f924"',
-        'readonly expected_formula_sha256="00e19cdcb1b7d99058a8a15f316e5dce2e4b5cd2afee14b272e7f5448624801d"',
+        'readonly expected_formula_sha256="773b90da6562a4018e1b5033b01432500002c4636cdfd35acf68d1a4b457590c"',
         "brew fetch --force",
         '--bottle-tag="$expected_bottle_tag"',
         'brew reinstall --force-bottle openssl@3',
@@ -783,7 +783,7 @@ for description, mutation in (
     (
         "reviewed formula digest removal",
         sealed_openssl_installer.replace(
-            'readonly expected_formula_sha256="00e19cdcb1b7d99058a8a15f316e5dce2e4b5cd2afee14b272e7f5448624801d"\n',
+            'readonly expected_formula_sha256="773b90da6562a4018e1b5033b01432500002c4636cdfd35acf68d1a4b457590c"\n',
             "",
             1,
         ),


### PR DESCRIPTION
## What & why

Restores the `openssl@3` formula pin to `773b90da…` — the value introduced by #712, which shipped **v1.8.60**. My #735 bumped it to `00e19cdc…` (the current canonical recipe hash) to clear a sealed-OpenSSL preflight failure, but that was counterproductive:

- The `macos-15-intel` runner fleet currently carries **two vintages** of the Homebrew `openssl@3` recipe file. Observed `ruby_source_checksum` across candidate runs: `773b90da, 00e19cdc, 773b90da, 773b90da` — roughly **3/4 of runners still have `773b90da`**.
- Both recipe hashes map to the **identical** compiled bottle `5477285c…` (OpenSSL 3.6.3), which is pinned separately and is the real supply-chain guarantee — unchanged either way.
- Pinning `00e19cdc…` (the minority) made the seal fail on ~3/4 of runners. Pinning `773b90da…` (the majority, proven at v1.8.60) lets the candidate clear the seal on ~first try.

This reverts the installer pin and its guard test back to `773b90da…`. No security regression — the compiled bottle digest pin is untouched.

## Follow-up (for release-security owner)
With the fleet now split, *any* single recipe-hash pin will occasionally flake until GitHub's runner images converge. The durable fix is to have the seal accept **both** reviewed recipe hashes (both map to bottle `5477285c…`) — a deliberate change to the supply-chain control, out of scope here.

SPEC-GOVERNANCE-DECLARATION-BEGIN
{
  "schema_version": "spec-pr-governance-v1",
  "behavior_change": "yes",
  "contract_change": "none",
  "specs": ["SPEC-020"],
  "requirements": ["SPEC-020-R001"],
  "authority_domains": ["provider-autoupdate"],
  "arbitration": ["CODE_BUG"],
  "tests": ["scripts/test-release-security-posture.sh"],
  "journeys": ["not-required"],
  "issue": "https://github.com/Augustas11/macprovider/issues/718"
}
SPEC-GOVERNANCE-DECLARATION-END

🤖 Generated with [Claude Code](https://claude.com/claude-code)
