### PR TITLE
Seam hardening P2: reconcile SPEC-032 with verified prod posture + sticky risk acceptance (#769)

### DIFF
--- a/audits/2026-07-27/AUDIT_SEAM_769_r2.md
+++ b/audits/2026-07-27/AUDIT_SEAM_769_r2.md
@@ -1,0 +1,26 @@
+# Review R2: #769 reconciliation (docs-only)
+
+ROUND 2. R1 found one HIGH: the v0.2 sweep missed spec claim sites (line 12
+"live in production" and the 2026-07-11 production-posture section) — the
+cross-cutting-sweep failure mode. FIXED in the amended commit, and the fix
+went deeper: probing the RUNNING process revealed the earlier "section absent
+→ zero-value OFF" mechanism was itself wrong — the process loads
+`--config-overlay /etc/macprovider/coordinator.pearl-overlays.yaml`, which
+EXPLICITLY sets `require_autotune_hello_gate: false` (revised 2026-07-22;
+v0.1's claim was accurate at its 2026-07-11 baseline). All five spec sites now
+corrected with the accurate mechanism; the production-posture section
+distinguishes the 2026-07-11 baseline from the 2026-07-27 posture; the
+runbook table now records the overlay facts including
+`telemetry_drift.enabled: true` live (so #764/#765 missing_benchmark observe
+alerts fire; quarantine stays dormant) and `pool.canary_enabled: false`
+explicit.
+
+Verify on `git diff origin/main...HEAD`: (1) no remaining stale prod-posture
+claim anywhere in SPEC-032 (grep it yourself — "live in production",
+"enabled in production", "true in prod", the posture section); (2) the new
+mechanism statements match the code (LoadWithOverlay semantics, overlay keys
+override); (3) the R1-passed items (risk note soundness, no sensitive leak,
+drift framing) only if this rework touched them.
+
+Report severity with file:line, ending `VERDICT: PASS (0 critical, 0 high, 0 medium)`
+or `VERDICT: FAIL (<counts>)`.

--- a/audits/2026-07-27/AUDIT_SEAM_769_r3.md
+++ b/audits/2026-07-27/AUDIT_SEAM_769_r3.md
@@ -1,0 +1,24 @@
+# Review R3 (final): #769 reconciliation (docs-only)
+
+ROUND 3. R2 found 2 HIGH: (1) more stale posture claims survived because they
+are LINE-WRAPPED and INDENTED in markdown — "enabled in\n   production" —
+which defeated both grep and exact-string replace (root cause found and
+fixed with whitespace-flexible regex + a wrap-proof flattened-text verify);
+(2) findings.md still carried the wrong "section absent" mechanism.
+
+Both fixed in the amended commit. All five spec sites now read: hello-gate
+enabled at the 2026-07-11 baseline, explicitly disabled by the 2026-07-22
+overlay revision (verified against the running process's --config-overlay);
+telemetry-drift observe mode enabled live (the spec's only live element now);
+the changelog and production-posture section carry the timeline; findings.md
+P2-4 attributes OFF to the explicit overlay false.
+
+Verify on `git diff origin/main...HEAD`: run your own wrap-proof check —
+flatten whitespace and search the FULL spec for any remaining
+present-tense claim that the hello-gate is enabled/live in production or
+that drift is disabled in production. Also confirm the corrected mechanism
+statements still match the code (LoadWithOverlay, main.go --config-overlay,
+gate wiring on RequireAutotuneHelloGate). R1-passed items unchanged.
+
+Report severity with file:line, ending `VERDICT: PASS (0 critical, 0 high, 0 medium)`
+or `VERDICT: FAIL (<counts>)`.

--- a/audits/2026-07-27/AUDIT_SEAM_769_r4.md
+++ b/audits/2026-07-27/AUDIT_SEAM_769_r4.md
@@ -1,0 +1,28 @@
+# Review R4 (FINAL round): #769 reconciliation (docs-only)
+
+ROUND 4 — final per repo audit policy; any new finding class here ships as a
+documented residual rather than another iteration.
+
+R3's findings, all fixed in the amended commit:
+- The four residual "live" phrasings are now PRECISION-qualified rather than
+  deleted, because two of them describe a SHIPPED-CODE property, not prod
+  posture: the FR-HG7 capability-gate bypass is "live in the shipped code
+  (moot at runtime while the gate is disabled in the overlay, but it defeats
+  the gate whenever enabled)"; the SIGHUP rationale reads "money-path gate
+  whenever enabled (disabled in the live overlay as of 2026-07-27)"; the
+  production-posture bullet narrows to "Part B (OPoI/canary)
+  specced-but-inactive, Part C telemetry-drift live in OBSERVE mode only";
+  the follow-up line says "shipped-code capability-gate bypass before any
+  re-enable".
+- The untracked review-prompt artifacts' stale mechanism text was corrected
+  (they are not part of the PR diff; fixed so they stop tripping reviews).
+
+Verify ONLY: (a) a wrap-proof flattened sweep of the FULL spec finds no
+remaining present-tense claim that the hello-gate or its enforcement is
+enabled/live in production (claims about the SHIPPED CODE qualified with
+"whenever enabled" are correct and expected); (b) the qualifications did not
+invert any technical meaning (FR-HG7 is still CRITICAL for the re-enable
+bar). Do not re-open R1/R2-passed scope.
+
+Report severity with file:line, ending `VERDICT: PASS (0 critical, 0 high, 0 medium)`
+or `VERDICT: FAIL (<counts>)`.

--- a/audits/2026-07-27/AUDIT_SEAM_769_security.md
+++ b/audits/2026-07-27/AUDIT_SEAM_769_security.md
@@ -1,0 +1,36 @@
+# Review: #769 hello-gate reconciliation + sticky risk-acceptance (docs-only PR)
+
+Review the FULL diff: `git diff origin/main...HEAD` (single commit; docs/spec
+only — SPEC-032 v0.2-draft corrections, a new runbook
+`ops/runbooks/seam-769-gate-posture-2026-07-27.md`, findings.md P2-4 update).
+This is a SECURITY-lens documentation review, not a code audit.
+
+Context: the live Pearl coordinator was probed read-only on 2026-07-27. Facts
+recorded: the running process loads --config-overlay /etc/macprovider/coordinator.pearl-overlays.yaml, which EXPLICITLY sets require_autotune_hello_gate: false (hello-gate OFF; corrected from an earlier zero-value-absent reading); canary timer inactive + DISABLED sentinel (accepted P0 #584
+exception); `warmup_gate_enabled` false live vs true committed (drift,
+surfaced not auto-fixed); `sticky_enabled` true (so the same-account TTFT
+side-channel risk-acceptance the issue requires is written, with a
+MUST-re-evaluate trigger before OpenRouter enrollment).
+
+Assess:
+1. Is the risk-acceptance note technically sound — is the side-channel
+   description accurate to how sticky affinity + KV residency work in this
+   codebase (spot-check the cited mechanisms: X-MacProvider-Conversation
+   routing, account-scoped sticky keys, #762 fingerprint keying)? Does it
+   under- or over-claim the isolation properties? Is the OpenRouter
+   marketplace-credential re-evaluation trigger correctly reasoned (many end
+   users behind one account credential)?
+2. Does the SPEC-032 correction introduce any NEW inaccuracy (verify the
+   corrected claims against the code: is the gate really config-gated
+   zero-value-off when the section is absent)?
+3. Does the runbook leak anything sensitive (paths, tokens, infra details
+   beyond what existing committed runbooks already expose — compare with
+   ops/runbooks/production-exception-register.md conventions)?
+4. Is the warmup-drift surfacing framed safely (does it avoid instructing a
+   dangerous action; is the "next deploy flips it ON" consequence claim
+   accurate given how the deploy scripts treat dist/coordinator.yaml —
+   check deploy tooling / check-deploy-config.sh)?
+
+Report severity CRITICAL / HIGH / MEDIUM / LOW / INFO with file:line and
+concrete reasoning, ending `VERDICT: PASS (0 critical, 0 high, 0 medium)` or
+`VERDICT: FAIL (<counts>)`.

--- a/audits/seam-hardening/findings.md
+++ b/audits/seam-hardening/findings.md
@@ -239,11 +239,19 @@ upgrade directive, add a `doctor` subcommand.
 Only a per-model *hardware-tier* gate exists; an old-but-hardware-eligible build can serve a model that
 needs a newer engine. **Fix:** add a per-model minimum-version floor to the routing gate.
 
-**P2-4 · Hygiene: hello-gate spec vs prod config; same-account timing risk** — `hygiene`
-`SPEC-032` claims the hello-gate is prod-on; committed prod config does not set it (also confirm
-`canary_enabled`/`warmup_gate_enabled` are ON in the live overlay — Go zero-value OFF). And if sticky
-routing is enabled for multi-tenant traffic, document acceptance of the residual same-account TTFT
-timing side-channel. **Fix:** reconcile spec vs overlay; write the risk-acceptance note.
+**P2-4 · Hygiene: hello-gate spec vs prod config; same-account timing risk** — `hygiene` — **FIXED (#769)**
+Live Pearl posture verified 2026-07-27 against the RUNNING process (`--config-overlay
+/etc/macprovider/coordinator.pearl-overlays.yaml`, overlay keys override): the overlay EXPLICITLY
+sets `require_autotune_hello_gate: false` (revised 2026-07-22; SPEC-032 v0.2-draft corrects its five
+prod-on claims — accurate at the 2026-07-11 baseline, drifted since) and `telemetry_drift.enabled:
+true` (observe — #764/#765 missing_benchmark alerts fire live; quarantine dormant); canary OFF
+(explicit overlay false + timer inactive + DISABLED sentinel — the accepted P0 #584 exception);
+`warmup_gate_enabled` false live vs true committed (DRIFT — surfaced, operator decision, not
+auto-fixed); `sticky_enabled` true →
+the same-account TTFT side-channel risk-acceptance is written, with an explicit MUST-re-evaluate
+trigger before OpenRouter enrollment (a marketplace credential collapses "same account" into "same
+marketplace"). All in `ops/runbooks/seam-769-gate-posture-2026-07-27.md`. **Residual:** hello-gate
+enable-after-survey shares the #765 live-pool survey prerequisite; warmup drift unresolved by design.
 
 ---
 

--- a/ops/runbooks/seam-769-gate-posture-2026-07-27.md
+++ b/ops/runbooks/seam-769-gate-posture-2026-07-27.md
@@ -1,0 +1,98 @@
+# Seam #769 — Live gate posture, spec reconciliation, and sticky-routing risk acceptance (2026-07-27)
+
+Epic #770, issue #769 (P2, hygiene). Everything below was verified against the
+**live** Pearl coordinator on 2026-07-27 — against the RUNNING process, whose
+cmdline is `--config /opt/macprovider/coordinator.yaml --config-overlay
+/etc/macprovider/coordinator.pearl-overlays.yaml` (per `ps`; overlay keys
+override base). Note two stale path citations in older runbooks: the
+production-exception-register greps `/etc/macprovider/coordinator.yaml`, which
+does not exist — base config is under `/opt/macprovider/`, and the overlay is
+the file that carries the gate posture (last modified 2026-07-22).
+
+## 1. Verified live posture
+
+| Control | Committed `dist/coordinator.yaml` | Live Pearl config | Effective |
+|---|---|---|---|
+| `proof_of_weights.require_autotune_hello_gate` | absent | **explicit `false` in the overlay** (was `true` at the spec's 2026-07-11 baseline) | **OFF** |
+| `proof_of_weights.telemetry_drift.enabled` | absent | **explicit `true` in the overlay** | **ON (observe)** — so the #764/#765 `missing_benchmark` observe alerts fire live; `quarantine_missing_benchmark` absent → #765 quarantine stays dormant |
+| `pool.canary_enabled` | absent | **explicit `false` in the overlay**; canary-buyer timer `inactive`, enable-gate absent, `DISABLED` sentinel present | **OFF** |
+| `pool.warmup_gate_enabled` | `true` ("STAGE 2: gate ON") | **`false`** (same stale comment) | OFF — **drift, see §3** |
+| `routing.sticky_enabled` | `true` | `true` | **ON — see §4** |
+| `provider_http.timeout_s` | 300 | 300 | (the #760 twin-wall follow-up input) |
+
+## 2. Spec reconciliation (done in this PR)
+
+SPEC-032 v0.1 claimed `require_autotune_hello_gate: true` "in the Pearl
+production overlay" in five places (§1 prose, numbering note, FR-HG1, config
+table, production-posture section). All corrected in v0.2-draft: the claim was
+accurate at the spec's 2026-07-11 baseline and the overlay was deliberately
+flipped to `false` by its 2026-07-22 revision — the gate is OFF in prod. The intended
+production posture remains ON, but flipping it requires a live-pool hardware-
+evidence survey first (the same precondition documented for the #765 benchmark
+quarantine in `audits/seam-hardening/findings.md`) — an unsurveyed enable
+could fence the current fleet, repeating the 2026-07-10 single-provider
+incident shape.
+
+The canary-off posture is the known, accepted P0 #584 exception (continuous
+canary disabled pending lab-Mac capacity); SPEC-032's incident references
+should be read with that posture in mind. Not a new decision — recorded here
+because #769 asked for proof of the canary state, and the proof came back
+"off".
+
+## 3. Warmup-gate drift (surfaced, deliberately NOT auto-fixed)
+
+Committed `phase4-coordinator/dist/coordinator.yaml:44` says
+`warmup_gate_enabled: true  # STAGE 2: gate ON (live test)`. The live file
+says `false` with the same comment — someone flipped the live value without
+updating the comment or back-porting to the committed template. Consequence:
+**the next deploy that syncs the committed template would silently flip the
+warmup gate ON in prod.**
+
+This runbook surfaces the drift; it does not resolve it, because the intent is
+unknowable from the config alone (was the STAGE 2 live test concluded-and-
+reverted, or is the live `false` the accident?). Resolution belongs to the
+operator with the STAGE 2 context. Options: (a) conclude the live test and set
+the committed template to `false` with a dated comment, or (b) restore `true`
+live via the normal deploy path. Until resolved, treat
+`ALLOW_CONFIG_DRIFT`-style deploys of this file as unsafe. (Same drift class
+as the 2026-07-02 sticky_enabled strip recorded in the committed file's own
+comments — this file has a history of live/committed divergence.)
+
+## 4. Sticky-routing same-account timing side-channel — RISK ACCEPTED
+
+`routing.sticky_enabled: true` is live, so the residual side-channel #769
+names is a present-tense property of production, and this section is the
+risk-acceptance note the issue requires.
+
+**The channel:** sticky conversation affinity (`X-MacProvider-Conversation`,
+PR #302) routes a conversation's requests to the provider already holding its
+KV/context. Within ONE account, a request that reuses another conversation's
+tag (or a prefix-cached prompt) can observe a TTFT difference — warm vs cold —
+and infer whether "that" conversation recently ran. Cross-account exposure is
+not in scope of this note: conversation tags are fingerprint-keyed per account
+at the gateway (#762) and sticky keys are account-scoped; cross-tenant
+isolation rests on the gateway boundary as documented in the seam audit
+(`audits/seam-hardening/findings.md`), with the provider's direct HTTP port
+required to stay off-tenant.
+
+**Why accepted:** (1) the observer must already be inside the account — the
+same principal that could simply read its own conversation history; (2) the
+signal is one bit (warm/cold) degraded by pool churn, canary-less routing
+variance, and the 1800s sticky TTL; (3) disabling sticky costs real TTFT for
+every multi-turn buyer, which is the metric OpenRouter ranks on. The trade is
+accepted for the current single-digit-provider beta fleet.
+
+**Revisit triggers:** enabling any sub-account/team feature where principals
+within one account have distinct privacy expectations; enrolling traffic
+where a marketplace (OpenRouter) multiplexes MANY end-users through one
+account credential — that collapses "same account" into "same marketplace",
+and this acceptance MUST be re-evaluated before enrollment; or exposing the
+provider HTTP port to tenants (breaks the isolation predicate above).
+
+## 5. Follow-ups (owned elsewhere, listed for traceability)
+
+- Coordinator twin-wall raise + C2/C2b deploy-gate retarget (P0-adjacent
+  follow-up from #760; `provider_http.timeout_s: 300` confirmed live above).
+- Hello-gate enable-after-survey and #765 quarantine enable-after-survey share
+  one prerequisite: a live-pool hardware-evidence/benchmark survey.
+- Warmup-gate drift resolution (§3) — operator decision.

--- a/specs/SPEC-032-proof-of-weights-hello-gate.md
+++ b/specs/SPEC-032-proof-of-weights-hello-gate.md
@@ -1,6 +1,6 @@
 # SPEC-032 — Autotune Hardware-Evidence Admission Gate, OPoI & Proof-of-Weights Boundary
 
-**Status:** v0.1-draft
+**Status:** v0.2-draft
 **Date:** 2026-07-11
 **Depends on:** SPEC-002 (coordinator admission, provider state machine; F-2 defines provisional/pinned tiers), SPEC-003 (open onboarding, tiers), **SPEC-008 (Tier-2 — authoritative on the model-hash routing-exclusion predicate and attestation; this spec MUST NOT override it)**, SPEC-031 (canary probe mechanism — OPoI reuses it), and the item-10 hardware-verifier verdict spec (owns `hardware-verifier.v2`, consumed here as an input). SPEC-020 (provider *autoupdate* trust table) is only tangentially related and is **not** the tier-definition source.
 **Related (distinct, cross-referenced only):** SPEC-030 (losslessness probe — a separate distributional probe family)
@@ -9,9 +9,11 @@
 2026-07-10 SPEC-vs-code drift audit; runbook item 9). Highest prior canonical spec
 was SPEC-031. This document is the reconstructed normative baseline for two
 coordinator trust signals that ship unspecced: the **autotune hardware-evidence
-admission gate** (the "hello-gate", **live in production**) and the **OPoI /
-proof-of-weights / telemetry-drift** signals (specced here but **disabled in
-production**). SPEC-031 explicitly deferred the *semantics* of `model_class_challenges`
+admission gate** (the "hello-gate", enabled in prod at the 2026-07-11 baseline,
+**explicitly disabled in the live Pearl overlay as of 2026-07-27** — see the
+production-posture section) and the **OPoI / proof-of-weights /
+telemetry-drift** signals (drift observe-mode **enabled live** since the
+2026-07-22 overlay revision; the rest disabled). SPEC-031 explicitly deferred the *semantics* of `model_class_challenges`
 and the OPoI pass flag to this baseline (SPEC-031 §2, §17); this spec owns them.
 
 ---
@@ -23,16 +25,18 @@ The coordinator carries two trust signals beyond the SPEC-031 liveness canary:
 1. **The autotune hello-gate** (`internal/autotune/gate.go`, `checkAutotuneHelloGate`
    in `internal/ws/server.go`) — an **admission** gate that, when enabled, refuses a
    provider at connect unless it presents fresh, verified **hardware evidence**
-   proving it can serve the model tier it claims. This gate is **enabled in
-   production** (`require_autotune_hello_gate: true` in the Pearl overlay) and is a
-   money-path / availability-path control: it is the gate that closed the intended
+   proving it can serve the model tier it claims. This gate was enabled in production at this spec's 2026-07-11 baseline but is **explicitly disabled
+   in the live Pearl overlay as of 2026-07-27** (`require_autotune_hello_gate: false`, overlay
+   revised 2026-07-22 — verified against the running process, epic #770 / #769; see the
+   production-posture section). It remains a money-path / availability-path control: it is the gate that closed the intended
    second provider in the 2026-07-10 transient-degrade incident (#2), leaving a
    single-provider pool.
 
 2. **OPoI / proof-of-weights / telemetry-drift** (`internal/pow/drift.go`) — a set
    of signals intended to detect a provider that has silently downgraded or swapped
-   its model. These are **disabled in production** and, critically, **as implemented
-   are not proof of weights at all**.
+   its model. Telemetry-drift observe mode is **enabled in the live overlay as of
+   2026-07-27** (`telemetry_drift.enabled: true`; the OPoI canary and every enforcement remain
+   off) and, critically, these signals **as implemented are not proof of weights at all**.
 
 **The central honesty problem.** "OPoI" (Overt Proof of Inference) and
 "proof_of_weights" are aspirational names for a mechanism that does not yet prove
@@ -48,8 +52,9 @@ telemetry-drift breach does **nothing but emit a `WARN` log**. This spec therefo
 **refuses to let "proof-of-weights" imply a guarantee the code does not deliver**:
 it labels OPoI **non-binding / liveness-derived**, defines what a *real*
 proof-of-weights test would require, and pins the current signals' guarantee ceiling
-at **observability-only**. The substantive, live normative content of this spec is
-the **hello-gate admission policy** (Part A).
+at **observability-only**. The substantive normative content of this spec is
+the **hello-gate admission policy** (Part A) — currently disabled in the live overlay (see the
+production-posture section).
 
 ## 2. Scope
 
@@ -108,8 +113,8 @@ the **hello-gate admission policy** (Part A).
 ## Part A — Autotune hardware-evidence admission gate
 
 **FR-HG1 — Gate activation.** The hello-gate is a no-op unless
-`proof_of_weights.require_autotune_hello_gate` is true (default false; **true in the
-Pearl production overlay**). When active, it MUST run at provider hello for **both**
+`proof_of_weights.require_autotune_hello_gate` is true (default false; **explicitly
+false in the live Pearl overlay as of 2026-07-27; see §1**). When active, it MUST run at provider hello for **both**
 the composed-auth (v2) and legacy admission paths, for **both** provisional and
 pinned tiers, **before** the provider is recorded in the pool
 (`recordProviderAdmission` / `checkOrRecordAdmission`). On the **composed-auth (v2)
@@ -291,7 +296,7 @@ heartbeat. Both branches matter: an *uncatalogued* transition target has no
 uncatalogued model buyers requested is exactly the capability-gate bypass this FR
 closes.
 
-> **Conformance gap (§14) — this is a live capability-gate bypass.** As shipped, the
+> **Conformance gap (§14) — a capability-gate bypass live in the shipped code (moot at runtime while the gate is disabled in the overlay, but it defeats the gate whenever enabled).** As shipped, the
 > gate runs **only at admission**; a heartbeat can then replace `Provider.ModelID`
 > (with a larger *or uncatalogued* model) without re-consulting the ceiling, and buyer
 > routing uses that mutable model id (uncatalogued Tier-2 status stays routable unless
@@ -386,8 +391,9 @@ measurement path — it can only observe canary outcomes — so `opoi_pass_rate_
 MUST require `pool.canary_enabled`. Validation enforces this **only when
 `telemetry_drift.enabled = true`** (the validator returns before the coupling check
 when drift is disabled), which is correct: the window is inert unless drift is enabled.
-With canary disabled (the production posture), OPoI is dormant; the hello-gate (Part A)
-is the only live element of this spec.
+With canary disabled (the production posture), OPoI is dormant. As of 2026-07-27 the
+hello-gate (Part A) is ALSO disabled in the live overlay, and telemetry-drift observe mode is
+the only live element of this spec.
 
 ## Config surface and reload contract
 
@@ -395,7 +401,7 @@ is the only live element of this spec.
 
 | Key | Type | Default | Meaning |
 |-----|------|---------|---------|
-| `require_autotune_hello_gate` | bool | `false` (**true in prod**) | Master switch for Part A. |
+| `require_autotune_hello_gate` | bool | `false` (**explicitly false in the live overlay as of 2026-07-27; see §1**) | Master switch for Part A. |
 | `autotune_evidence_ttl_days` | int | `30` | Admission-reuse freshness window (cutoff = `now − ttl`; **raising** relaxes, **lowering** tightens); `>0` required when gate or drift enabled. |
 | `telemetry_drift.enabled` | bool | `false` | Master switch for Part C. |
 | `telemetry_drift.tps_ratio_threshold` | float | `0.70` | (0,1]; TPS-below-baseline trigger. |
@@ -412,8 +418,9 @@ config is **startup-only**. SIGHUP *does* reload a substantial surface — the T
 block, rewards/billing flags, settlement config, USD-conversion config, and routing
 model classes — but **not** `proof_of_weights.*`: the hello-gate wiring is fixed at
 construction and the whole proof-of-weights block is read from the boot config, so it
-is outside the SIGHUP allowlist. Since the hello-gate is a **live money-path/
-availability gate on a single-provider-fragile pool**, changing it (e.g. to relax
+is outside the SIGHUP allowlist. Since the hello-gate is a **money-path/availability gate on a
+single-provider-fragile pool whenever enabled** (disabled in the live overlay
+as of 2026-07-27), changing it (e.g. to relax
 evidence requirements during a redundancy emergency, or to enable/disable the gate)
 currently forces a coordinator restart — the same restart-outage class that SPEC-031
 FR-CAN26 addresses and that caused the 2026-07-10 ~5h outage. This spec **requires**
@@ -456,9 +463,10 @@ sessions keep serving during an unbounded scan does not satisfy this. Conformanc
 | FR-CFG1 config surface | Implemented | `ProofOfWeightsConfig` + validation. |
 | FR-CFG2 reload without restart + existing-session re-eval | **Gap** | `proof_of_weights.*` startup-only; SIGHUP reloads Tier-2/billing/settlement/USD/routing-classes but not this block, and there is no re-evaluation of existing sessions on gate enable/tighten. |
 
-**Re-enable / hardening bar.** The priority is **FR-HG7** — a **CRITICAL-severity** live
-bypass: the ceiling is not wired into routing, so a heartbeat model-swap (to a larger
-**or uncatalogued** model) defeats the whole gate, meaning the live gate does not
+**Re-enable / hardening bar.** The priority is **FR-HG7** — a **CRITICAL-severity**
+bypass live in the shipped code: the ceiling is not wired into routing, so a
+heartbeat model-swap (to a larger **or uncatalogued** model) defeats the whole
+gate whenever it is enabled, meaning the gate as shipped does not
 actually protect buyers from a capability-mismatched *served* model. Then the
 redundancy levers — **FR-HG5** below-two alert + **FR-CFG2** (no-restart tuning *and*
 existing-session re-eval, so an operator can safely relax the gate in an emergency
@@ -546,22 +554,33 @@ Forward criteria (expected to FAIL against the current build; §14 Gap rows):
   to the admitted weights (statistical/distributional or cryptographic attestation);
   the current nonce-echo OPoI does not qualify and is not so labeled.
 
-## Production posture (as of 2026-07-11)
+## Production posture (2026-07-11 baseline; superseded — see 2026-07-27 below)
 
-Read-only Pearl check (`/etc/macprovider/coordinator.pearl-overlays.yaml`):
+Read-only Pearl check at the 2026-07-11 baseline
+(`/etc/macprovider/coordinator.pearl-overlays.yaml`):
 
-- **Hello-gate: ENABLED** (`require_autotune_hello_gate: true`, `autotune_evidence_ttl_days: 30`).
-  This is the live, load-bearing element; it is what closed the intended second
-  provider in incident #2. Prod is **`pool_size: 1`** right now — the single-provider
-  fragility is a **live** condition, not hypothetical.
+- **Hello-gate: ENABLED at that time** (`require_autotune_hello_gate: true`,
+  `autotune_evidence_ttl_days: 30`). It is what closed the intended second
+  provider in incident #2. Prod was **`pool_size: 1`** — the single-provider
+  fragility was a **live** condition, not hypothetical.
+
+**2026-07-27 posture (#769, verified against the running process):** the same
+overlay now sets `require_autotune_hello_gate: false` (flipped by the
+2026-07-22 overlay revision), `pool.canary_enabled: false` explicitly, and
+`telemetry_drift.enabled: true` (observe mode — so the #764/#765
+`missing_benchmark` observe alerts ARE live; the #765 quarantine stays dormant
+behind the absent `quarantine_missing_benchmark`). Full snapshot + drift notes:
+`ops/runbooks/seam-769-gate-posture-2026-07-27.md`.
 - **OPoI/canary: DISABLED** (`canary_enabled: false`, `opoi_pass_rate_window: 0`) — OPoI
-  is dormant; Part B/C are specced-but-inactive.
+  is dormant; Part B (OPoI/canary) is specced-but-inactive, and Part C
+  telemetry-drift is live in OBSERVE mode only (heartbeat TPS/hash alerts;
+  no enforcement).
 - The `telemetry_drift` block is present in the overlay; with the OPoI window at 0 and
   canary disabled, the OPoI pass-rate path is inactive (TPS/hash drift may evaluate at
   heartbeat but is alert-only regardless — FR-TD1).
 
-The highest-value follow-up is **FR-HG7** (wire the ceiling into routing — closes the
-live capability-gate bypass). The single-provider fragility's remedy is chiefly
+The highest-value follow-up is **FR-HG7** (wire the ceiling into routing —
+closes the shipped-code capability-gate bypass before any re-enable). The single-provider fragility's remedy is chiefly
 **operational** (acquire and verify a second provider for the tier), surfaced by the
 FR-HG5 below-two alert and made safely tunable by FR-CFG2; it is **not** solved by
 auto-admitting an unverified provider (the recorded `air5` was never-verified and a
@@ -585,8 +604,25 @@ smaller box), which is why v0.1 ships no automatic probation.
 
 ## Changelog
 
+- **v0.2-draft (2026-07-27, epic #770 / #769)** — Prod-posture reconciliation.
+  Corrected the "true in the Pearl production overlay" claims (five sites: §1
+  prose, numbering note, FR-HG1, config table, production-posture section):
+  the RUNNING process loads `--config-overlay
+  /etc/macprovider/coordinator.pearl-overlays.yaml`, and that overlay
+  EXPLICITLY sets `require_autotune_hello_gate: false` (revised 2026-07-22;
+  the v0.1 claim was accurate at its 2026-07-11 baseline and drifted since).
+  Related live posture recorded the same day: `pool.canary_enabled: false`
+  explicit in the overlay AND the canary-buyer timer inactive with the
+  DISABLED sentinel (the accepted P0 #584 exception);
+  `telemetry_drift.enabled: true` live (observe mode — #764/#765
+  missing_benchmark observe alerts fire; quarantine stays dormant);
+  `warmup_gate_enabled` false live vs true committed (drift; surfaced in
+  `ops/runbooks/seam-769-gate-posture-2026-07-27.md`, not silently "fixed").
+  Sticky routing IS enabled live; the same-account timing-side-channel
+  risk-acceptance note required by #769 lives in the same runbook.
+
 - **v0.1-draft (2026-07-11):** Initial reconstructed baseline (runbook item 9, Wave C).
-  Verify-before-design read-only Pearl check established that the **hello-gate is live
+  Verify-before-design read-only Pearl check established that the **hello-gate was live at the 2026-07-11 baseline (flipped off by the 2026-07-22 overlay revision — see v0.2)
   in production** (`require_autotune_hello_gate: true`, `pool_size: 1`) while
   OPoI/canary are disabled — reshaping the spec so the live hello-gate admission policy
   (Part A, incl. the FR-HG5 redundancy fix) is the substantive core and OPoI is


### PR DESCRIPTION
Closes #769. PR 8 of epic #770 (P2, hygiene). Docs/spec only — no behavior change.

## What this does

The issue asked to reconcile SPEC-032's hello-gate claims with prod and to write the sticky-routing risk note. Both required probing the **running** Pearl coordinator (read-only, 2026-07-27), which settled everything:

- **Hello-gate: OFF in prod, and the spec was wrong** — but subtly: the running process loads `--config-overlay /etc/macprovider/coordinator.pearl-overlays.yaml`, and that overlay **explicitly** sets `require_autotune_hello_gate: false` (revised 2026-07-22). SPEC-032 v0.1's "true in prod" was accurate at its 2026-07-11 baseline and drifted since. v0.2-draft corrects all claim sites and keeps the timeline honest, distinguishing prod *posture* from the FR-HG7 **shipped-code** capability-gate bypass (still CRITICAL for the re-enable bar, qualified "whenever enabled" rather than deleted).
- **Telemetry-drift observe mode is LIVE** (`telemetry_drift.enabled: true` in the overlay) — which means the #764/#765 `missing_benchmark` observe alerts fire in prod today; the #765 quarantine stays dormant behind the absent second flag. Now recorded.
- **Canary: OFF** (explicit overlay `false` + timer inactive + `DISABLED` sentinel) — the accepted P0 #584 exception, now written where #769 asked for proof.
- **Warmup-gate drift surfaced, deliberately not auto-fixed**: live `false` vs committed `true` with the same stale "gate ON" comment — the next template sync would silently flip a prod gate. Operator decision; both resolution options documented.
- **Sticky routing is ON** → the required same-account TTFT side-channel **risk-acceptance** is written (`ops/runbooks/seam-769-gate-posture-2026-07-27.md`), with an explicit **MUST-re-evaluate trigger before OpenRouter enrollment**: one marketplace credential collapses "same account" into "same marketplace".
- Stale path citations in older runbooks noted (`/etc/macprovider/coordinator.yaml` does not exist; base is under `/opt/macprovider/`, posture lives in the overlay).

## Review

Security-lens codex review, four rounds (docs precision, not design churn): R1 caught an incomplete claim sweep; R2 caught more — root cause being **line-wrapped, indented markdown defeating both grep and exact-string replace** (fixed with flattened-text sweeps + asserted whitespace-flexible regex; saved as a standing lesson); R3 caught the last four sites and drove the shipped-code-vs-posture qualification; R4: **PASS (0 critical, 0 high, 0 medium)**, explicitly confirming FR-HG7's CRITICAL meaning survived the qualification.

## Governance note

`spec-index / check` will be red: `ops/runbooks/**` is a non-governance path, and this PR honestly has no behavior change to declare. The check is advisory (not in `ci-required`); merging past the red per convention (precedent: #774). `contract_change: "yes"` because a canonical SPEC-NNN was edited (factual reconciliation, v0.1 → v0.2-draft).

SPEC-GOVERNANCE-DECLARATION-BEGIN
{
  "schema_version": "spec-pr-governance-v1",
  "behavior_change": "none",
  "contract_change": "yes",
  "specs": ["SPEC-032"],
  "requirements": [],
  "authority_domains": ["hardware-evidence-admission"],
  "arbitration": ["SPEC_BUG"],
  "tests": [],
  "journeys": ["not-required"],
  "issue": "https://github.com/Augustas11/macprovider/issues/770"
}
SPEC-GOVERNANCE-DECLARATION-END

🤖 Generated with [Claude Code](https://claude.com/claude-code)
