### PR TITLE
Bind Pearl runtime verifier to release source

### DIFF
--- a/.github/workflows/pearl-runtime-release.yml
+++ b/.github/workflows/pearl-runtime-release.yml
@@ -117,7 +117,8 @@ jobs:
           strings gateway-linux-amd64 > gateway-linux-amd64.strings
           grep -Fq "$tag" coordinator-linux-amd64.strings
           grep -Fq "$tag" gateway-linux-amd64.strings
-          python3 scripts/verify-pearl-go-binaries.py \
+          EXPECTED_REVISION="${{ steps.release_source.outputs.commit }}" \
+            python3 scripts/verify-pearl-go-binaries.py \
             coordinator-linux-amd64 coordinator-cli-linux-amd64 gateway-linux-amd64
 
       - name: Sign Pearl runtime metadata and checksums

--- a/scripts/test-pearl-runtime-release.sh
+++ b/scripts/test-pearl-runtime-release.sh
@@ -35,6 +35,8 @@ if "make_latest=true" in publish or "true|false) make_latest=false" not in publi
     raise SystemExit("runtime workflow must never make a runtime-only release latest")
 if 'RELEASE_PRERELEASE_INPUT: "true"' not in workflow:
     raise SystemExit("runtime workflow must force GitHub prerelease publication")
+if 'EXPECTED_REVISION="${{ steps.release_source.outputs.commit }}"' not in workflow:
+    raise SystemExit("runtime workflow must bind Pearl Go binary verification to the reviewed commit")
 patch_position = publish.find("gh api --method PATCH")
 if patch_position < 0:
     raise SystemExit("runtime workflow must publish by numeric-ID PATCH")


### PR DESCRIPTION
## Summary
- Pass `steps.release_source.outputs.commit` as `EXPECTED_REVISION` when the Pearl runtime workflow calls `verify-pearl-go-binaries.py`.
- Add a targeted workflow-shape assertion so runtime release publication cannot silently drop the reviewed-commit binding again.

## Why
The protected Pearl runtime workflow for `v1.8.70` failed before publication because the Go binary verifier now requires an explicit reviewed source revision. This preserves the intended provenance gate instead of bypassing it.

## Validation
- `bash scripts/test-pearl-runtime-release.sh`
- `python3 scripts/verify-pearl-go-binaries.py --self-test`
- `git diff --check`

SPEC-GOVERNANCE-DECLARATION-BEGIN
{
  "schema_version": "spec-pr-governance-v1",
  "behavior_change": "yes",
  "contract_change": "none",
  "specs": ["SPEC-020"],
  "requirements": ["SPEC-020-R002"],
  "authority_domains": ["provider-autoupdate"],
  "arbitration": ["CODE_BUG"],
  "tests": [
    "bash scripts/test-pearl-runtime-release.sh",
    "python3 scripts/verify-pearl-go-binaries.py --self-test",
    "git diff --check"
  ],
  "journeys": ["JOURNEY-PROVIDER-AUTOUPDATE-PHYSICAL"],
  "issue": "https://github.com/Augustas11/macprovider/issues/825"
}
SPEC-GOVERNANCE-DECLARATION-END
