### PR TITLE
fix(nginx): route /providers/ to coordinator :8444 (unbreak provider earnings $0.00)

### DIFF
--- a/phase4-coordinator/dist/nginx-coordinator.streamvc.live.conf
+++ b/phase4-coordinator/dist/nginx-coordinator.streamvc.live.conf
@@ -173,6 +173,22 @@ server {
         proxy_read_timeout 30s;
     }
 
+    # Provider-facing earnings/payout endpoints served by the coordinator
+    # provider mux on :8444 — GET /providers/{id}/earnings (provider-token
+    # authenticated; SPEC-016 payout-address endpoints share the /providers/
+    # mount). Without this route nginx returns 404 and EVERY provider's Malibu
+    # card shows $0.00, because the earnings client resolves coordinator_url
+    # into https://<host>/providers/{id}/earnings. Prefix location: longest
+    # match wins over `location /`, so ordering here is not load-bearing.
+    location /providers/ {
+        proxy_pass http://127.0.0.1:8444;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header Authorization $http_authorization;
+        proxy_read_timeout 30s;
+    }
+
     # ---------------------------------------------------------------------
     # /v1/receipt-keys/<provider_id> — public buyer endpoint per SPEC-002
     # v1.5 candidate annotation + SPEC-015 §10.7. UNAUTHENTICATED. Lives on


### PR DESCRIPTION
## Summary

Adds the missing `location /providers/` route to the coordinator nginx template
so the public **provider earnings endpoint is reachable**. This is the root
cause of every Malibu provider card showing **$0.00**.

## Root cause

The coordinator mounts `GET /providers/{id}/earnings` (and the SPEC-016 payout
address endpoints) on the **provider mux at `127.0.0.1:8444`**. The nginx site
template (`phase4-coordinator/dist/nginx-coordinator.streamvc.live.conf`) had
**no `/providers/` location**, so `https://coordinator.streamvc.live/providers/{id}/earnings`
returned nginx **404**. The provider earnings client resolves `coordinator_url`
into exactly that URL, so every provider's card decoded nil money fields → `$0.00`,
`Pending: <unknown>`, "waiting for the first paid job" — regardless of real credits.

Same class of nginx route-gap as the signed-feed endpoints (#822–#825).

## What changed

One `location /providers/` block proxying to `:8444`, mirroring the existing
`/admin/` block (passes `Authorization`; prefix location so longest-match wins
over `location /` — ordering is not load-bearing).

## Verified live (before this backport)

The live Pearl vhost was patched directly during incident response (backup +
`nginx -t` + reload). After the route was added:

```
GET https://coordinator.streamvc.live/providers/{id}/earnings
-> HTTP 200
   usdc_lifetime = 0.083632
   usdc_pending  = 0.083632
   total_credits = 83632
```
(was HTTP 404 before). This backport keeps the tracked template in sync so the
**next coordinator deploy does not regress the fix**.

## Governance declaration

Cites **`SPEC-022-R007`** (verified-model-settlement R-7: settlement, quarantine,
and payout exclusion — the requirement that governs **earnings visibility** and
the **earnings APIs**). This nginx route makes the provider earnings API actually
reachable, so it serves that requirement's earnings-visibility surface.
`SPEC-022-R00N` requirement IDs were registered in #834, so this cites a real
requirement and the `spec-index / check` job passes.

SPEC-GOVERNANCE-DECLARATION-BEGIN
{
  "schema_version": "spec-pr-governance-v1",
  "behavior_change": "yes",
  "contract_change": "none",
  "specs": ["SPEC-022"],
  "requirements": ["SPEC-022-R007"],
  "authority_domains": ["verified-model-settlement"],
  "arbitration": ["CODE_BUG"],
  "tests": ["not-required"],
  "journeys": ["not-required"],
  "issue": "https://github.com/Augustas11/macprovider/issues/614"
}
SPEC-GOVERNANCE-DECLARATION-END

🤖 Generated with [Claude Code](https://claude.com/claude-code)
