### PR TITLE
Fix Pearl canary stable aggregate false positive

### DIFF
--- a/ops/pearl-updater/macprovider-pearl-update
+++ b/ops/pearl-updater/macprovider-pearl-update
@@ -115,8 +115,8 @@ MAX_DOWNLOAD_BYTES = 512 * 1024 * 1024
 MAX_CANDIDATE_OUTPUT_BYTES = 64 * 1024
 MAX_BUYER_PROOF_STREAM_BYTES = 1024 * 1024
 MAX_BUYER_PROOF_STREAM_LINE_BYTES = 64 * 1024
-CANARY_AUTHORITY_VERSION = "issue-825-canary-fleet-r1"
-CANARY_AUTHORITY_COMMIT = "9875d9c6e81fa992a57f5221ff18f4e413cf7fc3"
+CANARY_AUTHORITY_VERSION = "issue-825-canary-fleet-r2"
+CANARY_AUTHORITY_COMMIT = "58ca2503b44929ee7a5ad793780af710f7882623"
 CANARY_UNIT_BUDGET_S = 180
 JOURNAL_SCHEMA_VERSION = 1
 CURRENT_RELEASE_SCHEMA_VERSION = 1
@@ -135,7 +135,7 @@ ROLLBACK_STEPS = (
 )
 CANARY_AUTHORITY_FILES = {
     Path("/opt/macprovider-canary-buyer/probe.mjs"): "e23354b4385d765e3e8af61c5ec4e49e97619a3eef120180b5f5fe175714c3e8",
-    Path("/opt/macprovider-canary-buyer/safety.mjs"): "708aa718faf43ce990e13a5b4ecb51a48f283c6cd1876f71121e309633cbbbbf",
+    Path("/opt/macprovider-canary-buyer/safety.mjs"): "e9e144b632a45bde5c115b9452b2513d38c814d08cb5087ee6a1e2fcb408c2ac",
     Path("/opt/macprovider-canary-buyer/run-canary.sh"): "6c5b31fce3b477aed8a85c7a0750e924360ed4828da49ca42ea693482e635585",
     Path("/opt/macprovider-canary-buyer/emergency-disable.sh"): "1380122e76b3b66ad812849e3684b38eaaed0790f0e6011e3f194bd215ab1c7e",
     Path("/etc/systemd/system/canary-buyer.service"): "e7f028164d7ca58adaebfb4b1d194016a587dfae78af3f3a0b456ae374efea8a",

--- a/ops/pearl-updater/test_pearl_updater.py
+++ b/ops/pearl-updater/test_pearl_updater.py
@@ -3277,10 +3277,10 @@ class PearlUpdaterTests(unittest.TestCase):
                 updater_module.CANARY_AUTHORITY_FILES[installed],
                 hashlib.sha256(source_at_authority).hexdigest(),
             )
-        self.assertEqual(updater_module.CANARY_AUTHORITY_VERSION, "issue-825-canary-fleet-r1")
+        self.assertEqual(updater_module.CANARY_AUTHORITY_VERSION, "issue-825-canary-fleet-r2")
         self.assertEqual(
             updater_module.CANARY_AUTHORITY_COMMIT,
-            "9875d9c6e81fa992a57f5221ff18f4e413cf7fc3",
+            "58ca2503b44929ee7a5ad793780af710f7882623",
         )
         subprocess.run(
             ["git", "cat-file", "-e", f"{updater_module.CANARY_AUTHORITY_COMMIT}^{{commit}}"],
@@ -3427,7 +3427,7 @@ class PearlUpdaterTests(unittest.TestCase):
             {
                 "schema_version": 1,
                 "kind": "legacy_rollback",
-                "authority": "issue-825-canary-fleet-r1",
+                "authority": "issue-825-canary-fleet-r2",
                 "transaction_id": "a" * 64,
                 "expires_at": observed["document"]["expires_at"],
                 "providers": [

--- a/test/e2e/canary-buyer/safety.mjs
+++ b/test/e2e/canary-buyer/safety.mjs
@@ -138,14 +138,16 @@ export function gatewayInvariantReasons(initial, current, {
     reasons.push(`pool_draining_${after.pool.draining}_gt_${maxDrainingProviders}`);
   }
   if (Number.isInteger(before?.pool?.total_providers)) {
-    const expectedTotal = before.pool.total_providers - (activeProviderLossAllowed ? 1 : 0);
-    if (after.pool.total_providers !== expectedTotal) {
+    const expectedTotal = before.pool.total_providers;
+    const allowedTotalLoss = activeProviderLossAllowed ? 1 : 0;
+    if (!countWithinLossAllowance(after.pool.total_providers, expectedTotal, allowedTotalLoss)) {
       reasons.push(`total_providers_changed_${before.pool.total_providers}_to_${after.pool.total_providers}`);
     }
   }
   if (Number.isInteger(before?.pool?.ready)) {
-    const expectedReady = before.pool.ready - (activeProviderLossAllowed ? 1 : 0);
-    if (after.pool.ready !== expectedReady) {
+    const expectedReady = before.pool.ready;
+    const allowedReadyLoss = activeProviderLossAllowed ? 1 : 0;
+    if (!countWithinLossAllowance(after.pool.ready, expectedReady, allowedReadyLoss)) {
       reasons.push(`ready_changed_${before.pool.ready}_to_${after.pool.ready}`);
     }
   }
@@ -159,12 +161,18 @@ export function gatewayInvariantReasons(initial, current, {
     if (observed.degraded || !observed.available) {
       reasons.push(`${id}:model_not_stably_available`);
     }
+    const allowedReadyLoss = activeProviderLossAllowed && id === activeModelID ? 1 : 0;
     if (Number.isInteger(model.ready_provider_count)
-        && observed.ready_provider_count !== model.ready_provider_count - (activeProviderLossAllowed && id === activeModelID ? 1 : 0)) {
+        && !countWithinLossAllowance(observed.ready_provider_count, model.ready_provider_count, allowedReadyLoss)) {
       reasons.push(`${id}:ready_provider_count_changed_${model.ready_provider_count}_to_${observed.ready_provider_count}`);
     }
   }
   return reasons;
+}
+
+function countWithinLossAllowance(observed, expected, allowedLoss) {
+  if (!Number.isInteger(observed) || !Number.isInteger(expected)) return false;
+  return observed <= expected && observed >= expected - allowedLoss;
 }
 
 export function poolzSnapshot(payload, nowMs = Date.now()) {

--- a/test/e2e/canary-buyer/safety.test.mjs
+++ b/test/e2e/canary-buyer/safety.test.mjs
@@ -84,6 +84,9 @@ test('hard request, token, and time budgets never admit an over-budget request',
 test('gateway pre/post invariants match exact active non-routable aggregation loss', () => {
   const initial = healthyGateway();
   assert.deepEqual(gatewayInvariantReasons(initial, initial, { minReadyProviders: 2 }), []);
+  assert.deepEqual(gatewayInvariantReasons(initial, initial, {
+    minReadyProviders: 2, activeModelID: 'model-a',
+  }), []);
   const active = structuredClone(initial);
   active.status = 'degraded';
   active.degraded = true;
@@ -102,6 +105,26 @@ test('gateway pre/post invariants match exact active non-routable aggregation lo
   assert.ok(gatewayInvariantReasons(initial, inventedDegradedRow, {
     minReadyProviders: 2, activeModelID: 'model-a',
   }).length > 0);
+  const duplicateActive = gatewaySnapshot({
+    status: 'up',
+    degraded: false,
+    coordinator: { status: 'up', checked_at: '2026-07-14T12:00:00Z' },
+    pool: { total_providers: 3, ready: 3, degraded: 0, draining: 0, unavailable: 0 },
+    models: [
+      { id: 'model-a', provider_count: 2, ready_provider_count: 2, slots_free: 2, available: true, degraded: false },
+      { id: 'model-b', provider_count: 1, ready_provider_count: 1, slots_free: 1, available: true, degraded: false },
+    ],
+  });
+  assert.deepEqual(gatewayInvariantReasons(duplicateActive, duplicateActive, {
+    minReadyProviders: 3, activeModelID: 'model-a',
+  }), []);
+  const duplicateActiveLoss = structuredClone(duplicateActive);
+  duplicateActiveLoss.pool.total_providers = 2;
+  duplicateActiveLoss.pool.ready = 2;
+  duplicateActiveLoss.models[0].ready_provider_count = 1;
+  assert.deepEqual(gatewayInvariantReasons(duplicateActive, duplicateActiveLoss, {
+    minReadyProviders: 3, activeModelID: 'model-a',
+  }), []);
   const changed = structuredClone(initial);
   changed.pool.ready = 1;
   changed.pool.draining = 1;


### PR DESCRIPTION
## Summary

Fixes the Pearl canary false positive that rolled back the v1.8.74 #825 deployment attempt after successful protected-fleet samples.

Changes:
- Allows the active-model gateway invariant to accept either unchanged aggregate counts or the existing one-provider transient active-request loss.
- Keeps non-active models and larger pool/model count changes fail-closed.
- Pins Pearl updater canary authority to `issue-825-canary-fleet-r2` at the corrected canary runtime commit and updates the protected `safety.mjs` digest.
- Updates updater tests for the new authority label and rollback authorization document.

Live failure this addresses:
- Pearl v1.8.74 attempted at `2026-08-01T09:49Z` and proved release assets, public TLS health/version, provider reconnect/warmup, gateway serving status, and three consecutive public protected-fleet samples.
- The final `canary-buyer` gate then aborted with `provider_state_regression` on unchanged counts such as `total_providers_changed_5_to_5` and `ready_provider_count_changed_1_to_1`, causing rollback to v1.8.68.

## Validation

- `git diff --check origin/main..HEAD`
- `node --test test/e2e/canary-buyer/safety.test.mjs test/e2e/canary-buyer/probe.test.mjs`
- `bash test/e2e/canary-buyer/run-canary.test.sh`
- `python3 -m unittest ops.pearl-updater.test_pearl_updater.PearlUpdaterTests.test_canary_rollout_authority_hashes_match_issue_825_duplicate_fleet_runtime ops.pearl-updater.test_pearl_updater.PearlUpdaterTests.test_canary_rollout_authority_binds_files_and_loaded_unit ops.pearl-updater.test_pearl_updater.PearlUpdaterTests.test_canary_expected_fleet_accepts_full_protected_duplicate_model_inventory`
- `python3 ops/pearl-updater/test_pearl_updater.py` (180 tests, 1 skipped)
- `bash scripts/test-pearl-runtime-release.sh`
- `python3 scripts/verify-pearl-go-binaries.py --self-test`

Tracking: #825

SPEC-GOVERNANCE-DECLARATION-BEGIN
{
  "schema_version": "spec-pr-governance-v1",
  "behavior_change": "yes",
  "contract_change": "none",
  "specs": ["SPEC-020"],
  "requirements": ["SPEC-020-R003", "SPEC-020-R004"],
  "authority_domains": ["provider-autoupdate", "canary-sanction-lifecycle"],
  "arbitration": ["CODE_BUG"],
  "tests": [
    "git diff --check origin/main..HEAD",
    "node --test test/e2e/canary-buyer/safety.test.mjs test/e2e/canary-buyer/probe.test.mjs",
    "bash test/e2e/canary-buyer/run-canary.test.sh",
    "python3 -m unittest ops.pearl-updater.test_pearl_updater.PearlUpdaterTests.test_canary_rollout_authority_hashes_match_issue_825_duplicate_fleet_runtime ops.pearl-updater.test_pearl_updater.PearlUpdaterTests.test_canary_rollout_authority_binds_files_and_loaded_unit ops.pearl-updater.test_pearl_updater.PearlUpdaterTests.test_canary_expected_fleet_accepts_full_protected_duplicate_model_inventory",
    "python3 ops/pearl-updater/test_pearl_updater.py",
    "bash scripts/test-pearl-runtime-release.sh",
    "python3 scripts/verify-pearl-go-binaries.py --self-test"
  ],
  "journeys": ["Pearl deploy after merge for issue 825"],
  "issue": "https://github.com/Augustas11/macprovider/issues/825"
}
SPEC-GOVERNANCE-DECLARATION-END
