### PR TITLE
fix(billing): emit usdc_* on provider /earnings so Malibu card shows real USD

### DIFF
--- a/audits/2026-07-30/AUDIT_EARNINGS_USDC_PROMPT.md
+++ b/audits/2026-07-30/AUDIT_EARNINGS_USDC_PROMPT.md
@@ -1,0 +1,35 @@
+# AUDIT — earnings usdc_* fix (fix/earnings-usdc-fields, money-path)
+
+Repo: /Users/augstar/macprovider-earnings-usdc. Audit the full diff of commit
+2c0f8bf9 vs origin/main (git diff origin/main -- phase4-coordinator/).
+
+## What it does
+The Malibu client (phase3-binary ProviderEarningsClient) decodes usdc_today/
+usdc_week/usdc_pending/usdc_lifetime, but the coordinator /providers/{id}/earnings
+endpoint (phase4-coordinator/internal/billing/endpoints.go earnings handler)
+emitted only *_credits — so every provider card showed $0.00 despite real
+payable credits. This adds the usdc_* fields.
+
+Changes:
+- billing/store.go: new usdPerMillionCreditsBits atomic.Uint64 +
+  SetUsdPerMillionCredits/UsdPerMillionCredits/creditsToUSD. NaN/Inf/neg → 0.
+- billing/endpoints.go earnings(): compute totalCredits/weekCredits/todayCredits
+  once; pending = total - paidOut (payouts not 'ready'/'voided'); emit
+  usdc_today/week/pending/lifetime = creditsToUSD(...).
+- cmd/coordinator/main.go: SetUsdPerMillionCredits at startup + SIGHUP reload
+  from cfg.Stats.Rollup.UsdPerMillionCredits.
+
+## Questions each lane must answer
+1. CODE: correctness of the credits→USD math + windows (today=midnight UTC,
+   week=Monday UTC, lifetime=all payable, pending=total-paidOut); float
+   precision/overflow; concurrency of the atomic rate read vs SIGHUP write;
+   any behavior change to existing *_credits fields or other response fields.
+2. SECURITY (money-path): can usdc_* mislead a provider about owed money?
+   pending semantics (is total-paidOut correct given payout statuses
+   'ready'/'voided'/paid)? Any way to over/under-report USD; NaN/Inf/negative
+   guarded; rate source trust (cfg.Stats.Rollup.UsdPerMillionCredits).
+3. ARCHITECT: is Store the right home for the rate; startup+reload wiring
+   complete and race-free; does this match the buyer-side usd_per_million
+   usage; any spec (SPEC-005 §11.4 earnings) contract concerns.
+
+## Bar: 0 CRITICAL / 0 HIGH / 0 MEDIUM. LOW/INFO may be carried.

--- a/phase4-coordinator/cmd/coordinator/main.go
+++ b/phase4-coordinator/cmd/coordinator/main.go
@@ -259,9 +259,6 @@ func main() {
 		os.Exit(1)
 	}
 	billingStore.SetForceCreditSettlementHoldSeconds(int64(cfg.Billing.ForceCreditSettlementHoldSeconds))
-	// Publish the credits→USD rate so the provider /earnings endpoint can fill
-	// the usdc_* fields the Malibu client displays (else every card shows $0.00).
-	billingStore.SetUsdPerMillionCredits(cfg.Stats.Rollup.UsdPerMillionCredits)
 	snapshotID, err := billingStore.InsertConfigSnapshot(context.Background(), cfg.Rewards, time.Now().UTC())
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "billing config snapshot: %v\n", err)
@@ -2397,8 +2394,6 @@ func reloadCoordinatorConfig(configPath string, startupTier2 config.Tier2Config,
 		}
 		buyerServer.SetBillingConfig(cfg.Rewards, snapshotID, cfg.Stats.Rollup.UsdPerMillionCredits)
 		billingStores[0].SetSettlementConfig(cfg.Settlement)
-		// Keep the provider /earnings usdc_* conversion rate in sync on SIGHUP.
-		billingStores[0].SetUsdPerMillionCredits(cfg.Stats.Rollup.UsdPerMillionCredits)
 		logger.Info().
 			Bool("billing.quarantine_resolution_force_void_enabled", cfg.Billing.QuarantineResolutionForceVoidEnabled).
 			Bool("billing.quarantine_resolution_force_credit_enabled", cfg.Billing.QuarantineResolutionForceCreditEnabled).

--- a/phase4-coordinator/cmd/coordinator/main.go
+++ b/phase4-coordinator/cmd/coordinator/main.go
@@ -259,6 +259,9 @@ func main() {
 		os.Exit(1)
 	}
 	billingStore.SetForceCreditSettlementHoldSeconds(int64(cfg.Billing.ForceCreditSettlementHoldSeconds))
+	// Publish the credits→USD rate so the provider /earnings endpoint can fill
+	// the usdc_* fields the Malibu client displays (else every card shows $0.00).
+	billingStore.SetUsdPerMillionCredits(cfg.Stats.Rollup.UsdPerMillionCredits)
 	snapshotID, err := billingStore.InsertConfigSnapshot(context.Background(), cfg.Rewards, time.Now().UTC())
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "billing config snapshot: %v\n", err)
@@ -2394,6 +2397,8 @@ func reloadCoordinatorConfig(configPath string, startupTier2 config.Tier2Config,
 		}
 		buyerServer.SetBillingConfig(cfg.Rewards, snapshotID, cfg.Stats.Rollup.UsdPerMillionCredits)
 		billingStores[0].SetSettlementConfig(cfg.Settlement)
+		// Keep the provider /earnings usdc_* conversion rate in sync on SIGHUP.
+		billingStores[0].SetUsdPerMillionCredits(cfg.Stats.Rollup.UsdPerMillionCredits)
 		logger.Info().
 			Bool("billing.quarantine_resolution_force_void_enabled", cfg.Billing.QuarantineResolutionForceVoidEnabled).
 			Bool("billing.quarantine_resolution_force_credit_enabled", cfg.Billing.QuarantineResolutionForceCreditEnabled).

--- a/phase4-coordinator/internal/billing/endpoints.go
+++ b/phase4-coordinator/internal/billing/endpoints.go
@@ -906,20 +906,24 @@ func (h *handler) earnings(w http.ResponseWriter, r *http.Request) {
 	todayArgs := append([]any{providerID, todayUTC}, rangeArgs...)
 	faultArgs := append([]any{providerID}, rangeArgs...)
 
-	// Payable provider_credits for the three windows the Malibu card shows
-	// (life / week / today). current_window == "this week" (since Monday UTC).
+	// Payable provider_credits for the range-scoped total plus the two rolling
+	// windows the Malibu card shows. current_window == "this week" (since Monday
+	// UTC); today == since midnight UTC. These honour any from/to range.
 	totalCredits := h.sum(r.Context(), `SELECT SUM(provider_credits) FROM spec022_payable_request_credits WHERE provider_id=?`+rangeSQL, totalArgs...)
 	weekCredits := h.sum(r.Context(), `SELECT SUM(provider_credits) FROM spec022_payable_request_credits WHERE provider_id=? AND `+sqliteTimeSince("ts_utc")+rangeSQL, currentArgs...)
 	todayCredits := h.sum(r.Context(), `SELECT SUM(provider_credits) FROM spec022_payable_request_credits WHERE provider_id=? AND `+sqliteTimeSince("ts_utc")+rangeSQL, todayArgs...)
-	// "Pending" = earned but not yet paid out. Any ledger_payout_ready row that
-	// is neither still-'ready' nor 'voided' represents credits already paid,
-	// so pending = total payable minus those. With payouts default-off (SPEC-016)
-	// this is 0 paid → pending == lifetime, which is the correct current state.
-	paidOutCredits := h.sum(r.Context(), `SELECT SUM(provider_credits) FROM ledger_payout_ready WHERE provider_id=? AND status NOT IN ('ready','voided')`, providerID)
-	pendingCredits := totalCredits - paidOutCredits
-	if pendingCredits < 0 {
-		pendingCredits = 0
-	}
+	// "Pending" = all USDC currently owed to the provider (earned, payout-
+	// eligible, not yet paid). It is a lifetime, range-INDEPENDENT figure — a
+	// from/to filter narrows the today/week/lifetime views but must never make
+	// owed money appear smaller — so it deliberately ignores rangeSQL. The
+	// SPEC-016 payout pipeline is default-off / not deployed, so no payable
+	// credit has been paid yet and every payable credit is still owed. When
+	// payouts go live, this must subtract only CONFIRMED, non-reorged/non-
+	// orphaned payouts (payout reorg/orphan compensation is tracked outside
+	// ledger_payout_ready — see internal/payout/reorg.go, orphans.go); a naive
+	// `status NOT IN ('ready','voided')` subtraction would UNDERSTATE owed money
+	// after an unresolved orphan, so it is intentionally not done here.
+	pendingCredits := h.sum(r.Context(), `SELECT SUM(provider_credits) FROM spec022_payable_request_credits WHERE provider_id=?`, providerID)
 
 	resp := map[string]any{
 		"provider_id":            providerID,
@@ -933,11 +937,14 @@ func (h *handler) earnings(w http.ResponseWriter, r *http.Request) {
 		// usdc_* are the USD figures the Malibu client (ProviderEarningsClient)
 		// decodes for the "today / wk / pending / life" card. Before this the
 		// endpoint emitted only *_credits, so every card read $0.00 regardless
-		// of real accrued earnings. Converted via the published rate.
-		"usdc_today":    h.store.creditsToUSD(todayCredits),
-		"usdc_week":     h.store.creditsToUSD(weekCredits),
-		"usdc_pending":  h.store.creditsToUSD(pendingCredits),
-		"usdc_lifetime": h.store.creditsToUSD(totalCredits),
+		// of real accrued earnings. Converted via the SPEC-016 §4.3 payout
+		// invariant (provider_credits == USDC base units, 6 decimals), so the
+		// displayed amount equals what the payout runner actually pays — not a
+		// tunable stats display rate that could diverge from real payouts.
+		"usdc_today":    providerCreditsToUSDC(todayCredits),
+		"usdc_week":     providerCreditsToUSDC(weekCredits),
+		"usdc_pending":  providerCreditsToUSDC(pendingCredits),
+		"usdc_lifetime": providerCreditsToUSDC(totalCredits),
 	}
 	idlePrewarm := statsprewarm.Summary{
 		EventsLast1h:        map[string]int64{},

--- a/phase4-coordinator/internal/billing/endpoints.go
+++ b/phase4-coordinator/internal/billing/endpoints.go
@@ -897,20 +897,47 @@ func (h *handler) earnings(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	rangeSQL, rangeArgs := earningsRangeFilter(rangeFrom, rangeTo, hasRange)
-	current := sqliteTimeText(currentMondayUTC(time.Now().UTC()))
+	nowUTC := time.Now().UTC()
+	current := sqliteTimeText(currentMondayUTC(nowUTC))
+	todayUTC := sqliteTimeText(time.Date(nowUTC.Year(), nowUTC.Month(), nowUTC.Day(), 0, 0, 0, 0, time.UTC))
 	models := h.modelsServed(r.Context(), providerID, rangeSQL, rangeArgs...)
 	totalArgs := append([]any{providerID}, rangeArgs...)
 	currentArgs := append([]any{providerID, current}, rangeArgs...)
+	todayArgs := append([]any{providerID, todayUTC}, rangeArgs...)
 	faultArgs := append([]any{providerID}, rangeArgs...)
+
+	// Payable provider_credits for the three windows the Malibu card shows
+	// (life / week / today). current_window == "this week" (since Monday UTC).
+	totalCredits := h.sum(r.Context(), `SELECT SUM(provider_credits) FROM spec022_payable_request_credits WHERE provider_id=?`+rangeSQL, totalArgs...)
+	weekCredits := h.sum(r.Context(), `SELECT SUM(provider_credits) FROM spec022_payable_request_credits WHERE provider_id=? AND `+sqliteTimeSince("ts_utc")+rangeSQL, currentArgs...)
+	todayCredits := h.sum(r.Context(), `SELECT SUM(provider_credits) FROM spec022_payable_request_credits WHERE provider_id=? AND `+sqliteTimeSince("ts_utc")+rangeSQL, todayArgs...)
+	// "Pending" = earned but not yet paid out. Any ledger_payout_ready row that
+	// is neither still-'ready' nor 'voided' represents credits already paid,
+	// so pending = total payable minus those. With payouts default-off (SPEC-016)
+	// this is 0 paid → pending == lifetime, which is the correct current state.
+	paidOutCredits := h.sum(r.Context(), `SELECT SUM(provider_credits) FROM ledger_payout_ready WHERE provider_id=? AND status NOT IN ('ready','voided')`, providerID)
+	pendingCredits := totalCredits - paidOutCredits
+	if pendingCredits < 0 {
+		pendingCredits = 0
+	}
+
 	resp := map[string]any{
 		"provider_id":            providerID,
-		"total_credits":          h.sum(r.Context(), `SELECT SUM(provider_credits) FROM spec022_payable_request_credits WHERE provider_id=?`+rangeSQL, totalArgs...),
-		"current_window_credits": h.sum(r.Context(), `SELECT SUM(provider_credits) FROM spec022_payable_request_credits WHERE provider_id=? AND `+sqliteTimeSince("ts_utc")+rangeSQL, currentArgs...),
+		"total_credits":          totalCredits,
+		"current_window_credits": weekCredits,
 		"last_payout_ready":      h.lastPayout(r.Context(), providerID),
 		"provider_share_bps":     h.latestShareBps(r.Context()),
 		"models_served":          models,
 		"rate_card_excerpt":      h.rateCardExcerpt(r.Context(), models),
 		"fault_count":            h.sum(r.Context(), `SELECT COUNT(*) FROM ledger_request_credits WHERE provider_id=? AND fault_flag != 'none'`+rangeSQL, faultArgs...),
+		// usdc_* are the USD figures the Malibu client (ProviderEarningsClient)
+		// decodes for the "today / wk / pending / life" card. Before this the
+		// endpoint emitted only *_credits, so every card read $0.00 regardless
+		// of real accrued earnings. Converted via the published rate.
+		"usdc_today":    h.store.creditsToUSD(todayCredits),
+		"usdc_week":     h.store.creditsToUSD(weekCredits),
+		"usdc_pending":  h.store.creditsToUSD(pendingCredits),
+		"usdc_lifetime": h.store.creditsToUSD(totalCredits),
 	}
 	idlePrewarm := statsprewarm.Summary{
 		EventsLast1h:        map[string]int64{},

--- a/phase4-coordinator/internal/billing/endpoints_test.go
+++ b/phase4-coordinator/internal/billing/endpoints_test.go
@@ -1251,11 +1251,11 @@ func TestWriteErrorEnvelopeShape(t *testing.T) {
 // (ProviderEarningsClient) actually decodes: usdc_today / usdc_week /
 // usdc_pending / usdc_lifetime. Before this fix the endpoint emitted only
 // *_credits, so every provider card rendered $0.00 despite real accrued
-// credits. usd = provider_credits * usd_per_million_credits / 1_000_000.
+// credits. usd = provider_credits / 1_000_000 (SPEC-016 §4.3 payout invariant:
+// provider_credits == USDC base units, 6 decimals).
 func TestEarningsEndpointEmitsUsdcFields(t *testing.T) {
 	_, store := newRequestAndBillingStores(t)
-	store.SetUsdPerMillionCredits(1.0)
-	// 500,000 payable credits @ $1/M => $0.50, all in the current day/week/life.
+	// 500,000 payable credits == $0.50 USDC, all in the current day/week/life.
 	insertCredit(t, store.db, "provider-a", time.Now().UTC(), 500000)
 
 	req := httptest.NewRequest(http.MethodGet, "/providers/provider-a/earnings", nil)
@@ -1286,18 +1286,22 @@ func TestEarningsEndpointEmitsUsdcFields(t *testing.T) {
 			t.Fatalf("%s missing from earnings response (client decodes nil -> $0.00)", name)
 		}
 		if *got != 0.5 {
-			t.Fatalf("%s=%v want 0.5", name, *got)
+			t.Fatalf("%s=%v want 0.5 (500000 base units / 1e6)", name, *got)
 		}
 	}
 }
 
-// TestEarningsEndpointUsdcZeroWhenRateUnset confirms the safe default: with
-// no published rate (0), usdc_* are 0 rather than NaN/absent — matching
-// pre-fix behaviour and never emitting a bogus USD figure.
-func TestEarningsEndpointUsdcZeroWhenRateUnset(t *testing.T) {
+// TestEarningsEndpointUsdcPendingIsRangeIndependent locks the security-audit
+// MEDIUM fixes: usdc_pending is all owed money and must not shrink when a
+// from/to range is supplied, whereas usdc_lifetime is range-scoped. An older
+// credit outside the range still counts as owed/pending.
+func TestEarningsEndpointUsdcPendingIsRangeIndependent(t *testing.T) {
 	_, store := newRequestAndBillingStores(t)
-	insertCredit(t, store.db, "provider-a", time.Now().UTC(), 500000)
-	req := httptest.NewRequest(http.MethodGet, "/providers/provider-a/earnings", nil)
+	// One old credit (outside the range) + one recent (inside the range).
+	insertCredit(t, store.db, "provider-a", time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC), 300000)
+	insertCredit(t, store.db, "provider-a", time.Date(2026, 6, 15, 12, 0, 0, 0, time.UTC), 200000)
+
+	req := httptest.NewRequest(http.MethodGet, "/providers/provider-a/earnings?from=2026-06-01&to=2026-06-30", nil)
 	req.Header.Set("Authorization", "Bearer good")
 	w := httptest.NewRecorder()
 	store.Handlers("operator", fakeTokens{"good": "provider-a"}, true, 60).ServeHTTP(w, req)
@@ -1306,11 +1310,15 @@ func TestEarningsEndpointUsdcZeroWhenRateUnset(t *testing.T) {
 	}
 	var resp struct {
 		UsdcLifetime float64 `json:"usdc_lifetime"`
+		UsdcPending  float64 `json:"usdc_pending"`
 	}
 	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
 		t.Fatal(err)
 	}
-	if resp.UsdcLifetime != 0 {
-		t.Fatalf("usdc_lifetime=%v want 0 when rate unset", resp.UsdcLifetime)
+	if resp.UsdcLifetime != 0.2 { // range-scoped: only the 200000 recent credit
+		t.Fatalf("usdc_lifetime=%v want 0.2 (range-scoped)", resp.UsdcLifetime)
+	}
+	if resp.UsdcPending != 0.5 { // all owed: (300000+200000)/1e6, ignores range
+		t.Fatalf("usdc_pending=%v want 0.5 (range-independent owed total)", resp.UsdcPending)
 	}
 }

--- a/phase4-coordinator/internal/billing/endpoints_test.go
+++ b/phase4-coordinator/internal/billing/endpoints_test.go
@@ -1246,3 +1246,71 @@ func TestWriteErrorEnvelopeShape(t *testing.T) {
 		t.Errorf("type for 500 = %q, want %q", got, "server_error")
 	}
 }
+
+// TestEarningsEndpointEmitsUsdcFields locks the contract the Malibu client
+// (ProviderEarningsClient) actually decodes: usdc_today / usdc_week /
+// usdc_pending / usdc_lifetime. Before this fix the endpoint emitted only
+// *_credits, so every provider card rendered $0.00 despite real accrued
+// credits. usd = provider_credits * usd_per_million_credits / 1_000_000.
+func TestEarningsEndpointEmitsUsdcFields(t *testing.T) {
+	_, store := newRequestAndBillingStores(t)
+	store.SetUsdPerMillionCredits(1.0)
+	// 500,000 payable credits @ $1/M => $0.50, all in the current day/week/life.
+	insertCredit(t, store.db, "provider-a", time.Now().UTC(), 500000)
+
+	req := httptest.NewRequest(http.MethodGet, "/providers/provider-a/earnings", nil)
+	req.Header.Set("Authorization", "Bearer good")
+	w := httptest.NewRecorder()
+	store.Handlers("operator", fakeTokens{"good": "provider-a"}, true, 60).ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s", w.Code, w.Body.String())
+	}
+	var resp struct {
+		TotalCredits float64  `json:"total_credits"`
+		UsdcToday    *float64 `json:"usdc_today"`
+		UsdcWeek     *float64 `json:"usdc_week"`
+		UsdcPending  *float64 `json:"usdc_pending"`
+		UsdcLifetime *float64 `json:"usdc_lifetime"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatal(err)
+	}
+	if resp.TotalCredits != 500000 {
+		t.Fatalf("total_credits=%v want 500000 (unchanged)", resp.TotalCredits)
+	}
+	for name, got := range map[string]*float64{
+		"usdc_today": resp.UsdcToday, "usdc_week": resp.UsdcWeek,
+		"usdc_pending": resp.UsdcPending, "usdc_lifetime": resp.UsdcLifetime,
+	} {
+		if got == nil {
+			t.Fatalf("%s missing from earnings response (client decodes nil -> $0.00)", name)
+		}
+		if *got != 0.5 {
+			t.Fatalf("%s=%v want 0.5", name, *got)
+		}
+	}
+}
+
+// TestEarningsEndpointUsdcZeroWhenRateUnset confirms the safe default: with
+// no published rate (0), usdc_* are 0 rather than NaN/absent — matching
+// pre-fix behaviour and never emitting a bogus USD figure.
+func TestEarningsEndpointUsdcZeroWhenRateUnset(t *testing.T) {
+	_, store := newRequestAndBillingStores(t)
+	insertCredit(t, store.db, "provider-a", time.Now().UTC(), 500000)
+	req := httptest.NewRequest(http.MethodGet, "/providers/provider-a/earnings", nil)
+	req.Header.Set("Authorization", "Bearer good")
+	w := httptest.NewRecorder()
+	store.Handlers("operator", fakeTokens{"good": "provider-a"}, true, 60).ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s", w.Code, w.Body.String())
+	}
+	var resp struct {
+		UsdcLifetime float64 `json:"usdc_lifetime"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatal(err)
+	}
+	if resp.UsdcLifetime != 0 {
+		t.Fatalf("usdc_lifetime=%v want 0 when rate unset", resp.UsdcLifetime)
+	}
+}

--- a/phase4-coordinator/internal/billing/endpoints_test.go
+++ b/phase4-coordinator/internal/billing/endpoints_test.go
@@ -1278,6 +1278,7 @@ func TestEarningsEndpointEmitsUsdcFields(t *testing.T) {
 	if resp.TotalCredits != 500000 {
 		t.Fatalf("total_credits=%v want 500000 (unchanged)", resp.TotalCredits)
 	}
+	// All four usdc_* fields must be present (a nil = the pre-fix $0.00 bug).
 	for name, got := range map[string]*float64{
 		"usdc_today": resp.UsdcToday, "usdc_week": resp.UsdcWeek,
 		"usdc_pending": resp.UsdcPending, "usdc_lifetime": resp.UsdcLifetime,
@@ -1285,8 +1286,21 @@ func TestEarningsEndpointEmitsUsdcFields(t *testing.T) {
 		if got == nil {
 			t.Fatalf("%s missing from earnings response (client decodes nil -> $0.00)", name)
 		}
-		if *got != 0.5 {
-			t.Fatalf("%s=%v want 0.5 (500000 base units / 1e6)", name, *got)
+	}
+	// lifetime + pending are range-/window-independent, so their conversion is
+	// asserted exactly: 500000 base units / 1e6 == $0.50.
+	if *resp.UsdcLifetime != 0.5 {
+		t.Fatalf("usdc_lifetime=%v want 0.5", *resp.UsdcLifetime)
+	}
+	if *resp.UsdcPending != 0.5 {
+		t.Fatalf("usdc_pending=%v want 0.5", *resp.UsdcPending)
+	}
+	// today/week depend on the handler's own UTC clock vs the seed time; a run
+	// crossing 00:00 (or Monday 00:00) UTC would zero the window. Assert only
+	// that they carry the credit's converted value or 0 — never a bogus figure.
+	for name, got := range map[string]float64{"usdc_today": *resp.UsdcToday, "usdc_week": *resp.UsdcWeek} {
+		if got != 0.5 && got != 0 {
+			t.Fatalf("%s=%v want 0.5 or 0 (UTC-boundary tolerant)", name, got)
 		}
 	}
 }

--- a/phase4-coordinator/internal/billing/store.go
+++ b/phase4-coordinator/internal/billing/store.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"math"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -37,6 +38,13 @@ type Store struct {
 	forceVoidEnabled       atomic.Bool
 	forceCreditEnabled     atomic.Bool
 	forceCreditHoldSeconds atomic.Int64
+	// usdPerMillionCreditsBits holds stats.rollup.usd_per_million_credits
+	// as math.Float64bits so the provider /earnings handler can convert
+	// ledger provider_credits into the usdc_* USD fields the Malibu client
+	// decodes. Written by SetUsdPerMillionCredits at startup and on SIGHUP
+	// reload; read lock-free per request. Zero (never set / rate 0) yields
+	// $0.00, matching pre-fix behaviour rather than emitting a bogus number.
+	usdPerMillionCreditsBits atomic.Uint64
 }
 
 const defaultForceCreditSettlementHoldSeconds int64 = 24 * 60 * 60
@@ -1078,6 +1086,32 @@ func (s *Store) SetSettlementConfig(cfg SettlementConfig) {
 	s.settlementMu.Lock()
 	defer s.settlementMu.Unlock()
 	s.settlement = cfg
+}
+
+// SetUsdPerMillionCredits publishes the credits→USD conversion rate
+// (stats.rollup.usd_per_million_credits) used by the provider /earnings
+// endpoint to fill the usdc_* fields. A negative or non-finite rate is
+// coerced to 0 (no conversion) so the handler never emits NaN/Inf USD.
+func (s *Store) SetUsdPerMillionCredits(rate float64) {
+	if math.IsNaN(rate) || math.IsInf(rate, 0) || rate < 0 {
+		rate = 0
+	}
+	s.usdPerMillionCreditsBits.Store(math.Float64bits(rate))
+}
+
+// UsdPerMillionCredits returns the published credits→USD rate, or 0 when
+// it has never been set.
+func (s *Store) UsdPerMillionCredits() float64 {
+	return math.Float64frombits(s.usdPerMillionCreditsBits.Load())
+}
+
+// creditsToUSD converts integer provider_credits to a USD amount using the
+// published rate: usd = credits * usd_per_million_credits / 1_000_000.
+func (s *Store) creditsToUSD(credits int64) float64 {
+	if credits <= 0 {
+		return 0
+	}
+	return float64(credits) * s.UsdPerMillionCredits() / 1_000_000
 }
 
 func (s *Store) SettlementConfig(defaultCfg SettlementConfig) SettlementConfig {

--- a/phase4-coordinator/internal/billing/store.go
+++ b/phase4-coordinator/internal/billing/store.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"math"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -38,13 +37,6 @@ type Store struct {
 	forceVoidEnabled       atomic.Bool
 	forceCreditEnabled     atomic.Bool
 	forceCreditHoldSeconds atomic.Int64
-	// usdPerMillionCreditsBits holds stats.rollup.usd_per_million_credits
-	// as math.Float64bits so the provider /earnings handler can convert
-	// ledger provider_credits into the usdc_* USD fields the Malibu client
-	// decodes. Written by SetUsdPerMillionCredits at startup and on SIGHUP
-	// reload; read lock-free per request. Zero (never set / rate 0) yields
-	// $0.00, matching pre-fix behaviour rather than emitting a bogus number.
-	usdPerMillionCreditsBits atomic.Uint64
 }
 
 const defaultForceCreditSettlementHoldSeconds int64 = 24 * 60 * 60
@@ -1088,30 +1080,21 @@ func (s *Store) SetSettlementConfig(cfg SettlementConfig) {
 	s.settlement = cfg
 }
 
-// SetUsdPerMillionCredits publishes the credits→USD conversion rate
-// (stats.rollup.usd_per_million_credits) used by the provider /earnings
-// endpoint to fill the usdc_* fields. A negative or non-finite rate is
-// coerced to 0 (no conversion) so the handler never emits NaN/Inf USD.
-func (s *Store) SetUsdPerMillionCredits(rate float64) {
-	if math.IsNaN(rate) || math.IsInf(rate, 0) || rate < 0 {
-		rate = 0
-	}
-	s.usdPerMillionCreditsBits.Store(math.Float64bits(rate))
-}
+// usdcBaseUnitsPerUSDC is the USDC fixed-point scale (6 decimals): one USDC
+// equals 1,000,000 base units.
+const usdcBaseUnitsPerUSDC = 1_000_000
 
-// UsdPerMillionCredits returns the published credits→USD rate, or 0 when
-// it has never been set.
-func (s *Store) UsdPerMillionCredits() float64 {
-	return math.Float64frombits(s.usdPerMillionCreditsBits.Load())
-}
-
-// creditsToUSD converts integer provider_credits to a USD amount using the
-// published rate: usd = credits * usd_per_million_credits / 1_000_000.
-func (s *Store) creditsToUSD(credits int64) float64 {
+// providerCreditsToUSDC converts ledger provider_credits into a USDC amount
+// using the SAME invariant the payout runner enforces at settlement time —
+// SPEC-016 §4.3 step 2: the on-chain payout amount in USDC base units equals
+// provider_credits exactly (phase4-coordinator/internal/payout/runner.go). So
+// the displayed usdc_* figure is, by construction, the amount the provider is
+// actually owed/paid, independent of any tunable stats display rate.
+func providerCreditsToUSDC(credits int64) float64 {
 	if credits <= 0 {
 		return 0
 	}
-	return float64(credits) * s.UsdPerMillionCredits() / 1_000_000
+	return float64(credits) / usdcBaseUnitsPerUSDC
 }
 
 func (s *Store) SettlementConfig(defaultCfg SettlementConfig) SettlementConfig {


### PR DESCRIPTION
## Summary

Fixes the reason **every provider's Malibu card shows $0.00** despite real
accrued earnings: a client/server contract mismatch on the provider
`/providers/{id}/earnings` endpoint.

The Malibu client (`phase3-binary` `ProviderEarningsClient`) decodes
`usdc_today` / `usdc_week` / `usdc_pending` / `usdc_lifetime`, but the
coordinator endpoint emitted only `total_credits` / `current_window_credits`
and **no** `usdc_*` fields. `grep usdc_today phase4-coordinator/` → 0 hits, so
every money field decoded to `nil` and the card rendered `$0.00` across the
board — verified live on Pearl: the ledger holds real payable credits
(network-wide ~903k credits; individual providers 6k–42k) all displayed as $0.

## What changed

`billing.earnings` now emits the four `usdc_*` fields, converted via the
**SPEC-016 §4.3 payout invariant** — `provider_credits == USDC base units`
(6 decimals), i.e. `usd = provider_credits / 1_000_000`. This is the same
value the payout runner pays on-chain (`internal/payout/runner.go:689`), so the
displayed amount equals what the provider is actually owed, independent of any
tunable stats display rate.

- `usdc_today` — since 00:00 UTC (range-scoped)
- `usdc_week` — since Monday 00:00 UTC (range-scoped)
- `usdc_lifetime` — all payable credits (range-scoped, mirrors `total_credits`)
- `usdc_pending` — all USDC currently owed; a **lifetime, range-INDEPENDENT**
  figure that never shrinks under a `from`/`to` filter. Payouts are default-off
  (SPEC-016), so every payable credit is still owed; a comment documents the
  correct confirmed-non-orphaned subtraction for when payouts go live.

`*_credits` and all other response fields are unchanged (now computed once and
reused). No config wiring; the conversion is a pure function of the ledger.

## Audit (3-lane codex, money-path)

- Security: r1 **1 HIGH + 2 MEDIUM** (tunable-rate divergence from payout;
  range/orphan pending bugs) → all fixed → **r2 0/0/0/0**
- Architect: r1 2 LOW → mooted by dropping the config rate → **r2 0/0/0/0**
- Code: r1 clean → r2 1 LOW (test UTC-boundary flake) → fixed → **r3 0/0/0/0**

## Test plan

- [x] `go build ./...`
- [x] `go test -count=1 ./...` (coordinator)
- [x] New: `TestEarningsEndpointEmitsUsdcFields` (usdc_* present; $0.50 for
      500k base units), `TestEarningsEndpointUsdcPendingIsRangeIndependent`
- [x] gofmt clean
- [ ] Deploy: separate, careful coordinator deploy (not in this PR) makes the
      change live; merging to main does not auto-deploy.

## Not in this PR

Provider #4's separate v1.8.67 `usage_mismatch` settlement-quarantine
regression (settlement integrity) is a distinct follow-up.

## Governance declaration note

`SPEC-005` has no migrated `SPEC-005-R###` requirement IDs in
`CONFORMANCE.json` yet (requirement-ID migration pending, same as SPEC-016),
and `phase4-coordinator/internal/billing/**` is a non-governance path, so
there is no declaration that passes the advisory `spec-index / check`
declaration substep — it cites the honest domain/section below and the
`unknown requirement` note is expected. Per repo rules the declaration check
is **advisory and non-required**; merge gates are `ci-required` + 1 approval.

SPEC-GOVERNANCE-DECLARATION-BEGIN
{
  "schema_version": "spec-pr-governance-v1",
  "behavior_change": "yes",
  "contract_change": "none",
  "specs": ["SPEC-005"],
  "requirements": ["SPEC-005 §11.4 provider earnings (requirement-ID migration pending)"],
  "authority_domains": ["billing-settlement-formula"],
  "arbitration": ["CODE_BUG"],
  "tests": ["phase4-coordinator/internal/billing/endpoints_test.go"],
  "journeys": ["not-required"]
}
SPEC-GOVERNANCE-DECLARATION-END

🤖 Generated with [Claude Code](https://claude.com/claude-code)
