### PR TITLE
Seam hardening P0: attestation-tier surfaces (#759) + no strike on buyer cancel (#761)

### DIFF
--- a/audits/seam-hardening/harness/README.md
+++ b/audits/seam-hardening/harness/README.md
@@ -38,7 +38,8 @@ cd phase4-coordinator && go test ./internal/buyer/  -run TestSeamH -v
 
 | Scenario | Finding | Verdict | What executes |
 |---|---|---|---|
-| **H3** `RelayTimeoutStrikesOnBuyerCancel` | P0-3 | **PASS = confirms FAIL** | one `ErrRelayTimeout` + a cancelled buyer ctx (threshold=1) → provider struck to `StateDegraded` |
+| **H3** `RelayTimeoutStrikesOnBuyerCancel` | P0-3 | **FIXED (#761) — asserts guard** | one `ErrRelayTimeout` + a cancelled buyer ctx (threshold=1) → cancel terminal, provider stays `StateReady` |
+| **H3s** `RelayTimeoutNoStrikeOnBuyerCancel` | P0-3 | **FIXED (#761) — asserts guard** | streaming twin, 20 iterations across the select race — provider stays `StateReady` |
 | **H4** `SingleTerminalWins` | P2-1 | **SKIP (documented)** | not unit-testable: no arbiter joins the billing terminal and the buyer-504 terminal; testable only once a single-terminal arbiter exists |
 
 The "confirms FAIL/GAP" tests pass by asserting the **buggy-today** behavior, so when a fix lands

--- a/phase4-coordinator/internal/buyer/seam_h3_test.go
+++ b/phase4-coordinator/internal/buyer/seam_h3_test.go
@@ -20,14 +20,14 @@ import (
 	"github.com/rs/zerolog"
 )
 
-// H3 · relay-timeout strikes provider health on a buyer cancel (INV-3).
-// EXPECTED: PASS = confirms the bug. The ErrRelayTimeout branch
-// (internal/buyer/server.go:2994-2996) calls recordBreakerFault WITHOUT the
-// r.Context().Err() buyer-cancel guard that its ErrRelayClosed sibling has
-// (:2997-3002). So a buyer/gateway cancel racing a relay timeout penalizes the
-// provider. With breakerThreshold=1 a single fault flips it to StateDegraded,
-// observed via the registry snapshot. When the guard is added, the provider
-// stays StateReady and this test flips red — a regression tripwire for the fix.
+// H3 · relay-timeout must NOT strike provider health on a buyer cancel (INV-3,
+// fixed by #761). The ErrRelayTimeout branch in forwardWSNonStreaming now
+// carries the same r.Context().Err() buyer-cancel guard as its ErrRelayClosed
+// sibling (streaming twin guarded in forwardWSStreamingBuffered), so a
+// buyer/gateway cancel racing a relay timeout is attributed to the buyer, not
+// the provider. With breakerThreshold=1 a single wrongly-recorded fault would
+// flip the provider to StateDegraded — this asserts the cancel terminal is
+// returned and the provider stays StateReady. Regression tripwire for #761.
 func TestSeamH3_RelayTimeoutStrikesOnBuyerCancel(t *testing.T) {
 	const providerID, assignedID = "p1", "current"
 	at := time.Unix(1716768000, 0).UTC()
@@ -63,11 +63,14 @@ func TestSeamH3_RelayTimeoutStrikesOnBuyerCancel(t *testing.T) {
 
 	result, attempt := s.forwardWSNonStreaming(w, r, "req-h3", provider, relay, nil, nil, 1)
 
-	if result != wsForwardTimedOut {
-		t.Fatalf("expected wsForwardTimedOut, got %v", result)
+	if result != wsForwardCancelled {
+		t.Fatalf("expected wsForwardCancelled (buyer-cancel guard, #761), got %v", result)
 	}
-	if attempt.Status != http.StatusGatewayTimeout {
-		t.Fatalf("expected 504 timeout attempt, got %d", attempt.Status)
+	if attempt.Status != http.StatusOK {
+		t.Fatalf("expected cancel attempt status 200, got %d", attempt.Status)
+	}
+	if attempt.FaultFlag != "" {
+		t.Fatalf("expected no breaker-qualifying fault flag on a buyer cancel, got %q", attempt.FaultFlag)
 	}
 
 	var got pool.State
@@ -80,15 +83,66 @@ func TestSeamH3_RelayTimeoutStrikesOnBuyerCancel(t *testing.T) {
 	if !found {
 		t.Fatalf("provider %q not found in registry snapshot", providerID)
 	}
-	if got != pool.StateDegraded {
-		t.Fatalf("H3: expected the provider to be struck to Degraded by a relay-timeout fault "+
-			"under a cancelled buyer ctx (the confirmed bug), got state %v. If it stayed Ready, "+
-			"the missing r.Context().Err() guard was ADDED at server.go:2994 — update the audit", got)
+	if got != pool.StateReady {
+		t.Fatalf("H3 REGRESSION (INV-3/#761): a relay timeout racing a cancelled buyer ctx struck "+
+			"provider health (state %v, want Ready). The ErrRelayTimeout branch in "+
+			"forwardWSNonStreaming must check r.Context().Err() before recordBreakerFault, "+
+			"mirroring its ErrRelayClosed sibling.", got)
 	}
-	t.Logf("CONFIRMED FINDING (INV-3): relay-timeout struck provider health (→Degraded) despite a "+
-		"cancelled buyer context — the ErrRelayTimeout branch (server.go:2994) lacks the buyer-cancel "+
-		"guard its ErrRelayClosed sibling has (:2997). Fix: add `if r.Context().Err()!=nil { return }` "+
-		"before recordBreakerFault. (Streaming twin: forwardWSStreamingBuffered :3299.)")
+}
+
+// H3-streaming · twin of H3 for the streaming relay path (#761). The
+// forwardWSStreaming ErrRelayTimeout branch carries the same buyer-cancel
+// guard. With a cancelled buyer ctx AND a pending ErrRelayTimeout the select
+// picks either case at random, so each iteration exercises the guarded timeout
+// branch with ~50% probability; 20 iterations make an unguarded strike
+// (provider → Degraded at threshold=1) practically certain to be caught.
+func TestSeamH3Streaming_RelayTimeoutNoStrikeOnBuyerCancel(t *testing.T) {
+	const providerID, assignedID = "p1", "current"
+	at := time.Unix(1716768000, 0).UTC()
+
+	for i := 0; i < 20; i++ {
+		reg := pool.NewRegistry(nil)
+		reg.Register(&pool.Provider{
+			ProviderID:       providerID,
+			AssignedID:       assignedID,
+			State:            pool.StateReady,
+			SlotsFree:        1,
+			SlotsTotal:       1,
+			MaxConcurrency:   1,
+			MaxContextTokens: 20000,
+			LastHeartbeatAt:  at,
+			LastActivityAt:   at,
+		}, nil)
+		s := NewServer(reg, zerolog.Nop(), at, WithBreakerConfig(1, 120*time.Second))
+		provider := pool.Provider{ProviderID: providerID, AssignedID: assignedID}
+
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+		r := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", nil).WithContext(ctx)
+		w := httptest.NewRecorder()
+
+		errCh := make(chan error, 1)
+		errCh <- providerws.ErrRelayTimeout
+		relay := &providerws.RelayStream{RequestID: "req-h3s", Errors: errCh}
+
+		result, attempt := s.forwardWSStreaming(w, r, "req-h3s", provider, relay, nil, 1)
+
+		if result != wsForwardCancelled {
+			t.Fatalf("iter %d: expected wsForwardCancelled, got %v", i, result)
+		}
+		if attempt.Status != http.StatusOK {
+			t.Fatalf("iter %d: expected cancel attempt status 200, got %d", i, attempt.Status)
+		}
+		for _, p := range reg.Snapshot() {
+			if p.ProviderID == providerID && p.State != pool.StateReady {
+				t.Fatalf("iter %d: H3-streaming REGRESSION (#761): relay timeout racing a cancelled "+
+					"buyer ctx struck provider health (state %v, want Ready) — the ErrRelayTimeout "+
+					"branch in forwardWSStreaming must check r.Context().Err() before "+
+					"recordBreakerFault", i, p.State)
+			}
+		}
+	}
 }
 
 // H4 · single-terminal-wins / paid-while-buyer-told-timeout (INV-6).

--- a/phase4-coordinator/internal/buyer/seam_h3_test.go
+++ b/phase4-coordinator/internal/buyer/seam_h3_test.go
@@ -91,13 +91,24 @@ func TestSeamH3_RelayTimeoutStrikesOnBuyerCancel(t *testing.T) {
 	}
 }
 
-// H3-streaming · twin of H3 for the streaming relay path (#761). The
-// forwardWSStreaming ErrRelayTimeout branch carries the same buyer-cancel
-// guard. With a cancelled buyer ctx AND a pending ErrRelayTimeout the select
-// picks either case at random, so each iteration exercises the guarded timeout
-// branch with ~50% probability; 20 iterations make an unguarded strike
-// (provider → Degraded at threshold=1) practically certain to be caught.
+// H3-streaming · twin of H3 for the streaming relay paths (#761). The
+// ErrRelayTimeout branch in forwardWSStreaming and the relay.Errors case in
+// forwardWSStreamingBuffered carry the same buyer-cancel guard as their
+// non-streaming sibling. With a cancelled buyer ctx AND a pending relay error
+// the select picks either case at random, so each iteration exercises the
+// guarded error branch with ~50% probability; 20 iterations make an unguarded
+// strike (provider → Degraded at threshold=1) or a mis-attributed failure
+// terminal practically certain to be caught. The buffered subtest forces the
+// buffered path via the per-request kill-switch env.
 func TestSeamH3Streaming_RelayTimeoutNoStrikeOnBuyerCancel(t *testing.T) {
+	t.Run("incremental", func(t *testing.T) { seamH3StreamingScenario(t) })
+	t.Run("buffered", func(t *testing.T) {
+		t.Setenv("COORDINATOR_STREAMING_FORCE_BUFFERED", "1")
+		seamH3StreamingScenario(t)
+	})
+}
+
+func seamH3StreamingScenario(t *testing.T) {
 	const providerID, assignedID = "p1", "current"
 	at := time.Unix(1716768000, 0).UTC()
 

--- a/phase4-coordinator/internal/buyer/server.go
+++ b/phase4-coordinator/internal/buyer/server.go
@@ -905,7 +905,10 @@ func attestationStateForProviders(providers []pool.Provider) tier2PredicateState
 			continue
 		}
 		total++
-		if p.AttestationStatus == pool.AttestationStatusAttested {
+		// Only hardware-rooted attestation counts: a self-signed SE key
+		// satisfies AttestationStatusAttested but proves key custody, not
+		// hardware trust, and must not be surfaced as attested.
+		if p.AttestationStatus == pool.AttestationStatusAttested && p.AttestationTier == pool.AttestationTierHardware {
 			attested++
 		} else {
 			unsupported++
@@ -2995,6 +2998,9 @@ func (s *Server) forwardWSNonStreaming(w http.ResponseWriter, r *http.Request, r
 			markProviderDone()
 			s.log.Warn().Err(err).Str("request_id", requestID).Str("provider_id", provider.ProviderID).Msg("ws relay failed")
 			if errors.Is(err, providerws.ErrRelayTimeout) {
+				if r.Context().Err() != nil {
+					return wsForwardCancelled, requestLogAttempt{Status: http.StatusOK, Error: "Buyer disconnected during request", EstimatedCompTokens: estimatedCompletion()}
+				}
 				s.recordBreakerFault(provider, breakerFaultRelayTimeout, requestID)
 				return wsForwardTimedOut, requestLogAttempt{Status: http.StatusGatewayTimeout, Error: "Selected provider timed out; buyer should retry", EstimatedCompTokens: estimatedCompletion(), FaultFlag: billing.FaultBreakerQualifying}
 			} else if errors.Is(err, providerws.ErrRelayClosed) {
@@ -3299,6 +3305,9 @@ func (s *Server) forwardWSStreaming(w http.ResponseWriter, r *http.Request, requ
 				return wsForwardProviderDisconnectedCommitted, requestLogAttempt{Status: http.StatusOK, Error: "Provider disconnected during streaming", EstimatedCompTokens: s.estimatedCompletionTokensFromBytes(bytesEmitted), FaultFlag: billing.FaultBreakerQualifying, SettlementOutput: settlementTracker.output(billing.TerminalStateUpstreamTransportDisconnect)}
 			}
 			if errors.Is(err, providerws.ErrRelayTimeout) {
+				if r.Context().Err() != nil {
+					return wsForwardCancelled, progressAttempt("Buyer disconnected during streaming", billing.FaultNone)
+				}
 				s.recordBreakerFault(provider, breakerFaultRelayTimeout, requestID)
 				if !committed {
 					return wsForwardTimedOut, requestLogAttempt{Status: http.StatusGatewayTimeout, Error: "Selected provider timed out; buyer should retry", EstimatedCompTokens: s.estimatedCompletionTokensFromBytes(bytesEmitted), FaultFlag: billing.FaultBreakerQualifying}

--- a/phase4-coordinator/internal/buyer/server.go
+++ b/phase4-coordinator/internal/buyer/server.go
@@ -3466,6 +3466,9 @@ func (s *Server) forwardWSStreamingBuffered(w http.ResponseWriter, r *http.Reque
 		case err := <-relay.Errors:
 			markProviderDone()
 			s.log.Warn().Err(err).Str("request_id", requestID).Str("provider_id", provider.ProviderID).Msg("ws buffered streaming relay failed")
+			if r.Context().Err() != nil {
+				return wsForwardCancelled, requestLogAttempt{Status: http.StatusOK, Error: "Buyer disconnected during buffered streaming", FaultFlag: billing.FaultNone}
+			}
 			if toolFinal.toolOpened && s.streamingDowngrade != nil {
 				s.streamingDowngrade.recordMalformed(streamingBuyer, provider.ProviderID, s.now())
 			}

--- a/phase4-coordinator/internal/buyer/server_test.go
+++ b/phase4-coordinator/internal/buyer/server_test.go
@@ -886,6 +886,15 @@ func TestInternalRoutingExposesEncryptedLegAndAttestationMetadata(t *testing.T) 
 	registry := pool.NewRegistry(nil)
 	registerTier2Provider(registry, "encrypted", "session-encrypted", "model-a", "https://encrypted.example", true, pool.AttestationStatusAttested)
 	registerTier2Provider(registry, "plain", "session-plain", "model-a", "https://plain.example", false, pool.AttestationStatusUnsupported)
+	// A status-attested provider with only a self-signed SE key must NOT count
+	// as attested on this surface (#759) — only hardware-tier attestation does.
+	registerTier2Provider(registry, "selfsigned", "session-selfsigned", "model-a", "https://selfsigned.example", false, pool.AttestationStatusAttested)
+	if !registry.SetSEPublicKey("encrypted", "session-encrypted", make([]byte, 64), pool.AttestationTierHardware) {
+		t.Fatal("failed to set hardware attestation tier on provider \"encrypted\"")
+	}
+	if !registry.SetSEPublicKey("selfsigned", "session-selfsigned", make([]byte, 64), pool.AttestationTierSelfSigned) {
+		t.Fatal("failed to set self-signed attestation tier on provider \"selfsigned\"")
+	}
 	server := buyer.NewServer(
 		registry,
 		zerolog.Nop(),
@@ -921,10 +930,12 @@ func TestInternalRoutingExposesEncryptedLegAndAttestationMetadata(t *testing.T) 
 	if err := json.Unmarshal(rr.Body.Bytes(), &got); err != nil {
 		t.Fatalf("json: %v", err)
 	}
-	if got.Tier2.EncryptedLeg.State != "partial" || got.Tier2.EncryptedLeg.EncryptedProviderCount != 1 || got.Tier2.EncryptedLeg.UnencryptedProviderCount != 1 || !got.Tier2.EncryptedLeg.Mixed || got.Tier2.EncryptedLeg.Scope != "coordinator_to_provider_only" {
+	if got.Tier2.EncryptedLeg.State != "partial" || got.Tier2.EncryptedLeg.EncryptedProviderCount != 1 || got.Tier2.EncryptedLeg.UnencryptedProviderCount != 2 || !got.Tier2.EncryptedLeg.Mixed || got.Tier2.EncryptedLeg.Scope != "coordinator_to_provider_only" {
 		t.Fatalf("encrypted leg metadata = %+v body=%s", got.Tier2.EncryptedLeg, rr.Body.String())
 	}
-	if got.Tier2.Attestation.State != "partial" || got.Tier2.Attestation.AttestedProviderCount != 1 || got.Tier2.Attestation.UnsupportedProviderCount != 1 || !got.Tier2.Attestation.Mixed {
+	// Only the hardware-tier provider counts as attested; the self-signed
+	// status-attested provider lands in the unsupported bucket (#759).
+	if got.Tier2.Attestation.State != "partial" || got.Tier2.Attestation.AttestedProviderCount != 1 || got.Tier2.Attestation.UnsupportedProviderCount != 2 || !got.Tier2.Attestation.Mixed {
 		t.Fatalf("attestation metadata = %+v body=%s", got.Tier2.Attestation, rr.Body.String())
 	}
 }

--- a/phase4-coordinator/internal/pool/provider.go
+++ b/phase4-coordinator/internal/pool/provider.go
@@ -59,6 +59,12 @@ const (
 	AttestationStatusUnsupported AttestationStatus = "unsupported"
 	AttestationStatusNotRequired AttestationStatus = "not_required"
 
+	// AttestationTier values (see Provider.AttestationTier). A self-signed SE
+	// key proves key custody, not hardware-rooted attestation — only
+	// AttestationTierHardware may be surfaced as hardware-attested.
+	AttestationTierSelfSigned = "self_signed"
+	AttestationTierHardware   = "hardware"
+
 	// AuthBearerValidated — connect arrived with a Bearer header that
 	// auth.Store.ValidateToken matched. Post-flag-flip this is the
 	// only admitted state.

--- a/phase4-coordinator/internal/stats/poolsnapshot/poolsnapshot.go
+++ b/phase4-coordinator/internal/stats/poolsnapshot/poolsnapshot.go
@@ -74,7 +74,10 @@ func (p *Provider) OverviewSnapshot() statsrollup.OverviewSnapshot {
 		}
 		snap.NodesOnline++
 		snap.CapacityEligibleProviderIDs = append(snap.CapacityEligibleProviderIDs, prov.ProviderID)
-		if prov.AttestationStatus == pool.AttestationStatusAttested {
+		// Hardware-attested means hardware-rooted attestation, not key custody:
+		// a self-signed SE key satisfies AttestationStatusAttested but must not
+		// count toward the public nodes_hardware_attested figure.
+		if prov.AttestationStatus == pool.AttestationStatusAttested && prov.AttestationTier == pool.AttestationTierHardware {
 			snap.NodesHardwareAttested++
 		}
 		snap.UnifiedRAMGBTotal += prov.RAMGB

--- a/phase4-coordinator/internal/stats/poolsnapshot/poolsnapshot_test.go
+++ b/phase4-coordinator/internal/stats/poolsnapshot/poolsnapshot_test.go
@@ -112,18 +112,23 @@ func TestExcludesPendingReceiptPubkey(t *testing.T) {
 }
 
 func TestHardwareAttestedSubset(t *testing.T) {
+	// Only hardware-tier attestation counts as hardware-attested (#759): a
+	// self-signed SE key (or a bare attested status with no tier) proves key
+	// custody, not hardware trust, and must not inflate the public figure.
 	src := fakeSrc{
-		{ProviderID: "a", State: pool.StateReady, AttestationStatus: pool.AttestationStatusAttested},
+		{ProviderID: "a", State: pool.StateReady, AttestationStatus: pool.AttestationStatusAttested, AttestationTier: pool.AttestationTierSelfSigned},
 		{ProviderID: "b", State: pool.StateReady, AttestationStatus: pool.AttestationStatusStale},
 		{ProviderID: "c", State: pool.StateReady, AttestationStatus: pool.AttestationStatusNotRequired},
-		{ProviderID: "d", State: pool.StateBusy, AttestationStatus: pool.AttestationStatusAttested},
+		{ProviderID: "d", State: pool.StateBusy, AttestationStatus: pool.AttestationStatusAttested, AttestationTier: pool.AttestationTierHardware},
+		{ProviderID: "e", State: pool.StateReady, AttestationStatus: pool.AttestationStatusAttested},
 	}
 	got := newFixed(src).OverviewSnapshot()
-	if got.NodesOnline != 4 {
-		t.Fatalf("NodesOnline=%d want 4", got.NodesOnline)
+	if got.NodesOnline != 5 {
+		t.Fatalf("NodesOnline=%d want 5", got.NodesOnline)
 	}
-	if got.NodesHardwareAttested != 2 {
-		t.Fatalf("NodesHardwareAttested=%d want 2", got.NodesHardwareAttested)
+	if got.NodesHardwareAttested != 1 {
+		t.Fatalf("NodesHardwareAttested=%d want 1 (only the hardware-tier provider; "+
+			"self-signed and tierless attested keys are key-custody, not hardware)", got.NodesHardwareAttested)
 	}
 }
 

--- a/phase4-coordinator/internal/ws/server.go
+++ b/phase4-coordinator/internal/ws/server.go
@@ -1775,7 +1775,7 @@ func (s *Server) handleV2Conn(conn net.Conn, connectionAuth providerAuth, payloa
 	entry.AttestationStatus = attestationStatus
 	if attestResult.SEResult != nil {
 		entry.SEPublicKey = append([]byte(nil), attestResult.SEResult.SEPublicKey...)
-		entry.AttestationTier = "self_signed"
+		entry.AttestationTier = pool.AttestationTierSelfSigned
 	}
 	if len(initial.ProviderReceiptPubkey) > 0 {
 		entry.ReceiptPubkey = append([]byte(nil), initial.ProviderReceiptPubkey...)


### PR DESCRIPTION
Closes #759. Closes #761. PR 1 of epic #770 (P0 tier, cheapest-first pair).

## #759 — Attestation surfaces reflect hardware tier, not key-custody

`nodes_hardware_attested` (pool snapshot → public network-stats) and the `/internal/routing` tier2 attestation state were computed from `AttestationStatus == "attested"`, which a self-signed **software** P-256 key satisfies. Both now additionally require `AttestationTier == "hardware"` (never emitted today, so both surfaces report zero/non-attested for the current fleet — matching our buyer-facing prose). Adds `pool.AttestationTierSelfSigned` / `pool.AttestationTierHardware` constants; the ws tier-set site now uses the constant. Field names and JSON shapes unchanged.

## #761 — No provider-health strike / failure attribution on buyer cancellation

The `ErrRelayTimeout` branches in `forwardWSNonStreaming` and `forwardWSStreaming` now check `r.Context().Err()` before `recordBreakerFault`, mirroring their `ErrRelayClosed` siblings. A buyer cancel racing a relay timeout is attributed to the buyer (cancel terminal, no breaker-qualifying fault) instead of striking the provider — two strikes in 120s would have degraded it out of routing.

Additionally (found by the security audit lane, R1): `forwardWSStreamingBuffered`'s `relay.Errors` case returned a 502 failure attempt with a breaker-qualifying fault flag on the same race — no breaker strike, but wrong billing/request-log attribution. Same guard applied there, returning the buffered path's own buyer-cancel terminal shape.

Completeness note: the issue pointed at `forwardWSStreamingBuffered:3299` for the streaming twin; the actual second breaker-strike site is in `forwardWSStreaming` (the buffered case never struck the breaker — its gap was attribution-only, now also fixed). The HTTP streaming path already guards ctx before its timeout fault. Verified this is the complete set.

## Tests

- `TestSeamH3_RelayTimeoutStrikesOnBuyerCancel` **flipped** per the #761 acceptance criterion: now asserts the cancel terminal + provider stays `Ready` (was: confirms the strike). Negative-checked: reverting the guards makes it fail.
- New `TestSeamH3Streaming_RelayTimeoutNoStrikeOnBuyerCancel` with `incremental` and `buffered` subtests (buffered forced via `t.Setenv(COORDINATOR_STREAMING_FORCE_BUFFERED)`), 20 iterations each across the select race.
- `TestHardwareAttestedSubset` updated to tier-gated semantics (hardware / self-signed / tierless cases) — this is the #759 acceptance test (software-key provider not counted).
- `TestInternalRoutingExposesEncryptedLegAndAttestationMetadata` extended with a hardware-tier and a self-signed provider; only the hardware one counts as attested.

Full `phase4-coordinator` `go vet ./... && go test ./...` green (pre- and post-rebase).

## Audit (three codex lanes, full `origin/main...HEAD` diff)

- code R1: **PASS (0C/0H/0M)** — one LOW carried: the streaming twin is probabilistic as a revert detector (select race; 20 iterations ⇒ ~1-in-2²⁰ escape odds per subtest). Documented, not blocking.
- architect R1: **PASS (0C/0H/0M)** — findings: none; validated with `-count=50` seam-test runs and the tier2 verifier scripts.
- security R1: FAIL (1 MEDIUM — the buffered-path attribution gap above) → fixed in this PR → security R2: **PASS (0C/0H/0M)**.

SPEC-GOVERNANCE-DECLARATION-BEGIN
{
  "schema_version": "spec-pr-governance-v1",
  "behavior_change": "yes",
  "contract_change": "none",
  "specs": ["SPEC-008", "SPEC-017", "SPEC-002", "SPEC-033"],
  "requirements": ["SPEC-033-R001"],
  "authority_domains": ["tier2-trust-evidence", "network-stats", "coordinator-admission-routing"],
  "arbitration": ["CODE_BUG"],
  "tests": ["phase4-coordinator/internal/buyer/seam_h3_test.go", "phase4-coordinator/internal/stats/poolsnapshot/poolsnapshot_test.go"],
  "journeys": ["not-required"],
  "issue": "https://github.com/Augustas11/macprovider/issues/770"
}
SPEC-GOVERNANCE-DECLARATION-END

🤖 Generated with [Claude Code](https://claude.com/claude-code)
