### PR TITLE
Fix Pearl rollback gate for live duplicate fleet

### DIFF
--- a/ops/pearl-updater/macprovider-pearl-update
+++ b/ops/pearl-updater/macprovider-pearl-update
@@ -4877,7 +4877,12 @@ class Updater:
                 raise UpdateError("public protected-fleet sample contains duplicate provider identities")
             current[provider_id] = row
         if not require_previous_baseline:
-            return True
+            ready_rows = sum(
+                1
+                for row in current.values()
+                if row.get("state") == "ready" and row.get("routing_eligible") is True
+            )
+            return ready_rows >= max(required_ready, len(current))
         return all(
             provider_id in current
             and current[provider_id].get("state") == "ready"
@@ -4904,12 +4909,16 @@ class Updater:
         )
         if self.previous_protected_providers:
             stable_samples = 0
+            relax_previous_baseline = (
+                legacy_rollback_version is not None
+                and self.config.buyer_canary_mode == BUYER_CANARY_MODE_REQUIRED
+            )
 
             def protected_fleet_stable() -> bool:
                 nonlocal stable_samples
                 try:
                     ready = self.protected_provider_fleet_ready(
-                        require_previous_baseline=legacy_rollback_version is None
+                        require_previous_baseline=not relax_previous_baseline
                     )
                 except Exception:
                     stable_samples = 0

--- a/ops/pearl-updater/macprovider-pearl-update
+++ b/ops/pearl-updater/macprovider-pearl-update
@@ -116,7 +116,7 @@ MAX_CANDIDATE_OUTPUT_BYTES = 64 * 1024
 MAX_BUYER_PROOF_STREAM_BYTES = 1024 * 1024
 MAX_BUYER_PROOF_STREAM_LINE_BYTES = 64 * 1024
 CANARY_AUTHORITY_VERSION = "issue-825-canary-fleet-r5"
-CANARY_AUTHORITY_COMMIT = "c633794fbe0c7c25f4c88bd63922bae71e929f5d"
+CANARY_AUTHORITY_COMMIT = "98d95cb73573307c0e55855d9c3bb2ccd8e97b92"
 CANARY_UNIT_BUDGET_S = 180
 JOURNAL_SCHEMA_VERSION = 1
 CURRENT_RELEASE_SCHEMA_VERSION = 1
@@ -134,7 +134,7 @@ ROLLBACK_STEPS = (
     "canary_timer",
 )
 CANARY_AUTHORITY_FILES = {
-    Path("/opt/macprovider-canary-buyer/probe.mjs"): "c0e147190dd7164ac708e3fa85b463ebd0038f91fb94a2bdbde8e2a1bf41a675",
+    Path("/opt/macprovider-canary-buyer/probe.mjs"): "3b29494164e526e95f83c3de522b00a1fa8dd18479b5e6db0b6aa125d0250c55",
     Path("/opt/macprovider-canary-buyer/safety.mjs"): "03111b34d7ea86c0869be41ca54ed7057f437a0611e4637fc5d315aeb602f632",
     Path("/opt/macprovider-canary-buyer/run-canary.sh"): "6c5b31fce3b477aed8a85c7a0750e924360ed4828da49ca42ea693482e635585",
     Path("/opt/macprovider-canary-buyer/emergency-disable.sh"): "1380122e76b3b66ad812849e3684b38eaaed0790f0e6011e3f194bd215ab1c7e",

--- a/ops/pearl-updater/macprovider-pearl-update
+++ b/ops/pearl-updater/macprovider-pearl-update
@@ -116,7 +116,7 @@ MAX_CANDIDATE_OUTPUT_BYTES = 64 * 1024
 MAX_BUYER_PROOF_STREAM_BYTES = 1024 * 1024
 MAX_BUYER_PROOF_STREAM_LINE_BYTES = 64 * 1024
 CANARY_AUTHORITY_VERSION = "issue-825-canary-fleet-r5"
-CANARY_AUTHORITY_COMMIT = "fe8028ee345815dd6b633dbf49290f6626514833"
+CANARY_AUTHORITY_COMMIT = "a9aaf2c3b33b8f2f34d26b3f2c52024718541d9d"
 CANARY_UNIT_BUDGET_S = 180
 JOURNAL_SCHEMA_VERSION = 1
 CURRENT_RELEASE_SCHEMA_VERSION = 1
@@ -134,7 +134,7 @@ ROLLBACK_STEPS = (
     "canary_timer",
 )
 CANARY_AUTHORITY_FILES = {
-    Path("/opt/macprovider-canary-buyer/probe.mjs"): "37b2dd26e2144940b131768c0d5e6e661cb398544ee074242781482ea1d3c885",
+    Path("/opt/macprovider-canary-buyer/probe.mjs"): "fb3624b7bba662e686914317b17a5baebec3fc38c97215130c10468c8246518c",
     Path("/opt/macprovider-canary-buyer/safety.mjs"): "03111b34d7ea86c0869be41ca54ed7057f437a0611e4637fc5d315aeb602f632",
     Path("/opt/macprovider-canary-buyer/run-canary.sh"): "6c5b31fce3b477aed8a85c7a0750e924360ed4828da49ca42ea693482e635585",
     Path("/opt/macprovider-canary-buyer/emergency-disable.sh"): "1380122e76b3b66ad812849e3684b38eaaed0790f0e6011e3f194bd215ab1c7e",

--- a/ops/pearl-updater/macprovider-pearl-update
+++ b/ops/pearl-updater/macprovider-pearl-update
@@ -4845,7 +4845,7 @@ class Updater:
         )
         return current, decision
 
-    def protected_provider_fleet_ready(self) -> bool:
+    def protected_provider_fleet_ready(self, *, require_previous_baseline: bool = True) -> bool:
         if not self.previous_protected_providers:
             return True
         poolz = self.get_authorized_json(
@@ -4857,11 +4857,13 @@ class Updater:
         if not isinstance(summary, dict) or not isinstance(rows, list):
             raise UpdateError("public protected-fleet sample omitted pool or summary")
         ready = summary.get("ready")
-        required_ready = max(
-            self.config.minimum_pool_ready_after_rollout,
-            self.previous_pool_ready or 0,
-            len(self.previous_protected_providers),
-        )
+        required_ready = self.config.minimum_pool_ready_after_rollout
+        if require_previous_baseline:
+            required_ready = max(
+                required_ready,
+                self.previous_pool_ready or 0,
+                len(self.previous_protected_providers),
+            )
         if type(ready) is not int or ready < required_ready:
             return False
         current: dict[str, dict[str, Any]] = {}
@@ -4874,6 +4876,8 @@ class Updater:
             if provider_id in current:
                 raise UpdateError("public protected-fleet sample contains duplicate provider identities")
             current[provider_id] = row
+        if not require_previous_baseline:
+            return True
         return all(
             provider_id in current
             and current[provider_id].get("state") == "ready"
@@ -4904,7 +4908,9 @@ class Updater:
             def protected_fleet_stable() -> bool:
                 nonlocal stable_samples
                 try:
-                    ready = self.protected_provider_fleet_ready()
+                    ready = self.protected_provider_fleet_ready(
+                        require_previous_baseline=legacy_rollback_version is None
+                    )
                 except Exception:
                     stable_samples = 0
                     raise

--- a/ops/pearl-updater/macprovider-pearl-update
+++ b/ops/pearl-updater/macprovider-pearl-update
@@ -116,7 +116,7 @@ MAX_CANDIDATE_OUTPUT_BYTES = 64 * 1024
 MAX_BUYER_PROOF_STREAM_BYTES = 1024 * 1024
 MAX_BUYER_PROOF_STREAM_LINE_BYTES = 64 * 1024
 CANARY_AUTHORITY_VERSION = "issue-825-canary-fleet-r5"
-CANARY_AUTHORITY_COMMIT = "a9aaf2c3b33b8f2f34d26b3f2c52024718541d9d"
+CANARY_AUTHORITY_COMMIT = "c633794fbe0c7c25f4c88bd63922bae71e929f5d"
 CANARY_UNIT_BUDGET_S = 180
 JOURNAL_SCHEMA_VERSION = 1
 CURRENT_RELEASE_SCHEMA_VERSION = 1
@@ -134,7 +134,7 @@ ROLLBACK_STEPS = (
     "canary_timer",
 )
 CANARY_AUTHORITY_FILES = {
-    Path("/opt/macprovider-canary-buyer/probe.mjs"): "fb3624b7bba662e686914317b17a5baebec3fc38c97215130c10468c8246518c",
+    Path("/opt/macprovider-canary-buyer/probe.mjs"): "c0e147190dd7164ac708e3fa85b463ebd0038f91fb94a2bdbde8e2a1bf41a675",
     Path("/opt/macprovider-canary-buyer/safety.mjs"): "03111b34d7ea86c0869be41ca54ed7057f437a0611e4637fc5d315aeb602f632",
     Path("/opt/macprovider-canary-buyer/run-canary.sh"): "6c5b31fce3b477aed8a85c7a0750e924360ed4828da49ca42ea693482e635585",
     Path("/opt/macprovider-canary-buyer/emergency-disable.sh"): "1380122e76b3b66ad812849e3684b38eaaed0790f0e6011e3f194bd215ab1c7e",

--- a/ops/pearl-updater/macprovider-pearl-update
+++ b/ops/pearl-updater/macprovider-pearl-update
@@ -115,8 +115,8 @@ MAX_DOWNLOAD_BYTES = 512 * 1024 * 1024
 MAX_CANDIDATE_OUTPUT_BYTES = 64 * 1024
 MAX_BUYER_PROOF_STREAM_BYTES = 1024 * 1024
 MAX_BUYER_PROOF_STREAM_LINE_BYTES = 64 * 1024
-CANARY_AUTHORITY_VERSION = "issue-825-canary-fleet-r4"
-CANARY_AUTHORITY_COMMIT = "63577a81c3fba02c98ef3048d66946b918fe7721"
+CANARY_AUTHORITY_VERSION = "issue-825-canary-fleet-r5"
+CANARY_AUTHORITY_COMMIT = "481e17264c3c4a8526822bc0fe8e54c3faf8f91e"
 CANARY_UNIT_BUDGET_S = 180
 JOURNAL_SCHEMA_VERSION = 1
 CURRENT_RELEASE_SCHEMA_VERSION = 1
@@ -134,7 +134,7 @@ ROLLBACK_STEPS = (
     "canary_timer",
 )
 CANARY_AUTHORITY_FILES = {
-    Path("/opt/macprovider-canary-buyer/probe.mjs"): "5d1ed3ca815f34d29f290fc634a27d7badd8821f48e96ef29be2226de8dd0f81",
+    Path("/opt/macprovider-canary-buyer/probe.mjs"): "c6c0c8b5959c965dfc162cc88e0bf6e7fdddd3bb15dc85a78cfc3d64f2872741",
     Path("/opt/macprovider-canary-buyer/safety.mjs"): "03111b34d7ea86c0869be41ca54ed7057f437a0611e4637fc5d315aeb602f632",
     Path("/opt/macprovider-canary-buyer/run-canary.sh"): "6c5b31fce3b477aed8a85c7a0750e924360ed4828da49ca42ea693482e635585",
     Path("/opt/macprovider-canary-buyer/emergency-disable.sh"): "1380122e76b3b66ad812849e3684b38eaaed0790f0e6011e3f194bd215ab1c7e",

--- a/ops/pearl-updater/macprovider-pearl-update
+++ b/ops/pearl-updater/macprovider-pearl-update
@@ -116,7 +116,7 @@ MAX_CANDIDATE_OUTPUT_BYTES = 64 * 1024
 MAX_BUYER_PROOF_STREAM_BYTES = 1024 * 1024
 MAX_BUYER_PROOF_STREAM_LINE_BYTES = 64 * 1024
 CANARY_AUTHORITY_VERSION = "issue-825-canary-fleet-r5"
-CANARY_AUTHORITY_COMMIT = "481e17264c3c4a8526822bc0fe8e54c3faf8f91e"
+CANARY_AUTHORITY_COMMIT = "fe8028ee345815dd6b633dbf49290f6626514833"
 CANARY_UNIT_BUDGET_S = 180
 JOURNAL_SCHEMA_VERSION = 1
 CURRENT_RELEASE_SCHEMA_VERSION = 1
@@ -134,7 +134,7 @@ ROLLBACK_STEPS = (
     "canary_timer",
 )
 CANARY_AUTHORITY_FILES = {
-    Path("/opt/macprovider-canary-buyer/probe.mjs"): "c6c0c8b5959c965dfc162cc88e0bf6e7fdddd3bb15dc85a78cfc3d64f2872741",
+    Path("/opt/macprovider-canary-buyer/probe.mjs"): "37b2dd26e2144940b131768c0d5e6e661cb398544ee074242781482ea1d3c885",
     Path("/opt/macprovider-canary-buyer/safety.mjs"): "03111b34d7ea86c0869be41ca54ed7057f437a0611e4637fc5d315aeb602f632",
     Path("/opt/macprovider-canary-buyer/run-canary.sh"): "6c5b31fce3b477aed8a85c7a0750e924360ed4828da49ca42ea693482e635585",
     Path("/opt/macprovider-canary-buyer/emergency-disable.sh"): "1380122e76b3b66ad812849e3684b38eaaed0790f0e6011e3f194bd215ab1c7e",

--- a/ops/pearl-updater/test_pearl_updater.py
+++ b/ops/pearl-updater/test_pearl_updater.py
@@ -3311,7 +3311,7 @@ class PearlUpdaterTests(unittest.TestCase):
         self.assertEqual(updater_module.CANARY_AUTHORITY_VERSION, "issue-825-canary-fleet-r5")
         self.assertEqual(
             updater_module.CANARY_AUTHORITY_COMMIT,
-            "63577a81c3fba02c98ef3048d66946b918fe7721",
+            "481e17264c3c4a8526822bc0fe8e54c3faf8f91e",
         )
         subprocess.run(
             ["git", "cat-file", "-e", f"{updater_module.CANARY_AUTHORITY_COMMIT}^{{commit}}"],

--- a/ops/pearl-updater/test_pearl_updater.py
+++ b/ops/pearl-updater/test_pearl_updater.py
@@ -3377,7 +3377,7 @@ class PearlUpdaterTests(unittest.TestCase):
         self.assertEqual(updater_module.CANARY_AUTHORITY_VERSION, "issue-825-canary-fleet-r5")
         self.assertEqual(
             updater_module.CANARY_AUTHORITY_COMMIT,
-            "a9aaf2c3b33b8f2f34d26b3f2c52024718541d9d",
+            "c633794fbe0c7c25f4c88bd63922bae71e929f5d",
         )
         subprocess.run(
             ["git", "cat-file", "-e", f"{updater_module.CANARY_AUTHORITY_COMMIT}^{{commit}}"],

--- a/ops/pearl-updater/test_pearl_updater.py
+++ b/ops/pearl-updater/test_pearl_updater.py
@@ -3377,7 +3377,7 @@ class PearlUpdaterTests(unittest.TestCase):
         self.assertEqual(updater_module.CANARY_AUTHORITY_VERSION, "issue-825-canary-fleet-r5")
         self.assertEqual(
             updater_module.CANARY_AUTHORITY_COMMIT,
-            "c633794fbe0c7c25f4c88bd63922bae71e929f5d",
+            "98d95cb73573307c0e55855d9c3bb2ccd8e97b92",
         )
         subprocess.run(
             ["git", "cat-file", "-e", f"{updater_module.CANARY_AUTHORITY_COMMIT}^{{commit}}"],

--- a/ops/pearl-updater/test_pearl_updater.py
+++ b/ops/pearl-updater/test_pearl_updater.py
@@ -2831,6 +2831,37 @@ class PearlUpdaterTests(unittest.TestCase):
         }
         self.assertFalse(self.updater.protected_provider_fleet_ready())
 
+    def test_public_protected_fleet_sample_relaxes_stale_baseline_for_rollback(self):
+        self.updater.previous_pool_ready = 5
+        self.updater.previous_protected_providers = [
+            "provider-a",
+            "provider-b",
+            "provider-c",
+            "provider-d",
+            "provider-e",
+        ]
+        self.updater.coordinator_operator_token = mock.Mock(return_value="operator-token")
+        rows = [
+            {"provider_id": f"provider-{suffix}", "state": "ready", "routing_eligible": True}
+            for suffix in ("a", "b", "c", "d")
+        ]
+        self.updater.get_authorized_json = mock.Mock(
+            return_value={"summary": {"ready": 4}, "pool": rows}
+        )
+
+        self.assertFalse(self.updater.protected_provider_fleet_ready())
+        self.assertTrue(
+            self.updater.protected_provider_fleet_ready(require_previous_baseline=False)
+        )
+
+        self.updater.get_authorized_json.return_value = {
+            "summary": {"ready": 0},
+            "pool": rows,
+        }
+        self.assertFalse(
+            self.updater.protected_provider_fleet_ready(require_previous_baseline=False)
+        )
+
     def test_snapshot_failure_restores_previously_active_services(self):
         release = self.verify()
         order = []
@@ -3277,7 +3308,7 @@ class PearlUpdaterTests(unittest.TestCase):
                 updater_module.CANARY_AUTHORITY_FILES[installed],
                 hashlib.sha256(source_at_authority).hexdigest(),
             )
-        self.assertEqual(updater_module.CANARY_AUTHORITY_VERSION, "issue-825-canary-fleet-r4")
+        self.assertEqual(updater_module.CANARY_AUTHORITY_VERSION, "issue-825-canary-fleet-r5")
         self.assertEqual(
             updater_module.CANARY_AUTHORITY_COMMIT,
             "63577a81c3fba02c98ef3048d66946b918fe7721",
@@ -3427,7 +3458,7 @@ class PearlUpdaterTests(unittest.TestCase):
             {
                 "schema_version": 1,
                 "kind": "legacy_rollback",
-                "authority": "issue-825-canary-fleet-r4",
+                "authority": "issue-825-canary-fleet-r5",
                 "transaction_id": "a" * 64,
                 "expires_at": observed["document"]["expires_at"],
                 "providers": [

--- a/ops/pearl-updater/test_pearl_updater.py
+++ b/ops/pearl-updater/test_pearl_updater.py
@@ -2698,6 +2698,65 @@ class PearlUpdaterTests(unittest.TestCase):
             ),
         )
 
+    def test_rollback_serving_proof_relaxes_baseline_only_with_required_canary(self):
+        identity = updater_module.RuntimeIdentity("v1.8.30", "v1.8.30", "1.8.30")
+        self.updater.previous_protected_providers = ["provider-a", "provider-b"]
+        self.updater.local_coordinator_identity_ready = mock.Mock(return_value=True)
+        self.updater.gateway_serving_ready = mock.Mock(return_value=True)
+        self.updater.public_identity_ready = mock.Mock(return_value=True)
+        self.updater.protected_provider_fleet_ready = mock.Mock(return_value=True)
+        self.updater.run_canary_gate = mock.Mock()
+
+        def wait_until_success(_description, _timeout, check):
+            for _ in range(4):
+                if check():
+                    return
+            self.fail("wait_for check did not succeed")
+
+        self.updater.wait_for = wait_until_success
+
+        self.updater.prove_serving_recovery(identity, legacy_rollback_version="1.8.30")
+
+        self.assertEqual(
+            self.updater.protected_provider_fleet_ready.call_args_list,
+            [mock.call(require_previous_baseline=False)] * 3,
+        )
+        self.updater.run_canary_gate.assert_called_once_with(
+            legacy_rollback_version="1.8.30"
+        )
+
+    def test_disabled_rollback_serving_proof_keeps_exact_baseline(self):
+        identity = updater_module.RuntimeIdentity("v1.8.30", "v1.8.30", "1.8.30")
+        self.updater.config = updater_module.dataclasses.replace(
+            self.updater.config,
+            buyer_canary_mode=updater_module.BUYER_CANARY_MODE_DISABLED,
+        )
+        self.updater.previous_protected_providers = ["provider-a", "provider-b"]
+        self.updater.local_coordinator_identity_ready = mock.Mock(return_value=True)
+        self.updater.gateway_serving_ready = mock.Mock(return_value=True)
+        self.updater.public_identity_ready = mock.Mock(return_value=True)
+        self.updater.protected_provider_fleet_ready = mock.Mock(return_value=True)
+        self.updater.verify_disabled_buyer_canary_posture = mock.Mock()
+        self.updater.run_canary_gate = mock.Mock()
+        self.updater.audit = mock.Mock()
+
+        def wait_until_success(_description, _timeout, check):
+            for _ in range(4):
+                if check():
+                    return
+            self.fail("wait_for check did not succeed")
+
+        self.updater.wait_for = wait_until_success
+
+        self.updater.prove_serving_recovery(identity, legacy_rollback_version="1.8.30")
+
+        self.assertEqual(
+            self.updater.protected_provider_fleet_ready.call_args_list,
+            [mock.call(require_previous_baseline=True)] * 3,
+        )
+        self.updater.verify_disabled_buyer_canary_posture.assert_called_once_with()
+        self.updater.run_canary_gate.assert_not_called()
+
     def test_runtime_only_rollout_requires_buyer_canary_mode(self):
         self.make_bundle(runtime_only=True)
         release = self.verify()
@@ -2857,6 +2916,13 @@ class PearlUpdaterTests(unittest.TestCase):
         self.updater.get_authorized_json.return_value = {
             "summary": {"ready": 0},
             "pool": rows,
+        }
+        self.assertFalse(
+            self.updater.protected_provider_fleet_ready(require_previous_baseline=False)
+        )
+        self.updater.get_authorized_json.return_value = {
+            "summary": {"ready": 4},
+            "pool": [{**rows[0], "routing_eligible": False}, *rows[1:]],
         }
         self.assertFalse(
             self.updater.protected_provider_fleet_ready(require_previous_baseline=False)

--- a/ops/pearl-updater/test_pearl_updater.py
+++ b/ops/pearl-updater/test_pearl_updater.py
@@ -3377,7 +3377,7 @@ class PearlUpdaterTests(unittest.TestCase):
         self.assertEqual(updater_module.CANARY_AUTHORITY_VERSION, "issue-825-canary-fleet-r5")
         self.assertEqual(
             updater_module.CANARY_AUTHORITY_COMMIT,
-            "fe8028ee345815dd6b633dbf49290f6626514833",
+            "a9aaf2c3b33b8f2f34d26b3f2c52024718541d9d",
         )
         subprocess.run(
             ["git", "cat-file", "-e", f"{updater_module.CANARY_AUTHORITY_COMMIT}^{{commit}}"],

--- a/ops/pearl-updater/test_pearl_updater.py
+++ b/ops/pearl-updater/test_pearl_updater.py
@@ -3377,7 +3377,7 @@ class PearlUpdaterTests(unittest.TestCase):
         self.assertEqual(updater_module.CANARY_AUTHORITY_VERSION, "issue-825-canary-fleet-r5")
         self.assertEqual(
             updater_module.CANARY_AUTHORITY_COMMIT,
-            "481e17264c3c4a8526822bc0fe8e54c3faf8f91e",
+            "fe8028ee345815dd6b633dbf49290f6626514833",
         )
         subprocess.run(
             ["git", "cat-file", "-e", f"{updater_module.CANARY_AUTHORITY_COMMIT}^{{commit}}"],

--- a/ops/runbooks/pearl-release-updater.md
+++ b/ops/runbooks/pearl-release-updater.md
@@ -376,7 +376,7 @@ sudo test ! -e /run/macprovider-canary-buyer/legacy-rollback.json
    required evidence that the old coordinator cannot authorize the substitute;
    it is not serving proof. After the updater activates the reviewed bridge,
    the new coordinator may classify those same exact ID/model/version rows
-   `legacy_bridge`; r4 accepts that classification only as a substitute for the
+   `legacy_bridge`; r5 accepts that classification only as a substitute for the
    missing direct signal while retaining every pool, routing, connection, and
    heartbeat invariant. Before that canary starts, the updater requires three
    consecutive authenticated public `/poolz` samples that contain every exact
@@ -581,19 +581,19 @@ archive/stats services are restored before their timers, and no timer is
 restored until that full serving proof succeeds. Even then the canary timer
 remains stopped if its enable gate is missing or its emergency-disable sentinel
 exists, including when either kill switch changes during timer restoration.
-When restoring a pre-direct-telemetry backend, r4 may create
+When restoring a pre-direct-telemetry backend, r5 may create
 `/run/macprovider-canary-buyer/legacy-rollback.json` only inside the active
 phase-journal restoration. That root-owned `0644` control binds the exact
 captured protected provider ID/model fleet, the exact prior advertised binary
 version, the 64-hex transaction ID, and an expiry no more than 15 minutes away.
 It substitutes only for missing provider v2 signals on unclassified legacy
 rows and, during the scoped legacy rollback recovery/final-serving window only,
-tolerates readiness/signal/count loss for an unexercised duplicate-model row
-that remains present, unclassified, identity/version/session-stable, and backed
-by another authorized same-model provider that is ready, routable, and fresh.
-Bridge/current/previous modes, wrong versions/models/IDs, stale sessions,
-provider disappearance, exercised-provider loss, unique-model capacity loss, and
-all other canary failures remain rejected. The updater
+tolerates readiness/signal/count loss or disappearance for one unexercised
+duplicate-model row when another authorized same-model provider is ready,
+routable, and fresh. If the duplicate row is still present, it must remain
+unclassified and identity/version/session-stable. Bridge/current/previous modes,
+wrong versions/models/IDs, stale sessions, exercised-provider loss,
+unique-model capacity loss, and all other canary failures remain rejected. The updater
 removes the control on every success or failure exit. Its presence outside a
 restoration blocks an ordinary rollout canary.
 The Better Stack heartbeat is then returned to its exact pre-maintenance paused

--- a/ops/runbooks/pearl-release-updater.md
+++ b/ops/runbooks/pearl-release-updater.md
@@ -114,7 +114,7 @@ First deploy the issue #825 r5 legacy duplicate recovery revision of #584's rede
 canary buyer exactly as reviewed, including its root-only `LoadCredential`
 files, safety observer, emergency stop, and classified no-load exits. The
 updater pins that complete runtime, service, and timer as rollout authority
-`issue-825-canary-fleet-r5` at source commit `a9aaf2c3b33b8f2f34d26b3f2c52024718541d9d`;
+`issue-825-canary-fleet-r5` at source commit `c633794fbe0c7c25f4c88bd63922bae71e929f5d`;
 the default `PEARL_UPDATER_BUYER_CANARY_MODE=required` posture fails `--plan`
 on any SHA drift, missing credential, invalid protected-fleet expected-fleet
 document, absent reviewed enable gate, active emergency-disable sentinel,

--- a/ops/runbooks/pearl-release-updater.md
+++ b/ops/runbooks/pearl-release-updater.md
@@ -114,7 +114,7 @@ First deploy the issue #825 r4 legacy duplicate recovery revision of #584's rede
 canary buyer exactly as reviewed, including its root-only `LoadCredential`
 files, safety observer, emergency stop, and classified no-load exits. The
 updater pins that complete runtime, service, and timer as rollout authority
-`issue-825-canary-fleet-r4` at source commit `63577a81c3fba02c98ef3048d66946b918fe7721`;
+`issue-825-canary-fleet-r5` at source commit `63577a81c3fba02c98ef3048d66946b918fe7721`;
 the default `PEARL_UPDATER_BUYER_CANARY_MODE=required` posture fails `--plan`
 on any SHA drift, missing credential, invalid protected-fleet expected-fleet
 document, absent reviewed enable gate, active emergency-disable sentinel,

--- a/ops/runbooks/pearl-release-updater.md
+++ b/ops/runbooks/pearl-release-updater.md
@@ -114,7 +114,7 @@ First deploy the issue #825 r5 legacy duplicate recovery revision of #584's rede
 canary buyer exactly as reviewed, including its root-only `LoadCredential`
 files, safety observer, emergency stop, and classified no-load exits. The
 updater pins that complete runtime, service, and timer as rollout authority
-`issue-825-canary-fleet-r5` at source commit `fe8028ee345815dd6b633dbf49290f6626514833`;
+`issue-825-canary-fleet-r5` at source commit `a9aaf2c3b33b8f2f34d26b3f2c52024718541d9d`;
 the default `PEARL_UPDATER_BUYER_CANARY_MODE=required` posture fails `--plan`
 on any SHA drift, missing credential, invalid protected-fleet expected-fleet
 document, absent reviewed enable gate, active emergency-disable sentinel,

--- a/ops/runbooks/pearl-release-updater.md
+++ b/ops/runbooks/pearl-release-updater.md
@@ -110,11 +110,11 @@ legacy git-describe bootstrap is no longer accepted.
 
 ## One-time installation
 
-First deploy the issue #825 r4 legacy duplicate recovery revision of #584's redesigned
+First deploy the issue #825 r5 legacy duplicate recovery revision of #584's redesigned
 canary buyer exactly as reviewed, including its root-only `LoadCredential`
 files, safety observer, emergency stop, and classified no-load exits. The
 updater pins that complete runtime, service, and timer as rollout authority
-`issue-825-canary-fleet-r5` at source commit `63577a81c3fba02c98ef3048d66946b918fe7721`;
+`issue-825-canary-fleet-r5` at source commit `481e17264c3c4a8526822bc0fe8e54c3faf8f91e`;
 the default `PEARL_UPDATER_BUYER_CANARY_MODE=required` posture fails `--plan`
 on any SHA drift, missing credential, invalid protected-fleet expected-fleet
 document, absent reviewed enable gate, active emergency-disable sentinel,

--- a/ops/runbooks/pearl-release-updater.md
+++ b/ops/runbooks/pearl-release-updater.md
@@ -114,7 +114,7 @@ First deploy the issue #825 r5 legacy duplicate recovery revision of #584's rede
 canary buyer exactly as reviewed, including its root-only `LoadCredential`
 files, safety observer, emergency stop, and classified no-load exits. The
 updater pins that complete runtime, service, and timer as rollout authority
-`issue-825-canary-fleet-r5` at source commit `481e17264c3c4a8526822bc0fe8e54c3faf8f91e`;
+`issue-825-canary-fleet-r5` at source commit `fe8028ee345815dd6b633dbf49290f6626514833`;
 the default `PEARL_UPDATER_BUYER_CANARY_MODE=required` posture fails `--plan`
 on any SHA drift, missing credential, invalid protected-fleet expected-fleet
 document, absent reviewed enable gate, active emergency-disable sentinel,

--- a/ops/runbooks/pearl-release-updater.md
+++ b/ops/runbooks/pearl-release-updater.md
@@ -114,7 +114,7 @@ First deploy the issue #825 r5 legacy duplicate recovery revision of #584's rede
 canary buyer exactly as reviewed, including its root-only `LoadCredential`
 files, safety observer, emergency stop, and classified no-load exits. The
 updater pins that complete runtime, service, and timer as rollout authority
-`issue-825-canary-fleet-r5` at source commit `c633794fbe0c7c25f4c88bd63922bae71e929f5d`;
+`issue-825-canary-fleet-r5` at source commit `98d95cb73573307c0e55855d9c3bb2ccd8e97b92`;
 the default `PEARL_UPDATER_BUYER_CANARY_MODE=required` posture fails `--plan`
 on any SHA drift, missing credential, invalid protected-fleet expected-fleet
 document, absent reviewed enable gate, active emergency-disable sentinel,

--- a/test/e2e/canary-buyer/probe.mjs
+++ b/test/e2e/canary-buyer/probe.mjs
@@ -1262,6 +1262,28 @@ function hasDirectProviderSignal(signal) {
   );
 }
 
+function directProviderSignalIdentityReasons(providers, expectedFleet) {
+  const expectedIDs = new Set(expectedFleet.map((row) => row.provider_id));
+  const seen = new Set();
+  const reasons = [];
+  for (const [index, signal] of providers.entries()) {
+    if (!hasDirectProviderSignal(signal)) continue;
+    const providerID = signal?.provider_id;
+    if (typeof providerID !== 'string' || providerID.length === 0) {
+      reasons.push(`provider_signal_identity_missing_${index}`);
+      continue;
+    }
+    if (!expectedIDs.has(providerID)) {
+      reasons.push(`provider_signal_unexpected_${providerID}`);
+    }
+    if (seen.has(providerID)) {
+      reasons.push(`provider_signal_duplicate_${providerID}`);
+    }
+    seen.add(providerID);
+  }
+  return reasons;
+}
+
 function recoveryProviderSignals(
   observation,
   expectedFleet,
@@ -1330,6 +1352,12 @@ export function recoverySoakObservationReasons(
       ),
     ),
   }, soakOptions);
+  for (const [index, sample] of samples.entries()) {
+    reasons.push(...directProviderSignalIdentityReasons(
+      Array.isArray(sample?.providers) ? sample.providers : [],
+      expectedFleet,
+    ).map((reason) => `sample_${index + 1}:${reason}`));
+  }
   return filterLegacyIdleDuplicateRecoveryReasons(reasons, {
     observations: samples,
     expectedFleet,
@@ -1492,6 +1520,7 @@ export function safetyObservationReasons(initial, observed, expectedFleet, {
     if (observed.providers.length !== expectedFleet.length) {
       reasons.push(`provider_signal_count_${observed.providers.length}_ne_${expectedFleet.length}`);
     }
+    reasons.push(...directProviderSignalIdentityReasons(observed.providers, expectedFleet));
     const initialByID = new Map((initial.providers || []).map((provider) => [provider.provider_id, provider]));
     const currentByID = new Map(observed.providers.map((provider) => [provider.provider_id, provider]));
     const currentPoolByID = new Map(observed.operator_pool.map((provider) => [provider.provider_id, provider]));

--- a/test/e2e/canary-buyer/probe.mjs
+++ b/test/e2e/canary-buyer/probe.mjs
@@ -1236,23 +1236,29 @@ function legacyIdleDuplicateReasonAllowed(reason, allowance) {
       return true;
     }
   }
-  let match = unscopedReason.match(/^ready_(\d+)_lt_(\d+)$/);
-  if (match && Number(match[2]) - Number(match[1]) <= allowance.count) return true;
-  match = unscopedReason.match(/^pool_unavailable_(\d+)_ne_0$/);
-  if (match && Number(match[1]) <= allowance.count) return true;
-  match = unscopedReason.match(/^ready_changed_(\d+)_to_(\d+)$/);
-  if (match && Number(match[1]) - Number(match[2]) <= allowance.count) return true;
-  match = unscopedReason.match(/^total_providers_changed_(\d+)_to_(\d+)$/);
-  if (match && Number(match[1]) - Number(match[2]) <= allowance.count) return true;
-  match = unscopedReason.match(/^provider_count_changed_(\d+)_to_(\d+)$/);
-  if (match && Number(match[1]) - Number(match[2]) <= allowance.count) return true;
-  match = unscopedReason.match(/^provider_signal_count_(\d+)_ne_(\d+)$/);
-  if (match && Number(match[2]) - Number(match[1]) <= allowance.count) return true;
-  match = unscopedReason.match(/^(.*):ready_provider_count_changed_(\d+)_to_(\d+)$/);
-  if (match) {
-    const allowedLoss = allowance.byModel.get(match[1]) || 0;
-    if (Number(match[2]) - Number(match[3]) <= allowedLoss) return true;
-  }
+	  let match = unscopedReason.match(/^ready_(\d+)_lt_(\d+)$/);
+	  if (match && Number(match[2]) - Number(match[1]) >= 1
+	      && Number(match[2]) - Number(match[1]) <= allowance.count) return true;
+	  match = unscopedReason.match(/^pool_unavailable_(\d+)_ne_0$/);
+	  if (match && Number(match[1]) <= allowance.count) return true;
+	  match = unscopedReason.match(/^ready_changed_(\d+)_to_(\d+)$/);
+	  if (match && Number(match[1]) - Number(match[2]) >= 1
+	      && Number(match[1]) - Number(match[2]) <= allowance.count) return true;
+	  match = unscopedReason.match(/^total_providers_changed_(\d+)_to_(\d+)$/);
+	  if (match && Number(match[1]) - Number(match[2]) >= 1
+	      && Number(match[1]) - Number(match[2]) <= allowance.count) return true;
+	  match = unscopedReason.match(/^provider_count_changed_(\d+)_to_(\d+)$/);
+	  if (match && Number(match[1]) - Number(match[2]) >= 1
+	      && Number(match[1]) - Number(match[2]) <= allowance.count) return true;
+	  match = unscopedReason.match(/^provider_signal_count_(\d+)_ne_(\d+)$/);
+	  if (match && Number(match[2]) - Number(match[1]) >= 1
+	      && Number(match[2]) - Number(match[1]) <= allowance.count) return true;
+	  match = unscopedReason.match(/^(.*):ready_provider_count_changed_(\d+)_to_(\d+)$/);
+	  if (match) {
+	    const allowedLoss = allowance.byModel.get(match[1]) || 0;
+	    if (Number(match[2]) - Number(match[3]) >= 1
+	        && Number(match[2]) - Number(match[3]) <= allowedLoss) return true;
+	  }
   return false;
 }
 
@@ -1521,12 +1527,13 @@ export function safetyObservationReasons(initial, observed, expectedFleet, {
       reasons.push(`provider_signal_count_${observed.providers.length}_ne_${expectedFleet.length}`);
     }
     reasons.push(...directProviderSignalIdentityReasons(observed.providers, expectedFleet));
-    const initialByID = new Map((initial.providers || []).map((provider) => [provider.provider_id, provider]));
-    const currentByID = new Map(observed.providers.map((provider) => [provider.provider_id, provider]));
-    const currentPoolByID = new Map(observed.operator_pool.map((provider) => [provider.provider_id, provider]));
-    for (const expected of expectedFleet) {
-      const current = currentByID.get(expected.provider_id);
-      if (!current) {
+	    const initialByID = new Map((initial.providers || []).map((provider) => [provider.provider_id, provider]));
+	    const currentByID = new Map(observed.providers.map((provider) => [provider.provider_id, provider]));
+	    const currentPoolByID = new Map(observed.operator_pool.map((provider) => [provider.provider_id, provider]));
+	    for (const expected of expectedFleet) {
+	      const current = currentByID.get(expected.provider_id);
+	      const rollbackAuthorization = legacyRollbackProviders?.get(expected.provider_id);
+	      if (!current) {
         const poolRow = currentPoolByID.get(expected.provider_id);
         const poolIndex = observed.operator_pool.indexOf(poolRow);
         const poolSlotSignal = poolIndex >= 0 ? observed.providers[poolIndex] : null;
@@ -1561,11 +1568,20 @@ export function safetyObservationReasons(initial, observed, expectedFleet, {
         allowedRuntimeStates: activeProviderID === current.provider_id ? ['ready', 'busy'] : ['ready'],
         requireObservationAdvance: requireProviderHeartbeatAdvance,
       }));
-      if (current.model_id !== expected.model_id) {
-        reasons.push(`${expected.provider_id}:telemetry_model_${current.model_id || 'missing'}_ne_${expected.model_id}`);
-      }
-    }
-  }
+	      if (current.model_id !== expected.model_id) {
+	        reasons.push(`${expected.provider_id}:telemetry_model_${current.model_id || 'missing'}_ne_${expected.model_id}`);
+	      }
+	      if (rollbackAuthorization) {
+	        const poolRow = currentPoolByID.get(expected.provider_id);
+	        if (current.binary_version !== rollbackAuthorization.binary_version) {
+	          reasons.push(`${expected.provider_id}:telemetry_binary_${current.binary_version || 'missing'}_ne_${rollbackAuthorization.binary_version}`);
+	        }
+	        if (poolRow?.binary_version !== rollbackAuthorization.binary_version) {
+	          reasons.push(`${expected.provider_id}:pool_binary_${poolRow?.binary_version || 'missing'}_ne_${rollbackAuthorization.binary_version}`);
+	        }
+	      }
+	    }
+	  }
   return [...new Set(filterLegacyIdleDuplicateRecoveryReasons(reasons, {
     observations: observed,
     expectedFleet,

--- a/test/e2e/canary-buyer/probe.mjs
+++ b/test/e2e/canary-buyer/probe.mjs
@@ -1175,9 +1175,9 @@ function legacyIdleDuplicateDropAllowance(
       });
       if (substituteReady) providerIDs.add(id);
     }
-  }
-  if (!providerIDs.size) return empty;
-  const byModel = new Map();
+	  }
+	  if (providerIDs.size !== 1) return empty;
+	  const byModel = new Map();
   for (const id of providerIDs) {
     const model = expectedByID.get(id)?.model_id || '';
     if (model) byModel.set(model, (byModel.get(model) || 0) + 1);

--- a/test/e2e/canary-buyer/probe.mjs
+++ b/test/e2e/canary-buyer/probe.mjs
@@ -74,7 +74,7 @@ const configuredTTFTSamples = intEnv('CANARY_TTFT_SAMPLES', 12, 1, 20);
 const configuredTPSSamples = intEnv('CANARY_TPS_SAMPLES', 3, 1, 10);
 const GATEWAY_STATUS_CACHE_TTL_MS = 10_000;
 const PRODUCTION_HEARTBEAT_CADENCE_MS = 30_000;
-const LEGACY_ROLLBACK_AUTHORITY = 'issue-825-canary-fleet-r4';
+const LEGACY_ROLLBACK_AUTHORITY = 'issue-825-canary-fleet-r5';
 const LEGACY_ROLLBACK_MAX_VALIDITY_MS = 15 * 60 * 1000;
 
 const CONFIG = {
@@ -1148,9 +1148,14 @@ function legacyIdleDuplicateDropAllowance(
     for (const expected of expectedFleet) {
       const id = expected.provider_id;
       if (heartbeatAdvanceProviderIDs.has(id) || !legacyRollbackProviders.has(id)) continue;
+      const authorization = legacyRollbackProviders.get(id);
+      const idAuthorized = authorization?.model_id === expected.model_id
+        && Number.isFinite(authorization?.expires_at_ms)
+        && nowMs < authorization.expires_at_ms;
+      if (!idAuthorized) continue;
       const row = currentByID.get(id);
       const rowAuthorized = row && legacyRollbackRowAuthorized(row, expected, legacyRollbackProviders, nowMs);
-      if (!rowAuthorized) continue;
+      if (row && !rowAuthorized) continue;
       const rowReady = row
         && rowAuthorized
         && row.state === 'ready'
@@ -1205,8 +1210,10 @@ function legacyIdleDuplicateReasonAllowed(reason, allowance) {
     const suffix = unscopedReason.slice(id.length + 1);
     if (
       suffix === 'expected_provider_not_ready'
+      || suffix === 'expected_provider_missing'
       || suffix === 'heartbeat_signal_missing'
       || suffix === 'provider_signal_missing'
+      || suffix === 'provider_disappeared'
       || /^state_[^:]+_not_ready$/.test(suffix)
       || /^heartbeat_stale_\d+(?:\.\d+)?ms_gt_\d+ms$/.test(suffix)
       || /^telemetry_observation_stale_\d+ms_gt_\d+ms$/.test(suffix)
@@ -1221,6 +1228,10 @@ function legacyIdleDuplicateReasonAllowed(reason, allowance) {
   match = unscopedReason.match(/^pool_unavailable_(\d+)_ne_0$/);
   if (match && Number(match[1]) <= allowance.count) return true;
   match = unscopedReason.match(/^ready_changed_(\d+)_to_(\d+)$/);
+  if (match && Number(match[1]) - Number(match[2]) <= allowance.count) return true;
+  match = unscopedReason.match(/^total_providers_changed_(\d+)_to_(\d+)$/);
+  if (match && Number(match[1]) - Number(match[2]) <= allowance.count) return true;
+  match = unscopedReason.match(/^provider_count_changed_(\d+)_to_(\d+)$/);
   if (match && Number(match[1]) - Number(match[2]) <= allowance.count) return true;
   match = unscopedReason.match(/^provider_signal_count_(\d+)_ne_(\d+)$/);
   if (match && Number(match[2]) - Number(match[1]) <= allowance.count) return true;

--- a/test/e2e/canary-buyer/probe.mjs
+++ b/test/e2e/canary-buyer/probe.mjs
@@ -1129,6 +1129,17 @@ function legacyRollbackRowAuthorized(row, expected, authorizedProviders, nowMs) 
     && row?.binary_version === authorization.binary_version;
 }
 
+function hasDuplicateProviderIDs(rows) {
+  const seen = new Set();
+  for (const row of rows) {
+    const providerID = row?.provider_id;
+    if (typeof providerID !== 'string' || providerID.length === 0) continue;
+    if (seen.has(providerID)) return true;
+    seen.add(providerID);
+  }
+  return false;
+}
+
 function legacyIdleDuplicateDropAllowance(
   observations,
   expectedFleet,
@@ -1144,6 +1155,8 @@ function legacyIdleDuplicateDropAllowance(
   const providerIDs = new Set();
   for (const observed of observedList) {
     const rows = Array.isArray(observed?.operator_pool) ? observed.operator_pool : [];
+    if (hasDuplicateProviderIDs(rows)) return empty;
+    if (hasDuplicateProviderIDs(Array.isArray(observed?.providers) ? observed.providers : [])) return empty;
     const currentByID = new Map(rows.map((row) => [row.provider_id, row]));
     for (const expected of expectedFleet) {
       const id = expected.provider_id;

--- a/test/e2e/canary-buyer/probe.test.mjs
+++ b/test/e2e/canary-buyer/probe.test.mjs
@@ -919,6 +919,55 @@ test('legacy rollback recovery tolerates only unexercised duplicate provider rea
     now,
   ).includes('sample_2:provider_signal_identity_missing_2'));
 
+  const wrongDirectRollbackVersion = structuredClone(observation);
+  wrongDirectRollbackVersion.providers.find(
+    (provider) => provider.provider_id === 'provider-b',
+  ).binary_version = '1.8.31';
+  assert.ok(safetyObservationReasons(observation, wrongDirectRollbackVersion, expectedFleet, {
+    legacyRollbackProviders: authorized,
+    nowMs: now,
+  }).includes('provider-b:telemetry_binary_1.8.31_ne_1.8.30'));
+
+  const wrongPoolRollbackVersion = structuredClone(observation);
+  wrongPoolRollbackVersion.operator_pool.find(
+    (row) => row.provider_id === 'provider-b',
+  ).binary_version = '1.8.31';
+  assert.ok(safetyObservationReasons(observation, wrongPoolRollbackVersion, expectedFleet, {
+    legacyRollbackProviders: authorized,
+    nowMs: now,
+  }).includes('provider-b:pool_binary_1.8.31_ne_1.8.30'));
+
+  const aggregateIncrease = structuredClone(missingDuplicate);
+  aggregateIncrease.gateway.pool.total_providers = 4;
+  aggregateIncrease.gateway.pool.ready = 4;
+  aggregateIncrease.gateway.models[1].provider_count = 3;
+  aggregateIncrease.gateway.models[1].ready_provider_count = 3;
+  aggregateIncrease.gateway.models[1].slots_free = 3;
+  assert.ok(safetyObservationReasons(observation, aggregateIncrease, expectedFleet, {
+    legacyRollbackProviders: authorized,
+    nowMs: now,
+    requireHeartbeatAdvance: true,
+    heartbeatAdvanceProviderIDs: exercisedProviderIDs,
+  }).some((reason) => (
+    reason === 'total_providers_changed_3_to_4'
+    || reason === 'ready_changed_3_to_4'
+    || reason === 'provider_count_changed_2_to_3'
+    || reason === 'model-b:ready_provider_count_changed_2_to_3'
+  )));
+  assert.ok(recoverySoakObservationReasons(
+    observation,
+    [recoveryOne, aggregateIncrease],
+    expectedFleet,
+    authorized,
+    scopedAdvance,
+    now,
+  ).some((reason) => (
+    reason === 'sample_1:total_providers_changed_3_to_4'
+    || reason === 'sample_1:ready_changed_3_to_4'
+    || reason === 'sample_1:provider_count_changed_2_to_3'
+    || reason === 'sample_1:model-b:ready_provider_count_changed_2_to_3'
+  )));
+
   const expandedExpectedFleet = [
     ...expectedFleet,
     { provider_id: 'provider-d', model_id: 'model-b' },

--- a/test/e2e/canary-buyer/probe.test.mjs
+++ b/test/e2e/canary-buyer/probe.test.mjs
@@ -875,6 +875,50 @@ test('legacy rollback recovery tolerates only unexercised duplicate provider rea
     heartbeatAdvanceProviderIDs: exercisedProviderIDs,
   }).some((reason) => reason.includes('provider-c')));
 
+  const rogueProviderSignal = structuredClone(missingDuplicate);
+  rogueProviderSignal.providers.push(safetyProvider('rogue-provider', 'model-b', 'rogue-session', {
+    binary_version: '1.8.30',
+    observation_id: 'rogue-provider-observation',
+    observed_at: new Date(now - 1_000).toISOString(),
+  }));
+  assert.ok(safetyObservationReasons(observation, rogueProviderSignal, expectedFleet, {
+    legacyRollbackProviders: authorized,
+    nowMs: now,
+    requireHeartbeatAdvance: true,
+    heartbeatAdvanceProviderIDs: exercisedProviderIDs,
+  }).includes('provider_signal_unexpected_rogue-provider'));
+  assert.ok(recoverySoakObservationReasons(
+    observation,
+    [recoveryOne, rogueProviderSignal],
+    expectedFleet,
+    authorized,
+    scopedAdvance,
+    now,
+  ).includes('sample_2:provider_signal_unexpected_rogue-provider'));
+
+  const missingProviderIDDirectSignal = structuredClone(missingDuplicate);
+  const anonymousSignal = safetyProvider('provider-c', 'model-b', 'session-2', {
+    binary_version: '1.8.30',
+    observation_id: 'anonymous-provider-observation',
+    observed_at: new Date(now - 1_000).toISOString(),
+  });
+  delete anonymousSignal.provider_id;
+  missingProviderIDDirectSignal.providers.push(anonymousSignal);
+  assert.ok(safetyObservationReasons(observation, missingProviderIDDirectSignal, expectedFleet, {
+    legacyRollbackProviders: authorized,
+    nowMs: now,
+    requireHeartbeatAdvance: true,
+    heartbeatAdvanceProviderIDs: exercisedProviderIDs,
+  }).includes('provider_signal_identity_missing_2'));
+  assert.ok(recoverySoakObservationReasons(
+    observation,
+    [recoveryOne, missingProviderIDDirectSignal],
+    expectedFleet,
+    authorized,
+    scopedAdvance,
+    now,
+  ).includes('sample_2:provider_signal_identity_missing_2'));
+
   const expandedExpectedFleet = [
     ...expectedFleet,
     { provider_id: 'provider-d', model_id: 'model-b' },

--- a/test/e2e/canary-buyer/probe.test.mjs
+++ b/test/e2e/canary-buyer/probe.test.mjs
@@ -463,7 +463,7 @@ test('legacy rollback authorization is exact, expiring, and limited to unclassif
   const document = {
     schema_version: 1,
     kind: 'legacy_rollback',
-    authority: 'issue-825-canary-fleet-r4',
+    authority: 'issue-825-canary-fleet-r5',
     transaction_id: 'a'.repeat(64),
     expires_at: new Date(now + 300_000).toISOString(),
     providers: expectedFleet.map((row) => ({ ...row, binary_version: '1.8.30' })),
@@ -616,7 +616,7 @@ test('legacy rollback recovery requires heartbeat advance only from exercised pr
   const document = {
     schema_version: 1,
     kind: 'legacy_rollback',
-    authority: 'issue-825-canary-fleet-r4',
+    authority: 'issue-825-canary-fleet-r5',
     transaction_id: 'b'.repeat(64),
     expires_at: new Date(now + 300_000).toISOString(),
     providers: expectedFleet.map((row) => ({ ...row, binary_version: '1.8.30' })),
@@ -720,7 +720,7 @@ test('legacy rollback recovery tolerates only unexercised duplicate provider rea
   const document = {
     schema_version: 1,
     kind: 'legacy_rollback',
-    authority: 'issue-825-canary-fleet-r4',
+    authority: 'issue-825-canary-fleet-r5',
     transaction_id: 'c'.repeat(64),
     expires_at: new Date(now + 300_000).toISOString(),
     providers: expectedFleet.map((row) => ({ ...row, binary_version: '1.8.30' })),
@@ -836,12 +836,28 @@ test('legacy rollback recovery tolerates only unexercised duplicate provider rea
 
   const missingDuplicate = structuredClone(recoveryTwo);
   missingDuplicate.gateway.pool.total_providers = 2;
+  missingDuplicate.gateway.pool.unavailable = 0;
   missingDuplicate.operator_pool = missingDuplicate.operator_pool.filter((row) => row.provider_id !== 'provider-c');
-  assert.ok(recoverySoakObservationReasons(
+  missingDuplicate.providers = missingDuplicate.providers.filter((provider) => provider.provider_id !== 'provider-c');
+  assert.deepEqual(recoverySoakObservationReasons(
     observation,
     [recoveryOne, missingDuplicate],
     expectedFleet,
     authorized,
+    scopedAdvance,
+    now,
+  ), []);
+  assert.deepEqual(safetyObservationReasons(observation, missingDuplicate, expectedFleet, {
+    legacyRollbackProviders: authorized,
+    nowMs: now,
+    requireHeartbeatAdvance: true,
+    heartbeatAdvanceProviderIDs: exercisedProviderIDs,
+  }), []);
+  assert.ok(recoverySoakObservationReasons(
+    observation,
+    [recoveryOne, missingDuplicate],
+    expectedFleet,
+    null,
     scopedAdvance,
     now,
   ).some((reason) => reason.includes('provider-c')));

--- a/test/e2e/canary-buyer/probe.test.mjs
+++ b/test/e2e/canary-buyer/probe.test.mjs
@@ -862,6 +862,65 @@ test('legacy rollback recovery tolerates only unexercised duplicate provider rea
     now,
   ).some((reason) => reason.includes('provider-c')));
 
+  const expandedExpectedFleet = [
+    ...expectedFleet,
+    { provider_id: 'provider-d', model_id: 'model-b' },
+  ];
+  const expandedDocument = {
+    ...document,
+    providers: expandedExpectedFleet.map((row) => ({ ...row, binary_version: '1.8.30' })),
+  };
+  const expandedAuthorized = validateLegacyRollbackAuthorization(expandedDocument, expandedExpectedFleet, now);
+  const providerDRow = {
+    provider_id: 'provider-d',
+    assigned_id: 'session-3',
+    model_id: 'model-b',
+    state: 'ready',
+    routing_eligible: true,
+    binary_version: '1.8.30',
+    connected_at: new Date(now - 60_000).toISOString(),
+    last_heartbeat_at: new Date(now - 1_000).toISOString(),
+    last_activity_at: new Date(now - 1_000).toISOString(),
+  };
+  const expandedObservation = structuredClone(observation);
+  expandedObservation.gateway.pool.total_providers = 4;
+  expandedObservation.gateway.pool.ready = 4;
+  expandedObservation.gateway.models[1].provider_count = 3;
+  expandedObservation.gateway.models[1].ready_provider_count = 3;
+  expandedObservation.gateway.models[1].slots_free = 3;
+  expandedObservation.operator_pool = poolzSnapshot({
+    pool: [
+      ...expandedObservation.operator_pool,
+      providerDRow,
+    ],
+  }, now);
+  expandedObservation.providers = [
+    ...expandedObservation.providers,
+    safetyProvider('provider-d', 'model-b', 'session-3', {
+      binary_version: '1.8.30',
+      observation_id: 'provider-d-initial',
+      observed_at: new Date(now - 1_000).toISOString(),
+    }),
+  ];
+  const twoMissingDuplicates = structuredClone(expandedObservation);
+  twoMissingDuplicates.gateway.pool.total_providers = 2;
+  twoMissingDuplicates.gateway.pool.ready = 2;
+  twoMissingDuplicates.gateway.models[1].provider_count = 1;
+  twoMissingDuplicates.gateway.models[1].ready_provider_count = 1;
+  twoMissingDuplicates.gateway.models[1].slots_free = 1;
+  twoMissingDuplicates.operator_pool = twoMissingDuplicates.operator_pool.filter(
+    (row) => !['provider-c', 'provider-d'].includes(row.provider_id),
+  );
+  twoMissingDuplicates.providers = twoMissingDuplicates.providers.filter(
+    (provider) => !['provider-c', 'provider-d'].includes(provider.provider_id),
+  );
+  assert.ok(safetyObservationReasons(expandedObservation, twoMissingDuplicates, expandedExpectedFleet, {
+    legacyRollbackProviders: expandedAuthorized,
+    nowMs: now,
+    requireHeartbeatAdvance: true,
+    heartbeatAdvanceProviderIDs: exercisedProviderIDs,
+  }).some((reason) => reason.includes('provider-c') || reason.includes('provider-d')));
+
   const uniqueLoss = structuredClone(recoveryTwo);
   const providerA = uniqueLoss.operator_pool.find((row) => row.provider_id === 'provider-a');
   providerA.state = 'unavailable';

--- a/test/e2e/canary-buyer/probe.test.mjs
+++ b/test/e2e/canary-buyer/probe.test.mjs
@@ -862,6 +862,19 @@ test('legacy rollback recovery tolerates only unexercised duplicate provider rea
     now,
   ).some((reason) => reason.includes('provider-c')));
 
+  const duplicatePoolIdentity = structuredClone(missingDuplicate);
+  const duplicateProviderB = structuredClone(
+    duplicatePoolIdentity.operator_pool.find((row) => row.provider_id === 'provider-b'),
+  );
+  duplicateProviderB.assigned_id = 'duplicate-session';
+  duplicatePoolIdentity.operator_pool.push(duplicateProviderB);
+  assert.ok(safetyObservationReasons(observation, duplicatePoolIdentity, expectedFleet, {
+    legacyRollbackProviders: authorized,
+    nowMs: now,
+    requireHeartbeatAdvance: true,
+    heartbeatAdvanceProviderIDs: exercisedProviderIDs,
+  }).some((reason) => reason.includes('provider-c')));
+
   const expandedExpectedFleet = [
     ...expectedFleet,
     { provider_id: 'provider-d', model_id: 'model-b' },


### PR DESCRIPTION
## Summary

Fixes the remaining Pearl #825 rollback/canary blocker for the current four-provider live fleet after one duplicate-model provider dropped from the prior five-provider baseline.

The updater now relaxes the stale previous protected-provider baseline only for legacy rollback when buyer canary mode is `required`. Disabled-canary rollback keeps the exact previous protected-fleet baseline. The relaxed public `/poolz` gate is still row-backed: every currently sampled row must be ready and routing-eligible, and duplicate provider identities fail closed.

The r5 canary authorization is bounded to one unexercised duplicate-model provider loss/disappearance during legacy rollback recovery/final-serving only. It now rejects duplicate, rogue, or anonymous direct telemetry identities; enforces rollback-authorized binary versions for direct telemetry and operator pool rows; and only waives aggregate count decreases, never increases.

The Pearl updater and runbook pin r5 authority `issue-825-canary-fleet-r5` to source commit `98d95cb73573307c0e55855d9c3bb2ccd8e97b92` and protected `probe.mjs` hash `3b29494164e526e95f83c3de522b00a1fa8dd18479b5e6db0b6aa125d0250c55`.

## Validation

- `python3 ops/pearl-updater/test_pearl_updater.py` (183 OK, 1 skipped)
- `node --test test/e2e/canary-buyer/probe.test.mjs test/e2e/canary-buyer/safety.test.mjs` (33/33 pass)
- `bash test/e2e/canary-buyer/run-canary.test.sh` (PASS)
- `bash scripts/test-pearl-runtime-release.sh` (PASS)
- `python3 scripts/verify-pearl-go-binaries.py --self-test` (PASS)
- `git diff --check origin/main..HEAD` (clean)

## Audit

Three independent audit lanes reviewed the committed `origin/main..HEAD` diff after the final version/direction fix and reported 0 Critical / 0 High / 0 Medium bugs:

- Code correctness: 0 C/H/M
- Security/safety invariants: 0 C/H/M
- Architecture/state-machine fit: 0 C/H/M

SPEC-GOVERNANCE-DECLARATION-BEGIN
{
  "schema_version": "spec-pr-governance-v1",
  "behavior_change": "yes",
  "contract_change": "none",
  "specs": ["SPEC-020"],
  "requirements": ["SPEC-020-R001"],
  "authority_domains": ["provider-autoupdate"],
  "arbitration": ["CODE_BUG"],
  "tests": [
    "python3 ops/pearl-updater/test_pearl_updater.py",
    "node --test test/e2e/canary-buyer/probe.test.mjs test/e2e/canary-buyer/safety.test.mjs",
    "bash test/e2e/canary-buyer/run-canary.test.sh",
    "bash scripts/test-pearl-runtime-release.sh",
    "python3 scripts/verify-pearl-go-binaries.py --self-test",
    "git diff --check origin/main..HEAD"
  ],
  "journeys": ["issue-825-pearl-runtime-deploy"],
  "issue": "https://github.com/Augustas11/macprovider/issues/825"
}
SPEC-GOVERNANCE-DECLARATION-END
