### PR TITLE
[DO NOT MERGE] fix(release): generalize Malibu download promotion off the v1.8.39 freeze

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1916,8 +1916,8 @@ jobs:
             --require-immutable \
             --openssl "$OPENSSL_BIN" >/dev/null
 
-      - name: Publish one-time Malibu 1.8.32 bootstrap bridge to Pearl
-        if: needs.build.outputs.tag == 'v1.8.39' && needs.build.outputs.prerelease == 'false'
+      - name: Publish Malibu download bridge to Pearl
+        if: needs.build.outputs.prerelease == 'false'
         env:
           MALIBU_DOWNLOAD_VPS_HOST: ${{ secrets.MALIBU_DOWNLOAD_VPS_HOST }}
           MALIBU_DOWNLOAD_SSH_KEY: ${{ secrets.MALIBU_DOWNLOAD_SSH_KEY }}
@@ -1935,10 +1935,42 @@ jobs:
           chmod 600 "$key_file"
           export MALIBU_DOWNLOAD_SSH_KEY="$key_file"
           tag="${{ needs.build.outputs.tag }}"
-          bash scripts/publish-malibu-latest-dmg.sh \
-            publication-manifest.json "Malibu-${tag}.dmg" appcast.xml \
-            compatibility-artifact-index.json checksums.txt checksums.txt.sig \
-            release-provenance.json
+          if [ "$tag" = v1.8.39 ]; then
+            # Frozen one-time bootstrap bridge: uses its own generated appcast and
+            # carries no acceptance-candidate.
+            bash scripts/publish-malibu-latest-dmg.sh \
+              publication-manifest.json "Malibu-${tag}.dmg" appcast.xml \
+              compatibility-artifact-index.json checksums.txt checksums.txt.sig \
+              release-provenance.json '' ''
+            exit 0
+          fi
+          # Generalized stable promotions serve the committed frozen legacy
+          # Sparkle bridge appcast (scripts/dist/malibu-frozen-bridge-appcast.xml)
+          # and REQUIRE the signed acceptance-candidate produced by
+          # acceptance-candidate.yml (schema macprovider.acceptance-candidate.v1,
+          # channel acceptance). That artifact only exists ~24h post-build after
+          # the acceptance soak, so it is not present in this build-time job.
+          # Build-time therefore never auto-publishes an un-accepted release; the
+          # operator runs the promotion after acceptance:
+          #   bash scripts/publish-malibu-latest-dmg.sh \
+          #     publication-manifest.json "Malibu-${tag}.dmg" \
+          #     scripts/dist/malibu-frozen-bridge-appcast.xml \
+          #     compatibility-artifact-index.json checksums.txt checksums.txt.sig \
+          #     release-provenance.json \
+          #     acceptance-candidate.json acceptance-candidate.json.sig
+          # TODO(operator): wire the acceptance-candidate.yml run artifact into a
+          # dedicated acceptance-triggered promotion workflow to fully automate
+          # this hand-off.
+          if [ -f acceptance-candidate.json ] && [ -f acceptance-candidate.json.sig ]; then
+            bash scripts/publish-malibu-latest-dmg.sh \
+              publication-manifest.json "Malibu-${tag}.dmg" \
+              scripts/dist/malibu-frozen-bridge-appcast.xml \
+              compatibility-artifact-index.json checksums.txt checksums.txt.sig \
+              release-provenance.json \
+              acceptance-candidate.json acceptance-candidate.json.sig
+          else
+            echo "::notice::skipping build-time Malibu download promotion for ${tag}: signed acceptance-candidate not present; run publish-malibu-latest-dmg.sh after acceptance"
+          fi
 
       - name: Verify published Tier-2 Release assets
         shell: bash

--- a/Makefile
+++ b/Makefile
@@ -62,6 +62,7 @@ test-dist:
 	bash scripts/test-release-security-posture.sh
 	bash scripts/test-malibu-bootstrap-bridge.sh
 	bash scripts/test-recover-malibu-publication.sh
+	bash scripts/test-malibu-acceptance-candidate-prepublish.sh
 	bash scripts/test-acceptance-candidate-security.sh
 	bash scripts/test-acceptance-candidate-metadata.sh
 	bash scripts/test-acceptance-promotion.sh

--- a/audits/2026-07-31/AUDIT_MALIBU_PUBLISH_GENERALIZE_PROMPT.md
+++ b/audits/2026-07-31/AUDIT_MALIBU_PUBLISH_GENERALIZE_PROMPT.md
@@ -1,0 +1,15 @@
+# Codex audit — generalize Malibu download promotion off the v1.8.39 freeze
+
+Read the full diff `/Users/augstar/macprovider-poc/scratchpad/malibu-publish-fulldiff.patch` and the changed files under `/Users/augstar/macprovider-malibu-publish-generalize/`. Report findings only (C/H/M/L/INFO, file:line, concrete failure scenario); do NOT edit.
+
+## Context (money-path, signature-enforced, install-breaking-if-wrong release infra)
+The Malibu download promotion was hard-locked to the one-time v1.8.39 Sparkle bootstrap. This change lifts the tag-locks so any stable vX.Y.Z can be promoted to download.malibu.tech, ships a COMMITTED frozen bridge appcast (`scripts/dist/malibu-frozen-bridge-appcast.xml`, sha `94ecf575...`, pinned as a constant in `install-malibu-publication.sh`) for non-v1.8.39 so the `/appcast.xml → .malibu-current/appcast.xml` symlink keeps resolving, keeps appcast GENERATION frozen, and wires the signed acceptance-candidate (`acceptance-candidate.json[.sig]`, produced by `acceptance-candidate.yml`, ecdsa-p256) into publish + the remote root install helper so it lands in the promoted `.malibu-releases/<id>/` dir under the same atomic/immutable checks. The install path `die 4`s without a valid acceptance-candidate.
+
+## Focus
+1. **Remote root helper `install-malibu-publication.sh`**: the acceptance-candidate present/absent gating (non-v1.8.39 requires the pair, v1.8.39 forbids it), name/mode/owner/symlink checks, inclusion in the atomic `.malibu-current` swap + immutable `cmp` set. Any path that promotes a dir MISSING a valid acceptance-candidate, or that breaks the atomicity/rollback.
+2. **Frozen appcast pin**: the constant `FROZEN_APPCAST_SHA256` vs the committed file — any drift risk not covered by `test-malibu-bootstrap-bridge.sh`; the deliberately-SKIPPED Sparkle enclosure-vs-DMG cross-check for non-v1.8.39 (replaced by a byte-compare to the committed appcast) — is that a real integrity gap?
+3. **Tag-lock lifts** in publish-malibu-latest-dmg.sh / verify-malibu-publication-set.sh / verify-malibu-bootstrap-publication.sh / release.yml: any check weakened beyond the intended tag-equality removal? Does the non-v1.8.39 path still bind dmg + manifest + provenance + checksums as strongly as v1.8.39?
+4. **release.yml**: the generalized publish step gates on `prerelease == 'false'` but skips (::notice::) when the acceptance-candidate isn't in the build workspace (it's produced ~24h post-build). Is the skip fail-safe (never publishes an un-accepted release), and is there any path where it publishes without the acceptance-candidate?
+5. Anything that could break installs for ALL users (die-4, broken symlink, wrong sha) if this promoted a real release.
+
+Note: 3 assertion updates in `test-release-security-posture.sh` are intentionally NOT yet applied (classifier-gated); that test currently fails at line 735 — do not report that as a code defect, but DO assess whether the intended new assertions are the right ones.

--- a/audits/2026-07-31/AUDIT_MALIBU_PUBLISH_R2_PROMPT.md
+++ b/audits/2026-07-31/AUDIT_MALIBU_PUBLISH_R2_PROMPT.md
@@ -1,0 +1,15 @@
+# Codex re-audit (round 2) — verify the two fixes
+
+Read the full diff `/Users/augstar/macprovider-poc/scratchpad/malibu-publish-fulldiff.patch` and the changed files under `/Users/augstar/macprovider-malibu-publish-generalize/`. Report findings only (C/H/M/L/INFO, file:line); do NOT edit.
+
+Round-1 findings being verified:
+1. (HIGH) acceptance-candidate placed without validation → FIX: `publish-malibu-latest-dmg.sh` now calls `acceptance-candidate-metadata.py verify` (ECDSA P-256, schema/channel, checksums.txt sha binding, 5m–24h non-expiry, tag/candidate_commit/compatibility_set_id pinned to this release) BEFORE any Pearl staging/transfer/swap; dies on failure. New negative test `test-malibu-acceptance-candidate-prepublish.sh`.
+2. (MEDIUM) constant cache-bust key → FIX: `verify-malibu-bootstrap-publication.sh` now uses the per-release DMG sha (non-v1.8.39).
+
+VERIFY:
+- Is the acceptance-candidate validation truly BEFORE any remote transfer/swap, fail-closed, and does it actually bind tag+commit+checksums+expiry+signature (not just presence)? Any bypass (e.g. v1.8.39 branch, missing-file path, or the remote helper still trusting unvalidated bytes)?
+- Is the per-release cache key correct and collision-free across releases?
+- Any NEW defect introduced by these two edits (arg plumbing, quoting, the new test's stubs hiding a real gap)?
+- Known/ignore: the 3 classifier-gated `test-release-security-posture.sh` assertions are intentionally not yet applied (that test fails at line 735) — not a code defect.
+
+If 0 C/H/M, say so explicitly.

--- a/scripts/dist/malibu-frozen-bridge-appcast.xml
+++ b/scripts/dist/malibu-frozen-bridge-appcast.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" standalone="yes"?>
+<rss xmlns:sparkle="http://www.andymatuschak.org/xml-namespaces/sparkle" version="2.0">
+    <channel>
+        <title>Malibu</title>
+        <item>
+            <title>1.8.39</title>
+            <pubDate>Wed, 15 Jul 2026 17:03:05 +0000</pubDate>
+            <sparkle:version>39</sparkle:version>
+            <sparkle:shortVersionString>1.8.39</sparkle:shortVersionString>
+            <sparkle:minimumSystemVersion>14.0</sparkle:minimumSystemVersion>
+            <enclosure url="https://download.malibu.tech/Malibu-v1.8.39.dmg" length="16255202" type="application/octet-stream" sparkle:edSignature="eal8O0OWZwgJfn0MLtpgonYB/VJbEf1raoVyZjnSBxSVfdnz1LDK6hscPo8TM/g2gHNtVKS+GUfautkXxmwLBw=="/>
+        </item>
+    </channel>
+</rss>

--- a/scripts/install-malibu-publication.sh
+++ b/scripts/install-malibu-publication.sh
@@ -6,7 +6,7 @@ die() {
   exit 1
 }
 
-[[ "$#" == 7 ]] || die "usage: WEBROOT TAG PUBLICATION_ID MANIFEST DMG APPCAST SHA256"
+[[ "$#" == 9 ]] || die "usage: WEBROOT TAG PUBLICATION_ID MANIFEST DMG APPCAST SHA256 ACCEPTANCE_CANDIDATE ACCEPTANCE_CANDIDATE_SIG"
 webroot="$1"
 tag="$2"
 release_id="$3"
@@ -14,12 +14,28 @@ manifest_source="$4"
 dmg_source="$5"
 appcast_source="$6"
 sha_source="$7"
+# Signed acceptance-candidate (acceptance-candidate.yml artifact). Placed into
+# the promoted release dir so the coordinator's install-time acceptance gate can
+# enforce it. The frozen v1.8.39 bootstrap bridge carries none, so the publisher
+# passes staged paths that do not exist for that tag.
+acceptance_source="$8"
+acceptance_sig_source="$9"
 
 [[ "$webroot" == /* ]] || die "webroot must be an absolute path"
 [[ "$webroot" =~ ^/[A-Za-z0-9._/-]+$ && "$webroot" != *'/../'* && "$webroot" != */.. ]] || die "unsafe webroot"
 [[ "$tag" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]] || die "tag must be vX.Y.Z"
-[[ "$tag" == v1.8.39 ]] || die "legacy Malibu publication is frozen to v1.8.39"
 [[ "$release_id" =~ ^[0-9a-f]{64}$ ]] || die "publication id must be a full content digest"
+
+if [[ "$tag" == v1.8.39 ]]; then
+  [[ ! -e "$acceptance_source" && ! -e "$acceptance_sig_source" ]] ||
+    die "the frozen v1.8.39 bridge does not carry an acceptance-candidate"
+  have_acceptance=0
+else
+  [[ -f "$acceptance_source" && ! -L "$acceptance_source" &&
+     -f "$acceptance_sig_source" && ! -L "$acceptance_sig_source" ]] ||
+    die "generalized Malibu promotion requires the staged acceptance-candidate pair"
+  have_acceptance=1
+fi
 
 testing="${MALIBU_PUBLICATION_TESTING:-0}"
 if [[ "$testing" == 1 ]]; then
@@ -31,7 +47,7 @@ else
   trusted_gid=0
 fi
 
-python3 - "$testing" "$trusted_uid" "$manifest_source" "$dmg_source" "$appcast_source" "$sha_source" "$tag" "$release_id" <<'PY'
+python3 - "$testing" "$trusted_uid" "$manifest_source" "$dmg_source" "$appcast_source" "$sha_source" "$tag" "$release_id" "$have_acceptance" "$acceptance_source" "$acceptance_sig_source" <<'PY'
 import hashlib
 import json
 import os
@@ -39,9 +55,24 @@ import pathlib
 import stat
 import sys
 
-testing, trusted_uid, manifest_name, dmg_name, appcast_name, sha_name, tag, publication_id = sys.argv[1:]
+# SHA-256 of scripts/dist/malibu-frozen-bridge-appcast.xml, the reviewed frozen
+# legacy Sparkle bridge appcast (v1.8.39). Non-v1.8.39 download promotions ship
+# this exact appcast, which is not a per-release GitHub asset, so this remote
+# root helper binds it to the pinned constant instead of the per-release
+# manifest. scripts/test-malibu-bootstrap-bridge.sh proves the pin matches the
+# committed file so the two cannot drift.
+FROZEN_APPCAST_SHA256 = "94ecf57584a2a203336d3219ea42dec1945bae2e123cfce0b1b39f8e0231d83c"
+
+(testing, trusted_uid, manifest_name, dmg_name, appcast_name, sha_name, tag,
+ publication_id, have_acceptance, acceptance_name, acceptance_sig_name) = sys.argv[1:]
 trusted_uid = int(trusted_uid)
 paths = [pathlib.Path(value) for value in (manifest_name, dmg_name, appcast_name, sha_name)]
+if have_acceptance == "1":
+    if pathlib.Path(acceptance_name).name != "acceptance-candidate.json":
+        raise SystemExit("acceptance-candidate input has an unexpected name")
+    if pathlib.Path(acceptance_sig_name).name != "acceptance-candidate.json.sig":
+        raise SystemExit("acceptance-candidate signature has an unexpected name")
+    paths.extend(pathlib.Path(value) for value in (acceptance_name, acceptance_sig_name))
 for path in paths:
     row = path.lstat()
     if not stat.S_ISREG(row.st_mode) or row.st_uid != trusted_uid or row.st_nlink != 1:
@@ -57,13 +88,19 @@ if manifest.get("schema_version") != 1 or manifest.get("tag") != tag or manifest
 if manifest.get("prerelease") is not False:
     raise SystemExit("prerelease must not publish the stable Malibu feed")
 assets = manifest.get("assets")
-expected_names = [f"Malibu-{tag}.dmg", "appcast.xml"]
-for path, name in zip(paths[1:3], expected_names):
-    row = assets.get(name) if isinstance(assets, dict) else None
-    digest = hashlib.sha256(path.read_bytes()).hexdigest()
-    if not isinstance(row, dict) or row.get("sha256") != digest or type(row.get("id")) is not int:
-        raise SystemExit(f"publication manifest does not bind {name}")
-expected_checksum = f"{hashlib.sha256(paths[1].read_bytes()).hexdigest()}  {expected_names[0]}\n"
+dmg_display_name = f"Malibu-{tag}.dmg"
+dmg_row = assets.get(dmg_display_name) if isinstance(assets, dict) else None
+dmg_digest = hashlib.sha256(paths[1].read_bytes()).hexdigest()
+if not isinstance(dmg_row, dict) or dmg_row.get("sha256") != dmg_digest or type(dmg_row.get("id")) is not int:
+    raise SystemExit(f"publication manifest does not bind {dmg_display_name}")
+appcast_digest = hashlib.sha256(paths[2].read_bytes()).hexdigest()
+if tag == "v1.8.39":
+    appcast_row = assets.get("appcast.xml") if isinstance(assets, dict) else None
+    if not isinstance(appcast_row, dict) or appcast_row.get("sha256") != appcast_digest or type(appcast_row.get("id")) is not int:
+        raise SystemExit("publication manifest does not bind appcast.xml")
+elif appcast_digest != FROZEN_APPCAST_SHA256:
+    raise SystemExit("appcast is not the frozen Malibu bridge appcast")
+expected_checksum = f"{dmg_digest}  {dmg_display_name}\n"
 if paths[3].read_text(encoding="utf-8") != expected_checksum:
     raise SystemExit("versioned DMG checksum file is invalid")
 PY
@@ -182,6 +219,10 @@ install -o "$trusted_uid" -g "$trusted_gid" -m 0644 "$dmg_source" "$stage/latest
 install -o "$trusted_uid" -g "$trusted_gid" -m 0644 "$appcast_source" "$stage/appcast.xml"
 install -o "$trusted_uid" -g "$trusted_gid" -m 0644 "$sha_source" "$stage/${dmg_name}.sha256"
 install -o "$trusted_uid" -g "$trusted_gid" -m 0644 "$manifest_source" "$stage/publication-manifest.json"
+if [[ "$have_acceptance" == 1 ]]; then
+  install -o "$trusted_uid" -g "$trusted_gid" -m 0644 "$acceptance_source" "$stage/acceptance-candidate.json"
+  install -o "$trusted_uid" -g "$trusted_gid" -m 0644 "$acceptance_sig_source" "$stage/acceptance-candidate.json.sig"
+fi
 
 if [[ -d "$release_dir" && ! -L "$release_dir" ]]; then
   validate_chain "$release_dir"
@@ -190,6 +231,12 @@ if [[ -d "$release_dir" && ! -L "$release_dir" ]]; then
     validate_node "$release_dir/$name" file
     cmp -s "$stage/$name" "$release_dir/$name" || die "immutable release differs: $release_dir/$name"
   done
+  if [[ "$have_acceptance" == 1 ]]; then
+    for name in acceptance-candidate.json acceptance-candidate.json.sig; do
+      validate_node "$release_dir/$name" file
+      cmp -s "$stage/$name" "$release_dir/$name" || die "immutable release differs: $release_dir/$name"
+    done
+  fi
   rm -rf "$stage"
 elif [[ -e "$release_dir" || -L "$release_dir" ]]; then
   die "release path is not an immutable directory: $release_dir"

--- a/scripts/publish-malibu-latest-dmg.sh
+++ b/scripts/publish-malibu-latest-dmg.sh
@@ -7,8 +7,8 @@ die() {
   exit 1
 }
 
-[[ "$#" == 7 ]] ||
-  die "usage: $0 MANIFEST DMG APPCAST ARTIFACT_INDEX CHECKSUMS SIGNATURE PROVENANCE"
+[[ "$#" == 9 ]] ||
+  die "usage: $0 MANIFEST DMG APPCAST ARTIFACT_INDEX CHECKSUMS SIGNATURE PROVENANCE ACCEPTANCE_CANDIDATE ACCEPTANCE_CANDIDATE_SIG"
 
 manifest="$1"
 asset="$2"
@@ -17,6 +17,13 @@ artifact_index="$4"
 checksums="$5"
 signature="$6"
 provenance="$7"
+# Signed acceptance-candidate produced by acceptance-candidate.yml (schema
+# macprovider.acceptance-candidate.v1, channel acceptance). Empty for the frozen
+# v1.8.39 bootstrap bridge, required for generalized stable promotions. The
+# signature/expiry are enforced by the coordinator's acceptance gate; this
+# script only transfers and places the already-signed files.
+acceptance_candidate="$8"
+acceptance_signature="$9"
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 
 bash "$SCRIPT_DIR/verify-malibu-publication-set.sh" \
@@ -38,17 +45,39 @@ print(
     manifest["release_id"],
     manifest["publication_id"],
     assets[f"Malibu-{tag}.dmg"]["id"],
-    assets["appcast.xml"]["id"],
+    # Non-v1.8.39 promotions ship the frozen bridge appcast, which is not a
+    # per-release GitHub asset, so it has no numeric manifest asset id.
+    assets.get("appcast.xml", {}).get("id", 0),
 )
 PY
 )
 [[ "$tag" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]] || die "manifest tag is invalid"
-[[ "$tag" == v1.8.39 ]] || die "legacy Malibu publication is frozen to v1.8.39"
 [[ "$commit" =~ ^[0-9a-f]{40}$ ]] || die "manifest commit is invalid"
 [[ "$release_number" =~ ^[1-9][0-9]*$ ]] || die "manifest release id is invalid"
 [[ "$publication_id" =~ ^[0-9a-f]{64}$ ]] || die "manifest publication id is invalid"
-[[ "$dmg_asset_id" =~ ^[1-9][0-9]*$ && "$appcast_asset_id" =~ ^[1-9][0-9]*$ ]] ||
-  die "manifest publication asset ids are invalid"
+[[ "$dmg_asset_id" =~ ^[1-9][0-9]*$ ]] || die "manifest publication dmg asset id is invalid"
+if [[ "$tag" == v1.8.39 ]]; then
+  [[ "$appcast_asset_id" =~ ^[1-9][0-9]*$ ]] || die "manifest publication appcast asset id is invalid"
+  # The frozen v1.8.39 bootstrap bridge predates the acceptance channel and
+  # carries no acceptance-candidate.
+  [[ -z "$acceptance_candidate" && -z "$acceptance_signature" ]] ||
+    die "the frozen v1.8.39 bridge does not carry an acceptance-candidate"
+else
+  # The frozen bridge appcast is a committed constant, not a release asset.
+  appcast_asset_id="frozen-bridge"
+  # Generalized stable promotions must place the signed acceptance-candidate so
+  # the coordinator's install-time acceptance gate can enforce it.
+  [[ -n "$acceptance_candidate" && -n "$acceptance_signature" ]] ||
+    die "generalized Malibu promotion requires the signed acceptance-candidate pair"
+  for path in "$acceptance_candidate" "$acceptance_signature"; do
+    [[ -f "$path" && ! -L "$path" ]] ||
+      die "acceptance-candidate input is not a regular file: $path"
+  done
+  [[ "$(basename "$acceptance_candidate")" == acceptance-candidate.json ]] ||
+    die "acceptance-candidate must be named acceptance-candidate.json"
+  [[ "$(basename "$acceptance_signature")" == acceptance-candidate.json.sig ]] ||
+    die "acceptance-candidate signature must be named acceptance-candidate.json.sig"
+fi
 
 VPS_HOST="${MALIBU_DOWNLOAD_VPS_HOST:-159.223.165.194}"
 SSH_KEY="${MALIBU_DOWNLOAD_SSH_KEY:-$HOME/.ssh/pearl_operator_ed25519}"
@@ -100,6 +129,10 @@ remote_stage="$(malibu_download_ssh 'set -eu
 helper="$SCRIPT_DIR/install-malibu-publication.sh"
 declare -a local_paths=("$manifest" "$asset" "$appcast" "$checksum_file" "$helper")
 declare -a remote_names=(publication-manifest.json "$dmg_name" appcast.xml "${dmg_name}.sha256" install-helper)
+if [[ -n "$acceptance_candidate" ]]; then
+  local_paths+=("$acceptance_candidate" "$acceptance_signature")
+  remote_names+=(acceptance-candidate.json acceptance-candidate.json.sig)
+fi
 declare -a expected_hashes=()
 for index in "${!local_paths[@]}"; do
   expected_hashes+=("$(sha256_file "${local_paths[$index]}")")
@@ -144,7 +177,8 @@ malibu_download_ssh "set -euo pipefail
     \"\$stage/publication-manifest.json\" \
     \"\$stage/$dmg_name\" \
     \"\$stage/appcast.xml\" \
-    \"\$stage/${dmg_name}.sha256\"
+    \"\$stage/${dmg_name}.sha256\" \
+    \"\$stage/acceptance-candidate.json\" \"\$stage/acceptance-candidate.json.sig\"
 "
 remote_stage=""
 

--- a/scripts/publish-malibu-latest-dmg.sh
+++ b/scripts/publish-malibu-latest-dmg.sh
@@ -30,7 +30,7 @@ bash "$SCRIPT_DIR/verify-malibu-publication-set.sh" \
   "$manifest" "$asset" "$appcast" "$artifact_index" \
   "$checksums" "$signature" "$provenance"
 
-read -r tag commit release_number publication_id dmg_asset_id appcast_asset_id < <(
+read -r tag commit release_number publication_id repository dmg_asset_id appcast_asset_id < <(
   python3 - "$manifest" <<'PY'
 import json
 import pathlib
@@ -44,6 +44,7 @@ print(
     manifest["commit"],
     manifest["release_id"],
     manifest["publication_id"],
+    manifest["repository"],
     assets[f"Malibu-{tag}.dmg"]["id"],
     # Non-v1.8.39 promotions ship the frozen bridge appcast, which is not a
     # per-release GitHub asset, so it has no numeric manifest asset id.
@@ -53,6 +54,7 @@ PY
 )
 [[ "$tag" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]] || die "manifest tag is invalid"
 [[ "$commit" =~ ^[0-9a-f]{40}$ ]] || die "manifest commit is invalid"
+[[ "$repository" =~ ^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$ ]] || die "manifest repository is invalid"
 [[ "$release_number" =~ ^[1-9][0-9]*$ ]] || die "manifest release id is invalid"
 [[ "$publication_id" =~ ^[0-9a-f]{64}$ ]] || die "manifest publication id is invalid"
 [[ "$dmg_asset_id" =~ ^[1-9][0-9]*$ ]] || die "manifest publication dmg asset id is invalid"
@@ -77,6 +79,23 @@ else
     die "acceptance-candidate must be named acceptance-candidate.json"
   [[ "$(basename "$acceptance_signature")" == acceptance-candidate.json.sig ]] ||
     die "acceptance-candidate signature must be named acceptance-candidate.json.sig"
+  # Fail closed BEFORE any Pearl transfer/promotion: the immutable release dir
+  # would otherwise pin a stale/expired/mismatched candidate that only the
+  # installer's die-4 rejects, and the same release id could never be repaired.
+  # Runs the same domain-separated ECDSA P-256 validation install.sh uses
+  # (schema/channel, signing key macprovider-acceptance-p256-v1, checksums.txt
+  # binding, 5m-24h validity window, not expired) and pins the candidate's
+  # tag/candidate_commit/compatibility_set_id to this exact release.
+  repo_root="$(cd "$SCRIPT_DIR/.." && pwd)"
+  python3 "$SCRIPT_DIR/acceptance-candidate-metadata.py" verify \
+    --input "$acceptance_candidate" \
+    --signature "$acceptance_signature" \
+    --public-key "$repo_root/security/acceptance-candidate-signing-public.pem" \
+    --checksums "$checksums" \
+    --repository "$repository" \
+    --tag "$tag" \
+    --candidate-commit "$commit" ||
+    die "acceptance-candidate signature/identity/expiry validation failed"
 fi
 
 VPS_HOST="${MALIBU_DOWNLOAD_VPS_HOST:-159.223.165.194}"

--- a/scripts/recover-malibu-publication.sh
+++ b/scripts/recover-malibu-publication.sh
@@ -177,7 +177,8 @@ python3 "$repo_root/scripts/capture-release-publication.py" \
 bash "$repo_root/scripts/publish-malibu-latest-dmg.sh" \
   "$manifest" "$work/Malibu-v1.8.39.dmg" "$work/appcast.xml" \
   "$work/compatibility-artifact-index.json" "$work/checksums.txt" \
-  "$work/checksums.txt.sig" "$work/release-provenance.json"
+  "$work/checksums.txt.sig" "$work/release-provenance.json" \
+  '' ''
 
 printf '[recover-malibu-publication] ok: immutable release %s republished to Pearl\n' \
   "$release_id"

--- a/scripts/test-malibu-acceptance-candidate-prepublish.sh
+++ b/scripts/test-malibu-acceptance-candidate-prepublish.sh
@@ -1,0 +1,166 @@
+#!/usr/bin/env bash
+# Prove publish-malibu-latest-dmg.sh validates the signed acceptance-candidate
+# (P-256 signature + schema + tag/candidate_commit/compatibility_set_id + expiry)
+# BEFORE any Pearl transfer/promotion, so a stale/expired/mismatched/dummy
+# candidate can never reach the immutable release dir or the .malibu-current swap.
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "$0")/.." && pwd -P)"
+work="$(mktemp -d "${TMPDIR:-/tmp}/malibu-acceptance-prepublish.XXXXXX")"
+trap 'rm -rf "$work"' EXIT
+
+fail() {
+  printf '[acceptance-prepublish-test] FAIL: %s\n' "$*" >&2
+  exit 1
+}
+
+command -v openssl >/dev/null 2>&1 || { echo "SKIP: openssl required"; exit 0; }
+
+# Isolated mirror so the "committed" acceptance public key is our ephemeral key
+# and no real Pearl SSH or release-set verification runs.
+mirror="$work/repo"
+mkdir -p "$mirror/scripts" "$mirror/security" "$work/input"
+cp "$repo_root/scripts/publish-malibu-latest-dmg.sh" "$mirror/scripts/"
+cp "$repo_root/scripts/acceptance-candidate-metadata.py" "$mirror/scripts/"
+
+# Stub the heavy release-set verifier: this test only exercises the acceptance
+# gate, which runs after it and before any transfer.
+printf '#!/usr/bin/env bash\nexit 0\n' > "$mirror/scripts/verify-malibu-publication-set.sh"
+# Stub the Pearl SSH transport. Reaching it means the acceptance gate passed;
+# it records a marker and fails so no real network/promotion happens.
+cat > "$mirror/scripts/malibu-download-ssh.sh" <<'SH'
+malibu_download_ssh() { printf 'reached-ssh\n' >> "$MOCK_SSH_MARKER"; return 1; }
+malibu_download_scp() { printf 'reached-ssh\n' >> "$MOCK_SSH_MARKER"; return 1; }
+SH
+chmod +x "$mirror/scripts/verify-malibu-publication-set.sh"
+
+openssl ecparam -name prime256v1 -genkey -noout -out "$work/acceptance-private.pem"
+openssl ec -in "$work/acceptance-private.pem" -pubout \
+  -out "$mirror/security/acceptance-candidate-signing-public.pem" >/dev/null 2>&1
+
+repository="Augustas11/macprovider"
+tag="v1.8.70"
+commit="$(printf 'c%.0s' {1..40})"
+
+# Minimal frozen-mode manifest (non-v1.8.39: no appcast asset). publish reads
+# only tag/commit/repository/release_id/publication_id and the DMG asset id.
+printf 'signed notarized 1.8.70 dmg bytes\n' > "$work/input/Malibu-${tag}.dmg"
+printf 'artifact index bytes\n' > "$work/input/compatibility-artifact-index.json"
+cp "$repo_root/scripts/dist/malibu-frozen-bridge-appcast.xml" "$work/input/frozen-appcast.xml"
+printf 'checksums-for-this-release\n' > "$work/input/checksums.txt"
+printf 'checksums signature bytes\n' > "$work/input/checksums.txt.sig"
+printf 'provenance bytes\n' > "$work/input/release-provenance.json"
+python3 - "$work/input/publication-manifest.json" "$work/input/Malibu-${tag}.dmg" "$repository" "$tag" "$commit" <<'PY'
+import hashlib, json, pathlib, sys
+output, dmg, repository, tag, commit = sys.argv[1:]
+dmg_digest = hashlib.sha256(pathlib.Path(dmg).read_bytes()).hexdigest()
+manifest = {
+    "schema_version": 1,
+    "repository": repository,
+    "tag": tag,
+    "commit": commit,
+    "prerelease": False,
+    "release_id": 505,
+    "publication_id": "0" * 64,
+    "assets": {f"Malibu-{tag}.dmg": {"id": 900, "sha256": dmg_digest}},
+}
+pathlib.Path(output).write_text(json.dumps(manifest, sort_keys=True, separators=(",", ":")) + "\n")
+PY
+
+# Sign an acceptance-candidate exactly as command_sign_acceptance does:
+# signature over  SIGNING_DOMAIN + canonical_bytes(metadata). Files use the
+# canonical basenames publish requires, isolated in a per-case directory.
+sign_candidate() {
+  local case_dir="$1" sign_tag="$2" sign_commit="$3" issued="$4" expires="$5"
+  mkdir -p "$case_dir"
+  local out_json="$case_dir/acceptance-candidate.json"
+  local out_sig="$case_dir/acceptance-candidate.json.sig"
+  python3 - "$out_json" "$work/input/checksums.txt" "$repository" "$sign_tag" "$sign_commit" "$issued" "$expires" <<'PY'
+import hashlib, json, pathlib, sys
+out, checksums, repository, tag, commit, issued, expires = sys.argv[1:]
+value = {
+    "candidate_commit": commit,
+    "candidate_ref": "refs/heads/main",
+    "channel": "acceptance",
+    "checksums": {"name": "checksums.txt", "sha256": hashlib.sha256(pathlib.Path(checksums).read_bytes()).hexdigest()},
+    "compatibility_set_id": f"{repository}:{tag}@{commit}",
+    "control_commit": "b" * 40,
+    "expires_at": expires,
+    "issued_at": issued,
+    "repository": repository,
+    "run_attempt": 1,
+    "run_id": "123456789",
+    "schema_version": "macprovider.acceptance-candidate.v1",
+    "signing": {"algorithm": "ecdsa-p256-sha256", "key_id": "macprovider-acceptance-p256-v1"},
+    "tag": tag,
+}
+canonical = (json.dumps(value, sort_keys=True, separators=(",", ":")) + "\n").encode()
+pathlib.Path(out).write_bytes(canonical)
+pathlib.Path(out + ".message").write_bytes(b"macprovider.acceptance-candidate.v1\n" + canonical)
+PY
+  openssl dgst -sha256 -sign "$work/acceptance-private.pem" \
+    -out "$case_dir/sig.der" "$out_json.message"
+  base64 < "$case_dir/sig.der" | tr -d '\n' > "$out_sig"
+  printf '\n' >> "$out_sig"
+}
+
+issued_now="$(python3 -c 'import datetime;print((datetime.datetime.now(datetime.timezone.utc)-datetime.timedelta(minutes=1)).strftime("%Y-%m-%dT%H:%M:%SZ"))')"
+expires_future="$(python3 -c 'import datetime;print((datetime.datetime.now(datetime.timezone.utc)+datetime.timedelta(hours=1)).strftime("%Y-%m-%dT%H:%M:%SZ"))')"
+issued_old="$(python3 -c 'import datetime;print((datetime.datetime.now(datetime.timezone.utc)-datetime.timedelta(hours=2)).strftime("%Y-%m-%dT%H:%M:%SZ"))')"
+expires_past="$(python3 -c 'import datetime;print((datetime.datetime.now(datetime.timezone.utc)-datetime.timedelta(hours=1)).strftime("%Y-%m-%dT%H:%M:%SZ"))')"
+
+run_publish() {
+  # $1 = acceptance json, $2 = acceptance sig
+  rm -f "$work/ssh.marker"
+  local key_file="$work/ssh-key"
+  printf 'test key\n' > "$key_file"
+  chmod 600 "$key_file"
+  MOCK_SSH_MARKER="$work/ssh.marker" \
+  MALIBU_DOWNLOAD_SSH_KEY="$key_file" \
+  MALIBU_DOWNLOAD_VPS_HOST=127.0.0.1 \
+    bash "$mirror/scripts/publish-malibu-latest-dmg.sh" \
+    "$work/input/publication-manifest.json" "$work/input/Malibu-${tag}.dmg" \
+    "$work/input/frozen-appcast.xml" "$work/input/compatibility-artifact-index.json" \
+    "$work/input/checksums.txt" "$work/input/checksums.txt.sig" \
+    "$work/input/release-provenance.json" \
+    "$1" "$2"
+}
+
+# 1) Valid candidate: passes the acceptance gate and REACHES the (stubbed) SSH
+#    transport. Publish then fails at the stub, which is expected.
+sign_candidate "$work/valid" "$tag" "$commit" "$issued_now" "$expires_future"
+if run_publish "$work/valid/acceptance-candidate.json" "$work/valid/acceptance-candidate.json.sig" \
+  >"$work/valid.out" 2>&1; then
+  fail "publish unexpectedly succeeded against the stubbed SSH transport"
+fi
+grep -q 'acceptance-candidate signature/identity/expiry validation failed' "$work/valid.out" &&
+  fail "valid acceptance-candidate was wrongly rejected"
+[[ -f "$work/ssh.marker" ]] || fail "valid candidate did not reach the SSH transport (gate over-rejected)"
+
+expect_prepublish_rejection() {
+  local label="$1" case_dir="$2"
+  if run_publish "$case_dir/acceptance-candidate.json" "$case_dir/acceptance-candidate.json.sig" \
+    >"$work/$label.out" 2>&1; then
+    fail "$label was accepted"
+  fi
+  grep -q 'acceptance-candidate signature/identity/expiry validation failed' "$work/$label.out" ||
+    { cat "$work/$label.out" >&2; fail "$label did not fail at the acceptance gate"; }
+  [[ ! -f "$work/ssh.marker" ]] || fail "$label reached the SSH transport before rejection"
+}
+
+# 2) Tampered signature (valid metadata, corrupted signature bytes).
+mkdir -p "$work/tampered"
+cp "$work/valid/acceptance-candidate.json" "$work/tampered/acceptance-candidate.json"
+printf 'AAAA%s\n' "$(base64 < "$work/valid/sig.der" | tr -d '\n' | cut -c5-)" \
+  > "$work/tampered/acceptance-candidate.json.sig"
+expect_prepublish_rejection tampered "$work/tampered"
+
+# 3) Expired candidate (valid signature, expires in the past).
+sign_candidate "$work/expired" "$tag" "$commit" "$issued_old" "$expires_past"
+expect_prepublish_rejection expired "$work/expired"
+
+# 4) Tag/commit mismatch (candidate signed for a different release).
+sign_candidate "$work/mismatch" "v1.8.71" "$(printf 'd%.0s' {1..40})" "$issued_now" "$expires_future"
+expect_prepublish_rejection mismatch "$work/mismatch"
+
+echo 'Malibu acceptance-candidate pre-publish validation checks passed'

--- a/scripts/test-malibu-bootstrap-bridge.sh
+++ b/scripts/test-malibu-bootstrap-bridge.sh
@@ -286,7 +286,8 @@ printf '%s  Malibu-v1.8.39.dmg\n' "$dmg_sha" > "$work/input/Malibu-v1.8.39.dmg.s
 MALIBU_PUBLICATION_TESTING=1 bash "$installer" \
   "$work/webroot" v1.8.39 "$publication_id" \
   "$work/input/publication-manifest.json" "$work/input/Malibu-v1.8.39.dmg" \
-  "$work/input/appcast.xml" "$work/input/Malibu-v1.8.39.dmg.sha256"
+  "$work/input/appcast.xml" "$work/input/Malibu-v1.8.39.dmg.sha256" \
+  '' ''
 
 [[ -L "$work/webroot/.malibu-current" ]] || fail "current pointer is not atomic"
 [[ "$(cat "$work/webroot/latest.dmg")" == 'signed dmg bytes' ]] || fail "latest DMG differs"
@@ -303,6 +304,7 @@ if MALIBU_PUBLICATION_TESTING=1 bash "$installer" \
   "$work/webroot" v1.8.39 "$drift_id" \
   "$work/input/publication-manifest-drift.json" "$work/input/Malibu-v1.8.39.dmg" \
   "$work/input/appcast-drift.xml" "$work/input/Malibu-v1.8.39.dmg.sha256" \
+  '' '' \
   >"$work/drift.out" 2>&1; then
   fail "same-tag publication drift was accepted"
 fi
@@ -315,23 +317,113 @@ if MALIBU_PUBLICATION_TESTING=1 bash "$installer" \
   "$work/prerelease-webroot" v1.8.39 "$publication_id" \
   "$work/input/prerelease.json" "$work/input/Malibu-v1.8.39.dmg" \
   "$work/input/appcast.xml" "$work/input/Malibu-v1.8.39.dmg.sha256" \
+  '' '' \
   >"$work/prerelease.out" 2>&1; then
   fail "prerelease bridge was accepted"
 fi
 grep -q 'prerelease must not publish' "$work/prerelease.out" || fail "prerelease rejection was unclear"
 
-if MALIBU_PUBLICATION_TESTING=1 bash "$installer" \
-  "$work/other-webroot" v1.8.40 "$publication_id" \
-  "$work/input/publication-manifest.json" "$work/input/Malibu-v1.8.39.dmg" \
-  "$work/input/appcast.xml" "$work/input/Malibu-v1.8.39.dmg.sha256" \
-  >"$work/tag.out" 2>&1; then
-  fail "bridge installer accepted a later tag"
-fi
-grep -q 'frozen to v1.8.39' "$work/tag.out" || fail "tag rejection was unclear"
-
+# The appcast generator stays frozen to v1.8.39, so a later tag must still be
+# rejected there even though the download promotion itself is generalized.
 if bash "$generator" v1.8.40 >"$work/generator.out" 2>&1; then
   fail "bridge generator accepted a later tag"
 fi
 grep -q 'frozen to v1.8.39' "$work/generator.out" || fail "generator tag rejection was unclear"
+
+# --- Generalized (non-v1.8.39) download promotion ---------------------------
+# A later stable tag is promoted with the committed frozen bridge appcast (which
+# is not a per-release asset) beside the newer DMG, plus the signed
+# acceptance-candidate produced by acceptance-candidate.yml.
+gen_tag=v1.8.70
+gen_dmg="$work/input/Malibu-${gen_tag}.dmg"
+printf 'signed notarized 1.8.70 dmg bytes\n' > "$gen_dmg"
+# Byte-identical to the committed frozen bridge appcast so its digest matches the
+# pin embedded in install-malibu-publication.sh.
+cp "$root/scripts/dist/malibu-frozen-bridge-appcast.xml" "$work/input/frozen-appcast.xml"
+printf '{"schema_version":"macprovider.acceptance-candidate.v1"}\n' \
+  > "$work/input/acceptance-candidate.json"
+printf 'acceptance signature bytes\n' > "$work/input/acceptance-candidate.json.sig"
+
+gen_publication_id="$(python3 - \
+  "$work/input/publication-manifest-generalized.json" \
+  "$gen_dmg" "$work/input/compatibility-artifact-index.json" "$gen_tag" <<'PY'
+import hashlib
+import json
+import pathlib
+import sys
+
+output, dmg_name, index_name, tag = sys.argv[1:]
+dmg_digest = hashlib.sha256(pathlib.Path(dmg_name).read_bytes()).hexdigest()
+index_digest = hashlib.sha256(pathlib.Path(index_name).read_bytes()).hexdigest()
+# Non-v1.8.39 promotions exclude the frozen bridge appcast from the manifest and
+# publication_id, exactly like capture-release-publication.py.
+identity = hashlib.sha256(json.dumps({
+    "compatibility_artifact_index_sha256": index_digest,
+    "dmg_sha256": dmg_digest,
+}, sort_keys=True, separators=(",", ":")).encode()).hexdigest()
+manifest = {
+    "schema_version": 1,
+    "repository": "Augustas11/macprovider",
+    "tag": tag,
+    "commit": "b" * 40,
+    "prerelease": False,
+    "release_id": 505,
+    "publication_id": identity,
+    "assets": {
+        f"Malibu-{tag}.dmg": {"id": 900, "sha256": dmg_digest},
+        "compatibility-artifact-index.json": {"id": 901, "sha256": index_digest},
+    },
+}
+pathlib.Path(output).write_text(json.dumps(manifest, sort_keys=True, separators=(",", ":")) + "\n")
+print(identity)
+PY
+)"
+gen_dmg_sha="$(shasum -a 256 "$gen_dmg" | awk '{print $1}')"
+printf '%s  Malibu-%s.dmg\n' "$gen_dmg_sha" "$gen_tag" > "$work/input/Malibu-${gen_tag}.dmg.sha256"
+
+MALIBU_PUBLICATION_TESTING=1 bash "$installer" \
+  "$work/generalized-webroot" "$gen_tag" "$gen_publication_id" \
+  "$work/input/publication-manifest-generalized.json" "$gen_dmg" \
+  "$work/input/frozen-appcast.xml" "$work/input/Malibu-${gen_tag}.dmg.sha256" \
+  "$work/input/acceptance-candidate.json" "$work/input/acceptance-candidate.json.sig"
+
+gen_release="$work/generalized-webroot/.malibu-current"
+[[ -L "$gen_release" ]] || fail "generalized current pointer is not atomic"
+[[ "$(cat "$work/generalized-webroot/latest.dmg")" == 'signed notarized 1.8.70 dmg bytes' ]] ||
+  fail "generalized latest DMG differs"
+[[ "$(cat "$work/generalized-webroot/Malibu-${gen_tag}.dmg")" == 'signed notarized 1.8.70 dmg bytes' ]] ||
+  fail "generalized versioned DMG differs"
+cmp -s "$work/generalized-webroot/appcast.xml" \
+  "$root/scripts/dist/malibu-frozen-bridge-appcast.xml" ||
+  fail "generalized promotion did not serve the frozen bridge appcast"
+cmp -s "$gen_release/acceptance-candidate.json" "$work/input/acceptance-candidate.json" ||
+  fail "generalized promotion did not place the acceptance-candidate"
+cmp -s "$gen_release/acceptance-candidate.json.sig" "$work/input/acceptance-candidate.json.sig" ||
+  fail "generalized promotion did not place the acceptance-candidate signature"
+
+# A generalized promotion must reject an appcast that is not the frozen bridge.
+printf 'not the frozen bridge appcast\n' > "$work/input/wrong-appcast.xml"
+if MALIBU_PUBLICATION_TESTING=1 bash "$installer" \
+  "$work/wrong-appcast-webroot" "$gen_tag" "$gen_publication_id" \
+  "$work/input/publication-manifest-generalized.json" "$gen_dmg" \
+  "$work/input/wrong-appcast.xml" "$work/input/Malibu-${gen_tag}.dmg.sha256" \
+  "$work/input/acceptance-candidate.json" "$work/input/acceptance-candidate.json.sig" \
+  >"$work/wrong-appcast.out" 2>&1; then
+  fail "generalized promotion accepted a non-frozen appcast"
+fi
+grep -q 'not the frozen Malibu bridge appcast' "$work/wrong-appcast.out" ||
+  fail "non-frozen appcast rejection was unclear"
+
+# A generalized promotion must require the signed acceptance-candidate pair.
+if MALIBU_PUBLICATION_TESTING=1 bash "$installer" \
+  "$work/missing-acceptance-webroot" "$gen_tag" "$gen_publication_id" \
+  "$work/input/publication-manifest-generalized.json" "$gen_dmg" \
+  "$work/input/frozen-appcast.xml" "$work/input/Malibu-${gen_tag}.dmg.sha256" \
+  '' '' \
+  >"$work/missing-acceptance.out" 2>&1; then
+  fail "generalized promotion accepted a missing acceptance-candidate"
+fi
+grep -q 'requires the staged acceptance-candidate pair' "$work/missing-acceptance.out" ||
+  fail "missing acceptance-candidate rejection was unclear"
 
 echo 'Malibu bootstrap bridge regression checks passed'

--- a/scripts/test-recover-malibu-publication.sh
+++ b/scripts/test-recover-malibu-publication.sh
@@ -112,13 +112,14 @@ SH
 cat >"$fixture/scripts/publish-malibu-latest-dmg.sh" <<'SH'
 #!/usr/bin/env bash
 set -euo pipefail
-[[ "$#" == 7 ]]
+[[ "$#" == 9 ]]
 python3 - "$@" <<'PY'
 import json
 import pathlib
 import sys
 
-manifest_path, dmg, appcast, index, checksums, signature, provenance = map(pathlib.Path, sys.argv[1:])
+(manifest_path, dmg, appcast, index, checksums, signature, provenance,
+ acceptance, acceptance_sig) = map(pathlib.Path, sys.argv[1:])
 manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
 assert manifest["release_id"] == 701
 assert manifest["tag"] == "v1.8.39"
@@ -131,6 +132,8 @@ assert [path.name for path in (dmg, appcast, index, checksums, signature, proven
     "checksums.txt.sig",
     "release-provenance.json",
 ]
+# The frozen v1.8.39 bridge recovery carries no acceptance-candidate.
+assert str(acceptance) == "." and str(acceptance_sig) == "."
 assert manifest["assets"]["compatibility-artifact-index.json"]["id"] == 803
 PY
 printf '%s\n' published >"$MOCK_PUBLISH_MARKER"

--- a/scripts/test-release-security-posture.sh
+++ b/scripts/test-release-security-posture.sh
@@ -754,7 +754,7 @@ for requirement in (
 ):
     if requirement not in pearl_bridge:
         raise SystemExit(f"Pearl bootstrap publication omits {requirement}")
-if publish.find("Publish one-time Malibu 1.8.32 bootstrap bridge to Pearl") < publish.find(
+if publish.find("Publish Malibu download bridge to Pearl") < publish.find(
     "cmp final-draft-manifest.json publication-manifest.json"
 ):
     raise SystemExit("Pearl bridge must publish only after immutable GitHub publication")

--- a/scripts/test-release-security-posture.sh
+++ b/scripts/test-release-security-posture.sh
@@ -288,7 +288,7 @@ PROTECTED_OPENSSL_CONSUMERS = (
     ("Create verified draft GitHub release", 1, 1),
     ("Publish only the revalidated numeric draft", 2, 2),
     ("Publish one append-only immutable discovery transport", 1, 1),
-    ("Publish one-time Malibu 1.8.32 bootstrap bridge to Pearl", 0, 0),
+    ("Publish Malibu download bridge to Pearl", 0, 0),
 )
 
 
@@ -732,20 +732,24 @@ for requirement in (
         raise SystemExit(f"final Malibu artifact verification omits: {requirement}")
 if publish.count("Generate one-time Malibu 1.8.32 bootstrap bridge") != 1:
     raise SystemExit("release workflow must contain exactly one named bootstrap generator")
-if publish.count("Publish one-time Malibu 1.8.32 bootstrap bridge to Pearl") != 1:
-    raise SystemExit("release workflow must contain exactly one named bootstrap publisher")
+if publish.count("Publish Malibu download bridge to Pearl") != 1:
+    raise SystemExit("release workflow must contain exactly one named download bridge publisher")
 bridge = publish.split("- name: Generate one-time Malibu 1.8.32 bootstrap bridge", 1)[1].split(
     "\n      - name:", 1
 )[0]
 pearl_bridge = publish.split(
-    "- name: Publish one-time Malibu 1.8.32 bootstrap bridge to Pearl", 1
+    "- name: Publish Malibu download bridge to Pearl", 1
 )[1].split("\n      - name:", 1)[0]
 if "if: needs.build.outputs.tag == 'v1.8.39'" not in bridge:
     raise SystemExit("legacy appcast generation is not frozen to v1.8.39")
 if "SPARKLE_EDDSA_PRIVATE_KEY" not in bridge or "verify-malibu-sparkle-signature.py" not in bridge:
     raise SystemExit("legacy appcast lacks protected signing or frozen-key verification")
-if "if: needs.build.outputs.tag == 'v1.8.39' && needs.build.outputs.prerelease == 'false'" not in pearl_bridge:
-    raise SystemExit("Pearl bridge publication is not frozen to stable v1.8.39")
+if "if: needs.build.outputs.prerelease == 'false'" not in pearl_bridge:
+    raise SystemExit("Pearl download bridge publication must gate on a stable release")
+if "scripts/dist/malibu-frozen-bridge-appcast.xml" not in pearl_bridge:
+    raise SystemExit("Pearl download bridge must ship the committed frozen Sparkle appcast")
+if "acceptance-candidate.json acceptance-candidate.json.sig" not in pearl_bridge:
+    raise SystemExit("Pearl download bridge must place the signed acceptance-candidate pair")
 for requirement in (
     "publish-malibu-latest-dmg.sh",
     "publication-manifest.json",

--- a/scripts/verify-malibu-bootstrap-publication.sh
+++ b/scripts/verify-malibu-bootstrap-publication.sh
@@ -10,10 +10,27 @@ die() {
 tag="$1"
 dmg="$2"
 appcast="$3"
-[[ "$tag" == v1.8.39 ]] || die "legacy Malibu publication is frozen to v1.8.39"
+[[ "$tag" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]] || die "tag must be vX.Y.Z"
 for path in "$dmg" "$appcast"; do
   [[ -f "$path" && ! -L "$path" ]] || die "expected a regular publication input: $path"
 done
+repo_root="$(cd "$(dirname "$0")/.." && pwd)"
+if [[ "$tag" != v1.8.39 ]]; then
+  # Non-v1.8.39 promotions ship the committed frozen legacy Sparkle bridge
+  # appcast. Confirm the local reference bytes match the committed constant so
+  # the public byte-comparison below anchors to the reviewed appcast.
+  frozen_bridge_appcast="$repo_root/scripts/dist/malibu-frozen-bridge-appcast.xml"
+  [[ -f "$frozen_bridge_appcast" && ! -L "$frozen_bridge_appcast" ]] ||
+    die "committed frozen bridge appcast is missing"
+  if command -v shasum >/dev/null 2>&1; then
+    a="$(shasum -a 256 "$appcast" | awk '{print $1}')"
+    b="$(shasum -a 256 "$frozen_bridge_appcast" | awk '{print $1}')"
+  else
+    a="$(sha256sum "$appcast" | awk '{print $1}')"
+    b="$(sha256sum "$frozen_bridge_appcast" | awk '{print $1}')"
+  fi
+  [[ "$a" == "$b" ]] || die "appcast is not the committed frozen Malibu bridge appcast"
+fi
 
 host="${MALIBU_DOWNLOAD_HOST:-download.malibu.tech}"
 base="https://${host}"
@@ -47,9 +64,15 @@ for published_dmg in "$work/latest.dmg" "$work/Malibu-${tag}.dmg"; do
     die "public DMG bytes differ from the immutable release asset: $published_dmg"
 done
 
-repo_root="$(cd "$(dirname "$0")/.." && pwd)"
-python3 "$repo_root/scripts/verify-malibu-sparkle-signature.py" \
-  "$tag" "$work/latest.dmg" "$work/appcast.xml" \
-  "$repo_root/scripts/dist/malibu-v1.8.32-sparkle-public-key"
+# The Sparkle EdDSA enclosure signature binds the appcast to the DMG it
+# advertises, which only corresponds for the v1.8.39 bootstrap. Non-v1.8.39
+# promotions serve the frozen bridge appcast (already confirmed byte-identical
+# to the committed constant) beside a newer DMG it does not describe.
+if [[ "$tag" == v1.8.39 ]]; then
+  python3 "$repo_root/scripts/verify-malibu-sparkle-signature.py" \
+    "$tag" "$work/latest.dmg" "$work/appcast.xml" \
+    "$repo_root/scripts/dist/malibu-v1.8.32-sparkle-public-key"
+fi
 
-printf '[verify-malibu-bootstrap-publication] ok: %s is the exact v1.8.39 bridge\n' "$base"
+printf '[verify-malibu-bootstrap-publication] ok: %s serves the exact published bytes for %s\n' \
+  "$base" "$tag"

--- a/scripts/verify-malibu-bootstrap-publication.sh
+++ b/scripts/verify-malibu-bootstrap-publication.sh
@@ -51,7 +51,15 @@ curl_args=(
   --fail --show-error --silent --location --proto '=https' --tlsv1.2
   --connect-timeout 20 --max-time 240 --retry 3 --retry-delay 2
 )
-cache_key="publication=${expected_appcast_sha}"
+# The cache-bust key must vary per release so a CDN/proxy cannot serve a stale
+# prior latest.dmg. For non-v1.8.39 promotions the appcast is the frozen bridge
+# constant (identical every release), so key off the per-release DMG sha; the
+# v1.8.39 bootstrap keeps its unique per-release appcast sha.
+if [[ "$tag" == v1.8.39 ]]; then
+  cache_key="publication=${expected_appcast_sha}"
+else
+  cache_key="publication=${expected_dmg_sha}"
+fi
 curl "${curl_args[@]}" -o "$work/appcast.xml" "${base}/appcast.xml?${cache_key}"
 curl "${curl_args[@]}" -o "$work/latest.dmg" "${base}/latest.dmg?${cache_key}"
 curl "${curl_args[@]}" -o "$work/Malibu-${tag}.dmg" \

--- a/scripts/verify-malibu-publication-set.sh
+++ b/scripts/verify-malibu-publication-set.sh
@@ -33,21 +33,38 @@ print(value.get("repository", ""), value.get("tag", ""), value.get("commit", "")
 PY
 )"
 read -r expected_repository expected_tag expected_commit <<< "$expected_identity"
-[[ "$expected_tag" == v1.8.39 ]] || die "legacy Malibu publication is frozen to v1.8.39"
+[[ "$expected_tag" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]] || die "publication tag is invalid"
+frozen_bridge_appcast="$repo_root/scripts/dist/malibu-frozen-bridge-appcast.xml"
+if [[ "$expected_tag" == v1.8.39 ]]; then
+  frozen_appcast=false
+else
+  # Non-v1.8.39 download promotions ship the committed frozen legacy Sparkle
+  # bridge appcast, which is NOT part of the per-release signed provenance, so
+  # it is excluded from checksum coverage and verified against the committed
+  # constant below.
+  frozen_appcast=true
+fi
+if [[ "$frozen_appcast" == true ]]; then
+  checksum_assets=("$dmg" "$artifact_index" "$provenance")
+else
+  checksum_assets=("$dmg" "$appcast" "$artifact_index" "$provenance")
+fi
 bash "$repo_root/scripts/verify-release-checksums.sh" \
   --allow-partial --openssl "$openssl_bin" \
   "$checksums" "$signature" "$provenance" \
   "$expected_repository" "$expected_tag" "$expected_commit" \
-  "$dmg" "$appcast" "$artifact_index" "$provenance" >/dev/null
+  "${checksum_assets[@]}" >/dev/null
 
-publication_identity="$(python3 - "$manifest" "$dmg" "$appcast" "$artifact_index" "$checksums" "$signature" "$provenance" <<'PY'
+publication_identity="$(python3 - "$frozen_appcast" "$frozen_bridge_appcast" "$manifest" "$dmg" "$appcast" "$artifact_index" "$checksums" "$signature" "$provenance" <<'PY'
 import hashlib
 import json
 import pathlib
 import re
 import sys
 
-manifest_path, dmg_path, appcast_path, index_path, checksums_path, signature_path, provenance_path = map(pathlib.Path, sys.argv[1:])
+frozen_mode = sys.argv[1] == "true"
+frozen_ref = pathlib.Path(sys.argv[2])
+manifest_path, dmg_path, appcast_path, index_path, checksums_path, signature_path, provenance_path = map(pathlib.Path, sys.argv[3:])
 manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
 provenance = json.loads(provenance_path.read_text(encoding="utf-8"))
 if manifest.get("schema_version") != 1 or provenance.get("schema_version") != 1:
@@ -61,21 +78,23 @@ tag = manifest.get("tag")
 commit = manifest.get("commit")
 if not isinstance(tag, str) or not re.fullmatch(r"v\d+\.\d+\.\d+", tag):
     raise SystemExit("invalid publication tag")
-if tag != "v1.8.39":
-    raise SystemExit("legacy Malibu publication is frozen to v1.8.39")
 if not isinstance(commit, str) or not re.fullmatch(r"[0-9a-f]{40}", commit):
     raise SystemExit("invalid publication commit")
 if type(manifest.get("release_id")) is not int or manifest["release_id"] <= 0:
     raise SystemExit("invalid numeric release id")
 
-paths = [dmg_path, appcast_path, index_path, checksums_path, signature_path, provenance_path]
+# For non-v1.8.39 promotions the frozen legacy Sparkle bridge appcast is not a
+# per-release signed asset, so it is excluded from the manifest/provenance
+# binding here and verified against the committed constant below instead.
+if frozen_mode:
+    paths = [dmg_path, index_path, checksums_path, signature_path, provenance_path]
+else:
+    paths = [dmg_path, appcast_path, index_path, checksums_path, signature_path, provenance_path]
 local = {path.name: hashlib.sha256(path.read_bytes()).hexdigest() for path in paths}
 dmg_name = f"Malibu-{tag}.dmg"
-if (
-    dmg_path.name != dmg_name
-    or appcast_path.name != "appcast.xml"
-    or index_path.name != "compatibility-artifact-index.json"
-):
+if dmg_path.name != dmg_name or index_path.name != "compatibility-artifact-index.json":
+    raise SystemExit("publication filenames do not match the tag")
+if not frozen_mode and appcast_path.name != "appcast.xml":
     raise SystemExit("publication filenames do not match the tag")
 assets = manifest.get("assets")
 if not isinstance(assets, dict):
@@ -93,12 +112,23 @@ for name, digest in signed_assets.items():
     if not isinstance(row, dict) or row.get("sha256") != digest:
         raise SystemExit(f"signed provenance differs from publication manifest for {name}")
 
-content = json.dumps(
-    {
+if frozen_mode:
+    if not frozen_ref.is_file() or frozen_ref.is_symlink():
+        raise SystemExit("committed frozen bridge appcast is missing")
+    if hashlib.sha256(appcast_path.read_bytes()).hexdigest() != hashlib.sha256(frozen_ref.read_bytes()).hexdigest():
+        raise SystemExit("appcast is not the committed frozen Malibu bridge appcast")
+    publication_content = {
+        "compatibility_artifact_index_sha256": local["compatibility-artifact-index.json"],
+        "dmg_sha256": local[dmg_name],
+    }
+else:
+    publication_content = {
         "appcast_sha256": local["appcast.xml"],
         "compatibility_artifact_index_sha256": local["compatibility-artifact-index.json"],
         "dmg_sha256": local[dmg_name],
-    },
+    }
+content = json.dumps(
+    publication_content,
     sort_keys=True,
     separators=(",", ":"),
 ).encode()
@@ -113,9 +143,17 @@ read -r tag commit <<< "$publication_identity"
   die "publication identity verification failed"
 
 bash "$repo_root/scripts/test-coordinator-advertised-version.sh" "$tag"
-python3 "$repo_root/scripts/verify-malibu-sparkle-signature.py" \
-  "$tag" "$dmg" "$appcast" \
-  "$repo_root/scripts/dist/malibu-v1.8.32-sparkle-public-key"
+# The Sparkle EdDSA cross-check binds the appcast enclosure to the DMG it
+# advertises. That correspondence only holds for the v1.8.39 bootstrap, whose
+# appcast describes its own DMG. Non-v1.8.39 promotions ship the frozen bridge
+# appcast (verified byte-identical to the committed constant above) alongside a
+# newer DMG the frozen appcast does not describe, so the enclosure cross-check
+# does not apply.
+if [[ "$frozen_appcast" == false ]]; then
+  python3 "$repo_root/scripts/verify-malibu-sparkle-signature.py" \
+    "$tag" "$dmg" "$appcast" \
+    "$repo_root/scripts/dist/malibu-v1.8.32-sparkle-public-key"
+fi
 bash "$repo_root/scripts/verify-malibu-release-artifacts.sh" \
   "$dmg" --legacy-app-only-no-provider-tarball
 


### PR DESCRIPTION
> ⚠️ **DO NOT MERGE YET.** One item remains: a staging publish to validate the signature-enforced remote path (the 3 release-security test edits are now applied — test green). This generalizes signature-enforced, install-breaking-if-wrong release infra that cannot be exercised in CI — it needs one staging publish to validate the remote path.

## Problem

The Malibu download promotion (`download.malibu.tech`) was hard-locked to the one-time **v1.8.39** Sparkle bootstrap in six places (the release.yml publish gate, `publish-malibu-latest-dmg.sh`, `verify-malibu-publication-set.sh` ×2, the remote root `install-malibu-publication.sh`, `verify-malibu-bootstrap-publication.sh`). Every release since 1.8.39 shipped a Malibu.dmg to GitHub but was **never promotable** to the download — the tooling refuses any other tag. Result: `download.malibu.tech` has been frozen at **v1.8.53** since Jul 20, and each new release silently lags. (The Sparkle *appcast* is a separate legacy bridge and is intentionally frozen — not the update path; Malibu users update via the coordinator CLI-autoupdate.)

## Change

Generalize the download **promotion** so any stable `vX.Y.Z` can be promoted, without disturbing the frozen Sparkle bridge:

- **Lift the six `v1.8.39` tag-locks** (tag-equality only; every signature/checksum/mode/symlink-safety check preserved).
- **Ship the committed frozen bridge appcast** (`scripts/dist/malibu-frozen-bridge-appcast.xml`, sha-pinned in the remote helper) for non-v1.8.39 promotions so the `/appcast.xml → .malibu-current/appcast.xml` symlink keeps resolving. Appcast **generation** stays frozen.
- **Wire the signed acceptance-candidate** (`acceptance-candidate.yml` artifact) into publish + the remote helper so it lands in the promoted release dir under the same atomic/immutable checks — and **validate it before any Pearl transfer** (ECDSA P-256 signature, schema/channel, `checksums.txt` binding, 5m–24h non-expiry, and `tag`/`candidate_commit`/`compatibility_set_id` pinned to this exact release). A stale/expired/mismatched/dummy pair now dies **before** the immutable release dir can pin it, instead of bricking installs at die-4 with no in-place repair.
- **Per-release cache-bust key** (DMG sha, not the constant frozen-appcast sha) so CDNs can't serve a stale `latest.dmg`.
- New negative test `test-malibu-acceptance-candidate-prepublish.sh` (valid passes; tampered/expired/mismatched rejected pre-transfer), wired into `make test-dist`.

## Audit

Three-lane codex (code/security/architect), two rounds → **0 CRITICAL / HIGH / MEDIUM**.
- R1 HIGH "removes the live coordinator release gate" was a **stale-base false positive** (origin/main added that gate in `b0b7289a` after branch point); rebased away.
- R1 HIGH (real): acceptance-candidate placed without validation → fixed (pre-promotion ECDSA validation, above).
- R1 MEDIUM (real): constant cache key → fixed (per-release DMG sha).
- R2: both fixes verified to hold. Residual **LOW** (carried): the remote root helper doesn't independently re-validate the candidate — defense-in-depth only; the normal publish path validates before SSH/transfer, so the helper is never reached with an unvalidated pair.

## Before merge (human-gated)

1. ~~3 assertion updates in `scripts/test-release-security-posture.sh`~~ — **DONE** (user-authorized; step-name renames + gate assertion `prerelease == 'false'` + frozen-appcast/acceptance-candidate asserts; `test-release-security-posture.sh` passes).
2. **One staging publish** to validate the signature-enforced remote path end-to-end (CI can't). ← the only remaining gate.

## Follow-up (not in this PR)

- **Auto-promote post-acceptance:** wire the download promotion into `promote-acceptance-candidate.yml` so every accepted release promotes automatically — otherwise it stays a manual step and keeps lagging. This is the deeper "why it's broken each release" fix.
- **v1.8.69 (the swap-fix release) cannot be promoted** — its acceptance-candidate can't be minted post-tag ("candidate tag already exists"). Not needed: users already get the fix via coordinator CLI-autoupdate. It rides the next release cut with the acceptance flow run pre-tag.

## Governance

Infra/CI + release-tooling PR (no authority domain governs CI/release scripts), so there is no honest spec-governance declaration; `spec-index / check` is advisory and non-required. No behavior change to any SPEC contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
