### PR TITLE
Seam hardening P1: capacity clamp + over-claim tripwire (#764), fail-suspect on missing benchmark (#765)

### DIFF
--- a/audits/seam-hardening/findings.md
+++ b/audits/seam-hardening/findings.md
@@ -9,9 +9,9 @@ built) live in `harness/` and are named `TestSeam*`.
 |---|---|---|
 | 1 · settlement / deadline | **FAIL** | one flat request wall-clock; two money-integrity gaps |
 | 2 · cache-tenant-isolation | **PASS by construction** | server-authored account-HMAC scope; KV in-memory only |
-| 3 · backend-rollout-safety | **PASS (1 gap)** | strong flags/canary/self-update; perf telemetry not backend-segmented |
+| 3 · backend-rollout-safety | **PASS** (gap closed, #764) | strong flags/canary/self-update; perf telemetry now segmented by `binary_version` on `/poolz` |
 | 4 · attestation-honesty | **FAIL (client-facing)** | prose honest, but stat surfaces over-claim hardware trust |
-| 5 · fleet-version-floor | **PASS (2 gaps)** | blocks incompatible/known-bad builds; capacity trusted blindly |
+| 5 · fleet-version-floor | **PASS (1 gap)** | blocks incompatible/known-bad builds; capacity now clamped at ingest (#764); version floor still unset in prod (P2-2) |
 
 Fundamentals are strong (cache isolation, rollout discipline, signed-catalog admission,
 honest prose). Exposure concentrates in two client-facing FAILs (settlement flat-wall,
@@ -76,15 +76,66 @@ row — the buyer already got a committed 200. Tokens delivered, nobody billed, 
 sealed on terminal, with a startup recovery scan. Reservation-before-dispatch already exists.
 
 **P1-3 · Capacity trusted blindly; no clamp, no tripwire** — `ranking`/`supply` (closes a slice-3 + slice-5 gap)
-Provider-reported `max_concurrency` is granted verbatim (`phase4-coordinator/internal/ws/server.go:2249`,
-`:4196`, `relay.go:423`); the only drift signal is observe-only + default-off (`pow/drift.go:218`,
-`config.go:104`). A stale/over-claiming build serves silently. **Fix:** `min(hello, ceiling)` capacity
-clamp + a permanent over-claim tripwire counter on the heartbeat path, and segment TTFT/TPS rollups by
-`binary_version`/backend (`stats/handlers.go:78`). Keep the verified-benchmark baseline (`drift.go:151`).
+**FIXED coordinator-side (issue #764).** Nothing gateway-side: the gateway never reads
+provider capacity — the claim enters at the coordinator's provider-WS ingest and is consumed
+by coordinator routing and relay admission, so the clamp belongs there and there only.
+Provider-reported `max_concurrency` was granted verbatim (`phase4-coordinator/internal/ws/server.go:2249`,
+`:4196`, `relay.go:423`); the only drift signal was observe-only + default-off (`pow/drift.go:218`,
+`config.go:104`). A stale/over-claiming build served silently.
+**Shipped:**
+- `pool.max_concurrency_ceiling` (default **8**, `0` = disabled) — sized off the Mac/MLX reality
+  where requests serialize and the autotune recommender refuses `max_concurrency_override > 1`.
+- `pool.ClampCapacity` (`internal/pool/capacity_clamp.go`) applies `min(reported, ceiling)` and
+  keeps slots coherent: `slots_total <= clamped max`, `used = total - free` carried across the
+  clamp, `free` never negative and never above total.
+- Applied at **all three** provider-controlled ingest points, upstream of `pool.Registry`:
+  hello/registration, heartbeat, and `state_update` (the third one was not in the original
+  finding — an unclamped `state_update` would have restored inflated free slots right after a
+  clamped heartbeat). `relay.go` admission reads the clamped pool entry, so it needs no change.
+- Permanent tripwire `provider_capacity_over_claim_total{phase}` (prometheus counter; monotonic
+  for the process lifetime, incremented on **every** offending frame) + a
+  `provider_capacity_over_claim` warn log with provider_id / reported / ceiling / effective.
+- TTFT/TPS segmentation: the SPEC-017 rollup has no TTFT/TPS aggregate to extend (its overview
+  schema is a locked 14-field counter set with no latency), so the segmentation is additive on
+  the live snapshot surface — a `by_binary_version` block in the `/poolz` summary carrying
+  per-version provider/slot counts, canary-measured TTFT (avg + max) and sustained TPS, and the
+  provider-reported TPS estimate alongside. Fed by new
+  `pool.Registry.RecordCanaryLatency`, the coordinator's only live latency measurement.
+**Residual:** the segmentation covers canary-probed providers only — a provider that has never
+been probed (or a deployment with `pool.canary_enabled` off) contributes to the counts but not
+the latency averages; `*_samples` fields make that explicit rather than letting a zero read as
+"fast". Buyer-relay TTFT is still not timed into the pool. `/poolz` is operator-authenticated,
+so the segmentation is not a public surface.
+*Tripwire tests:* `internal/pool/capacity_clamp_test.go`, `internal/ws/capacity_clamp_test.go`,
+`internal/ws/poolz_version_segments_test.go`.
 
 **P1-4 · Runtime perf gate fails open on absent benchmark** — `ranking`
-`pow/drift.go` skips the TPS/hash check when `!hasBenchmark` — un-benchmarked providers are silently
-un-gated. **Fix:** treat "no verified benchmark" as quarantine-until-proven (absence = suspect).
+**FIXED coordinator-side (issue #765), shipped dormant.** Nothing gateway-side: routing
+eligibility is a coordinator concept. `pow/drift.go` skipped the TPS/hash check when
+`!hasBenchmark` — un-benchmarked providers were silently un-gated.
+**Shipped:** absence of a verified benchmark is now a distinct suspect bucket.
+- `pow.EvaluateHeartbeatWithVerdict` returns a tri-state `BenchmarkVerdict`
+  (Verified / Missing / Unknown) from the SAME evidence lookup the alerts already do — no extra
+  evidence-store round trip. Both silent-exit paths are covered: no verified evidence at all,
+  and evidence carrying no benchmark for the model actually being served.
+- A store **error** stays `Unknown` on purpose. Fail-suspect applies to provider claims, not to
+  infrastructure: a database blip must not quarantine the fleet.
+- Enforcement reuses the existing gating mechanism rather than inventing one — a
+  `BenchmarkQuarantined` flag on `pool.Provider` checked by `RoutingEligible()` /
+  `ServingCapable()`, exactly how the other suspect buckets (`AuthSelfMinted`, legacy catalog
+  admission, `PendingReceiptPubkey`) are expressed. No new state machine, no canary/breaker hold
+  collision.
+- **Config gate:** `proof_of_weights.telemetry_drift.quarantine_missing_benchmark`, default
+  false, and `Validate()` rejects it without `telemetry_drift.enabled` (itself default-off). Both
+  flags must be set before an un-benchmarked provider stops receiving buyer traffic, because the
+  verified-evidence pipeline does not yet cover the whole fleet. With the gate off the verdict is
+  always `Unknown` and routing is byte-for-byte pre-#765 — pinned by a unit test.
+**Residual:** enabling the gate on the current fleet would quarantine every provider without
+verified autotune hardware evidence; measuring that fraction on the live pool is a prerequisite
+to the rollout and has not been done. Release is per-heartbeat, so a provider that produces a
+benchmark is un-quarantined on its next heartbeat with no operator action.
+*Tripwire tests:* `internal/pow/drift_missing_benchmark_test.go`,
+`internal/pool/benchmark_quarantine_test.go`, `internal/ws/poolz_version_segments_test.go`.
 
 ### P2 — debt
 
@@ -125,6 +176,9 @@ timing side-channel. **Fix:** reconcile spec vs overlay; write the risk-acceptan
 
 1. **P0-1** + **P0-3** — two-line changes, highest stakes-per-character.
 2. **P0-2** — the flat-wall decomposition.
-3. **P1-3** — one clamp+tripwire closes the seam-3 and seam-5 gaps together.
+3. ~~**P1-3**~~ — **DONE (#764)**: one clamp+tripwire closed the seam-3 and seam-5 gaps together.
+   **P1-4** landed with it (#765) but ships dormant behind
+   `telemetry_drift.quarantine_missing_benchmark`; enabling it needs a live-fleet measurement of
+   how many providers lack verified benchmarks.
 4. **P1-1 / P1-2** — money integrity before real buyer volume.
 5. P2 as debt burn-down.

--- a/phase4-coordinator/cmd/coordinator/main.go
+++ b/phase4-coordinator/cmd/coordinator/main.go
@@ -524,6 +524,10 @@ func main() {
 	// transaction boundary. Generic Postgres signature exemptions are never
 	// recovery authority.
 	wsOpts = append(wsOpts, providerws.WithAdmissionIdentityRecoveryAdminStore(tokenStore))
+	// Issue #764 tripwire. Deliberately OUTSIDE the statsPools branch: the
+	// capacity ceiling is always active, so its counter must always be wired —
+	// a coordinator without a stats database must not silently lose the signal.
+	wsOpts = append(wsOpts, providerws.WithCapacityOverClaimMetrics(metricsHandle))
 	if statsPools != nil {
 		wsOpts = append(wsOpts, providerws.WithIdlePrewarmRecorder(statsprewarm.NewRecorder(statsPools.Rollup)))
 		wsOpts = append(wsOpts, providerws.WithIdlePrewarmMetrics(metricsHandle))
@@ -615,6 +619,7 @@ func main() {
 			cfg.ProofOfWeights.TelemetryDrift.OPoIPassRateWindow,
 			cfg.ProofOfWeights.TelemetryDrift.OPoIPassRateThreshold,
 			cfg.ProofOfWeights.TelemetryDrift.AlertCooldownSeconds,
+			cfg.ProofOfWeights.TelemetryDrift.QuarantineMissingBenchmark,
 		)
 		if err != nil {
 			logger.Fatal().Err(err).Msg("proof_of_weights.telemetry_drift config invalid")
@@ -626,6 +631,7 @@ func main() {
 			Float64("tps_ratio_threshold", driftCfg.TPSRatioThreshold).
 			Int("tps_min_requests_window", driftCfg.TPSMinRequestsWindow).
 			Int("opoi_pass_rate_window", driftCfg.OPoIPassRateWindow).
+			Bool("quarantine_missing_benchmark", driftCfg.QuarantineMissingBenchmark).
 			Msg("proof-of-weights telemetry drift alerts enabled")
 	}
 	if cfg.Auth.RequireProviderTokens {

--- a/phase4-coordinator/internal/config/config.go
+++ b/phase4-coordinator/internal/config/config.go
@@ -114,6 +114,15 @@ type TelemetryDriftConfig struct {
 	OPoIPassRateWindow       int      `yaml:"opoi_pass_rate_window"`
 	OPoIPassRateThreshold    float64  `yaml:"opoi_pass_rate_threshold"`
 	AlertCooldownSeconds     int      `yaml:"alert_cooldown_s"`
+	// QuarantineMissingBenchmark turns the "no verified benchmark" observation
+	// from a silent pass into a routing quarantine (fail-suspect, not
+	// fail-open). It is a SECOND gate on top of Enabled — enabling
+	// telemetry_drift alone keeps the existing observe-only posture and only
+	// starts emitting the `missing_benchmark` alert. Both flags must be true
+	// before an un-benchmarked provider stops receiving buyer traffic, because
+	// the verified-evidence pipeline (autotune hardware evidence) does not yet
+	// cover the whole fleet and a single-flag rollout could empty the pool.
+	QuarantineMissingBenchmark bool `yaml:"quarantine_missing_benchmark"`
 }
 
 type CoordinatorConfig struct {
@@ -449,7 +458,28 @@ type PoolConfig struct {
 	// routing.failover_timeout_s (which governs replacement selection, not
 	// liveness). Defaults to 90s (3x the 30s heartbeat interval).
 	HeartbeatMissThresholdS int `yaml:"heartbeat_miss_threshold_s"`
-	WakeGapThresholdS       int `yaml:"wake_gap_threshold_s"`
+	// MaxConcurrencyCeiling caps the provider-reported `max_concurrency` (and
+	// the derived slot counts) at ingest (issue #764). Without it a box
+	// reporting 9999 is granted 9999 admission slots and out-ranks the honest
+	// fleet.
+	//
+	// The default 8 is the LARGEST value the honest fleet can produce: the
+	// provider CLI derives max_concurrency from the RAM tier and its top tier
+	// (64GB+) is exactly 8 (phase3-binary/.../ProviderStatus.swift `defaults(
+	// forPhysicalMemoryGB:)` — 8GB→1, 16GB→2, 32GB→4, 64GB+→8). The autotune
+	// recommender is stricter still, refusing to publish a
+	// `max_concurrency_override` above 1 (internal/buyer/autotune_feeds.go),
+	// because these are Macs running MLX where a generation saturates
+	// unified-memory bandwidth and requests effectively serialize. So 8 clamps
+	// nothing a current honest provider reports while making a 9999 claim
+	// inert. Raise it only alongside a provider-side tier that legitimately
+	// exceeds it.
+	//
+	// An over-claiming provider is NOT rejected (it may simply be running an
+	// old or misconfigured build) — it is clamped and counted by the permanent
+	// over-claim tripwire. 0 disables the clamp entirely.
+	MaxConcurrencyCeiling int `yaml:"max_concurrency_ceiling"`
+	WakeGapThresholdS     int `yaml:"wake_gap_threshold_s"`
 	// WakeGapThresholdMs, when > 0, overrides WakeGapThresholdS for
 	// millisecond-precision test scenarios. Not for production use.
 	WakeGapThresholdMs      int  `yaml:"wake_gap_threshold_ms"`
@@ -975,6 +1005,7 @@ func Default() Config {
 			HeartbeatIntervalS:      30,
 			DisconnectGracePeriodS:  30,
 			HeartbeatMissThresholdS: 90,
+			MaxConcurrencyCeiling:   8,
 			WakeGapThresholdS:       120,
 			WarmupFallbackS:         60,
 			WarmupGateEnabled:       true,
@@ -1699,6 +1730,11 @@ func (c Config) Validate() error {
 	if c.Pool.WarmupFallbackS <= 0 {
 		return fmt.Errorf("pool warmup_fallback_s must be > 0")
 	}
+	// 0 is the explicit "no ceiling" escape hatch (pre-clamp behavior);
+	// negatives are always an operator typo.
+	if c.Pool.MaxConcurrencyCeiling < 0 {
+		return fmt.Errorf("pool.max_concurrency_ceiling must be >= 0 (0 disables the clamp)")
+	}
 	if c.Pool.WarmupGateEnabled && (c.Pool.WarmupGateTimeoutS <= 0 || c.Pool.WarmupGateMaxTokens <= 0) {
 		return fmt.Errorf("pool warmup gate settings must be > 0 when enabled")
 	}
@@ -2044,6 +2080,13 @@ func (c Config) validateProofOfWeights() error {
 		}
 	}
 	if !p.TelemetryDrift.Enabled {
+		// The quarantine is a second gate ON TOP of the drift evaluator; it
+		// cannot run without it. Rejecting the combination here (rather than
+		// silently ignoring it) keeps a half-configured overlay from reading
+		// as "enforcement on".
+		if p.TelemetryDrift.QuarantineMissingBenchmark {
+			return fmt.Errorf("proof_of_weights.telemetry_drift.quarantine_missing_benchmark requires telemetry_drift.enabled")
+		}
 		return nil
 	}
 	if p.AutotuneEvidenceTTLDays <= 0 {

--- a/phase4-coordinator/internal/config/seam_764_765_test.go
+++ b/phase4-coordinator/internal/config/seam_764_765_test.go
@@ -1,0 +1,60 @@
+package config_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/augstar/macprovider-coordinator/internal/config"
+)
+
+func seamValidatableConfig() config.Config {
+	cfg := config.Default()
+	cfg.Auth.OperatorKey = "test-operator-key"
+	cfg.Auth.GatewayServiceToken = "test-gateway-service-token"
+	return cfg
+}
+
+// The ceiling default must be a real number, not the Go zero value — a 0
+// default would ship the clamp disabled and silently reproduce issue #764.
+func TestDefaultMaxConcurrencyCeilingIsSet(t *testing.T) {
+	if got := config.Default().Pool.MaxConcurrencyCeiling; got != 8 {
+		t.Fatalf("Default().Pool.MaxConcurrencyCeiling = %d, want 8", got)
+	}
+}
+
+func TestValidateMaxConcurrencyCeiling(t *testing.T) {
+	cfg := seamValidatableConfig()
+	cfg.Pool.MaxConcurrencyCeiling = -1
+	if err := cfg.Validate(); err == nil || !strings.Contains(err.Error(), "pool.max_concurrency_ceiling") {
+		t.Fatalf("Validate() = %v, want a max_concurrency_ceiling error", err)
+	}
+
+	// 0 is the documented escape hatch back to pre-#764 behavior.
+	cfg.Pool.MaxConcurrencyCeiling = 0
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("Validate() with ceiling 0 = %v, want nil (0 disables the clamp)", err)
+	}
+
+	cfg.Pool.MaxConcurrencyCeiling = 16
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("Validate() with ceiling 16 = %v, want nil", err)
+	}
+}
+
+// Issue #765 dormancy: the quarantine must be off by default and must not be
+// configurable without the drift evaluator that produces its verdict.
+func TestQuarantineMissingBenchmarkDefaultsOffAndRequiresDriftEnabled(t *testing.T) {
+	if config.Default().ProofOfWeights.TelemetryDrift.QuarantineMissingBenchmark {
+		t.Fatal("telemetry_drift.quarantine_missing_benchmark must default to false")
+	}
+	if config.Default().ProofOfWeights.TelemetryDrift.Enabled {
+		t.Fatal("telemetry_drift.enabled must default to false")
+	}
+
+	cfg := seamValidatableConfig()
+	cfg.ProofOfWeights.TelemetryDrift.QuarantineMissingBenchmark = true
+	err := cfg.Validate()
+	if err == nil || !strings.Contains(err.Error(), "quarantine_missing_benchmark requires telemetry_drift.enabled") {
+		t.Fatalf("Validate() = %v, want the quarantine/enabled coupling error", err)
+	}
+}

--- a/phase4-coordinator/internal/pool/benchmark_quarantine_test.go
+++ b/phase4-coordinator/internal/pool/benchmark_quarantine_test.go
@@ -1,0 +1,96 @@
+package pool
+
+import (
+	"testing"
+	"time"
+)
+
+func quarantineTestProvider() *Provider {
+	return &Provider{
+		ProviderID:       "provider-a",
+		AssignedID:       "assigned-a",
+		ModelID:          "model-a",
+		State:            StateReady,
+		MaxConcurrency:   1,
+		SlotsTotal:       1,
+		SlotsFree:        1,
+		MaxContextTokens: 4096,
+		AdmittedAt:       time.Now().UTC(),
+	}
+}
+
+// Issue #765: the fail-suspect bucket must remove the provider from buyer
+// routing without touching its state, tier, or session.
+func TestBenchmarkQuarantineRemovesProviderFromRouting(t *testing.T) {
+	t.Parallel()
+	p := quarantineTestProvider()
+	if !p.RoutingEligible() || !p.ServingCapable() {
+		t.Fatalf("baseline provider must be routable: routing=%v serving=%v", p.RoutingEligible(), p.ServingCapable())
+	}
+	p.BenchmarkQuarantined = true
+	if p.RoutingEligible() {
+		t.Fatal("quarantined provider must not be routing eligible")
+	}
+	if p.ServingCapable() {
+		t.Fatal("quarantined provider must not count as buyer-serving capacity")
+	}
+	if p.State != StateReady {
+		t.Fatalf("quarantine must not mutate provider state, got %q", p.State)
+	}
+}
+
+func TestSetBenchmarkQuarantineReportsTransitionsOnly(t *testing.T) {
+	t.Parallel()
+	r := NewRegistry(nil)
+	if _, ok := r.RegisterAt(quarantineTestProvider(), nil, time.Now().UTC()); !ok {
+		t.Fatal("register failed")
+	}
+
+	if changed := r.SetBenchmarkQuarantine("provider-a", "assigned-a", true); !changed {
+		t.Fatal("first quarantine must report a transition")
+	}
+	if changed := r.SetBenchmarkQuarantine("provider-a", "assigned-a", true); changed {
+		t.Fatal("repeat quarantine must not report a transition (log once, not per heartbeat)")
+	}
+	snap := r.Snapshot()
+	if len(snap) != 1 || !snap[0].BenchmarkQuarantined {
+		t.Fatalf("snapshot did not carry the quarantine flag: %+v", snap)
+	}
+	if snap[0].RoutingEligible() {
+		t.Fatal("quarantined provider is still routing eligible in the snapshot")
+	}
+
+	if changed := r.SetBenchmarkQuarantine("provider-a", "assigned-a", false); !changed {
+		t.Fatal("release must report a transition")
+	}
+	snap = r.Snapshot()
+	if snap[0].BenchmarkQuarantined {
+		t.Fatal("release did not clear the quarantine flag")
+	}
+	if !snap[0].RoutingEligible() {
+		t.Fatal("released provider must be routable again")
+	}
+
+	// A stale session id must never move another session's flag.
+	if changed := r.SetBenchmarkQuarantine("provider-a", "stale-assigned", true); changed {
+		t.Fatal("stale assigned_id must not flip the quarantine flag")
+	}
+}
+
+func TestRecordCanaryLatencyKeepsLastRealObservation(t *testing.T) {
+	t.Parallel()
+	r := NewRegistry(nil)
+	if _, ok := r.RegisterAt(quarantineTestProvider(), nil, time.Now().UTC()); !ok {
+		t.Fatal("register failed")
+	}
+	r.RecordCanaryLatency("provider-a", "assigned-a", 1200, 18.5)
+	// A skipped / transport-failed probe measured nothing and must not zero it.
+	r.RecordCanaryLatency("provider-a", "assigned-a", 0, 0)
+	snap := r.Snapshot()
+	if snap[0].CanaryLastTTFTMS != 1200 {
+		t.Fatalf("ttft = %d, want 1200", snap[0].CanaryLastTTFTMS)
+	}
+	if snap[0].CanaryLastSustainedTPS != 18.5 {
+		t.Fatalf("tps = %v, want 18.5", snap[0].CanaryLastSustainedTPS)
+	}
+}

--- a/phase4-coordinator/internal/pool/capacity_clamp.go
+++ b/phase4-coordinator/internal/pool/capacity_clamp.go
@@ -37,9 +37,13 @@ type ClampedCapacity struct {
 //     one that claims 9999 total / 0 free (saturated) stays fully busy.
 //
 // A ceiling <= 0 disables the clamp and passes the triple through untouched, so
-// an operator can restore pre-#764 behavior without a code change. Negative or
-// absent reported values are left alone rather than invented: capacity is
-// clamped here, never fabricated.
+// an operator can restore pre-#764 behavior without a code change. With the
+// clamp active, a reported max_concurrency below 1 is floored to 1: a negative
+// (or zero) claim is not "less capacity" — downstream the relay admission
+// guard only enforces its cap when MaxConcurrency > 0, so letting a negative
+// value through would DISABLE concurrency admission entirely (security-lane
+// finding, audit R1). Flooring to 1 keeps the cap armed at the minimum and
+// counts the nonsense claim on the tripwire.
 func ClampCapacity(maxConcurrency, slotsTotal, slotsFree, ceiling int) ClampedCapacity {
 	out := ClampedCapacity{
 		MaxConcurrency: maxConcurrency,
@@ -50,14 +54,12 @@ func ClampCapacity(maxConcurrency, slotsTotal, slotsFree, ceiling int) ClampedCa
 	if ceiling <= 0 {
 		return out
 	}
-	out.OverClaimed = maxConcurrency > ceiling || slotsTotal > ceiling
+	out.OverClaimed = maxConcurrency > ceiling || slotsTotal > ceiling || maxConcurrency < 1
 	if out.MaxConcurrency > ceiling {
 		out.MaxConcurrency = ceiling
 	}
-	if out.MaxConcurrency < 0 {
-		// A negative claim is nonsense the ceiling cannot clamp, and the slot
-		// repair below would only propagate it. Leave the triple untouched.
-		return out
+	if out.MaxConcurrency < 1 {
+		out.MaxConcurrency = 1
 	}
 	// used is computed from the RAW pair so a saturated provider stays
 	// saturated after the ceiling shrinks its total.

--- a/phase4-coordinator/internal/pool/capacity_clamp.go
+++ b/phase4-coordinator/internal/pool/capacity_clamp.go
@@ -1,0 +1,84 @@
+package pool
+
+// Provider-reported capacity is a claim, not a measurement: `max_concurrency`,
+// `slots_total`, and `slots_free` all arrive verbatim from the provider binary
+// on hello and on every heartbeat. Before issue #764 they were granted as-is,
+// so a box reporting 9999 was handed 9999 admission slots — it out-ranked the
+// honest fleet and absorbed traffic it could not serve. The clamp below is the
+// ingest-side ceiling; it runs upstream of pool.Registry so every downstream
+// consumer (routing, relay admission, /poolz capacity, stats) sees only the
+// clamped numbers.
+
+// ClampedCapacity is the effective capacity after the operator ceiling has been
+// applied to one provider-reported triple.
+type ClampedCapacity struct {
+	MaxConcurrency int
+	SlotsTotal     int
+	SlotsFree      int
+	// OverClaimed reports that the provider claimed capacity ABOVE the ceiling
+	// — the tripwire condition. It is deliberately narrower than "something
+	// changed": a coherence-only repair (slots_total above max_concurrency but
+	// both under the ceiling) is a provider bug, not an over-claim.
+	OverClaimed bool
+	// ReportedMax is the raw claim, retained for the tripwire log line.
+	ReportedMax int
+}
+
+// ClampCapacity applies ceiling to a provider-reported (max_concurrency,
+// slots_total, slots_free) triple.
+//
+// Coherence rules, in order:
+//
+//  1. effective max_concurrency = min(reported, ceiling)
+//  2. slots_total may never exceed the effective max_concurrency
+//  3. the used/free relationship is preserved: used = total - free is carried
+//     across the clamp, and free is re-derived as total - used. A provider that
+//     claims 9999 total / 9999 free (idle) stays fully free after clamping;
+//     one that claims 9999 total / 0 free (saturated) stays fully busy.
+//
+// A ceiling <= 0 disables the clamp and passes the triple through untouched, so
+// an operator can restore pre-#764 behavior without a code change. Negative or
+// absent reported values are left alone rather than invented: capacity is
+// clamped here, never fabricated.
+func ClampCapacity(maxConcurrency, slotsTotal, slotsFree, ceiling int) ClampedCapacity {
+	out := ClampedCapacity{
+		MaxConcurrency: maxConcurrency,
+		SlotsTotal:     slotsTotal,
+		SlotsFree:      slotsFree,
+		ReportedMax:    maxConcurrency,
+	}
+	if ceiling <= 0 {
+		return out
+	}
+	out.OverClaimed = maxConcurrency > ceiling || slotsTotal > ceiling
+	if out.MaxConcurrency > ceiling {
+		out.MaxConcurrency = ceiling
+	}
+	if out.MaxConcurrency < 0 {
+		// A negative claim is nonsense the ceiling cannot clamp, and the slot
+		// repair below would only propagate it. Leave the triple untouched.
+		return out
+	}
+	// used is computed from the RAW pair so a saturated provider stays
+	// saturated after the ceiling shrinks its total.
+	used := slotsTotal - slotsFree
+	if used < 0 {
+		used = 0
+	}
+	if out.SlotsTotal > out.MaxConcurrency {
+		out.SlotsTotal = out.MaxConcurrency
+	}
+	if out.SlotsTotal < 0 {
+		out.SlotsTotal = 0
+	}
+	if used > out.SlotsTotal {
+		used = out.SlotsTotal
+	}
+	if free := out.SlotsTotal - used; free < out.SlotsFree {
+		out.SlotsFree = free
+	}
+	if out.SlotsFree < 0 {
+		out.SlotsFree = 0
+	}
+	return out
+}

--- a/phase4-coordinator/internal/pool/capacity_clamp_test.go
+++ b/phase4-coordinator/internal/pool/capacity_clamp_test.go
@@ -62,9 +62,26 @@ func TestClampCapacity(t *testing.T) {
 			wantMax: 9999, wantTotal: 9999, wantFree: 9999,
 		},
 		{
-			name:           "negative claim is left alone rather than fabricated",
+			// Audit R1 (security): a negative claim must NOT pass through —
+			// the relay admission guard only enforces when MaxConcurrency > 0,
+			// so an untouched -1 would disable concurrency admission
+			// entirely. Floor to 1 and count it on the tripwire.
+			name:           "negative claim floors to one and trips the counter",
 			maxConcurrency: -1, total: 0, free: 0, ceil: 8,
-			wantMax: -1, wantTotal: 0, wantFree: 0,
+			wantMax: 1, wantTotal: 0, wantFree: 0,
+			wantOverClaim: true,
+		},
+		{
+			name:           "negative claim with inflated slots floors and clamps",
+			maxConcurrency: -1, total: 9999, free: 9999, ceil: 8,
+			wantMax: 1, wantTotal: 1, wantFree: 1,
+			wantOverClaim: true,
+		},
+		{
+			name:           "zero claim floors to one and trips the counter",
+			maxConcurrency: 0, total: 0, free: 0, ceil: 8,
+			wantMax: 1, wantTotal: 0, wantFree: 0,
+			wantOverClaim: true,
 		},
 	}
 	for _, tc := range cases {

--- a/phase4-coordinator/internal/pool/capacity_clamp_test.go
+++ b/phase4-coordinator/internal/pool/capacity_clamp_test.go
@@ -1,0 +1,115 @@
+package pool
+
+import "testing"
+
+func TestClampCapacity(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name                              string
+		maxConcurrency, total, free, ceil int
+		wantMax, wantTotal, wantFree      int
+		wantOverClaim                     bool
+	}{
+		{
+			name:           "under ceiling is untouched",
+			maxConcurrency: 4, total: 4, free: 2, ceil: 8,
+			wantMax: 4, wantTotal: 4, wantFree: 2,
+		},
+		{
+			name:           "exactly at ceiling is not an over-claim",
+			maxConcurrency: 8, total: 8, free: 8, ceil: 8,
+			wantMax: 8, wantTotal: 8, wantFree: 8,
+		},
+		{
+			name:           "absurd idle claim collapses to the ceiling and stays fully free",
+			maxConcurrency: 9999, total: 9999, free: 9999, ceil: 8,
+			wantMax: 8, wantTotal: 8, wantFree: 8,
+			wantOverClaim: true,
+		},
+		{
+			name:           "absurd saturated claim stays saturated after clamping",
+			maxConcurrency: 9999, total: 9999, free: 0, ceil: 8,
+			wantMax: 8, wantTotal: 8, wantFree: 0,
+			wantOverClaim: true,
+		},
+		{
+			name:           "partial usage is carried across the clamp",
+			maxConcurrency: 100, total: 100, free: 97, ceil: 8,
+			// used = 3 → free = 8 - 3 = 5
+			wantMax: 8, wantTotal: 8, wantFree: 5,
+			wantOverClaim: true,
+		},
+		{
+			name:           "usage above the clamped total cannot drive free negative",
+			maxConcurrency: 100, total: 100, free: 1, ceil: 8,
+			wantMax: 8, wantTotal: 8, wantFree: 0,
+			wantOverClaim: true,
+		},
+		{
+			name:           "slots_total above max_concurrency is repaired below the ceiling",
+			maxConcurrency: 2, total: 4, free: 4, ceil: 8,
+			wantMax: 2, wantTotal: 2, wantFree: 2,
+		},
+		{
+			name:           "slots_total alone above the ceiling is an over-claim",
+			maxConcurrency: 4, total: 9999, free: 9999, ceil: 8,
+			wantMax: 4, wantTotal: 4, wantFree: 4,
+			wantOverClaim: true,
+		},
+		{
+			name:           "zero ceiling disables the clamp entirely",
+			maxConcurrency: 9999, total: 9999, free: 9999, ceil: 0,
+			wantMax: 9999, wantTotal: 9999, wantFree: 9999,
+		},
+		{
+			name:           "negative claim is left alone rather than fabricated",
+			maxConcurrency: -1, total: 0, free: 0, ceil: 8,
+			wantMax: -1, wantTotal: 0, wantFree: 0,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := ClampCapacity(tc.maxConcurrency, tc.total, tc.free, tc.ceil)
+			if got.MaxConcurrency != tc.wantMax || got.SlotsTotal != tc.wantTotal || got.SlotsFree != tc.wantFree {
+				t.Fatalf("ClampCapacity(%d,%d,%d,%d) = (max %d, total %d, free %d), want (%d, %d, %d)",
+					tc.maxConcurrency, tc.total, tc.free, tc.ceil,
+					got.MaxConcurrency, got.SlotsTotal, got.SlotsFree,
+					tc.wantMax, tc.wantTotal, tc.wantFree)
+			}
+			if got.OverClaimed != tc.wantOverClaim {
+				t.Fatalf("OverClaimed = %v, want %v", got.OverClaimed, tc.wantOverClaim)
+			}
+			if got.ReportedMax != tc.maxConcurrency {
+				t.Fatalf("ReportedMax = %d, want the raw claim %d", got.ReportedMax, tc.maxConcurrency)
+			}
+		})
+	}
+}
+
+// Slot coherence is the invariant the ranking layer depends on: a clamped
+// provider must never advertise more free slots than it has total, and never
+// more total than its clamped concurrency.
+func TestClampCapacitySlotCoherence(t *testing.T) {
+	t.Parallel()
+	const ceiling = 8
+	for maxConcurrency := 0; maxConcurrency <= 40; maxConcurrency += 7 {
+		for total := 0; total <= 40; total += 5 {
+			for free := 0; free <= 40; free += 3 {
+				got := ClampCapacity(maxConcurrency, total, free, ceiling)
+				if got.MaxConcurrency > ceiling {
+					t.Fatalf("max_concurrency %d exceeds ceiling for (%d,%d,%d)", got.MaxConcurrency, maxConcurrency, total, free)
+				}
+				if got.SlotsTotal > got.MaxConcurrency {
+					t.Fatalf("slots_total %d exceeds clamped max %d for (%d,%d,%d)", got.SlotsTotal, got.MaxConcurrency, maxConcurrency, total, free)
+				}
+				if got.SlotsFree > got.SlotsTotal {
+					t.Fatalf("slots_free %d exceeds slots_total %d for (%d,%d,%d)", got.SlotsFree, got.SlotsTotal, maxConcurrency, total, free)
+				}
+				if got.SlotsFree < 0 {
+					t.Fatalf("slots_free %d is negative for (%d,%d,%d)", got.SlotsFree, maxConcurrency, total, free)
+				}
+			}
+		}
+	}
+}

--- a/phase4-coordinator/internal/pool/provider.go
+++ b/phase4-coordinator/internal/pool/provider.go
@@ -2187,6 +2187,20 @@ func (r *Registry) Conn(providerID, assignedID string) (net.Conn, error) {
 	return p.conn, nil
 }
 
+// CurrentMaxConcurrency returns the live (already ingest-clamped) concurrency
+// cap for a registered provider. Used by the state_update slot clamp so a
+// provider cannot report slot counts above its own admitted capacity (#764
+// audit R1, security lane).
+func (r *Registry) CurrentMaxConcurrency(providerID string) (int, bool) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	p := r.providers[providerID]
+	if p == nil {
+		return 0, false
+	}
+	return p.MaxConcurrency, true
+}
+
 func (r *Registry) Snapshot() []Provider {
 	r.mu.RLock()
 	defer r.mu.RUnlock()

--- a/phase4-coordinator/internal/pool/provider.go
+++ b/phase4-coordinator/internal/pool/provider.go
@@ -178,6 +178,20 @@ type Provider struct {
 	CanaryFailCount     int             `json:"canary_fail_count,omitempty"`
 	CanaryLastCheckedAt *time.Time      `json:"canary_last_checked_at,omitempty"`
 	CanaryLastFailedAt  *time.Time      `json:"canary_last_failed_at,omitempty"`
+	// CanaryLastTTFTMS / CanaryLastSustainedTPS are the wall-time latency
+	// metrics of the most recent completed canary probe. They are the only
+	// coordinator-measured live TTFT/TPS signal (buyer relays are not timed
+	// into the pool), so /poolz uses them for the per-binary_version
+	// segmentation that isolates a slow backend build. Zero = never probed.
+	CanaryLastTTFTMS       int     `json:"canary_last_ttft_ms,omitempty"`
+	CanaryLastSustainedTPS float64 `json:"canary_last_sustained_tps,omitempty"`
+	// BenchmarkQuarantined marks a provider that has no verified autotune
+	// benchmark while the telemetry-drift quarantine gate is enabled. Absence
+	// of a benchmark is a DISTINCT suspect bucket (issue #765): it is not proof
+	// of misbehaviour, so the session stays admitted and operator-visible, but
+	// it is fail-suspect rather than fail-open and receives no buyer traffic
+	// until a benchmark exists. Always false when the gate is off.
+	BenchmarkQuarantined bool `json:"benchmark_quarantined,omitempty"`
 	// LastBuyerSuccessAt is the most recent coordinator-observed successful
 	// buyer relay for this provider (HTTP 2xx / completed stream). Used by
 	// FR-CAN23 observed-serving residual so a peer that never served buyers
@@ -439,6 +453,9 @@ func (p Provider) RoutingEligible() bool {
 	if len(p.PendingReceiptPubkey) > 0 {
 		return false
 	}
+	if p.BenchmarkQuarantined {
+		return false
+	}
 	return p.State == StateReady && p.SlotsFree > 0
 }
 
@@ -456,6 +473,9 @@ func (p Provider) ServingCapable() bool {
 		return false
 	}
 	if len(p.PendingReceiptPubkey) > 0 {
+		return false
+	}
+	if p.BenchmarkQuarantined {
 		return false
 	}
 	return p.State == StateReady || p.State == StateBusy
@@ -1563,6 +1583,43 @@ func (r *Registry) SetModelClassOPoIPass(providerID, assignedID string, pass *bo
 		return
 	}
 	p.ModelClassOPoIPass = pass
+}
+
+// RecordCanaryLatency stores the wall-time metrics of a completed canary probe
+// so /poolz can segment live TTFT/TPS by binary_version. Non-positive values
+// are ignored (a skipped or transport-failed probe measured nothing), which
+// keeps the last real observation rather than zeroing it.
+func (r *Registry) RecordCanaryLatency(providerID, assignedID string, ttftMS int, sustainedTPS float64) {
+	if ttftMS <= 0 {
+		return
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	p := r.providers[providerID]
+	if p == nil || p.AssignedID != assignedID {
+		return
+	}
+	p.CanaryLastTTFTMS = ttftMS
+	if sustainedTPS > 0 && !math.IsNaN(sustainedTPS) && !math.IsInf(sustainedTPS, 0) {
+		p.CanaryLastSustainedTPS = sustainedTPS
+	}
+}
+
+// SetBenchmarkQuarantine flips the issue-#765 fail-suspect bucket for a live
+// session. Returns true when the flag CHANGED, so the caller can log the
+// transition once instead of on every heartbeat.
+func (r *Registry) SetBenchmarkQuarantine(providerID, assignedID string, quarantined bool) bool {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	p := r.providers[providerID]
+	if p == nil || p.AssignedID != assignedID {
+		return false
+	}
+	if p.BenchmarkQuarantined == quarantined {
+		return false
+	}
+	p.BenchmarkQuarantined = quarantined
+	return true
 }
 
 func (r *Registry) applyCanarySanctionLocked(p *Provider) {

--- a/phase4-coordinator/internal/pow/drift.go
+++ b/phase4-coordinator/internal/pow/drift.go
@@ -16,6 +16,13 @@ const EventTelemetryDriftDetected = "pow_telemetry_drift_detected"
 
 const defaultTPSMinRequestsWindow = 2
 
+// SignalMissingBenchmark is the issue-#765 suspect bucket: the provider has no
+// verified autotune benchmark, so the TPS and artifact-drift gates below have
+// no baseline to compare against. Before #765 that state exited the evaluator
+// silently (fail-open) — it is now a named signal and, when
+// QuarantineMissingBenchmark is set, a routing quarantine.
+const SignalMissingBenchmark = "missing_benchmark"
+
 type TelemetryDriftConfig struct {
 	Enabled                  bool
 	TPSRatioThreshold        float64
@@ -26,7 +33,30 @@ type TelemetryDriftConfig struct {
 	OPoIPassRateWindow       int
 	OPoIPassRateThreshold    float64
 	AlertCooldown            time.Duration
+	// QuarantineMissingBenchmark escalates SignalMissingBenchmark from an
+	// observe-only alert to BenchmarkVerdictMissing, which the caller applies
+	// as a routing quarantine. Default false so the evaluator keeps its
+	// existing observe posture until an operator opts in.
+	QuarantineMissingBenchmark bool
 }
+
+// BenchmarkVerdict is the evaluator's per-heartbeat opinion on whether the
+// provider has a verified-benchmark baseline. It is deliberately tri-state: an
+// evidence-store failure MUST NOT read as "no benchmark", or a database blip
+// would quarantine the whole fleet.
+type BenchmarkVerdict int
+
+const (
+	// BenchmarkVerdictUnknown — evaluator disabled, quarantine gate off, or the
+	// evidence lookup errored. The caller leaves the quarantine flag as-is.
+	BenchmarkVerdictUnknown BenchmarkVerdict = iota
+	// BenchmarkVerdictVerified — a verified benchmark resolved for the
+	// provider's live model. The caller clears any quarantine.
+	BenchmarkVerdictVerified
+	// BenchmarkVerdictMissing — the provider has no verified benchmark. The
+	// caller quarantines it until one exists.
+	BenchmarkVerdictMissing
+)
 
 type Alert struct {
 	Signal               string
@@ -105,23 +135,74 @@ func ResolveVerifiedBenchmark(catalog *autotune.Catalog, evidence autotune.Verif
 	return autotune.VerifiedBenchmark{}, false
 }
 
+// EvaluateHeartbeat preserves the pre-#765 alert-only contract for callers that
+// do not act on the benchmark verdict.
 func (e *Evaluator) EvaluateHeartbeat(ctx context.Context, provider pool.Provider) []Alert {
+	alerts, _ := e.EvaluateHeartbeatWithVerdict(ctx, provider)
+	return alerts
+}
+
+// EvaluateHeartbeatWithVerdict returns the drift alerts plus the issue-#765
+// verified-benchmark verdict.
+//
+// The verdict is computed from the SAME evidence lookup the alerts use, so the
+// quarantine costs no extra evidence-store round trip. Note the two distinct
+// "no benchmark" paths, both of which used to exit silently: the provider may
+// have no verified evidence AT ALL (LatestVerified !ok), or evidence that
+// carries no benchmark for the model it is currently serving
+// (ResolveVerifiedBenchmark false). Both are suspect; a store ERROR is not.
+func (e *Evaluator) EvaluateHeartbeatWithVerdict(ctx context.Context, provider pool.Provider) ([]Alert, BenchmarkVerdict) {
 	if e == nil || !e.cfg.Enabled {
-		return nil
+		return nil, BenchmarkVerdictUnknown
 	}
 	evidence, ok, err := e.evidence.LatestVerified(ctx, provider.ProviderID, e.evidenceTTL)
-	if err != nil || !ok {
-		return nil
+	if err != nil {
+		// Infrastructure failure, not a provider claim. Fail neutral: keep the
+		// previous verdict rather than quarantining (or releasing) on a blip.
+		return nil, BenchmarkVerdictUnknown
 	}
-	benchmark, hasBenchmark := ResolveVerifiedBenchmark(e.catalog, evidence, provider.ModelID)
+	var (
+		benchmark    autotune.VerifiedBenchmark
+		hasBenchmark bool
+	)
+	if ok {
+		benchmark, hasBenchmark = ResolveVerifiedBenchmark(e.catalog, evidence, provider.ModelID)
+	}
 	var alerts []Alert
-	if alert, ok := e.evaluateTPS(provider, benchmark, hasBenchmark); ok {
-		alerts = append(alerts, alert)
+	if !hasBenchmark {
+		alerts = append(alerts, Alert{
+			Signal:     SignalMissingBenchmark,
+			ProviderID: provider.ProviderID,
+			AssignedID: provider.AssignedID,
+			ModelID:    provider.ModelID,
+		})
 	}
-	if alert, ok := e.evaluateHash(provider, benchmark, hasBenchmark); ok {
-		alerts = append(alerts, alert)
+	if ok {
+		// Unchanged pre-#765 behavior: the TPS and hash gates run only when the
+		// provider has verified evidence. A provider with no evidence at all
+		// reaches only the missing-benchmark signal above, exactly as it
+		// previously reached nothing.
+		if alert, fired := e.evaluateTPS(provider, benchmark, hasBenchmark); fired {
+			alerts = append(alerts, alert)
+		}
+		if alert, fired := e.evaluateHash(provider, benchmark, hasBenchmark); fired {
+			alerts = append(alerts, alert)
+		}
 	}
-	return e.filterCooldown(alerts)
+	return e.filterCooldown(alerts), e.benchmarkVerdict(hasBenchmark)
+}
+
+// benchmarkVerdict keeps the enforcement decision behind the second config
+// gate. With the gate off the caller is told nothing changed, so the flag it
+// owns is never set and routing is byte-for-byte the pre-#765 behavior.
+func (e *Evaluator) benchmarkVerdict(hasBenchmark bool) BenchmarkVerdict {
+	if !e.cfg.QuarantineMissingBenchmark {
+		return BenchmarkVerdictUnknown
+	}
+	if hasBenchmark {
+		return BenchmarkVerdictVerified
+	}
+	return BenchmarkVerdictMissing
 }
 
 func (e *Evaluator) RecordModelClassCanary(provider pool.Provider, passed bool) []Alert {
@@ -290,21 +371,22 @@ func ParseHashAlertStatuses(values []string) ([]pool.HashStatus, error) {
 	return out, nil
 }
 
-func TelemetryDriftConfigFrom(enabled bool, tpsRatio, tpsMinAbsolute float64, tpsMinRequestsWindow int, hashStatuses []string, hashArtifactDrift bool, opoiWindow int, opoiThreshold float64, cooldownSeconds int) (TelemetryDriftConfig, error) {
+func TelemetryDriftConfigFrom(enabled bool, tpsRatio, tpsMinAbsolute float64, tpsMinRequestsWindow int, hashStatuses []string, hashArtifactDrift bool, opoiWindow int, opoiThreshold float64, cooldownSeconds int, quarantineMissingBenchmark bool) (TelemetryDriftConfig, error) {
 	statuses, err := ParseHashAlertStatuses(hashStatuses)
 	if err != nil {
 		return TelemetryDriftConfig{}, err
 	}
 	cooldown := time.Duration(cooldownSeconds) * time.Second
 	return TelemetryDriftConfig{
-		Enabled:                  enabled,
-		TPSRatioThreshold:        tpsRatio,
-		TPSMinAbsolute:           tpsMinAbsolute,
-		TPSMinRequestsWindow:     tpsMinRequestsWindow,
-		HashAlertOnStatus:        statuses,
-		HashAlertOnArtifactDrift: hashArtifactDrift,
-		OPoIPassRateWindow:       opoiWindow,
-		OPoIPassRateThreshold:    opoiThreshold,
-		AlertCooldown:            cooldown,
+		QuarantineMissingBenchmark: quarantineMissingBenchmark,
+		Enabled:                    enabled,
+		TPSRatioThreshold:          tpsRatio,
+		TPSMinAbsolute:             tpsMinAbsolute,
+		TPSMinRequestsWindow:       tpsMinRequestsWindow,
+		HashAlertOnStatus:          statuses,
+		HashAlertOnArtifactDrift:   hashArtifactDrift,
+		OPoIPassRateWindow:         opoiWindow,
+		OPoIPassRateThreshold:      opoiThreshold,
+		AlertCooldown:              cooldown,
 	}, nil
 }

--- a/phase4-coordinator/internal/pow/drift_missing_benchmark_test.go
+++ b/phase4-coordinator/internal/pow/drift_missing_benchmark_test.go
@@ -1,0 +1,150 @@
+package pow
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/augstar/macprovider-coordinator/internal/autotune"
+	"github.com/augstar/macprovider-coordinator/internal/pool"
+)
+
+type erroringEvidence struct{}
+
+func (erroringEvidence) LatestVerified(context.Context, string, time.Duration) (autotune.VerifiedEvidence, bool, error) {
+	return autotune.VerifiedEvidence{}, false, errors.New("evidence store down")
+}
+
+func missingBenchmarkCatalog(t *testing.T) *autotune.Catalog {
+	t.Helper()
+	return mustCatalog(t, `{
+		"version":"test","source":"operator_curated_autotune_candidate_catalog",
+		"rows":{"qwen3-coder-30b-a3b-instruct":{"model_id":"mlx-community/Qwen3-Coder-30B-A3B-Instruct-4bit","min_ram_gb":28,"bench_gate":{"min_sustained_tps":20,"max_4k_ttft_ms":3500}}}
+	}`)
+}
+
+func missingBenchmarkProvider() pool.Provider {
+	return pool.Provider{
+		ProviderID: "mac",
+		AssignedID: "sess-1",
+		ModelID:    "qwen3-coder-30b-a3b-instruct",
+		HashStatus: pool.HashStatusVerified,
+	}
+}
+
+func verifiedBenchmarkEvidence() autotune.VerifiedEvidence {
+	return autotune.VerifiedEvidence{
+		Benchmarks: []autotune.VerifiedBenchmark{{
+			ModelKey:       "qwen3-coder-30b-a3b-instruct",
+			ModelID:        "mlx-community/Qwen3-Coder-30B-A3B-Instruct-4bit",
+			SustainedTPS:   20,
+			ArtifactSHA256: "abc123",
+		}},
+	}
+}
+
+func newMissingBenchmarkEvaluator(t *testing.T, quarantine bool, evidence autotune.EvidenceStore) *Evaluator {
+	t.Helper()
+	e := NewEvaluator(TelemetryDriftConfig{
+		Enabled:                    true,
+		TPSRatioThreshold:          0.70,
+		AlertCooldown:              time.Second,
+		QuarantineMissingBenchmark: quarantine,
+	}, missingBenchmarkCatalog(t), evidence, 30*24*time.Hour)
+	e.now = func() time.Time { return time.Unix(0, 0) }
+	return e
+}
+
+// Issue #765 acceptance: with the gate ENABLED, a provider with no verified
+// benchmark yields the Missing verdict the caller turns into a quarantine.
+func TestEvaluateHeartbeatMissingBenchmarkQuarantinesWhenEnabled(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name     string
+		evidence autotune.EvidenceStore
+	}{
+		{name: "no verified evidence at all", evidence: stubEvidence{ok: false}},
+		{
+			name: "evidence without a benchmark for the served model",
+			evidence: stubEvidence{ok: true, evidence: autotune.VerifiedEvidence{
+				Benchmarks: []autotune.VerifiedBenchmark{{
+					ModelKey:     "some-other-model",
+					ModelID:      "mlx-community/Some-Other-Model",
+					SustainedTPS: 20,
+				}},
+			}},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			evaluator := newMissingBenchmarkEvaluator(t, true, tc.evidence)
+			alerts, verdict := evaluator.EvaluateHeartbeatWithVerdict(context.Background(), missingBenchmarkProvider())
+			if verdict != BenchmarkVerdictMissing {
+				t.Fatalf("verdict = %v, want BenchmarkVerdictMissing", verdict)
+			}
+			if len(alerts) == 0 || alerts[0].Signal != SignalMissingBenchmark {
+				t.Fatalf("alerts = %#v, want a %s alert", alerts, SignalMissingBenchmark)
+			}
+		})
+	}
+}
+
+// Pins the CURRENT default posture: with the quarantine gate off, an
+// un-benchmarked provider produces no verdict, so routing is unchanged.
+func TestEvaluateHeartbeatMissingBenchmarkIsObserveOnlyByDefault(t *testing.T) {
+	t.Parallel()
+	evaluator := newMissingBenchmarkEvaluator(t, false, stubEvidence{ok: false})
+	alerts, verdict := evaluator.EvaluateHeartbeatWithVerdict(context.Background(), missingBenchmarkProvider())
+	if verdict != BenchmarkVerdictUnknown {
+		t.Fatalf("verdict = %v, want BenchmarkVerdictUnknown with the gate off", verdict)
+	}
+	if len(alerts) != 1 || alerts[0].Signal != SignalMissingBenchmark {
+		t.Fatalf("alerts = %#v, want the observe-only %s alert", alerts, SignalMissingBenchmark)
+	}
+}
+
+// A disabled evaluator must be completely inert — the pre-#765 contract.
+func TestEvaluateHeartbeatDisabledEvaluatorIsInert(t *testing.T) {
+	t.Parallel()
+	var evaluator *Evaluator
+	alerts, verdict := evaluator.EvaluateHeartbeatWithVerdict(context.Background(), missingBenchmarkProvider())
+	if len(alerts) != 0 || verdict != BenchmarkVerdictUnknown {
+		t.Fatalf("nil evaluator = (%#v, %v), want (nil, Unknown)", alerts, verdict)
+	}
+	disabled := NewEvaluator(TelemetryDriftConfig{QuarantineMissingBenchmark: true}, missingBenchmarkCatalog(t), stubEvidence{ok: false}, time.Hour)
+	alerts, verdict = disabled.EvaluateHeartbeatWithVerdict(context.Background(), missingBenchmarkProvider())
+	if len(alerts) != 0 || verdict != BenchmarkVerdictUnknown {
+		t.Fatalf("disabled evaluator = (%#v, %v), want (nil, Unknown)", alerts, verdict)
+	}
+}
+
+// A verified benchmark releases the quarantine ("until it produces one").
+func TestEvaluateHeartbeatVerifiedBenchmarkReleasesQuarantine(t *testing.T) {
+	t.Parallel()
+	evaluator := newMissingBenchmarkEvaluator(t, true, stubEvidence{ok: true, evidence: verifiedBenchmarkEvidence()})
+	alerts, verdict := evaluator.EvaluateHeartbeatWithVerdict(context.Background(), missingBenchmarkProvider())
+	if verdict != BenchmarkVerdictVerified {
+		t.Fatalf("verdict = %v, want BenchmarkVerdictVerified", verdict)
+	}
+	for _, alert := range alerts {
+		if alert.Signal == SignalMissingBenchmark {
+			t.Fatalf("unexpected %s alert for a benchmarked provider: %#v", SignalMissingBenchmark, alert)
+		}
+	}
+}
+
+// An evidence-store failure is infrastructure, not a provider claim. It must
+// stay Unknown or a database blip would quarantine the whole fleet.
+func TestEvaluateHeartbeatEvidenceErrorDoesNotQuarantine(t *testing.T) {
+	t.Parallel()
+	evaluator := newMissingBenchmarkEvaluator(t, true, erroringEvidence{})
+	alerts, verdict := evaluator.EvaluateHeartbeatWithVerdict(context.Background(), missingBenchmarkProvider())
+	if verdict != BenchmarkVerdictUnknown {
+		t.Fatalf("verdict = %v, want BenchmarkVerdictUnknown on an evidence-store error", verdict)
+	}
+	if len(alerts) != 0 {
+		t.Fatalf("alerts = %#v, want none on an evidence-store error", alerts)
+	}
+}

--- a/phase4-coordinator/internal/stats/metrics/metrics.go
+++ b/phase4-coordinator/internal/stats/metrics/metrics.go
@@ -71,6 +71,11 @@ type Metrics struct {
 	CredentialBootstrapTotal     *prometheus.CounterVec
 	ReferralEventTotal           *prometheus.CounterVec
 	ProviderConnectionEventTotal *prometheus.CounterVec
+	// CapacityOverClaimTotal is the issue-#764 over-claim tripwire. It is
+	// PERMANENT by construction: a prometheus counter never decreases and is
+	// never reset for the process lifetime, and the coordinator increments it
+	// on every offending frame rather than once per provider.
+	CapacityOverClaimTotal *prometheus.CounterVec
 }
 
 // New registers all five metrics against reg and returns the
@@ -157,6 +162,13 @@ func New(reg prometheus.Registerer) *Metrics {
 				Help: "Count of provider hash status transitions to hash_mismatch (Proof of Weights W1 observability).",
 			},
 		),
+		CapacityOverClaimTotal: f.NewCounterVec(
+			prometheus.CounterOpts{
+				Name: "provider_capacity_over_claim_total",
+				Help: "Permanent count of provider-reported capacity claims above pool.max_concurrency_ceiling, by ingest phase.",
+			},
+			[]string{"phase"},
+		),
 		CredentialBootstrapTotal: f.NewCounterVec(
 			prometheus.CounterOpts{
 				Name: "credential_bootstrap_total",
@@ -242,6 +254,16 @@ func (m *Metrics) IncModelHashMismatch() {
 		return
 	}
 	m.ModelHashMismatchTotal.Inc()
+}
+
+// IncCapacityOverClaim records one provider capacity claim above the operator
+// ceiling. phase is a closed set ("hello" | "heartbeat"); no
+// provider-controlled string is ever used as a label.
+func (m *Metrics) IncCapacityOverClaim(phase string) {
+	if m == nil || m.CapacityOverClaimTotal == nil {
+		return
+	}
+	m.CapacityOverClaimTotal.WithLabelValues(phase).Inc()
 }
 
 func (m *Metrics) IncCredentialBootstrap(outcome string) {

--- a/phase4-coordinator/internal/ws/capacity_clamp_test.go
+++ b/phase4-coordinator/internal/ws/capacity_clamp_test.go
@@ -177,12 +177,43 @@ func TestStateUpdateSlotsAreClamped(t *testing.T) {
 	payload := []byte(`{"type":"state_update","state":"ready","metrics_snapshot":{"slots_free":9999,"slots_total":9999}}`)
 	server.handleStateUpdate("provider-a", "assigned-a", payload)
 
+	// Audit R1 (security): the reference is the provider's LIVE clamped cap
+	// (2), not the global ceiling (8) — otherwise a max-2 provider could hold
+	// slots_total=8 via state_update until the next heartbeat, which is real
+	// over-admission for HTTP-forwarding providers with no relay limiter.
 	snap := registry.Snapshot()
-	if snap[0].SlotsTotal > 8 || snap[0].SlotsFree > 8 {
-		t.Fatalf("state_update slots = (total %d, free %d), want both <= 8", snap[0].SlotsTotal, snap[0].SlotsFree)
+	if snap[0].SlotsTotal != 2 || snap[0].SlotsFree != 2 {
+		t.Fatalf("state_update slots = (total %d, free %d), want (2, 2) — the provider's live cap, not the ceiling", snap[0].SlotsTotal, snap[0].SlotsFree)
 	}
 	if got := capacityOverClaimMetricValue(t, reg, capacityPhaseStateUpdate); got != 1 {
 		t.Fatalf("state_update tripwire = %v, want 1", got)
+	}
+}
+
+// Audit R1 (security lane HIGH): a NEGATIVE max_concurrency claim must not
+// pass through the clamp — the relay admission guard only enforces its cap
+// when MaxConcurrency > 0, so an untouched -1 would disable concurrency
+// admission entirely while inflated slots absorb routing.
+func TestNegativeMaxConcurrencyClaimIsFloored(t *testing.T) {
+	t.Parallel()
+	reg := prometheus.NewRegistry()
+	registry := pool.NewRegistry(nil)
+	server := NewServer(capacityTestConfig(8), registry, zerolog.Nop(),
+		WithCapacityOverClaimMetrics(statsmetrics.New(reg)))
+	registerCapacityTestProvider(t, server, registry, 2)
+
+	payload := []byte(`{"type":"heartbeat","status":"ready","model_id":"model-a","model_params_b":7.0,"ram_gb":16,"max_context_tokens":32768,"max_concurrency":-1,"slots_free":9999,"slots_total":9999,"throughput_tps_estimate":19.8,"requests_served_since_last":0,"avg_latency_ms_since_last":0.0,"throughput_tps_since_last":0.0}`)
+	server.handleHeartbeat(nil, "provider-a", "assigned-a", payload)
+
+	snap := registry.Snapshot()
+	if snap[0].MaxConcurrency != 1 {
+		t.Fatalf("negative claim produced MaxConcurrency=%d, want floor 1 (relay cap must stay armed)", snap[0].MaxConcurrency)
+	}
+	if snap[0].SlotsTotal > 1 || snap[0].SlotsFree > 1 {
+		t.Fatalf("negative claim slots = (total %d, free %d), want both <= 1", snap[0].SlotsTotal, snap[0].SlotsFree)
+	}
+	if got := capacityOverClaimMetricValue(t, reg, capacityPhaseHeartbeat); got < 1 {
+		t.Fatalf("heartbeat tripwire = %v, want >= 1 for a nonsense claim", got)
 	}
 }
 

--- a/phase4-coordinator/internal/ws/capacity_clamp_test.go
+++ b/phase4-coordinator/internal/ws/capacity_clamp_test.go
@@ -1,0 +1,204 @@
+package ws
+
+import (
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/rs/zerolog"
+
+	"github.com/augstar/macprovider-coordinator/internal/config"
+	"github.com/augstar/macprovider-coordinator/internal/pool"
+	statsmetrics "github.com/augstar/macprovider-coordinator/internal/stats/metrics"
+)
+
+func capacityTestConfig(ceiling int) config.Config {
+	cfg := config.Default()
+	cfg.Pool.MaxConcurrencyCeiling = ceiling
+	// The warm-up gate would admit the provider as degraded, which is
+	// orthogonal to the capacity clamp under test.
+	cfg.Pool.WarmupGateEnabled = false
+	return cfg
+}
+
+func capacityTestHello(maxConcurrency int) Hello {
+	return Hello{
+		Type:             "hello",
+		ProviderID:       "provider-a",
+		Hostname:         "mac-a",
+		ModelID:          "model-a",
+		ModelParamsB:     7,
+		RAMGB:            16,
+		MaxContextTokens: 32768,
+		MaxConcurrency:   maxConcurrency,
+		BinaryVersion:    "1.8.48",
+	}
+}
+
+func capacityOverClaimMetricValue(t *testing.T, reg *prometheus.Registry, phase string) float64 {
+	t.Helper()
+	families, err := reg.Gather()
+	if err != nil {
+		t.Fatalf("gather: %v", err)
+	}
+	for _, mf := range families {
+		if mf.GetName() != "provider_capacity_over_claim_total" {
+			continue
+		}
+		for _, metric := range mf.GetMetric() {
+			for _, label := range metric.GetLabel() {
+				if label.GetName() == "phase" && label.GetValue() == phase {
+					return metric.GetCounter().GetValue()
+				}
+			}
+		}
+	}
+	return 0
+}
+
+// Issue #764 AC (hello): an over-claiming registration is admitted but capped.
+func TestHelloCapacityIsClampedToCeiling(t *testing.T) {
+	t.Parallel()
+	reg := prometheus.NewRegistry()
+	server := NewServer(capacityTestConfig(8), pool.NewRegistry(nil), zerolog.Nop(),
+		WithCapacityOverClaimMetrics(statsmetrics.New(reg)))
+
+	entry, ok := server.prepareProviderAdmission(nil, providerAuth{validated: true, providerID: "provider-a"}, capacityTestHello(9999))
+	if !ok || entry == nil {
+		t.Fatal("prepareProviderAdmission rejected a well-formed hello")
+	}
+	if entry.MaxConcurrency != 8 || entry.SlotsTotal != 8 || entry.SlotsFree != 8 {
+		t.Fatalf("clamped hello = (max %d, total %d, free %d), want (8, 8, 8)", entry.MaxConcurrency, entry.SlotsTotal, entry.SlotsFree)
+	}
+	if got := capacityOverClaimMetricValue(t, reg, capacityPhaseHello); got != 1 {
+		t.Fatalf("hello tripwire = %v, want 1", got)
+	}
+}
+
+func TestHelloCapacityWithinCeilingIsUntouched(t *testing.T) {
+	t.Parallel()
+	reg := prometheus.NewRegistry()
+	server := NewServer(capacityTestConfig(8), pool.NewRegistry(nil), zerolog.Nop(),
+		WithCapacityOverClaimMetrics(statsmetrics.New(reg)))
+
+	entry, ok := server.prepareProviderAdmission(nil, providerAuth{validated: true, providerID: "provider-a"}, capacityTestHello(2))
+	if !ok || entry == nil {
+		t.Fatal("prepareProviderAdmission rejected a well-formed hello")
+	}
+	if entry.MaxConcurrency != 2 || entry.SlotsTotal != 2 || entry.SlotsFree != 2 {
+		t.Fatalf("honest hello = (max %d, total %d, free %d), want (2, 2, 2)", entry.MaxConcurrency, entry.SlotsTotal, entry.SlotsFree)
+	}
+	if got := capacityOverClaimMetricValue(t, reg, capacityPhaseHello); got != 0 {
+		t.Fatalf("hello tripwire = %v, want 0 for an honest claim", got)
+	}
+}
+
+func registerCapacityTestProvider(t *testing.T, server *Server, registry *pool.Registry, maxConcurrency int) {
+	t.Helper()
+	entry, ok := server.prepareProviderAdmission(nil, providerAuth{validated: true, providerID: "provider-a"}, capacityTestHello(maxConcurrency))
+	if !ok || entry == nil {
+		t.Fatal("prepareProviderAdmission rejected a well-formed hello")
+	}
+	entry.AssignedID = "assigned-a"
+	if _, registered := registry.RegisterAt(entry, nil, time.Now().UTC()); !registered {
+		t.Fatal("register failed")
+	}
+}
+
+// Issue #764 AC (heartbeat): the offending heartbeat is clamped AND increments
+// the tripwire. Slot coherence is preserved across the clamp.
+func TestHeartbeatCapacityIsClampedAndTripsTheWire(t *testing.T) {
+	t.Parallel()
+	reg := prometheus.NewRegistry()
+	registry := pool.NewRegistry(nil)
+	server := NewServer(capacityTestConfig(8), registry, zerolog.Nop(),
+		WithCapacityOverClaimMetrics(statsmetrics.New(reg)))
+	registerCapacityTestProvider(t, server, registry, 2)
+
+	// 9999 total with 9990 free = 9 in use; after clamping to 8 total the
+	// provider must not advertise more free slots than it has.
+	payload := []byte(`{"type":"heartbeat","status":"ready","model_id":"model-a","model_params_b":7.0,"ram_gb":16,"max_context_tokens":32768,"max_concurrency":9999,"slots_free":9990,"slots_total":9999,"throughput_tps_estimate":19.8,"requests_served_since_last":0,"avg_latency_ms_since_last":0.0,"throughput_tps_since_last":0.0}`)
+	server.handleHeartbeat(nil, "provider-a", "assigned-a", payload)
+
+	snap := registry.Snapshot()
+	if len(snap) != 1 {
+		t.Fatalf("snapshot len = %d, want 1", len(snap))
+	}
+	if snap[0].MaxConcurrency != 8 || snap[0].SlotsTotal != 8 {
+		t.Fatalf("clamped heartbeat = (max %d, total %d), want (8, 8)", snap[0].MaxConcurrency, snap[0].SlotsTotal)
+	}
+	if snap[0].SlotsFree > snap[0].SlotsTotal {
+		t.Fatalf("slots_free %d exceeds slots_total %d", snap[0].SlotsFree, snap[0].SlotsTotal)
+	}
+	if got := capacityOverClaimMetricValue(t, reg, capacityPhaseHeartbeat); got != 1 {
+		t.Fatalf("heartbeat tripwire = %v, want 1", got)
+	}
+}
+
+// "Permanent" means monotonic: the counter keeps rising on every offending
+// frame and never falls back when the provider starts behaving.
+func TestCapacityOverClaimTripwireIsMonotonic(t *testing.T) {
+	t.Parallel()
+	reg := prometheus.NewRegistry()
+	registry := pool.NewRegistry(nil)
+	server := NewServer(capacityTestConfig(8), registry, zerolog.Nop(),
+		WithCapacityOverClaimMetrics(statsmetrics.New(reg)))
+	registerCapacityTestProvider(t, server, registry, 2)
+
+	overClaim := []byte(`{"type":"heartbeat","status":"ready","model_id":"model-a","model_params_b":7.0,"ram_gb":16,"max_context_tokens":32768,"max_concurrency":9999,"slots_free":9999,"slots_total":9999,"throughput_tps_estimate":19.8,"requests_served_since_last":0,"avg_latency_ms_since_last":0.0,"throughput_tps_since_last":0.0}`)
+	honest := []byte(`{"type":"heartbeat","status":"ready","model_id":"model-a","model_params_b":7.0,"ram_gb":16,"max_context_tokens":32768,"max_concurrency":2,"slots_free":2,"slots_total":2,"throughput_tps_estimate":19.8,"requests_served_since_last":0,"avg_latency_ms_since_last":0.0,"throughput_tps_since_last":0.0}`)
+
+	for i := 0; i < 3; i++ {
+		server.handleHeartbeat(nil, "provider-a", "assigned-a", overClaim)
+	}
+	if got := capacityOverClaimMetricValue(t, reg, capacityPhaseHeartbeat); got != 3 {
+		t.Fatalf("tripwire after 3 offending heartbeats = %v, want 3 (counts every frame)", got)
+	}
+	server.handleHeartbeat(nil, "provider-a", "assigned-a", honest)
+	if got := capacityOverClaimMetricValue(t, reg, capacityPhaseHeartbeat); got != 3 {
+		t.Fatalf("tripwire after an honest heartbeat = %v, want 3 (never decrements)", got)
+	}
+	if snap := registry.Snapshot(); snap[0].MaxConcurrency != 2 {
+		t.Fatalf("honest heartbeat max_concurrency = %d, want 2", snap[0].MaxConcurrency)
+	}
+}
+
+// state_update is the third provider-controlled capacity ingest; leaving it
+// unclamped would let a provider restore inflated free slots after a clamped
+// heartbeat.
+func TestStateUpdateSlotsAreClamped(t *testing.T) {
+	t.Parallel()
+	reg := prometheus.NewRegistry()
+	registry := pool.NewRegistry(nil)
+	server := NewServer(capacityTestConfig(8), registry, zerolog.Nop(),
+		WithCapacityOverClaimMetrics(statsmetrics.New(reg)))
+	registerCapacityTestProvider(t, server, registry, 2)
+
+	payload := []byte(`{"type":"state_update","state":"ready","metrics_snapshot":{"slots_free":9999,"slots_total":9999}}`)
+	server.handleStateUpdate("provider-a", "assigned-a", payload)
+
+	snap := registry.Snapshot()
+	if snap[0].SlotsTotal > 8 || snap[0].SlotsFree > 8 {
+		t.Fatalf("state_update slots = (total %d, free %d), want both <= 8", snap[0].SlotsTotal, snap[0].SlotsFree)
+	}
+	if got := capacityOverClaimMetricValue(t, reg, capacityPhaseStateUpdate); got != 1 {
+		t.Fatalf("state_update tripwire = %v, want 1", got)
+	}
+}
+
+// A zero ceiling restores pre-#764 behavior exactly: no clamp, no tripwire.
+func TestZeroCeilingDisablesClampAndTripwire(t *testing.T) {
+	t.Parallel()
+	reg := prometheus.NewRegistry()
+	registry := pool.NewRegistry(nil)
+	server := NewServer(capacityTestConfig(0), registry, zerolog.Nop(),
+		WithCapacityOverClaimMetrics(statsmetrics.New(reg)))
+	registerCapacityTestProvider(t, server, registry, 9999)
+
+	if snap := registry.Snapshot(); snap[0].MaxConcurrency != 9999 {
+		t.Fatalf("max_concurrency with ceiling 0 = %d, want the raw 9999", snap[0].MaxConcurrency)
+	}
+	if got := capacityOverClaimMetricValue(t, reg, capacityPhaseHello); got != 0 {
+		t.Fatalf("hello tripwire with ceiling 0 = %v, want 0", got)
+	}
+}

--- a/phase4-coordinator/internal/ws/poolz_version_segments.go
+++ b/phase4-coordinator/internal/ws/poolz_version_segments.go
@@ -1,0 +1,131 @@
+package ws
+
+import (
+	"math"
+	"sort"
+	"strings"
+
+	"github.com/augstar/macprovider-coordinator/internal/pool"
+)
+
+// Issue #764 asked for TTFT/TPS rollups segmented by binary_version so a slow
+// or misbehaving backend build is separable from the honest fleet. The SPEC-017
+// stats rollup pipeline has no TTFT/TPS aggregate to extend — its overview
+// schema is a locked 14-field counter set with no latency at all — so the
+// cheapest ADDITIVE surface is the live /poolz snapshot, which already carries
+// binary_version per provider. This adds a `by_binary_version` block to the
+// /poolz summary; no existing field name or shape changes.
+//
+// The latency inputs are the canary probe metrics recorded on the pool entry
+// (pool.Registry.RecordCanaryLatency) — the coordinator's only live TTFT/TPS
+// measurement. Buyer relays are not timed into the pool, so a provider that has
+// never been canary-probed contributes to the counts but not to the latency
+// averages; the `*_samples` fields make that explicit rather than letting a
+// zero read as "fast".
+
+// poolzVersionSegment is one binary_version's slice of the live pool.
+type poolzVersionSegment struct {
+	Providers       int `json:"providers"`
+	RoutingEligible int `json:"routing_eligible"`
+	SlotsTotal      int `json:"slots_total"`
+	SlotsFree       int `json:"slots_free"`
+
+	// Canary-measured latency. Averages are omitted (null) when no provider on
+	// this version has been probed yet.
+	CanaryTTFTSamples int      `json:"canary_ttft_samples"`
+	CanaryTTFTMSAvg   *float64 `json:"canary_ttft_ms_avg"`
+	CanaryTTFTMSMax   *int     `json:"canary_ttft_ms_max"`
+	CanaryTPSSamples  int      `json:"canary_sustained_tps_samples"`
+	CanaryTPSAvg      *float64 `json:"canary_sustained_tps_avg"`
+
+	// Provider-reported throughput estimate, kept alongside the measured values
+	// so a version whose SELF-REPORTED number diverges from its canary-measured
+	// number is visible in one place.
+	ReportedTPSSamples int      `json:"reported_tps_estimate_samples"`
+	ReportedTPSAvg     *float64 `json:"reported_tps_estimate_avg"`
+
+	Models []string `json:"models"`
+}
+
+// poolzUnknownBinaryVersion keys providers that report no binary_version
+// (pre-versioning builds). Never an empty JSON key.
+const poolzUnknownBinaryVersion = "unknown"
+
+// poolzVersionSegments builds the per-binary_version breakdown. Pure over the
+// snapshot; safe to call under the /poolz handler with no additional locking.
+func poolzVersionSegments(providers []pool.Provider) map[string]poolzVersionSegment {
+	type accumulator struct {
+		seg          poolzVersionSegment
+		ttftSum      float64
+		tpsSum       float64
+		reportedSum  float64
+		ttftMax      int
+		modelsSeen   map[string]struct{}
+		modelsSorted []string
+	}
+	acc := map[string]*accumulator{}
+	for _, p := range providers {
+		version := strings.TrimSpace(p.BinaryVersion)
+		if version == "" {
+			version = poolzUnknownBinaryVersion
+		}
+		a := acc[version]
+		if a == nil {
+			a = &accumulator{modelsSeen: map[string]struct{}{}}
+			acc[version] = a
+		}
+		a.seg.Providers++
+		if p.RoutingEligible() {
+			a.seg.RoutingEligible++
+		}
+		a.seg.SlotsTotal += p.SlotsTotal
+		a.seg.SlotsFree += p.SlotsFree
+		if p.CanaryLastTTFTMS > 0 {
+			a.seg.CanaryTTFTSamples++
+			a.ttftSum += float64(p.CanaryLastTTFTMS)
+			if p.CanaryLastTTFTMS > a.ttftMax {
+				a.ttftMax = p.CanaryLastTTFTMS
+			}
+		}
+		if finitePositive(p.CanaryLastSustainedTPS) {
+			a.seg.CanaryTPSSamples++
+			a.tpsSum += p.CanaryLastSustainedTPS
+		}
+		if finitePositive(p.ThroughputTPSEstimate) {
+			a.seg.ReportedTPSSamples++
+			a.reportedSum += p.ThroughputTPSEstimate
+		}
+		if model := strings.TrimSpace(p.ModelID); model != "" {
+			if _, seen := a.modelsSeen[model]; !seen {
+				a.modelsSeen[model] = struct{}{}
+				a.modelsSorted = append(a.modelsSorted, model)
+			}
+		}
+	}
+	out := make(map[string]poolzVersionSegment, len(acc))
+	for version, a := range acc {
+		seg := a.seg
+		if seg.CanaryTTFTSamples > 0 {
+			avg := a.ttftSum / float64(seg.CanaryTTFTSamples)
+			seg.CanaryTTFTMSAvg = &avg
+			maxTTFT := a.ttftMax
+			seg.CanaryTTFTMSMax = &maxTTFT
+		}
+		if seg.CanaryTPSSamples > 0 {
+			avg := a.tpsSum / float64(seg.CanaryTPSSamples)
+			seg.CanaryTPSAvg = &avg
+		}
+		if seg.ReportedTPSSamples > 0 {
+			avg := a.reportedSum / float64(seg.ReportedTPSSamples)
+			seg.ReportedTPSAvg = &avg
+		}
+		sort.Strings(a.modelsSorted)
+		seg.Models = a.modelsSorted
+		out[version] = seg
+	}
+	return out
+}
+
+func finitePositive(v float64) bool {
+	return v > 0 && !math.IsNaN(v) && !math.IsInf(v, 0)
+}

--- a/phase4-coordinator/internal/ws/poolz_version_segments_test.go
+++ b/phase4-coordinator/internal/ws/poolz_version_segments_test.go
@@ -1,0 +1,142 @@
+package ws
+
+import (
+	"testing"
+
+	"github.com/rs/zerolog"
+
+	"github.com/augstar/macprovider-coordinator/internal/pool"
+	"github.com/augstar/macprovider-coordinator/internal/pow"
+)
+
+// Issue #764 AC: per-backend TTFT/TPS must be segmentable.
+func TestPoolzVersionSegmentsSeparatesBackendLatency(t *testing.T) {
+	t.Parallel()
+	providers := []pool.Provider{
+		{
+			ProviderID: "fast-1", BinaryVersion: "1.8.48", ModelID: "model-a",
+			State: pool.StateReady, SlotsTotal: 2, SlotsFree: 2,
+			CanaryLastTTFTMS: 800, CanaryLastSustainedTPS: 20, ThroughputTPSEstimate: 21,
+		},
+		{
+			ProviderID: "fast-2", BinaryVersion: "1.8.48", ModelID: "model-b",
+			State: pool.StateReady, SlotsTotal: 2, SlotsFree: 0,
+			CanaryLastTTFTMS: 1200, CanaryLastSustainedTPS: 10, ThroughputTPSEstimate: 11,
+		},
+		{
+			ProviderID: "slow-1", BinaryVersion: "1.8.40", ModelID: "model-a",
+			State: pool.StateReady, SlotsTotal: 1, SlotsFree: 1,
+			CanaryLastTTFTMS: 9000, CanaryLastSustainedTPS: 2, ThroughputTPSEstimate: 19,
+		},
+		{
+			// Never probed and no version: contributes to counts only.
+			ProviderID: "unprobed", ModelID: "model-a",
+			State: pool.StateReady, SlotsTotal: 1, SlotsFree: 1,
+		},
+	}
+	segments := poolzVersionSegments(providers)
+	if len(segments) != 3 {
+		t.Fatalf("segments = %d, want 3 (1.8.48, 1.8.40, unknown)", len(segments))
+	}
+
+	fast := segments["1.8.48"]
+	if fast.Providers != 2 || fast.RoutingEligible != 1 || fast.SlotsTotal != 4 || fast.SlotsFree != 2 {
+		t.Fatalf("1.8.48 counts = %+v", fast)
+	}
+	if fast.CanaryTTFTMSAvg == nil || *fast.CanaryTTFTMSAvg != 1000 {
+		t.Fatalf("1.8.48 ttft avg = %v, want 1000", fast.CanaryTTFTMSAvg)
+	}
+	if fast.CanaryTTFTMSMax == nil || *fast.CanaryTTFTMSMax != 1200 {
+		t.Fatalf("1.8.48 ttft max = %v, want 1200", fast.CanaryTTFTMSMax)
+	}
+	if fast.CanaryTPSAvg == nil || *fast.CanaryTPSAvg != 15 {
+		t.Fatalf("1.8.48 tps avg = %v, want 15", fast.CanaryTPSAvg)
+	}
+	if len(fast.Models) != 2 || fast.Models[0] != "model-a" || fast.Models[1] != "model-b" {
+		t.Fatalf("1.8.48 models = %v, want sorted [model-a model-b]", fast.Models)
+	}
+
+	slow := segments["1.8.40"]
+	if slow.CanaryTTFTMSAvg == nil || *slow.CanaryTTFTMSAvg != 9000 {
+		t.Fatalf("1.8.40 ttft avg = %v, want 9000 (the slow backend is separable)", slow.CanaryTTFTMSAvg)
+	}
+	// The reported estimate does NOT expose the regression; the measured value
+	// does. Keeping both in one block is the point of the segmentation.
+	if slow.ReportedTPSAvg == nil || *slow.ReportedTPSAvg != 19 {
+		t.Fatalf("1.8.40 reported tps avg = %v, want 19", slow.ReportedTPSAvg)
+	}
+
+	unknown := segments[poolzUnknownBinaryVersion]
+	if unknown.Providers != 1 {
+		t.Fatalf("unknown providers = %d, want 1", unknown.Providers)
+	}
+	if unknown.CanaryTTFTSamples != 0 || unknown.CanaryTTFTMSAvg != nil {
+		t.Fatalf("unprobed provider must not report a latency average: %+v", unknown)
+	}
+}
+
+func TestPoolzVersionSegmentsEmptyPool(t *testing.T) {
+	t.Parallel()
+	if got := poolzVersionSegments(nil); len(got) != 0 {
+		t.Fatalf("segments for an empty pool = %v, want empty", got)
+	}
+}
+
+// Issue #765 wiring: the verdict is applied to the pool only for the two
+// decisive values; Unknown must leave the flag exactly as it was.
+func TestApplyBenchmarkQuarantineHonoursVerdict(t *testing.T) {
+	t.Parallel()
+	registry := pool.NewRegistry(nil)
+	server := NewServer(capacityTestConfig(8), registry, zerolog.Nop())
+	registerCapacityTestProvider(t, server, registry, 2)
+
+	quarantined := func() bool { return registry.Snapshot()[0].BenchmarkQuarantined }
+
+	server.applyBenchmarkQuarantine("provider-a", "assigned-a", "model-a", pow.BenchmarkVerdictUnknown)
+	if quarantined() {
+		t.Fatal("Unknown verdict must not quarantine")
+	}
+	server.applyBenchmarkQuarantine("provider-a", "assigned-a", "model-a", pow.BenchmarkVerdictMissing)
+	if !quarantined() {
+		t.Fatal("Missing verdict must quarantine")
+	}
+	if registry.Snapshot()[0].RoutingEligible() {
+		t.Fatal("a quarantined provider must not be routed buyer traffic")
+	}
+	// A store blip mid-quarantine must not release the provider.
+	server.applyBenchmarkQuarantine("provider-a", "assigned-a", "model-a", pow.BenchmarkVerdictUnknown)
+	if !quarantined() {
+		t.Fatal("Unknown verdict must not release an existing quarantine")
+	}
+	server.applyBenchmarkQuarantine("provider-a", "assigned-a", "model-a", pow.BenchmarkVerdictVerified)
+	if quarantined() {
+		t.Fatal("Verified verdict must release the quarantine")
+	}
+	if !registry.Snapshot()[0].RoutingEligible() {
+		t.Fatal("a released provider must be routable again")
+	}
+}
+
+// Default posture pin: with no drift evaluator wired (the shipping default) a
+// heartbeat never touches the quarantine flag, so routing is unchanged.
+func TestHeartbeatWithoutDriftEvaluatorNeverQuarantines(t *testing.T) {
+	t.Parallel()
+	registry := pool.NewRegistry(nil)
+	cfg := capacityTestConfig(8)
+	if cfg.ProofOfWeights.TelemetryDrift.Enabled || cfg.ProofOfWeights.TelemetryDrift.QuarantineMissingBenchmark {
+		t.Fatal("config.Default() must keep the drift quarantine dormant")
+	}
+	server := NewServer(cfg, registry, zerolog.Nop())
+	registerCapacityTestProvider(t, server, registry, 2)
+
+	payload := []byte(`{"type":"heartbeat","status":"ready","model_id":"model-a","model_params_b":7.0,"ram_gb":16,"max_context_tokens":32768,"max_concurrency":2,"slots_free":2,"slots_total":2,"throughput_tps_estimate":19.8,"requests_served_since_last":0,"avg_latency_ms_since_last":0.0,"throughput_tps_since_last":0.0}`)
+	server.handleHeartbeat(nil, "provider-a", "assigned-a", payload)
+
+	snap := registry.Snapshot()
+	if snap[0].BenchmarkQuarantined {
+		t.Fatal("an un-benchmarked provider must stay routable while the gate is off")
+	}
+	if !snap[0].RoutingEligible() {
+		t.Fatal("default posture changed provider routing eligibility")
+	}
+}

--- a/phase4-coordinator/internal/ws/server.go
+++ b/phase4-coordinator/internal/ws/server.go
@@ -4548,22 +4548,32 @@ func poolHardwareCapacity(summary *HardwareSummary) *pool.ProviderHardwareCapaci
 }
 
 // clampStateUpdateSlots applies the capacity ceiling to a state_update's
-// optional slot pair. state_update carries no max_concurrency, so the ceiling
-// itself is the reference total. Absent (nil) fields stay absent — the clamp
-// never materializes a value the provider did not send.
+// optional slot pair. state_update carries no max_concurrency, so the
+// reference total is the provider's LIVE (already ingest-clamped) cap — not
+// the global ceiling: a provider admitted at MaxConcurrency=2 must not hold
+// slots_total=8 via state_update until the next heartbeat repairs it (#764
+// audit R1, security lane; HTTP-forwarding providers have no relay-side
+// active limiter, so inflated slots there are real over-admission). The
+// ceiling is the fallback reference when the provider is unknown. Absent
+// (nil) fields stay absent — the clamp never materializes a value the
+// provider did not send.
 func (s *Server) clampStateUpdateSlots(providerID string, slotsTotal, slotsFree *int) (*int, *int) {
 	ceiling := s.maxConcurrencyCeiling()
 	if ceiling <= 0 || (slotsTotal == nil && slotsFree == nil) {
 		return slotsTotal, slotsFree
 	}
-	total, free := ceiling, ceiling
+	reference := ceiling
+	if live, ok := s.pool.CurrentMaxConcurrency(providerID); ok && live > 0 && live < reference {
+		reference = live
+	}
+	total, free := reference, reference
 	if slotsTotal != nil {
 		total = *slotsTotal
 	}
 	if slotsFree != nil {
 		free = *slotsFree
 	}
-	clamped := pool.ClampCapacity(ceiling, total, free, ceiling)
+	clamped := pool.ClampCapacity(reference, total, free, reference)
 	if clamped.SlotsTotal == total && clamped.SlotsFree == free {
 		return slotsTotal, slotsFree
 	}

--- a/phase4-coordinator/internal/ws/server.go
+++ b/phase4-coordinator/internal/ws/server.go
@@ -142,6 +142,7 @@ type Server struct {
 	idlePrewarmMetrics             IdlePrewarmMetrics
 	modelHashMismatchMetrics       ModelHashMismatchMetrics
 	credentialBootstrapMetrics     CredentialBootstrapMetrics
+	capacityOverClaimMetrics       CapacityOverClaimMetrics
 	connectionEvents               ConnectionEventStore
 	connectionEventMetrics         ConnectionEventMetrics
 	closeEventMeta                 sync.Map // net.Conn -> closeEventMeta
@@ -319,6 +320,29 @@ type CredentialBootstrapMetrics interface {
 	IncCredentialBootstrap(outcome string)
 }
 
+// CapacityOverClaimMetrics receives the issue-#764 tripwire. The counter is
+// PERMANENT: it is a process-lifetime prometheus counter that never resets and
+// is incremented on EVERY offending frame, not once per provider — a box that
+// keeps over-claiming keeps counting, so the rate is itself the signal.
+type CapacityOverClaimMetrics interface {
+	IncCapacityOverClaim(phase string)
+}
+
+// EventProviderCapacityOverClaim is the structured-log event name for a
+// provider-reported capacity claim above pool.max_concurrency_ceiling.
+const EventProviderCapacityOverClaim = "provider_capacity_over_claim"
+
+// EventProviderBenchmarkQuarantine is the structured-log event name for an
+// issue-#765 fail-suspect transition (quarantined / released).
+const EventProviderBenchmarkQuarantine = "provider_benchmark_quarantine"
+
+// capacity-over-claim tripwire phases. Closed set — used as a prometheus label.
+const (
+	capacityPhaseHello       = "hello"
+	capacityPhaseHeartbeat   = "heartbeat"
+	capacityPhaseStateUpdate = "state_update"
+)
+
 const (
 	idlePrewarmEventBurst           = 10
 	idlePrewarmEventRefillPerSecond = 1
@@ -483,6 +507,12 @@ func WithModelHashMismatchMetrics(metrics ModelHashMismatchMetrics) Option {
 func WithCredentialBootstrapMetrics(metrics CredentialBootstrapMetrics) Option {
 	return func(s *Server) {
 		s.credentialBootstrapMetrics = metrics
+	}
+}
+
+func WithCapacityOverClaimMetrics(metrics CapacityOverClaimMetrics) Option {
+	return func(s *Server) {
+		s.capacityOverClaimMetrics = metrics
 	}
 }
 
@@ -2240,6 +2270,21 @@ func (s *Server) prepareProviderAdmission(conn net.Conn, auth providerAuth, hell
 	if s.cfg.Pool.WarmupGateEnabled {
 		initialState = pool.StateDegraded
 	}
+	// Issue #764: clamp the reported capacity BEFORE it enters the registry, so
+	// no downstream consumer ever sees the raw claim. A fresh session starts
+	// fully free, so the reported triple is (max, max, max).
+	capacity := s.clampProviderCapacity(hello.MaxConcurrency, hello.MaxConcurrency, hello.MaxConcurrency)
+	if capacity.OverClaimed {
+		s.recordCapacityOverClaim(capacityPhaseHello)
+		s.log.Warn().
+			Str("event", EventProviderCapacityOverClaim).
+			Str("provider_id", hello.ProviderID).
+			Str("phase", capacityPhaseHello).
+			Int("reported_max_concurrency", capacity.ReportedMax).
+			Int("ceiling", s.maxConcurrencyCeiling()).
+			Int("effective_max_concurrency", capacity.MaxConcurrency).
+			Msg("provider capacity claim exceeds the operator ceiling; clamped")
+	}
 	return &pool.Provider{
 		ProviderID:             hello.ProviderID,
 		AssignedID:             assignedID,
@@ -2248,9 +2293,9 @@ func (s *Server) prepareProviderAdmission(conn net.Conn, auth providerAuth, hell
 		ModelParamsB:           hello.ModelParamsB,
 		RAMGB:                  hello.RAMGB,
 		MaxContextTokens:       hello.MaxContextTokens,
-		MaxConcurrency:         hello.MaxConcurrency,
-		SlotsFree:              hello.MaxConcurrency,
-		SlotsTotal:             hello.MaxConcurrency,
+		MaxConcurrency:         capacity.MaxConcurrency,
+		SlotsFree:              capacity.SlotsFree,
+		SlotsTotal:             capacity.SlotsTotal,
 		ThroughputTPSEstimate:  hello.ThroughputTPSEstimate,
 		ModelLoadTimeMs:        hello.ModelLoadTimeMs,
 		EndpointURL:            endpointURL,
@@ -3630,6 +3675,10 @@ func (s *Server) runCanaryProbeAtEpoch(provider pool.Provider, epoch uint64) boo
 		return false
 	}
 	outcome := attempt.outcome
+	// Issue #764: the canary is the coordinator's only live TTFT/TPS
+	// measurement. Recording it on the pool entry is what makes /poolz able to
+	// segment latency by binary_version and isolate a slow backend build.
+	s.pool.RecordCanaryLatency(provider.ProviderID, provider.AssignedID, attempt.metrics.TTFTMS, attempt.metrics.SustainedTPS)
 	if attempt.modelClassBank {
 		pass := outcome == canaryProbePass
 		s.pool.SetModelClassOPoIPass(provider.ProviderID, provider.AssignedID, &pass)
@@ -4258,6 +4307,52 @@ func (s *Server) handlePreflightAck(providerID, assignedID string, payload []byt
 	s.log.Warn().Str("provider_id", providerID).Str("request_id", ack.RequestID).Msg("unexpected preflight_ack")
 }
 
+// maxConcurrencyCeiling is the operator cap on provider-reported concurrency.
+// 0 (or negative, which Validate rejects) disables the clamp.
+func (s *Server) maxConcurrencyCeiling() int {
+	return s.cfg.Pool.MaxConcurrencyCeiling
+}
+
+// clampProviderCapacity applies the ceiling to one provider-reported triple.
+// Every provider-controlled capacity ingest point MUST route through this.
+func (s *Server) clampProviderCapacity(maxConcurrency, slotsTotal, slotsFree int) pool.ClampedCapacity {
+	return pool.ClampCapacity(maxConcurrency, slotsTotal, slotsFree, s.maxConcurrencyCeiling())
+}
+
+// recordCapacityOverClaim fires the permanent tripwire. It is called once per
+// offending frame and never decrements; the counter is monotonic for the
+// process lifetime by construction (prometheus.Counter).
+func (s *Server) recordCapacityOverClaim(phase string) {
+	if s.capacityOverClaimMetrics != nil {
+		s.capacityOverClaimMetrics.IncCapacityOverClaim(phase)
+	}
+}
+
+// applyBenchmarkQuarantine translates the issue-#765 verdict into the pool's
+// fail-suspect flag. BenchmarkVerdictUnknown (gate off, evaluator off, or an
+// evidence-store error) deliberately leaves the flag untouched.
+func (s *Server) applyBenchmarkQuarantine(providerID, assignedID, modelID string, verdict pow.BenchmarkVerdict) {
+	var quarantined bool
+	switch verdict {
+	case pow.BenchmarkVerdictMissing:
+		quarantined = true
+	case pow.BenchmarkVerdictVerified:
+		quarantined = false
+	default:
+		return
+	}
+	if !s.pool.SetBenchmarkQuarantine(providerID, assignedID, quarantined) {
+		return
+	}
+	s.log.Warn().
+		Str("event", EventProviderBenchmarkQuarantine).
+		Str("provider_id", providerID).
+		Str("assigned_id", assignedID).
+		Str("model_id", modelID).
+		Bool("quarantined", quarantined).
+		Msg("provider verified-benchmark quarantine state changed")
+}
+
 func (s *Server) handleHeartbeat(conn net.Conn, providerID, assignedID string, payload []byte) {
 	hb, presence, field, err := ParseHeartbeat(payload)
 	if err != nil {
@@ -4292,15 +4387,34 @@ func (s *Server) handleHeartbeat(conn net.Conn, providerID, assignedID string, p
 			return
 		}
 	}
+	// Issue #764: clamp before ApplyHeartbeat, which assigns MaxConcurrency /
+	// SlotsTotal / SlotsFree onto the pool entry verbatim. Clamping here (rather
+	// than inside the registry) keeps the ceiling a single ingest-side concern
+	// and covers the relay's admission check, which reads
+	// provider.MaxConcurrency straight off the pool entry.
+	capacity := s.clampProviderCapacity(hb.MaxConcurrency, hb.SlotsTotal, hb.SlotsFree)
+	if capacity.OverClaimed {
+		s.recordCapacityOverClaim(capacityPhaseHeartbeat)
+		s.log.Warn().
+			Str("event", EventProviderCapacityOverClaim).
+			Str("provider_id", providerID).
+			Str("phase", capacityPhaseHeartbeat).
+			Int("reported_max_concurrency", capacity.ReportedMax).
+			Int("reported_slots_total", hb.SlotsTotal).
+			Int("ceiling", s.maxConcurrencyCeiling()).
+			Int("effective_max_concurrency", capacity.MaxConcurrency).
+			Int("effective_slots_total", capacity.SlotsTotal).
+			Msg("provider capacity claim exceeds the operator ceiling; clamped")
+	}
 	entry, gap, ok := s.pool.ApplyHeartbeat(providerID, assignedID, pool.HeartbeatUpdate{
 		Status:                    state,
 		ModelID:                   hb.ModelID,
 		ModelParamsB:              hb.ModelParamsB,
 		RAMGB:                     hb.RAMGB,
 		MaxContextTokens:          hb.MaxContextTokens,
-		MaxConcurrency:            hb.MaxConcurrency,
-		SlotsFree:                 hb.SlotsFree,
-		SlotsTotal:                hb.SlotsTotal,
+		MaxConcurrency:            capacity.MaxConcurrency,
+		SlotsFree:                 capacity.SlotsFree,
+		SlotsTotal:                capacity.SlotsTotal,
 		ThroughputTPSEstimate:     hb.ThroughputTPSEstimate,
 		RequestsServedSinceLast:   hb.RequestsServedSinceLast,
 		ThroughputTPSSinceLast:    hb.ThroughputTPSSinceLast,
@@ -4357,7 +4471,13 @@ func (s *Server) handleHeartbeat(conn net.Conn, providerID, assignedID string, p
 			Msg("provider heartbeat")
 	}
 	if s.telemetryDrift != nil {
-		s.logTelemetryDriftAlerts(s.telemetryDrift.EvaluateHeartbeat(context.Background(), *entry))
+		alerts, verdict := s.telemetryDrift.EvaluateHeartbeatWithVerdict(context.Background(), *entry)
+		s.logTelemetryDriftAlerts(alerts)
+		// Issue #765: absence of a verified benchmark is fail-suspect, not
+		// fail-open. Dormant unless BOTH telemetry_drift.enabled and
+		// telemetry_drift.quarantine_missing_benchmark are set, in which case
+		// the verdict is Unknown and routing is untouched.
+		s.applyBenchmarkQuarantine(providerID, assignedID, entry.ModelID, verdict)
 	}
 }
 
@@ -4427,6 +4547,49 @@ func poolHardwareCapacity(summary *HardwareSummary) *pool.ProviderHardwareCapaci
 	}
 }
 
+// clampStateUpdateSlots applies the capacity ceiling to a state_update's
+// optional slot pair. state_update carries no max_concurrency, so the ceiling
+// itself is the reference total. Absent (nil) fields stay absent — the clamp
+// never materializes a value the provider did not send.
+func (s *Server) clampStateUpdateSlots(providerID string, slotsTotal, slotsFree *int) (*int, *int) {
+	ceiling := s.maxConcurrencyCeiling()
+	if ceiling <= 0 || (slotsTotal == nil && slotsFree == nil) {
+		return slotsTotal, slotsFree
+	}
+	total, free := ceiling, ceiling
+	if slotsTotal != nil {
+		total = *slotsTotal
+	}
+	if slotsFree != nil {
+		free = *slotsFree
+	}
+	clamped := pool.ClampCapacity(ceiling, total, free, ceiling)
+	if clamped.SlotsTotal == total && clamped.SlotsFree == free {
+		return slotsTotal, slotsFree
+	}
+	s.recordCapacityOverClaim(capacityPhaseStateUpdate)
+	s.log.Warn().
+		Str("event", EventProviderCapacityOverClaim).
+		Str("provider_id", providerID).
+		Str("phase", capacityPhaseStateUpdate).
+		Int("reported_slots_total", total).
+		Int("reported_slots_free", free).
+		Int("ceiling", ceiling).
+		Int("effective_slots_total", clamped.SlotsTotal).
+		Int("effective_slots_free", clamped.SlotsFree).
+		Msg("provider capacity claim exceeds the operator ceiling; clamped")
+	outTotal, outFree := slotsTotal, slotsFree
+	if slotsTotal != nil {
+		v := clamped.SlotsTotal
+		outTotal = &v
+	}
+	if slotsFree != nil {
+		v := clamped.SlotsFree
+		outFree = &v
+	}
+	return outTotal, outFree
+}
+
 func (s *Server) handleStateUpdate(providerID, assignedID string, payload []byte) {
 	update, field, err := ParseStateUpdate(payload)
 	if err != nil {
@@ -4441,10 +4604,16 @@ func (s *Server) handleStateUpdate(providerID, assignedID string, payload []byte
 	if state == pool.StateReady && s.warmupGatePending(providerID) {
 		state = pool.StateDegraded
 	}
+	// Issue #764: state_update is the THIRD provider-controlled capacity ingest
+	// (after hello and heartbeat) — it writes SlotsFree/SlotsTotal straight onto
+	// the pool entry. Leaving it unclamped would let a provider restore an
+	// inflated free-slot count immediately after a clamped heartbeat, so the
+	// ceiling applies here too.
+	slotsTotal, slotsFree := s.clampStateUpdateSlots(providerID, update.MetricsSnapshot.SlotsTotal, update.MetricsSnapshot.SlotsFree)
 	entry, ok := s.pool.ApplyStateUpdate(providerID, assignedID, pool.StateUpdate{
 		State:               state,
-		SlotsFree:           update.MetricsSnapshot.SlotsFree,
-		SlotsTotal:          update.MetricsSnapshot.SlotsTotal,
+		SlotsFree:           slotsFree,
+		SlotsTotal:          slotsTotal,
 		LastAutoupdateEvent: update.LastAutoupdateEvent,
 		At:                  s.now(),
 	})
@@ -4818,7 +4987,10 @@ func (s *Server) handlePoolz(w http.ResponseWriter, r *http.Request) {
 		TotalSlots     int      `json:"total_slots"`
 		FreeSlots      int      `json:"free_slots"`
 		Models         []string `json:"models"`
-	}{TotalProviders: len(providers)}
+		// Issue #764 — additive per-binary_version TTFT/TPS + capacity
+		// breakdown. New key only; the six fields above keep their shapes.
+		ByBinaryVersion map[string]poolzVersionSegment `json:"by_binary_version"`
+	}{TotalProviders: len(providers), ByBinaryVersion: poolzVersionSegments(providers)}
 	cfg := s.tier2Config()
 	for _, p := range providers {
 		// SPEC-015 §7 / TestProviderAuthV2ReceiptRotationCandidateWithout


### PR DESCRIPTION
Closes #764. Closes #765. PR 3 of epic #770 (P1 tier, ranking/supply pair).

## #764 — Clamp provider-reported capacity + permanent over-claim tripwire

Provider-reported `max_concurrency`/slots were granted verbatim — a box reporting 9999 got 9999 admission slots and out-ranked the honest fleet. Now clamped to `pool.max_concurrency_ceiling` (default **8** — the provider CLI's own top RAM-tier value from `ProviderStatus.swift`, so no honest current provider is touched) at **three** ingest points: hello, heartbeat, and `state_update` (the issue named two; `state_update` was an unclamped bypass that could restore inflated slots right after a clamped heartbeat). `pool.ClampCapacity` preserves the used/free relationship across the clamp. Over-claims increment a permanent `provider_capacity_over_claim_total{phase}` counter + warn log. Per-`binary_version` TTFT/TPS segmentation added as an additive `by_binary_version` block on the operator `/poolz` summary (the SPEC-017 rollup has no latency aggregate to extend), fed by canary probe latencies newly recorded onto pool entries, with `*_samples` fields so unprobed versions don't read as fast.

## #765 — Fail-suspect (not fail-open) on missing verified benchmark

The drift evaluator's `!hasBenchmark` early-return silently un-gated un-benchmarked providers. Now a tri-state verdict: when enabled, "no verified benchmark" sets `BenchmarkQuarantined`, checked in `RoutingEligible()`/`ServingCapable()` — the same shape as the existing suspect flags. **Ships dormant**: requires both `telemetry_drift.enabled` (default off) and the new `telemetry_drift.quarantine_missing_benchmark` (default false; `Validate` rejects it without the former). Default-off routing behavior is pinned byte-for-byte by tests. Flipping it on the live fleet requires a pool survey first (how many providers lack verified autotune evidence) — documented residual in `findings.md`.

## Audit (three codex lanes, full `origin/main...HEAD` diff)

- code R1: **PASS (0C/0H/0M)** — 2 LOWs carried (below).
- architect R1: **PASS (0C/0H/0M)** — same 2 LOWs.
- security R1: FAIL (1 HIGH + 1 MEDIUM) → both fixed in-round → security R2: **PASS (0C/0H/0M)**.
  - HIGH: a **negative** `max_concurrency` claim passed the clamp untouched, and the relay admission guard only enforces when `MaxConcurrency > 0` — so `max_concurrency=-1` + inflated slots disabled concurrency admission entirely. Fixed: sub-1 claims floor to 1 (relay cap stays armed at minimum) and count on the tripwire; unit + heartbeat-ingest e2e coverage.
  - MEDIUM: `state_update` clamped against the global ceiling, so a max-2 provider could hold `slots_total=8` until the next heartbeat — real over-admission for HTTP-forwarding providers (no relay-side limiter). Fixed: the reference is now the provider's live clamped cap (`Registry.CurrentMaxConcurrency`), ceiling as fallback for unknown providers.

Carried LOWs: (1) a `state_update` between heartbeats can still skew free-slot telemetry within the provider's own cap — bounded, relay admission unaffected; (2) deployments with `telemetry_drift.enabled` (observe mode) will see new `missing_benchmark` observe alerts for unbenchmarked providers — operator noise, no routing change.

Verification: full `phase4-coordinator` `go build && go vet && go test ./...` green (37 packages); `make lint-coordinator` 0 issues.

SPEC-GOVERNANCE-DECLARATION-BEGIN
{
  "schema_version": "spec-pr-governance-v1",
  "behavior_change": "yes",
  "contract_change": "none",
  "specs": ["SPEC-002", "SPEC-031", "SPEC-017", "SPEC-033"],
  "requirements": ["SPEC-033-R001"],
  "authority_domains": ["coordinator-admission-routing", "canary-sanction-lifecycle", "network-stats"],
  "arbitration": ["CODE_BUG"],
  "tests": ["phase4-coordinator/internal/pool/capacity_clamp_test.go", "phase4-coordinator/internal/ws/capacity_clamp_test.go", "phase4-coordinator/internal/pow/drift_missing_benchmark_test.go"],
  "journeys": ["not-required"],
  "issue": "https://github.com/Augustas11/macprovider/issues/770"
}
SPEC-GOVERNANCE-DECLARATION-END

🤖 Generated with [Claude Code](https://claude.com/claude-code)
