### PR TITLE
Advance provider release target to v1.8.65

### DIFF
--- a/phase3-binary/Sources/macprovider-cli/CoordinatorClient.swift
+++ b/phase3-binary/Sources/macprovider-cli/CoordinatorClient.swift
@@ -146,7 +146,7 @@ actor CoordinatorClient {
     typealias InstalledCompatibilityManifest = @Sendable (URL, String) -> CompatibilitySetManifest?
     typealias ReloadHelperFence = @Sendable () throws -> Void
 
-    static let binaryVersion = "1.8.64"
+    static let binaryVersion = "1.8.65"
     private static let keepaliveDebugEnabled = ProcessInfo.processInfo.environment["MACPROVIDER_KEEPALIVE_DEBUG"] == "1"
 
     private let coordinatorURL: URL

--- a/phase4-coordinator/coordinator.yaml.example
+++ b/phase4-coordinator/coordinator.yaml.example
@@ -184,7 +184,7 @@ autotune:
 # legacy cohort (DECISION_CRITERIA Entry 161). `required_binary_version` is a
 # hard admission floor, not an autoupdate target, and is unaffected by the gate.
 coordinator_advertised_version:
-  latest_binary_version: "1.8.64"
+  latest_binary_version: "1.8.65"
   required_binary_version: ""
 
 auth:

--- a/phase4-coordinator/dist/coordinator.yaml
+++ b/phase4-coordinator/dist/coordinator.yaml
@@ -313,4 +313,4 @@ providers:
 # legacy cohort (DECISION_CRITERIA Entry 161). Setting this value does not, and
 # must not, re-arm the legacy binary-only updater.
 coordinator_advertised_version:
-  latest_binary_version: "1.8.64"
+  latest_binary_version: "1.8.65"

--- a/phase4-coordinator/dist/coordinator.yaml.example
+++ b/phase4-coordinator/dist/coordinator.yaml.example
@@ -358,7 +358,7 @@ malibu_emission:
 # Use for security fixes that must not be optional. Leave unset for advisory
 # releases.
 coordinator_advertised_version:
-  latest_binary_version: "1.8.64"
+  latest_binary_version: "1.8.65"
   # required_binary_version: "1.7.0"
 
 # Enumerated providers (SPEC-002 v1.0.4 Finding F-2: every provider_id that

--- a/scripts/test-malibu-bootstrap-bridge.sh
+++ b/scripts/test-malibu-bootstrap-bridge.sh
@@ -126,11 +126,11 @@ PY
 
 create_test_app "$work/later.app" 1.8.45 45
 cp "$work/later.app/Contents/Info.plist" "$work/later.Info.plist"
-python3 "$trust_anchor_helper" preflight v1.8.64 \
+python3 "$trust_anchor_helper" preflight v1.8.65 \
   "$work/later.app" "$legacy_key" >/dev/null
 cmp "$work/later.Info.plist" "$work/later.app/Contents/Info.plist" ||
   fail "candidate preflight mutated independently versioned Malibu"
-python3 "$trust_anchor_helper" prepare v1.8.64 \
+python3 "$trust_anchor_helper" prepare v1.8.65 \
   "$work/later.app" "$legacy_key" >/dev/null
 cmp "$work/later.Info.plist" "$work/later.app/Contents/Info.plist" ||
   fail "non-bridge preparation mutated independently versioned Malibu"
@@ -143,7 +143,7 @@ expect_anchor_failure wrong-bridge-version 'bundle version 1.8.45 does not match
 
 create_test_app "$work/reserved-bridge-version.app" 1.8.39 39
 expect_anchor_failure reserved-bridge-version 'reserved for the v1.8.39 trust-anchor release' \
-  preflight v1.8.64 "$work/reserved-bridge-version.app" "$legacy_key"
+  preflight v1.8.65 "$work/reserved-bridge-version.app" "$legacy_key"
 
 create_test_app "$work/missing-anchor.app" 1.8.39 39
 expect_anchor_failure missing-anchor 'must contain only the exact frozen' \


### PR DESCRIPTION
## Summary
- bump macprovider-cli binaryVersion to v1.8.65
- update coordinator advertised latest_binary_version to v1.8.65
- update Malibu bridge regression test inputs to the new provider release tag

## Why
v1.8.64 candidate built and verified successfully, but production promotion was dispatched after main advanced to #747. The release-source guard correctly refused to sign v1.8.64 from a different main tip. This bumps the release target on the current reviewed main tip so candidate and production promotion can share the same commit again.

## Validation
- `bash -n scripts/test-malibu-bootstrap-bridge.sh scripts/test-release-security-posture.sh scripts/test-tier2-provider-release.sh`
- `bash scripts/test-coordinator-advertised-version.sh v1.8.65`
- `bash scripts/test-malibu-bootstrap-bridge.sh`
- `bash scripts/test-malibu-independent-release.sh`
- `rg -n "1\.8\.64|v1\.8\.64" phase3-binary phase4-coordinator scripts/test-malibu-bootstrap-bridge.sh .github/workflows/release.yml` returned no release-target matches
- `git diff --check`

SPEC-GOVERNANCE-DECLARATION-BEGIN
{
  "schema_version": "spec-pr-governance-v1",
  "behavior_change": "yes",
  "contract_change": "none",
  "specs": ["SPEC-020", "SPEC-025"],
  "requirements": ["SPEC-020-R002"],
  "authority_domains": ["provider-autoupdate", "native-app-lifecycle"],
  "arbitration": ["CODE_BUG"],
  "tests": ["scripts/test-coordinator-advertised-version.sh v1.8.65", "scripts/test-malibu-bootstrap-bridge.sh", "scripts/test-malibu-independent-release.sh"],
  "journeys": ["not-required"],
  "issue": "https://github.com/Augustas11/macprovider/issues/610"
}
SPEC-GOVERNANCE-DECLARATION-END