### PR TITLE
Bump version to 1.8.79 for CLI release (keep-awake fix for fleet autoupdate)

### DIFF
--- a/phase3-binary/Sources/macprovider-cli/CoordinatorClient.swift
+++ b/phase3-binary/Sources/macprovider-cli/CoordinatorClient.swift
@@ -146,7 +146,7 @@ actor CoordinatorClient {
     typealias InstalledCompatibilityManifest = @Sendable (URL, String) -> CompatibilitySetManifest?
     typealias ReloadHelperFence = @Sendable () throws -> Void
 
-    static let binaryVersion = "1.8.69"
+    static let binaryVersion = "1.8.79"
     private static let keepaliveDebugEnabled = ProcessInfo.processInfo.environment["MACPROVIDER_KEEPALIVE_DEBUG"] == "1"
 
     private let coordinatorURL: URL

--- a/phase4-coordinator/coordinator.yaml.example
+++ b/phase4-coordinator/coordinator.yaml.example
@@ -186,7 +186,7 @@ autotune:
 # legacy cohort (DECISION_CRITERIA Entry 161). `required_binary_version` is a
 # hard admission floor, not an autoupdate target, and is unaffected by the gate.
 coordinator_advertised_version:
-  latest_binary_version: "1.8.69"
+  latest_binary_version: "1.8.79"
   required_binary_version: ""
 
 auth:

--- a/phase4-coordinator/dist/coordinator.yaml
+++ b/phase4-coordinator/dist/coordinator.yaml
@@ -365,7 +365,7 @@ providers:
 # the already-true rejection explicit and machine-readable instead of leaving
 # a legacy build to fail later, opaquely, on catalog admission.
 #
-# It is deliberately far below the current release (1.8.69) and below the
+# It is deliberately far below the current release (1.8.79) and below the
 # #610 first-hop bridge build (1.8.48, which is additionally exempt from the
 # floor by construction — see prepareProviderAdmission's firstHopOnly skip),
 # so raising it is a separate, deliberate act. Raise it only in lockstep with
@@ -373,5 +373,5 @@ providers:
 # reconnecting and tells its operator to upgrade, and one without it
 # reconnect-loops.
 coordinator_advertised_version:
-  latest_binary_version: "1.8.69"
+  latest_binary_version: "1.8.79"
   required_binary_version: "1.8.33"

--- a/phase4-coordinator/dist/coordinator.yaml.example
+++ b/phase4-coordinator/dist/coordinator.yaml.example
@@ -373,7 +373,7 @@ malibu_emission:
 # routing. Keys match model_id case-insensitively; values must be bare
 # numeric versions or the coordinator refuses to start.
 coordinator_advertised_version:
-  latest_binary_version: "1.8.69"
+  latest_binary_version: "1.8.79"
   # required_binary_version: "1.7.0"
   # per_model_required_binary_version:
   #   "mlx-community/Qwen3-Coder-30B-A3B-Instruct-4bit": "1.8.60"


### PR DESCRIPTION
## Cut provider-CLI release v1.8.79 — deliver the keep-awake fix to the fleet

### Why
The client keep-awake fix (`77d4b50b`, 2026-08-01) — binds the macOS sleep
assertion to serving intent so App Nap / reconnect backoff can't freeze a
serving Mac's heartbeat — was **merged to main but never published as a macOS
provider release**. Every release since v1.8.69 (v1.8.70..v1.8.78) is a Linux
**Pearl-runtime** coordinator prerelease with **no macOS CLI / Malibu /
compatibility-set artifact**. So providers on v1.8.69 are stranded on the
pre-fix client.

**Observed live (Pearl coordinator, 2026-08-02):** provider "MacBook Air — Влад"
(`mp-038459680a…`, joined 2026-07-31, on v1.8.69) flapped **81 disconnects/6h** —
heartbeats stop, coordinator's 60s read deadline expires (`i/o timeout`), drop,
reconnect, repeat = his reported "works 1–2 min, then searching for a network."
Isolated to his node; zero coordinator-side rejections. Signature = App-Nap
heartbeat starvation, exactly what `77d4b50b` fixes.

### What
Version-bump only (mirrors the v1.8.69 bump `5adef036`): `binaryVersion`
1.8.69 → 1.8.79 and the `coordinator_advertised_version.latest_binary_version`
templates to match. `required_binary_version` (hard admission floor) unchanged.

The compatibility-set manifest schema is **byte-identical** to v1.8.69
(`scripts/compatibility-set-manifest.py` unchanged across the tags; 9-file
`CATALOG_FILES`), so v1.8.69 (exact-9) clients cross to v1.8.79 with **no
bridge**. The ≤1.8.66 (exact-7) forward-incompat trap is a separate older-fleet
concern and is out of scope here.

### Rollout sequence (post-merge)
1. Tag `v1.8.79` at the merge commit, push tag.
2. Dispatch `release.yml` (version `v1.8.79`) as a **prerelease canary** —
   builds/signs/notarizes CLI + Malibu, publishes compatibility-set. Requires
   `production-release` environment approval.
3. Advance Pearl live `recommended_binary_version` 1.8.69 → 1.8.79 + reload
   coordinator (watched) → v1.8.69 clients autoupdate via the coordinator source.
4. Confirm the fleet adopts (Vlad's disconnect count drops), then promote the
   canary to stable/latest (the live-recommendation release gate passes once
   Pearl advertises 1.8.79).

### Governance declaration
This is release version-plumbing (swift version constant + coordinator config
templates). Non-governance paths, but no canonical SPEC requirement governs a
version bump — same shape as the documented "no honest declaration" CI-only
case. The advisory `spec-index / check` job is **not** a merge requirement
(only `ci-required` + 1 approval are). Not fabricating a spec link.
