### PR TITLE
Fix v1.8.66 x86 release package compile

### DIFF
--- a/phase3-binary/Sources/macprovider-cli/KVDiskCacheKeys.swift
+++ b/phase3-binary/Sources/macprovider-cli/KVDiskCacheKeys.swift
@@ -328,7 +328,7 @@ struct KVSecItemKeychain: KVKeychain {
     let accessGroup: String
 
     init(accessGroup: String? = nil) {
-        self.accessGroup = SecureEnclaveIdentity.resolveAccessGroup(accessGroup)
+        self.accessGroup = MacProviderKeychainAccessGroup.resolve(accessGroup)
     }
 
     private func nonInteractiveBase(service: String) -> [String: Any] {

--- a/phase3-binary/Sources/macprovider-cli/SecureEnclaveIdentity.swift
+++ b/phase3-binary/Sources/macprovider-cli/SecureEnclaveIdentity.swift
@@ -62,6 +62,20 @@ private func osStatus(from cfError: Unmanaged<CFError>?) -> OSStatus {
     return OSStatus(nsError.code)
 }
 
+enum MacProviderKeychainAccessGroup {
+    static func resolve(_ override: String?) -> String {
+        if let override { return override }
+        if let env = ProcessInfo.processInfo.environment["MACPROVIDER_KEYCHAIN_ACCESS_GROUP"],
+           !env.isEmpty { return env }
+        // Production value: replace TEAMID with the 10-char Apple Developer Team ID.
+        // The keychain-access-groups entitlement must list this group.
+        // During local dev/CI, set MACPROVIDER_KEYCHAIN_ACCESS_GROUP to a signed
+        // test group or leave unset — loadOrCreate will throw missingEntitlement,
+        // which the generator treats as graceful SE-unavailable.
+        return "REPLACEME.live.streamvc.macprovider"
+    }
+}
+
 // MARK: - SecureEnclaveIdentity
 
 #if arch(arm64)
@@ -193,15 +207,7 @@ final class SecureEnclaveIdentity: @unchecked Sendable {
     // MARK: - Access Group Resolution
 
     static func resolveAccessGroup(_ override: String?) -> String {
-        if let override { return override }
-        if let env = ProcessInfo.processInfo.environment["MACPROVIDER_KEYCHAIN_ACCESS_GROUP"],
-           !env.isEmpty { return env }
-        // Production value: replace TEAMID with the 10-char Apple Developer Team ID.
-        // The keychain-access-groups entitlement must list this group.
-        // During local dev/CI, set MACPROVIDER_KEYCHAIN_ACCESS_GROUP to a signed
-        // test group or leave unset — loadOrCreate will throw missingEntitlement,
-        // which the generator treats as graceful SE-unavailable.
-        return "REPLACEME.live.streamvc.macprovider"
+        MacProviderKeychainAccessGroup.resolve(override)
     }
 
     // MARK: - Private Helpers


### PR DESCRIPTION
## Summary

The `v1.8.66` unsigned release candidate for #785 failed in the release workflow before artifact capture while compiling the provider package for the x86_64 slice:

- run: https://github.com/Augustas11/macprovider/actions/runs/30371217727
- job: `Build unsigned release inputs from reviewed main`
- failing step: `Build package`
- error: `KVDiskCacheKeys.swift:331:28: error: cannot find 'SecureEnclaveIdentity' in scope`

Root cause: `KVSecItemKeychain` compiled for both release architectures, but its access-group resolver lived on `SecureEnclaveIdentity`, whose type is intentionally `#if arch(arm64)`.

This PR moves the access-group resolution into an architecture-neutral helper and keeps `SecureEnclaveIdentity.resolveAccessGroup` as an arm64 delegating API. It does not publish release assets, create/move tags, or mutate Pearl.

## Validation

- `xcodebuild -scheme macprovider-cli -configuration Release -destination 'generic/platform=macOS' -derivedDataPath /tmp/macprovider-v1866-package-fix-build -onlyUsePackageVersionsFromResolvedFile -skipPackagePluginValidation -skipMacroValidation clean build`
- `lipo -archs /tmp/macprovider-v1866-package-fix-build/Build/Products/Release/macprovider-cli` -> `x86_64 arm64`
- `/tmp/macprovider-v1866-package-fix-build/Build/Products/Release/macprovider-cli --version` -> `1.8.66`
- `cd phase3-binary && swift test --filter KVDiskCacheStoreTests` -> 65 executed, 3 skipped, 0 failures
- `git diff --check`

## #785 release/deploy note

After merge, rerun the `v1.8.66` release sequence from the new merged commit. Do not reuse or move burned tags. Do not deploy Pearl until a fresh unsigned candidate passes build plus arm64 runtime verification, signed assets are published for the new merged commit, and the runtime release verifier passes.

SPEC-GOVERNANCE-DECLARATION-BEGIN
{
  "schema_version": "spec-pr-governance-v1",
  "behavior_change": "yes",
  "contract_change": "none",
  "specs": ["SPEC-020", "SPEC-037"],
  "requirements": ["SPEC-020-R001", "SPEC-037-R001"],
  "authority_domains": ["provider-autoupdate", "kv-cache-persistence"],
  "arbitration": ["CODE_BUG"],
  "tests": [
    "xcodebuild -scheme macprovider-cli -configuration Release -destination generic/platform=macOS clean build",
    "swift test --filter KVDiskCacheStoreTests"
  ],
  "journeys": ["not-required"],
  "issue": "https://github.com/Augustas11/macprovider/issues/785"
}
SPEC-GOVERNANCE-DECLARATION-END
