### PR TITLE
Fix Pearl canary for duplicate-model protected fleets

### DIFF
--- a/ops/pearl-updater/macprovider-pearl-update
+++ b/ops/pearl-updater/macprovider-pearl-update
@@ -115,8 +115,8 @@ MAX_DOWNLOAD_BYTES = 512 * 1024 * 1024
 MAX_CANDIDATE_OUTPUT_BYTES = 64 * 1024
 MAX_BUYER_PROOF_STREAM_BYTES = 1024 * 1024
 MAX_BUYER_PROOF_STREAM_LINE_BYTES = 64 * 1024
-CANARY_AUTHORITY_VERSION = "issue-585-integration-r7"
-CANARY_AUTHORITY_COMMIT = "43138cee6dd26f18a11934390fc6b3b0623f1e00"
+CANARY_AUTHORITY_VERSION = "issue-825-canary-fleet-r1"
+CANARY_AUTHORITY_COMMIT = "9875d9c6e81fa992a57f5221ff18f4e413cf7fc3"
 CANARY_UNIT_BUDGET_S = 180
 JOURNAL_SCHEMA_VERSION = 1
 CURRENT_RELEASE_SCHEMA_VERSION = 1
@@ -134,11 +134,11 @@ ROLLBACK_STEPS = (
     "canary_timer",
 )
 CANARY_AUTHORITY_FILES = {
-    Path("/opt/macprovider-canary-buyer/probe.mjs"): "73d47710a0a1a33c1f2b474f11a273f555b89d99118b5347be29492baba42a5d",
-    Path("/opt/macprovider-canary-buyer/safety.mjs"): "65c07f1c8e111bc402e5e22f6a1871d66186bb6f618175a8f2aafebfa7ab743c",
+    Path("/opt/macprovider-canary-buyer/probe.mjs"): "e23354b4385d765e3e8af61c5ec4e49e97619a3eef120180b5f5fe175714c3e8",
+    Path("/opt/macprovider-canary-buyer/safety.mjs"): "708aa718faf43ce990e13a5b4ecb51a48f283c6cd1876f71121e309633cbbbbf",
     Path("/opt/macprovider-canary-buyer/run-canary.sh"): "6c5b31fce3b477aed8a85c7a0750e924360ed4828da49ca42ea693482e635585",
     Path("/opt/macprovider-canary-buyer/emergency-disable.sh"): "1380122e76b3b66ad812849e3684b38eaaed0790f0e6011e3f194bd215ab1c7e",
-    Path("/etc/systemd/system/canary-buyer.service"): "fcc5413a717373af4112d2cc62a2eabc9eeb7e48e3a5233b3cc81f4ca3bbfabb",
+    Path("/etc/systemd/system/canary-buyer.service"): "e7f028164d7ca58adaebfb4b1d194016a587dfae78af3f3a0b456ae374efea8a",
     Path("/etc/systemd/system/canary-buyer.timer"): "deb5e3acf67b8d713f61b3167224e908c6754e65e143d84840dba8fea3eb7a18",
 }
 CANARY_AUTHORITY_FILE_MODES = {
@@ -157,8 +157,11 @@ CANARY_EXPECTED_MODELS = frozenset(
     {
         "mlx-community/Qwen3-Coder-30B-A3B-Instruct-4bit",
         "mlx-community/Llama-3.2-3B-Instruct-4bit",
+        "mlx-community/Qwen3-8B-4bit",
     }
 )
+CANARY_MIN_EXPECTED_PROVIDERS = len(CANARY_EXPECTED_MODELS)
+CANARY_MAX_EXPECTED_PROVIDERS = 100
 CANARY_AUTHORITY_PRIVATE_FILES = {
     CANARY_BUYER_TOKEN: "canary buyer token",
     CANARY_HEARTBEAT_URL: "canary heartbeat URL",
@@ -2713,15 +2716,16 @@ class Updater:
             not isinstance(document, dict)
             or document.get("schema_version") != 1
             or not isinstance(providers, list)
-            or len(providers) != 2
+            or len(providers) < CANARY_MIN_EXPECTED_PROVIDERS
+            or len(providers) > CANARY_MAX_EXPECTED_PROVIDERS
             or any(not isinstance(row, dict) for row in providers)
             or any(not isinstance(value, str) or not value for value in provider_ids + model_ids)
-            or len(set(provider_ids)) != 2
-            or len(set(model_ids)) != 2
+            or len(set(provider_ids)) != len(provider_ids)
+            or not set(model_ids).issubset(CANARY_EXPECTED_MODELS)
             or set(model_ids) != CANARY_EXPECTED_MODELS
         ):
             raise UpdateError(
-                "canary expected fleet must bind exactly two unique providers to the pinned service models"
+                "canary expected fleet must bind unique protected providers to the pinned service models"
             )
         return normalized
 

--- a/ops/pearl-updater/test_pearl_updater.py
+++ b/ops/pearl-updater/test_pearl_updater.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import ast
 import grp
+import hashlib
 import importlib.machinery
 import importlib.util
 import io
@@ -3134,6 +3135,10 @@ class PearlUpdaterTests(unittest.TestCase):
                             "provider_id": "provider-b",
                             "model_id": "mlx-community/Llama-3.2-3B-Instruct-4bit",
                         },
+                        {
+                            "provider_id": "provider-c",
+                            "model_id": "mlx-community/Qwen3-8B-4bit",
+                        },
                     ],
                 }
             )
@@ -3236,7 +3241,7 @@ class PearlUpdaterTests(unittest.TestCase):
             with self.assertRaisesRegex(updater_module.UpdateError, "pinned service models"):
                 self.updater.verify_canary_authority()
 
-    def test_canary_rollout_authority_hashes_match_issue_585_integration_runtime(self):
+    def test_canary_rollout_authority_hashes_match_issue_825_duplicate_fleet_runtime(self):
         sources = {
             Path("/opt/macprovider-canary-buyer/probe.mjs"):
                 REPO_ROOT / "test/e2e/canary-buyer/probe.mjs",
@@ -3254,14 +3259,33 @@ class PearlUpdaterTests(unittest.TestCase):
         self.assertEqual(set(updater_module.CANARY_AUTHORITY_FILES), set(sources))
         self.assertEqual(set(updater_module.CANARY_AUTHORITY_FILE_MODES), set(sources))
         for installed, source in sources.items():
+            source_at_authority = subprocess.run(
+                [
+                    "git",
+                    "show",
+                    f"{updater_module.CANARY_AUTHORITY_COMMIT}:{source.relative_to(REPO_ROOT).as_posix()}",
+                ],
+                cwd=REPO_ROOT,
+                check=True,
+                capture_output=True,
+            ).stdout
             self.assertEqual(
                 updater_module.CANARY_AUTHORITY_FILES[installed],
                 updater_module.sha256_file(source),
             )
-        self.assertEqual(updater_module.CANARY_AUTHORITY_VERSION, "issue-585-integration-r7")
+            self.assertEqual(
+                updater_module.CANARY_AUTHORITY_FILES[installed],
+                hashlib.sha256(source_at_authority).hexdigest(),
+            )
+        self.assertEqual(updater_module.CANARY_AUTHORITY_VERSION, "issue-825-canary-fleet-r1")
         self.assertEqual(
             updater_module.CANARY_AUTHORITY_COMMIT,
-            "43138cee6dd26f18a11934390fc6b3b0623f1e00",
+            "9875d9c6e81fa992a57f5221ff18f4e413cf7fc3",
+        )
+        subprocess.run(
+            ["git", "cat-file", "-e", f"{updater_module.CANARY_AUTHORITY_COMMIT}^{{commit}}"],
+            cwd=REPO_ROOT,
+            check=True,
         )
         self.assertEqual(
             updater_module.CANARY_AUTHORITY_FILE_MODES,
@@ -3279,12 +3303,14 @@ class PearlUpdaterTests(unittest.TestCase):
             {
                 "mlx-community/Qwen3-Coder-30B-A3B-Instruct-4bit",
                 "mlx-community/Llama-3.2-3B-Instruct-4bit",
+                "mlx-community/Qwen3-8B-4bit",
             },
         )
         service_models = "Environment=CANARY_MODELS=" + ",".join(
             (
                 "mlx-community/Qwen3-Coder-30B-A3B-Instruct-4bit",
                 "mlx-community/Llama-3.2-3B-Instruct-4bit",
+                "mlx-community/Qwen3-8B-4bit",
             )
         )
         self.assertIn(
@@ -3292,6 +3318,48 @@ class PearlUpdaterTests(unittest.TestCase):
             (REPO_ROOT / "test/e2e/canary-buyer/canary-buyer.service").read_text(),
         )
         self.assertEqual(updater_module.CANARY_UNIT_BUDGET_S, 180)
+
+    def test_canary_expected_fleet_accepts_full_protected_duplicate_model_inventory(self):
+        expected_fleet = self.root / "five-provider-fleet.json"
+        providers = [
+            {
+                "provider_id": "provider-a",
+                "model_id": "mlx-community/Llama-3.2-3B-Instruct-4bit",
+            },
+            {
+                "provider_id": "provider-b",
+                "model_id": "mlx-community/Qwen3-Coder-30B-A3B-Instruct-4bit",
+            },
+            {
+                "provider_id": "provider-c",
+                "model_id": "mlx-community/Qwen3-8B-4bit",
+            },
+            {
+                "provider_id": "provider-d",
+                "model_id": "mlx-community/Llama-3.2-3B-Instruct-4bit",
+            },
+            {
+                "provider_id": "provider-e",
+                "model_id": "mlx-community/Llama-3.2-3B-Instruct-4bit",
+            },
+        ]
+        expected_fleet.write_text(
+            json.dumps({"schema_version": 1, "providers": providers}) + "\n"
+        )
+        expected_fleet.chmod(0o600)
+
+        with mock.patch.object(updater_module, "CANARY_EXPECTED_FLEET", expected_fleet):
+            self.assertEqual(self.updater._canary_expected_fleet(), providers)
+
+        providers[0] = {**providers[0], "model_id": "unexpected-model"}
+        expected_fleet.write_text(
+            json.dumps({"schema_version": 1, "providers": providers}) + "\n"
+        )
+        with (
+            mock.patch.object(updater_module, "CANARY_EXPECTED_FLEET", expected_fleet),
+            self.assertRaisesRegex(updater_module.UpdateError, "pinned service models"),
+        ):
+            self.updater._canary_expected_fleet()
 
     def test_legacy_rollback_authorization_is_exact_and_removed_after_gate(self):
         expected_fleet = self.root / "rollback-expected-fleet.json"
@@ -3304,6 +3372,10 @@ class PearlUpdaterTests(unittest.TestCase):
                 "provider_id": "provider-b",
                 "model_id": "mlx-community/Llama-3.2-3B-Instruct-4bit",
             },
+            {
+                "provider_id": "provider-c",
+                "model_id": "mlx-community/Qwen3-8B-4bit",
+            },
         ]
         expected_fleet.write_text(
             json.dumps({"schema_version": 1, "providers": providers}) + "\n"
@@ -3313,8 +3385,8 @@ class PearlUpdaterTests(unittest.TestCase):
             "macprovider-coordinator.service": True,
             "macprovider-gateway.service": True,
         }
-        self.updater.previous_pool_ready = 2
-        self.updater.previous_protected_providers = ["provider-a", "provider-b"]
+        self.updater.previous_pool_ready = 3
+        self.updater.previous_protected_providers = ["provider-a", "provider-b", "provider-c"]
         self.updater.journal = {
             "transaction_id": "a" * 64,
             "previous_advertised_version": "1.8.30",
@@ -3355,7 +3427,7 @@ class PearlUpdaterTests(unittest.TestCase):
             {
                 "schema_version": 1,
                 "kind": "legacy_rollback",
-                "authority": "issue-585-integration-r7",
+                "authority": "issue-825-canary-fleet-r1",
                 "transaction_id": "a" * 64,
                 "expires_at": observed["document"]["expires_at"],
                 "providers": [
@@ -3375,6 +3447,10 @@ class PearlUpdaterTests(unittest.TestCase):
                 "provider_id": "provider-b",
                 "model_id": "mlx-community/Llama-3.2-3B-Instruct-4bit",
             },
+            {
+                "provider_id": "provider-c",
+                "model_id": "mlx-community/Qwen3-8B-4bit",
+            },
         ]
         expected_fleet.write_text(
             json.dumps({"schema_version": 1, "providers": providers}) + "\n"
@@ -3384,8 +3460,8 @@ class PearlUpdaterTests(unittest.TestCase):
             "macprovider-coordinator.service": True,
             "macprovider-gateway.service": True,
         }
-        self.updater.previous_pool_ready = 2
-        self.updater.previous_protected_providers = ["provider-a", "provider-b"]
+        self.updater.previous_pool_ready = 3
+        self.updater.previous_protected_providers = ["provider-a", "provider-b", "provider-c"]
         self.updater.journal = {
             "transaction_id": "a" * 64,
             "previous_advertised_version": "1.8.30",
@@ -3456,14 +3532,18 @@ class PearlUpdaterTests(unittest.TestCase):
                             "provider_id": "provider-b",
                             "model_id": "mlx-community/Llama-3.2-3B-Instruct-4bit",
                         },
+                        {
+                            "provider_id": "provider-c",
+                            "model_id": "mlx-community/Qwen3-8B-4bit",
+                        },
                     ],
                 }
             )
             + "\n"
         )
         expected_fleet.chmod(0o600)
-        self.updater.previous_pool_ready = 2
-        self.updater.previous_protected_providers = ["provider-a", "provider-b"]
+        self.updater.previous_pool_ready = 3
+        self.updater.previous_protected_providers = ["provider-a", "provider-b", "provider-c"]
         self.updater.journal = {
             "transaction_id": "b" * 64,
             "previous_advertised_version": "1.8.30",
@@ -3490,8 +3570,9 @@ class PearlUpdaterTests(unittest.TestCase):
         expected_fleet = self.root / "expected-fleet.json"
         expected_fleet.write_text(
             '{"schema_version":1,"providers":['
-            '{"provider_id":"a","model_id":"model-a"},'
-            '{"provider_id":"b","model_id":"model-b"}]}'
+            '{"provider_id":"a","model_id":"mlx-community/Qwen3-Coder-30B-A3B-Instruct-4bit"},'
+            '{"provider_id":"b","model_id":"mlx-community/Llama-3.2-3B-Instruct-4bit"},'
+            '{"provider_id":"c","model_id":"mlx-community/Qwen3-8B-4bit"}]}'
         )
         expected_fleet.chmod(0o600)
 
@@ -3526,8 +3607,9 @@ class PearlUpdaterTests(unittest.TestCase):
         expected_fleet = self.root / "expected-fleet.json"
         expected_fleet.write_text(
             '{"schema_version":1,"providers":['
-            '{"provider_id":"a","model_id":"model-a"},'
-            '{"provider_id":"b","model_id":"model-b"}]}'
+            '{"provider_id":"a","model_id":"mlx-community/Qwen3-Coder-30B-A3B-Instruct-4bit"},'
+            '{"provider_id":"b","model_id":"mlx-community/Llama-3.2-3B-Instruct-4bit"},'
+            '{"provider_id":"c","model_id":"mlx-community/Qwen3-8B-4bit"}]}'
         )
         expected_fleet.chmod(0o600)
         control_dir = self.root / "canary-control"

--- a/ops/runbooks/pearl-release-updater.md
+++ b/ops/runbooks/pearl-release-updater.md
@@ -114,9 +114,9 @@ First deploy the #585 integration revision of #584's redesigned canary buyer
 exactly as reviewed, including its root-only `LoadCredential` files, safety
 observer, emergency stop, and classified no-load exits. The
 updater pins that complete runtime, service, and timer as rollout authority
-`issue-585-integration-r7` at source commit `43138cee6dd26f18a11934390fc6b3b0623f1e00`;
+`issue-825-canary-fleet-r1` at source commit `9875d9c6e81fa992a57f5221ff18f4e413cf7fc3`;
 the default `PEARL_UPDATER_BUYER_CANARY_MODE=required` posture fails `--plan`
-on any SHA drift, missing credential, invalid two-provider expected-fleet
+on any SHA drift, missing credential, invalid protected-fleet expected-fleet
 document, absent reviewed enable gate, active emergency-disable sentinel,
 unexpected unit drop-in, stale systemd fragment, or changed three-minute
 canary budget. The one allowed canary drop-in is the updater's exact root-owned
@@ -144,7 +144,11 @@ From the authority commit's reviewed checkout, install the four runtime files
 as executable root-owned files and the two units as non-executable root-owned
 fragments. Provision all four `LoadCredential` inputs as exact `0600` files,
 remove the retired environment file, and reload systemd without enabling either
-schedule:
+schedule. The reviewed expected-fleet JSON must enumerate the complete live
+protected provider fleet, not a two-provider sample: every protected provider
+ID must be unique, duplicate model IDs are allowed when several providers serve
+the same model, and the distinct model set must match the canary service's
+`CANARY_MODELS` list exactly.
 
 ```bash
 sudo install -d -o root -g root -m 0755 /opt/macprovider-canary-buyer
@@ -580,7 +584,7 @@ exists, including when either kill switch changes during timer restoration.
 When restoring a pre-direct-telemetry backend, r4 may create
 `/run/macprovider-canary-buyer/legacy-rollback.json` only inside the active
 phase-journal restoration. That root-owned `0644` control binds the exact
-captured two-provider ID/model fleet, the exact prior advertised binary
+captured protected provider ID/model fleet, the exact prior advertised binary
 version, the 64-hex transaction ID, and an expiry no more than 15 minutes away.
 It substitutes only for missing provider v2 signals on unclassified legacy
 rows; bridge/current/previous modes, wrong versions/models/IDs, stale sessions,

--- a/test/e2e/canary-buyer/README.md
+++ b/test/e2e/canary-buyer/README.md
@@ -60,10 +60,10 @@ automatically repeated. `CANARY_DEGRADED_RETRIES` values other than `0` are
 rejected before the probe process starts. Every invocation is also wrapped by
 GNU `timeout`/`gtimeout` (`120s` liveness, `330s` qualification by default), so
 DNS, output delivery, or runtime bugs cannot defeat the external deadline.
-The exact two-provider/two-model topology is a code invariant, not an operator
-override. During every stream a separate safety observer polls at two-second
-intervals and aborts the request immediately if provider, heartbeat, thermal,
-memory, queue, session, or build identity regresses.
+The exact expected-fleet topology is the reviewed provider inventory, not an
+operator count override. During every stream a separate safety observer polls
+at two-second intervals and aborts the request immediately if provider,
+heartbeat, thermal, memory, queue, session, or build identity regresses.
 
 For systemd, install `probe.mjs`, `safety.mjs`, `run-canary.sh`, and
 `emergency-disable.sh` together,
@@ -134,12 +134,15 @@ not listed; no unlisted provider other than that exact target is accepted):
 
 Scheduled liveness uses the same document without an allowed extra target, so
 membership, provider IDs, model IDs, Ready/routable state, and heartbeat
-freshness must all match exactly. The document is required to contain exactly
-two unique providers mapped one-to-one to two unique models.
-`CANARY_MODELS` must exactly equal the unique
-model set in the document. The shipped schedules pin both live models:
+freshness must all match exactly. The document is required to contain the
+operator-reviewed live protected fleet: provider IDs are unique, duplicate
+model IDs are allowed when multiple protected providers serve the same model,
+and every model in the fleet must be probed by `CANARY_MODELS`.
+`CANARY_MODELS` must exactly equal the unique model set in the document. The
+shipped schedules pin Pearl's live models:
 `mlx-community/Qwen3-Coder-30B-A3B-Instruct-4bit` and
-`mlx-community/Llama-3.2-3B-Instruct-4bit`, producing one 8-token request each.
+`mlx-community/Llama-3.2-3B-Instruct-4bit`, and
+`mlx-community/Qwen3-8B-4bit`, producing one 8-token request each.
 Each provider heartbeat carries versioned `safety_telemetry`; the coordinator
 validates it, stamps receipt freshness, and publishes it through authenticated
 `/poolz`. Version 2 binds the observation to the coordinator session, binary,
@@ -149,8 +152,8 @@ if any expected provider lacks a complete measurement,
 so Pearl does not need a provider-local route to enforce queue, restart,
 memory-pressure, RSS, thermal, and runtime-state invariants.
 GPU utilization is explicitly marked `host` scope: Apple exposes AGX device
-utilization rather than per-process accounting. The two-provider fleet keeps
-one provider service per physical Mac, and evidence reviewers treat this as a
+utilization rather than per-process accounting. The expected fleet keeps one
+provider service per physical Mac, and evidence reviewers treat this as a
 host-condition signal rather than misattributing it to the provider process.
 
 Baseline file schema:

--- a/test/e2e/canary-buyer/canary-buyer.service
+++ b/test/e2e/canary-buyer/canary-buyer.service
@@ -36,7 +36,7 @@ LoadCredential=operator_token:/etc/macprovider/canary-buyer.operator-token
 LoadCredential=expected_fleet:/etc/macprovider/canary-buyer.expected-fleet.json
 Environment=CANARY_BASE=https://api.streamvc.live
 Environment=CANARY_POOLZ_URL=https://coordinator.streamvc.live/poolz
-Environment=CANARY_MODELS=mlx-community/Qwen3-Coder-30B-A3B-Instruct-4bit,mlx-community/Llama-3.2-3B-Instruct-4bit
+Environment=CANARY_MODELS=mlx-community/Qwen3-Coder-30B-A3B-Instruct-4bit,mlx-community/Llama-3.2-3B-Instruct-4bit,mlx-community/Qwen3-8B-4bit
 Environment=CANARY_MIN_READY_PROVIDERS=2
 Environment=CANARY_NODE_BIN=/usr/bin/node
 Environment=CANARY_METRICS_OUT=/var/lib/macprovider-canary-buyer/canary_buyer.prom

--- a/test/e2e/canary-buyer/com.streamvc.canary-buyer.plist
+++ b/test/e2e/canary-buyer/com.streamvc.canary-buyer.plist
@@ -40,7 +40,7 @@
     <key>CANARY_POOLZ_URL</key>
     <string>https://coordinator.streamvc.live/poolz</string>
     <key>CANARY_MODELS</key>
-    <string>mlx-community/Qwen3-Coder-30B-A3B-Instruct-4bit,mlx-community/Llama-3.2-3B-Instruct-4bit</string>
+    <string>mlx-community/Qwen3-Coder-30B-A3B-Instruct-4bit,mlx-community/Llama-3.2-3B-Instruct-4bit,mlx-community/Qwen3-8B-4bit</string>
     <key>CANARY_MIN_READY_PROVIDERS</key>
     <string>2</string>
     <key>CANARY_OPERATOR_TOKEN_FILE</key>

--- a/test/e2e/canary-buyer/probe.mjs
+++ b/test/e2e/canary-buyer/probe.mjs
@@ -74,7 +74,7 @@ const configuredTTFTSamples = intEnv('CANARY_TTFT_SAMPLES', 12, 1, 20);
 const configuredTPSSamples = intEnv('CANARY_TPS_SAMPLES', 3, 1, 10);
 const GATEWAY_STATUS_CACHE_TTL_MS = 10_000;
 const PRODUCTION_HEARTBEAT_CADENCE_MS = 30_000;
-const LEGACY_ROLLBACK_AUTHORITY = 'issue-585-integration-r7';
+const LEGACY_ROLLBACK_AUTHORITY = 'issue-825-canary-fleet-r1';
 const LEGACY_ROLLBACK_MAX_VALIDITY_MS = 15 * 60 * 1000;
 
 const CONFIG = {
@@ -101,7 +101,7 @@ const CONFIG = {
   minDecodeTpsP50: numberEnv('CANARY_MIN_DECODE_TPS_P50', 15),
   minCachedPromptRatio: numberEnv('CANARY_MIN_CACHED_PROMPT_RATIO', 0.1),
   minReadyProviders: intEnv('CANARY_MIN_READY_PROVIDERS', 2, 1, 100),
-  expectedProviderCount: 2,
+  expectedProviderCount: intEnv('CANARY_EXPECTED_PROVIDER_COUNT', 0, 0, 100),
   maxRequestsPerProvider: intEnv('CANARY_MAX_REQUESTS_PER_PROVIDER', isQualification ? 17 : 4, 1, 100),
   maxCompletionTokensPerProvider: intEnv('CANARY_MAX_COMPLETION_TOKENS_PER_PROVIDER', isQualification ? 512 : 32, 1, 4096),
   maxRunDurationMs: intEnv('CANARY_MAX_RUN_DURATION_MS', isQualification ? 300000 : 90000, 10000, 900000),
@@ -1006,8 +1006,9 @@ async function loadExpectedFleet() {
     throw new Error(`cannot read CANARY_EXPECTED_FLEET_FILE: ${error.message || error}`);
   }
   return validateExpectedFleetDocument(parsed, {
-    expectedProviderCount: CONFIG.expectedProviderCount,
-    requireUniqueModels: true,
+    expectedProviderCount: CONFIG.expectedProviderCount || null,
+    minProviderCount: CONFIG.minReadyProviders,
+    requireUniqueModels: CONFIG.mode === 'qualification',
   });
 }
 
@@ -1060,6 +1061,26 @@ export async function pollPostRequestRecovery({
 function expectedPoolRows(poolRows, expectedFleet) {
   const ids = new Set(expectedFleet.map((row) => row.provider_id));
   return poolRows.filter((row) => ids.has(row.provider_id));
+}
+
+function activeExpectedProviderID(observed, expectedFleet, activeModelID, {
+  qualification = false,
+  activeProviderIDHint = '',
+} = {}) {
+  if (!activeModelID) return '';
+  if (qualification) return CONFIG.isolatedProviderID;
+  const candidateIDs = new Set(
+    expectedFleet
+      .filter((row) => row.model_id === activeModelID)
+      .map((row) => row.provider_id),
+  );
+  if (!candidateIDs.size) return '';
+  if (activeProviderIDHint && candidateIDs.has(activeProviderIDHint)) return activeProviderIDHint;
+  const busy = (observed.operator_pool || []).filter((row) => candidateIDs.has(row.provider_id)
+    && row.state === 'busy'
+    && row.routing_eligible === false);
+  if (busy.length === 1) return busy[0].provider_id;
+  return candidateIDs.size === 1 ? [...candidateIDs][0] : '';
 }
 
 function isLegacyBridgeProviderSignalSubstitute(row, expected) {
@@ -1239,17 +1260,17 @@ async function loadLegacyRollbackAuthorization(expectedFleet) {
 export function safetyObservationReasons(initial, observed, expectedFleet, {
   requireHeartbeatAdvance = false,
   activeModelID = '',
+  activeProviderIDHint = '',
   cachedGatewayModelID = '',
   allowLegacyBridgeProviderSignals = false,
   legacyRollbackProviders = null,
   nowMs = Date.now(),
 } = {}) {
   const qualification = CONFIG.mode === 'qualification';
-  const activeProviderID = activeModelID
-    ? (qualification
-      ? CONFIG.isolatedProviderID
-      : expectedFleet.find((row) => row.model_id === activeModelID)?.provider_id || '')
-    : '';
+  const activeProviderID = activeExpectedProviderID(observed, expectedFleet, activeModelID, {
+    qualification,
+    activeProviderIDHint,
+  });
   const activePoolRow = activeProviderID
     ? (observed.operator_pool || []).find((row) => row.provider_id === activeProviderID)
     : null;
@@ -1386,12 +1407,13 @@ function createControl(initial, baselines, expectedFleet, budget, legacyRollback
   const observeAndCheck = async (phase, {
     timeoutMs = CONFIG.reqTimeoutMs,
     activeModelID = '',
+    activeProviderIDHint = '',
   } = {}) => {
     if (failure) return null;
     try {
       const observed = await observeSafety(budget, timeoutMs);
       observations.push(observed);
-      const reasons = observationReasons(observed, { activeModelID });
+      const reasons = observationReasons(observed, { activeModelID, activeProviderIDHint });
       if (reasons.length) fail(classifySignalReasons(reasons), reasons, phase);
       return observed;
     } catch (error) {
@@ -1402,7 +1424,7 @@ function createControl(initial, baselines, expectedFleet, budget, legacyRollback
     }
   };
 
-  const observeAfterRequest = async (model) => {
+  const observeAfterRequest = async (model, activeProviderIDHint = '') => {
     const phase = `after_request_${budget.requests}`;
     try {
       const result = await pollPostRequestRecovery({
@@ -1414,6 +1436,7 @@ function createControl(initial, baselines, expectedFleet, budget, legacyRollback
         strictReasons: (observed) => observationReasons(observed, {}),
         transientReasons: (observed) => observationReasons(observed, {
           activeModelID: model,
+          activeProviderIDHint,
           cachedGatewayModelID: model,
         }),
         maxWaitMs: Math.min(CONFIG.postRequestRecoveryMs, budget.remainingDurationMs()),
@@ -1490,7 +1513,7 @@ function createControl(initial, baselines, expectedFleet, budget, legacyRollback
       // that exact correlated shape while polling through the cache TTL plus
       // one poll/observer margin, then require a fully strict snapshot before
       // another request can start.
-      await observeAfterRequest(model);
+      await observeAfterRequest(model, result.provider || '');
     },
     async monitorDuringRequest(requestAbort, stopSignal, activeModelID) {
       let sample = 0;

--- a/test/e2e/canary-buyer/probe.test.mjs
+++ b/test/e2e/canary-buyer/probe.test.mjs
@@ -290,6 +290,54 @@ test('active-request safety correlates exact busy pool row, dropped gateway mode
   }), []);
 });
 
+test('active-request safety accepts a non-first duplicate-model provider without dropping the model', () => {
+  const now = Date.now();
+  const stamp = (offset) => new Date(now + offset).toISOString();
+  const expectedFleet = [
+    { provider_id: 'provider-a', model_id: 'model-a' },
+    { provider_id: 'provider-b', model_id: 'model-b' },
+    { provider_id: 'provider-c', model_id: 'model-b' },
+  ];
+  const gateway = gatewaySnapshot({
+    status: 'up', degraded: false, coordinator: { status: 'up', checked_at: stamp(0) },
+    pool: { total_providers: 3, ready: 3, degraded: 0, draining: 0, unavailable: 0 },
+    models: [
+      { id: 'model-a', provider_count: 1, ready_provider_count: 1, slots_free: 1, available: true, availability: 'available', degraded: false },
+      { id: 'model-b', provider_count: 2, ready_provider_count: 2, slots_free: 2, available: true, availability: 'available', degraded: false },
+    ],
+  });
+  const operatorPool = poolzSnapshot({ pool: expectedFleet.map(({ provider_id, model_id }, index) => ({
+    provider_id, assigned_id: `session-${index}`, model_id, state: 'ready', routing_eligible: true,
+    connected_at: stamp(-60_000), last_heartbeat_at: stamp(-1_000), last_activity_at: stamp(-500),
+  })) }, now);
+  const providers = [
+    safetyProvider('provider-a', 'model-a', 'session-0'),
+    safetyProvider('provider-b', 'model-b', 'session-1'),
+    safetyProvider('provider-c', 'model-b', 'session-2'),
+  ];
+  const initial = { gateway, operator_pool: operatorPool, providers };
+  const observed = structuredClone(initial);
+  observed.operator_pool[2].state = 'busy';
+  observed.operator_pool[2].routing_eligible = false;
+  observed.providers[2].status = 'busy';
+  observed.providers[2].requests_in_flight = 1;
+  observed.gateway.pool.total_providers = 2;
+  observed.gateway.pool.ready = 2;
+  observed.gateway.models[1].ready_provider_count = 1;
+  observed.gateway.models[1].slots_free = 1;
+
+  assert.ok(safetyObservationReasons(initial, observed, expectedFleet).length > 0);
+  assert.deepEqual(safetyObservationReasons(initial, observed, expectedFleet, {
+    activeModelID: 'model-b',
+  }), []);
+
+  const droppedDuplicateModel = structuredClone(observed);
+  droppedDuplicateModel.gateway.models = droppedDuplicateModel.gateway.models.filter((model) => model.id !== 'model-b');
+  assert.ok(safetyObservationReasons(initial, droppedDuplicateModel, expectedFleet, {
+    activeModelID: 'model-b',
+  }).includes('model-b:model_disappeared'));
+});
+
 test('liveness substitutes missing v2 signals only for exact legacy-bridge provider rows', () => {
   const now = Date.now();
   const stamp = (offset) => new Date(now + offset).toISOString();
@@ -379,7 +427,7 @@ test('legacy rollback authorization is exact, expiring, and limited to unclassif
   const document = {
     schema_version: 1,
     kind: 'legacy_rollback',
-    authority: 'issue-585-integration-r7',
+    authority: 'issue-825-canary-fleet-r1',
     transaction_id: 'a'.repeat(64),
     expires_at: new Date(now + 300_000).toISOString(),
     providers: expectedFleet.map((row) => ({ ...row, binary_version: '1.8.30' })),

--- a/test/e2e/canary-buyer/safety.mjs
+++ b/test/e2e/canary-buyer/safety.mjs
@@ -110,22 +110,24 @@ export function gatewayInvariantReasons(initial, current, {
   const beforeModels = new Map((before?.models || []).map((model) => [model.id, model]));
   const afterModels = new Map((after.models || []).map((model) => [model.id, model]));
   // The gateway excludes a coordinator row as soon as it becomes
-  // non-routable. With one provider per model, an active request therefore
-  // removes exactly one provider and its model from the buyer-facing
-  // aggregate; it does not surface as pool.degraded=1.
+  // non-routable. An active request may therefore remove exactly one provider
+  // from the buyer-facing aggregate. The model disappears only when that was
+  // the model's sole ready provider; duplicate-provider models must remain
+  // available with one fewer ready provider.
   const activeModelBefore = activeModelID ? beforeModels.get(activeModelID) : null;
   const activeModelDropped = Boolean(activeModelBefore && !afterModels.has(activeModelID));
-  const activeLossAllowed = activeModelDropped && activeModelBefore.provider_count === 1;
-  if (!['up', ...(activeLossAllowed ? ['degraded'] : [])].includes(after.status)
+  const activeProviderLossAllowed = Boolean(activeModelBefore);
+  const activeModelLossAllowed = activeModelDropped && activeModelBefore.provider_count === 1;
+  if (!['up', ...(activeModelLossAllowed ? ['degraded'] : [])].includes(after.status)
       || after.coordinator_status !== 'up') reasons.push('gateway_or_coordinator_not_up');
-  if (after.degraded !== (after.status === 'degraded') || (after.degraded && !activeLossAllowed)) {
+  if (after.degraded !== (after.status === 'degraded') || (after.degraded && !activeModelLossAllowed)) {
     reasons.push('gateway_degraded');
   }
   if (!Number.isInteger(after.pool.total_providers) || !Number.isInteger(after.pool.ready)) {
     reasons.push('pool_signal_missing');
     return reasons;
   }
-  const minimumReady = Math.max(0, minReadyProviders - (activeLossAllowed ? 1 : 0));
+  const minimumReady = Math.max(0, minReadyProviders - (activeProviderLossAllowed ? 1 : 0));
   if (after.pool.ready < minimumReady) reasons.push(`ready_${after.pool.ready}_lt_${minimumReady}`);
   for (const state of ['degraded', 'unavailable']) {
     if (!Number.isInteger(after.pool[state])) reasons.push(`pool_${state}_signal_missing`);
@@ -136,13 +138,13 @@ export function gatewayInvariantReasons(initial, current, {
     reasons.push(`pool_draining_${after.pool.draining}_gt_${maxDrainingProviders}`);
   }
   if (Number.isInteger(before?.pool?.total_providers)) {
-    const expectedTotal = before.pool.total_providers - (activeLossAllowed ? 1 : 0);
+    const expectedTotal = before.pool.total_providers - (activeProviderLossAllowed ? 1 : 0);
     if (after.pool.total_providers !== expectedTotal) {
       reasons.push(`total_providers_changed_${before.pool.total_providers}_to_${after.pool.total_providers}`);
     }
   }
   if (Number.isInteger(before?.pool?.ready)) {
-    const expectedReady = before.pool.ready - (activeLossAllowed ? 1 : 0);
+    const expectedReady = before.pool.ready - (activeProviderLossAllowed ? 1 : 0);
     if (after.pool.ready !== expectedReady) {
       reasons.push(`ready_changed_${before.pool.ready}_to_${after.pool.ready}`);
     }
@@ -151,14 +153,14 @@ export function gatewayInvariantReasons(initial, current, {
     if (!id) continue;
     const observed = afterModels.get(id);
     if (!observed) {
-      if (!(activeLossAllowed && id === activeModelID)) reasons.push(`${id}:model_disappeared`);
+      if (!(activeModelLossAllowed && id === activeModelID)) reasons.push(`${id}:model_disappeared`);
       continue;
     }
     if (observed.degraded || !observed.available) {
       reasons.push(`${id}:model_not_stably_available`);
     }
     if (Number.isInteger(model.ready_provider_count)
-        && observed.ready_provider_count !== model.ready_provider_count) {
+        && observed.ready_provider_count !== model.ready_provider_count - (activeProviderLossAllowed && id === activeModelID ? 1 : 0)) {
       reasons.push(`${id}:ready_provider_count_changed_${model.ready_provider_count}_to_${observed.ready_provider_count}`);
     }
   }
@@ -462,9 +464,10 @@ export function responseIdentityReasons(result, requestedModel, expectedFleet, {
     reasons.push(`${requestedModel}:response_model_${result?.responseModel || 'missing'}_ne_${requestedModel}`);
   }
   const matching = expectedFleet.filter((row) => row.model_id === requestedModel);
-  const expectedProvider = expectedProviderID || (matching.length === 1 ? matching[0].provider_id : '');
-  if (!expectedProvider) reasons.push(`${requestedModel}:expected_provider_mapping_missing_or_ambiguous`);
-  if (result?.provider !== expectedProvider) {
+  const expectedProviders = expectedProviderID ? [expectedProviderID] : matching.map((row) => row.provider_id);
+  if (!expectedProviders.length) reasons.push(`${requestedModel}:expected_provider_mapping_missing`);
+  if (!expectedProviders.includes(result?.provider || '')) {
+    const expectedProvider = expectedProviderID || (expectedProviders.length ? expectedProviders.join('|') : 'unresolved');
     reasons.push(`${requestedModel}:response_provider_${result?.provider || 'missing'}_ne_${expectedProvider || 'unresolved'}`);
   }
   return reasons;
@@ -486,10 +489,29 @@ export function performanceRegressionReasons(result, baseline, sampleClass) {
   return reasons;
 }
 
-export function validateExpectedFleetDocument(document, { expectedProviderCount = 2, requireUniqueModels = true } = {}) {
-  if (document?.schema_version !== 1 || !Array.isArray(document?.providers)
-      || document.providers.length !== expectedProviderCount) {
-    throw new Error(`expected fleet file must contain schema_version=1 and exactly ${expectedProviderCount} providers`);
+export function validateExpectedFleetDocument(document, {
+  expectedProviderCount = null,
+  minProviderCount = 1,
+  maxProviderCount = 100,
+  requireUniqueModels = true,
+} = {}) {
+  if (expectedProviderCount != null
+      && (!Number.isSafeInteger(expectedProviderCount) || expectedProviderCount < 1)) {
+    throw new Error('expectedProviderCount must be a positive integer when set');
+  }
+  if (!Number.isSafeInteger(minProviderCount) || minProviderCount < 1
+      || !Number.isSafeInteger(maxProviderCount) || maxProviderCount < minProviderCount) {
+    throw new Error('expected fleet provider bounds are invalid');
+  }
+  if (document?.schema_version !== 1 || !Array.isArray(document?.providers)) {
+    throw new Error('expected fleet file must contain schema_version=1 and a providers list');
+  }
+  const actualCount = document.providers.length;
+  if (expectedProviderCount != null && actualCount !== expectedProviderCount) {
+    throw new Error(`expected fleet file must contain exactly ${expectedProviderCount} providers`);
+  }
+  if (actualCount < minProviderCount || actualCount > maxProviderCount) {
+    throw new Error(`expected fleet file must contain between ${minProviderCount} and ${maxProviderCount} providers`);
   }
   const seen = new Set();
   const models = new Set();

--- a/test/e2e/canary-buyer/safety.test.mjs
+++ b/test/e2e/canary-buyer/safety.test.mjs
@@ -263,11 +263,19 @@ test('expected fleet and qualification isolation require exact provider/model/ro
     targetProviderID: 'provider-b', targetModel: 'model-b', maxHeartbeatAgeMs: 90_000,
     localProviderSignal: provider({ provider_id: 'provider-b', model_id: 'model-b', coordinator_session_id: 'session-b' }),
   }).includes('isolation_target_still_routable'));
+  assert.deepEqual(validateExpectedFleetDocument({ schema_version: 1, providers: [
+    { provider_id: 'provider-a', model_id: 'model-a' },
+    { provider_id: 'provider-b', model_id: 'model-a' },
+    { provider_id: 'provider-c', model_id: 'model-c' },
+  ] }, { requireUniqueModels: false }), [
+    { provider_id: 'provider-a', model_id: 'model-a' },
+    { provider_id: 'provider-b', model_id: 'model-a' },
+    { provider_id: 'provider-c', model_id: 'model-c' },
+  ]);
   assert.throws(() => validateExpectedFleetDocument({ schema_version: 1, providers: [
     { provider_id: 'provider-a', model_id: 'model-a' },
     { provider_id: 'provider-b', model_id: 'model-b' },
-    { provider_id: 'provider-c', model_id: 'model-c' },
-  ] }), /exactly 2/);
+  ] }, { expectedProviderCount: 3 }), /exactly 3/);
   assert.throws(() => validateExpectedFleetDocument({ schema_version: 1, providers: [
     { provider_id: 'provider-a', model_id: 'model-a' },
     { provider_id: 'provider-b', model_id: 'model-a' },
@@ -283,6 +291,22 @@ test('response attribution requires exact provider and model in both canary mode
   assert.deepEqual(responseIdentityReasons({ provider: '', responseModel: 'model-b' }, 'model-a', fleet), [
     'model-a:response_model_model-b_ne_model-a',
     'model-a:response_provider_missing_ne_provider-a',
+  ]);
+  const duplicateModelFleet = [
+    { provider_id: 'provider-a', model_id: 'model-a' },
+    { provider_id: 'provider-b', model_id: 'model-a' },
+  ];
+  assert.deepEqual(responseIdentityReasons({ provider: 'provider-b', responseModel: 'model-a' }, 'model-a', duplicateModelFleet), []);
+  assert.deepEqual(responseIdentityReasons({ provider: 'provider-c', responseModel: 'model-a' }, 'model-a', duplicateModelFleet), [
+    'model-a:response_provider_provider-c_ne_provider-a|provider-b',
+  ]);
+  assert.deepEqual(responseIdentityReasons(
+    { provider: 'provider-b', responseModel: 'model-a' },
+    'model-a',
+    duplicateModelFleet,
+    { expectedProviderID: 'provider-a' },
+  ), [
+    'model-a:response_provider_provider-b_ne_provider-a',
   ]);
 });
 


### PR DESCRIPTION
## Summary

Fixes the Pearl canary/deploy gate for production fleets where multiple protected providers legitimately serve the same model. The prior liveness/updater authority treated the expected fleet as one-provider-per-model, which blocked #825 on Pearl's five-provider pool.

Changes:
- Allows liveness canaries and updater fleet validation to use the full protected provider fleet while still requiring unique provider IDs, bounded fleet size, known models, and exact unique `CANARY_MODELS` coverage.
- Keeps qualification mode strict: one isolated expected provider and an exact provider/model response attribution.
- Updates active-request safety so duplicate-model providers can be isolated by observed busy provider or response provider hint without treating the whole model as lost.
- Pins the Pearl updater rollback authority to `issue-825-canary-fleet-r1` and verifies protected canary file hashes against the source-authority commit.

## Validation

- `git diff --check origin/main..HEAD`
- `node --test test/e2e/canary-buyer/probe.test.mjs test/e2e/canary-buyer/safety.test.mjs`
- `bash test/e2e/canary-buyer/run-canary.test.sh`
- `python3 ops/pearl-updater/test_pearl_updater.py`
- `bash scripts/test-pearl-runtime-release.sh`
- `python3 scripts/verify-pearl-go-binaries.py --self-test`
- Three audit lanes: code, security, and architect all at 0 Critical / 0 High / 0 Medium findings.

SPEC-GOVERNANCE-DECLARATION-BEGIN
{
  "schema_version": "spec-pr-governance-v1",
  "behavior_change": "yes",
  "contract_change": "none",
  "specs": ["SPEC-020"],
  "requirements": ["SPEC-020-R003", "SPEC-020-R004"],
  "authority_domains": ["provider-autoupdate", "canary-sanction-lifecycle"],
  "arbitration": ["CODE_BUG"],
  "tests": [
    "git diff --check origin/main..HEAD",
    "node --test test/e2e/canary-buyer/probe.test.mjs test/e2e/canary-buyer/safety.test.mjs",
    "bash test/e2e/canary-buyer/run-canary.test.sh",
    "python3 ops/pearl-updater/test_pearl_updater.py",
    "bash scripts/test-pearl-runtime-release.sh",
    "python3 scripts/verify-pearl-go-binaries.py --self-test"
  ],
  "journeys": ["Pearl deploy after merge for issue 825"],
  "issue": "https://github.com/Augustas11/macprovider/issues/825"
}
SPEC-GOVERNANCE-DECLARATION-END
