### PR TITLE
Sign Malibu nested payloads without mutating provider CLI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -758,6 +758,21 @@ jobs:
             exit 1
           fi
 
+          # Sign nested copied payloads explicitly before signing the outer
+          # app. Do not use codesign --deep here: the standalone provider CLI
+          # is already signed and must remain byte-identical to the tarball
+          # CLI after it is embedded in Malibu.app.
+          codesign --force \
+            --timestamp \
+            --sign "$SIGNING_ID" \
+            "$APP/Contents/MacOS/mlx.metallib"
+          while IFS= read -r -d '' nested_bundle; do
+            codesign --force \
+              --timestamp \
+              --sign "$SIGNING_ID" \
+              "$nested_bundle"
+          done < <(find "$APP/Contents/MacOS" -mindepth 1 -maxdepth 1 -type d -name '*.bundle' -print0)
+
           SOURCE_CLI_REQUIREMENT=$(codesign -d -r- "$APP/Contents/MacOS/macprovider-cli" 2>&1)
           source_cli_sha256="$(shasum -a 256 "$WORK/macprovider-cli" | awk '{print $1}')"
           codesign --force \

--- a/scripts/test-release-security-posture.sh
+++ b/scripts/test-release-security-posture.sh
@@ -604,12 +604,26 @@ compatibility_copy = app_sign.find(
 )
 anchor_prepare = app_sign.find("prepare-malibu-bootstrap-trust-anchor.py prepare")
 anchor_verify = app_sign.find("prepare-malibu-bootstrap-trust-anchor.py verify")
-app_codesign = app_sign.find("codesign --force \\")
-if min(first_bundle_write, compatibility_copy, anchor_prepare, anchor_verify, app_codesign) < 0 or not (
-    anchor_prepare < first_bundle_write < compatibility_copy < anchor_verify < app_codesign
+nested_payload_sign = app_sign.find("Sign nested copied payloads explicitly")
+app_codesign = app_sign.find("--entitlements phase3-binary/app/Malibu.entitlements")
+if min(
+    first_bundle_write,
+    compatibility_copy,
+    anchor_prepare,
+    anchor_verify,
+    nested_payload_sign,
+    app_codesign,
+) < 0 or not (
+    anchor_prepare
+    < first_bundle_write
+    < compatibility_copy
+    < anchor_verify
+    < nested_payload_sign
+    < app_codesign
 ):
     raise SystemExit(
-        "Malibu app must be preflighted before bundle writes and reverified before codesign"
+        "Malibu app must be preflighted before bundle writes, reverified, "
+        "and explicitly sign nested payloads before outer codesign"
     )
 if "codesign --force --deep" in app_sign:
     raise SystemExit("Malibu app signing must not recursively re-sign the embedded provider CLI")
@@ -627,6 +641,9 @@ for requirement in (
     "source_cli_sha256",
     "bundled_cli_sha256",
     "Malibu embedded CLI sha256 differs from standalone CLI",
+    "Sign nested copied payloads explicitly",
+    '"$APP/Contents/MacOS/mlx.metallib"',
+    "nested_bundle",
 ):
     if requirement not in app_sign:
         raise SystemExit(f"Malibu signing omits trust-continuity guard: {requirement}")


### PR DESCRIPTION
## Summary

Fixes the v1.8.62 production release failure in `Sign + notarize + staple Malibu.app`.

The prior hardening correctly removed recursive app signing so the embedded provider CLI would not be mutated after standalone signing. The production run then exposed the next missing step: `mlx.metallib` is a nested code-like payload and must be signed explicitly before the outer app is signed/verified.

This PR:

- signs `Contents/MacOS/mlx.metallib` explicitly before outer Malibu.app signing;
- signs copied SwiftPM `.bundle` directories explicitly before outer Malibu.app signing;
- keeps `macprovider-cli` untouched after the standalone signed CLI is copied into Malibu.app;
- keeps the SHA-256 byte-identity guard between standalone CLI and embedded CLI;
- extends the posture test to require explicit nested payload signing before outer app codesign.

## Validation

- `bash scripts/test-release-security-posture.sh`
- `bash scripts/test-tier2-provider-release.sh`
- `bash scripts/test-malibu-independent-release.sh`
- YAML parse for `.github/workflows/release.yml`
- `git diff --check`

## Release note

This is release-pipeline-only. It does not change product code or the v1.8.62 release tag payload. After merge, rerun `release.yml` for `v1.8.62` from `main`; the workflow file changes should apply while the release source remains the signed `v1.8.62` tag commit.

SPEC-GOVERNANCE-DECLARATION-BEGIN
{
  "schema_version": "spec-pr-governance-v1",
  "behavior_change": "yes",
  "contract_change": "none",
  "specs": ["SPEC-020"],
  "requirements": ["SPEC-020-R001"],
  "authority_domains": ["provider-autoupdate"],
  "arbitration": ["CODE_BUG"],
  "tests": ["scripts/test-release-security-posture.sh", "scripts/test-tier2-provider-release.sh", "scripts/test-malibu-independent-release.sh"],
  "journeys": ["provider-release-verification"],
  "issue": "https://github.com/Augustas11/macprovider/issues/608"
}
SPEC-GOVERNANCE-DECLARATION-END

