### PR TITLE
Make Pearl deploy load canary token from stable custody

### DIFF
--- a/ops/runbooks/catalog-release-provider-upgrade.md
+++ b/ops/runbooks/catalog-release-provider-upgrade.md
@@ -596,11 +596,23 @@ The direct-deploy recovery procedure is:
 10. Confirm coordinator and gateway health report the installed signed pair and
    coordinator catalog status reports the intended release/signer.
 11. Set `CATALOG_CANARY_PROVIDER_ID` to a real enrolled canary provider and
-   provide `CATALOG_CANARY_AUTH_TOKEN` from the coordinator operator key, not
-   the gateway/coordinator service token. The deployment compatibility view is
-   `/v1/pool/check?details=deployment`, which is operator-only; the deploy
-   script proves this token against the Pearl coordinator operator-key digest
-   before any upload or restart.
+   provide the coordinator operator key, not the gateway/coordinator service
+   token. Prefer a stable local secret source on the operator Mac rather than a
+   raw shell variable: either `CATALOG_CANARY_AUTH_TOKEN_FILE` pointing at a
+   `0600` one-line bearer-token file, or a macOS Keychain generic-password item
+   selected by `CATALOG_CANARY_AUTH_TOKEN_KEYCHAIN_SERVICE`
+   (default `macprovider.catalog-canary.operator-token`) and
+   `CATALOG_CANARY_AUTH_TOKEN_KEYCHAIN_ACCOUNT` (default current `USER`).
+   `CATALOG_CANARY_AUTH_TOKEN` remains accepted only as an explicit override.
+   For file-based operation, keep the token file outside the repo and verify
+   `/usr/bin/stat -f %Lp "$CATALOG_CANARY_AUTH_TOKEN_FILE"` reports `600`.
+   For Keychain operation, provision the item once from the trusted
+   operator-held token by running `/usr/bin/security add-generic-password -U -s macprovider.catalog-canary.operator-token -a "$USER" -w`,
+   then entering the token at the prompt; do not pass the token in argv.
+   Do not copy the operator key out of Pearl during deploy. The deployment
+   compatibility view is `/v1/pool/check?details=deployment`, which is
+   operator-only; the deploy script proves this token against the Pearl
+   coordinator operator-key digest before any upload or restart.
    The deploy must poll `/v1/pool/check` until that exact provider reports
    `buyer_serving: true`, `catalog_admission_mode: current`, the exact active
    release/policy/digest/signer envelope, a valid selected row identity, and

--- a/phase4-coordinator/dist/deploy-pearl-vps.sh
+++ b/phase4-coordinator/dist/deploy-pearl-vps.sh
@@ -32,6 +32,15 @@
 #   CATALOG_CANARY_AUTH_TOKEN required for production deploys. Use the
 #                    coordinator operator key; service tokens are not
 #                    accepted by operator-only deployment evidence.
+#   CATALOG_CANARY_AUTH_TOKEN_FILE optional local root/operator-only file
+#                    containing the coordinator operator key. Used only when
+#                    CATALOG_CANARY_AUTH_TOKEN is unset.
+#   CATALOG_CANARY_AUTH_TOKEN_KEYCHAIN_SERVICE optional macOS Keychain generic
+#                    password service to read when both direct env and file
+#                    token sources are unset. Default:
+#                    macprovider.catalog-canary.operator-token.
+#   CATALOG_CANARY_AUTH_TOKEN_KEYCHAIN_ACCOUNT optional Keychain account.
+#                    Default: current USER.
 #   CATALOG_CANARY_SSH_TARGET required for production deploys. SSH target for
 #                    the operator-controlled canary Mac (for example user@host).
 #   CATALOG_CANARY_SSH_KEY default: ~/.ssh/macprovider_canary_ed25519
@@ -137,6 +146,9 @@ STATS_DOMAIN="${STATS_DOMAIN:-stats.streamvc.live}"
 EMAIL="${EMAIL:-augstar@gmail.com}"
 CATALOG_CANARY_PROVIDER_ID="${CATALOG_CANARY_PROVIDER_ID:-}"
 CATALOG_CANARY_AUTH_TOKEN="${CATALOG_CANARY_AUTH_TOKEN:-}"
+CATALOG_CANARY_AUTH_TOKEN_FILE="${CATALOG_CANARY_AUTH_TOKEN_FILE:-}"
+CATALOG_CANARY_AUTH_TOKEN_KEYCHAIN_SERVICE="${CATALOG_CANARY_AUTH_TOKEN_KEYCHAIN_SERVICE:-macprovider.catalog-canary.operator-token}"
+CATALOG_CANARY_AUTH_TOKEN_KEYCHAIN_ACCOUNT="${CATALOG_CANARY_AUTH_TOKEN_KEYCHAIN_ACCOUNT:-${USER:-}}"
 CATALOG_CANARY_SSH_TARGET="${CATALOG_CANARY_SSH_TARGET:-}"
 CATALOG_CANARY_SSH_KEY="${CATALOG_CANARY_SSH_KEY:-$HOME/.ssh/macprovider_canary_ed25519}"
 CATALOG_CANARY_INSTALL_DIR="${CATALOG_CANARY_INSTALL_DIR:-macprovider/catalog-release}"
@@ -191,6 +203,70 @@ _validate_catalog_canary_auth_token() {
 
 _catalog_canary_auth_token_sha256() {
   printf '%s' "$1" | shasum -a 256 | awk '{print tolower($1)}'
+}
+
+_catalog_canary_auth_token_from_file() {
+  local path="$1"
+  python3 - "$path" <<'PY'
+import os
+import stat
+import sys
+
+path = sys.argv[1]
+nofollow = getattr(os, "O_NOFOLLOW", 0)
+try:
+    fd = os.open(path, os.O_RDONLY | nofollow)
+except FileNotFoundError:
+    raise SystemExit(f"token file is missing: {path}")
+except OSError as exc:
+    raise SystemExit(f"token file is not safely readable: {path}: {exc}")
+try:
+    info = os.fstat(fd)
+    if not stat.S_ISREG(info.st_mode):
+        raise SystemExit(f"token file is not a regular file: {path}")
+    if stat.S_IMODE(info.st_mode) & (stat.S_IRWXG | stat.S_IRWXO):
+        raise SystemExit(f"token file must not be group/other accessible: {path}")
+    raw = os.read(fd, 514)
+finally:
+    os.close(fd)
+if len(raw) > 513:
+    raise SystemExit("token file is too large")
+try:
+    value = raw.decode("utf-8")
+except UnicodeDecodeError:
+    raise SystemExit("token file must be UTF-8 text")
+if value.endswith("\n"):
+    value = value[:-1]
+if value.endswith("\r"):
+    value = value[:-1]
+if "\n" in value or "\r" in value:
+    raise SystemExit("token file must contain exactly one bearer token line")
+print(value, end="")
+PY
+}
+
+_load_catalog_canary_auth_token() {
+  [ -z "$CATALOG_CANARY_AUTH_TOKEN" ] || return 0
+  if [ -n "$CATALOG_CANARY_AUTH_TOKEN_FILE" ]; then
+    CATALOG_CANARY_AUTH_TOKEN="$(_catalog_canary_auth_token_from_file "$CATALOG_CANARY_AUTH_TOKEN_FILE")" || {
+      echo "aborting deploy: could not read CATALOG_CANARY_AUTH_TOKEN_FILE" >&2
+      exit 1
+    }
+    echo "  loaded catalog canary bearer from CATALOG_CANARY_AUTH_TOKEN_FILE" >&2
+    return 0
+  fi
+  if [ -n "$CATALOG_CANARY_AUTH_TOKEN_KEYCHAIN_SERVICE" ] &&
+     [ -n "$CATALOG_CANARY_AUTH_TOKEN_KEYCHAIN_ACCOUNT" ] &&
+     [ -x /usr/bin/security ]; then
+    CATALOG_CANARY_AUTH_TOKEN="$(
+      /usr/bin/security find-generic-password -w \
+        -s "$CATALOG_CANARY_AUTH_TOKEN_KEYCHAIN_SERVICE" \
+        -a "$CATALOG_CANARY_AUTH_TOKEN_KEYCHAIN_ACCOUNT" 2>/dev/null || true
+    )"
+    if [ -n "$CATALOG_CANARY_AUTH_TOKEN" ]; then
+      echo "  loaded catalog canary bearer from macOS Keychain service=$CATALOG_CANARY_AUTH_TOKEN_KEYCHAIN_SERVICE account=$CATALOG_CANARY_AUTH_TOKEN_KEYCHAIN_ACCOUNT" >&2
+    fi
+  fi
 }
 
 _catalog_canary_auth_token_matches_operator_key() {
@@ -389,6 +465,7 @@ if ! printf '%s' "$EMAIL" | grep -Eq '^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z
   exit 1
 fi
 if [ "$DRY_RUN_LOCAL" != "1" ]; then
+  _load_catalog_canary_auth_token
   if ! printf '%s' "$CATALOG_CANARY_PROVIDER_ID" | grep -Eq '^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$'; then
     echo "aborting deploy: CATALOG_CANARY_PROVIDER_ID is required and must be a safe provider ID" >&2
     echo "  Select a provider expected to reconnect after restart; deployment commits only after pool admission." >&2
@@ -396,6 +473,8 @@ if [ "$DRY_RUN_LOCAL" != "1" ]; then
   fi
   if ! _validate_catalog_canary_auth_token "$CATALOG_CANARY_AUTH_TOKEN"; then
     echo "aborting deploy: CATALOG_CANARY_AUTH_TOKEN is required and must be a safe 32-512 character bearer token" >&2
+    echo "  Provide it via CATALOG_CANARY_AUTH_TOKEN, CATALOG_CANARY_AUTH_TOKEN_FILE, or macOS Keychain service=$CATALOG_CANARY_AUTH_TOKEN_KEYCHAIN_SERVICE account=$CATALOG_CANARY_AUTH_TOKEN_KEYCHAIN_ACCOUNT." >&2
+    echo "  The deploy will later prove this secret matches Pearl's coordinator operator key by SHA-256; it never copies key material from Pearl." >&2
     exit 1
   fi
   if ! printf '%s' "$CATALOG_CANARY_SSH_TARGET" | grep -Eq '^([A-Za-z_][A-Za-z0-9._-]*@)?[A-Za-z0-9]([A-Za-z0-9.-]{0,252}[A-Za-z0-9])?$'; then

--- a/phase4-coordinator/dist/test/check_deploy_static_feed_access.test.sh
+++ b/phase4-coordinator/dist/test/check_deploy_static_feed_access.test.sh
@@ -261,11 +261,21 @@ grep -q 'CATALOG_CANARY_AUTH_TOKEN is required' "$DEPLOY_SH" ||
   fail "deploy must require authenticated canary evidence"
 
 token_validator_tmp="$(mktemp)"
+token_loader_tmp="$(mktemp)"
 canary_operator_guard_tmp="$(mktemp)"
-trap 'rm -f "$token_validator_tmp" "$canary_operator_guard_tmp"' EXIT
+security_mock_dir="$(mktemp -d)"
+trap 'rm -f "$token_validator_tmp" "$token_loader_tmp" "$canary_operator_guard_tmp"; rm -rf "$security_mock_dir"' EXIT
 awk '/^_validate_catalog_canary_auth_token\(\) \{/{f=1} f{print} f&&/^\}$/{exit}' "$DEPLOY_SH" > "$token_validator_tmp"
 grep -qF '_validate_catalog_canary_auth_token()' "$token_validator_tmp" ||
   fail "deploy must keep an extractable portable canary token validator"
+awk '
+  /^_catalog_canary_auth_token_from_file\(\) \{/ { f=1 }
+  f { print }
+  /^_load_catalog_canary_auth_token\(\) \{/ { loader=1 }
+  f && loader && /^\}$/ { exit }
+' "$DEPLOY_SH" > "$token_loader_tmp"
+grep -qF '_load_catalog_canary_auth_token()' "$token_loader_tmp" ||
+  fail "deploy must keep an extractable catalog canary token loader"
 awk '
   /^_catalog_canary_auth_token_sha256\(\) \{/ { f=1 }
   f { print }
@@ -278,6 +288,11 @@ grep -qF 'CATALOG_CANARY_AUTH_TOKEN must be the coordinator operator key' "$DEPL
   fail "deploy must name the operator-key-only canary token requirement"
 grep -qF '/v1/pool/check?details=deployment is operator-only' "$DEPLOY_SH" ||
   fail "deploy must document that service tokens cannot satisfy deployment evidence"
+grep -qF 'CATALOG_CANARY_AUTH_TOKEN_FILE' "$DEPLOY_SH" &&
+  grep -qF 'macOS Keychain service=' "$DEPLOY_SH" &&
+  grep -qF '/usr/bin/security find-generic-password -w' "$DEPLOY_SH" &&
+  ! grep -qF 'command -v security' "$DEPLOY_SH" ||
+  fail "deploy must support stable file/keychain catalog-canary token sources"
 # BSD grep rejects interval upper bounds greater than 255. Length checks belong
 # in Bash so the production deploy remains portable on the operator Mac.
 if grep -qF '{32,512}' "$DEPLOY_SH"; then
@@ -304,6 +319,57 @@ _validate_catalog_canary_auth_token "$token_512" ||
 ! _validate_catalog_canary_auth_token "${token_32}"$'\r''header = "X-Injected: yes"' ||
   fail "canary token validator must reject carriage-return curl-config injection"
 
+# shellcheck disable=SC1090
+. "$token_loader_tmp"
+token_file_dir="$(mktemp -d)"
+trap 'rm -f "$token_validator_tmp" "$token_loader_tmp" "$canary_operator_guard_tmp"; rm -rf "$token_file_dir" "$security_mock_dir"' EXIT
+token_file="$token_file_dir/catalog-canary-token"
+printf '%s\n' "$token_32" > "$token_file"
+chmod 600 "$token_file"
+CATALOG_CANARY_AUTH_TOKEN=""
+CATALOG_CANARY_AUTH_TOKEN_FILE="$token_file"
+_load_catalog_canary_auth_token >/dev/null 2>&1
+[ "$CATALOG_CANARY_AUTH_TOKEN" = "$token_32" ] ||
+  fail "canary token loader must read a strict 0600 token file"
+chmod 644 "$token_file"
+if _catalog_canary_auth_token_from_file "$token_file" >/dev/null 2>&1; then
+  fail "canary token file loader must reject group/other-accessible files"
+fi
+chmod 600 "$token_file"
+printf '%s\n%s\n' "$token_32" "$token_32" > "$token_file"
+if _catalog_canary_auth_token_from_file "$token_file" >/dev/null 2>&1; then
+  fail "canary token file loader must reject multi-line token files"
+fi
+cat > "$security_mock_dir/security" <<'SH'
+#!/usr/bin/env sh
+: > "$SECURITY_MOCK_MARKER"
+printf '%s' "$SECURITY_MOCK_TOKEN"
+SH
+chmod 700 "$security_mock_dir/security"
+security_mock_marker="$security_mock_dir/security.executed"
+old_path="$PATH"
+PATH="$security_mock_dir:$PATH"
+SECURITY_MOCK_MARKER="$security_mock_marker"
+SECURITY_MOCK_TOKEN="$token_32"
+export SECURITY_MOCK_MARKER SECURITY_MOCK_TOKEN
+CATALOG_CANARY_AUTH_TOKEN=""
+# shellcheck disable=SC2034
+CATALOG_CANARY_AUTH_TOKEN_FILE=""
+# shellcheck disable=SC2034
+CATALOG_CANARY_AUTH_TOKEN_KEYCHAIN_SERVICE="macprovider.test.no-path-security.$$"
+# shellcheck disable=SC2034
+CATALOG_CANARY_AUTH_TOKEN_KEYCHAIN_ACCOUNT="operator"
+_load_catalog_canary_auth_token >/dev/null 2>&1 || {
+  PATH="$old_path"
+  fail "canary token loader must ignore PATH-selected security binaries"
+}
+PATH="$old_path"
+unset SECURITY_MOCK_MARKER SECURITY_MOCK_TOKEN
+[ ! -e "$security_mock_marker" ] ||
+  fail "canary token loader must not execute a PATH-selected security binary"
+[ -z "$CATALOG_CANARY_AUTH_TOKEN" ] ||
+  fail "canary token loader must not accept a PATH-selected security binary"
+
 HEX64=0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
 HEX64B=fedcba9876543210fedcba9876543210fedcba9876543210fedcba9876543210
 HEX64_SHA256="$(printf '%s' "$HEX64" | shasum -a 256 | awk '{print $1}')"
@@ -324,7 +390,7 @@ _catalog_canary_auth_token_matches_operator_key "$HEX64" "$(printf '%s' "$HEX64_
   fail "canary token guard must preserve token syntax validation"
 
 deadline_alarm_tmp="$(mktemp)"
-trap 'rm -f "$token_validator_tmp" "$canary_operator_guard_tmp" "$deadline_alarm_tmp"' EXIT
+trap 'rm -f "$token_validator_tmp" "$token_loader_tmp" "$canary_operator_guard_tmp" "$deadline_alarm_tmp"; rm -rf "$token_file_dir" "$security_mock_dir"' EXIT
 awk '/^_run_with_deadline_alarm\(\) \{/{f=1} f{print} f&&/^\}$/{exit}' "$DEPLOY_SH" > "$deadline_alarm_tmp"
 grep -qF '_run_with_deadline_alarm()' "$deadline_alarm_tmp" ||
   fail "deploy must keep an extractable subprocess deadline helper"
@@ -340,7 +406,7 @@ _run_with_deadline_alarm 2 sh -c 'exit 0' ||
   fail "subprocess deadline helper must preserve successful commands"
 
 deadline_parser_tmp="$(mktemp)"
-trap 'rm -f "$token_validator_tmp" "$canary_operator_guard_tmp" "$deadline_alarm_tmp" "$deadline_parser_tmp"' EXIT
+trap 'rm -f "$token_validator_tmp" "$token_loader_tmp" "$canary_operator_guard_tmp" "$deadline_alarm_tmp" "$deadline_parser_tmp"; rm -rf "$token_file_dir" "$security_mock_dir"' EXIT
 awk '/^_parse_model_hash_legacy_until\(\) \{/{f=1} f{print} f&&/^\}$/{exit}' "$DEPLOY_SH" > "$deadline_parser_tmp"
 grep -qF '_parse_model_hash_legacy_until()' "$deadline_parser_tmp" ||
   fail "deploy must keep an extractable MODEL_HASH_LEGACY_UNTIL parser"
@@ -438,6 +504,12 @@ grep -q 'KEEP_DOWNLOADS=1 scripts/verify-tier2-provider-release.sh' "$CATALOG_RU
   grep -q 'prior provider live' "$CATALOG_RUNBOOK" &&
   grep -q 'MACPROVIDER_EMERGENCY_ROLLBACK=1' "$CATALOG_RUNBOOK" ||
   fail "catalog runbook must prefetch without mutation and document bounded emergency rollback"
+
+grep -qF '/usr/bin/security add-generic-password' "$CATALOG_RUNBOOK" &&
+  grep -qF 'do not pass the token in argv' "$CATALOG_RUNBOOK" &&
+  grep -qF '/usr/bin/stat -f %Lp "$CATALOG_CANARY_AUTH_TOKEN_FILE"' "$CATALOG_RUNBOOK" &&
+  ! grep -qF -- '-w "$CATALOG_CANARY_AUTH_TOKEN"' "$CATALOG_RUNBOOK" ||
+  fail "catalog runbook must provision stable canary secrets without PATH lookup or argv token exposure"
 
 grep -q 'PEARL_UPDATER_PROVIDER_ADMISSION_POLICY=bridge_required' "$PEARL_RUNBOOK" &&
   grep -q 'PEARL_UPDATER_MINIMUM_POOL_READY_AFTER_ROLLOUT=' "$PEARL_RUNBOOK" &&


### PR DESCRIPTION
## Summary

This PR makes the direct Pearl deploy path usable from stable operator-held token custody for #825 Gap B.

- Adds `CATALOG_CANARY_AUTH_TOKEN_FILE` as a strict local one-line token source: regular file, no group/other access, size-bounded, UTF-8, no CR/LF injection.
- Adds macOS Keychain fallback through `/usr/bin/security find-generic-password` only, avoiding PATH-selected helpers at the point the operator token is materialized.
- Keeps `CATALOG_CANARY_AUTH_TOKEN` as an explicit override and preserves the existing Pearl SHA-256 proof that the token matches the coordinator operator key before upload/restart.
- Updates the Pearl deploy runbook to prefer stable local token custody, avoid copying the operator key from Pearl, use `/usr/bin/stat`, and provision Keychain prompt-mode without putting the token in argv.

This is intentionally a bounded Gap B slice. It does not claim full #825 closure because canary SSH target/key provisioning remains an operational follow-up.

## Validation

- `bash -n phase4-coordinator/dist/deploy-pearl-vps.sh`
- `bash phase4-coordinator/dist/test/check_deploy_static_feed_access.test.sh`
- `bash scripts/test-live-coordinator-release-gate.sh`
- `bash phase4-coordinator/dist/test/check_deploy_config_test.sh`
- `git diff --check`
- `shellcheck --severity=warning phase4-coordinator/dist/test/check_deploy_static_feed_access.test.sh`
- 3-lane Codex audit after fixes: code/security/architect final2 all `0 C/H/M`

## Not Tested

- Live Pearl deployment
- Real macOS Keychain item lookup
- Physical canary Mac SSH proof

SPEC-GOVERNANCE-DECLARATION-BEGIN
{
  "schema_version": "spec-pr-governance-v1",
  "behavior_change": "yes",
  "contract_change": "none",
  "issue": "https://github.com/Augustas11/macprovider/issues/825",
  "specs": ["SPEC-023"],
  "requirements": ["SPEC-023-R001", "SPEC-023-R002"],
  "authority_domains": ["installer-autotune-policy", "model-catalog-identity"],
  "arbitration": ["UNKNOWN"],
  "tests": [
    "bash -n phase4-coordinator/dist/deploy-pearl-vps.sh",
    "bash phase4-coordinator/dist/test/check_deploy_static_feed_access.test.sh",
    "bash scripts/test-live-coordinator-release-gate.sh",
    "bash phase4-coordinator/dist/test/check_deploy_config_test.sh",
    "git diff --check",
    "shellcheck --severity=warning phase4-coordinator/dist/test/check_deploy_static_feed_access.test.sh"
  ],
  "journeys": ["not-required"]
}
SPEC-GOVERNANCE-DECLARATION-END
