### PR TITLE
fix(settlement): don't cap billable tokens in settlement evidence tuple (Llama/gpt-oss usage_mismatch quarantine)

### DIFF
--- a/phase4-coordinator/internal/buyer/billing_recorder.go
+++ b/phase4-coordinator/internal/buyer/billing_recorder.go
@@ -535,9 +535,29 @@ func (b *billingRecorder) recordSettlementAttemptOutput(ctx context.Context, sto
 	}
 	billableInput := observedInput
 	billableOutput := observedOutput
-	if in.PromptTokenUpperBound != nil && billableInput > *in.PromptTokenUpperBound {
-		billableInput = *in.PromptTokenUpperBound
-	}
+	// The settlement evidence tuple must mirror what an honest provider signs in
+	// its receipt, because tupleUsageMatchesLedger requires the coordinator's
+	// ExpectedUsage to EXACTLY equal the provider receipt's 5 usage fields for
+	// EVERY terminal state (settlement_verifier.go), and SPEC-015 (receipts
+	// terminal-state table) fixes billable_input_tokens == observed_input_tokens
+	// for the fully consumed prompt (== for normal_done; the delivered prefix on
+	// positive-money partial/error states also bills the whole input).
+	//
+	// The prompt-token upper bound is a byte-heuristic (len(body)/4, see
+	// estimateTokens) anti-inflation cap for the buyer LEDGER money amount
+	// (billing.boundProviderReportedPromptTokens). It MUST NOT be applied to the
+	// settlement evidence here: the provider cannot reproduce the coordinator's
+	// len(body)/4 value, so capping billable_input below observed_input produces a
+	// tuple no honest receipt can match -> usage_mismatch -> quarantine of EVERY
+	// settlement for models whose chat-template tokenization exceeds len(body)/4
+	// (Llama-3.2/3.1, gpt-oss). This is evidence-only and changes no credited
+	// amount: verified settlement credit sync re-bounds billable to the ledger
+	// prompt (syncVerifiedReceiptLedgerCreditForAttemptTx) and the ledger prompt is
+	// itself independently capped in the hot path.
+	//
+	// Byte-estimated usage is not settlement-capable (UsageCrossChecked is false),
+	// and non-normal_done zero-prefix attempts bill nothing: both zero billable
+	// below, which is what an honest provider also reports for those cases.
 	if usageSource == billing.UsageSourceByteEstimated {
 		billableInput = 0
 		billableOutput = 0

--- a/phase4-coordinator/internal/buyer/billing_recorder_test.go
+++ b/phase4-coordinator/internal/buyer/billing_recorder_test.go
@@ -11,7 +11,15 @@ import (
 	"github.com/augstar/macprovider-coordinator/internal/requestlog"
 )
 
-func TestRecordSettlementAttemptOutputBoundsBillablePromptEvidence(t *testing.T) {
+// TestRecordSettlementAttemptOutputNormalDoneBillableEqualsObserved locks in the
+// SPEC-015 receipts invariant: for a normal_done attempt the settlement evidence
+// tuple MUST carry billable_input_tokens == observed_input_tokens, even when the
+// provider-reported prompt tokens exceed the len(body)/4 prompt-token upper bound.
+// Capping billable below observed here produces a tuple the settlement verifier
+// rejects (usage_observed_mismatch) and that no honest provider receipt can match,
+// which quarantined 100% of settlements for models whose chat-template tokenization
+// exceeds len(body)/4 (Llama-3.2/3.1, gpt-oss). Regression guard for that bug.
+func TestRecordSettlementAttemptOutputNormalDoneBillableEqualsObserved(t *testing.T) {
 	dbPath := filepath.Join(t.TempDir(), "coordinator.db")
 	reqLog, err := requestlog.OpenStore(dbPath)
 	if err != nil {
@@ -23,10 +31,12 @@ func TestRecordSettlementAttemptOutputBoundsBillablePromptEvidence(t *testing.T)
 		t.Fatalf("billing.NewStore: %v", err)
 	}
 
+	// bound (len(body)/4) is deliberately far below the provider-reported prompt
+	// tokens, as happens for short prompts under a token-dense chat template.
 	bound := int64(10)
 	reportedPrompt := int64(100)
 	completion := int64(4)
-	rec := &billingRecorder{accountID: "acct-bounded", requestID: "req-bounded"}
+	rec := &billingRecorder{accountID: "acct-normaldone", requestID: "req-normaldone"}
 	rec.setPromptTokenUpperBound(bound)
 	output := &billing.SettlementOutput{
 		Content:             "ok",
@@ -34,7 +44,7 @@ func TestRecordSettlementAttemptOutputBoundsBillablePromptEvidence(t *testing.T)
 		TerminalState:       billing.TerminalStateNormalDone,
 	}
 	err = rec.recordSettlementAttemptOutput(context.Background(), store, billing.HotPathInput{
-		RequestID:             "req-bounded",
+		RequestID:             "req-normaldone",
 		ProviderID:            "provider-a",
 		PromptTokens:          &reportedPrompt,
 		PromptTokenUpperBound: &bound,
@@ -50,7 +60,78 @@ func TestRecordSettlementAttemptOutputBoundsBillablePromptEvidence(t *testing.T)
 		t.Fatalf("open db: %v", err)
 	}
 	defer db.Close()
-	if err := db.QueryRow(`SELECT usage_canonical_json FROM settlement_attempt_outputs WHERE request_id = ?`, "req-bounded").Scan(&raw); err != nil {
+	if err := db.QueryRow(`SELECT usage_canonical_json FROM settlement_attempt_outputs WHERE request_id = ?`, "req-normaldone").Scan(&raw); err != nil {
+		t.Fatalf("query usage: %v", err)
+	}
+	var usage struct {
+		BillableInputTokens  int64 `json:"billable_input_tokens"`
+		ObservedInputTokens  int64 `json:"observed_input_tokens"`
+		BillableOutputTokens int64 `json:"billable_output_tokens"`
+		ObservedOutputTokens int64 `json:"observed_output_tokens"`
+	}
+	if err := json.Unmarshal([]byte(raw), &usage); err != nil {
+		t.Fatalf("decode usage: %v", err)
+	}
+	// SPEC-015 normal_done: billable == observed on both axes; NOT capped to bound.
+	if usage.BillableInputTokens != reportedPrompt || usage.ObservedInputTokens != reportedPrompt {
+		t.Fatalf("normal_done prompt evidence = billable %d observed %d, want both %d (SPEC-015 billable==observed, uncapped)", usage.BillableInputTokens, usage.ObservedInputTokens, reportedPrompt)
+	}
+	if usage.BillableOutputTokens != completion || usage.ObservedOutputTokens != completion {
+		t.Fatalf("normal_done completion evidence = billable %d observed %d, want both %d", usage.BillableOutputTokens, usage.ObservedOutputTokens, completion)
+	}
+}
+
+// TestRecordSettlementAttemptOutputPartialPrefixBillableEqualsObserved proves that
+// a positive-money non-normal_done terminal state WITH a delivered prefix
+// (provider_error/buyer_cancel/gateway_timeout/upstream_transport_disconnect) also
+// carries billable_input == observed_input in the settlement evidence, uncapped by
+// the len(body)/4 prompt-token bound. tupleUsageMatchesLedger requires exact
+// equality with the provider receipt for EVERY terminal state, and the provider
+// cannot reproduce the coordinator's byte-heuristic cap; capping here would
+// quarantine token-dense-prompt partial settlements the same way it did normal_done.
+func TestRecordSettlementAttemptOutputPartialPrefixBillableEqualsObserved(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "coordinator.db")
+	reqLog, err := requestlog.OpenStore(dbPath)
+	if err != nil {
+		t.Fatalf("open request log: %v", err)
+	}
+	t.Cleanup(func() { _ = reqLog.Close() })
+	store, err := billing.NewStore(reqLog.DB())
+	if err != nil {
+		t.Fatalf("billing.NewStore: %v", err)
+	}
+
+	bound := int64(10)
+	reportedPrompt := int64(100)
+	completion := int64(4)
+	rec := &billingRecorder{accountID: "acct-partial", requestID: "req-partial", server: &Server{}}
+	rec.setPromptTokenUpperBound(bound)
+	// Non-normal_done terminal state with a delivered prefix (delivered > 0 so the
+	// delivered==0 zeroing branch does not fire).
+	output := &billing.SettlementOutput{
+		Content:             "partial-prefix",
+		Available:           true,
+		OutputPrefixEndByte: int64(len("partial-prefix")),
+		TerminalState:       billing.TerminalStateProviderError,
+	}
+	err = rec.recordSettlementAttemptOutput(context.Background(), store, billing.HotPathInput{
+		RequestID:             "req-partial",
+		ProviderID:            "provider-a",
+		PromptTokens:          &reportedPrompt,
+		PromptTokenUpperBound: &bound,
+		CompletionTokens:      &completion,
+	}, output)
+	if err != nil {
+		t.Fatalf("recordSettlementAttemptOutput: %v", err)
+	}
+
+	var raw string
+	db, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer db.Close()
+	if err := db.QueryRow(`SELECT usage_canonical_json FROM settlement_attempt_outputs WHERE request_id = ?`, "req-partial").Scan(&raw); err != nil {
 		t.Fatalf("query usage: %v", err)
 	}
 	var usage struct {
@@ -60,8 +141,8 @@ func TestRecordSettlementAttemptOutputBoundsBillablePromptEvidence(t *testing.T)
 	if err := json.Unmarshal([]byte(raw), &usage); err != nil {
 		t.Fatalf("decode usage: %v", err)
 	}
-	if usage.BillableInputTokens != bound || usage.ObservedInputTokens != reportedPrompt {
-		t.Fatalf("usage prompt evidence = billable %d observed %d, want billable %d observed %d", usage.BillableInputTokens, usage.ObservedInputTokens, bound, reportedPrompt)
+	if usage.BillableInputTokens != reportedPrompt || usage.ObservedInputTokens != reportedPrompt {
+		t.Fatalf("partial-prefix prompt evidence = billable %d observed %d, want both %d (billable==observed, uncapped)", usage.BillableInputTokens, usage.ObservedInputTokens, reportedPrompt)
 	}
 }
 


### PR DESCRIPTION
## Summary

Fixes a **coordinator settlement bug** that quarantined **100% of settlement
receipts** for every provider serving a model whose chat-template tokenization
is denser than `len(body)/4` — Llama-3.2/3.1 and gpt-oss — with reason
`usage_mismatch`. Verified live on the Pearl coordinator DB: `mp-bcacdf97`
(MrBeison, Llama-3.2-3B) 138/138 quarantined, 0 verified; `mp-70558`
(Llama-3.1-8B) 19/20 quarantined; the same single provider binary verifies
Qwen3-30B but quarantines its own gpt-oss-20b. It is **not** a provider CLI
version regression — the model-family split proves it.

## Root cause

`recordSettlementAttemptOutput` built the settlement **evidence** tuple by
capping `billable_input` at the prompt-token upper bound
(`estimateTokens = len(json_body)/4`, `server.go`). But:

- `tupleUsageMatchesLedger` (`settlement_verifier.go`) requires the coordinator's
  `ExpectedUsage` to **exactly** equal the provider receipt's five usage fields
  for **every** terminal state, and
- **SPEC-015** (receipts terminal-state table, `normal_done` row) mandates
  `billable_input_tokens == observed_input_tokens` for a fully consumed prompt.
- `observed_input` is the **provider-reported** `prompt_tokens`
  (`billing_recorder.go` ← `server.go` `tokenPointersFromUsageObject(end.Usage)`).

When a model's real prompt tokenization exceeds `len(body)/4` (token-dense chat
templates on short prompts — e.g. observed 48 tokens on a ~150-byte body), the
coordinator produced a `normal_done` tuple with `billable_input < observed_input`,
which (a) violates its **own** verifier invariant and (b) can never equal an
honest provider receipt → `usage_mismatch` → quarantine. Qwen prompts stay under
`len(body)/4`, so they verify (~98%).

## What changed

Remove the prompt-token upper-bound cap from the settlement **evidence** tuple
entirely (`internal/buyer/billing_recorder.go`). Billable now mirrors observed
for settlement-capable `coordinator_observed` usage across all terminal states
(`normal_done` and delivered-prefix partial/error, which also bill the whole
consumed input). Byte-estimated usage (not settlement-capable) and
non-`normal_done` zero-prefix attempts still zero billable — exactly what an
honest provider reports for those cases.

## Dollar-neutral (verification-only change)

The settlement evidence tuple never prices anything. Confirmed by all three
audit lanes with file:line:

- Provider credits are computed from the **independently** hot-path-capped ledger
  prompt (`hotpath.go` `boundProviderReportedPromptTokens` → `ComputeCredits`).
- Even in enforce mode, verified credit sync re-bounds
  `min(settlement_billable, ledger_prompt)`
  (`settlement_receipts.go` `syncVerifiedReceiptLedgerCreditForAttemptTx`).
- Payable/payout views aggregate `ledger_request_credits`, not settlement usage
  JSON (`store.go`, `settlement.go`, `payout/runner.go`).
- Finality reporting rewrites billable from the ledger charged prompt
  (`settlement_finality.go`).

Anti-inflation of the buyer/provider money amount is preserved — it lives in the
ledger, not the receipt evidence.

## Scope / impact

Production is in **observe** mode, where the payable view admits credits on
`ledger.quarantined = 0` regardless of the settlement verdict, so this fix does
**not** change any provider's *currently* payable USD. Its value is:

1. Settlement **integrity** — the coordinator stops producing self-contradictory
   tuples and quarantining honest receipts network-wide.
2. A hard **prerequisite** for ever enabling **enforce** mode / SPEC-016 payouts,
   where `usage_mismatch` would zero out every Llama/gpt-oss provider.

## Not in this PR (separate follow-ups)

- The same `len(body)/4` bound also caps the **ledger money amount**
  (`hotpath.go`), under-charging Llama/gpt-oss ~20-25% on prompt tokens on short
  bodies in every mode. Distinct money-path fix + audit.
- The 138 already-quarantined verdicts are only fixed for **new** receipts;
  recovering them needs a separate operator re-verification / `force_credit`
  quarantine-resolution plan.

## Audit (3-lane codex, full diff, money-path)

Two rounds. Round 1 raised one architect MEDIUM (the cap still applied to
non-`normal_done` delivered-prefix states, same quarantine class) + one LOW
(comment scope); the fix was broadened to remove the cap entirely and the tests
updated. Round 2 converged:

- Code: **0 C / 0 H / 0 M / 0 L**
- Security: **0 C / 0 H / 0 M / 0 L / 0 INFO** (dollar-neutrality proven through
  the payout runner)
- Architect: **0 C / 0 H / 0 M / 0 L / 0 INFO** (round-1 MEDIUM + LOW confirmed
  resolved)

## Test plan

- [x] `go build ./...`
- [x] `go test -count=1 ./...` (coordinator) — 0 failures
- [x] `TestRecordSettlementAttemptOutputNormalDoneBillableEqualsObserved` —
      normal_done billable==observed (uncapped) when reported prompt > bound
- [x] `TestRecordSettlementAttemptOutputPartialPrefixBillableEqualsObserved` —
      delivered-prefix provider_error billable==observed (uncapped)
- [x] `TestRecordSettlementAttemptOutputByteEstimatedBuyerCancelIsNotBillable` —
      byte-estimated still zeroes billable
- [x] gofmt clean
- [ ] Deploy: a separate careful coordinator deploy (not in this PR) makes new
      settlements verify; merging does not auto-deploy.

## Governance declaration

Cites **`SPEC-022-R003`** (route-time verification snapshot; R-3.4 / R-3.4.1
require settlement usage to be derived from / cross-checked against
coordinator/gateway-observed canonical state) — the exact invariant this fix
restores. Requirement IDs for the `verified-model-settlement` domain were
registered in #834; this PR is rebased on that so the declaration cites a real
requirement and the `spec-index / check` job passes.

SPEC-GOVERNANCE-DECLARATION-BEGIN
{
  "schema_version": "spec-pr-governance-v1",
  "behavior_change": "yes",
  "contract_change": "none",
  "specs": ["SPEC-022", "SPEC-015"],
  "requirements": ["SPEC-022-R003"],
  "authority_domains": ["verified-model-settlement"],
  "arbitration": ["CODE_BUG"],
  "tests": ["phase4-coordinator/internal/buyer/billing_recorder_test.go"],
  "journeys": ["not-required"],
  "issue": "https://github.com/Augustas11/macprovider/issues/614"
}
SPEC-GOVERNANCE-DECLARATION-END

🤖 Generated with [Claude Code](https://claude.com/claude-code)
