### PR TITLE
Let Pearl canary accept stable active-provider counts

### DIFF
--- a/ops/pearl-updater/macprovider-pearl-update
+++ b/ops/pearl-updater/macprovider-pearl-update
@@ -115,8 +115,8 @@ MAX_DOWNLOAD_BYTES = 512 * 1024 * 1024
 MAX_CANDIDATE_OUTPUT_BYTES = 64 * 1024
 MAX_BUYER_PROOF_STREAM_BYTES = 1024 * 1024
 MAX_BUYER_PROOF_STREAM_LINE_BYTES = 64 * 1024
-CANARY_AUTHORITY_VERSION = "issue-825-canary-fleet-r1"
-CANARY_AUTHORITY_COMMIT = "9875d9c6e81fa992a57f5221ff18f4e413cf7fc3"
+CANARY_AUTHORITY_VERSION = "issue-825-canary-fleet-r2"
+CANARY_AUTHORITY_COMMIT = "d2b31d0f2e18631764f9a5f4c1c5b28cc0b46142"
 CANARY_UNIT_BUDGET_S = 180
 JOURNAL_SCHEMA_VERSION = 1
 CURRENT_RELEASE_SCHEMA_VERSION = 1
@@ -134,8 +134,8 @@ ROLLBACK_STEPS = (
     "canary_timer",
 )
 CANARY_AUTHORITY_FILES = {
-    Path("/opt/macprovider-canary-buyer/probe.mjs"): "e23354b4385d765e3e8af61c5ec4e49e97619a3eef120180b5f5fe175714c3e8",
-    Path("/opt/macprovider-canary-buyer/safety.mjs"): "708aa718faf43ce990e13a5b4ecb51a48f283c6cd1876f71121e309633cbbbbf",
+    Path("/opt/macprovider-canary-buyer/probe.mjs"): "f61f8e05b700c013116cd0f0148af02004a7a73d01b47d6b77a1cd85aa366c71",
+    Path("/opt/macprovider-canary-buyer/safety.mjs"): "7d40264bd9a2f344147ac4d8197aaa1f8ebdfbebf92f55ba36d654e8e5351004",
     Path("/opt/macprovider-canary-buyer/run-canary.sh"): "6c5b31fce3b477aed8a85c7a0750e924360ed4828da49ca42ea693482e635585",
     Path("/opt/macprovider-canary-buyer/emergency-disable.sh"): "1380122e76b3b66ad812849e3684b38eaaed0790f0e6011e3f194bd215ab1c7e",
     Path("/etc/systemd/system/canary-buyer.service"): "e7f028164d7ca58adaebfb4b1d194016a587dfae78af3f3a0b456ae374efea8a",

--- a/ops/pearl-updater/test_pearl_updater.py
+++ b/ops/pearl-updater/test_pearl_updater.py
@@ -3277,10 +3277,10 @@ class PearlUpdaterTests(unittest.TestCase):
                 updater_module.CANARY_AUTHORITY_FILES[installed],
                 hashlib.sha256(source_at_authority).hexdigest(),
             )
-        self.assertEqual(updater_module.CANARY_AUTHORITY_VERSION, "issue-825-canary-fleet-r1")
+        self.assertEqual(updater_module.CANARY_AUTHORITY_VERSION, "issue-825-canary-fleet-r2")
         self.assertEqual(
             updater_module.CANARY_AUTHORITY_COMMIT,
-            "9875d9c6e81fa992a57f5221ff18f4e413cf7fc3",
+            "d2b31d0f2e18631764f9a5f4c1c5b28cc0b46142",
         )
         subprocess.run(
             ["git", "cat-file", "-e", f"{updater_module.CANARY_AUTHORITY_COMMIT}^{{commit}}"],
@@ -3427,7 +3427,7 @@ class PearlUpdaterTests(unittest.TestCase):
             {
                 "schema_version": 1,
                 "kind": "legacy_rollback",
-                "authority": "issue-825-canary-fleet-r1",
+                "authority": "issue-825-canary-fleet-r2",
                 "transaction_id": "a" * 64,
                 "expires_at": observed["document"]["expires_at"],
                 "providers": [

--- a/ops/runbooks/pearl-release-updater.md
+++ b/ops/runbooks/pearl-release-updater.md
@@ -110,11 +110,11 @@ legacy git-describe bootstrap is no longer accepted.
 
 ## One-time installation
 
-First deploy the #585 integration revision of #584's redesigned canary buyer
-exactly as reviewed, including its root-only `LoadCredential` files, safety
-observer, emergency stop, and classified no-load exits. The
+First deploy the issue #825 r2 active-count revision of #584's redesigned
+canary buyer exactly as reviewed, including its root-only `LoadCredential`
+files, safety observer, emergency stop, and classified no-load exits. The
 updater pins that complete runtime, service, and timer as rollout authority
-`issue-825-canary-fleet-r1` at source commit `9875d9c6e81fa992a57f5221ff18f4e413cf7fc3`;
+`issue-825-canary-fleet-r2` at source commit `d2b31d0f2e18631764f9a5f4c1c5b28cc0b46142`;
 the default `PEARL_UPDATER_BUYER_CANARY_MODE=required` posture fails `--plan`
 on any SHA drift, missing credential, invalid protected-fleet expected-fleet
 document, absent reviewed enable gate, active emergency-disable sentinel,

--- a/test/e2e/canary-buyer/probe.mjs
+++ b/test/e2e/canary-buyer/probe.mjs
@@ -74,7 +74,7 @@ const configuredTTFTSamples = intEnv('CANARY_TTFT_SAMPLES', 12, 1, 20);
 const configuredTPSSamples = intEnv('CANARY_TPS_SAMPLES', 3, 1, 10);
 const GATEWAY_STATUS_CACHE_TTL_MS = 10_000;
 const PRODUCTION_HEARTBEAT_CADENCE_MS = 30_000;
-const LEGACY_ROLLBACK_AUTHORITY = 'issue-825-canary-fleet-r1';
+const LEGACY_ROLLBACK_AUTHORITY = 'issue-825-canary-fleet-r2';
 const LEGACY_ROLLBACK_MAX_VALIDITY_MS = 15 * 60 * 1000;
 
 const CONFIG = {

--- a/test/e2e/canary-buyer/probe.test.mjs
+++ b/test/e2e/canary-buyer/probe.test.mjs
@@ -427,7 +427,7 @@ test('legacy rollback authorization is exact, expiring, and limited to unclassif
   const document = {
     schema_version: 1,
     kind: 'legacy_rollback',
-    authority: 'issue-825-canary-fleet-r1',
+    authority: 'issue-825-canary-fleet-r2',
     transaction_id: 'a'.repeat(64),
     expires_at: new Date(now + 300_000).toISOString(),
     providers: expectedFleet.map((row) => ({ ...row, binary_version: '1.8.30' })),

--- a/test/e2e/canary-buyer/probe.test.mjs
+++ b/test/e2e/canary-buyer/probe.test.mjs
@@ -290,6 +290,42 @@ test('active-request safety correlates exact busy pool row, dropped gateway mode
   }), []);
 });
 
+test('active-request safety accepts unchanged gateway counts while provider is busy', () => {
+  const now = Date.now();
+  const stamp = (offset) => new Date(now + offset).toISOString();
+  const expectedFleet = [
+    { provider_id: 'provider-a', model_id: 'model-a' },
+    { provider_id: 'provider-b', model_id: 'model-b' },
+  ];
+  const gateway = gatewaySnapshot({
+    status: 'up', degraded: false, coordinator: { status: 'up', checked_at: stamp(0) },
+    pool: { total_providers: 2, ready: 2, degraded: 0, draining: 0, unavailable: 0 },
+    models: expectedFleet.map(({ model_id }) => ({
+      id: model_id, provider_count: 1, ready_provider_count: 1, slots_free: 1,
+      available: true, availability: 'available', degraded: false,
+    })),
+  });
+  const operatorPool = poolzSnapshot({ pool: expectedFleet.map(({ provider_id, model_id }, index) => ({
+    provider_id, assigned_id: `session-${index}`, model_id, state: 'ready', routing_eligible: true,
+    connected_at: stamp(-60_000), last_heartbeat_at: stamp(-1_000), last_activity_at: stamp(-500),
+  })) }, now);
+  const providers = [
+    safetyProvider('provider-a', 'model-a', 'session-0'),
+    safetyProvider('provider-b', 'model-b', 'session-1'),
+  ];
+  const initial = { gateway, operator_pool: operatorPool, providers };
+  const observed = structuredClone(initial);
+  observed.operator_pool[0].state = 'busy';
+  observed.operator_pool[0].routing_eligible = false;
+  observed.providers[0].status = 'busy';
+  observed.providers[0].requests_in_flight = 1;
+
+  assert.ok(safetyObservationReasons(initial, observed, expectedFleet).length > 0);
+  assert.deepEqual(safetyObservationReasons(initial, observed, expectedFleet, {
+    activeModelID: 'model-a',
+  }), []);
+});
+
 test('active-request safety accepts a non-first duplicate-model provider without dropping the model', () => {
   const now = Date.now();
   const stamp = (offset) => new Date(now + offset).toISOString();

--- a/test/e2e/canary-buyer/safety.mjs
+++ b/test/e2e/canary-buyer/safety.mjs
@@ -109,11 +109,11 @@ export function gatewayInvariantReasons(initial, current, {
   const reasons = [];
   const beforeModels = new Map((before?.models || []).map((model) => [model.id, model]));
   const afterModels = new Map((after.models || []).map((model) => [model.id, model]));
-  // The gateway excludes a coordinator row as soon as it becomes
-  // non-routable. An active request may therefore remove exactly one provider
-  // from the buyer-facing aggregate. The model disappears only when that was
-  // the model's sole ready provider; duplicate-provider models must remain
-  // available with one fewer ready provider.
+  // The gateway may exclude a coordinator row as soon as it becomes
+  // non-routable, but some runtimes keep the active row buyer-visible while the
+  // request is in flight. Accept either stable counts or one active-provider
+  // loss. The model may disappear only when that was its sole ready provider;
+  // duplicate-provider models must remain available.
   const activeModelBefore = activeModelID ? beforeModels.get(activeModelID) : null;
   const activeModelDropped = Boolean(activeModelBefore && !afterModels.has(activeModelID));
   const activeProviderLossAllowed = Boolean(activeModelBefore);
@@ -138,14 +138,14 @@ export function gatewayInvariantReasons(initial, current, {
     reasons.push(`pool_draining_${after.pool.draining}_gt_${maxDrainingProviders}`);
   }
   if (Number.isInteger(before?.pool?.total_providers)) {
-    const expectedTotal = before.pool.total_providers - (activeProviderLossAllowed ? 1 : 0);
-    if (after.pool.total_providers !== expectedTotal) {
+    const minTotal = before.pool.total_providers - (activeProviderLossAllowed ? 1 : 0);
+    if (after.pool.total_providers < minTotal || after.pool.total_providers > before.pool.total_providers) {
       reasons.push(`total_providers_changed_${before.pool.total_providers}_to_${after.pool.total_providers}`);
     }
   }
   if (Number.isInteger(before?.pool?.ready)) {
-    const expectedReady = before.pool.ready - (activeProviderLossAllowed ? 1 : 0);
-    if (after.pool.ready !== expectedReady) {
+    const minReady = before.pool.ready - (activeProviderLossAllowed ? 1 : 0);
+    if (after.pool.ready < minReady || after.pool.ready > before.pool.ready) {
       reasons.push(`ready_changed_${before.pool.ready}_to_${after.pool.ready}`);
     }
   }
@@ -159,9 +159,11 @@ export function gatewayInvariantReasons(initial, current, {
     if (observed.degraded || !observed.available) {
       reasons.push(`${id}:model_not_stably_available`);
     }
-    if (Number.isInteger(model.ready_provider_count)
-        && observed.ready_provider_count !== model.ready_provider_count - (activeProviderLossAllowed && id === activeModelID ? 1 : 0)) {
-      reasons.push(`${id}:ready_provider_count_changed_${model.ready_provider_count}_to_${observed.ready_provider_count}`);
+    if (Number.isInteger(model.ready_provider_count)) {
+      const minReady = model.ready_provider_count - (activeProviderLossAllowed && id === activeModelID ? 1 : 0);
+      if (observed.ready_provider_count < minReady || observed.ready_provider_count > model.ready_provider_count) {
+        reasons.push(`${id}:ready_provider_count_changed_${model.ready_provider_count}_to_${observed.ready_provider_count}`);
+      }
     }
   }
   return reasons;

--- a/test/e2e/canary-buyer/safety.test.mjs
+++ b/test/e2e/canary-buyer/safety.test.mjs
@@ -93,6 +93,9 @@ test('gateway pre/post invariants match exact active non-routable aggregation lo
   assert.deepEqual(gatewayInvariantReasons(initial, active, {
     minReadyProviders: 2, activeModelID: 'model-a',
   }), []);
+  assert.deepEqual(gatewayInvariantReasons(initial, initial, {
+    minReadyProviders: 2, activeModelID: 'model-a',
+  }), []);
   const inventedDegradedRow = structuredClone(initial);
   inventedDegradedRow.pool.ready = 1;
   inventedDegradedRow.pool.degraded = 1;


### PR DESCRIPTION
## Summary

Follow-up for #825 after the first Pearl `v1.8.74` deploy attempt failed closed in the buyer canary. Pearl's Qwen3-8B provider stayed visible in the gateway aggregate while the liveness request was in flight, but the safety observer expected a forced one-provider aggregate decrement for the active model and aborted the request before it could complete.

Changes:
- Treat the active-request gateway aggregate as a bounded range: stable counts or one active-provider loss are allowed; aggregate growth and extra loss still fail closed.
- Keep the allowance scoped to the identified active model/provider and outside qualification isolation.
- Add integrated `safetyObservationReasons` regression coverage for Pearl's exact path: active single-provider row busy/non-routable, provider telemetry one request in flight, gateway counts unchanged.
- Move the Pearl canary authority to `issue-825-canary-fleet-r2`, with protected file hashes pinned to source-authority commit `d2b31d0f2e18631764f9a5f4c1c5b28cc0b46142`.
- Update the operator runbook wording to name the r2 #825 active-count authority.

## Validation

- `python3 ops/pearl-updater/test_pearl_updater.py` — 180 OK, 1 skipped
- `node --test test/e2e/canary-buyer/probe.test.mjs test/e2e/canary-buyer/safety.test.mjs` — 31/31 pass
- `bash test/e2e/canary-buyer/run-canary.test.sh`
- `bash scripts/test-pearl-runtime-release.sh`
- `python3 scripts/verify-pearl-go-binaries.py --self-test`
- `git diff --check origin/main..HEAD`
- Three audit lanes: code, security/ops, and architect all at 0 Critical / 0 High / 0 Medium findings; Low comments were fixed in this branch.

SPEC-GOVERNANCE-DECLARATION-BEGIN
{
  "schema_version": "spec-pr-governance-v1",
  "behavior_change": "yes",
  "contract_change": "none",
  "specs": ["SPEC-020"],
  "requirements": ["SPEC-020-R003", "SPEC-020-R004"],
  "authority_domains": ["provider-autoupdate", "canary-sanction-lifecycle"],
  "arbitration": ["CODE_BUG"],
  "tests": [
    "python3 ops/pearl-updater/test_pearl_updater.py",
    "node --test test/e2e/canary-buyer/probe.test.mjs test/e2e/canary-buyer/safety.test.mjs",
    "bash test/e2e/canary-buyer/run-canary.test.sh",
    "bash scripts/test-pearl-runtime-release.sh",
    "python3 scripts/verify-pearl-go-binaries.py --self-test",
    "git diff --check origin/main..HEAD"
  ],
  "journeys": ["Pearl deploy retry after merge for issue 825"],
  "issue": "https://github.com/Augustas11/macprovider/issues/825"
}
SPEC-GOVERNANCE-DECLARATION-END
