### PR TITLE
Keep slow active providers routable during decode

### DIFF
--- a/phase4-coordinator/internal/ws/relay.go
+++ b/phase4-coordinator/internal/ws/relay.go
@@ -1312,6 +1312,7 @@ func (s *Server) dispatchInference(ctx context.Context, provider pool.Provider, 
 	if err != nil {
 		return nil, err
 	}
+	s.extendProviderReadDeadlineForActive(provider)
 	payload, err := session.sealInferenceRequest(provider, requestID, body, stream, settlementMetadata, ConversationKeyFromContext(ctx))
 	if err != nil {
 		if errors.Is(err, errTier2C2PCounterExhausted) {

--- a/phase4-coordinator/internal/ws/relay_test.go
+++ b/phase4-coordinator/internal/ws/relay_test.go
@@ -182,6 +182,132 @@ func TestRelayDispatchRoutesChunkAndEndByRequestID(t *testing.T) {
 	}
 }
 
+func TestActiveRelayPreventsHeartbeatMonitorCloseBeforeFirstChunk(t *testing.T) {
+	serverConn, providerConn := net.Pipe()
+	defer providerConn.Close()
+	defer serverConn.Close()
+
+	cfg := config.Default()
+	cfg.Routing.FailoverTimeoutS = 1
+	cfg.Routing.RequestTimeoutS = 5
+	cfg.Pool.HeartbeatMissThresholdS = 1
+
+	registry := pool.NewRegistry(nil)
+	stale := time.Now().Add(-2 * time.Second)
+	provider := &pool.Provider{
+		ProviderID:      "p-active",
+		AssignedID:      "s-active",
+		ModelID:         "model-a",
+		Tier:            pool.TierProvisional,
+		InferencePath:   pool.InferencePathWSTunneled,
+		State:           pool.StateReady,
+		SlotsFree:       1,
+		SlotsTotal:      1,
+		MaxConcurrency:  1,
+		LastActivityAt:  stale,
+		LastHeartbeatAt: stale,
+	}
+	registry.Register(provider, serverConn)
+	s := NewServer(cfg, registry, zerolog.Nop())
+	session := newProviderSession("p-active", "s-active", serverConn, 1)
+	s.sessions.Store(sessionKey("p-active", "s-active"), session)
+	go session.runWriter()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	relay, err := s.DispatchInference(ctx, *provider, "req-slow", []byte(`{"model":"model-a"}`), true)
+	if err != nil {
+		t.Fatalf("dispatch: %v", err)
+	}
+	defer relay.cancel("test_done")
+	if _, op, err := wsutil.ReadServerData(providerConn); err != nil {
+		t.Fatalf("read inference_request: %v", err)
+	} else if op != gobwas.OpText {
+		t.Fatalf("op = %v, want text", op)
+	}
+
+	go s.monitorHeartbeat("p-active", "s-active", serverConn)
+	time.Sleep(1500 * time.Millisecond)
+
+	if providerConn.SetReadDeadline(time.Now().Add(100*time.Millisecond)) != nil {
+		t.Fatal("set provider read deadline")
+	}
+	if _, _, err := wsutil.ReadServerData(providerConn); err == nil {
+		t.Fatal("expected no server frame while active relay is still waiting")
+	} else if !errors.Is(err, os.ErrDeadlineExceeded) {
+		t.Fatalf("provider websocket was closed while relay was active: %v", err)
+	}
+	if !session.hasActive() {
+		t.Fatal("relay active state was removed before request context ended")
+	}
+}
+
+func TestActiveRelayLivenessSuppressionEndsWhenRequestContextExpires(t *testing.T) {
+	serverConn, providerConn := net.Pipe()
+	defer providerConn.Close()
+	defer serverConn.Close()
+
+	cfg := config.Default()
+	cfg.Routing.FailoverTimeoutS = 1
+	cfg.Routing.RequestTimeoutS = 1
+	cfg.Pool.HeartbeatMissThresholdS = 1
+
+	registry := pool.NewRegistry(nil)
+	stale := time.Now().Add(-2 * time.Second)
+	provider := &pool.Provider{
+		ProviderID:      "p-expiring",
+		AssignedID:      "s-expiring",
+		ModelID:         "model-a",
+		Tier:            pool.TierProvisional,
+		InferencePath:   pool.InferencePathWSTunneled,
+		State:           pool.StateReady,
+		SlotsFree:       1,
+		SlotsTotal:      1,
+		MaxConcurrency:  1,
+		LastActivityAt:  stale,
+		LastHeartbeatAt: stale,
+	}
+	registry.Register(provider, serverConn)
+	s := NewServer(cfg, registry, zerolog.Nop())
+	session := newProviderSession("p-expiring", "s-expiring", serverConn, 1)
+	s.sessions.Store(sessionKey("p-expiring", "s-expiring"), session)
+	go session.runWriter()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer cancel()
+	relay, err := s.DispatchInference(ctx, *provider, "req-expiring", []byte(`{"model":"model-a"}`), true)
+	if err != nil {
+		t.Fatalf("dispatch: %v", err)
+	}
+	defer relay.cancel("test_done")
+	if _, op, err := wsutil.ReadServerData(providerConn); err != nil {
+		t.Fatalf("read inference_request: %v", err)
+	} else if op != gobwas.OpText {
+		t.Fatalf("op = %v, want text", op)
+	}
+
+	go s.monitorHeartbeat("p-expiring", "s-expiring", serverConn)
+	until := time.Now().Add(3 * time.Second)
+	for session.hasActive() && time.Now().Before(until) {
+		time.Sleep(10 * time.Millisecond)
+	}
+	if session.hasActive() {
+		t.Fatal("relay active state did not clear after request context expired")
+	}
+	for time.Now().Before(until) {
+		if err := providerConn.SetReadDeadline(time.Now().Add(100 * time.Millisecond)); err != nil {
+			t.Fatalf("set provider read deadline: %v", err)
+		}
+		if _, _, err := wsutil.ReadServerData(providerConn); err != nil {
+			if errors.Is(err, os.ErrDeadlineExceeded) {
+				continue
+			}
+			return
+		}
+	}
+	t.Fatal("provider websocket stayed open after active relay expired and heartbeat remained stale")
+}
+
 func TestRelayDispatchCarriesConversationKeyFromContext(t *testing.T) {
 	serverConn, providerConn := net.Pipe()
 	defer providerConn.Close()

--- a/phase4-coordinator/internal/ws/server.go
+++ b/phase4-coordinator/internal/ws/server.go
@@ -3056,7 +3056,7 @@ func (s *Server) readProviderLoop(conn net.Conn, providerID, assignedID string) 
 		controlReply = s.directControlReply(conn)
 	}
 	for {
-		s.setReadDeadline(conn, s.cfg.HeartbeatMissThreshold())
+		s.setReadDeadline(conn, s.providerReadTimeout(providerID, assignedID))
 		payload, op, err := s.readClientData(conn, controlReply)
 		if err != nil {
 			s.log.Warn().Err(err).Str("provider_id", providerID).Msg("provider websocket read failed")
@@ -5286,6 +5286,9 @@ func (s *Server) monitorHeartbeat(providerID, assignedID string, conn net.Conn) 
 		if s.now().Sub(last) <= threshold {
 			continue
 		}
+		if s.providerHasActiveRelay(providerID, assignedID) {
+			continue
+		}
 		s.log.Warn().
 			Str("provider_id", providerID).
 			Dur("gap", s.now().Sub(last)).
@@ -5305,6 +5308,39 @@ func (s *Server) monitorHeartbeat(providerID, assignedID string, conn net.Conn) 
 		_ = conn.Close()
 		return
 	}
+}
+
+func (s *Server) providerReadTimeout(providerID, assignedID string) time.Duration {
+	provider, ok := s.pool.Resolve(providerID, assignedID)
+	if !ok {
+		return s.cfg.HeartbeatMissThreshold()
+	}
+	if s.providerHasActiveRelay(providerID, assignedID) {
+		return s.activeRelayReadTimeout(provider)
+	}
+	return s.providerLivenessThreshold(provider)
+}
+
+func (s *Server) extendProviderReadDeadlineForActive(provider pool.Provider) {
+	session, ok := s.storedSessionFor(provider.ProviderID, provider.AssignedID)
+	if !ok || !session.hasActive() {
+		return
+	}
+	s.setReadDeadline(session.conn, s.activeRelayReadTimeout(provider))
+}
+
+func (s *Server) providerHasActiveRelay(providerID, assignedID string) bool {
+	session, ok := s.storedSessionFor(providerID, assignedID)
+	return ok && session.hasActive()
+}
+
+func (s *Server) activeRelayReadTimeout(provider pool.Provider) time.Duration {
+	threshold := s.providerLivenessThreshold(provider)
+	requestTimeout := time.Duration(s.cfg.Routing.RequestTimeoutS) * time.Second
+	if requestTimeout > threshold {
+		return requestTimeout
+	}
+	return threshold
 }
 
 func (s *Server) providerLivenessThreshold(provider pool.Provider) time.Duration {

--- a/phase5-gateway/internal/router/chat_proxy.go
+++ b/phase5-gateway/internal/router/chat_proxy.go
@@ -76,6 +76,8 @@ const (
 	legacySettlementPolicyVersion     = "spec022-prereq-v0"
 	settlementHoldFallbackTTL         = 5 * time.Minute
 	maxStreamingFallbackMetadataBytes = int64(64 << 10)
+	decodeIdleSlowModelProgressTokens = 5
+	decodeIdleSlowModelMax            = 60 * time.Second
 )
 
 var errStreamingIdleTimeout = errors.New("streaming upstream idle timeout")
@@ -563,7 +565,7 @@ func (s *Server) handleChatCompletions(w http.ResponseWriter, r *http.Request) {
 		// 17.7 fallback usage_events insert in settleAfterCommit
 		// uses the SAME window_date as the original reservation
 		// (avoids drift for streams that cross UTC midnight).
-		s.forwardStreamingChat(w, r, resp, subject, promptEstimate, maxUsageTokens, maxTokens, retryExhausted, priorProviderDispatch, deadlines, structuredStreaming, window, timing)
+		s.forwardStreamingChat(w, r, resp, subject, promptEstimate, maxUsageTokens, maxTokens, model, retryExhausted, priorProviderDispatch, deadlines, structuredStreaming, window, timing)
 		return
 	}
 	s.forwardNonStreamingChat(w, r, resp, subject, promptEstimate, maxUsageTokens, maxTokens, retryExhausted, priorProviderDispatch, window)
@@ -865,7 +867,7 @@ func emitProviderAttribution(dst, src http.Header) {
 	}
 }
 
-func (s *Server) forwardStreamingChat(w http.ResponseWriter, r *http.Request, resp *http.Response, subject usageSubject, promptEstimate, maxUsageTokens, maxTokens int64, retryExhausted, priorProviderDispatch bool, deadlines *requestDeadlines, structuredStreaming bool, reservationWindow string, timing *gatewayPhaseTiming) {
+func (s *Server) forwardStreamingChat(w http.ResponseWriter, r *http.Request, resp *http.Response, subject usageSubject, promptEstimate, maxUsageTokens, maxTokens int64, model string, retryExhausted, priorProviderDispatch bool, deadlines *requestDeadlines, structuredStreaming bool, reservationWindow string, timing *gatewayPhaseTiming) {
 	upstreamCtx := deadlines.Context()
 	cancelUpstream := deadlines.Cancel
 	if resp.StatusCode == http.StatusServiceUnavailable {
@@ -958,7 +960,7 @@ func (s *Server) forwardStreamingChat(w http.ResponseWriter, r *http.Request, re
 	// keeps the socket warm with role-only or usage-only frames no longer
 	// holds the stream open forever. A zero deadline preserves the legacy
 	// "no idle timeout" sentinel (streaming_idle_ms <= 0).
-	idleTimeout := s.cfg.StreamingIdleTimeout()
+	idleTimeout := adaptiveDecodeIdleTimeout(model, s.cfg)
 	progressDeadline := streamingProgressDeadline(idleTimeout)
 	var emitted int64
 	var serializedEmitted int64
@@ -1248,7 +1250,7 @@ func (s *Server) forwardStreamingChat(w http.ResponseWriter, r *http.Request, re
 		if errors.Is(err, errStreamingIdleTimeout) {
 			slog.Warn("streaming coordinator idle timeout",
 				"request_id", requestID(r),
-				"timeout_ms", s.cfg.Timeouts.StreamingIdleMS,
+				"timeout_ms", idleTimeout.Milliseconds(),
 				"deadline_phase", deadlineReasonDecodeIdle,
 			)
 			deadlines.noteReason(deadlineReasonDecodeIdle)
@@ -1360,6 +1362,40 @@ func streamingProgressDeadline(idleTimeout time.Duration) time.Time {
 		return time.Time{}
 	}
 	return time.Now().Add(idleTimeout)
+}
+
+func adaptiveDecodeIdleTimeout(model string, cfg config.Config) time.Duration {
+	base := cfg.StreamingIdleTimeout()
+	if base <= 0 {
+		return base
+	}
+	expectedTPS, ok := expectedDecodeTokensPerSecond(model)
+	if !ok || expectedTPS <= 0 {
+		return base
+	}
+	perToken := time.Duration(math.Ceil(float64(time.Second) / expectedTPS))
+	adaptive := perToken * decodeIdleSlowModelProgressTokens
+	if adaptive > decodeIdleSlowModelMax {
+		adaptive = decodeIdleSlowModelMax
+	}
+	if adaptive > base {
+		return adaptive
+	}
+	return base
+}
+
+func expectedDecodeTokensPerSecond(model string) (float64, bool) {
+	name := strings.ToLower(model)
+	switch {
+	case strings.Contains(name, "70b"), strings.Contains(name, "72b"):
+		return 0.17, true
+	case strings.Contains(name, "30b"), strings.Contains(name, "32b"):
+		return 0.25, true
+	case strings.Contains(name, "20b"), strings.Contains(name, "22b"), strings.Contains(name, "24b"):
+		return 0.5, true
+	default:
+		return 0, false
+	}
 }
 
 // readStreamingLineWithIdleTimeout reads one SSE line, giving up at deadline.

--- a/phase5-gateway/internal/router/request_deadlines_test.go
+++ b/phase5-gateway/internal/router/request_deadlines_test.go
@@ -58,6 +58,29 @@ func TestStreamCeilingNeverBelowLegacyWall(t *testing.T) {
 	}
 }
 
+func TestAdaptiveDecodeIdleTimeoutExtendsSlowModelClasses(t *testing.T) {
+	cfg := config.Default()
+	cfg.Timeouts.StreamingIdleMS = 500
+
+	if got, want := adaptiveDecodeIdleTimeout("llama", cfg), 500*time.Millisecond; got != want {
+		t.Fatalf("unknown model idle timeout=%s want configured %s", got, want)
+	}
+
+	unbounded := cfg
+	unbounded.Timeouts.StreamingIdleMS = 0
+	if got := adaptiveDecodeIdleTimeout("mlx-community/Qwen3-Coder-30B-A3B-Instruct-4bit", unbounded); got != 0 {
+		t.Fatalf("unbounded 30B idle timeout=%s want no timeout sentinel", got)
+	}
+
+	got := adaptiveDecodeIdleTimeout("mlx-community/Qwen3-Coder-30B-A3B-Instruct-4bit", cfg)
+	if got <= cfg.StreamingIdleTimeout() {
+		t.Fatalf("30B idle timeout=%s want greater than configured %s", got, cfg.StreamingIdleTimeout())
+	}
+	if got > decodeIdleSlowModelMax {
+		t.Fatalf("30B idle timeout=%s exceeds cap %s", got, decodeIdleSlowModelMax)
+	}
+}
+
 // TestEffectiveStreamCeilingClampsStructuredOutput pins the deliberate
 // conservative choice in #760: SPEC-019 v0.2.4 §AC-V2-9 normatively fixes the
 // structured-output streaming budget at 300s, so structured streams keep that
@@ -401,6 +424,46 @@ func TestContentProgressKeepsStreamAliveAcrossIdleBudget(t *testing.T) {
 	body := resp.Body.String()
 	if !strings.Contains(body, "data: [DONE]") || strings.Contains(body, "provider_timeout") {
 		t.Fatalf("a content-progressing stream was cut by the idle budget; body=%.400q", body)
+	}
+}
+
+func TestSlowThirtyBContentProgressUsesAdaptiveDecodeIdleBudget(t *testing.T) {
+	client := seamStreamingUpstreamCtx(func(pw *io.PipeWriter, ctx context.Context) {
+		frames := []string{
+			`data: {"id":"c","choices":[{"delta":{"content":"slow"}}]}` + "\n\n",
+			`data: {"id":"c","choices":[{"delta":{"content":" token"}}]}` + "\n\n",
+			`data: [DONE]` + "\n\n",
+		}
+		for i, frame := range frames {
+			if _, err := pw.Write([]byte(frame)); err != nil {
+				return
+			}
+			if i == len(frames)-1 {
+				break
+			}
+			select {
+			case <-ctx.Done():
+				_ = pw.CloseWithError(ctx.Err())
+				return
+			case <-time.After(750 * time.Millisecond):
+			}
+		}
+		_ = pw.Close()
+	})
+	h, store, _, cfg := newTestHarnessConfig(t, fakeOAuth{}, func(cfg *config.Config) {
+		cfg.Coordinator.BuyerURL = "http://coordinator.test"
+		cfg.Timeouts.StreamingIdleMS = 500
+		cfg.Timeouts.FirstTokenSeconds = 30
+		cfg.Timeouts.CoordinatorRequestSeconds = 30
+		cfg.Timeouts.StreamCeilingFloorSeconds = 30
+		cfg.Timeouts.StreamCeilingMaxSeconds = 60
+	}, WithHTTPClient(client))
+	key := createAccountAndKey(t, store, cfg, "acct_slow_30b")
+
+	resp := postChat(t, h, key, `{"model":"mlx-community/Qwen3-Coder-30B-A3B-Instruct-4bit","stream":true,"max_tokens":500,"messages":[{"role":"user","content":"hi"}]}`, nil)
+	body := resp.Body.String()
+	if !strings.Contains(body, "data: [DONE]") || strings.Contains(body, "provider_timeout") {
+		t.Fatalf("slow 30B content-progressing stream was cut by decode idle; body=%.400q", body)
 	}
 }
 


### PR DESCRIPTION
## Summary

Refs #816, #817, #818.

- Coordinator: treats an assigned active relay as bounded provider liveness, so a stale heartbeat alone cannot close a provider while it is actively decoding before the first chunk.
- Gateway: adapts the streaming content-progress `decode_idle` budget for known slow model classes such as 30B/70B, while preserving the configured no-timeout sentinel and the existing hung-stream protections.
- Adds regressions for active-relay survival, active cleanup after request timeout, slow 30B content progress, heartbeat-only idle timeout, and `streaming_idle_ms <= 0` behavior.

## Validation

- `cd phase4-coordinator && go test ./internal/ws`
- `cd phase5-gateway && go test ./internal/router`
- `cd phase4-coordinator && go test ./...`
- `cd phase5-gateway && go test ./...`
- 3-lane Codex audit loop: code/security/architecture all CLEAR, 0 critical/high/medium after follow-up fixes.

## Deployment Notes

Server-side only. No provider CLI release or fleet auto-update is included; #819 remains deferred. After merge, deploy coordinator and gateway to Pearl, verify `/healthz`, verify active provider liveness behavior, verify no false 30B `decode_idle`, then close #817/#818 and update #816.

SPEC-GOVERNANCE-DECLARATION-BEGIN
{
  "schema_version": "spec-pr-governance-v1",
  "behavior_change": "yes",
  "contract_change": "none",
  "specs": ["SPEC-002", "SPEC-006"],
  "requirements": ["SPEC-002-R001"],
  "authority_domains": ["coordinator-admission-routing", "buyer-api-error-contract"],
  "arbitration": ["CODE_BUG"],
  "tests": [
    "phase4-coordinator go test ./...",
    "phase5-gateway go test ./...",
    "3-lane Codex audit loop: code/security/architecture CLEAR 0 C/H/M"
  ],
  "journeys": ["not-required"],
  "issue": "https://github.com/Augustas11/macprovider/issues/816"
}
SPEC-GOVERNANCE-DECLARATION-END
