### PR TITLE
Harden coordinator release tag deploy provenance

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -95,6 +95,7 @@ test-dist:
 	bash phase4-coordinator/dist/test/check_stats_inventory_deploy_test.sh
 	bash phase4-coordinator/dist/test/check_stats_billing_mirror_deploy_test.sh
 	bash phase4-coordinator/dist/test/coord_deploy_config_mode_test.sh
+	bash phase4-coordinator/dist/test/coordinator_release_tag_guard.test.sh
 	bash phase4-coordinator/dist/test/check_deploy_static_feed_access.test.sh
 	bash phase4-coordinator/dist/test/coordinator_deploy_recovery.test.sh
 	bash phase4-coordinator/dist/test/coord_deploy_smoke_probe.test.sh

--- a/ops/runbooks/malibu-pearl-deploy.md
+++ b/ops/runbooks/malibu-pearl-deploy.md
@@ -13,7 +13,7 @@
 | Changes | Does NOT change |
 |---------|-----------------|
 | Applies Postgres migrations `012_malibu_emission_ledger` + `014_malibu_trust_unlock` | `malibu_emission.enabled` (stays `false`) |
-| Installs coordinator binary with `writer_dsn` wired | Withdrawable MALIBU flow |
+| Validates/restarts signed coordinator runtime with `writer_dsn` wired | Withdrawable MALIBU flow |
 | Merges MALIBU overlay into Pearl `coordinator.pearl-overlays.yaml` | Base `/opt/macprovider/coordinator.yaml` |
 | Mounts `GET /v1/provider/malibu-accrual` read API | Base nginx vhost (add `location = /v1/provider/malibu-accrual` per §4.4) |
 
@@ -52,6 +52,7 @@ After first deploy with `MALIBU_EMISSION_WRITER_PASSWORD` set, rotate the passwo
 ## 2. Quick deploy (scripted)
 
 ```bash
+git checkout vX.Y.Z
 cd phase4-coordinator
 bash scripts/build-linux.sh
 bash dist/deploy-malibu-emission-pearl.sh
@@ -79,9 +80,12 @@ SKIP_MIGRATE=1 bash dist/deploy-malibu-emission-pearl.sh
 
 ## 3. Manual steps (if not using script)
 
-### 3.1 Build + upload binary
+### 3.1 Production binary authority
 
-Same as [`opoi-pearl-deploy.md`](./opoi-pearl-deploy.md) §3.1–3.2.
+Do not build, upload, or install coordinator binaries manually for production
+MALIBU work. Production runtime bytes must come from the signed Pearl runtime
+release/updater and then pass the guarded `deploy-pearl-vps.sh` provenance
+checks. Manual steps below are overlay/migration reference only.
 
 ### 3.2 Apply migrations
 
@@ -190,13 +194,11 @@ ssh pearl 'sudo rm /etc/systemd/system/macprovider-coordinator.service.d/malibu-
 
 Set `malibu_emission.enabled: false` in pearl overlay and restart.
 
-### 6.3 Binary rollback
+### 6.3 Runtime rollback
 
-```bash
-ssh pearl 'sudo install -o root -g macprovider -m 0750 \
-  /opt/macprovider/coordinator.prev /opt/macprovider/coordinator \
-  && sudo systemctl restart macprovider-coordinator'
-```
+Do not restore `/opt/macprovider/coordinator` by copying local or `.prev`
+bytes. Use the signed Pearl runtime updater/rollback path for binary rollback,
+then rerun the guarded deploy validation if a MALIBU overlay remains enabled.
 
 ---
 

--- a/ops/runbooks/opoi-pearl-deploy.md
+++ b/ops/runbooks/opoi-pearl-deploy.md
@@ -12,11 +12,13 @@
 
 | Changes | Does NOT change |
 |---------|-----------------|
-| `/opt/macprovider/coordinator` binary (linux/amd64) | `/opt/macprovider/coordinator.yaml` base file |
+| OPoI overlay and systemd drop-in | `/opt/macprovider/coordinator.yaml` base file |
 | `/etc/macprovider/coordinator.opoi-v0-staging.yaml` overlay | nginx / TLS / gateway |
-| systemd drop-in with `--config-overlay` | Full `deploy-pearl-vps.sh` path |
+| systemd drop-in with `--config-overlay` | Coordinator/runtime binaries |
 
 Canaries enable via overlay only — rollback removes drop-in without editing production YAML.
+Production binary bytes must come from the signed Pearl runtime updater and the
+guarded `deploy-pearl-vps.sh` path, not this retired overlay runbook.
 
 ---
 
@@ -33,9 +35,10 @@ Canaries enable via overlay only — rollback removes drop-in without editing pr
 
 ## 2. Quick deploy (scripted)
 
-From a clean checkout of `origin/main`:
+From a clean checkout of the exact coordinator release tag:
 
 ```bash
+git checkout vX.Y.Z
 cd phase4-coordinator
 bash scripts/build-linux.sh
 bash dist/deploy-opoi-v0-pearl.sh
@@ -57,46 +60,38 @@ FORCE_RESTART=1 bash dist/deploy-opoi-v0-pearl.sh
 
 ## 3. Manual deploy (step-by-step)
 
-### 3.1 Build binary (operator Mac)
+### 3.1 Production binary authority
+
+Do not upload or install `dist/coordinator-linux-amd64` manually for production
+OPoI work. Production coordinator, coordinator-cli, gateway, and sidecar bytes
+must already be installed from the signed Pearl runtime release/updater; direct
+deploys only restart/validate those bytes after release provenance gates pass.
+
+Dev-only cross-compile (not production deployable):
 
 ```bash
 cd phase4-coordinator
-bash scripts/build-linux.sh
-# → dist/coordinator-linux-amd64 @ <git describe>
-```
-
-Cross-compile only (no sidecars required for OPoI):
-
-```bash
-cd phase4-coordinator
+ALLOW_NON_RELEASE_COORDINATOR_BUILD=1 \
 VERSION="$(git describe --always --dirty --tags)"
 GOOS=linux GOARCH=amd64 go build \
   -ldflags "-X main.version=${VERSION}" \
   -o dist/coordinator-linux-amd64 ./cmd/coordinator
 ```
 
-### 3.2 Upload artifacts
+### 3.2 Upload overlay artifacts only
 
 ```bash
 SSH_KEY=~/.ssh/pearl_operator_ed25519
 PEARL=root@159.223.165.194
 
-scp -i "$SSH_KEY" dist/coordinator-linux-amd64 "$PEARL:/tmp/coordinator-linux-amd64"
 scp -i "$SSH_KEY" coordinator.opoi-v0-staging.yaml "$PEARL:/etc/macprovider/"
 scp -i "$SSH_KEY" dist/systemd/opoi-v0.conf.example "$PEARL:/tmp/opoi-v0.conf"
 ```
 
-### 3.3 Install on Pearl
+### 3.3 Install overlay on Pearl
 
 ```bash
 ssh -i "$SSH_KEY" "$PEARL" 'set -e
-  # Binary snapshot for rollback
-  if [ -x /opt/macprovider/coordinator ]; then
-    install -o root -g macprovider -m 0750 \
-      /opt/macprovider/coordinator /opt/macprovider/coordinator.prev
-  fi
-  install -o root -g macprovider -m 0750 \
-    /tmp/coordinator-linux-amd64 /opt/macprovider/coordinator
   install -o root -g macprovider -m 0640 \
     /etc/macprovider/coordinator.opoi-v0-staging.yaml \
     /etc/macprovider/coordinator.opoi-v0-staging.yaml
@@ -152,7 +147,7 @@ Base unit (unchanged): `phase4-coordinator/dist/macprovider-coordinator.service`
 curl -sS https://coordinator.streamvc.live/healthz | jq '{version, pool_size}'
 ```
 
-Version should match local `git describe` from the build tree.
+Version should match the exact checked-out release tag (`vX.Y.Z`).
 
 ### 5.2 Canary logs (wait up to `canary_interval_s` = 300s)
 
@@ -193,20 +188,18 @@ Then `systemctl restart macprovider-coordinator` (no binary change needed).
 
 ## 6. Rollback
 
-### 6.1 Disable canaries (keep new binary)
+### 6.1 Disable canaries
 
 ```bash
 ssh pearl 'sudo rm /etc/systemd/system/macprovider-coordinator.service.d/opoi-v0.conf \
   && sudo systemctl daemon-reload && sudo systemctl restart macprovider-coordinator'
 ```
 
-### 6.2 Binary rollback
+### 6.2 Runtime rollback
 
-```bash
-ssh pearl 'sudo install -o root -g macprovider -m 0750 \
-  /opt/macprovider/coordinator.prev /opt/macprovider/coordinator \
-  && sudo systemctl restart macprovider-coordinator'
-```
+Do not restore `/opt/macprovider/coordinator` by copying local or `.prev`
+bytes. Use the signed Pearl runtime updater/rollback path for binary rollback,
+then rerun the guarded deploy validation if an overlay remains enabled.
 
 See `OPS.md` §2 and `audits/2026-06-10/ROLLBACK_PROCEDURE.md`.
 

--- a/phase4-coordinator/README.md
+++ b/phase4-coordinator/README.md
@@ -45,10 +45,15 @@ The full suite (`go test ./...`) is the only required gate; the named subsets ar
 Production builds run on Apple Silicon and ship to a linux/amd64 VPS. CGO-free `modernc.org/sqlite` makes this a one-liner:
 
 ```sh
-scripts/build-linux.sh           # version-stamped via git describe; refuses dirty trees
+scripts/build-linux.sh           # version-stamped from an exact vX.Y.Z release tag
 ```
 
-Output: `dist/coordinator-linux-amd64`. Override the dirty guard with `FORCE_DIRTY=1` (the version string then ends in `-dirty` or `-dirty-forced` so `/healthz` can self-identify the override at deploy time — see `dist/check-deploy-config.sh` and the M0-5 deploy-rollback story).
+Output: `dist/coordinator-linux-amd64`. Production builds refuse `main`,
+`vX.Y.Z-N-g<hash>`, dirty, and untagged checkouts so deploy provenance cannot
+self-confirm a regressing `git describe` string. For local/dev artifacts only,
+set `ALLOW_NON_RELEASE_COORDINATOR_BUILD=1`; combine it with `FORCE_DIRTY=1`
+only when you deliberately want a dirty dev stamp. The Pearl production deploy
+does not accept non-release coordinator versions.
 
 ## Deployment
 

--- a/phase4-coordinator/dist/deploy-pearl-vps.sh
+++ b/phase4-coordinator/dist/deploy-pearl-vps.sh
@@ -25,7 +25,12 @@
 #                                 stats cert outages must not break the
 #                                 primary deploy — issue #244 root cause).
 #   FORCE_RESTART    default: 0   bypass connected-provider guard at step 1c/6c
-#   STRICT_PROVENANCE default: 0  fail if /healthz lacks `version` field
+#   STRICT_PROVENANCE default: 0  legacy compatibility knob. Exact release
+#                    provenance is now always fatal on missing/mismatched
+#                    /healthz version.
+#                    Production deploys always require this checkout to be
+#                    exactly one clean numeric release tag (vX.Y.Z); there is
+#                    no non-release production deploy override.
 #   CATALOG_CANARY_PROVIDER_ID required for production deploys. The provider
 #                    must reconnect after restart and pass authenticated
 #                    compatibility admission through /v1/pool/check before commit.
@@ -315,6 +320,87 @@ print(values[0], end="")
 ' "$1"
 }
 
+_coordinator_release_tag_version() {
+  local module_dir="$1" repo_root candidates count dirty_state tag head rows tag_object peeled_count peeled_commit tag_type verify_output remote_url
+  local release_tag_remote="origin"
+  local release_tag_remote_url="https://github.com/Augustas11/macprovider.git"
+  local release_tag_signer_line='Good "git" signature for augstar@gmail.com with ED25519 key SHA256:6DgoKNaOgF5c7NPHTAbNxJ2LT0uuj8U/3zObOOZjRiA'
+  repo_root="$(git -C "$module_dir" rev-parse --show-toplevel)"
+  dirty_state="$(git -C "$repo_root" status --porcelain)"
+  if [ -n "$dirty_state" ]; then
+    echo "aborting deploy: coordinator production deploy requires a clean release-tag checkout" >&2
+    git -C "$repo_root" status --short >&2
+    return 1
+  fi
+  candidates="$(git -C "$repo_root" tag --points-at HEAD | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' || true)"
+  count="$(printf '%s\n' "$candidates" | sed '/^$/d' | wc -l | tr -d '[:space:]')"
+  case "$count" in
+    1)
+      tag="$candidates"
+      ;;
+    0)
+      echo "aborting deploy: HEAD is not exactly a numeric release tag (vX.Y.Z)" >&2
+      echo "  Deploy the signed coordinator/gateway release tag first; do not let git describe from main become production version authority." >&2
+      return 1
+      ;;
+    *)
+      echo "aborting deploy: HEAD has multiple numeric release tags:" >&2
+      printf '%s\n' "$candidates" | sed 's/^/  - /' >&2
+      return 1
+      ;;
+  esac
+  tag_type="$(git -C "$repo_root" cat-file -t "$tag" 2>/dev/null || true)"
+  if [ "$tag_type" != tag ]; then
+    echo "aborting deploy: $tag is not an annotated signed release tag" >&2
+    return 1
+  fi
+  if ! verify_output="$(git -C "$repo_root" verify-tag "$tag" 2>&1)"; then
+    echo "aborting deploy: $tag does not verify as a trusted signed tag" >&2
+    return 1
+  fi
+  if ! printf '%s\n' "$verify_output" | grep -qxF "$release_tag_signer_line"; then
+    echo "aborting deploy: $tag was signed by an unauthorized release signer" >&2
+    return 1
+  fi
+  remote_url="$(git -C "$repo_root" remote get-url "$release_tag_remote" 2>/dev/null || true)"
+  case "$remote_url" in
+    https://github.com/Augustas11/macprovider.git|git@github.com:Augustas11/macprovider.git|ssh://git@github.com/Augustas11/macprovider.git) ;;
+    *)
+      echo "aborting deploy: $release_tag_remote must point at the canonical Augustas11/macprovider GitHub repository" >&2
+      return 1
+      ;;
+  esac
+  head="$(git -C "$repo_root" rev-parse HEAD)"
+  rows="$(git -C "$repo_root" ls-remote "$release_tag_remote_url" "refs/tags/$tag" "refs/tags/$tag^{}")"
+  tag_object="$(printf '%s\n' "$rows" | awk -v ref="refs/tags/$tag" '$2 == ref { print $1 }')"
+  peeled_commit="$(printf '%s\n' "$rows" | awk -v ref="refs/tags/$tag^{}" '$2 == ref { print $1 }')"
+  peeled_count="$(printf '%s\n' "$peeled_commit" | awk 'NF { count++ } END { print count + 0 }')"
+  if [ -z "$tag_object" ] || [ "$peeled_count" != 1 ] || [ "$peeled_commit" != "$head" ]; then
+    echo "aborting deploy: $tag is not the protected remote annotated tag for HEAD on $release_tag_remote" >&2
+    return 1
+  fi
+  printf '%s %s\n' "$tag" "$head"
+}
+
+_coordinator_verify_deployed_version() {
+  local healthz_body="$1" expected_version="$2" deployed_version
+  deployed_version=$(printf '%s' "$healthz_body" | python3 -c "import sys,json; print(json.load(sys.stdin).get('version', '?'))" 2>/dev/null || echo "?")
+  if [ "$deployed_version" = "?" ]; then
+    echo "  CRITICAL provenance MISSING: /healthz returned no \"version\" field" >&2
+    echo "           This almost certainly means the deployed binary predates the" >&2
+    echo "           M0-5 instrumentation (PR #18) and the rollback gate is bypassed." >&2
+    echo "           Expected was: $expected_version" >&2
+    echo "           See audits/2026-06-10/ROLLBACK_PROCEDURE.md to replace the live binary." >&2
+    return 7
+  elif [ "$deployed_version" = "$expected_version" ]; then
+    echo "  provenance OK: deployed=$deployed_version | expected=$expected_version"
+  else
+    echo "  aborting deploy: provenance mismatch: deployed=$deployed_version | expected=$expected_version" >&2
+    echo "       (deployed binary does not match the exact local release tag — rollback before commit)" >&2
+    return 8
+  fi
+}
+
 _tier2_migration_gate_remote_script() {
   cat <<'SH'
 set -eu
@@ -458,6 +544,54 @@ PY
 SH
 }
 
+# R3 SEC MED — reuse the already-resolved physical dir from the
+# symlink walker rather than recomputing from `$0` (which is the
+# symlink path) + logical `pwd`. All later artifact reads,
+# check-deploy-config, config uploads, and vhost templates hang
+# off DIST_DIR, so any parent-symlink retargeting attack that
+# survives helper sourcing would still land here.
+DIST_DIR="$_PEARL_TLS_SCRIPT_DIR"
+MODULE_DIR="$(cd "$DIST_DIR/.." && pwd -P)"
+REPO_ROOT="$(git -C "$MODULE_DIR" rev-parse --show-toplevel)"
+
+COORDINATOR_RELEASE_VERSION=""
+COORDINATOR_RELEASE_COMMIT=""
+if [ "$DRY_RUN_LOCAL" != "1" ]; then
+  COORDINATOR_RELEASE_IDENTITY="$(_coordinator_release_tag_version "$MODULE_DIR")" || exit 2
+  COORDINATOR_RELEASE_VERSION="${COORDINATOR_RELEASE_IDENTITY%% *}"
+  COORDINATOR_RELEASE_COMMIT="${COORDINATOR_RELEASE_IDENTITY#* }"
+  echo "  release tag OK: $COORDINATOR_RELEASE_VERSION @ $COORDINATOR_RELEASE_COMMIT"
+  GH_HOST=github.com bash "$REPO_ROOT/scripts/verify-pearl-runtime-release.sh" \
+    --tag "$COORDINATOR_RELEASE_VERSION" \
+    --expected-commit "$COORDINATOR_RELEASE_COMMIT" \
+    --repository "Augustas11/macprovider" \
+    --remote "origin"
+fi
+
+PINNED_DEPLOY_INPUT_DIR=""
+PINNED_DIST_DIR="$DIST_DIR"
+PINNED_STATIC_FEEDS_DIR="$DIST_DIR/../../phase3-binary/dist/static"
+PINNED_AUTOTUNE_DIR="$DIST_DIR/../../phase3-binary/catalog/autotune"
+PINNED_SCRIPTS_DIR="$DIST_DIR/../../scripts"
+if [ "$DRY_RUN_LOCAL" != "1" ]; then
+  PINNED_DEPLOY_INPUT_DIR="$(umask 077 && mktemp -d -t macprovider-deploy-inputs.XXXXXXXX)" || {
+    echo "aborting deploy: mktemp failed for pinned deploy inputs" >&2
+    exit 2
+  }
+  trap 'rm -rf "${PINNED_DEPLOY_INPUT_DIR:-}"' EXIT HUP INT TERM
+  git -C "$REPO_ROOT" archive --format=tar "$COORDINATOR_RELEASE_COMMIT" -- \
+    phase4-coordinator/dist \
+    phase3-binary/dist/static \
+    phase3-binary/catalog/autotune \
+    scripts/catalog-release.py \
+    scripts/sign-catalog.go \
+    | tar -xf - -C "$PINNED_DEPLOY_INPUT_DIR"
+  PINNED_DIST_DIR="$PINNED_DEPLOY_INPUT_DIR/phase4-coordinator/dist"
+  PINNED_STATIC_FEEDS_DIR="$PINNED_DEPLOY_INPUT_DIR/phase3-binary/dist/static"
+  PINNED_AUTOTUNE_DIR="$PINNED_DEPLOY_INPUT_DIR/phase3-binary/catalog/autotune"
+  PINNED_SCRIPTS_DIR="$PINNED_DEPLOY_INPUT_DIR/scripts"
+fi
+
 # Email validator — RFC-conformant pre-validation is overkill; we just
 # need to reject metacharacters that would split a shell arg.
 if ! printf '%s' "$EMAIL" | grep -Eq '^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$'; then
@@ -508,34 +642,27 @@ if [ "${STATS_DOMAIN:-stats.streamvc.live}" != "stats.streamvc.live" ]; then
   exit 1
 fi
 
-# R3 SEC MED — reuse the already-resolved physical dir from the
-# symlink walker rather than recomputing from `$0` (which is the
-# symlink path) + logical `pwd`. All later artifact reads,
-# check-deploy-config, config uploads, and vhost templates hang
-# off DIST_DIR, so any parent-symlink retargeting attack that
-# survives helper sourcing would still land here.
-DIST_DIR="$_PEARL_TLS_SCRIPT_DIR"
 BINARY="$DIST_DIR/coordinator-linux-amd64"
 CLI_BINARY="$DIST_DIR/coordinator-cli-linux-amd64"
 STATS_INVENTORY_BINARY="$DIST_DIR/stats-inventory-sync-linux-amd64"
 STATS_BILLING_MIRROR_BINARY="$DIST_DIR/stats-billing-mirror-linux-amd64"
 STATS_HARDWARE_VERIFIER_BINARY="$DIST_DIR/stats-hardware-verifier-linux-amd64"
-CONFIG="$DIST_DIR/coordinator.yaml"
+CONFIG="$PINNED_DIST_DIR/coordinator.yaml"
 DEPLOY_CONFIG="$CONFIG"
-SERVICE="$DIST_DIR/macprovider-coordinator.service"
-DEPLOY_RECOVER="$DIST_DIR/coordinator-deploy-recover.sh"
-DEPLOY_GUARD="$DIST_DIR/systemd/macprovider-coordinator-deploy-guard.conf"
-DEPLOY_RECOVERY_SERVICE="$DIST_DIR/systemd/macprovider-coordinator-deploy-recovery.service"
-DEPLOY_WATCHDOG_SERVICE="$DIST_DIR/systemd/macprovider-coordinator-deploy-watchdog.service"
-STATS_INVENTORY_SERVICE="$DIST_DIR/stats-inventory-sync.service"
-STATS_INVENTORY_TIMER="$DIST_DIR/stats-inventory-sync.timer"
-STATS_BILLING_MIRROR_SERVICE="$DIST_DIR/stats-billing-mirror.service"
-STATS_BILLING_MIRROR_TIMER="$DIST_DIR/stats-billing-mirror.timer"
-STATS_HARDWARE_VERIFIER_SERVICE="$DIST_DIR/stats-hardware-verifier.service"
-STATS_HARDWARE_VERIFIER_TIMER="$DIST_DIR/stats-hardware-verifier.timer"
-NGINX_SITE="$DIST_DIR/nginx-coordinator.streamvc.live.conf"
-TCP_SYSCTL="$DIST_DIR/sysctl.d/99-macprovider-tcp.conf"
-TCP_BBR_MODULES_LOAD="$DIST_DIR/modules-load.d/tcp_bbr.conf"
+SERVICE="$PINNED_DIST_DIR/macprovider-coordinator.service"
+DEPLOY_RECOVER="$PINNED_DIST_DIR/coordinator-deploy-recover.sh"
+DEPLOY_GUARD="$PINNED_DIST_DIR/systemd/macprovider-coordinator-deploy-guard.conf"
+DEPLOY_RECOVERY_SERVICE="$PINNED_DIST_DIR/systemd/macprovider-coordinator-deploy-recovery.service"
+DEPLOY_WATCHDOG_SERVICE="$PINNED_DIST_DIR/systemd/macprovider-coordinator-deploy-watchdog.service"
+STATS_INVENTORY_SERVICE="$PINNED_DIST_DIR/stats-inventory-sync.service"
+STATS_INVENTORY_TIMER="$PINNED_DIST_DIR/stats-inventory-sync.timer"
+STATS_BILLING_MIRROR_SERVICE="$PINNED_DIST_DIR/stats-billing-mirror.service"
+STATS_BILLING_MIRROR_TIMER="$PINNED_DIST_DIR/stats-billing-mirror.timer"
+STATS_HARDWARE_VERIFIER_SERVICE="$PINNED_DIST_DIR/stats-hardware-verifier.service"
+STATS_HARDWARE_VERIFIER_TIMER="$PINNED_DIST_DIR/stats-hardware-verifier.timer"
+NGINX_SITE="$PINNED_DIST_DIR/nginx-coordinator.streamvc.live.conf"
+TCP_SYSCTL="$PINNED_DIST_DIR/sysctl.d/99-macprovider-tcp.conf"
+TCP_BBR_MODULES_LOAD="$PINNED_DIST_DIR/modules-load.d/tcp_bbr.conf"
 # SPEC-017 v0.1.8 Step 4.B — additional nginx artifacts the
 # coordinator vhost depends on:
 #   - stats-shared.conf is the http-context snippet declaring the
@@ -548,28 +675,28 @@ TCP_BBR_MODULES_LOAD="$DIST_DIR/modules-load.d/tcp_bbr.conf"
 #     `stats.streamvc.live` vhost.
 # Both files MUST exist before this deploy proceeds; they are
 # installed below alongside the coordinator vhost.
-NGINX_STATS_SHARED="$DIST_DIR/nginx-snippets/stats-shared.conf"
-NGINX_STATS_SECHEADERS="$DIST_DIR/nginx-snippets/stats-security-headers.conf"
-NGINX_STATS_CORS_429="$DIST_DIR/nginx-snippets/cors-429.conf"
-NGINX_STATS_PROXY_PUBLIC="$DIST_DIR/nginx-snippets/stats-proxy-public.conf"
-NGINX_STATS_PROXY_PARTNER="$DIST_DIR/nginx-snippets/stats-proxy-partner.conf"
-NGINX_STATS_SITE="$DIST_DIR/nginx-stats.streamvc.live.conf"
+NGINX_STATS_SHARED="$PINNED_DIST_DIR/nginx-snippets/stats-shared.conf"
+NGINX_STATS_SECHEADERS="$PINNED_DIST_DIR/nginx-snippets/stats-security-headers.conf"
+NGINX_STATS_CORS_429="$PINNED_DIST_DIR/nginx-snippets/cors-429.conf"
+NGINX_STATS_PROXY_PUBLIC="$PINNED_DIST_DIR/nginx-snippets/stats-proxy-public.conf"
+NGINX_STATS_PROXY_PARTNER="$PINNED_DIST_DIR/nginx-snippets/stats-proxy-partner.conf"
+NGINX_STATS_SITE="$PINNED_DIST_DIR/nginx-stats.streamvc.live.conf"
 # SPEC-023 signed recommendation feeds served on the buyer mux at
 # /v1/rate-card, /v1/demand-rank and /v1/autotune-candidates (+ .sig sidecars).
 # Files live in phase3-binary/dist/static/ in the repo. Deploy installs
 # them into /opt/macprovider/autotune/ for coordinator startup load.
-STATIC_FEEDS_DIR="$DIST_DIR/../../phase3-binary/dist/static"
+STATIC_FEEDS_DIR="$PINNED_STATIC_FEEDS_DIR"
 STATIC_DEMAND_JSON="$STATIC_FEEDS_DIR/demand-rank.json"
 STATIC_DEMAND_SIG="$STATIC_FEEDS_DIR/demand-rank.json.sig"
 STATIC_AUTOTUNE_JSON="$STATIC_FEEDS_DIR/autotune-candidates.json"
 STATIC_AUTOTUNE_SIG="$STATIC_FEEDS_DIR/autotune-candidates.json.sig"
 STATIC_RATE_CARD_JSON="$STATIC_FEEDS_DIR/rate-card.json"
 STATIC_RATE_CARD_SIG="$STATIC_FEEDS_DIR/rate-card.json.sig"
-AUTOTUNE_RELEASE_MANIFEST="$DIST_DIR/../../phase3-binary/catalog/autotune/release.json"
-AUTOTUNE_TRUSTED_KEYS="$DIST_DIR/../../phase3-binary/catalog/autotune/trusted-keys.json"
-AUTOTUNE_TIER2_JSON="$DIST_DIR/../../phase3-binary/catalog/autotune/tier2-catalog.json"
-AUTOTUNE_RELEASE_VERIFY="$DIST_DIR/../../scripts/catalog-release.py"
-AUTOTUNE_TIER2_VERIFIER="$DIST_DIR/../../scripts/sign-catalog.go"
+AUTOTUNE_RELEASE_MANIFEST="$PINNED_AUTOTUNE_DIR/release.json"
+AUTOTUNE_TRUSTED_KEYS="$PINNED_AUTOTUNE_DIR/trusted-keys.json"
+AUTOTUNE_TIER2_JSON="$PINNED_AUTOTUNE_DIR/tier2-catalog.json"
+AUTOTUNE_RELEASE_VERIFY="$PINNED_SCRIPTS_DIR/catalog-release.py"
+AUTOTUNE_TIER2_VERIFIER="$PINNED_SCRIPTS_DIR/sign-catalog.go"
 CATALOG_SOURCE="${CATALOG_SOURCE:-$AUTOTUNE_TIER2_JSON}"
 
 python3 "$AUTOTUNE_RELEASE_VERIFY" verify
@@ -950,6 +1077,10 @@ trap '
   rm -f "${RATE_CARD_MIGRATED_OVERLAY_TMP:-}"
   rm -f "${RATE_CARD_MIGRATED_OVERLAY_VALIDATION_TMP:-}"
   rm -f "${GATEWAY_REMOTE_CONFIG_TMP:-}"
+  rm -f "${DEPLOY_INPUT_MANIFEST_TMP:-}"
+  rm -f "${RECOVERY_INPUT_MANIFEST_TMP:-}"
+  rm -f "${TCP_INPUT_MANIFEST_TMP:-}"
+  rm -rf "${PINNED_DEPLOY_INPUT_DIR:-}"
   rm -rf "${STATIC_SMOKE_DIR:-}"
   if [ -n "${DEPLOY_TMP:-}" ]; then
     $SSH "rm -rf $DEPLOY_TMP" 2>/dev/null || true
@@ -1480,7 +1611,7 @@ if [ -n "$CATALOG_REMOTE_PATH" ]; then
     echo "aborting deploy: cannot bind Tier-2 identity without $STATIC_AUTOTUNE_JSON" >&2
     exit 5
   fi
-  python3 "$DIST_DIR/../../scripts/catalog-release.py" check-tier2-binding \
+  python3 "$AUTOTUNE_RELEASE_VERIFY" check-tier2-binding \
     --candidate "$STATIC_AUTOTUNE_JSON" \
     --tier2 "$TMP_CATALOG_PINNED" || {
     echo "aborting deploy: Tier-2 catalog conflicts with autotune release identity (#608)" >&2
@@ -1508,6 +1639,17 @@ $SCP "$DEPLOY_RECOVER" "$VPS_USER@$VPS_HOST:$RECOVERY_DEPLOY_TMP/coordinator-dep
 $SCP "$DEPLOY_GUARD" "$VPS_USER@$VPS_HOST:$RECOVERY_DEPLOY_TMP/10-deploy-transaction-guard.conf"
 $SCP "$DEPLOY_RECOVERY_SERVICE" "$VPS_USER@$VPS_HOST:$RECOVERY_DEPLOY_TMP/macprovider-coordinator-deploy-recovery.service"
 $SCP "$DEPLOY_WATCHDOG_SERVICE" "$VPS_USER@$VPS_HOST:$RECOVERY_DEPLOY_TMP/macprovider-coordinator-deploy-watchdog.service"
+RECOVERY_INPUT_MANIFEST_TMP="$(umask 077 && mktemp -t macprovider-recovery-inputs.XXXXXXXX)" || {
+  echo "aborting deploy: mktemp failed for recovery input manifest" >&2
+  exit 2
+}
+shasum -a 256 "$DEPLOY_RECOVER" | awk '{ print $1 "  coordinator-deploy-recover" }' >> "$RECOVERY_INPUT_MANIFEST_TMP"
+shasum -a 256 "$DEPLOY_GUARD" | awk '{ print $1 "  10-deploy-transaction-guard.conf" }' >> "$RECOVERY_INPUT_MANIFEST_TMP"
+shasum -a 256 "$DEPLOY_RECOVERY_SERVICE" | awk '{ print $1 "  macprovider-coordinator-deploy-recovery.service" }' >> "$RECOVERY_INPUT_MANIFEST_TMP"
+shasum -a 256 "$DEPLOY_WATCHDOG_SERVICE" | awk '{ print $1 "  macprovider-coordinator-deploy-watchdog.service" }' >> "$RECOVERY_INPUT_MANIFEST_TMP"
+$SCP "$RECOVERY_INPUT_MANIFEST_TMP" "$VPS_USER@$VPS_HOST:$RECOVERY_DEPLOY_TMP/recovery-inputs.sha256"
+$SSH "cd $RECOVERY_DEPLOY_TMP && shasum -a 256 -c recovery-inputs.sha256 >/dev/null"
+echo "  recovery staged input digests OK"
 $SSH "set -e
   _helper_next=/opt/macprovider/coordinator-deploy-recover.next.\$\$
   _unit_next=/etc/systemd/system/macprovider-coordinator-deploy-recovery.service.next.\$\$
@@ -2688,6 +2830,22 @@ EOF
     $SSH "rm -rf $TCP_SYSCTL_TMP" 2>/dev/null || true
     exit 1
   fi
+  TCP_INPUT_MANIFEST_TMP="$(umask 077 && mktemp -t macprovider-tcp-inputs.XXXXXXXX)" || {
+    echo "aborting deploy: mktemp failed for TCP input manifest" >&2
+    $SSH "rm -rf $TCP_SYSCTL_TMP" 2>/dev/null || true
+    exit 2
+  }
+  shasum -a 256 "$TCP_SYSCTL" | awk '{ print $1 "  macprovider-tcp.conf" }' >> "$TCP_INPUT_MANIFEST_TMP"
+  shasum -a 256 "$TCP_BBR_MODULES_LOAD" | awk '{ print $1 "  tcp_bbr.conf" }' >> "$TCP_INPUT_MANIFEST_TMP"
+  if ! $SCP "$TCP_INPUT_MANIFEST_TMP" "$VPS_USER@$VPS_HOST:$TCP_SYSCTL_TMP/tcp-inputs.sha256"; then
+    $SSH "rm -rf $TCP_SYSCTL_TMP" 2>/dev/null || true
+    exit 1
+  fi
+  if ! $SSH "cd $TCP_SYSCTL_TMP && shasum -a 256 -c tcp-inputs.sha256 >/dev/null"; then
+    $SSH "rm -rf $TCP_SYSCTL_TMP" 2>/dev/null || true
+    exit 1
+  fi
+  log "  TCP staged input digests OK"
   TCP_SYSCTL_RESULT=$($SSH "bash -s -- '$TCP_SYSCTL_TMP'" <<'REMOTE_TCP_SYSCTL'
     set -e
     tmp_dir="$1"
@@ -2977,6 +3135,65 @@ esac
 log "  staging dir: $DEPLOY_TMP (root:root 0700)"
 $SSH "install -d -o root -g root -m 0700 $DEPLOY_TMP/scripts"
 
+DEPLOY_INPUT_MANIFEST_TMP="$(umask 077 && mktemp -t macprovider-deploy-inputs.XXXXXXXX)" || {
+  echo "aborting deploy: mktemp failed for deploy input manifest" >&2
+  exit 2
+}
+_append_deploy_input_digest() {
+  local source_path="$1" remote_name="$2"
+  shasum -a 256 "$source_path" | awk -v name="$remote_name" '{ print $1 "  " name }' >> "$DEPLOY_INPUT_MANIFEST_TMP"
+}
+_append_deploy_input_digest "$BINARY" "coordinator-linux-amd64"
+_append_deploy_input_digest "$CLI_BINARY" "coordinator-cli-linux-amd64"
+_append_deploy_input_digest "$STATS_INVENTORY_BINARY" "stats-inventory-sync-linux-amd64"
+_append_deploy_input_digest "$STATS_BILLING_MIRROR_BINARY" "stats-billing-mirror-linux-amd64"
+_append_deploy_input_digest "$STATS_HARDWARE_VERIFIER_BINARY" "stats-hardware-verifier-linux-amd64"
+if [ "$CONFIG_MODE" = "apply-tracked" ]; then
+  _append_deploy_input_digest "$CONFIG" "coordinator.yaml"
+elif [ "${RATE_CARD_CONFIG_MIGRATION_ACTIVE:-0}" = "1" ]; then
+  _append_deploy_input_digest "$RATE_CARD_MIGRATED_CONFIG_TMP" "coordinator.rate-card-migration.yaml"
+elif [ "$C2_TIMER_CONFIG_MIGRATION" = "1" ]; then
+  _append_deploy_input_digest "$C2_TIMER_MIGRATED_CONFIG_TMP" "coordinator.c2-timer-migration.yaml"
+fi
+if [ "${RATE_CARD_MIGRATION_OVERLAY_ACTIVE:-0}" = "1" ]; then
+  _append_deploy_input_digest "$RATE_CARD_MIGRATED_OVERLAY_TMP" "coordinator.pearl-overlays.rate-card-migration.yaml"
+elif [ "${C2_TIMER_MIGRATION_OVERLAY_ACTIVE:-0}" = "1" ]; then
+  _append_deploy_input_digest "$C2_TIMER_MIGRATED_OVERLAY_TMP" "coordinator.pearl-overlays.c2-timer-migration.yaml"
+fi
+for _deploy_input in \
+  "$SERVICE=macprovider-coordinator.service" \
+  "$STATS_INVENTORY_SERVICE=stats-inventory-sync.service" \
+  "$STATS_INVENTORY_TIMER=stats-inventory-sync.timer" \
+  "$STATS_BILLING_MIRROR_SERVICE=stats-billing-mirror.service" \
+  "$STATS_BILLING_MIRROR_TIMER=stats-billing-mirror.timer" \
+  "$STATS_HARDWARE_VERIFIER_SERVICE=stats-hardware-verifier.service" \
+  "$STATS_HARDWARE_VERIFIER_TIMER=stats-hardware-verifier.timer" \
+  "$NGINX_SITE=nginx-coordinator-full.conf" \
+  "$NGINX_STATS_SHARED=nginx-stats-shared.conf" \
+  "$NGINX_STATS_SECHEADERS=nginx-stats-security-headers.conf" \
+  "$NGINX_STATS_CORS_429=nginx-stats-cors-429.conf" \
+  "$NGINX_STATS_PROXY_PUBLIC=nginx-stats-proxy-public.conf" \
+  "$NGINX_STATS_PROXY_PARTNER=nginx-stats-proxy-partner.conf" \
+  "$NGINX_STATS_SITE=nginx-stats.streamvc.live.conf" \
+  "$STATIC_DEMAND_JSON=demand-rank.json" \
+  "$STATIC_DEMAND_SIG=demand-rank.json.sig" \
+  "$STATIC_AUTOTUNE_JSON=autotune-candidates.json" \
+  "$STATIC_AUTOTUNE_SIG=autotune-candidates.json.sig" \
+  "$STATIC_RATE_CARD_JSON=rate-card.json" \
+  "$STATIC_RATE_CARD_SIG=rate-card.json.sig" \
+  "$AUTOTUNE_RELEASE_MANIFEST=release.json" \
+  "$AUTOTUNE_TRUSTED_KEYS=trusted-keys.json" \
+  "$AUTOTUNE_RELEASE_VERIFY=scripts/catalog-release.py" \
+  "$AUTOTUNE_TIER2_VERIFIER=scripts/sign-catalog.go"; do
+  _append_deploy_input_digest "${_deploy_input%%=*}" "${_deploy_input#*=}"
+done
+if [ -n "$CATALOG_REMOTE_PATH" ]; then
+  _append_deploy_input_digest "$TMP_CATALOG_PINNED" "tier2-catalog.json"
+  _append_deploy_input_digest "$TMP_CATALOG_PUBKEY" "tier2-catalog.pub"
+else
+  _append_deploy_input_digest "$AUTOTUNE_TIER2_JSON" "tier2-catalog.json"
+fi
+
 $SCP "$BINARY"      "$VPS_USER@$VPS_HOST:$DEPLOY_TMP/coordinator-linux-amd64"
 $SCP "$CLI_BINARY"  "$VPS_USER@$VPS_HOST:$DEPLOY_TMP/coordinator-cli-linux-amd64"
 $SCP "$STATS_INVENTORY_BINARY"  "$VPS_USER@$VPS_HOST:$DEPLOY_TMP/stats-inventory-sync-linux-amd64"
@@ -3041,6 +3258,9 @@ if [ -n "$CATALOG_REMOTE_PATH" ]; then
   $SCP "$TMP_CATALOG_PINNED" "$VPS_USER@$VPS_HOST:$DEPLOY_TMP/tier2-catalog.json"
   $SCP "$TMP_CATALOG_PUBKEY" "$VPS_USER@$VPS_HOST:$DEPLOY_TMP/tier2-catalog.pub"
 fi
+$SCP "$DEPLOY_INPUT_MANIFEST_TMP" "$VPS_USER@$VPS_HOST:$DEPLOY_TMP/deploy-inputs.sha256"
+$SSH "cd $DEPLOY_TMP && shasum -a 256 -c deploy-inputs.sha256 >/dev/null"
+echo "  staged deploy input digests OK"
 
 if [ "$CONFIG_MODE" = "apply-tracked" ] || [ "$C2_TIMER_CONFIG_MIGRATION" = "1" ] || [ "${RATE_CARD_CONFIG_MIGRATION_ACTIVE:-0}" = "1" ] || [ "${RATE_CARD_MIGRATION_OVERLAY_ACTIVE:-0}" = "1" ]; then
   # M1-6 / DEVE-5 Part D: dated backup of the remote coordinator.yaml on Pearl
@@ -3088,6 +3308,10 @@ $SSH "set -e
   fi
   # coordinator-cli is operator-facing, but remains part of the same release
   # and therefore has an exact durable snapshot like the daemon binary.
+  if [ ! -x /opt/macprovider/coordinator-cli ] || ! cmp -s $DEPLOY_TMP/coordinator-cli-linux-amd64 /opt/macprovider/coordinator-cli; then
+    echo 'refusing coordinator-cli replacement from direct deploy: install the signed matching Pearl runtime release first' >&2
+    exit 1
+  fi
   install -o root -g macprovider -m 0750 $DEPLOY_TMP/coordinator-cli-linux-amd64 /opt/macprovider/coordinator-cli
   # stats-inventory-sync is an operator sidecar, not a coordinator child.
   # It runs under its own Unix identity and only receives execute access
@@ -3108,14 +3332,28 @@ $SSH "set -e
   elif ! grep -qx "parity_required=absent" /opt/macprovider/.coordinator-deploy-sidecar-prior-state; then
     echo "refusing stats-inventory sidecar install: invalid pre-quiesce parity state" >&2
     exit 1
+  elif [ ! -x /opt/macprovider-stats/stats-inventory-sync ] ||
+       ! cmp -s $DEPLOY_TMP/stats-inventory-sync-linux-amd64 /opt/macprovider-stats/stats-inventory-sync; then
+    echo "refusing stats-inventory sidecar replacement from direct deploy: install the signed matching stats sidecar release first" >&2
+    exit 1
   fi
   install -o root -g macprovider-stats -m 0750 $DEPLOY_TMP/stats-inventory-sync-linux-amd64 /opt/macprovider-stats/stats-inventory-sync
   # stats-billing-mirror is an out-of-band stats sidecar. It runs as the
   # dedicated macprovider-stats identity and gets read access only to the
   # SQLite ledger files via file ACLs below.
+  if [ ! -x /opt/macprovider-stats/stats-billing-mirror ] ||
+     ! cmp -s $DEPLOY_TMP/stats-billing-mirror-linux-amd64 /opt/macprovider-stats/stats-billing-mirror; then
+    echo "refusing stats-billing-mirror replacement from direct deploy: install the signed matching stats sidecar release first" >&2
+    exit 1
+  fi
   install -o root -g macprovider-stats -m 0750 $DEPLOY_TMP/stats-billing-mirror-linux-amd64 /opt/macprovider-stats/stats-billing-mirror
   # stats-hardware-verifier is an out-of-band stats sidecar. It promotes
   # queued autotune evidence after conservative verification.
+  if [ ! -x /opt/macprovider-stats/stats-hardware-verifier ] ||
+     ! cmp -s $DEPLOY_TMP/stats-hardware-verifier-linux-amd64 /opt/macprovider-stats/stats-hardware-verifier; then
+    echo "refusing stats-hardware-verifier replacement from direct deploy: install the signed matching stats sidecar release first" >&2
+    exit 1
+  fi
   install -o root -g macprovider-stats -m 0750 $DEPLOY_TMP/stats-hardware-verifier-linux-amd64 /opt/macprovider-stats/stats-hardware-verifier
   if [ '$CONFIG_MODE' = 'apply-tracked' ]; then
     install -o root -g macprovider -m 0640 $DEPLOY_TMP/coordinator.yaml /opt/macprovider/coordinator.yaml
@@ -3586,36 +3824,13 @@ echo "  GET https://$DOMAIN/healthz"
 HEALTHZ_BODY=$(curl -fsS --max-time 10 --max-filesize 65536 "https://$DOMAIN/healthz" || { echo "healthz failed"; exit 1; })
 printf '%s\n' "$HEALTHZ_BODY" | python3 -m json.tool
 
-# Provenance check: compare the deployed version (from /healthz) against
-# what the local working tree would have built. Three outcomes:
-#   - "?"        the binary predates PR #18 and has no `version` field on
-#                /healthz at all → CRITICAL line (and abort if
-#                STRICT_PROVENANCE=1) because the entire M0-5 instrumentation
-#                got bypassed. By design still non-fatal by default so the
-#                operator can decide.
-#   - matched    OK line.
-#   - mismatched WARN line (the deployed binary was built from a different
-#                commit than the local tree — usually means an unstaged or
-#                unfetched change locally; investigate before trusting).
+# Provenance check: compare the deployed version (from /healthz) against the
+# exact release tag validated before any production SSH mutation. Missing and
+# mismatched versions are fatal while rollback is still armed; otherwise a clean
+# tag checkout could still commit a stale ignored dist/coordinator-linux-amd64.
 # See audits/2026-06-10/ROLLBACK_PROCEDURE.md for the rollback path.
-DEPLOYED_VERSION=$(printf '%s' "$HEALTHZ_BODY" | python3 -c "import sys,json; print(json.load(sys.stdin).get('version', '?'))" 2>/dev/null || echo "?")
-EXPECTED_VERSION=$(git describe --always --dirty --tags 2>/dev/null || git rev-parse --short HEAD)
-if [ "$DEPLOYED_VERSION" = "?" ]; then
-  echo "  CRITICAL provenance MISSING: /healthz returned no \"version\" field" >&2
-  echo "           This almost certainly means the deployed binary predates the" >&2
-  echo "           M0-5 instrumentation (PR #18) and the rollback gate is bypassed." >&2
-  echo "           Expected was: $EXPECTED_VERSION" >&2
-  echo "           See audits/2026-06-10/ROLLBACK_PROCEDURE.md to replace the live binary." >&2
-  if [ "${STRICT_PROVENANCE:-0}" = "1" ]; then
-    echo "  STRICT_PROVENANCE=1 set — aborting." >&2
-    exit 7
-  fi
-elif [ "$DEPLOYED_VERSION" = "$EXPECTED_VERSION" ]; then
-  echo "  provenance OK: deployed=$DEPLOYED_VERSION | expected=$EXPECTED_VERSION"
-else
-  echo "  WARN provenance mismatch: deployed=$DEPLOYED_VERSION | expected=$EXPECTED_VERSION" >&2
-  echo "       (build artifact does not match the local working tree — investigate before relying on this deploy)" >&2
-fi
+EXPECTED_VERSION="$COORDINATOR_RELEASE_VERSION"
+_coordinator_verify_deployed_version "$HEALTHZ_BODY" "$EXPECTED_VERSION" || exit $?
 
 echo "  GET https://$DOMAIN/v1/models -> expect 404 (buyer API is gateway-only)"
 STATUS=$(curl -sS -o /dev/null -w '%{http_code}' --max-time 10 "https://$DOMAIN/v1/models")

--- a/phase4-coordinator/dist/test/check_stats_billing_mirror_deploy_test.sh
+++ b/phase4-coordinator/dist/test/check_stats_billing_mirror_deploy_test.sh
@@ -23,9 +23,9 @@ done
 
 grep -qF 'STATS_BILLING_MIRROR_BINARY="$DIST_DIR/stats-billing-mirror-linux-amd64"' "$DEPLOY_SH" ||
   fail "deploy script missing billing mirror binary variable"
-grep -qF 'STATS_BILLING_MIRROR_SERVICE="$DIST_DIR/stats-billing-mirror.service"' "$DEPLOY_SH" ||
+grep -qF 'STATS_BILLING_MIRROR_SERVICE="$PINNED_DIST_DIR/stats-billing-mirror.service"' "$DEPLOY_SH" ||
   fail "deploy script missing billing mirror service variable"
-grep -qF 'STATS_BILLING_MIRROR_TIMER="$DIST_DIR/stats-billing-mirror.timer"' "$DEPLOY_SH" ||
+grep -qF 'STATS_BILLING_MIRROR_TIMER="$PINNED_DIST_DIR/stats-billing-mirror.timer"' "$DEPLOY_SH" ||
   fail "deploy script missing billing mirror timer variable"
 grep -qF '$SCP "$STATS_BILLING_MIRROR_BINARY" "$VPS_USER@$VPS_HOST:$DEPLOY_TMP/stats-billing-mirror-linux-amd64"' "$DEPLOY_SH" ||
   fail "deploy script missing billing mirror binary upload"

--- a/phase4-coordinator/dist/test/check_stats_inventory_deploy_test.sh
+++ b/phase4-coordinator/dist/test/check_stats_inventory_deploy_test.sh
@@ -26,9 +26,9 @@ done
 
 grep -qF 'STATS_INVENTORY_BINARY="$DIST_DIR/stats-inventory-sync-linux-amd64"' "$DEPLOY_SH" ||
   fail "deploy script missing sidecar binary variable"
-grep -qF 'STATS_INVENTORY_SERVICE="$DIST_DIR/stats-inventory-sync.service"' "$DEPLOY_SH" ||
+grep -qF 'STATS_INVENTORY_SERVICE="$PINNED_DIST_DIR/stats-inventory-sync.service"' "$DEPLOY_SH" ||
   fail "deploy script missing sidecar service variable"
-grep -qF 'STATS_INVENTORY_TIMER="$DIST_DIR/stats-inventory-sync.timer"' "$DEPLOY_SH" ||
+grep -qF 'STATS_INVENTORY_TIMER="$PINNED_DIST_DIR/stats-inventory-sync.timer"' "$DEPLOY_SH" ||
   fail "deploy script missing sidecar timer variable"
 grep -qF 'getent group macprovider-stats' "$DEPLOY_SH" ||
   fail "deploy script must create isolated stats group"

--- a/phase4-coordinator/dist/test/coordinator_release_tag_guard.test.sh
+++ b/phase4-coordinator/dist/test/coordinator_release_tag_guard.test.sh
@@ -1,0 +1,302 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+DEPLOY_SH="$SCRIPT_DIR/../deploy-pearl-vps.sh"
+BUILD_SH="$SCRIPT_DIR/../../scripts/build-linux.sh"
+
+fail() {
+  echo "FAIL: $*" >&2
+  exit 1
+}
+
+bash -n "$DEPLOY_SH"
+bash -n "$BUILD_SH"
+
+grep -qF '_coordinator_release_tag_version()' "$BUILD_SH" ||
+  fail "build script must keep an extractable release-tag helper"
+grep -qF '_coordinator_release_tag_version()' "$DEPLOY_SH" ||
+  fail "deploy script must keep an extractable release-tag helper"
+grep -qF 'ALLOW_NON_RELEASE_COORDINATOR_BUILD=1' "$BUILD_SH" ||
+  fail "build script must require an explicit local/dev opt-out for non-release artifacts"
+grep -qF 'FORCE_DIRTY is only allowed with ALLOW_NON_RELEASE_COORDINATOR_BUILD=1' "$BUILD_SH" ||
+  fail "build script must prevent FORCE_DIRTY from stamping dirty production artifacts as release builds"
+grep -qF "GOENV=off GOFLAGS='' GOWORK=off GOOS=linux GOARCH=amd64 go build" "$BUILD_SH" ||
+  fail "production coordinator builds must disable ambient Go environment poisoning"
+grep -qF 'COORDINATOR_RELEASE_IDENTITY="$(_coordinator_release_tag_version "$MODULE_DIR")"' "$DEPLOY_SH" ||
+  fail "deploy script must preflight the exact release tag before production SSH mutation"
+grep -qF 'SHA256:6DgoKNaOgF5c7NPHTAbNxJ2LT0uuj8U/3zObOOZjRiA' "$BUILD_SH" ||
+  fail "build script must pin the authorized release tag signer"
+grep -qF 'SHA256:6DgoKNaOgF5c7NPHTAbNxJ2LT0uuj8U/3zObOOZjRiA' "$DEPLOY_SH" ||
+  fail "deploy script must pin the authorized release tag signer"
+grep -qF 'https://github.com/Augustas11/macprovider.git' "$BUILD_SH" ||
+  fail "build script must pin release tag lookup to canonical GitHub URL"
+grep -qF 'https://github.com/Augustas11/macprovider.git' "$DEPLOY_SH" ||
+  fail "deploy script must pin release tag lookup to canonical GitHub URL"
+grep -qF 'GH_HOST=github.com bash "$REPO_ROOT/scripts/verify-pearl-runtime-release.sh"' "$DEPLOY_SH" ||
+  fail "deploy script must force gh release preflight to github.com"
+grep -qF -- '--repository "Augustas11/macprovider"' "$DEPLOY_SH" ||
+  fail "deploy script must pin the GitHub release repository"
+grep -qF -- '--remote "origin"' "$DEPLOY_SH" ||
+  fail "deploy script must pin the release-tag remote"
+! grep -qF '${GITHUB_REPOSITORY:-' "$DEPLOY_SH" ||
+  fail "deploy script must not accept caller-controlled GitHub release repositories"
+! grep -qF '${RELEASE_TAG_REMOTE:-' "$DEPLOY_SH" ||
+  fail "deploy script must not accept caller-controlled release-tag remotes"
+grep -qF 'verify-pearl-runtime-release.sh' "$DEPLOY_SH" ||
+  fail "deploy script must preflight signed Pearl runtime release assets before production SSH mutation"
+grep -qF 'git -C "$REPO_ROOT" archive --format=tar "$COORDINATOR_RELEASE_COMMIT"' "$DEPLOY_SH" ||
+  fail "deploy must pin tracked inputs from the verified release commit"
+grep -qF 'git -C "$REPO_ROOT" archive --format=tar "$COORDINATOR_RELEASE_COMMIT" -- phase4-coordinator' "$BUILD_SH" ||
+  fail "production build must compile from a snapshot of the verified release commit"
+grep -qF 'deploy-inputs.sha256' "$DEPLOY_SH" ||
+  fail "deploy must verify remote staged input digests before install/execute"
+grep -qF 'recovery-inputs.sha256' "$DEPLOY_SH" ||
+  fail "deploy must verify recovery guard staged input digests before install"
+grep -qF 'tcp-inputs.sha256' "$DEPLOY_SH" ||
+  fail "deploy must verify TCP staged input digests before remote sysctl mutation"
+grep -qF 'python3 "$AUTOTUNE_RELEASE_VERIFY" check-tier2-binding' "$DEPLOY_SH" ||
+  fail "deploy must use the pinned catalog-release verifier for Tier-2 binding checks"
+grep -qF 'EXPECTED_VERSION="$COORDINATOR_RELEASE_VERSION"' "$DEPLOY_SH" ||
+  fail "deploy provenance must compare healthz against the preflighted exact release tag"
+! grep -qF 'EXPECTED_VERSION=$(git describe --always --dirty --tags' "$DEPLOY_SH" ||
+  fail "deploy provenance must not derive expected version from git describe"
+grep -qF 'refusing coordinator-cli replacement from direct deploy' "$DEPLOY_SH" ||
+  fail "deploy must not replace coordinator-cli from ignored local artifacts"
+grep -qF 'refusing stats-billing-mirror replacement from direct deploy' "$DEPLOY_SH" ||
+  fail "deploy must not replace stats-billing-mirror from ignored local artifacts"
+grep -qF 'refusing stats-hardware-verifier replacement from direct deploy' "$DEPLOY_SH" ||
+  fail "deploy must not replace stats-hardware-verifier from ignored local artifacts"
+grep -qF '_coordinator_verify_deployed_version "$HEALTHZ_BODY" "$EXPECTED_VERSION" || exit $?' "$DEPLOY_SH" ||
+  fail "deploy provenance mismatch must be fatal before the commit marker"
+! grep -qF 'WARN provenance mismatch' "$DEPLOY_SH" ||
+  fail "deploy provenance mismatch must not be warning-only"
+release_check_line="$(grep -nF 'COORDINATOR_RELEASE_IDENTITY="$(_coordinator_release_tag_version "$MODULE_DIR")"' "$DEPLOY_SH" | head -n1 | cut -d: -f1)"
+token_load_line="$(grep -nF '_load_catalog_canary_auth_token' "$DEPLOY_SH" | tail -n1 | cut -d: -f1)"
+[ -n "$release_check_line" ] && [ -n "$token_load_line" ] && [ "$release_check_line" -lt "$token_load_line" ] ||
+  fail "deploy must reject non-release checkouts before reading catalog canary credentials"
+provenance_check_line="$(grep -nF '_coordinator_verify_deployed_version "$HEALTHZ_BODY" "$EXPECTED_VERSION" || exit $?' "$DEPLOY_SH" | head -n1 | cut -d: -f1)"
+commit_line="$(grep -nF 'touch /opt/macprovider/.coordinator-deploy-rollback/committed' "$DEPLOY_SH" | head -n1 | cut -d: -f1)"
+[ -n "$provenance_check_line" ] && [ -n "$commit_line" ] && [ "$provenance_check_line" -lt "$commit_line" ] ||
+  fail "deploy must verify exact release provenance before committing rollback state"
+
+work="$(mktemp -d "${TMPDIR:-/tmp}/coordinator-release-tag-guard.XXXXXX")"
+trap 'rm -rf "$work"' EXIT
+real_git="$(command -v git)"
+export REAL_GIT="$real_git"
+mkdir -p "$work/bin"
+cat > "$work/bin/git" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+repo=""
+args=("$@")
+for ((i = 0; i < ${#args[@]}; i++)); do
+  if [ "${args[$i]}" = "-C" ] && [ "$((i + 1))" -lt "${#args[@]}" ]; then
+    repo="${args[$((i + 1))]}"
+  fi
+done
+for arg in "$@"; do
+  if [ "$arg" = "verify-tag" ]; then
+    [ "${FAKE_GIT_VERIFY_TAG_FAIL:-0}" != "1" ] || exit 1
+    if [ "${FAKE_GIT_VERIFY_TAG_UNAUTHORIZED:-0}" = "1" ]; then
+      echo 'Good "git" signature for attacker@example.invalid with ED25519 key SHA256:unauthorized' >&2
+      exit 0
+    fi
+    if [ "${FAKE_GIT_VERIFY_TAG_SPOOF_PRINCIPAL:-0}" = "1" ]; then
+      echo 'Good "git" signature for SHA256:6DgoKNaOgF5c7NPHTAbNxJ2LT0uuj8U/3zObOOZjRiA with ED25519 key SHA256:unauthorized' >&2
+      exit 0
+    fi
+    echo 'Good "git" signature for augstar@gmail.com with ED25519 key SHA256:6DgoKNaOgF5c7NPHTAbNxJ2LT0uuj8U/3zObOOZjRiA' >&2
+    exit 0
+  fi
+done
+for ((i = 0; i < ${#args[@]}; i++)); do
+  if [ "${args[$i]}" = "remote" ] && [ "${args[$((i + 1))]:-}" = "get-url" ] && [ "${args[$((i + 2))]:-}" = "origin" ]; then
+    echo "https://github.com/Augustas11/macprovider.git"
+    exit 0
+  fi
+  if [ "${args[$i]}" = "ls-remote" ] && [ "${args[$((i + 1))]:-}" = "https://github.com/Augustas11/macprovider.git" ]; then
+    [ -n "$repo" ] || {
+      echo "fake git: missing -C repo for canonical ls-remote" >&2
+      exit 2
+    }
+    local_origin="$("$REAL_GIT" -C "$repo" remote get-url origin)"
+    args[$((i + 1))]="$local_origin"
+    exec "$REAL_GIT" "${args[@]}"
+  fi
+done
+exec "$REAL_GIT" "$@"
+SH
+chmod +x "$work/bin/git"
+export PATH="$work/bin:$PATH"
+
+extract_build_helper="$work/build-helper.sh"
+extract_deploy_helper="$work/deploy-helper.sh"
+extract_provenance_helper="$work/provenance-helper.sh"
+awk '/^_coordinator_release_tag_version\(\) \{/{f=1} f{print} f&&/^\}$/{exit}' "$BUILD_SH" > "$extract_build_helper"
+awk '/^_coordinator_release_tag_version\(\) \{/{f=1} f{print} f&&/^\}$/{exit}' "$DEPLOY_SH" > "$extract_deploy_helper"
+awk '/^_coordinator_verify_deployed_version\(\) \{/{f=1} f{print} f&&/^\}$/{exit}' "$DEPLOY_SH" > "$extract_provenance_helper"
+
+init_repo() {
+  local repo="$1"
+  git init -q "$repo"
+  git -C "$repo" config user.name release-tag-guard-test
+  git -C "$repo" config user.email release-tag-guard-test@example.invalid
+  printf '%s\n' one > "$repo/value"
+  git -C "$repo" add value
+  git -C "$repo" commit -qm one
+  git init --bare -q "$repo.git"
+  git -C "$repo" remote add origin "$repo.git"
+  git -C "$repo" push -q origin HEAD:refs/heads/main
+}
+
+publish_annotated_tag() {
+  local repo="$1" tag="$2"
+  git -C "$repo" tag -a "$tag" -m "$tag"
+  git -C "$repo" push -q origin "refs/tags/$tag"
+}
+
+run_build_helper() {
+  local repo="$1"
+  (
+    cd "$repo"
+    # shellcheck disable=SC2034 # consumed by the extracted build helper
+    REPO_ROOT="$(git rev-parse --show-toplevel)"
+    # shellcheck disable=SC1090
+    . "$extract_build_helper"
+    _coordinator_release_tag_version
+  )
+}
+
+run_deploy_helper() {
+  local repo="$1"
+  (
+    # shellcheck disable=SC1090
+    . "$extract_deploy_helper"
+    _coordinator_release_tag_version "$repo"
+  )
+}
+
+repo_exact="$work/exact"
+init_repo "$repo_exact"
+publish_annotated_tag "$repo_exact" v1.8.70
+exact_commit="$(git -C "$repo_exact" rev-parse HEAD)"
+[ "$(run_build_helper "$repo_exact")" = "v1.8.70 $exact_commit" ] ||
+  fail "build helper must return the exact numeric release tag"
+[ "$(run_deploy_helper "$repo_exact")" = "v1.8.70 $exact_commit" ] ||
+  fail "deploy helper must return the exact numeric release tag"
+
+if FAKE_GIT_VERIFY_TAG_FAIL=1 run_build_helper "$repo_exact" >"$work/unsigned.out" 2>&1; then
+  fail "build helper accepted a release tag whose signature verification failed"
+fi
+grep -qF 'does not verify as a trusted signed tag' "$work/unsigned.out" ||
+  fail "build helper must reject unsigned or untrusted release tags"
+
+if FAKE_GIT_VERIFY_TAG_UNAUTHORIZED=1 run_deploy_helper "$repo_exact" >"$work/unauthorized.out" 2>&1; then
+  fail "deploy helper accepted a release tag signed by an unauthorized key"
+fi
+grep -qF 'signed by an unauthorized release signer' "$work/unauthorized.out" ||
+  fail "deploy helper must reject release tags signed by unauthorized keys"
+
+if FAKE_GIT_VERIFY_TAG_SPOOF_PRINCIPAL=1 run_build_helper "$repo_exact" >"$work/spoof-principal.out" 2>&1; then
+  fail "build helper accepted a release tag with the authorized fingerprint only in the signer principal"
+fi
+grep -qF 'signed by an unauthorized release signer' "$work/spoof-principal.out" ||
+  fail "build helper must match the authorized signer line exactly"
+
+repo_lightweight="$work/lightweight"
+init_repo "$repo_lightweight"
+git -C "$repo_lightweight" tag v1.8.77
+git -C "$repo_lightweight" push -q origin refs/tags/v1.8.77
+if run_deploy_helper "$repo_lightweight" >"$work/lightweight.out" 2>&1; then
+  fail "deploy helper accepted a lightweight release tag"
+fi
+grep -qF 'not an annotated signed release tag' "$work/lightweight.out" ||
+  fail "deploy helper must reject lightweight numeric tags"
+
+repo_main="$work/main"
+init_repo "$repo_main"
+if run_build_helper "$repo_main" >"$work/main-build.out" 2>&1; then
+  fail "build helper accepted an untagged main checkout"
+fi
+grep -qF 'HEAD is not exactly a numeric release tag' "$work/main-build.out" ||
+  fail "build helper must explain untagged checkout rejection"
+if run_deploy_helper "$repo_main" >"$work/main-deploy.out" 2>&1; then
+  fail "deploy helper accepted an untagged main checkout"
+fi
+grep -qF 'git describe from main' "$work/main-deploy.out" ||
+  fail "deploy helper must name the git-describe-from-main footgun"
+
+repo_ahead="$work/ahead"
+init_repo "$repo_ahead"
+publish_annotated_tag "$repo_ahead" v1.8.71
+printf '%s\n' two > "$repo_ahead/value"
+git -C "$repo_ahead" commit -qam two
+if run_build_helper "$repo_ahead" >"$work/ahead-build.out" 2>&1; then
+  fail "build helper accepted a vX.Y.Z-N-gHASH checkout"
+fi
+grep -qF 'HEAD is not exactly a numeric release tag' "$work/ahead-build.out" ||
+  fail "build helper must reject commits ahead of a release tag"
+
+repo_bad_tag="$work/bad-tag"
+init_repo "$repo_bad_tag"
+git -C "$repo_bad_tag" tag v1.8.72-1-gabcdef
+if run_build_helper "$repo_bad_tag" >"$work/bad-tag.out" 2>&1; then
+  fail "build helper accepted a describe-shaped non-release tag"
+fi
+grep -qF 'HEAD is not exactly a numeric release tag' "$work/bad-tag.out" ||
+  fail "build helper must reject describe-shaped tags"
+
+repo_multi="$work/multi"
+init_repo "$repo_multi"
+git -C "$repo_multi" tag -a v1.8.73 -m v1.8.73
+git -C "$repo_multi" tag -a v1.8.74 -m v1.8.74
+if run_deploy_helper "$repo_multi" >"$work/multi.out" 2>&1; then
+  fail "deploy helper accepted multiple numeric release tags on one commit"
+fi
+grep -qF 'multiple numeric release tags' "$work/multi.out" ||
+  fail "deploy helper must reject ambiguous multiple release tags"
+
+repo_dirty="$work/dirty"
+init_repo "$repo_dirty"
+publish_annotated_tag "$repo_dirty" v1.8.75
+printf '%s\n' dirty > "$repo_dirty/untracked"
+if run_deploy_helper "$repo_dirty" >"$work/dirty.out" 2>&1; then
+  fail "deploy helper accepted a dirty release-tag checkout"
+fi
+grep -qF 'requires a clean release-tag checkout' "$work/dirty.out" ||
+  fail "deploy helper must reject dirty production deploy checkouts"
+
+repo_nested="$work/nested-root"
+init_repo "$repo_nested"
+publish_annotated_tag "$repo_nested" v1.8.76
+mkdir -p "$repo_nested/phase4-coordinator"
+printf '%s\n' root-dirty > "$repo_nested/root-untracked"
+if run_deploy_helper "$repo_nested/phase4-coordinator" >"$work/nested-dirty.out" 2>&1; then
+  fail "deploy helper accepted a dirty repository root when called with the coordinator module"
+fi
+grep -qF 'requires a clean release-tag checkout' "$work/nested-dirty.out" ||
+  fail "deploy helper must reject root-level dirtiness, not only module dirtiness"
+
+(
+  # shellcheck disable=SC1090
+  . "$extract_provenance_helper"
+  if _coordinator_verify_deployed_version '{"version":"v1.8.76"}' v1.8.76 >"$work/provenance-match.out" 2>&1; then
+    grep -qF 'provenance OK' "$work/provenance-match.out" ||
+      fail "matching deployed release must report provenance OK"
+  else
+    fail "matching deployed release was rejected"
+  fi
+  if _coordinator_verify_deployed_version '{"version":"v1.8.75"}' v1.8.76 >"$work/provenance-mismatch.out" 2>&1; then
+    fail "mismatched deployed release was warning-only"
+  fi
+  grep -qF 'aborting deploy: provenance mismatch' "$work/provenance-mismatch.out" ||
+    fail "mismatched deployed release must abort before commit"
+  if _coordinator_verify_deployed_version '{"status":"ok"}' v1.8.76 >"$work/provenance-missing.out" 2>&1; then
+    fail "missing deployed release version was accepted"
+  fi
+  grep -qF 'CRITICAL provenance MISSING' "$work/provenance-missing.out" ||
+    fail "missing deployed release version must abort before commit"
+)
+
+echo "PASS: coordinator release tag guards reject git-describe deploy footguns"

--- a/phase4-coordinator/scripts/build-linux.sh
+++ b/phase4-coordinator/scripts/build-linux.sh
@@ -11,13 +11,77 @@
 #   dist/stats-hardware-verifier-linux-amd64
 #                                      — autotune hardware evidence verifier
 #
+# Production builds must run from exactly one numeric release tag (vX.Y.Z).
+# Set ALLOW_NON_RELEASE_COORDINATOR_BUILD=1 only for local/dev artifacts; that
+# opt-out restores the old git-describe stamp and is not accepted by the Pearl
+# production deploy.
+#
 # Refuses to build with uncommitted changes by default; set FORCE_DIRTY=1
-# to override (the resulting binary's version string will end in "-dirty"
-# via `git describe --dirty` for modified-tracked dirty, or
-# "-dirty-forced" appended below for untracked-only dirty, so the deploy
-# gate can still tell either way).
+# to override only together with ALLOW_NON_RELEASE_COORDINATOR_BUILD=1 (the
+# resulting dev binary's version string will end in "-dirty" via
+# `git describe --dirty` for modified-tracked dirty, or "-dirty-forced"
+# appended below for untracked-only dirty).
 set -euo pipefail
 cd "$(dirname "$0")/.."
+SOURCE_DIR="$(pwd -P)"
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+
+_coordinator_release_tag_version() {
+  local candidates count tag head rows tag_object peeled_count peeled_commit tag_type verify_output remote_url
+  local release_tag_remote="origin"
+  local release_tag_remote_url="https://github.com/Augustas11/macprovider.git"
+  local release_tag_signer_line='Good "git" signature for augstar@gmail.com with ED25519 key SHA256:6DgoKNaOgF5c7NPHTAbNxJ2LT0uuj8U/3zObOOZjRiA'
+  candidates="$(git -C "$REPO_ROOT" tag --points-at HEAD | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' || true)"
+  count="$(printf '%s\n' "$candidates" | sed '/^$/d' | wc -l | tr -d '[:space:]')"
+  case "$count" in
+    1)
+      tag="$candidates"
+      ;;
+    0)
+      echo "refusing production coordinator build: HEAD is not exactly a numeric release tag (vX.Y.Z)" >&2
+      echo "  Build production coordinator artifacts from the signed release tag, not from main or git describe output." >&2
+      echo "  For local/dev artifacts only, set ALLOW_NON_RELEASE_COORDINATOR_BUILD=1." >&2
+      return 1
+      ;;
+    *)
+      echo "refusing production coordinator build: HEAD has multiple numeric release tags:" >&2
+      printf '%s\n' "$candidates" | sed 's/^/  - /' >&2
+      return 1
+      ;;
+  esac
+
+  tag_type="$(git -C "$REPO_ROOT" cat-file -t "$tag" 2>/dev/null || true)"
+  if [ "$tag_type" != tag ]; then
+    echo "refusing production coordinator build: $tag is not an annotated signed release tag" >&2
+    return 1
+  fi
+  if ! verify_output="$(git -C "$REPO_ROOT" verify-tag "$tag" 2>&1)"; then
+    echo "refusing production coordinator build: $tag does not verify as a trusted signed tag" >&2
+    return 1
+  fi
+  if ! printf '%s\n' "$verify_output" | grep -qxF "$release_tag_signer_line"; then
+    echo "refusing production coordinator build: $tag was signed by an unauthorized release signer" >&2
+    return 1
+  fi
+  remote_url="$(git -C "$REPO_ROOT" remote get-url "$release_tag_remote" 2>/dev/null || true)"
+  case "$remote_url" in
+    https://github.com/Augustas11/macprovider.git|git@github.com:Augustas11/macprovider.git|ssh://git@github.com/Augustas11/macprovider.git) ;;
+    *)
+      echo "refusing production coordinator build: $release_tag_remote must point at the canonical Augustas11/macprovider GitHub repository" >&2
+      return 1
+      ;;
+  esac
+  head="$(git -C "$REPO_ROOT" rev-parse HEAD)"
+  rows="$(git -C "$REPO_ROOT" ls-remote "$release_tag_remote_url" "refs/tags/$tag" "refs/tags/$tag^{}")"
+  tag_object="$(printf '%s\n' "$rows" | awk -v ref="refs/tags/$tag" '$2 == ref { print $1 }')"
+  peeled_commit="$(printf '%s\n' "$rows" | awk -v ref="refs/tags/$tag^{}" '$2 == ref { print $1 }')"
+  peeled_count="$(printf '%s\n' "$peeled_commit" | awk 'NF { count++ } END { print count + 0 }')"
+  if [ -z "$tag_object" ] || [ "$peeled_count" != 1 ] || [ "$peeled_commit" != "$head" ]; then
+    echo "refusing production coordinator build: $tag is not the protected remote annotated tag for HEAD on $release_tag_remote" >&2
+    return 1
+  fi
+  printf '%s %s\n' "$tag" "$head"
+}
 
 # `git status --porcelain` catches BOTH modified-tracked AND untracked
 # files (relative to this module's pwd). `git diff --quiet` would miss a
@@ -25,14 +89,35 @@ cd "$(dirname "$0")/.."
 # in a binary whose -ldflags-stamped version still reports "clean" via
 # `git describe` (which also ignores untracked files for its --dirty
 # suffix). See M0-5 Phase 1 follow-up.
-DIRTY_STATE="$(git status --porcelain -- .)"
+DIRTY_STATE="$(git -C "$REPO_ROOT" status --porcelain)"
+if [ -n "${FORCE_DIRTY:-}" ] && [ "${ALLOW_NON_RELEASE_COORDINATOR_BUILD:-0}" != "1" ]; then
+  echo "refusing FORCE_DIRTY for production coordinator build" >&2
+  echo "  FORCE_DIRTY is only allowed with ALLOW_NON_RELEASE_COORDINATOR_BUILD=1 for local/dev artifacts." >&2
+  exit 1
+fi
 if [ -z "${FORCE_DIRTY:-}" ] && [ -n "$DIRTY_STATE" ]; then
   echo "refusing to build with uncommitted or untracked changes (set FORCE_DIRTY=1 to override)" >&2
-  git status --short -- . >&2
+  git -C "$REPO_ROOT" status --short >&2
   exit 1
 fi
 
-VERSION="$(git describe --always --dirty --tags 2>/dev/null || git rev-parse --short HEAD)"
+BUILD_WORK_DIR="$SOURCE_DIR"
+RELEASE_BUILD_INPUT_DIR=""
+COORDINATOR_RELEASE_COMMIT=""
+if [ "${ALLOW_NON_RELEASE_COORDINATOR_BUILD:-0}" = "1" ]; then
+  VERSION="$(git describe --always --dirty --tags 2>/dev/null || git rev-parse --short HEAD)"
+else
+  COORDINATOR_RELEASE_IDENTITY="$(_coordinator_release_tag_version)"
+  VERSION="${COORDINATOR_RELEASE_IDENTITY%% *}"
+  COORDINATOR_RELEASE_COMMIT="${COORDINATOR_RELEASE_IDENTITY#* }"
+  RELEASE_BUILD_INPUT_DIR="$(umask 077 && mktemp -d -t macprovider-release-build.XXXXXXXX)" || {
+    echo "refusing production coordinator build: mktemp failed for verified release input snapshot" >&2
+    exit 1
+  }
+  trap 'rm -rf "${RELEASE_BUILD_INPUT_DIR:-}"' EXIT HUP INT TERM
+  git -C "$REPO_ROOT" archive --format=tar "$COORDINATOR_RELEASE_COMMIT" -- phase4-coordinator | tar -xf - -C "$RELEASE_BUILD_INPUT_DIR"
+  BUILD_WORK_DIR="$RELEASE_BUILD_INPUT_DIR/phase4-coordinator"
+fi
 # `git describe --dirty` only marks modifications to tracked files. If
 # FORCE_DIRTY=1 overrode an UNTRACKED-only dirty state (a brand-new file
 # the operator hasn't `git add`'d yet), the version stamp would otherwise
@@ -46,9 +131,9 @@ if [ -n "${FORCE_DIRTY:-}" ] && [ -n "$DIRTY_STATE" ]; then
   esac
 fi
 
-OUT="dist/coordinator-linux-amd64"
-mkdir -p dist
-GOOS=linux GOARCH=amd64 go build -ldflags "-X main.version=${VERSION}" -o "$OUT" ./cmd/coordinator
+OUT="$SOURCE_DIR/dist/coordinator-linux-amd64"
+mkdir -p "$SOURCE_DIR/dist"
+(cd "$BUILD_WORK_DIR" && GOENV=off GOFLAGS='' GOWORK=off GOOS=linux GOARCH=amd64 go build -ldflags "-X main.version=${VERSION}" -o "$OUT" ./cmd/coordinator)
 echo "built $OUT @ ${VERSION}"
 
 # coordinator-cli ships alongside the daemon so the operator has token
@@ -59,18 +144,18 @@ echo "built $OUT @ ${VERSION}"
 # routine prune-tokens / list-tokens. No version stamp — the CLI has
 # no main.version symbol; the deploy script logs which build it just
 # installed.
-CLI_OUT="dist/coordinator-cli-linux-amd64"
-GOOS=linux GOARCH=amd64 go build -o "$CLI_OUT" ./cmd/coordinator-cli
+CLI_OUT="$SOURCE_DIR/dist/coordinator-cli-linux-amd64"
+(cd "$BUILD_WORK_DIR" && GOENV=off GOFLAGS='' GOWORK=off GOOS=linux GOARCH=amd64 go build -o "$CLI_OUT" ./cmd/coordinator-cli)
 echo "built $CLI_OUT @ ${VERSION}"
 
-INVENTORY_OUT="dist/stats-inventory-sync-linux-amd64"
-GOOS=linux GOARCH=amd64 go build -o "$INVENTORY_OUT" ./cmd/stats-inventory-sync
+INVENTORY_OUT="$SOURCE_DIR/dist/stats-inventory-sync-linux-amd64"
+(cd "$BUILD_WORK_DIR" && GOENV=off GOFLAGS='' GOWORK=off GOOS=linux GOARCH=amd64 go build -o "$INVENTORY_OUT" ./cmd/stats-inventory-sync)
 echo "built $INVENTORY_OUT @ ${VERSION}"
 
-BILLING_MIRROR_OUT="dist/stats-billing-mirror-linux-amd64"
-GOOS=linux GOARCH=amd64 go build -o "$BILLING_MIRROR_OUT" ./cmd/stats-billing-mirror
+BILLING_MIRROR_OUT="$SOURCE_DIR/dist/stats-billing-mirror-linux-amd64"
+(cd "$BUILD_WORK_DIR" && GOENV=off GOFLAGS='' GOWORK=off GOOS=linux GOARCH=amd64 go build -o "$BILLING_MIRROR_OUT" ./cmd/stats-billing-mirror)
 echo "built $BILLING_MIRROR_OUT @ ${VERSION}"
 
-HARDWARE_VERIFIER_OUT="dist/stats-hardware-verifier-linux-amd64"
-GOOS=linux GOARCH=amd64 go build -o "$HARDWARE_VERIFIER_OUT" ./cmd/stats-hardware-verifier
+HARDWARE_VERIFIER_OUT="$SOURCE_DIR/dist/stats-hardware-verifier-linux-amd64"
+(cd "$BUILD_WORK_DIR" && GOENV=off GOFLAGS='' GOWORK=off GOOS=linux GOARCH=amd64 go build -o "$HARDWARE_VERIFIER_OUT" ./cmd/stats-hardware-verifier)
 echo "built $HARDWARE_VERIFIER_OUT @ ${VERSION}"


### PR DESCRIPTION
## Summary

Fixes #820 by making production coordinator build/deploy provenance fail closed on anything except the exact signed release tag.

- Require exactly one annotated `vX.Y.Z` tag at `HEAD`, verified by the authorized release signer and canonical upstream tag target.
- Build production coordinator artifacts from a git archive of the verified release commit, while keeping `ALLOW_NON_RELEASE_COORDINATOR_BUILD=1` for local/dev artifacts.
- Make Pearl deploy preflight the same verified commit, pin tracked deploy inputs from that commit, force GitHub release lookup to `github.com`, and checksum recovery/TCP/main staging before remote mutation.
- Update deploy/runbook docs and add a regression test covering main/ahead-of-tag rejection, unsigned/lightweight/multiple tag rejection, signer spoof rejection, dirty checkout rejection, fatal `/healthz.version` mismatch, and deploy input pinning.

## Validation

- `bash phase4-coordinator/dist/test/coordinator_release_tag_guard.test.sh`
- `shellcheck --severity=warning phase4-coordinator/scripts/build-linux.sh phase4-coordinator/dist/test/coordinator_release_tag_guard.test.sh`
- `bash -n phase4-coordinator/scripts/build-linux.sh phase4-coordinator/dist/deploy-pearl-vps.sh`
- `bash phase4-coordinator/dist/test/check_stats_inventory_deploy_test.sh`
- `bash phase4-coordinator/dist/test/check_stats_billing_mirror_deploy_test.sh`
- `bash phase4-coordinator/dist/test/check_pearl_tcp_test.sh`
- `make vet-coordinator`
- `make test-coordinator`
- `make test-dist`
- `git diff --cached --check`
- 3-lane audits: `CODE AUDIT: 0 C/H/M findings`, `SECURITY AUDIT: 0 C/H/M findings`, `ARCH AUDIT: 0 C/H/M findings`

Not live-tested: Pearl production deploy and real GitHub release download through the deploy wrapper.

SPEC-GOVERNANCE-DECLARATION-BEGIN
{
  "schema_version": "spec-pr-governance-v1",
  "behavior_change": "yes",
  "contract_change": "none",
  "specs": ["SPEC-020"],
  "requirements": ["SPEC-020-R002"],
  "authority_domains": ["provider-autoupdate"],
  "arbitration": ["CODE_BUG"],
  "tests": [
    "phase4-coordinator/dist/test/coordinator_release_tag_guard.test.sh",
    "make test-dist"
  ],
  "journeys": ["not-required"],
  "issue": "https://github.com/Augustas11/macprovider/issues/820"
}
SPEC-GOVERNANCE-DECLARATION-END
