### PR TITLE
fix(ci): repair Aug-1 date-rot in billing + production-exceptions tests (repo-wide CI outage)

### DIFF
--- a/phase4-coordinator/internal/billing/endpoints_test.go
+++ b/phase4-coordinator/internal/billing/endpoints_test.go
@@ -1002,6 +1002,11 @@ func TestEarningsEndpointIncludesProviderSettlementReceiptReasonCodes(t *testing
 		t.Fatalf("zero settlement state=%#v, want valid zero_settled", zeroState)
 	}
 
+	// The fixture stamps receipts at a fixed ~2026-07-01 terminal_state_ts; the
+	// default diagnostics window is a rolling 31 days, so re-stamp the seeded
+	// verdicts to now (receipts are recent relative to an earnings query) to keep
+	// this assertion from drifting out of the window over calendar time.
+	restampSettlementVerdictsToNow(t, store)
 	req := httptest.NewRequest(http.MethodGet, "/providers/"+input.ProviderID+"/earnings", nil)
 	req.Header.Set("Authorization", "Bearer good")
 	w := httptest.NewRecorder()
@@ -1078,6 +1083,10 @@ func TestProvidersEndpointIncludesRedactedSettlementReceiptDiagnostics(t *testin
 		t.Fatal(err)
 	}
 
+	// The /admin/ledger/providers diagnostics window is a fixed rolling 31 days
+	// (not range-parameterized), so re-stamp the seeded verdicts to now to keep
+	// this assertion from drifting out of the window over calendar time.
+	restampSettlementVerdictsToNow(t, store)
 	req := httptest.NewRequest(http.MethodGet, "/admin/ledger/providers", nil)
 	req.Header.Set("Authorization", "Bearer operator")
 	w := httptest.NewRecorder()

--- a/phase4-coordinator/internal/billing/settlement_receipts_test.go
+++ b/phase4-coordinator/internal/billing/settlement_receipts_test.go
@@ -712,17 +712,22 @@ WHERE account_scope = ? AND request_id = ? AND attempt_n = ? AND provider_id = ?
 }
 
 // restampSettlementVerdictsToNow moves every seeded settlement_receipt_verdicts
-// row's received_at_unix_ms to the current time. Fixtures carry a fixed
-// terminal_state_ts (~2026-07-01), but the earnings/providers diagnostics
-// summaries filter on a rolling ~31-day window, so a fixed fixture timestamp
-// drifts out of range as calendar time advances. The verdict outcome (which the
-// summary counts) is unchanged; only the window-membership timestamp is updated.
+// row's received_at_unix_ms to just inside the rolling diagnostics window.
+// Fixtures carry a fixed terminal_state_ts (~2026-07-01), but the
+// earnings/providers diagnostics summaries filter on a rolling ~31-day window
+// ending at now, so a fixed fixture timestamp drifts out of range as calendar
+// time advances. Stamping one hour before now (not exactly now) keeps the row
+// strictly inside [now-31d, now) regardless of the test runner's wall clock —
+// stamping exactly at now lands on the window's exclusive upper bound and is
+// dropped. Only the window-membership timestamp changes; verdict outcome (which
+// the summary counts) is untouched.
 func restampSettlementVerdictsToNow(t *testing.T, store *Store) {
 	t.Helper()
+	within := time.Now().UTC().Add(-time.Hour).UnixMilli()
 	if _, err := store.db.ExecContext(
 		context.Background(),
 		"UPDATE settlement_receipt_verdicts SET received_at_unix_ms = ?",
-		time.Now().UTC().UnixMilli(),
+		within,
 	); err != nil {
 		t.Fatal(err)
 	}

--- a/phase4-coordinator/internal/billing/settlement_receipts_test.go
+++ b/phase4-coordinator/internal/billing/settlement_receipts_test.go
@@ -711,6 +711,23 @@ WHERE account_scope = ? AND request_id = ? AND attempt_n = ? AND provider_id = ?
 	}
 }
 
+// restampSettlementVerdictsToNow moves every seeded settlement_receipt_verdicts
+// row's received_at_unix_ms to the current time. Fixtures carry a fixed
+// terminal_state_ts (~2026-07-01), but the earnings/providers diagnostics
+// summaries filter on a rolling ~31-day window, so a fixed fixture timestamp
+// drifts out of range as calendar time advances. The verdict outcome (which the
+// summary counts) is unchanged; only the window-membership timestamp is updated.
+func restampSettlementVerdictsToNow(t *testing.T, store *Store) {
+	t.Helper()
+	if _, err := store.db.ExecContext(
+		context.Background(),
+		"UPDATE settlement_receipt_verdicts SET received_at_unix_ms = ?",
+		time.Now().UTC().UnixMilli(),
+	); err != nil {
+		t.Fatal(err)
+	}
+}
+
 func seedSettlementReceiptEvidence(t *testing.T, store *Store, input SettlementVerifyInput) {
 	t.Helper()
 	routeDigest, err := store.InsertRouteSnapshot(context.Background(), input.RouteSnapshot)

--- a/scripts/production_exceptions.py
+++ b/scripts/production_exceptions.py
@@ -681,7 +681,7 @@ def check_expiry_self_extension(
             )
 
 
-def validate_stale_register(doc: dict[str, Any], result: ValidationResult) -> None:
+def validate_stale_register(doc: dict[str, Any], result: ValidationResult, now: datetime | None = None) -> None:
     """Structural validation for a stale/backup register before sync simulation.
 
     Historical mode: do not require tombstones for removed rows (stale may
@@ -692,7 +692,7 @@ def validate_stale_register(doc: dict[str, Any], result: ValidationResult) -> No
         return
     # Full structural validation, then drop historical-only missing_tombstone
     # findings that cannot apply to pre-tombstone backups.
-    historical = validate_register(doc, tombstones={"schema_version": TOMBSTONE_SCHEMA_VERSION, "updated_at": "1970-01-01T00:00:00Z", "updated_by": "historical", "environment": ENVIRONMENT, "tombstones": []})
+    historical = validate_register(doc, tombstones={"schema_version": TOMBSTONE_SCHEMA_VERSION, "updated_at": "1970-01-01T00:00:00Z", "updated_by": "historical", "environment": ENVIRONMENT, "tombstones": []}, now=now)
     for finding in historical.findings:
         if finding.code == "missing_tombstone":
             continue
@@ -708,11 +708,13 @@ def simulate_config_sync_restore(
     current_doc: dict[str, Any],
     stale_authoritative_doc: dict[str, Any],
     tombstones: dict[str, Any],
+    now: datetime | None = None,
 ) -> ValidationResult:
     """Model a sync/rollback that re-applies stale authoritative exception rows."""
+    now = now or datetime.now(timezone.utc)
     result = ValidationResult()
-    result.extend(validate_register(current_doc, tombstones=tombstones))
-    validate_stale_register(stale_authoritative_doc, result)
+    result.extend(validate_register(current_doc, tombstones=tombstones, now=now))
+    validate_stale_register(stale_authoritative_doc, result, now=now)
     if result.errors:
         # Malformed current/stale/tombstones already fail closed; do not pretend OK.
         return result.dedupe()
@@ -1132,7 +1134,8 @@ def cmd_sync_check(args: argparse.Namespace) -> int:
     tombstones = load_json(
         Path(args.tombstones) if args.tombstones else default_tombstone_path(root)
     )
-    result = simulate_config_sync_restore(current, stale, tombstones)
+    now = parse_rfc3339(args.now) if args.now else datetime.now(timezone.utc)
+    result = simulate_config_sync_restore(current, stale, tombstones, now=now)
     for finding in result.findings:
         print(finding.format(), file=sys.stderr if finding.severity == "error" else sys.stdout)
     if result.errors:

--- a/scripts/tests/test_production_exceptions.py
+++ b/scripts/tests/test_production_exceptions.py
@@ -201,7 +201,7 @@ class ProductionExceptionsTests(unittest.TestCase):
                 }
             ]
         )
-        result = pe.simulate_config_sync_restore(current, stale, tombstones)
+        result = pe.simulate_config_sync_restore(current, stale, tombstones, now=NOW)
         self.assertTrue(any(f.code == "resurrection" for f in result.errors))
 
     def test_health_report_allowlists_and_omits_free_prose(self):
@@ -527,6 +527,8 @@ class ProductionExceptionsTests(unittest.TestCase):
                 [
                     "--tombstones",
                     str(tombs),
+                    "--now",
+                    "2026-07-22T12:00:00Z",
                     "sync-check",
                     "--current",
                     str(register),
@@ -538,6 +540,8 @@ class ProductionExceptionsTests(unittest.TestCase):
             # Documented form with --tombstones after subcommand also works.
             rc_sync2 = pe.main(
                 [
+                    "--now",
+                    "2026-07-22T12:00:00Z",
                     "sync-check",
                     "--current",
                     str(register),


### PR DESCRIPTION
## What

Repairs a **repo-wide CI outage** that began at the **2026-08-01 UTC rollover**. `main` was green at 18:20Z July 31 and went red at Aug 1 — via two pre-existing, date-dependent **test** bugs (no product defect). This blocks every open PR, so it should merge first.

## Root causes (both date-rot in tests)

1. **`internal/billing` settlement-receipt endpoint tests** — fixtures stamp receipts at a fixed `terminal_state_ts` (~2026-07-01), but the earnings/`/admin/ledger/providers` diagnostics summaries filter on a **rolling ~31-day window**. On Aug 1 the window's lower bound (`now-31d` ≈ Jul 1 **04:31**) advanced past the fixture receipts (Jul 1 **00:00**) → all counts dropped to 0. Fix: `restampSettlementVerdictsToNow` moves seeded verdict rows' `received_at_unix_ms` to now (outcome unchanged; only the window-membership timestamp), making the assertions calendar-independent. (`/admin/ledger/providers` uses a fixed non-range window, so a query-range fix can't reach it — hence the data-level fix.)

2. **`scripts` production-exceptions** — `simulate_config_sync_restore` / `validate_stale_register` took no clock, so `sync-check` used the **real** wall clock while its fixtures assume the fixed test `NOW` (2026-07-22). Threaded an optional `now` through both (default = real now, backward-compatible) and into `cmd_sync_check` via `--now`; pinned the clock in the two affected tests.

## Verification
- `go test ./internal/billing` green; `go vet` clean
- `bash scripts/test-production-exceptions.sh` exits 0; full `test_production_exceptions` unittest suite passes

## Scope
Test-clock/fixture-window only. **No production runtime behavior change**: the one production-code edit (`production_exceptions.py`) adds an optional `now` parameter that defaults to the existing real-now behavior. The production exceptions **register** (`ops/exceptions/*.json`) is untouched.

## CI note
`spec-index / check` is advisory (only `ci-required` + 1 review gate merge). No SPEC requirement governs CI test-clock fixes and there's no runtime behavior change, so there is no honest spec to cite — per repo policy I don't fabricate one.

SPEC-GOVERNANCE-DECLARATION-BEGIN
{
  "schema_version": "spec-pr-governance-v1",
  "behavior_change": "none",
  "contract_change": "none",
  "specs": [],
  "requirements": [],
  "authority_domains": [],
  "arbitration": [],
  "tests": ["phase4-coordinator/internal/billing/endpoints_test.go", "scripts/tests/test_production_exceptions.py"],
  "journeys": ["not-required"]
}
SPEC-GOVERNANCE-DECLARATION-END
