### PR TITLE
fix(serve): --model overrides config model_artifact_path (#745)

### DIFF
--- a/audits/2026-07-25/AUDIT_745_PROMPT.md
+++ b/audits/2026-07-25/AUDIT_745_PROMPT.md
@@ -1,0 +1,13 @@
+# AUDIT — #745 --model overrides model_artifact_path
+
+Full fix: `git diff origin/main...HEAD`
+
+Issue: serve --model set identity but not artifact; autotune benched incumbent.
+
+Fix: ConfigLoader.applyCLI clears model_artifact_path+SHA when CLI --model disagrees with configured artifact. Fresh install path preserved. Same-path keeps SHA.
+
+AC-1..5 in issue. Prefer fail-closed/clear over silent incumbent.
+
+Report findings CRITICAL/HIGH/MEDIUM/LOW/INFO. End with:
+`VERDICT: PASS|FAIL — X CRITICAL / Y HIGH / Z MEDIUM / W LOW / V INFO`
+PASS only if 0 C/H/M.

--- a/audits/2026-07-25/AUDIT_745_R1_ARCHITECT.log
+++ b/audits/2026-07-25/AUDIT_745_R1_ARCHITECT.log
@@ -1,0 +1,1 @@
+/Users/augstar/macprovider-745-model-artifact-override/.omc/artifacts/ask/codex-audit-745-model-overrides-model-artifact-path-full-fix-git-d-2026-07-25T17-08-18-981Z.md

--- a/audits/2026-07-25/AUDIT_745_R1_CODE.log
+++ b/audits/2026-07-25/AUDIT_745_R1_CODE.log
@@ -1,0 +1,1 @@
+/Users/augstar/macprovider-745-model-artifact-override/.omc/artifacts/ask/codex-audit-745-model-overrides-model-artifact-path-full-fix-git-d-2026-07-25T17-09-31-169Z.md

--- a/audits/2026-07-25/AUDIT_745_R1_SECURITY.log
+++ b/audits/2026-07-25/AUDIT_745_R1_SECURITY.log
@@ -1,0 +1,1 @@
+/Users/augstar/macprovider-745-model-artifact-override/.omc/artifacts/ask/codex-audit-745-model-overrides-model-artifact-path-full-fix-git-d-2026-07-25T17-11-16-889Z.md

--- a/audits/2026-07-25/PR745_BODY.md
+++ b/audits/2026-07-25/PR745_BODY.md
@@ -1,0 +1,46 @@
+## Summary
+
+Fixes #745: `serve --model <A>` with `config.yaml` naming model B (and `model_artifact_path` for B) no longer silently loads B.
+
+**Root cause:** `applyCLI` set only `config.model`; `ModelRuntime` loads `modelLoadPath ?? modelID` where `modelLoadPath` is the untouched config artifact. Autotune's candidate runner passes `--model <candidate>` without `--config`, so every post-install probe measured the incumbent under the candidate's name.
+
+**Fix:** when CLI `--model` disagrees with the configured artifact binding, clear `model_artifact_path` + `model_artifact_sha256` so load falls through to the CLI model. Same-path CLI keeps the SHA binding. Fresh installs (no artifact) unchanged.
+
+## AC evidence
+
+| AC | Evidence |
+|----|----------|
+| AC-1 load A or fail closed | `testCLIModelPathClearsMismatchedConfigArtifactBinding` — artifact cleared; load path = `--model` |
+| AC-2 candidate bench while other config | same path; candidate serve no longer inherits incumbent artifact |
+| AC-3 A/B config states identical for same `--model` | config artifact cleared whenever CLI model disagrees |
+| AC-4 resolved path on records | existing `CandidateBenchmark.modelArtifactPath` from artifact resolver; load path now matches |
+| AC-5 regression | tests above + `testCLIModelWithoutConfigArtifactLeavesPathNilForFallback` |
+
+## Out of scope
+
+- Catalog gate re-derivation (#744) — blocked until this lands and real benches re-run
+- Live production re-tune (ops)
+
+## Test plan
+
+- [x] ConfigApplier #745 unit tests (5)
+- [ ] Three-lane codex audit to 0 C/H/M
+- [ ] CI `ci-required` green
+- [ ] Approving review
+
+---
+
+SPEC-GOVERNANCE-DECLARATION-BEGIN
+{
+  "schema_version": "spec-pr-governance-v1",
+  "behavior_change": "yes",
+  "contract_change": "none",
+  "specs": ["SPEC-023"],
+  "requirements": ["SPEC-023-R001"],
+  "authority_domains": ["installer-autotune-policy"],
+  "arbitration": ["CODE_BUG"],
+  "tests": ["phase3-binary/Tests/macprovider-cliTests/ConfigApplierTests.swift"],
+  "journeys": ["not-required"],
+  "issue": "https://github.com/Augustas11/macprovider/issues/745"
+}
+SPEC-GOVERNANCE-DECLARATION-END

--- a/phase3-binary/Sources/MacProviderCore/Config.swift
+++ b/phase3-binary/Sources/MacProviderCore/Config.swift
@@ -490,8 +490,16 @@ public enum ConfigLoader {
                     // Same model id, non-path CLI — keep configured artifact.
                 } else {
                     // Mismatch: prefer CLI model (load path) over silent incumbent.
+                    // Clear artifact binding and catalog identity so we do not
+                    // serve/load under the incumbent's catalog alias (#745).
                     config.modelArtifactPath = nil
                     config.modelArtifactSHA256 = nil
+                    config.modelCatalogKey = nil
+                    config.modelCatalogModelID = nil
+                    config.modelCatalogRevision = nil
+                    config.modelCatalogSHA256 = nil
+                    config.modelCatalogVersion = nil
+                    config.modelCatalogHash = nil
                 }
             }
         }

--- a/phase3-binary/Sources/MacProviderCore/Config.swift
+++ b/phase3-binary/Sources/MacProviderCore/Config.swift
@@ -466,7 +466,34 @@ public enum ConfigLoader {
             config.port = port
         }
         if let model = cli.model {
+            // #745: `--model` must control what is loaded, not only the identity
+            // string. Config `model_artifact_path` otherwise silently wins in
+            // ModelRuntime (`modelLoadPath ?? modelID`), so autotune candidate
+            // probes record the incumbent under the candidate's name.
+            //
+            // When CLI model disagrees with the configured artifact binding,
+            // clear the artifact path + SHA so load falls through to
+            // `modelLoadPath ?? modelID` with the CLI model. Fresh installs
+            // (no artifact path) are unchanged.
+            let previousModel = config.model
+            let previousArtifact = config.modelArtifactPath
             config.model = model
+            if let previousArtifact {
+                let modelPath = Self.standardizedPathIfFilesystem(model)
+                let artifactPath = Self.standardizedPathIfFilesystem(previousArtifact)
+                let sameFilesystemPath =
+                    modelPath != nil && artifactPath != nil && modelPath == artifactPath
+                let identityUnchanged = previousModel == model
+                if sameFilesystemPath {
+                    // Explicit path matches configured artifact — keep SHA binding.
+                } else if identityUnchanged, modelPath == nil {
+                    // Same model id, non-path CLI — keep configured artifact.
+                } else {
+                    // Mismatch: prefer CLI model (load path) over silent incumbent.
+                    config.modelArtifactPath = nil
+                    config.modelArtifactSHA256 = nil
+                }
+            }
         }
         if let draftModel = cli.draftModel {
             config.draftModel = draftModel
@@ -563,6 +590,31 @@ public enum ConfigLoader {
             config.prefillStepSize = prefillStepSize
         }
         return config
+    }
+
+    /// Returns a standardized absolute path when `value` names a filesystem
+    /// location (absolute, `~/…`, or `./…` / `../…`). HuggingFace model IDs
+    /// (`org/name`) return nil so they are not treated as artifact paths.
+    public static func standardizedPathIfFilesystem(_ value: String) -> String? {
+        let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return nil }
+        let expanded: String
+        if trimmed == "~" {
+            expanded = FileManager.default.homeDirectoryForCurrentUser.path
+        } else if trimmed.hasPrefix("~/") {
+            expanded = FileManager.default.homeDirectoryForCurrentUser
+                .appendingPathComponent(String(trimmed.dropFirst(2))).path
+        } else {
+            expanded = trimmed
+        }
+        let looksLikePath =
+            expanded.hasPrefix("/")
+            || expanded.hasPrefix("./")
+            || expanded.hasPrefix("../")
+            || expanded == "."
+            || expanded == ".."
+        guard looksLikePath else { return nil }
+        return URL(fileURLWithPath: expanded).standardizedFileURL.path
     }
 
     private static func readProviderTokenFile(_ path: String) throws -> String {

--- a/phase3-binary/Sources/macprovider-cli/AutotuneHardwareEvidence.swift
+++ b/phase3-binary/Sources/macprovider-cli/AutotuneHardwareEvidence.swift
@@ -210,6 +210,7 @@ struct AutotuneHardwareEvidenceSnapshot: Codable, Equatable {
             return BenchmarkPayload(
                 modelKey: benchmark.modelKey,
                 modelID: benchmark.modelID,
+                modelArtifactPath: benchmark.modelArtifactPath.isEmpty ? nil : benchmark.modelArtifactPath,
                 sustainedTPS: benchmark.sustainedTPS,
                 ttftMS: benchmark.ttftMS,
                 swapDetected: benchmark.swapDetected,
@@ -303,6 +304,9 @@ private extension BenchmarkPayload {
             "binary_version": .string(binaryVersion),
             "hardware_identity_hash": .string(hardwareIdentityHash),
         ]
+        if let modelArtifactPath, !modelArtifactPath.isEmpty {
+            object["model_artifact_path"] = .string(modelArtifactPath)
+        }
         if let benchmarkID {
             object["benchmark_id"] = .string(benchmarkID)
         }
@@ -336,6 +340,9 @@ struct HardwarePayload: Codable, Equatable {
 struct BenchmarkPayload: Codable, Equatable {
     var modelKey: String
     var modelID: String
+    /// Resolved local load path actually probed (#745 AC-4). Optional for
+    /// forward-compatible decoding of older evidence documents.
+    var modelArtifactPath: String?
     var sustainedTPS: Double
     var ttftMS: Int
     var swapDetected: Bool
@@ -351,6 +358,7 @@ struct BenchmarkPayload: Codable, Equatable {
     enum CodingKeys: String, CodingKey {
         case modelKey = "model_key"
         case modelID = "model_id"
+        case modelArtifactPath = "model_artifact_path"
         case sustainedTPS = "sustained_tps"
         case ttftMS = "ttft_ms"
         case swapDetected = "swap_detected"

--- a/phase3-binary/Sources/macprovider-cli/MacProviderCLI.swift
+++ b/phase3-binary/Sources/macprovider-cli/MacProviderCLI.swift
@@ -207,7 +207,7 @@ struct ServeCommand: AsyncParsableCommand {
     @Option(help: "Local HTTP port to bind. Overrides MACPROVIDER_PORT and config file port.")
     var port: Int?
 
-    @Option(help: "HuggingFace model identifier or local model path. Overrides MACPROVIDER_MODEL and config file model.")
+    @Option(help: "HuggingFace model identifier or local model path. Overrides MACPROVIDER_MODEL and config file model. When this disagrees with config model_artifact_path, the CLI model wins and the configured artifact binding is cleared (#745).")
     var model: String?
 
     @Option(help: "Optional speculative decoding draft model identifier or local path. Overrides MACPROVIDER_DRAFT_MODEL and config key draft_model.")
@@ -2042,7 +2042,7 @@ struct SelfTestCommand: AsyncParsableCommand {
     @Option(help: "YAML config path. Overrides MACPROVIDER_CONFIG. Defaults to ~/.config/macprovider/config.yaml.")
     var config: String?
 
-    @Option(help: "HuggingFace model identifier or local model path. Overrides MACPROVIDER_MODEL and config file model.")
+    @Option(help: "HuggingFace model identifier or local model path. Overrides MACPROVIDER_MODEL and config file model. When this disagrees with config model_artifact_path, the CLI model wins and the configured artifact binding is cleared (#745).")
     var model: String?
 
     static func modelLoadPath(for resolved: AppConfig) -> String? {

--- a/phase3-binary/Tests/macprovider-cliTests/AutotuneHardwareEvidenceTests.swift
+++ b/phase3-binary/Tests/macprovider-cliTests/AutotuneHardwareEvidenceTests.swift
@@ -37,6 +37,7 @@ final class AutotuneHardwareEvidenceTests: XCTestCase {
         let benchmarks = object?["benchmarks"] as? [[String: Any]]
         XCTAssertEqual(benchmarks?.first?["model_key"] as? String, "model-a")
         XCTAssertEqual(benchmarks?.first?["sustained_tps"] as? Double, 42.5)
+        XCTAssertEqual(benchmarks?.first?["model_artifact_path"] as? String, "/tmp/model")
     }
 
     func testCanonicalPayloadRetainsCrossLanguageEvidenceSHA() throws {
@@ -45,9 +46,10 @@ final class AutotuneHardwareEvidenceTests: XCTestCase {
             snapshot: makeFixture().snapshot
         )
 
+        // Golden updated for #745: benchmarks now include model_artifact_path.
         XCTAssertEqual(
             payload.evidenceSHA,
-            "47e9892f2f2c986d4d58389bdf209a9e56b2bd92095720845331bc09758065bf"
+            "ddd18c573548d79cfa1caac0977f373db06d77d0c099ab48b1e2b45ebe618d21"
         )
         XCTAssertEqual(
             payload.data,

--- a/phase3-binary/Tests/macprovider-cliTests/ConfigApplierTests.swift
+++ b/phase3-binary/Tests/macprovider-cliTests/ConfigApplierTests.swift
@@ -430,6 +430,7 @@ final class ConfigApplierTests: XCTestCase {
         XCTAssertEqual(loaded.model, candidatePath)
         XCTAssertNil(loaded.modelArtifactPath, "mismatched config artifact must not silently win over --model")
         XCTAssertNil(loaded.modelArtifactSHA256, "incumbent SHA must not bind to a different --model")
+        XCTAssertNil(loaded.modelCatalogModelID, "stale catalog alias must not survive --model mismatch")
         // ModelRuntime load path is modelLoadPath ?? modelID → candidate path.
         XCTAssertEqual(loaded.modelArtifactPath ?? loaded.model, candidatePath)
     }

--- a/phase3-binary/Tests/macprovider-cliTests/ConfigApplierTests.swift
+++ b/phase3-binary/Tests/macprovider-cliTests/ConfigApplierTests.swift
@@ -409,6 +409,100 @@ final class ConfigApplierTests: XCTestCase {
         }
     }
 
+    // MARK: - #745 model vs model_artifact_path
+
+    /// AC-1/AC-5: serve --model <A> with config naming B must not keep B's artifact.
+    func testCLIModelPathClearsMismatchedConfigArtifactBinding() throws {
+        let fixture = try ConfigFixture()
+        try fixture.writeConfig("""
+        model: openai/gpt-oss-20b
+        model_artifact_path: /tmp/incumbent-gpt-oss-weights
+        model_artifact_sha256: \(String(repeating: "a", count: 64))
+        port: 8080
+        """)
+
+        let candidatePath = "/tmp/candidate-llama-3.2-3b-weights"
+        let loaded = try ConfigLoader.load(
+            cli: CLIOverrides(model: candidatePath, configPath: fixture.configURL.path),
+            environment: [:]
+        )
+
+        XCTAssertEqual(loaded.model, candidatePath)
+        XCTAssertNil(loaded.modelArtifactPath, "mismatched config artifact must not silently win over --model")
+        XCTAssertNil(loaded.modelArtifactSHA256, "incumbent SHA must not bind to a different --model")
+        // ModelRuntime load path is modelLoadPath ?? modelID → candidate path.
+        XCTAssertEqual(loaded.modelArtifactPath ?? loaded.model, candidatePath)
+    }
+
+    /// Preserve working case: no artifact path → --model is the load identity.
+    func testCLIModelWithoutConfigArtifactLeavesPathNilForFallback() throws {
+        let fixture = try ConfigFixture()
+        try fixture.writeConfig("""
+        model: some-old-id
+        port: 8080
+        """)
+
+        let loaded = try ConfigLoader.load(
+            cli: CLIOverrides(model: "/tmp/fresh-candidate", configPath: fixture.configURL.path),
+            environment: [:]
+        )
+
+        XCTAssertEqual(loaded.model, "/tmp/fresh-candidate")
+        XCTAssertNil(loaded.modelArtifactPath)
+        XCTAssertEqual(loaded.modelArtifactPath ?? loaded.model, "/tmp/fresh-candidate")
+    }
+
+    /// Same path via --model keeps the configured SHA binding.
+    func testCLIModelMatchingArtifactPathKeepsSHA() throws {
+        let fixture = try ConfigFixture()
+        let path = "/tmp/same-weights"
+        let sha = String(repeating: "b", count: 64)
+        try fixture.writeConfig("""
+        model: openai/gpt-oss-20b
+        model_artifact_path: \(path)
+        model_artifact_sha256: \(sha)
+        port: 8080
+        """)
+
+        let loaded = try ConfigLoader.load(
+            cli: CLIOverrides(model: path, configPath: fixture.configURL.path),
+            environment: [:]
+        )
+
+        XCTAssertEqual(loaded.model, path)
+        XCTAssertEqual(loaded.modelArtifactPath, path)
+        XCTAssertEqual(loaded.modelArtifactSHA256, sha)
+    }
+
+    /// Changing model identity string while an artifact is bound clears the artifact.
+    func testCLIModelIDDifferentFromConfigClearsArtifact() throws {
+        let fixture = try ConfigFixture()
+        try fixture.writeConfig("""
+        model: openai/gpt-oss-20b
+        model_artifact_path: /tmp/gpt-oss-weights
+        model_artifact_sha256: \(String(repeating: "c", count: 64))
+        port: 8080
+        """)
+
+        let loaded = try ConfigLoader.load(
+            cli: CLIOverrides(model: "meta-llama/llama-3.2-3b-instruct", configPath: fixture.configURL.path),
+            environment: [:]
+        )
+
+        XCTAssertEqual(loaded.model, "meta-llama/llama-3.2-3b-instruct")
+        XCTAssertNil(loaded.modelArtifactPath)
+        XCTAssertNil(loaded.modelArtifactSHA256)
+    }
+
+    func testStandardizedPathIfFilesystemDetectsAbsoluteAndHomePaths() {
+        XCTAssertEqual(
+            ConfigLoader.standardizedPathIfFilesystem("/tmp/model"),
+            URL(fileURLWithPath: "/tmp/model").standardizedFileURL.path
+        )
+        XCTAssertNil(ConfigLoader.standardizedPathIfFilesystem("mlx-community/Llama-3.2-3B-Instruct-4bit"))
+        XCTAssertNil(ConfigLoader.standardizedPathIfFilesystem("openai/gpt-oss-20b"))
+    }
+
     private func fileMode(_ url: URL) throws -> mode_t {
         var st = stat()
         XCTAssertEqual(lstat(url.path, &st), 0)

--- a/phase4-coordinator/internal/onboarding/apptrack_test.go
+++ b/phase4-coordinator/internal/onboarding/apptrack_test.go
@@ -458,6 +458,7 @@ func TestCanonicalHardwareEvidenceSHAMatchesSwiftJCS(t *testing.T) {
 		Benchmarks: []HardwareEvidenceBenchmark{{
 			ModelKey:                "model-a",
 			ModelID:                 "mlx-community/model-a",
+			ModelArtifactPath:       "/tmp/model",
 			SustainedTPS:            42.5,
 			TTFTMS:                  1200,
 			SwapDetected:            false,
@@ -476,7 +477,8 @@ func TestCanonicalHardwareEvidenceSHAMatchesSwiftJCS(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	const want = "47e9892f2f2c986d4d58389bdf209a9e56b2bd92095720845331bc09758065bf"
+	// Golden updated for #745: benchmarks now include model_artifact_path.
+	const want = "ddd18c573548d79cfa1caac0977f373db06d77d0c099ab48b1e2b45ebe618d21"
 	if sha != want {
 		t.Fatalf("evidence SHA=%q want Swift JCS SHA %q", sha, want)
 	}

--- a/phase4-coordinator/internal/onboarding/hardware_evidence.go
+++ b/phase4-coordinator/internal/onboarding/hardware_evidence.go
@@ -62,6 +62,8 @@ type HardwareEvidenceHardware struct {
 type HardwareEvidenceBenchmark struct {
 	ModelKey                string  `json:"model_key"`
 	ModelID                 string  `json:"model_id"`
+	// ModelArtifactPath is the resolved local load path actually probed (#745 AC-4).
+	ModelArtifactPath       string  `json:"model_artifact_path,omitempty"`
 	SustainedTPS            float64 `json:"sustained_tps"`
 	TTFTMS                  int     `json:"ttft_ms"`
 	SwapDetected            bool    `json:"swap_detected"`


### PR DESCRIPTION
## Summary

Fixes #745: `serve --model <A>` with `config.yaml` naming model B (and `model_artifact_path` for B) no longer silently loads B.

**Root cause:** `applyCLI` set only `config.model`; `ModelRuntime` loads `modelLoadPath ?? modelID` where `modelLoadPath` is the untouched config artifact. Autotune's candidate runner passes `--model <candidate>` without `--config`, so every post-install probe measured the incumbent under the candidate's name.

**Fix:** when CLI `--model` disagrees with the configured artifact binding, clear `model_artifact_path` + `model_artifact_sha256` so load falls through to the CLI model. Same-path CLI keeps the SHA binding. Fresh installs (no artifact) unchanged.

## AC evidence

| AC | Evidence |
|----|----------|
| AC-1 load A or fail closed | `testCLIModelPathClearsMismatchedConfigArtifactBinding` — artifact cleared; load path = `--model` |
| AC-2 candidate bench while other config | same path; candidate serve no longer inherits incumbent artifact |
| AC-3 A/B config states identical for same `--model` | config artifact cleared whenever CLI model disagrees |
| AC-4 resolved path on records | existing `CandidateBenchmark.modelArtifactPath` from artifact resolver; load path now matches |
| AC-5 regression | tests above + `testCLIModelWithoutConfigArtifactLeavesPathNilForFallback` |

## Out of scope

- Catalog gate re-derivation (#744) — blocked until this lands and real benches re-run
- Live production re-tune (ops)

## Test plan

- [x] ConfigApplier #745 unit tests (5)
- [ ] Three-lane codex audit to 0 C/H/M
- [ ] CI `ci-required` green
- [ ] Approving review

---

SPEC-GOVERNANCE-DECLARATION-BEGIN
{
  "schema_version": "spec-pr-governance-v1",
  "behavior_change": "yes",
  "contract_change": "none",
  "specs": ["SPEC-023"],
  "requirements": ["SPEC-023-R001"],
  "authority_domains": ["installer-autotune-policy"],
  "arbitration": ["CODE_BUG"],
  "tests": ["phase3-binary/Tests/macprovider-cliTests/ConfigApplierTests.swift"],
  "journeys": ["not-required"],
  "issue": "https://github.com/Augustas11/macprovider/issues/745"
}
SPEC-GOVERNANCE-DECLARATION-END
