### PR TITLE
Fix the discovery-head renewal failing on every run under bash 3.2

### DIFF
--- a/.github/workflows/renew-release-discovery-head.yml
+++ b/.github/workflows/renew-release-discovery-head.yml
@@ -231,6 +231,9 @@ jobs:
             --openssl "$OPENSSL_BIN" >/dev/null
           cmp "$WORK/latest/compatibility-artifact-index.json" \
             "$WORK/current/compatibility-artifact-index.json"
+          # macos runners ship bash 3.2, where "${empty[@]}" is an unbound-variable
+          # error under `set -u`. A head with no signed policy minimum and no
+          # revocations leaves this array empty, so expand it guardedly below.
           policy_args=()
           while IFS= read -r arg; do
             [[ -n "$arg" ]] && policy_args+=("$arg")
@@ -270,7 +273,7 @@ jobs:
             --attempt "$GITHUB_RUN_ATTEMPT" \
             --compatibility-manifest "$WORK/latest/compatibility-set.json" \
             --target-artifact-index "$WORK/latest/compatibility-artifact-index.json" \
-            "${policy_args[@]}" \
+            ${policy_args[@]+"${policy_args[@]}"} \
             --issued-at "$issued_at" \
             --expires-at "$expires_at" \
             --private-key "$key" \


### PR DESCRIPTION
## Problem

`renew-release-discovery-head.yml` has **never completed successfully** — two runs in
its entire history, one cancelled (2026-07-24) and one failed (2026-07-25, run
[30172994013](https://github.com/Augustas11/macprovider/actions/runs/30172994013)).
The failure is deterministic, not flaky.

`policy_args` is populated only when the current discovery head carries a
`signed_policy_minimum` or a `signed_policy_revoked` entry. The live head carries
neither:

```json
"signed_policy_minimum": null,
"signed_policy_revoked": []
```

So the array is always empty, and `"${policy_args[@]}"` is an **unbound-variable error
under `set -u` on bash 3.2** — which is what macOS runners ship. The failing run's log:

```
.../87752473-....sh: line 88: policy_args[@]: unbound variable
```

The `sign` step died there, before writing its `transport_tag` output and before
copying the artifact index. The `publish` step then ran with an empty
`TRANSPORT_TAG:` and failed with
`no matches found for .../renew-discovery/compatibility-artifact-index.json`.

Both downstream symptoms have this one cause.

## Consequence

Signed release discovery could never be renewed, so both heads lapsed past
`expires_at` and the client's fail-closed guard
(`SignedReleaseDiscovery.swift:101`, `expires > now`) rejected them fleet-wide:

| Head | Target | Expired |
|---|---|---|
| Fixed `release-discovery` tag (`immutable: true`) | v1.8.55 | 2026-07-21T21:04:27Z |
| Newest transport | v1.8.61 | 2026-07-25T10:11:03Z |

Fresh installs were unaffected — `install.sh` does not consume the discovery
transport. This was an update-path outage only.

## Fix

Expand the array guardedly. Verified against real bash 3.2.57:

```
OLD empty  : policy_args[@]: unbound variable
NEW empty  : argc=2 [A] [B]
NEW filled : argc=4 [A] [--signed-policy-minimum=1.8.0] [--signed-policy-revoked=x y] [B]
```

Element quoting is preserved, including arguments containing spaces.

## Sweep

Checked every macOS-runner workflow for the same pattern. The other bare expansions
are arrays populated by construction — `acceptance-candidate.yml` starts
`package_resolution_args=(archive)`, and the release-asset arrays always carry
entries — so this is the only instance that can be empty in practice. Not changing
them.

## Proof required before this is called done

A green re-dispatch publishing a new transport whose `expires_at` is in the future.
Workflow success alone is not proof; the published head will be fetched and its
expiry checked.

SPEC-GOVERNANCE-DECLARATION-BEGIN
{
  "schema_version": "spec-pr-governance-v1",
  "behavior_change": "yes",
  "contract_change": "none",
  "specs": ["SPEC-020"],
  "requirements": ["SPEC-020-R001"],
  "authority_domains": ["provider-autoupdate"],
  "arbitration": ["CODE_BUG"],
  "tests": ["scripts/verify-release-discovery-transport.py"],
  "journeys": ["not-required"],
  "issue": "https://github.com/Augustas11/macprovider/issues/658"
}
SPEC-GOVERNANCE-DECLARATION-END

🤖 Generated with [Claude Code](https://claude.com/claude-code)
