### PR TITLE
feat(payout): POST /admin/ledger/payout-ready compensation endpoint (SPEC-016 §9.5b)

### DIFF
--- a/phase4-coordinator/cmd/coordinator/main.go
+++ b/phase4-coordinator/cmd/coordinator/main.go
@@ -860,7 +860,12 @@ func main() {
 	if statsPools != nil {
 		idlePrewarmReader = statsprewarm.NewReader(statsPools.Reader)
 	}
-	billingHandler := billingStore.HandlersWithQuarantineGatesAndIdlePrewarm(
+	// SPEC-005 vX.Y+1 §9.5b — the `/admin/ledger/payout-ready`
+	// reorg-compensation endpoint caps provider_credits at the same
+	// immutable §5.2 per-payout ceiling the runner enforces
+	// (payout.security.per_payout_cap_usdc_base_units). payout.security.*
+	// is not live-reloaded, so the cap is threaded in as a scalar here.
+	billingHandler := billingStore.HandlersWithQuarantineGatesIdlePrewarmAndPayoutCap(
 		cfg.Auth.OperatorKey,
 		tokenStore,
 		cfg.Auth.RequireProviderTokens,
@@ -868,6 +873,7 @@ func main() {
 		cfg.Billing.QuarantineResolutionForceVoidEnabled,
 		cfg.Billing.QuarantineResolutionForceCreditEnabled,
 		idlePrewarmReader,
+		cfg.Payout.Security.PerPayoutCapUSDCBaseUnits,
 	)
 	// §11.5 launch-gate item 10 — operator-visible startup state.
 	logger.Info().

--- a/phase4-coordinator/internal/billing/endpoints.go
+++ b/phase4-coordinator/internal/billing/endpoints.go
@@ -50,19 +50,30 @@ func (s *Store) Handlers(operatorKey string, tokenStore tokenValidator, requireP
 // below) so it shares atomicity with the ledger_config_snapshots
 // row §13.2 already requires.
 func (s *Store) HandlersWithQuarantineGate(operatorKey string, tokenStore tokenValidator, requireProviderTokens bool, earningsRateLimitPerMin int, forceVoidEnabled bool) http.Handler {
-	return s.handlersInternal(operatorKey, "", tokenStore, requireProviderTokens, earningsRateLimitPerMin, forceVoidEnabled, false, nil)
+	return s.handlersInternal(operatorKey, "", tokenStore, requireProviderTokens, earningsRateLimitPerMin, forceVoidEnabled, false, nil, 0)
 }
 
 func (s *Store) HandlersWithQuarantineGateAndIdlePrewarm(operatorKey string, tokenStore tokenValidator, requireProviderTokens bool, earningsRateLimitPerMin int, forceVoidEnabled bool, idlePrewarm idlePrewarmReader) http.Handler {
-	return s.handlersInternal(operatorKey, "", tokenStore, requireProviderTokens, earningsRateLimitPerMin, forceVoidEnabled, false, idlePrewarm)
+	return s.handlersInternal(operatorKey, "", tokenStore, requireProviderTokens, earningsRateLimitPerMin, forceVoidEnabled, false, idlePrewarm, 0)
 }
 
 func (s *Store) HandlersWithQuarantineGates(operatorKey string, tokenStore tokenValidator, requireProviderTokens bool, earningsRateLimitPerMin int, forceVoidEnabled bool, forceCreditEnabled bool) http.Handler {
-	return s.handlersInternal(operatorKey, "", tokenStore, requireProviderTokens, earningsRateLimitPerMin, forceVoidEnabled, forceCreditEnabled, nil)
+	return s.handlersInternal(operatorKey, "", tokenStore, requireProviderTokens, earningsRateLimitPerMin, forceVoidEnabled, forceCreditEnabled, nil, 0)
 }
 
 func (s *Store) HandlersWithQuarantineGatesAndIdlePrewarm(operatorKey string, tokenStore tokenValidator, requireProviderTokens bool, earningsRateLimitPerMin int, forceVoidEnabled bool, forceCreditEnabled bool, idlePrewarm idlePrewarmReader) http.Handler {
-	return s.handlersInternal(operatorKey, "", tokenStore, requireProviderTokens, earningsRateLimitPerMin, forceVoidEnabled, forceCreditEnabled, idlePrewarm)
+	return s.handlersInternal(operatorKey, "", tokenStore, requireProviderTokens, earningsRateLimitPerMin, forceVoidEnabled, forceCreditEnabled, idlePrewarm, 0)
+}
+
+// HandlersWithQuarantineGatesIdlePrewarmAndPayoutCap is the SPEC-005
+// vX.Y+1 constructor (SPEC-016 §9.5b HARD prereq) that additionally
+// threads the immutable §5.2 per-payout cap
+// (payout.security.per_payout_cap_usdc_base_units) into the
+// `/admin/ledger/payout-ready` reorg-compensation handler. The cap is
+// a startup-immutable scalar (payout.security.* is not live-reloaded),
+// so it is passed by value rather than read through a reload primitive.
+func (s *Store) HandlersWithQuarantineGatesIdlePrewarmAndPayoutCap(operatorKey string, tokenStore tokenValidator, requireProviderTokens bool, earningsRateLimitPerMin int, forceVoidEnabled bool, forceCreditEnabled bool, idlePrewarm idlePrewarmReader, perPayoutCapBaseUnits int64) http.Handler {
+	return s.handlersInternal(operatorKey, "", tokenStore, requireProviderTokens, earningsRateLimitPerMin, forceVoidEnabled, forceCreditEnabled, idlePrewarm, perPayoutCapBaseUnits)
 }
 
 // HandlersWithBridge mounts the admin/provider handlers. The
@@ -75,10 +86,10 @@ func (s *Store) HandlersWithQuarantineGatesAndIdlePrewarm(operatorKey string, to
 // accepted. Handlers (the legacy single-arg signature) is kept as a
 // thin shim so test fixtures and direct callers don't churn.
 func (s *Store) HandlersWithBridge(operatorKey, _gatewayServiceTokenIgnoredAdminOnly string, tokenStore tokenValidator, requireProviderTokens bool, earningsRateLimitPerMin int) http.Handler {
-	return s.handlersInternal(operatorKey, _gatewayServiceTokenIgnoredAdminOnly, tokenStore, requireProviderTokens, earningsRateLimitPerMin, false, false, nil)
+	return s.handlersInternal(operatorKey, _gatewayServiceTokenIgnoredAdminOnly, tokenStore, requireProviderTokens, earningsRateLimitPerMin, false, false, nil, 0)
 }
 
-func (s *Store) handlersInternal(operatorKey, _gatewayServiceTokenIgnoredAdminOnly string, tokenStore tokenValidator, requireProviderTokens bool, earningsRateLimitPerMin int, forceVoidEnabled bool, forceCreditEnabled bool, idlePrewarm idlePrewarmReader) http.Handler {
+func (s *Store) handlersInternal(operatorKey, _gatewayServiceTokenIgnoredAdminOnly string, tokenStore tokenValidator, requireProviderTokens bool, earningsRateLimitPerMin int, forceVoidEnabled bool, forceCreditEnabled bool, idlePrewarm idlePrewarmReader, perPayoutCapBaseUnits int64) http.Handler {
 	// SPEC-005 v0.4 (issue #169) — handler CONSTRUCTION must not be
 	// able to silently flip the live route-layer flag. R8 fix
 	// (ARCH-M1) replaces the unconditional SetForceVoidEnabled call
@@ -107,6 +118,7 @@ func (s *Store) handlersInternal(operatorKey, _gatewayServiceTokenIgnoredAdminOn
 		tokenStore:              tokenStore,
 		requireProviderTokens:   requireProviderTokens,
 		earningsRateLimitPerMin: earningsRateLimitPerMin,
+		perPayoutCapBaseUnits:   perPayoutCapBaseUnits,
 		lastEarnings:            map[string][]time.Time{},
 		adminBucket:             newAdminRateLimiter(),
 		idlePrewarm:             idlePrewarm,
@@ -121,6 +133,7 @@ type handler struct {
 	tokenStore              tokenValidator
 	requireProviderTokens   bool
 	earningsRateLimitPerMin int
+	perPayoutCapBaseUnits   int64
 	mu                      sync.Mutex
 	lastEarnings            map[string][]time.Time
 	adminBucket             *adminRateLimiter
@@ -245,6 +258,12 @@ func (h *handler) serveHTTP(w http.ResponseWriter, r *http.Request) {
 			h.forceCreditHandler(w, r, m.id)
 			return
 		}
+	}
+	// SPEC-005 vX.Y+1 §9.5b reorg-compensation admin endpoint
+	// (SPEC-016 §9.5b HARD prereq for USDC payouts).
+	if r.URL.Path == payoutReadyPath {
+		h.payoutReadyHandler(w, r)
+		return
 	}
 	switch {
 	case r.URL.Path == "/admin/ledger/summary":

--- a/phase4-coordinator/internal/billing/payout_ready.go
+++ b/phase4-coordinator/internal/billing/payout_ready.go
@@ -1,0 +1,487 @@
+package billing
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/augstar/macprovider-coordinator/internal/auth"
+)
+
+// SPEC-005 vX.Y+1 §9.5b `POST /admin/ledger/payout-ready` admin
+// endpoint — the SPEC-016 §9.5b HARD prerequisite for the USDC payout
+// pipeline's §4.7 reorg-compensation flow.
+//
+// The endpoint inserts a fresh `ledger_payout_ready` compensation row
+// bound (in the SAME BEGIN IMMEDIATE transaction) to the IMMUTABLE
+// `payout_reorg_orphans.observed_*` snapshot columns owned by
+// SPEC-016. It does NOT set `compensation_settlement_id` — that link
+// is written later by `/admin/payout/record-orphan` (the two-call
+// flow). The `UNIQUE(idempotency_key)` constraint on
+// `ledger_payout_ready` is the double-compensation guard.
+//
+// This handler MIRRORS the force-void write path in quarantine.go:
+// Content-Type / size guards, a dedicated conn running an explicit
+// `BEGIN IMMEDIATE` (modernc.org/sqlite's BeginTx does not map to
+// IMMEDIATE without a DSN txlock we don't control), a committed bool
+// with a deferred ROLLBACK, and the audit_log INSERT through the SAME
+// conn so it shares atomicity with the ledger row.
+
+const (
+	payoutReadyPath          = "/admin/ledger/payout-ready"
+	eventPayoutReadyInserted = "ledger_payout_ready_admin_inserted"
+	// payoutReadyActor is a fixed principal marker, NOT the operator
+	// bearer secret. The §9.5b.1 contract phrases the audit `actor`
+	// field as `actor=operator_key`, meaning the request was
+	// authenticated by the operator key — writing the literal secret
+	// into a durable audit table would leak it. See NOTE in the
+	// handler / implementation report.
+	payoutReadyActor = "operator_key"
+)
+
+// reorgCompensationKeyRe matches the §9.5b.1 idempotency_key shape;
+// the two capture groups are orig_payout_id and orig_attempt_seq.
+var reorgCompensationKeyRe = regexp.MustCompile(`^reorg_compensation:(\d+):(\d+)$`)
+
+type payoutReadyRequest struct {
+	ProviderID               string `json:"provider_id"`
+	GrossCredits             int64  `json:"gross_credits"`
+	ProviderCredits          int64  `json:"provider_credits"`
+	OperatorCredits          int64  `json:"operator_credits"`
+	CadenceDays              int64  `json:"cadence_days"`
+	SourceCreditCount        int64  `json:"source_credit_count"`
+	MinPayoutCreditsOverride int64  `json:"min_payout_credits_override"`
+	IdempotencyKey           string `json:"idempotency_key"`
+	WindowStartUTC           string `json:"window_start_utc"`
+	WindowEndUTC             string `json:"window_end_utc"`
+	Reason                   string `json:"reason"`
+}
+
+// payoutReadyHandler implements POST /admin/ledger/payout-ready.
+func (h *handler) payoutReadyHandler(w http.ResponseWriter, r *http.Request) {
+	// FIX 13 fail-closed: the §5.2 per-payout cap is a money-path
+	// blast-radius bound. A legacy / mis-wired construction (any
+	// constructor other than HandlersWithQuarantineGatesIdlePrewarmAndPayoutCap
+	// passes 0) MUST NOT be able to mount a payout authorizer with an
+	// unbounded (cap 0 → everything > 0 rejected, but a future
+	// >=-comparison regression could invert that) or absent cap. When
+	// the cap is not positively configured we treat the endpoint as
+	// NOT MOUNTED — byte-indistinguishable 404 before auth, so a
+	// mis-wired binary cannot authorize any compensation at all.
+	if h.perPayoutCapBaseUnits <= 0 {
+		writeError(w, http.StatusNotFound, "not_found", "not found")
+		return
+	}
+	// Auth (403) → admin rate limit (429) → method (405), per §9.5b.1.
+	if !auth.OperatorOnlyBearerMatches(r.Header, h.operatorKey) {
+		writeError(w, http.StatusForbidden, "forbidden", "operator key required")
+		return
+	}
+	if !h.allowAdminRequest(w) {
+		return
+	}
+	if r.Method != http.MethodPost {
+		writeError(w, http.StatusMethodNotAllowed, "method_not_allowed", "method not allowed")
+		return
+	}
+
+	// Body-shape pre-checks before reading (mirror quarantine.go).
+	if ct := r.Header.Get("Content-Type"); !isJSONContentType(ct) {
+		writeError(w, http.StatusUnsupportedMediaType, "unsupported_media_type", "content-type must be application/json")
+		return
+	}
+	if r.ContentLength > maxBodyBytes {
+		writeError(w, http.StatusRequestEntityTooLarge, "request_too_large", "body exceeds 4 KiB")
+		return
+	}
+	r.Body = http.MaxBytesReader(w, r.Body, maxBodyBytes+1)
+	defer r.Body.Close()
+
+	body, ok := decodePayoutReadyBody(w, r)
+	if !ok {
+		return
+	}
+
+	// §9.5b.1 400s — request-shape validation before touching the DB.
+	headerKey := r.Header.Get("Idempotency-Key")
+	if headerKey != body.IdempotencyKey {
+		writeError(w, http.StatusBadRequest, "bad_request", "Idempotency-Key header must byte-equal body idempotency_key")
+		return
+	}
+	m := reorgCompensationKeyRe.FindStringSubmatch(body.IdempotencyKey)
+	if m == nil {
+		writeError(w, http.StatusBadRequest, "bad_request", "idempotency_key must match ^reorg_compensation:\\d+:\\d+$")
+		return
+	}
+	// Regex guarantees the two groups are decimal digit runs; the only
+	// remaining failure is int64 overflow.
+	origPayoutID, err := strconv.ParseInt(m[1], 10, 64)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, "bad_request", "orig_payout_id overflows int64")
+		return
+	}
+	origAttemptSeq, err := strconv.ParseInt(m[2], 10, 64)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, "bad_request", "orig_attempt_seq overflows int64")
+		return
+	}
+	// The idempotency_key MUST be the CANONICAL encoding of the parsed
+	// orphan identity. The regex admits leading zeros / non-minimal
+	// encodings (e.g. `reorg_compensation:05:1`), which parse to the
+	// SAME (payout_id, attempt_seq) yet are DISTINCT TEXT keys — so
+	// UNIQUE(idempotency_key) would not collide and the exact-text
+	// replay probe would miss, letting two rows bind to one orphan
+	// (double-pay). Requiring canonical form makes the text key 1:1 with
+	// the orphan identity.
+	if body.IdempotencyKey != fmt.Sprintf("reorg_compensation:%d:%d", origPayoutID, origAttemptSeq) {
+		writeError(w, http.StatusBadRequest, "bad_request", "non-canonical idempotency_key; leading zeros / non-minimal encodings are rejected")
+		return
+	}
+	if strings.TrimSpace(body.ProviderID) == "" {
+		writeError(w, http.StatusBadRequest, "bad_request", "provider_id is required")
+		return
+	}
+	if strings.TrimSpace(body.Reason) == "" {
+		writeError(w, http.StatusBadRequest, "bad_request", "reason is required")
+		return
+	}
+	if body.CadenceDays <= 0 {
+		writeError(w, http.StatusBadRequest, "bad_request", "cadence_days must be > 0")
+		return
+	}
+	if body.SourceCreditCount <= 0 {
+		writeError(w, http.StatusBadRequest, "bad_request", "source_credit_count must be > 0")
+		return
+	}
+	if body.MinPayoutCreditsOverride != 0 {
+		writeError(w, http.StatusBadRequest, "bad_request", "min_payout_credits_override must be 0")
+		return
+	}
+	// Synthetic window values must be RFC3339Nano; normalize to the
+	// canonical SQLite text form used by every other ledger time column.
+	windowStart, okStart := normalizeSQLiteTimeText(body.WindowStartUTC)
+	if !okStart {
+		writeError(w, http.StatusBadRequest, "bad_request", "window_start_utc must be RFC3339Nano")
+		return
+	}
+	windowEnd, okEnd := normalizeSQLiteTimeText(body.WindowEndUTC)
+	if !okEnd {
+		writeError(w, http.StatusBadRequest, "bad_request", "window_end_utc must be RFC3339Nano")
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(r.Context(), 5*time.Second)
+	defer cancel()
+
+	conn, err := h.store.db.Conn(ctx)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "internal_error", "acquire conn: "+err.Error())
+		return
+	}
+	defer conn.Close()
+	if _, err := conn.ExecContext(ctx, `BEGIN IMMEDIATE`); err != nil {
+		writeError(w, http.StatusInternalServerError, "internal_error", "begin immediate: "+err.Error())
+		return
+	}
+	committed := false
+	defer func() {
+		if !committed {
+			_, _ = conn.ExecContext(context.Background(), `ROLLBACK`)
+		}
+	}()
+
+	// Idempotent-replay probe (§9.5b.1 lines 4386–4387): a repeated
+	// idempotency_key MUST return 409 with the ORIGINAL 201 body,
+	// regardless of the orphan's CURRENT state. Once a compensation has
+	// been recorded and its orphan resolved/linked, the orphan
+	// preconditions below (resolved_at_utc IS NULL → no_matching_orphan;
+	// compensation_settlement_id.Valid → already_compensated) would
+	// otherwise short-circuit a replay to a 422. Probing the ledger key
+	// first makes a true replay win. The UNIQUE-violation path on the
+	// INSERT below stays as the concurrency backstop for two first-calls
+	// racing before either commits. QueryRowContext closes its Rows, so
+	// the dedicated conn stays free for the subsequent statements.
+	var replayID int64
+	switch err := conn.QueryRowContext(ctx, `
+SELECT id FROM ledger_payout_ready WHERE idempotency_key = ?`, body.IdempotencyKey).Scan(&replayID); {
+	case err == nil:
+		writeJSON(w, http.StatusConflict, map[string]any{"id": replayID})
+		return
+	case errors.Is(err, sql.ErrNoRows):
+		// Fresh key — proceed to orphan preconditions + INSERT.
+	default:
+		writeError(w, http.StatusInternalServerError, "internal_error", "replay probe: "+err.Error())
+		return
+	}
+
+	// §9.5b.1 orphan binding — SELECT the IMMUTABLE snapshot columns in
+	// the SAME transaction as the INSERT.
+	var (
+		observedProviderID      string
+		observedProviderCredits int64
+		observedGrossCredits    int64
+		observedAmountBaseUnits int64
+		compensationSettlement  sql.NullInt64
+		isCancelSelfTransfer    int64
+	)
+	// JOIN payout_attempts (1:1 on (payout_id, attempt_seq)) to pull
+	// is_cancel_self_transfer, which lives on payout_attempts, NOT on
+	// payout_reorg_orphans. §9.5b.1 line 4481 requires EXACTLY ONE
+	// orphan row: two unresolved orphans with different orphan_tx_hash
+	// can coexist for the same (payout_id, attempt_seq) (the partial
+	// UNIQUE index keys on orphan_tx_hash too), so we fail closed on
+	// multiplicity rather than silently binding to the first. The
+	// `resolved_at_utc IS NULL` filter (matching the idx_pro_unresolved
+	// compensable set) excludes orphans an operator terminally resolved
+	// via /admin/payout/record-orphan — e.g. "no compensation; provider
+	// acknowledged" — which leave compensation_settlement_id NULL but
+	// MUST NOT mint a payout. A resolved orphan yields 0 rows → the
+	// existing no_matching_orphan 422 (fail-closed).
+	rows, err := conn.QueryContext(ctx, `
+SELECT pro.observed_provider_id, pro.observed_provider_credits, pro.observed_gross_credits,
+       pro.observed_amount_base_units, pro.compensation_settlement_id,
+       pa.is_cancel_self_transfer
+  FROM payout_reorg_orphans pro
+  JOIN payout_attempts pa
+    ON pa.payout_id = pro.payout_id AND pa.attempt_seq = pro.attempt_seq
+ WHERE pro.payout_id = ? AND pro.attempt_seq = ? AND pro.resolved_at_utc IS NULL`, origPayoutID, origAttemptSeq)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "internal_error", "orphan lookup: "+err.Error())
+		return
+	}
+	if !rows.Next() {
+		rowsErr := rows.Err()
+		rows.Close()
+		if rowsErr != nil {
+			writeError(w, http.StatusInternalServerError, "internal_error", "orphan lookup: "+rowsErr.Error())
+			return
+		}
+		writeValidationError(w, "no_matching_orphan", "no payout_reorg_orphans row for the idempotency_key")
+		return
+	}
+	if err := rows.Scan(&observedProviderID, &observedProviderCredits, &observedGrossCredits,
+		&observedAmountBaseUnits, &compensationSettlement, &isCancelSelfTransfer); err != nil {
+		rows.Close()
+		writeError(w, http.StatusInternalServerError, "internal_error", "orphan scan: "+err.Error())
+		return
+	}
+	multiple := rows.Next()
+	rowsErr := rows.Err()
+	// Close the Rows explicitly before issuing further statements on the
+	// same dedicated conn — an open Rows on a MaxOpenConns(1) *sql.DB
+	// would block the subsequent INSERT / COMMIT on this conn.
+	rows.Close()
+	if rowsErr != nil {
+		writeError(w, http.StatusInternalServerError, "internal_error", "orphan lookup: "+rowsErr.Error())
+		return
+	}
+	if multiple {
+		writeValidationError(w, "ambiguous_orphan", "multiple unresolved payout_reorg_orphans rows for the idempotency_key")
+		return
+	}
+	if compensationSettlement.Valid {
+		writeValidationError(w, "orphan_already_compensated", "orphan already has a compensation_settlement_id")
+		return
+	}
+	// Cancel-self-transfer orphans are NON-compensable: per SPEC-016
+	// lines 2043–2048 a cancel self-transfer does not consume
+	// ledger_payout_ready and the §9.5b compensation flow does not
+	// apply (the §4.3 cancel carve-out). record-orphan writes an orphan
+	// row for cancel attempts too, so the endpoint MUST reject them here
+	// or it would mint real USDC for a non-compensable event.
+	if isCancelSelfTransfer == 1 {
+		writeValidationError(w, "orphan_not_compensable", "cancel-self-transfer orphans are not compensable (SPEC-016 §9.5b/§4.3 carve-out)")
+		return
+	}
+	// Binding assertions — name the failed field per §9.5b.1.
+	if body.ProviderID != observedProviderID {
+		writeOrphanMismatch(w, "provider_id")
+		return
+	}
+	if body.ProviderCredits != observedProviderCredits {
+		writeOrphanMismatch(w, "provider_credits")
+		return
+	}
+	// The compensation gross MUST equal the observed PROVIDER credits
+	// (operator share is pinned to 0), NOT observed_gross_credits.
+	if body.GrossCredits != observedProviderCredits {
+		writeOrphanMismatch(w, "gross_credits")
+		return
+	}
+	if body.OperatorCredits != 0 {
+		writeOrphanMismatch(w, "operator_credits")
+		return
+	}
+	_ = observedGrossCredits    // recorded for audit trail; not a target
+	_ = observedAmountBaseUnits // recorded for audit trail; not a target
+
+	// Provider must exist in provider_tokens (§9.5b.1 422).
+	var providerExists int
+	if err := conn.QueryRowContext(ctx, `
+SELECT EXISTS(SELECT 1 FROM provider_tokens WHERE provider_id = ?)`, body.ProviderID).Scan(&providerExists); err != nil {
+		writeError(w, http.StatusInternalServerError, "internal_error", "provider lookup: "+err.Error())
+		return
+	}
+	if providerExists == 0 {
+		writeValidationError(w, "provider_not_found", "provider_id not found in provider_tokens")
+		return
+	}
+	// STRICT equality gross == provider (v0.1.8; §9.5b.1). Redundant
+	// with the binding checks above (both pin to observed_provider_credits)
+	// but asserted explicitly so a future binding change cannot silently
+	// admit gross != provider skimming into reconciliation drift.
+	if body.GrossCredits != body.ProviderCredits {
+		writeValidationError(w, "gross_provider_mismatch", "gross_credits must strictly equal provider_credits")
+		return
+	}
+	// §5.2 per-payout cap. 1 credit == 1 USDC base unit (C3 invariant),
+	// so no unit conversion.
+	if body.ProviderCredits > h.perPayoutCapBaseUnits {
+		writeValidationError(w, "per_payout_cap_exceeded", "provider_credits exceeds per_payout_cap_usdc_base_units")
+		return
+	}
+
+	nowTime := h.store.now().UTC()
+	now := sqliteTimeText(nowTime)
+	reason := body.Reason
+
+	// INSERT the compensation row. operator_credits and
+	// min_payout_credits are pinned to 0; payout_currency /
+	// payout_external_id default to NULL. Does NOT trigger a settlement
+	// run and does NOT write ledger_request_credits.
+	res, err := conn.ExecContext(ctx, `
+INSERT INTO ledger_payout_ready
+    (provider_id, window_start_utc, window_end_utc, cadence_days, source_credit_count,
+     gross_credits, provider_credits, operator_credits, min_payout_credits,
+     status, idempotency_key, created_at_utc)
+VALUES (?, ?, ?, ?, ?, ?, ?, 0, 0, 'ready', ?, ?)`,
+		body.ProviderID, windowStart, windowEnd, body.CadenceDays, body.SourceCreditCount,
+		body.GrossCredits, body.ProviderCredits, body.IdempotencyKey, now)
+	if err != nil {
+		if isSQLiteUniqueConstraint(err) {
+			// idempotency_key replay (or window collision). Release the
+			// tx conn BEFORE re-reading via h.store.db — MaxOpenConns(1)
+			// on the shared *sql.DB would otherwise deadlock the re-read.
+			// FIX 10: ROLLBACK with context.Background(), NOT the request
+			// ctx — a canceled/expired request ctx would skip the ROLLBACK
+			// and leave the BEGIN IMMEDIATE txn open on the sole conn,
+			// wedging the billing store.
+			_, _ = conn.ExecContext(context.Background(), `ROLLBACK`)
+			committed = true // suppress the deferred ROLLBACK
+			conn.Close()
+			h.respondPayoutReadyReplay(w, ctx, body.IdempotencyKey)
+			return
+		}
+		writeError(w, http.StatusInternalServerError, "internal_error", "insert payout_ready: "+err.Error())
+		return
+	}
+	newID, err := res.LastInsertId()
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "internal_error", "last insert id: "+err.Error())
+		return
+	}
+
+	// Audit-log INSERT through the SAME conn (shares atomicity). Exactly
+	// the six §9.5b.1 fields; actor is the principal marker, not the secret.
+	payload := map[string]any{
+		"provider_id":     body.ProviderID,
+		"id":              newID,
+		"idempotency_key": body.IdempotencyKey,
+		"reason":          reason,
+		"actor":           payoutReadyActor,
+		"ts_utc":          now,
+	}
+	payloadJSON, err := json.Marshal(payload)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "internal_error", "marshal audit payload: "+err.Error())
+		return
+	}
+	if _, err := conn.ExecContext(ctx, `
+INSERT INTO audit_log (ts_utc, event_type, provider_id, payload_json)
+VALUES (?, ?, ?, ?)`, now, eventPayoutReadyInserted, body.ProviderID, string(payloadJSON)); err != nil {
+		writeError(w, http.StatusInternalServerError, "internal_error", "insert audit: "+err.Error())
+		return
+	}
+
+	if _, err := conn.ExecContext(ctx, `COMMIT`); err != nil {
+		writeError(w, http.StatusInternalServerError, "internal_error", "commit: "+err.Error())
+		return
+	}
+	committed = true
+
+	// FIX 9 / §9.5b.1 line ~4448: emit the structured LOG event in
+	// addition to the durable audit_log row. Exactly the six spec
+	// fields; actor is the fixed principal marker payoutReadyActor —
+	// NEVER the operator bearer secret / KEK / token.
+	h.log.Info().
+		Str("event", eventPayoutReadyInserted).
+		Str("provider_id", body.ProviderID).
+		Int64("id", newID).
+		Str("idempotency_key", body.IdempotencyKey).
+		Str("reason", reason).
+		Str("actor", payoutReadyActor).
+		Str("ts_utc", now).
+		Msg("payout-ready reorg-compensation row inserted")
+
+	writeJSON(w, http.StatusCreated, map[string]any{"id": newID})
+}
+
+// respondPayoutReadyReplay re-reads the winning row's id by
+// idempotency_key and returns the original 201-shaped body with a 409.
+// The caller MUST release the tx conn before calling this.
+func (h *handler) respondPayoutReadyReplay(w http.ResponseWriter, ctx context.Context, idempotencyKey string) {
+	var id int64
+	err := h.store.db.QueryRowContext(ctx, `
+SELECT id FROM ledger_payout_ready WHERE idempotency_key = ?`, idempotencyKey).Scan(&id)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			// The UNIQUE violation was on (provider_id, window_start_utc,
+			// window_end_utc), not idempotency_key — a genuine window
+			// collision with a different key. Report a conflict rather
+			// than fabricating a replay body.
+			writeError(w, http.StatusConflict, "window_conflict", "compensation window collides with an existing row")
+			return
+		}
+		writeError(w, http.StatusInternalServerError, "internal_error", "re-read payout_ready: "+err.Error())
+		return
+	}
+	writeJSON(w, http.StatusConflict, map[string]any{"id": id})
+}
+
+// writeOrphanMismatch emits the §9.5b.1 422 orphan_mismatch naming the
+// failed binding field.
+func writeOrphanMismatch(w http.ResponseWriter, field string) {
+	writeValidationError(w, "orphan_mismatch", "orphan binding mismatch on field: "+field)
+}
+
+// decodePayoutReadyBody decodes the request body into a
+// payoutReadyRequest, rejecting unknown fields and trailing content
+// with a 400 and distinguishing 413 (body too large).
+func decodePayoutReadyBody(w http.ResponseWriter, r *http.Request) (payoutReadyRequest, bool) {
+	body := payoutReadyRequest{}
+	dec := json.NewDecoder(r.Body)
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(&body); err != nil {
+		var mbErr *http.MaxBytesError
+		if errors.As(err, &mbErr) {
+			writeError(w, http.StatusRequestEntityTooLarge, "request_too_large", "body exceeds 4 KiB")
+			return body, false
+		}
+		writeError(w, http.StatusBadRequest, "bad_request", "invalid json body")
+		return body, false
+	}
+	// Reject trailing tokens after the top-level object (`{...} 42`).
+	if _, err := dec.Token(); err != io.EOF {
+		writeError(w, http.StatusBadRequest, "bad_request", "body must contain a single JSON object")
+		return body, false
+	}
+	return body, true
+}

--- a/phase4-coordinator/internal/billing/payout_ready_test.go
+++ b/phase4-coordinator/internal/billing/payout_ready_test.go
@@ -1,0 +1,986 @@
+package billing
+
+import (
+	"database/sql"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+// SPEC-005 vX.Y+1 §9.5b acceptance tests for
+// `POST /admin/ledger/payout-ready` (SPEC-016 §9.5b HARD prereq for
+// USDC payouts). Mirrors quarantine_test.go: in-package httptest with
+// an operator bearer, a single SQLite file shared by
+// ledger_payout_ready + payout_reorg_orphans + provider_tokens.
+
+const testPerPayoutCap int64 = 500_000_000
+
+// payoutReadyFixture builds a billing store and creates the sibling
+// tables the endpoint queries in-transaction. In production these are
+// created on the same DB file by auth.OpenStore (provider_tokens) and
+// the SPEC-016 payout migrations (payout_attempts, payout_reorg_orphans);
+// here we create them by hand.
+func payoutReadyFixture(t *testing.T) *Store {
+	t.Helper()
+	_, store := newRequestAndBillingStores(t)
+	createAuditLogForTest(t, store.db)
+	createPayoutReadySiblingTables(t, store.db)
+	return store
+}
+
+func createPayoutReadySiblingTables(t *testing.T, db *sql.DB) {
+	t.Helper()
+	stmts := []string{
+		`CREATE TABLE IF NOT EXISTS provider_tokens (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    token_hash TEXT NOT NULL UNIQUE,
+    token_prefix TEXT NOT NULL,
+    provider_id TEXT NOT NULL DEFAULT '',
+    provider_name TEXT NOT NULL,
+    created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now')),
+    revoked_at TEXT DEFAULT NULL,
+    last_used_at TEXT DEFAULT NULL
+);`,
+		`CREATE TABLE IF NOT EXISTS payout_attempts (
+    payout_id        INTEGER NOT NULL REFERENCES ledger_payout_ready(id) ON DELETE RESTRICT,
+    attempt_seq      INTEGER NOT NULL CHECK(attempt_seq >= 1),
+    chain            TEXT NOT NULL CHECK(chain = 'base-mainnet'),
+    from_address     TEXT NOT NULL,
+    to_address       TEXT NOT NULL,
+    amount_base_units INTEGER NOT NULL CHECK(amount_base_units > 0),
+    nonce            INTEGER NOT NULL CHECK(nonce >= 0),
+    raw_signed_tx    BLOB NULL,
+    tx_hash          TEXT NULL,
+    broadcast_at_utc TEXT NULL,
+    confirmed_at_utc TEXT NULL,
+    block_number     INTEGER NULL,
+    gas_used_native_wei INTEGER NULL,
+    is_cancel_self_transfer INTEGER NOT NULL DEFAULT 0 CHECK(is_cancel_self_transfer IN (0,1)),
+    last_error       TEXT NULL,
+    abandoned_at_utc TEXT NULL,
+    abandoned_reason TEXT NULL,
+    cancel_reconfirm_stale_paged_at_utc TEXT NULL,
+    updated_at_utc   TEXT NOT NULL,
+    PRIMARY KEY(payout_id, attempt_seq)
+);`,
+		`CREATE TABLE IF NOT EXISTS payout_reorg_orphans (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    payout_id        INTEGER NOT NULL REFERENCES ledger_payout_ready(id) ON DELETE RESTRICT,
+    attempt_seq      INTEGER NOT NULL,
+    orphan_tx_hash   TEXT NOT NULL,
+    last_seen_block  INTEGER NOT NULL,
+    observed_at_utc  TEXT NOT NULL,
+    rpc_source       TEXT NOT NULL,
+    observed_provider_id           TEXT    NOT NULL,
+    observed_provider_credits      INTEGER NOT NULL,
+    observed_gross_credits         INTEGER NOT NULL,
+    observed_amount_base_units     INTEGER NOT NULL,
+    operator_resolution TEXT NULL,
+    compensation_settlement_id INTEGER NULL REFERENCES ledger_payout_ready(id) ON DELETE RESTRICT,
+    resolved_at_utc  TEXT NULL,
+    FOREIGN KEY(payout_id, attempt_seq) REFERENCES payout_attempts(payout_id, attempt_seq) ON DELETE RESTRICT
+);`,
+	}
+	for _, s := range stmts {
+		if _, err := db.Exec(s); err != nil {
+			t.Fatalf("create sibling table: %v", err)
+		}
+	}
+}
+
+func seedProviderToken(t *testing.T, db *sql.DB, providerID string) {
+	t.Helper()
+	if _, err := db.Exec(`
+INSERT INTO provider_tokens (token_hash, token_prefix, provider_id, provider_name)
+VALUES (?, 'mp_', ?, ?)`, "hash-"+providerID, providerID, providerID); err != nil {
+		t.Fatalf("seed provider token: %v", err)
+	}
+}
+
+// seedOrphan inserts the original ledger_payout_ready row, a
+// payout_attempts row, and an unresolved payout_reorg_orphans row with
+// the given observed snapshot values. Returns (origPayoutID, attemptSeq).
+//
+// FIX 11: the original (mutable) ledger_payout_ready row is deliberately
+// seeded with DIFFERENT provider_id / provider_credits / gross_credits
+// than the immutable observed_* orphan snapshot. The endpoint binds to
+// observed_*, so a regression that read the mutable lpr.* row instead
+// would bind to these divergent values and fail the binding tests.
+func seedOrphan(t *testing.T, store *Store, providerID string, observedProviderCredits, observedGrossCredits, observedAmountBaseUnits int64) (int64, int64) {
+	t.Helper()
+	db := store.db
+	// Original payout row (the one that got reorged) — mutable values
+	// intentionally divergent from the observed_* snapshot below.
+	res, err := db.Exec(`
+INSERT INTO ledger_payout_ready
+    (provider_id, window_start_utc, window_end_utc, cadence_days, source_credit_count,
+     gross_credits, provider_credits, operator_credits, min_payout_credits,
+     status, idempotency_key, created_at_utc)
+VALUES (?, ?, ?, 1, 1, ?, ?, 0, 0, 'ready', ?, ?)`,
+		providerID+"-lpr-mutable", "2026-01-01T00:00:00.000000000Z", "2026-01-02T00:00:00.000000000Z",
+		observedGrossCredits+500, observedProviderCredits+500,
+		"settle:"+providerID+":orig-"+time.Now().UTC().Format("20060102150405.000000000"),
+		"2026-01-01T00:00:00.000000000Z")
+	if err != nil {
+		t.Fatalf("seed orig payout: %v", err)
+	}
+	origPayoutID, _ := res.LastInsertId()
+	const attemptSeq int64 = 1
+	if _, err := db.Exec(`
+INSERT INTO payout_attempts
+    (payout_id, attempt_seq, chain, from_address, to_address,
+     amount_base_units, nonce, tx_hash, broadcast_at_utc, is_cancel_self_transfer, updated_at_utc)
+VALUES (?, ?, 'base-mainnet', '0xfrom', '0xto', ?, 1, '0xorphan', '2026-01-03T00:00:00Z', 0, '2026-01-03T00:00:00Z')`,
+		origPayoutID, attemptSeq, observedAmountBaseUnits); err != nil {
+		t.Fatalf("seed attempt: %v", err)
+	}
+	insertOrphanRow(t, db, origPayoutID, attemptSeq, "0xorphan", providerID,
+		observedProviderCredits, observedGrossCredits, observedAmountBaseUnits)
+	return origPayoutID, attemptSeq
+}
+
+func insertOrphanRow(t *testing.T, db *sql.DB, payoutID, attemptSeq int64, txHash, providerID string, observedProviderCredits, observedGrossCredits, observedAmountBaseUnits int64) {
+	t.Helper()
+	if _, err := db.Exec(`
+INSERT INTO payout_reorg_orphans
+    (payout_id, attempt_seq, orphan_tx_hash, last_seen_block, observed_at_utc, rpc_source,
+     observed_provider_id, observed_provider_credits, observed_gross_credits, observed_amount_base_units)
+VALUES (?, ?, ?, 100, '2026-01-03T00:00:00Z', 'both', ?, ?, ?, ?)`,
+		payoutID, attemptSeq, txHash, providerID,
+		observedProviderCredits, observedGrossCredits, observedAmountBaseUnits); err != nil {
+		t.Fatalf("insert orphan row: %v", err)
+	}
+}
+
+func markAttemptCancel(t *testing.T, db *sql.DB, payoutID, attemptSeq int64) {
+	t.Helper()
+	if _, err := db.Exec(`
+UPDATE payout_attempts SET is_cancel_self_transfer = 1 WHERE payout_id = ? AND attempt_seq = ?`,
+		payoutID, attemptSeq); err != nil {
+		t.Fatalf("mark attempt cancel: %v", err)
+	}
+}
+
+func compensationKey(origPayoutID, attemptSeq int64) string {
+	return "reorg_compensation:" + itoa(origPayoutID) + ":" + itoa(attemptSeq)
+}
+
+// payoutReadyBodyMap builds a well-formed request body for the given
+// orphan; callers mutate individual fields to exercise error paths.
+func payoutReadyBodyMap(providerID, key string, providerCredits int64) map[string]any {
+	return map[string]any{
+		"provider_id":                 providerID,
+		"gross_credits":               providerCredits,
+		"provider_credits":            providerCredits,
+		"operator_credits":            0,
+		"cadence_days":                1,
+		"source_credit_count":         1,
+		"min_payout_credits_override": 0,
+		"idempotency_key":             key,
+		"window_start_utc":            "2026-01-03T00:00:00.000000000Z",
+		"window_end_utc":              "2026-01-03T00:00:00.000001000Z",
+		"reason":                      "reorg compensation for orphaned payout",
+	}
+}
+
+func doPayoutReady(t *testing.T, store *Store, headerKey string, bodyObj any, ct, bearer string) *httptest.ResponseRecorder {
+	t.Helper()
+	var reader *strings.Reader
+	switch b := bodyObj.(type) {
+	case string:
+		reader = strings.NewReader(b)
+	default:
+		raw, err := json.Marshal(b)
+		if err != nil {
+			t.Fatalf("marshal body: %v", err)
+		}
+		reader = strings.NewReader(string(raw))
+	}
+	req := httptest.NewRequest(http.MethodPost, payoutReadyPath, reader)
+	if bearer != "" {
+		req.Header.Set("Authorization", "Bearer "+bearer)
+	}
+	if ct != "" {
+		req.Header.Set("Content-Type", ct)
+	}
+	if headerKey != "" {
+		req.Header.Set("Idempotency-Key", headerKey)
+	}
+	w := httptest.NewRecorder()
+	store.HandlersWithQuarantineGatesIdlePrewarmAndPayoutCap("operator", fakeTokens{}, true, 60, false, false, nil, testPerPayoutCap).ServeHTTP(w, req)
+	return w
+}
+
+func decodeErrCode(t *testing.T, w *httptest.ResponseRecorder) string {
+	t.Helper()
+	var env struct {
+		Error struct {
+			Code string `json:"code"`
+		} `json:"error"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &env); err != nil {
+		t.Fatalf("decode error envelope: %v (body=%s)", err, w.Body.String())
+	}
+	return env.Error.Code
+}
+
+// assertNoPayoutReadySideEffects locks the no-durable-side-effect
+// invariant on rejection paths: no ledger_payout_ready row for the key
+// and no ledger_payout_ready_admin_inserted audit row.
+func assertNoPayoutReadySideEffects(t *testing.T, store *Store, key string) {
+	t.Helper()
+	if n := scalar(t, store.db, `SELECT COUNT(*) FROM ledger_payout_ready WHERE idempotency_key = ?`, key); n != 0 {
+		t.Errorf("ledger_payout_ready rows for key=%q = %d want 0 (rejection must not insert)", key, n)
+	}
+	if n := scalar(t, store.db, `SELECT COUNT(*) FROM audit_log WHERE event_type = ?`, eventPayoutReadyInserted); n != 0 {
+		t.Errorf("audit rows=%d want 0 (rejection must not audit)", n)
+	}
+}
+
+// --- 1. happy path ---------------------------------------------------
+
+func TestPayoutReady_HappyPath(t *testing.T) {
+	store := payoutReadyFixture(t)
+	const provider = "prov-happy"
+	seedProviderToken(t, store.db, provider)
+	origID, seq := seedOrphan(t, store, provider, 900, 950, 900)
+	key := compensationKey(origID, seq)
+
+	w := doPayoutReady(t, store, key, payoutReadyBodyMap(provider, key, 900), "application/json", "operator")
+	if w.Code != http.StatusCreated {
+		t.Fatalf("code=%d body=%s want 201", w.Code, w.Body.String())
+	}
+	var resp struct {
+		ID int64 `json:"id"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode 201 body: %v", err)
+	}
+	if resp.ID <= 0 {
+		t.Fatalf("expected positive id, got %d", resp.ID)
+	}
+	// Assert the inserted row shape.
+	var (
+		status          string
+		minPayout       int64
+		operatorCredits int64
+		gross           int64
+		providerCredits int64
+		currency        sql.NullString
+		externalID      sql.NullString
+		idem            string
+	)
+	if err := store.db.QueryRow(`
+SELECT status, min_payout_credits, operator_credits, gross_credits, provider_credits,
+       payout_currency, payout_external_id, idempotency_key
+  FROM ledger_payout_ready WHERE id = ?`, resp.ID).Scan(
+		&status, &minPayout, &operatorCredits, &gross, &providerCredits,
+		&currency, &externalID, &idem); err != nil {
+		t.Fatalf("read inserted row: %v", err)
+	}
+	if status != "ready" {
+		t.Errorf("status=%q want ready", status)
+	}
+	if minPayout != 0 || operatorCredits != 0 {
+		t.Errorf("min_payout=%d operator_credits=%d want 0/0", minPayout, operatorCredits)
+	}
+	if gross != 900 || providerCredits != 900 {
+		t.Errorf("gross=%d provider=%d want 900/900", gross, providerCredits)
+	}
+	if currency.Valid || externalID.Valid {
+		t.Errorf("expected NULL currency/external_id, got currency=%v external=%v", currency, externalID)
+	}
+	if idem != key {
+		t.Errorf("idempotency_key=%q want %q", idem, key)
+	}
+	// compensation_settlement_id MUST remain NULL — the two-call flow
+	// links it later.
+	var compID sql.NullInt64
+	if err := store.db.QueryRow(`
+SELECT compensation_settlement_id FROM payout_reorg_orphans WHERE payout_id=? AND attempt_seq=?`,
+		origID, seq).Scan(&compID); err != nil {
+		t.Fatalf("read orphan: %v", err)
+	}
+	if compID.Valid {
+		t.Errorf("compensation_settlement_id must stay NULL, got %d", compID.Int64)
+	}
+}
+
+// --- 13. audit event emitted with 6 fields ---------------------------
+
+func TestPayoutReady_AuditEventSixFields(t *testing.T) {
+	store := payoutReadyFixture(t)
+	const provider = "prov-audit"
+	seedProviderToken(t, store.db, provider)
+	origID, seq := seedOrphan(t, store, provider, 900, 950, 900)
+	key := compensationKey(origID, seq)
+
+	w := doPayoutReady(t, store, key, payoutReadyBodyMap(provider, key, 900), "application/json", "operator")
+	if w.Code != http.StatusCreated {
+		t.Fatalf("code=%d want 201", w.Code)
+	}
+	var payloadJSON string
+	if err := store.db.QueryRow(`
+SELECT payload_json FROM audit_log WHERE event_type = ?`, eventPayoutReadyInserted).Scan(&payloadJSON); err != nil {
+		t.Fatalf("read audit row: %v", err)
+	}
+	var payload map[string]any
+	if err := json.Unmarshal([]byte(payloadJSON), &payload); err != nil {
+		t.Fatalf("decode audit payload: %v", err)
+	}
+	want := []string{"provider_id", "id", "idempotency_key", "reason", "actor", "ts_utc"}
+	if len(payload) != len(want) {
+		t.Fatalf("audit payload has %d fields %v, want exactly %d %v", len(payload), payload, len(want), want)
+	}
+	for _, k := range want {
+		if _, ok := payload[k]; !ok {
+			t.Errorf("audit payload missing field %q", k)
+		}
+	}
+	if payload["actor"] != payoutReadyActor {
+		t.Errorf("actor=%v want %q (principal marker, not the secret)", payload["actor"], payoutReadyActor)
+	}
+	if payload["provider_id"] != provider {
+		t.Errorf("provider_id=%v want %q", payload["provider_id"], provider)
+	}
+	if payload["idempotency_key"] != key {
+		t.Errorf("idempotency_key=%v want %q", payload["idempotency_key"], key)
+	}
+}
+
+// --- 4. replay -> 409 with original body -----------------------------
+
+func TestPayoutReady_Replay409(t *testing.T) {
+	store := payoutReadyFixture(t)
+	const provider = "prov-replay"
+	seedProviderToken(t, store.db, provider)
+	origID, seq := seedOrphan(t, store, provider, 900, 950, 900)
+	key := compensationKey(origID, seq)
+	body := payoutReadyBodyMap(provider, key, 900)
+
+	w1 := doPayoutReady(t, store, key, body, "application/json", "operator")
+	if w1.Code != http.StatusCreated {
+		t.Fatalf("first call code=%d want 201", w1.Code)
+	}
+	var first struct {
+		ID int64 `json:"id"`
+	}
+	_ = json.Unmarshal(w1.Body.Bytes(), &first)
+
+	w2 := doPayoutReady(t, store, key, body, "application/json", "operator")
+	if w2.Code != http.StatusConflict {
+		t.Fatalf("replay code=%d body=%s want 409", w2.Code, w2.Body.String())
+	}
+	var second struct {
+		ID int64 `json:"id"`
+	}
+	if err := json.Unmarshal(w2.Body.Bytes(), &second); err != nil {
+		t.Fatalf("decode replay body: %v", err)
+	}
+	if second.ID != first.ID {
+		t.Errorf("replay id=%d want original %d", second.ID, first.ID)
+	}
+	// Exactly one row must exist for the key.
+	n := scalar(t, store.db, `SELECT COUNT(*) FROM ledger_payout_ready WHERE idempotency_key = ?`, key)
+	if n != 1 {
+		t.Errorf("row count for key=%d want 1 (no double-insert)", n)
+	}
+}
+
+// --- 4b. replay AFTER the orphan is resolved/linked -> still 409 -----
+// §9.5b.1 lines 4386–4387: a repeated idempotency_key MUST return 409
+// with the ORIGINAL 201 body regardless of the orphan's current state.
+// Once the compensation is recorded and its orphan linked+resolved, the
+// orphan preconditions would reject a replay as 422 — the top-of-txn
+// ledger-key probe must make the replay win instead.
+func TestPayoutReady_ReplayAfterOrphanResolved409(t *testing.T) {
+	store := payoutReadyFixture(t)
+	const provider = "prov-replay-resolved"
+	seedProviderToken(t, store.db, provider)
+	origID, seq := seedOrphan(t, store, provider, 900, 950, 900)
+	key := compensationKey(origID, seq)
+	body := payoutReadyBodyMap(provider, key, 900)
+
+	w1 := doPayoutReady(t, store, key, body, "application/json", "operator")
+	if w1.Code != http.StatusCreated {
+		t.Fatalf("first call code=%d want 201", w1.Code)
+	}
+	var first struct {
+		ID int64 `json:"id"`
+	}
+	if err := json.Unmarshal(w1.Body.Bytes(), &first); err != nil {
+		t.Fatalf("decode 201 body: %v", err)
+	}
+
+	// Simulate the /admin/payout/record-orphan link+resolve step: the
+	// orphan is now compensated AND resolved (both preconditions that
+	// would otherwise 422 a replay).
+	if _, err := store.db.Exec(`
+UPDATE payout_reorg_orphans
+   SET compensation_settlement_id = ?, resolved_at_utc = '2026-01-05T00:00:00Z'
+ WHERE payout_id = ? AND attempt_seq = ?`, first.ID, origID, seq); err != nil {
+		t.Fatalf("link+resolve orphan: %v", err)
+	}
+
+	w2 := doPayoutReady(t, store, key, body, "application/json", "operator")
+	if w2.Code != http.StatusConflict {
+		t.Fatalf("replay code=%d body=%s want 409 (not 422)", w2.Code, w2.Body.String())
+	}
+	var second struct {
+		ID int64 `json:"id"`
+	}
+	if err := json.Unmarshal(w2.Body.Bytes(), &second); err != nil {
+		t.Fatalf("decode replay body: %v", err)
+	}
+	if second.ID != first.ID {
+		t.Errorf("replay id=%d want original %d", second.ID, first.ID)
+	}
+	if n := scalar(t, store.db, `SELECT COUNT(*) FROM ledger_payout_ready WHERE idempotency_key = ?`, key); n != 1 {
+		t.Errorf("row count=%d want 1 (replay must not insert)", n)
+	}
+}
+
+// --- 2. header != body key -> 400 ------------------------------------
+
+func TestPayoutReady_HeaderKeyMismatch400(t *testing.T) {
+	store := payoutReadyFixture(t)
+	const provider = "prov-hdr"
+	seedProviderToken(t, store.db, provider)
+	origID, seq := seedOrphan(t, store, provider, 900, 950, 900)
+	key := compensationKey(origID, seq)
+	w := doPayoutReady(t, store, "reorg_compensation:999:999", payoutReadyBodyMap(provider, key, 900), "application/json", "operator")
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("code=%d body=%s want 400", w.Code, w.Body.String())
+	}
+}
+
+// --- 3. bad key regex -> 400 -----------------------------------------
+
+func TestPayoutReady_BadKeyRegex400(t *testing.T) {
+	store := payoutReadyFixture(t)
+	const provider = "prov-badkey"
+	seedProviderToken(t, store.db, provider)
+	seedOrphan(t, store, provider, 900, 950, 900)
+	bad := "settlement:1:1"
+	body := payoutReadyBodyMap(provider, bad, 900)
+	w := doPayoutReady(t, store, bad, body, "application/json", "operator")
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("code=%d body=%s want 400", w.Code, w.Body.String())
+	}
+}
+
+// --- 3b. non-canonical (leading-zero) key -> 400, no double-pay ------
+// The regex admits leading zeros, so `reorg_compensation:05:1` parses
+// to the SAME orphan (5,1) as the canonical `reorg_compensation:5:1`
+// yet is a DISTINCT TEXT key — accepting it would let two ledger rows
+// bind to one orphan (double-pay) since UNIQUE(idempotency_key) and the
+// exact-text replay probe both key on the raw string. It MUST 400.
+func TestPayoutReady_NonCanonicalKey400(t *testing.T) {
+	store := payoutReadyFixture(t)
+	const provider = "prov-canon"
+	seedProviderToken(t, store.db, provider)
+	// Seed an orphan whose (payout_id, attempt_seq) is exactly (N, 1);
+	// then alias its key with a leading zero on the payout_id.
+	origID, seq := seedOrphan(t, store, provider, 900, 950, 900)
+	canonical := compensationKey(origID, seq)
+	aliased := "reorg_compensation:0" + itoa(origID) + ":" + itoa(seq)
+	if aliased == canonical {
+		t.Fatalf("aliased key %q unexpectedly equals canonical %q", aliased, canonical)
+	}
+	w := doPayoutReady(t, store, aliased, payoutReadyBodyMap(provider, aliased, 900), "application/json", "operator")
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("code=%d body=%s want 400", w.Code, w.Body.String())
+	}
+	// No row for EITHER encoding.
+	if n := scalar(t, store.db, `SELECT COUNT(*) FROM ledger_payout_ready WHERE idempotency_key IN (?, ?)`, aliased, canonical); n != 0 {
+		t.Errorf("ledger rows for aliased/canonical=%d want 0", n)
+	}
+
+	// Positive control: the canonical key still succeeds against the
+	// same orphan.
+	w2 := doPayoutReady(t, store, canonical, payoutReadyBodyMap(provider, canonical, 900), "application/json", "operator")
+	if w2.Code != http.StatusCreated {
+		t.Fatalf("canonical code=%d body=%s want 201", w2.Code, w2.Body.String())
+	}
+	if n := scalar(t, store.db, `SELECT COUNT(*) FROM ledger_payout_ready WHERE idempotency_key = ?`, canonical); n != 1 {
+		t.Errorf("canonical rows=%d want 1", n)
+	}
+}
+
+// --- 5. no matching orphan -> 422 ------------------------------------
+
+func TestPayoutReady_NoMatchingOrphan422(t *testing.T) {
+	store := payoutReadyFixture(t)
+	const provider = "prov-noorphan"
+	seedProviderToken(t, store.db, provider)
+	// No orphan seeded; craft a key pointing at a nonexistent orphan.
+	key := compensationKey(4242, 1)
+	w := doPayoutReady(t, store, key, payoutReadyBodyMap(provider, key, 900), "application/json", "operator")
+	if w.Code != http.StatusUnprocessableEntity {
+		t.Fatalf("code=%d body=%s want 422", w.Code, w.Body.String())
+	}
+	if code := decodeErrCode(t, w); code != "no_matching_orphan" {
+		t.Errorf("code=%q want no_matching_orphan", code)
+	}
+	assertNoPayoutReadySideEffects(t, store, key)
+}
+
+// --- 6. already compensated -> 422 -----------------------------------
+
+func TestPayoutReady_AlreadyCompensated422(t *testing.T) {
+	store := payoutReadyFixture(t)
+	const provider = "prov-comp"
+	seedProviderToken(t, store.db, provider)
+	origID, seq := seedOrphan(t, store, provider, 900, 950, 900)
+	// Simulate the later /admin/payout/record-orphan link step.
+	if _, err := store.db.Exec(`
+UPDATE payout_reorg_orphans SET compensation_settlement_id = ? WHERE payout_id=? AND attempt_seq=?`,
+		origID, origID, seq); err != nil {
+		t.Fatalf("set compensation id: %v", err)
+	}
+	key := compensationKey(origID, seq)
+	w := doPayoutReady(t, store, key, payoutReadyBodyMap(provider, key, 900), "application/json", "operator")
+	if w.Code != http.StatusUnprocessableEntity {
+		t.Fatalf("code=%d body=%s want 422", w.Code, w.Body.String())
+	}
+	if code := decodeErrCode(t, w); code != "orphan_already_compensated" {
+		t.Errorf("code=%q want orphan_already_compensated", code)
+	}
+	assertNoPayoutReadySideEffects(t, store, key)
+}
+
+// --- 7. each binding mismatch -> 422 orphan_mismatch (named field) ---
+
+func TestPayoutReady_BindingMismatch422(t *testing.T) {
+	cases := []struct {
+		name   string
+		mutate func(m map[string]any)
+		field  string
+	}{
+		{"provider_id", func(m map[string]any) { m["provider_id"] = "other-prov" }, "provider_id"},
+		{"provider_credits", func(m map[string]any) { m["provider_credits"] = 800; m["gross_credits"] = 800 }, "provider_credits"},
+		{"gross_credits", func(m map[string]any) { m["gross_credits"] = 800 }, "gross_credits"},
+		{"operator_credits", func(m map[string]any) { m["operator_credits"] = 5 }, "operator_credits"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			store := payoutReadyFixture(t)
+			provider := "prov-bind-" + tc.name
+			seedProviderToken(t, store.db, provider)
+			// Seed a second provider token so a provider_id mismatch is
+			// not itself a provider_not_found.
+			seedProviderToken(t, store.db, "other-prov")
+			origID, seq := seedOrphan(t, store, provider, 900, 950, 900)
+			key := compensationKey(origID, seq)
+			body := payoutReadyBodyMap(provider, key, 900)
+			tc.mutate(body)
+			w := doPayoutReady(t, store, key, body, "application/json", "operator")
+			if w.Code != http.StatusUnprocessableEntity {
+				t.Fatalf("code=%d body=%s want 422", w.Code, w.Body.String())
+			}
+			if code := decodeErrCode(t, w); code != "orphan_mismatch" {
+				t.Fatalf("code=%q want orphan_mismatch", code)
+			}
+			// The message must name the failed field.
+			if !strings.Contains(w.Body.String(), tc.field) {
+				t.Errorf("body %s does not name field %q", w.Body.String(), tc.field)
+			}
+			assertNoPayoutReadySideEffects(t, store, key)
+		})
+	}
+}
+
+// --- 8. provider_credits > cap -> 422 --------------------------------
+
+func TestPayoutReady_OverCap422(t *testing.T) {
+	store := payoutReadyFixture(t)
+	const provider = "prov-cap"
+	seedProviderToken(t, store.db, provider)
+	over := testPerPayoutCap + 1
+	origID, seq := seedOrphan(t, store, provider, over, over, over)
+	key := compensationKey(origID, seq)
+	w := doPayoutReady(t, store, key, payoutReadyBodyMap(provider, key, over), "application/json", "operator")
+	if w.Code != http.StatusUnprocessableEntity {
+		t.Fatalf("code=%d body=%s want 422", w.Code, w.Body.String())
+	}
+	if code := decodeErrCode(t, w); code != "per_payout_cap_exceeded" {
+		t.Errorf("code=%q want per_payout_cap_exceeded", code)
+	}
+	assertNoPayoutReadySideEffects(t, store, key)
+}
+
+// --- 9. gross != provider strict -> 422 ------------------------------
+// Both the orphan binding (gross must equal observed_provider_credits)
+// and the standalone strict check (gross must equal provider_credits)
+// reject gross != provider. Binding is evaluated first, so a gross !=
+// provider request 422s as orphan_mismatch; the standalone
+// gross_provider_mismatch check is defense-in-depth against a future
+// binding change. Accept either code.
+func TestPayoutReady_GrossProviderStrict_CoveredByBinding(t *testing.T) {
+	store := payoutReadyFixture(t)
+	const provider = "prov-strict"
+	seedProviderToken(t, store.db, provider)
+	origID, seq := seedOrphan(t, store, provider, 900, 950, 900)
+	key := compensationKey(origID, seq)
+	body := payoutReadyBodyMap(provider, key, 900)
+	// gross != provider; binding pins gross to observed_provider_credits(900)
+	// so gross=800 trips gross_credits binding first.
+	body["gross_credits"] = 800
+	w := doPayoutReady(t, store, key, body, "application/json", "operator")
+	if w.Code != http.StatusUnprocessableEntity {
+		t.Fatalf("code=%d want 422", w.Code)
+	}
+	code := decodeErrCode(t, w)
+	if code != "orphan_mismatch" && code != "gross_provider_mismatch" {
+		t.Errorf("code=%q want orphan_mismatch or gross_provider_mismatch", code)
+	}
+	assertNoPayoutReadySideEffects(t, store, key)
+}
+
+// --- 10. unknown provider -> 422 -------------------------------------
+
+func TestPayoutReady_UnknownProvider422(t *testing.T) {
+	store := payoutReadyFixture(t)
+	const provider = "prov-unknown"
+	// Deliberately do NOT seed provider_tokens for this provider.
+	origID, seq := seedOrphan(t, store, provider, 900, 950, 900)
+	key := compensationKey(origID, seq)
+	w := doPayoutReady(t, store, key, payoutReadyBodyMap(provider, key, 900), "application/json", "operator")
+	if w.Code != http.StatusUnprocessableEntity {
+		t.Fatalf("code=%d body=%s want 422", w.Code, w.Body.String())
+	}
+	if code := decodeErrCode(t, w); code != "provider_not_found" {
+		t.Errorf("code=%q want provider_not_found", code)
+	}
+	assertNoPayoutReadySideEffects(t, store, key)
+}
+
+// --- 11. missing bearer -> 403 ---------------------------------------
+
+func TestPayoutReady_MissingBearer403(t *testing.T) {
+	store := payoutReadyFixture(t)
+	const provider = "prov-noauth"
+	seedProviderToken(t, store.db, provider)
+	origID, seq := seedOrphan(t, store, provider, 900, 950, 900)
+	key := compensationKey(origID, seq)
+	w := doPayoutReady(t, store, key, payoutReadyBodyMap(provider, key, 900), "application/json", "")
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("code=%d body=%s want 403", w.Code, w.Body.String())
+	}
+	assertNoPayoutReadySideEffects(t, store, key)
+}
+
+// --- 12. wrong method -> 405 -----------------------------------------
+
+func TestPayoutReady_WrongMethod405(t *testing.T) {
+	store := payoutReadyFixture(t)
+	req := httptest.NewRequest(http.MethodGet, payoutReadyPath, nil)
+	req.Header.Set("Authorization", "Bearer operator")
+	w := httptest.NewRecorder()
+	store.HandlersWithQuarantineGatesIdlePrewarmAndPayoutCap("operator", fakeTokens{}, true, 60, false, false, nil, testPerPayoutCap).ServeHTTP(w, req)
+	if w.Code != http.StatusMethodNotAllowed {
+		t.Fatalf("code=%d body=%s want 405", w.Code, w.Body.String())
+	}
+}
+
+// mountedPayoutReadyHandler builds a single persistent handler (shared
+// admin rate-limit bucket) with the given cap. Reuse it across requests
+// to exercise rate-limit exhaustion.
+func mountedPayoutReadyHandler(store *Store, cap int64) http.Handler {
+	return store.HandlersWithQuarantineGatesIdlePrewarmAndPayoutCap("operator", fakeTokens{}, true, 60, false, false, nil, cap)
+}
+
+func payoutReadyReq(method, bearer, headerKey, bodyJSON string) *http.Request {
+	req := httptest.NewRequest(method, payoutReadyPath, strings.NewReader(bodyJSON))
+	if bearer != "" {
+		req.Header.Set("Authorization", "Bearer "+bearer)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	if headerKey != "" {
+		req.Header.Set("Idempotency-Key", headerKey)
+	}
+	return req
+}
+
+// --- FIX 12a. wrong bearer -> 403 (auth precedes method) -------------
+
+func TestPayoutReady_WrongBearer403(t *testing.T) {
+	store := payoutReadyFixture(t)
+	const provider = "prov-wrongbearer"
+	seedProviderToken(t, store.db, provider)
+	origID, seq := seedOrphan(t, store, provider, 900, 950, 900)
+	key := compensationKey(origID, seq)
+	// Wrong bearer on a POST → 403.
+	w := doPayoutReady(t, store, key, payoutReadyBodyMap(provider, key, 900), "application/json", "not-the-operator")
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("code=%d body=%s want 403", w.Code, w.Body.String())
+	}
+	assertNoPayoutReadySideEffects(t, store, key)
+
+	// Order: auth precedes method — a GET with a wrong bearer is 403,
+	// NOT 405.
+	h := mountedPayoutReadyHandler(store, testPerPayoutCap)
+	wg := httptest.NewRecorder()
+	h.ServeHTTP(wg, payoutReadyReq(http.MethodGet, "not-the-operator", key, "{}"))
+	if wg.Code != http.StatusForbidden {
+		t.Fatalf("GET+wrong-bearer code=%d want 403 (auth before method)", wg.Code)
+	}
+	assertNoPayoutReadySideEffects(t, store, key)
+}
+
+// --- FIX 12c. non-POST (PUT) -> 405 ----------------------------------
+
+func TestPayoutReady_PutMethod405(t *testing.T) {
+	store := payoutReadyFixture(t)
+	h := mountedPayoutReadyHandler(store, testPerPayoutCap)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, payoutReadyReq(http.MethodPut, "operator", "reorg_compensation:1:1", "{}"))
+	if w.Code != http.StatusMethodNotAllowed {
+		t.Fatalf("PUT code=%d body=%s want 405", w.Code, w.Body.String())
+	}
+	assertNoPayoutReadySideEffects(t, store, "reorg_compensation:1:1")
+}
+
+// --- FIX 12d. admin rate-limit exhausted -> 429 (precedes method) ----
+
+func TestPayoutReady_RateLimit429(t *testing.T) {
+	store := payoutReadyFixture(t)
+	h := mountedPayoutReadyHandler(store, testPerPayoutCap)
+	// Drain the shared bucket (capacity 128). Each AUTHENTICATED request
+	// consumes a token regardless of outcome; these all 400 on the bad
+	// key (post-auth, post-ratelimit) so they never insert.
+	var got429 bool
+	for i := 0; i < 200; i++ {
+		w := httptest.NewRecorder()
+		h.ServeHTTP(w, payoutReadyReq(http.MethodPost, "operator", "bad-key", `{"idempotency_key":"bad-key"}`))
+		if w.Code == http.StatusTooManyRequests {
+			got429 = true
+		}
+	}
+	if !got429 {
+		t.Fatalf("expected at least one 429 after draining the admin bucket")
+	}
+	// Order: rate-limit precedes method — a GET on the drained bucket is
+	// 429, NOT 405.
+	wg := httptest.NewRecorder()
+	h.ServeHTTP(wg, payoutReadyReq(http.MethodGet, "operator", "reorg_compensation:1:1", "{}"))
+	if wg.Code != http.StatusTooManyRequests {
+		t.Fatalf("GET on drained bucket code=%d want 429 (rate-limit before method)", wg.Code)
+	}
+	// No durable side-effects from any of the above.
+	if n := scalar(t, store.db, `SELECT COUNT(*) FROM ledger_payout_ready`); n != 0 {
+		t.Errorf("ledger rows=%d want 0", n)
+	}
+	if n := scalar(t, store.db, `SELECT COUNT(*) FROM audit_log WHERE event_type = ?`, eventPayoutReadyInserted); n != 0 {
+		t.Errorf("audit rows=%d want 0", n)
+	}
+}
+
+// --- FIX 13. cap <= 0 -> fail-closed 404 (endpoint not mounted) ------
+
+func TestPayoutReady_CapZeroFailsClosed(t *testing.T) {
+	store := payoutReadyFixture(t)
+	const provider = "prov-capzero"
+	seedProviderToken(t, store.db, provider)
+	origID, seq := seedOrphan(t, store, provider, 900, 950, 900)
+	key := compensationKey(origID, seq)
+	bodyJSON, _ := json.Marshal(payoutReadyBodyMap(provider, key, 900))
+	for _, cap := range []int64{0, -1} {
+		h := mountedPayoutReadyHandler(store, cap)
+		w := httptest.NewRecorder()
+		h.ServeHTTP(w, payoutReadyReq(http.MethodPost, "operator", key, string(bodyJSON)))
+		if w.Code != http.StatusNotFound {
+			t.Fatalf("cap=%d code=%d body=%s want 404 (fail-closed)", cap, w.Code, w.Body.String())
+		}
+		assertNoPayoutReadySideEffects(t, store, key)
+	}
+}
+
+// --- FIX 11. binds to immutable observed_* snapshot, not mutable lpr --
+// After the orphan snapshot is recorded, mutating the original
+// ledger_payout_ready row's provider_credits MUST NOT change the
+// accept/reject decision: the endpoint binds to observed_*.
+func TestPayoutReady_BindsToSnapshotNotMutableRow(t *testing.T) {
+	store := payoutReadyFixture(t)
+	const provider = "prov-snapshot"
+	seedProviderToken(t, store.db, provider)
+	// observed_provider_credits = 900. seedOrphan already seeds the
+	// original lpr row with a DIVERGENT value (900+500=1400).
+	origID, seq := seedOrphan(t, store, provider, 900, 950, 900)
+	key := compensationKey(origID, seq)
+
+	// Mutate the original (mutable) lpr row's provider_credits to 800.
+	if _, err := store.db.Exec(`
+UPDATE ledger_payout_ready SET provider_credits = 800 WHERE id = ?`, origID); err != nil {
+		t.Fatalf("mutate lpr: %v", err)
+	}
+
+	// A request matching the MUTATED lpr (800) but NOT observed_* (900)
+	// must be rejected — proves the endpoint does not read lpr.*.
+	rejBody := payoutReadyBodyMap(provider, key, 800)
+	wRej := doPayoutReady(t, store, key, rejBody, "application/json", "operator")
+	if wRej.Code != http.StatusUnprocessableEntity {
+		t.Fatalf("lpr-matching request code=%d body=%s want 422", wRej.Code, wRej.Body.String())
+	}
+	if code := decodeErrCode(t, wRej); code != "orphan_mismatch" {
+		t.Errorf("code=%q want orphan_mismatch", code)
+	}
+	assertNoPayoutReadySideEffects(t, store, key)
+
+	// A request matching observed_* (900) still succeeds despite the
+	// mutated lpr row — decision unchanged, bound to the snapshot.
+	wOK := doPayoutReady(t, store, key, payoutReadyBodyMap(provider, key, 900), "application/json", "operator")
+	if wOK.Code != http.StatusCreated {
+		t.Fatalf("observed-matching request code=%d body=%s want 201", wOK.Code, wOK.Body.String())
+	}
+}
+
+// --- extra: missing reason -> 400 ------------------------------------
+
+func TestPayoutReady_MissingReason400(t *testing.T) {
+	store := payoutReadyFixture(t)
+	const provider = "prov-reason"
+	seedProviderToken(t, store.db, provider)
+	origID, seq := seedOrphan(t, store, provider, 900, 950, 900)
+	key := compensationKey(origID, seq)
+	body := payoutReadyBodyMap(provider, key, 900)
+	body["reason"] = "   "
+	w := doPayoutReady(t, store, key, body, "application/json", "operator")
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("code=%d body=%s want 400", w.Code, w.Body.String())
+	}
+}
+
+// --- 14. same-DB cross-txn atomicity: a failed insert leaves no
+//         audit row and no ledger row (all-or-nothing). -------------
+
+func TestPayoutReady_AtomicityNoPartialWrites(t *testing.T) {
+	store := payoutReadyFixture(t)
+	const provider = "prov-atomic"
+	seedProviderToken(t, store.db, provider)
+	// over-cap request: fails AFTER orphan lookup + provider check but
+	// BEFORE any INSERT — no ledger row, no audit row must persist.
+	over := testPerPayoutCap + 1
+	origID, seq := seedOrphan(t, store, provider, over, over, over)
+	key := compensationKey(origID, seq)
+	w := doPayoutReady(t, store, key, payoutReadyBodyMap(provider, key, over), "application/json", "operator")
+	if w.Code != http.StatusUnprocessableEntity {
+		t.Fatalf("code=%d want 422", w.Code)
+	}
+	if n := scalar(t, store.db, `SELECT COUNT(*) FROM ledger_payout_ready WHERE idempotency_key = ?`, key); n != 0 {
+		t.Errorf("ledger rows for failed request=%d want 0", n)
+	}
+	if n := scalar(t, store.db, `SELECT COUNT(*) FROM audit_log WHERE event_type = ?`, eventPayoutReadyInserted); n != 0 {
+		t.Errorf("audit rows for failed request=%d want 0", n)
+	}
+
+	// Now prove the SUCCESS path writes BOTH rows atomically in the same
+	// SQLite DB (ledger row + audit row appear together).
+	store2 := payoutReadyFixture(t)
+	seedProviderToken(t, store2.db, provider)
+	oID, s2 := seedOrphan(t, store2, provider, 900, 950, 900)
+	k2 := compensationKey(oID, s2)
+	w2 := doPayoutReady(t, store2, k2, payoutReadyBodyMap(provider, k2, 900), "application/json", "operator")
+	if w2.Code != http.StatusCreated {
+		t.Fatalf("code=%d want 201", w2.Code)
+	}
+	ledgerN := scalar(t, store2.db, `SELECT COUNT(*) FROM ledger_payout_ready WHERE idempotency_key = ?`, k2)
+	auditN := scalar(t, store2.db, `SELECT COUNT(*) FROM audit_log WHERE event_type = ?`, eventPayoutReadyInserted)
+	if ledgerN != 1 || auditN != 1 {
+		t.Errorf("atomic success wrote ledger=%d audit=%d want 1/1", ledgerN, auditN)
+	}
+}
+
+// --- 15. cancel-self-transfer orphan -> 422 orphan_not_compensable ---
+// SPEC-016 lines 2043–2048: a cancel self-transfer does not consume
+// ledger_payout_ready and the §9.5b compensation flow does not apply.
+// record-orphan writes an orphan row for cancel attempts too, so the
+// endpoint MUST reject them or it would mint USDC for a non-compensable
+// event.
+func TestPayoutReady_CancelOrphanNotCompensable422(t *testing.T) {
+	store := payoutReadyFixture(t)
+	const provider = "prov-cancel"
+	seedProviderToken(t, store.db, provider)
+	origID, seq := seedOrphan(t, store, provider, 900, 950, 900)
+	markAttemptCancel(t, store.db, origID, seq)
+	key := compensationKey(origID, seq)
+	w := doPayoutReady(t, store, key, payoutReadyBodyMap(provider, key, 900), "application/json", "operator")
+	if w.Code != http.StatusUnprocessableEntity {
+		t.Fatalf("code=%d body=%s want 422", w.Code, w.Body.String())
+	}
+	if code := decodeErrCode(t, w); code != "orphan_not_compensable" {
+		t.Errorf("code=%q want orphan_not_compensable", code)
+	}
+	if n := scalar(t, store.db, `SELECT COUNT(*) FROM ledger_payout_ready WHERE idempotency_key = ?`, key); n != 0 {
+		t.Errorf("ledger rows=%d want 0 (no compensation minted)", n)
+	}
+	if n := scalar(t, store.db, `SELECT COUNT(*) FROM audit_log WHERE event_type = ?`, eventPayoutReadyInserted); n != 0 {
+		t.Errorf("audit rows=%d want 0", n)
+	}
+}
+
+// --- 16. ambiguous orphan (two unresolved rows) -> 422 ---------------
+// SPEC §9.5b.1 line 4481 requires EXACTLY ONE orphan row. The partial
+// UNIQUE index keys on orphan_tx_hash, so two unresolved orphans with
+// different tx hashes for the same (payout_id, attempt_seq) can coexist.
+func TestPayoutReady_AmbiguousOrphan422(t *testing.T) {
+	store := payoutReadyFixture(t)
+	const provider = "prov-ambig"
+	seedProviderToken(t, store.db, provider)
+	origID, seq := seedOrphan(t, store, provider, 900, 950, 900)
+	// Second unresolved orphan for the same (payout_id, attempt_seq),
+	// different orphan_tx_hash.
+	insertOrphanRow(t, store.db, origID, seq, "0xorphan-2", provider, 900, 950, 900)
+	key := compensationKey(origID, seq)
+	w := doPayoutReady(t, store, key, payoutReadyBodyMap(provider, key, 900), "application/json", "operator")
+	if w.Code != http.StatusUnprocessableEntity {
+		t.Fatalf("code=%d body=%s want 422", w.Code, w.Body.String())
+	}
+	if code := decodeErrCode(t, w); code != "ambiguous_orphan" {
+		t.Errorf("code=%q want ambiguous_orphan", code)
+	}
+	if n := scalar(t, store.db, `SELECT COUNT(*) FROM ledger_payout_ready WHERE idempotency_key = ?`, key); n != 0 {
+		t.Errorf("ledger rows=%d want 0", n)
+	}
+	if n := scalar(t, store.db, `SELECT COUNT(*) FROM audit_log WHERE event_type = ?`, eventPayoutReadyInserted); n != 0 {
+		t.Errorf("audit rows=%d want 0 (ambiguity path must not audit)", n)
+	}
+}
+
+// --- 17. terminally-resolved (uncompensated) orphan -> 422 -----------
+// An operator can record a terminal "no compensation" resolution via
+// /admin/payout/record-orphan (operator_resolution + resolved_at_utc
+// set, compensation_settlement_id left NULL). Such an orphan MUST NOT
+// be compensable — the endpoint filters on resolved_at_utc IS NULL and
+// so returns no_matching_orphan (fail-closed), not a fresh payout.
+func TestPayoutReady_ResolvedOrphanNotCompensable422(t *testing.T) {
+	store := payoutReadyFixture(t)
+	const provider = "prov-resolved"
+	seedProviderToken(t, store.db, provider)
+	origID, seq := seedOrphan(t, store, provider, 900, 950, 900)
+	// Terminal record-only resolution: operator decided NOT to pay.
+	if _, err := store.db.Exec(`
+UPDATE payout_reorg_orphans
+   SET operator_resolution = 'no compensation; provider acknowledged',
+       resolved_at_utc = '2026-01-04T00:00:00Z'
+ WHERE payout_id = ? AND attempt_seq = ?`, origID, seq); err != nil {
+		t.Fatalf("set terminal resolution: %v", err)
+	}
+	key := compensationKey(origID, seq)
+	w := doPayoutReady(t, store, key, payoutReadyBodyMap(provider, key, 900), "application/json", "operator")
+	if w.Code != http.StatusUnprocessableEntity {
+		t.Fatalf("code=%d body=%s want 422", w.Code, w.Body.String())
+	}
+	if code := decodeErrCode(t, w); code != "no_matching_orphan" {
+		t.Errorf("code=%q want no_matching_orphan", code)
+	}
+	if n := scalar(t, store.db, `SELECT COUNT(*) FROM ledger_payout_ready WHERE idempotency_key = ?`, key); n != 0 {
+		t.Errorf("ledger rows=%d want 0 (resolved orphan must not mint payout)", n)
+	}
+	if n := scalar(t, store.db, `SELECT COUNT(*) FROM audit_log WHERE event_type = ?`, eventPayoutReadyInserted); n != 0 {
+		t.Errorf("audit rows=%d want 0", n)
+	}
+}

--- a/specs/CONFORMANCE.json
+++ b/specs/CONFORMANCE.json
@@ -426,7 +426,7 @@
     {
       "spec_id": "SPEC-016",
       "title": "Provider payout pipeline (USDC on Base)",
-      "version": "0.1.24",
+      "version": "0.1.25",
       "path": "specs/SPEC-016-payout-pipeline.md",
       "status": "draft",
       "owner": "@Augustas11",

--- a/specs/README.md
+++ b/specs/README.md
@@ -24,7 +24,7 @@ it can no longer drift. Do not hand-edit the table; edit each spec's
 | SPEC-013 | `macprovider-cli autotune` subcommand | 0.3.1 | normative | pending | pending corpus migration | [SPEC-013-cli-autotune.md](SPEC-013-cli-autotune.md) |
 | SPEC-014 | Provider Portal (seller-facing web surface) | 0.9 | draft | pending | pending corpus migration | [SPEC-014-provider-portal.md](SPEC-014-provider-portal.md) |
 | SPEC-015 | Verifiable inference receipts | 0.4.2 | normative | pending | pending corpus migration | [SPEC-015-receipts.md](SPEC-015-receipts.md) |
-| SPEC-016 | Provider payout pipeline (USDC on Base) | 0.1.24 | draft | pending | pending: 11 | [SPEC-016-payout-pipeline.md](SPEC-016-payout-pipeline.md) |
+| SPEC-016 | Provider payout pipeline (USDC on Base) | 0.1.25 | draft | pending | pending: 11 | [SPEC-016-payout-pipeline.md](SPEC-016-payout-pipeline.md) |
 | SPEC-017 | Network Stats API | 0.1.9 | normative | pending | pending: 1 | [SPEC-017-network-stats-api.md](SPEC-017-network-stats-api.md) |
 | SPEC-018 | Agentic tool calling (provider-side response synthesis) | 0.2.7 | normative | pending | pending: 2 | [SPEC-018-agentic-tool-calling.md](SPEC-018-agentic-tool-calling.md) |
 | SPEC-019 | Structured output (`response_format: json_schema`) | 0.2.5 | normative | pending | pending corpus migration | [SPEC-019-structured-output.md](SPEC-019-structured-output.md) |

--- a/specs/SPEC-016-payout-pipeline.md
+++ b/specs/SPEC-016-payout-pipeline.md
@@ -1,9 +1,14 @@
 # SPEC-016 — Provider payout pipeline (USDC on Base)
 
-**Version:** 0.1.24 (2026-07-31, draft — preliminary conformance-unit anchors
-for the default-off payout implementation merged by PR #164. No payout
-behavior, runner activation, production deployment, or §9 prerequisite state
-changes.)
+**Version:** 0.1.25 (2026-08-01, draft — §9.5b.1 assertion-set reconciliation
+to the merged SPEC-005 `POST /admin/ledger/payout-ready` IMPL: canonical
+idempotency_key requirement (leading-zero-alias double-pay defense), replay
+precedence, `payout_attempts` join with `is_cancel_self_transfer = 0`
+non-compensable carve-out, `resolved_at_utc IS NULL` unresolved filter, and
+`ambiguous_orphan` multiplicity guard. Documentation of enforced endpoint
+behavior; no runner activation, production deployment, or §9 prerequisite
+state changes. Prior: 0.1.24 (2026-07-31, preliminary conformance-unit
+anchors for the default-off payout implementation merged by PR #164).)
 **Status:** Draft (IMPL merged via PR #164, default-off — `payout.enabled=false`
 everywhere until the operator funds the hot wallet and discharges the eight
 §9 prerequisites; flipping the flag is an operator decision gated on §9).
@@ -4445,13 +4450,19 @@ discharged:
      constraint. The `+ 1µs * orphan_id` offset on the end
      prevents collision when multiple orphans for the same
      provider are observed in the same nanosecond.
-   - Every successful invocation MUST emit a SPEC-005
-     structured log event
+   - Every successful invocation MUST record
      `ledger_payout_ready_admin_inserted` with
      `provider_id, id, idempotency_key, reason,
      actor=operator_key, ts_utc` so the operator audit
      trail covers admin-inserted rows separately from
-     settlement-emitted rows.
+     settlement-emitted rows. v0.1.25 (SPEC-005 IMPL
+     reconciliation): this is recorded BOTH as a durable
+     `audit_log` row written in the SAME transaction as the
+     INSERT (the authoritative, tamper-evident audit trail,
+     mirroring the quarantine force-void endpoint) AND as a
+     post-commit structured log event for observability /
+     alerting. `actor` is the fixed principal marker string
+     `"operator_key"`, never the operator bearer secret.
    - **The SPEC-005 IMPL MUST bind the compensation row to
      the original orphan's IMMUTABLE snapshot columns in
      the SAME SQLite transaction as the INSERT.** Closes
@@ -4467,19 +4478,53 @@ discharged:
      orphan. v0.1.9 (codex round-10 CRIT-1 framing):
      the IMPL MUST parse `orig_payout_id` and
      `orig_attempt_seq` from the `idempotency_key` regex
-     match, then `SELECT
-     observed_provider_id,
-     observed_provider_credits,
-     observed_gross_credits,
-     observed_amount_base_units,
-     compensation_settlement_id
-     FROM payout_reorg_orphans
-     WHERE payout_id = <orig_payout_id>
-     AND attempt_seq = <orig_attempt_seq>`
+     match, and MUST reject any non-canonical spelling —
+     require `idempotency_key ==
+     "reorg_compensation:<orig_payout_id>:<orig_attempt_seq>"`
+     with minimal decimal encodings (else 400): the
+     `UNIQUE(idempotency_key)` guard keys on raw text, so a
+     leading-zero alias (`reorg_compensation:05:1` vs
+     `:5:1`) would otherwise bind the same orphan twice and
+     double-pay (v0.1.25). Then, in the SAME SQLite
+     transaction as the INSERT, FIRST probe `SELECT id FROM
+     ledger_payout_ready WHERE idempotency_key = <key>` — if
+     present, return 409 with the original `{"id": <id>}`
+     body (REPLAY PRECEDENCE: this wins over every orphan
+     precondition below, so a replay is idempotent
+     regardless of the orphan's later resolution or
+     compensation state). Otherwise `SELECT
+     pro.observed_provider_id,
+     pro.observed_provider_credits,
+     pro.observed_gross_credits,
+     pro.observed_amount_base_units,
+     pro.compensation_settlement_id,
+     pa.is_cancel_self_transfer
+     FROM payout_reorg_orphans pro
+     JOIN payout_attempts pa
+       ON pa.payout_id = pro.payout_id
+      AND pa.attempt_seq = pro.attempt_seq
+     WHERE pro.payout_id = <orig_payout_id>
+     AND pro.attempt_seq = <orig_attempt_seq>
+     AND pro.resolved_at_utc IS NULL`
      in the SAME SQLite transaction as the INSERT, and
      assert ALL of:
      - exactly one row returned (else 422
-       `no_matching_orphan`)
+       `no_matching_orphan` for zero rows; 422
+       `ambiguous_orphan` for more than one — two unresolved
+       orphans with different `orphan_tx_hash` can coexist
+       for the same `(payout_id, attempt_seq)`, so
+       multiplicity fails closed) (v0.1.25)
+     - the orphan is UNRESOLVED: the `resolved_at_utc IS
+       NULL` filter excludes terminal record-only
+       resolutions (e.g. `operator_resolution = "no
+       compensation; provider acknowledged"`), which yield
+       zero rows → 422 `no_matching_orphan` (v0.1.25)
+     - `is_cancel_self_transfer = 0` (else 422
+       `orphan_not_compensable`) — cancel self-transfer
+       reorgs are non-compensable (the §4.3 carve-out;
+       record-orphan writes an orphan row for cancel
+       attempts too, so the compensation endpoint MUST
+       reject them) (v0.1.25)
      - `compensation_settlement_id IS NULL` (else 422
        `orphan_already_compensated`)
      - request `provider_id = observed_provider_id`


### PR DESCRIPTION
## SPEC-016 §9.5b — `POST /admin/ledger/payout-ready` compensation endpoint (SPEC-005 IMPL)

Implements the operator endpoint that inserts a `ledger_payout_ready` compensation
row for a payout orphaned by a chain reorg (§9.5b.1). A row it writes becomes
eligible for a real USDC transfer, so the endpoint is a strict **anti-double-pay
authorization gate** — an operator cannot manufacture or inflate a payout; every
inserted row binds 1:1 to an immutable `payout_reorg_orphans` snapshot.

Payouts remain **default-off** (`payout.enabled: false`); this lands the endpoint
under the same disabled admin surface as the rest of the SPEC-016 pipeline. No
runner activation, deployment, or §9-prerequisite state change.

### Behavior
- Auth: `OperatorOnly` bearer (403) → admin rate-limit (429) → POST-only (405).
- Idempotency key `^reorg_compensation:<payout_id>:<attempt_seq>$`, header == body,
  and a **canonical-encoding** check (rejects leading-zero aliases like `05:1`) so
  the `UNIQUE(idempotency_key)` text guard is 1:1 with the parsed orphan identity.
- One `BEGIN IMMEDIATE` transaction:
  - **Replay probe** first — existing row for the key ⇒ `409` with the original id
    (idempotent regardless of the orphan's later resolution/compensation state).
  - Orphan lookup **joins `payout_attempts`** and filters `resolved_at_utc IS NULL`;
    asserts exactly-one (`0 → no_matching_orphan`, `>1 → ambiguous_orphan`),
    `is_cancel_self_transfer = 0` (`orphan_not_compensable`, §4.3 carve-out),
    `compensation_settlement_id IS NULL` (`orphan_already_compensated`), and the
    immutable binding (`provider_id`, `provider_credits`, `gross_credits ==
    observed_provider_credits`, `operator_credits = 0`), then the per-payout cap.
  - INSERT (`operator_credits`/`min_payout_credits` pinned 0) + audit event
    `ledger_payout_ready_admin_inserted` (actor = fixed `operator_key` marker, never
    the bearer secret) → `COMMIT` → `201 {id}`.

### SPEC reconciliation (v0.1.24 → v0.1.25)
The §9.5b.1 normative assertion set is tightened to match the merged IMPL: canonical
idempotency_key requirement, replay precedence, `payout_attempts` join with the
`is_cancel_self_transfer = 0` non-compensable carve-out, the `resolved_at_utc IS NULL`
unresolved filter, and the `ambiguous_orphan` multiplicity guard. Documentation of
enforced behavior only.

### Audit
6 rounds of 3-lane Codex audit (code / security / architect). Distinct
money-path defects found and fixed across rounds — cancel-self-transfer
compensability, resolved-orphan compensation, replay-after-resolve, a
leading-zero idempotency-key **double-pay** alias, spec-vs-code audit-event
contradiction, ctx-cancellation txn-leak, snapshot-binding test gap, and
legacy-constructor fail-closed — plus one false positive (gross binding)
correctly rejected against SPEC §9.5b.1 (gross binds to `observed_provider_credits`).
**Final pass (round 6): 0 CRITICAL / 0 HIGH / 0 MEDIUM on all three lanes.**

Two LOWs carried (documented, non-blocking): (1) `TestPayoutReady_CapZeroFailsClosed`
exercises cap `0/-1` with a valid bearer but does not separately pin the
deliberate pre-auth ordering of the `cap<=0 → 404`; (2) the post-commit zerolog
`ledger_payout_ready_admin_inserted` event is emitted but not directly asserted
in a test (the durable `audit_log` row it accompanies is asserted). Neither
affects payout authorization. The `cap<=0 → 404` returns before auth by design
(fail-closed for a mis-wired binary); in production the cap is always `> 0`, so
the pre-auth 404 path is unreachable.

### Tests
25 in-package cases: happy path, every 400/409/422 rejection (each asserting zero
ledger + zero audit side-effects), cancel/resolved/ambiguous/non-canonical guards,
replay-after-resolve `409`, and cross-transaction atomicity.
`go build ./...`, `go vet`, `go test ./internal/billing/` all green.

SPEC-GOVERNANCE-DECLARATION-BEGIN
{
  "schema_version": "spec-pr-governance-v1",
  "behavior_change": "yes",
  "contract_change": "yes",
  "specs": ["SPEC-016"],
  "requirements": ["SPEC-016-R006"],
  "authority_domains": ["payout-lifecycle"],
  "arbitration": ["CODE_BUG"],
  "tests": ["phase4-coordinator/internal/billing/payout_ready_test.go"],
  "journeys": ["not-required"],
  "issue": "https://github.com/Augustas11/macprovider/issues/614"
}
SPEC-GOVERNANCE-DECLARATION-END

🤖 Generated with [Claude Code](https://claude.com/claude-code)
