### PR TITLE
Fix hardware evidence replay for provider updates

### DIFF
--- a/phase4-coordinator/internal/onboarding/apptrack_test.go
+++ b/phase4-coordinator/internal/onboarding/apptrack_test.go
@@ -653,6 +653,71 @@ func TestHandleHardwareEvidenceReturnsExistingReplayBeforeProviderRateLimit(t *t
 	}
 }
 
+func TestHandleHardwareEvidenceReturnsSameIdentityReplayBeforeProviderRateLimit(t *testing.T) {
+	now := time.Date(2026, 7, 31, 13, 0, 0, 0, time.UTC)
+	body, err := json.Marshal(validHardwareEvidenceBody(now))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var evidence HardwareEvidenceRequest
+	if err := json.Unmarshal(body, &evidence); err != nil {
+		t.Fatal(err)
+	}
+	evidenceSHA, _, err := canonicalEvidenceSHA(evidence)
+	if err != nil {
+		t.Fatal(err)
+	}
+	stats := &fakeStatsDB{
+		identityReplayFound: true,
+		identityReplayRecord: HardwareEvidenceJobRecord{
+			JobID:       43,
+			Status:      hardwareEvidenceJobPending,
+			EvidenceSHA: evidenceSHA,
+			Replay:      true,
+		},
+	}
+	handler := testRegisterHandler(stats, &fakeAuthStore{
+		validateOK:         true,
+		validateProviderID: "mac",
+	}, nil)
+	handler.Now = func() time.Time { return now }
+	handler.HardwareEvidenceProviderRateLimiter = denyLimiter{}
+	req := httptest.NewRequest(http.MethodPost, "/v1/providers/hardware-evidence", bytes.NewReader(body))
+	req.Header.Set("Authorization", "Bearer provider-token")
+	rr := httptest.NewRecorder()
+
+	handler.HandleHardwareEvidence(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s", rr.Code, rr.Body.String())
+	}
+	if !strings.Contains(rr.Body.String(), `"status":"existing"`) || !strings.Contains(rr.Body.String(), `"evidence_sha":"`+evidenceSHA+`"`) {
+		t.Fatalf("body=%s, want existing replay with submitted evidence sha", rr.Body.String())
+	}
+	if stats.evidenceProviderID != "" {
+		t.Fatal("same-identity replay inserted a new verification job")
+	}
+	if stats.identityReplayProviderID != "mac" ||
+		stats.identityReplayHash != evidence.Hardware.HardwareIdentityHash ||
+		stats.identityReplaySHA != evidenceSHA {
+		t.Fatalf("unexpected identity replay lookup provider=%q hash=%q sha=%q",
+			stats.identityReplayProviderID, stats.identityReplayHash, stats.identityReplaySHA)
+	}
+}
+
+func TestHardwareEvidenceResponseStatusMarksStoreReplayExisting(t *testing.T) {
+	evidenceSHA := strings.Repeat("e", 64)
+	status, accepted := hardwareEvidenceResponseStatus(HardwareEvidenceJobRecord{
+		JobID:       42,
+		EvidenceSHA: evidenceSHA,
+		Status:      hardwareEvidenceJobPending,
+		Replay:      true,
+	}, false, evidenceSHA)
+	if !accepted || status != hardwareEvidenceResponseExisting {
+		t.Fatalf("status=%q accepted=%v, want existing accepted replay", status, accepted)
+	}
+}
+
 func TestHandleHardwareEvidenceRejectsReboundOrStaleBenchmarkBindings(t *testing.T) {
 	now := time.Date(2026, 7, 3, 12, 0, 0, 0, time.UTC)
 	tests := []struct {
@@ -1379,6 +1444,12 @@ type fakeStatsDB struct {
 	existingEvidenceRecord     HardwareEvidenceJobRecord
 	existingEvidenceFound      bool
 	existingEvidenceErr        error
+	identityReplayProviderID   string
+	identityReplayHash         string
+	identityReplaySHA          string
+	identityReplayRecord       HardwareEvidenceJobRecord
+	identityReplayFound        bool
+	identityReplayErr          error
 	prepareErr                 error
 	prepared                   bool
 	preparedErr                error
@@ -1472,6 +1543,13 @@ func (f *fakeStatsDB) ExistingHardwareVerificationJob(ctx context.Context, provi
 	f.existingEvidenceProviderID = providerID
 	f.existingEvidenceSHA = evidenceSHA
 	return f.existingEvidenceRecord, f.existingEvidenceFound, f.existingEvidenceErr
+}
+
+func (f *fakeStatsDB) ExistingActiveHardwareVerificationJobForHardwareIdentity(ctx context.Context, providerID, hardwareIdentityHash, responseEvidenceSHA string) (HardwareEvidenceJobRecord, bool, error) {
+	f.identityReplayProviderID = providerID
+	f.identityReplayHash = hardwareIdentityHash
+	f.identityReplaySHA = responseEvidenceSHA
+	return f.identityReplayRecord, f.identityReplayFound, f.identityReplayErr
 }
 
 type fakeAppAttestVerifier struct {

--- a/phase4-coordinator/internal/onboarding/hardware_evidence.go
+++ b/phase4-coordinator/internal/onboarding/hardware_evidence.go
@@ -60,8 +60,8 @@ type HardwareEvidenceHardware struct {
 }
 
 type HardwareEvidenceBenchmark struct {
-	ModelKey                string  `json:"model_key"`
-	ModelID                 string  `json:"model_id"`
+	ModelKey string `json:"model_key"`
+	ModelID  string `json:"model_id"`
 	// ModelArtifactPath is the resolved local load path actually probed (#745 AC-4).
 	ModelArtifactPath       string  `json:"model_artifact_path,omitempty"`
 	SustainedTPS            float64 `json:"sustained_tps"`
@@ -82,6 +82,11 @@ type HardwareEvidenceJobRecord struct {
 	EvidenceSHA    string
 	Status         string
 	DecisionReason string
+	Replay         bool
+}
+
+type hardwareVerificationJobQueryer interface {
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 // InsertHardwareVerificationJob queues provider-authenticated evidence for the
@@ -126,6 +131,14 @@ SELECT id, status, decision_reason
 	}
 	if !errors.Is(err, sql.ErrNoRows) {
 		return HardwareEvidenceJobRecord{}, err
+	}
+
+	existing, found, err := existingActiveHardwareVerificationJobForHardwareIdentity(ctx, tx, providerID, evidence.Hardware.HardwareIdentityHash, evidenceSHA)
+	if err != nil {
+		return HardwareEvidenceJobRecord{}, err
+	}
+	if found {
+		return existing, nil
 	}
 
 	var recentJobs int
@@ -207,6 +220,40 @@ LIMIT 1`,
 	}
 	record.EvidenceSHA = evidenceSHA
 	return record, nil
+}
+
+func (s *PGStore) ExistingActiveHardwareVerificationJobForHardwareIdentity(ctx context.Context, providerID, hardwareIdentityHash, responseEvidenceSHA string) (HardwareEvidenceJobRecord, bool, error) {
+	if s == nil || s.db == nil {
+		return HardwareEvidenceJobRecord{}, false, errors.New("onboarding postgres store is nil")
+	}
+	return existingActiveHardwareVerificationJobForHardwareIdentity(ctx, s.db, providerID, hardwareIdentityHash, responseEvidenceSHA)
+}
+
+func existingActiveHardwareVerificationJobForHardwareIdentity(ctx context.Context, queryer hardwareVerificationJobQueryer, providerID, hardwareIdentityHash, responseEvidenceSHA string) (HardwareEvidenceJobRecord, bool, error) {
+	hardwareIdentityHash = strings.TrimSpace(hardwareIdentityHash)
+	if !isLowerSHA256(hardwareIdentityHash) || !isLowerSHA256(responseEvidenceSHA) {
+		return HardwareEvidenceJobRecord{}, false, nil
+	}
+	var existing HardwareEvidenceJobRecord
+	err := queryer.QueryRowContext(ctx, `
+SELECT id, status, decision_reason
+  FROM hardware_verification_jobs
+ WHERE provider_id = $1
+   AND status IN ('pending', 'waiting_trust')
+   AND evidence #>> '{hardware,hardware_identity_hash}' = $2
+ ORDER BY submitted_at DESC, id DESC
+ LIMIT 1`, providerID, hardwareIdentityHash).Scan(&existing.JobID, &existing.Status, &existing.DecisionReason)
+	if errors.Is(err, sql.ErrNoRows) {
+		return HardwareEvidenceJobRecord{}, false, nil
+	}
+	if err != nil {
+		return HardwareEvidenceJobRecord{}, false, err
+	}
+	// Echo the submitted payload SHA so strict clients can treat the
+	// same-hardware replay as successful without creating a new job.
+	existing.EvidenceSHA = responseEvidenceSHA
+	existing.Replay = true
+	return existing, true, nil
 }
 
 func (s *PGStore) ExistingHardwareVerificationJob(ctx context.Context, providerID, evidenceSHA string) (HardwareEvidenceJobRecord, bool, error) {
@@ -309,6 +356,24 @@ func (h *Handler) HandleHardwareEvidence(w http.ResponseWriter, r *http.Request)
 			return
 		}
 	}
+	if identityReplayStore, ok := h.StatsDB.(interface {
+		ExistingActiveHardwareVerificationJobForHardwareIdentity(context.Context, string, string, string) (HardwareEvidenceJobRecord, bool, error)
+	}); ok {
+		existing, found, lookupErr := identityReplayStore.ExistingActiveHardwareVerificationJobForHardwareIdentity(ctx, providerID, req.Hardware.HardwareIdentityHash, evidenceSHA)
+		if lookupErr != nil {
+			writeJSONError(w, http.StatusServiceUnavailable, "unavailable", "hardware evidence queue unavailable")
+			return
+		}
+		if found {
+			status, accepted := hardwareEvidenceResponseStatus(existing, false, evidenceSHA)
+			if !accepted {
+				writeJSONError(w, http.StatusConflict, "evidence_replay_not_accepted", "existing hardware identity evidence is not in an accepted replay state")
+				return
+			}
+			writeHardwareEvidenceResponse(w, status, providerID, existing)
+			return
+		}
+	}
 	if h.HardwareEvidenceProviderRateLimiter != nil && !h.HardwareEvidenceProviderRateLimiter.Allow(providerID) {
 		w.Header().Set("Retry-After", "600")
 		writeJSONError(w, http.StatusTooManyRequests, "rate_limited", "hardware evidence provider rate limit exceeded")
@@ -342,6 +407,7 @@ func hardwareEvidenceResponseStatus(record HardwareEvidenceJobRecord, replay boo
 	if record.JobID <= 0 || record.EvidenceSHA != expectedEvidenceSHA || !isLowerSHA256(record.EvidenceSHA) {
 		return "", false
 	}
+	replay = replay || record.Replay
 	switch record.Status {
 	case hardwareEvidenceJobPending:
 		if replay {

--- a/phase4-coordinator/internal/stats/integration_test.go
+++ b/phase4-coordinator/internal/stats/integration_test.go
@@ -40,6 +40,7 @@ package stats_test
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
 	"os"
 	"strings"
@@ -1653,6 +1654,99 @@ RETURNING id`, tc.providerID, tc.status, tc.decisionReason, tc.evidenceSHA).Scan
 			record.Status != tc.status || record.DecisionReason != tc.decisionReason {
 			t.Fatalf("loaded %s record = %+v found=%v", tc.status, record, found)
 		}
+	}
+}
+
+func TestHardwareEvidenceSameIdentityReplayBypassesAdmissionCap(t *testing.T) {
+	fx := startPostgres(t)
+	adminDB := applyMigrationsAndStubOLTP(t, fx)
+	store, err := onboarding.OpenPGStore(fx.roleDSN(roleProviderOnboard))
+	if err != nil {
+		t.Fatalf("open onboarding store: %v", err)
+	}
+	defer store.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	const providerID = "p-update-admission"
+	sameHash := strings.Repeat("c", 64)
+	changedHash := strings.Repeat("d", 64)
+	oldEvidenceSHA := strings.Repeat("a", 64)
+	oldEvidenceJSON := fmt.Sprintf(`{"hardware":{"hardware_identity_hash":%q}}`, sameHash)
+	var oldJobID int64
+	if err := adminDB.QueryRowContext(ctx, `
+INSERT INTO hardware_verification_jobs (
+    provider_id, source, status, chip, chip_normalized, unified_memory_gb,
+    bandwidth_tier, os_version, binary_version, benchmark_count,
+    max_sustained_tps, generated_at, decision_reason, evidence, evidence_sha256
+) VALUES (
+    $1, 'autotune', 'waiting_trust', 'Apple M5', 'apple m5', 32,
+    'C', '15.5', '1.8.67', 1, 42.5, now(),
+    'hardware-verifier.v2:trust_missing', $2::jsonb, $3
+)
+RETURNING id`, providerID, oldEvidenceJSON, oldEvidenceSHA).Scan(&oldJobID); err != nil {
+		t.Fatalf("seed waiting trust row: %v", err)
+	}
+
+	generatedAt := time.Date(2026, 7, 31, 13, 0, 0, 0, time.UTC)
+	evidence := hardwareEvidenceRequestForIntegration(providerID, sameHash, "1.8.68", generatedAt)
+	record, err := store.InsertHardwareVerificationJob(ctx, providerID, evidence, generatedAt)
+	if err != nil {
+		t.Fatalf("same hardware replay insert: %v", err)
+	}
+	if record.JobID != oldJobID || record.Status != "waiting_trust" || !record.Replay {
+		t.Fatalf("same hardware record=%+v, want old waiting_trust replay job %d", record, oldJobID)
+	}
+	if record.EvidenceSHA == oldEvidenceSHA || len(record.EvidenceSHA) != 64 {
+		t.Fatalf("replay evidence sha=%q, want submitted payload sha distinct from old row", record.EvidenceSHA)
+	}
+	var jobCount int
+	if err := adminDB.QueryRowContext(ctx,
+		`SELECT COUNT(*) FROM hardware_verification_jobs WHERE provider_id = $1`,
+		providerID,
+	).Scan(&jobCount); err != nil {
+		t.Fatalf("count jobs: %v", err)
+	}
+	if jobCount != 1 {
+		t.Fatalf("job count=%d, want replay without new job", jobCount)
+	}
+
+	changedEvidence := hardwareEvidenceRequestForIntegration(providerID, changedHash, "1.8.68", generatedAt)
+	if _, err := store.InsertHardwareVerificationJob(ctx, providerID, changedEvidence, generatedAt); !errors.Is(err, onboarding.ErrHardwareEvidenceRateLimited) {
+		t.Fatalf("changed hardware error=%v, want rate limited", err)
+	}
+}
+
+func hardwareEvidenceRequestForIntegration(providerID, hardwareIdentityHash, binaryVersion string, generatedAt time.Time) onboarding.HardwareEvidenceRequest {
+	return onboarding.HardwareEvidenceRequest{
+		SchemaVersion:          "hardware_evidence.autotune.v1",
+		ProviderID:             providerID,
+		GeneratedAt:            generatedAt.Format(time.RFC3339),
+		CandidateCatalogSHA256: strings.Repeat("b", 64),
+		RecommendedModel:       "mlx-community/Qwen2.5-Coder-7B-Instruct-4bit",
+		Hardware: onboarding.HardwareEvidenceHardware{
+			Chip:                 "Apple M5",
+			MemoryGB:             32,
+			BandwidthTier:        "C",
+			Detected:             true,
+			OSVersion:            "15.5",
+			BinaryVersion:        binaryVersion,
+			HardwareIdentityHash: hardwareIdentityHash,
+		},
+		Benchmarks: []onboarding.HardwareEvidenceBenchmark{{
+			ModelKey:                "qwen-7b",
+			ModelID:                 "mlx-community/Qwen2.5-Coder-7B-Instruct-4bit",
+			SustainedTPS:            42.5,
+			TTFTMS:                  1200,
+			SwapDetected:            false,
+			ThermalThrottleDetected: false,
+			ArtifactSHA256:          strings.Repeat("e", 64),
+			CandidateCatalogSHA256:  strings.Repeat("b", 64),
+			BenchmarkID:             "bench-1",
+			GeneratedAt:             generatedAt.Format(time.RFC3339),
+			BinaryVersion:           binaryVersion,
+			HardwareIdentityHash:    hardwareIdentityHash,
+		}},
 	}
 }
 

--- a/specs/SPEC-033-hardware-verifier.md
+++ b/specs/SPEC-033-hardware-verifier.md
@@ -462,11 +462,16 @@ the batch tally.
 - `evidence_sha256` is `UNIQUE` and computed by a **canonical** hash (`canonicalEvidenceSHA`); the
   enqueue path keys on it, so the **same evidence document creates at most one queue row** — a
   replay collides and is routed through the fail-closed replay state machine (§3.1).
+- A provider-authenticated install/update resubmission for the **same active
+  `hardware_identity_hash`** may return an admission-success replay while a prior job is
+  `pending`/`waiting_trust`. This is not a new queue row and not a trust verdict; it only
+  acknowledges that evidence for the same hardware root is already awaiting verifier/operator
+  progress. Changed hardware identities still enter the normal admission cap and trust flow.
 - **One queue row does NOT mean one evaluation.** A `waiting_trust` job is re-`Evaluate`d on every
   batch run until it reaches a terminal state; this is by design (§6). Idempotency is preserved by
   the terminal-safe write `WHERE` + trigger B: a job cannot double-promote or be reopened.
-- Net: **exactly one queue row per distinct document; exactly one *terminal verdict* committed;
-  possibly many interim `waiting_trust` evaluations.**
+- Net: **at most one active admission row per hardware root during pending trust; exactly one
+  *terminal verdict* committed; possibly many interim `waiting_trust` evaluations.**
 
 ---
 


### PR DESCRIPTION
## Summary
- Treat active same-provider same-hardware_identity_hash evidence as an existing replay before provider and DB admission caps.
- Preserve changed-hardware behavior: new hardware identities still hit the normal rate-limit/operator approval path.
- Document the #838 same-hardware admission replay exception in SPEC-033.

Closes #838.

## Validation
- go test ./internal/onboarding ./internal/stats -count=1
- go test ./... -count=1 in phase4-coordinator
- go test -tags=integration ./internal/stats -run TestHardwareEvidenceSameIdentityReplayBypassesAdmissionCap -count=1 -v compiled; local rootless Docker unavailable, so the live Postgres case skipped locally and should run in CI.
- 3-lane code/security/architecture auditors: 0 C/H/M findings.

SPEC-GOVERNANCE-DECLARATION-BEGIN
{
  "schema_version": "spec-pr-governance-v1",
  "behavior_change": "yes",
  "contract_change": "yes",
  "specs": ["SPEC-033"],
  "requirements": ["SPEC-033-R001"],
  "authority_domains": ["hardware-evidence-admission"],
  "arbitration": ["CODE_BUG"],
  "tests": [
    "go test ./internal/onboarding ./internal/stats -count=1",
    "go test ./... -count=1 in phase4-coordinator",
    "go test -tags=integration ./internal/stats -run TestHardwareEvidenceSameIdentityReplayBypassesAdmissionCap -count=1 -v"
  ],
  "journeys": ["provider CLI install/update while hardware trust is waiting_trust"],
  "issue": "https://github.com/Augustas11/macprovider/issues/838"
}
SPEC-GOVERNANCE-DECLARATION-END