### PR TITLE
Decouple Pearl runtime release lane

### DIFF
--- a/.github/workflows/pearl-runtime-release.yml
+++ b/.github/workflows/pearl-runtime-release.yml
@@ -1,0 +1,378 @@
+name: Release Pearl runtime
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Runtime release tag, for example v1.8.66"
+        required: true
+        type: string
+      prerelease:
+        description: "Runtime-only releases are always GitHub prereleases and never latest"
+        required: false
+        default: true
+        type: boolean
+permissions:
+  contents: read
+
+concurrency:
+  group: production-release
+  cancel-in-progress: false
+
+jobs:
+  sign_publish_runtime:
+    name: Sign and publish Pearl runtime release
+    runs-on: macos-15-intel
+    environment: production-release
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout reviewed runtime source
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Verify reviewed runtime source
+        id: release_source
+        shell: bash
+        env:
+          RELEASE_VERSION_INPUT: ${{ github.event.inputs.version }}
+          RELEASE_PRERELEASE_INPUT: "true"
+        run: |
+          set -euo pipefail
+          bash scripts/validate-release-inputs.sh \
+            "$RELEASE_VERSION_INPUT" "$RELEASE_PRERELEASE_INPUT" false
+          tag="$RELEASE_VERSION_INPUT"
+          commit="$(git rev-parse HEAD)"
+          bash scripts/verify-release-source.sh \
+            "$tag" "$commit" origin --require-existing
+          echo "tag=$tag" >> "$GITHUB_OUTPUT"
+          echo "commit=$commit" >> "$GITHUB_OUTPUT"
+          echo "prerelease=$RELEASE_PRERELEASE_INPUT" >> "$GITHUB_OUTPUT"
+
+      - name: Setup Go for Pearl binaries
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16
+        with:
+          go-version-file: phase4-coordinator/go.mod
+          cache-dependency-path: |
+            phase4-coordinator/go.sum
+            phase5-gateway/go.sum
+
+      - name: Select and verify reviewed release toolchain
+        shell: bash
+        run: |
+          set -euo pipefail
+          sudo xcode-select -s /Applications/Xcode_16.4.app/Contents/Developer
+          bash scripts/verify-release-toolchain.sh release-toolchain.json
+
+      - name: Seal OpenSSL 3 for protected runtime signing
+        id: protected_openssl
+        shell: bash
+        env:
+          HOMEBREW_NO_AUTO_UPDATE: "1"
+        run: |
+          set -euo pipefail
+          sealed_bin="$(
+            bash scripts/install-sealed-release-openssl.sh \
+              /private/var/macprovider-openssl-pearl-runtime
+          )"
+          "$sealed_bin" version | grep -E '^OpenSSL 3\.'
+          printf 'bin=%s\n' "$sealed_bin" >> "$GITHUB_OUTPUT"
+
+      - name: Verify protected GitHub release posture before runtime signing
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_POSTURE_TOKEN }}
+        run: bash scripts/verify-github-release-posture.sh "$GITHUB_REPOSITORY" production-release 28995904
+
+      - name: Build Pearl linux-amd64 runtime pair
+        shell: bash
+        run: |
+          set -euo pipefail
+          tag="${{ steps.release_source.outputs.tag }}"
+          (
+            cd phase4-coordinator
+            GOTOOLCHAIN=local CGO_ENABLED=0 GOOS=linux GOARCH=amd64 \
+              go build -mod=readonly -trimpath -buildvcs=true \
+              -ldflags "-s -w -X main.version=$tag" \
+              -o "$GITHUB_WORKSPACE/coordinator-linux-amd64" ./cmd/coordinator
+            GOTOOLCHAIN=local CGO_ENABLED=0 GOOS=linux GOARCH=amd64 \
+              go build -mod=readonly -trimpath -buildvcs=true \
+              -ldflags "-s -w" \
+              -o "$GITHUB_WORKSPACE/coordinator-cli-linux-amd64" ./cmd/coordinator-cli
+          )
+          (
+            cd phase5-gateway
+            GOTOOLCHAIN=local CGO_ENABLED=0 GOOS=linux GOARCH=amd64 \
+              go build -mod=readonly -trimpath -buildvcs=true \
+              -ldflags "-s -w -X main.version=$tag" \
+              -o "$GITHUB_WORKSPACE/gateway-linux-amd64" ./cmd/gateway
+          )
+          file coordinator-linux-amd64 coordinator-cli-linux-amd64 gateway-linux-amd64 | tee pearl-file.txt
+          grep -Eq "coordinator-linux-amd64:[[:space:]]+ELF 64-bit.*x86-64" pearl-file.txt
+          grep -Eq "coordinator-cli-linux-amd64:[[:space:]]+ELF 64-bit.*x86-64" pearl-file.txt
+          grep -Eq "gateway-linux-amd64:[[:space:]]+ELF 64-bit.*x86-64" pearl-file.txt
+          strings coordinator-linux-amd64 > coordinator-linux-amd64.strings
+          strings gateway-linux-amd64 > gateway-linux-amd64.strings
+          grep -Fq "$tag" coordinator-linux-amd64.strings
+          grep -Fq "$tag" gateway-linux-amd64.strings
+          python3 scripts/verify-pearl-go-binaries.py \
+            coordinator-linux-amd64 coordinator-cli-linux-amd64 gateway-linux-amd64
+
+      - name: Sign Pearl runtime metadata and checksums
+        id: assets
+        shell: bash
+        env:
+          MACPROVIDER_RELEASE_SIGNING_KEY_PEM: ${{ secrets.MACPROVIDER_RELEASE_SIGNING_KEY_PEM }}
+          OPENSSL_BIN: ${{ steps.protected_openssl.outputs.bin }}
+        run: |
+          set -euo pipefail
+          tag="${{ steps.release_source.outputs.tag }}"
+          commit="${{ steps.release_source.outputs.commit }}"
+          if [ -z "$MACPROVIDER_RELEASE_SIGNING_KEY_PEM" ]; then
+            echo "MACPROVIDER_RELEASE_SIGNING_KEY_PEM secret is required" >&2
+            exit 1
+          fi
+          release_signing_key="$(mktemp "$RUNNER_TEMP/release-signing-private.XXXXXX.pem")"
+          cleanup_release_signing_key() {
+            rm -f "$release_signing_key"
+          }
+          trap cleanup_release_signing_key EXIT
+          printf "%s\n" "$MACPROVIDER_RELEASE_SIGNING_KEY_PEM" > "$release_signing_key"
+          chmod 600 "$release_signing_key"
+          coordinator_sha="$(shasum -a 256 coordinator-linux-amd64 | awk '{print $1}')"
+          coordinator_cli_sha="$(shasum -a 256 coordinator-cli-linux-amd64 | awk '{print $1}')"
+          gateway_sha="$(shasum -a 256 gateway-linux-amd64 | awk '{print $1}')"
+          RELEASE_TAG="$tag" \
+          RELEASE_COMMIT="$commit" \
+          COORDINATOR_SHA="$coordinator_sha" \
+          COORDINATOR_CLI_SHA="$coordinator_cli_sha" \
+          GATEWAY_SHA="$gateway_sha" \
+          python3 - <<'PY'
+          import json
+          import os
+
+          tag = os.environ["RELEASE_TAG"]
+          rollout = {
+              "mode": "strict_post_migration",
+              "enforce_provider_admission": True,
+              "bridge_duration_s": 0,
+          }
+          metadata = {
+              "schema_version": 1,
+              "release_lane": "pearl_runtime",
+              "repository": "Augustas11/macprovider",
+              "tag": tag,
+              "release_version": tag.removeprefix("v"),
+              "commit": os.environ["RELEASE_COMMIT"],
+              "architecture": "linux-amd64",
+              "provider_admission_rollout": rollout,
+              "components": {
+                  "coordinator": {
+                      "asset": "coordinator-linux-amd64",
+                      "sha256": os.environ["COORDINATOR_SHA"],
+                      "embedded_version": tag,
+                  },
+                  "gateway": {
+                      "asset": "gateway-linux-amd64",
+                      "sha256": os.environ["GATEWAY_SHA"],
+                      "embedded_version": tag,
+                  },
+              },
+              "catalog": None,
+              "operator_artifacts": {
+                  "coordinator_cli": {
+                      "asset": "coordinator-cli-linux-amd64",
+                      "sha256": os.environ["COORDINATOR_CLI_SHA"],
+                  },
+              },
+          }
+          with open("pearl-release.json", "w", encoding="utf-8") as output:
+              json.dump(metadata, output, sort_keys=True, separators=(",", ":"))
+              output.write("\n")
+          PY
+          "$OPENSSL_BIN" dgst -sha256 -sign "$release_signing_key" \
+            -out pearl-release.json.sig pearl-release.json
+          "$OPENSSL_BIN" dgst -sha256 \
+            -verify ops/pearl-updater/release-signing-public.pem \
+            -signature pearl-release.json.sig pearl-release.json
+          release_assets=(
+            coordinator-linux-amd64
+            coordinator-cli-linux-amd64
+            gateway-linux-amd64
+            pearl-release.json
+            pearl-release.json.sig
+          )
+          python3 scripts/build-release-provenance.py \
+            "$tag" "$commit" "$GITHUB_REPOSITORY" \
+            "${{ steps.release_source.outputs.prerelease }}" release-toolchain.json \
+            release-provenance.json "${release_assets[@]}"
+          release_assets+=(release-provenance.json)
+          : > checksums.txt
+          for release_asset in "${release_assets[@]}"; do
+            shasum -a 256 "$release_asset" >> checksums.txt
+          done
+          "$OPENSSL_BIN" dgst -sha256 -sign "$release_signing_key" \
+            -out checksums.txt.sig checksums.txt
+          printf "%s\n" "${release_assets[@]}" > release-assets.txt
+
+      - name: Prepare runtime release notes
+        shell: bash
+        run: |
+          set -euo pipefail
+          tag="${{ steps.release_source.outputs.tag }}"
+          cat > release-notes.md <<EOF
+          # Pearl runtime $tag
+
+          Signed Pearl coordinator/gateway runtime bundle. This release lane
+          intentionally excludes provider app, Malibu.app, catalog, and
+          static-feed assets.
+          EOF
+
+      - name: Create verified draft GitHub release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          OPENSSL_BIN: ${{ steps.protected_openssl.outputs.bin }}
+          RELEASE_POSTURE_TOKEN: ${{ secrets.RELEASE_POSTURE_TOKEN }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          tag="${{ steps.release_source.outputs.tag }}"
+          commit="${{ steps.release_source.outputs.commit }}"
+          bash scripts/verify-release-source.sh "$tag" "$commit" origin --require-existing
+          GH_TOKEN="$RELEASE_POSTURE_TOKEN" \
+            bash scripts/verify-github-release-posture.sh \
+              "$GITHUB_REPOSITORY" production-release 28995904
+          release_assets=()
+          while IFS= read -r release_asset; do
+            [ -n "$release_asset" ] && release_assets+=("$release_asset")
+          done < release-assets.txt
+          bash scripts/verify-release-checksums.sh \
+            --openssl "$OPENSSL_BIN" \
+            checksums.txt checksums.txt.sig release-provenance.json \
+            "$GITHUB_REPOSITORY" "$tag" "$commit" \
+            "${release_assets[@]}"
+          gh release create "$tag" \
+            "${release_assets[@]}" \
+            checksums.txt \
+            checksums.txt.sig \
+            --title "Pearl runtime $tag" \
+            --notes-file release-notes.md \
+            --target "$commit" \
+            --verify-tag \
+            --draft
+          gh release view "$tag" \
+            --json databaseId,isDraft,tagName,targetCommitish > draft-release-cli.json
+          python3 scripts/verify-release-draft-identity.py cli \
+            draft-release-cli.json "$tag" "$commit" > draft-release-id.txt
+
+      - name: Publish only the revalidated numeric draft
+        env:
+          GH_TOKEN: ${{ github.token }}
+          OPENSSL_BIN: ${{ steps.protected_openssl.outputs.bin }}
+          PRERELEASE_INPUT: ${{ steps.release_source.outputs.prerelease }}
+          RELEASE_POSTURE_TOKEN: ${{ secrets.RELEASE_POSTURE_TOKEN }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          tag="${{ steps.release_source.outputs.tag }}"
+          commit="${{ steps.release_source.outputs.commit }}"
+          release_id="$(cat draft-release-id.txt)"
+          [[ "$release_id" =~ ^[1-9][0-9]*$ ]] || {
+            echo "::error::captured draft release id is invalid" >&2
+            exit 1
+          }
+          case "$PRERELEASE_INPUT" in
+            true|false) make_latest=false ;;
+            *) echo "::error::validated prerelease state was lost" >&2; exit 1 ;;
+          esac
+          release_assets=()
+          while IFS= read -r release_asset; do
+            [ -n "$release_asset" ] && release_assets+=("$release_asset")
+          done < release-assets.txt
+          bash scripts/verify-release-source.sh "$tag" "$commit" origin --require-existing
+          GH_TOKEN="$RELEASE_POSTURE_TOKEN" \
+            bash scripts/verify-github-release-posture.sh \
+              "$GITHUB_REPOSITORY" production-release 28995904
+          bash scripts/verify-release-checksums.sh \
+            --openssl "$OPENSSL_BIN" \
+            checksums.txt checksums.txt.sig release-provenance.json \
+            "$GITHUB_REPOSITORY" "$tag" "$commit" \
+            "${release_assets[@]}"
+          gh api -H 'X-GitHub-Api-Version: 2026-03-10' \
+            "repos/$GITHUB_REPOSITORY/releases/$release_id" > final-draft-api.json
+          python3 scripts/verify-release-draft-identity.py api \
+            final-draft-api.json "$tag" "$commit" --release-id "$release_id" >/dev/null
+          python3 scripts/capture-release-publication.py --draft --runtime-only \
+            --notes-file release-notes.md --expected-title "Pearl runtime $tag" \
+            final-draft-api.json release-provenance.json final-draft-manifest.json \
+            "${release_assets[@]}" checksums.txt checksums.txt.sig
+          gh api -H 'X-GitHub-Api-Version: 2026-03-10' \
+            "repos/$GITHUB_REPOSITORY/releases/latest" > stable-latest-before.json
+          python3 - stable-latest-before.json <<'PY'
+          import json
+          import pathlib
+          import sys
+
+          latest = json.loads(pathlib.Path(sys.argv[1]).read_text(encoding="utf-8"))
+          latest_id = latest.get("id")
+          if type(latest_id) is not int or latest_id <= 0:
+              raise SystemExit("stable latest endpoint before publication did not return a positive release id")
+          PY
+          gh api --method PATCH -H 'X-GitHub-Api-Version: 2026-03-10' \
+            "repos/$GITHUB_REPOSITORY/releases/$release_id" \
+            -F draft=false \
+            -F prerelease=true \
+            -f make_latest="$make_latest" > published-release-api.json
+          gh api -H 'X-GitHub-Api-Version: 2026-03-10' \
+            "repos/$GITHUB_REPOSITORY/releases/$release_id" > immutable-release-by-id.json
+          gh api -H 'X-GitHub-Api-Version: 2026-03-10' \
+            "repos/$GITHUB_REPOSITORY/releases/tags/$tag" > immutable-release-by-tag.json
+          gh api -H 'X-GitHub-Api-Version: 2026-03-10' \
+            "repos/$GITHUB_REPOSITORY/releases/latest" > stable-latest-after.json
+          python3 scripts/capture-release-publication.py --runtime-only \
+            --notes-file release-notes.md --expected-title "Pearl runtime $tag" \
+            immutable-release-by-id.json release-provenance.json publication-manifest-by-id.json \
+            "${release_assets[@]}" checksums.txt checksums.txt.sig
+          python3 scripts/capture-release-publication.py --runtime-only \
+            --notes-file release-notes.md --expected-title "Pearl runtime $tag" \
+            immutable-release-by-tag.json release-provenance.json publication-manifest-by-tag.json \
+            "${release_assets[@]}" checksums.txt checksums.txt.sig
+          cmp final-draft-manifest.json publication-manifest-by-id.json
+          cmp final-draft-manifest.json publication-manifest-by-tag.json
+          python3 - "$release_id" "$PRERELEASE_INPUT" \
+            immutable-release-by-id.json immutable-release-by-tag.json \
+            stable-latest-before.json stable-latest-after.json <<'PY'
+          import json
+          import pathlib
+          import sys
+
+          release_id = int(sys.argv[1])
+          prerelease = sys.argv[2] == "true"
+          by_id = json.loads(pathlib.Path(sys.argv[3]).read_text(encoding="utf-8"))
+          by_tag = json.loads(pathlib.Path(sys.argv[4]).read_text(encoding="utf-8"))
+          latest_before = json.loads(pathlib.Path(sys.argv[5]).read_text(encoding="utf-8"))
+          latest_after = json.loads(pathlib.Path(sys.argv[6]).read_text(encoding="utf-8"))
+          for label, release in (("numeric", by_id), ("tag", by_tag)):
+              if release.get("id") != release_id:
+                  raise SystemExit(f"{label} release lookup differs from captured numeric id")
+              if release.get("draft") is not False or release.get("immutable") is not True:
+                  raise SystemExit(f"{label} release is not public and immutable")
+              if release.get("prerelease") is not prerelease:
+                  raise SystemExit(f"{label} release prerelease state differs from validated input")
+          if latest_after.get("id") == release_id:
+              raise SystemExit("runtime-only release unexpectedly resolves through the stable latest endpoint")
+          latest_before_id = latest_before.get("id")
+          latest_after_id = latest_after.get("id")
+          if type(latest_before_id) is not int or latest_before_id <= 0:
+              raise SystemExit("stable latest endpoint before publication did not return a positive release id")
+          if type(latest_after_id) is not int or latest_after_id <= 0:
+              raise SystemExit("stable latest endpoint after publication did not return a positive release id")
+          if latest_before_id != latest_after_id:
+              raise SystemExit("runtime-only release changed the stable latest endpoint")
+          PY
+          scripts/verify-pearl-runtime-release.sh \
+            --tag "$tag" \
+            --expected-commit "$commit" \
+            --repository "$GITHUB_REPOSITORY"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1408,6 +1408,7 @@ jobs:
               raise SystemExit("unsupported provider admission rollout policy")
           metadata = {
               "schema_version": 1,
+              "release_lane": "pearl_runtime_catalog",
               "repository": "Augustas11/macprovider",
               "tag": tag,
               "release_version": tag.removeprefix("v"),

--- a/ops/pearl-updater/macprovider-pearl-update
+++ b/ops/pearl-updater/macprovider-pearl-update
@@ -78,6 +78,7 @@ AUXILIARY_UNITS = (
     "stats-billing-mirror.service",
 )
 COORDINATOR_ASSET = "coordinator-linux-amd64"
+COORDINATOR_CLI_ASSET = "coordinator-cli-linux-amd64"
 GATEWAY_ASSET = "gateway-linux-amd64"
 CATALOG_ASSETS = (
     "release.json",
@@ -94,6 +95,13 @@ CONTROL_ASSETS = (
     "checksums.txt",
     "checksums.txt.sig",
 )
+RUNTIME_ASSETS = (
+    COORDINATOR_ASSET,
+    COORDINATOR_CLI_ASSET,
+    GATEWAY_ASSET,
+)
+RELEASE_LANE_RUNTIME = "pearl_runtime"
+RELEASE_LANE_RUNTIME_WITH_CATALOG = "pearl_runtime_catalog"
 SEMVER_RE = re.compile(r"^(?:v)?(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$")
 LEGACY_GIT_DESCRIBE_RE = re.compile(
     r"^v?(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)-([1-9][0-9]*)-g([0-9a-f]{7,40})$"
@@ -291,9 +299,14 @@ class Release:
     provider_advertised_version: str
     coordinator: Component
     gateway: Component
-    catalog: CatalogRelease
+    catalog: CatalogRelease | None
     provider_admission_rollout: ProviderAdmissionRollout
     directory: Path
+    release_lane: str = RELEASE_LANE_RUNTIME_WITH_CATALOG
+
+    @property
+    def has_catalog(self) -> bool:
+        return self.catalog is not None
 
 
 @dataclasses.dataclass(frozen=True)
@@ -333,9 +346,10 @@ class InstalledRelease:
             "commit": release.commit,
             "coordinator_sha256": release.coordinator.sha256,
             "gateway_sha256": release.gateway.sha256,
-            "catalog_release_id": release.catalog.release_id,
-            "catalog_policy_version": release.catalog.policy_version,
         }
+        if release.catalog is not None:
+            expected["catalog_release_id"] = release.catalog.release_id
+            expected["catalog_policy_version"] = release.catalog.policy_version
         return all(self.durable.get(key) == value for key, value in expected.items())
 
 
@@ -1022,21 +1036,28 @@ class Updater:
         previous_advertised = (
             self.config_update.previous_version if self.config_update is not None else str(previous)
         )
+        release_record: dict[str, object] = {
+            "tag": release.tag,
+            "version": str(release.version),
+            "commit": release.commit,
+            "provider_advertised_version": self.release_identity(release).advertised_version,
+            "coordinator_sha256": release.coordinator.sha256,
+            "gateway_sha256": release.gateway.sha256,
+            "provider_admission_rollout": dataclasses.asdict(release.provider_admission_rollout),
+            "release_lane": release.release_lane,
+        }
+        if release.catalog is not None:
+            release_record.update(
+                {
+                    "catalog_release_id": release.catalog.release_id,
+                    "catalog_policy_version": release.catalog.policy_version,
+                    "catalog_files": dict(release.catalog.files),
+                }
+            )
         self.journal = {
             "schema_version": JOURNAL_SCHEMA_VERSION,
             "phase": "prepared",
-            "release": {
-                "tag": release.tag,
-                "version": str(release.version),
-                "commit": release.commit,
-                "provider_advertised_version": release.provider_advertised_version,
-                "coordinator_sha256": release.coordinator.sha256,
-                "gateway_sha256": release.gateway.sha256,
-                "catalog_release_id": release.catalog.release_id,
-                "catalog_policy_version": release.catalog.policy_version,
-                "catalog_files": dict(release.catalog.files),
-                "provider_admission_rollout": dataclasses.asdict(release.provider_admission_rollout),
-            },
+            "release": release_record,
             "previous_version": str(previous),
             "previous_advertised_version": previous_advertised,
             "buyer_canary_mode": self.config.buyer_canary_mode,
@@ -1218,11 +1239,12 @@ class Updater:
 
     def acquire_release(self, work: Path, source_dir: Path | None, requested_tag: str | None) -> Release:
         if source_dir is not None:
-            for asset in (*CONTROL_ASSETS, COORDINATOR_ASSET, GATEWAY_ASSET, *CATALOG_ASSETS):
+            for asset in (*CONTROL_ASSETS, *RUNTIME_ASSETS, *CATALOG_ASSETS):
                 source = source_dir / asset
-                if not source.is_file():
+                if asset in (*CONTROL_ASSETS, *RUNTIME_ASSETS) and not source.is_file():
                     raise UpdateError(f"test source missing asset: {asset}")
-                shutil.copyfile(source, work / asset)
+                if source.is_file():
+                    shutil.copyfile(source, work / asset)
             return self.verify_release(work, requested_tag)
 
         tags = [requested_tag] if requested_tag else self.release_tags()
@@ -1242,11 +1264,23 @@ class Updater:
                 continue
             for asset in CONTROL_ASSETS[1:]:
                 self.download(f"{base}/{asset}", candidate / asset)
-            for asset in (COORDINATOR_ASSET, GATEWAY_ASSET, *CATALOG_ASSETS):
+            for asset in RUNTIME_ASSETS:
                 self.download(f"{base}/{asset}", candidate / asset)
-            return self.verify_release(candidate, tag)
+            try:
+                metadata = json.loads((candidate / "pearl-release.json").read_text(encoding="utf-8"))
+            except (ValueError, OSError) as exc:
+                raise UpdateError("release metadata is invalid JSON") from exc
+            if isinstance(metadata, dict) and isinstance(metadata.get("catalog"), dict):
+                for asset in CATALOG_ASSETS:
+                    self.download(f"{base}/{asset}", candidate / asset)
+            release = self.verify_release(candidate, tag)
+            if requested_tag is None and release.release_lane == RELEASE_LANE_RUNTIME:
+                self.audit("release_skipped", "runtime_only_requires_explicit_tag", candidate=tag)
+                shutil.rmtree(candidate)
+                continue
+            return release
         self.audit("release_selection", "no_eligible_release")
-        raise NoEligibleRelease("no signed Pearl release with the required artifact set was found")
+        raise NoEligibleRelease("no signed Pearl runtime release with the required artifact set was found")
 
     def verify_release(self, directory: Path, expected_tag: str | None) -> Release:
         checksums_path = directory / "checksums.txt"
@@ -1257,12 +1291,10 @@ class Updater:
         for name in (
             "pearl-release.json",
             "pearl-release.json.sig",
-            COORDINATOR_ASSET,
-            GATEWAY_ASSET,
-            *CATALOG_ASSETS,
+            *RUNTIME_ASSETS,
         ):
             if name not in checksums:
-                raise UpdateError(f"signed checksums omit required asset: {name}")
+                raise UpdateError(f"signed checksums omit required Pearl runtime asset: {name}")
             if sha256_file(directory / name) != checksums[name]:
                 raise UpdateError(f"checksum mismatch for {name}")
         try:
@@ -1270,6 +1302,23 @@ class Updater:
         except (ValueError, OSError) as exc:
             raise UpdateError("release metadata is invalid JSON") from exc
         release = self.parse_metadata(metadata, directory)
+        operator_artifacts = metadata.get("operator_artifacts")
+        coordinator_cli = operator_artifacts.get("coordinator_cli") if isinstance(operator_artifacts, dict) else None
+        if not isinstance(coordinator_cli, dict):
+            raise UpdateError("release metadata coordinator CLI artifact is missing")
+        coordinator_cli_sha = coordinator_cli.get("sha256")
+        if coordinator_cli.get("asset") != COORDINATOR_CLI_ASSET:
+            raise UpdateError("release metadata coordinator CLI asset mismatch")
+        if not isinstance(coordinator_cli_sha, str) or not SHA256_RE.fullmatch(coordinator_cli_sha):
+            raise UpdateError("release metadata coordinator CLI checksum invalid")
+        if coordinator_cli_sha != checksums[COORDINATOR_CLI_ASSET]:
+            raise UpdateError("metadata/checksums disagreement for coordinator-cli-linux-amd64")
+        if release.catalog is not None:
+            for name in CATALOG_ASSETS:
+                if name not in checksums:
+                    raise UpdateError(f"signed checksums omit required catalog/feed asset: {name}")
+                if sha256_file(directory / name) != checksums[name]:
+                    raise UpdateError(f"checksum mismatch for {name}")
         if expected_tag and release.tag != expected_tag:
             raise UpdateError(f"signed metadata tag {release.tag} does not match selected tag {expected_tag}")
         for component in (release.coordinator, release.gateway):
@@ -1284,17 +1333,29 @@ class Updater:
                 asset=component.asset,
                 sha256=component.sha256,
             )
-        self.verify_catalog_release(release)
+        validate_elf_amd64(directory / COORDINATOR_CLI_ASSET)
+        self.audit(
+            "release_component_verified",
+            "static_success",
+            candidate=release.tag,
+            asset=COORDINATOR_CLI_ASSET,
+            sha256=coordinator_cli_sha,
+        )
+        if release.catalog is not None:
+            self.verify_catalog_release(release)
         self.audit(
             "release_control_set_verified",
             "success",
             candidate=release.tag,
             commit=release.commit,
             provider_advertised_version=release.provider_advertised_version,
+            release_lane=release.release_lane,
         )
         return release
 
     def verify_catalog_release(self, release: Release) -> None:
+        if release.catalog is None:
+            raise UpdateError("Pearl runtime release is not catalog-bound")
         catalog = release.catalog
         manifest_path = release.directory / "release.json"
         try:
@@ -1453,20 +1514,21 @@ class Updater:
             self._assert_candidate_validation_file(destination, executable=True)
             if sha256_file(destination) != component.sha256:
                 raise UpdateError(f"candidate staging checksum mismatch: {component.asset}")
-        for name in CATALOG_ASSETS:
-            source = release.directory / name
-            self._trusted_regular_file(source, f"verified catalog asset {name}")
-            if sha256_file(source) != release.catalog.files[name]:
-                raise UpdateError(f"verified catalog asset changed before staging: {name}")
-            destination = validation / name
-            self.atomic_replace(
-                source,
-                destination,
-                uid=self.trusted_uid,
-                gid=self.candidate_gid,
-                mode=0o640,
-            )
-            self._assert_candidate_validation_file(destination, executable=False)
+        if release.catalog is not None:
+            for name in CATALOG_ASSETS:
+                source = release.directory / name
+                self._trusted_regular_file(source, f"verified catalog asset {name}")
+                if sha256_file(source) != release.catalog.files[name]:
+                    raise UpdateError(f"verified catalog asset changed before staging: {name}")
+                destination = validation / name
+                self.atomic_replace(
+                    source,
+                    destination,
+                    uid=self.trusted_uid,
+                    gid=self.candidate_gid,
+                    mode=0o640,
+                )
+                self._assert_candidate_validation_file(destination, executable=False)
         _fsync_directory(validation)
         self._assert_candidate_validation_directory(validation)
         return dataclasses.replace(release, directory=validation)
@@ -1493,7 +1555,6 @@ class Updater:
             raise UpdateError("release metadata repository/architecture mismatch")
         tag = metadata.get("tag")
         commit = metadata.get("commit")
-        advertised = metadata.get("provider_advertised_version")
         channel = metadata.get("channel", "production")
         if not isinstance(tag, str) or not SEMVER_RE.fullmatch(tag):
             raise UpdateError("release metadata tag is invalid")
@@ -1502,9 +1563,19 @@ class Updater:
             raise UpdateError("release metadata version/tag mismatch")
         if not isinstance(commit, str) or not COMMIT_RE.fullmatch(commit):
             raise UpdateError("release metadata commit is invalid")
-        if not isinstance(advertised, str):
-            raise UpdateError("release metadata advertised version is missing")
-        SemVer.parse(advertised)
+        release_lane = metadata.get("release_lane", RELEASE_LANE_RUNTIME_WITH_CATALOG)
+        if release_lane not in (RELEASE_LANE_RUNTIME, RELEASE_LANE_RUNTIME_WITH_CATALOG):
+            raise UpdateError("release metadata lane is invalid")
+        advertised_raw = metadata.get("provider_advertised_version")
+        if release_lane == RELEASE_LANE_RUNTIME:
+            if advertised_raw is not None:
+                raise UpdateError("runtime-only Pearl release metadata must not carry provider advertised version")
+            advertised = str(version)
+        else:
+            if not isinstance(advertised_raw, str):
+                raise UpdateError("release metadata advertised version is missing")
+            SemVer.parse(advertised_raw)
+            advertised = advertised_raw
         if channel == "private_acceptance":
             if not self.config.allow_private_acceptance:
                 raise UpdateError(
@@ -1513,7 +1584,7 @@ class Updater:
                 )
         elif channel not in ("production",):
             raise UpdateError("release metadata channel is invalid")
-        elif advertised != str(version):
+        elif release_lane != RELEASE_LANE_RUNTIME and advertised != str(version):
             raise UpdateError("release metadata advertised version must match the release version")
         components = metadata.get("components")
         if not isinstance(components, dict):
@@ -1530,27 +1601,33 @@ class Updater:
                 raise UpdateError(f"release metadata {name} embedded version invalid")
             return Component(required_asset, digest, str(embedded))
 
+        catalog_release: CatalogRelease | None = None
         catalog = metadata.get("catalog")
-        if not isinstance(catalog, dict):
-            raise UpdateError("release metadata catalog is missing")
-        release_id = catalog.get("release_id")
-        policy_version = catalog.get("policy_version")
-        files = catalog.get("files")
-        if (
-            not isinstance(release_id, str)
-            or not re.fullmatch(r"[A-Za-z0-9][A-Za-z0-9._-]{0,127}", release_id)
-            or not isinstance(policy_version, str)
-            or not re.fullmatch(r"[A-Za-z0-9][A-Za-z0-9._-]{0,127}", policy_version)
-            or not isinstance(files, dict)
-            or set(files) != set(CATALOG_ASSETS)
-        ):
-            raise UpdateError("release metadata catalog identity/files are invalid")
-        catalog_files: dict[str, str] = {}
-        for name in CATALOG_ASSETS:
-            digest = files.get(name)
-            if not isinstance(digest, str) or not SHA256_RE.fullmatch(digest):
-                raise UpdateError(f"release metadata catalog checksum invalid for {name}")
-            catalog_files[name] = digest
+        if release_lane == RELEASE_LANE_RUNTIME:
+            if catalog not in (None, {}):
+                raise UpdateError("runtime-only Pearl release metadata must not bind catalog/feed assets")
+        else:
+            if not isinstance(catalog, dict):
+                raise UpdateError("release metadata catalog is missing")
+            release_id = catalog.get("release_id")
+            policy_version = catalog.get("policy_version")
+            files = catalog.get("files")
+            if (
+                not isinstance(release_id, str)
+                or not re.fullmatch(r"[A-Za-z0-9][A-Za-z0-9._-]{0,127}", release_id)
+                or not isinstance(policy_version, str)
+                or not re.fullmatch(r"[A-Za-z0-9][A-Za-z0-9._-]{0,127}", policy_version)
+                or not isinstance(files, dict)
+                or set(files) != set(CATALOG_ASSETS)
+            ):
+                raise UpdateError("release metadata catalog identity/files are invalid")
+            catalog_files: dict[str, str] = {}
+            for name in CATALOG_ASSETS:
+                digest = files.get(name)
+                if not isinstance(digest, str) or not SHA256_RE.fullmatch(digest):
+                    raise UpdateError(f"release metadata catalog checksum invalid for {name}")
+                catalog_files[name] = digest
+            catalog_release = CatalogRelease(release_id, policy_version, catalog_files)
 
         rollout = metadata.get("provider_admission_rollout")
         rollout_shape_valid = (
@@ -1572,6 +1649,8 @@ class Updater:
         )
         if not bridge_rollout and not strict_rollout:
             raise UpdateError("release metadata provider-admission rollout policy is invalid")
+        if release_lane == RELEASE_LANE_RUNTIME and not strict_rollout:
+            raise UpdateError("runtime-only Pearl release metadata must not bind provider admission bridge policy")
 
         return Release(
             tag,
@@ -1580,13 +1659,14 @@ class Updater:
             advertised,
             component("coordinator", COORDINATOR_ASSET),
             component("gateway", GATEWAY_ASSET),
-            CatalogRelease(release_id, policy_version, catalog_files),
+            catalog_release,
             ProviderAdmissionRollout(
                 rollout["mode"],
                 rollout["enforce_provider_admission"],
                 rollout["bridge_duration_s"],
             ),
             directory,
+            release_lane,
         )
 
     def revoked_versions(self) -> set[SemVer]:
@@ -1708,14 +1788,17 @@ class Updater:
 
     def assess_candidate(self, release: Release) -> tuple[SemVer, str]:
         current, decision = self.eligibility(release)
-        self._preflight_legacy_tier2_cutover()
-        if _path_entry_exists(self._legacy_tier2_catalog_path()):
+        if release.catalog is not None:
+            self._preflight_legacy_tier2_cutover()
+        if release.catalog is not None and _path_entry_exists(self._legacy_tier2_catalog_path()):
             if decision != "repair_pair" or release.version != current:
                 raise UpdateError("legacy Tier-2 cutover requires same-version repair_pair before upgrade")
         self.verify_candidate_versions(release)
         return current, decision
 
     def installed_catalog_is_coherent(self, release: Release) -> bool:
+        if release.catalog is None:
+            return True
         catalog_root = self.install_root / "autotune"
         releases = catalog_root / "releases"
         current = catalog_root / "current"
@@ -2312,7 +2395,7 @@ class Updater:
                 effective_model_hash_legacy_until = model_hash_legacy_until
         if not located:
             raise UpdateError("effective coordinator configuration has no advertised binary version field")
-        if not tier2_catalog_owners:
+        if release.catalog is not None and not tier2_catalog_owners:
             raise UpdateError("effective coordinator configuration has no tier2.catalog_path field")
         if effective_require_hash_verified not in ("false", "true"):
             raise UpdateError("effective tier2.require_hash_verified must be explicitly false or true")
@@ -2323,46 +2406,53 @@ class Updater:
             raise UpdateError("enforced hash verification cannot retain the model hash algorithm legacy bridge")
         target, index, match, lines = located[-1]
         previous = next(value for value in match.groups()[1:4] if value is not None)
-        lines[index] = f'{match.group(1)}"{release.provider_advertised_version}"{match.group(5)}{match.group(6) or ""}'
         payloads = dict(config_texts)
-        if self.config.provider_admission_policy != release.provider_admission_rollout.mode:
-            raise UpdateError("signed provider-admission rollout policy does not match updater policy")
-        rollout = release.provider_admission_rollout
         bridge_deadline: str | None = None
-        if rollout.mode == "bridge_required":
-            bridge_budget = rollout.bridge_duration_s
-            required_budget = (
-                self.config.provider_recovery_timeout_s
-                + self.config.service_health_timeout_s
-                + self.config.minimum_bridge_remaining_s
+        next_version = previous
+        if release.catalog is not None:
+            lines[index] = f'{match.group(1)}"{release.provider_advertised_version}"{match.group(5)}{match.group(6) or ""}'
+            next_version = release.provider_advertised_version
+            if self.config.provider_admission_policy != release.provider_admission_rollout.mode:
+                raise UpdateError("signed provider-admission rollout policy does not match updater policy")
+            rollout = release.provider_admission_rollout
+            if rollout.mode == "bridge_required":
+                bridge_budget = rollout.bridge_duration_s
+                required_budget = (
+                    self.config.provider_recovery_timeout_s
+                    + self.config.service_health_timeout_s
+                    + self.config.minimum_bridge_remaining_s
+                )
+                if bridge_budget <= required_budget:
+                    raise UpdateError("signed provider-admission bridge duration is below the recovery safety budget")
+                bridge_deadline = (
+                    datetime.datetime.now(datetime.timezone.utc)
+                    + datetime.timedelta(seconds=bridge_budget)
+                ).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+            payloads[target] = self._set_yaml_section_scalars(
+                "".join(lines),
+                target,
+                "autotune",
+                {
+                    "enforce_provider_admission": "true" if rollout.enforce_provider_admission else "false",
+                    "provider_admission_bridge_deadline": (
+                        json.dumps(bridge_deadline) if bridge_deadline is not None else None
+                    ),
+                },
             )
-            if bridge_budget <= required_budget:
-                raise UpdateError("signed provider-admission bridge duration is below the recovery safety budget")
-            bridge_deadline = (
-                datetime.datetime.now(datetime.timezone.utc)
-                + datetime.timedelta(seconds=bridge_budget)
-            ).replace(microsecond=0).isoformat().replace("+00:00", "Z")
-        payloads[target] = self._set_yaml_section_scalars(
-            "".join(lines),
-            target,
-            "autotune",
-            {
-                "enforce_provider_admission": "true" if rollout.enforce_provider_admission else "false",
-                "provider_admission_bridge_deadline": (
-                    json.dumps(bridge_deadline) if bridge_deadline is not None else None
-                ),
-            },
-        )
-        catalog_target, previous_catalog_path = tier2_catalog_owners[-1]
-        next_catalog_path = str(self._current_tier2_catalog_path())
-        payloads[catalog_target] = self._set_yaml_section_scalars(
-            payloads[catalog_target],
-            catalog_target,
-            "tier2",
-            {
-                "catalog_path": next_catalog_path,
-            },
-        )
+        catalog_target: Path | None = None
+        previous_catalog_path: str | None = None
+        next_catalog_path: str | None = None
+        if release.catalog is not None:
+            catalog_target, previous_catalog_path = tier2_catalog_owners[-1]
+            next_catalog_path = str(self._current_tier2_catalog_path())
+            payloads[catalog_target] = self._set_yaml_section_scalars(
+                payloads[catalog_target],
+                catalog_target,
+                "tier2",
+                {
+                    "catalog_path": next_catalog_path,
+                },
+            )
         staged_configs: dict[Path, Path] = {}
         for config_index, path in enumerate(config_paths):
             payload = payloads[path]
@@ -2395,7 +2485,7 @@ class Updater:
             )
             if candidate_require_hash is not None:
                 staged_require_hash_verified = candidate_require_hash
-        if staged_catalog_path != next_catalog_path:
+        if release.catalog is not None and staged_catalog_path != next_catalog_path:
             raise UpdateError("staged effective tier2.catalog_path is not the release-bound current catalog path")
         if staged_require_hash_verified != effective_require_hash_verified:
             raise UpdateError("staged effective tier2.require_hash_verified must preserve the live enforcement state")
@@ -2426,10 +2516,10 @@ class Updater:
             staged=staged,
             original_sha256=config_hashes[target],
             previous_version=previous,
-            next_version=release.provider_advertised_version,
+            next_version=next_version,
             catalog_target=catalog_target,
-            catalog_staged=staged_configs[catalog_target],
-            catalog_original_sha256=config_hashes[catalog_target],
+            catalog_staged=staged_configs[catalog_target] if catalog_target is not None else None,
+            catalog_original_sha256=config_hashes[catalog_target] if catalog_target is not None else None,
             previous_catalog_path=previous_catalog_path,
             next_catalog_path=next_catalog_path,
         )
@@ -2440,12 +2530,15 @@ class Updater:
             candidate=release.tag,
             target=str(target),
             previous_version=previous,
-            next_version=release.provider_advertised_version,
-            catalog_target=str(catalog_target),
-            previous_catalog_path=previous_catalog_path,
-            next_catalog_path=next_catalog_path,
-            provider_admission_policy=release.provider_admission_rollout.mode,
+            next_version=next_version,
+            catalog_target=str(catalog_target) if catalog_target is not None else "",
+            previous_catalog_path=previous_catalog_path or "",
+            next_catalog_path=next_catalog_path or "",
+            provider_admission_policy=(
+                release.provider_admission_rollout.mode if release.catalog is not None else "preserved"
+            ),
             provider_admission_bridge_deadline=bridge_deadline,
+            release_lane=release.release_lane,
         )
         return update
 
@@ -3578,50 +3671,51 @@ class Updater:
             self._durable_copy(current_state, tx / "previous-current-release.json")
             state_manifest["sha256"] = sha256_file(tx / "previous-current-release.json")
         self._write_json(tx / "state-manifest.json", state_manifest)
-        catalog_root = self.install_root / "autotune"
-        current = catalog_root / "current"
-        previous = catalog_root / ".previous-target"
-        current_target: str | None = None
-        if _path_entry_exists(current):
-            current_info = current.lstat()
-            if not stat.S_ISLNK(current_info.st_mode):
-                raise UpdateError("catalog current pointer is not a symlink")
-            current_target = os.readlink(current)
-            self._validate_catalog_target(current_target)
-        previous_target: str | None = None
-        if _path_entry_exists(previous):
-            previous_target = _read_trusted_text(
-                previous,
-                "catalog previous pointer",
-                trusted_uid=self.trusted_uid,
-            ).strip()
-            if previous_target:
-                self._validate_catalog_target(previous_target)
-        candidate_directory_name = self._catalog_release_directory_name(release)
-        candidate_path = catalog_root / "releases" / candidate_directory_name
-        legacy_tier2 = self.install_root / "tier2-catalog.json"
-        legacy_tier2_manifest: dict[str, object] = {"existed": _path_entry_exists(legacy_tier2)}
-        if legacy_tier2_manifest["existed"]:
-            legacy_info = self._trusted_regular_file(legacy_tier2, "legacy Tier-2 catalog")
-            self._durable_copy(legacy_tier2, tx / "previous-tier2-catalog.json")
-            legacy_tier2_manifest.update(
-                {
-                    "sha256": sha256_file(tx / "previous-tier2-catalog.json"),
-                    "uid": legacy_info.st_uid,
-                    "gid": legacy_info.st_gid,
-                    "mode": stat.S_IMODE(legacy_info.st_mode),
-                }
-            )
-        self._write_json(
-            tx / "catalog-manifest.json",
-            {
+        catalog_manifest: dict[str, object] = {"owns_catalog": False}
+        if release.catalog is not None:
+            catalog_root = self.install_root / "autotune"
+            current = catalog_root / "current"
+            previous = catalog_root / ".previous-target"
+            current_target: str | None = None
+            if _path_entry_exists(current):
+                current_info = current.lstat()
+                if not stat.S_ISLNK(current_info.st_mode):
+                    raise UpdateError("catalog current pointer is not a symlink")
+                current_target = os.readlink(current)
+                self._validate_catalog_target(current_target)
+            previous_target: str | None = None
+            if _path_entry_exists(previous):
+                previous_target = _read_trusted_text(
+                    previous,
+                    "catalog previous pointer",
+                    trusted_uid=self.trusted_uid,
+                ).strip()
+                if previous_target:
+                    self._validate_catalog_target(previous_target)
+            candidate_directory_name = self._catalog_release_directory_name(release)
+            candidate_path = catalog_root / "releases" / candidate_directory_name
+            legacy_tier2 = self.install_root / "tier2-catalog.json"
+            legacy_tier2_manifest: dict[str, object] = {"existed": _path_entry_exists(legacy_tier2)}
+            if legacy_tier2_manifest["existed"]:
+                legacy_info = self._trusted_regular_file(legacy_tier2, "legacy Tier-2 catalog")
+                self._durable_copy(legacy_tier2, tx / "previous-tier2-catalog.json")
+                legacy_tier2_manifest.update(
+                    {
+                        "sha256": sha256_file(tx / "previous-tier2-catalog.json"),
+                        "uid": legacy_info.st_uid,
+                        "gid": legacy_info.st_gid,
+                        "mode": stat.S_IMODE(legacy_info.st_mode),
+                    }
+                )
+            catalog_manifest = {
+                "owns_catalog": True,
                 "current_target": current_target,
                 "previous_target": previous_target,
                 "candidate_existed": _path_entry_exists(candidate_path),
                 "candidate_release_id": candidate_directory_name,
                 "legacy_tier2": legacy_tier2_manifest,
-            },
-        )
+            }
+        self._write_json(tx / "catalog-manifest.json", catalog_manifest)
         db_dir = tx / "databases"
         db_dir.mkdir(mode=0o700)
         manifest = []
@@ -3711,6 +3805,8 @@ class Updater:
 
     @staticmethod
     def _catalog_release_content_digest(release: Release) -> str:
+        if release.catalog is None:
+            raise UpdateError("Pearl runtime release is not catalog-bound")
         digest = hashlib.sha256()
         for name in CATALOG_ASSETS:
             asset_digest = release.catalog.files.get(name, "")
@@ -3724,6 +3820,8 @@ class Updater:
 
     @staticmethod
     def _catalog_release_directory_name(release: Release) -> str:
+        if release.catalog is None:
+            raise UpdateError("Pearl runtime release is not catalog-bound")
         manifest_digest = release.catalog.files.get("release.json", "")
         if not SHA256_RE.fullmatch(manifest_digest):
             raise UpdateError("catalog release manifest checksum is invalid")
@@ -3791,6 +3889,8 @@ class Updater:
         _fsync_directory(catalog_root)
 
     def install_catalog(self, release: Release) -> None:
+        if release.catalog is None:
+            raise UpdateError("Pearl runtime release is not catalog-bound")
         self._preflight_legacy_tier2_cutover()
         catalog_root = self.install_root / "autotune"
         releases = catalog_root / "releases"
@@ -3895,7 +3995,8 @@ class Updater:
         self.audit("release_component_installed", "success", candidate=release.tag, component="coordinator")
         self.atomic_install(release.directory / release.gateway.asset, self.install_root / "gateway")
         self.audit("release_component_installed", "success", candidate=release.tag, component="gateway")
-        self.install_catalog(release)
+        if release.catalog is not None:
+            self.install_catalog(release)
         installed_config_targets = []
         for staged, destination in (
             (self.config_update.staged, self.config_update.target),
@@ -3950,9 +4051,11 @@ class Updater:
         health = self.get_json("http://127.0.0.1:9443/healthz")
         return health.get("status") == "ok" and health.get("version") == identity.gateway_version
 
-    @staticmethod
-    def release_identity(release: Release) -> RuntimeIdentity:
-        return RuntimeIdentity(release.tag, release.tag, release.provider_advertised_version)
+    def release_identity(self, release: Release) -> RuntimeIdentity:
+        advertised_version = release.provider_advertised_version
+        if release.catalog is None and self.config_update is not None:
+            advertised_version = self.config_update.next_version
+        return RuntimeIdentity(release.tag, release.tag, advertised_version)
 
     def local_coordinator_ready(self, release: Release, require_pool: bool) -> bool:
         return self.local_coordinator_identity_ready(self.release_identity(release), require_pool)
@@ -4069,7 +4172,8 @@ class Updater:
         release: Release,
         expected_require_hash_verified: str | None = None,
     ) -> None:
-        self.assert_effective_tier2_catalog_path(expected_require_hash_verified)
+        if release.catalog is not None:
+            self.assert_effective_tier2_catalog_path(expected_require_hash_verified)
         identity = self.release_identity(release)
         if not self.local_coordinator_identity_ready(identity, False):
             raise UpdateError("live coordinator version does not match signed release")
@@ -4083,8 +4187,9 @@ class Updater:
         publication_paths = [
             *effective_config_paths,
             gateway_config,
-            self.install_root / "autotune" / "current",
         ]
+        if release.catalog is not None:
+            publication_paths.append(self.install_root / "autotune" / "current")
         try:
             min_start_after_ns = max(path.lstat().st_mtime_ns for path in publication_paths)
         except OSError as exc:
@@ -4103,15 +4208,24 @@ class Updater:
             release.tag,
             min_start_after_ns,
         )
+        audit_fields: dict[str, object] = {
+            "coordinator_pid": coordinator["pid"],
+            "gateway_pid": gateway["pid"],
+            "coordinator_inode": coordinator["inode"],
+            "gateway_inode": gateway["inode"],
+            "release_lane": release.release_lane,
+        }
+        if release.catalog is not None:
+            audit_fields.update(
+                {
+                    "tier2_catalog_path": str(self._current_tier2_catalog_path()),
+                    "tier2_catalog_sha256": release.catalog.files["tier2-catalog.json"],
+                }
+            )
         self.audit(
             "live_runtime_binding",
             "success",
-            coordinator_pid=coordinator["pid"],
-            gateway_pid=gateway["pid"],
-            coordinator_inode=coordinator["inode"],
-            gateway_inode=gateway["inode"],
-            tier2_catalog_path=str(self._current_tier2_catalog_path()),
-            tier2_catalog_sha256=release.catalog.files["tier2-catalog.json"],
+            **audit_fields,
         )
 
     def verify_live_sighup_binding(
@@ -4119,6 +4233,8 @@ class Updater:
         release: Release,
         expected_require_hash_verified: str,
     ) -> None:
+        if release.catalog is None:
+            raise UpdateError("hash-enforced proof requires a catalog-bound Pearl release")
         self.assert_effective_tier2_catalog_path(expected_require_hash_verified)
         identity = self.release_identity(release)
         if not self.local_coordinator_identity_ready(identity, False):
@@ -4182,6 +4298,8 @@ class Updater:
         return self.public_identity_ready(self.release_identity(release))
 
     def catalog_manifest_path(self, release: Release) -> Path:
+        if release.catalog is None:
+            raise UpdateError("Pearl runtime release is not catalog-bound")
         candidate = release.directory / "release.json"
         if not candidate.is_file():
             candidate = self.install_root / "autotune" / "current" / "release.json"
@@ -4897,7 +5015,12 @@ class Updater:
             bridge_remaining_s=remaining_s,
         )
 
+    def verify_runtime_only_buyer_canary_policy(self, release: Release) -> None:
+        if release.catalog is None and self.config.buyer_canary_mode != BUYER_CANARY_MODE_REQUIRED:
+            raise UpdateError("runtime-only Pearl release requires buyer canary mode required")
+
     def verify_rollout(self, release: Release) -> None:
+        self.verify_runtime_only_buyer_canary_policy(release)
         self.systemctl("start", "macprovider-coordinator.service")
         self.wait_for(
             "coordinator systemd active state",
@@ -4905,7 +5028,8 @@ class Updater:
             lambda: self.service_active("macprovider-coordinator.service"),
         )
         self.wait_for("coordinator health/version", self.config.service_health_timeout_s, lambda: self.local_coordinator_ready(release, False))
-        self.assert_effective_tier2_catalog_path()
+        if release.catalog is not None:
+            self.assert_effective_tier2_catalog_path()
         self.systemctl("start", "macprovider-gateway.service")
         self.wait_for(
             "gateway systemd active state",
@@ -4916,8 +5040,16 @@ class Updater:
         self.verify_live_runtime_binding(release)
         self.restore_auxiliary_services()
         self.prove_serving_recovery(self.release_identity(release))
-        self.verify_provider_admission_rollout_policy()
-        self.verify_exact_catalog_admission(release)
+        if release.catalog is not None:
+            self.verify_provider_admission_rollout_policy()
+            self.verify_exact_catalog_admission(release)
+        else:
+            self.audit(
+                "provider_admission_rollout_policy",
+                "preserved",
+                release_lane=release.release_lane,
+                operator_policy=self.config.provider_admission_policy or "unspecified",
+            )
         if self.rollback_armed and not self.reconciling:
             self._journal_transition(
                 "provider_install_ready",
@@ -4930,7 +5062,8 @@ class Updater:
                 candidate=release.tag,
                 provider_recovery_timeout_s=self.config.provider_recovery_timeout_s,
             )
-        self.verify_exact_provider_canary(release)
+        if release.catalog is not None:
+            self.verify_exact_provider_canary(release)
         self.verify_buyer_canary_rollout_posture()
         self.restore_auxiliary_timers()
         self._restore_canary_timer()
@@ -4992,39 +5125,55 @@ class Updater:
             if state_manifest.get("sha256") != sha256_file(previous_state):
                 raise UpdateError("rollback installed release state checksum mismatch")
         catalog_manifest = self._transaction_json(tx, "catalog-manifest.json")
-        if not isinstance(catalog_manifest, dict) or set(catalog_manifest) != {
-            "current_target",
-            "previous_target",
-            "candidate_existed",
-            "candidate_release_id",
-            "legacy_tier2",
-        }:
+        if not isinstance(catalog_manifest, dict):
             raise UpdateError("rollback catalog manifest is invalid")
-        for key in ("current_target", "previous_target"):
-            value = catalog_manifest[key]
-            if value is not None:
-                if not isinstance(value, str):
-                    raise UpdateError("rollback catalog pointer is invalid")
-                if value:
-                    self._validate_catalog_target(value)
-        if type(catalog_manifest["candidate_existed"]) is not bool or not re.fullmatch(
-            r"[A-Za-z0-9][A-Za-z0-9._-]{0,191}", str(catalog_manifest["candidate_release_id"])
-        ):
-            raise UpdateError("rollback catalog release identity is invalid")
-        legacy_tier2 = catalog_manifest["legacy_tier2"]
-        if not isinstance(legacy_tier2, dict) or type(legacy_tier2.get("existed")) is not bool:
-            raise UpdateError("rollback legacy Tier-2 manifest is invalid")
-        if legacy_tier2["existed"]:
-            if set(legacy_tier2) != {"existed", "sha256", "uid", "gid", "mode"}:
+        owns_catalog = catalog_manifest.get("owns_catalog", True)
+        if type(owns_catalog) is not bool:
+            raise UpdateError("rollback catalog ownership flag is invalid")
+        if not owns_catalog:
+            if set(catalog_manifest) != {"owns_catalog"}:
+                raise UpdateError("rollback runtime-only catalog manifest is invalid")
+        else:
+            catalog_keys = set(catalog_manifest)
+            owned_keys = {
+                "current_target",
+                "previous_target",
+                "candidate_existed",
+                "candidate_release_id",
+                "legacy_tier2",
+            }
+            if "owns_catalog" in catalog_keys:
+                owned_keys.add("owns_catalog")
+            if catalog_keys != owned_keys:
+                raise UpdateError("rollback catalog manifest is invalid")
+        if not owns_catalog:
+            catalog_manifest = None
+        if catalog_manifest is not None:
+            for key in ("current_target", "previous_target"):
+                value = catalog_manifest[key]
+                if value is not None:
+                    if not isinstance(value, str):
+                        raise UpdateError("rollback catalog pointer is invalid")
+                    if value:
+                        self._validate_catalog_target(value)
+            if type(catalog_manifest["candidate_existed"]) is not bool or not re.fullmatch(
+                r"[A-Za-z0-9][A-Za-z0-9._-]{0,191}", str(catalog_manifest["candidate_release_id"])
+            ):
+                raise UpdateError("rollback catalog release identity is invalid")
+            legacy_tier2 = catalog_manifest["legacy_tier2"]
+            if not isinstance(legacy_tier2, dict) or type(legacy_tier2.get("existed")) is not bool:
                 raise UpdateError("rollback legacy Tier-2 manifest is invalid")
-            previous_tier2 = tx / "previous-tier2-catalog.json"
-            self._trusted_regular_file(previous_tier2, "rollback legacy Tier-2 snapshot", private=True)
-            if legacy_tier2["sha256"] != sha256_file(previous_tier2):
-                raise UpdateError("rollback legacy Tier-2 snapshot checksum mismatch")
-            if any(type(legacy_tier2[field]) is not int for field in ("uid", "gid", "mode")):
-                raise UpdateError("rollback legacy Tier-2 metadata is invalid")
-        elif set(legacy_tier2) != {"existed"}:
-            raise UpdateError("rollback absent legacy Tier-2 manifest is invalid")
+            if legacy_tier2["existed"]:
+                if set(legacy_tier2) != {"existed", "sha256", "uid", "gid", "mode"}:
+                    raise UpdateError("rollback legacy Tier-2 manifest is invalid")
+                previous_tier2 = tx / "previous-tier2-catalog.json"
+                self._trusted_regular_file(previous_tier2, "rollback legacy Tier-2 snapshot", private=True)
+                if legacy_tier2["sha256"] != sha256_file(previous_tier2):
+                    raise UpdateError("rollback legacy Tier-2 snapshot checksum mismatch")
+                if any(type(legacy_tier2[field]) is not int for field in ("uid", "gid", "mode")):
+                    raise UpdateError("rollback legacy Tier-2 metadata is invalid")
+            elif set(legacy_tier2) != {"existed"}:
+                raise UpdateError("rollback absent legacy Tier-2 manifest is invalid")
         previous_versions = self._transaction_json(tx, "previous-versions.json")
         if not isinstance(previous_versions, dict) or set(previous_versions) != {"coordinator", "gateway"}:
             raise UpdateError("rollback previous versions manifest is invalid")
@@ -5116,6 +5265,9 @@ class Updater:
 
     def _restore_catalog(self, tx: Path) -> None:
         manifest = self._transaction_json(tx, "catalog-manifest.json")
+        if manifest.get("owns_catalog") is False:
+            self.audit("catalog_rollback", "skipped", reason="runtime-only transaction")
+            return
         catalog_root = self.install_root / "autotune"
         self._replace_catalog_pointer("current", manifest["current_target"])
         legacy_tier2 = self.install_root / "tier2-catalog.json"
@@ -5390,11 +5542,13 @@ class Updater:
             "provider_advertised_version",
             "coordinator_sha256",
             "gateway_sha256",
-            "catalog_release_id",
-            "catalog_policy_version",
-            "catalog_files",
             "provider_admission_rollout",
         }
+        if "release_lane" in payload:
+            required.add("release_lane")
+        has_catalog = "catalog_release_id" in payload or "catalog_policy_version" in payload or "catalog_files" in payload
+        if has_catalog:
+            required.update({"catalog_release_id", "catalog_policy_version", "catalog_files"})
         if set(payload) != required:
             raise UpdateError("phase journal committed release fields are invalid")
         tag = payload["tag"]
@@ -5403,9 +5557,7 @@ class Updater:
         advertised = payload["provider_advertised_version"]
         coordinator_sha = payload["coordinator_sha256"]
         gateway_sha = payload["gateway_sha256"]
-        catalog_release_id = payload["catalog_release_id"]
-        catalog_policy_version = payload["catalog_policy_version"]
-        catalog_files = payload["catalog_files"]
+        release_lane = payload.get("release_lane", RELEASE_LANE_RUNTIME_WITH_CATALOG)
         rollout = payload["provider_admission_rollout"]
         if not isinstance(tag, str) or not SEMVER_RE.fullmatch(tag):
             raise UpdateError("phase journal committed release tag is invalid")
@@ -5421,16 +5573,26 @@ class Updater:
             raise UpdateError("phase journal committed coordinator hash is invalid")
         if not isinstance(gateway_sha, str) or not SHA256_RE.fullmatch(gateway_sha):
             raise UpdateError("phase journal committed gateway hash is invalid")
-        if (
-            not isinstance(catalog_release_id, str)
-            or not re.fullmatch(r"[A-Za-z0-9][A-Za-z0-9._-]{0,127}", catalog_release_id)
-            or not isinstance(catalog_policy_version, str)
-            or not re.fullmatch(r"[A-Za-z0-9][A-Za-z0-9._-]{0,127}", catalog_policy_version)
-            or not isinstance(catalog_files, dict)
-            or set(catalog_files) != set(CATALOG_ASSETS)
-            or any(not isinstance(value, str) or not SHA256_RE.fullmatch(value) for value in catalog_files.values())
-        ):
-            raise UpdateError("phase journal committed catalog identity is invalid")
+        if release_lane not in (RELEASE_LANE_RUNTIME, RELEASE_LANE_RUNTIME_WITH_CATALOG):
+            raise UpdateError("phase journal committed release lane is invalid")
+        catalog_release: CatalogRelease | None = None
+        if has_catalog:
+            catalog_release_id = payload["catalog_release_id"]
+            catalog_policy_version = payload["catalog_policy_version"]
+            catalog_files = payload["catalog_files"]
+            if (
+                not isinstance(catalog_release_id, str)
+                or not re.fullmatch(r"[A-Za-z0-9][A-Za-z0-9._-]{0,127}", catalog_release_id)
+                or not isinstance(catalog_policy_version, str)
+                or not re.fullmatch(r"[A-Za-z0-9][A-Za-z0-9._-]{0,127}", catalog_policy_version)
+                or not isinstance(catalog_files, dict)
+                or set(catalog_files) != set(CATALOG_ASSETS)
+                or any(not isinstance(value, str) or not SHA256_RE.fullmatch(value) for value in catalog_files.values())
+            ):
+                raise UpdateError("phase journal committed catalog identity is invalid")
+            catalog_release = CatalogRelease(catalog_release_id, catalog_policy_version, dict(catalog_files))
+        elif release_lane != RELEASE_LANE_RUNTIME:
+            raise UpdateError("phase journal catalog-bound release omits catalog identity")
         rollout_shape_valid = (
             isinstance(rollout, dict)
             and set(rollout) == {"mode", "enforce_provider_admission", "bridge_duration_s"}
@@ -5457,13 +5619,14 @@ class Updater:
             advertised,
             Component(COORDINATOR_ASSET, coordinator_sha, tag),
             Component(GATEWAY_ASSET, gateway_sha, tag),
-            CatalogRelease(catalog_release_id, catalog_policy_version, dict(catalog_files)),
+            catalog_release,
             ProviderAdmissionRollout(
                 rollout["mode"],
                 rollout["enforce_provider_admission"],
                 rollout["bridge_duration_s"],
             ),
             Path("/committed-release"),
+            release_lane,
         )
 
     def reconcile_committed_success(self, payload: dict[str, Any]) -> None:
@@ -5474,6 +5637,20 @@ class Updater:
         self._journal_transition("committed_success_reverified")
 
     def persist_success(self, release: Release, previous: SemVer) -> None:
+        path = self.state_root / "current-release.json"
+        previous_state: dict[str, Any] | None = None
+        if _path_entry_exists(path):
+            self._trusted_regular_file(path, "installed release state", private=True)
+            previous_payload = json.loads(
+                _read_trusted_text(
+                    path,
+                    "installed release state",
+                    trusted_uid=self.trusted_uid,
+                    private=True,
+                )
+            )
+            if isinstance(previous_payload, dict):
+                previous_state = previous_payload
         state = {
             "schema_version": CURRENT_RELEASE_SCHEMA_VERSION,
             "version": str(release.version),
@@ -5483,15 +5660,22 @@ class Updater:
             "installed_at": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
             "coordinator_sha256": release.coordinator.sha256,
             "gateway_sha256": release.gateway.sha256,
-            "catalog_release_id": release.catalog.release_id,
-            "catalog_policy_version": release.catalog.policy_version,
-            "catalog_files": dict(release.catalog.files),
+            "release_lane": release.release_lane,
             "transaction": str(self.transaction),
         }
+        if release.catalog is not None:
+            state.update(
+                {
+                    "catalog_release_id": release.catalog.release_id,
+                    "catalog_policy_version": release.catalog.policy_version,
+                    "catalog_files": dict(release.catalog.files),
+                }
+            )
+        elif previous_state is not None:
+            catalog_keys = ("catalog_release_id", "catalog_policy_version", "catalog_files")
+            if all(key in previous_state for key in catalog_keys):
+                state.update({key: previous_state[key] for key in catalog_keys})
         self._ensure_private_directory(self.state_root, "updater state directory")
-        path = self.state_root / "current-release.json"
-        if _path_entry_exists(path):
-            self._trusted_regular_file(path, "installed release state", private=True)
         self._journal_transition(
             "success_state_persist_pending",
             pending_action={"kind": "state_replace", "destination": str(path)},
@@ -5503,6 +5687,7 @@ class Updater:
         self._journal_transition("success_state_persisted", pending_action=None, success_persisted=True)
 
     def apply(self, release: Release, previous: SemVer) -> None:
+        self.verify_runtime_only_buyer_canary_policy(release)
         self.audit("rollout_started", "in_progress", candidate=release.tag, previous=str(previous))
         self._start_journal(release, previous)
         try:
@@ -5891,9 +6076,11 @@ def main(argv: list[str]) -> int:
             return 0
         current, decision = updater.assess_candidate(release)
         config_update = updater.prepare_config_update(release)
+        updater.verify_runtime_only_buyer_canary_policy(release)
         updater.verify_buyer_canary_rollout_posture()
         updater.validate_deadman_configuration()
-        updater.validate_catalog_canary_configuration()
+        if release.catalog is not None:
+            updater.validate_catalog_canary_configuration()
         if decision == "already_current" and config_update.previous_version != config_update.next_version:
             decision = "repair_config"
             updater.audit(
@@ -5909,8 +6096,9 @@ def main(argv: list[str]) -> int:
             "candidate": release.tag,
             "candidate_commit": release.commit,
             "current_version": str(current),
-            "provider_advertised_version": release.provider_advertised_version,
+            "provider_advertised_version": config_update.next_version,
             "advertised_version_config": str(config_update.target),
+            "release_lane": release.release_lane,
             "canary_rollout_authority": (
                 CANARY_AUTHORITY_VERSION
                 if config.buyer_canary_mode == BUYER_CANARY_MODE_REQUIRED

--- a/ops/pearl-updater/test_pearl_updater.py
+++ b/ops/pearl-updater/test_pearl_updater.py
@@ -225,33 +225,54 @@ class PearlUpdaterTests(unittest.TestCase):
         advertised_version: str | None = None,
         rollout_mode: str = "bridge_required",
         channel: str | None = None,
-    ):
+        runtime_only: bool = False,
+        ):
         tag = "v" + version
         advertised_version = advertised_version or version
+        if runtime_only and rollout_mode == "bridge_required":
+            rollout_mode = "strict_post_migration"
         coordinator = self.bundle / updater_module.COORDINATOR_ASSET
+        coordinator_cli = self.bundle / updater_module.COORDINATOR_CLI_ASSET
         gateway = self.bundle / updater_module.GATEWAY_ASSET
         coordinator.write_bytes(fake_elf("coordinator"))
+        coordinator_cli.write_bytes(fake_elf("coordinator-cli"))
         gateway.write_bytes(fake_elf("gateway"))
-        catalog_sources = {
-            "release.json": REPO_ROOT / "phase3-binary/catalog/autotune/release.json",
-            "trusted-keys.json": REPO_ROOT / "phase3-binary/catalog/autotune/trusted-keys.json",
-            "tier2-catalog.json": REPO_ROOT / "phase3-binary/catalog/autotune/tier2-catalog.json",
-            "autotune-candidates.json": REPO_ROOT / "phase3-binary/dist/static/autotune-candidates.json",
-            "autotune-candidates.json.sig": REPO_ROOT / "phase3-binary/dist/static/autotune-candidates.json.sig",
-            "demand-rank.json": REPO_ROOT / "phase3-binary/dist/static/demand-rank.json",
-            "demand-rank.json.sig": REPO_ROOT / "phase3-binary/dist/static/demand-rank.json.sig",
-        }
-        for name, source in catalog_sources.items():
-            shutil.copyfile(source, self.bundle / name)
-        catalog_manifest = json.loads((self.bundle / "release.json").read_text(encoding="utf-8"))
+        for name in updater_module.CATALOG_ASSETS:
+            (self.bundle / name).unlink(missing_ok=True)
+        catalog_metadata = None
+        catalog_assets = []
+        release_lane = updater_module.RELEASE_LANE_RUNTIME
+        if not runtime_only:
+            catalog_sources = {
+                "release.json": REPO_ROOT / "phase3-binary/catalog/autotune/release.json",
+                "trusted-keys.json": REPO_ROOT / "phase3-binary/catalog/autotune/trusted-keys.json",
+                "tier2-catalog.json": REPO_ROOT / "phase3-binary/catalog/autotune/tier2-catalog.json",
+                "autotune-candidates.json": REPO_ROOT / "phase3-binary/dist/static/autotune-candidates.json",
+                "autotune-candidates.json.sig": REPO_ROOT / "phase3-binary/dist/static/autotune-candidates.json.sig",
+                "demand-rank.json": REPO_ROOT / "phase3-binary/dist/static/demand-rank.json",
+                "demand-rank.json.sig": REPO_ROOT / "phase3-binary/dist/static/demand-rank.json.sig",
+            }
+            for name, source in catalog_sources.items():
+                shutil.copyfile(source, self.bundle / name)
+            catalog_manifest = json.loads((self.bundle / "release.json").read_text(encoding="utf-8"))
+            catalog_assets = [self.bundle / name for name in updater_module.CATALOG_ASSETS]
+            catalog_metadata = {
+                "release_id": catalog_manifest["release_id"],
+                "policy_version": catalog_manifest["policy_version"],
+                "files": {
+                    name: updater_module.sha256_file(self.bundle / name)
+                    for name in updater_module.CATALOG_ASSETS
+                },
+            }
+            release_lane = updater_module.RELEASE_LANE_RUNTIME_WITH_CATALOG
         metadata = {
             "schema_version": 1,
+            "release_lane": release_lane,
             "repository": updater_module.PINNED_REPOSITORY,
             "tag": tag,
             "release_version": version,
             "commit": "a" * 40,
             "architecture": "linux-amd64",
-            "provider_advertised_version": advertised_version,
             "provider_admission_rollout": {
                 "mode": rollout_mode,
                 "enforce_provider_admission": rollout_mode == "strict_post_migration",
@@ -269,15 +290,16 @@ class PearlUpdaterTests(unittest.TestCase):
                     "embedded_version": tag,
                 },
             },
-            "catalog": {
-                "release_id": catalog_manifest["release_id"],
-                "policy_version": catalog_manifest["policy_version"],
-                "files": {
-                    name: updater_module.sha256_file(self.bundle / name)
-                    for name in updater_module.CATALOG_ASSETS
+            "catalog": catalog_metadata,
+            "operator_artifacts": {
+                "coordinator_cli": {
+                    "asset": coordinator_cli.name,
+                    "sha256": updater_module.sha256_file(coordinator_cli),
                 },
             },
         }
+        if not runtime_only:
+            metadata["provider_advertised_version"] = advertised_version
         if channel is not None:
             metadata["channel"] = channel
         metadata_path = self.bundle / "pearl-release.json"
@@ -287,8 +309,9 @@ class PearlUpdaterTests(unittest.TestCase):
             metadata_path,
             self.bundle / "pearl-release.json.sig",
             coordinator,
+            coordinator_cli,
             gateway,
-            *(self.bundle / name for name in updater_module.CATALOG_ASSETS),
+            *catalog_assets,
         ]
         checksums = self.bundle / "checksums.txt"
         checksums.write_text("".join(f"{updater_module.sha256_file(path)}  {path.name}\n" for path in assets))
@@ -410,6 +433,128 @@ class PearlUpdaterTests(unittest.TestCase):
         self.assertEqual(recovered.version, updater_module.SemVer.parse("1.8.27"))
         self.assertEqual(recovered.provider_advertised_version, "1.8.26")
 
+    def test_runtime_only_release_verifies_without_catalog_feed_assets(self):
+        self.make_bundle(runtime_only=True)
+
+        release = self.verify()
+
+        self.assertEqual(release.release_lane, updater_module.RELEASE_LANE_RUNTIME)
+        self.assertIsNone(release.catalog)
+        for name in updater_module.CATALOG_ASSETS:
+            self.assertFalse((release.directory / name).exists(), name)
+
+    def test_runtime_only_release_requires_explicit_tag_for_remote_acquire(self):
+        self.make_bundle(runtime_only=True)
+        self.updater.release_tags = mock.Mock(return_value=["v1.8.27"])
+        self.updater.audit = mock.Mock()
+
+        def fake_download(url: str, destination: Path) -> None:
+            shutil.copyfile(self.bundle / url.rsplit("/", 1)[-1], destination)
+
+        self.updater.download = mock.Mock(side_effect=fake_download)
+        auto_work = self.root / "auto-acquire"
+        explicit_work = self.root / "explicit-acquire"
+        auto_work.mkdir()
+        explicit_work.mkdir()
+
+        with self.assertRaisesRegex(updater_module.NoEligibleRelease, "no signed Pearl runtime release"):
+            self.updater.acquire_release(auto_work, None, None)
+
+        self.updater.audit.assert_any_call(
+            "release_skipped",
+            "runtime_only_requires_explicit_tag",
+            candidate="v1.8.27",
+        )
+
+        release = self.updater.acquire_release(explicit_work, None, "v1.8.27")
+
+        self.assertEqual(release.release_lane, updater_module.RELEASE_LANE_RUNTIME)
+
+    def test_runtime_only_metadata_rejects_provider_config_authority(self):
+        self.make_bundle(runtime_only=True)
+        payload = json.loads((self.bundle / "pearl-release.json").read_text())
+        payload["provider_advertised_version"] = "1.8.27"
+
+        with self.assertRaisesRegex(updater_module.UpdateError, "must not carry provider advertised version"):
+            self.updater.parse_metadata(payload, self.bundle)
+
+    def test_runtime_only_metadata_rejects_provider_bridge_policy(self):
+        self.make_bundle(runtime_only=True)
+        payload = json.loads((self.bundle / "pearl-release.json").read_text())
+        payload["provider_admission_rollout"] = {
+            "mode": "bridge_required",
+            "enforce_provider_admission": False,
+            "bridge_duration_s": 86400,
+        }
+
+        with self.assertRaisesRegex(updater_module.UpdateError, "must not bind provider admission bridge policy"):
+            self.updater.parse_metadata(payload, self.bundle)
+
+    def test_runtime_only_plan_preserves_existing_catalog_pointer(self):
+        self.make_bundle(runtime_only=True)
+        install = self.updater.install_root
+        install.mkdir(parents=True)
+        base = install / "coordinator.yaml"
+        existing_catalog = "/opt/macprovider/autotune/current/tier2-catalog.json"
+        base.write_text(
+            'coordinator_advertised_version:\n  latest_binary_version: "1.8.26"\n'
+            "tier2:\n"
+            f"  catalog_path: {existing_catalog}\n"
+            "  require_hash_verified: false\n"
+        )
+        self.updater.coordinator_runtime = mock.Mock(
+            return_value=updater_module.CoordinatorRuntime(base, None, {})
+        )
+        release = self.stage(self.verify())
+
+        update = self.updater.prepare_config_update(release)
+
+        self.assertIsNone(update.catalog_target)
+        self.assertIsNone(update.catalog_staged)
+        self.assertEqual(update.previous_version, "1.8.26")
+        self.assertEqual(update.next_version, "1.8.26")
+        self.assertIn('latest_binary_version: "1.8.26"', update.staged.read_text())
+        self.assertIn(f"catalog_path: {existing_catalog}", update.staged.read_text())
+        self.assertEqual(
+            self.updater.release_identity(release),
+            updater_module.RuntimeIdentity("v1.8.27", "v1.8.27", "1.8.26"),
+        )
+
+    def test_runtime_only_success_preserves_durable_catalog_identity(self):
+        catalog_release = self.verify().catalog
+        self.assertIsNotNone(catalog_release)
+        self.updater.state_root.mkdir(parents=True, exist_ok=True)
+        self.updater.state_root.chmod(0o700)
+        state = self.updater.state_root / "current-release.json"
+        state.write_text(
+            json.dumps(
+                {
+                    "schema_version": updater_module.CURRENT_RELEASE_SCHEMA_VERSION,
+                    "version": "1.8.26",
+                    "tag": "v1.8.26",
+                    "commit": "b" * 40,
+                    "coordinator_sha256": "0" * 64,
+                    "gateway_sha256": "1" * 64,
+                    "catalog_release_id": catalog_release.release_id,
+                    "catalog_policy_version": catalog_release.policy_version,
+                    "catalog_files": dict(catalog_release.files),
+                }
+            )
+            + "\n"
+        )
+        state.chmod(0o600)
+        self.make_bundle(runtime_only=True)
+        release = self.verify()
+        self.updater.transaction = self.root / "tx-runtime-success"
+
+        self.updater.persist_success(release, updater_module.SemVer.parse("1.8.26"))
+
+        persisted = json.loads(state.read_text())
+        self.assertEqual(persisted["release_lane"], updater_module.RELEASE_LANE_RUNTIME)
+        self.assertEqual(persisted["catalog_release_id"], catalog_release.release_id)
+        self.assertEqual(persisted["catalog_policy_version"], catalog_release.policy_version)
+        self.assertEqual(persisted["catalog_files"], catalog_release.files)
+
     def test_private_acceptance_opt_in_does_not_relax_production_metadata(self):
         self.make_bundle(advertised_version="1.8.26")
         self.updater.config = updater_module.dataclasses.replace(
@@ -445,6 +590,7 @@ class PearlUpdaterTests(unittest.TestCase):
             self.bundle / "pearl-release.json",
             self.bundle / "pearl-release.json.sig",
             self.bundle / updater_module.COORDINATOR_ASSET,
+            self.bundle / updater_module.COORDINATOR_CLI_ASSET,
             self.bundle / updater_module.GATEWAY_ASSET,
             *(self.bundle / name for name in updater_module.CATALOG_ASSETS),
         ]
@@ -471,6 +617,7 @@ class PearlUpdaterTests(unittest.TestCase):
             metadata_path,
             self.bundle / "pearl-release.json.sig",
             self.bundle / updater_module.COORDINATOR_ASSET,
+            self.bundle / updater_module.COORDINATOR_CLI_ASSET,
             self.bundle / updater_module.GATEWAY_ASSET,
             *(self.bundle / name for name in updater_module.CATALOG_ASSETS),
         ]
@@ -589,6 +736,73 @@ class PearlUpdaterTests(unittest.TestCase):
 
         self.assertFalse((install / "autotune" / "current").exists())
         self.assertFalse(legacy_tier2.exists())
+
+    def test_runtime_only_snapshot_does_not_capture_catalog_ownership(self):
+        self.make_bundle(runtime_only=True)
+        install = self.updater.install_root
+        install.mkdir(parents=True)
+        for name in ("coordinator", "gateway"):
+            (install / name).write_bytes(fake_elf("installed-" + name))
+            (install / name).chmod(0o750)
+        (install / "gateway.yaml").write_text("gateway: {}\n")
+        (install / "gateway.yaml").chmod(0o600)
+        base = install / "coordinator.yaml"
+        base.write_text(
+            'coordinator_advertised_version:\n  latest_binary_version: "1.8.26"\n'
+            "tier2:\n"
+            f"  catalog_path: {install}/autotune/current/tier2-catalog.json\n"
+            "  require_hash_verified: false\n"
+        )
+        base.chmod(0o600)
+        releases = install / "autotune" / "releases"
+        releases.mkdir(parents=True, mode=0o750)
+        (install / "autotune").chmod(0o750)
+        (releases / "catalog-a").mkdir(mode=0o750)
+        (install / "autotune" / "current").symlink_to("releases/catalog-a")
+        previous = install / "autotune" / ".previous-target"
+        previous.write_text("releases/catalog-a\n")
+        previous.chmod(0o600)
+        self.updater.coordinator_runtime = mock.Mock(
+            return_value=updater_module.CoordinatorRuntime(base, None, {})
+        )
+        self.updater.previous_versions = {
+            "coordinator": "1.8.26",
+            "gateway": "1.8.26",
+        }
+        release = self.stage(self.verify())
+        self.updater.prepare_config_update(release)
+
+        tx = self.updater.snapshot(release)
+
+        manifest = json.loads((tx / "catalog-manifest.json").read_text())
+        self.assertEqual(manifest, {"owns_catalog": False})
+        self.assertFalse((tx / "previous-tier2-catalog.json").exists())
+
+    def test_runtime_only_catalog_rollback_is_noop(self):
+        install = self.updater.install_root
+        releases = install / "autotune" / "releases"
+        releases.mkdir(parents=True, mode=0o750)
+        (install / "autotune").chmod(0o750)
+        (releases / "catalog-b").mkdir(mode=0o750)
+        (install / "autotune" / "current").symlink_to("releases/catalog-b")
+        previous = install / "autotune" / ".previous-target"
+        previous.write_text("releases/catalog-b\n")
+        previous.chmod(0o600)
+        tx = self.root / "runtime-only-catalog-noop"
+        tx.mkdir(mode=0o700)
+        (tx / "catalog-manifest.json").write_text('{"owns_catalog":false}\n')
+        (tx / "catalog-manifest.json").chmod(0o600)
+        self.updater.audit = mock.Mock()
+
+        self.updater._restore_catalog(tx)
+
+        self.assertEqual(os.readlink(install / "autotune" / "current"), "releases/catalog-b")
+        self.assertEqual(previous.read_text().strip(), "releases/catalog-b")
+        self.updater.audit.assert_called_once_with(
+            "catalog_rollback",
+            "skipped",
+            reason="runtime-only transaction",
+        )
 
     def test_catalog_install_uses_service_group_and_repairs_restrictive_umask(self):
         release = self.stage(self.verify())
@@ -818,6 +1032,7 @@ class PearlUpdaterTests(unittest.TestCase):
             ),
             release.provider_admission_rollout,
             release.directory,
+            updater_module.RELEASE_LANE_RUNTIME_WITH_CATALOG,
         )
 
         original_name = self.updater._catalog_release_directory_name(release)
@@ -2475,6 +2690,37 @@ class PearlUpdaterTests(unittest.TestCase):
                 "exact_provider_canary"
             ),
         )
+
+    def test_runtime_only_rollout_requires_buyer_canary_mode(self):
+        self.make_bundle(runtime_only=True)
+        release = self.verify()
+        self.updater.config = updater_module.dataclasses.replace(
+            self.updater.config,
+            buyer_canary_mode=updater_module.BUYER_CANARY_MODE_DISABLED,
+        )
+
+        with self.assertRaisesRegex(updater_module.UpdateError, "runtime-only Pearl release requires buyer canary"):
+            self.updater.verify_rollout(release)
+
+    def test_runtime_only_apply_rejects_disabled_canary_before_journal_or_mutation(self):
+        self.make_bundle(runtime_only=True)
+        release = self.verify()
+        self.updater.config = updater_module.dataclasses.replace(
+            self.updater.config,
+            buyer_canary_mode=updater_module.BUYER_CANARY_MODE_DISABLED,
+        )
+        self.updater.audit = mock.Mock()
+        self.updater._start_journal = mock.Mock()
+        self.updater.stop_for_rollout = mock.Mock()
+        self.updater.install_release = mock.Mock()
+
+        with self.assertRaisesRegex(updater_module.UpdateError, "runtime-only Pearl release requires buyer canary"):
+            self.updater.apply(release, updater_module.SemVer.parse("1.8.26"))
+
+        self.updater.audit.assert_not_called()
+        self.updater._start_journal.assert_not_called()
+        self.updater.stop_for_rollout.assert_not_called()
+        self.updater.install_release.assert_not_called()
 
     def test_run_canary_gate_rejects_disabled_mode(self):
         self.updater.config = updater_module.dataclasses.replace(
@@ -4549,6 +4795,7 @@ class PearlUpdaterTests(unittest.TestCase):
             ),
             updater_module.ProviderAdmissionRollout("bridge_required", False, 86400),
             work,
+            updater_module.RELEASE_LANE_RUNTIME_WITH_CATALOG,
         )
         for name in updater_module.CATALOG_ASSETS:
             shutil.copyfile(self.bundle / name, work / name)
@@ -5326,6 +5573,15 @@ class PearlUpdaterTests(unittest.TestCase):
             "grep -Fx 'PEARL_UPDATER_PROVIDER_RECOVERY_TIMEOUT_S=900'",
             text,
         )
+        self.assertIn("Pearl has four separate release/config sources of truth", text)
+        self.assertIn("**Pearl runtime release**", text)
+        self.assertIn('release_lane: "pearl_runtime"', text)
+        self.assertIn("**Provider app release**", text)
+        self.assertIn("**Catalog/feed release**", text)
+        self.assertIn("**Pearl config release/reconciliation**", text)
+        self.assertIn("the updater leaves `tier2.catalog_path` unchanged", text)
+        self.assertIn("reported as missing Pearl\nruntime assets", text)
+        self.assertIn("CONFIG_MODE=preserve-live", text)
 
         example = SCRIPT.parent / "pearl-updater.conf.example"
         example_text = example.read_text(encoding="utf-8")

--- a/ops/runbooks/pearl-config-reconciliation.md
+++ b/ops/runbooks/pearl-config-reconciliation.md
@@ -85,13 +85,22 @@ scripts/verify-pearl-runtime-release.sh \
 
 If the tag exists but peels to a different commit, stop and select or cut a new
 reviewed release target. Do not move an existing public tag to make it fit. If
-the GitHub Release is missing `pearl-release.json`, `coordinator-linux-amd64`,
-`gateway-linux-amd64`, or the signed checksum/catalog assets, stop before
-`macprovider-pearl-update --apply`; the release is not a usable Pearl runtime
-release for this deploy.
+the GitHub Release is missing `pearl-release.json`,
+`coordinator-linux-amd64`, `gateway-linux-amd64`,
+`coordinator-cli-linux-amd64`, or the signed checksum controls, stop before
+`macprovider-pearl-update --apply`; the release is missing Pearl runtime
+assets and is not usable for this deploy. Catalog/feed assets are required only
+when `pearl-release.json` declares or defaults to the catalog-bound
+`pearl_runtime_catalog` lane. Runtime-only `pearl_runtime` releases deliberately
+leave Pearl's existing `tier2.catalog_path` and static feed state unchanged.
 
 For issue #785, this check is the boundary between the solved config-drift
-blocker and the remaining signed-pair release blocker. The broader release-lane
-split is tracked separately in #792 and is not required before finishing #785,
-provided the selected Pearl runtime release passes this preflight and the
-updater's own plan/apply gates.
+blocker and the signed-pair release blocker. Publish a runtime-only Pearl
+release from the exact reviewed source as a GitHub prerelease/non-latest
+runtime bundle, run
+`macprovider-pearl-update --plan --tag vX.Y.Z`, then
+`macprovider-pearl-update --apply --tag vX.Y.Z` with the buyer canary gate
+reviewed/enabled and `PEARL_UPDATER_BUYER_CANARY_MODE=required`. After the
+signed coordinator/gateway pair is live, retry the direct deploy with
+`CONFIG_MODE=preserve-live` so the reviewed config classification is preserved
+without smuggling runtime or catalog changes through the deploy script.

--- a/ops/runbooks/pearl-release-updater.md
+++ b/ops/runbooks/pearl-release-updater.md
@@ -7,16 +7,45 @@ The authenticated recovery action from PR #538 remains operator-only.
 
 ## Release trust contract
 
-Every ordinary `vMAJOR.MINOR.PATCH` GitHub release now contains:
+Pearl has four separate release/config sources of truth:
 
-- `coordinator-linux-amd64`, `coordinator-cli-linux-amd64`, and
-  `gateway-linux-amd64`;
-- `pearl-release.json` with the exact repository, tag, commit, component
-  hashes, embedded versions, architecture, and provider version advertised by
-  the coordinator configuration, plus the operator-selected signed provider
-  admission policy (`bridge_required` during migration or
-  `strict_post_migration` after closure);
-- detached signatures for `pearl-release.json` and `checksums.txt`.
+- **Pearl runtime release**: the signed coordinator/gateway runtime bundle for
+  Pearl. Its required assets are `coordinator-linux-amd64`,
+  `coordinator-cli-linux-amd64`, `gateway-linux-amd64`,
+  `pearl-release.json`, `pearl-release.json.sig`, `checksums.txt`, and
+  `checksums.txt.sig`. Runtime-only releases set
+  `release_lane: "pearl_runtime"` and do not carry provider app,
+  Malibu.app, catalog, or static-feed assets. The updater preserves the live
+  `tier2.catalog_path` and feed state for this lane. The protected runtime
+  workflow publishes this lane as a GitHub prerelease with `make_latest=false`,
+  so it never takes over the provider-app stable `/releases/latest` authority
+  and is applied only by explicit tag.
+- **Provider app release**: the signed Mac provider CLI, Malibu.app package,
+  standalone tarball, and provider artifact index. Release verification for
+  this lane proves the standalone CLI and Malibu-embedded CLI byte identity;
+  it is not proof that Pearl has a usable coordinator/gateway runtime bundle.
+- **Catalog/feed release**: the Tier-2 catalog, trusted keys,
+  autotune-candidates feed, demand-rank feed, signatures, release ledger, and
+  provider-side catalog admission evidence. This lane owns policy/feed
+  identity and static-feed signatures; it is not a coordinator/gateway binary
+  rollout.
+- **Pearl config release/reconciliation**: the reviewed
+  `ops/pearl/config/source-of-truth.yaml` classification plus the live
+  Pearl config preserved by `CONFIG_MODE=preserve-live`. This lane decides
+  which live fields may remain operator-owned; it does not publish or install
+  runtime binaries.
+
+The older catalog-bound Pearl bundle remains supported as
+`release_lane: "pearl_runtime_catalog"` for backwards-compatible releases that
+intentionally couple coordinator/gateway runtime assets with catalog/feed
+assets. In that lane, `pearl-release.json` must include the exact repository,
+tag, commit, component hashes, embedded versions, architecture, provider
+version advertised by the coordinator configuration, signed provider admission
+policy (`bridge_required` during migration or `strict_post_migration` after
+closure), and the catalog release identity/files. Runtime-only releases carry
+only the signed runtime component hashes plus a strict no-op admission shape;
+they must not carry `provider_advertised_version`, and `catalog` is absent or
+`null`.
 
 The protected release workflow first builds a complete unsigned candidate from
 the exact fresh `origin/main` tip while the requested tag is absent. After that
@@ -107,6 +136,9 @@ posture before state capture, after stable public fleet recovery, and after
 the exact physical catalog-provider proof. Public identity, three consecutive
 protected-fleet samples, admission policy, exact catalog admission, and the
 physical provider canary remain mandatory. The default remains `required`.
+Runtime-only `pearl_runtime` releases are not eligible for this disabled mode:
+because they deliberately omit the exact catalog/provider gates, apply requires
+`PEARL_UPDATER_BUYER_CANARY_MODE=required` and a passing buyer canary.
 
 From the authority commit's reviewed checkout, install the four runtime files
 as executable root-owned files and the two units as non-executable root-owned
@@ -248,16 +280,40 @@ scripts/verify-pearl-runtime-release.sh \
 
 This preflight checks the immutable git tag target, `pearl-release.json`,
 `coordinator-linux-amd64`, `gateway-linux-amd64`,
-`coordinator-cli-linux-amd64`, signed checksum controls, and the catalog files
-the Pearl updater needs. It is intentionally not a substitute for
-`macprovider-pearl-update`: the updater still performs signature verification,
-transaction staging, rollback, provider-drain protection, and serving gates
-before any live mutation.
+`coordinator-cli-linux-amd64`, and signed checksum controls. If
+`pearl-release.json` declares `release_lane: "pearl_runtime_catalog"` or omits
+`release_lane` for a legacy catalog-bound bundle, the preflight also requires
+the catalog/feed assets and their signed hashes. If it declares
+`release_lane: "pearl_runtime"`, missing catalog/feed assets are accepted and
+the updater leaves `tier2.catalog_path` unchanged. A GitHub tag that exists
+without coordinator or gateway runtime assets must be reported as missing Pearl
+runtime assets, not as a generic CLI/provider-app release failure. It is
+intentionally not a substitute for `macprovider-pearl-update`: the updater
+still performs signature verification, transaction staging, rollback,
+provider-drain protection, and serving gates before any live mutation.
 
 If the preflight fails because the GitHub Release is missing Pearl runtime
 assets, do not apply an older available release just because its plan succeeds.
 Select or cut a reviewed runtime release whose tag, metadata commit, and deploy
 source match. Do not move an existing public tag to repair identity drift.
+
+For the safe issue #785 path, publish a runtime-only Pearl release from the
+exact reviewed source commit. Runtime-only GitHub releases are deliberately
+published as prereleases with `make_latest=false`; they are never selected by
+the updater's automatic stable-release discovery and must be applied by
+explicit tag. Verify that tag with the command above, then run the updater
+against that same tag with `PEARL_UPDATER_BUYER_CANARY_MODE` left at
+`required` and the buyer canary gate reviewed/enabled:
+
+```bash
+sudo /usr/local/sbin/macprovider-pearl-update --plan --tag vX.Y.Z
+sudo /usr/local/sbin/macprovider-pearl-update --apply --tag vX.Y.Z
+```
+
+After the signed coordinator/gateway pair is live, resume the direct deploy
+with `CONFIG_MODE=preserve-live`. That deploy may reconcile reviewed Pearl
+config ownership, but it must not be used to replace only one runtime binary or
+to smuggle a catalog/feed change into the runtime lane.
 
 ## First production rollout
 

--- a/scripts/acceptance-candidate-metadata.py
+++ b/scripts/acceptance-candidate-metadata.py
@@ -326,24 +326,45 @@ def build_pearl(args: argparse.Namespace) -> dict:
     tag = require_string(args.tag, TAG, "tag")
     commit = require_string(args.commit, HEX40, "commit")
     compatibility_set_id = f"{repository}:{tag}@{commit}"
-    provider_cli_version = compatibility_provider_cli_version(
-        args.compatibility_manifest,
-        compatibility_set_id,
-    )
-    catalog = args.catalog_directory
-    files = {name: sha256(catalog / name, f"catalog {name}") for name in CATALOG_NAMES}
-    release = strict_json(catalog / "release.json", "catalog release", catalog_release=True)
-    release_id = release.get("release_id")
-    policy_version = release.get("policy_version")
-    if not isinstance(release_id, str) or not release_id or not isinstance(policy_version, str) or not policy_version:
-        fail("catalog release: release_id and policy_version are required")
+    if args.runtime_only and args.catalog_directory is not None:
+        fail("Pearl runtime metadata: --runtime-only cannot bind --catalog-directory")
+    if not args.runtime_only and args.catalog_directory is None:
+        fail("Pearl runtime metadata: --catalog-directory is required unless --runtime-only is set")
+    if not args.runtime_only and args.compatibility_manifest is None:
+        fail("Pearl runtime metadata: --compatibility-manifest is required for catalog-bound releases")
+    if not args.runtime_only and args.provider_advertised_version is not None:
+        fail("Pearl runtime metadata: catalog-bound releases derive provider version from --compatibility-manifest")
+    if args.runtime_only and args.compatibility_manifest is not None:
+        fail("Pearl runtime metadata: --runtime-only cannot bind --compatibility-manifest")
+    if args.runtime_only and args.provider_advertised_version is not None:
+        fail("Pearl runtime metadata: --runtime-only cannot bind --provider-advertised-version")
+    if args.runtime_only and args.provider_admission_policy != "strict_post_migration":
+        fail("Pearl runtime metadata: --runtime-only cannot bind provider admission bridge policy")
+    provider_cli_version = None
+    if not args.runtime_only:
+        provider_cli_version = compatibility_provider_cli_version(
+            args.compatibility_manifest,
+            compatibility_set_id,
+        )
+    catalog_metadata = None
+    release_lane = "pearl_runtime"
+    if args.catalog_directory is not None:
+        catalog = args.catalog_directory
+        files = {name: sha256(catalog / name, f"catalog {name}") for name in CATALOG_NAMES}
+        release = strict_json(catalog / "release.json", "catalog release", catalog_release=True)
+        release_id = release.get("release_id")
+        policy_version = release.get("policy_version")
+        if not isinstance(release_id, str) or not release_id or not isinstance(policy_version, str) or not policy_version:
+            fail("catalog release: release_id and policy_version are required")
+        catalog_metadata = {"files": files, "policy_version": policy_version, "release_id": release_id}
+        release_lane = "pearl_runtime_catalog"
     rollout = {
         "bridge_required": {"bridge_duration_s": 86400, "enforce_provider_admission": False, "mode": "bridge_required"},
         "strict_post_migration": {"bridge_duration_s": 0, "enforce_provider_admission": True, "mode": "strict_post_migration"},
     }[args.provider_admission_policy]
-    return {
+    metadata = {
         "architecture": "linux-amd64",
-        "catalog": {"files": files, "policy_version": policy_version, "release_id": release_id},
+        "catalog": catalog_metadata,
         "channel": args.channel,
         "commit": commit,
         "components": {
@@ -365,12 +386,15 @@ def build_pearl(args: argparse.Namespace) -> dict:
             }
         },
         "provider_admission_rollout": rollout,
-        "provider_advertised_version": provider_cli_version,
+        "release_lane": release_lane,
         "release_version": tag.removeprefix("v"),
         "repository": repository,
         "schema_version": 1,
         "tag": tag,
     }
+    if provider_cli_version is not None:
+        metadata["provider_advertised_version"] = provider_cli_version
+    return metadata
 
 
 def command_build_pearl(args: argparse.Namespace) -> None:
@@ -655,10 +679,12 @@ def parser() -> argparse.ArgumentParser:
     pearl.add_argument("--repository", required=True)
     pearl.add_argument("--tag", required=True)
     pearl.add_argument("--commit", required=True)
-    pearl.add_argument("--compatibility-manifest", required=True, type=pathlib.Path)
+    pearl.add_argument("--compatibility-manifest", type=pathlib.Path)
+    pearl.add_argument("--provider-advertised-version")
     pearl.add_argument("--provider-admission-policy", choices=("bridge_required", "strict_post_migration"), required=True)
     pearl.add_argument("--channel", choices=("private_acceptance", "production"), default="private_acceptance")
-    pearl.add_argument("--catalog-directory", required=True, type=pathlib.Path)
+    pearl.add_argument("--catalog-directory", type=pathlib.Path)
+    pearl.add_argument("--runtime-only", action="store_true")
     pearl.add_argument("--coordinator", required=True, type=pathlib.Path)
     pearl.add_argument("--coordinator-cli", required=True, type=pathlib.Path)
     pearl.add_argument("--gateway", required=True, type=pathlib.Path)

--- a/scripts/capture-release-publication.py
+++ b/scripts/capture-release-publication.py
@@ -14,14 +14,27 @@ arguments = sys.argv[1:]
 draft_mode = bool(arguments and arguments[0] == "--draft")
 if draft_mode:
     arguments = arguments[1:]
+runtime_only = bool(arguments and arguments[0] == "--runtime-only")
+if runtime_only:
+    arguments = arguments[1:]
 notes_path = None
 if arguments[:1] == ["--notes-file"]:
     if len(arguments) < 2:
         fail("--notes-file requires a path")
     notes_path = pathlib.Path(arguments[1])
     arguments = arguments[2:]
+expected_title_override = None
+if arguments[:1] == ["--expected-title"]:
+    if len(arguments) < 2:
+        fail("--expected-title requires a value")
+    expected_title_override = arguments[1]
+    arguments = arguments[2:]
 if len(arguments) < 4:
-    fail("usage: [--draft] [--notes-file PATH] RELEASE_JSON PROVENANCE_JSON OUTPUT RELEASE_ASSET...")
+    fail(
+        "usage: [--draft] [--runtime-only] [--notes-file PATH] "
+        "[--expected-title VALUE] "
+        "RELEASE_JSON PROVENANCE_JSON OUTPUT RELEASE_ASSET..."
+    )
 
 release_path, provenance_path, output_path, *local_asset_names = arguments
 release = json.loads(pathlib.Path(release_path).read_text(encoding="utf-8"))
@@ -50,7 +63,7 @@ if release.get("tag_name") != tag:
     fail("numeric release tag differs from signed provenance")
 if release.get("target_commitish") != commit:
     fail("numeric release target differs from signed provenance")
-expected_title = f"macprovider-cli {tag}"
+expected_title = expected_title_override or f"macprovider-cli {tag}"
 body_sha256 = None
 if notes_path is not None:
     if not notes_path.is_file() or notes_path.is_symlink():
@@ -109,6 +122,8 @@ required_local = {
     "checksums.txt",
     "checksums.txt.sig",
 }
+if runtime_only:
+    required_local = expected_names
 if not required_local <= set(local_assets):
     fail("captured publication files are incomplete")
 
@@ -128,16 +143,23 @@ for name, digest in signed_assets.items():
     if name in local_assets and local_assets[name][1] != digest:
         fail(f"signed provenance hash differs for {name}")
 
-dmg_name = f"Malibu-{tag}.dmg"
-index_name = "compatibility-artifact-index.json"
-if dmg_name not in local_assets or index_name not in local_assets:
-    fail("publication requires Malibu DMG and compatibility artifact index")
-publication_content = {
-    "compatibility_artifact_index_sha256": local_assets[index_name][1],
-    "dmg_sha256": local_assets[dmg_name][1],
-}
-if "appcast.xml" in local_assets:
-    publication_content["appcast_sha256"] = local_assets["appcast.xml"][1]
+if runtime_only:
+    publication_content = {
+        "runtime_assets_sha256": {
+            name: manifest_assets[name]["sha256"] for name in sorted(expected_names)
+        }
+    }
+else:
+    dmg_name = f"Malibu-{tag}.dmg"
+    index_name = "compatibility-artifact-index.json"
+    if dmg_name not in local_assets or index_name not in local_assets:
+        fail("publication requires Malibu DMG and compatibility artifact index")
+    publication_content = {
+        "compatibility_artifact_index_sha256": local_assets[index_name][1],
+        "dmg_sha256": local_assets[dmg_name][1],
+    }
+    if "appcast.xml" in local_assets:
+        publication_content["appcast_sha256"] = local_assets["appcast.xml"][1]
 content = json.dumps(
     publication_content,
     sort_keys=True,

--- a/scripts/test-acceptance-candidate-security.sh
+++ b/scripts/test-acceptance-candidate-security.sh
@@ -436,6 +436,74 @@ pearl = json.loads(pathlib.Path(sys.argv[1]).read_text())
 if pearl.get("channel") != "production":
     raise SystemExit("promotion-ready Pearl metadata did not declare the production channel")
 PY
+python3 "$metadata" build-pearl \
+  --repository Augustas11/macprovider \
+  --tag "$tag" \
+  --commit "$candidate_commit" \
+  --provider-admission-policy strict_post_migration \
+  --runtime-only \
+  --coordinator "$work/assets/coordinator-linux-amd64" \
+  --coordinator-cli "$work/assets/coordinator-cli-linux-amd64" \
+  --gateway "$work/assets/gateway-linux-amd64" \
+  --output "$work/pearl-runtime-only.json"
+python3 - "$work/pearl-runtime-only.json" "$tag" <<'PY'
+import json
+import pathlib
+import sys
+
+pearl = json.loads(pathlib.Path(sys.argv[1]).read_text())
+tag = sys.argv[2]
+if pearl.get("release_lane") != "pearl_runtime":
+    raise SystemExit("runtime-only Pearl metadata did not declare the runtime lane")
+if pearl.get("catalog") is not None:
+    raise SystemExit("runtime-only Pearl metadata bound catalog state")
+if "provider_advertised_version" in pearl:
+    raise SystemExit("runtime-only Pearl metadata carried provider version authority")
+PY
+if python3 "$metadata" build-pearl \
+  --repository Augustas11/macprovider \
+  --tag "$tag" \
+  --commit "$candidate_commit" \
+  --provider-admission-policy strict_post_migration \
+  --provider-advertised-version 1.8.31 \
+  --runtime-only \
+  --coordinator "$work/assets/coordinator-linux-amd64" \
+  --coordinator-cli "$work/assets/coordinator-cli-linux-amd64" \
+  --gateway "$work/assets/gateway-linux-amd64" \
+  --output "$work/pearl-runtime-only-with-provider-version.json" >"$work/runtime-only-provider-version.out" 2>&1; then
+  echo "Pearl metadata builder accepted runtime-only provider version binding" >&2
+  exit 1
+fi
+grep -q -- '--runtime-only cannot bind --provider-advertised-version' "$work/runtime-only-provider-version.out"
+if python3 "$metadata" build-pearl \
+  --repository Augustas11/macprovider \
+  --tag "$tag" \
+  --commit "$candidate_commit" \
+  --provider-admission-policy bridge_required \
+  --runtime-only \
+  --coordinator "$work/assets/coordinator-linux-amd64" \
+  --coordinator-cli "$work/assets/coordinator-cli-linux-amd64" \
+  --gateway "$work/assets/gateway-linux-amd64" \
+  --output "$work/pearl-runtime-only-with-bridge.json" >"$work/runtime-only-bridge.out" 2>&1; then
+  echo "Pearl metadata builder accepted runtime-only provider bridge binding" >&2
+  exit 1
+fi
+grep -q -- '--runtime-only cannot bind provider admission bridge policy' "$work/runtime-only-bridge.out"
+if python3 "$metadata" build-pearl \
+  --repository Augustas11/macprovider \
+  --tag "$tag" \
+  --commit "$candidate_commit" \
+  --compatibility-manifest "$work/pearl-compatibility.json" \
+  --provider-admission-policy bridge_required \
+  --runtime-only \
+  --coordinator "$work/assets/coordinator-linux-amd64" \
+  --coordinator-cli "$work/assets/coordinator-cli-linux-amd64" \
+  --gateway "$work/assets/gateway-linux-amd64" \
+  --output "$work/pearl-runtime-only-with-compatibility.json" >"$work/runtime-only-compatibility.out" 2>&1; then
+  echo "Pearl metadata builder accepted runtime-only compatibility binding" >&2
+  exit 1
+fi
+grep -q -- '--runtime-only cannot bind --compatibility-manifest' "$work/runtime-only-compatibility.out"
 python3 - "$work/pearl-catalog/release.json" <<'PY'
 import json
 import pathlib

--- a/scripts/test-pearl-runtime-release.sh
+++ b/scripts/test-pearl-runtime-release.sh
@@ -3,6 +3,7 @@ set -euo pipefail
 
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 guard="$repo_root/scripts/verify-pearl-runtime-release.sh"
+runtime_workflow="$repo_root/.github/workflows/pearl-runtime-release.yml"
 work="$(mktemp -d "${TMPDIR:-/tmp}/pearl-runtime-release-test.XXXXXX")"
 trap 'rm -rf "$work"' EXIT
 
@@ -12,6 +13,67 @@ fail() {
 }
 
 bash -n "$guard"
+python3 - "$runtime_workflow" <<'PY'
+import pathlib
+import sys
+
+workflow = pathlib.Path(sys.argv[1]).read_text(encoding="utf-8")
+if workflow.count("scripts/verify-github-release-posture.sh") < 3:
+    raise SystemExit("runtime workflow must verify protected posture before signing, draft, and publish")
+before_sign = workflow.split("- name: Sign Pearl runtime metadata and checksums", 1)[0]
+if "Verify protected GitHub release posture before runtime signing" not in before_sign:
+    raise SystemExit("runtime workflow must verify protected posture before importing signing key")
+create = workflow.split("- name: Create verified draft GitHub release", 1)[1].split(
+    "- name: Publish only the revalidated numeric draft", 1
+)[0]
+if "RELEASE_POSTURE_TOKEN" not in create or "verify-github-release-posture.sh" not in create:
+    raise SystemExit("runtime workflow must recheck protected posture before draft creation")
+publish = workflow.split("- name: Publish only the revalidated numeric draft", 1)[1]
+if "RELEASE_POSTURE_TOKEN" not in publish or "verify-github-release-posture.sh" not in publish:
+    raise SystemExit("runtime workflow must recheck protected posture immediately before publication")
+if "make_latest=true" in publish or "true|false) make_latest=false" not in publish:
+    raise SystemExit("runtime workflow must never make a runtime-only release latest")
+if 'RELEASE_PRERELEASE_INPUT: "true"' not in workflow:
+    raise SystemExit("runtime workflow must force GitHub prerelease publication")
+patch_position = publish.find("gh api --method PATCH")
+if patch_position < 0:
+    raise SystemExit("runtime workflow must publish by numeric-ID PATCH")
+positive_latest_position = publish.find("stable latest endpoint before publication did not return a positive release id")
+if positive_latest_position < 0 or positive_latest_position > patch_position:
+    raise SystemExit("runtime workflow must validate stable latest before publishing anything")
+if "-F prerelease=false" in publish:
+    raise SystemExit("runtime workflow must never promote runtime-only releases to GitHub stable releases")
+for required in (
+    "capture-release-publication.py --draft --runtime-only",
+    "--expected-title \"Pearl runtime $tag\"",
+    "final-draft-api.json release-provenance.json final-draft-manifest.json",
+):
+    if publish.find(required) < 0 or publish.find(required) > patch_position:
+        raise SystemExit(f"runtime workflow draft asset capture is incomplete: {required}")
+for required in (
+    "-F prerelease=true",
+    "published-release-api.json",
+    "immutable-release-by-id.json release-provenance.json publication-manifest-by-id.json",
+    "immutable-release-by-tag.json release-provenance.json publication-manifest-by-tag.json",
+    "cmp final-draft-manifest.json publication-manifest-by-id.json",
+    "cmp final-draft-manifest.json publication-manifest-by-tag.json",
+):
+    if publish.find(required, patch_position) < 0:
+        raise SystemExit(f"runtime workflow immutable asset capture is incomplete: {required}")
+for required in (
+    "stable-latest-before.json",
+    "stable-latest-after.json",
+    "stable latest endpoint before publication did not return a positive release id",
+    "stable latest endpoint after publication did not return a positive release id",
+    "runtime-only release unexpectedly resolves through the stable latest endpoint",
+    "runtime-only release changed the stable latest endpoint",
+):
+    if required not in publish:
+        raise SystemExit(f"runtime workflow latest-preservation check is incomplete: {required}")
+latest_window = publish[publish.find("stable-latest-before.json"):publish.find("python3 scripts/capture-release-publication.py --runtime-only")]
+if "printf '%s\\n' '{}'" in latest_window:
+    raise SystemExit("runtime workflow must fail closed when stable latest cannot be fetched")
+PY
 
 git init --bare -q "$work/remote.git"
 git init -q "$work/source"
@@ -33,6 +95,7 @@ make_release_dir() {
   local directory="$1"
   local tag="$2"
   local commit="$3"
+  local lane="${4:-pearl_runtime_catalog}"
   rm -rf "$directory"
   mkdir -p "$directory"
   printf '%s\n' coordinator > "$directory/coordinator-linux-amd64"
@@ -47,7 +110,7 @@ make_release_dir() {
   printf '%s\n' autotune-candidates-sig > "$directory/autotune-candidates.json.sig"
   printf '%s\n' demand-rank > "$directory/demand-rank.json"
   printf '%s\n' demand-rank-sig > "$directory/demand-rank.json.sig"
-  python3 - "$directory" "$tag" "$commit" <<'PY'
+  python3 - "$directory" "$tag" "$commit" "$lane" <<'PY'
 import hashlib
 import json
 import pathlib
@@ -56,19 +119,38 @@ import sys
 directory = pathlib.Path(sys.argv[1])
 tag = sys.argv[2]
 commit = sys.argv[3]
+lane = sys.argv[4]
 version = tag.removeprefix("v")
 
 def digest(name: str) -> str:
     return hashlib.sha256((directory / name).read_bytes()).hexdigest()
 
+catalog = None
+if lane == "pearl_runtime_catalog":
+    catalog = {
+        "release_id": "test-release",
+        "policy_version": "test-policy",
+        "files": {
+            "release.json": digest("release.json"),
+            "trusted-keys.json": digest("trusted-keys.json"),
+            "tier2-catalog.json": digest("tier2-catalog.json"),
+            "autotune-candidates.json": digest("autotune-candidates.json"),
+            "autotune-candidates.json.sig": digest("autotune-candidates.json.sig"),
+            "demand-rank.json": digest("demand-rank.json"),
+            "demand-rank.json.sig": digest("demand-rank.json.sig"),
+        },
+    }
+elif lane != "pearl_runtime":
+    raise SystemExit(f"unsupported lane: {lane}")
+
 metadata = {
     "schema_version": 1,
+    "release_lane": lane,
     "repository": "Augustas11/macprovider",
     "tag": tag,
     "release_version": version,
     "commit": commit,
     "architecture": "linux-amd64",
-    "provider_advertised_version": version,
     "components": {
         "coordinator": {
             "asset": "coordinator-linux-amd64",
@@ -81,20 +163,16 @@ metadata = {
             "embedded_version": tag,
         },
     },
-    "catalog": {
-        "release_id": "test-release",
-        "policy_version": "test-policy",
-        "files": {
-            "release.json": digest("release.json"),
-            "trusted-keys.json": digest("trusted-keys.json"),
-            "tier2-catalog.json": digest("tier2-catalog.json"),
-            "autotune-candidates.json": digest("autotune-candidates.json"),
-            "autotune-candidates.json.sig": digest("autotune-candidates.json.sig"),
-            "demand-rank.json": digest("demand-rank.json"),
-            "demand-rank.json.sig": digest("demand-rank.json.sig"),
+    "catalog": catalog,
+    "operator_artifacts": {
+        "coordinator_cli": {
+            "asset": "coordinator-cli-linux-amd64",
+            "sha256": digest("coordinator-cli-linux-amd64"),
         },
     },
 }
+if lane == "pearl_runtime_catalog":
+    metadata["provider_advertised_version"] = version
 (directory / "pearl-release.json").write_text(
     json.dumps(metadata, sort_keys=True, separators=(",", ":")) + "\n",
     encoding="utf-8",
@@ -108,10 +186,148 @@ for path in sorted(directory.iterdir()):
 PY
 }
 
+fake_gh_dir="$work/fake-gh"
+mkdir -p "$fake_gh_dir"
+cat > "$fake_gh_dir/gh" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ "${1:-}" != "release" ]]; then
+  echo "unsupported fake gh command" >&2
+  exit 2
+fi
+shift
+case "${1:-}" in
+  view)
+    tag="$2"
+    python3 - "$FAKE_GH_RELEASE_DIR" "$tag" <<'PY'
+import json
+import os
+import pathlib
+import sys
+
+directory = pathlib.Path(sys.argv[1])
+tag = sys.argv[2]
+assets = [{"name": path.name} for path in sorted(directory.iterdir()) if path.is_file()]
+metadata = json.loads((directory / "pearl-release.json").read_text(encoding="utf-8"))
+prerelease = metadata.get("release_lane") == "pearl_runtime"
+if os.environ.get("FAKE_GH_PRERELEASE") == "false":
+    prerelease = False
+print(json.dumps({
+    "tagName": tag,
+    "isDraft": False,
+    "isPrerelease": prerelease,
+    "assets": assets,
+}))
+PY
+    ;;
+  download)
+    tag="$2"
+    shift 2
+    destination=""
+    patterns=()
+    while [[ $# -gt 0 ]]; do
+      case "$1" in
+        --repo)
+          shift 2
+          ;;
+        --dir)
+          destination="$2"
+          shift 2
+          ;;
+        --pattern)
+          patterns+=("$2")
+          shift 2
+          ;;
+        --clobber)
+          shift
+          ;;
+        *)
+          echo "unsupported fake gh release download argument: $1" >&2
+          exit 2
+          ;;
+      esac
+    done
+    mkdir -p "$destination"
+    for pattern in "${patterns[@]}"; do
+      cp "$FAKE_GH_RELEASE_DIR/$pattern" "$destination/$pattern"
+    done
+    ;;
+  *)
+    echo "unsupported fake gh release subcommand: ${1:-}" >&2
+    exit 2
+    ;;
+esac
+SH
+chmod +x "$fake_gh_dir/gh"
+
 make_release_dir "$work/release-ok" v1.8.66 "$second"
 bash "$guard" --tag v1.8.66 --expected-commit "$second" \
   --remote "$work/remote.git" --release-dir "$work/release-ok" |
   grep -q 'ok: v1.8.66 has Pearl runtime assets'
+
+make_release_dir "$work/release-runtime-only" v1.8.66 "$second" pearl_runtime
+rm "$work/release-runtime-only"/release.json \
+  "$work/release-runtime-only"/trusted-keys.json \
+  "$work/release-runtime-only"/tier2-catalog.json \
+  "$work/release-runtime-only"/autotune-candidates.json \
+  "$work/release-runtime-only"/autotune-candidates.json.sig \
+  "$work/release-runtime-only"/demand-rank.json \
+  "$work/release-runtime-only"/demand-rank.json.sig
+bash "$guard" --tag v1.8.66 --expected-commit "$second" \
+  --remote "$work/remote.git" --release-dir "$work/release-runtime-only" |
+  grep -q 'ok: v1.8.66 has Pearl runtime assets'
+
+make_release_dir "$work/release-catalog-bound-missing-feed" v1.8.66 "$second"
+rm "$work/release-catalog-bound-missing-feed/demand-rank.json"
+if bash "$guard" --tag v1.8.66 --expected-commit "$second" \
+  --remote "$work/remote.git" --release-dir "$work/release-catalog-bound-missing-feed" \
+  >"$work/catalog-bound-missing-feed.out" 2>&1; then
+  fail "accepted a catalog-bound Pearl runtime release missing a feed asset"
+fi
+grep -q 'missing catalog/feed asset(s) for catalog-bound Pearl runtime release: demand-rank.json' \
+  "$work/catalog-bound-missing-feed.out"
+
+make_release_dir "$work/release-catalog-bound-tampered-feed" v1.8.66 "$second"
+printf '\n' >> "$work/release-catalog-bound-tampered-feed/autotune-candidates.json"
+if bash "$guard" --tag v1.8.66 --expected-commit "$second" \
+  --remote "$work/remote.git" --release-dir "$work/release-catalog-bound-tampered-feed" \
+  >"$work/catalog-bound-tampered-feed.out" 2>&1; then
+  fail "accepted a catalog-bound Pearl runtime release with tampered feed bytes"
+fi
+grep -q 'autotune-candidates.json sha256 does not match pearl-release.json catalog metadata' \
+  "$work/catalog-bound-tampered-feed.out"
+
+make_release_dir "$work/release-github-runtime-only" v1.8.66 "$second" pearl_runtime
+rm "$work/release-github-runtime-only"/release.json \
+  "$work/release-github-runtime-only"/trusted-keys.json \
+  "$work/release-github-runtime-only"/tier2-catalog.json \
+  "$work/release-github-runtime-only"/autotune-candidates.json \
+  "$work/release-github-runtime-only"/autotune-candidates.json.sig \
+  "$work/release-github-runtime-only"/demand-rank.json \
+  "$work/release-github-runtime-only"/demand-rank.json.sig
+FAKE_GH_RELEASE_DIR="$work/release-github-runtime-only" PATH="$fake_gh_dir:$PATH" \
+  bash "$guard" --tag v1.8.66 --expected-commit "$second" \
+    --remote "$work/remote.git" |
+  grep -q 'ok: v1.8.66 has Pearl runtime assets'
+
+if FAKE_GH_RELEASE_DIR="$work/release-github-runtime-only" FAKE_GH_PRERELEASE=false PATH="$fake_gh_dir:$PATH" \
+  bash "$guard" --tag v1.8.66 --expected-commit "$second" \
+    --remote "$work/remote.git" >"$work/github-runtime-only-stable.out" 2>&1; then
+  fail "accepted a GitHub runtime-only Pearl release that was not a prerelease"
+fi
+grep -q 'runtime-only Pearl releases must be GitHub prereleases' \
+  "$work/github-runtime-only-stable.out"
+
+make_release_dir "$work/release-github-catalog-bound-missing-feed" v1.8.66 "$second"
+rm "$work/release-github-catalog-bound-missing-feed/demand-rank.json"
+if FAKE_GH_RELEASE_DIR="$work/release-github-catalog-bound-missing-feed" PATH="$fake_gh_dir:$PATH" \
+  bash "$guard" --tag v1.8.66 --expected-commit "$second" \
+    --remote "$work/remote.git" >"$work/github-catalog-bound-missing-feed.out" 2>&1; then
+  fail "accepted a GitHub catalog-bound Pearl runtime release missing a feed asset"
+fi
+grep -q 'missing catalog/feed asset(s) for catalog-bound Pearl runtime release: demand-rank.json' \
+  "$work/github-catalog-bound-missing-feed.out"
 
 if bash "$guard" --tag v1.8.65 --expected-commit "$second" \
   --remote "$work/remote.git" --release-dir "$work/release-ok" \

--- a/scripts/test-release-publication-provenance.sh
+++ b/scripts/test-release-publication-provenance.sh
@@ -111,6 +111,136 @@ python3 "$capture" --draft --notes-file "$work/release-notes.md" \
   "$work/draft-publication-manifest.json" "${local_assets[@]}"
 cmp "$work/publication-manifest.json" "$work/draft-publication-manifest.json"
 
+runtime="$work/runtime"
+mkdir -p "$runtime"
+printf 'runtime coordinator payload\n' > "$runtime/coordinator-linux-amd64"
+printf 'runtime coordinator cli payload\n' > "$runtime/coordinator-cli-linux-amd64"
+printf 'runtime gateway payload\n' > "$runtime/gateway-linux-amd64"
+printf 'runtime pearl metadata\n' > "$runtime/pearl-release.json"
+printf 'runtime pearl metadata signature\n' > "$runtime/pearl-release.json.sig"
+printf 'runtime release notes\n' > "$runtime/release-notes.md"
+cp "$work/release-toolchain.json" "$runtime/release-toolchain.json"
+python3 "$build" "$tag" "$commit" Augustas11/macprovider false \
+  "$runtime/release-toolchain.json" "$runtime/release-provenance.json" \
+  "$runtime/coordinator-linux-amd64" "$runtime/coordinator-cli-linux-amd64" \
+  "$runtime/gateway-linux-amd64" "$runtime/pearl-release.json" \
+  "$runtime/pearl-release.json.sig"
+(
+  cd "$runtime"
+  shasum -a 256 \
+    coordinator-linux-amd64 coordinator-cli-linux-amd64 gateway-linux-amd64 \
+    pearl-release.json pearl-release.json.sig release-provenance.json \
+    > checksums.txt
+)
+printf 'runtime checksum signature\n' > "$runtime/checksums.txt.sig"
+python3 - "$runtime" "$tag" "$commit" <<'PY'
+import hashlib
+import json
+import pathlib
+import sys
+
+root, tag, commit = pathlib.Path(sys.argv[1]), sys.argv[2], sys.argv[3]
+names = [
+    "coordinator-linux-amd64",
+    "coordinator-cli-linux-amd64",
+    "gateway-linux-amd64",
+    "pearl-release.json",
+    "pearl-release.json.sig",
+    "release-provenance.json",
+    "checksums.txt",
+    "checksums.txt.sig",
+]
+assets = []
+for asset_id, name in enumerate(names, 701):
+    digest = hashlib.sha256((root / name).read_bytes()).hexdigest()
+    assets.append({"id": asset_id, "name": name, "digest": f"sha256:{digest}"})
+release = {
+    "id": 601,
+    "tag_name": tag,
+    "target_commitish": commit,
+    "draft": True,
+    "immutable": False,
+    "prerelease": False,
+    "name": f"Pearl runtime {tag}",
+    "body": "runtime release notes\n",
+    "assets": assets,
+}
+(root / "release-draft.json").write_text(json.dumps(release), encoding="utf-8")
+PY
+runtime_assets=(
+  "$runtime/coordinator-linux-amd64"
+  "$runtime/coordinator-cli-linux-amd64"
+  "$runtime/gateway-linux-amd64"
+  "$runtime/pearl-release.json"
+  "$runtime/pearl-release.json.sig"
+  "$runtime/release-provenance.json"
+  "$runtime/checksums.txt"
+  "$runtime/checksums.txt.sig"
+)
+python3 "$capture" --draft --runtime-only \
+  --notes-file "$runtime/release-notes.md" --expected-title "Pearl runtime $tag" \
+  "$runtime/release-draft.json" "$runtime/release-provenance.json" \
+  "$runtime/draft-publication-manifest.json" "${runtime_assets[@]}"
+python3 - "$runtime/release-draft.json" "$runtime/release-public.json" <<'PY'
+import json, pathlib, sys
+draft_path, public_path = map(pathlib.Path, sys.argv[1:])
+public = json.loads(draft_path.read_text())
+public["draft"] = False
+public["immutable"] = True
+public["prerelease"] = False
+public_path.write_text(json.dumps(public), encoding="utf-8")
+PY
+python3 "$capture" --runtime-only \
+  --notes-file "$runtime/release-notes.md" --expected-title "Pearl runtime $tag" \
+  "$runtime/release-public.json" "$runtime/release-provenance.json" \
+  "$runtime/final-publication-manifest.json" "${runtime_assets[@]}"
+cmp "$runtime/draft-publication-manifest.json" "$runtime/final-publication-manifest.json"
+
+python3 - "$runtime/release-draft.json" "$runtime/release-drift.json" <<'PY'
+import json, pathlib, sys
+data = json.loads(pathlib.Path(sys.argv[1]).read_text())
+data["assets"][1]["digest"] = "sha256:" + "0" * 64
+pathlib.Path(sys.argv[2]).write_text(json.dumps(data))
+PY
+if python3 "$capture" --draft --runtime-only \
+  --notes-file "$runtime/release-notes.md" --expected-title "Pearl runtime $tag" \
+  "$runtime/release-drift.json" "$runtime/release-provenance.json" \
+  "$runtime/drift-manifest.json" "${runtime_assets[@]}" >"$runtime/drift.out" 2>&1; then
+  echo "runtime draft capture accepted GitHub asset digest drift" >&2
+  exit 1
+fi
+grep -q 'GitHub digest differs from captured workflow asset' "$runtime/drift.out"
+
+python3 - "$runtime/release-draft.json" "$runtime/release-missing.json" <<'PY'
+import json, pathlib, sys
+data = json.loads(pathlib.Path(sys.argv[1]).read_text())
+data["assets"] = [row for row in data["assets"] if row["name"] != "gateway-linux-amd64"]
+pathlib.Path(sys.argv[2]).write_text(json.dumps(data))
+PY
+if python3 "$capture" --draft --runtime-only \
+  --notes-file "$runtime/release-notes.md" --expected-title "Pearl runtime $tag" \
+  "$runtime/release-missing.json" "$runtime/release-provenance.json" \
+  "$runtime/missing-manifest.json" "${runtime_assets[@]}" >"$runtime/missing.out" 2>&1; then
+  echo "runtime draft capture accepted a missing GitHub asset" >&2
+  exit 1
+fi
+grep -q 'asset names differ from the signed release set' "$runtime/missing.out"
+
+python3 - "$runtime/release-draft.json" "$runtime/release-extra.json" <<'PY'
+import json, pathlib, sys
+data = json.loads(pathlib.Path(sys.argv[1]).read_text())
+data["assets"].append({"id": 999, "name": "unexpected", "digest": "sha256:" + "0" * 64})
+pathlib.Path(sys.argv[2]).write_text(json.dumps(data))
+PY
+if python3 "$capture" --draft --runtime-only \
+  --notes-file "$runtime/release-notes.md" --expected-title "Pearl runtime $tag" \
+  "$runtime/release-extra.json" "$runtime/release-provenance.json" \
+  "$runtime/extra-manifest.json" "${runtime_assets[@]}" >"$runtime/extra.out" 2>&1; then
+  echo "runtime draft capture accepted an unsigned extra GitHub asset" >&2
+  exit 1
+fi
+grep -q 'asset names differ from the signed release set' "$runtime/extra.out"
+
 cat > "$work/release-draft-cli.json" <<EOF
 {"databaseId":401,"isDraft":true,"tagName":"$tag","targetCommitish":"$commit"}
 EOF

--- a/scripts/verify-pearl-runtime-release.sh
+++ b/scripts/verify-pearl-runtime-release.sh
@@ -87,13 +87,6 @@ required_assets=(
   coordinator-linux-amd64
   coordinator-cli-linux-amd64
   gateway-linux-amd64
-  release.json
-  trusted-keys.json
-  tier2-catalog.json
-  autotune-candidates.json
-  autotune-candidates.json.sig
-  demand-rank.json
-  demand-rank.json.sig
 )
 
 validate_release_dir() {
@@ -139,6 +132,9 @@ except Exception as exc:
 
 if not isinstance(metadata, dict) or metadata.get("schema_version") != 1:
     fail("pearl-release.json has unsupported schema")
+lane = metadata.get("release_lane", "pearl_runtime_catalog")
+if lane not in {"pearl_runtime", "pearl_runtime_catalog"}:
+    fail("pearl-release.json release_lane is invalid")
 if metadata.get("repository") != repository:
     fail(f"pearl-release.json repository is {metadata.get('repository')!r}, expected {repository!r}")
 if metadata.get("tag") != tag:
@@ -150,8 +146,12 @@ if metadata.get("architecture") != "linux-amd64":
 version = tag.removeprefix("v")
 if metadata.get("release_version") != version:
     fail("pearl-release.json release_version does not match the tag")
-if metadata.get("provider_advertised_version") != version:
-    fail("pearl-release.json provider_advertised_version does not match the tag")
+if lane == "pearl_runtime":
+    if "provider_advertised_version" in metadata:
+        fail("pearl-release.json runtime-only lane must not carry provider advertised version")
+else:
+    if metadata.get("provider_advertised_version") != version:
+        fail("pearl-release.json provider_advertised_version does not match the tag")
 
 components = metadata.get("components")
 if not isinstance(components, dict):
@@ -172,6 +172,17 @@ for name, asset in component_assets.items():
     actual = hashlib.sha256((directory / asset).read_bytes()).hexdigest()
     if actual != digest:
         fail(f"{asset} sha256 does not match pearl-release.json")
+
+operator_artifacts = metadata.get("operator_artifacts")
+coordinator_cli = operator_artifacts.get("coordinator_cli") if isinstance(operator_artifacts, dict) else None
+if not isinstance(coordinator_cli, dict) or coordinator_cli.get("asset") != "coordinator-cli-linux-amd64":
+    fail("pearl-release.json coordinator CLI artifact does not bind coordinator-cli-linux-amd64")
+coordinator_cli_digest = coordinator_cli.get("sha256")
+if not isinstance(coordinator_cli_digest, str) or not sha_re.fullmatch(coordinator_cli_digest):
+    fail("pearl-release.json coordinator CLI sha256 is invalid")
+actual = hashlib.sha256((directory / "coordinator-cli-linux-amd64").read_bytes()).hexdigest()
+if actual != coordinator_cli_digest:
+    fail("coordinator-cli-linux-amd64 sha256 does not match pearl-release.json")
 
 checksums = {}
 for raw in (directory / "checksums.txt").read_text(encoding="utf-8").splitlines():
@@ -194,9 +205,6 @@ for asset in required_assets:
         fail(f"checksums.txt digest mismatch for {asset}")
 
 catalog = metadata.get("catalog")
-if not isinstance(catalog, dict):
-    fail("pearl-release.json catalog metadata is missing")
-catalog_files = catalog.get("files")
 expected_catalog_assets = {
     "release.json",
     "trusted-keys.json",
@@ -206,8 +214,30 @@ expected_catalog_assets = {
     "demand-rank.json",
     "demand-rank.json.sig",
 }
-if set(catalog_files if isinstance(catalog_files, dict) else ()) != expected_catalog_assets:
-    fail("pearl-release.json catalog file set is invalid")
+if lane == "pearl_runtime":
+    if catalog not in (None, {}):
+        fail("pearl-release.json runtime-only lane must not bind catalog/feed assets")
+else:
+    if not isinstance(catalog, dict):
+        fail("pearl-release.json catalog metadata is missing")
+    catalog_files = catalog.get("files")
+    if set(catalog_files if isinstance(catalog_files, dict) else ()) != expected_catalog_assets:
+        fail("pearl-release.json catalog file set is invalid")
+    missing_catalog = sorted(asset for asset in expected_catalog_assets if not (directory / asset).is_file())
+    if missing_catalog:
+        fail("missing catalog/feed asset(s) for catalog-bound Pearl runtime release: " + " ".join(missing_catalog))
+    for asset in sorted(expected_catalog_assets):
+        metadata_digest = catalog_files.get(asset)
+        if not isinstance(metadata_digest, str) or not sha_re.fullmatch(metadata_digest):
+            fail(f"pearl-release.json catalog sha256 is invalid for {asset}")
+        actual = hashlib.sha256((directory / asset).read_bytes()).hexdigest()
+        if actual != metadata_digest:
+            fail(f"{asset} sha256 does not match pearl-release.json catalog metadata")
+        checksum_digest = checksums.get(asset)
+        if checksum_digest is None:
+            fail(f"checksums.txt omits catalog/feed asset: {asset}")
+        if checksum_digest != actual:
+            fail(f"checksums.txt digest mismatch for catalog/feed asset: {asset}")
 
 print(f"[verify-pearl-runtime-release] ok: {tag} has Pearl runtime assets for {expected_commit}")
 PY
@@ -222,7 +252,7 @@ command -v gh >/dev/null 2>&1 || die "gh CLI is required unless --release-dir is
 work="$(mktemp -d "${TMPDIR:-/tmp}/pearl-runtime-release.XXXXXX")"
 trap 'rm -rf "$work"' EXIT
 
-if ! gh release view "$tag" --repo "$repository" --json tagName,isDraft,assets > "$work/release.json" 2>"$work/release.err"; then
+if ! gh release view "$tag" --repo "$repository" --json tagName,isDraft,isPrerelease,assets > "$work/release.json" 2>"$work/release.err"; then
   die "Pearl runtime release assets are missing for $tag: GitHub release not found"
 fi
 
@@ -255,65 +285,79 @@ if missing:
 PY
 
 gh release download "$tag" --repo "$repository" --dir "$work/assets" \
-  --pattern pearl-release.json --pattern checksums.txt --clobber >/dev/null
+  --pattern pearl-release.json --pattern pearl-release.json.sig \
+  --pattern checksums.txt --pattern checksums.txt.sig \
+  --pattern coordinator-linux-amd64 --pattern coordinator-cli-linux-amd64 \
+  --pattern gateway-linux-amd64 --clobber >/dev/null
 
-# Download only the runtime pair for digest validation. The asset-list check
-# above proves the remaining signed catalog/operator files are present, and the
-# updater performs full signature and catalog validation before live mutation.
-gh release download "$tag" --repo "$repository" --dir "$work/assets" \
-  --pattern coordinator-linux-amd64 --pattern gateway-linux-amd64 --clobber >/dev/null
-
-# Create empty placeholders for already-proven present assets that are not
-# downloaded in GitHub mode. Their checksums are verified by macprovider-pearl-update.
-for asset in "${required_assets[@]}"; do
-  [[ -e "$work/assets/$asset" ]] || : > "$work/assets/$asset"
-done
-
-PEARL_RELEASE_DIR="$work/assets" \
-PEARL_RELEASE_TAG="$tag" \
-PEARL_RELEASE_EXPECTED_COMMIT="$expected_commit" \
-PEARL_RELEASE_REPOSITORY="$repository" \
-PEARL_RELEASE_REQUIRED_ASSETS="$(printf '%s\n' pearl-release.json checksums.txt coordinator-linux-amd64 gateway-linux-amd64)" \
-  python3 - <<'PY'
-import hashlib
+lane="$(
+  PEARL_RELEASE_METADATA="$work/assets/pearl-release.json" python3 - <<'PY'
 import json
 import os
-import pathlib
-import re
 import sys
 
-
-def fail(message: str) -> None:
-    print(f"[verify-pearl-runtime-release] ERROR: {message}", file=sys.stderr)
+try:
+    metadata = json.loads(open(os.environ["PEARL_RELEASE_METADATA"], encoding="utf-8").read())
+except Exception as exc:
+    print(f"[verify-pearl-runtime-release] ERROR: pearl-release.json is not valid JSON: {exc}", file=sys.stderr)
     raise SystemExit(1)
-
-
-directory = pathlib.Path(os.environ["PEARL_RELEASE_DIR"])
-tag = os.environ["PEARL_RELEASE_TAG"]
-expected_commit = os.environ["PEARL_RELEASE_EXPECTED_COMMIT"]
-repository = os.environ["PEARL_RELEASE_REPOSITORY"]
-metadata = json.loads((directory / "pearl-release.json").read_text(encoding="utf-8"))
-if metadata.get("repository") != repository:
-    fail("pearl-release.json repository mismatch")
-if metadata.get("tag") != tag:
-    fail("pearl-release.json tag mismatch")
-if metadata.get("commit") != expected_commit:
-    fail(f"pearl-release.json commit is {metadata.get('commit')!r}, expected {expected_commit!r}")
-if metadata.get("architecture") != "linux-amd64":
-    fail("pearl-release.json architecture must be linux-amd64")
-components = metadata.get("components")
-if not isinstance(components, dict):
-    fail("pearl-release.json components are missing")
-sha_re = re.compile(r"^[0-9a-f]{64}$")
-for name, asset in (("coordinator", "coordinator-linux-amd64"), ("gateway", "gateway-linux-amd64")):
-    row = components.get(name)
-    if not isinstance(row, dict) or row.get("asset") != asset:
-        fail(f"pearl-release.json {name} component does not bind {asset}")
-    digest = row.get("sha256")
-    if not isinstance(digest, str) or not sha_re.fullmatch(digest):
-        fail(f"pearl-release.json {name} sha256 is invalid")
-    actual = hashlib.sha256((directory / asset).read_bytes()).hexdigest()
-    if actual != digest:
-        fail(f"{asset} sha256 does not match pearl-release.json")
-print(f"[verify-pearl-runtime-release] ok: {tag} has Pearl runtime assets for {expected_commit}")
+lane = metadata.get("release_lane", "pearl_runtime_catalog") if isinstance(metadata, dict) else None
+if lane not in {"pearl_runtime", "pearl_runtime_catalog"}:
+    print("[verify-pearl-runtime-release] ERROR: pearl-release.json release_lane is invalid", file=sys.stderr)
+    raise SystemExit(1)
+print(lane)
 PY
+)"
+
+if [[ "$lane" = "pearl_runtime_catalog" ]]; then
+  catalog_assets=(
+    release.json
+    trusted-keys.json
+    tier2-catalog.json
+    autotune-candidates.json
+    autotune-candidates.json.sig
+    demand-rank.json
+    demand-rank.json.sig
+  )
+  PEARL_RELEASE_VIEW="$work/release.json" \
+  PEARL_RELEASE_CATALOG_ASSETS="$(printf '%s\n' "${catalog_assets[@]}")" \
+    python3 - <<'PY'
+import json
+import os
+import sys
+
+payload = json.loads(open(os.environ["PEARL_RELEASE_VIEW"], encoding="utf-8").read())
+assets = payload.get("assets")
+names = {row.get("name") for row in assets if isinstance(row, dict)}
+required = {line for line in os.environ["PEARL_RELEASE_CATALOG_ASSETS"].splitlines() if line}
+missing = sorted(required - names)
+if missing:
+    print(
+        "[verify-pearl-runtime-release] ERROR: missing catalog/feed asset(s) for catalog-bound Pearl runtime release: "
+        + " ".join(missing),
+        file=sys.stderr,
+    )
+    raise SystemExit(1)
+PY
+  gh release download "$tag" --repo "$repository" --dir "$work/assets" \
+    --pattern release.json --pattern trusted-keys.json \
+    --pattern tier2-catalog.json --pattern autotune-candidates.json \
+    --pattern autotune-candidates.json.sig --pattern demand-rank.json \
+    --pattern demand-rank.json.sig --clobber >/dev/null
+else
+  PEARL_RELEASE_VIEW="$work/release.json" python3 - <<'PY'
+import json
+import os
+import sys
+
+payload = json.loads(open(os.environ["PEARL_RELEASE_VIEW"], encoding="utf-8").read())
+if payload.get("isPrerelease") is not True:
+    print(
+        "[verify-pearl-runtime-release] ERROR: runtime-only Pearl releases must be GitHub prereleases",
+        file=sys.stderr,
+    )
+    raise SystemExit(1)
+PY
+fi
+
+validate_release_dir "$work/assets"


### PR DESCRIPTION
## Summary
- Fixes #792 by splitting Pearl runtime-only release publication from the catalog-bound provider release lane.
- Forces runtime-only GitHub releases to publish as prerelease/non-latest and captures remote immutable asset provenance after upload.
- Keeps updater auto-discovery and config reconciliation on catalog/feed/provider authority unless an explicit runtime tag is requested.

## Verification
- PASS: 3-lane Codex auditors code/security/architect at 0 Critical/High/Medium findings.
- `bash scripts/test-pearl-runtime-release.sh`
- `bash scripts/test-release-publication-provenance.sh`
- `bash scripts/test-release-security-posture.sh`
- `bash scripts/test-acceptance-candidate-security.sh`
- `bash scripts/test-acceptance-candidate-metadata.sh`
- `PYTHONDONTWRITEBYTECODE=1 python3 -m unittest -q ops/pearl-updater/test_pearl_updater.py`
- `go test ./internal/autotune`
- YAML parse, shell syntax, Python compile, and `git diff --check origin/main`

## Governance
SPEC-GOVERNANCE-DECLARATION-BEGIN
{
  "schema_version": "spec-pr-governance-v1",
  "behavior_change": "yes",
  "contract_change": "none",
  "issue": "https://github.com/Augustas11/macprovider/issues/792",
  "specs": ["SPEC-020", "SPEC-023", "SPEC-010"],
  "requirements": ["SPEC-020-R001", "SPEC-020-R002", "SPEC-020-R003", "SPEC-023-R001", "SPEC-010-R001", "SPEC-010-R004"],
  "authority_domains": ["provider-autoupdate", "installer-autotune-policy", "model-catalog-identity"],
  "arbitration": ["UNKNOWN"],
  "tests": [
    "bash scripts/test-pearl-runtime-release.sh",
    "bash scripts/test-release-publication-provenance.sh",
    "bash scripts/test-release-security-posture.sh",
    "bash scripts/test-acceptance-candidate-security.sh",
    "bash scripts/test-acceptance-candidate-metadata.sh",
    "PYTHONDONTWRITEBYTECODE=1 python3 -m unittest -q ops/pearl-updater/test_pearl_updater.py",
    "go test ./internal/autotune"
  ],
  "journeys": ["not-required"]
}
SPEC-GOVERNANCE-DECLARATION-END

## Notes
- Runtime-only releases remain explicit-tag only.
- GitHub-hosted release publication workflow was not live-run locally; coverage is via workflow/static checks and shell regression harnesses.