### PR TITLE
Promote verified candidate artifacts into release signing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,11 @@ on:
         required: false
         default: false
         type: boolean
+      promote_run_id:
+        description: "Reuse a previously verified unsigned candidate run instead of rebuilding"
+        required: false
+        default: ""
+        type: string
       provider_admission_policy:
         description: "Signed provider admission rollout policy"
         required: true
@@ -61,6 +66,7 @@ jobs:
           RELEASE_VERSION_INPUT: ${{ github.event.inputs.version }}
           RELEASE_PRERELEASE_INPUT: ${{ github.event.inputs.prerelease || 'false' }}
           RELEASE_CANDIDATE_INPUT: ${{ github.event.inputs.candidate || 'false' }}
+          PROMOTE_RUN_ID_INPUT: ${{ github.event.inputs.promote_run_id || '' }}
           PROVIDER_ADMISSION_POLICY_INPUT: ${{ github.event.inputs.provider_admission_policy || 'strict_post_migration' }}
         run: |
           set -euo pipefail
@@ -76,6 +82,16 @@ jobs:
           absence_policy="--require-existing"
           if [[ "$RELEASE_CANDIDATE_INPUT" == "true" ]]; then
             absence_policy="--allow-absent"
+          fi
+          if [[ -n "$PROMOTE_RUN_ID_INPUT" ]]; then
+            if [[ "$RELEASE_CANDIDATE_INPUT" == "true" ]]; then
+              echo "::error::candidate builds cannot promote another candidate run" >&2
+              exit 1
+            fi
+            if [[ ! "$PROMOTE_RUN_ID_INPUT" =~ ^[0-9]+$ ]]; then
+              echo "::error::promote_run_id must be a numeric GitHub Actions run id" >&2
+              exit 1
+            fi
           fi
           bash scripts/verify-release-source.sh \
             "$tag" "$commit" origin "$absence_policy"
@@ -99,6 +115,7 @@ jobs:
           bash scripts/verify-release-toolchain.sh "$RUNNER_TEMP/release-toolchain.json"
 
       - name: Setup Go for Pearl binaries
+        if: ${{ github.event.inputs.promote_run_id == '' }}
         # Pinned to actions/setup-go v6.5.0. Linux binaries are cross-compiled
         # without CGO and carried as unsigned inputs into the protected signer.
         uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16
@@ -109,6 +126,7 @@ jobs:
             phase5-gateway/go.sum
 
       - name: Seal the Tier-2 verifier toolchain
+        if: ${{ github.event.inputs.promote_run_id == '' }}
         shell: bash
         run: |
           set -euo pipefail
@@ -121,6 +139,7 @@ jobs:
           sudo test -x /private/var/macprovider-go-verifier/bin/go
 
       - name: Build Pearl linux-amd64 binaries
+        if: ${{ github.event.inputs.promote_run_id == '' }}
         shell: bash
         run: |
           set -euo pipefail
@@ -156,12 +175,14 @@ jobs:
           grep -Fq "$tag" "$RUNNER_TEMP/gateway-linux-amd64.strings"
 
       - name: Install reviewed XcodeGen artifact
+        if: ${{ github.event.inputs.promote_run_id == '' }}
         shell: bash
         run: |
           set -euo pipefail
           bash scripts/install-pinned-xcodegen.sh "$RUNNER_TEMP/xcodegen-2.45.4"
 
       - name: Preflight protected OpenSSL seal before tag creation
+        if: ${{ github.event.inputs.promote_run_id == '' }}
         shell: bash
         run: |
           set -euo pipefail
@@ -171,6 +192,7 @@ jobs:
           printf 'OPENSSL_BIN=%s\n' "$sealed_bin" >> "$GITHUB_ENV"
 
       - name: Build package
+        if: ${{ github.event.inputs.promote_run_id == '' }}
         shell: bash
         env:
           PROVIDER_ADMISSION_POLICY_INPUT: ${{ github.event.inputs.provider_admission_policy || 'strict_post_migration' }}
@@ -182,6 +204,7 @@ jobs:
             ./package.sh "${{ steps.release_source.outputs.tag }}"
 
       - name: Build Malibu.app
+        if: ${{ github.event.inputs.promote_run_id == '' }}
         shell: bash
         run: |
           set -euo pipefail
@@ -200,6 +223,7 @@ jobs:
             "$RUNNER_TEMP/Malibu.app"
 
       - name: Capture unsigned build artifact
+        if: ${{ github.event.inputs.promote_run_id == '' }}
         shell: bash
         run: |
           set -euo pipefail
@@ -229,6 +253,84 @@ jobs:
             unsigned-release-inputs/unsigned-release-manifest.json \
             "${unsigned_assets[@]}"
 
+      - name: Restore promoted unsigned candidate artifact
+        if: ${{ github.event.inputs.promote_run_id != '' }}
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PROMOTE_RUN_ID: ${{ github.event.inputs.promote_run_id }}
+        run: |
+          set -euo pipefail
+          tag="${{ steps.release_source.outputs.tag }}"
+          commit="${{ steps.release_source.outputs.commit }}"
+          prerelease="${{ steps.release_source.outputs.prerelease }}"
+          artifact_name="unsigned-release-${commit}"
+
+          python3 - "$GITHUB_REPOSITORY" "$PROMOTE_RUN_ID" "$commit" <<'PY'
+          import json
+          import subprocess
+          import sys
+
+          repo, run_id, expected_commit = sys.argv[1:4]
+          run = json.loads(subprocess.check_output([
+              "gh", "api", f"repos/{repo}/actions/runs/{run_id}",
+          ], text=True))
+          if run.get("head_sha") != expected_commit:
+              raise SystemExit(
+                  f"promoted run head_sha {run.get('head_sha')} does not match {expected_commit}"
+              )
+          if run.get("event") != "workflow_dispatch":
+              raise SystemExit("promoted run must be a manual release workflow dispatch")
+          if run.get("status") != "completed":
+              raise SystemExit("promoted run must be completed before production signing")
+          if run.get("conclusion") not in {"cancelled", "success"}:
+              raise SystemExit(
+                  f"promoted run conclusion must be cancelled-at-signing or success, got {run.get('conclusion')}"
+              )
+
+          jobs = json.loads(subprocess.check_output([
+              "gh", "api", f"repos/{repo}/actions/runs/{run_id}/jobs", "--paginate",
+          ], text=True))
+          by_name = {}
+          for job in jobs.get("jobs", []):
+              by_name.setdefault(job.get("name"), []).append(job)
+
+          def require_success(name):
+              if not any(job.get("conclusion") == "success" for job in by_name.get(name, [])):
+                  raise SystemExit(f"promoted run lacks a successful {name} job")
+
+          require_success("Build unsigned release inputs from reviewed main")
+          require_success("Verify unsigned provider runtime on arm64")
+          if any(
+              job.get("conclusion") == "success"
+              for job in by_name.get("Sign and publish reviewed release", [])
+          ):
+              raise SystemExit("promoted candidate run must not have completed production signing")
+          PY
+
+          mkdir -p unsigned-release-inputs
+          gh run download "$PROMOTE_RUN_ID" \
+            --repo "$GITHUB_REPOSITORY" \
+            --name "$artifact_name" \
+            --dir unsigned-release-inputs
+
+          unsigned_assets=(
+            "unsigned-release-inputs/phase3-binary-m4-${tag}.tar.gz"
+            unsigned-release-inputs/Malibu.app.tar.gz
+            unsigned-release-inputs/release-toolchain.json
+            unsigned-release-inputs/coordinator-linux-amd64
+            unsigned-release-inputs/coordinator-cli-linux-amd64
+            unsigned-release-inputs/gateway-linux-amd64
+          )
+          python3 scripts/build-release-provenance.py \
+            "$tag" "$commit" \
+            "$GITHUB_REPOSITORY" "$prerelease" \
+            unsigned-release-inputs/release-toolchain.json \
+            "$RUNNER_TEMP/expected-unsigned-release-manifest.json" \
+            "${unsigned_assets[@]}"
+          cmp unsigned-release-inputs/unsigned-release-manifest.json \
+            "$RUNNER_TEMP/expected-unsigned-release-manifest.json"
+
       - name: Verify staged Pearl Go binaries
         env:
           EXPECTED_REVISION: ${{ steps.release_source.outputs.commit }}
@@ -245,7 +347,7 @@ jobs:
           name: unsigned-release-${{ steps.release_source.outputs.commit }}
           path: unsigned-release-inputs/
           if-no-files-found: error
-          retention-days: 1
+          retention-days: 7
 
   verify_provider_runtime:
     name: Verify unsigned provider runtime on arm64

--- a/phase3-binary/Sources/macprovider-cli/CoordinatorClient.swift
+++ b/phase3-binary/Sources/macprovider-cli/CoordinatorClient.swift
@@ -146,7 +146,7 @@ actor CoordinatorClient {
     typealias InstalledCompatibilityManifest = @Sendable (URL, String) -> CompatibilitySetManifest?
     typealias ReloadHelperFence = @Sendable () throws -> Void
 
-    static let binaryVersion = "1.8.63"
+    static let binaryVersion = "1.8.64"
     private static let keepaliveDebugEnabled = ProcessInfo.processInfo.environment["MACPROVIDER_KEEPALIVE_DEBUG"] == "1"
 
     private let coordinatorURL: URL

--- a/phase4-coordinator/coordinator.yaml.example
+++ b/phase4-coordinator/coordinator.yaml.example
@@ -184,7 +184,7 @@ autotune:
 # legacy cohort (DECISION_CRITERIA Entry 161). `required_binary_version` is a
 # hard admission floor, not an autoupdate target, and is unaffected by the gate.
 coordinator_advertised_version:
-  latest_binary_version: "1.8.63"
+  latest_binary_version: "1.8.64"
   required_binary_version: ""
 
 auth:

--- a/phase4-coordinator/dist/coordinator.yaml
+++ b/phase4-coordinator/dist/coordinator.yaml
@@ -313,4 +313,4 @@ providers:
 # legacy cohort (DECISION_CRITERIA Entry 161). Setting this value does not, and
 # must not, re-arm the legacy binary-only updater.
 coordinator_advertised_version:
-  latest_binary_version: "1.8.63"
+  latest_binary_version: "1.8.64"

--- a/phase4-coordinator/dist/coordinator.yaml.example
+++ b/phase4-coordinator/dist/coordinator.yaml.example
@@ -358,7 +358,7 @@ malibu_emission:
 # Use for security fixes that must not be optional. Leave unset for advisory
 # releases.
 coordinator_advertised_version:
-  latest_binary_version: "1.8.63"
+  latest_binary_version: "1.8.64"
   # required_binary_version: "1.7.0"
 
 # Enumerated providers (SPEC-002 v1.0.4 Finding F-2: every provider_id that

--- a/scripts/test-malibu-bootstrap-bridge.sh
+++ b/scripts/test-malibu-bootstrap-bridge.sh
@@ -126,11 +126,11 @@ PY
 
 create_test_app "$work/later.app" 1.8.45 45
 cp "$work/later.app/Contents/Info.plist" "$work/later.Info.plist"
-python3 "$trust_anchor_helper" preflight v1.8.63 \
+python3 "$trust_anchor_helper" preflight v1.8.64 \
   "$work/later.app" "$legacy_key" >/dev/null
 cmp "$work/later.Info.plist" "$work/later.app/Contents/Info.plist" ||
   fail "candidate preflight mutated independently versioned Malibu"
-python3 "$trust_anchor_helper" prepare v1.8.63 \
+python3 "$trust_anchor_helper" prepare v1.8.64 \
   "$work/later.app" "$legacy_key" >/dev/null
 cmp "$work/later.Info.plist" "$work/later.app/Contents/Info.plist" ||
   fail "non-bridge preparation mutated independently versioned Malibu"
@@ -143,7 +143,7 @@ expect_anchor_failure wrong-bridge-version 'bundle version 1.8.45 does not match
 
 create_test_app "$work/reserved-bridge-version.app" 1.8.39 39
 expect_anchor_failure reserved-bridge-version 'reserved for the v1.8.39 trust-anchor release' \
-  preflight v1.8.63 "$work/reserved-bridge-version.app" "$legacy_key"
+  preflight v1.8.64 "$work/reserved-bridge-version.app" "$legacy_key"
 
 create_test_app "$work/missing-anchor.app" 1.8.39 39
 expect_anchor_failure missing-anchor 'must contain only the exact frozen' \

--- a/scripts/test-release-security-posture.sh
+++ b/scripts/test-release-security-posture.sh
@@ -86,6 +86,15 @@ candidate_input = re.search(
 )
 if candidate_input is None:
     raise SystemExit("candidate dispatch input must be a boolean defaulting to false")
+promote_input = re.search(
+    r"\n      promote_run_id:\n"
+    r"(?:        .*\n)*?"
+    r"        default: \"\"\n"
+    r"        type: string\n",
+    text,
+)
+if promote_input is None:
+    raise SystemExit("release workflow must expose a string promote_run_id input")
 build = text.split("\n  build:\n", 1)[1].split(
     "\n  verify_provider_runtime:\n", 1
 )[0]
@@ -104,6 +113,7 @@ def unique_step(job, name):
 
 PEARL_SETUP_GO_SHA = "924ae3a1cded613372ab5595356fb5720e22ba16"
 PEARL_GO_SEAL_STEP = (
+    "        if: ${{ github.event.inputs.promote_run_id == '' }}\n"
     "        shell: bash\n"
     "        run: |\n"
     "          set -euo pipefail\n"
@@ -115,7 +125,9 @@ PEARL_GO_SEAL_STEP = (
     "          sudo chmod -R go-w /private/var/macprovider-go-verifier\n"
     "          sudo test -x /private/var/macprovider-go-verifier/bin/go"
 )
-CI_GO_SEAL_STEP = PEARL_GO_SEAL_STEP.replace("-g wheel", "-g root").replace(
+CI_GO_SEAL_STEP = PEARL_GO_SEAL_STEP.replace(
+    "        if: ${{ github.event.inputs.promote_run_id == '' }}\n", "", 1
+).replace("-g wheel", "-g root").replace(
     "root:wheel", "root:root"
 )
 SEALED_GO_EXECUTABLE = "/private/var/macprovider-go-verifier/bin/go"
@@ -126,6 +138,7 @@ PEARL_SETUP_SEAL_BUILD_SEQUENCE = (
     f"{PEARL_GO_SEAL_STEP}\n"
     "\n      - name: Build Pearl linux-amd64 binaries\n"
 )
+SLOW_BUILD_SKIP_GUARD = "        if: ${{ github.event.inputs.promote_run_id == '' }}"
 PEARL_SEALED_GO_REQUIREMENT = (
     "          CATALOG_RELEASE_REQUIRE_SEALED_GO_VERIFIER=1 \\\n"
     '            MACPROVIDER_PROVIDER_ADMISSION_POLICY="$PROVIDER_ADMISSION_POLICY_INPUT" \\\n'
@@ -152,14 +165,15 @@ UNSIGNED_UPLOAD_STEP = (
     '          name: unsigned-release-${{ steps.release_source.outputs.commit }}\n'
     "          path: unsigned-release-inputs/\n"
     "          if-no-files-found: error\n"
-    "          retention-days: 1"
+    "          retention-days: 7"
 )
 MALIBU_CANDIDATE_PREFLIGHT = (
     '          python3 "$GITHUB_WORKSPACE/scripts/prepare-malibu-bootstrap-trust-anchor.py" preflight \\\n'
     '            "$tag" "$RUNNER_TEMP/Malibu.app" \\\n'
     '            "$GITHUB_WORKSPACE/scripts/dist/malibu-v1.8.32-sparkle-public-key"'
 )
-MALIBU_BUILD_STEP = r'''        shell: bash
+MALIBU_BUILD_STEP = r'''        if: ${{ github.event.inputs.promote_run_id == '' }}
+        shell: bash
         run: |
           set -euo pipefail
           cd phase3-binary/app
@@ -175,7 +189,8 @@ MALIBU_BUILD_STEP = r'''        shell: bash
             CODE_SIGNING_ALLOWED=NO
           cp -R "$RUNNER_TEMP/Malibu.xcarchive/Products/Applications/Malibu.app" \
             "$RUNNER_TEMP/Malibu.app"'''
-MALIBU_CAPTURE_STEP = r'''        shell: bash
+MALIBU_CAPTURE_STEP = r'''        if: ${{ github.event.inputs.promote_run_id == '' }}
+        shell: bash
         run: |
           set -euo pipefail
           tag="${{ steps.release_source.outputs.tag }}"
@@ -216,7 +231,8 @@ PROTECTED_OPENSSL3_STEP = r'''        id: protected_openssl
           "$sealed_bin" version | grep -E '^OpenSSL 3\.'
           printf 'bin=%s\n' "$sealed_bin" >> "$GITHUB_OUTPUT"'''
 PROTECTED_OPENSSL_ROOT = "/private/var/macprovider-openssl-verifier"
-PROTECTED_OPENSSL_CANDIDATE_STEP = r'''        shell: bash
+PROTECTED_OPENSSL_CANDIDATE_STEP = r'''        if: ${{ github.event.inputs.promote_run_id == '' }}
+        shell: bash
         run: |
           set -euo pipefail
           candidate_root="/private/var/macprovider-openssl-candidate-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
@@ -224,6 +240,25 @@ PROTECTED_OPENSSL_CANDIDATE_STEP = r'''        shell: bash
           "$sealed_bin" version | grep -E '^OpenSSL 3\.'
           printf 'OPENSSL_BIN=%s\n' "$sealed_bin" >> "$GITHUB_ENV"
 '''
+PROMOTED_CANDIDATE_RESTORE_REQUIREMENTS = (
+    "        if: ${{ github.event.inputs.promote_run_id != '' }}",
+    "          GH_TOKEN: ${{ github.token }}",
+    "          PROMOTE_RUN_ID: ${{ github.event.inputs.promote_run_id }}",
+    '          artifact_name="unsigned-release-${commit}"',
+    '              "gh", "api", f"repos/{repo}/actions/runs/{run_id}",',
+    '          if run.get("head_sha") != expected_commit:',
+    '          if run.get("event") != "workflow_dispatch":',
+    '          if run.get("status") != "completed":',
+    '          if run.get("conclusion") not in {"cancelled", "success"}:',
+    '              "gh", "api", f"repos/{repo}/actions/runs/{run_id}/jobs", "--paginate",',
+    '          require_success("Build unsigned release inputs from reviewed main")',
+    '          require_success("Verify unsigned provider runtime on arm64")',
+    '              for job in by_name.get("Sign and publish reviewed release", [])',
+    '          gh run download "$PROMOTE_RUN_ID" \\',
+    '            --name "$artifact_name" \\',
+    "scripts/build-release-provenance.py",
+    'cmp unsigned-release-inputs/unsigned-release-manifest.json',
+)
 SEALED_OPENSSL_WRAPPER = r'''#!/bin/bash -p
 set -euo pipefail
 
@@ -284,6 +319,7 @@ def validate_candidate_openssl(job):
 def validate_malibu_candidate_preflight(job):
     build_app = unique_step(job, "Build Malibu.app")
     capture = unique_step(job, "Capture unsigned build artifact")
+    promoted_restore = unique_step(job, "Restore promoted unsigned candidate artifact")
     if build_app.strip("\n") != MALIBU_BUILD_STEP:
         raise SystemExit(
             "candidate Malibu build must retain the exact reviewed step"
@@ -294,15 +330,21 @@ def validate_malibu_candidate_preflight(job):
         )
     build_marker = "\n      - name: Build Malibu.app\n"
     capture_marker = "\n      - name: Capture unsigned build artifact\n"
+    restore_marker = "\n      - name: Restore promoted unsigned candidate artifact\n"
     verify_marker = "\n      - name: Verify staged Pearl Go binaries\n"
     if job.count(build_marker + build_app + capture_marker) != 1:
         raise SystemExit(
             "candidate Malibu build and fail-closed capture must remain adjacent"
         )
-    if job.count(capture_marker + capture + verify_marker) != 1:
+    if job.count(capture_marker + capture + restore_marker + promoted_restore + verify_marker) != 1:
         raise SystemExit(
-            "candidate artifact capture and exact verifier must remain adjacent"
+            "candidate artifact capture/promotion and exact verifier must remain adjacent"
         )
+    for requirement in PROMOTED_CANDIDATE_RESTORE_REQUIREMENTS:
+        if promoted_restore.count(requirement) != 1:
+            raise SystemExit(
+                f"promoted candidate restore step lacks exact gate: {requirement}"
+            )
     preflight_position = capture.find(MALIBU_CANDIDATE_PREFLIGHT)
     tar_position = capture.find(
         "tar czf unsigned-release-inputs/Malibu.app.tar.gz"
@@ -348,9 +390,21 @@ def validate_pearl_toolchain(job):
     sealed_go_path = str(pathlib.PurePosixPath(SEALED_GO_EXECUTABLE).parent.parent)
     if job.count(sealed_go_path) != PEARL_GO_SEAL_STEP.count(sealed_go_path):
         raise SystemExit("sealed Go verifier path must appear only in the exact seal step")
-    expected_sequence = PEARL_SETUP_SEAL_BUILD_SEQUENCE.format(setup_go=setup_go.rstrip("\n"))
-    if job.count(expected_sequence) != 1:
-        raise SystemExit("Pearl Setup Go, verifier seal, and binary build must remain adjacent and ordered")
+    for name, step in (
+        ("Setup Go for Pearl binaries", setup_go),
+        ("Build Pearl linux-amd64 binaries", pearl_build),
+        ("Build package", package_build),
+    ):
+        if step.count(SLOW_BUILD_SKIP_GUARD) != 1:
+            raise SystemExit(f"{name} must be skipped when promoting a candidate artifact")
+    setup_position = job.find("- name: Setup Go for Pearl binaries")
+    seal_position = job.find("- name: Seal the Tier-2 verifier toolchain")
+    pearl_position = job.find("- name: Build Pearl linux-amd64 binaries")
+    package_position = job.find("- name: Build package")
+    if min(setup_position, seal_position, pearl_position, package_position) < 0 or not (
+        setup_position < seal_position < pearl_position < package_position
+    ):
+        raise SystemExit("Pearl Setup Go, verifier seal, binary build, and package build must remain ordered")
     if package_build.count(PEARL_SEALED_GO_REQUIREMENT) != 1:
         raise SystemExit("release package verification must require the sealed Go verifier")
     if job.count("CATALOG_RELEASE_REQUIRE_SEALED_GO_VERIFIER") != 1:
@@ -955,8 +1009,10 @@ malibu_preflight_group_suppression_mutation = build.replace(
 )
 malibu_step_continue_on_error_mutation = build.replace(
     "\n      - name: Capture unsigned build artifact\n"
+    "        if: ${{ github.event.inputs.promote_run_id == '' }}\n"
     "        shell: bash\n",
     "\n      - name: Capture unsigned build artifact\n"
+    "        if: ${{ github.event.inputs.promote_run_id == '' }}\n"
     "        continue-on-error: true\n"
     "        shell: bash\n",
     1,


### PR DESCRIPTION
## Summary
- add a `promote_run_id` release input so production signing can reuse the exact unsigned artifact from a verified candidate run
- validate the promoted run's commit, manual-dispatch provenance, completed status, required successful build + arm64 verification jobs, and absence of completed production signing
- skip the slow unsigned package/Malibu rebuild when promoting, then re-upload the restored artifact into the current production run for the protected signer
- bump the provider CLI target to v1.8.64 because v1.8.63 cannot include workflow hardening after its tag already exists

## Why
Candidate verification currently proves one unsigned package, but production then rebuilds another package before signing. That is the failure mode that produced the v1.8.61 binary mismatch and repeated long release loops. This change makes candidate verification promote into signing instead of asking production to rebuild the same source again.

## Validation
- `python3` YAML parse of `.github/workflows/release.yml`
- `bash -n scripts/test-release-security-posture.sh scripts/test-tier2-provider-release.sh scripts/test-malibu-bootstrap-bridge.sh`
- `bash scripts/test-release-security-posture.sh`
- `bash scripts/test-tier2-provider-release.sh`
- `bash scripts/test-coordinator-advertised-version.sh v1.8.64`
- `bash scripts/test-malibu-bootstrap-bridge.sh`
- `bash scripts/test-malibu-independent-release.sh`
- `git diff --check`
- local dry run downloaded a real candidate artifact and verified manifest/provenance/Pearl binary revision checks

SPEC-GOVERNANCE-DECLARATION-BEGIN
{
  "schema_version": "spec-pr-governance-v1",
  "behavior_change": "yes",
  "contract_change": "none",
  "specs": ["SPEC-020", "SPEC-025"],
  "requirements": ["SPEC-020-R002"],
  "authority_domains": ["provider-autoupdate", "native-app-lifecycle"],
  "arbitration": ["CODE_BUG"],
  "tests": ["scripts/test-release-security-posture.sh", "scripts/test-tier2-provider-release.sh", "scripts/test-coordinator-advertised-version.sh v1.8.64", "scripts/test-malibu-bootstrap-bridge.sh", "scripts/test-malibu-independent-release.sh"],
  "journeys": ["not-required"],
  "issue": "https://github.com/Augustas11/macprovider/issues/610"
}
SPEC-GOVERNANCE-DECLARATION-END