### PR TITLE
Keep Pearl release toolchain snapshots out of VCS builds

### DIFF
--- a/.github/workflows/pearl-runtime-release.yml
+++ b/.github/workflows/pearl-runtime-release.yml
@@ -60,11 +60,14 @@ jobs:
             phase5-gateway/go.sum
 
       - name: Select and verify reviewed release toolchain
+        id: release_toolchain
         shell: bash
         run: |
           set -euo pipefail
           sudo xcode-select -s /Applications/Xcode_16.4.app/Contents/Developer
-          bash scripts/verify-release-toolchain.sh release-toolchain.json
+          toolchain_json="$RUNNER_TEMP/release-toolchain.json"
+          bash scripts/verify-release-toolchain.sh "$toolchain_json"
+          printf 'json=%s\n' "$toolchain_json" >> "$GITHUB_OUTPUT"
 
       - name: Seal OpenSSL 3 for protected runtime signing
         id: protected_openssl
@@ -94,6 +97,12 @@ jobs:
           artifact_dir="$RUNNER_TEMP/pearl-runtime-build"
           rm -rf "$artifact_dir"
           mkdir -p "$artifact_dir"
+          git_status="$(git status --porcelain --untracked-files=all)"
+          if [ -n "$git_status" ]; then
+            echo "::error::runtime checkout is dirty before Pearl Go build" >&2
+            printf '%s\n' "$git_status" >&2
+            exit 1
+          fi
           (
             cd phase4-coordinator
             GOTOOLCHAIN=local CGO_ENABLED=0 GOOS=linux GOARCH=amd64 \
@@ -153,6 +162,7 @@ jobs:
           trap cleanup_release_signing_key EXIT
           printf "%s\n" "$MACPROVIDER_RELEASE_SIGNING_KEY_PEM" > "$release_signing_key"
           chmod 600 "$release_signing_key"
+          install -m 0644 "${{ steps.release_toolchain.outputs.json }}" release-toolchain.json
           coordinator_sha="$(shasum -a 256 coordinator-linux-amd64 | awk '{print $1}')"
           coordinator_cli_sha="$(shasum -a 256 coordinator-cli-linux-amd64 | awk '{print $1}')"
           gateway_sha="$(shasum -a 256 gateway-linux-amd64 | awk '{print $1}')"

--- a/scripts/test-pearl-runtime-release.sh
+++ b/scripts/test-pearl-runtime-release.sh
@@ -37,11 +37,20 @@ if 'RELEASE_PRERELEASE_INPUT: "true"' not in workflow:
     raise SystemExit("runtime workflow must force GitHub prerelease publication")
 if 'EXPECTED_REVISION="${{ steps.release_source.outputs.commit }}"' not in workflow:
     raise SystemExit("runtime workflow must bind Pearl Go binary verification to the reviewed commit")
+before_build = workflow.split("- name: Build Pearl linux-amd64 runtime pair", 1)[0]
+if "id: release_toolchain" not in before_build:
+    raise SystemExit("runtime workflow must expose the reviewed toolchain path as a step output")
+if 'toolchain_json="$RUNNER_TEMP/release-toolchain.json"' not in before_build:
+    raise SystemExit("runtime workflow must keep release-toolchain.json outside the git worktree before Go builds")
+if "scripts/verify-release-toolchain.sh release-toolchain.json" in before_build:
+    raise SystemExit("runtime workflow must not write release-toolchain.json into the git worktree before Go builds")
 build = workflow.split("- name: Build Pearl linux-amd64 runtime pair", 1)[1].split(
     "- name: Sign Pearl runtime metadata and checksums", 1
 )[0]
 if 'artifact_dir="$RUNNER_TEMP/pearl-runtime-build"' not in build:
     raise SystemExit("runtime workflow must build Pearl Go binaries outside the git worktree")
+if "git status --porcelain --untracked-files=all" not in build:
+    raise SystemExit("runtime workflow must fail closed when the checkout is dirty before Go builds")
 if '-o "$GITHUB_WORKSPACE/' in build:
     raise SystemExit("runtime workflow must not write Go build outputs into the git worktree")
 if 'python3 scripts/verify-pearl-go-binaries.py \\\n            "$artifact_dir/coordinator-linux-amd64" \\\n            "$artifact_dir/coordinator-cli-linux-amd64" \\\n            "$artifact_dir/gateway-linux-amd64"' not in build:
@@ -50,6 +59,14 @@ verify_position = build.find("python3 scripts/verify-pearl-go-binaries.py")
 install_position = build.find('install -m 0755 "$artifact_dir/coordinator-linux-amd64" coordinator-linux-amd64')
 if verify_position < 0 or install_position < 0 or install_position < verify_position:
     raise SystemExit("runtime workflow must copy release assets into the workspace only after binary verification")
+sign = workflow.split("- name: Sign Pearl runtime metadata and checksums", 1)[1].split(
+    "- name: Prepare runtime release notes", 1
+)[0]
+toolchain_copy = 'install -m 0644 "${{ steps.release_toolchain.outputs.json }}" release-toolchain.json'
+if toolchain_copy not in sign:
+    raise SystemExit("runtime workflow must copy release-toolchain.json into release assets only after binary verification")
+if sign.find(toolchain_copy) > sign.find("scripts/build-release-provenance.py"):
+    raise SystemExit("runtime workflow must copy release-toolchain.json before building provenance")
 patch_position = publish.find("gh api --method PATCH")
 if patch_position < 0:
     raise SystemExit("runtime workflow must publish by numeric-ID PATCH")


### PR DESCRIPTION
## Summary
- keep the reviewed release-toolchain snapshot in RUNNER_TEMP until Pearl Go binary provenance verification passes
- add a pre-build dirty-check so the runtime workflow fails before producing binaries if the checkout is dirty
- extend the Pearl runtime workflow guard test for this release failure mode

## Validation
- bash scripts/test-pearl-runtime-release.sh
- python3 scripts/verify-pearl-go-binaries.py --self-test
- git diff --check

## Release evidence
- Follow-up for failed v1.8.72 runtime release run 30691413236: verifier still saw vcs.modified=true because release-toolchain.json was written into the checkout before go build.

SPEC-GOVERNANCE-DECLARATION-BEGIN
{
  "schema_version": "spec-pr-governance-v1",
  "behavior_change": "yes",
  "contract_change": "none",
  "specs": ["SPEC-020"],
  "requirements": ["SPEC-020-R002"],
  "authority_domains": ["provider-autoupdate"],
  "arbitration": ["CODE_BUG"],
  "tests": [
    "bash scripts/test-pearl-runtime-release.sh",
    "python3 scripts/verify-pearl-go-binaries.py --self-test",
    "git diff --check"
  ],
  "journeys": ["JOURNEY-PROVIDER-AUTOUPDATE-PHYSICAL"],
  "issue": "https://github.com/Augustas11/macprovider/issues/825"
}
SPEC-GOVERNANCE-DECLARATION-END