### PR TITLE
Seam hardening P2: single-terminal-wins consistency arbiter, observe-only (#766)

### DIFF
--- a/audits/seam-hardening/findings.md
+++ b/audits/seam-hardening/findings.md
@@ -224,10 +224,60 @@ benchmark is un-quarantined on its next heartbeat with no operator action.
 
 ### P2 — debt
 
-**P2-1 · Single-terminal-wins request arbiter** — `money` — H4 (blocked)
-No arbiter joins the billing terminal (`billing_recorder.go:220`) and the buyer-504 terminal
-(`server.go:2996`); billing can complete while the buyer is told it timed out. **Fix:** a terminal
-latch/actor. Not unit-testable until it exists (see `harness/` H4).
+**P2-1 · Single-terminal-wins request arbiter** — `money` — H4
+**FIXED coordinator-side (issue #766), observe-only.** Nothing gateway-side.
+
+**The original framing was half wrong, and the correction is the finding.** There is **no
+goroutine race**: `recordRow` and every buyer write run on the request goroutine (the buyer
+package's only other goroutine is the recovery probe), and the relay layer's
+timeout-vs-completion race is *already* single-winner arbitrated under `activeMu`
+(`internal/ws/relay.go` — `done`/`errs` buffered 1, `done` pushed before `close(chunks)`). That
+arbitration is a **verified strength; a second latch there would be a regression.** The real gap
+was **structural**: nothing published "a buyer terminal was admitted", so `recordRow` could not
+observe whether the ledger and the buyer's HTTP status agreed. Today's no-charge-on-timeout
+property is an **accident** of two independent zeroing rules (`billing/formula.go`
+`FaultBreakerQualifying` early-return, and `billing_recorder.go`'s byte-estimated zeroing);
+nothing asserted it, and nothing would have noticed if either drifted.
+
+**Decision: consistency arbiter, NOT suppression.** Suppressing a "late" billing row is
+**under-billing** — the winning 200 row is written *after* the buyer terminal on the WS paths,
+and `forward_loop_test.go` scenario 2 pins the two-row `(502, retried=0)` + `(200, retried=1)`
+shape as the money contract. A suppressed provider credit is invisible and unrecoverable; an
+over-credit is detectable and reversible from the ledger — the same fail-open philosophy as
+#763. So the money rule is: **the buyer terminal wins the buyer's refund decision; every attempt
+row is retained for the provider ledger.** Only the late *buyer* terminal is telemetry-only,
+which `net/http` already enforces at the byte level.
+
+**Shipped:**
+- `internal/buyer/terminal_arbiter.go` — a per-request `requestTerminal` that latches the
+  buyer-visible terminal, records every credited row with a sequence number and an ordering
+  flag, and evaluates two agreement predicates.
+- The latch lives on the **existing** `noPriorDispatchResponseWriter` one-shot gate
+  (`phase_timing.go`) — the same point that stamps the item-18 no-charge marker, because that is
+  by construction the first buyer-visible write. The marker decision body is preserved verbatim
+  (`stampNoChargeMarker`); `settlementNoPriorDispatchHeader` is read by the gateway for
+  settle-vs-refund.
+- Rows are published from `billingRecorder.recordRow` immediately after **both**
+  `providerCredited = true` sites, so the arbiter sees exactly what the ledger credited.
+- Predicates: **I-1** a credited row with a success-shaped status under a ≥5xx buyer terminal and
+  no `FaultBreakerQualifying` flag (= *paid while the buyer was told it failed*); **I-2** a
+  dispatched request that served a 2xx and never credited anybody (= *served, unpaid*), evaluated
+  once at end-of-request against monotonic signals — never against the per-attempt
+  `dispatchedThisAttempt`, which resets on every failover iteration.
+- **Observe-only:** package-level `atomic.Uint64` counters (`buyerTerminalConflictTotal`,
+  `buyerTerminalLateTotal`, mirroring the `internal/ws/relay.go` idiom) plus
+  `event=terminal_conflict` / `event=buyer_terminal_late` warn logs. No enforcement, no config
+  flag, no response or ledger change. Enforcement — if ever — belongs in a later change designed
+  against real counter data.
+
+**Residual:** no prometheus surface (the buyer `Server` has no metrics handle; plumbing one is a
+separate change), so the counters are process-local and read via logs today. The
+`formula.go`-vs-`billing_recorder.go` double zeroing rule is now *observable* but still
+unreconciled — that is a spec decision, not a code fix, and is deliberately out of scope. The
+arbiter also does not treat the discarded `w.Write` error on the WS terminal as a signal.
+*Tripwire tests:* `internal/buyer/seam_h4_test.go` — five scenarios covering both terminal
+orderings, the forced credited-while-buyer-told-500 conflict, the predicate table, and
+claim-once across every transport.
 
 **P2-2 · Version floor unset in prod + client can't parse the rejection** — `supply`
 `required_binary_version` is set nowhere in prod config, and the Swift client has no `case 4004`
@@ -276,4 +326,7 @@ enable-after-survey shares the #765 live-pool survey prerequisite; warmup drift 
 4. ~~**P1-1 / P1-2**~~ — **DONE (#762, #763)**: money integrity before real buyer volume. #762 makes an
    id-less retry bill once; #763 makes an after-commit settle recoverable. Both keep the durable
    `(account_id, request_id)` key as the invariant — neither adds a second source of truth for money.
-5. P2 as debt burn-down.
+5. P2 as debt burn-down. ~~**P2-1**~~ — **DONE (#766)**, observe-only: the arbiter asserts that the
+   buyer terminal and the billing ledger agree, and deliberately does **not** suppress anything —
+   suppressing a late row would under-bill every failover retry. Enforcement stays out until the
+   conflict counter has been read on live traffic.

--- a/audits/seam-hardening/harness/README.md
+++ b/audits/seam-hardening/harness/README.md
@@ -17,6 +17,8 @@ Test files:
 - `phase5-gateway/internal/settlement/journal/journal_test.go` (H7's durability siblings: the
   per-effect fsync, torn tails, rotation/prune, reopen-after-close, the hard size cap)
 - `phase4-coordinator/internal/buyer/seam_h3_test.go`
+- `phase4-coordinator/internal/buyer/seam_h4_test.go` (H4's five scenarios, #766 — the H4 skip
+  is gone; `seam_h3_test.go` keeps a pointer comment where it used to live)
 
 ## Run
 
@@ -27,7 +29,7 @@ cd phase5-gateway     && go test ./internal/settlement/... -v                   
 cd phase4-coordinator && go test ./internal/buyer/  -run TestSeamH -v
 ```
 
-## Results (verified 2026-07-27) — 7 of 8 execute; only H4 is a documented skip
+## Results (verified 2026-07-27) — all 8 scenarios execute; no skips remain
 
 **Gateway suite**
 
@@ -47,13 +49,28 @@ cd phase4-coordinator && go test ./internal/buyer/  -run TestSeamH -v
 |---|---|---|---|
 | **H3** `RelayTimeoutStrikesOnBuyerCancel` | P0-3 | **FIXED (#761) — asserts guard** | one `ErrRelayTimeout` + a cancelled buyer ctx (threshold=1) → cancel terminal, provider stays `StateReady` |
 | **H3s** `RelayTimeoutNoStrikeOnBuyerCancel` | P0-3 | **FIXED (#761) — asserts guard** | streaming twin, 20 iterations across the select race — provider stays `StateReady` |
-| **H4** `SingleTerminalWins` | P2-1 | **SKIP (documented)** | not unit-testable: no arbiter joins the billing terminal and the buyer-504 terminal; testable only once a single-terminal arbiter exists |
+| **H4** `AgreeingTimeoutTerminal` | P2-1 | **FIXED (#766) — asserts arbiter** | relay timeout + LIVE buyer ctx, `MaxRetries=0` → `renderRetryExhausted` owns the buyer 504; one 504 row, claimed terminal 504, row seq **<** claim seq (bill-before-write), 0 conflicts |
+| **H4** `PostTerminalBillingRowIsOrderedAndAgrees` | P2-1 | **FIXED (#766) — asserts arbiter** | WS non-streaming generic relay error writes 502 inline, row logged after → **inverse** ordering (claim seq < row seq, `Late=true`), still 0 conflicts — "late" is an ordering fact, not a fault |
+| **H4** `CreditedWhileBuyerToldFailedIsAConflict` | P2-1 | **FIXED (#766) — the tripwire** | `settlement_attempt_outputs` dropped → provider credited (200, no breaker fault) while the buyer is told 500 → exactly 1 conflict, `buyerTerminalConflictTotal` +1, and the row is **retained, not suppressed** |
+| **H4** `TerminalArbiterPredicates` | P2-1 | **FIXED (#766)** | predicate table: I-1 conflict; `FaultBreakerQualifying` exempt (formula.go zeroes it); I-2 served-2xx-unpaid only at end-of-request; no-dispatch / no-billing exemptions; double-claim keeps the first; idempotent evaluation; nil-inert |
+| **H4** `ClaimOncePerTransport` | P2-1 | **FIXED (#766)** | WS non-streaming, WS streaming incremental **and** buffered, HTTP buffered, HTTP streaming — the claimed terminal equals the status the buyer observed on every transport |
 
 The "confirms FAIL/GAP" tests pass by asserting the **buggy-today** behavior, so when a fix lands
 they flip to failing-until-the-assertion-is-updated — a durable regression tripwire per finding.
 As of #763 no gateway scenario is still in that state: H1, H5a and H7 have all been re-pointed at the
 shipped fix, with their scenarios (not their assertions) left untouched, so each one now guards a
 behavior instead of documenting a gap.
+
+**H4's skip is retired (#766).** Its stated premise — "a cross-path race observable only end-to-end
+and non-deterministically" — was half wrong. There is no goroutine race: `recordRow` and every buyer
+write run on the request goroutine, and the relay layer's timeout-vs-completion race is already
+single-winner arbitrated under `activeMu`. The gap was **structural** — nothing published "a buyer
+terminal was admitted", so nothing could assert the ledger and the buyer's HTTP status agreed. With
+the arbiter publishing both sides the property is fully deterministic, and the tripwire forces the
+disagreement by dropping a settlement table rather than by adding a production test seam. Note that
+the arbiter is a **consistency** arbiter: it never suppresses a billing row, because a late row is
+the normal shape of the WS write-before-bill paths and suppressing it would under-bill every
+failover retry.
 
 ## Mechanism note (surfaced by wiring H1)
 

--- a/phase4-coordinator/internal/buyer/billing_recorder.go
+++ b/phase4-coordinator/internal/buyer/billing_recorder.go
@@ -113,7 +113,13 @@ type billingRecorder struct {
 	// dispatch boundary, not at request_log write time, so streaming
 	// failover-before-first-chunk and HTTP/WS retries share one
 	// monotonic attempt identity surface for later receipt settlement.
-	routeSnapshotAttemptN   int
+	routeSnapshotAttemptN int
+	// terminal is the per-request single-terminal-wins arbiter (#766).
+	// OBSERVE-ONLY: it latches the buyer-visible terminal at the first
+	// committed write and records every credited row, then asserts the two
+	// agree. It NEVER gates a billing row. May be nil on recorders built by
+	// direct struct construction in tests — every call site nil-guards.
+	terminal                *requestTerminal
 	outputCursorByte        int64
 	settlementAttemptN      int
 	hasSettlementAttemptN   bool
@@ -137,6 +143,52 @@ func (s *Server) newBillingRecorder(r *http.Request, state *forwardState, starte
 		accountID:               accountID,
 		authenticatedAccount:    authenticatedAccount,
 		hasAuthenticatedAccount: hasAuthenticatedAccount,
+		terminal:                newRequestTerminal(&s.log, requestID, accountID),
+	}
+}
+
+// claimBuyerTerminal latches the buyer-visible terminal status. Called from
+// noPriorDispatchResponseWriter.mark at the first committed write (#766).
+func (b *billingRecorder) claimBuyerTerminal(code int) {
+	if b == nil || b.terminal == nil {
+		return
+	}
+	b.terminal.claimBuyer(code)
+}
+
+// noteLateBuyerTerminal records a buyer write that arrived after the terminal
+// was latched. Telemetry only — net/http already discarded it.
+func (b *billingRecorder) noteLateBuyerTerminal(code int) {
+	if b == nil || b.terminal == nil {
+		return
+	}
+	b.terminal.noteLateBuyerWrite(code)
+}
+
+// noteBillableRow publishes a durably-credited provider row to the arbiter.
+func (b *billingRecorder) noteBillableRow(status, attemptN int, faultFlag string) {
+	if b == nil || b.terminal == nil {
+		return
+	}
+	b.terminal.noteBillableRow(status, attemptN, faultFlag)
+}
+
+// evaluateTerminalAgreement runs once per request, deferred from
+// handleChatCompletions so it observes the WS paths' post-write billing rows.
+// Observe-only: it emits warn logs + bumps package counters, and never changes
+// the response or the ledger.
+func (b *billingRecorder) evaluateTerminalAgreement() {
+	if b == nil || b.terminal == nil {
+		return
+	}
+	billingEnabled := false
+	if b.server != nil {
+		store, _, _ := b.server.billingState()
+		billingEnabled = store != nil && b.server.reqLog != nil
+	}
+	b.terminal.evaluateEndOfRequest(billingEnabled)
+	if b.server != nil && b.server.terminalObserver != nil {
+		b.server.terminalObserver(b.terminal)
 	}
 }
 
@@ -194,6 +246,12 @@ func (b *billingRecorder) beginDispatchAttempt() {
 // false and the response carries the item-18 no-charge marker.
 func (b *billingRecorder) markProviderDispatched() {
 	b.dispatchedThisAttempt = true
+	// Monotonic twin for the arbiter's end-of-request "served but unpaid"
+	// predicate — dispatchedThisAttempt resets above on every failover
+	// iteration, so it cannot answer "did this REQUEST ever dispatch?".
+	if b.terminal != nil {
+		b.terminal.noteDispatch()
+	}
 }
 
 // setRequestID updates the requestID field after idempotency-key
@@ -202,6 +260,9 @@ func (b *billingRecorder) markProviderDispatched() {
 // post-idempotency-rewrite semantics.
 func (b *billingRecorder) setRequestID(requestID string) {
 	b.requestID = requestID
+	if b.terminal != nil {
+		b.terminal.setRequestID(requestID)
+	}
 }
 
 // recordRow is the typed equivalent of the pre-refactor
@@ -355,6 +416,12 @@ func (b *billingRecorder) recordRow(
 		// leaves the ledger-exact "credited" signal set (conservative vs
 		// under-charge: the gateway settles rather than erasing real credit).
 		b.providerCredited = true
+		// #766 observe-only: publish the credited row to the request arbiter
+		// so the buyer terminal / ledger agreement is checkable. Placed with
+		// providerCredited (i.e. BEFORE the settlement-output bookkeeping) so
+		// the arbiter sees exactly what the ledger credited, including when a
+		// settlement-persist failure later turns the buyer terminal into a 500.
+		b.noteBillableRow(status, attemptN, faultFlag)
 		if err := b.recordSettlementAttemptOutput(ctx, billingStore, billingInput, settlementOutput); err != nil {
 			return err
 		}
@@ -375,6 +442,8 @@ func (b *billingRecorder) recordRow(
 		// provider-bound billable row has persisted (reqLog.Insert above
 		// succeeded) and settlement is being recorded now.
 		b.providerCredited = true
+		// #766 observe-only, same contract as the hot-path site above.
+		b.noteBillableRow(status, attemptN, faultFlag)
 		accountScope := accountScopeForSettlement(b.accountID)
 		settlementMode, settlementVersion := b.settlementPolicyForLedger()
 		billingInput := billing.HotPathInput{

--- a/phase4-coordinator/internal/buyer/phase_timing.go
+++ b/phase4-coordinator/internal/buyer/phase_timing.go
@@ -156,25 +156,36 @@ func (w *phaseTimingResponseWriter) inject() {
 // unmarked so the gateway settles-on-estimate rather than refunds. On a
 // streaming 200 the attempt was dispatched and non-503, so the marker is
 // absent; the gateway ignores the marker on 200 regardless.
+//
+// #766: this is ALSO the single-terminal latch. The first write through this
+// wrapper is by definition the buyer-visible terminal (net/http discards any
+// later status), so the same one-shot gate that stamps the marker publishes
+// the claim to the request arbiter (terminal_arbiter.go). The sync.Once became
+// mu+claimed only so the already-claimed branch can record the late write; the
+// marker decision body itself is preserved verbatim in stampNoChargeMarker —
+// settlementNoPriorDispatchHeader semantics are read by the gateway for
+// settle-vs-refund and are pinned by the item-18 tests.
 type noPriorDispatchResponseWriter struct {
 	http.ResponseWriter
-	rec  *billingRecorder
-	once sync.Once
+	rec *billingRecorder
+
+	mu      sync.Mutex
+	claimed bool
 }
 
 func (w *noPriorDispatchResponseWriter) WriteHeader(code int) {
-	w.mark(code)
+	w.mark(code, true)
 	w.ResponseWriter.WriteHeader(code)
 }
 
 func (w *noPriorDispatchResponseWriter) Write(b []byte) (int, error) {
 	// A Write with no prior WriteHeader is an implicit 200 (net/http default).
-	w.mark(http.StatusOK)
+	w.mark(http.StatusOK, false)
 	return w.ResponseWriter.Write(b)
 }
 
 func (w *noPriorDispatchResponseWriter) Flush() {
-	w.mark(http.StatusOK)
+	w.mark(http.StatusOK, false)
 	if flusher, ok := w.ResponseWriter.(http.Flusher); ok {
 		flusher.Flush()
 	}
@@ -184,21 +195,47 @@ func (w *noPriorDispatchResponseWriter) Unwrap() http.ResponseWriter {
 	return w.ResponseWriter
 }
 
-func (w *noPriorDispatchResponseWriter) mark(code int) {
-	w.once.Do(func() {
-		if w.rec == nil {
-			return
+// mark is the one-shot latch. explicit distinguishes a real status assertion
+// (WriteHeader) from the implicit-200 that Write/Flush carry: once the terminal
+// is claimed, subsequent body writes and flushes are ordinary response traffic,
+// NOT competing terminals, and must not be counted as late writes — otherwise
+// buyerTerminalLateTotal would just be a stream-chunk counter. A WriteHeader
+// after the latch IS a competing terminal (net/http discards it and logs
+// "superfluous WriteHeader"), so it is counted.
+func (w *noPriorDispatchResponseWriter) mark(code int, explicit bool) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if w.claimed {
+		if explicit {
+			// Lost the latch: net/http already committed the earlier status,
+			// so this terminal is telemetry-only. Never suppressed, never
+			// billed against — just counted (#766, observe-only).
+			w.rec.noteLateBuyerTerminal(code)
 		}
-		// Any billed prior attempt, or a billable current terminal attempt,
-		// means the response must NOT carry the no-charge marker.
-		if w.rec.providerCredited {
-			return
-		}
-		if w.rec.dispatchedThisAttempt && code != http.StatusServiceUnavailable {
-			return
-		}
-		w.Header().Set(settlementNoPriorDispatchHeader, "1")
-	})
+		return
+	}
+	w.claimed = true
+	w.stampNoChargeMarker(code)
+	w.rec.claimBuyerTerminal(code)
+}
+
+// stampNoChargeMarker is the item-18 marker body, preserved VERBATIM from the
+// pre-#766 sync.Once closure. It is extracted only so the terminal claim in
+// mark can run unconditionally — the decision logic, the early returns, and
+// the header write are byte-identical to the previous implementation.
+func (w *noPriorDispatchResponseWriter) stampNoChargeMarker(code int) {
+	if w.rec == nil {
+		return
+	}
+	// Any billed prior attempt, or a billable current terminal attempt,
+	// means the response must NOT carry the no-charge marker.
+	if w.rec.providerCredited {
+		return
+	}
+	if w.rec.dispatchedThisAttempt && code != http.StatusServiceUnavailable {
+		return
+	}
+	w.Header().Set(settlementNoPriorDispatchHeader, "1")
 }
 
 func writePhaseTimingHeaders(h http.Header, state *forwardState, now time.Time) {

--- a/phase4-coordinator/internal/buyer/seam_h3_test.go
+++ b/phase4-coordinator/internal/buyer/seam_h3_test.go
@@ -156,19 +156,21 @@ func seamH3StreamingScenario(t *testing.T) {
 	}
 }
 
-// H4 · single-terminal-wins / paid-while-buyer-told-timeout (INV-6).
-// Documented skip: not unit-testable. There is no arbiter/latch joining the two
-// terminal paths — billing settlement (billingRecorder.recordRow,
-// internal/buyer/billing_recorder.go:220) and the buyer 504 timeout terminal
-// (forwardWSNonStreaming, internal/buyer/server.go:2996) are produced by independent
-// paths. The "billing completed while the buyer was told it timed out" property is an
-// emergent cross-path race, observable only end-to-end and non-deterministically;
-// unit-asserting an ordering that no code enforces is not meaningful. Convert to a real
-// test once a terminal latch is introduced at the recordRow seam (a single-terminal
-// request-arbiter). See audits/seam-hardening/findings.md INV-6/INV-9.
-func TestSeamH4_SingleTerminalWins(t *testing.T) {
-	t.Skip("INV-6: no single-terminal-wins request actor exists; the billing terminal " +
-		"(billing_recorder.go:220) and the buyer 504 terminal (server.go:2996) are independent " +
-		"paths with no arbiter. The gap is a cross-path race observable only end-to-end. Attach a " +
-		"real test at the recordRow seam once a single-terminal request-arbiter is introduced.")
-}
+// H4 · single-terminal-wins / paid-while-buyer-told-failed (INV-6).
+// The documented skip that used to live here is GONE — #766 introduced the
+// single-terminal request arbiter (internal/buyer/terminal_arbiter.go), and the
+// scenarios now live in seam_h4_test.go:
+//
+//	TestSeamH4_AgreeingTimeoutTerminal                  — bill-before-write ordering
+//	TestSeamH4_PostTerminalBillingRowIsOrderedAndAgrees — write-before-bill ordering
+//	TestSeamH4_CreditedWhileBuyerToldFailedIsAConflict  — the INV-6 tripwire
+//	TestSeamH4_TerminalArbiterPredicates                — predicate unit table
+//	TestSeamH4_ClaimOncePerTransport                    — latch coverage per transport
+//
+// The skip's premise was half wrong: there is no cross-goroutine race (recordRow
+// and every buyer write run on the request goroutine, and the relay layer's
+// timeout-vs-completion race is already single-winner arbitrated under activeMu).
+// The gap was STRUCTURAL — nothing published "a buyer terminal was admitted", so
+// nothing could assert the ledger and the buyer's HTTP status agreed. With the
+// arbiter publishing both sides the property is deterministic, and H4-3 forces
+// the disagreement without any production-code seam.

--- a/phase4-coordinator/internal/buyer/seam_h4_test.go
+++ b/phase4-coordinator/internal/buyer/seam_h4_test.go
@@ -412,6 +412,33 @@ func TestSeamH4_TerminalArbiterPredicates(t *testing.T) {
 		}
 	})
 
+	t.Run("zero_credit_breaker_row_does_not_mask_served_unpaid", func(t *testing.T) {
+		// Audit R1 (code MEDIUM): attempt 0 logs a zero-credit
+		// breaker-qualifying row (formula.go zeroes it), attempt 1 commits a
+		// 200 to the buyer and its post-commit recordRow fails. The breaker
+		// row must NOT suppress the served-but-unpaid conflict — only a row
+		// that actually pays may.
+		rt := newRequestTerminal(nil, "req-3b", "acct-1")
+		rt.noteDispatch()
+		rt.noteBillableRow(http.StatusBadGateway, 0, billing.FaultBreakerQualifying)
+		rt.claimBuyer(http.StatusOK)
+		rt.evaluateEndOfRequest(true)
+		if got := rt.Conflicts(); got != 1 {
+			t.Fatalf("conflicts = %d, want 1 — a zero-credit breaker row is not payment", got)
+		}
+	})
+
+	t.Run("paying_row_suppresses_served_unpaid", func(t *testing.T) {
+		rt := newRequestTerminal(nil, "req-3c", "acct-1")
+		rt.noteDispatch()
+		rt.noteBillableRow(http.StatusOK, 1, billing.FaultNone)
+		rt.claimBuyer(http.StatusOK)
+		rt.evaluateEndOfRequest(true)
+		if got := rt.Conflicts(); got != 0 {
+			t.Fatalf("conflicts = %d, want 0 — a credited paying row settles the debt", got)
+		}
+	})
+
 	t.Run("served_2xx_without_dispatch_is_not_a_conflict", func(t *testing.T) {
 		rt := newRequestTerminal(nil, "req-4", "acct-1")
 		rt.claimBuyer(http.StatusOK)

--- a/phase4-coordinator/internal/buyer/seam_h4_test.go
+++ b/phase4-coordinator/internal/buyer/seam_h4_test.go
@@ -1,0 +1,607 @@
+package buyer
+
+// Seam-hardening e2e harness — coordinator-side scenario H4
+// (single-terminal-wins / paid-while-buyer-told-failed, INV-6). Companion to
+// the H3 scenarios in seam_h3_test.go and the risk register in
+// audits/seam-hardening/.
+//
+// These replace the documented H4 skip. The skip's premise ("a cross-path race
+// observable only end-to-end") was WRONG in one important way and right in
+// another: there is no goroutine race — recordRow and every buyer write run on
+// the request goroutine — but there was no arbiter publishing the buyer
+// terminal, so nothing could assert that the ledger and the buyer's HTTP
+// status agreed. #766 adds that arbiter (terminal_arbiter.go, observe-only),
+// which makes the property deterministically testable.
+//
+// Run: go test ./internal/buyer/ -run TestSeamH4 -count=1 -v
+
+import (
+	"bytes"
+	"context"
+	"database/sql"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/augstar/macprovider-coordinator/internal/billing"
+	"github.com/augstar/macprovider-coordinator/internal/config"
+	"github.com/augstar/macprovider-coordinator/internal/pool"
+	"github.com/augstar/macprovider-coordinator/internal/requestlog"
+	providerws "github.com/augstar/macprovider-coordinator/internal/ws"
+	"github.com/rs/zerolog"
+)
+
+// ---------------------------------------------------------------------------
+// Local harness. Deliberately package-internal: the shared helpers in
+// server_test.go live in the external buyer_test package and cannot reach the
+// arbiter, which is request-scoped and unexported.
+// ---------------------------------------------------------------------------
+
+func h4OpenRequestLog(t *testing.T) (*requestlog.Store, string) {
+	t.Helper()
+	dbPath := filepath.Join(t.TempDir(), "coordinator.db")
+	store, err := requestlog.OpenStore(dbPath)
+	if err != nil {
+		t.Fatalf("open request log: %v", err)
+	}
+	if _, err := store.DB().Exec(`
+CREATE TABLE IF NOT EXISTS audit_log (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    ts_utc TEXT NOT NULL,
+    event_type TEXT NOT NULL,
+    provider_id TEXT,
+    payload_json TEXT NOT NULL
+);`); err != nil {
+		t.Fatalf("create audit_log: %v", err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+	return store, dbPath
+}
+
+func h4RegisterWSProvider(reg *pool.Registry, providerID, assignedID, modelID string) {
+	reg.Register(&pool.Provider{
+		ProviderID:            providerID,
+		AssignedID:            assignedID,
+		Hostname:              providerID + ".local",
+		ModelID:               modelID,
+		ModelParamsB:          7,
+		RAMGB:                 16,
+		MaxContextTokens:      20000,
+		MaxConcurrency:        1,
+		SlotsFree:             1,
+		SlotsTotal:            1,
+		ThroughputTPSEstimate: 30,
+		Tier:                  pool.TierProvisional,
+		InferencePath:         pool.InferencePathWSTunneled,
+		State:                 pool.StateReady,
+		LastHeartbeatAt:       time.Now().UTC(),
+		ConnectedAt:           time.Now().UTC(),
+		BinaryVersion:         "0.1.0",
+	}, nil)
+}
+
+func h4PostChat(t *testing.T, s *Server, body []byte) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", bytes.NewReader(body))
+	rr := httptest.NewRecorder()
+	s.Handler().ServeHTTP(rr, req)
+	_, _ = io.Copy(io.Discard, rr.Result().Body)
+	return rr
+}
+
+func h4RequestLogStatuses(t *testing.T, dbPath string) []int {
+	t.Helper()
+	db, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatalf("open request log db: %v", err)
+	}
+	defer db.Close()
+	rows, err := db.Query(`SELECT status FROM request_log ORDER BY id`)
+	if err != nil {
+		t.Fatalf("query request_log: %v", err)
+	}
+	defer rows.Close()
+	var out []int
+	for rows.Next() {
+		var status int
+		if err := rows.Scan(&status); err != nil {
+			t.Fatalf("scan request_log: %v", err)
+		}
+		out = append(out, status)
+	}
+	return out
+}
+
+func h4Rewards() config.RewardsConfig {
+	return config.RewardsConfig{
+		GlobalMultiplier: 1.0,
+		ProviderShare:    0.90,
+		RateCard: map[string]config.RateCardEntry{
+			"model-a": {PromptCreditsPerMtok: 1000000, CompletionCreditsPerMtok: 2000000},
+		},
+	}
+}
+
+// h4Server builds a WS-tunneled single-provider coordinator with billing wired
+// and installs the arbiter observation seam.
+func h4Server(t *testing.T, reqLog *requestlog.Store, relay RelayFunc, observed **requestTerminal) *Server {
+	t.Helper()
+	billingStore, err := billing.NewStore(reqLog.DB())
+	if err != nil {
+		t.Fatalf("billing.NewStore: %v", err)
+	}
+	registry := pool.NewRegistry(nil)
+	h4RegisterWSProvider(registry, "p1", "s1", "model-a")
+	s := NewServer(
+		registry,
+		zerolog.Nop(),
+		time.Unix(1716768000, 0),
+		WithRequestLog(reqLog),
+		WithBilling(billingStore, h4Rewards()),
+		WithRoutingConfig(config.RoutingConfig{MaxRetries: 0, StickyTTLS: 1800, StickyMaxEntries: 10000}),
+		WithRelay(relay, time.Second),
+	)
+	s.terminalObserver = func(rt *requestTerminal) { *observed = rt }
+	return s
+}
+
+func h4RelayErr(err error) RelayFunc {
+	return func(_ context.Context, _ pool.Provider, reqID string, _ []byte, _ bool) (*providerws.RelayStream, error) {
+		errs := make(chan error, 1)
+		errs <- err
+		return &providerws.RelayStream{RequestID: reqID, Errors: errs}, nil
+	}
+}
+
+func h4RelaySuccess() RelayFunc {
+	return func(_ context.Context, _ pool.Provider, reqID string, _ []byte, _ bool) (*providerws.RelayStream, error) {
+		chunks := make(chan providerws.InferenceResponseChunk, 2)
+		done := make(chan providerws.InferenceResponseEnd, 1)
+		errs := make(chan error, 1)
+		go func() {
+			chunks <- providerws.InferenceResponseChunk{Type: "inference_response_chunk", RequestID: reqID, Seq: 0, Data: `{"id":"ok","choices":[{"message":{"content":"ok"}}],"usage":{"prompt_tokens":2,"completion_tokens":1,"total_tokens":3}}`}
+			done <- providerws.InferenceResponseEnd{Type: "inference_response_end", RequestID: reqID, Status: "complete", ChunksSent: 1}
+		}()
+		return &providerws.RelayStream{RequestID: reqID, Chunks: chunks, Done: done, Errors: errs}, nil
+	}
+}
+
+const h4ChatBody = `{"model":"model-a","messages":[{"role":"user","content":"hello"}]}`
+
+// ---------------------------------------------------------------------------
+// H4-1 · agreeing terminal, bill-before-write ordering.
+//
+// Relay yields ErrRelayTimeout with a LIVE buyer context (so the #761
+// buyer-cancel guard does not fire) → wsForwardTimedOut → retry budget is
+// exhausted at MaxRetries=0 → renderRetryExhausted owns the buyer 504. That
+// callback logs the attempt row BEFORE writeError, so the credited row is
+// observed at a LOWER sequence than the buyer claim. Both sides say 504:
+// agreement, zero conflicts.
+// ---------------------------------------------------------------------------
+func TestSeamH4_AgreeingTimeoutTerminal(t *testing.T) {
+	reqLog, dbPath := h4OpenRequestLog(t)
+	var observed *requestTerminal
+	s := h4Server(t, reqLog, h4RelayErr(providerws.ErrRelayTimeout), &observed)
+
+	rr := h4PostChat(t, s, []byte(h4ChatBody))
+
+	if rr.Code != http.StatusGatewayTimeout {
+		t.Fatalf("buyer status = %d, want 504; body=%s", rr.Code, rr.Body.String())
+	}
+	if statuses := h4RequestLogStatuses(t, dbPath); len(statuses) != 1 || statuses[0] != http.StatusGatewayTimeout {
+		t.Fatalf("request_log statuses = %v, want exactly [504]", statuses)
+	}
+	if observed == nil {
+		t.Fatal("terminal arbiter was never evaluated")
+	}
+	claim, ok := observed.claimedBuyer()
+	if !ok {
+		t.Fatal("no buyer terminal was claimed for a request that wrote a 504")
+	}
+	if claim.Status != http.StatusGatewayTimeout {
+		t.Fatalf("claimed buyer terminal = %d, want 504", claim.Status)
+	}
+	if claim.Source != terminalSourceBuyerWrite {
+		t.Fatalf("claim source = %q, want %q", claim.Source, terminalSourceBuyerWrite)
+	}
+	if got := observed.LateBuyerWrites(); got != 0 {
+		t.Fatalf("late buyer writes = %d, want 0 (single write path)", got)
+	}
+	rows := observed.Rows()
+	if len(rows) != 1 {
+		t.Fatalf("credited rows = %d, want 1: %#v", len(rows), rows)
+	}
+	if rows[0].Status != http.StatusGatewayTimeout {
+		t.Fatalf("credited row status = %d, want 504", rows[0].Status)
+	}
+	// ORDERING: renderRetryExhausted logs then writes.
+	if rows[0].Seq >= claim.Seq {
+		t.Fatalf("expected the billing row (seq %d) to precede the buyer terminal (seq %d) on the "+
+			"retry-exhausted path — renderRetryExhausted logs the attempt before writeError",
+			rows[0].Seq, claim.Seq)
+	}
+	if rows[0].Late {
+		t.Fatal("credited row marked Late on a bill-before-write path")
+	}
+	if got := observed.Conflicts(); got != 0 {
+		t.Fatalf("conflicts = %d, want 0 — buyer 504 and a 504 row agree", got)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// H4-2 · agreeing terminal, write-before-bill (INVERSE) ordering.
+//
+// The WS-non-streaming relay error that is neither Timeout, Closed, AEAD nor
+// NAK-fallback writes the 502 INLINE inside forwardWSNonStreaming and only
+// then returns wsForwardFailed, whose row is written afterwards by
+// handleNonRetryableTerminal. The arbiter must record the inverse sequence and
+// flag the row Late — and still find zero conflicts, because a 502 row under a
+// 502 buyer terminal agrees. This pins that "Late" is an ordering fact, not a
+// fault, which is exactly why late rows are never suppressed.
+// ---------------------------------------------------------------------------
+func TestSeamH4_PostTerminalBillingRowIsOrderedAndAgrees(t *testing.T) {
+	reqLog, dbPath := h4OpenRequestLog(t)
+	var observed *requestTerminal
+	s := h4Server(t, reqLog, h4RelayErr(errors.New("relay exploded")), &observed)
+
+	rr := h4PostChat(t, s, []byte(h4ChatBody))
+
+	if rr.Code != http.StatusBadGateway {
+		t.Fatalf("buyer status = %d, want 502; body=%s", rr.Code, rr.Body.String())
+	}
+	if statuses := h4RequestLogStatuses(t, dbPath); len(statuses) != 1 || statuses[0] != http.StatusBadGateway {
+		t.Fatalf("request_log statuses = %v, want exactly [502]", statuses)
+	}
+	if observed == nil {
+		t.Fatal("terminal arbiter was never evaluated")
+	}
+	claim, ok := observed.claimedBuyer()
+	if !ok {
+		t.Fatal("no buyer terminal was claimed for a request that wrote a 502")
+	}
+	if claim.Status != http.StatusBadGateway {
+		t.Fatalf("claimed buyer terminal = %d, want 502", claim.Status)
+	}
+	rows := observed.Rows()
+	if len(rows) != 1 {
+		t.Fatalf("credited rows = %d, want 1: %#v", len(rows), rows)
+	}
+	if rows[0].Status != http.StatusBadGateway {
+		t.Fatalf("credited row status = %d, want 502", rows[0].Status)
+	}
+	// INVERSE ORDERING vs H4-1: buyer terminal first, billing row after.
+	if claim.Seq >= rows[0].Seq {
+		t.Fatalf("expected the buyer terminal (seq %d) to precede the billing row (seq %d) on the "+
+			"WS write-before-bill path", claim.Seq, rows[0].Seq)
+	}
+	if !rows[0].Late {
+		t.Fatal("credited row not marked Late although it was recorded after the buyer terminal — " +
+			"the arbiter must observe write-before-bill ordering, which is precisely why late rows " +
+			"are recorded rather than suppressed (suppression would under-bill every failover retry)")
+	}
+	if got := observed.Conflicts(); got != 0 {
+		t.Fatalf("conflicts = %d, want 0 — buyer 502 and a 502 row agree", got)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// H4-3 · THE TRIPWIRE: provider credited while the buyer was told the request
+// failed (INV-6 / I-1).
+//
+// Forced deterministically without touching production code: drop
+// settlement_attempt_outputs after the stores are built. The WS success path
+// then runs logSuccess → recordRow → WriteHotPath SUCCEEDS (the provider is
+// credited, providerCredited=true, row status 200) → recordSettlementAttemptOutput
+// fails on the missing table → logSuccess returns an error → forwardWSNonStreaming
+// writes 500 request_log_failed to the buyer.
+//
+// Result: the ledger says a provider earned a 200-status credit with no
+// breaker-qualifying fault flag (so neither of the two accidental zeroing
+// rules applies), while the buyer was told the request failed. Pre-#766
+// nothing in the coordinator could see that. If this test ever reports zero
+// conflicts, the arbiter has stopped observing the money seam it exists for.
+// ---------------------------------------------------------------------------
+func TestSeamH4_CreditedWhileBuyerToldFailedIsAConflict(t *testing.T) {
+	reqLog, dbPath := h4OpenRequestLog(t)
+	var observed *requestTerminal
+	s := h4Server(t, reqLog, h4RelaySuccess(), &observed)
+
+	// After billing.NewStore has migrated the schema: remove the settlement
+	// attempt-output table so the post-credit bookkeeping fails.
+	if _, err := reqLog.DB().Exec(`DROP TABLE settlement_attempt_outputs`); err != nil {
+		t.Fatalf("drop settlement_attempt_outputs: %v", err)
+	}
+
+	before := buyerTerminalConflictTotal.Load()
+	rr := h4PostChat(t, s, []byte(h4ChatBody))
+
+	if rr.Code != http.StatusInternalServerError {
+		t.Fatalf("buyer status = %d, want 500 (request_log_failed); body=%s", rr.Code, rr.Body.String())
+	}
+	if statuses := h4RequestLogStatuses(t, dbPath); len(statuses) != 1 || statuses[0] != http.StatusOK {
+		t.Fatalf("request_log statuses = %v, want exactly [200] (the provider WAS credited)", statuses)
+	}
+	if observed == nil {
+		t.Fatal("terminal arbiter was never evaluated")
+	}
+	claim, ok := observed.claimedBuyer()
+	if !ok || claim.Status != http.StatusInternalServerError {
+		t.Fatalf("claimed buyer terminal = %+v (ok=%v), want status 500", claim, ok)
+	}
+	rows := observed.Rows()
+	if len(rows) != 1 {
+		t.Fatalf("credited rows = %d, want 1: %#v", len(rows), rows)
+	}
+	if rows[0].Status != http.StatusOK {
+		t.Fatalf("credited row status = %d, want 200", rows[0].Status)
+	}
+	if rows[0].FaultFlag == billing.FaultBreakerQualifying {
+		t.Fatalf("credited row carries %q — the formula.go zeroing rule would apply and this would "+
+			"not be a money conflict; the fixture no longer exercises INV-6", rows[0].FaultFlag)
+	}
+	if got := observed.Conflicts(); got != 1 {
+		t.Fatalf("conflicts = %d, want 1 — a provider was credited (200, no breaker fault) while the "+
+			"buyer was told 500. This is INV-6 'paid while the buyer was told it failed'; the arbiter "+
+			"must observe it", got)
+	}
+	if delta := buyerTerminalConflictTotal.Load() - before; delta != 1 {
+		t.Fatalf("buyerTerminalConflictTotal delta = %d, want 1", delta)
+	}
+	// The billing row is NOT suppressed: consistency arbiter, not suppression
+	// arbiter. Suppressing it would erase a real provider credit.
+	if !observed.Rows()[0].Conflicted {
+		t.Fatal("conflicting row not marked Conflicted")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// H4-4 · arbiter unit table. Pins the predicates independently of transport.
+// ---------------------------------------------------------------------------
+func TestSeamH4_TerminalArbiterPredicates(t *testing.T) {
+	t.Run("credited_success_row_under_5xx_buyer_terminal_conflicts", func(t *testing.T) {
+		rt := newRequestTerminal(nil, "req-1", "acct-1")
+		rt.noteDispatch()
+		if !rt.claimBuyer(http.StatusGatewayTimeout) {
+			t.Fatal("first claim must win")
+		}
+		rt.noteBillableRow(http.StatusOK, 0, billing.FaultNone)
+		rt.evaluateEndOfRequest(true)
+		if got := rt.Conflicts(); got != 1 {
+			t.Fatalf("conflicts = %d, want 1", got)
+		}
+	})
+
+	t.Run("breaker_qualifying_row_is_not_a_conflict", func(t *testing.T) {
+		rt := newRequestTerminal(nil, "req-2", "acct-1")
+		rt.noteDispatch()
+		rt.claimBuyer(http.StatusGatewayTimeout)
+		// A breaker-qualifying 504 row is zeroed by billing/formula.go, and a
+		// >=400 status is not success-shaped either.
+		rt.noteBillableRow(http.StatusGatewayTimeout, 0, billing.FaultBreakerQualifying)
+		rt.evaluateEndOfRequest(true)
+		if got := rt.Conflicts(); got != 0 {
+			t.Fatalf("conflicts = %d, want 0", got)
+		}
+	})
+
+	t.Run("breaker_qualifying_success_row_is_not_a_conflict", func(t *testing.T) {
+		rt := newRequestTerminal(nil, "req-2b", "acct-1")
+		rt.noteDispatch()
+		rt.claimBuyer(http.StatusGatewayTimeout)
+		rt.noteBillableRow(http.StatusOK, 0, billing.FaultBreakerQualifying)
+		rt.evaluateEndOfRequest(true)
+		if got := rt.Conflicts(); got != 0 {
+			t.Fatalf("conflicts = %d, want 0 — FaultBreakerQualifying zeroes the credit", got)
+		}
+	})
+
+	t.Run("served_2xx_without_credited_row_conflicts_at_end_of_request", func(t *testing.T) {
+		rt := newRequestTerminal(nil, "req-3", "acct-1")
+		rt.noteDispatch()
+		rt.claimBuyer(http.StatusOK)
+		if got := rt.Conflicts(); got != 0 {
+			t.Fatalf("conflicts = %d before end-of-request, want 0 — I-2 is a whole-request predicate", got)
+		}
+		rt.evaluateEndOfRequest(true)
+		if got := rt.Conflicts(); got != 1 {
+			t.Fatalf("conflicts = %d, want 1 (dispatched, served 2xx, never credited)", got)
+		}
+	})
+
+	t.Run("served_2xx_without_dispatch_is_not_a_conflict", func(t *testing.T) {
+		rt := newRequestTerminal(nil, "req-4", "acct-1")
+		rt.claimBuyer(http.StatusOK)
+		rt.evaluateEndOfRequest(true)
+		if got := rt.Conflicts(); got != 0 {
+			t.Fatalf("conflicts = %d, want 0 — nothing dispatched, nobody is owed", got)
+		}
+	})
+
+	t.Run("served_2xx_without_billing_wired_is_not_a_conflict", func(t *testing.T) {
+		rt := newRequestTerminal(nil, "req-5", "acct-1")
+		rt.noteDispatch()
+		rt.claimBuyer(http.StatusOK)
+		rt.evaluateEndOfRequest(false)
+		if got := rt.Conflicts(); got != 0 {
+			t.Fatalf("conflicts = %d, want 0 — a coordinator with no billing store credits nobody by design", got)
+		}
+	})
+
+	t.Run("double_claim_retains_the_first_and_counts_the_late_write", func(t *testing.T) {
+		rt := newRequestTerminal(nil, "req-6", "acct-1")
+		if !rt.claimBuyer(http.StatusGatewayTimeout) {
+			t.Fatal("first claim must win")
+		}
+		if rt.claimBuyer(http.StatusOK) {
+			t.Fatal("second claim must lose — net/http already committed the first status")
+		}
+		claim, ok := rt.claimedBuyer()
+		if !ok || claim.Status != http.StatusGatewayTimeout {
+			t.Fatalf("claim = %+v (ok=%v), want the FIRST terminal (504)", claim, ok)
+		}
+		if got := rt.LateBuyerWrites(); got != 1 {
+			t.Fatalf("late buyer writes = %d, want 1", got)
+		}
+	})
+
+	t.Run("end_of_request_is_idempotent", func(t *testing.T) {
+		rt := newRequestTerminal(nil, "req-7", "acct-1")
+		rt.noteDispatch()
+		rt.claimBuyer(http.StatusOK)
+		rt.evaluateEndOfRequest(true)
+		rt.evaluateEndOfRequest(true)
+		if got := rt.Conflicts(); got != 1 {
+			t.Fatalf("conflicts = %d, want 1 — a second evaluation must not double-count", got)
+		}
+	})
+
+	t.Run("nil_arbiter_is_inert", func(t *testing.T) {
+		var rt *requestTerminal
+		rt.noteDispatch()
+		rt.noteBillableRow(http.StatusOK, 0, billing.FaultNone)
+		rt.noteLateBuyerWrite(http.StatusOK)
+		rt.setRequestID("x")
+		rt.evaluateEndOfRequest(true)
+		if rt.claimBuyer(http.StatusOK) {
+			t.Fatal("nil arbiter must not report a winning claim")
+		}
+		if rt.Conflicts() != 0 || rt.LateBuyerWrites() != 0 || rt.Rows() != nil {
+			t.Fatal("nil arbiter accessors must be zero-valued")
+		}
+		if _, ok := rt.claimedBuyer(); ok {
+			t.Fatal("nil arbiter must not report a claim")
+		}
+	})
+}
+
+// ---------------------------------------------------------------------------
+// H4-5 · claim-once across every transport. The latch lives on one wrapper, so
+// this is a per-transport regression net against a future path that writes its
+// terminal outside noPriorDispatchResponseWriter (which would leave the claim
+// unset and silently blind the arbiter).
+// ---------------------------------------------------------------------------
+func TestSeamH4_ClaimOncePerTransport(t *testing.T) {
+	const streamBody = `{"model":"model-a","stream":true,"messages":[{"role":"user","content":"hello"}]}`
+	cases := []struct {
+		name     string
+		body     string
+		relay    RelayFunc
+		buffered bool
+	}{
+		{name: "ws_non_streaming_success", body: h4ChatBody, relay: h4RelaySuccess()},
+		{name: "ws_non_streaming_error", body: h4ChatBody, relay: h4RelayErr(errors.New("relay exploded"))},
+		{name: "ws_streaming_incremental_success", body: streamBody, relay: h4RelaySuccess()},
+		{name: "ws_streaming_incremental_error", body: streamBody, relay: h4RelayErr(errors.New("relay exploded"))},
+		{name: "ws_streaming_buffered_success", body: streamBody, relay: h4RelaySuccess(), buffered: true},
+		{name: "ws_streaming_buffered_error", body: streamBody, relay: h4RelayErr(errors.New("relay exploded")), buffered: true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.buffered {
+				t.Setenv("COORDINATOR_STREAMING_FORCE_BUFFERED", "1")
+			}
+			reqLog, _ := h4OpenRequestLog(t)
+			var observed *requestTerminal
+			s := h4Server(t, reqLog, tc.relay, &observed)
+
+			rr := h4PostChat(t, s, []byte(tc.body))
+
+			if observed == nil {
+				t.Fatal("terminal arbiter was never evaluated")
+			}
+			claim, ok := observed.claimedBuyer()
+			if !ok {
+				t.Fatalf("no buyer terminal claimed although the buyer received status %d — a write "+
+					"path bypassed noPriorDispatchResponseWriter", rr.Code)
+			}
+			if claim.Status != rr.Code {
+				t.Fatalf("claimed terminal = %d but the buyer observed %d — the latch must capture "+
+					"the FIRST committed status", claim.Status, rr.Code)
+			}
+		})
+	}
+
+	t.Run("http_forwarding_transports", func(t *testing.T) {
+		upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			var buf bytes.Buffer
+			_, _ = io.Copy(&buf, r.Body)
+			if bytes.Contains(buf.Bytes(), []byte(`"stream":true`)) {
+				w.Header().Set("Content-Type", "text/event-stream")
+				w.WriteHeader(http.StatusOK)
+				_, _ = w.Write([]byte("data: {\"id\":\"ok\",\"choices\":[{\"delta\":{\"content\":\"ok\"}}]}\n\ndata: [DONE]\n\n"))
+				if f, ok := w.(http.Flusher); ok {
+					f.Flush()
+				}
+				return
+			}
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"id":"ok","choices":[{"message":{"content":"ok"}}],"usage":{"prompt_tokens":2,"completion_tokens":1,"total_tokens":3}}`))
+		}))
+		defer upstream.Close()
+
+		for _, tc := range []struct {
+			name string
+			body string
+		}{
+			{"http_buffered", h4ChatBody},
+			{"http_streaming", `{"model":"model-a","stream":true,"messages":[{"role":"user","content":"hello"}]}`},
+		} {
+			t.Run(tc.name, func(t *testing.T) {
+				reqLog, _ := h4OpenRequestLog(t)
+				billingStore, err := billing.NewStore(reqLog.DB())
+				if err != nil {
+					t.Fatalf("billing.NewStore: %v", err)
+				}
+				registry := pool.NewRegistry([]config.ProviderConfig{{ProviderID: "h1", EndpointURL: upstream.URL}})
+				registry.Register(&pool.Provider{
+					ProviderID:            "h1",
+					AssignedID:            "s1",
+					Hostname:              "h1.local",
+					ModelID:               "model-a",
+					ModelParamsB:          7,
+					RAMGB:                 16,
+					MaxContextTokens:      20000,
+					MaxConcurrency:        1,
+					SlotsFree:             1,
+					SlotsTotal:            1,
+					ThroughputTPSEstimate: 30,
+					EndpointURL:           upstream.URL,
+					Tier:                  pool.TierPinned,
+					InferencePath:         pool.InferencePathHTTPForwarding,
+					State:                 pool.StateReady,
+					LastHeartbeatAt:       time.Now().UTC(),
+					ConnectedAt:           time.Now().UTC(),
+					BinaryVersion:         "0.1.0",
+				}, nil)
+				var observed *requestTerminal
+				s := NewServer(
+					registry,
+					zerolog.Nop(),
+					time.Unix(1716768000, 0),
+					WithRequestLog(reqLog),
+					WithBilling(billingStore, h4Rewards()),
+					WithRoutingConfig(config.RoutingConfig{MaxRetries: 0, StickyTTLS: 1800, StickyMaxEntries: 10000}),
+				)
+				s.terminalObserver = func(rt *requestTerminal) { observed = rt }
+
+				rr := h4PostChat(t, s, []byte(tc.body))
+
+				if observed == nil {
+					t.Fatal("terminal arbiter was never evaluated")
+				}
+				claim, ok := observed.claimedBuyer()
+				if !ok {
+					t.Fatalf("no buyer terminal claimed although the buyer received status %d", rr.Code)
+				}
+				if claim.Status != rr.Code {
+					t.Fatalf("claimed terminal = %d but the buyer observed %d", claim.Status, rr.Code)
+				}
+			})
+		}
+	})
+}

--- a/phase4-coordinator/internal/buyer/server.go
+++ b/phase4-coordinator/internal/buyer/server.go
@@ -245,6 +245,13 @@ type Server struct {
 	autotuneFeeds     AutotuneFeeds
 	now               func() time.Time
 	version           string
+	// terminalObserver is the #766 arbiter observation seam. Nil in
+	// production — no Option sets it and nothing in the serving path reads
+	// the arbiter's state; the production surface is the warn logs plus the
+	// package counters in terminal_arbiter.go. Tests set it directly to
+	// assert per-request claim/row ordering, which is not otherwise
+	// reachable because the arbiter is owned by a request-scoped recorder.
+	terminalObserver func(*requestTerminal)
 }
 
 type receiptKeysBucket struct {
@@ -1769,6 +1776,12 @@ func (s *Server) handleChatCompletions(w http.ResponseWriter, r *http.Request) {
 	// preserving the pre-refactor closure's "latest value at fire time"
 	// semantics for what used to be captured outer-scope variables.
 	rec := s.newBillingRecorder(r, state, startedAt, originalRequestID, externalRequestID, accountID, authenticatedAccount, hasAuthenticatedAccount)
+	// #766 single-terminal-wins arbiter (observe-only). Deferred here so the
+	// agreement check runs after the whole request has settled — the WS paths
+	// record their billing row AFTER the terminal write, so an end-of-handler
+	// evaluation is the only point where both sides are known. It never
+	// touches the response or the ledger.
+	defer rec.evaluateTerminalAgreement()
 	// Item 18: centrally stamp the positive no-prior-dispatch marker on any
 	// terminal response written while no provider has been billably credited
 	// for this request (rec.providerCredited false, and — for the current

--- a/phase4-coordinator/internal/buyer/terminal_arbiter.go
+++ b/phase4-coordinator/internal/buyer/terminal_arbiter.go
@@ -1,0 +1,362 @@
+package buyer
+
+import (
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/augstar/macprovider-coordinator/internal/billing"
+	"github.com/rs/zerolog"
+)
+
+// terminal_arbiter.go — issue #766 (seam-hardening epic #770).
+//
+// WHAT THIS IS: a per-request CONSISTENCY arbiter. It publishes the single
+// buyer-visible terminal (the first committed HTTP status) and every credited
+// billing row, then asserts the two agree. It is OBSERVE-ONLY: package-level
+// counters + warn logs, no enforcement, no suppression, no config surface.
+//
+// WHAT THIS IS NOT: a suppression arbiter. Suppressing a "late" billing row
+// would UNDER-BILL every failover retry — the winning 200 row is written after
+// the buyer terminal on the WS paths, and forward_loop_test.go scenario 2 pins
+// the two-row (502, retried=0) + (200, retried=1) shape as the money contract.
+// A suppressed provider credit is invisible and unrecoverable; an over-credit
+// is detectable and reversible from the ledger. So: NEVER gate a billing row.
+// Only the late BUYER terminal is telemetry-only, which is already true at the
+// byte level (net/http discards a second WriteHeader).
+//
+// WHY IT IS NEEDED despite there being no goroutine race: recordRow and every
+// buyer write run on the request goroutine, and the relay layer's
+// timeout-vs-completion race is already single-winner arbitrated under
+// activeMu (internal/ws/relay.go). The real gap H4 named is STRUCTURAL —
+// nothing published "a buyer terminal was admitted", so recordRow could not
+// observe whether the ledger and the buyer's HTTP status agreed. Today's
+// no-charge-on-timeout property is an ACCIDENT of two independent zeroing
+// rules (billing/formula.go FaultBreakerQualifying early-return and
+// billing_recorder.go's byte-estimated zeroing); nothing asserts it. This file
+// makes the disagreement observable so enforcement (if ever) can be designed
+// against real counter data rather than a guess.
+//
+// Money-path rule encoded here: the buyer terminal wins the BUYER's refund
+// decision (the gateway reads settlementNoPriorDispatchHeader, stamped at the
+// same latch point); every attempt row is retained for the PROVIDER ledger.
+
+// terminalSourceBuyerWrite is the only claim source today: the first
+// buyer-visible write through noPriorDispatchResponseWriter. The field exists
+// so a future claim site (e.g. a relay-side terminal) is distinguishable in
+// the logs without changing the schema.
+const terminalSourceBuyerWrite = "buyer_write"
+
+// Package-level observe-only counters, mirroring the internal/ws/relay.go
+// idiom (relayEndFrameAADMismatchTotal / relayBufferExceededTotal). Deliberately
+// NOT prometheus: the buyer Server has no metrics handle, and plumbing one is
+// out of scope for an observe-only change.
+var (
+	// buyerTerminalConflictTotal counts requests-events where the buyer's
+	// committed HTTP status and a credited billing row disagreed.
+	buyerTerminalConflictTotal atomic.Uint64
+	// buyerTerminalLateTotal counts buyer writes that arrived after the
+	// terminal was already claimed (telemetry-only; net/http drops them).
+	buyerTerminalLateTotal atomic.Uint64
+)
+
+// terminalClaim is the winning buyer terminal for a request.
+type terminalClaim struct {
+	Status int
+	Source string
+	At     time.Time
+	Seq    uint64
+}
+
+// billableRowEvent is one credited provider row as observed by the arbiter.
+// Only rows that reached providerCredited=true are noted — a row that failed
+// to persist never credited anyone and is not part of the agreement check.
+type billableRowEvent struct {
+	Status    int
+	AttemptN  int
+	FaultFlag string
+	Seq       uint64
+	// Late is true when the row was noted after the buyer terminal was
+	// already claimed. This is NORMAL on the WS paths (write-before-bill)
+	// and is recorded for ordering evidence, not as a fault.
+	Late bool
+	// Conflicted marks a row already counted against the conflict predicate,
+	// so the end-of-request sweep does not double-count it.
+	Conflicted bool
+}
+
+// requestTerminal is the per-request arbiter. One instance per
+// billingRecorder, i.e. one per handleChatCompletions invocation. The mutex is
+// belt-and-braces: all writers are on the request goroutine today, but the
+// latch must stay correct if a future path publishes from a relay goroutine.
+type requestTerminal struct {
+	mu        sync.Mutex
+	log       *zerolog.Logger
+	requestID string
+	accountID string
+
+	seq          uint64
+	buyer        *terminalClaim
+	lateBuyer    int
+	dispatched   bool
+	rows         []billableRowEvent
+	conflicts    int
+	endEvaluated bool
+}
+
+func newRequestTerminal(log *zerolog.Logger, requestID, accountID string) *requestTerminal {
+	return &requestTerminal{log: log, requestID: requestID, accountID: accountID}
+}
+
+// setRequestID follows the post-idempotency-reservation request-id rewrite so
+// conflict logs join against the id the ledger actually used.
+func (t *requestTerminal) setRequestID(requestID string) {
+	if t == nil {
+		return
+	}
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.requestID = requestID
+}
+
+// claimBuyer latches the buyer-visible terminal. Returns true for the FIRST
+// caller only; a later caller is recorded as a late (telemetry-only) write.
+func (t *requestTerminal) claimBuyer(code int) bool {
+	if t == nil {
+		return false
+	}
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if t.buyer != nil {
+		t.noteLateBuyerWriteLocked(code)
+		return false
+	}
+	t.buyer = &terminalClaim{
+		Status: code,
+		Source: terminalSourceBuyerWrite,
+		At:     time.Now().UTC(),
+		Seq:    t.nextSeqLocked(),
+	}
+	return true
+}
+
+// noteLateBuyerWrite records a buyer write that lost the latch race.
+func (t *requestTerminal) noteLateBuyerWrite(code int) {
+	if t == nil {
+		return
+	}
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.noteLateBuyerWriteLocked(code)
+}
+
+func (t *requestTerminal) noteLateBuyerWriteLocked(code int) {
+	t.lateBuyer++
+	t.nextSeqLocked()
+	buyerTerminalLateTotal.Add(1)
+	winner := 0
+	if t.buyer != nil {
+		winner = t.buyer.Status
+	}
+	t.warnLocked().
+		Str("event", "buyer_terminal_late").
+		Int("buyer_status", winner).
+		Int("row_status", 0).
+		Int("attempt_n", -1).
+		Str("fault_flag", "").
+		Bool("late", true).
+		Int("late_status", code).
+		Int("late_writes", t.lateBuyer).
+		Msg("buyer terminal already claimed; later write is telemetry-only")
+}
+
+// noteDispatch records that at least one attempt reached a provider relay.
+// Monotonic for the whole request — deliberately NOT the per-attempt
+// billingRecorder.dispatchedThisAttempt, which resets on every failover
+// iteration and would make the end-of-request "served but unpaid" predicate
+// fire spuriously on any request whose last attempt did not dispatch.
+func (t *requestTerminal) noteDispatch() {
+	if t == nil {
+		return
+	}
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.dispatched = true
+}
+
+// noteBillableRow publishes a durably-credited provider row. Called from
+// recordRow immediately after providerCredited is set on BOTH credit sites.
+func (t *requestTerminal) noteBillableRow(status, attemptN int, faultFlag string) {
+	if t == nil {
+		return
+	}
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	row := billableRowEvent{
+		Status:    status,
+		AttemptN:  attemptN,
+		FaultFlag: faultFlag,
+		Seq:       t.nextSeqLocked(),
+		Late:      t.buyer != nil,
+	}
+	t.rows = append(t.rows, row)
+	idx := len(t.rows) - 1
+	// Predicate I-1 can only be decided once the buyer terminal is known. On
+	// the WS write-before-bill paths it already is; on the bill-before-write
+	// paths the end-of-request sweep picks the row up.
+	if t.buyer != nil && t.rowConflictsLocked(t.rows[idx]) {
+		t.rows[idx].Conflicted = true
+		t.recordConflictLocked(conflictCreditedWhileBuyerFailed, t.rows[idx])
+	}
+}
+
+const (
+	// conflictCreditedWhileBuyerFailed: the provider was paid for an attempt
+	// the buyer was told failed with a 5xx, and the row carries no
+	// breaker-qualifying fault flag (which is what billing/formula.go relies
+	// on to zero the credit). This is the "paid while buyer told timeout"
+	// property H4/INV-6 names.
+	conflictCreditedWhileBuyerFailed = "credited_row_while_buyer_terminal_failed"
+	// conflictServedWithoutCredit: the buyer got a 2xx off a dispatched
+	// attempt but no provider row ever credited. The provider served and was
+	// not paid.
+	conflictServedWithoutCredit = "served_2xx_without_credited_row"
+)
+
+// rowConflictsLocked is predicate I-1. A credited row with a success-shaped
+// status (<400) under a >=5xx buyer terminal is a conflict UNLESS the row is
+// flagged breaker-qualifying — that flag is the existing (accidental, but
+// real) zeroing rule in billing/formula.go, so such a row does not actually
+// move money.
+func (t *requestTerminal) rowConflictsLocked(row billableRowEvent) bool {
+	if t.buyer == nil || t.buyer.Status < 500 {
+		return false
+	}
+	if row.Status >= 400 {
+		return false
+	}
+	return row.FaultFlag != billing.FaultBreakerQualifying
+}
+
+// evaluateEndOfRequest runs once, after handleChatCompletions has fully
+// returned, so it sees the WS paths' post-write billing rows.
+//
+// billingEnabled gates the "served but unpaid" predicate: a coordinator with
+// no billing store (or no request log) never credits anybody by design, and
+// reporting every 200 as unpaid would be pure noise.
+func (t *requestTerminal) evaluateEndOfRequest(billingEnabled bool) {
+	if t == nil {
+		return
+	}
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if t.endEvaluated {
+		return
+	}
+	t.endEvaluated = true
+	if t.buyer == nil {
+		return
+	}
+	// I-1 sweep for rows credited BEFORE the buyer terminal was claimed
+	// (HTTP paths bill before the write; the WS success path bills inside
+	// logSuccess and can then fail the terminal with a 500).
+	for i := range t.rows {
+		if t.rows[i].Conflicted {
+			continue
+		}
+		if t.rowConflictsLocked(t.rows[i]) {
+			t.rows[i].Conflicted = true
+			t.recordConflictLocked(conflictCreditedWhileBuyerFailed, t.rows[i])
+		}
+	}
+	// I-2: served-but-unpaid. Evaluated once, at the end, against the
+	// monotonic dispatch + credit signals.
+	if !billingEnabled || !t.dispatched {
+		return
+	}
+	if t.buyer.Status < 200 || t.buyer.Status >= 300 {
+		return
+	}
+	if len(t.rows) > 0 {
+		return
+	}
+	t.recordConflictLocked(conflictServedWithoutCredit, billableRowEvent{AttemptN: -1})
+}
+
+func (t *requestTerminal) recordConflictLocked(reason string, row billableRowEvent) {
+	t.conflicts++
+	buyerTerminalConflictTotal.Add(1)
+	buyerStatus := 0
+	if t.buyer != nil {
+		buyerStatus = t.buyer.Status
+	}
+	t.warnLocked().
+		Str("event", "terminal_conflict").
+		Str("reason", reason).
+		Int("buyer_status", buyerStatus).
+		Int("row_status", row.Status).
+		Int("attempt_n", row.AttemptN).
+		Str("fault_flag", row.FaultFlag).
+		Bool("late", row.Late).
+		Int("credited_rows", len(t.rows)).
+		Msg("buyer terminal and billing rows disagree")
+}
+
+func (t *requestTerminal) nextSeqLocked() uint64 {
+	t.seq++
+	return t.seq
+}
+
+func (t *requestTerminal) warnLocked() *zerolog.Event {
+	logger := t.log
+	if logger == nil {
+		nop := zerolog.Nop()
+		logger = &nop
+	}
+	return logger.Warn().
+		Str("request_id", t.requestID).
+		Str("account_id", t.accountID)
+}
+
+// claimedBuyer returns the winning terminal claim, if any.
+func (t *requestTerminal) claimedBuyer() (terminalClaim, bool) {
+	if t == nil {
+		return terminalClaim{}, false
+	}
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if t.buyer == nil {
+		return terminalClaim{}, false
+	}
+	return *t.buyer, true
+}
+
+// Conflicts returns the number of buyer-terminal/billing-row disagreements.
+func (t *requestTerminal) Conflicts() int {
+	if t == nil {
+		return 0
+	}
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return t.conflicts
+}
+
+// Rows returns a copy of the credited-row events, in observation order.
+func (t *requestTerminal) Rows() []billableRowEvent {
+	if t == nil {
+		return nil
+	}
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return append([]billableRowEvent(nil), t.rows...)
+}
+
+// LateBuyerWrites returns the count of buyer writes that lost the latch.
+func (t *requestTerminal) LateBuyerWrites() int {
+	if t == nil {
+		return 0
+	}
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return t.lateBuyer
+}

--- a/phase4-coordinator/internal/buyer/terminal_arbiter.go
+++ b/phase4-coordinator/internal/buyer/terminal_arbiter.go
@@ -277,8 +277,14 @@ func (t *requestTerminal) evaluateEndOfRequest(billingEnabled bool) {
 	if t.buyer.Status < 200 || t.buyer.Status >= 300 {
 		return
 	}
-	if len(t.rows) > 0 {
-		return
+	// Audit R1 (code MEDIUM): the suppressor must be a row that actually PAYS,
+	// not merely any recorded row — a zero-credit breaker-qualifying row from
+	// a failed earlier attempt (which billing/formula.go zeroes) must not mask
+	// a served-but-unpaid final attempt.
+	for i := range t.rows {
+		if t.rows[i].Status < 400 && t.rows[i].FaultFlag != billing.FaultBreakerQualifying {
+			return
+		}
 	}
 	t.recordConflictLocked(conflictServedWithoutCredit, billableRowEvent{AttemptN: -1})
 }


### PR DESCRIPTION
Closes #766. PR 6 of epic #770 (P2, money path, observe-only).

## The finding that reframed the issue

The issue assumed a cross-goroutine race between billing settlement and the buyer-504 terminal. The design investigation **disproved it**: `recordRow` and every buyer write run on the request goroutine, and the relay layer already arbitrates timeout-vs-completion single-winner under `activeMu` (verified strength, untouched). The real gap is structural — nothing publishes the buyer terminal, so the money seam cannot observe agreement with it, and today's no-charge-on-timeout invariant is an **accident** of two independent zeroing rules (`formula.go`'s `FaultBreakerQualifying` early-return; `billing_recorder`'s byte-estimated zeroing). Any future edit to either silently starts charging for requests the buyer was told failed, with nothing to catch it.

## What shipped: a consistency arbiter, not a suppression arbiter

A per-request `requestTerminal` latch on `billingRecorder`, claimed at the first buyer-visible write inside `noPriorDispatchResponseWriter` (the item-18 no-charge-marker body moved **verbatim** — its `settlementNoPriorDispatchHeader` is read by the gateway for settle-vs-refund and its tests pass untouched). Credited rows are noted after both `providerCredited` sites with sequence + late ordering. Two conflict predicates: **provider-paid-while-buyer-refused** (checked at note time and swept at end-of-request) and **served-but-unpaid** (end-of-request, gated on billing being wired, against monotonic dispatch state). Billing rows are **never suppressed** — suppression would under-bill every failover retry (`forward_loop_test.go` scenario 2 pins the two-row shape); a recorded over-credit is ledger-visible and reversible, a suppressed credit is invisible — the same fail-open philosophy as #763. Late buyer `WriteHeader`s are telemetry-only (only explicit post-latch `WriteHeader` counts; body-write implicit-200s are ordinary traffic). Package-level atomic counters + `terminal_conflict`/`buyer_terminal_late` warn logs; no enforcement (a later, flag-gated decision after reading the counter on live traffic), no prometheus (buyer `Server` has no metrics handle).

**Expected first live signal**: the pre-existing `"Could not durably log settlement receipt"` 500-after-credited-200 class is a *genuine* conflict the counter will now expose — a non-zero counter is the arbiter working, not broken.

H4 — the harness's last documented skip — is now **five real tests / 23 subtests**: agreeing-timeout ordering (row `Seq` < buyer claim), post-terminal row inverse ordering, the DROP-TABLE-forced credited-while-buyer-told-500 conflict tripwire, the arbiter unit table, and claim-once across seven transport variants. All 8 harness scenarios now execute with no skips.

## Audit (three codex lanes, full diff)

- security R1: **PASS 0/0/0**. architect R1: **PASS 0/0/0**.
- code R1: 1 MEDIUM — the served-unpaid predicate was suppressed by *any* prior row, so a zero-credit breaker-qualifying row from a failed earlier attempt masked exactly the shape it exists to catch. Fixed: the suppressor must be a **paying** row (`status < 400` and `FaultFlag != FaultBreakerQualifying`, consistent with predicate I-1), with masking + suppression regression subtests. code R2: **PASS 0/0/0**.

Carried/documented: `terminalObserver` is a test-only field on the money-path `Server` (nil in prod, no Option sets it; the alternative was log-scraping the ordering assertions); the conflict counter is process-global (tests assert deltas); out-of-scope items named in the design (zeroing-rule reconciliation is a real finding needing its own spec decision).

Full coordinator suite + `-race` on `internal/buyer` + cross-service integration module green, pre- and post-rebase.

SPEC-GOVERNANCE-DECLARATION-BEGIN
{
  "schema_version": "spec-pr-governance-v1",
  "behavior_change": "yes",
  "contract_change": "none",
  "specs": ["SPEC-005", "SPEC-006", "SPEC-036"],
  "requirements": ["SPEC-036-R001"],
  "authority_domains": ["billing-settlement-formula", "buyer-api-error-contract", "compute-integrity-settlement"],
  "arbitration": ["CODE_BUG"],
  "tests": ["phase4-coordinator/internal/buyer/seam_h4_test.go"],
  "journeys": ["not-required"],
  "issue": "https://github.com/Augustas11/macprovider/issues/770"
}
SPEC-GOVERNANCE-DECLARATION-END

🤖 Generated with [Claude Code](https://claude.com/claude-code)
