### PR TITLE
feat(payout): wire payout_runner_lease_conflict + payout_nonce_gap alerts (SPEC-016 §7.1)

### DIFF
--- a/dist/synthetic-alerts/README.md
+++ b/dist/synthetic-alerts/README.md
@@ -171,25 +171,26 @@ Reconciling SPEC-016 §9 item 6's enumeration against the coordinator's actual
 emitted event names surfaced money-path spec-vs-code divergences. They are
 recorded here rather than silently resolved:
 
-### A. Enumerated by §9 item 6 but NEVER emitted by the code (`spec-only-not-emitted`)
+### A. Formerly `spec-only-not-emitted` — NOW WIRED (2026-08-02)
 
-- **`payout_nonce_gap` (WARN)** — §7.1 / §9 item 6 list it, but no
-  `phase4-coordinator` source emits a `payout_nonce_gap` event. The nonce-gap
-  condition surfaces instead via `payout_nonce_cold_start_within_tolerance`
-  (INFO) and `payout_invariant_violation`. Either the emission is missing or the
-  spec over-enumerates.
-- **`payout_runner_lease_conflict` (PAGE)** — §7.1 (NEW v0.1.8) / §9 item 6 list
-  it, but the lease code emits `payout_runner_lease_taken_over` and
-  `payout_runner_lease_lost` instead; no `payout_runner_lease_conflict` string
-  exists in the code. (§4.3's "IMPL test required (1)" even asserts this event.)
+Both events below were previously enumerated by §9 item 6 but emitted by no
+`phase4-coordinator` source. That gap is now **closed**: they are wired as
+`code` events in `catalog.tsv` and participate in the default verification set.
 
-These are an **implementation gap**, not a verification item. Because the code
-never emits them, a synthetic alert for them would let an operator "verify" a
-matcher that can never fire from real traffic (false readiness). They are
-therefore **excluded from `./emit.sh`'s default set** and are emitted only by
-`./emit.sh --reserved`, marked `"reserved":true,"not_yet_emitted":true`. Close
-the gap by wiring the emission (then move the row to `code` and it re-enters the
-default verification set), or delete the row if the spec over-enumerated.
+- **`payout_nonce_gap` (WARN)** — emitted by `RunOnce`'s §7.1 pre-check
+  (`checkNonceGap`, `internal/payout/runner.go`) when the on-chain pending nonce
+  falls behind the DB cursor via a real abandon hole. Catalogued `code`.
+- **`payout_runner_lease_conflict` (PAGE)** — emitted by the lease path
+  (`internal/payout/lease*.go`) on a competing-holder conflict. Catalogued
+  `code`.
+
+Related recovery-only diagnostics introduced alongside the R2-HIGH fix are
+**non-alert info events** (no `severity` field) and are listed in
+`non-alert-allowlist.txt`, not `catalog.tsv`:
+`payout_nonce_gap_precheck_skipped`, `payout_nonce_gap_reorg_suspect`, and
+`payout_nonce_gap_recovery_only` (the per-cycle recovery-only diagnostic — a
+rebroadcastable crash-recovery attempt sits at the pending nonce; fresh
+allocation is suppressed for that cycle while the persisted bytes re-broadcast).
 
 ### B. Missing `severity` field on PAGE/WARN events — FIXED (2026-08-01)
 

--- a/dist/synthetic-alerts/catalog.tsv
+++ b/dist/synthetic-alerts/catalog.tsv
@@ -84,5 +84,5 @@ provider_payout_address_change_rejected	WARN	code	-
 provider_payout_address_rejected_unknown_provider	WARN	code	-
 payout_capped	INFO	info	-
 payout_cancel_self_transfer_confirmed	INFO	info	-
-payout_nonce_gap	WARN	spec-only-not-emitted	-
-payout_runner_lease_conflict	PAGE	spec-only-not-emitted	-
+payout_nonce_gap	WARN	code	-
+payout_runner_lease_conflict	PAGE	code	-

--- a/dist/synthetic-alerts/non-alert-allowlist.txt
+++ b/dist/synthetic-alerts/non-alert-allowlist.txt
@@ -37,6 +37,9 @@ payout_funding_rpc_unavailable	info-event
 payout_hot_wallet_funding	db-table
 payout_id	db-column
 payout_nonce_cold_start_within_tolerance	info-event
+payout_nonce_gap_precheck_skipped	info-event
+payout_nonce_gap_recovery_only	info-event
+payout_nonce_gap_reorg_suspect	info-event
 payout_not_allowed	reason-value
 payout_paid	info-event
 payout_reorg_orphan_resolved	info-event

--- a/phase4-coordinator/internal/payout/attempts.go
+++ b/phase4-coordinator/internal/payout/attempts.go
@@ -413,6 +413,18 @@ SELECT COUNT(*) FROM payout_attempts
 // UpsertNonceCursor records the runner's chosen cold-start nonce
 // for the given from_address. RPC values are persisted for
 // post-hoc forensics.
+//
+// Cold-start-only (the sole caller is cmd/coordinator's startup
+// ColdStartNonceSync path; AllocateNextNonceTx/BumpNonceCursorTx
+// own the in-txn allocation cursor). SPEC-016:1749-1750 defines the
+// cold-start cursor as max(cursor_in_db, max(rpc_a, rpc_b)), so the
+// ON CONFLICT must take the MAX of the stored and incoming next_nonce
+// — never overwrite. A plain overwrite would let a restart whose RPC
+// pending nonce lags the DB cursor (e.g. DB=8, chain-pending=7) erase
+// a real abandoned-unfilled hole and stall the money path. Mainnet
+// nonces never decrease, so MAX is always the correct cursor. The
+// rpc_a/rpc_b/last_synced columns stay excluded.* — they are forensic
+// snapshots of THIS sync, not monotonic state.
 func UpsertNonceCursor(ctx context.Context, db *sql.DB, fromAddress string, nextNonce uint64,
 	rpcAValue, rpcBValue uint64, nowUTC string,
 ) error {
@@ -421,7 +433,7 @@ INSERT INTO wallet_nonce_cursor
   (from_address, next_nonce, last_synced_at_utc, rpc_a_last_value, rpc_b_last_value)
 VALUES (?, ?, ?, ?, ?)
 ON CONFLICT(from_address) DO UPDATE SET
-  next_nonce = excluded.next_nonce,
+  next_nonce = MAX(wallet_nonce_cursor.next_nonce, excluded.next_nonce),
   last_synced_at_utc = excluded.last_synced_at_utc,
   rpc_a_last_value = excluded.rpc_a_last_value,
   rpc_b_last_value = excluded.rpc_b_last_value`,
@@ -479,6 +491,67 @@ func BumpNonceCursorTx(ctx context.Context, conn *sql.Conn, fromAddress string, 
 		nowUTC, strings.ToLower(fromAddress),
 	)
 	return err
+}
+
+// ---- §7.1 payout_nonce_gap pre-check helpers ----------------------------
+
+// nonceGapCauseExists reports whether an abandoned, still-unconfirmed,
+// NON-cancel payout_attempts row occupies `nonce` for from_address —
+// the durable CAUSE that ties a payout_nonce_gap emission to an
+// operator abandon (§4.6) rather than to unrelated chain state. An
+// abandoned-unfilled non-cancel attempt is exactly the hole a gap
+// detector must confirm on-chain (observed_pending_nonce == this
+// nonce). Columns: abandoned_at_utc (set = abandoned), confirmed_at_utc
+// (NULL = not confirmed), is_cancel_self_transfer (0 = not a cancel).
+func nonceGapCauseExists(ctx context.Context, db *sql.DB, fromAddress string, nonce uint64) (bool, error) {
+	var exists int
+	if err := db.QueryRowContext(ctx, `
+SELECT EXISTS(
+  SELECT 1 FROM payout_attempts
+   WHERE from_address = ?
+     AND nonce = ?
+     AND abandoned_at_utc IS NOT NULL
+     AND confirmed_at_utc IS NULL
+     AND is_cancel_self_transfer = 0)`,
+		strings.ToLower(fromAddress), int64(nonce),
+	).Scan(&exists); err != nil {
+		return false, err
+	}
+	return exists == 1, nil
+}
+
+// rebroadcastableAttemptExists reports whether a LIVE persisted-but-
+// unbroadcast (rebroadcastable) attempt occupies `nonce` — a
+// crash-recovery in progress that will re-broadcast the persisted bytes
+// next cycle. This mirrors processRow's rebroadcast precondition
+// exactly: rebroadcastAndPoll (§4.3 step 5) only re-sends when
+// raw_signed_tx holds non-empty bytes AND a tx_hash is present (a row
+// with raw bytes but no hash is treated as an invariant violation, not
+// rebroadcast), with broadcast_at_utc / confirmed_at_utc / abandoned_at_utc
+// all NULL. Matching the same predicate here is what makes this a safe
+// "will be filled next cycle" suppressor: a malformed row (raw bytes,
+// NULL/empty tx_hash) is NOT rebroadcastable, so it must not suppress a
+// real gap. Without this guard a crash between persist and broadcast
+// would false-alarm as a gap even though the nonce is about to be filled.
+func rebroadcastableAttemptExists(ctx context.Context, db *sql.DB, fromAddress string, nonce uint64) (bool, error) {
+	var exists int
+	if err := db.QueryRowContext(ctx, `
+SELECT EXISTS(
+  SELECT 1 FROM payout_attempts
+   WHERE from_address = ?
+     AND nonce = ?
+     AND raw_signed_tx IS NOT NULL
+     AND length(raw_signed_tx) > 0
+     AND tx_hash IS NOT NULL
+     AND tx_hash <> ''
+     AND broadcast_at_utc IS NULL
+     AND confirmed_at_utc IS NULL
+     AND abandoned_at_utc IS NULL)`,
+		strings.ToLower(fromAddress), int64(nonce),
+	).Scan(&exists); err != nil {
+		return false, err
+	}
+	return exists == 1, nil
 }
 
 // ---- helpers ------------------------------------------------------------

--- a/phase4-coordinator/internal/payout/attempts_test.go
+++ b/phase4-coordinator/internal/payout/attempts_test.go
@@ -123,13 +123,24 @@ func TestNonceCursor_RoundTrip(t *testing.T) {
 	if got != 7 {
 		t.Errorf("got %d, want 7", got)
 	}
-	// Upsert again (bump).
+	// Upsert again with a HIGHER value (forward sync) → cursor advances.
 	if err := UpsertNonceCursor(ctx, db, addr, 8, 8, 8, NowUTC()); err != nil {
 		t.Fatalf("Upsert #2: %v", err)
 	}
 	got, _, _ = ReadNonceCursor(ctx, db, addr)
 	if got != 8 {
-		t.Errorf("got %d, want 8 after upsert", got)
+		t.Errorf("got %d, want 8 after forward upsert", got)
+	}
+	// SPEC-016:1749-1750 monotonicity: a restart whose chosen nonce LAGS
+	// the stored cursor (e.g. chain pending nonce behind the DB cursor
+	// because of an abandoned-unfilled hole) must NOT erase the hole. The
+	// ON CONFLICT takes MAX(stored, incoming), so the cursor stays at 8.
+	if err := UpsertNonceCursor(ctx, db, addr, 5, 5, 5, NowUTC()); err != nil {
+		t.Fatalf("Upsert #3 (lagging): %v", err)
+	}
+	got, _, _ = ReadNonceCursor(ctx, db, addr)
+	if got != 8 {
+		t.Errorf("got %d, want 8 (cursor must not regress below stored value)", got)
 	}
 }
 

--- a/phase4-coordinator/internal/payout/lease.go
+++ b/phase4-coordinator/internal/payout/lease.go
@@ -34,8 +34,10 @@ type LeaseState struct {
 }
 
 // ErrLeaseConflict is returned by Acquire when a fresh holder
-// already owns the lease (heartbeat within window). Caller emits
-// payout_runner_lease_conflict per §7.1 + refuses to start.
+// already owns the lease (heartbeat within window). Acquire itself
+// emits payout_runner_lease_conflict per §7.1 (see the emission
+// inside Acquire below) before returning this error; the caller must
+// NOT re-emit it (avoids a double-emit) and refuses to start.
 var ErrLeaseConflict = errors.New("payout: runner lease conflict (fresh holder)")
 
 // ErrLeaseLost surfaces from Heartbeat / SelfFence when this
@@ -138,7 +140,25 @@ VALUES (1, ?, ?, ?, ?, ?, ?, 0)`,
 	}
 	staleWindow := 3 * runInterval
 	if now.Sub(hbTime) < staleWindow {
-		// Fresh holder — conflict.
+		// Fresh holder — conflict. Emit the §7.1
+		// payout_runner_lease_conflict PAGE event (§4.8b acquire
+		// step 3) before refusing to start. The local_pid /
+		// local_started_at_utc values are exactly the ones this
+		// Acquire would have used for its own INSERT (host/pid line
+		// 64-65; started_at = now, formatUTC(now) — mirrors the fresh
+		// INSERT's holder_started_at_utc). Control flow + the returned
+		// ErrLeaseConflict are unchanged.
+		log.Error().
+			Str("event", "payout_runner_lease_conflict").
+			Str("severity", "PAGE").
+			Int("local_pid", pid).
+			Str("local_started_at_utc", formatUTC(now)).
+			Str("holder_host", existingHost).
+			Int64("holder_pid", existingPID).
+			Str("holder_started_at_utc", existingStartedAt).
+			Str("holder_heartbeat_at_utc", existingHeartbeat).
+			Str("ts_utc", formatUTC(now)).
+			Send()
 		return LeaseState{}, false, fmt.Errorf("%w: holder_host=%s holder_pid=%d holder_started_at_utc=%s heartbeat_at_utc=%s",
 			ErrLeaseConflict, existingHost, existingPID, existingStartedAt, existingHeartbeat)
 	}

--- a/phase4-coordinator/internal/payout/lease_conflict_2process_test.go
+++ b/phase4-coordinator/internal/payout/lease_conflict_2process_test.go
@@ -1,0 +1,309 @@
+package payout
+
+import (
+	"bufio"
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/augstar/macprovider-coordinator/internal/sqliteutil"
+	"github.com/rs/zerolog"
+	_ "modernc.org/sqlite"
+)
+
+// SPEC-016:2964-2967 — "IMPL test required (1)": the payout_runner_lease
+// conflict must be proven across a REAL process boundary, not just
+// same-process. TestAcquire_ConflictEmitsLeaseConflictEvent
+// (lease_conflict_emit_test.go) exercises the emission fields cheaply but
+// runs both Acquires in ONE process, so local_pid == holder_pid there and
+// the cross-process local_pid != holder_pid distinction is never checked.
+//
+// This test spawns two ACTUAL OS processes against the SAME file-backed
+// sqlite DB (the standard Go "re-exec the test binary behind an env flag"
+// idiom, matching the subprocess pattern in cmd/coordinator/dispatch_test.go
+// and cmd/coordinator/partnerkeys_integration_test.go):
+//
+//   - Subprocess A: Acquire → wins the fresh lease (its INSERT stamps a live
+//     heartbeat), prints its real pid, then holds briefly.
+//   - Subprocess B: Acquire → must return ErrLeaseConflict, emit
+//     payout_runner_lease_conflict (PAGE, all 7 §7.1 fields) with
+//     holder_pid == A's real pid and local_pid == B's real pid (DISTINCT),
+//     and exit non-zero.
+//
+// Determinism: A commits its INSERT before it signals "acquired" on stdout,
+// and the parent only starts B after reading that signal — so B always sees a
+// committed heartbeat that is fresh (well inside the 3×5min stale window).
+// There is no timing race; the conflict is decided by the persisted row, not
+// by A still running.
+
+// leaseSubprocEnvRole gates the re-exec entrypoint below so a normal
+// `go test` invocation never runs the subprocess body inline.
+const (
+	leaseSubprocEnvRole = "PAYOUT_LEASE_SUBPROC_ROLE"
+	leaseSubprocEnvDB   = "PAYOUT_LEASE_SUBPROC_DB"
+
+	// Exit codes the subprocess uses so the parent can distinguish the
+	// expected outcome from wrong ones.
+	leaseExitAAcquired  = 0 // A won the fresh lease and held
+	leaseExitBConflict  = 3 // B correctly hit ErrLeaseConflict
+	leaseExitUnexpected = 4 // any other outcome (wrong-shape)
+)
+
+// openLeaseFileDB opens the shared file-backed sqlite DB at path and applies
+// the same minimum schema + migrations openTestDB uses (ledger_payout_ready
+// slice first, per the SPEC-016 same-DB pin, then Migrate which creates
+// payout_runner_lease). Unlike openTestDB it takes an explicit path so the
+// two subprocesses share one file (an in-memory DB cannot cross processes).
+func openLeaseFileDB(path string) (*sql.DB, error) {
+	db, err := sql.Open("sqlite", sqliteutil.WithPragmas(path))
+	if err != nil {
+		return nil, fmt.Errorf("open db: %w", err)
+	}
+	if _, err := db.ExecContext(context.Background(), `
+CREATE TABLE IF NOT EXISTS ledger_payout_ready (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    provider_id TEXT NOT NULL,
+    window_start_utc TEXT NOT NULL,
+    window_end_utc TEXT NOT NULL,
+    cadence_days INTEGER NOT NULL CHECK(cadence_days > 0),
+    source_credit_count INTEGER NOT NULL CHECK(source_credit_count > 0),
+    gross_credits INTEGER NOT NULL CHECK(gross_credits >= 0),
+    provider_credits INTEGER NOT NULL CHECK(provider_credits >= 0),
+    operator_credits INTEGER NOT NULL CHECK(operator_credits >= 0),
+    min_payout_credits INTEGER NOT NULL CHECK(min_payout_credits >= 0),
+    payout_currency TEXT NULL,
+    payout_external_id TEXT NULL,
+    status TEXT NOT NULL DEFAULT 'ready' CHECK(status IN ('ready','consumed','voided')),
+    idempotency_key TEXT NOT NULL,
+    created_at_utc TEXT NOT NULL,
+    UNIQUE(provider_id, window_start_utc, window_end_utc),
+    UNIQUE(idempotency_key)
+);`); err != nil {
+		_ = db.Close()
+		return nil, fmt.Errorf("seed ledger_payout_ready: %w", err)
+	}
+	if err := Migrate(context.Background(), db); err != nil {
+		_ = db.Close()
+		return nil, fmt.Errorf("migrate: %w", err)
+	}
+	return db, nil
+}
+
+// TestLeaseConflictSubprocess is the re-exec entrypoint. It does nothing
+// under a normal `go test` run (env unset); the parent test below invokes it
+// with the role + DB path env set, one OS process per role.
+func TestLeaseConflictSubprocess(t *testing.T) {
+	role := os.Getenv(leaseSubprocEnvRole)
+	if role == "" {
+		t.Skip("not a lease-conflict subprocess (env unset)")
+	}
+	dbPath := os.Getenv(leaseSubprocEnvDB)
+	db, err := openLeaseFileDB(dbPath)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "subprocess %s: open db: %v\n", role, err)
+		os.Exit(leaseExitUnexpected)
+	}
+	defer db.Close()
+	pid := os.Getpid()
+
+	switch role {
+	case "A":
+		// Route Acquire's own info log to stderr so stdout carries ONLY the
+		// machine-readable ready line the parent scans for.
+		logger := zerolog.New(os.Stderr)
+		_, takeover, err := Acquire(context.Background(), db, testRunInterval, logger)
+		if err != nil || takeover {
+			fmt.Fprintf(os.Stderr, "A: unexpected acquire err=%v takeover=%v\n", err, takeover)
+			os.Exit(leaseExitUnexpected)
+		}
+		// Signal the parent (post-COMMIT) with our real pid, then hold the
+		// lease briefly so A is a live concurrent holder while B runs.
+		fmt.Printf("{\"role\":\"A\",\"pid\":%d,\"status\":\"acquired\"}\n", pid)
+		os.Stdout.Sync()
+		time.Sleep(3 * time.Second)
+		os.Exit(leaseExitAAcquired)
+	case "B":
+		// Acquire must emit payout_runner_lease_conflict to stdout (the
+		// parent parses it) and return ErrLeaseConflict.
+		logger := zerolog.New(os.Stdout)
+		_, _, err := Acquire(context.Background(), db, testRunInterval, logger)
+		if !errors.Is(err, ErrLeaseConflict) {
+			fmt.Fprintf(os.Stderr, "B: acquire err=%v, want ErrLeaseConflict\n", err)
+			os.Exit(leaseExitUnexpected)
+		}
+		os.Exit(leaseExitBConflict)
+	default:
+		fmt.Fprintf(os.Stderr, "unknown role %q\n", role)
+		os.Exit(leaseExitUnexpected)
+	}
+}
+
+// leaseSubprocCmd builds an exec.Cmd that re-runs THIS test binary, matching
+// only TestLeaseConflictSubprocess, with the given role + shared DB path.
+func leaseSubprocCmd(role, dbPath string) *exec.Cmd {
+	cmd := exec.Command(os.Args[0], "-test.run", "^TestLeaseConflictSubprocess$")
+	cmd.Env = append(os.Environ(),
+		leaseSubprocEnvRole+"="+role,
+		leaseSubprocEnvDB+"="+dbPath,
+	)
+	return cmd
+}
+
+func leaseExitCode(err error) int {
+	if err == nil {
+		return 0
+	}
+	var ee *exec.ExitError
+	if errors.As(err, &ee) {
+		return ee.ExitCode()
+	}
+	return -1
+}
+
+// TestAcquire_LeaseConflict_TwoProcess is the real cross-process test.
+func TestAcquire_LeaseConflict_TwoProcess(t *testing.T) {
+	if os.Getenv(leaseSubprocEnvRole) != "" {
+		// We are a re-exec'd child; the child logic lives in
+		// TestLeaseConflictSubprocess. Nothing to do here.
+		t.Skip("child process")
+	}
+	// A shared, file-backed DB both subprocesses open (in-memory can't cross
+	// the process boundary). Kept in the test's TempDir (auto-cleaned).
+	dbPath := filepath.Join(t.TempDir(), "lease_2proc.db")
+
+	// --- Subprocess A: win + hold the fresh lease. ---
+	cmdA := leaseSubprocCmd("A", dbPath)
+	stdoutA, err := cmdA.StdoutPipe()
+	if err != nil {
+		t.Fatalf("A stdout pipe: %v", err)
+	}
+	cmdA.Stderr = os.Stderr
+	if err := cmdA.Start(); err != nil {
+		t.Fatalf("start A: %v", err)
+	}
+	// Read A's stdout until the post-COMMIT "acquired" line appears; capture
+	// A's real pid. This gate guarantees the lease row is committed + fresh
+	// before B runs (no timing race).
+	var aPID int
+	scanner := bufio.NewScanner(stdoutA)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" {
+			continue
+		}
+		var msg struct {
+			Role   string `json:"role"`
+			PID    int    `json:"pid"`
+			Status string `json:"status"`
+		}
+		if err := json.Unmarshal([]byte(line), &msg); err != nil {
+			continue
+		}
+		if msg.Role == "A" && msg.Status == "acquired" {
+			aPID = msg.PID
+			break
+		}
+	}
+	if aPID == 0 {
+		_ = cmdA.Process.Kill()
+		_ = cmdA.Wait()
+		t.Fatalf("A never signalled a committed acquire")
+	}
+	if osPID := cmdA.Process.Pid; osPID != aPID {
+		t.Fatalf("A reported pid %d != its OS pid %d", aPID, osPID)
+	}
+
+	// --- Subprocess B: must conflict against A's fresh, committed lease. ---
+	cmdB := leaseSubprocCmd("B", dbPath)
+	var bStdout strings.Builder
+	cmdB.Stdout = &bStdout
+	cmdB.Stderr = os.Stderr
+	if err := cmdB.Start(); err != nil {
+		t.Fatalf("start B: %v", err)
+	}
+	bPID := cmdB.Process.Pid
+	bErr := cmdB.Wait()
+
+	// A has done its job; let it finish (it sleeps a few seconds then exits 0).
+	if err := cmdA.Wait(); err != nil {
+		t.Errorf("A exited with error: %v (exit=%d)", err, leaseExitCode(err))
+	}
+
+	// B must have exited non-zero, specifically with the conflict code.
+	if code := leaseExitCode(bErr); code != leaseExitBConflict {
+		t.Fatalf("B exit code = %d, want %d (ErrLeaseConflict + non-zero); stdout=%q",
+			code, leaseExitBConflict, bStdout.String())
+	}
+
+	// Parse the payout_runner_lease_conflict event B emitted on stdout.
+	ev := parseLeaseConflictEvent(t, bStdout.String())
+
+	if got := ev["event"]; got != "payout_runner_lease_conflict" {
+		t.Errorf("event = %v, want payout_runner_lease_conflict", got)
+	}
+	if got := ev["severity"]; got != "PAGE" {
+		t.Errorf("severity = %v, want PAGE", got)
+	}
+	if got := ev["level"]; got != "error" {
+		t.Errorf("level = %v, want error", got)
+	}
+	// All 7 §7.1 fields present.
+	for _, f := range []string{
+		"local_pid", "local_started_at_utc",
+		"holder_host", "holder_pid", "holder_started_at_utc",
+		"holder_heartbeat_at_utc", "ts_utc",
+	} {
+		if _, ok := ev[f]; !ok {
+			t.Errorf("missing §7.1 field %q in %v", f, ev)
+		}
+	}
+
+	// The crux this same-process test could never assert: holder_pid is A's
+	// real pid, local_pid is B's real pid, and the two are DISTINCT.
+	holderPID, ok := ev["holder_pid"].(float64)
+	if !ok {
+		t.Fatalf("holder_pid not numeric: %v", ev["holder_pid"])
+	}
+	localPID, ok := ev["local_pid"].(float64)
+	if !ok {
+		t.Fatalf("local_pid not numeric: %v", ev["local_pid"])
+	}
+	if int(holderPID) != aPID {
+		t.Errorf("holder_pid = %d, want %d (A's real pid)", int(holderPID), aPID)
+	}
+	if int(localPID) != bPID {
+		t.Errorf("local_pid = %d, want %d (B's real pid)", int(localPID), bPID)
+	}
+	if int(holderPID) == int(localPID) {
+		t.Errorf("holder_pid == local_pid (%d): cross-process distinction not exercised", int(holderPID))
+	}
+}
+
+// parseLeaseConflictEvent finds the payout_runner_lease_conflict JSON line in
+// B's captured stdout and returns it as a map. Fails the test if absent.
+func parseLeaseConflictEvent(t *testing.T, stdout string) map[string]any {
+	t.Helper()
+	for _, line := range strings.Split(stdout, "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		var ev map[string]any
+		if err := json.Unmarshal([]byte(line), &ev); err != nil {
+			continue
+		}
+		if ev["event"] == "payout_runner_lease_conflict" {
+			return ev
+		}
+	}
+	t.Fatalf("payout_runner_lease_conflict event not found in B stdout=%q", stdout)
+	return nil
+}

--- a/phase4-coordinator/internal/payout/lease_conflict_emit_test.go
+++ b/phase4-coordinator/internal/payout/lease_conflict_emit_test.go
@@ -1,0 +1,73 @@
+package payout
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+)
+
+// TestAcquire_ConflictEmitsLeaseConflictEvent is the §4.3 "IMPL test
+// required (1)" for the payout_runner_lease_conflict PAGE alert: when a
+// second Acquire runs against a DB row held by a FRESH holder, Acquire
+// MUST emit payout_runner_lease_conflict per §7.1 with the full field
+// set AND return ErrLeaseConflict (SPEC-016 §4.8b acquire step 3).
+func TestAcquire_ConflictEmitsLeaseConflictEvent(t *testing.T) {
+	db := openTestDB(t)
+
+	// First acquire wins the (fresh) lease. Its INSERT stamps a live
+	// heartbeat, so the second acquire below sees a fresh holder.
+	quiet, _ := quietLogger()
+	state1, _, err := Acquire(context.Background(), db, testRunInterval, quiet)
+	if err != nil {
+		t.Fatalf("Acquire #1: %v", err)
+	}
+
+	// Second acquire conflicts. Capture its structured output.
+	logger, buf := quietLogger()
+	_, _, err = Acquire(context.Background(), db, testRunInterval, logger)
+	if !errors.Is(err, ErrLeaseConflict) {
+		t.Fatalf("Acquire #2 err = %v, want ErrLeaseConflict", err)
+	}
+
+	var ev map[string]any
+	if e := json.Unmarshal(buf.Bytes(), &ev); e != nil {
+		t.Fatalf("parse emitted event %q: %v", buf.String(), e)
+	}
+
+	if got := ev["event"]; got != "payout_runner_lease_conflict" {
+		t.Errorf("event = %v, want payout_runner_lease_conflict", got)
+	}
+	if got := ev["severity"]; got != "PAGE" {
+		t.Errorf("severity = %v, want PAGE", got)
+	}
+	if got := ev["level"]; got != "error" {
+		t.Errorf("level = %v, want error", got)
+	}
+
+	// Every §7.1 field must be present.
+	for _, f := range []string{
+		"local_pid", "local_started_at_utc",
+		"holder_host", "holder_pid", "holder_started_at_utc",
+		"holder_heartbeat_at_utc", "ts_utc",
+	} {
+		if _, ok := ev[f]; !ok {
+			t.Errorf("missing §7.1 field %q in %v", f, ev)
+		}
+	}
+
+	// The holder_* fields must describe the FIRST (surviving) holder,
+	// not the conflicting caller.
+	if got := ev["holder_host"]; got != state1.HolderHost {
+		t.Errorf("holder_host = %v, want %v (first holder)", got, state1.HolderHost)
+	}
+	if got, ok := ev["holder_pid"].(float64); !ok || int(got) != state1.HolderPID {
+		t.Errorf("holder_pid = %v, want %d (first holder)", ev["holder_pid"], state1.HolderPID)
+	}
+	// local_pid is this process's pid (the same value Acquire would use
+	// for its own INSERT); with both acquires in one test process it
+	// equals the first holder's pid — assert it is present + numeric.
+	if _, ok := ev["local_pid"].(float64); !ok {
+		t.Errorf("local_pid not numeric: %v", ev["local_pid"])
+	}
+}

--- a/phase4-coordinator/internal/payout/runner.go
+++ b/phase4-coordinator/internal/payout/runner.go
@@ -159,6 +159,27 @@ type Runner struct {
 	//
 	// Single-threaded under mu+inFlight; cleared in RunOnce defer.
 	runningBalance *big.Int
+
+	// recoveryOnly latches the R2-HIGH "recovery-only cycle" mode:
+	// checkNonceGap returned gapRecoveryOnly (a rebroadcastable
+	// crash-recovery attempt sits at the on-chain pending nonce, one
+	// below the DB cursor). In this mode the row loop still drives
+	// recovery rebroadcast + all unrelated in-flight polls/confirms,
+	// but the single terminal fresh-allocation call site in processRow
+	// is suppressed (returns rowOutcomeSkipped) so NO fresh nonce is
+	// allocated past the unfilled hole this cycle. Set by RunOnce's
+	// gap switch and cleared in the same cycle's defer. Single-threaded
+	// under mu+inFlight.
+	recoveryOnly bool
+	// gapRecoveryObservedNonce / gapRecoveryExpectedNonce carry the
+	// on-chain observed pending nonce and the DB cursor's expected nonce
+	// captured by checkNonceGap on the gapRecoveryOnly path. They exist
+	// ONLY so RunOnce can emit the per-cycle payout_nonce_gap_recovery_only
+	// diagnostic (from_address + observed/expected + ts) — they are never
+	// used to target or drive an attempt. Meaningful only while
+	// recoveryOnly is true; single-threaded under mu+inFlight.
+	gapRecoveryObservedNonce uint64
+	gapRecoveryExpectedNonce uint64
 }
 
 // hotWalletBalance returns the cycle-scoped running USDC balance
@@ -517,6 +538,48 @@ func (r *Runner) RunOnce(ctx context.Context) (string, error) {
 	// the cycle.
 	r.opts.ChronicOutage.Evaluate(ctx, now)
 
+	// SPEC-016 §7.1 payout_nonce_gap pre-check. Runs ONCE per cycle
+	// BEFORE the §4.3 step 1 SELECT and BEFORE any fresh nonce
+	// allocation. A confirmed gap (on-chain pending nonce fell BEHIND
+	// the DB cursor via an abandoned-unfilled hole) HALTS the whole
+	// cadence cycle for the single hot wallet: no rows are processed,
+	// nothing is allocated/built/broadcast, and NO automatic gap-fill
+	// is attempted. Per-cycle skip only — the next cadence cycle
+	// re-checks against fresh on-chain state.
+	// R2-HIGH tri-state gate (architect Option A). gapHalt returns
+	// without processing rows; gapProceed runs the normal cycle;
+	// gapRecoveryOnly latches r.recoveryOnly so the row loop drives
+	// recovery + unrelated in-flight work but processRow suppresses the
+	// single fresh-allocation call site (no fresh nonce past the hole).
+	decision, err := r.checkNonceGap(ctx, now)
+	if err != nil {
+		return runID, fmt.Errorf("checkNonceGap: %w", err)
+	}
+	switch decision {
+	case gapHalt:
+		return runID, nil
+	case gapRecoveryOnly:
+		r.recoveryOnly = true
+		defer func() { r.recoveryOnly = false }()
+		// Per-cycle §7.1 diagnostic: a rebroadcastable crash-recovery
+		// attempt sits at the on-chain pending nonce, so this cycle
+		// suppresses fresh allocation and lets the normal row loop drive
+		// the recovery rebroadcast + all unrelated in-flight work. Emitted
+		// EVERY recovery-only cycle so an unselectable-recovery fail-closed
+		// PAUSE (payout_allowed=0 / cooling-off / off-page) is visible to
+		// the operator rather than a silent payout stall.
+		r.opts.Logger.Warn().
+			Str("event", "payout_nonce_gap_recovery_only").
+			Str("run_id", runID).
+			Str("from_address", strings.ToLower(r.opts.Security.HotWalletAddress)).
+			Uint64("expected_nonce", r.gapRecoveryExpectedNonce).
+			Uint64("observed_pending_nonce", r.gapRecoveryObservedNonce).
+			Str("ts_utc", now.UTC().Format(time.RFC3339Nano)).
+			Send()
+	case gapProceed:
+		// normal cycle
+	}
+
 	// §4.3 step 1: SELECT ready rows.
 	hotWallet := r.opts.Security.HotWalletAddress
 	rows, err := SelectReadyPayouts(ctx, r.opts.DB, hotWallet, now.Format(time.RFC3339Nano), snap.MaxRowsPerRun)
@@ -645,6 +708,189 @@ func (r *Runner) currentHotWalletUSDCBalance(ctx context.Context) (*big.Int, err
 		return nil, fmt.Errorf("currentHotWalletUSDCBalance: parse failed")
 	}
 	return bal, nil
+}
+
+// gapDecision is the tri-state result of the §7.1 nonce-gap pre-check
+// (R2-HIGH, architect Option A). It replaces the old (bool halt, error)
+// return so a rebroadcastable-at-observed hole no longer collapses into
+// a blanket "proceed" that lets the row loop allocate past the hole.
+type gapDecision int
+
+const (
+	// gapProceed: no gap to guard (no cursor yet, or observed >=
+	// expected). Normal cycle — fresh allocation may happen.
+	gapProceed gapDecision = iota
+	// gapHalt: fail-closed. Nonce state unverifiable, a real abandon
+	// hole, or a reorg-suspect chain contradiction. RunOnce returns
+	// without processing any row this cycle.
+	gapHalt
+	// gapRecoveryOnly: a rebroadcastable crash-recovery attempt sits at
+	// the on-chain pending nonce (observed = expected-1). The cycle
+	// proceeds to drive that attempt's rebroadcast + all unrelated
+	// in-flight polls/confirms, but the single terminal fresh-allocation
+	// call site in processRow is suppressed so NO fresh nonce is
+	// allocated past the unfilled hole this cycle.
+	gapRecoveryOnly
+)
+
+// checkNonceGap performs the SPEC-016 §7.1 payout_nonce_gap (WARN)
+// pre-check ONCE per cadence cycle, BEFORE any fresh nonce is
+// allocated. It guards fresh nonce allocation: the on-chain pending
+// nonce having fallen BEHIND the DB cursor (observed_pending_nonce <
+// expected_nonce) means nonce `observed` is not yet mined, so allocating
+// N+1 into that hole would stall the money path on-chain. This is a
+// SAFETY GATE, so it fails CLOSED: every path that cannot POSITIVELY
+// prove the hole is benign crash-recovery HALTS the cycle (return
+// halt=true after emitting the right diagnostic) rather than falling
+// through to allocation. RunOnce then skips ALL rows this cycle for the
+// single hot wallet — no allocate/build/broadcast and NO automatic
+// gap-fill. The next cadence cycle re-checks against fresh on-chain
+// state. This is a per-cycle skip, NOT a runner halt (RequestHalt stays
+// reserved for §7.4 negative-drift).
+//
+// Decision table (each path maps to a concrete RPC/DB check):
+//   - no cursor yet                         → cold-start incomplete; cannot
+//     compute a gap → proceed (nothing to guard yet)
+//   - two-RPC read error / >1 disagreement  → nonce state UNVERIFIABLE →
+//     HALT fail-closed (emit payout_nonce_gap_precheck_skipped). A
+//     transient blip is re-checked next cycle; a chronic RPC outage is
+//     separately PAGEd by the chronic-outage detector. This must NOT fall
+//     through to allocation — an unverified cursor is exactly when a hole
+//     could be allocated into.
+//   - observed >= expected                  → steady state (==) or an
+//     out-of-band spend (observed>expected is a DIFFERENT pathology,
+//     NOT payout_nonce_gap) → proceed
+//   - observed < expected: a nonce MAY be missing. Resolve via the
+//     payout_attempts row at nonce == observed, in this order:
+//     1. rebroadcastable attempt AT observed → benign crash-recovery
+//     (bytes re-broadcast next cycle) → PROCEED. This is the ONLY
+//     proceed path in the observed<expected branch.
+//     2. abandoned/unconfirmed/non-cancel CAUSE AT observed → real
+//     abandon hole → emit payout_nonce_gap (WARN) → HALT.
+//     3. otherwise (a confirmed row AT observed, OR nothing at observed)
+//     → chain-contradicted / unexplained. Because observed is not yet
+//     mined, any confirmed_at_utc row at `observed` is stale-by-
+//     definition (reorged-out inside the reorg window), so it must
+//     NOT suppress the gap. Emit payout_nonce_gap_reorg_suspect (info)
+//     → HALT. The reorg poller (reorg.go) independently detects and
+//     reconciles the stale row and emits its own payout_reorg_*
+//     alerts; this halt only prevents allocating into the hole
+//     meanwhile.
+//
+// This also closes a latent stall: an operator abandon WITHOUT a cancel
+// (§4.6 permits broadcast_cancel_self_transfer:false) leaves the
+// abandoned row out of LookupExistingLatest, so cancelsBlockFresh stays
+// false and processRow would allocate N+1 into the hole and stall
+// silently on-chain. The halt here fires in exactly that state.
+//
+// R2-HIGH (architect Option A): the rebroadcastable-at-observed path no
+// longer returns a blanket "proceed" — that let the row loop fresh-
+// allocate N+1 past the unfilled hole whenever the recovery attempt was
+// not selected by SelectReadyPayouts or its rebroadcast failed, stalling
+// the whole hot wallet on-chain. It now returns gapRecoveryOnly: the
+// cycle proceeds far enough to drive recovery + unrelated in-flight
+// work, but suppresses fresh allocation. See gapDecision.
+func (r *Runner) checkNonceGap(ctx context.Context, now time.Time) (gapDecision, error) {
+	hotWallet := r.opts.Security.HotWalletAddress
+	expected, ok, err := ReadNonceCursor(ctx, r.opts.DB, hotWallet)
+	if err != nil {
+		return gapHalt, fmt.Errorf("ReadNonceCursor: %w", err)
+	}
+	if !ok {
+		return gapProceed, nil
+	}
+
+	// Per-cycle two-RPC pending-nonce read, reusing the audited
+	// ColdStartNonceSync discipline (both RPCs, "pending" tag, ±1
+	// tolerance, chosen = max). observed = chosen. A returned error is
+	// either a transient RPC failure OR a >1 cross-RPC disagreement;
+	// both mean "skip the gap check this cycle" — NOT a gap.
+	observed, _, _, _, err := r.opts.RPCs.ColdStartNonceSync(ctx, hotWallet)
+	if err != nil {
+		// Nonce state is UNVERIFIABLE this cycle (transient RPC failure OR
+		// a >1 cross-RPC disagreement). Fail CLOSED: HALT rather than
+		// allocate against an unverified cursor — an unverified read is
+		// exactly the state in which a fresh N+1 could be dropped into a
+		// hole and stall. Info diagnostic only; a chronic RPC outage is
+		// separately PAGEd by the chronic-outage detector. Redact the raw
+		// error (an RPC URL can carry a secret) — log only a classified
+		// error class, never err.Error()/the URL.
+		r.opts.Logger.Warn().
+			Str("event", "payout_nonce_gap_precheck_skipped").
+			Str("error_class", classifyRPCErr(err)).
+			Str("from_address", strings.ToLower(hotWallet)).
+			Str("ts_utc", now.UTC().Format(time.RFC3339Nano)).
+			Send()
+		return gapHalt, nil
+	}
+
+	if observed >= expected {
+		return gapProceed, nil
+	}
+
+	// observed < expected: a nonce MAY be missing at nonce == observed.
+	// Resolve via the payout_attempts row there. Fail closed on everything
+	// except a positively-benign crash-recovery.
+
+	// 1. Rebroadcastable attempt AT observed → benign crash-recovery; the
+	//    persisted bytes re-broadcast next cycle and fill the nonce. This
+	//    is the ONLY proceed path in this branch.
+	rebroad, err := rebroadcastableAttemptExists(ctx, r.opts.DB, hotWallet, observed)
+	if err != nil {
+		return gapHalt, fmt.Errorf("rebroadcastableAttemptExists: %w", err)
+	}
+	if rebroad {
+		// R2-HIGH (architect Option A): the persisted bytes WILL be
+		// re-broadcast to fill the hole, but only if the recovery attempt
+		// is actually driven this cycle. Do NOT blanket-proceed (that let
+		// the row loop fresh-allocate N+1 past the hole when the recovery
+		// row was unselectable or its rebroadcast failed). Enter
+		// recovery-only mode: the normal row loop rebroadcasts the
+		// selected recovery attempt (and any live cancel) while
+		// processRow suppresses fresh allocation. Capture observed +
+		// expected purely so RunOnce can emit the per-cycle
+		// payout_nonce_gap_recovery_only diagnostic.
+		r.gapRecoveryObservedNonce = observed
+		r.gapRecoveryExpectedNonce = expected
+		return gapRecoveryOnly, nil
+	}
+
+	// 2. Durable abandon CAUSE AT observed (abandoned, unconfirmed,
+	//    non-cancel) → a real abandon hole. Emit §7.1 payout_nonce_gap
+	//    (WARN) and HALT. Checked before the reorg-suspect fallback so the
+	//    dual case (a real abandon CAUSE and a stale confirmed row both at
+	//    observed) is reported as the more specific payout_nonce_gap.
+	cause, err := nonceGapCauseExists(ctx, r.opts.DB, hotWallet, observed)
+	if err != nil {
+		return gapHalt, fmt.Errorf("nonceGapCauseExists: %w", err)
+	}
+	if cause {
+		r.opts.Logger.Warn().
+			Str("event", "payout_nonce_gap").
+			Str("severity", "WARN").
+			Str("from_address", strings.ToLower(hotWallet)).
+			Uint64("expected_nonce", expected).
+			Uint64("observed_pending_nonce", observed).
+			Str("ts_utc", now.UTC().Format(time.RFC3339Nano)).
+			Send()
+		return gapHalt, nil
+	}
+
+	// 3. Otherwise: a confirmed row sits at observed (stale-by-definition,
+	//    since observed is not yet mined → reorged-out inside the reorg
+	//    window), OR nothing at all sits at observed (chain-contradicted /
+	//    unexplained). Both are uncertain, so HALT fail-closed. Emit an
+	//    info payout_nonce_gap_reorg_suspect (NO raw RPC error/URL); the
+	//    reorg poller reconciles the stale row and emits its own
+	//    payout_reorg_* alerts.
+	r.opts.Logger.Warn().
+		Str("event", "payout_nonce_gap_reorg_suspect").
+		Str("from_address", strings.ToLower(hotWallet)).
+		Uint64("expected_nonce", expected).
+		Uint64("observed_pending_nonce", observed).
+		Str("ts_utc", now.UTC().Format(time.RFC3339Nano)).
+		Send()
+	return gapHalt, nil
 }
 
 type rowOutcome int
@@ -788,6 +1034,16 @@ func (r *Runner) processRow(ctx context.Context, runID string, row ReadyRow) (ro
 		return rowOutcomeSkipped, nil
 	}
 
+	// R2-HIGH (architect Option A): in recovery-only mode suppress ONLY
+	// this terminal fresh-allocation call site. Every earlier branch
+	// (claimAndLog, rebroadcastAndPoll, pollAndConfirm, cancel handling)
+	// has already run unchanged above, so recovery rebroadcast + all
+	// unrelated in-flight polls/confirms still progress this cycle — only
+	// a FRESH nonce allocation past the unfilled hole is prevented.
+	if r.recoveryOnly {
+		return rowOutcomeSkipped, nil
+	}
+
 	// Fresh allocation (§4.3 step 5 — INSERT inside BEGIN IMMEDIATE).
 	return r.allocateBuildSignBroadcast(ctx, runID, row, amount)
 }
@@ -798,9 +1054,14 @@ func (r *Runner) processRow(ctx context.Context, runID string, row ReadyRow) (ro
 // accept, then transition to pollAndConfirm. Closes
 // [code:1.1] MAJOR.
 func (r *Runner) rebroadcastAndPoll(ctx context.Context, conn *sql.Conn, runID string, row ReadyRow, attempt *AttemptRow) (rowOutcome, error) {
-	if !attempt.TxHash.Valid {
-		// Defensive: a row with raw_signed_tx but no tx_hash is a
-		// SPEC violation. Surface as invariant.
+	if !attempt.TxHash.Valid || attempt.TxHash.String == "" {
+		// Defensive: a row with raw_signed_tx but NULL or EMPTY tx_hash is
+		// a SPEC violation and is NOT rebroadcastable. R2-LOW-2: this Go
+		// precondition must match the round-1-tightened
+		// rebroadcastableAttemptExists SQL (tx_hash IS NOT NULL AND
+		// tx_hash <> ''); a malformed empty-hash row must fall through to
+		// fail-closed here, never attempt a malformed rebroadcast. Surface
+		// as invariant.
 		r.emitInvariantViolation(row.PayoutID, "raw_signed_tx_without_hash", fmt.Sprintf("attempt_seq=%d", attempt.AttemptSeq))
 		return rowOutcomeFailed, nil
 	}

--- a/phase4-coordinator/internal/payout/runner_nonce_gap_test.go
+++ b/phase4-coordinator/internal/payout/runner_nonce_gap_test.go
@@ -1,0 +1,538 @@
+package payout
+
+import (
+	"bytes"
+	"context"
+	"database/sql"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/rs/zerolog"
+)
+
+// nonceGapSetup wires a runner with a capture buffer so tests can
+// assert exactly which §7.1 events the payout_nonce_gap pre-check
+// emits, plus a `sent` flag proving the cycle broadcasts NOTHING when
+// it halts on a gap.
+type nonceGapSetup struct {
+	runner  *Runner
+	db      *sql.DB
+	buf     *bytes.Buffer
+	hotAddr string
+	sent    *bool
+}
+
+func setupNonceGapRunner(t *testing.T, cursor uint64) *nonceGapSetup {
+	t.Helper()
+	db := openTestDB(t)
+	rawHex := "59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d"
+	raw, _ := hex.DecodeString(rawHex)
+	signer, err := NewLocalFileSignerFromKey(raw)
+	if err != nil {
+		t.Fatalf("signer: %v", err)
+	}
+	hotAddr := signer.FromAddress()
+
+	buf := &bytes.Buffer{}
+	logger := zerolog.New(buf)
+	state, _, err := Acquire(context.Background(), db, testRunInterval, logger)
+	if err != nil {
+		t.Fatalf("Acquire: %v", err)
+	}
+	if err := UpsertNonceCursor(context.Background(), db, hotAddr, cursor, 0, 0, NowUTC()); err != nil {
+		t.Fatalf("UpsertNonceCursor: %v", err)
+	}
+
+	sent := false
+	markSent := func(_ context.Context, _ []byte) (string, error) {
+		sent = true
+		return "0xdeadbeef", nil
+	}
+	primary := &mockRPCClient{label: "primary", sendFn: markSent}
+	secondary := &mockRPCClient{label: "secondary", sendFn: markSent}
+
+	opts := RunnerOptions{
+		DB:                    db,
+		Security:              SecurityConfig{HotWalletAddress: hotAddr},
+		RPCs:                  TwoRPCs{Primary: primary, Secondary: secondary},
+		Signer:                signer,
+		Claimer:               &mockClaimer{claimed: true},
+		Logger:                logger,
+		RunInterval:           testRunInterval,
+		MaxRowsPerRun:         50,
+		ConfirmationBlocks:    5,
+		PerPayoutCapBaseUnits: 1_000_000_000_000,
+		PerDayCapBaseUnits:    10_000_000_000_000,
+		ReceiptPollInterval:   1 * time.Millisecond,
+		ReceiptPollTimeout:    100 * time.Millisecond,
+		NowFn:                 func() time.Time { return time.Now().UTC() },
+	}
+	runner, err := NewRunner(opts, state)
+	if err != nil {
+		t.Fatalf("NewRunner: %v", err)
+	}
+	// Default: both RPCs agree on pending nonce == cursor (steady state).
+	primary.txCountFn = pendingFn(cursor)
+	secondary.txCountFn = pendingFn(cursor)
+	return &nonceGapSetup{runner: runner, db: db, buf: buf, hotAddr: hotAddr, sent: &sent}
+}
+
+// setPending makes both RPCs report the same pending nonce.
+func (s *nonceGapSetup) setPending(n uint64) {
+	s.runner.opts.RPCs.Primary.(*mockRPCClient).txCountFn = pendingFn(n)
+	s.runner.opts.RPCs.Secondary.(*mockRPCClient).txCountFn = pendingFn(n)
+}
+
+// setPendingSplit makes the two RPCs disagree (a on primary, b on
+// secondary).
+func (s *nonceGapSetup) setPendingSplit(a, b uint64) {
+	s.runner.opts.RPCs.Primary.(*mockRPCClient).txCountFn = pendingFn(a)
+	s.runner.opts.RPCs.Secondary.(*mockRPCClient).txCountFn = pendingFn(b)
+}
+
+// seedAbandonedNonCancel inserts an abandoned, unconfirmed, non-cancel
+// attempt occupying `nonce` — the CAUSE of a nonce_gap (an operator
+// abandon WITHOUT a cancel per §4.6).
+func (s *nonceGapSetup) seedAbandonedNonCancel(t *testing.T, payoutID int64, nonce uint64) {
+	t.Helper()
+	now := NowUTC()
+	if _, err := s.db.ExecContext(context.Background(), `
+INSERT INTO payout_attempts
+  (payout_id, attempt_seq, chain, from_address, to_address,
+   amount_base_units, nonce, is_cancel_self_transfer,
+   abandoned_at_utc, abandoned_reason, updated_at_utc)
+VALUES (?, 1, 'base-mainnet', ?, '0x00000000000000000000000000000000000000to',
+        100, ?, 0, ?, 'operator-abandon-no-cancel', ?)`,
+		payoutID, strings.ToLower(s.hotAddr), int64(nonce), now, now); err != nil {
+		t.Fatalf("seed abandoned non-cancel: %v", err)
+	}
+}
+
+// seedLivePersistedUnbroadcast inserts a crash-recovery attempt
+// (raw_signed_tx present, not broadcast, not confirmed, not abandoned)
+// occupying `nonce`.
+func (s *nonceGapSetup) seedLivePersistedUnbroadcast(t *testing.T, payoutID int64, nonce uint64) {
+	t.Helper()
+	now := NowUTC()
+	if _, err := s.db.ExecContext(context.Background(), `
+INSERT INTO payout_attempts
+  (payout_id, attempt_seq, chain, from_address, to_address,
+   amount_base_units, nonce, raw_signed_tx, tx_hash,
+   is_cancel_self_transfer, updated_at_utc)
+VALUES (?, 2, 'base-mainnet', ?, '0x00000000000000000000000000000000000000to',
+        100, ?, X'0102', '0xhash', 0, ?)`,
+		payoutID, strings.ToLower(s.hotAddr), int64(nonce), now); err != nil {
+		t.Fatalf("seed live persisted-unbroadcast: %v", err)
+	}
+}
+
+// seedConfirmedCancel inserts a confirmed cancel-self-transfer filling
+// `nonce`.
+func (s *nonceGapSetup) seedConfirmedCancel(t *testing.T, payoutID int64, nonce uint64) {
+	t.Helper()
+	now := NowUTC()
+	if _, err := s.db.ExecContext(context.Background(), `
+INSERT INTO payout_attempts
+  (payout_id, attempt_seq, chain, from_address, to_address,
+   amount_base_units, nonce, tx_hash, broadcast_at_utc, confirmed_at_utc,
+   is_cancel_self_transfer, updated_at_utc)
+VALUES (?, 3, 'base-mainnet', ?, ?, 1, ?, '0xcancelhash', ?, ?, 1, ?)`,
+		payoutID, strings.ToLower(s.hotAddr), strings.ToLower(s.hotAddr),
+		int64(nonce), now, now, now); err != nil {
+		t.Fatalf("seed confirmed cancel: %v", err)
+	}
+}
+
+func pendingFn(n uint64) func(context.Context, string) (uint64, error) {
+	return func(context.Context, string) (uint64, error) { return n, nil }
+}
+
+// attemptCount returns the total payout_attempts row count — the
+// R2-MEDIUM zero-ALLOCATION probe: a fail-closed / recovery-only cycle
+// must never INSERT a fresh attempt row.
+func (s *nonceGapSetup) attemptCount(t *testing.T) int {
+	t.Helper()
+	var n int
+	if err := s.db.QueryRowContext(context.Background(),
+		`SELECT COUNT(*) FROM payout_attempts`).Scan(&n); err != nil {
+		t.Fatalf("count payout_attempts: %v", err)
+	}
+	return n
+}
+
+// cursorNow reads the current wallet_nonce_cursor.next_nonce — the other
+// half of the R2-MEDIUM zero-ALLOCATION probe: a fresh allocation bumps
+// this cursor, so an unchanged cursor proves no nonce was allocated.
+func (s *nonceGapSetup) cursorNow(t *testing.T) uint64 {
+	t.Helper()
+	cur, ok, err := ReadNonceCursor(context.Background(), s.db, s.hotAddr)
+	if err != nil || !ok {
+		t.Fatalf("ReadNonceCursor: ok=%v err=%v", ok, err)
+	}
+	return cur
+}
+
+// assertNoAllocation asserts that neither a new payout_attempts row was
+// INSERTed nor the nonce cursor bumped since the baseline snapshot — the
+// R2-MEDIUM assertion that a fail-closed / recovery-only cycle allocates
+// ZERO nonces (not merely broadcasts nothing).
+func assertNoAllocation(t *testing.T, s *nonceGapSetup, wantCount int, wantCursor uint64) {
+	t.Helper()
+	if got := s.attemptCount(t); got != wantCount {
+		t.Errorf("payout_attempts count = %d, want %d (cycle must NOT allocate a fresh attempt)", got, wantCount)
+	}
+	if got := s.cursorNow(t); got != wantCursor {
+		t.Errorf("nonce cursor = %d, want %d (cycle must NOT bump the cursor)", got, wantCursor)
+	}
+}
+
+// findEvent returns the first newline-delimited JSON log line whose
+// "event" field equals name, or nil.
+func findEvent(t *testing.T, buf *bytes.Buffer, name string) map[string]any {
+	t.Helper()
+	for _, line := range strings.Split(strings.TrimSpace(buf.String()), "\n") {
+		if line == "" {
+			continue
+		}
+		var ev map[string]any
+		if err := json.Unmarshal([]byte(line), &ev); err != nil {
+			continue
+		}
+		if ev["event"] == name {
+			return ev
+		}
+	}
+	return nil
+}
+
+// TestRunner_NonceGap_DetectedHaltsAndEmits is the core regression: an
+// operator abandon WITHOUT a cancel (the latent-stall bug) leaves an
+// abandoned non-cancel attempt at nonce N while the DB cursor advanced
+// to N+1. With both RPCs reporting pending == N (observed < expected),
+// RunOnce MUST halt the whole cycle, emit payout_nonce_gap (WARN) with
+// from_address / expected_nonce=N+1 / observed_pending_nonce=N, and
+// broadcast NOTHING.
+func TestRunner_NonceGap_DetectedHaltsAndEmits(t *testing.T) {
+	const N = uint64(7)
+	s := setupNonceGapRunner(t, N+1) // cursor = expected = N+1
+	pid := insertReadyRow(t, s.db, "p1", "settle:p1:gap")
+	s.seedAbandonedNonCancel(t, pid, N)
+	// R4 MEDIUM (non-vacuous zero-allocation): seed a SELECTABLE ready
+	// payout for a DIFFERENT provider (payout-allowed address + ready row)
+	// so a regression that failed to halt WOULD fresh-allocate a nonce and
+	// broadcast it (markSent flips *s.sent). Without a selectable candidate
+	// the zero-alloc / zero-broadcast asserts below could pass vacuously —
+	// nothing would allocate regardless of whether the halt fired.
+	insertPayoutAddress(t, s.db, "p2", s.hotAddr)
+	insertReadyRow(t, s.db, "p2", "settle:p2:gap-selectable")
+	s.setPending(N) // observed = N < expected = N+1
+
+	baseCount, baseCursor := s.attemptCount(t), s.cursorNow(t)
+	if _, err := s.runner.RunOnce(context.Background()); err != nil {
+		t.Fatalf("RunOnce: %v", err)
+	}
+	// R3 MEDIUM: a detected-gap halt must allocate ZERO nonces (no fresh
+	// attempt row, cursor unmoved) — not merely broadcast nothing.
+	assertNoAllocation(t, s, baseCount, baseCursor)
+
+	ev := findEvent(t, s.buf, "payout_nonce_gap")
+	if ev == nil {
+		t.Fatalf("payout_nonce_gap not emitted; log=%s", s.buf.String())
+	}
+	if ev["severity"] != "WARN" {
+		t.Errorf("severity = %v, want WARN", ev["severity"])
+	}
+	if ev["level"] != "warn" {
+		t.Errorf("level = %v, want warn", ev["level"])
+	}
+	if got := ev["from_address"]; got != strings.ToLower(s.hotAddr) {
+		t.Errorf("from_address = %v, want %s", got, strings.ToLower(s.hotAddr))
+	}
+	if got, ok := ev["expected_nonce"].(float64); !ok || uint64(got) != N+1 {
+		t.Errorf("expected_nonce = %v, want %d", ev["expected_nonce"], N+1)
+	}
+	if got, ok := ev["observed_pending_nonce"].(float64); !ok || uint64(got) != N {
+		t.Errorf("observed_pending_nonce = %v, want %d", ev["observed_pending_nonce"], N)
+	}
+	if _, ok := ev["ts_utc"]; !ok {
+		t.Error("missing ts_utc")
+	}
+	if *s.sent {
+		t.Error("cycle broadcast a transaction on a halted nonce-gap cycle")
+	}
+}
+
+// TestRunner_NonceGap_FailClosed locks the §7.1 gate's fail-CLOSED
+// semantics after the audit-round-1 fix: the ONLY path that proceeds to
+// allocation in the observed<expected branch is a benign
+// rebroadcastable crash-recovery. Everything uncertain HALTS the cycle
+// and broadcasts NOTHING. Each subtest seeds a payout-allowed address +
+// ready row so a SPURIOUS proceed WOULD broadcast — asserting
+// sent==false is therefore a real "zero broadcast" proof, not a vacuous
+// one.
+func TestRunner_NonceGap_FailClosed(t *testing.T) {
+	// runCycle executes one cycle and fails on unexpected errors.
+	runCycle := func(t *testing.T, s *nonceGapSetup) {
+		t.Helper()
+		if _, err := s.runner.RunOnce(context.Background()); err != nil {
+			t.Fatalf("RunOnce: %v", err)
+		}
+	}
+	assertNoGapAlert := func(t *testing.T, s *nonceGapSetup) {
+		t.Helper()
+		if ev := findEvent(t, s.buf, "payout_nonce_gap"); ev != nil {
+			t.Fatalf("payout_nonce_gap wrongly emitted: %v", ev)
+		}
+	}
+	assertZeroBroadcast := func(t *testing.T, s *nonceGapSetup) {
+		t.Helper()
+		if *s.sent {
+			t.Error("cycle broadcast a transaction on a halted nonce-gap cycle")
+		}
+	}
+
+	// --- PROCEED paths (no halt, cycle continues) ------------------------
+
+	t.Run("steady_state", func(t *testing.T) {
+		// observed == expected → early return, normal cycle, no gap.
+		s := setupNonceGapRunner(t, 5)
+		s.setPending(5)
+		runCycle(t, s)
+		assertNoGapAlert(t, s)
+		if findEvent(t, s.buf, "payout_nonce_gap_reorg_suspect") != nil {
+			t.Error("steady state must not emit reorg_suspect")
+		}
+	})
+
+	t.Run("observed_greater_than_expected", func(t *testing.T) {
+		// observed > expected is an out-of-band-spend class, NOT a gap;
+		// early return, no halt.
+		s := setupNonceGapRunner(t, 5)
+		s.setPending(9)
+		runCycle(t, s)
+		assertNoGapAlert(t, s)
+		if findEvent(t, s.buf, "payout_nonce_gap_reorg_suspect") != nil {
+			t.Error("observed>expected must not emit reorg_suspect")
+		}
+	})
+
+	t.Run("crash_recovery_rebroadcastable_proceeds", func(t *testing.T) {
+		// A live persisted-but-unbroadcast attempt fills the nonce (D4):
+		// the ONLY proceed path in the observed<expected branch. With the
+		// address row present the cycle actually continues and REACHES the
+		// broadcast path (rebroadcast of the persisted bytes) — proving the
+		// gate let it through rather than silently processing zero rows.
+		const N = uint64(4)
+		s := setupNonceGapRunner(t, N+1)
+		insertPayoutAddress(t, s.db, "p1", s.hotAddr)
+		pid := insertReadyRow(t, s.db, "p1", "settle:p1:crash")
+		s.seedAbandonedNonCancel(t, pid, N)       // CAUSE present
+		s.seedLivePersistedUnbroadcast(t, pid, N) // but rebroadcastable at N
+		s.setPending(N)
+		runCycle(t, s)
+		assertNoGapAlert(t, s)
+		if findEvent(t, s.buf, "payout_nonce_gap_reorg_suspect") != nil {
+			t.Errorf("crash-recovery must not emit reorg_suspect; log=%s", s.buf.String())
+		}
+		if !*s.sent {
+			t.Error("crash-recovery proceed did not reach the broadcast path (rebroadcast)")
+		}
+	})
+
+	// --- HALT paths (fail closed, zero broadcast) ------------------------
+
+	t.Run("rpc_disagreement_gt1_halts", func(t *testing.T) {
+		// |a-b| > 1 → nonce state unverifiable → HALT fail-closed. Emit
+		// precheck_skipped, no payout_nonce_gap, and broadcast NOTHING even
+		// though a ready payout is waiting.
+		s := setupNonceGapRunner(t, 9)
+		insertPayoutAddress(t, s.db, "p1", s.hotAddr)
+		pid := insertReadyRow(t, s.db, "p1", "settle:p1:disagree")
+		s.seedAbandonedNonCancel(t, pid, 7)
+		s.setPendingSplit(7, 12) // diff = 5 > 1
+		baseCount, baseCursor := s.attemptCount(t), s.cursorNow(t)
+		runCycle(t, s)
+		assertNoGapAlert(t, s)
+		assertZeroBroadcast(t, s)
+		assertNoAllocation(t, s, baseCount, baseCursor)
+		if findEvent(t, s.buf, "payout_nonce_gap_precheck_skipped") == nil {
+			t.Errorf("expected payout_nonce_gap_precheck_skipped; log=%s", s.buf.String())
+		}
+	})
+
+	t.Run("rpc_hard_error_halts_and_redacts", func(t *testing.T) {
+		// A hard RPC error (secret-bearing URL) → HALT fail-closed, zero
+		// broadcast, and the emitted diagnostic must NOT leak the raw
+		// error/URL (F4 redaction).
+		const secret = "https://mainnet.rpc.example/v2/SUPERSECRETKEY123"
+		s := setupNonceGapRunner(t, 9)
+		insertPayoutAddress(t, s.db, "p1", s.hotAddr)
+		pid := insertReadyRow(t, s.db, "p1", "settle:p1:hard")
+		s.seedAbandonedNonCancel(t, pid, 8)
+		hardErr := func(context.Context, string) (uint64, error) {
+			return 0, fmt.Errorf("dial %s: connection refused", secret)
+		}
+		s.runner.opts.RPCs.Primary.(*mockRPCClient).txCountFn = hardErr
+		s.runner.opts.RPCs.Secondary.(*mockRPCClient).txCountFn = hardErr
+		baseCount, baseCursor := s.attemptCount(t), s.cursorNow(t)
+		runCycle(t, s)
+		assertNoGapAlert(t, s)
+		assertZeroBroadcast(t, s)
+		assertNoAllocation(t, s, baseCount, baseCursor)
+		ev := findEvent(t, s.buf, "payout_nonce_gap_precheck_skipped")
+		if ev == nil {
+			t.Fatalf("expected payout_nonce_gap_precheck_skipped; log=%s", s.buf.String())
+		}
+		if _, ok := ev["error_class"]; !ok {
+			t.Error("precheck_skipped must carry a classified error_class")
+		}
+		if strings.Contains(s.buf.String(), secret) || strings.Contains(s.buf.String(), "SUPERSECRETKEY") {
+			t.Errorf("diagnostic leaked the raw RPC URL/secret; log=%s", s.buf.String())
+		}
+	})
+
+	t.Run("confirmed_cancel_at_observed_halts_reorg_suspect", func(t *testing.T) {
+		// A CONFIRMED cancel row sits at observed. Since observed is not yet
+		// mined, that confirmed_at_utc is stale-by-definition (reorged-out),
+		// so it must NOT suppress the gap. No abandon CAUSE present → step 3
+		// → HALT as reorg_suspect, zero broadcast.
+		const N = uint64(3)
+		s := setupNonceGapRunner(t, N+1)
+		insertPayoutAddress(t, s.db, "p1", s.hotAddr)
+		pid := insertReadyRow(t, s.db, "p1", "settle:p1:cancel")
+		s.seedConfirmedCancel(t, pid, N) // confirmed cancel at N, no abandon cause
+		s.setPending(N)
+		baseCount, baseCursor := s.attemptCount(t), s.cursorNow(t)
+		runCycle(t, s)
+		assertNoGapAlert(t, s)
+		assertZeroBroadcast(t, s)
+		assertNoAllocation(t, s, baseCount, baseCursor)
+		assertReorgSuspect(t, s, s.hotAddr, N+1, N)
+	})
+
+	t.Run("cause_absent_halts_reorg_suspect", func(t *testing.T) {
+		// observed < expected but NOTHING sits at observed → chain-
+		// contradicted / unexplained → HALT fail-closed as reorg_suspect,
+		// zero broadcast (previously fell through to allocation).
+		const N = uint64(6)
+		s := setupNonceGapRunner(t, 8)
+		insertPayoutAddress(t, s.db, "p1", s.hotAddr)
+		_ = insertReadyRow(t, s.db, "p1", "settle:p1:absent")
+		s.setPending(N)
+		baseCount, baseCursor := s.attemptCount(t), s.cursorNow(t)
+		runCycle(t, s)
+		assertNoGapAlert(t, s)
+		assertZeroBroadcast(t, s)
+		assertNoAllocation(t, s, baseCount, baseCursor)
+		assertReorgSuspect(t, s, s.hotAddr, 8, N)
+	})
+
+	t.Run("dual_cause_and_confirmed_emits_nonce_gap", func(t *testing.T) {
+		// Architect dual scenario: a real abandon CAUSE and a stale
+		// confirmed cancel BOTH at observed. CAUSE check precedes the
+		// reorg-suspect fallback, so this reports the more specific
+		// payout_nonce_gap (WARN) and HALTs, zero broadcast.
+		const N = uint64(3)
+		s := setupNonceGapRunner(t, N+1)
+		insertPayoutAddress(t, s.db, "p1", s.hotAddr)
+		pid := insertReadyRow(t, s.db, "p1", "settle:p1:dual")
+		s.seedAbandonedNonCancel(t, pid, N)
+		s.seedConfirmedCancel(t, pid, N)
+		s.setPending(N)
+		baseCount, baseCursor := s.attemptCount(t), s.cursorNow(t)
+		runCycle(t, s)
+		assertZeroBroadcast(t, s)
+		assertNoAllocation(t, s, baseCount, baseCursor)
+		if findEvent(t, s.buf, "payout_nonce_gap") == nil {
+			t.Errorf("dual case must emit payout_nonce_gap; log=%s", s.buf.String())
+		}
+		if findEvent(t, s.buf, "payout_nonce_gap_reorg_suspect") != nil {
+			t.Error("dual case must NOT emit reorg_suspect (cause takes precedence)")
+		}
+	})
+}
+
+// assertReorgSuspect asserts a payout_nonce_gap_reorg_suspect info event
+// fired with the expected redacted fields and no raw RPC error/URL.
+func assertReorgSuspect(t *testing.T, s *nonceGapSetup, hotAddr string, expected, observed uint64) {
+	t.Helper()
+	ev := findEvent(t, s.buf, "payout_nonce_gap_reorg_suspect")
+	if ev == nil {
+		t.Fatalf("payout_nonce_gap_reorg_suspect not emitted; log=%s", s.buf.String())
+	}
+	if got := ev["from_address"]; got != strings.ToLower(hotAddr) {
+		t.Errorf("from_address = %v, want %s", got, strings.ToLower(hotAddr))
+	}
+	if got, ok := ev["expected_nonce"].(float64); !ok || uint64(got) != expected {
+		t.Errorf("expected_nonce = %v, want %d", ev["expected_nonce"], expected)
+	}
+	if got, ok := ev["observed_pending_nonce"].(float64); !ok || uint64(got) != observed {
+		t.Errorf("observed_pending_nonce = %v, want %d", ev["observed_pending_nonce"], observed)
+	}
+	if _, ok := ev["ts_utc"]; !ok {
+		t.Error("missing ts_utc")
+	}
+	// reorg_suspect must not carry a severity field (info diagnostic, not
+	// an alert) and must not leak a raw error string.
+	if _, ok := ev["severity"]; ok {
+		t.Error("reorg_suspect must not carry a severity field (it is a non-alert info event)")
+	}
+	if _, ok := ev["error"]; ok {
+		t.Error("reorg_suspect must not carry a raw error field")
+	}
+}
+
+// TestRunner_NonceGap_RestartCursorMonotonic (F2) proves the cold-start
+// cursor is monotonic: a restart whose chosen RPC nonce LAGS the stored
+// cursor (because an abandoned-unfilled hole advanced the cursor past the
+// chain's pending nonce) must NOT drop the cursor and erase the hole.
+// Before the MAX() fix, UpsertNonceCursor overwrote the cursor to N,
+// making expected==observed==N so the very next checkNonceGap saw no gap
+// and allocated into the hole. After the fix the cursor stays N+1 and the
+// gap is still detected + halted.
+func TestRunner_NonceGap_RestartCursorMonotonic(t *testing.T) {
+	const N = uint64(7)
+	s := setupNonceGapRunner(t, N+1) // stored cursor = expected = N+1
+	pid := insertReadyRow(t, s.db, "p1", "settle:p1:restart")
+	s.seedAbandonedNonCancel(t, pid, N) // abandoned-unfilled hole at N
+
+	// Simulate a process restart: ColdStartNonceSync chose N (the chain
+	// pending nonce lags the DB cursor by 1). UpsertNonceCursor must keep
+	// the higher stored value.
+	if err := UpsertNonceCursor(context.Background(), s.db, s.hotAddr, N, N, N, NowUTC()); err != nil {
+		t.Fatalf("UpsertNonceCursor (restart): %v", err)
+	}
+	cur, ok, err := ReadNonceCursor(context.Background(), s.db, s.hotAddr)
+	if err != nil || !ok {
+		t.Fatalf("ReadNonceCursor: ok=%v err=%v", ok, err)
+	}
+	if cur != N+1 {
+		t.Fatalf("cursor regressed to %d after lagging restart, want %d (MAX must hold the hole)", cur, N+1)
+	}
+
+	// R4 MEDIUM (non-vacuous zero-allocation): seed a SELECTABLE ready
+	// payout for a DIFFERENT provider so a regression that dropped the
+	// cursor / erased the hole WOULD fresh-allocate + broadcast it. Makes
+	// the zero-alloc / zero-broadcast asserts below non-vacuous.
+	insertPayoutAddress(t, s.db, "p2", s.hotAddr)
+	insertReadyRow(t, s.db, "p2", "settle:p2:restart-selectable")
+
+	// The gap is still detectable + halts.
+	s.setPending(N) // observed = N < expected = N+1
+	baseCount, baseCursor := s.attemptCount(t), s.cursorNow(t)
+	if _, err := s.runner.RunOnce(context.Background()); err != nil {
+		t.Fatalf("RunOnce: %v", err)
+	}
+	if findEvent(t, s.buf, "payout_nonce_gap") == nil {
+		t.Fatalf("payout_nonce_gap not detected after monotonic restart; log=%s", s.buf.String())
+	}
+	if *s.sent {
+		t.Error("cycle broadcast on a halted nonce-gap cycle after restart")
+	}
+	// R3 MEDIUM: the restart-monotonicity halt must also allocate ZERO nonces.
+	assertNoAllocation(t, s, baseCount, baseCursor)
+}

--- a/phase4-coordinator/internal/payout/runner_recovery_only_test.go
+++ b/phase4-coordinator/internal/payout/runner_recovery_only_test.go
@@ -1,0 +1,587 @@
+package payout
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+)
+
+// R2-HIGH recovery-only regression suite (architect Option A + targeting
+// rider). Common shape: cursor = N+1, chain pending = N, a rebroadcastable
+// crash-recovery attempt R at nonce N for payout P_rec, plus a second ready
+// row P2 with NO existing attempt and a payout-allowed address — so P2 WOULD
+// fresh-allocate if the gate leaked. checkNonceGap therefore returns
+// gapRecoveryOnly; the cycle must drive R's rebroadcast + suppress ALL fresh
+// allocation.
+
+// countingSigner wraps a Signer to prove the fresh-allocation path (the ONLY
+// SignTx caller) is never reached in a recovery-only cycle. Rebroadcast
+// re-sends persisted bytes and never signs.
+type countingSigner struct {
+	inner Signer
+	calls int
+}
+
+func (c *countingSigner) FromAddress() string { return c.inner.FromAddress() }
+
+func (c *countingSigner) SignTx(ctx context.Context, unsignedTxBytes []byte) ([]byte, string, error) {
+	c.calls++
+	return c.inner.SignTx(ctx, unsignedTxBytes)
+}
+
+// recoveryRawBytes mirrors the raw_signed_tx seeded by
+// seedLivePersistedUnbroadcast (X'0102'). A broadcast of exactly these bytes
+// is the recovery rebroadcast; anything else is a FRESH broadcast.
+var recoveryRawBytes = []byte{0x01, 0x02}
+
+// broadcastRecorder classifies each SendRawTransaction call as a recovery
+// rebroadcast (raw == X'0102') or a fresh broadcast (a real signed tx).
+type broadcastRecorder struct {
+	recovery int
+	fresh    int
+}
+
+func (s *nonceGapSetup) installSigner(t *testing.T) *countingSigner {
+	t.Helper()
+	cs := &countingSigner{inner: s.runner.opts.Signer}
+	s.runner.opts.Signer = cs
+	return cs
+}
+
+// installBroadcastRecorder wires both RPC sendFns to classify broadcasts.
+// recoveryOK controls whether the recovery rebroadcast is accepted (T2/T4) or
+// rejected on both RPCs (T1). Fresh broadcasts always "succeed" so a leaked
+// fresh allocation would be unmistakably visible.
+func (s *nonceGapSetup) installBroadcastRecorder(t *testing.T, recoveryOK bool) *broadcastRecorder {
+	t.Helper()
+	rec := &broadcastRecorder{}
+	fn := func(_ context.Context, raw []byte) (string, error) {
+		if bytes.Equal(raw, recoveryRawBytes) {
+			rec.recovery++
+			if !recoveryOK {
+				// Non nonce-too-low rejection on both RPCs → acceptedAny=false.
+				return "", fmt.Errorf("rpc rejected rebroadcast")
+			}
+			return "0xrecoveryhash", nil
+		}
+		rec.fresh++
+		*s.sent = true
+		return "0xfreshhash", nil
+	}
+	s.runner.opts.RPCs.Primary.(*mockRPCClient).sendFn = fn
+	s.runner.opts.RPCs.Secondary.(*mockRPCClient).sendFn = fn
+	return rec
+}
+
+// rpcCallCounts tallies the confirmation/verification RPC calls a cycle makes
+// so a test can prove WHICH dispatch path ran (not merely its outcome):
+//   - receipt   → TransactionReceipt: the poll path (pollCancelOnce for a
+//     broadcast-unconfirmed cancel, pollAndConfirm for the normal USDC path).
+//   - txByHash  → TransactionByHash: reached only inside the verification
+//     bodies (verifyCancelTxView / verifyChainSideTransfer) after a confirmed
+//     receipt — i.e. the ERC-20 Transfer-log / cancel-tx-body verification.
+//   - callUSDC  → CallContract to the USDC contract: balance/verify reads.
+type rpcCallCounts struct {
+	receipt  int
+	txByHash int
+	callUSDC int
+}
+
+// installRPCCallCounters wires counting closures onto both RPCs' receipt,
+// tx-by-hash, and call-contract methods. Each closure preserves the mock's
+// default "absent" return (receipt/tx nil, empty call result) so runner
+// behavior is unchanged — only observability is added. Sequential RPC use
+// (BroadcastBoth / pollAndConfirm / pollCancelOnce all call Primary then
+// Secondary in-goroutine) makes the plain int counters race-safe.
+func (s *nonceGapSetup) installRPCCallCounters(t *testing.T) *rpcCallCounts {
+	t.Helper()
+	c := &rpcCallCounts{}
+	for _, rpc := range []*mockRPCClient{
+		s.runner.opts.RPCs.Primary.(*mockRPCClient),
+		s.runner.opts.RPCs.Secondary.(*mockRPCClient),
+	} {
+		rpc.receiptFn = func(context.Context, string) (*Receipt, error) { c.receipt++; return nil, nil }
+		rpc.txByHashFn = func(context.Context, string) (*Transaction, error) { c.txByHash++; return nil, nil }
+		rpc.callFn = func(context.Context, string, []byte) ([]byte, error) { c.callUSDC++; return nil, nil }
+	}
+	return c
+}
+
+// broadcastAtNull reports whether the attempt at (hot wallet, nonce) still has
+// a NULL broadcast_at_utc.
+func (s *nonceGapSetup) broadcastAtNull(t *testing.T, nonce uint64) bool {
+	t.Helper()
+	var isNull int
+	if err := s.db.QueryRowContext(context.Background(),
+		`SELECT broadcast_at_utc IS NULL FROM payout_attempts
+		  WHERE from_address = ? AND nonce = ? ORDER BY attempt_seq DESC LIMIT 1`,
+		strings.ToLower(s.hotAddr), int64(nonce)).Scan(&isNull); err != nil {
+		t.Fatalf("broadcastAtNull query: %v", err)
+	}
+	return isNull == 1
+}
+
+// insertPayoutAddressAllowed inserts a provider_payout_addresses row with an
+// explicit payout_allowed flag (insertPayoutAddress hardcodes allowed=1).
+func insertPayoutAddressAllowed(t *testing.T, s *nonceGapSetup, providerID string, allowed int) {
+	t.Helper()
+	canonicalHot, err := CanonicalizeEIP55(s.hotAddr)
+	if err != nil {
+		t.Fatalf("canonicalize hot wallet: %v", err)
+	}
+	past := "2026-01-01T00:00:00Z"
+	providerAddr := "0x000000000000000000000000000000000000dEaD"
+	if _, err := s.db.ExecContext(context.Background(), `
+INSERT INTO provider_payout_addresses
+  (provider_id, chain, address, payout_allowed, pending_until_utc,
+   rotated_from, registered_at_utc, registered_against_hot_wallet)
+VALUES (?, 'base-mainnet', ?, ?, ?, NULL, ?, ?)`,
+		providerID, providerAddr, allowed, past, past, canonicalHot); err != nil {
+		t.Fatalf("insert payout address: %v", err)
+	}
+}
+
+// TestRecoveryOnly_T1_RebroadcastFailsBoth_NoFreshAlloc: R's rebroadcast is
+// rejected on both RPCs; P2 must still NOT fresh-allocate. Proves the
+// pre-fix HIGH bug (fresh-alloc past the hole when recovery fails) is closed.
+func TestRecoveryOnly_T1_RebroadcastFailsBoth_NoFreshAlloc(t *testing.T) {
+	const N = uint64(4)
+	s := setupNonceGapRunner(t, N+1) // cursor = expected = N+1
+	insertPayoutAddress(t, s.db, "p_rec", s.hotAddr)
+	insertPayoutAddress(t, s.db, "p2", s.hotAddr)
+	pRec := insertReadyRow(t, s.db, "p_rec", "settle:p_rec:t1")
+	_ = insertReadyRow(t, s.db, "p2", "settle:p2:t1")
+	s.seedLivePersistedUnbroadcast(t, pRec, N) // rebroadcastable R at N
+	s.setPending(N)                            // observed = N < expected = N+1
+
+	cs := s.installSigner(t)
+	rec := s.installBroadcastRecorder(t, false /*recoveryOK*/)
+	baseCount, baseCursor := s.attemptCount(t), s.cursorNow(t)
+
+	if _, err := s.runner.RunOnce(context.Background()); err != nil {
+		t.Fatalf("RunOnce: %v", err)
+	}
+
+	if !s.broadcastAtNull(t, N) {
+		t.Error("R.broadcast_at_utc was stamped despite both-RPC rejection")
+	}
+	assertNoAllocation(t, s, baseCount, baseCursor) // no P2 attempt, cursor unmoved
+	if cs.calls != 0 {
+		t.Errorf("SignTx calls = %d, want 0 (no fresh allocation in recovery-only)", cs.calls)
+	}
+	if rec.fresh != 0 {
+		t.Errorf("fresh broadcasts = %d, want 0", rec.fresh)
+	}
+	if rec.recovery == 0 {
+		t.Error("recovery rebroadcast was never attempted")
+	}
+	if findEvent(t, s.buf, "payout_nonce_gap_recovery_only") == nil {
+		t.Errorf("payout_nonce_gap_recovery_only not emitted; log=%s", s.buf.String())
+	}
+}
+
+// TestRecoveryOnly_T2_RecoveryExcluded_PausesFailClosed: P_rec is absent from
+// SelectReadyPayouts (payout_allowed=0, then LIMIT off-page). With the R2
+// targeting rider deleted, an UNSELECTABLE recovery is no longer driven
+// out-of-band — the wallet PAUSES fail-closed: zero fresh allocation for the
+// second ready row P2, cursor unchanged, no signing, no broadcast at all, and
+// the per-cycle payout_nonce_gap_recovery_only WARN fires so the stuck hole is
+// visible to the operator until they intervene. (The intentional round-2
+// "rider drives recovery despite exclusion" behavior is removed as defective.)
+func TestRecoveryOnly_T2_RecoveryExcluded_PausesFailClosed(t *testing.T) {
+	const N = uint64(4)
+
+	assertPaused := func(t *testing.T, s *nonceGapSetup, cs *countingSigner, rec *broadcastRecorder, baseCount int, baseCursor uint64) {
+		t.Helper()
+		if cs.calls != 0 {
+			t.Errorf("SignTx calls = %d, want 0 (fail-closed pause: no fresh allocation)", cs.calls)
+		}
+		if rec.fresh != 0 {
+			t.Errorf("fresh broadcasts = %d, want 0", rec.fresh)
+		}
+		if rec.recovery != 0 {
+			t.Errorf("recovery rebroadcasts = %d, want 0 (unselectable recovery is NOT driven out-of-band)", rec.recovery)
+		}
+		if *s.sent {
+			t.Error("a transaction was broadcast during a fail-closed recovery-only pause")
+		}
+		// P2 must have zero new attempt; the cursor must not bump. R's row
+		// existed at baseline, so baseCount already includes it.
+		assertNoAllocation(t, s, baseCount, baseCursor)
+		if findEvent(t, s.buf, "payout_nonce_gap_recovery_only") == nil {
+			t.Errorf("payout_nonce_gap_recovery_only WARN not emitted on fail-closed pause; log=%s", s.buf.String())
+		}
+	}
+
+	t.Run("payout_allowed_0", func(t *testing.T) {
+		s := setupNonceGapRunner(t, N+1)
+		insertPayoutAddressAllowed(t, s, "p_rec", 0)  // NOT selectable
+		insertPayoutAddress(t, s.db, "p2", s.hotAddr) // allowed
+		pRec := insertReadyRow(t, s.db, "p_rec", "settle:p_rec:t2a")
+		_ = insertReadyRow(t, s.db, "p2", "settle:p2:t2a")
+		s.seedLivePersistedUnbroadcast(t, pRec, N)
+		s.setPending(N)
+
+		cs := s.installSigner(t)
+		rec := s.installBroadcastRecorder(t, true /*recoveryOK*/)
+		baseCount, baseCursor := s.attemptCount(t), s.cursorNow(t)
+
+		if _, err := s.runner.RunOnce(context.Background()); err != nil {
+			t.Fatalf("RunOnce: %v", err)
+		}
+		assertPaused(t, s, cs, rec, baseCount, baseCursor)
+	})
+
+	t.Run("off_page_via_limit", func(t *testing.T) {
+		s := setupNonceGapRunner(t, N+1)
+		s.runner.opts.MaxRowsPerRun = 1 // only the first row by id is selected
+		// P2 gets the lower id so it fills the single SELECT slot; P_rec is
+		// off-page. With the rider gone it is unreachable this cycle → pause.
+		insertPayoutAddress(t, s.db, "p2", s.hotAddr)
+		insertPayoutAddress(t, s.db, "p_rec", s.hotAddr)
+		_ = insertReadyRow(t, s.db, "p2", "settle:p2:t2b")
+		pRec := insertReadyRow(t, s.db, "p_rec", "settle:p_rec:t2b")
+		s.seedLivePersistedUnbroadcast(t, pRec, N)
+		s.setPending(N)
+
+		cs := s.installSigner(t)
+		rec := s.installBroadcastRecorder(t, true /*recoveryOK*/)
+		baseCount, baseCursor := s.attemptCount(t), s.cursorNow(t)
+
+		if _, err := s.runner.RunOnce(context.Background()); err != nil {
+			t.Fatalf("RunOnce: %v", err)
+		}
+		assertPaused(t, s, cs, rec, baseCount, baseCursor)
+	})
+}
+
+// TestRecoveryOnly_T3_Liveness_FreshAllocProceeds proves recovery-only mode
+// does NOT leak into the steady-state happy path: observed==expected →
+// gapProceed → a fresh allocation happens (attempt inserted + cursor bumped +
+// fresh broadcast). This is the guard against a gate that latches safe forever.
+func TestRecoveryOnly_T3_Liveness_FreshAllocProceeds(t *testing.T) {
+	const N = uint64(5)
+	s := setupNonceGapRunner(t, N) // cursor == chain pending == steady state
+	insertPayoutAddress(t, s.db, "p1", s.hotAddr)
+	_ = insertReadyRow(t, s.db, "p1", "settle:p1:t3")
+	s.setPending(N) // observed == expected → gapProceed
+
+	cs := s.installSigner(t)
+	rec := s.installBroadcastRecorder(t, true)
+	baseCount, baseCursor := s.attemptCount(t), s.cursorNow(t)
+
+	if _, err := s.runner.RunOnce(context.Background()); err != nil {
+		t.Fatalf("RunOnce: %v", err)
+	}
+	if got := s.attemptCount(t); got != baseCount+1 {
+		t.Errorf("attempt count = %d, want %d (fresh allocation must insert one attempt)", got, baseCount+1)
+	}
+	if got := s.cursorNow(t); got != baseCursor+1 {
+		t.Errorf("cursor = %d, want %d (fresh allocation must bump the cursor)", got, baseCursor+1)
+	}
+	if cs.calls != 1 {
+		t.Errorf("SignTx calls = %d, want 1 (one fresh allocation)", cs.calls)
+	}
+	if rec.fresh != 2 { // both RPCs
+		t.Errorf("fresh broadcasts = %d, want 2 (both RPCs, one fresh tx)", rec.fresh)
+	}
+	if findEvent(t, s.buf, "payout_nonce_gap_recovery_only") != nil {
+		t.Error("steady state must NOT emit payout_nonce_gap_recovery_only")
+	}
+}
+
+// TestRecoveryOnly_T4_Convergence: cycle 1 accepts R's rebroadcast (stamps
+// broadcast_at) but does NOT fresh-allocate P2 that same cycle; cycle 2 (now
+// observed==expected) proceeds normally and P2 fresh-allocates. Proves the
+// gate does not half-open mid-cycle and converges the next cycle.
+func TestRecoveryOnly_T4_Convergence(t *testing.T) {
+	const N = uint64(4)
+	s := setupNonceGapRunner(t, N+1)
+	insertPayoutAddress(t, s.db, "p_rec", s.hotAddr)
+	insertPayoutAddress(t, s.db, "p2", s.hotAddr)
+	pRec := insertReadyRow(t, s.db, "p_rec", "settle:p_rec:t4")
+	_ = insertReadyRow(t, s.db, "p2", "settle:p2:t4")
+	s.seedLivePersistedUnbroadcast(t, pRec, N)
+	s.setPending(N) // observed = N < expected = N+1 → recovery-only
+
+	cs := s.installSigner(t)
+	rec := s.installBroadcastRecorder(t, true /*recoveryOK*/)
+	baseCount, baseCursor := s.attemptCount(t), s.cursorNow(t)
+
+	// --- Cycle 1: recovery-only ---
+	if _, err := s.runner.RunOnce(context.Background()); err != nil {
+		t.Fatalf("RunOnce cycle1: %v", err)
+	}
+	if s.broadcastAtNull(t, N) {
+		t.Error("cycle1: R.broadcast_at_utc not stamped after accepted rebroadcast")
+	}
+	if rec.recovery == 0 {
+		t.Error("cycle1: recovery rebroadcast not attempted")
+	}
+	if cs.calls != 0 {
+		t.Errorf("cycle1: SignTx calls = %d, want 0 (no fresh alloc mid-recovery)", cs.calls)
+	}
+	if rec.fresh != 0 {
+		t.Errorf("cycle1: fresh broadcasts = %d, want 0", rec.fresh)
+	}
+	if got := s.attemptCount(t); got != baseCount {
+		t.Errorf("cycle1: attempt count = %d, want %d (P2 must NOT fresh-allocate this cycle)", got, baseCount)
+	}
+	if got := s.cursorNow(t); got != baseCursor {
+		t.Errorf("cycle1: cursor = %d, want %d (must not bump mid-recovery)", got, baseCursor)
+	}
+
+	// --- Cycle 2: chain now includes N (R broadcast) → observed = N+1 == expected ---
+	s.buf.Reset()
+	s.setPending(N + 1)
+	cycle2BaseCount := s.attemptCount(t)
+	cycle2BaseCursor := s.cursorNow(t)
+	if _, err := s.runner.RunOnce(context.Background()); err != nil {
+		t.Fatalf("RunOnce cycle2: %v", err)
+	}
+	if findEvent(t, s.buf, "payout_nonce_gap_recovery_only") != nil {
+		t.Error("cycle2: must NOT re-enter recovery-only once observed==expected")
+	}
+	if got := s.attemptCount(t); got != cycle2BaseCount+1 {
+		t.Errorf("cycle2: attempt count = %d, want %d (P2 fresh-allocates now)", got, cycle2BaseCount+1)
+	}
+	if got := s.cursorNow(t); got != cycle2BaseCursor+1 {
+		t.Errorf("cycle2: cursor = %d, want %d (fresh allocation bumps cursor)", got, cycle2BaseCursor+1)
+	}
+	if cs.calls != 1 {
+		t.Errorf("cycle2: cumulative SignTx calls = %d, want 1 (one fresh alloc across both cycles)", cs.calls)
+	}
+}
+
+// seedLivePersistedUnbroadcastCancel inserts a persisted-but-unbroadcast
+// cancel-self-transfer (is_cancel_self_transfer=1) occupying `nonce`: raw bytes
+// = recoveryRawBytes (so installBroadcastRecorder classifies a rebroadcast of
+// it as "recovery", never "fresh"), tx_hash present, broadcast/confirmed/
+// abandoned all NULL. This matches rebroadcastableAttemptExists' predicate (no
+// is_cancel_self_transfer filter), so checkNonceGap enters gapRecoveryOnly.
+func (s *nonceGapSetup) seedLivePersistedUnbroadcastCancel(t *testing.T, payoutID int64, nonce uint64) {
+	t.Helper()
+	now := NowUTC()
+	if _, err := s.db.ExecContext(context.Background(), `
+INSERT INTO payout_attempts
+  (payout_id, attempt_seq, chain, from_address, to_address,
+   amount_base_units, nonce, raw_signed_tx, tx_hash,
+   is_cancel_self_transfer, updated_at_utc)
+VALUES (?, 2, 'base-mainnet', ?, ?,
+        1, ?, X'0102', '0xcancelhash', 1, ?)`,
+		payoutID, strings.ToLower(s.hotAddr), strings.ToLower(s.hotAddr),
+		int64(nonce), now); err != nil {
+		t.Fatalf("seed live persisted-unbroadcast cancel: %v", err)
+	}
+}
+
+// TestRecoveryOnly_CancelAtObserved_UsesCancelPath (R3 regression for the
+// deleted rider's cancel-misrouting bug): a persisted-unbroadcast CANCEL
+// (is_cancel_self_transfer=1) sits at the on-chain pending nonce and its payout
+// IS selectable. checkNonceGap → gapRecoveryOnly, and the NORMAL row loop must
+// rebroadcast it via the CANCEL dispatch (rebroadcastCancel), NEVER through the
+// generic provider-USDC verification path and NEVER ClaimPayoutReady. The
+// deleted rider routed every recovery through rebroadcastAndPoll→pollAndConfirm
+// (USDC-transfer verification), which would false-alarm payout_chain_value_mismatch
+// on a 1-wei self-transfer. This proves that misrouting is gone.
+func TestRecoveryOnly_CancelAtObserved_UsesCancelPath(t *testing.T) {
+	const N = uint64(4)
+	s := setupNonceGapRunner(t, N+1) // cursor = expected = N+1
+	insertPayoutAddress(t, s.db, "p_cancel", s.hotAddr)
+	pCancel := insertReadyRow(t, s.db, "p_cancel", "settle:p_cancel:cancelobs")
+	s.seedLivePersistedUnbroadcastCancel(t, pCancel, N)
+	s.setPending(N) // observed = N < expected = N+1 → recovery-only
+
+	cs := s.installSigner(t)
+	rec := s.installBroadcastRecorder(t, true /*recoveryOK*/)
+	counts := s.installRPCCallCounters(t)
+	claimer := s.runner.opts.Claimer.(*mockClaimer)
+	baseCount, baseCursor := s.attemptCount(t), s.cursorNow(t)
+
+	if _, err := s.runner.RunOnce(context.Background()); err != nil {
+		t.Fatalf("RunOnce: %v", err)
+	}
+
+	// The cancel was rebroadcast (its raw bytes == recoveryRawBytes → counted
+	// as a "recovery" broadcast, not a fresh one) via the CANCEL path.
+	if rec.recovery == 0 {
+		t.Error("cancel was never rebroadcast via the normal loop's cancel dispatch")
+	}
+	if rec.fresh != 0 {
+		t.Errorf("fresh broadcasts = %d, want 0 (a cancel must not fresh-allocate)", rec.fresh)
+	}
+	if cs.calls != 0 {
+		t.Errorf("SignTx calls = %d, want 0 (cancel rebroadcast re-sends persisted bytes)", cs.calls)
+	}
+	// R4 MEDIUM (prove the PATH, not just the outcome): an unbroadcast cancel
+	// at observed is dispatched through rebroadcastCancel (a pure
+	// SendRawTransaction of the persisted envelope — counted above as
+	// rec.recovery), and MUST NOT be routed through the generic USDC
+	// confirmation/verification path (pollAndConfirm → verifyChainSideTransfer).
+	// TransactionReceipt (the poll) and TransactionByHash (the chain-side value
+	// verification body) are made ONLY by that path in this cycle, so ZERO such
+	// reads proves the misrouting the deleted rider introduced (every recovery
+	// through pollAndConfirm's ERC-20 Transfer-log verification, which
+	// false-alarms on a 1-wei self-transfer) is gone. (pollCancelOnce itself is
+	// unreachable here: it fires only for a broadcast-unconfirmed cancel,
+	// whereas checkNonceGap enters recovery-only only for an *unbroadcast*
+	// rebroadcastable attempt — so the cancel is dispatched via
+	// rebroadcastCancel, never pollCancelOnce. CallContract is NOT asserted: it
+	// is the per-cycle hot-wallet USDC balance pre-flight, not part of either
+	// dispatch path.)
+	if counts.receipt != 0 {
+		t.Errorf("TransactionReceipt calls = %d, want 0 (USDC/cancel poll path must not run for a rebroadcast-only cancel)", counts.receipt)
+	}
+	if counts.txByHash != 0 {
+		t.Errorf("TransactionByHash calls = %d, want 0 (chain-side value verification must not run for a cancel)", counts.txByHash)
+	}
+	// NEVER claim: cancels do NOT consume ledger_payout_ready.
+	if len(claimer.calls) != 0 {
+		t.Errorf("ClaimPayoutReady calls = %d, want 0 (a cancel must never be claimed)", len(claimer.calls))
+	}
+	// NEVER the generic USDC-transfer value verification → no false mismatch.
+	if ev := findEvent(t, s.buf, "payout_chain_value_mismatch"); ev != nil {
+		t.Errorf("payout_chain_value_mismatch wrongly emitted for a cancel: %v", ev)
+	}
+	// broadcast_at stamped on the cancel (accepted); zero fresh allocation.
+	if s.broadcastAtNull(t, N) {
+		t.Error("cancel.broadcast_at_utc not stamped after accepted rebroadcast")
+	}
+	assertNoAllocation(t, s, baseCount, baseCursor)
+	if findEvent(t, s.buf, "payout_nonce_gap_recovery_only") == nil {
+		t.Errorf("payout_nonce_gap_recovery_only not emitted; log=%s", s.buf.String())
+	}
+}
+
+// TestRecoveryOnly_DelayedReceipt_PolledByNormalLoop (R3 regression for the
+// deleted rider's "accepted-but-delayed recovery left permanently unpolled"
+// bug): a recovery rebroadcast is accepted (broadcast_at stamped) but its
+// receipt is not yet present. The recovery attempt must keep being polled by
+// the NORMAL row loop on subsequent cycles (never stranded), must NOT be
+// double-claimed while unconfirmed, and must NOT leak a fresh allocation while
+// the hole persists.
+func TestRecoveryOnly_DelayedReceipt_PolledByNormalLoop(t *testing.T) {
+	const N = uint64(4)
+	s := setupNonceGapRunner(t, N+1) // cursor = expected = N+1
+	insertPayoutAddress(t, s.db, "p_rec", s.hotAddr)
+	pRec := insertReadyRow(t, s.db, "p_rec", "settle:p_rec:delayed")
+	s.seedLivePersistedUnbroadcast(t, pRec, N)
+	s.setPending(N) // observed = N < expected = N+1 → recovery-only
+
+	cs := s.installSigner(t)
+	rec := s.installBroadcastRecorder(t, true /*recoveryOK*/)
+	claimer := s.runner.opts.Claimer.(*mockClaimer)
+	// Receipt stays absent for the whole test (the counting closures return
+	// nil, matching the default receiptFn == nil), so R is accepted into the
+	// mempool but never confirms. The counters prove the NORMAL poll path is
+	// actually exercised (poll counter > 0) rather than silently skipped —
+	// otherwise the "not double-claimed / not stranded" asserts could pass
+	// vacuously if polling never ran at all.
+	counts := s.installRPCCallCounters(t)
+	baseCount, baseCursor := s.attemptCount(t), s.cursorNow(t)
+
+	// --- Cycle 1: recovery-only; rebroadcast accepted + stamped, unconfirmed ---
+	if _, err := s.runner.RunOnce(context.Background()); err != nil {
+		t.Fatalf("RunOnce cycle1: %v", err)
+	}
+	if s.broadcastAtNull(t, N) {
+		t.Error("cycle1: R.broadcast_at_utc not stamped after accepted rebroadcast")
+	}
+	if rec.recovery == 0 {
+		t.Error("cycle1: recovery rebroadcast not attempted")
+	}
+	if rec.fresh != 0 || cs.calls != 0 {
+		t.Errorf("cycle1: fresh=%d SignTx=%d, want 0/0 (no fresh alloc mid-recovery)", rec.fresh, cs.calls)
+	}
+	if len(claimer.calls) != 0 {
+		t.Errorf("cycle1: claim calls = %d, want 0 (receipt absent → not confirmed)", len(claimer.calls))
+	}
+	// R4 MEDIUM: cycle 1 rebroadcasts R then transitions to pollAndConfirm
+	// (the normal poll path), which polls the receipt — so the poll counter
+	// must have advanced. A regression that skipped polling would leave it 0.
+	if counts.receipt == 0 {
+		t.Error("cycle1: normal poll path never invoked (TransactionReceipt count == 0)")
+	}
+	assertNoAllocation(t, s, baseCount, baseCursor)
+
+	// --- Cycle 2: hole still open (pending lags at N), R now broadcast so no
+	// longer rebroadcastable → fail-closed halt; still zero alloc, no claim. ---
+	s.buf.Reset()
+	if _, err := s.runner.RunOnce(context.Background()); err != nil {
+		t.Fatalf("RunOnce cycle2: %v", err)
+	}
+	if len(claimer.calls) != 0 {
+		t.Errorf("cycle2: claim calls = %d, want 0", len(claimer.calls))
+	}
+	assertNoAllocation(t, s, baseCount, baseCursor)
+
+	// --- Cycle 3: pending advances to N+1 (tx reflected) but receipt STILL
+	// absent → gapProceed; the NORMAL loop polls R via pollAndConfirm. R stays
+	// unconfirmed (not stranded, not double-claimed), no fresh alloc leaks. ---
+	s.buf.Reset()
+	s.setPending(N + 1)
+	pollsBeforeC3 := counts.receipt
+	if _, err := s.runner.RunOnce(context.Background()); err != nil {
+		t.Fatalf("RunOnce cycle3: %v", err)
+	}
+	// R4 MEDIUM: cycle 3 is gapProceed; the NORMAL row loop must re-poll R via
+	// pollAndConfirm. Proven by a fresh TransactionReceipt read this cycle — R
+	// is not stranded/left permanently unpolled once the pending nonce catches
+	// up. A regression that dropped R from the normal loop would leave this 0.
+	if counts.receipt <= pollsBeforeC3 {
+		t.Errorf("cycle3: R was not re-polled by the normal loop (receipt count %d, want > %d)", counts.receipt, pollsBeforeC3)
+	}
+	if len(claimer.calls) != 0 {
+		t.Errorf("cycle3: claim calls = %d, want 0 (receipt still absent)", len(claimer.calls))
+	}
+	// R is still broadcast-but-unconfirmed and was re-polled by the normal
+	// loop, not left permanently unpolled.
+	if s.broadcastAtNull(t, N) {
+		t.Error("cycle3: R.broadcast_at_utc unexpectedly cleared")
+	}
+	// No fresh attempt was allocated (R is the only ready row); cursor holds.
+	assertNoAllocation(t, s, baseCount, baseCursor)
+}
+
+// TestRecoveryOnly_MalformedEmptyHash_NotRebroadcast (R2-LOW-2): an attempt
+// with non-empty raw_signed_tx but an EMPTY tx_hash is malformed and must NOT
+// be rebroadcast — the Go precondition must match the tightened
+// rebroadcastableAttemptExists SQL (tx_hash <> ”). It falls through to a
+// fail-closed invariant violation, broadcasting nothing.
+func TestRecoveryOnly_MalformedEmptyHash_NotRebroadcast(t *testing.T) {
+	const N = uint64(5)
+	s := setupNonceGapRunner(t, N) // steady state cursor; no gap
+	insertPayoutAddress(t, s.db, "p1", s.hotAddr)
+	pid := insertReadyRow(t, s.db, "p1", "settle:p1:malformed")
+	// Seed an attempt with raw bytes present but tx_hash = '' (empty string,
+	// NOT NULL). broadcast/confirmed/abandoned all NULL → processRow's
+	// rebroadcast branch (len(raw)>0 && !broadcast && !abandoned) is entered.
+	now := NowUTC()
+	if _, err := s.db.ExecContext(context.Background(), `
+INSERT INTO payout_attempts
+  (payout_id, attempt_seq, chain, from_address, to_address,
+   amount_base_units, nonce, raw_signed_tx, tx_hash,
+   is_cancel_self_transfer, updated_at_utc)
+VALUES (?, 1, 'base-mainnet', ?, '0x00000000000000000000000000000000000000to',
+        100, ?, X'0102', '', 0, ?)`,
+		pid, strings.ToLower(s.hotAddr), int64(N-1), now); err != nil {
+		t.Fatalf("seed malformed attempt: %v", err)
+	}
+	s.setPending(N) // observed == expected → gapProceed → processRow runs
+
+	if _, err := s.runner.RunOnce(context.Background()); err != nil {
+		t.Fatalf("RunOnce: %v", err)
+	}
+	if *s.sent {
+		t.Error("a malformed empty-tx_hash attempt was rebroadcast (must fail closed)")
+	}
+	ev := findEvent(t, s.buf, "payout_invariant_violation")
+	if ev == nil {
+		t.Fatalf("expected payout_invariant_violation for malformed empty-hash row; log=%s", s.buf.String())
+	}
+	if ev["where"] != "raw_signed_tx_without_hash" {
+		t.Errorf("invariant where = %v, want raw_signed_tx_without_hash", ev["where"])
+	}
+}

--- a/phase4-coordinator/internal/payout/runner_test.go
+++ b/phase4-coordinator/internal/payout/runner_test.go
@@ -1295,6 +1295,15 @@ VALUES (?, 1, 'base-mainnet', ?, ?, 80, 1, X'02', ?, ?, ?, 100, 0, ?)`,
 	}
 	secondary.txByHashFn = primary.txByHashFn
 
+	// Realistic on-chain pending nonce for the §7.1 pre-check: the prior
+	// confirmed attempt consumed nonce 1, so the chain pending nonce is 2
+	// == the DB cursor (steady state). Without this the mock defaults to 0,
+	// which the fail-CLOSED nonce-gap gate correctly reads as a suspicious
+	// hole (observed 0 < expected 2) and halts. Set it so the gate sees
+	// steady state and lets the fresh row through.
+	primary.txCountFn = pendingFn(2)
+	secondary.txCountFn = pendingFn(2)
+
 	claimer := &mockClaimer{claimed: true}
 	opts := RunnerOptions{
 		DB:                    db,

--- a/phase4-coordinator/internal/payout/testing_helpers_test.go
+++ b/phase4-coordinator/internal/payout/testing_helpers_test.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/augstar/macprovider-coordinator/internal/sqliteutil"
 	_ "modernc.org/sqlite"
@@ -83,4 +84,30 @@ VALUES (?, '2026-01-01T00:00:00Z', '2026-01-08T00:00:00Z', 7,
 		t.Fatalf("last insert id: %v", err)
 	}
 	return id
+}
+
+// insertPayoutAddress seeds a payout-allowed provider_payout_addresses
+// row for providerID registered against hotWallet, so a ready payout can
+// actually be SELECTed by §4.3 step 1 (SelectReadyPayouts INNER JOINs
+// provider_payout_addresses on registered_against_hot_wallet) and PROCEED
+// to allocate/broadcast when a cycle is meant to continue. Without this
+// row the join returns nothing, so a "proceed" cycle would silently
+// process zero rows and a test could not tell a real proceed apart from a
+// halt. Mirrors the happy-path seeding in runner_test.go.
+func insertPayoutAddress(t *testing.T, db *sql.DB, providerID, hotWallet string) {
+	t.Helper()
+	canonicalHot, err := CanonicalizeEIP55(hotWallet)
+	if err != nil {
+		t.Fatalf("canonicalize hot wallet: %v", err)
+	}
+	past := time.Now().Add(-1 * time.Hour).UTC().Format(time.RFC3339Nano)
+	providerAddr := "0x000000000000000000000000000000000000dEaD"
+	if _, err := db.ExecContext(context.Background(), `
+INSERT INTO provider_payout_addresses
+  (provider_id, chain, address, payout_allowed, pending_until_utc,
+   rotated_from, registered_at_utc, registered_against_hot_wallet)
+VALUES (?, 'base-mainnet', ?, 1, ?, NULL, ?, ?)`,
+		providerID, providerAddr, past, past, canonicalHot); err != nil {
+		t.Fatalf("insert payout address: %v", err)
+	}
 }


### PR DESCRIPTION
## SPEC-016 §7.1 — wire `payout_runner_lease_conflict` + `payout_nonce_gap` (+ recovery-only nonce-gap safety gate)

Follow-up to #865 (§9.6 synthetic-alert harness), which catalogued two §7.1 alerts as
`spec-only-not-emitted` and flagged them as a prerequisite before `payout.enabled: true`. This
wires their emission. Payouts remain **default-off**; no runner activation or deployment.

### What this emits
- **`payout_runner_lease_conflict`** (PAGE) — emitted inside `Acquire()` on the fresh-holder
  conflict path (§4.8b acquire step 3) with all seven §7.1 fields (`local_pid`,
  `local_started_at_utc`, `holder_host`, `holder_pid`, `holder_started_at_utc`,
  `holder_heartbeat_at_utc`, `ts_utc`). Control flow + `ErrLeaseConflict` return unchanged; no
  duplicate caller-side emission.
- **`payout_nonce_gap`** (WARN) — a per-cycle detector at the top of `RunOnce`, **before** ready-row
  selection and any fresh nonce allocation. It detects the definitive gap direction only
  (on-chain pending nonce fell **behind** the DB cursor via an abandoned-unfilled hole) and
  **fails closed on every uncertainty**.

### Nonce-gap safety gate (the load-bearing part)
The detector is a **safety gate guarding fresh nonce allocation**, not observability — allocating
`N+1` while nonce `N` is an unfilled hole stalls the entire hot wallet on-chain. It also closes a
**latent silent stall**: an operator abandon *without* a cancel left the abandoned row out of the
allocator's lookup, so the runner would allocate `N+1` into the hole and stall silently.

- Every uncertain path **halts the cycle** (allocate nothing): two-RPC read error / >1
  disagreement, an unexplained/`reorg_suspect` hole, or an abandon-cause hole (emits
  `payout_nonce_gap`). A confirmed row at `nonce == observed_pending` is chain-contradicted
  (pending==N ⇒ N not mined), so it is treated as a stale/reorged confirmation → halt, never a
  "fill".
- **Recovery-only cycle:** the sole benign case (a persisted-but-unbroadcast crash-recovery
  attempt at the hole) suppresses **only** fresh nonce allocation for the cycle — the recovery
  rebroadcast and all unrelated in-flight polls/confirms proceed via the normal, already-audited
  loop (cancels dispatch through `rebroadcastCancel`/`pollCancelOnce`, not USDC verification). An
  unselectable recovery **pauses fail-closed** and emits `payout_nonce_gap_recovery_only` each
  cycle for operator visibility. Zero fresh nonces mint while a hole persists.
- **Cold-start cursor is now monotonic** `MAX(cursor_in_db, max(rpc_a, rpc_b))` per SPEC-016
  §nonce-cold-start (line ~1749). The prior `UpsertNonceCursor` plainly overwrote with the RPC
  value, so a restart with the DB cursor ahead of chain-pending could lower the cursor and erase a
  hole. This is a fix to conform to the SPEC's stated invariant.
- RPC errors in the new diagnostics are redacted (`error_class`, never the secret-bearing URL).

### Tests
- `payout_nonce_gap` happy path + fail-closed suite: RPC hard-error, RPC >1 disagreement, reorg-
  suspect, dual abandon+stale-cancel, restart cursor monotonicity — each asserting **zero fresh
  allocation** (no new attempt row, `next_nonce` unchanged) **and** zero broadcast, with a
  selectable ready payout seeded so the asserts are non-vacuous.
- Recovery-only: cancel-at-observed proven to use the cancel dispatch path (RPC call-counters;
  never USDC-verify, never `ClaimPayoutReady`) and delayed-receipt proven re-polled by the normal
  loop (not stranded).
- `payout_runner_lease_conflict`: same-process emission/field test **plus** the SPEC-016
  "IMPL test required (1)" **real two-process** integration test — re-execs the test binary as two
  OS processes against a shared file-backed sqlite DB, asserting the second returns
  `ErrLeaseConflict`, emits the PAGE alert with distinct real `holder_pid`/`local_pid`, and exits
  non-zero (deterministic, passes at `-count=3`).
- §9.6 catalog flipped both events `spec-only-not-emitted → code`; `payout_nonce_gap_reorg_suspect`
  and `payout_nonce_gap_recovery_only` added to the non-alert allowlist; completeness+severity gate
  green.

### Audit
5 rounds of 3-lane Codex audit (code / security / architect) on the full combined diff each round,
to **0 CRITICAL / 0 HIGH / 0 MEDIUM** on all three lanes. Real money-path defects found and fixed
across rounds: R1 — detector was fail-*open* on RPC uncertainty / stale-cancel / restart (3 HIGH) →
fail-closed everywhere + monotonic cursor (a SPEC invariant violation) + deleted a chain-
contradicted confirmed-cancel suppressor; R2 — the crash-recovery proceed path could still fresh-
allocate past the hole (1 HIGH) → architect-ruled recovery-only cycle; R3 — a targeting rider added
in R2 misrouted cancels through USDC verification / used reconstructed ledger values → **removed the
rider**, relying on the normal loop; R4/R5 — test-verification depth (non-vacuous asserts, path
call-counters, real two-process lease test). Final round: APPROVE / architectural status CLEAR.

### Verification
`go build ./...`, `go vet`, `go test ./internal/payout/ ./cmd/coordinator/ ./internal/billing/`,
`go test -race ./internal/payout`, the two-process lease test at `-count=3`, `gofmt`,
`git diff --check` — all clean. (Pre-existing unrelated race flake in
`internal/billing/quarantine_test.go:1088` is out of scope.)

SPEC-GOVERNANCE-DECLARATION-BEGIN
{
  "schema_version": "spec-pr-governance-v1",
  "behavior_change": "yes",
  "contract_change": "none",
  "specs": ["SPEC-016"],
  "requirements": ["SPEC-016-R010"],
  "authority_domains": ["payout-lifecycle"],
  "arbitration": ["CODE_BUG"],
  "tests": ["phase4-coordinator/internal/payout/runner_nonce_gap_test.go", "phase4-coordinator/internal/payout/lease_conflict_2process_test.go"],
  "journeys": ["not-required"],
  "issue": "https://github.com/Augustas11/macprovider/issues/614"
}
SPEC-GOVERNANCE-DECLARATION-END

🤖 Generated with [Claude Code](https://claude.com/claude-code)
