### PR TITLE
Fix provider watchdog PID validation on macOS

### DIFF
--- a/ops/macprovider-watchdog/watchdog.sh
+++ b/ops/macprovider-watchdog/watchdog.sh
@@ -134,12 +134,20 @@ provider_process_pid() {
   command -v lsof >/dev/null 2>&1 || return 1
   executable_output="$(lsof -a -p "$candidate" -d txt -Fn 2>/dev/null)" || return 1
   command_paths="$(printf "%s\n" "$executable_output" | awk 'substr($0, 1, 1) == "n" && length($0) > 1 { print substr($0, 2) }')"
-  [ "$(printf "%s\n" "$command_paths" | awk 'NF { count++ } END { print count + 0 }')" -eq 1 ] || return 1
-  command_path="$command_paths"
-  if command -v realpath >/dev/null 2>&1 && [ -e "$command_path" ]; then
-    command_path="$(realpath "$command_path" 2>/dev/null || printf "%s" "$command_path")"
-  fi
-  [ "$command_path" = "$expected" ] || return 1
+  found_expected=""
+  while IFS= read -r command_path; do
+    [ -n "$command_path" ] || continue
+    if command -v realpath >/dev/null 2>&1 && [ -e "$command_path" ]; then
+      command_path="$(realpath "$command_path" 2>/dev/null || printf "%s" "$command_path")"
+    fi
+    if [ "$command_path" = "$expected" ]; then
+      found_expected=1
+      break
+    fi
+  done <<EOF
+$command_paths
+EOF
+  [ "$found_expected" = 1 ] || return 1
   printf "%s" "$candidate"
 }
 

--- a/phase3-binary/dist/install.sh
+++ b/phase3-binary/dist/install.sh
@@ -6271,12 +6271,20 @@ provider_process_pid() {
   command -v lsof >/dev/null 2>&1 || return 1
   executable_output="$(lsof -a -p "$candidate" -d txt -Fn 2>/dev/null)" || return 1
   command_paths="$(printf "%s\n" "$executable_output" | awk 'substr($0, 1, 1) == "n" && length($0) > 1 { print substr($0, 2) }')"
-  [ "$(printf "%s\n" "$command_paths" | awk 'NF { count++ } END { print count + 0 }')" -eq 1 ] || return 1
-  command_path="$command_paths"
-  if command -v realpath >/dev/null 2>&1 && [ -e "$command_path" ]; then
-    command_path="$(realpath "$command_path" 2>/dev/null || printf "%s" "$command_path")"
-  fi
-  [ "$command_path" = "$expected" ] || return 1
+  found_expected=""
+  while IFS= read -r command_path; do
+    [ -n "$command_path" ] || continue
+    if command -v realpath >/dev/null 2>&1 && [ -e "$command_path" ]; then
+      command_path="$(realpath "$command_path" 2>/dev/null || printf "%s" "$command_path")"
+    fi
+    if [ "$command_path" = "$expected" ]; then
+      found_expected=1
+      break
+    fi
+  done <<EOF
+$command_paths
+EOF
+  [ "$found_expected" = 1 ] || return 1
   printf "%s" "$candidate"
 }
 

--- a/phase3-binary/dist/test/watchdog_health_scope.test.sh
+++ b/phase3-binary/dist/test/watchdog_health_scope.test.sh
@@ -85,7 +85,11 @@ EOF
 cat > "$TMP/bin/lsof" <<'EOF'
 #!/usr/bin/env bash
 case "$*" in
-  *'-d txt -Fn'*) printf 'n%s\n' "$HOME/macprovider/macprovider-cli" ;;
+  *'-d txt -Fn'*)
+    printf 'n%s\n' "/usr/lib/dyld"
+    printf 'n%s\n' "$HOME/macprovider/macprovider-cli"
+    printf 'n%s\n' "$HOME/Library/Application Support/macprovider/provider.sqlite-shm"
+    ;;
   *) echo 4242 ;;
 esac
 EOF
@@ -149,7 +153,10 @@ EOF
 cat > "$TMP/bin/lsof" <<'EOF'
 #!/usr/bin/env bash
 case "$*" in
-  *'-d txt -Fn'*) printf 'n%s\n' "$HOME/macprovider/macprovider-cli" ;;
+  *'-d txt -Fn'*)
+    printf 'n%s\n' "/usr/lib/dyld"
+    printf 'n%s\n' "$HOME/macprovider/macprovider-cli"
+    ;;
   *) echo 9999 ;;
 esac
 EOF


### PR DESCRIPTION
## Summary

Fixes the provider watchdog launchd PID validator so a healthy provider process is accepted when `lsof -d txt -Fn` reports the provider binary plus additional macOS text vnode mappings such as dyld or mapped runtime files.

The previous check required exactly one text mapping. On the Pearl canary Mac, that produced repeated false `has no validated PID` watchdog messages even though launchd was running the configured provider binary and the local provider listener was healthy.

## Changes

- Accept the configured provider binary when it appears anywhere in the normalized `lsof -d txt` path set for the launchd PID.
- Preserve fail-closed behavior when launchd reports ambiguous PIDs or the provider binary is absent from the validated process mappings.
- Update the installer-embedded watchdog copy and the inline drift check remains green.
- Extend watchdog health-scope coverage with multi-text-mapping fixtures.

## Validation

- `bash phase3-binary/dist/test/watchdog_health_scope.test.sh`
- `bash phase3-binary/dist/test/watchdog_rollback_paths.test.sh`
- `git diff --check`
- `make test-dist`

SPEC-GOVERNANCE-DECLARATION-BEGIN
{
  "schema_version": "spec-pr-governance-v1",
  "behavior_change": "yes",
  "contract_change": "none",
  "specs": ["SPEC-020"],
  "requirements": ["SPEC-020-R001"],
  "authority_domains": ["provider-autoupdate"],
  "arbitration": ["CODE_BUG"],
  "tests": [
    "phase3-binary/dist/test/watchdog_health_scope.test.sh",
    "phase3-binary/dist/test/watchdog_rollback_paths.test.sh",
    "scripts/test-watchdog-inline-drift.sh",
    "make test-dist"
  ],
  "journeys": ["not-required"],
  "issue": "https://github.com/Augustas11/macprovider/issues/785"
}
SPEC-GOVERNANCE-DECLARATION-END