### PR TITLE
Seam hardening P0: per-phase deadlines replace the flat request wall (#760)

### DIFF
--- a/audits/seam-hardening/findings.md
+++ b/audits/seam-hardening/findings.md
@@ -34,12 +34,25 @@ key-custody (e.g. `nodes_key_attested`). Buyer prose already says "no hardware a
 the schema up to the prose. *Tripwire: none yet (add a pool-snapshot unit test).*
 
 **P0-2 · Single request wall-clock kills healthy long generations** — `ranking` — test `TestSeamH1`
-`upCtx = context.WithTimeout(r.Context(), CoordinatorTimeout())` (`phase5-gateway/.../chat_proxy.go:122`,
-default 300s) spans the whole request; enforced on a mid-stream generation via the transport closing
-the body on `upCtx` expiry (the read loop at `:1047` is on `r.Context()`+the 10s idle timer). A
-legitimate long stream that keeps emitting is cut at the wall → 5xx against our public error rate.
-**Fix:** decompose into admission/connect + first-token + decode-progress (the 10s idle timer) +
-a `max_tokens`-derived safety ceiling; coordinate with the coordinator per-attempt ctx.
+**FIXED gateway-side (issue #760).** `upCtx = context.WithTimeout(r.Context(), CoordinatorTimeout())`
+(`phase5-gateway/.../chat_proxy.go:122`, default 300s) spanned the whole request; it was enforced on a
+mid-stream generation via the transport closing the body on `upCtx` expiry (the read loop is on
+`r.Context()`+the idle timer). A legitimate long stream that kept emitting was cut at the wall → 5xx
+against our public error rate. The wall had a second, hidden copy in `http.Client.Timeout`
+(`cmd/gateway/main.go`), which also covers body reads.
+**Fix (shipped):** one cancel funnel (`context.WithCancelCause`) with per-phase budgets in
+`phase5-gateway/internal/router/request_deadlines.go` — `admission` (120s) → `first_token` (120s) →
+a never-re-armed `stream_ceiling` = clamp(60s + `max_tokens`×250ms, ≥ `coordinator_request_seconds`,
+≤ 900s) — plus the decode-idle timer converted from "any byte" to CONTENT progress, `Client.Timeout`
+dropped to 0 with the connect budget moved to dial/TLS, and the concurrency lease scaled to the
+effective ceiling. Non-streaming keeps a flat wall (`non_stream_request_seconds`, 300s, unchanged).
+`TestSeamH1` flipped to `ProgressingStreamSurvivesLegacyWall` (PASS = certifies the fix).
+**Residual (not fixed here):** the coordinator has the same flat-wall shape one hop up
+(`phase4-coordinator/internal/buyer/server.go` attempt ctx, `routing.request_timeout_s` 280s;
+`providerhttp/client.go` 300s), so buyer-visible improvement past ~280s needs the prod overlay raised
+to ≥ the gateway ceiling and `check-deploy-config.sh` C2/C2b retargeted at the streaming ceiling.
+Structured-output streams also keep a hard 300s sub-ceiling: SPEC-019 v0.2.4 §AC-V2-9 pins that
+number, and raising it is a contract change requiring a spec amendment.
 
 **P0-3 · Provider health struck on buyer/gateway cancellation** — `supply` — test `TestSeamH3`
 The `ErrRelayTimeout` branch (`phase4-coordinator/internal/buyer/server.go:2994-2996`) calls

--- a/audits/seam-hardening/harness/README.md
+++ b/audits/seam-hardening/harness/README.md
@@ -26,7 +26,7 @@ cd phase4-coordinator && go test ./internal/buyer/  -run TestSeamH -v
 
 | Scenario | Finding | Verdict | What executes |
 |---|---|---|---|
-| **H1** `FlatWallKillsProgressingStream` | P0-2 | **PASS = confirms FAIL** | a steadily-progressing stream is cut at the (shortened) total wall, never hitting the idle timer |
+| **H1** `ProgressingStreamSurvivesLegacyWall` | P0-2 | **PASS = certifies FIX** (#760) | a steadily-progressing stream runs 3s past a 1s legacy wall and completes with `[DONE]`, no `provider_disconnected`, clean usage outcome |
 | **H2** `BuyerDisconnectSettlesConsumerSide` | — | **PASS** | buyer-cancel → consumer-side settle, billed bounded to delivered |
 | **H5a** `IdlessRetryDoubleBills` | P1-1 | **PASS = confirms FAIL** | two id-less calls bill 40 (2×20) |
 | **H5b** `StableRequestIDBillsOnce` | P1-1 | **PASS** (control) | same-UUID 2nd call → 409, billed once (20) |
@@ -47,10 +47,27 @@ they flip to failing-until-the-assertion-is-updated — a durable regression tri
 
 ## Mechanism note (surfaced by wiring H1)
 
-The total wall is `upCtx = context.WithTimeout(r.Context(), CoordinatorTimeout())`
+The total wall **was** `upCtx = context.WithTimeout(r.Context(), CoordinatorTimeout())`
 (`chat_proxy.go:122`); the upstream request is created with it (`http.NewRequestWithContext(upCtx,…)`).
-The streaming read loop selects on `r.Context()` + the 10s idle timer (`:1047`), **not** `upCtx` — so
-the total wall reaches a mid-stream generation only because the real `net/http.Transport` closes the
+The streaming read loop selects on `r.Context()` + the idle timer, **not** `upCtx` — so
+the total wall reached a mid-stream generation only because the real `net/http.Transport` closes the
 body when `upCtx` expires. A naive mock pipe ignores ctx and would let a stream outlive the wall (a
 test artifact, not a code fix); `seamStreamingUpstreamCtx` honors the request ctx to emulate the real
-transport, confirming P0-2 faithfully.
+transport, which is what made the original P0-2 confirmation faithful — and is exactly what makes the
+flipped test a real regression tripwire now.
+
+**Post-#760.** That wall is replaced by one cancel funnel with per-phase budgets
+(`phase5-gateway/internal/router/request_deadlines.go`): `admission` → `first_token` →
+a never-re-armed `stream_ceiling` derived from `max_tokens`, plus the idle timer converted from
+"any byte" to CONTENT progress. Non-streaming keeps its flat wall
+(`timeouts.non_stream_request_seconds`, unchanged 300s). H1 therefore flipped from
+"PASS = confirms FAIL" to "PASS = certifies FIX", with the scenario itself untouched.
+
+The wall had a **second copy** the harness cannot see: `http.Client.Timeout` in `cmd/gateway/main.go`,
+which also covers body reads. Fixing only the request context would have been a production no-op, so
+the client is now built by a testable `newCoordinatorClient(cfg)` with `Timeout: 0` and a dedicated
+regression test (`cmd/gateway`, `TestCoordinatorClientHasNoBodyTimeout`, `httptest.NewServer`-backed).
+
+The companion clocks in the harness suite live in
+`phase5-gateway/internal/router/request_deadlines_test.go` (ceiling on an endless stream, heartbeat-only
+stream vs. content progress, first-token phase, cause-based structured-output timeout).

--- a/phase5-gateway/cmd/gateway/main.go
+++ b/phase5-gateway/cmd/gateway/main.go
@@ -5,6 +5,7 @@ import (
 	"flag"
 	"fmt"
 	"log/slog"
+	"net"
 	"net/http"
 	"os"
 	"os/signal"
@@ -80,21 +81,7 @@ func main() {
 	go runReservationReaper(ctx, store, time.Duration(cfg.Quotas.ReaperIntervalHours)*time.Hour)
 	go runOAuthStatePruner(ctx, store, time.Minute)
 
-	// coordinatorTransport clones the default transport and adds
-	// ResponseHeaderTimeout so buyers get a bounded failure if the coordinator
-	// holds the connection without sending headers. This timeout must be at
-	// least as long as coordinator_request_seconds — neither non-streaming
-	// (full-buffer) nor streaming (post-#92: first commit-worthy SSE event)
-	// coordinator responses commit headers earlier than provider work
-	// completion. A 60s default pre-#92 silently failed any non-streaming
-	// inference > 60s and now any streaming inference whose first valid event
-	// took > 60s; the new 300s default tracks the full request budget.
-	coordinatorTransport := http.DefaultTransport.(*http.Transport).Clone()
-	coordinatorTransport.ResponseHeaderTimeout = cfg.CoordinatorHeaderTimeout()
-	coordinatorClient := &http.Client{
-		Timeout:   cfg.CoordinatorTimeout(),
-		Transport: coordinatorTransport,
-	}
+	coordinatorClient := newCoordinatorClient(cfg)
 	oauthClient := &http.Client{Timeout: 30 * time.Second}
 	oauth := auth.NewGitHubProvider(cfg.Auth.OAuth.GitHub, oauthClient)
 	gatewayRouter := router.New(cfg, store, oauth,
@@ -125,6 +112,36 @@ func main() {
 		slog.Warn("gateway shutdown error", "error", err)
 	}
 	slog.Info("gateway shutdown complete")
+}
+
+// newCoordinatorClient builds the coordinator-facing HTTP client.
+//
+// Client.Timeout is deliberately ZERO. Pre-#760 it was
+// coordinator_request_seconds, which made it a SECOND flat wall — one that
+// covers body reads, so it cut a healthy streaming generation at 300s no
+// matter what the request context allowed. The router's per-phase deadlines
+// (internal/router/request_deadlines.go) are the only request-level clock now;
+// leaving Client.Timeout set would silently override them and make the
+// decomposition a production no-op (the router tests inject a Timeout-less
+// client, so they cannot see this wall — hence this function exists to be
+// tested directly).
+//
+// The transport keeps two bounded budgets:
+//   - dial + TLS handshake = coordinator_connect_seconds. A hung TCP/TLS
+//     handshake is never legitimate work, so it fails fast.
+//   - ResponseHeaderTimeout = coordinator_header_timeout_seconds, UNCHANGED.
+//     It must NOT be lowered to the connect budget: neither non-streaming
+//     (full-buffer) nor streaming (post-#92: first commit-worthy SSE event)
+//     coordinator responses commit headers before provider work completes,
+//     and shortening it reintroduces the #92 / #171 regression where a
+//     slow-but-valid inference false-failed as coordinator_unavailable.
+func newCoordinatorClient(cfg config.Config) *http.Client {
+	transport := http.DefaultTransport.(*http.Transport).Clone()
+	transport.ResponseHeaderTimeout = cfg.CoordinatorHeaderTimeout()
+	connect := cfg.CoordinatorConnectTimeout()
+	transport.DialContext = (&net.Dialer{Timeout: connect, KeepAlive: 30 * time.Second}).DialContext
+	transport.TLSHandshakeTimeout = connect
+	return &http.Client{Timeout: 0, Transport: transport}
 }
 
 func newHTTPServer(addr string, handler http.Handler) *http.Server {

--- a/phase5-gateway/cmd/gateway/main_test.go
+++ b/phase5-gateway/cmd/gateway/main_test.go
@@ -2,10 +2,14 @@ package main
 
 import (
 	"context"
+	"io"
 	"net/http"
+	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
+	"github.com/augstar/macprovider-gateway/internal/config"
 	"github.com/augstar/macprovider-gateway/internal/router"
 )
 
@@ -138,5 +142,77 @@ func TestRunSettlementReconcilerRunsOnInterval(t *testing.T) {
 	case <-done:
 	case <-time.After(time.Second):
 		t.Fatal("settlement reconciler did not stop after interval test cancellation")
+	}
+}
+
+// TestCoordinatorClientHasNoBodyTimeout is the production half of issue #760.
+//
+// The router's per-phase deadlines are invisible from inside the router tests,
+// which inject their own Timeout-less http.Client. In production the real
+// client used to carry Timeout = coordinator_request_seconds — a SECOND flat
+// wall that covers BODY reads, so decomposing the request context alone would
+// have been a no-op: a healthy stream would still have died at the same 300s.
+//
+// The test drives the real newCoordinatorClient against a real
+// httptest.NewServer that commits headers immediately and then dribbles body
+// bytes for longer than coordinator_request_seconds. If Client.Timeout is ever
+// reintroduced, the body read fails here.
+func TestCoordinatorClientHasNoBodyTimeout(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream; charset=utf-8")
+		w.WriteHeader(http.StatusOK)
+		flusher, _ := w.(http.Flusher)
+		for i := 0; i < 6; i++ {
+			_, _ = io.WriteString(w, "data: {\"delta\":\"x\"}\n\n")
+			if flusher != nil {
+				flusher.Flush()
+			}
+			time.Sleep(250 * time.Millisecond)
+		}
+	}))
+	defer srv.Close()
+
+	cfg := config.Default()
+	// A 1s legacy wall: any request-spanning client timeout derived from it
+	// cuts the ~1.5s body below.
+	cfg.Timeouts.CoordinatorRequestSeconds = 1
+	client := newCoordinatorClient(cfg)
+
+	if client.Timeout != 0 {
+		t.Fatalf("coordinator client Timeout=%s; it MUST be 0 — a client-level timeout is a hidden "+
+			"second request wall that overrides the router's per-phase deadlines (#760)", client.Timeout)
+	}
+	transport, ok := client.Transport.(*http.Transport)
+	if !ok {
+		t.Fatalf("coordinator transport is %T, want *http.Transport", client.Transport)
+	}
+	if transport.ResponseHeaderTimeout != cfg.CoordinatorHeaderTimeout() {
+		t.Fatalf("ResponseHeaderTimeout=%s want %s — lowering it to the connect budget reintroduces the #92/#171 regression",
+			transport.ResponseHeaderTimeout, cfg.CoordinatorHeaderTimeout())
+	}
+	if transport.TLSHandshakeTimeout != cfg.CoordinatorConnectTimeout() {
+		t.Fatalf("TLSHandshakeTimeout=%s want the connect budget %s", transport.TLSHandshakeTimeout, cfg.CoordinatorConnectTimeout())
+	}
+	if transport.DialContext == nil {
+		t.Fatal("DialContext is nil; the connect budget is not applied to dialling")
+	}
+
+	start := time.Now()
+	resp, err := client.Get(srv.URL)
+	if err != nil {
+		t.Fatalf("coordinator request failed: %v", err)
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	elapsed := time.Since(start)
+	if err != nil {
+		t.Fatalf("body read failed after %s: %v — a hidden client-level wall is back", elapsed, err)
+	}
+	if elapsed <= cfg.CoordinatorTimeout() {
+		t.Fatalf("body completed in %s, which is within coordinator_request_seconds (%s) — the test "+
+			"no longer exercises a body read that outlives the legacy wall", elapsed, cfg.CoordinatorTimeout())
+	}
+	if !strings.Contains(string(body), "data: ") {
+		t.Fatalf("unexpected body %q", string(body))
 	}
 }

--- a/phase5-gateway/gateway.yaml.example
+++ b/phase5-gateway/gateway.yaml.example
@@ -95,10 +95,45 @@ timeouts:
   # provider doesn't false-fail with coordinator_unavailable here, while the
   # 300s total bound still fails fast on a truly hung coordinator.
   coordinator_header_timeout_seconds: 300
+  # --- issue #760: per-phase deadlines (streaming path) -------------------
+  # coordinator_request_seconds above is no longer the streaming wall. It is
+  # kept as (a) the deploy-gate C2/C2b anchor and (b) the FLOOR of the derived
+  # streaming ceiling below, so decomposing the wall can only ever let a
+  # request live longer than it does today, never cut one that survives.
+  #
+  # TCP dial + TLS handshake budget. A hung handshake is never legitimate
+  # work. Deliberately NOT applied to response headers — shortening
+  # coordinator_header_timeout_seconds reintroduces the #92 / #171 regression
+  # where a slow-but-valid inference false-failed as coordinator_unavailable.
+  coordinator_connect_seconds: 60
+  # Gateway first byte of request -> coordinator response headers, across the
+  # whole 503/502 retry loop. This is the one real behavior change of #760: a
+  # pre-header hang now fails at 120s instead of 300s.
+  coordinator_admission_seconds: 120
+  # Response headers -> first content-bearing SSE delta. Must be
+  # <= coordinator_header_timeout_seconds (the transport gives up first).
+  first_token_seconds: 120
+  # Hard streaming safety ceiling, derived from the request's max_tokens:
+  #   clamp(floor + max_tokens * per_token_ms,
+  #         >= coordinator_request_seconds, <= max)
+  # Armed once at gateway first byte of request and never re-armed, so no
+  # amount of upstream progress can push it out. stream_ceiling_max_seconds
+  # is the operator dial for how long one account_concurrency slot can be
+  # held (quotas.account_concurrency x this value in the worst case).
+  stream_ceiling_floor_seconds: 60
+  stream_ceiling_per_token_ms: 250
+  stream_ceiling_max_seconds: 900
+  # Non-streaming requests keep a single flat wall: the coordinator buffers
+  # the whole response, so there is no intermediate phase to observe. Same
+  # 300s as the legacy wall — zero behavior change on that path.
+  non_stream_request_seconds: 300
   streaming_cancel_ms: 500
   # Post-first-byte stream idle timeout. If the coordinator stops producing
   # SSE bytes, terminate with provider_timeout before buyer clients hit their
-  # own shorter request deadlines.
+  # own shorter request deadlines. #760 made this a CONTENT-progress budget:
+  # it is re-based only by a frame carrying generated text, so a provider that
+  # keeps the socket warm with role-only, keepalive, or usage-only frames no
+  # longer holds the stream open indefinitely.
   streaming_idle_ms: 10000
 
 retry_503:

--- a/phase5-gateway/gateway.yaml.example
+++ b/phase5-gateway/gateway.yaml.example
@@ -124,9 +124,10 @@ timeouts:
   stream_ceiling_per_token_ms: 250
   stream_ceiling_max_seconds: 900
   # Non-streaming requests keep a single flat wall: the coordinator buffers
-  # the whole response, so there is no intermediate phase to observe. Same
-  # 300s as the legacy wall — zero behavior change on that path.
-  non_stream_request_seconds: 300
+  # the whole response, so there is no intermediate phase to observe.
+  # 0 (or unset) inherits coordinator_request_seconds — zero behavior change
+  # on that path, including configs that raised only the legacy wall.
+  non_stream_request_seconds: 0
   streaming_cancel_ms: 500
   # Post-first-byte stream idle timeout. If the coordinator stops producing
   # SSE bytes, terminate with provider_timeout before buyer clients hit their

--- a/phase5-gateway/gateway.yaml.example
+++ b/phase5-gateway/gateway.yaml.example
@@ -110,9 +110,10 @@ timeouts:
   # whole 503/502 retry loop. This is the one real behavior change of #760: a
   # pre-header hang now fails at 120s instead of 300s.
   coordinator_admission_seconds: 120
-  # Response headers -> first content-bearing SSE delta. Must be
+  # Response headers -> first content-bearing SSE delta. 0 (or unset) derives
+  # min(120, coordinator_header_timeout_seconds); an explicit value must be
   # <= coordinator_header_timeout_seconds (the transport gives up first).
-  first_token_seconds: 120
+  first_token_seconds: 0
   # Hard streaming safety ceiling, derived from the request's max_tokens:
   #   clamp(floor + max_tokens * per_token_ms,
   #         >= coordinator_request_seconds, <= max)

--- a/phase5-gateway/internal/config/config.go
+++ b/phase5-gateway/internal/config/config.go
@@ -152,7 +152,9 @@ type TimeoutsConfig struct {
 	StreamCeilingMaxSeconds   int `yaml:"stream_ceiling_max_seconds"`
 	// NonStreamRequestSeconds is the flat wall retained for non-streaming
 	// requests, where the coordinator buffers the whole response and there
-	// are no intermediate phases to observe.
+	// are no intermediate phases to observe. 0 (the default) inherits
+	// coordinator_request_seconds, so a pre-#760 config that raised only the
+	// legacy wall keeps its non-streaming bound unchanged.
 	NonStreamRequestSeconds int `yaml:"non_stream_request_seconds"`
 	StreamingCancelMS       int `yaml:"streaming_cancel_ms"`
 	StreamingIdleMS         int `yaml:"streaming_idle_ms"`
@@ -259,7 +261,7 @@ func Default() Config {
 			StreamCeilingFloorSeconds:   60,
 			StreamCeilingPerTokenMS:     250,
 			StreamCeilingMaxSeconds:     900,
-			NonStreamRequestSeconds:     300,
+			NonStreamRequestSeconds:     0, // inherit coordinator_request_seconds
 			StreamingCancelMS:           500,
 			StreamingIdleMS:             10000,
 		},
@@ -494,7 +496,7 @@ func (c Config) Validate() error {
 	if c.Timeouts.CoordinatorConnectSeconds <= 0 || c.Timeouts.CoordinatorAdmissionSeconds <= 0 ||
 		c.Timeouts.FirstTokenSeconds <= 0 || c.Timeouts.StreamCeilingFloorSeconds <= 0 ||
 		c.Timeouts.StreamCeilingPerTokenMS <= 0 || c.Timeouts.StreamCeilingMaxSeconds <= 0 ||
-		c.Timeouts.NonStreamRequestSeconds <= 0 {
+		c.Timeouts.NonStreamRequestSeconds < 0 {
 		return fmt.Errorf("timeouts phase budgets must be positive")
 	}
 	if c.Timeouts.CoordinatorAdmissionSeconds < c.Timeouts.CoordinatorConnectSeconds {
@@ -520,8 +522,8 @@ func (c Config) Validate() error {
 		return fmt.Errorf("timeouts.stream_ceiling_max_seconds (%d) must be >= timeouts.coordinator_request_seconds (%d) — the per-phase streaming ceiling must never be shorter than the flat wall it replaces",
 			c.Timeouts.StreamCeilingMaxSeconds, c.Timeouts.CoordinatorRequestSeconds)
 	}
-	if c.Timeouts.NonStreamRequestSeconds < c.Timeouts.CoordinatorConnectSeconds {
-		return fmt.Errorf("timeouts.non_stream_request_seconds (%d) must be >= timeouts.coordinator_connect_seconds (%d)",
+	if c.Timeouts.NonStreamRequestSeconds > 0 && c.Timeouts.NonStreamRequestSeconds < c.Timeouts.CoordinatorConnectSeconds {
+		return fmt.Errorf("timeouts.non_stream_request_seconds (%d) must be >= timeouts.coordinator_connect_seconds (%d), or 0 to inherit coordinator_request_seconds",
 			c.Timeouts.NonStreamRequestSeconds, c.Timeouts.CoordinatorConnectSeconds)
 	}
 	if !c.Settlement.ReconcileEnabled {
@@ -689,7 +691,12 @@ func (c Config) FirstTokenTimeout() time.Duration {
 }
 
 // NonStreamRequestTimeout is the flat wall retained for non-streaming
-// requests (unchanged behavior: same 300s default as the legacy wall).
+// requests. Unset (0) inherits CoordinatorTimeout so a pre-#760 config that
+// raised only coordinator_request_seconds keeps its non-streaming bound
+// (#760 audit, architect lane).
 func (c Config) NonStreamRequestTimeout() time.Duration {
+	if c.Timeouts.NonStreamRequestSeconds <= 0 {
+		return c.CoordinatorTimeout()
+	}
 	return time.Duration(c.Timeouts.NonStreamRequestSeconds) * time.Second
 }

--- a/phase5-gateway/internal/config/config.go
+++ b/phase5-gateway/internal/config/config.go
@@ -130,8 +130,32 @@ type CapacityConfig struct {
 type TimeoutsConfig struct {
 	CoordinatorRequestSeconds       int `yaml:"coordinator_request_seconds"`
 	CoordinatorHeaderTimeoutSeconds int `yaml:"coordinator_header_timeout_seconds"`
-	StreamingCancelMS               int `yaml:"streaming_cancel_ms"`
-	StreamingIdleMS                 int `yaml:"streaming_idle_ms"`
+	// Issue #760 per-phase deadlines. These replace the single flat
+	// request wall on the STREAMING path; the non-streaming path keeps a
+	// flat wall (non_stream_request_seconds). YAML-only by design — the
+	// env: resolver is secrets-only, so there are no env overrides here.
+	//
+	// CoordinatorConnectSeconds bounds TCP dial + TLS handshake to the
+	// coordinator (transport-level, per connection attempt).
+	CoordinatorConnectSeconds int `yaml:"coordinator_connect_seconds"`
+	// CoordinatorAdmissionSeconds bounds gateway first-byte-of-request to
+	// coordinator response headers, ACROSS the 503/502 retry loop.
+	CoordinatorAdmissionSeconds int `yaml:"coordinator_admission_seconds"`
+	// FirstTokenSeconds bounds response headers to the first
+	// content-bearing delta on a streaming response.
+	FirstTokenSeconds int `yaml:"first_token_seconds"`
+	// StreamCeiling* derive the hard streaming safety bound from the
+	// request's max_tokens: clamp(floor + max_tokens*per_token,
+	// >= coordinator_request_seconds, <= max).
+	StreamCeilingFloorSeconds int `yaml:"stream_ceiling_floor_seconds"`
+	StreamCeilingPerTokenMS   int `yaml:"stream_ceiling_per_token_ms"`
+	StreamCeilingMaxSeconds   int `yaml:"stream_ceiling_max_seconds"`
+	// NonStreamRequestSeconds is the flat wall retained for non-streaming
+	// requests, where the coordinator buffers the whole response and there
+	// are no intermediate phases to observe.
+	NonStreamRequestSeconds int `yaml:"non_stream_request_seconds"`
+	StreamingCancelMS       int `yaml:"streaming_cancel_ms"`
+	StreamingIdleMS         int `yaml:"streaming_idle_ms"`
 }
 
 type SettlementConfig struct {
@@ -219,7 +243,26 @@ func Default() Config {
 		Capacity: CapacityConfig{
 			MonthlyBudgetUSD: 500, ReadyProviderDegradedThreshold: 1, ProjectedCostTier1Percent: 80, TierCooldownSeconds: 3600,
 		},
-		Timeouts: TimeoutsConfig{CoordinatorRequestSeconds: 300, CoordinatorHeaderTimeoutSeconds: 300, StreamingCancelMS: 500, StreamingIdleMS: 10000},
+		Timeouts: TimeoutsConfig{
+			CoordinatorRequestSeconds:       300,
+			CoordinatorHeaderTimeoutSeconds: 300,
+			// #760 defaults. Connect 60s (NOT 15s) so a provider warmup
+			// window behind a cold coordinator does not 503 the buyer.
+			// Admission 120s fails a pre-header hang ~2.5x faster than the
+			// old 300s wall. First token 120s covers a slow prefill.
+			// Ceiling 60s + 250ms/token, capped at 900s and floored at
+			// coordinator_request_seconds so it is never shorter than the
+			// flat wall it replaces.
+			CoordinatorConnectSeconds:   60,
+			CoordinatorAdmissionSeconds: 120,
+			FirstTokenSeconds:           120,
+			StreamCeilingFloorSeconds:   60,
+			StreamCeilingPerTokenMS:     250,
+			StreamCeilingMaxSeconds:     900,
+			NonStreamRequestSeconds:     300,
+			StreamingCancelMS:           500,
+			StreamingIdleMS:             10000,
+		},
 		Settlement: SettlementConfig{
 			ReconcileEnabled:               true,
 			ReconcileIntervalSeconds:       30,
@@ -447,6 +490,40 @@ func (c Config) Validate() error {
 		return fmt.Errorf("timeouts.coordinator_header_timeout_seconds (%d) must be >= timeouts.coordinator_request_seconds (%d) — see SPEC-002 FR-P11a (post-#92)",
 			c.Timeouts.CoordinatorHeaderTimeoutSeconds, c.Timeouts.CoordinatorRequestSeconds)
 	}
+	// Issue #760 per-phase deadline orderings.
+	if c.Timeouts.CoordinatorConnectSeconds <= 0 || c.Timeouts.CoordinatorAdmissionSeconds <= 0 ||
+		c.Timeouts.FirstTokenSeconds <= 0 || c.Timeouts.StreamCeilingFloorSeconds <= 0 ||
+		c.Timeouts.StreamCeilingPerTokenMS <= 0 || c.Timeouts.StreamCeilingMaxSeconds <= 0 ||
+		c.Timeouts.NonStreamRequestSeconds <= 0 {
+		return fmt.Errorf("timeouts phase budgets must be positive")
+	}
+	if c.Timeouts.CoordinatorAdmissionSeconds < c.Timeouts.CoordinatorConnectSeconds {
+		return fmt.Errorf("timeouts.coordinator_admission_seconds (%d) must be >= timeouts.coordinator_connect_seconds (%d) — admission spans the connect attempt plus the retry loop",
+			c.Timeouts.CoordinatorAdmissionSeconds, c.Timeouts.CoordinatorConnectSeconds)
+	}
+	// Twin of the C2b rule above, for the first-token phase: the transport
+	// gives up on a header-less coordinator after coordinator_header_timeout_
+	// seconds, so a first_token budget beyond that can never be observed —
+	// streaming headers commit at the first commit-worthy SSE event (post-#92).
+	if c.Timeouts.CoordinatorHeaderTimeoutSeconds < c.Timeouts.FirstTokenSeconds {
+		return fmt.Errorf("timeouts.coordinator_header_timeout_seconds (%d) must be >= timeouts.first_token_seconds (%d) — the transport header timeout bounds the first commit-worthy SSE event",
+			c.Timeouts.CoordinatorHeaderTimeoutSeconds, c.Timeouts.FirstTokenSeconds)
+	}
+	if c.Timeouts.StreamCeilingMaxSeconds < c.Timeouts.StreamCeilingFloorSeconds {
+		return fmt.Errorf("timeouts.stream_ceiling_max_seconds (%d) must be >= timeouts.stream_ceiling_floor_seconds (%d)",
+			c.Timeouts.StreamCeilingMaxSeconds, c.Timeouts.StreamCeilingFloorSeconds)
+	}
+	// Monotonicity invariant (#760): the derived streaming ceiling floors at
+	// coordinator_request_seconds, so a max BELOW it would make the clamp
+	// self-contradictory and hide a config that intended to SHORTEN the wall.
+	if c.Timeouts.StreamCeilingMaxSeconds < c.Timeouts.CoordinatorRequestSeconds {
+		return fmt.Errorf("timeouts.stream_ceiling_max_seconds (%d) must be >= timeouts.coordinator_request_seconds (%d) — the per-phase streaming ceiling must never be shorter than the flat wall it replaces",
+			c.Timeouts.StreamCeilingMaxSeconds, c.Timeouts.CoordinatorRequestSeconds)
+	}
+	if c.Timeouts.NonStreamRequestSeconds < c.Timeouts.CoordinatorConnectSeconds {
+		return fmt.Errorf("timeouts.non_stream_request_seconds (%d) must be >= timeouts.coordinator_connect_seconds (%d)",
+			c.Timeouts.NonStreamRequestSeconds, c.Timeouts.CoordinatorConnectSeconds)
+	}
 	if !c.Settlement.ReconcileEnabled {
 		return fmt.Errorf("settlement.reconcile_enabled must be true")
 	}
@@ -585,4 +662,34 @@ func (c Config) CoordinatorHeaderTimeout() time.Duration {
 
 func (c Config) StreamingIdleTimeout() time.Duration {
 	return time.Duration(c.Timeouts.StreamingIdleMS) * time.Millisecond
+}
+
+// The accessors below back the issue #760 per-phase deadlines. See
+// TimeoutsConfig for what each phase bounds and
+// phase5-gateway/internal/router/request_deadlines.go for how they are armed.
+
+// CoordinatorConnectTimeout bounds TCP dial + TLS handshake on the
+// coordinator transport. It is deliberately NOT applied to response headers:
+// making the header timeout this short reintroduces the #92/#171 regression
+// where a slow-but-valid first SSE event false-failed as coordinator_unavailable.
+func (c Config) CoordinatorConnectTimeout() time.Duration {
+	return time.Duration(c.Timeouts.CoordinatorConnectSeconds) * time.Second
+}
+
+// CoordinatorAdmissionTimeout bounds gateway first byte of request to
+// coordinator response headers, across the whole 503/502 retry loop.
+func (c Config) CoordinatorAdmissionTimeout() time.Duration {
+	return time.Duration(c.Timeouts.CoordinatorAdmissionSeconds) * time.Second
+}
+
+// FirstTokenTimeout bounds response headers to the first content-bearing
+// streaming delta.
+func (c Config) FirstTokenTimeout() time.Duration {
+	return time.Duration(c.Timeouts.FirstTokenSeconds) * time.Second
+}
+
+// NonStreamRequestTimeout is the flat wall retained for non-streaming
+// requests (unchanged behavior: same 300s default as the legacy wall).
+func (c Config) NonStreamRequestTimeout() time.Duration {
+	return time.Duration(c.Timeouts.NonStreamRequestSeconds) * time.Second
 }

--- a/phase5-gateway/internal/config/config.go
+++ b/phase5-gateway/internal/config/config.go
@@ -141,7 +141,8 @@ type TimeoutsConfig struct {
 	// CoordinatorAdmissionSeconds bounds gateway first-byte-of-request to
 	// coordinator response headers, ACROSS the 503/502 retry loop.
 	CoordinatorAdmissionSeconds int `yaml:"coordinator_admission_seconds"`
-	// FirstTokenSeconds bounds response headers to the first
+	// FirstTokenSeconds (0 = derive: min(120, coordinator_header_timeout_
+	// seconds)) bounds response headers to the first
 	// content-bearing delta on a streaming response.
 	FirstTokenSeconds int `yaml:"first_token_seconds"`
 	// StreamCeiling* derive the hard streaming safety bound from the
@@ -257,7 +258,7 @@ func Default() Config {
 			// flat wall it replaces.
 			CoordinatorConnectSeconds:   60,
 			CoordinatorAdmissionSeconds: 120,
-			FirstTokenSeconds:           120,
+			FirstTokenSeconds:           0, // derive min(120, header timeout)
 			StreamCeilingFloorSeconds:   60,
 			StreamCeilingPerTokenMS:     250,
 			StreamCeilingMaxSeconds:     900,
@@ -494,7 +495,7 @@ func (c Config) Validate() error {
 	}
 	// Issue #760 per-phase deadline orderings.
 	if c.Timeouts.CoordinatorConnectSeconds <= 0 || c.Timeouts.CoordinatorAdmissionSeconds <= 0 ||
-		c.Timeouts.FirstTokenSeconds <= 0 || c.Timeouts.StreamCeilingFloorSeconds <= 0 ||
+		c.Timeouts.FirstTokenSeconds < 0 || c.Timeouts.StreamCeilingFloorSeconds <= 0 ||
 		c.Timeouts.StreamCeilingPerTokenMS <= 0 || c.Timeouts.StreamCeilingMaxSeconds <= 0 ||
 		c.Timeouts.NonStreamRequestSeconds < 0 {
 		return fmt.Errorf("timeouts phase budgets must be positive")
@@ -507,8 +508,12 @@ func (c Config) Validate() error {
 	// gives up on a header-less coordinator after coordinator_header_timeout_
 	// seconds, so a first_token budget beyond that can never be observed —
 	// streaming headers commit at the first commit-worthy SSE event (post-#92).
-	if c.Timeouts.CoordinatorHeaderTimeoutSeconds < c.Timeouts.FirstTokenSeconds {
-		return fmt.Errorf("timeouts.coordinator_header_timeout_seconds (%d) must be >= timeouts.first_token_seconds (%d) — the transport header timeout bounds the first commit-worthy SSE event",
+	// Only an EXPLICIT first_token budget can conflict with the transport
+	// header timeout; the derived default (0) clamps itself to it, so a
+	// pre-#760 config with a short header timeout still boots (the CI
+	// integration fixtures use 60s, and prod configs are off-repo).
+	if c.Timeouts.FirstTokenSeconds > 0 && c.Timeouts.CoordinatorHeaderTimeoutSeconds < c.Timeouts.FirstTokenSeconds {
+		return fmt.Errorf("timeouts.coordinator_header_timeout_seconds (%d) must be >= timeouts.first_token_seconds (%d) — the transport header timeout bounds the first commit-worthy SSE event; set first_token_seconds to 0 to derive it",
 			c.Timeouts.CoordinatorHeaderTimeoutSeconds, c.Timeouts.FirstTokenSeconds)
 	}
 	if c.Timeouts.StreamCeilingMaxSeconds < c.Timeouts.StreamCeilingFloorSeconds {
@@ -685,8 +690,20 @@ func (c Config) CoordinatorAdmissionTimeout() time.Duration {
 }
 
 // FirstTokenTimeout bounds response headers to the first content-bearing
-// streaming delta.
+// streaming delta. Unset (0) derives min(120s, the transport header timeout):
+// the header timeout already acts as a de-facto first-token bound (streaming
+// headers commit at the first SSE event, post-#92), so the derived budget can
+// never promise more time than the transport allows, and short-header configs
+// (CI fixtures, conservative prod overlays) keep booting unchanged (#760 CI
+// integration failure).
 func (c Config) FirstTokenTimeout() time.Duration {
+	if c.Timeouts.FirstTokenSeconds <= 0 {
+		derived := 120 * time.Second
+		if header := c.CoordinatorHeaderTimeout(); header > 0 && header < derived {
+			derived = header
+		}
+		return derived
+	}
 	return time.Duration(c.Timeouts.FirstTokenSeconds) * time.Second
 }
 

--- a/phase5-gateway/internal/config/config_test.go
+++ b/phase5-gateway/internal/config/config_test.go
@@ -244,7 +244,7 @@ func TestPhaseDeadlineDefaults(t *testing.T) {
 	}{
 		{"coordinator_connect_seconds", cfg.Timeouts.CoordinatorConnectSeconds, 60},
 		{"coordinator_admission_seconds", cfg.Timeouts.CoordinatorAdmissionSeconds, 120},
-		{"first_token_seconds", cfg.Timeouts.FirstTokenSeconds, 120},
+		{"first_token_seconds", cfg.Timeouts.FirstTokenSeconds, 0},
 		{"stream_ceiling_floor_seconds", cfg.Timeouts.StreamCeilingFloorSeconds, 60},
 		{"stream_ceiling_per_token_ms", cfg.Timeouts.StreamCeilingPerTokenMS, 250},
 		{"stream_ceiling_max_seconds", cfg.Timeouts.StreamCeilingMaxSeconds, 900},
@@ -274,6 +274,22 @@ func TestPhaseDeadlineDefaults(t *testing.T) {
 	explicit.Timeouts.NonStreamRequestSeconds = 300
 	if got := explicit.NonStreamRequestTimeout(); got != 300*time.Second {
 		t.Errorf("explicit non_stream_request_seconds must win over inheritance, got %s want 300s", got)
+	}
+	// Unset first_token_seconds derives min(120s, header timeout) so a
+	// short-header config (CI integration fixtures use 60s) still boots and
+	// gets a coherent budget instead of a Validate rejection (#760 CI red).
+	if got := cfg.FirstTokenTimeout(); got != 120*time.Second {
+		t.Errorf("derived FirstTokenTimeout=%s want 120s under the default header timeout", got)
+	}
+	shortHeader := cfg
+	shortHeader.Timeouts.CoordinatorHeaderTimeoutSeconds = 60
+	if got := shortHeader.FirstTokenTimeout(); got != 60*time.Second {
+		t.Errorf("derived FirstTokenTimeout=%s want 60s clamped to the header timeout", got)
+	}
+	explicitFT := cfg
+	explicitFT.Timeouts.FirstTokenSeconds = 30
+	if got := explicitFT.FirstTokenTimeout(); got != 30*time.Second {
+		t.Errorf("explicit first_token_seconds must win over derivation, got %s want 30s", got)
 	}
 	if err := validTestConfig().Validate(); err != nil {
 		t.Fatalf("default phase budgets must satisfy Validate(): %v", err)
@@ -314,8 +330,13 @@ func TestValidateRejectsInconsistentPhaseDeadlines(t *testing.T) {
 			wantSub: "non_stream_request_seconds",
 		},
 		{
+			name:    "negative first token budget",
+			mutate:  func(c *Config) { c.Timeouts.FirstTokenSeconds = -1 },
+			wantSub: "phase budgets must be positive",
+		},
+		{
 			name:    "zero phase budget",
-			mutate:  func(c *Config) { c.Timeouts.FirstTokenSeconds = 0 },
+			mutate:  func(c *Config) { c.Timeouts.CoordinatorConnectSeconds = 0 },
 			wantSub: "phase budgets must be positive",
 		},
 	} {

--- a/phase5-gateway/internal/config/config_test.go
+++ b/phase5-gateway/internal/config/config_test.go
@@ -3,6 +3,7 @@ package config
 import (
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestQuotaReaperDefaults(t *testing.T) {
@@ -247,7 +248,7 @@ func TestPhaseDeadlineDefaults(t *testing.T) {
 		{"stream_ceiling_floor_seconds", cfg.Timeouts.StreamCeilingFloorSeconds, 60},
 		{"stream_ceiling_per_token_ms", cfg.Timeouts.StreamCeilingPerTokenMS, 250},
 		{"stream_ceiling_max_seconds", cfg.Timeouts.StreamCeilingMaxSeconds, 900},
-		{"non_stream_request_seconds", cfg.Timeouts.NonStreamRequestSeconds, 300},
+		{"non_stream_request_seconds", cfg.Timeouts.NonStreamRequestSeconds, 0},
 	} {
 		if tc.got != tc.want {
 			t.Errorf("%s=%d want %d", tc.name, tc.got, tc.want)
@@ -258,6 +259,21 @@ func TestPhaseDeadlineDefaults(t *testing.T) {
 	if cfg.NonStreamRequestTimeout() != cfg.CoordinatorTimeout() {
 		t.Errorf("NonStreamRequestTimeout=%s must equal the legacy CoordinatorTimeout=%s (no behavior change on the non-streaming path)",
 			cfg.NonStreamRequestTimeout(), cfg.CoordinatorTimeout())
+	}
+	// Unset non_stream_request_seconds must INHERIT an operator-raised legacy
+	// wall, not silently regress it to the compiled default (#760 audit,
+	// architect lane: a pre-#760 config setting only
+	// coordinator_request_seconds: 600 must keep 600s non-streaming).
+	inherited := cfg
+	inherited.Timeouts.CoordinatorRequestSeconds = 600
+	if got := inherited.NonStreamRequestTimeout(); got != 600*time.Second {
+		t.Errorf("NonStreamRequestTimeout with only coordinator_request_seconds raised = %s, want 600s (inherit)", got)
+	}
+	explicit := cfg
+	explicit.Timeouts.CoordinatorRequestSeconds = 600
+	explicit.Timeouts.NonStreamRequestSeconds = 300
+	if got := explicit.NonStreamRequestTimeout(); got != 300*time.Second {
+		t.Errorf("explicit non_stream_request_seconds must win over inheritance, got %s want 300s", got)
 	}
 	if err := validTestConfig().Validate(); err != nil {
 		t.Fatalf("default phase budgets must satisfy Validate(): %v", err)

--- a/phase5-gateway/internal/config/config_test.go
+++ b/phase5-gateway/internal/config/config_test.go
@@ -231,3 +231,88 @@ func validTestConfig() Config {
 	cfg.Auth.OAuth.GitHub.ClientSecret = "client-secret"
 	return cfg
 }
+
+// ---- issue #760: per-phase deadline config --------------------------------
+
+func TestPhaseDeadlineDefaults(t *testing.T) {
+	cfg := Default()
+	for _, tc := range []struct {
+		name string
+		got  int
+		want int
+	}{
+		{"coordinator_connect_seconds", cfg.Timeouts.CoordinatorConnectSeconds, 60},
+		{"coordinator_admission_seconds", cfg.Timeouts.CoordinatorAdmissionSeconds, 120},
+		{"first_token_seconds", cfg.Timeouts.FirstTokenSeconds, 120},
+		{"stream_ceiling_floor_seconds", cfg.Timeouts.StreamCeilingFloorSeconds, 60},
+		{"stream_ceiling_per_token_ms", cfg.Timeouts.StreamCeilingPerTokenMS, 250},
+		{"stream_ceiling_max_seconds", cfg.Timeouts.StreamCeilingMaxSeconds, 900},
+		{"non_stream_request_seconds", cfg.Timeouts.NonStreamRequestSeconds, 300},
+	} {
+		if tc.got != tc.want {
+			t.Errorf("%s=%d want %d", tc.name, tc.got, tc.want)
+		}
+	}
+	// The non-streaming wall must stay at the legacy flat wall so #760 is a
+	// no-op on that path.
+	if cfg.NonStreamRequestTimeout() != cfg.CoordinatorTimeout() {
+		t.Errorf("NonStreamRequestTimeout=%s must equal the legacy CoordinatorTimeout=%s (no behavior change on the non-streaming path)",
+			cfg.NonStreamRequestTimeout(), cfg.CoordinatorTimeout())
+	}
+	if err := validTestConfig().Validate(); err != nil {
+		t.Fatalf("default phase budgets must satisfy Validate(): %v", err)
+	}
+}
+
+func TestValidateRejectsInconsistentPhaseDeadlines(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		mutate  func(*Config)
+		wantSub string
+	}{
+		{
+			name:    "admission below connect",
+			mutate:  func(c *Config) { c.Timeouts.CoordinatorAdmissionSeconds = 30 },
+			wantSub: "coordinator_admission_seconds",
+		},
+		{
+			name:    "first token above header timeout",
+			mutate:  func(c *Config) { c.Timeouts.FirstTokenSeconds = 600 },
+			wantSub: "first_token_seconds",
+		},
+		{
+			name:    "ceiling max below floor",
+			mutate:  func(c *Config) { c.Timeouts.StreamCeilingFloorSeconds = 950 },
+			wantSub: "stream_ceiling_floor_seconds",
+		},
+		{
+			// Monotonicity invariant: an operator must not be able to make the
+			// derived streaming ceiling SHORTER than the flat wall it replaced.
+			name:    "ceiling max below legacy wall",
+			mutate:  func(c *Config) { c.Timeouts.StreamCeilingMaxSeconds = 120 },
+			wantSub: "stream_ceiling_max_seconds",
+		},
+		{
+			name:    "non-stream wall below connect budget",
+			mutate:  func(c *Config) { c.Timeouts.NonStreamRequestSeconds = 5 },
+			wantSub: "non_stream_request_seconds",
+		},
+		{
+			name:    "zero phase budget",
+			mutate:  func(c *Config) { c.Timeouts.FirstTokenSeconds = 0 },
+			wantSub: "phase budgets must be positive",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := validTestConfig()
+			tc.mutate(&cfg)
+			err := cfg.Validate()
+			if err == nil {
+				t.Fatalf("Validate() accepted %s", tc.name)
+			}
+			if !strings.Contains(err.Error(), tc.wantSub) {
+				t.Fatalf("Validate() error = %q, want substring %q", err.Error(), tc.wantSub)
+			}
+		})
+	}
+}

--- a/phase5-gateway/internal/router/chat_proxy.go
+++ b/phase5-gateway/internal/router/chat_proxy.go
@@ -116,11 +116,19 @@ func (s *Server) handleChatCompletions(w http.ResponseWriter, r *http.Request) {
 	start := s.now()
 	timing := newGatewayPhaseTiming(start)
 	// AC-V2-9: gateway-side first-byte-of-request is the SPEC-019 v0.2
-	// wall-clock zero-point. The 300s budget (`coordinator_request_seconds`
-	// by convention) measures from this point to provider terminal SSE frame
-	// emission. Pre-upstream gateway time counts against the budget.
-	upCtx, cancelUpstream := context.WithTimeout(r.Context(), s.cfg.CoordinatorTimeout())
-	defer cancelUpstream()
+	// wall-clock zero-point. Phases that bound the whole request are armed
+	// FROM this point, so pre-upstream gateway time (slow request-body read,
+	// quota/concurrency reservation) still counts against the budget.
+	//
+	// #760: this used to be one flat context.WithTimeout(CoordinatorTimeout())
+	// spanning admission + first token + the entire decode, which cut healthy
+	// long generations. It is now a single cancel funnel with re-armable
+	// per-phase budgets; the admission phase is armed here and narrowed or
+	// replaced once the request is parsed.
+	deadlines := newRequestDeadlines(r.Context())
+	defer deadlines.Stop()
+	deadlines.armPhaseFromStart(deadlinePhaseAdmission, s.cfg.CoordinatorAdmissionTimeout())
+	upCtx := deadlines.Context()
 	sw := &statusWriter{ResponseWriter: w, statusCode: 0}
 	w = sw
 	// Issue #190 R1 security HIGH: chat-completion responses now
@@ -138,6 +146,11 @@ func (s *Server) handleChatCompletions(w http.ResponseWriter, r *http.Request) {
 	var accountID, model string
 	var streamMode bool
 	defer func() {
+		// deadline_phase names the clock that ended the request when one
+		// did (admission / first_token / stream_ceiling / decode_idle /
+		// non_stream_wall). Operator-facing ONLY: every buyer-visible
+		// terminal keeps its existing code (provider_timeout,
+		// coordinator_unavailable), so no error-code contract widens here.
 		attrs := []any{
 			"request_id", requestID(r),
 			"account_id", accountID,
@@ -145,6 +158,7 @@ func (s *Server) handleChatCompletions(w http.ResponseWriter, r *http.Request) {
 			"stream", streamMode,
 			"wall_ms", s.now().Sub(start).Milliseconds(),
 			"status", sw.statusCode,
+			"deadline_phase", deadlines.expiredPhase(),
 		}
 		attrs = append(attrs, timing.attrs(s.now())...)
 		slog.Info("chat completion", attrs...)
@@ -223,6 +237,20 @@ func (s *Server) handleChatCompletions(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusBadRequest, "invalid_request_error", "max_tokens_exceeded", "max_tokens exceeds configured limit")
 		return
 	}
+	structuredStreaming := chat.Stream && chat.hasStructuredOutput()
+	// #760: max_tokens is now known, so the request's total bound can be
+	// armed. Streaming gets the derived safety ceiling (never shorter than
+	// the legacy flat wall); non-streaming KEEPS the flat wall, because the
+	// coordinator buffers the whole response and there is no intermediate
+	// phase to observe. Both are measured from gateway first byte of request
+	// (AC-V2-9), so this is not a budget extension for non-streaming.
+	requestBound := s.cfg.NonStreamRequestTimeout()
+	if chat.Stream {
+		requestBound = s.effectiveStreamCeiling(maxTokens, structuredStreaming)
+		deadlines.armCeiling(requestBound)
+	} else {
+		deadlines.armPhaseFromStart(deadlinePhaseNonStreamWall, requestBound)
+	}
 	promptEstimate := estimatePromptTokens(body)
 	promptReservation := promptCapTokens(body)
 	reservationTokens := promptReservation + maxTokens
@@ -289,9 +317,14 @@ func (s *Server) handleChatCompletions(w http.ResponseWriter, r *http.Request) {
 		concurrencyErrCode = "demo_concurrency_exceeded"
 		concurrencyErrMsg = "Demo concurrency limit exceeded"
 	}
+	// #760 R4: the lease must outlive the request's own bound, or a long
+	// streaming generation releases its concurrency slot while still running
+	// and reopens the M1-8 / PERF-6 pool-saturation regression. requestBound
+	// is the streaming ceiling (or the non-streaming flat wall), so the
+	// lease scales with it instead of the fixed legacy wall.
 	concurrencyDecision, concurrencyErr := s.store.AcquireConcurrency(r.Context(), storage.ConcurrencyRequest{
 		AccountID: subject.AccountID, RequestID: requestID(r), Limit: concurrencyLimit,
-		CreatedAt: s.now(), ExpiresAt: s.now().Add(s.cfg.CoordinatorTimeout() + time.Minute),
+		CreatedAt: s.now(), ExpiresAt: s.now().Add(requestBound + time.Minute),
 	})
 	if errors.Is(concurrencyErr, storage.ErrQuotaExceeded) {
 		_ = s.store.RefundReservation(context.Background(), subject.AccountID, requestID(r), s.now().Unix())
@@ -393,11 +426,14 @@ func (s *Server) handleChatCompletions(w http.ResponseWriter, r *http.Request) {
 		}
 		return upReq, nil
 	}
-	structuredStreaming := chat.Stream && chat.hasStructuredOutput()
 	timing.markCoordinatorStart(s.now())
 	resp, retryExhausted, priorProviderDispatch, err := s.doCoordinatorChatWithRetry(upCtx, r, subject.AccountID, buildUpReq)
 	if err != nil {
-		if structuredStreaming && errors.Is(upCtx.Err(), context.DeadlineExceeded) {
+		// #760: upCtx is now cancel-with-cause, so upCtx.Err() reports
+		// context.Canceled on an expired phase budget and the legacy
+		// errors.Is(upCtx.Err(), context.DeadlineExceeded) check would
+		// silently stop matching. Ask the cause instead.
+		if _, phaseExpired := phaseDeadlineExceeded(upCtx); structuredStreaming && phaseExpired {
 			if !s.settleBeforeResponse(w, r, subject, promptEstimate, 0, maxUsageTokens, "gateway_estimated", "provider_timeout") {
 				return
 			}
@@ -417,7 +453,7 @@ func (s *Server) handleChatCompletions(w http.ResponseWriter, r *http.Request) {
 		// 17.7 fallback usage_events insert in settleAfterCommit
 		// uses the SAME window_date as the original reservation
 		// (avoids drift for streams that cross UTC midnight).
-		s.forwardStreamingChat(w, r, resp, subject, promptEstimate, maxUsageTokens, maxTokens, retryExhausted, priorProviderDispatch, cancelUpstream, upCtx, structuredStreaming, window, timing)
+		s.forwardStreamingChat(w, r, resp, subject, promptEstimate, maxUsageTokens, maxTokens, retryExhausted, priorProviderDispatch, deadlines, structuredStreaming, window, timing)
 		return
 	}
 	s.forwardNonStreamingChat(w, r, resp, subject, promptEstimate, maxUsageTokens, maxTokens, retryExhausted, priorProviderDispatch, window)
@@ -719,7 +755,9 @@ func emitProviderAttribution(dst, src http.Header) {
 	}
 }
 
-func (s *Server) forwardStreamingChat(w http.ResponseWriter, r *http.Request, resp *http.Response, subject usageSubject, promptEstimate, maxUsageTokens, maxTokens int64, retryExhausted, priorProviderDispatch bool, cancelUpstream func(), upstreamCtx context.Context, structuredStreaming bool, reservationWindow string, timing *gatewayPhaseTiming) {
+func (s *Server) forwardStreamingChat(w http.ResponseWriter, r *http.Request, resp *http.Response, subject usageSubject, promptEstimate, maxUsageTokens, maxTokens int64, retryExhausted, priorProviderDispatch bool, deadlines *requestDeadlines, structuredStreaming bool, reservationWindow string, timing *gatewayPhaseTiming) {
+	upstreamCtx := deadlines.Context()
+	cancelUpstream := deadlines.Cancel
 	if resp.StatusCode == http.StatusServiceUnavailable {
 		body, _ := io.ReadAll(resp.Body)
 		if coordinatorTier2PolicyError(resp.StatusCode, body) {
@@ -785,6 +823,11 @@ func (s *Server) forwardStreamingChat(w http.ResponseWriter, r *http.Request, re
 	w.Header().Set("X-Accel-Buffering", "no")
 	w.WriteHeader(http.StatusOK)
 	flusher, _ := w.(http.Flusher)
+	// #760: the coordinator has committed streaming headers, which post-#92
+	// means it accepted the request and is relaying provider output. The
+	// admission budget is done; from here the first content-bearing delta is
+	// on its own clock, disarmed below the moment one arrives.
+	deadlines.armPhase(deadlinePhaseFirstToken, s.cfg.FirstTokenTimeout())
 	reader := bufio.NewReaderSize(resp.Body, maxStreamingLineBytes)
 	var cancelOnce sync.Once
 	cancelCoordinator := func() {
@@ -799,6 +842,14 @@ func (s *Server) forwardStreamingChat(w http.ResponseWriter, r *http.Request, re
 		case <-done:
 		}
 	}()
+	// #760: the streaming idle timer is now an absolute CONTENT-progress
+	// deadline rather than a per-read duration. It is re-based only when a
+	// frame carries generated text (see forwardLine), so a provider that
+	// keeps the socket warm with role-only or usage-only frames no longer
+	// holds the stream open forever. A zero deadline preserves the legacy
+	// "no idle timeout" sentinel (streaming_idle_ms <= 0).
+	idleTimeout := s.cfg.StreamingIdleTimeout()
+	progressDeadline := streamingProgressDeadline(idleTimeout)
 	var emitted int64
 	var serializedEmitted int64
 	var reported *tokenUsage
@@ -960,6 +1011,19 @@ func (s *Server) forwardStreamingChat(w http.ResponseWriter, r *http.Request, re
 					return true
 				}
 				deltaBytes, hasChoices, parseOK := streamingCompletionDeltaBytes(data)
+				if deltaBytes > 0 {
+					// #760: CONTENT progress, not byte progress. Only a frame
+					// carrying generated text counts — role-only deltas, ids,
+					// keepalives and usage-only frames are exactly what a
+					// wedged provider keeps emitting, so letting them reset
+					// the idle timer made the timer unable to catch the
+					// failure it exists for. streamingCompletionDeltaBytes
+					// already excludes the role/id/type/name scaffolding keys.
+					progressDeadline = streamingProgressDeadline(idleTimeout)
+					// First content-bearing delta: the first-token phase is
+					// satisfied. Only the (never-re-armed) ceiling remains.
+					deadlines.disarmPhase()
+				}
 				frameBytes := boundedStreamingFallbackFrameBytes(line)
 				if !parseOK {
 					slog.Warn("streaming gateway estimate saw malformed chunk; truncating stream", "request_id", requestID(r))
@@ -1043,7 +1107,7 @@ func (s *Server) forwardStreamingChat(w http.ResponseWriter, r *http.Request, re
 		return true
 	}
 	for {
-		line, err := readStreamingLineWithIdleTimeout(r.Context(), reader, s.cfg.StreamingIdleTimeout(), cancelCoordinator, resp.Body)
+		line, err := readStreamingLineWithIdleTimeout(r.Context(), reader, progressDeadline, cancelCoordinator, resp.Body)
 		if errors.Is(err, bufio.ErrBufferFull) {
 			slog.Error("streaming coordinator line exceeded limit", "request_id", requestID(r), "max_line_bytes", maxStreamingLineBytes)
 			// Gateway-side truncation due to oversized line — NOT a
@@ -1058,7 +1122,12 @@ func (s *Server) forwardStreamingChat(w http.ResponseWriter, r *http.Request, re
 			return
 		}
 		if errors.Is(err, errStreamingIdleTimeout) {
-			slog.Warn("streaming coordinator idle timeout", "request_id", requestID(r), "timeout_ms", s.cfg.Timeouts.StreamingIdleMS)
+			slog.Warn("streaming coordinator idle timeout",
+				"request_id", requestID(r),
+				"timeout_ms", s.cfg.Timeouts.StreamingIdleMS,
+				"deadline_phase", deadlineReasonDecodeIdle,
+			)
+			deadlines.noteReason(deadlineReasonDecodeIdle)
 			settleIdleTimeout()
 			return
 		}
@@ -1075,6 +1144,25 @@ func (s *Server) forwardStreamingChat(w http.ResponseWriter, r *http.Request, re
 		}
 		if r.Context().Err() != nil {
 			settleCancelled()
+			return
+		}
+		// #760: a phase budget (first_token / stream_ceiling) expiring cancels
+		// the upstream, which surfaces here as a read error. That is a TIMEOUT,
+		// not a provider disconnect: it must settle through the same
+		// settleIdleTimeout funnel as the decode-idle timer so the buyer sees
+		// provider_timeout and the usage row records provider_timeout. Emitting
+		// provider_disconnected + settleTruncated here was the SPEC-019 AC-V2-9
+		// violation. settleIdleTimeout already handles the structured-output
+		// envelope and the already-forwarded-terminal-frame case, so this
+		// subsumes the former structuredStreaming-only DeadlineExceeded branch
+		// (which, post-cause-cancellation, would never match again anyway).
+		if phase, expired := phaseDeadlineExceeded(upstreamCtx); expired {
+			slog.Warn("streaming phase deadline exceeded",
+				"request_id", requestID(r),
+				"deadline_phase", phase,
+				"structured_streaming", structuredStreaming,
+			)
+			settleIdleTimeout()
 			return
 		}
 		slog.Error("streaming coordinator read failed", "request_id", requestID(r), "error", err)
@@ -1107,14 +1195,6 @@ func (s *Server) forwardStreamingChat(w http.ResponseWriter, r *http.Request, re
 		// that lands, a buyer retrying after this envelope MAY incur
 		// a fresh reservation if the coordinator's idempotency-cache
 		// response isn't refund-honored on the gateway side.
-		if structuredStreaming && errors.Is(upstreamCtx.Err(), context.DeadlineExceeded) {
-			writeStructuredOutputTimeoutSSE(w, requestID(r))
-			if flusher != nil {
-				flusher.Flush()
-			}
-			settleObservedContent("provider_timeout")
-			return
-		}
 		writeProviderDisconnectedSSE(w)
 		if flusher != nil {
 			flusher.Flush()
@@ -1147,16 +1227,40 @@ type streamingReadResult struct {
 	err  error
 }
 
-func readStreamingLineWithIdleTimeout(ctx context.Context, reader *bufio.Reader, idleTimeout time.Duration, cancelUpstream func(), body io.Closer) ([]byte, error) {
+// streamingProgressDeadline converts the configured idle budget into the
+// absolute content-progress deadline the read loop carries. It preserves the
+// legacy "no idle timeout" sentinel: a non-positive budget yields the zero
+// time, which readStreamingLineWithIdleTimeout treats as unbounded.
+func streamingProgressDeadline(idleTimeout time.Duration) time.Time {
 	if idleTimeout <= 0 {
+		return time.Time{}
+	}
+	return time.Now().Add(idleTimeout)
+}
+
+// readStreamingLineWithIdleTimeout reads one SSE line, giving up at deadline.
+//
+// #760: the parameter is an absolute CONTENT-progress deadline, not a
+// per-read duration. The caller re-bases it only when a frame carried
+// generated text, so heartbeat/keepalive/usage-only frames consume the budget
+// instead of renewing it. A zero deadline means "no idle timeout" and matches
+// the pre-#760 `idleTimeout <= 0` sentinel.
+func readStreamingLineWithIdleTimeout(ctx context.Context, reader *bufio.Reader, deadline time.Time, cancelUpstream func(), body io.Closer) ([]byte, error) {
+	if deadline.IsZero() {
 		return reader.ReadSlice('\n')
+	}
+	remaining := time.Until(deadline)
+	if remaining <= 0 {
+		cancelUpstream()
+		_ = body.Close()
+		return nil, errStreamingIdleTimeout
 	}
 	ch := make(chan streamingReadResult, 1)
 	go func() {
 		line, err := reader.ReadSlice('\n')
 		ch <- streamingReadResult{line: line, err: err}
 	}()
-	timer := time.NewTimer(idleTimeout)
+	timer := time.NewTimer(remaining)
 	defer timer.Stop()
 	select {
 	case result := <-ch:

--- a/phase5-gateway/internal/router/chat_proxy.go
+++ b/phase5-gateway/internal/router/chat_proxy.go
@@ -2283,54 +2283,50 @@ func streamingCompletionDeltaBytes(data string) (int64, bool, bool) {
 	return n, len(envelope.Choices) > 0, true
 }
 
+// generatedDeltaStringBytes counts the bytes of genuinely generated output in
+// one choice delta. It is PATH-aware, not key-aware: only the known
+// OpenAI-shape output paths count (delta.content, delta.reasoning_content,
+// delta.refusal, delta.text, delta.function_call.arguments,
+// delta.tool_calls[].function.arguments). This both bounds billing estimation
+// to real content and — since #760 — gates the streaming content-progress
+// deadline, so traversal must never descend through unknown containers: a
+// per-key allowlist would let delta:{"foo":{"content":"x"}} fabricate
+// progress and hold a slot to the stream ceiling (audit R2, code+security).
 func generatedDeltaStringBytes(raw json.RawMessage) (int64, bool) {
-	var delta any
+	var delta struct {
+		Content          *string `json:"content"`
+		ReasoningContent *string `json:"reasoning_content"`
+		Refusal          *string `json:"refusal"`
+		Text             *string `json:"text"`
+		FunctionCall     *struct {
+			Arguments *string `json:"arguments"`
+		} `json:"function_call"`
+		ToolCalls []struct {
+			Function *struct {
+				Arguments *string `json:"arguments"`
+			} `json:"function"`
+		} `json:"tool_calls"`
+	}
 	if err := json.Unmarshal(raw, &delta); err != nil {
+		// Also rejects non-object deltas, preserving the previous
+		// "delta must be a JSON object" contract.
 		return 0, false
 	}
-	if _, ok := delta.(map[string]any); !ok {
-		return 0, false
-	}
-	return countGeneratedDeltaStrings("", delta), true
-}
-
-func countGeneratedDeltaStrings(key string, value any) int64 {
-	switch v := value.(type) {
-	case map[string]any:
-		var n int64
-		for childKey, childValue := range v {
-			n += countGeneratedDeltaStrings(childKey, childValue)
+	var n int64
+	for _, s := range []*string{delta.Content, delta.ReasoningContent, delta.Refusal, delta.Text} {
+		if s != nil {
+			n += int64(len(*s))
 		}
-		return n
-	case []any:
-		var n int64
-		for _, childValue := range v {
-			n += countGeneratedDeltaStrings(key, childValue)
-		}
-		return n
-	case string:
-		if !countDeltaStringKey(key) {
-			return 0
-		}
-		return int64(len(v))
-	default:
-		return 0
 	}
-}
-
-func countDeltaStringKey(key string) bool {
-	// Allowlist of delta keys that carry genuinely generated output. This
-	// both bounds billing estimation to real content and — since #760 —
-	// gates the streaming content-progress deadline, so it must not be a
-	// denylist: an unknown key (e.g. delta:{"foo":"x"}) would otherwise let
-	// a provider reset the progress timer and hold a slot to the stream
-	// ceiling without emitting anything a client consumes.
-	switch strings.ToLower(key) {
-	case "content", "reasoning_content", "refusal", "arguments", "text":
-		return true
-	default:
-		return false
+	if delta.FunctionCall != nil && delta.FunctionCall.Arguments != nil {
+		n += int64(len(*delta.FunctionCall.Arguments))
 	}
+	for _, tc := range delta.ToolCalls {
+		if tc.Function != nil && tc.Function.Arguments != nil {
+			n += int64(len(*tc.Function.Arguments))
+		}
+	}
+	return n, true
 }
 
 func sseDataValue(line string) (string, bool) {

--- a/phase5-gateway/internal/router/chat_proxy.go
+++ b/phase5-gateway/internal/router/chat_proxy.go
@@ -428,6 +428,22 @@ func (s *Server) handleChatCompletions(w http.ResponseWriter, r *http.Request) {
 	}
 	timing.markCoordinatorStart(s.now())
 	resp, retryExhausted, priorProviderDispatch, err := s.doCoordinatorChatWithRetry(upCtx, r, subject.AccountID, buildUpReq)
+	if err == nil && resp != nil && structuredStreaming {
+		// #760 audit (code lane): the retry loop returns its last retryable
+		// 502/503 with err == nil when the admission budget expires during
+		// backoff. A structured-streaming buyer's contract is an SSE stream,
+		// so passing that JSON error through would bypass the structured
+		// provider_timeout terminal. Convert here, covering every stale-resp
+		// return path in the loop at once.
+		if _, phaseExpired := phaseDeadlineExceeded(upCtx); phaseExpired {
+			_ = resp.Body.Close()
+			if !s.settleBeforeResponse(w, r, subject, promptEstimate, 0, maxUsageTokens, "gateway_estimated", "provider_timeout") {
+				return
+			}
+			writeStructuredOutputTimeoutSSE(w, requestID(r))
+			return
+		}
+	}
 	if err != nil {
 		// #760: upCtx is now cancel-with-cause, so upCtx.Err() reports
 		// context.Canceled on an expired phase budget and the legacy
@@ -2303,11 +2319,17 @@ func countGeneratedDeltaStrings(key string, value any) int64 {
 }
 
 func countDeltaStringKey(key string) bool {
+	// Allowlist of delta keys that carry genuinely generated output. This
+	// both bounds billing estimation to real content and — since #760 —
+	// gates the streaming content-progress deadline, so it must not be a
+	// denylist: an unknown key (e.g. delta:{"foo":"x"}) would otherwise let
+	// a provider reset the progress timer and hold a slot to the stream
+	// ceiling without emitting anything a client consumes.
 	switch strings.ToLower(key) {
-	case "", "role", "id", "type", "name":
-		return false
-	default:
+	case "content", "reasoning_content", "refusal", "arguments", "text":
 		return true
+	default:
+		return false
 	}
 }
 

--- a/phase5-gateway/internal/router/request_deadlines.go
+++ b/phase5-gateway/internal/router/request_deadlines.go
@@ -1,0 +1,274 @@
+package router
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"math"
+	"sync"
+	"time"
+
+	"github.com/augstar/macprovider-gateway/internal/config"
+)
+
+// Per-phase request deadlines (issue #760 / seam finding P0-2).
+//
+// Before this file the chat proxy ran on ONE flat wall —
+// `context.WithTimeout(r.Context(), CoordinatorTimeout())` — that spanned
+// admission, first token, and the entire decode. A healthy stream that kept
+// emitting tokens was still cut at 300s, surfacing as a 5xx against our public
+// error rate even though nothing had actually stalled.
+//
+// The replacement keeps exactly ONE cancel funnel (so every existing
+// cancelUpstream/cancelCoordinator call site is unchanged) and decomposes the
+// wall into phases that are armed and re-armed as the request advances:
+//
+//	admission       gateway first byte -> coordinator response headers
+//	first_token     response headers   -> first content-bearing delta
+//	stream_ceiling  gateway first byte -> hard max_tokens-derived safety bound
+//	non_stream_wall gateway first byte -> full buffered response (flat, legacy)
+//
+// Decode progress between tokens is NOT a phase: it stays on the existing
+// streaming idle timer, which #760 converts from "any byte" to "content
+// progress" (see readStreamingLineWithIdleTimeout).
+//
+// Cancellation carries a CAUSE. Callers must therefore ask
+// phaseDeadlineExceeded(ctx) rather than errors.Is(ctx.Err(),
+// context.DeadlineExceeded): a cause-cancelled context reports
+// context.Canceled from Err(), so the legacy DeadlineExceeded checks would
+// silently stop matching.
+const (
+	deadlinePhaseAdmission     = "admission"
+	deadlinePhaseFirstToken    = "first_token"
+	deadlinePhaseStreamCeiling = "stream_ceiling"
+	deadlinePhaseNonStreamWall = "non_stream_wall"
+	// deadlineReasonDecodeIdle is not a requestDeadlines phase (the idle
+	// timer lives in the read loop) but shares the deadline_phase log field
+	// so operators see one vocabulary for every timeout terminal.
+	deadlineReasonDecodeIdle = "decode_idle"
+)
+
+// spec019StructuredStreamingCeiling is the structured-output streaming budget
+// SPEC-019 v0.2.4 pins normatively (§AC-V2-9: "300s from gateway first byte of
+// request to provider terminal SSE frame").
+//
+// TODO(#760): the max_tokens-derived ceiling below can legitimately exceed
+// 300s for large generations, and OpenRouter traffic routinely carries
+// response_format. Raising the structured bound is a SPEC-019 amendment
+// (contract_change: yes) and is deliberately NOT taken in this PR, so
+// structured streams keep the pinned 300s sub-ceiling and the contract is
+// unchanged. Revisit together with the SPEC-019 §AC-V2-9 amendment decision.
+const spec019StructuredStreamingCeiling = 300 * time.Second
+
+// phaseDeadlineError is the cancellation cause recorded when a phase budget
+// expires. It carries the phase so the terminal path can log WHICH clock ran
+// out without widening any buyer-visible error code.
+type phaseDeadlineError struct {
+	Phase string
+}
+
+func (e *phaseDeadlineError) Error() string {
+	return fmt.Sprintf("request phase deadline exceeded: %s", e.Phase)
+}
+
+// requestDeadlines owns the upstream request context and the timers that can
+// cancel it. Exactly one phase timer is armed at a time (it is re-armed as the
+// request advances); the ceiling timer is armed at most once and is never
+// re-armed, so a stream can never extend its own hard bound.
+type requestDeadlines struct {
+	ctx    context.Context
+	cancel context.CancelCauseFunc
+
+	// startedAt is real wall-clock time at handler entry, deliberately NOT
+	// the injectable s.now() clock: tests pin s.now() to a constant, and
+	// these are timer budgets, not billing timestamps. SPEC-019 AC-V2-9
+	// makes gateway first-byte-of-request the zero point, so phases that
+	// bound the whole request are armed *from start* and pre-upstream
+	// gateway time counts against them.
+	startedAt time.Time
+
+	mu      sync.Mutex
+	stopped bool
+	phase   *time.Timer
+	ceiling *time.Timer
+	// reason is an explicitly recorded terminal clock that has no
+	// cancellation cause of its own — today only the decode-idle timer,
+	// which cancels the upstream itself and reports via a sentinel error.
+	reason string
+}
+
+func newRequestDeadlines(parent context.Context) *requestDeadlines {
+	ctx, cancel := context.WithCancelCause(parent)
+	return &requestDeadlines{ctx: ctx, cancel: cancel, startedAt: time.Now()}
+}
+
+// Context returns the upstream context every coordinator request is built on.
+func (d *requestDeadlines) Context() context.Context { return d.ctx }
+
+// Cancel is the single cancel funnel handed to the streaming read loop as
+// cancelUpstream. It records a plain cancellation, so a phase cause already
+// latched by an expiring timer wins (context.CancelCauseFunc keeps the first
+// cause) and the terminal path still reports the phase that fired.
+func (d *requestDeadlines) Cancel() { d.cancel(context.Canceled) }
+
+// Stop releases the timers and cancels the context. Safe to call twice; the
+// handler defers it exactly where `defer cancelUpstream()` used to sit.
+func (d *requestDeadlines) Stop() {
+	d.mu.Lock()
+	d.stopped = true
+	if d.phase != nil {
+		d.phase.Stop()
+		d.phase = nil
+	}
+	if d.ceiling != nil {
+		d.ceiling.Stop()
+		d.ceiling = nil
+	}
+	d.mu.Unlock()
+	d.Cancel()
+}
+
+// armPhase (re-)arms the single phase timer for budget measured from now,
+// replacing whatever phase was armed before.
+func (d *requestDeadlines) armPhase(phase string, budget time.Duration) {
+	d.armPhaseAt(phase, budget)
+}
+
+// armPhaseFromStart (re-)arms the phase timer for budget measured from
+// gateway first byte of request, so slow request-body reads and pre-upstream
+// gateway work count against the budget (SPEC-019 AC-V2-9).
+func (d *requestDeadlines) armPhaseFromStart(phase string, budget time.Duration) {
+	d.armPhaseAt(phase, budget-time.Since(d.startedAt))
+}
+
+func (d *requestDeadlines) armPhaseAt(phase string, remaining time.Duration) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	if d.stopped {
+		return
+	}
+	if d.phase != nil {
+		d.phase.Stop()
+	}
+	if remaining <= 0 {
+		d.phase = nil
+		d.cancel(&phaseDeadlineError{Phase: phase})
+		return
+	}
+	d.phase = time.AfterFunc(remaining, func() {
+		d.cancel(&phaseDeadlineError{Phase: phase})
+	})
+}
+
+// disarmPhase drops the phase timer without touching the ceiling. Called once
+// the stream is demonstrably producing content: from there on, decode progress
+// is policed by the idle timer and the total by the ceiling.
+func (d *requestDeadlines) disarmPhase() {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	if d.phase != nil {
+		d.phase.Stop()
+		d.phase = nil
+	}
+}
+
+// armCeiling arms the hard streaming bound, measured from gateway first byte
+// of request. It is armed at most once and never re-armed, so no amount of
+// upstream progress can push the ceiling out.
+func (d *requestDeadlines) armCeiling(budget time.Duration) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	if d.stopped || d.ceiling != nil {
+		return
+	}
+	remaining := budget - time.Since(d.startedAt)
+	if remaining <= 0 {
+		d.cancel(&phaseDeadlineError{Phase: deadlinePhaseStreamCeiling})
+		return
+	}
+	d.ceiling = time.AfterFunc(remaining, func() {
+		d.cancel(&phaseDeadlineError{Phase: deadlinePhaseStreamCeiling})
+	})
+}
+
+// noteReason records a terminal clock that is not a cancellation cause.
+func (d *requestDeadlines) noteReason(reason string) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	if d.reason == "" {
+		d.reason = reason
+	}
+}
+
+// expiredPhase reports the clock that ended the request, or "". Used by the
+// per-request log defer to stamp deadline_phase. An explicitly noted reason
+// wins over the cancellation cause, because the idle timer cancels the
+// upstream itself and would otherwise be masked by a plain cancellation.
+func (d *requestDeadlines) expiredPhase() string {
+	d.mu.Lock()
+	reason := d.reason
+	d.mu.Unlock()
+	if reason != "" {
+		return reason
+	}
+	phase, _ := phaseDeadlineExceeded(d.ctx)
+	return phase
+}
+
+// phaseDeadlineExceeded reports whether ctx was cancelled by an expiring phase
+// budget, and which phase.
+//
+// This REPLACES errors.Is(ctx.Err(), context.DeadlineExceeded) at every call
+// site: the upstream context is now cancel-with-cause, so Err() reports
+// context.Canceled and the legacy check would never match again.
+func phaseDeadlineExceeded(ctx context.Context) (string, bool) {
+	var deadline *phaseDeadlineError
+	if errors.As(context.Cause(ctx), &deadline) {
+		return deadline.Phase, true
+	}
+	return "", false
+}
+
+// streamCeiling derives the hard streaming bound from the request's max_tokens:
+//
+//	clamp(floor + max_tokens*per_token, >= coordinator_request_seconds, <= max)
+//
+// max_tokens is never absent here — handleChatCompletions substitutes the
+// configured per-request cap and rejects anything above it before this runs.
+//
+// The lower clamp is a monotonicity invariant: the ceiling must never be
+// SHORTER than the flat wall it replaces, so decomposing the wall can only
+// ever let a request live longer, never cut one that survives today.
+// effectiveStreamCeiling is streamCeiling plus the SPEC-019 sub-ceiling that
+// still binds structured-output streams. See spec019StructuredStreamingCeiling
+// for why the pinned 300s is not raised in this change.
+func (s *Server) effectiveStreamCeiling(maxTokens int64, structuredStreaming bool) time.Duration {
+	ceiling := streamCeiling(maxTokens, s.cfg)
+	if structuredStreaming && ceiling > spec019StructuredStreamingCeiling {
+		return spec019StructuredStreamingCeiling
+	}
+	return ceiling
+}
+
+func streamCeiling(maxTokens int64, cfg config.Config) time.Duration {
+	totalMS := int64(cfg.Timeouts.StreamCeilingFloorSeconds) * 1000
+	perTokenMS := int64(cfg.Timeouts.StreamCeilingPerTokenMS)
+	maxMS := int64(cfg.Timeouts.StreamCeilingMaxSeconds) * 1000
+	if maxTokens > 0 && perTokenMS > 0 {
+		// Saturate instead of overflowing: max_tokens is operator-configurable
+		// (limits.max_tokens_per_request) and the clamp below discards the
+		// saturated value anyway.
+		if maxTokens > (math.MaxInt64-totalMS)/perTokenMS {
+			totalMS = math.MaxInt64
+		} else {
+			totalMS += maxTokens * perTokenMS
+		}
+	}
+	if totalMS > maxMS {
+		totalMS = maxMS
+	}
+	if minMS := int64(cfg.Timeouts.CoordinatorRequestSeconds) * 1000; totalMS < minMS {
+		totalMS = minMS
+	}
+	return time.Duration(totalMS) * time.Millisecond
+}

--- a/phase5-gateway/internal/router/request_deadlines_test.go
+++ b/phase5-gateway/internal/router/request_deadlines_test.go
@@ -1,0 +1,374 @@
+package router
+
+import (
+	"context"
+	"errors"
+	"io"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/augstar/macprovider-gateway/internal/config"
+)
+
+// ---- unit: the derived streaming ceiling -----------------------------------
+
+// TestStreamCeilingNeverBelowLegacyWall pins the monotonicity invariant that
+// makes removing the flat wall safe: whatever max_tokens a buyer asks for, the
+// derived ceiling is never SHORTER than coordinator_request_seconds, so #760
+// can only let a request live longer than it does today — never cut one that
+// survives today.
+func TestStreamCeilingNeverBelowLegacyWall(t *testing.T) {
+	cfg := config.Default()
+	legacy := cfg.CoordinatorTimeout()
+	max := time.Duration(cfg.Timeouts.StreamCeilingMaxSeconds) * time.Second
+
+	var previous time.Duration
+	for _, maxTokens := range []int64{1, 16, 128, 512, 1024, 4096, 65536, 1 << 40, 1<<63 - 1} {
+		got := streamCeiling(maxTokens, cfg)
+		if got < legacy {
+			t.Fatalf("streamCeiling(max_tokens=%d)=%s is BELOW the legacy wall %s", maxTokens, got, legacy)
+		}
+		if got > max {
+			t.Fatalf("streamCeiling(max_tokens=%d)=%s exceeds stream_ceiling_max_seconds %s", maxTokens, got, max)
+		}
+		if got < previous {
+			t.Fatalf("streamCeiling is not monotonic in max_tokens: %d -> %s after %s", maxTokens, got, previous)
+		}
+		previous = got
+	}
+
+	// The formula itself, on a value that lands strictly between the clamps:
+	// floor 60s + 2000 * 250ms = 560s (below the 900s max, above the 300s
+	// legacy floor).
+	if got, want := streamCeiling(2000, cfg), 560*time.Second; got != want {
+		t.Fatalf("streamCeiling(2000)=%s want %s (floor + max_tokens*per_token)", got, want)
+	}
+	// Below the crossover the legacy floor dominates — that IS the
+	// monotonicity guarantee, not a bug.
+	if got, want := streamCeiling(512, cfg), legacy; got != want {
+		t.Fatalf("streamCeiling(512)=%s want the legacy floor %s", got, want)
+	}
+	// A legacy wall raised above the derived value floors the result.
+	raised := cfg
+	raised.Timeouts.CoordinatorRequestSeconds = 600
+	if got, want := streamCeiling(1, raised), 600*time.Second; got != want {
+		t.Fatalf("streamCeiling with coordinator_request_seconds=600 returned %s want %s", got, want)
+	}
+}
+
+// TestEffectiveStreamCeilingClampsStructuredOutput pins the deliberate
+// conservative choice in #760: SPEC-019 v0.2.4 §AC-V2-9 normatively fixes the
+// structured-output streaming budget at 300s, so structured streams keep that
+// sub-ceiling until the spec is amended (contract_change stays "none").
+func TestEffectiveStreamCeilingClampsStructuredOutput(t *testing.T) {
+	s := &Server{cfg: config.Default()}
+	plain := s.effectiveStreamCeiling(4096, false)
+	if plain <= spec019StructuredStreamingCeiling {
+		t.Fatalf("precondition: plain ceiling %s must exceed the SPEC-019 bound %s for this test to mean anything",
+			plain, spec019StructuredStreamingCeiling)
+	}
+	if got := s.effectiveStreamCeiling(4096, true); got != spec019StructuredStreamingCeiling {
+		t.Fatalf("structured streaming ceiling=%s want the SPEC-019 pinned %s", got, spec019StructuredStreamingCeiling)
+	}
+	// The sub-ceiling only ever shortens: a small request stays on its own
+	// (already shorter) derived ceiling.
+	short := config.Default()
+	short.Timeouts.StreamCeilingFloorSeconds = 10
+	short.Timeouts.StreamCeilingPerTokenMS = 1
+	short.Timeouts.CoordinatorRequestSeconds = 10
+	shortServer := &Server{cfg: short}
+	if got, want := shortServer.effectiveStreamCeiling(16, true), 10016*time.Millisecond; got != want {
+		t.Fatalf("structured ceiling=%s want %s (derived value already below the SPEC-019 bound)", got, want)
+	}
+}
+
+// ---- unit: the cancellation-cause contract ---------------------------------
+
+// TestPhaseDeadlineExceededDistinguishesPlainCancellation guards the silent
+// regression #760 could have introduced. The upstream context is now
+// cancel-WITH-CAUSE, so ctx.Err() reports context.Canceled even when a phase
+// budget expired: every call site had to move off
+// errors.Is(ctx.Err(), context.DeadlineExceeded). This test fails if
+// phaseDeadlineExceeded ever starts confusing the two.
+func TestPhaseDeadlineExceededDistinguishesPlainCancellation(t *testing.T) {
+	expired := newRequestDeadlines(context.Background())
+	defer expired.Stop()
+	expired.armPhase(deadlinePhaseFirstToken, time.Millisecond)
+	select {
+	case <-expired.Context().Done():
+	case <-time.After(2 * time.Second):
+		t.Fatal("phase timer never fired")
+	}
+	if !errors.Is(expired.Context().Err(), context.Canceled) {
+		t.Fatalf("ctx.Err()=%v; a cause-cancelled context reports context.Canceled — the legacy DeadlineExceeded check is exactly what this test forbids", expired.Context().Err())
+	}
+	if errors.Is(expired.Context().Err(), context.DeadlineExceeded) {
+		t.Fatal("ctx.Err() reported DeadlineExceeded; the legacy check would have masked the migration")
+	}
+	phase, ok := phaseDeadlineExceeded(expired.Context())
+	if !ok || phase != deadlinePhaseFirstToken {
+		t.Fatalf("phaseDeadlineExceeded=(%q,%v) want (%q,true)", phase, ok, deadlinePhaseFirstToken)
+	}
+	if got := expired.expiredPhase(); got != deadlinePhaseFirstToken {
+		t.Fatalf("expiredPhase=%q want %q", got, deadlinePhaseFirstToken)
+	}
+
+	// A plain cancel (buyer disconnect, gateway-side abort) is NOT a phase
+	// deadline and must not be reported as one.
+	plain := newRequestDeadlines(context.Background())
+	plain.Cancel()
+	if phase, ok := phaseDeadlineExceeded(plain.Context()); ok {
+		t.Fatalf("plain cancellation reported phase %q", phase)
+	}
+	if got := plain.expiredPhase(); got != "" {
+		t.Fatalf("expiredPhase=%q want empty for a plain cancellation", got)
+	}
+	plain.Stop()
+
+	// The ceiling is armed at most once: a second arm must not extend it.
+	ceiling := newRequestDeadlines(context.Background())
+	defer ceiling.Stop()
+	ceiling.armCeiling(50 * time.Millisecond)
+	ceiling.armCeiling(time.Hour)
+	select {
+	case <-ceiling.Context().Done():
+	case <-time.After(2 * time.Second):
+		t.Fatal("ceiling was re-armed and never fired")
+	}
+	if got := ceiling.expiredPhase(); got != deadlinePhaseStreamCeiling {
+		t.Fatalf("expiredPhase=%q want %q", got, deadlinePhaseStreamCeiling)
+	}
+}
+
+// ---- streaming: each phase ends the request on its own clock ---------------
+
+// endlessContentStream emits a content-bearing delta every `every` until the
+// upstream request context is cancelled, i.e. a generation that never stalls.
+func endlessContentStream(every time.Duration) func(*io.PipeWriter, context.Context) {
+	return endlessFrameStream(every, `data: {"id":"c","choices":[{"delta":{"content":"x"}}]}`+"\n\n")
+}
+
+func endlessFrameStream(every time.Duration, frame string) func(*io.PipeWriter, context.Context) {
+	return func(pw *io.PipeWriter, ctx context.Context) {
+		for {
+			if _, err := pw.Write([]byte(frame)); err != nil {
+				return
+			}
+			select {
+			case <-ctx.Done():
+				_ = pw.CloseWithError(ctx.Err())
+				return
+			case <-time.After(every):
+			}
+		}
+	}
+}
+
+// TestStreamCeilingFiresOnEndlessStream is the safety half of #760: removing
+// the flat wall must not make a runaway generation unbounded. A stream that
+// keeps emitting real content forever is still cut, by the max_tokens-derived
+// ceiling, and settles as provider_timeout — not provider_disconnected.
+func TestStreamCeilingFiresOnEndlessStream(t *testing.T) {
+	client := seamStreamingUpstreamCtx(endlessContentStream(50 * time.Millisecond))
+	h, store, dbPath, cfg := newTestHarnessConfig(t, fakeOAuth{}, func(cfg *config.Config) {
+		cfg.Coordinator.BuyerURL = "http://coordinator.test"
+		// Ceiling = clamp(1s + 20*1ms, >=1s, <=1s) = 1s. The idle timer and
+		// the first-token phase are left long so the ceiling is the only
+		// clock that can fire.
+		cfg.Timeouts.CoordinatorRequestSeconds = 1
+		cfg.Timeouts.StreamCeilingFloorSeconds = 1
+		cfg.Timeouts.StreamCeilingPerTokenMS = 1
+		cfg.Timeouts.StreamCeilingMaxSeconds = 1
+		cfg.Timeouts.StreamingIdleMS = 30000
+		cfg.Timeouts.FirstTokenSeconds = 300
+	}, WithHTTPClient(client))
+	key := createAccountAndKey(t, store, cfg, "acct_ceiling")
+
+	start := time.Now()
+	resp := postChat(t, h, key, `{"model":"llama","stream":true,"max_tokens":20,"messages":[{"role":"user","content":"hi"}]}`, nil)
+	elapsed := time.Since(start)
+
+	if elapsed > 5*time.Second {
+		t.Fatalf("endless stream ran %s — the ceiling did not bound it", elapsed)
+	}
+	body := resp.Body.String()
+	if !strings.Contains(body, `"code":"provider_timeout"`) || !strings.Contains(body, "data: [DONE]") {
+		t.Fatalf("want provider_timeout + [DONE] terminal after %s; body=%.400q", elapsed, body)
+	}
+	if strings.Contains(body, "provider_disconnected") {
+		t.Fatalf("ceiling expiry must not surface as a provider disconnect; body=%.400q", body)
+	}
+	if outcome, _ := usageEventOutcome(t, dbPath, "acct_ceiling"); outcome != "provider_timeout" {
+		t.Fatalf("usage outcome=%q want provider_timeout", outcome)
+	}
+}
+
+// TestHeartbeatOnlyStreamDiesAtProgressIdle is the highest-value guard in
+// #760. Dropping the flat wall is only safe because the idle timer became a
+// CONTENT-progress budget: a provider that keeps the socket warm with
+// role-only / keepalive frames produces bytes forever but no tokens, and under
+// the old "any byte resets the timer" rule nothing would have stopped it once
+// the wall was gone.
+func TestHeartbeatOnlyStreamDiesAtProgressIdle(t *testing.T) {
+	// A role-only delta: real SSE traffic, zero generated content.
+	// streamingCompletionDeltaBytes excludes role/id/type/name, so this must
+	// NOT count as progress.
+	client := seamStreamingUpstreamCtx(endlessFrameStream(40*time.Millisecond,
+		`data: {"id":"c","choices":[{"delta":{"role":"assistant"}}]}`+"\n\n"))
+	h, store, dbPath, cfg := newTestHarnessConfig(t, fakeOAuth{}, func(cfg *config.Config) {
+		cfg.Coordinator.BuyerURL = "http://coordinator.test"
+		cfg.Timeouts.StreamingIdleMS = 400
+		// Every other clock is left long: only the content-progress budget
+		// can end this stream.
+		cfg.Timeouts.CoordinatorRequestSeconds = 300
+		cfg.Timeouts.FirstTokenSeconds = 300
+		cfg.Timeouts.StreamCeilingFloorSeconds = 300
+		cfg.Timeouts.StreamCeilingMaxSeconds = 900
+	}, WithHTTPClient(client))
+	key := createAccountAndKey(t, store, cfg, "acct_heartbeat")
+
+	start := time.Now()
+	resp := postChat(t, h, key, `{"model":"llama","stream":true,"max_tokens":500,"messages":[{"role":"user","content":"hi"}]}`, nil)
+	elapsed := time.Since(start)
+
+	if elapsed > 5*time.Second {
+		t.Fatalf("heartbeat-only stream ran %s — byte traffic is still resetting the idle timer, "+
+			"so the decode-progress guard cannot catch a wedged provider", elapsed)
+	}
+	if !strings.Contains(resp.Body.String(), `"code":"provider_timeout"`) {
+		t.Fatalf("want provider_timeout terminal after %s; body=%.400q", elapsed, resp.Body.String())
+	}
+	if outcome, _ := usageEventOutcome(t, dbPath, "acct_heartbeat"); outcome != "provider_timeout" {
+		t.Fatalf("usage outcome=%q want provider_timeout", outcome)
+	}
+}
+
+// TestContentProgressKeepsStreamAliveAcrossIdleBudget is the control for the
+// test above: the same idle budget, but frames that DO carry content. The
+// stream must survive well past the budget, proving the timer measures
+// progress rather than elapsed time.
+func TestContentProgressKeepsStreamAliveAcrossIdleBudget(t *testing.T) {
+	client := seamStreamingUpstreamCtx(func(pw *io.PipeWriter, ctx context.Context) {
+		for i := 0; i < 10; i++ {
+			if _, err := pw.Write([]byte(`data: {"id":"c","choices":[{"delta":{"content":"x"}}]}` + "\n\n")); err != nil {
+				return
+			}
+			select {
+			case <-ctx.Done():
+				_ = pw.CloseWithError(ctx.Err())
+				return
+			case <-time.After(100 * time.Millisecond):
+			}
+		}
+		_, _ = pw.Write([]byte(`data: [DONE]` + "\n\n"))
+		_ = pw.Close()
+	})
+	h, store, _, cfg := newTestHarnessConfig(t, fakeOAuth{}, func(cfg *config.Config) {
+		cfg.Coordinator.BuyerURL = "http://coordinator.test"
+		// 400ms of idle budget, 1s+ of streaming: only per-frame content
+		// progress can carry it to [DONE].
+		cfg.Timeouts.StreamingIdleMS = 400
+	}, WithHTTPClient(client))
+	key := createAccountAndKey(t, store, cfg, "acct_progress")
+
+	resp := postChat(t, h, key, `{"model":"llama","stream":true,"max_tokens":500,"messages":[{"role":"user","content":"hi"}]}`, nil)
+	body := resp.Body.String()
+	if !strings.Contains(body, "data: [DONE]") || strings.Contains(body, "provider_timeout") {
+		t.Fatalf("a content-progressing stream was cut by the idle budget; body=%.400q", body)
+	}
+}
+
+// TestFirstTokenDeadlineFiresBeforeCeiling covers the gap between "headers
+// committed" and "first token": the coordinator accepted the request and then
+// produced nothing. The idle timer and the ceiling are both left long, so only
+// the first-token phase can end this request.
+func TestFirstTokenDeadlineFiresBeforeCeiling(t *testing.T) {
+	client := seamStreamingUpstreamCtx(func(pw *io.PipeWriter, ctx context.Context) {
+		<-ctx.Done() // headers committed, then silence
+		_ = pw.CloseWithError(ctx.Err())
+	})
+	h, store, dbPath, cfg := newTestHarnessConfig(t, fakeOAuth{}, func(cfg *config.Config) {
+		cfg.Coordinator.BuyerURL = "http://coordinator.test"
+		cfg.Timeouts.FirstTokenSeconds = 1
+		cfg.Timeouts.StreamingIdleMS = 30000
+		cfg.Timeouts.CoordinatorRequestSeconds = 300
+		cfg.Timeouts.StreamCeilingFloorSeconds = 300
+	}, WithHTTPClient(client))
+	key := createAccountAndKey(t, store, cfg, "acct_first_token")
+
+	start := time.Now()
+	resp := postChat(t, h, key, `{"model":"llama","stream":true,"max_tokens":500,"messages":[{"role":"user","content":"hi"}]}`, nil)
+	elapsed := time.Since(start)
+
+	if elapsed > 5*time.Second {
+		t.Fatalf("silent post-header stream ran %s — the first-token phase did not fire", elapsed)
+	}
+	if !strings.Contains(resp.Body.String(), `"code":"provider_timeout"`) {
+		t.Fatalf("want provider_timeout terminal after %s; body=%.400q", elapsed, resp.Body.String())
+	}
+	if strings.Contains(resp.Body.String(), "provider_disconnected") {
+		t.Fatalf("first-token expiry must not surface as a provider disconnect; body=%.400q", resp.Body.String())
+	}
+	if outcome, _ := usageEventOutcome(t, dbPath, "acct_first_token"); outcome != "provider_timeout" {
+		t.Fatalf("usage outcome=%q want provider_timeout", outcome)
+	}
+}
+
+// TestStructuredStreamingTimeoutUsesCause is the regression tripwire for the
+// riskiest edit in #760: the two
+// errors.Is(upstreamCtx.Err(), context.DeadlineExceeded) checks that used to
+// select the SPEC-019 structured-output timeout envelope. Cause-based
+// cancellation makes ctx.Err() report context.Canceled, so a missed migration
+// would silently downgrade this buyer-visible terminal to
+// provider_disconnected / stream_truncated with no compile error.
+func TestStructuredStreamingTimeoutUsesCause(t *testing.T) {
+	t.Run("mid_stream", func(t *testing.T) {
+		client := seamStreamingUpstreamCtx(func(pw *io.PipeWriter, ctx context.Context) {
+			// A committed but content-less frame: headers are up, the
+			// first-token phase is still armed.
+			_, _ = pw.Write([]byte(`data: {"id":"c","choices":[{"delta":{},"finish_reason":null}]}` + "\n\n"))
+			<-ctx.Done()
+			_ = pw.CloseWithError(ctx.Err())
+		})
+		h, store, dbPath, cfg := newTestHarnessConfig(t, fakeOAuth{}, func(cfg *config.Config) {
+			cfg.Coordinator.BuyerURL = "http://coordinator.test"
+			cfg.Timeouts.FirstTokenSeconds = 1
+			cfg.Timeouts.StreamingIdleMS = 30000
+		}, WithHTTPClient(client))
+		key := createAccountAndKey(t, store, cfg, "acct_structured_cause_mid")
+
+		resp := postChat(t, h, key, structuredStreamingRequestBody(), nil)
+		body := resp.Body.String()
+		if !strings.Contains(body, `"code":"provider_timeout"`) || !strings.Contains(body, `"settlement_ran":true`) {
+			t.Fatalf("structured mid-stream timeout lost its SPEC-019 envelope; body=%.400q", body)
+		}
+		if strings.Contains(body, "provider_disconnected") || strings.Contains(body, "stream_truncated") {
+			t.Fatalf("structured mid-stream timeout downgraded to a disconnect envelope; body=%.400q", body)
+		}
+		if outcome, _ := usageEventOutcome(t, dbPath, "acct_structured_cause_mid"); outcome != "provider_timeout" {
+			t.Fatalf("usage outcome=%q want provider_timeout", outcome)
+		}
+	})
+
+	t.Run("pre_header", func(t *testing.T) {
+		client := hangingCoordinatorClient()
+		h, store, dbPath, cfg := newTestHarnessConfig(t, fakeOAuth{}, func(cfg *config.Config) {
+			cfg.Coordinator.BuyerURL = "http://coordinator.test"
+			cfg.Timeouts.CoordinatorAdmissionSeconds = 1
+		}, WithHTTPClient(client))
+		key := createAccountAndKey(t, store, cfg, "acct_structured_cause_pre")
+
+		resp := postChat(t, h, key, structuredStreamingRequestBody(), nil)
+		body := resp.Body.String()
+		if !strings.Contains(body, `"code":"provider_timeout"`) {
+			t.Fatalf("structured pre-header timeout lost its SPEC-019 envelope; body=%.400q", body)
+		}
+		if strings.Contains(body, "coordinator_unavailable") {
+			t.Fatalf("structured pre-header timeout fell through to the generic 503; body=%.400q", body)
+		}
+		if outcome, _ := usageEventOutcome(t, dbPath, "acct_structured_cause_pre"); outcome != "provider_timeout" {
+			t.Fatalf("usage outcome=%q want provider_timeout", outcome)
+		}
+	})
+}

--- a/phase5-gateway/internal/router/request_deadlines_test.go
+++ b/phase5-gateway/internal/router/request_deadlines_test.go
@@ -251,33 +251,48 @@ func TestHeartbeatOnlyStreamDiesAtProgressIdle(t *testing.T) {
 // content-progress timer, disarm the first-token phase, or hold a slot to the
 // stream ceiling while shipping nothing a client consumes.
 func TestUnknownDeltaKeyDoesNotCountAsProgress(t *testing.T) {
-	client := seamStreamingUpstreamCtx(endlessFrameStream(40*time.Millisecond,
-		`data: {"id":"c","choices":[{"delta":{"foo":"x"}}]}`+"\n\n"))
-	h, store, dbPath, cfg := newTestHarnessConfig(t, fakeOAuth{}, func(cfg *config.Config) {
-		cfg.Coordinator.BuyerURL = "http://coordinator.test"
-		cfg.Timeouts.StreamingIdleMS = 400
-		// Every other clock is left long: only the content-progress budget
-		// can end this stream.
-		cfg.Timeouts.CoordinatorRequestSeconds = 300
-		cfg.Timeouts.FirstTokenSeconds = 300
-		cfg.Timeouts.StreamCeilingFloorSeconds = 300
-		cfg.Timeouts.StreamCeilingMaxSeconds = 900
-	}, WithHTTPClient(client))
-	key := createAccountAndKey(t, store, cfg, "acct_unknown_delta")
-
-	start := time.Now()
-	resp := postChat(t, h, key, `{"model":"llama","stream":true,"max_tokens":500,"messages":[{"role":"user","content":"hi"}]}`, nil)
-	elapsed := time.Since(start)
-
-	if elapsed > 5*time.Second {
-		t.Fatalf("unknown-key delta stream ran %s — the classifier is counting non-allowlisted "+
-			"keys as generated output, so a provider can fabricate progress", elapsed)
+	cases := []struct {
+		name    string
+		account string
+		frame   string
+	}{
+		{"flat_unknown_key", "acct_unknown_delta",
+			`data: {"id":"c","choices":[{"delta":{"foo":"x"}}]}` + "\n\n"},
+		// R2 bypass class: allowlisted leaf smuggled under an unknown
+		// container must not count either.
+		{"allowlisted_leaf_under_unknown_container", "acct_nested_delta",
+			`data: {"id":"c","choices":[{"delta":{"foo":{"content":"x"}}}]}` + "\n\n"},
 	}
-	if !strings.Contains(resp.Body.String(), `"code":"provider_timeout"`) {
-		t.Fatalf("want provider_timeout terminal after %s; body=%.400q", elapsed, resp.Body.String())
-	}
-	if outcome, _ := usageEventOutcome(t, dbPath, "acct_unknown_delta"); outcome != "provider_timeout" {
-		t.Fatalf("usage outcome=%q want provider_timeout", outcome)
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			client := seamStreamingUpstreamCtx(endlessFrameStream(40*time.Millisecond, tc.frame))
+			h, store, dbPath, cfg := newTestHarnessConfig(t, fakeOAuth{}, func(cfg *config.Config) {
+				cfg.Coordinator.BuyerURL = "http://coordinator.test"
+				cfg.Timeouts.StreamingIdleMS = 400
+				// Every other clock is left long: only the content-progress
+				// budget can end this stream.
+				cfg.Timeouts.CoordinatorRequestSeconds = 300
+				cfg.Timeouts.FirstTokenSeconds = 300
+				cfg.Timeouts.StreamCeilingFloorSeconds = 300
+				cfg.Timeouts.StreamCeilingMaxSeconds = 900
+			}, WithHTTPClient(client))
+			key := createAccountAndKey(t, store, cfg, tc.account)
+
+			start := time.Now()
+			resp := postChat(t, h, key, `{"model":"llama","stream":true,"max_tokens":500,"messages":[{"role":"user","content":"hi"}]}`, nil)
+			elapsed := time.Since(start)
+
+			if elapsed > 5*time.Second {
+				t.Fatalf("non-content delta stream ran %s — the classifier is counting "+
+					"non-output paths as generated output, so a provider can fabricate progress", elapsed)
+			}
+			if !strings.Contains(resp.Body.String(), `"code":"provider_timeout"`) {
+				t.Fatalf("want provider_timeout terminal after %s; body=%.400q", elapsed, resp.Body.String())
+			}
+			if outcome, _ := usageEventOutcome(t, dbPath, tc.account); outcome != "provider_timeout" {
+				t.Fatalf("usage outcome=%q want provider_timeout", outcome)
+			}
+		})
 	}
 }
 
@@ -331,9 +346,15 @@ func TestDeltaClassifierAllowlist(t *testing.T) {
 		{"reasoning_content", `{"choices":[{"delta":{"reasoning_content":"abc"}}]}`, 3},
 		{"refusal", `{"choices":[{"delta":{"refusal":"no"}}]}`, 2},
 		{"tool_call_arguments", `{"choices":[{"delta":{"tool_calls":[{"index":0,"function":{"name":"f","arguments":"{\"a\":1}"}}]}}]}`, 7},
+		{"function_call_arguments", `{"choices":[{"delta":{"function_call":{"name":"f","arguments":"{\"a\":1}"}}}]}`, 7},
 		{"unknown_key", `{"choices":[{"delta":{"foo":"xxxxxxxx"}}]}`, 0},
 		{"role_only", `{"choices":[{"delta":{"role":"assistant"}}]}`, 0},
 		{"nested_unknown", `{"choices":[{"delta":{"metadata":{"blob":"xxxxxxxx"}}}]}`, 0},
+		// R2 bypass class: an allowlisted LEAF under an unknown container must
+		// not count — the classifier is path-aware, not key-aware.
+		{"allowlisted_leaf_under_unknown_container", `{"choices":[{"delta":{"foo":{"content":"xxxxxxxx"}}}]}`, 0},
+		{"arguments_under_unknown_container", `{"choices":[{"delta":{"metadata":{"arguments":"xxxxxxxx"}}}]}`, 0},
+		{"content_under_unknown_array", `{"choices":[{"delta":{"foo":[{"text":"xxxxxxxx"}]}}]}`, 0},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/phase5-gateway/internal/router/request_deadlines_test.go
+++ b/phase5-gateway/internal/router/request_deadlines_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"io"
+	"net/http"
 	"strings"
 	"testing"
 	"time"
@@ -241,6 +242,109 @@ func TestHeartbeatOnlyStreamDiesAtProgressIdle(t *testing.T) {
 	}
 	if outcome, _ := usageEventOutcome(t, dbPath, "acct_heartbeat"); outcome != "provider_timeout" {
 		t.Fatalf("usage outcome=%q want provider_timeout", outcome)
+	}
+}
+
+// TestUnknownDeltaKeyDoesNotCountAsProgress pins the #760 security-lane fix:
+// the delta classifier is an ALLOWLIST of generated-output keys, so a provider
+// emitting frames with unknown keys (delta:{"foo":"x"}) cannot reset the
+// content-progress timer, disarm the first-token phase, or hold a slot to the
+// stream ceiling while shipping nothing a client consumes.
+func TestUnknownDeltaKeyDoesNotCountAsProgress(t *testing.T) {
+	client := seamStreamingUpstreamCtx(endlessFrameStream(40*time.Millisecond,
+		`data: {"id":"c","choices":[{"delta":{"foo":"x"}}]}`+"\n\n"))
+	h, store, dbPath, cfg := newTestHarnessConfig(t, fakeOAuth{}, func(cfg *config.Config) {
+		cfg.Coordinator.BuyerURL = "http://coordinator.test"
+		cfg.Timeouts.StreamingIdleMS = 400
+		// Every other clock is left long: only the content-progress budget
+		// can end this stream.
+		cfg.Timeouts.CoordinatorRequestSeconds = 300
+		cfg.Timeouts.FirstTokenSeconds = 300
+		cfg.Timeouts.StreamCeilingFloorSeconds = 300
+		cfg.Timeouts.StreamCeilingMaxSeconds = 900
+	}, WithHTTPClient(client))
+	key := createAccountAndKey(t, store, cfg, "acct_unknown_delta")
+
+	start := time.Now()
+	resp := postChat(t, h, key, `{"model":"llama","stream":true,"max_tokens":500,"messages":[{"role":"user","content":"hi"}]}`, nil)
+	elapsed := time.Since(start)
+
+	if elapsed > 5*time.Second {
+		t.Fatalf("unknown-key delta stream ran %s — the classifier is counting non-allowlisted "+
+			"keys as generated output, so a provider can fabricate progress", elapsed)
+	}
+	if !strings.Contains(resp.Body.String(), `"code":"provider_timeout"`) {
+		t.Fatalf("want provider_timeout terminal after %s; body=%.400q", elapsed, resp.Body.String())
+	}
+	if outcome, _ := usageEventOutcome(t, dbPath, "acct_unknown_delta"); outcome != "provider_timeout" {
+		t.Fatalf("usage outcome=%q want provider_timeout", outcome)
+	}
+}
+
+// TestStructuredTimeoutDuringRetryBackoff pins the #760 code-lane fix: when
+// the admission budget expires during retry backoff, doCoordinatorChatWithRetry
+// returns its last retryable 503 with err == nil. A structured-streaming buyer
+// must still receive the SPEC-019 provider_timeout SSE terminal — not the raw
+// JSON 503 pass-through.
+func TestStructuredTimeoutDuringRetryBackoff(t *testing.T) {
+	client := &http.Client{Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+		return responseWithBody(http.StatusServiceUnavailable, http.Header{"Content-Type": []string{"application/json"}}, noProviderBody()), nil
+	})}
+	h, store, dbPath, cfg := newTestHarnessConfig(t, fakeOAuth{}, func(cfg *config.Config) {
+		cfg.Coordinator.BuyerURL = "http://coordinator.test"
+		cfg.Retry503.Enabled = true
+		cfg.Retry503.MaxAttempts = 3
+		// Backoff (3s) straddles the 1s admission budget: the phase expires
+		// while the retry loop sleeps, exercising the stale-resp return path.
+		cfg.Retry503.BackoffBaseMs = 3000
+		cfg.Retry503.BackoffMaxMs = 3000
+		cfg.Timeouts.CoordinatorAdmissionSeconds = 1
+	}, WithHTTPClient(client))
+	key := createAccountAndKey(t, store, cfg, "acct_structured_backoff")
+
+	start := time.Now()
+	resp := postChat(t, h, key, structuredStreamingRequestBody(), nil)
+	elapsed := time.Since(start)
+
+	body := resp.Body.String()
+	if !strings.Contains(body, `"code":"provider_timeout"`) {
+		t.Fatalf("structured buyer got a non-timeout terminal after admission expiry in backoff "+
+			"(%s); body=%.400q", elapsed, body)
+	}
+	if strings.Contains(body, "no_provider_available") || strings.Contains(body, "coordinator_unavailable") {
+		t.Fatalf("raw JSON 503 passed through to a structured-streaming buyer; body=%.400q", body)
+	}
+	if outcome, _ := usageEventOutcome(t, dbPath, "acct_structured_backoff"); outcome != "provider_timeout" {
+		t.Fatalf("usage outcome=%q want provider_timeout", outcome)
+	}
+}
+
+// TestDeltaClassifierAllowlist unit-pins which delta keys count as generated
+// output for both billing estimation and (since #760) deadline progress.
+func TestDeltaClassifierAllowlist(t *testing.T) {
+	cases := []struct {
+		name string
+		data string
+		want int64
+	}{
+		{"content", `{"choices":[{"delta":{"content":"abcd"}}]}`, 4},
+		{"reasoning_content", `{"choices":[{"delta":{"reasoning_content":"abc"}}]}`, 3},
+		{"refusal", `{"choices":[{"delta":{"refusal":"no"}}]}`, 2},
+		{"tool_call_arguments", `{"choices":[{"delta":{"tool_calls":[{"index":0,"function":{"name":"f","arguments":"{\"a\":1}"}}]}}]}`, 7},
+		{"unknown_key", `{"choices":[{"delta":{"foo":"xxxxxxxx"}}]}`, 0},
+		{"role_only", `{"choices":[{"delta":{"role":"assistant"}}]}`, 0},
+		{"nested_unknown", `{"choices":[{"delta":{"metadata":{"blob":"xxxxxxxx"}}}]}`, 0},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, _, ok := streamingCompletionDeltaBytes(tc.data)
+			if !ok {
+				t.Fatalf("classifier rejected valid frame %q", tc.data)
+			}
+			if got != tc.want {
+				t.Fatalf("deltaBytes=%d want %d for %q", got, tc.want, tc.data)
+			}
+		})
 	}
 }
 

--- a/phase5-gateway/internal/router/seam_harness_test.go
+++ b/phase5-gateway/internal/router/seam_harness_test.go
@@ -254,22 +254,32 @@ func TestSeamH2_BuyerDisconnectSettlesConsumerSide(t *testing.T) {
 		"non-streaming refunds — asymmetry per 02-macprovider-audit.md.", outcome, source, used)
 }
 
-// ---- H1 · flat wall kills a progressing stream (INV-1, INV-2) --------------
-// EXPECTED: FAIL today. One flat total wall (chat_proxy.go:122, CoordinatorTimeout)
-// spans the whole request, so a steadily-progressing stream is cut at the wall even
-// though it never hit the 10s decode-idle timer. Timeout shortened to 1s for the test.
+// ---- H1 · progressing stream survives the legacy wall (INV-1, INV-2) -------
+// EXPECTED: PASS = certifies the P0-2 FIX (issue #760). This test used to be
+// TestSeamH1_FlatWallKillsProgressingStream and asserted the buggy-today behavior:
+// one flat total wall (chat_proxy.go:122, CoordinatorTimeout) spanning the whole
+// request, cutting a steadily-progressing stream even though it never hit the decode
+// idle timer. Per-phase deadlines replaced that wall, so the SAME scenario — legacy
+// wall shortened to 1s, a healthy stream emitting for 3s — must now complete cleanly.
+//
+// The scenario is deliberately unchanged (including seamStreamingUpstreamCtx, which
+// honors the upstream request ctx exactly as the real transport does): what flipped
+// is the verdict, so the test remains a durable tripwire. A regression that
+// reintroduces any request-spanning flat wall — the ctx wall here, or the
+// http.Client.Timeout twin in cmd/gateway (see TestCoordinatorClientHasNoBodyTimeout)
+// — turns this red again.
 
-func TestSeamH1_FlatWallKillsProgressingStream(t *testing.T) {
+func TestSeamH1_ProgressingStreamSurvivesLegacyWall(t *testing.T) {
 	client := seamStreamingUpstreamCtx(func(pw *io.PipeWriter, ctx context.Context) {
 		// Emit a token every 200ms (well under the 10s idle timer) for up to 3s,
-		// i.e. a HEALTHY, steadily-progressing stream. Honor the total-wall context
-		// exactly as the real transport does: when upCtx fires, abort the body.
+		// i.e. a HEALTHY, steadily-progressing stream. Honor the upstream request
+		// context exactly as the real transport does: if it fires, abort the body.
 		for i := 0; i < 15; i++ {
 			if _, err := pw.Write([]byte(`data: {"id":"c","choices":[{"delta":{"content":"x"}}]}` + "\n\n")); err != nil {
 				return
 			}
 			select {
-			case <-ctx.Done(): // total wall fired mid-stream → transport aborts the body
+			case <-ctx.Done(): // a deadline fired mid-stream → transport aborts the body
 				_ = pw.CloseWithError(ctx.Err())
 				return
 			case <-time.After(200 * time.Millisecond):
@@ -278,8 +288,11 @@ func TestSeamH1_FlatWallKillsProgressingStream(t *testing.T) {
 		_, _ = pw.Write([]byte(`data: [DONE]` + "\n\n"))
 		_ = pw.Close()
 	})
-	h, store, _, cfg := newTestHarnessConfig(t, fakeOAuth{}, func(cfg *config.Config) {
+	h, store, dbPath, cfg := newTestHarnessConfig(t, fakeOAuth{}, func(cfg *config.Config) {
 		cfg.Coordinator.BuyerURL = "http://coordinator.test"
+		// The legacy flat wall. Post-#760 it only floors the derived streaming
+		// ceiling (clamp >= coordinator_request_seconds); it no longer bounds a
+		// progressing stream.
 		cfg.Timeouts.CoordinatorRequestSeconds = 1
 		cfg.Timeouts.CoordinatorHeaderTimeoutSeconds = 1
 	}, WithHTTPClient(client))
@@ -290,19 +303,32 @@ func TestSeamH1_FlatWallKillsProgressingStream(t *testing.T) {
 	r := postChat(t, h, key, body, map[string]string{"X-Request-ID": "44444444-4444-4444-8444-444444444444"})
 	elapsed := time.Since(start)
 
-	completedCleanly := strings.Contains(r.Body.String(), "data: [DONE]") &&
-		!strings.Contains(r.Body.String(), "provider_disconnected")
-	if elapsed < 2*time.Second && !completedCleanly {
-		t.Logf("CONFIRMED FINDING (INV-1/INV-2 FAIL): a progressing stream was cut at the "+
-			"flat %s wall after %s (never hit the 10s idle timer). Fix: decompose into "+
-			"per-phase leases (chat_proxy.go:122).", time.Second, elapsed.Round(10*time.Millisecond))
-		return
+	if r.Code != http.StatusOK {
+		t.Fatalf("stream status=%d want 200; body=%.300q", r.Code, r.Body.String())
 	}
-	if completedCleanly {
-		t.Fatalf("stream completed cleanly in %s despite a 1s total wall — the flat wall was "+
-			"FIXED (per-phase leases?); update the audit", elapsed)
+	if !strings.Contains(r.Body.String(), "data: [DONE]") {
+		t.Fatalf("REGRESSION (INV-1/INV-2): progressing stream did not reach [DONE] after %s "+
+			"— a request-spanning flat wall is back. body=%.300q",
+			elapsed.Round(10*time.Millisecond), r.Body.String())
 	}
-	t.Fatalf("inconclusive: elapsed=%s completedCleanly=%v body=%.200q", elapsed, completedCleanly, r.Body.String())
+	for _, forbidden := range []string{"provider_disconnected", "provider_timeout", "stream_truncated"} {
+		if strings.Contains(r.Body.String(), forbidden) {
+			t.Fatalf("REGRESSION (INV-1/INV-2): healthy stream emitted a %s terminal after %s; body=%.300q",
+				forbidden, elapsed.Round(10*time.Millisecond), r.Body.String())
+		}
+	}
+	// The mock upstream declares no settlement-finality trailer, so a cleanly
+	// completed stream settles on the legacy path, which relabels "ok" as
+	// "unverified_streaming". Both are clean-completion outcomes; what must
+	// never appear is a timeout/truncation outcome.
+	outcome, source := usageEventOutcome(t, dbPath, "acct_h1")
+	if outcome != "ok" && outcome != "unverified_streaming" {
+		t.Fatalf("REGRESSION (INV-1/INV-2): usage outcome=%q source=%q, want a clean-completion "+
+			"outcome for a stream that ran to [DONE]", outcome, source)
+	}
+	t.Logf("PASS (P0-2 FIXED, #760): a progressing stream ran %s past a %s legacy wall and "+
+		"completed with [DONE], outcome=%q source=%q.",
+		elapsed.Round(10*time.Millisecond), time.Second, outcome, source)
 }
 
 // ---- H3 · relay-timeout strikes provider on buyer-cancel (INV-3) -----------

--- a/phase5-gateway/internal/router/server_test.go
+++ b/phase5-gateway/internal/router/server_test.go
@@ -3875,37 +3875,73 @@ func (f *settlementFailStore) RefundReservation(context.Context, string, string,
 	return nil
 }
 
-func TestChatCompletionsCoordinatorTimeoutAppliesToStreamAndNonStream(t *testing.T) {
-	client := &http.Client{Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+// hangingCoordinatorClient answers every upstream request by blocking until
+// the request context is cancelled — i.e. a coordinator that accepts the
+// connection and never commits response headers.
+func hangingCoordinatorClient() *http.Client {
+	return &http.Client{Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
 		<-r.Context().Done()
 		return nil, r.Context().Err()
 	})}
+}
+
+// #760 split TestChatCompletionsCoordinatorTimeoutAppliesToStreamAndNonStream:
+// the two modes no longer share one clock, so one test per clock.
+//
+// STREAMING: a coordinator that accepts the connection and never commits
+// headers is bounded by the admission phase. The streaming ceiling is left at
+// its (much longer) default so the only clock that can end this request is
+// admission.
+//
+// The admission phase deliberately does NOT bound the non-streaming path: the
+// coordinator buffers a non-streaming response in full, so its headers do not
+// commit until provider work completes and a 120s admission budget would
+// false-fail a legitimate slow inference. That path keeps its flat wall —
+// TestNonStreamingStillBoundedByRequestWall below.
+func TestChatCompletionsAdmissionDeadlineFailsFastPreHeader(t *testing.T) {
+	client := hangingCoordinatorClient()
 	h, store, _, cfg := newTestHarnessConfig(t, fakeOAuth{}, func(cfg *config.Config) {
 		cfg.Coordinator.BuyerURL = "http://coordinator.test"
-		cfg.Timeouts.CoordinatorRequestSeconds = 1
+		cfg.Timeouts.CoordinatorAdmissionSeconds = 1
 	}, WithHTTPClient(client))
+	fullKey := createAccountAndKey(t, store, cfg, "acct_admission_stream")
 
-	for _, tc := range []struct {
-		name string
-		body string
-	}{
-		{name: "non_stream", body: `{"model":"llama","max_tokens":20,"messages":[{"role":"user","content":"hi"}],"stream":false}`},
-		{name: "stream", body: `{"model":"llama","max_tokens":20,"messages":[{"role":"user","content":"hi"}],"stream":true}`},
-	} {
-		t.Run(tc.name, func(t *testing.T) {
-			fullKey := createAccountAndKey(t, store, cfg, "acct_timeout_"+tc.name)
-			start := time.Now()
-			resp := postChat(t, h, fullKey, tc.body, nil)
-			elapsed := time.Since(start)
-			if resp.Code != http.StatusServiceUnavailable {
-				t.Fatalf("status=%d body=%s", resp.Code, resp.Body.String())
-			}
-			if elapsed > 2500*time.Millisecond {
-				t.Fatalf("elapsed=%s, want <=2.5s", elapsed)
-			}
-			assertErrorCode(t, resp.Body.String(), "coordinator_unavailable")
-		})
+	start := time.Now()
+	resp := postChat(t, h, fullKey, `{"model":"llama","max_tokens":20,"messages":[{"role":"user","content":"hi"}],"stream":true}`, nil)
+	elapsed := time.Since(start)
+	if resp.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status=%d body=%s", resp.Code, resp.Body.String())
 	}
+	if elapsed > 2500*time.Millisecond {
+		t.Fatalf("elapsed=%s, want <=2.5s (coordinator_admission_seconds=1)", elapsed)
+	}
+	assertErrorCode(t, resp.Body.String(), "coordinator_unavailable")
+}
+
+// TestNonStreamingStillBoundedByRequestWall pins the non-streaming path to its
+// own flat wall. The admission budget is deliberately long here so the ONLY
+// clock that can end the request is non_stream_request_seconds — if a future
+// change routes non-streaming through the (much longer) streaming ceiling or
+// drops its wall entirely, this test stops returning in ~1s.
+func TestNonStreamingStillBoundedByRequestWall(t *testing.T) {
+	client := hangingCoordinatorClient()
+	h, store, _, cfg := newTestHarnessConfig(t, fakeOAuth{}, func(cfg *config.Config) {
+		cfg.Coordinator.BuyerURL = "http://coordinator.test"
+		cfg.Timeouts.NonStreamRequestSeconds = 1
+		cfg.Timeouts.CoordinatorAdmissionSeconds = 600
+	}, WithHTTPClient(client))
+	fullKey := createAccountAndKey(t, store, cfg, "acct_non_stream_wall")
+
+	start := time.Now()
+	resp := postChat(t, h, fullKey, `{"model":"llama","max_tokens":20,"messages":[{"role":"user","content":"hi"}],"stream":false}`, nil)
+	elapsed := time.Since(start)
+	if resp.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status=%d body=%s", resp.Code, resp.Body.String())
+	}
+	if elapsed > 2500*time.Millisecond {
+		t.Fatalf("elapsed=%s, want <=2.5s (non_stream_request_seconds=1)", elapsed)
+	}
+	assertErrorCode(t, resp.Body.String(), "coordinator_unavailable")
 }
 
 func TestChatCompletionsCoordinatorRequestCancelsWithBuyerContext(t *testing.T) {

--- a/phase5-gateway/internal/router/streaming_structured_output_test.go
+++ b/phase5-gateway/internal/router/streaming_structured_output_test.go
@@ -99,6 +99,9 @@ func TestStreamingStructuredOutputGatewayTimeoutEmitsProviderTimeout(t *testing.
 	h, store, dbPath, cfg := newTestHarnessConfig(t, fakeOAuth{}, func(cfg *config.Config) {
 		cfg.Coordinator.BuyerURL = "http://coordinator.test"
 		cfg.Timeouts.CoordinatorRequestSeconds = 1
+		// #760: the pre-header wall is the admission phase now, not
+		// coordinator_request_seconds.
+		cfg.Timeouts.CoordinatorAdmissionSeconds = 1
 	}, WithHTTPClient(client))
 	accountID := "acct_stream_structured_timeout"
 	fullKey := createAccountAndKey(t, store, cfg, accountID)
@@ -143,6 +146,10 @@ func TestStreamingStructuredOutputPostFirstByteTimeoutPreservesProviderTimeoutSe
 		cfg.Timeouts.CoordinatorRequestSeconds = 1
 		cfg.Timeouts.CoordinatorHeaderTimeoutSeconds = 1
 		cfg.Timeouts.StreamingIdleMS = 5000
+		// #760: the upstream committed headers and then emitted a
+		// content-LESS frame, so the clock that must fire here is the
+		// first-token phase, not the (longer) idle timer.
+		cfg.Timeouts.FirstTokenSeconds = 1
 	}, WithHTTPClient(client))
 	accountID := "acct_stream_structured_mid_timeout"
 	fullKey := createAccountAndKey(t, store, cfg, accountID)
@@ -186,6 +193,10 @@ func TestStreamingStructuredOutputUpstreamContextStartsAtRequestEntry(t *testing
 	h, store, dbPath, cfg := newTestHarnessConfig(t, fakeOAuth{}, func(cfg *config.Config) {
 		cfg.Coordinator.BuyerURL = "http://coordinator.test"
 		cfg.Timeouts.CoordinatorRequestSeconds = 1
+		// #760 AC-V2-9 guard: the admission phase is armed FROM gateway
+		// first byte of request, so the 1.1s request-body read below must
+		// exhaust it before the upstream is ever dialled.
+		cfg.Timeouts.CoordinatorAdmissionSeconds = 1
 	}, WithHTTPClient(client))
 	accountID := "acct_stream_structured_entry_timeout"
 	fullKey := createAccountAndKey(t, store, cfg, accountID)


### PR DESCRIPTION
Closes #760. PR 2 of epic #770 (last P0 item).

## What changed

A single 300s wall — `upCtx` in `chat_proxy.go` **plus a hidden second wall** in `http.Client.Timeout` (which covers response-body reads, making any ctx-only fix a production no-op) — cut legitimately-progressing streams mid-generation and surfaced them as 5xx. As an OpenRouter upstream that means de-ranking for *succeeding slowly*.

Streaming decomposition (new `internal/router/request_deadlines.go`: one `context.WithCancelCause` funnel + a re-armable phase timer + a never-re-armed ceiling timer, typed phase causes):

| Phase | Bound | Notes |
|---|---|---|
| admission | 120s (`coordinator_admission_seconds`) | spans the whole retry loop; TCP/TLS connect budget (60s) enforced at the transport dial layer, not as a ctx deadline (avoids the #92/#171 slow-header regression) |
| first_token | 120s (`first_token_seconds`) | armed after upstream headers, disarmed on first content delta |
| content-progress idle | 10s (existing) | **converted from any-line to content-byte progress** — heartbeat/empty-delta streams now die in 10s instead of resetting the timer for 300s |
| stream ceiling | `clamp(60s + max_tokens×250ms, ≥300s, ≤900s)` | monotonically more permissive than today; `max_tokens` always present (substituted/capped upstream) |

Non-streaming keeps a flat 300s wall (`non_stream_wall` phase) — explicit no-behavior-change. Structured-output streaming keeps a hard 300s sub-ceiling because SPEC-019 §AC-V2-9 normatively pins 300s; the amendment decision is deferred (TODO in code), keeping `contract_change: "none"`.

Also: every streaming deadline expiry now routes through `settleIdleTimeout()` → `provider_timeout` — fixing the prior mis-classification of mid-stream wall expiry as `provider_disconnected`/`stream_truncated` (a SPEC-019 AC-V2-9 violation). Both `errors.Is(ctx.Err(), DeadlineExceeded)` checks migrated to `context.Cause` via `phaseDeadlineExceeded` (silent-regression trap otherwise). Concurrency-lease `ExpiresAt` scales with the effective ceiling (avoids re-opening the M1-8/PERF-6 slot-freed-while-running gap). `deadline_phase` added to request logs (additive only). 7 new YAML keys under `timeouts:` with fail-closed `Validate()` ordering rules; zero-value back-compat (configs setting none of the new keys get safe defaults).

Tripwire flipped: `TestSeamH1_ProgressingStreamSurvivesLegacyWall` — a steadily-emitting stream survives the legacy wall and completes. New coverage: endless-stream ceiling, heartbeat-only death at progress-idle (+content-progress control), first-token phase, admission fails fast pre-header, non-streaming still bounded, `streamCeiling` monotonicity unit, `newCoordinatorClient` has no body timeout (httptest-backed, real client), structured timeout uses Cause (pre-header + mid-stream), config validate cases. Full `phase5-gateway` suite green incl. `-race` on router+cmd; router package runtime dropped 442s → ~19s (old tests were waiting out real walls).

## Deploy notes (operator action before rollout)

1. ~~Fail-closed config check~~ **resolved in-PR**: the first CI run proved the fail-closed `header ≥ first_token` rule bricks short-header configs (the integration fixtures use 60s). `first_token_seconds` now defaults to 0 = derive `min(120s, header timeout)`, so any pre-#760 config boots unchanged with a coherent budget; only an explicitly-set conflicting value fails closed.
2. **Coordinator twin wall is now dominant**: `routing.request_timeout_s=280` / `provider_http.timeout_s=300` still cut at ~280s, so the gateway ceiling delivers no buyer-visible improvement past that until the coordinator overlay is raised and the C2/C2b deploy gates are retargeted at the streaming ceiling. Scoped as a follow-up (documented in `audits/seam-hardening/findings.md`).
3. Worst-case slot-hold rises from ~6min to ~16min for a content-progressing stream; `stream_ceiling_max_seconds` is the operator dial (documented in `gateway.yaml.example`).

## Audit (three codex lanes, full `origin/main...HEAD` diff)

R1 — one finding per lane, all fixed in-round:
- security R1 **HIGH**: the delta classifier was a denylist, so unknown delta keys (`delta:{"foo":"x"}`) counted as generated output — a provider could fabricate progress (reset the 10s timer, disarm first-token, hold a slot to the ceiling) and inflate gateway-estimated billing. Fixed: allowlist (`content`, `reasoning_content`, `refusal`, `arguments`, `text`) shared by billing estimation and deadline progress, + `TestUnknownDeltaKeyDoesNotCountAsProgress` / `TestDeltaClassifierAllowlist`.
- architect R1 MEDIUM: `non_stream_request_seconds` hard-defaulted to 300, silently regressing configs that had raised only `coordinator_request_seconds`. Fixed: 0/unset inherits the legacy wall; explicit values win.
- code R1 MEDIUM: admission expiry during retry backoff returned the stale retryable 502/503 with `err == nil`, passing raw JSON through to structured-streaming buyers instead of the SPEC-019 `provider_timeout` SSE. Fixed with a single caller-side conversion covering all three stale-resp return paths, + `TestStructuredTimeoutDuringRetryBackoff` (negative-checked).

R2 (all three lanes re-fired):
- architect: **PASS (0C/0H/0M)** — accepted, not re-fired further.
- code + security: the SAME single HIGH — the R1 per-key allowlist still counted an allowlisted leaf smuggled under an unknown container (`delta:{"foo":{"content":"x"}}`). Fixed: the classifier is now **path-aware** — a typed unmarshal extracts only the known OpenAI output paths (`delta.content`, `reasoning_content`, `refusal`, `text`, `function_call.arguments`, `tool_calls[].function.arguments`) and never descends through unknown containers. Regression cases at unit + streaming e2e level.

R3 (code + security only):
- code: **PASS (0 critical, 0 high, 0 medium)**
- security: **PASS (0 critical, 0 high, 0 medium)**

Post-R3, CI-driven: the first `ci-required` run went red because the `header ≥ first_token` Validate rule rejected the integration fixtures' 60s header timeout (the flagged boot-brick risk, proven). Fixed with the same inherit pattern as the non-stream wall (unset ⇒ derive `min(120s, header)`); the failing integration tests verified green locally. Config-surface change only; passed lanes not re-fired per repo convention.

Carried non-blocking: code R1 INFO (`streaming_idle_ms` ≤0 sentinel is unreachable behind validation — doc mismatch only); pre-existing gofmt drift in files not authored here; fail-closed consequence of the typed classifier — a delta whose `content` is a non-string (e.g. multimodal part arrays) counts zero progress and ends at the idle budget, intentional for this text-model marketplace.

Governance note: the requirement corpus does not yet cover the gateway request-lifecycle domain (SPEC-019/SPEC-006 have no conformance requirement IDs); citing the settlement-terminal pairing as the nearest real requirement.

SPEC-GOVERNANCE-DECLARATION-BEGIN
{
  "schema_version": "spec-pr-governance-v1",
  "behavior_change": "yes",
  "contract_change": "none",
  "specs": ["SPEC-019", "SPEC-006", "SPEC-036"],
  "requirements": ["SPEC-036-R001"],
  "authority_domains": ["structured-output", "buyer-api-error-contract", "compute-integrity-settlement"],
  "arbitration": ["CODE_BUG"],
  "tests": ["phase5-gateway/internal/router/seam_harness_test.go", "phase5-gateway/internal/router/request_deadlines_test.go"],
  "journeys": ["not-required"],
  "issue": "https://github.com/Augustas11/macprovider/issues/770"
}
SPEC-GOVERNANCE-DECLARATION-END

🤖 Generated with [Claude Code](https://claude.com/claude-code)
