### PR TITLE
Seam hardening P2: fleet + per-model binary version floors (#767, #768)

### DIFF
--- a/audits/seam-hardening/findings.md
+++ b/audits/seam-hardening/findings.md
@@ -11,7 +11,7 @@ built) live in `harness/` and are named `TestSeam*`.
 | 2 · cache-tenant-isolation | **PASS by construction** | server-authored account-HMAC scope; KV in-memory only |
 | 3 · backend-rollout-safety | **PASS** (gap closed, #764) | strong flags/canary/self-update; perf telemetry now segmented by `binary_version` on `/poolz` |
 | 4 · attestation-honesty | **FAIL (client-facing)** | prose honest, but stat surfaces over-claim hardware trust |
-| 5 · fleet-version-floor | **PASS (1 gap)** | blocks incompatible/known-bad builds; capacity now clamped at ingest (#764); version floor still unset in prod (P2-2) |
+| 5 · fleet-version-floor | **PASS** (gaps closed, #767/#768) | blocks incompatible/known-bad builds; capacity clamped at ingest (#764); floor now SET in the prod overlay + a 4004 close stops the client's reconnect loop (P2-2); per-model routing floors share one check across routing/self-route/warm gates (P2-3) |
 
 Fundamentals are strong (cache isolation, rollout discipline, signed-catalog admission,
 honest prose). Exposure concentrates in two client-facing FAILs (settlement flat-wall,
@@ -279,15 +279,58 @@ arbiter also does not treat the discarded `w.Write` error on the WS terminal as 
 orderings, the forced credited-while-buyer-told-500 conflict, the predicate table, and
 claim-once across every transport.
 
-**P2-2 · Version floor unset in prod + client can't parse the rejection** — `supply`
-`required_binary_version` is set nowhere in prod config, and the Swift client has no `case 4004`
-(`phase3-binary/.../CoordinatorClient.swift:1460-1499`) → a below-floor close is a silent reconnect
-loop, not an upgrade directive. **Fix:** set the floor in the prod overlay, add a `4004` handler + an
-upgrade directive, add a `doctor` subcommand.
+**P2-2 · Version floor unset in prod + client can't parse the rejection** — `supply` — issue #767
+**FIXED.** `required_binary_version` was set nowhere in prod config, and the Swift client had no
+`case 4004` (`phase3-binary/.../CoordinatorClient.swift`) → a below-floor close fell through the
+close-code switch to `default: nil`, so the raw transport error propagated and the reconnect loop
+retried forever. The operator saw an unexplained flap, not an upgrade directive. (Confirmed live at
+fix time: `https://coordinator.streamvc.live/healthz` published a recommendation and no floor.)
+**Fix (shipped):** three parts.
+1. `required_binary_version: "1.8.33"` in the committed prod overlay
+(`phase4-coordinator/dist/coordinator.yaml`). 1.8.33 is the first release that declares a
+`compatibility_set_id` — everything ≤1.8.32 is the legacy cohort that already receives no autoupdate
+recommendation and already cannot satisfy the live overlay's `accepted_ids` gate. So the floor fences
+nobody currently admissible; it makes an already-true rejection explicit and machine-readable instead
+of leaving a legacy build to fail later on catalog admission. It sits far below the current release
+and below the #610 first-hop bridge build (1.8.48, additionally exempt by `firstHopOnly`), so raising
+it stays a deliberate act. `config.Validate` now rejects an unparseable floor at load.
+2. Swift `case 4004 where reason.hasPrefix("version_unsupported")` types the close, parses the
+required target out of the coordinator's `below required <version>` suffix (degrading to "the latest
+release" when absent or implausible), emits a human stderr directive plus a structured
+`coordinator_version_floor_rejected` event, and **returns out of `runReconnectLoop`** — mirroring the
+terminal-bootstrap pattern, because a below-floor fleet retrying on backoff is exactly the hammering
+the floor exists to prevent. Lifecycle records `catalog_incompatible` / `binary_version_unsupported`.
+3. `macprovider-cli doctor` — offline-first diagnostics (binary version, config path, provider id,
+coordinator endpoint) plus a floor check against the coordinator's existing `/healthz`, which now also
+publishes `required_binary_version`. No new coordinator endpoint. Unreachable degrades to
+`unreachable` and exits 0; below-floor exits 1.
+*Tripwire tests:* `internal/ws/seam_767_version_floor_test.go` (healthz surface + the exact close
+reason the client parses), `internal/config/seam_767_768_test.go` (prod overlay carries the floor;
+floor ≤ latest; malformed floors rejected), `Tests/macprovider-cliTests/VersionFloorRejectionTests.swift`
+(one attempt then stop), `Tests/macprovider-cliTests/DoctorCommandTests.swift`.
 
-**P2-3 · No per-model version floor** — `supply`
-Only a per-model *hardware-tier* gate exists; an old-but-hardware-eligible build can serve a model that
-needs a newer engine. **Fix:** add a per-model minimum-version floor to the routing gate.
+**P2-3 · No per-model version floor** — `supply` — issue #768
+**FIXED.** Only a per-model *hardware-tier* gate existed (the signed autotune candidate catalog's
+`min_ram_gb` / `min_bandwidth_tier` rows, evaluated once at WS hello), so an old-but-hardware-eligible
+build could serve a model needing a newer engine.
+**Fix (shipped):** `coordinator_advertised_version.per_model_required_binary_version` (model_id →
+minimum version), evaluated by ONE helper — `internal/versionfloor.Check` — called from every gate:
+public routing (`routing.EligibilityChecker.ProviderMeetsModelVersionFloor` → new
+`ReasonModelVersionFloor` + a `model_version_floor_unmet` 503 so operators see a supply-VERSION
+problem, not a supply-VOLUME one), the self-route / hard-pin preflight path
+(`validatePinnedProviderForRequest`, which bypasses the routing filter entirely), the slot-queue
+candidate list (which re-derives the routing gates by hand), and the warm-pool gates
+(`runWarmupGateAttempt`, `canaryBuyerServing`) — we never warm a box we won't route to. The version
+comparator moved to `internal/versionfloor` and the global hello floor now delegates to it, so there
+is exactly one ordering in the coordinator.
+*Posture:* unset map = no floors = byte-identical routing. A provider whose `binary_version` is
+unparseable while a floor is in force fails **safe** (gated out) and logs at WARN — that is suspect,
+not merely stale. A routine below-floor exclusion logs at DEBUG on the per-request buyer path (the
+503 code carries it) and at INFO once at the warmup gate. Floors are read at startup; changing them
+needs a coordinator restart, same as the global floor.
+*Tripwire tests:* `internal/versionfloor/versionfloor_test.go`,
+`internal/buyer/seam_768_version_floor_test.go` (all three gates + unconfigured byte-identity),
+`internal/ws/seam_768_warm_floor_test.go`, `internal/routing/filter_test.go`.
 
 **P2-4 · Hygiene: hello-gate spec vs prod config; same-account timing risk** — `hygiene` — **FIXED (#769)**
 Live Pearl posture verified 2026-07-27 against the RUNNING process (`--config-overlay
@@ -326,7 +369,12 @@ enable-after-survey shares the #765 live-pool survey prerequisite; warmup drift 
 4. ~~**P1-1 / P1-2**~~ — **DONE (#762, #763)**: money integrity before real buyer volume. #762 makes an
    id-less retry bill once; #763 makes an after-commit settle recoverable. Both keep the durable
    `(account_id, request_id)` key as the invariant — neither adds a second source of truth for money.
-5. P2 as debt burn-down. ~~**P2-1**~~ — **DONE (#766)**, observe-only: the arbiter asserts that the
+5. ~~**P2-1**~~ — **DONE (#766)**, observe-only: the arbiter asserts that the
    buyer terminal and the billing ledger agree, and deliberately does **not** suppress anything —
    suppressing a late row would under-bill every failover retry. Enforcement stays out until the
    conflict counter has been read on live traffic.
+6. ~~**P2-2 / P2-3**~~ — **DONE (#767, #768)**: seam 5's floor stopped being theoretical. The prod
+   overlay carries `required_binary_version` for the first time, a 4004 close is an upgrade directive
+   that stops the client's reconnect loop, `doctor` makes the standing checkable offline, and per-model
+   routing floors share one check across the public routing, self-route preflight, warm-pool, and
+   slot-queue gates (incl. the poll-time recheck from the audit).

--- a/phase3-binary/Sources/macprovider-cli/CoordinatorClient.swift
+++ b/phase3-binary/Sources/macprovider-cli/CoordinatorClient.swift
@@ -258,6 +258,10 @@ actor CoordinatorClient {
     private let bootstrapReceiptSigningKey: Curve25519.Signing.PrivateKey?
     private let bootstrapReferralCode: String?
     private var terminalBootstrapReferralFailure: ReferralBootstrapFailure?
+    // #767: set when the coordinator closed us with 4004 version_unsupported.
+    // Non-nil means the reconnect loop stopped on purpose and will not resume
+    // until the binary is upgraded and the process restarts.
+    private var terminalVersionFloorRejection: CoordinatorVersionFloorRejection?
     private let receiptIdentitySigningKeys: [Curve25519.Signing.PrivateKey]
     private let persistReceiptIdentitySigningKey: (@Sendable (Curve25519.Signing.PrivateKey) throws -> Void)?
 
@@ -676,6 +680,25 @@ actor CoordinatorClient {
                 consecutiveAuthProtocolFailures = 0
             } catch {
                 await cleanupConnection()
+                // #767: a 4004 version_unsupported close is TERMINAL. Retrying
+                // cannot succeed until the binary is upgraded, and a below-floor
+                // fleet retrying on backoff is exactly the hammering the floor
+                // exists to prevent. Mirror the terminal-bootstrap pattern
+                // below: record the reason, tell the operator what to do, and
+                // return out of the loop entirely.
+                if let floorRejection = Self.versionFloorRejection(for: error) {
+                    terminalVersionFloorRejection = floorRejection
+                    recordConnectionFailureDiagnostic(
+                        reasonCode: "binary_version_unsupported",
+                        error: error
+                    )
+                    recordConnectionFailureLifecycle(
+                        state: .catalogIncompatible,
+                        reasonCode: "binary_version_unsupported"
+                    )
+                    Self.emitVersionFloorUpgradeDirective(floorRejection)
+                    return
+                }
                 if credentialBootstrap,
                    let terminalFailure = Self.terminalBootstrapReferralFailure(for: error) {
                     terminalBootstrapReferralFailure = terminalFailure
@@ -785,6 +808,96 @@ actor CoordinatorClient {
         terminalBootstrapReferralFailure
     }
 
+    /// A coordinator 4004 `version_unsupported` close (issue #767). This build is
+    /// below the coordinator's hard admission floor, so reconnecting cannot
+    /// succeed until the binary is upgraded — it is terminal, not transient.
+    struct CoordinatorVersionFloorRejection: Equatable, Sendable {
+        /// The version this binary reported in its hello.
+        let currentVersion: String
+        /// The coordinator's required minimum, when it named one. Absent means
+        /// the coordinator sent a reason we could not parse a target out of;
+        /// the directive degrades to "upgrade to the latest release".
+        let requiredVersion: String?
+        /// The sanitized close reason, for diagnostics.
+        let reason: String
+    }
+
+    /// Recognises the terminal version-floor rejection. Only a `version_unsupported`
+    /// rejection qualifies; every other close stays on the ordinary retry path.
+    static func versionFloorRejection(for error: Error) -> CoordinatorVersionFloorRejection? {
+        guard let authError = error as? CoordinatorAuthError,
+              case .rejected(let code, let message) = authError,
+              code == "version_unsupported" else {
+            return nil
+        }
+        return CoordinatorVersionFloorRejection(
+            currentVersion: binaryVersion,
+            requiredVersion: requiredBinaryVersion(from: message),
+            reason: message
+        )
+    }
+
+    /// Parses the required target out of the coordinator's close reason. The
+    /// coordinator sends "version_unsupported: binary_version X below required Y"
+    /// (phase4-coordinator/internal/ws/server.go); an older or future coordinator
+    /// that words it differently yields nil, and the caller degrades gracefully
+    /// rather than printing a wrong target.
+    static func requiredBinaryVersion(from reason: String) -> String? {
+        let marker = "below required "
+        guard let range = reason.range(of: marker) else {
+            return nil
+        }
+        let candidate = reason[range.upperBound...]
+            .split(whereSeparator: { $0 == " " || $0 == "\t" })
+            .first
+            .map(String.init)?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        guard let candidate, !candidate.isEmpty else {
+            return nil
+        }
+        // Defensive: only echo a plausible version back to the operator, never
+        // arbitrary coordinator-controlled text.
+        let allowed = CharacterSet(charactersIn: "0123456789.")
+        guard candidate.unicodeScalars.allSatisfy({ allowed.contains($0) }) else {
+            return nil
+        }
+        return candidate
+    }
+
+    /// The terminal version-floor rejection that stopped the reconnect loop, if
+    /// one did. Nil while the loop is healthy or stopped for any other reason.
+    func coordinatorVersionFloorRejection() -> CoordinatorVersionFloorRejection? {
+        terminalVersionFloorRejection
+    }
+
+    /// Emits the upgrade directive: a human line on stderr plus a structured
+    /// stderr event, matching the CLI's existing emitTokenPersistEvent shape.
+    static func emitVersionFloorUpgradeDirective(_ rejection: CoordinatorVersionFloorRejection) {
+        let target = rejection.requiredVersion.map { "v\($0)" } ?? "the latest release"
+        FileHandle.standardError.write(Data((
+            "FATAL coordinator rejected this build: binary version " +
+            "\(rejection.currentVersion) is below the required minimum \(target). " +
+            "Upgrade with 'macprovider-cli update', then restart the provider. " +
+            "Reconnect attempts stopped — a below-floor build must not hammer the coordinator.\n"
+        ).utf8))
+        var payload: [String: String] = [
+            "event": "coordinator_version_floor_rejected",
+            "close_code": "4004",
+            "current_binary_version": rejection.currentVersion,
+            "reason": rejection.reason,
+        ]
+        if let requiredVersion = rejection.requiredVersion {
+            payload["required_binary_version"] = requiredVersion
+        }
+        do {
+            var data = try JSONSerialization.data(withJSONObject: payload, options: [.sortedKeys])
+            data.append(0x0A)
+            FileHandle.standardError.write(data)
+        } catch {
+            FileHandle.standardError.write(Data("{\"event\":\"coordinator_version_floor_rejected\"}\n".utf8))
+        }
+    }
+
     struct ConnectionLifecycleClassification: Equatable, Sendable {
         let state: ProviderLifecycleState
         let reasonCode: String
@@ -848,6 +961,16 @@ actor CoordinatorClient {
                 return ConnectionLifecycleClassification(
                     state: .coordinatorUnavailable,
                     reasonCode: "autotune_gate_unavailable"
+                )
+            }
+            // #767: below the coordinator's hard binary-version floor. Same
+            // family as a catalog/compatibility rejection — this build cannot
+            // serve until it is upgraded — but with its own reason code so
+            // Malibu can surface "upgrade" instead of "reinstall the catalog".
+            if normalized == "version_unsupported" {
+                return ConnectionLifecycleClassification(
+                    state: .catalogIncompatible,
+                    reasonCode: "binary_version_unsupported"
                 )
             }
             if normalized.contains("catalog") || normalized.contains("compatibility") {
@@ -1515,6 +1638,17 @@ actor CoordinatorClient {
             reason == "referral_exhausted" ||
             reason == "referral_conflict":
             return .rejected(code: reason, message: reason)
+        case 4004 where reason.hasPrefix("version_unsupported"):
+            // Issue #767: the coordinator's hard binary-version floor
+            // (`coordinator_advertised_version.required_binary_version`) closes
+            // with CloseVersionUnsupported and a reason shaped
+            // "version_unsupported: binary_version <ours> below required <theirs>".
+            // Before this case the close fell through to `default: nil`, so the
+            // raw transport error propagated and the reconnect loop retried
+            // forever — the operator saw an unexplained flap instead of an
+            // upgrade directive. The FULL reason is carried in `message` so the
+            // required target can be parsed out; see requiredBinaryVersion(from:).
+            return .rejected(code: "version_unsupported", message: reason)
         case 4008 where reason == "credential_bootstrap_rate_limited":
             return .rejected(code: reason, message: reason)
         case 4000 where reason == "unrecognized auth message":

--- a/phase3-binary/Sources/macprovider-cli/DoctorCommand.swift
+++ b/phase3-binary/Sources/macprovider-cli/DoctorCommand.swift
@@ -1,0 +1,294 @@
+import ArgumentParser
+import Foundation
+import MacProviderCore
+
+/// Issue #767 — offline-first provider diagnostics.
+///
+///     macprovider-cli doctor [--config PATH] [--json] [--offline]
+///
+/// The motivating failure: a build below the coordinator's
+/// `required_binary_version` is closed with 4004 and (before #767) silently
+/// reconnect-looped. An operator needed a way to ask "what version am I, what
+/// does the coordinator demand, and am I above the line" WITHOUT a live
+/// session. Everything except the last question is answered from local state,
+/// so `doctor` is useful on a box that cannot reach the coordinator at all.
+///
+/// The reachable check reuses the coordinator's existing `/healthz`, which
+/// publishes `recommended_binary_version` and (as of #767)
+/// `required_binary_version`. No new coordinator endpoint was invented.
+struct DoctorCommand: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "doctor",
+        abstract: "Report this provider's binary version, coordinator endpoint, and version-floor standing."
+    )
+
+    @Option(help: "YAML config path. Overrides MACPROVIDER_CONFIG. Defaults to ~/.config/macprovider/config.yaml.")
+    var config: String?
+
+    @Flag(help: "Emit a single JSON object instead of human-readable lines.")
+    var json = false
+
+    @Flag(help: "Skip the coordinator reachability + version-floor check entirely.")
+    var offline = false
+
+    @Option(help: "Seconds to wait for the coordinator /healthz probe.")
+    var timeoutSeconds: Double = 3
+
+    func run() async throws {
+        let resolved = try ConfigLoader.load(cli: CLIOverrides(configPath: config))
+        let report = await DoctorRunner(
+            binaryVersion: CoordinatorClient.binaryVersion,
+            coordinatorURL: resolved.coordinatorURL,
+            providerID: resolved.providerID,
+            configPath: resolved.configPath,
+            offline: offline,
+            fetch: DoctorRunner.liveFetch(timeout: timeoutSeconds)
+        ).run()
+        if json {
+            DoctorReportPrinter.emitJSON(report)
+        } else {
+            DoctorReportPrinter.emitText(report)
+        }
+        // A build the coordinator would refuse is a real, actionable fault, so
+        // doctor exits non-zero for it. Unreachable is NOT a fault: an
+        // offline-first tool must not fail because the network is down.
+        if report.floorStanding == .belowFloor {
+            throw ExitCode(1)
+        }
+    }
+}
+
+/// The coordinator's published version standing for this binary.
+enum DoctorFloorStanding: String, Equatable, Sendable {
+    /// The coordinator was not consulted (--offline, or no usable URL).
+    case notChecked = "not_checked"
+    /// The coordinator could not be reached, or answered unusably.
+    case unreachable
+    /// The coordinator publishes no floor.
+    case noFloorConfigured = "no_floor_configured"
+    /// This binary satisfies the published floor.
+    case aboveFloor = "above_floor"
+    /// This binary is below the published floor — it will be closed with 4004.
+    case belowFloor = "below_floor"
+    /// A floor is published but one of the two versions could not be compared.
+    case indeterminate
+}
+
+struct DoctorReport: Equatable, Sendable {
+    let binaryVersion: String
+    let configPath: String
+    let coordinatorURL: String?
+    let providerID: String?
+    let healthzURL: String?
+    let coordinatorVersion: String?
+    let requiredBinaryVersion: String?
+    let recommendedBinaryVersion: String?
+    let floorStanding: DoctorFloorStanding
+    let note: String?
+}
+
+/// What `/healthz` tells us. Kept separate from the transport so tests can
+/// drive every branch without a network.
+struct DoctorHealthz: Equatable, Sendable {
+    let version: String?
+    let requiredBinaryVersion: String?
+    let recommendedBinaryVersion: String?
+}
+
+struct DoctorRunner: Sendable {
+    let binaryVersion: String
+    let coordinatorURL: String?
+    let providerID: String?
+    let configPath: String
+    let offline: Bool
+    /// Returns nil when the coordinator is unreachable or answers unusably.
+    let fetch: @Sendable (URL) async -> DoctorHealthz?
+
+    /// Derives the `/healthz` URL from the configured coordinator WebSocket URL.
+    /// Copied from CoordinatorReadinessClient.readinessURL: reject embedded
+    /// credentials, and permit plaintext only for loopback.
+    static func healthzURL(coordinatorURL: String?) -> URL? {
+        guard let coordinatorURL,
+              var components = URLComponents(string: coordinatorURL),
+              components.user == nil,
+              components.password == nil,
+              let host = components.host?.lowercased()
+        else {
+            return nil
+        }
+        switch components.scheme?.lowercased() {
+        case "wss", "https":
+            components.scheme = "https"
+        case "ws" where host == "localhost" || host == "127.0.0.1" || host == "::1",
+             "http" where host == "localhost" || host == "127.0.0.1" || host == "::1":
+            components.scheme = "http"
+        default:
+            return nil
+        }
+        components.path = "/healthz"
+        components.query = nil
+        components.fragment = nil
+        return components.url
+    }
+
+    /// Compares this binary against a published floor. An unparseable version on
+    /// either side is `indeterminate`, never a silent pass: doctor must not tell
+    /// an operator they are fine when it could not actually check.
+    static func standing(binaryVersion: String, requiredBinaryVersion: String?) -> DoctorFloorStanding {
+        guard let required = requiredBinaryVersion?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !required.isEmpty else {
+            return .noFloorConfigured
+        }
+        guard isComparableVersion(binaryVersion), isComparableVersion(required) else {
+            return .indeterminate
+        }
+        // Ordering itself is delegated to the CLI's existing comparator; this
+        // adds only the strictness SelfUpdate.compareSemver lacks (it maps a
+        // non-numeric component to 0 rather than reporting it).
+        return SelfUpdate.compareSemver(binaryVersion, required) == .orderedAscending
+            ? .belowFloor
+            : .aboveFloor
+    }
+
+    /// Bare numeric version, 1-3 components, optional leading `v`. Matches what
+    /// the coordinator accepts for `required_binary_version`.
+    static func isComparableVersion(_ value: String) -> Bool {
+        let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.range(of: #"^[vV]?[0-9]+(\.[0-9]+){0,2}$"#, options: .regularExpression) != nil
+    }
+
+    func run() async -> DoctorReport {
+        let url = Self.healthzURL(coordinatorURL: coordinatorURL)
+        if offline {
+            return report(url: url, healthz: nil, standing: .notChecked, note: "coordinator check skipped (--offline)")
+        }
+        guard let url else {
+            return report(
+                url: nil,
+                healthz: nil,
+                standing: .notChecked,
+                note: coordinatorURL == nil
+                    ? "no coordinator_url configured"
+                    : "coordinator_url is not a usable https/wss endpoint"
+            )
+        }
+        guard let healthz = await fetch(url) else {
+            return report(url: url, healthz: nil, standing: .unreachable, note: "coordinator /healthz unreachable")
+        }
+        let standing = Self.standing(
+            binaryVersion: binaryVersion,
+            requiredBinaryVersion: healthz.requiredBinaryVersion
+        )
+        var note: String?
+        switch standing {
+        case .belowFloor:
+            note = "this build is below the coordinator's required minimum; it will be closed with 4004 version_unsupported. Run 'macprovider-cli update'."
+        case .indeterminate:
+            note = "could not compare this binary version against the coordinator's floor"
+        default:
+            note = nil
+        }
+        return report(url: url, healthz: healthz, standing: standing, note: note)
+    }
+
+    private func report(
+        url: URL?,
+        healthz: DoctorHealthz?,
+        standing: DoctorFloorStanding,
+        note: String?
+    ) -> DoctorReport {
+        DoctorReport(
+            binaryVersion: binaryVersion,
+            configPath: configPath,
+            coordinatorURL: coordinatorURL,
+            providerID: providerID,
+            healthzURL: url?.absoluteString,
+            coordinatorVersion: healthz?.version,
+            requiredBinaryVersion: healthz?.requiredBinaryVersion,
+            recommendedBinaryVersion: healthz?.recommendedBinaryVersion,
+            floorStanding: standing,
+            note: note
+        )
+    }
+
+    static func liveFetch(timeout: TimeInterval) -> @Sendable (URL) async -> DoctorHealthz? {
+        { url in
+            var request = URLRequest(url: url)
+            request.httpMethod = "GET"
+            request.timeoutInterval = max(1, timeout)
+            let configuration = URLSessionConfiguration.ephemeral
+            configuration.timeoutIntervalForRequest = max(1, timeout)
+            let session = URLSession(configuration: configuration)
+            defer { session.finishTasksAndInvalidate() }
+            guard let (data, response) = try? await session.data(for: request),
+                  let http = response as? HTTPURLResponse,
+                  http.statusCode == 200 else {
+                return nil
+            }
+            return parseHealthz(data)
+        }
+    }
+
+    static func parseHealthz(_ data: Data) -> DoctorHealthz? {
+        guard let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            return nil
+        }
+        func string(_ key: String) -> String? {
+            guard let value = object[key] as? String else { return nil }
+            let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+            return trimmed.isEmpty ? nil : trimmed
+        }
+        return DoctorHealthz(
+            version: string("version"),
+            requiredBinaryVersion: string("required_binary_version"),
+            recommendedBinaryVersion: string("recommended_binary_version")
+        )
+    }
+}
+
+enum DoctorReportPrinter {
+    static func emitText(_ report: DoctorReport) {
+        var lines: [String] = [
+            "macprovider-cli doctor",
+            "  binary_version:              \(report.binaryVersion)",
+            "  config_path:                 \(report.configPath)",
+            "  provider_id:                 \(report.providerID ?? "(unset)")",
+            "  coordinator_url:             \(report.coordinatorURL ?? "(unset)")",
+            "  coordinator_healthz:         \(report.healthzURL ?? "(not derivable)")",
+            "  coordinator_version:         \(report.coordinatorVersion ?? "(unknown)")",
+            "  required_binary_version:     \(report.requiredBinaryVersion ?? "(none published)")",
+            "  recommended_binary_version:  \(report.recommendedBinaryVersion ?? "(none published)")",
+            "  version_floor_standing:      \(report.floorStanding.rawValue)",
+        ]
+        if let note = report.note {
+            lines.append("  note:                        \(note)")
+        }
+        FileHandle.standardOutput.write(Data((lines.joined(separator: "\n") + "\n").utf8))
+    }
+
+    static func emitJSON(_ report: DoctorReport) {
+        var payload: [String: Any] = [
+            "binary_version": report.binaryVersion,
+            "config_path": report.configPath,
+            "version_floor_standing": report.floorStanding.rawValue,
+        ]
+        payload["provider_id"] = report.providerID
+        payload["coordinator_url"] = report.coordinatorURL
+        payload["coordinator_healthz_url"] = report.healthzURL
+        payload["coordinator_version"] = report.coordinatorVersion
+        payload["required_binary_version"] = report.requiredBinaryVersion
+        payload["recommended_binary_version"] = report.recommendedBinaryVersion
+        payload["note"] = report.note
+        let compacted = payload.compactMapValues { $0 }
+        guard JSONSerialization.isValidJSONObject(compacted),
+              var data = try? JSONSerialization.data(
+                withJSONObject: compacted,
+                options: [.sortedKeys, .withoutEscapingSlashes]
+              ) else {
+            FileHandle.standardOutput.write(Data("{\"binary_version\":\"\(report.binaryVersion)\"}\n".utf8))
+            return
+        }
+        data.append(0x0A)
+        FileHandle.standardOutput.write(data)
+    }
+}

--- a/phase3-binary/Sources/macprovider-cli/MacProviderCLI.swift
+++ b/phase3-binary/Sources/macprovider-cli/MacProviderCLI.swift
@@ -40,7 +40,7 @@ struct MacProviderCLI: AsyncParsableCommand {
         commandName: "macprovider-cli",
         abstract: "OpenAI-compatible Mac Provider inference CLI.",
         version: CoordinatorClient.binaryVersion,
-        subcommands: [ServeCommand.self, SelfTestCommand.self, StatusCommand.self, ClaimCommand.self, UpdateCommand.self, UninstallCommand.self, ModelsCommand.self, AutotuneCommand.self, BootstrapAuthCommand.self, RotateKeyCommand.self, CredentialsCommand.self, LifecycleStateCommand.self, LifecycleLeaseCommand.self, Spec028CanaryCommand.self, Spec028BenchmarkCommand.self, LegacySpec028CanaryCommand.self, LegacySpec028BenchmarkCommand.self, DecodeBenchCommand.self, EnrollCommand.self, ReleasePayloadPreflightCommand.self, KVCacheCommand.self],
+        subcommands: [ServeCommand.self, SelfTestCommand.self, StatusCommand.self, ClaimCommand.self, UpdateCommand.self, UninstallCommand.self, ModelsCommand.self, AutotuneCommand.self, BootstrapAuthCommand.self, RotateKeyCommand.self, CredentialsCommand.self, LifecycleStateCommand.self, LifecycleLeaseCommand.self, Spec028CanaryCommand.self, Spec028BenchmarkCommand.self, LegacySpec028CanaryCommand.self, LegacySpec028BenchmarkCommand.self, DecodeBenchCommand.self, EnrollCommand.self, ReleasePayloadPreflightCommand.self, KVCacheCommand.self, DoctorCommand.self],
         defaultSubcommand: ServeCommand.self
     )
 }

--- a/phase3-binary/Tests/macprovider-cliTests/DoctorCommandTests.swift
+++ b/phase3-binary/Tests/macprovider-cliTests/DoctorCommandTests.swift
@@ -1,0 +1,136 @@
+import Foundation
+import XCTest
+@testable import macprovider_cli
+
+/// Issue #767 item 3 — `macprovider-cli doctor`. Offline-first: everything but
+/// the floor comparison is answerable with no network at all.
+final class DoctorCommandTests: XCTestCase {
+    private func runner(
+        binaryVersion: String = "1.8.65",
+        coordinatorURL: String? = "wss://coordinator.streamvc.live/ws/provider",
+        offline: Bool = false,
+        fetch: @escaping @Sendable (URL) async -> DoctorHealthz?
+    ) -> DoctorRunner {
+        DoctorRunner(
+            binaryVersion: binaryVersion,
+            coordinatorURL: coordinatorURL,
+            providerID: "mac",
+            configPath: "/tmp/macprovider-doctor-test.yaml",
+            offline: offline,
+            fetch: fetch
+        )
+    }
+
+    private static let unreachable: @Sendable (URL) async -> DoctorHealthz? = { _ in nil }
+
+    // MARK: - endpoint derivation
+
+    func testHealthzURLDerivation() {
+        XCTAssertEqual(
+            DoctorRunner.healthzURL(coordinatorURL: "wss://coordinator.streamvc.live/ws/provider")?.absoluteString,
+            "https://coordinator.streamvc.live/healthz"
+        )
+        XCTAssertEqual(
+            DoctorRunner.healthzURL(coordinatorURL: "ws://127.0.0.1:8444/ws/provider")?.absoluteString,
+            "http://127.0.0.1:8444/healthz"
+        )
+        // Plaintext is loopback-only, credentials are refused, and a garbage or
+        // absent URL yields nil rather than a guessed endpoint.
+        XCTAssertNil(DoctorRunner.healthzURL(coordinatorURL: "ws://coordinator.streamvc.live/ws/provider"))
+        XCTAssertNil(DoctorRunner.healthzURL(coordinatorURL: "wss://user:pass@coordinator.streamvc.live/ws/provider"))
+        XCTAssertNil(DoctorRunner.healthzURL(coordinatorURL: "not a url"))
+        XCTAssertNil(DoctorRunner.healthzURL(coordinatorURL: nil))
+    }
+
+    // MARK: - floor standing
+
+    func testStandingAgainstPublishedFloor() {
+        XCTAssertEqual(DoctorRunner.standing(binaryVersion: "1.8.32", requiredBinaryVersion: "1.8.33"), .belowFloor)
+        XCTAssertEqual(DoctorRunner.standing(binaryVersion: "1.8.33", requiredBinaryVersion: "1.8.33"), .aboveFloor)
+        XCTAssertEqual(DoctorRunner.standing(binaryVersion: "1.8.65", requiredBinaryVersion: "1.8.33"), .aboveFloor)
+        XCTAssertEqual(DoctorRunner.standing(binaryVersion: "1.8.65", requiredBinaryVersion: nil), .noFloorConfigured)
+        XCTAssertEqual(DoctorRunner.standing(binaryVersion: "1.8.65", requiredBinaryVersion: "  "), .noFloorConfigured)
+        // Never claim "you're fine" from a comparison that did not happen.
+        XCTAssertEqual(DoctorRunner.standing(binaryVersion: "1.8.65-dev", requiredBinaryVersion: "1.8.33"), .indeterminate)
+        XCTAssertEqual(DoctorRunner.standing(binaryVersion: "1.8.65", requiredBinaryVersion: "latest"), .indeterminate)
+    }
+
+    // MARK: - offline-first behavior
+
+    func testOfflineSkipsTheCoordinatorEntirely() async {
+        let probed = LockedBox(false)
+        let report = await runner(offline: true, fetch: { _ in
+            probed.set(true)
+            return nil
+        }).run()
+        XCTAssertFalse(probed.get(), "--offline must not touch the network")
+        XCTAssertEqual(report.floorStanding, .notChecked)
+        XCTAssertEqual(report.binaryVersion, "1.8.65")
+        XCTAssertEqual(report.coordinatorURL, "wss://coordinator.streamvc.live/ws/provider")
+        XCTAssertNil(report.requiredBinaryVersion)
+    }
+
+    func testUnreachableCoordinatorDegradesGracefully() async {
+        let report = await runner(fetch: Self.unreachable).run()
+        XCTAssertEqual(report.floorStanding, .unreachable)
+        // Local facts are still reported — that is the point of offline-first.
+        XCTAssertEqual(report.binaryVersion, "1.8.65")
+        XCTAssertEqual(report.healthzURL, "https://coordinator.streamvc.live/healthz")
+    }
+
+    func testMissingCoordinatorURLIsNotChecked() async {
+        let report = await runner(coordinatorURL: nil, fetch: Self.unreachable).run()
+        XCTAssertEqual(report.floorStanding, .notChecked)
+        XCTAssertNil(report.healthzURL)
+    }
+
+    func testBelowFloorIsReportedWithTheRequiredTarget() async {
+        let report = await runner(binaryVersion: "1.8.32", fetch: { _ in
+            DoctorHealthz(
+                version: "v1.4.0",
+                requiredBinaryVersion: "1.8.33",
+                recommendedBinaryVersion: "1.8.65"
+            )
+        }).run()
+        XCTAssertEqual(report.floorStanding, .belowFloor)
+        XCTAssertEqual(report.requiredBinaryVersion, "1.8.33")
+        XCTAssertEqual(report.recommendedBinaryVersion, "1.8.65")
+        XCTAssertEqual(report.coordinatorVersion, "v1.4.0")
+        XCTAssertTrue(try! XCTUnwrap(report.note).contains("4004"))
+    }
+
+    func testAboveFloorIsClean() async {
+        let report = await runner(fetch: { _ in
+            DoctorHealthz(version: "v1.4.0", requiredBinaryVersion: "1.8.33", recommendedBinaryVersion: "1.8.65")
+        }).run()
+        XCTAssertEqual(report.floorStanding, .aboveFloor)
+        XCTAssertNil(report.note)
+    }
+
+    func testNoFloorPublished() async {
+        let report = await runner(fetch: { _ in
+            DoctorHealthz(version: "v1.4.0", requiredBinaryVersion: nil, recommendedBinaryVersion: "1.8.65")
+        }).run()
+        XCTAssertEqual(report.floorStanding, .noFloorConfigured)
+    }
+
+    // MARK: - healthz parsing
+
+    func testParseHealthz() throws {
+        let body = Data("""
+        {"status":"ok","version":"v1.4.0","recommended_binary_version":"1.8.65","required_binary_version":"1.8.33"}
+        """.utf8)
+        let parsed = try XCTUnwrap(DoctorRunner.parseHealthz(body))
+        XCTAssertEqual(parsed.version, "v1.4.0")
+        XCTAssertEqual(parsed.requiredBinaryVersion, "1.8.33")
+        XCTAssertEqual(parsed.recommendedBinaryVersion, "1.8.65")
+
+        // The coordinator omits required_binary_version when no floor is set.
+        let noFloor = try XCTUnwrap(DoctorRunner.parseHealthz(Data("""
+        {"status":"ok","version":"v1.4.0","recommended_binary_version":"1.8.65"}
+        """.utf8)))
+        XCTAssertNil(noFloor.requiredBinaryVersion)
+
+        XCTAssertNil(DoctorRunner.parseHealthz(Data("not json".utf8)))
+    }
+}

--- a/phase3-binary/Tests/macprovider-cliTests/VersionFloorRejectionTests.swift
+++ b/phase3-binary/Tests/macprovider-cliTests/VersionFloorRejectionTests.swift
@@ -1,0 +1,234 @@
+import Foundation
+import XCTest
+@testable import MacProviderCore
+@testable import macprovider_cli
+
+/// Issue #767 — a build below the coordinator's `required_binary_version` is
+/// closed with 4004 `version_unsupported`. Before this, the close fell through
+/// the close-code switch and the reconnect loop retried forever, so an operator
+/// saw an unexplained flap instead of an upgrade directive.
+final class VersionFloorRejectionTests: XCTestCase {
+    private func makeStatus() -> ProviderStatus {
+        ProviderStatus(
+            modelID: "model-a",
+            modelLoaded: true,
+            capacity: ProviderCapacity(maxContextOverride: 20_000, maxConcurrencyOverride: 1)
+        )
+    }
+
+    private func makeConfig() -> AppConfig {
+        var config = AppConfig.defaults(configPath: "/tmp/macprovider-version-floor-test.yaml")
+        config.coordinatorURL = "wss://127.0.0.1:8444/ws/provider"
+        config.providerID = "mp-0123456789abcdef0123456789abcdef"
+        config.model = "model-a"
+        return config
+    }
+
+    // MARK: - close-code classification
+
+    func testVersionUnsupportedCloseIsTypedWithTheRequiredTarget() async throws {
+        let socket = VersionFloorFakeSocket(
+            closeCodeRawValue: 4004,
+            closeReasonText: "version_unsupported: binary_version 1.8.32 below required 1.8.33"
+        )
+        let runtime = try await ModelRuntime(modelID: nil)
+        let client = try XCTUnwrap(CoordinatorClient(
+            config: makeConfig(),
+            modelRuntime: runtime,
+            providerStatus: makeStatus(),
+            attestationGenerator: VersionFloorNoAttestationGenerator(),
+            webSocketFactory: { _ in socket },
+            sleepAssertionFactory: { nil }
+        ))
+
+        do {
+            try await client.connectAndRunOnceForTest()
+            XCTFail("a 4004 version_unsupported close must throw")
+        } catch let CoordinatorAuthError.rejected(code, message) {
+            XCTAssertEqual(code, "version_unsupported")
+            XCTAssertTrue(message.contains("below required 1.8.33"), message)
+        } catch {
+            XCTFail("unexpected error: \(error)")
+        }
+    }
+
+    func testRequiredBinaryVersionParsedFromCloseReason() {
+        XCTAssertEqual(
+            CoordinatorClient.requiredBinaryVersion(
+                from: "version_unsupported: binary_version 1.8.32 below required 1.8.33"
+            ),
+            "1.8.33"
+        )
+        // Degrade gracefully rather than printing a wrong or hostile target.
+        XCTAssertNil(CoordinatorClient.requiredBinaryVersion(from: "version_unsupported"))
+        XCTAssertNil(CoordinatorClient.requiredBinaryVersion(from: "version_unsupported: below required "))
+        XCTAssertNil(
+            CoordinatorClient.requiredBinaryVersion(
+                from: "version_unsupported: below required rm -rf /"
+            )
+        )
+    }
+
+    func testVersionFloorRejectionOnlyMatchesTheFloorClose() {
+        let matched = CoordinatorClient.versionFloorRejection(
+            for: CoordinatorAuthError.rejected(
+                code: "version_unsupported",
+                message: "version_unsupported: binary_version 1.8.32 below required 1.9.0"
+            )
+        )
+        XCTAssertEqual(matched?.requiredVersion, "1.9.0")
+        XCTAssertEqual(matched?.currentVersion, CoordinatorClient.binaryVersion)
+
+        XCTAssertNil(CoordinatorClient.versionFloorRejection(
+            for: CoordinatorAuthError.rejected(code: "invalid_token", message: "invalid_token")
+        ))
+        XCTAssertNil(CoordinatorClient.versionFloorRejection(for: VersionFloorTestError.closedByCoordinator))
+    }
+
+    func testVersionUnsupportedLifecycleClassification() {
+        let classification = CoordinatorClient.lifecycleClassification(
+            for: CoordinatorAuthError.rejected(
+                code: "version_unsupported",
+                message: "version_unsupported: binary_version 1.8.32 below required 1.8.33"
+            )
+        )
+        XCTAssertEqual(classification.state, .catalogIncompatible)
+        XCTAssertEqual(classification.reasonCode, "binary_version_unsupported")
+    }
+
+    // MARK: - the reconnect loop must STOP
+
+    /// The load-bearing acceptance: a below-floor build must not hammer the
+    /// coordinator. One attempt, then the loop returns and never retries.
+    func testVersionFloorRejectionStopsTheReconnectLoop() async throws {
+        let attempts = VersionFloorAttemptCounter()
+        let runtime = try await ModelRuntime(modelID: nil)
+        let client = try XCTUnwrap(CoordinatorClient(
+            config: makeConfig(),
+            modelRuntime: runtime,
+            providerStatus: makeStatus(),
+            reconnectInitialBackoffNanoseconds: 1_000_000,
+            attestationGenerator: VersionFloorNoAttestationGenerator(),
+            sleepAssertionFactory: { nil },
+            connectAndRunOverride: {
+                _ = await attempts.record()
+                throw CoordinatorAuthError.rejected(
+                    code: "version_unsupported",
+                    message: "version_unsupported: binary_version 1.8.32 below required 1.9.0"
+                )
+            }
+        ))
+        await client.suppressSignedRecoveryDiscoveryForTest()
+
+        await client.start()
+        try await waitUntil(timeoutNanoseconds: 2_000_000_000) {
+            await client.coordinatorVersionFloorRejection() != nil
+        }
+        // Give the loop ample time to make a second attempt if it were going to.
+        try await Task.sleep(nanoseconds: 200_000_000)
+        await client.stop()
+
+        let count = await attempts.current()
+        XCTAssertEqual(count, 1, "a below-floor build must not retry; it made \(count) attempts")
+        let recorded = await client.coordinatorVersionFloorRejection()
+        let rejection = try XCTUnwrap(recorded)
+        XCTAssertEqual(rejection.requiredVersion, "1.9.0")
+        XCTAssertEqual(rejection.currentVersion, CoordinatorClient.binaryVersion)
+    }
+
+    /// A non-floor rejection must keep the ordinary retry behavior — the new
+    /// terminal branch must not swallow transient failures.
+    func testOtherRejectionsStillRetry() async throws {
+        let attempts = VersionFloorAttemptCounter()
+        let runtime = try await ModelRuntime(modelID: nil)
+        let client = try XCTUnwrap(CoordinatorClient(
+            config: makeConfig(),
+            modelRuntime: runtime,
+            providerStatus: makeStatus(),
+            reconnectInitialBackoffNanoseconds: 1_000_000,
+            attestationGenerator: VersionFloorNoAttestationGenerator(),
+            sleepAssertionFactory: { nil },
+            connectAndRunOverride: {
+                _ = await attempts.record()
+                throw VersionFloorTestError.closedByCoordinator
+            }
+        ))
+        await client.suppressSignedRecoveryDiscoveryForTest()
+
+        await client.start()
+        try await waitUntil(timeoutNanoseconds: 2_000_000_000) {
+            await attempts.current() >= 3
+        }
+        await client.stop()
+
+        let recorded = await client.coordinatorVersionFloorRejection()
+        XCTAssertNil(recorded, "a transport failure must not be recorded as a version-floor rejection")
+    }
+
+    private func waitUntil(
+        timeoutNanoseconds: UInt64,
+        _ condition: @Sendable () async -> Bool
+    ) async throws {
+        let deadline = DispatchTime.now().uptimeNanoseconds + timeoutNanoseconds
+        while DispatchTime.now().uptimeNanoseconds < deadline {
+            if await condition() {
+                return
+            }
+            try await Task.sleep(nanoseconds: 5_000_000)
+        }
+        XCTFail("condition not met within timeout")
+    }
+}
+
+enum VersionFloorTestError: Error {
+    case closedByCoordinator
+}
+
+actor VersionFloorAttemptCounter {
+    private var count = 0
+
+    func record() -> Int {
+        count += 1
+        return count
+    }
+
+    func current() -> Int {
+        count
+    }
+}
+
+/// Minimal local fakes — CoordinatorClientTests' own fakes are file-private.
+struct VersionFloorNoAttestationGenerator: Tier2AttestationTokenGenerating, @unchecked Sendable {
+    func makeAttestationToken(
+        challengeBase64URL: String?,
+        authAttemptID: String,
+        providerID: String,
+        binaryVersion: String,
+        snapshot: ProviderSnapshot,
+        providerECDHPublicKey: String
+    ) async -> [String: Any]? {
+        nil
+    }
+}
+
+/// A socket that immediately fails every receive and reports the close
+/// diagnostics the coordinator would have sent.
+final class VersionFloorFakeSocket: ProviderWebSocketTask, @unchecked Sendable {
+    let closeCodeRawValueForDiagnostics: Int?
+    let closeReasonTextForDiagnostics: String?
+
+    init(closeCodeRawValue: Int?, closeReasonText: String?) {
+        self.closeCodeRawValueForDiagnostics = closeCodeRawValue
+        self.closeReasonTextForDiagnostics = closeReasonText
+    }
+
+    func resume() {}
+
+    func send(_ message: URLSessionWebSocketTask.Message) async throws {}
+
+    func receive() async throws -> URLSessionWebSocketTask.Message {
+        throw VersionFloorTestError.closedByCoordinator
+    }
+
+    func cancel(with _: URLSessionWebSocketTask.CloseCode, reason _: Data?) {}
+}

--- a/phase4-coordinator/cmd/coordinator/main.go
+++ b/phase4-coordinator/cmd/coordinator/main.go
@@ -802,6 +802,7 @@ func main() {
 		buyer.WithFailoverConfig(cfg.Routing.FailoverEnabled, time.Duration(cfg.Routing.FailoverTimeoutS)*time.Second),
 		buyer.WithRoutingConfig(cfg.Routing),
 		buyer.WithTier2Config(cfg.Tier2),
+		buyer.WithModelVersionFloors(cfg.CoordinatorAdvertisedVersion.PerModelRequiredBinaryVersion),
 		buyer.WithLimitsConfig(cfg.Limits),
 		buyer.WithTrustedProxies(mustParseTrustedProxies(cfg, logger)),
 		buyer.WithOperatorKey(cfg.Auth.OperatorKey),

--- a/phase4-coordinator/dist/coordinator.yaml
+++ b/phase4-coordinator/dist/coordinator.yaml
@@ -313,5 +313,28 @@ providers:
 # operator-assisted full installer is the ONLY sanctioned upgrade path for that
 # legacy cohort (DECISION_CRITERIA Entry 161). Setting this value does not, and
 # must not, re-arm the legacy binary-only updater.
+#
+# `required_binary_version` (issue #767) is the HARD admission floor: a hello
+# below it is closed with 4004 version_unsupported. Prior to #767 it was set
+# nowhere in prod, so seam 5's floor existed only in code.
+#
+# WHY 1.8.33 and not something higher: 1.8.33 is the first release that
+# declares a `compatibility_set_id` in its hello — the boundary this file
+# already documents above. Everything at or below 1.8.32 is the legacy
+# pre-compatibility-set cohort that (a) receives no autoupdate
+# recommendation by design, and (b) cannot satisfy the live Pearl overlay's
+# `coordinator.compatibility_set.accepted_ids` gate because it sends no set
+# id at all. So the floor fences nobody who is currently admissible; it makes
+# the already-true rejection explicit and machine-readable instead of leaving
+# a legacy build to fail later, opaquely, on catalog admission.
+#
+# It is deliberately far below the current release (1.8.65) and below the
+# #610 first-hop bridge build (1.8.48, which is additionally exempt from the
+# floor by construction — see prepareProviderAdmission's firstHopOnly skip),
+# so raising it is a separate, deliberate act. Raise it only in lockstep with
+# a fleet-wide upgrade: a below-floor CLI carrying the #767 handler stops
+# reconnecting and tells its operator to upgrade, and one without it
+# reconnect-loops.
 coordinator_advertised_version:
   latest_binary_version: "1.8.65"
+  required_binary_version: "1.8.33"

--- a/phase4-coordinator/dist/coordinator.yaml.example
+++ b/phase4-coordinator/dist/coordinator.yaml.example
@@ -350,13 +350,28 @@ malibu_emission:
 # clone deploy.
 #
 # `required_binary_version` (optional) hard-rejects providers below the
-# version, closing WS with CloseVersionTooOld. It is a hard admission floor,
-# not an autoupdate target, and is NOT subject to the S-H1 capability gate.
-# Use for security fixes that must not be optional. Leave unset for advisory
-# releases.
+# version, closing WS with 4004 version_unsupported. It is a hard admission
+# floor, not an autoupdate target, and is NOT subject to the S-H1 capability
+# gate. Use for security fixes that must not be optional. Leave unset for
+# advisory releases. CLIs carrying the #767 handler surface the close as an
+# upgrade directive and STOP reconnecting; older builds retry forever, which
+# is why the floor must be chosen below the deployed fleet.
+#
+# `per_model_required_binary_version` (optional, issue #768) is a PER-MODEL
+# ROUTING floor, not an admission floor: a below-floor provider stays
+# connected (so it can still self-update) but is excluded from public
+# routing, from the self-route / hard-pin preflight path, and from the
+# warm-pool candidate gates. It sits beside the per-model HARDWARE tier gate
+# (the signed autotune candidate catalog's min_ram_gb / min_bandwidth_tier
+# rows), which answers "is this box big enough" but never "is this build new
+# enough for the engine this model needs". Unset = no floors = byte-identical
+# routing. Keys match model_id case-insensitively; values must be bare
+# numeric versions or the coordinator refuses to start.
 coordinator_advertised_version:
   latest_binary_version: "1.8.65"
   # required_binary_version: "1.7.0"
+  # per_model_required_binary_version:
+  #   "mlx-community/Qwen3-Coder-30B-A3B-Instruct-4bit": "1.8.60"
 
 # Enumerated providers (SPEC-002 v1.0.4 Finding F-2: every provider_id that
 # may connect MUST be listed here). Edit this list locally — DO NOT

--- a/phase4-coordinator/internal/buyer/seam_768_version_floor_test.go
+++ b/phase4-coordinator/internal/buyer/seam_768_version_floor_test.go
@@ -1,0 +1,174 @@
+package buyer
+
+import (
+	"testing"
+	"time"
+
+	"github.com/augstar/macprovider-coordinator/internal/pool"
+	"github.com/augstar/macprovider-coordinator/internal/routing"
+	"github.com/rs/zerolog"
+)
+
+const (
+	floorModelID   = "mlx-community/Qwen3-Coder-30B-A3B-Instruct-4bit"
+	unflooredModel = "mlx-community/Qwen2.5-7B-Instruct-4bit"
+)
+
+func versionFloorServer(t *testing.T, floors map[string]string) *Server {
+	t.Helper()
+	registry := pool.NewRegistry(nil)
+	return NewServer(
+		registry,
+		zerolog.Nop(),
+		time.Now().UTC(),
+		WithModelVersionFloors(floors),
+	)
+}
+
+func versionFloorProvider(providerID, modelID, binaryVersion string) pool.Provider {
+	return pool.Provider{
+		ProviderID:       providerID,
+		AssignedID:       "s-" + providerID,
+		ModelID:          modelID,
+		BinaryVersion:    binaryVersion,
+		State:            pool.StateReady,
+		Tier:             pool.TierPinned,
+		MaxContextTokens: 50000,
+		MaxConcurrency:   1,
+		SlotsTotal:       1,
+		SlotsFree:        1,
+		EndpointURL:      "https://" + providerID + ".example",
+		InferencePath:    pool.InferencePathHTTPForwarding,
+		LastHeartbeatAt:  time.Now().UTC(),
+		ConnectedAt:      time.Now().UTC(),
+	}
+}
+
+func versionFloorChecker(s *Server, model string) *eligibilityCtx {
+	return &eligibilityCtx{s: s, model: model, estimatedTokens: 100, tier2Cfg: s.tier2Config()}
+}
+
+// TestModelVersionFloorGate is the #768 unit contract on the SHARED helper:
+// same map, same verdict, in every gate.
+func TestModelVersionFloorGate(t *testing.T) {
+	s := versionFloorServer(t, map[string]string{floorModelID: "1.8.60"})
+	for _, tc := range []struct {
+		name    string
+		model   string
+		version string
+		want    bool
+	}{
+		{name: "below floor excluded", model: floorModelID, version: "1.8.59", want: false},
+		{name: "at floor admitted", model: floorModelID, version: "1.8.60", want: true},
+		{name: "above floor admitted", model: floorModelID, version: "1.8.65", want: true},
+		{name: "unfloored model untouched", model: unflooredModel, version: "0.1.0", want: true},
+		// A provider reporting a version we cannot parse while a floor is in
+		// force is suspect, so it fails SAFE (gated out), not open.
+		{name: "malformed version fails safe", model: floorModelID, version: "1.8.65-dev", want: false},
+		{name: "empty version fails safe", model: floorModelID, version: "", want: false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			p := versionFloorProvider("p", tc.model, tc.version)
+			if got := s.providerMeetsModelVersionFloor(p); got != tc.want {
+				t.Fatalf("providerMeetsModelVersionFloor(%q@%q) = %v, want %v", tc.model, tc.version, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestModelVersionFloorExcludesFromPublicRouting covers gate 1 of 3.
+func TestModelVersionFloorExcludesFromPublicRouting(t *testing.T) {
+	s := versionFloorServer(t, map[string]string{floorModelID: "1.8.60"})
+	providers := []pool.Provider{
+		versionFloorProvider("old", floorModelID, "1.8.59"),
+		versionFloorProvider("new", floorModelID, "1.8.65"),
+	}
+	res := routing.EligibleCandidates(
+		providers,
+		routing.NewExcluded(0),
+		pool.Provider.SortKey,
+		versionFloorChecker(s, floorModelID),
+	)
+	if len(res.Eligible) != 1 || res.Eligible[0].ProviderID != "new" {
+		t.Fatalf("eligible = %+v, want only the above-floor provider", res.Eligible)
+	}
+	if got := res.Counts[routing.ReasonModelVersionFloor]; got != 1 {
+		t.Fatalf("ReasonModelVersionFloor count = %d, want 1 (counts=%v)", got, res.Counts)
+	}
+}
+
+// TestModelVersionFloorExcludesFromSelfRoutePreflight covers gate 2 of 3: the
+// pinned / self-route path bypasses routing.EligibleCandidates entirely, so it
+// must re-apply the floor or a hard pin is a hole through the public gate.
+func TestModelVersionFloorExcludesFromSelfRoutePreflight(t *testing.T) {
+	s := versionFloorServer(t, map[string]string{floorModelID: "1.8.60"})
+	old := versionFloorProvider("old", floorModelID, "1.8.59")
+	_, routeErr := s.validatePinnedProviderForRequest(old, floorModelID, 100, "Pinned provider not available", nil)
+	if routeErr == nil {
+		t.Fatal("validatePinnedProviderForRequest accepted a below-floor pinned provider")
+	}
+	if routeErr.code != "model_version_floor_unmet" {
+		t.Fatalf("route error code = %q, want model_version_floor_unmet", routeErr.code)
+	}
+	if routeErr.status != 503 {
+		t.Fatalf("route error status = %d, want 503", routeErr.status)
+	}
+
+	fresh := versionFloorProvider("new", floorModelID, "1.8.65")
+	if _, routeErr := s.validatePinnedProviderForRequest(fresh, floorModelID, 100, "Pinned provider not available", nil); routeErr != nil {
+		t.Fatalf("above-floor pinned provider rejected: %+v", routeErr)
+	}
+}
+
+// TestModelVersionFloorExcludesFromSlotQueue covers the slot queue, which
+// re-derives the public routing gate list by hand.
+func TestModelVersionFloorExcludesFromSlotQueue(t *testing.T) {
+	s := versionFloorServer(t, map[string]string{floorModelID: "1.8.60"})
+	busy := func(providerID, version string) pool.Provider {
+		p := versionFloorProvider(providerID, floorModelID, version)
+		p.SlotsFree = 0 // slot-queue eligibility requires a saturated provider
+		return p
+	}
+	providers := []pool.Provider{busy("old", "1.8.59"), busy("new", "1.8.65")}
+	got := s.slotQueueCandidates(providers, routing.NewExcluded(0), versionFloorChecker(s, floorModelID))
+	if len(got) != 1 || got[0].ProviderID != "new" {
+		t.Fatalf("slotQueueCandidates = %+v, want only the above-floor provider", got)
+	}
+}
+
+// TestModelVersionFloorUnconfiguredIsByteIdentical is the default-posture
+// guarantee: with no floors configured, every gate behaves exactly as it did
+// before #768 — including for a provider whose version is unparseable.
+func TestModelVersionFloorUnconfiguredIsByteIdentical(t *testing.T) {
+	s := versionFloorServer(t, nil)
+	providers := []pool.Provider{
+		versionFloorProvider("ancient", floorModelID, "0.1.0"),
+		versionFloorProvider("garbled", floorModelID, "not-a-version"),
+		versionFloorProvider("blank", floorModelID, ""),
+	}
+	res := routing.EligibleCandidates(
+		providers,
+		routing.NewExcluded(0),
+		pool.Provider.SortKey,
+		versionFloorChecker(s, floorModelID),
+	)
+	if len(res.Eligible) != len(providers) {
+		t.Fatalf("eligible = %d, want all %d (unconfigured floors must not filter)", len(res.Eligible), len(providers))
+	}
+	if got := res.Counts[routing.ReasonModelVersionFloor]; got != 0 {
+		t.Fatalf("ReasonModelVersionFloor count = %d, want 0", got)
+	}
+	for _, p := range providers {
+		if _, routeErr := s.validatePinnedProviderForRequest(p, floorModelID, 100, "unavailable", nil); routeErr != nil {
+			t.Fatalf("pinned %q rejected with no floors configured: %+v", p.ProviderID, routeErr)
+		}
+	}
+}
+
+// TestModelVersionFloorErrorCodeIsClassified keeps the new buyer-visible code
+// inside the SPEC-006 §5.2 retryability contract the AST guard enforces.
+func TestModelVersionFloorErrorCodeIsClassified(t *testing.T) {
+	if !spec018Retryable("model_version_floor_unmet") {
+		t.Fatal("model_version_floor_unmet must be retryable=true: the fleet self-updates, so the same request can succeed later")
+	}
+}

--- a/phase4-coordinator/internal/buyer/seam_768_version_floor_test.go
+++ b/phase4-coordinator/internal/buyer/seam_768_version_floor_test.go
@@ -172,3 +172,47 @@ func TestModelVersionFloorErrorCodeIsClassified(t *testing.T) {
 		t.Fatal("model_version_floor_unmet must be retryable=true: the fleet self-updates, so the same request can succeed later")
 	}
 }
+
+// TestModelVersionFloorRecheckedAtSlotQueuePoll pins the #768 audit R1
+// finding (security+architect MEDIUM): the waiter stores only providerID, so
+// the provider polled off the queue may not be the one that passed
+// slotQueueCandidates — a same-ID reconnect below the per-model floor must
+// terminate the wait (model_version_floor_unmet path), never be served.
+func TestModelVersionFloorRecheckedAtSlotQueuePoll(t *testing.T) {
+	registry := pool.NewRegistry(nil)
+	s := NewServer(
+		registry,
+		zerolog.Nop(),
+		time.Now().UTC(),
+		WithModelVersionFloors(map[string]string{floorModelID: "1.8.60"}),
+	)
+	// The provider now registered under the queued ID is BELOW the floor —
+	// the same-ID-reconnect shape.
+	below := versionFloorProvider("p-queued", floorModelID, "1.8.50")
+	registry.Register(&below, nil)
+
+	waiter, ok := s.slotQueue.enter("p-queued")
+	if !ok {
+		t.Fatal("enter returned no waiter")
+	}
+	defer s.slotQueue.leave(waiter)
+
+	_, status := s.pollQueuedProvider(waiter, floorModelID, nil, 100)
+	if status != queuedProviderTerminal {
+		t.Fatalf("pollQueuedProvider status = %v, want terminal — a below-floor same-ID "+
+			"replacement must not be served off the slot queue", status)
+	}
+
+	// Control: the same poll serves an above-floor provider.
+	registry2 := pool.NewRegistry(nil)
+	s2 := NewServer(registry2, zerolog.Nop(), time.Now().UTC(),
+		WithModelVersionFloors(map[string]string{floorModelID: "1.8.60"}))
+	above := versionFloorProvider("p-queued", floorModelID, "1.8.65")
+	registry2.Register(&above, nil)
+	w2, _ := s2.slotQueue.enter("p-queued")
+	defer s2.slotQueue.leave(w2)
+	got, status2 := s2.pollQueuedProvider(w2, floorModelID, nil, 100)
+	if status2 != queuedProviderAvailable || got.ProviderID != "p-queued" {
+		t.Fatalf("control poll = (%q, %v), want the above-floor provider available", got.ProviderID, status2)
+	}
+}

--- a/phase4-coordinator/internal/buyer/server.go
+++ b/phase4-coordinator/internal/buyer/server.go
@@ -6384,6 +6384,13 @@ func (s *Server) pollQueuedProvider(waiter *slotWaiter, model string, class *con
 		if !s.providerMatchesRequest(provider, model, class) || provider.MaxContextTokens < estimatedTokens {
 			return pool.Provider{}, queuedProviderTerminal
 		}
+		// #768 audit R1 (security+architect MEDIUM): the waiter stores only
+		// providerID, so the provider polled here may not be the one that
+		// passed slotQueueCandidates — a same-ID reconnect below the
+		// per-model floor must not be served off the queue.
+		if !s.providerMeetsModelVersionFloor(provider) {
+			return pool.Provider{}, queuedProviderTerminal
+		}
 		if !provider.CapacityEligible() || provider.State != pool.StateReady || s.tier2ProviderExcluded(provider) || !s.checkQuota(provider) {
 			return pool.Provider{}, queuedProviderTerminal
 		}

--- a/phase4-coordinator/internal/buyer/server.go
+++ b/phase4-coordinator/internal/buyer/server.go
@@ -34,6 +34,7 @@ import (
 	"github.com/augstar/macprovider-coordinator/internal/routing"
 	"github.com/augstar/macprovider-coordinator/internal/routing/sticky"
 	"github.com/augstar/macprovider-coordinator/internal/tier2"
+	"github.com/augstar/macprovider-coordinator/internal/versionfloor"
 	providerws "github.com/augstar/macprovider-coordinator/internal/ws"
 	"github.com/go-chi/chi/v5"
 	"github.com/google/uuid"
@@ -73,7 +74,11 @@ var spec018RetryableByCode = map[string]bool{
 	"provisional_quota_exceeded": true, // 429, ships Retry-After: 3600 (writeErrorTypedParam)
 	"preflight_rejected":         true, // 503, all providers rejected/timed out during preflight
 	"idempotency_unavailable":    true, // 503, durable request logging unavailable
-	"rate_limited":               true, // 429, Tier-2 disclosure endpoints already ship Retry-After: 1
+	// 503, #768: every candidate for the model is below its minimum binary
+	// version. Retryable — the fleet self-updates, so the same request can
+	// succeed once a provider upgrades and reconnects.
+	"model_version_floor_unmet": true,
+	"rate_limited":              true, // 429, Tier-2 disclosure endpoints already ship Retry-After: 1
 	// Permanent/client errors — retrying will not help (SPEC-006 §5.2).
 	"model_not_found":                                         false,
 	"context_exceeds_capacity":                                false,
@@ -210,6 +215,10 @@ type Server struct {
 	requireGatewayContext bool
 	tier2Mu               sync.RWMutex
 	tier2                 config.Tier2Config
+	// modelVersionFloors is the #768 per-model minimum-binary-version map
+	// (model_id -> minimum version). Read-only after construction; nil/empty
+	// means no floors, which is byte-identical to pre-#768 routing.
+	modelVersionFloors    map[string]string
 	reqLog                requestLogInserter
 	reqLogStore           *requestlog.Store
 	provisionalWeight     float64
@@ -441,6 +450,60 @@ func WithStreamingMetricsMaxSamples(maxSamples int) Option {
 		s.streamingDowngrade = newStreamingDowngradeStoreWithLimit(maxSamples)
 		s.streamingTiming = newStreamingTimingCollectorWithLimit(maxSamples)
 	}
+}
+
+// WithModelVersionFloors installs the #768 per-model minimum-binary-version
+// map. Unset (or empty) keeps routing byte-identical to pre-#768 behavior.
+func WithModelVersionFloors(floors map[string]string) Option {
+	return func(s *Server) {
+		if len(floors) == 0 {
+			s.modelVersionFloors = nil
+			return
+		}
+		copied := make(map[string]string, len(floors))
+		for modelID, floor := range floors {
+			copied[modelID] = floor
+		}
+		s.modelVersionFloors = copied
+	}
+}
+
+// providerMeetsModelVersionFloor is the buyer-plane entry point to the ONE
+// #768 gate. Three call sites share it — the public routing filter
+// (eligibilityCtx.ProviderMeetsModelVersionFloor), the self-route / hard-pin
+// preflight path (validatePinnedProviderForRequest), and the slot-queue
+// candidate list — and internal/ws calls the same versionfloor.Check for the
+// warm-pool gates, so a box we would refuse to route to is never warmed.
+func (s *Server) providerMeetsModelVersionFloor(p pool.Provider) bool {
+	result := versionfloor.Check(s.modelVersionFloors, p.ModelID, p.BinaryVersion)
+	if result.Allowed {
+		return true
+	}
+	// A provider reporting an unparseable version while a floor is in force is
+	// suspect, not merely stale — that warns. An honestly-old build is routine
+	// and is evaluated per provider per request, so it stays at debug; the
+	// operator-visible signal for that case is the `model_version_floor_unmet`
+	// 503 envelope plus the per-request routing decision log.
+	event := s.log.Debug()
+	if result.Malformed {
+		event = s.log.Warn()
+	}
+	event.
+		Str("event", "model_version_floor_excluded").
+		Str("provider_id", p.ProviderID).
+		Str("assigned_id", p.AssignedID).
+		Str("model_id", p.ModelID).
+		Str("binary_version", p.BinaryVersion).
+		Str("required_binary_version", result.Floor).
+		Bool("binary_version_malformed", result.Malformed).
+		Msg("provider excluded by per-model binary version floor")
+	return false
+}
+
+// modelVersionFloorFor reports the configured floor for a provider's model,
+// empty when none applies. Used only to build operator-legible error text.
+func (s *Server) modelVersionFloorFor(p pool.Provider) string {
+	return versionfloor.Check(s.modelVersionFloors, p.ModelID, p.BinaryVersion).Floor
 }
 
 func (s *Server) SetTier2Config(cfg config.Tier2Config) {
@@ -5469,6 +5532,12 @@ func (s *Server) selectProviderExcluding(ctx context.Context, requestID string, 
 		if result.Counts[routing.ReasonTier2Attestation] > 0 {
 			return pool.Provider{}, &routeError{status: http.StatusServiceUnavailable, code: "tier2_attestation_required", message: "No attested provider available for model `" + req.Model + "`.", typ: "server_error"}
 		}
+		// #768: the pool has boxes for this model, they are just too old to
+		// serve it. Distinct from generic no_provider_available so operators
+		// see a supply-version problem instead of a supply-volume one.
+		if result.Counts[routing.ReasonModelVersionFloor] > 0 {
+			return pool.Provider{}, &routeError{status: http.StatusServiceUnavailable, code: "model_version_floor_unmet", message: "No provider running a new enough binary is available for model `" + req.Model + "`.", typ: "server_error"}
+		}
 		return pool.Provider{}, &routeError{status: http.StatusServiceUnavailable, code: "no_provider_available", message: "No provider available for model " + req.Model}
 	}
 	objective := s.objectiveForRequest(headers, class)
@@ -6154,6 +6223,17 @@ func (s *Server) validatePinnedProviderForRequest(p pool.Provider, model string,
 	if !s.providerMatchesRequest(p, model, class) {
 		return pool.Provider{}, &routeError{status: http.StatusNotFound, code: "model_not_found", message: "Pinned provider serves different model"}
 	}
+	// #768 self-route preflight gate. The pinned/self-route path bypasses
+	// routing.EligibleCandidates entirely, so the floor must be re-applied here
+	// or a hard pin would be a hole straight through the public routing gate.
+	if !s.providerMeetsModelVersionFloor(p) {
+		return pool.Provider{}, &routeError{
+			status:  http.StatusServiceUnavailable,
+			code:    "model_version_floor_unmet",
+			message: "Pinned provider `" + p.ProviderID + "` runs a binary below the minimum version required for model `" + p.ModelID + "` (>= " + s.modelVersionFloorFor(p) + ").",
+			typ:     "server_error",
+		}
+	}
 	if p.MaxContextTokens < estimatedTokens {
 		return pool.Provider{}, &routeError{status: http.StatusRequestEntityTooLarge, code: "context_exceeds_capacity", message: "Request exceeds pinned provider context capacity"}
 	}
@@ -6330,6 +6410,13 @@ func (s *Server) slotQueueCandidates(providers []pool.Provider, excluded routing
 		if !s.providerMatchesRequest(provider, checker.model, checker.class) || !checker.ProviderContextSufficient(provider) {
 			continue
 		}
+		// The slot queue re-derives the public routing gate list by hand; the
+		// #768 floor has to be re-applied here or a below-floor provider would
+		// still be queued for (and eventually served) the model it is too old
+		// to run.
+		if !checker.ProviderMeetsModelVersionFloor(provider) {
+			continue
+		}
 		reason, _ := checker.Tier2Decision(provider)
 		if reason != 0 || !checker.QuotaPermits(provider) {
 			continue
@@ -6456,6 +6543,12 @@ type eligibilityCtx struct {
 // either failure as ReasonModelMismatch to preserve byte identity.
 func (c *eligibilityCtx) ProviderMatchesRequest(p pool.Provider) bool {
 	return c.s.providerMatchesRequest(p, c.model, c.class) && p.RoutingEligible()
+}
+
+// ProviderMeetsModelVersionFloor delegates to the shared #768 gate. See
+// Server.providerMeetsModelVersionFloor.
+func (c *eligibilityCtx) ProviderMeetsModelVersionFloor(p pool.Provider) bool {
+	return c.s.providerMeetsModelVersionFloor(p)
 }
 
 func (c *eligibilityCtx) ProviderContextSufficient(p pool.Provider) bool {

--- a/phase4-coordinator/internal/config/config.go
+++ b/phase4-coordinator/internal/config/config.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"github.com/augstar/macprovider-coordinator/internal/stats/hardwareverify"
+	"github.com/augstar/macprovider-coordinator/internal/versionfloor"
 	"gopkg.in/yaml.v3"
 )
 
@@ -741,6 +742,23 @@ type Tier2MDMConfig struct {
 type CoordinatorAdvertisedVersion struct {
 	LatestBinaryVersion   string `yaml:"latest_binary_version"`
 	RequiredBinaryVersion string `yaml:"required_binary_version"`
+	// PerModelRequiredBinaryVersion is the #768 per-model minimum binary
+	// version floor: model_id -> minimum version. It sits BESIDE the
+	// per-model hardware-tier gate (the signed autotune candidate catalog's
+	// min_ram_gb / min_bandwidth_tier rows), which answers "is this box big
+	// enough" but never "is this build new enough for the engine this model
+	// needs".
+	//
+	// Unset (nil/empty) is the default posture and is byte-identical to
+	// pre-#768 routing. Keys are matched case-insensitively against the
+	// provider's advertised model_id. Values are validated at load; an
+	// unparseable floor is a config error, not a silent fence.
+	//
+	// Unlike RequiredBinaryVersion (a hard ADMISSION floor enforced at the
+	// provider hello with a 4004 close), these floors are ROUTING floors: a
+	// below-floor provider stays connected and can still self-update, it just
+	// is not routed to, warmed, or counted as a serving peer for that model.
+	PerModelRequiredBinaryVersion map[string]string `yaml:"per_model_required_binary_version"`
 }
 
 type AuthConfig struct {
@@ -1645,6 +1663,9 @@ func (c Config) Validate() error {
 	if err := c.validateCompatibilitySet(); err != nil {
 		return err
 	}
+	if err := c.validateAdvertisedVersions(); err != nil {
+		return err
+	}
 	if _, err := c.TrustedProxyPrefixes(); err != nil {
 		return err
 	}
@@ -1927,6 +1948,30 @@ func (c Config) Validate() error {
 			if err := ValidateEndpointURL(p.EndpointURL); err != nil {
 				return fmt.Errorf("provider %q endpoint_url must be a valid https URL (http allowed only for 127.0.0.1/localhost)", p.ProviderID)
 			}
+		}
+	}
+	return nil
+}
+
+// validateAdvertisedVersions rejects unparseable version floors at load. A
+// typo in `required_binary_version` would fence the whole fleet at hello
+// (compareSemver reports invalid, and invalid is treated as below-floor); a
+// typo in a per-model floor would silently unroute one model. Both are config
+// errors, so they fail the process at startup instead of in production.
+func (c Config) validateAdvertisedVersions() error {
+	advertised := c.CoordinatorAdvertisedVersion
+	if required := strings.TrimSpace(advertised.RequiredBinaryVersion); required != "" && !versionfloor.Valid(required) {
+		return fmt.Errorf("coordinator_advertised_version.required_binary_version %q must be a bare numeric version (e.g. 1.8.33)", required)
+	}
+	if latest := strings.TrimSpace(advertised.LatestBinaryVersion); latest != "" && !versionfloor.Valid(latest) {
+		return fmt.Errorf("coordinator_advertised_version.latest_binary_version %q must be a bare numeric version (e.g. 1.8.65)", latest)
+	}
+	for modelID, floor := range advertised.PerModelRequiredBinaryVersion {
+		if strings.TrimSpace(modelID) == "" {
+			return fmt.Errorf("coordinator_advertised_version.per_model_required_binary_version has an empty model_id key")
+		}
+		if !versionfloor.Valid(floor) {
+			return fmt.Errorf("coordinator_advertised_version.per_model_required_binary_version[%q] = %q must be a bare numeric version (e.g. 1.8.33)", modelID, floor)
 		}
 	}
 	return nil

--- a/phase4-coordinator/internal/config/seam_767_768_test.go
+++ b/phase4-coordinator/internal/config/seam_767_768_test.go
@@ -1,0 +1,111 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/augstar/macprovider-coordinator/internal/versionfloor"
+	"gopkg.in/yaml.v3"
+)
+
+// TestDeployCoordinatorYAMLSetsBinaryVersionFloor is the #767 P2-2 regression:
+// the committed prod overlay MUST carry a real `required_binary_version`. Seam
+// 5's floor existed only in code before this — the enforcement was live but
+// unconfigured, so no build was ever actually fenced.
+//
+// It also pins the safety property that made 1.8.33 choosable: the floor must
+// stay at or below the advertised latest release, so setting it can never fence
+// the build the coordinator is simultaneously recommending.
+func TestDeployCoordinatorYAMLSetsBinaryVersionFloor(t *testing.T) {
+	raw, err := os.ReadFile(filepath.Join("..", "..", "dist", "coordinator.yaml"))
+	if err != nil {
+		t.Fatalf("read dist/coordinator.yaml: %v", err)
+	}
+	var cfg Config
+	if err := yaml.Unmarshal(raw, &cfg); err != nil {
+		t.Fatalf("parse dist/coordinator.yaml: %v", err)
+	}
+	required := strings.TrimSpace(cfg.CoordinatorAdvertisedVersion.RequiredBinaryVersion)
+	if required == "" {
+		t.Fatal("dist/coordinator.yaml coordinator_advertised_version.required_binary_version is unset (#767 P2-2)")
+	}
+	if required != "1.8.33" {
+		t.Fatalf("required_binary_version = %q, want 1.8.33 (the first release that declares a compatibility_set_id; raising it is a deliberate fleet-wide act)", required)
+	}
+	latest := strings.TrimSpace(cfg.CoordinatorAdvertisedVersion.LatestBinaryVersion)
+	if latest == "" {
+		t.Fatal("dist/coordinator.yaml latest_binary_version is unset")
+	}
+	if cmp, ok := versionfloor.Compare(required, latest); !ok || cmp > 0 {
+		t.Fatalf("required_binary_version %q must not exceed latest_binary_version %q", required, latest)
+	}
+}
+
+func TestValidateRejectsMalformedVersionFloors(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		mutate  func(*Config)
+		wantSub string
+	}{
+		{
+			name:    "malformed required floor",
+			mutate:  func(c *Config) { c.CoordinatorAdvertisedVersion.RequiredBinaryVersion = "1.8.33-rc1" },
+			wantSub: "required_binary_version",
+		},
+		{
+			name:    "malformed latest",
+			mutate:  func(c *Config) { c.CoordinatorAdvertisedVersion.LatestBinaryVersion = "latest" },
+			wantSub: "latest_binary_version",
+		},
+		{
+			name: "malformed per-model floor",
+			mutate: func(c *Config) {
+				c.CoordinatorAdvertisedVersion.PerModelRequiredBinaryVersion = map[string]string{"model-a": "newest"}
+			},
+			wantSub: "per_model_required_binary_version",
+		},
+		{
+			name: "empty per-model key",
+			mutate: func(c *Config) {
+				c.CoordinatorAdvertisedVersion.PerModelRequiredBinaryVersion = map[string]string{"  ": "1.8.33"}
+			},
+			wantSub: "empty model_id key",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := validTestConfig()
+			tc.mutate(&cfg)
+			err := cfg.Validate()
+			if err == nil {
+				t.Fatalf("Validate() = nil, want error mentioning %q", tc.wantSub)
+			}
+			if !strings.Contains(err.Error(), tc.wantSub) {
+				t.Fatalf("Validate() error = %v, want mention of %q", err, tc.wantSub)
+			}
+		})
+	}
+}
+
+func TestValidateAcceptsWellFormedVersionFloors(t *testing.T) {
+	cfg := validTestConfig()
+	cfg.CoordinatorAdvertisedVersion.RequiredBinaryVersion = "1.8.33"
+	cfg.CoordinatorAdvertisedVersion.LatestBinaryVersion = "1.8.65"
+	cfg.CoordinatorAdvertisedVersion.PerModelRequiredBinaryVersion = map[string]string{
+		"mlx-community/Qwen3-Coder-30B-A3B-Instruct-4bit": "1.8.60",
+	}
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("Validate() = %v, want nil", err)
+	}
+}
+
+// TestValidateUnsetVersionFloorsStayValid pins the default posture: an overlay
+// that sets no floors at all is still a valid config.
+func TestValidateUnsetVersionFloorsStayValid(t *testing.T) {
+	cfg := validTestConfig()
+	cfg.CoordinatorAdvertisedVersion = CoordinatorAdvertisedVersion{}
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("Validate() with no advertised versions = %v, want nil", err)
+	}
+}

--- a/phase4-coordinator/internal/routing/filter.go
+++ b/phase4-coordinator/internal/routing/filter.go
@@ -36,6 +36,11 @@ const (
 	// ReasonQuotaBlocked — provider failed the admission-quota
 	// check (typically provisional-tier rate cap).
 	ReasonQuotaBlocked
+	// ReasonModelVersionFloor — provider's reported binary_version is
+	// below the per-model minimum configured in
+	// coordinator_advertised_version.per_model_required_binary_version,
+	// or is unparseable while such a floor is in force (#768).
+	ReasonModelVersionFloor
 )
 
 // EligibilityChecker is the cross-package boundary between the
@@ -56,6 +61,17 @@ type EligibilityChecker interface {
 	// class check with RoutingEligible(); a false return is
 	// reported as ReasonModelMismatch.
 	ProviderMatchesRequest(p pool.Provider) bool
+
+	// ProviderMeetsModelVersionFloor reports whether the provider's
+	// reported binary_version satisfies the per-model minimum
+	// version floor (#768). A false return is reported as
+	// ReasonModelVersionFloor. Implementations MUST delegate to the
+	// SAME versionfloor.Check used by the self-route preflight and
+	// warm-pool gates — "we never warm a box we won't route to"
+	// only holds while all three share one verdict. With no floors
+	// configured the implementation MUST return true for every
+	// provider so selection stays byte-identical to pre-#768.
+	ProviderMeetsModelVersionFloor(p pool.Provider) bool
 
 	// ProviderContextSufficient reports whether the provider's
 	// MaxContextTokens fits the request's estimated token budget.
@@ -121,10 +137,15 @@ type FilterResult struct {
 //  2. ProviderMatchesRequest (model/class + FR-P5 state) — combined
 //     gate; either failure is ReasonModelMismatch (the inline loop
 //     short-circuits to `continue` without separating the two)
-//  3. ProviderContextSufficient — ReasonContextTooSmall
-//  4. Tier2Decision — ReasonTier2HashMismatch / ReasonTier2Hash
+//  3. ProviderMeetsModelVersionFloor — ReasonModelVersionFloor
+//     (#768). Runs immediately after the model match because the
+//     floor is keyed BY model; a no-op when no floors are
+//     configured, so default-config selection stays byte-identical
+//     (AC-SR-1).
+//  4. ProviderContextSufficient — ReasonContextTooSmall
+//  5. Tier2Decision — ReasonTier2HashMismatch / ReasonTier2Hash
 //     Required / ReasonTier2EncryptedLeg / ReasonTier2Attestation
-//  5. QuotaPermits — ReasonQuotaBlocked (applied as a second pass
+//  6. QuotaPermits — ReasonQuotaBlocked (applied as a second pass
 //     here to preserve the "quota is soft, drives 429 only when
 //     every other check passed" semantics)
 //
@@ -150,6 +171,10 @@ func EligibleCandidates(
 		}
 		if !checker.ProviderMatchesRequest(p) {
 			res.Counts[ReasonModelMismatch]++
+			continue
+		}
+		if !checker.ProviderMeetsModelVersionFloor(p) {
+			res.Counts[ReasonModelVersionFloor]++
 			continue
 		}
 		if !checker.ProviderContextSufficient(p) {

--- a/phase4-coordinator/internal/routing/filter_test.go
+++ b/phase4-coordinator/internal/routing/filter_test.go
@@ -10,15 +10,22 @@ import (
 // stubChecker is a hand-rolled EligibilityChecker for tests; the
 // real implementation lives on internal/buyer/server.go.
 type stubChecker struct {
-	matches    map[string]bool
-	contextOK  map[string]bool
-	tier2      map[string]routing.RejectionReason
-	tier2Hash  map[string]pool.HashStatus
-	quotaOK    map[string]bool
+	matches        map[string]bool
+	versionFloorOK map[string]bool
+	contextOK      map[string]bool
+	tier2          map[string]routing.RejectionReason
+	tier2Hash      map[string]pool.HashStatus
+	quotaOK        map[string]bool
 }
 
 func (s *stubChecker) ProviderMatchesRequest(p pool.Provider) bool {
 	if v, ok := s.matches[p.ProviderID]; ok {
+		return v
+	}
+	return true
+}
+func (s *stubChecker) ProviderMeetsModelVersionFloor(p pool.Provider) bool {
+	if v, ok := s.versionFloorOK[p.ProviderID]; ok {
 		return v
 	}
 	return true
@@ -200,17 +207,22 @@ func TestEligibleCandidates_PreQuotaCountTracksFirstLoopSurvivors(t *testing.T) 
 // quota) is enforced for every provider AND a rejected provider
 // never reaches a later gate.
 type recordingChecker struct {
-	t            *testing.T
-	calls        []string // "providerID/gate"
-	matchFail    map[string]bool
-	contextFail  map[string]bool
-	tier2Reason  map[string]routing.RejectionReason
-	quotaFail    map[string]bool
+	t                *testing.T
+	calls            []string // "providerID/gate"
+	matchFail        map[string]bool
+	versionFloorFail map[string]bool
+	contextFail      map[string]bool
+	tier2Reason      map[string]routing.RejectionReason
+	quotaFail        map[string]bool
 }
 
 func (r *recordingChecker) ProviderMatchesRequest(p pool.Provider) bool {
 	r.calls = append(r.calls, p.ProviderID+"/match")
 	return !r.matchFail[p.ProviderID]
+}
+func (r *recordingChecker) ProviderMeetsModelVersionFloor(p pool.Provider) bool {
+	r.calls = append(r.calls, p.ProviderID+"/version_floor")
+	return !r.versionFloorFail[p.ProviderID]
 }
 func (r *recordingChecker) ProviderContextSufficient(p pool.Provider) bool {
 	r.calls = append(r.calls, p.ProviderID+"/context")
@@ -236,15 +248,15 @@ func TestEligibleCandidates_OrderingExcludedShortCircuitsEverything(t *testing.T
 	ex.Add(providers[0], keyer)
 	checker := &recordingChecker{t: t, matchFail: map[string]bool{"match-fail-y": true}}
 	res := routing.EligibleCandidates(providers, ex, keyer, checker)
-	// Excluded provider MUST never reach match/context/tier2/quota.
+	// Excluded provider MUST never reach match/version_floor/context/tier2/quota.
 	for _, c := range checker.calls {
-		if c == "excluded-x/match" || c == "excluded-x/context" || c == "excluded-x/tier2" || c == "excluded-x/quota" {
+		if c == "excluded-x/match" || c == "excluded-x/version_floor" || c == "excluded-x/context" || c == "excluded-x/tier2" || c == "excluded-x/quota" {
 			t.Fatalf("excluded provider hit later gate: %q (full calls: %v)", c, checker.calls)
 		}
 	}
-	// match-fail-y reaches match but NOT context/tier2/quota.
+	// match-fail-y reaches match but NOT version_floor/context/tier2/quota.
 	for _, c := range checker.calls {
-		if c == "match-fail-y/context" || c == "match-fail-y/tier2" || c == "match-fail-y/quota" {
+		if c == "match-fail-y/version_floor" || c == "match-fail-y/context" || c == "match-fail-y/tier2" || c == "match-fail-y/quota" {
 			t.Fatalf("match-rejected provider hit later gate: %q", c)
 		}
 	}
@@ -255,12 +267,14 @@ func TestEligibleCandidates_OrderingExcludedShortCircuitsEverything(t *testing.T
 
 func TestEligibleCandidates_OrderingPerProviderSequence(t *testing.T) {
 	// For a provider that passes every gate, the call sequence MUST
-	// be exactly match → context → tier2 → quota. FR-SR-18 order.
+	// be exactly match → version_floor → context → tier2 → quota.
+	// FR-SR-18 order, with the #768 per-model version floor inserted
+	// right after the model match (it is keyed BY model).
 	t.Parallel()
 	providers := []pool.Provider{{ProviderID: "p", AssignedID: "s"}}
 	checker := &recordingChecker{t: t}
 	routing.EligibleCandidates(providers, routing.NewExcluded(0), keyer, checker)
-	want := []string{"p/match", "p/context", "p/tier2", "p/quota"}
+	want := []string{"p/match", "p/version_floor", "p/context", "p/tier2", "p/quota"}
 	if len(checker.calls) != len(want) {
 		t.Fatalf("call count: want %d, got %d (calls=%v)", len(want), len(checker.calls), checker.calls)
 	}
@@ -276,7 +290,7 @@ func TestEligibleCandidates_OrderingContextRejectStopsBeforeTier2AndQuota(t *tes
 	providers := []pool.Provider{{ProviderID: "p", AssignedID: "s"}}
 	checker := &recordingChecker{t: t, contextFail: map[string]bool{"p": true}}
 	routing.EligibleCandidates(providers, routing.NewExcluded(0), keyer, checker)
-	want := []string{"p/match", "p/context"}
+	want := []string{"p/match", "p/version_floor", "p/context"}
 	if len(checker.calls) != len(want) {
 		t.Fatalf("context-reject: want sequence %v, got %v", want, checker.calls)
 	}
@@ -307,5 +321,44 @@ func TestEligibleCandidates_EmptyInputEmptyResult(t *testing.T) {
 	}
 	if len(res.Counts) != 0 {
 		t.Errorf("empty input: want empty Counts, got %v", res.Counts)
+	}
+}
+
+// TestEligibleCandidates_ModelVersionFloorRejects covers the #768 gate inside
+// the composition loop: a below-floor provider is dropped with its own reason
+// rather than being folded into ReasonModelMismatch, so the caller can emit a
+// supply-VERSION 503 instead of a supply-VOLUME one.
+func TestEligibleCandidates_ModelVersionFloorRejects(t *testing.T) {
+	t.Parallel()
+	providers := []pool.Provider{mkProvider("old"), mkProvider("new")}
+	checker := &stubChecker{versionFloorOK: map[string]bool{"old": false}}
+	res := routing.EligibleCandidates(providers, routing.NewExcluded(0), keyer, checker)
+	if len(res.Eligible) != 1 || res.Eligible[0].ProviderID != "new" {
+		t.Fatalf("eligible = %+v, want only the above-floor provider", res.Eligible)
+	}
+	if got := res.Counts[routing.ReasonModelVersionFloor]; got != 1 {
+		t.Fatalf("ReasonModelVersionFloor = %d, want 1 (counts=%v)", got, res.Counts)
+	}
+	if got := res.Counts[routing.ReasonModelMismatch]; got != 0 {
+		t.Fatalf("ReasonModelMismatch = %d, want 0 — the floor must not be folded into the model gate", got)
+	}
+}
+
+// TestEligibleCandidates_OrderingVersionFloorRejectStopsBeforeContext pins the
+// gate order: the floor is keyed BY model, so it runs right after the model
+// match and short-circuits every later gate.
+func TestEligibleCandidates_OrderingVersionFloorRejectStopsBeforeContext(t *testing.T) {
+	t.Parallel()
+	providers := []pool.Provider{{ProviderID: "p", AssignedID: "s"}}
+	checker := &recordingChecker{t: t, versionFloorFail: map[string]bool{"p": true}}
+	routing.EligibleCandidates(providers, routing.NewExcluded(0), keyer, checker)
+	want := []string{"p/match", "p/version_floor"}
+	if len(checker.calls) != len(want) {
+		t.Fatalf("calls = %v, want exactly %v", checker.calls, want)
+	}
+	for i := range want {
+		if checker.calls[i] != want[i] {
+			t.Fatalf("call[%d] = %q, want %q (full: %v)", i, checker.calls[i], want[i], checker.calls)
+		}
 	}
 }

--- a/phase4-coordinator/internal/versionfloor/versionfloor.go
+++ b/phase4-coordinator/internal/versionfloor/versionfloor.go
@@ -1,0 +1,155 @@
+// Package versionfloor owns the coordinator's binary-version comparison and
+// the per-model minimum-binary-version gate (issue #768).
+//
+// It is deliberately a dependency-free leaf so every gate that must share the
+// SAME verdict can import it: the public routing filter (internal/buyer via
+// internal/routing), the self-route / hard-pin preflight path (internal/buyer),
+// and the warm-pool candidate gates (internal/ws). "We never warm a box we
+// won't route to" only holds if all three call one implementation.
+//
+// Compare is the single version comparator in the coordinator — the global
+// `required_binary_version` admission floor (internal/ws) and the per-model
+// floors both use it, so a version string can never mean two different things
+// at two different gates.
+package versionfloor
+
+import (
+	"strconv"
+	"strings"
+)
+
+// Compare orders two dotted numeric version strings ("1.8.65", "v1.8", "2").
+// It returns -1/0/1 and a validity flag; the flag is false when EITHER side is
+// not a bare 1-to-3 component numeric version. Callers MUST treat an invalid
+// parse as "does not satisfy the floor" — see Check.
+func Compare(lhs, rhs string) (int, bool) {
+	left, okLeft := parts(lhs)
+	right, okRight := parts(rhs)
+	if !okLeft || !okRight {
+		return 0, false
+	}
+	n := len(left)
+	if len(right) > n {
+		n = len(right)
+	}
+	for i := 0; i < n; i++ {
+		var l, r int
+		if i < len(left) {
+			l = left[i]
+		}
+		if i < len(right) {
+			r = right[i]
+		}
+		switch {
+		case l < r:
+			return -1, true
+		case l > r:
+			return 1, true
+		}
+	}
+	return 0, true
+}
+
+// Valid reports whether value parses as a bare numeric version. Used by config
+// validation so a typo in an operator-authored floor is rejected at load time
+// rather than silently fencing an entire model at runtime.
+func Valid(value string) bool {
+	_, ok := parts(value)
+	return ok
+}
+
+func parts(value string) ([]int, bool) {
+	value = strings.TrimLeft(strings.TrimSpace(value), "vV")
+	if value == "" {
+		return nil, false
+	}
+	fields := strings.Split(value, ".")
+	if len(fields) > 3 {
+		return nil, false
+	}
+	out := make([]int, 0, len(fields))
+	for _, field := range fields {
+		field = strings.TrimSpace(field)
+		if field == "" {
+			return nil, false
+		}
+		for _, r := range field {
+			if r < '0' || r > '9' {
+				return nil, false
+			}
+		}
+		n, err := strconv.Atoi(field)
+		if err != nil {
+			return nil, false
+		}
+		out = append(out, n)
+	}
+	for len(out) < 3 {
+		out = append(out, 0)
+	}
+	return out, true
+}
+
+// Result is the verdict of one per-model floor evaluation.
+//
+// Floor is the configured minimum for the model, empty when none is configured
+// (in which case Allowed is always true — an unconfigured map is byte-identical
+// to pre-#768 behavior). Malformed marks the fail-safe case: a floor IS
+// configured for the model and the provider's reported binary version could not
+// be parsed. A provider that reports an unparseable version while a floor is in
+// force is suspect, so it is gated out and the caller logs it.
+type Result struct {
+	Allowed   bool
+	Floor     string
+	Malformed bool
+}
+
+// Check is THE per-model minimum-binary-version gate. Every call site — public
+// routing, self-route preflight, warm-pool candidate selection — must go
+// through it so the three can never diverge.
+//
+// Semantics, in order:
+//
+//	no floors configured, or no floor for this model -> allowed (no behavior change)
+//	provider version unparseable                     -> DENIED, Malformed=true (fail safe)
+//	configured floor unparseable                     -> DENIED, Malformed=true (defense in
+//	                                                    depth; config.Validate rejects these
+//	                                                    at load so this is unreachable in prod)
+//	provider version < floor                         -> DENIED
+//	otherwise                                        -> allowed
+func Check(floors map[string]string, modelID, binaryVersion string) Result {
+	if len(floors) == 0 {
+		return Result{Allowed: true}
+	}
+	floor := lookup(floors, modelID)
+	if floor == "" {
+		return Result{Allowed: true}
+	}
+	cmp, ok := Compare(binaryVersion, floor)
+	if !ok {
+		return Result{Allowed: false, Floor: floor, Malformed: true}
+	}
+	if cmp < 0 {
+		return Result{Allowed: false, Floor: floor}
+	}
+	return Result{Allowed: true, Floor: floor}
+}
+
+// lookup resolves the floor for modelID. Exact hit first (the hot path), then a
+// case-insensitive fallback so operator-authored YAML keys match the same way
+// buyer-side model comparison does (strings.EqualFold).
+func lookup(floors map[string]string, modelID string) string {
+	if v, ok := floors[modelID]; ok {
+		return strings.TrimSpace(v)
+	}
+	target := strings.ToLower(strings.TrimSpace(modelID))
+	if target == "" {
+		return ""
+	}
+	for k, v := range floors {
+		if strings.ToLower(strings.TrimSpace(k)) == target {
+			return strings.TrimSpace(v)
+		}
+	}
+	return ""
+}

--- a/phase4-coordinator/internal/versionfloor/versionfloor_test.go
+++ b/phase4-coordinator/internal/versionfloor/versionfloor_test.go
@@ -1,0 +1,122 @@
+package versionfloor
+
+import "testing"
+
+func TestCompareOrdersAndRejectsNonNumeric(t *testing.T) {
+	for _, tc := range []struct {
+		lhs, rhs string
+		want     int
+		valid    bool
+	}{
+		{lhs: "1.8.33", rhs: "1.8.33", want: 0, valid: true},
+		{lhs: "1.8.32", rhs: "1.8.33", want: -1, valid: true},
+		{lhs: "1.8.65", rhs: "1.8.33", want: 1, valid: true},
+		{lhs: "v1.9", rhs: "1.8.99", want: 1, valid: true},
+		{lhs: "2", rhs: "1.8.65", want: 1, valid: true},
+		// Suffixed / non-numeric / over-long versions are NOT comparable. The
+		// existing hello floor pins this (TestProviderHelloRejectsSuffixed
+		// RequiredBinaryVersion) and Check turns it into a denial.
+		{lhs: "1.8.33-dev", rhs: "1.8.33", valid: false},
+		{lhs: "1.8.33", rhs: "1.8.33.1", valid: false},
+		{lhs: "", rhs: "1.0.0", valid: false},
+		{lhs: "1..3", rhs: "1.0.0", valid: false},
+	} {
+		got, ok := Compare(tc.lhs, tc.rhs)
+		if ok != tc.valid {
+			t.Fatalf("Compare(%q,%q) valid = %v, want %v", tc.lhs, tc.rhs, ok, tc.valid)
+		}
+		if ok && got != tc.want {
+			t.Fatalf("Compare(%q,%q) = %d, want %d", tc.lhs, tc.rhs, got, tc.want)
+		}
+	}
+}
+
+func TestValid(t *testing.T) {
+	for _, ok := range []string{"1", "1.2", "1.2.3", "v1.8.65", " 1.8.65 "} {
+		if !Valid(ok) {
+			t.Fatalf("Valid(%q) = false, want true", ok)
+		}
+	}
+	for _, bad := range []string{"", "latest", "1.8.65-rc1", "1.2.3.4", "1.-2"} {
+		if Valid(bad) {
+			t.Fatalf("Valid(%q) = true, want false", bad)
+		}
+	}
+}
+
+// TestCheckUnconfiguredIsNoOp is the default-posture guarantee: with no floors
+// configured, no provider is ever excluded, whatever it reports.
+func TestCheckUnconfiguredIsNoOp(t *testing.T) {
+	for _, floors := range []map[string]string{nil, {}} {
+		for _, version := range []string{"", "0.1.0", "1.8.65", "garbage"} {
+			got := Check(floors, "model-a", version)
+			if !got.Allowed || got.Floor != "" || got.Malformed {
+				t.Fatalf("Check(%v, model-a, %q) = %+v, want allowed no-op", floors, version, got)
+			}
+		}
+	}
+}
+
+func TestCheckPerModelFloor(t *testing.T) {
+	floors := map[string]string{
+		"mlx-community/Qwen3-Coder-30B-A3B-Instruct-4bit": "1.8.60",
+	}
+	for _, tc := range []struct {
+		name          string
+		modelID       string
+		binaryVersion string
+		wantAllowed   bool
+		wantFloor     string
+		wantMalformed bool
+	}{
+		{
+			name: "unfloored model untouched", modelID: "mlx-community/Qwen2.5-7B-Instruct-4bit",
+			binaryVersion: "0.1.0", wantAllowed: true,
+		},
+		{
+			name: "below floor denied", modelID: "mlx-community/Qwen3-Coder-30B-A3B-Instruct-4bit",
+			binaryVersion: "1.8.59", wantAllowed: false, wantFloor: "1.8.60",
+		},
+		{
+			name: "at floor allowed", modelID: "mlx-community/Qwen3-Coder-30B-A3B-Instruct-4bit",
+			binaryVersion: "1.8.60", wantAllowed: true, wantFloor: "1.8.60",
+		},
+		{
+			name: "above floor allowed", modelID: "mlx-community/Qwen3-Coder-30B-A3B-Instruct-4bit",
+			binaryVersion: "1.8.65", wantAllowed: true, wantFloor: "1.8.60",
+		},
+		{
+			name: "model id matched case-insensitively", modelID: "MLX-COMMUNITY/qwen3-coder-30b-a3b-instruct-4bit",
+			binaryVersion: "1.8.59", wantAllowed: false, wantFloor: "1.8.60",
+		},
+		// Fail-safe: a provider reporting a version we cannot parse while a
+		// floor is in force is suspect. Gate it out, and flag it so the caller
+		// can log it louder than an honestly-old build.
+		{
+			name: "malformed provider version fails safe", modelID: "mlx-community/Qwen3-Coder-30B-A3B-Instruct-4bit",
+			binaryVersion: "1.8.60-hotfix", wantAllowed: false, wantFloor: "1.8.60", wantMalformed: true,
+		},
+		{
+			name: "empty provider version fails safe", modelID: "mlx-community/Qwen3-Coder-30B-A3B-Instruct-4bit",
+			binaryVersion: "", wantAllowed: false, wantFloor: "1.8.60", wantMalformed: true,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got := Check(floors, tc.modelID, tc.binaryVersion)
+			if got.Allowed != tc.wantAllowed || got.Floor != tc.wantFloor || got.Malformed != tc.wantMalformed {
+				t.Fatalf("Check(%q,%q) = %+v, want allowed=%v floor=%q malformed=%v",
+					tc.modelID, tc.binaryVersion, got, tc.wantAllowed, tc.wantFloor, tc.wantMalformed)
+			}
+		})
+	}
+}
+
+// TestCheckMalformedFloorFailsSafe is defense in depth: config.Validate rejects
+// an unparseable floor at load, so this path is unreachable in prod — but if it
+// were ever reached it must deny, not silently allow.
+func TestCheckMalformedFloorFailsSafe(t *testing.T) {
+	got := Check(map[string]string{"model-a": "latest"}, "model-a", "1.8.65")
+	if got.Allowed || !got.Malformed {
+		t.Fatalf("Check with malformed floor = %+v, want denied+malformed", got)
+	}
+}

--- a/phase4-coordinator/internal/ws/seam_767_version_floor_test.go
+++ b/phase4-coordinator/internal/ws/seam_767_version_floor_test.go
@@ -1,0 +1,108 @@
+package ws_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/augstar/macprovider-coordinator/internal/config"
+	providerws "github.com/augstar/macprovider-coordinator/internal/ws"
+)
+
+// TestProviderHealthzPublishesRequiredBinaryVersion is the coordinator half of
+// #767 item 3: `macprovider-cli doctor` needs a reachable surface that names
+// the hard admission floor, and /healthz already carries the recommendation.
+// Reusing it avoids inventing a provider-facing version endpoint.
+func TestProviderHealthzPublishesRequiredBinaryVersion(t *testing.T) {
+	ts := newProviderServer(t, func(cfg *config.Config) {
+		cfg.CoordinatorAdvertisedVersion.LatestBinaryVersion = "1.8.65"
+		cfg.CoordinatorAdvertisedVersion.RequiredBinaryVersion = "1.8.33"
+	})
+	defer ts.Close()
+
+	body := fetchHealthzVersions(t, ts.URL)
+	if body.RequiredBinaryVersion != "1.8.33" {
+		t.Fatalf("required_binary_version = %q, want 1.8.33", body.RequiredBinaryVersion)
+	}
+	if body.RecommendedBinaryVersion != "1.8.65" {
+		t.Fatalf("recommended_binary_version = %q, want 1.8.65", body.RecommendedBinaryVersion)
+	}
+}
+
+// TestProviderHealthzOmitsUnsetRequiredBinaryVersion keeps the field absent
+// (not an empty string) when no floor is configured, so `doctor` can tell "no
+// floor" apart from "floor is empty".
+func TestProviderHealthzOmitsUnsetRequiredBinaryVersion(t *testing.T) {
+	ts := newProviderServer(t)
+	defer ts.Close()
+
+	resp, err := http.Get(ts.URL + "/healthz")
+	if err != nil {
+		t.Fatalf("healthz: %v", err)
+	}
+	defer resp.Body.Close()
+	var raw map[string]any
+	if err := json.NewDecoder(resp.Body).Decode(&raw); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if _, present := raw["required_binary_version"]; present {
+		t.Fatalf("required_binary_version present with no floor configured: %v", raw["required_binary_version"])
+	}
+}
+
+// TestProviderHelloBelowFloorClosesWithParsableReason pins the wire contract the
+// Swift `case 4004` handler parses: close code 4004 and a reason that names BOTH
+// the rejected version and the required one, in a shape the client can split on
+// ("below required <version>").
+func TestProviderHelloBelowFloorClosesWithParsableReason(t *testing.T) {
+	ts := newProviderServer(t, func(cfg *config.Config) {
+		cfg.CoordinatorAdvertisedVersion.RequiredBinaryVersion = "1.8.33"
+	})
+	defer ts.Close()
+
+	hello := validHello("below-floor")
+	hello["binary_version"] = "1.8.32"
+	code, reason := sendHelloExpectClose(t, ts.URL, hello)
+	if code != providerws.CloseVersionUnsupported {
+		t.Fatalf("close code = %d, want %d (version_unsupported)", code, providerws.CloseVersionUnsupported)
+	}
+	if !strings.HasPrefix(reason, "version_unsupported:") {
+		t.Fatalf("close reason = %q, want a version_unsupported: prefix", reason)
+	}
+	if !strings.Contains(reason, "binary_version 1.8.32") {
+		t.Fatalf("close reason = %q, want the rejected version named", reason)
+	}
+	// The client parses the required target out of this suffix; changing the
+	// wording is a client-visible contract change.
+	idx := strings.Index(reason, "below required ")
+	if idx < 0 {
+		t.Fatalf("close reason = %q, want a 'below required <version>' suffix", reason)
+	}
+	if got := strings.TrimSpace(reason[idx+len("below required "):]); got != "1.8.33" {
+		t.Fatalf("parsed required version = %q, want 1.8.33", got)
+	}
+}
+
+func fetchHealthzVersions(t *testing.T, baseURL string) struct {
+	RecommendedBinaryVersion string `json:"recommended_binary_version"`
+	RequiredBinaryVersion    string `json:"required_binary_version"`
+} {
+	t.Helper()
+	var body struct {
+		RecommendedBinaryVersion string `json:"recommended_binary_version"`
+		RequiredBinaryVersion    string `json:"required_binary_version"`
+	}
+	resp, err := http.Get(baseURL + "/healthz")
+	if err != nil {
+		t.Fatalf("healthz: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("healthz status = %d", resp.StatusCode)
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	return body
+}

--- a/phase4-coordinator/internal/ws/seam_768_warm_floor_test.go
+++ b/phase4-coordinator/internal/ws/seam_768_warm_floor_test.go
@@ -1,0 +1,80 @@
+package ws
+
+import (
+	"testing"
+	"time"
+
+	"github.com/augstar/macprovider-coordinator/internal/config"
+	"github.com/augstar/macprovider-coordinator/internal/pool"
+	"github.com/rs/zerolog"
+)
+
+const warmFloorModelID = "mlx-community/Qwen3-Coder-30B-A3B-Instruct-4bit"
+
+func warmFloorServer(t *testing.T, floors map[string]string) *Server {
+	t.Helper()
+	cfg := config.Default()
+	cfg.CoordinatorAdvertisedVersion.PerModelRequiredBinaryVersion = floors
+	return NewServer(cfg, pool.NewRegistry(nil), zerolog.Nop())
+}
+
+func warmFloorProvider(providerID, binaryVersion string) pool.Provider {
+	now := time.Now().UTC()
+	return pool.Provider{
+		ProviderID:       providerID,
+		AssignedID:       "s-" + providerID,
+		ModelID:          warmFloorModelID,
+		BinaryVersion:    binaryVersion,
+		State:            pool.StateReady,
+		Tier:             pool.TierPinned,
+		MaxContextTokens: 50000,
+		MaxConcurrency:   1,
+		SlotsTotal:       1,
+		SlotsFree:        1,
+		EndpointURL:      "https://" + providerID + ".example",
+		InferencePath:    pool.InferencePathHTTPForwarding,
+		LastHeartbeatAt:  now,
+		ConnectedAt:      now,
+	}
+}
+
+// TestWarmPoolGateSharesModelVersionFloor is the "we never warm a box we won't
+// route to" half of #768: the warm-pool candidate gates read the same map and
+// the same versionfloor.Check the buyer-side routing gates read.
+func TestWarmPoolGateSharesModelVersionFloor(t *testing.T) {
+	s := warmFloorServer(t, map[string]string{warmFloorModelID: "1.8.60"})
+
+	old := warmFloorProvider("old", "1.8.59")
+	if s.canaryBuyerServing(old) {
+		t.Fatal("canaryBuyerServing admitted a below-floor provider as a serving peer")
+	}
+	if s.runWarmupGateAttempt(old, 1) {
+		t.Fatal("runWarmupGateAttempt warmed a below-floor provider")
+	}
+
+	fresh := warmFloorProvider("new", "1.8.65")
+	if !s.canaryBuyerServing(fresh) {
+		t.Fatal("canaryBuyerServing rejected an above-floor provider")
+	}
+
+	// Malformed version fails SAFE at the warm gates too.
+	garbled := warmFloorProvider("garbled", "1.8.65-dev")
+	if s.canaryBuyerServing(garbled) {
+		t.Fatal("canaryBuyerServing admitted a provider with an unparseable binary_version while a floor is in force")
+	}
+}
+
+// TestWarmPoolGateUnconfiguredIsByteIdentical pins the default posture at the
+// warm gates: unset floors never exclude, not even an unparseable version.
+func TestWarmPoolGateUnconfiguredIsByteIdentical(t *testing.T) {
+	s := warmFloorServer(t, nil)
+	for _, version := range []string{"0.1.0", "not-a-version", ""} {
+		p := warmFloorProvider("p", version)
+		if s.belowModelVersionFloor(p, "test") {
+			t.Fatalf("belowModelVersionFloor(%q) = true with no floors configured", version)
+		}
+		if !s.canaryBuyerServing(p) {
+			t.Fatalf("canaryBuyerServing(%q) = false with no floors configured", version)
+		}
+	}
+}

--- a/phase4-coordinator/internal/ws/server.go
+++ b/phase4-coordinator/internal/ws/server.go
@@ -12,7 +12,6 @@ import (
 	"math/big"
 	"net"
 	"net/http"
-	"strconv"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -24,6 +23,7 @@ import (
 	"github.com/augstar/macprovider-coordinator/internal/providerevents"
 	"github.com/augstar/macprovider-coordinator/internal/providerhttp"
 	"github.com/augstar/macprovider-coordinator/internal/tier2"
+	"github.com/augstar/macprovider-coordinator/internal/versionfloor"
 	gobwas "github.com/gobwas/ws"
 	"github.com/gobwas/ws/wsutil"
 	"github.com/google/uuid"
@@ -753,6 +753,14 @@ func (s *Server) canaryBuyerServing(p pool.Provider) bool {
 		return false
 	}
 	if s.tier2WarmupExcluded(p) {
+		return false
+	}
+	// #768: a peer below the per-model version floor is not routable, so it
+	// must not count as a buyer-serving peer either. Silent, like the tier2
+	// predicate above it: this runs under the pool registry lock and can be
+	// evaluated repeatedly per provider, and the same exclusion is already
+	// logged once at the warmup gate.
+	if !s.modelVersionFloor(p).Allowed {
 		return false
 	}
 	return true
@@ -2630,64 +2638,47 @@ func (s *Server) checkOrRecordAdmission(hello Hello, pinned bool, record bool) (
 	return s.admission.CheckAdmit(hello, pinned, s.connectedProvisional())
 }
 
+// compareSemver is a thin alias for the coordinator's single version
+// comparator. The implementation moved to internal/versionfloor (#768) so the
+// per-model floors evaluated in internal/buyer and the global admission floor
+// enforced here cannot drift into two different orderings.
 func compareSemver(lhs, rhs string) (int, bool) {
-	left, okLeft := semverParts(lhs)
-	right, okRight := semverParts(rhs)
-	if !okLeft || !okRight {
-		return 0, false
-	}
-	n := len(left)
-	if len(right) > n {
-		n = len(right)
-	}
-	for i := 0; i < n; i++ {
-		var l, r int
-		if i < len(left) {
-			l = left[i]
-		}
-		if i < len(right) {
-			r = right[i]
-		}
-		switch {
-		case l < r:
-			return -1, true
-		case l > r:
-			return 1, true
-		}
-	}
-	return 0, true
+	return versionfloor.Compare(lhs, rhs)
 }
 
-func semverParts(value string) ([]int, bool) {
-	value = strings.TrimLeft(strings.TrimSpace(value), "vV")
-	if value == "" {
-		return nil, false
+// modelVersionFloor evaluates the per-model minimum-binary-version floor
+// (#768) for a pool provider. Same map, same helper, same verdict as the
+// buyer-side routing gates — see versionfloor.Check.
+func (s *Server) modelVersionFloor(p pool.Provider) versionfloor.Result {
+	return versionfloor.Check(
+		s.cfg.CoordinatorAdvertisedVersion.PerModelRequiredBinaryVersion,
+		p.ModelID,
+		p.BinaryVersion,
+	)
+}
+
+// belowModelVersionFloor is the warm-pool half of the #768 gate: a provider we
+// would refuse to route to must not be warmed or counted as a serving peer.
+func (s *Server) belowModelVersionFloor(p pool.Provider, gate string) bool {
+	result := s.modelVersionFloor(p)
+	if result.Allowed {
+		return false
 	}
-	parts := strings.Split(value, ".")
-	if len(parts) > 3 {
-		return nil, false
+	event := s.log.Info()
+	if result.Malformed {
+		event = s.log.Warn()
 	}
-	out := make([]int, 0, len(parts))
-	for _, part := range parts {
-		part = strings.TrimSpace(part)
-		if part == "" {
-			return nil, false
-		}
-		for _, r := range part {
-			if r < '0' || r > '9' {
-				return nil, false
-			}
-		}
-		n, err := strconv.Atoi(part)
-		if err != nil {
-			return nil, false
-		}
-		out = append(out, n)
-	}
-	for len(out) < 3 {
-		out = append(out, 0)
-	}
-	return out, true
+	event.
+		Str("event", "model_version_floor_excluded").
+		Str("gate", gate).
+		Str("provider_id", p.ProviderID).
+		Str("assigned_id", p.AssignedID).
+		Str("model_id", p.ModelID).
+		Str("binary_version", p.BinaryVersion).
+		Str("required_binary_version", result.Floor).
+		Bool("binary_version_malformed", result.Malformed).
+		Msg("provider excluded by per-model binary version floor")
+	return true
 }
 
 // registerProviderSession installs the WS session in the registry +
@@ -3464,6 +3455,12 @@ func (s *Server) runWarmupGate(provider pool.Provider) {
 }
 
 func (s *Server) runWarmupGateAttempt(provider pool.Provider, attempt int) bool {
+	// #768 warm-pool candidate gate: we never warm a box we won't route to.
+	// Checked here (not in the WS-only branch) so the HTTP-forwarding path is
+	// covered by the same verdict.
+	if s.belowModelVersionFloor(provider, "warmup_gate") {
+		return false
+	}
 	body, err := json.Marshal(map[string]any{
 		"model": providerProbeModelID(provider),
 		"messages": []map[string]string{{
@@ -4921,6 +4918,14 @@ func (s *Server) handleHealthz(w http.ResponseWriter, r *http.Request) {
 		RequestsActive           int    `json:"requests_active"`
 		Version                  string `json:"version"`
 		RecommendedBinaryVersion string `json:"recommended_binary_version"`
+		// RequiredBinaryVersion mirrors the hard admission floor so
+		// `macprovider-cli doctor` can tell an operator WHY a build is being
+		// closed with 4004 without inventing a new coordinator endpoint
+		// (#767). Empty when no floor is configured. Like the recommendation
+		// above it is NOT capability-gated: /healthz is an operator/monitoring
+		// mirror, and no legacy CLI code path reads it to drive an autoupdate
+		// — a floor is a rejection reason, never an update target.
+		RequiredBinaryVersion string `json:"required_binary_version,omitempty"`
 		// TrustAuthorityDegraded is true when the hardware-trust revalidation
 		// sweep has failed to read the trust store for trustSweepDegradedThreshold
 		// consecutive ticks (issue #582 FIX C). It signals operators that active
@@ -4942,6 +4947,7 @@ func (s *Server) handleHealthz(w http.ResponseWriter, r *http.Request) {
 		// field, which IS gated above. Gating this monitoring value would blind
 		// operators with no security benefit.
 		RecommendedBinaryVersion: s.cfg.CoordinatorAdvertisedVersion.LatestBinaryVersion,
+		RequiredBinaryVersion:    strings.TrimSpace(s.cfg.CoordinatorAdvertisedVersion.RequiredBinaryVersion),
 		TrustAuthorityDegraded:   s.trustAuthorityDegraded.Load(),
 	}
 	for _, p := range providers {


### PR DESCRIPTION
Closes #767. Closes #768. PR 7 of epic #770 — **closes the epic's last children**.

## #767 — Binary version floor + client rejection handling

`required_binary_version: "1.8.33"` is now set in the committed prod config. The value is chosen to **fence nobody currently admissible**: 1.8.33 is the first release declaring a `compatibility_set_id`, and everything older already fails the live overlay's `accepted_ids` — the floor turns an opaque later rejection into an explicit, machine-readable one (the #610 bridge build is additionally exempt via `firstHopOnly`; a test pins floor ≤ latest). The Swift client gains a `4004 / version_unsupported` handler that surfaces the required version as an upgrade directive (stderr + structured event) and **terminates the reconnect loop** instead of hammering the coordinator, plus a `doctor` subcommand (offline diagnostics + `/healthz` check; `/healthz` now publishes `required_binary_version`, omitempty — no new endpoint). Config load rejects unparseable floors.

`doctor` against live Pearl immediately proved its worth: live advertises `1.8.61`/no floor while the committed file said `1.8.65` — the committed floor takes effect at the next deploy (documented; independently confirms P2-2 was real).

## #768 — Per-model minimum version floors

A coordinator config map, shipped **empty** (no behavior change by default) — deliberately *not* a field in the signed catalog `Row`, which would enter `RowIdentity` and invalidate every provider's cryptographically-bound benchmark evidence. **One shared check** (new `internal/versionfloor`, now the coordinator's single semver comparator) wired into every path that selects or touches a provider for a model: public routing, the pinned-provider preflight (the "self-route" path that bypasses the routing filter), the warm-pool gates on both transports plus canary serving, **`slotQueueCandidates` (a fourth leak the issue didn't name)**, and — from the audit — the slot-queue *poll*. Malformed provider versions fail safe (gated out, WARN). New retryable 503 `model_version_floor_unmet` (AST-guard registered; unreachable while the map is empty).

## Audit (three codex lanes, full diff)

- code R1: **PASS 0/0/0** (comparator equivalence, Swift close-frame parsing, gate wiring all verified).
- security + architect R1 converged on one MEDIUM: the slot-queue **waiter stores only providerID**, so `pollQueuedProvider` re-resolved against the live snapshot without rechecking the floor — a same-ID reconnect below floor could be served off the queue. Fixed with the shared check before reservation + a below-floor-replacement/above-floor-control regression test. Combined R2: **PASS 0/0/0**.

## Documented residual + carried LOWs

- **Floors rest on self-reported `binary_version`** (security MEDIUM, by design): the identity signature binds the provider *key to the claim*, not the running binary to a release — no provenance anchor exists in the system today (SPEC-033 hardware evidence doesn't hash binaries). Version floors are **supply hygiene against stale honest builds, not an anti-adversary control**; binary provenance is trust-model roadmap territory.
- LOW: `canaryProbeEligible` omits the floor (probe traffic only; weakens "don't probe what we won't route to"). LOW: the Swift receipt-key-rotation path makes bounded extra handshakes before the reconnect loop observes 4004.
- Floors are startup-only (not in the SIGHUP allowlist, matching pre-existing behavior) — a floor change needs a coordinator restart, with the single-provider-pool caution documented.

Verification: full coordinator suite, cross-service integration module, `swift build` + all 15 new Swift tests green. One pre-existing environment-dependent `SelfUpdateTests` failure (reads the real install authority instead of the injected version) proven pre-existing via clean-tree revert; untouched.

SPEC-GOVERNANCE-DECLARATION-BEGIN
{
  "schema_version": "spec-pr-governance-v1",
  "behavior_change": "yes",
  "contract_change": "none",
  "specs": ["SPEC-002", "SPEC-020", "SPEC-010"],
  "requirements": ["SPEC-020-R001"],
  "authority_domains": ["coordinator-admission-routing", "provider-autoupdate", "model-catalog-identity"],
  "arbitration": ["CODE_BUG"],
  "tests": ["phase4-coordinator/internal/versionfloor/versionfloor_test.go", "phase4-coordinator/internal/buyer/seam_768_version_floor_test.go", "phase3-binary/Tests/macprovider-cliTests/VersionFloorRejectionTests.swift"],
  "journeys": ["not-required"],
  "issue": "https://github.com/Augustas11/macprovider/issues/770"
}
SPEC-GOVERNANCE-DECLARATION-END

🤖 Generated with [Claude Code](https://claude.com/claude-code)
