### PR TITLE
Gate stable releases on live coordinator readiness

### DIFF
--- a/.github/workflows/promote-acceptance-candidate.yml
+++ b/.github/workflows/promote-acceptance-candidate.yml
@@ -469,6 +469,15 @@ jobs:
             echo "FAIL: origin/main moved under bound exception authority before undraft" >&2
             exit 1
           fi
+          echo "::group::Verify live coordinator release gate"
+          env -u GH_TOKEN -u RELEASE_POSTURE_TOKEN \
+            python3 scripts/verify-live-coordinator-release-gate.py \
+            --tag "$TAG" \
+            --pearl-release-json "$accepted/pearl-release.json" \
+            --trusted-keys "$accepted/trusted-keys.json" \
+            --coordinator-url https://coordinator.streamvc.live \
+            --openssl "$OPENSSL_BIN"
+          echo "::endgroup::"
           # Repository rules and the production-release environment serialize
           # the sole owner publication path. Re-fetch the exact numeric draft
           # and tag immediately before this irreversible transition.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1808,6 +1808,18 @@ jobs:
             final-draft-by-id.json release-provenance.json final-draft-manifest.json \
             "${release_assets[@]}" checksums.txt checksums.txt.sig
 
+          if [ "$PRERELEASE_INPUT" = false ]; then
+            echo "::group::Verify live coordinator release gate"
+            env -u GH_TOKEN -u RELEASE_POSTURE_TOKEN \
+              python3 scripts/verify-live-coordinator-release-gate.py \
+              --tag "$tag" \
+              --pearl-release-json pearl-release.json \
+              --trusted-keys trusted-keys.json \
+              --coordinator-url https://coordinator.streamvc.live \
+              --openssl "$OPENSSL_BIN"
+            echo "::endgroup::"
+          fi
+
           gh api --method PATCH -H 'X-GitHub-Api-Version: 2026-03-10' \
             "repos/$GITHUB_REPOSITORY/releases/$release_id" \
             -F draft=false \

--- a/Makefile
+++ b/Makefile
@@ -58,6 +58,7 @@ test-dist:
 	bash scripts/test-malibu-independent-release.sh
 	bash scripts/test-release-tag-target.sh
 	bash scripts/test-pearl-runtime-release.sh
+	bash scripts/test-live-coordinator-release-gate.sh
 	bash scripts/test-release-security-posture.sh
 	bash scripts/test-malibu-bootstrap-bridge.sh
 	bash scripts/test-recover-malibu-publication.sh

--- a/scripts/test-acceptance-promotion.sh
+++ b/scripts/test-acceptance-promotion.sh
@@ -111,6 +111,33 @@ if 'git merge-base --is-ancestor "$CONTROL_SHA"' not in protected:
     raise SystemExit("acceptance signer control commit need not remain reachable from main")
 if protected.count('scripts/verify-release-tag-target.sh "$TAG" "$CANDIDATE_SHA" origin --require-existing') < 2:
     raise SystemExit("exact protected tag is not revalidated immediately before publication")
+publish_step = protected.split(
+    "- name: Reverify and publish only the captured numeric draft", 1
+)[1].split("\n      - name:", 1)[0]
+live_gate = publish_step.find("scripts/verify-live-coordinator-release-gate.py")
+patch = publish_step.find("gh api --method PATCH")
+final_draft_capture = publish_step.find("scripts/capture-release-publication.py --draft")
+final_authority = publish_step.find("origin/main moved under bound exception authority before undraft")
+if live_gate < 0:
+    raise SystemExit("promotion public-transition step omits the live coordinator release gate")
+if patch < 0:
+    raise SystemExit("promotion public-transition step lost numeric release PATCH")
+if final_draft_capture < 0 or final_authority < 0:
+    raise SystemExit("promotion public-transition step lost final draft or authority regate")
+if live_gate < final_draft_capture or live_gate < final_authority:
+    raise SystemExit("promotion live coordinator gate must run after final draft and authority regates")
+if live_gate > patch or publish_step.find("-F draft=false") < live_gate:
+    raise SystemExit("promotion live coordinator gate must run before undraft/latest publication")
+for requirement in (
+    "env -u GH_TOKEN -u RELEASE_POSTURE_TOKEN",
+    "--tag \"$TAG\"",
+    "--pearl-release-json \"$accepted/pearl-release.json\"",
+    "--trusted-keys \"$accepted/trusted-keys.json\"",
+    "--coordinator-url https://coordinator.streamvc.live",
+    "--openssl \"$OPENSSL_BIN\"",
+):
+    if requirement not in publish_step:
+        raise SystemExit(f"promotion live coordinator gate omits: {requirement}")
 if '[\\"candidate_ref\\"]' in protected or '.removeprefix(\\"refs/heads/\\")' in protected:
     raise SystemExit("candidate ref extraction contains shell-literal Python escapes")
 if 'print(json.load(open(sys.argv[1]))["candidate_ref"])' not in protected:

--- a/scripts/test-live-coordinator-release-gate.sh
+++ b/scripts/test-live-coordinator-release-gate.sh
@@ -1,0 +1,446 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+guard="$root/scripts/verify-live-coordinator-release-gate.py"
+workflow="$root/.github/workflows/release.yml"
+promotion_workflow="$root/.github/workflows/promote-acceptance-candidate.yml"
+work="$(mktemp -d "${TMPDIR:-/tmp}/live-coordinator-release-gate.XXXXXX")"
+trap 'rm -rf "$work"' EXIT
+
+fail() {
+  echo "FAIL: $*" >&2
+  exit 1
+}
+
+bash -n "$0"
+python3 -m py_compile "$guard"
+
+make_fixture() {
+  local directory="$1"
+  local tag="${2:-v1.8.68}"
+  local live_version="${3:-v1.8.68}"
+  local generated_at="${4:-2026-07-30T12:00:00Z}"
+  local demand_generated_at="${5:-$generated_at}"
+  local signer="${6:-streamvc-autotune-static-v4}"
+  rm -rf "$directory"
+  mkdir -p "$directory/live"
+  python3 - "$directory" "$tag" "$live_version" "$generated_at" "$demand_generated_at" "$signer" <<'PY'
+import hashlib
+import json
+import base64
+import pathlib
+import subprocess
+import sys
+
+directory = pathlib.Path(sys.argv[1])
+tag = sys.argv[2]
+live_version = sys.argv[3]
+generated_at = sys.argv[4]
+demand_generated_at = sys.argv[5]
+signer = sys.argv[6]
+live = directory / "live"
+policy_version = "autotune-policy-v1"
+key_path = directory / "autotune-test-ed25519.pem"
+subprocess.run(
+    ["openssl", "genpkey", "-algorithm", "Ed25519", "-out", str(key_path)],
+    check=True,
+    stdout=subprocess.DEVNULL,
+    stderr=subprocess.PIPE,
+    text=True,
+)
+public_der = subprocess.check_output(
+    ["openssl", "pkey", "-in", str(key_path), "-pubout", "-outform", "DER"],
+)
+public_key_base64 = base64.b64encode(public_der[-32:]).decode("ascii")
+
+def write_endpoint(name, value):
+    (live / name).write_text(
+        json.dumps(value, sort_keys=True, separators=(",", ":")) + "\n",
+        encoding="utf-8",
+    )
+
+write_endpoint("v1_autotune-candidates", {
+    "version": "fixture-release",
+    "generated_at": generated_at,
+    "policy_version": policy_version,
+    "source": "fixture",
+    "rows": {},
+})
+write_endpoint("v1_demand-rank", {
+    "version": "fixture-release",
+    "generated_at": demand_generated_at,
+    "policy_version": policy_version,
+    "source": "fixture",
+    "cold_start_floor": 0.15,
+    "diversification_band": 0.85,
+    "rows": {},
+})
+write_endpoint("v1_rate-card", {
+    "version": "fixture-rate-card",
+    "generated_at": generated_at,
+    "policy_version": policy_version,
+    "usd_per_million_credits": 1.0,
+    "rows": {
+        "default": {
+            "prompt_rate_per_mtok": 1,
+            "prompt_cache_hit_rate_per_mtok": 1,
+            "completion_rate_per_mtok": 1,
+            "provider_share_bps": 9000,
+            "global_multiplier_ppm": 1000000,
+        }
+    },
+})
+
+for feed_name, sig_name in (
+    ("v1_autotune-candidates", "v1_autotune-candidates.sig"),
+    ("v1_demand-rank", "v1_demand-rank.sig"),
+    ("v1_rate-card", "v1_rate-card.sig"),
+):
+    signature = subprocess.check_output(
+        [
+            "openssl",
+            "pkeyutl",
+            "-sign",
+            "-inkey",
+            str(key_path),
+            "-rawin",
+            "-in",
+            str(live / feed_name),
+        ],
+    )
+    write_endpoint(sig_name, {
+        "alg": "ed25519",
+        "key_id": signer,
+        "signature": base64.b64encode(signature).decode("ascii"),
+    })
+write_endpoint("healthz.json", {"status": "ok", "version": live_version})
+
+(directory / "trusted-keys.json").write_text(
+    json.dumps({
+        "schema_version": "macprovider.autotune-keys.v1",
+        "keys": {
+            "streamvc-autotune-static-v4": {
+                "status": "active",
+                "public_key_base64": public_key_base64,
+            }
+        },
+    }, sort_keys=True, separators=(",", ":")) + "\n",
+    encoding="utf-8",
+)
+endpoint_to_asset = {
+    "autotune-candidates.json": "v1_autotune-candidates",
+    "autotune-candidates.json.sig": "v1_autotune-candidates.sig",
+    "demand-rank.json": "v1_demand-rank",
+    "demand-rank.json.sig": "v1_demand-rank.sig",
+    "rate-card.json": "v1_rate-card",
+    "rate-card.json.sig": "v1_rate-card.sig",
+}
+files = {
+    asset: hashlib.sha256((live / endpoint).read_bytes()).hexdigest()
+    for asset, endpoint in endpoint_to_asset.items()
+}
+files["trusted-keys.json"] = hashlib.sha256((directory / "trusted-keys.json").read_bytes()).hexdigest()
+metadata = {
+    "schema_version": 1,
+    "release_lane": "pearl_runtime_catalog",
+    "repository": "Augustas11/macprovider",
+    "tag": tag,
+    "release_version": tag.removeprefix("v"),
+    "provider_advertised_version": tag.removeprefix("v"),
+    "commit": "a" * 40,
+    "architecture": "linux-amd64",
+    "catalog": {
+        "release_id": "fixture-release",
+        "policy_version": policy_version,
+        "files": files,
+    },
+}
+(directory / "pearl-release.json").write_text(
+    json.dumps(metadata, sort_keys=True, separators=(",", ":")) + "\n",
+    encoding="utf-8",
+)
+PY
+}
+
+run_guard() {
+  local directory="$1"
+  python3 "$guard" \
+    --tag v1.8.68 \
+    --pearl-release-json "$directory/pearl-release.json" \
+    --trusted-keys "$directory/trusted-keys.json" \
+    --coordinator-url https://coordinator.fixture.invalid \
+    --coordinator-dir "$directory/live" \
+    --now 2026-07-30T12:05:00Z
+}
+
+make_fixture "$work/ok"
+run_guard "$work/ok" | grep -q 'ok: https://coordinator.fixture.invalid serves v1.8.68 feed set'
+
+make_fixture "$work/git-describe-healthz" v1.8.68 v1.8.69-2-gabcdef0
+run_guard "$work/git-describe-healthz" | grep -q 'healthz_version=v1.8.69-2-gabcdef0'
+
+make_fixture "$work/prerelease-healthz" v1.8.68 v1.8.68-rc.1
+if run_guard "$work/prerelease-healthz" >"$work/prerelease-healthz.out" 2>&1; then
+  fail "accepted a prerelease coordinator health version"
+fi
+grep -q "/healthz version is not vX.Y.Z or X.Y.Z: 'v1.8.68-rc.1'" "$work/prerelease-healthz.out"
+
+make_fixture "$work/dirty-healthz" v1.8.68 v1.8.68-dirty
+if run_guard "$work/dirty-healthz" >"$work/dirty-healthz.out" 2>&1; then
+  fail "accepted a dirty coordinator health version"
+fi
+grep -q "/healthz version is not vX.Y.Z or X.Y.Z: 'v1.8.68-dirty'" "$work/dirty-healthz.out"
+
+make_fixture "$work/missing-sig"
+rm "$work/missing-sig/live/v1_rate-card.sig"
+if run_guard "$work/missing-sig" >"$work/missing-sig.out" 2>&1; then
+  fail "accepted a live coordinator missing rate-card.sig"
+fi
+grep -q 'fixture coordinator response is missing for /v1/rate-card.sig' "$work/missing-sig.out"
+
+make_fixture "$work/stale-healthz" v1.8.68 v1.8.67
+if run_guard "$work/stale-healthz" >"$work/stale-healthz.out" 2>&1; then
+  fail "accepted a coordinator older than the shipped CLI release"
+fi
+grep -q "/healthz version 'v1.8.67' is older than release 1.8.68" "$work/stale-healthz.out"
+
+make_fixture "$work/hash-drift"
+printf '\n' >> "$work/hash-drift/live/v1_rate-card"
+if run_guard "$work/hash-drift" >"$work/hash-drift.out" 2>&1; then
+  fail "accepted live feed bytes that differ from release metadata"
+fi
+grep -q 'live coordinator /v1/rate-card sha256 .* does not match release metadata' "$work/hash-drift.out"
+
+make_fixture "$work/unpaired" v1.8.68 v1.8.68 2026-07-30T12:00:00Z 2026-07-30T12:00:01Z
+if run_guard "$work/unpaired" >"$work/unpaired.out" 2>&1; then
+  fail "accepted feeds that are not mutually paired"
+fi
+grep -q 'feed set is not mutually paired by generated_at and policy_version' "$work/unpaired.out"
+
+make_fixture "$work/future-feed" v1.8.68 v1.8.68 2026-07-30T12:15:01Z
+if run_guard "$work/future-feed" >"$work/future-feed.out" 2>&1; then
+  fail "accepted a live feed generated more than 10 minutes in the future"
+fi
+grep -q "generated_at '2026-07-30T12:15:01Z' is more than 10 minutes in the future" "$work/future-feed.out"
+
+make_fixture "$work/stale-feed" v1.8.68 v1.8.68 2026-06-30T12:04:59Z
+if run_guard "$work/stale-feed" >"$work/stale-feed.out" 2>&1; then
+  fail "accepted a live feed generated more than 30 days ago"
+fi
+grep -q "generated_at '2026-06-30T12:04:59Z' is more than 30 days old" "$work/stale-feed.out"
+
+make_fixture "$work/bad-signature"
+python3 - "$work/bad-signature" <<'PY'
+import base64
+import hashlib
+import json
+import pathlib
+import sys
+
+directory = pathlib.Path(sys.argv[1])
+sig_path = directory / "live" / "v1_rate-card.sig"
+sidecar = json.loads(sig_path.read_text(encoding="utf-8"))
+sidecar["signature"] = base64.b64encode(b"\0" * 64).decode("ascii")
+sig_path.write_text(json.dumps(sidecar, sort_keys=True, separators=(",", ":")) + "\n", encoding="utf-8")
+metadata_path = directory / "pearl-release.json"
+metadata = json.loads(metadata_path.read_text(encoding="utf-8"))
+metadata["catalog"]["files"]["rate-card.json.sig"] = hashlib.sha256(sig_path.read_bytes()).hexdigest()
+metadata_path.write_text(json.dumps(metadata, sort_keys=True, separators=(",", ":")) + "\n", encoding="utf-8")
+PY
+if run_guard "$work/bad-signature" >"$work/bad-signature.out" 2>&1; then
+  fail "accepted a metadata-bound signature sidecar that does not verify"
+fi
+grep -q 'rate-card.json.sig signature verification failed' "$work/bad-signature.out"
+
+make_fixture "$work/unknown-signer" v1.8.68 v1.8.68 2026-07-30T12:00:00Z 2026-07-30T12:00:00Z unknown-static-key
+if run_guard "$work/unknown-signer" >"$work/unknown-signer.out" 2>&1; then
+  fail "accepted a signature key outside the release trusted keyring"
+fi
+grep -q "key_id 'unknown-static-key' is not in the release trusted keyring" "$work/unknown-signer.out"
+
+make_fixture "$work/disabled-key"
+python3 - "$work/disabled-key" <<'PY'
+import hashlib
+import json
+import pathlib
+import sys
+
+directory = pathlib.Path(sys.argv[1])
+trusted = directory / "trusted-keys.json"
+value = json.loads(trusted.read_text(encoding="utf-8"))
+value["keys"]["streamvc-autotune-static-v4"]["status"] = "disabled"
+trusted.write_text(json.dumps(value, sort_keys=True, separators=(",", ":")) + "\n", encoding="utf-8")
+metadata = json.loads((directory / "pearl-release.json").read_text(encoding="utf-8"))
+metadata["catalog"]["files"]["trusted-keys.json"] = hashlib.sha256(trusted.read_bytes()).hexdigest()
+(directory / "pearl-release.json").write_text(
+    json.dumps(metadata, sort_keys=True, separators=(",", ":")) + "\n",
+    encoding="utf-8",
+)
+PY
+if run_guard "$work/disabled-key" >"$work/disabled-key.out" 2>&1; then
+  fail "accepted an unsupported trusted key status"
+fi
+grep -q "status is unsupported: 'disabled'" "$work/disabled-key.out"
+
+make_fixture "$work/keyring-drift"
+python3 - "$work/keyring-drift/trusted-keys.json" <<'PY'
+import json
+import pathlib
+import sys
+
+path = pathlib.Path(sys.argv[1])
+value = json.loads(path.read_text(encoding="utf-8"))
+value["keys"]["streamvc-autotune-static-extra"] = {
+    "status": "active",
+    "public_key_base64": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+}
+path.write_text(json.dumps(value, sort_keys=True, separators=(",", ":")) + "\n", encoding="utf-8")
+PY
+if run_guard "$work/keyring-drift" >"$work/keyring-drift.out" 2>&1; then
+  fail "accepted trusted-keys.json that differs from release metadata"
+fi
+grep -q 'trusted-keys.json sha256 .* does not match release metadata' "$work/keyring-drift.out"
+
+make_fixture "$work/http-policy"
+if python3 "$guard" \
+  --tag v1.8.68 \
+  --pearl-release-json "$work/http-policy/pearl-release.json" \
+  --trusted-keys "$work/http-policy/trusted-keys.json" \
+  --coordinator-url http://coordinator.fixture.invalid \
+  >"$work/http-policy.out" 2>&1; then
+  fail "accepted a non-HTTPS live coordinator URL"
+fi
+grep -q -- '--coordinator-url must use https:// for live verification' "$work/http-policy.out"
+
+python3 - "$guard" <<'PY'
+import importlib.util
+import types
+import urllib.error
+import sys
+
+spec = importlib.util.spec_from_file_location("live_gate", sys.argv[1])
+live_gate = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(live_gate)
+
+captured_headers = {}
+
+class RedirectingOpener:
+    def open(self, request, timeout):
+        captured_headers.update(request.header_items())
+        raise urllib.error.HTTPError(
+            request.full_url,
+            302,
+            "Found",
+            {"Location": "https://coordinator.fixture.invalid/other"},
+            None,
+        )
+
+live_gate.urllib.request.build_opener = lambda *args, **kwargs: RedirectingOpener()
+args = types.SimpleNamespace(
+    coordinator_dir=None,
+    coordinator_url="https://coordinator.fixture.invalid",
+    timeout_s=1,
+    max_bytes=1024,
+)
+try:
+    live_gate.load_endpoint(args, "/v1/rate-card")
+except live_gate.GateError as exc:
+    message = str(exc)
+else:
+    raise SystemExit("accepted redirected live coordinator response")
+if "redirected with HTTP 302" not in message:
+    raise SystemExit(f"expected redirect rejection, got: {message}")
+if captured_headers.get("Cache-control") != "no-cache" or captured_headers.get("Pragma") != "no-cache":
+    raise SystemExit(f"expected no-cache request headers, got: {captured_headers}")
+if captured_headers.get("User-agent") not in ("", None):
+    raise SystemExit(f"expected no gate-specific user-agent, got: {captured_headers}")
+PY
+
+python3 - "$workflow" "$promotion_workflow" <<'PY'
+import pathlib
+import sys
+
+def require_stable_gate(
+    workflow_path,
+    step_name,
+    tag_arg,
+    pearl_release_arg,
+    trusted_keys_arg,
+    final_authority_marker=None,
+):
+    workflow = pathlib.Path(workflow_path).read_text(encoding="utf-8")
+    if "Verify live coordinator release gate" not in workflow:
+        raise SystemExit(f"{workflow_path} must include the live coordinator release gate")
+    if "scripts/verify-live-coordinator-release-gate.py" not in workflow:
+        raise SystemExit(f"{workflow_path} must call the live coordinator release gate")
+    publish = workflow.split(f"- name: {step_name}", 1)[1]
+    checksum_verify = publish.find("scripts/verify-release-checksums.sh")
+    draft_capture = publish.find("scripts/capture-release-publication.py --draft")
+    final_authority = (
+        publish.find(final_authority_marker)
+        if final_authority_marker is not None
+        else -1
+    )
+    public_patch = publish.find("gh api --method PATCH")
+    draft_false = publish.find("-F draft=false")
+    make_latest = publish.find("-f make_latest")
+    published = publish.find("scripts/verify-published-release.py")
+    gate_label = publish.find("Verify live coordinator release gate")
+    gate = publish.find("scripts/verify-live-coordinator-release-gate.py")
+    discovery = publish.find("- name: Publish one append-only immutable discovery transport")
+    if checksum_verify < 0:
+        raise SystemExit(f"{workflow_path} lost signed checksum verification")
+    if draft_capture < 0:
+        raise SystemExit(f"{workflow_path} lost final draft publication capture")
+    if final_authority_marker is not None and final_authority < 0:
+        raise SystemExit(f"{workflow_path} lost final exception/source authority gate")
+    if public_patch < 0 or draft_false < 0 or make_latest < 0:
+        raise SystemExit(f"{workflow_path} lost public/latest publication transition")
+    if published < 0:
+        raise SystemExit(f"{workflow_path} lost immutable publication verification")
+    if gate_label < 0 or gate < 0:
+        raise SystemExit(f"{workflow_path} lost live coordinator gate label or command")
+    if gate < gate_label:
+        raise SystemExit("live coordinator gate command must follow its gate label")
+    if gate < checksum_verify:
+        raise SystemExit("live coordinator gate command must run after signed checksum verification")
+    if gate < draft_capture:
+        raise SystemExit("live coordinator gate command must run after final draft publication capture")
+    if final_authority_marker is not None and gate < final_authority:
+        raise SystemExit("live coordinator gate command must run after final exception/source authority gate")
+    if gate > public_patch or gate > draft_false or gate > make_latest:
+        raise SystemExit("live coordinator gate command must run before public/latest publication")
+    if published < public_patch:
+        raise SystemExit("immutable publication verification must run after publication")
+    if discovery >= 0 and gate > discovery:
+        raise SystemExit("live coordinator gate command must run before follow-on publication side effects")
+    for required in (
+        tag_arg,
+        pearl_release_arg,
+        trusted_keys_arg,
+        "--coordinator-url https://coordinator.streamvc.live",
+        "--openssl \"$OPENSSL_BIN\"",
+        "env -u GH_TOKEN -u RELEASE_POSTURE_TOKEN",
+    ):
+        if required not in publish:
+            raise SystemExit(f"live coordinator gate call is missing {required}")
+
+require_stable_gate(
+    sys.argv[1],
+    "Publish only the revalidated numeric draft",
+    "--tag \"$tag\"",
+    "--pearl-release-json pearl-release.json",
+    "--trusted-keys trusted-keys.json",
+)
+require_stable_gate(
+    sys.argv[2],
+    "Reverify and publish only the captured numeric draft",
+    "--tag \"$TAG\"",
+    "--pearl-release-json \"$accepted/pearl-release.json\"",
+    "--trusted-keys \"$accepted/trusted-keys.json\"",
+    final_authority_marker="origin/main moved under bound exception authority before undraft",
+)
+PY
+
+echo "PASS: live coordinator release gate"

--- a/scripts/test-release-security-posture.sh
+++ b/scripts/test-release-security-posture.sh
@@ -286,7 +286,7 @@ PROTECTED_OPENSSL_CONSUMERS = (
     ("Prepare release assets", 4, 1),
     ("Require an advancing immutable discovery head", 2, 2),
     ("Create verified draft GitHub release", 1, 1),
-    ("Publish only the revalidated numeric draft", 1, 1),
+    ("Publish only the revalidated numeric draft", 2, 2),
     ("Publish one append-only immutable discovery transport", 1, 1),
     ("Publish one-time Malibu 1.8.32 bootstrap bridge to Pearl", 0, 0),
 )

--- a/scripts/verify-live-coordinator-release-gate.py
+++ b/scripts/verify-live-coordinator-release-gate.py
@@ -1,0 +1,386 @@
+#!/usr/bin/env python3
+import argparse
+import base64
+import datetime
+import hashlib
+import json
+import os
+import pathlib
+import re
+import subprocess
+import sys
+import tempfile
+import urllib.error
+import urllib.request
+
+
+FEEDS = {
+    "autotune-candidates.json": "/v1/autotune-candidates",
+    "autotune-candidates.json.sig": "/v1/autotune-candidates.sig",
+    "demand-rank.json": "/v1/demand-rank",
+    "demand-rank.json.sig": "/v1/demand-rank.sig",
+    "rate-card.json": "/v1/rate-card",
+    "rate-card.json.sig": "/v1/rate-card.sig",
+}
+PRIMARY_FEEDS = ("autotune-candidates.json", "demand-rank.json", "rate-card.json")
+SIG_FEEDS = ("autotune-candidates.json.sig", "demand-rank.json.sig", "rate-card.json.sig")
+RELEASE_CATALOG_FILES = tuple(FEEDS) + ("trusted-keys.json",)
+SHA256_RE = re.compile(r"^[0-9a-f]{64}$")
+TAG_RE = re.compile(r"^v([0-9]+)\.([0-9]+)\.([0-9]+)$")
+VERSION_RE = re.compile(r"^v?([0-9]+)\.([0-9]+)\.([0-9]+)(?:-[0-9]+-g[0-9a-f]{7,40})?$")
+ED25519_SPKI_DER_PREFIX = bytes.fromhex("302a300506032b6570032100")
+TRUSTED_KEY_STATUSES = {"active", "bridge"}
+FUTURE_TOLERANCE = datetime.timedelta(minutes=10)
+STALE_AFTER = datetime.timedelta(days=30)
+
+
+class GateError(Exception):
+    pass
+
+
+class NoRedirectHandler(urllib.request.HTTPRedirectHandler):
+    def redirect_request(self, req, fp, code, msg, headers, newurl):
+        return None
+
+
+def fail(message: str) -> None:
+    raise GateError(message)
+
+
+def read_json(path: pathlib.Path, label: str) -> object:
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except Exception as exc:
+        fail(f"{label} is not valid JSON: {exc}")
+
+
+def parse_semver(value: object, label: str) -> tuple[int, int, int]:
+    if not isinstance(value, str):
+        fail(f"{label} is not a version string")
+    match = VERSION_RE.fullmatch(value.strip())
+    if match is None:
+        fail(f"{label} is not vX.Y.Z or X.Y.Z: {value!r}")
+    return tuple(int(part) for part in match.groups())
+
+
+def endpoint_file_name(path: str) -> str:
+    return path.removeprefix("/").replace("/", "_")
+
+
+def load_endpoint(args: argparse.Namespace, path: str) -> bytes:
+    if args.coordinator_dir:
+        root = pathlib.Path(args.coordinator_dir)
+        candidates = [root / endpoint_file_name(path)]
+        if path == "/healthz":
+            candidates.append(root / "healthz.json")
+        for candidate in candidates:
+            if candidate.is_file():
+                return candidate.read_bytes()
+        fail(f"fixture coordinator response is missing for {path}")
+
+    base = args.coordinator_url.rstrip("/")
+    if not base.startswith("https://"):
+        fail("--coordinator-url must use https:// for live verification")
+    url = base + path
+    request = urllib.request.Request(
+        url,
+        headers={
+            "User-Agent": "",
+            "Cache-Control": "no-cache",
+            "Pragma": "no-cache",
+        },
+    )
+    opener = urllib.request.build_opener(NoRedirectHandler)
+    try:
+        with opener.open(request, timeout=args.timeout_s) as response:
+            status = getattr(response, "status", None)
+            if status != 200:
+                fail(f"{url} returned HTTP {status}, expected 200")
+            return response.read(args.max_bytes + 1)
+    except urllib.error.HTTPError as exc:
+        if exc.code in (301, 302, 303, 307, 308):
+            fail(f"{url} redirected with HTTP {exc.code}, expected direct coordinator response")
+        fail(f"{url} returned HTTP {exc.code}, expected 200")
+    except urllib.error.URLError as exc:
+        fail(f"{url} could not be fetched: {exc.reason}")
+    except TimeoutError:
+        fail(f"{url} timed out")
+
+
+def sha256(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+def parse_json_bytes(data: bytes, label: str) -> object:
+    try:
+        return json.loads(data.decode("utf-8"))
+    except Exception as exc:
+        fail(f"{label} response is not valid JSON: {exc}")
+
+
+def parse_rfc3339(value: str, label: str) -> datetime.datetime:
+    try:
+        normalized = value.replace("Z", "+00:00")
+        parsed = datetime.datetime.fromisoformat(normalized)
+    except ValueError:
+        fail(f"{label} generated_at must be RFC3339: {value!r}")
+    if parsed.tzinfo is None:
+        fail(f"{label} generated_at must include a timezone: {value!r}")
+    return parsed.astimezone(datetime.timezone.utc)
+
+
+def parse_now(value: str) -> datetime.datetime:
+    parsed = parse_rfc3339(value, "--now")
+    return parsed
+
+
+def decode_canonical_b64(value: object, label: str, expected_len: int) -> bytes:
+    if not isinstance(value, str):
+        fail(f"{label} is not a string")
+    try:
+        decoded = base64.b64decode(value, validate=True)
+    except Exception as exc:
+        fail(f"{label} is not canonical padded base64: {exc}")
+    if base64.b64encode(decoded).decode("ascii") != value:
+        fail(f"{label} is not canonical padded base64")
+    if len(decoded) != expected_len:
+        fail(f"{label} must decode to {expected_len} bytes")
+    return decoded
+
+
+def active_keyring(trusted_keys_path: pathlib.Path) -> dict[str, bytes]:
+    value = read_json(trusted_keys_path, "trusted-keys.json")
+    if not isinstance(value, dict) or not isinstance(value.get("keys"), dict):
+        fail("trusted-keys.json does not contain a keys object")
+    if value.get("schema_version") != "macprovider.autotune-keys.v1":
+        fail("trusted-keys.json has unsupported schema_version")
+    result: dict[str, bytes] = {}
+    for key_id, metadata in value["keys"].items():
+        if not isinstance(key_id, str) or not isinstance(metadata, dict):
+            fail("trusted-keys.json has malformed key metadata")
+        if not key_id or key_id.strip() != key_id:
+            fail("trusted-keys.json contains an invalid key_id")
+        status = metadata.get("status")
+        if status in TRUSTED_KEY_STATUSES:
+            result[key_id] = decode_canonical_b64(
+                metadata.get("public_key_base64"),
+                f"trusted-keys.json keys.{key_id}.public_key_base64",
+                32,
+            )
+        elif status != "retired":
+            fail(f"trusted-keys.json keys.{key_id}.status is unsupported: {status!r}")
+    if not result:
+        fail("trusted-keys.json has no non-retired keys")
+    return result
+
+
+def verify_ed25519(
+    openssl: str,
+    public_key: bytes,
+    body: bytes,
+    signature: bytes,
+    label: str,
+) -> None:
+    with tempfile.TemporaryDirectory(prefix="macprovider-ed25519-verify.") as root:
+        root_path = pathlib.Path(root)
+        public_key_path = root_path / "public.der"
+        body_path = root_path / "body.json"
+        signature_path = root_path / "signature.bin"
+        public_key_path.write_bytes(ED25519_SPKI_DER_PREFIX + public_key)
+        body_path.write_bytes(body)
+        signature_path.write_bytes(signature)
+        try:
+            result = subprocess.run(
+                [
+                    openssl,
+                    "pkeyutl",
+                    "-verify",
+                    "-pubin",
+                    "-keyform",
+                    "DER",
+                    "-inkey",
+                    str(public_key_path),
+                    "-rawin",
+                    "-sigfile",
+                    str(signature_path),
+                    "-in",
+                    str(body_path),
+                ],
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+                check=False,
+            )
+        except FileNotFoundError:
+            fail(f"OpenSSL executable not found: {openssl}")
+    if result.returncode != 0:
+        fail(f"{label} signature verification failed")
+
+
+def parse_signature_sidecar(value: object, name: str) -> tuple[str, bytes]:
+    if not isinstance(value, dict):
+        fail(f"{name} response is not a JSON object")
+    if set(value) != {"key_id", "alg", "signature"}:
+        fail(f"{name} response has unexpected signature sidecar fields")
+    if value.get("alg") != "ed25519":
+        fail(f"{name} does not use ed25519")
+    key_id = value.get("key_id")
+    if not isinstance(key_id, str) or not key_id or key_id.strip() != key_id:
+        fail(f"{name} missing key_id")
+    signature = decode_canonical_b64(value.get("signature"), f"{name} signature", 64)
+    return key_id, signature
+
+
+def validate_metadata(args: argparse.Namespace) -> tuple[str, dict[str, str]]:
+    match = TAG_RE.fullmatch(args.tag)
+    if match is None:
+        fail("--tag must be vX.Y.Z")
+    expected_version = args.tag.removeprefix("v")
+    metadata = read_json(pathlib.Path(args.pearl_release_json), "pearl-release.json")
+    if not isinstance(metadata, dict) or metadata.get("schema_version") != 1:
+        fail("pearl-release.json has unsupported schema")
+    if metadata.get("tag") != args.tag:
+        fail(f"pearl-release.json tag is {metadata.get('tag')!r}, expected {args.tag!r}")
+    if metadata.get("release_version") != expected_version:
+        fail("pearl-release.json release_version does not match the tag")
+    advertised = metadata.get("provider_advertised_version")
+    if advertised is not None and advertised != expected_version:
+        fail("pearl-release.json provider_advertised_version does not match the tag")
+    catalog = metadata.get("catalog")
+    if not isinstance(catalog, dict):
+        fail("pearl-release.json does not bind catalog/feed metadata")
+    files = catalog.get("files")
+    if not isinstance(files, dict):
+        fail("pearl-release.json catalog.files is missing")
+    expected = {}
+    for name in RELEASE_CATALOG_FILES:
+        digest = files.get(name)
+        if not isinstance(digest, str) or SHA256_RE.fullmatch(digest) is None:
+            fail(f"pearl-release.json catalog hash is missing or invalid for {name}")
+        expected[name] = digest
+    trusted_keys_digest = sha256(pathlib.Path(args.trusted_keys).read_bytes())
+    if trusted_keys_digest != expected["trusted-keys.json"]:
+        fail(
+            f"trusted-keys.json sha256 {trusted_keys_digest} does not match "
+            f"release metadata {expected['trusted-keys.json']}"
+        )
+    return expected_version, expected
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Verify the live coordinator serves the feed set required by a CLI release."
+    )
+    parser.add_argument("--tag", required=True, help="release tag, vX.Y.Z")
+    parser.add_argument("--pearl-release-json", required=True, help="release pearl-release.json")
+    parser.add_argument("--trusted-keys", required=True, help="release trusted-keys.json")
+    parser.add_argument(
+        "--coordinator-url",
+        default="https://coordinator.streamvc.live",
+        help="public coordinator origin",
+    )
+    parser.add_argument(
+        "--coordinator-dir",
+        help="fixture directory containing v1_* endpoint files and healthz.json",
+    )
+    parser.add_argument("--timeout-s", type=float, default=10.0)
+    parser.add_argument("--max-bytes", type=int, default=4 * 1024 * 1024)
+    parser.add_argument(
+        "--openssl",
+        default=os.environ.get("OPENSSL_BIN", "openssl"),
+        help="OpenSSL executable used for Ed25519 verification",
+    )
+    parser.add_argument(
+        "--now",
+        help=argparse.SUPPRESS,
+    )
+    args = parser.parse_args()
+
+    try:
+        expected_version, expected_hashes = validate_metadata(args)
+        trusted = active_keyring(pathlib.Path(args.trusted_keys))
+
+        bodies: dict[str, bytes] = {}
+        parsed: dict[str, object] = {}
+        for name, endpoint in FEEDS.items():
+            body = load_endpoint(args, endpoint)
+            if len(body) > args.max_bytes:
+                fail(f"{endpoint} response exceeds {args.max_bytes} bytes")
+            digest = sha256(body)
+            if digest != expected_hashes[name]:
+                fail(
+                    f"live coordinator {endpoint} sha256 {digest} does not match "
+                    f"release metadata {expected_hashes[name]}"
+                )
+            bodies[name] = body
+            parsed[name] = parse_json_bytes(body, name)
+
+        generated_at = None
+        generated_at_instant = None
+        policy_version = None
+        now = parse_now(args.now) if args.now else datetime.datetime.now(datetime.timezone.utc)
+        for name in PRIMARY_FEEDS:
+            value = parsed[name]
+            if not isinstance(value, dict):
+                fail(f"{name} response is not a JSON object")
+            current_generated_at = value.get("generated_at")
+            current_policy_version = value.get("policy_version")
+            if not isinstance(current_generated_at, str) or not current_generated_at:
+                fail(f"{name} missing generated_at")
+            if not isinstance(current_policy_version, str) or not current_policy_version:
+                fail(f"{name} missing policy_version")
+            current_generated_at_instant = parse_rfc3339(current_generated_at, name)
+            if current_generated_at_instant > now + FUTURE_TOLERANCE:
+                fail(
+                    f"{name} generated_at {current_generated_at!r} is more than "
+                    "10 minutes in the future"
+                )
+            if now - current_generated_at_instant > STALE_AFTER:
+                fail(f"{name} generated_at {current_generated_at!r} is more than 30 days old")
+            if generated_at is None:
+                generated_at = current_generated_at
+                generated_at_instant = current_generated_at_instant
+                policy_version = current_policy_version
+            elif (
+                current_generated_at != generated_at
+                or current_generated_at_instant != generated_at_instant
+                or current_policy_version != policy_version
+            ):
+                fail("live coordinator feed set is not mutually paired by generated_at and policy_version")
+
+        for name in SIG_FEEDS:
+            key_id, signature = parse_signature_sidecar(parsed[name], name)
+            if key_id not in trusted:
+                fail(f"{name} key_id {key_id!r} is not in the release trusted keyring")
+            signed_name = name.removesuffix(".sig")
+            if signed_name not in bodies:
+                fail(f"{name} does not correspond to a fetched feed body")
+            verify_ed25519(args.openssl, trusted[key_id], bodies[signed_name], signature, name)
+
+        healthz = parse_json_bytes(load_endpoint(args, "/healthz"), "healthz")
+        if not isinstance(healthz, dict):
+            fail("/healthz response is not a JSON object")
+        if healthz.get("status") != "ok":
+            fail(f"/healthz status is {healthz.get('status')!r}, expected 'ok'")
+        live_version = parse_semver(healthz.get("version"), "/healthz version")
+        required_version = parse_semver(expected_version, "release version")
+        if live_version < required_version:
+            fail(
+                f"/healthz version {healthz.get('version')!r} is older than "
+                f"release {expected_version}"
+            )
+
+        print(
+            "[verify-live-coordinator-release-gate] ok: "
+            f"{args.coordinator_url.rstrip('/')} serves {args.tag} feed set "
+            f"generated_at={generated_at} policy_version={policy_version} "
+            f"healthz_version={healthz.get('version')}"
+        )
+        return 0
+    except GateError as exc:
+        print(f"[verify-live-coordinator-release-gate] ERROR: {exc}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add a stable-only live coordinator release gate before direct release undraft/latest publication
- add the same gate before accepted-candidate promotion undraft/latest publication
- verify live feed hashes, Ed25519 sidecars, trusted keyring binding, feed pairing/freshness, HTTPS/no-redirect fetching, and coordinator health version
- add regression coverage to test-dist, release-security posture, and acceptance-promotion tests

Closes #822.

## Validation
- bash scripts/test-live-coordinator-release-gate.sh
- bash scripts/test-release-security-posture.sh
- bash scripts/test-acceptance-promotion.sh
- git diff --check
- make test-dist
- 3-lane Codex audit: code/security/architecture all reported 0 Critical, 0 High, 0 Medium

SPEC-GOVERNANCE-DECLARATION-BEGIN
{
  "schema_version": "spec-pr-governance-v1",
  "behavior_change": "yes",
  "contract_change": "none",
  "specs": ["SPEC-023"],
  "requirements": ["SPEC-023-R001"],
  "authority_domains": ["provider-autoupdate"],
  "arbitration": ["CODE_BUG"],
  "tests": ["scripts/test-live-coordinator-release-gate.sh", "scripts/test-release-security-posture.sh", "scripts/test-acceptance-promotion.sh", "make test-dist"],
  "journeys": ["not-required"],
  "issue": "https://github.com/Augustas11/macprovider/issues/822"
}
SPEC-GOVERNANCE-DECLARATION-END