### PR TITLE
Classify Pearl config drift before deploys

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -74,6 +74,7 @@ test-dist:
 	bash scripts/test-tier2-provider-release.sh
 	PYTHONDONTWRITEBYTECODE=1 python3 -m unittest -v ops/pearl-updater/test_pearl_updater.py
 	PYTHONDONTWRITEBYTECODE=1 python3 -m unittest -v ops/pearl-updater/test_tier2_enforcement_watchdog.py
+	PYTHONDONTWRITEBYTECODE=1 python3 -m unittest -v ops/pearl/config/test_pearl_config_reconcile.py
 	bash scripts/test-tier2-enforcement-safety.sh
 	bash ops/pearl-updater/test_transaction_gate_systemd.sh
 	bash phase3-binary/dist/test/check_baked_static_feed_sync.test.sh

--- a/ops/pearl/config/reconcile_pearl_config.py
+++ b/ops/pearl/config/reconcile_pearl_config.py
@@ -1,0 +1,796 @@
+#!/usr/bin/env python3
+"""Read-only Pearl coordinator config drift reconciliation.
+
+The tool compares the repo-owned tracked coordinator config with Pearl's live
+config files, classifies known differences through source-of-truth.yaml, masks
+secret-shaped values, and exits non-zero only for unknown drift.
+"""
+
+from __future__ import annotations
+
+import argparse
+import copy
+import hashlib
+import re
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+try:
+    import yaml
+except ImportError as exc:  # pragma: no cover - exercised only on deficient hosts.
+    raise SystemExit("PyYAML is required for Pearl config reconciliation") from exc
+
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+DEFAULT_MANIFEST = REPO_ROOT / "ops/pearl/config/source-of-truth.yaml"
+DEFAULT_TRACKED_CONFIG = REPO_ROOT / "phase4-coordinator/dist/coordinator.yaml"
+
+SECRET_FIELD_RE = re.compile(
+    r"(^|[._-])(secret|token|keys?|dsn|password|credentials?|hmac)([._-]|$)",
+    re.IGNORECASE,
+)
+ENV_ASSIGNMENT_RE = re.compile(r"^\s*(?:export\s+)?([A-Za-z_][A-Za-z0-9_]*)\s*=")
+ENV_REFERENCE_RE = re.compile(r"^env:[A-Za-z_][A-Za-z0-9_]*$")
+REMOTE_MALFORMED_ENV_RE = re.compile(r"^__MACPROVIDER_MALFORMED_ENV_LINE_([1-9][0-9]*)=<MASKED>$")
+SECRET_VALUE_RE = re.compile(
+    r"(?ix)"
+    r"("
+    r"(?:bearer|basic)\s+\S+"
+    r"|(?:sk|pk|rk|ghp|github_pat|xox[baprs]|AKIA)[A-Za-z0-9_=-]{8,}"
+    r"|[A-Fa-f0-9]{32,}"
+    r"|[A-Za-z0-9_./+=-]{48,}"
+    r"|://[^/\s:@]+:[^/\s@]+@"
+    r")"
+)
+SSH_TARGET_RE = re.compile(
+    r"^(?:[A-Za-z0-9_][A-Za-z0-9_.-]*@)?[A-Za-z0-9_][A-Za-z0-9_.-]*$"
+)
+
+
+@dataclass(frozen=True)
+class Drift:
+    path: str
+    kind: str
+    tracked: Any
+    live: Any
+
+
+@dataclass
+class Finding:
+    category: str
+    path: str
+    message: str
+    owner: str = ""
+
+
+@dataclass(frozen=True)
+class EnvLine:
+    key: str | None
+    line_no: int
+    malformed: bool = False
+
+
+@dataclass
+class ProviderIndex:
+    rows: dict[str, dict[str, Any]]
+    unknown: list[Finding]
+
+
+@dataclass
+class LiveEvidence:
+    config: Any
+    overlay: Any
+    overlay_present: bool
+    env_text: str
+
+
+def load_yaml_file(path: Path, *, required: bool = True) -> Any:
+    if not path.exists():
+        if required:
+            raise FileNotFoundError(path)
+        return {}
+    text = path.read_text(encoding="utf-8")
+    return load_yaml_text(text, str(path))
+
+
+def load_yaml_text(text: str, label: str) -> Any:
+    try:
+        return yaml.safe_load(text) or {}
+    except yaml.YAMLError as exc:
+        mark = getattr(exc, "problem_mark", None)
+        location = f" at line {mark.line + 1}, column {mark.column + 1}" if mark else ""
+        raise SystemExit(f"failed to parse {label}{location}") from exc
+
+
+def normalize_scalar(value: Any) -> Any:
+    if isinstance(value, (str, int, float, bool)) or value is None:
+        return value
+    return value
+
+
+def value_matches(expected: Any, actual: Any) -> bool:
+    return normalize_scalar(expected) == normalize_scalar(actual)
+
+
+def is_secret_path(path: str) -> bool:
+    if path.endswith("catalog_public_key") or path.endswith("public_key"):
+        return False
+    return bool(SECRET_FIELD_RE.search(path))
+
+
+def is_secret_shaped_value(value: Any) -> bool:
+    return isinstance(value, str) and bool(SECRET_VALUE_RE.search(value))
+
+
+def display_value(path: str, value: Any) -> str:
+    if value is _ABSENT:
+        return "<ABSENT>"
+    if is_secret_path(path):
+        if isinstance(value, str) and ENV_REFERENCE_RE.fullmatch(value):
+            return value
+        return "<MASKED>"
+    if is_secret_shaped_value(value):
+        return "<MASKED>"
+    return repr(value)
+
+
+def safe_path_segment(value: str) -> str:
+    if is_secret_shaped_value(value):
+        digest = hashlib.sha256(value.encode("utf-8")).hexdigest()[:12]
+        return f"<MASKED:{digest}>"
+    return value
+
+
+def render_safe_path(path: str) -> str:
+    parts = re.split(r"([.\[\]])", path)
+    return "".join(safe_path_segment(part) if part not in {".", "[", "]"} else part for part in parts)
+
+
+class _Absent:
+    pass
+
+
+_ABSENT = _Absent()
+
+
+def strip_providers(config: Any) -> Any:
+    if not isinstance(config, dict):
+        return config
+    clone = copy.deepcopy(config)
+    clone.pop("providers", None)
+    return clone
+
+
+def flatten(value: Any, prefix: str = "") -> dict[str, Any]:
+    if isinstance(value, dict):
+        if not value:
+            return {prefix: value}
+        out: dict[str, Any] = {}
+        for key in sorted(value):
+            child = f"{prefix}.{key}" if prefix else str(key)
+            out.update(flatten(value[key], child))
+        return out
+    if isinstance(value, list):
+        if not value:
+            return {prefix: value}
+        out = {}
+        for idx, item in enumerate(value):
+            child = f"{prefix}[{idx}]"
+            out.update(flatten(item, child))
+        return out
+    return {prefix: value}
+
+
+def provider_index(config: Any, *, side: str) -> ProviderIndex:
+    providers = config.get("providers", []) if isinstance(config, dict) else []
+    rows: dict[str, dict[str, Any]] = {}
+    unknown: list[Finding] = []
+    if not isinstance(providers, list):
+        unknown.append(
+            Finding(
+                category="Unknown",
+                path=f"providers.{side}",
+                owner="registered_static_providers",
+                message="providers section is not a list",
+            )
+        )
+        return ProviderIndex(rows=rows, unknown=unknown)
+    for index, row in enumerate(providers):
+        path = f"providers.{side}[{index}]"
+        if not isinstance(row, dict):
+            unknown.append(
+                Finding(
+                    category="Unknown",
+                    path=path,
+                    owner="registered_static_providers",
+                    message="provider row is not a mapping",
+                )
+            )
+            continue
+        provider_id = row.get("provider_id")
+        if not isinstance(provider_id, str) or not provider_id:
+            unknown.append(
+                Finding(
+                    category="Unknown",
+                    path=path,
+                    owner="registered_static_providers",
+                    message="provider row is missing a non-empty provider_id",
+                )
+            )
+            continue
+        if provider_id in rows:
+            unknown.append(
+                Finding(
+                    category="Unknown",
+                    path=f"{path}.provider_id",
+                    owner="registered_static_providers",
+                    message=f"duplicate provider_id {safe_path_segment(provider_id)!r}",
+                )
+            )
+            continue
+        rows[provider_id] = row
+    return ProviderIndex(rows=rows, unknown=unknown)
+
+
+def path_has_prefix(path: str, prefixes: list[str]) -> bool:
+    return any(path == prefix or path.startswith(prefix + ".") for prefix in prefixes)
+
+
+def owner_for_path(path: str, manifest: dict[str, Any]) -> str:
+    if is_secret_path(path):
+        return "pearl_operator_secrets"
+    if path_has_prefix(path, manifest.get("fleet_version_policy_owned_prefixes", [])):
+        return "fleet_version_admission_policy"
+    if path_has_prefix(path, manifest.get("pearl_overlay_owned_prefixes", [])):
+        return "pearl_production_overlay"
+    if path_has_prefix(path, manifest.get("tracked_base_owned_prefixes", [])):
+        if path == manifest.get("rate_card", {}).get("path") or path.startswith(
+            manifest.get("rate_card", {}).get("path", "") + "."
+        ):
+            return manifest.get("rate_card", {}).get("owner", "tracked_rate_card_source")
+        return "base_product_defaults"
+    return ""
+
+
+def compare_flattened(tracked: dict[str, Any], live: dict[str, Any]) -> list[Drift]:
+    drifts: list[Drift] = []
+    for path in sorted(set(tracked) | set(live)):
+        tracked_value = tracked.get(path, _ABSENT)
+        live_value = live.get(path, _ABSENT)
+        if tracked_value == live_value:
+            continue
+        if tracked_value is _ABSENT:
+            kind = "live_only"
+        elif live_value is _ABSENT:
+            kind = "tracked_only"
+        else:
+            kind = "value_mismatch"
+        drifts.append(Drift(path=path, kind=kind, tracked=tracked_value, live=live_value))
+    return drifts
+
+
+def known_drift_map(manifest: dict[str, Any]) -> dict[str, dict[str, Any]]:
+    return {item["path"]: item for item in manifest.get("known_config_drift", [])}
+
+
+def classify_config_drifts(
+    drifts: list[Drift], manifest: dict[str, Any]
+) -> tuple[list[Finding], list[Finding], list[Finding]]:
+    evidence: list[Finding] = []
+    inference: list[Finding] = []
+    unknown: list[Finding] = []
+    known = known_drift_map(manifest)
+
+    for drift in drifts:
+        rule = known.get(drift.path)
+        if rule and rule.get("drift_kind") == drift.kind:
+            tracked_ok = "tracked" not in rule or value_matches(rule["tracked"], drift.tracked)
+            live_ok = "live" not in rule or value_matches(rule["live"], drift.live)
+            if tracked_ok and live_ok:
+                finding = Finding(
+                    category=rule.get("category", "Evidence"),
+                    path=drift.path,
+                    owner=rule.get("owner", ""),
+                    message=(
+                        f"{drift.kind}: tracked={display_value(drift.path, drift.tracked)} "
+                        f"live={display_value(drift.path, drift.live)}"
+                    ),
+                )
+                if finding.category == "Inference":
+                    inference.append(finding)
+                else:
+                    evidence.append(finding)
+                continue
+        unknown.append(
+            Finding(
+                category="Unknown",
+                path=drift.path,
+                owner=owner_for_path(drift.path, manifest) or "unclassified",
+                message=(
+                    f"{drift.kind}: tracked={display_value(drift.path, drift.tracked)} "
+                    f"live={display_value(drift.path, drift.live)}"
+                ),
+            )
+        )
+    return evidence, inference, unknown
+
+
+def classify_provider_rows(
+    tracked: dict[str, dict[str, Any]], live: dict[str, dict[str, Any]], manifest: dict[str, Any]
+) -> tuple[list[Finding], list[Finding], list[Finding]]:
+    evidence: list[Finding] = []
+    inference: list[Finding] = []
+    unknown: list[Finding] = []
+
+    provider_rules = manifest.get("provider_rows", {})
+    tracked_static = set(provider_rules.get("tracked_static_provider_ids", []))
+    pearl_static = set(provider_rules.get("pearl_registered_static_provider_ids", []))
+    registered_field_types = provider_rules.get("registered_provider_field_types", {})
+    live_only_category = provider_rules.get("live_only_registered_provider_category", "Inference")
+    owner = provider_rules.get("owner", "registered_static_providers")
+
+    for provider_id in sorted(set(tracked) | set(live)):
+        path = f"providers.{safe_path_segment(provider_id)}"
+        if provider_id not in tracked:
+            if provider_id in pearl_static:
+                finding = Finding(
+                    category=live_only_category,
+                    path=path,
+                    owner=owner,
+                    message="live-only provider row is classified as Pearl registered/static provider posture",
+                )
+                if finding.category == "Evidence":
+                    evidence.append(finding)
+                else:
+                    inference.append(finding)
+                unknown.extend(
+                    classify_live_only_registered_provider_fields(
+                        path,
+                        live[provider_id],
+                        registered_field_types,
+                        owner,
+                    )
+                )
+            else:
+                unknown.append(
+                    Finding(
+                        category="Unknown",
+                        path=path,
+                        owner="unclassified",
+                        message="live-only provider row is not listed in source-of-truth manifest",
+                    )
+                )
+            continue
+        if provider_id not in live:
+            if provider_id in tracked_static:
+                unknown.append(
+                    Finding(
+                        category="Unknown",
+                        path=path,
+                        owner=owner,
+                        message="tracked static provider row is absent from live config",
+                    )
+                )
+            else:
+                unknown.append(
+                    Finding(
+                        category="Unknown",
+                        path=path,
+                        owner="unclassified",
+                        message="tracked-only provider row is not classified",
+                    )
+                )
+            continue
+        if tracked[provider_id] == live[provider_id]:
+            evidence.append(
+                Finding(
+                    category="Evidence",
+                    path=path,
+                    owner=owner,
+                    message="tracked provider row matches live",
+                )
+            )
+            continue
+        tracked_flat = flatten(tracked[provider_id])
+        live_flat = flatten(live[provider_id])
+        row_drifts = compare_flattened(tracked_flat, live_flat)
+        for drift in row_drifts:
+            drift_path = f"{path}.{drift.path}" if drift.path else path
+            unknown.append(
+                Finding(
+                    category="Unknown",
+                    path=drift_path,
+                    owner=owner,
+                    message=(
+                        f"{drift.kind}: tracked={display_provider_drift_value(drift.tracked)} "
+                        f"live={display_provider_drift_value(drift.live)}"
+                    ),
+                )
+            )
+    return evidence, inference, unknown
+
+
+def classify_live_only_registered_provider_fields(
+    provider_path: str,
+    row: dict[str, Any],
+    field_types: dict[str, str],
+    owner: str,
+) -> list[Finding]:
+    unknown: list[Finding] = []
+    for field, value in sorted(row.items()):
+        field_path = f"{provider_path}.{field}"
+        expected_type = field_types.get(field)
+        if expected_type is None:
+            unknown.append(
+                Finding(
+                    category="Unknown",
+                    path=field_path,
+                    owner=owner,
+                    message="live-only registered provider field is not listed in source-of-truth manifest; value=<MASKED>",
+                )
+            )
+            continue
+        if not provider_value_matches_type(value, expected_type):
+            unknown.append(
+                Finding(
+                    category="Unknown",
+                    path=field_path,
+                    owner=owner,
+                    message=(
+                        "live-only registered provider field does not match "
+                        f"manifest type {expected_type}; value=<MASKED>"
+                    ),
+                )
+            )
+    return unknown
+
+
+def display_provider_drift_value(value: Any) -> str:
+    if value is _ABSENT:
+        return "<ABSENT>"
+    return "<MASKED>"
+
+
+def provider_value_matches_type(value: Any, expected_type: str) -> bool:
+    if expected_type == "string":
+        return isinstance(value, str)
+    if expected_type == "integer":
+        return isinstance(value, int) and not isinstance(value, bool)
+    if expected_type == "number":
+        return isinstance(value, (int, float)) and not isinstance(value, bool)
+    if expected_type == "boolean":
+        return isinstance(value, bool)
+    if expected_type == "string_list":
+        return isinstance(value, list) and all(isinstance(item, str) for item in value)
+    return False
+
+
+def parse_env_lines(text: str) -> list[EnvLine]:
+    lines: list[EnvLine] = []
+    for line_no, line in enumerate(text.splitlines(), start=1):
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        remote_malformed = REMOTE_MALFORMED_ENV_RE.fullmatch(stripped)
+        if remote_malformed:
+            lines.append(EnvLine(key=None, line_no=int(remote_malformed.group(1)), malformed=True))
+            continue
+        match = ENV_ASSIGNMENT_RE.match(line)
+        if match:
+            lines.append(EnvLine(key=match.group(1), line_no=line_no))
+        else:
+            lines.append(EnvLine(key=None, line_no=line_no, malformed=True))
+    return lines
+
+
+def classify_env_lines(lines: list[EnvLine], manifest: dict[str, Any]) -> tuple[list[Finding], list[Finding]]:
+    env_rules = manifest.get("env_key_names", {})
+    allowed = set(env_rules.get("allowed", []))
+    evidence: list[Finding] = []
+    unknown: list[Finding] = []
+    seen: set[str] = set()
+    for line in lines:
+        if line.malformed:
+            unknown.append(
+                Finding(
+                    category="Unknown",
+                    path=f"coordinator.env.line_{line.line_no}",
+                    owner="unclassified",
+                    message="malformed env line is not a KEY=VALUE assignment; value=<MASKED>",
+                )
+            )
+            continue
+        key = line.key or ""
+        if key in seen:
+            unknown.append(
+                Finding(
+                    category="Unknown",
+                    path=f"coordinator.env.{key}",
+                    owner="unclassified",
+                    message="duplicate env key name is ambiguous; value=<MASKED>",
+                )
+            )
+            continue
+        seen.add(key)
+        if key in allowed:
+            evidence.append(
+                Finding(
+                    category="Evidence",
+                    path=f"coordinator.env.{key}",
+                    owner="pearl_operator_secrets",
+                    message="key name is classified; value=<MASKED>",
+                )
+            )
+        else:
+            unknown.append(
+                Finding(
+                    category="Unknown",
+                    path=f"coordinator.env.{key}",
+                    owner="unclassified",
+                    message="env key name is not listed in source-of-truth manifest; value=<MASKED>",
+                )
+            )
+    return evidence, unknown
+
+
+def validate_ssh_target(target: str) -> None:
+    if not SSH_TARGET_RE.fullmatch(target):
+        raise SystemExit("ssh target must be a conservative alias or user@host")
+
+
+def run_ssh(target: str, remote_script: str) -> str:
+    validate_ssh_target(target)
+    command = [
+        "ssh",
+        "-o",
+        "BatchMode=yes",
+        "-o",
+        "ConnectTimeout=10",
+        target,
+        f"sudo -n sh -c {sh_quote(remote_script)}",
+    ]
+    try:
+        result = subprocess.run(
+            command,
+            check=False,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            timeout=30,
+        )
+    except subprocess.TimeoutExpired as exc:
+        raise SystemExit(f"ssh read timed out for {target}") from exc
+    if result.returncode != 0:
+        stderr = result.stderr.strip()
+        raise SystemExit(f"ssh read failed for {target}: {stderr or 'no stderr'}")
+    return result.stdout
+
+
+def remote_env_inventory_script(env_path: str) -> str:
+    quoted_path = sh_quote(env_path)
+    return (
+        f"test -r {quoted_path} && "
+        "awk '"
+        "/^[[:space:]]*($|#)/ { next } "
+        "/^[[:space:]]*(export[[:space:]]+)?[A-Za-z_][A-Za-z0-9_]*[[:space:]]*=/ { "
+        "line=$0; "
+        "sub(/^[[:space:]]*(export[[:space:]]+)?/, \"\", line); "
+        "sub(/[[:space:]]*=.*/, \"\", line); "
+        "print line \"=<MASKED>\"; "
+        "next "
+        "} "
+        "{ print \"__MACPROVIDER_MALFORMED_ENV_LINE_\" NR \"=<MASKED>\" }"
+        f"' {quoted_path}"
+    )
+
+
+def read_live_via_ssh(target: str, manifest: dict[str, Any]) -> LiveEvidence:
+    files = manifest["pearl"]["files"]
+    config_path = files["base_product_defaults"]["live_path"]
+    overlay_path = files["production_overlay"]["live_path"]
+    env_path = files["secrets_env"]["live_path"]
+    config_text = run_ssh(target, f"cat {sh_quote(config_path)}")
+    overlay_text = run_ssh(
+        target,
+        f"test -r {sh_quote(overlay_path)} && cat {sh_quote(overlay_path)} || "
+        "printf '__MACPROVIDER_OVERLAY_MISSING__\\n'",
+    )
+    overlay_present = overlay_text.strip() != "__MACPROVIDER_OVERLAY_MISSING__"
+    env_keys_text = run_ssh(target, remote_env_inventory_script(env_path))
+    return LiveEvidence(
+        config=load_yaml_text(config_text, config_path),
+        overlay=load_yaml_text(overlay_text, overlay_path) if overlay_present and overlay_text.strip() else {},
+        overlay_present=overlay_present,
+        env_text=env_keys_text,
+    )
+
+
+def sh_quote(value: str) -> str:
+    return "'" + value.replace("'", "'\"'\"'") + "'"
+
+
+def summarize_exact_matches(tracked: dict[str, Any], live: dict[str, Any], manifest: dict[str, Any]) -> list[Finding]:
+    counts: dict[str, int] = {}
+    for path, tracked_value in tracked.items():
+        if path in live and live[path] == tracked_value:
+            owner = owner_for_path(path, manifest) or "unclassified_equal"
+            counts[owner] = counts.get(owner, 0) + 1
+    return [
+        Finding(
+            category="Evidence",
+            path=f"summary.{owner}",
+            owner=owner,
+            message=f"{count} tracked/live scalar fields match",
+        )
+        for owner, count in sorted(counts.items())
+    ]
+
+
+def classify_overlay(live_overlay: Any, manifest: dict[str, Any]) -> tuple[list[Finding], list[Finding]]:
+    evidence: list[Finding] = []
+    unknown: list[Finding] = []
+    if live_overlay is None or live_overlay == {} or live_overlay == []:
+        return evidence, unknown
+    overlay_flat = flatten(live_overlay)
+    if not overlay_flat:
+        return evidence, unknown
+    prefixes = manifest.get("pearl_overlay_owned_prefixes", [])
+    for path in sorted(overlay_flat):
+        finding_path = f"production_overlay.{path}"
+        if path_has_prefix(path, prefixes):
+            evidence.append(
+                Finding(
+                    category="Evidence",
+                    path=finding_path,
+                    owner="pearl_production_overlay",
+                    message="live overlay field is classified; value=<MASKED>",
+                )
+            )
+        else:
+            unknown.append(
+                Finding(
+                    category="Unknown",
+                    path=finding_path,
+                    owner="unclassified",
+                    message="live overlay field is not listed in source-of-truth manifest; value=<MASKED>",
+                )
+            )
+    return evidence, unknown
+
+
+def render_findings(evidence: list[Finding], inference: list[Finding], unknown: list[Finding]) -> str:
+    lines = [
+        "Pearl config reconciliation (read-only)",
+        "",
+        "Evidence:",
+    ]
+    lines.extend(render_category(evidence))
+    lines.extend(["", "Inference:"])
+    lines.extend(render_category(inference))
+    lines.extend(["", "Unknown:"])
+    lines.extend(render_category(unknown))
+    return "\n".join(lines) + "\n"
+
+
+def render_category(findings: list[Finding]) -> list[str]:
+    if not findings:
+        return ["- none"]
+    lines: list[str] = []
+    for finding in findings:
+        owner = f" [{finding.owner}]" if finding.owner else ""
+        lines.append(f"- {render_safe_path(finding.path)}: {finding.message}{owner}")
+    return lines
+
+
+def reconcile(
+    *,
+    manifest_path: Path,
+    tracked_config_path: Path,
+    live_config_path: Path | None,
+    live_overlay_path: Path | None,
+    live_env_path: Path | None,
+    ssh_target: str | None,
+) -> tuple[str, int]:
+    manifest = load_yaml_file(manifest_path)
+    tracked_config = load_yaml_file(tracked_config_path)
+
+    if ssh_target:
+        live_evidence = read_live_via_ssh(ssh_target, manifest)
+        live_config = live_evidence.config
+        live_overlay = live_evidence.overlay
+        live_overlay_present = live_evidence.overlay_present
+        live_env_text = live_evidence.env_text
+    else:
+        if live_config_path is None:
+            raise SystemExit("either --live-config or --ssh-target is required")
+        if live_env_path is None:
+            raise SystemExit("--live-env is required when not using --ssh-target")
+        live_config = load_yaml_file(live_config_path)
+        live_overlay = load_yaml_file(live_overlay_path, required=False) if live_overlay_path else {}
+        live_overlay_present = live_overlay_path is not None and live_overlay_path.exists()
+        live_env_text = live_env_path.read_text(encoding="utf-8")
+
+    tracked_flat = flatten(strip_providers(tracked_config))
+    live_flat = flatten(strip_providers(live_config))
+    config_drifts = compare_flattened(tracked_flat, live_flat)
+
+    evidence = summarize_exact_matches(tracked_flat, live_flat, manifest)
+    drift_evidence, drift_inference, drift_unknown = classify_config_drifts(config_drifts, manifest)
+    evidence.extend(drift_evidence)
+    inference = drift_inference
+    unknown = drift_unknown
+
+    tracked_providers = provider_index(tracked_config, side="tracked")
+    live_providers = provider_index(live_config, side="live")
+    unknown.extend(tracked_providers.unknown)
+    unknown.extend(live_providers.unknown)
+    provider_evidence, provider_inference, provider_unknown = classify_provider_rows(
+        tracked_providers.rows, live_providers.rows, manifest
+    )
+    evidence.extend(provider_evidence)
+    inference.extend(provider_inference)
+    unknown.extend(provider_unknown)
+
+    overlay_evidence, overlay_unknown = classify_overlay(live_overlay, manifest)
+    if not live_overlay_present:
+        unknown.append(
+            Finding(
+                category="Unknown",
+                path="production_overlay",
+                owner="pearl_production_overlay",
+                message="overlay evidence file is missing or unreadable",
+            )
+        )
+    elif overlay_evidence or overlay_unknown:
+        evidence.extend(overlay_evidence)
+        unknown.extend(overlay_unknown)
+    else:
+        inference.append(
+            Finding(
+                category="Inference",
+                path="production_overlay",
+                owner="pearl_production_overlay",
+                message="overlay file absent or empty in provided evidence",
+            )
+        )
+
+    env_evidence, env_unknown = classify_env_lines(parse_env_lines(live_env_text), manifest)
+    evidence.extend(env_evidence)
+    unknown.extend(env_unknown)
+
+    evidence.sort(key=lambda item: item.path)
+    inference.sort(key=lambda item: item.path)
+    unknown.sort(key=lambda item: item.path)
+    return render_findings(evidence, inference, unknown), 1 if unknown else 0
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--manifest", type=Path, default=DEFAULT_MANIFEST)
+    parser.add_argument("--tracked-config", type=Path, default=DEFAULT_TRACKED_CONFIG)
+    parser.add_argument("--live-config", type=Path)
+    parser.add_argument("--live-overlay", type=Path)
+    parser.add_argument("--live-env", type=Path)
+    parser.add_argument("--ssh-target", help="SSH target such as pearl; read-only")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv or sys.argv[1:])
+    output, rc = reconcile(
+        manifest_path=args.manifest,
+        tracked_config_path=args.tracked_config,
+        live_config_path=args.live_config,
+        live_overlay_path=args.live_overlay,
+        live_env_path=args.live_env,
+        ssh_target=args.ssh_target,
+    )
+    sys.stdout.write(output)
+    return rc
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/ops/pearl/config/source-of-truth.yaml
+++ b/ops/pearl/config/source-of-truth.yaml
@@ -1,0 +1,139 @@
+schema_version: pearl-config-source-v1
+issue: 785
+description: >
+  Pearl coordinator config source-of-truth classification for read-only drift
+  reconciliation. This manifest classifies ownership; it is not a migration
+  plan and must not be used to overwrite live production config.
+
+pearl:
+  ssh_target: pearl
+  files:
+    base_product_defaults:
+      repo_path: phase4-coordinator/dist/coordinator.yaml
+      live_path: /opt/macprovider/coordinator.yaml
+      owner: base_product_defaults
+    production_overlay:
+      live_path: /etc/macprovider/coordinator.pearl-overlays.yaml
+      owner: pearl_production_overlay
+      repo_mirror: manifest-only
+      note: >
+        Overlay contents can contain production-only posture. PR B tracks
+        ownership here without checking a non-secret mirror into the repo.
+    secrets_env:
+      live_path: /etc/macprovider/coordinator.env
+      owner: pearl_operator_secrets
+      values: never_log
+
+tracked_base_owned_prefixes:
+  - listen
+  - coordinator.require_gateway_context
+  - pool
+  - routing
+  - provider_http
+  - limits
+  - relay
+  - auth.require_provider_tokens
+  - auth.allow_tokenless_provisional_bootstrap
+  - referrals
+  - explorer
+  - stats
+  - onboarding
+  - storage
+  - logging
+  - autotune
+  - rewards.rate_card
+  - rewards.global_multiplier
+  - rewards.provider_share
+  - admission
+  - tier2
+
+fleet_version_policy_owned_prefixes:
+  - coordinator_advertised_version
+
+pearl_overlay_owned_prefixes:
+  - coordinator.compatibility_set
+  - pool.canary_enabled
+  - malibu_emission
+  - opoi
+  - proof_of_weights
+
+known_config_drift:
+  - path: pool.heartbeat_interval_s
+    drift_kind: value_mismatch
+    tracked: 30
+    live: 1
+    owner: pearl_production_overlay
+    category: Evidence
+    rationale: Current Pearl runtime posture; PR C should migrate it field-scope into the overlay.
+  - path: pool.warmup_gate_enabled
+    drift_kind: value_mismatch
+    tracked: true
+    live: false
+    owner: pearl_production_overlay
+    category: Evidence
+    rationale: Current Pearl runtime posture; PR C should migrate it field-scope into the overlay.
+  - path: coordinator_advertised_version.latest_binary_version
+    drift_kind: value_mismatch
+    tracked: "1.8.65"
+    live: "1.8.61"
+    owner: fleet_version_admission_policy
+    category: Evidence
+    rationale: Capability-gated recommendation policy drift is classified for operator review.
+  - path: coordinator_advertised_version.required_binary_version
+    drift_kind: tracked_only
+    tracked: "1.8.33"
+    owner: fleet_version_admission_policy
+    category: Evidence
+    rationale: Hard admission floor exists in tracked source; absence live is classified until PR C.
+
+provider_rows:
+  tracked_static_provider_ids:
+    - mac
+  pearl_registered_static_provider_ids:
+    - augustass-macbook-air
+  registered_provider_field_types:
+    provider_id: string
+    endpoint_url: string
+    display_name: string
+    model: string
+    model_id: string
+    status: string
+    priority: integer
+    weight: number
+    max_concurrent_requests: integer
+    tags: string_list
+  live_only_registered_provider_category: Inference
+  owner: registered_static_providers
+  source_note: >
+    Provider rows are config posture, not secrets. Token material remains in
+    coordinator.env or databases and must never be mirrored here.
+
+env_key_names:
+  allowed:
+    - APPLE_TEAM_ID
+    - C2C_COORD_OPERATOR_KEY_SHA256
+    - C2C_COORD_SERVICE_TOKEN_SHA256
+    - CATALOG_CANARY_AUTH_TOKEN
+    - CATALOG_CANARY_PROVIDER_ID
+    - GATEWAY_SERVICE_TOKEN
+    - MALIBU_EMISSION_WRITER_DSN
+    - MODEL_HASH_LEGACY_UNTIL
+    - ONBOARDING_AUTH_POLICY_APPROVE_DSN
+    - ONBOARDING_AUTH_POLICY_CUTOVER_DSN
+    - ONBOARDING_AUTH_POLICY_REQUEST_DSN
+    - ONBOARDING_HARDWARE_TRUST_APPROVE_DSN
+    - ONBOARDING_HARDWARE_TRUST_REQUEST_DSN
+    - ONBOARDING_POSTGRES_DSN
+    - OPERATOR_AUTH_POLICY_A
+    - OPERATOR_AUTH_POLICY_B
+    - OPERATOR_KEY
+    - STATS_PARTNER_KEYS_WRITER_DSN
+    - STATS_READER_DSN
+    - STATS_ROLLUP_DSN
+  note: Only key names may be printed; values are always masked.
+
+rate_card:
+  source: phase4-coordinator/dist/coordinator.yaml
+  path: rewards.rate_card
+  owner: tracked_rate_card_source
+  policy: Live rate-card drift is unknown unless a future manifest revision explicitly classifies it.

--- a/ops/pearl/config/test_pearl_config_reconcile.py
+++ b/ops/pearl/config/test_pearl_config_reconcile.py
@@ -1,0 +1,388 @@
+#!/usr/bin/env python3
+import importlib.util
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[3]
+TOOL = ROOT / "ops/pearl/config/reconcile_pearl_config.py"
+DATA = ROOT / "ops/pearl/config/testdata"
+
+spec = importlib.util.spec_from_file_location("reconcile_pearl_config", TOOL)
+assert spec is not None and spec.loader is not None
+reconcile_module = importlib.util.module_from_spec(spec)
+sys.modules[spec.name] = reconcile_module
+spec.loader.exec_module(reconcile_module)
+
+
+class PearlConfigReconcileTest(unittest.TestCase):
+    def run_tool(self, *args):
+        return subprocess.run(
+            [sys.executable, str(TOOL), *args],
+            cwd=ROOT,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            check=False,
+        )
+
+    def test_known_drift_fixture_is_classified(self):
+        result = self.run_tool(
+            "--tracked-config",
+            str(DATA / "known-drift-tracked.yaml"),
+            "--live-config",
+            str(DATA / "known-drift-live.yaml"),
+            "--live-overlay",
+            str(DATA / "known-drift-overlay.yaml"),
+            "--live-env",
+            str(DATA / "known-drift.env"),
+        )
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        self.assertIn("Evidence:", result.stdout)
+        self.assertIn("pool.heartbeat_interval_s: value_mismatch: tracked=30 live=1", result.stdout)
+        self.assertIn(
+            "pool.warmup_gate_enabled: value_mismatch: tracked=True live=False",
+            result.stdout,
+        )
+        self.assertIn(
+            "coordinator_advertised_version.latest_binary_version: "
+            "value_mismatch: tracked='1.8.65' live='1.8.61'",
+            result.stdout,
+        )
+        self.assertIn(
+            "coordinator_advertised_version.required_binary_version: "
+            "tracked_only: tracked='1.8.33' live=<ABSENT>",
+            result.stdout,
+        )
+        self.assertIn("Inference:", result.stdout)
+        self.assertIn(
+            "providers.augustass-macbook-air: live-only provider row is classified",
+            result.stdout,
+        )
+        self.assertIn("Unknown:\n- none", result.stdout)
+
+    def test_unknown_config_drift_exits_nonzero(self):
+        result = self.run_tool(
+            "--tracked-config",
+            str(DATA / "known-drift-tracked.yaml"),
+            "--live-config",
+            str(DATA / "unknown-live.yaml"),
+            "--live-overlay",
+            str(DATA / "known-drift-overlay.yaml"),
+            "--live-env",
+            str(DATA / "known-drift.env"),
+        )
+        self.assertEqual(result.returncode, 1, result.stdout + result.stderr)
+        self.assertIn("Unknown:", result.stdout)
+        self.assertIn("routing.request_timeout_s", result.stdout)
+        self.assertIn("rewards.rate_card.default.prompt_credits_per_mtok", result.stdout)
+
+    def test_live_env_is_required_for_fixture_mode(self):
+        result = self.run_tool(
+            "--tracked-config",
+            str(DATA / "known-drift-tracked.yaml"),
+            "--live-config",
+            str(DATA / "known-drift-live.yaml"),
+            "--live-overlay",
+            str(DATA / "known-drift-overlay.yaml"),
+        )
+        self.assertEqual(result.returncode, 1, result.stdout + result.stderr)
+        self.assertIn("--live-env is required when not using --ssh-target", result.stderr)
+
+    def test_malformed_env_line_exits_nonzero_without_value(self):
+        result = self.run_tool(
+            "--tracked-config",
+            str(DATA / "known-drift-tracked.yaml"),
+            "--live-config",
+            str(DATA / "known-drift-live.yaml"),
+            "--live-overlay",
+            str(DATA / "known-drift-overlay.yaml"),
+            "--live-env",
+            str(DATA / "malformed-env.env"),
+        )
+        self.assertEqual(result.returncode, 1, result.stdout + result.stderr)
+        self.assertIn("coordinator.env.line_2", result.stdout)
+        self.assertIn("malformed env line", result.stdout)
+        self.assertNotIn("redaction-sentinel-not-for-output", result.stdout)
+
+    def test_secret_shaped_values_are_masked(self):
+        result = self.run_tool(
+            "--tracked-config",
+            str(DATA / "known-drift-tracked.yaml"),
+            "--live-config",
+            str(DATA / "unknown-live.yaml"),
+            "--live-overlay",
+            str(DATA / "known-drift-overlay.yaml"),
+            "--live-env",
+            str(DATA / "known-drift.env"),
+        )
+        forbidden = [
+            "redaction-sentinel-not-for-output",
+            "inline-redaction-sentinel-not-for-output",
+        ]
+        for value in forbidden:
+            self.assertNotIn(value, result.stdout)
+            self.assertNotIn(value, result.stderr)
+        self.assertIn("coordinator.env.OPERATOR_KEY: key name is classified; value=<MASKED>", result.stdout)
+        self.assertIn("diagnostics.debug_label", result.stdout)
+        self.assertIn("diagnostics.debug_label: live_only: tracked=<ABSENT> live=<MASKED>", result.stdout)
+
+    def test_embedded_secret_shaped_substrings_are_masked(self):
+        values = [
+            "prefix bearer abcdefghijklmnop suffix",
+            "prefix ghp_abcdefghijklmnopqrstuvwxyz suffix",
+            "prefix 0123456789abcdef0123456789abcdef suffix",
+        ]
+        for value in values:
+            self.assertEqual(reconcile_module.display_value("diagnostics.note", value), "<MASKED>")
+
+        rendered_path = reconcile_module.render_safe_path(
+            "diagnostics.prefix-ghp_abcdefghijklmnopqrstuvwxyz-suffix"
+        )
+        self.assertIn("diagnostics.<MASKED:", rendered_path)
+        self.assertNotIn("ghp_abcdefghijklmnopqrstuvwxyz", rendered_path)
+
+    def test_local_yaml_parse_error_does_not_print_source_snippet(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            live_config = Path(tmp) / "live.yaml"
+            live_config.write_text(
+                "listen:\n"
+                "  buyer_port: 8443\n"
+                "diagnostics: [sk-redaction-sentinel-not-for-output\n",
+                encoding="utf-8",
+            )
+            result = self.run_tool(
+                "--tracked-config",
+                str(DATA / "known-drift-tracked.yaml"),
+                "--live-config",
+                str(live_config),
+                "--live-overlay",
+                str(DATA / "known-drift-overlay.yaml"),
+                "--live-env",
+                str(DATA / "known-drift.env"),
+            )
+        self.assertEqual(result.returncode, 1, result.stdout + result.stderr)
+        self.assertIn("failed to parse", result.stderr)
+        self.assertNotIn("redaction-sentinel-not-for-output", result.stdout)
+        self.assertNotIn("redaction-sentinel-not-for-output", result.stderr)
+
+    def test_secret_shaped_provider_id_is_masked_in_paths(self):
+        tracked_config = reconcile_module.load_yaml_file(DATA / "known-drift-tracked.yaml")
+        live_config = reconcile_module.load_yaml_file(DATA / "known-drift-live.yaml")
+        secret_provider_id = "sk-redaction-sentinel-not-for-output-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+        live_config["providers"].append({"provider_id": secret_provider_id, "endpoint_url": ""})
+        live_config["providers"].append({"provider_id": secret_provider_id, "endpoint_url": ""})
+
+        tracked_index = reconcile_module.provider_index(tracked_config, side="tracked")
+        live_index = reconcile_module.provider_index(live_config, side="live")
+        evidence, inference, unknown = reconcile_module.classify_provider_rows(
+            tracked_index.rows,
+            live_index.rows,
+            reconcile_module.load_yaml_file(ROOT / "ops/pearl/config/source-of-truth.yaml"),
+        )
+        rendered = reconcile_module.render_findings(evidence, inference, live_index.unknown + unknown)
+
+        self.assertIn("providers.<MASKED:", rendered)
+        self.assertNotIn(secret_provider_id, rendered)
+
+    def test_secret_shaped_dynamic_keys_are_masked_in_rendered_paths(self):
+        manifest = reconcile_module.load_yaml_file(ROOT / "ops/pearl/config/source-of-truth.yaml")
+        secret_yaml_key = "sk-redaction-sentinel-not-for-output-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+        secret_env_key = "sk_redaction_sentinel_not_for_output_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+
+        _, _, config_unknown = reconcile_module.classify_config_drifts(
+            [reconcile_module.Drift(path=secret_yaml_key, kind="live_only", tracked=reconcile_module._ABSENT, live={})],
+            manifest,
+        )
+        overlay_evidence, overlay_unknown = reconcile_module.classify_overlay({secret_yaml_key: {}}, manifest)
+        env_evidence, env_unknown = reconcile_module.classify_env_lines(
+            reconcile_module.parse_env_lines(f"{secret_env_key}=value\n"),
+            manifest,
+        )
+        rendered = reconcile_module.render_findings(
+            overlay_evidence + env_evidence,
+            [],
+            config_unknown + overlay_unknown + env_unknown,
+        )
+
+        self.assertIn("<MASKED:", rendered)
+        self.assertNotIn(secret_yaml_key, rendered)
+        self.assertNotIn(secret_env_key, rendered)
+
+    def test_unknown_overlay_field_exits_nonzero_without_value(self):
+        result = self.run_tool(
+            "--tracked-config",
+            str(DATA / "known-drift-tracked.yaml"),
+            "--live-config",
+            str(DATA / "known-drift-live.yaml"),
+            "--live-overlay",
+            str(DATA / "unknown-overlay.yaml"),
+            "--live-env",
+            str(DATA / "known-drift.env"),
+        )
+        self.assertEqual(result.returncode, 1, result.stdout + result.stderr)
+        self.assertIn("production_overlay.unexpected.private_key", result.stdout)
+        self.assertIn("value=<MASKED>", result.stdout)
+        self.assertNotIn("redaction-sentinel-not-for-output", result.stdout)
+
+    def test_unknown_env_key_exits_nonzero_without_value(self):
+        result = self.run_tool(
+            "--tracked-config",
+            str(DATA / "known-drift-tracked.yaml"),
+            "--live-config",
+            str(DATA / "known-drift-live.yaml"),
+            "--live-overlay",
+            str(DATA / "known-drift-overlay.yaml"),
+            "--live-env",
+            str(DATA / "unknown-env.env"),
+        )
+        self.assertEqual(result.returncode, 1, result.stdout + result.stderr)
+        self.assertIn("coordinator.env.CATALOG_CANARY_PRIVATE_KEY", result.stdout)
+        self.assertNotIn("redaction-sentinel-not-for-output", result.stdout)
+
+    def test_duplicate_env_key_is_unknown(self):
+        manifest = reconcile_module.load_yaml_file(ROOT / "ops/pearl/config/source-of-truth.yaml")
+        _, unknown = reconcile_module.classify_env_lines(
+            reconcile_module.parse_env_lines("OPERATOR_KEY=first\nOPERATOR_KEY=second\n"),
+            manifest,
+        )
+        self.assertEqual([finding.path for finding in unknown], ["coordinator.env.OPERATOR_KEY"])
+        self.assertIn("duplicate env key", unknown[0].message)
+
+    def test_ssh_target_validation_rejects_option_like_target(self):
+        result = self.run_tool("--ssh-target=-oProxyCommand=echo")
+        self.assertEqual(result.returncode, 1, result.stdout + result.stderr)
+        self.assertIn("ssh target must be a conservative alias or user@host", result.stderr)
+
+    def test_ssh_env_inventory_preserves_malformed_line_marker(self):
+        manifest = reconcile_module.load_yaml_file(ROOT / "ops/pearl/config/source-of-truth.yaml")
+        calls = []
+
+        def fake_run_ssh(target, remote_script):
+            calls.append(remote_script)
+            if "coordinator.pearl-overlays.yaml" in remote_script:
+                return "coordinator:\n  compatibility_set:\n    target_id: example\n"
+            if "coordinator.env" in remote_script:
+                return "OPERATOR_KEY=<MASKED>\n__MACPROVIDER_MALFORMED_ENV_LINE_42=<MASKED>\n"
+            return "{}\n"
+
+        original = reconcile_module.run_ssh
+        reconcile_module.run_ssh = fake_run_ssh
+        try:
+            live_evidence = reconcile_module.read_live_via_ssh("pearl", manifest)
+        finally:
+            reconcile_module.run_ssh = original
+
+        self.assertTrue(any("__MACPROVIDER_MALFORMED_ENV_LINE_" in call for call in calls))
+        _, unknown = reconcile_module.classify_env_lines(
+            reconcile_module.parse_env_lines(live_evidence.env_text),
+            manifest,
+        )
+        self.assertEqual([finding.path for finding in unknown], ["coordinator.env.line_42"])
+
+    def test_ssh_missing_overlay_evidence_is_unknown(self):
+        manifest_path = ROOT / "ops/pearl/config/source-of-truth.yaml"
+
+        def fake_run_ssh(target, remote_script):
+            if "coordinator.pearl-overlays.yaml" in remote_script:
+                return "__MACPROVIDER_OVERLAY_MISSING__\n"
+            if "coordinator.env" in remote_script:
+                return "OPERATOR_KEY=<MASKED>\nGATEWAY_SERVICE_TOKEN=<MASKED>\n"
+            return (DATA / "known-drift-live.yaml").read_text(encoding="utf-8")
+
+        original = reconcile_module.run_ssh
+        reconcile_module.run_ssh = fake_run_ssh
+        try:
+            output, rc = reconcile_module.reconcile(
+                manifest_path=manifest_path,
+                tracked_config_path=DATA / "known-drift-tracked.yaml",
+                live_config_path=None,
+                live_overlay_path=None,
+                live_env_path=None,
+                ssh_target="pearl",
+            )
+        finally:
+            reconcile_module.run_ssh = original
+
+        self.assertEqual(rc, 1, output)
+        self.assertIn("production_overlay: overlay evidence file is missing or unreadable", output)
+
+    def test_present_empty_overlay_is_inference_not_unknown(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            overlay_path = Path(tmpdir) / "empty-overlay.yaml"
+            overlay_path.write_text("", encoding="utf-8")
+            result = self.run_tool(
+                "--tracked-config",
+                str(DATA / "known-drift-tracked.yaml"),
+                "--live-config",
+                str(DATA / "known-drift-live.yaml"),
+                "--live-overlay",
+                str(overlay_path),
+                "--live-env",
+                str(DATA / "known-drift.env"),
+            )
+
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        self.assertIn(
+            "production_overlay: overlay file absent or empty in provided evidence",
+            result.stdout,
+        )
+        self.assertIn("Unknown:\n- none", result.stdout)
+
+    def test_malformed_provider_rows_are_unknown(self):
+        live_config = reconcile_module.load_yaml_file(DATA / "known-drift-live.yaml")
+        live_config["providers"].append({"endpoint_url": "https://example.invalid"})
+        live_config["providers"].append("not-a-provider-row")
+        live_config["providers"].append({"provider_id": "augustass-macbook-air", "endpoint_url": ""})
+
+        index = reconcile_module.provider_index(live_config, side="live")
+
+        paths = [finding.path for finding in index.unknown]
+        self.assertIn("providers.live[2]", paths)
+        self.assertIn("providers.live[3]", paths)
+        self.assertIn("providers.live[4].provider_id", paths)
+
+    def test_live_only_registered_provider_unknown_fields_are_unknown(self):
+        manifest = reconcile_module.load_yaml_file(ROOT / "ops/pearl/config/source-of-truth.yaml")
+        tracked_config = reconcile_module.load_yaml_file(DATA / "known-drift-tracked.yaml")
+        live_config = reconcile_module.load_yaml_file(DATA / "known-drift-live.yaml")
+        live_config["providers"][1]["private_note"] = "short-note"
+        live_config["providers"][1]["tags"] = [{"private_note": "nested-short-note"}]
+        live_config["providers"][1]["endpoint_url"] = 7
+
+        evidence, inference, unknown = reconcile_module.classify_provider_rows(
+            reconcile_module.provider_index(tracked_config, side="tracked").rows,
+            reconcile_module.provider_index(live_config, side="live").rows,
+            manifest,
+        )
+        rendered = reconcile_module.render_findings(evidence, inference, unknown)
+
+        self.assertIn("providers.augustass-macbook-air.private_note", rendered)
+        self.assertIn("providers.augustass-macbook-air.tags", rendered)
+        self.assertIn("providers.augustass-macbook-air.endpoint_url", rendered)
+        self.assertIn("value=<MASKED>", rendered)
+        self.assertNotIn("short-note", rendered)
+        self.assertNotIn("nested-short-note", rendered)
+
+    def test_secret_container_children_are_masked(self):
+        result = self.run_tool(
+            "--tracked-config",
+            str(DATA / "known-drift-tracked.yaml"),
+            "--live-config",
+            str(DATA / "unknown-live.yaml"),
+            "--live-overlay",
+            str(DATA / "known-drift-overlay.yaml"),
+            "--live-env",
+            str(DATA / "known-drift.env"),
+        )
+        self.assertEqual(result.returncode, 1, result.stdout + result.stderr)
+        self.assertIn("auth.operator_keys.alice", result.stdout)
+        self.assertIn("live=<MASKED>", result.stdout)
+        self.assertNotIn("inline-redaction-sentinel-not-for-output", result.stdout)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/ops/pearl/config/testdata/known-drift-live.yaml
+++ b/ops/pearl/config/testdata/known-drift-live.yaml
@@ -1,0 +1,24 @@
+listen:
+  buyer_port: 8443
+pool:
+  heartbeat_interval_s: 1
+  warmup_gate_enabled: false
+routing:
+  request_timeout_s: 280
+auth:
+  operator_key: env:OPERATOR_KEY
+  gateway_service_token: env:GATEWAY_SERVICE_TOKEN
+providers:
+  - provider_id: mac
+    endpoint_url: ""
+    display_name: Pearl Mac provider
+  - provider_id: augustass-macbook-air
+    endpoint_url: ""
+    display_name: Augustas MacBook Air
+rewards:
+  rate_card:
+    default:
+      prompt_credits_per_mtok: 500000
+      completion_credits_per_mtok: 1000000
+coordinator_advertised_version:
+  latest_binary_version: "1.8.61"

--- a/ops/pearl/config/testdata/known-drift-overlay.yaml
+++ b/ops/pearl/config/testdata/known-drift-overlay.yaml
@@ -1,0 +1,7 @@
+coordinator:
+  compatibility_set:
+    target_id: "Augustas11/macprovider:v1.8.61@example"
+    accepted_ids:
+      - "Augustas11/macprovider:v1.8.61@example"
+pool:
+  canary_enabled: false

--- a/ops/pearl/config/testdata/known-drift-tracked.yaml
+++ b/ops/pearl/config/testdata/known-drift-tracked.yaml
@@ -1,0 +1,22 @@
+listen:
+  buyer_port: 8443
+pool:
+  heartbeat_interval_s: 30
+  warmup_gate_enabled: true
+routing:
+  request_timeout_s: 280
+auth:
+  operator_key: env:OPERATOR_KEY
+  gateway_service_token: env:GATEWAY_SERVICE_TOKEN
+providers:
+  - provider_id: mac
+    endpoint_url: ""
+    display_name: Pearl Mac provider
+rewards:
+  rate_card:
+    default:
+      prompt_credits_per_mtok: 500000
+      completion_credits_per_mtok: 1000000
+coordinator_advertised_version:
+  latest_binary_version: "1.8.65"
+  required_binary_version: "1.8.33"

--- a/ops/pearl/config/testdata/known-drift.env
+++ b/ops/pearl/config/testdata/known-drift.env
@@ -1,0 +1,5 @@
+OPERATOR_KEY=redaction-sentinel-not-for-output
+GATEWAY_SERVICE_TOKEN=redaction-sentinel-not-for-output
+STATS_READER_DSN=redaction-sentinel-not-for-output
+STATS_ROLLUP_DSN=redaction-sentinel-not-for-output
+ONBOARDING_POSTGRES_DSN=redaction-sentinel-not-for-output

--- a/ops/pearl/config/testdata/malformed-env.env
+++ b/ops/pearl/config/testdata/malformed-env.env
@@ -1,0 +1,2 @@
+OPERATOR_KEY=redaction-sentinel-not-for-output
+not an assignment redaction-sentinel-not-for-output

--- a/ops/pearl/config/testdata/unknown-env.env
+++ b/ops/pearl/config/testdata/unknown-env.env
@@ -1,0 +1,2 @@
+OPERATOR_KEY=redaction-sentinel-not-for-output
+CATALOG_CANARY_PRIVATE_KEY=redaction-sentinel-not-for-output

--- a/ops/pearl/config/testdata/unknown-live.yaml
+++ b/ops/pearl/config/testdata/unknown-live.yaml
@@ -1,0 +1,25 @@
+listen:
+  buyer_port: 8443
+pool:
+  heartbeat_interval_s: 1
+  warmup_gate_enabled: false
+routing:
+  request_timeout_s: 999
+diagnostics:
+  debug_label: sk-redaction-sentinel-not-for-output
+auth:
+  operator_key: env:inline-redaction-sentinel-not-for-output
+  gateway_service_token: env:GATEWAY_SERVICE_TOKEN
+  operator_keys:
+    alice: inline-redaction-sentinel-not-for-output
+providers:
+  - provider_id: mac
+    endpoint_url: ""
+    display_name: Pearl Mac provider
+rewards:
+  rate_card:
+    default:
+      prompt_credits_per_mtok: 600000
+      completion_credits_per_mtok: 1000000
+coordinator_advertised_version:
+  latest_binary_version: "1.8.61"

--- a/ops/pearl/config/testdata/unknown-overlay.yaml
+++ b/ops/pearl/config/testdata/unknown-overlay.yaml
@@ -1,0 +1,5 @@
+coordinator:
+  compatibility_set:
+    target_id: "Augustas11/macprovider:v1.8.61@example"
+unexpected:
+  private_key: redaction-sentinel-not-for-output

--- a/ops/runbooks/README.md
+++ b/ops/runbooks/README.md
@@ -15,3 +15,4 @@
 | **#540 AEAD rekey** | [`540-aead-rekey-oneshot.md`](./540-aead-rekey-oneshot.md) | Isolated, approved, no-retry request/age rekey evidence |
 | **#584 emergency-disable drill** | [`584-emergency-disable-drill.md`](./584-emergency-disable-drill.md) | Pearl kill-switch drill paper; never re-enables timer/gates |
 | **#584 physical baselines** | [`584-physical-baseline-matrix.md`](./584-physical-baseline-matrix.md) | Per-tier floors + thermal/memory collection matrix before re-enable |
+| **#785 Pearl config reconciliation** | [`pearl-config-reconciliation.md`](./pearl-config-reconciliation.md) | Read-only source-of-truth drift classification before coordinator deploys |

--- a/ops/runbooks/pearl-config-reconciliation.md
+++ b/ops/runbooks/pearl-config-reconciliation.md
@@ -1,0 +1,28 @@
+# Pearl Config Reconciliation
+
+Use this read-only check before Pearl coordinator deploys when `CONFIG_MODE` is
+`preserve-live`, and before any reviewed config migration. It classifies live
+Pearl config drift against the repo source-of-truth manifest without mutating
+Pearl and without printing secret values.
+
+```bash
+python3 ops/pearl/config/reconcile_pearl_config.py --ssh-target pearl
+```
+
+Expected output has three sections:
+
+- `Evidence`: exact tracked/live matches, manifest-declared drift, classified
+  env key names, and manifest-classified overlay fields.
+- `Inference`: live-only posture that the manifest classifies without mirroring
+  secret or production-only values, such as registered/static provider rows.
+- `Unknown`: unclassified drift. Treat any entry here as a stop condition for
+  deploy; the tool exits non-zero.
+
+To classify new drift, update `ops/pearl/config/source-of-truth.yaml` with the
+owner, path, drift kind, and non-secret expected value or rationale. Keep PRs
+scoped: this manifest classifies ownership only. Field-scoped migration from
+live base config into `/etc/macprovider/coordinator.pearl-overlays.yaml` belongs
+in the follow-up migration PR.
+
+Never paste `/etc/macprovider/coordinator.env` values into issues, fixtures,
+PR bodies, or runbooks. The reconciler prints key names only.

--- a/scripts/test-production-exceptions.sh
+++ b/scripts/test-production-exceptions.sh
@@ -221,7 +221,7 @@ rm -f /tmp/exc-cap.out
 # unrelated successors and a merge fan-out larger than any numeric window.
 hist="$(mktemp -d "${TMPDIR:-/tmp}/exception-hist.XXXXXX")"
 python3 - "$hist" "$root" <<'PY'
-import json, subprocess, sys
+import json, os, subprocess, sys
 from pathlib import Path
 
 hist = Path(sys.argv[1])
@@ -231,9 +231,27 @@ import production_exceptions as pe
 
 repo = hist / "repo"
 repo.mkdir()
-subprocess.check_call(["git", "init", "-b", "main"], cwd=repo, stdout=subprocess.DEVNULL)
-subprocess.check_call(["git", "config", "user.email", "test@example.com"], cwd=repo)
-subprocess.check_call(["git", "config", "user.name", "test"], cwd=repo)
+git_env = os.environ.copy()
+for name in ("GIT_COMMON_DIR", "GIT_DIR", "GIT_INDEX_FILE", "GIT_WORK_TREE"):
+    git_env.pop(name, None)
+
+
+def git_call(*args, **kwargs):
+    kwargs.setdefault("cwd", repo)
+    kwargs.setdefault("env", git_env)
+    return subprocess.check_call(["git", *args], **kwargs)
+
+
+def git_output(*args, **kwargs):
+    kwargs.setdefault("cwd", repo)
+    kwargs.setdefault("env", git_env)
+    kwargs.setdefault("text", True)
+    return subprocess.check_output(["git", *args], **kwargs)
+
+
+git_call("init", "-b", "main", stdout=subprocess.DEVNULL)
+git_call("config", "user.email", "test@example.com")
+git_call("config", "user.name", "test")
 
 reg = {
   "$schema": "./production-exceptions.schema.json",
@@ -278,63 +296,37 @@ reg_dir = repo / "ops/exceptions"
 reg_dir.mkdir(parents=True)
 (reg_dir / "production-exceptions.json").write_text(json.dumps(reg, indent=2) + "\n")
 (reg_dir / "removed-exception-tombstones.json").write_text(json.dumps(tombs, indent=2) + "\n")
-subprocess.check_call(["git", "add", "."], cwd=repo)
-subprocess.check_call(["git", "commit", "-m", "baseline"], cwd=repo, stdout=subprocess.DEVNULL)
-baseline = subprocess.check_output(["git", "rev-parse", "HEAD"], cwd=repo, text=True).strip()
+git_call("add", ".")
+git_call("commit", "-m", "baseline", stdout=subprocess.DEVNULL)
+baseline = git_output("rev-parse", "HEAD").strip()
 
 reg["exceptions"][0]["expires_at"] = "2026-10-01T00:00:00Z"
 tombs["tombstones"] = []
 (reg_dir / "production-exceptions.json").write_text(json.dumps(reg, indent=2) + "\n")
 (reg_dir / "removed-exception-tombstones.json").write_text(json.dumps(tombs, indent=2) + "\n")
-subprocess.check_call(["git", "add", "."], cwd=repo)
-subprocess.check_call(["git", "commit", "-m", "weaken"], cwd=repo, stdout=subprocess.DEVNULL)
-weaken = subprocess.check_output(["git", "rev-parse", "HEAD"], cwd=repo, text=True).strip()
+git_call("add", ".")
+git_call("commit", "-m", "weaken", stdout=subprocess.DEVNULL)
+weaken = git_output("rev-parse", "HEAD").strip()
 
 (repo / "unrelated.txt").write_text("0\n")
-subprocess.check_call(["git", "add", "unrelated.txt"], cwd=repo)
-subprocess.check_call(["git", "commit", "-m", "unrelated-0"], cwd=repo, stdout=subprocess.DEVNULL)
+git_call("add", "unrelated.txt")
+git_call("commit", "-m", "unrelated-0", stdout=subprocess.DEVNULL)
 for i in range(1, 40):
     # Empty commits keep first-parent depth without stressing the object store.
-    subprocess.check_call(
-        ["git", "commit", "--allow-empty", "-m", f"unrelated-{i}"],
-        cwd=repo,
-        stdout=subprocess.DEVNULL,
-    )
+    git_call("commit", "--allow-empty", "-m", f"unrelated-{i}", stdout=subprocess.DEVNULL)
 
-subprocess.check_call(
-    ["git", "checkout", "-b", "side", baseline],
-    cwd=repo,
-    stdout=subprocess.DEVNULL,
-    stderr=subprocess.DEVNULL,
-)
+git_call("checkout", "-b", "side", baseline, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
 for i in range(40):
-    subprocess.check_call(
-        ["git", "commit", "--allow-empty", "-m", f"side-{i}"],
-        cwd=repo,
-        stdout=subprocess.DEVNULL,
-    )
-subprocess.check_call(
-    ["git", "checkout", "main"],
-    cwd=repo,
-    stdout=subprocess.DEVNULL,
-    stderr=subprocess.DEVNULL,
-)
-subprocess.check_call(
-    ["git", "merge", "--no-ff", "-m", "merge-side", "side"],
-    cwd=repo,
-    stdout=subprocess.DEVNULL,
-)
-tip = subprocess.check_output(["git", "rev-parse", "HEAD"], cwd=repo, text=True).strip()
+    git_call("commit", "--allow-empty", "-m", f"side-{i}", stdout=subprocess.DEVNULL)
+git_call("checkout", "main", stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+git_call("merge", "--no-ff", "-m", "merge-side", "side", stdout=subprocess.DEVNULL)
+tip = git_output("rev-parse", "HEAD").strip()
 
-raw = subprocess.check_output(["git", "rev-list", "-n", "32", tip], cwd=repo, text=True).split()
-path = subprocess.check_output(
-    [
-      "git", "rev-list", "--first-parent", tip, "--",
+raw = git_output("rev-list", "-n", "32", tip).split()
+path = git_output(
+    "rev-list", "--first-parent", tip, "--",
       "ops/exceptions/production-exceptions.json",
       "ops/exceptions/removed-exception-tombstones.json",
-    ],
-    cwd=repo,
-    text=True,
 ).split()
 if baseline not in path or weaken not in path:
     raise SystemExit(f"path-scoped history missing authority commits: {path}")
@@ -348,7 +340,7 @@ if not revs or revs[0] != tip:
 
 
 def show(rev, path_name):
-    raw_doc = subprocess.check_output(["git", "show", f"{rev}:{path_name}"], cwd=repo, text=True)
+    raw_doc = git_output("show", f"{rev}:{path_name}")
     return json.loads(raw_doc)
 
 regs = [show(rev, "ops/exceptions/production-exceptions.json") for rev in reversed(revs)]


### PR DESCRIPTION
## Summary
- Add `ops/pearl/config/source-of-truth.yaml` to classify Pearl coordinator config ownership, known drift, overlay/env/provider posture, fleet version policy, and tracked rate-card authority.
- Add read-only `ops/pearl/config/reconcile_pearl_config.py` for fixture or SSH evidence comparison with Evidence / Inference / Unknown output and fail-closed unknown drift.
- Add fixture-based reconciliation tests, wire them into `make test-dist`, and document the operator workflow in the Pearl reconciliation runbook.

## Safety
- No Pearl production state was modified.
- Live Pearl SSH reconciliation was not run in this implementation pass.
- Fixtures and output use key names and redaction sentinels only, never live secret values.
- Field-scoped config migration remains deferred to PR C.

## Validation
- `PYTHONDONTWRITEBYTECODE=1 python3 -B -m unittest -v ops/pearl/config/test_pearl_config_reconcile.py`
- `bash phase4-coordinator/dist/test/coord_deploy_config_mode_test.sh`
- `make test-dist`
- `git diff --cached --check`
- Three-lane audit loop: code, security, and architecture all CLEAR after fixes

SPEC-GOVERNANCE-DECLARATION-BEGIN
{
  "schema_version": "spec-pr-governance-v1",
  "behavior_change": "yes",
  "contract_change": "none",
  "specs": ["SPEC-010", "SPEC-020"],
  "requirements": ["SPEC-010-R005", "SPEC-020-R001"],
  "authority_domains": ["model-catalog-identity", "provider-autoupdate"],
  "arbitration": ["CODE_BUG"],
  "tests": [
    "ops/pearl/config/test_pearl_config_reconcile.py",
    "phase4-coordinator/dist/test/coord_deploy_config_mode_test.sh",
    "make test-dist"
  ],
  "journeys": ["not-required"],
  "issue": "https://github.com/Augustas11/macprovider/issues/785"
}
SPEC-GOVERNANCE-DECLARATION-END