### PR TITLE
Preserve Pearl live coordinator config by default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -89,6 +89,7 @@ test-dist:
 	bash phase4-coordinator/dist/test/check_nginx_stats_test.sh
 	bash phase4-coordinator/dist/test/check_stats_inventory_deploy_test.sh
 	bash phase4-coordinator/dist/test/check_stats_billing_mirror_deploy_test.sh
+	bash phase4-coordinator/dist/test/coord_deploy_config_mode_test.sh
 	bash phase4-coordinator/dist/test/check_deploy_static_feed_access.test.sh
 	bash phase4-coordinator/dist/test/coordinator_deploy_recovery.test.sh
 	bash phase4-coordinator/dist/test/coord_deploy_smoke_probe.test.sh

--- a/phase4-coordinator/dist/deploy-pearl-vps.sh
+++ b/phase4-coordinator/dist/deploy-pearl-vps.sh
@@ -52,7 +52,15 @@
 #                    raw credential values. Production computes these proofs
 #                    on Pearl and returns only the digests.
 #   SKIP_C2_CHECK    default: 0   skip C2 timer/header assertions only (development only)
-#   ALLOW_CONFIG_DRIFT default: 0 push local coordinator.yaml over live one
+#   CONFIG_MODE      default: preserve-live
+#                    preserve-live: validate and keep Pearl's live
+#                    /opt/macprovider/coordinator.yaml; tracked dist/
+#                    coordinator.yaml is not uploaded or installed.
+#                    apply-tracked: install tracked dist/coordinator.yaml only
+#                    when it already matches live. Broad ALLOW_CONFIG_DRIFT=1
+#                    is rejected; use a reviewed config migration instead.
+#   ALLOW_CONFIG_DRIFT deprecated: broad local-over-live config replacement is
+#                    refused by this script.
 #   SKIP_TCP_TUNING default: 0    skip Pearl TCP sysctl install/apply step
 #   MODEL_HASH_LEGACY_UNTIL is read from /etc/macprovider/coordinator.env
 #                    when the production config declares the bounded
@@ -122,6 +130,20 @@ CATALOG_CANARY_AUTH_TOKEN="${CATALOG_CANARY_AUTH_TOKEN:-}"
 CATALOG_CANARY_SSH_TARGET="${CATALOG_CANARY_SSH_TARGET:-}"
 CATALOG_CANARY_SSH_KEY="${CATALOG_CANARY_SSH_KEY:-$HOME/.ssh/macprovider_canary_ed25519}"
 CATALOG_CANARY_INSTALL_DIR="${CATALOG_CANARY_INSTALL_DIR:-macprovider/catalog-release}"
+CONFIG_MODE="${CONFIG_MODE:-preserve-live}"
+case "$CONFIG_MODE" in
+  preserve-live|apply-tracked) ;;
+  *)
+    echo "aborting deploy: CONFIG_MODE must be preserve-live or apply-tracked, got: $CONFIG_MODE" >&2
+    exit 2
+    ;;
+esac
+if [ "${ALLOW_CONFIG_DRIFT:-0}" = "1" ]; then
+  echo "aborting deploy: ALLOW_CONFIG_DRIFT=1 is no longer a safe deploy bypass." >&2
+  echo "  Use CONFIG_MODE=preserve-live for code/catalog deploys that keep Pearl's live config." >&2
+  echo "  Use a reviewed field-scoped config migration for production config changes." >&2
+  exit 2
+fi
 
 # Issue #244 R1 SEC HIGH-1 / CODE MED-2 / ARCH HIGH-2 — validate operator-
 # overridable values up front so they cannot inject shell metacharacters
@@ -401,6 +423,7 @@ STATS_INVENTORY_BINARY="$DIST_DIR/stats-inventory-sync-linux-amd64"
 STATS_BILLING_MIRROR_BINARY="$DIST_DIR/stats-billing-mirror-linux-amd64"
 STATS_HARDWARE_VERIFIER_BINARY="$DIST_DIR/stats-hardware-verifier-linux-amd64"
 CONFIG="$DIST_DIR/coordinator.yaml"
+DEPLOY_CONFIG="$CONFIG"
 SERVICE="$DIST_DIR/macprovider-coordinator.service"
 DEPLOY_RECOVER="$DIST_DIR/coordinator-deploy-recover.sh"
 DEPLOY_GUARD="$DIST_DIR/systemd/macprovider-coordinator-deploy-guard.conf"
@@ -560,7 +583,7 @@ yaml_tier2_value() {
 # query e.g. `stats.enabled` in addition to `tier2.catalog_path`. Same
 # scoping rule: read keys until the next top-level block.
 yaml_block_value() {
-  yaml_file_block_value "$CONFIG" "$1" "$2"
+  yaml_file_block_value "$DEPLOY_CONFIG" "$1" "$2"
 }
 
 yaml_file_block_value() {
@@ -586,18 +609,109 @@ yaml_file_block_value() {
   ' "$file"
 }
 
+# Local validation may need to read Pearl's live coordinator.yaml in
+# CONFIG_MODE=preserve-live. Preserve env:NAME references because later gates
+# prove those runtime variables on Pearl; mask inline secret material before it
+# can land in a local temp file or logs.
+redact_dsn() {
+  sed -E 's#(postgres(ql)?://[^:/@[:space:]]+:)[^@[:space:]]+@#\1***@#g'
+}
+sanitize_live_config_for_local_validation() {
+  awk '
+    function indent_of(s) {
+      match(s, /^[[:space:]]*/)
+      return RLENGTH
+    }
+    function mask_scalar(s) {
+      sub(/:.*/, ": <MASKED>", s)
+      return s
+    }
+    function suppress_secret_continuation(s) {
+      skip_secret_block = 1
+      secret_block_indent = indent_of(s)
+    }
+    function mask_secret_scalar(s) {
+      suppress_secret_continuation(s)
+      return mask_scalar(s)
+    }
+    skip_secret_block && $0 ~ /^[[:space:]]*(#|$)/ { next }
+    skip_secret_block {
+      if (indent_of($0) > secret_block_indent) {
+        next
+      }
+      skip_secret_block = 0
+    }
+    /^[^[:space:]#][^:]*:[[:space:]]*/ {
+      in_auth = ($0 ~ /^auth:[[:space:]]*(#.*)?$/)
+      in_referrals = ($0 ~ /^referrals:[[:space:]]*(#.*)?$/)
+      in_secret_map = 0
+    }
+    in_auth && /^[[:space:]]*operator_keys:[[:space:]]*(#.*)?$/ {
+      in_secret_map = 1
+      secret_map_indent = indent_of($0)
+      print
+      next
+    }
+    in_referrals && /^[[:space:]]*hmac_keys:[[:space:]]*(#.*)?$/ {
+      in_secret_map = 1
+      secret_map_indent = indent_of($0)
+      print
+      next
+    }
+    in_secret_map && $0 !~ /^[[:space:]]*(#|$)/ {
+      current_indent = indent_of($0)
+      if (current_indent <= secret_map_indent) {
+        in_secret_map = 0
+      }
+    }
+    in_secret_map && /^[[:space:]]*[A-Za-z0-9_.-]+:[[:space:]]*/ {
+      if ($0 ~ /^[[:space:]]*[A-Za-z0-9_.-]+:[[:space:]]*env:[A-Za-z_][A-Za-z0-9_]*([[:space:]]*(#.*)?)?$/) {
+        suppress_secret_continuation($0)
+        print
+      } else {
+        print mask_secret_scalar($0)
+      }
+      next
+    }
+    /^[[:space:]]*catalog_public_key:[[:space:]]*/ { print; next }
+    /^[[:space:]]*[a-zA-Z0-9_]*(_key|_secret|_token|_dsn|dsn):[[:space:]]*/ {
+      if ($0 ~ /^[[:space:]]*[a-zA-Z0-9_]*(_key|_secret|_token|_dsn|dsn):[[:space:]]*env:[A-Za-z_][A-Za-z0-9_]*([[:space:]]*(#.*)?)?$/) {
+        suppress_secret_continuation($0)
+        print
+      } else {
+        print mask_secret_scalar($0)
+      }
+      next
+    }
+    { print }
+  ' | redact_dsn
+}
+normalize_yaml() {
+  # Mask any field whose name ends in _key / _secret / _token, then strip
+  # pure-comment lines and blanks so the drift check focuses on semantic
+  # differences (values + structure) rather than comment-placement noise.
+  sanitize_live_config_for_local_validation \
+    | sed -E 's/^([[:space:]]*[a-zA-Z0-9_]*(_key|_secret|_token)):[[:space:]]*.*$/\1: <MASKED>/' \
+    | sed -E 's/[[:space:]]+#.*$//' \
+    | grep -vE '^[[:space:]]*(#|$)'
+}
+print_config_drift_diff() {
+  redact_dsn | sed 's/^/    /' >&2
+}
+
 # R5 ARCH M1 — early coherence check: if the operator set
 # STATS_REQUIRED=1 but coordinator.yaml has stats.enabled=false (or
 # unset), the deploy would restart the binary then exit 9 in step 8.
 # Catch it BEFORE any SSH mutation.
-if [ "${STATS_REQUIRED:-0}" = "1" ]; then
+assert_stats_required_matches_effective_config() {
+  [ "${STATS_REQUIRED:-0}" = "1" ] || return 0
   _stats_enabled_pre="$(yaml_block_value stats enabled)"
   if [ "$_stats_enabled_pre" != "true" ]; then
-    echo "aborting deploy: STATS_REQUIRED=1 but stats.enabled is not true in $CONFIG ('$_stats_enabled_pre')." >&2
+    echo "aborting deploy: STATS_REQUIRED=1 but stats.enabled is not true in $DEPLOY_CONFIG ('$_stats_enabled_pre')." >&2
     echo "  Either set stats.enabled: true in coordinator.yaml, or drop STATS_REQUIRED=1." >&2
     exit 5
   fi
-fi
+}
 
 # Issue #582 (MEDIUM #6) — stats-inventory-sync restore-on-failure state.
 # The old 2-column sidecar is quiesced (stop+disable) BEFORE migration 019
@@ -679,6 +793,7 @@ trap '
   rm -f "${TMP_CATALOG_PUBKEY:-}"
   rm -f "${TMP_CATALOG_PINNED:-}"
   rm -f "${CATALOG_SMOKE_TMP:-}"
+  rm -f "${LIVE_COORDINATOR_CONFIG_TMP:-}"
   rm -f "${GATEWAY_REMOTE_CONFIG_TMP:-}"
   rm -rf "${STATIC_SMOKE_DIR:-}"
   if [ -n "${DEPLOY_TMP:-}" ]; then
@@ -892,6 +1007,29 @@ if [ "$DRY_RUN_LOCAL" = "1" ]; then
   echo "  local dry-run C2 check passed"
   exit 0
 else
+  if [ "$CONFIG_MODE" = "preserve-live" ]; then
+    LIVE_COORDINATOR_CONFIG_TMP="$(umask 077 && mktemp -t macprovider-coordinator-live-config.XXXXXXXX)" || {
+      echo "aborting deploy: mktemp failed for installed coordinator config copy" >&2; exit 5;
+    }
+    LIVE_COORDINATOR_CONFIG_REMOTE_SHA="$($SSH "sha256sum /opt/macprovider/coordinator.yaml | awk '{print \$1}'")" || {
+      echo "aborting deploy: could not hash installed coordinator config on Pearl" >&2
+      exit 5
+    }
+    $SSH 'test -f /opt/macprovider/coordinator.yaml || { echo "missing installed coordinator config: /opt/macprovider/coordinator.yaml" >&2; exit 1; }; cat /opt/macprovider/coordinator.yaml' \
+      | sanitize_live_config_for_local_validation > "$LIVE_COORDINATOR_CONFIG_TMP" || {
+      echo "aborting deploy: could not read installed coordinator config from Pearl" >&2
+      exit 5
+    }
+    LIVE_COORDINATOR_CONFIG_SHA=$(shasum -a 256 "$LIVE_COORDINATOR_CONFIG_TMP" | awk '{print $1}')
+    DEPLOY_CONFIG="$LIVE_COORDINATOR_CONFIG_TMP"
+    echo "  CONFIG_MODE=preserve-live — validating Pearl live coordinator config"
+    echo "    remote sha256=$LIVE_COORDINATOR_CONFIG_REMOTE_SHA"
+    echo "    sanitized validation copy sha256=$LIVE_COORDINATOR_CONFIG_SHA"
+  else
+    DEPLOY_CONFIG="$CONFIG"
+    echo "  CONFIG_MODE=apply-tracked — validating tracked coordinator config: $CONFIG"
+  fi
+  assert_stats_required_matches_effective_config
   if [ "${SKIP_C2_CHECK:-0}" = "1" ]; then
     echo "  SKIP_C2_CHECK=1 set — skipping timer/header assertions only; credential proof remains mandatory" >&2
   fi
@@ -939,8 +1077,8 @@ else
       *) printf '%s' - ;;
     esac
   }
-  _coord_op_name="$(_c2c_env_name "$(yaml_file_block_value "$CONFIG" auth operator_key)")" || exit 5
-  _coord_svc_name="$(_c2c_env_name "$(yaml_file_block_value "$CONFIG" auth gateway_service_token)")" || exit 5
+  _coord_op_name="$(_c2c_env_name "$(yaml_file_block_value "$DEPLOY_CONFIG" auth operator_key)")" || exit 5
+  _coord_svc_name="$(_c2c_env_name "$(yaml_file_block_value "$DEPLOY_CONFIG" auth gateway_service_token)")" || exit 5
   _gateway_svc_name="$(_c2c_env_name "$(yaml_file_block_value "$GATEWAY_REMOTE_CONFIG_TMP" coordinator service_token)")" || exit 5
   _gateway_op_name="$(_c2c_env_name "$(yaml_file_block_value "$GATEWAY_REMOTE_CONFIG_TMP" coordinator operator_key)")" || exit 5
   _c2c_proofs="$($SSH python3 - coordinator-deploy "$_coord_op_name" "$_coord_svc_name" "$_gateway_svc_name" "$_gateway_op_name" < "$C2C_PROOF_SCRIPT")" || {
@@ -962,7 +1100,7 @@ EOF
   C2C_GATEWAY_OPERATOR_KEY_SHA256="$C2C_GATEWAY_OPERATOR_KEY_SHA256" \
   MODEL_HASH_LEGACY_UNTIL="$MODEL_HASH_LEGACY_UNTIL_FOR_GATE" \
   SKIP_C2_CHECK="${SKIP_C2_CHECK:-0}" \
-    bash "$CHECK_SCRIPT" "$CONFIG" "$GATEWAY_REMOTE_CONFIG_TMP" || {
+    bash "$CHECK_SCRIPT" "$DEPLOY_CONFIG" "$GATEWAY_REMOTE_CONFIG_TMP" || {
     echo "aborting deploy: config-drift check failed" >&2; exit 5;
   }
 fi
@@ -1115,22 +1253,8 @@ log "step 1b/9: drift check vs live /opt/macprovider/coordinator.yaml"
 # that would have surfaced that drift before the restart.
 #
 # Secrets are masked in the SSH pipe so unmasked Pearl content never lands
-# on local disk. Operator opts into pushing local-over-live with
-# ALLOW_CONFIG_DRIFT=1.
-normalize_yaml() {
-  # Mask any field whose name ends in _key / _secret / _token, then strip
-  # pure-comment lines and blanks so the drift check focuses on semantic
-  # differences (values + structure) rather than comment-placement noise.
-  sed -E 's/^([[:space:]]*[a-zA-Z0-9_]*(_key|_secret|_token)):[[:space:]]*.*$/\1: <MASKED>/' \
-    | sed -E 's/[[:space:]]+#.*$//' \
-    | grep -vE '^[[:space:]]*(#|$)'
-}
-redact_dsn() {
-  sed -E 's#(postgres(ql)?://[^:/@[:space:]]+:)[^@[:space:]]+@#\1***@#g'
-}
-print_config_drift_diff() {
-  redact_dsn | sed 's/^/    /' >&2
-}
+# on local disk. CONFIG_MODE=preserve-live keeps the live config in place; a
+# tracked-config replacement is allowed only when tracked already matches live.
 tier2_require_hash_verified() {
   awk '
     /^tier2:[[:space:]]*$/ {
@@ -1182,32 +1306,46 @@ LIVE_NORM=$($SSH 'cat /opt/macprovider/coordinator.yaml' 2>/dev/null | normalize
   echo "could not pull live coordinator.yaml from Pearl for drift check" >&2; exit 6;
 }
 LOCAL_NORM=$(normalize_yaml < "$CONFIG")
-LIVE_TIER2_HASH_REQUIRED="$(printf '%s\n' "$LIVE_NORM" | tier2_require_hash_verified || true)"
-LOCAL_TIER2_HASH_REQUIRED="$(printf '%s\n' "$LOCAL_NORM" | tier2_require_hash_verified || true)"
-if [ -z "$LIVE_TIER2_HASH_REQUIRED" ] || [ -z "$LOCAL_TIER2_HASH_REQUIRED" ]; then
-  echo "" >&2
-  echo "  Aborting: direct deploy requires one unambiguous tier2.require_hash_verified boolean in both configs." >&2
-  exit 9
-fi
-if [ "$LOCAL_TIER2_HASH_REQUIRED" != "$LIVE_TIER2_HASH_REQUIRED" ]; then
-  echo "" >&2
-  echo "  Aborting: direct deploy cannot change tier2.require_hash_verified." >&2
-  echo "  Use the reviewed enforcement or rollback transaction for that state transition." >&2
-  echo "  ALLOW_CONFIG_DRIFT does not bypass this enforcement state-transition guard." >&2
-  exit 9
+if [ "$CONFIG_MODE" = "apply-tracked" ]; then
+  LIVE_CONFIG_SHA="$($SSH "sha256sum /opt/macprovider/coordinator.yaml | awk '{print \$1}'")" || {
+    echo "could not hash live coordinator.yaml on Pearl for tracked-config deploy" >&2; exit 6;
+  }
+  LOCAL_CONFIG_SHA="$(shasum -a 256 "$CONFIG" | awk '{print $1}')"
+  if [ "$LOCAL_CONFIG_SHA" != "$LIVE_CONFIG_SHA" ]; then
+    echo "" >&2
+    echo "  Aborting: CONFIG_MODE=apply-tracked requires exact live/tracked coordinator.yaml byte equality." >&2
+    echo "  local sha256=$LOCAL_CONFIG_SHA" >&2
+    echo "  live  sha256=$LIVE_CONFIG_SHA" >&2
+    echo "  Use CONFIG_MODE=preserve-live for code/catalog deploys, or a reviewed field-scoped config migration for config changes." >&2
+    exit 8
+  fi
+  LIVE_TIER2_HASH_REQUIRED="$(printf '%s\n' "$LIVE_NORM" | tier2_require_hash_verified || true)"
+  LOCAL_TIER2_HASH_REQUIRED="$(printf '%s\n' "$LOCAL_NORM" | tier2_require_hash_verified || true)"
+  if [ -z "$LIVE_TIER2_HASH_REQUIRED" ] || [ -z "$LOCAL_TIER2_HASH_REQUIRED" ]; then
+    echo "" >&2
+    echo "  Aborting: tracked-config deploy requires one unambiguous tier2.require_hash_verified boolean in both configs." >&2
+    exit 9
+  fi
+  if [ "$LOCAL_TIER2_HASH_REQUIRED" != "$LIVE_TIER2_HASH_REQUIRED" ]; then
+    echo "" >&2
+    echo "  Aborting: tracked-config deploy cannot change tier2.require_hash_verified." >&2
+    echo "  Use the reviewed enforcement or rollback transaction for that state transition." >&2
+    exit 9
+  fi
 fi
 if ! DRIFT_DIFF=$(diff <(printf '%s\n' "$LOCAL_NORM") <(printf '%s\n' "$LIVE_NORM")); then
   echo "" >&2
   echo "  CONFIG DRIFT detected (secrets masked; '<' = local, '>' = live):" >&2
   printf '%s\n' "$DRIFT_DIFF" | print_config_drift_diff
   echo "" >&2
-  if [ "${ALLOW_CONFIG_DRIFT:-0}" != "1" ]; then
-    echo "  Aborting. The local config will overwrite the live one on deploy." >&2
-    echo "  Review the diff above. To proceed (pushing local over live):" >&2
-    echo "    ALLOW_CONFIG_DRIFT=1 $0" >&2
+  if [ "$CONFIG_MODE" = "preserve-live" ]; then
+    echo "  CONFIG_MODE=preserve-live set — live coordinator.yaml will be preserved." >&2
+    echo "  Tracked coordinator.yaml is not uploaded or installed in this mode." >&2
+  else
+    echo "  Aborting. CONFIG_MODE=apply-tracked may install tracked coordinator.yaml only when it already matches live." >&2
+    echo "  Broad ALLOW_CONFIG_DRIFT=1 is disabled; use a reviewed field-scoped config migration." >&2
     exit 8
   fi
-  echo "  ALLOW_CONFIG_DRIFT=1 set — proceeding despite drift." >&2
 else
   echo "  ok: local config matches live (modulo secrets)"
 fi
@@ -1375,7 +1513,7 @@ if [ "$STATS_ENABLED_LOCAL" = "true" ]; then
     echo "  ok: required stats DSN env vars are present in coordinator.env"
   '
 else
-  echo "  stats.enabled is not true in $CONFIG — skipping stats env preflight"
+  echo "  stats.enabled is not true in $DEPLOY_CONFIG — skipping stats env preflight"
 fi
 
 # Issue #582 MIGRATION-019 ORDERING — quiesce the OLD stats-inventory-sync
@@ -2536,7 +2674,11 @@ $SCP "$CLI_BINARY"  "$VPS_USER@$VPS_HOST:$DEPLOY_TMP/coordinator-cli-linux-amd64
 $SCP "$STATS_INVENTORY_BINARY"  "$VPS_USER@$VPS_HOST:$DEPLOY_TMP/stats-inventory-sync-linux-amd64"
 $SCP "$STATS_BILLING_MIRROR_BINARY" "$VPS_USER@$VPS_HOST:$DEPLOY_TMP/stats-billing-mirror-linux-amd64"
 $SCP "$STATS_HARDWARE_VERIFIER_BINARY" "$VPS_USER@$VPS_HOST:$DEPLOY_TMP/stats-hardware-verifier-linux-amd64"
-$SCP "$CONFIG"      "$VPS_USER@$VPS_HOST:$DEPLOY_TMP/coordinator.yaml"
+if [ "$CONFIG_MODE" = "apply-tracked" ]; then
+  $SCP "$CONFIG" "$VPS_USER@$VPS_HOST:$DEPLOY_TMP/coordinator.yaml"
+else
+  log "  CONFIG_MODE=preserve-live — not uploading tracked coordinator.yaml"
+fi
 $SCP "$SERVICE"     "$VPS_USER@$VPS_HOST:$DEPLOY_TMP/macprovider-coordinator.service"
 $SCP "$STATS_INVENTORY_SERVICE" "$VPS_USER@$VPS_HOST:$DEPLOY_TMP/stats-inventory-sync.service"
 $SCP "$STATS_INVENTORY_TIMER"   "$VPS_USER@$VPS_HOST:$DEPLOY_TMP/stats-inventory-sync.timer"
@@ -2581,21 +2723,24 @@ if [ -n "$CATALOG_REMOTE_PATH" ]; then
   $SCP "$TMP_CATALOG_PUBKEY" "$VPS_USER@$VPS_HOST:$DEPLOY_TMP/tier2-catalog.pub"
 fi
 
-# M1-6 / DEVE-5 Part D: dated backup of the remote coordinator.yaml on Pearl
-# BEFORE we overwrite it. Step 1b already aborted on drift unless the
-# operator opted in, but the audit also calls for a persistent
-# remote-side backup so a bad deploy can be inspected/reverted without
-# trusting the operator's local copy. Backups live next to the live config
-# at /opt/macprovider/coordinator.yaml.bak-<UTC>.
-$SSH "exec 8>/opt/macprovider/.coordinator-deploy-operation.lock
-      flock -s 8
-      if [ -f /opt/macprovider/coordinator.yaml ]; then
-        install -o root -g macprovider -m 0640 /opt/macprovider/coordinator.yaml /opt/macprovider/coordinator.yaml.prev
-        install -o root -g macprovider -m 0640 /opt/macprovider/coordinator.yaml /opt/macprovider/coordinator.yaml.bak-$BACKUP_TS
-        echo '  remote-config backup saved at /opt/macprovider/coordinator.yaml.bak-$BACKUP_TS'
-      else
-        echo '  no live coordinator.yaml — first deploy, skipping backup'
-      fi"
+if [ "$CONFIG_MODE" = "apply-tracked" ]; then
+  # M1-6 / DEVE-5 Part D: dated backup of the remote coordinator.yaml on Pearl
+  # BEFORE we overwrite it. Step 1b already aborted on drift, but the audit
+  # also calls for a persistent remote-side backup so a bad deploy can be
+  # inspected/reverted without trusting the operator's local copy. Backups live
+  # next to the live config at /opt/macprovider/coordinator.yaml.bak-<UTC>.
+  $SSH "exec 8>/opt/macprovider/.coordinator-deploy-operation.lock
+        flock -s 8
+        if [ -f /opt/macprovider/coordinator.yaml ]; then
+          install -o root -g macprovider -m 0640 /opt/macprovider/coordinator.yaml /opt/macprovider/coordinator.yaml.prev
+          install -o root -g macprovider -m 0640 /opt/macprovider/coordinator.yaml /opt/macprovider/coordinator.yaml.bak-$BACKUP_TS
+          echo '  remote-config backup saved at /opt/macprovider/coordinator.yaml.bak-$BACKUP_TS'
+        else
+          echo '  no live coordinator.yaml — first deploy, skipping backup'
+        fi"
+else
+  log "  CONFIG_MODE=preserve-live — skipping coordinator.yaml backup because no config overwrite will occur"
+fi
 
 $SSH "set -e
   exec 8>/opt/macprovider/.coordinator-deploy-operation.lock
@@ -2644,7 +2789,11 @@ $SSH "set -e
   # stats-hardware-verifier is an out-of-band stats sidecar. It promotes
   # queued autotune evidence after conservative verification.
   install -o root -g macprovider-stats -m 0750 $DEPLOY_TMP/stats-hardware-verifier-linux-amd64 /opt/macprovider-stats/stats-hardware-verifier
-  install -o root -g macprovider -m 0640 $DEPLOY_TMP/coordinator.yaml /opt/macprovider/coordinator.yaml
+  if [ '$CONFIG_MODE' = 'apply-tracked' ]; then
+    install -o root -g macprovider -m 0640 $DEPLOY_TMP/coordinator.yaml /opt/macprovider/coordinator.yaml
+  else
+    echo '  preserving live /opt/macprovider/coordinator.yaml'
+  fi
   install -o root -g root       -m 0644 $DEPLOY_TMP/macprovider-coordinator.service /etc/systemd/system/macprovider-coordinator.service
   install -o root -g root       -m 0644 $DEPLOY_TMP/stats-inventory-sync.service /etc/systemd/system/stats-inventory-sync.service
   install -o root -g root       -m 0644 $DEPLOY_TMP/stats-inventory-sync.timer /etc/systemd/system/stats-inventory-sync.timer
@@ -3624,8 +3773,8 @@ echo "  SPEC-023 exact-byte canary OK: selected provider's live process uses the
 # R5 ARCH MED-1: coordinator's `stats.enabled` defaults FALSE — when
 # it's not set or set to false, /v1/stats/* routes don't exist. Hitting
 # them blind would flag a perfectly valid stats-disabled deploy as
-# degraded. Parse `stats.enabled` from the SAME coordinator.yaml we
-# just deployed; gate the smoke check on it.
+# degraded. Parse `stats.enabled` from the same effective coordinator.yaml
+# the restarted service uses; gate the smoke check on it.
 STATS_ENABLED_LOCAL="$(yaml_block_value stats enabled)"
 if [ "$STATS_ENABLED_LOCAL" = "true" ]; then
   STATS_SMOKE_NONCE="${BACKUP_TS:-$(date -u +%Y%m%dT%H%M%SZ)}-$$"
@@ -3643,7 +3792,7 @@ if [ "$STATS_ENABLED_LOCAL" = "true" ]; then
     else
       echo "  ABORT: $STATS_DOMAIN /v1/stats/health returned status=$STATS_STATUS (expected 200)" >&2
     fi
-    echo "  stats.enabled=true in $CONFIG — public stats smoke is mandatory." >&2
+    echo "  stats.enabled=true in $DEPLOY_CONFIG — public stats smoke is mandatory." >&2
     exit 9
   fi
   echo "  ok: $STATS_DOMAIN /v1/stats/health responded 200"
@@ -3673,7 +3822,7 @@ if [ "$STATS_ENABLED_LOCAL" = "true" ]; then
   fi
   if [ "$STATS_LEADERBOARD_STATUS" != "200" ]; then
     echo "  ABORT: $STATS_DOMAIN /v1/stats/leaderboard returned status=$STATS_LEADERBOARD_STATUS (expected 200)" >&2
-    echo "  stats.enabled=true in $CONFIG — Malibu stats population smoke is mandatory." >&2
+    echo "  stats.enabled=true in $DEPLOY_CONFIG — Malibu stats population smoke is mandatory." >&2
     exit 9
   else
     echo "  ok: $STATS_DOMAIN /v1/stats/leaderboard responded 200"
@@ -3683,11 +3832,11 @@ else
   # explicitly asked for strict mode but disabled stats — that's
   # incoherent; refuse. Otherwise just log and skip.
   if [ "${STATS_REQUIRED:-0}" = "1" ]; then
-    echo "  ABORT: STATS_REQUIRED=1 but stats.enabled is not true in $CONFIG." >&2
+    echo "  ABORT: STATS_REQUIRED=1 but stats.enabled is not true in $DEPLOY_CONFIG." >&2
     echo "         Enable stats in coordinator.yaml or drop STATS_REQUIRED=1." >&2
     exit 9
   fi
-  echo "  stats.enabled is not true in $CONFIG — skipping $STATS_DOMAIN smoke check"
+  echo "  stats.enabled is not true in $DEPLOY_CONFIG — skipping $STATS_DOMAIN smoke check"
 fi
 
 log "step 9/9: tail the coordinator journal for sanity"

--- a/phase4-coordinator/dist/test/check_deploy_static_feed_access.test.sh
+++ b/phase4-coordinator/dist/test/check_deploy_static_feed_access.test.sh
@@ -151,14 +151,16 @@ grep -q 'cmp -s \$DEPLOY_TMP/coordinator-linux-amd64 /opt/macprovider/coordinato
   fail "direct catalog deploy must not replace one half of the signed coordinator/gateway pair"
 
 grep -qF 'tier2_require_hash_verified()' "$DEPLOY_SH" &&
-  grep -qF 'direct deploy cannot change tier2.require_hash_verified' "$DEPLOY_SH" &&
-  grep -qF 'ALLOW_CONFIG_DRIFT does not bypass this enforcement state-transition guard' "$DEPLOY_SH" ||
-  fail "direct deploy must hard-block every Tier-2 enforcement state transition"
-enforcement_guard_line=$(grep -nF 'direct deploy cannot change tier2.require_hash_verified' "$DEPLOY_SH" | head -n1 | cut -d: -f1)
-config_drift_override_line=$(grep -nF 'if [ "${ALLOW_CONFIG_DRIFT:-0}" != "1" ]' "$DEPLOY_SH" | head -n1 | cut -d: -f1)
-[ -n "$enforcement_guard_line" ] && [ -n "$config_drift_override_line" ] &&
-  [ "$enforcement_guard_line" -lt "$config_drift_override_line" ] ||
-  fail "Tier-2 enforcement transition guard must run before the config-drift override"
+  grep -qF 'tracked-config deploy cannot change tier2.require_hash_verified' "$DEPLOY_SH" &&
+  grep -qF 'if [ "$CONFIG_MODE" = "apply-tracked" ]; then' "$DEPLOY_SH" ||
+  fail "tracked-config deploy must hard-block every Tier-2 enforcement state transition"
+enforcement_mode_line=$(grep -nF 'if [ "$CONFIG_MODE" = "apply-tracked" ]; then' "$DEPLOY_SH" | head -n1 | cut -d: -f1)
+enforcement_guard_line=$(grep -nF 'tracked-config deploy cannot change tier2.require_hash_verified' "$DEPLOY_SH" | head -n1 | cut -d: -f1)
+apply_tracked_drift_line=$(grep -nF 'CONFIG_MODE=apply-tracked may install tracked coordinator.yaml only when it already matches live' "$DEPLOY_SH" | head -n1 | cut -d: -f1)
+[ -n "$enforcement_mode_line" ] && [ -n "$enforcement_guard_line" ] && [ -n "$apply_tracked_drift_line" ] &&
+  [ "$enforcement_mode_line" -lt "$enforcement_guard_line" ] &&
+  [ "$enforcement_guard_line" -lt "$apply_tracked_drift_line" ] ||
+  fail "Tier-2 enforcement transition guard must run before tracked-config drift handling"
 tier2_parser_tmp="$(mktemp)"
 awk '/^tier2_require_hash_verified\(\) \{/{f=1} f{print} f&&/^\}$/{exit}' "$DEPLOY_SH" >"$tier2_parser_tmp"
 # shellcheck disable=SC1090

--- a/phase4-coordinator/dist/test/coord_deploy_c2_precheck.test.sh
+++ b/phase4-coordinator/dist/test/coord_deploy_c2_precheck.test.sh
@@ -25,8 +25,8 @@ if [ "$local_count" != "1" ]; then
   fail "local GATEWAY_CONFIG C2 path should appear exactly once inside --dry-run-local, got $local_count"
 fi
 
-grep -q 'bash "$CHECK_SCRIPT" "$CONFIG" "$GATEWAY_REMOTE_CONFIG_TMP"' "$DEPLOY_SH" ||
-  fail "production C2 path does not validate the installed Pearl gateway config copy"
+grep -q 'bash "$CHECK_SCRIPT" "$DEPLOY_CONFIG" "$GATEWAY_REMOTE_CONFIG_TMP"' "$DEPLOY_SH" ||
+  fail "production C2 path does not validate the effective coordinator config with the installed Pearl gateway config copy"
 
 for proof in C2C_COORD_OPERATOR_KEY_SHA256 C2C_COORD_SERVICE_TOKEN_SHA256 C2C_GATEWAY_SERVICE_TOKEN_SHA256 C2C_GATEWAY_OPERATOR_KEY_SHA256; do
   grep -q "$proof=\"\$$proof\"" "$DEPLOY_SH" ||

--- a/phase4-coordinator/dist/test/coord_deploy_config_mode_test.sh
+++ b/phase4-coordinator/dist/test/coord_deploy_config_mode_test.sh
@@ -1,0 +1,153 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+DEPLOY_SH="$SCRIPT_DIR/../deploy-pearl-vps.sh"
+
+fail() {
+  echo "FAIL: $*" >&2
+  exit 1
+}
+
+bash -n "$DEPLOY_SH"
+
+grep -q 'CONFIG_MODE="${CONFIG_MODE:-preserve-live}"' "$DEPLOY_SH" ||
+  fail "deploy script must default CONFIG_MODE to preserve-live"
+
+grep -q 'ALLOW_CONFIG_DRIFT=1 is no longer a safe deploy bypass' "$DEPLOY_SH" ||
+  fail "deploy script must reject broad ALLOW_CONFIG_DRIFT=1"
+
+grep -q 'LIVE_COORDINATOR_CONFIG_TMP=.*macprovider-coordinator-live-config' "$DEPLOY_SH" ||
+  fail "preserve-live mode must read Pearl live coordinator config into a temp validation copy"
+
+grep -q 'sanitize_live_config_for_local_validation > "$LIVE_COORDINATOR_CONFIG_TMP"' "$DEPLOY_SH" ||
+  fail "live coordinator config temp copy must be sanitized before local validation"
+
+sanitizer_tmp="$(mktemp)"
+trap 'rm -f "$sanitizer_tmp"' EXIT
+awk 'f && /^print_config_drift_diff\(\) \{/{exit} /^redact_dsn\(\) \{/{f=1} f{print}' "$DEPLOY_SH" > "$sanitizer_tmp"
+# shellcheck disable=SC1090
+. "$sanitizer_tmp"
+sanitized_sample="$(sanitize_live_config_for_local_validation <<'EOF'
+auth:
+  operator_key: |
+    block-top-level-secret
+  api_secret: plain-top-level-secret
+    plain-top-level-continuation
+  quoted_secret: "quoted-top-level-secret
+    quoted-top-level-continuation"
+  gateway_service_token: env:COORDINATOR_SERVICE_TOKEN
+    env-token-continuation
+  operator_keys:
+    alice: inline-named-operator-secret
+    bob: env:BOB_OPERATOR_KEY
+      env-operator-continuation
+    carol: >
+      block-named-operator-secret
+    charlie: plain-operator-secret
+      plain-operator-continuation
+    dave: "quoted-operator-secret
+      quoted-operator-continuation"
+    erin: 'single-quoted-operator-secret
+      single-quoted-operator-continuation'
+tier2:
+  catalog_public_key: public-ed25519-key
+referrals:
+  hmac_keys:
+    current: inline-referral-hmac-secret
+    next: env:REFERRAL_HMAC_KEY
+      env-referral-continuation
+    future: |
+      block-referral-hmac-secret
+    later: plain-referral-hmac-secret
+      plain-referral-hmac-continuation
+    after: "quoted-referral-hmac-secret
+      quoted-referral-hmac-continuation"
+stats:
+  onboarding_postgres_dsn: postgres://writer:plaintext@db.example/macprovider
+EOF
+)"
+case "$sanitized_sample" in
+  *'operator_key: <MASKED>'*) ;;
+  *) fail "sanitizer must mask inline secret-shaped keys" ;;
+esac
+case "$sanitized_sample" in
+  *'gateway_service_token: env:COORDINATOR_SERVICE_TOKEN'*) ;;
+  *) fail "sanitizer must preserve env:NAME references for runtime proof" ;;
+esac
+case "$sanitized_sample" in
+  *'alice: <MASKED>'*'bob: env:BOB_OPERATOR_KEY'*) ;;
+  *) fail "sanitizer must mask inline auth.operator_keys children and preserve env children" ;;
+esac
+case "$sanitized_sample" in
+  *'catalog_public_key: public-ed25519-key'*) ;;
+  *) fail "sanitizer must preserve public catalog key required for catalog verification" ;;
+esac
+case "$sanitized_sample" in
+  *'current: <MASKED>'*'next: env:REFERRAL_HMAC_KEY'*) ;;
+  *) fail "sanitizer must mask inline referrals.hmac_keys children and preserve env children" ;;
+esac
+case "$sanitized_sample" in
+  *'onboarding_postgres_dsn: <MASKED>'*) ;;
+  *) fail "sanitizer must mask inline DSN fields" ;;
+esac
+case "$sanitized_sample" in
+  *block-top-level-secret*|*plain-top-level-secret*|*plain-top-level-continuation*|*quoted-top-level-secret*|*quoted-top-level-continuation*|*env-token-continuation*|*inline-named-operator-secret*|*env-operator-continuation*|*block-named-operator-secret*|*plain-operator-secret*|*plain-operator-continuation*|*quoted-operator-secret*|*quoted-operator-continuation*|*single-quoted-operator-secret*|*single-quoted-operator-continuation*|*inline-referral-hmac-secret*|*env-referral-continuation*|*block-referral-hmac-secret*|*plain-referral-hmac-secret*|*plain-referral-hmac-continuation*|*quoted-referral-hmac-secret*|*quoted-referral-hmac-continuation*|*plaintext*) fail "sanitizer leaked inline secret material" ;;
+esac
+normalized_sample="$(printf '%s\n' "$sanitized_sample" | normalize_yaml)"
+case "$normalized_sample" in
+  *public-ed25519-key*|*inline-named-operator-secret*|*env-operator-continuation*|*block-named-operator-secret*|*plain-operator-secret*|*plain-operator-continuation*|*quoted-operator-secret*|*quoted-operator-continuation*|*single-quoted-operator-secret*|*single-quoted-operator-continuation*|*inline-referral-hmac-secret*|*env-referral-continuation*|*block-referral-hmac-secret*|*plain-referral-hmac-secret*|*plain-referral-hmac-continuation*|*quoted-referral-hmac-secret*|*quoted-referral-hmac-continuation*) fail "drift normalizer leaked key material" ;;
+esac
+case "$normalized_sample" in
+  *'catalog_public_key: <MASKED>'*) ;;
+  *) fail "drift normalizer must mask public-key-shaped values before diff output" ;;
+esac
+case "$normalized_sample" in
+  *'alice: <MASKED>'*) ;;
+  *) fail "drift normalizer must mask auth.operator_keys children before diff output" ;;
+esac
+case "$normalized_sample" in
+  *'current: <MASKED>'*) ;;
+  *) fail "drift normalizer must mask referrals.hmac_keys children before diff output" ;;
+esac
+
+grep -q 'DEPLOY_CONFIG="$LIVE_COORDINATOR_CONFIG_TMP"' "$DEPLOY_SH" ||
+  fail "preserve-live mode must validate against the live coordinator config copy"
+
+stats_guard_line=$(grep -nF 'assert_stats_required_matches_effective_config' "$DEPLOY_SH" | tail -n1 | cut -d: -f1)
+deploy_config_line=$(grep -nF 'DEPLOY_CONFIG="$LIVE_COORDINATOR_CONFIG_TMP"' "$DEPLOY_SH" | head -n1 | cut -d: -f1)
+upload_line=$(grep -nF '$SCP "$BINARY"' "$DEPLOY_SH" | head -n1 | cut -d: -f1)
+[ -n "$stats_guard_line" ] && [ -n "$deploy_config_line" ] && [ -n "$upload_line" ] &&
+  [ "$deploy_config_line" -lt "$stats_guard_line" ] &&
+  [ "$stats_guard_line" -lt "$upload_line" ] ||
+  fail "STATS_REQUIRED guard must run after effective config selection and before deploy uploads"
+
+grep -q 'rm -f "${LIVE_COORDINATOR_CONFIG_TMP:-}"' "$DEPLOY_SH" ||
+  fail "EXIT trap must clean the sanitized live coordinator config temp copy"
+
+grep -q 'CONFIG_MODE=preserve-live — not uploading tracked coordinator.yaml' "$DEPLOY_SH" ||
+  fail "preserve-live mode must not upload tracked coordinator.yaml"
+
+grep -q 'CONFIG_MODE=preserve-live — skipping coordinator.yaml backup because no config overwrite will occur' "$DEPLOY_SH" ||
+  fail "preserve-live mode must not create overwrite-oriented coordinator.yaml backups"
+
+grep -q "if \\[ '\\\$CONFIG_MODE' = 'apply-tracked' \\]; then" "$DEPLOY_SH" ||
+  fail "remote install must guard coordinator.yaml replacement on CONFIG_MODE=apply-tracked"
+
+grep -q 'install -o root -g macprovider -m 0640 $DEPLOY_TMP/coordinator.yaml /opt/macprovider/coordinator.yaml' "$DEPLOY_SH" ||
+  fail "apply-tracked mode must retain the explicit coordinator.yaml install path"
+
+install_line=$(grep -nF 'install -o root -g macprovider -m 0640 $DEPLOY_TMP/coordinator.yaml /opt/macprovider/coordinator.yaml' "$DEPLOY_SH" | tail -n1 | cut -d: -f1)
+guard_line=$(grep -nF "if [ '\$CONFIG_MODE' = 'apply-tracked' ]; then" "$DEPLOY_SH" | tail -n1 | cut -d: -f1)
+[ -n "$install_line" ] && [ -n "$guard_line" ] ||
+  fail "could not locate coordinator.yaml install guard or install line"
+[ "$guard_line" -lt "$install_line" ] && [ $((install_line - guard_line)) -le 2 ] ||
+  fail "coordinator.yaml install is not immediately guarded by CONFIG_MODE=apply-tracked"
+
+grep -q 'CONFIG_MODE=apply-tracked may install tracked coordinator.yaml only when it already matches live' "$DEPLOY_SH" ||
+  fail "apply-tracked drift path must fail closed instead of recommending ALLOW_CONFIG_DRIFT"
+
+grep -q 'CONFIG_MODE=apply-tracked requires exact live/tracked coordinator.yaml byte equality' "$DEPLOY_SH" ||
+  fail "apply-tracked mode must require exact live/tracked config hashes before install"
+
+echo "PASS: coordinator deploy preserves live config by default and refuses broad drift override"


### PR DESCRIPTION
## Summary

- Make Pearl coordinator deploys preserve `/opt/macprovider/coordinator.yaml` by default with `CONFIG_MODE=preserve-live`.
- Reject broad `ALLOW_CONFIG_DRIFT=1`; `CONFIG_MODE=apply-tracked` can install tracked config only when live/tracked bytes already match.
- Validate production deploy gates against the effective config and sanitize any live-config copy before it touches local disk or drift output.
- Add regression coverage for config-mode behavior and secret-safe drift redaction.

## Validation

- `make test-dist`
- `bash phase4-coordinator/dist/test/coord_deploy_config_mode_test.sh`
- `bash phase4-coordinator/dist/test/check_deploy_static_feed_access.test.sh`
- `bash phase4-coordinator/dist/test/coord_deploy_c2_precheck.test.sh`
- `bash phase4-coordinator/dist/test/check_deploy_config_test.sh`
- `git diff --check`
- Code/security/architecture audit loop: final code and security verdicts `0 critical/high/medium`; architecture issue resolved by wiring the new test into `make test-dist`.

Optional live nginx smokes remained skipped by their default optional gates during `make test-dist`. No Pearl production state was modified.

## Governance note

This is deploy-tooling mitigation for issue #785. The closest current structured authority is SPEC-020/provider-autoupdate because the guard prevents code deploys from clobbering Pearl live fleet/version-admission posture such as `coordinator_advertised_version`. It does not change `specs/AUTHORITY.json`, `specs/CONFORMANCE.json`, or a canonical spec.

SPEC-GOVERNANCE-DECLARATION-BEGIN
{
  "schema_version": "spec-pr-governance-v1",
  "behavior_change": "yes",
  "contract_change": "none",
  "specs": ["SPEC-020"],
  "requirements": ["SPEC-020-R004"],
  "authority_domains": ["provider-autoupdate"],
  "arbitration": ["CODE_BUG"],
  "tests": ["make test-dist", "phase4-coordinator/dist/test/coord_deploy_config_mode_test.sh"],
  "journeys": ["not-required"],
  "issue": "https://github.com/Augustas11/macprovider/issues/785"
}
SPEC-GOVERNANCE-DECLARATION-END
