### PR TITLE
Gate stable releases on live provider recommendation

### DIFF
--- a/ops/runbooks/catalog-release-provider-upgrade.md
+++ b/ops/runbooks/catalog-release-provider-upgrade.md
@@ -128,7 +128,11 @@ The same signed network-release manifest also binds:
 - the exact catalog release directory selected as the next `current`; the
   activation transaction derives `previous` from the verified live pointer and
   snapshots it before mutation;
-- coordinator configuration that advertises the same provider version.
+- coordinator configuration that advertises the same provider version. The
+  stable public release gate must prove live
+  `/healthz.recommended_binary_version` equals the provider CLI release before
+  undrafting and moving `latest`; prerelease canaries do not require fleet-wide
+  advertisement.
 
 No generated output is edited independently. CI, packaging, coordinator
 startup, and deploy all verify the same release before accepting it.

--- a/phase4-coordinator/internal/billing/endpoints.go
+++ b/phase4-coordinator/internal/billing/endpoints.go
@@ -573,7 +573,7 @@ SELECT lrc.provider_id,
 			providerIDs = append(providerIDs, providerID)
 		}
 	}
-	diagnosticsFrom, diagnosticsTo := settlementReceiptDiagnosticsWindow(h.store.now().UTC(), time.Time{}, time.Time{}, false)
+	diagnosticsFrom, diagnosticsTo := settlementReceiptDiagnosticsWindow(h.store.nowUTC(), time.Time{}, time.Time{}, false)
 	summaries, err := h.settlementReceiptSummariesForProviders(ctx, providerIDs, diagnosticsFrom, diagnosticsTo, true, 3)
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, "internal_error", err.Error())
@@ -963,7 +963,7 @@ func (h *handler) earnings(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 	resp["idle_prewarm"] = idlePrewarm
-	diagnosticsFrom, diagnosticsTo := settlementReceiptDiagnosticsWindow(h.store.now().UTC(), rangeFrom, rangeTo, hasRange)
+	diagnosticsFrom, diagnosticsTo := settlementReceiptDiagnosticsWindow(h.store.nowUTC(), rangeFrom, rangeTo, hasRange)
 	summaries, err := h.settlementReceiptSummariesForProviders(r.Context(), []string{providerID}, diagnosticsFrom, diagnosticsTo, true, 5)
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, "internal_error", err.Error())

--- a/phase4-coordinator/internal/billing/endpoints_test.go
+++ b/phase4-coordinator/internal/billing/endpoints_test.go
@@ -948,6 +948,7 @@ func TestEarningsEndpointIncludesProviderSettlementReceiptReasonCodes(t *testing
 	createSettlementReceiptAuditLog(t, store.db)
 	setSettlementReceiptNow(store, time.UnixMilli(input.ReceiptReceivedUnixMS).UTC().Add(24*time.Hour).UnixMilli())
 	seedSettlementReceiptEvidence(t, store, input)
+	setSettlementReceiptNow(store, input.ReceiptReceivedUnixMS+int64(24*time.Hour/time.Millisecond))
 	insertCredit(t, store.db, input.ProviderID, time.Now().UTC(), 500)
 
 	state, err := store.IngestSettlementReceipt(context.Background(), SettlementReceiptIngestionInput{
@@ -1064,6 +1065,7 @@ func TestProvidersEndpointIncludesRedactedSettlementReceiptDiagnostics(t *testin
 	createSettlementReceiptAuditLog(t, store.db)
 	setSettlementReceiptNow(store, time.UnixMilli(input.ReceiptReceivedUnixMS).UTC().Add(24*time.Hour).UnixMilli())
 	seedSettlementReceiptEvidence(t, store, input)
+	setSettlementReceiptNow(store, input.ReceiptReceivedUnixMS+int64(24*time.Hour/time.Millisecond))
 	insertCredit(t, store.db, input.ProviderID, time.Now().UTC(), 500)
 
 	if _, err := store.IngestSettlementReceipt(context.Background(), SettlementReceiptIngestionInput{

--- a/phase4-coordinator/internal/stats/handlers_integration_test.go
+++ b/phase4-coordinator/internal/stats/handlers_integration_test.go
@@ -1447,8 +1447,9 @@ func TestTrustedUntrustedXFF(t *testing.T) {
 	reader := readerPool(t, fx)
 
 	// Untrusted-proxy case: limiter keys on r.RemoteAddr,
-	// ignoring rotated XFF. After 300 invalid-bearer requests
-	// from the same r.RemoteAddr, request 301 returns 429.
+	// ignoring rotated XFF. Send enough invalid-bearer requests
+	// that one fixed-window minute rollover cannot split the
+	// sample below the 300 rpm auth-failure cap in both windows.
 	muxUntrusted := stats.NewMux(
 		store.New(reader),
 		stats.CORSConfig{AccessControlMaxAgeSeconds: 60},
@@ -1460,7 +1461,7 @@ func TestTrustedUntrustedXFF(t *testing.T) {
 	hdr := http.Header{}
 	hdr.Set("Authorization", "Bearer mpk_invalid_xff")
 	var rate429 int
-	for i := 0; i < 350; i++ {
+	for i := 0; i < 650; i++ {
 		req := httptest.NewRequest(http.MethodGet, "/v1/stats/leaderboard", nil)
 		req.Header.Set("Authorization", "Bearer mpk_invalid_xff")
 		// Rotate XFF; the untrusted limiter ignores it.

--- a/scripts/production_exceptions.py
+++ b/scripts/production_exceptions.py
@@ -681,7 +681,11 @@ def check_expiry_self_extension(
             )
 
 
-def validate_stale_register(doc: dict[str, Any], result: ValidationResult) -> None:
+def validate_stale_register(
+    doc: dict[str, Any],
+    result: ValidationResult,
+    now: datetime | None = None,
+) -> None:
     """Structural validation for a stale/backup register before sync simulation.
 
     Historical mode: do not require tombstones for removed rows (stale may
@@ -692,7 +696,17 @@ def validate_stale_register(doc: dict[str, Any], result: ValidationResult) -> No
         return
     # Full structural validation, then drop historical-only missing_tombstone
     # findings that cannot apply to pre-tombstone backups.
-    historical = validate_register(doc, tombstones={"schema_version": TOMBSTONE_SCHEMA_VERSION, "updated_at": "1970-01-01T00:00:00Z", "updated_by": "historical", "environment": ENVIRONMENT, "tombstones": []})
+    historical = validate_register(
+        doc,
+        now=now,
+        tombstones={
+            "schema_version": TOMBSTONE_SCHEMA_VERSION,
+            "updated_at": "1970-01-01T00:00:00Z",
+            "updated_by": "historical",
+            "environment": ENVIRONMENT,
+            "tombstones": [],
+        },
+    )
     for finding in historical.findings:
         if finding.code == "missing_tombstone":
             continue
@@ -708,11 +722,12 @@ def simulate_config_sync_restore(
     current_doc: dict[str, Any],
     stale_authoritative_doc: dict[str, Any],
     tombstones: dict[str, Any],
+    now: datetime | None = None,
 ) -> ValidationResult:
     """Model a sync/rollback that re-applies stale authoritative exception rows."""
     result = ValidationResult()
-    result.extend(validate_register(current_doc, tombstones=tombstones))
-    validate_stale_register(stale_authoritative_doc, result)
+    result.extend(validate_register(current_doc, now=now, tombstones=tombstones))
+    validate_stale_register(stale_authoritative_doc, result, now=now)
     if result.errors:
         # Malformed current/stale/tombstones already fail closed; do not pretend OK.
         return result.dedupe()
@@ -1129,10 +1144,11 @@ def cmd_sync_check(args: argparse.Namespace) -> int:
     root = Path(args.root) if args.root else repo_root_from_here()
     current = load_json(Path(args.current))
     stale = load_json(Path(args.stale))
+    now = parse_rfc3339(args.now) if args.now else datetime.now(timezone.utc)
     tombstones = load_json(
         Path(args.tombstones) if args.tombstones else default_tombstone_path(root)
     )
-    result = simulate_config_sync_restore(current, stale, tombstones)
+    result = simulate_config_sync_restore(current, stale, tombstones, now=now)
     for finding in result.findings:
         print(finding.format(), file=sys.stderr if finding.severity == "error" else sys.stdout)
     if result.errors:

--- a/scripts/test-live-coordinator-release-gate.sh
+++ b/scripts/test-live-coordinator-release-gate.sh
@@ -197,6 +197,12 @@ if run_guard "$work/dirty-healthz" >"$work/dirty-healthz.out" 2>&1; then
 fi
 grep -q "/healthz version is not vX.Y.Z or X.Y.Z: 'v1.8.68-dirty'" "$work/dirty-healthz.out"
 
+make_fixture "$work/padded-healthz" v1.8.68 " v1.8.68 "
+if run_guard "$work/padded-healthz" >"$work/padded-healthz.out" 2>&1; then
+  fail "accepted a padded coordinator health version"
+fi
+grep -q "/healthz version is not vX.Y.Z or X.Y.Z: ' v1.8.68 '" "$work/padded-healthz.out"
+
 make_fixture "$work/missing-sig"
 rm "$work/missing-sig/live/v1_rate-card.sig"
 if run_guard "$work/missing-sig" >"$work/missing-sig.out" 2>&1; then
@@ -214,25 +220,56 @@ make_fixture "$work/missing-recommended" v1.8.68 v1.8.68 2026-07-30T12:00:00Z 20
 if run_guard "$work/missing-recommended" >"$work/missing-recommended.out" 2>&1; then
   fail "accepted a live coordinator without recommended_binary_version"
 fi
-grep -q "/healthz missing recommended_binary_version" "$work/missing-recommended.out"
+grep -q '/healthz recommended_binary_version is missing or not a version string' "$work/missing-recommended.out"
 
 make_fixture "$work/malformed-recommended" v1.8.68 v1.8.68 2026-07-30T12:00:00Z 2026-07-30T12:00:00Z streamvc-autotune-static-v4 latest
 if run_guard "$work/malformed-recommended" >"$work/malformed-recommended.out" 2>&1; then
   fail "accepted a malformed recommended_binary_version"
 fi
-grep -q "/healthz recommended_binary_version is not vX.Y.Z or X.Y.Z: 'latest'" "$work/malformed-recommended.out"
+grep -q "/healthz recommended_binary_version is not X.Y.Z: 'latest'" "$work/malformed-recommended.out"
 
 make_fixture "$work/suffixed-recommended" v1.8.68 v1.8.68 2026-07-30T12:00:00Z 2026-07-30T12:00:00Z streamvc-autotune-static-v4 1.8.68-2-gabcdef0
 if run_guard "$work/suffixed-recommended" >"$work/suffixed-recommended.out" 2>&1; then
   fail "accepted a git-describe recommended_binary_version"
 fi
-grep -q "/healthz recommended_binary_version is not vX.Y.Z or X.Y.Z: '1.8.68-2-gabcdef0'" "$work/suffixed-recommended.out"
+grep -q "/healthz recommended_binary_version is not X.Y.Z: '1.8.68-2-gabcdef0'" "$work/suffixed-recommended.out"
 
-make_fixture "$work/lagging-recommended" v1.8.68 v1.8.68 2026-07-30T12:00:00Z 2026-07-30T12:00:00Z streamvc-autotune-static-v4 1.8.67
-if run_guard "$work/lagging-recommended" >"$work/lagging-recommended.out" 2>&1; then
-  fail "accepted a live coordinator advertising a stale recommended_binary_version"
+make_fixture "$work/zero-padded-tag" v01.8.68 v1.8.68
+if python3 "$guard" \
+  --tag v01.8.68 \
+  --pearl-release-json "$work/zero-padded-tag/pearl-release.json" \
+  --trusted-keys "$work/zero-padded-tag/trusted-keys.json" \
+  --coordinator-url https://coordinator.fixture.invalid \
+  --coordinator-dir "$work/zero-padded-tag/live" \
+  --now 2026-07-30T12:05:00Z \
+  >"$work/zero-padded-tag.out" 2>&1; then
+  fail "accepted a zero-padded release tag"
 fi
-grep -q "/healthz recommended_binary_version '1.8.67' does not match release 1.8.68" "$work/lagging-recommended.out"
+grep -q -- '--tag must be vX.Y.Z' "$work/zero-padded-tag.out"
+
+make_fixture "$work/stale-recommended" v1.8.68 v1.8.68 2026-07-30T12:00:00Z 2026-07-30T12:00:00Z streamvc-autotune-static-v4 1.8.67
+if run_guard "$work/stale-recommended" >"$work/stale-recommended.out" 2>&1; then
+  fail "accepted a live coordinator recommending an older CLI than the release"
+fi
+grep -q "/healthz recommended_binary_version '1.8.67' does not match release 1.8.68" "$work/stale-recommended.out"
+
+make_fixture "$work/padded-recommended" v1.8.68 v1.8.68 2026-07-30T12:00:00Z 2026-07-30T12:00:00Z streamvc-autotune-static-v4 " 1.8.68 "
+if run_guard "$work/padded-recommended" >"$work/padded-recommended.out" 2>&1; then
+  fail "accepted a live coordinator with padded recommended_binary_version"
+fi
+grep -q "/healthz recommended_binary_version is not X.Y.Z: ' 1.8.68 '" "$work/padded-recommended.out"
+
+make_fixture "$work/zero-padded-recommended" v1.8.68 v1.8.68 2026-07-30T12:00:00Z 2026-07-30T12:00:00Z streamvc-autotune-static-v4 01.8.68
+if run_guard "$work/zero-padded-recommended" >"$work/zero-padded-recommended.out" 2>&1; then
+  fail "accepted a live coordinator with zero-padded recommended_binary_version"
+fi
+grep -q "/healthz recommended_binary_version is not X.Y.Z: '01.8.68'" "$work/zero-padded-recommended.out"
+
+make_fixture "$work/future-recommended" v1.8.68 v1.8.68 2026-07-30T12:00:00Z 2026-07-30T12:00:00Z streamvc-autotune-static-v4 1.8.69
+if run_guard "$work/future-recommended" >"$work/future-recommended.out" 2>&1; then
+  fail "accepted a live coordinator recommending a different CLI than the release"
+fi
+grep -q "/healthz recommended_binary_version '1.8.69' does not match release 1.8.68" "$work/future-recommended.out"
 
 make_fixture "$work/hash-drift"
 printf '\n' >> "$work/hash-drift/live/v1_rate-card"

--- a/scripts/test-production-exceptions.sh
+++ b/scripts/test-production-exceptions.sh
@@ -418,7 +418,9 @@ tombs = {
 (work / "stale.json").write_text(json.dumps(active))
 (work / "tombs.json").write_text(json.dumps(tombs))
 PY
-if python3 scripts/check-production-exceptions.py sync-check \
+if python3 scripts/check-production-exceptions.py \
+  --now 2026-07-22T12:00:00Z \
+  sync-check \
   --current "$work/current.json" \
   --stale "$work/stale.json" \
   --tombstones "$work/tombs.json"; then

--- a/scripts/tests/test_production_exceptions.py
+++ b/scripts/tests/test_production_exceptions.py
@@ -208,7 +208,7 @@ class ProductionExceptionsTests(unittest.TestCase):
                 }
             ]
         )
-        result = pe.simulate_config_sync_restore(current, stale, tombstones)
+        result = pe.simulate_config_sync_restore(current, stale, tombstones, now=NOW)
         self.assertTrue(any(f.code == "resurrection" for f in result.errors))
 
     def test_health_report_allowlists_and_omits_free_prose(self):
@@ -377,7 +377,7 @@ class ProductionExceptionsTests(unittest.TestCase):
             ),
         ]
         for stale, expect_prefix in cases:
-            result = pe.simulate_config_sync_restore(current, stale, _tombstones())
+            result = pe.simulate_config_sync_restore(current, stale, _tombstones(), now=NOW)
             self.assertTrue(
                 any(f.code.startswith(expect_prefix) for f in result.errors),
                 msg=f"expected {expect_prefix} in {[f.code for f in result.errors]} for {stale!r}",
@@ -485,7 +485,7 @@ class ProductionExceptionsTests(unittest.TestCase):
     def test_sync_check_fails_on_malformed_stale(self):
         current = _minimal_register()
         stale = {"schema_version": "wrong", "environment": "nope", "exceptions": {}}
-        result = pe.simulate_config_sync_restore(current, stale, _tombstones())
+        result = pe.simulate_config_sync_restore(current, stale, _tombstones(), now=NOW)
         self.assertTrue(any(f.code.startswith("stale_") for f in result.errors))
 
     def test_cli_gate_report_and_sync_roundtrip(self):
@@ -534,6 +534,8 @@ class ProductionExceptionsTests(unittest.TestCase):
                 [
                     "--tombstones",
                     str(tombs),
+                    "--now",
+                    "2026-07-22T12:00:00Z",
                     "sync-check",
                     "--current",
                     str(register),
@@ -545,6 +547,8 @@ class ProductionExceptionsTests(unittest.TestCase):
             # Documented form with --tombstones after subcommand also works.
             rc_sync2 = pe.main(
                 [
+                    "--now",
+                    "2026-07-22T12:00:00Z",
                     "sync-check",
                     "--current",
                     str(register),
@@ -585,6 +589,8 @@ class ProductionExceptionsTests(unittest.TestCase):
                 [
                     "--tombstones",
                     str(tmp_path / "tombs.json"),
+                    "--now",
+                    "2026-07-22T12:00:00Z",
                     "sync-check",
                     "--current",
                     str(tmp_path / "current.json"),
@@ -597,6 +603,8 @@ class ProductionExceptionsTests(unittest.TestCase):
                 [
                     "--tombstones",
                     str(tmp_path / "empty.json"),
+                    "--now",
+                    "2026-07-22T12:00:00Z",
                     "sync-check",
                     "--current",
                     str(tmp_path / "current.json"),

--- a/scripts/verify-live-coordinator-release-gate.py
+++ b/scripts/verify-live-coordinator-release-gate.py
@@ -26,9 +26,15 @@ PRIMARY_FEEDS = ("autotune-candidates.json", "demand-rank.json", "rate-card.json
 SIG_FEEDS = ("autotune-candidates.json.sig", "demand-rank.json.sig", "rate-card.json.sig")
 RELEASE_CATALOG_FILES = tuple(FEEDS) + ("trusted-keys.json",)
 SHA256_RE = re.compile(r"^[0-9a-f]{64}$")
-TAG_RE = re.compile(r"^v([0-9]+)\.([0-9]+)\.([0-9]+)$")
-VERSION_RE = re.compile(r"^v?([0-9]+)\.([0-9]+)\.([0-9]+)(?:-[0-9]+-g[0-9a-f]{7,40})?$")
-RECOMMENDED_VERSION_RE = re.compile(r"^[vV]?([0-9]+)\.([0-9]+)\.([0-9]+)$")
+VERSION_COMPONENT = r"(0|[1-9][0-9]*)"
+TAG_RE = re.compile(rf"^v{VERSION_COMPONENT}\.{VERSION_COMPONENT}\.{VERSION_COMPONENT}$")
+VERSION_RE = re.compile(
+    rf"^v?{VERSION_COMPONENT}\.{VERSION_COMPONENT}\.{VERSION_COMPONENT}"
+    r"(?:-[0-9]+-g[0-9a-f]{7,40})?$"
+)
+ADVERTISED_VERSION_RE = re.compile(
+    rf"^{VERSION_COMPONENT}\.{VERSION_COMPONENT}\.{VERSION_COMPONENT}$"
+)
 ED25519_SPKI_DER_PREFIX = bytes.fromhex("302a300506032b6570032100")
 TRUSTED_KEY_STATUSES = {"active", "bridge"}
 FUTURE_TOLERANCE = datetime.timedelta(minutes=10)
@@ -58,18 +64,18 @@ def read_json(path: pathlib.Path, label: str) -> object:
 def parse_semver(value: object, label: str) -> tuple[int, int, int]:
     if not isinstance(value, str):
         fail(f"{label} is not a version string")
-    match = VERSION_RE.fullmatch(value.strip())
+    match = VERSION_RE.fullmatch(value)
     if match is None:
         fail(f"{label} is not vX.Y.Z or X.Y.Z: {value!r}")
     return tuple(int(part) for part in match.groups())
 
 
-def parse_recommended_semver(value: object, label: str) -> tuple[int, int, int]:
+def parse_advertised_version(value: object, label: str) -> tuple[int, int, int]:
     if not isinstance(value, str):
-        fail(f"{label} is not a version string")
-    match = RECOMMENDED_VERSION_RE.fullmatch(value.strip())
+        fail(f"{label} is missing or not a version string")
+    match = ADVERTISED_VERSION_RE.fullmatch(value)
     if match is None:
-        fail(f"{label} is not vX.Y.Z or X.Y.Z: {value!r}")
+        fail(f"{label} is not X.Y.Z: {value!r}")
     return tuple(int(part) for part in match.groups())
 
 
@@ -379,17 +385,15 @@ def main() -> int:
                 f"/healthz version {healthz.get('version')!r} is older than "
                 f"release {expected_version}"
             )
-        if "recommended_binary_version" not in healthz:
-            fail("/healthz missing recommended_binary_version")
-        recommended_version = parse_recommended_semver(
-            healthz.get("recommended_binary_version"),
+        recommended_value = healthz.get("recommended_binary_version")
+        recommended_version = parse_advertised_version(
+            recommended_value,
             "/healthz recommended_binary_version",
         )
-        if recommended_version != required_version:
+        if recommended_version != required_version or recommended_value != expected_version:
             fail(
-                f"/healthz recommended_binary_version "
-                f"{healthz.get('recommended_binary_version')!r} does not match "
-                f"release {expected_version}"
+                f"/healthz recommended_binary_version {recommended_value!r} "
+                f"does not match release {expected_version}"
             )
 
         print(
@@ -397,7 +401,7 @@ def main() -> int:
             f"{args.coordinator_url.rstrip('/')} serves {args.tag} feed set "
             f"generated_at={generated_at} policy_version={policy_version} "
             f"healthz_version={healthz.get('version')} "
-            f"recommended_binary_version={healthz.get('recommended_binary_version')}"
+            f"recommended_binary_version={recommended_value}"
         )
         return 0
     except GateError as exc:


### PR DESCRIPTION
## Summary

Fixes #823. Refs #825.

This tightens the stable live coordinator release gate so a provider CLI release cannot be published as public/latest unless production Pearl proves both sides of the contract:

- live catalog feed bytes and signatures match the release-bound `pearl-release.json`
- live `/healthz.version` is canonical and not older than the release
- live `/healthz.recommended_binary_version` is exact, canonical `X.Y.Z`, and byte-matches the provider CLI release

The runbook now documents that this is a stable public/latest gate; prerelease canaries do not require fleet-wide advertisement.

This also fixes date-bound/stability failures found while validating the PR:

- production-exception sync-check tests now pass the existing `--now` fixture clock through sync simulation paths
- settlement receipt diagnostics windows now use the billing store clock, allowing endpoint fixtures to pin time without changing payout accounting or redaction behavior
- stats XFF limiter integration coverage now sends enough fixed-remote invalid auth requests to survive one fixed-window minute rollover without changing production limiter behavior

## Validation

- `bash scripts/test-live-coordinator-release-gate.sh`
- `python3 -m py_compile scripts/verify-live-coordinator-release-gate.py scripts/production_exceptions.py scripts/tests/test_production_exceptions.py`
- `bash -n scripts/test-live-coordinator-release-gate.sh scripts/test-production-exceptions.sh`
- `shellcheck scripts/test-live-coordinator-release-gate.sh`
- `shellcheck --severity=warning scripts/test-production-exceptions.sh scripts/test-live-coordinator-release-gate.sh`
- `bash scripts/test-production-exceptions.sh`
- `python3 -m unittest -v scripts.tests.test_production_exceptions`
- `bash scripts/test-coordinator-advertised-version-test.sh`
- `bash scripts/test-acceptance-promotion.sh`
- `bash scripts/test-release-security-posture.sh`
- `go test ./internal/billing -run 'TestEarningsEndpointIncludesProviderSettlementReceiptReasonCodes|TestProvidersEndpointIncludesRedactedSettlementReceiptDiagnostics'` from `phase4-coordinator`
- `go test ./internal/ws -run 'TestProviderHealthzReportsInjectedVersion|TestProviderHealthzPublishesRequiredBinaryVersion|TestProviderHealthzOmitsUnsetRequiredBinaryVersion'` from `phase4-coordinator`
- `go test -tags=integration -timeout 10m ./internal/stats -run '^TestTrustedUntrustedXFF$' -count=1 -v` from `phase4-coordinator` (compiled; skipped locally because rootless Docker is unavailable)
- `make test-coordinator`
- `make test-dist`
- `git diff --check origin/main...HEAD`
- Code/security/architect R4 audits on the full nine-file diff: 0 C/H/M
- GitHub CI on `a589ef0f`: all required checks green, including `ci-required`

## Not Tested

- Live Pearl deployment.

SPEC-GOVERNANCE-DECLARATION-BEGIN
{
  "schema_version": "spec-pr-governance-v1",
  "behavior_change": "yes",
  "contract_change": "none",
  "issue": "https://github.com/Augustas11/macprovider/issues/825",
  "specs": ["SPEC-023"],
  "requirements": ["SPEC-023-R001", "SPEC-023-R002"],
  "authority_domains": ["installer-autotune-policy", "model-catalog-identity"],
  "arbitration": ["UNKNOWN"],
  "tests": [
    "bash scripts/test-live-coordinator-release-gate.sh",
    "python3 -m py_compile scripts/verify-live-coordinator-release-gate.py scripts/production_exceptions.py scripts/tests/test_production_exceptions.py",
    "bash -n scripts/test-live-coordinator-release-gate.sh scripts/test-production-exceptions.sh",
    "shellcheck scripts/test-live-coordinator-release-gate.sh",
    "shellcheck --severity=warning scripts/test-production-exceptions.sh scripts/test-live-coordinator-release-gate.sh",
    "bash scripts/test-production-exceptions.sh",
    "python3 -m unittest -v scripts.tests.test_production_exceptions",
    "bash scripts/test-coordinator-advertised-version-test.sh",
    "bash scripts/test-acceptance-promotion.sh",
    "bash scripts/test-release-security-posture.sh",
    "go test ./internal/billing -run 'TestEarningsEndpointIncludesProviderSettlementReceiptReasonCodes|TestProvidersEndpointIncludesRedactedSettlementReceiptDiagnostics'",
    "go test ./internal/ws -run 'TestProviderHealthzReportsInjectedVersion|TestProviderHealthzPublishesRequiredBinaryVersion|TestProviderHealthzOmitsUnsetRequiredBinaryVersion'",
    "go test -tags=integration -timeout 10m ./internal/stats -run '^TestTrustedUntrustedXFF$' -count=1 -v",
    "make test-coordinator",
    "make test-dist",
    "git diff --check origin/main...HEAD"
  ],
  "journeys": ["not-required"]
}
SPEC-GOVERNANCE-DECLARATION-END