### PR TITLE
fix(autotune): disqualify swap from paid recommendations (#742)

### DIFF
--- a/audits/2026-07-25/AUDIT_742_FINAL_TALLY.md
+++ b/audits/2026-07-25/AUDIT_742_FINAL_TALLY.md
@@ -1,0 +1,30 @@
+# #742 final audit tally
+
+Full-fix audits of `origin/main...HEAD` for the complete #742 change.
+
+| Round | Lane | Verdict | C | H | M | L | I |
+|-------|------|---------|---|---|---|---|---|
+| R1 | code | FAIL | 0 | 1 | 0 | 0 | 0 |
+| R1 | security | PASS | 0 | 0 | 0 | 1 | 0 |
+| R1 | architect | FAIL | 0 | 0 | 2 | 1 | 0 |
+| R2 | code | PASS | 0 | 0 | 0 | 0 | 0 |
+| R2 | security | PASS | 0 | 0 | 0 | 0 | 0 |
+| R2 | architect | FAIL | 0 | 0 | 1 | 0 | 0 |
+| R3 | architect | PASS | 0 | 0 | 0 | 0 | 0 |
+
+**Final: 0 CRITICAL / 0 HIGH / 0 MEDIUM across all three lanes.**
+
+## R1 → fixes
+
+1. CODE HIGH: accept `--gate-ttft-ms 0` as disabled; reject only negatives.
+2. ARCH MEDIUM: path-dependent default — classic Stage1/2 omit → 60s (SPEC-013); paid `--recommend` omit → disabled (AC-3).
+3. ARCH MEDIUM / SEC LOW: SPEC-023 §8 donor no longer lists no-swap as non-bypassable.
+4. ARCH LOW: §5/AC-12 warn wording narrowed to no-paid fallthrough.
+
+## R2 → fixes
+
+1. ARCH MEDIUM: §7.2 + AC-21 allow conditional swap diagnostic in donor transcript.
+
+## Carried LOW/INFO
+
+None remaining after R3.

--- a/audits/2026-07-25/AUDIT_742_R1_ARCHITECT.log
+++ b/audits/2026-07-25/AUDIT_742_R1_ARCHITECT.log
@@ -1,0 +1,1 @@
+/Users/augstar/macprovider-742-swap-gate/.omc/artifacts/ask/codex-audit-742-swap-paid-hard-veto-remove-60s-ttft-default-archit-2026-07-25T16-36-18-655Z.md

--- a/audits/2026-07-25/AUDIT_742_R1_CODE.log
+++ b/audits/2026-07-25/AUDIT_742_R1_CODE.log
@@ -1,0 +1,1 @@
+/Users/augstar/macprovider-742-swap-gate/.omc/artifacts/ask/codex-audit-742-swap-paid-hard-veto-remove-60s-ttft-default-code-l-2026-07-25T16-38-40-360Z.md

--- a/audits/2026-07-25/AUDIT_742_R1_SECURITY.log
+++ b/audits/2026-07-25/AUDIT_742_R1_SECURITY.log
@@ -1,0 +1,1 @@
+/Users/augstar/macprovider-742-swap-gate/.omc/artifacts/ask/codex-audit-742-swap-paid-hard-veto-remove-60s-ttft-default-securi-2026-07-25T16-36-37-384Z.md

--- a/audits/2026-07-25/AUDIT_742_R1_TALLY.md
+++ b/audits/2026-07-25/AUDIT_742_R1_TALLY.md
@@ -1,0 +1,19 @@
+# #742 R1 audit tally (full-fix diff)
+
+| Lane | Verdict | C | H | M | L | I |
+|------|---------|---|---|---|---|---|
+| code | FAIL | 0 | 1 | 0 | 0 | 0 |
+| security | PASS | 0 | 0 | 0 | 1 | 0 |
+| architect | FAIL | 0 | 0 | 2 | 1 | 0 |
+
+## R1 findings addressed in R2
+
+1. **CODE HIGH** — accept `--gate-ttft-ms 0` as disabled; reject only negatives.
+2. **ARCH MEDIUM** — path-dependent default: classic Stage1/2 keeps SPEC-013 60s when omitted; paid `--recommend` defaults to disabled (0).
+3. **ARCH MEDIUM / SEC LOW** — SPEC-023 §8 donor text no longer lists no-swap as non-bypassable; swap advisory for donor.
+4. **ARCH LOW** — §5/AC-12 wording narrowed: emit `swap_observed_under_load` when swap causes no paid row.
+
+Artifacts:
+- `.omc/artifacts/ask/codex-audit-742-*-code-*.md`
+- `.omc/artifacts/ask/codex-audit-742-*-securi-*.md`
+- `.omc/artifacts/ask/codex-audit-742-*-archit-*.md`

--- a/audits/2026-07-25/AUDIT_742_R2_ARCHITECT.log
+++ b/audits/2026-07-25/AUDIT_742_R2_ARCHITECT.log
@@ -1,0 +1,1 @@
+/Users/augstar/macprovider-742-swap-gate/.omc/artifacts/ask/codex-audit-742-r2-re-audit-after-r1-fixes-architect-lane-you-are--2026-07-25T16-43-10-169Z.md

--- a/audits/2026-07-25/AUDIT_742_R2_CODE.log
+++ b/audits/2026-07-25/AUDIT_742_R2_CODE.log
@@ -1,0 +1,1 @@
+/Users/augstar/macprovider-742-swap-gate/.omc/artifacts/ask/codex-audit-742-r2-re-audit-after-r1-fixes-code-lane-you-are-the-c-2026-07-25T16-42-20-873Z.md

--- a/audits/2026-07-25/AUDIT_742_R2_SECURITY.log
+++ b/audits/2026-07-25/AUDIT_742_R2_SECURITY.log
@@ -1,0 +1,1 @@
+/Users/augstar/macprovider-742-swap-gate/.omc/artifacts/ask/codex-audit-742-r2-re-audit-after-r1-fixes-security-lane-you-are-t-2026-07-25T16-43-03-396Z.md

--- a/audits/2026-07-25/AUDIT_742_R3_ARCHITECT.log
+++ b/audits/2026-07-25/AUDIT_742_R3_ARCHITECT.log
@@ -1,0 +1,1 @@
+/Users/augstar/macprovider-742-swap-gate/.omc/artifacts/ask/codex-audit-742-r3-architect-re-check-residual-7-2-only-you-are-th-2026-07-25T16-45-34-015Z.md

--- a/audits/2026-07-25/AUDIT_742_SWAP_GATE_ARCHITECT_PROMPT.md
+++ b/audits/2026-07-25/AUDIT_742_SWAP_GATE_ARCHITECT_PROMPT.md
@@ -1,0 +1,50 @@
+# AUDIT — #742 swap paid hard-veto + remove 60s TTFT default — architect lane
+
+You are the ARCHITECT audit lane reviewing the complete fix for GitHub issue
+#742 as it will land (full diff vs the merge base).
+
+Repo root: the current working directory (a macprovider worktree on branch
+`fix/742-disqualify-swap`).
+
+## Scope (full fix)
+
+```bash
+git diff origin/main...HEAD -- \
+  phase3-binary/Sources/macprovider-cli/AutotuneCommand.swift \
+  phase3-binary/Sources/macprovider-cli/AutotuneRecommend.swift \
+  phase3-binary/Sources/macprovider-cli/Stage1Iterator.swift \
+  phase3-binary/Sources/macprovider-cli/Stage2HillClimb.swift \
+  phase3-binary/Tests/macprovider-cliTests/AutotuneCommandTests.swift \
+  phase3-binary/Tests/macprovider-cliTests/AutotuneRecommendTests.swift \
+  specs/SPEC-023-installer-autotune-recommend.md \
+  specs/README.md
+```
+
+Also read issue #742 and related issues #743/#744/#745 only for boundary
+clarity — this PR must not implement those.
+
+## Architectural constraints
+
+1. Minimum change that stops the live incident (swapping model selected).
+2. Do not enforce unmeasured catalog `bench_gate` thresholds.
+3. Do not change SPEC-023 §4 scoring (that's #744).
+4. Preserve donor mode as escape hatch when no non-swapping paid row exists.
+5. Absolute TTFT ceiling selection is deferred to #744; this PR only removes
+   the indefensible 60s default.
+
+## Lane focus
+
+- Is the paid vs donor boundary clean and future-compatible with #744/#745?
+- Does treating `gateTTFTMS == 0` as "disabled" conflict with SPEC-013
+  classic-autotune semantics in a way that must be called out?
+- Any layering violation (scoring vs eligibility vs probe feasibility)?
+- Spec amendment scope: is v0.7 the right size, or did we under/over-specify?
+- Sequencing: does anything here bake in bad catalog measurements (#745)?
+
+Report findings as a numbered list; each finding must state severity
+(CRITICAL / HIGH / MEDIUM / LOW / INFO), file:line when possible, the defect,
+and a concrete fix. End with exactly one summary line:
+
+`VERDICT: PASS|FAIL — X CRITICAL / Y HIGH / Z MEDIUM / W LOW / V INFO`
+
+PASS only if 0 CRITICAL, 0 HIGH, 0 MEDIUM.

--- a/audits/2026-07-25/AUDIT_742_SWAP_GATE_CODE_PROMPT.md
+++ b/audits/2026-07-25/AUDIT_742_SWAP_GATE_CODE_PROMPT.md
@@ -1,0 +1,55 @@
+# AUDIT — #742 swap paid hard-veto + remove 60s TTFT default — code lane
+
+You are the CODE audit lane reviewing the complete fix for GitHub issue #742
+as it will land (full diff vs the merge base, not an incremental slice).
+
+Repo root: the current working directory (a macprovider worktree on branch
+`fix/742-disqualify-swap`).
+
+## Scope (full fix)
+
+```bash
+git diff origin/main...HEAD -- \
+  phase3-binary/Sources/macprovider-cli/AutotuneCommand.swift \
+  phase3-binary/Sources/macprovider-cli/AutotuneRecommend.swift \
+  phase3-binary/Sources/macprovider-cli/Stage1Iterator.swift \
+  phase3-binary/Sources/macprovider-cli/Stage2HillClimb.swift \
+  phase3-binary/Tests/macprovider-cliTests/AutotuneCommandTests.swift \
+  phase3-binary/Tests/macprovider-cliTests/AutotuneRecommendTests.swift \
+  specs/SPEC-023-installer-autotune-recommend.md \
+  specs/README.md
+```
+
+Also read issue #742 and SPEC-023 v0.7 change log + §5 + AC-12/AC-22.
+
+## Intended behavior (do not expand)
+
+1. `swap_detected == true` hard-blocks **paid** recommendation (`isEligible`).
+2. Donor mode still admits swap (advisory) when other donor gates pass.
+3. No default `gateTTFTMS = 60_000`; omitting `--gate-ttft-ms` disables the
+   Stage 1/2 TTFT feasibility ceiling (`0` means disabled).
+4. Do **not** hard-enforce catalog `bench_gate` TPS/TTFT — still advisory.
+5. SPEC-023 §4 scoring is untouched; only §5 eligibility gains the swap gate.
+
+## Acceptance criteria to verify
+
+- AC-1: swapping candidate never becomes `recommended_model`
+- AC-2/AC-5: 2026-07-23 M5/32GB fixture never yields `qwen3-coder-30b-a3b-instruct`
+- AC-3: no 60s TTFT default reachable on paid path
+- AC-4: all-swapping paid rows → donor with transcript/why naming swap
+
+## Lane focus
+
+- Correctness of eligibility / donor separation
+- Warning attachment not reintroducing false positives for clean paid picks
+- Stage1/Stage2 `gateTTFTMS == 0` skip path
+- Test coverage adequacy and fixture fidelity
+- Spec/code consistency for v0.7
+
+Report findings as a numbered list; each finding must state severity
+(CRITICAL / HIGH / MEDIUM / LOW / INFO), file:line when possible, the defect,
+and a concrete fix. End with exactly one summary line:
+
+`VERDICT: PASS|FAIL — X CRITICAL / Y HIGH / Z MEDIUM / W LOW / V INFO`
+
+PASS only if 0 CRITICAL, 0 HIGH, 0 MEDIUM.

--- a/audits/2026-07-25/AUDIT_742_SWAP_GATE_R2_ARCHITECT_PROMPT.md
+++ b/audits/2026-07-25/AUDIT_742_SWAP_GATE_R2_ARCHITECT_PROMPT.md
@@ -1,0 +1,42 @@
+# AUDIT — #742 R2 re-audit after R1 fixes — architect lane
+
+You are the ARCHITECT audit lane re-reviewing the **complete** #742 fix after R1
+remediation. Audit the full fix diff vs origin/main, not an incremental slice.
+
+Repo root: current worktree on `fix/742-disqualify-swap`.
+
+## Full-fix scope
+
+```bash
+git diff origin/main...HEAD -- \
+  phase3-binary/Sources/macprovider-cli/AutotuneCommand.swift \
+  phase3-binary/Sources/macprovider-cli/AutotuneRecommend.swift \
+  phase3-binary/Sources/macprovider-cli/Stage1Iterator.swift \
+  phase3-binary/Sources/macprovider-cli/Stage2HillClimb.swift \
+  phase3-binary/Tests/macprovider-cliTests/AutotuneCommandTests.swift \
+  phase3-binary/Tests/macprovider-cliTests/AutotuneRecommendTests.swift \
+  specs/SPEC-023-installer-autotune-recommend.md \
+  specs/README.md
+```
+
+Also read `audits/2026-07-25/AUDIT_742_R1_TALLY.md` for R1 findings claimed fixed.
+
+## Intended post-R1 behavior
+
+1. Paid: `swap_detected` hard-blocks `recommended_model`; donor keeps swap advisory.
+2. `--gate-ttft-ms` optional; explicit `0` disables; negatives rejected.
+3. Classic Stage 1/2 omitted → 60_000 (SPEC-013); paid `--recommend` omitted → 0 (disabled). AC-3.
+4. Catalog bench_gate TPS/TTFT still advisory. §4 scoring untouched.
+5. SPEC-023 §8 donor no longer requires no-swap; AC-12/§5 warn on swap when no paid row.
+
+## R1 residual risk to re-check
+
+- Path-dependent gate resolution is actually used on both paths.
+- Donor / paid boundary still clean.
+- No silent 60s default on paid path.
+- Spec internal consistency (§5, §8, AC-12, AC-22, changelog).
+
+Report findings numbered with severity CRITICAL/HIGH/MEDIUM/LOW/INFO.
+End with exactly:
+`VERDICT: PASS|FAIL — X CRITICAL / Y HIGH / Z MEDIUM / W LOW / V INFO`
+PASS only if 0 CRITICAL, 0 HIGH, 0 MEDIUM.

--- a/audits/2026-07-25/AUDIT_742_SWAP_GATE_R2_CODE_PROMPT.md
+++ b/audits/2026-07-25/AUDIT_742_SWAP_GATE_R2_CODE_PROMPT.md
@@ -1,0 +1,42 @@
+# AUDIT — #742 R2 re-audit after R1 fixes — code lane
+
+You are the CODE audit lane re-reviewing the **complete** #742 fix after R1
+remediation. Audit the full fix diff vs origin/main, not an incremental slice.
+
+Repo root: current worktree on `fix/742-disqualify-swap`.
+
+## Full-fix scope
+
+```bash
+git diff origin/main...HEAD -- \
+  phase3-binary/Sources/macprovider-cli/AutotuneCommand.swift \
+  phase3-binary/Sources/macprovider-cli/AutotuneRecommend.swift \
+  phase3-binary/Sources/macprovider-cli/Stage1Iterator.swift \
+  phase3-binary/Sources/macprovider-cli/Stage2HillClimb.swift \
+  phase3-binary/Tests/macprovider-cliTests/AutotuneCommandTests.swift \
+  phase3-binary/Tests/macprovider-cliTests/AutotuneRecommendTests.swift \
+  specs/SPEC-023-installer-autotune-recommend.md \
+  specs/README.md
+```
+
+Also read `audits/2026-07-25/AUDIT_742_R1_TALLY.md` for R1 findings claimed fixed.
+
+## Intended post-R1 behavior
+
+1. Paid: `swap_detected` hard-blocks `recommended_model`; donor keeps swap advisory.
+2. `--gate-ttft-ms` optional; explicit `0` disables; negatives rejected.
+3. Classic Stage 1/2 omitted → 60_000 (SPEC-013); paid `--recommend` omitted → 0 (disabled). AC-3.
+4. Catalog bench_gate TPS/TTFT still advisory. §4 scoring untouched.
+5. SPEC-023 §8 donor no longer requires no-swap; AC-12/§5 warn on swap when no paid row.
+
+## R1 residual risk to re-check
+
+- Path-dependent gate resolution is actually used on both paths.
+- Donor / paid boundary still clean.
+- No silent 60s default on paid path.
+- Spec internal consistency (§5, §8, AC-12, AC-22, changelog).
+
+Report findings numbered with severity CRITICAL/HIGH/MEDIUM/LOW/INFO.
+End with exactly:
+`VERDICT: PASS|FAIL — X CRITICAL / Y HIGH / Z MEDIUM / W LOW / V INFO`
+PASS only if 0 CRITICAL, 0 HIGH, 0 MEDIUM.

--- a/audits/2026-07-25/AUDIT_742_SWAP_GATE_R2_SECURITY_PROMPT.md
+++ b/audits/2026-07-25/AUDIT_742_SWAP_GATE_R2_SECURITY_PROMPT.md
@@ -1,0 +1,42 @@
+# AUDIT — #742 R2 re-audit after R1 fixes — security lane
+
+You are the SECURITY audit lane re-reviewing the **complete** #742 fix after R1
+remediation. Audit the full fix diff vs origin/main, not an incremental slice.
+
+Repo root: current worktree on `fix/742-disqualify-swap`.
+
+## Full-fix scope
+
+```bash
+git diff origin/main...HEAD -- \
+  phase3-binary/Sources/macprovider-cli/AutotuneCommand.swift \
+  phase3-binary/Sources/macprovider-cli/AutotuneRecommend.swift \
+  phase3-binary/Sources/macprovider-cli/Stage1Iterator.swift \
+  phase3-binary/Sources/macprovider-cli/Stage2HillClimb.swift \
+  phase3-binary/Tests/macprovider-cliTests/AutotuneCommandTests.swift \
+  phase3-binary/Tests/macprovider-cliTests/AutotuneRecommendTests.swift \
+  specs/SPEC-023-installer-autotune-recommend.md \
+  specs/README.md
+```
+
+Also read `audits/2026-07-25/AUDIT_742_R1_TALLY.md` for R1 findings claimed fixed.
+
+## Intended post-R1 behavior
+
+1. Paid: `swap_detected` hard-blocks `recommended_model`; donor keeps swap advisory.
+2. `--gate-ttft-ms` optional; explicit `0` disables; negatives rejected.
+3. Classic Stage 1/2 omitted → 60_000 (SPEC-013); paid `--recommend` omitted → 0 (disabled). AC-3.
+4. Catalog bench_gate TPS/TTFT still advisory. §4 scoring untouched.
+5. SPEC-023 §8 donor no longer requires no-swap; AC-12/§5 warn on swap when no paid row.
+
+## R1 residual risk to re-check
+
+- Path-dependent gate resolution is actually used on both paths.
+- Donor / paid boundary still clean.
+- No silent 60s default on paid path.
+- Spec internal consistency (§5, §8, AC-12, AC-22, changelog).
+
+Report findings numbered with severity CRITICAL/HIGH/MEDIUM/LOW/INFO.
+End with exactly:
+`VERDICT: PASS|FAIL — X CRITICAL / Y HIGH / Z MEDIUM / W LOW / V INFO`
+PASS only if 0 CRITICAL, 0 HIGH, 0 MEDIUM.

--- a/audits/2026-07-25/AUDIT_742_SWAP_GATE_R3_ARCHITECT_PROMPT.md
+++ b/audits/2026-07-25/AUDIT_742_SWAP_GATE_R3_ARCHITECT_PROMPT.md
@@ -1,0 +1,22 @@
+# AUDIT — #742 R3 architect re-check (residual §7.2 only)
+
+You are the ARCHITECT lane. R2 code and security already PASS with 0 C/H/M.
+R2 architect had 1 MEDIUM: §7.2 vs AC-12/AC-21 donor transcript contradiction.
+
+## Claimed fix
+
+SPEC-023 §7.2 and AC-21 were amended so the donor transcript MAY include the
+conditional swap diagnostic line when swap caused no paid row. Code in
+`AutotuneRecommend.swift` humanTranscript matches that contract.
+
+## Required reading
+
+- `git diff origin/main...HEAD -- specs/SPEC-023-installer-autotune-recommend.md`
+- donor transcript code in `AutotuneRecommend.swift` (`humanTranscript`)
+- `audits/2026-07-25/AUDIT_742_R1_TALLY.md`
+
+Confirm the R2 MEDIUM is closed and no new C/H/M remain on the full fix.
+
+End with exactly:
+`VERDICT: PASS|FAIL — X CRITICAL / Y HIGH / Z MEDIUM / W LOW / V INFO`
+PASS only if 0 CRITICAL, 0 HIGH, 0 MEDIUM.

--- a/audits/2026-07-25/AUDIT_742_SWAP_GATE_SECURITY_PROMPT.md
+++ b/audits/2026-07-25/AUDIT_742_SWAP_GATE_SECURITY_PROMPT.md
@@ -1,0 +1,47 @@
+# AUDIT — #742 swap paid hard-veto + remove 60s TTFT default — security lane
+
+You are the SECURITY audit lane reviewing the complete fix for GitHub issue
+#742 as it will land (full diff vs the merge base).
+
+Repo root: the current working directory (a macprovider worktree on branch
+`fix/742-disqualify-swap`).
+
+## Scope (full fix)
+
+```bash
+git diff origin/main...HEAD -- \
+  phase3-binary/Sources/macprovider-cli/AutotuneCommand.swift \
+  phase3-binary/Sources/macprovider-cli/AutotuneRecommend.swift \
+  phase3-binary/Sources/macprovider-cli/Stage1Iterator.swift \
+  phase3-binary/Sources/macprovider-cli/Stage2HillClimb.swift \
+  phase3-binary/Tests/macprovider-cliTests/AutotuneCommandTests.swift \
+  phase3-binary/Tests/macprovider-cliTests/AutotuneRecommendTests.swift \
+  specs/SPEC-023-installer-autotune-recommend.md \
+  specs/README.md
+```
+
+## Threat / abuse model for this change
+
+- Money-path-adjacent: decides which model a provider serves and earns from.
+- Locally measured swap must not be spoofable via catalog / remote feeds.
+- Donor mode must not re-open a paid network path for a swapping row.
+- Removing the 60s TTFT default must not create a path that silently prefers
+  attacker-controlled remote catalog thresholds as hard gates.
+
+## Lane focus
+
+- Can a remote catalog or demand feed force a swapping model into paid serve?
+- Does donor-mode commit still block network-connected paid registration for
+  non-recommendable / swap-only rows (SPEC-023 AC-23)?
+- Does disabling TTFT ceiling (flag omitted) create an availability or DoS
+  vector against the installer/autotune path itself?
+- Integrity of benchmark evidence identity (catalog SHA / hardware hash) still
+  required before eligibility?
+
+Report findings as a numbered list; each finding must state severity
+(CRITICAL / HIGH / MEDIUM / LOW / INFO), file:line when possible, the defect,
+and a concrete fix. End with exactly one summary line:
+
+`VERDICT: PASS|FAIL — X CRITICAL / Y HIGH / Z MEDIUM / W LOW / V INFO`
+
+PASS only if 0 CRITICAL, 0 HIGH, 0 MEDIUM.

--- a/phase3-binary/Sources/macprovider-cli/AutotuneCommand.swift
+++ b/phase3-binary/Sources/macprovider-cli/AutotuneCommand.swift
@@ -39,8 +39,13 @@ struct AutotuneCommand: AsyncParsableCommand {
     @Option(help: "Stage 2 replicates per knob cell.")
     var stage2Replicates = 3
 
-    @Option(name: .customLong("gate-ttft-ms"), help: "Maximum p95 TTFT in milliseconds for feasibility.")
-    var gateTTFTMS = 60_000
+    /// Path-dependent default (#742 / AC-3):
+    /// - classic Stage 1/2 (SPEC-013): omitted → 60_000 ms
+    /// - paid `--recommend` (SPEC-023): omitted → disabled (0); no 60s default
+    /// Explicit `0` disables the ceiling on either path. Absolute buyer-facing
+    /// TTFT bounds land with selection-quality work (#744).
+    @Option(name: .customLong("gate-ttft-ms"), help: "Maximum p95 TTFT in milliseconds for Stage 1/2 feasibility. 0 disables the ceiling. Classic autotune defaults to 60000 when omitted; --recommend has no TTFT default.")
+    var gateTTFTMS: Int?
 
     @Option(help: "Relative throughput tie band for TTFT tiebreak.")
     var tpsTieEpsilon = 0.02
@@ -238,7 +243,7 @@ struct AutotuneCommand: AsyncParsableCommand {
             candidateModelsJSON: candidatesJSON,
             stage1Replicates: stage1Replicates,
             stage2Replicates: stage2Replicates,
-            gateTTFTMS: gateTTFTMS,
+            gateTTFTMS: resolvedGateTTFTMS(forRecommend: false),
             tpsTieEpsilon: tpsTieEpsilon,
             recommendationJSON: nil,
             recipeHash: nil,
@@ -314,7 +319,7 @@ struct AutotuneCommand: AsyncParsableCommand {
                     candidates: plan.candidates,
                     candidatesBySize: Self.candidatesBySize(for: plan),
                     targetContext: targetContext,
-                    gateTTFTMS: gateTTFTMS,
+                    gateTTFTMS: resolvedGateTTFTMS(forRecommend: false),
                     stage1Replicates: stage1Replicates,
                     port: port,
                     drainGrace: drainGrace,
@@ -388,7 +393,7 @@ struct AutotuneCommand: AsyncParsableCommand {
                     maxBatchAxis: try Self.parsePositiveIntAxis(maxBatchAxis, flag: "--max-batch-axis"),
                     maxContextAxis: try Self.parseMaxContextAxis(maxContextAxis, targetContext: targetContext),
                     targetContext: targetContext,
-                    gateTTFTMS: gateTTFTMS,
+                    gateTTFTMS: resolvedGateTTFTMS(forRecommend: false),
                     stage2Replicates: stage2Replicates,
                     tpsTieEpsilon: tpsTieEpsilon,
                     port: port,
@@ -585,12 +590,21 @@ struct AutotuneCommand: AsyncParsableCommand {
             candidateModels: plan.candidates,
             stage1Replicates: stage1Replicates,
             stage2Replicates: stage2Replicates,
-            gateTTFTMS: gateTTFTMS,
+            gateTTFTMS: resolvedGateTTFTMS(forRecommend: false),
             tpsTieEpsilon: tpsTieEpsilon,
             recommendation: recommendation,
             infeasible: infeasible,
             dbPath: dbPath
         )
+    }
+
+    /// Resolve the TTFT feasibility ceiling.
+    /// - `0` means disabled (explicit or paid-path default).
+    /// - Classic Stage 1/2 keeps SPEC-013's 60s default when the flag is omitted.
+    /// - Paid `--recommend` never inherits that 60s default (#742 AC-3).
+    private func resolvedGateTTFTMS(forRecommend: Bool) -> Int {
+        if let gateTTFTMS { return gateTTFTMS }
+        return forRecommend ? 0 : 60_000
     }
 
     private static func recommendation(
@@ -678,7 +692,8 @@ struct AutotuneCommand: AsyncParsableCommand {
             lines.append("  \(index + 1). \(model)")
         }
         lines.append("autotune: stage1_replicates=\(stage1Replicates) stage2_replicates=\(stage2Replicates)")
-        lines.append("autotune: gate_ttft_ms=\(gateTTFTMS) tps_tie_epsilon=\(tpsTieEpsilon)")
+        let classicGate = resolvedGateTTFTMS(forRecommend: false)
+        lines.append("autotune: gate_ttft_ms=\(classicGate == 0 ? "disabled" : String(classicGate)) tps_tie_epsilon=\(tpsTieEpsilon)")
         lines.append("autotune: kv_bits_axis=\(kvBitsAxis) max_batch_axis=\(maxBatchAxis) max_context_axis=\(maxContextAxis.isEmpty ? "<target-context>" : maxContextAxis)")
         lines.append("autotune: port=\(port) db_path=\(dbPath) retain_runs=\(retainRuns)")
         lines.append("[dry-run] would evaluate Stage 1 candidates in this order and then hill-climb knobs only within the first feasible model.")
@@ -695,8 +710,8 @@ struct AutotuneCommand: AsyncParsableCommand {
         guard stage2Replicates >= 1 else {
             throw ValidationError("--stage2-replicates must be >= 1")
         }
-        guard gateTTFTMS > 0 else {
-            throw ValidationError("--gate-ttft-ms must be > 0")
+        if let gateTTFTMS, gateTTFTMS < 0 {
+            throw ValidationError("--gate-ttft-ms must be >= 0 (0 disables the TTFT feasibility ceiling)")
         }
         guard tpsTieEpsilon >= 0 else {
             throw ValidationError("--tps-tie-epsilon must be >= 0")
@@ -847,7 +862,7 @@ struct AutotuneCommand: AsyncParsableCommand {
         let outcomes = try await AutotuneRecommendationBenchmarker().benchmarks(
             request: request,
             targetContext: Self.spec023RecommendationProbeContext,
-            gateTTFTMS: gateTTFTMS,
+            gateTTFTMS: resolvedGateTTFTMS(forRecommend: true),
             replicates: stage1Replicates,
             port: port,
             interruptFlag: interruptFlag,

--- a/phase3-binary/Sources/macprovider-cli/AutotuneRecommend.swift
+++ b/phase3-binary/Sources/macprovider-cli/AutotuneRecommend.swift
@@ -45,10 +45,9 @@ enum AutotuneRecommendWarning: String, CaseIterable {
     /// to this row for served inference, so credits still flow — the
     /// warning surfaces the discovery-tier pricing to the operator.
     case rateCardDefaultTierUsed = "rate_card_default_tier_used"
-    /// v1.7.6 Track A2a: at least one recommended candidate observed
-    /// swap pageouts during the Stage 1 probe. Swap is advisory; the
-    /// operator should be aware that heavy real-world context loads may
-    /// push this Mac into swap.
+    /// Observed swap pageouts during the Stage 1 probe. Paid recommendations
+    /// treat this as a hard eligibility veto (#742 / SPEC-023 v0.7); the warning
+    /// still surfaces so donor-mode transcripts can name the reason.
     case swapObservedUnderLoad = "swap_observed_under_load"
     /// Advisory QoS warning when measured TPS misses the signed catalog target.
     case tpsBelowGate = "tps_below_gate"
@@ -1624,9 +1623,14 @@ struct AutotuneRecommendEngine {
                let candidate = request.candidateCatalog.rows[target.catalogKey] {
                 warnings.formUnion(Self.advisoryBenchmarkWarnings(benchmark, candidate: candidate))
             }
-            if request.benchmarks[target.catalogKey]?.swapDetected == true {
-                warnings.insert(.swapObservedUnderLoad)
-            }
+        }
+        // #742: paid path hard-vetoes swap. Surface the warning when swap is why
+        // no paid row landed (donor fallthrough / no-eligible), including the case
+        // where no donor candidate exists. Do not warn on a clean paid pick just
+        // because a lower-ranked ineligible row swapped.
+        if recommended == nil,
+           request.benchmarks.values.contains(where: \.swapDetected) {
+            warnings.insert(.swapObservedUnderLoad)
         }
 
         let resultCandidates = eligible.isEmpty ? Array(scored.prefix(5)) : Array(eligible.prefix(5))
@@ -1669,9 +1673,12 @@ struct AutotuneRecommendEngine {
         guard candidate.minRAMGB <= request.hardware.memoryGB - Self.safetyMarginGB else { return false }
         guard request.hardware.bandwidthTier.satisfies(minimum: candidate.minBandwidthTier) else { return false }
         guard let benchmark else { return false }
-        // SPEC-023 v0.2: signed TPS/TTFT gates are advisory QoS warnings, not
-        // eligibility vetoes. Thermal throttling remains the runtime hard block.
+        // SPEC-023 v0.7 (#742): swap is a paid-path hard veto — a locally
+        // measured fact that needs no catalog threshold. Signed TPS/TTFT gates
+        // remain advisory QoS warnings. Thermal throttling stays a hard block.
+        // Donor-mode keeps swap advisory (see donorModeCompatible).
         return !benchmark.thermalThrottleDetected
+            && !benchmark.swapDetected
             && Self.cachedBenchmarkAdmitted(benchmark, request: request, modelKey: modelKey)
     }
 
@@ -1794,6 +1801,9 @@ struct AutotuneRecommendEngine {
         if benchmark?.thermalThrottleDetected == true {
             return "\(modelKey) did not clear the thermal throttle recommendation gate.".prefixString(140)
         }
+        if benchmark?.swapDetected == true {
+            return "\(modelKey) did not clear the swap recommendation gate (swap detected under probe load).".prefixString(140)
+        }
         return "\(modelKey) did not clear one or more recommendation gates.".prefixString(140)
     }
 }
@@ -1869,10 +1879,16 @@ extension AutotuneRecommendResult {
             """
         }
         let best = donorFallbackModel ?? "none"
+        let swapReason: String
+        if warnings.contains(.swapObservedUnderLoad) {
+            swapReason = "\nAt least one candidate was disqualified because swap was detected under probe load.\n"
+        } else {
+            swapReason = ""
+        }
         return """
         Detected \(machineOrChip), \(hardware.memoryGB) GB unified memory, Tier \(hardware.bandwidthTier.rawValue).
         No catalog model currently fits this Mac for network serving.
-
+        \(swapReason)
         Best compatible option: \(best)
         Recommendation: donor mode only
 

--- a/phase3-binary/Sources/macprovider-cli/Stage1Iterator.swift
+++ b/phase3-binary/Sources/macprovider-cli/Stage1Iterator.swift
@@ -524,7 +524,8 @@ struct Stage1Prober: Stage1Probing {
         }
 
         let p95 = percentile95(ttfts)
-        if p95 > Double(gateTTFTMS) {
+        // gateTTFTMS == 0 means the ceiling is disabled (#742: no 60s default).
+        if gateTTFTMS > 0, p95 > Double(gateTTFTMS) {
             return .infeasible(
                 reason: "TTFT p95 \(Int(p95.rounded()))ms exceeded gate \(gateTTFTMS)ms",
                 nErr: ttfts.filter { $0 > Double(gateTTFTMS) }.count

--- a/phase3-binary/Sources/macprovider-cli/Stage2HillClimb.swift
+++ b/phase3-binary/Sources/macprovider-cli/Stage2HillClimb.swift
@@ -436,7 +436,8 @@ struct Stage2Prober: Stage2Probing {
                         measuredPromptTokens: measuredPromptTokens
                     )
                 }
-                if result.ttftMS > Double(gateTTFTMS) {
+                // gateTTFTMS == 0 means the ceiling is disabled (#742: no 60s default).
+                if gateTTFTMS > 0, result.ttftMS > Double(gateTTFTMS) {
                     nErr += 1
                     firstFailure = firstFailure ?? "TTFT \(Int(result.ttftMS.rounded()))ms exceeded gate \(gateTTFTMS)ms"
                     continue

--- a/phase3-binary/Tests/macprovider-cliTests/AutotuneCommandTests.swift
+++ b/phase3-binary/Tests/macprovider-cliTests/AutotuneCommandTests.swift
@@ -3,6 +3,24 @@ import XCTest
 @testable import macprovider_cli
 
 final class AutotuneCommandTests: XCTestCase {
+    /// #742 AC-3: paid --recommend never inherits a 60 s TTFT default;
+    /// classic Stage 1/2 keeps SPEC-013's 60s default when the flag is omitted.
+    func testGateTTFTMSPathDependentDefaultAndExplicitZero() throws {
+        let omitted = try AutotuneCommand.parse(["--dry-run"])
+        XCTAssertNil(omitted.gateTTFTMS)
+
+        let recommend = try AutotuneCommand.parse(["--recommend", "--dry-run"])
+        XCTAssertNil(recommend.gateTTFTMS)
+
+        let explicit = try AutotuneCommand.parse(["--gate-ttft-ms", "3500", "--dry-run"])
+        XCTAssertEqual(explicit.gateTTFTMS, 3500)
+
+        let disabled = try AutotuneCommand.parse(["--gate-ttft-ms", "0", "--dry-run"])
+        XCTAssertEqual(disabled.gateTTFTMS, 0)
+
+        XCTAssertThrowsError(try AutotuneCommand.parse(["--gate-ttft-ms", "-1", "--dry-run"]))
+    }
+
     func testDefaultCandidatePlanIsLargestFirst() throws {
         let command = try AutotuneCommand.parse(["--dry-run"])
         let plan = try command.candidatePlan()

--- a/phase3-binary/Tests/macprovider-cliTests/AutotuneRecommendTests.swift
+++ b/phase3-binary/Tests/macprovider-cliTests/AutotuneRecommendTests.swift
@@ -531,8 +531,10 @@ final class AutotuneRecommendTests: XCTestCase {
             hardwareIdentityHash: request.hardware.hardwareIdentityHash
         )
         // The cached benchmark was recorded under the pre-update CLI version.
+        // Keep swap false: #742 makes swap a paid hard veto; this test isolates
+        // CLI marketing-version independence of cached evidence admission.
         var benchmark = try XCTUnwrap(request.benchmarks[modelKey])
-        benchmark.swapDetected = true
+        benchmark.swapDetected = false
         request.benchmarks[modelKey] = benchmark
 
         // A CLI update alone advances the marketing version with every
@@ -553,7 +555,7 @@ final class AutotuneRecommendTests: XCTestCase {
         XCTAssertEqual(result.recommendedModel, modelKey)
         XCTAssertNotEqual(result.recommendedModel, "none")
         XCTAssertFalse(result.humanTranscript().contains("donor mode only"))
-        XCTAssertTrue(result.warnings.contains(.swapObservedUnderLoad))
+        XCTAssertFalse(result.warnings.contains(.swapObservedUnderLoad))
     }
 
     func testRowIdentityPreservesEvidenceAcrossUnrelatedCatalogChange() throws {
@@ -2363,7 +2365,7 @@ final class AutotuneRecommendTests: XCTestCase {
         XCTAssertFalse(result.warnings.contains(.rateCardDefaultTierUsed))
     }
 
-    func testSwapDetectedNoLongerBlocksEligibilityButEmitsWarning() throws {
+    func testSwapDetectedHardBlocksPaidEligibilityAndEmitsWarning() throws {
         var request = try makeRequest()
         let modelKey = "qwen3-coder-30b-a3b-instruct"
         // Flip swap flag on the existing feasible benchmark fixture.
@@ -2373,9 +2375,111 @@ final class AutotuneRecommendTests: XCTestCase {
 
         let result = AutotuneRecommendEngine().recommend(request)
 
-        XCTAssertEqual(result.recommendedModel, modelKey, "v1.7.6 Track A2a: swap detected must not veto eligibility")
+        // #742 / SPEC-023 v0.7: swap is a paid-path hard veto.
+        XCTAssertNil(result.recommendedModel, "swap_detected must disqualify paid recommendation")
+        XCTAssertNotEqual(result.recommendedModel, modelKey)
         XCTAssertTrue(result.warnings.contains(.swapObservedUnderLoad))
-        XCTAssertFalse(result.warnings.contains(.noEligibleModel))
+        XCTAssertTrue(result.warnings.contains(.noEligibleModel))
+        XCTAssertTrue(
+            result.allCandidates.contains { $0.catalogKey == modelKey && !$0.eligible && $0.why.localizedCaseInsensitiveContains("swap") }
+        )
+        XCTAssertTrue(result.humanTranscript().localizedCaseInsensitiveContains("swap"))
+    }
+
+    /// AC-1/AC-2/AC-5 for #742: replay the recorded 2026-07-23 M5/32 GB
+    /// production benchmark. The swapping qwen3-coder-30b row must never win.
+    func testM5_32GB_2026_07_23FixtureNeverRecommendsSwappingQwenCoder() throws {
+        var request = try makeMultiCandidateRequest(modelKeys: [
+            "qwen3-coder-30b-a3b-instruct",
+            "openai/gpt-oss-20b",
+            "qwen3-8b",
+            "meta-llama/llama-3.2-3b-instruct",
+        ])
+        request.hardware = AutotuneRecommendHardware(
+            machine: "Mac16,12",
+            chip: "Apple M5",
+            memoryGB: 32,
+            bandwidthTier: .c,
+            osVersion: "Version 26.5 (Build 25F71)",
+            binaryVersion: "1.8.60",
+            diversificationID: "fixture-div-2026-07-23",
+            hardwareIdentityHash: "fixture-hw-2026-07-23"
+        )
+        let generatedAt = Self.date("2026-07-23T12:00:00Z")
+        request.generatedAt = generatedAt
+
+        // Recorded production row that selected the live incident model.
+        request.benchmarks["qwen3-coder-30b-a3b-instruct"] = try fixtureBenchmark(
+            modelKey: "qwen3-coder-30b-a3b-instruct",
+            request: request,
+            sustainedTPS: 13.452081348183558,
+            ttftMS: 10_995,
+            swapDetected: true,
+            generatedAt: generatedAt
+        )
+        // Next-best measured row on the same Mac after the hand-switch (no swap).
+        request.benchmarks["openai/gpt-oss-20b"] = try fixtureBenchmark(
+            modelKey: "openai/gpt-oss-20b",
+            request: request,
+            sustainedTPS: 30.5,
+            ttftMS: 3_423,
+            swapDetected: false,
+            generatedAt: generatedAt
+        )
+        // Smaller rows that fit 32 GB and clear swap — present so the engine
+        // has non-swapping paid alternatives if gpt-oss is unavailable.
+        request.benchmarks["qwen3-8b"] = try fixtureBenchmark(
+            modelKey: "qwen3-8b",
+            request: request,
+            sustainedTPS: 40.0,
+            ttftMS: 1_200,
+            swapDetected: false,
+            generatedAt: generatedAt
+        )
+        request.benchmarks["meta-llama/llama-3.2-3b-instruct"] = try fixtureBenchmark(
+            modelKey: "meta-llama/llama-3.2-3b-instruct",
+            request: request,
+            sustainedTPS: 60.0,
+            ttftMS: 400,
+            swapDetected: false,
+            generatedAt: generatedAt
+        )
+
+        let result = AutotuneRecommendEngine().recommend(request)
+
+        XCTAssertNotEqual(result.recommendedModel, "qwen3-coder-30b-a3b-instruct")
+        XCTAssertNotNil(result.recommendedModel, "at least one non-swapping paid row must remain eligible")
+        let qwen = try XCTUnwrap(result.allCandidates.first { $0.catalogKey == "qwen3-coder-30b-a3b-instruct" })
+        XCTAssertFalse(qwen.eligible)
+        XCTAssertTrue(qwen.why.localizedCaseInsensitiveContains("swap"))
+    }
+
+    /// AC-4: when every paid row swaps, fall to donor mode with swap named.
+    func testAllSwappingPaidRowsFallToDonorWithSwapReason() throws {
+        var request = try makeRequest(modelKey: "qwen3-coder-30b-a3b-instruct")
+        request.hardware = AutotuneRecommendHardware(
+            machine: "Mac-test",
+            chip: "Apple M5",
+            memoryGB: 32,
+            bandwidthTier: .c,
+            osVersion: "macOS 15",
+            binaryVersion: "test-bin",
+            diversificationID: "diversification",
+            hardwareIdentityHash: "hardware"
+        )
+        var benchmark = try XCTUnwrap(request.benchmarks["qwen3-coder-30b-a3b-instruct"])
+        benchmark.swapDetected = true
+        benchmark.sustainedTPS = 13.452081348183558
+        benchmark.ttftMS = 10_995
+        request.benchmarks["qwen3-coder-30b-a3b-instruct"] = benchmark
+
+        let result = AutotuneRecommendEngine().recommend(request)
+
+        XCTAssertNil(result.recommendedModel)
+        XCTAssertTrue(result.warnings.contains(.noEligibleModel))
+        XCTAssertTrue(result.warnings.contains(.swapObservedUnderLoad))
+        XCTAssertTrue(result.humanTranscript().contains("donor mode only"))
+        XCTAssertTrue(result.humanTranscript().localizedCaseInsensitiveContains("swap"))
     }
 
     func testThermalThrottleStillHardBlocksEligibility() throws {
@@ -2992,6 +3096,86 @@ final class AutotuneRecommendTests: XCTestCase {
           "source": "fixture"
         }
         """
+    }
+
+    private func makeMultiCandidateRequest(modelKeys: [String]) throws -> AutotuneRecommendRequest {
+        var demand = try AutotuneStaticInputs.decodeDemandRank(Data(AutotuneStaticInputs.bakedDemandRankJSON.utf8))
+        var catalog = try AutotuneStaticInputs.decodeCandidateCatalog(Data(AutotuneStaticInputs.bakedCandidateCatalogJSON.utf8))
+        var rateCard = try AutotuneStaticInputs.decodeRateCard(Data(AutotuneStaticInputs.bakedRateCardJSON.utf8))
+        let keySet = Set(modelKeys)
+        let normalizedKeys = Set(modelKeys.map(AutotuneModelKeyNormalizer.normalize))
+        demand.rows = demand.rows.filter { keySet.contains($0.key) }
+        catalog.rows = catalog.rows.filter { keySet.contains($0.key) }
+        rateCard.rows = rateCard.rows.filter { keySet.contains($0.key) || normalizedKeys.contains($0.key) }
+
+        let catalogSHA = AutotuneStaticInputs.candidateCatalogSHA256(bytes: Data(AutotuneStaticInputs.bakedCandidateCatalogJSON.utf8))
+        let generatedAt = Self.date("2026-07-02T00:00:00Z")
+        let hardware = AutotuneRecommendHardware(
+            machine: "Mac-test",
+            chip: "Apple M4 Pro",
+            memoryGB: 64,
+            bandwidthTier: .c,
+            osVersion: "macOS 15",
+            binaryVersion: "test-bin",
+            diversificationID: "diversification",
+            hardwareIdentityHash: "hardware"
+        )
+        var benchmarks: [String: CandidateBenchmark] = [:]
+        for modelKey in modelKeys {
+            let candidate = try XCTUnwrap(catalog.rows[modelKey], "missing catalog row \(modelKey)")
+            benchmarks[modelKey] = CandidateBenchmark(
+                modelKey: modelKey,
+                sustainedTPS: 100,
+                ttftMS: max(1, candidate.benchGate.max4KTTFTMS - 1),
+                swapDetected: false,
+                thermalThrottleDetected: false,
+                artifactSHA256: candidate.modelSHA256 ?? String(repeating: "f", count: 64),
+                modelArtifactPath: "/tmp/\(modelKey)",
+                benchmarkID: "bench-\(modelKey)",
+                generatedAt: generatedAt,
+                candidateCatalogSHA256: catalogSHA,
+                binaryVersion: hardware.binaryVersion,
+                modelID: candidate.modelID,
+                hardwareIdentityHash: hardware.hardwareIdentityHash
+            )
+        }
+        return AutotuneRecommendRequest(
+            hardware: hardware,
+            demandRank: demand,
+            candidateCatalog: catalog,
+            candidateCatalogSHA256: catalogSHA,
+            rateCard: rateCard,
+            benchmarks: benchmarks,
+            warnings: [],
+            generatedAt: generatedAt,
+            donorMode: false
+        )
+    }
+
+    private func fixtureBenchmark(
+        modelKey: String,
+        request: AutotuneRecommendRequest,
+        sustainedTPS: Double,
+        ttftMS: Int,
+        swapDetected: Bool,
+        generatedAt: Date
+    ) throws -> CandidateBenchmark {
+        let candidate = try XCTUnwrap(request.candidateCatalog.rows[modelKey])
+        return CandidateBenchmark(
+            modelKey: modelKey,
+            sustainedTPS: sustainedTPS,
+            ttftMS: ttftMS,
+            swapDetected: swapDetected,
+            thermalThrottleDetected: false,
+            artifactSHA256: candidate.modelSHA256 ?? String(repeating: "f", count: 64),
+            modelArtifactPath: "/tmp/\(modelKey)",
+            benchmarkID: "bench-2026-07-23-\(modelKey)",
+            generatedAt: generatedAt,
+            candidateCatalogSHA256: request.candidateCatalogSHA256,
+            binaryVersion: request.hardware.binaryVersion,
+            modelID: candidate.modelID,
+            hardwareIdentityHash: request.hardware.hardwareIdentityHash
+        )
     }
 
     private func makeRequest(modelKey: String = "qwen3-coder-30b-a3b-instruct") throws -> AutotuneRecommendRequest {

--- a/specs/CONFORMANCE.json
+++ b/specs/CONFORMANCE.json
@@ -637,7 +637,7 @@
     {
       "spec_id": "SPEC-023",
       "title": "Installer-Integrated Autotune Recommend",
-      "version": "v0.6",
+      "version": "v0.7",
       "path": "specs/SPEC-023-installer-autotune-recommend.md",
       "status": "normative",
       "owner": "@Augustas11",

--- a/specs/README.md
+++ b/specs/README.md
@@ -31,7 +31,7 @@ it can no longer drift. Do not hand-edit the table; edit each spec's
 | SPEC-020 | Provider autoupdate | v0.1.11 | normative | pending | nonconformant: 4 | [SPEC-020-provider-autoupdate.md](SPEC-020-provider-autoupdate.md) |
 | SPEC-021 | MALIBU bootstrap rewards emission ledger | 0.1.0 | draft | pending | pending corpus migration | [SPEC-021-malibu-emission-ledger.md](SPEC-021-malibu-emission-ledger.md) |
 | SPEC-022 | Verified model settlement | v0.1.5 | draft | pending | pending corpus migration | [SPEC-022-verified-model-settlement.md](SPEC-022-verified-model-settlement.md) |
-| SPEC-023 | Installer-Integrated Autotune Recommend | v0.6 | normative | pending | pending: 1 | [SPEC-023-installer-autotune-recommend.md](SPEC-023-installer-autotune-recommend.md) |
+| SPEC-023 | Installer-Integrated Autotune Recommend | v0.7 | normative | pending | pending: 1 | [SPEC-023-installer-autotune-recommend.md](SPEC-023-installer-autotune-recommend.md) |
 | SPEC-024 | Prefix-cache billing and provider-local cache isolation | 0.2.1 | normative | pending | pending corpus migration | [SPEC-024-prefix-cache-billing.md](SPEC-024-prefix-cache-billing.md) |
 | SPEC-025 | Native Mac App (signed `.dmg` + menu bar wrapper) | v0.21 | draft | pending | pending corpus migration | [SPEC-025-native-mac-app.md](SPEC-025-native-mac-app.md) |
 | SPEC-026 | Browserless Provider Onboarding (one-click Launch Provider) | v0.26 | draft | pending | pending corpus migration | [SPEC-026-browserless-provider-onboarding.md](SPEC-026-browserless-provider-onboarding.md) |

--- a/specs/SPEC-023-installer-autotune-recommend.md
+++ b/specs/SPEC-023-installer-autotune-recommend.md
@@ -1,10 +1,16 @@
 # SPEC-023 — Installer-Integrated Autotune Recommend
-version: v0.6
+version: v0.7
 status: LOCKED
 owner: operator (a11)
-last-locked: 2026-07-10
+last-locked: 2026-07-25
 
 ## Change log
+
+- **v0.7 (2026-07-25)** — Swap is a paid-path hard eligibility veto (#742).
+  1. **`swap_detected == true` disqualifies paid recommendation.** Swap is a locally measured fact about the provider machine (pageouts during the Stage 1 probe). It needs no catalog threshold and applies on hardware never benchmarked in advance. A swapping row MUST NOT become `recommended_model`.
+  2. **§4 scoring untouched.** Ranking, demand weight, and payout-first order are unchanged; only §5 eligibility gains the swap gate.
+  3. **Donor mode keeps swap advisory.** When no non-swapping paid row exists, the CLI falls to donor mode and MUST name swap in the transcript / candidate `why` / `swap_observed_under_load` warning. Donor commit still admits a swapping row when other donor gates pass.
+  4. **No 60 s TTFT feasibility default on the paid path.** `autotune --recommend` MUST NOT default its probe TTFT ceiling to 60_000 ms. Omitting `--gate-ttft-ms` on `--recommend` disables that ceiling (`0`). Classic (non-recommend) Stage 1/2 retains the SPEC-013 60_000 ms default when the flag is omitted. Absolute buyer-facing TTFT bounds are deferred to selection-quality work (#744). Catalog `bench_gate` TPS/TTFT fields remain advisory.
 
 - **v0.6 (2026-07-10)** — Catalog recovery, trust-state separation, and buyer-coverage scoring.
   1. **One release unit.** Candidate and demand JSON, exact-byte SHA-256 digests, detached signatures, trusted verifier keyring, baked Swift payload, and release manifest are generated and verified from one canonical release directory. Candidate and demand feeds in one release share `version`, `generated_at`, and `policy_version`.
@@ -143,7 +149,7 @@ Required hardware fields:
 || `diversification_id` | string | HMAC-SHA256-derived provider ID if configured, otherwise HMAC-SHA256-derived stable machine identity | Input to deterministic diversification. Raw machine fingerprints MUST NOT be persisted, logged, emitted in JSON, included in support bundles, or sent to coordinator/gateway as part of v0.1 recommendation. |
 || `candidate_benchmarks[model_key].sustained_tps` | float | local autotune benchmark | Warm steady-state decode tokens/sec for each candidate. |
 || `candidate_benchmarks[model_key].ttft_ms` | integer | local autotune benchmark | Time to first token under the v0.1 benchmark prompt shape. |
-|| `candidate_benchmarks[model_key].swap_detected` | boolean | local probe | **[amended v0.2]** Observed swap emits `swap_observed_under_load` warning; does not fail eligibility. |
+|| `candidate_benchmarks[model_key].swap_detected` | boolean | local probe | **[amended v0.7 / #742]** Observed swap fails paid eligibility (hard block) and emits `swap_observed_under_load`. Donor mode keeps swap advisory. |
 || `candidate_benchmarks[model_key].thermal_throttle_detected` | boolean | local probe | Thermal throttle during probe fails eligibility. **[unchanged v0.2: hard block]** |
 
 HMAC identity rules:
@@ -175,7 +181,7 @@ Optional hardware fields:
 ||---|---|---|
 || `machine` | string | Human-readable Mac product name if available. |
 || `power_watts` | float | Used only when an electricity estimate is available. Absence must not fail recommendation. |
-|| `measured_memory_pressure` | string enum | May be used for confidence. **[amended v0.2: the only runtime hard failure is `thermal_throttle_detected == true`; swap is advisory per change log v0.2 point 1]**. |
+|| `measured_memory_pressure` | string enum | May be used for confidence. **[amended v0.7: runtime hard failures are `thermal_throttle_detected == true` and paid-path `swap_detected == true`]**. |
 || `benchmark_id` | string | Stable ID of the local benchmark run, included when available. |
 
 ### 3.2 Candidate/admission catalog
@@ -432,9 +438,10 @@ A row is eligible only if every gate passes:
 
 - `sustained_tps >= model.bench_gate.min_sustained_tps` **[v0.2 amendment: advisory; missing emits `tps_below_gate` warning but does not veto eligibility]**.
 - `ttft_ms <= model.bench_gate.max_4k_ttft_ms` **[v0.2 amendment: advisory; missing emits `ttft_above_gate` warning but does not veto eligibility]**.
-- `swap_detected == false` **[v0.2 amendment (originally shipped v1.7.6): advisory; observed swap emits `swap_observed_under_load` warning but does not veto eligibility]**.
-- `thermal_throttle_detected == false` **[unchanged from v0.1: hard block; the ONLY runtime hard eligibility gate in v0.2]**.
+- `swap_detected == false` **[amended v0.7 / #742: hard block for paid recommendation. When swap causes no paid row to land, emit `swap_observed_under_load`. Donor mode keeps swap advisory]**.
+- `thermal_throttle_detected == false` **[unchanged from v0.1: hard block]**.
 - The candidate benchmark must be from the current `benchmark_id` or from a cached run whose candidate catalog hash, binary version, model ID, and HMAC-derived hardware identity hash match and whose `generated_at` is no older than 7 days.
+- There is no default 60_000 ms TTFT feasibility ceiling on the paid `--recommend` path. Omitting `--gate-ttft-ms` with `--recommend` disables that ceiling; absolute buyer-facing TTFT bounds are out of scope for v0.7. Classic non-recommend Stage 1/2 retains the SPEC-013 default.
 
 In v0.4, there is no paid financial gate. All eligible rows proceed to recommendation regardless of earnings projections. Real earnings are recorded only after tokens are served.
 
@@ -531,17 +538,28 @@ Happy path applies only when at least one recommendable model is eligible and cl
 
 ### 7.2 Donor-tier path
 
-Use this text verbatim, replacing braces with computed values:
+Use this text as the donor transcript, replacing braces with computed values.
+When at least one candidate was disqualified for `swap_detected == true`, the CLI
+MUST insert the optional swap diagnostic line shown below (including its trailing
+blank line). When no swap disqualification applied, omit that line entirely so the
+blank line after the "No catalog model..." sentence remains a single blank line.
 
 ```text
 Detected {machine_or_chip}, {memory_gb} GB unified memory, Tier {bandwidth_tier}.
 No catalog model currently fits this Mac for network serving.
-
+{optional_swap_diagnostic}
 Best compatible option: {best_compatible_model}
 Recommendation: donor mode only
 
 You can keep this Mac configured for donor-mode testing, but it is not expected to earn meaningful revenue on the current rate card.
 Enable donor mode? [y/N]
+```
+
+`{optional_swap_diagnostic}` is either empty or exactly:
+
+```text
+At least one candidate was disqualified because swap was detected under probe load.
+
 ```
 
 Donor-tier path applies when no row passes all §5 gates and only a donor-compatible non-default row remains available for explicit local donor-mode testing.
@@ -557,7 +575,7 @@ v0.1 locks an explicit local donor-mode override:
 When `donor_mode == true`:
 
 - The CLI may skip only the recommendability and demand-rank `recommendable == true` default-selection gate.
-- The CLI MUST NOT bypass signed candidate-catalog presence, immutable model revision, canonical artifact-set digest check, `runtime_status != "blocked"`, model ID allowlist, RAM headroom, no-swap, no-thermal, or runtime-support gates.
+- The CLI MUST NOT bypass signed candidate-catalog presence, immutable model revision, canonical artifact-set digest check, `runtime_status != "blocked"`, model ID allowlist, RAM headroom, no-thermal, or runtime-support gates. Swap remains advisory for donor-mode commit (paid path hard-blocks swap per §5 / AC-12).
 - A donor-mode row must have signed candidate metadata with `runtime_status` equal to `candidate`, `listed`, or `recommendable`; `blocked` rows remain forbidden.
 - SPEC-023 does not add coordinator/gateway donor-routing or settlement behavior. Applying donor mode may write local config and status only; it MUST NOT auto-start or auto-register a network-connected paid provider for a non-recommendable donor row. Network-connected donor serving requires a separate donor-routing/settlement spec or build prerequisite.
 - The CLI must print an explicit warning before commit:
@@ -654,7 +672,7 @@ AC-10: A row with demand `recommendable: false` or candidate `runtime_status != 
 
 AC-11: A row whose `model.min_ram_gb > mac.ram_gb - 4` fails `hardware_fits` and is not benchmarked. v0.4 has no arbitrary local-model or custom donor-mode path override; any donor-mode selection must still select a row from the signed selected candidate catalog and pass §3.2, §5, §8, and AC-22 controls.
 
-AC-12 **[amended v0.2]**: A row whose local benchmark records `thermal_throttle_detected == true` fails eligibility (hard block). A row whose local benchmark records `swap_detected == true` emits `swap_observed_under_load` warning but does NOT fail eligibility on that basis alone.
+AC-12 **[amended v0.7 / #742]**: A row whose local benchmark records `thermal_throttle_detected == true` fails paid eligibility (hard block). A row whose local benchmark records `swap_detected == true` fails paid eligibility (hard block), MUST NOT become `recommended_model`, and emits `swap_observed_under_load`. When every paid row fails for swap (or other §5 gates) the CLI falls to donor mode and the transcript / candidate `why` names swap.
 
 AC-13 **[amended v0.2]**: A row whose benchmark misses `min_sustained_tps` or `max_4k_ttft_ms` emits `tps_below_gate` / `ttft_above_gate` warnings but does NOT fail eligibility on that basis alone.
 
@@ -666,9 +684,9 @@ AC-16: Missing candidate metadata, missing immutable `model_revision`, or missin
 
 AC-20: The happy-path transcript exactly matches §7.1 with per-token rate display.
 
-AC-21: The donor-tier transcript exactly matches §7.2.
+AC-21 **[amended v0.7 / #742]**: The donor-tier transcript matches §7.2, including the conditional swap diagnostic when swap caused no paid row to land (AC-12).
 
-AC-22 **[amended v0.4]**: `--donor-mode` allows a non-recommendable model to be locally committed only after printing the §8 warning, writing `donor_mode: true`, and verifying signed catalog metadata, immutable model revision, canonical artifact-set digest, `runtime_status != "blocked"`, model allowlist, RAM headroom, no-thermal-throttle, and runtime support. Swap and TPS/TTFT gates are advisory; observing them emits warnings but does not block donor-mode commit.
+AC-22 **[amended v0.7 / #742]**: `--donor-mode` allows a non-recommendable model to be locally committed only after printing the §8 warning, writing `donor_mode: true`, and verifying signed catalog metadata, immutable model revision, canonical artifact-set digest, `runtime_status != "blocked"`, model allowlist, RAM headroom, no-thermal-throttle, and runtime support. Swap remains advisory for donor-mode commit (paid path hard-blocks swap per AC-12); TPS/TTFT catalog gates remain advisory. Observing swap/TPS/TTFT emits warnings but does not block donor-mode commit.
 
 AC-23: Applying donor mode for a non-recommendable row does not auto-start or auto-register a network-connected paid provider. Any network-connected donor serving is blocked until a separate donor-routing/settlement prerequisite exists.
 


### PR DESCRIPTION
## Summary

Fixes #742 — the live incident where a swapping model (`qwen3-coder-30b-a3b-instruct`, 10,995 ms TTFT, `swap_detected=true`) was selected as a paid recommendation.

Two changes only (per issue scope):

1. **`swap_detected == true` hard-blocks paid eligibility** while remaining advisory for donor mode.
2. **No 60 s TTFT default on the paid `--recommend` path.** Classic Stage 1/2 keeps SPEC-013's 60s default when `--gate-ttft-ms` is omitted; paid recommend defaults to disabled. Explicit `0` disables the ceiling on either path.

SPEC-023 → **v0.7** (§5 eligibility only; §4 scoring untouched). Catalog `bench_gate` TPS/TTFT remain advisory — not enforced here (that was the wrong earlier design).

## Acceptance criteria evidence

| AC | Evidence |
|----|----------|
| AC-1 swap never `recommended_model` | `testSwapDetectedHardBlocksPaidEligibilityAndEmitsWarning` |
| AC-2/AC-5 M5/32GB 2026-07-23 fixture never yields qwen3-coder while swapping | `testM5_32GB_2026_07_23FixtureNeverRecommendsSwappingQwenCoder` (tps=13.45, ttft=10995, swap=true) |
| AC-3 no 60s default on paid path | `testGateTTFTMSPathDependentDefaultAndExplicitZero`; `resolvedGateTTFTMS(forRecommend: true)` → 0 when omitted |
| AC-4 all-swapping paid rows → donor naming swap | `testAllSwappingPaidRowsFallToDonorWithSwapReason` |

## Audit loop (full-fix diff)

Three independent codex lanes via `omc ask codex`, full fix vs `origin/main`:

| Round | code | security | architect |
|-------|------|----------|-----------|
| R1 | FAIL 0/1/0 | PASS 0/0/0 +1L | FAIL 0/0/2 +1L |
| R2 | **PASS 0/0/0** | **PASS 0/0/0** | FAIL 0/0/1 |
| R3 | (held) | (held) | **PASS 0/0/0** |

**Final: 0 CRITICAL / 0 HIGH / 0 MEDIUM.** Receipts in `audits/2026-07-25/`.

R1→R2 fixes: accept `--gate-ttft-ms 0`; path-dependent TTFT default; SPEC-023 §8 donor swap advisory; warning scope.
R2→R3 fix: §7.2 / AC-21 allow conditional swap diagnostic in donor transcript.

## Test plan

- [x] `swift test --filter AutotuneRecommendTests` (124 pass)
- [x] Stage1/Stage2/AutotuneCommand related suites green
- [x] Targeted swap + gate regression tests green after R1/R2 fixes
- [ ] CI `ci-required` green
- [ ] One approving review

## Out of scope (sequenced later)

- #743 interim `recommendable: false` for gpt-oss-20b (next)
- #745 `--model` must override `model_artifact_path`
- #744 selection quality / gate re-derivation (blocked on #745)

---

SPEC-GOVERNANCE-DECLARATION-BEGIN
{
  "schema_version": "spec-pr-governance-v1",
  "behavior_change": "yes",
  "contract_change": "yes",
  "specs": ["SPEC-023"],
  "requirements": ["SPEC-023-R001"],
  "authority_domains": ["installer-autotune-policy"],
  "arbitration": ["CODE_BUG"],
  "tests": [
    "phase3-binary/Tests/macprovider-cliTests/AutotuneRecommendTests.swift",
    "phase3-binary/Tests/macprovider-cliTests/AutotuneCommandTests.swift"
  ],
  "journeys": ["not-required"],
  "issue": "https://github.com/Augustas11/macprovider/issues/742"
}
SPEC-GOVERNANCE-DECLARATION-END
