### PR TITLE
Advance provider release target to v1.8.62

### DIFF
--- a/phase3-binary/Sources/macprovider-cli/CoordinatorClient.swift
+++ b/phase3-binary/Sources/macprovider-cli/CoordinatorClient.swift
@@ -146,7 +146,7 @@ actor CoordinatorClient {
     typealias InstalledCompatibilityManifest = @Sendable (URL, String) -> CompatibilitySetManifest?
     typealias ReloadHelperFence = @Sendable () throws -> Void
 
-    static let binaryVersion = "1.8.61"
+    static let binaryVersion = "1.8.62"
     private static let keepaliveDebugEnabled = ProcessInfo.processInfo.environment["MACPROVIDER_KEEPALIVE_DEBUG"] == "1"
 
     private let coordinatorURL: URL

--- a/phase4-coordinator/coordinator.yaml.example
+++ b/phase4-coordinator/coordinator.yaml.example
@@ -184,7 +184,7 @@ autotune:
 # legacy cohort (DECISION_CRITERIA Entry 161). `required_binary_version` is a
 # hard admission floor, not an autoupdate target, and is unaffected by the gate.
 coordinator_advertised_version:
-  latest_binary_version: "1.8.61"
+  latest_binary_version: "1.8.62"
   required_binary_version: ""
 
 auth:

--- a/phase4-coordinator/dist/coordinator.yaml
+++ b/phase4-coordinator/dist/coordinator.yaml
@@ -313,4 +313,4 @@ providers:
 # legacy cohort (DECISION_CRITERIA Entry 161). Setting this value does not, and
 # must not, re-arm the legacy binary-only updater.
 coordinator_advertised_version:
-  latest_binary_version: "1.8.61"
+  latest_binary_version: "1.8.62"

--- a/phase4-coordinator/dist/coordinator.yaml.example
+++ b/phase4-coordinator/dist/coordinator.yaml.example
@@ -358,7 +358,7 @@ malibu_emission:
 # Use for security fixes that must not be optional. Leave unset for advisory
 # releases.
 coordinator_advertised_version:
-  latest_binary_version: "1.8.61"
+  latest_binary_version: "1.8.62"
   # required_binary_version: "1.7.0"
 
 # Enumerated providers (SPEC-002 v1.0.4 Finding F-2: every provider_id that

--- a/scripts/test-malibu-bootstrap-bridge.sh
+++ b/scripts/test-malibu-bootstrap-bridge.sh
@@ -126,11 +126,11 @@ PY
 
 create_test_app "$work/later.app" 1.8.45 45
 cp "$work/later.app/Contents/Info.plist" "$work/later.Info.plist"
-python3 "$trust_anchor_helper" preflight v1.8.61 \
+python3 "$trust_anchor_helper" preflight v1.8.62 \
   "$work/later.app" "$legacy_key" >/dev/null
 cmp "$work/later.Info.plist" "$work/later.app/Contents/Info.plist" ||
   fail "candidate preflight mutated independently versioned Malibu"
-python3 "$trust_anchor_helper" prepare v1.8.61 \
+python3 "$trust_anchor_helper" prepare v1.8.62 \
   "$work/later.app" "$legacy_key" >/dev/null
 cmp "$work/later.Info.plist" "$work/later.app/Contents/Info.plist" ||
   fail "non-bridge preparation mutated independently versioned Malibu"
@@ -143,7 +143,7 @@ expect_anchor_failure wrong-bridge-version 'bundle version 1.8.45 does not match
 
 create_test_app "$work/reserved-bridge-version.app" 1.8.39 39
 expect_anchor_failure reserved-bridge-version 'reserved for the v1.8.39 trust-anchor release' \
-  preflight v1.8.61 "$work/reserved-bridge-version.app" "$legacy_key"
+  preflight v1.8.62 "$work/reserved-bridge-version.app" "$legacy_key"
 
 create_test_app "$work/missing-anchor.app" 1.8.39 39
 expect_anchor_failure missing-anchor 'must contain only the exact frozen' \


### PR DESCRIPTION
## Summary

Advance the provider CLI release target from `v1.8.61` to `v1.8.62` after `v1.8.61` failed updater verification with `embedded_cli_mismatch`.

Changes:

- `CoordinatorClient.binaryVersion` -> `1.8.62`
- coordinator advertised `latest_binary_version` -> `1.8.62` in runtime/example configs
- Malibu bootstrap bridge tests updated to use the current non-bridge release tag while preserving Malibu app version independence (`1.8.45` remains unchanged)

This intentionally does not patch or reuse `v1.8.61`; that release is public/immutable and should remain treated as not production-verified.

## Tests

- `bash scripts/test-coordinator-advertised-version.sh v1.8.62`
- `bash scripts/test-malibu-bootstrap-bridge.sh`
- `bash scripts/test-release-security-posture.sh`
- `bash scripts/test-tier2-provider-release.sh`
- `bash scripts/test-malibu-independent-release.sh`
- `git diff --check`

## Audit

- Architecture/process audit: 0 C/H/M/L, INFO only that candidate must run after merge to `main`
- Security/release audit: 0 C/H/M/L
- Correctness lane timed out; covered by targeted guards and file-for-file comparison with the prior v1.8.61 bump shape

SPEC-GOVERNANCE-DECLARATION-BEGIN
{
  "schema_version": "spec-pr-governance-v1",
  "behavior_change": "yes",
  "contract_change": "none",
  "specs": ["SPEC-020", "SPEC-025"],
  "requirements": ["SPEC-020-R002"],
  "authority_domains": ["provider-autoupdate", "native-app-lifecycle"],
  "arbitration": ["CODE_BUG"],
  "tests": [
    "scripts/test-coordinator-advertised-version.sh v1.8.62",
    "scripts/test-malibu-bootstrap-bridge.sh",
    "scripts/test-release-security-posture.sh",
    "scripts/test-tier2-provider-release.sh",
    "scripts/test-malibu-independent-release.sh"
  ],
  "journeys": ["not-required"],
  "issue": "https://github.com/Augustas11/macprovider/issues/610"
}
SPEC-GOVERNANCE-DECLARATION-END
