### PR TITLE
Fix Pearl rollback recovery for idle duplicate providers

### DIFF
--- a/ops/pearl-updater/macprovider-pearl-update
+++ b/ops/pearl-updater/macprovider-pearl-update
@@ -115,8 +115,8 @@ MAX_DOWNLOAD_BYTES = 512 * 1024 * 1024
 MAX_CANDIDATE_OUTPUT_BYTES = 64 * 1024
 MAX_BUYER_PROOF_STREAM_BYTES = 1024 * 1024
 MAX_BUYER_PROOF_STREAM_LINE_BYTES = 64 * 1024
-CANARY_AUTHORITY_VERSION = "issue-825-canary-fleet-r2"
-CANARY_AUTHORITY_COMMIT = "d2b31d0f2e18631764f9a5f4c1c5b28cc0b46142"
+CANARY_AUTHORITY_VERSION = "issue-825-canary-fleet-r3"
+CANARY_AUTHORITY_COMMIT = "e742e42672d78a3f656f7665ac1cb129f731cc19"
 CANARY_UNIT_BUDGET_S = 180
 JOURNAL_SCHEMA_VERSION = 1
 CURRENT_RELEASE_SCHEMA_VERSION = 1
@@ -134,8 +134,8 @@ ROLLBACK_STEPS = (
     "canary_timer",
 )
 CANARY_AUTHORITY_FILES = {
-    Path("/opt/macprovider-canary-buyer/probe.mjs"): "f61f8e05b700c013116cd0f0148af02004a7a73d01b47d6b77a1cd85aa366c71",
-    Path("/opt/macprovider-canary-buyer/safety.mjs"): "7d40264bd9a2f344147ac4d8197aaa1f8ebdfbebf92f55ba36d654e8e5351004",
+    Path("/opt/macprovider-canary-buyer/probe.mjs"): "d707b4a6ff1d72209f3bf7d7ade6cbbd707d4539b7cac53f9b1263fba21b1b45",
+    Path("/opt/macprovider-canary-buyer/safety.mjs"): "03111b34d7ea86c0869be41ca54ed7057f437a0611e4637fc5d315aeb602f632",
     Path("/opt/macprovider-canary-buyer/run-canary.sh"): "6c5b31fce3b477aed8a85c7a0750e924360ed4828da49ca42ea693482e635585",
     Path("/opt/macprovider-canary-buyer/emergency-disable.sh"): "1380122e76b3b66ad812849e3684b38eaaed0790f0e6011e3f194bd215ab1c7e",
     Path("/etc/systemd/system/canary-buyer.service"): "e7f028164d7ca58adaebfb4b1d194016a587dfae78af3f3a0b456ae374efea8a",

--- a/ops/pearl-updater/test_pearl_updater.py
+++ b/ops/pearl-updater/test_pearl_updater.py
@@ -3277,10 +3277,10 @@ class PearlUpdaterTests(unittest.TestCase):
                 updater_module.CANARY_AUTHORITY_FILES[installed],
                 hashlib.sha256(source_at_authority).hexdigest(),
             )
-        self.assertEqual(updater_module.CANARY_AUTHORITY_VERSION, "issue-825-canary-fleet-r2")
+        self.assertEqual(updater_module.CANARY_AUTHORITY_VERSION, "issue-825-canary-fleet-r3")
         self.assertEqual(
             updater_module.CANARY_AUTHORITY_COMMIT,
-            "d2b31d0f2e18631764f9a5f4c1c5b28cc0b46142",
+            "e742e42672d78a3f656f7665ac1cb129f731cc19",
         )
         subprocess.run(
             ["git", "cat-file", "-e", f"{updater_module.CANARY_AUTHORITY_COMMIT}^{{commit}}"],
@@ -3427,7 +3427,7 @@ class PearlUpdaterTests(unittest.TestCase):
             {
                 "schema_version": 1,
                 "kind": "legacy_rollback",
-                "authority": "issue-825-canary-fleet-r2",
+                "authority": "issue-825-canary-fleet-r3",
                 "transaction_id": "a" * 64,
                 "expires_at": observed["document"]["expires_at"],
                 "providers": [

--- a/ops/runbooks/pearl-release-updater.md
+++ b/ops/runbooks/pearl-release-updater.md
@@ -110,11 +110,11 @@ legacy git-describe bootstrap is no longer accepted.
 
 ## One-time installation
 
-First deploy the issue #825 r2 active-count revision of #584's redesigned
+First deploy the issue #825 r3 exercised-provider recovery revision of #584's redesigned
 canary buyer exactly as reviewed, including its root-only `LoadCredential`
 files, safety observer, emergency stop, and classified no-load exits. The
 updater pins that complete runtime, service, and timer as rollout authority
-`issue-825-canary-fleet-r2` at source commit `d2b31d0f2e18631764f9a5f4c1c5b28cc0b46142`;
+`issue-825-canary-fleet-r3` at source commit `e742e42672d78a3f656f7665ac1cb129f731cc19`;
 the default `PEARL_UPDATER_BUYER_CANARY_MODE=required` posture fails `--plan`
 on any SHA drift, missing credential, invalid protected-fleet expected-fleet
 document, absent reviewed enable gate, active emergency-disable sentinel,

--- a/test/e2e/canary-buyer/probe.mjs
+++ b/test/e2e/canary-buyer/probe.mjs
@@ -74,7 +74,7 @@ const configuredTTFTSamples = intEnv('CANARY_TTFT_SAMPLES', 12, 1, 20);
 const configuredTPSSamples = intEnv('CANARY_TPS_SAMPLES', 3, 1, 10);
 const GATEWAY_STATUS_CACHE_TTL_MS = 10_000;
 const PRODUCTION_HEARTBEAT_CADENCE_MS = 30_000;
-const LEGACY_ROLLBACK_AUTHORITY = 'issue-825-canary-fleet-r2';
+const LEGACY_ROLLBACK_AUTHORITY = 'issue-825-canary-fleet-r3';
 const LEGACY_ROLLBACK_MAX_VALIDITY_MS = 15 * 60 * 1000;
 
 const CONFIG = {
@@ -1259,6 +1259,7 @@ async function loadLegacyRollbackAuthorization(expectedFleet) {
 
 export function safetyObservationReasons(initial, observed, expectedFleet, {
   requireHeartbeatAdvance = false,
+  heartbeatAdvanceProviderIDs = null,
   activeModelID = '',
   activeProviderIDHint = '',
   cachedGatewayModelID = '',
@@ -1306,6 +1307,7 @@ export function safetyObservationReasons(initial, observed, expectedFleet, {
   reasons.push(...poolzInvariantReasons(initialExpected, currentExpected, {
     maxHeartbeatAgeMs: CONFIG.maxHeartbeatAgeMs,
     requireHeartbeatAdvance,
+    heartbeatAdvanceProviderIDs,
     activeProviderID: qualification ? '' : activeProviderID,
   }));
 
@@ -1368,12 +1370,14 @@ export function safetyObservationReasons(initial, observed, expectedFleet, {
         continue;
       }
       const before = initialByID.get(expected.provider_id) || current;
+      const requireProviderHeartbeatAdvance = requireHeartbeatAdvance
+        && (!heartbeatAdvanceProviderIDs || heartbeatAdvanceProviderIDs.has(expected.provider_id));
       reasons.push(...providerSignalReasons(before, current, {
         maxMemoryGrowthMB: CONFIG.maxMemoryGrowthMB,
         maxMemoryFraction: CONFIG.maxMemoryFraction,
         maxRequestsInFlight: activeProviderID === current.provider_id ? 1 : 0,
         allowedRuntimeStates: activeProviderID === current.provider_id ? ['ready', 'busy'] : ['ready'],
-        requireObservationAdvance: requireHeartbeatAdvance,
+        requireObservationAdvance: requireProviderHeartbeatAdvance,
       }));
       if (current.model_id !== expected.model_id) {
         reasons.push(`${expected.provider_id}:telemetry_model_${current.model_id || 'missing'}_ne_${expected.model_id}`);
@@ -1767,6 +1771,9 @@ async function main() {
       ...(record.error ? [`${record.phase}:${record.error}`] : []),
       ...record.reasons.map((reason) => `${record.phase}:${reason}`),
     ]);
+    const heartbeatAdvanceProviderIDs = legacyRollbackProviders?.size && budget.providers.size
+      ? new Set([...budget.providers.keys()].filter(Boolean))
+      : null;
     recoveryReasons.push(...recoverySoakObservationReasons(
       initial,
       recoverySamples,
@@ -1780,12 +1787,14 @@ async function main() {
         maxMemoryFraction: CONFIG.maxMemoryFraction,
         requireNominalThermal: CONFIG.mode === 'qualification',
         allowLegacyBridgeProviderSignals: CONFIG.allowLegacyBridgeProviderSignals,
+        heartbeatAdvanceProviderIDs,
       },
     ));
     const finalRecovery = recoverySamples.at(-1);
     if (finalRecovery) {
       recoveryReasons.push(...safetyObservationReasons(initial, finalRecovery, expectedFleet, {
         requireHeartbeatAdvance: true,
+        heartbeatAdvanceProviderIDs,
         allowLegacyBridgeProviderSignals: CONFIG.allowLegacyBridgeProviderSignals,
         legacyRollbackProviders,
       }).map((reason) => `recovery_final:${reason}`));

--- a/test/e2e/canary-buyer/probe.test.mjs
+++ b/test/e2e/canary-buyer/probe.test.mjs
@@ -463,7 +463,7 @@ test('legacy rollback authorization is exact, expiring, and limited to unclassif
   const document = {
     schema_version: 1,
     kind: 'legacy_rollback',
-    authority: 'issue-825-canary-fleet-r2',
+    authority: 'issue-825-canary-fleet-r3',
     transaction_id: 'a'.repeat(64),
     expires_at: new Date(now + 300_000).toISOString(),
     providers: expectedFleet.map((row) => ({ ...row, binary_version: '1.8.30' })),
@@ -604,6 +604,110 @@ test('legacy rollback authorization is exact, expiring, and limited to unclassif
   ]) {
     assert.throws(() => validateLegacyRollbackAuthorization(invalid, expectedFleet, now));
   }
+});
+
+test('legacy rollback recovery requires heartbeat advance only from exercised providers', () => {
+  const now = Date.parse('2026-08-01T10:21:58Z');
+  const expectedFleet = [
+    { provider_id: 'provider-a', model_id: 'model-a' },
+    { provider_id: 'provider-b', model_id: 'model-b' },
+    { provider_id: 'provider-c', model_id: 'model-b' },
+  ];
+  const document = {
+    schema_version: 1,
+    kind: 'legacy_rollback',
+    authority: 'issue-825-canary-fleet-r3',
+    transaction_id: 'b'.repeat(64),
+    expires_at: new Date(now + 300_000).toISOString(),
+    providers: expectedFleet.map((row) => ({ ...row, binary_version: '1.8.30' })),
+  };
+  const authorized = validateLegacyRollbackAuthorization(document, expectedFleet, now);
+  const gateway = gatewaySnapshot({
+    status: 'up',
+    degraded: false,
+    coordinator: { status: 'up', checked_at: new Date(now).toISOString() },
+    pool: { total_providers: 3, ready: 3, degraded: 0, draining: 0, unavailable: 0 },
+    models: [
+      { id: 'model-a', provider_count: 1, ready_provider_count: 1, slots_free: 1, available: true, availability: 'available', degraded: false },
+      { id: 'model-b', provider_count: 2, ready_provider_count: 2, slots_free: 2, available: true, availability: 'available', degraded: false },
+    ],
+  });
+  const operatorPool = poolzSnapshot({ pool: expectedFleet.map(({ provider_id, model_id }, index) => ({
+    provider_id,
+    assigned_id: `session-${index}`,
+    model_id,
+    state: 'ready',
+    routing_eligible: true,
+    binary_version: '1.8.30',
+    connected_at: new Date(now - 60_000).toISOString(),
+    last_heartbeat_at: new Date(now - 1_000).toISOString(),
+    last_activity_at: new Date(now - 1_000).toISOString(),
+  })) }, now);
+  const providers = expectedFleet.map(({ provider_id, model_id }, index) => safetyProvider(
+    provider_id,
+    model_id,
+    `session-${index}`,
+    {
+      binary_version: '1.8.30',
+      observation_id: `${provider_id}-initial`,
+      observed_at: new Date().toISOString(),
+    },
+  ));
+  const observation = { gateway, operator_pool: operatorPool, providers };
+  const recoveryOne = structuredClone(observation);
+  const recoveryTwo = structuredClone(observation);
+  const exercisedProviderIDs = new Set(['provider-a', 'provider-b']);
+
+  for (const [index, sample] of [recoveryOne, recoveryTwo].entries()) {
+    for (const row of sample.operator_pool) {
+      if (exercisedProviderIDs.has(row.provider_id)) {
+        row.last_heartbeat_at_ms += (index + 1) * 30_000;
+        row.last_activity_at_ms += (index + 1) * 30_000;
+      }
+      row.heartbeat_age_ms = 0;
+      row.activity_age_ms = 0;
+    }
+    for (const provider of sample.providers) {
+      if (exercisedProviderIDs.has(provider.provider_id)) {
+        provider.observation_id = `${provider.provider_id}-sample-${index + 1}`;
+        provider.observed_at_ms += (index + 1) * 30_000;
+      }
+      provider.observation_age_ms = 0;
+    }
+  }
+
+  const scopedAdvance = {
+    minReadyProviders: 3,
+    maxHeartbeatAgeMs: 90_000,
+    heartbeatAdvanceProviderIDs: exercisedProviderIDs,
+  };
+  assert.deepEqual(recoverySoakObservationReasons(
+    observation,
+    [recoveryOne, recoveryTwo],
+    expectedFleet,
+    authorized,
+    scopedAdvance,
+    now,
+  ), []);
+  assert.deepEqual(safetyObservationReasons(observation, recoveryTwo, expectedFleet, {
+    legacyRollbackProviders: authorized,
+    nowMs: now,
+    requireHeartbeatAdvance: true,
+    heartbeatAdvanceProviderIDs: exercisedProviderIDs,
+  }), []);
+  assert.ok(recoverySoakObservationReasons(
+    observation,
+    [recoveryOne, recoveryTwo],
+    expectedFleet,
+    authorized,
+    { minReadyProviders: 3, maxHeartbeatAgeMs: 90_000 },
+    now,
+  ).some((reason) => reason.includes('provider-c')));
+  assert.ok(safetyObservationReasons(observation, recoveryTwo, expectedFleet, {
+    legacyRollbackProviders: authorized,
+    nowMs: now,
+    requireHeartbeatAdvance: true,
+  }).some((reason) => reason.includes('provider-c')));
 });
 
 test('post-request recovery outlives the gateway active-loss cache window', async () => {

--- a/test/e2e/canary-buyer/safety.mjs
+++ b/test/e2e/canary-buyer/safety.mjs
@@ -199,6 +199,7 @@ export function poolzInvariantReasons(initial, current, {
   maxHeartbeatAgeMs = 90_000,
   requireHeartbeatAdvance = false,
   activeProviderID = '',
+  heartbeatAdvanceProviderIDs = null,
 } = {}) {
   const before = Array.isArray(initial) ? initial : poolzSnapshot(initial);
   const after = Array.isArray(current) ? current : poolzSnapshot(current);
@@ -236,7 +237,9 @@ export function poolzInvariantReasons(initial, current, {
         && observed.last_heartbeat_at_ms < expected.last_heartbeat_at_ms) {
       reasons.push(`${id}:heartbeat_regressed`);
     }
-    if (requireHeartbeatAdvance) {
+    const requireProviderHeartbeatAdvance = requireHeartbeatAdvance
+      && (!heartbeatAdvanceProviderIDs || heartbeatAdvanceProviderIDs.has(id));
+    if (requireProviderHeartbeatAdvance) {
       const heartbeatAdvanced = expected.last_heartbeat_at_ms != null
         && observed.last_heartbeat_at_ms != null
         && observed.last_heartbeat_at_ms > expected.last_heartbeat_at_ms;
@@ -629,6 +632,7 @@ export function recoverySoakReasons({
       reasons.push(...poolzInvariantReasons(poolzSamples[0], poolzSamples[poolzSamples.length - 1], {
         maxHeartbeatAgeMs: options.maxHeartbeatAgeMs,
         requireHeartbeatAdvance: true,
+        heartbeatAdvanceProviderIDs: options.heartbeatAdvanceProviderIDs || null,
       }).map((reason) => `final:${reason}`));
     }
   }
@@ -644,7 +648,8 @@ export function recoverySoakReasons({
           const previous = previousSet.find((sample) => sample.provider_id === initial.provider_id) || initial;
           reasons.push(...providerSignalReasons(previous, current, {
           ...options,
-          requireObservationAdvance: true,
+          requireObservationAdvance: !options.heartbeatAdvanceProviderIDs
+            || options.heartbeatAdvanceProviderIDs.has(initial.provider_id),
         }).map((reason) => `sample_${index}:${reason}`));
         }
       }


### PR DESCRIPTION
## Summary

Fixes the Pearl rollback-recovery canary blocker found while closing #825: legacy rollback recovery now requires heartbeat/telemetry advancement only from providers that actually served successful canary requests, while all expected providers must still remain fresh, ready, identity-stable, and model/serviceable.

This keeps normal rollout recovery strict and scopes the allowance to legacy rollback authorization plus exercised providers.

## Validation

- `node --test test/e2e/canary-buyer/probe.test.mjs test/e2e/canary-buyer/safety.test.mjs` (32/32 pass)
- `python3 ops/pearl-updater/test_pearl_updater.py` (180 OK, 1 skipped)
- `bash test/e2e/canary-buyer/run-canary.test.sh` (PASS)
- `bash scripts/test-pearl-runtime-release.sh` (PASS)
- `python3 scripts/verify-pearl-go-binaries.py --self-test` (PASS)
- `git diff --check origin/main..HEAD` (clean)

## Audit

Pending three-lane audit against the full fix diff before approval/merge.

SPEC-GOVERNANCE-DECLARATION-BEGIN
{
  "schema_version": "spec-pr-governance-v1",
  "behavior_change": "yes",
  "contract_change": "none",
  "specs": ["SPEC-020"],
  "requirements": ["SPEC-020-R001"],
  "authority_domains": ["provider-autoupdate"],
  "arbitration": ["CODE_BUG"],
  "tests": [
    "node --test test/e2e/canary-buyer/probe.test.mjs test/e2e/canary-buyer/safety.test.mjs",
    "python3 ops/pearl-updater/test_pearl_updater.py",
    "bash test/e2e/canary-buyer/run-canary.test.sh",
    "bash scripts/test-pearl-runtime-release.sh",
    "python3 scripts/verify-pearl-go-binaries.py --self-test",
    "git diff --check origin/main..HEAD"
  ],
  "journeys": ["issue-825-pearl-runtime-deploy"],
  "issue": "https://github.com/Augustas11/macprovider/issues/825"
}
SPEC-GOVERNANCE-DECLARATION-END