### PR TITLE
Seam hardening P1: bill each request once — replay id-less retries (#762)

### DIFF
--- a/audits/seam-hardening/findings.md
+++ b/audits/seam-hardening/findings.md
@@ -64,9 +64,37 @@ path (`forwardWSStreamingBuffered:3299`).
 
 ### P1 — before real volume
 
-**P1-1 · Retry double-bill without a stable request id** — `money` — test `TestSeamH5a` · issue #200
-An id-less buyer retry (which OpenRouter does) mints a fresh request_id (`server.go:240-244`) → a new
-reservation → billed again. **Fix:** gateway-native `Idempotency-Key` dedupe (tracked in #200).
+**P1-1 · Retry double-bill without a stable request id** — `money` — test `TestSeamH5a` · issue #762
+**FIXED gateway-side (issue #762).** An id-less buyer retry (which OpenRouter does by default) minted a
+fresh request_id (`phase5-gateway/.../server.go:240-244`), so the durable `(account_id, request_id)`
+reservation key never matched and each attempt reserved + settled independently → one buyer intent,
+N bills.
+**Fix (shipped):** a bounded in-memory fingerprint index
+(`phase5-gateway/internal/router/idless_dedupe.go`) over `"mpg-idless-v1"` ‖ account ‖ demo-token-hash ‖
+conversation tag ‖ SHA-256 of the RAW body bytes, consulted only for gateway-minted ids with no
+`Idempotency-Key` (both are higher-precedence dedupe contracts and bypass this path). An identical
+re-send inside `quotas.idless_dedupe_window_seconds` (default 60s, measured from attempt 1's TERMINAL;
+`0` disables) REPLAYS attempt 1's buyer-visible response, and an identical attempt arriving while
+attempt 1 is still in flight COALESCES onto it — holding no reservation and no concurrency lease while
+it waits (cap 4 waiters).
+**What is and is not authoritative:** the money invariant remains the durable reservation key. The
+index is a UX layer: on any miss — process restart, LRU/body eviction, oversize response, poisoned
+(truncated) stream, waiter-cap overflow — the retry adopts attempt 1's request id and falls through to
+the existing `duplicate_request_id` 409. Degraded UX, never a second bill. Publish is gated on a
+buyer-visible 2xx, NOT on settlement finality, so SPEC-022 hold entries still replay; replays call no
+Reserve/Settle/Hold and are invisible to the settlement reconciler by construction. Replayed headers
+are a whitelist (`Content-Type`, `X-Provider-Id`, `X-Request-ID`, new `X-MacProvider-Dedupe: replay`,
+plus freshly recomputed rate-limit headers); `X-MacProvider-Settlement-*` and `Retry-After` are never
+replayed. Metrics: `gateway_idless_dedupe_{replay,inflight_wait,conflict,uncacheable}_total`.
+`TestSeamH5a` flipped to `IdlessRetryBillsOnce` (PASS = certifies the fix); the miss and bypass paths
+are covered by `TestIdlessDedupe_*` in `phase5-gateway/internal/router/idless_dedupe_test.go`.
+**Residual (not fixed here):** the index is per-process and in-memory, so a gateway restart between
+attempts still double-bills — identical to today's behavior, not a regression. A durable
+`request_fingerprints` table (fingerprint → request_id, no body) is the named follow-up. The one real
+false positive is a deliberate re-roll at temperature > 0: same account, same demo token, same
+conversation tag, byte-identical body, no ids, inside 60s of attempt 1's terminal. It is bounded by the
+window, the five opt-outs, and the conflict counter — not by "did the buyer receive it", which the
+tripwire forecloses. Buyer-supplied `Idempotency-Key` dedupe on the coordinator path remains #200.
 
 **P1-2 · Settlement not crash-durable** — `money` — test `TestSeamH7`
 On the streaming after-commit path, if `SettleReservation` and the `EnsureUsageEvent` fallback both

--- a/audits/seam-hardening/harness/README.md
+++ b/audits/seam-hardening/harness/README.md
@@ -11,6 +11,7 @@ are deterministic and need no running server or credentials.
 
 Test files:
 - `phase5-gateway/internal/router/seam_harness_test.go`
+- `phase5-gateway/internal/router/idless_dedupe_test.go` (H5a's miss/bypass siblings, #762)
 - `phase4-coordinator/internal/buyer/seam_h3_test.go`
 
 ## Run
@@ -28,7 +29,7 @@ cd phase4-coordinator && go test ./internal/buyer/  -run TestSeamH -v
 |---|---|---|---|
 | **H1** `ProgressingStreamSurvivesLegacyWall` | P0-2 | **PASS = certifies FIX** (#760) | a steadily-progressing stream runs 3s past a 1s legacy wall and completes with `[DONE]`, no `provider_disconnected`, clean usage outcome |
 | **H2** `BuyerDisconnectSettlesConsumerSide` | — | **PASS** | buyer-cancel → consumer-side settle, billed bounded to delivered |
-| **H5a** `IdlessRetryDoubleBills` | P1-1 | **PASS = confirms FAIL** | two id-less calls bill 40 (2×20) |
+| **H5a** `IdlessRetryBillsOnce` | P1-1 | **PASS = certifies FIX** (#762) | two id-less calls bill 20 once; 2nd carries `X-MacProvider-Dedupe: replay` with attempt 1's exact body, upstream dispatched once |
 | **H5b** `StableRequestIDBillsOnce` | P1-1 | **PASS** (control) | same-UUID 2nd call → 409, billed once (20) |
 | **H6** `ProviderOverReportBoundedToDelivered` | — | **PASS** | provider `completion_tokens=100000` rejected → estimate, billed 24 not 100008 |
 | **H7** `SettlementNotCrashDurable` | P1-2 | **PASS = confirms GAP** | committed 200 stream + settle double-failure → usage row dropped, refunded, nobody billed |
@@ -67,6 +68,20 @@ The wall had a **second copy** the harness cannot see: `http.Client.Timeout` in 
 which also covers body reads. Fixing only the request context would have been a production no-op, so
 the client is now built by a testable `newCoordinatorClient(cfg)` with `Timeout: 0` and a dedicated
 regression test (`cmd/gateway`, `TestCoordinatorClientHasNoBodyTimeout`, `httptest.NewServer`-backed).
+
+## Mechanism note (H5a, post-#762)
+
+H5a's scenario is likewise untouched — two byte-identical id-less calls — but its verdict flipped from
+"PASS = confirms FAIL" to "PASS = certifies FIX". A fingerprint over the RAW body bytes (plus account,
+demo-token hash, and sticky conversation tag) lets attempt 2 replay attempt 1's buyer-visible response
+instead of re-dispatching inference; `X-MacProvider-Dedupe: replay` is what the tripwire asserts on.
+
+The replay cache is explicitly NOT the money invariant, so a green H5a alone would over-claim: the
+durable `(account_id, request_id)` reservation key still is, and every cache miss adopts attempt 1's id
+and lands on the existing `duplicate_request_id` 409. `idless_dedupe_test.go` carries that half —
+outside-window resend, truncated stream, error terminal, waiter-cap overflow (asserting the adopted id
+on the 409), body eviction, both bypasses, and the `idless_dedupe_window_seconds: 0` kill switch — so
+"billed once" is proven on the miss paths and not only on the happy path.
 
 The companion clocks in the harness suite live in
 `phase5-gateway/internal/router/request_deadlines_test.go` (ceiling on an endless stream, heartbeat-only

--- a/phase5-gateway/internal/config/config.go
+++ b/phase5-gateway/internal/config/config.go
@@ -104,6 +104,11 @@ type QuotasConfig struct {
 	SignupAccountsPerIPPerDay   int   `yaml:"signup_accounts_per_ip_per_day"`
 	ReaperIntervalHours         uint  `yaml:"reaper_interval_hours"`
 	ReservationMaxAgeHours      uint  `yaml:"reservation_max_age_hours"`
+	// IdlessDedupeWindowSeconds bounds how long after attempt 1's terminal
+	// an identical, id-less re-send is treated as a retry of that attempt
+	// (issue #762). 0 DISABLES id-less dedupe entirely — the operator kill
+	// switch that restores the pre-#762 bill-every-attempt behavior.
+	IdlessDedupeWindowSeconds uint `yaml:"idless_dedupe_window_seconds"`
 }
 
 type LimitsConfig struct {
@@ -234,6 +239,11 @@ func Default() Config {
 			SignupAccountsPerIPPerDay:   3,
 			ReaperIntervalHours:         1,
 			ReservationMaxAgeHours:      24,
+			// #762: 60s covers the SDK/OpenRouter retry ladder (which
+			// re-sends within seconds) without turning the gateway into a
+			// general response cache. Longer windows widen the only real
+			// false-positive: a deliberate re-roll at temperature > 0.
+			IdlessDedupeWindowSeconds: 60,
 		},
 		Limits: LimitsConfig{
 			MaxTokensPerRequest:          4096,
@@ -466,6 +476,11 @@ func (c Config) Validate() error {
 	}
 	if c.Quotas.ReservationMaxAgeHours < 2 {
 		return fmt.Errorf("quotas.reservation_max_age_hours must be >= 2")
+	}
+	// 0 is legal (kill switch). The upper bound keeps a typo from turning the
+	// bounded retry-dedupe index into a long-lived response cache.
+	if c.Quotas.IdlessDedupeWindowSeconds > 3600 {
+		return fmt.Errorf("quotas.idless_dedupe_window_seconds must be <= 3600")
 	}
 	if c.Limits.MaxTokensPerRequest <= 0 || c.Limits.DemoMaxTokensPerRequest <= 0 || c.Limits.RequestBodyBytes <= 0 {
 		return fmt.Errorf("limits must be positive")

--- a/phase5-gateway/internal/router/chat_proxy.go
+++ b/phase5-gateway/internal/router/chat_proxy.go
@@ -251,6 +251,68 @@ func (s *Server) handleChatCompletions(w http.ResponseWriter, r *http.Request) {
 	} else {
 		deadlines.armPhaseFromStart(deadlinePhaseNonStreamWall, requestBound)
 	}
+	// #762 (seam finding P1-1): bill each buyer intent once even when the
+	// retry carries no id. An id-less retry — the OpenRouter default — mints
+	// a fresh request_id per attempt, so the durable (account_id, request_id)
+	// reservation key never matches and every attempt reserves and settles
+	// again.
+	//
+	// Precedence, highest first: a buyer-supplied Idempotency-Key owns dedupe
+	// (the coordinator path, issue #200) and a client-supplied UUID
+	// X-Request-ID already deduped durably. Only gateway-minted ids — the
+	// case where the buyer expressed no identity at all — reach the
+	// fingerprint path.
+	//
+	// The fingerprint is computed here, AFTER validation, so a malformed or
+	// over-cap request can never occupy a slot. The index is a UX layer, not
+	// the money invariant: on any miss the retry adopts attempt 1's id and
+	// falls through to the durable duplicate_request_id 409 below.
+	var dedupeFingerprint string
+	if dedupeWindow := s.idlessDedupeWindow(); dedupeWindow > 0 &&
+		requestIDClass(r) == retry503RequestIDClassGatewayGenerated &&
+		strings.TrimSpace(r.Header.Get("Idempotency-Key")) == "" {
+		dedupeFingerprint = idlessRequestFingerprint(
+			subject.AccountID,
+			subject.DemoTokenHash,
+			strings.TrimSpace(r.Header.Get("X-MacProvider-Conversation")),
+			body,
+		)
+		entry, adopted := s.idlessDedupe.claim(dedupeFingerprint, requestID(r), s.now(), dedupeWindow)
+		if adopted {
+			// Attempt 1 owns this entry. Clearing the fingerprint is
+			// load-bearing: it makes the terminal defer below a no-op, so
+			// only the claim winner can ever publish or drop.
+			dedupeFingerprint = ""
+			// Adopt attempt 1's id for the rest of the request. The response
+			// header must be overwritten too — the middleware already wrote
+			// this attempt's freshly minted id (server.go:257) — or a
+			// fall-through 409 would name an id the buyer cannot correlate.
+			r = r.WithContext(context.WithValue(r.Context(), requestIDKey{}, entry.requestID))
+			w.Header().Set("X-Request-ID", entry.requestID)
+			if s.replayIdlessDuplicate(w, r, subject, dailyQuota, entry, dedupeWindow, deadlines) {
+				return
+			}
+		} else {
+			sw.armDedupeCapture(idlessDedupeMaxEntryBytes)
+			defer func() {
+				if dedupeFingerprint == "" {
+					return
+				}
+				// Publish is gated on a buyer-visible 2xx, not on settlement
+				// finality: a SPEC-022 hold is still a delivered answer, and
+				// a retry of it must not re-run inference. A buyer who
+				// disconnected never saw the whole response, so nothing is
+				// cached for them (their partial is settled as usual).
+				if sw.dedupePublishable() && r.Context().Err() == nil {
+					s.idlessDedupe.publish(dedupeFingerprint, requestID(r), sw.statusCode,
+						w.Header().Get("Content-Type"), w.Header().Get("X-Provider-Id"),
+						sw.dedupeCapture(), s.now())
+					return
+				}
+				s.idlessDedupe.drop(dedupeFingerprint, requestID(r))
+			}()
+		}
+	}
 	promptEstimate := estimatePromptTokens(body)
 	promptReservation := promptCapTokens(body)
 	reservationTokens := promptReservation + maxTokens
@@ -2516,10 +2578,55 @@ func readLimitedBody(r io.Reader, maxBytes int64) ([]byte, error) {
 // statusWriter wraps http.ResponseWriter to capture the HTTP status code that
 // was written. handleChatCompletions uses it for an end-of-request log line
 // (G3 — operator observability for the flaky-provider failure mode).
+//
+// #762 extends it with a bounded capture of the buyer-visible body, armed
+// ONLY for the request that won an id-less dedupe fingerprint claim. The
+// capture is what a later identical id-less retry replays instead of paying
+// for a second generation.
 type statusWriter struct {
 	http.ResponseWriter
 	statusCode int
 	flushed    bool
+
+	captureArmed bool
+	captureCap   int
+	capture      []byte
+	overflowed   bool
+	// poisoned marks a response that reached the buyer as a 200 but is not
+	// a complete answer — a mid-stream SSE error frame. Replaying a
+	// truncated stream would hand a retry a worse answer than a fresh
+	// dispatch, so poisoned responses are dropped, not cached.
+	poisoned bool
+}
+
+// armDedupeCapture starts recording the buyer-visible body, up to limit bytes.
+func (sw *statusWriter) armDedupeCapture(limit int) {
+	sw.captureArmed = true
+	sw.captureCap = limit
+}
+
+// dedupePublishable reports whether the captured response may be replayed to
+// an identical id-less retry: a complete, buyer-visible 2xx that fit the cap.
+func (sw *statusWriter) dedupePublishable() bool {
+	return sw.captureArmed && !sw.poisoned && !sw.overflowed &&
+		sw.statusCode >= 200 && sw.statusCode < 300
+}
+
+func (sw *statusWriter) dedupeCapture() []byte {
+	if !sw.captureArmed || sw.overflowed {
+		return nil
+	}
+	return sw.capture
+}
+
+// poisonDedupeCapture marks the response behind w as un-replayable. Called
+// from every mid-stream SSE error writer: those frames ride on an already
+// committed 200, so the status code alone cannot tell a complete stream from
+// a truncated one. A no-op for any writer that is not a *statusWriter.
+func poisonDedupeCapture(w http.ResponseWriter) {
+	if sw, ok := w.(*statusWriter); ok {
+		sw.poisoned = true
+	}
 }
 
 func (sw *statusWriter) WriteHeader(code int) {
@@ -2534,6 +2641,16 @@ func (sw *statusWriter) Write(b []byte) (int, error) {
 	if !sw.flushed {
 		sw.statusCode = http.StatusOK
 		sw.flushed = true
+	}
+	if sw.captureArmed && !sw.overflowed {
+		if len(sw.capture)+len(b) > sw.captureCap {
+			// Oversize responses are not cached at all (rather than
+			// truncated): a partial replay would be a wrong answer.
+			sw.overflowed = true
+			sw.capture = nil
+		} else {
+			sw.capture = append(sw.capture, b...)
+		}
 	}
 	return sw.ResponseWriter.Write(b)
 }
@@ -2557,6 +2674,10 @@ func (sw *statusWriter) Flush() {
 // dedicated writeProviderDisconnectedSSE wrapper so its strings
 // are centralized and resistant to drift.
 func writeSSEError(w http.ResponseWriter, message, errType, code string) {
+	// #762: an SSE error frame means this 200 stream is NOT a complete
+	// answer. Poison the dedupe capture so an identical id-less retry gets a
+	// fresh dispatch instead of replaying a truncated generation.
+	poisonDedupeCapture(w)
 	// H1: SSE error frames carry retryable too, classified by the same
 	// gatewayRetryableByCode table writeError uses. Headers are already
 	// flushed by the time an SSE frame is emitted (the stream started as
@@ -2576,6 +2697,8 @@ func writeStructuredOutputTimeoutSSE(w http.ResponseWriter, requestID string) {
 	// emitted, rather than a hardcoded false — a provider timeout IS
 	// retryable, and hardcoding false here contradicted the coordinator's
 	// own provider_timeout:true classification for the identical code.
+	// #762: a timeout terminal is never a replayable answer.
+	poisonDedupeCapture(w)
 	w.Header().Set("Content-Type", "text/event-stream; charset=utf-8")
 	payload, _ := json.Marshal(map[string]any{
 		"error": map[string]any{
@@ -2601,6 +2724,10 @@ func writeStructuredOutputTimeoutSSE(w http.ResponseWriter, requestID string) {
 // future refactors lean on a single named contract surface instead
 // of free-form writeSSEError args. Issue #186; architect R1 NOTE.
 func writeProviderDisconnectedSSE(w http.ResponseWriter) {
+	// #762: explicit here as well as inside writeSSEError, so a future
+	// refactor that stops routing this envelope through writeSSEError cannot
+	// silently start caching truncated streams.
+	poisonDedupeCapture(w)
 	writeSSEError(w, "Provider disconnected during streaming", "server_error", "provider_disconnected")
 }
 

--- a/phase5-gateway/internal/router/chat_proxy.go
+++ b/phase5-gateway/internal/router/chat_proxy.go
@@ -326,6 +326,20 @@ func (s *Server) handleChatCompletions(w http.ResponseWriter, r *http.Request) {
 						sw.dedupeCapture(), s.now())
 					return
 				}
+				// Audit R2 (code HIGH): a COMPLETE, delivered, billed 2xx
+				// whose body merely exceeded the replay cap must keep its
+				// fp->request_id mapping — dropping it would let an identical
+				// id-less retry mint a fresh id and bill again. Publish a
+				// body-less stub instead: the retry adopts the id and lands
+				// on the durable 409. Only poisoned attempts (partial or
+				// error content, failed buyer writes) and buyer disconnects
+				// drop, because those retries MUST re-dispatch.
+				if sw.dedupeDeliveredButUncacheable() && r.Context().Err() == nil {
+					s.idlessDedupe.publish(dedupeFingerprint, requestID(r), sw.statusCode,
+						w.Header().Get("Content-Type"), w.Header().Get("X-Provider-Id"),
+						nil, s.now())
+					return
+				}
 				s.idlessDedupe.drop(dedupeFingerprint, requestID(r))
 			}()
 		}
@@ -2640,6 +2654,15 @@ func (sw *statusWriter) armDedupeCapture(limit int) {
 // an identical id-less retry: a complete, buyer-visible 2xx that fit the cap.
 func (sw *statusWriter) dedupePublishable() bool {
 	return sw.captureArmed && !sw.poisoned && !sw.overflowed &&
+		sw.statusCode >= 200 && sw.statusCode < 300
+}
+
+// dedupeDeliveredButUncacheable reports a fully-delivered, unpoisoned 2xx
+// whose body exceeded the replay cap: the response reached the buyer and was
+// billed, so its fp->request_id mapping must survive as a body-less stub
+// even though replay is unavailable (audit R2, code HIGH).
+func (sw *statusWriter) dedupeDeliveredButUncacheable() bool {
+	return sw.captureArmed && !sw.poisoned && sw.overflowed &&
 		sw.statusCode >= 200 && sw.statusCode < 300
 }
 

--- a/phase5-gateway/internal/router/chat_proxy.go
+++ b/phase5-gateway/internal/router/chat_proxy.go
@@ -275,10 +275,17 @@ func (s *Server) handleChatCompletions(w http.ResponseWriter, r *http.Request) {
 			subject.AccountID,
 			subject.DemoTokenHash,
 			strings.TrimSpace(r.Header.Get("X-MacProvider-Conversation")),
+			strings.TrimSpace(r.Header.Get("X-MacProvider-Retry")),
 			body,
 		)
 		entry, adopted := s.idlessDedupe.claim(dedupeFingerprint, requestID(r), s.now(), dedupeWindow)
-		if adopted {
+		switch {
+		case entry == nil:
+			// In-flight claim cap is full. Skip dedupe entirely rather than
+			// letting the map grow: this request behaves exactly as it did
+			// pre-#762 (its own id, its own reservation, its own bill).
+			dedupeFingerprint = ""
+		case adopted:
 			// Attempt 1 owns this entry. Clearing the fingerprint is
 			// load-bearing: it makes the terminal defer below a no-op, so
 			// only the claim winner can ever publish or drop.
@@ -292,11 +299,21 @@ func (s *Server) handleChatCompletions(w http.ResponseWriter, r *http.Request) {
 			if s.replayIdlessDuplicate(w, r, subject, dailyQuota, entry, dedupeWindow, deadlines) {
 				return
 			}
-		} else {
+		default:
 			sw.armDedupeCapture(idlessDedupeMaxEntryBytes)
 			defer func() {
 				if dedupeFingerprint == "" {
 					return
+				}
+				// A panic unwinding through here has already written part of
+				// a 2xx in the streaming case; the recovery middleware will
+				// turn it into internal_error. Publishing that partial would
+				// cache a response no buyer ever completed, so drop it and
+				// re-panic so the middleware still sees and handles the
+				// panic exactly as before.
+				if recovered := recover(); recovered != nil {
+					s.idlessDedupe.drop(dedupeFingerprint, requestID(r))
+					panic(recovered)
 				}
 				// Publish is gated on a buyer-visible 2xx, not on settlement
 				// finality: a SPEC-022 hold is still a delivered answer, and
@@ -1026,6 +1043,11 @@ func (s *Server) forwardStreamingChat(w http.ResponseWriter, r *http.Request, re
 	}
 	settleCancelled := func() {
 		cancelCoordinator()
+		// #762: the buyer never received the whole stream — either they
+		// disconnected or a write to them failed. Poison explicitly rather
+		// than relying on r.Context().Err() being observable in the publish
+		// defer: a failed write does not necessarily cancel the context.
+		poisonDedupeCapture(w)
 		settleObservedContent("client_disconnect")
 	}
 	settleIdleTimeout := func() {
@@ -1078,6 +1100,11 @@ func (s *Server) forwardStreamingChat(w http.ResponseWriter, r *http.Request, re
 				}
 				if code := terminalSSEErrorCode(data); isSpec019TerminalSSEErrorCode(code) {
 					terminalStructuredErrorCode = code
+					// #762: a 200 stream that ends in a SPEC-019 terminal
+					// error envelope is refunded, not an answer. Caching it
+					// would replay a stale provider error to a retry that
+					// deserves a fresh dispatch.
+					poisonDedupeCapture(w)
 					if _, err := w.Write(line); err != nil {
 						slog.Warn("streaming buyer write failed", "request_id", requestID(r), "error", err)
 						refundTerminalStructuredError()
@@ -1176,6 +1203,10 @@ func (s *Server) forwardStreamingChat(w http.ResponseWriter, r *http.Request, re
 		}
 		if _, err := w.Write(line); err != nil {
 			slog.Warn("streaming buyer write failed", "request_id", requestID(r), "error", err)
+			// #762: explicit, even though settleCancelled poisons too — this
+			// is the exact path an audit flagged as publishing a partial,
+			// never-delivered 2xx.
+			poisonDedupeCapture(w)
 			settleCancelled()
 			return false
 		}
@@ -2642,17 +2673,28 @@ func (sw *statusWriter) Write(b []byte) (int, error) {
 		sw.statusCode = http.StatusOK
 		sw.flushed = true
 	}
-	if sw.captureArmed && !sw.overflowed {
-		if len(sw.capture)+len(b) > sw.captureCap {
+	// Capture what the buyer actually RECEIVED, which is what the underlying
+	// writer reports — not what we handed it. Capturing before the write let
+	// a failed or short write (buyer gone mid-stream) be published as a
+	// complete 2xx and replayed to the next retry.
+	n, err := sw.ResponseWriter.Write(b)
+	if sw.captureArmed && !sw.overflowed && !sw.poisoned {
+		switch {
+		case err != nil:
+			// The buyer did not get all of this. Whatever we hold is a
+			// partial response; it must never be replayed.
+			sw.poisoned = true
+			sw.capture = nil
+		case len(sw.capture)+n > sw.captureCap:
 			// Oversize responses are not cached at all (rather than
 			// truncated): a partial replay would be a wrong answer.
 			sw.overflowed = true
 			sw.capture = nil
-		} else {
-			sw.capture = append(sw.capture, b...)
+		default:
+			sw.capture = append(sw.capture, b[:n]...)
 		}
 	}
-	return sw.ResponseWriter.Write(b)
+	return n, err
 }
 
 // Flush satisfies http.Flusher so SSE streaming through this wrapper still

--- a/phase5-gateway/internal/router/idless_dedupe.go
+++ b/phase5-gateway/internal/router/idless_dedupe.go
@@ -1,0 +1,416 @@
+package router
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"net/http"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+// Id-less retry dedupe (issue #762 / seam finding P1-1).
+//
+// OpenRouter — and most SDK retry loops — re-send a failed or slow request
+// WITHOUT an X-Request-ID. The gateway middleware mints a fresh id per
+// attempt, so the durable (account_id, request_id) primary key on
+// quota_reservations never matches and every attempt reserves + settles
+// independently: one buyer intent, N bills.
+//
+// This index gives an identical, id-less re-send a chance to REPLAY attempt
+// 1's buyer-visible response instead of re-dispatching inference, and to
+// COALESCE onto attempt 1 while it is still in flight.
+//
+// It is deliberately NOT the money invariant. The durable reservation key
+// still is: a retry that finds no usable cache entry adopts attempt 1's
+// request_id and falls through to the existing duplicate_request_id 409.
+// Every miss path (process restart, LRU eviction, oversize body, poisoned
+// stream) therefore degrades to a 409, never to a second bill.
+//
+// Sizing mirrors requestRateLimiter (request_rate_limiter.go): a bounded map
+// with a periodic prune and LRU eviction, so a hostile buyer cannot grow the
+// gateway's heap by varying request bodies.
+const (
+	// idlessDedupeFingerprintVersion is mixed into every fingerprint so a
+	// future change to the keying inputs can never collide with entries
+	// computed by an older build.
+	idlessDedupeFingerprintVersion = "mpg-idless-v1"
+
+	idlessDedupeMaxEntries    = 4096
+	idlessDedupeMaxEntryBytes = 1 << 20  // 1 MiB per cached response body
+	idlessDedupeMaxTotalBytes = 32 << 20 // 32 MiB of cached bodies overall
+	idlessDedupePruneInterval = time.Minute
+	// idlessDedupeMaxWaiters bounds how many concurrent identical attempts
+	// may park on one in-flight request. Waiters hold no quota reservation
+	// and no concurrency lease, but they do hold a server goroutine.
+	idlessDedupeMaxWaiters = 4
+
+	// idlessDedupeHeader marks a replayed response so buyers (and the
+	// harness) can tell a cache replay from a fresh generation.
+	idlessDedupeHeader      = "X-MacProvider-Dedupe"
+	idlessDedupeHeaderValue = "replay"
+)
+
+// idlessRequestFingerprint keys the dedupe index.
+//
+// The body is hashed as RAW BYTES, not canonicalized JSON: byte-identity is
+// upstream-identity, and any normalization would widen the false-positive
+// surface (two different requests collapsing onto one answer) in exchange for
+// catching retries that no real client emits. The coordinator's request
+// hashing takes the same position.
+//
+// Everything that changes the generated answer is either in those bytes
+// (model, messages, stream, max_tokens, response_format) or in the explicit
+// key parts below (tenant, demo token, sticky conversation). Transport-level
+// headers — Authorization, IP, User-Agent, Accept*, the id headers — are
+// deliberately excluded: they vary across a legitimate retry.
+func idlessRequestFingerprint(accountID, demoTokenHash, conversationTag string, body []byte) string {
+	bodyDigest := sha256.Sum256(body)
+	h := sha256.New()
+	for _, part := range []string{idlessDedupeFingerprintVersion, accountID, demoTokenHash, conversationTag} {
+		h.Write([]byte(part))
+		h.Write([]byte{0})
+	}
+	h.Write(bodyDigest[:])
+	return hex.EncodeToString(h.Sum(nil))
+}
+
+// idlessDedupeEntry is one fingerprint's slot. It is created by the request
+// that WON the claim and is only ever published or dropped by that request
+// (ownership is checked on requestID) — see publish/drop.
+type idlessDedupeEntry struct {
+	// requestID is attempt 1's gateway-minted id. Adopting it is what makes
+	// the durable reservation key the real duplicate detector.
+	requestID string
+	// done is closed exactly once, when the owner reaches a terminal state
+	// (published or dropped). Waiters park on it.
+	done   chan struct{}
+	closed bool
+
+	completed   bool
+	status      int
+	contentType string
+	providerID  string
+	// body is the captured buyer-visible response. nil means "replay
+	// unavailable" — never cached, or the body was evicted under memory
+	// pressure while the fingerprint→requestID mapping was kept.
+	body []byte
+
+	terminalAt time.Time
+	lastSeen   time.Time
+	waiters    int
+}
+
+func (e *idlessDedupeEntry) closeLocked() {
+	if !e.closed {
+		e.closed = true
+		close(e.done)
+	}
+}
+
+// idlessDedupeReplay is an immutable snapshot of a replayable entry, taken
+// under the index lock so the writer never touches shared state.
+type idlessDedupeReplay struct {
+	requestID   string
+	status      int
+	contentType string
+	providerID  string
+	body        []byte
+}
+
+type idlessDedupeIndex struct {
+	mu         sync.Mutex
+	entries    map[string]*idlessDedupeEntry
+	totalBytes int
+	lastPruned time.Time
+
+	replayTotal       atomic.Int64
+	inflightWaitTotal atomic.Int64
+	conflictTotal     atomic.Int64
+	uncacheableTotal  atomic.Int64
+}
+
+func newIdlessDedupeIndex() *idlessDedupeIndex {
+	return &idlessDedupeIndex{entries: make(map[string]*idlessDedupeEntry)}
+}
+
+// claim registers requestID as the owner of fp, or reports that an earlier
+// attempt already owns it. adopted=true means the caller must NOT publish or
+// drop the entry; it either replays or falls through to the durable 409.
+func (x *idlessDedupeIndex) claim(fp, requestID string, now time.Time, window time.Duration) (*idlessDedupeEntry, bool) {
+	x.mu.Lock()
+	defer x.mu.Unlock()
+	if entry := x.entries[fp]; entry != nil {
+		// The window is measured from attempt 1's TERMINAL, not its start:
+		// a 900s generation must still dedupe a retry sent right after it
+		// finishes. In-flight entries never expire — they are bounded by
+		// the owning request's own ceiling.
+		if entry.completed && now.Sub(entry.terminalAt) > window {
+			x.removeLocked(fp, entry)
+		} else {
+			entry.lastSeen = now
+			return entry, true
+		}
+	}
+	x.pruneForInsertLocked(now, window)
+	entry := &idlessDedupeEntry{requestID: requestID, done: make(chan struct{}), lastSeen: now}
+	x.entries[fp] = entry
+	return entry, false
+}
+
+// publish records the owner's buyer-visible 2xx response. A no-op unless
+// requestID still owns fp (the entry may have been evicted, or replaced by a
+// later attempt after eviction).
+func (x *idlessDedupeIndex) publish(fp, requestID string, status int, contentType, providerID string, body []byte, now time.Time) {
+	x.mu.Lock()
+	defer x.mu.Unlock()
+	entry := x.entries[fp]
+	if entry == nil || entry.requestID != requestID || entry.completed {
+		return
+	}
+	entry.status = status
+	entry.contentType = contentType
+	entry.providerID = providerID
+	if len(body) > 0 && len(body) <= idlessDedupeMaxEntryBytes {
+		entry.body = body
+		x.totalBytes += len(body)
+	}
+	entry.completed = true
+	entry.terminalAt = now
+	entry.lastSeen = now
+	entry.closeLocked()
+	x.evictBodiesLocked()
+}
+
+// drop retires an entry whose owner did NOT produce a replayable response
+// (non-2xx, truncated stream, buyer disconnect, oversize body). Parked
+// waiters are woken and fall through to the durable 409; later attempts find
+// no entry at all and re-dispatch normally.
+func (x *idlessDedupeIndex) drop(fp, requestID string) {
+	x.mu.Lock()
+	defer x.mu.Unlock()
+	entry := x.entries[fp]
+	if entry == nil || entry.requestID != requestID {
+		return
+	}
+	x.removeLocked(fp, entry)
+	x.uncacheableTotal.Add(1)
+}
+
+// awaitTerminal parks until the owner reaches a terminal state. It reports
+// false when the waiter cap is already reached or ctx expires first, which
+// sends the caller to the durable 409 rather than to a second dispatch.
+func (x *idlessDedupeIndex) awaitTerminal(ctx context.Context, entry *idlessDedupeEntry) bool {
+	x.mu.Lock()
+	if entry.closed {
+		x.mu.Unlock()
+		return true
+	}
+	if entry.waiters >= idlessDedupeMaxWaiters {
+		x.mu.Unlock()
+		return false
+	}
+	entry.waiters++
+	x.mu.Unlock()
+	x.inflightWaitTotal.Add(1)
+	defer func() {
+		x.mu.Lock()
+		entry.waiters--
+		x.mu.Unlock()
+	}()
+	select {
+	case <-entry.done:
+		return true
+	case <-ctx.Done():
+		return false
+	}
+}
+
+// replaySnapshot returns a replayable copy of entry, or ok=false when the
+// entry never completed, was dropped, lost its body to eviction, or fell
+// outside the window between the claim and now.
+func (x *idlessDedupeIndex) replaySnapshot(entry *idlessDedupeEntry, now time.Time, window time.Duration) (idlessDedupeReplay, bool) {
+	x.mu.Lock()
+	defer x.mu.Unlock()
+	if !entry.completed || entry.body == nil {
+		return idlessDedupeReplay{}, false
+	}
+	if now.Sub(entry.terminalAt) > window {
+		return idlessDedupeReplay{}, false
+	}
+	entry.lastSeen = now
+	return idlessDedupeReplay{
+		requestID:   entry.requestID,
+		status:      entry.status,
+		contentType: entry.contentType,
+		providerID:  entry.providerID,
+		body:        entry.body,
+	}, true
+}
+
+func (x *idlessDedupeIndex) removeLocked(fp string, entry *idlessDedupeEntry) {
+	delete(x.entries, fp)
+	if entry.body != nil {
+		x.totalBytes -= len(entry.body)
+		entry.body = nil
+	}
+	entry.closeLocked()
+}
+
+func (x *idlessDedupeIndex) pruneForInsertLocked(now time.Time, window time.Duration) {
+	if len(x.entries) < idlessDedupeMaxEntries {
+		if !x.lastPruned.IsZero() && now.Sub(x.lastPruned) < idlessDedupePruneInterval {
+			return
+		}
+		x.pruneExpiredLocked(now, window)
+		return
+	}
+	x.pruneExpiredLocked(now, window)
+	for len(x.entries) >= idlessDedupeMaxEntries {
+		if !x.evictOldestLocked() {
+			// Everything left is in flight: an owner is still running and
+			// waiters may be parked on it, so evicting would strand them.
+			// The map can only exceed the cap by the number of concurrent
+			// in-flight requests, which the concurrency limiter bounds.
+			return
+		}
+	}
+}
+
+func (x *idlessDedupeIndex) pruneExpiredLocked(now time.Time, window time.Duration) {
+	x.lastPruned = now
+	for fp, entry := range x.entries {
+		if entry.completed && now.Sub(entry.terminalAt) > window {
+			x.removeLocked(fp, entry)
+		}
+	}
+}
+
+// evictOldestLocked drops the least recently seen COMPLETED entry. In-flight
+// entries are never evicted (see pruneForInsertLocked).
+func (x *idlessDedupeIndex) evictOldestLocked() bool {
+	var oldestFP string
+	var oldest *idlessDedupeEntry
+	for fp, entry := range x.entries {
+		if !entry.completed {
+			continue
+		}
+		if oldest == nil || entry.lastSeen.Before(oldest.lastSeen) {
+			oldestFP, oldest = fp, entry
+		}
+	}
+	if oldest == nil {
+		return false
+	}
+	x.removeLocked(oldestFP, oldest)
+	return true
+}
+
+// evictBodiesLocked enforces the total-bytes cap by dropping cached BODIES,
+// least recently seen first. The fingerprint→requestID mapping survives, so a
+// retry inside the window still adopts attempt 1's id and still gets the
+// durable 409 instead of a second bill — losing the replay costs UX, not
+// money.
+func (x *idlessDedupeIndex) evictBodiesLocked() {
+	for x.totalBytes > idlessDedupeMaxTotalBytes {
+		var oldest *idlessDedupeEntry
+		for _, entry := range x.entries {
+			if entry.body == nil {
+				continue
+			}
+			if oldest == nil || entry.lastSeen.Before(oldest.lastSeen) {
+				oldest = entry
+			}
+		}
+		if oldest == nil {
+			return
+		}
+		x.totalBytes -= len(oldest.body)
+		oldest.body = nil
+	}
+}
+
+// idlessDedupeWindow is the operator-facing kill switch and blast radius for
+// the whole feature: 0 disables id-less dedupe entirely and restores the
+// pre-#762 behavior (every id-less retry bills again).
+func (s *Server) idlessDedupeWindow() time.Duration {
+	return time.Duration(s.cfg.Quotas.IdlessDedupeWindowSeconds) * time.Second
+}
+
+// replayIdlessDuplicate serves an adopted retry from attempt 1's cached
+// response. It reports false when no replay is possible — in-flight wait cap
+// or expiry, dropped entry, evicted body — leaving the caller to fall through
+// to ReserveQuota, which returns ErrReservationExists for the adopted id and
+// yields the existing duplicate_request_id 409.
+//
+// Nothing on this path reserves, settles, or holds: a replay is invisible to
+// the settlement reconciler by construction, because attempt 1 already booked
+// the one and only charge.
+func (s *Server) replayIdlessDuplicate(w http.ResponseWriter, r *http.Request, subject usageSubject, dailyQuota int64, entry *idlessDedupeEntry, window time.Duration, deadlines *requestDeadlines) bool {
+	if !s.idlessDedupe.awaitTerminal(deadlines.Context(), entry) {
+		s.idlessDedupe.conflictTotal.Add(1)
+		return false
+	}
+	snapshot, ok := s.idlessDedupe.replaySnapshot(entry, s.now(), window)
+	if !ok {
+		s.idlessDedupe.conflictTotal.Add(1)
+		return false
+	}
+	header := w.Header()
+	// Header whitelist. Only what identifies the response is replayed;
+	// per-attempt settlement telemetry and retry hints are NEVER echoed,
+	// because they describe attempt 1's billing transaction, not this one.
+	for name := range header {
+		if strings.HasPrefix(strings.ToLower(name), "x-macprovider-settlement-") {
+			header.Del(name)
+		}
+	}
+	header.Del("Retry-After")
+	if snapshot.contentType != "" {
+		header.Set("Content-Type", snapshot.contentType)
+	}
+	if snapshot.providerID != "" {
+		header.Set("X-Provider-Id", snapshot.providerID)
+	}
+	header.Set("X-Request-ID", snapshot.requestID)
+	header.Set(idlessDedupeHeader, idlessDedupeHeaderValue)
+	// Rate-limit headers are recomputed, never replayed: the buyer's quota
+	// moved on between attempt 1 and this retry.
+	usageWindow := s.now().UTC().Format("2006-01-02")
+	if used, reserved, err := s.readStore().DailyUsage(r.Context(), subject.AccountID, usageWindow); err == nil {
+		remaining := dailyQuota - used - reserved
+		if remaining < 0 {
+			remaining = 0
+		}
+		setRateLimitHeaders(w, dailyQuota, remaining, resetUnix(usageWindow))
+	}
+	w.WriteHeader(snapshot.status)
+	if _, err := w.Write(snapshot.body); err != nil {
+		return true
+	}
+	if flusher, ok := w.(http.Flusher); ok && strings.HasPrefix(snapshot.contentType, "text/event-stream") {
+		flusher.Flush()
+	}
+	s.idlessDedupe.replayTotal.Add(1)
+	return true
+}
+
+func (x *idlessDedupeIndex) prometheus() string {
+	var b strings.Builder
+	b.WriteString("# HELP gateway_idless_dedupe_replay_total Id-less retries served from attempt 1's cached response.\n")
+	b.WriteString("# TYPE gateway_idless_dedupe_replay_total counter\n")
+	fmt.Fprintf(&b, "gateway_idless_dedupe_replay_total %d\n", x.replayTotal.Load())
+	b.WriteString("# HELP gateway_idless_dedupe_inflight_wait_total Id-less retries that parked on an in-flight identical attempt.\n")
+	b.WriteString("# TYPE gateway_idless_dedupe_inflight_wait_total counter\n")
+	fmt.Fprintf(&b, "gateway_idless_dedupe_inflight_wait_total %d\n", x.inflightWaitTotal.Load())
+	b.WriteString("# HELP gateway_idless_dedupe_conflict_total Id-less retries that adopted attempt 1's request id and fell through to the durable duplicate_request_id 409.\n")
+	b.WriteString("# TYPE gateway_idless_dedupe_conflict_total counter\n")
+	fmt.Fprintf(&b, "gateway_idless_dedupe_conflict_total %d\n", x.conflictTotal.Load())
+	b.WriteString("# HELP gateway_idless_dedupe_uncacheable_total Attempts whose terminal response was not replayable (non-2xx, truncated stream, buyer disconnect, oversize body).\n")
+	b.WriteString("# TYPE gateway_idless_dedupe_uncacheable_total counter\n")
+	fmt.Fprintf(&b, "gateway_idless_dedupe_uncacheable_total %d\n", x.uncacheableTotal.Load())
+	return b.String()
+}

--- a/phase5-gateway/internal/router/idless_dedupe.go
+++ b/phase5-gateway/internal/router/idless_dedupe.go
@@ -39,14 +39,32 @@ const (
 	// computed by an older build.
 	idlessDedupeFingerprintVersion = "mpg-idless-v1"
 
-	idlessDedupeMaxEntries    = 4096
-	idlessDedupeMaxEntryBytes = 1 << 20  // 1 MiB per cached response body
-	idlessDedupeMaxTotalBytes = 32 << 20 // 32 MiB of cached bodies overall
+	// Two separate caps, because the two things an entry holds cost wildly
+	// different amounts of memory and wildly different amounts of money when
+	// dropped.
+	//
+	// The BODY is the expensive part (up to 1 MiB) and losing it costs only
+	// UX: the retry still adopts attempt 1's request id and still lands on
+	// the durable 409. The fp→requestID MAPPING is ~100 bytes and losing it
+	// INSIDE the window costs money: the retry mints a fresh id, reserves
+	// independently, and bills twice. So memory pressure spends bodies first
+	// and keeps bare mapping stubs until the window expires.
+	idlessDedupeMaxBodies     = 4096      // entries still holding a response
+	idlessDedupeMaxMappings   = 65536     // fp→requestID stubs, body or not
+	idlessDedupeMaxEntryBytes = 1 << 20   // 1 MiB per cached response body
+	idlessDedupeMaxTotalBytes = 32 << 20  // 32 MiB of cached bodies overall
 	idlessDedupePruneInterval = time.Minute
 	// idlessDedupeMaxWaiters bounds how many concurrent identical attempts
 	// may park on one in-flight request. Waiters hold no quota reservation
 	// and no concurrency lease, but they do hold a server goroutine.
 	idlessDedupeMaxWaiters = 4
+	// idlessDedupeMaxInFlight bounds concurrently-claimed (not yet terminal)
+	// entries. The claim happens BEFORE ReserveQuota and AcquireConcurrency
+	// — that is what keeps a waiter from holding a reservation — so the
+	// account concurrency limiter does NOT bound this map. Past the cap the
+	// gateway skips dedupe for that request entirely rather than growing
+	// without limit: it proceeds exactly as it did pre-#762.
+	idlessDedupeMaxInFlight = 4096
 
 	// idlessDedupeHeader marks a replayed response so buyers (and the
 	// harness) can tell a cache replay from a fresh generation.
@@ -62,15 +80,31 @@ const (
 // catching retries that no real client emits. The coordinator's request
 // hashing takes the same position.
 //
-// Everything that changes the generated answer is either in those bytes
-// (model, messages, stream, max_tokens, response_format) or in the explicit
-// key parts below (tenant, demo token, sticky conversation). Transport-level
+// Components, in order, each NUL-terminated so no part can be shifted into
+// its neighbour:
+//
+//  1. idlessDedupeFingerprintVersion — the keying-scheme tag.
+//  2. accountID — the billed tenant.
+//  3. demoTokenHash — distinguishes two demo sessions behind one IP.
+//  4. conversationTag — X-MacProvider-Conversation, which selects sticky
+//     routing and therefore which provider answers.
+//  5. retryHint — X-MacProvider-Retry, which copyForwardHeaders forwards to
+//     the coordinator where it changes retry/failover behaviour. Two requests
+//     that differ only in this header are NOT the same dispatch.
+//  6. SHA-256 of the raw body bytes.
+//
+// Everything else that changes the generated answer is inside those bytes
+// (model, messages, stream, max_tokens, response_format). Transport-level
 // headers — Authorization, IP, User-Agent, Accept*, the id headers — are
 // deliberately excluded: they vary across a legitimate retry.
-func idlessRequestFingerprint(accountID, demoTokenHash, conversationTag string, body []byte) string {
+//
+// Adding a component is a keying change: bump idlessDedupeFingerprintVersion
+// when one is added to a build that is already deployed, so old and new
+// fingerprints cannot collide.
+func idlessRequestFingerprint(accountID, demoTokenHash, conversationTag, retryHint string, body []byte) string {
 	bodyDigest := sha256.Sum256(body)
 	h := sha256.New()
-	for _, part := range []string{idlessDedupeFingerprintVersion, accountID, demoTokenHash, conversationTag} {
+	for _, part := range []string{idlessDedupeFingerprintVersion, accountID, demoTokenHash, conversationTag, retryHint} {
 		h.Write([]byte(part))
 		h.Write([]byte{0})
 	}
@@ -125,12 +159,18 @@ type idlessDedupeIndex struct {
 	mu         sync.Mutex
 	entries    map[string]*idlessDedupeEntry
 	totalBytes int
+	// bodyCount and inFlight are derived counts kept incrementally so the
+	// hot path never scans the map to answer "am I over a cap".
+	bodyCount  int
+	inFlight   int
 	lastPruned time.Time
 
-	replayTotal       atomic.Int64
-	inflightWaitTotal atomic.Int64
-	conflictTotal     atomic.Int64
-	uncacheableTotal  atomic.Int64
+	replayTotal              atomic.Int64
+	inflightWaitTotal        atomic.Int64
+	conflictTotal            atomic.Int64
+	uncacheableTotal         atomic.Int64
+	mappingPressureEvictions atomic.Int64
+	inflightCapSkips         atomic.Int64
 }
 
 func newIdlessDedupeIndex() *idlessDedupeIndex {
@@ -138,8 +178,13 @@ func newIdlessDedupeIndex() *idlessDedupeIndex {
 }
 
 // claim registers requestID as the owner of fp, or reports that an earlier
-// attempt already owns it. adopted=true means the caller must NOT publish or
-// drop the entry; it either replays or falls through to the durable 409.
+// attempt already owns it.
+//
+//   - (entry, true)  — adopted: an earlier attempt owns fp. The caller must
+//     NOT publish or drop; it replays, or falls through to the durable 409.
+//   - (entry, false) — this request won the claim and owns the entry.
+//   - (nil, false)   — the in-flight cap is full. Dedupe is skipped entirely
+//     for this request; it proceeds as a fresh, independent request.
 func (x *idlessDedupeIndex) claim(fp, requestID string, now time.Time, window time.Duration) (*idlessDedupeEntry, bool) {
 	x.mu.Lock()
 	defer x.mu.Unlock()
@@ -156,8 +201,13 @@ func (x *idlessDedupeIndex) claim(fp, requestID string, now time.Time, window ti
 		}
 	}
 	x.pruneForInsertLocked(now, window)
+	if x.inFlight >= idlessDedupeMaxInFlight {
+		x.inflightCapSkips.Add(1)
+		return nil, false
+	}
 	entry := &idlessDedupeEntry{requestID: requestID, done: make(chan struct{}), lastSeen: now}
 	x.entries[fp] = entry
+	x.inFlight++
 	return entry, false
 }
 
@@ -177,10 +227,12 @@ func (x *idlessDedupeIndex) publish(fp, requestID string, status int, contentTyp
 	if len(body) > 0 && len(body) <= idlessDedupeMaxEntryBytes {
 		entry.body = body
 		x.totalBytes += len(body)
+		x.bodyCount++
 	}
 	entry.completed = true
 	entry.terminalAt = now
 	entry.lastSeen = now
+	x.inFlight--
 	entry.closeLocked()
 	x.evictBodiesLocked()
 }
@@ -253,15 +305,33 @@ func (x *idlessDedupeIndex) replaySnapshot(entry *idlessDedupeEntry, now time.Ti
 
 func (x *idlessDedupeIndex) removeLocked(fp string, entry *idlessDedupeEntry) {
 	delete(x.entries, fp)
-	if entry.body != nil {
-		x.totalBytes -= len(entry.body)
-		entry.body = nil
+	if !entry.completed {
+		x.inFlight--
 	}
+	x.releaseBodyLocked(entry)
 	entry.closeLocked()
 }
 
+func (x *idlessDedupeIndex) releaseBodyLocked(entry *idlessDedupeEntry) {
+	if entry.body == nil {
+		return
+	}
+	x.totalBytes -= len(entry.body)
+	x.bodyCount--
+	entry.body = nil
+}
+
+// pruneForInsertLocked keeps the MAPPING table bounded. Note what it does not
+// do: it never evicts a window-valid mapping to make room for a body. Body
+// pressure is handled entirely by evictBodiesLocked, which downgrades entries
+// to stubs instead of deleting them.
+//
+// Deleting a window-valid mapping is a money event (the retry mints a fresh
+// id and bills again), so it happens only when the far larger mapping cap is
+// itself exhausted — 65536 live fingerprints inside one window — and is
+// counted as the documented residual.
 func (x *idlessDedupeIndex) pruneForInsertLocked(now time.Time, window time.Duration) {
-	if len(x.entries) < idlessDedupeMaxEntries {
+	if len(x.entries) < idlessDedupeMaxMappings {
 		if !x.lastPruned.IsZero() && now.Sub(x.lastPruned) < idlessDedupePruneInterval {
 			return
 		}
@@ -269,14 +339,15 @@ func (x *idlessDedupeIndex) pruneForInsertLocked(now time.Time, window time.Dura
 		return
 	}
 	x.pruneExpiredLocked(now, window)
-	for len(x.entries) >= idlessDedupeMaxEntries {
-		if !x.evictOldestLocked() {
+	for len(x.entries) >= idlessDedupeMaxMappings {
+		if !x.evictOldestMappingLocked() {
 			// Everything left is in flight: an owner is still running and
-			// waiters may be parked on it, so evicting would strand them.
-			// The map can only exceed the cap by the number of concurrent
-			// in-flight requests, which the concurrency limiter bounds.
+			// waiters may be parked on it, so evicting would strand them and
+			// silently void the owner's publish. idlessDedupeMaxInFlight is
+			// the cap that actually bounds this case.
 			return
 		}
+		x.mappingPressureEvictions.Add(1)
 	}
 }
 
@@ -289,9 +360,10 @@ func (x *idlessDedupeIndex) pruneExpiredLocked(now time.Time, window time.Durati
 	}
 }
 
-// evictOldestLocked drops the least recently seen COMPLETED entry. In-flight
-// entries are never evicted (see pruneForInsertLocked).
-func (x *idlessDedupeIndex) evictOldestLocked() bool {
+// evictOldestMappingLocked deletes the least recently seen COMPLETED entry
+// outright — mapping included. This is the money-losing eviction; see
+// pruneForInsertLocked for when it is allowed to run.
+func (x *idlessDedupeIndex) evictOldestMappingLocked() bool {
 	var oldestFP string
 	var oldest *idlessDedupeEntry
 	for fp, entry := range x.entries {
@@ -309,13 +381,13 @@ func (x *idlessDedupeIndex) evictOldestLocked() bool {
 	return true
 }
 
-// evictBodiesLocked enforces the total-bytes cap by dropping cached BODIES,
-// least recently seen first. The fingerprint→requestID mapping survives, so a
-// retry inside the window still adopts attempt 1's id and still gets the
-// durable 409 instead of a second bill — losing the replay costs UX, not
-// money.
+// evictBodiesLocked enforces the body caps (count and total bytes) by
+// downgrading entries to bare mapping stubs, least recently seen first. The
+// fingerprint→requestID mapping SURVIVES, so a retry inside the window still
+// adopts attempt 1's id and still gets the durable 409 instead of a second
+// bill — losing the replay costs UX, not money.
 func (x *idlessDedupeIndex) evictBodiesLocked() {
-	for x.totalBytes > idlessDedupeMaxTotalBytes {
+	for x.totalBytes > idlessDedupeMaxTotalBytes || x.bodyCount > idlessDedupeMaxBodies {
 		var oldest *idlessDedupeEntry
 		for _, entry := range x.entries {
 			if entry.body == nil {
@@ -328,8 +400,7 @@ func (x *idlessDedupeIndex) evictBodiesLocked() {
 		if oldest == nil {
 			return
 		}
-		x.totalBytes -= len(oldest.body)
-		oldest.body = nil
+		x.releaseBodyLocked(oldest)
 	}
 }
 
@@ -412,5 +483,11 @@ func (x *idlessDedupeIndex) prometheus() string {
 	b.WriteString("# HELP gateway_idless_dedupe_uncacheable_total Attempts whose terminal response was not replayable (non-2xx, truncated stream, buyer disconnect, oversize body).\n")
 	b.WriteString("# TYPE gateway_idless_dedupe_uncacheable_total counter\n")
 	fmt.Fprintf(&b, "gateway_idless_dedupe_uncacheable_total %d\n", x.uncacheableTotal.Load())
+	b.WriteString("# HELP gateway_idless_dedupe_mapping_pressure_evictions_total Window-valid fingerprint mappings deleted under mapping-table pressure; each one lets a later id-less retry bill again.\n")
+	b.WriteString("# TYPE gateway_idless_dedupe_mapping_pressure_evictions_total counter\n")
+	fmt.Fprintf(&b, "gateway_idless_dedupe_mapping_pressure_evictions_total %d\n", x.mappingPressureEvictions.Load())
+	b.WriteString("# HELP gateway_idless_dedupe_inflight_cap_skip_total Requests that bypassed dedupe because the in-flight claim cap was full.\n")
+	b.WriteString("# TYPE gateway_idless_dedupe_inflight_cap_skip_total counter\n")
+	fmt.Fprintf(&b, "gateway_idless_dedupe_inflight_cap_skip_total %d\n", x.inflightCapSkips.Load())
 	return b.String()
 }

--- a/phase5-gateway/internal/router/idless_dedupe_test.go
+++ b/phase5-gateway/internal/router/idless_dedupe_test.go
@@ -824,37 +824,111 @@ func TestIdlessDedupeIndex_ExpiredEntryIsReclaimedFresh(t *testing.T) {
 	}
 }
 
-func TestIdlessDedupeIndex_EvictsLRUCompletedButNeverInFlight(t *testing.T) {
+// Body pressure must spend BODIES, never window-valid mappings. A tenant
+// churning unique fingerprints past the body cap may cost everyone their
+// cached responses; it must not cost anyone their dedupe (and therefore their
+// second bill).
+func TestIdlessDedupeIndex_BodyPressureKeepsWindowValidMappings(t *testing.T) {
 	index := newIdlessDedupeIndex()
 	base := fixedNow()
 	window := time.Hour
 
-	// Fill the map with completed entries, oldest first.
-	for i := 0; i < idlessDedupeMaxEntries; i++ {
-		fp := "completed-" + strconv.Itoa(i)
-		at := base.Add(time.Duration(i) * time.Millisecond)
+	// The oldest entry: published first, never touched again, so it is the
+	// LRU victim for every body eviction that follows.
+	index.claim("victim", "req-victim", base, window)
+	index.publish("victim", "req-victim", http.StatusOK, "application/json", "", []byte("answer"), base)
+
+	// Churn well past the body cap with unique fingerprints.
+	for i := 0; i < idlessDedupeMaxBodies+64; i++ {
+		fp := "churn-" + strconv.Itoa(i)
+		at := base.Add(time.Duration(i+1) * time.Millisecond)
 		index.claim(fp, "req-"+strconv.Itoa(i), at, window)
 		index.publish(fp, "req-"+strconv.Itoa(i), http.StatusOK, "application/json", "", []byte("a"), at)
 	}
-	if got := len(index.entries); got != idlessDedupeMaxEntries {
-		t.Fatalf("entries=%d want %d", got, idlessDedupeMaxEntries)
-	}
-	index.claim("newcomer", "req-new", base.Add(time.Second), window)
-	if len(index.entries) > idlessDedupeMaxEntries {
-		t.Fatalf("entries=%d exceeds the cap %d", len(index.entries), idlessDedupeMaxEntries)
-	}
-	if _, exists := index.entries["completed-0"]; exists {
-		t.Fatal("the least recently seen completed entry survived eviction")
-	}
 
-	// In-flight entries are never evicted: a parked waiter would be stranded
-	// and its owner's publish would silently vanish.
-	inflight := newIdlessDedupeIndex()
-	for i := 0; i < idlessDedupeMaxEntries+2; i++ {
-		inflight.claim("inflight-"+strconv.Itoa(i), "req-"+strconv.Itoa(i), base, window)
+	if got := index.bodyCount; got > idlessDedupeMaxBodies {
+		t.Fatalf("bodyCount=%d exceeds the body cap %d", got, idlessDedupeMaxBodies)
 	}
-	if got := len(inflight.entries); got != idlessDedupeMaxEntries+2 {
-		t.Fatalf("in-flight entries=%d want %d (an in-flight owner was evicted)", got, idlessDedupeMaxEntries+2)
+	// The mapping — the money-bearing half — survived.
+	entry, adopted := index.claim("victim", "req-retry", base.Add(time.Second), window)
+	if !adopted {
+		t.Fatal("body pressure deleted a window-valid mapping: an id-less retry would now double-bill")
+	}
+	if entry.requestID != "req-victim" {
+		t.Fatalf("adopted requestID=%q want req-victim", entry.requestID)
+	}
+	if entry.body != nil {
+		t.Fatal("the victim kept its body; the test never exercised body eviction")
+	}
+	if got := index.mappingPressureEvictions.Load(); got != 0 {
+		t.Fatalf("mapping_pressure_evictions=%d want 0 (body pressure must not delete mappings)", got)
+	}
+}
+
+// Only exhausting the far larger MAPPING cap may delete a window-valid
+// mapping, and when it does it is counted as the documented residual.
+func TestIdlessDedupeIndex_MappingPressureEvictsOldestAndCounts(t *testing.T) {
+	index := newIdlessDedupeIndex()
+	base := fixedNow()
+	window := time.Hour
+
+	for i := 0; i < idlessDedupeMaxMappings; i++ {
+		fp := "m-" + strconv.Itoa(i)
+		at := base.Add(time.Duration(i) * time.Millisecond)
+		index.claim(fp, "req-"+strconv.Itoa(i), at, window)
+		// No body: this is purely mapping-table pressure.
+		index.publish(fp, "req-"+strconv.Itoa(i), http.StatusOK, "application/json", "", nil, at)
+	}
+	if got := len(index.entries); got != idlessDedupeMaxMappings {
+		t.Fatalf("entries=%d want %d", got, idlessDedupeMaxMappings)
+	}
+	index.claim("newcomer", "req-new", base.Add(time.Hour/2), window)
+	if got := len(index.entries); got > idlessDedupeMaxMappings {
+		t.Fatalf("entries=%d exceeds the mapping cap %d", got, idlessDedupeMaxMappings)
+	}
+	if _, exists := index.entries["m-0"]; exists {
+		t.Fatal("the least recently seen mapping survived eviction")
+	}
+	if got := index.mappingPressureEvictions.Load(); got < 1 {
+		t.Fatalf("mapping_pressure_evictions=%d want >= 1 (the residual must be observable)", got)
+	}
+}
+
+// In-flight entries are never evicted — a parked waiter would be stranded and
+// its owner's publish would silently vanish. The in-flight cap is what bounds
+// that map instead.
+func TestIdlessDedupeIndex_InFlightNeverEvictedAndCapped(t *testing.T) {
+	index := newIdlessDedupeIndex()
+	base := fixedNow()
+	window := time.Hour
+
+	for i := 0; i < idlessDedupeMaxInFlight; i++ {
+		if entry, _ := index.claim("inflight-"+strconv.Itoa(i), "req-"+strconv.Itoa(i), base, window); entry == nil {
+			t.Fatalf("claim %d was refused below the in-flight cap", i)
+		}
+	}
+	if got := len(index.entries); got != idlessDedupeMaxInFlight {
+		t.Fatalf("in-flight entries=%d want %d (an in-flight owner was evicted)", got, idlessDedupeMaxInFlight)
+	}
+	entry, adopted := index.claim("over-cap", "req-over", base, window)
+	if entry != nil || adopted {
+		t.Fatalf("claim past the in-flight cap returned (%v, %v); want (nil, false) = skip dedupe", entry, adopted)
+	}
+	if got := index.inflightCapSkips.Load(); got != 1 {
+		t.Fatalf("inflight_cap_skip_total=%d want 1", got)
+	}
+	// A terminal frees a slot.
+	index.publish("inflight-0", "req-0", http.StatusOK, "application/json", "", []byte("a"), base)
+	if index.inFlight != idlessDedupeMaxInFlight-1 {
+		t.Fatalf("inFlight=%d want %d after one terminal", index.inFlight, idlessDedupeMaxInFlight-1)
+	}
+	if entry, _ := index.claim("after-terminal", "req-after", base, window); entry == nil {
+		t.Fatal("a freed in-flight slot was not reusable")
+	}
+	// Dropping an in-flight entry frees its slot too.
+	index.drop("inflight-1", "req-1")
+	if index.inFlight != idlessDedupeMaxInFlight-1 {
+		t.Fatalf("inFlight=%d after a drop; the slot was not released", index.inFlight)
 	}
 }
 
@@ -904,15 +978,17 @@ func TestIdlessDedupeIndex_WaiterCapAndContextExpiry(t *testing.T) {
 }
 
 func TestIdlessRequestFingerprintIsKeyedOnEveryPart(t *testing.T) {
-	base := idlessRequestFingerprint("acct", "demo-hash", "thread-1", []byte(`{"a":1}`))
+	base := idlessRequestFingerprint("acct", "demo-hash", "thread-1", "", []byte(`{"a":1}`))
 	cases := map[string]string{
-		"same inputs":         idlessRequestFingerprint("acct", "demo-hash", "thread-1", []byte(`{"a":1}`)),
-		"other account":       idlessRequestFingerprint("acct2", "demo-hash", "thread-1", []byte(`{"a":1}`)),
-		"other demo token":    idlessRequestFingerprint("acct", "demo-hash-2", "thread-1", []byte(`{"a":1}`)),
-		"other conversation":  idlessRequestFingerprint("acct", "demo-hash", "thread-2", []byte(`{"a":1}`)),
-		"other body":          idlessRequestFingerprint("acct", "demo-hash", "thread-1", []byte(`{"a":2}`)),
-		"whitespace in body":  idlessRequestFingerprint("acct", "demo-hash", "thread-1", []byte(`{"a": 1}`)),
-		"field-shifted parts": idlessRequestFingerprint("acc", "tdemo-hash", "thread-1", []byte(`{"a":1}`)),
+		"same inputs":         idlessRequestFingerprint("acct", "demo-hash", "thread-1", "", []byte(`{"a":1}`)),
+		"other account":       idlessRequestFingerprint("acct2", "demo-hash", "thread-1", "", []byte(`{"a":1}`)),
+		"other demo token":    idlessRequestFingerprint("acct", "demo-hash-2", "thread-1", "", []byte(`{"a":1}`)),
+		"other conversation":  idlessRequestFingerprint("acct", "demo-hash", "thread-2", "", []byte(`{"a":1}`)),
+		"retry hint present":  idlessRequestFingerprint("acct", "demo-hash", "thread-1", "1", []byte(`{"a":1}`)),
+		"other retry hint":    idlessRequestFingerprint("acct", "demo-hash", "thread-1", "2", []byte(`{"a":1}`)),
+		"other body":          idlessRequestFingerprint("acct", "demo-hash", "thread-1", "", []byte(`{"a":2}`)),
+		"whitespace in body":  idlessRequestFingerprint("acct", "demo-hash", "thread-1", "", []byte(`{"a": 1}`)),
+		"field-shifted parts": idlessRequestFingerprint("acc", "tdemo-hash", "thread-1", "", []byte(`{"a":1}`)),
 	}
 	for name, got := range cases {
 		if name == "same inputs" {
@@ -924,5 +1000,128 @@ func TestIdlessRequestFingerprintIsKeyedOnEveryPart(t *testing.T) {
 		if got == base {
 			t.Fatalf("%s: fingerprint collided with the base request", name)
 		}
+	}
+	if cases["retry hint present"] == cases["other retry hint"] {
+		t.Fatal("two different X-MacProvider-Retry values produced the same fingerprint")
+	}
+}
+
+// failingAfterWriter is an http.ResponseWriter whose underlying writes start
+// failing after allowBytes bytes have been accepted — the buyer's socket
+// dying mid-stream while the handler is still emitting.
+type failingAfterWriter struct {
+	*httptest.ResponseRecorder
+	allowBytes int
+	written    int
+}
+
+func (f *failingAfterWriter) Write(b []byte) (int, error) {
+	if f.written >= f.allowBytes {
+		return 0, errors.New("injected buyer write failure")
+	}
+	n := len(b)
+	if f.written+n > f.allowBytes {
+		n = f.allowBytes - f.written
+	}
+	_, _ = f.ResponseRecorder.Write(b[:n])
+	f.written += n
+	if n < len(b) {
+		return n, errors.New("injected buyer write failure")
+	}
+	return n, nil
+}
+
+func (f *failingAfterWriter) Flush() {}
+
+// Audit R1 (security+code HIGH, finding 2): a mid-stream buyer write failure
+// after the 200 commit must poison the capture — the buyer never received the
+// full response, so publishing it would replay a partial/not-delivered stream
+// to the retry. The retry must re-dispatch.
+func TestIdlessDedupe_BuyerWriteFailureNotReplayed(t *testing.T) {
+	var hits atomic.Int32
+	client := idlessStreamingUpstream(&hits, func(pw *io.PipeWriter) {
+		_, _ = io.WriteString(pw, `data: {"id":"c","choices":[{"delta":{"content":"hello world"}}]}`+"\n\n")
+		_, _ = io.WriteString(pw, `data: {"id":"c","choices":[{"delta":{"content":"more"}}]}`+"\n\n")
+		_, _ = io.WriteString(pw, `data: [DONE]`+"\n\n")
+		_ = pw.Close()
+	})
+	h, store, _, cfg := newTestHarnessConfig(t, fakeOAuth{}, func(cfg *config.Config) {
+		cfg.Coordinator.BuyerURL = "http://coordinator.test"
+	}, WithHTTPClient(client))
+	key := createAccountAndKey(t, store, cfg, "acct_idless_writefail")
+
+	body := `{"model":"llama","stream":true,"max_tokens":20,"messages":[{"role":"user","content":"hi"}]}`
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader(body))
+	req.Header.Set("Authorization", "Bearer "+key)
+	req.Header.Set("Content-Type", "application/json")
+	// Accept only the first few bytes, then fail every buyer write.
+	fw := &failingAfterWriter{ResponseRecorder: httptest.NewRecorder(), allowBytes: 10}
+	h.ServeHTTP(fw, req)
+
+	second := postChat(t, h, key, body, nil)
+	assertNoDedupeReplay(t, second, "retry after a buyer write failure")
+	if second.Code != http.StatusOK {
+		t.Fatalf("retry status=%d body=%s", second.Code, second.Body.String())
+	}
+	if got := hits.Load(); got != 2 {
+		t.Fatalf("upstream dispatches=%d want 2 (a partially-delivered 200 must not be cached)", got)
+	}
+}
+
+// panicWriter panics on the second buyer write — a mid-handler panic in the
+// handler goroutine after the 200 commit (the statusWriter methods run on the
+// handler goroutine, unlike upstream Body reads, which #760 moved to a reader
+// goroutine where a panic would be process-fatal for any request).
+type panicWriter struct {
+	*httptest.ResponseRecorder
+	writes int
+}
+
+func (p *panicWriter) Write(b []byte) (int, error) {
+	p.writes++
+	// Panic exactly once, on the second buyer write - later writes (the
+	// recovery middleware error body) must succeed or the middleware own
+	// recover would re-crash.
+	if p.writes == 2 {
+		panic("injected mid-handler panic")
+	}
+	return p.ResponseRecorder.Write(b)
+}
+
+func (p *panicWriter) Flush() {}
+
+// Audit R1 (architect LOW, finding 5): a mid-handler panic after the 200
+// commit unwinds through the owner's publish defer. The defer must DROP the
+// entry (never publish the partial capture) and re-panic so the recovery
+// middleware still handles it. The retry must re-dispatch.
+func TestIdlessDedupe_HandlerPanicDropsEntryAndRepanics(t *testing.T) {
+	var hits atomic.Int32
+	client := idlessStreamingUpstream(&hits, func(pw *io.PipeWriter) {
+		_, _ = io.WriteString(pw, `data: {"id":"c","choices":[{"delta":{"content":"one"}}]}`+"\n\n")
+		_, _ = io.WriteString(pw, `data: {"id":"c","choices":[{"delta":{"content":"two"}}]}`+"\n\n")
+		_, _ = io.WriteString(pw, `data: [DONE]`+"\n\n")
+		_ = pw.Close()
+	})
+	h, store, _, cfg := newTestHarnessConfig(t, fakeOAuth{}, func(cfg *config.Config) {
+		cfg.Coordinator.BuyerURL = "http://coordinator.test"
+	}, WithHTTPClient(client))
+	key := createAccountAndKey(t, store, cfg, "acct_idless_panic")
+
+	body := `{"model":"llama","stream":true,"max_tokens":20,"messages":[{"role":"user","content":"hi"}]}`
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader(body))
+	req.Header.Set("Authorization", "Bearer "+key)
+	req.Header.Set("Content-Type", "application/json")
+	pw := &panicWriter{ResponseRecorder: httptest.NewRecorder()}
+	// The dedupe defer must recover, drop, and re-panic; the recovery
+	// middleware then swallows it, so ServeHTTP returns normally.
+	h.ServeHTTP(pw, req)
+
+	second := postChat(t, h, key, body, nil)
+	assertNoDedupeReplay(t, second, "retry after a mid-handler panic")
+	if !strings.Contains(second.Body.String(), "data: [DONE]") {
+		t.Fatalf("retry did not stream a fresh completion: %.300q", second.Body.String())
+	}
+	if got := hits.Load(); got != 2 {
+		t.Fatalf("upstream dispatches=%d want 2 (a panicked attempt must be dropped, not cached)", got)
 	}
 }

--- a/phase5-gateway/internal/router/idless_dedupe_test.go
+++ b/phase5-gateway/internal/router/idless_dedupe_test.go
@@ -1125,3 +1125,45 @@ func TestIdlessDedupe_HandlerPanicDropsEntryAndRepanics(t *testing.T) {
 		t.Fatalf("upstream dispatches=%d want 2 (a panicked attempt must be dropped, not cached)", got)
 	}
 }
+
+// Audit R2 (code HIGH): a COMPLETE, delivered, billed 2xx whose body merely
+// exceeded the 1 MiB replay cap must keep its fp->request_id mapping as a
+// body-less stub — the identical id-less retry adopts the id and lands on the
+// durable 409 (billed once). Dropping the mapping would let the retry mint a
+// fresh id, re-dispatch, and bill again.
+func TestIdlessDedupe_OversizedDelivered2xxKeepsMappingStub(t *testing.T) {
+	big := strings.Repeat("x", (1<<20)+4096) // > replay cap, < upstream body cap
+	bodyJSON := `{"id":"chatcmpl_big","object":"chat.completion","usage":{"prompt_tokens":3,"completion_tokens":4,"total_tokens":7},"choices":[{"index":0,"message":{"role":"assistant","content":"` + big + `"},"finish_reason":"stop"}]}`
+	var hits atomic.Int32
+	client := &http.Client{Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+		if r.URL.Path != "/v1/chat/completions" {
+			return responseWithBody(http.StatusNotFound, nil, `{}`), nil
+		}
+		hits.Add(1)
+		return responseWithBody(http.StatusOK,
+			http.Header{"Content-Type": []string{"application/json"}}, bodyJSON), nil
+	})}
+	h, store, dbPath, cfg := newTestHarnessConfig(t, fakeOAuth{}, func(cfg *config.Config) {
+		cfg.Coordinator.BuyerURL = "http://coordinator.test"
+	}, WithHTTPClient(client))
+	key := createAccountAndKey(t, store, cfg, "acct_idless_oversize")
+
+	body := `{"model":"llama","stream":false,"max_tokens":20,"messages":[{"role":"user","content":"hi"}]}`
+	first := postChat(t, h, key, body, nil)
+	if first.Code != http.StatusOK {
+		t.Fatalf("attempt 1 status=%d", first.Code)
+	}
+
+	second := postChat(t, h, key, body, nil)
+	if second.Code != http.StatusConflict {
+		t.Fatalf("retry of an oversized delivered 2xx must hit the durable 409 via the "+
+			"mapping stub, got %d body=%.200q", second.Code, second.Body.String())
+	}
+	assertErrorCode(t, second.Body.String(), "duplicate_request_id")
+	if got := hits.Load(); got != 1 {
+		t.Fatalf("upstream dispatches=%d want 1 (the mapping stub must prevent re-dispatch)", got)
+	}
+	if outcome, _ := usageEventOutcome(t, dbPath, "acct_idless_oversize"); outcome != "ok" {
+		t.Fatalf("usage outcome=%q want ok (billed exactly once, by attempt 1)", outcome)
+	}
+}

--- a/phase5-gateway/internal/router/idless_dedupe_test.go
+++ b/phase5-gateway/internal/router/idless_dedupe_test.go
@@ -1,0 +1,928 @@
+package router
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/augstar/macprovider-gateway/internal/config"
+)
+
+// Issue #762 (seam finding P1-1) — bill each request once when the retry
+// carries no id.
+//
+// The behavior under test has two halves that must be kept apart:
+//
+//   - The MONEY invariant is the durable (account_id, request_id) primary key
+//     on quota_reservations. Every test here that asserts "billed once" is
+//     asserting that key still holds.
+//   - The REPLAY cache is a UX layer on top of it. When it misses, the retry
+//     adopts attempt 1's id and gets the existing duplicate_request_id 409 —
+//     degraded, never a second bill.
+//
+// Tests are therefore paired: one asserts the replay actually happens, its
+// sibling asserts the bypass/miss path still bills once (or, for the opt-outs,
+// that nothing changed at all).
+
+const idlessDedupeBody = `{"model":"llama","max_tokens":20,"messages":[{"role":"user","content":"hi"}]}`
+
+// ---- helpers ---------------------------------------------------------------
+
+// distinctRequestID stamps a unique client-supplied UUID X-Request-ID onto a
+// header set, opting the request OUT of the #762 id-less dedupe path.
+//
+// Tests about concurrency, request-rate, or quota caps deliberately drive many
+// byte-identical bodies through one account. Before #762 those were distinct
+// requests by definition; now an id-less pair is a retry of one intent. Giving
+// each attempt its own id keeps those tests testing what they were written to
+// test — the dedupe behavior itself is covered in this file.
+func distinctRequestID(base map[string]string) map[string]string {
+	headers := make(map[string]string, len(base)+1)
+	for key, value := range base {
+		headers[key] = value
+	}
+	headers["X-Request-ID"] = newUUID()
+	return headers
+}
+
+// idlessJSONUpstream answers the chat path with a fixed non-streaming 200 and
+// counts dispatches. extra headers (if any) are merged into the response so a
+// test can prove which upstream headers survive to the buyer.
+func idlessJSONUpstream(completion string, hits *atomic.Int32, extra http.Header) *http.Client {
+	return &http.Client{Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+		if r.URL.Path != "/v1/chat/completions" {
+			return responseWithBody(http.StatusNotFound, nil, `{}`), nil
+		}
+		hits.Add(1)
+		header := http.Header{"Content-Type": []string{"application/json"}}
+		for key, values := range extra {
+			for _, value := range values {
+				header.Add(key, value)
+			}
+		}
+		return responseWithBody(http.StatusOK, header, completion), nil
+	})}
+}
+
+// idlessStreamingUpstream is seamStreamingUpstream with a dispatch counter.
+func idlessStreamingUpstream(hits *atomic.Int32, onWrite func(pw *io.PipeWriter)) *http.Client {
+	return &http.Client{Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+		if r.URL.Path != "/v1/chat/completions" {
+			return responseWithBody(http.StatusNotFound, nil, `{}`), nil
+		}
+		hits.Add(1)
+		pr, pw := io.Pipe()
+		go onWrite(pw)
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     http.Header{"Content-Type": []string{"text/event-stream; charset=utf-8"}},
+			Body:       pr,
+		}, nil
+	})}
+}
+
+func idlessMetric(t *testing.T, h http.Handler, name string) int64 {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodGet, "/metrics", nil)
+	resp := httptest.NewRecorder()
+	h.ServeHTTP(resp, req)
+	if resp.Code != http.StatusOK {
+		t.Fatalf("GET /metrics status=%d", resp.Code)
+	}
+	for _, line := range strings.Split(resp.Body.String(), "\n") {
+		if !strings.HasPrefix(line, name+" ") {
+			continue
+		}
+		value, err := strconv.ParseInt(strings.TrimSpace(strings.TrimPrefix(line, name+" ")), 10, 64)
+		if err != nil {
+			t.Fatalf("parse metric %s from %q: %v", name, line, err)
+		}
+		return value
+	}
+	t.Fatalf("metric %s missing from /metrics", name)
+	return 0
+}
+
+func waitForIdlessMetric(t *testing.T, h http.Handler, name string, want int64) {
+	t.Helper()
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		if idlessMetric(t, h, name) >= want {
+			return
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Fatalf("metric %s never reached %d", name, want)
+}
+
+func recvResponse(t *testing.T, ch <-chan *httptest.ResponseRecorder, what string) *httptest.ResponseRecorder {
+	t.Helper()
+	select {
+	case resp := <-ch:
+		return resp
+	case <-time.After(10 * time.Second):
+		t.Fatalf("%s never returned", what)
+		return nil
+	}
+}
+
+func assertNoDedupeReplay(t *testing.T, resp *httptest.ResponseRecorder, what string) {
+	t.Helper()
+	if got := resp.Header().Get(idlessDedupeHeader); got != "" {
+		t.Fatalf("%s: unexpected %s=%q (this attempt must not be a replay)", what, idlessDedupeHeader, got)
+	}
+}
+
+// ---- replay + coalesce (the fix) -------------------------------------------
+
+// Two byte-identical id-less requests overlapping in time must coalesce onto
+// ONE dispatch: the second parks on the first (holding no reservation and no
+// concurrency lease) and replays its answer.
+func TestIdlessDedupe_ConcurrentIdenticalRequestsBillOnce(t *testing.T) {
+	var hits atomic.Int32
+	entered := make(chan struct{}, 1)
+	release := make(chan struct{})
+	client := &http.Client{Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+		if r.URL.Path != "/v1/chat/completions" {
+			return responseWithBody(http.StatusNotFound, nil, `{}`), nil
+		}
+		hits.Add(1)
+		entered <- struct{}{}
+		<-release
+		return responseWithBody(http.StatusOK,
+			http.Header{"Content-Type": []string{"application/json"}}, seamCompletionJSON), nil
+	})}
+	h, store, dbPath, cfg := newTestHarnessConfig(t, fakeOAuth{}, func(cfg *config.Config) {
+		cfg.Coordinator.BuyerURL = "http://coordinator.test"
+	}, WithHTTPClient(client))
+	key := createAccountAndKey(t, store, cfg, "acct_idless_concurrent")
+
+	firstCh := make(chan *httptest.ResponseRecorder, 1)
+	go func() { firstCh <- postChat(t, h, key, idlessDedupeBody, nil) }()
+	select {
+	case <-entered:
+	case <-time.After(5 * time.Second):
+		close(release)
+		t.Fatal("upstream never received the first dispatch")
+	}
+
+	secondCh := make(chan *httptest.ResponseRecorder, 1)
+	go func() { secondCh <- postChat(t, h, key, idlessDedupeBody, nil) }()
+	// Deterministic: the second attempt is provably parked on the first
+	// before the first is allowed to finish.
+	waitForIdlessMetric(t, h, "gateway_idless_dedupe_inflight_wait_total", 1)
+	close(release)
+
+	first := recvResponse(t, firstCh, "first attempt")
+	second := recvResponse(t, secondCh, "second attempt")
+	if first.Code != http.StatusOK || second.Code != http.StatusOK {
+		t.Fatalf("statuses first=%d second=%d, want 200/200 (second=%s)", first.Code, second.Code, second.Body.String())
+	}
+	if got := second.Header().Get(idlessDedupeHeader); got != idlessDedupeHeaderValue {
+		t.Fatalf("coalesced attempt %s=%q want %q", idlessDedupeHeader, got, idlessDedupeHeaderValue)
+	}
+	if got := hits.Load(); got != 1 {
+		t.Fatalf("upstream dispatches=%d want 1 (the second attempt re-dispatched instead of coalescing)", got)
+	}
+	if first.Body.String() != second.Body.String() {
+		t.Fatalf("coalesced body differs:\n first=%s\nsecond=%s", first.Body.String(), second.Body.String())
+	}
+	if used := billedTokens(t, h, key); used != 20 {
+		t.Fatalf("billed %v want 20", used)
+	}
+	state := gatewaySettlementSnapshot(t, dbPath, "acct_idless_concurrent")
+	if state.settledRows != 1 || state.activeRows != 0 {
+		t.Fatalf("reservations %+v; want exactly one settled row and no active hold", state)
+	}
+}
+
+func TestIdlessDedupe_StreamingRetryReplays(t *testing.T) {
+	var hits atomic.Int32
+	sse := `data: {"id":"c","choices":[{"delta":{"content":"hello"}}]}` + "\n\n" +
+		`data: {"id":"c","usage":{"prompt_tokens":8,"completion_tokens":2,"total_tokens":10},"choices":[{"delta":{},"finish_reason":"stop"}]}` + "\n\n" +
+		`data: [DONE]` + "\n\n"
+	client := idlessStreamingUpstream(&hits, func(pw *io.PipeWriter) {
+		_, _ = io.WriteString(pw, sse)
+		_ = pw.Close()
+	})
+	h, store, _, cfg := newTestHarnessConfig(t, fakeOAuth{}, func(cfg *config.Config) {
+		cfg.Coordinator.BuyerURL = "http://coordinator.test"
+	}, WithHTTPClient(client))
+	key := createAccountAndKey(t, store, cfg, "acct_idless_stream")
+
+	body := `{"model":"llama","stream":true,"max_tokens":20,"messages":[{"role":"user","content":"hi"}]}`
+	first := postChat(t, h, key, body, nil)
+	if first.Code != http.StatusOK || !strings.Contains(first.Body.String(), "data: [DONE]") {
+		t.Fatalf("attempt 1 status=%d body=%.300q", first.Code, first.Body.String())
+	}
+	billedAfterFirst := billedTokens(t, h, key)
+
+	second := postChat(t, h, key, body, nil)
+	if second.Code != http.StatusOK {
+		t.Fatalf("attempt 2 status=%d body=%s", second.Code, second.Body.String())
+	}
+	if got := second.Header().Get(idlessDedupeHeader); got != idlessDedupeHeaderValue {
+		t.Fatalf("streaming retry %s=%q want %q", idlessDedupeHeader, got, idlessDedupeHeaderValue)
+	}
+	if !strings.Contains(second.Body.String(), "data: [DONE]") {
+		t.Fatalf("replayed stream is not terminated: %.300q", second.Body.String())
+	}
+	if first.Body.String() != second.Body.String() {
+		t.Fatalf("replayed stream differs:\n first=%.300q\nsecond=%.300q", first.Body.String(), second.Body.String())
+	}
+	if got := second.Header().Get("Content-Type"); !strings.HasPrefix(got, "text/event-stream") {
+		t.Fatalf("replayed Content-Type=%q want text/event-stream", got)
+	}
+	if got := hits.Load(); got != 1 {
+		t.Fatalf("upstream dispatches=%d want 1", got)
+	}
+	if used := billedTokens(t, h, key); used != billedAfterFirst {
+		t.Fatalf("streaming replay billed again: %v -> %v", billedAfterFirst, used)
+	}
+}
+
+// A replay must not echo attempt 1's per-attempt headers. Only the whitelist
+// (Content-Type, X-Provider-Id, X-Request-ID, the dedupe marker) plus freshly
+// recomputed rate-limit headers may cross.
+func TestIdlessDedupe_ReplayEmitsNoSettlementHeaders(t *testing.T) {
+	var hits atomic.Int32
+	client := idlessJSONUpstream(seamCompletionJSON, &hits, http.Header{
+		"X-Upstream-Trace":                 []string{"attempt-1"},
+		"X-MacProvider-Provider":           []string{"peer-a"},
+		"X-MacProvider-Settlement-Outcome": []string{"settled"},
+		"Retry-After":                      []string{"7"},
+	})
+	h, store, _, cfg := newTestHarnessConfig(t, fakeOAuth{}, func(cfg *config.Config) {
+		cfg.Coordinator.BuyerURL = "http://coordinator.test"
+	}, WithHTTPClient(client))
+	key := createAccountAndKey(t, store, cfg, "acct_idless_headers")
+
+	first := postChat(t, h, key, idlessDedupeBody, nil)
+	if first.Code != http.StatusOK {
+		t.Fatalf("attempt 1 status=%d body=%s", first.Code, first.Body.String())
+	}
+	attemptOneID := first.Header().Get("X-Request-ID")
+	if attemptOneID == "" {
+		t.Fatal("attempt 1 emitted no X-Request-ID")
+	}
+	if got := first.Header().Get("X-Upstream-Trace"); got != "attempt-1" {
+		t.Fatalf("attempt 1 X-Upstream-Trace=%q want attempt-1 (test would be vacuous otherwise)", got)
+	}
+
+	second := postChat(t, h, key, idlessDedupeBody, nil)
+	if got := second.Header().Get(idlessDedupeHeader); got != idlessDedupeHeaderValue {
+		t.Fatalf("attempt 2 %s=%q want %q", idlessDedupeHeader, got, idlessDedupeHeaderValue)
+	}
+	// The replay is built from a whitelist, not from attempt 1's header map:
+	// a passthrough header that attempt 1 carried must NOT reappear.
+	if got := second.Header().Get("X-Upstream-Trace"); got != "" {
+		t.Fatalf("replay echoed attempt 1's passthrough header X-Upstream-Trace=%q", got)
+	}
+	for name := range second.Header() {
+		if strings.HasPrefix(strings.ToLower(name), "x-macprovider-settlement-") {
+			t.Fatalf("replay carries settlement header %s (it describes attempt 1's billing transaction)", name)
+		}
+	}
+	if got := second.Header().Get("Retry-After"); got != "" {
+		t.Fatalf("replay carries Retry-After=%q", got)
+	}
+	// X-Request-ID is attempt 1's, because attempt 1 is the request that was
+	// actually billed and logged.
+	if got := second.Header().Get("X-Request-ID"); got != attemptOneID {
+		t.Fatalf("replay X-Request-ID=%q want attempt 1's %q", got, attemptOneID)
+	}
+	if got := second.Header().Get("X-Provider-Id"); got != "peer-a" {
+		t.Fatalf("replay X-Provider-Id=%q want peer-a", got)
+	}
+	for _, name := range []string{"X-RateLimit-Limit", "X-RateLimit-Remaining", "X-RateLimit-Reset"} {
+		if second.Header().Get(name) == "" {
+			t.Fatalf("replay is missing recomputed %s", name)
+		}
+	}
+	if got := hits.Load(); got != 1 {
+		t.Fatalf("upstream dispatches=%d want 1", got)
+	}
+}
+
+// The gateway's over-report bound (INV-7) is attempt 1's property; replaying
+// its response must not add a second usage row or reopen a hold.
+func TestIdlessDedupe_ReplayPreservesBoundedToDelivered(t *testing.T) {
+	var hits atomic.Int32
+	sse := `data: {"id":"c","choices":[{"delta":{"content":"ok"}}]}` + "\n\n" +
+		`data: {"id":"c","usage":{"prompt_tokens":8,"completion_tokens":100000,"total_tokens":100008},"choices":[{"delta":{},"finish_reason":"stop"}]}` + "\n\n" +
+		`data: [DONE]` + "\n\n"
+	client := idlessStreamingUpstream(&hits, func(pw *io.PipeWriter) {
+		_, _ = io.WriteString(pw, sse)
+		_ = pw.Close()
+	})
+	h, store, dbPath, cfg := newTestHarnessConfig(t, fakeOAuth{}, func(cfg *config.Config) {
+		cfg.Coordinator.BuyerURL = "http://coordinator.test"
+	}, WithHTTPClient(client))
+	key := createAccountAndKey(t, store, cfg, "acct_idless_bounded")
+
+	body := `{"model":"llama","stream":true,"max_tokens":20,"messages":[{"role":"user","content":"hi"}]}`
+	if r := postChat(t, h, key, body, nil); r.Code != http.StatusOK {
+		t.Fatalf("attempt 1 status=%d body=%s", r.Code, r.Body.String())
+	}
+	billedAfterFirst := billedTokens(t, h, key)
+	if billedAfterFirst >= 1000 {
+		t.Fatalf("INV-7 precondition broken: attempt 1 billed %v (over-report was accepted)", billedAfterFirst)
+	}
+
+	second := postChat(t, h, key, body, nil)
+	if got := second.Header().Get(idlessDedupeHeader); got != idlessDedupeHeaderValue {
+		t.Fatalf("attempt 2 %s=%q want %q", idlessDedupeHeader, got, idlessDedupeHeaderValue)
+	}
+	if got := hits.Load(); got != 1 {
+		t.Fatalf("upstream dispatches=%d want 1", got)
+	}
+	if used := billedTokens(t, h, key); used != billedAfterFirst {
+		t.Fatalf("replay changed the bill: %v -> %v", billedAfterFirst, used)
+	}
+	state := gatewaySettlementSnapshot(t, dbPath, "acct_idless_bounded")
+	if state.usageRows != 1 || state.settledRows != 1 || state.activeRows != 0 {
+		t.Fatalf("reservations/usage %+v; want usageRows=1 settledRows=1 activeRows=0", state)
+	}
+}
+
+// The replay cache is bounded, so it must have a safe overflow. Past the
+// waiter cap an attempt does NOT get its own dispatch: it adopts attempt 1's
+// request id and lands on the durable duplicate_request_id 409 — the same
+// answer a cache miss after a restart or an eviction produces. Degraded UX,
+// still exactly one bill.
+func TestIdlessDedupe_OverWaiterCapFallsThroughToDurable409(t *testing.T) {
+	var hits atomic.Int32
+	entered := make(chan struct{}, 1)
+	release := make(chan struct{})
+	client := &http.Client{Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+		if r.URL.Path != "/v1/chat/completions" {
+			return responseWithBody(http.StatusNotFound, nil, `{}`), nil
+		}
+		hits.Add(1)
+		entered <- struct{}{}
+		<-release
+		return responseWithBody(http.StatusOK,
+			http.Header{"Content-Type": []string{"application/json"}}, seamCompletionJSON), nil
+	})}
+	h, store, dbPath, cfg := newTestHarnessConfig(t, fakeOAuth{}, func(cfg *config.Config) {
+		cfg.Coordinator.BuyerURL = "http://coordinator.test"
+	}, WithHTTPClient(client))
+	key := createAccountAndKey(t, store, cfg, "acct_idless_overcap")
+
+	ownerCh := make(chan *httptest.ResponseRecorder, 1)
+	go func() { ownerCh <- postChat(t, h, key, idlessDedupeBody, nil) }()
+	select {
+	case <-entered:
+	case <-time.After(5 * time.Second):
+		close(release)
+		t.Fatal("upstream never received the owner's dispatch")
+	}
+
+	waiters := make(chan *httptest.ResponseRecorder, idlessDedupeMaxWaiters)
+	for i := 0; i < idlessDedupeMaxWaiters; i++ {
+		go func() { waiters <- postChat(t, h, key, idlessDedupeBody, nil) }()
+	}
+	waitForIdlessMetric(t, h, "gateway_idless_dedupe_inflight_wait_total", int64(idlessDedupeMaxWaiters))
+
+	// One more identical attempt: the waiter slots are full, so this one must
+	// resolve immediately rather than park.
+	overCap := postChat(t, h, key, idlessDedupeBody, nil)
+	if overCap.Code != http.StatusConflict {
+		t.Fatalf("over-cap attempt status=%d want 409; body=%s", overCap.Code, overCap.Body.String())
+	}
+	assertErrorCode(t, overCap.Body.String(), "duplicate_request_id")
+	assertNoDedupeReplay(t, overCap, "over-cap attempt")
+	if got := idlessMetric(t, h, "gateway_idless_dedupe_conflict_total"); got < 1 {
+		t.Fatalf("conflict_total=%d want >= 1", got)
+	}
+
+	close(release)
+	owner := recvResponse(t, ownerCh, "owner attempt")
+	if owner.Code != http.StatusOK {
+		t.Fatalf("owner status=%d body=%s", owner.Code, owner.Body.String())
+	}
+	// The 409 must name the id the buyer's request was folded onto, not the
+	// fresh id the middleware minted for this attempt.
+	if got, want := overCap.Header().Get("X-Request-ID"), owner.Header().Get("X-Request-ID"); got != want {
+		t.Fatalf("over-cap 409 X-Request-ID=%q want the adopted %q", got, want)
+	}
+	for i := 0; i < idlessDedupeMaxWaiters; i++ {
+		resp := recvResponse(t, waiters, "parked waiter")
+		if resp.Code != http.StatusOK {
+			t.Fatalf("parked waiter status=%d body=%s", resp.Code, resp.Body.String())
+		}
+		if got := resp.Header().Get(idlessDedupeHeader); got != idlessDedupeHeaderValue {
+			t.Fatalf("parked waiter %s=%q want %q", idlessDedupeHeader, got, idlessDedupeHeaderValue)
+		}
+	}
+	if got := hits.Load(); got != 1 {
+		t.Fatalf("upstream dispatches=%d want 1", got)
+	}
+	if used := billedTokens(t, h, key); used != 20 {
+		t.Fatalf("billed %v want 20 (six identical id-less attempts, one intent)", used)
+	}
+	state := gatewaySettlementSnapshot(t, dbPath, "acct_idless_overcap")
+	if state.settledRows != 1 || state.activeRows != 0 {
+		t.Fatalf("reservations %+v; want exactly one settled row", state)
+	}
+}
+
+// ---- the bounds: what must NOT be swallowed --------------------------------
+
+// The window is the executable bound on the one real false positive (a
+// deliberate re-roll at temperature > 0). Past it, an identical id-less
+// request is a NEW request and bills again.
+func TestIdlessDedupe_OutsideWindowNotSwallowed(t *testing.T) {
+	var hits atomic.Int32
+	now := fixedNow()
+	client := idlessJSONUpstream(seamCompletionJSON, &hits, nil)
+	h, store, _, cfg := newTestHarnessConfig(t, fakeOAuth{}, func(cfg *config.Config) {
+		cfg.Coordinator.BuyerURL = "http://coordinator.test"
+		cfg.Quotas.IdlessDedupeWindowSeconds = 60
+	}, WithNow(func() time.Time { return now }), WithHTTPClient(client))
+	key := createAccountAndKey(t, store, cfg, "acct_idless_window")
+
+	if r := postChat(t, h, key, idlessDedupeBody, nil); r.Code != http.StatusOK {
+		t.Fatalf("attempt 1 status=%d body=%s", r.Code, r.Body.String())
+	}
+	now = now.Add(61 * time.Second)
+
+	second := postChat(t, h, key, idlessDedupeBody, nil)
+	if second.Code != http.StatusOK {
+		t.Fatalf("attempt 2 status=%d body=%s", second.Code, second.Body.String())
+	}
+	assertNoDedupeReplay(t, second, "outside-window resend")
+	if got := hits.Load(); got != 2 {
+		t.Fatalf("upstream dispatches=%d want 2 (a resend past the window must re-generate)", got)
+	}
+	if used := billedTokens(t, h, key); used != 40 {
+		t.Fatalf("billed %v want 40 (two distinct requests)", used)
+	}
+}
+
+// A 200 stream that ended in an error frame is not an answer. Replaying it
+// would hand the retry a worse result than a fresh dispatch.
+func TestIdlessDedupe_TruncatedStreamNotReplayed(t *testing.T) {
+	var hits atomic.Int32
+	client := idlessStreamingUpstream(&hits, func(pw *io.PipeWriter) {
+		_, _ = io.WriteString(pw, `data: {"id":"c","choices":[{"delta":{"content":"partial"}}]}`+"\n\n")
+		_ = pw.CloseWithError(errors.New("injected mid-stream upstream failure"))
+	})
+	h, store, _, cfg := newTestHarnessConfig(t, fakeOAuth{}, func(cfg *config.Config) {
+		cfg.Coordinator.BuyerURL = "http://coordinator.test"
+	}, WithHTTPClient(client))
+	key := createAccountAndKey(t, store, cfg, "acct_idless_truncated")
+
+	body := `{"model":"llama","stream":true,"max_tokens":20,"messages":[{"role":"user","content":"hi"}]}`
+	first := postChat(t, h, key, body, nil)
+	if first.Code != http.StatusOK {
+		t.Fatalf("attempt 1 status=%d body=%s", first.Code, first.Body.String())
+	}
+	if !strings.Contains(first.Body.String(), "provider_disconnected") {
+		t.Fatalf("attempt 1 did not emit the mid-stream error envelope: %.300q", first.Body.String())
+	}
+
+	second := postChat(t, h, key, body, nil)
+	assertNoDedupeReplay(t, second, "retry after a truncated stream")
+	if got := hits.Load(); got != 2 {
+		t.Fatalf("upstream dispatches=%d want 2 (a truncated 200 must not be cached)", got)
+	}
+}
+
+// An error terminal is dropped, not cached: the retry re-dispatches exactly as
+// it does today.
+func TestIdlessDedupe_ErrorAttemptNotReplayed(t *testing.T) {
+	var hits atomic.Int32
+	client := &http.Client{Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+		if r.URL.Path != "/v1/chat/completions" {
+			return responseWithBody(http.StatusNotFound, nil, `{}`), nil
+		}
+		hits.Add(1)
+		return responseWithBody(http.StatusServiceUnavailable,
+			http.Header{"Content-Type": []string{"application/json"}},
+			`{"error":{"code":"no_provider_available","message":"No provider available","param":null,"type":"service_unavailable"}}`), nil
+	})}
+	h, store, dbPath, cfg := newTestHarnessConfig(t, fakeOAuth{}, func(cfg *config.Config) {
+		cfg.Coordinator.BuyerURL = "http://coordinator.test"
+		// Keep the 503 ladder out of the dispatch count: this test is about
+		// caching, not about retry_503.
+		cfg.Retry503.Enabled = false
+	}, WithHTTPClient(client))
+	key := createAccountAndKey(t, store, cfg, "acct_idless_error")
+
+	first := postChat(t, h, key, idlessDedupeBody, nil)
+	if first.Code != http.StatusServiceUnavailable {
+		t.Fatalf("attempt 1 status=%d want 503 body=%s", first.Code, first.Body.String())
+	}
+	afterFirst := hits.Load()
+
+	second := postChat(t, h, key, idlessDedupeBody, nil)
+	if second.Code != http.StatusServiceUnavailable {
+		t.Fatalf("attempt 2 status=%d want 503 body=%s", second.Code, second.Body.String())
+	}
+	assertNoDedupeReplay(t, second, "retry after an error terminal")
+	if got := hits.Load(); got <= afterFirst {
+		t.Fatalf("upstream dispatches did not increase (%d -> %d): the error terminal was cached", afterFirst, got)
+	}
+	if used := billedTokens(t, h, key); used != 0 {
+		t.Fatalf("billed %v for two refunded errors, want 0", used)
+	}
+	state := gatewaySettlementSnapshot(t, dbPath, "acct_idless_error")
+	if state.activeRows != 0 {
+		t.Fatalf("reservations %+v; want no active hold after two refunded errors", state)
+	}
+}
+
+// Byte-identity of the raw body is the key. Anything that changes the bytes —
+// a trailing space, the stream flag — or the sticky conversation tag is a
+// different request.
+func TestIdlessDedupe_DifferentBodyNotDeduped(t *testing.T) {
+	cases := []struct {
+		name         string
+		first        string
+		second       string
+		firstHeader  map[string]string
+		secondHeader map[string]string
+	}{
+		{
+			name:   "trailing whitespace in content",
+			first:  `{"model":"llama","max_tokens":20,"messages":[{"role":"user","content":"hi"}]}`,
+			second: `{"model":"llama","max_tokens":20,"messages":[{"role":"user","content":"hi "}]}`,
+		},
+		{
+			name:   "stream flag flipped",
+			first:  `{"model":"llama","stream":false,"max_tokens":20,"messages":[{"role":"user","content":"hi"}]}`,
+			second: `{"model":"llama","stream":true,"max_tokens":20,"messages":[{"role":"user","content":"hi"}]}`,
+		},
+		{
+			name:         "different conversation tag",
+			first:        idlessDedupeBody,
+			second:       idlessDedupeBody,
+			firstHeader:  map[string]string{"X-MacProvider-Conversation": "thread-1"},
+			secondHeader: map[string]string{"X-MacProvider-Conversation": "thread-2"},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var hits atomic.Int32
+			// Both shapes are answered non-streaming; the "stream flag" case
+			// only needs the two attempts to be distinguishable, and the
+			// gateway's streaming reader tolerates a JSON body being absent
+			// from the cache either way.
+			client := idlessStreamingUpstream(&hits, func(pw *io.PipeWriter) {
+				_, _ = io.WriteString(pw,
+					`data: {"id":"c","usage":{"prompt_tokens":8,"completion_tokens":2,"total_tokens":10},"choices":[{"delta":{"content":"ok"},"finish_reason":"stop"}]}`+
+						"\n\n"+`data: [DONE]`+"\n\n")
+				_ = pw.Close()
+			})
+			h, store, _, cfg := newTestHarnessConfig(t, fakeOAuth{}, func(cfg *config.Config) {
+				cfg.Coordinator.BuyerURL = "http://coordinator.test"
+			}, WithHTTPClient(client))
+			key := createAccountAndKey(t, store, cfg, "acct_idless_distinct")
+
+			if r := postChat(t, h, key, tc.first, tc.firstHeader); r.Code != http.StatusOK {
+				t.Fatalf("attempt 1 status=%d body=%s", r.Code, r.Body.String())
+			}
+			second := postChat(t, h, key, tc.second, tc.secondHeader)
+			if second.Code != http.StatusOK {
+				t.Fatalf("attempt 2 status=%d body=%s", second.Code, second.Body.String())
+			}
+			assertNoDedupeReplay(t, second, tc.name)
+			if got := hits.Load(); got != 2 {
+				t.Fatalf("upstream dispatches=%d want 2", got)
+			}
+		})
+	}
+}
+
+// ---- opt-outs: higher-precedence dedupe owns the request -------------------
+
+// A client-supplied UUID X-Request-ID already deduped durably (harness H5b).
+// #762 must not touch that path: the second attempt still 409s rather than
+// silently replaying.
+func TestIdlessDedupe_ClientSuppliedIDBypasses(t *testing.T) {
+	var hits atomic.Int32
+	client := idlessJSONUpstream(seamCompletionJSON, &hits, nil)
+	h, store, _, cfg := newTestHarnessConfig(t, fakeOAuth{}, func(cfg *config.Config) {
+		cfg.Coordinator.BuyerURL = "http://coordinator.test"
+	}, WithHTTPClient(client))
+	key := createAccountAndKey(t, store, cfg, "acct_idless_clientid")
+
+	headers := map[string]string{"X-Request-ID": "11111111-1111-4111-8111-111111111111"}
+	if r := postChat(t, h, key, idlessDedupeBody, headers); r.Code != http.StatusOK {
+		t.Fatalf("attempt 1 status=%d body=%s", r.Code, r.Body.String())
+	}
+	second := postChat(t, h, key, idlessDedupeBody, headers)
+	if second.Code != http.StatusConflict {
+		t.Fatalf("attempt 2 status=%d want 409 body=%s", second.Code, second.Body.String())
+	}
+	assertErrorCode(t, second.Body.String(), "duplicate_request_id")
+	assertNoDedupeReplay(t, second, "client-supplied id")
+	if got := hits.Load(); got != 1 {
+		t.Fatalf("upstream dispatches=%d want 1", got)
+	}
+	if used := billedTokens(t, h, key); used != 20 {
+		t.Fatalf("billed %v want 20", used)
+	}
+}
+
+// A buyer-supplied Idempotency-Key is the coordinator's dedupe contract
+// (issue #200). The gateway forwards it and passes the coordinator's replay
+// verdict through untouched, refunding the attempt.
+func TestIdlessDedupe_IdempotencyKeyBypasses(t *testing.T) {
+	var hits atomic.Int32
+	client := &http.Client{Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+		if r.URL.Path != "/v1/chat/completions" {
+			return responseWithBody(http.StatusNotFound, nil, `{}`), nil
+		}
+		if r.Header.Get("Idempotency-Key") == "" {
+			return responseWithBody(http.StatusBadRequest, nil, `{"error":{"code":"missing_idempotency_key"}}`), nil
+		}
+		if hits.Add(1) == 1 {
+			return responseWithBody(http.StatusOK,
+				http.Header{"Content-Type": []string{"application/json"}}, seamCompletionJSON), nil
+		}
+		return responseWithBody(http.StatusConflict,
+			http.Header{"Content-Type": []string{"application/json"}},
+			`{"error":{"code":"idempotency_key_replayed","message":"Idempotency key already used","param":null,"type":"invalid_request_error"}}`), nil
+	})}
+	h, store, dbPath, cfg := newTestHarnessConfig(t, fakeOAuth{}, func(cfg *config.Config) {
+		cfg.Coordinator.BuyerURL = "http://coordinator.test"
+	}, WithHTTPClient(client))
+	key := createAccountAndKey(t, store, cfg, "acct_idless_idempotency")
+
+	headers := map[string]string{"Idempotency-Key": "idem-762"}
+	if r := postChat(t, h, key, idlessDedupeBody, headers); r.Code != http.StatusOK {
+		t.Fatalf("attempt 1 status=%d body=%s", r.Code, r.Body.String())
+	}
+	second := postChat(t, h, key, idlessDedupeBody, headers)
+	if second.Code != http.StatusConflict {
+		t.Fatalf("attempt 2 status=%d want the coordinator's 409 passthrough; body=%s", second.Code, second.Body.String())
+	}
+	assertErrorCode(t, second.Body.String(), "idempotency_key_replayed")
+	assertNoDedupeReplay(t, second, "idempotency-key request")
+	if got := hits.Load(); got != 2 {
+		t.Fatalf("upstream dispatches=%d want 2 (the gateway must not shortcut the coordinator's dedupe)", got)
+	}
+	if used := billedTokens(t, h, key); used != 20 {
+		t.Fatalf("billed %v want 20 (the replayed attempt must be refunded)", used)
+	}
+	state := gatewaySettlementSnapshot(t, dbPath, "acct_idless_idempotency")
+	if state.activeRows != 0 {
+		t.Fatalf("reservations %+v; want no active hold", state)
+	}
+}
+
+// The operator kill switch restores the pre-#762 behavior exactly.
+func TestIdlessDedupe_DisabledByZeroWindow(t *testing.T) {
+	var hits atomic.Int32
+	client := idlessJSONUpstream(seamCompletionJSON, &hits, nil)
+	h, store, _, cfg := newTestHarnessConfig(t, fakeOAuth{}, func(cfg *config.Config) {
+		cfg.Coordinator.BuyerURL = "http://coordinator.test"
+		cfg.Quotas.IdlessDedupeWindowSeconds = 0
+	}, WithHTTPClient(client))
+	key := createAccountAndKey(t, store, cfg, "acct_idless_disabled")
+
+	if r := postChat(t, h, key, idlessDedupeBody, nil); r.Code != http.StatusOK {
+		t.Fatalf("attempt 1 status=%d body=%s", r.Code, r.Body.String())
+	}
+	second := postChat(t, h, key, idlessDedupeBody, nil)
+	if second.Code != http.StatusOK {
+		t.Fatalf("attempt 2 status=%d body=%s", second.Code, second.Body.String())
+	}
+	assertNoDedupeReplay(t, second, "kill-switched gateway")
+	if got := hits.Load(); got != 2 {
+		t.Fatalf("upstream dispatches=%d want 2", got)
+	}
+	if used := billedTokens(t, h, key); used != 40 {
+		t.Fatalf("billed %v want 40 (kill switch must restore the pre-#762 behavior)", used)
+	}
+}
+
+// ---- index unit tests ------------------------------------------------------
+
+func TestIdlessDedupeIndex_OnlyClaimWinnerPublishesOrDrops(t *testing.T) {
+	index := newIdlessDedupeIndex()
+	now := fixedNow()
+	window := time.Minute
+
+	entry, adopted := index.claim("fp", "req-owner", now, window)
+	if adopted {
+		t.Fatal("first claim must win the fingerprint")
+	}
+	if _, adopted := index.claim("fp", "req-second", now, window); !adopted {
+		t.Fatal("second claim must adopt the owner's entry")
+	}
+
+	// A non-owner cannot publish...
+	index.publish("fp", "req-second", http.StatusOK, "application/json", "peer", []byte("intruder"), now)
+	if _, ok := index.replaySnapshot(entry, now, window); ok {
+		t.Fatal("a non-owner published a response")
+	}
+	// ...nor drop.
+	index.drop("fp", "req-second")
+	if index.entries["fp"] != entry {
+		t.Fatal("a non-owner dropped the owner's entry")
+	}
+
+	index.publish("fp", "req-owner", http.StatusOK, "application/json", "peer", []byte("answer"), now)
+	snapshot, ok := index.replaySnapshot(entry, now, window)
+	if !ok {
+		t.Fatal("owner publish did not make the entry replayable")
+	}
+	if snapshot.requestID != "req-owner" || string(snapshot.body) != "answer" || snapshot.status != http.StatusOK {
+		t.Fatalf("snapshot=%+v", snapshot)
+	}
+	select {
+	case <-entry.done:
+	default:
+		t.Fatal("publish did not wake parked waiters")
+	}
+
+	// Publishing twice must not double-count bytes or reopen the entry.
+	before := index.totalBytes
+	index.publish("fp", "req-owner", http.StatusOK, "application/json", "peer", []byte("second answer"), now)
+	if index.totalBytes != before {
+		t.Fatalf("republish changed totalBytes %d -> %d", before, index.totalBytes)
+	}
+}
+
+func TestIdlessDedupeIndex_DropWakesWaitersAndClearsMapping(t *testing.T) {
+	index := newIdlessDedupeIndex()
+	now := fixedNow()
+	entry, _ := index.claim("fp", "req-owner", now, time.Minute)
+
+	index.drop("fp", "req-owner")
+	if _, exists := index.entries["fp"]; exists {
+		t.Fatal("drop left the fingerprint mapped")
+	}
+	select {
+	case <-entry.done:
+	default:
+		t.Fatal("drop did not wake parked waiters")
+	}
+	if !index.awaitTerminal(context.Background(), entry) {
+		t.Fatal("awaitTerminal must return immediately for a dropped entry")
+	}
+	if _, ok := index.replaySnapshot(entry, now, time.Minute); ok {
+		t.Fatal("a dropped entry must never be replayable")
+	}
+	if got := index.uncacheableTotal.Load(); got != 1 {
+		t.Fatalf("uncacheable_total=%d want 1", got)
+	}
+}
+
+// Memory pressure costs the cached BODY, never the fingerprint→requestID
+// mapping: the retry must still adopt attempt 1's id and hit the durable 409.
+func TestIdlessDedupeIndex_EvictedBodyKeepsMapping(t *testing.T) {
+	index := newIdlessDedupeIndex()
+	now := fixedNow()
+	window := time.Minute
+	entry, _ := index.claim("fp", "req-owner", now, window)
+	index.publish("fp", "req-owner", http.StatusOK, "application/json", "peer", []byte("answer"), now)
+
+	index.mu.Lock()
+	index.totalBytes = idlessDedupeMaxTotalBytes + 1
+	index.evictBodiesLocked()
+	index.mu.Unlock()
+
+	mapped, adopted := index.claim("fp", "req-retry", now, window)
+	if !adopted {
+		t.Fatal("body eviction also dropped the fingerprint mapping")
+	}
+	if mapped.requestID != "req-owner" {
+		t.Fatalf("adopted requestID=%q want the owner's req-owner", mapped.requestID)
+	}
+	if _, ok := index.replaySnapshot(entry, now, window); ok {
+		t.Fatal("an evicted body must not be replayable")
+	}
+}
+
+func TestIdlessDedupeIndex_ExpiredEntryIsReclaimedFresh(t *testing.T) {
+	index := newIdlessDedupeIndex()
+	now := fixedNow()
+	window := time.Minute
+	index.claim("fp", "req-owner", now, window)
+	index.publish("fp", "req-owner", http.StatusOK, "application/json", "peer", []byte("answer"), now)
+
+	entry, adopted := index.claim("fp", "req-retry", now.Add(2*time.Minute), window)
+	if adopted {
+		t.Fatal("a resend past the window must claim a fresh entry")
+	}
+	if entry.requestID != "req-retry" {
+		t.Fatalf("fresh entry requestID=%q want req-retry", entry.requestID)
+	}
+	if index.totalBytes != 0 {
+		t.Fatalf("expired entry leaked %d cached bytes", index.totalBytes)
+	}
+}
+
+func TestIdlessDedupeIndex_EvictsLRUCompletedButNeverInFlight(t *testing.T) {
+	index := newIdlessDedupeIndex()
+	base := fixedNow()
+	window := time.Hour
+
+	// Fill the map with completed entries, oldest first.
+	for i := 0; i < idlessDedupeMaxEntries; i++ {
+		fp := "completed-" + strconv.Itoa(i)
+		at := base.Add(time.Duration(i) * time.Millisecond)
+		index.claim(fp, "req-"+strconv.Itoa(i), at, window)
+		index.publish(fp, "req-"+strconv.Itoa(i), http.StatusOK, "application/json", "", []byte("a"), at)
+	}
+	if got := len(index.entries); got != idlessDedupeMaxEntries {
+		t.Fatalf("entries=%d want %d", got, idlessDedupeMaxEntries)
+	}
+	index.claim("newcomer", "req-new", base.Add(time.Second), window)
+	if len(index.entries) > idlessDedupeMaxEntries {
+		t.Fatalf("entries=%d exceeds the cap %d", len(index.entries), idlessDedupeMaxEntries)
+	}
+	if _, exists := index.entries["completed-0"]; exists {
+		t.Fatal("the least recently seen completed entry survived eviction")
+	}
+
+	// In-flight entries are never evicted: a parked waiter would be stranded
+	// and its owner's publish would silently vanish.
+	inflight := newIdlessDedupeIndex()
+	for i := 0; i < idlessDedupeMaxEntries+2; i++ {
+		inflight.claim("inflight-"+strconv.Itoa(i), "req-"+strconv.Itoa(i), base, window)
+	}
+	if got := len(inflight.entries); got != idlessDedupeMaxEntries+2 {
+		t.Fatalf("in-flight entries=%d want %d (an in-flight owner was evicted)", got, idlessDedupeMaxEntries+2)
+	}
+}
+
+func TestIdlessDedupeIndex_WaiterCapAndContextExpiry(t *testing.T) {
+	index := newIdlessDedupeIndex()
+	now := fixedNow()
+	entry, _ := index.claim("fp", "req-owner", now, time.Minute)
+
+	// Fill the waiter slots with parked goroutines.
+	parked := make(chan bool, idlessDedupeMaxWaiters)
+	for i := 0; i < idlessDedupeMaxWaiters; i++ {
+		go func() { parked <- index.awaitTerminal(context.Background(), entry) }()
+	}
+	deadline := time.Now().Add(3 * time.Second)
+	for {
+		index.mu.Lock()
+		waiters := entry.waiters
+		index.mu.Unlock()
+		if waiters == idlessDedupeMaxWaiters {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("only %d of %d waiters parked", waiters, idlessDedupeMaxWaiters)
+		}
+		time.Sleep(time.Millisecond)
+	}
+	if index.awaitTerminal(context.Background(), entry) {
+		t.Fatal("a waiter over the cap must be rejected, not parked")
+	}
+
+	// An expiring request context releases a parked waiter.
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if index.awaitTerminal(ctx, entry) {
+		t.Fatal("awaitTerminal must report failure when the request context is done")
+	}
+
+	index.publish("fp", "req-owner", http.StatusOK, "application/json", "", []byte("a"), now)
+	for i := 0; i < idlessDedupeMaxWaiters; i++ {
+		if !<-parked {
+			t.Fatal("a parked waiter did not observe the owner's terminal")
+		}
+	}
+	if got := index.inflightWaitTotal.Load(); got < int64(idlessDedupeMaxWaiters) {
+		t.Fatalf("inflight_wait_total=%d want >= %d", got, idlessDedupeMaxWaiters)
+	}
+}
+
+func TestIdlessRequestFingerprintIsKeyedOnEveryPart(t *testing.T) {
+	base := idlessRequestFingerprint("acct", "demo-hash", "thread-1", []byte(`{"a":1}`))
+	cases := map[string]string{
+		"same inputs":         idlessRequestFingerprint("acct", "demo-hash", "thread-1", []byte(`{"a":1}`)),
+		"other account":       idlessRequestFingerprint("acct2", "demo-hash", "thread-1", []byte(`{"a":1}`)),
+		"other demo token":    idlessRequestFingerprint("acct", "demo-hash-2", "thread-1", []byte(`{"a":1}`)),
+		"other conversation":  idlessRequestFingerprint("acct", "demo-hash", "thread-2", []byte(`{"a":1}`)),
+		"other body":          idlessRequestFingerprint("acct", "demo-hash", "thread-1", []byte(`{"a":2}`)),
+		"whitespace in body":  idlessRequestFingerprint("acct", "demo-hash", "thread-1", []byte(`{"a": 1}`)),
+		"field-shifted parts": idlessRequestFingerprint("acc", "tdemo-hash", "thread-1", []byte(`{"a":1}`)),
+	}
+	for name, got := range cases {
+		if name == "same inputs" {
+			if got != base {
+				t.Fatalf("%s: fingerprint is not stable", name)
+			}
+			continue
+		}
+		if got == base {
+			t.Fatalf("%s: fingerprint collided with the base request", name)
+		}
+	}
+}

--- a/phase5-gateway/internal/router/integration_test.go
+++ b/phase5-gateway/internal/router/integration_test.go
@@ -200,11 +200,12 @@ func TestDemoChatQuotaExhaustionIsSeparateFromAccountQuota(t *testing.T) {
 	}, WithHTTPClient(client))
 	demo := issueDemoToken(t, h, "1.2.3.4")
 	body := `{"model":"llama","max_tokens":8,"messages":[{"role":"user","content":"hi"}]}`
-	first := postChat(t, h, "", body, map[string]string{"X-Demo-Token": demo, "X-Real-IP": "1.2.3.4"})
+	demoHeaders := map[string]string{"X-Demo-Token": demo, "X-Real-IP": "1.2.3.4"}
+	first := postChat(t, h, "", body, distinctRequestID(demoHeaders))
 	if first.Code != http.StatusOK {
 		t.Fatalf("first demo status=%d body=%s", first.Code, first.Body.String())
 	}
-	second := postChat(t, h, "", body, map[string]string{"X-Demo-Token": demo, "X-Real-IP": "1.2.3.4"})
+	second := postChat(t, h, "", body, distinctRequestID(demoHeaders))
 	if second.Code != http.StatusTooManyRequests {
 		t.Fatalf("second demo status=%d body=%s", second.Code, second.Body.String())
 	}
@@ -238,7 +239,7 @@ func TestAccountConcurrencyCap(t *testing.T) {
 	body := `{"model":"llama","max_tokens":8,"messages":[{"role":"user","content":"hi"}]}`
 	done := make(chan *httptest.ResponseRecorder, 2)
 	for i := 0; i < 2; i++ {
-		go func() { done <- postChat(t, h, key, body, nil) }()
+		go func() { done <- postChat(t, h, key, body, distinctRequestID(nil)) }()
 	}
 	for i := 0; i < 2; i++ {
 		select {
@@ -247,7 +248,7 @@ func TestAccountConcurrencyCap(t *testing.T) {
 			t.Fatal("timed out waiting for upstream request")
 		}
 	}
-	third := postChat(t, h, key, body, nil)
+	third := postChat(t, h, key, body, distinctRequestID(nil))
 	if third.Code != http.StatusTooManyRequests {
 		t.Fatalf("third status=%d body=%s", third.Code, third.Body.String())
 	}
@@ -297,13 +298,13 @@ func TestAccountRequestRateLimitRejectsBurstBeforeUpstream(t *testing.T) {
 	body := `{"model":"llama","max_tokens":8,"messages":[{"role":"user","content":"hi"}]}`
 
 	for i := 0; i < 2; i++ {
-		resp := postChat(t, h, key, body, nil)
+		resp := postChat(t, h, key, body, distinctRequestID(nil))
 		if resp.Code != http.StatusOK {
 			t.Fatalf("admitted request %d status=%d body=%s", i, resp.Code, resp.Body.String())
 		}
 	}
 	beforeReject := gatewaySettlementSnapshot(t, dbPath, "acct_request_rate_burst")
-	third := postChat(t, h, key, body, nil)
+	third := postChat(t, h, key, body, distinctRequestID(nil))
 	if third.Code != http.StatusTooManyRequests {
 		t.Fatalf("third request status=%d body=%s, want 429", third.Code, third.Body.String())
 	}
@@ -318,7 +319,7 @@ func TestAccountRequestRateLimitRejectsBurstBeforeUpstream(t *testing.T) {
 	}
 
 	now = now.Add(time.Second)
-	fourth := postChat(t, h, key, body, nil)
+	fourth := postChat(t, h, key, body, distinctRequestID(nil))
 	if fourth.Code != http.StatusOK {
 		t.Fatalf("request after refill status=%d body=%s", fourth.Code, fourth.Body.String())
 	}
@@ -349,7 +350,7 @@ func TestRunawayBuyerBurstGetsQuick429sAtGateway(t *testing.T) {
 	body := `{"model":"llama","max_tokens":8,"messages":[{"role":"user","content":"hi"}]}`
 
 	done := make(chan *httptest.ResponseRecorder, 1)
-	go func() { done <- postChat(t, h, key, body, nil) }()
+	go func() { done <- postChat(t, h, key, body, distinctRequestID(nil)) }()
 	select {
 	case <-entered:
 	case <-time.After(2 * time.Second):
@@ -357,7 +358,7 @@ func TestRunawayBuyerBurstGetsQuick429sAtGateway(t *testing.T) {
 	}
 
 	for i := 0; i < 19; i++ {
-		resp := postChat(t, h, key, body, nil)
+		resp := postChat(t, h, key, body, distinctRequestID(nil))
 		if resp.Code != http.StatusTooManyRequests {
 			t.Fatalf("burst request %d status=%d body=%s, want 429", i+2, resp.Code, resp.Body.String())
 		}
@@ -457,7 +458,7 @@ func TestDemoConcurrencyCap(t *testing.T) {
 
 	done := make(chan *httptest.ResponseRecorder, 2)
 	for i := 0; i < 2; i++ {
-		go func() { done <- postChat(t, h, "", body, headers) }()
+		go func() { done <- postChat(t, h, "", body, distinctRequestID(headers)) }()
 	}
 	for i := 0; i < 2; i++ {
 		select {
@@ -466,7 +467,7 @@ func TestDemoConcurrencyCap(t *testing.T) {
 			t.Fatal("timed out waiting for upstream demo request to enter")
 		}
 	}
-	third := postChat(t, h, "", body, headers)
+	third := postChat(t, h, "", body, distinctRequestID(headers))
 	if third.Code != http.StatusTooManyRequests {
 		t.Fatalf("third demo request status=%d body=%s, want 429", third.Code, third.Body.String())
 	}

--- a/phase5-gateway/internal/router/seam_harness_test.go
+++ b/phase5-gateway/internal/router/seam_harness_test.go
@@ -105,11 +105,26 @@ const seamCompletionJSON = `{"id":"c","object":"chat.completion","created":1,"mo
 	`"usage":{"prompt_tokens":8,"completion_tokens":12,"total_tokens":20},` +
 	`"choices":[{"index":0,"message":{"role":"assistant","content":"hello"},"finish_reason":"stop"}]}`
 
-// ---- H5 · id-less retry double-bill (INV-11) -------------------------------
-// EXPECTED: FAIL today (issue #200). An id-less buyer retry — which OpenRouter does —
-// mints a fresh request_id, so each attempt reserves+settles independently → double-bill.
+// ---- H5 · id-less retry bills once (INV-11) --------------------------------
+// EXPECTED: PASS = certifies the P1-1 FIX (issue #762). This test used to be
+// TestSeamH5a_IdlessRetryDoubleBills and asserted the buggy-today behavior: an id-less
+// buyer retry — which OpenRouter does by default — mints a fresh request_id per attempt,
+// so the durable (account_id, request_id) reservation key never matched and each attempt
+// reserved + settled independently → one buyer intent, two bills.
+//
+// #762 fingerprints the raw body (plus tenant / demo token / conversation tag) for
+// gateway-minted ids only, and REPLAYS attempt 1's buyer-visible response to an identical
+// re-send inside the configured window. The scenario is deliberately unchanged: what
+// flipped is the verdict, so the test stays a durable tripwire. A regression that
+// re-dispatches an id-less retry — or that bills it twice while still replaying — turns
+// this red again.
+//
+// The replay cache is NOT the money invariant. A cache miss (restart, eviction, oversize
+// body, truncated stream) adopts attempt 1's id and falls through to the durable
+// duplicate_request_id 409, so "billed once" holds even when the replay does not. See
+// TestIdlessDedupe_* in idless_dedupe_test.go for those paths.
 
-func TestSeamH5a_IdlessRetryDoubleBills(t *testing.T) {
+func TestSeamH5a_IdlessRetryBillsOnce(t *testing.T) {
 	var upstreamHits int
 	client := seamJSONUpstream(seamCompletionJSON, &upstreamHits)
 	h, store, _, cfg := newTestHarnessConfig(t, fakeOAuth{}, func(cfg *config.Config) {
@@ -118,23 +133,35 @@ func TestSeamH5a_IdlessRetryDoubleBills(t *testing.T) {
 	key := createAccountAndKey(t, store, cfg, "acct_h5a")
 
 	body := `{"model":"llama","max_tokens":20,"messages":[{"role":"user","content":"hi"}]}`
-	// No X-Request-ID → each call mints a fresh id → distinct reservations.
-	if r := postChat(t, h, key, body, nil); r.Code != http.StatusOK {
-		t.Fatalf("call 1 status=%d body=%s", r.Code, r.Body.String())
+	// No X-Request-ID → each call mints a fresh id → pre-#762, distinct reservations.
+	first := postChat(t, h, key, body, nil)
+	if first.Code != http.StatusOK {
+		t.Fatalf("call 1 status=%d body=%s", first.Code, first.Body.String())
 	}
-	if r := postChat(t, h, key, body, nil); r.Code != http.StatusOK {
-		t.Fatalf("call 2 status=%d body=%s", r.Code, r.Body.String())
+	second := postChat(t, h, key, body, nil)
+	if second.Code != http.StatusOK {
+		t.Fatalf("call 2 status=%d body=%s", second.Code, second.Body.String())
 	}
 
-	used := billedTokens(t, h, key)
-	if used == 40 {
-		t.Logf("CONFIRMED FINDING (INV-11 FAIL): id-less retry double-billed %v tokens "+
-			"(2×20); upstream hit %d times. Fix: gateway-native Idempotency-Key dedupe "+
-			"(server.go:240-244, issue #200).", used, upstreamHits)
-		return
+	if got := second.Header().Get("X-MacProvider-Dedupe"); got != "replay" {
+		t.Fatalf("REGRESSION (INV-11): id-less retry was not served as a replay; "+
+			"X-MacProvider-Dedupe=%q want %q", got, "replay")
 	}
-	t.Fatalf("expected double-bill of 40 (confirmed finding); got daily_tokens_used=%v "+
-		"(if this is 20, the idempotency gap was FIXED — update the audit)", used)
+	if upstreamHits != 1 {
+		t.Fatalf("REGRESSION (INV-11): id-less retry re-dispatched inference; upstream hit %d times, want 1",
+			upstreamHits)
+	}
+	if first.Body.String() != second.Body.String() {
+		t.Fatalf("replay body differs from attempt 1:\n first=%s\nsecond=%s",
+			first.Body.String(), second.Body.String())
+	}
+	used := billedTokens(t, h, key)
+	if used != 20 {
+		t.Fatalf("REGRESSION (INV-11): id-less retry billed %v tokens, want 20 "+
+			"(40 = the pre-#762 double-bill is back)", used)
+	}
+	t.Logf("PASS (P1-1 FIXED, #762): id-less retry replayed attempt 1's response "+
+		"(upstream hits=%d, billed=%v once).", upstreamHits, used)
 }
 
 func TestSeamH5b_StableRequestIDBillsOnce(t *testing.T) {

--- a/phase5-gateway/internal/router/server.go
+++ b/phase5-gateway/internal/router/server.go
@@ -62,6 +62,9 @@ type Server struct {
 	retry503Metrics *retry503Metrics
 	adminMetrics    *adminStateWriteMetrics
 	chatStartLimits *requestRateLimiter
+	// idlessDedupe backs the #762 id-less retry replay/coalesce cache. It is
+	// per-process and non-authoritative; see idless_dedupe.go.
+	idlessDedupe *idlessDedupeIndex
 }
 
 // readStore returns the read-only view of the database. M2-4: this
@@ -167,6 +170,7 @@ func New(cfg config.Config, store Store, oauth auth.OAuthProvider, opts ...Optio
 		retry503Metrics:  newRetry503Metrics(),
 		adminMetrics:     newAdminStateWriteMetrics(),
 		chatStartLimits:  newRequestRateLimiter(),
+		idlessDedupe:     newIdlessDedupeIndex(),
 	}
 	for _, opt := range opts {
 		opt(s)
@@ -233,6 +237,7 @@ func (s *Server) handleMetrics(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "text/plain; version=0.0.4; charset=utf-8")
 	_, _ = w.Write([]byte(s.retry503Metrics.prometheus()))
 	_, _ = w.Write([]byte(s.adminMetrics.prometheus()))
+	_, _ = w.Write([]byte(s.idlessDedupe.prometheus()))
 }
 
 func (s *Server) middleware(next http.Handler) http.Handler {

--- a/test/integration/scenarios_test.go
+++ b/test/integration/scenarios_test.go
@@ -516,6 +516,11 @@ func TestStickyHeaderForwardedToCoordinator(t *testing.T) {
 
 	const totalRequests = 6
 	for i := 0; i < totalRequests; i++ {
+		// Post-#762 the gateway coalesces byte-identical id-less requests
+		// (replay, one dispatch). This test needs six real dispatches to
+		// exercise sticky forwarding, so each request opts out with a
+		// distinct client-supplied X-Request-ID — the documented bypass.
+		headers["X-Request-ID"] = fmt.Sprintf("11111111-1111-4111-8111-%012d", i)
 		status, _, respBody := s.chatRequest(headers, body)
 		if status != http.StatusOK {
 			t.Fatalf("sticky chat %d status=%d body=%s", i, status, string(respBody))


### PR DESCRIPTION
Closes #762. PR 4 of epic #770 (P1 tier, money path). Complements the closed #200 (client-supplied `Idempotency-Key` on error paths); this is the case #200 cannot cover — a successful completion retried with no stable id at all, which OpenRouter's retries produce.

## Mechanism

An id-less retry minted a fresh `request_id`, so each attempt reserved and settled independently — the buyer was billed twice for one completion (the H5a tripwire billed 40 for 2×20). Now a fingerprint index (SHA-256 over `"mpg-idless-v1"` ‖ account ‖ demo-token-hash ‖ conversation tag ‖ `X-MacProvider-Retry` ‖ SHA-256(raw body)) makes an id-less retry **adopt** attempt 1's `request_id`, and a bounded in-memory cache **replays** attempt 1's response; in-flight duplicates coalesce on the owner's terminal (waiter cap 4, admission-deadline bounded, no reservation or concurrency lease held while parked).

**The money invariant is not the cache.** It rides the existing durable `(account_id, request_id)` reservation PK: any cache miss — restart, eviction, oversized body, waiter overflow, drop — falls through to `ReserveQuota` under the *adopted* id and the existing `409 duplicate_request_id`. Degraded UX, never a double bill.

Precedence (highest wins): `Idempotency-Key` → skip (coordinator #200 path); client-supplied UUID `X-Request-ID` → skip (H5b 409 path); else fingerprint. Window 60s from attempt 1's terminal (`quotas.idless_dedupe_window_seconds`, `0` = kill switch, max 3600). Bounds: 4096 entries / 1MiB per body / 32MiB total; mapping stubs (~100B) persist to window expiry under a separate 65536 cap. Truncated/failed/poisoned streams are never replayed. Replay whitelists headers (`Content-Type`, `X-Provider-Id`, `X-Request-ID` = attempt 1's, new `X-MacProvider-Dedupe: replay`); never `X-MacProvider-Settlement-*`/`Retry-After`; rate-limit headers recomputed. Metrics: `gateway_idless_dedupe_{replay,inflight_wait,conflict,uncacheable,mapping_pressure_evictions,inflight_cap_skip}_total`.

Tripwire flipped: `TestSeamH5a_IdlessRetryBillsOnce` (both 200, replay header, one dispatch, identical bodies, billed 20). ~25 new tests incl. concurrent-identical under `-race`, outside-window non-swallow, poison/truncation, both bypasses, zero-window kill switch, oversized-2xx stub, buyer-write-failure, handler-panic, and index-ownership units.

## Audit (three codex lanes, full diff)

- R1: all three lanes failed — union 2 HIGH + 2 MEDIUM + 1 LOW, all fixed in-round:
  - **HIGH** (security): whole-entry LRU eviction deleted window-valid fp→id mappings — a tenant churning 4096 fingerprints could evict another tenant's mapping and reopen double-billing. Fixed: two-tier eviction; bodies evict freely, mapping stubs persist to window expiry under a 65536 cap (pressure evictions metric-visible).
  - **HIGH** (security+code): `statusWriter` captured bytes before the buyer write succeeded, and the buyer-write-failure path didn't poison — a partial, never-delivered 2xx could be replayed. Fixed: capture only delivered bytes, poison on write error + on the client-disconnect settle path.
  - MEDIUM (all lanes): `X-MacProvider-Retry` (a forwarded coordinator-behavior header) joined the fingerprint. MEDIUM (security): hard in-flight cap (claims happen before concurrency acquisition, so the map wasn't actually bounded); over-cap requests skip dedupe entirely. LOW: publish defer is panic-aware (recover → drop → re-panic).
- R2: security **PASS 0/0/0**, architect **PASS 0/0/0**; code found 1 HIGH — a complete, delivered, billed 2xx over the 1MiB replay cap was dropped at terminal, deleting the mapping (retry re-billed). Fixed: delivered-but-uncacheable 2xx publishes a **body-less mapping stub** (retry → adopted-id 409, billed once); only poisoned/disconnected attempts drop.
- R3 (code only): **PASS 0/0/0**.

## Accepted residuals (documented)

Deliberate byte-identical re-rolls within 60s of terminal get the cached answer (bounded by window, five opt-outs, conflict counter — foreclosed by the tripwire's own contract); crash/restart loses the index → retry double-bills exactly as today (durable fingerprint table is the named follow-up); the claim→reserve race can serve the "wrong" one of ≥5 concurrent identicals (never a double bill); parallel-identical sampling traffic now coalesces (opt-out: send `X-Request-ID`); mapping-cap pressure eviction needs 65536 live fingerprints in one 60s window (metric-visible); +32MiB max RSS; H2 partial-delivery carve-out (bounded double charge on buyer-disconnect retries).

Full `phase5-gateway` suite + `-race` green, pre- and post-rebase. #763 contract honored: the replay path performs no reserve/settle and will write no journal records.

SPEC-GOVERNANCE-DECLARATION-BEGIN
{
  "schema_version": "spec-pr-governance-v1",
  "behavior_change": "yes",
  "contract_change": "none",
  "specs": ["SPEC-005", "SPEC-006", "SPEC-036"],
  "requirements": ["SPEC-036-R001"],
  "authority_domains": ["billing-settlement-formula", "buyer-api-error-contract", "compute-integrity-settlement"],
  "arbitration": ["CODE_BUG"],
  "tests": ["phase5-gateway/internal/router/seam_harness_test.go", "phase5-gateway/internal/router/idless_dedupe_test.go"],
  "journeys": ["not-required"],
  "issue": "https://github.com/Augustas11/macprovider/issues/770"
}
SPEC-GOVERNANCE-DECLARATION-END

🤖 Generated with [Claude Code](https://claude.com/claude-code)
