### PR TITLE
Keep Pearl runtime builds out of the worktree

### DIFF
--- a/.github/workflows/pearl-runtime-release.yml
+++ b/.github/workflows/pearl-runtime-release.yml
@@ -91,35 +91,46 @@ jobs:
         run: |
           set -euo pipefail
           tag="${{ steps.release_source.outputs.tag }}"
+          artifact_dir="$RUNNER_TEMP/pearl-runtime-build"
+          rm -rf "$artifact_dir"
+          mkdir -p "$artifact_dir"
           (
             cd phase4-coordinator
             GOTOOLCHAIN=local CGO_ENABLED=0 GOOS=linux GOARCH=amd64 \
               go build -mod=readonly -trimpath -buildvcs=true \
               -ldflags "-s -w -X main.version=$tag" \
-              -o "$GITHUB_WORKSPACE/coordinator-linux-amd64" ./cmd/coordinator
+              -o "$artifact_dir/coordinator-linux-amd64" ./cmd/coordinator
             GOTOOLCHAIN=local CGO_ENABLED=0 GOOS=linux GOARCH=amd64 \
               go build -mod=readonly -trimpath -buildvcs=true \
               -ldflags "-s -w" \
-              -o "$GITHUB_WORKSPACE/coordinator-cli-linux-amd64" ./cmd/coordinator-cli
+              -o "$artifact_dir/coordinator-cli-linux-amd64" ./cmd/coordinator-cli
           )
           (
             cd phase5-gateway
             GOTOOLCHAIN=local CGO_ENABLED=0 GOOS=linux GOARCH=amd64 \
               go build -mod=readonly -trimpath -buildvcs=true \
               -ldflags "-s -w -X main.version=$tag" \
-              -o "$GITHUB_WORKSPACE/gateway-linux-amd64" ./cmd/gateway
+              -o "$artifact_dir/gateway-linux-amd64" ./cmd/gateway
           )
-          file coordinator-linux-amd64 coordinator-cli-linux-amd64 gateway-linux-amd64 | tee pearl-file.txt
-          grep -Eq "coordinator-linux-amd64:[[:space:]]+ELF 64-bit.*x86-64" pearl-file.txt
-          grep -Eq "coordinator-cli-linux-amd64:[[:space:]]+ELF 64-bit.*x86-64" pearl-file.txt
-          grep -Eq "gateway-linux-amd64:[[:space:]]+ELF 64-bit.*x86-64" pearl-file.txt
-          strings coordinator-linux-amd64 > coordinator-linux-amd64.strings
-          strings gateway-linux-amd64 > gateway-linux-amd64.strings
-          grep -Fq "$tag" coordinator-linux-amd64.strings
-          grep -Fq "$tag" gateway-linux-amd64.strings
+          file \
+            "$artifact_dir/coordinator-linux-amd64" \
+            "$artifact_dir/coordinator-cli-linux-amd64" \
+            "$artifact_dir/gateway-linux-amd64" | tee "$artifact_dir/pearl-file.txt"
+          grep -Eq "coordinator-linux-amd64:[[:space:]]+ELF 64-bit.*x86-64" "$artifact_dir/pearl-file.txt"
+          grep -Eq "coordinator-cli-linux-amd64:[[:space:]]+ELF 64-bit.*x86-64" "$artifact_dir/pearl-file.txt"
+          grep -Eq "gateway-linux-amd64:[[:space:]]+ELF 64-bit.*x86-64" "$artifact_dir/pearl-file.txt"
+          strings "$artifact_dir/coordinator-linux-amd64" > "$artifact_dir/coordinator-linux-amd64.strings"
+          strings "$artifact_dir/gateway-linux-amd64" > "$artifact_dir/gateway-linux-amd64.strings"
+          grep -Fq "$tag" "$artifact_dir/coordinator-linux-amd64.strings"
+          grep -Fq "$tag" "$artifact_dir/gateway-linux-amd64.strings"
           EXPECTED_REVISION="${{ steps.release_source.outputs.commit }}" \
             python3 scripts/verify-pearl-go-binaries.py \
-            coordinator-linux-amd64 coordinator-cli-linux-amd64 gateway-linux-amd64
+            "$artifact_dir/coordinator-linux-amd64" \
+            "$artifact_dir/coordinator-cli-linux-amd64" \
+            "$artifact_dir/gateway-linux-amd64"
+          install -m 0755 "$artifact_dir/coordinator-linux-amd64" coordinator-linux-amd64
+          install -m 0755 "$artifact_dir/coordinator-cli-linux-amd64" coordinator-cli-linux-amd64
+          install -m 0755 "$artifact_dir/gateway-linux-amd64" gateway-linux-amd64
 
       - name: Sign Pearl runtime metadata and checksums
         id: assets

--- a/scripts/test-pearl-runtime-release.sh
+++ b/scripts/test-pearl-runtime-release.sh
@@ -37,6 +37,19 @@ if 'RELEASE_PRERELEASE_INPUT: "true"' not in workflow:
     raise SystemExit("runtime workflow must force GitHub prerelease publication")
 if 'EXPECTED_REVISION="${{ steps.release_source.outputs.commit }}"' not in workflow:
     raise SystemExit("runtime workflow must bind Pearl Go binary verification to the reviewed commit")
+build = workflow.split("- name: Build Pearl linux-amd64 runtime pair", 1)[1].split(
+    "- name: Sign Pearl runtime metadata and checksums", 1
+)[0]
+if 'artifact_dir="$RUNNER_TEMP/pearl-runtime-build"' not in build:
+    raise SystemExit("runtime workflow must build Pearl Go binaries outside the git worktree")
+if '-o "$GITHUB_WORKSPACE/' in build:
+    raise SystemExit("runtime workflow must not write Go build outputs into the git worktree")
+if 'python3 scripts/verify-pearl-go-binaries.py \\\n            "$artifact_dir/coordinator-linux-amd64" \\\n            "$artifact_dir/coordinator-cli-linux-amd64" \\\n            "$artifact_dir/gateway-linux-amd64"' not in build:
+    raise SystemExit("runtime workflow must verify the out-of-worktree Pearl Go binaries")
+verify_position = build.find("python3 scripts/verify-pearl-go-binaries.py")
+install_position = build.find('install -m 0755 "$artifact_dir/coordinator-linux-amd64" coordinator-linux-amd64')
+if verify_position < 0 or install_position < 0 or install_position < verify_position:
+    raise SystemExit("runtime workflow must copy release assets into the workspace only after binary verification")
 patch_position = publish.find("gh api --method PATCH")
 if patch_position < 0:
     raise SystemExit("runtime workflow must publish by numeric-ID PATCH")


### PR DESCRIPTION
## Summary
- build Pearl runtime Go binaries under `$RUNNER_TEMP` instead of the git checkout
- verify the temp binaries' Go VCS metadata before copying release assets into the workspace
- extend the Pearl runtime release guard test to prevent worktree-output regressions

## Root Cause
The `v1.8.71` Pearl runtime release run failed after PR #856 correctly bound verification to the reviewed commit. The runtime build step wrote binaries into `$GITHUB_WORKSPACE`, making the checkout dirty during subsequent `go build -buildvcs=true` invocations, so the verifier rejected `vcs.modified=true`.

## Validation
- `bash scripts/test-pearl-runtime-release.sh`
- `python3 scripts/verify-pearl-go-binaries.py --self-test`
- `git diff --check`

Local full cross-build was not run because this Mac has Go `1.26.4`; the modules require Go `1.26.5` with `GOTOOLCHAIN=local`. The GitHub runner owns that end-to-end proof.

SPEC-GOVERNANCE-DECLARATION-BEGIN
{
  "schema_version": "spec-pr-governance-v1",
  "behavior_change": "yes",
  "contract_change": "none",
  "specs": ["SPEC-020"],
  "requirements": ["SPEC-020-R002"],
  "authority_domains": ["provider-autoupdate"],
  "arbitration": ["CODE_BUG"],
  "tests": [
    "bash scripts/test-pearl-runtime-release.sh",
    "python3 scripts/verify-pearl-go-binaries.py --self-test",
    "git diff --check"
  ],
  "journeys": ["JOURNEY-PROVIDER-AUTOUPDATE-PHYSICAL"],
  "issue": "https://github.com/Augustas11/macprovider/issues/825"
}
SPEC-GOVERNANCE-DECLARATION-END
