### PR TITLE
chore(spec-022): migrate requirement IDs (register SPEC-022-R001..R011)

### DIFF
--- a/specs/CONFORMANCE.json
+++ b/specs/CONFORMANCE.json
@@ -603,7 +603,7 @@
     {
       "spec_id": "SPEC-022",
       "title": "Verified model settlement",
-      "version": "v0.1.5",
+      "version": "v0.1.6",
       "path": "specs/SPEC-022-verified-model-settlement.md",
       "status": "draft",
       "owner": "@Augustas11",
@@ -627,11 +627,12 @@
       "last_reconciled_commit": null,
       "last_reconciled_at": null,
       "evidence": [],
-      "requirement_id_migration": "pending",
+      "requirement_id_migration": "complete",
       "gap": {
         "verdict": "UNKNOWN",
         "owner": "@Augustas11",
-        "issue": "https://github.com/Augustas11/macprovider/issues/614"
+        "issue": "https://github.com/Augustas11/macprovider/issues/614",
+        "rationale": "Requirement IDs SPEC-022-R001..R011 registered (one per normative requirement group R-1..R-11) in v0.1.6; conformance reconciliation of the settlement pipeline tracked under the verified-model-settlement domain."
       }
     },
     {
@@ -2847,6 +2848,171 @@
         "owner": "@Augustas11",
         "issue": "https://github.com/Augustas11/macprovider/issues/614",
         "rationale": "FR-PKV14 (operator configuration surface mirroring SPEC-037 FR-KVP11: triple-source precedence, default-off, block size, pool capacity, fallback policy): normative in SPEC-039 v0.1; implementation and tests land in the follow-up IMPL PR."
+      }
+    },
+    {
+      "requirement_id": "SPEC-022-R001",
+      "spec_id": "SPEC-022",
+      "state": "pending",
+      "implementation": [],
+      "tests": [],
+      "journeys": [],
+      "evidence": [],
+      "gap": {
+        "verdict": "UNKNOWN",
+        "owner": "@Augustas11",
+        "issue": "https://github.com/Augustas11/macprovider/issues/614",
+        "rationale": "R-1 policy authority and mode (single authoritative verified_model_settlement surface; default observe MUST NOT change money; enforce activation preconditions; effective policy recorded and read from request-start row): normative in SPEC-022 v0.1.6; settlement pipeline runs in observe mode and reconciliation to conformant is tracked under the verified-model-settlement domain."
+      }
+    },
+    {
+      "requirement_id": "SPEC-022-R002",
+      "spec_id": "SPEC-022",
+      "state": "pending",
+      "implementation": [],
+      "tests": [],
+      "journeys": [],
+      "evidence": [],
+      "gap": {
+        "verdict": "UNKNOWN",
+        "owner": "@Augustas11",
+        "issue": "https://github.com/Augustas11/macprovider/issues/614",
+        "rationale": "R-2 entrypoint and routing preconditions (covered paid entrypoints; active signed catalog at route time; route only to hash_verified provider/model pairs; fail-closed warm-swap): normative in SPEC-022 v0.1.6; settlement pipeline runs in observe mode and reconciliation to conformant is tracked under the verified-model-settlement domain."
+      }
+    },
+    {
+      "requirement_id": "SPEC-022-R003",
+      "spec_id": "SPEC-022",
+      "state": "pending",
+      "implementation": [],
+      "tests": [],
+      "journeys": [],
+      "evidence": [],
+      "gap": {
+        "verdict": "UNKNOWN",
+        "owner": "@Augustas11",
+        "issue": "https://github.com/Augustas11/macprovider/issues/614",
+        "rationale": "R-3 route-time verification snapshot (immutable per-attempt snapshot; model-hash triple-equality; usage/prompt_hash/output_hash cross-check against coordinator-observed canonical state; quarantine on unavailable/mismatch): normative in SPEC-022 v0.1.6; settlement pipeline runs in observe mode and reconciliation to conformant is tracked under the verified-model-settlement domain."
+      }
+    },
+    {
+      "requirement_id": "SPEC-022-R004",
+      "spec_id": "SPEC-022",
+      "state": "pending",
+      "implementation": [],
+      "tests": [],
+      "journeys": [],
+      "evidence": [],
+      "gap": {
+        "verdict": "UNKNOWN",
+        "owner": "@Augustas11",
+        "issue": "https://github.com/Augustas11/macprovider/issues/614",
+        "rationale": "R-4 receipt requirement (settlement-capable provider-signed receipt for any debitable/creditable outcome; null model_hash and legacy receipts non-settling; signature necessary not sufficient; receipt-key identity binding; terminal receipt selection is idempotent): normative in SPEC-022 v0.1.6; settlement pipeline runs in observe mode and reconciliation to conformant is tracked under the verified-model-settlement domain."
+      }
+    },
+    {
+      "requirement_id": "SPEC-022-R005",
+      "spec_id": "SPEC-022",
+      "state": "pending",
+      "implementation": [],
+      "tests": [],
+      "journeys": [],
+      "evidence": [],
+      "gap": {
+        "verdict": "UNKNOWN",
+        "owner": "@Augustas11",
+        "issue": "https://github.com/Augustas11/macprovider/issues/614",
+        "rationale": "R-5 streaming receipts (first-class paid traffic; terminal-state binding; partial-prefix binding for partial-output settlement with coordinator-observed cross-check; async verification decoupled; per-attempt failover settles delivered verified prefixes without double-charge): normative in SPEC-022 v0.1.6; settlement pipeline runs in observe mode and reconciliation to conformant is tracked under the verified-model-settlement domain."
+      }
+    },
+    {
+      "requirement_id": "SPEC-022-R006",
+      "spec_id": "SPEC-022",
+      "state": "pending",
+      "implementation": [],
+      "tests": [],
+      "journeys": [],
+      "evidence": [],
+      "gap": {
+        "verdict": "UNKNOWN",
+        "owner": "@Augustas11",
+        "issue": "https://github.com/Augustas11/macprovider/issues/614",
+        "rationale": "R-6 buyer receipt retrieval (owner/operator auth; no raw prompts or outputs; proof/metadata only; defined retention, rate limits, idempotency, 404/403, pending/quarantined visibility): normative in SPEC-022 v0.1.6; settlement pipeline runs in observe mode and reconciliation to conformant is tracked under the verified-model-settlement domain."
+      }
+    },
+    {
+      "requirement_id": "SPEC-022-R007",
+      "spec_id": "SPEC-022",
+      "state": "pending",
+      "implementation": [],
+      "tests": [],
+      "journeys": [],
+      "evidence": [],
+      "gap": {
+        "verdict": "UNKNOWN",
+        "owner": "@Augustas11",
+        "issue": "https://github.com/Augustas11/macprovider/issues/614",
+        "rationale": "R-7 settlement, quarantine, and payout exclusion (receipt-verification gate before any credit/earnings/sweep/payout; non-verified excluded; quarantine mandatory for trust failures and terminal; no fallback to provider-reported usage under enforce; operator money-positive bypasses forbidden): normative in SPEC-022 v0.1.6; settlement pipeline runs in observe mode and reconciliation to conformant is tracked under the verified-model-settlement domain."
+      }
+    },
+    {
+      "requirement_id": "SPEC-022-R008",
+      "spec_id": "SPEC-022",
+      "state": "pending",
+      "implementation": [],
+      "tests": [],
+      "journeys": [],
+      "evidence": [],
+      "gap": {
+        "verdict": "UNKNOWN",
+        "owner": "@Augustas11",
+        "issue": "https://github.com/Augustas11/macprovider/issues/614",
+        "rationale": "R-8 buyer debit semantics (reservation-first; final debit only on verified; quarantine/deadline releases reservation and keeps provider credit zero; zero_settled terminal; buyer surfaces distinguish pending/verified/quarantined/zero_settled): normative in SPEC-022 v0.1.6; settlement pipeline runs in observe mode and reconciliation to conformant is tracked under the verified-model-settlement domain."
+      }
+    },
+    {
+      "requirement_id": "SPEC-022-R009",
+      "spec_id": "SPEC-022",
+      "state": "pending",
+      "implementation": [],
+      "tests": [],
+      "journeys": [],
+      "evidence": [],
+      "gap": {
+        "verdict": "UNKNOWN",
+        "owner": "@Augustas11",
+        "issue": "https://github.com/Augustas11/macprovider/issues/614",
+        "rationale": "R-9 rollout, migration, and rollback (effective policy by request-start timestamp and attempt identity; no retroactive reclassification; enforced rows retain original policy/deadline/payout-exclusion across rollback; pre-existing payout-ready rows excluded from the snapshot): normative in SPEC-022 v0.1.6; settlement pipeline runs in observe mode and reconciliation to conformant is tracked under the verified-model-settlement domain."
+      }
+    },
+    {
+      "requirement_id": "SPEC-022-R010",
+      "spec_id": "SPEC-022",
+      "state": "pending",
+      "implementation": [],
+      "tests": [],
+      "journeys": [],
+      "evidence": [],
+      "gap": {
+        "verdict": "UNKNOWN",
+        "owner": "@Augustas11",
+        "issue": "https://github.com/Augustas11/macprovider/issues/614",
+        "rationale": "R-10 buyer disclosure (distinguish catalog-verified identity from unattested hardware/runtime; mixed-pool claims constrained; observe mode MUST NOT claim enforcement; excluded entrypoints named; partial-charge and failover disclosure): normative in SPEC-022 v0.1.6; settlement pipeline runs in observe mode and reconciliation to conformant is tracked under the verified-model-settlement domain."
+      }
+    },
+    {
+      "requirement_id": "SPEC-022-R011",
+      "spec_id": "SPEC-022",
+      "state": "pending",
+      "implementation": [],
+      "tests": [],
+      "journeys": [],
+      "evidence": [],
+      "gap": {
+        "verdict": "UNKNOWN",
+        "owner": "@Augustas11",
+        "issue": "https://github.com/Augustas11/macprovider/issues/614",
+        "rationale": "R-11 audit and observability (structured per-attempt settlement audit event; no raw prompts/outputs/receipt material; aggregate verified/pending/quarantined/zero_settled counters; recovery/backfill audit completeness): normative in SPEC-022 v0.1.6; settlement pipeline runs in observe mode and reconciliation to conformant is tracked under the verified-model-settlement domain."
       }
     }
   ]

--- a/specs/README.md
+++ b/specs/README.md
@@ -30,7 +30,7 @@ it can no longer drift. Do not hand-edit the table; edit each spec's
 | SPEC-019 | Structured output (`response_format: json_schema`) | 0.2.5 | normative | pending | pending corpus migration | [SPEC-019-structured-output.md](SPEC-019-structured-output.md) |
 | SPEC-020 | Provider autoupdate | v0.1.11 | normative | pending | pending: 4 | [SPEC-020-provider-autoupdate.md](SPEC-020-provider-autoupdate.md) |
 | SPEC-021 | MALIBU bootstrap rewards emission ledger | 0.1.0 | draft | pending | pending corpus migration | [SPEC-021-malibu-emission-ledger.md](SPEC-021-malibu-emission-ledger.md) |
-| SPEC-022 | Verified model settlement | v0.1.5 | draft | pending | pending corpus migration | [SPEC-022-verified-model-settlement.md](SPEC-022-verified-model-settlement.md) |
+| SPEC-022 | Verified model settlement | v0.1.6 | draft | complete | pending: 11 | [SPEC-022-verified-model-settlement.md](SPEC-022-verified-model-settlement.md) |
 | SPEC-023 | Installer-Integrated Autotune Recommend | v0.8.6 | normative | pending | pending: 2 | [SPEC-023-installer-autotune-recommend.md](SPEC-023-installer-autotune-recommend.md) |
 | SPEC-024 | Prefix-cache billing and provider-local cache isolation | 0.2.1 | normative | pending | pending corpus migration | [SPEC-024-prefix-cache-billing.md](SPEC-024-prefix-cache-billing.md) |
 | SPEC-025 | Native Mac App (signed `.dmg` + menu bar wrapper) | v0.22 | draft | pending | pending corpus migration | [SPEC-025-native-mac-app.md](SPEC-025-native-mac-app.md) |

--- a/specs/SPEC-022-verified-model-settlement.md
+++ b/specs/SPEC-022-verified-model-settlement.md
@@ -1,11 +1,21 @@
 # SPEC-022 - Verified model settlement
 
-Version: v0.1.5
+Version: v0.1.6
 Status: Draft, lock-ready after round-4 closure
 Date drafted: 2026-06-30
 Depends on: SPEC-001, SPEC-002, SPEC-005, SPEC-006, SPEC-008, SPEC-010, SPEC-011, SPEC-015, SPEC-016
 
 ## Change log
+
+### v0.1.6
+
+Editorial, non-normative: registers the conformance-unit requirement IDs
+`SPEC-022-R001`..`SPEC-022-R011` (one per normative requirement group R-1..R-11)
+in `specs/CONFORMANCE.json` and anchors each ID in the corresponding `### R-N`
+requirement-group header under `## Normative requirements`. No requirement text, obligation, or
+observable contract changes; this only migrates SPEC-022 out of the
+`requirement_id_migration: pending` state so governance declarations can cite
+verified-model-settlement requirements.
 
 ### v0.1.5
 
@@ -349,7 +359,12 @@ state and terminal-state timestamp.
 
 ## Normative requirements
 
-### R-1. Policy authority and mode
+Requirement IDs `SPEC-022-R001`..`SPEC-022-R011` are the conformance units and
+map one-to-one to the top-level requirement groups R-1..R-11 below; the `R-N.M`
+sub-clauses are the normative obligations within each group. The IDs are
+registered in `specs/CONFORMANCE.json`.
+
+### R-1. Policy authority and mode (SPEC-022-R001)
 
 R-1.1. Implementations MUST expose exactly one authoritative
 `verified_model_settlement` policy surface from the coordinator.
@@ -380,7 +395,7 @@ policy version and mode, not the current effective policy. If a service cannot
 obtain the effective policy, it MUST fail closed for paid traffic covered by the
 claim.
 
-### R-2. Entrypoint and routing preconditions
+### R-2. Entrypoint and routing preconditions (SPEC-022-R002)
 
 R-2.1. Every paid entrypoint is either covered by SPEC-022 enforce mode,
 disabled for paid traffic, or explicitly excluded from the product claim and
@@ -406,7 +421,7 @@ predicate." Ordinary routing filters still apply, including provider readiness,
 auth state, slots, model support, context limits, breaker state, quota policy,
 and sticky-affinity rules.
 
-### R-3. Route-time verification snapshot
+### R-3. Route-time verification snapshot (SPEC-022-R003)
 
 R-3.1. For every covered request attempt, the coordinator MUST create and
 persist a route-time verification snapshot before forwarding work to the
@@ -441,7 +456,7 @@ unexpired at route time. A request routed under an expired, unverifiable, or
 missing catalog MUST be quarantined and MUST NOT final-debit the buyer or pay
 the provider.
 
-### R-4. Receipt requirement
+### R-4. Receipt requirement (SPEC-022-R004)
 
 R-4.1. Every covered paid request that completes with any buyer-debitable or
 provider-creditable outcome MUST produce a settlement-capable provider-signed
@@ -474,7 +489,7 @@ or `zero_settled`) closes the row for SPEC-022 money movement. Subsequent
 receipts for the same attempt MUST be idempotent no-ops or rejected and MUST NOT
 change buyer debit, provider credit, payout readiness, or settlement outcome.
 
-### R-5. Streaming receipts
+### R-5. Streaming receipts (SPEC-022-R005)
 
 R-5.1. Streaming requests are first-class paid traffic. They MUST satisfy the
 same settlement-capable receipt requirement as non-streaming requests before
@@ -530,7 +545,7 @@ the sum of verified billable per-attempt prefixes. Unverified prefixes MUST NOT
 be final-debited to the buyer or positively settled to any provider. Overlapping
 or duplicate output across attempts MUST NOT be charged or credited twice.
 
-### R-6. Buyer receipt retrieval
+### R-6. Buyer receipt retrieval (SPEC-022-R006)
 
 R-6.1. If a buyer receipt retrieval endpoint is exposed, the requester MUST
 authenticate as the account that owns the exact `(account_id, request_id,
@@ -546,7 +561,7 @@ R-6.4. The retrieval spec MUST define retention, rate limits, idempotency,
 404/403 behavior, and whether pending/quarantined receipts are visible to
 buyers.
 
-### R-7. Settlement, quarantine, and payout exclusion
+### R-7. Settlement, quarantine, and payout exclusion (SPEC-022-R007)
 
 R-7.1. SPEC-005 settlement MUST add a receipt-verification gate before any row
 can create final buyer debit, provider credit, earnings visibility, settlement
@@ -591,7 +606,7 @@ may define an exception only with a receipt-failure-specific hold, evidence
 bundle, dual-control audit trail, and explicit exclusion from automatic payout
 until hold expiry.
 
-### R-8. Buyer debit semantics
+### R-8. Buyer debit semantics (SPEC-022-R008)
 
 R-8.1. Covered traffic uses reservation-first buyer accounting. Buyer quota or
 balance may be reserved while the request runs, but final debit MUST wait for
@@ -623,7 +638,7 @@ many agentic requests are in flight, and release behavior after terminal
 outcomes. A terminal SPEC-022 row MUST NOT permanently reduce buyer available
 quota through a stale reservation.
 
-### R-9. Rollout, migration, and rollback
+### R-9. Rollout, migration, and rollback (SPEC-022-R009)
 
 R-9.1. The effective policy applies by request-start timestamp and request
 attempt identity.
@@ -643,7 +658,7 @@ R-9.5. Pre-existing payout-ready rows created before SPEC-022 enforce mode MUST
 be explicitly classified as outside the policy snapshot. They MUST NOT be used
 as evidence that SPEC-022 enforcement is active.
 
-### R-10. Buyer disclosure
+### R-10. Buyer disclosure (SPEC-022-R010)
 
 R-10.1. `/v1/models` and product docs MUST distinguish:
 
@@ -681,7 +696,7 @@ request can briefly keep quota reserved while receipt verification is pending,
 and that the reservation releases or refunds on a non-`verified` terminal
 outcome.
 
-### R-11. Audit and observability
+### R-11. Audit and observability (SPEC-022-R011)
 
 R-11.1. Every covered request attempt MUST produce a structured settlement
 verdict audit event containing at least:


### PR DESCRIPTION
## Summary

Migrates **SPEC-022 (verified-model-settlement)** into the requirement-ID
conformance system: registers `SPEC-022-R001`..`SPEC-022-R011` — one per
top-level normative requirement group R-1..R-11 — in `specs/CONFORMANCE.json`,
and flips SPEC-022 `requirement_id_migration` from `"pending"` to `"complete"`.

## Why

The `verified-model-settlement` authority domain (owner SPEC-022; consumers
SPEC-005/015/016) had **zero** migrated requirement IDs in `CONFORMANCE.json`.
Consequently any behaviour-change PR touching settlement — e.g.
[#833](https://github.com/Augustas11/macprovider/pull/833), the coordinator
`usage_mismatch` fix — cannot file a valid `SPEC-GOVERNANCE` declaration
(`behavior_change: yes` on a non-governance path requires a real requirement ID,
and `"none"` is disallowed there), so the advisory `spec-index / check`
declaration substep fails for an unmigrated corpus rather than for anything wrong
in the PR. This migration provides citable IDs and closes that gap for the whole
domain. Same pattern already applied to SPEC-035/036/037.

## What changed

- `specs/CONFORMANCE.json` — add 11 `SPEC-022-R0NN` requirement entries (state
  `pending`, empty implementation/tests/journeys/evidence, owned issue-linked gap
  `#614`), and set SPEC-022 `requirement_id_migration: "complete"`, `version:
  "v0.1.6"`, with a migration rationale on its gap.
- `specs/SPEC-022-verified-model-settlement.md` — anchor each ID in its `### R-N.`
  header, add a mapping note, bump to v0.1.6 with an **editorial, non-normative**
  changelog entry.
- `specs/README.md` — regenerated index.

**No requirement text, obligation, or observable contract changes.** The IDs are
one-to-one with the existing normative groups; nothing about settlement behaviour,
money movement, or the SPEC's obligations is altered. All entries are `pending`
because the settlement pipeline's conformance reconciliation is still tracked
under `#614` — identical to how SPEC-035/036/037 registered their catalogs.

## Verification (local governance gates)

- `python3 scripts/check_spec_governance.py` → **passed**
- `python3 scripts/gen_spec_index.py --check` → **ok: spec index is up to date**
- `python3 scripts/gen_spec_index.py --lint` → **ok: specs/ root is canonical-only**
- `python3 scripts/check_spec_pr_declaration.py` (this PR's declaration) →
  **no errors** — so the `check` job (including the declaration substep) passes.

## Audit (3-lane codex)

Governance-correctness / declaration / side-effects lanes — verdicts in the PR
thread; bar 0 C/H/M.

## Follow-up

Once merged, [#833](https://github.com/Augustas11/macprovider/pull/833) rebases
and updates its declaration to cite `SPEC-022-R003` (route-time verification
snapshot / usage cross-check — the requirement its fix enforces), turning its
`check` job green as well.

SPEC-GOVERNANCE-DECLARATION-BEGIN
{
  "schema_version": "spec-pr-governance-v1",
  "behavior_change": "none",
  "contract_change": "yes",
  "specs": ["SPEC-022"],
  "requirements": [],
  "authority_domains": ["verified-model-settlement"],
  "arbitration": [],
  "tests": [],
  "journeys": [],
  "issue": "https://github.com/Augustas11/macprovider/issues/614"
}
SPEC-GOVERNANCE-DECLARATION-END

🤖 Generated with [Claude Code](https://claude.com/claude-code)
