### PR TITLE
Enable Codex-compatible stateless Responses facade

### DIFF
--- a/phase5-gateway/README.md
+++ b/phase5-gateway/README.md
@@ -12,8 +12,8 @@ Phase 5 gateway implementation for SPEC-006 v0.8.3. The gateway is intentionally
 - Minimal `/account` handoff page that displays a newly issued key once and clears the handoff cookie.
 - HMAC/SHA API key generation, hash-only storage, validation, rotation, revocation, and account-history preservation.
 - HMAC demo-session token issuance/validation with per-IP issuance limits and demo-only kill switch.
-- `/v1/models`, `/v1/usage`, `/v1/chat/completions`, `/v1/status`, `/v1/feedback`, `/healthz`.
-- OpenAI-shaped chat forwarding to `coordinator.buyer_url`, including SSE pass-through and buyer disconnect cancellation.
+- `/v1/models`, `/v1/usage`, `/v1/chat/completions`, optional stateless `/v1/responses`, `/v1/status`, `/v1/feedback`, `/healthz`.
+- OpenAI-shaped chat forwarding to `coordinator.buyer_url`, including SSE pass-through and buyer disconnect cancellation; the optional Responses facade translates into the same billed path.
 - Quota reservation/settlement for success, 503 refund, 502/504 prompt-only or partial usage, demo chat usage, provider-reported streaming actuals, and byte-estimation fallback.
 - Storage-backed per-account concurrency caps.
 - Inbound and outbound `X-MacProvider-*` stripping plus UUID-v4 `X-Request-ID` generation/forwarding.

--- a/phase5-gateway/gateway.yaml.example
+++ b/phase5-gateway/gateway.yaml.example
@@ -166,6 +166,13 @@ routing:
   sticky_enabled: false
   sticky_ttl_s: 1800
 
+features:
+  # Stateless OpenAI Responses API compatibility facade. When enabled,
+  # POST /v1/responses translates full-context Responses requests into the
+  # existing billed chat-completions pipeline. Server-side response state,
+  # hosted tools, and multimodal input remain unsupported.
+  responses_api_enabled: false
+
 cors:
   allowed_origins:
     - https://console.streamvc.live

--- a/phase5-gateway/internal/config/config.go
+++ b/phase5-gateway/internal/config/config.go
@@ -29,6 +29,7 @@ type Config struct {
 	Routing     RoutingConfig     `yaml:"routing"`
 	Retry503    Retry503Config    `yaml:"retry_503"`
 	Explorer    ExplorerConfig    `yaml:"explorer"`
+	Features    FeaturesConfig    `yaml:"features"`
 }
 
 type ListenConfig struct {
@@ -238,6 +239,10 @@ type ExplorerConfig struct {
 	Enabled bool `yaml:"enabled"`
 }
 
+type FeaturesConfig struct {
+	ResponsesAPIEnabled bool `yaml:"responses_api_enabled"`
+}
+
 func Default() Config {
 	return Config{
 		Listen: ListenConfig{BindAddress: "127.0.0.1", Port: 9443},
@@ -343,6 +348,7 @@ func Default() Config {
 		Routing:  RoutingConfig{StickyEnabled: false, StickyTTLS: 1800},
 		Retry503: Retry503Config{Enabled: true, MaxAttempts: 3, BackoffBaseMs: 100, BackoffMaxMs: 500},
 		Explorer: ExplorerConfig{Enabled: false},
+		Features: FeaturesConfig{ResponsesAPIEnabled: false},
 	}
 }
 

--- a/phase5-gateway/internal/router/chat_proxy.go
+++ b/phase5-gateway/internal/router/chat_proxy.go
@@ -221,6 +221,14 @@ func (s *Server) handleChatCompletions(w http.ResponseWriter, r *http.Request) {
 		)
 		return
 	}
+	if adapter := responsesAdapterFromContext(r.Context()); adapter != nil {
+		translatedBody, translateErr := adapter.translateRequest(body)
+		if translateErr != nil {
+			writeResponsesTranslationError(w, http.StatusBadRequest, translateErr)
+			return
+		}
+		body = translatedBody
+	}
 	chat, err := parseChatRequest(body)
 	if err != nil {
 		writeError(w, http.StatusBadRequest, "invalid_request_error", "invalid_request", err.Error())
@@ -830,10 +838,19 @@ func (s *Server) forwardNonStreamingChat(w http.ResponseWriter, r *http.Request,
 	} else {
 		tokenSource = "provider_reported"
 	}
+	body = usageBodyWithTokenUsage(body, usage)
+	if adapter := responsesAdapterFromContext(r.Context()); adapter != nil && !adapter.stream {
+		if err := adapter.prepareNonStreamingResponse(body); err != nil {
+			if !s.settleBeforeResponseWithCoordinatorFinality(w, r, subject, promptEstimate, 0, maxUsageTokens, "gateway_estimated", "invalid_provider_response", resp.Header) {
+				return
+			}
+			writeError(w, http.StatusBadGateway, "api_error", "invalid_provider_response", "Upstream provider returned invalid response")
+			return
+		}
+	}
 	if !s.settleBeforeResponseWithCoordinatorFinality(w, r, subject, usage.PromptTokens, usage.CompletionTokens, maxUsageTokens, tokenSource, "ok", resp.Header) {
 		return
 	}
-	body = usageBodyWithTokenUsage(body, usage)
 	emitProviderAttribution(w.Header(), resp.Header)
 	copyReceiptEligibleHeaders(w.Header(), resp.Header)
 	w.Header().Set("Content-Type", contentTypeOrJSON(resp.Header))

--- a/phase5-gateway/internal/router/chat_proxy.go
+++ b/phase5-gateway/internal/router/chat_proxy.go
@@ -221,12 +221,15 @@ func (s *Server) handleChatCompletions(w http.ResponseWriter, r *http.Request) {
 		)
 		return
 	}
+	dedupeEntrypoint := idlessDedupeEntrypointChat
+	dedupeBody := body
 	if adapter := responsesAdapterFromContext(r.Context()); adapter != nil {
 		translatedBody, translateErr := adapter.translateRequest(body)
 		if translateErr != nil {
 			writeResponsesTranslationError(w, http.StatusBadRequest, translateErr)
 			return
 		}
+		dedupeEntrypoint = idlessDedupeEntrypointResponses
 		body = translatedBody
 	}
 	chat, err := parseChatRequest(body)
@@ -283,11 +286,12 @@ func (s *Server) handleChatCompletions(w http.ResponseWriter, r *http.Request) {
 		requestIDClass(r) == retry503RequestIDClassGatewayGenerated &&
 		strings.TrimSpace(r.Header.Get("Idempotency-Key")) == "" {
 		dedupeFingerprint = idlessRequestFingerprint(
+			dedupeEntrypoint,
 			subject.AccountID,
 			subject.DemoTokenHash,
 			strings.TrimSpace(r.Header.Get("X-MacProvider-Conversation")),
 			strings.TrimSpace(r.Header.Get("X-MacProvider-Retry")),
-			body,
+			dedupeBody,
 		)
 		entry, adopted := s.idlessDedupe.claim(dedupeFingerprint, requestID(r), s.now(), dedupeWindow)
 		switch {
@@ -307,11 +311,22 @@ func (s *Server) handleChatCompletions(w http.ResponseWriter, r *http.Request) {
 			// fall-through 409 would name an id the buyer cannot correlate.
 			r = r.WithContext(context.WithValue(r.Context(), requestIDKey{}, entry.requestID))
 			w.Header().Set("X-Request-ID", entry.requestID)
+			var replayAdapter *responsesAdapter
+			if adapter := responsesAdapterFromContext(r.Context()); adapter != nil {
+				replayAdapter = adapter
+				replayAdapter.beginReplayPassthrough()
+			}
 			if s.replayIdlessDuplicate(w, r, subject, dailyQuota, entry, dedupeWindow, deadlines) {
 				return
 			}
+			if replayAdapter != nil {
+				replayAdapter.endReplayPassthrough()
+			}
 		default:
 			sw.armDedupeCapture(idlessDedupeMaxEntryBytes)
+			if adapter := responsesAdapterFromContext(r.Context()); adapter != nil {
+				adapter.armDedupeCapture(idlessDedupeMaxEntryBytes)
+			}
 			defer func() {
 				if dedupeFingerprint == "" {
 					return
@@ -326,12 +341,33 @@ func (s *Server) handleChatCompletions(w http.ResponseWriter, r *http.Request) {
 					s.idlessDedupe.drop(dedupeFingerprint, requestID(r))
 					panic(recovered)
 				}
+				adapter := responsesAdapterFromContext(r.Context())
+				if adapter != nil {
+					adapter.finish()
+				}
 				// Publish is gated on a buyer-visible 2xx, not on settlement
 				// finality: a SPEC-022 hold is still a delivered answer, and
 				// a retry of it must not re-run inference. A buyer who
 				// disconnected never saw the whole response, so nothing is
 				// cached for them (their partial is settled as usual).
-				if sw.dedupePublishable() && r.Context().Err() == nil {
+				if adapter != nil && sw.dedupeDelivered2xx() && r.Context().Err() == nil {
+					capture := adapter.dedupeCapture()
+					if capture != nil {
+						s.idlessDedupe.publish(dedupeFingerprint, requestID(r), sw.statusCode,
+							w.Header().Get("Content-Type"), w.Header().Get("X-Provider-Id"),
+							capture, s.now())
+						return
+					}
+					if adapter.dedupeDeliveredButUncacheable() {
+						s.idlessDedupe.publish(dedupeFingerprint, requestID(r), sw.statusCode,
+							w.Header().Get("Content-Type"), w.Header().Get("X-Provider-Id"),
+							nil, s.now())
+						return
+					}
+					s.idlessDedupe.drop(dedupeFingerprint, requestID(r))
+					return
+				}
+				if adapter == nil && sw.dedupePublishable() && r.Context().Err() == nil {
 					s.idlessDedupe.publish(dedupeFingerprint, requestID(r), sw.statusCode,
 						w.Header().Get("Content-Type"), w.Header().Get("X-Provider-Id"),
 						sw.dedupeCapture(), s.now())
@@ -841,7 +877,11 @@ func (s *Server) forwardNonStreamingChat(w http.ResponseWriter, r *http.Request,
 	body = usageBodyWithTokenUsage(body, usage)
 	if adapter := responsesAdapterFromContext(r.Context()); adapter != nil && !adapter.stream {
 		if err := adapter.prepareNonStreamingResponse(body); err != nil {
-			if !s.settleBeforeResponseWithCoordinatorFinality(w, r, subject, promptEstimate, 0, maxUsageTokens, "gateway_estimated", "invalid_provider_response", resp.Header) {
+			settlePrompt, settleCompletion, settleSource := promptEstimate, int64(0), "gateway_estimated"
+			if ok {
+				settlePrompt, settleCompletion, settleSource = usage.PromptTokens, usage.CompletionTokens, tokenSource
+			}
+			if !s.settleBeforeResponseWithCoordinatorFinality(w, r, subject, settlePrompt, settleCompletion, maxUsageTokens, settleSource, "invalid_provider_response", resp.Header) {
 				return
 			}
 			writeError(w, http.StatusBadGateway, "api_error", "invalid_provider_response", "Upstream provider returned invalid response")
@@ -2798,7 +2838,11 @@ func (sw *statusWriter) armDedupeCapture(limit int) {
 // dedupePublishable reports whether the captured response may be replayed to
 // an identical id-less retry: a complete, buyer-visible 2xx that fit the cap.
 func (sw *statusWriter) dedupePublishable() bool {
-	return sw.captureArmed && !sw.poisoned && !sw.overflowed &&
+	return sw.dedupeDelivered2xx() && !sw.overflowed
+}
+
+func (sw *statusWriter) dedupeDelivered2xx() bool {
+	return sw.captureArmed && !sw.poisoned &&
 		sw.statusCode >= 200 && sw.statusCode < 300
 }
 

--- a/phase5-gateway/internal/router/disclosure.go
+++ b/phase5-gateway/internal/router/disclosure.go
@@ -228,8 +228,10 @@ const settlementBuyerReceiptStatusDisclosure = "Buyer receipt and status surface
 
 func makeVerifiedModelSettlementDisclosure(includeResponses ...bool) verifiedModelSettlementDisclosure {
 	included := []string{"POST /v1/chat/completions"}
+	enforceMode := settlementEnforceModeDisclosure
 	if len(includeResponses) > 0 && includeResponses[0] {
 		included = append(included, "POST /v1/responses")
+		enforceMode = "Enforce mode may settle only covered paid POST /v1/chat/completions and POST /v1/responses attempts whose settlement-capable receipt reaches verified finality; mixed pools are not described as fully verified."
 	}
 	return verifiedModelSettlementDisclosure{
 		IncludedPaidEntrypoints: included,
@@ -239,7 +241,7 @@ func makeVerifiedModelSettlementDisclosure(includeResponses ...bool) verifiedMod
 		ModelIdentity:       settlementModelIdentityDisclosure,
 		ModelIdentityCaveat: settlementModelIdentityCaveatDisclosure,
 		ObserveMode:         settlementObserveModeDisclosure,
-		EnforceMode:         settlementEnforceModeDisclosure,
+		EnforceMode:         enforceMode,
 		PendingReservation:  settlementPendingReservationDisclosure,
 		Outcomes: settlementOutcomeDisclosure{
 			Pending:     settlementPendingOutcomeDisclosure,

--- a/phase5-gateway/internal/router/disclosure.go
+++ b/phase5-gateway/internal/router/disclosure.go
@@ -226,9 +226,13 @@ const settlementPartialChargeDisclosure = "Buyer cancel, gateway timeout, provid
 const settlementStreamingFailoverDisclosure = "Transparent streaming failover bills only delivered, verified output across attempts and does not double-charge overlapping output; verified here means receipt-bound under the provider-reported-hash caveat above."
 const settlementBuyerReceiptStatusDisclosure = "Buyer receipt and status surfaces expose pending, verified, quarantined, and zero_settled labels without raw prompts or raw outputs."
 
-func makeVerifiedModelSettlementDisclosure() verifiedModelSettlementDisclosure {
+func makeVerifiedModelSettlementDisclosure(includeResponses ...bool) verifiedModelSettlementDisclosure {
+	included := []string{"POST /v1/chat/completions"}
+	if len(includeResponses) > 0 && includeResponses[0] {
+		included = append(included, "POST /v1/responses")
+	}
 	return verifiedModelSettlementDisclosure{
-		IncludedPaidEntrypoints: []string{"POST /v1/chat/completions"},
+		IncludedPaidEntrypoints: included,
 		ExcludedPaidEntrypoints: []string{
 			"legacy direct-tunnel buyer paths at coordinator.streamvc.live, m4.streamvc.live, and m1.streamvc.live unless separately disabled or migrated behind the gateway paid ledger",
 		},
@@ -305,7 +309,7 @@ func (s *Server) makeTier1Disclosure(ctxs ...context.Context) tier1Disclosure {
 		HardwareAttestation:     "none",
 		Tier2Milestone:          "future",
 		ModelVerificationLimit:  modelVerificationLimitDisclosure,
-		VerifiedModelSettlement: makeVerifiedModelSettlementDisclosure(),
+		VerifiedModelSettlement: makeVerifiedModelSettlementDisclosure(s.cfg.Features.ResponsesAPIEnabled),
 		StickyAffinity: &stickyAffinityDisclosure{
 			Enabled: false, TTLSeconds: 0,
 			Description: "Sticky affinity is disabled; related requests are not preferentially routed to the same provider.",

--- a/phase5-gateway/internal/router/idless_dedupe.go
+++ b/phase5-gateway/internal/router/idless_dedupe.go
@@ -37,7 +37,10 @@ const (
 	// idlessDedupeFingerprintVersion is mixed into every fingerprint so a
 	// future change to the keying inputs can never collide with entries
 	// computed by an older build.
-	idlessDedupeFingerprintVersion = "mpg-idless-v1"
+	idlessDedupeFingerprintVersion = "mpg-idless-v2"
+
+	idlessDedupeEntrypointChat      = "chat"
+	idlessDedupeEntrypointResponses = "responses"
 
 	// Two separate caps, because the two things an entry holds cost wildly
 	// different amounts of memory and wildly different amounts of money when
@@ -49,10 +52,10 @@ const (
 	// INSIDE the window costs money: the retry mints a fresh id, reserves
 	// independently, and bills twice. So memory pressure spends bodies first
 	// and keeps bare mapping stubs until the window expires.
-	idlessDedupeMaxBodies     = 4096      // entries still holding a response
-	idlessDedupeMaxMappings   = 65536     // fp→requestID stubs, body or not
-	idlessDedupeMaxEntryBytes = 1 << 20   // 1 MiB per cached response body
-	idlessDedupeMaxTotalBytes = 32 << 20  // 32 MiB of cached bodies overall
+	idlessDedupeMaxBodies     = 4096     // entries still holding a response
+	idlessDedupeMaxMappings   = 65536    // fp→requestID stubs, body or not
+	idlessDedupeMaxEntryBytes = 1 << 20  // 1 MiB per cached response body
+	idlessDedupeMaxTotalBytes = 32 << 20 // 32 MiB of cached bodies overall
 	idlessDedupePruneInterval = time.Minute
 	// idlessDedupeMaxWaiters bounds how many concurrent identical attempts
 	// may park on one in-flight request. Waiters hold no quota reservation
@@ -84,14 +87,15 @@ const (
 // its neighbour:
 //
 //  1. idlessDedupeFingerprintVersion — the keying-scheme tag.
-//  2. accountID — the billed tenant.
-//  3. demoTokenHash — distinguishes two demo sessions behind one IP.
-//  4. conversationTag — X-MacProvider-Conversation, which selects sticky
+//  2. entrypoint — the public API facade whose wire contract is being served.
+//  3. accountID — the billed tenant.
+//  4. demoTokenHash — distinguishes two demo sessions behind one IP.
+//  5. conversationTag — X-MacProvider-Conversation, which selects sticky
 //     routing and therefore which provider answers.
-//  5. retryHint — X-MacProvider-Retry, which copyForwardHeaders forwards to
+//  6. retryHint — X-MacProvider-Retry, which copyForwardHeaders forwards to
 //     the coordinator where it changes retry/failover behaviour. Two requests
 //     that differ only in this header are NOT the same dispatch.
-//  6. SHA-256 of the raw body bytes.
+//  7. SHA-256 of the raw body bytes.
 //
 // Everything else that changes the generated answer is inside those bytes
 // (model, messages, stream, max_tokens, response_format). Transport-level
@@ -101,10 +105,10 @@ const (
 // Adding a component is a keying change: bump idlessDedupeFingerprintVersion
 // when one is added to a build that is already deployed, so old and new
 // fingerprints cannot collide.
-func idlessRequestFingerprint(accountID, demoTokenHash, conversationTag, retryHint string, body []byte) string {
+func idlessRequestFingerprint(entrypoint, accountID, demoTokenHash, conversationTag, retryHint string, body []byte) string {
 	bodyDigest := sha256.Sum256(body)
 	h := sha256.New()
-	for _, part := range []string{idlessDedupeFingerprintVersion, accountID, demoTokenHash, conversationTag, retryHint} {
+	for _, part := range []string{idlessDedupeFingerprintVersion, entrypoint, accountID, demoTokenHash, conversationTag, retryHint} {
 		h.Write([]byte(part))
 		h.Write([]byte{0})
 	}

--- a/phase5-gateway/internal/router/idless_dedupe_test.go
+++ b/phase5-gateway/internal/router/idless_dedupe_test.go
@@ -2,6 +2,7 @@ package router
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"io"
 	"net/http"
@@ -138,6 +139,16 @@ func assertNoDedupeReplay(t *testing.T, resp *httptest.ResponseRecorder, what st
 	if got := resp.Header().Get(idlessDedupeHeader); got != "" {
 		t.Fatalf("%s: unexpected %s=%q (this attempt must not be a replay)", what, idlessDedupeHeader, got)
 	}
+}
+
+func translatedResponsesChatBodyForDedupeTest(t *testing.T, responsesBody string) string {
+	t.Helper()
+	adapter := newResponsesAdapter(httptest.NewRecorder(), newUUID(), nil)
+	translated, err := adapter.translateRequest([]byte(responsesBody))
+	if err != nil {
+		t.Fatalf("translate Responses request for collision fixture: %v", err)
+	}
+	return string(translated)
 }
 
 // ---- replay + coalesce (the fix) -------------------------------------------
@@ -602,6 +613,100 @@ func TestIdlessDedupe_DifferentBodyNotDeduped(t *testing.T) {
 	}
 }
 
+func TestIdlessDedupe_ResponsesThenChatDoNotShareFingerprint(t *testing.T) {
+	var hits atomic.Int32
+	var firstUpstreamBody string
+	client := &http.Client{Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+		if r.URL.Path != "/v1/chat/completions" {
+			return responseWithBody(http.StatusNotFound, nil, `{}`), nil
+		}
+		raw, _ := io.ReadAll(r.Body)
+		if hits.Load() == 0 {
+			firstUpstreamBody = string(raw)
+		}
+		hits.Add(1)
+		return responseWithBody(http.StatusOK, http.Header{"Content-Type": []string{"application/json"}}, `{
+			"id":"chatcmpl_cross_endpoint",
+			"object":"chat.completion",
+			"created":1782864000,
+			"model":"llama",
+			"usage":{"prompt_tokens":5,"completion_tokens":3,"total_tokens":8},
+			"choices":[{"index":0,"message":{"role":"assistant","content":"cross endpoint answer"},"finish_reason":"stop"}]
+		}`), nil
+	})}
+	h, store, _, cfg := newTestHarnessConfig(t, fakeOAuth{}, enableResponsesWithCoordinator, WithHTTPClient(client))
+	key := createAccountAndKey(t, store, cfg, "acct_idless_responses_then_chat")
+	responsesBody := `{"model":"llama","input":"hi","max_output_tokens":20,"store":false}`
+
+	first := postResponses(t, h, key, responsesBody, nil)
+	if first.Code != http.StatusOK {
+		t.Fatalf("Responses attempt status=%d body=%s", first.Code, first.Body.String())
+	}
+	if firstUpstreamBody == "" {
+		t.Fatal("Responses attempt did not reach upstream")
+	}
+	second := postChat(t, h, key, firstUpstreamBody, nil)
+	if second.Code != http.StatusOK {
+		t.Fatalf("chat attempt status=%d body=%s", second.Code, second.Body.String())
+	}
+	assertNoDedupeReplay(t, second, "chat after Responses")
+	if got := hits.Load(); got != 2 {
+		t.Fatalf("upstream dispatches=%d want 2", got)
+	}
+	var payload map[string]any
+	if err := json.Unmarshal(second.Body.Bytes(), &payload); err != nil {
+		t.Fatalf("decode chat response: %v body=%s", err, second.Body.String())
+	}
+	if payload["object"] != "chat.completion" {
+		t.Fatalf("chat response object=%v want chat.completion body=%s", payload["object"], second.Body.String())
+	}
+}
+
+func TestIdlessDedupe_ChatThenResponsesDoNotShareFingerprint(t *testing.T) {
+	var hits atomic.Int32
+	client := &http.Client{Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+		if r.URL.Path != "/v1/chat/completions" {
+			return responseWithBody(http.StatusNotFound, nil, `{}`), nil
+		}
+		hits.Add(1)
+		return responseWithBody(http.StatusOK, http.Header{"Content-Type": []string{"application/json"}}, `{
+			"id":"chatcmpl_cross_endpoint",
+			"object":"chat.completion",
+			"created":1782864000,
+			"model":"llama",
+			"usage":{"prompt_tokens":5,"completion_tokens":3,"total_tokens":8},
+			"choices":[{"index":0,"message":{"role":"assistant","content":"cross endpoint answer"},"finish_reason":"stop"}]
+		}`), nil
+	})}
+	h, store, _, cfg := newTestHarnessConfig(t, fakeOAuth{}, enableResponsesWithCoordinator, WithHTTPClient(client))
+	key := createAccountAndKey(t, store, cfg, "acct_idless_chat_then_responses")
+	responsesBody := `{"model":"llama","input":"hi","max_output_tokens":20,"store":false}`
+	chatBody := translatedResponsesChatBodyForDedupeTest(t, responsesBody)
+
+	first := postChat(t, h, key, chatBody, nil)
+	if first.Code != http.StatusOK {
+		t.Fatalf("chat attempt status=%d body=%s", first.Code, first.Body.String())
+	}
+	second := postResponses(t, h, key, responsesBody, nil)
+	if second.Code != http.StatusOK {
+		t.Fatalf("Responses attempt status=%d body=%s", second.Code, second.Body.String())
+	}
+	assertNoDedupeReplay(t, second, "Responses after chat")
+	if got := hits.Load(); got != 2 {
+		t.Fatalf("upstream dispatches=%d want 2", got)
+	}
+	var payload map[string]any
+	if err := json.Unmarshal(second.Body.Bytes(), &payload); err != nil {
+		t.Fatalf("decode Responses response: %v body=%s", err, second.Body.String())
+	}
+	if payload["object"] != "response" {
+		t.Fatalf("Responses object=%v want response body=%s", payload["object"], second.Body.String())
+	}
+	if strings.Contains(second.Body.String(), `"choices"`) {
+		t.Fatalf("Responses endpoint returned chat wire format: %s", second.Body.String())
+	}
+}
+
 // ---- opt-outs: higher-precedence dedupe owns the request -------------------
 
 // A client-supplied UUID X-Request-ID already deduped durably (harness H5b).
@@ -978,17 +1083,18 @@ func TestIdlessDedupeIndex_WaiterCapAndContextExpiry(t *testing.T) {
 }
 
 func TestIdlessRequestFingerprintIsKeyedOnEveryPart(t *testing.T) {
-	base := idlessRequestFingerprint("acct", "demo-hash", "thread-1", "", []byte(`{"a":1}`))
+	base := idlessRequestFingerprint(idlessDedupeEntrypointChat, "acct", "demo-hash", "thread-1", "", []byte(`{"a":1}`))
 	cases := map[string]string{
-		"same inputs":         idlessRequestFingerprint("acct", "demo-hash", "thread-1", "", []byte(`{"a":1}`)),
-		"other account":       idlessRequestFingerprint("acct2", "demo-hash", "thread-1", "", []byte(`{"a":1}`)),
-		"other demo token":    idlessRequestFingerprint("acct", "demo-hash-2", "thread-1", "", []byte(`{"a":1}`)),
-		"other conversation":  idlessRequestFingerprint("acct", "demo-hash", "thread-2", "", []byte(`{"a":1}`)),
-		"retry hint present":  idlessRequestFingerprint("acct", "demo-hash", "thread-1", "1", []byte(`{"a":1}`)),
-		"other retry hint":    idlessRequestFingerprint("acct", "demo-hash", "thread-1", "2", []byte(`{"a":1}`)),
-		"other body":          idlessRequestFingerprint("acct", "demo-hash", "thread-1", "", []byte(`{"a":2}`)),
-		"whitespace in body":  idlessRequestFingerprint("acct", "demo-hash", "thread-1", "", []byte(`{"a": 1}`)),
-		"field-shifted parts": idlessRequestFingerprint("acc", "tdemo-hash", "thread-1", "", []byte(`{"a":1}`)),
+		"same inputs":         idlessRequestFingerprint(idlessDedupeEntrypointChat, "acct", "demo-hash", "thread-1", "", []byte(`{"a":1}`)),
+		"other entrypoint":    idlessRequestFingerprint(idlessDedupeEntrypointResponses, "acct", "demo-hash", "thread-1", "", []byte(`{"a":1}`)),
+		"other account":       idlessRequestFingerprint(idlessDedupeEntrypointChat, "acct2", "demo-hash", "thread-1", "", []byte(`{"a":1}`)),
+		"other demo token":    idlessRequestFingerprint(idlessDedupeEntrypointChat, "acct", "demo-hash-2", "thread-1", "", []byte(`{"a":1}`)),
+		"other conversation":  idlessRequestFingerprint(idlessDedupeEntrypointChat, "acct", "demo-hash", "thread-2", "", []byte(`{"a":1}`)),
+		"retry hint present":  idlessRequestFingerprint(idlessDedupeEntrypointChat, "acct", "demo-hash", "thread-1", "1", []byte(`{"a":1}`)),
+		"other retry hint":    idlessRequestFingerprint(idlessDedupeEntrypointChat, "acct", "demo-hash", "thread-1", "2", []byte(`{"a":1}`)),
+		"other body":          idlessRequestFingerprint(idlessDedupeEntrypointChat, "acct", "demo-hash", "thread-1", "", []byte(`{"a":2}`)),
+		"whitespace in body":  idlessRequestFingerprint(idlessDedupeEntrypointChat, "acct", "demo-hash", "thread-1", "", []byte(`{"a": 1}`)),
+		"field-shifted parts": idlessRequestFingerprint(idlessDedupeEntrypointChat, "acc", "tdemo-hash", "thread-1", "", []byte(`{"a":1}`)),
 	}
 	for name, got := range cases {
 		if name == "same inputs" {

--- a/phase5-gateway/internal/router/responses.go
+++ b/phase5-gateway/internal/router/responses.go
@@ -250,7 +250,7 @@ func (a *responsesAdapter) translateRequest(body []byte) ([]byte, *responsesTran
 	if err := validateResponsesTools(req.Tools); err != nil {
 		return nil, err
 	}
-	if err := validateResponsesControls(req.Conversation, req.Include, req.Truncation, req.Background, req.Reasoning, req.ParallelToolCalls, req.ResponseFormat); err != nil {
+	if err := validateResponsesControls(req.Conversation, req.Truncation, req.Background, req.ResponseFormat); err != nil {
 		return nil, err
 	}
 	textFormat, chatResponseFormat, textErr := responsesTextConfigToChatResponseFormat(req.Text)
@@ -269,14 +269,20 @@ func (a *responsesAdapter) translateRequest(body []byte) ([]byte, *responsesTran
 	if req.MaxOutputTokens != nil {
 		chat["max_tokens"] = *req.MaxOutputTokens
 	}
-	if len(req.Tools) > 0 {
-		chat["tools"] = responsesToolsToChatTools(req.Tools)
+	chatTools := responsesToolsToChatTools(req.Tools)
+	if len(chatTools) > 0 {
+		chat["tools"] = chatTools
 	}
 	if req.ToolChoice != nil {
-		chat["tool_choice"] = responsesToolChoiceToChatToolChoice(req.ToolChoice)
+		if toolChoice, ok := responsesToolChoiceToChatToolChoice(req.ToolChoice, chatTools); ok {
+			chat["tool_choice"] = toolChoice
+		}
 	}
 	if len(chatResponseFormat) > 0 {
 		chat["response_format"] = json.RawMessage(chatResponseFormat)
+	}
+	if parallelToolCalls, ok := req.ParallelToolCalls.(bool); ok {
+		chat["parallel_tool_calls"] = parallelToolCalls
 	}
 	if req.Temperature != nil {
 		chat["temperature"] = req.Temperature
@@ -436,47 +442,24 @@ func responsesContentToText(v any) string {
 }
 
 func validateResponsesTools(tools []map[string]any) *responsesTranslationError {
-	for i, tool := range tools {
-		typ, _ := tool["type"].(string)
-		if typ == "function" {
-			continue
-		}
-		if typ == "" {
-			typ = "unknown"
-		}
-		return &responsesTranslationError{
-			code:    "unsupported_parameter",
-			param:   fmt.Sprintf("tools[%d].type", i),
-			message: fmt.Sprintf("Responses tool type %q is not supported", typ),
-		}
-	}
+	// Responses clients may send hosted or namespace tool declarations that this
+	// local Chat Completions provider cannot execute. Translation flattens usable
+	// function tools and drops the rest instead of rejecting the whole turn.
 	return nil
 }
 
-func validateResponsesControls(conversation, include json.RawMessage, truncation *string, background *bool, reasoning, parallelToolCalls any, responseFormat json.RawMessage) *responsesTranslationError {
+func validateResponsesControls(conversation json.RawMessage, truncation *string, background *bool, responseFormat json.RawMessage) *responsesTranslationError {
 	if len(bytes.TrimSpace(responseFormat)) > 0 && !jsonRawIsNull(responseFormat) {
 		return &responsesTranslationError{code: "unsupported_parameter", param: "response_format", message: "response_format is not supported on /v1/responses; use text.format"}
 	}
 	if len(bytes.TrimSpace(conversation)) > 0 && !jsonRawIsEmptyValue(conversation) {
 		return &responsesTranslationError{code: "unsupported_parameter", param: "conversation", message: "conversation is not supported; send the full input with store:false"}
 	}
-	if len(bytes.TrimSpace(include)) > 0 && !jsonRawIsEmptyValue(include) {
-		return &responsesTranslationError{code: "unsupported_parameter", param: "include", message: "include is not supported"}
-	}
 	if background != nil && *background {
 		return &responsesTranslationError{code: "unsupported_parameter", param: "background", message: "background:true is not supported"}
 	}
 	if truncation != nil && *truncation != "" && *truncation != "disabled" {
 		return &responsesTranslationError{code: "unsupported_parameter", param: "truncation", message: "Only truncation:\"disabled\" is supported"}
-	}
-	if !jsonLikeEmpty(reasoning) {
-		return &responsesTranslationError{code: "unsupported_parameter", param: "reasoning", message: "reasoning controls are not supported"}
-	}
-	if !jsonLikeEmpty(parallelToolCalls) {
-		if enabled, ok := parallelToolCalls.(bool); ok && enabled {
-			return nil
-		}
-		return &responsesTranslationError{code: "unsupported_parameter", param: "parallel_tool_calls", message: "Only default parallel_tool_calls behavior is supported"}
 	}
 	return nil
 }
@@ -568,32 +551,104 @@ func cloneMap(in map[string]any) map[string]any {
 
 func responsesToolsToChatTools(tools []map[string]any) []map[string]any {
 	out := make([]map[string]any, 0, len(tools))
-	for _, tool := range tools {
-		if typ, _ := tool["type"].(string); typ != "function" {
-			continue
-		}
+	usedNames := make(map[string]struct{}, len(tools))
+	var addFunction func(tool map[string]any, namespace string)
+	addFunction = func(tool map[string]any, namespace string) {
 		fn := map[string]any{}
 		for _, key := range []string{"name", "description", "parameters", "strict"} {
 			if value, ok := tool[key]; ok {
 				fn[key] = value
 			}
 		}
+		name, _ := fn["name"].(string)
+		if name != "" {
+			finalName := name
+			if _, exists := usedNames[finalName]; exists {
+				// Chat function names must be unique; keep Codex's original names
+				// unless a real collision forces a namespace-derived prefix.
+				if namespace != "" {
+					finalName = namespace + "_" + name
+				}
+				finalName = uniqueResponsesToolName(finalName, usedNames)
+				fn["name"] = finalName
+			}
+			usedNames[finalName] = struct{}{}
+		}
 		out = append(out, map[string]any{"type": "function", "function": fn})
+	}
+	for _, tool := range tools {
+		switch typ, _ := tool["type"].(string); typ {
+		case "function":
+			addFunction(tool, "")
+		case "namespace":
+			namespace, _ := tool["name"].(string)
+			for _, nested := range responsesNestedTools(tool["tools"]) {
+				if nestedType, _ := nested["type"].(string); nestedType == "function" {
+					addFunction(nested, namespace)
+				}
+			}
+		}
 	}
 	return out
 }
 
-func responsesToolChoiceToChatToolChoice(choice any) any {
+func responsesNestedTools(v any) []map[string]any {
+	switch typed := v.(type) {
+	case []map[string]any:
+		return typed
+	case []any:
+		out := make([]map[string]any, 0, len(typed))
+		for _, item := range typed {
+			if tool, ok := item.(map[string]any); ok {
+				out = append(out, tool)
+			}
+		}
+		return out
+	default:
+		return nil
+	}
+}
+
+func uniqueResponsesToolName(name string, used map[string]struct{}) string {
+	candidate := name
+	for i := 2; ; i++ {
+		if _, exists := used[candidate]; !exists {
+			return candidate
+		}
+		candidate = fmt.Sprintf("%s_%d", name, i)
+	}
+}
+
+func responsesToolChoiceToChatToolChoice(choice any, tools []map[string]any) (any, bool) {
+	if len(tools) == 0 {
+		if s, ok := choice.(string); ok && (s == "auto" || s == "none") {
+			return choice, true
+		}
+		return nil, false
+	}
 	m, ok := choice.(map[string]any)
 	if !ok {
-		return choice
+		return choice, true
 	}
 	if typ, _ := m["type"].(string); typ == "function" {
 		if name, _ := m["name"].(string); name != "" {
-			return map[string]any{"type": "function", "function": map[string]any{"name": name}}
+			if !responsesChatToolsContainName(tools, name) {
+				return nil, false
+			}
+			return map[string]any{"type": "function", "function": map[string]any{"name": name}}, true
 		}
 	}
-	return choice
+	return choice, true
+}
+
+func responsesChatToolsContainName(tools []map[string]any, name string) bool {
+	for _, tool := range tools {
+		fn, _ := tool["function"].(map[string]any)
+		if got, _ := fn["name"].(string); got == name {
+			return true
+		}
+	}
+	return false
 }
 
 func (a *responsesAdapter) translateNonStreamingResponse(body []byte) ([]byte, error) {

--- a/phase5-gateway/internal/router/responses.go
+++ b/phase5-gateway/internal/router/responses.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"regexp"
 	"sort"
@@ -27,19 +28,22 @@ type responsesAdapter struct {
 	requestID string
 	now       func() time.Time
 
-	model           string
-	instructions    *string
-	maxOutputTokens *int64
-	stream          bool
-	tools           []map[string]any
-	toolChoice      any
-	textFormat      any
+	model             string
+	instructions      *string
+	maxOutputTokens   *int64
+	stream            bool
+	tools             []map[string]any
+	toolChoice        any
+	textFormat        any
+	parallelToolCalls bool
 
 	status      int
 	wroteHeader bool
 	body        bytes.Buffer
 	lineBuf     bytes.Buffer
 	prepared    []byte
+	finished    bool
+	passthrough bool
 
 	responseID     string
 	messageID      string
@@ -55,6 +59,11 @@ type responsesAdapter struct {
 	seq            int64
 	toolCalls      map[int]*responsesStreamToolCall
 	writeErr       error
+
+	captureArmed bool
+	captureCap   int
+	capture      []byte
+	overflowed   bool
 }
 
 type responsesStreamToolCall struct {
@@ -78,11 +87,12 @@ func newResponsesAdapter(dst http.ResponseWriter, requestID string, now func() t
 		now = func() time.Time { return time.Now().UTC() }
 	}
 	return &responsesAdapter{
-		dst:        dst,
-		requestID:  requestID,
-		now:        now,
-		messageOut: -1,
-		toolCalls:  make(map[int]*responsesStreamToolCall),
+		dst:               dst,
+		requestID:         requestID,
+		now:               now,
+		messageOut:        -1,
+		toolCalls:         make(map[int]*responsesStreamToolCall),
+		parallelToolCalls: true,
 	}
 }
 
@@ -119,6 +129,10 @@ func (a *responsesAdapter) WriteHeader(code int) {
 	}
 	a.status = code
 	a.wroteHeader = true
+	if a.passthrough {
+		a.dst.WriteHeader(code)
+		return
+	}
 	if a.stream && code == http.StatusOK {
 		h := a.dst.Header()
 		h.Del("Content-Length")
@@ -139,6 +153,9 @@ func (a *responsesAdapter) Write(p []byte) (int, error) {
 	if !a.wroteHeader {
 		a.WriteHeader(http.StatusOK)
 	}
+	if a.passthrough {
+		return a.dst.Write(p)
+	}
 	if !a.stream || a.status != http.StatusOK {
 		_, _ = a.body.Write(p)
 		return len(p), nil
@@ -158,21 +175,38 @@ func (a *responsesAdapter) Write(p []byte) (int, error) {
 }
 
 func (a *responsesAdapter) Flush() {
-	if a.stream {
+	if a.stream || a.passthrough {
 		a.flush()
 	}
 }
 
+func (a *responsesAdapter) beginReplayPassthrough() {
+	a.passthrough = true
+	a.finished = true
+}
+
+func (a *responsesAdapter) endReplayPassthrough() {
+	a.passthrough = false
+	a.finished = false
+}
+
 func (a *responsesAdapter) finish() {
+	if a.finished {
+		return
+	}
+	a.finished = true
 	if a.stream {
 		if a.status != 0 && a.status != http.StatusOK {
 			a.dst.WriteHeader(a.status)
-			_, _ = a.dst.Write(a.body.Bytes())
+			_, _ = a.writeFinalBytes(a.body.Bytes())
 			return
 		}
 		if a.lineBuf.Len() > 0 && a.status == http.StatusOK {
 			a.handleChatStreamLine(a.lineBuf.String())
 			a.lineBuf.Reset()
+		}
+		if a.status == http.StatusOK && !a.streamTerminal {
+			a.emitStreamDone()
 		}
 		return
 	}
@@ -192,11 +226,11 @@ func (a *responsesAdapter) finish() {
 		}
 		a.dst.Header().Set("Content-Type", "application/json")
 		a.dst.WriteHeader(http.StatusOK)
-		_, _ = a.dst.Write(body)
+		_, _ = a.writeFinalBytes(body)
 		return
 	}
 	a.dst.WriteHeader(status)
-	_, _ = a.dst.Write(a.body.Bytes())
+	_, _ = a.writeFinalBytes(a.body.Bytes())
 }
 
 func (a *responsesAdapter) prepareNonStreamingResponse(body []byte) error {
@@ -269,12 +303,19 @@ func (a *responsesAdapter) translateRequest(body []byte) ([]byte, *responsesTran
 	if req.MaxOutputTokens != nil {
 		chat["max_tokens"] = *req.MaxOutputTokens
 	}
-	chatTools := responsesToolsToChatTools(req.Tools)
+	chatTools, toolsErr := responsesToolsToChatTools(req.Tools)
+	if toolsErr != nil {
+		return nil, toolsErr
+	}
 	if len(chatTools) > 0 {
 		chat["tools"] = chatTools
 	}
 	if req.ToolChoice != nil {
-		if toolChoice, ok := responsesToolChoiceToChatToolChoice(req.ToolChoice, chatTools); ok {
+		toolChoice, choiceErr := responsesToolChoiceToChatToolChoice(req.ToolChoice, chatTools)
+		if choiceErr != nil {
+			return nil, choiceErr
+		}
+		if toolChoice != nil {
 			chat["tool_choice"] = toolChoice
 		}
 	}
@@ -283,6 +324,7 @@ func (a *responsesAdapter) translateRequest(body []byte) ([]byte, *responsesTran
 	}
 	if parallelToolCalls, ok := req.ParallelToolCalls.(bool); ok {
 		chat["parallel_tool_calls"] = parallelToolCalls
+		a.parallelToolCalls = parallelToolCalls
 	}
 	if req.Temperature != nil {
 		chat["temperature"] = req.Temperature
@@ -301,7 +343,7 @@ func (a *responsesAdapter) translateRequest(body []byte) ([]byte, *responsesTran
 	a.instructions = req.Instructions
 	a.maxOutputTokens = req.MaxOutputTokens
 	a.stream = req.Stream
-	a.tools = req.Tools
+	a.tools = responsesToolsEchoFromChatTools(chatTools)
 	a.toolChoice = req.ToolChoice
 	a.textFormat = textFormat
 	return body, nil
@@ -549,11 +591,11 @@ func cloneMap(in map[string]any) map[string]any {
 	return out
 }
 
-func responsesToolsToChatTools(tools []map[string]any) []map[string]any {
+func responsesToolsToChatTools(tools []map[string]any) ([]map[string]any, *responsesTranslationError) {
 	out := make([]map[string]any, 0, len(tools))
 	usedNames := make(map[string]struct{}, len(tools))
-	var addFunction func(tool map[string]any, namespace string)
-	addFunction = func(tool map[string]any, namespace string) {
+	var addFunction func(tool map[string]any) *responsesTranslationError
+	addFunction = func(tool map[string]any) *responsesTranslationError {
 		fn := map[string]any{}
 		for _, key := range []string{"name", "description", "parameters", "strict"} {
 			if value, ok := tool[key]; ok {
@@ -562,32 +604,50 @@ func responsesToolsToChatTools(tools []map[string]any) []map[string]any {
 		}
 		name, _ := fn["name"].(string)
 		if name != "" {
-			finalName := name
-			if _, exists := usedNames[finalName]; exists {
-				// Chat function names must be unique; keep Codex's original names
-				// unless a real collision forces a namespace-derived prefix.
-				if namespace != "" {
-					finalName = namespace + "_" + name
-				}
-				finalName = uniqueResponsesToolName(finalName, usedNames)
-				fn["name"] = finalName
+			if _, exists := usedNames[name]; exists {
+				return &responsesTranslationError{code: "unsupported_parameter", param: "tools", message: fmt.Sprintf("tools contains multiple functions named %q after flattening", name)}
 			}
-			usedNames[finalName] = struct{}{}
+			usedNames[name] = struct{}{}
 		}
 		out = append(out, map[string]any{"type": "function", "function": fn})
+		return nil
 	}
 	for _, tool := range tools {
 		switch typ, _ := tool["type"].(string); typ {
 		case "function":
-			addFunction(tool, "")
+			if err := addFunction(tool); err != nil {
+				return nil, err
+			}
 		case "namespace":
-			namespace, _ := tool["name"].(string)
 			for _, nested := range responsesNestedTools(tool["tools"]) {
 				if nestedType, _ := nested["type"].(string); nestedType == "function" {
-					addFunction(nested, namespace)
+					if err := addFunction(nested); err != nil {
+						return nil, err
+					}
 				}
 			}
 		}
+	}
+	return out, nil
+}
+
+func responsesToolsEchoFromChatTools(tools []map[string]any) []map[string]any {
+	if len(tools) == 0 {
+		return nil
+	}
+	out := make([]map[string]any, 0, len(tools))
+	for _, tool := range tools {
+		fn, _ := tool["function"].(map[string]any)
+		if fn == nil {
+			continue
+		}
+		echo := map[string]any{"type": "function"}
+		for _, key := range []string{"name", "description", "parameters", "strict"} {
+			if value, ok := fn[key]; ok {
+				echo[key] = value
+			}
+		}
+		out = append(out, echo)
 	}
 	return out
 }
@@ -609,36 +669,33 @@ func responsesNestedTools(v any) []map[string]any {
 	}
 }
 
-func uniqueResponsesToolName(name string, used map[string]struct{}) string {
-	candidate := name
-	for i := 2; ; i++ {
-		if _, exists := used[candidate]; !exists {
-			return candidate
+func responsesToolChoiceToChatToolChoice(choice any, tools []map[string]any) (any, *responsesTranslationError) {
+	if s, ok := choice.(string); ok {
+		switch s {
+		case "auto", "none":
+			return choice, nil
+		case "required":
+			if len(tools) == 0 {
+				return nil, &responsesTranslationError{code: "unsupported_parameter", param: "tool_choice", message: "tool_choice requires at least one supported function tool"}
+			}
+			return choice, nil
+		default:
+			return nil, &responsesTranslationError{code: "unsupported_parameter", param: "tool_choice", message: fmt.Sprintf("tool_choice %q is not supported", s)}
 		}
-		candidate = fmt.Sprintf("%s_%d", name, i)
-	}
-}
-
-func responsesToolChoiceToChatToolChoice(choice any, tools []map[string]any) (any, bool) {
-	if len(tools) == 0 {
-		if s, ok := choice.(string); ok && (s == "auto" || s == "none") {
-			return choice, true
-		}
-		return nil, false
 	}
 	m, ok := choice.(map[string]any)
 	if !ok {
-		return choice, true
+		return choice, nil
 	}
 	if typ, _ := m["type"].(string); typ == "function" {
 		if name, _ := m["name"].(string); name != "" {
 			if !responsesChatToolsContainName(tools, name) {
-				return nil, false
+				return nil, &responsesTranslationError{code: "unsupported_parameter", param: "tool_choice", message: fmt.Sprintf("tool_choice references unavailable function tool %q", name)}
 			}
-			return map[string]any{"type": "function", "function": map[string]any{"name": name}}, true
+			return map[string]any{"type": "function", "function": map[string]any{"name": name}}, nil
 		}
 	}
-	return choice, true
+	return nil, &responsesTranslationError{code: "unsupported_parameter", param: "tool_choice", message: "tool_choice is not supported by the Responses facade"}
 }
 
 func responsesChatToolsContainName(tools []map[string]any, name string) bool {
@@ -663,19 +720,8 @@ func (a *responsesAdapter) translateNonStreamingResponse(body []byte) ([]byte, e
 			TotalTokens        int64 `json:"total_tokens"`
 		} `json:"usage"`
 		Choices []struct {
-			Message struct {
-				Role      string `json:"role"`
-				Content   any    `json:"content"`
-				ToolCalls []struct {
-					ID       string `json:"id"`
-					Type     string `json:"type"`
-					Function struct {
-						Name      string `json:"name"`
-						Arguments string `json:"arguments"`
-					} `json:"function"`
-				} `json:"tool_calls"`
-			} `json:"message"`
-			FinishReason string `json:"finish_reason"`
+			Message      json.RawMessage `json:"message"`
+			FinishReason string          `json:"finish_reason"`
 		} `json:"choices"`
 	}
 	if err := json.Unmarshal(body, &chat); err != nil {
@@ -691,41 +737,76 @@ func (a *responsesAdapter) translateNonStreamingResponse(body []byte) ([]byte, e
 		model = a.model
 	}
 	output := []map[string]any{}
-	if len(chat.Choices) > 0 {
-		msg := chat.Choices[0].Message
-		text := stripThinkBlocks(responsesContentToText(msg.Content))
-		if text != "" {
-			output = append(output, map[string]any{
-				"id":      "msg_" + idSuffix(id),
-				"type":    "message",
-				"role":    "assistant",
-				"status":  "completed",
-				"content": []map[string]any{{"type": "output_text", "text": text, "annotations": []any{}}},
-			})
+	if len(chat.Choices) == 0 {
+		return nil, fmt.Errorf("missing choices")
+	}
+	if len(bytes.TrimSpace(chat.Choices[0].Message)) == 0 || jsonRawIsNull(chat.Choices[0].Message) {
+		return nil, fmt.Errorf("missing assistant message")
+	}
+	var msg struct {
+		Role         string  `json:"role"`
+		Content      any     `json:"content"`
+		Refusal      *string `json:"refusal"`
+		FunctionCall *struct {
+			Name      string `json:"name"`
+			Arguments string `json:"arguments"`
+		} `json:"function_call"`
+		ToolCalls []struct {
+			ID       string `json:"id"`
+			Type     string `json:"type"`
+			Function struct {
+				Name      string `json:"name"`
+				Arguments string `json:"arguments"`
+			} `json:"function"`
+		} `json:"tool_calls"`
+	}
+	if err := json.Unmarshal(chat.Choices[0].Message, &msg); err != nil {
+		return nil, err
+	}
+	text := stripThinkBlocks(responsesContentToText(msg.Content))
+	if msg.Refusal != nil {
+		text = strings.TrimSpace(text + *msg.Refusal)
+	}
+	if text != "" {
+		output = append(output, map[string]any{
+			"id":      "msg_" + idSuffix(id),
+			"type":    "message",
+			"role":    "assistant",
+			"status":  "completed",
+			"content": []map[string]any{{"type": "output_text", "text": text, "annotations": []any{}}},
+		})
+	}
+	for _, tc := range msg.ToolCalls {
+		if tc.Type != "" && tc.Type != "function" {
+			continue
 		}
-		for _, tc := range msg.ToolCalls {
-			if tc.Type != "" && tc.Type != "function" {
-				continue
-			}
-			callID := tc.ID
-			if callID == "" {
-				callID = "call_" + idSuffix(id)
-			}
-			output = append(output, map[string]any{
-				"id":        "fc_" + idSuffix(callID),
-				"type":      "function_call",
-				"call_id":   callID,
-				"name":      tc.Function.Name,
-				"arguments": tc.Function.Arguments,
-				"status":    "completed",
-			})
+		callID := tc.ID
+		if callID == "" {
+			callID = "call_" + idSuffix(id)
 		}
+		output = append(output, map[string]any{
+			"id":        "fc_" + idSuffix(callID),
+			"type":      "function_call",
+			"call_id":   callID,
+			"name":      tc.Function.Name,
+			"arguments": tc.Function.Arguments,
+			"status":    "completed",
+		})
+	}
+	if msg.FunctionCall != nil {
+		callID := "call_" + idSuffix(id)
+		output = append(output, map[string]any{
+			"id":        "fc_" + idSuffix(callID),
+			"type":      "function_call",
+			"call_id":   callID,
+			"name":      msg.FunctionCall.Name,
+			"arguments": msg.FunctionCall.Arguments,
+			"status":    "completed",
+		})
 	}
 	status := "completed"
 	incompleteDetails := any(nil)
-	if len(chat.Choices) > 0 {
-		_, status, incompleteDetails = responsesTerminalFromFinishReason(chat.Choices[0].FinishReason)
-	}
+	_, status, incompleteDetails = responsesTerminalFromFinishReason(chat.Choices[0].FinishReason)
 	resp := a.responseObjectWith(id, created, status, output, responsesUsageMap(
 		chat.Usage.PromptTokens,
 		chat.Usage.CachedPromptTokens,
@@ -770,7 +851,12 @@ func (a *responsesAdapter) handleChatStreamLine(line string) {
 			Delta struct {
 				Content          *string `json:"content"`
 				ReasoningContent *string `json:"reasoning_content"`
-				ToolCalls        []struct {
+				Refusal          *string `json:"refusal"`
+				FunctionCall     *struct {
+					Name      string `json:"name"`
+					Arguments string `json:"arguments"`
+				} `json:"function_call"`
+				ToolCalls []struct {
 					Index    int    `json:"index"`
 					ID       string `json:"id"`
 					Type     string `json:"type"`
@@ -803,8 +889,14 @@ func (a *responsesAdapter) handleChatStreamLine(line string) {
 	if delta.Content != nil {
 		a.emitTextDelta(a.filterThinkContent(*delta.Content))
 	}
+	if delta.Refusal != nil {
+		a.emitTextDelta(*delta.Refusal)
+	}
 	for _, tc := range delta.ToolCalls {
 		a.emitToolCallDelta(tc.Index, tc.ID, tc.Function.Name, tc.Function.Arguments)
+	}
+	if delta.FunctionCall != nil {
+		a.emitToolCallDelta(0, "", delta.FunctionCall.Name, delta.FunctionCall.Arguments)
 	}
 	if chunk.Choices[0].FinishReason != nil {
 		a.finishReason = *chunk.Choices[0].FinishReason
@@ -991,7 +1083,59 @@ func (a *responsesAdapter) writeBytes(p []byte) {
 	if a.writeErr != nil {
 		return
 	}
-	_, a.writeErr = a.dst.Write(p)
+	n, err := a.dst.Write(p)
+	a.captureDedupeBytes(p[:n], err)
+	if err != nil {
+		a.writeErr = err
+		return
+	}
+	if n != len(p) {
+		a.writeErr = io.ErrShortWrite
+	}
+}
+
+func (a *responsesAdapter) writeFinalBytes(p []byte) (int, error) {
+	n, err := a.dst.Write(p)
+	a.captureDedupeBytes(p[:n], err)
+	if err == nil && n != len(p) {
+		err = io.ErrShortWrite
+	}
+	if err != nil {
+		a.writeErr = err
+	}
+	return n, err
+}
+
+func (a *responsesAdapter) armDedupeCapture(limit int) {
+	a.captureArmed = true
+	a.captureCap = limit
+}
+
+func (a *responsesAdapter) captureDedupeBytes(p []byte, err error) {
+	if !a.captureArmed || a.overflowed {
+		return
+	}
+	if err != nil {
+		a.capture = nil
+		return
+	}
+	if len(a.capture)+len(p) > a.captureCap {
+		a.overflowed = true
+		a.capture = nil
+		return
+	}
+	a.capture = append(a.capture, p...)
+}
+
+func (a *responsesAdapter) dedupeCapture() []byte {
+	if !a.captureArmed || a.overflowed || a.writeErr != nil {
+		return nil
+	}
+	return a.capture
+}
+
+func (a *responsesAdapter) dedupeDeliveredButUncacheable() bool {
+	return a.captureArmed && a.overflowed && a.writeErr == nil
 }
 
 func (a *responsesAdapter) nextSeq() int64 {
@@ -1017,6 +1161,9 @@ func (a *responsesAdapter) responseObject(status string, output []map[string]any
 }
 
 func (a *responsesAdapter) responseObjectWith(id string, created int64, status string, output []map[string]any, usage map[string]any) map[string]any {
+	if output == nil {
+		output = []map[string]any{}
+	}
 	return map[string]any{
 		"id":                   id,
 		"object":               "response",
@@ -1028,7 +1175,7 @@ func (a *responsesAdapter) responseObjectWith(id string, created int64, status s
 		"max_output_tokens":    a.maxOutputTokens,
 		"model":                a.model,
 		"output":               output,
-		"parallel_tool_calls":  true,
+		"parallel_tool_calls":  a.parallelToolCalls,
 		"previous_response_id": nil,
 		"reasoning":            map[string]any{"effort": nil, "summary": nil},
 		"store":                false,
@@ -1045,8 +1192,11 @@ func (a *responsesAdapter) responseObjectWith(id string, created int64, status s
 }
 
 func responsesTerminalFromFinishReason(reason string) (event, status string, incompleteDetails any) {
-	if reason == "length" {
+	switch reason {
+	case "length":
 		return "response.incomplete", "incomplete", map[string]any{"reason": "max_output_tokens"}
+	case "content_filter":
+		return "response.incomplete", "incomplete", map[string]any{"reason": "content_filter"}
 	}
 	return "response.completed", "completed", nil
 }
@@ -1094,7 +1244,11 @@ func idSuffix(id string) string {
 var thinkBlockRE = regexp.MustCompile(`(?s)<think>.*?</think>`)
 
 func stripThinkBlocks(s string) string {
-	return strings.TrimSpace(thinkBlockRE.ReplaceAllString(s, ""))
+	s = thinkBlockRE.ReplaceAllString(s, "")
+	if start := strings.LastIndex(s, "<think>"); start >= 0 {
+		s = s[:start]
+	}
+	return strings.TrimSpace(s)
 }
 
 func (a *responsesAdapter) filterThinkContent(s string) string {

--- a/phase5-gateway/internal/router/responses.go
+++ b/phase5-gateway/internal/router/responses.go
@@ -1,0 +1,1094 @@
+package router
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"regexp"
+	"sort"
+	"strings"
+	"time"
+)
+
+type responsesAdapterContextKey struct{}
+
+type responsesTranslationError struct {
+	code    string
+	param   string
+	message string
+}
+
+func (e responsesTranslationError) Error() string { return e.message }
+
+type responsesAdapter struct {
+	dst       http.ResponseWriter
+	requestID string
+	now       func() time.Time
+
+	model           string
+	instructions    *string
+	maxOutputTokens *int64
+	stream          bool
+	tools           []map[string]any
+	toolChoice      any
+	textFormat      any
+
+	status      int
+	wroteHeader bool
+	body        bytes.Buffer
+	lineBuf     bytes.Buffer
+	prepared    []byte
+
+	responseID     string
+	messageID      string
+	messageOut     int
+	nextOut        int
+	streamUsage    map[string]any
+	finishReason   string
+	streamTerminal bool
+	text           strings.Builder
+	textOpen       bool
+	thinkPending   string
+	thinkInBlock   bool
+	seq            int64
+	toolCalls      map[int]*responsesStreamToolCall
+	writeErr       error
+}
+
+type responsesStreamToolCall struct {
+	ID        string
+	CallID    string
+	Name      string
+	Output    int
+	Arguments strings.Builder
+	Opened    bool
+}
+
+func (s *Server) handleResponses(w http.ResponseWriter, r *http.Request) {
+	adapter := newResponsesAdapter(w, requestID(r), s.now)
+	ctx := context.WithValue(r.Context(), responsesAdapterContextKey{}, adapter)
+	s.handleChatCompletions(adapter, r.WithContext(ctx))
+	adapter.finish()
+}
+
+func newResponsesAdapter(dst http.ResponseWriter, requestID string, now func() time.Time) *responsesAdapter {
+	if now == nil {
+		now = func() time.Time { return time.Now().UTC() }
+	}
+	return &responsesAdapter{
+		dst:        dst,
+		requestID:  requestID,
+		now:        now,
+		messageOut: -1,
+		toolCalls:  make(map[int]*responsesStreamToolCall),
+	}
+}
+
+func responsesAdapterFromContext(ctx context.Context) *responsesAdapter {
+	adapter, _ := ctx.Value(responsesAdapterContextKey{}).(*responsesAdapter)
+	return adapter
+}
+
+func writeResponsesTranslationError(w http.ResponseWriter, status int, err *responsesTranslationError) {
+	retryable := gatewayRetryable(err.code)
+	setGatewayRetryAfter(w, status, err.code, retryable)
+	param := any(nil)
+	if err.param != "" {
+		param = err.param
+	}
+	writeJSON(w, status, map[string]any{
+		"error": map[string]any{
+			"message":   err.message,
+			"type":      "invalid_request_error",
+			"param":     param,
+			"code":      err.code,
+			"retryable": retryable,
+		},
+	})
+}
+
+func (a *responsesAdapter) Header() http.Header {
+	return a.dst.Header()
+}
+
+func (a *responsesAdapter) WriteHeader(code int) {
+	if a.wroteHeader {
+		return
+	}
+	a.status = code
+	a.wroteHeader = true
+	if a.stream && code == http.StatusOK {
+		h := a.dst.Header()
+		h.Del("Content-Length")
+		h.Set("Content-Type", "text/event-stream; charset=utf-8")
+		h.Set("Cache-Control", "no-store, no-cache, no-transform")
+		h.Set("X-Accel-Buffering", "no")
+		a.dst.WriteHeader(code)
+		a.emitResponsesSSE("response.created", map[string]any{
+			"type":            "response.created",
+			"response":        a.responseObject("in_progress", nil),
+			"sequence_number": a.nextSeq(),
+		})
+		a.flush()
+	}
+}
+
+func (a *responsesAdapter) Write(p []byte) (int, error) {
+	if !a.wroteHeader {
+		a.WriteHeader(http.StatusOK)
+	}
+	if !a.stream || a.status != http.StatusOK {
+		_, _ = a.body.Write(p)
+		return len(p), nil
+	}
+	a.lineBuf.Write(p)
+	for {
+		line, err := a.lineBuf.ReadString('\n')
+		if err != nil {
+			a.lineBuf.WriteString(line)
+			return len(p), nil
+		}
+		a.handleChatStreamLine(line)
+		if a.writeErr != nil {
+			return 0, a.writeErr
+		}
+	}
+}
+
+func (a *responsesAdapter) Flush() {
+	if a.stream {
+		a.flush()
+	}
+}
+
+func (a *responsesAdapter) finish() {
+	if a.stream {
+		if a.status != 0 && a.status != http.StatusOK {
+			a.dst.WriteHeader(a.status)
+			_, _ = a.dst.Write(a.body.Bytes())
+			return
+		}
+		if a.lineBuf.Len() > 0 && a.status == http.StatusOK {
+			a.handleChatStreamLine(a.lineBuf.String())
+			a.lineBuf.Reset()
+		}
+		return
+	}
+	status := a.status
+	if status == 0 {
+		status = http.StatusOK
+	}
+	if status == http.StatusOK {
+		body := a.prepared
+		var err error
+		if body == nil {
+			body, err = a.translateNonStreamingResponse(a.body.Bytes())
+		}
+		if err != nil {
+			writeError(a.dst, http.StatusBadGateway, "api_error", "invalid_provider_response", "Upstream provider returned invalid response")
+			return
+		}
+		a.dst.Header().Set("Content-Type", "application/json")
+		a.dst.WriteHeader(http.StatusOK)
+		_, _ = a.dst.Write(body)
+		return
+	}
+	a.dst.WriteHeader(status)
+	_, _ = a.dst.Write(a.body.Bytes())
+}
+
+func (a *responsesAdapter) prepareNonStreamingResponse(body []byte) error {
+	translated, err := a.translateNonStreamingResponse(body)
+	if err != nil {
+		return err
+	}
+	a.prepared = translated
+	return nil
+}
+
+func (a *responsesAdapter) translateRequest(body []byte) ([]byte, *responsesTranslationError) {
+	var req struct {
+		Model              string           `json:"model"`
+		Input              json.RawMessage  `json:"input"`
+		Instructions       *string          `json:"instructions"`
+		Tools              []map[string]any `json:"tools"`
+		ToolChoice         any              `json:"tool_choice"`
+		MaxOutputTokens    *int64           `json:"max_output_tokens"`
+		Stream             bool             `json:"stream"`
+		PreviousResponseID *string          `json:"previous_response_id"`
+		Store              *bool            `json:"store"`
+		Temperature        any              `json:"temperature"`
+		TopP               any              `json:"top_p"`
+		ResponseFormat     json.RawMessage  `json:"response_format"`
+		Text               json.RawMessage  `json:"text"`
+		Metadata           any              `json:"metadata"`
+		User               any              `json:"user"`
+		Reasoning          any              `json:"reasoning"`
+		ParallelToolCalls  any              `json:"parallel_tool_calls"`
+		Conversation       json.RawMessage  `json:"conversation"`
+		Include            json.RawMessage  `json:"include"`
+		Truncation         *string          `json:"truncation"`
+		Background         *bool            `json:"background"`
+	}
+	if err := json.Unmarshal(body, &req); err != nil {
+		return nil, &responsesTranslationError{code: "invalid_request", message: "Malformed JSON"}
+	}
+	if strings.TrimSpace(req.Model) == "" {
+		return nil, &responsesTranslationError{code: "invalid_request", message: "model is required"}
+	}
+	if len(bytes.TrimSpace(req.Input)) == 0 || bytes.Equal(bytes.TrimSpace(req.Input), []byte("null")) {
+		return nil, &responsesTranslationError{code: "invalid_request", message: "input is required"}
+	}
+	if req.PreviousResponseID != nil && strings.TrimSpace(*req.PreviousResponseID) != "" {
+		return nil, &responsesTranslationError{code: "unsupported_parameter", param: "previous_response_id", message: "previous_response_id is not supported; send the full input with store:false"}
+	}
+	if req.Store != nil && *req.Store {
+		return nil, &responsesTranslationError{code: "unsupported_parameter", param: "store", message: "store:true is not supported; send the full input with store:false"}
+	}
+	if err := validateResponsesTools(req.Tools); err != nil {
+		return nil, err
+	}
+	if err := validateResponsesControls(req.Conversation, req.Include, req.Truncation, req.Background, req.Reasoning, req.ParallelToolCalls, req.ResponseFormat); err != nil {
+		return nil, err
+	}
+	textFormat, chatResponseFormat, textErr := responsesTextConfigToChatResponseFormat(req.Text)
+	if textErr != nil {
+		return nil, textErr
+	}
+	messages, inputErr := responsesInputToChatMessages(req.Instructions, req.Input)
+	if inputErr != nil {
+		return nil, &responsesTranslationError{code: "invalid_request", message: inputErr.Error()}
+	}
+	chat := map[string]any{
+		"model":    req.Model,
+		"messages": messages,
+		"stream":   req.Stream,
+	}
+	if req.MaxOutputTokens != nil {
+		chat["max_tokens"] = *req.MaxOutputTokens
+	}
+	if len(req.Tools) > 0 {
+		chat["tools"] = responsesToolsToChatTools(req.Tools)
+	}
+	if req.ToolChoice != nil {
+		chat["tool_choice"] = responsesToolChoiceToChatToolChoice(req.ToolChoice)
+	}
+	if len(chatResponseFormat) > 0 {
+		chat["response_format"] = json.RawMessage(chatResponseFormat)
+	}
+	if req.Temperature != nil {
+		chat["temperature"] = req.Temperature
+	}
+	if req.TopP != nil {
+		chat["top_p"] = req.TopP
+	}
+	if req.User != nil {
+		chat["user"] = req.User
+	}
+	body, marshalErr := json.Marshal(chat)
+	if marshalErr != nil {
+		return nil, &responsesTranslationError{code: "invalid_request", message: "Could not encode translated request"}
+	}
+	a.model = req.Model
+	a.instructions = req.Instructions
+	a.maxOutputTokens = req.MaxOutputTokens
+	a.stream = req.Stream
+	a.tools = req.Tools
+	a.toolChoice = req.ToolChoice
+	a.textFormat = textFormat
+	return body, nil
+}
+
+func responsesInputToChatMessages(instructions *string, input json.RawMessage) ([]map[string]any, error) {
+	messages := make([]map[string]any, 0, 4)
+	if instructions != nil && strings.TrimSpace(*instructions) != "" {
+		messages = append(messages, map[string]any{"role": "system", "content": *instructions})
+	}
+	var text string
+	if err := json.Unmarshal(input, &text); err == nil {
+		if strings.TrimSpace(text) == "" {
+			return nil, fmt.Errorf("input is required")
+		}
+		messages = append(messages, map[string]any{"role": "user", "content": text})
+		return messages, nil
+	}
+	var items []map[string]any
+	if err := json.Unmarshal(input, &items); err != nil {
+		return nil, fmt.Errorf("input must be a string or array")
+	}
+	for _, item := range items {
+		converted, ok, err := responsesInputItemToChatMessage(item)
+		if err != nil {
+			return nil, err
+		}
+		if ok {
+			messages = append(messages, converted)
+		}
+	}
+	if len(messages) == 0 || (len(messages) == 1 && messages[0]["role"] == "system") {
+		return nil, fmt.Errorf("input produced no chat messages")
+	}
+	return messages, nil
+}
+
+func responsesInputItemToChatMessage(item map[string]any) (map[string]any, bool, error) {
+	itemType, _ := item["type"].(string)
+	switch itemType {
+	case "input_image", "input_file", "input_audio", "image_generation_call", "file_search_call", "web_search_call", "computer_call", "code_interpreter_call", "mcp_call":
+		return nil, false, fmt.Errorf("%s input is not supported", itemType)
+	case "function_call_output":
+		callID, _ := item["call_id"].(string)
+		output := responsesContentToText(item["output"])
+		if callID == "" {
+			callID, _ = item["id"].(string)
+		}
+		return map[string]any{"role": "tool", "tool_call_id": callID, "content": output}, true, nil
+	case "function_call":
+		name, _ := item["name"].(string)
+		args := responsesContentToText(item["arguments"])
+		callID, _ := item["call_id"].(string)
+		id, _ := item["id"].(string)
+		toolCallID := callID
+		if toolCallID == "" {
+			toolCallID = id
+		}
+		return map[string]any{
+			"role":    "assistant",
+			"content": nil,
+			"tool_calls": []map[string]any{{
+				"id":   toolCallID,
+				"type": "function",
+				"function": map[string]any{
+					"name":      name,
+					"arguments": args,
+				},
+			}},
+		}, true, nil
+	}
+	role, _ := item["role"].(string)
+	if role == "" {
+		if itemType == "message" {
+			role = "user"
+		} else {
+			return nil, false, nil
+		}
+	}
+	if role == "developer" {
+		role = "system"
+	}
+	if !responsesContentSupported(item["content"]) {
+		return nil, false, fmt.Errorf("non-text content is not supported")
+	}
+	content := responsesContentToText(item["content"])
+	if content == "" && itemType != "message" {
+		return nil, false, nil
+	}
+	return map[string]any{"role": role, "content": content}, true, nil
+}
+
+func responsesContentSupported(v any) bool {
+	parts, ok := v.([]any)
+	if !ok {
+		return true
+	}
+	for _, part := range parts {
+		m, ok := part.(map[string]any)
+		if !ok {
+			continue
+		}
+		if typ, _ := m["type"].(string); typ != "" && typ != "input_text" && typ != "output_text" && typ != "text" {
+			return false
+		}
+	}
+	return true
+}
+
+func responsesContentToText(v any) string {
+	switch typed := v.(type) {
+	case nil:
+		return ""
+	case string:
+		return typed
+	case []any:
+		parts := make([]string, 0, len(typed))
+		for _, part := range typed {
+			if m, ok := part.(map[string]any); ok {
+				for _, key := range []string{"text", "input_text", "output_text"} {
+					if s, ok := m[key].(string); ok {
+						parts = append(parts, s)
+						break
+					}
+				}
+			} else if s, ok := part.(string); ok {
+				parts = append(parts, s)
+			}
+		}
+		return strings.Join(parts, "")
+	default:
+		b, err := json.Marshal(v)
+		if err != nil {
+			return ""
+		}
+		return string(b)
+	}
+}
+
+func validateResponsesTools(tools []map[string]any) *responsesTranslationError {
+	for i, tool := range tools {
+		typ, _ := tool["type"].(string)
+		if typ == "function" {
+			continue
+		}
+		if typ == "" {
+			typ = "unknown"
+		}
+		return &responsesTranslationError{
+			code:    "unsupported_parameter",
+			param:   fmt.Sprintf("tools[%d].type", i),
+			message: fmt.Sprintf("Responses tool type %q is not supported", typ),
+		}
+	}
+	return nil
+}
+
+func validateResponsesControls(conversation, include json.RawMessage, truncation *string, background *bool, reasoning, parallelToolCalls any, responseFormat json.RawMessage) *responsesTranslationError {
+	if len(bytes.TrimSpace(responseFormat)) > 0 && !jsonRawIsNull(responseFormat) {
+		return &responsesTranslationError{code: "unsupported_parameter", param: "response_format", message: "response_format is not supported on /v1/responses; use text.format"}
+	}
+	if len(bytes.TrimSpace(conversation)) > 0 && !jsonRawIsEmptyValue(conversation) {
+		return &responsesTranslationError{code: "unsupported_parameter", param: "conversation", message: "conversation is not supported; send the full input with store:false"}
+	}
+	if len(bytes.TrimSpace(include)) > 0 && !jsonRawIsEmptyValue(include) {
+		return &responsesTranslationError{code: "unsupported_parameter", param: "include", message: "include is not supported"}
+	}
+	if background != nil && *background {
+		return &responsesTranslationError{code: "unsupported_parameter", param: "background", message: "background:true is not supported"}
+	}
+	if truncation != nil && *truncation != "" && *truncation != "disabled" {
+		return &responsesTranslationError{code: "unsupported_parameter", param: "truncation", message: "Only truncation:\"disabled\" is supported"}
+	}
+	if !jsonLikeEmpty(reasoning) {
+		return &responsesTranslationError{code: "unsupported_parameter", param: "reasoning", message: "reasoning controls are not supported"}
+	}
+	if !jsonLikeEmpty(parallelToolCalls) {
+		if enabled, ok := parallelToolCalls.(bool); ok && enabled {
+			return nil
+		}
+		return &responsesTranslationError{code: "unsupported_parameter", param: "parallel_tool_calls", message: "Only default parallel_tool_calls behavior is supported"}
+	}
+	return nil
+}
+
+func jsonRawIsNull(raw json.RawMessage) bool {
+	return bytes.Equal(bytes.TrimSpace(raw), []byte("null"))
+}
+
+func jsonRawIsEmptyValue(raw json.RawMessage) bool {
+	trimmed := bytes.TrimSpace(raw)
+	if len(trimmed) == 0 || bytes.Equal(trimmed, []byte("null")) {
+		return true
+	}
+	var v any
+	if err := json.Unmarshal(trimmed, &v); err != nil {
+		return false
+	}
+	return jsonLikeEmpty(v)
+}
+
+func jsonLikeEmpty(v any) bool {
+	if v == nil {
+		return true
+	}
+	switch typed := v.(type) {
+	case map[string]any:
+		return len(typed) == 0
+	case []any:
+		return len(typed) == 0
+	default:
+		return false
+	}
+}
+
+func responsesTextConfigToChatResponseFormat(raw json.RawMessage) (any, json.RawMessage, *responsesTranslationError) {
+	format := map[string]any{"type": "text"}
+	if len(bytes.TrimSpace(raw)) == 0 || jsonRawIsNull(raw) {
+		return format, nil, nil
+	}
+	var text struct {
+		Format map[string]any `json:"format"`
+	}
+	if err := json.Unmarshal(raw, &text); err != nil {
+		return nil, nil, &responsesTranslationError{code: "invalid_request", param: "text", message: "text must be an object"}
+	}
+	if text.Format == nil {
+		return format, nil, nil
+	}
+	typ, _ := text.Format["type"].(string)
+	switch typ {
+	case "", "text":
+		return map[string]any{"type": "text"}, nil, nil
+	case "json_object":
+		chat, err := json.Marshal(map[string]any{"type": "json_object"})
+		if err != nil {
+			return nil, nil, &responsesTranslationError{code: "invalid_request", param: "text.format", message: "Could not encode text.format"}
+		}
+		return cloneMap(text.Format), chat, nil
+	case "json_schema":
+		jsonSchema := map[string]any{}
+		for _, key := range []string{"name", "description", "schema", "strict"} {
+			if value, ok := text.Format[key]; ok {
+				jsonSchema[key] = value
+			}
+		}
+		if _, ok := jsonSchema["name"]; !ok {
+			return nil, nil, &responsesTranslationError{code: "invalid_request", param: "text.format.name", message: "text.format.name is required for json_schema"}
+		}
+		if _, ok := jsonSchema["schema"]; !ok {
+			return nil, nil, &responsesTranslationError{code: "invalid_request", param: "text.format.schema", message: "text.format.schema is required for json_schema"}
+		}
+		chat, err := json.Marshal(map[string]any{"type": "json_schema", "json_schema": jsonSchema})
+		if err != nil {
+			return nil, nil, &responsesTranslationError{code: "invalid_request", param: "text.format", message: "Could not encode text.format"}
+		}
+		return cloneMap(text.Format), chat, nil
+	default:
+		return nil, nil, &responsesTranslationError{code: "unsupported_parameter", param: "text.format.type", message: fmt.Sprintf("text.format.type %q is not supported", typ)}
+	}
+}
+
+func cloneMap(in map[string]any) map[string]any {
+	out := make(map[string]any, len(in))
+	for k, v := range in {
+		out[k] = v
+	}
+	return out
+}
+
+func responsesToolsToChatTools(tools []map[string]any) []map[string]any {
+	out := make([]map[string]any, 0, len(tools))
+	for _, tool := range tools {
+		if typ, _ := tool["type"].(string); typ != "function" {
+			continue
+		}
+		fn := map[string]any{}
+		for _, key := range []string{"name", "description", "parameters", "strict"} {
+			if value, ok := tool[key]; ok {
+				fn[key] = value
+			}
+		}
+		out = append(out, map[string]any{"type": "function", "function": fn})
+	}
+	return out
+}
+
+func responsesToolChoiceToChatToolChoice(choice any) any {
+	m, ok := choice.(map[string]any)
+	if !ok {
+		return choice
+	}
+	if typ, _ := m["type"].(string); typ == "function" {
+		if name, _ := m["name"].(string); name != "" {
+			return map[string]any{"type": "function", "function": map[string]any{"name": name}}
+		}
+	}
+	return choice
+}
+
+func (a *responsesAdapter) translateNonStreamingResponse(body []byte) ([]byte, error) {
+	var chat struct {
+		ID      string `json:"id"`
+		Created int64  `json:"created"`
+		Model   string `json:"model"`
+		Usage   struct {
+			PromptTokens       int64 `json:"prompt_tokens"`
+			CachedPromptTokens int64 `json:"cached_prompt_tokens"`
+			CompletionTokens   int64 `json:"completion_tokens"`
+			TotalTokens        int64 `json:"total_tokens"`
+		} `json:"usage"`
+		Choices []struct {
+			Message struct {
+				Role      string `json:"role"`
+				Content   any    `json:"content"`
+				ToolCalls []struct {
+					ID       string `json:"id"`
+					Type     string `json:"type"`
+					Function struct {
+						Name      string `json:"name"`
+						Arguments string `json:"arguments"`
+					} `json:"function"`
+				} `json:"tool_calls"`
+			} `json:"message"`
+			FinishReason string `json:"finish_reason"`
+		} `json:"choices"`
+	}
+	if err := json.Unmarshal(body, &chat); err != nil {
+		return nil, err
+	}
+	id := responsesIDFromChatID(chat.ID, a.requestID)
+	created := chat.Created
+	if created == 0 {
+		created = a.now().Unix()
+	}
+	model := chat.Model
+	if model == "" {
+		model = a.model
+	}
+	output := []map[string]any{}
+	if len(chat.Choices) > 0 {
+		msg := chat.Choices[0].Message
+		text := stripThinkBlocks(responsesContentToText(msg.Content))
+		if text != "" {
+			output = append(output, map[string]any{
+				"id":      "msg_" + idSuffix(id),
+				"type":    "message",
+				"role":    "assistant",
+				"status":  "completed",
+				"content": []map[string]any{{"type": "output_text", "text": text, "annotations": []any{}}},
+			})
+		}
+		for _, tc := range msg.ToolCalls {
+			if tc.Type != "" && tc.Type != "function" {
+				continue
+			}
+			callID := tc.ID
+			if callID == "" {
+				callID = "call_" + idSuffix(id)
+			}
+			output = append(output, map[string]any{
+				"id":        "fc_" + idSuffix(callID),
+				"type":      "function_call",
+				"call_id":   callID,
+				"name":      tc.Function.Name,
+				"arguments": tc.Function.Arguments,
+				"status":    "completed",
+			})
+		}
+	}
+	status := "completed"
+	incompleteDetails := any(nil)
+	if len(chat.Choices) > 0 {
+		_, status, incompleteDetails = responsesTerminalFromFinishReason(chat.Choices[0].FinishReason)
+	}
+	resp := a.responseObjectWith(id, created, status, output, responsesUsageMap(
+		chat.Usage.PromptTokens,
+		chat.Usage.CachedPromptTokens,
+		chat.Usage.CompletionTokens,
+		chat.Usage.TotalTokens,
+	))
+	resp["incomplete_details"] = incompleteDetails
+	return json.Marshal(resp)
+}
+
+func (a *responsesAdapter) handleChatStreamLine(line string) {
+	trimmed := strings.TrimRight(line, "\r\n")
+	if strings.TrimSpace(trimmed) == "" {
+		return
+	}
+	data, ok := sseDataValue(trimmed)
+	if !ok {
+		return
+	}
+	if data == "[DONE]" {
+		a.emitStreamDone()
+		return
+	}
+	var errorFrame struct {
+		Error *responsesStreamError `json:"error"`
+	}
+	if err := json.Unmarshal([]byte(data), &errorFrame); err == nil && errorFrame.Error != nil {
+		a.emitStreamFailed(errorFrame.Error)
+		return
+	}
+	var chunk struct {
+		ID      string `json:"id"`
+		Created int64  `json:"created"`
+		Model   string `json:"model"`
+		Usage   *struct {
+			PromptTokens       int64 `json:"prompt_tokens"`
+			CachedPromptTokens int64 `json:"cached_prompt_tokens"`
+			CompletionTokens   int64 `json:"completion_tokens"`
+			TotalTokens        int64 `json:"total_tokens"`
+		} `json:"usage"`
+		Choices []struct {
+			Delta struct {
+				Content          *string `json:"content"`
+				ReasoningContent *string `json:"reasoning_content"`
+				ToolCalls        []struct {
+					Index    int    `json:"index"`
+					ID       string `json:"id"`
+					Type     string `json:"type"`
+					Function struct {
+						Name      string `json:"name"`
+						Arguments string `json:"arguments"`
+					} `json:"function"`
+				} `json:"tool_calls"`
+			} `json:"delta"`
+			FinishReason *string `json:"finish_reason"`
+		} `json:"choices"`
+	}
+	if err := json.Unmarshal([]byte(data), &chunk); err != nil {
+		a.emitStreamFailed(&responsesStreamError{Message: "Upstream stream returned malformed data", Type: "api_error", Code: "stream_malformed"})
+		return
+	}
+	if chunk.ID != "" && a.responseID == "" {
+		a.responseID = responsesIDFromChatID(chunk.ID, a.requestID)
+	}
+	if chunk.Model != "" {
+		a.model = chunk.Model
+	}
+	if chunk.Usage != nil {
+		a.streamUsage = responsesUsageMap(chunk.Usage.PromptTokens, chunk.Usage.CachedPromptTokens, chunk.Usage.CompletionTokens, chunk.Usage.TotalTokens)
+	}
+	if len(chunk.Choices) == 0 {
+		return
+	}
+	delta := chunk.Choices[0].Delta
+	if delta.Content != nil {
+		a.emitTextDelta(a.filterThinkContent(*delta.Content))
+	}
+	for _, tc := range delta.ToolCalls {
+		a.emitToolCallDelta(tc.Index, tc.ID, tc.Function.Name, tc.Function.Arguments)
+	}
+	if chunk.Choices[0].FinishReason != nil {
+		a.finishReason = *chunk.Choices[0].FinishReason
+	}
+	a.flush()
+}
+
+func (a *responsesAdapter) emitTextDelta(delta string) {
+	if delta == "" {
+		return
+	}
+	if a.messageID == "" {
+		a.messageID = "msg_" + idSuffix(a.effectiveResponseID())
+	}
+	if !a.textOpen {
+		a.messageOut = a.nextOutputIndex()
+		a.emitResponsesSSE("response.output_item.added", map[string]any{
+			"type": "response.output_item.added", "output_index": a.messageOut,
+			"item":            map[string]any{"id": a.messageID, "type": "message", "role": "assistant", "status": "in_progress", "content": []any{}},
+			"sequence_number": a.nextSeq(),
+		})
+		a.emitResponsesSSE("response.content_part.added", map[string]any{
+			"type": "response.content_part.added", "item_id": a.messageID, "output_index": a.messageOut, "content_index": 0,
+			"part":            map[string]any{"type": "output_text", "text": "", "annotations": []any{}},
+			"sequence_number": a.nextSeq(),
+		})
+		a.textOpen = true
+	}
+	a.text.WriteString(delta)
+	a.emitResponsesSSE("response.output_text.delta", map[string]any{
+		"type": "response.output_text.delta", "item_id": a.messageID, "output_index": a.messageOut, "content_index": 0,
+		"delta": delta, "sequence_number": a.nextSeq(),
+	})
+}
+
+func (a *responsesAdapter) emitToolCallDelta(index int, id, name, arguments string) {
+	tc := a.toolCalls[index]
+	if tc == nil {
+		callID := id
+		if callID == "" {
+			callID = fmt.Sprintf("call_%s_%d", idSuffix(a.effectiveResponseID()), index)
+		}
+		tc = &responsesStreamToolCall{ID: "fc_" + idSuffix(callID), CallID: callID, Name: name}
+		a.toolCalls[index] = tc
+	}
+	if name != "" {
+		tc.Name = name
+	}
+	if !tc.Opened {
+		tc.Output = a.nextOutputIndex()
+		a.emitResponsesSSE("response.output_item.added", map[string]any{
+			"type": "response.output_item.added", "output_index": tc.Output,
+			"item":            map[string]any{"id": tc.ID, "type": "function_call", "call_id": tc.CallID, "name": tc.Name, "arguments": "", "status": "in_progress"},
+			"sequence_number": a.nextSeq(),
+		})
+		tc.Opened = true
+	}
+	if arguments != "" {
+		tc.Arguments.WriteString(arguments)
+		a.emitResponsesSSE("response.function_call_arguments.delta", map[string]any{
+			"type": "response.function_call_arguments.delta", "item_id": tc.ID, "output_index": tc.Output,
+			"delta": arguments, "sequence_number": a.nextSeq(),
+		})
+	}
+}
+
+func (a *responsesAdapter) emitStreamDone() {
+	if a.streamTerminal {
+		return
+	}
+	if remainder := a.flushThinkRemainder(); remainder != "" {
+		a.emitTextDelta(remainder)
+	}
+	output := []map[string]any{}
+	if a.textOpen {
+		text := a.text.String()
+		a.emitResponsesSSE("response.output_text.done", map[string]any{
+			"type": "response.output_text.done", "item_id": a.messageID, "output_index": a.messageOut, "content_index": 0,
+			"text": text, "sequence_number": a.nextSeq(),
+		})
+		part := map[string]any{"type": "output_text", "text": text, "annotations": []any{}}
+		a.emitResponsesSSE("response.content_part.done", map[string]any{
+			"type": "response.content_part.done", "item_id": a.messageID, "output_index": a.messageOut, "content_index": 0,
+			"part": part, "sequence_number": a.nextSeq(),
+		})
+		item := map[string]any{"id": a.messageID, "type": "message", "role": "assistant", "status": "completed", "content": []map[string]any{part}}
+		a.emitResponsesSSE("response.output_item.done", map[string]any{
+			"type": "response.output_item.done", "output_index": a.messageOut, "item": item, "sequence_number": a.nextSeq(),
+		})
+		output = append(output, item)
+	}
+	toolCalls := make([]*responsesStreamToolCall, 0, len(a.toolCalls))
+	for _, tc := range a.toolCalls {
+		toolCalls = append(toolCalls, tc)
+	}
+	sort.Slice(toolCalls, func(i, j int) bool {
+		return toolCalls[i].Output < toolCalls[j].Output
+	})
+	for _, tc := range toolCalls {
+		args := tc.Arguments.String()
+		a.emitResponsesSSE("response.function_call_arguments.done", map[string]any{
+			"type": "response.function_call_arguments.done", "item_id": tc.ID, "output_index": tc.Output,
+			"name": tc.Name, "arguments": args, "sequence_number": a.nextSeq(),
+		})
+		item := map[string]any{"id": tc.ID, "type": "function_call", "call_id": tc.CallID, "name": tc.Name, "arguments": args, "status": "completed"}
+		a.emitResponsesSSE("response.output_item.done", map[string]any{
+			"type": "response.output_item.done", "output_index": tc.Output, "item": item, "sequence_number": a.nextSeq(),
+		})
+		output = append(output, item)
+	}
+	event, status, incompleteDetails := responsesTerminalFromFinishReason(a.finishReason)
+	response := a.responseObjectWith(a.effectiveResponseID(), a.now().Unix(), status, output, a.streamUsage)
+	response["incomplete_details"] = incompleteDetails
+	a.emitResponsesSSE(event, map[string]any{
+		"type": event, "response": response, "sequence_number": a.nextSeq(),
+	})
+	a.writeBytes([]byte("data: [DONE]\n\n"))
+	a.flush()
+	a.streamTerminal = true
+}
+
+type responsesStreamError struct {
+	Message   string `json:"message"`
+	Type      string `json:"type"`
+	Code      string `json:"code"`
+	Param     any    `json:"param"`
+	Retryable any    `json:"retryable"`
+}
+
+func (a *responsesAdapter) emitStreamFailed(errFrame *responsesStreamError) {
+	if a.streamTerminal {
+		return
+	}
+	code := errFrame.Code
+	if code == "" {
+		code = "provider_error"
+	}
+	message := errFrame.Message
+	if message == "" {
+		message = "Upstream provider failed"
+	}
+	errType := errFrame.Type
+	if errType == "" {
+		errType = "api_error"
+	}
+	errorObject := map[string]any{"code": code, "message": message, "type": errType}
+	if errFrame.Param != nil {
+		errorObject["param"] = errFrame.Param
+	}
+	if errFrame.Retryable != nil {
+		errorObject["retryable"] = errFrame.Retryable
+	}
+	response := a.responseObjectWith(a.effectiveResponseID(), a.now().Unix(), "failed", nil, a.streamUsage)
+	response["error"] = errorObject
+	a.emitResponsesSSE("response.failed", map[string]any{
+		"type": "response.failed", "response": response, "sequence_number": a.nextSeq(),
+	})
+	a.writeBytes([]byte("data: [DONE]\n\n"))
+	a.flush()
+	a.streamTerminal = true
+}
+
+func (a *responsesAdapter) emitResponsesSSE(event string, payload map[string]any) {
+	if a.writeErr != nil {
+		return
+	}
+	b, err := json.Marshal(payload)
+	if err != nil {
+		return
+	}
+	a.writeBytes([]byte("event: " + event + "\n"))
+	a.writeBytes([]byte("data: "))
+	a.writeBytes(b)
+	a.writeBytes([]byte("\n\n"))
+}
+
+func (a *responsesAdapter) flush() {
+	if f, ok := a.dst.(http.Flusher); ok {
+		f.Flush()
+	}
+}
+
+func (a *responsesAdapter) writeBytes(p []byte) {
+	if a.writeErr != nil {
+		return
+	}
+	_, a.writeErr = a.dst.Write(p)
+}
+
+func (a *responsesAdapter) nextSeq() int64 {
+	a.seq++
+	return a.seq
+}
+
+func (a *responsesAdapter) nextOutputIndex() int {
+	out := a.nextOut
+	a.nextOut++
+	return out
+}
+
+func (a *responsesAdapter) effectiveResponseID() string {
+	if a.responseID == "" {
+		a.responseID = "resp_" + idSuffix(a.requestID)
+	}
+	return a.responseID
+}
+
+func (a *responsesAdapter) responseObject(status string, output []map[string]any) map[string]any {
+	return a.responseObjectWith(a.effectiveResponseID(), a.now().Unix(), status, output, nil)
+}
+
+func (a *responsesAdapter) responseObjectWith(id string, created int64, status string, output []map[string]any, usage map[string]any) map[string]any {
+	return map[string]any{
+		"id":                   id,
+		"object":               "response",
+		"created_at":           created,
+		"status":               status,
+		"error":                nil,
+		"incomplete_details":   nil,
+		"instructions":         a.instructions,
+		"max_output_tokens":    a.maxOutputTokens,
+		"model":                a.model,
+		"output":               output,
+		"parallel_tool_calls":  true,
+		"previous_response_id": nil,
+		"reasoning":            map[string]any{"effort": nil, "summary": nil},
+		"store":                false,
+		"temperature":          nil,
+		"text":                 map[string]any{"format": firstNonNil(a.textFormat, map[string]any{"type": "text"})},
+		"tool_choice":          firstNonNil(a.toolChoice, "auto"),
+		"tools":                a.tools,
+		"top_p":                nil,
+		"truncation":           "disabled",
+		"usage":                usage,
+		"user":                 nil,
+		"metadata":             map[string]any{},
+	}
+}
+
+func responsesTerminalFromFinishReason(reason string) (event, status string, incompleteDetails any) {
+	if reason == "length" {
+		return "response.incomplete", "incomplete", map[string]any{"reason": "max_output_tokens"}
+	}
+	return "response.completed", "completed", nil
+}
+
+func responsesUsageMap(prompt, cached, completion, total int64) map[string]any {
+	return map[string]any{
+		"input_tokens":         prompt,
+		"output_tokens":        completion,
+		"total_tokens":         total,
+		"input_tokens_details": map[string]any{"cached_tokens": cached, "cache_write_tokens": 0},
+		"output_tokens_details": map[string]any{
+			"reasoning_tokens": 0,
+		},
+	}
+}
+
+func firstNonNil(v any, fallback any) any {
+	if v != nil {
+		return v
+	}
+	return fallback
+}
+
+func responsesIDFromChatID(chatID, requestID string) string {
+	source := chatID
+	if source == "" {
+		source = requestID
+	}
+	return "resp_" + idSuffix(source)
+}
+
+var nonIDChar = regexp.MustCompile(`[^A-Za-z0-9_-]+`)
+
+func idSuffix(id string) string {
+	id = strings.Trim(nonIDChar.ReplaceAllString(id, "_"), "_")
+	if id == "" {
+		return "generated"
+	}
+	if len(id) > 48 {
+		return id[len(id)-48:]
+	}
+	return id
+}
+
+var thinkBlockRE = regexp.MustCompile(`(?s)<think>.*?</think>`)
+
+func stripThinkBlocks(s string) string {
+	return strings.TrimSpace(thinkBlockRE.ReplaceAllString(s, ""))
+}
+
+func (a *responsesAdapter) filterThinkContent(s string) string {
+	input := a.thinkPending + s
+	a.thinkPending = ""
+	var out strings.Builder
+	for input != "" {
+		if a.thinkInBlock {
+			if end := strings.Index(input, "</think>"); end >= 0 {
+				input = input[end+len("</think>"):]
+				a.thinkInBlock = false
+				continue
+			}
+			a.thinkPending = longestSuffixThatPrefixes(input, "</think>")
+			return out.String()
+		}
+		if start := strings.Index(input, "<think>"); start >= 0 {
+			out.WriteString(input[:start])
+			input = input[start+len("<think>"):]
+			a.thinkInBlock = true
+			continue
+		}
+		a.thinkPending = longestSuffixThatPrefixes(input, "<think>")
+		out.WriteString(input[:len(input)-len(a.thinkPending)])
+		return out.String()
+	}
+	return out.String()
+}
+
+func (a *responsesAdapter) flushThinkRemainder() string {
+	if a.thinkInBlock {
+		a.thinkPending = ""
+		return ""
+	}
+	remainder := a.thinkPending
+	a.thinkPending = ""
+	return remainder
+}
+
+func longestSuffixThatPrefixes(s, prefix string) string {
+	max := len(prefix) - 1
+	if len(s) < max {
+		max = len(s)
+	}
+	for n := max; n > 0; n-- {
+		suffix := s[len(s)-n:]
+		if strings.HasPrefix(prefix, suffix) {
+			return suffix
+		}
+	}
+	return ""
+}

--- a/phase5-gateway/internal/router/responses_test.go
+++ b/phase5-gateway/internal/router/responses_test.go
@@ -1,0 +1,510 @@
+package router
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/augstar/macprovider-gateway/internal/config"
+)
+
+func TestResponsesRouteFlagOffReturnsNotFound(t *testing.T) {
+	h, store, _, cfg := newTestHarness(t, fakeOAuth{})
+	key := createAccountAndKey(t, store, cfg, "acct_responses_flag_off")
+
+	resp := postResponses(t, h, key, `{"model":"llama","input":"hi","store":false}`, nil)
+
+	if resp.Code != http.StatusNotFound {
+		t.Fatalf("status=%d want 404 body=%s", resp.Code, resp.Body.String())
+	}
+}
+
+func TestResponsesNonStreamingTranslatesThroughChatPipeline(t *testing.T) {
+	var capturedPath string
+	var capturedBody map[string]any
+	client := &http.Client{Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+		capturedPath = r.URL.Path
+		if err := json.NewDecoder(r.Body).Decode(&capturedBody); err != nil {
+			t.Fatalf("decode upstream request: %v", err)
+		}
+		return responseWithBody(http.StatusOK, http.Header{"Content-Type": []string{"application/json"}}, `{
+			"id":"chatcmpl_resp_1",
+			"object":"chat.completion",
+			"created":1782864000,
+			"model":"llama",
+			"usage":{"prompt_tokens":5,"cached_prompt_tokens":2,"completion_tokens":3,"total_tokens":8},
+			"choices":[{"index":0,"message":{"role":"assistant","content":"<think>hidden</think> visible answer"},"finish_reason":"stop"}]
+		}`), nil
+	})}
+	h, store, dbPath, cfg := newTestHarnessConfig(t, fakeOAuth{}, enableResponsesWithCoordinator, WithHTTPClient(client))
+	key := createAccountAndKey(t, store, cfg, "acct_responses_nonstream")
+
+	resp := postResponses(t, h, key, `{
+		"model":"llama",
+		"instructions":"be terse",
+		"input":[{"role":"user","content":[{"type":"input_text","text":"hi"}]}],
+		"max_output_tokens":20,
+		"store":false,
+		"tools":[{"type":"function","name":"lookup","description":"lookup","parameters":{"type":"object"}}]
+	}`, map[string]string{"X-Request-ID": "12121212-1212-4212-8212-121212121212"})
+
+	if resp.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s", resp.Code, resp.Body.String())
+	}
+	if capturedPath != "/v1/chat/completions" {
+		t.Fatalf("upstream path=%q want /v1/chat/completions", capturedPath)
+	}
+	if got := capturedBody["max_tokens"].(float64); got != 20 {
+		t.Fatalf("translated max_tokens=%v want 20", got)
+	}
+	messages := capturedBody["messages"].([]any)
+	if len(messages) != 2 {
+		t.Fatalf("translated messages=%v want system+user", messages)
+	}
+	if messages[0].(map[string]any)["role"] != "system" || messages[0].(map[string]any)["content"] != "be terse" {
+		t.Fatalf("system message not translated: %v", messages[0])
+	}
+	if messages[1].(map[string]any)["role"] != "user" || messages[1].(map[string]any)["content"] != "hi" {
+		t.Fatalf("user message not translated: %v", messages[1])
+	}
+	tools := capturedBody["tools"].([]any)
+	fn := tools[0].(map[string]any)["function"].(map[string]any)
+	if fn["name"] != "lookup" {
+		t.Fatalf("tool not translated: %v", tools)
+	}
+
+	var body map[string]any
+	if err := json.Unmarshal(resp.Body.Bytes(), &body); err != nil {
+		t.Fatalf("responses json: %v body=%s", err, resp.Body.String())
+	}
+	if body["object"] != "response" || body["status"] != "completed" || body["store"] != false {
+		t.Fatalf("bad response envelope: %v", body)
+	}
+	output := body["output"].([]any)
+	message := output[0].(map[string]any)
+	if message["status"] != "completed" {
+		t.Fatalf("message status=%v want completed", message["status"])
+	}
+	text := message["content"].([]any)[0].(map[string]any)["text"]
+	if text != "visible answer" {
+		t.Fatalf("output text=%q want stripped visible answer", text)
+	}
+	usage := body["usage"].(map[string]any)
+	if usage["input_tokens"].(float64) != 5 || usage["output_tokens"].(float64) != 3 {
+		t.Fatalf("usage not mapped: %v", usage)
+	}
+	if usage["output_tokens_details"].(map[string]any)["reasoning_tokens"].(float64) != 0 {
+		t.Fatalf("usage output details not populated: %v", usage)
+	}
+	gotSettlement := gatewaySettlementSnapshot(t, dbPath, "acct_responses_nonstream")
+	if gotSettlement.usageRows != 1 || gotSettlement.settledRows != 1 || gotSettlement.activeRows != 0 {
+		t.Fatalf("settlement=%+v want one settled usage row", gotSettlement)
+	}
+}
+
+func TestResponsesNonStreamingLengthFinishReasonIsIncomplete(t *testing.T) {
+	adapter := newResponsesAdapter(httptest.NewRecorder(), "23232323-2323-4232-8232-232323232323", nil)
+	adapter.model = "llama"
+
+	body, err := adapter.translateNonStreamingResponse([]byte(`{
+		"id":"chatcmpl_incomplete",
+		"created":1782864000,
+		"model":"llama",
+		"usage":{"prompt_tokens":5,"completion_tokens":20,"total_tokens":25},
+		"choices":[{"message":{"role":"assistant","content":"partial"},"finish_reason":"length"}]
+	}`))
+	if err != nil {
+		t.Fatalf("translate response: %v", err)
+	}
+	var resp map[string]any
+	if err := json.Unmarshal(body, &resp); err != nil {
+		t.Fatalf("responses json: %v", err)
+	}
+	if resp["status"] != "incomplete" {
+		t.Fatalf("status=%v want incomplete body=%s", resp["status"], string(body))
+	}
+	details := resp["incomplete_details"].(map[string]any)
+	if details["reason"] != "max_output_tokens" {
+		t.Fatalf("incomplete_details=%v want max_output_tokens", details)
+	}
+}
+
+func TestResponsesRejectsUnsupportedStateBeforeReservation(t *testing.T) {
+	tests := []struct {
+		name string
+		body string
+		code string
+	}{
+		{name: "store_true", body: `{"model":"llama","input":"hi","store":true}`, code: "unsupported_parameter"},
+		{name: "previous_response_id", body: `{"model":"llama","input":"hi","store":false,"previous_response_id":"resp_123"}`, code: "unsupported_parameter"},
+		{name: "hosted_tool", body: `{"model":"llama","input":"hi","store":false,"tools":[{"type":"web_search_preview"}]}`, code: "unsupported_parameter"},
+		{name: "multimodal_content", body: `{"model":"llama","input":[{"role":"user","content":[{"type":"input_image","image_url":"https://example.invalid/a.png"}]}],"store":false}`, code: "invalid_request"},
+		{name: "legacy_response_format", body: `{"model":"llama","input":"hi","store":false,"response_format":{"type":"json_object"}}`, code: "unsupported_parameter"},
+		{name: "conversation", body: `{"model":"llama","input":"hi","store":false,"conversation":{"id":"conv_123"}}`, code: "unsupported_parameter"},
+		{name: "include", body: `{"model":"llama","input":"hi","store":false,"include":["file_search_call.results"]}`, code: "unsupported_parameter"},
+		{name: "background", body: `{"model":"llama","input":"hi","store":false,"background":true}`, code: "unsupported_parameter"},
+		{name: "truncation_auto", body: `{"model":"llama","input":"hi","store":false,"truncation":"auto"}`, code: "unsupported_parameter"},
+		{name: "reasoning", body: `{"model":"llama","input":"hi","store":false,"reasoning":{"effort":"low"}}`, code: "unsupported_parameter"},
+		{name: "parallel_tool_calls_false", body: `{"model":"llama","input":"hi","store":false,"parallel_tool_calls":false}`, code: "unsupported_parameter"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			called := false
+			client := &http.Client{Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+				called = true
+				return responseWithBody(http.StatusOK, nil, `{}`), nil
+			})}
+			h, store, dbPath, cfg := newTestHarnessConfig(t, fakeOAuth{}, enableResponsesWithCoordinator, WithHTTPClient(client))
+			acct := "acct_responses_reject_" + tc.name
+			key := createAccountAndKey(t, store, cfg, acct)
+
+			resp := postResponses(t, h, key, tc.body, nil)
+
+			if resp.Code != http.StatusBadRequest {
+				t.Fatalf("status=%d want 400 body=%s", resp.Code, resp.Body.String())
+			}
+			assertErrorCode(t, resp.Body.String(), tc.code)
+			if called {
+				t.Fatalf("coordinator was called for rejected request")
+			}
+			gotSettlement := gatewaySettlementSnapshot(t, dbPath, acct)
+			if gotSettlement.usageRows != 0 || gotSettlement.activeRows != 0 || gotSettlement.settledRows != 0 {
+				t.Fatalf("settlement after rejected request=%+v want empty", gotSettlement)
+			}
+		})
+	}
+}
+
+func TestResponsesStreamingPostTranslationValidationErrorIsForwarded(t *testing.T) {
+	called := false
+	client := &http.Client{Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+		called = true
+		return responseWithBody(http.StatusOK, nil, `{}`), nil
+	})}
+	h, store, dbPath, cfg := newTestHarnessConfig(t, fakeOAuth{}, enableResponsesWithCoordinator, WithHTTPClient(client))
+	key := createAccountAndKey(t, store, cfg, "acct_responses_stream_validation")
+
+	resp := postResponses(t, h, key, `{"model":"llama","input":"hi","stream":true,"max_output_tokens":999999999,"store":false}`, nil)
+
+	if resp.Code != http.StatusBadRequest {
+		t.Fatalf("status=%d want 400 body=%s", resp.Code, resp.Body.String())
+	}
+	assertErrorCode(t, resp.Body.String(), "max_tokens_exceeded")
+	if called {
+		t.Fatalf("coordinator was called for max-token rejected request")
+	}
+	gotSettlement := gatewaySettlementSnapshot(t, dbPath, "acct_responses_stream_validation")
+	if gotSettlement.usageRows != 0 || gotSettlement.activeRows != 0 || gotSettlement.settledRows != 0 {
+		t.Fatalf("settlement after rejected request=%+v want empty", gotSettlement)
+	}
+}
+
+func TestResponsesTextFormatTranslatesToChatResponseFormat(t *testing.T) {
+	var capturedBody map[string]any
+	client := &http.Client{Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+		if err := json.NewDecoder(r.Body).Decode(&capturedBody); err != nil {
+			t.Fatalf("decode upstream request: %v", err)
+		}
+		return responseWithBody(http.StatusOK, http.Header{"Content-Type": []string{"application/json"}}, `{
+			"id":"chatcmpl_structured",
+			"created":1782864000,
+			"model":"llama",
+			"usage":{"prompt_tokens":5,"completion_tokens":3,"total_tokens":8},
+			"choices":[{"message":{"role":"assistant","content":"{\"answer\":\"hi\"}"},"finish_reason":"stop"}]
+		}`), nil
+	})}
+	h, store, _, cfg := newTestHarnessConfig(t, fakeOAuth{}, enableResponsesWithCoordinator, WithHTTPClient(client))
+	key := createAccountAndKey(t, store, cfg, "acct_responses_text_format")
+
+	resp := postResponses(t, h, key, `{
+		"model":"llama",
+		"input":"hi",
+		"store":false,
+		"text":{"format":{"type":"json_schema","name":"answer_schema","strict":true,"schema":{"type":"object","properties":{"answer":{"type":"string"}},"required":["answer"],"additionalProperties":false}}}
+	}`, nil)
+
+	if resp.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s", resp.Code, resp.Body.String())
+	}
+	responseFormat := capturedBody["response_format"].(map[string]any)
+	if responseFormat["type"] != "json_schema" {
+		t.Fatalf("chat response_format=%v want json_schema", responseFormat)
+	}
+	jsonSchema := responseFormat["json_schema"].(map[string]any)
+	if jsonSchema["name"] != "answer_schema" || jsonSchema["strict"] != true {
+		t.Fatalf("chat json_schema not translated: %v", jsonSchema)
+	}
+	var body map[string]any
+	if err := json.Unmarshal(resp.Body.Bytes(), &body); err != nil {
+		t.Fatalf("responses json: %v", err)
+	}
+	text := body["text"].(map[string]any)
+	format := text["format"].(map[string]any)
+	if format["type"] != "json_schema" || format["name"] != "answer_schema" {
+		t.Fatalf("response text.format=%v want echoed json_schema", format)
+	}
+}
+
+func TestResponsesStreamingUpstreamNonOKErrorIsForwarded(t *testing.T) {
+	client := &http.Client{Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+		return responseWithBody(http.StatusBadGateway, http.Header{"Content-Type": []string{"application/json"}}, `{"error":{"message":"bad upstream","type":"api_error","code":"provider_error"}}`), nil
+	})}
+	h, store, dbPath, cfg := newTestHarnessConfig(t, fakeOAuth{}, enableResponsesWithCoordinator, WithHTTPClient(client))
+	key := createAccountAndKey(t, store, cfg, "acct_responses_stream_upstream_non_ok")
+
+	resp := postResponses(t, h, key, `{"model":"llama","input":"hi","stream":true,"max_output_tokens":20,"store":false}`, map[string]string{"X-Request-ID": "57575757-5757-4757-8757-575757575757"})
+
+	if resp.Code != http.StatusBadGateway {
+		t.Fatalf("status=%d want 502 body=%s", resp.Code, resp.Body.String())
+	}
+	assertErrorCode(t, resp.Body.String(), "upstream_provider_error")
+	outcome, source := usageEventOutcome(t, dbPath, "acct_responses_stream_upstream_non_ok")
+	if outcome != "upstream_error" || source != "gateway_estimated" {
+		t.Fatalf("usage outcome/source=%s/%s want upstream_error/gateway_estimated", outcome, source)
+	}
+}
+
+func TestResponsesNonStreamingInvalidProviderResponseDoesNotSettleOK(t *testing.T) {
+	client := &http.Client{Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+		return responseWithBody(http.StatusOK, http.Header{"Content-Type": []string{"application/json"}}, `not-json`), nil
+	})}
+	h, store, dbPath, cfg := newTestHarnessConfig(t, fakeOAuth{}, enableResponsesWithCoordinator, WithHTTPClient(client))
+	key := createAccountAndKey(t, store, cfg, "acct_responses_invalid_provider_response")
+
+	resp := postResponses(t, h, key, `{"model":"llama","input":"hi","max_output_tokens":20,"store":false}`, map[string]string{"X-Request-ID": "68686868-6868-4686-8686-686868686868"})
+
+	if resp.Code != http.StatusBadGateway {
+		t.Fatalf("status=%d want 502 body=%s", resp.Code, resp.Body.String())
+	}
+	assertErrorCode(t, resp.Body.String(), "invalid_provider_response")
+	outcome, source, completion, _ := usageEventOutcomeAndTokens(t, dbPath, "acct_responses_invalid_provider_response")
+	if outcome != "invalid_provider_response" || source != "gateway_estimated" || completion != 0 {
+		t.Fatalf("usage outcome/source/completion=%s/%s/%d want invalid_provider_response/gateway_estimated/0", outcome, source, completion)
+	}
+}
+
+func TestResponsesInputFunctionCallUsesCallIDForChatToolID(t *testing.T) {
+	adapter := newResponsesAdapter(httptest.NewRecorder(), "56565656-5656-4656-8656-565656565656", nil)
+
+	body, err := adapter.translateRequest([]byte(`{
+		"model":"llama",
+		"input":[
+			{"role":"user","content":"hi"},
+			{"type":"function_call","id":"fc_lookup","call_id":"call_lookup","name":"lookup","arguments":"{\"q\":\"hi\"}"},
+			{"type":"function_call_output","call_id":"call_lookup","output":"ok"}
+		],
+		"store":false
+	}`))
+	if err != nil {
+		t.Fatalf("translate request: %v", err)
+	}
+	var chat map[string]any
+	if err := json.Unmarshal(body, &chat); err != nil {
+		t.Fatalf("chat json: %v", err)
+	}
+	messages := chat["messages"].([]any)
+	assistant := messages[1].(map[string]any)
+	toolCall := assistant["tool_calls"].([]any)[0].(map[string]any)
+	if toolCall["id"] != "call_lookup" {
+		t.Fatalf("chat tool_call id=%v want call_lookup", toolCall["id"])
+	}
+	tool := messages[2].(map[string]any)
+	if tool["tool_call_id"] != "call_lookup" {
+		t.Fatalf("tool_call_id=%v want call_lookup", tool["tool_call_id"])
+	}
+}
+
+func TestResponsesStreamingTextAndToolEvents(t *testing.T) {
+	stream := strings.Join([]string{
+		`data: {"id":"chatcmpl_stream_resp","model":"llama","choices":[{"delta":{"content":"hel"}}]}`,
+		`data: {"id":"chatcmpl_stream_resp","model":"llama","choices":[{"delta":{"content":"lo"}}]}`,
+		`data: {"id":"chatcmpl_stream_resp","model":"llama","choices":[{"delta":{"tool_calls":[{"index":0,"id":"call_lookup","type":"function","function":{"name":"lookup","arguments":"{\"q\""}}]}}]}`,
+		`data: {"id":"chatcmpl_stream_resp","model":"llama","choices":[{"delta":{"tool_calls":[{"index":0,"function":{"arguments":":\"hi\"}"}}]}}]}`,
+		`data: {"id":"chatcmpl_stream_resp","model":"llama","usage":{"prompt_tokens":4,"completion_tokens":5,"total_tokens":9},"choices":[{"delta":{},"finish_reason":"tool_calls"}]}`,
+		`data: [DONE]`,
+		``,
+	}, "\n\n")
+	client := &http.Client{Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+		return responseWithBody(http.StatusOK, http.Header{"Content-Type": []string{"text/event-stream; charset=utf-8"}}, stream), nil
+	})}
+	h, store, dbPath, cfg := newTestHarnessConfig(t, fakeOAuth{}, enableResponsesWithCoordinator, WithHTTPClient(client))
+	key := createAccountAndKey(t, store, cfg, "acct_responses_stream")
+
+	resp := postResponses(t, h, key, `{
+		"model":"llama",
+		"input":"hi",
+		"stream":true,
+		"max_output_tokens":20,
+		"store":false,
+		"tools":[{"type":"function","name":"lookup","parameters":{"type":"object"}}]
+	}`, map[string]string{"X-Request-ID": "34343434-3434-4434-8434-343434343434"})
+
+	if resp.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s", resp.Code, resp.Body.String())
+	}
+	body := resp.Body.String()
+	for _, want := range []string{
+		"event: response.created",
+		"event: response.output_text.delta",
+		`"status":"in_progress"`,
+		`"delta":"hel"`,
+		"event: response.function_call_arguments.delta",
+		"event: response.function_call_arguments.done",
+		`"name":"lookup"`,
+		"event: response.completed",
+		`"status":"completed"`,
+		`"input_tokens":4`,
+		`"reasoning_tokens":0`,
+		"data: [DONE]",
+	} {
+		if !strings.Contains(body, want) {
+			t.Fatalf("stream missing %q:\n%s", want, body)
+		}
+	}
+	gotSettlement := gatewaySettlementSnapshot(t, dbPath, "acct_responses_stream")
+	if gotSettlement.usageRows != 1 || gotSettlement.settledRows != 1 || gotSettlement.activeRows != 0 {
+		t.Fatalf("settlement=%+v want one settled usage row", gotSettlement)
+	}
+}
+
+func TestResponsesStreamingChatErrorBecomesFailedTerminal(t *testing.T) {
+	rec := httptest.NewRecorder()
+	adapter := newResponsesAdapter(rec, "67676767-6767-4676-8676-676767676767", nil)
+	adapter.stream = true
+	adapter.model = "llama"
+	adapter.WriteHeader(http.StatusOK)
+
+	adapter.handleChatStreamLine(`data: {"error":{"message":"Provider timed out during streaming","type":"api_error","code":"provider_timeout","retryable":true}}`)
+	adapter.handleChatStreamLine(`data: [DONE]`)
+
+	body := rec.Body.String()
+	for _, want := range []string{
+		"event: response.failed",
+		`"status":"failed"`,
+		`"code":"provider_timeout"`,
+		"data: [DONE]",
+	} {
+		if !strings.Contains(body, want) {
+			t.Fatalf("failed stream missing %q:\n%s", want, body)
+		}
+	}
+	if strings.Contains(body, "event: response.completed") {
+		t.Fatalf("failed stream emitted completed:\n%s", body)
+	}
+}
+
+func TestResponsesStreamingSplitThinkAndReasoningContentAreHidden(t *testing.T) {
+	rec := httptest.NewRecorder()
+	adapter := newResponsesAdapter(rec, "89898989-8989-4898-8898-898989898989", nil)
+	adapter.stream = true
+	adapter.model = "llama"
+	adapter.WriteHeader(http.StatusOK)
+
+	adapter.handleChatStreamLine(`data: {"id":"chatcmpl_think","model":"llama","choices":[{"delta":{"content":"<thi"}}]}`)
+	adapter.handleChatStreamLine(`data: {"id":"chatcmpl_think","model":"llama","choices":[{"delta":{"content":"nk>hidden"}}]}`)
+	adapter.handleChatStreamLine(`data: {"id":"chatcmpl_think","model":"llama","choices":[{"delta":{"reasoning_content":"also hidden","content":"</think> visible"}}]}`)
+	adapter.handleChatStreamLine(`data: [DONE]`)
+
+	body := rec.Body.String()
+	if strings.Contains(body, "hidden") || strings.Contains(body, "<think") || strings.Contains(body, "reasoning_content") {
+		t.Fatalf("stream leaked hidden reasoning:\n%s", body)
+	}
+	if !strings.Contains(body, `"delta":" visible"`) || !strings.Contains(body, "event: response.completed") {
+		t.Fatalf("stream missing visible completion:\n%s", body)
+	}
+}
+
+func TestResponsesStreamingLengthFinishReasonIsIncomplete(t *testing.T) {
+	rec := httptest.NewRecorder()
+	adapter := newResponsesAdapter(rec, "90909090-9090-4090-8090-909090909090", nil)
+	adapter.stream = true
+	adapter.model = "llama"
+	adapter.WriteHeader(http.StatusOK)
+
+	adapter.handleChatStreamLine(`data: {"id":"chatcmpl_incomplete_stream","model":"llama","usage":{"prompt_tokens":3,"completion_tokens":7,"total_tokens":10},"choices":[{"delta":{"content":"partial"},"finish_reason":"length"}]}`)
+	adapter.handleChatStreamLine(`data: [DONE]`)
+
+	body := rec.Body.String()
+	for _, want := range []string{
+		"event: response.incomplete",
+		`"status":"incomplete"`,
+		`"reason":"max_output_tokens"`,
+		`"input_tokens":3`,
+		"data: [DONE]",
+	} {
+		if !strings.Contains(body, want) {
+			t.Fatalf("incomplete stream missing %q:\n%s", want, body)
+		}
+	}
+	if strings.Contains(body, "event: response.completed") {
+		t.Fatalf("incomplete stream emitted completed:\n%s", body)
+	}
+}
+
+func TestResponsesStreamingToolOnlyStartsAtOutputIndexZero(t *testing.T) {
+	rec := httptest.NewRecorder()
+	adapter := newResponsesAdapter(rec, "78787878-7878-4878-8878-787878787878", nil)
+	adapter.stream = true
+	adapter.model = "llama"
+	adapter.WriteHeader(http.StatusOK)
+
+	adapter.handleChatStreamLine(`data: {"id":"chatcmpl_tool_only","model":"llama","choices":[{"delta":{"tool_calls":[{"index":0,"id":"call_lookup","type":"function","function":{"name":"lookup","arguments":"{\"q\":\"hi\"}"}}]}}]}`)
+	adapter.handleChatStreamLine(`data: [DONE]`)
+
+	body := rec.Body.String()
+	for _, want := range []string{
+		"event: response.function_call_arguments.delta",
+		`"output_index":0`,
+		"event: response.completed",
+		"data: [DONE]",
+	} {
+		if !strings.Contains(body, want) {
+			t.Fatalf("tool-only stream missing %q:\n%s", want, body)
+		}
+	}
+}
+
+func TestResponsesDisclosureIncludesEndpointOnlyWhenEnabled(t *testing.T) {
+	defaultDisclosure := (&Server{}).makeTier1Disclosure()
+	if !reflectDeepEqualStrings(defaultDisclosure.VerifiedModelSettlement.IncludedPaidEntrypoints, []string{"POST /v1/chat/completions"}) {
+		t.Fatalf("default included entrypoints=%v", defaultDisclosure.VerifiedModelSettlement.IncludedPaidEntrypoints)
+	}
+	cfg := config.Default()
+	cfg.Features.ResponsesAPIEnabled = true
+	enabledDisclosure := (&Server{cfg: cfg}).makeTier1Disclosure()
+	if !reflectDeepEqualStrings(enabledDisclosure.VerifiedModelSettlement.IncludedPaidEntrypoints, []string{"POST /v1/chat/completions", "POST /v1/responses"}) {
+		t.Fatalf("enabled included entrypoints=%v", enabledDisclosure.VerifiedModelSettlement.IncludedPaidEntrypoints)
+	}
+}
+
+func enableResponsesWithCoordinator(cfg *config.Config) {
+	cfg.Features.ResponsesAPIEnabled = true
+	cfg.Coordinator.BuyerURL = "http://coordinator.test"
+}
+
+func postResponses(t *testing.T, h http.Handler, bearer, body string, headers map[string]string) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodPost, "/v1/responses", strings.NewReader(body))
+	req.Header.Set("Authorization", "Bearer "+bearer)
+	req.Header.Set("Content-Type", "application/json")
+	for key, value := range headers {
+		req.Header.Set(key, value)
+	}
+	resp := httptest.NewRecorder()
+	h.ServeHTTP(resp, req)
+	return resp
+}
+
+func reflectDeepEqualStrings(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/phase5-gateway/internal/router/responses_test.go
+++ b/phase5-gateway/internal/router/responses_test.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync/atomic"
 	"testing"
 
 	"github.com/augstar/macprovider-gateway/internal/config"
@@ -104,6 +105,91 @@ func TestResponsesNonStreamingTranslatesThroughChatPipeline(t *testing.T) {
 	}
 }
 
+func TestResponsesIdlessDedupeNonStreamingReplaysResponsesWireFormat(t *testing.T) {
+	var hits atomic.Int32
+	client := &http.Client{Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+		hits.Add(1)
+		return responseWithBody(http.StatusOK, http.Header{"Content-Type": []string{"application/json"}}, `{
+			"id":"chatcmpl_idless_responses",
+			"object":"chat.completion",
+			"created":1782864000,
+			"model":"llama",
+			"usage":{"prompt_tokens":5,"completion_tokens":3,"total_tokens":8},
+			"choices":[{"index":0,"message":{"role":"assistant","content":"responses answer"},"finish_reason":"stop"}]
+		}`), nil
+	})}
+	h, store, _, cfg := newTestHarnessConfig(t, fakeOAuth{}, enableResponsesWithCoordinator, WithHTTPClient(client))
+	key := createAccountAndKey(t, store, cfg, "acct_responses_idless_nonstream")
+	body := `{"model":"llama","input":"hi","max_output_tokens":20,"store":false}`
+
+	first := postResponses(t, h, key, body, nil)
+	second := postResponses(t, h, key, body, nil)
+
+	if first.Code != http.StatusOK || second.Code != http.StatusOK {
+		t.Fatalf("statuses first=%d second=%d second_body=%s", first.Code, second.Code, second.Body.String())
+	}
+	if got := second.Header().Get(idlessDedupeHeader); got != idlessDedupeHeaderValue {
+		t.Fatalf("retry %s=%q want %q", idlessDedupeHeader, got, idlessDedupeHeaderValue)
+	}
+	if got := hits.Load(); got != 1 {
+		t.Fatalf("upstream dispatches=%d want 1", got)
+	}
+	if first.Body.String() != second.Body.String() {
+		t.Fatalf("replayed body differs:\n first=%s\nsecond=%s", first.Body.String(), second.Body.String())
+	}
+	if strings.Contains(second.Body.String(), `"chat.completion"`) || strings.Contains(second.Body.String(), `"choices"`) {
+		t.Fatalf("replayed chat wire format on Responses endpoint:\n%s", second.Body.String())
+	}
+	var payload map[string]any
+	if err := json.Unmarshal(second.Body.Bytes(), &payload); err != nil {
+		t.Fatalf("replayed response is not JSON: %v body=%s", err, second.Body.String())
+	}
+	if payload["object"] != "response" {
+		t.Fatalf("replayed object=%v want response body=%s", payload["object"], second.Body.String())
+	}
+}
+
+func TestResponsesIdlessDedupeStreamingReplaysResponsesWireFormat(t *testing.T) {
+	var hits atomic.Int32
+	stream := strings.Join([]string{
+		`data: {"id":"chatcmpl_idless_stream","model":"llama","choices":[{"delta":{"content":"hel"}}]}`,
+		`data: {"id":"chatcmpl_idless_stream","model":"llama","usage":{"prompt_tokens":4,"completion_tokens":2,"total_tokens":6},"choices":[{"delta":{"content":"lo"},"finish_reason":"stop"}]}`,
+		`data: [DONE]`,
+		``,
+	}, "\n\n")
+	client := &http.Client{Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+		hits.Add(1)
+		return responseWithBody(http.StatusOK, http.Header{"Content-Type": []string{"text/event-stream; charset=utf-8"}}, stream), nil
+	})}
+	h, store, _, cfg := newTestHarnessConfig(t, fakeOAuth{}, enableResponsesWithCoordinator, WithHTTPClient(client))
+	key := createAccountAndKey(t, store, cfg, "acct_responses_idless_stream")
+	body := `{"model":"llama","input":"hi","stream":true,"max_output_tokens":20,"store":false}`
+
+	first := postResponses(t, h, key, body, nil)
+	second := postResponses(t, h, key, body, nil)
+
+	if first.Code != http.StatusOK || second.Code != http.StatusOK {
+		t.Fatalf("statuses first=%d second=%d second_body=%s", first.Code, second.Code, second.Body.String())
+	}
+	if got := second.Header().Get(idlessDedupeHeader); got != idlessDedupeHeaderValue {
+		t.Fatalf("retry %s=%q want %q", idlessDedupeHeader, got, idlessDedupeHeaderValue)
+	}
+	if got := hits.Load(); got != 1 {
+		t.Fatalf("upstream dispatches=%d want 1", got)
+	}
+	if first.Body.String() != second.Body.String() {
+		t.Fatalf("replayed stream differs:\n first=%s\nsecond=%s", first.Body.String(), second.Body.String())
+	}
+	for _, want := range []string{"event: response.created", "event: response.output_text.delta", "event: response.completed", "data: [DONE]"} {
+		if !strings.Contains(second.Body.String(), want) {
+			t.Fatalf("replayed Responses stream missing %q:\n%s", want, second.Body.String())
+		}
+	}
+	if strings.Contains(second.Body.String(), `"choices"`) {
+		t.Fatalf("replayed chat SSE on Responses endpoint:\n%s", second.Body.String())
+	}
+}
+
 func TestResponsesCodex0146DefaultToolsAreFlattened(t *testing.T) {
 	var capturedBody map[string]any
 	client := &http.Client{Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
@@ -161,6 +247,13 @@ func TestResponsesCodex0146DefaultToolsAreFlattened(t *testing.T) {
 	if _, ok := capturedBody["reasoning"]; ok {
 		t.Fatalf("forwarded Responses reasoning control: %v", capturedBody["reasoning"])
 	}
+	var responseBody map[string]any
+	if err := json.Unmarshal(resp.Body.Bytes(), &responseBody); err != nil {
+		t.Fatalf("decode response: %v body=%s", err, resp.Body.String())
+	}
+	if got, ok := responseBody["parallel_tool_calls"].(bool); !ok || got {
+		t.Fatalf("response parallel_tool_calls=%v want false", responseBody["parallel_tool_calls"])
+	}
 	tools := capturedBody["tools"].([]any)
 	wantNames := []string{
 		"exec_command",
@@ -201,6 +294,27 @@ func TestResponsesCodex0146DefaultToolsAreFlattened(t *testing.T) {
 			t.Fatalf("missing forwarded tool %q in %v", name, tools)
 		}
 	}
+	responseTools := responseBody["tools"].([]any)
+	if len(responseTools) != len(wantNames) {
+		t.Fatalf("response tool count=%d want %d tools=%v", len(responseTools), len(wantNames), responseTools)
+	}
+	responseToolNames := make(map[string]bool, len(responseTools))
+	for _, raw := range responseTools {
+		tool := raw.(map[string]any)
+		if tool["type"] != "function" {
+			t.Fatalf("response echoed non-function tool: %v", tool)
+		}
+		name := tool["name"].(string)
+		if name == "multi_agent_v1" || name == "web_search" {
+			t.Fatalf("response echoed dropped tool %q in %v", name, responseTools)
+		}
+		responseToolNames[name] = true
+	}
+	for _, name := range wantNames {
+		if !responseToolNames[name] {
+			t.Fatalf("response missing echoed forwarded tool %q in %v", name, responseTools)
+		}
+	}
 }
 
 func TestResponsesUnknownHostedToolTypeIsAcceptedAndDropped(t *testing.T) {
@@ -234,6 +348,13 @@ func TestResponsesUnknownHostedToolTypeIsAcceptedAndDropped(t *testing.T) {
 	if _, ok := capturedBody["tools"]; ok {
 		t.Fatalf("forwarded tools for dropped hosted tool: %v", capturedBody["tools"])
 	}
+	var responseBody map[string]any
+	if err := json.Unmarshal(resp.Body.Bytes(), &responseBody); err != nil {
+		t.Fatalf("decode response: %v body=%s", err, resp.Body.String())
+	}
+	if tools, ok := responseBody["tools"].([]any); ok && len(tools) > 0 {
+		t.Fatalf("response echoed dropped hosted tool: %v", tools)
+	}
 }
 
 func TestResponsesNonStreamingLengthFinishReasonIsIncomplete(t *testing.T) {
@@ -263,11 +384,112 @@ func TestResponsesNonStreamingLengthFinishReasonIsIncomplete(t *testing.T) {
 	}
 }
 
+func TestResponsesNonStreamingContentFilterFinishReasonIsIncomplete(t *testing.T) {
+	adapter := newResponsesAdapter(httptest.NewRecorder(), "28282828-2828-4282-8282-282828282828", nil)
+	adapter.model = "llama"
+
+	body, err := adapter.translateNonStreamingResponse([]byte(`{
+		"id":"chatcmpl_content_filter",
+		"created":1782864000,
+		"model":"llama",
+		"usage":{"prompt_tokens":5,"completion_tokens":4,"total_tokens":9},
+		"choices":[{"message":{"role":"assistant","content":"filtered partial"},"finish_reason":"content_filter"}]
+	}`))
+	if err != nil {
+		t.Fatalf("translate response: %v", err)
+	}
+	var resp map[string]any
+	if err := json.Unmarshal(body, &resp); err != nil {
+		t.Fatalf("responses json: %v", err)
+	}
+	if resp["status"] != "incomplete" {
+		t.Fatalf("status=%v want incomplete body=%s", resp["status"], string(body))
+	}
+	details := resp["incomplete_details"].(map[string]any)
+	if details["reason"] != "content_filter" {
+		t.Fatalf("incomplete_details=%v want content_filter", details)
+	}
+}
+
+func TestResponsesNonStreamingTranslatesRefusal(t *testing.T) {
+	adapter := newResponsesAdapter(httptest.NewRecorder(), "26262626-2626-4262-8262-262626262626", nil)
+	adapter.model = "llama"
+
+	body, err := adapter.translateNonStreamingResponse([]byte(`{
+		"id":"chatcmpl_refusal",
+		"created":1782864000,
+		"model":"llama",
+		"usage":{"prompt_tokens":5,"completion_tokens":4,"total_tokens":9},
+		"choices":[{"message":{"role":"assistant","refusal":"I cannot help with that."},"finish_reason":"stop"}]
+	}`))
+	if err != nil {
+		t.Fatalf("translate response: %v", err)
+	}
+	var resp map[string]any
+	if err := json.Unmarshal(body, &resp); err != nil {
+		t.Fatalf("responses json: %v body=%s", err, string(body))
+	}
+	output := resp["output"].([]any)
+	message := output[0].(map[string]any)
+	content := message["content"].([]any)
+	if got := content[0].(map[string]any)["text"]; got != "I cannot help with that." {
+		t.Fatalf("refusal text=%v want visible refusal body=%s", got, string(body))
+	}
+}
+
+func TestResponsesNonStreamingTranslatesLegacyFunctionCall(t *testing.T) {
+	adapter := newResponsesAdapter(httptest.NewRecorder(), "27272727-2727-4272-8272-272727272727", nil)
+	adapter.model = "llama"
+
+	body, err := adapter.translateNonStreamingResponse([]byte(`{
+		"id":"chatcmpl_legacy_function_call",
+		"created":1782864000,
+		"model":"llama",
+		"usage":{"prompt_tokens":5,"completion_tokens":4,"total_tokens":9},
+		"choices":[{"message":{"role":"assistant","function_call":{"name":"lookup","arguments":"{\"q\":\"hi\"}"}},"finish_reason":"function_call"}]
+	}`))
+	if err != nil {
+		t.Fatalf("translate response: %v", err)
+	}
+	var resp map[string]any
+	if err := json.Unmarshal(body, &resp); err != nil {
+		t.Fatalf("responses json: %v body=%s", err, string(body))
+	}
+	output := resp["output"].([]any)
+	call := output[0].(map[string]any)
+	if call["type"] != "function_call" || call["name"] != "lookup" || call["arguments"] != `{"q":"hi"}` {
+		t.Fatalf("legacy function_call not translated: %v body=%s", call, string(body))
+	}
+}
+
+func TestResponsesNonStreamingStripsUnterminatedThinkBlock(t *testing.T) {
+	adapter := newResponsesAdapter(httptest.NewRecorder(), "25252525-2525-4252-8252-252525252525", nil)
+	adapter.model = "llama"
+
+	body, err := adapter.translateNonStreamingResponse([]byte(`{
+		"id":"chatcmpl_truncated_think",
+		"created":1782864000,
+		"model":"llama",
+		"usage":{"prompt_tokens":5,"completion_tokens":20,"total_tokens":25},
+		"choices":[{"message":{"role":"assistant","content":"visible <think>secret"},"finish_reason":"length"}]
+	}`))
+	if err != nil {
+		t.Fatalf("translate response: %v", err)
+	}
+	if strings.Contains(string(body), "secret") || strings.Contains(string(body), "<think") {
+		t.Fatalf("unterminated think block leaked: %s", string(body))
+	}
+	if !strings.Contains(string(body), `"text":"visible"`) {
+		t.Fatalf("visible text missing after think strip: %s", string(body))
+	}
+}
+
 func TestResponsesRejectsUnsupportedStateBeforeReservation(t *testing.T) {
 	tests := []struct {
-		name string
-		body string
-		code string
+		name  string
+		body  string
+		code  string
+		param string
 	}{
 		{name: "store_true", body: `{"model":"llama","input":"hi","store":true}`, code: "unsupported_parameter"},
 		{name: "previous_response_id", body: `{"model":"llama","input":"hi","store":false,"previous_response_id":"resp_123"}`, code: "unsupported_parameter"},
@@ -276,6 +498,9 @@ func TestResponsesRejectsUnsupportedStateBeforeReservation(t *testing.T) {
 		{name: "conversation", body: `{"model":"llama","input":"hi","store":false,"conversation":{"id":"conv_123"}}`, code: "unsupported_parameter"},
 		{name: "background", body: `{"model":"llama","input":"hi","store":false,"background":true}`, code: "unsupported_parameter"},
 		{name: "truncation_auto", body: `{"model":"llama","input":"hi","store":false,"truncation":"auto"}`, code: "unsupported_parameter"},
+		{name: "required_tool_choice_only_dropped_tool", body: `{"model":"llama","input":"hi","store":false,"tool_choice":"required","tools":[{"type":"future_hosted_tool","name":"future_search"}]}`, code: "unsupported_parameter", param: "tool_choice"},
+		{name: "specific_tool_choice_missing_flattened_tool", body: `{"model":"llama","input":"hi","store":false,"tool_choice":{"type":"function","name":"missing"},"tools":[{"type":"function","name":"lookup","parameters":{"type":"object"}}]}`, code: "unsupported_parameter", param: "tool_choice"},
+		{name: "colliding_flattened_tool_names", body: `{"model":"llama","input":"hi","store":false,"tools":[{"type":"function","name":"lookup","parameters":{"type":"object"}},{"type":"namespace","name":"ns","tools":[{"type":"function","name":"lookup","parameters":{"type":"object"}}]}]}`, code: "unsupported_parameter", param: "tools"},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
@@ -294,6 +519,19 @@ func TestResponsesRejectsUnsupportedStateBeforeReservation(t *testing.T) {
 				t.Fatalf("status=%d want 400 body=%s", resp.Code, resp.Body.String())
 			}
 			assertErrorCode(t, resp.Body.String(), tc.code)
+			if tc.param != "" {
+				var payload struct {
+					Error struct {
+						Param any `json:"param"`
+					} `json:"error"`
+				}
+				if err := json.Unmarshal(resp.Body.Bytes(), &payload); err != nil {
+					t.Fatalf("decode error response: %v body=%s", err, resp.Body.String())
+				}
+				if payload.Error.Param != tc.param {
+					t.Fatalf("error param=%v want %s body=%s", payload.Error.Param, tc.param, resp.Body.String())
+				}
+			}
 			if called {
 				t.Fatalf("coordinator was called for rejected request")
 			}
@@ -413,6 +651,118 @@ func TestResponsesNonStreamingInvalidProviderResponseDoesNotSettleOK(t *testing.
 	}
 }
 
+func TestResponsesNonStreamingEmptyStopCompletionSettlesOK(t *testing.T) {
+	client := &http.Client{Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+		return responseWithBody(http.StatusOK, http.Header{"Content-Type": []string{"application/json"}}, `{
+			"id":"chatcmpl_empty_stop",
+			"object":"chat.completion",
+			"created":1782864000,
+			"model":"llama",
+			"usage":{"prompt_tokens":11,"completion_tokens":0,"total_tokens":11},
+			"choices":[{"index":0,"message":{"role":"assistant","content":"<think>hidden</think>"},"finish_reason":"stop"}]
+		}`), nil
+	})}
+	h, store, dbPath, cfg := newTestHarnessConfig(t, fakeOAuth{}, enableResponsesWithCoordinator, WithHTTPClient(client))
+	key := createAccountAndKey(t, store, cfg, "acct_responses_empty_stop")
+
+	resp := postResponses(t, h, key, `{"model":"llama","input":"hi","max_output_tokens":20,"store":false}`, map[string]string{"X-Request-ID": "29292929-2929-4292-8292-292929292929"})
+
+	if resp.Code != http.StatusOK {
+		t.Fatalf("status=%d want 200 body=%s", resp.Code, resp.Body.String())
+	}
+	var payload map[string]any
+	if err := json.Unmarshal(resp.Body.Bytes(), &payload); err != nil {
+		t.Fatalf("responses json: %v body=%s", err, resp.Body.String())
+	}
+	if payload["status"] != "completed" {
+		t.Fatalf("status=%v want completed body=%s", payload["status"], resp.Body.String())
+	}
+	output := payload["output"].([]any)
+	if len(output) != 0 {
+		t.Fatalf("output=%v want empty output array", output)
+	}
+	outcome, source, completion, prompt := usageEventOutcomeAndTokens(t, dbPath, "acct_responses_empty_stop")
+	if outcome != "ok" || source != "provider_reported" || prompt != 11 || completion != 0 {
+		t.Fatalf("usage outcome/source/prompt/completion=%s/%s/%d/%d want ok/provider_reported/11/0", outcome, source, prompt, completion)
+	}
+}
+
+func TestResponsesNonStreamingEmptyChoicesInvalidProviderResponseDoesNotSettleOK(t *testing.T) {
+	tests := []struct {
+		name     string
+		upstream string
+	}{
+		{
+			name: "empty",
+			upstream: `{
+				"id":"chatcmpl_empty_choices",
+				"object":"chat.completion",
+				"created":1782864000,
+				"model":"llama",
+				"usage":{"prompt_tokens":11,"completion_tokens":7,"total_tokens":18},
+				"choices":[]
+			}`,
+		},
+		{
+			name: "missing",
+			upstream: `{
+				"id":"chatcmpl_missing_choices",
+				"object":"chat.completion",
+				"created":1782864000,
+				"model":"llama",
+				"usage":{"prompt_tokens":11,"completion_tokens":7,"total_tokens":18}
+			}`,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			client := &http.Client{Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+				return responseWithBody(http.StatusOK, http.Header{"Content-Type": []string{"application/json"}}, tc.upstream), nil
+			})}
+			h, store, dbPath, cfg := newTestHarnessConfig(t, fakeOAuth{}, enableResponsesWithCoordinator, WithHTTPClient(client))
+			acct := "acct_responses_empty_choices_" + tc.name
+			key := createAccountAndKey(t, store, cfg, acct)
+
+			resp := postResponses(t, h, key, `{"model":"llama","input":"hi","max_output_tokens":20,"store":false}`, map[string]string{"X-Request-ID": newUUID()})
+
+			if resp.Code != http.StatusBadGateway {
+				t.Fatalf("status=%d want 502 body=%s", resp.Code, resp.Body.String())
+			}
+			assertErrorCode(t, resp.Body.String(), "invalid_provider_response")
+			outcome, source, completion, prompt := usageEventOutcomeAndTokens(t, dbPath, acct)
+			if outcome != "invalid_provider_response" || source != "provider_reported" || prompt != 11 || completion != 7 {
+				t.Fatalf("usage outcome/source/prompt/completion=%s/%s/%d/%d want invalid_provider_response/provider_reported/11/7", outcome, source, prompt, completion)
+			}
+		})
+	}
+}
+
+func TestResponsesNonStreamingTranslationFailureSettlesParsedProviderUsage(t *testing.T) {
+	client := &http.Client{Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+		return responseWithBody(http.StatusOK, http.Header{"Content-Type": []string{"application/json"}}, `{
+			"id":"chatcmpl_bad_choices",
+			"object":"chat.completion",
+			"created":1782864000,
+			"model":"llama",
+			"usage":{"prompt_tokens":11,"completion_tokens":7,"total_tokens":18},
+			"choices":{"not":"an array"}
+		}`), nil
+	})}
+	h, store, dbPath, cfg := newTestHarnessConfig(t, fakeOAuth{}, enableResponsesWithCoordinator, WithHTTPClient(client))
+	key := createAccountAndKey(t, store, cfg, "acct_responses_invalid_translation_with_usage")
+
+	resp := postResponses(t, h, key, `{"model":"llama","input":"hi","max_output_tokens":20,"store":false}`, map[string]string{"X-Request-ID": "24242424-2424-4242-8242-242424242424"})
+
+	if resp.Code != http.StatusBadGateway {
+		t.Fatalf("status=%d want 502 body=%s", resp.Code, resp.Body.String())
+	}
+	assertErrorCode(t, resp.Body.String(), "invalid_provider_response")
+	outcome, source, completion, prompt := usageEventOutcomeAndTokens(t, dbPath, "acct_responses_invalid_translation_with_usage")
+	if outcome != "invalid_provider_response" || source != "provider_reported" || prompt != 11 || completion != 7 {
+		t.Fatalf("usage outcome/source/prompt/completion=%s/%s/%d/%d want invalid_provider_response/provider_reported/11/7", outcome, source, prompt, completion)
+	}
+}
+
 func TestResponsesInputFunctionCallUsesCallIDForChatToolID(t *testing.T) {
 	adapter := newResponsesAdapter(httptest.NewRecorder(), "56565656-5656-4656-8656-565656565656", nil)
 
@@ -476,6 +826,7 @@ func TestResponsesStreamingTextAndToolEvents(t *testing.T) {
 	for _, want := range []string{
 		"event: response.created",
 		"event: response.output_text.delta",
+		`"output":[]`,
 		`"status":"in_progress"`,
 		`"delta":"hel"`,
 		"event: response.function_call_arguments.delta",
@@ -497,6 +848,89 @@ func TestResponsesStreamingTextAndToolEvents(t *testing.T) {
 	}
 }
 
+func TestResponsesStreamingRefusalAndLegacyFunctionCallEvents(t *testing.T) {
+	rec := httptest.NewRecorder()
+	adapter := newResponsesAdapter(rec, "46464646-4646-4646-8646-464646464646", nil)
+	adapter.stream = true
+	adapter.model = "llama"
+	adapter.WriteHeader(http.StatusOK)
+
+	adapter.handleChatStreamLine(`data: {"id":"chatcmpl_refusal_fc","model":"llama","choices":[{"delta":{"refusal":"cannot comply"}}]}`)
+	adapter.handleChatStreamLine(`data: {"id":"chatcmpl_refusal_fc","model":"llama","choices":[{"delta":{"function_call":{"name":"lookup","arguments":"{\"q\":\"hi\"}"}}}]}`)
+	adapter.handleChatStreamLine(`data: [DONE]`)
+
+	body := rec.Body.String()
+	for _, want := range []string{
+		"event: response.output_text.delta",
+		`"delta":"cannot comply"`,
+		"event: response.function_call_arguments.delta",
+		"event: response.function_call_arguments.done",
+		`"name":"lookup"`,
+		`\"q\":\"hi\"`,
+		"event: response.completed",
+		"data: [DONE]",
+	} {
+		if !strings.Contains(body, want) {
+			t.Fatalf("stream missing %q:\n%s", want, body)
+		}
+	}
+}
+
+func TestResponsesStreamingCleanEOFEmitsTerminalDone(t *testing.T) {
+	rec := httptest.NewRecorder()
+	adapter := newResponsesAdapter(rec, "47474747-4747-4747-8747-474747474747", nil)
+	adapter.stream = true
+	adapter.model = "llama"
+	adapter.WriteHeader(http.StatusOK)
+
+	if _, err := adapter.Write([]byte(`data: {"id":"chatcmpl_clean_eof","model":"llama","usage":{"prompt_tokens":3,"completion_tokens":2,"total_tokens":5},"choices":[{"delta":{"content":"ok"},"finish_reason":"stop"}]}`)); err != nil {
+		t.Fatalf("write stream chunk: %v", err)
+	}
+	adapter.finish()
+
+	body := rec.Body.String()
+	for _, want := range []string{
+		`"delta":"ok"`,
+		"event: response.completed",
+		`"input_tokens":3`,
+		"data: [DONE]",
+	} {
+		if !strings.Contains(body, want) {
+			t.Fatalf("clean EOF stream missing %q:\n%s", want, body)
+		}
+	}
+	if strings.Contains(body, "event: response.failed") {
+		t.Fatalf("clean EOF stream emitted failed:\n%s", body)
+	}
+}
+
+func TestResponsesStreamingContentFilterFinishReasonIsIncomplete(t *testing.T) {
+	rec := httptest.NewRecorder()
+	adapter := newResponsesAdapter(rec, "48484848-4848-4848-8848-484848484848", nil)
+	adapter.stream = true
+	adapter.model = "llama"
+	adapter.WriteHeader(http.StatusOK)
+
+	adapter.handleChatStreamLine(`data: {"id":"chatcmpl_stream_filter","model":"llama","usage":{"prompt_tokens":3,"completion_tokens":1,"total_tokens":4},"choices":[{"delta":{},"finish_reason":"content_filter"}]}`)
+	adapter.handleChatStreamLine(`data: [DONE]`)
+
+	body := rec.Body.String()
+	for _, want := range []string{
+		"event: response.incomplete",
+		`"status":"incomplete"`,
+		`"reason":"content_filter"`,
+		`"output":[]`,
+		"data: [DONE]",
+	} {
+		if !strings.Contains(body, want) {
+			t.Fatalf("content-filter stream missing %q:\n%s", want, body)
+		}
+	}
+	if strings.Contains(body, "event: response.completed") {
+		t.Fatalf("content-filter stream emitted completed:\n%s", body)
+	}
+}
+
 func TestResponsesStreamingChatErrorBecomesFailedTerminal(t *testing.T) {
 	rec := httptest.NewRecorder()
 	adapter := newResponsesAdapter(rec, "67676767-6767-4676-8676-676767676767", nil)
@@ -511,6 +945,7 @@ func TestResponsesStreamingChatErrorBecomesFailedTerminal(t *testing.T) {
 	for _, want := range []string{
 		"event: response.failed",
 		`"status":"failed"`,
+		`"output":[]`,
 		`"code":"provider_timeout"`,
 		"data: [DONE]",
 	} {
@@ -599,11 +1034,17 @@ func TestResponsesDisclosureIncludesEndpointOnlyWhenEnabled(t *testing.T) {
 	if !reflectDeepEqualStrings(defaultDisclosure.VerifiedModelSettlement.IncludedPaidEntrypoints, []string{"POST /v1/chat/completions"}) {
 		t.Fatalf("default included entrypoints=%v", defaultDisclosure.VerifiedModelSettlement.IncludedPaidEntrypoints)
 	}
+	if strings.Contains(defaultDisclosure.VerifiedModelSettlement.EnforceMode, "POST /v1/responses") {
+		t.Fatalf("default enforce disclosure mentions disabled responses endpoint: %q", defaultDisclosure.VerifiedModelSettlement.EnforceMode)
+	}
 	cfg := config.Default()
 	cfg.Features.ResponsesAPIEnabled = true
 	enabledDisclosure := (&Server{cfg: cfg}).makeTier1Disclosure()
 	if !reflectDeepEqualStrings(enabledDisclosure.VerifiedModelSettlement.IncludedPaidEntrypoints, []string{"POST /v1/chat/completions", "POST /v1/responses"}) {
 		t.Fatalf("enabled included entrypoints=%v", enabledDisclosure.VerifiedModelSettlement.IncludedPaidEntrypoints)
+	}
+	if !strings.Contains(enabledDisclosure.VerifiedModelSettlement.EnforceMode, "POST /v1/responses") {
+		t.Fatalf("enabled enforce disclosure omits responses endpoint: %q", enabledDisclosure.VerifiedModelSettlement.EnforceMode)
 	}
 }
 

--- a/phase5-gateway/internal/router/responses_test.go
+++ b/phase5-gateway/internal/router/responses_test.go
@@ -104,6 +104,138 @@ func TestResponsesNonStreamingTranslatesThroughChatPipeline(t *testing.T) {
 	}
 }
 
+func TestResponsesCodex0146DefaultToolsAreFlattened(t *testing.T) {
+	var capturedBody map[string]any
+	client := &http.Client{Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+		if err := json.NewDecoder(r.Body).Decode(&capturedBody); err != nil {
+			t.Fatalf("decode upstream request: %v", err)
+		}
+		return responseWithBody(http.StatusOK, http.Header{"Content-Type": []string{"application/json"}}, `{
+			"id":"chatcmpl_codex_tools",
+			"object":"chat.completion",
+			"created":1782864000,
+			"model":"llama",
+			"usage":{"prompt_tokens":5,"completion_tokens":3,"total_tokens":8},
+			"choices":[{"index":0,"message":{"role":"assistant","content":"ok"},"finish_reason":"stop"}]
+		}`), nil
+	})}
+	h, store, _, cfg := newTestHarnessConfig(t, fakeOAuth{}, enableResponsesWithCoordinator, WithHTTPClient(client))
+	key := createAccountAndKey(t, store, cfg, "acct_responses_codex_0146_tools")
+
+	resp := postResponses(t, h, key, `{
+		"model":"llama",
+		"input":"hi",
+		"include":["reasoning.encrypted_content"],
+		"reasoning":{"summary":"auto"},
+		"parallel_tool_calls":false,
+		"store":false,
+		"tools":[
+			{"type":"function","name":"exec_command","description":"Run a command","parameters":{"type":"object"},"strict":true},
+			{"type":"function","name":"write_stdin","description":"Write to a command","parameters":{"type":"object"},"strict":true},
+			{"type":"function","name":"update_plan","description":"Update the plan","parameters":{"type":"object"},"strict":true},
+			{"type":"function","name":"request_user_input","description":"Ask for user input","parameters":{"type":"object"},"strict":true},
+			{"type":"function","name":"view_image","description":"View an image","parameters":{"type":"object"},"strict":true},
+			{"type":"namespace","name":"multi_agent_v1","tools":[
+				{"type":"function","name":"close_agent","description":"Close an agent","parameters":{"type":"object"},"strict":true},
+				{"type":"function","name":"resume_agent","description":"Resume an agent","parameters":{"type":"object"},"strict":true},
+				{"type":"function","name":"send_input","description":"Send input to an agent","parameters":{"type":"object"},"strict":true},
+				{"type":"function","name":"spawn_agent","description":"Spawn an agent","parameters":{"type":"object"},"strict":true},
+				{"type":"function","name":"wait_agent","description":"Wait for an agent","parameters":{"type":"object"},"strict":true}
+			]},
+			{"type":"function","name":"get_goal","description":"Get the current goal","parameters":{"type":"object"},"strict":true},
+			{"type":"function","name":"create_goal","description":"Create a goal","parameters":{"type":"object"},"strict":true},
+			{"type":"function","name":"update_goal","description":"Update the goal","parameters":{"type":"object"},"strict":true},
+			{"type":"web_search","external_web_access":true}
+		]
+	}`, nil)
+
+	if resp.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s", resp.Code, resp.Body.String())
+	}
+	if parallelToolCalls, ok := capturedBody["parallel_tool_calls"].(bool); !ok || parallelToolCalls {
+		t.Fatalf("forwarded parallel_tool_calls=%v want false", capturedBody["parallel_tool_calls"])
+	}
+	if _, ok := capturedBody["include"]; ok {
+		t.Fatalf("forwarded Responses include control: %v", capturedBody["include"])
+	}
+	if _, ok := capturedBody["reasoning"]; ok {
+		t.Fatalf("forwarded Responses reasoning control: %v", capturedBody["reasoning"])
+	}
+	tools := capturedBody["tools"].([]any)
+	wantNames := []string{
+		"exec_command",
+		"write_stdin",
+		"update_plan",
+		"request_user_input",
+		"view_image",
+		"close_agent",
+		"resume_agent",
+		"send_input",
+		"spawn_agent",
+		"wait_agent",
+		"get_goal",
+		"create_goal",
+		"update_goal",
+	}
+	if len(tools) != len(wantNames) {
+		t.Fatalf("forwarded tool count=%d want %d tools=%v", len(tools), len(wantNames), tools)
+	}
+	gotNames := make(map[string]bool, len(tools))
+	for _, raw := range tools {
+		tool := raw.(map[string]any)
+		if tool["type"] != "function" {
+			t.Fatalf("forwarded non-function tool: %v", tool)
+		}
+		fn := tool["function"].(map[string]any)
+		name := fn["name"].(string)
+		if name == "multi_agent_v1" || name == "web_search" {
+			t.Fatalf("forwarded dropped tool %q in %v", name, tools)
+		}
+		if fn["parameters"].(map[string]any)["type"] != "object" {
+			t.Fatalf("tool parameters not preserved for %q: %v", name, fn)
+		}
+		gotNames[name] = true
+	}
+	for _, name := range wantNames {
+		if !gotNames[name] {
+			t.Fatalf("missing forwarded tool %q in %v", name, tools)
+		}
+	}
+}
+
+func TestResponsesUnknownHostedToolTypeIsAcceptedAndDropped(t *testing.T) {
+	var capturedBody map[string]any
+	client := &http.Client{Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+		if err := json.NewDecoder(r.Body).Decode(&capturedBody); err != nil {
+			t.Fatalf("decode upstream request: %v", err)
+		}
+		return responseWithBody(http.StatusOK, http.Header{"Content-Type": []string{"application/json"}}, `{
+			"id":"chatcmpl_unknown_hosted_tool",
+			"object":"chat.completion",
+			"created":1782864000,
+			"model":"llama",
+			"usage":{"prompt_tokens":5,"completion_tokens":3,"total_tokens":8},
+			"choices":[{"index":0,"message":{"role":"assistant","content":"ok"},"finish_reason":"stop"}]
+		}`), nil
+	})}
+	h, store, _, cfg := newTestHarnessConfig(t, fakeOAuth{}, enableResponsesWithCoordinator, WithHTTPClient(client))
+	key := createAccountAndKey(t, store, cfg, "acct_responses_unknown_hosted_tool")
+
+	resp := postResponses(t, h, key, `{
+		"model":"llama",
+		"input":"hi",
+		"store":false,
+		"tools":[{"type":"future_hosted_tool","name":"future_search"}]
+	}`, nil)
+
+	if resp.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s", resp.Code, resp.Body.String())
+	}
+	if _, ok := capturedBody["tools"]; ok {
+		t.Fatalf("forwarded tools for dropped hosted tool: %v", capturedBody["tools"])
+	}
+}
+
 func TestResponsesNonStreamingLengthFinishReasonIsIncomplete(t *testing.T) {
 	adapter := newResponsesAdapter(httptest.NewRecorder(), "23232323-2323-4232-8232-232323232323", nil)
 	adapter.model = "llama"
@@ -139,15 +271,11 @@ func TestResponsesRejectsUnsupportedStateBeforeReservation(t *testing.T) {
 	}{
 		{name: "store_true", body: `{"model":"llama","input":"hi","store":true}`, code: "unsupported_parameter"},
 		{name: "previous_response_id", body: `{"model":"llama","input":"hi","store":false,"previous_response_id":"resp_123"}`, code: "unsupported_parameter"},
-		{name: "hosted_tool", body: `{"model":"llama","input":"hi","store":false,"tools":[{"type":"web_search_preview"}]}`, code: "unsupported_parameter"},
 		{name: "multimodal_content", body: `{"model":"llama","input":[{"role":"user","content":[{"type":"input_image","image_url":"https://example.invalid/a.png"}]}],"store":false}`, code: "invalid_request"},
 		{name: "legacy_response_format", body: `{"model":"llama","input":"hi","store":false,"response_format":{"type":"json_object"}}`, code: "unsupported_parameter"},
 		{name: "conversation", body: `{"model":"llama","input":"hi","store":false,"conversation":{"id":"conv_123"}}`, code: "unsupported_parameter"},
-		{name: "include", body: `{"model":"llama","input":"hi","store":false,"include":["file_search_call.results"]}`, code: "unsupported_parameter"},
 		{name: "background", body: `{"model":"llama","input":"hi","store":false,"background":true}`, code: "unsupported_parameter"},
 		{name: "truncation_auto", body: `{"model":"llama","input":"hi","store":false,"truncation":"auto"}`, code: "unsupported_parameter"},
-		{name: "reasoning", body: `{"model":"llama","input":"hi","store":false,"reasoning":{"effort":"low"}}`, code: "unsupported_parameter"},
-		{name: "parallel_tool_calls_false", body: `{"model":"llama","input":"hi","store":false,"parallel_tool_calls":false}`, code: "unsupported_parameter"},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {

--- a/phase5-gateway/internal/router/server.go
+++ b/phase5-gateway/internal/router/server.go
@@ -215,6 +215,9 @@ func (s *Server) Handler() http.Handler {
 	mux.Handle("/v1/models", s.withCORS(http.MethodGet, http.HandlerFunc(s.handleModels)))
 	mux.HandleFunc("/v1/usage", s.handleUsage)
 	mux.Handle("/v1/chat/completions", s.withCORS(http.MethodPost, http.HandlerFunc(s.handleChatCompletions)))
+	if s.cfg.Features.ResponsesAPIEnabled {
+		mux.Handle("/v1/responses", s.withCORS(http.MethodPost, http.HandlerFunc(s.handleResponses)))
+	}
 	mux.Handle("/v1/sticky", s.withCORS(http.MethodDelete, http.HandlerFunc(s.handleStickyDelete)))
 	mux.Handle("/v1/status", s.withCORS(http.MethodGet, http.HandlerFunc(s.handleStatus)))
 	mux.HandleFunc("/v1/feedback", s.handleFeedback)
@@ -385,7 +388,7 @@ func (s *Server) handleUsage(w http.ResponseWriter, r *http.Request) {
 			"window_date": window, "daily_tokens_used": used, "daily_tokens_reserved": reserved,
 			"daily_tokens_remaining": remaining, "daily_tokens_limit": limit,
 		},
-		"settlement_disclosure": makeVerifiedModelSettlementDisclosure(),
+		"settlement_disclosure": makeVerifiedModelSettlementDisclosure(s.cfg.Features.ResponsesAPIEnabled),
 		"capacity":              map[string]any{"tier": tier.Tier},
 		"keys":                  keys,
 		"models":                []any{},
@@ -914,9 +917,10 @@ var gatewayRetryableByCode = map[string]bool{
 	"rate_limited":               true,
 	// Gateway-generated transient/availability codes (no coordinator-body
 	// equivalent — the gateway itself constructs these envelopes).
-	"coordinator_unavailable": true,
-	"upstream_provider_error": true,
-	"invalid_provider_usage":  true,
+	"coordinator_unavailable":   true,
+	"upstream_provider_error":   true,
+	"invalid_provider_usage":    true,
+	"invalid_provider_response": true,
 	// rate_limit_exceeded-typed 429s that actually ship a backoff signal
 	// (Retry-After via setConcurrencyRateLimitHeaders, or X-RateLimit-Reset
 	// via setRateLimitHeaders) — H-R2. (signup_rate_limited was the one

--- a/phase5-gateway/internal/router/server_test.go
+++ b/phase5-gateway/internal/router/server_test.go
@@ -6176,7 +6176,7 @@ var gatewayEmittedErrorCodes = []string{
 	"invalid_feedback_source", "invalid_handoff", "invalid_kill_switch",
 	"invalid_kill_switch_version", "invalid_limit", "invalid_operator_token",
 	"invalid_provider_usage", "invalid_rating", "invalid_request",
-	"invalid_request_body", "invalid_request_id", "invalid_window",
+	"invalid_provider_response", "invalid_request_body", "invalid_request_id", "invalid_window",
 	"keys_load_failed", "max_tokens_exceeded", "method_not_allowed",
 	"missing_bearer_token", "n_must_be_1", "no_provider_available",
 	"nonce_unavailable", "not_found", "oauth_action_unknown",

--- a/phase5-gateway/internal/router/templates/docs.md
+++ b/phase5-gateway/internal/router/templates/docs.md
@@ -84,6 +84,7 @@ Primary buyer endpoints:
 | Method | Path | Auth |
 |---|---|---|
 | `POST` | `/v1/chat/completions` | Bearer API key or browser demo token |
+| `POST` | `/v1/responses` | Bearer API key or browser demo token; available when the Responses compatibility flag is enabled |
 | `GET` | `/v1/models` | Bearer API key or demo token |
 | `GET` | `/v1/status` | Public |
 | `GET` | `/v1/usage` | Bearer API key |
@@ -99,6 +100,12 @@ Multimodal parts such as `image_url` are not supported in v1 and return
 `unsupported_content_shape`.
 
 Covered paid settlement claims are limited to `POST /v1/chat/completions`. Buyer cancel, gateway timeout, provider error, or upstream disconnect can create a partial charge only when a settlement-capable receipt binds the delivered output prefix and partial usage.
+
+### Responses API
+
+`POST /v1/responses` is a stateless OpenAI Responses compatibility facade over the same billed chat-completions pipeline. Send the full `input` on every request with `store:false`. Function tools and `text.format` structured output are translated into the chat pipeline. `previous_response_id`, `store:true`, `conversation`, `include`, `background:true`, non-disabled `truncation`, `reasoning` controls, non-default `parallel_tool_calls`, hosted tools, and multimodal input are not supported.
+
+When the Responses compatibility flag is enabled, covered paid settlement claims include `POST /v1/responses` and `POST /v1/chat/completions`.
 
 Excluded legacy/direct paths are outside this SPEC-022 gateway settlement claim unless separately disabled or migrated behind the gateway paid ledger: `coordinator.streamvc.live`, `m4.streamvc.live`, and `m1.streamvc.live`.
 

--- a/phase5-gateway/internal/router/templates/docs.md
+++ b/phase5-gateway/internal/router/templates/docs.md
@@ -99,11 +99,11 @@ Text-only structured `messages[].content` arrays are accepted for `system` and
 Multimodal parts such as `image_url` are not supported in v1 and return
 `unsupported_content_shape`.
 
-Covered paid settlement claims are limited to `POST /v1/chat/completions`. Buyer cancel, gateway timeout, provider error, or upstream disconnect can create a partial charge only when a settlement-capable receipt binds the delivered output prefix and partial usage.
+Covered paid settlement claims are limited to `POST /v1/chat/completions`, plus `POST /v1/responses` when the Responses compatibility flag is enabled. Buyer cancel, gateway timeout, provider error, or upstream disconnect can create a partial charge only when a settlement-capable receipt binds the delivered output prefix and partial usage.
 
 ### Responses API
 
-`POST /v1/responses` is a stateless OpenAI Responses compatibility facade over the same billed chat-completions pipeline. Send the full `input` on every request with `store:false`. Function tools and `text.format` structured output are translated into the chat pipeline. `previous_response_id`, `store:true`, `conversation`, `include`, `background:true`, non-disabled `truncation`, `reasoning` controls, non-default `parallel_tool_calls`, hosted tools, and multimodal input are not supported.
+`POST /v1/responses` is a stateless OpenAI Responses compatibility facade over the same billed chat-completions pipeline. Send the full `input` on every request with `store:false`. Function tools and `text.format` structured output are translated into the chat pipeline. `include`, `reasoning` summary controls, and `parallel_tool_calls` are tolerated; unsupported hosted or unknown tools are dropped before provider dispatch. `previous_response_id`, `store:true`, `conversation`, `background:true`, non-disabled `truncation`, `response_format`, and multimodal input are not supported.
 
 When the Responses compatibility flag is enabled, covered paid settlement claims include `POST /v1/responses` and `POST /v1/chat/completions`.
 


### PR DESCRIPTION
## Summary

Implements issue #830 by adding a default-off `POST /v1/responses` compatibility facade in `phase5-gateway`.

The route translates stateless OpenAI Responses requests into the existing billed `/v1/chat/completions` pipeline. It preserves the current auth, quota reservation, upstream forwarding, settlement, receipt, and disclosure path rather than adding a parallel money path.

## What changed

- Adds `features.responses_api_enabled`, defaulting to `false`.
- Registers `POST /v1/responses` only when the feature flag is enabled.
- Translates Responses `input`, `instructions`, function tools, tool choice, `max_output_tokens`, streaming, and official `text.format` structured-output settings into chat-completions requests.
- Rejects unsupported or stateful Responses controls before reservation, including `store:true`, `previous_response_id`, `conversation`, unsupported `include`, `background:true`, non-disabled `truncation`, non-empty `reasoning`, non-default `parallel_tool_calls`, hosted tools, multimodal input, and legacy `response_format`.
- Converts chat responses and SSE frames back into SDK-parseable Responses objects/events, including tool-call events, failed/incomplete terminals, usage details, and stateful `<think>` filtering across stream chunks.
- Updates docs, config example, and settlement disclosure entrypoints when the feature is enabled.

## Validation

- `go test ./internal/router -run "TestResponses" -count=1`
- `go test ./...`
- `git diff --check`
- 3-lane Codex audit to 0 C/H/M:
  - Code lane: PASS 0 C/H/M
  - Security lane: PASS 0 C/H/M
  - Architect lane: PASS 0 C/H/M

## Not tested

- Live provider smoke.
- Codex 0.146+ end-to-end parsing against a deployed gateway.

Closes #830

---

## 3-lane audit (money-path)

A 4-round Codex audit (code / security / architect lanes via `omc ask codex`) was run against the full PR diff. Result: **Security clean (0/0/0), money-path integrity confirmed** — the architect lane verified settlement finality, quota reservation, retries, sticky routing, streaming failover, cancellation, and id-less dedupe are **not** bypassed by the adapter. All CRITICAL/HIGH/MEDIUM findings across rounds were fixed (see commits): unsatisfiable tool_choice, namespace collision, settlement under-count on translation failure, dropped refusal/legacy function_call output, missing stream terminal on clean EOF, cross-endpoint dedupe fingerprint/replay wire-format, empty-choices vs empty-content settlement, output null→[], content_filter→incomplete, and disclosure/docs consistency. Regression tests added for each; `go vet` + full `internal/router` suite green. Residual items are LOW/INFO only. Feature ships default-off (`features.responses_api_enabled: false`).

SPEC-GOVERNANCE-DECLARATION-BEGIN
{
  "schema_version": "spec-pr-governance-v1",
  "behavior_change": "yes",
  "contract_change": "none",
  "specs": ["SPEC-006", "SPEC-018"],
  "requirements": ["SPEC-018-R001"],
  "authority_domains": ["buyer-api-error-contract", "agentic-tool-calling"],
  "arbitration": ["CODE_BUG"],
  "tests": ["phase5-gateway/internal/router/responses_test.go"],
  "journeys": ["not-required"],
  "issue": "https://github.com/Augustas11/macprovider/issues/830"
}
SPEC-GOVERNANCE-DECLARATION-END
