### PR TITLE
Reject swapped autotune evidence at the coordinator

### DIFF
--- a/phase4-coordinator/internal/autotune/gate.go
+++ b/phase4-coordinator/internal/autotune/gate.go
@@ -88,6 +88,9 @@ func benchmarkPassesGate(benchmark VerifiedBenchmark, row Row, catalogSHA256, ro
 	if benchmark.ThermalThrottleDetected {
 		return false
 	}
+	if benchmark.SwapDetected {
+		return false
+	}
 	if strings.TrimSpace(benchmark.CandidateRowIdentity) != "" {
 		if !strings.EqualFold(strings.TrimSpace(benchmark.CandidateRowIdentity), strings.TrimSpace(rowIdentity)) {
 			return false

--- a/phase4-coordinator/internal/autotune/gate_test.go
+++ b/phase4-coordinator/internal/autotune/gate_test.go
@@ -124,6 +124,79 @@ func TestEvaluateHelloGateRejectsThermalThrottle(t *testing.T) {
 	}
 }
 
+func TestEvaluateHelloGateRejectsSwapDetected(t *testing.T) {
+	t.Parallel()
+	catalog := mustCatalog(t, `{
+		"version":"test",
+		"generated_at":"2026-07-08T00:00:00Z",
+		"source":"operator_curated_autotune_candidate_catalog",
+		"rows":{
+			"small":{"model_id":"mlx-community/Llama-3.2-3B-Instruct-4bit","model_revision":"7f0dc925e0d0afb0322d96f9255cfddf2ba5636e","model_sha256":"3975387f249977e5e8bfb7ed0d352f8258ac3d630f961ce1dd952f428ee7216a","min_ram_gb":4,"min_bandwidth_tier":"C","bench_gate":{"min_sustained_tps":15,"max_4k_ttft_ms":2500},"runtime_status":"recommendable"}
+		}
+	}`)
+	evidence := autotune.VerifiedEvidence{
+		CandidateCatalogSHA256: catalog.SHA256,
+		Benchmarks: []autotune.VerifiedBenchmark{
+			{
+				ModelKey:               "small",
+				ModelID:                "mlx-community/Llama-3.2-3B-Instruct-4bit",
+				SustainedTPS:           20,
+				TTFTMS:                 1000,
+				SwapDetected:           true,
+				ArtifactSHA256:         "3975387f249977e5e8bfb7ed0d352f8258ac3d630f961ce1dd952f428ee7216a",
+				CandidateCatalogSHA256: catalog.SHA256,
+			},
+		},
+	}
+	decision := autotune.EvaluateHelloGate(catalog, evidence, "mlx-community/Llama-3.2-3B-Instruct-4bit")
+	if decision.Allowed || decision.Reason != "autotune_evidence_invalid" {
+		t.Fatalf("decision = %+v", decision)
+	}
+}
+
+func TestEvaluateHelloGateIgnoresSwappedHigherTierBenchmark(t *testing.T) {
+	t.Parallel()
+	catalog := mustCatalog(t, `{
+		"version":"test",
+		"generated_at":"2026-07-08T00:00:00Z",
+		"source":"operator_curated_autotune_candidate_catalog",
+		"rows":{
+			"small":{"model_id":"mlx-community/Llama-3.2-3B-Instruct-4bit","model_revision":"7f0dc925e0d0afb0322d96f9255cfddf2ba5636e","model_sha256":"3975387f249977e5e8bfb7ed0d352f8258ac3d630f961ce1dd952f428ee7216a","min_ram_gb":4,"min_bandwidth_tier":"C","bench_gate":{"min_sustained_tps":15,"max_4k_ttft_ms":2500},"runtime_status":"recommendable"},
+			"large":{"model_id":"mlx-community/Qwen3-Coder-30B-A3B-Instruct-4bit","model_revision":"6e302ea604ad9ab206367e2c501d1571023e7b6d","model_sha256":"10adb5da9840c8fe0e3036b10f6e2f8f34b41c615f3925b4132302e9cdbab9c0","min_ram_gb":28,"min_bandwidth_tier":"C","bench_gate":{"min_sustained_tps":20,"max_4k_ttft_ms":3000},"runtime_status":"recommendable"}
+		}
+	}`)
+	evidence := autotune.VerifiedEvidence{
+		CandidateCatalogSHA256: catalog.SHA256,
+		Benchmarks: []autotune.VerifiedBenchmark{
+			{
+				ModelKey:               "small",
+				ModelID:                "mlx-community/Llama-3.2-3B-Instruct-4bit",
+				SustainedTPS:           20,
+				TTFTMS:                 1000,
+				ArtifactSHA256:         "3975387f249977e5e8bfb7ed0d352f8258ac3d630f961ce1dd952f428ee7216a",
+				CandidateCatalogSHA256: catalog.SHA256,
+			},
+			{
+				ModelKey:               "large",
+				ModelID:                "mlx-community/Qwen3-Coder-30B-A3B-Instruct-4bit",
+				SustainedTPS:           30,
+				TTFTMS:                 1000,
+				SwapDetected:           true,
+				ArtifactSHA256:         "10adb5da9840c8fe0e3036b10f6e2f8f34b41c615f3925b4132302e9cdbab9c0",
+				CandidateCatalogSHA256: catalog.SHA256,
+			},
+		},
+	}
+	allowed := autotune.EvaluateHelloGate(catalog, evidence, "mlx-community/Llama-3.2-3B-Instruct-4bit")
+	if !allowed.Allowed || allowed.MaxAdmittedModelKey != "small" {
+		t.Fatalf("under-tier hello: %+v", allowed)
+	}
+	rejected := autotune.EvaluateHelloGate(catalog, evidence, "mlx-community/Qwen3-Coder-30B-A3B-Instruct-4bit")
+	if rejected.Allowed || rejected.Reason != "autotune_model_cap_exceeded" {
+		t.Fatalf("swapped higher tier raised cap: %+v", rejected)
+	}
+}
+
 func TestEvaluateHelloGateTreatsTPSAndTTFTMissesAsAdvisory(t *testing.T) {
 	t.Parallel()
 	catalog := mustCatalog(t, `{


### PR DESCRIPTION
## Summary

This mirrors the client-side `swap_detected` hard veto in the coordinator autotune admission gate. A swapped benchmark row can no longer establish or raise the maximum admitted model ceiling.

## Validation

- `go test -count=1 ./internal/autotune ./internal/pow ./internal/ws`
- `git diff --check`
- Three-lane Codex audit loop:
  - code: 0 critical / 0 high / 0 medium
  - security: 0 critical / 0 high / 0 medium
  - architect: 0 critical / 0 high / 0 medium

## Audit note

Architect lane carried one LOW non-blocking follow-up: SPEC-032 contract-doc sync should be handled separately so its prose names `swap_detected` consistently with the implementation and SPEC-023.

SPEC-GOVERNANCE-DECLARATION-BEGIN
{
  "schema_version": "spec-pr-governance-v1",
  "behavior_change": "yes",
  "contract_change": "none",
  "specs": ["SPEC-023"],
  "requirements": ["SPEC-023-R001"],
  "authority_domains": ["installer-autotune-policy"],
  "arbitration": ["CODE_BUG"],
  "tests": ["go test -count=1 ./internal/autotune ./internal/pow ./internal/ws", "three-lane code/security/architect audit"],
  "journeys": ["not-required"]
}
SPEC-GOVERNANCE-DECLARATION-END
