### PR TITLE
Fix Pearl rollback gate for idle duplicate telemetry

### DIFF
--- a/ops/pearl-updater/macprovider-pearl-update
+++ b/ops/pearl-updater/macprovider-pearl-update
@@ -115,8 +115,8 @@ MAX_DOWNLOAD_BYTES = 512 * 1024 * 1024
 MAX_CANDIDATE_OUTPUT_BYTES = 64 * 1024
 MAX_BUYER_PROOF_STREAM_BYTES = 1024 * 1024
 MAX_BUYER_PROOF_STREAM_LINE_BYTES = 64 * 1024
-CANARY_AUTHORITY_VERSION = "issue-825-canary-fleet-r3"
-CANARY_AUTHORITY_COMMIT = "e742e42672d78a3f656f7665ac1cb129f731cc19"
+CANARY_AUTHORITY_VERSION = "issue-825-canary-fleet-r4"
+CANARY_AUTHORITY_COMMIT = "63577a81c3fba02c98ef3048d66946b918fe7721"
 CANARY_UNIT_BUDGET_S = 180
 JOURNAL_SCHEMA_VERSION = 1
 CURRENT_RELEASE_SCHEMA_VERSION = 1
@@ -134,7 +134,7 @@ ROLLBACK_STEPS = (
     "canary_timer",
 )
 CANARY_AUTHORITY_FILES = {
-    Path("/opt/macprovider-canary-buyer/probe.mjs"): "d707b4a6ff1d72209f3bf7d7ade6cbbd707d4539b7cac53f9b1263fba21b1b45",
+    Path("/opt/macprovider-canary-buyer/probe.mjs"): "5d1ed3ca815f34d29f290fc634a27d7badd8821f48e96ef29be2226de8dd0f81",
     Path("/opt/macprovider-canary-buyer/safety.mjs"): "03111b34d7ea86c0869be41ca54ed7057f437a0611e4637fc5d315aeb602f632",
     Path("/opt/macprovider-canary-buyer/run-canary.sh"): "6c5b31fce3b477aed8a85c7a0750e924360ed4828da49ca42ea693482e635585",
     Path("/opt/macprovider-canary-buyer/emergency-disable.sh"): "1380122e76b3b66ad812849e3684b38eaaed0790f0e6011e3f194bd215ab1c7e",

--- a/ops/pearl-updater/test_pearl_updater.py
+++ b/ops/pearl-updater/test_pearl_updater.py
@@ -3277,10 +3277,10 @@ class PearlUpdaterTests(unittest.TestCase):
                 updater_module.CANARY_AUTHORITY_FILES[installed],
                 hashlib.sha256(source_at_authority).hexdigest(),
             )
-        self.assertEqual(updater_module.CANARY_AUTHORITY_VERSION, "issue-825-canary-fleet-r3")
+        self.assertEqual(updater_module.CANARY_AUTHORITY_VERSION, "issue-825-canary-fleet-r4")
         self.assertEqual(
             updater_module.CANARY_AUTHORITY_COMMIT,
-            "e742e42672d78a3f656f7665ac1cb129f731cc19",
+            "63577a81c3fba02c98ef3048d66946b918fe7721",
         )
         subprocess.run(
             ["git", "cat-file", "-e", f"{updater_module.CANARY_AUTHORITY_COMMIT}^{{commit}}"],
@@ -3427,7 +3427,7 @@ class PearlUpdaterTests(unittest.TestCase):
             {
                 "schema_version": 1,
                 "kind": "legacy_rollback",
-                "authority": "issue-825-canary-fleet-r3",
+                "authority": "issue-825-canary-fleet-r4",
                 "transaction_id": "a" * 64,
                 "expires_at": observed["document"]["expires_at"],
                 "providers": [

--- a/ops/runbooks/pearl-release-updater.md
+++ b/ops/runbooks/pearl-release-updater.md
@@ -110,11 +110,11 @@ legacy git-describe bootstrap is no longer accepted.
 
 ## One-time installation
 
-First deploy the issue #825 r3 exercised-provider recovery revision of #584's redesigned
+First deploy the issue #825 r4 legacy duplicate recovery revision of #584's redesigned
 canary buyer exactly as reviewed, including its root-only `LoadCredential`
 files, safety observer, emergency stop, and classified no-load exits. The
 updater pins that complete runtime, service, and timer as rollout authority
-`issue-825-canary-fleet-r3` at source commit `e742e42672d78a3f656f7665ac1cb129f731cc19`;
+`issue-825-canary-fleet-r4` at source commit `63577a81c3fba02c98ef3048d66946b918fe7721`;
 the default `PEARL_UPDATER_BUYER_CANARY_MODE=required` posture fails `--plan`
 on any SHA drift, missing credential, invalid protected-fleet expected-fleet
 document, absent reviewed enable gate, active emergency-disable sentinel,
@@ -587,8 +587,13 @@ phase-journal restoration. That root-owned `0644` control binds the exact
 captured protected provider ID/model fleet, the exact prior advertised binary
 version, the 64-hex transaction ID, and an expiry no more than 15 minutes away.
 It substitutes only for missing provider v2 signals on unclassified legacy
-rows; bridge/current/previous modes, wrong versions/models/IDs, stale sessions,
-capacity loss, and all other canary failures remain rejected. The updater
+rows and, during the scoped legacy rollback recovery/final-serving window only,
+tolerates readiness/signal/count loss for an unexercised duplicate-model row
+that remains present, unclassified, identity/version/session-stable, and backed
+by another authorized same-model provider that is ready, routable, and fresh.
+Bridge/current/previous modes, wrong versions/models/IDs, stale sessions,
+provider disappearance, exercised-provider loss, unique-model capacity loss, and
+all other canary failures remain rejected. The updater
 removes the control on every success or failure exit. Its presence outside a
 restoration blocks an ordinary rollout canary.
 The Better Stack heartbeat is then returned to its exact pre-maintenance paused

--- a/test/e2e/canary-buyer/probe.mjs
+++ b/test/e2e/canary-buyer/probe.mjs
@@ -74,7 +74,7 @@ const configuredTTFTSamples = intEnv('CANARY_TTFT_SAMPLES', 12, 1, 20);
 const configuredTPSSamples = intEnv('CANARY_TPS_SAMPLES', 3, 1, 10);
 const GATEWAY_STATUS_CACHE_TTL_MS = 10_000;
 const PRODUCTION_HEARTBEAT_CADENCE_MS = 30_000;
-const LEGACY_ROLLBACK_AUTHORITY = 'issue-825-canary-fleet-r3';
+const LEGACY_ROLLBACK_AUTHORITY = 'issue-825-canary-fleet-r4';
 const LEGACY_ROLLBACK_MAX_VALIDITY_MS = 15 * 60 * 1000;
 
 const CONFIG = {
@@ -1115,6 +1115,123 @@ function isLegacyRollbackProviderSignalSubstitute(
     && row?.binary_version === authorization.binary_version;
 }
 
+function legacyRollbackRowAuthorized(row, expected, authorizedProviders, nowMs) {
+  const authorization = authorizedProviders?.get(expected?.provider_id || '');
+  return authorization?.model_id === expected?.model_id
+    && Number.isFinite(authorization?.expires_at_ms)
+    && nowMs < authorization.expires_at_ms
+    && row?.provider_id === expected.provider_id
+    && typeof row?.assigned_id === 'string'
+    && row.assigned_id.length > 0
+    && row?.model_id === expected.model_id
+    && Number.isFinite(row?.connected_at_ms)
+    && row?.catalog_admission_mode == null
+    && row?.binary_version === authorization.binary_version;
+}
+
+function legacyIdleDuplicateDropAllowance(
+  observations,
+  expectedFleet,
+  legacyRollbackProviders,
+  heartbeatAdvanceProviderIDs,
+  nowMs,
+) {
+  const empty = { providerIDs: new Set(), byModel: new Map(), count: 0 };
+  if (!legacyRollbackProviders?.size || !heartbeatAdvanceProviderIDs) return empty;
+  const observedList = Array.isArray(observations) ? observations.filter(Boolean) : [observations].filter(Boolean);
+  if (!observedList.length) return empty;
+  const expectedByID = new Map(expectedFleet.map((row) => [row.provider_id, row]));
+  const providerIDs = new Set();
+  for (const observed of observedList) {
+    const rows = Array.isArray(observed?.operator_pool) ? observed.operator_pool : [];
+    const currentByID = new Map(rows.map((row) => [row.provider_id, row]));
+    for (const expected of expectedFleet) {
+      const id = expected.provider_id;
+      if (heartbeatAdvanceProviderIDs.has(id) || !legacyRollbackProviders.has(id)) continue;
+      const row = currentByID.get(id);
+      const rowAuthorized = row && legacyRollbackRowAuthorized(row, expected, legacyRollbackProviders, nowMs);
+      if (!rowAuthorized) continue;
+      const rowReady = row
+        && rowAuthorized
+        && row.state === 'ready'
+        && row.routing_eligible === true
+        && Number.isFinite(row.heartbeat_age_ms)
+        && row.heartbeat_age_ms <= CONFIG.maxHeartbeatAgeMs;
+      if (rowReady) continue;
+      const substituteReady = rows.some((candidate) => {
+        if (!candidate?.provider_id || candidate.provider_id === id) return false;
+        const candidateExpected = expectedByID.get(candidate.provider_id);
+        if (!candidateExpected || candidateExpected.model_id !== expected.model_id) return false;
+        return legacyRollbackRowAuthorized(candidate, candidateExpected, legacyRollbackProviders, nowMs)
+          && candidate.state === 'ready'
+          && candidate.routing_eligible === true
+          && Number.isFinite(candidate.heartbeat_age_ms)
+          && candidate.heartbeat_age_ms <= CONFIG.maxHeartbeatAgeMs;
+      });
+      if (substituteReady) providerIDs.add(id);
+    }
+  }
+  if (!providerIDs.size) return empty;
+  const byModel = new Map();
+  for (const id of providerIDs) {
+    const model = expectedByID.get(id)?.model_id || '';
+    if (model) byModel.set(model, (byModel.get(model) || 0) + 1);
+  }
+  return { providerIDs, byModel, count: providerIDs.size };
+}
+
+function filterLegacyIdleDuplicateRecoveryReasons(reasons, {
+  observations,
+  expectedFleet,
+  legacyRollbackProviders,
+  heartbeatAdvanceProviderIDs,
+  nowMs,
+}) {
+  const allowance = legacyIdleDuplicateDropAllowance(
+    observations,
+    expectedFleet,
+    legacyRollbackProviders,
+    heartbeatAdvanceProviderIDs,
+    nowMs,
+  );
+  if (!allowance.count) return reasons;
+  return reasons.filter((reason) => !legacyIdleDuplicateReasonAllowed(reason, allowance));
+}
+
+function legacyIdleDuplicateReasonAllowed(reason, allowance) {
+  const unscopedReason = reason.replace(/^(?:sample_\d+|final|recovery_final|recovery_soak):/, '');
+  for (const id of allowance.providerIDs) {
+    if (!unscopedReason.startsWith(`${id}:`)) continue;
+    const suffix = unscopedReason.slice(id.length + 1);
+    if (
+      suffix === 'expected_provider_not_ready'
+      || suffix === 'heartbeat_signal_missing'
+      || suffix === 'provider_signal_missing'
+      || /^state_[^:]+_not_ready$/.test(suffix)
+      || /^heartbeat_stale_\d+(?:\.\d+)?ms_gt_\d+ms$/.test(suffix)
+      || /^telemetry_observation_stale_\d+ms_gt_\d+ms$/.test(suffix)
+      || /^provider_state_[^:]+_not_allowed$/.test(suffix)
+      || suffix === 'coordinator_disconnected'
+    ) {
+      return true;
+    }
+  }
+  let match = unscopedReason.match(/^ready_(\d+)_lt_(\d+)$/);
+  if (match && Number(match[2]) - Number(match[1]) <= allowance.count) return true;
+  match = unscopedReason.match(/^pool_unavailable_(\d+)_ne_0$/);
+  if (match && Number(match[1]) <= allowance.count) return true;
+  match = unscopedReason.match(/^ready_changed_(\d+)_to_(\d+)$/);
+  if (match && Number(match[1]) - Number(match[2]) <= allowance.count) return true;
+  match = unscopedReason.match(/^provider_signal_count_(\d+)_ne_(\d+)$/);
+  if (match && Number(match[2]) - Number(match[1]) <= allowance.count) return true;
+  match = unscopedReason.match(/^(.*):ready_provider_count_changed_(\d+)_to_(\d+)$/);
+  if (match) {
+    const allowedLoss = allowance.byModel.get(match[1]) || 0;
+    if (Number(match[2]) - Number(match[3]) <= allowedLoss) return true;
+  }
+  return false;
+}
+
 function hasDirectProviderSignal(signal) {
   return Object.entries(signal || {}).some(
     ([field, value]) => field !== 'source' && value != null,
@@ -1165,7 +1282,7 @@ export function recoverySoakObservationReasons(
     allowLegacyBridgeProviderSignals = false,
     ...soakOptions
   } = options;
-  return recoverySoakReasons({
+  const reasons = recoverySoakReasons({
     gatewayInitial: initial.gateway,
     gatewaySamples: samples.map((sample) => sample.gateway),
     poolzInitial: expectedPoolRows(initial.operator_pool, expectedFleet),
@@ -1189,6 +1306,13 @@ export function recoverySoakObservationReasons(
       ),
     ),
   }, soakOptions);
+  return filterLegacyIdleDuplicateRecoveryReasons(reasons, {
+    observations: samples,
+    expectedFleet,
+    legacyRollbackProviders,
+    heartbeatAdvanceProviderIDs: soakOptions.heartbeatAdvanceProviderIDs || null,
+    nowMs,
+  });
 }
 
 export function validateLegacyRollbackAuthorization(document, expectedFleet, nowMs = Date.now()) {
@@ -1352,8 +1476,9 @@ export function safetyObservationReasons(initial, observed, expectedFleet, {
       if (!current) {
         const poolRow = currentPoolByID.get(expected.provider_id);
         const poolIndex = observed.operator_pool.indexOf(poolRow);
-        const directSignalMissing = poolIndex >= 0
-          && !hasDirectProviderSignal(observed.providers[poolIndex]);
+        const poolSlotSignal = poolIndex >= 0 ? observed.providers[poolIndex] : null;
+        const directSignalPresent = poolIndex >= 0 && hasDirectProviderSignal(poolSlotSignal);
+        const directSignalMissing = poolIndex >= 0 && !directSignalPresent;
         if (allowLegacyBridgeProviderSignals && isLegacyBridgeProviderSignalSubstitute(poolRow, expected)) {
           continue;
         }
@@ -1364,6 +1489,10 @@ export function safetyObservationReasons(initial, observed, expectedFleet, {
           nowMs,
           activeProviderID,
         )) {
+          continue;
+        }
+        if (directSignalPresent && poolSlotSignal?.provider_id !== expected.provider_id) {
+          reasons.push(`${expected.provider_id}:provider_signal_identity_mismatch_${poolSlotSignal?.provider_id || 'missing'}`);
           continue;
         }
         reasons.push(`${expected.provider_id}:provider_signal_missing`);
@@ -1384,7 +1513,13 @@ export function safetyObservationReasons(initial, observed, expectedFleet, {
       }
     }
   }
-  return [...new Set(reasons)];
+  return [...new Set(filterLegacyIdleDuplicateRecoveryReasons(reasons, {
+    observations: observed,
+    expectedFleet,
+    legacyRollbackProviders,
+    heartbeatAdvanceProviderIDs,
+    nowMs,
+  }))];
 }
 
 function createControl(initial, baselines, expectedFleet, budget, legacyRollbackProviders) {
@@ -1744,6 +1879,9 @@ async function main() {
       )
     );
   }
+  const heartbeatAdvanceProviderIDs = legacyRollbackProviders?.size && budget.providers.size
+    ? new Set([...budget.providers.keys()].filter(Boolean))
+    : null;
   let post = null;
   const recoverySamples = [];
   const recoveryRecords = [];
@@ -1760,7 +1898,7 @@ async function main() {
         recoveryRecords.push({ observed: null, reasons: [], error: budget.timeReason() || 'hard_deadline_exhausted', phase: 'recovery_soak' });
         break;
       }
-      const record = await control.observeRaw('recovery_soak');
+      const record = await control.observeRaw('recovery_soak', { heartbeatAdvanceProviderIDs });
       recoveryRecords.push(record);
       if (record.observed) {
         post = record.observed;
@@ -1771,9 +1909,6 @@ async function main() {
       ...(record.error ? [`${record.phase}:${record.error}`] : []),
       ...record.reasons.map((reason) => `${record.phase}:${reason}`),
     ]);
-    const heartbeatAdvanceProviderIDs = legacyRollbackProviders?.size && budget.providers.size
-      ? new Set([...budget.providers.keys()].filter(Boolean))
-      : null;
     recoveryReasons.push(...recoverySoakObservationReasons(
       initial,
       recoverySamples,

--- a/test/e2e/canary-buyer/probe.test.mjs
+++ b/test/e2e/canary-buyer/probe.test.mjs
@@ -463,7 +463,7 @@ test('legacy rollback authorization is exact, expiring, and limited to unclassif
   const document = {
     schema_version: 1,
     kind: 'legacy_rollback',
-    authority: 'issue-825-canary-fleet-r3',
+    authority: 'issue-825-canary-fleet-r4',
     transaction_id: 'a'.repeat(64),
     expires_at: new Date(now + 300_000).toISOString(),
     providers: expectedFleet.map((row) => ({ ...row, binary_version: '1.8.30' })),
@@ -566,7 +566,7 @@ test('legacy rollback authorization is exact, expiring, and limited to unclassif
     malformedDirectSignal,
     expectedFleet,
     { legacyRollbackProviders: authorized, nowMs: now },
-  ).includes('provider-a:provider_signal_missing'));
+  ).some((reason) => reason.startsWith('provider-a:')));
 
   const replacementSession = structuredClone(observation);
   replacementSession.operator_pool[0].assigned_id = 'replacement-session';
@@ -616,7 +616,7 @@ test('legacy rollback recovery requires heartbeat advance only from exercised pr
   const document = {
     schema_version: 1,
     kind: 'legacy_rollback',
-    authority: 'issue-825-canary-fleet-r3',
+    authority: 'issue-825-canary-fleet-r4',
     transaction_id: 'b'.repeat(64),
     expires_at: new Date(now + 300_000).toISOString(),
     providers: expectedFleet.map((row) => ({ ...row, binary_version: '1.8.30' })),
@@ -708,6 +708,242 @@ test('legacy rollback recovery requires heartbeat advance only from exercised pr
     nowMs: now,
     requireHeartbeatAdvance: true,
   }).some((reason) => reason.includes('provider-c')));
+});
+
+test('legacy rollback recovery tolerates only unexercised duplicate provider readiness loss', () => {
+  const now = Date.parse('2026-08-01T10:53:42Z');
+  const expectedFleet = [
+    { provider_id: 'provider-a', model_id: 'model-a' },
+    { provider_id: 'provider-b', model_id: 'model-b' },
+    { provider_id: 'provider-c', model_id: 'model-b' },
+  ];
+  const document = {
+    schema_version: 1,
+    kind: 'legacy_rollback',
+    authority: 'issue-825-canary-fleet-r4',
+    transaction_id: 'c'.repeat(64),
+    expires_at: new Date(now + 300_000).toISOString(),
+    providers: expectedFleet.map((row) => ({ ...row, binary_version: '1.8.30' })),
+  };
+  const authorized = validateLegacyRollbackAuthorization(document, expectedFleet, now);
+  const gateway = gatewaySnapshot({
+    status: 'up',
+    degraded: false,
+    coordinator: { status: 'up', checked_at: new Date(now).toISOString() },
+    pool: { total_providers: 3, ready: 3, degraded: 0, draining: 0, unavailable: 0 },
+    models: [
+      { id: 'model-a', provider_count: 1, ready_provider_count: 1, slots_free: 1, available: true, availability: 'available', degraded: false },
+      { id: 'model-b', provider_count: 2, ready_provider_count: 2, slots_free: 2, available: true, availability: 'available', degraded: false },
+    ],
+  });
+  const operatorPool = poolzSnapshot({ pool: expectedFleet.map(({ provider_id, model_id }, index) => ({
+    provider_id,
+    assigned_id: `session-${index}`,
+    model_id,
+    state: 'ready',
+    routing_eligible: true,
+    binary_version: '1.8.30',
+    connected_at: new Date(now - 60_000).toISOString(),
+    last_heartbeat_at: new Date(now - 1_000).toISOString(),
+    last_activity_at: new Date(now - 1_000).toISOString(),
+  })) }, now);
+  const providers = expectedFleet.map(({ provider_id, model_id }, index) => safetyProvider(
+    provider_id,
+    model_id,
+    `session-${index}`,
+    {
+      binary_version: '1.8.30',
+      observation_id: `${provider_id}-initial`,
+      observed_at: new Date(now - 1_000).toISOString(),
+    },
+  ));
+  const observation = { gateway, operator_pool: operatorPool, providers };
+  const exercisedProviderIDs = new Set(['provider-a', 'provider-b']);
+  const recoveryOne = structuredClone(observation);
+  const recoveryTwo = structuredClone(observation);
+  for (const [index, sample] of [recoveryOne, recoveryTwo].entries()) {
+    for (const row of sample.operator_pool) {
+      if (exercisedProviderIDs.has(row.provider_id)) {
+        row.last_heartbeat_at_ms += (index + 1) * 30_000;
+        row.last_activity_at_ms += (index + 1) * 30_000;
+      }
+      row.heartbeat_age_ms = 0;
+      row.activity_age_ms = 0;
+    }
+    for (const provider of sample.providers) {
+      if (exercisedProviderIDs.has(provider.provider_id)) {
+        provider.observation_id = `${provider.provider_id}-sample-${index + 1}`;
+        provider.observed_at_ms += (index + 1) * 30_000;
+      }
+      provider.observation_age_ms = 0;
+    }
+  }
+  recoveryTwo.gateway.pool.ready = 2;
+  recoveryTwo.gateway.pool.unavailable = 1;
+  recoveryTwo.gateway.models[1].ready_provider_count = 1;
+  const droppedDuplicate = recoveryTwo.operator_pool.find((row) => row.provider_id === 'provider-c');
+  droppedDuplicate.state = 'unavailable';
+  droppedDuplicate.routing_eligible = false;
+  droppedDuplicate.heartbeat_age_ms = 120_000;
+
+  const scopedAdvance = {
+    minReadyProviders: 3,
+    maxHeartbeatAgeMs: 90_000,
+    heartbeatAdvanceProviderIDs: exercisedProviderIDs,
+  };
+  assert.deepEqual(recoverySoakObservationReasons(
+    observation,
+    [recoveryOne, recoveryTwo],
+    expectedFleet,
+    authorized,
+    scopedAdvance,
+    now,
+  ), []);
+  assert.deepEqual(safetyObservationReasons(observation, recoveryTwo, expectedFleet, {
+    legacyRollbackProviders: authorized,
+    nowMs: now,
+    requireHeartbeatAdvance: true,
+    heartbeatAdvanceProviderIDs: exercisedProviderIDs,
+  }), []);
+  assert.ok(safetyObservationReasons(observation, recoveryTwo, expectedFleet, {
+    legacyRollbackProviders: authorized,
+    nowMs: now,
+    requireHeartbeatAdvance: true,
+  }).map((reason) => `recovery_soak:${reason}`).some((reason) => reason.includes('provider-c')));
+  assert.deepEqual(safetyObservationReasons(observation, recoveryTwo, expectedFleet, {
+    legacyRollbackProviders: authorized,
+    nowMs: now,
+    requireHeartbeatAdvance: true,
+    heartbeatAdvanceProviderIDs: exercisedProviderIDs,
+  }).map((reason) => `recovery_soak:${reason}`), []);
+
+  assert.ok(recoverySoakObservationReasons(
+    observation,
+    [recoveryOne, recoveryTwo],
+    expectedFleet,
+    authorized,
+    { ...scopedAdvance, heartbeatAdvanceProviderIDs: new Set(['provider-a', 'provider-b', 'provider-c']) },
+    now,
+  ).some((reason) => reason.includes('provider-c')));
+  assert.ok(recoverySoakObservationReasons(
+    observation,
+    [recoveryOne, recoveryTwo],
+    expectedFleet,
+    null,
+    scopedAdvance,
+    now,
+  ).some((reason) => reason.includes('provider-c')));
+
+  const missingDuplicate = structuredClone(recoveryTwo);
+  missingDuplicate.gateway.pool.total_providers = 2;
+  missingDuplicate.operator_pool = missingDuplicate.operator_pool.filter((row) => row.provider_id !== 'provider-c');
+  assert.ok(recoverySoakObservationReasons(
+    observation,
+    [recoveryOne, missingDuplicate],
+    expectedFleet,
+    authorized,
+    scopedAdvance,
+    now,
+  ).some((reason) => reason.includes('provider-c')));
+
+  const uniqueLoss = structuredClone(recoveryTwo);
+  const providerA = uniqueLoss.operator_pool.find((row) => row.provider_id === 'provider-a');
+  providerA.state = 'unavailable';
+  providerA.routing_eligible = false;
+  uniqueLoss.gateway.models[0].available = false;
+  uniqueLoss.gateway.models[0].degraded = true;
+  uniqueLoss.gateway.models[0].ready_provider_count = 0;
+  assert.ok(safetyObservationReasons(observation, uniqueLoss, expectedFleet, {
+    legacyRollbackProviders: authorized,
+    nowMs: now,
+    requireHeartbeatAdvance: true,
+    heartbeatAdvanceProviderIDs: exercisedProviderIDs,
+  }).some((reason) => reason.includes('provider-a')));
+
+  const currentCatalogMode = structuredClone(recoveryTwo);
+  currentCatalogMode.operator_pool.find((row) => row.provider_id === 'provider-c').catalog_admission_mode = 'current';
+  assert.ok(safetyObservationReasons(observation, currentCatalogMode, expectedFleet, {
+    legacyRollbackProviders: authorized,
+    nowMs: now,
+    requireHeartbeatAdvance: true,
+    heartbeatAdvanceProviderIDs: exercisedProviderIDs,
+  }).some((reason) => reason.includes('provider-c')));
+
+  const wrongProviderSignal = structuredClone(recoveryTwo);
+  const duplicateSignalIndex = wrongProviderSignal.providers.findIndex((provider) => provider.provider_id === 'provider-c');
+  wrongProviderSignal.providers[duplicateSignalIndex].provider_id = 'wrong-provider';
+  assert.ok(safetyObservationReasons(observation, wrongProviderSignal, expectedFleet, {
+    legacyRollbackProviders: authorized,
+    nowMs: now,
+    requireHeartbeatAdvance: true,
+    heartbeatAdvanceProviderIDs: exercisedProviderIDs,
+  }).some((reason) => reason.includes('provider-c:provider_signal_identity_mismatch_wrong-provider')));
+  const missingProviderIDSignal = structuredClone(recoveryTwo);
+  const missingProviderIDSignalIndex = missingProviderIDSignal.providers.findIndex((provider) => provider.provider_id === 'provider-c');
+  delete missingProviderIDSignal.providers[missingProviderIDSignalIndex].provider_id;
+  assert.ok(safetyObservationReasons(observation, missingProviderIDSignal, expectedFleet, {
+    legacyRollbackProviders: authorized,
+    nowMs: now,
+    requireHeartbeatAdvance: true,
+    heartbeatAdvanceProviderIDs: exercisedProviderIDs,
+  }).some((reason) => reason.includes('provider-c:provider_signal_identity_mismatch_missing')));
+
+  const substringExpectedFleet = [
+    { provider_id: 'a', model_id: 'model-b' },
+    { provider_id: 'provider-a', model_id: 'model-b' },
+    { provider_id: 'provider-b', model_id: 'model-b' },
+  ];
+  const substringDocument = {
+    ...document,
+    providers: substringExpectedFleet.map((row) => ({ ...row, binary_version: '1.8.30' })),
+  };
+  const substringAuthorized = validateLegacyRollbackAuthorization(substringDocument, substringExpectedFleet, now);
+  const substringInitial = {
+    gateway: gatewaySnapshot({
+      status: 'up',
+      degraded: false,
+      coordinator: { status: 'up', checked_at: new Date(now).toISOString() },
+      pool: { total_providers: 3, ready: 3, degraded: 0, draining: 0, unavailable: 0 },
+      models: [
+        { id: 'model-b', provider_count: 3, ready_provider_count: 3, slots_free: 3, available: true, availability: 'available', degraded: false },
+      ],
+    }),
+    operator_pool: poolzSnapshot({ pool: substringExpectedFleet.map(({ provider_id, model_id }, index) => ({
+      provider_id,
+      assigned_id: `substring-session-${index}`,
+      model_id,
+      state: 'ready',
+      routing_eligible: true,
+      binary_version: '1.8.30',
+      connected_at: new Date(now - 60_000).toISOString(),
+      last_heartbeat_at: new Date(now - 1_000).toISOString(),
+      last_activity_at: new Date(now - 1_000).toISOString(),
+    })) }, now),
+    providers: substringExpectedFleet.map(({ provider_id, model_id }, index) => safetyProvider(
+      provider_id,
+      model_id,
+      `substring-session-${index}`,
+      {
+        binary_version: '1.8.30',
+        observation_id: `${provider_id}-initial`,
+        observed_at: new Date(now - 1_000).toISOString(),
+      },
+    )),
+  };
+  const substringObserved = structuredClone(substringInitial);
+  substringObserved.operator_pool.find((row) => row.provider_id === 'a').state = 'unavailable';
+  substringObserved.operator_pool.find((row) => row.provider_id === 'a').routing_eligible = false;
+  substringObserved.operator_pool.find((row) => row.provider_id === 'provider-a').state = 'unavailable';
+  substringObserved.operator_pool.find((row) => row.provider_id === 'provider-a').routing_eligible = false;
+  substringObserved.gateway.pool.ready = 1;
+  substringObserved.gateway.pool.unavailable = 2;
+  substringObserved.gateway.models[0].ready_provider_count = 1;
+  assert.ok(safetyObservationReasons(substringInitial, substringObserved, substringExpectedFleet, {
+    legacyRollbackProviders: substringAuthorized,
+    nowMs: now,
+    requireHeartbeatAdvance: true,
+    heartbeatAdvanceProviderIDs: new Set(['provider-a', 'provider-b']),
+  }).some((reason) => reason.includes('provider-a:expected_provider_not_ready')));
 });
 
 test('post-request recovery outlives the gateway active-loss cache window', async () => {


### PR DESCRIPTION
## Summary

Fixes the remaining Pearl #825 rollback-reconciliation blocker: legacy rollback recovery now tolerates only an unexercised duplicate-model provider that remains present, unclassified, identity/version/session-stable, and backed by another authorized same-model provider that is ready, routable, and fresh.

The allowance is scoped to legacy rollback recovery/final-serving checks and exercised-provider heartbeat advancement. It does not waive provider disappearance, wrong or blank direct telemetry identity, substring provider-ID collisions, catalog current/previous/bridge modes, exercised-provider loss, unique-model loss, version/model/session drift, or stale authority.

The Pearl updater and runbook now pin r4 authority `issue-825-canary-fleet-r4` to source commit `63577a81c3fba02c98ef3048d66946b918fe7721` and probe hash `5d1ed3ca815f34d29f290fc634a27d7badd8821f48e96ef29be2226de8dd0f81`.

## Validation

- `node --test test/e2e/canary-buyer/probe.test.mjs test/e2e/canary-buyer/safety.test.mjs` (33/33 pass)
- `python3 ops/pearl-updater/test_pearl_updater.py` (180 OK, 1 skipped)
- `bash test/e2e/canary-buyer/run-canary.test.sh` (PASS)
- `bash scripts/test-pearl-runtime-release.sh` (PASS)
- `python3 scripts/verify-pearl-go-binaries.py --self-test` (PASS)
- `git diff --check origin/main..HEAD` (clean)

## Audit

Three independent audit lanes reviewed the committed `origin/main..HEAD` diff and reported 0 Critical / 0 High / 0 Medium bugs:

- Code correctness: 0 C/H/M
- Security/safety invariants: 0 C/H/M
- Architecture/operational fit: 0 C/H/M

Unstaged dirty files outside the committed PR diff were present in the local worktree and explicitly excluded from review and staging.

SPEC-GOVERNANCE-DECLARATION-BEGIN
{
  "schema_version": "spec-pr-governance-v1",
  "behavior_change": "yes",
  "contract_change": "none",
  "specs": ["SPEC-020"],
  "requirements": ["SPEC-020-R001"],
  "authority_domains": ["provider-autoupdate"],
  "arbitration": ["CODE_BUG"],
  "tests": [
    "node --test test/e2e/canary-buyer/probe.test.mjs test/e2e/canary-buyer/safety.test.mjs",
    "python3 ops/pearl-updater/test_pearl_updater.py",
    "bash test/e2e/canary-buyer/run-canary.test.sh",
    "bash scripts/test-pearl-runtime-release.sh",
    "python3 scripts/verify-pearl-go-binaries.py --self-test",
    "git diff --check origin/main..HEAD"
  ],
  "journeys": ["issue-825-pearl-runtime-deploy"],
  "issue": "https://github.com/Augustas11/macprovider/issues/825"
}
SPEC-GOVERNANCE-DECLARATION-END

