### PR TITLE
Add seam-hardening audit harness and tripwire regression tests (#770 PR 0)

### DIFF
--- a/audits/seam-hardening/README.md
+++ b/audits/seam-hardening/README.md
@@ -1,0 +1,42 @@
+# Seam Hardening — pre-OpenRouter-enrollment audit
+
+Before enrolling our gateway as an upstream provider on OpenRouter, we audited the
+**seams** between buyer ↔ gateway ↔ coordinator ↔ provider for correctness and
+robustness gaps. These seams — not the model or inference quality — are where a
+marketplace enrollment puts us at risk: OpenRouter publicly scores providers on
+latency + error rate (and routes buyers away on strikes), reconciles billing on
+reported usage, and retries requests. Gaps here are cheap to fix now and
+costly/visible once we take scored traffic.
+
+**Scenario under test:** our `phase5-gateway` enrolled as an OpenRouter upstream,
+driven by buyer traffic.
+
+## Method
+
+Each finding is grounded two ways:
+1. **Located** — a concrete `file:line` in our own codebase and a failure scenario.
+2. **Checked** — where practical, an executable regression test that asserts the
+   buggy behavior today and flips red when the fix lands (see `harness/`).
+
+Only checked/located findings are carried into `findings.md`.
+
+## Seam taxonomy
+
+1. **request-lifecycle / deadlines** — per-phase leases vs one flat wall-clock
+2. **error-classification** — 5xx-fault vs capacity-shed vs buyer-cancel
+3. **usage & settlement** — reserve→settle, partial-usage survival, idempotency, durability
+4. **fault-attribution / reputation** — never strike provider health for platform/cancel failures
+5. **cache-tenant-isolation** — server-authored scope; no cross-account timing/at-rest oracle
+6. **backend-rollout-safety** — canary + kill-switch + per-slot telemetry; absence is its own bucket
+7. **attestation-honesty** — claim only load-bearing, end-to-end-verified controls
+8. **fleet-version-floor** — provider version floors + stale-build defense + auto-update
+
+## Contents
+
+| File | What |
+|---|---|
+| `findings.md` | Risk register: per-finding verdict, `file:line`, failure scenario, fix, tripwire test |
+| `harness/` | Executable regression tests (Go), results table, and run commands |
+
+The prioritized remediation (P0/P1/P2) at the end of `findings.md` is the source for the
+tracked GitHub issues under the **Seam hardening before OpenRouter enrollment** epic.

--- a/audits/seam-hardening/findings.md
+++ b/audits/seam-hardening/findings.md
@@ -1,0 +1,117 @@
+# Seam-Hardening Findings & Remediation
+
+Verdicts against the eight seams. `file:line` are in our own repo. Tripwire tests (where
+built) live in `harness/` and are named `TestSeam*`.
+
+## Scorecard
+
+| Seam | Verdict | One-line |
+|---|---|---|
+| 1 · settlement / deadline | **FAIL** | one flat request wall-clock; two money-integrity gaps |
+| 2 · cache-tenant-isolation | **PASS by construction** | server-authored account-HMAC scope; KV in-memory only |
+| 3 · backend-rollout-safety | **PASS (1 gap)** | strong flags/canary/self-update; perf telemetry not backend-segmented |
+| 4 · attestation-honesty | **FAIL (client-facing)** | prose honest, but stat surfaces over-claim hardware trust |
+| 5 · fleet-version-floor | **PASS (2 gaps)** | blocks incompatible/known-bad builds; capacity trusted blindly |
+
+Fundamentals are strong (cache isolation, rollout discipline, signed-catalog admission,
+honest prose). Exposure concentrates in two client-facing FAILs (settlement flat-wall,
+attestation schema) plus a shared observability gap (capacity/backend telemetry).
+
+---
+
+## Findings by severity
+
+### P0 — before enrolling on OpenRouter
+
+**P0-1 · Attestation surfaces report hardware trust that a software key satisfies** — `credibility`
+Two machine-readable surfaces — `nodes_hardware_attested` (public network-stats) and the
+`/v1/models` `hardware_attestation` state — are computed from `AttestationStatus == "attested"`,
+which a self-signed software P-256 key satisfies (`phase4-coordinator/.../poolsnapshot.go:77-78`,
+`internal/buyer/server.go:898-925`). The `hardware` tier is never emitted, and the hardware-rooted
+controls are gated off in prod. A client trusting the field over-trusts the fleet.
+**Fix:** gate both surfaces on `AttestationTier == "hardware"` (never true today) or rename to
+key-custody (e.g. `nodes_key_attested`). Buyer prose already says "no hardware attestation" — bring
+the schema up to the prose. *Tripwire: none yet (add a pool-snapshot unit test).*
+
+**P0-2 · Single request wall-clock kills healthy long generations** — `ranking` — test `TestSeamH1`
+`upCtx = context.WithTimeout(r.Context(), CoordinatorTimeout())` (`phase5-gateway/.../chat_proxy.go:122`,
+default 300s) spans the whole request; enforced on a mid-stream generation via the transport closing
+the body on `upCtx` expiry (the read loop at `:1047` is on `r.Context()`+the 10s idle timer). A
+legitimate long stream that keeps emitting is cut at the wall → 5xx against our public error rate.
+**Fix:** decompose into admission/connect + first-token + decode-progress (the 10s idle timer) +
+a `max_tokens`-derived safety ceiling; coordinate with the coordinator per-attempt ctx.
+
+**P0-3 · Provider health struck on buyer/gateway cancellation** — `supply` — test `TestSeamH3`
+The `ErrRelayTimeout` branch (`phase4-coordinator/internal/buyer/server.go:2994-2996`) calls
+`recordBreakerFault` unconditionally; its `ErrRelayClosed` sibling (`:2997-3002`) guards on
+`r.Context().Err() != nil`. A buyer cancel racing a relay timeout strikes the provider; two strikes
+in 120s degrade it (`pool/provider.go:1574`) → dropped from routing.
+**Fix:** add the `r.Context().Err()` guard to the `ErrRelayTimeout` branch; twin fix on the streaming
+path (`forwardWSStreamingBuffered:3299`).
+
+### P1 — before real volume
+
+**P1-1 · Retry double-bill without a stable request id** — `money` — test `TestSeamH5a` · issue #200
+An id-less buyer retry (which OpenRouter does) mints a fresh request_id (`server.go:240-244`) → a new
+reservation → billed again. **Fix:** gateway-native `Idempotency-Key` dedupe (tracked in #200).
+
+**P1-2 · Settlement not crash-durable** — `money` — test `TestSeamH7`
+On the streaming after-commit path, if `SettleReservation` and the `EnsureUsageEvent` fallback both
+fail (`phase5-gateway/.../chat_proxy.go:1974-1993`), the gateway logs, refunds, and drops the usage
+row — the buyer already got a committed 200. Tokens delivered, nobody billed, no durable record.
+**Fix:** append-only settlement journal keyed by (account, request_id)+effect, written before dispatch,
+sealed on terminal, with a startup recovery scan. Reservation-before-dispatch already exists.
+
+**P1-3 · Capacity trusted blindly; no clamp, no tripwire** — `ranking`/`supply` (closes a slice-3 + slice-5 gap)
+Provider-reported `max_concurrency` is granted verbatim (`phase4-coordinator/internal/ws/server.go:2249`,
+`:4196`, `relay.go:423`); the only drift signal is observe-only + default-off (`pow/drift.go:218`,
+`config.go:104`). A stale/over-claiming build serves silently. **Fix:** `min(hello, ceiling)` capacity
+clamp + a permanent over-claim tripwire counter on the heartbeat path, and segment TTFT/TPS rollups by
+`binary_version`/backend (`stats/handlers.go:78`). Keep the verified-benchmark baseline (`drift.go:151`).
+
+**P1-4 · Runtime perf gate fails open on absent benchmark** — `ranking`
+`pow/drift.go` skips the TPS/hash check when `!hasBenchmark` — un-benchmarked providers are silently
+un-gated. **Fix:** treat "no verified benchmark" as quarantine-until-proven (absence = suspect).
+
+### P2 — debt
+
+**P2-1 · Single-terminal-wins request arbiter** — `money` — H4 (blocked)
+No arbiter joins the billing terminal (`billing_recorder.go:220`) and the buyer-504 terminal
+(`server.go:2996`); billing can complete while the buyer is told it timed out. **Fix:** a terminal
+latch/actor. Not unit-testable until it exists (see `harness/` H4).
+
+**P2-2 · Version floor unset in prod + client can't parse the rejection** — `supply`
+`required_binary_version` is set nowhere in prod config, and the Swift client has no `case 4004`
+(`phase3-binary/.../CoordinatorClient.swift:1460-1499`) → a below-floor close is a silent reconnect
+loop, not an upgrade directive. **Fix:** set the floor in the prod overlay, add a `4004` handler + an
+upgrade directive, add a `doctor` subcommand.
+
+**P2-3 · No per-model version floor** — `supply`
+Only a per-model *hardware-tier* gate exists; an old-but-hardware-eligible build can serve a model that
+needs a newer engine. **Fix:** add a per-model minimum-version floor to the routing gate.
+
+**P2-4 · Hygiene: hello-gate spec vs prod config; same-account timing risk** — `hygiene`
+`SPEC-032` claims the hello-gate is prod-on; committed prod config does not set it (also confirm
+`canary_enabled`/`warmup_gate_enabled` are ON in the live overlay — Go zero-value OFF). And if sticky
+routing is enabled for multi-tenant traffic, document acceptance of the residual same-account TTFT
+timing side-channel. **Fix:** reconcile spec vs overlay; write the risk-acceptance note.
+
+---
+
+## Verified strengths — do not regress
+
+- **Cache-tenant isolation (seam 2):** conversation/cache scope = `HMAC(secret, scope‖accountID‖tag)`
+  server-side (`phase5-gateway/.../chat_proxy.go:2061`); KV cache in-memory only. No cross-tenant oracle.
+- **Rollout discipline (seam 3):** default-OFF engine flags + kill switches; signed compatibility-set
+  floor with mandatory rollback set; correctness canary; verified-predecessor self-update + quarantine.
+- **Admission (seam 5):** compat-set + signed-catalog + model-hash, enforced at connect **and** reconnect,
+  ON in prod. Blocks incompatible/known-bad builds cleanly.
+- **Honest buyer prose (seam 4):** copy that says "no hardware attestation" + a MUST-NOT-claim list.
+
+## Cheapest-first sequence
+
+1. **P0-1** + **P0-3** — two-line changes, highest stakes-per-character.
+2. **P0-2** — the flat-wall decomposition.
+3. **P1-3** — one clamp+tripwire closes the seam-3 and seam-5 gaps together.
+4. **P1-1 / P1-2** — money integrity before real buyer volume.
+5. P2 as debt burn-down.

--- a/audits/seam-hardening/harness/README.md
+++ b/audits/seam-hardening/harness/README.md
@@ -1,0 +1,55 @@
+# harness/ — executable seam regression tests
+
+Simulates **our `phase5-gateway` enrolled as an OpenRouter upstream** and runs the
+adversarial scenarios that reproduce each seam risk in `../findings.md`, asserting on wire
+status + `usage` billing + settlement/health outcome.
+
+The rig is not a separate server: the "mock-upstream" is a controllable `roundTripFunc`
+transport injected into the gateway via `WithHTTPClient` (and, for the coordinator tests, a
+directly-driven `RelayStream`). This reuses each package's own test scaffolding, so the tests
+are deterministic and need no running server or credentials.
+
+Test files:
+- `phase5-gateway/internal/router/seam_harness_test.go`
+- `phase4-coordinator/internal/buyer/seam_h3_test.go`
+
+## Run
+
+```bash
+cd phase5-gateway     && go test ./internal/router/ -run TestSeam  -v
+cd phase4-coordinator && go test ./internal/buyer/  -run TestSeamH -v
+```
+
+## Results (verified 2026-07-26) — 7 of 8 execute; only H4 is a documented skip
+
+**Gateway suite**
+
+| Scenario | Finding | Verdict | What executes |
+|---|---|---|---|
+| **H1** `FlatWallKillsProgressingStream` | P0-2 | **PASS = confirms FAIL** | a steadily-progressing stream is cut at the (shortened) total wall, never hitting the idle timer |
+| **H2** `BuyerDisconnectSettlesConsumerSide` | — | **PASS** | buyer-cancel → consumer-side settle, billed bounded to delivered |
+| **H5a** `IdlessRetryDoubleBills` | P1-1 | **PASS = confirms FAIL** | two id-less calls bill 40 (2×20) |
+| **H5b** `StableRequestIDBillsOnce` | P1-1 | **PASS** (control) | same-UUID 2nd call → 409, billed once (20) |
+| **H6** `ProviderOverReportBoundedToDelivered` | — | **PASS** | provider `completion_tokens=100000` rejected → estimate, billed 24 not 100008 |
+| **H7** `SettlementNotCrashDurable` | P1-2 | **PASS = confirms GAP** | committed 200 stream + settle double-failure → usage row dropped, refunded, nobody billed |
+| H3 / H4 | P0-3 / P2-1 | pointer-SKIP | see coordinator suite |
+
+**Coordinator suite**
+
+| Scenario | Finding | Verdict | What executes |
+|---|---|---|---|
+| **H3** `RelayTimeoutStrikesOnBuyerCancel` | P0-3 | **PASS = confirms FAIL** | one `ErrRelayTimeout` + a cancelled buyer ctx (threshold=1) → provider struck to `StateDegraded` |
+| **H4** `SingleTerminalWins` | P2-1 | **SKIP (documented)** | not unit-testable: no arbiter joins the billing terminal and the buyer-504 terminal; testable only once a single-terminal arbiter exists |
+
+The "confirms FAIL/GAP" tests pass by asserting the **buggy-today** behavior, so when a fix lands
+they flip to failing-until-the-assertion-is-updated — a durable regression tripwire per finding.
+
+## Mechanism note (surfaced by wiring H1)
+
+The total wall is `upCtx = context.WithTimeout(r.Context(), CoordinatorTimeout())`
+(`chat_proxy.go:122`); the upstream request is created with it (`http.NewRequestWithContext(upCtx,…)`).
+The streaming read loop selects on `r.Context()` + the 10s idle timer (`:1047`), **not** `upCtx` — so
+the total wall reaches a mid-stream generation only because the real `net/http.Transport` closes the
+body when `upCtx` expires. A naive mock pipe ignores ctx and would let a stream outlive the wall (a
+test artifact, not a code fix); `seamStreamingUpstreamCtx` honors the request ctx to emulate the real
+transport, confirming P0-2 faithfully.

--- a/phase4-coordinator/internal/buyer/seam_h3_test.go
+++ b/phase4-coordinator/internal/buyer/seam_h3_test.go
@@ -1,0 +1,109 @@
+package buyer
+
+// Seam-hardening e2e harness — coordinator-side scenarios H3 and H4.
+// Companion to the gateway suite in
+// phase5-gateway/internal/router/seam_harness_test.go and the risk register in
+// audits/seam-hardening/. These live in phase4-coordinator because provider-health
+// attribution and terminal ordering are the coordinator's job.
+//
+// Run: go test ./internal/buyer/ -run TestSeamH -count=1 -v
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/augstar/macprovider-coordinator/internal/pool"
+	providerws "github.com/augstar/macprovider-coordinator/internal/ws"
+	"github.com/rs/zerolog"
+)
+
+// H3 · relay-timeout strikes provider health on a buyer cancel (INV-3).
+// EXPECTED: PASS = confirms the bug. The ErrRelayTimeout branch
+// (internal/buyer/server.go:2994-2996) calls recordBreakerFault WITHOUT the
+// r.Context().Err() buyer-cancel guard that its ErrRelayClosed sibling has
+// (:2997-3002). So a buyer/gateway cancel racing a relay timeout penalizes the
+// provider. With breakerThreshold=1 a single fault flips it to StateDegraded,
+// observed via the registry snapshot. When the guard is added, the provider
+// stays StateReady and this test flips red — a regression tripwire for the fix.
+func TestSeamH3_RelayTimeoutStrikesOnBuyerCancel(t *testing.T) {
+	const providerID, assignedID = "p1", "current"
+	at := time.Unix(1716768000, 0).UTC()
+
+	reg := pool.NewRegistry(nil)
+	reg.Register(&pool.Provider{
+		ProviderID:       providerID,
+		AssignedID:       assignedID,
+		State:            pool.StateReady, // RecordBreakerFault only acts on Ready/Busy
+		SlotsFree:        1,
+		SlotsTotal:       1,
+		MaxConcurrency:   1,
+		MaxContextTokens: 20000,
+		LastHeartbeatAt:  at,
+		LastActivityAt:   at,
+	}, nil)
+
+	// threshold=1 so ONE fault trips Degraded (default is 2).
+	s := NewServer(reg, zerolog.Nop(), at, WithBreakerConfig(1, 120*time.Second))
+	provider := pool.Provider{ProviderID: providerID, AssignedID: assignedID}
+
+	// Buyer/gateway cancel that races the relay timeout.
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	r := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", nil).WithContext(ctx)
+	w := httptest.NewRecorder()
+
+	// Synthetic relay yielding exactly one ErrRelayTimeout; Chunks/Done nil block
+	// harmlessly in the select, cancel func stays nil.
+	errCh := make(chan error, 1)
+	errCh <- providerws.ErrRelayTimeout
+	relay := &providerws.RelayStream{RequestID: "req-h3", Errors: errCh}
+
+	result, attempt := s.forwardWSNonStreaming(w, r, "req-h3", provider, relay, nil, nil, 1)
+
+	if result != wsForwardTimedOut {
+		t.Fatalf("expected wsForwardTimedOut, got %v", result)
+	}
+	if attempt.Status != http.StatusGatewayTimeout {
+		t.Fatalf("expected 504 timeout attempt, got %d", attempt.Status)
+	}
+
+	var got pool.State
+	found := false
+	for _, p := range reg.Snapshot() {
+		if p.ProviderID == providerID {
+			got, found = p.State, true
+		}
+	}
+	if !found {
+		t.Fatalf("provider %q not found in registry snapshot", providerID)
+	}
+	if got != pool.StateDegraded {
+		t.Fatalf("H3: expected the provider to be struck to Degraded by a relay-timeout fault "+
+			"under a cancelled buyer ctx (the confirmed bug), got state %v. If it stayed Ready, "+
+			"the missing r.Context().Err() guard was ADDED at server.go:2994 — update the audit", got)
+	}
+	t.Logf("CONFIRMED FINDING (INV-3): relay-timeout struck provider health (→Degraded) despite a "+
+		"cancelled buyer context — the ErrRelayTimeout branch (server.go:2994) lacks the buyer-cancel "+
+		"guard its ErrRelayClosed sibling has (:2997). Fix: add `if r.Context().Err()!=nil { return }` "+
+		"before recordBreakerFault. (Streaming twin: forwardWSStreamingBuffered :3299.)")
+}
+
+// H4 · single-terminal-wins / paid-while-buyer-told-timeout (INV-6).
+// Documented skip: not unit-testable. There is no arbiter/latch joining the two
+// terminal paths — billing settlement (billingRecorder.recordRow,
+// internal/buyer/billing_recorder.go:220) and the buyer 504 timeout terminal
+// (forwardWSNonStreaming, internal/buyer/server.go:2996) are produced by independent
+// paths. The "billing completed while the buyer was told it timed out" property is an
+// emergent cross-path race, observable only end-to-end and non-deterministically;
+// unit-asserting an ordering that no code enforces is not meaningful. Convert to a real
+// test once a terminal latch is introduced at the recordRow seam (a single-terminal
+// request-arbiter). See audits/seam-hardening/findings.md INV-6/INV-9.
+func TestSeamH4_SingleTerminalWins(t *testing.T) {
+	t.Skip("INV-6: no single-terminal-wins request actor exists; the billing terminal " +
+		"(billing_recorder.go:220) and the buyer 504 terminal (server.go:2996) are independent " +
+		"paths with no arbiter. The gap is a cross-path race observable only end-to-end. Attach a " +
+		"real test at the recordRow seam once a single-terminal request-arbiter is introduced.")
+}

--- a/phase5-gateway/internal/router/seam_harness_test.go
+++ b/phase5-gateway/internal/router/seam_harness_test.go
@@ -1,0 +1,386 @@
+package router
+
+// Seam-hardening e2e harness — executable regression tests for the buyer↔gateway↔
+// coordinator↔provider seam risks documented in audits/seam-hardening/ (scenarios
+// H1–H7), driving phase5-gateway as if it were an OpenRouter upstream. The
+// "mock-upstream" is a controllable roundTripFunc transport injected via
+// WithHTTPClient — it stands in for coordinator.buyer_url with per-scenario injection
+// (slow drip, buyer disconnect, usage over-report, id-less retry, etc.).
+//
+// Each test maps to a finding in audits/seam-hardening/findings.md and carries its
+// EXPECTED verdict. Tests whose subject is a confirmed FAIL assert the buggy-today
+// behavior (so a fix flips them red); PASS tests certify a real strength.
+//
+// Run: go test ./internal/router/ -run TestSeam -count=1 -v
+//
+// Coordinator-side scenarios (H3 breaker attribution, H4 paid-while-timed-out) live in
+// phase4-coordinator, not this package — recorded as documented Skips below with their
+// exact injection points.
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/augstar/macprovider-gateway/internal/config"
+	"github.com/augstar/macprovider-gateway/internal/storage"
+	"github.com/augstar/macprovider-gateway/internal/storage/sqlite"
+)
+
+// ---- mock-upstream helpers -------------------------------------------------
+
+// seamStreamingUpstream returns an http.Client whose transport answers the
+// gateway's POST {BuyerURL}/v1/chat/completions with a 200 text/event-stream whose
+// body is produced by onWrite (via an io.Pipe), letting a scenario inject slow
+// drip, mid-stream close, or a final usage chunk. Non-chat paths 404.
+func seamStreamingUpstream(onWrite func(pw *io.PipeWriter)) *http.Client {
+	return &http.Client{Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+		if r.URL.Path != "/v1/chat/completions" {
+			return responseWithBody(http.StatusNotFound, nil, `{}`), nil
+		}
+		pr, pw := io.Pipe()
+		go onWrite(pw)
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     http.Header{"Content-Type": []string{"text/event-stream; charset=utf-8"}},
+			Body:       pr,
+		}, nil
+	})}
+}
+
+// seamStreamingUpstreamCtx is like seamStreamingUpstream but passes the upstream
+// request context (which the gateway sets to upCtx = the total-wall deadline via
+// http.NewRequestWithContext at chat_proxy.go:347) into onWrite. A faithful mock must
+// stop writing and close the body when that context fires — exactly what the real
+// net/http.Transport does in production when the total wall expires. (A plain
+// roundTripFunc pipe does NOT honor ctx, which would let a stream outlive the wall.)
+func seamStreamingUpstreamCtx(onWrite func(pw *io.PipeWriter, ctx context.Context)) *http.Client {
+	return &http.Client{Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+		if r.URL.Path != "/v1/chat/completions" {
+			return responseWithBody(http.StatusNotFound, nil, `{}`), nil
+		}
+		pr, pw := io.Pipe()
+		go onWrite(pw, r.Context())
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     http.Header{"Content-Type": []string{"text/event-stream; charset=utf-8"}},
+			Body:       pr,
+		}, nil
+	})}
+}
+
+// seamJSONUpstream returns an http.Client that answers with a fixed non-streaming
+// 200 application/json completion (used by the idempotency scenarios).
+func seamJSONUpstream(completion string, seen *int) *http.Client {
+	return &http.Client{Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+		if r.URL.Path != "/v1/chat/completions" {
+			return responseWithBody(http.StatusNotFound, nil, `{}`), nil
+		}
+		if seen != nil {
+			*seen++
+		}
+		return responseWithBody(http.StatusOK,
+			http.Header{"Content-Type": []string{"application/json"}}, completion), nil
+	})}
+}
+
+// billedTokens reads /v1/usage and returns daily_tokens_used.
+func billedTokens(t *testing.T, h http.Handler, key string) float64 {
+	t.Helper()
+	resp := assertStatus(t, h, http.MethodGet, "/v1/usage", key, "", "1.2.3.4", http.StatusOK)
+	quota := readQuota(t, resp)
+	used, ok := quota["daily_tokens_used"].(float64)
+	if !ok {
+		t.Fatalf("daily_tokens_used missing/non-numeric in quota=%v", quota)
+	}
+	return used
+}
+
+const seamCompletionJSON = `{"id":"c","object":"chat.completion","created":1,"model":"llama",` +
+	`"usage":{"prompt_tokens":8,"completion_tokens":12,"total_tokens":20},` +
+	`"choices":[{"index":0,"message":{"role":"assistant","content":"hello"},"finish_reason":"stop"}]}`
+
+// ---- H5 · id-less retry double-bill (INV-11) -------------------------------
+// EXPECTED: FAIL today (issue #200). An id-less buyer retry — which OpenRouter does —
+// mints a fresh request_id, so each attempt reserves+settles independently → double-bill.
+
+func TestSeamH5a_IdlessRetryDoubleBills(t *testing.T) {
+	var upstreamHits int
+	client := seamJSONUpstream(seamCompletionJSON, &upstreamHits)
+	h, store, _, cfg := newTestHarnessConfig(t, fakeOAuth{}, func(cfg *config.Config) {
+		cfg.Coordinator.BuyerURL = "http://coordinator.test"
+	}, WithHTTPClient(client))
+	key := createAccountAndKey(t, store, cfg, "acct_h5a")
+
+	body := `{"model":"llama","max_tokens":20,"messages":[{"role":"user","content":"hi"}]}`
+	// No X-Request-ID → each call mints a fresh id → distinct reservations.
+	if r := postChat(t, h, key, body, nil); r.Code != http.StatusOK {
+		t.Fatalf("call 1 status=%d body=%s", r.Code, r.Body.String())
+	}
+	if r := postChat(t, h, key, body, nil); r.Code != http.StatusOK {
+		t.Fatalf("call 2 status=%d body=%s", r.Code, r.Body.String())
+	}
+
+	used := billedTokens(t, h, key)
+	if used == 40 {
+		t.Logf("CONFIRMED FINDING (INV-11 FAIL): id-less retry double-billed %v tokens "+
+			"(2×20); upstream hit %d times. Fix: gateway-native Idempotency-Key dedupe "+
+			"(server.go:240-244, issue #200).", used, upstreamHits)
+		return
+	}
+	t.Fatalf("expected double-bill of 40 (confirmed finding); got daily_tokens_used=%v "+
+		"(if this is 20, the idempotency gap was FIXED — update the audit)", used)
+}
+
+func TestSeamH5b_StableRequestIDBillsOnce(t *testing.T) {
+	// Control: a stable UUID X-Request-ID must dedupe — 2nd call 409s, billed once.
+	client := seamJSONUpstream(seamCompletionJSON, nil)
+	h, store, _, cfg := newTestHarnessConfig(t, fakeOAuth{}, func(cfg *config.Config) {
+		cfg.Coordinator.BuyerURL = "http://coordinator.test"
+	}, WithHTTPClient(client))
+	key := createAccountAndKey(t, store, cfg, "acct_h5b")
+
+	body := `{"model":"llama","max_tokens":20,"messages":[{"role":"user","content":"hi"}]}`
+	hdr := map[string]string{"X-Request-ID": "11111111-1111-4111-8111-111111111111"}
+	if r := postChat(t, h, key, body, hdr); r.Code != http.StatusOK {
+		t.Fatalf("call 1 status=%d body=%s", r.Code, r.Body.String())
+	}
+	r2 := postChat(t, h, key, body, hdr)
+	if r2.Code == http.StatusOK {
+		t.Fatalf("call 2 with same X-Request-ID should not re-succeed; body=%s", r2.Body.String())
+	}
+	used := billedTokens(t, h, key)
+	if used != 20 {
+		t.Fatalf("stable-id idempotency broken: billed %v want 20 (2nd call code=%d)", used, r2.Code)
+	}
+	t.Logf("PASS (INV-11 control): stable X-Request-ID deduped — 2nd call code=%d, billed once (%v).",
+		r2.Code, used)
+}
+
+// ---- H6 · provider over-reports usage → bounded to delivered (INV-7) -------
+// EXPECTED: PASS. The gateway rejects a provider completion count that exceeds the
+// emitted bytes / max_tokens and downgrades to a byte-estimate (charge bounded by
+// delivered: committed <= delivered-to-client <= provider-claimed).
+
+func TestSeamH6_ProviderOverReportBoundedToDelivered(t *testing.T) {
+	sse := `data: {"id":"c","choices":[{"delta":{"content":"ok"}}]}` + "\n\n" +
+		// completion_tokens=100000 wildly exceeds max_tokens=20 and the 2 emitted bytes:
+		`data: {"id":"c","usage":{"prompt_tokens":8,"completion_tokens":100000,"total_tokens":100008},"choices":[{"delta":{},"finish_reason":"stop"}]}` + "\n\n" +
+		`data: [DONE]` + "\n\n"
+	client := seamStreamingUpstream(func(pw *io.PipeWriter) {
+		_, _ = pw.Write([]byte(sse))
+		_ = pw.Close()
+	})
+	h, store, dbPath, cfg := newTestHarnessConfig(t, fakeOAuth{}, func(cfg *config.Config) {
+		cfg.Coordinator.BuyerURL = "http://coordinator.test"
+	}, WithHTTPClient(client))
+	key := createAccountAndKey(t, store, cfg, "acct_h6")
+
+	body := `{"model":"llama","stream":true,"max_tokens":20,"messages":[{"role":"user","content":"hi"}]}`
+	r := postChat(t, h, key, body, map[string]string{"X-Request-ID": "22222222-2222-4222-8222-222222222222"})
+	if r.Code != http.StatusOK || !strings.Contains(r.Body.String(), "data: [DONE]") {
+		t.Fatalf("stream code=%d body=%s", r.Code, r.Body.String())
+	}
+
+	_, source := usageEventOutcome(t, dbPath, "acct_h6")
+	used := billedTokens(t, h, key)
+	if source == "provider_reported" || used >= 1000 {
+		t.Fatalf("INV-7 VIOLATED: provider over-report accepted (source=%s, billed=%v) — "+
+			"charge not bounded to delivered", source, used)
+	}
+	t.Logf("PASS (INV-7): over-report rejected → source=%s, billed bounded to %v (not 100008).",
+		source, used)
+}
+
+// ---- H2 · buyer disconnect mid-stream (INV-5, INV-7) -----------------------
+// EXPECTED: PASS-with-nuance. Streaming buyer-disconnect settles a byte-estimated
+// partial (consumer-side outcome), bounded to delivered — never a provider fault.
+// (The asymmetry vs non-streaming refund is documented in 02-macprovider-audit.md.)
+
+func TestSeamH2_BuyerDisconnectSettlesConsumerSide(t *testing.T) {
+	delivered := make(chan struct{})
+	release := make(chan struct{})
+	client := seamStreamingUpstream(func(pw *io.PipeWriter) {
+		_, _ = pw.Write([]byte(`data: {"id":"c","choices":[{"delta":{"content":"hello"}}]}` + "\n\n"))
+		close(delivered)
+		<-release // hold the stream open until the test cancels the buyer
+		_ = pw.Close()
+	})
+	h, store, dbPath, cfg := newTestHarnessConfig(t, fakeOAuth{}, func(cfg *config.Config) {
+		cfg.Coordinator.BuyerURL = "http://coordinator.test"
+	}, WithHTTPClient(client))
+	key := createAccountAndKey(t, store, cfg, "acct_h2")
+
+	body := `{"model":"llama","stream":true,"max_tokens":500,"messages":[{"role":"user","content":"hi"}]}`
+	ctx, cancel := context.WithCancel(context.Background())
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader(body)).WithContext(ctx)
+	req.Header.Set("Authorization", "Bearer "+key)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Request-ID", "33333333-3333-4333-8333-333333333333")
+	rec := httptest.NewRecorder()
+
+	done := make(chan struct{})
+	go func() { h.ServeHTTP(rec, req); close(done) }()
+
+	select {
+	case <-delivered:
+	case <-time.After(3 * time.Second):
+		close(release)
+		t.Fatal("upstream never delivered first chunk")
+	}
+	cancel()       // buyer disconnects mid-stream
+	close(release) // let the upstream goroutine finish
+	select {
+	case <-done:
+	case <-time.After(3 * time.Second):
+		t.Fatal("handler did not return after buyer cancel")
+	}
+
+	outcome, source := usageEventOutcome(t, dbPath, "acct_h2")
+	if strings.Contains(outcome, "provider") && strings.Contains(outcome, "error") {
+		t.Fatalf("INV-5 VIOLATED: buyer-cancel booked as a provider fault (outcome=%s)", outcome)
+	}
+	used := billedTokens(t, h, key)
+	if used > 100 { // bounded to the one delivered delta, not the 500-token max
+		t.Fatalf("INV-7 VIOLATED: buyer-cancel billed %v (> delivered bound)", used)
+	}
+	t.Logf("PASS (INV-5/INV-7): buyer-disconnect settled consumer-side outcome=%q source=%q "+
+		"billed=%v (bounded to delivered). Note: streaming BILLS the estimate while "+
+		"non-streaming refunds — asymmetry per 02-macprovider-audit.md.", outcome, source, used)
+}
+
+// ---- H1 · flat wall kills a progressing stream (INV-1, INV-2) --------------
+// EXPECTED: FAIL today. One flat total wall (chat_proxy.go:122, CoordinatorTimeout)
+// spans the whole request, so a steadily-progressing stream is cut at the wall even
+// though it never hit the 10s decode-idle timer. Timeout shortened to 1s for the test.
+
+func TestSeamH1_FlatWallKillsProgressingStream(t *testing.T) {
+	client := seamStreamingUpstreamCtx(func(pw *io.PipeWriter, ctx context.Context) {
+		// Emit a token every 200ms (well under the 10s idle timer) for up to 3s,
+		// i.e. a HEALTHY, steadily-progressing stream. Honor the total-wall context
+		// exactly as the real transport does: when upCtx fires, abort the body.
+		for i := 0; i < 15; i++ {
+			if _, err := pw.Write([]byte(`data: {"id":"c","choices":[{"delta":{"content":"x"}}]}` + "\n\n")); err != nil {
+				return
+			}
+			select {
+			case <-ctx.Done(): // total wall fired mid-stream → transport aborts the body
+				_ = pw.CloseWithError(ctx.Err())
+				return
+			case <-time.After(200 * time.Millisecond):
+			}
+		}
+		_, _ = pw.Write([]byte(`data: [DONE]` + "\n\n"))
+		_ = pw.Close()
+	})
+	h, store, _, cfg := newTestHarnessConfig(t, fakeOAuth{}, func(cfg *config.Config) {
+		cfg.Coordinator.BuyerURL = "http://coordinator.test"
+		cfg.Timeouts.CoordinatorRequestSeconds = 1
+		cfg.Timeouts.CoordinatorHeaderTimeoutSeconds = 1
+	}, WithHTTPClient(client))
+	key := createAccountAndKey(t, store, cfg, "acct_h1")
+
+	body := `{"model":"llama","stream":true,"max_tokens":500,"messages":[{"role":"user","content":"hi"}]}`
+	start := time.Now()
+	r := postChat(t, h, key, body, map[string]string{"X-Request-ID": "44444444-4444-4444-8444-444444444444"})
+	elapsed := time.Since(start)
+
+	completedCleanly := strings.Contains(r.Body.String(), "data: [DONE]") &&
+		!strings.Contains(r.Body.String(), "provider_disconnected")
+	if elapsed < 2*time.Second && !completedCleanly {
+		t.Logf("CONFIRMED FINDING (INV-1/INV-2 FAIL): a progressing stream was cut at the "+
+			"flat %s wall after %s (never hit the 10s idle timer). Fix: decompose into "+
+			"per-phase leases (chat_proxy.go:122).", time.Second, elapsed.Round(10*time.Millisecond))
+		return
+	}
+	if completedCleanly {
+		t.Fatalf("stream completed cleanly in %s despite a 1s total wall — the flat wall was "+
+			"FIXED (per-phase leases?); update the audit", elapsed)
+	}
+	t.Fatalf("inconclusive: elapsed=%s completedCleanly=%v body=%.200q", elapsed, completedCleanly, r.Body.String())
+}
+
+// ---- H3 · relay-timeout strikes provider on buyer-cancel (INV-3) -----------
+// IMPLEMENTED coordinator-side (this behavior is the coordinator's, not the gateway's):
+// phase4-coordinator/internal/buyer/seam_h3_test.go :: TestSeamH3_RelayTimeoutStrikesOnBuyerCancel
+// (a real, passing regression test — confirms the provider is struck to Degraded).
+func TestSeamH3_RelayTimeoutBuyerCancelGuard(t *testing.T) {
+	t.Skip("Implemented in phase4-coordinator/internal/buyer/seam_h3_test.go " +
+		"(TestSeamH3_RelayTimeoutStrikesOnBuyerCancel) — that package owns the breaker path " +
+		"(server.go:2994). Run: go test ./internal/buyer/ -run TestSeamH3 in phase4-coordinator.")
+}
+
+// ---- H4 · paid-while-buyer-told-timeout (INV-6) ----------------------------
+// Documented coordinator-side: no arbiter joins the two terminal paths, so it is not
+// unit-testable. See phase4-coordinator/internal/buyer/seam_h3_test.go :: TestSeamH4_SingleTerminalWins.
+func TestSeamH4_NoPaidWhileTimedOut(t *testing.T) {
+	t.Skip("Documented in phase4-coordinator/internal/buyer/seam_h3_test.go " +
+		"(TestSeamH4_SingleTerminalWins): billing terminal (billing_recorder.go:220) and the " +
+		"buyer 504 terminal (server.go:2996) are independent paths with no latch — an emergent " +
+		"cross-path race, testable only once a single-terminal-arbiter actor exists.")
+}
+
+// ---- H7 · settlement not crash-durable (INV-8) -----------------------------
+// EXPECTED: PASS = confirms the GAP. On the STREAMING after-commit path the buyer has
+// already received a committed 200 stream; if SettleReservation AND the EnsureUsageEvent
+// fallback both fail (a crash/DB pathology between reserve and settle), the gateway logs,
+// refunds, and DROPS the usage row (chat_proxy.go:1974-1993) — the buyer got the tokens,
+// nobody is billed, and there is no durable journal to reconcile from. (Non-streaming just
+// 500s the buyer, so the committed-success-with-dropped-row case is streaming-specific.)
+func TestSeamH7_SettlementNotCrashDurable(t *testing.T) {
+	// Streaming upstream: a provider usage chunk then [DONE] → committed 200, settlement
+	// runs after commit via settleAfterCommit.
+	client := seamStreamingUpstream(func(pw *io.PipeWriter) {
+		_, _ = io.WriteString(pw, `data: {"id":"c","usage":{"prompt_tokens":8,"completion_tokens":12,"total_tokens":20},"choices":[{"delta":{"content":"hi"}}]}`+
+			"\n\n"+`data: [DONE]`+"\n\n")
+		_ = pw.Close()
+	})
+	// The harness returns the real *sqlite.Store; wrap it in a settle-failing spy and
+	// build a fresh gateway over the SAME store/db (chat_proxy_retry_test.go:503-504 pattern).
+	_, store, dbPath, cfg := newTestHarnessConfig(t, fakeOAuth{}, func(cfg *config.Config) {
+		cfg.Coordinator.BuyerURL = "http://coordinator.test"
+	}, WithHTTPClient(client))
+	spy := &settleFailSpyStore{Store: store}
+	h := New(cfg, spy, fakeOAuth{}, WithNow(fixedNow), WithHTTPClient(client)).Handler()
+	key := createAccountAndKey(t, store, cfg, "acct_h7")
+
+	body := `{"model":"llama","stream":true,"max_tokens":20,"messages":[{"role":"user","content":"hi"}]}`
+	resp := postChat(t, h, key, body, map[string]string{"X-Request-ID": "77777777-7777-4777-8777-777777777777"})
+	if resp.Code != http.StatusOK {
+		t.Fatalf("expected a committed 200 stream despite settle failure; got %d body=%s", resp.Code, resp.Body.String())
+	}
+
+	got := gatewaySettlementSnapshot(t, dbPath, "acct_h7")
+	if got.usageRows != 0 {
+		t.Fatalf("expected the audit row to be DROPPED (INV-8 gap); usageRows=%d — if this is 1, "+
+			"settlement became crash-durable; update the audit", got.usageRows)
+	}
+	if got.refundedRows != 1 || got.activeRows != 0 || got.activeReserved != 0 {
+		t.Fatalf("expected clean refund after the drop; got %+v (want refunded=1 active=0 reserved=0)", got)
+	}
+	t.Logf("CONFIRMED FINDING (INV-8 gap): buyer received a committed 200 stream, but the "+
+		"settlement double-failure DROPPED the usage row (usageRows=0) and refunded — "+
+		"tokens delivered, nobody billed, no durable journal (chat_proxy.go:1974-1993; "+
+		"fix = a durable append-only settlement journal).")
+}
+
+// settleFailSpyStore forces the settleAfterCommit double-failure branch: SettleReservation
+// fails, then the EnsureUsageEvent fallback also fails → the gateway logs, refunds
+// (delegated to the real store), and drops the audit row. ReserveQuota + RefundReservation
+// are inherited from the embedded *sqlite.Store so the reservation is created then refunded.
+type settleFailSpyStore struct {
+	*sqlite.Store
+}
+
+func (s *settleFailSpyStore) SettleReservation(context.Context, storage.ReservationSettlement) error {
+	return errors.New("injected settle failure (H7)")
+}
+
+func (s *settleFailSpyStore) EnsureUsageEvent(context.Context, storage.UsageEvent) error {
+	return errors.New("injected usage-event fallback failure (H7)")
+}


### PR DESCRIPTION
PR 0 of the seam-hardening epic #770: lands the audit risk register (`audits/seam-hardening/`) and the executable tripwire regression tests that every child issue's acceptance criterion references.

## What this adds

- `audits/seam-hardening/README.md` — audit method + seam taxonomy
- `audits/seam-hardening/findings.md` — risk register (per-finding verdict, file:line, failure scenario, fix, tripwire)
- `audits/seam-hardening/harness/README.md` — harness design, run commands, results table (verified 2026-07-26, re-verified on this branch)
- `phase5-gateway/internal/router/seam_harness_test.go` — H1/H2/H5a/H5b/H6/H7
- `phase4-coordinator/internal/buyer/seam_h3_test.go` — H3 (+H4 documented skip)

## No behavior change

Docs + test files only. The "confirms FAIL/GAP" tests (H1, H3, H5a, H7) deliberately assert the **buggy-today** behavior so they flip red when each fix lands — a durable per-finding regression tripwire. Fix PRs (#759–#769) will flip the corresponding assertions.

## Verification on this branch (off 15f95d9f)

```
phase5-gateway:     go test ./internal/router/ -run TestSeam  → 6 PASS, 2 pointer-SKIP
phase4-coordinator: go test ./internal/buyer/  -run TestSeamH → H3 PASS, H4 documented SKIP
```

## Governance note

`spec-index / check` will be red on this PR: `audits/**` and test files are non-governance paths, but this PR has no behavior change and no spec to honestly cite. The check is advisory (not in the `ci-required` context); merging past the red per established convention rather than fabricating a spec link.

SPEC-GOVERNANCE-DECLARATION-BEGIN
{
  "schema_version": "spec-pr-governance-v1",
  "behavior_change": "none",
  "contract_change": "none",
  "specs": [],
  "requirements": [],
  "authority_domains": [],
  "arbitration": [],
  "tests": ["phase5-gateway/internal/router/seam_harness_test.go", "phase4-coordinator/internal/buyer/seam_h3_test.go"],
  "journeys": ["not-required"],
  "issue": "https://github.com/Augustas11/macprovider/issues/770"
}
SPEC-GOVERNANCE-DECLARATION-END

🤖 Generated with [Claude Code](https://claude.com/claude-code)
