### PR TITLE
Harden Malibu CLI release identity checks

### DIFF
--- a/.github/workflows/malibu-release.yml
+++ b/.github/workflows/malibu-release.yml
@@ -357,7 +357,7 @@ jobs:
             --wait
           xcrun stapler staple "$dmg"
           xcrun stapler validate "$dmg"
-          bash scripts/verify-malibu-release-artifacts.sh "$dmg"
+          bash scripts/verify-malibu-release-artifacts.sh "$dmg" --expected-cli-sha256 "$CLI_SHA256"
 
           dmg_sha="$(shasum -a 256 "$dmg" | awk '{print $1}')"
           printf '%s  %s\n' "$dmg_sha" "$(basename "$dmg")" > "$dmg.sha256"
@@ -600,7 +600,7 @@ jobs:
               if manifest.get(key) != value:
                   raise SystemExit(f"candidate manifest mismatch for {key}")
           PY
-          bash scripts/verify-malibu-release-artifacts.sh "$dmg"
+          bash scripts/verify-malibu-release-artifacts.sh "$dmg" --expected-cli-sha256 "$CLI_SHA256"
           codesign --verify --strict --verbose=2 "$dmg"
           codesign -dv --verbose=4 "$dmg" 2>&1 | grep -qx "TeamIdentifier=$TEAM_ID"
           mount_dir="$(mktemp -d "$RUNNER_TEMP/malibu-candidate.XXXXXX")"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -759,7 +759,8 @@ jobs:
           fi
 
           SOURCE_CLI_REQUIREMENT=$(codesign -d -r- "$APP/Contents/MacOS/macprovider-cli" 2>&1)
-          codesign --force --deep \
+          source_cli_sha256="$(shasum -a 256 "$WORK/macprovider-cli" | awk '{print $1}')"
+          codesign --force \
             --options runtime \
             --timestamp \
             --preserve-metadata=identifier \
@@ -768,6 +769,12 @@ jobs:
             "$APP"
 
           codesign --verify --strict --verbose=2 --deep "$APP"
+          bundled_cli_sha256="$(shasum -a 256 "$APP/Contents/MacOS/macprovider-cli" | awk '{print $1}')"
+          if [ "$bundled_cli_sha256" != "$source_cli_sha256" ]; then
+            echo "::error::Malibu embedded CLI sha256 differs from standalone CLI" >&2
+            echo "::error::standalone=$source_cli_sha256 embedded=$bundled_cli_sha256" >&2
+            exit 1
+          fi
           BUNDLED_CLI_REQUIREMENT=$(codesign -d -r- "$APP/Contents/MacOS/macprovider-cli" 2>&1)
           printf '%s\n' "$BUNDLED_CLI_REQUIREMENT" | grep -F 'identifier "live.streamvc.macprovider.cli"' >/dev/null || {
             echo "::error::Bundling changed the CLI designated requirement identifier" >&2
@@ -1118,8 +1125,10 @@ jobs:
           set -euo pipefail
           tag="${{ needs.build.outputs.tag }}"
           dmg="phase3-binary/app/dist/Malibu-${tag}.dmg"
+          provider_tarball="phase3-binary/dist/phase3-binary-m4-${tag}.tar.gz"
           test -f "$dmg"
-          bash scripts/verify-malibu-release-artifacts.sh "$dmg"
+          test -f "$provider_tarball"
+          bash scripts/verify-malibu-release-artifacts.sh "$dmg" --provider-tarball "$provider_tarball"
           if [ "$tag" = v1.8.39 ]; then
             appcast="phase3-binary/app/dist/appcast.xml"
             test -f "$appcast"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -92,4 +92,13 @@ files (`git diff <base> -- <files...>`). Do **not** diff against
 `origin/main` when `main` already contains an earlier part of the same
 fix.
 
+## 8. Release verification — don't trust workflow green alone
+
+For provider CLI releases that ship Malibu.app plus the standalone tarball,
+verify byte identity between both embedded `macprovider-cli` binaries after
+final signing/packaging, and verify the updater path from the previous stable
+version. Do not treat candidate green, matching `--version`, or Gatekeeper
+success as production proof. See `CLAUDE.md` and
+`docs/runbooks/provider-cli-release-verification.md`.
+
 For the canonical, full version of every rule above, see `CLAUDE.md`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -211,6 +211,38 @@ spec-linked PR (how #713 shipped its `ci.yml` edit). Do not relax `ci.yml`
 into the governance-only allowlist to dodge this — that regime looks
 deliberate.
 
+## Release verification: workflow green is not production proof
+
+For every provider CLI release that ships both a standalone provider tarball
+and Malibu.app, the release contract is the installer/updater contract, not
+just GitHub Actions success.
+
+Rules:
+
+1. The `macprovider-cli` inside Malibu.app must be byte-identical to the
+   `macprovider-cli` inside the standalone provider tarball after all signing,
+   notarization, stapling, and packaging steps. Compare SHA-256 bytes, not
+   only `--version`, codesign requirement text, Gatekeeper, or notarization.
+2. Do not use recursive app signing (`codesign --force --deep`) on a bundle
+   after copying in the already-signed standalone provider CLI. Sign nested
+   code explicitly first, sign the outer app without `--deep`, then verify the
+   app with `codesign --verify --deep`.
+3. Do not mark a release production-verified until the updater path from the
+   previous stable version accepts it. `embedded_cli_mismatch` is a correct
+   fail-closed updater rejection, not a warning to bypass.
+4. Candidate workflow green is only candidate evidence. Final release proof
+   must come from immutable release assets after publication/download, with
+   signatures/checksums verified and the updater invariant exercised.
+5. If a public immutable release violates these invariants, do not patch the
+   release in place. Keep coordinator recommendation on the previous stable
+   version and cut a new release with matching artifacts.
+
+Keep product-specific smoke tests separate from release packaging proof. For
+example, Buzz/null-tool-schema verification proves the product fix; it does
+not prove the updater or Malibu packaging invariants above.
+
+Runbook: `docs/runbooks/provider-cli-release-verification.md`.
+
 ## Other repo conventions worth remembering
 
 - Every implementation slice must pass the audit loop before being treated as

--- a/docs/runbooks/provider-cli-release-verification.md
+++ b/docs/runbooks/provider-cli-release-verification.md
@@ -1,0 +1,78 @@
+# Provider CLI release verification
+
+This runbook covers release/updater correctness only. Keep product-specific
+smokes, such as Buzz tool-schema/null behavior, in a separate QA checklist.
+
+## Hard release invariants
+
+- The standalone tarball CLI and the Malibu.app embedded CLI must be the same
+  bytes after final signing, notarization, stapling, and packaging.
+- The updater must accept the release from the previous stable CLI.
+- Candidate workflow success is not production verification.
+- Public release assets are immutable; do not patch a bad release in place.
+
+## Candidate release gate
+
+Run the candidate workflow from `main`:
+
+```bash
+gh workflow run release.yml \
+  --ref main \
+  -f version=vX.Y.Z \
+  -f candidate=true \
+  -f prerelease=false \
+  -f provider_admission_policy=strict_post_migration
+```
+
+Pre-approval evidence:
+
+- build job succeeds
+- arm64 verification succeeds
+- `sign_publish` parks for approval
+
+Protected candidate evidence, if intentionally approved for a dry-run signing
+check:
+
+- `Verify Malibu release cryptographic bindings` ran
+- `scripts/verify-malibu-release-artifacts.sh` compared the Malibu embedded
+  CLI with the standalone provider tarball
+
+Do not approve candidate `sign_publish` unless intentionally testing protected
+publication/signing behavior.
+
+## Production release gate
+
+1. Create the signed annotated tag on the intended `main` commit.
+2. Run `release.yml` with `candidate=false`.
+3. Approve the production-release environment only from the owner account.
+4. After publication, download the immutable assets and verify checksums and
+   signatures.
+5. Verify the Malibu artifact against the standalone provider tarball:
+
+```bash
+bash scripts/verify-malibu-release-artifacts.sh \
+  Malibu-vX.Y.Z.dmg \
+  --provider-tarball macprovider-cli-vX.Y.Z-darwin-arm64.tar.gz
+```
+
+6. Verify local updater acceptance from the previous stable CLI:
+
+```bash
+macprovider-cli update --check
+macprovider-cli update
+macprovider-cli --version
+macprovider-cli status --advanced
+```
+
+If the updater returns `embedded_cli_mismatch`, the release is not
+production-verified. Keep the coordinator recommendation on the previous
+stable version and cut a new release with matching artifacts.
+
+## What not to count as release proof
+
+- matching `macprovider-cli --version`
+- matching codesign designated-requirement text
+- Gatekeeper acceptance alone
+- notarization/stapling alone
+- simple local chat/completions curl
+- product-specific Buzz smoke tests

--- a/scripts/test-release-security-posture.sh
+++ b/scripts/test-release-security-posture.sh
@@ -604,13 +604,15 @@ compatibility_copy = app_sign.find(
 )
 anchor_prepare = app_sign.find("prepare-malibu-bootstrap-trust-anchor.py prepare")
 anchor_verify = app_sign.find("prepare-malibu-bootstrap-trust-anchor.py verify")
-app_codesign = app_sign.find("codesign --force --deep")
+app_codesign = app_sign.find("codesign --force \\")
 if min(first_bundle_write, compatibility_copy, anchor_prepare, anchor_verify, app_codesign) < 0 or not (
     anchor_prepare < first_bundle_write < compatibility_copy < anchor_verify < app_codesign
 ):
     raise SystemExit(
         "Malibu app must be preflighted before bundle writes and reverified before codesign"
     )
+if "codesign --force --deep" in app_sign:
+    raise SystemExit("Malibu app signing must not recursively re-sign the embedded provider CLI")
 if app_sign.count("prepare-malibu-bootstrap-trust-anchor.py prepare") != 1:
     raise SystemExit("Malibu signing must prepare the one-time trust anchor exactly once")
 if app_sign.count("prepare-malibu-bootstrap-trust-anchor.py verify") != 1:
@@ -622,6 +624,9 @@ for requirement in (
     "scripts/dist/malibu-v1.8.32-sparkle-public-key",
     '/usr/bin/otool -L "$APP/Contents/MacOS/Malibu"',
     "Malibu bridge must not link a Sparkle runtime",
+    "source_cli_sha256",
+    "bundled_cli_sha256",
+    "Malibu embedded CLI sha256 differs from standalone CLI",
 ):
     if requirement not in app_sign:
         raise SystemExit(f"Malibu signing omits trust-continuity guard: {requirement}")
@@ -648,6 +653,9 @@ for requirement in (
     "malibu-v1.8.32-sparkle-public-key",
     '/usr/bin/otool -L "$app_path/Contents/MacOS/Malibu"',
     "Malibu must not link a Sparkle runtime",
+    "verify_embedded_cli_identity",
+    "choose exactly one CLI identity mode",
+    "Malibu embedded CLI sha256 differs from expected CLI",
 ):
     if requirement not in malibu_artifact_verifier:
         raise SystemExit(f"final Malibu artifact verification omits: {requirement}")

--- a/scripts/test-tier2-provider-release.sh
+++ b/scripts/test-tier2-provider-release.sh
@@ -85,7 +85,7 @@ make_release_fixture() {
   local binary_dir="$fixture_dir/bin"
   local asset="$fixture_dir/macprovider-cli-v$version-darwin-arm64.tar.gz"
   local pkg_asset="$fixture_dir/macprovider-cli-v$version-darwin-arm64.pkg"
-  local app_asset="$fixture_dir/Malibu-v$version.zip"
+  local app_asset="$fixture_dir/Malibu-v$version.dmg"
   make_fake_binary "$binary_dir" "$version" "$include_surfaces"
   tar -czf "$asset" -C "$binary_dir" macprovider-cli mlx.metallib
   sha256_file "$asset" | awk -v asset="$(basename "$asset")" '{ print $1 "  " asset }' >"$fixture_dir/checksums.txt"
@@ -114,11 +114,14 @@ make_release_fixture() {
   case "$app_mode" in
     none)
       ;;
-    good)
+    good|bad-cli)
       local app_root="$fixture_dir/app-root"
       mkdir -p "$app_root/Malibu.app/Contents/MacOS"
       printf '%s\n' '#!/usr/bin/env bash' 'exit 0' >"$app_root/Malibu.app/Contents/MacOS/Malibu"
       cp "$binary_dir/macprovider-cli" "$app_root/Malibu.app/Contents/MacOS/macprovider-cli"
+      if [ "$app_mode" = "bad-cli" ]; then
+        printf '%s\n' '# app signing mutated this copy' >>"$app_root/Malibu.app/Contents/MacOS/macprovider-cli"
+      fi
       cp "$binary_dir/mlx.metallib" "$app_root/Malibu.app/Contents/MacOS/mlx.metallib"
       chmod +x "$app_root/Malibu.app/Contents/MacOS/Malibu" "$app_root/Malibu.app/Contents/MacOS/macprovider-cli"
       (cd "$app_root" && python3 - "$app_asset" <<'PY'
@@ -167,7 +170,7 @@ done
 [ -n "$url" ] || exit 2
 name="${url##*/}"
 case "$name" in
-  macprovider-cli-*-darwin-arm64.tar.gz|macprovider-cli-*-darwin-arm64.pkg|Malibu-v*.zip|checksums.txt|checksums.txt.sig)
+  macprovider-cli-*-darwin-arm64.tar.gz|macprovider-cli-*-darwin-arm64.pkg|Malibu-v*.dmg|checksums.txt|checksums.txt.sig)
     cp "$RELEASE_FIXTURE_DIR/$name" "$out"
     ;;
   *)
@@ -210,26 +213,46 @@ exit 2
 SH
 chmod +x "$WORKDIR/xcrun"
 
-cat >"$WORKDIR/ditto" <<'SH'
+cat >"$WORKDIR/hdiutil" <<'SH'
 #!/usr/bin/env bash
 set -euo pipefail
-if [ "${1:-}" = "-x" ] && [ "${2:-}" = "-k" ]; then
-  archive="$3"
-  out="$4"
-  mkdir -p "$out"
-  python3 - "$archive" "$out" <<'PY'
+if [ "${1:-}" = "attach" ]; then
+  mount=""
+  archive=""
+  shift
+  while [ "$#" -gt 0 ]; do
+    case "$1" in
+      -mountpoint)
+        mount="$2"
+        shift 2
+        ;;
+      -*)
+        shift
+        ;;
+      *)
+        archive="$1"
+        shift
+        ;;
+    esac
+  done
+  [ -n "$mount" ] && [ -n "$archive" ] || exit 2
+  mkdir -p "$mount"
+  python3 - "$archive" "$mount" <<'PY'
 import sys
 import zipfile
 
 with zipfile.ZipFile(sys.argv[1]) as archive:
     archive.extractall(sys.argv[2])
 PY
-  chmod +x "$out/Malibu.app/Contents/MacOS/Malibu" "$out/Malibu.app/Contents/MacOS/macprovider-cli"
+  chmod +x "$mount/Malibu.app/Contents/MacOS/Malibu" "$mount/Malibu.app/Contents/MacOS/macprovider-cli"
+  exit 0
+fi
+if [ "${1:-}" = "detach" ]; then
   exit 0
 fi
 exit 2
 SH
-chmod +x "$WORKDIR/ditto"
+chmod +x "$WORKDIR/hdiutil"
 
 cat >"$WORKDIR/lipo" <<'SH'
 #!/usr/bin/env bash
@@ -337,15 +360,27 @@ app_fixture="$WORKDIR/app-release"
 make_release_fixture "$app_fixture" "1.2.6" "1" "none" "good"
 PATH="$WORKDIR:$PATH" \
   CURL_BIN="$WORKDIR/curl" \
-  DITTO_BIN="$WORKDIR/ditto" \
   RELEASE_FIXTURE_DIR="$app_fixture" \
   MACPROVIDER_CHECKSUM_PUBLIC_KEY_PEM="$PUBLIC_KEY_PEM" \
   RELEASE_TAG=v1.2.6 \
   "$VERIFIER" >"$WORKDIR/app.out" 2>"$WORKDIR/app.err"
-assert_contains "$WORKDIR/app.err" "Malibu.app zip sha256 verified"
+assert_contains "$WORKDIR/app.err" "Malibu.app DMG sha256 verified"
+assert_contains "$WORKDIR/app.err" "Malibu.app bundled binary matches tarball binary"
 assert_contains "$WORKDIR/app.err" "Malibu.app code signature verified"
-assert_contains "$WORKDIR/app.err" "Malibu.app stapler validation passed"
+assert_contains "$WORKDIR/app.err" "Malibu.app DMG stapler validation passed"
 assert_contains "$WORKDIR/app.err" "Malibu.app Gatekeeper assessment passed"
+
+bad_app_fixture="$WORKDIR/bad-app-release"
+make_release_fixture "$bad_app_fixture" "1.2.6" "1" "none" "bad-cli"
+if PATH="$WORKDIR:$PATH" \
+  CURL_BIN="$WORKDIR/curl" \
+  RELEASE_FIXTURE_DIR="$bad_app_fixture" \
+  MACPROVIDER_CHECKSUM_PUBLIC_KEY_PEM="$PUBLIC_KEY_PEM" \
+  RELEASE_TAG=v1.2.6 \
+  "$VERIFIER" >"$WORKDIR/bad-app.out" 2>"$WORKDIR/bad-app.err"; then
+  die "mismatched Malibu.app CLI unexpectedly passed"
+fi
+assert_contains "$WORKDIR/bad-app.err" "Malibu.app bundled binary sha256 differs from tarball binary"
 
 bad_package_fixture="$WORKDIR/bad-package-release"
 make_release_fixture "$bad_package_fixture" "1.2.6" "1" "bad-extra"

--- a/scripts/verify-malibu-publication-set.sh
+++ b/scripts/verify-malibu-publication-set.sh
@@ -116,6 +116,7 @@ bash "$repo_root/scripts/test-coordinator-advertised-version.sh" "$tag"
 python3 "$repo_root/scripts/verify-malibu-sparkle-signature.py" \
   "$tag" "$dmg" "$appcast" \
   "$repo_root/scripts/dist/malibu-v1.8.32-sparkle-public-key"
-bash "$repo_root/scripts/verify-malibu-release-artifacts.sh" "$dmg"
+bash "$repo_root/scripts/verify-malibu-release-artifacts.sh" \
+  "$dmg" --legacy-app-only-no-provider-tarball
 
 printf '[verify-malibu-publication-set] ok: release %s (%s)\n' "$tag" "$commit"

--- a/scripts/verify-malibu-release-artifacts.sh
+++ b/scripts/verify-malibu-release-artifacts.sh
@@ -2,10 +2,12 @@
 # Post-release Gatekeeper checks for signed Malibu artifacts (SPEC-025 P2).
 #
 # Usage:
-#   bash scripts/verify-malibu-release-artifacts.sh Malibu-v1.8.11.dmg
-#   bash scripts/verify-malibu-release-artifacts.sh /Applications/Malibu.app
+#   bash scripts/verify-malibu-release-artifacts.sh Malibu-v1.8.11.dmg --provider-tarball macprovider-cli-v1.8.11-darwin-arm64.tar.gz
+#   bash scripts/verify-malibu-release-artifacts.sh /Applications/Malibu.app --expected-cli-sha256 <sha256>
+#   bash scripts/verify-malibu-release-artifacts.sh Malibu-v1.8.39.dmg --legacy-app-only-no-provider-tarball
 #
-# Validates codesign, stapler, and spctl on a locally downloaded release asset.
+# Validates codesign, stapler, spctl, and an explicit embedded CLI identity
+# proof against either the standalone provider tarball or an expected digest.
 
 set -euo pipefail
 
@@ -18,16 +20,101 @@ die() {
   exit 1
 }
 
-[ $# -eq 1 ] || die "usage: $0 <Malibu.app path or Malibu-*.dmg>"
+[ $# -ge 2 ] || die "usage: $0 <Malibu.app path or Malibu-*.dmg> (--provider-tarball <tar.gz> | --expected-cli-sha256 <sha256> | --legacy-app-only-no-provider-tarball)"
 
 target="$1"
+shift
+provider_tarball=""
+expected_cli_sha256=""
+legacy_app_only=0
 [ -e "$target" ] || die "missing: $target"
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --provider-tarball)
+      [ -z "$provider_tarball" ] || die "--provider-tarball specified more than once"
+      [ "$#" -ge 2 ] || die "--provider-tarball requires a path"
+      provider_tarball="$2"
+      shift 2
+      ;;
+    --expected-cli-sha256)
+      [ -z "$expected_cli_sha256" ] || die "--expected-cli-sha256 specified more than once"
+      [ "$#" -ge 2 ] || die "--expected-cli-sha256 requires a digest"
+      expected_cli_sha256="$2"
+      shift 2
+      ;;
+    --legacy-app-only-no-provider-tarball)
+      [ "$legacy_app_only" -eq 0 ] || die "--legacy-app-only-no-provider-tarball specified more than once"
+      legacy_app_only=1
+      shift
+      ;;
+    *)
+      die "unknown argument: $1"
+      ;;
+  esac
+done
+
+identity_mode_count=0
+[ -n "$provider_tarball" ] && identity_mode_count=$((identity_mode_count + 1))
+[ -n "$expected_cli_sha256" ] && identity_mode_count=$((identity_mode_count + 1))
+[ "$legacy_app_only" -eq 1 ] && identity_mode_count=$((identity_mode_count + 1))
+[ "$identity_mode_count" -eq 1 ] ||
+  die "choose exactly one CLI identity mode: --provider-tarball, --expected-cli-sha256, or --legacy-app-only-no-provider-tarball"
+[ -z "$provider_tarball" ] || [ -f "$provider_tarball" ] || die "missing provider tarball: $provider_tarball"
+if [ -n "$expected_cli_sha256" ] && ! printf '%s\n' "$expected_cli_sha256" | grep -Eq '^[0-9a-fA-F]{64}$'; then
+  die "--expected-cli-sha256 must be a 64-character hex digest"
+fi
+
+sha256_file() {
+  local path="$1"
+  if command -v shasum >/dev/null 2>&1; then
+    shasum -a 256 "$path" | awk '{print $1}'
+    return
+  fi
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum "$path" | awk '{print $1}'
+    return
+  fi
+  die "missing shasum or sha256sum"
+}
+
+verify_embedded_cli_identity() {
+  local app_path="$1"
+  local expected_sha="$expected_cli_sha256"
+  local extract_dir
+  local embedded_cli_sha
+
+  [ -x "$app_path/Contents/MacOS/macprovider-cli" ] ||
+    die "Malibu.app lacks executable bundled macprovider-cli"
+  embedded_cli_sha="$(sha256_file "$app_path/Contents/MacOS/macprovider-cli")"
+
+  if [ "$legacy_app_only" -eq 1 ]; then
+    printf '[verify-malibu-release] warning: legacy app-only verification skipped standalone CLI byte identity\n' >&2
+    return 0
+  fi
+
+  if [ -n "$provider_tarball" ]; then
+    extract_dir="$(mktemp -d "${TMPDIR:-/tmp}/malibu-provider-cli.XXXXXX")"
+    tar -xzf "$provider_tarball" -C "$extract_dir" macprovider-cli ||
+      die "provider tarball does not contain macprovider-cli"
+    [ -x "$extract_dir/macprovider-cli" ] ||
+      die "provider tarball macprovider-cli is not executable"
+    expected_sha="$(sha256_file "$extract_dir/macprovider-cli")"
+    rm -rf "$extract_dir"
+  fi
+
+  [ -n "$expected_sha" ] || die "missing expected CLI sha256"
+
+  [ "$embedded_cli_sha" = "$expected_sha" ] ||
+    die "Malibu embedded CLI sha256 differs from expected CLI: embedded=$embedded_cli_sha expected=$expected_sha"
+}
 
 verify_update_posture() {
   local app_path="$1"
   local malibu_links
 
   python3 "$trust_anchor_helper" verify "$app_path" "$legacy_sparkle_key"
+  verify_embedded_cli_identity "$app_path"
   malibu_links="$(/usr/bin/otool -L "$app_path/Contents/MacOS/Malibu")" ||
     die "could not inspect Malibu runtime linkage"
   if printf '%s\n' "$malibu_links" | /usr/bin/grep -F Sparkle >/dev/null; then

--- a/scripts/verify-tier2-provider-release.sh
+++ b/scripts/verify-tier2-provider-release.sh
@@ -12,7 +12,7 @@ INSTALL_SH="${INSTALL_SH:-$REPO_ROOT/phase3-binary/dist/install.sh}"
 CHECKER="${CHECKER:-$REPO_ROOT/scripts/check-tier2-provider-artifact.sh}"
 CURL_BIN="${CURL_BIN:-curl}"
 OPENSSL_BIN="${OPENSSL_BIN:-openssl}"
-DITTO_BIN="${DITTO_BIN:-/usr/bin/ditto}"
+HDIUTIL_BIN="${HDIUTIL_BIN:-hdiutil}"
 PROVIDER_VERSION_OVERRIDE="${PROVIDER_VERSION:-}"
 KEEP_DOWNLOADS="${KEEP_DOWNLOADS:-0}"
 DOWNLOAD_ATTEMPTS="${DOWNLOAD_ATTEMPTS:-1}"
@@ -32,7 +32,8 @@ Downloads a macprovider-cli GitHub Release asset set, verifies the signed
 checksum manifest using the installer public key, verifies the release tarball
 checksum, then runs scripts/check-tier2-provider-artifact.sh against the
 downloaded tarball. When the release also contains Malibu.app, this verifies
-the app zip checksum, code signature, stapled ticket, and Gatekeeper
+the app DMG checksum, code signature, stapled ticket, Gatekeeper, and bundled
+CLI byte identity against the standalone provider tarball.
 assessment. This script is read-only against GitHub and does not mutate local
 release state unless KEEP_DOWNLOADS=1 is set.
 
@@ -41,7 +42,7 @@ Environment:
   RELEASE_TAG                         default: v1.2.6
   INSTALL_SH                          default: phase3-binary/dist/install.sh
   CHECKER                             default: scripts/check-tier2-provider-artifact.sh
-  DITTO_BIN                           default: /usr/bin/ditto
+  HDIUTIL_BIN                         default: hdiutil
   MACPROVIDER_CHECKSUM_PUBLIC_KEY_PEM optional public key override
   PROVIDER_VERSION                    default: RELEASE_TAG without leading v
   KEEP_DOWNLOADS=1                    keep downloaded artifacts and print path
@@ -300,7 +301,11 @@ PY
 
 tmpdir=""
 temp_parent=""
+app_mount_dir=""
 cleanup() {
+  if [ -n "$app_mount_dir" ] && [ -d "$app_mount_dir" ]; then
+    "$HDIUTIL_BIN" detach "$app_mount_dir" -quiet >/dev/null 2>&1 || true
+  fi
   if [ -n "$tmpdir" ] && [ "$KEEP_DOWNLOADS" != "1" ]; then
     case "$tmpdir" in
       "$temp_parent"/tier2-provider-release.*) rm -rf "$tmpdir" ;;
@@ -364,7 +369,7 @@ download_file() {
 
 asset="macprovider-cli-${RELEASE_TAG}-darwin-arm64.tar.gz"
 pkg_asset="macprovider-cli-${RELEASE_TAG}-darwin-arm64.pkg"
-app_asset="Malibu-${RELEASE_TAG}.zip"
+app_asset="Malibu-${RELEASE_TAG}.dmg"
 base="https://github.com/${GITHUB_REPO}/releases/download/${RELEASE_TAG}"
 
 temp_parent="${TMPDIR:-/tmp}"
@@ -374,8 +379,7 @@ tmpdir="$(mktemp -d "$temp_parent/tier2-provider-release.XXXXXX")"
 
 tarball_path="$tmpdir/$asset"
 pkg_path="$tmpdir/$pkg_asset"
-app_zip_path="$tmpdir/$app_asset"
-app_extract_dir="$tmpdir/malibu-app"
+app_dmg_path="$tmpdir/$app_asset"
 checksums_path="$tmpdir/checksums.txt"
 checksums_sig_path="$tmpdir/checksums.txt.sig"
 public_key_path="$tmpdir/release-signing-public.pem"
@@ -462,34 +466,44 @@ fi
 
 app_expected_sha="$(checksum_for_asset "$checksums_path" "$app_asset")"
 if [ -n "$app_expected_sha" ]; then
-  download_file "$base/$app_asset" "$app_zip_path" "$app_asset"
-  app_actual_sha="$(sha256_file "$app_zip_path")"
-  [ "$app_actual_sha" = "$app_expected_sha" ] || die "Malibu.app zip sha256 mismatch: got $app_actual_sha want $app_expected_sha"
-  log "Malibu.app zip sha256 verified: $app_actual_sha"
+  download_file "$base/$app_asset" "$app_dmg_path" "$app_asset"
+  app_actual_sha="$(sha256_file "$app_dmg_path")"
+  [ "$app_actual_sha" = "$app_expected_sha" ] || die "Malibu.app DMG sha256 mismatch: got $app_actual_sha want $app_expected_sha"
+  log "Malibu.app DMG sha256 verified: $app_actual_sha"
 
-  require_command "$DITTO_BIN"
-  require_command python3
+  require_command "$HDIUTIL_BIN"
   require_command codesign
   require_command spctl
   require_command xcrun
-  validate_malibu_app_zip "$app_zip_path" || die "Malibu.app zip layout validation failed"
-  mkdir -p "$app_extract_dir"
-  "$DITTO_BIN" -x -k "$app_zip_path" "$app_extract_dir" || die "failed to extract $app_asset"
-  app_path="$app_extract_dir/Malibu.app"
-  [ -d "$app_path" ] || die "$app_asset did not contain Malibu.app"
+  app_mount_dir="$tmpdir/malibu-dmg"
+  mkdir -p "$app_mount_dir"
+  "$HDIUTIL_BIN" attach -nobrowse -mountpoint "$app_mount_dir" "$app_dmg_path" >/dev/null ||
+    die "failed to mount $app_asset"
+  app_path="$app_mount_dir/Malibu.app"
+  [ -d "$app_path" ] || die "$app_asset does not contain Malibu.app"
   [ -x "$app_path/Contents/MacOS/macprovider-cli" ] || die "Malibu.app lacks executable bundled macprovider-cli"
+  app_tar_payload_dir="$tmpdir/app-tar-payload"
+  mkdir -p "$app_tar_payload_dir"
+  tar -xzf "$tarball_path" -C "$app_tar_payload_dir" macprovider-cli || die "provider tarball lacks macprovider-cli"
+  app_tar_binary_sha="$(sha256_file "$app_tar_payload_dir/macprovider-cli")"
+  app_binary_sha="$(sha256_file "$app_path/Contents/MacOS/macprovider-cli")"
+  [ "$app_binary_sha" = "$app_tar_binary_sha" ] ||
+    die "Malibu.app bundled binary sha256 differs from tarball binary"
+  log "Malibu.app bundled binary matches tarball binary: $app_binary_sha"
   if [ ! -f "$app_path/Contents/MacOS/mlx.metallib" ] && \
      [ ! -f "$app_path/Contents/MacOS/mlx-swift_Cmlx.bundle/Contents/Resources/default.metallib" ]; then
     die "Malibu.app lacks adjacent MLX Metal resources for bundled macprovider-cli"
   fi
   codesign --verify --strict --deep --verbose=2 "$app_path" || die "Malibu.app code signature verification failed"
   log "Malibu.app code signature verified"
-  xcrun stapler validate "$app_path" || die "Malibu.app stapler validation failed"
-  log "Malibu.app stapler validation passed"
-  spctl -a -vvv -t exec "$app_path" || die "Malibu.app failed Gatekeeper assessment"
+  xcrun stapler validate "$app_dmg_path" || die "Malibu.app DMG stapler validation failed"
+  log "Malibu.app DMG stapler validation passed"
+  spctl -a -vvv -t open "$app_dmg_path" || spctl -a -vvv -t exec "$app_path" || die "Malibu.app failed Gatekeeper assessment"
   log "Malibu.app Gatekeeper assessment passed"
+  "$HDIUTIL_BIN" detach "$app_mount_dir" -quiet >/dev/null 2>&1 || true
+  app_mount_dir=""
 else
-  log "no Malibu.app entry in checksums.txt; app-track release absent"
+  log "no Malibu.app DMG entry in checksums.txt; app-track release absent"
 fi
 
 PROVIDER_ARTIFACT="$tarball_path" \


### PR DESCRIPTION
## Summary

This PR hardens the provider CLI release path against the v1.8.61 class of failure where the standalone tarball CLI and Malibu.app embedded CLI had the same version but different bytes.

Changes:

- stop recursive `codesign --force --deep` app signing after copying the already-signed provider CLI into Malibu.app
- add post-sign SHA-256 equality checks between `$WORK/macprovider-cli` and `Malibu.app/Contents/MacOS/macprovider-cli`
- make `scripts/verify-malibu-release-artifacts.sh` require an explicit CLI identity mode:
  - `--provider-tarball` for normal provider releases
  - `--expected-cli-sha256` for independent Malibu releases
  - `--legacy-app-only-no-provider-tarball` only for the frozen v1.8.39 bridge publication path
- update the published Tier-2 release verifier to check the real `Malibu-<tag>.dmg` asset instead of the stale `.zip` asset shape
- add repo rules + runbook so future agents do not treat workflow green, matching version, codesign, Gatekeeper, or Buzz/product smokes as release packaging proof

## Non-goals

- no Buzz/product verification is added here
- no new release is run here
- no updater-transition fixture is added here; updater acceptance remains a required post-publication proof in the runbook

## Tests

- `bash -n scripts/verify-malibu-release-artifacts.sh scripts/verify-tier2-provider-release.sh scripts/test-tier2-provider-release.sh scripts/test-release-security-posture.sh scripts/verify-malibu-publication-set.sh`
- `bash scripts/test-release-security-posture.sh`
- `bash scripts/test-tier2-provider-release.sh`
- `bash scripts/test-malibu-independent-release.sh`
- YAML parse for `.github/workflows/release.yml` and `.github/workflows/malibu-release.yml`
- `git diff --check`

SPEC-GOVERNANCE-DECLARATION-BEGIN
{
  "schema_version": "spec-pr-governance-v1",
  "behavior_change": "yes",
  "contract_change": "none",
  "specs": ["SPEC-020", "SPEC-025"],
  "requirements": ["SPEC-020-R002"],
  "authority_domains": ["provider-autoupdate", "native-app-lifecycle"],
  "arbitration": ["CODE_BUG"],
  "tests": [
    "scripts/test-release-security-posture.sh",
    "scripts/test-tier2-provider-release.sh",
    "scripts/test-malibu-independent-release.sh"
  ],
  "journeys": ["not-required"],
  "issue": "https://github.com/Augustas11/macprovider/issues/610"
}
SPEC-GOVERNANCE-DECLARATION-END
