### PR TITLE
SPEC-038 continuous-batching scaffold — flag-off, serial-identical (no engine wired)

### DIFF
--- a/audits/2026-07-29/AUDIT_SPEC_038_SCAFFOLD_ARCHITECT.md
+++ b/audits/2026-07-29/AUDIT_SPEC_038_SCAFFOLD_ARCHITECT.md
@@ -1,0 +1,56 @@
+# SPEC-038 scaffold BUILD audit — ARCHITECT lane
+
+First read the shared context file in this same directory:
+`AUDIT_SPEC_038_SCAFFOLD_COMMON.md`. It defines the worktree, the diff range to
+audit, what the scaffold intentionally is, and what NOT to flag.
+
+You are the architect lane. Weight your review toward SPEC-038 conformance and
+the durability of the engine-agnostic seam, each anchored to a diff line and,
+where relevant, a `SPEC-038-R0xx` / `FR-CB*` requirement:
+
+1. **SPEC conformance of what IS built.** The scaffold only claims to satisfy a
+   subset of requirements: FR-CB9 (flag-off serial identity), FR-CB8 (explicit
+   reason-coded rejection / permissive serial route, never silent downgrade),
+   FR-CB10 (version-pin discipline: unreviewed API must not float into serve
+   path — here enforced by `reviewedUpstreamBatchRevision == nil` + strict
+   fail), FR-CB12 (SPEC-028 draft mutual exclusion), FR-CB14 (aggregate-TG as
+   total tokens over common wall-clock). Verify the code actually upholds each of
+   these it claims, and that it does NOT overclaim any requirement it does not
+   implement (e.g. it must not report itself as doing a shared forward /
+   continuous batching in telemetry — FR-CB3/FR-CB14).
+
+2. **No contradiction with the merged normative SPEC.** Cross-check the outcome
+   mode-matrix (SPEC §5) and the reason codes against the SPEC's named errors.
+   The scaffold reuses `draft_model_capacity_shortfall` for the draft-exclusion
+   reason and status 503 vs 400 split (unpinned = 503, kv_bits/draft = 400).
+   Is that consistent with SPEC-038 FR-CB8/FR-CB12 and existing SPEC-028
+   behavior? Flag any place the scaffold's behavior would contradict the SPEC a
+   future engine PR must honor.
+
+3. **Engine-agnostic seam quality.** Is the seam (`ContinuousBatchingPolicy`,
+   `ContinuousBatchingCapability`, the `ModelRuntime` hooks) shaped so the real
+   Approach-A upstream engine — or the Approach-B fallback — can be dropped in
+   WITHOUT reworking config/CLI/telemetry or breaking flag-off parity? Call out
+   seam decisions that will force churn or a breaking change when the engine
+   lands (e.g. capability struct missing a field the engine needs, policy
+   evaluated at the wrong lifecycle point, `shouldUseSerialPath` semantics that
+   won't extend to a real supported-batch case).
+
+4. **Capacity mapping direction (FR-CB11).** `maxActiveRows` is derived from
+   `maxBatch` / Entry 110 `max_concurrency_override`. Confirm the scaffold does
+   not synthesize capacity above Entry 110 and does not alter `slots_total` /
+   `slots_free`. (The engine will own the live mapping; here only confirm the
+   scaffold doesn't move it.)
+
+5. **Independence & isolation (FR-CB7, FR-CB16).** The policy lives on the
+   `ModelRuntime` actor. Confirm no new shared mutable state escapes the actor,
+   and nothing here touches SPEC-037 KV persistence layout.
+
+6. **Test adequacy for the seam.** Do the tests cover the requirement subset the
+   scaffold claims (defaults, precedence, strict rejection reason precedence,
+   permissive route, draft exclusion, queue-limit default/validation, runtime
+   threading, MSB math)? Name any claimed-behavior gap with no test.
+
+Report per the severity bar in the shared context. Anchor every finding to a
+diff line and, where applicable, a requirement ID. State explicitly if a
+weighting question above is clean.

--- a/audits/2026-07-29/AUDIT_SPEC_038_SCAFFOLD_CODE.md
+++ b/audits/2026-07-29/AUDIT_SPEC_038_SCAFFOLD_CODE.md
@@ -1,0 +1,51 @@
+# SPEC-038 scaffold BUILD audit — CODE lane
+
+First read the shared context file in this same directory:
+`AUDIT_SPEC_038_SCAFFOLD_COMMON.md`. It defines the worktree, the diff range to
+audit, what the scaffold intentionally is, and what NOT to flag.
+
+You are the code-quality/correctness lane. Weight your review toward ordinary
+software-engineering defects in the diff, each anchored to a line:
+
+1. **Correctness of the policy logic.** `ContinuousBatchingPolicy.capability`,
+   `queueLimit`, `defaultQueueLimit`, `validateStrictStartup`,
+   `strictMessage`, `logSerialRouteIfNeeded`: off-by-one, wrong precedence,
+   wrong default (`2 * maxActiveRows`), `max(1, …)` clamping, mode/reason
+   mismatch. Verify the `guard`/`if` branch logic returns exactly the intended
+   outcome for every (mode, draft, kv_bits, revision) tuple.
+
+2. **Config plumbing correctness.** The new `assign` overloads for
+   `ContinuousBatchingMode` from YAML dict (bool→on/off coercion, NSNull skip,
+   lowercase parse) and from env; CLI→env→YAML precedence in `ConfigLoader`;
+   the CLI `--continuous-batching` invalid-value throw; the `CLIOverrides`
+   round-trip. Look for a source (YAML/env/CLI) that silently ignores the knob,
+   a case-sensitivity bug, or a precedence inversion. Confirm the YAML bool
+   coercion is intended and cannot mis-parse a string like "on"/"off".
+
+3. **Error handling.** Every throw path (`ConfigError.invalidValue`, `APIError`,
+   `ExitCode(2)`, `MSBAggregateThroughputError`) surfaces an actionable message;
+   no swallowed error; the `do/catch let error as APIError` in
+   `runContinuousBatchingPreflight` cannot leak a non-APIError or crash.
+
+4. **MSB helper.** `msbAggregateThroughput`: seeding `start`/`end` from
+   `samples[0]` then min/max over all — correct? Empty-guard first. The
+   per-sample guard (`decodedTokens >= 0`, `decodeEndedAt > decodeStartedAt`)
+   and the final `commonWallSeconds > 0` guard: any reachable division-by-zero,
+   negative, or silently-wrong aggregate? Are `Date` min/max and
+   `timeIntervalSince` used correctly?
+
+5. **Test adequacy & quality.** Do the new tests in `ScaffoldTests.swift` and
+   `ServingKnobsConfigTests.swift` actually assert the behavior (not just
+   no-throw)? Any missing case: strict `on` unpinned throwing the right
+   `code`/status, canary emitting the telemetry line, invalid-mode rejection at
+   each source, queue-limit `< 1` at each source, MSB invalid samples. Flag weak
+   assertions or untested branches (e.g. the `off`-mode inert path, the env-only
+   `assign` overload, `strictMessage` text).
+
+6. **General hygiene.** Dead code, unreachable branches, misleading names,
+   `Sendable`/actor-isolation mistakes introduced by THIS diff (not pre-existing
+   warnings elsewhere), resource/handle misuse in the `FileHandle.standardError`
+   writes.
+
+Report per the severity bar in the shared context. Anchor every finding to a
+diff line. State explicitly if a weighting question above is clean.

--- a/audits/2026-07-29/AUDIT_SPEC_038_SCAFFOLD_COMMON.md
+++ b/audits/2026-07-29/AUDIT_SPEC_038_SCAFFOLD_COMMON.md
@@ -1,0 +1,58 @@
+# Shared context — SPEC-038 continuous-batching scaffold BUILD audit
+
+Worktree: `/Users/augstar/macprovider-232-continuous-batching`
+Branch: `feature/232-continuous-batching` (one commit `709efbb5` ahead of `origin/main`).
+
+## How to read the change under audit
+Run exactly:
+```
+git -C /Users/augstar/macprovider-232-continuous-batching diff origin/main...HEAD
+```
+That range IS the entire change you are auditing. Read the full files it touches
+for context, and read the normative spec:
+`/Users/augstar/macprovider-232-continuous-batching/specs/SPEC-038-continuous-batching.md`
+(authority domain `continuous-batching-serving`, requirements `SPEC-038-R001..R016`).
+
+## What this change IS (audit against THIS intent — do not fault it for being this)
+This is the **integration-surface-only scaffold** for SPEC-038 continuous batching.
+It deliberately wires NO batch engine and runs NO shared forward. The pinned
+dependency `mlx-swift-lm` 3.31.4 ships no reviewed batch API (upstream PR #263
+pending), so `ContinuousBatchingPolicy.reviewedUpstreamBatchRevision` is
+intentionally `nil` and strict `on` mode is designed to fail closed.
+
+Concretely the scaffold adds:
+- A default-OFF operator knob `continuous_batching: off | canary | on`
+  (config key / `MACPROVIDER_CONTINUOUS_BATCHING` env / `--continuous-batching`
+  CLI) plus a bounded `continuous_batch_queue_limit`.
+- `ContinuousBatchingPolicy` — a pure policy layer computing a capability and:
+  - `off` (default): serial path, fully inert.
+  - `on` (strict): fails preflight with a named reason
+    (`continuous_batching_unavailable` / `..._unsupported_kv_bits` /
+    `draft_model_capacity_shortfall`) because no engine is pinned.
+  - `canary` (permissive): serial-routes and emits an observable
+    `event=continuous_batching_unsupported action=serial_routed reason=...`
+    telemetry line. Never a silent downgrade.
+- `ModelRuntime` wiring that threads the mode/queue-limit and calls the policy
+  at preflight / non-streaming / streaming entry points.
+- An MSB aggregate-throughput helper that computes total decoded tokens over a
+  common wall-clock interval (never a sum of per-request durations).
+- Unit tests for config precedence, strict rejection, permissive routing,
+  draft exclusion, queue-limit validation, runtime threading, MSB math.
+
+## DO NOT FLAG THESE (intended and correct)
+- "No batch engine / no shared forward is implemented." Intentional and correct
+  for a scaffold; SPEC §1 and the mode matrix (§5) require flag-off byte-parity
+  and gate the real engine behind FR-CB10/FR-CB15. Absence of an engine is not a
+  defect here.
+- "`reviewedUpstreamBatchRevision` is nil." Intentional — there is no reviewed
+  upstream pin yet; strict `on` must fail closed until one exists (FR-CB10).
+- Pre-existing Swift-6 `Sendable` warnings in files this diff does not touch.
+
+## Severity bar
+Report findings as CRITICAL / HIGH / MEDIUM / LOW / INFO. Convergence bar is
+0 CRITICAL / 0 HIGH / 0 MEDIUM. For each finding give: severity, file:line,
+the concrete problem, why it matters, and a specific fix. If you find nothing at
+a severity, say so explicitly. Do not invent findings to fill the report; a
+clean scaffold legitimately converges at 0/0/0. Anchor every claim to a real
+line in the diff — no speculative "could in a future engine" findings unless the
+scaffold code itself is wrong today.

--- a/audits/2026-07-29/AUDIT_SPEC_038_SCAFFOLD_SECURITY.md
+++ b/audits/2026-07-29/AUDIT_SPEC_038_SCAFFOLD_SECURITY.md
@@ -1,0 +1,55 @@
+# SPEC-038 scaffold BUILD audit — SECURITY / CORRECTNESS lane
+
+First read the shared context file in this same directory:
+`AUDIT_SPEC_038_SCAFFOLD_COMMON.md`. It defines the worktree, the diff range to
+audit, what the scaffold intentionally is, and what NOT to flag.
+
+You are the security/correctness lane. This is a **money-path** repo. Weight your
+review toward these questions, each tied to a concrete line of the diff:
+
+1. **Flag-OFF must be truly inert.** When `continuous_batching` is `off` (the
+   default), is the per-request serve path (preflight / non-streaming /
+   streaming in `ModelRuntime.swift`) byte-for-byte identical to today? Verify
+   `applyContinuousBatchingPolicy` performs NO side effect, NO stderr write, NO
+   usage/receipt/billing/slots mutation when mode is `off`. Confirm it cannot
+   throw in `off` mode. If off-mode adds any observable behavior, that is a
+   FR-CB9 regression — flag it.
+
+2. **Strict fail-closed guard cannot be bypassed.** In `on` mode with no pinned
+   upstream revision (the only real state today), can any input make
+   `validateStrictStartup` NOT throw, or make the serve path proceed as if
+   batching were available? Check the reason-precedence ordering in
+   `ContinuousBatchingPolicy.capability` (draft → kv_bits → unpinned) for a hole
+   that yields `reason == nil` while `mode == .on`. Check startup preflight AND
+   the per-request `applyContinuousBatchingPolicy` are consistent (no path that
+   serves under `on` without the guard).
+
+3. **Permissive canary is observable, never a silent downgrade.** In `canary`
+   mode does every serial-route emit the `event=continuous_batching_unsupported
+   action=serial_routed reason=...` signal (FR-CB8 requires BOTH branches
+   observable)? Conversely, is there uncontrolled/duplicate logging — e.g. the
+   policy is invoked at preflight AND non-streaming AND streaming, so a single
+   request may emit the line multiple times, or every request re-emits it
+   (unbounded stderr volume) where the SPEC's AC-7 expects a once-per-attach
+   notice. Assess whether per-request repeated logging is a correctness/operability
+   defect and at what severity.
+
+4. **No money-path regression.** Confirm the diff touches no billing, receipt,
+   settlement, coordinator, router, or auth code, and that the receipt/usage
+   tuple is untouched. Confirm the new `APIError` strict-rejection path returns a
+   fail-closed error and never a partial/settled result.
+
+5. **MSB helper ships no unmeasured throughput claim.** `msbAggregateThroughput`
+   in `DecodeBenchCommand.swift`: confirm it only computes math on caller-supplied
+   samples, is not wired into any advertised/persisted capacity or heartbeat
+   signal, and that its validation (empty, non-monotonic, negative tokens,
+   zero-wall) is sound. Flag any integer/float edge (overflow, div-by-zero,
+   negative interval) that is actually reachable.
+
+6. **Input validation of the new knobs.** Queue-limit and mode parsing across
+   CLI/env/YAML: any injection, unbounded value, or precedence bug
+   (CLI > env > YAML) that lets an invalid/unsafe config through? Confirm the
+   `< 1` queue-limit rejection fires on every source.
+
+Report per the severity bar in the shared context. Anchor every finding to a
+diff line. State explicitly if a weighting question above is clean.

--- a/audits/_prompts/BUILD_IMPL_SPEC_232_CONTINUOUS_BATCHING.md
+++ b/audits/_prompts/BUILD_IMPL_SPEC_232_CONTINUOUS_BATCHING.md
@@ -65,4 +65,3 @@ Run targeted Swift tests for changed config/runtime/harness behavior, then run
 the relevant package build or test subset. Do not claim the feature implements
 true shared-forward decode unless the code actually has a batch API and test
 evidence for one model forward per active decode step.
-

--- a/audits/_prompts/BUILD_IMPL_SPEC_232_CONTINUOUS_BATCHING.md
+++ b/audits/_prompts/BUILD_IMPL_SPEC_232_CONTINUOUS_BATCHING.md
@@ -1,0 +1,68 @@
+# BUILD IMPL — SPEC-038 continuous batching first implementation slice
+
+You are a senior systems engineer implementing SPEC-038 for the macprovider
+provider runtime. Work in a fresh worktree from `origin/main`; do not edit the
+canonical checkout. Treat `docs/research/RESEARCH_232_MULTISTREAM_BATCHING_MEMO.md`
+and `specs/SPEC-038-continuous-batching.md` as the requirements source.
+
+## Goal
+
+Land the first safe, reviewable implementation slice for continuous batching:
+default-off operator controls, explicit unsupported-mode handling, scheduler
+capability state, bounded FCFS admission scaffolding, and MSB measurement
+contract support, without claiming or enabling shared-forward batching before a
+reviewed upstream `mlx-swift-lm` batch API exists.
+
+## Constraints
+
+- The pinned dependency remains `mlx-swift-lm` 3.31.4. That release has no
+  reviewed public `BatchGenerator` / `GenerationBatch` API, so the serve path
+  must not advertise true continuous batching or fabricate a shared forward.
+- `continuous_batching=off` is the default and must be byte-compatible with the
+  current serial `AsyncSemaphore` + `TokenIterator` path.
+- `continuous_batching=on` must fail preflight with a named reason until a
+  reviewed upstream batch API/revision is pinned and the implementation can
+  actually run one shared forward for active rows.
+- `continuous_batching=canary` is permissive: unsupported tuples are explicitly
+  serial-routed with observable reason-coded telemetry. No silent fallback.
+- Draft-enabled SPEC-028 remains mutually exclusive with batching.
+- Any `kv_bits` with batching requested is unsupported in this slice and must
+  be rejected or serial-routed according to mode.
+- Queue/admission scaffolding must be bounded and FCFS, but must not introduce
+  an unbounded second HTTP or relay queue.
+- Do not touch coordinator billing, router, auth, or settlement code.
+
+## Required code shape
+
+1. Add config/CLI/env/YAML plumbing:
+   - `continuous_batching`: `off | canary | on`
+   - `continuous_batch_queue_limit`: positive integer; default `2 * slots_total`
+2. Add runtime capability/preflight helpers that expose:
+   - effective scheduler mode
+   - max active rows derived from Entry 110 `maxBatch`
+   - queue limit
+   - reviewed upstream revision/pin status
+   - unsupported reason codes
+3. Preserve serial fallback by default:
+   - both non-streaming and streaming use the existing path unless the mode is
+     explicitly requested and supported.
+4. Fail loud for strict mode:
+   - `on` plus missing upstream batch API => `continuous_batching_unavailable`
+   - `on` plus `kv_bits` => `continuous_batching_unsupported_kv_bits`
+   - draft model plus batching request => existing/spec-compatible draft
+     capacity shortfall behavior.
+5. Emit observable permissive telemetry in canary mode:
+   - `event=continuous_batching_unsupported action=serial_routed reason=...`
+6. Add tests covering defaults, config precedence, strict rejection, permissive
+   serial routing, draft exclusion, queue-limit default/validation, and runtime
+   threading.
+7. Add or extend an MSB harness utility so aggregate TG is computed as total
+   decoded tokens over common wall-clock, not summed per-request durations.
+
+## Verification
+
+Run targeted Swift tests for changed config/runtime/harness behavior, then run
+the relevant package build or test subset. Do not claim the feature implements
+true shared-forward decode unless the code actually has a batch API and test
+evidence for one model forward per active decode step.
+

--- a/phase3-binary/Sources/MacProviderCore/Config.swift
+++ b/phase3-binary/Sources/MacProviderCore/Config.swift
@@ -16,6 +16,12 @@ public enum LogLevel: String, Sendable {
     case critical
 }
 
+public enum ContinuousBatchingMode: String, Sendable {
+    case off
+    case canary
+    case on
+}
+
 public struct AppConfig: Equatable, Sendable {
     public var port: Int
     public var model: String?
@@ -108,6 +114,8 @@ public struct AppConfig: Equatable, Sendable {
     // Triple-exposed: yaml key `prefill_step_size`, env `MACPROVIDER_PREFILL_STEP_SIZE`,
     // CLI `--prefill-step-size`.
     public var prefillStepSize: Int
+    public var continuousBatching: ContinuousBatchingMode
+    public var continuousBatchQueueLimit: Int?
 
     // SPEC-037 FR-KVP11: encrypted KV survival disk tier. Default-off; resolved
     // fail-closed (invalid value ⇒ tier disabled + `errors` populated, never a
@@ -169,6 +177,8 @@ public struct AppConfig: Equatable, Sendable {
             managedBy: nil,
             streamInterval: 1,
             prefillStepSize: 512,
+            continuousBatching: .off,
+            continuousBatchQueueLimit: nil,
             kvDiskCache: .defaults()
         )
     }
@@ -210,6 +220,8 @@ public struct CLIOverrides: Equatable, Sendable {
     public var idlePrewarmRunOnBattery: Bool?
     public var streamInterval: Int?
     public var prefillStepSize: Int?
+    public var continuousBatching: String?
+    public var continuousBatchQueueLimit: Int?
     // SPEC-037 FR-KVP11: KV disk-tier CLI flags (`--kv-disk-cache-*`).
     public var kvDiskCache: KVDiskCacheCLIOverrides
 
@@ -246,6 +258,8 @@ public struct CLIOverrides: Equatable, Sendable {
         idlePrewarmRunOnBattery: Bool? = nil,
         streamInterval: Int? = nil,
         prefillStepSize: Int? = nil,
+        continuousBatching: String? = nil,
+        continuousBatchQueueLimit: Int? = nil,
         kvDiskCache: KVDiskCacheCLIOverrides = KVDiskCacheCLIOverrides()
     ) {
         self.port = port
@@ -280,6 +294,8 @@ public struct CLIOverrides: Equatable, Sendable {
         self.idlePrewarmRunOnBattery = idlePrewarmRunOnBattery
         self.streamInterval = streamInterval
         self.prefillStepSize = prefillStepSize
+        self.continuousBatching = continuousBatching
+        self.continuousBatchQueueLimit = continuousBatchQueueLimit
         self.kvDiskCache = kvDiskCache
     }
 }
@@ -427,6 +443,8 @@ public enum ConfigLoader {
         try assign(&config.managedBy, from: dict, key: "managed_by", expected: "string")
         try assign(&config.streamInterval, from: dict, key: "stream_interval", expected: "integer >= 1")
         try assign(&config.prefillStepSize, from: dict, key: "prefill_step_size", expected: "integer >= 1")
+        try assign(&config.continuousBatching, from: dict, key: "continuous_batching", expected: "off, canary, or on")
+        try assign(&config.continuousBatchQueueLimit, from: dict, key: "continuous_batch_queue_limit", expected: "integer >= 1")
         return config
     }
 
@@ -478,6 +496,8 @@ public enum ConfigLoader {
         try assign(&config.managedBy, from: environment, env: "MACPROVIDER_MANAGED_BY", expected: "string")
         try assign(&config.streamInterval, from: environment, env: "MACPROVIDER_STREAM_INTERVAL", expected: "integer >= 1")
         try assign(&config.prefillStepSize, from: environment, env: "MACPROVIDER_PREFILL_STEP_SIZE", expected: "integer >= 1")
+        try assign(&config.continuousBatching, from: environment, env: "MACPROVIDER_CONTINUOUS_BATCHING", expected: "off, canary, or on")
+        try assign(&config.continuousBatchQueueLimit, from: environment, env: "MACPROVIDER_CONTINUOUS_BATCH_QUEUE_LIMIT", expected: "integer >= 1")
         return config
     }
 
@@ -617,6 +637,19 @@ public enum ConfigLoader {
         }
         if let prefillStepSize = cli.prefillStepSize {
             config.prefillStepSize = prefillStepSize
+        }
+        if let continuousBatching = cli.continuousBatching {
+            guard let mode = ContinuousBatchingMode(rawValue: continuousBatching.lowercased()) else {
+                throw ConfigError.invalidValue(
+                    key: "--continuous-batching",
+                    value: continuousBatching,
+                    expected: "off, canary, or on"
+                )
+            }
+            config.continuousBatching = mode
+        }
+        if let continuousBatchQueueLimit = cli.continuousBatchQueueLimit {
+            config.continuousBatchQueueLimit = continuousBatchQueueLimit
         }
         return config
     }
@@ -777,6 +810,18 @@ public enum ConfigLoader {
         field = format
     }
 
+    private static func assign(_ field: inout ContinuousBatchingMode, from dict: [String: Any], key: String, expected: String) throws {
+        guard let value = dict[key], !(value is NSNull) else { return }
+        if let bool = value as? Bool {
+            field = bool ? .on : .off
+            return
+        }
+        guard let string = value as? String, let mode = ContinuousBatchingMode(rawValue: string.lowercased()) else {
+            throw ConfigError.invalidValue(key: key, value: String(describing: value), expected: expected)
+        }
+        field = mode
+    }
+
     private static func assign(_ field: inout Int, from env: [String: String], env key: String, expected: String) throws {
         guard let value = env[key] else { return }
         guard let int = Int(value) else {
@@ -841,6 +886,14 @@ public enum ConfigLoader {
             throw ConfigError.invalidValue(key: key, value: value, expected: expected)
         }
         field = format
+    }
+
+    private static func assign(_ field: inout ContinuousBatchingMode, from env: [String: String], env key: String, expected: String) throws {
+        guard let value = env[key] else { return }
+        guard let mode = ContinuousBatchingMode(rawValue: value.lowercased()) else {
+            throw ConfigError.invalidValue(key: key, value: value, expected: expected)
+        }
+        field = mode
     }
 
     private static func parseBool(_ value: String) -> Bool? {

--- a/phase3-binary/Sources/macprovider-cli/ContinuousBatching.swift
+++ b/phase3-binary/Sources/macprovider-cli/ContinuousBatching.swift
@@ -1,0 +1,111 @@
+import Foundation
+import MacProviderCore
+
+enum ContinuousBatchingUnsupportedReason: String, Sendable, Equatable {
+    case upstreamBatchAPIUnpinned = "upstream_batch_api_unpinned"
+    case kvBitsUnsupported = "kv_bits_unsupported"
+    case draftSpecDecodeMutualExclusion = "draft_spec_decode_mutual_exclusion"
+
+    var apiCode: String {
+        switch self {
+        case .upstreamBatchAPIUnpinned:
+            return "continuous_batching_unavailable"
+        case .kvBitsUnsupported:
+            return "continuous_batching_unsupported_kv_bits"
+        case .draftSpecDecodeMutualExclusion:
+            return "draft_model_capacity_shortfall"
+        }
+    }
+}
+
+struct ContinuousBatchingCapability: Sendable, Equatable {
+    let mode: ContinuousBatchingMode
+    let maxActiveRows: Int
+    let queueLimit: Int
+    let reviewedUpstreamRevision: String?
+    let unsupportedReason: ContinuousBatchingUnsupportedReason?
+
+    var isRequested: Bool {
+        mode != .off
+    }
+
+    var shouldUseSerialPath: Bool {
+        mode == .off || mode == .canary
+    }
+}
+
+enum ContinuousBatchingPolicy {
+    static let reviewedUpstreamBatchRevision: String? = nil
+
+    static func defaultQueueLimit(maxActiveRows: Int) -> Int {
+        max(1, maxActiveRows) * 2
+    }
+
+    static func queueLimit(configured: Int?, maxActiveRows: Int) -> Int {
+        configured ?? defaultQueueLimit(maxActiveRows: maxActiveRows)
+    }
+
+    static func capability(
+        mode: ContinuousBatchingMode,
+        maxBatch: Int,
+        queueLimit configuredQueueLimit: Int?,
+        kvBits: Int?,
+        draftConfigured: Bool,
+        reviewedUpstreamRevision: String? = reviewedUpstreamBatchRevision
+    ) -> ContinuousBatchingCapability {
+        let maxActiveRows = max(1, maxBatch)
+        let queueLimit = queueLimit(configured: configuredQueueLimit, maxActiveRows: maxActiveRows)
+        let reason: ContinuousBatchingUnsupportedReason?
+        if mode == .off {
+            reason = nil
+        } else if draftConfigured {
+            reason = .draftSpecDecodeMutualExclusion
+        } else if kvBits != nil {
+            reason = .kvBitsUnsupported
+        } else if reviewedUpstreamRevision == nil {
+            reason = .upstreamBatchAPIUnpinned
+        } else {
+            reason = nil
+        }
+        return ContinuousBatchingCapability(
+            mode: mode,
+            maxActiveRows: maxActiveRows,
+            queueLimit: queueLimit,
+            reviewedUpstreamRevision: reviewedUpstreamRevision,
+            unsupportedReason: reason
+        )
+    }
+
+    static func validateStrictStartup(_ capability: ContinuousBatchingCapability) throws {
+        guard capability.mode == .on, let reason = capability.unsupportedReason else {
+            return
+        }
+        let status = reason == .upstreamBatchAPIUnpinned ? 503 : 400
+        throw APIError(
+            status: status,
+            message: strictMessage(for: reason),
+            type: "invalid_request_error",
+            code: reason.apiCode
+        )
+    }
+
+    static func strictMessage(for reason: ContinuousBatchingUnsupportedReason) -> String {
+        switch reason {
+        case .upstreamBatchAPIUnpinned:
+            return "continuous batching requires a reviewed pinned mlx-swift-lm batch API"
+        case .kvBitsUnsupported:
+            return "continuous batching does not support kv_bits in this release"
+        case .draftSpecDecodeMutualExclusion:
+            return "continuous batching is mutually exclusive with speculative decoding in this release"
+        }
+    }
+
+    static func logSerialRouteIfNeeded(_ capability: ContinuousBatchingCapability) {
+        guard capability.mode == .canary, let reason = capability.unsupportedReason else {
+            return
+        }
+        FileHandle.standardError.write(Data((
+            "event=continuous_batching_unsupported action=serial_routed reason=\(reason.rawValue)\n"
+        ).utf8))
+    }
+}

--- a/phase3-binary/Sources/macprovider-cli/DecodeBenchCommand.swift
+++ b/phase3-binary/Sources/macprovider-cli/DecodeBenchCommand.swift
@@ -463,6 +463,7 @@ struct MSBAggregateThroughputReport: Sendable, Equatable {
 enum MSBAggregateThroughputError: Error, Equatable {
     case emptySamples
     case invalidSample
+    case tokenCountOverflow
 }
 
 func msbAggregateThroughput(_ samples: [MSBAggregateThroughputInput]) throws -> MSBAggregateThroughputReport {
@@ -476,7 +477,11 @@ func msbAggregateThroughput(_ samples: [MSBAggregateThroughputInput]) throws -> 
         guard sample.decodedTokens >= 0, sample.decodeEndedAt > sample.decodeStartedAt else {
             throw MSBAggregateThroughputError.invalidSample
         }
-        totalDecodedTokens += sample.decodedTokens
+        let (sum, overflowed) = totalDecodedTokens.addingReportingOverflow(sample.decodedTokens)
+        guard !overflowed else {
+            throw MSBAggregateThroughputError.tokenCountOverflow
+        }
+        totalDecodedTokens = sum
         start = min(start, sample.decodeStartedAt)
         end = max(end, sample.decodeEndedAt)
     }

--- a/phase3-binary/Sources/macprovider-cli/DecodeBenchCommand.swift
+++ b/phase3-binary/Sources/macprovider-cli/DecodeBenchCommand.swift
@@ -448,6 +448,49 @@ func decodeBenchFormatTPS(_ v: Double) -> String {
     String(format: "%.1f", v)
 }
 
+struct MSBAggregateThroughputInput: Sendable, Equatable {
+    let decodedTokens: Int
+    let decodeStartedAt: Date
+    let decodeEndedAt: Date
+}
+
+struct MSBAggregateThroughputReport: Sendable, Equatable {
+    let totalDecodedTokens: Int
+    let commonWallSeconds: TimeInterval
+    let aggregateTokensPerSecond: Double
+}
+
+enum MSBAggregateThroughputError: Error, Equatable {
+    case emptySamples
+    case invalidSample
+}
+
+func msbAggregateThroughput(_ samples: [MSBAggregateThroughputInput]) throws -> MSBAggregateThroughputReport {
+    guard !samples.isEmpty else {
+        throw MSBAggregateThroughputError.emptySamples
+    }
+    var totalDecodedTokens = 0
+    var start = samples[0].decodeStartedAt
+    var end = samples[0].decodeEndedAt
+    for sample in samples {
+        guard sample.decodedTokens >= 0, sample.decodeEndedAt > sample.decodeStartedAt else {
+            throw MSBAggregateThroughputError.invalidSample
+        }
+        totalDecodedTokens += sample.decodedTokens
+        start = min(start, sample.decodeStartedAt)
+        end = max(end, sample.decodeEndedAt)
+    }
+    let commonWallSeconds = end.timeIntervalSince(start)
+    guard commonWallSeconds > 0 else {
+        throw MSBAggregateThroughputError.invalidSample
+    }
+    return MSBAggregateThroughputReport(
+        totalDecodedTokens: totalDecodedTokens,
+        commonWallSeconds: commonWallSeconds,
+        aggregateTokensPerSecond: Double(totalDecodedTokens) / commonWallSeconds
+    )
+}
+
 /// Reduce an operator-supplied string to a basename-safe slug.
 /// Prevents path-traversal sequences (`../`) from reaching the output path.
 func decodeBenchSanitizeFilenameComponent(_ input: String) -> String {

--- a/phase3-binary/Sources/macprovider-cli/MacProviderCLI.swift
+++ b/phase3-binary/Sources/macprovider-cli/MacProviderCLI.swift
@@ -304,6 +304,12 @@ struct ServeCommand: AsyncParsableCommand {
     )
     var prefillStepSize: Int?
 
+    @Option(help: "Continuous batching mode: off, canary, or on. Default off. Strict on fails until a reviewed mlx-swift-lm batch API is pinned. Overrides MACPROVIDER_CONTINUOUS_BATCHING and config key continuous_batching.")
+    var continuousBatching: String?
+
+    @Option(help: "Bounded continuous-batching waiting queue limit. Default 2 * active slots. Overrides MACPROVIDER_CONTINUOUS_BATCH_QUEUE_LIMIT and config key continuous_batch_queue_limit.")
+    var continuousBatchQueueLimit: Int?
+
     // SPEC-037 FR-KVP11 — encrypted KV survival disk-tier CLI flags (MEDIUM-5). Each is
     // an Optional so absence defers to the environment / YAML / default; the resolver
     // (KVDiskCacheConfigResolver) applies CLI-wins precedence and fails closed on any
@@ -443,6 +449,12 @@ struct ServeCommand: AsyncParsableCommand {
             ).utf8))
             throw ExitCode(2)
         }
+        if let queueLimit = resolved.continuousBatchQueueLimit, queueLimit < 1 {
+            FileHandle.standardError.write(Data((
+                "--continuous-batch-queue-limit \(queueLimit) must be >= 1\n"
+            ).utf8))
+            throw ExitCode(2)
+        }
         if let draftModel = resolved.draftModel,
            draftModel.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
             FileHandle.standardError.write(Data("--draft-model must be non-empty\n".utf8))
@@ -451,6 +463,25 @@ struct ServeCommand: AsyncParsableCommand {
         if let hash = resolved.draftModelArtifactSHA256,
            hash.range(of: #"^[0-9a-f]{64}$"#, options: .regularExpression) == nil {
             FileHandle.standardError.write(Data("draft_model_artifact_sha256 must be 64 lowercase hex characters\n".utf8))
+            throw ExitCode(2)
+        }
+    }
+
+    static func runContinuousBatchingPreflight(_ resolved: AppConfig) throws {
+        let capability = ContinuousBatchingPolicy.capability(
+            mode: resolved.continuousBatching,
+            maxBatch: resolved.maxConcurrencyOverride ?? 1,
+            queueLimit: resolved.continuousBatchQueueLimit,
+            kvBits: resolved.kvBitsOverride,
+            draftConfigured: resolved.draftModel?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == false
+        )
+        if resolved.continuousBatching == .canary {
+            ContinuousBatchingPolicy.logSerialRouteIfNeeded(capability)
+        }
+        do {
+            try ContinuousBatchingPolicy.validateStrictStartup(capability)
+        } catch let error as APIError {
+            FileHandle.standardError.write(Data("\(error.code): \(error.message)\n".utf8))
             throw ExitCode(2)
         }
     }
@@ -813,6 +844,8 @@ struct ServeCommand: AsyncParsableCommand {
                 idlePrewarmRunOnBattery: idlePrewarmRunOnBattery,
                 streamInterval: streamInterval,
                 prefillStepSize: prefillStepSize,
+                continuousBatching: continuousBatching,
+                continuousBatchQueueLimit: continuousBatchQueueLimit,
                 // SPEC-037 FR-KVP11 (MEDIUM-5): forward the KV disk-tier flags so the
                 // triple-source config surface (CLI → env → YAML) is complete.
                 kvDiskCache: kvDiskCacheCLIOverrides
@@ -1031,6 +1064,8 @@ struct ServeCommand: AsyncParsableCommand {
                 kvBitsOverride: effectiveKVBits,
                 prefillStepSize: resolved.prefillStepSize,
                 maxBatch: resolved.maxConcurrencyOverride ?? 1,
+                continuousBatchingMode: resolved.continuousBatching,
+                continuousBatchQueueLimit: resolved.continuousBatchQueueLimit,
                 warmSwapEnabled: resolved.enableWarmSwap,
                 swapDrainTimeoutSeconds: resolved.swapDrainTimeoutSeconds,
                 catalogModelIDAlias: catalogModelIDAlias,
@@ -2047,6 +2082,7 @@ struct ServeCommand: AsyncParsableCommand {
             coordinatorAcceptsSpecDecodeTelemetry: coordinatorAcceptsSpecDecodeTelemetry
         )
         try Self.runSpecDecodeCapacityPreflight(&resolved)
+        try Self.runContinuousBatchingPreflight(resolved)
 
         let serveLock = try acquireServeLock(resolved)
         do {
@@ -2350,6 +2386,8 @@ private func printResolvedConfiguration(_ config: AppConfig) {
     print("  kv_bits: \(config.kvBitsOverride.map(String.init) ?? "<unset, mlx default>")")
     print("  max_context: \(config.maxContextOverride.map(String.init) ?? "<unset, per-tier default>")")
     print("  max_batch: \(config.maxConcurrencyOverride.map(String.init) ?? "1")")
+    print("  continuous_batching: \(config.continuousBatching.rawValue)")
+    print("  continuous_batch_queue_limit: \(config.continuousBatchQueueLimit.map(String.init) ?? "<unset, 2 * max_batch>")")
     print("  enable_receipts: \(config.enableReceipts)")
     print("  idle_prewarm.enabled: \(config.idlePrewarmEnabled)")
     print("  idle_prewarm.idle_threshold_seconds: \(config.idlePrewarmIdleThresholdSeconds)")

--- a/phase3-binary/Sources/macprovider-cli/ModelRuntime.swift
+++ b/phase3-binary/Sources/macprovider-cli/ModelRuntime.swift
@@ -427,6 +427,8 @@ actor ModelRuntime: ModelRuntimeServing {
     private var coldTierAttached = false
     private let inferenceGate: AsyncSemaphore
     private let maxBatch: Int
+    private let continuousBatchingMode: ContinuousBatchingMode
+    private let continuousBatchQueueLimit: Int?
     private let warmSwapEnabled: Bool
     private let swapDrainTimeoutSeconds: Int
     private var providerStatus: ProviderStatus?
@@ -547,6 +549,8 @@ actor ModelRuntime: ModelRuntimeServing {
         kvBitsOverride: Int? = nil,
         prefillStepSize: Int = 512,
         maxBatch: Int = 1,
+        continuousBatchingMode: ContinuousBatchingMode = .off,
+        continuousBatchQueueLimit: Int? = nil,
         warmSwapEnabled: Bool = false,
         swapDrainTimeoutSeconds: Int = 30,
         catalogModelIDAlias: String? = nil,
@@ -570,6 +574,8 @@ actor ModelRuntime: ModelRuntimeServing {
         self.conversationCache = ConversationCache()
         self.maxBatch = max(1, maxBatch)
         self.inferenceGate = AsyncSemaphore(value: max(1, maxBatch))
+        self.continuousBatchingMode = continuousBatchingMode
+        self.continuousBatchQueueLimit = continuousBatchQueueLimit
         self.warmSwapEnabled = warmSwapEnabled
         self.swapDrainTimeoutSeconds = swapDrainTimeoutSeconds
         self.verifiedCatalogArtifactSHA256 = verifiedModelArtifactSHA256
@@ -658,6 +664,8 @@ actor ModelRuntime: ModelRuntimeServing {
         kvBitsOverride: Int? = nil,
         prefillStepSize: Int = 512,
         maxBatch: Int = 1,
+        continuousBatchingMode: ContinuousBatchingMode = .off,
+        continuousBatchQueueLimit: Int? = nil,
         warmSwapEnabled: Bool,
         swapDrainTimeoutSeconds: Int = 30,
         providerStatus: ProviderStatus? = nil,
@@ -693,6 +701,8 @@ actor ModelRuntime: ModelRuntimeServing {
         self.conversationCache = ConversationCache()
         self.maxBatch = max(1, maxBatch)
         self.inferenceGate = AsyncSemaphore(value: max(1, maxBatch))
+        self.continuousBatchingMode = continuousBatchingMode
+        self.continuousBatchQueueLimit = continuousBatchQueueLimit
         self.warmSwapEnabled = warmSwapEnabled
         self.swapDrainTimeoutSeconds = swapDrainTimeoutSeconds
         self.providerStatus = providerStatus
@@ -905,6 +915,30 @@ actor ModelRuntime: ModelRuntimeServing {
 
     func maxBatchForTest() -> Int {
         maxBatch
+    }
+
+    func continuousBatchingCapabilityForTest() -> ContinuousBatchingCapability {
+        continuousBatchingCapability(draftConfigured: currentDraftModelID != nil)
+    }
+
+    private func continuousBatchingCapability(draftConfigured: Bool) -> ContinuousBatchingCapability {
+        ContinuousBatchingPolicy.capability(
+            mode: continuousBatchingMode,
+            maxBatch: maxBatch,
+            queueLimit: continuousBatchQueueLimit,
+            kvBits: kvBitsOverride,
+            draftConfigured: draftConfigured
+        )
+    }
+
+    private func applyContinuousBatchingPolicy(snapshot: RuntimeSnapshot) throws {
+        let capability = continuousBatchingCapability(
+            draftConfigured: snapshot.hasTargetCompatibleDraft || currentDraftModelID != nil
+        )
+        if continuousBatchingMode == .canary {
+            ContinuousBatchingPolicy.logSerialRouteIfNeeded(capability)
+        }
+        try ContinuousBatchingPolicy.validateStrictStartup(capability)
     }
 
     func maxContextTokensForTest() -> Int {
@@ -1136,6 +1170,7 @@ actor ModelRuntime: ModelRuntimeServing {
 
     func preflight(_ request: ChatCompletionRequest, with handle: RequestHandle) async throws {
         try handle.drainCancelled.check()
+        try applyContinuousBatchingPolicy(snapshot: handle.snapshot)
         guard let container = handle.snapshot.container else {
             if testCompletion != nil {
                 return
@@ -1297,6 +1332,7 @@ actor ModelRuntime: ModelRuntimeServing {
         let snapshot = handle.snapshot
         let drainCancelled = handle.drainCancelled
         try drainCancelled.check()
+        try applyContinuousBatchingPolicy(snapshot: snapshot)
         if let testSpeculativeCompletion,
            Self.speculativeRoute(
                for: request,
@@ -1676,6 +1712,7 @@ actor ModelRuntime: ModelRuntimeServing {
     ) async throws -> CompletionResult {
         let snapshot = handle.snapshot
         let drainCancelled = handle.drainCancelled
+        try applyContinuousBatchingPolicy(snapshot: snapshot)
         let structuredAccumulator = StructuredStreamingContentAccumulator(enabled: Self.requiresStructuredValidation(request.responseFormat))
         let idleState = StructuredStreamingIdleState(enabled: Self.requiresStructuredValidation(request.responseFormat))
         if let testSpeculativeStream,

--- a/phase3-binary/Tests/macprovider-cliTests/ScaffoldTests.swift
+++ b/phase3-binary/Tests/macprovider-cliTests/ScaffoldTests.swift
@@ -76,4 +76,36 @@ final class DecodeBenchHelperTests: XCTestCase {
         let long = String(repeating: "x", count: 100)
         XCTAssertEqual(decodeBenchSanitizeFilenameComponent(long).count, 80)
     }
+
+    func testMSBAggregateThroughputUsesCommonWallClock() throws {
+        let base = Date(timeIntervalSince1970: 100)
+        let report = try msbAggregateThroughput([
+            MSBAggregateThroughputInput(
+                decodedTokens: 100,
+                decodeStartedAt: base,
+                decodeEndedAt: base.addingTimeInterval(10)
+            ),
+            MSBAggregateThroughputInput(
+                decodedTokens: 100,
+                decodeStartedAt: base.addingTimeInterval(2),
+                decodeEndedAt: base.addingTimeInterval(12)
+            ),
+        ])
+
+        XCTAssertEqual(report.totalDecodedTokens, 200)
+        XCTAssertEqual(report.commonWallSeconds, 12, accuracy: 0.001)
+        XCTAssertEqual(report.aggregateTokensPerSecond, 200.0 / 12.0, accuracy: 0.001)
+    }
+
+    func testMSBAggregateThroughputRejectsInvalidSamples() {
+        XCTAssertThrowsError(try msbAggregateThroughput([])) { error in
+            XCTAssertEqual(error as? MSBAggregateThroughputError, .emptySamples)
+        }
+        let now = Date()
+        XCTAssertThrowsError(try msbAggregateThroughput([
+            MSBAggregateThroughputInput(decodedTokens: 1, decodeStartedAt: now, decodeEndedAt: now),
+        ])) { error in
+            XCTAssertEqual(error as? MSBAggregateThroughputError, .invalidSample)
+        }
+    }
 }

--- a/phase3-binary/Tests/macprovider-cliTests/ScaffoldTests.swift
+++ b/phase3-binary/Tests/macprovider-cliTests/ScaffoldTests.swift
@@ -108,4 +108,22 @@ final class DecodeBenchHelperTests: XCTestCase {
             XCTAssertEqual(error as? MSBAggregateThroughputError, .invalidSample)
         }
     }
+
+    func testMSBAggregateThroughputRejectsTokenCountOverflow() {
+        let base = Date(timeIntervalSince1970: 100)
+        XCTAssertThrowsError(try msbAggregateThroughput([
+            MSBAggregateThroughputInput(
+                decodedTokens: Int.max,
+                decodeStartedAt: base,
+                decodeEndedAt: base.addingTimeInterval(1)
+            ),
+            MSBAggregateThroughputInput(
+                decodedTokens: 1,
+                decodeStartedAt: base,
+                decodeEndedAt: base.addingTimeInterval(1)
+            ),
+        ])) { error in
+            XCTAssertEqual(error as? MSBAggregateThroughputError, .tokenCountOverflow)
+        }
+    }
 }

--- a/phase3-binary/Tests/macprovider-cliTests/ServingKnobsConfigTests.swift
+++ b/phase3-binary/Tests/macprovider-cliTests/ServingKnobsConfigTests.swift
@@ -22,6 +22,8 @@ final class ServingKnobsConfigTests: XCTestCase {
         XCTAssertNil(config.kvBitsOverride)
         XCTAssertNil(config.maxContextOverride)
         XCTAssertNil(config.maxConcurrencyOverride)
+        XCTAssertEqual(config.continuousBatching, .off)
+        XCTAssertNil(config.continuousBatchQueueLimit)
         XCTAssertFalse(config.enableReceipts)
     }
 
@@ -131,6 +133,56 @@ final class ServingKnobsConfigTests: XCTestCase {
         XCTAssertEqual(config.maxConcurrencyOverride, 2)
     }
 
+    // MARK: - continuous batching controls
+
+    func testContinuousBatchingCLIOverridesEnvironmentOverridesYAML() throws {
+        let config = try ConfigLoader.load(
+            cli: CLIOverrides(continuousBatching: "on", continuousBatchQueueLimit: 7),
+            environment: [
+                "MACPROVIDER_CONTINUOUS_BATCHING": "canary",
+                "MACPROVIDER_CONTINUOUS_BATCH_QUEUE_LIMIT": "5",
+            ],
+            fileExists: { _ in true },
+            readFile: { _ in "continuous_batching: off\ncontinuous_batch_queue_limit: 3\n" }
+        )
+        XCTAssertEqual(config.continuousBatching, .on)
+        XCTAssertEqual(config.continuousBatchQueueLimit, 7)
+    }
+
+    func testContinuousBatchingEnvironmentOverridesYAML() throws {
+        let config = try ConfigLoader.load(
+            cli: CLIOverrides(),
+            environment: [
+                "MACPROVIDER_CONTINUOUS_BATCHING": "canary",
+                "MACPROVIDER_CONTINUOUS_BATCH_QUEUE_LIMIT": "6",
+            ],
+            fileExists: { _ in true },
+            readFile: { _ in "continuous_batching: off\ncontinuous_batch_queue_limit: 2\n" }
+        )
+        XCTAssertEqual(config.continuousBatching, .canary)
+        XCTAssertEqual(config.continuousBatchQueueLimit, 6)
+    }
+
+    func testContinuousBatchingYAMLApplied() throws {
+        let config = try ConfigLoader.load(
+            cli: CLIOverrides(),
+            environment: [:],
+            fileExists: { _ in true },
+            readFile: { _ in "continuous_batching: canary\ncontinuous_batch_queue_limit: 4\n" }
+        )
+        XCTAssertEqual(config.continuousBatching, .canary)
+        XCTAssertEqual(config.continuousBatchQueueLimit, 4)
+    }
+
+    func testContinuousBatchingRejectsInvalidMode() throws {
+        XCTAssertThrowsError(try ConfigLoader.load(
+            cli: CLIOverrides(continuousBatching: "maybe"),
+            environment: [:],
+            fileExists: { _ in false },
+            readFile: { _ in "" }
+        ))
+    }
+
     // MARK: - Preflight validation
 
     func testKvBitsPreflightRejectsInvalidValue() throws {
@@ -168,6 +220,50 @@ final class ServingKnobsConfigTests: XCTestCase {
         XCTAssertThrowsError(try ServeCommand.runServingKnobsPreflight(config))
     }
 
+    func testContinuousBatchQueueLimitPreflightRejectsZero() throws {
+        var config = AppConfig.defaults()
+        config.continuousBatchQueueLimit = 0
+        XCTAssertThrowsError(try ServeCommand.runServingKnobsPreflight(config))
+    }
+
+    func testContinuousBatchingStrictOnFailsUntilUpstreamBatchAPIPinned() throws {
+        var config = AppConfig.defaults()
+        config.continuousBatching = .on
+        config.maxConcurrencyOverride = 2
+        XCTAssertThrowsError(try ServeCommand.runContinuousBatchingPreflight(config))
+    }
+
+    func testContinuousBatchingCanarySerialRoutesUnsupportedPin() throws {
+        var config = AppConfig.defaults()
+        config.continuousBatching = .canary
+        config.maxConcurrencyOverride = 2
+        XCTAssertNoThrow(try ServeCommand.runContinuousBatchingPreflight(config))
+    }
+
+    func testContinuousBatchingPolicyReportsKvBitsBeforeMissingPin() {
+        let capability = ContinuousBatchingPolicy.capability(
+            mode: .on,
+            maxBatch: 2,
+            queueLimit: nil,
+            kvBits: 4,
+            draftConfigured: false
+        )
+        XCTAssertEqual(capability.queueLimit, 4)
+        XCTAssertEqual(capability.unsupportedReason, .kvBitsUnsupported)
+    }
+
+    func testContinuousBatchingPolicyReportsDraftMutualExclusion() {
+        let capability = ContinuousBatchingPolicy.capability(
+            mode: .on,
+            maxBatch: 2,
+            queueLimit: 9,
+            kvBits: nil,
+            draftConfigured: true
+        )
+        XCTAssertEqual(capability.queueLimit, 9)
+        XCTAssertEqual(capability.unsupportedReason, .draftSpecDecodeMutualExclusion)
+    }
+
     // MARK: - Runtime threading
 
     func testRuntimeReceivesKvBitsOverride() async throws {
@@ -200,6 +296,22 @@ final class ServingKnobsConfigTests: XCTestCase {
         )
         let observed = await runtime.maxBatchForTest()
         XCTAssertEqual(observed, 3)
+    }
+
+    func testRuntimeReceivesContinuousBatchingControls() async throws {
+        let runtime = ModelRuntime(
+            modelID: "test-model",
+            maxBatch: 3,
+            continuousBatchingMode: .canary,
+            continuousBatchQueueLimit: 5,
+            warmSwapEnabled: false,
+            loader: { _ in throw TestRuntimeError.notExpected }
+        )
+        let observed = await runtime.continuousBatchingCapabilityForTest()
+        XCTAssertEqual(observed.mode, .canary)
+        XCTAssertEqual(observed.maxActiveRows, 3)
+        XCTAssertEqual(observed.queueLimit, 5)
+        XCTAssertEqual(observed.unsupportedReason, .upstreamBatchAPIUnpinned)
     }
 
     func testRuntimeDefaultMaxBatchIsOne() async throws {

--- a/phase3-binary/Tests/macprovider-cliTests/ServingKnobsConfigTests.swift
+++ b/phase3-binary/Tests/macprovider-cliTests/ServingKnobsConfigTests.swift
@@ -183,6 +183,24 @@ final class ServingKnobsConfigTests: XCTestCase {
         ))
     }
 
+    func testContinuousBatchingRejectsInvalidModeFromEnvironment() throws {
+        XCTAssertThrowsError(try ConfigLoader.load(
+            cli: CLIOverrides(),
+            environment: ["MACPROVIDER_CONTINUOUS_BATCHING": "maybe"],
+            fileExists: { _ in false },
+            readFile: { _ in "" }
+        ))
+    }
+
+    func testContinuousBatchingRejectsInvalidModeFromYAML() throws {
+        XCTAssertThrowsError(try ConfigLoader.load(
+            cli: CLIOverrides(),
+            environment: [:],
+            fileExists: { _ in true },
+            readFile: { _ in "continuous_batching: maybe\n" }
+        ))
+    }
+
     // MARK: - Preflight validation
 
     func testKvBitsPreflightRejectsInvalidValue() throws {
@@ -231,6 +249,74 @@ final class ServingKnobsConfigTests: XCTestCase {
         config.continuousBatching = .on
         config.maxConcurrencyOverride = 2
         XCTAssertThrowsError(try ServeCommand.runContinuousBatchingPreflight(config))
+    }
+
+    // Lock the fail-closed strict-mode error contract (status + code), not just
+    // that it throws — a future regression could keep "throws" while silently
+    // changing the client-visible status or reason code.
+    func testValidateStrictStartupErrorContract() throws {
+        func assertStrictError(
+            kvBits: Int?,
+            draftConfigured: Bool,
+            expectedStatus: Int,
+            expectedCode: String,
+            line: UInt = #line
+        ) {
+            let capability = ContinuousBatchingPolicy.capability(
+                mode: .on,
+                maxBatch: 2,
+                queueLimit: nil,
+                kvBits: kvBits,
+                draftConfigured: draftConfigured
+            )
+            XCTAssertThrowsError(
+                try ContinuousBatchingPolicy.validateStrictStartup(capability),
+                line: line
+            ) { error in
+                guard let apiError = error as? APIError else {
+                    return XCTFail("expected APIError, got \(error)", line: line)
+                }
+                XCTAssertEqual(apiError.status, expectedStatus, line: line)
+                XCTAssertEqual(apiError.code, expectedCode, line: line)
+                XCTAssertFalse(apiError.message.isEmpty, line: line)
+            }
+        }
+
+        // Unpinned upstream batch API => 503 continuous_batching_unavailable.
+        assertStrictError(
+            kvBits: nil,
+            draftConfigured: false,
+            expectedStatus: 503,
+            expectedCode: "continuous_batching_unavailable"
+        )
+        // kv_bits requested => 400 continuous_batching_unsupported_kv_bits.
+        assertStrictError(
+            kvBits: 4,
+            draftConfigured: false,
+            expectedStatus: 400,
+            expectedCode: "continuous_batching_unsupported_kv_bits"
+        )
+        // Draft model requested => 400 draft_model_capacity_shortfall (draft takes precedence).
+        assertStrictError(
+            kvBits: nil,
+            draftConfigured: true,
+            expectedStatus: 400,
+            expectedCode: "draft_model_capacity_shortfall"
+        )
+    }
+
+    // Off mode is inert: strict validation never throws regardless of otherwise-
+    // unsupported inputs (FR-CB9 flag-off parity).
+    func testValidateStrictStartupOffModeIsInert() throws {
+        let capability = ContinuousBatchingPolicy.capability(
+            mode: .off,
+            maxBatch: 2,
+            queueLimit: nil,
+            kvBits: 4,
+            draftConfigured: true
+        )
+        XCTAssertNil(capability.unsupportedReason)
+        XCTAssertNoThrow(try ContinuousBatchingPolicy.validateStrictStartup(capability))
     }
 
     func testContinuousBatchingCanarySerialRoutesUnsupportedPin() throws {


### PR DESCRIPTION
## SPEC-038 continuous-batching scaffold — flag-off, serial-identical

This lands the **integration surface only** for SPEC-038 continuous batching.
No batch engine is wired and no shared forward runs. `mlx-swift-lm` 3.31.4 ships
no reviewed batch API (upstream PR #263 pending), so the real decode engine is a
later, separately-gated step (FR-CB10 pin + FR-CB15 real-hardware enable).

### What this adds
- **Default-OFF operator knob** `continuous_batching: off | canary | on` across
  config key / `MACPROVIDER_CONTINUOUS_BATCHING` env / `--continuous-batching`
  CLI, plus a bounded `continuous_batch_queue_limit` (default `2 * active slots`).
- **`ContinuousBatchingPolicy`** — pure policy layer:
  - `off` (default): serial path, fully inert — no per-request usage/receipt/
    billing/slots change (FR-CB9).
  - `on` (strict): fails preflight fail-closed with a named reason until a
    reviewed upstream batch API is pinned (`continuous_batching_unavailable`),
    or `..._unsupported_kv_bits`, or draft mutual-exclusion (FR-CB8/FR-CB10/FR-CB12).
  - `canary` (permissive): serial-routes with an observable
    `event=continuous_batching_unsupported action=serial_routed reason=...`
    signal — never a silent downgrade (FR-CB8).
- **`ModelRuntime` wiring** threading the mode/queue-limit through the actor and
  invoking the policy at the serve entry points.
- **MSB aggregate-throughput helper** computing total decoded tokens over a
  common wall-clock interval, refusing to sum per-request durations (FR-CB14).
- Unit tests for config precedence, strict rejection reason precedence,
  permissive routing, draft exclusion, queue-limit default/validation, runtime
  threading, and MSB math.

Serial path is unchanged when the flag is off; the engine flip is a later gated
step. This is not production-enabled: FR-CB15 real-hardware enable gate governs
any real-traffic use.

### Audit — three-lane codex BUILD audit (code / security / architect)
All three lanes converged **0 CRITICAL / 0 HIGH / 0 MEDIUM on round 1**. Prompts
are committed under `audits/2026-07-29/AUDIT_SPEC_038_SCAFFOLD_*.md`.

**Applied this PR (round-1 fixes):**
- **security LOW-2** — `msbAggregateThroughput` now guards integer overflow of
  the token sum (`addingReportingOverflow` → new `.tokenCountOverflow`) instead
  of silently wrapping.
- **code LOW-1** — test hardening: source-specific invalid-mode rejection for
  env and YAML; direct `validateStrictStartup` assertions locking status + reason
  code for the unpinned/`kv_bits`/draft branches; off-mode inertness assertion;
  MSB overflow rejection test. (48 tests, was 43.)
- Stripped a trailing blank line at EOF (git-diff-check whitespace nit).

**Carried LOW / INFO (documented, not fixed — engine-era or debatable):**
- **security LOW-1** — in `canary` mode the unsupported-notice line is emitted
  per request / per serve entry point rather than once-per-attach (AC-7). Only
  affects opt-in canary stderr volume; no billing/receipt/usage/serving effect.
  Once-per-attach dedup requires per-attach actor state and lands with the real
  engine when there is genuine serial-routing traffic.
- **architect LOW-1** — canary serial-route telemetry logs the internal reason
  `rawValue` (`upstream_batch_api_unpinned`, `draft_spec_decode_mutual_exclusion`)
  while strict rejection returns the client API `code`
  (`continuous_batching_unavailable`, `draft_model_capacity_shortfall`). This is
  an intentional two-taxonomy split — telemetry reason descriptors vs client
  error codes — kept as-is; a future engine PR may reconcile if operators prefer
  one taxonomy.
- **architect INFO-1** — `ContinuousBatchingCapability.shouldUseSerialPath` is a
  boolean that cannot yet express a future *supported* canary batch route. Unused
  today (no engine); to be replaced by a route enum when the engine lands.

### Verification
- `swift build --package-path phase3-binary` — green
- `swift test --package-path phase3-binary --filter 'ServingKnobsConfigTests|DecodeBenchHelperTests'` — green

SPEC-GOVERNANCE-DECLARATION-BEGIN
{
  "schema_version": "spec-pr-governance-v1",
  "behavior_change": "yes",
  "contract_change": "none",
  "specs": ["SPEC-038"],
  "requirements": ["SPEC-038-R008", "SPEC-038-R009", "SPEC-038-R010", "SPEC-038-R012", "SPEC-038-R014"],
  "authority_domains": ["continuous-batching-serving"],
  "arbitration": ["CODE_BUG"],
  "tests": ["phase3-binary/Tests/macprovider-cliTests/ServingKnobsConfigTests.swift", "phase3-binary/Tests/macprovider-cliTests/ScaffoldTests.swift"],
  "journeys": ["not-required"],
  "issue": "https://github.com/Augustas11/macprovider/issues/614"
}
SPEC-GOVERNANCE-DECLARATION-END
