### PR TITLE
fix(#815): guard autotune SIGTRAP + fail-safe launchd restore

### DIFF
--- a/phase3-binary/Sources/macprovider-cli/AutotuneCommand.swift
+++ b/phase3-binary/Sources/macprovider-cli/AutotuneCommand.swift
@@ -1103,7 +1103,12 @@ struct AutotuneCommand: AsyncParsableCommand {
             shouldRestore = true
         }
 
-        let drainResult = try ProviderDrainer().drain(
+        let drainer = ProviderDrainer()
+        let restoreGuard = shouldRestore
+            ? try drainer.startLaunchdCrashRestoreGuard(for: conflict)
+            : nil
+
+        let drainResult = try drainer.drain(
             conflict,
             port: port,
             graceSeconds: TimeInterval(drainGrace)
@@ -1131,7 +1136,8 @@ struct AutotuneCommand: AsyncParsableCommand {
         var restoreError: Error?
         if shouldRestore {
             do {
-                _ = try ProviderDrainer().restore(conflict, restartForeground: true)
+                _ = try drainer.restore(conflict, restartForeground: true)
+                restoreGuard?.dismiss()
             } catch {
                 restoreError = error
             }

--- a/phase3-binary/Sources/macprovider-cli/AutotuneRecommend.swift
+++ b/phase3-binary/Sources/macprovider-cli/AutotuneRecommend.swift
@@ -3195,6 +3195,19 @@ struct AutotuneRecommendationBenchmarker {
                 let safety = ProbeSafetyAssessment.assess(before: before, after: after)
                 switch probe {
                 case .feasible(let medianTPS, let p95TTFTMS):
+                    if let invalidDiagnostic = Self.invalidFeasibleDiagnostic(
+                        medianTPS: medianTPS,
+                        p95TTFTMS: p95TTFTMS
+                    ) {
+                        if prefetchedArtifacts != nil {
+                            throw AutotuneRecommendError.candidateProbeFailed(
+                                modelKey: modelKey,
+                                reason: invalidDiagnostic
+                            )
+                        }
+                        diagnostics[modelKey] = invalidDiagnostic
+                        continue
+                    }
                     let generatedAt = clock()
                     results[modelKey] = CandidateBenchmark(
                         modelKey: modelKey,
@@ -3256,6 +3269,32 @@ struct AutotuneRecommendationBenchmarker {
             return "bandwidth tier \(hardware.bandwidthTier.rawValue) below minimum \(row.minBandwidthTier.rawValue)"
         }
         return nil
+    }
+
+    private static func invalidFeasibleDiagnostic(
+        medianTPS: Double,
+        p95TTFTMS: Double
+    ) -> String? {
+        guard medianTPS.isFinite, medianTPS > 0 else {
+            return "Stage 1 probe produced invalid feasible throughput \(diagnosticNumber(medianTPS))"
+        }
+        guard p95TTFTMS.isFinite, p95TTFTMS >= 0, p95TTFTMS <= Double(Int32.max) else {
+            return "Stage 1 probe produced invalid feasible TTFT \(diagnosticNumber(p95TTFTMS))ms"
+        }
+        return nil
+    }
+
+    private static func diagnosticNumber(_ value: Double) -> String {
+        if value.isNaN {
+            return "nan"
+        }
+        if value == .infinity {
+            return "infinity"
+        }
+        if value == -.infinity {
+            return "-infinity"
+        }
+        return value.jsonNumber
     }
 }
 

--- a/phase3-binary/Sources/macprovider-cli/ProviderConflictDetector.swift
+++ b/phase3-binary/Sources/macprovider-cli/ProviderConflictDetector.swift
@@ -175,6 +175,7 @@ struct ProviderDrainer {
     typealias ProcessRunningProbe = (Int32) -> Bool
     typealias PortProbe = (Int) -> Bool
     typealias ForegroundRestarter = ([String]) throws -> Void
+    typealias LaunchdRestoreGuardStarter = (_ launchdDomain: String, _ plistPath: String) throws -> ProviderLaunchdRestoreGuard
 
     static let launchctlPath = "/bin/launchctl"
     static let launchdLabel = ProviderConflictDetector.launchdLabel
@@ -186,6 +187,7 @@ struct ProviderDrainer {
     private let processIsRunning: ProcessRunningProbe
     private let portIsOpen: PortProbe
     private let foregroundRestarter: ForegroundRestarter
+    private let launchdRestoreGuardStarter: LaunchdRestoreGuardStarter
     private let warningWriter: (String) -> Void
 
     init(
@@ -197,6 +199,7 @@ struct ProviderDrainer {
         processIsRunning: @escaping ProcessRunningProbe = ProviderDrainer.defaultProcessIsRunning,
         portIsOpen: @escaping PortProbe = MacProviderPortProbe.isOpen,
         foregroundRestarter: @escaping ForegroundRestarter = ProviderDrainer.defaultForegroundRestarter,
+        launchdRestoreGuardStarter: @escaping LaunchdRestoreGuardStarter = ProviderLaunchdRestoreGuard.start,
         warningWriter: @escaping (String) -> Void = ProviderDrainer.defaultWarningWriter
     ) {
         self.uid = uid
@@ -206,6 +209,7 @@ struct ProviderDrainer {
         self.processIsRunning = processIsRunning
         self.portIsOpen = portIsOpen
         self.foregroundRestarter = foregroundRestarter
+        self.launchdRestoreGuardStarter = launchdRestoreGuardStarter
         self.warningWriter = warningWriter
     }
 
@@ -242,6 +246,13 @@ struct ProviderDrainer {
             try foregroundRestarter(argv)
             return .restored
         }
+    }
+
+    func startLaunchdCrashRestoreGuard(for conflict: ProviderConflict) throws -> ProviderLaunchdRestoreGuard? {
+        guard case .launchdManaged = conflict else {
+            return nil
+        }
+        return try launchdRestoreGuardStarter(launchdDomain, plistURL.path)
     }
 
     private var launchdDomain: String {
@@ -310,5 +321,74 @@ struct ProviderDrainer {
 
     static func defaultWarningWriter(_ warning: String) {
         FileHandle.standardError.write(Data(("\(warning)\n").utf8))
+    }
+}
+
+final class ProviderLaunchdRestoreGuard {
+    static let dismissToken = "__macprovider_launchd_restore_guard_dismiss__"
+    static let restoreScript = """
+        trap '' HUP INT QUIT TERM
+        while IFS= read -r line; do
+          [ "$line" = "$4" ] && exit 0
+        done
+        "$1" bootstrap "$2" "$3" >/dev/null 2>&1 || true
+        """
+
+    private let lock = NSLock()
+    private var dismissed = false
+    private let dismissHandler: () -> Void
+
+    init(dismissHandler: @escaping () -> Void) {
+        self.dismissHandler = dismissHandler
+    }
+
+    func dismiss() {
+        lock.lock()
+        if dismissed {
+            lock.unlock()
+            return
+        }
+        dismissed = true
+        lock.unlock()
+        dismissHandler()
+    }
+
+    static func start(launchdDomain: String, plistPath: String) throws -> ProviderLaunchdRestoreGuard {
+        try start(
+            launchdDomain: launchdDomain,
+            plistPath: plistPath,
+            launchctlPath: "/bin/launchctl"
+        )
+    }
+
+    static func start(
+        launchdDomain: String,
+        plistPath: String,
+        launchctlPath: String
+    ) throws -> ProviderLaunchdRestoreGuard {
+        let process = Process()
+        let stdin = Pipe()
+        process.executableURL = URL(fileURLWithPath: "/bin/sh")
+        process.arguments = [
+            "-c",
+            restoreScript,
+            "macprovider-launchd-restore-guard",
+            launchctlPath,
+            launchdDomain,
+            plistPath,
+            dismissToken,
+        ]
+        process.standardInput = stdin.fileHandleForReading
+        process.standardOutput = Pipe()
+        process.standardError = Pipe()
+        try process.run()
+
+        return ProviderLaunchdRestoreGuard {
+            try? stdin.fileHandleForWriting.write(
+                contentsOf: Data("\(dismissToken)\n".utf8)
+            )
+            try? stdin.fileHandleForWriting.close()
+            process.waitUntilExit()
+        }
     }
 }

--- a/phase3-binary/Sources/macprovider-cli/Stage1Iterator.swift
+++ b/phase3-binary/Sources/macprovider-cli/Stage1Iterator.swift
@@ -524,6 +524,19 @@ struct Stage1Prober: Stage1Probing {
         }
 
         let p95 = percentile95(ttfts)
+        let medianTPS = median(throughputs)
+        guard medianTPS.isFinite, medianTPS > 0 else {
+            return .infeasible(
+                reason: "Stage 1 probe produced invalid throughput \(stage1DiagnosticNumber(medianTPS))",
+                nErr: max(1, replicates)
+            )
+        }
+        guard p95.isFinite, p95 >= 0, p95 <= Double(Int32.max) else {
+            return .infeasible(
+                reason: "Stage 1 probe produced invalid TTFT \(stage1DiagnosticNumber(p95))ms",
+                nErr: max(1, replicates)
+            )
+        }
         // gateTTFTMS == 0 means the ceiling is disabled (#742: no 60s default).
         if gateTTFTMS > 0, p95 > Double(gateTTFTMS) {
             return .infeasible(
@@ -533,7 +546,7 @@ struct Stage1Prober: Stage1Probing {
         }
 
         return .feasible(
-            medianTPS: median(throughputs),
+            medianTPS: medianTPS,
             p95TTFTMS: p95
         )
     }
@@ -659,6 +672,20 @@ struct Stage1Prober: Stage1Probing {
             return (sorted[mid - 1] + sorted[mid]) / 2
         }
         return sorted[mid]
+    }
+
+    private func stage1DiagnosticNumber(_ value: Double) -> String {
+        if value.isNaN {
+            return "nan"
+        }
+        if value == .infinity {
+            return "infinity"
+        }
+        if value == -.infinity {
+            return "-infinity"
+        }
+        return String(format: "%.6f", value)
+            .replacingOccurrences(of: #"\.?0+$"#, with: "", options: .regularExpression)
     }
 }
 

--- a/phase3-binary/Tests/macprovider-cliTests/AutotuneRecommendTests.swift
+++ b/phase3-binary/Tests/macprovider-cliTests/AutotuneRecommendTests.swift
@@ -3120,6 +3120,123 @@ final class AutotuneRecommendTests: XCTestCase {
         )
     }
 
+    func testBenchmarksDiagnosesInvalidFeasibleMeasurementsWithoutTrapping() async throws {
+        let modelKey = "qwen3-coder-30b-a3b-instruct"
+        var request = try makeRequest(modelKey: modelKey)
+        let row = try XCTUnwrap(request.candidateCatalog.rows[modelKey])
+        let revision = try XCTUnwrap(row.modelRevision)
+        let hub = try tempDir()
+        let resolver = CachedModelArtifactResolver(hubRoot: hub)
+        let snapshot = resolver.snapshotURL(modelID: row.modelID, revision: revision)
+        try FileManager.default.createDirectory(at: snapshot, withIntermediateDirectories: true)
+        try Data("weights".utf8).write(to: snapshot.appendingPathComponent("weights.bin"))
+        request.candidateCatalog.rows[modelKey]?.modelSHA256 = try ModelArtifactVerifier.canonicalArtifactHash(directory: snapshot)
+        request.benchmarks = [:]
+        let benchmarker = AutotuneRecommendationBenchmarker(
+            artifactResolver: resolver,
+            runnerFactory: { try CandidateProviderRunner(providerBinaryPath: "/bin/true") },
+            prober: RecordingStage1Prober(results: [
+                snapshot.path: .feasible(medianTPS: 0, p95TTFTMS: .infinity),
+            ]),
+            safetySampler: StaticProbeSafetySampler()
+        )
+
+        let outcomes = try await benchmarker.benchmarks(
+            request: request,
+            targetContext: 4_000,
+            gateTTFTMS: 3_000,
+            replicates: 1,
+            port: 18080
+        )
+
+        XCTAssertNil(outcomes.benchmarks[modelKey])
+        let diagnostic = try XCTUnwrap(outcomes.diagnostics[modelKey])
+        XCTAssertTrue(diagnostic.contains("invalid feasible throughput"), diagnostic)
+    }
+
+    func testBenchmarksDiagnosesInvalidFeasibleTTFTWithoutTrapping() async throws {
+        let modelKey = "qwen3-coder-30b-a3b-instruct"
+        var request = try makeRequest(modelKey: modelKey)
+        let row = try XCTUnwrap(request.candidateCatalog.rows[modelKey])
+        let revision = try XCTUnwrap(row.modelRevision)
+        let hub = try tempDir()
+        let resolver = CachedModelArtifactResolver(hubRoot: hub)
+        let snapshot = resolver.snapshotURL(modelID: row.modelID, revision: revision)
+        try FileManager.default.createDirectory(at: snapshot, withIntermediateDirectories: true)
+        try Data("weights".utf8).write(to: snapshot.appendingPathComponent("weights.bin"))
+        request.candidateCatalog.rows[modelKey]?.modelSHA256 = try ModelArtifactVerifier.canonicalArtifactHash(directory: snapshot)
+        request.benchmarks = [:]
+        let benchmarker = AutotuneRecommendationBenchmarker(
+            artifactResolver: resolver,
+            runnerFactory: { try CandidateProviderRunner(providerBinaryPath: "/bin/true") },
+            prober: RecordingStage1Prober(results: [
+                snapshot.path: .feasible(medianTPS: 42, p95TTFTMS: .infinity),
+            ]),
+            safetySampler: StaticProbeSafetySampler()
+        )
+
+        let outcomes = try await benchmarker.benchmarks(
+            request: request,
+            targetContext: 4_000,
+            gateTTFTMS: 3_000,
+            replicates: 1,
+            port: 18080
+        )
+
+        XCTAssertNil(outcomes.benchmarks[modelKey])
+        let diagnostic = try XCTUnwrap(outcomes.diagnostics[modelKey])
+        XCTAssertTrue(diagnostic.contains("invalid feasible TTFT infinityms"), diagnostic)
+    }
+
+    func testReceiptBoundBenchmarkFailsClosedOnInvalidFeasibleMeasurement() async throws {
+        let modelKey = "qwen3-coder-30b-a3b-instruct"
+        var request = try makeRequest(modelKey: modelKey)
+        request.hardware.memoryGB = 64
+        request.hardware.bandwidthTier = .a
+        let row = try XCTUnwrap(request.candidateCatalog.rows[modelKey])
+        let revision = try XCTUnwrap(row.modelRevision)
+        let hub = try tempDir()
+        let resolver = CachedModelArtifactResolver(hubRoot: hub)
+        let snapshot = resolver.snapshotURL(modelID: row.modelID, revision: revision)
+        try FileManager.default.createDirectory(at: snapshot, withIntermediateDirectories: true)
+        try Data("weights".utf8).write(to: snapshot.appendingPathComponent("weights.bin"))
+        let artifactSHA = try ModelArtifactVerifier.canonicalArtifactHash(directory: snapshot)
+        request.candidateCatalog.rows[modelKey]?.modelSHA256 = artifactSHA
+        request.benchmarks = [:]
+        let prefetched = PrefetchedModelArtifact(
+            modelKey: modelKey,
+            modelID: row.modelID,
+            modelRevision: revision,
+            candidateRowIdentity: try XCTUnwrap(request.candidateCatalog.rowIdentity(for: modelKey)),
+            path: snapshot.path,
+            sha256: artifactSHA
+        )
+        let benchmarker = AutotuneRecommendationBenchmarker(
+            artifactResolver: resolver,
+            runnerFactory: { try CandidateProviderRunner(providerBinaryPath: "/bin/true") },
+            prober: RecordingStage1Prober(results: [
+                snapshot.path: .feasible(medianTPS: .nan, p95TTFTMS: 900),
+            ]),
+            safetySampler: StaticProbeSafetySampler()
+        )
+
+        do {
+            _ = try await benchmarker.benchmarks(
+                request: request,
+                targetContext: 4_000,
+                gateTTFTMS: 3_000,
+                replicates: 1,
+                port: 18_080,
+                candidateModelIDs: [row.modelID],
+                prefetchedArtifacts: [modelKey: prefetched]
+            )
+            XCTFail("receipt-bound invalid feasible output must fail before state replacement")
+        } catch AutotuneRecommendError.candidateProbeFailed(let failedModelKey, let reason) {
+            XCTAssertEqual(failedModelKey, modelKey)
+            XCTAssertTrue(reason.contains("invalid feasible throughput nan"), reason)
+        }
+    }
+
     func testReceiptBoundBenchmarkFailsClosedWhenCandidateIsNotReady() async throws {
         let modelKey = "qwen3-coder-30b-a3b-instruct"
         var request = try makeRequest(modelKey: modelKey)

--- a/phase3-binary/Tests/macprovider-cliTests/ProviderConflictDetectorTests.swift
+++ b/phase3-binary/Tests/macprovider-cliTests/ProviderConflictDetectorTests.swift
@@ -159,6 +159,115 @@ final class ProviderDrainerTests: XCTestCase {
         XCTAssertEqual(calls[0].1, ["bootstrap", "gui/502", plistURL.path])
     }
 
+    func testLaunchdCrashRestoreGuardStartsOnlyForLaunchdManagedConflict() throws {
+        let plistURL = URL(fileURLWithPath: "/Users/provider/Library/LaunchAgents/live.streamvc.macprovider.plist")
+        var starts: [(String, String)] = []
+        var dismissCount = 0
+        let drainer = ProviderDrainer(
+            uid: 502,
+            plistURL: plistURL,
+            launchdRestoreGuardStarter: { domain, plistPath in
+                starts.append((domain, plistPath))
+                return ProviderLaunchdRestoreGuard {
+                    dismissCount += 1
+                }
+            }
+        )
+
+        let guardHandle = try XCTUnwrap(
+            try drainer.startLaunchdCrashRestoreGuard(for: .launchdManaged(pid: nil))
+        )
+        XCTAssertEqual(starts.count, 1)
+        XCTAssertEqual(starts[0].0, "gui/502")
+        XCTAssertEqual(starts[0].1, plistURL.path)
+
+        XCTAssertNil(try drainer.startLaunchdCrashRestoreGuard(for: .none))
+        XCTAssertNil(
+            try drainer.startLaunchdCrashRestoreGuard(
+                for: .foreground(pid: 515, argv: ["/usr/local/bin/macprovider-cli", "serve"])
+            )
+        )
+        XCTAssertEqual(starts.count, 1)
+
+        guardHandle.dismiss()
+        guardHandle.dismiss()
+        XCTAssertEqual(dismissCount, 1)
+    }
+
+    func testLaunchdRestoreGuardScriptBootstrapsOnceOnEOFWithoutDismissToken() throws {
+        let fixture = try makeLaunchdGuardFixture()
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/bin/sh")
+        process.arguments = [
+            "-c",
+            ProviderLaunchdRestoreGuard.restoreScript,
+            "macprovider-launchd-restore-guard-test",
+            fixture.launchctl.path,
+            "gui/502",
+            "/Users/provider/Library/LaunchAgents/live.streamvc.macprovider.plist",
+            ProviderLaunchdRestoreGuard.dismissToken,
+        ]
+        process.standardInput = Pipe().fileHandleForReading
+        process.standardOutput = Pipe()
+        process.standardError = Pipe()
+
+        try process.run()
+        process.waitUntilExit()
+
+        XCTAssertEqual(process.terminationStatus, 0)
+        let log = try String(contentsOf: fixture.log, encoding: .utf8)
+        XCTAssertEqual(
+            log,
+            "bootstrap gui/502 /Users/provider/Library/LaunchAgents/live.streamvc.macprovider.plist\n"
+        )
+    }
+
+    func testLaunchdRestoreGuardIgnoresHangupBeforeEOF() throws {
+        let fixture = try makeLaunchdGuardFixture()
+        let stdin = Pipe()
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/bin/sh")
+        process.arguments = [
+            "-c",
+            ProviderLaunchdRestoreGuard.restoreScript,
+            "macprovider-launchd-restore-guard-test",
+            fixture.launchctl.path,
+            "gui/502",
+            "/Users/provider/Library/LaunchAgents/live.streamvc.macprovider.plist",
+            ProviderLaunchdRestoreGuard.dismissToken,
+        ]
+        process.standardInput = stdin.fileHandleForReading
+        process.standardOutput = Pipe()
+        process.standardError = Pipe()
+
+        try process.run()
+        Thread.sleep(forTimeInterval: 0.05)
+        XCTAssertEqual(Darwin.kill(process.processIdentifier, SIGHUP), 0)
+        try stdin.fileHandleForWriting.close()
+        process.waitUntilExit()
+
+        XCTAssertEqual(process.terminationStatus, 0)
+        let log = try String(contentsOf: fixture.log, encoding: .utf8)
+        XCTAssertEqual(
+            log,
+            "bootstrap gui/502 /Users/provider/Library/LaunchAgents/live.streamvc.macprovider.plist\n"
+        )
+    }
+
+    func testLaunchdRestoreGuardDismissTokenExitsWithoutBootstrap() throws {
+        let fixture = try makeLaunchdGuardFixture()
+        let guardHandle = try ProviderLaunchdRestoreGuard.start(
+            launchdDomain: "gui/502",
+            plistPath: "/Users/provider/Library/LaunchAgents/live.streamvc.macprovider.plist",
+            launchctlPath: fixture.launchctl.path
+        )
+
+        guardHandle.dismiss()
+
+        let log = try String(contentsOf: fixture.log, encoding: .utf8)
+        XCTAssertEqual(log, "")
+    }
+
     // MARK: - Round-1 audit fix tests (drainer scope)
 
     /// Round-1 G.3 closure: the foreground drain MUST emit the SIGKILL-
@@ -208,5 +317,25 @@ final class ProviderDrainerTests: XCTestCase {
 
         XCTAssertEqual(try drainer.restore(conflict, restartForeground: true), .restored)
         XCTAssertEqual(restarts, [["/usr/local/bin/macprovider-cli", "serve", "--model", "X"]])
+    }
+
+    private func makeLaunchdGuardFixture() throws -> (launchctl: URL, log: URL) {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("launchd-restore-guard-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        addTeardownBlock {
+            try? FileManager.default.removeItem(at: directory)
+        }
+        let log = directory.appendingPathComponent("launchctl.log")
+        try Data().write(to: log)
+        let launchctl = directory.appendingPathComponent("launchctl")
+        let script = """
+        #!/bin/sh
+        printf "%s %s %s\\n" "$1" "$2" "$3" >> "\(log.path)"
+        exit 0
+        """
+        try script.write(to: launchctl, atomically: true, encoding: .utf8)
+        try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: launchctl.path)
+        return (launchctl, log)
     }
 }

--- a/phase3-binary/Tests/macprovider-cliTests/Stage1IteratorTests.swift
+++ b/phase3-binary/Tests/macprovider-cliTests/Stage1IteratorTests.swift
@@ -363,6 +363,29 @@ final class Stage1IteratorTests: XCTestCase {
         XCTAssertEqual(nErr, 1)
     }
 
+    func testStage1ProberInvalidTTFTWithPositiveGateReturnsInfeasibleWithoutTrapping() async throws {
+        let port = try unusedPort()
+        let runner = try CandidateProviderRunner(
+            providerBinaryPath: try emptyCompletionSSEScript().path,
+            logDirectory: try temporaryDirectory(name: "stage1-invalid-ttft-logs")
+        )
+
+        let result = try await Stage1Prober(readyTimeoutSec: 5, stopGraceSeconds: 1).probe(
+            model: "model-a",
+            port: port,
+            runner: runner,
+            targetContext: 64,
+            gateTTFTMS: 10,
+            replicates: 1
+        )
+
+        guard case .infeasible(let reason, let nErr) = result else {
+            return XCTFail("expected infeasible, got \(result)")
+        }
+        XCTAssertTrue(reason.contains("invalid throughput 0"), reason)
+        XCTAssertEqual(nErr, 1)
+    }
+
     // MARK: - Round-1 audit fix tests
 
     /// Round-1 D.1 closure: HTTP non-2xx responses MUST classify as
@@ -929,6 +952,66 @@ final class Stage1IteratorTests: XCTestCase {
                 time.sleep(delay)
                 chunk = json.dumps({"choices":[{"delta":{"content":response_text}}]})
                 client.sendall(f"data: {chunk}\\n\\n".encode())
+                client.sendall(b"data: [DONE]\\n\\n")
+                client.close()
+                continue
+            body = "not found"
+            client.sendall((
+                "HTTP/1.1 404 Not Found\\r\\n"
+                f"Content-Length: {len(body)}\\r\\n"
+                "Connection: close\\r\\n"
+                "\\r\\n"
+                f"{body}"
+            ).encode())
+            client.close()
+        """
+        try script.write(to: scriptURL, atomically: true, encoding: .utf8)
+        try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: scriptURL.path)
+        return scriptURL
+    }
+
+    private func emptyCompletionSSEScript() throws -> URL {
+        let directory = try temporaryDirectory(name: "stage1-empty-sse-provider")
+        let scriptURL = directory.appendingPathComponent("empty-sse-provider")
+        let script = """
+        #!/usr/bin/env python3
+        import socket, sys
+
+        args = sys.argv[1:]
+        if "serve" not in args or "--no-join" not in args:
+            sys.stderr.write("expected serve --no-join\\n")
+            sys.exit(2)
+        port = int(args[args.index("--port") + 1])
+
+        server = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        server.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        server.bind(("127.0.0.1", port))
+        server.listen(16)
+        print("stage1 empty sse provider ready", flush=True)
+
+        while True:
+            client, _ = server.accept()
+            request = client.recv(65536).decode("utf-8", "ignore")
+            if "GET /v1/models " in request:
+                body = '{"object":"list","data":[{"id":"stub","object":"model"}]}'
+                client.sendall((
+                    "HTTP/1.1 200 OK\\r\\n"
+                    "Content-Type: application/json\\r\\n"
+                    f"Content-Length: {len(body)}\\r\\n"
+                    "Connection: close\\r\\n"
+                    "\\r\\n"
+                    f"{body}"
+                ).encode())
+                client.close()
+                continue
+            if "POST /v1/chat/completions " in request:
+                client.sendall((
+                    "HTTP/1.1 200 OK\\r\\n"
+                    "Content-Type: text/event-stream\\r\\n"
+                    "Cache-Control: no-cache\\r\\n"
+                    "Connection: close\\r\\n"
+                    "\\r\\n"
+                ).encode())
                 client.sendall(b"data: [DONE]\\n\\n")
                 client.close()
                 continue


### PR DESCRIPTION
## Summary

Fixes #815: `macprovider-cli autotune --recommend` hard-crashed with
**SIGTRAP / EXC_BREAKPOINT** when benchmarking `gpt-oss-20b-MXFP4-Q8`,
and — because it died mid `--recover-hardware-admission` — left the
launchd-managed provider **drained and never restored** (fail-unsafe).

Two independent defects, both closed:

### 1. The trap (non-finite Stage-1 measurement → `Int(...)` precondition)

- `Stage1Iterator.swift`: validate median TPS and p95 TTFT are finite and
  in-range **before** the TTFT-gate formatting/conversion; an invalid
  measurement now returns `.infeasible` with a diagnostic instead of
  flowing into a trapping `Int(...)`.
- `AutotuneRecommend.swift`: reject invalid `.feasible` Stage-1 outputs
  **before** `CandidateBenchmark` construction. With prefetched artifacts
  the candidate fails explicitly (`candidateProbeFailed`); otherwise it is
  recorded in diagnostics and the run **continues to the next candidate**
  rather than trapping the whole process.

### 2. Fail-unsafe recovery (crash strands the provider drained)

- `AutotuneCommand.swift` + `ProviderConflictDetector.swift`: arm a
  **launchd restore guard** before `--recover-hardware-admission` drains a
  launchd provider; dismiss it only after a normal restore succeeds.
- The guard is a `/bin/sh` child that `trap ''`s HUP/INT/QUIT/TERM (so a
  parent crash or signal cannot take it down), reads stdin, and:
  - on the dismiss token → exits 0 without touching launchd (normal path);
  - on stdin **EOF** (parent died / was SIGKILLed → pipe closes) →
    `launchctl bootstrap` restores the provider.
  - launchd domain / plist path are passed as **separate argv** (`$1..$4`),
    never interpolated into the script — no shell-injection surface.

So any exit path — clean, exception, or crash — leaves the provider
loaded rather than stranded.

## Audit

3-lane codex audit (code / security / architect) on the full fix,
including a follow-up pass after the HUP-handling refinement:
**CRITICAL 0 / HIGH 0 / MEDIUM 0**.

## Test plan

- [x] Focused #815 regressions: 8 pass (invalid benchmark values, Stage-1
      invalid measurements, guard EOF-restore, dismiss-no-bootstrap,
      HUP-before-EOF)
- [x] Affected suites `AutotuneRecommendTests | ProviderConflictDetectorTests
      | ProviderDrainerTests | Stage1IteratorTests`: 177 pass, 0 fail
      (1 pre-existing launchctl integration skip)
- [x] `git diff --check origin/main`: clean
- [ ] Full `swift test`: one pre-existing failure outside this patch
      (`StageForwardParityTests`, MLX "Failed to load the default
      metallib" — environment, not code); CI runs it in a clean env

## Not in this PR

- Does **not** ship a CLI release. Reaching Provider #4 (on v1.8.66) needs
  a separate versioned CLI + Malibu release per
  `docs/runbooks/provider-cli-release-verification.md`.
- Does **not** change the gpt-oss-20b demand `recommendable` flag — that is
  the separately-tracked #743 / PR #749 harmony hold.

SPEC-GOVERNANCE-DECLARATION-BEGIN
{
  "schema_version": "spec-pr-governance-v1",
  "behavior_change": "yes",
  "contract_change": "none",
  "specs": ["SPEC-023"],
  "requirements": ["SPEC-023-R001"],
  "authority_domains": ["installer-autotune-policy"],
  "arbitration": ["CODE_BUG"],
  "tests": ["phase3-binary/Tests/macprovider-cliTests/AutotuneRecommendTests.swift", "phase3-binary/Tests/macprovider-cliTests/Stage1IteratorTests.swift", "phase3-binary/Tests/macprovider-cliTests/ProviderConflictDetectorTests.swift"],
  "journeys": ["not-required"],
  "issue": "https://github.com/Augustas11/macprovider/issues/815"
}
SPEC-GOVERNANCE-DECLARATION-END

🤖 Generated with [Claude Code](https://claude.com/claude-code)
