### PR TITLE
feat(payout): SPEC-016 §9.6 synthetic-alert verification harness + alerting-contract fixes

### DIFF
--- a/dist/synthetic-alerts/README.md
+++ b/dist/synthetic-alerts/README.md
@@ -1,0 +1,232 @@
+# SPEC-016 §9 item 6 — synthetic payout alerts
+
+This directory is the operator harness for **SPEC-016 payout-pipeline §9
+cutover prerequisite item 6**:
+
+> **BetterStack alert filter extended** to match EVERY §7.1 event with
+> severity=PAGE or severity=WARN. … Operator MUST verify with ONE synthetic
+> alert per **ENUMERATED PAGE/WARN event NAME** (NOT one per severity tier)
+> before flipping `payout.enabled: true`.
+
+Per-event (not per-tier) verification is the point: a per-tier check that only
+confirms "at least one PAGE alert fires" would silently pass even if
+`payout_runner_lease_lost` were typo'd in the BetterStack filter as
+`payout_runner_lease_lst`. The BetterStack monitor config lives in the
+BetterStack UI, **not** in this repo, so this harness cannot assert the matchers
+directly. Instead it:
+
+> **Matchers MUST key on the `event` field + the `severity` field — never on the
+> zerolog `level`.** Some real events emit a PAGE `severity` at a non-error
+> level (e.g. `payout_reorg_orphan_recorded` logs at `level=warn` with
+> `severity=PAGE`). The synthetic lines make the `severity` field authoritative
+> and identical to the catalog; the `level` field is cosmetic.
+
+1. **Emits** one synthetic structured-log line per enumerated PAGE/WARN event
+   name (`emit.sh`), in the exact zerolog-JSON shape the coordinator emits real
+   events, so the operator can watch each one land in BetterStack.
+2. **Guarantees** (`catalog.tsv` + the coordinator completeness test) that the
+   enumerated set stays complete versus the code's actual emitted event names,
+   so a newly added PAGE/WARN event can never ship without a catalog entry — and
+   therefore without an operator deciding on a matcher.
+
+## Files
+
+| File | Role |
+| --- | --- |
+| `catalog.tsv` | **Single source of truth for alert events.** `event_name  severity  status  page_capable`. Shared by `emit.sh` and the completeness test. |
+| `non-alert-allowlist.txt` | Reviewed list of `payout_`/`provider_payout_` string literals that are NOT alert events (DB tables/columns, INFO-only events, reason strings), each with a one-word reason. |
+| `emit.sh` | POSIX-sh emitter. `--list`, `--event NAME`, default (emitted PAGE/WARN), `--include-info`, `--reserved`. |
+| `README.md` | This file. |
+
+The completeness test lives with the code it guards:
+`phase4-coordinator/internal/payout/synthetic_alerts_catalog_test.go`.
+
+**Why it is a literal-presence check, not an emission scanner.** Statically
+deciding *which* zerolog emissions are PAGE/WARN alerts, from arbitrary Go, is
+undecidable — an AST scanner that tries to follow the event name and severity
+through helpers, structs, closures, and threaded parameters can always be fooled
+by one more indirection. So the test does **not** analyse emission. It is
+**style-agnostic**: it scans every non-test `.go` file under
+`phase4-coordinator/internal/payout/` (recursively) and
+`phase4-coordinator/cmd/coordinator/` for every identifier-shaped string literal
+matching `^(payout_|provider_payout_)[a-z0-9_]+$`, and requires **each** to be
+classified as exactly one of:
+
+1. a catalogued **alert** event → `catalog.tsv`, or
+2. a reviewed **non-alert** string → `non-alert-allowlist.txt`.
+
+Any unclassified literal **fails the test** (fail-closed): a new alert event
+necessarily introduces a new event-name literal (or `const`) somewhere, and it
+cannot ship silently. Alert event names must be plain literals/consts — a
+**dynamically constructed** alert name (`fmt.Sprintf("payout_%s", …)` or
+`"payout_" + x`) also fails, which is what keeps the literal-presence guarantee
+sound. (A `payout_`-prefixed *prose message* such as an `Error()` string is not
+identifier-shaped and is correctly ignored.)
+
+**Dynamic (page-capable) severity.** An event whose severity is computed at
+runtime and can escalate to PAGE (e.g. `payout_stale_outbox_backlog`, WARN →
+PAGE on `scan_ceiling_hit`) is marked `page_capable` in the catalog. `emit.sh`
+emits BOTH a WARN and a PAGE synthetic line for it.
+
+**Dynamic (page-capable) severity.** An event whose severity is computed at
+runtime and can escalate to PAGE (e.g. `payout_stale_outbox_backlog`, WARN →
+PAGE on `scan_ceiling_hit`) is marked `page_capable` in the catalog. `emit.sh`
+emits BOTH a WARN and a PAGE synthetic line for it, and the test fails if such an
+event is mis-catalogued as WARN-only.
+
+## Operator procedure (run BEFORE `payout.enabled: true`)
+
+Do this on the coordinator host (Pearl VPS), where the coordinator's stdout is
+captured by systemd-journald and forwarded to BetterStack.
+
+1. **Preview the catalog.**
+
+   ```sh
+   ./emit.sh --list
+   ```
+
+   The **verification set is the emitted set**: `./emit.sh` (default) emits one
+   synthetic line per PAGE/WARN event the coordinator ACTUALLY emits (`code`
+   rows). `info` rows are optional (`--include-info`).
+   `spec-only-not-emitted` rows are **excluded** from the default — the code
+   never emits them, so a matcher for them can never fire from real traffic.
+   They are an implementation gap (see Discrepancies below), available only via
+   `./emit.sh --reserved`, and are NOT part of pre-enablement verification.
+
+2. **Fire the synthetic alerts into the same journald stream the coordinator
+   uses.**
+
+   ```sh
+   ./emit.sh | systemd-cat -t macprovider-coordinator
+   ```
+
+   (Adjust the syslog identifier to whatever the coordinator unit uses, so the
+   lines pass through the identical BetterStack ingest path.) Every line carries
+   `"synthetic":true` and a `"note"` — they are safe and self-identifying.
+
+3. **In the BetterStack UI, confirm EACH event name fired its matcher —
+   one per name.** Do not accept "a PAGE alert fired"; check the full list off
+   name-by-name against `./emit.sh --list`. Any name that does NOT trigger is a
+   missing or mistyped matcher — fix it in BetterStack and re-run
+   `./emit.sh --event <name>` for just that one.
+
+4. **Only after every enumerated PAGE/WARN name is confirmed** may the operator
+   proceed with the remaining §9 prerequisites and flip `payout.enabled: true`.
+
+To re-test a single event after fixing a matcher:
+
+```sh
+./emit.sh --event payout_runner_lease_lost | systemd-cat -t macprovider-coordinator
+```
+
+## Keeping the catalog honest
+
+The catalog is not a static hand-maintained list that can drift from the code.
+`synthetic_alerts_catalog_test.go` runs in CI and:
+
+- **FAILS closed on any unclassified `payout_`/`provider_payout_` identifier
+  literal** in the scanned source — it must be an alert (`catalog.tsv`) or a
+  reviewed non-alert (`non-alert-allowlist.txt`). This is the load-bearing
+  guarantee: a new alert event introduces a new literal, which cannot ship
+  without a classification decision.
+- **FAILS on a dynamically constructed alert name** — `fmt.Sprintf("payout_%s")`,
+  `"payout_" + x`, and the one-more-indirection variant where a `payout_`
+  fragment (a literal ending in `_`, e.g. `"payout_"`) is stored in a variable
+  and concatenated later. This forbids the patterns that could hide a new alert
+  name from a literal check. (A `payout_`-prefixed prose message is not
+  identifier-shaped and is ignored.)
+- **ENFORCES severity-presence on every catalogued alert (sound, per-site).**
+  For each catalogued `code` event — a FINITE, known list — the test resolves
+  every production zerolog chain that emits it (following string literals,
+  consts, struct-field literals, string-returning helpers, and event names
+  threaded through emit-helper parameters) and asserts EACH emitting chain sets
+  a `severity` field matching the catalog. It FAILS, with `file:line`, if any
+  emission site lacks severity, emits the wrong severity, or can emit `PAGE`
+  dynamically for a non-`page_capable` WARN event — and FAILS closed if a
+  catalogued alert has no resolvable emission at all. This is what makes it
+  impossible to ship a catalogued alert whose real event line would miss a
+  `severity`-keyed BetterStack matcher (the false-verification bug class), and it
+  replaces the earlier best-effort check that could miss a per-site gap. The
+  requirement is gated on the catalog SEVERITY (PAGE/WARN), not on a status
+  value, so no status can exempt an emitted alert from carrying severity (there
+  is deliberately no `code-untagged` status). And if a payout-package emission
+  sets an `event` field whose name the harness cannot resolve while carrying no
+  severity, the test FAILS closed rather than skipping it — an emission it can't
+  analyze can never silently pass.
+- **FAILS on a catalog typo** — every catalog entry (except
+  `spec-only-not-emitted`) must appear as a literal in the scanned source.
+- **FAILS if a `spec-only-not-emitted` event starts appearing as a literal**
+  without being reclassified, so the discrepancy list can't silently rot.
+
+When you add a new payout PAGE/WARN event: add its `event`+`severity` field in
+the coordinator, add a `code` row here, add the BetterStack matcher, and verify
+with `./emit.sh --event <name>` as part of the change's go-live gate (SPEC-016
+§9 item 6 requires this for every new event). When you add a non-alert
+`payout_`-shaped string (a new table/column/reason/INFO event), add it to
+`non-alert-allowlist.txt` with a one-word reason.
+
+## Discrepancies found while building this catalog (2026-08-01)
+
+Reconciling SPEC-016 §9 item 6's enumeration against the coordinator's actual
+emitted event names surfaced money-path spec-vs-code divergences. They are
+recorded here rather than silently resolved:
+
+### A. Enumerated by §9 item 6 but NEVER emitted by the code (`spec-only-not-emitted`)
+
+- **`payout_nonce_gap` (WARN)** — §7.1 / §9 item 6 list it, but no
+  `phase4-coordinator` source emits a `payout_nonce_gap` event. The nonce-gap
+  condition surfaces instead via `payout_nonce_cold_start_within_tolerance`
+  (INFO) and `payout_invariant_violation`. Either the emission is missing or the
+  spec over-enumerates.
+- **`payout_runner_lease_conflict` (PAGE)** — §7.1 (NEW v0.1.8) / §9 item 6 list
+  it, but the lease code emits `payout_runner_lease_taken_over` and
+  `payout_runner_lease_lost` instead; no `payout_runner_lease_conflict` string
+  exists in the code. (§4.3's "IMPL test required (1)" even asserts this event.)
+
+These are an **implementation gap**, not a verification item. Because the code
+never emits them, a synthetic alert for them would let an operator "verify" a
+matcher that can never fire from real traffic (false readiness). They are
+therefore **excluded from `./emit.sh`'s default set** and are emitted only by
+`./emit.sh --reserved`, marked `"reserved":true,"not_yet_emitted":true`. Close
+the gap by wiring the emission (then move the row to `code` and it re-enters the
+default verification set), or delete the row if the spec over-enumerated.
+
+### B. Missing `severity` field on PAGE/WARN events — FIXED (2026-08-01)
+
+Four §9 item-6 alerts were emitted WITHOUT a `severity` field, so a BetterStack
+matcher keyed on `severity` would have missed the real event (the synthetic line
+had severity, the production line did not — false verification). The production
+emission sites now set the field, and the catalog rows are `code`:
+
+- `payout_failed` → `.Str("severity","PAGE")` (both emission sites in `runner.go`)
+- `payout_signer_unavailable` → `.Str("severity","PAGE")` (`runner.go`)
+- `provider_payout_address_change_rejected` → `.Str("severity","WARN")` (`addresses.go` `emitFailure`)
+- `provider_payout_address_rejected_unknown_provider` → `.Str("severity","WARN")` (`addresses.go` `emitReject`)
+
+The severity-consistency check (below) now enforces that these keep matching the
+catalog.
+
+### C. Emitted by code as PAGE/WARN but NOT enumerated in §9 item 6
+
+§9 item 6's list is explicitly a "CURRENT minimum filter set … always re-verify
+against §7.1" and is stale relative to the code. The following carry a real
+PAGE/WARN `severity` field in the coordinator but are absent from the item 6
+enumeration; they ARE included in this catalog (status `code`) so the operator
+provisions matchers for them:
+
+`payout_admin_invoked_while_halted` (WARN),
+`payout_chain_balance_rpc_disagreement` (PAGE),
+`payout_chain_balance_rpc_error` (WARN),
+`payout_daily_cap_tripped` (WARN),
+`payout_reorg_orphan_recorded` (PAGE),
+`payout_reorg_poll_rpc_error` (WARN),
+`payout_runner_halted` (PAGE),
+`payout_runner_halted_skipping_cycle` (PAGE),
+`payout_runtime_flag_sync_emit_failed` (PAGE).
+
+This is exactly the "later minor revisions silently missed events" failure mode
+§9 item 6 warns about; the completeness test now prevents it from recurring.
+
+> Note: `payout_stale_outbox_backlog` emits a **dynamic** severity — `WARN`
+> normally, escalating to `PAGE` when `scan_ceiling_hit=true`. It is catalogued
+> as WARN (its floor); its matcher must treat it as PAGE-capable.

--- a/dist/synthetic-alerts/catalog.tsv
+++ b/dist/synthetic-alerts/catalog.tsv
@@ -1,0 +1,88 @@
+# SPEC-016 payout PAGE/WARN synthetic-alert catalog
+#
+# Single source of truth shared by:
+#   - dist/synthetic-alerts/emit.sh            (the synthetic-alert emitter)
+#   - phase4-coordinator/internal/payout/synthetic_alerts_catalog_test.go
+#     (the completeness test that keeps this file in lock-step with the code)
+#
+# This catalog exists to satisfy SPEC-016 §9 cutover prerequisite item 6:
+# before flipping `payout.enabled: true`, the operator MUST verify with ONE
+# synthetic alert per ENUMERATED PAGE/WARN event NAME (NOT one per severity
+# tier) that each event fires its BetterStack matcher. Per-event verification
+# catches typos and missing matchers a per-tier check would silently miss
+# (e.g. `payout_runner_lease_lost` typo'd as `payout_runner_lease_lst`).
+#
+# BetterStack matchers MUST key on the `event` field + the `severity` field,
+# NOT the zerolog `level`: some real events emit a PAGE `severity` at a non-error
+# level (e.g. payout_reorg_orphan_recorded logs at warn level with severity=PAGE).
+#
+# Columns (TAB-separated):
+#   1. event_name    - the structured-log `event` field value the coordinator emits
+#   2. severity      - PAGE | WARN | INFO. For a page_capable event this is the
+#                      FLOOR severity (the value the event emits by default).
+#   3. status        - provenance / reconciliation state (see below)
+#   4. page_capable  - "page_capable" if the event emits a DYNAMIC severity that
+#                      can escalate to PAGE at runtime (e.g. WARN -> PAGE); "-"
+#                      otherwise. emit.sh emits BOTH a WARN and a PAGE synthetic
+#                      line for these so the operator verifies both matchers.
+#
+# status values:
+#   code                   Emitted by the coordinator with an explicit
+#                          `severity` field (PAGE or WARN). Operator MUST have a
+#                          BetterStack matcher and MUST verify it with a
+#                          synthetic alert. This is the normal case. The harness
+#                          ENFORCES that every emission site carries a matching
+#                          severity field (there is deliberately no "untagged"
+#                          status that could exempt an emitted PAGE/WARN alert).
+#   info                   Emitted by the coordinator at INFO. §9 item 6 lists it
+#                          as OPTIONAL for the alert filter. Not emitted as a
+#                          synthetic alert by default (see emit.sh --include-info).
+#   spec-only-not-emitted  Enumerated by SPEC-016 §9 item 6 as PAGE/WARN but NOT
+#                          emitted anywhere in the coordinator source.
+#                          DISCREPANCY: either the spec over-enumerates or the
+#                          emission is missing. Carried so the operator still
+#                          provisions the matcher; the completeness test asserts
+#                          the name stays ABSENT from code until reconciled.
+#
+# See README.md for the operator procedure and the full discrepancy write-up.
+#
+# event_name	severity	status	page_capable
+payout_admin_invoked_while_halted	WARN	code	-
+payout_attempt_abandoned	PAGE	code	-
+payout_cancel_self_transfer_reconfirm_stale	PAGE	code	-
+payout_chain_balance_drift_negative	PAGE	code	-
+payout_chain_balance_drift_positive	WARN	code	-
+payout_chain_balance_rpc_disagreement	PAGE	code	-
+payout_chain_balance_rpc_error	WARN	code	-
+payout_chain_value_mismatch	PAGE	code	-
+payout_config_reload_rejected	PAGE	code	-
+payout_config_reloaded	PAGE	code	-
+payout_daily_cap_tripped	WARN	code	-
+payout_flag_audit_reaped	WARN	code	-
+payout_insufficient_funds	PAGE	code	-
+payout_invariant_violation	PAGE	code	-
+payout_low_balance	WARN	code	-
+payout_low_native_balance	WARN	code	-
+payout_registration_paused	PAGE	code	-
+payout_registration_resumed	PAGE	code	-
+payout_reorg_orphan_recorded	PAGE	code	-
+payout_reorg_poll_rpc_error	WARN	code	-
+payout_reorg_revert	PAGE	code	-
+payout_rpc_chronic_outage	PAGE	code	-
+payout_rpc_disagreement	PAGE	code	-
+payout_runner_halted	PAGE	code	-
+payout_runner_halted_skipping_cycle	PAGE	code	-
+payout_runner_lease_lost	PAGE	code	-
+payout_runner_lease_taken_over	PAGE	code	-
+payout_runtime_flag_sync_emit_failed	PAGE	code	-
+payout_spki_drain_skipped_unsupported_client	WARN	code	-
+payout_stale_outbox_backlog	WARN	code	page_capable
+payout_stale_outbox_reaped	WARN	code	-
+payout_failed	PAGE	code	-
+payout_signer_unavailable	PAGE	code	-
+provider_payout_address_change_rejected	WARN	code	-
+provider_payout_address_rejected_unknown_provider	WARN	code	-
+payout_capped	INFO	info	-
+payout_cancel_self_transfer_confirmed	INFO	info	-
+payout_nonce_gap	WARN	spec-only-not-emitted	-
+payout_runner_lease_conflict	PAGE	spec-only-not-emitted	-

--- a/dist/synthetic-alerts/emit.sh
+++ b/dist/synthetic-alerts/emit.sh
@@ -1,0 +1,163 @@
+#!/bin/sh
+# SPEC-016 §9 item 6 synthetic-alert emitter.
+#
+# Emits ONE synthetic structured-log line per enumerated payout PAGE/WARN event
+# name, in the SAME zerolog-JSON shape the coordinator emits real events, so the
+# operator can confirm in BetterStack that EACH event name fires its matcher
+# BEFORE flipping `payout.enabled: true`.
+#
+# BetterStack matchers MUST key on the `event` field + the `severity` field, NOT
+# the zerolog `level`. Some real events emit a PAGE severity at a non-error level
+# (e.g. payout_reorg_orphan_recorded logs at warn level with severity=PAGE), so
+# the `severity` field printed here is authoritative and always matches the
+# catalog; the `level` field is cosmetic (derived from severity for realism).
+#
+# For a page_capable event (dynamic severity, e.g. payout_stale_outbox_backlog
+# escalating WARN->PAGE), BOTH a WARN and a PAGE synthetic line are emitted so
+# the operator verifies BOTH matchers.
+#
+# The DEFAULT set is the events the coordinator ACTUALLY emits — the true
+# pre-enablement verification list. `spec-only-not-emitted` events (enumerated by
+# the spec but never emitted by the code) are EXCLUDED from the default: emitting
+# a synthetic line for them would let an operator "verify" a matcher for an event
+# that can never fire (false readiness). They are available only via --reserved,
+# marked `"reserved":true,"not_yet_emitted":true`, and are an implementation gap
+# to close (wire the emission) before they count toward enablement.
+#
+# Every emitted line carries `"synthetic":true` and a `"note"` so these can
+# NEVER be mistaken for a real incident. Source of truth is catalog.tsv (shared
+# with the coordinator completeness test); this script hard-codes NO event list.
+#
+# Usage:
+#   ./emit.sh                 Emit one synthetic line per EMITTED PAGE/WARN event (default)
+#   ./emit.sh --include-info  Also emit the INFO-class events (§9 item 6 optional)
+#   ./emit.sh --reserved      Emit ONLY the spec-only-not-emitted events (marked reserved)
+#   ./emit.sh --event NAME    Emit just the one event NAME
+#   ./emit.sh --list          Print the catalog (name severity status page_capable)
+#   ./emit.sh --help          Show this help
+#
+# Output goes to stdout. On the coordinator host, pipe into the same journald
+# stream the coordinator uses, e.g.:  ./emit.sh | systemd-cat -t macprovider-coordinator
+set -eu
+
+SCRIPT_DIR=$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)
+CATALOG="$SCRIPT_DIR/catalog.tsv"
+SPEC_REF="SPEC-016 §9 item 6 synthetic-alert verification"
+NOTE="SYNTHETIC verification emission - NOT a real incident - see dist/synthetic-alerts/README.md"
+RESERVED_NOTE="RESERVED event - the coordinator does NOT emit this yet - NOT part of pre-enablement verification; wire the emission before relying on its matcher. SYNTHETIC."
+
+if [ ! -f "$CATALOG" ]; then
+	echo "emit.sh: catalog not found: $CATALOG" >&2
+	exit 1
+fi
+
+usage() { sed -n '2,40p' "$0" | sed 's/^# \{0,1\}//'; }
+
+INCLUDE_INFO=0
+ONE_EVENT=""
+MODE=emit
+
+while [ $# -gt 0 ]; do
+	case "$1" in
+		--list) MODE=list ;;
+		--reserved) MODE=reserved ;;
+		--include-info) INCLUDE_INFO=1 ;;
+		--event) shift; [ $# -gt 0 ] || { echo "emit.sh: --event needs a NAME" >&2; exit 2; }; ONE_EVENT="$1" ;;
+		--help|-h) usage; exit 0 ;;
+		*) echo "emit.sh: unknown argument: $1" >&2; usage >&2; exit 2 ;;
+	esac
+	shift
+done
+
+# level_for SEVERITY -> zerolog level string. Cosmetic only; matchers key on the
+# `severity` field, not `level`.
+level_for() {
+	case "$1" in
+		PAGE) echo error ;;
+		WARN) echo warn ;;
+		*)    echo info ;;
+	esac
+}
+
+# Stream the catalog data rows (comments/blank lines dropped).
+rows() {
+	grep -v '^[[:space:]]*#' "$CATALOG" | grep -v '^[[:space:]]*$'
+}
+
+now_utc() {
+	# RFC3339 with nanoseconds where the platform supports it; falls back cleanly.
+	date -u +%Y-%m-%dT%H:%M:%S.%N%z 2>/dev/null | sed 's/\([0-9][0-9]\)$/:\1/' \
+		|| date -u +%Y-%m-%dT%H:%M:%SZ
+}
+
+# emit_one NAME SEVERITY STATUS -> one JSON line with an authoritative severity.
+# A `spec-only-not-emitted` event is marked reserved/not_yet_emitted so an
+# operator can never mistake it for a real, verifiable pre-enablement alert.
+emit_one() {
+	_name=$1; _severity=$2; _status=$3
+	_level=$(level_for "$_severity")
+	_ts=$(now_utc)
+	if [ "$_status" = "spec-only-not-emitted" ]; then
+		printf '{"level":"%s","event":"%s","severity":"%s","synthetic":true,"reserved":true,"not_yet_emitted":true,"catalog_status":"%s","spec_ref":"%s","note":"%s","ts_utc":"%s","time":"%s"}\n' \
+			"$_level" "$_name" "$_severity" "$_status" "$SPEC_REF" "$RESERVED_NOTE" "$_ts" "$_ts"
+	else
+		printf '{"level":"%s","event":"%s","severity":"%s","synthetic":true,"catalog_status":"%s","spec_ref":"%s","note":"%s","ts_utc":"%s","time":"%s"}\n' \
+			"$_level" "$_name" "$_severity" "$_status" "$SPEC_REF" "$NOTE" "$_ts" "$_ts"
+	fi
+}
+
+# emit_row NAME SEVERITY STATUS PAGE_CAPABLE -> emit the floor line, plus a PAGE
+# escalation line when the event is page_capable (and the floor is not PAGE).
+emit_row() {
+	_n=$1; _s=$2; _st=$3; _pc=$4
+	emit_one "$_n" "$_s" "$_st"
+	if [ "$_pc" = "page_capable" ] && [ "$_s" != "PAGE" ]; then
+		emit_one "$_n" "PAGE" "$_st"
+	fi
+}
+
+if [ "$MODE" = list ]; then
+	printf '%-52s %-8s %-22s %s\n' "EVENT" "SEVERITY" "STATUS" "PAGE_CAPABLE"
+	rows | while IFS='	' read -r name severity status page; do
+		printf '%-52s %-8s %-22s %s\n' "$name" "$severity" "$status" "$page"
+	done
+	exit 0
+fi
+
+if [ "$MODE" = reserved ]; then
+	# ONLY the spec-only-not-emitted events, clearly marked reserved. These are
+	# an IMPLEMENTATION gap: the code never emits them, so they are NOT part of
+	# the pre-enablement per-event verification set.
+	rows | while IFS='	' read -r name severity status page; do
+		[ "$status" = "spec-only-not-emitted" ] && emit_row "$name" "$severity" "$status" "$page" || :
+	done
+	exit 0
+fi
+
+if [ -n "$ONE_EVENT" ]; then
+	found=0
+	while IFS='	' read -r name severity status page; do
+		[ "$name" = "$ONE_EVENT" ] || continue
+		emit_row "$name" "$severity" "$status" "$page"
+		found=1
+		break
+	done <<EOF
+$(rows)
+EOF
+	if [ "$found" -eq 0 ]; then
+		echo "emit.sh: no such event in catalog: $ONE_EVENT" >&2
+		exit 3
+	fi
+	exit 0
+fi
+
+# Default: synthetic line(s) per PAGE/WARN event that the code actually emits.
+# spec-only-not-emitted events are EXCLUDED (they can never fire — see --reserved);
+# INFO events only with --include-info.
+rows | while IFS='	' read -r name severity status page; do
+	[ "$status" = "spec-only-not-emitted" ] && continue
+	case "$severity" in
+		PAGE|WARN) emit_row "$name" "$severity" "$status" "$page" ;;
+		INFO) [ "$INCLUDE_INFO" -eq 1 ] && emit_row "$name" "$severity" "$status" "$page" || : ;;
+	esac
+done

--- a/dist/synthetic-alerts/non-alert-allowlist.txt
+++ b/dist/synthetic-alerts/non-alert-allowlist.txt
@@ -1,0 +1,60 @@
+# Non-alert payout_/provider_payout_ string literals.
+#
+# The synthetic-alerts completeness test (synthetic_alerts_catalog_test.go)
+# scans every non-test .go file under phase4-coordinator/internal/payout/ and
+# phase4-coordinator/cmd/coordinator/ for identifier-shaped string literals
+# matching ^(payout_|provider_payout_)[a-z0-9_]+$. EVERY such literal must be
+# classified as exactly one of:
+#   (a) a catalogued ALERT event  -> dist/synthetic-alerts/catalog.tsv, or
+#   (b) a reviewed NON-ALERT string -> this file.
+# Any literal that is neither FAILS the test (fail-closed): a new alert event
+# cannot ship without a catalog entry (and thus a BetterStack matcher + a
+# synthetic-alert verification), and a new non-alert string must be reviewed
+# and listed here.
+#
+# Format: <literal><TAB><one-word reason>. Reasons:
+#   db-table     - SQLite table name
+#   db-column    - SQLite column name
+#   reason-value - a `reason`/error-class/HTTP body string, not an event name
+#   info-event   - a structured-log event emitted WITHOUT a PAGE/WARN severity
+#                  field (INFO/debug/operational); not part of the §9 item 6
+#                  alert filter. If one of these is ever promoted to a PAGE/WARN
+#                  alert (a `severity` field added), MOVE it to catalog.tsv.
+#
+# literal	reason
+payout_attempts	db-table
+payout_balance_probe_rpc_error	info-event
+payout_chain_balance_db_error	info-event
+payout_chain_balance_decode_error	info-event
+payout_chain_balance_ok	info-event
+payout_flag_audit_reaper_claim_failed	info-event
+payout_flag_audit_reaper_failed	info-event
+payout_flag_audit_reaper_pass	info-event
+payout_funding_receipt_mismatch	info-event
+payout_funding_recorded	info-event
+payout_funding_rpc_error	info-event
+payout_funding_rpc_unavailable	info-event
+payout_hot_wallet_funding	db-table
+payout_id	db-column
+payout_nonce_cold_start_within_tolerance	info-event
+payout_not_allowed	reason-value
+payout_paid	info-event
+payout_reorg_orphan_resolved	info-event
+payout_reorg_orphans	db-table
+payout_run_finished	info-event
+payout_run_now_invoked	info-event
+payout_run_started	info-event
+payout_runner_halted_skipping_rows	info-event
+payout_runner_lease	db-table
+payout_runner_lease_left_to_stale_out	info-event
+payout_runner_state	db-table
+payout_runtime_flag_write_failed	info-event
+payout_stale_outbox_claim_failed	info-event
+payout_stale_outbox_produced	info-event
+payout_stale_outbox_producer_conn_failed	info-event
+payout_stale_outbox_producer_failed	info-event
+payout_stale_outbox_reaper_failed	info-event
+payout_tuning_sighup_received	info-event
+provider_payout_address_changed	info-event
+provider_payout_address_nonces	db-table
+provider_payout_addresses	db-table

--- a/phase4-coordinator/internal/payout/addresses.go
+++ b/phase4-coordinator/internal/payout/addresses.go
@@ -531,6 +531,7 @@ func (s *AddressesService) pausedConn(ctx context.Context, conn *sql.Conn) (bool
 			// sentinel-asymmetry detector (bootstrap.go)
 			// HALT the process at next boot.
 			s.Log.Error().Str("event", "payout_invariant_violation").
+				Str("severity", "PAGE").
 				Str("where", "runtime_flag missing").
 				Str("name", "registration_paused").Send()
 			return false, fmt.Errorf("runtime flag missing")
@@ -574,6 +575,7 @@ func (s *AddressesService) emitFailure(r *http.Request, providerID, reason, subm
 	}
 	s.Log.Info().
 		Str("event", ev.Event).
+		Str("severity", "WARN").
 		Str("provider_id", ev.ProviderID).
 		Str("reason", ev.Reason).
 		Str("src_ip", ev.SrcIP).
@@ -585,6 +587,7 @@ func (s *AddressesService) emitFailure(r *http.Request, providerID, reason, subm
 func (s *AddressesService) emitReject(r *http.Request, providerID, eventName, submittedAddress string) {
 	s.Log.Info().
 		Str("event", eventName).
+		Str("severity", "WARN").
 		Str("provider_id", providerID).
 		Str("src_ip", clientIP(r)).
 		Str("submitted_fingerprint", addressFingerprint(submittedAddress)).

--- a/phase4-coordinator/internal/payout/pauseresume.go
+++ b/phase4-coordinator/internal/payout/pauseresume.go
@@ -155,6 +155,7 @@ func (s *PauseResumeService) serveFlip(
 		s.log.Warn().Err(err).
 			Int64("audit_id", result.AuditID).
 			Str("event", "payout_runtime_flag_sync_emit_failed").
+			Str("severity", "PAGE").
 			Send()
 	}
 

--- a/phase4-coordinator/internal/payout/runner.go
+++ b/phase4-coordinator/internal/payout/runner.go
@@ -1111,6 +1111,7 @@ func (r *Runner) allocateBuildSignBroadcast(ctx context.Context, runID string, r
 			// error_class, ts_utc.
 			r.opts.Logger.Error().
 				Str("event", "payout_signer_unavailable").
+				Str("severity", "PAGE").
 				Str("from_address", r.opts.Security.HotWalletAddress).
 				Str("error_class", err.Error()).
 				Str("ts_utc", r.opts.NowFn().UTC().Format(time.RFC3339Nano)).
@@ -1345,6 +1346,7 @@ func (r *Runner) claimAndLog(ctx context.Context, runID string, row ReadyRow, at
 		// provider_id, stage, error_class, error_text, ts_utc.
 		r.opts.Logger.Error().
 			Str("event", "payout_failed").
+			Str("severity", "PAGE").
 			Str("run_id", runID).
 			Int64("payout_id", row.PayoutID).
 			Int("attempt_seq", attempt.AttemptSeq).
@@ -1359,6 +1361,7 @@ func (r *Runner) claimAndLog(ctx context.Context, runID string, row ReadyRow, at
 	if !claimed {
 		r.opts.Logger.Warn().
 			Str("event", "payout_failed").
+			Str("severity", "PAGE").
 			Str("run_id", runID).
 			Int64("payout_id", row.PayoutID).
 			Int("attempt_seq", attempt.AttemptSeq).

--- a/phase4-coordinator/internal/payout/synthetic_alerts_catalog_test.go
+++ b/phase4-coordinator/internal/payout/synthetic_alerts_catalog_test.go
@@ -1,0 +1,1150 @@
+package payout_test
+
+// TestSyntheticAlertsCatalog is the load-bearing guard for SPEC-016 §9 cutover
+// prerequisite item 6: before `payout.enabled: true`, the operator must verify
+// ONE synthetic alert per ENUMERATED PAGE/WARN event name. The enumeration
+// lives in dist/synthetic-alerts/catalog.tsv, the single source of truth shared
+// with dist/synthetic-alerts/emit.sh.
+//
+// DESIGN: sound static enumeration of "which zerolog emissions are PAGE/WARN
+// alerts" from arbitrary Go is undecidable — an AST scanner can always be fooled
+// by another way of routing the event name or severity. So this test does NOT
+// try to understand emission. It is a STYLE-AGNOSTIC literal-presence check:
+//
+//   Every identifier-shaped string literal matching ^(payout_|provider_payout_)
+//   [a-z0-9_]+$ in the scanned source MUST be classified as exactly one of:
+//     (a) a catalogued alert event      -> dist/synthetic-alerts/catalog.tsv, or
+//     (b) a reviewed non-alert string   -> dist/synthetic-alerts/non-alert-allowlist.txt
+//
+// It does not matter HOW an event is emitted; a new alert event necessarily
+// introduces a new event-name literal (or const literal) somewhere, and this
+// test fails closed on any unclassified one. Alert event names must be literals
+// or consts — dynamically constructed alert names (fmt.Sprintf("payout_%s"),
+// "payout_" + x) are forbidden and also fail, keeping the check sound.
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+// ---------------------------------------------------------------------------
+// Catalog + allowlist
+// ---------------------------------------------------------------------------
+
+type catalogEntry struct {
+	severity    string // PAGE | WARN | INFO (floor severity for page_capable)
+	status      string // code | info | spec-only-not-emitted
+	pageCapable bool
+}
+
+func findRepoRoot(t *testing.T) string {
+	t.Helper()
+	dir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("Getwd: %v", err)
+	}
+	for {
+		if _, err := os.Stat(filepath.Join(dir, "dist", "synthetic-alerts", "catalog.tsv")); err == nil {
+			return dir
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			t.Fatalf("could not locate dist/synthetic-alerts/catalog.tsv walking up from working dir")
+		}
+		dir = parent
+	}
+}
+
+func loadCatalog(t *testing.T, root string) map[string]catalogEntry {
+	t.Helper()
+	path := filepath.Join(root, "dist", "synthetic-alerts", "catalog.tsv")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("open catalog: %v", err)
+	}
+	out := make(map[string]catalogEntry)
+	for i, line := range strings.Split(string(data), "\n") {
+		ln := i + 1
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" || strings.HasPrefix(trimmed, "#") {
+			continue
+		}
+		parts := strings.Split(line, "\t")
+		if len(parts) != 4 {
+			t.Fatalf("catalog.tsv:%d: expected 4 TAB-separated fields, got %d: %q", ln, len(parts), line)
+		}
+		name, sev, status, page := parts[0], parts[1], parts[2], parts[3]
+		switch sev {
+		case "PAGE", "WARN", "INFO":
+		default:
+			t.Fatalf("catalog.tsv:%d: bad severity %q", ln, sev)
+		}
+		switch status {
+		case "code", "info", "spec-only-not-emitted":
+		default:
+			// `code-untagged` is intentionally NOT accepted: it was a latent
+			// bypass of the severity-presence check. An emitted PAGE/WARN alert
+			// must carry a severity field regardless of status.
+			t.Fatalf("catalog.tsv:%d: bad status %q", ln, status)
+		}
+		var pageCapable bool
+		switch page {
+		case "-":
+		case "page_capable":
+			pageCapable = true
+		default:
+			t.Fatalf("catalog.tsv:%d: bad page_capable %q", ln, page)
+		}
+		if _, dup := out[name]; dup {
+			t.Fatalf("catalog.tsv:%d: duplicate event %q", ln, name)
+		}
+		out[name] = catalogEntry{severity: sev, status: status, pageCapable: pageCapable}
+	}
+	return out
+}
+
+func loadAllowlist(t *testing.T, root string) map[string]string {
+	t.Helper()
+	path := filepath.Join(root, "dist", "synthetic-alerts", "non-alert-allowlist.txt")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("open allowlist: %v", err)
+	}
+	out := make(map[string]string)
+	for i, line := range strings.Split(string(data), "\n") {
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" || strings.HasPrefix(trimmed, "#") {
+			continue
+		}
+		fields := strings.Fields(trimmed)
+		if len(fields) != 2 {
+			t.Fatalf("non-alert-allowlist.txt:%d: expected `<literal> <reason>`, got %q", i+1, line)
+		}
+		out[fields[0]] = fields[1]
+	}
+	return out
+}
+
+// ---------------------------------------------------------------------------
+// Scanner: collect payout_/provider_payout_ string literals + dynamic-name uses
+// ---------------------------------------------------------------------------
+
+type scanResult struct {
+	literals map[string]string // identifier literal -> "file:line" of first sighting
+	dynamic  []string          // dynamic alert-name constructions (fail-closed)
+}
+
+const (
+	prefixA = "payout_"
+	prefixB = "provider_payout_"
+)
+
+func hasPayoutPrefix(v string) bool {
+	return strings.HasPrefix(v, prefixA) || strings.HasPrefix(v, prefixB)
+}
+
+func isIdentChars(v string) bool {
+	for _, r := range v {
+		if !(r >= 'a' && r <= 'z' || r >= '0' && r <= '9' || r == '_') {
+			return false
+		}
+	}
+	return true
+}
+
+// isEventIdentifier reports whether v is shaped exactly like a COMPLETE event
+// name: a payout_/provider_payout_ prefix followed only by [a-z0-9_] and NOT
+// ending in '_'. A real event name never ends in '_'; a trailing underscore is
+// the tell-tale of a concatenation prefix fragment (see isNameFragment).
+func isEventIdentifier(v string) bool {
+	return hasPayoutPrefix(v) && isIdentChars(v) && !strings.HasSuffix(v, "_")
+}
+
+// isNameFragment reports whether v is a payout_-prefixed identifier fragment
+// ending in '_' (e.g. "payout_", "payout_flag_") — the shape used to build an
+// event name by concatenation across statements/variables (indirect dynamic
+// construction). Alert names must be whole literals, so these fail.
+func isNameFragment(v string) bool {
+	return hasPayoutPrefix(v) && isIdentChars(v) && strings.HasSuffix(v, "_")
+}
+
+// isDynamicNameTemplate reports whether v looks like a format template that
+// builds a payout_-prefixed event name (e.g. "payout_%s") — a payout_ prefix
+// followed only by [a-z0-9_%] and containing at least one '%'. Prose messages
+// that merely start with an event name (they contain spaces/`=`/`:`) are NOT
+// templates and are ignored.
+func isDynamicNameTemplate(v string) bool {
+	if !hasPayoutPrefix(v) || !strings.Contains(v, "%") {
+		return false
+	}
+	for _, r := range v {
+		if !(r >= 'a' && r <= 'z' || r >= '0' && r <= '9' || r == '_' || r == '%') {
+			return false
+		}
+	}
+	return true
+}
+
+func scanFiles(fset *token.FileSet, files []*ast.File) scanResult {
+	res := scanResult{literals: map[string]string{}}
+	for _, f := range files {
+		ast.Inspect(f, func(n ast.Node) bool {
+			switch x := n.(type) {
+			case *ast.BasicLit:
+				if x.Kind != token.STRING {
+					return true
+				}
+				v, err := strconv.Unquote(x.Value)
+				if err != nil {
+					return true
+				}
+				switch {
+				case isEventIdentifier(v):
+					if _, seen := res.literals[v]; !seen {
+						res.literals[v] = fset.Position(x.Pos()).String()
+					}
+				case isNameFragment(v):
+					res.dynamic = append(res.dynamic,
+						fset.Position(x.Pos()).String()+": payout_-prefixed name fragment "+strconv.Quote(v)+
+							" — looks like it builds an alert name by concatenation; alert event names MUST be whole string literals/consts")
+				case isDynamicNameTemplate(v):
+					res.dynamic = append(res.dynamic,
+						fset.Position(x.Pos()).String()+": dynamic alert-name template "+strconv.Quote(v)+
+							" — alert event names MUST be plain string literals/consts, not fmt-constructed")
+				}
+			case *ast.BinaryExpr:
+				if x.Op != token.ADD {
+					return true
+				}
+				// Flag `"payout_..." + <non-literal>` (dynamic concat of an
+				// event name). Constant "a"+"b" concatenation is fine.
+				for _, pair := range [][2]ast.Expr{{x.X, x.Y}, {x.Y, x.X}} {
+					lit, ok := stringLitValue(pair[0])
+					if !ok || !isEventIdentifier(lit) {
+						continue
+					}
+					if _, otherIsLit := stringLitValue(pair[1]); otherIsLit {
+						continue // constant concatenation
+					}
+					res.dynamic = append(res.dynamic,
+						fset.Position(x.Pos()).String()+": dynamic alert-name concatenation of "+strconv.Quote(lit)+
+							" — alert event names MUST be plain string literals/consts")
+				}
+			}
+			return true
+		})
+	}
+	return res
+}
+
+func stringLitValue(e ast.Expr) (string, bool) {
+	bl, ok := e.(*ast.BasicLit)
+	if !ok || bl.Kind != token.STRING {
+		return "", false
+	}
+	v, err := strconv.Unquote(bl.Value)
+	if err != nil {
+		return "", false
+	}
+	return v, true
+}
+
+// ---------------------------------------------------------------------------
+// Sound severity-PRESENCE audit over the FINITE set of catalogued alert events
+// ---------------------------------------------------------------------------
+//
+// For every catalogued `code` alert event, this asserts that EACH production
+// emission carries a `severity` field matching the catalog. Enumerating "which
+// arbitrary emission is an alert" is undecidable, but the catalogued names are a
+// finite list, so we resolve, for each emitting zerolog chain, the concrete
+// event name(s) it produces — via string literals, consts, struct-field
+// literals, string-returning helpers, and arguments threaded through emit-helper
+// parameters (e.g. serveFlip -> emitFlipEvent) — and pair each with that chain's
+// severity. Then, per catalogued event:
+//   - if NO emitter is found -> FAIL closed (can't confirm severity), and
+//   - if ANY emitting chain lacks/ mismatches the severity -> FAIL with file:line.
+// This is fail-closed: an unresolved emission never silently passes a catalogued
+// event; it makes the event look un-emitted and fails.
+
+type chainSev struct {
+	present bool // a `severity` field is set in the chain
+	lits    map[string]bool
+	dynPage bool // severity is a runtime value that can be "PAGE"
+}
+
+type emitter struct {
+	sev chainSev
+	pos string
+}
+
+type sinkKey struct {
+	fn    *ast.FuncDecl
+	param string
+}
+
+// resolveEmitters returns, for every event name emitted anywhere in the scanned
+// source, the list of emitting chains (with each chain's severity + position).
+// It also returns "unresolved" findings: payout-package emission chains whose
+// event NAME cannot be reduced to concrete values AND which carry NO severity
+// field — a chain that could be an untagged alert the harness can't verify.
+// These fail the audit CLOSED (never silently skipped).
+func resolveEmitters(fset *token.FileSet, files []*ast.File) (map[string][]emitter, []string) {
+	funcByName := map[string][]*ast.FuncDecl{}
+	stringConsts := map[string]string{}
+	var calls []callRec
+	for _, f := range files {
+		for _, d := range f.Decls {
+			switch decl := d.(type) {
+			case *ast.FuncDecl:
+				funcByName[decl.Name.Name] = append(funcByName[decl.Name.Name], decl)
+			case *ast.GenDecl:
+				if decl.Tok == token.CONST {
+					for _, spec := range decl.Specs {
+						if vs, ok := spec.(*ast.ValueSpec); ok {
+							for i, nm := range vs.Names {
+								if i < len(vs.Values) {
+									if v, ok := stringLitValue(vs.Values[i]); ok {
+										stringConsts[nm.Name] = v
+									}
+								}
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+
+	// Collect every call site with its enclosing named func.
+	for _, f := range files {
+		for _, d := range f.Decls {
+			fd, ok := d.(*ast.FuncDecl)
+			if !ok || fd.Body == nil {
+				continue
+			}
+			ast.Inspect(fd.Body, func(n ast.Node) bool {
+				if ce, ok := n.(*ast.CallExpr); ok {
+					if name := calleeName(ce); name != "" {
+						calls = append(calls, callRec{name: name, args: ce.Args, enc: fd})
+					}
+				}
+				return true
+			})
+		}
+	}
+
+	funcReturnStrings := func(name string) (lits []string, allLiteral bool) {
+		recs := funcByName[name]
+		if len(recs) == 0 {
+			return nil, false
+		}
+		allLiteral, saw := true, false
+		for _, rec := range recs {
+			if rec.Body == nil {
+				continue
+			}
+			ast.Inspect(rec.Body, func(n ast.Node) bool {
+				if _, ok := n.(*ast.FuncLit); ok {
+					return false
+				}
+				if ret, ok := n.(*ast.ReturnStmt); ok {
+					for _, r := range ret.Results {
+						saw = true
+						if v, ok := stringLitValue(r); ok {
+							lits = append(lits, v)
+						} else {
+							allLiteral = false
+						}
+					}
+				}
+				return true
+			})
+		}
+		if !saw {
+			return nil, false
+		}
+		return lits, allLiteral
+	}
+
+	// resolveExpr reduces an event-name expression to concrete names, a sink to
+	// thread, or unresolved.
+	var resolveExpr func(e ast.Expr, enc *ast.FuncDecl) ([]string, *sinkKey, bool)
+	resolveExpr = func(e ast.Expr, enc *ast.FuncDecl) ([]string, *sinkKey, bool) {
+		switch x := e.(type) {
+		case *ast.BasicLit:
+			if v, ok := stringLitValue(x); ok {
+				return []string{v}, nil, true
+			}
+		case *ast.Ident:
+			if v, ok := stringConsts[x.Name]; ok {
+				return []string{v}, nil, true
+			}
+			if rhs := localVarRHS(enc, x.Name); len(rhs) > 0 {
+				var names []string
+				for _, r := range rhs {
+					if v, ok := stringLitValue(r); ok {
+						names = append(names, v)
+						continue
+					}
+					if ce, ok := r.(*ast.CallExpr); ok {
+						if lits, all := funcReturnStrings(calleeName(ce)); all && len(lits) > 0 {
+							names = append(names, lits...)
+							continue
+						}
+					}
+					return nil, nil, false
+				}
+				return names, nil, true
+			}
+			if enc != nil && paramIndex(enc, x.Name) >= 0 {
+				return nil, &sinkKey{fn: enc, param: x.Name}, true
+			}
+		case *ast.CallExpr:
+			if lits, all := funcReturnStrings(calleeName(x)); all && len(lits) > 0 {
+				return lits, nil, true
+			}
+		case *ast.SelectorExpr:
+			if base, ok := x.X.(*ast.Ident); ok {
+				if v, ok := compositeFieldLit(enc, base.Name, x.Sel.Name); ok {
+					return []string{v}, nil, true
+				}
+			}
+		}
+		return nil, nil, false
+	}
+
+	out := map[string][]emitter{}
+	var unresolved []string
+	add := func(name string, sev chainSev, pos string) {
+		out[name] = append(out[name], emitter{sev: sev, pos: pos})
+	}
+	// flagUnresolved records an inconclusive emission that lacks severity. Scoped
+	// to package "payout" (where every event is a payout alert-or-info) so it
+	// cannot false-fail on unrelated `package main` coordinator logging.
+	flagUnresolved := func(pkg string, sev chainSev, pos string) {
+		if pkg == "payout" && !sev.present {
+			unresolved = append(unresolved,
+				pos+": emission sets an `event` field whose name the harness cannot resolve, and the chain has NO severity — "+
+					"cannot verify it is not an untagged alert; use a literal/const event name, or add a literal Str(\"severity\",...) the check can see")
+		}
+	}
+
+	// Walk chains; resolve their event expr(s) and attach the chain's severity.
+	visitChains(files, func(pkg string, enc *ast.FuncDecl, eventExprs []ast.Expr, sev chainSev, pos string) {
+		for _, e := range eventExprs {
+			names, sink, ok := resolveExpr(e, enc)
+			if !ok {
+				flagUnresolved(pkg, sev, pos) // inconclusive + no severity => fail closed
+				continue
+			}
+			if sink == nil {
+				for _, n := range names {
+					add(n, sev, pos)
+				}
+				continue
+			}
+			// Thread the sink parameter to its call-site values (to a fixpoint),
+			// attaching THIS chain's severity to whatever names resolve.
+			visited := map[sinkKey]bool{}
+			queue := []sinkKey{*sink}
+			for len(queue) > 0 {
+				sk := queue[0]
+				queue = queue[1:]
+				if visited[sk] {
+					continue
+				}
+				visited[sk] = true
+				idx := paramIndex(sk.fn, sk.param)
+				arity := len(flatParams(sk.fn))
+				for _, c := range calls {
+					if c.name != sk.fn.Name.Name || len(c.args) != arity || idx < 0 || idx >= len(c.args) {
+						continue
+					}
+					n2, sink2, ok2 := resolveExpr(c.args[idx], c.enc)
+					if !ok2 {
+						// A call site feeds this emit-helper an event name the
+						// harness can't resolve. If the helper chain lacks
+						// severity, the emission could be an untagged alert.
+						flagUnresolved(pkg, sev, pos)
+						continue
+					}
+					if sink2 != nil {
+						queue = append(queue, *sink2)
+						continue
+					}
+					for _, n := range n2 {
+						add(n, sev, pos)
+					}
+				}
+			}
+		}
+	})
+	return out, unresolved
+}
+
+type callRec struct {
+	name string
+	args []ast.Expr
+	enc  *ast.FuncDecl
+}
+
+func calleeName(call *ast.CallExpr) string {
+	switch fn := call.Fun.(type) {
+	case *ast.Ident:
+		return fn.Name
+	case *ast.SelectorExpr:
+		return fn.Sel.Name
+	}
+	return ""
+}
+
+func flatParams(fd *ast.FuncDecl) []string {
+	var out []string
+	if fd == nil || fd.Type == nil || fd.Type.Params == nil {
+		return out
+	}
+	for _, field := range fd.Type.Params.List {
+		if len(field.Names) == 0 {
+			out = append(out, "")
+			continue
+		}
+		for _, nm := range field.Names {
+			out = append(out, nm.Name)
+		}
+	}
+	return out
+}
+
+func paramIndex(fd *ast.FuncDecl, name string) int {
+	for i, p := range flatParams(fd) {
+		if p == name {
+			return i
+		}
+	}
+	return -1
+}
+
+func localVarRHS(fd *ast.FuncDecl, name string) []ast.Expr {
+	var out []ast.Expr
+	if fd == nil || fd.Body == nil {
+		return out
+	}
+	ast.Inspect(fd.Body, func(n ast.Node) bool {
+		as, ok := n.(*ast.AssignStmt)
+		if !ok || len(as.Lhs) != len(as.Rhs) {
+			return true
+		}
+		for i, lhs := range as.Lhs {
+			if id, ok := lhs.(*ast.Ident); ok && id.Name == name {
+				out = append(out, as.Rhs[i])
+			}
+		}
+		return true
+	})
+	return out
+}
+
+func compositeFieldLit(fd *ast.FuncDecl, varName, fieldName string) (string, bool) {
+	if fd == nil || fd.Body == nil {
+		return "", false
+	}
+	var found string
+	var ok bool
+	ast.Inspect(fd.Body, func(n ast.Node) bool {
+		as, isAssign := n.(*ast.AssignStmt)
+		if !isAssign {
+			return true
+		}
+		for i, lhs := range as.Lhs {
+			id, isID := lhs.(*ast.Ident)
+			if !isID || id.Name != varName || i >= len(as.Rhs) {
+				continue
+			}
+			cl, isCL := as.Rhs[i].(*ast.CompositeLit)
+			if !isCL {
+				continue
+			}
+			for _, elt := range cl.Elts {
+				kv, isKV := elt.(*ast.KeyValueExpr)
+				if !isKV {
+					continue
+				}
+				if key, isKey := kv.Key.(*ast.Ident); isKey && key.Name == fieldName {
+					if v, isStr := stringLitValue(kv.Value); isStr {
+						found, ok = v, true
+					}
+				}
+			}
+		}
+		return true
+	})
+	return found, ok
+}
+
+// strFieldArg returns the value expression of a `.Str("<field>", X)` call.
+func strFieldArg(call *ast.CallExpr, field string) (ast.Expr, bool) {
+	sel, ok := call.Fun.(*ast.SelectorExpr)
+	if !ok || sel.Sel.Name != "Str" || len(call.Args) != 2 {
+		return nil, false
+	}
+	if key, ok := stringLitValue(call.Args[0]); !ok || key != field {
+		return nil, false
+	}
+	return call.Args[1], true
+}
+
+func localStringAssignments(fd *ast.FuncDecl, name string) []string {
+	var out []string
+	if fd == nil || fd.Body == nil {
+		return out
+	}
+	ast.Inspect(fd.Body, func(n ast.Node) bool {
+		as, ok := n.(*ast.AssignStmt)
+		if !ok {
+			return true
+		}
+		for i, lhs := range as.Lhs {
+			id, ok := lhs.(*ast.Ident)
+			if !ok || id.Name != name || i >= len(as.Rhs) {
+				continue
+			}
+			if v, ok := stringLitValue(as.Rhs[i]); ok {
+				out = append(out, v)
+			}
+		}
+		return true
+	})
+	return out
+}
+
+// visitChains calls fn once per zerolog chain (ExprStmt) that sets an `event`
+// field, passing the enclosing named func, the event value expression(s), the
+// chain's severity, and the source position of the first event field.
+func visitChains(files []*ast.File, fn func(pkg string, enc *ast.FuncDecl, eventExprs []ast.Expr, sev chainSev, pos string)) {
+	// position printing needs a FileSet; recover it from the file set the
+	// parser used by carrying positions through the shared set below.
+	for _, f := range files {
+		pkg := ""
+		if f.Name != nil {
+			pkg = f.Name.Name
+		}
+		for _, d := range f.Decls {
+			fd, ok := d.(*ast.FuncDecl)
+			if !ok || fd.Body == nil {
+				continue
+			}
+			ast.Inspect(fd.Body, func(n ast.Node) bool {
+				stmt, ok := n.(*ast.ExprStmt)
+				if !ok {
+					return true
+				}
+				var events []ast.Expr
+				var sevLits []string
+				var sevIdents []string
+				var firstEventPos token.Pos
+				ast.Inspect(stmt, func(m ast.Node) bool {
+					call, ok := m.(*ast.CallExpr)
+					if !ok {
+						return true
+					}
+					if e, ok := strFieldArg(call, "event"); ok {
+						if len(events) == 0 {
+							firstEventPos = e.Pos()
+						}
+						events = append(events, e)
+					}
+					if sv, ok := strFieldArg(call, "severity"); ok {
+						if v, ok := stringLitValue(sv); ok {
+							sevLits = append(sevLits, v)
+						} else if id, ok := sv.(*ast.Ident); ok {
+							sevIdents = append(sevIdents, id.Name)
+						} else {
+							sevIdents = append(sevIdents, "") // dynamic, non-ident
+						}
+					}
+					return true
+				})
+				if len(events) == 0 {
+					return true
+				}
+				sev := chainSev{lits: map[string]bool{}}
+				if len(sevLits) > 0 || len(sevIdents) > 0 {
+					sev.present = true
+				}
+				for _, s := range sevLits {
+					sev.lits[s] = true
+				}
+				for _, id := range sevIdents {
+					if id == "" {
+						sev.dynPage = true
+						continue
+					}
+					for _, v := range localStringAssignments(fd, id) {
+						sev.lits[v] = true
+						if v == "PAGE" {
+							sev.dynPage = true
+						}
+					}
+				}
+				fn(pkg, fd, events, sev, chainPos(firstEventPos))
+				return true
+			})
+		}
+	}
+}
+
+// chainPos is set by auditCatalogSeverity via a package-level FileSet pointer so
+// visitChains can print positions without threading the set everywhere.
+var curFset *token.FileSet
+
+func chainPos(p token.Pos) string {
+	if curFset == nil || p == token.NoPos {
+		return "<pos?>"
+	}
+	return curFset.Position(p).String()
+}
+
+// auditCatalogSeverity is the sound per-site check: every catalogued `code`
+// event must be emitted, and every one of its emitting chains must carry a
+// matching severity field.
+func auditCatalogSeverity(fset *token.FileSet, files []*ast.File, catalog map[string]catalogEntry) []string {
+	curFset = fset
+	defer func() { curFset = nil }()
+	emitters, unresolved := resolveEmitters(fset, files)
+
+	// Fail closed on any payout emission the harness could not analyze.
+	var errs []string
+	errs = append(errs, unresolved...)
+	for name, entry := range catalog {
+		// The severity requirement is gated on the CATALOG SEVERITY, not the
+		// status, so no status value (e.g. a resurrected `code-untagged`) can
+		// exempt an emitted PAGE/WARN alert. INFO events are not alerts;
+		// spec-only-not-emitted events are intentionally not emitted (the
+		// literal-presence reverse guard asserts their absence).
+		if entry.severity == "INFO" || entry.status == "spec-only-not-emitted" {
+			continue
+		}
+		ems := emitters[name]
+		if len(ems) == 0 {
+			errs = append(errs, "catalogued alert "+name+" ("+entry.severity+") has no resolvable production emission — "+
+				"the harness cannot confirm its severity; emit it via a literal/const/known helper carrying Str(\"severity\",...)")
+			continue
+		}
+		for _, em := range ems {
+			if !em.sev.present {
+				errs = append(errs, em.pos+": catalogued alert "+name+" is emitted WITHOUT a severity field — "+
+					"add Str(\"severity\",\""+entry.severity+"\") to this zerolog chain")
+				continue
+			}
+			if entry.pageCapable {
+				for s := range em.sev.lits {
+					if s != "WARN" && s != "PAGE" {
+						errs = append(errs, em.pos+": page_capable event "+name+" emits unexpected severity "+s)
+					}
+				}
+				continue
+			}
+			if em.sev.dynPage && entry.severity != "PAGE" {
+				errs = append(errs, em.pos+": event "+name+" can emit severity=PAGE dynamically but catalog says "+
+					entry.severity+" without page_capable")
+			}
+			for s := range em.sev.lits {
+				if s != entry.severity {
+					errs = append(errs, em.pos+": severity mismatch for "+name+": code emits "+s+", catalog says "+entry.severity)
+				}
+			}
+		}
+	}
+	sort.Strings(errs)
+	return errs
+}
+
+// ---------------------------------------------------------------------------
+// Loading the scanned sources
+// ---------------------------------------------------------------------------
+
+func scannedGoFiles(t *testing.T, root string) []string {
+	t.Helper()
+	var out []string
+	payoutRoot := filepath.Join(root, "phase4-coordinator", "internal", "payout")
+	if err := filepath.WalkDir(payoutRoot, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() || !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
+			return nil
+		}
+		out = append(out, path)
+		return nil
+	}); err != nil {
+		t.Fatalf("walk payout: %v", err)
+	}
+	cmdGlob := filepath.Join(root, "phase4-coordinator", "cmd", "coordinator", "*.go")
+	matches, err := filepath.Glob(cmdGlob)
+	if err != nil {
+		t.Fatalf("glob coordinator: %v", err)
+	}
+	for _, m := range matches {
+		if !strings.HasSuffix(m, "_test.go") {
+			out = append(out, m)
+		}
+	}
+	if len(out) < 10 {
+		t.Fatalf("scannedGoFiles found too few files (%d) — layout changed?", len(out))
+	}
+	sort.Strings(out)
+	return out
+}
+
+func parseFiles(t *testing.T, paths []string) (*token.FileSet, []*ast.File) {
+	t.Helper()
+	fset := token.NewFileSet()
+	var files []*ast.File
+	for _, p := range paths {
+		f, err := parser.ParseFile(fset, p, nil, 0)
+		if err != nil {
+			t.Fatalf("parse %s: %v", p, err)
+		}
+		files = append(files, f)
+	}
+	return fset, files
+}
+
+// ---------------------------------------------------------------------------
+// Validation (shared by the real test and the fixtures)
+// ---------------------------------------------------------------------------
+
+func validate(res scanResult, catalog map[string]catalogEntry, allowlist map[string]string) []string {
+	var errs []string
+
+	// Fail closed on any dynamically constructed alert name.
+	errs = append(errs, res.dynamic...)
+
+	// FORWARD (completeness): every payout_ identifier literal must be either a
+	// catalogued alert OR an allowlisted non-alert string.
+	for lit, pos := range res.literals {
+		_, inCatalog := catalog[lit]
+		_, inAllow := allowlist[lit]
+		switch {
+		case inCatalog && inAllow:
+			errs = append(errs, lit+" is in BOTH catalog.tsv and the non-alert allowlist — pick one")
+		case !inCatalog && !inAllow:
+			errs = append(errs, pos+": unclassified payout literal "+strconv.Quote(lit)+
+				" — classify it as an ALERT event in dist/synthetic-alerts/catalog.tsv, "+
+				"or as a NON-ALERT string in dist/synthetic-alerts/non-alert-allowlist.txt")
+		}
+	}
+
+	// REVERSE (typo / rot guard): every catalog alert name must appear as a
+	// literal in the scanned source, EXCEPT spec-only-not-emitted rows (which
+	// must stay absent until the emission is wired).
+	for name, entry := range catalog {
+		_, present := res.literals[name]
+		if entry.status == "spec-only-not-emitted" {
+			if present {
+				errs = append(errs, "catalog marks "+name+" spec-only-not-emitted, but a literal now exists in the source — "+
+					"reclassify it to code (with a severity field) in catalog.tsv")
+			}
+			continue
+		}
+		if !present {
+			errs = append(errs, "catalog entry "+name+" (status "+entry.status+") does not appear as a string literal in the scanned source — "+
+				"likely a typo in catalog.tsv or a removed event")
+		}
+	}
+
+	sort.Strings(errs)
+	return errs
+}
+
+// ---------------------------------------------------------------------------
+// The real test
+// ---------------------------------------------------------------------------
+
+func TestSyntheticAlertsCatalog(t *testing.T) {
+	root := findRepoRoot(t)
+	catalog := loadCatalog(t, root)
+	allowlist := loadAllowlist(t, root)
+
+	paths := scannedGoFiles(t, root)
+	fset, files := parseFiles(t, paths)
+	res := scanFiles(fset, files)
+
+	if len(res.literals) == 0 {
+		t.Fatal("scanner found zero payout literals — scan is broken")
+	}
+
+	for _, e := range validate(res, catalog, allowlist) {
+		t.Error(e)
+	}
+
+	// Sound per-site severity-presence: every catalogued alert must be emitted
+	// with a matching severity field at every emission site.
+	for _, e := range auditCatalogSeverity(fset, files, catalog) {
+		t.Error(e)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Negative fixtures: prove the check fails on each escape path.
+// ---------------------------------------------------------------------------
+
+func scanSrc(t *testing.T, src string) scanResult {
+	t.Helper()
+	fset := token.NewFileSet()
+	f, err := parser.ParseFile(fset, "fixture.go", src, 0)
+	if err != nil {
+		t.Fatalf("parse fixture: %v", err)
+	}
+	return scanFiles(fset, []*ast.File{f})
+}
+
+func hasErrorContaining(errs []string, sub string) bool {
+	for _, e := range errs {
+		if strings.Contains(e, sub) {
+			return true
+		}
+	}
+	return false
+}
+
+func TestScanner_NegativeFixtures(t *testing.T) {
+	emptyCat := map[string]catalogEntry{}
+	emptyAllow := map[string]string{}
+
+	t.Run("unclassified_literal_fails", func(t *testing.T) {
+		// A brand-new event literal, emitted via any mechanism, that is in
+		// neither the catalog nor the allowlist.
+		src := `package p
+func f(log L, name string) { log.Error().Str("event", name).Send() }
+func use(log L) { f(log, "payout_xyz_totally_new") }`
+		res := scanSrc(t, src)
+		if _, ok := res.literals["payout_xyz_totally_new"]; !ok {
+			t.Fatal("literal was not collected")
+		}
+		if !hasErrorContaining(validate(res, emptyCat, emptyAllow), "payout_xyz_totally_new") {
+			t.Fatal("expected unclassified-literal failure")
+		}
+		// Classified as an alert -> passes; classified as non-alert -> passes.
+		cat := map[string]catalogEntry{"payout_xyz_totally_new": {severity: "PAGE", status: "code"}}
+		if hasErrorContaining(validate(res, cat, emptyAllow), "payout_xyz_totally_new") {
+			t.Fatal("catalogued literal should not fail forward")
+		}
+		allow := map[string]string{"payout_xyz_totally_new": "info-event"}
+		if hasErrorContaining(validate(res, emptyCat, allow), "unclassified") {
+			t.Fatal("allowlisted literal should not fail forward")
+		}
+	})
+
+	t.Run("dynamic_sprintf_name_fails", func(t *testing.T) {
+		src := `package p
+import "fmt"
+func f(log L, tier string) { log.Error().Str("event", fmt.Sprintf("payout_%s_tripped", tier)).Send() }`
+		res := scanSrc(t, src)
+		if len(res.dynamic) == 0 || !hasErrorContaining(validate(res, emptyCat, emptyAllow), "dynamic alert-name template") {
+			t.Fatalf("expected dynamic-template failure, dynamic=%v", res.dynamic)
+		}
+	})
+
+	t.Run("dynamic_concat_name_fails", func(t *testing.T) {
+		src := `package p
+func f(log L, tier string) { ev := "payout_" + tier; log.Error().Str("event", ev).Send() }`
+		res := scanSrc(t, src)
+		if len(validate(res, emptyCat, emptyAllow)) == 0 {
+			t.Fatalf("expected dynamic-concat failure, dynamic=%v", res.dynamic)
+		}
+	})
+
+	t.Run("indirect_fragment_name_fails", func(t *testing.T) {
+		// One-more-indirection: prefix stored in a var, concatenated later.
+		// The "payout_" fragment literal must fail even though the "+" operands
+		// are both variables.
+		src := `package p
+func f(log L, suffix string) {
+	p := "payout_"
+	ev := p + suffix
+	log.Error().Str("event", ev).Send()
+}`
+		res := scanSrc(t, src)
+		if !hasErrorContaining(res.dynamic, "name fragment") {
+			t.Fatalf("expected fragment failure, dynamic=%v", res.dynamic)
+		}
+		if len(validate(res, emptyCat, emptyAllow)) == 0 {
+			t.Fatal("indirect fragment must cause a validation failure")
+		}
+	})
+
+	t.Run("prose_message_not_flagged", func(t *testing.T) {
+		// A payout_-prefixed ERROR MESSAGE (not an event name) must NOT be
+		// mistaken for a dynamic alert name (regression guard for bootstrap.go).
+		src := `package p
+import "fmt"
+func e(where, msg string) string { return fmt.Sprintf("payout_invariant_violation where=%q: %s", where, msg) }`
+		res := scanSrc(t, src)
+		if len(res.dynamic) != 0 {
+			t.Fatalf("prose message wrongly flagged as dynamic name: %v", res.dynamic)
+		}
+		if len(res.literals) != 0 {
+			t.Fatalf("prose message wrongly collected as identifier literal: %v", res.literals)
+		}
+	})
+
+	t.Run("catalog_typo_fails", func(t *testing.T) {
+		// Catalog names a code event that does not exist as a literal.
+		src := `package p
+func f(log L) { log.Warn().Str("event", "payout_low_balance").Str("severity", "WARN").Send() }`
+		res := scanSrc(t, src)
+		cat := map[string]catalogEntry{
+			"payout_low_balance": {severity: "WARN", status: "code"},
+			"payout_low_balancx": {severity: "WARN", status: "code"}, // typo
+		}
+		allow := map[string]string{}
+		if !hasErrorContaining(validate(res, cat, allow), "payout_low_balancx") {
+			t.Fatal("expected reverse typo failure")
+		}
+	})
+
+	t.Run("spec_only_present_fails", func(t *testing.T) {
+		// A spec-only-not-emitted event that now appears as a literal must fail.
+		src := `package p
+func f(log L) { log.Error().Str("event", "payout_nonce_gap").Str("severity", "WARN").Send() }`
+		res := scanSrc(t, src)
+		cat := map[string]catalogEntry{"payout_nonce_gap": {severity: "WARN", status: "spec-only-not-emitted"}}
+		allow := map[string]string{}
+		if !hasErrorContaining(validate(res, cat, allow), "spec-only-not-emitted") {
+			t.Fatal("expected spec-only-present failure")
+		}
+	})
+}
+
+func auditSevSrc(t *testing.T, src string, catalog map[string]catalogEntry) []string {
+	t.Helper()
+	fset := token.NewFileSet()
+	f, err := parser.ParseFile(fset, "fixture.go", src, 0)
+	if err != nil {
+		t.Fatalf("parse fixture: %v", err)
+	}
+	return auditCatalogSeverity(fset, []*ast.File{f}, catalog)
+}
+
+func TestSeverityAudit_NegativeFixtures(t *testing.T) {
+	t.Run("catalogued_event_without_severity_fails", func(t *testing.T) {
+		src := `package p
+func f(log L) { log.Error().Str("event", "payout_x_alert").Send() }`
+		cat := map[string]catalogEntry{"payout_x_alert": {severity: "PAGE", status: "code"}}
+		if !hasErrorContaining(auditSevSrc(t, src, cat), "WITHOUT a severity field") {
+			t.Fatal("expected missing-severity failure")
+		}
+	})
+
+	t.Run("wrong_severity_fails", func(t *testing.T) {
+		src := `package p
+func f(log L) { log.Warn().Str("event", "payout_x_alert").Str("severity", "WARN").Send() }`
+		cat := map[string]catalogEntry{"payout_x_alert": {severity: "PAGE", status: "code"}}
+		if !hasErrorContaining(auditSevSrc(t, src, cat), "severity mismatch") {
+			t.Fatal("expected severity mismatch failure")
+		}
+		catOK := map[string]catalogEntry{"payout_x_alert": {severity: "WARN", status: "code"}}
+		if len(auditSevSrc(t, src, catOK)) != 0 {
+			t.Fatal("matching severity should pass")
+		}
+	})
+
+	t.Run("helper_emitted_without_severity_fails", func(t *testing.T) {
+		// Event name reaches the .Str("event", …) site only as a helper
+		// parameter (variable). The check must trace the helper and still catch
+		// the missing severity.
+		src := `package p
+func emit(log L, name string) { log.Error().Str("event", name).Send() }
+func use(log L) { emit(log, "payout_x_alert") }`
+		cat := map[string]catalogEntry{"payout_x_alert": {severity: "PAGE", status: "code"}}
+		if !hasErrorContaining(auditSevSrc(t, src, cat), "WITHOUT a severity field") {
+			t.Fatal("expected helper missing-severity failure")
+		}
+		// With severity in the helper chain -> passes.
+		srcOK := `package p
+func emit(log L, name string) { log.Error().Str("event", name).Str("severity", "PAGE").Send() }
+func use(log L) { emit(log, "payout_x_alert") }`
+		if len(auditSevSrc(t, srcOK, cat)) != 0 {
+			t.Fatal("helper WITH severity should pass")
+		}
+	})
+
+	t.Run("no_emission_fails_closed", func(t *testing.T) {
+		// Catalogued alert never emitted anywhere -> fail-closed.
+		src := `package p
+func f(log L) { log.Error().Str("event", "payout_other").Str("severity", "PAGE").Send() }`
+		cat := map[string]catalogEntry{"payout_missing_alert": {severity: "PAGE", status: "code"}}
+		if !hasErrorContaining(auditSevSrc(t, src, cat), "no resolvable production emission") {
+			t.Fatal("expected fail-closed no-emission failure")
+		}
+	})
+
+	t.Run("status_does_not_exempt_from_severity", func(t *testing.T) {
+		// MEDIUM-1: a catalogued PAGE alert emitted without severity must FAIL
+		// regardless of status — a resurrected `code-untagged` (or any status)
+		// cannot bypass the severity requirement. Gate is severity-based.
+		src := `package p
+func f(log L) { log.Error().Str("event", "payout_x_alert").Send() }`
+		for _, status := range []string{"code", "code-untagged", "whatever"} {
+			cat := map[string]catalogEntry{"payout_x_alert": {severity: "PAGE", status: status}}
+			if !hasErrorContaining(auditSevSrc(t, src, cat), "WITHOUT a severity field") {
+				t.Fatalf("status %q must not exempt an emitted alert from the severity check", status)
+			}
+		}
+		// INFO severity is genuinely exempt (not an alert).
+		catInfo := map[string]catalogEntry{"payout_x_alert": {severity: "INFO", status: "info"}}
+		if len(auditSevSrc(t, src, catInfo)) != 0 {
+			t.Fatal("INFO event should not require a severity field")
+		}
+	})
+
+	t.Run("unresolvable_emitted_alert_fails_closed_not_skipped", func(t *testing.T) {
+		// MEDIUM-2: a payout emission whose event NAME the harness cannot
+		// resolve AND which lacks severity must FAIL (not be silently skipped).
+		src := `package payout
+func f(log L, in string) { log.Error().Str("event", computeName(in)).Send() }`
+		cat := map[string]catalogEntry{}
+		if !hasErrorContaining(auditSevSrc(t, src, cat), "cannot resolve") {
+			t.Fatal("expected fail-closed on an unresolvable, severity-less payout emission")
+		}
+		// The same emission WITH a literal severity is verifiable -> no failure.
+		srcOK := `package payout
+func f(log L, in string) { log.Error().Str("event", computeName(in)).Str("severity", "PAGE").Send() }`
+		if len(auditSevSrc(t, srcOK, cat)) != 0 {
+			t.Fatal("an unresolvable name WITH a visible severity should not fail")
+		}
+		// Outside package payout (e.g. general coordinator logging) it is not
+		// flagged, avoiding false positives on non-payout events.
+		srcMain := `package main
+func f(log L, in string) { log.Error().Str("event", computeName(in)).Send() }`
+		if len(auditSevSrc(t, srcMain, cat)) != 0 {
+			t.Fatal("non-payout package must not trip the unresolved check")
+		}
+	})
+
+	t.Run("page_capable_dynamic_ok_but_warn_only_catalog_fails", func(t *testing.T) {
+		src := `package p
+func f(log L, ceil bool) {
+	sev := "WARN"
+	if ceil { sev = "PAGE" }
+	log.Warn().Str("event", "payout_dyn_alert").Str("severity", sev).Send()
+}`
+		cat := map[string]catalogEntry{"payout_dyn_alert": {severity: "WARN", status: "code"}}
+		if !hasErrorContaining(auditSevSrc(t, src, cat), "page_capable") {
+			t.Fatal("expected page_capable failure")
+		}
+		catOK := map[string]catalogEntry{"payout_dyn_alert": {severity: "WARN", status: "code", pageCapable: true}}
+		if len(auditSevSrc(t, src, catOK)) != 0 {
+			t.Fatal("page_capable catalog should pass")
+		}
+	})
+}


### PR DESCRIPTION
## SPEC-016 §9.6 — payout synthetic-alert verification harness + alerting-contract fixes

Implements the §9 cutover prerequisite (item 6): before `payout.enabled: true`, the
operator must verify **one synthetic alert per enumerated §7.1 PAGE/WARN event name**
(not per severity tier) so a typo'd/missing BetterStack matcher can't leave a payout
failure silent. BetterStack config lives in the BetterStack UI (not the repo), so the
repo deliverable is a synthetic-log **emitter** + a **completeness/severity gate** that
keeps the catalog in lock-step with the code.

Payouts remain **default-off**; this is enablement-readiness tooling + the alerting
wiring it uncovered.

### What this adds
- **`dist/synthetic-alerts/`** — `catalog.tsv` (single source of truth: `event  severity
  status  page_capable`), `emit.sh` (one marked synthetic line per event — `"synthetic":
  true`; `--list` / `--event` / `--reserved`; dual WARN+PAGE for page-capable), a reviewed
  `non-alert-allowlist.txt` (36 non-alert `payout_` literals), and an operator `README.md`.
- **Completeness gate** (`internal/payout/synthetic_alerts_catalog_test.go`): a **sound,
  style-agnostic** check — every `payout_`/`provider_payout_` string literal in
  non-test `internal/payout` (recursive) + `cmd/coordinator` must be either a catalogued
  alert or an allowlisted non-alert; **fails closed** on any unclassified literal or any
  dynamically-constructed alert name. Plus a **severity-presence gate**: every catalogued
  alert must be emitted with a `severity` field matching the catalog (resolving literals,
  consts, struct-fields, string-returning helpers, and helper-threaded event names to a
  fixpoint); unresolved-but-emitted alerts fail closed. A new alert can't ship untagged.
- **Matchers key on `event`+`severity`, never zerolog `level`** (some events emit a PAGE
  `severity` at a non-error level) — documented + enforced.

### Alerting-contract fixes it uncovered (production)
The gate surfaced that 8 §7.1 alert emissions were **missing the `severity` field** their
matchers key on — so those payout failures would never have paged/warned at enablement:
`payout_failed` (×2, PAGE), `payout_signer_unavailable` (PAGE), `payout_invariant_violation`
(PAGE), `payout_runtime_flag_sync_emit_failed` (PAGE) in `runner.go`/`addresses.go`/
`pauseresume.go`, and `provider_payout_address_change_rejected` / `_rejected_unknown_provider`
(WARN) in `addresses.go`. Each fix adds only the `severity` field (level/message/logic
unchanged).

### Known gap flagged for follow-up (not in scope here)
Two §9-enumerated alerts are **never emitted by code** — `payout_runner_lease_conflict`
(PAGE, spec says "IMPL test required") and `payout_nonce_gap` (WARN). They're catalogued
`spec-only-not-emitted` and excluded from operator verification (an operator can't verify
an alert that can't fire). Wiring their emission is a prerequisite before enablement.

### Audit
Iterated Codex audit (code / security / architect). The completeness *test* was
re-architected once (static AST enumeration is undecidable → sound literal-presence), then
the alerting-contract gaps were swept and closed, and the gate hardened (status can't
exempt an emitted alert from severity; unresolved emissions fail closed). Final state:
production tagging verified correct, all gates + 14 negative fixtures green; one HIGH
(per-`rpc_label` synthetic coverage) rejected as beyond spec — §9 item-6 is per-event-name,
not per-dimension.

### Tests
`go build ./...`, `go vet`, `go test ./internal/payout/ ./cmd/coordinator/`, `gofmt`,
`shellcheck emit.sh` — all clean. `TestSyntheticAlertsCatalog` + `TestScanner_NegativeFixtures`
(7) + `TestSeverityAudit_NegativeFixtures` (7) pass.

SPEC-GOVERNANCE-DECLARATION-BEGIN
{
  "schema_version": "spec-pr-governance-v1",
  "behavior_change": "yes",
  "contract_change": "none",
  "specs": ["SPEC-016"],
  "requirements": ["SPEC-016-R010"],
  "authority_domains": ["payout-lifecycle"],
  "arbitration": ["CODE_BUG"],
  "tests": ["phase4-coordinator/internal/payout/synthetic_alerts_catalog_test.go"],
  "journeys": ["not-required"],
  "issue": "https://github.com/Augustas11/macprovider/issues/614"
}
SPEC-GOVERNANCE-DECLARATION-END

🤖 Generated with [Claude Code](https://claude.com/claude-code)
