### PR TITLE
Mute provider-churn alert email on the Pearl monitor

### DIFF
--- a/audits/2026-07-25/AUDIT_MONITOR_EMAIL_MUTE_R1_ARCHITECT_PROMPT.md
+++ b/audits/2026-07-25/AUDIT_MONITOR_EMAIL_MUTE_R1_ARCHITECT_PROMPT.md
@@ -1,0 +1,87 @@
+# AUDIT_MONITOR_EMAIL_MUTE_R1_ARCHITECT_PROMPT
+
+You are auditing the ARCHITECT lane of a change to the Pearl-side observability
+monitor in this repository (branch `fix/monitor-email-mute-provider-churn`).
+
+## Audit target — the FULL fix as it will land
+
+```
+git diff origin/main -- phase4-coordinator/dist/monitor phase4-coordinator/dist/test/check_monitor_email_mute_test.sh
+```
+
+Files:
+
+- `phase4-coordinator/dist/monitor/macprovider-monitor.py`
+- `phase4-coordinator/dist/monitor/README.md`
+- `phase4-coordinator/dist/test/check_monitor_email_mute_test.sh` (new)
+
+Related unchanged context you should read:
+
+- `phase4-coordinator/dist/monitor/macprovider-monitor.service` / `.timer`
+- `phase4-coordinator/dist/test/check_monitor_sandbox_test.sh`
+- `phase4-coordinator/dist/deploy-pearl-vps.sh` (monitor.env perms block)
+- `ops/pearl-updater/macprovider-pearl-updater-alert` (a SEPARATE tool that
+  reads the same `/etc/macprovider/monitor.env` and requires the keys
+  `ALERT_EMAIL`, `GMAIL_USER`, `GMAIL_APP_PASSWORD`)
+
+## What the change does and why
+
+The monitor runs on a 3-minute systemd timer and emails every alerting state
+transition. On the current single-Mac fleet, provider churn dominates: Pearl
+journald shows 237 emailed alerts in 7 days, ~95% of them
+`provider … dropped from pool`, `pool has 0 ready providers`, and
+`gateway status -> idle`. The operator asked for those to stop while real
+service-down alerts keep arriving.
+
+The change tags every alert with a KIND and routes email per kind:
+`provider`, `pool`, `gateway_status` are journal-only by default; `service`
+and `static_feed` still email. `EMAIL_MUTED_KINDS` in
+`/etc/macprovider/monitor.env` overrides (`all` / `none` / explicit list).
+
+Lock bar: 0 critical, 0 high, 0 medium.
+
+## Focus
+
+- Is per-kind mail routing the right abstraction, or is this a rate-limiting /
+  deduplication / flap-damping problem wearing a filter's clothes? The observed
+  pattern is one Mac oscillating; argue which mechanism actually matches the
+  failure mode, and whether the chosen one will still be right when the fleet
+  has 20 providers instead of 1.
+- Default-off vs config-off: the change hardcodes a default mute set in the
+  script AND allows `EMAIL_MUTED_KINDS` to override it. Is a code-level default
+  correct here, or should Pearl's `monitor.env` carry the whole policy so the
+  routing decision is an ops artifact rather than a source-tree constant?
+  Consider that `monitor.py` is redeployed by `deploy-pearl-vps.sh` while
+  `monitor.env` is not overwritten.
+- Kind taxonomy: are the five kinds the right cut? Is `gateway_status` really
+  distinct from `service`? Does `pool` belong with `provider`? Will a future
+  alert have no natural home, or force a wrong one?
+- Layering: alert classification, routing policy, and delivery now all live in
+  one 300-line script with no unit-test seam other than `runpy`. Is that
+  proportionate to the problem, or is a seam warranted?
+- Observability of the suppression itself: is the `N alert(s) journal-only`
+  line enough for an operator to later reconstruct what was withheld and why?
+  Is there a discoverability trap where someone debugging "why no email"
+  cannot find the knob?
+- Does the README/docstring accurately describe the shipped behavior, including
+  the state-sealing consequence of muting? Any doc/code drift?
+- Coupling to `ops/pearl-updater/macprovider-pearl-updater-alert` through the
+  shared env file: is growing `monitor.env` into a multi-consumer config the
+  right direction, and is the new key namespaced clearly enough?
+- Reversibility: how does the operator restore the old behavior, and is that
+  path documented and testable?
+
+## Output format
+
+Start with exactly one summary line:
+
+`VERDICT: READY | COUNTS: C=0 H=0 M=0 L=<n>`
+
+or:
+
+`VERDICT: NEEDS REVISION | COUNTS: C=<n> H=<n> M=<n> L=<n>`
+
+Then list ID-prefixed findings, ordered by severity: `ARCH-C-1`, `ARCH-H-1`,
+`ARCH-M-1`, `ARCH-L-1`. Each finding must cite concrete repo evidence
+(file:line). Do not include Critical/High/Medium findings unless they should
+block the merge. The stop bar is 0 C/H/M.

--- a/audits/2026-07-25/AUDIT_MONITOR_EMAIL_MUTE_R1_CODE_PROMPT.md
+++ b/audits/2026-07-25/AUDIT_MONITOR_EMAIL_MUTE_R1_CODE_PROMPT.md
@@ -1,0 +1,87 @@
+# AUDIT_MONITOR_EMAIL_MUTE_R1_CODE_PROMPT
+
+You are auditing the CODE lane of a change to the Pearl-side observability
+monitor in this repository (branch `fix/monitor-email-mute-provider-churn`).
+
+## Audit target — the FULL fix as it will land
+
+```
+git diff origin/main -- phase4-coordinator/dist/monitor phase4-coordinator/dist/test/check_monitor_email_mute_test.sh
+```
+
+Files:
+
+- `phase4-coordinator/dist/monitor/macprovider-monitor.py`
+- `phase4-coordinator/dist/monitor/README.md`
+- `phase4-coordinator/dist/test/check_monitor_email_mute_test.sh` (new)
+
+Related unchanged context you should read:
+
+- `phase4-coordinator/dist/monitor/macprovider-monitor.service` / `.timer`
+- `phase4-coordinator/dist/test/check_monitor_sandbox_test.sh`
+- `phase4-coordinator/dist/deploy-pearl-vps.sh` (monitor.env perms block)
+- `ops/pearl-updater/macprovider-pearl-updater-alert` (a SEPARATE tool that
+  reads the same `/etc/macprovider/monitor.env` and requires the keys
+  `ALERT_EMAIL`, `GMAIL_USER`, `GMAIL_APP_PASSWORD`)
+
+## What the change does and why
+
+The monitor runs on a 3-minute systemd timer and emails every alerting state
+transition. On the current single-Mac fleet, provider churn dominates: Pearl
+journald shows 237 emailed alerts in 7 days, ~95% of them
+`provider … dropped from pool`, `pool has 0 ready providers`, and
+`gateway status -> idle`. The operator asked for those to stop while real
+service-down alerts keep arriving.
+
+The change tags every alert with a KIND and routes email per kind:
+`provider`, `pool`, `gateway_status` are journal-only by default; `service`
+and `static_feed` still email. `EMAIL_MUTED_KINDS` in
+`/etc/macprovider/monitor.env` overrides (`all` / `none` / explicit list).
+
+Lock bar: 0 critical, 0 high, 0 medium.
+
+## Focus
+
+- Correctness of the 2-tuple → 3-tuple alert refactor: is every alert site
+  tagged, and is every consumer (`print`, `alerting`, `send_email`, subject
+  line, body) unpacking the new shape correctly? Any residual index-based
+  access (`alerts[0][1]`) that now reads the wrong element?
+- `muted_kinds()` parsing: absent key, empty value, `none`, `all`, whitespace,
+  case, duplicates, unknown names, and a value like `none,service`. Is any
+  input silently interpreted as "mute everything" — i.e. could an operator
+  typo suppress a real page?
+- State-machine interaction. Before the change: `alerting and delivery is
+  False` → do not `save_state`, so the transition re-fires next poll. After:
+  fully-muted rounds call `send_email` not at all, so `delivery is None` and
+  state advances. Is that correct and non-lossy, or can a real alert now be
+  sealed away without ever being delivered anywhere?
+- Mixed rounds: some muted, some emailable, SMTP fails. What re-fires on the
+  next poll, and can a muted alert be lost or duplicated as a result?
+- Does the change alter any observable journald line other than by adding
+  `(kind)`? Existing operator greps / runbooks keyed on the old
+  `[SEVERITY] message` prefix — is back-compat of the log shape preserved or
+  knowingly broken? Cite any runbook or script that greps these lines.
+- Does anything here break `ops/pearl-updater/macprovider-pearl-updater-alert`,
+  which shares `monitor.env`? (Note the change adds a key rather than
+  removing one — confirm.)
+- Test quality: does `check_monitor_email_mute_test.sh` actually fail if the
+  routing regresses? Does its `main.__globals__.update(m)` stubbing prove
+  real behavior, or is it self-fulfilling? Would it catch a newly added,
+  untagged alert site?
+- Python compatibility with the Pearl runtime (`/usr/bin/python3` on the VPS)
+  and the sandboxed systemd unit.
+
+## Output format
+
+Start with exactly one summary line:
+
+`VERDICT: READY | COUNTS: C=0 H=0 M=0 L=<n>`
+
+or:
+
+`VERDICT: NEEDS REVISION | COUNTS: C=<n> H=<n> M=<n> L=<n>`
+
+Then list ID-prefixed findings, ordered by severity: `CODE-C-1`, `CODE-H-1`,
+`CODE-M-1`, `CODE-L-1`. Each finding must cite concrete repo evidence
+(file:line). Do not include Critical/High/Medium findings unless they should
+block the merge. The stop bar is 0 C/H/M.

--- a/audits/2026-07-25/AUDIT_MONITOR_EMAIL_MUTE_R1_SECURITY_PROMPT.md
+++ b/audits/2026-07-25/AUDIT_MONITOR_EMAIL_MUTE_R1_SECURITY_PROMPT.md
@@ -1,0 +1,84 @@
+# AUDIT_MONITOR_EMAIL_MUTE_R1_SECURITY_PROMPT
+
+You are auditing the SECURITY lane of a change to the Pearl-side observability
+monitor in this repository (branch `fix/monitor-email-mute-provider-churn`).
+
+## Audit target — the FULL fix as it will land
+
+```
+git diff origin/main -- phase4-coordinator/dist/monitor phase4-coordinator/dist/test/check_monitor_email_mute_test.sh
+```
+
+Files:
+
+- `phase4-coordinator/dist/monitor/macprovider-monitor.py`
+- `phase4-coordinator/dist/monitor/README.md`
+- `phase4-coordinator/dist/test/check_monitor_email_mute_test.sh` (new)
+
+Related unchanged context you should read:
+
+- `phase4-coordinator/dist/monitor/macprovider-monitor.service` / `.timer`
+- `phase4-coordinator/dist/test/check_monitor_sandbox_test.sh`
+- `phase4-coordinator/dist/deploy-pearl-vps.sh` (monitor.env perms block)
+- `ops/pearl-updater/macprovider-pearl-updater-alert` (a SEPARATE tool that
+  reads the same `/etc/macprovider/monitor.env` and requires the keys
+  `ALERT_EMAIL`, `GMAIL_USER`, `GMAIL_APP_PASSWORD`)
+
+## What the change does and why
+
+The monitor runs on a 3-minute systemd timer and emails every alerting state
+transition. On the current single-Mac fleet, provider churn dominates: Pearl
+journald shows 237 emailed alerts in 7 days, ~95% of them
+`provider … dropped from pool`, `pool has 0 ready providers`, and
+`gateway status -> idle`. The operator asked for those to stop while real
+service-down alerts keep arriving.
+
+The change tags every alert with a KIND and routes email per kind:
+`provider`, `pool`, `gateway_status` are journal-only by default; `service`
+and `static_feed` still email. `EMAIL_MUTED_KINDS` in
+`/etc/macprovider/monitor.env` overrides (`all` / `none` / explicit list).
+
+Lock bar: 0 critical, 0 high, 0 medium.
+
+## Focus
+
+- Alert-suppression risk is the core security question: this change makes a
+  monitoring system deliberately stop delivering some alerts. Enumerate what an
+  operator loses. Can any condition that previously reached the operator's inbox
+  now reach nobody at all (journald retention, no log shipper, no other sink)?
+- Is the default mute set defensible, or does it hide a genuine
+  availability/security signal? Specifically: `pool has 0 ready providers` is
+  CRITICAL and now journal-only — argue whether a sustained (not churn) pool
+  outage is still detectable, and by what.
+- Config-injection and trust: `EMAIL_MUTED_KINDS` is read from
+  `/etc/macprovider/monitor.env` (root:macprovider 0640). Can a value in that
+  file cause anything worse than mis-routing — unbounded memory, log injection
+  via unsanitized echo of the raw value into journald, format-string issues,
+  or control characters written to a terminal reading the journal?
+- Does the unknown-kind WARN echo attacker-influenced text into journald
+  unescaped? Note `{name!r}` and assess whether that is sufficient.
+- Does the change weaken the "SMTP failed -> do not seal state" guarantee that
+  exists to prevent silent alert loss? Trace every path through the
+  `alerting` / `delivery` gate in the new code.
+- Any secret-handling regression: does the new code path log, email, or
+  otherwise expose `GMAIL_APP_PASSWORD`, `ALERT_EMAIL`, or `OPERATOR_KEY`?
+- Does the shared `monitor.env` contract with
+  `ops/pearl-updater/macprovider-pearl-updater-alert` (strict owner/mode
+  validation, `REQUIRED_KEYS`) still hold with an extra key present?
+- Denial-of-notification: could a flapping provider now mask a concurrent
+  real `service` alert (e.g. via state sealing or subject-line selection)?
+
+## Output format
+
+Start with exactly one summary line:
+
+`VERDICT: READY | COUNTS: C=0 H=0 M=0 L=<n>`
+
+or:
+
+`VERDICT: NEEDS REVISION | COUNTS: C=<n> H=<n> M=<n> L=<n>`
+
+Then list ID-prefixed findings, ordered by severity: `SEC-C-1`, `SEC-H-1`,
+`SEC-M-1`, `SEC-L-1`. Each finding must cite concrete repo evidence
+(file:line). Do not include Critical/High/Medium findings unless they should
+block the merge. The stop bar is 0 C/H/M.

--- a/phase4-coordinator/dist/monitor/README.md
+++ b/phase4-coordinator/dist/monitor/README.md
@@ -37,10 +37,40 @@ to smtp.gmail.com is open on Pearl. Until the password is filled in, the monitor
 runs journal-only.
 
 ## What it alerts on (transition-based)
-- pool `ready == 0` (idle / no buyer capacity) — CRITICAL
-- SPEC-023 autotune feeds (`/v1/autotune-candidates`, `.sig`, `/v1/demand-rank`, `.sig`) unreachable from Pearl — CRITICAL
-- a provider → `unavailable` (breaker re-trip / `warmup_failed` / removed) — WARN
-- a provider → `degraded` (breaker trip / warm-up hold) — WARN
-- a provider dropped from the pool — WARN
-- coordinator `/healthz` or gateway `/v1/status` unreachable — CRITICAL
-- recoveries — INFO
+
+Each alert carries a **kind**, which decides whether it is emailed. Journald
+receives all of them either way.
+
+| Kind | Alerts | Emailed by default |
+| --- | --- | --- |
+| `pool` | pool `ready == 0` (CRITICAL) / pool recovered (INFO) | no |
+| `provider` | provider → `unavailable` / → `degraded` / dropped from pool (WARN), recovered (INFO) | no |
+| `gateway_status` | gateway self-reports `idle` / `degraded` / `down` (WARN) | no |
+| `service` | coordinator `/healthz` or gateway `/v1/status` unreachable (CRITICAL), `/poolz` read failed (WARN), recovery (INFO) | **yes** |
+| `static_feed` | SPEC-023 autotune feeds (`/v1/autotune-candidates`, `.sig`, `/v1/demand-rank`, `.sig`) unreachable from Pearl (CRITICAL), recovery (INFO) | **yes** |
+
+## Email volume control (`EMAIL_MUTED_KINDS`)
+
+On a small fleet a single Mac going in and out of the pool produces
+`provider` + `pool` + `gateway_status` transitions every few minutes — 237
+emails in one week on Pearl, none of them operator-actionable. Those three
+kinds are therefore **journal-only by default**; the kinds that mean the
+Pearl-side services themselves are down still page.
+
+Override in `/etc/macprovider/monitor.env`:
+
+```
+EMAIL_MUTED_KINDS=provider,pool,gateway_status   # the default
+EMAIL_MUTED_KINDS=all                            # email off entirely
+EMAIL_MUTED_KINDS=none                           # email everything (pre-mute behaviour)
+```
+
+Unknown kind names are logged and ignored rather than silently changing
+routing. Muting affects **delivery only** — muted alerts still count as
+alerting transitions for the state machine, and
+
+```sh
+journalctl -u macprovider-monitor -S -24h | grep -E '\[(CRITICAL|WARN)\]'
+```
+
+remains the complete record.

--- a/phase4-coordinator/dist/monitor/macprovider-monitor.py
+++ b/phase4-coordinator/dist/monitor/macprovider-monitor.py
@@ -13,10 +13,21 @@ Alerts go to stdout (captured by journald) ALWAYS, and to email if
 /etc/macprovider/monitor.env provides Gmail submission creds. Run on a
 systemd timer (see macprovider-monitor.timer), e.g. every 3 minutes.
 
+Every alert carries a KIND (see ALERT_KINDS). Kinds listed in
+EMAIL_MUTED_KINDS stay journal-only instead of being emailed: on a small
+fleet, single-provider churn (drop / breaker / pool-idle) transitions
+dominate the mail volume without carrying operator-actionable signal,
+while the rare service-down kinds do. Muting is a mail-routing decision
+only — journald still records every alert, and the state machine still
+treats muted alerts as alerting transitions.
+
 Config (/etc/macprovider/monitor.env, optional, KEY=VALUE lines):
   ALERT_EMAIL=augstar@gmail.com
   GMAIL_USER=augstar@gmail.com
   GMAIL_APP_PASSWORD=xxxxxxxxxxxxxxxx   # 16-char Google app password (2FA)
+  EMAIL_MUTED_KINDS=provider,pool,gateway_status   # optional; this is the
+      # default. "all" mutes every kind (journal-only); "none" (or an empty
+      # value) emails every kind, the pre-mute behaviour.
 """
 
 import json
@@ -44,6 +55,25 @@ STATIC_FEEDS = (
 TIMEOUT = 8
 HOST = socket.gethostname()
 
+# Alert kinds. Every alert is tagged with exactly one of these so email
+# routing can be decided per class instead of per severity (a single-mac
+# fleet makes "pool has 0 ready providers" CRITICAL-but-routine).
+KIND_PROVIDER = "provider"            # per-provider state transitions / drops
+KIND_POOL = "pool"                    # pool ready-count emptied / recovered
+KIND_GATEWAY_STATUS = "gateway_status"  # gateway self-reported idle/degraded/down
+KIND_SERVICE = "service"              # coordinator/gateway endpoint unreachable
+KIND_STATIC_FEED = "static_feed"      # SPEC-023 signed static feeds
+ALERT_KINDS = (
+    KIND_PROVIDER,
+    KIND_POOL,
+    KIND_GATEWAY_STATUS,
+    KIND_SERVICE,
+    KIND_STATIC_FEED,
+)
+# Provider churn on a small fleet is journal-only by default; the kinds that
+# mean "the Pearl-side services themselves are down" still page by email.
+DEFAULT_EMAIL_MUTED_KINDS = (KIND_PROVIDER, KIND_POOL, KIND_GATEWAY_STATUS)
+
 
 def load_env(path):
     env = {}
@@ -58,6 +88,36 @@ def load_env(path):
     except FileNotFoundError:
         pass
     return env
+
+
+def muted_kinds(env):
+    """Resolve the set of alert kinds that must NOT be emailed.
+
+    Absent key -> DEFAULT_EMAIL_MUTED_KINDS. "all" -> every kind (email off
+    entirely). "none" or an empty value -> nothing muted (pre-mute
+    behaviour). Unknown names are reported to journald and ignored, so a
+    typo cannot silently unmute a page or mute one.
+    """
+    raw = env.get("EMAIL_MUTED_KINDS")
+    if raw is None:
+        return set(DEFAULT_EMAIL_MUTED_KINDS)
+    names = [n.strip().lower() for n in raw.split(",")]
+    names = [n for n in names if n]
+    if not names or names == ["none"]:
+        return set()
+    if "all" in names:
+        return set(ALERT_KINDS)
+    muted = set()
+    for name in names:
+        if name in ALERT_KINDS:
+            muted.add(name)
+        else:
+            print(
+                f"[WARN] ignoring unknown EMAIL_MUTED_KINDS entry {name!r} "
+                f"(known kinds: {', '.join(ALERT_KINDS)})",
+                flush=True,
+            )
+    return muted
 
 
 def operator_key():
@@ -106,7 +166,7 @@ def save_state(state):
 
 def main():
     env = load_env(ENV_FILE)
-    alerts = []  # (severity, message)
+    alerts = []  # (severity, kind, message)
 
     # --- coordinator health + pool ---
     coord_up = True
@@ -116,7 +176,7 @@ def main():
         ready = h.get("pool_ready", 0)
     except Exception as e:  # noqa: BLE001
         coord_up = False
-        alerts.append(("CRITICAL", f"coordinator /healthz unreachable: {e}"))
+        alerts.append(("CRITICAL", KIND_SERVICE, f"coordinator /healthz unreachable: {e}"))
         ready = None
 
     if coord_up:
@@ -126,7 +186,7 @@ def main():
                 pool[p["provider_id"]] = p.get("state", "?")
             ready = pz.get("summary", {}).get("ready", ready)
         except Exception as e:  # noqa: BLE001
-            alerts.append(("WARN", f"/poolz read failed: {e}"))
+            alerts.append(("WARN", KIND_SERVICE, f"/poolz read failed: {e}"))
 
     # --- gateway status ---
     gw_up = True
@@ -136,7 +196,7 @@ def main():
         gw_status = s.get("status")
     except Exception as e:  # noqa: BLE001
         gw_up = False
-        alerts.append(("CRITICAL", f"gateway /v1/status unreachable: {e}"))
+        alerts.append(("CRITICAL", KIND_SERVICE, f"gateway /v1/status unreachable: {e}"))
 
     # --- SPEC-023 signed static feeds (public nginx surface) ---
     static_ok = True
@@ -158,9 +218,9 @@ def main():
 
     # pool emptied (idle)
     if coord_up and ready == 0 and prev_ready != 0:
-        alerts.append(("CRITICAL", "pool has 0 ready providers (idle) — no buyer capacity"))
+        alerts.append(("CRITICAL", KIND_POOL, "pool has 0 ready providers (idle) — no buyer capacity"))
     elif coord_up and ready and prev_ready == 0:
-        alerts.append(("INFO", f"pool recovered: {ready} ready provider(s)"))
+        alerts.append(("INFO", KIND_POOL, f"pool recovered: {ready} ready provider(s)"))
 
     # per-provider state transitions (breaker / warm-up-gate / disconnect)
     for pid, st in pool.items():
@@ -168,33 +228,43 @@ def main():
         if was == st:
             continue
         if st == "unavailable":
-            alerts.append(("WARN", f"provider {pid} -> unavailable (breaker re-trip / warmup_failed / removed)"))
+            alerts.append(("WARN", KIND_PROVIDER, f"provider {pid} -> unavailable (breaker re-trip / warmup_failed / removed)"))
         elif st == "degraded":
-            alerts.append(("WARN", f"provider {pid} -> degraded (breaker trip / warm-up hold / recovery)"))
+            alerts.append(("WARN", KIND_PROVIDER, f"provider {pid} -> degraded (breaker trip / warm-up hold / recovery)"))
         elif st == "ready" and was in ("degraded", "unavailable"):
-            alerts.append(("INFO", f"provider {pid} recovered -> ready"))
+            alerts.append(("INFO", KIND_PROVIDER, f"provider {pid} recovered -> ready"))
     for pid, was in prev_pool.items():
         if pid not in pool and was != "unavailable":
-            alerts.append(("WARN", f"provider {pid} dropped from pool (was {was})"))
+            alerts.append(("WARN", KIND_PROVIDER, f"provider {pid} dropped from pool (was {was})"))
 
     # service up/down transitions
     if not coord_up and prev_coord_up:
         pass  # already alerted above
     elif coord_up and not prev_coord_up:
-        alerts.append(("INFO", "coordinator recovered"))
+        alerts.append(("INFO", KIND_SERVICE, "coordinator recovered"))
     if gw_up and gw_status != prev_gw_status and gw_status in ("idle", "degraded", "down"):
-        alerts.append(("WARN", f"gateway status -> {gw_status}"))
+        alerts.append(("WARN", KIND_GATEWAY_STATUS, f"gateway status -> {gw_status}"))
     if not static_ok and prev_static_ok:
-        alerts.append(("CRITICAL", "SPEC-023 static feeds unreachable: " + "; ".join(static_failures)))
+        alerts.append(("CRITICAL", KIND_STATIC_FEED, "SPEC-023 static feeds unreachable: " + "; ".join(static_failures)))
     elif static_ok and not prev_static_ok:
-        alerts.append(("INFO", "SPEC-023 static feeds recovered"))
+        alerts.append(("INFO", KIND_STATIC_FEED, "SPEC-023 static feeds recovered"))
 
     # --- emit alerts ---
-    for sev, msg in alerts:
-        print(f"[{sev}] {msg}", flush=True)
+    # journald gets every alert regardless of email routing.
+    for sev, kind, msg in alerts:
+        print(f"[{sev}] ({kind}) {msg}", flush=True)
+    muted = muted_kinds(env)
+    emailable = [a for a in alerts if a[1] not in muted]
+    suppressed = len(alerts) - len(emailable)
+    if suppressed:
+        print(
+            f"[INFO] {suppressed} alert(s) journal-only "
+            f"(EMAIL_MUTED_KINDS: {','.join(sorted(muted))})",
+            flush=True,
+        )
     delivery = None
-    if alerts:
-        delivery = send_email(env, alerts)
+    if emailable:
+        delivery = send_email(env, emailable)
 
     # Persist only when EITHER (a) the new state is non-alerting (transitions
     # to healthy save unconditionally), OR (b) at least one non-journald
@@ -210,7 +280,9 @@ def main():
         "gw_status": gw_status,
         "static_ok": static_ok,
     }
-    alerting = any(sev in ("CRITICAL", "WARN") for sev, _ in alerts)
+    # Muted alerts still count as alerting transitions: muting changes where
+    # an alert is delivered, not whether the condition happened.
+    alerting = any(sev in ("CRITICAL", "WARN") for sev, _, _ in alerts)
     # `delivery is not False` keeps the strong "SMTP failed -> don't seal"
     # guarantee while letting journal-only mode (delivery is None) advance
     # state normally. Without an external delivery path journald IS the
@@ -226,7 +298,7 @@ def main():
 
 
 def send_email(env, alerts):
-    """Attempt to deliver alerts.
+    """Attempt to deliver the non-muted alerts.
 
     Returns True on successful delivery, False if delivery was attempted
     and failed, and None if no non-journald recipient is configured (the
@@ -238,12 +310,15 @@ def send_email(env, alerts):
     if not (user and pw and to):
         print("[INFO] email not configured (set GMAIL_* in /etc/macprovider/monitor.env) — journal-only", flush=True)
         return None
-    worst = "CRITICAL" if any(s == "CRITICAL" for s, _ in alerts) else "WARN"
-    body = "\n".join(f"[{s}] {m}" for s, m in alerts)
+    # Muting makes INFO-only mail (e.g. a lone "coordinator recovered")
+    # common, so the subject must be able to say INFO instead of WARN.
+    severities = {s for s, _, _ in alerts}
+    worst = next(s for s in ("CRITICAL", "WARN", "INFO") if s in severities)
+    body = "\n".join(f"[{s}] ({k}) {m}" for s, k, m in alerts)
     msg = EmailMessage()
     msg["From"] = user
     msg["To"] = to
-    msg["Subject"] = f"[macprovider {worst}] {HOST}: {alerts[0][1][:60]}"
+    msg["Subject"] = f"[macprovider {worst}] {HOST}: {alerts[0][2][:60]}"
     msg.set_content(f"macprovider monitor on {HOST}\n\n{body}\n")
     try:
         with smtplib.SMTP("smtp.gmail.com", 587, timeout=TIMEOUT) as smtp:

--- a/phase4-coordinator/dist/test/check_monitor_email_mute_test.sh
+++ b/phase4-coordinator/dist/test/check_monitor_email_mute_test.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+# Contract test for the monitor's per-kind email routing.
+#
+# Provider churn on a small fleet must stay journal-only by default while
+# service-down alerts still page, every alert site must carry a known kind,
+# and journald must keep receiving everything regardless of routing.
+set -euo pipefail
+
+DIST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+MONITOR="$DIST_DIR/monitor/macprovider-monitor.py"
+
+python3 - "$MONITOR" <<'PY'
+import runpy
+import sys
+
+m = runpy.run_path(sys.argv[1], run_name="monitor_email_mute_test")
+muted_kinds = m["muted_kinds"]
+send_email = m["send_email"]
+KINDS = m["ALERT_KINDS"]
+
+# --- default: provider churn muted, service/static-feed still emailed ---
+default = muted_kinds({})
+assert default == {"provider", "pool", "gateway_status"}, default
+assert "service" not in default
+assert "static_feed" not in default
+
+# --- explicit overrides ---
+assert muted_kinds({"EMAIL_MUTED_KINDS": "all"}) == set(KINDS)
+assert muted_kinds({"EMAIL_MUTED_KINDS": "none"}) == set()
+assert muted_kinds({"EMAIL_MUTED_KINDS": ""}) == set()
+assert muted_kinds({"EMAIL_MUTED_KINDS": " Provider , POOL "}) == {"provider", "pool"}
+# An unknown name is ignored, and must not drag the known ones down with it.
+assert muted_kinds({"EMAIL_MUTED_KINDS": "provider,typo"}) == {"provider"}
+
+# --- unconfigured email stays journal-only (returns None, not False) ---
+assert send_email({}, [("CRITICAL", "service", "down")]) is None
+
+# --- every alert kind referenced in the source is a declared kind ---
+src = open(sys.argv[1]).read()
+import re
+used = set(re.findall(r'alerts\.append\(\("[A-Z]+", (KIND_[A-Z_]+),', src))
+declared = {f"KIND_{k.upper()}" for k in KINDS}
+assert used, "no tagged alert sites found — did the alert tuples change shape?"
+assert used <= declared, used - declared
+# Untagged 2-tuple alert sites would silently bypass routing.
+assert not re.search(r'alerts\.append\(\("[A-Z]+", f?"', src), "untagged alert site"
+
+print("PASS: monitor email routing mutes provider churn and pages on service loss")
+PY
+
+# --- end-to-end: a provider drop must not reach SMTP, a coordinator outage must ---
+STATE_DIR="$(mktemp -d)"
+trap 'rm -rf "$STATE_DIR"' EXIT
+STATE_DIRECTORY="$STATE_DIR" python3 - "$MONITOR" <<'PY'
+import runpy
+import sys
+
+path = sys.argv[1]
+
+
+def run(pool_state, env, coord_up=True):
+    """Run main() once against a stubbed coordinator; return emailed alerts."""
+    m = runpy.run_path(path, run_name="monitor_email_mute_e2e")
+    sent = []
+
+    def fake_get_json(url, bearer=None):
+        if not coord_up:
+            raise OSError("connection refused")
+        if url.endswith("/healthz"):
+            return {"pool_ready": len(pool_state)}
+        if url.endswith("/poolz"):
+            return {
+                "pool": [{"provider_id": p, "state": s} for p, s in pool_state.items()],
+                "summary": {"ready": sum(1 for s in pool_state.values() if s == "ready")},
+            }
+        return {"status": "ready" if pool_state else "idle"}
+
+    m["get_json"] = fake_get_json
+    m["probe_static_feed"] = lambda url: b"ok"
+    m["load_env"] = lambda path: env
+    m["send_email"] = lambda env, alerts: sent.extend(alerts) or True
+    # Rebind the module globals main() actually resolves against.
+    main = m["main"]
+    main.__globals__.update(m)
+    main()
+    return sent
+
+
+# Seed: one ready provider, nothing to alert on yet.
+run({"mp-a": "ready"}, {})
+
+# The provider drops out of the pool entirely -> churn + pool-idle, no email.
+sent = run({}, {})
+assert sent == [], f"provider churn must not be emailed by default: {sent}"
+
+# Same transition with muting turned off -> it does email (opt-out works).
+run({"mp-a": "ready"}, {"EMAIL_MUTED_KINDS": "none"})
+sent = run({}, {"EMAIL_MUTED_KINDS": "none"})
+assert [k for _, k, _ in sent] and "provider" in [k for _, k, _ in sent], sent
+
+# Coordinator itself unreachable -> still pages.
+sent = run({}, {}, coord_up=False)
+assert sent, "coordinator outage must still email"
+assert {k for _, k, _ in sent} == {"service"}, sent
+assert all(sev == "CRITICAL" for sev, _, _ in sent), sent
+
+print("PASS: end-to-end — provider drop is journal-only, coordinator outage still emails")
+PY


### PR DESCRIPTION
## Problem

The Pearl-side `macprovider-monitor` timer emailed **237 alerts in 7 days**.
A 3-day journald tally shows what they were:

| count | alert |
| --- | --- |
| 34 | `[WARN] gateway status -> idle` |
| 34 | `[CRITICAL] pool has 0 ready providers (idle)` |
| 25 + 18 | `[WARN] provider … dropped from pool (was ready)` |
| 10 + 6 | `[WARN] provider … -> unavailable` |
| 3 | genuine service-down (coordinator `/healthz`, gateway `/v1/status`, SPEC-023 static feeds 502) |

On a single-Mac fleet one provider oscillating produces the whole top block
every few minutes, and each transition is CRITICAL/WARN by severity even
though none of it is operator-actionable. The 3 alerts that *are* actionable
were buried under ~98% noise.

## Change

Every alert now carries a **kind**, and email is routed per kind rather than
per severity:

| kind | emailed by default |
| --- | --- |
| `provider`, `pool`, `gateway_status` | no — journal-only |
| `service`, `static_feed` | **yes** |

`EMAIL_MUTED_KINDS` in `/etc/macprovider/monitor.env` overrides the default:
an explicit list, `all` (email off entirely), or `none` (pre-mute behaviour).
Unknown names are logged and ignored so a typo cannot silently suppress a page.

Muting is a **delivery** decision only:

- journald still receives every alert, now prefixed `[SEV] (kind) message`
- muted alerts still count as alerting transitions for the state machine
- the "SMTP failed → do not seal state" guarantee is unchanged for the alerts
  that are still emailed

`ops/pearl-updater/macprovider-pearl-updater-alert`, which shares
`monitor.env`, is unaffected — this adds a key rather than removing one, so
its `REQUIRED_KEYS` check still passes and updater-failure mail still sends.

## Tests

New `phase4-coordinator/dist/test/check_monitor_email_mute_test.sh`:

- unit: `muted_kinds()` across absent/empty/`none`/`all`/whitespace/case/unknown
- unit: unconfigured email returns `None` (journal-only), not `False`
- source contract: every `alerts.append` site is tagged with a declared kind,
  and an untagged 2-tuple site fails the test
- end-to-end against a stubbed coordinator: a provider drop reaches journald
  but never SMTP; the same transition with `EMAIL_MUTED_KINDS=none` does
  email; a coordinator outage still emails CRITICAL

Existing `check_monitor_sandbox_test.sh` still passes.

## Audit

Three codex lanes against the full diff (prompts in `audits/2026-07-25/`):

- CODE — `READY | C=0 H=0 M=0 L=2`
- ARCHITECT — `READY | C=0 H=0 M=0 L=3`
- SECURITY — `NEEDS REVISION | C=0 H=0 M=1 L=0`

**SEC-M-1 carried, accepted, not fixed.** Muting `pool` means a *sustained*
pool-zero outage (not just flapping) is now journal-only as well, and journald
is the only sink on Pearl. That is the explicit intent of the request — these
alerts had stopped carrying signal. Restore paging for it at any time with
`EMAIL_MUTED_KINDS=provider,gateway_status` in `monitor.env`, no redeploy.

LOWs carried (no email-routing impact): CODE-L-1 — a mixed muted+emailable
round whose SMTP send fails re-prints the muted lines to journald next poll,
because state sealing is all-or-nothing; the service-alert retry guarantee is
what that protects. CODE-L-2 — the untagged-alert-site check is a source
regex, so a future alert assembled indirectly could evade it. ARCH LOWs are
about kind taxonomy and where the default policy should live.

## Governance declaration

`phase4-coordinator/dist/monitor/**` is a non-governance path, so
`behavior_change: "none"` is rejected — but no domain in `specs/AUTHORITY.json`
governs the Pearl-side monitor script (`provider-connection-diagnostics` /
SPEC-035 covers the coordinator's own diagnostics journal and `/admin/providers*`
endpoints, not this alert-mail router). Rather than fabricate a spec link, the
declaration below is filed honestly with empty spec arrays and
`spec-index / check` is expected to go red. That job is advisory; only
`ci-required` + 1 approval gate merge.

SPEC-GOVERNANCE-DECLARATION-BEGIN
{
  "schema_version": "spec-pr-governance-v1",
  "behavior_change": "yes",
  "contract_change": "none",
  "specs": [],
  "requirements": [],
  "authority_domains": [],
  "arbitration": [],
  "tests": ["phase4-coordinator/dist/test/check_monitor_email_mute_test.sh"],
  "journeys": ["not-required"],
  "issue": ""
}
SPEC-GOVERNANCE-DECLARATION-END
