### PR TITLE
Seam hardening P1: durable settlement journal — no billed-but-dropped usage rows (#763)

### DIFF
--- a/audits/seam-hardening/findings.md
+++ b/audits/seam-hardening/findings.md
@@ -96,12 +96,69 @@ conversation tag, byte-identical body, no ids, inside 60s of attempt 1's termina
 window, the five opt-outs, and the conflict counter — not by "did the buyer receive it", which the
 tripwire forecloses. Buyer-supplied `Idempotency-Key` dedupe on the coordinator path remains #200.
 
-**P1-2 · Settlement not crash-durable** — `money` — test `TestSeamH7`
-On the streaming after-commit path, if `SettleReservation` and the `EnsureUsageEvent` fallback both
-fail (`phase5-gateway/.../chat_proxy.go:1974-1993`), the gateway logs, refunds, and drops the usage
-row — the buyer already got a committed 200. Tokens delivered, nobody billed, no durable record.
-**Fix:** append-only settlement journal keyed by (account, request_id)+effect, written before dispatch,
-sealed on terminal, with a startup recovery scan. Reservation-before-dispatch already exists.
+**P1-2 · Settlement not crash-durable** — `money` — test `TestSeamH7` · issue #763
+**FIXED gateway-side (issue #763).** On the streaming after-commit path, if `SettleReservation` and
+the `EnsureUsageEvent` fallback both failed, the gateway logged, refunded, and dropped the usage row —
+the buyer already had a committed 200. Tokens delivered, nobody billed, no durable record. The
+refunded reservation carries `settlement_hold=0`, so it was invisible to the SPEC-022 reconciler
+(`ListSettlementHeldReservations` selects active + hold=1): nothing else would ever have found it.
+**Fix (shipped):** a durable append-only **JSONL settlement journal**
+(`phase5-gateway/internal/settlement/journal`), NOT a table in `gateway.db`. Same-DB storage would
+have produced a green test and an unchanged risk — every failure class that takes out the settle write
+(the `MaxOpenConns=1` write connection, a DB-file pathology, a torn WAL after power loss) takes the
+journal write out with it; a second sqlite file is the same driver and the same page cache. Segments
+`effects-<unixmilli>-<pid>.jsonl`, dir `0700` / files `0600`, records keyed
+`(account_id, request_id, effect)` in three kinds — `effect` / `seal` / `quarantine` — and **never**
+any prompt or response text.
+**Durability contract:** `WriteEffect` is one `write(2)` + `fsync` BEFORE returning, so the effect is
+on stable storage before the settle attempt begins (`TestSettlementJournal_EffectWriteFsyncs` pins the
+call order through the real file). Seals are deliberately NOT fsynced — a lost seal costs one
+idempotent re-drive, never a bill. Segment create/unlink fsync the parent directory.
+**Where it arms:** `settleAfterCommit` only — the single choke point every after-commit terminal
+funnels through, and the only place where the buyer has been served and the durable bill has not been
+written. The reservation IS the pre-dispatch arm, so v1 adds no second one: a pre-dispatch record
+would carry no token payload and would scale the journal with traffic rather than with settlements.
+Journal write failures are **fail-open** — the settle proceeds, an error log and
+`gateway_settlement_journal_write_failures_total` fire, and only recovery coverage is lost
+(`TestSettlementJournal_WriteFailureDoesNotBlockSettle`).
+**Recovery:** `RecoverSettlementJournal` (`internal/router/settlement_journal_recovery.go`) re-drives
+unsealed effects through the SAME ladder — `SettleReservation`/`SettleDemoReservation` → seal
+`settled`; reservation missing/terminal → `EnsureUsageEvent` (+`EnsureDemoUsageEvent`) →
+`RefundReservation` → seal `usage_event`; `ErrUsageEventConflict` → no seal, quarantine after 10
+attempts with a CRITICAL log + gauge. It runs BOTH as a bounded startup pass and on its own ticker
+(`settlement.journal_recovery_interval_s`, default 30s, separate from the SPEC-022 reconciler):
+startup alone would not help, because the H7 failure is a logical double failure inside a running
+process that nothing restarts. A 60s grace window keeps recovery off effects whose request may still
+be in flight; the batch limit (100) protects the single write connection; fully-sealed,
+quarantine-free segments prune after 168h. Every rung is idempotent, so a re-drive of an
+already-settled request matches the existing row and bills nothing
+(`TestSettlementJournal_SettleLandedButSealLost`).
+**Config:** `settlement.journal_{enabled,dir,fsync,segment_max_bytes,max_total_bytes,retention_hours,
+recovery_interval_s,recovery_batch_limit,recovery_grace_s}`. `journal_enabled` and `journal_fsync` are
+REQUIRED true by `Validate` (mirroring `reconcile_enabled`) and default true, so a pre-#763
+`gateway.yaml` that sets none of them still boots with the journal on. `journal_dir` defaults to a
+sibling of `storage.db_path`. `cmd/gateway` opens the journal right after `sqlite.Open` and exits on
+failure — a silently-disabled journal has no other symptom, which is why
+`TestGatewayRouterCarriesSettlementJournal` pins the wiring. Metrics:
+`gateway_settlement_journal_{effects,seals,quarantines,write_failures,recovered}_total`,
+`_unsealed`, `_quarantined`, `_bytes`.
+`TestSeamH7` flipped to `SettlementRecoveredFromJournal` (PASS = certifies the fix): the in-band drop
+is UNCHANGED (`usageRows=0`, refunded=1 — the in-band drop was never the bug, the PERMANENCE was), and
+a second Server over the same store and journal recovers the bill to `usageRows=1` / 20 tokens, refund
+intact, seal `usage_event`, second pass a no-op.
+**Deliberately NOT covered:** (a) **disk full** (failure class C6) — untestable locally; the hard
+`journal_max_total_bytes` cap refuses records with a CRITICAL log rather than filling the volume
+sqlite lives on, which is the lesser harm but still a coverage gap. (b) **A journal-write failure AND
+the settle double-failure in the same request** — metric-visible (`write_failures_total` plus the
+§ 17.7 error log) but unrecoverable by construction. (c) **Crash mid-stream before any terminal** — no
+effect is armed; the reservation reaper refunds, unchanged. (d) **The SPEC-022 hold-marker sibling
+leak** — the debit/hold terminals never call `settleAfterCommit`, so a lost hold marker is still only
+reconcilable coordinator-side; the `effect` key field is future-proofed for it, but it is NOT a v1
+effect kind. (e) **Multi-instance arbitration** — the journal is single-writer, matching today's
+single-gateway deployment; two gateways over one directory would each re-drive the other's effects.
+(f) **Non-streaming settles** — they run BEFORE the response and 500 the buyer on failure, so there is
+no delivered-but-unbilled window to journal. **Residual:** the conflict-attempt counter is
+process-local, so a restart resets it — that only delays a quarantine, it can never double-bill.
 
 **P1-3 · Capacity trusted blindly; no clamp, no tripwire** — `ranking`/`supply` (closes a slice-3 + slice-5 gap)
 **FIXED coordinator-side (issue #764).** Nothing gateway-side: the gateway never reads
@@ -208,5 +265,7 @@ timing side-channel. **Fix:** reconcile spec vs overlay; write the risk-acceptan
    **P1-4** landed with it (#765) but ships dormant behind
    `telemetry_drift.quarantine_missing_benchmark`; enabling it needs a live-fleet measurement of
    how many providers lack verified benchmarks.
-4. **P1-1 / P1-2** — money integrity before real buyer volume.
+4. ~~**P1-1 / P1-2**~~ — **DONE (#762, #763)**: money integrity before real buyer volume. #762 makes an
+   id-less retry bill once; #763 makes an after-commit settle recoverable. Both keep the durable
+   `(account_id, request_id)` key as the invariant — neither adds a second source of truth for money.
 5. P2 as debt burn-down.

--- a/audits/seam-hardening/harness/README.md
+++ b/audits/seam-hardening/harness/README.md
@@ -12,16 +12,22 @@ are deterministic and need no running server or credentials.
 Test files:
 - `phase5-gateway/internal/router/seam_harness_test.go`
 - `phase5-gateway/internal/router/idless_dedupe_test.go` (H5a's miss/bypass siblings, #762)
+- `phase5-gateway/internal/router/settlement_journal_recovery_test.go` (H7's recovery-ladder
+  siblings, #763)
+- `phase5-gateway/internal/settlement/journal/journal_test.go` (H7's durability siblings: the
+  per-effect fsync, torn tails, rotation/prune, reopen-after-close, the hard size cap)
 - `phase4-coordinator/internal/buyer/seam_h3_test.go`
 
 ## Run
 
 ```bash
 cd phase5-gateway     && go test ./internal/router/ -run TestSeam  -v
+cd phase5-gateway     && go test ./internal/router/ -run TestSettlementJournal -v   # H7 siblings (#763)
+cd phase5-gateway     && go test ./internal/settlement/... -v                       # journal durability (#763)
 cd phase4-coordinator && go test ./internal/buyer/  -run TestSeamH -v
 ```
 
-## Results (verified 2026-07-26) — 7 of 8 execute; only H4 is a documented skip
+## Results (verified 2026-07-27) — 7 of 8 execute; only H4 is a documented skip
 
 **Gateway suite**
 
@@ -32,7 +38,7 @@ cd phase4-coordinator && go test ./internal/buyer/  -run TestSeamH -v
 | **H5a** `IdlessRetryBillsOnce` | P1-1 | **PASS = certifies FIX** (#762) | two id-less calls bill 20 once; 2nd carries `X-MacProvider-Dedupe: replay` with attempt 1's exact body, upstream dispatched once |
 | **H5b** `StableRequestIDBillsOnce` | P1-1 | **PASS** (control) | same-UUID 2nd call → 409, billed once (20) |
 | **H6** `ProviderOverReportBoundedToDelivered` | — | **PASS** | provider `completion_tokens=100000` rejected → estimate, billed 24 not 100008 |
-| **H7** `SettlementNotCrashDurable` | P1-2 | **PASS = confirms GAP** | committed 200 stream + settle double-failure → usage row dropped, refunded, nobody billed |
+| **H7** `SettlementRecoveredFromJournal` | P1-2 | **PASS = certifies FIX** (#763) | committed 200 stream + settle double-failure → still dropped IN-BAND (refunded, `usageRows=0`), but the effect journaled before the attempt is re-driven by a second Server over the same store + journal into `usageRows=1` / 20 tokens, refund intact, seal `usage_event`; a second pass is a no-op |
 | H3 / H4 | P0-3 / P2-1 | pointer-SKIP | see coordinator suite |
 
 **Coordinator suite**
@@ -45,6 +51,9 @@ cd phase4-coordinator && go test ./internal/buyer/  -run TestSeamH -v
 
 The "confirms FAIL/GAP" tests pass by asserting the **buggy-today** behavior, so when a fix lands
 they flip to failing-until-the-assertion-is-updated — a durable regression tripwire per finding.
+As of #763 no gateway scenario is still in that state: H1, H5a and H7 have all been re-pointed at the
+shipped fix, with their scenarios (not their assertions) left untouched, so each one now guards a
+behavior instead of documenting a gap.
 
 ## Mechanism note (surfaced by wiring H1)
 
@@ -82,6 +91,25 @@ and lands on the existing `duplicate_request_id` 409. `idless_dedupe_test.go` ca
 outside-window resend, truncated stream, error terminal, waiter-cap overflow (asserting the adopted id
 on the 409), body eviction, both bypasses, and the `idless_dedupe_window_seconds: 0` kill switch — so
 "billed once" is proven on the miss paths and not only on the happy path.
+
+## Mechanism note (H7, post-#763)
+
+H7's scenario is untouched — same settle-failing spy, same double failure — and so is its IN-BAND
+outcome: the request goroutine still refunds and still writes no usage row, because at that point
+there is nothing left to try. What flipped is the PERMANENCE. The settle effect is journaled (one
+`write(2)` + `fsync`) BEFORE the settle attempt, to an append-only JSONL file that is deliberately
+NOT `gateway.db`: a table in the same sqlite file shares every failure mode with the write that just
+failed, so it would have turned H7 green while leaving the risk untouched.
+
+The tripwire therefore asserts BOTH halves — the in-band drop AND the recovery — and it runs the same
+`RecoverSettlementJournal` entry point `cmd/gateway` runs at startup and on its ticker. A regression
+that stops arming the effect, seals it before the durable bill exists, or breaks a rung of the
+re-drive ladder turns H7 red again. What H7 alone does NOT prove: that the record is durable across a
+power loss (`journal_test.go` pins the fsync call order through the real file), that a re-drive of an
+already-settled request cannot double-bill (`TestSettlementJournal_SettleLandedButSealLost`), or that
+a `#762` replay journals nothing (`TestSettlementJournal_ReplayedIdlessRetryWritesNoEffect`) — a
+replay performs no reserve and no settle, so a journal record there would describe a money effect
+that never happened.
 
 The companion clocks in the harness suite live in
 `phase5-gateway/internal/router/request_deadlines_test.go` (ceiling on an endless stream, heartbeat-only

--- a/phase5-gateway/cmd/gateway/main.go
+++ b/phase5-gateway/cmd/gateway/main.go
@@ -15,6 +15,7 @@ import (
 	"github.com/augstar/macprovider-gateway/internal/auth"
 	"github.com/augstar/macprovider-gateway/internal/config"
 	"github.com/augstar/macprovider-gateway/internal/router"
+	"github.com/augstar/macprovider-gateway/internal/settlement/journal"
 	"github.com/augstar/macprovider-gateway/internal/storage/sqlite"
 )
 
@@ -55,6 +56,21 @@ func main() {
 		}
 	}()
 
+	// #763: open the durable settlement journal next to the database it
+	// protects. FAIL-CLOSED: a gateway that cannot journal cannot recover a
+	// dropped settlement, and a silently-disabled journal is exactly the
+	// hole the router's discard implementation would create.
+	settlementJournal, err := openSettlementJournal(cfg)
+	if err != nil {
+		slog.Error("open settlement journal failed", "dir", cfg.SettlementJournalDir(), "error", err)
+		os.Exit(1)
+	}
+	defer func() {
+		if err := settlementJournal.Close(); err != nil {
+			slog.Warn("close settlement journal failed", "error", err)
+		}
+	}()
+
 	// M2-4 / PERF-4: open a SECOND handle in read-only mode for the
 	// explorer + /v1/usage GET-only handlers. The primary handle is
 	// SetMaxOpenConns(1) so BEGIN IMMEDIATE writes serialize cleanly,
@@ -84,11 +100,37 @@ func main() {
 	coordinatorClient := newCoordinatorClient(cfg)
 	oauthClient := &http.Client{Timeout: 30 * time.Second}
 	oauth := auth.NewGitHubProvider(cfg.Auth.OAuth.GitHub, oauthClient)
-	gatewayRouter := router.New(cfg, store, oauth,
-		router.WithHTTPClient(coordinatorClient),
-		router.WithVersion(version),
-		router.WithReadStore(readStore),
-	)
+	gatewayRouter := newGatewayRouter(cfg, store, readStore, oauth, coordinatorClient, settlementJournal)
+	// #763: drain whatever the previous process left unsealed BEFORE
+	// listening, then keep draining on a ticker. Startup alone is not
+	// enough — the H7 failure is a logical double-failure inside a running
+	// process, which nothing would ever restart the gateway to fix.
+	if cfg.Settlement.JournalEnabled {
+		recoverCtx, cancel := context.WithTimeout(ctx, settlementJournalRecoveryTimeout)
+		summary, err := gatewayRouter.RecoverSettlementJournal(recoverCtx, cfg.Settlement.JournalRecoveryBatchLimit)
+		cancel()
+		if err != nil {
+			// CRITICAL but not fatal: refusing to serve because recovery
+			// failed would turn a recoverable billing gap into an outage.
+			slog.Error("CRITICAL gateway settlement journal startup recovery failed; serving anyway",
+				"error", err)
+		} else if summary.Scanned > 0 || summary.Unsealed > 0 || summary.Malformed > 0 {
+			slog.Info("gateway settlement journal startup recovery completed",
+				"scanned", summary.Scanned,
+				"recovered", summary.Recovered,
+				"quarantined", summary.Quarantined,
+				"skipped", summary.Skipped,
+				"errors", summary.Errors,
+				"unsealed", summary.Unsealed,
+				"malformed", summary.Malformed,
+			)
+		}
+		go runSettlementJournalRecovery(ctx, gatewayRouter,
+			time.Duration(cfg.Settlement.JournalRecoveryIntervalSeconds)*time.Second,
+			cfg.Settlement.JournalRecoveryBatchLimit,
+			settlementJournalRecoveryTimeout,
+		)
+	}
 	if cfg.Settlement.ReconcileEnabled {
 		go runSettlementReconciler(ctx, gatewayRouter,
 			time.Duration(cfg.Settlement.ReconcileIntervalSeconds)*time.Second,
@@ -151,6 +193,98 @@ func newHTTPServer(addr string, handler http.Handler) *http.Server {
 		ReadHeaderTimeout: 10 * time.Second,
 		ReadTimeout:       30 * time.Second,
 		IdleTimeout:       120 * time.Second,
+	}
+}
+
+// openSettlementJournal builds the real #763 journal from config. It is a
+// named function so TestOpenSettlementJournal* can drive the same code path
+// production does (the wiring, not a re-implementation of it).
+func openSettlementJournal(cfg config.Config) (*journal.Journal, error) {
+	return journal.Open(journal.Options{
+		Dir:             cfg.SettlementJournalDir(),
+		Fsync:           cfg.Settlement.JournalFsync,
+		SegmentMaxBytes: cfg.Settlement.JournalSegmentMaxBytes,
+		MaxTotalBytes:   cfg.Settlement.JournalMaxTotalBytes,
+	})
+}
+
+// newGatewayRouter assembles the production router. Extracted from main so
+// TestGatewayRouterCarriesSettlementJournal can assert that the real journal
+// actually reaches the Server — a nil/discard journal here would disable
+// settlement durability with no other visible symptom.
+func newGatewayRouter(
+	cfg config.Config,
+	store router.Store,
+	readStore router.ReadStore,
+	oauth auth.OAuthProvider,
+	coordinatorClient *http.Client,
+	settlementJournal router.SettlementJournal,
+) *router.Server {
+	return router.New(cfg, store, oauth,
+		router.WithHTTPClient(coordinatorClient),
+		router.WithVersion(version),
+		router.WithReadStore(readStore),
+		router.WithSettlementJournal(settlementJournal),
+	)
+}
+
+// settlementJournalRecoveryTimeout bounds one recovery pass (startup and
+// periodic alike). Recovery shares the store's single write connection with
+// the money path, so a pass that cannot finish promptly must yield rather
+// than hold the connection.
+const settlementJournalRecoveryTimeout = 30 * time.Second
+
+type settlementJournalRecoverer interface {
+	RecoverSettlementJournal(context.Context, int) (router.SettlementJournalRecoverySummary, error)
+}
+
+// runSettlementJournalRecovery is modeled on runSettlementReconciler but is a
+// SEPARATE loop on purpose: the SPEC-022 reconciler round-trips the
+// coordinator for reservations that are still held, while this pass only
+// re-drives locally journaled effects — different failure modes, different
+// cadence, and folding them together would make one stall the other.
+func runSettlementJournalRecovery(ctx context.Context, recoverer settlementJournalRecoverer, interval time.Duration, limit int, requestTimeout time.Duration) {
+	if interval <= 0 {
+		interval = 30 * time.Second
+	}
+	if limit <= 0 {
+		limit = 100
+	}
+	if requestTimeout <= 0 {
+		requestTimeout = settlementJournalRecoveryTimeout
+	}
+	recoverPass := func() {
+		runCtx, cancel := context.WithTimeout(ctx, requestTimeout)
+		defer cancel()
+		summary, err := recoverer.RecoverSettlementJournal(runCtx, limit)
+		if err != nil {
+			slog.Warn("gateway settlement journal recovery failed", "error", err)
+			return
+		}
+		if summary.Scanned > 0 || summary.Errors > 0 || summary.Quarantined > 0 {
+			slog.Info("gateway settlement journal recovery completed",
+				"scanned", summary.Scanned,
+				"recovered", summary.Recovered,
+				"settled", summary.Settled,
+				"usage_events", summary.UsageEvents,
+				"quarantined", summary.Quarantined,
+				"retried", summary.Retried,
+				"skipped", summary.Skipped,
+				"errors", summary.Errors,
+				"pruned", summary.Pruned,
+			)
+		}
+	}
+	recoverPass()
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			recoverPass()
+		}
 	}
 }
 

--- a/phase5-gateway/cmd/gateway/main_test.go
+++ b/phase5-gateway/cmd/gateway/main_test.go
@@ -5,12 +5,16 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/augstar/macprovider-gateway/internal/config"
 	"github.com/augstar/macprovider-gateway/internal/router"
+	"github.com/augstar/macprovider-gateway/internal/settlement/journal"
+	"github.com/augstar/macprovider-gateway/internal/storage/sqlite"
 )
 
 func TestNewHTTPServerAppliesTimeouts(t *testing.T) {
@@ -142,6 +146,118 @@ func TestRunSettlementReconcilerRunsOnInterval(t *testing.T) {
 	case <-done:
 	case <-time.After(time.Second):
 		t.Fatal("settlement reconciler did not stop after interval test cancellation")
+	}
+}
+
+type fakeSettlementJournalRecoverer struct {
+	calls chan int
+}
+
+func (f *fakeSettlementJournalRecoverer) RecoverSettlementJournal(ctx context.Context, limit int) (router.SettlementJournalRecoverySummary, error) {
+	select {
+	case <-ctx.Done():
+		return router.SettlementJournalRecoverySummary{}, ctx.Err()
+	case f.calls <- limit:
+		return router.SettlementJournalRecoverySummary{Scanned: 1, Recovered: 1}, nil
+	}
+}
+
+func TestRunSettlementJournalRecoveryRunsImmediatelyAndOnInterval(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	fake := &fakeSettlementJournalRecoverer{calls: make(chan int, 4)}
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		runSettlementJournalRecovery(ctx, fake, 10*time.Millisecond, 41, time.Second)
+	}()
+	for i := 0; i < 2; i++ {
+		select {
+		case got := <-fake.calls:
+			if got != 41 {
+				t.Fatalf("recovery call %d limit=%d want 41", i+1, got)
+			}
+		case <-time.After(time.Second):
+			t.Fatalf("settlement journal recovery call %d did not arrive", i+1)
+		}
+	}
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("settlement journal recovery did not stop after context cancellation")
+	}
+}
+
+// TestGatewayRouterCarriesSettlementJournal is the wiring tripwire for #763.
+//
+// The router falls back to a DISCARD journal when none is registered, and a
+// discard journal has no symptom: requests succeed, /metrics stays at zero,
+// and settlement durability is simply off. So the production assembly path is
+// exercised end to end — open the real journal, build the router the way
+// main() does, write an effect, and prove the Server can recover it. A
+// dropped WithSettlementJournal option turns this red.
+func TestGatewayRouterCarriesSettlementJournal(t *testing.T) {
+	dir := t.TempDir()
+	cfg := config.Default()
+	cfg.Auth.KeyHashSecret = "test-key-hash-secret"
+	cfg.Auth.Demo.SigningSecret = "test-demo-secret"
+	cfg.Storage.DBPath = filepath.Join(dir, "gateway.db")
+	cfg.Settlement.JournalRecoveryGraceSeconds = 0
+
+	store, err := sqlite.Open(context.Background(), cfg.Storage.DBPath)
+	if err != nil {
+		t.Fatalf("sqlite.Open: %v", err)
+	}
+	defer store.Close()
+
+	settlementJournal, err := openSettlementJournal(cfg)
+	if err != nil {
+		t.Fatalf("openSettlementJournal: %v", err)
+	}
+	defer settlementJournal.Close()
+	if got := settlementJournal.Dir(); got != filepath.Join(dir, "settlement-journal") {
+		t.Fatalf("journal dir=%q want the sqlite sibling", got)
+	}
+
+	gatewayRouter := newGatewayRouter(cfg, store, store, nil, http.DefaultClient, settlementJournal)
+	if err := settlementJournal.WriteEffect(journal.Record{
+		AccountID:        "acct_wiring",
+		RequestID:        "req-wiring",
+		Effect:           journal.EffectSettle,
+		WindowDate:       "2026-05-29",
+		PromptTokens:     8,
+		CompletionTokens: 12,
+		TotalTokens:      20,
+		MaxTotalTokens:   20,
+		TokenSource:      "provider_reported",
+		Outcome:          "ok",
+	}); err != nil {
+		t.Fatalf("WriteEffect: %v", err)
+	}
+
+	summary, err := gatewayRouter.RecoverSettlementJournal(context.Background(), cfg.Settlement.JournalRecoveryBatchLimit)
+	if err != nil {
+		t.Fatalf("RecoverSettlementJournal: %v", err)
+	}
+	if summary.Scanned != 1 {
+		t.Fatalf("summary=%+v — the router did not see the journal main() opened; the real journal is not wired "+
+			"into router.New and settlement durability is silently disabled", summary)
+	}
+}
+
+// TestOpenSettlementJournalFailsClosed: main() exits when this errors, which
+// is the only thing standing between a misconfigured journal directory and a
+// gateway that serves with durability off.
+func TestOpenSettlementJournalFailsClosed(t *testing.T) {
+	locked := filepath.Join(t.TempDir(), "locked")
+	if err := os.Mkdir(locked, 0o500); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(locked, 0o700) })
+	cfg := config.Default()
+	cfg.Settlement.JournalDir = filepath.Join(locked, "settlement-journal")
+	if _, err := openSettlementJournal(cfg); err == nil {
+		t.Fatal("openSettlementJournal accepted an unwritable directory; main() would boot without durability")
 	}
 }
 

--- a/phase5-gateway/internal/config/config.go
+++ b/phase5-gateway/internal/config/config.go
@@ -5,6 +5,7 @@ import (
 	"net"
 	"net/url"
 	"os"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -171,6 +172,50 @@ type SettlementConfig struct {
 	ReconcileIntervalSeconds       int  `yaml:"reconcile_interval_s"`
 	ReconcileBatchLimit            int  `yaml:"reconcile_batch_limit"`
 	ReconcileRequestTimeoutSeconds int  `yaml:"reconcile_request_timeout_s"`
+
+	// Issue #763 durable settlement journal. Every knob defaults to a
+	// working value in Default(), and Load() decodes YAML ON TOP of
+	// Default(), so a pre-#763 config that sets none of these boots with the
+	// journal on — the same back-compat mechanism reconcile_enabled relies
+	// on.
+	//
+	// JournalEnabled mirrors ReconcileEnabled: Validate REQUIRES true. The
+	// journal is the only thing standing between an after-commit settle
+	// failure and an unbillable delivered request, so disabling it is not an
+	// operator-tunable posture.
+	JournalEnabled bool `yaml:"journal_enabled"`
+	// JournalDir defaults to <dir of storage.db_path>/settlement-journal.
+	// See Config.SettlementJournalDir.
+	JournalDir string `yaml:"journal_dir"`
+	// JournalFsync controls the per-effect fsync. Validate requires true:
+	// without it the journal survives a process crash but NOT a power loss,
+	// which is most of the point. The field exists as an escape hatch for
+	// throwaway environments that construct Config directly (tests,
+	// benchmarks) and never call Validate.
+	JournalFsync bool `yaml:"journal_fsync"`
+	// JournalSegmentMaxBytes bounds one segment file.
+	JournalSegmentMaxBytes int64 `yaml:"journal_segment_max_bytes"`
+	// JournalMaxTotalBytes is the HARD cap across all segments. Past it the
+	// journal refuses records with a CRITICAL log instead of filling the
+	// disk out from under sqlite (settlement still runs: journal writes are
+	// fail-open).
+	JournalMaxTotalBytes int64 `yaml:"journal_max_total_bytes"`
+	// JournalRetentionHours bounds how long a fully-sealed, quarantine-free
+	// segment is kept before pruning.
+	JournalRetentionHours int `yaml:"journal_retention_hours"`
+	// JournalRecoveryIntervalSeconds paces the recovery loop. It is
+	// deliberately its OWN knob rather than a reuse of
+	// reconcile_interval_s: the SPEC-022 reconciler talks to the
+	// coordinator, this pass only touches local disk plus the local DB.
+	JournalRecoveryIntervalSeconds int `yaml:"journal_recovery_interval_s"`
+	// JournalRecoveryBatchLimit bounds effects re-driven per pass. The store
+	// runs at MaxOpenConns=1, so an unbounded pass would stall the money
+	// path behind recovery work.
+	JournalRecoveryBatchLimit int `yaml:"journal_recovery_batch_limit"`
+	// JournalRecoveryGraceSeconds holds back effects written within the
+	// window, so recovery cannot race a settle that is still in flight on
+	// its request goroutine.
+	JournalRecoveryGraceSeconds int `yaml:"journal_recovery_grace_s"`
 }
 
 type CORSConfig struct {
@@ -281,6 +326,18 @@ func Default() Config {
 			ReconcileIntervalSeconds:       30,
 			ReconcileBatchLimit:            100,
 			ReconcileRequestTimeoutSeconds: 10,
+			// #763. journal_enabled must DEFAULT to true because Validate
+			// requires it: a pre-#763 gateway.yaml sets no journal keys, and
+			// a false default would refuse to boot every existing config.
+			JournalEnabled:                 true,
+			JournalDir:                     "", // derive from storage.db_path
+			JournalFsync:                   true,
+			JournalSegmentMaxBytes:         16 << 20,
+			JournalMaxTotalBytes:           512 << 20,
+			JournalRetentionHours:          168,
+			JournalRecoveryIntervalSeconds: 30,
+			JournalRecoveryBatchLimit:      100,
+			JournalRecoveryGraceSeconds:    60,
 		},
 		CORS:     CORSConfig{AllowedOrigins: []string{"https://console.streamvc.live", "https://streamvc.live"}},
 		Routing:  RoutingConfig{StickyEnabled: false, StickyTTLS: 1800},
@@ -558,6 +615,34 @@ func (c Config) Validate() error {
 	if c.Settlement.ReconcileRequestTimeoutSeconds <= 0 {
 		return fmt.Errorf("settlement.reconcile_request_timeout_s must be > 0 when settlement.reconcile_enabled is true")
 	}
+	// #763 durable settlement journal. Mirrors the reconcile_enabled rule:
+	// the money-path invariant it protects (a delivered request is always
+	// billable) is not an operator posture.
+	if !c.Settlement.JournalEnabled {
+		return fmt.Errorf("settlement.journal_enabled must be true (issue #763: without the journal an after-commit settle failure permanently drops the bill)")
+	}
+	if !c.Settlement.JournalFsync {
+		return fmt.Errorf("settlement.journal_fsync must be true (an unsynced journal survives a process crash but not a power loss)")
+	}
+	if c.Settlement.JournalSegmentMaxBytes <= 0 {
+		return fmt.Errorf("settlement.journal_segment_max_bytes must be > 0")
+	}
+	if c.Settlement.JournalMaxTotalBytes < c.Settlement.JournalSegmentMaxBytes {
+		return fmt.Errorf("settlement.journal_max_total_bytes (%d) must be >= settlement.journal_segment_max_bytes (%d)",
+			c.Settlement.JournalMaxTotalBytes, c.Settlement.JournalSegmentMaxBytes)
+	}
+	if c.Settlement.JournalRetentionHours <= 0 {
+		return fmt.Errorf("settlement.journal_retention_hours must be > 0")
+	}
+	if c.Settlement.JournalRecoveryIntervalSeconds <= 0 {
+		return fmt.Errorf("settlement.journal_recovery_interval_s must be > 0")
+	}
+	if c.Settlement.JournalRecoveryBatchLimit <= 0 || c.Settlement.JournalRecoveryBatchLimit > 500 {
+		return fmt.Errorf("settlement.journal_recovery_batch_limit must be between 1 and 500")
+	}
+	if c.Settlement.JournalRecoveryGraceSeconds < 0 {
+		return fmt.Errorf("settlement.journal_recovery_grace_s must be >= 0")
+	}
 	if c.Routing.StickyTTLS <= 0 {
 		return fmt.Errorf("routing.sticky_ttl_s must be > 0")
 	}
@@ -644,6 +729,17 @@ func requireURL(field, raw string) error {
 		return fmt.Errorf("%s must be an absolute URL", field)
 	}
 	return nil
+}
+
+// SettlementJournalDir resolves the #763 journal directory. An explicit
+// settlement.journal_dir wins; otherwise it is a sibling of the sqlite file,
+// which keeps the journal on the same volume as the database it protects (a
+// journal on a different, unmounted volume would fail open silently).
+func (c Config) SettlementJournalDir() string {
+	if dir := strings.TrimSpace(c.Settlement.JournalDir); dir != "" {
+		return dir
+	}
+	return filepath.Join(filepath.Dir(c.Storage.DBPath), "settlement-journal")
 }
 
 func (c Config) Address() string {

--- a/phase5-gateway/internal/config/config_test.go
+++ b/phase5-gateway/internal/config/config_test.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"os"
 	"strings"
 	"testing"
 	"time"
@@ -141,6 +142,146 @@ func TestSettlementReconcileConfigValidation(t *testing.T) {
 		"zero request timeout": {
 			mutate: func(cfg *Config) { cfg.Settlement.ReconcileRequestTimeoutSeconds = 0 },
 			want:   "settlement.reconcile_request_timeout_s must be > 0",
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			cfg := validTestConfig()
+			tc.mutate(&cfg)
+			err := cfg.Validate()
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("Validate error=%v want containing %q", err, tc.want)
+			}
+		})
+	}
+}
+
+// TestSettlementJournalDefaults pins the #763 defaults, and with them the
+// BACK-COMPAT contract: Validate REQUIRES journal_enabled and journal_fsync,
+// so both must default to true or every pre-#763 gateway.yaml (which sets no
+// journal keys at all) would refuse to boot.
+func TestSettlementJournalDefaults(t *testing.T) {
+	cfg := Default()
+	if !cfg.Settlement.JournalEnabled {
+		t.Fatal("Settlement.JournalEnabled=false want true — a false default would break every existing config")
+	}
+	if !cfg.Settlement.JournalFsync {
+		t.Fatal("Settlement.JournalFsync=false want true")
+	}
+	if cfg.Settlement.JournalSegmentMaxBytes != 16<<20 {
+		t.Fatalf("JournalSegmentMaxBytes=%d want 16MiB", cfg.Settlement.JournalSegmentMaxBytes)
+	}
+	if cfg.Settlement.JournalMaxTotalBytes != 512<<20 {
+		t.Fatalf("JournalMaxTotalBytes=%d want 512MiB", cfg.Settlement.JournalMaxTotalBytes)
+	}
+	if cfg.Settlement.JournalRetentionHours != 168 {
+		t.Fatalf("JournalRetentionHours=%d want 168", cfg.Settlement.JournalRetentionHours)
+	}
+	if cfg.Settlement.JournalRecoveryIntervalSeconds != 30 {
+		t.Fatalf("JournalRecoveryIntervalSeconds=%d want 30", cfg.Settlement.JournalRecoveryIntervalSeconds)
+	}
+	if cfg.Settlement.JournalRecoveryBatchLimit != 100 {
+		t.Fatalf("JournalRecoveryBatchLimit=%d want 100", cfg.Settlement.JournalRecoveryBatchLimit)
+	}
+	if cfg.Settlement.JournalRecoveryGraceSeconds != 60 {
+		t.Fatalf("JournalRecoveryGraceSeconds=%d want 60", cfg.Settlement.JournalRecoveryGraceSeconds)
+	}
+	// A zero-value journal_dir derives a sibling of the sqlite file, so the
+	// journal always lands on the same volume as the DB it protects.
+	cfg.Storage.DBPath = "/var/lib/macprovider/gateway.db"
+	if got := cfg.SettlementJournalDir(); got != "/var/lib/macprovider/settlement-journal" {
+		t.Fatalf("SettlementJournalDir()=%q want the sqlite sibling", got)
+	}
+	cfg.Settlement.JournalDir = "/mnt/journal"
+	if got := cfg.SettlementJournalDir(); got != "/mnt/journal" {
+		t.Fatalf("SettlementJournalDir()=%q want the explicit override", got)
+	}
+}
+
+// TestSettlementJournalConfigBackCompat drives the real Load() path over a
+// config that predates #763: it must boot, with the journal on.
+func TestSettlementJournalConfigBackCompat(t *testing.T) {
+	yaml := `
+listen:
+  bind_address: 127.0.0.1
+  port: 9443
+public:
+  base_url: https://api.streamvc.live
+  account_path: /account
+coordinator:
+  buyer_url: http://127.0.0.1:8443
+  operator_url: http://127.0.0.1:8444
+  operator_key: operator-key
+  service_token: service-token
+  poolz_poll_interval_s: 10
+storage:
+  driver: sqlite
+  db_path: /var/lib/macprovider/gateway.db
+auth:
+  key_hash_secret: secret
+  github_oauth_enabled: false
+  demo:
+    signing_secret: demo-secret
+settlement:
+  reconcile_enabled: true
+  reconcile_interval_s: 30
+  reconcile_batch_limit: 100
+  reconcile_request_timeout_s: 10
+`
+	path := t.TempDir() + "/gateway.yaml"
+	if err := os.WriteFile(path, []byte(yaml), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatalf("a pre-#763 config must still load: %v", err)
+	}
+	if !cfg.Settlement.JournalEnabled || !cfg.Settlement.JournalFsync {
+		t.Fatalf("journal defaults lost on a partial settlement block: %+v", cfg.Settlement)
+	}
+	if cfg.Settlement.ReconcileIntervalSeconds != 30 {
+		t.Fatalf("explicit reconcile keys were clobbered: %+v", cfg.Settlement)
+	}
+	if got := cfg.SettlementJournalDir(); got != "/var/lib/macprovider/settlement-journal" {
+		t.Fatalf("derived journal dir=%q", got)
+	}
+}
+
+func TestSettlementJournalConfigValidation(t *testing.T) {
+	for name, tc := range map[string]struct {
+		mutate func(*Config)
+		want   string
+	}{
+		"disabled journal": {
+			mutate: func(cfg *Config) { cfg.Settlement.JournalEnabled = false },
+			want:   "settlement.journal_enabled must be true",
+		},
+		"fsync off": {
+			mutate: func(cfg *Config) { cfg.Settlement.JournalFsync = false },
+			want:   "settlement.journal_fsync must be true",
+		},
+		"zero segment cap": {
+			mutate: func(cfg *Config) { cfg.Settlement.JournalSegmentMaxBytes = 0 },
+			want:   "settlement.journal_segment_max_bytes must be > 0",
+		},
+		"total cap below segment cap": {
+			mutate: func(cfg *Config) { cfg.Settlement.JournalMaxTotalBytes = 1 << 10 },
+			want:   "settlement.journal_max_total_bytes",
+		},
+		"zero retention": {
+			mutate: func(cfg *Config) { cfg.Settlement.JournalRetentionHours = 0 },
+			want:   "settlement.journal_retention_hours must be > 0",
+		},
+		"zero recovery interval": {
+			mutate: func(cfg *Config) { cfg.Settlement.JournalRecoveryIntervalSeconds = 0 },
+			want:   "settlement.journal_recovery_interval_s must be > 0",
+		},
+		"oversized recovery batch": {
+			mutate: func(cfg *Config) { cfg.Settlement.JournalRecoveryBatchLimit = 501 },
+			want:   "settlement.journal_recovery_batch_limit must be between 1 and 500",
+		},
+		"negative grace": {
+			mutate: func(cfg *Config) { cfg.Settlement.JournalRecoveryGraceSeconds = -1 },
+			want:   "settlement.journal_recovery_grace_s must be >= 0",
 		},
 	} {
 		t.Run(name, func(t *testing.T) {

--- a/phase5-gateway/internal/router/chat_proxy.go
+++ b/phase5-gateway/internal/router/chat_proxy.go
@@ -2329,7 +2329,8 @@ func (s *Server) settleAfterCommit(r *http.Request, subject usageSubject, prompt
 		// (audit R1, architect MEDIUM): sealing past a failed refund would
 		// suppress recovery's retry and leave DailyUsage double-counting the
 		// usage row plus the still-active hold until the reaper.
-		if refundErr != nil {
+		if refundErr != nil && !errors.Is(refundErr, storage.ErrReservationNotFound) &&
+			!errors.Is(refundErr, storage.ErrReservationTerminal) {
 			slog.Warn("gateway settlement §17.7 refund failed; leaving journal effect unsealed for recovery",
 				"request_id", requestID(r),
 				"account_id", subject.AccountID,

--- a/phase5-gateway/internal/router/chat_proxy.go
+++ b/phase5-gateway/internal/router/chat_proxy.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"github.com/augstar/macprovider-gateway/internal/config"
+	"github.com/augstar/macprovider-gateway/internal/settlement/journal"
 	"github.com/augstar/macprovider-gateway/internal/storage"
 )
 
@@ -2153,6 +2154,62 @@ func parseSettlementPendingDeadlineUnixMS(raw string) int64 {
 }
 
 func (s *Server) settleAfterCommit(r *http.Request, subject usageSubject, prompt, completion, maxTotal int64, source, outcome, reservationWindow string) {
+	// WINDOW: use the reservation window captured at admission time (not
+	// s.now()) so a stream that crosses UTC midnight settles against the SAME
+	// daily quota window the buyer's reservation was made against. ISS-187 R1
+	// architect+code MAJOR.
+	//
+	// Hoisted above the settle attempt by #763 so the journal record and the
+	// § 17.7 fallback below share ONE value. A journal record carrying a
+	// different window than the fallback would re-drive into an
+	// ErrUsageEventConflict against the row the fallback wrote.
+	window := reservationWindow
+	if window == "" {
+		window = s.now().UTC().Format("2006-01-02")
+	}
+	// ARM (#763 / seam finding P1-2): durably record the money effect BEFORE
+	// attempting it. Everything below this line — the settle, the fallback,
+	// the refund — can fail logically, crash the process, or lose power; the
+	// effect record survives all three and the recovery pass
+	// (settlement_journal_recovery.go) re-drives it.
+	//
+	// The reservation is the PRE-DISPATCH arm and already exists, so v1
+	// journals only this after-commit effect: it is the single point where
+	// the buyer has been served and the durable bill has not been written.
+	journalKey := journal.Key{
+		AccountID: subject.AccountID,
+		RequestID: requestID(r),
+		Effect:    journal.EffectSettle,
+	}
+	armed := true
+	if journalErr := s.journal.WriteEffect(journal.Record{
+		AccountID:        journalKey.AccountID,
+		RequestID:        journalKey.RequestID,
+		Effect:           journalKey.Effect,
+		WindowDate:       window,
+		PromptTokens:     prompt,
+		CompletionTokens: completion,
+		TotalTokens:      prompt + completion,
+		MaxTotalTokens:   maxTotal,
+		TokenSource:      source,
+		Outcome:          outcome,
+		DemoIdentity:     subject.DemoIdentity,
+		DemoTokenHash:    subject.DemoTokenHash,
+	}); journalErr != nil {
+		// FAIL-OPEN, deliberately. The buyer already has the bytes; refusing
+		// to settle because the journal is unavailable would turn a
+		// durability outage into a billing outage. The write-failure metric
+		// and this log are the signal that recovery coverage is degraded for
+		// this request. Pinned by TestSettlementJournal_WriteFailureDoesNotBlockSettle.
+		armed = false
+		slog.Error("gateway settlement journal effect write failed; settling anyway (recovery coverage lost for this request)",
+			"request_id", journalKey.RequestID,
+			"account_id", journalKey.AccountID,
+			"source", source,
+			"outcome", outcome,
+			"error", journalErr,
+		)
+	}
 	if err := s.settleRequest(r, subject, prompt, completion, maxTotal, source, outcome); err != nil {
 		slog.Error("gateway settlement failed after response commit",
 			"request_id", requestID(r),
@@ -2176,15 +2233,9 @@ func (s *Server) settleAfterCommit(r *http.Request, subject usageSubject, prompt
 		// coordinator request_log), so the SPEC-005 mirror is
 		// unaffected by this fix.
 		//
-		// WINDOW: use the reservation window captured at admission
-		// time (not s.now()) so a stream that crosses UTC midnight
-		// settles against the SAME daily quota window the buyer's
-		// reservation was made against. ISS-187 R1 architect+code
-		// MAJOR.
-		window := reservationWindow
-		if window == "" {
-			window = s.now().UTC().Format("2006-01-02")
-		}
+		// The window is computed once above the arm — see the comment
+		// there for why it is the admission-time window (#187) and why
+		// it must be shared with the journal record (#763).
 		ev := storage.UsageEvent{
 			RequestID:        requestID(r),
 			AccountID:        subject.AccountID,
@@ -2204,9 +2255,18 @@ func (s *Server) settleAfterCommit(r *http.Request, subject usageSubject, prompt
 			// collision detected via row-mismatch verify inside
 			// EnsureUsageEvent. Log loudly and release the
 			// reservation hold so the buyer's quota is not held
-			// forever. The audit row is lost; operators must
-			// reconcile from coordinator-side request_log.
-			slog.Error("gateway SPEC-006 § 17.7 fallback usage_events insert failed",
+			// forever.
+			//
+			// #763: this branch does NOT seal. The effect record
+			// armed above stays unsealed on purpose, so the
+			// recovery pass re-drives it once the underlying
+			// pathology clears. Pre-#763 the audit row was simply
+			// lost here and operators had to reconcile from the
+			// coordinator-side request_log; now that reconciliation
+			// is deferred to the settlement journal, with the
+			// request_log as the backstop for an effect that
+			// eventually quarantines.
+			slog.Error("gateway SPEC-006 § 17.7 fallback usage_events insert failed; audit row deferred to the settlement journal",
 				"request_id", requestID(r),
 				"account_id", subject.AccountID,
 				"source", source,
@@ -2257,12 +2317,34 @@ func (s *Server) settleAfterCommit(r *http.Request, subject usageSubject, prompt
 		// DB error, leaving the reservation row in 'active' state),
 		// the call releases the quota hold.
 		_ = s.store.RefundReservation(context.Background(), subject.AccountID, requestID(r), s.now().Unix())
+		// SEAL (#763): the durable bill exists (usage_events) and the hold is
+		// released, so the effect is complete and must never be re-driven.
+		//
+		// Sealing LAST — after the refund rather than immediately after
+		// EnsureUsageEvent — keeps every crash window recoverable: a crash
+		// before the seal re-drives into EnsureUsageEvent (payload matches →
+		// nil) and RefundReservation (no-op), which is exactly this branch
+		// again. Sealing before the refund would instead leave a quota hold
+		// that only the reaper clears.
+		if armed {
+			s.sealSettlementEffect(journalKey, journal.SealUsageEvent)
+		}
 		slog.Warn("gateway settlement used SPEC-006 § 17.7 fallback usage_events insert (settle_path failure)",
 			"request_id", requestID(r),
 			"account_id", subject.AccountID,
 			"outcome", outcome,
 			"settle_error", err.Error(),
 		)
+		return
+	}
+	// The normal path: SettleReservation wrote the usage_events row and
+	// closed the reservation in one transaction. Seal the effect (#763).
+	// A seal lost to a crash here is harmless: the re-drive finds the
+	// reservation terminal, EnsureUsageEvent matches the row SettleReservation
+	// already wrote, and the effect seals then — no second bill. That is what
+	// TestSettlementJournal_SettleLandedButSealLost pins.
+	if armed {
+		s.sealSettlementEffect(journalKey, journal.SealSettled)
 	}
 }
 

--- a/phase5-gateway/internal/router/chat_proxy.go
+++ b/phase5-gateway/internal/router/chat_proxy.go
@@ -2316,7 +2316,7 @@ func (s *Server) settleAfterCommit(r *http.Request, subject usageSubject, prompt
 		// IS still active (e.g., settleRequest failed on a transient
 		// DB error, leaving the reservation row in 'active' state),
 		// the call releases the quota hold.
-		_ = s.store.RefundReservation(context.Background(), subject.AccountID, requestID(r), s.now().Unix())
+		refundErr := s.store.RefundReservation(context.Background(), subject.AccountID, requestID(r), s.now().Unix())
 		// SEAL (#763): the durable bill exists (usage_events) and the hold is
 		// released, so the effect is complete and must never be re-driven.
 		//
@@ -2325,8 +2325,17 @@ func (s *Server) settleAfterCommit(r *http.Request, subject usageSubject, prompt
 		// before the seal re-drives into EnsureUsageEvent (payload matches →
 		// nil) and RefundReservation (no-op), which is exactly this branch
 		// again. Sealing before the refund would instead leave a quota hold
-		// that only the reaper clears.
-		if armed {
+		// that only the reaper clears. And the seal is GATED on the refund
+		// (audit R1, architect MEDIUM): sealing past a failed refund would
+		// suppress recovery's retry and leave DailyUsage double-counting the
+		// usage row plus the still-active hold until the reaper.
+		if refundErr != nil {
+			slog.Warn("gateway settlement §17.7 refund failed; leaving journal effect unsealed for recovery",
+				"request_id", requestID(r),
+				"account_id", subject.AccountID,
+				"error", refundErr.Error(),
+			)
+		} else if armed {
 			s.sealSettlementEffect(journalKey, journal.SealUsageEvent)
 		}
 		slog.Warn("gateway settlement used SPEC-006 § 17.7 fallback usage_events insert (settle_path failure)",

--- a/phase5-gateway/internal/router/seam_harness_test.go
+++ b/phase5-gateway/internal/router/seam_harness_test.go
@@ -28,6 +28,7 @@ import (
 	"time"
 
 	"github.com/augstar/macprovider-gateway/internal/config"
+	"github.com/augstar/macprovider-gateway/internal/settlement/journal"
 	"github.com/augstar/macprovider-gateway/internal/storage"
 	"github.com/augstar/macprovider-gateway/internal/storage/sqlite"
 )
@@ -378,14 +379,26 @@ func TestSeamH4_NoPaidWhileTimedOut(t *testing.T) {
 		"cross-path race, testable only once a single-terminal-arbiter actor exists.")
 }
 
-// ---- H7 · settlement not crash-durable (INV-8) -----------------------------
-// EXPECTED: PASS = confirms the GAP. On the STREAMING after-commit path the buyer has
-// already received a committed 200 stream; if SettleReservation AND the EnsureUsageEvent
-// fallback both fail (a crash/DB pathology between reserve and settle), the gateway logs,
-// refunds, and DROPS the usage row (chat_proxy.go:1974-1993) — the buyer got the tokens,
-// nobody is billed, and there is no durable journal to reconcile from. (Non-streaming just
-// 500s the buyer, so the committed-success-with-dropped-row case is streaming-specific.)
-func TestSeamH7_SettlementNotCrashDurable(t *testing.T) {
+// ---- H7 · settlement is crash-durable via the journal (INV-8) --------------
+// EXPECTED: PASS = certifies the P1-2 FIX (issue #763). This test used to be
+// TestSeamH7_SettlementNotCrashDurable and asserted the buggy-today behavior: on the
+// STREAMING after-commit path the buyer has already received a committed 200 stream, and
+// when SettleReservation AND the EnsureUsageEvent fallback both failed the gateway logged,
+// refunded, and DROPPED the usage row — tokens delivered, nobody billed, nothing to
+// reconcile from. (Non-streaming just 500s the buyer, so the committed-success-with-
+// dropped-row case is streaming-specific.)
+//
+// The scenario is deliberately unchanged — same spy, same double failure, same in-band
+// outcome (the in-band drop was never the bug; the PERMANENCE was). What flipped is what
+// happens next: the settle effect was journaled BEFORE the attempt, so a later process
+// re-drives it into a durable bill. The test therefore runs the recovery the production
+// loop runs (RecoverSettlementJournal, cmd/gateway startup + ticker) against a SECOND
+// Server over the SAME store and the SAME journal directory, with no failure spy — i.e.
+// the pathology cleared, exactly as after a restart.
+//
+// A regression that stops journaling the effect, seals it prematurely, or breaks the
+// re-drive ladder turns this red again.
+func TestSeamH7_SettlementRecoveredFromJournal(t *testing.T) {
 	// Streaming upstream: a provider usage chunk then [DONE] → committed 200, settlement
 	// runs after commit via settleAfterCommit.
 	client := seamStreamingUpstream(func(pw *io.PipeWriter) {
@@ -397,9 +410,14 @@ func TestSeamH7_SettlementNotCrashDurable(t *testing.T) {
 	// build a fresh gateway over the SAME store/db (chat_proxy_retry_test.go:503-504 pattern).
 	_, store, dbPath, cfg := newTestHarnessConfig(t, fakeOAuth{}, func(cfg *config.Config) {
 		cfg.Coordinator.BuyerURL = "http://coordinator.test"
+		// The recovery pass below acts on an effect written moments ago; the
+		// grace window has its own coverage in
+		// TestSettlementJournal_GraceWindowSkipsYoungEntries.
+		cfg.Settlement.JournalRecoveryGraceSeconds = 0
 	}, WithHTTPClient(client))
+	jnl := openTestJournal(t, cfg)
 	spy := &settleFailSpyStore{Store: store}
-	h := New(cfg, spy, fakeOAuth{}, WithNow(fixedNow), WithHTTPClient(client)).Handler()
+	h := New(cfg, spy, fakeOAuth{}, WithNow(fixedNow), WithHTTPClient(client), WithSettlementJournal(jnl)).Handler()
 	key := createAccountAndKey(t, store, cfg, "acct_h7")
 
 	body := `{"model":"llama","stream":true,"max_tokens":20,"messages":[{"role":"user","content":"hi"}]}`
@@ -408,18 +426,88 @@ func TestSeamH7_SettlementNotCrashDurable(t *testing.T) {
 		t.Fatalf("expected a committed 200 stream despite settle failure; got %d body=%s", resp.Code, resp.Body.String())
 	}
 
+	// IN-BAND: unchanged. The double failure still refunds and still writes no usage row
+	// in the request's own goroutine — there is nothing left to try in-band.
 	got := gatewaySettlementSnapshot(t, dbPath, "acct_h7")
 	if got.usageRows != 0 {
-		t.Fatalf("expected the audit row to be DROPPED (INV-8 gap); usageRows=%d — if this is 1, "+
-			"settlement became crash-durable; update the audit", got.usageRows)
+		t.Fatalf("in-band usageRows=%d want 0 — the double-failure branch must NOT invent an "+
+			"in-band bill; the journal is what makes it recoverable", got.usageRows)
 	}
 	if got.refundedRows != 1 || got.activeRows != 0 || got.activeReserved != 0 {
-		t.Fatalf("expected clean refund after the drop; got %+v (want refunded=1 active=0 reserved=0)", got)
+		t.Fatalf("expected clean refund after the in-band drop; got %+v (want refunded=1 active=0 reserved=0)", got)
 	}
-	t.Logf("CONFIRMED FINDING (INV-8 gap): buyer received a committed 200 stream, but the "+
-		"settlement double-failure DROPPED the usage row (usageRows=0) and refunded — "+
-		"tokens delivered, nobody billed, no durable journal (chat_proxy.go:1974-1993; "+
-		"fix = a durable append-only settlement journal).")
+
+	// THE FIX: the effect is on disk, unsealed, with the full billing payload.
+	scan, err := jnl.Scan()
+	if err != nil {
+		t.Fatalf("journal Scan: %v", err)
+	}
+	if len(scan.Unsealed) != 1 {
+		t.Fatalf("REGRESSION (INV-8): journal holds %d unsealed effects, want exactly 1 — the "+
+			"after-commit settle was not armed, so the dropped bill is unrecoverable again", len(scan.Unsealed))
+	}
+	effect := scan.Unsealed[0]
+	if effect.AccountID != "acct_h7" || effect.RequestID != "77777777-7777-4777-8777-777777777777" {
+		t.Fatalf("journaled effect identity=%s/%s want acct_h7/7777…", effect.AccountID, effect.RequestID)
+	}
+	if effect.PromptTokens != 8 || effect.CompletionTokens != 12 || effect.TotalTokens != 20 ||
+		effect.TokenSource != "provider_reported" {
+		t.Fatalf("journaled payload=%+v want 8/12/20 provider_reported — the record must reproduce "+
+			"the usage row the settle would have written", effect)
+	}
+	if effect.WindowDate != fixedNow().UTC().Format("2006-01-02") {
+		t.Fatalf("journaled window_date=%q want the admission-time window %q",
+			effect.WindowDate, fixedNow().UTC().Format("2006-01-02"))
+	}
+
+	// RECOVERY: a second Server over the SAME store (no spy — the pathology cleared) and
+	// the SAME journal directory, running exactly what cmd/gateway runs at startup and on
+	// its ticker.
+	recovered := New(cfg, store, fakeOAuth{}, WithNow(fixedNow), WithSettlementJournal(jnl))
+	summary, err := recovered.RecoverSettlementJournal(context.Background(), 0)
+	if err != nil {
+		t.Fatalf("RecoverSettlementJournal: %v", err)
+	}
+	if summary.Recovered != 1 || summary.Quarantined != 0 || summary.Errors != 0 {
+		t.Fatalf("recovery summary=%+v want recovered=1 quarantined=0 errors=0", summary)
+	}
+
+	after := gatewaySettlementSnapshot(t, dbPath, "acct_h7")
+	if after.usageRows != 1 {
+		t.Fatalf("REGRESSION (INV-8): after recovery usageRows=%d want 1 — the delivered request is "+
+			"still unbilled, which is the whole finding", after.usageRows)
+	}
+	if used := billedTokens(t, h, key); used != 20 {
+		t.Fatalf("recovered bill=%v want 20 (the tokens the buyer actually received)", used)
+	}
+	if after.refundedRows != 1 {
+		t.Fatalf("state=%+v want the original refund to STAND — recovery restores the audit row via the "+
+			"§ 17.7 fallback, it does not resurrect the reservation", after)
+	}
+	sealResult := ""
+	for _, rec := range journalRecords(t, jnl.Dir()) {
+		if rec.Kind == journal.KindSeal && rec.RequestID == "77777777-7777-4777-8777-777777777777" {
+			sealResult = rec.Result
+		}
+	}
+	if sealResult != journal.SealUsageEvent {
+		t.Fatalf("seal result=%q want %q", sealResult, journal.SealUsageEvent)
+	}
+
+	// IDEMPOTENCE: recovery runs on a ticker, so a second pass is the normal case.
+	second, err := recovered.RecoverSettlementJournal(context.Background(), 0)
+	if err != nil {
+		t.Fatalf("second RecoverSettlementJournal: %v", err)
+	}
+	if second.Recovered != 0 || second.Scanned != 0 {
+		t.Fatalf("second pass summary=%+v want a no-op", second)
+	}
+	if rows, total := usageTokenTotals(t, dbPath, "acct_h7"); rows != 1 || total != 20 {
+		t.Fatalf("DOUBLE BILL on the second recovery pass: rows=%d total=%d", rows, total)
+	}
+	t.Logf("PASS (P1-2 FIXED, #763): the settlement double-failure still drops the row in-band, but "+
+		"the effect journaled before the attempt let a later pass restore it — usageRows=1, billed=20, "+
+		"refund intact, seal=%q, second pass a no-op.", sealResult)
 }
 
 // settleFailSpyStore forces the settleAfterCommit double-failure branch: SettleReservation

--- a/phase5-gateway/internal/router/server.go
+++ b/phase5-gateway/internal/router/server.go
@@ -65,6 +65,12 @@ type Server struct {
 	// idlessDedupe backs the #762 id-less retry replay/coalesce cache. It is
 	// per-process and non-authoritative; see idless_dedupe.go.
 	idlessDedupe *idlessDedupeIndex
+	// journal is the durable settlement journal (#763). Never nil — New
+	// installs a discard implementation when cmd/gateway did not register a
+	// real one — so the money path can call it unguarded.
+	journal SettlementJournal
+	// journalAttempts bounds conflicted re-drives before quarantine.
+	journalAttempts *settlementJournalAttempts
 }
 
 // readStore returns the read-only view of the database. M2-4: this
@@ -171,6 +177,8 @@ func New(cfg config.Config, store Store, oauth auth.OAuthProvider, opts ...Optio
 		adminMetrics:     newAdminStateWriteMetrics(),
 		chatStartLimits:  newRequestRateLimiter(),
 		idlessDedupe:     newIdlessDedupeIndex(),
+		journal:          discardSettlementJournal{},
+		journalAttempts:  newSettlementJournalAttempts(),
 	}
 	for _, opt := range opts {
 		opt(s)
@@ -238,6 +246,7 @@ func (s *Server) handleMetrics(w http.ResponseWriter, r *http.Request) {
 	_, _ = w.Write([]byte(s.retry503Metrics.prometheus()))
 	_, _ = w.Write([]byte(s.adminMetrics.prometheus()))
 	_, _ = w.Write([]byte(s.idlessDedupe.prometheus()))
+	_, _ = w.Write([]byte(s.journal.MetricsSnapshot().Prometheus()))
 }
 
 func (s *Server) middleware(next http.Handler) http.Handler {

--- a/phase5-gateway/internal/router/settlement_journal.go
+++ b/phase5-gateway/internal/router/settlement_journal.go
@@ -1,0 +1,93 @@
+package router
+
+import (
+	"sync"
+	"time"
+
+	"github.com/augstar/macprovider-gateway/internal/settlement/journal"
+)
+
+// SettlementJournal is the router-local view of the durable settlement
+// journal (issue #763 / seam finding P1-2), in the same spirit as Store and
+// ReadStore: the router depends on the narrow behavior it needs, and
+// cmd/gateway supplies the real *journal.Journal.
+//
+// The journal is what makes an after-commit settlement recoverable. The
+// effect record is on stable storage BEFORE the settle attempt, so a settle
+// that fails logically, crashes the process, or loses power still leaves a
+// re-drivable record — the case the H7 tripwire used to certify as a
+// permanent loss.
+type SettlementJournal interface {
+	WriteEffect(rec journal.Record) error
+	WriteSeal(key journal.Key, result string) error
+	WriteQuarantine(key journal.Key, reason string, attempts int) error
+	Scan() (journal.ScanResult, error)
+	Prune(before time.Time) (int, error)
+	RecordRecovered(result string)
+	SetPending(unsealed, quarantined int64)
+	MetricsSnapshot() journal.Snapshot
+}
+
+// discardSettlementJournal is the no-op journal New falls back to when no
+// journal is registered (unit tests, `gateway -check`). It is deliberately a
+// silent no-op rather than an error: the settle path must never fail because
+// journaling is unavailable. Production cannot reach it — cmd/gateway always
+// passes a real journal and exits if it cannot open one, config.Validate
+// requires settlement.journal_enabled, and TestGatewayRouterCarriesSettlementJournal
+// pins the wiring.
+type discardSettlementJournal struct{}
+
+func (discardSettlementJournal) WriteEffect(journal.Record) error    { return nil }
+func (discardSettlementJournal) WriteSeal(journal.Key, string) error { return nil }
+func (discardSettlementJournal) WriteQuarantine(journal.Key, string, int) error {
+	return nil
+}
+func (discardSettlementJournal) Scan() (journal.ScanResult, error) { return journal.ScanResult{}, nil }
+func (discardSettlementJournal) Prune(time.Time) (int, error)      { return 0, nil }
+func (discardSettlementJournal) RecordRecovered(string)            {}
+func (discardSettlementJournal) SetPending(int64, int64)           {}
+func (discardSettlementJournal) MetricsSnapshot() journal.Snapshot {
+	return journal.Snapshot{}
+}
+
+// WithSettlementJournal registers the durable settlement journal.
+func WithSettlementJournal(j SettlementJournal) Option {
+	return func(s *Server) {
+		if j != nil {
+			s.journal = j
+		}
+	}
+}
+
+// settlementJournalAttempts counts conflicted re-drive attempts per effect
+// key. It is process-local on purpose: the counter only decides WHEN a
+// permanently-conflicted effect is quarantined, and a restart that resets it
+// merely delays the quarantine — it can never cause a double bill, because
+// every re-drive goes through the idempotent EnsureUsageEvent verify.
+type settlementJournalAttempts struct {
+	mu     sync.Mutex
+	counts map[journal.Key]int
+}
+
+func newSettlementJournalAttempts() *settlementJournalAttempts {
+	return &settlementJournalAttempts{counts: map[journal.Key]int{}}
+}
+
+func (a *settlementJournalAttempts) next(key journal.Key) int {
+	if a == nil {
+		return 1
+	}
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	a.counts[key]++
+	return a.counts[key]
+}
+
+func (a *settlementJournalAttempts) clear(key journal.Key) {
+	if a == nil {
+		return
+	}
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	delete(a.counts, key)
+}

--- a/phase5-gateway/internal/router/settlement_journal_recovery.go
+++ b/phase5-gateway/internal/router/settlement_journal_recovery.go
@@ -252,9 +252,21 @@ func (s *Server) redriveSettlementEffect(ctx context.Context, rec journal.Record
 		}
 	}
 	// Release any still-active hold so DailyUsage does not double-count the
-	// buyer's quota. No-op when the reservation is already terminal, which is
-	// the common case here.
-	_ = s.store.RefundReservation(ctx, rec.AccountID, rec.RequestID, s.now().Unix())
+	// buyer's quota. An already-terminal/missing reservation surfaces as
+	// ErrReservationNotFound (the UPDATE matches only status='active' rows)
+	// and is the benign common case; anything else is a real DB failure. The seal is GATED on it (audit R2, code
+	// MEDIUM — the mirror of the settleAfterCommit gate): sealing past a
+	// failed refund would suppress this very re-drive and leave the active
+	// hold double-counting until the reaper.
+	if refundErr := s.store.RefundReservation(ctx, rec.AccountID, rec.RequestID, s.now().Unix()); refundErr != nil &&
+		!errors.Is(refundErr, storage.ErrReservationNotFound) && !errors.Is(refundErr, storage.ErrReservationTerminal) {
+		slog.Warn("gateway settlement journal re-drive refund failed; leaving effect unsealed",
+			"account_id", rec.AccountID,
+			"request_id", rec.RequestID,
+			"error", refundErr,
+		)
+		return journal.RecoveredRetry, nil
+	}
 	s.sealSettlementEffect(key, journal.SealUsageEvent)
 	s.journalAttempts.clear(key)
 	slog.Warn("gateway settlement journal recovered a dropped settlement via the SPEC-006 § 17.7 fallback",

--- a/phase5-gateway/internal/router/settlement_journal_recovery.go
+++ b/phase5-gateway/internal/router/settlement_journal_recovery.go
@@ -1,0 +1,296 @@
+package router
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"time"
+
+	"github.com/augstar/macprovider-gateway/internal/settlement/journal"
+	"github.com/augstar/macprovider-gateway/internal/storage"
+)
+
+// Settlement-journal recovery (issue #763 / seam finding P1-2).
+//
+// The journal's effect records are only worth writing if something re-drives
+// them. This is that something. It mirrors the SPEC-022 reconciler
+// (settlement_reconcile.go) in shape — a bounded, idempotent pass exposed as
+// a method so cmd/gateway can run it once at startup and then on a ticker —
+// but it is deliberately a SEPARATE loop with its own knobs. The SPEC-022
+// reconciler only ever sees reservations that are still active with
+// settlement_hold=1; the effects this pass recovers are precisely the ones
+// that are invisible to it (already refunded, or with a reservation row that
+// is gone).
+//
+// STARTUP IS NOT ENOUGH. The failure that motivated the journal (H7) is a
+// LOGICAL double failure inside a running process, not a crash: nothing would
+// ever restart the gateway to trigger a startup-only scan. Hence the periodic
+// loop.
+
+const (
+	defaultSettlementJournalRecoveryLimit = 100
+	maxSettlementJournalRecoveryLimit     = 500
+	// settlementJournalMaxConflictAttempts bounds how many passes an
+	// ErrUsageEventConflict effect is retried before it is quarantined.
+	// A conflict means the durable row disagrees with the journaled payload,
+	// which no amount of retrying resolves; the counter exists so a
+	// transient-looking conflict is not quarantined on its first sighting.
+	settlementJournalMaxConflictAttempts = 10
+)
+
+// SettlementJournalRecoverySummary reports one recovery pass.
+type SettlementJournalRecoverySummary struct {
+	// Scanned counts effects the pass attempted to re-drive.
+	Scanned int `json:"scanned"`
+	// Recovered counts effects that reached a durable terminal in this pass
+	// (settled + usage_event).
+	Recovered   int `json:"recovered"`
+	Settled     int `json:"settled"`
+	UsageEvents int `json:"usage_events"`
+	Quarantined int `json:"quarantined"`
+	// Skipped counts effects held back by the grace window.
+	Skipped int `json:"skipped"`
+	// Retried counts conflicted effects left for a later pass.
+	Retried int `json:"retried"`
+	Errors  int `json:"errors"`
+	Pruned  int `json:"pruned"`
+	// Malformed and Unsealed describe the journal as scanned, before the
+	// pass ran.
+	Malformed int `json:"malformed"`
+	Unsealed  int `json:"unsealed"`
+}
+
+// RecoverSettlementJournal re-drives unsealed settlement effects.
+//
+// It is idempotent by construction: every ladder rung is an idempotent store
+// call keyed by (account_id, request_id), so running it twice — or racing it
+// against the SPEC-022 reconciler — cannot bill twice. A second pass over an
+// already-recovered journal recovers nothing.
+func (s *Server) RecoverSettlementJournal(ctx context.Context, limit int) (SettlementJournalRecoverySummary, error) {
+	if limit <= 0 {
+		limit = defaultSettlementJournalRecoveryLimit
+	}
+	if limit > maxSettlementJournalRecoveryLimit {
+		limit = maxSettlementJournalRecoveryLimit
+	}
+	scan, err := s.journal.Scan()
+	if err != nil {
+		return SettlementJournalRecoverySummary{}, err
+	}
+	summary := SettlementJournalRecoverySummary{
+		Malformed: scan.Malformed,
+		Unsealed:  len(scan.Unsealed),
+	}
+	s.journal.SetPending(int64(len(scan.Unsealed)), int64(scan.Quarantined))
+
+	now := s.now().UTC()
+	grace := time.Duration(s.cfg.Settlement.JournalRecoveryGraceSeconds) * time.Second
+	for _, rec := range scan.Unsealed {
+		if summary.Scanned >= limit {
+			break
+		}
+		if ctx.Err() != nil {
+			break
+		}
+		// GRACE WINDOW: an effect written moments ago is probably still in
+		// flight on its request goroutine — the arm happens BEFORE the
+		// settle. Re-driving it there would race the live settle for the
+		// same reservation. Waiting costs nothing: the effect is durable.
+		if grace > 0 && now.Sub(rec.WrittenAt()) < grace {
+			summary.Skipped++
+			continue
+		}
+		summary.Scanned++
+		result, err := s.redriveSettlementEffect(ctx, rec)
+		if err != nil {
+			summary.Errors++
+			s.journal.RecordRecovered(journal.RecoveredError)
+			slog.Error("gateway settlement journal re-drive failed; effect stays unsealed for the next pass",
+				"account_id", rec.AccountID,
+				"request_id", rec.RequestID,
+				"effect", rec.Effect,
+				"error", err,
+			)
+			continue
+		}
+		s.journal.RecordRecovered(result)
+		switch result {
+		case journal.RecoveredSettled:
+			summary.Settled++
+			summary.Recovered++
+		case journal.RecoveredUsageEvent:
+			summary.UsageEvents++
+			summary.Recovered++
+		case journal.RecoveredQuarantined:
+			summary.Quarantined++
+		case journal.RecoveredRetry:
+			summary.Retried++
+		}
+	}
+
+	if retention := time.Duration(s.cfg.Settlement.JournalRetentionHours) * time.Hour; retention > 0 {
+		pruned, err := s.journal.Prune(now.Add(-retention))
+		if err != nil {
+			slog.Warn("gateway settlement journal prune failed", "error", err)
+		}
+		summary.Pruned = pruned
+	}
+	return summary, nil
+}
+
+// redriveSettlementEffect replays one journaled effect through the SAME
+// ladder settleAfterCommit uses, in the same order:
+//
+//	SettleReservation (or SettleDemoReservation)      → seal "settled"
+//	  ↳ reservation missing/terminal:
+//	     EnsureUsageEvent (+EnsureDemoUsageEvent)
+//	     then RefundReservation (no-op when terminal)  → seal "usage_event"
+//	       ↳ ErrUsageEventConflict: NO seal, quarantine after N attempts
+//
+// The payload comes verbatim from the journal, which is why the effect record
+// must carry every field EnsureUsageEvent's verify compares (created_at
+// excluded): a re-drive of an effect whose settle ALREADY landed must match
+// the existing row and return nil, not conflict. That is the no-double-bill
+// proof (TestSettlementJournal_SettleLandedButSealLost).
+func (s *Server) redriveSettlementEffect(ctx context.Context, rec journal.Record) (string, error) {
+	key := rec.Key()
+	if rec.Effect != journal.EffectSettle {
+		// A future effect kind written by a newer build. Leave it alone
+		// rather than guessing at its ladder.
+		return journal.RecoveredRetry, nil
+	}
+	if !rec.TokensConsistent() {
+		// The store rejects total != prompt+completion, so this effect can
+		// never settle. Retrying forever would pin its segment; quarantine
+		// makes it operator-visible instead.
+		return s.quarantineSettlementEffect(key, "token_totals_inconsistent", 0), nil
+	}
+
+	settlement := storage.ReservationSettlement{
+		AccountID:        rec.AccountID,
+		RequestID:        rec.RequestID,
+		PromptTokens:     rec.PromptTokens,
+		CompletionTokens: rec.CompletionTokens,
+		TotalTokens:      rec.TotalTokens,
+		MaxTotalTokens:   rec.MaxTotalTokens,
+		TokenSource:      rec.TokenSource,
+		Outcome:          rec.Outcome,
+		SettledAt:        s.now(),
+	}
+	var settleErr error
+	if rec.DemoIdentity != "" {
+		settleErr = s.store.SettleDemoReservation(ctx, settlement, storage.DemoUsageEvent{
+			RequestID:     rec.RequestID,
+			ClientIP:      rec.DemoIdentity,
+			DemoTokenHash: rec.DemoTokenHash,
+			CreatedAt:     s.now(),
+		})
+	} else {
+		settleErr = s.store.SettleReservation(ctx, settlement)
+	}
+	if settleErr == nil {
+		s.sealSettlementEffect(key, journal.SealSettled)
+		s.journalAttempts.clear(key)
+		return journal.RecoveredSettled, nil
+	}
+	if !errors.Is(settleErr, storage.ErrReservationNotFound) && !errors.Is(settleErr, storage.ErrReservationTerminal) {
+		// Transient (or unknown) — keep the effect unsealed and try again.
+		return "", settleErr
+	}
+
+	ev := storage.UsageEvent{
+		RequestID:        rec.RequestID,
+		AccountID:        rec.AccountID,
+		DemoIdentity:     rec.DemoIdentity,
+		WindowDate:       rec.WindowDate,
+		PromptTokens:     rec.PromptTokens,
+		CompletionTokens: rec.CompletionTokens,
+		TotalTokens:      rec.TotalTokens,
+		TokenSource:      rec.TokenSource,
+		Outcome:          rec.Outcome,
+		CreatedAt:        s.now(),
+	}
+	if err := s.store.EnsureUsageEvent(ctx, ev); err != nil {
+		if !errors.Is(err, storage.ErrUsageEventConflict) {
+			return "", err
+		}
+		attempts := s.journalAttempts.next(key)
+		if attempts < settlementJournalMaxConflictAttempts {
+			slog.Warn("gateway settlement journal re-drive conflicts with the durable usage row; retrying",
+				"account_id", rec.AccountID,
+				"request_id", rec.RequestID,
+				"attempts", attempts,
+				"max_attempts", settlementJournalMaxConflictAttempts,
+			)
+			return journal.RecoveredRetry, nil
+		}
+		return s.quarantineSettlementEffect(key, "usage_event_conflict", attempts), nil
+	}
+	if rec.DemoIdentity != "" {
+		if demoErr := s.store.EnsureDemoUsageEvent(ctx, storage.DemoUsageEvent{
+			RequestID:     rec.RequestID,
+			ClientIP:      rec.DemoIdentity,
+			DemoTokenHash: rec.DemoTokenHash,
+			WindowDate:    rec.WindowDate,
+			TotalTokens:   rec.TotalTokens,
+			CreatedAt:     s.now(),
+		}); demoErr != nil {
+			// Non-fatal, exactly as in settleAfterCommit: usage_events is the
+			// load-bearing money-path row.
+			slog.Warn("gateway settlement journal re-drive demo_usage_events insert failed (usage_events row is OK)",
+				"account_id", rec.AccountID,
+				"request_id", rec.RequestID,
+				"demo_identity", rec.DemoIdentity,
+				"error", demoErr,
+			)
+		}
+	}
+	// Release any still-active hold so DailyUsage does not double-count the
+	// buyer's quota. No-op when the reservation is already terminal, which is
+	// the common case here.
+	_ = s.store.RefundReservation(ctx, rec.AccountID, rec.RequestID, s.now().Unix())
+	s.sealSettlementEffect(key, journal.SealUsageEvent)
+	s.journalAttempts.clear(key)
+	slog.Warn("gateway settlement journal recovered a dropped settlement via the SPEC-006 § 17.7 fallback",
+		"account_id", rec.AccountID,
+		"request_id", rec.RequestID,
+		"window_date", rec.WindowDate,
+		"total_tokens", rec.TotalTokens,
+		"token_source", rec.TokenSource,
+		"outcome", rec.Outcome,
+	)
+	return journal.RecoveredUsageEvent, nil
+}
+
+func (s *Server) sealSettlementEffect(key journal.Key, result string) {
+	if err := s.journal.WriteSeal(key, result); err != nil {
+		// A lost seal costs one idempotent re-drive on the next pass, never
+		// a bill — the whole reason seals are not fsynced.
+		slog.Warn("gateway settlement journal seal write failed; the effect will be re-driven idempotently",
+			"account_id", key.AccountID,
+			"request_id", key.RequestID,
+			"result", result,
+			"error", err,
+		)
+	}
+}
+
+func (s *Server) quarantineSettlementEffect(key journal.Key, reason string, attempts int) string {
+	if err := s.journal.WriteQuarantine(key, reason, attempts); err != nil {
+		slog.Error("gateway settlement journal quarantine write failed",
+			"account_id", key.AccountID,
+			"request_id", key.RequestID,
+			"reason", reason,
+			"error", err,
+		)
+	}
+	s.journalAttempts.clear(key)
+	slog.Error("CRITICAL gateway settlement journal quarantined an unrecoverable effect; reconcile from the coordinator request_log",
+		"account_id", key.AccountID,
+		"request_id", key.RequestID,
+		"effect", key.Effect,
+		"reason", reason,
+		"attempts", attempts,
+	)
+	return journal.RecoveredQuarantined
+}

--- a/phase5-gateway/internal/router/settlement_journal_recovery.go
+++ b/phase5-gateway/internal/router/settlement_journal_recovery.go
@@ -220,6 +220,19 @@ func (s *Server) redriveSettlementEffect(ctx context.Context, rec journal.Record
 		if !errors.Is(err, storage.ErrUsageEventConflict) {
 			return "", err
 		}
+		// Audit R2 (architect MEDIUM): a conflicting durable row means SOME
+		// bill exists for this request — the money question goes to
+		// retry/quarantine below, but the quota HOLD must not keep
+		// double-counting against the buyer while it does. Best-effort
+		// release; already-terminal is the benign sentinel.
+		if refundErr := s.store.RefundReservation(ctx, rec.AccountID, rec.RequestID, s.now().Unix()); refundErr != nil &&
+			!errors.Is(refundErr, storage.ErrReservationNotFound) && !errors.Is(refundErr, storage.ErrReservationTerminal) {
+			slog.Warn("gateway settlement journal conflict-path refund failed; hold released on a later pass",
+				"account_id", rec.AccountID,
+				"request_id", rec.RequestID,
+				"error", refundErr,
+			)
+		}
 		attempts := s.journalAttempts.next(key)
 		if attempts < settlementJournalMaxConflictAttempts {
 			slog.Warn("gateway settlement journal re-drive conflicts with the durable usage row; retrying",

--- a/phase5-gateway/internal/router/settlement_journal_recovery.go
+++ b/phase5-gateway/internal/router/settlement_journal_recovery.go
@@ -193,10 +193,16 @@ func (s *Server) redriveSettlementEffect(ctx context.Context, rec journal.Record
 		s.journalAttempts.clear(key)
 		return journal.RecoveredSettled, nil
 	}
-	if !errors.Is(settleErr, storage.ErrReservationNotFound) && !errors.Is(settleErr, storage.ErrReservationTerminal) {
-		// Transient (or unknown) — keep the effect unsealed and try again.
-		return "", settleErr
-	}
+	// Audit R1 (code HIGH): do NOT bail out on an unclassified settle error.
+	// The §17.7 crash window (EnsureUsageEvent succeeded, crash before the
+	// refund) leaves an ACTIVE reservation plus an existing usage row, so
+	// SettleReservation fails on the usage_events PK with an error that is
+	// neither NotFound nor Terminal — and would wedge here forever while
+	// DailyUsage double-counts. Fall through to the idempotent rung instead:
+	// EnsureUsageEvent verifies-or-inserts, the refund releases the hold, and
+	// the seal lands. If the settle failure was transient DB pathology, the
+	// fallback rung either completes the equivalent §17.7 outcome or fails
+	// too, leaving the effect unsealed for the next tick.
 
 	ev := storage.UsageEvent{
 		RequestID:        rec.RequestID,

--- a/phase5-gateway/internal/router/settlement_journal_recovery.go
+++ b/phase5-gateway/internal/router/settlement_journal_recovery.go
@@ -227,11 +227,17 @@ func (s *Server) redriveSettlementEffect(ctx context.Context, rec journal.Record
 		// release; already-terminal is the benign sentinel.
 		if refundErr := s.store.RefundReservation(ctx, rec.AccountID, rec.RequestID, s.now().Unix()); refundErr != nil &&
 			!errors.Is(refundErr, storage.ErrReservationNotFound) && !errors.Is(refundErr, storage.ErrReservationTerminal) {
-			slog.Warn("gateway settlement journal conflict-path refund failed; hold released on a later pass",
+			// Audit R3 (architect MEDIUM): a failed hold release must NOT
+			// consume a conflict attempt — quarantining on the final attempt
+			// with the hold still active would suppress the re-drive that
+			// releases it. Retry without counting; the conflict clock only
+			// advances once the hold is off the books.
+			slog.Warn("gateway settlement journal conflict-path refund failed; retrying before counting the attempt",
 				"account_id", rec.AccountID,
 				"request_id", rec.RequestID,
 				"error", refundErr,
 			)
+			return journal.RecoveredRetry, nil
 		}
 		attempts := s.journalAttempts.next(key)
 		if attempts < settlementJournalMaxConflictAttempts {

--- a/phase5-gateway/internal/router/settlement_journal_recovery_test.go
+++ b/phase5-gateway/internal/router/settlement_journal_recovery_test.go
@@ -866,3 +866,42 @@ func TestSettlementJournal_RecoveryRefundFailureRetriesBeforeSealing(t *testing.
 		t.Fatalf("still unsealed after healthy recovery")
 	}
 }
+
+// TestSettlementJournal_ConflictPathReleasesActiveHold pins the audit R2
+// architect MEDIUM: when the durable usage row conflicts with the journaled
+// payload, the money question goes to retry/quarantine — but the still-active
+// reservation hold must be released immediately, not left double-counting
+// against the buyer's quota until the reaper.
+func TestSettlementJournal_ConflictPathReleasesActiveHold(t *testing.T) {
+	srv, store, dbPath, jnl, _ := newJournalHarness(t, nil)
+	seedJournalReservation(t, store, "acct_confhold", "req-confhold", 100)
+	rec := journalSettleEffect("acct_confhold", "req-confhold")
+	if err := jnl.WriteEffect(rec); err != nil {
+		t.Fatalf("WriteEffect: %v", err)
+	}
+	// A conflicting durable row (different totals), reservation still ACTIVE.
+	if err := store.EnsureUsageEvent(context.Background(), storage.UsageEvent{
+		RequestID: "req-confhold", AccountID: "acct_confhold",
+		WindowDate: rec.WindowDate, PromptTokens: rec.PromptTokens,
+		CompletionTokens: rec.CompletionTokens + 1, TotalTokens: rec.TotalTokens + 1,
+		TokenSource: rec.TokenSource, Outcome: rec.Outcome, CreatedAt: fixedNow(),
+	}); err != nil {
+		t.Fatalf("EnsureUsageEvent seed: %v", err)
+	}
+
+	summary, err := srv.RecoverSettlementJournal(context.Background(), 0)
+	if err != nil {
+		t.Fatalf("RecoverSettlementJournal: %v", err)
+	}
+	if summary.Retried != 1 {
+		t.Fatalf("summary=%+v want the conflict to enter the retry path", summary)
+	}
+	snap := gatewaySettlementSnapshot(t, dbPath, "acct_confhold")
+	if snap.activeRows != 0 || snap.activeReserved != 0 {
+		t.Fatalf("conflict path left the hold active: %+v — quota double-counts until the reaper", snap)
+	}
+	// The money row stays operator-visible/unresolved: still unsealed.
+	if scan, _ := jnl.Scan(); len(scan.Unsealed) != 1 {
+		t.Fatalf("Unsealed=%d want 1 (conflict must not seal)", len(scan.Unsealed))
+	}
+}

--- a/phase5-gateway/internal/router/settlement_journal_recovery_test.go
+++ b/phase5-gateway/internal/router/settlement_journal_recovery_test.go
@@ -809,3 +809,60 @@ func TestSettlementJournal_RefundFailureLeavesEffectUnsealed(t *testing.T) {
 		t.Fatalf("effect still unsealed after recovery")
 	}
 }
+
+// TestSettlementJournal_RecoveryRefundFailureRetriesBeforeSealing pins the
+// audit R2 code MEDIUM — the mirror of the settleAfterCommit seal gate:
+// recovery's own refund step must not seal past a failed RefundReservation,
+// or this very re-drive is suppressed while the active hold double-counts.
+func TestSettlementJournal_RecoveryRefundFailureRetriesBeforeSealing(t *testing.T) {
+	srv, store, dbPath, jnl, cfg := newJournalHarness(t, nil)
+	_ = srv
+	seedJournalReservation(t, store, "acct_recrefund", "req-recrefund", 100)
+	rec := journalSettleEffect("acct_recrefund", "req-recrefund")
+	if err := jnl.WriteEffect(rec); err != nil {
+		t.Fatalf("WriteEffect: %v", err)
+	}
+	// Crash window: usage row exists, reservation still active.
+	if err := store.EnsureUsageEvent(context.Background(), storage.UsageEvent{
+		RequestID: "req-recrefund", AccountID: "acct_recrefund",
+		WindowDate: rec.WindowDate, PromptTokens: rec.PromptTokens,
+		CompletionTokens: rec.CompletionTokens, TotalTokens: rec.TotalTokens,
+		TokenSource: rec.TokenSource, Outcome: rec.Outcome, CreatedAt: fixedNow(),
+	}); err != nil {
+		t.Fatalf("EnsureUsageEvent seed: %v", err)
+	}
+
+	// First pass: refund fails → the effect must stay unsealed.
+	failing := New(cfg, &refundFailSpyStore{Store: store}, fakeOAuth{}, WithNow(fixedNow), WithSettlementJournal(jnl))
+	first, err := failing.RecoverSettlementJournal(context.Background(), 0)
+	if err != nil {
+		t.Fatalf("first pass: %v", err)
+	}
+	if first.UsageEvents != 0 {
+		t.Fatalf("first pass summary=%+v — must not count a recovery whose refund failed", first)
+	}
+	if scan, _ := jnl.Scan(); len(scan.Unsealed) != 1 {
+		t.Fatalf("effect sealed past a failed recovery refund (Unsealed=%d want 1)", len(scan.Unsealed))
+	}
+
+	// Second pass over the real store completes: refund, seal, one bill.
+	healthy := New(cfg, store, fakeOAuth{}, WithNow(fixedNow), WithSettlementJournal(jnl))
+	second, err := healthy.RecoverSettlementJournal(context.Background(), 0)
+	if err != nil {
+		t.Fatalf("second pass: %v", err)
+	}
+	if second.UsageEvents != 1 {
+		t.Fatalf("second pass summary=%+v want one usage-event recovery", second)
+	}
+	rows, total := usageTokenTotals(t, dbPath, "acct_recrefund")
+	if rows != 1 || total != 20 {
+		t.Fatalf("rows=%d total=%d want 1/20", rows, total)
+	}
+	snap := gatewaySettlementSnapshot(t, dbPath, "acct_recrefund")
+	if snap.activeRows != 0 || snap.activeReserved != 0 {
+		t.Fatalf("hold not released: %+v", snap)
+	}
+	if scan, _ := jnl.Scan(); len(scan.Unsealed) != 0 {
+		t.Fatalf("still unsealed after healthy recovery")
+	}
+}

--- a/phase5-gateway/internal/router/settlement_journal_recovery_test.go
+++ b/phase5-gateway/internal/router/settlement_journal_recovery_test.go
@@ -1,0 +1,688 @@
+package router
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/augstar/macprovider-gateway/internal/config"
+	"github.com/augstar/macprovider-gateway/internal/settlement/journal"
+	"github.com/augstar/macprovider-gateway/internal/storage"
+	"github.com/augstar/macprovider-gateway/internal/storage/sqlite"
+)
+
+// Durable settlement journal recovery (issue #763 / seam finding P1-2).
+//
+// The tests below are the executable half of the fix: the journal is only
+// worth writing if an unsealed effect is re-driven into a durable bill, and
+// only SAFE if every re-drive is idempotent. Each test names the property it
+// pins in its own comment.
+
+const journalTestWindow = "2026-05-29" // fixedNow()'s UTC date
+
+func journalTestConfig(t *testing.T, mutate func(*config.Config)) config.Config {
+	t.Helper()
+	cfg := config.Default()
+	cfg.Auth.KeyHashSecret = "test-key-hash-secret"
+	cfg.Auth.Demo.SigningSecret = "test-demo-secret"
+	cfg.Coordinator.OperatorKey = "operator-key"
+	cfg.Coordinator.ServiceToken = "service-token"
+	cfg.Storage.DBPath = filepath.Join(t.TempDir(), "gateway.db")
+	// Most tests want recovery to act on the effect they just wrote; the
+	// grace window has its own test.
+	cfg.Settlement.JournalRecoveryGraceSeconds = 0
+	if mutate != nil {
+		mutate(&cfg)
+	}
+	return cfg
+}
+
+func openTestJournal(t *testing.T, cfg config.Config) *journal.Journal {
+	t.Helper()
+	j, err := journal.Open(journal.Options{
+		Dir:             cfg.SettlementJournalDir(),
+		Fsync:           cfg.Settlement.JournalFsync,
+		SegmentMaxBytes: cfg.Settlement.JournalSegmentMaxBytes,
+		MaxTotalBytes:   cfg.Settlement.JournalMaxTotalBytes,
+		// Share the server's clock so the grace window is deterministic.
+		Now: fixedNow,
+	})
+	if err != nil {
+		t.Fatalf("journal.Open: %v", err)
+	}
+	t.Cleanup(func() { _ = j.Close() })
+	return j
+}
+
+// newJournalHarness returns a Server wired to a real sqlite store and a real
+// on-disk journal — no fakes on the money path.
+func newJournalHarness(t *testing.T, mutate func(*config.Config), opts ...Option) (*Server, *sqlite.Store, string, *journal.Journal, config.Config) {
+	t.Helper()
+	cfg := journalTestConfig(t, mutate)
+	store, err := sqlite.Open(context.Background(), cfg.Storage.DBPath)
+	if err != nil {
+		t.Fatalf("sqlite.Open: %v", err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+	jnl := openTestJournal(t, cfg)
+	allOpts := append([]Option{WithNow(fixedNow), WithSettlementJournal(jnl)}, opts...)
+	return New(cfg, store, fakeOAuth{}, allOpts...), store, cfg.Storage.DBPath, jnl, cfg
+}
+
+func seedJournalReservation(t *testing.T, store *sqlite.Store, accountID, requestID string, tokens int64) {
+	t.Helper()
+	if err := store.CreateAccount(context.Background(), storage.Account{
+		AccountID: accountID, Status: "active", QuotaClass: "default", ConcurrencyClass: "default", CreatedAt: fixedNow(),
+	}); err != nil && !strings.Contains(err.Error(), "UNIQUE") {
+		t.Fatalf("CreateAccount: %v", err)
+	}
+	if _, err := store.ReserveQuota(context.Background(), storage.ReservationRequest{
+		AccountID:       accountID,
+		RequestID:       requestID,
+		WindowDate:      journalTestWindow,
+		RequestedTokens: tokens,
+		DailyQuota:      100000,
+		CreatedAt:       fixedNow(),
+		ExpiresAt:       fixedNow().Add(time.Hour),
+	}); err != nil {
+		t.Fatalf("ReserveQuota: %v", err)
+	}
+}
+
+func journalSettleEffect(accountID, requestID string) journal.Record {
+	return journal.Record{
+		AccountID:        accountID,
+		RequestID:        requestID,
+		Effect:           journal.EffectSettle,
+		WindowDate:       journalTestWindow,
+		PromptTokens:     8,
+		CompletionTokens: 12,
+		TotalTokens:      20,
+		MaxTotalTokens:   20,
+		TokenSource:      "provider_reported",
+		Outcome:          "ok",
+	}
+}
+
+func journalEffectKey(rec journal.Record) journal.Key {
+	return journal.Key{AccountID: rec.AccountID, RequestID: rec.RequestID, Effect: rec.Effect}
+}
+
+func demoUsageRows(t *testing.T, dbPath, requestID string) int64 {
+	t.Helper()
+	db, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	defer db.Close()
+	var count int64
+	if err := db.QueryRow(`SELECT COUNT(*) FROM demo_usage_events WHERE request_id = ?`, requestID).Scan(&count); err != nil {
+		t.Fatalf("query demo_usage_events: %v", err)
+	}
+	return count
+}
+
+// journalRecords reads the on-disk JSONL back with nothing but encoding/json,
+// so the tests assert the persisted FORMAT and not just the writer's view of
+// it. A record shape change that breaks an older process's ability to recover
+// shows up here.
+func journalRecords(t *testing.T, dir string) []journal.Record {
+	t.Helper()
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("read journal dir: %v", err)
+	}
+	names := []string{}
+	for _, entry := range entries {
+		if strings.HasPrefix(entry.Name(), "effects-") && strings.HasSuffix(entry.Name(), ".jsonl") {
+			names = append(names, entry.Name())
+		}
+	}
+	sort.Strings(names)
+	var records []journal.Record
+	for _, name := range names {
+		raw, err := os.ReadFile(filepath.Join(dir, name))
+		if err != nil {
+			t.Fatalf("read segment %s: %v", name, err)
+		}
+		for _, line := range strings.Split(string(raw), "\n") {
+			if strings.TrimSpace(line) == "" {
+				continue
+			}
+			var rec journal.Record
+			if err := json.Unmarshal([]byte(line), &rec); err != nil {
+				t.Fatalf("segment %s line %q is not a journal record: %v", name, line, err)
+			}
+			records = append(records, rec)
+		}
+	}
+	return records
+}
+
+func usageTokenTotals(t *testing.T, dbPath, accountID string) (rows, total int64) {
+	t.Helper()
+	db, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	defer db.Close()
+	if err := db.QueryRow(`SELECT COUNT(*), COALESCE(SUM(total_tokens), 0) FROM usage_events WHERE account_id = ?`, accountID).
+		Scan(&rows, &total); err != nil {
+		t.Fatalf("query usage_events: %v", err)
+	}
+	return rows, total
+}
+
+// TestSettlementJournal_RecoveryRedrivesUnsealedEffect: the plain case — the
+// process died between the arm and the settle, so the reservation is still
+// active. Recovery settles it exactly as the request would have.
+func TestSettlementJournal_RecoveryRedrivesUnsealedEffect(t *testing.T) {
+	srv, store, dbPath, jnl, _ := newJournalHarness(t, nil)
+	seedJournalReservation(t, store, "acct_redrive", "req-redrive", 100)
+	if err := jnl.WriteEffect(journalSettleEffect("acct_redrive", "req-redrive")); err != nil {
+		t.Fatalf("WriteEffect: %v", err)
+	}
+
+	summary, err := srv.RecoverSettlementJournal(context.Background(), 0)
+	if err != nil {
+		t.Fatalf("RecoverSettlementJournal: %v", err)
+	}
+	if summary.Settled != 1 || summary.Recovered != 1 || summary.Errors != 0 {
+		t.Fatalf("summary=%+v want settled=1 recovered=1 errors=0", summary)
+	}
+	state := gatewaySettlementSnapshot(t, dbPath, "acct_redrive")
+	if state.usageRows != 1 || state.settledRows != 1 || state.activeRows != 0 {
+		t.Fatalf("state=%+v want usageRows=1 settledRows=1 activeRows=0", state)
+	}
+	scan, _ := jnl.Scan()
+	if len(scan.Unsealed) != 0 {
+		t.Fatalf("Unsealed=%d want 0 — a recovered effect must be sealed", len(scan.Unsealed))
+	}
+}
+
+// TestSettlementJournal_RefundedReservationRedrivesViaUsageEvent isolates the
+// H7 shape: the double failure already refunded the reservation, so the
+// reservation rung is dead and only the § 17.7 usage-event rung can restore
+// the bill.
+func TestSettlementJournal_RefundedReservationRedrivesViaUsageEvent(t *testing.T) {
+	srv, store, dbPath, jnl, _ := newJournalHarness(t, nil)
+	seedJournalReservation(t, store, "acct_refunded", "req-refunded", 100)
+	if err := store.RefundReservation(context.Background(), "acct_refunded", "req-refunded", fixedNow().Unix()); err != nil {
+		t.Fatalf("RefundReservation: %v", err)
+	}
+	if err := jnl.WriteEffect(journalSettleEffect("acct_refunded", "req-refunded")); err != nil {
+		t.Fatalf("WriteEffect: %v", err)
+	}
+
+	summary, err := srv.RecoverSettlementJournal(context.Background(), 0)
+	if err != nil {
+		t.Fatalf("RecoverSettlementJournal: %v", err)
+	}
+	if summary.UsageEvents != 1 || summary.Recovered != 1 {
+		t.Fatalf("summary=%+v want usage_events=1 recovered=1", summary)
+	}
+	rows, total := usageTokenTotals(t, dbPath, "acct_refunded")
+	if rows != 1 || total != 20 {
+		t.Fatalf("usage rows=%d total=%d want 1 row of 20 tokens", rows, total)
+	}
+	state := gatewaySettlementSnapshot(t, dbPath, "acct_refunded")
+	if state.refundedRows != 1 {
+		t.Fatalf("state=%+v want the refund to stand (recovery must not resurrect the reservation)", state)
+	}
+	scan, _ := jnl.Scan()
+	if len(scan.Unsealed) != 0 || scan.Seals != 1 {
+		t.Fatalf("scan Unsealed=%d Seals=%d want 0/1", len(scan.Unsealed), scan.Seals)
+	}
+}
+
+// TestSettlementJournal_SealedEffectNotRedriven: a seal is the "do not touch"
+// marker. If it were ignored, every completed request would be re-driven on
+// every pass.
+func TestSettlementJournal_SealedEffectNotRedriven(t *testing.T) {
+	srv, store, dbPath, jnl, _ := newJournalHarness(t, nil)
+	seedJournalReservation(t, store, "acct_sealed", "req-sealed", 100)
+	rec := journalSettleEffect("acct_sealed", "req-sealed")
+	if err := jnl.WriteEffect(rec); err != nil {
+		t.Fatalf("WriteEffect: %v", err)
+	}
+	if err := jnl.WriteSeal(journalEffectKey(rec), journal.SealSettled); err != nil {
+		t.Fatalf("WriteSeal: %v", err)
+	}
+
+	summary, err := srv.RecoverSettlementJournal(context.Background(), 0)
+	if err != nil {
+		t.Fatalf("RecoverSettlementJournal: %v", err)
+	}
+	if summary.Scanned != 0 || summary.Recovered != 0 {
+		t.Fatalf("summary=%+v want a sealed effect to be skipped entirely", summary)
+	}
+	state := gatewaySettlementSnapshot(t, dbPath, "acct_sealed")
+	if state.usageRows != 0 || state.activeRows != 1 {
+		t.Fatalf("state=%+v want the store untouched (usageRows=0 activeRows=1)", state)
+	}
+}
+
+// TestSettlementJournal_SettleLandedButSealLost is the NO-DOUBLE-BILL proof.
+//
+// Worst realistic crash window: SettleReservation committed (the buyer IS
+// billed) and the process died before the seal, which is not fsynced by
+// design. Recovery must find the reservation terminal, match the existing
+// usage row through EnsureUsageEvent's payload verify, and seal — leaving
+// exactly ONE bill. If the journaled payload ever drifts from what
+// SettleReservation persists, this test goes red with a conflict instead.
+func TestSettlementJournal_SettleLandedButSealLost(t *testing.T) {
+	srv, store, dbPath, jnl, _ := newJournalHarness(t, nil)
+	seedJournalReservation(t, store, "acct_seallost", "req-seallost", 100)
+	rec := journalSettleEffect("acct_seallost", "req-seallost")
+	if err := jnl.WriteEffect(rec); err != nil {
+		t.Fatalf("WriteEffect: %v", err)
+	}
+	// The settle landed, exactly as settleRequest would have written it.
+	if err := store.SettleReservation(context.Background(), storage.ReservationSettlement{
+		AccountID: rec.AccountID, RequestID: rec.RequestID,
+		PromptTokens: rec.PromptTokens, CompletionTokens: rec.CompletionTokens,
+		MaxTotalTokens: rec.MaxTotalTokens, TokenSource: rec.TokenSource,
+		Outcome: rec.Outcome, SettledAt: fixedNow(),
+	}); err != nil {
+		t.Fatalf("SettleReservation: %v", err)
+	}
+	// ...and the seal was lost.
+
+	summary, err := srv.RecoverSettlementJournal(context.Background(), 0)
+	if err != nil {
+		t.Fatalf("RecoverSettlementJournal: %v", err)
+	}
+	if summary.Quarantined != 0 || summary.Errors != 0 {
+		t.Fatalf("summary=%+v — a re-drive over an already-settled request must be benign; a conflict here "+
+			"means the journaled payload no longer reproduces what SettleReservation persists", summary)
+	}
+	if summary.UsageEvents != 1 {
+		t.Fatalf("summary=%+v want the re-drive to resolve via the idempotent usage-event rung", summary)
+	}
+	rows, total := usageTokenTotals(t, dbPath, "acct_seallost")
+	if rows != 1 || total != 20 {
+		t.Fatalf("DOUBLE BILL: usage rows=%d total=%d want exactly 1 row of 20 tokens", rows, total)
+	}
+	scan, _ := jnl.Scan()
+	if len(scan.Unsealed) != 0 {
+		t.Fatalf("Unsealed=%d want 0", len(scan.Unsealed))
+	}
+}
+
+// TestSettlementJournal_IdempotentAcrossTwoScans: recovery runs on a ticker,
+// so "twice" is the normal case, not an edge case.
+func TestSettlementJournal_IdempotentAcrossTwoScans(t *testing.T) {
+	srv, store, dbPath, jnl, _ := newJournalHarness(t, nil)
+	seedJournalReservation(t, store, "acct_twice", "req-twice", 100)
+	if err := jnl.WriteEffect(journalSettleEffect("acct_twice", "req-twice")); err != nil {
+		t.Fatalf("WriteEffect: %v", err)
+	}
+	if _, err := srv.RecoverSettlementJournal(context.Background(), 0); err != nil {
+		t.Fatalf("first pass: %v", err)
+	}
+	second, err := srv.RecoverSettlementJournal(context.Background(), 0)
+	if err != nil {
+		t.Fatalf("second pass: %v", err)
+	}
+	if second.Scanned != 0 || second.Recovered != 0 {
+		t.Fatalf("second pass summary=%+v want a no-op", second)
+	}
+	rows, total := usageTokenTotals(t, dbPath, "acct_twice")
+	if rows != 1 || total != 20 {
+		t.Fatalf("DOUBLE BILL across two passes: rows=%d total=%d", rows, total)
+	}
+}
+
+// TestSettlementJournal_ConflictQuarantines: when the durable row disagrees
+// with the journaled payload, no amount of retrying resolves it. The effect
+// must stop being retried, become operator-visible, and — critically — never
+// write a second bill.
+func TestSettlementJournal_ConflictQuarantines(t *testing.T) {
+	srv, store, dbPath, jnl, _ := newJournalHarness(t, nil)
+	seedJournalReservation(t, store, "acct_conflict", "req-conflict", 100)
+	// The durable row says 8/12; the journal says 8/13.
+	if err := store.SettleReservation(context.Background(), storage.ReservationSettlement{
+		AccountID: "acct_conflict", RequestID: "req-conflict",
+		PromptTokens: 8, CompletionTokens: 12, MaxTotalTokens: 100,
+		TokenSource: "provider_reported", Outcome: "ok", SettledAt: fixedNow(),
+	}); err != nil {
+		t.Fatalf("SettleReservation: %v", err)
+	}
+	rec := journalSettleEffect("acct_conflict", "req-conflict")
+	rec.CompletionTokens = 13
+	rec.TotalTokens = 21
+	rec.MaxTotalTokens = 100
+	if err := jnl.WriteEffect(rec); err != nil {
+		t.Fatalf("WriteEffect: %v", err)
+	}
+
+	for pass := 1; pass < settlementJournalMaxConflictAttempts; pass++ {
+		summary, err := srv.RecoverSettlementJournal(context.Background(), 0)
+		if err != nil {
+			t.Fatalf("pass %d: %v", pass, err)
+		}
+		if summary.Retried != 1 || summary.Quarantined != 0 {
+			t.Fatalf("pass %d summary=%+v want retried=1 quarantined=0", pass, summary)
+		}
+	}
+	final, err := srv.RecoverSettlementJournal(context.Background(), 0)
+	if err != nil {
+		t.Fatalf("final pass: %v", err)
+	}
+	if final.Quarantined != 1 {
+		t.Fatalf("final summary=%+v want quarantined=1 after %d attempts", final, settlementJournalMaxConflictAttempts)
+	}
+	after, err := srv.RecoverSettlementJournal(context.Background(), 0)
+	if err != nil {
+		t.Fatalf("post-quarantine pass: %v", err)
+	}
+	if after.Scanned != 0 {
+		t.Fatalf("post-quarantine summary=%+v want the effect to stop being re-driven", after)
+	}
+	rows, total := usageTokenTotals(t, dbPath, "acct_conflict")
+	if rows != 1 || total != 20 {
+		t.Fatalf("conflict wrote a second bill: rows=%d total=%d want the original 1 row of 20", rows, total)
+	}
+	if snapshot := jnl.MetricsSnapshot(); snapshot.Quarantines != 1 {
+		t.Fatalf("quarantines metric=%d want 1", snapshot.Quarantines)
+	}
+}
+
+// TestSettlementJournal_GraceWindowSkipsYoungEntries: the arm happens BEFORE
+// the settle, so a fresh effect usually belongs to a request that is still
+// running. Re-driving it would race the live settle for the same reservation.
+func TestSettlementJournal_GraceWindowSkipsYoungEntries(t *testing.T) {
+	srv, store, dbPath, jnl, _ := newJournalHarness(t, func(cfg *config.Config) {
+		cfg.Settlement.JournalRecoveryGraceSeconds = 60
+	})
+	seedJournalReservation(t, store, "acct_grace", "req-grace", 100)
+	if err := jnl.WriteEffect(journalSettleEffect("acct_grace", "req-grace")); err != nil {
+		t.Fatalf("WriteEffect: %v", err)
+	}
+
+	summary, err := srv.RecoverSettlementJournal(context.Background(), 0)
+	if err != nil {
+		t.Fatalf("RecoverSettlementJournal: %v", err)
+	}
+	if summary.Skipped != 1 || summary.Scanned != 0 {
+		t.Fatalf("summary=%+v want the young effect skipped", summary)
+	}
+	if state := gatewaySettlementSnapshot(t, dbPath, "acct_grace"); state.usageRows != 0 {
+		t.Fatalf("state=%+v want no bill written inside the grace window", state)
+	}
+	// Past the window (same journal dir, a clock 10 minutes later) it recovers.
+	later := New(srv.cfg, srv.store.(*sqlite.Store), fakeOAuth{},
+		WithNow(func() time.Time { return fixedNow().Add(10 * time.Minute) }),
+		WithSettlementJournal(jnl))
+	summary, err = later.RecoverSettlementJournal(context.Background(), 0)
+	if err != nil {
+		t.Fatalf("late pass: %v", err)
+	}
+	if summary.Recovered != 1 {
+		t.Fatalf("late summary=%+v want recovered=1 once the grace window elapsed", summary)
+	}
+}
+
+// TestSettlementJournal_WriteFailureDoesNotBlockSettle pins the fail-open
+// residual: the buyer already has the bytes, so a journal outage must degrade
+// recovery coverage, never billing. The write-failure metric is the signal.
+func TestSettlementJournal_WriteFailureDoesNotBlockSettle(t *testing.T) {
+	// Streaming, because settleAfterCommit — the only journaled path — is
+	// reached only after a committed 200 stream. Non-streaming settles BEFORE
+	// the response and 500s the buyer on failure, so it has no
+	// delivered-but-unbilled window to journal.
+	srv, store, dbPath, jnl, cfg := newJournalHarness(t, func(cfg *config.Config) {
+		cfg.Coordinator.BuyerURL = "http://coordinator.test"
+	}, WithHTTPClient(seamStreamingUpstream(func(pw *io.PipeWriter) {
+		_, _ = io.WriteString(pw, `data: {"id":"c","usage":{"prompt_tokens":8,"completion_tokens":12,"total_tokens":20},"choices":[{"delta":{"content":"hi"}}]}`+
+			"\n\n"+`data: [DONE]`+"\n\n")
+		_ = pw.Close()
+	})))
+	// Make the journal directory read-only AFTER Open, so segment creation
+	// fails on the first record — a disk that went read-only under a running
+	// gateway.
+	dir := cfg.SettlementJournalDir()
+	if err := os.Chmod(dir, 0o500); err != nil {
+		t.Fatalf("chmod journal dir: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(dir, 0o700) })
+
+	h := srv.Handler()
+	key := createAccountAndKey(t, store, cfg, "acct_jwfail")
+	body := `{"model":"llama","stream":true,"max_tokens":20,"messages":[{"role":"user","content":"hi"}]}`
+	resp := postChat(t, h, key, body, map[string]string{"X-Request-ID": "abababab-abab-4bab-8bab-abababababab"})
+	if resp.Code != 200 {
+		t.Fatalf("chat status=%d body=%s", resp.Code, resp.Body.String())
+	}
+
+	rows, total := usageTokenTotals(t, dbPath, "acct_jwfail")
+	if rows != 1 || total != 20 {
+		t.Fatalf("journal write failure blocked settlement: usage rows=%d total=%d want 1/20", rows, total)
+	}
+	if snapshot := jnl.MetricsSnapshot(); snapshot.WriteFailures == 0 {
+		t.Fatalf("write_failures=0 — a failed journal write must be visible in /metrics, not silent")
+	}
+}
+
+// TestSettlementJournal_DemoRedriveWritesBothTables: demo traffic needs the
+// demo_usage_events sibling row (SPEC-006 §4.5 / §14.3), on both rungs.
+func TestSettlementJournal_DemoRedriveWritesBothTables(t *testing.T) {
+	t.Run("settle rung", func(t *testing.T) {
+		srv, store, dbPath, jnl, _ := newJournalHarness(t, nil)
+		seedJournalReservation(t, store, "acct_demo1", "req-demo1", 100)
+		rec := journalSettleEffect("acct_demo1", "req-demo1")
+		rec.DemoIdentity = "203.0.113.9"
+		rec.DemoTokenHash = "demo-hash-1"
+		if err := jnl.WriteEffect(rec); err != nil {
+			t.Fatalf("WriteEffect: %v", err)
+		}
+		summary, err := srv.RecoverSettlementJournal(context.Background(), 0)
+		if err != nil {
+			t.Fatalf("recover: %v", err)
+		}
+		if summary.Settled != 1 {
+			t.Fatalf("summary=%+v want settled=1", summary)
+		}
+		if rows, _ := usageTokenTotals(t, dbPath, "acct_demo1"); rows != 1 {
+			t.Fatalf("usage rows=%d want 1", rows)
+		}
+		if got := demoUsageRows(t, dbPath, "req-demo1"); got != 1 {
+			t.Fatalf("demo_usage_events rows=%d want 1", got)
+		}
+	})
+
+	t.Run("usage-event rung", func(t *testing.T) {
+		srv, store, dbPath, jnl, _ := newJournalHarness(t, nil)
+		seedJournalReservation(t, store, "acct_demo2", "req-demo2", 100)
+		if err := store.RefundReservation(context.Background(), "acct_demo2", "req-demo2", fixedNow().Unix()); err != nil {
+			t.Fatalf("RefundReservation: %v", err)
+		}
+		rec := journalSettleEffect("acct_demo2", "req-demo2")
+		rec.DemoIdentity = "203.0.113.10"
+		rec.DemoTokenHash = "demo-hash-2"
+		if err := jnl.WriteEffect(rec); err != nil {
+			t.Fatalf("WriteEffect: %v", err)
+		}
+		summary, err := srv.RecoverSettlementJournal(context.Background(), 0)
+		if err != nil {
+			t.Fatalf("recover: %v", err)
+		}
+		if summary.UsageEvents != 1 {
+			t.Fatalf("summary=%+v want usage_events=1", summary)
+		}
+		if rows, _ := usageTokenTotals(t, dbPath, "acct_demo2"); rows != 1 {
+			t.Fatalf("usage rows=%d want 1", rows)
+		}
+		if got := demoUsageRows(t, dbPath, "req-demo2"); got != 1 {
+			t.Fatalf("demo_usage_events rows=%d want 1 — the demo audit row must be restored too", got)
+		}
+	})
+}
+
+// TestSettlementJournal_RecoveryRacesSPEC022Reconciler: the two loops share
+// one write connection and one reservation table. In production they cannot
+// contend for the same request (the SPEC-022 debit/hold paths never call
+// settleAfterCommit, so no effect is armed for a held reservation), but the
+// invariant must not DEPEND on that: running both over the same request
+// concurrently still yields exactly one bill.
+func TestSettlementJournal_RecoveryRacesSPEC022Reconciler(t *testing.T) {
+	coordinator := &http.Client{Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+		return responseWithBody(200, http.Header{"Content-Type": []string{"application/json"}},
+			`{"request_id":"req-race","mode":"enforce","policy_version":"v1","outcome":"verified",`+
+				`"receipt_result":"valid","reason":"verified_settlement","closed":true,`+
+				`"prompt_tokens":8,"completion_tokens":12,"total_tokens":20,"token_source":"coordinator_observed"}`), nil
+	})}
+	srv, store, dbPath, jnl, _ := newJournalHarness(t, func(cfg *config.Config) {
+		cfg.Coordinator.OperatorURL = "http://coordinator.test"
+	}, WithHTTPClient(coordinator))
+	seedJournalReservation(t, store, "acct_race", "req-race", 100)
+	if err := store.MarkReservationSettlementHold(context.Background(), "acct_race", "req-race"); err != nil {
+		t.Fatalf("MarkReservationSettlementHold: %v", err)
+	}
+	rec := journalSettleEffect("acct_race", "req-race")
+	rec.TokenSource = "coordinator_observed"
+	rec.Outcome = "spec022_verified"
+	if err := jnl.WriteEffect(rec); err != nil {
+		t.Fatalf("WriteEffect: %v", err)
+	}
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		if _, err := srv.RecoverSettlementJournal(context.Background(), 0); err != nil {
+			t.Errorf("journal recovery: %v", err)
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		if _, err := srv.ReconcileSettlementHolds(context.Background(), 10); err != nil {
+			t.Errorf("SPEC-022 reconcile: %v", err)
+		}
+	}()
+	wg.Wait()
+
+	rows, total := usageTokenTotals(t, dbPath, "acct_race")
+	if rows != 1 || total != 20 {
+		t.Fatalf("concurrent recovery + SPEC-022 reconcile produced rows=%d total=%d; want exactly one 20-token bill", rows, total)
+	}
+	state := gatewaySettlementSnapshot(t, dbPath, "acct_race")
+	if state.activeRows != 0 {
+		t.Fatalf("state=%+v want no reservation left active", state)
+	}
+}
+
+// TestSettlementJournal_ReplayedIdlessRetryWritesNoEffect pins the #762
+// interaction contract: a replayed id-less retry performs NO reserve and NO
+// settle, so it must journal nothing. A journal entry there would describe a
+// money effect that never happened, and recovery would then bill it.
+func TestSettlementJournal_ReplayedIdlessRetryWritesNoEffect(t *testing.T) {
+	// Streaming again: the after-commit settle is the only journaled path, so
+	// a non-streaming pair would prove nothing about the interaction.
+	var upstreamHits int
+	client := &http.Client{Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+		if r.URL.Path != "/v1/chat/completions" {
+			return responseWithBody(http.StatusNotFound, nil, `{}`), nil
+		}
+		upstreamHits++
+		return responseWithBody(http.StatusOK,
+			http.Header{"Content-Type": []string{"text/event-stream; charset=utf-8"}},
+			`data: {"id":"c","usage":{"prompt_tokens":8,"completion_tokens":12,"total_tokens":20},"choices":[{"delta":{"content":"hi"}}]}`+
+				"\n\n"+`data: [DONE]`+"\n\n"), nil
+	})}
+	srv, store, dbPath, jnl, cfg := newJournalHarness(t, func(cfg *config.Config) {
+		cfg.Coordinator.BuyerURL = "http://coordinator.test"
+	}, WithHTTPClient(client))
+	h := srv.Handler()
+	key := createAccountAndKey(t, store, cfg, "acct_replay")
+
+	body := `{"model":"llama","stream":true,"max_tokens":20,"messages":[{"role":"user","content":"hi"}]}`
+	if r := postChat(t, h, key, body, nil); r.Code != 200 {
+		t.Fatalf("attempt 1 status=%d body=%s", r.Code, r.Body.String())
+	}
+	afterFirst, err := jnl.Scan()
+	if err != nil {
+		t.Fatalf("Scan: %v", err)
+	}
+	if afterFirst.Effects != 1 {
+		t.Fatalf("effects after attempt 1 = %d, want exactly 1", afterFirst.Effects)
+	}
+
+	second := postChat(t, h, key, body, nil)
+	if second.Code != 200 || second.Header().Get(idlessDedupeHeader) != idlessDedupeHeaderValue {
+		t.Fatalf("attempt 2 was not a replay: status=%d dedupe=%q", second.Code, second.Header().Get(idlessDedupeHeader))
+	}
+	afterSecond, err := jnl.Scan()
+	if err != nil {
+		t.Fatalf("Scan: %v", err)
+	}
+	if afterSecond.Effects != afterFirst.Effects {
+		t.Fatalf("the #762 replay wrote %d new journal effect(s); a replay performs no reserve/settle and must journal nothing",
+			afterSecond.Effects-afterFirst.Effects)
+	}
+	if upstreamHits != 1 {
+		t.Fatalf("upstream hits=%d want 1", upstreamHits)
+	}
+	rows, total := usageTokenTotals(t, dbPath, "acct_replay")
+	if rows != 1 || total != 20 {
+		t.Fatalf("replay billed twice: rows=%d total=%d", rows, total)
+	}
+}
+
+// TestSettlementJournal_BatchLimitBoundsOnePass: recovery shares the store's
+// single write connection with the money path, so a pass must be bounded.
+func TestSettlementJournal_BatchLimitBoundsOnePass(t *testing.T) {
+	srv, store, _, jnl, _ := newJournalHarness(t, nil)
+	for _, id := range []string{"req-b1", "req-b2", "req-b3"} {
+		seedJournalReservation(t, store, "acct_batch", id, 100)
+		if err := jnl.WriteEffect(journalSettleEffect("acct_batch", id)); err != nil {
+			t.Fatalf("WriteEffect %s: %v", id, err)
+		}
+	}
+	summary, err := srv.RecoverSettlementJournal(context.Background(), 2)
+	if err != nil {
+		t.Fatalf("recover: %v", err)
+	}
+	if summary.Scanned != 2 || summary.Recovered != 2 {
+		t.Fatalf("summary=%+v want the pass bounded at 2", summary)
+	}
+	scan, _ := jnl.Scan()
+	if len(scan.Unsealed) != 1 {
+		t.Fatalf("Unsealed=%d want 1 left for the next pass", len(scan.Unsealed))
+	}
+}
+
+// TestSettlementJournal_MetricsExposedOnMetricsEndpoint keeps the journal
+// observable: an unsealed backlog that nobody can see is the same operational
+// blind spot as the dropped row it replaced.
+func TestSettlementJournal_MetricsExposedOnMetricsEndpoint(t *testing.T) {
+	srv, store, _, jnl, _ := newJournalHarness(t, nil)
+	seedJournalReservation(t, store, "acct_metrics", "req-metrics", 100)
+	if err := jnl.WriteEffect(journalSettleEffect("acct_metrics", "req-metrics")); err != nil {
+		t.Fatalf("WriteEffect: %v", err)
+	}
+	if _, err := srv.RecoverSettlementJournal(context.Background(), 0); err != nil {
+		t.Fatalf("recover: %v", err)
+	}
+	resp := assertStatus(t, srv.Handler(), http.MethodGet, "/metrics", "", "", "127.0.0.1", 200)
+	out := resp.Body.String()
+	for _, want := range []string{
+		"gateway_settlement_journal_effects_total",
+		"gateway_settlement_journal_seals_total",
+		"gateway_settlement_journal_recovered_total{result=\"settled\"} 1",
+		"gateway_settlement_journal_unsealed",
+	} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("/metrics missing %q", want)
+		}
+	}
+}

--- a/phase5-gateway/internal/router/settlement_journal_recovery_test.go
+++ b/phase5-gateway/internal/router/settlement_journal_recovery_test.go
@@ -905,3 +905,47 @@ func TestSettlementJournal_ConflictPathReleasesActiveHold(t *testing.T) {
 		t.Fatalf("Unsealed=%d want 1 (conflict must not seal)", len(scan.Unsealed))
 	}
 }
+
+// TestSettlementJournal_ConflictRefundFailureDoesNotConsumeAttempts pins the
+// audit R3 architect MEDIUM: a real refund failure on the conflict path must
+// not advance the quarantine clock — quarantining with the hold still active
+// would suppress the very re-drive that releases it.
+func TestSettlementJournal_ConflictRefundFailureDoesNotConsumeAttempts(t *testing.T) {
+	srv, store, dbPath, jnl, cfg := newJournalHarness(t, nil)
+	_ = srv
+	seedJournalReservation(t, store, "acct_confretry", "req-confretry", 100)
+	rec := journalSettleEffect("acct_confretry", "req-confretry")
+	if err := jnl.WriteEffect(rec); err != nil {
+		t.Fatalf("WriteEffect: %v", err)
+	}
+	if err := store.EnsureUsageEvent(context.Background(), storage.UsageEvent{
+		RequestID: "req-confretry", AccountID: "acct_confretry",
+		WindowDate: rec.WindowDate, PromptTokens: rec.PromptTokens,
+		CompletionTokens: rec.CompletionTokens + 1, TotalTokens: rec.TotalTokens + 1,
+		TokenSource: rec.TokenSource, Outcome: rec.Outcome, CreatedAt: fixedNow(),
+	}); err != nil {
+		t.Fatalf("EnsureUsageEvent seed: %v", err)
+	}
+
+	// Many passes with a refund-failing store: never quarantine, hold intact
+	// question deferred, effect stays re-drivable.
+	failing := New(cfg, &refundFailSpyStore{Store: store}, fakeOAuth{}, WithNow(fixedNow), WithSettlementJournal(jnl))
+	for pass := 0; pass < settlementJournalMaxConflictAttempts+3; pass++ {
+		summary, err := failing.RecoverSettlementJournal(context.Background(), 0)
+		if err != nil {
+			t.Fatalf("pass %d: %v", pass, err)
+		}
+		if summary.Quarantined != 0 {
+			t.Fatalf("pass %d quarantined the effect while the hold release kept failing", pass)
+		}
+	}
+	// Healthy store: hold released, conflict clock starts, quarantine follows.
+	healthy := New(cfg, store, fakeOAuth{}, WithNow(fixedNow), WithSettlementJournal(jnl))
+	if _, err := healthy.RecoverSettlementJournal(context.Background(), 0); err != nil {
+		t.Fatalf("healthy pass: %v", err)
+	}
+	snap := gatewaySettlementSnapshot(t, dbPath, "acct_confretry")
+	if snap.activeRows != 0 || snap.activeReserved != 0 {
+		t.Fatalf("hold not released once refunds work: %+v", snap)
+	}
+}

--- a/phase5-gateway/internal/router/settlement_journal_recovery_test.go
+++ b/phase5-gateway/internal/router/settlement_journal_recovery_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"encoding/json"
+	"errors"
 	"io"
 	"net/http"
 	"os"
@@ -684,5 +685,127 @@ func TestSettlementJournal_MetricsExposedOnMetricsEndpoint(t *testing.T) {
 		if !strings.Contains(out, want) {
 			t.Fatalf("/metrics missing %q", want)
 		}
+	}
+}
+
+// TestSettlementJournal_CrashBetweenUsageEventAndRefundRecovers pins the
+// audit R1 code-HIGH crash window: the §17.7 fallback wrote the usage row,
+// then the process crashed before RefundReservation. On restart the DB holds
+// an ACTIVE reservation plus a matching usage row, so SettleReservation fails
+// on the usage_events PK with an error that is neither NotFound nor Terminal.
+// Recovery must fall through to the idempotent rung (verify → refund → seal)
+// instead of wedging on the unclassified settle error while DailyUsage
+// double-counts.
+func TestSettlementJournal_CrashBetweenUsageEventAndRefundRecovers(t *testing.T) {
+	srv, store, dbPath, jnl, _ := newJournalHarness(t, nil)
+	seedJournalReservation(t, store, "acct_crashwin", "req-crashwin", 100)
+	rec := journalSettleEffect("acct_crashwin", "req-crashwin")
+	if err := jnl.WriteEffect(rec); err != nil {
+		t.Fatalf("WriteEffect: %v", err)
+	}
+	// Simulate the crash window: the usage row exists (identical payload),
+	// the reservation is still active, the effect is unsealed.
+	if err := store.EnsureUsageEvent(context.Background(), storage.UsageEvent{
+		RequestID: "req-crashwin", AccountID: "acct_crashwin",
+		WindowDate: rec.WindowDate, PromptTokens: rec.PromptTokens,
+		CompletionTokens: rec.CompletionTokens, TotalTokens: rec.TotalTokens,
+		TokenSource: rec.TokenSource, Outcome: rec.Outcome, CreatedAt: fixedNow(),
+	}); err != nil {
+		t.Fatalf("EnsureUsageEvent seed: %v", err)
+	}
+
+	summary, err := srv.RecoverSettlementJournal(context.Background(), 0)
+	if err != nil {
+		t.Fatalf("RecoverSettlementJournal: %v", err)
+	}
+	if summary.UsageEvents != 1 || summary.Quarantined != 0 || summary.Errors != 0 {
+		t.Fatalf("summary=%+v — the crash window must resolve via the idempotent rung, "+
+			"not wedge on the unclassified settle error", summary)
+	}
+	rows, total := usageTokenTotals(t, dbPath, "acct_crashwin")
+	if rows != 1 || total != 20 {
+		t.Fatalf("rows=%d total=%d want exactly 1 row of 20 tokens", rows, total)
+	}
+	snap := gatewaySettlementSnapshot(t, dbPath, "acct_crashwin")
+	if snap.activeRows != 0 || snap.activeReserved != 0 {
+		t.Fatalf("reservation hold not released: %+v — DailyUsage would double-count "+
+			"the usage row plus the active hold", snap)
+	}
+	scan, _ := jnl.Scan()
+	if len(scan.Unsealed) != 0 {
+		t.Fatalf("Unsealed=%d want 0 (sealed usage_event)", len(scan.Unsealed))
+	}
+}
+
+// refundFailSpyStore drives the §17.7 branch (settle fails, usage-event
+// fallback succeeds via the real store) with a failing RefundReservation.
+type refundFailSpyStore struct {
+	*sqlite.Store
+}
+
+func (s *refundFailSpyStore) SettleReservation(context.Context, storage.ReservationSettlement) error {
+	return errors.New("injected settle failure (seal-gate test)")
+}
+
+func (s *refundFailSpyStore) RefundReservation(context.Context, string, string, int64) error {
+	return errors.New("injected refund failure (seal-gate test)")
+}
+
+// TestSettlementJournal_RefundFailureLeavesEffectUnsealed pins the audit R1
+// architect MEDIUM: the §17.7 fallback must NOT seal past a failed
+// RefundReservation — a sealed effect suppresses recovery's retry, leaving
+// the still-active hold double-counting against the buyer's quota until the
+// reaper. Unsealed, recovery retries the refund and only then seals.
+func TestSettlementJournal_RefundFailureLeavesEffectUnsealed(t *testing.T) {
+	client := seamStreamingUpstream(func(pw *io.PipeWriter) {
+		_, _ = io.WriteString(pw, `data: {"id":"c","usage":{"prompt_tokens":8,"completion_tokens":12,"total_tokens":20},"choices":[{"delta":{"content":"hi"}}]}`+
+			"\n\n"+`data: [DONE]`+"\n\n")
+		_ = pw.Close()
+	})
+	_, store, dbPath, cfg := newTestHarnessConfig(t, fakeOAuth{}, func(cfg *config.Config) {
+		cfg.Coordinator.BuyerURL = "http://coordinator.test"
+		cfg.Settlement.JournalRecoveryGraceSeconds = 0
+	}, WithHTTPClient(client))
+	jnl := openTestJournal(t, cfg)
+	spy := &refundFailSpyStore{Store: store}
+	h := New(cfg, spy, fakeOAuth{}, WithNow(fixedNow), WithHTTPClient(client), WithSettlementJournal(jnl)).Handler()
+	key := createAccountAndKey(t, store, cfg, "acct_refundfail")
+
+	body := `{"model":"llama","stream":true,"max_tokens":20,"messages":[{"role":"user","content":"hi"}]}`
+	resp := postChat(t, h, key, body, map[string]string{"X-Request-ID": "88888888-8888-4888-8888-888888888888"})
+	if resp.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s", resp.Code, resp.Body.String())
+	}
+
+	// The usage row landed (§17.7 fallback), the refund failed, so the effect
+	// must remain UNSEALED for recovery.
+	scan, err := jnl.Scan()
+	if err != nil {
+		t.Fatalf("Scan: %v", err)
+	}
+	if len(scan.Unsealed) != 1 {
+		t.Fatalf("Unsealed=%d want 1 — sealing past a failed refund suppresses the retry", len(scan.Unsealed))
+	}
+
+	// Recovery over the real store retries: usage row verifies, refund
+	// succeeds, seal lands, hold released, still exactly one bill.
+	recovered := New(cfg, store, fakeOAuth{}, WithNow(fixedNow), WithSettlementJournal(jnl))
+	summary, err := recovered.RecoverSettlementJournal(context.Background(), 0)
+	if err != nil {
+		t.Fatalf("RecoverSettlementJournal: %v", err)
+	}
+	if summary.UsageEvents != 1 {
+		t.Fatalf("summary=%+v want one usage-event re-drive", summary)
+	}
+	rows, total := usageTokenTotals(t, dbPath, "acct_refundfail")
+	if rows != 1 || total != 20 {
+		t.Fatalf("rows=%d total=%d want 1/20", rows, total)
+	}
+	snap := gatewaySettlementSnapshot(t, dbPath, "acct_refundfail")
+	if snap.activeRows != 0 || snap.activeReserved != 0 {
+		t.Fatalf("hold not released after recovery: %+v", snap)
+	}
+	if scan, _ := jnl.Scan(); len(scan.Unsealed) != 0 {
+		t.Fatalf("effect still unsealed after recovery")
 	}
 }

--- a/phase5-gateway/internal/settlement/journal/journal.go
+++ b/phase5-gateway/internal/settlement/journal/journal.go
@@ -56,6 +56,7 @@ package journal
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log/slog"
 	"os"
@@ -64,6 +65,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"syscall"
 	"time"
 )
 
@@ -706,7 +708,17 @@ func fsyncDir(dir string) error {
 	}
 	defer d.Close()
 	if err := d.Sync(); err != nil {
-		slog.Warn("gateway settlement journal could not fsync its directory", "dir", dir, "error", err)
+		// Some filesystems reject directory fsync outright (EINVAL/ENOTSUP);
+		// that is a platform quirk, not a durability failure, and is safe to
+		// ignore. Any OTHER error means the new segment's directory entry may
+		// not survive power loss — propagate it so WriteEffect reports the
+		// failure instead of returning a false durability promise (audit R1,
+		// code MEDIUM).
+		if errors.Is(err, syscall.EINVAL) || errors.Is(err, syscall.ENOTSUP) {
+			slog.Warn("gateway settlement journal directory fsync unsupported on this filesystem", "dir", dir, "error", err)
+			return nil
+		}
+		return fmt.Errorf("settlement journal: fsync dir %s: %w", dir, err)
 	}
 	return nil
 }

--- a/phase5-gateway/internal/settlement/journal/journal.go
+++ b/phase5-gateway/internal/settlement/journal/journal.go
@@ -1,0 +1,712 @@
+// Package journal implements the durable, append-only settlement journal
+// behind issue #763 (seam finding P1-2, "settlement not crash-durable").
+//
+// # WHY A SEPARATE FILE AND NOT A TABLE IN gateway.db
+//
+// The failure this closes is "the buyer received a committed 200 stream and
+// nobody was billed": SettleReservation failed AND the SPEC-006 § 17.7
+// EnsureUsageEvent fallback failed, so chat_proxy.settleAfterCommit refunded
+// and dropped the audit row. Writing the recovery record into the SAME sqlite
+// file that just failed would produce a green test and an unchanged risk —
+// every failure class that takes out the settle write (single write
+// connection contention, a DB-file pathology, a torn WAL after power loss)
+// takes out the journal write with it. A second sqlite file is only
+// marginally better: same driver, same page cache, same failure modes.
+//
+// So the journal is a plain append-only JSONL file with an fsync per EFFECT
+// record. That is the only mechanism that survives the whole class: the
+// effect is on stable storage before the settle attempt begins, so the
+// recovery scan can re-drive it after a logical failure, a process crash, or
+// a power loss.
+//
+// # RECORD MODEL
+//
+// Three kinds, all keyed by (account_id, request_id, effect):
+//
+//   - "effect"     — an after-commit money effect is ABOUT to be attempted.
+//     Carries the complete billing payload, which must be
+//     sufficient to rebuild storage.ReservationSettlement and
+//     storage.UsageEvent byte-identically so a re-drive passes
+//     EnsureUsageEvent's payload verify (created_at excluded).
+//   - "seal"       — the effect reached a terminal, durable outcome
+//     ("settled" via the reservation, or "usage_event" via the
+//     § 17.7 fallback). A sealed key is never re-driven.
+//   - "quarantine" — the re-drive hit an unresolvable conflict
+//     (storage.ErrUsageEventConflict) repeatedly. Suppresses
+//     further re-drive and pins the segment against pruning so an
+//     operator can reconcile from the coordinator request_log.
+//
+// The journal NEVER contains prompt or response text. It holds account_id,
+// request_id, token counts, window date, token source, outcome, and (for
+// demo traffic) the demo identity and demo token hash — the same fields the
+// gateway already persists in usage_events. Directory 0700, files 0600.
+//
+// DURABILITY CONTRACT
+//
+//   - WriteEffect performs a SINGLE write(2) of one line and then fsyncs
+//     BEFORE returning. Losing an effect record loses the ability to
+//     recover the bill, so it is the one record that must be on stable
+//     storage synchronously.
+//   - WriteSeal does NOT fsync. A lost seal costs one idempotent re-drive
+//     (EnsureUsageEvent matches the existing row and returns nil), never a
+//     double bill.
+//   - Segment create and unlink fsync the parent directory, so a segment
+//     that exists after a crash is visible in the directory entry too.
+package journal
+
+import (
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+)
+
+// RecordVersion is stamped into every record. Readers refuse versions they
+// do not understand rather than guessing at a payload shape.
+const RecordVersion = 1
+
+// Record kinds.
+const (
+	KindEffect     = "effect"
+	KindSeal       = "seal"
+	KindQuarantine = "quarantine"
+)
+
+// EffectSettle is the only effect kind v1 journals: the after-commit
+// settlement performed by chat_proxy.settleAfterCommit. The field is part of
+// the record key so a later effect (e.g. the SPEC-022 hold marker) can be
+// added without rewriting existing journals.
+const EffectSettle = "settle"
+
+// Seal results.
+const (
+	SealSettled    = "settled"
+	SealUsageEvent = "usage_event"
+)
+
+// Filesystem contract.
+const (
+	segmentPrefix = "effects-"
+	segmentSuffix = ".jsonl"
+	dirMode       = os.FileMode(0o700)
+	fileMode      = os.FileMode(0o600)
+
+	// DefaultSegmentMaxBytes bounds one segment file. Small enough that a
+	// scan reads it into memory without thought, large enough that rotation
+	// is rare on the money path.
+	DefaultSegmentMaxBytes int64 = 16 << 20
+	// DefaultMaxTotalBytes is the HARD cap across all segments. Past it the
+	// journal refuses new records (see ErrFull) instead of filling the disk
+	// out from under sqlite. That is a deliberate lesser-harm choice: a
+	// refused journal write is fail-open (settlement still runs, the metric
+	// and the CRITICAL log fire), whereas a full disk takes the gateway's
+	// database with it.
+	DefaultMaxTotalBytes int64 = 512 << 20
+)
+
+// Sentinel errors.
+var (
+	// ErrFull is returned once the journal has reached its hard size cap.
+	ErrFull = fmt.Errorf("settlement journal is full")
+	// ErrClosed is returned by writes issued after Close.
+	ErrClosed = fmt.Errorf("settlement journal is closed")
+)
+
+// Key identifies one money effect. Every record carries it; seals and
+// quarantines refer back to the effect they resolve.
+type Key struct {
+	AccountID string
+	RequestID string
+	Effect    string
+}
+
+// Record is one JSONL line.
+//
+// Field-shape rule: everything needed to rebuild storage.ReservationSettlement
+// AND storage.UsageEvent must be here, because the recovery ladder writes
+// both. created_at is deliberately NOT journaled — EnsureUsageEvent excludes
+// it from the payload verify, and re-deriving it at re-drive time keeps the
+// record free of a value that would otherwise look authoritative.
+type Record struct {
+	Version         int    `json:"v"`
+	Kind            string `json:"kind"`
+	AccountID       string `json:"account_id"`
+	RequestID       string `json:"request_id"`
+	Effect          string `json:"effect"`
+	WrittenAtUnixMS int64  `json:"written_at_unix_ms"`
+
+	// Effect payload (kind == KindEffect).
+	WindowDate       string `json:"window_date,omitempty"`
+	PromptTokens     int64  `json:"prompt_tokens,omitempty"`
+	CompletionTokens int64  `json:"completion_tokens,omitempty"`
+	TotalTokens      int64  `json:"total_tokens,omitempty"`
+	MaxTotalTokens   int64  `json:"max_total_tokens,omitempty"`
+	TokenSource      string `json:"token_source,omitempty"`
+	Outcome          string `json:"outcome,omitempty"`
+	DemoIdentity     string `json:"demo_identity,omitempty"`
+	DemoTokenHash    string `json:"demo_token_hash,omitempty"`
+
+	// Seal payload (kind == KindSeal): SealSettled or SealUsageEvent.
+	Result string `json:"result,omitempty"`
+
+	// Quarantine payload (kind == KindQuarantine).
+	Reason   string `json:"reason,omitempty"`
+	Attempts int    `json:"attempts,omitempty"`
+}
+
+// Key returns the record's (account, request, effect) identity.
+func (r Record) Key() Key {
+	return Key{AccountID: r.AccountID, RequestID: r.RequestID, Effect: r.Effect}
+}
+
+// WrittenAt is the record's write time in UTC.
+func (r Record) WrittenAt() time.Time {
+	return time.UnixMilli(r.WrittenAtUnixMS).UTC()
+}
+
+// TokensConsistent reports whether the journaled totals agree. A record that
+// fails this can never settle (the store rejects total != prompt+completion),
+// so the recovery ladder quarantines it instead of retrying forever.
+func (r Record) TokensConsistent() bool {
+	if r.PromptTokens < 0 || r.CompletionTokens < 0 || r.TotalTokens < 0 {
+		return false
+	}
+	return r.TotalTokens == r.PromptTokens+r.CompletionTokens
+}
+
+// Options configures Open.
+type Options struct {
+	// Dir is the journal directory. Created 0700 if missing.
+	Dir string
+	// Fsync enables the per-effect fsync. It defaults to ON via config;
+	// the escape hatch exists only for throwaway environments and is
+	// rejected by config.Validate in the production posture.
+	Fsync bool
+	// SegmentMaxBytes bounds one segment file (0 → DefaultSegmentMaxBytes).
+	SegmentMaxBytes int64
+	// MaxTotalBytes is the hard cap across all segments
+	// (0 → DefaultMaxTotalBytes).
+	MaxTotalBytes int64
+	// Now overrides the clock (tests).
+	Now func() time.Time
+}
+
+// fileHandle is the narrow view of a segment file the journal writes
+// through. It exists so TestSettlementJournal_EffectWriteFsyncs can wrap the
+// REAL file and observe that WriteEffect issued Sync before returning —
+// without that seam, "we fsync effects" is an unverifiable claim, and it is
+// the single property this whole package exists to provide.
+type fileHandle interface {
+	Write(p []byte) (int, error)
+	Sync() error
+	Close() error
+}
+
+// Journal is a single-writer append-only settlement journal. All methods are
+// safe for concurrent use.
+type Journal struct {
+	dir             string
+	fsync           bool
+	segmentMaxBytes int64
+	maxTotalBytes   int64
+	now             func() time.Time
+
+	mu           sync.Mutex
+	file         fileHandle
+	segmentName  string
+	segmentBytes int64
+	totalBytes   int64
+	closed       bool
+
+	// wrapFile decorates a freshly opened segment file. Identity in
+	// production; tests substitute a recorder.
+	wrapFile func(fileHandle) fileHandle
+
+	metrics metrics
+}
+
+// Open prepares the journal directory and returns a ready journal. It does
+// NOT create a segment: segments appear on the first write, so a gateway that
+// never bills never litters the directory.
+//
+// Open fails closed. cmd/gateway exits on error rather than serving with
+// settlement durability silently disabled.
+func Open(opts Options) (*Journal, error) {
+	dir := strings.TrimSpace(opts.Dir)
+	if dir == "" {
+		return nil, fmt.Errorf("settlement journal: dir must be set")
+	}
+	if err := os.MkdirAll(dir, dirMode); err != nil {
+		return nil, fmt.Errorf("settlement journal: create dir %s: %w", dir, err)
+	}
+	// An inherited directory may be group/world readable; the journal holds
+	// account ids and token counts, so tighten it every boot.
+	if err := os.Chmod(dir, dirMode); err != nil {
+		return nil, fmt.Errorf("settlement journal: chmod dir %s: %w", dir, err)
+	}
+	probe, err := os.CreateTemp(dir, ".writable-*")
+	if err != nil {
+		return nil, fmt.Errorf("settlement journal: dir %s is not writable: %w", dir, err)
+	}
+	probeName := probe.Name()
+	_ = probe.Close()
+	_ = os.Remove(probeName)
+
+	j := &Journal{
+		dir:             dir,
+		fsync:           opts.Fsync,
+		segmentMaxBytes: opts.SegmentMaxBytes,
+		maxTotalBytes:   opts.MaxTotalBytes,
+		now:             opts.Now,
+		wrapFile:        func(f fileHandle) fileHandle { return f },
+	}
+	if j.segmentMaxBytes <= 0 {
+		j.segmentMaxBytes = DefaultSegmentMaxBytes
+	}
+	if j.maxTotalBytes <= 0 {
+		j.maxTotalBytes = DefaultMaxTotalBytes
+	}
+	if j.now == nil {
+		j.now = func() time.Time { return time.Now().UTC() }
+	}
+	j.metrics.init()
+	bytes, err := dirBytes(dir)
+	if err != nil {
+		return nil, err
+	}
+	j.totalBytes = bytes
+	j.metrics.setBytes(bytes)
+	return j, nil
+}
+
+// Dir returns the journal directory.
+func (j *Journal) Dir() string { return j.dir }
+
+// WriteEffect durably records an effect that is about to be attempted: one
+// write(2), then fsync, before returning.
+func (j *Journal) WriteEffect(rec Record) error {
+	rec.Kind = KindEffect
+	if rec.Effect == "" {
+		rec.Effect = EffectSettle
+	}
+	if err := j.append(rec, j.fsync); err != nil {
+		return err
+	}
+	j.metrics.incEffects()
+	return nil
+}
+
+// WriteSeal records that an effect reached a durable terminal. Deliberately
+// NOT fsynced: a lost seal costs one idempotent re-drive, never a bill.
+func (j *Journal) WriteSeal(key Key, result string) error {
+	if err := j.append(Record{
+		Kind:      KindSeal,
+		AccountID: key.AccountID,
+		RequestID: key.RequestID,
+		Effect:    key.Effect,
+		Result:    result,
+	}, false); err != nil {
+		return err
+	}
+	j.metrics.incSeals()
+	return nil
+}
+
+// WriteQuarantine records that an effect cannot be re-driven. Like a seal it
+// suppresses further re-drive, but unlike a seal it pins its segment against
+// pruning and raises a gauge, because the money outcome is UNRESOLVED and an
+// operator has to reconcile it from the coordinator request_log.
+func (j *Journal) WriteQuarantine(key Key, reason string, attempts int) error {
+	if err := j.append(Record{
+		Kind:      KindQuarantine,
+		AccountID: key.AccountID,
+		RequestID: key.RequestID,
+		Effect:    key.Effect,
+		Reason:    reason,
+		Attempts:  attempts,
+	}, j.fsync); err != nil {
+		return err
+	}
+	j.metrics.incQuarantines()
+	return nil
+}
+
+func (j *Journal) append(rec Record, sync bool) error {
+	rec.Version = RecordVersion
+	if rec.WrittenAtUnixMS == 0 {
+		rec.WrittenAtUnixMS = j.now().UTC().UnixMilli()
+	}
+	line, err := json.Marshal(rec)
+	if err != nil {
+		j.metrics.incWriteFailures()
+		return fmt.Errorf("settlement journal: marshal record: %w", err)
+	}
+	line = append(line, '\n')
+
+	j.mu.Lock()
+	defer j.mu.Unlock()
+	if j.closed {
+		j.metrics.incWriteFailures()
+		return ErrClosed
+	}
+	if j.totalBytes+int64(len(line)) > j.maxTotalBytes {
+		j.metrics.incWriteFailures()
+		// CRITICAL, not Warn: durability is off until an operator drains the
+		// directory. Refusing the write is the lesser harm — see
+		// DefaultMaxTotalBytes.
+		slog.Error("CRITICAL gateway settlement journal is full; refusing new records",
+			"dir", j.dir,
+			"total_bytes", j.totalBytes,
+			"max_total_bytes", j.maxTotalBytes,
+			"account_id", rec.AccountID,
+			"request_id", rec.RequestID,
+			"kind", rec.Kind,
+		)
+		return ErrFull
+	}
+	if err := j.ensureSegmentLocked(int64(len(line))); err != nil {
+		j.metrics.incWriteFailures()
+		return err
+	}
+	n, err := j.file.Write(line)
+	j.segmentBytes += int64(n)
+	j.totalBytes += int64(n)
+	j.metrics.setBytes(j.totalBytes)
+	if err != nil {
+		j.metrics.incWriteFailures()
+		return fmt.Errorf("settlement journal: write record: %w", err)
+	}
+	if sync {
+		if err := j.file.Sync(); err != nil {
+			j.metrics.incWriteFailures()
+			return fmt.Errorf("settlement journal: fsync record: %w", err)
+		}
+	}
+	return nil
+}
+
+func (j *Journal) ensureSegmentLocked(need int64) error {
+	if j.file != nil && j.segmentBytes+need <= j.segmentMaxBytes {
+		return nil
+	}
+	if j.file != nil {
+		if err := j.file.Close(); err != nil {
+			return fmt.Errorf("settlement journal: close segment %s: %w", j.segmentName, err)
+		}
+		j.file = nil
+	}
+	name := segmentName(j.now(), os.Getpid())
+	path := filepath.Join(j.dir, name)
+	// O_EXCL: two segments minted inside the same millisecond by the same
+	// pid would otherwise silently share a file.
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_EXCL|os.O_WRONLY|os.O_APPEND, fileMode)
+	if err != nil {
+		if !os.IsExist(err) {
+			return fmt.Errorf("settlement journal: create segment %s: %w", path, err)
+		}
+		f, err = os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_APPEND, fileMode)
+		if err != nil {
+			return fmt.Errorf("settlement journal: open segment %s: %w", path, err)
+		}
+	}
+	// A segment that exists but whose directory entry is not durable is a
+	// segment a crash can lose whole.
+	if err := fsyncDir(j.dir); err != nil {
+		_ = f.Close()
+		return err
+	}
+	info, err := f.Stat()
+	if err != nil {
+		_ = f.Close()
+		return fmt.Errorf("settlement journal: stat segment %s: %w", path, err)
+	}
+	j.file = j.wrapFile(f)
+	j.segmentName = name
+	j.segmentBytes = info.Size()
+	return nil
+}
+
+// Close flushes and closes the active segment. Subsequent writes return
+// ErrClosed; Scan still works (it reads the directory, not the handle).
+func (j *Journal) Close() error {
+	j.mu.Lock()
+	defer j.mu.Unlock()
+	j.closed = true
+	if j.file == nil {
+		return nil
+	}
+	err := j.file.Close()
+	j.file = nil
+	j.segmentName = ""
+	j.segmentBytes = 0
+	return err
+}
+
+// SegmentState is one segment's recovery-relevant shape.
+type SegmentState struct {
+	Name string
+	// Effects is how many effect records the segment holds.
+	Effects int
+	// Unsealed counts this segment's effects that have no seal ANYWHERE in
+	// the journal (a seal commonly lands in a later segment).
+	Unsealed int
+	// Quarantined counts this segment's effects that carry a quarantine.
+	Quarantined int
+	ModTime     time.Time
+}
+
+// ScanResult is the whole-journal view the recovery pass works from.
+type ScanResult struct {
+	// Unsealed holds every effect with no seal and no quarantine, in append
+	// order (oldest first) — the re-drive queue.
+	Unsealed []Record
+	Effects  int
+	Seals    int
+	// Quarantined counts distinct quarantined effect keys.
+	Quarantined int
+	// Malformed counts lines that failed to parse or carried an unknown
+	// version, ANYWHERE except a torn final line.
+	Malformed int
+	// TornTails counts segments whose last line lacked a terminating
+	// newline — the expected shape of a crash mid-append.
+	TornTails int
+	Segments  []SegmentState
+}
+
+// Scan reads every segment oldest→newest and reduces it to the unsealed set.
+//
+// Corruption policy: a torn FINAL line in a segment is the normal crash
+// signature (the fsync'd prefix is intact, the tail is not) — warn and skip.
+// A parse failure anywhere ELSE means real corruption; log loudly and skip
+// the line rather than aborting the pass, so one bad byte cannot strand every
+// other recoverable bill.
+func (j *Journal) Scan() (ScanResult, error) {
+	names, err := segmentNames(j.dir)
+	if err != nil {
+		return ScanResult{}, err
+	}
+	var result ScanResult
+	sealed := map[Key]bool{}
+	quarantined := map[Key]bool{}
+	effects := map[Key]Record{}
+	var order []Key
+	segmentKeys := map[string][]Key{}
+
+	for _, name := range names {
+		path := filepath.Join(j.dir, name)
+		data, err := os.ReadFile(path)
+		if err != nil {
+			if os.IsNotExist(err) {
+				continue // pruned by a concurrent pass
+			}
+			return ScanResult{}, fmt.Errorf("settlement journal: read segment %s: %w", path, err)
+		}
+		state := SegmentState{Name: name}
+		if info, statErr := os.Stat(path); statErr == nil {
+			state.ModTime = info.ModTime()
+		}
+		lines := strings.Split(string(data), "\n")
+		// strings.Split leaves a trailing "" for a well-terminated file; a
+		// non-empty last element is a torn append.
+		if last := lines[len(lines)-1]; last != "" {
+			result.TornTails++
+			slog.Warn("gateway settlement journal segment has a torn final line (crash signature); skipping it",
+				"segment", name, "bytes", len(last))
+		}
+		lines = lines[:len(lines)-1]
+		for i, line := range lines {
+			if strings.TrimSpace(line) == "" {
+				continue
+			}
+			var rec Record
+			if err := json.Unmarshal([]byte(line), &rec); err != nil || rec.Version != RecordVersion {
+				result.Malformed++
+				slog.Error("gateway settlement journal record is unreadable; skipping it (money effect may be unrecoverable)",
+					"segment", name, "line", i+1, "version", rec.Version, "error", err)
+				continue
+			}
+			key := rec.Key()
+			switch rec.Kind {
+			case KindEffect:
+				result.Effects++
+				state.Effects++
+				if _, seen := effects[key]; !seen {
+					effects[key] = rec
+					order = append(order, key)
+				}
+				segmentKeys[name] = append(segmentKeys[name], key)
+			case KindSeal:
+				result.Seals++
+				sealed[key] = true
+			case KindQuarantine:
+				quarantined[key] = true
+			default:
+				result.Malformed++
+				slog.Error("gateway settlement journal record has an unknown kind; skipping it",
+					"segment", name, "line", i+1, "kind", rec.Kind)
+			}
+		}
+		result.Segments = append(result.Segments, state)
+	}
+
+	for _, key := range order {
+		if sealed[key] || quarantined[key] {
+			continue
+		}
+		result.Unsealed = append(result.Unsealed, effects[key])
+	}
+	for i := range result.Segments {
+		for _, key := range segmentKeys[result.Segments[i].Name] {
+			if quarantined[key] {
+				result.Segments[i].Quarantined++
+				continue
+			}
+			if !sealed[key] {
+				result.Segments[i].Unsealed++
+			}
+		}
+	}
+	result.Quarantined = len(quarantined)
+	return result, nil
+}
+
+// Prune unlinks segments that are fully sealed, hold no quarantined effect,
+// and were last written before `before`. The ACTIVE segment is never pruned.
+func (j *Journal) Prune(before time.Time) (int, error) {
+	scan, err := j.Scan()
+	if err != nil {
+		return 0, err
+	}
+	j.mu.Lock()
+	active := j.segmentName
+	j.mu.Unlock()
+
+	pruned := 0
+	for _, seg := range scan.Segments {
+		if seg.Name == active || seg.Unsealed > 0 || seg.Quarantined > 0 {
+			continue
+		}
+		if seg.ModTime.IsZero() || !seg.ModTime.Before(before) {
+			continue
+		}
+		path := filepath.Join(j.dir, seg.Name)
+		info, err := os.Stat(path)
+		if err != nil {
+			continue
+		}
+		if err := os.Remove(path); err != nil {
+			if os.IsNotExist(err) {
+				continue
+			}
+			return pruned, fmt.Errorf("settlement journal: prune segment %s: %w", path, err)
+		}
+		if err := fsyncDir(j.dir); err != nil {
+			return pruned, err
+		}
+		pruned++
+		j.mu.Lock()
+		j.totalBytes -= info.Size()
+		if j.totalBytes < 0 {
+			j.totalBytes = 0
+		}
+		j.metrics.setBytes(j.totalBytes)
+		j.mu.Unlock()
+	}
+	return pruned, nil
+}
+
+// RecordRecovered counts one re-drive outcome for /metrics.
+func (j *Journal) RecordRecovered(result string) { j.metrics.incRecovered(result) }
+
+// SetPending publishes the current unsealed / quarantined gauges.
+func (j *Journal) SetPending(unsealed, quarantined int64) {
+	j.metrics.setPending(unsealed, quarantined)
+}
+
+// MetricsSnapshot returns a consistent copy of the journal counters.
+func (j *Journal) MetricsSnapshot() Snapshot { return j.metrics.snapshot() }
+
+func segmentName(now time.Time, pid int) string {
+	return fmt.Sprintf("%s%d-%d%s", segmentPrefix, now.UTC().UnixMilli(), pid, segmentSuffix)
+}
+
+// segmentNames returns the segment file names sorted oldest→newest by the
+// millisecond stamp in the name (NOT lexicographically, and NOT by mtime:
+// mtime moves when a seal lands in an older segment... which it cannot, but
+// relying on the name keeps the ordering a pure function of the writer).
+func segmentNames(dir string) ([]string, error) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("settlement journal: read dir %s: %w", dir, err)
+	}
+	type seg struct {
+		name  string
+		stamp int64
+	}
+	segs := make([]seg, 0, len(entries))
+	for _, entry := range entries {
+		name := entry.Name()
+		if entry.IsDir() || !strings.HasPrefix(name, segmentPrefix) || !strings.HasSuffix(name, segmentSuffix) {
+			continue
+		}
+		trimmed := strings.TrimSuffix(strings.TrimPrefix(name, segmentPrefix), segmentSuffix)
+		stampRaw, _, _ := strings.Cut(trimmed, "-")
+		stamp, err := strconv.ParseInt(stampRaw, 10, 64)
+		if err != nil {
+			slog.Warn("gateway settlement journal segment has an unparseable name; scanning it last", "segment", name)
+			stamp = 1<<62 - 1
+		}
+		segs = append(segs, seg{name: name, stamp: stamp})
+	}
+	sort.Slice(segs, func(a, b int) bool {
+		if segs[a].stamp != segs[b].stamp {
+			return segs[a].stamp < segs[b].stamp
+		}
+		return segs[a].name < segs[b].name
+	})
+	names := make([]string, 0, len(segs))
+	for _, s := range segs {
+		names = append(names, s.name)
+	}
+	return names, nil
+}
+
+func dirBytes(dir string) (int64, error) {
+	names, err := segmentNames(dir)
+	if err != nil {
+		return 0, err
+	}
+	var total int64
+	for _, name := range names {
+		info, err := os.Stat(filepath.Join(dir, name))
+		if err != nil {
+			continue
+		}
+		total += info.Size()
+	}
+	return total, nil
+}
+
+// fsyncDir makes a create/unlink of a segment durable. On platforms where a
+// directory cannot be opened for sync this is a no-op rather than a failure —
+// the record write itself is still fsynced.
+func fsyncDir(dir string) error {
+	d, err := os.Open(dir)
+	if err != nil {
+		return fmt.Errorf("settlement journal: open dir %s: %w", dir, err)
+	}
+	defer d.Close()
+	if err := d.Sync(); err != nil {
+		slog.Warn("gateway settlement journal could not fsync its directory", "dir", dir, "error", err)
+	}
+	return nil
+}

--- a/phase5-gateway/internal/settlement/journal/journal_test.go
+++ b/phase5-gateway/internal/settlement/journal/journal_test.go
@@ -1,0 +1,383 @@
+package journal
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func testJournal(t *testing.T, mutate func(*Options)) *Journal {
+	t.Helper()
+	opts := Options{Dir: filepath.Join(t.TempDir(), "settlement-journal"), Fsync: true}
+	if mutate != nil {
+		mutate(&opts)
+	}
+	j, err := Open(opts)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	t.Cleanup(func() { _ = j.Close() })
+	return j
+}
+
+func effect(requestID string) Record {
+	return Record{
+		AccountID:        "acct_j",
+		RequestID:        requestID,
+		WindowDate:       "2026-05-29",
+		PromptTokens:     8,
+		CompletionTokens: 12,
+		TotalTokens:      20,
+		MaxTotalTokens:   20,
+		TokenSource:      "provider_reported",
+		Outcome:          "ok",
+	}
+}
+
+// recordingFile wraps the REAL segment file and records the call order, so
+// the fsync assertion below is about production behavior and not about a
+// stubbed-out file.
+type recordingFile struct {
+	inner fileHandle
+	calls *[]string
+}
+
+func (f recordingFile) Write(p []byte) (int, error) {
+	*f.calls = append(*f.calls, "write")
+	return f.inner.Write(p)
+}
+
+func (f recordingFile) Sync() error {
+	*f.calls = append(*f.calls, "sync")
+	return f.inner.Sync()
+}
+
+func (f recordingFile) Close() error { return f.inner.Close() }
+
+// TestSettlementJournal_EffectWriteFsyncs pins THE load-bearing property of
+// this package: an effect record is on stable storage before WriteEffect
+// returns, i.e. before the settle attempt it describes begins. Without it the
+// journal degrades to "durable unless the machine actually loses power",
+// which is most of the failure classes issue #763 exists to cover.
+//
+// It also pins the other half of the contract: seals are NOT fsynced. A seal
+// costs one idempotent re-drive if lost, so paying a second fsync per billed
+// request for it would be a pure latency tax.
+//
+// This test must never be skipped. If it becomes awkward, the guard to keep
+// is "Sync fired, after the write, before the return" — nothing else here is
+// load-bearing.
+func TestSettlementJournal_EffectWriteFsyncs(t *testing.T) {
+	var calls []string
+	j := testJournal(t, nil)
+	j.wrapFile = func(f fileHandle) fileHandle { return recordingFile{inner: f, calls: &calls} }
+
+	if err := j.WriteEffect(effect("req-fsync")); err != nil {
+		t.Fatalf("WriteEffect: %v", err)
+	}
+	if len(calls) != 2 || calls[0] != "write" || calls[1] != "sync" {
+		t.Fatalf("WriteEffect call sequence = %v, want [write sync] — the effect record MUST be fsynced "+
+			"BEFORE WriteEffect returns, or a power loss between the arm and the settle loses the bill", calls)
+	}
+
+	if err := j.WriteSeal(Key{AccountID: "acct_j", RequestID: "req-fsync", Effect: EffectSettle}, SealSettled); err != nil {
+		t.Fatalf("WriteSeal: %v", err)
+	}
+	if len(calls) != 3 || calls[2] != "write" {
+		t.Fatalf("WriteSeal call sequence = %v, want a trailing bare write — seals must NOT fsync "+
+			"(a lost seal costs one idempotent re-drive, not a bill)", calls)
+	}
+}
+
+func TestSettlementJournal_DirAndFileModesAreTight(t *testing.T) {
+	j := testJournal(t, nil)
+	if err := j.WriteEffect(effect("req-modes")); err != nil {
+		t.Fatalf("WriteEffect: %v", err)
+	}
+	info, err := os.Stat(j.Dir())
+	if err != nil {
+		t.Fatalf("stat dir: %v", err)
+	}
+	if got := info.Mode().Perm(); got != 0o700 {
+		t.Fatalf("journal dir mode=%o want 0700", got)
+	}
+	names, err := segmentNames(j.Dir())
+	if err != nil || len(names) != 1 {
+		t.Fatalf("segmentNames=%v err=%v want exactly one segment", names, err)
+	}
+	segInfo, err := os.Stat(filepath.Join(j.Dir(), names[0]))
+	if err != nil {
+		t.Fatalf("stat segment: %v", err)
+	}
+	if got := segInfo.Mode().Perm(); got != 0o600 {
+		t.Fatalf("segment mode=%o want 0600", got)
+	}
+	// The journal carries billing identity, never conversation content.
+	raw, err := os.ReadFile(filepath.Join(j.Dir(), names[0]))
+	if err != nil {
+		t.Fatalf("read segment: %v", err)
+	}
+	var rec Record
+	if err := json.Unmarshal([]byte(strings.TrimSpace(string(raw))), &rec); err != nil {
+		t.Fatalf("segment line is not a v1 record: %v (%s)", err, raw)
+	}
+	if rec.Version != RecordVersion || rec.Kind != KindEffect || rec.Effect != EffectSettle {
+		t.Fatalf("record=%+v want v%d effect/settle", rec, RecordVersion)
+	}
+	if rec.WrittenAtUnixMS == 0 {
+		t.Fatal("record has no write timestamp; the recovery grace window depends on it")
+	}
+}
+
+func TestSettlementJournal_TornTailLineIgnored(t *testing.T) {
+	j := testJournal(t, nil)
+	if err := j.WriteEffect(effect("req-a")); err != nil {
+		t.Fatalf("WriteEffect a: %v", err)
+	}
+	if err := j.WriteEffect(effect("req-b")); err != nil {
+		t.Fatalf("WriteEffect b: %v", err)
+	}
+	names, _ := segmentNames(j.Dir())
+	path := filepath.Join(j.Dir(), names[0])
+	// A crash mid-append: a partial line with no terminating newline. The
+	// fsync'd prefix is intact; only the tail is garbage.
+	f, err := os.OpenFile(path, os.O_WRONLY|os.O_APPEND, 0o600)
+	if err != nil {
+		t.Fatalf("open segment: %v", err)
+	}
+	if _, err := f.WriteString(`{"v":1,"kind":"effect","account_id":"acct_j","req`); err != nil {
+		t.Fatalf("write torn tail: %v", err)
+	}
+	_ = f.Close()
+
+	scan, err := j.Scan()
+	if err != nil {
+		t.Fatalf("Scan: %v", err)
+	}
+	if scan.TornTails != 1 {
+		t.Fatalf("TornTails=%d want 1", scan.TornTails)
+	}
+	if scan.Malformed != 0 {
+		t.Fatalf("Malformed=%d want 0 — a torn FINAL line is the expected crash signature, not corruption", scan.Malformed)
+	}
+	if len(scan.Unsealed) != 2 {
+		t.Fatalf("Unsealed=%d want 2 — the intact prefix must still be recoverable", len(scan.Unsealed))
+	}
+}
+
+func TestSettlementJournal_MalformedMidFileLineIsSkippedLoudly(t *testing.T) {
+	j := testJournal(t, nil)
+	if err := j.WriteEffect(effect("req-a")); err != nil {
+		t.Fatalf("WriteEffect a: %v", err)
+	}
+	names, _ := segmentNames(j.Dir())
+	path := filepath.Join(j.Dir(), names[0])
+	f, _ := os.OpenFile(path, os.O_WRONLY|os.O_APPEND, 0o600)
+	if _, err := f.WriteString("{not json}\n"); err != nil {
+		t.Fatalf("write garbage: %v", err)
+	}
+	_ = f.Close()
+	if err := j.WriteEffect(effect("req-b")); err != nil {
+		t.Fatalf("WriteEffect b: %v", err)
+	}
+
+	scan, err := j.Scan()
+	if err != nil {
+		t.Fatalf("Scan: %v", err)
+	}
+	if scan.Malformed != 1 {
+		t.Fatalf("Malformed=%d want 1", scan.Malformed)
+	}
+	if len(scan.Unsealed) != 2 {
+		t.Fatalf("Unsealed=%d want 2 — one bad line must not strand the other recoverable effects", len(scan.Unsealed))
+	}
+}
+
+func TestSettlementJournal_SegmentRotationAndPrune(t *testing.T) {
+	// One record is ~250 bytes, so a 300-byte cap rotates on every write.
+	j := testJournal(t, func(o *Options) { o.SegmentMaxBytes = 300 })
+	keys := []Key{}
+	for _, id := range []string{"req-1", "req-2", "req-3"} {
+		if err := j.WriteEffect(effect(id)); err != nil {
+			t.Fatalf("WriteEffect %s: %v", id, err)
+		}
+		keys = append(keys, Key{AccountID: "acct_j", RequestID: id, Effect: EffectSettle})
+		// Segment names carry a millisecond stamp; keep them distinct so the
+		// oldest→newest scan order is unambiguous.
+		time.Sleep(2 * time.Millisecond)
+	}
+	scan, err := j.Scan()
+	if err != nil {
+		t.Fatalf("Scan: %v", err)
+	}
+	if len(scan.Segments) < 3 {
+		t.Fatalf("segments=%d want >=3 — the segment cap did not rotate", len(scan.Segments))
+	}
+	if len(scan.Unsealed) != 3 {
+		t.Fatalf("Unsealed=%d want 3", len(scan.Unsealed))
+	}
+	// Scan order must be oldest→newest: recovery re-drives in the order the
+	// effects were armed.
+	for i, want := range []string{"req-1", "req-2", "req-3"} {
+		if scan.Unsealed[i].RequestID != want {
+			t.Fatalf("Unsealed[%d]=%s want %s (segments must scan oldest→newest)", i, scan.Unsealed[i].RequestID, want)
+		}
+	}
+
+	// Nothing is prunable while effects are unsealed, however old.
+	if pruned, err := j.Prune(time.Now().Add(time.Hour)); err != nil || pruned != 0 {
+		t.Fatalf("Prune with unsealed effects pruned=%d err=%v, want 0 — an unsealed effect is an unrecovered bill", pruned, err)
+	}
+	for _, key := range keys[:2] {
+		if err := j.WriteSeal(key, SealSettled); err != nil {
+			t.Fatalf("WriteSeal: %v", err)
+		}
+	}
+	// req-3 is still unsealed, and the seals landed in the ACTIVE segment,
+	// so only the two sealed non-active segments may go.
+	pruned, err := j.Prune(time.Now().Add(time.Hour))
+	if err != nil {
+		t.Fatalf("Prune: %v", err)
+	}
+	if pruned != 2 {
+		t.Fatalf("pruned=%d want 2 (the two fully-sealed, non-active segments)", pruned)
+	}
+	scan, err = j.Scan()
+	if err != nil {
+		t.Fatalf("Scan after prune: %v", err)
+	}
+	if len(scan.Unsealed) != 1 || scan.Unsealed[0].RequestID != "req-3" {
+		t.Fatalf("after prune Unsealed=%+v want only req-3", scan.Unsealed)
+	}
+	if snapshot := j.MetricsSnapshot(); snapshot.Bytes <= 0 {
+		t.Fatalf("bytes gauge=%d want >0 after prune", snapshot.Bytes)
+	}
+}
+
+func TestSettlementJournal_QuarantinedSegmentIsNotPruned(t *testing.T) {
+	j := testJournal(t, func(o *Options) { o.SegmentMaxBytes = 300 })
+	if err := j.WriteEffect(effect("req-q")); err != nil {
+		t.Fatalf("WriteEffect: %v", err)
+	}
+	time.Sleep(2 * time.Millisecond)
+	key := Key{AccountID: "acct_j", RequestID: "req-q", Effect: EffectSettle}
+	if err := j.WriteQuarantine(key, "usage_event_conflict", 10); err != nil {
+		t.Fatalf("WriteQuarantine: %v", err)
+	}
+	if pruned, err := j.Prune(time.Now().Add(time.Hour)); err != nil || pruned != 0 {
+		t.Fatalf("pruned=%d err=%v want 0 — a quarantined effect must stay on disk for the operator", pruned, err)
+	}
+	scan, err := j.Scan()
+	if err != nil {
+		t.Fatalf("Scan: %v", err)
+	}
+	if scan.Quarantined != 1 {
+		t.Fatalf("Quarantined=%d want 1", scan.Quarantined)
+	}
+	if len(scan.Unsealed) != 0 {
+		t.Fatalf("Unsealed=%d want 0 — a quarantine suppresses re-drive", len(scan.Unsealed))
+	}
+}
+
+func TestSettlementJournal_ReopenAfterCloseRecovers(t *testing.T) {
+	// Process-crash proxy (failure class C4): everything written before the
+	// close must be visible to the next process.
+	dir := filepath.Join(t.TempDir(), "settlement-journal")
+	first, err := Open(Options{Dir: dir, Fsync: true})
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	if err := first.WriteEffect(effect("req-crash")); err != nil {
+		t.Fatalf("WriteEffect: %v", err)
+	}
+	if err := first.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	if err := first.WriteEffect(effect("req-after-close")); err != ErrClosed {
+		t.Fatalf("write after Close err=%v want ErrClosed", err)
+	}
+
+	second, err := Open(Options{Dir: dir, Fsync: true})
+	if err != nil {
+		t.Fatalf("reopen: %v", err)
+	}
+	defer second.Close()
+	scan, err := second.Scan()
+	if err != nil {
+		t.Fatalf("Scan: %v", err)
+	}
+	if len(scan.Unsealed) != 1 || scan.Unsealed[0].RequestID != "req-crash" {
+		t.Fatalf("reopened journal Unsealed=%+v want the pre-crash effect", scan.Unsealed)
+	}
+	if scan.Unsealed[0].TotalTokens != 20 || scan.Unsealed[0].TokenSource != "provider_reported" {
+		t.Fatalf("reopened effect lost its billing payload: %+v", scan.Unsealed[0])
+	}
+	if err := second.WriteSeal(scan.Unsealed[0].Key(), SealUsageEvent); err != nil {
+		t.Fatalf("WriteSeal: %v", err)
+	}
+	scan, _ = second.Scan()
+	if len(scan.Unsealed) != 0 {
+		t.Fatalf("after seal Unsealed=%d want 0", len(scan.Unsealed))
+	}
+}
+
+func TestSettlementJournal_HardSizeCapRefusesWrites(t *testing.T) {
+	// The lesser-harm choice: refusing a journal record is fail-open for
+	// billing (settlement still runs), while filling the disk takes sqlite —
+	// and therefore the whole money path — down with it.
+	j := testJournal(t, func(o *Options) { o.MaxTotalBytes = 300; o.SegmentMaxBytes = 300 })
+	if err := j.WriteEffect(effect("req-1")); err != nil {
+		t.Fatalf("first WriteEffect: %v", err)
+	}
+	err := j.WriteEffect(effect("req-2"))
+	if err != ErrFull {
+		t.Fatalf("second WriteEffect err=%v want ErrFull", err)
+	}
+	snapshot := j.MetricsSnapshot()
+	if snapshot.WriteFailures != 1 {
+		t.Fatalf("write_failures=%d want 1", snapshot.WriteFailures)
+	}
+	if snapshot.Effects != 1 {
+		t.Fatalf("effects=%d want 1 (the refused write must not count)", snapshot.Effects)
+	}
+	scan, _ := j.Scan()
+	if len(scan.Unsealed) != 1 {
+		t.Fatalf("Unsealed=%d want 1 — the accepted effect must still be recoverable", len(scan.Unsealed))
+	}
+}
+
+func TestSettlementJournal_OpenFailsClosedOnUnwritableDir(t *testing.T) {
+	root := t.TempDir()
+	locked := filepath.Join(root, "locked")
+	if err := os.Mkdir(locked, 0o500); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(locked, 0o700) })
+	if _, err := Open(Options{Dir: filepath.Join(locked, "settlement-journal"), Fsync: true}); err == nil {
+		t.Fatal("Open on an unwritable path returned nil error; cmd/gateway would boot with durability silently disabled")
+	}
+}
+
+func TestSettlementJournal_MetricsSnapshotRenders(t *testing.T) {
+	j := testJournal(t, nil)
+	if err := j.WriteEffect(effect("req-m")); err != nil {
+		t.Fatalf("WriteEffect: %v", err)
+	}
+	j.RecordRecovered(RecoveredUsageEvent)
+	j.SetPending(3, 1)
+	out := j.MetricsSnapshot().Prometheus()
+	for _, want := range []string{
+		"gateway_settlement_journal_effects_total 1",
+		"gateway_settlement_journal_recovered_total{result=\"usage_event\"} 1",
+		"gateway_settlement_journal_unsealed 3",
+		"gateway_settlement_journal_quarantined 1",
+		"gateway_settlement_journal_bytes",
+	} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("metrics output missing %q:\n%s", want, out)
+		}
+	}
+}

--- a/phase5-gateway/internal/settlement/journal/metrics.go
+++ b/phase5-gateway/internal/settlement/journal/metrics.go
@@ -1,0 +1,176 @@
+package journal
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+	"sync"
+)
+
+// Recovery result labels for gateway_settlement_journal_recovered_total.
+const (
+	// RecoveredSettled — the re-drive settled the still-active reservation.
+	RecoveredSettled = "settled"
+	// RecoveredUsageEvent — the reservation was gone or terminal, so the
+	// SPEC-006 § 17.7 fallback wrote the usage row instead.
+	RecoveredUsageEvent = "usage_event"
+	// RecoveredQuarantined — an unresolvable ErrUsageEventConflict.
+	RecoveredQuarantined = "quarantined"
+	// RecoveredRetry — a conflict that has not yet exhausted its attempts.
+	RecoveredRetry = "retry"
+	// RecoveredError — a transient failure; the effect stays unsealed and
+	// is retried on the next pass.
+	RecoveredError = "error"
+)
+
+var recoveredLabels = []string{
+	RecoveredSettled,
+	RecoveredUsageEvent,
+	RecoveredQuarantined,
+	RecoveredRetry,
+	RecoveredError,
+}
+
+// Snapshot is a consistent copy of the journal counters, following the
+// retry_metrics.go snapshot pattern (take the lock once, render outside it).
+type Snapshot struct {
+	Effects       int64
+	Seals         int64
+	Quarantines   int64
+	WriteFailures int64
+	Unsealed      int64
+	Quarantined   int64
+	Recovered     map[string]int64
+	Bytes         int64
+}
+
+type metrics struct {
+	mu            sync.Mutex
+	effects       int64
+	seals         int64
+	quarantines   int64
+	writeFailures int64
+	unsealed      int64
+	quarantined   int64
+	recovered     map[string]int64
+	bytes         int64
+}
+
+func (m *metrics) init() {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.recovered = newRecoveredMap()
+}
+
+func newRecoveredMap() map[string]int64 {
+	out := make(map[string]int64, len(recoveredLabels))
+	for _, label := range recoveredLabels {
+		out[label] = 0
+	}
+	return out
+}
+
+func (m *metrics) incEffects() {
+	m.mu.Lock()
+	m.effects++
+	m.mu.Unlock()
+}
+
+func (m *metrics) incSeals() {
+	m.mu.Lock()
+	m.seals++
+	m.mu.Unlock()
+}
+
+func (m *metrics) incQuarantines() {
+	m.mu.Lock()
+	m.quarantines++
+	m.mu.Unlock()
+}
+
+func (m *metrics) incWriteFailures() {
+	m.mu.Lock()
+	m.writeFailures++
+	m.mu.Unlock()
+}
+
+func (m *metrics) incRecovered(result string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.recovered == nil {
+		m.recovered = newRecoveredMap()
+	}
+	if _, known := m.recovered[result]; !known {
+		result = RecoveredError
+	}
+	m.recovered[result]++
+}
+
+func (m *metrics) setPending(unsealed, quarantined int64) {
+	m.mu.Lock()
+	m.unsealed = unsealed
+	m.quarantined = quarantined
+	m.mu.Unlock()
+}
+
+func (m *metrics) setBytes(bytes int64) {
+	m.mu.Lock()
+	m.bytes = bytes
+	m.mu.Unlock()
+}
+
+func (m *metrics) snapshot() Snapshot {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	recovered := newRecoveredMap()
+	for label, count := range m.recovered {
+		recovered[label] = count
+	}
+	return Snapshot{
+		Effects:       m.effects,
+		Seals:         m.seals,
+		Quarantines:   m.quarantines,
+		WriteFailures: m.writeFailures,
+		Unsealed:      m.unsealed,
+		Quarantined:   m.quarantined,
+		Recovered:     recovered,
+		Bytes:         m.bytes,
+	}
+}
+
+// Prometheus renders the snapshot in the gateway's /metrics text format.
+func (s Snapshot) Prometheus() string {
+	var b strings.Builder
+	b.WriteString("# HELP gateway_settlement_journal_effects_total Settlement effects durably journaled before the settle attempt.\n")
+	b.WriteString("# TYPE gateway_settlement_journal_effects_total counter\n")
+	fmt.Fprintf(&b, "gateway_settlement_journal_effects_total %d\n", s.Effects)
+	b.WriteString("# HELP gateway_settlement_journal_seals_total Journaled effects sealed after reaching a durable terminal.\n")
+	b.WriteString("# TYPE gateway_settlement_journal_seals_total counter\n")
+	fmt.Fprintf(&b, "gateway_settlement_journal_seals_total %d\n", s.Seals)
+	b.WriteString("# HELP gateway_settlement_journal_quarantines_total Journaled effects quarantined as unresolvable.\n")
+	b.WriteString("# TYPE gateway_settlement_journal_quarantines_total counter\n")
+	fmt.Fprintf(&b, "gateway_settlement_journal_quarantines_total %d\n", s.Quarantines)
+	b.WriteString("# HELP gateway_settlement_journal_write_failures_total Journal record writes that failed (settlement continues fail-open).\n")
+	b.WriteString("# TYPE gateway_settlement_journal_write_failures_total counter\n")
+	fmt.Fprintf(&b, "gateway_settlement_journal_write_failures_total %d\n", s.WriteFailures)
+	b.WriteString("# HELP gateway_settlement_journal_unsealed Unsealed settlement effects observed by the last recovery scan.\n")
+	b.WriteString("# TYPE gateway_settlement_journal_unsealed gauge\n")
+	fmt.Fprintf(&b, "gateway_settlement_journal_unsealed %d\n", s.Unsealed)
+	b.WriteString("# HELP gateway_settlement_journal_quarantined Quarantined settlement effects awaiting operator reconciliation.\n")
+	b.WriteString("# TYPE gateway_settlement_journal_quarantined gauge\n")
+	fmt.Fprintf(&b, "gateway_settlement_journal_quarantined %d\n", s.Quarantined)
+	b.WriteString("# HELP gateway_settlement_journal_recovered_total Settlement effects re-driven by the journal recovery pass.\n")
+	b.WriteString("# TYPE gateway_settlement_journal_recovered_total counter\n")
+	labels := make([]string, 0, len(s.Recovered))
+	for label := range s.Recovered {
+		labels = append(labels, label)
+	}
+	sort.Strings(labels)
+	for _, label := range labels {
+		fmt.Fprintf(&b, "gateway_settlement_journal_recovered_total{result=%q} %d\n", label, s.Recovered[label])
+	}
+	b.WriteString("# HELP gateway_settlement_journal_bytes Bytes currently held by settlement journal segments.\n")
+	b.WriteString("# TYPE gateway_settlement_journal_bytes gauge\n")
+	fmt.Fprintf(&b, "gateway_settlement_journal_bytes %d\n", s.Bytes)
+	return b.String()
+}

--- a/phase5-gateway/internal/storage/sqlite/store.go
+++ b/phase5-gateway/internal/storage/sqlite/store.go
@@ -1297,7 +1297,13 @@ func (s *Store) SettleDemoReservation(ctx context.Context, settlement storage.Re
 		return err
 	}
 	if status != "active" {
-		return fmt.Errorf("reservation %s is %s", settlement.RequestID, status)
+		// Wraps the sentinel exactly like SettleReservation does. A caller
+		// that CLASSIFIES the error (the #763 journal recovery ladder) must
+		// see a terminal demo reservation as terminal, or it would retry an
+		// already-settled effect forever instead of falling through to the
+		// idempotent usage-event rung. The settle path itself is unaffected:
+		// settleAfterCommit treats every settle error identically.
+		return fmt.Errorf("%w: reservation %s is %s", storage.ErrReservationTerminal, settlement.RequestID, status)
 	}
 	if settlement.SettledAt.IsZero() {
 		settlement.SettledAt = time.Now().UTC()

--- a/phase5-gateway/internal/storage/sqlite/store_test.go
+++ b/phase5-gateway/internal/storage/sqlite/store_test.go
@@ -1123,6 +1123,33 @@ func TestReservationErrorBranches(t *testing.T) {
 	}
 }
 
+// TestSettleDemoReservationTerminalWrapsSentinel: the demo twin must classify
+// like its non-demo sibling. The #763 journal recovery ladder branches on
+// ErrReservationTerminal to fall through to the idempotent usage-event rung;
+// an unwrapped error there would make it retry an already-settled demo
+// request on every pass, forever.
+func TestSettleDemoReservationTerminalWrapsSentinel(t *testing.T) {
+	ctx := context.Background()
+	store := newTestStore(t)
+	createAccount(t, store, "acct_demo_terminal")
+	if _, err := store.ReserveQuota(ctx, storage.ReservationRequest{
+		AccountID: "acct_demo_terminal", RequestID: "req_demo_terminal", WindowDate: "2026-05-29",
+		RequestedTokens: 5, DailyQuota: 100,
+	}); err != nil {
+		t.Fatalf("ReserveQuota: %v", err)
+	}
+	if err := store.RefundReservation(ctx, "acct_demo_terminal", "req_demo_terminal", fixedTime().Unix()); err != nil {
+		t.Fatalf("RefundReservation: %v", err)
+	}
+	err := store.SettleDemoReservation(ctx, storage.ReservationSettlement{
+		AccountID: "acct_demo_terminal", RequestID: "req_demo_terminal", PromptTokens: 1,
+		TokenSource: "provider_reported", Outcome: "ok",
+	}, storage.DemoUsageEvent{RequestID: "req_demo_terminal", ClientIP: "203.0.113.7"})
+	if !errors.Is(err, storage.ErrReservationTerminal) {
+		t.Fatalf("SettleDemoReservation on refunded reservation err=%v, want ErrReservationTerminal", err)
+	}
+}
+
 func TestReservationSettlementRejectsInvalidTokenTotals(t *testing.T) {
 	ctx := context.Background()
 	store := newTestStore(t)


### PR DESCRIPTION
Closes #763. PR 5 of epic #770 — completes the P1 tier.

## What changed

On the streaming after-commit path, if `SettleReservation` AND the `EnsureUsageEvent` fallback both failed, the gateway logged, refunded, and **dropped the usage row** — the buyer had a committed 200 stream, the provider gets paid via the coordinator, and nothing is billed with no durable record. The SPEC-022 reconciler structurally cannot catch it (it scans `active+settlement_hold=1` rows and rejects non-`coordinator_observed` tokens).

**Mechanism**: a separate append-only JSONL journal (`internal/settlement/journal`) with fsync-per-effect — deliberately **not** a table in `gateway.db`, which would flip the tripwire while covering none of the real failure classes (same handle, same file, same WAL, `synchronous=NORMAL`), and not a second sqlite file (same driver, correlated failure). Effects are armed in `settleAfterCommit` before the settle attempt (full billing payload, never prompt/response text; 0700/0600) and sealed after; the double-failure branch leaves them unsealed. Journal write failures are fail-open (bytes already flowed) and metric-visible. A hard total-size cap refuses writes with a CRITICAL log rather than filling the disk.

**Recovery** runs at startup (bounded pass; CRITICAL-but-serve on failure) and on its own periodic loop (own knobs, independent of the SPEC-022 reconciler): grace window, batch cap, the existing idempotent settle ladder (`EnsureUsageEvent`'s payload verify is the no-double-bill guard), quarantine after repeated payload conflicts, retention prune. v1 journals the settle effect only — reservation-before-dispatch is already the durable arm; `SettleDemoReservation` now wraps `ErrReservationTerminal` so the ladder can classify demo terminals.

Tripwire flipped: `TestSeamH7_SettlementRecoveredFromJournal` — the forced double-failure leaves one unsealed effect; a second Server over the same store recovers exactly one usage row (billed 20), idempotent on re-scan. 27 new tests incl. fsync-order (the load-bearing property), settle-landed-but-seal-lost, crash-window, conflict quarantine + hold release, torn tail, rotation/prune, demo re-drive, reconciler race, #762-replay-writes-no-effect, config back-compat via real `Load()`.

## Audit (three codex lanes, full diff — four rounds, each a strict narrowing)

- security R1: **PASS 0/0/0** (accepted).
- code R1 HIGH: recovery wedged on the §17.7 crash window (active reservation + existing usage row → unclassified settle error) → fixed with fall-through to the idempotent rung. code R1 MEDIUM: `fsyncDir` swallowed real errors → propagate (EINVAL/ENOTSUP whitelisted). architect R1 MEDIUM: §17.7 sealed past a failed refund → seal gated on refund success.
- code R2 MEDIUM: the same seal gate was missing at recovery's own refund → mirrored. During this fix the H7 tripwire itself caught an over-strict gate (`ErrReservationNotFound` is the benign already-terminal sentinel and must still seal — treating it as failure wedged effects perpetually unsealed).
- architect R2 MEDIUM: the conflict path never released an active hold → best-effort refund before retry/quarantine. code R3: **PASS 0/0/0**.
- architect R3 MEDIUM (final narrowing): a refund failure on the last conflict attempt still quarantined, stranding the hold → a failed hold release no longer consumes an attempt. architect R4 (final round): **PASS 0/0/0**.

## Deliberately not covered (documented in findings.md)

Disk-full (C6 — no local journal survives it); journal-write + settle compound failure (fail-open, metric-visible); crash mid-stream before any terminal (reaper refunds, as today); the SPEC-022 hold-marker sibling leak (`effect` field future-proofed, not v1); multi-instance journal arbitration (single gateway today, no lockfile). Scope is the streaming after-commit path — non-streaming settles fail closed pre-response and have no delivered-but-unbilled window. Operational notes: recovery bills retroactively into the journaled `window_date`; one fsync per billed streaming request (after commit, invisible to TTFT; group-commit escape hatch deliberately unbuilt); `gateway -check` now creates the journal dir.

All three suites green pre-push: gateway `go build/vet/test ./...`, `-race` on router+journal, and the cross-service integration module.

SPEC-GOVERNANCE-DECLARATION-BEGIN
{
  "schema_version": "spec-pr-governance-v1",
  "behavior_change": "yes",
  "contract_change": "none",
  "specs": ["SPEC-005", "SPEC-006", "SPEC-036"],
  "requirements": ["SPEC-036-R001"],
  "authority_domains": ["billing-settlement-formula", "buyer-api-error-contract", "compute-integrity-settlement"],
  "arbitration": ["CODE_BUG"],
  "tests": ["phase5-gateway/internal/router/seam_harness_test.go", "phase5-gateway/internal/router/settlement_journal_recovery_test.go", "phase5-gateway/internal/settlement/journal/journal_test.go"],
  "journeys": ["not-required"],
  "issue": "https://github.com/Augustas11/macprovider/issues/770"
}
SPEC-GOVERNANCE-DECLARATION-END

🤖 Generated with [Claude Code](https://claude.com/claude-code)
