### PR TITLE
fix(release): accept reviewed OpenSSL formula vintages in release seal

### DIFF
--- a/scripts/install-sealed-release-openssl.sh
+++ b/scripts/install-sealed-release-openssl.sh
@@ -8,7 +8,12 @@ readonly expected_formula_revision="0"
 readonly expected_bottle_rebuild="1"
 readonly expected_bottle_tag="sequoia"
 readonly expected_bottle_sha256="5477285c4ebec45713873ae4002affece39e427c5f1b655c6a3df49c6b90f924"
-readonly expected_formula_sha256="00e19cdcb1b7d99058a8a15f316e5dce2e4b5cd2afee14b272e7f5448624801d"
+# GitHub macos-15-intel runners currently expose either reviewed Homebrew
+# formula text digest for this same OpenSSL 3.6.3 sequoia bottle.
+readonly -a expected_formula_sha256s=(
+  "773b90da6562a4018e1b5033b01432500002c4636cdfd35acf68d1a4b457590c"
+  "00e19cdcb1b7d99058a8a15f316e5dce2e4b5cd2afee14b272e7f5448624801d"
+)
 
 if [ "$#" -ne 1 ]; then
   echo "usage: $0 /private/var/macprovider-openssl-<name>" >&2
@@ -36,7 +41,7 @@ HOMEBREW_NO_AUTO_UPDATE=1 brew info --json=v2 openssl@3 >"$formula_json"
 python3 - "$formula_json" \
   "$expected_openssl_version" "$expected_formula_revision" \
   "$expected_bottle_rebuild" "$expected_bottle_tag" \
-  "$expected_bottle_sha256" "$expected_formula_sha256" <<'PY'
+  "$expected_bottle_sha256" "${expected_formula_sha256s[@]}" <<'PY'
 import json
 import pathlib
 import sys
@@ -48,8 +53,10 @@ import sys
     expected_rebuild,
     expected_tag,
     expected_bottle_sha256,
-    expected_formula_sha256,
+    *expected_formula_sha256s,
 ) = sys.argv[1:]
+if not expected_formula_sha256s:
+    raise SystemExit("reviewed OpenSSL formula digest allowlist must not be empty")
 payload = json.loads(pathlib.Path(metadata_path).read_text(encoding="utf-8"))
 formulae = payload.get("formulae")
 if not isinstance(formulae, list) or len(formulae) != 1:
@@ -64,16 +71,18 @@ checks = {
     "bottle rebuild": (str(bottle.get("rebuild")), expected_rebuild),
     "bottle sha256": (bottle_file.get("sha256"), expected_bottle_sha256),
     "bottle cellar": (bottle_file.get("cellar"), "/usr/local/Cellar"),
-    "formula sha256": (
-        formula.get("ruby_source_checksum", {}).get("sha256"),
-        expected_formula_sha256,
-    ),
 }
 for label, (actual, expected) in checks.items():
     if actual != expected:
         raise SystemExit(
             f"reviewed OpenSSL {label} drifted: expected {expected!r}, got {actual!r}"
         )
+actual_formula_sha256 = formula.get("ruby_source_checksum", {}).get("sha256")
+if actual_formula_sha256 not in expected_formula_sha256s:
+    raise SystemExit(
+        "reviewed OpenSSL formula sha256 drifted: expected one of "
+        f"{sorted(expected_formula_sha256s)!r}, got {actual_formula_sha256!r}"
+    )
 PY
 
 HOMEBREW_NO_AUTO_UPDATE=1 brew fetch --force \

--- a/scripts/test-release-security-posture.sh
+++ b/scripts/test-release-security-posture.sh
@@ -727,7 +727,10 @@ def validate_sealed_openssl_installer(candidate):
         'readonly expected_openssl_version="3.6.3"',
         'readonly expected_bottle_tag="sequoia"',
         'readonly expected_bottle_sha256="5477285c4ebec45713873ae4002affece39e427c5f1b655c6a3df49c6b90f924"',
-        'readonly expected_formula_sha256="00e19cdcb1b7d99058a8a15f316e5dce2e4b5cd2afee14b272e7f5448624801d"',
+        'readonly -a expected_formula_sha256s=(',
+        '"773b90da6562a4018e1b5033b01432500002c4636cdfd35acf68d1a4b457590c"',
+        '"00e19cdcb1b7d99058a8a15f316e5dce2e4b5cd2afee14b272e7f5448624801d"',
+        "actual_formula_sha256 not in expected_formula_sha256s",
         "brew fetch --force",
         '--bottle-tag="$expected_bottle_tag"',
         'brew reinstall --force-bottle openssl@3',
@@ -781,9 +784,25 @@ for description, mutation in (
         ),
     ),
     (
-        "reviewed formula digest removal",
+        "reviewed legacy formula digest removal",
         sealed_openssl_installer.replace(
-            'readonly expected_formula_sha256="00e19cdcb1b7d99058a8a15f316e5dce2e4b5cd2afee14b272e7f5448624801d"\n',
+            '  "773b90da6562a4018e1b5033b01432500002c4636cdfd35acf68d1a4b457590c"\n',
+            "",
+            1,
+        ),
+    ),
+    (
+        "reviewed current formula digest removal",
+        sealed_openssl_installer.replace(
+            '  "00e19cdcb1b7d99058a8a15f316e5dce2e4b5cd2afee14b272e7f5448624801d"\n',
+            "",
+            1,
+        ),
+    ),
+    (
+        "reviewed formula digest membership removal",
+        sealed_openssl_installer.replace(
+            "actual_formula_sha256 not in expected_formula_sha256s",
             "",
             1,
         ),


### PR DESCRIPTION
## Summary

- Allow the sealed release OpenSSL preflight to accept exactly the two reviewed `openssl@3` formula text digests observed across the GitHub `macos-15-intel` runner fleet.
- Preserve the exact OpenSSL `3.6.3` version, sequoia bottle tag/rebuild, pinned bottle sha256 `5477285c4ebec45713873ae4002affece39e427c5f1b655c6a3df49c6b90f924`, forced bottle install, and receipt checks.
- Update `scripts/test-release-security-posture.sh` so the guard requires both reviewed formula digests and fails if either digest or the membership check is removed.

## Root cause

Homebrew changed only the `openssl@3` formula recipe text while GitHub runners still expose both recipe vintages. A single formula-text hash therefore makes the release pipeline depend on runner-image vintage even though both formula states map to the same pinned bottle digest.

## Validation

- `bash -n scripts/install-sealed-release-openssl.sh scripts/test-release-security-posture.sh`
- `scripts/test-release-security-posture.sh`
- `git diff --check`

SPEC-GOVERNANCE-DECLARATION-BEGIN
{
  "schema_version": "spec-pr-governance-v1",
  "behavior_change": "yes",
  "contract_change": "none",
  "specs": ["SPEC-020"],
  "requirements": ["SPEC-020-R001"],
  "authority_domains": ["provider-autoupdate"],
  "arbitration": ["CODE_BUG"],
  "tests": ["scripts/test-release-security-posture.sh"],
  "journeys": ["not-required"],
  "issue": "https://github.com/Augustas11/macprovider/issues/608"
}
SPEC-GOVERNANCE-DECLARATION-END
