### PR TITLE
Fail canary deploy evidence before stale bearer rollout

### DIFF
--- a/ops/pearl-updater/macprovider-pearl-update
+++ b/ops/pearl-updater/macprovider-pearl-update
@@ -4274,6 +4274,15 @@ class Updater:
         ).strip()
         if not re.fullmatch(r"[A-Za-z0-9._~-]{32,512}", token):
             raise UpdateError("catalog canary authorization token is invalid")
+        operator_token = self.coordinator_operator_token()
+        if not secrets.compare_digest(
+            hashlib.sha256(token.encode()).digest(),
+            hashlib.sha256(operator_token.encode()).digest(),
+        ):
+            raise UpdateError(
+                "catalog canary authorization token must be the coordinator operator key; "
+                "service tokens cannot satisfy details=deployment evidence"
+            )
         return provider_id, token
 
     def prove_catalog_canary_mac(

--- a/ops/pearl-updater/pearl-updater.conf.example
+++ b/ops/pearl-updater/pearl-updater.conf.example
@@ -53,8 +53,9 @@ PEARL_UPDATER_DEADMAN_HEARTBEAT_ID=
 PEARL_UPDATER_DEADMAN_API_TOKEN_FILE=/etc/macprovider/pearl-updater.betterstack-token
 
 # Required exact provider admission and independent on-Mac proof. The bearer
-# token must authorize details=deployment. Both secret files are root-owned 0600;
-# the SSH host key must already be present in root's known_hosts.
+# token is the coordinator operator key for operator-only details=deployment;
+# service tokens are rejected. Both secret files are root-owned 0600; the SSH
+# host key must already be present in root's known_hosts.
 PEARL_UPDATER_CATALOG_CANARY_PROVIDER_ID=
 PEARL_UPDATER_CATALOG_CANARY_AUTH_TOKEN_FILE=/etc/macprovider/pearl-updater.catalog-canary-token
 PEARL_UPDATER_CATALOG_CANARY_SSH_TARGET=

--- a/ops/pearl-updater/test_pearl_updater.py
+++ b/ops/pearl-updater/test_pearl_updater.py
@@ -1800,6 +1800,7 @@ class PearlUpdaterTests(unittest.TestCase):
             catalog_canary_ssh_key_file=key,
             catalog_canary_known_hosts_file=known_hosts,
         )
+        self.updater.coordinator_operator_token = mock.Mock(return_value="t" * 32)
         order = []
         self.updater.prove_catalog_canary_mac = mock.Mock(
             side_effect=lambda *_args, **_kwargs: order.append("mac")
@@ -1831,6 +1832,32 @@ class PearlUpdaterTests(unittest.TestCase):
 
         self.assertEqual(order, ["mac", "pool"])
 
+    def test_exact_provider_canary_requires_operator_key_token(self):
+        release = self.verify()
+        token = self.root / "catalog-token"
+        key = self.root / "catalog-ssh-key"
+        known_hosts = self.root / "catalog-known-hosts"
+        token.write_text("s" * 32 + "\n")
+        key.write_text("private-key\n")
+        known_hosts.write_text("canary.example ssh-ed25519 AAAATEST\n")
+        token.chmod(0o600)
+        key.chmod(0o600)
+        known_hosts.chmod(0o600)
+        self.updater.config = updater_module.dataclasses.replace(
+            self.updater.config,
+            catalog_canary_provider_id="catalog-canary",
+            catalog_canary_auth_token_file=token,
+            catalog_canary_ssh_target="operator@canary.example",
+            catalog_canary_ssh_key_file=key,
+            catalog_canary_known_hosts_file=known_hosts,
+        )
+        self.updater.coordinator_operator_token = mock.Mock(return_value="o" * 32)
+        self.updater.prove_catalog_canary_mac = mock.Mock()
+
+        with self.assertRaisesRegex(updater_module.UpdateError, "must be the coordinator operator key"):
+            self.updater.verify_exact_provider_canary(release)
+        self.updater.prove_catalog_canary_mac.assert_not_called()
+
     def test_exact_provider_canary_retries_full_proof_and_session_bound_admission(self):
         release = self.verify()
         token = self.root / "catalog-token"
@@ -1851,6 +1878,7 @@ class PearlUpdaterTests(unittest.TestCase):
             catalog_canary_ssh_key_file=key,
             catalog_canary_known_hosts_file=known_hosts,
         )
+        self.updater.coordinator_operator_token = mock.Mock(return_value="t" * 32)
         row_identity = "b" * 64
         self.updater.prove_catalog_canary_mac = mock.Mock(
             side_effect=[

--- a/ops/runbooks/catalog-release-provider-upgrade.md
+++ b/ops/runbooks/catalog-release-provider-upgrade.md
@@ -593,7 +593,11 @@ The direct-deploy recovery procedure is:
 10. Confirm coordinator and gateway health report the installed signed pair and
    coordinator catalog status reports the intended release/signer.
 11. Set `CATALOG_CANARY_PROVIDER_ID` to a real enrolled canary provider and
-   provide `CATALOG_CANARY_AUTH_TOKEN` for the protected compatibility view.
+   provide `CATALOG_CANARY_AUTH_TOKEN` from the coordinator operator key, not
+   the gateway/coordinator service token. The deployment compatibility view is
+   `/v1/pool/check?details=deployment`, which is operator-only; the deploy
+   script proves this token against the Pearl coordinator operator-key digest
+   before any upload or restart.
    The deploy must poll `/v1/pool/check` until that exact provider reports
    `buyer_serving: true`, `catalog_admission_mode: current`, the exact active
    release/policy/digest/signer envelope, a valid selected row identity, and

--- a/ops/runbooks/pearl-release-updater.md
+++ b/ops/runbooks/pearl-release-updater.md
@@ -166,11 +166,13 @@ printf '%s\n' "$BETTERSTACK_UPTIME_API_TOKEN" | \
 ```
 
 Provision one enrolled catalog-aware canary Mac as the release commit witness.
-Create a coordinator bearer token authorized for `details=deployment` and a
-dedicated read-only SSH key as root-owned `0600` files on Pearl. Store the
-canary Mac host key in a dedicated root-owned `0600` known-hosts file; the
-hardened service cannot read root's home directory and always uses
-`StrictHostKeyChecking=yes`. Configure these values in
+Store the coordinator operator key, not the gateway/coordinator service token,
+as the catalog-canary bearer for `details=deployment`, and store a dedicated
+read-only SSH key as root-owned `0600` files on Pearl. The
+`/v1/pool/check?details=deployment` evidence path is operator-only; service
+tokens are rejected. Store the canary Mac host key in a dedicated root-owned
+`0600` known-hosts file; the hardened service cannot read root's home directory
+and always uses `StrictHostKeyChecking=yes`. Configure these values in
 `/etc/macprovider/pearl-updater.conf`:
 
 ```text
@@ -321,7 +323,7 @@ PEARL_UPDATER_MINIMUM_BRIDGE_REMAINING_S=1200
    floor, strict admission during this bridge rollout, or a bridge without the
    configured safe remaining window.
 5. Set `PEARL_UPDATER_ENABLED=1` and keep the config, revocation list, Better
-   Stack token, catalog-canary bearer token, and catalog-canary SSH key
+   Stack token, catalog-canary operator-key bearer, and catalog-canary SSH key
    `root:root 0600`.
 6. Prove the live root-owned config carries the exact outer handoff deadline
    and bridge safety window before starting the plan. These reads expose no

--- a/phase4-coordinator/dist/deploy-pearl-vps.sh
+++ b/phase4-coordinator/dist/deploy-pearl-vps.sh
@@ -148,6 +148,22 @@ _validate_catalog_canary_auth_token() {
   esac
 }
 
+_catalog_canary_auth_token_sha256() {
+  printf '%s' "$1" | shasum -a 256 | awk '{print tolower($1)}'
+}
+
+_catalog_canary_auth_token_matches_operator_key() {
+  local token="$1" operator_key_sha="$2" token_sha operator_sha_lc
+  _validate_catalog_canary_auth_token "$token" || return 1
+  case "$operator_key_sha" in
+    ""|*[!0-9a-fA-F]*) return 1 ;;
+  esac
+  [ "${#operator_key_sha}" -eq 64 ] || return 1
+  token_sha="$(_catalog_canary_auth_token_sha256 "$token")" || return 1
+  operator_sha_lc="$(printf '%s' "$operator_key_sha" | tr 'A-F' 'a-f')"
+  [ "$token_sha" = "$operator_sha_lc" ]
+}
+
 _run_with_deadline_alarm() {
   local timeout_s="$1"
   shift
@@ -934,6 +950,12 @@ else
   read -r C2C_COORD_OPERATOR_KEY_SHA256 C2C_COORD_SERVICE_TOKEN_SHA256 C2C_GATEWAY_SERVICE_TOKEN_SHA256 C2C_GATEWAY_OPERATOR_KEY_SHA256 <<EOF
 $_c2c_proofs
 EOF
+  if ! _catalog_canary_auth_token_matches_operator_key "$CATALOG_CANARY_AUTH_TOKEN" "$C2C_COORD_OPERATOR_KEY_SHA256"; then
+    echo "aborting deploy: CATALOG_CANARY_AUTH_TOKEN must be the coordinator operator key" >&2
+    echo "  /v1/pool/check?details=deployment is operator-only; service tokens cannot satisfy deployment evidence." >&2
+    echo "  Update the operator-held canary token source before retrying; no secret material was copied from Pearl." >&2
+    exit 5
+  fi
   C2C_COORD_OPERATOR_KEY_SHA256="$C2C_COORD_OPERATOR_KEY_SHA256" \
   C2C_COORD_SERVICE_TOKEN_SHA256="$C2C_COORD_SERVICE_TOKEN_SHA256" \
   C2C_GATEWAY_SERVICE_TOKEN_SHA256="$C2C_GATEWAY_SERVICE_TOKEN_SHA256" \

--- a/phase4-coordinator/dist/test/check_deploy_static_feed_access.test.sh
+++ b/phase4-coordinator/dist/test/check_deploy_static_feed_access.test.sh
@@ -246,10 +246,23 @@ grep -q 'CATALOG_CANARY_AUTH_TOKEN is required' "$DEPLOY_SH" ||
   fail "deploy must require authenticated canary evidence"
 
 token_validator_tmp="$(mktemp)"
-trap 'rm -f "$token_validator_tmp"' EXIT
+canary_operator_guard_tmp="$(mktemp)"
+trap 'rm -f "$token_validator_tmp" "$canary_operator_guard_tmp"' EXIT
 awk '/^_validate_catalog_canary_auth_token\(\) \{/{f=1} f{print} f&&/^\}$/{exit}' "$DEPLOY_SH" > "$token_validator_tmp"
 grep -qF '_validate_catalog_canary_auth_token()' "$token_validator_tmp" ||
   fail "deploy must keep an extractable portable canary token validator"
+awk '
+  /^_catalog_canary_auth_token_sha256\(\) \{/ { f=1 }
+  f { print }
+  /^_catalog_canary_auth_token_matches_operator_key\(\) \{/ { matcher=1 }
+  f && matcher && /^\}$/ { exit }
+' "$DEPLOY_SH" > "$canary_operator_guard_tmp"
+grep -qF '_catalog_canary_auth_token_matches_operator_key()' "$canary_operator_guard_tmp" ||
+  fail "deploy must keep an extractable canary operator-key proof guard"
+grep -qF 'CATALOG_CANARY_AUTH_TOKEN must be the coordinator operator key' "$DEPLOY_SH" ||
+  fail "deploy must name the operator-key-only canary token requirement"
+grep -qF '/v1/pool/check?details=deployment is operator-only' "$DEPLOY_SH" ||
+  fail "deploy must document that service tokens cannot satisfy deployment evidence"
 # BSD grep rejects interval upper bounds greater than 255. Length checks belong
 # in Bash so the production deploy remains portable on the operator Mac.
 if grep -qF '{32,512}' "$DEPLOY_SH"; then
@@ -276,8 +289,27 @@ _validate_catalog_canary_auth_token "$token_512" ||
 ! _validate_catalog_canary_auth_token "${token_32}"$'\r''header = "X-Injected: yes"' ||
   fail "canary token validator must reject carriage-return curl-config injection"
 
+HEX64=0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+HEX64B=fedcba9876543210fedcba9876543210fedcba9876543210fedcba9876543210
+HEX64_SHA256="$(printf '%s' "$HEX64" | shasum -a 256 | awk '{print $1}')"
+HEX64B_SHA256="$(printf '%s' "$HEX64B" | shasum -a 256 | awk '{print $1}')"
+# shellcheck disable=SC1090
+. "$canary_operator_guard_tmp"
+_catalog_canary_auth_token_matches_operator_key "$HEX64" "$HEX64_SHA256" ||
+  fail "canary token guard must accept the coordinator operator key"
+_catalog_canary_auth_token_matches_operator_key "$HEX64" "$(printf '%s' "$HEX64_SHA256" | tr 'a-f' 'A-F')" ||
+  fail "canary token guard must accept uppercase proof digests"
+! _catalog_canary_auth_token_matches_operator_key "$HEX64B" "$HEX64_SHA256" ||
+  fail "canary token guard must reject a distinct service token"
+! _catalog_canary_auth_token_matches_operator_key "$HEX64" "$HEX64B_SHA256" ||
+  fail "canary token guard must reject a mismatched operator proof"
+! _catalog_canary_auth_token_matches_operator_key "$HEX64" short ||
+  fail "canary token guard must reject malformed operator proof digests"
+! _catalog_canary_auth_token_matches_operator_key "${HEX64}!" "$HEX64_SHA256" ||
+  fail "canary token guard must preserve token syntax validation"
+
 deadline_alarm_tmp="$(mktemp)"
-trap 'rm -f "$token_validator_tmp" "$deadline_alarm_tmp"' EXIT
+trap 'rm -f "$token_validator_tmp" "$canary_operator_guard_tmp" "$deadline_alarm_tmp"' EXIT
 awk '/^_run_with_deadline_alarm\(\) \{/{f=1} f{print} f&&/^\}$/{exit}' "$DEPLOY_SH" > "$deadline_alarm_tmp"
 grep -qF '_run_with_deadline_alarm()' "$deadline_alarm_tmp" ||
   fail "deploy must keep an extractable subprocess deadline helper"
@@ -293,7 +325,7 @@ _run_with_deadline_alarm 2 sh -c 'exit 0' ||
   fail "subprocess deadline helper must preserve successful commands"
 
 deadline_parser_tmp="$(mktemp)"
-trap 'rm -f "$token_validator_tmp" "$deadline_alarm_tmp" "$deadline_parser_tmp"' EXIT
+trap 'rm -f "$token_validator_tmp" "$canary_operator_guard_tmp" "$deadline_alarm_tmp" "$deadline_parser_tmp"' EXIT
 awk '/^_parse_model_hash_legacy_until\(\) \{/{f=1} f{print} f&&/^\}$/{exit}' "$DEPLOY_SH" > "$deadline_parser_tmp"
 grep -qF '_parse_model_hash_legacy_until()' "$deadline_parser_tmp" ||
   fail "deploy must keep an extractable MODEL_HASH_LEGACY_UNTIL parser"


### PR DESCRIPTION
## Summary

- Require direct Pearl deploy `CATALOG_CANARY_AUTH_TOKEN` to match the Pearl-proven coordinator operator-key digest before deploy proceeds.
- Make the Pearl updater reject a catalog-canary token file that does not match the effective coordinator operator key before Mac proof or `/v1/pool/check?details=deployment` polling.
- Update manual/updater runbooks to state that deployment evidence uses the coordinator operator key, not the service token.

## Validation

- `bash phase4-coordinator/dist/test/check_deploy_static_feed_access.test.sh`
- `bash phase4-coordinator/dist/test/check_deploy_config_test.sh`
- `python3 phase4-coordinator/dist/test/c2c_runtime_proof_test.py`
- `python3 -m unittest ops.pearl-updater.test_pearl_updater`
- `git diff --check origin/main --`
- `bash -n phase4-coordinator/dist/deploy-pearl-vps.sh phase4-coordinator/dist/test/check_deploy_static_feed_access.test.sh phase4-coordinator/dist/check-deploy-config.sh phase4-coordinator/dist/test/check_deploy_config_test.sh`
- `python3 -m py_compile ops/pearl-updater/macprovider-pearl-update ops/pearl-updater/test_pearl_updater.py phase4-coordinator/dist/lib/c2c_runtime_proof.py phase4-coordinator/dist/test/c2c_runtime_proof_test.py`
- 3-lane audit: code/security/architecture all 0 C/H/M

## Notes

Refs #785. This does not claim live Pearl deploy proof; no production credentials or services were accessed.

SPEC-GOVERNANCE-DECLARATION-BEGIN
{
  "schema_version": "spec-pr-governance-v1",
  "behavior_change": "yes",
  "contract_change": "none",
  "specs": ["SPEC-020", "SPEC-023"],
  "requirements": ["SPEC-020-R001", "SPEC-023-R001"],
  "authority_domains": ["provider-autoupdate", "installer-autotune-policy"],
  "arbitration": ["CODE_BUG"],
  "tests": [
    "phase4-coordinator/dist/test/check_deploy_static_feed_access.test.sh",
    "phase4-coordinator/dist/test/check_deploy_config_test.sh",
    "phase4-coordinator/dist/test/c2c_runtime_proof_test.py",
    "ops/pearl-updater/test_pearl_updater.py"
  ],
  "journeys": ["not-required"],
  "issue": "https://github.com/Augustas11/macprovider/issues/785"
}
SPEC-GOVERNANCE-DECLARATION-END