### PR TITLE
Reconcile SPEC-016 payout conformance anchors

### DIFF
--- a/specs/CONFORMANCE.json
+++ b/specs/CONFORMANCE.json
@@ -426,7 +426,7 @@
     {
       "spec_id": "SPEC-016",
       "title": "Provider payout pipeline (USDC on Base)",
-      "version": "0.1.23",
+      "version": "0.1.24",
       "path": "specs/SPEC-016-payout-pipeline.md",
       "status": "draft",
       "owner": "@Augustas11",
@@ -439,16 +439,24 @@
         "SPEC-006",
         "SPEC-014"
       ],
-      "implementation_status": "pending-reconciliation",
-      "production_status": "pending-verification",
-      "last_reconciled_commit": null,
-      "last_reconciled_at": null,
-      "evidence": [],
+      "implementation_status": "partial",
+      "production_status": "not-deployed",
+      "last_reconciled_commit": "ed26cc8f3178b5da44fae93483df1d931410e35f",
+      "last_reconciled_at": "2026-07-31",
+      "evidence": [
+        {
+          "artifact": "commit:ed26cc8f3178b5da44fae93483df1d931410e35f",
+          "source": null,
+          "captured_at": "2026-07-31",
+          "expires_at": "2027-07-31"
+        }
+      ],
       "requirement_id_migration": "pending",
       "gap": {
         "verdict": "UNKNOWN",
         "owner": "@Augustas11",
-        "issue": "https://github.com/Augustas11/macprovider/issues/614"
+        "issue": "https://github.com/Augustas11/macprovider/issues/614",
+        "rationale": "PR #164 merged the SPEC-016 USDC-on-Base payout implementation and PR #827 repaired the spec-index drift, but the runner remains default-off with payout.enabled=false and no production activation claim. Reconciliation records partial/default-off implementation evidence and preliminary pending requirement anchors only; exhaustive clause-level requirement ID migration, production deployment, §9 operator prerequisites, signed journey-result support, and per-requirement conformance remain pending under the payout-lifecycle domain."
       }
     },
     {
@@ -3034,6 +3042,171 @@
         "owner": "@Augustas11",
         "issue": "https://github.com/Augustas11/macprovider/issues/614",
         "rationale": "R-11 audit and observability (structured per-attempt settlement audit event; no raw prompts/outputs/receipt material; aggregate verified/pending/quarantined/zero_settled counters; recovery/backfill audit completeness): normative in SPEC-022 v0.1.6; settlement pipeline runs in observe mode and reconciliation to conformant is tracked under the verified-model-settlement domain."
+      }
+    },
+    {
+      "requirement_id": "SPEC-016-R001",
+      "spec_id": "SPEC-016",
+      "state": "pending",
+      "implementation": [],
+      "tests": [],
+      "journeys": [],
+      "evidence": [],
+      "gap": {
+        "verdict": "UNKNOWN",
+        "owner": "@Augustas11",
+        "issue": "https://github.com/Augustas11/macprovider/issues/614",
+        "rationale": "Default-off rail scope, USDC-on-Base operator prerequisites, and activation boundary (§1, §2, §9): preliminary anchor for the existing obligation area; implementation merged default-off by PR #164, but production enablement and §9 operator prerequisite evidence remain pending."
+      }
+    },
+    {
+      "requirement_id": "SPEC-016-R002",
+      "spec_id": "SPEC-016",
+      "state": "pending",
+      "implementation": [],
+      "tests": [],
+      "journeys": [],
+      "evidence": [],
+      "gap": {
+        "verdict": "UNKNOWN",
+        "owner": "@Augustas11",
+        "issue": "https://github.com/Augustas11/macprovider/issues/614",
+        "rationale": "Provider payout-address registration, EIP-712 proof-of-possession, replay protection, cooling-off, and rotation semantics (§3): preliminary anchor for the existing obligation area; implementation exists under internal/payout address handling, but conformance mappings and signed journey evidence remain pending."
+      }
+    },
+    {
+      "requirement_id": "SPEC-016-R003",
+      "spec_id": "SPEC-016",
+      "state": "pending",
+      "implementation": [],
+      "tests": [],
+      "journeys": [],
+      "evidence": [],
+      "gap": {
+        "verdict": "UNKNOWN",
+        "owner": "@Augustas11",
+        "issue": "https://github.com/Augustas11/macprovider/issues/614",
+        "rationale": "Payout package boundary, read surfaces, handler inventory, and import-graph ownership (§3.4, §4.1, §7.3): preliminary anchor for the existing obligation area; implementation exists in the coordinator payout package and wiring, but mappings/tests are not yet reconciled to conformant."
+      }
+    },
+    {
+      "requirement_id": "SPEC-016-R004",
+      "spec_id": "SPEC-016",
+      "state": "pending",
+      "implementation": [],
+      "tests": [],
+      "journeys": [],
+      "evidence": [],
+      "gap": {
+        "verdict": "UNKNOWN",
+        "owner": "@Augustas11",
+        "issue": "https://github.com/Augustas11/macprovider/issues/614",
+        "rationale": "Runner selection, signing, broadcast, two-RPC confirmation, and ClaimPayoutReady finalization (§4.3): preliminary anchor for the existing obligation area; runner implementation merged default-off, but production activation, mapped tests, and journey evidence remain pending."
+      }
+    },
+    {
+      "requirement_id": "SPEC-016-R005",
+      "spec_id": "SPEC-016",
+      "state": "pending",
+      "implementation": [],
+      "tests": [],
+      "journeys": [],
+      "evidence": [],
+      "gap": {
+        "verdict": "UNKNOWN",
+        "owner": "@Augustas11",
+        "issue": "https://github.com/Augustas11/macprovider/issues/614",
+        "rationale": "Payout attempt schema, idempotent retry, nonce-gap fill, cancel self-transfer, and abandon-attempt recovery (§4.5, §4.6): preliminary anchor for the existing obligation area; implementation merged default-off, but conformance mappings and evidence remain pending."
+      }
+    },
+    {
+      "requirement_id": "SPEC-016-R006",
+      "spec_id": "SPEC-016",
+      "state": "pending",
+      "implementation": [],
+      "tests": [],
+      "journeys": [],
+      "evidence": [],
+      "gap": {
+        "verdict": "UNKNOWN",
+        "owner": "@Augustas11",
+        "issue": "https://github.com/Augustas11/macprovider/issues/614",
+        "rationale": "Reorg polling, orphan recording, compensation, and funding-recording admin flows (§4.7, §4.9): preliminary anchor for the existing obligation area; implementation merged default-off, but operator runbook evidence and signed journey-result support remain pending."
+      }
+    },
+    {
+      "requirement_id": "SPEC-016-R007",
+      "spec_id": "SPEC-016",
+      "state": "pending",
+      "implementation": [],
+      "tests": [],
+      "journeys": [],
+      "evidence": [],
+      "gap": {
+        "verdict": "UNKNOWN",
+        "owner": "@Augustas11",
+        "issue": "https://github.com/Augustas11/macprovider/issues/614",
+        "rationale": "Runtime flags, pause/resume, runner lease, self-fencing, and crash-safe audit outboxes (§4.8, §4.8a, §4.8b, §4.8c, §6.4.1): preliminary anchor for the existing obligation area; implementation merged default-off, but conformance mappings and production evidence remain pending."
+      }
+    },
+    {
+      "requirement_id": "SPEC-016-R008",
+      "spec_id": "SPEC-016",
+      "state": "pending",
+      "implementation": [],
+      "tests": [],
+      "journeys": [],
+      "evidence": [],
+      "gap": {
+        "verdict": "UNKNOWN",
+        "owner": "@Augustas11",
+        "issue": "https://github.com/Augustas11/macprovider/issues/614",
+        "rationale": "Payout caps, hot-wallet balances, gas accounting, and conservation reconciliation (§5, §6.2, §7.4): preliminary anchor for the existing obligation area; implementation merged default-off, but funded-wallet operation and reconciliation evidence remain pending."
+      }
+    },
+    {
+      "requirement_id": "SPEC-016-R009",
+      "spec_id": "SPEC-016",
+      "state": "pending",
+      "implementation": [],
+      "tests": [],
+      "journeys": [],
+      "evidence": [],
+      "gap": {
+        "verdict": "UNKNOWN",
+        "owner": "@Augustas11",
+        "issue": "https://github.com/Augustas11/macprovider/issues/614",
+        "rationale": "Signer custody, Linux-only process hardening, two-RPC discipline, SPKI pinning, and reload boundaries (§6.3, §6.4, §6.5): preliminary anchor for the existing obligation area; implementation merged default-off, but production host evidence and signed journey-result support remain pending."
+      }
+    },
+    {
+      "requirement_id": "SPEC-016-R010",
+      "spec_id": "SPEC-016",
+      "state": "pending",
+      "implementation": [],
+      "tests": [],
+      "journeys": [],
+      "evidence": [],
+      "gap": {
+        "verdict": "UNKNOWN",
+        "owner": "@Augustas11",
+        "issue": "https://github.com/Augustas11/macprovider/issues/614",
+        "rationale": "Structured audit events, retention, operator queries, BetterStack alert filters, and runbook obligations (§7, §9): preliminary anchor for the existing obligation area; implementation and runbook artifacts merged, but alert verification and production evidence remain pending."
+      }
+    },
+    {
+      "requirement_id": "SPEC-016-R011",
+      "spec_id": "SPEC-016",
+      "state": "pending",
+      "implementation": [],
+      "tests": [],
+      "journeys": [],
+      "evidence": [],
+      "gap": {
+        "verdict": "UNKNOWN",
+        "owner": "@Augustas11",
+        "issue": "https://github.com/Augustas11/macprovider/issues/614",
+        "rationale": "Provider-token custody and compliance payout eligibility (§8, v0.1.20 Wave-2 custody gate): preliminary anchor for the existing obligation area; normative custody gate retained through v0.1.23, but provider eligibility policy and production evidence remain pending."
       }
     }
   ]

--- a/specs/README.md
+++ b/specs/README.md
@@ -24,7 +24,7 @@ it can no longer drift. Do not hand-edit the table; edit each spec's
 | SPEC-013 | `macprovider-cli autotune` subcommand | 0.3.1 | normative | pending | pending corpus migration | [SPEC-013-cli-autotune.md](SPEC-013-cli-autotune.md) |
 | SPEC-014 | Provider Portal (seller-facing web surface) | 0.9 | draft | pending | pending corpus migration | [SPEC-014-provider-portal.md](SPEC-014-provider-portal.md) |
 | SPEC-015 | Verifiable inference receipts | 0.4.2 | normative | pending | pending corpus migration | [SPEC-015-receipts.md](SPEC-015-receipts.md) |
-| SPEC-016 | Provider payout pipeline (USDC on Base) | 0.1.23 | draft | pending | pending corpus migration | [SPEC-016-payout-pipeline.md](SPEC-016-payout-pipeline.md) |
+| SPEC-016 | Provider payout pipeline (USDC on Base) | 0.1.24 | draft | pending | pending: 11 | [SPEC-016-payout-pipeline.md](SPEC-016-payout-pipeline.md) |
 | SPEC-017 | Network Stats API | 0.1.9 | normative | pending | pending: 1 | [SPEC-017-network-stats-api.md](SPEC-017-network-stats-api.md) |
 | SPEC-018 | Agentic tool calling (provider-side response synthesis) | 0.2.7 | normative | pending | pending: 2 | [SPEC-018-agentic-tool-calling.md](SPEC-018-agentic-tool-calling.md) |
 | SPEC-019 | Structured output (`response_format: json_schema`) | 0.2.5 | normative | pending | pending corpus migration | [SPEC-019-structured-output.md](SPEC-019-structured-output.md) |

--- a/specs/SPEC-016-payout-pipeline.md
+++ b/specs/SPEC-016-payout-pipeline.md
@@ -1,6 +1,9 @@
 # SPEC-016 — Provider payout pipeline (USDC on Base)
 
-**Version:** 0.1.23 (2026-07-30, draft — lineage reconciliation per issue #586. Merges the two divergent `v0.1.2x` lineages: the `main` v0.1.20 Wave-2 provider-token custody gate (2026-07-04 — payout attempts require provider-token trust: pinned/operator-issued, bearer-validated, or explicit `self_minted_verified` proof; tokenless self-minted sessions are not payout eligible) AND the `impl/spec-016` v0.1.22 IMPL follow-up (2026-06-29 — §7.1 gains `payout_stale_outbox_backlog`, `payout_rpc_chronic_outage`, `payout_spki_drain_skipped_unsupported_client`; §4.7 step 5 keyset-paginated bounded-memory scan with `staleOutboxScanCeiling=20000`; §4.4 two-RPC discipline via `TrackingRPCClient` + `ChronicOutageTracker`). Both lineages' normative content is retained in full; see the v0.1.23 change-log entry for the drop-nothing cross-check.)
+**Version:** 0.1.24 (2026-07-31, draft — preliminary conformance-unit anchors
+for the default-off payout implementation merged by PR #164. No payout
+behavior, runner activation, production deployment, or §9 prerequisite state
+changes.)
 **Status:** Draft (IMPL merged via PR #164, default-off — `payout.enabled=false`
 everywhere until the operator funds the hot wallet and discharges the eight
 §9 prerequisites; flipping the flag is an operator decision gated on §9).
@@ -15,6 +18,40 @@ filed as a separate follow-up).
 
 ---
 
+## Preliminary conformance unit IDs
+
+SPEC-016 v0.1.24 registers `SPEC-016-R001`..`SPEC-016-R011` in
+`specs/CONFORMANCE.json` as pending preliminary conformance anchors. These IDs
+group existing normative obligation areas without changing them:
+
+- `SPEC-016-R001` — default-off rail scope, operator prerequisites, and
+  activation boundary.
+- `SPEC-016-R002` — provider payout-address registration, EIP-712
+  proof-of-possession, replay protection, cooling-off, and rotation semantics.
+- `SPEC-016-R003` — payout package boundary, read surfaces, handler inventory,
+  and import-graph ownership.
+- `SPEC-016-R004` — runner selection, signing, broadcast, two-RPC confirmation,
+  and `ClaimPayoutReady` finalization.
+- `SPEC-016-R005` — payout attempt schema, idempotent retry, nonce-gap fill,
+  and abandon-attempt recovery.
+- `SPEC-016-R006` — reorg polling, orphan recording, compensation, and
+  funding-recording admin flows.
+- `SPEC-016-R007` — runtime flags, pause/resume, runner lease, self-fencing,
+  and crash-safe audit outboxes.
+- `SPEC-016-R008` — payout caps, hot-wallet balances, gas accounting, and
+  conservation reconciliation.
+- `SPEC-016-R009` — signer custody, Linux-only process hardening, RPC
+  discipline, and reload boundaries.
+- `SPEC-016-R010` — structured audit events, retention, operator queries, and
+  alert/runbook obligations.
+- `SPEC-016-R011` — provider-token custody and compliance payout eligibility.
+
+All eleven remain `pending`. They are not exhaustive clause-level migration:
+`requirement_id_migration` remains `pending` until a later reconciliation pass
+attaches stable IDs directly to every normative `MUST`, `MUST NOT`, and
+security/recovery `SHOULD`, and until implementation mappings, tests, and the
+signed journey-result contract required by `payout-lifecycle` are reconciled.
+
 ## Change log
 
 Audit-narrative-by-round detail lives in the per-round audit files
@@ -24,6 +61,16 @@ git-history-only). The change-log entries below are one-liners per
 version pointing at the corresponding audit file. Per
 [[feedback-spec-audit-file-convention]], audit narrative does NOT
 live in this SPEC body.
+
+**v0.1.24 (2026-07-31, draft — #614 preliminary conformance anchors):**
+Editorial, non-normative reconciliation after the PR #164 payout implementation
+and PR #827 spec-index repair landed. Registers `SPEC-016-R001`..`SPEC-016-R011`
+as pending preliminary anchors in `specs/CONFORMANCE.json`, updates the manifest
+to record partial/default-off implementation evidence, keeps requirement
+migration pending, and preserves the production-not-deployed gap. This does NOT
+enable `payout.enabled`, declare the runner production-ready, satisfy any §9
+operator prerequisite, or promote any `payout-lifecycle` requirement to
+`conformant`.
 
 **v0.1.23 (2026-07-30, draft — lineage reconciliation, issue #586):**
 Merges the forked `main` and `impl/spec-016` spec lineages when PR #164


### PR DESCRIPTION
## Summary

Addresses the payout-related #614 reconciliation branch now that PR #164 merged the USDC-on-Base payout implementation and PR #827 repaired SPEC-016 spec-index drift.

This PR is governance-only:

- bumps SPEC-016 to v0.1.24 for preliminary conformance anchors;
- records SPEC-016 implementation status as `partial` and production status as `not-deployed`;
- registers `SPEC-016-R001` through `SPEC-016-R011` as pending preliminary anchors;
- keeps `requirement_id_migration: pending` until exact clause-level migration is done;
- preserves the `payout-lifecycle` signed-journey gate and makes no `conformant` or production activation claim.

No payout runner activation, hot-wallet operation, authority promotion, or live provider payout behavior changes are included.

## Validation

- `python3 scripts/check_spec_governance.py --base-ref origin/main`
- `python3 scripts/gen_spec_index.py --check`
- `python3 scripts/gen_spec_index.py --lint`
- `python3 -m unittest scripts.tests.test_spec_governance scripts.tests.test_spec_pr_declaration`
- `git diff --check`
- 3-lane audit: code 0 C/H/M, security 0 C/H/M after one Medium fix, architecture 0 C/H/M

## Audit Notes

Security initially flagged marking requirement migration complete as too strong for broad payout groups. The fix keeps migration pending and labels the new IDs as preliminary anchors only.

SPEC-GOVERNANCE-DECLARATION-BEGIN
{
  "schema_version": "spec-pr-governance-v1",
  "behavior_change": "none",
  "contract_change": "yes",
  "specs": ["SPEC-016"],
  "requirements": ["SPEC-016-R001", "SPEC-016-R002", "SPEC-016-R003", "SPEC-016-R004", "SPEC-016-R005", "SPEC-016-R006", "SPEC-016-R007", "SPEC-016-R008", "SPEC-016-R009", "SPEC-016-R010", "SPEC-016-R011"],
  "authority_domains": ["payout-lifecycle"],
  "arbitration": ["UNKNOWN"],
  "tests": ["scripts/check_spec_governance.py", "scripts/gen_spec_index.py", "scripts.tests.test_spec_governance", "scripts.tests.test_spec_pr_declaration"],
  "journeys": ["not-required"],
  "issue": "https://github.com/Augustas11/macprovider/issues/614"
}
SPEC-GOVERNANCE-DECLARATION-END
