### PR TITLE
Autotune: measure decode throughput for reasoning models (admit gpt-oss-20b)

### DIFF
--- a/phase3-binary/Sources/macprovider-cli/HTTPServer.swift
+++ b/phase3-binary/Sources/macprovider-cli/HTTPServer.swift
@@ -1456,6 +1456,24 @@ final class RouterHandler: ChannelInboundHandler, @unchecked Sendable {
             "completion_tokens": completion.completionTokens,
             "total_tokens": completion.promptTokens + completion.completionTokens,
             "macprovider_model_hash_observed": completion.modelHashObserved ?? NSNull(),
+            // Total tokens decoded across ALL channels (reasoning/analysis +
+            // final), NOT just the visible final channel that `completion_tokens`
+            // reports. For Harmony/reasoning models (gpt-oss-20b) the analysis
+            // channel is suppressed from `completion_tokens`, so a gibberish
+            // autotune probe can show `completion_tokens` ≈ 0 while real decode
+            // work happened. This namespaced vendor extension (additive; does not
+            // change `completion_tokens`/billing/OpenAI-compat) lets the autotune
+            // throughput probe measure honest decode rate. Origin:
+            // CompletionResult.generatedCompletionTokens (= generationTokenCount).
+            "macprovider_generated_completion_tokens": completion.generatedCompletionTokens,
+            // Provider-measured warm-decode wall-time (ms) from the first
+            // decoded token of ANY channel to the generate result. The autotune
+            // throughput probe divides total decoded tokens by this window to
+            // measure honest decode rate for reasoning models whose analysis
+            // channel is silent in the SSE stream (no deltas, no client-visible
+            // timing). Additive vendor extension; does not affect billing or
+            // OpenAI-compat. NSNull when the serve path did not record timing.
+            "macprovider_generation_ms": completion.generationMilliseconds ?? NSNull(),
         ]
     }
 

--- a/phase3-binary/Sources/macprovider-cli/MacProviderCLI.swift
+++ b/phase3-binary/Sources/macprovider-cli/MacProviderCLI.swift
@@ -394,6 +394,24 @@ struct ServeCommand: AsyncParsableCommand {
         }
     }
 
+    /// Round-2 code MEDIUM-3: autotune candidates must not use speculative
+    /// decoding. The serve-stream speculative path (`collectSpeculativeText`)
+    /// owns its own decode loop and never fires the outer `decodeTimer`, so a
+    /// candidate launched with a configured draft model would emit
+    /// `macprovider_generation_ms: null` and the Stage 1/2 probe would silently
+    /// fall back to client timing (which cannot see a reasoning model's
+    /// suppressed decode window). Force speculative decoding OFF for candidates
+    /// by clearing the resolved draft model so the probe always exercises the
+    /// main, timed decode path. Incumbent serve is untouched.
+    static func applyAutotuneCandidateDraftSuppression(
+        _ resolved: inout AppConfig,
+        autotuneCandidate: Bool
+    ) {
+        guard autotuneCandidate else { return }
+        resolved.draftModel = nil
+        resolved.draftModelArtifactSHA256 = nil
+    }
+
     static func runDrainTimeoutPreflight(_ resolved: AppConfig) throws {
         if !(5...600).contains(resolved.swapDrainTimeoutSeconds) {
             FileHandle.standardError.write(Data((
@@ -850,6 +868,13 @@ struct ServeCommand: AsyncParsableCommand {
         // preflight bundle repeats this idempotent check after acquiring its
         // dependencies so direct callers retain the same validation contract.
         try Self.runSupportedModelsPreflight(&resolved)
+
+        // Round-2 code MEDIUM-3: clear the resolved draft model for autotune
+        // candidates so the speculative route is never taken and the probe
+        // exercises the main, timed decode path. Applied before the draft-model
+        // capacity/artifact preflights and ModelRuntime construction so nothing
+        // downstream sees a draft model for a candidate.
+        Self.applyAutotuneCandidateDraftSuppression(&resolved, autotuneCandidate: autotuneCandidate)
 
         // Autotune candidates (`--autotune-candidate`, always with `--no-join`)
         // share the incumbent's lifecycle directory but persist to a distinct

--- a/phase3-binary/Sources/macprovider-cli/ModelRuntime.swift
+++ b/phase3-binary/Sources/macprovider-cli/ModelRuntime.swift
@@ -1991,6 +1991,15 @@ actor ModelRuntime: ModelRuntimeServing {
                     let generationContext = Self.harmonyTerminalPreservingContext(from: context, modelID: request.model)
 
                     let promptTokenIds: [Int32] = lmInput.text.tokens.asArray(Int32.self)
+                    // Autotune throughput probe: measure warm-decode
+                    // wall-time on the provider so the client can derive an
+                    // honest decode rate even for reasoning models whose
+                    // analysis channel is silent in the SSE stream. Fires on
+                    // the first decoded token of ANY channel (reasoning or
+                    // final) inside the generate closure below; the duration
+                    // to the generate result is reported as
+                    // `macprovider_generation_ms`.
+                    let decodeTimer = FirstTokenRecorder()
                     // SPEC-037 FR-KVP2.5: speculative-decode routing is
                     // determined BEFORE any conversation-cache begin(). A
                     // speculative-routed request acquires no lease, triggers no
@@ -2019,6 +2028,13 @@ actor ModelRuntime: ModelRuntimeServing {
                             drainCancelled: drainCancelled,
                             blockingInferenceExecutor: blockingInferenceExecutor
                         )
+                        // Warm-decode wall-time for the speculative path.
+                        // collectSpeculativeText owns its own decode loop and
+                        // does not fire `decodeTimer`, so this resolves to nil
+                        // here; the field is passed for construction-site parity
+                        // with the non-speculative path.
+                        let decodeEndedAt = Date()
+                        let generationMS = decodeTimer.durationMilliseconds(until: decodeEndedAt)
                         try drainCancelled.check()
                         try Task.checkCancellation()
 
@@ -2063,6 +2079,7 @@ actor ModelRuntime: ModelRuntimeServing {
                             promptTokens: promptTokenIds.count,
                             cachedPromptTokens: 0,
                             completionTokens: generated.generationTokenCount,
+                            generationMilliseconds: generationMS,
                             toolCalls: parsed.toolCalls.isEmpty ? nil : parsed.toolCalls,
                             modelHashObserved: Self.validObservedModelHash(snapshot.modelHash),
                             specDecodeDraftedTokens: generated.draftedTokens,
@@ -2133,6 +2150,16 @@ actor ModelRuntime: ModelRuntimeServing {
                         let result: BlockingGenerateResult = try await blockingInferenceExecutor.run { inferenceCancellation in
                             BlockingGenerateResult(generate(input: iteratorInput, context: generationContext, iterator: iterator) { tokens in
                                 EgressPerfTraceKey.current?.recordDecodeCallbackEntry()
+                                // Round-2 code LOW: only start the decode timer
+                                // on a callback that actually carries a token.
+                                // An empty first callback would otherwise start
+                                // the clock during prefill and inflate the
+                                // measured decode window. Mirrors the
+                                // `if !tokens.isEmpty { firstToken.recordIfMissing() }`
+                                // guards elsewhere in this file.
+                                if !tokens.isEmpty {
+                                    decodeTimer.recordIfMissing()
+                                }
                                 if Task.isCancelled || inferenceCancellation.isCancelled || shouldCancel() || drainCancelled.isFired || idleCancellation.isFired {
                                     return .stop
                                 }
@@ -2206,6 +2233,13 @@ actor ModelRuntime: ModelRuntimeServing {
                                 return .more
                             })
                         }
+                        // Warm-decode wall-time: from the first decoded token
+                        // (any channel) to the generate result. Reported to the
+                        // client as `macprovider_generation_ms` so the autotune
+                        // probe can divide total decoded tokens by this window
+                        // even when the reasoning channel is silent in SSE.
+                        let decodeEndedAt = Date()
+                        let generationMS = decodeTimer.durationMilliseconds(until: decodeEndedAt)
                         try drainCancelled.check()
                         try Task.checkCancellation()
                         if shouldCancel() {
@@ -2292,6 +2326,7 @@ actor ModelRuntime: ModelRuntimeServing {
                             kvCacheBytesReused: kvCacheBytesReused,
                             completionTokens: parsed.completionTokens,
                             generatedCompletionTokens: parsed.generatedCompletionTokens,
+                            generationMilliseconds: generationMS,
                             toolCalls: parsed.toolCalls.isEmpty ? nil : parsed.toolCalls,
                             modelHashObserved: Self.validObservedModelHash(snapshot.modelHash)
                         )
@@ -3339,6 +3374,10 @@ actor ModelRuntime: ModelRuntimeServing {
             completionTokens: completion.completionTokens,
             generatedCompletionTokens: completion.generatedCompletionTokens,
             ttftMilliseconds: completion.ttftMilliseconds,
+            // Architect LOW: forward the decode-window so the structured
+            // streaming path's usage carries `macprovider_generation_ms`
+            // instead of null, matching the non-structured path.
+            generationMilliseconds: completion.generationMilliseconds,
             toolCalls: completion.toolCalls,
             modelHashObserved: completion.modelHashObserved,
             specDecodeDraftedTokens: completion.specDecodeDraftedTokens,
@@ -3923,6 +3962,7 @@ struct CompletionResult: Sendable {
     let completionTokens: Int
     let generatedCompletionTokens: Int
     let ttftMilliseconds: Int64?
+    let generationMilliseconds: Int64?
     let toolCalls: [ToolCall]?
     let modelHashObserved: String?
     let specDecodeDraftedTokens: Int
@@ -3938,6 +3978,7 @@ struct CompletionResult: Sendable {
         completionTokens: Int,
         generatedCompletionTokens: Int? = nil,
         ttftMilliseconds: Int64? = nil,
+        generationMilliseconds: Int64? = nil,
         toolCalls: [ToolCall]? = nil,
         modelHashObserved: String? = nil,
         specDecodeDraftedTokens: Int = 0,
@@ -3955,6 +3996,7 @@ struct CompletionResult: Sendable {
         self.completionTokens = completionTokens
         self.generatedCompletionTokens = max(0, generatedCompletionTokens ?? completionTokens)
         self.ttftMilliseconds = ttftMilliseconds
+        self.generationMilliseconds = generationMilliseconds
         self.toolCalls = toolCalls
         self.modelHashObserved = modelHashObserved
         self.specDecodeDraftedTokens = max(0, specDecodeDraftedTokens)
@@ -3973,6 +4015,7 @@ struct CompletionResult: Sendable {
             completionTokens: completionTokens,
             generatedCompletionTokens: generatedCompletionTokens,
             ttftMilliseconds: ttftMilliseconds,
+            generationMilliseconds: generationMilliseconds,
             toolCalls: toolCalls,
             modelHashObserved: observed,
             specDecodeDraftedTokens: specDecodeDraftedTokens,
@@ -4001,6 +4044,12 @@ private final class FirstTokenRecorder: @unchecked Sendable {
             return nil
         }
         return max(0, Int64(timestamp.timeIntervalSince(start) * 1000))
+    }
+
+    func durationMilliseconds(until end: Date) -> Int64? {
+        lock.lock(); defer { lock.unlock() }
+        guard let timestamp else { return nil }
+        return max(0, Int64(end.timeIntervalSince(timestamp) * 1000))
     }
 }
 

--- a/phase3-binary/Sources/macprovider-cli/Stage1Iterator.swift
+++ b/phase3-binary/Sources/macprovider-cli/Stage1Iterator.swift
@@ -589,6 +589,26 @@ struct Stage1Prober: Stage1Probing {
         // whitespace-separated English words (English averages ~0.75
         // words/token, under-counting by ~1.3x).
         var deltaCount = 0
+        // Reasoning models (gpt-oss-20b / Harmony) suppress their
+        // analysis/reasoning channel from `delta.content`, so on the
+        // probe's nonsense padded prompt they generate tokens but emit
+        // ZERO visible content deltas. The provider closes the stream with
+        // a usage chunk (`choices: []` + `usage`) that carries the honest
+        // total decode count in `macprovider_generated_completion_tokens`
+        // (all channels incl. suppressed reasoning; HTTPServer.swift
+        // `usage()`). Track the latest reported value so finalization can
+        // derive throughput from it, not from counting visible content
+        // deltas — otherwise reasoning models measure 0 tok/s and are
+        // wrongly marked infeasible.
+        var usageDecodedTokens: Int?
+        // Provider-reported warm-decode wall-time (ms) from the terminal
+        // usage chunk (`macprovider_generation_ms`). This is the ONLY honest
+        // decode-window signal for reasoning models, whose analysis channel
+        // is silent in the SSE stream so the client cannot time it. When
+        // present, finalization divides total decoded tokens by this window
+        // instead of any client-observed timing. Whole milliseconds (the
+        // provider emits an Int64); see `usageGenerationMS(from:)`.
+        var usageGenerationMS: Int?
 
         for try await rawLine in bytes.lines {
             guard rawLine.hasPrefix("data:") else {
@@ -597,6 +617,12 @@ struct Stage1Prober: Stage1Probing {
             let payload = rawLine.dropFirst(5).trimmingCharacters(in: .whitespacesAndNewlines)
             if payload == "[DONE]" {
                 break
+            }
+            if let usage = Self.usageDecodedTokens(from: payload) {
+                usageDecodedTokens = usage
+            }
+            if let generationMS = Self.usageGenerationMS(from: payload) {
+                usageGenerationMS = generationMS
             }
             guard let content = Self.contentDelta(from: payload), !content.isEmpty else {
                 continue
@@ -608,36 +634,227 @@ struct Stage1Prober: Stage1Probing {
             deltaCount += 1
         }
 
-        guard let firstTokenAt else {
-            return SingleProbeResult(
-                statusCode: statusCode,
-                ttftMS: .infinity,
-                generatedText: generatedText,
-                throughputTPS: 0
-            )
-        }
-
-        // v1.7.8 Track A4: measure generation-only throughput.
-        // Pre-v1.7.8 the denominator was `ended - started`, which
-        // included TTFT (the full prefill wall-clock, 5-30s on M-Base
-        // even after v1.7.7's prewarm on a 3200-token prompt).
-        // That inflated the denominator by ~4-10x and drove reported
-        // TPS to 3-4 tok/s for candidates that actually stream 25-40
-        // tok/s in warm generation. Catalog `min_sustained_tps`
-        // (20-30 range) expresses warm-generation throughput, so this
-        // is the semantics the gate expects.
         let ended = clock()
-        let generationElapsed = max(0.001, ended.timeIntervalSince(firstTokenAt))
-        let outputTokens = max(1, deltaCount)
+        let metrics = Self.finalizeProbeMetrics(
+            contentFallbackTokens: deltaCount,
+            usageDecodedTokens: usageDecodedTokens,
+            usageGenerationMS: usageGenerationMS,
+            firstTokenAt: firstTokenAt,
+            started: started,
+            ended: ended
+        )
         return SingleProbeResult(
             statusCode: statusCode,
-            ttftMS: max(0, firstTokenAt.timeIntervalSince(started) * 1_000),
+            ttftMS: metrics.ttftMS,
             generatedText: generatedText,
-            throughputTPS: Double(outputTokens) / generationElapsed
+            throughputTPS: metrics.throughputTPS
         )
     }
 
-    private static func contentDelta(from payload: String) -> String? {
+    /// Derives TTFT and decode throughput from a completed probe stream.
+    /// Extracted as a pure static function so the finalization logic is
+    /// unit-testable without spawning a provider process.
+    ///
+    /// Throughput branch order (highest fidelity first). The decoded-token
+    /// count is authoritative: `nil` means absent/invalid, an explicit `0`
+    /// means the provider decoded nothing (infeasible), and any positive value
+    /// is the all-channel decode count.
+    ///
+    ///  1. **Decoded count present (authoritative).**
+    ///     a. `== 0` → `(.infinity, 0)` — the provider reports it decoded
+    ///        nothing; infeasible regardless of any observed content (round-2
+    ///        code MEDIUM-2).
+    ///     b. `> 0` AND `usageGenerationMS != nil && ms >= 1` → provider-timed:
+    ///        `usageDecodedTokens / max(0.001, ms/1000)`. This is the only
+    ///        correct path for reasoning models: their analysis channel is
+    ///        silent in SSE, so client-observed timing cannot see the decode
+    ///        window at all. The 1 ms floor bounds throughput (round-2 security
+    ///        HIGH: a fractional/sub-ms window otherwise inflates TPS).
+    ///     c. `> 0` with no usable ms → warm-generation window when a visible
+    ///        token was seen (`ended - firstTokenAt`), else the full request
+    ///        window (`ended - started`); both floored at 0.001s. Conservative
+    ///        but positive.
+    ///  2. **Decoded count absent (`nil`).**
+    ///     a. Legacy content window for older serve builds (non-reasoning
+    ///        models) that stream visible content but no vendor usage fields:
+    ///        `contentFallbackTokens / max(0.001, ended - firstTokenAt)`.
+    ///     b. else → `(.infinity, 0)`, the genuinely-infeasible case.
+    ///
+    /// TTFT is the first-content-token elapsed when a visible token was seen;
+    /// otherwise the full request elapsed (best available signal for a
+    /// reasoning-only stream). It is NEVER `.infinity` when tokens were
+    /// decoded.
+    static func finalizeProbeMetrics(
+        contentFallbackTokens: Int,
+        usageDecodedTokens: Int?,
+        usageGenerationMS: Int?,
+        firstTokenAt: Date?,
+        started: Date,
+        ended: Date
+    ) -> (ttftMS: Double, throughputTPS: Double) {
+        // TTFT: time to first content token when observed; otherwise the
+        // full request elapsed (best available signal for a reasoning-only
+        // stream). Computed up front so every non-infeasible branch shares it.
+        let ttftMS = firstTokenAt.map { max(0, $0.timeIntervalSince(started) * 1_000) }
+            ?? max(0, ended.timeIntervalSince(started) * 1_000)
+
+        // Branch 1: authoritative decoded-token count present (may be 0).
+        if let usageDecodedTokens {
+            // 1a: an authoritative 0 means the provider decoded nothing —
+            // infeasible regardless of any observed content.
+            if usageDecodedTokens == 0 {
+                return (ttftMS: .infinity, throughputTPS: 0)
+            }
+            // 1b: provider-timed. Only when the vendor decode window is present,
+            // at least 1 whole millisecond, AND not larger than the observed
+            // request wall-time (plus a small tolerance for clock skew /
+            // measurement boundaries). The decode window is a subset of the
+            // request, so a value exceeding the observed request duration —
+            // e.g. an overflowed `Int64.max` that would otherwise yield a
+            // garbage ~0 TPS "feasible" replicate — is malformed and ignored,
+            // falling through to the conservative client-timed window. Floor
+            // the denominator at 1 ms.
+            let requestElapsedMS = max(0, ended.timeIntervalSince(started) * 1_000)
+            let generationWindowToleranceMS = 250.0
+            if let usageGenerationMS, usageGenerationMS >= 1,
+               Double(usageGenerationMS) <= requestElapsedMS + generationWindowToleranceMS {
+                let generationElapsedSec = max(0.001, Double(usageGenerationMS) / 1000)
+                return (ttftMS: ttftMS, throughputTPS: Double(usageDecodedTokens) / generationElapsedSec)
+            }
+            // 1c: decoded count but no usable timing — divide by the
+            // warm-generation window when a visible token was seen, else the
+            // full request window. Both floored at 0.001s.
+            if let firstTokenAt {
+                let generationElapsed = max(0.001, ended.timeIntervalSince(firstTokenAt))
+                return (ttftMS: ttftMS, throughputTPS: Double(usageDecodedTokens) / generationElapsed)
+            }
+            let requestElapsed = max(0.001, ended.timeIntervalSince(started))
+            return (ttftMS: ttftMS, throughputTPS: Double(usageDecodedTokens) / requestElapsed)
+        }
+
+        // Branch 2a: legacy warm-generation window for older serve builds
+        // (non-reasoning models) that stream visible content but no vendor
+        // usage fields. `firstTokenAt` is only set on a NON-empty content
+        // delta, so content was observed — at least one token was generated
+        // even when the delta/word count rounds to 0 (e.g. a whitespace-only
+        // delta like " "). `max(1, ...)` preserves the pre-existing Stage 1
+        // `max(1, deltaCount)` / Stage 2 `max(1, wordCount)` fallback and
+        // avoids a false-infeasible verdict on such legacy output.
+        if let firstTokenAt {
+            let fallbackTokens = max(1, contentFallbackTokens)
+            let generationElapsed = max(0.001, ended.timeIntervalSince(firstTokenAt))
+            return (ttftMS: ttftMS, throughputTPS: Double(fallbackTokens) / generationElapsed)
+        }
+
+        // Branch 2b: genuinely nothing generated.
+        return (ttftMS: .infinity, throughputTPS: 0)
+    }
+
+    /// Extracts the `usage` object from a payload IFF the payload is a
+    /// genuine terminal usage chunk: a valid JSON object with a top-level
+    /// `choices` key that is an EMPTY array and a `usage` object. A content
+    /// chunk that also carries `usage` has a non-empty `choices` array and is
+    /// rejected here so it is never mistaken for the terminal usage chunk.
+    private static func terminalUsageObject(from payload: String) -> [String: Any]? {
+        guard let data = payload.data(using: .utf8),
+              let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let choices = json["choices"] as? [Any], choices.isEmpty,
+              let usage = json["usage"] as? [String: Any]
+        else {
+            return nil
+        }
+        return usage
+    }
+
+    /// True when `num` is a JSON boolean masquerading as an `NSNumber`
+    /// (`true`/`false` bridge to `NSNumber` and would otherwise pass numeric
+    /// checks as 1/0).
+    private static func isBoolean(_ num: NSNumber) -> Bool {
+        CFGetTypeID(num) == CFBooleanGetTypeID()
+    }
+
+    /// Parses the streamed terminal usage chunk (`choices: []` + top-level
+    /// `usage`) and returns the honest decode-token count for throughput
+    /// measurement.
+    ///
+    /// Prefers `usage.macprovider_generated_completion_tokens` — the total
+    /// tokens the model decoded across ALL channels (reasoning/analysis +
+    /// final). This is the correct throughput numerator: for Harmony
+    /// reasoning models (gpt-oss-20b) the analysis channel is suppressed
+    /// from `completion_tokens`, so on the probe's gibberish prompt
+    /// `completion_tokens` can be ~0 while real decode work happened.
+    /// Falls back to `usage.completion_tokens` for older serve builds that
+    /// predate the namespaced field (non-reasoning models, where the two
+    /// are equal).
+    ///
+    /// Hardened against malformed/hostile values: rejects booleans,
+    /// non-integral (fractional) numbers, negatives, and values greater than
+    /// `maxTokens` (the probe caps `max_tokens` at `maxTokens`; an honest
+    /// provider cannot decode more completion tokens than the cap, so a
+    /// larger value — including an overflowed `Int.max` — is malformed).
+    /// Returns nil for ordinary content chunks, `[DONE]`, malformed payloads,
+    /// and any value failing validation, which makes finalization fall back
+    /// rather than trust an inflated count.
+    static func usageDecodedTokens(from payload: String) -> Int? {
+        guard let usage = terminalUsageObject(from: payload) else {
+            return nil
+        }
+        // Round-2 code MEDIUM-1: when the namespaced field is PRESENT it is
+        // authoritative — its validation result (which is nil for a bool,
+        // fractional, negative, or over-cap value) is returned as-is. We must
+        // NOT fall back to `completion_tokens` in that case, or a hostile
+        // provider could suppress the honest all-channel count with a
+        // malformed value and have the probe trust the (possibly ~0)
+        // final-channel `completion_tokens` instead.
+        if let generatedRaw = usage["macprovider_generated_completion_tokens"] {
+            guard let generated = generatedRaw as? NSNumber else { return nil }
+            return validatedTokenCount(generated)
+        }
+        if let completionTokens = usage["completion_tokens"] as? NSNumber {
+            return validatedTokenCount(completionTokens)
+        }
+        return nil
+    }
+
+    /// Validates an `NSNumber` token count: not a boolean, integral,
+    /// nonnegative, and not greater than `maxTokens`. Returns the `Int` value
+    /// or nil.
+    private static func validatedTokenCount(_ num: NSNumber) -> Int? {
+        guard !isBoolean(num) else { return nil }
+        let value = num.doubleValue
+        guard value.isFinite else { return nil }
+        // Integral check: reject fractional values.
+        guard Double(num.int64Value) == value else { return nil }
+        let tokens = num.int64Value
+        guard tokens >= 0, tokens <= Int64(maxTokens) else { return nil }
+        return Int(tokens)
+    }
+
+    /// Parses the provider-reported warm-decode wall-time
+    /// (`macprovider_generation_ms`) from the terminal usage chunk. The
+    /// provider emits this as an `Int64` (whole milliseconds), so the value
+    /// must be a non-boolean, finite, integral, nonnegative `NSNumber`.
+    /// Round-2 security HIGH: a lenient `Double` accepted sub-millisecond
+    /// values (e.g. `0.001`) that inflated throughput by ~10^6; rejecting
+    /// fractional/negative/non-finite values (→ nil) forces finalization onto
+    /// a floored, honest window. Returns whole `Int` milliseconds, else nil.
+    static func usageGenerationMS(from payload: String) -> Int? {
+        guard let usage = terminalUsageObject(from: payload),
+              let generationMS = usage["macprovider_generation_ms"] as? NSNumber,
+              !isBoolean(generationMS)
+        else {
+            return nil
+        }
+        let value = generationMS.doubleValue
+        guard value.isFinite else { return nil }
+        // Integral check: reject fractional values.
+        guard Double(generationMS.int64Value) == value else { return nil }
+        let ms = generationMS.int64Value
+        guard ms >= 0 else { return nil }
+        return Int(ms)
+    }
+
+    static func contentDelta(from payload: String) -> String? {
         guard let data = payload.data(using: .utf8),
               let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
               let choices = json["choices"] as? [[String: Any]],
@@ -669,7 +886,9 @@ struct Stage1Prober: Stage1Probing {
         let sorted = values.sorted()
         let mid = sorted.count / 2
         if sorted.count.isMultiple(of: 2) {
-            return (sorted[mid - 1] + sorted[mid]) / 2
+            // Overflow-safe average (round-2 security MEDIUM): `a/2 + b/2`
+            // avoids the intermediate `a + b` overflowing to `.infinity`.
+            return sorted[mid - 1] / 2 + sorted[mid] / 2
         }
         return sorted[mid]
     }

--- a/phase3-binary/Sources/macprovider-cli/Stage2HillClimb.swift
+++ b/phase3-binary/Sources/macprovider-cli/Stage2HillClimb.swift
@@ -436,6 +436,19 @@ struct Stage2Prober: Stage2Probing {
                         measuredPromptTokens: measuredPromptTokens
                     )
                 }
+                // Reject non-finite TTFT / non-positive throughput BEFORE
+                // recording the replicate. finalizeProbeMetrics returns
+                // `(.infinity, 0)` for a stream that generated nothing (empty
+                // or zero-usage). This guard MUST run independent of
+                // `gateTTFTMS`: when `gateTTFTMS == 0` disables the TTFT
+                // ceiling below, an unguarded `(0, ∞)` replicate would be
+                // appended and yield `.feasible(medianTPS: 0, p95TTFTMS: ∞)`
+                // — an infeasible cell wrongly marked feasible.
+                guard result.throughputTPS.isFinite, result.throughputTPS > 0, result.ttftMS.isFinite else {
+                    nErr += 1
+                    firstFailure = firstFailure ?? "probe produced no measurable throughput (TPS \(result.throughputTPS), TTFT \(result.ttftMS)ms)"
+                    continue
+                }
                 // gateTTFTMS == 0 means the ceiling is disabled (#742: no 60s default).
                 if gateTTFTMS > 0, result.ttftMS > Double(gateTTFTMS) {
                     nErr += 1
@@ -480,9 +493,25 @@ struct Stage2Prober: Stage2Probing {
             )
         }
 
+        // Round-2 security MEDIUM: guard the cell aggregate before declaring it
+        // feasible. Even with the per-replicate guards above, the median of
+        // enormous-but-finite per-replicate values can overflow to `.infinity`
+        // (the averaging is now overflow-safe, but this backstops any residual
+        // non-finite/non-positive aggregate). A non-finite or non-positive
+        // aggregate is an infeasible cell, never a winner.
+        let medianTPS = median(throughputs)
+        let p95TTFTMS = percentile95(ttfts)
+        guard medianTPS.isFinite, medianTPS > 0, p95TTFTMS.isFinite else {
+            return .infeasible(
+                reason: "Stage 2 aggregate produced invalid metrics (median TPS \(medianTPS), p95 TTFT \(p95TTFTMS)ms)",
+                nErr: replicateCount,
+                measuredPromptTokens: measuredPromptTokens
+            )
+        }
+
         return .feasible(
-            medianTPS: median(throughputs),
-            p95TTFTMS: percentile95(ttfts),
+            medianTPS: medianTPS,
+            p95TTFTMS: p95TTFTMS,
             measuredPromptTokens: measuredPromptTokens
         )
     }
@@ -510,6 +539,20 @@ struct Stage2Prober: Stage2Probing {
         let statusCode = (response as? HTTPURLResponse)?.statusCode ?? 0
         var generatedText = ""
         var firstTokenAt: Date?
+        // Reasoning models (gpt-oss-20b / Harmony) suppress their
+        // analysis/reasoning channel from `delta.content`, so on the
+        // probe's nonsense padded prompt they generate tokens but emit
+        // ZERO visible content deltas. The provider closes the stream with
+        // a usage chunk (`choices: []` + `usage`) that carries the honest
+        // total decode count in `macprovider_generated_completion_tokens`
+        // (all channels incl. suppressed reasoning; HTTPServer.swift
+        // `usage()`) and the warm-decode wall-time in
+        // `macprovider_generation_ms`. Track the latest reported values so
+        // finalization can derive throughput from them, not from counting
+        // visible content deltas — otherwise reasoning models measure
+        // 0 tok/s and are wrongly marked infeasible.
+        var usageDecodedTokens: Int?
+        var usageGenerationMS: Int?
 
         for try await rawLine in bytes.lines {
             guard rawLine.hasPrefix("data:") else {
@@ -518,6 +561,12 @@ struct Stage2Prober: Stage2Probing {
             let payload = rawLine.dropFirst(5).trimmingCharacters(in: .whitespacesAndNewlines)
             if payload == "[DONE]" {
                 break
+            }
+            if let usage = Stage1Prober.usageDecodedTokens(from: payload) {
+                usageDecodedTokens = usage
+            }
+            if let generationMS = Stage1Prober.usageGenerationMS(from: payload) {
+                usageGenerationMS = generationMS
             }
             guard let content = Self.contentDelta(from: payload), !content.isEmpty else {
                 continue
@@ -528,23 +577,25 @@ struct Stage2Prober: Stage2Probing {
             generatedText += content
         }
 
-        guard let firstTokenAt else {
-            return Stage2SingleProbeResult(
-                statusCode: statusCode,
-                ttftMS: .infinity,
-                generatedText: generatedText,
-                throughputTPS: 0
-            )
-        }
-
         let ended = clock()
-        let outputTokens = max(1, generatedText.split(whereSeparator: \.isWhitespace).count)
-        let elapsed = max(0.001, ended.timeIntervalSince(started))
+        // Share Stage 1's finalization so both stages agree on decode
+        // throughput and the reasoning-model fallback. Stage 2 preserves its
+        // historical content-fallback numerator (word count of the visible
+        // text) for older serve builds without the vendor timing field.
+        let contentWordCount = generatedText.split(whereSeparator: \.isWhitespace).count
+        let metrics = Stage1Prober.finalizeProbeMetrics(
+            contentFallbackTokens: contentWordCount,
+            usageDecodedTokens: usageDecodedTokens,
+            usageGenerationMS: usageGenerationMS,
+            firstTokenAt: firstTokenAt,
+            started: started,
+            ended: ended
+        )
         return Stage2SingleProbeResult(
             statusCode: statusCode,
-            ttftMS: max(0, firstTokenAt.timeIntervalSince(started) * 1_000),
+            ttftMS: metrics.ttftMS,
             generatedText: generatedText,
-            throughputTPS: Double(outputTokens) / elapsed
+            throughputTPS: metrics.throughputTPS
         )
     }
 
@@ -568,19 +619,32 @@ struct Stage2Prober: Stage2Probing {
     }
 
     private func percentile95(_ values: [Double]) -> Double {
+        Stage2Prober.percentile95(values)
+    }
+
+    static func percentile95(_ values: [Double]) -> Double {
         let sorted = values.sorted()
         let index = max(0, min(sorted.count - 1, Int(ceil(Double(sorted.count) * 0.95)) - 1))
         return sorted[index]
     }
 
     private func median(_ values: [Double]) -> Double {
+        Stage2Prober.median(values)
+    }
+
+    /// Overflow-safe median. Internal (not private) so the round-2 security
+    /// MEDIUM overflow guard is directly unit-testable.
+    static func median(_ values: [Double]) -> Double {
         guard !values.isEmpty else {
             return 0
         }
         let sorted = values.sorted()
         let mid = sorted.count / 2
         if sorted.count.isMultiple(of: 2) {
-            return (sorted[mid - 1] + sorted[mid]) / 2
+            // Round-2 security MEDIUM: average as `a/2 + b/2` rather than
+            // `(a + b) / 2` so two enormous-but-finite middle values do not
+            // overflow to `.infinity` before the aggregate guard runs.
+            return sorted[mid - 1] / 2 + sorted[mid] / 2
         }
         return sorted[mid]
     }

--- a/phase3-binary/Tests/macprovider-cliTests/HTTPServerReceiptTests.swift
+++ b/phase3-binary/Tests/macprovider-cliTests/HTTPServerReceiptTests.swift
@@ -83,6 +83,7 @@ final class HTTPServerReceiptTests: XCTestCase {
                 completionTokens: 0,
                 generatedCompletionTokens: 7,
                 ttftMilliseconds: 7,
+                generationMilliseconds: 350,
                 toolCalls: [
                     ToolCall(
                         id: "call_fixture",
@@ -99,6 +100,16 @@ final class HTTPServerReceiptTests: XCTestCase {
         XCTAssertEqual(response.status, .ok, response.body)
         XCTAssertEqual(parsed.tuple["tokens_out"] as? Int, 7)
         XCTAssertTrue(response.body.contains(#""completion_tokens":0"#), response.body)
+        // The `usage` object also exposes the honest total decode count
+        // (all channels incl. suppressed reasoning) as an additive vendor
+        // field, WITHOUT changing `completion_tokens`. The autotune
+        // throughput probe reads this so reasoning models (whose visible
+        // final count can be 0 on a probe prompt) measure non-zero tok/s.
+        XCTAssertTrue(response.body.contains(#""macprovider_generated_completion_tokens":7"#), response.body)
+        // The provider-measured warm-decode wall-time is surfaced in the same
+        // `usage` object so the autotune probe can divide total decoded tokens
+        // by it. Additive; does not change `completion_tokens`.
+        XCTAssertTrue(response.body.contains(#""macprovider_generation_ms":350"#), response.body)
         XCTAssertTrue(parsed.publicKey.isValidSignature(parsed.signature, for: parsed.tupleData))
     }
 

--- a/phase3-binary/Tests/macprovider-cliTests/Spec028PlumbingTests.swift
+++ b/phase3-binary/Tests/macprovider-cliTests/Spec028PlumbingTests.swift
@@ -352,6 +352,42 @@ final class Spec028PlumbingTests: XCTestCase {
         XCTAssertEqual(loadPath, "/models/local-smoke")
     }
 
+    /// Round-2 code MEDIUM-3 (Fix E): an autotune candidate with a draft model
+    /// configured (via flag/env/config, all collapsing into the resolved
+    /// AppConfig) must resolve to NO draft model, so the speculative route —
+    /// whose decode loop never fires the outer decode timer — is never taken
+    /// and the probe always exercises the main, timed decode path.
+    func testAutotuneCandidateSuppressesResolvedDraftModel() {
+        var config = AppConfig.defaults()
+        config.draftModel = "/models/draft"
+        config.draftModelArtifactSHA256 = String(repeating: "a", count: 64)
+
+        ServeCommand.applyAutotuneCandidateDraftSuppression(&config, autotuneCandidate: true)
+
+        XCTAssertNil(config.draftModel,
+            "autotune candidate must resolve to no draft model (speculative decode disabled)")
+        XCTAssertNil(config.draftModelArtifactSHA256,
+            "the draft artifact hash must be cleared alongside the draft model")
+
+        // Downstream capacity preflight must now be a no-op (no draft model).
+        var followOn = config
+        XCTAssertNoThrow(try ServeCommand.runSpecDecodeCapacityPreflight(&followOn))
+    }
+
+    /// Non-candidate serve must keep its configured draft model untouched.
+    func testNonAutotuneCandidateKeepsResolvedDraftModel() {
+        var config = AppConfig.defaults()
+        config.draftModel = "/models/draft"
+        let hash = String(repeating: "b", count: 64)
+        config.draftModelArtifactSHA256 = hash
+
+        ServeCommand.applyAutotuneCandidateDraftSuppression(&config, autotuneCandidate: false)
+
+        XCTAssertEqual(config.draftModel, "/models/draft",
+            "a normal serve must retain its draft model")
+        XCTAssertEqual(config.draftModelArtifactSHA256, hash)
+    }
+
     func testTokenizerArtifactFingerprintBindsTokenizerFiles() throws {
         let first = try makeTokenizerSnapshot(tokenizerJSON: #"{"model":"same"}"#, configJSON: #"{"eos_token":"</s>"}"#)
         let matching = try makeTokenizerSnapshot(tokenizerJSON: #"{"model":"same"}"#, configJSON: #"{"eos_token":"</s>"}"#)

--- a/phase3-binary/Tests/macprovider-cliTests/Stage1IteratorTests.swift
+++ b/phase3-binary/Tests/macprovider-cliTests/Stage1IteratorTests.swift
@@ -439,6 +439,467 @@ final class Stage1IteratorTests: XCTestCase {
         XCTAssertGreaterThan(medianTPS, 0)
     }
 
+    // MARK: - Reasoning-model throughput fix
+
+    /// Reasoning models (gpt-oss-20b / Harmony) suppress their analysis
+    /// channel from `delta.content`, so the probe sees ZERO content
+    /// deltas AND — crucially — the provider reports `completion_tokens`
+    /// = 0 (visible-final only) for a probe that elicits no final answer.
+    /// The honest decode count lives in the additive vendor field
+    /// `macprovider_generated_completion_tokens`. This end-to-end test
+    /// drives the prober against a server that emits only empty-content
+    /// deltas + a usage chunk with `completion_tokens: 0` and the
+    /// generated-tokens field, and asserts the candidate is feasible with
+    /// positive throughput — NOT the 0 tok/s "invalid throughput"
+    /// infeasible verdict that pre-fix code (and a completion_tokens-only
+    /// fix) produced.
+    func testStage1ProberReasoningOnlyStreamUsesGeneratedTokens() async throws {
+        let port = try unusedPort()
+        let runner = try CandidateProviderRunner(
+            providerBinaryPath: try reasoningOnlyUsageScript(generatedTokens: 40).path,
+            logDirectory: try temporaryDirectory(name: "stage1-reasoning-only-logs")
+        )
+
+        let result = try await Stage1Prober(readyTimeoutSec: 10, stopGraceSeconds: 1).probe(
+            model: "gpt-oss-20b",
+            port: port,
+            runner: runner,
+            targetContext: 64,
+            gateTTFTMS: 60_000,
+            replicates: 1
+        )
+
+        guard case .feasible(let medianTPS, _) = result else {
+            return XCTFail("reasoning-only stream must be feasible, got \(result)")
+        }
+        XCTAssertGreaterThan(medianTPS, 0,
+            "macprovider_generated_completion_tokens must yield positive throughput for reasoning models even when completion_tokens is 0")
+        // 40 decoded tokens / 2000ms provider decode window = 20 tok/s. The
+        // measured median must track the PROVIDER-reported decode rate, not
+        // a client-timed artifact.
+        XCTAssertEqual(medianTPS, 20.0, accuracy: 0.5,
+            "throughput must equal the provider-reported decode rate (40 tokens / 2000ms = 20 tok/s)")
+    }
+
+    /// Unit: reasoning-only finalization. No content deltas
+    /// (`firstTokenAt == nil`) but a decode-token count → throughput
+    /// derived from it over the full request window, TTFT finite.
+    func testFinalizeProbeMetricsReasoningOnlyStream() {
+        let started = Date(timeIntervalSince1970: 1_000)
+        let ended = started.addingTimeInterval(2.0)
+        // Branch 3: a decoded-token count but no provider timing and no
+        // visible token → divide by the full request window (conservative).
+        let metrics = Stage1Prober.finalizeProbeMetrics(
+            contentFallbackTokens: 0,
+            usageDecodedTokens: 50,
+            usageGenerationMS: nil,
+            firstTokenAt: nil,
+            started: started,
+            ended: ended
+        )
+        XCTAssertEqual(metrics.throughputTPS, 25.0, accuracy: 0.0001,
+            "50 tokens / 2s full window = 25 tok/s")
+        XCTAssertEqual(metrics.ttftMS, 2_000, accuracy: 0.0001,
+            "no content token observed → TTFT falls back to full elapsed")
+        XCTAssertTrue(metrics.ttftMS.isFinite)
+    }
+
+    /// Unit: provider-timed path (branch 1). When the usage chunk carries
+    /// BOTH a decoded-token count and `macprovider_generation_ms`,
+    /// throughput = tokens / (generationMS / 1000) — the authoritative,
+    /// all-channel decode rate, independent of client-observed timing.
+    func testFinalizeProbeMetricsProviderTimedIsAuthoritative() {
+        let started = Date(timeIntervalSince1970: 1_000)
+        let firstTokenAt = started.addingTimeInterval(0.2)
+        let ended = started.addingTimeInterval(1.2)
+        let metrics = Stage1Prober.finalizeProbeMetrics(
+            contentFallbackTokens: 10,
+            usageDecodedTokens: 12,
+            usageGenerationMS: 1_000,
+            firstTokenAt: firstTokenAt,
+            started: started,
+            ended: ended
+        )
+        XCTAssertEqual(metrics.throughputTPS, 12.0, accuracy: 0.0001,
+            "12 decoded tokens / 1s provider decode window = 12 tok/s")
+        XCTAssertEqual(metrics.ttftMS, 200, accuracy: 0.0001)
+    }
+
+    /// Unit: the MIXED reasoning+final case that fixes the HIGH. A stream
+    /// with 5s of silent reasoning then 1s of visible final output reports
+    /// 110 total decoded tokens over a 6000ms provider decode window. The
+    /// client-observed content window (`ended - firstTokenAt` = 1s) would
+    /// wrongly yield 110 tok/s; the provider-timed path must yield
+    /// ≈18.3 tok/s.
+    func testFinalizeProbeMetricsMixedReasoningAndFinal() {
+        let started = Date(timeIntervalSince1970: 1_000)
+        let firstTokenAt = started.addingTimeInterval(5.0)
+        let ended = started.addingTimeInterval(6.0)
+        let metrics = Stage1Prober.finalizeProbeMetrics(
+            contentFallbackTokens: 20,
+            usageDecodedTokens: 110,
+            usageGenerationMS: 6_000,
+            firstTokenAt: firstTokenAt,
+            started: started,
+            ended: ended
+        )
+        XCTAssertEqual(metrics.throughputTPS, 110.0 / 6.0, accuracy: 0.01,
+            "110 tokens / 6s provider decode window ≈ 18.3 tok/s, NOT 110")
+        XCTAssertLessThan(metrics.throughputTPS, 20,
+            "must NOT report the content-window rate (110 tok/s)")
+        XCTAssertEqual(metrics.ttftMS, 5_000, accuracy: 0.0001)
+    }
+
+    /// Unit (code round-3 MEDIUM): a `usageGenerationMS` larger than the
+    /// observed request wall-time is malformed — the decode window is a
+    /// subset of the request. An overflowed `Int64.max` must NOT be trusted
+    /// (it would yield a garbage ~0 TPS "feasible" replicate); the provider
+    /// branch (1b) is skipped and finalization falls through to the
+    /// conservative client-timed window (1c here, since a visible token was
+    /// seen).
+    func testFinalizeProbeMetricsRejectsGenerationMSExceedingRequestWindow() {
+        let started = Date(timeIntervalSince1970: 1_000)
+        let firstTokenAt = started.addingTimeInterval(0.2)
+        let ended = started.addingTimeInterval(1.2)
+
+        // Int64.max ms → absurdly larger than the 1.2s request → ignored.
+        let overflow = Stage1Prober.finalizeProbeMetrics(
+            contentFallbackTokens: 10,
+            usageDecodedTokens: 40,
+            usageGenerationMS: Int(Int64.max),
+            firstTokenAt: firstTokenAt,
+            started: started,
+            ended: ended
+        )
+        // Falls to 1c: decoded count (40) over the warm-generation window (1s).
+        XCTAssertEqual(overflow.throughputTPS, 40.0, accuracy: 0.0001,
+            "generation_ms > request window must be ignored, not trusted")
+
+        // A merely-too-large value (5s reported for a 1.2s request) is also
+        // rejected.
+        let tooLarge = Stage1Prober.finalizeProbeMetrics(
+            contentFallbackTokens: 10,
+            usageDecodedTokens: 40,
+            usageGenerationMS: 5_000,
+            firstTokenAt: firstTokenAt,
+            started: started,
+            ended: ended
+        )
+        XCTAssertEqual(tooLarge.throughputTPS, 40.0, accuracy: 0.0001)
+    }
+
+    /// Unit: a `usageGenerationMS` within the observed request window (plus
+    /// tolerance) IS trusted as the provider decode window.
+    func testFinalizeProbeMetricsAcceptsGenerationMSWithinRequestWindow() {
+        let started = Date(timeIntervalSince1970: 1_000)
+        let ended = started.addingTimeInterval(2.0)
+        let metrics = Stage1Prober.finalizeProbeMetrics(
+            contentFallbackTokens: 0,
+            usageDecodedTokens: 40,
+            usageGenerationMS: 1_800,
+            firstTokenAt: nil,
+            started: started,
+            ended: ended
+        )
+        XCTAssertEqual(metrics.throughputTPS, 40.0 / 1.8, accuracy: 0.01,
+            "1800ms decode window inside the 2s request is authoritative")
+    }
+
+    /// Unit (code round-4 MEDIUM): a legacy stream with observed content but
+    /// a fallback token count of 0 (e.g. a whitespace-only delta whose word
+    /// split is empty) must NOT be infeasible — content was observed, so at
+    /// least one token counts. Preserves the prior `max(1, wordCount)` /
+    /// `max(1, deltaCount)` behavior.
+    func testFinalizeProbeMetricsContentObservedButZeroFallbackCountsAsOne() {
+        let started = Date(timeIntervalSince1970: 1_000)
+        let firstTokenAt = started.addingTimeInterval(0.2)
+        let ended = started.addingTimeInterval(1.2)
+        let metrics = Stage1Prober.finalizeProbeMetrics(
+            contentFallbackTokens: 0,
+            usageDecodedTokens: nil,
+            usageGenerationMS: nil,
+            firstTokenAt: firstTokenAt,
+            started: started,
+            ended: ended
+        )
+        XCTAssertEqual(metrics.throughputTPS, 1.0, accuracy: 0.0001,
+            "content observed → at least 1 token / 1s window = 1 tok/s, not infeasible")
+        XCTAssertTrue(metrics.throughputTPS.isFinite)
+        XCTAssertEqual(metrics.ttftMS, 200, accuracy: 0.0001)
+    }
+
+    /// Unit: content stream without a usage chunk (older serve builds).
+    /// Falls back (branch 2) to the content-delta count over the
+    /// generation window.
+    func testFinalizeProbeMetricsContentStreamWithoutUsage() {
+        let started = Date(timeIntervalSince1970: 1_000)
+        let firstTokenAt = started.addingTimeInterval(0.2)
+        let ended = started.addingTimeInterval(1.2)
+        let metrics = Stage1Prober.finalizeProbeMetrics(
+            contentFallbackTokens: 10,
+            usageDecodedTokens: nil,
+            usageGenerationMS: nil,
+            firstTokenAt: firstTokenAt,
+            started: started,
+            ended: ended
+        )
+        XCTAssertEqual(metrics.throughputTPS, 10.0, accuracy: 0.0001,
+            "10 deltas / 1s generation window = 10 tok/s")
+        XCTAssertEqual(metrics.ttftMS, 200, accuracy: 0.0001)
+    }
+
+    /// Unit: a decoded-token count present but `usageGenerationMS` == 0
+    /// (degenerate provider timing) must NOT divide by zero — the provider
+    /// branch (1b) requires ms >= 1. Round-2 code MEDIUM-2 branch order: the
+    /// authoritative decoded count (12) is preferred over the content-delta
+    /// fallback (10), divided by the warm-generation window (1c).
+    func testFinalizeProbeMetricsZeroGenerationMSFallsThrough() {
+        let started = Date(timeIntervalSince1970: 1_000)
+        let firstTokenAt = started.addingTimeInterval(0.2)
+        let ended = started.addingTimeInterval(1.2)
+        let metrics = Stage1Prober.finalizeProbeMetrics(
+            contentFallbackTokens: 10,
+            usageDecodedTokens: 12,
+            usageGenerationMS: 0,
+            firstTokenAt: firstTokenAt,
+            started: started,
+            ended: ended
+        )
+        XCTAssertEqual(metrics.throughputTPS, 12.0, accuracy: 0.0001,
+            "generationMS<1 → skip provider path; decoded count over the 1s warm window = 12 tok/s")
+        XCTAssertTrue(metrics.throughputTPS.isFinite)
+    }
+
+    /// Unit: truly empty generation (no content deltas AND no usage) →
+    /// throughput 0 with an infinite TTFT sentinel, preserving the
+    /// pre-existing infeasible verdict.
+    func testFinalizeProbeMetricsTrulyEmptyIsZero() {
+        let started = Date(timeIntervalSince1970: 1_000)
+        let ended = started.addingTimeInterval(1.0)
+        let metrics = Stage1Prober.finalizeProbeMetrics(
+            contentFallbackTokens: 0,
+            usageDecodedTokens: nil,
+            usageGenerationMS: nil,
+            firstTokenAt: nil,
+            started: started,
+            ended: ended
+        )
+        XCTAssertEqual(metrics.throughputTPS, 0)
+        XCTAssertEqual(metrics.ttftMS, .infinity)
+    }
+
+    /// Unit: an explicit decoded-token count of 0 also means nothing was
+    /// generated → throughput 0.
+    func testFinalizeProbeMetricsExplicitZeroUsageIsZero() {
+        let started = Date(timeIntervalSince1970: 1_000)
+        let ended = started.addingTimeInterval(1.0)
+        let metrics = Stage1Prober.finalizeProbeMetrics(
+            contentFallbackTokens: 0,
+            usageDecodedTokens: 0,
+            usageGenerationMS: nil,
+            firstTokenAt: nil,
+            started: started,
+            ended: ended
+        )
+        XCTAssertEqual(metrics.throughputTPS, 0)
+        XCTAssertEqual(metrics.ttftMS, .infinity)
+    }
+
+    /// Unit: the usage-chunk parser. Prefers the additive
+    /// `macprovider_generated_completion_tokens` (total decode count
+    /// incl. suppressed reasoning) over `completion_tokens`; falls back to
+    /// `completion_tokens` when the generated field is absent (older serve
+    /// builds); returns nil for ordinary content chunks, `[DONE]`, and
+    /// malformed payloads.
+    func testUsageDecodedTokensParsing() {
+        // Generated field present + completion_tokens 0 (the reasoning-only
+        // case): the generated field wins.
+        let reasoningChunk = #"{"choices":[],"usage":{"prompt_tokens":100,"completion_tokens":0,"macprovider_generated_completion_tokens":57,"total_tokens":100}}"#
+        XCTAssertEqual(Stage1Prober.usageDecodedTokens(from: reasoningChunk), 57,
+            "generated-tokens field must win over completion_tokens")
+
+        // Generated field present alongside a non-zero completion_tokens:
+        // still prefer the (larger) generated total (both within the
+        // max_tokens cap).
+        let bothChunk = #"{"choices":[],"usage":{"prompt_tokens":100,"completion_tokens":12,"macprovider_generated_completion_tokens":60,"total_tokens":112}}"#
+        XCTAssertEqual(Stage1Prober.usageDecodedTokens(from: bothChunk), 60)
+
+        // Older serve build without the generated field → fall back to
+        // completion_tokens.
+        let legacyChunk = #"{"choices":[],"usage":{"prompt_tokens":100,"completion_tokens":42,"total_tokens":142}}"#
+        XCTAssertEqual(Stage1Prober.usageDecodedTokens(from: legacyChunk), 42)
+
+        let contentChunk = #"{"choices":[{"delta":{"content":"hi"}}]}"#
+        XCTAssertNil(Stage1Prober.usageDecodedTokens(from: contentChunk))
+
+        XCTAssertNil(Stage1Prober.usageDecodedTokens(from: "[DONE]"))
+        XCTAssertNil(Stage1Prober.usageDecodedTokens(from: "not-valid-json"))
+
+        let usageNoTokens = #"{"choices":[],"usage":{"prompt_tokens":100}}"#
+        XCTAssertNil(Stage1Prober.usageDecodedTokens(from: usageNoTokens))
+    }
+
+    /// Unit: hardened usage-chunk parser rejects malformed/hostile values.
+    /// Each must return nil so finalization falls back rather than trusting
+    /// an inflated or nonsensical count.
+    func testUsageDecodedTokensParserHardening() {
+        // Boolean masquerading as a number (JSON `true` bridges to NSNumber).
+        let boolChunk = #"{"choices":[],"usage":{"macprovider_generated_completion_tokens":true}}"#
+        XCTAssertNil(Stage1Prober.usageDecodedTokens(from: boolChunk),
+            "boolean token count must be rejected")
+
+        // Fractional (non-integral) value.
+        let fractionalChunk = #"{"choices":[],"usage":{"macprovider_generated_completion_tokens":12.5}}"#
+        XCTAssertNil(Stage1Prober.usageDecodedTokens(from: fractionalChunk),
+            "fractional token count must be rejected")
+
+        // Negative value.
+        let negativeChunk = #"{"choices":[],"usage":{"macprovider_generated_completion_tokens":-3}}"#
+        XCTAssertNil(Stage1Prober.usageDecodedTokens(from: negativeChunk),
+            "negative token count must be rejected")
+
+        // Int.max — an overflow/garbage sentinel far above the cap.
+        let intMaxChunk = #"{"choices":[],"usage":{"macprovider_generated_completion_tokens":9223372036854775807}}"#
+        XCTAssertNil(Stage1Prober.usageDecodedTokens(from: intMaxChunk),
+            "Int.max token count must be rejected")
+
+        // Greater than the probe's max_tokens cap (64): an honest provider
+        // cannot decode more completion tokens than the cap.
+        let oversizedChunk = #"{"choices":[],"usage":{"macprovider_generated_completion_tokens":65}}"#
+        XCTAssertNil(Stage1Prober.usageDecodedTokens(from: oversizedChunk),
+            "value > maxTokens must be rejected")
+        // Exactly the cap is valid.
+        let atCapChunk = #"{"choices":[],"usage":{"macprovider_generated_completion_tokens":64}}"#
+        XCTAssertEqual(Stage1Prober.usageDecodedTokens(from: atCapChunk), 64)
+
+        // A content chunk that ALSO carries usage (non-empty choices) must
+        // NOT be treated as the terminal usage chunk.
+        let contentWithUsage = #"{"choices":[{"delta":{"content":"hi"}}],"usage":{"macprovider_generated_completion_tokens":50}}"#
+        XCTAssertNil(Stage1Prober.usageDecodedTokens(from: contentWithUsage),
+            "non-empty choices must not be treated as terminal usage chunk")
+
+        // The valid reasoning chunk still parses.
+        let validChunk = #"{"choices":[],"usage":{"completion_tokens":0,"macprovider_generated_completion_tokens":57}}"#
+        XCTAssertEqual(Stage1Prober.usageDecodedTokens(from: validChunk), 57)
+    }
+
+    /// Unit: `usageGenerationMS` parser — terminal-shape checks plus a
+    /// non-boolean, finite, integral, nonnegative whole-millisecond value.
+    func testUsageGenerationMSParsing() {
+        let validChunk = #"{"choices":[],"usage":{"macprovider_generated_completion_tokens":40,"macprovider_generation_ms":2000}}"#
+        XCTAssertEqual(Stage1Prober.usageGenerationMS(from: validChunk), 2000)
+
+        // Round-2 security HIGH: the provider emits whole-ms Int64. A
+        // fractional value is malformed and must be rejected (a lenient Double
+        // accepting `0.001` inflated throughput by ~10^6).
+        let fractionalChunk = #"{"choices":[],"usage":{"macprovider_generation_ms":1234.5}}"#
+        XCTAssertNil(Stage1Prober.usageGenerationMS(from: fractionalChunk),
+            "fractional generation_ms must be rejected")
+
+        // Sub-millisecond fraction (the exact HIGH exploit value) rejected.
+        let subMsChunk = #"{"choices":[],"usage":{"macprovider_generation_ms":0.001}}"#
+        XCTAssertNil(Stage1Prober.usageGenerationMS(from: subMsChunk),
+            "0.001ms must be rejected, not accepted as a 10^6x TPS multiplier")
+
+        // An integral value encoded as a JSON float (e.g. 2000.0) is still a
+        // whole number of ms and is accepted.
+        let integralFloatChunk = #"{"choices":[],"usage":{"macprovider_generation_ms":2000.0}}"#
+        XCTAssertEqual(Stage1Prober.usageGenerationMS(from: integralFloatChunk), 2000)
+
+        // Zero is a valid, finite, integral, nonnegative value (the caller's
+        // finalization treats ms < 1 as "no usable timing").
+        let zeroChunk = #"{"choices":[],"usage":{"macprovider_generation_ms":0}}"#
+        XCTAssertEqual(Stage1Prober.usageGenerationMS(from: zeroChunk), 0)
+
+        // Boolean rejected.
+        let boolChunk = #"{"choices":[],"usage":{"macprovider_generation_ms":true}}"#
+        XCTAssertNil(Stage1Prober.usageGenerationMS(from: boolChunk))
+
+        // Negative rejected.
+        let negativeChunk = #"{"choices":[],"usage":{"macprovider_generation_ms":-5}}"#
+        XCTAssertNil(Stage1Prober.usageGenerationMS(from: negativeChunk))
+
+        // Non-empty choices rejected.
+        let contentWithUsage = #"{"choices":[{"delta":{"content":"hi"}}],"usage":{"macprovider_generation_ms":2000}}"#
+        XCTAssertNil(Stage1Prober.usageGenerationMS(from: contentWithUsage))
+
+        // Absent field → nil.
+        let noField = #"{"choices":[],"usage":{"macprovider_generated_completion_tokens":40}}"#
+        XCTAssertNil(Stage1Prober.usageGenerationMS(from: noField))
+
+        XCTAssertNil(Stage1Prober.usageGenerationMS(from: "[DONE]"))
+        XCTAssertNil(Stage1Prober.usageGenerationMS(from: "not-valid-json"))
+    }
+
+    /// Round-2 security HIGH: a valid integer ms drives the provider-timed
+    /// branch, and the denominator is floored at 1 ms (0.001s) so throughput
+    /// stays bounded even at the minimum reportable window. The pre-fix lenient
+    /// Double path let `0.001` ms give `64 / (0.001/1000)` = 64,000,000 TPS;
+    /// the floored integer path caps ms=1 at `64 / 0.001s` = 64,000 TPS.
+    func testFinalizeProbeMetricsProviderTimedUsesOneMillisecondFloor() {
+        let started = Date(timeIntervalSince1970: 1_000)
+        let ended = started.addingTimeInterval(2.0)
+        let metrics = Stage1Prober.finalizeProbeMetrics(
+            contentFallbackTokens: 0,
+            usageDecodedTokens: 64,
+            usageGenerationMS: 1,
+            firstTokenAt: nil,
+            started: started,
+            ended: ended
+        )
+        XCTAssertEqual(metrics.throughputTPS, 64.0 / 0.001, accuracy: 0.0001,
+            "ms=1 floors the denominator at 0.001s → 64,000 TPS, not an unbounded value")
+        XCTAssertTrue(metrics.throughputTPS.isFinite)
+    }
+
+    /// Round-2 code MEDIUM-2 (Fix D): an authoritative decoded-count of 0 means
+    /// the provider decoded nothing — infeasible — even when a stray content
+    /// delta was observed and a first-token time exists. The count is
+    /// authoritative over the content fallback.
+    func testFinalizeProbeMetricsAuthoritativeZeroBeatsContentFallback() {
+        let started = Date(timeIntervalSince1970: 1_000)
+        let firstTokenAt = started.addingTimeInterval(0.2)
+        let ended = started.addingTimeInterval(1.2)
+        let metrics = Stage1Prober.finalizeProbeMetrics(
+            contentFallbackTokens: 1,
+            usageDecodedTokens: 0,
+            usageGenerationMS: nil,
+            firstTokenAt: firstTokenAt,
+            started: started,
+            ended: ended
+        )
+        XCTAssertEqual(metrics.throughputTPS, 0,
+            "authoritative decoded-count 0 → infeasible regardless of observed content")
+        XCTAssertEqual(metrics.ttftMS, .infinity)
+    }
+
+    /// Round-2 code MEDIUM-1 (Fix C): when the namespaced generated field is
+    /// PRESENT but invalid, the parser returns nil and must NOT silently fall
+    /// back to `completion_tokens`.
+    func testUsageDecodedTokensPresentButInvalidDoesNotFallBack() {
+        // Generated > maxTokens cap (65 > 64) with a valid completion_tokens 32:
+        // present-but-invalid → nil, NOT 32.
+        let overCapChunk = #"{"choices":[],"usage":{"completion_tokens":32,"macprovider_generated_completion_tokens":65}}"#
+        XCTAssertNil(Stage1Prober.usageDecodedTokens(from: overCapChunk),
+            "present-but-over-cap generated field must yield nil, not fall back to completion_tokens")
+
+        // Generated boolean with a valid completion_tokens 20 → nil.
+        let boolChunk = #"{"choices":[],"usage":{"completion_tokens":20,"macprovider_generated_completion_tokens":true}}"#
+        XCTAssertNil(Stage1Prober.usageDecodedTokens(from: boolChunk),
+            "present-but-boolean generated field must yield nil, not fall back to completion_tokens")
+
+        // Generated JSON null (present as NSNull) with valid completion_tokens → nil.
+        let nullChunk = #"{"choices":[],"usage":{"completion_tokens":20,"macprovider_generated_completion_tokens":null}}"#
+        XCTAssertNil(Stage1Prober.usageDecodedTokens(from: nullChunk),
+            "present-but-null generated field must yield nil, not fall back to completion_tokens")
+
+        // Sanity: when the generated field is genuinely ABSENT, completion_tokens
+        // is still used (unchanged fallback behavior).
+        let absentChunk = #"{"choices":[],"usage":{"completion_tokens":20}}"#
+        XCTAssertEqual(Stage1Prober.usageDecodedTokens(from: absentChunk), 20,
+            "absent generated field → fall back to completion_tokens")
+    }
+
     /// Round-1 K.1 closure: persistence-field assertion. The iterator
     /// MUST write Stage 1 rows with `stage = 1`, `replicates_n = stage1Replicates`,
     /// `max_context_cap = targetContext`, `kv_bits = NULL`,
@@ -952,6 +1413,104 @@ final class Stage1IteratorTests: XCTestCase {
                 time.sleep(delay)
                 chunk = json.dumps({"choices":[{"delta":{"content":response_text}}]})
                 client.sendall(f"data: {chunk}\\n\\n".encode())
+                client.sendall(b"data: [DONE]\\n\\n")
+                client.close()
+                continue
+            body = "not found"
+            client.sendall((
+                "HTTP/1.1 404 Not Found\\r\\n"
+                f"Content-Length: {len(body)}\\r\\n"
+                "Connection: close\\r\\n"
+                "\\r\\n"
+                f"{body}"
+            ).encode())
+            client.close()
+        """
+        try script.write(to: scriptURL, atomically: true, encoding: .utf8)
+        try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: scriptURL.path)
+        return scriptURL
+    }
+
+    /// Emits a reasoning-model stream faithful to the real provider:
+    /// empty-content deltas (the visible analysis channel gpt-oss
+    /// suppresses) followed by the terminal usage chunk with
+    /// `completion_tokens: 0` (visible-final only, as the real provider
+    /// reports when a probe elicits no final answer) AND the additive
+    /// `macprovider_generated_completion_tokens` carrying the honest total
+    /// decode count. The prober must derive throughput from the generated
+    /// field, not the (zero) content deltas or the (zero) completion_tokens.
+    private func reasoningOnlyUsageScript(generatedTokens: Int) throws -> URL {
+        let directory = try temporaryDirectory(name: "stage1-reasoning-only-provider")
+        let scriptURL = directory.appendingPathComponent("reasoning-only-provider")
+        let script = """
+        #!/usr/bin/env python3
+        import json, socket, sys, time
+
+        args = sys.argv[1:]
+        if "serve" not in args or "--no-join" not in args:
+            sys.stderr.write("expected serve --no-join\\n")
+            sys.exit(2)
+        port = int(args[args.index("--port") + 1])
+
+        server = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        server.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        server.bind(("127.0.0.1", port))
+        server.listen(16)
+        print("stage1 reasoning-only provider ready", flush=True)
+
+        generated_tokens = \(generatedTokens)
+        generation_ms = generated_tokens * 50
+
+        while True:
+            client, _ = server.accept()
+            request = client.recv(65536).decode("utf-8", "ignore")
+            if "GET /v1/models " in request:
+                body = '{"object":"list","data":[{"id":"stub","object":"model"}]}'
+                client.sendall((
+                    "HTTP/1.1 200 OK\\r\\n"
+                    "Content-Type: application/json\\r\\n"
+                    f"Content-Length: {len(body)}\\r\\n"
+                    "Connection: close\\r\\n"
+                    "\\r\\n"
+                    f"{body}"
+                ).encode())
+                client.close()
+                continue
+            if "POST /v1/chat/completions " in request:
+                client.sendall((
+                    "HTTP/1.1 200 OK\\r\\n"
+                    "Content-Type: text/event-stream\\r\\n"
+                    "Cache-Control: no-cache\\r\\n"
+                    "Connection: close\\r\\n"
+                    "\\r\\n"
+                ).encode())
+                # Reasoning models emit empty-content deltas (the parser
+                # skips them) while generating suppressed analysis tokens.
+                for _ in range(3):
+                    chunk = json.dumps({"choices":[{"delta":{"content":""}}]})
+                    client.sendall(f"data: {chunk}\\n\\n".encode())
+                # Spend real wall-time equal to the decode window we report,
+                # so the observed request duration contains it (the probe
+                # rejects a generation_ms larger than the request window).
+                time.sleep(generation_ms / 1000.0)
+                # Terminal usage chunk: completion_tokens is the visible-
+                # final count (0 for a reasoning-only probe); the honest
+                # total decode count is the macprovider vendor field.
+                usage_chunk = json.dumps({
+                    "choices": [],
+                    "usage": {
+                        "prompt_tokens": 51,
+                        "completion_tokens": 0,
+                        "macprovider_generated_completion_tokens": generated_tokens,
+                        # Provider-measured warm-decode wall-time. 50ms/token
+                        # → generated_tokens / (ms/1000) = 20 tok/s for the
+                        # 40-token fixture, the authoritative decode rate the
+                        # probe must report.
+                        "macprovider_generation_ms": generation_ms,
+                        "total_tokens": 51,
+                    },
+                })
+                client.sendall(f"data: {usage_chunk}\\n\\n".encode())
                 client.sendall(b"data: [DONE]\\n\\n")
                 client.close()
                 continue

--- a/phase3-binary/Tests/macprovider-cliTests/Stage2HillClimbTests.swift
+++ b/phase3-binary/Tests/macprovider-cliTests/Stage2HillClimbTests.swift
@@ -247,6 +247,261 @@ final class Stage2HillClimbTests: XCTestCase {
         ))
     }
 
+    // MARK: - Stage 2 feasibility guard + fallback (real prober)
+
+    /// Fix 2: a stream that generates NOTHING (empty SSE) yields
+    /// `(.infinity, 0)` from finalizeProbeMetrics. With `gateTTFTMS == 0` the
+    /// TTFT ceiling is disabled, so the pre-fix code appended a `(0, ∞)`
+    /// replicate and returned `.feasible(medianTPS: 0, p95TTFTMS: ∞)`. The
+    /// guard must reject the non-positive throughput / non-finite TTFT and
+    /// mark the cell infeasible — INDEPENDENT of `gateTTFTMS`.
+    func testStage2ProberEmptyStreamWithZeroGateIsInfeasible() async throws {
+        let port = try unusedPort()
+        let runner = try CandidateProviderRunner(
+            providerBinaryPath: try stage2EmptyStreamScript().path,
+            logDirectory: try temporaryDirectory(name: "stage2-empty-logs")
+        )
+
+        let result = try await Stage2Prober(readyTimeoutSec: 10, stopGraceSeconds: 1).probe(
+            model: "gpt-oss-20b",
+            port: port,
+            runner: runner,
+            knobs: WinningKnobs(kvBits: nil, maxBatch: 1, maxContext: 2_000),
+            targetContext: 64,
+            gateTTFTMS: 0,
+            replicates: 1
+        )
+
+        guard case .infeasible = result else {
+            return XCTFail("empty stream with gateTTFTMS==0 must be infeasible, got \(result)")
+        }
+    }
+
+    /// Fix 5: older serve builds emit multi-word content deltas but NO usage
+    /// chunk. Stage 2 must measure throughput from the WORD count of the
+    /// visible text (its historical fallback numerator), not the delta count.
+    /// The script emits 2 deltas of 15 words each (30 words, 2 deltas) then
+    /// holds the stream ~0.3s before closing, so the generation window is
+    /// well-defined: a word-count numerator yields ~100 tok/s while a
+    /// delta-count numerator would yield only ~6 tok/s.
+    func testStage2ProberOlderServerMeasuresFromWordCount() async throws {
+        let port = try unusedPort()
+        let runner = try CandidateProviderRunner(
+            providerBinaryPath: try stage2WordCountFallbackScript().path,
+            logDirectory: try temporaryDirectory(name: "stage2-wordcount-logs")
+        )
+
+        let result = try await Stage2Prober(readyTimeoutSec: 10, stopGraceSeconds: 1).probe(
+            model: "legacy-model",
+            port: port,
+            runner: runner,
+            knobs: WinningKnobs(kvBits: nil, maxBatch: 1, maxContext: 2_000),
+            targetContext: 64,
+            gateTTFTMS: 60_000,
+            replicates: 1
+        )
+
+        guard case .feasible(let medianTPS, _, _) = result else {
+            return XCTFail("older-server multi-word stream must be feasible, got \(result)")
+        }
+        // 30 words / ~0.3s ≈ 100 tok/s. A delta-count numerator (2 deltas)
+        // could reach at most ~6-7 tok/s over the same window. Assert well
+        // above that ceiling so only the word-count numerator can pass.
+        XCTAssertGreaterThan(medianTPS, 30,
+            "throughput must be derived from the word count, not the delta count; got \(medianTPS)")
+    }
+
+    /// Round-2 security MEDIUM (Fix B): the aggregate median that feeds a
+    /// `.feasible` cell must be overflow-safe. Two enormous-but-finite
+    /// per-replicate throughputs averaged as `(a + b) / 2` overflow to
+    /// `.infinity`; averaged as `a / 2 + b / 2` they stay finite. A finite
+    /// median then passes the `medianTPS.isFinite && medianTPS > 0` guard,
+    /// while an `.infinity` would have been rejected — either way the cell is
+    /// never marked `.feasible(medianTPS: .infinity)`.
+    func testStage2AggregateMedianIsOverflowSafe() {
+        let enormous = Double.greatestFiniteMagnitude
+        // Naive averaging overflows; confirm the harness's premise.
+        XCTAssertEqual((enormous + enormous) / 2, .infinity,
+            "premise: naive (a + b) / 2 overflows for two greatestFiniteMagnitude values")
+
+        let median = Stage2Prober.median([enormous, enormous])
+        XCTAssertTrue(median.isFinite,
+            "overflow-safe median must stay finite for two enormous-but-finite replicates")
+        XCTAssertEqual(median, enormous, accuracy: enormous * 1e-12)
+        XCTAssertNotEqual(median, .infinity,
+            "median must never be .infinity — that would yield .feasible(medianTPS: .infinity)")
+    }
+
+    private func stage2EmptyStreamScript() throws -> URL {
+        let directory = try temporaryDirectory(name: "stage2-empty-provider")
+        let scriptURL = directory.appendingPathComponent("empty-provider")
+        let script = """
+        #!/usr/bin/env python3
+        import socket, sys
+
+        args = sys.argv[1:]
+        if "serve" not in args or "--no-join" not in args:
+            sys.stderr.write("expected serve --no-join\\n")
+            sys.exit(2)
+        port = int(args[args.index("--port") + 1])
+
+        server = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        server.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        server.bind(("127.0.0.1", port))
+        server.listen(16)
+        print("stage2 empty provider ready", flush=True)
+
+        while True:
+            client, _ = server.accept()
+            request = client.recv(65536).decode("utf-8", "ignore")
+            if "GET /v1/models " in request:
+                body = '{"object":"list","data":[{"id":"stub","object":"model"}]}'
+                client.sendall((
+                    "HTTP/1.1 200 OK\\r\\n"
+                    "Content-Type: application/json\\r\\n"
+                    f"Content-Length: {len(body)}\\r\\n"
+                    "Connection: close\\r\\n"
+                    "\\r\\n"
+                    f"{body}"
+                ).encode())
+                client.close()
+                continue
+            if "POST /v1/chat/completions " in request:
+                client.sendall((
+                    "HTTP/1.1 200 OK\\r\\n"
+                    "Content-Type: text/event-stream\\r\\n"
+                    "Cache-Control: no-cache\\r\\n"
+                    "Connection: close\\r\\n"
+                    "\\r\\n"
+                ).encode())
+                client.sendall(b"data: [DONE]\\n\\n")
+                client.close()
+                continue
+            body = "not found"
+            client.sendall((
+                "HTTP/1.1 404 Not Found\\r\\n"
+                f"Content-Length: {len(body)}\\r\\n"
+                "Connection: close\\r\\n"
+                "\\r\\n"
+                f"{body}"
+            ).encode())
+            client.close()
+        """
+        try script.write(to: scriptURL, atomically: true, encoding: .utf8)
+        try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: scriptURL.path)
+        return scriptURL
+    }
+
+    private func stage2WordCountFallbackScript() throws -> URL {
+        let directory = try temporaryDirectory(name: "stage2-wordcount-provider")
+        let scriptURL = directory.appendingPathComponent("wordcount-provider")
+        let script = """
+        #!/usr/bin/env python3
+        import json, socket, sys, time
+
+        args = sys.argv[1:]
+        if "serve" not in args or "--no-join" not in args:
+            sys.stderr.write("expected serve --no-join\\n")
+            sys.exit(2)
+        port = int(args[args.index("--port") + 1])
+
+        server = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        server.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        server.bind(("127.0.0.1", port))
+        server.listen(16)
+        print("stage2 wordcount provider ready", flush=True)
+
+        # 15 words per delta, 2 deltas → 30 words / 2 deltas. NO usage chunk
+        # (older serve build), so finalization must use the word count.
+        words = " ".join(f"w{i}" for i in range(15))
+
+        while True:
+            client, _ = server.accept()
+            request = client.recv(65536).decode("utf-8", "ignore")
+            if "GET /v1/models " in request:
+                body = '{"object":"list","data":[{"id":"stub","object":"model"}]}'
+                client.sendall((
+                    "HTTP/1.1 200 OK\\r\\n"
+                    "Content-Type: application/json\\r\\n"
+                    f"Content-Length: {len(body)}\\r\\n"
+                    "Connection: close\\r\\n"
+                    "\\r\\n"
+                    f"{body}"
+                ).encode())
+                client.close()
+                continue
+            if "POST /v1/chat/completions " in request:
+                client.sendall((
+                    "HTTP/1.1 200 OK\\r\\n"
+                    "Content-Type: text/event-stream\\r\\n"
+                    "Cache-Control: no-cache\\r\\n"
+                    "Connection: close\\r\\n"
+                    "\\r\\n"
+                ).encode())
+                for _ in range(2):
+                    chunk = json.dumps({"choices":[{"delta":{"content":words + " "}}]})
+                    client.sendall(f"data: {chunk}\\n\\n".encode())
+                # Hold the stream open so the generation window is well-defined
+                # (~0.3s) before the terminal [DONE]. No usage chunk emitted.
+                time.sleep(0.3)
+                client.sendall(b"data: [DONE]\\n\\n")
+                client.close()
+                continue
+            body = "not found"
+            client.sendall((
+                "HTTP/1.1 404 Not Found\\r\\n"
+                f"Content-Length: {len(body)}\\r\\n"
+                "Connection: close\\r\\n"
+                "\\r\\n"
+                f"{body}"
+            ).encode())
+            client.close()
+        """
+        try script.write(to: scriptURL, atomically: true, encoding: .utf8)
+        try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: scriptURL.path)
+        return scriptURL
+    }
+
+    private func temporaryDirectory(name: String) throws -> URL {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("\(name)-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        addTeardownBlock {
+            try? FileManager.default.removeItem(at: directory)
+        }
+        return directory
+    }
+
+    private func unusedPort() throws -> Int {
+        let socketFD = socket(AF_INET, SOCK_STREAM, 0)
+        XCTAssertGreaterThanOrEqual(socketFD, 0)
+        defer { close(socketFD) }
+
+        var addr = sockaddr_in()
+        addr.sin_len = UInt8(MemoryLayout<sockaddr_in>.size)
+        addr.sin_family = sa_family_t(AF_INET)
+        addr.sin_port = 0
+        addr.sin_addr = in_addr(s_addr: inet_addr("127.0.0.1"))
+
+        var bindAddr = addr
+        let bindResult = withUnsafePointer(to: &bindAddr) {
+            $0.withMemoryRebound(to: sockaddr.self, capacity: 1) {
+                Darwin.bind(socketFD, $0, socklen_t(MemoryLayout<sockaddr_in>.size))
+            }
+        }
+        XCTAssertEqual(bindResult, 0)
+
+        var boundAddr = sockaddr_in()
+        var length = socklen_t(MemoryLayout<sockaddr_in>.size)
+        let nameResult = withUnsafeMutablePointer(to: &boundAddr) {
+            $0.withMemoryRebound(to: sockaddr.self, capacity: 1) {
+                getsockname(socketFD, $0, &length)
+            }
+        }
+        XCTAssertEqual(nameResult, 0)
+        return Int(UInt16(bigEndian: boundAddr.sin_port))
+    }
+
     private func makeHillClimb(
         db: AutotuneDB,
         prober: StubStage2Prober,


### PR DESCRIPTION
## Autotune: measure decode throughput for reasoning models (admit gpt-oss-20b)

### Problem
Reasoning/Harmony models (e.g. `gpt-oss-20b`) suppress their analysis channel
from `delta.content`. The autotune Stage 1/2 throughput probe measured decode
rate by counting non-empty content SSE deltas, so on the probe's gibberish
prompt a reasoning model produced **zero** content deltas → measured throughput
`0` → `"invalid throughput 0"` → infeasible → **no admission evidence** → the
coordinator returns `no_provider_available` (503). The model works fine for real
requests; it simply can never be benchmarked, so it can never be routed.

### Root cause
The provider's streaming `usage.completion_tokens` is, for Harmony models, the
**visible final-channel** count only (`CompletionResult.completionTokens`), not
the total decoded across all channels. And the SSE stream is silent during the
(suppressed) reasoning phase, so the **client cannot observe the decode window**
at all. Throughput therefore cannot be measured client-side for reasoning
models.

### Fix
Provider now reports the honest decode signals in the streaming `usage` object
as additive, namespaced vendor fields (buyer `completion_tokens`/billing and
OpenAI-compat unchanged; the coordinator-relay usage contract is untouched):
- `macprovider_generated_completion_tokens` — total tokens decoded across all
  channels (reasoning + final).
- `macprovider_generation_ms` — warm decode wall-time (first decoded token →
  last), measured in the serve-stream loop via `FirstTokenRecorder`.

The autotune probe computes `throughput = generated_tokens / generation_ms`,
which is the correct all-channel decode rate — immune to reasoning-silence and
to prefill. Speculative decode is disabled for `--autotune-candidate` so the
probe always exercises the timed path. Parser and Stage 2 aggregation hardened
(terminal-shape + integer validation, `max_tokens` cap, 1 ms floor,
overflow-safe median, finite/positive feasibility guards).

### Testing
`swift build` clean; autotune + provider-usage suites green (Stage 1, Stage 2,
Spec028 plumbing, HTTPServer receipt/usage). New tests cover: reasoning-only
stream → feasible with correct TPS; mixed reasoning+final → all-channel rate
(not the inflated visible-window rate); parser rejection of
bool/fractional/negative/oversized/non-terminal usage; authoritative-zero →
infeasible; Stage 2 empty-stream-with-disabled-TTFT-gate → infeasible; Stage 2
older-server word-count fallback; `--autotune-candidate` draft suppression;
provider `usage` carries both new fields.

### Audit
Three-lane codex audit (code / security / architect) run to convergence:
round 1 (1 HIGH + 4 MEDIUM) → round 2 (architect PASS; 1 HIGH + several MEDIUM)
→ round 3 hardening → **0 CRITICAL / 0 HIGH / 0 MEDIUM** across all lanes.
Residuals are LOW/INFO (pre-existing local-candidate trust limitation;
loopback-only metadata visibility).

SPEC-GOVERNANCE-DECLARATION-BEGIN
{
  "schema_version": "spec-pr-governance-v1",
  "behavior_change": "yes",
  "contract_change": "none",
  "specs": ["SPEC-023", "SPEC-013"],
  "requirements": ["SPEC-023-R001"],
  "authority_domains": ["autotune-recommendation"],
  "arbitration": ["CODE_BUG"],
  "tests": ["phase3-binary/Tests/macprovider-cliTests/Stage1IteratorTests.swift", "phase3-binary/Tests/macprovider-cliTests/Stage2HillClimbTests.swift", "phase3-binary/Tests/macprovider-cliTests/HTTPServerReceiptTests.swift"],
  "journeys": ["not-required"],
  "issue": "https://github.com/Augustas11/macprovider/issues/614"
}
SPEC-GOVERNANCE-DECLARATION-END

🤖 Generated with [Claude Code](https://claude.com/claude-code)
