### PR TITLE
Fix Pearl catalog directory identity for keyring drift

### DIFF
--- a/ops/pearl-updater/macprovider-pearl-update
+++ b/ops/pearl-updater/macprovider-pearl-update
@@ -3710,11 +3710,25 @@ class Updater:
             raise UpdateError(f"unsafe catalog pointer target: {target!r}")
 
     @staticmethod
+    def _catalog_release_content_digest(release: Release) -> str:
+        digest = hashlib.sha256()
+        for name in CATALOG_ASSETS:
+            asset_digest = release.catalog.files.get(name, "")
+            if not SHA256_RE.fullmatch(asset_digest):
+                raise UpdateError(f"catalog release {name} checksum is invalid")
+            digest.update(name.encode("utf-8"))
+            digest.update(b"\0")
+            digest.update(asset_digest.encode("ascii"))
+            digest.update(b"\n")
+        return digest.hexdigest()
+
+    @staticmethod
     def _catalog_release_directory_name(release: Release) -> str:
         manifest_digest = release.catalog.files.get("release.json", "")
         if not SHA256_RE.fullmatch(manifest_digest):
             raise UpdateError("catalog release manifest checksum is invalid")
-        return f"{release.catalog.release_id}-{manifest_digest[:16]}"
+        content_digest = Updater._catalog_release_content_digest(release)
+        return f"{release.catalog.release_id}-{content_digest[:16]}"
 
     def _current_tier2_catalog_path(self) -> Path:
         return self.install_root / "autotune" / "current" / "tier2-catalog.json"

--- a/ops/pearl-updater/test_pearl_updater.py
+++ b/ops/pearl-updater/test_pearl_updater.py
@@ -800,6 +800,33 @@ class PearlUpdaterTests(unittest.TestCase):
         )
         self.assertFalse((install / "tier2-catalog.json").exists())
 
+    def test_catalog_directory_identity_includes_keyring_digest(self):
+        release = self.stage(self.verify())
+        changed_files = dict(release.catalog.files)
+        changed_files["trusted-keys.json"] = "f" * 64
+        rebound_keyring = updater_module.Release(
+            release.tag,
+            release.version,
+            release.commit,
+            release.provider_advertised_version,
+            release.coordinator,
+            release.gateway,
+            updater_module.CatalogRelease(
+                release.catalog.release_id,
+                release.catalog.policy_version,
+                changed_files,
+            ),
+            release.provider_admission_rollout,
+            release.directory,
+        )
+
+        original_name = self.updater._catalog_release_directory_name(release)
+        rebound_name = self.updater._catalog_release_directory_name(rebound_keyring)
+
+        self.assertNotEqual(original_name, rebound_name)
+        self.assertTrue(original_name.startswith(f"{release.catalog.release_id}-"))
+        self.assertTrue(rebound_name.startswith(f"{release.catalog.release_id}-"))
+
     def test_catalog_install_repairs_existing_release_permissions_for_service(self):
         release = self.stage(self.verify())
         install = self.updater.install_root

--- a/ops/runbooks/608-pearl-tier2-single-authority.md
+++ b/ops/runbooks/608-pearl-tier2-single-authority.md
@@ -15,7 +15,7 @@ enable gate, the buyer-canary timer, and
 Abort before mutation unless all facts below are freshly true:
 
 - coordinator and gateway v1.8.60 are active and healthy;
-- the active signed catalog is
+- the active signed catalog is the legacy `release.json`-addressed directory
   `releases/published-2026-07-10-catalog-recovery-v1-386803eac2069a37`;
 - active and legacy Tier-2 SHA-256 are both
   `ec2a2b64ed3a00bb0b185840ea5d9edee6a07d4ecb551775db5f69316e463d92`;

--- a/ops/runbooks/catalog-release-provider-upgrade.md
+++ b/ops/runbooks/catalog-release-provider-upgrade.md
@@ -49,9 +49,12 @@ when its release metadata and both existing feed records remain byte-for-byte
 identical; no new two-feed row or later Tier-2 removal is accepted.
 
 Pearl release directories are content-addressed as
-`<release_id>-<release.json sha256 prefix>`, so a three-feed publication never
-overwrites the older two-feed directory that may share its release ID. After
-Entry 190, the coordinator reads Tier-2 only from
+`<release_id>-<catalog asset-set sha256 prefix>`, where the digest binds every
+signed catalog envelope member (`release.json`, `trusted-keys.json`, all three
+feed files, and detached feed signatures). A keyring-only or signature-only
+catalog change therefore creates a new immutable directory instead of
+overwriting an existing directory with the same release ID. After Entry 190,
+the coordinator reads Tier-2 only from
 `/opt/macprovider/autotune/current/tier2-catalog.json`. Updater and direct
 deploy stage all three signed feeds inside the immutable release directory,
 then atomically switch the single `autotune/current` pointer. During the

--- a/phase4-coordinator/dist/deploy-pearl-vps.sh
+++ b/phase4-coordinator/dist/deploy-pearl-vps.sh
@@ -517,12 +517,42 @@ import json, pathlib, sys
 print(json.loads(pathlib.Path(sys.argv[1]).read_text())["feeds"]["tier2-catalog.json"]["sha256"])
 PY
 )"
-AUTOTUNE_RELEASE_MANIFEST_SHA256="$(shasum -a 256 "$AUTOTUNE_RELEASE_MANIFEST" | awk '{print $1}')"
+AUTOTUNE_RELEASE_CONTENT_SHA256="$(python3 - \
+  "$AUTOTUNE_RELEASE_MANIFEST" \
+  "$AUTOTUNE_TRUSTED_KEYS" \
+  "$AUTOTUNE_TIER2_JSON" \
+  "$STATIC_AUTOTUNE_JSON" \
+  "$STATIC_AUTOTUNE_SIG" \
+  "$STATIC_DEMAND_JSON" \
+  "$STATIC_DEMAND_SIG" <<'PY'
+import hashlib
+import pathlib
+import sys
+
+assets = (
+    ("release.json", pathlib.Path(sys.argv[1])),
+    ("trusted-keys.json", pathlib.Path(sys.argv[2])),
+    ("tier2-catalog.json", pathlib.Path(sys.argv[3])),
+    ("autotune-candidates.json", pathlib.Path(sys.argv[4])),
+    ("autotune-candidates.json.sig", pathlib.Path(sys.argv[5])),
+    ("demand-rank.json", pathlib.Path(sys.argv[6])),
+    ("demand-rank.json.sig", pathlib.Path(sys.argv[7])),
+)
+digest = hashlib.sha256()
+for name, path in assets:
+    asset_digest = hashlib.sha256(path.read_bytes()).hexdigest()
+    digest.update(name.encode("utf-8"))
+    digest.update(b"\0")
+    digest.update(asset_digest.encode("ascii"))
+    digest.update(b"\n")
+print(digest.hexdigest())
+PY
+)"
 if ! printf '%s' "$AUTOTUNE_RELEASE_ID" | grep -Eq '^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$'; then
   echo "invalid autotune release_id: $AUTOTUNE_RELEASE_ID" >&2
   exit 1
 fi
-AUTOTUNE_RELEASE_DIR_NAME="$AUTOTUNE_RELEASE_ID-$(printf '%s' "$AUTOTUNE_RELEASE_MANIFEST_SHA256" | cut -c1-16)"
+AUTOTUNE_RELEASE_DIR_NAME="$AUTOTUNE_RELEASE_ID-$(printf '%s' "$AUTOTUNE_RELEASE_CONTENT_SHA256" | cut -c1-16)"
 
 # coordinator-cli is required ALONGSIDE the daemon (SPEC-003 v0.8.3
 # FR-C9.4 strict-reject path still requires `coordinator-cli

--- a/phase4-coordinator/dist/test/check_deploy_static_feed_access.test.sh
+++ b/phase4-coordinator/dist/test/check_deploy_static_feed_access.test.sh
@@ -20,6 +20,11 @@ bash -n "$RECOVER_SH"
 grep -q '_autotune_release=\\$_autotune_root/releases/$AUTOTUNE_RELEASE_DIR_NAME' "$DEPLOY_SH" ||
   fail "deploy must stage a content-addressed immutable catalog envelope"
 
+grep -q 'AUTOTUNE_RELEASE_CONTENT_SHA256=' "$DEPLOY_SH" &&
+  grep -q 'trusted-keys.json' "$DEPLOY_SH" &&
+  grep -q 'asset_digest = hashlib.sha256(path.read_bytes()).hexdigest()' "$DEPLOY_SH" ||
+  fail "deploy must content-address catalog envelopes by the full catalog asset set"
+
 grep -q 'install .*tier2-catalog.json \\$_autotune_stage/tier2-catalog.json' "$DEPLOY_SH" &&
   grep -q 'verify-directory --directory \\$_autotune_stage --tier2-public-key-file' "$DEPLOY_SH" ||
   fail "deploy must stage and authenticate Tier-2 inside the release envelope"


### PR DESCRIPTION
## Summary

- changes Pearl immutable catalog directory naming from `release_id + release.json digest` to `release_id + full catalog asset-set digest`
- aligns `macprovider-pearl-update` and `deploy-pearl-vps.sh` so signed updater and direct deploy stage the same directory identity
- adds a regression for the v1.8.66 failure mode: same `release_id` and `release.json`, different `trusted-keys.json`
- updates runbooks to document the new asset-set identity and label the current Pearl path as legacy `release.json`-addressed

## Why

Pearl refused the signed v1.8.66 updater apply because the existing immutable catalog directory `published-2026-07-10-catalog-recovery-v1-386803eac2069a37` shared the same `release_id` and `release.json` digest as the candidate, but had different `trusted-keys.json` bytes. The updater correctly refused to overwrite it. The directory identity needs to bind every immutable catalog asset, not only `release.json`.

Expected new directory for the current signed catalog envelope:

`published-2026-07-10-catalog-recovery-v1-a3fd97ea8b6679e8`

## Validation

- `python3 -m unittest -v ops.pearl-updater.test_pearl_updater`
- deploy-script tests under `phase4-coordinator/dist/test/*.sh` for deploy/static-feed paths
- `bash phase4-coordinator/dist/test/check_deploy_static_feed_access.test.sh`
- `bash -n phase4-coordinator/dist/deploy-pearl-vps.sh`
- `git diff --check`

## Rollout Notes

After merge, install the merged updater on Pearl before retrying `macprovider-pearl-update --apply --tag v1.8.66`. Do not run direct deploy while an updater transaction is active. #785 remains open until Pearl deploy proof passes.

<!-- SPEC-GOVERNANCE-DECLARATION-BEGIN
{
  "schema_version": "spec-pr-governance-v1",
  "behavior_change": "yes",
  "contract_change": "yes",
  "issue": "https://github.com/Augustas11/macprovider/issues/785",
  "specs": ["SPEC-023"],
  "requirements": ["SPEC-023-R001"],
  "authority_domains": ["installer-autotune-policy", "model-catalog-identity"],
  "arbitration": ["CODE_BUG"],
  "tests": ["python3 -m unittest -v ops.pearl-updater.test_pearl_updater", "phase4-coordinator/dist deploy/static-feed shell tests", "bash -n phase4-coordinator/dist/deploy-pearl-vps.sh", "git diff --check"],
  "journeys": ["not-run-live-pearl-retry"]
}
SPEC-GOVERNANCE-DECLARATION-END -->
