### PR TITLE
cli 1.8.81: ship payout-address subcommand for Malibu Add-wallet

### DIFF
--- a/phase3-binary/Sources/macprovider-cli/CoordinatorClient.swift
+++ b/phase3-binary/Sources/macprovider-cli/CoordinatorClient.swift
@@ -146,7 +146,7 @@ actor CoordinatorClient {
     typealias InstalledCompatibilityManifest = @Sendable (URL, String) -> CompatibilitySetManifest?
     typealias ReloadHelperFence = @Sendable () throws -> Void
 
-    static let binaryVersion = "1.8.79"
+    static let binaryVersion = "1.8.81"
     private static let keepaliveDebugEnabled = ProcessInfo.processInfo.environment["MACPROVIDER_KEEPALIVE_DEBUG"] == "1"
 
     private let coordinatorURL: URL

--- a/phase4-coordinator/coordinator.yaml.example
+++ b/phase4-coordinator/coordinator.yaml.example
@@ -186,7 +186,7 @@ autotune:
 # legacy cohort (DECISION_CRITERIA Entry 161). `required_binary_version` is a
 # hard admission floor, not an autoupdate target, and is unaffected by the gate.
 coordinator_advertised_version:
-  latest_binary_version: "1.8.79"
+  latest_binary_version: "1.8.81"
   required_binary_version: ""
 
 auth:

--- a/phase4-coordinator/dist/coordinator.yaml
+++ b/phase4-coordinator/dist/coordinator.yaml
@@ -373,5 +373,5 @@ providers:
 # reconnecting and tells its operator to upgrade, and one without it
 # reconnect-loops.
 coordinator_advertised_version:
-  latest_binary_version: "1.8.79"
+  latest_binary_version: "1.8.81"
   required_binary_version: "1.8.33"

--- a/phase4-coordinator/dist/coordinator.yaml.example
+++ b/phase4-coordinator/dist/coordinator.yaml.example
@@ -373,7 +373,7 @@ malibu_emission:
 # routing. Keys match model_id case-insensitively; values must be bare
 # numeric versions or the coordinator refuses to start.
 coordinator_advertised_version:
-  latest_binary_version: "1.8.79"
+  latest_binary_version: "1.8.81"
   # required_binary_version: "1.7.0"
   # per_model_required_binary_version:
   #   "mlx-community/Qwen3-Coder-30B-A3B-Instruct-4bit": "1.8.60"


### PR DESCRIPTION
## macprovider-cli 1.8.81 — ship the payout-address subcommand for Malibu Add-wallet

Bumps `CoordinatorClient.binaryVersion 1.8.79 → 1.8.81` so a signed CLI release
can carry the `payout-address challenge` / `payout-address register` subcommand
(`PayoutAddressCommand`, added in #882 `64d4ba62`). No released CLI currently
has it — the newest (v1.8.79) predates #882 — which an end-to-end test of the
Malibu 1.8.47 Add-wallet flow surfaced (`Error: 2 unexpected arguments:
'payout-address', 'challenge'` because the embedded v1.8.79 CLI falls through to
`serve`).

v1.8.80 is the coordinator daemon release tag, so the CLI advances to v1.8.81.
This does NOT advance the fleet: the coordinator's `recommended_binary_version`
stays 1.8.79, and Malibu embeds this CLI directly (not via the autoupdate/compat
path), so the #813 autoupdate-compat brick risk is not engaged.

SPEC-GOVERNANCE-DECLARATION-BEGIN
{
  "schema_version": "spec-pr-governance-v1",
  "behavior_change": "yes",
  "contract_change": "none",
  "specs": ["SPEC-016"],
  "requirements": ["SPEC-016-R002"],
  "authority_domains": ["payout-lifecycle"],
  "arbitration": ["CODE_BUG"],
  "tests": ["scripts/test-coordinator-advertised-version.sh"],
  "journeys": ["not-required"],
  "issue": "https://github.com/Augustas11/macprovider/issues/614"
}
SPEC-GOVERNANCE-DECLARATION-END
