### PR TITLE
SPEC-039 Phase-2: runtime bridge + FR-PKV10 contiguous KVCache (#887)

### DIFF
--- a/phase3-binary/Sources/MacProviderCore/PagedKVEngine.swift
+++ b/phase3-binary/Sources/MacProviderCore/PagedKVEngine.swift
@@ -185,6 +185,10 @@ public struct PagedKVGates: Equatable, Sendable {
     public let observedMetallibSHA256: String?
     public let observedKernelIdentifier: String?
     public let observedParityLabel: String?
+    /// Pool epoch observed from the live allocator/runtime. Keeping this separate
+    /// from the sizing proof prevents a proof for epoch N from being reused after
+    /// the allocator has rolled to epoch N+1.
+    public let observedPoolEpoch: Int?
     public let moeDispatchProven: Bool
     public let engineBridgeAvailable: Bool
 
@@ -198,6 +202,7 @@ public struct PagedKVGates: Equatable, Sendable {
         observedMetallibSHA256: String? = nil,
         observedKernelIdentifier: String? = nil,
         observedParityLabel: String? = nil,
+        observedPoolEpoch: Int? = nil,
         moeDispatchProven: Bool = false,
         engineBridgeAvailable: Bool = false
     ) {
@@ -210,6 +215,7 @@ public struct PagedKVGates: Equatable, Sendable {
         self.observedMetallibSHA256 = observedMetallibSHA256
         self.observedKernelIdentifier = observedKernelIdentifier
         self.observedParityLabel = observedParityLabel
+        self.observedPoolEpoch = observedPoolEpoch
         self.moeDispatchProven = moeDispatchProven
         self.engineBridgeAvailable = engineBridgeAvailable
     }
@@ -224,6 +230,7 @@ public struct PagedKVGates: Equatable, Sendable {
         observedMetallibSHA256: nil,
         observedKernelIdentifier: nil,
         observedParityLabel: nil,
+        observedPoolEpoch: nil,
         moeDispatchProven: false,
         engineBridgeAvailable: false
     )
@@ -239,8 +246,131 @@ public struct PagedKVGates: Equatable, Sendable {
             observedMetallibSHA256: nil,
             observedKernelIdentifier: nil,
             observedParityLabel: nil,
+            observedPoolEpoch: nil,
             moeDispatchProven: false,
             engineBridgeAvailable: false
+        )
+    }
+}
+
+/// A provider-local observation of the runtime tuple used by SPEC-039 attach.
+///
+/// The values in this type are observations, not descriptor defaults. Callers
+/// must obtain them from the loaded model/runtime probe (or an offline fixture
+/// that represents that probe); the attach gate never derives them from the
+/// descriptor it is about to advertise.
+public struct PagedKVRuntimeObservation: Equatable, Sendable {
+    public let modelID: String
+    public let modelSHA256: String
+    public let tokenizerSHA256: String?
+    public let chatTemplateSHA256: String?
+    public let modelFamily: String
+    public let cacheClass: String
+    public let kvDType: PagedKVDType
+    public let requiresMoEDispatch: Bool
+    public let hardwareClass: String?
+    public let metallibSHA256: String?
+    public let kernelIdentifier: String?
+    public let parityLabel: String?
+    public let poolEpoch: Int?
+    public let metallibAvailable: Bool
+    public let kernelRegistered: Bool
+    public let parityEstablished: Bool
+    public let hardwareSizingProof: PagedKVHardwareSizingProof?
+    public let moeDispatchProven: Bool
+
+    public init(
+        modelID: String,
+        modelSHA256: String,
+        tokenizerSHA256: String?,
+        chatTemplateSHA256: String?,
+        modelFamily: String,
+        cacheClass: String,
+        kvDType: PagedKVDType = .fp16,
+        requiresMoEDispatch: Bool,
+        hardwareClass: String?,
+        metallibSHA256: String?,
+        kernelIdentifier: String?,
+        parityLabel: String?,
+        poolEpoch: Int?,
+        metallibAvailable: Bool,
+        kernelRegistered: Bool,
+        parityEstablished: Bool,
+        hardwareSizingProof: PagedKVHardwareSizingProof?,
+        moeDispatchProven: Bool
+    ) {
+        self.modelID = modelID
+        self.modelSHA256 = modelSHA256
+        self.tokenizerSHA256 = tokenizerSHA256
+        self.chatTemplateSHA256 = chatTemplateSHA256
+        self.modelFamily = modelFamily
+        self.cacheClass = cacheClass
+        self.kvDType = kvDType
+        self.requiresMoEDispatch = requiresMoEDispatch
+        self.hardwareClass = hardwareClass
+        self.metallibSHA256 = metallibSHA256
+        self.kernelIdentifier = kernelIdentifier
+        self.parityLabel = parityLabel
+        self.poolEpoch = poolEpoch
+        self.metallibAvailable = metallibAvailable
+        self.kernelRegistered = kernelRegistered
+        self.parityEstablished = parityEstablished
+        self.hardwareSizingProof = hardwareSizingProof
+        self.moeDispatchProven = moeDispatchProven
+    }
+
+    /// Returns whether every observed identity field is complete and covered by
+    /// the sizing proof for this exact configuration and allocator epoch.
+    public func matches(config: PagedKVConfig) -> Bool {
+        guard let hardwareClass,
+              let metallibSHA256,
+              let kernelIdentifier,
+              let parityLabel,
+              let poolEpoch,
+              let hardwareSizingProof
+        else { return false }
+        guard PagedKVAttachGate.recognizedModelFamilies.contains(modelFamily),
+              PagedKVAttachGate.allowedCacheClasses.contains(cacheClass),
+              !modelID.isEmpty,
+              !modelSHA256.isEmpty,
+              kvDType == .fp16,
+              metallibAvailable,
+              kernelRegistered,
+              parityEstablished,
+              !requiresMoEDispatch || moeDispatchProven
+        else { return false }
+        return hardwareSizingProof.covers(
+            config: config,
+            modelID: modelID,
+            modelSHA256: modelSHA256,
+            tokenizerSHA256: tokenizerSHA256,
+            chatTemplateSHA256: chatTemplateSHA256,
+            modelFamily: modelFamily,
+            observedHardwareClass: hardwareClass,
+            observedMetallibSHA256: metallibSHA256,
+            observedKernelIdentifier: kernelIdentifier,
+            observedParityLabel: parityLabel,
+            poolEpoch: poolEpoch
+        )
+    }
+
+    /// Converts a validated observation into the gate input consumed by the
+    /// existing attach decision. `bridgeAvailable` is deliberately supplied by
+    /// the runtime owner only after it has installed the request-level bridge.
+    public func gates(config: PagedKVConfig, bridgeAvailable: Bool) -> PagedKVGates {
+        PagedKVGates(
+            identityAvailable: !modelID.isEmpty && !modelSHA256.isEmpty,
+            observedHardwareClass: hardwareClass,
+            metallibAvailable: metallibAvailable,
+            kernelRegistered: kernelRegistered,
+            parityEstablished: parityEstablished,
+            hardwareSizingProof: hardwareSizingProof,
+            observedMetallibSHA256: metallibSHA256,
+            observedKernelIdentifier: kernelIdentifier,
+            observedParityLabel: parityLabel,
+            observedPoolEpoch: poolEpoch,
+            moeDispatchProven: moeDispatchProven,
+            engineBridgeAvailable: bridgeAvailable && matches(config: config)
         )
     }
 }
@@ -318,7 +448,7 @@ public enum PagedKVAttachGate {
                   observedMetallibSHA256: observedMetallibSHA256,
                   observedKernelIdentifier: observedKernelIdentifier,
                   observedParityLabel: observedParityLabel,
-                  poolEpoch: 1
+                  poolEpoch: gates.observedPoolEpoch ?? sizingProof.poolEpoch
               )
         else {
             return fail(.allocator)

--- a/phase3-binary/Sources/macprovider-cli/ModelRuntime.swift
+++ b/phase3-binary/Sources/macprovider-cli/ModelRuntime.swift
@@ -591,6 +591,15 @@ actor ModelRuntime: ModelRuntimeServing {
     private let prefillStepSize: Int
     private let pagedKVConfig: PagedKVConfig
     private var pagedKVAttachDecision: PagedKVAttachDecision
+    /// An observed tuple is optional by design. Nil keeps the shipped path
+    /// fail-closed; it is never synthesized from the descriptor.
+    private var pagedKVRuntimeObservation: PagedKVRuntimeObservation?
+    /// The descriptor is supplied by the trusted packaging/probe layer. The
+    /// runtime attach path may compare an observation with it, but never
+    /// promotes a descriptor manufactured from that same observation.
+    private var pagedKVTrustedDescriptor: PagedKVDescriptor?
+    private var pagedKVRuntimeBridge: PagedKVRuntimeBridge?
+    private let pagedKVSharedForwardBackend: PagedKVSharedForwardBackend?
     private let conversationCache: ConversationCache
     /// SPEC-037 stage 5 — set once the serve process activates the encrypted disk
     /// cold tier (FR-KVP7). Gates all per-request cold-tier context construction;
@@ -718,7 +727,8 @@ actor ModelRuntime: ModelRuntimeServing {
         chatTemplateSHA256: String?,
         kvBitsOverride: Int?,
         runtimeCacheClass: String,
-        modelCapabilities: PagedKVRuntimeModelCapabilities? = nil
+        modelCapabilities: PagedKVRuntimeModelCapabilities? = nil,
+        gates: PagedKVGates? = nil
     ) -> PagedKVAttachDecision {
         let cacheClassForDecision = runtimeCacheClass == Self.pagedKVUnavailableCacheClass
             ? PagedKVAttachGate.allowedCacheClasses[0]
@@ -731,9 +741,91 @@ actor ModelRuntime: ModelRuntimeServing {
             chatTemplateSHA256: chatTemplateSHA256,
             kvBitsOverride: kvBitsOverride,
             runtimeCacheClass: cacheClassForDecision,
-            gates: .runtimeClosed(identityAvailable: modelHash?.isEmpty == false),
+            gates: gates ?? .runtimeClosed(identityAvailable: modelHash?.isEmpty == false),
             modelCapabilities: modelCapabilities
         )
+    }
+
+    /// Resolve the decision and bridge together. The bridge is created only
+    /// after a candidate descriptor exists, and a failed bridge construction
+    /// recomputes the decision with `engineBridgeAvailable == false`.
+    private nonisolated static func pagedKVRuntimeAttach(
+        config: PagedKVConfig,
+        modelID: String?,
+        modelHash: String?,
+        tokenizerSHA256: String?,
+        chatTemplateSHA256: String?,
+        kvBitsOverride: Int?,
+        runtimeCacheClass: String,
+        modelCapabilities: PagedKVRuntimeModelCapabilities,
+        observation: PagedKVRuntimeObservation?,
+        trustedDescriptor: PagedKVDescriptor?
+    ) -> (PagedKVAttachDecision, PagedKVRuntimeBridge?) {
+        let cacheClass = runtimeCacheClass == Self.pagedKVUnavailableCacheClass
+            ? PagedKVAttachGate.allowedCacheClasses[0]
+            : runtimeCacheClass
+        guard let observation, let trustedDescriptor else {
+            let closed = Self.pagedKVAttachDecision(
+                config: config,
+                modelID: modelID,
+                modelHash: modelHash,
+                tokenizerSHA256: tokenizerSHA256,
+                chatTemplateSHA256: chatTemplateSHA256,
+                kvBitsOverride: kvBitsOverride,
+                runtimeCacheClass: cacheClass,
+                gates: observation?.gates(config: config, bridgeAvailable: false)
+                    ?? .runtimeClosed(identityAvailable: modelHash?.isEmpty == false),
+                modelCapabilities: modelCapabilities
+            )
+            return (closed, nil)
+        }
+        let candidateGates = observation.gates(config: config, bridgeAvailable: true)
+        let candidate = Self.pagedKVAttachDecision(
+            config: config,
+            modelID: modelID,
+            modelHash: modelHash,
+            tokenizerSHA256: tokenizerSHA256,
+            chatTemplateSHA256: chatTemplateSHA256,
+            kvBitsOverride: kvBitsOverride,
+            runtimeCacheClass: cacheClass,
+            gates: candidateGates,
+            modelCapabilities: modelCapabilities
+        )
+        guard let candidateDescriptor = candidate.descriptor,
+              candidateDescriptor == trustedDescriptor
+        else {
+            let closed = Self.pagedKVAttachDecision(
+                config: config,
+                modelID: modelID,
+                modelHash: modelHash,
+                tokenizerSHA256: tokenizerSHA256,
+                chatTemplateSHA256: chatTemplateSHA256,
+                kvBitsOverride: kvBitsOverride,
+                runtimeCacheClass: cacheClass,
+                gates: observation.gates(config: config, bridgeAvailable: false),
+                modelCapabilities: modelCapabilities
+            )
+            return (closed, nil)
+        }
+        guard let bridge = try? PagedKVRuntimeBridge(
+            config: config,
+            observation: observation,
+            descriptor: trustedDescriptor
+        ) else {
+            let closed = Self.pagedKVAttachDecision(
+                config: config,
+                modelID: modelID,
+                modelHash: modelHash,
+                tokenizerSHA256: tokenizerSHA256,
+                chatTemplateSHA256: chatTemplateSHA256,
+                kvBitsOverride: kvBitsOverride,
+                runtimeCacheClass: cacheClass,
+                gates: observation.gates(config: config, bridgeAvailable: false),
+                modelCapabilities: modelCapabilities
+            )
+            return (closed, nil)
+        }
+        return (candidate, bridge)
     }
 
     private static let pagedKVUnavailableCacheClass = "unavailable"
@@ -840,11 +932,11 @@ actor ModelRuntime: ModelRuntimeServing {
         }
     }
 
-    nonisolated static func enforcePagedKVPreflight(_ decision: PagedKVAttachDecision) throws {
-        if case .attached = decision {
-            // This IMPL installs the default-off contract and attach gate only. Serving
-            // still requires a runtime owner that reserves a request lease, injects
-            // PagedKVCache, and releases/retains the handle around TokenIterator.
+    nonisolated static func enforcePagedKVPreflight(
+        _ decision: PagedKVAttachDecision,
+        bridgeAvailable: Bool = false
+    ) throws {
+        if case .attached = decision, !bridgeAvailable {
             throw APIError(
                 status: 503,
                 message: "Inference engine unavailable",
@@ -906,6 +998,9 @@ actor ModelRuntime: ModelRuntimeServing {
         maxBatch: Int = 1,
         continuousBatchingMode: ContinuousBatchingMode = .off,
         continuousBatchQueueLimit: Int? = nil,
+        pagedKVRuntimeObservation: PagedKVRuntimeObservation? = nil,
+        pagedKVTrustedDescriptor: PagedKVDescriptor? = nil,
+        pagedKVSharedForwardDriver: (any PagedKVSharedForwardDriver)? = nil,
         warmSwapEnabled: Bool = false,
         swapDrainTimeoutSeconds: Int = 30,
         catalogModelIDAlias: String? = nil,
@@ -936,6 +1031,31 @@ actor ModelRuntime: ModelRuntimeServing {
             kvBitsOverride: kvBitsOverride,
             runtimeCacheClass: Self.pagedKVUnavailableCacheClass
         )
+        self.pagedKVRuntimeObservation = pagedKVRuntimeObservation
+        self.pagedKVTrustedDescriptor = pagedKVTrustedDescriptor
+        self.pagedKVRuntimeBridge = nil
+        self.pagedKVSharedForwardBackend = pagedKVSharedForwardDriver.map {
+            PagedKVSharedForwardBackend(driver: $0)
+        }
+        if let pagedKVRuntimeObservation {
+            let runtimeAttach = Self.pagedKVRuntimeAttach(
+                config: pagedKVConfig,
+                modelID: modelID,
+                modelHash: verifiedModelArtifactSHA256,
+                tokenizerSHA256: pagedKVRuntimeObservation.tokenizerSHA256,
+                chatTemplateSHA256: pagedKVRuntimeObservation.chatTemplateSHA256,
+                kvBitsOverride: kvBitsOverride,
+                runtimeCacheClass: pagedKVRuntimeObservation.cacheClass,
+                modelCapabilities: Self.pagedKVModelCapabilities(
+                    modelID: modelID,
+                    configJSONData: nil
+                ),
+                observation: pagedKVRuntimeObservation,
+                trustedDescriptor: pagedKVTrustedDescriptor
+            )
+            self.pagedKVAttachDecision = runtimeAttach.0
+            self.pagedKVRuntimeBridge = runtimeAttach.1
+        }
         self.conversationCache = ConversationCache()
         let boundedMaxBatch = min(max(1, maxBatch), ProviderCapacity.maxConcurrencyOverrideLimit)
         self.maxBatch = boundedMaxBatch
@@ -997,7 +1117,7 @@ actor ModelRuntime: ModelRuntimeServing {
             )
             : Self.pagedKVUnavailableCacheClass
         let modelCapabilities = Self.pagedKVModelCapabilities(modelID: modelID, directory: directory)
-        self.pagedKVAttachDecision = Self.pagedKVRuntimeCapabilityDecision(
+        let runtimeAttach = Self.pagedKVRuntimeAttach(
             config: self.pagedKVConfig,
             modelID: modelID,
             modelHash: self.currentModelHash,
@@ -1005,8 +1125,12 @@ actor ModelRuntime: ModelRuntimeServing {
             chatTemplateSHA256: tokenizerHashes.template,
             kvBitsOverride: self.kvBitsOverride,
             runtimeCacheClass: runtimeCacheClass,
-            modelCapabilities: modelCapabilities
+            modelCapabilities: modelCapabilities,
+            observation: pagedKVRuntimeObservation,
+            trustedDescriptor: self.pagedKVTrustedDescriptor
         )
+        self.pagedKVAttachDecision = runtimeAttach.0
+        self.pagedKVRuntimeBridge = runtimeAttach.1
         Self.logPagedKVAttachDecision(self.pagedKVAttachDecision)
 
         if let draftModelID = normalizedDraftModelID {
@@ -1056,6 +1180,9 @@ actor ModelRuntime: ModelRuntimeServing {
         maxBatch: Int = 1,
         continuousBatchingMode: ContinuousBatchingMode = .off,
         continuousBatchQueueLimit: Int? = nil,
+        pagedKVRuntimeObservation: PagedKVRuntimeObservation? = nil,
+        pagedKVTrustedDescriptor: PagedKVDescriptor? = nil,
+        pagedKVSharedForwardDriver: (any PagedKVSharedForwardDriver)? = nil,
         warmSwapEnabled: Bool,
         swapDrainTimeoutSeconds: Int = 30,
         providerStatus: ProviderStatus? = nil,
@@ -1098,6 +1225,31 @@ actor ModelRuntime: ModelRuntimeServing {
             kvBitsOverride: kvBitsOverride,
             runtimeCacheClass: Self.pagedKVUnavailableCacheClass
         )
+        self.pagedKVRuntimeObservation = pagedKVRuntimeObservation
+        self.pagedKVTrustedDescriptor = pagedKVTrustedDescriptor
+        self.pagedKVRuntimeBridge = nil
+        self.pagedKVSharedForwardBackend = pagedKVSharedForwardDriver.map {
+            PagedKVSharedForwardBackend(driver: $0)
+        }
+        if let pagedKVRuntimeObservation {
+            let runtimeAttach = Self.pagedKVRuntimeAttach(
+                config: pagedKVConfig,
+                modelID: modelID,
+                modelHash: modelHash,
+                tokenizerSHA256: pagedKVRuntimeObservation.tokenizerSHA256,
+                chatTemplateSHA256: pagedKVRuntimeObservation.chatTemplateSHA256,
+                kvBitsOverride: kvBitsOverride,
+                runtimeCacheClass: pagedKVRuntimeObservation.cacheClass,
+                modelCapabilities: Self.pagedKVModelCapabilities(
+                    modelID: modelID,
+                    configJSONData: nil
+                ),
+                observation: pagedKVRuntimeObservation,
+                trustedDescriptor: pagedKVTrustedDescriptor
+            )
+            self.pagedKVAttachDecision = runtimeAttach.0
+            self.pagedKVRuntimeBridge = runtimeAttach.1
+        }
         self.conversationCache = ConversationCache()
         let boundedMaxBatch = min(max(1, maxBatch), ProviderCapacity.maxConcurrencyOverrideLimit)
         self.maxBatch = boundedMaxBatch
@@ -1345,10 +1497,31 @@ actor ModelRuntime: ModelRuntimeServing {
         stickyCacheEligible: Bool,
         requestStateRepresentable: Bool = true
     ) -> ContinuousBatchingCapability {
-        // The independently observed runtime tuple and scheduler backend are
-        // installed by the deferred SPEC-039 engine bridge. Do not manufacture
-        // a self-fulfilling tuple from the advertised descriptor.
-        let requestedTuple: ContinuousBatchingRequestedTuple? = nil
+        // Do not manufacture a self-fulfilling tuple from the advertised
+        // descriptor. The tuple is copied only from the independently observed
+        // runtime identity, and the backend must have been installed as well.
+        let requestedTuple: ContinuousBatchingRequestedTuple? = {
+            guard let observation = pagedKVRuntimeObservation,
+                  let bridge = pagedKVRuntimeBridge,
+                  bridge.isAttached
+            else { return nil }
+            return ContinuousBatchingRequestedTuple(
+                modelID: observation.modelID,
+                modelSHA256: observation.modelSHA256,
+                tokenizerSHA256: observation.tokenizerSHA256,
+                chatTemplateSHA256: observation.chatTemplateSHA256,
+                cacheClass: observation.cacheClass,
+                kvDType: observation.kvDType,
+                requiresMoE: observation.requiresMoEDispatch,
+                hardwareClass: observation.hardwareClass ?? "",
+                metallibSHA256: observation.metallibSHA256 ?? "",
+                kernelIdentifier: observation.kernelIdentifier ?? "",
+                parityLabel: observation.parityLabel ?? "",
+                poolEpoch: observation.poolEpoch ?? -1
+            )
+        }()
+        let schedulerBackendAvailable = pagedKVRuntimeBridge?.isAttached == true
+            && pagedKVSharedForwardBackend != nil
         return ContinuousBatchingPolicy.capability(
             mode: continuousBatchingMode,
             maxBatch: maxBatch,
@@ -1357,7 +1530,7 @@ actor ModelRuntime: ModelRuntimeServing {
             draftConfigured: draftConfigured,
             stickyCacheEligible: stickyCacheEligible,
             requestStateRepresentable: requestStateRepresentable,
-            schedulerBackendAvailable: false,
+            schedulerBackendAvailable: schedulerBackendAvailable,
             pagedKVDecision: pagedKVAttachDecision,
             requestedTuple: requestedTuple
         )
@@ -1540,7 +1713,12 @@ actor ModelRuntime: ModelRuntimeServing {
                 prefillStepSize: prefillStepSize
             )
             : Self.pagedKVUnavailableCacheClass
-        pagedKVAttachDecision = Self.pagedKVRuntimeCapabilityDecision(
+        let observationForTarget = pagedKVRuntimeObservation.flatMap { observation in
+            observation.modelID == modelID && observation.modelSHA256 == modelHash
+                ? observation
+                : nil
+        }
+        let runtimeAttach = Self.pagedKVRuntimeAttach(
             config: pagedKVConfig,
             modelID: modelID,
             modelHash: modelHash,
@@ -1548,8 +1726,22 @@ actor ModelRuntime: ModelRuntimeServing {
             chatTemplateSHA256: chatTemplateSHA256,
             kvBitsOverride: kvBitsOverride,
             runtimeCacheClass: runtimeCacheClass,
-            modelCapabilities: modelCapabilities
+            modelCapabilities: modelCapabilities,
+            observation: observationForTarget,
+            trustedDescriptor: pagedKVTrustedDescriptor.flatMap { descriptor in
+                descriptor.modelID == modelID && descriptor.modelSHA256 == modelHash
+                    ? descriptor
+                    : nil
+            }
         )
+        pagedKVRuntimeObservation = observationForTarget
+        pagedKVTrustedDescriptor = pagedKVTrustedDescriptor.flatMap { descriptor in
+            descriptor.modelID == modelID && descriptor.modelSHA256 == modelHash
+                ? descriptor
+                : nil
+        }
+        pagedKVAttachDecision = runtimeAttach.0
+        pagedKVRuntimeBridge = runtimeAttach.1
         Self.logPagedKVAttachDecision(pagedKVAttachDecision)
         currentDraftModelID = draftModelID
         currentDraftTargetModelID = draftModelID == nil ? nil : modelID
@@ -1695,7 +1887,10 @@ actor ModelRuntime: ModelRuntimeServing {
 
     func preflight(_ request: ChatCompletionRequest, with handle: RequestHandle) async throws {
         try applyContinuousBatchingPolicy(request: request, snapshot: handle.snapshot)
-        try Self.enforcePagedKVPreflight(pagedKVAttachDecision)
+        try Self.enforcePagedKVPreflight(
+            pagedKVAttachDecision,
+            bridgeAvailable: pagedKVRuntimeBridge?.isAttached == true
+        )
         try handle.drainCancelled.check()
         guard let container = handle.snapshot.container else {
             if testCompletion != nil {
@@ -1719,7 +1914,10 @@ actor ModelRuntime: ModelRuntimeServing {
 
     func pagedKVPreflight(_ request: ChatCompletionRequest, with handle: RequestHandle) async throws {
         try applyContinuousBatchingPolicy(request: request, snapshot: handle.snapshot)
-        try Self.enforcePagedKVPreflight(pagedKVAttachDecision)
+        try Self.enforcePagedKVPreflight(
+            pagedKVAttachDecision,
+            bridgeAvailable: pagedKVRuntimeBridge?.isAttached == true
+        )
         try handle.drainCancelled.check()
     }
 
@@ -1871,7 +2069,10 @@ actor ModelRuntime: ModelRuntimeServing {
         // emission for this request. (Streaming preflights first and suppresses
         // here to stay exactly-once.)
         try applyContinuousBatchingPolicy(request: request, snapshot: snapshot, emitTelemetry: true)
-        try Self.enforcePagedKVPreflight(pagedKVAttachDecision)
+        try Self.enforcePagedKVPreflight(
+            pagedKVAttachDecision,
+            bridgeAvailable: pagedKVRuntimeBridge?.isAttached == true
+        )
         try drainCancelled.check()
         if let testSpeculativeCompletion,
            Self.speculativeRoute(
@@ -1912,11 +2113,25 @@ actor ModelRuntime: ModelRuntimeServing {
         let inferenceGate = inferenceGate
         let blockingInferenceExecutor = blockingInferenceExecutor
         let stopTokenFilter = stopTokenFilter
-        let completion = try await Self.withDrainCancellation(drainCancelled) {
-            try await inferenceGate.withPermit {
-                try drainCancelled.check()
-                try Task.checkCancellation()
-                return try await container.perform { context in
+        let pagedAttachment: PagedKVRequestAttachment?
+        if let pagedBridge = pagedKVRuntimeBridge,
+           pagedBridge.isAttached,
+           case .attached = pagedKVAttachDecision,
+           request.conversationKey == nil {
+            pagedAttachment = try await pagedBridge.reserve(
+                requestID: "request-\(UUID().uuidString)",
+                maxTokens: maxContextTokens
+            )
+        } else {
+            pagedAttachment = nil
+        }
+        let completion: CompletionResult
+        do {
+            completion = try await Self.withDrainCancellation(drainCancelled) {
+                try await inferenceGate.withPermit {
+                    try drainCancelled.check()
+                    try Task.checkCancellation()
+                    return try await container.perform { context in
                     try drainCancelled.check()
                     try Task.checkCancellation()
                     let input = try Self.userInput(for: request)
@@ -1982,6 +2197,10 @@ actor ModelRuntime: ModelRuntimeServing {
                             if let reusableCache = lease?.reusableCache, let lcp = lease?.lcp {
                                 kvCache = reusableCache.layers
                                 iteratorInput = LMInput(tokens: MLXArray(Array(promptTokenIds[lcp...])))
+                            } else if let pagedAttachment {
+                                let layerCount = generationContext.model.newCache(parameters: nil).count
+                                kvCache = try pagedAttachment.makeCacheLayers(count: layerCount)
+                                iteratorInput = lmInput
                             } else {
                                 // SPEC-037 FR-KVP1: a tier-eligible request must run on a
                                 // KVCacheSimple so captureSnapshot can serialize it; keep the
@@ -2090,7 +2309,22 @@ actor ModelRuntime: ModelRuntimeServing {
                         }
                         throw error
                     }
+                    }
                 }
+            }
+        } catch {
+            if let pagedAttachment {
+                try? await pagedAttachment.release()
+            }
+            throw error
+        }
+        if let pagedAttachment {
+            do {
+                _ = try await pagedAttachment.checkpoint()
+                try await pagedAttachment.release()
+            } catch {
+                try? await pagedAttachment.release()
+                throw error
             }
         }
         return (completion, snapshot)
@@ -2286,7 +2520,10 @@ actor ModelRuntime: ModelRuntimeServing {
         let snapshot = handle.snapshot
         let drainCancelled = handle.drainCancelled
         try applyContinuousBatchingPolicy(request: request, snapshot: snapshot, emitTelemetry: false)
-        try Self.enforcePagedKVPreflight(pagedKVAttachDecision)
+        try Self.enforcePagedKVPreflight(
+            pagedKVAttachDecision,
+            bridgeAvailable: pagedKVRuntimeBridge?.isAttached == true
+        )
         let structuredAccumulator = StructuredStreamingContentAccumulator(enabled: Self.requiresStructuredValidation(request.responseFormat))
         let idleState = StructuredStreamingIdleState(enabled: Self.requiresStructuredValidation(request.responseFormat))
         if let testSpeculativeStream,

--- a/phase3-binary/Sources/macprovider-cli/PagedKVCache.swift
+++ b/phase3-binary/Sources/macprovider-cli/PagedKVCache.swift
@@ -13,6 +13,12 @@ struct PagedKVGatherKernel {
         uint within_block = logical_token - (logical_block * block_size_tokens);
         uint physical_block = uint(block_ids[logical_block]);
         uint physical_token = (physical_block * block_size_tokens) + within_block;
+        if (logical_token >= logical_token_count || lane >= token_stride
+            || logical_block >= block_count || physical_block >= block_count
+            || physical_token >= physical_token_count) {
+            gathered[elem] = 0;
+            return;
+        }
         gathered[elem] = physical[physical_token * token_stride + lane];
     """
 
@@ -32,6 +38,8 @@ struct PagedKVGatherKernel {
         logicalTokens: Int,
         blockSizeTokens: Int,
         tokenStride: Int,
+        physicalTokenCount: Int,
+        blockCount: Int,
         outputShape: [Int],
         using kernel: MLXFast.MLXFastKernel
     ) -> MLXArray {
@@ -41,6 +49,9 @@ struct PagedKVGatherKernel {
             template: [
                 ("block_size_tokens", blockSizeTokens),
                 ("token_stride", tokenStride),
+                ("logical_token_count", logicalTokens),
+                ("physical_token_count", physicalTokenCount),
+                ("block_count", blockCount),
             ],
             grid: (count, 1, 1),
             threadGroup: (min(count, 256), 1, 1),
@@ -50,13 +61,9 @@ struct PagedKVGatherKernel {
     }
 }
 
-/// Compile-time `KVCache` seam for the future installed paged runtime bridge.
-///
-/// `ModelRuntime` deliberately never injects this class in the current merge:
-/// `engineBridgeAvailable` is false in runtime gates and `.attached` preflight
-/// fails closed. The class remains type-checked against `mlx-swift-lm` so the
-/// follow-up bridge can wire request-level reservation, real gather execution,
-/// and parity tests without changing public buyer behavior.
+/// Paged serving cache backed by the SPEC-039 block binding. The runtime bridge
+/// owns reservation/lifecycle; this cache owns the `KVCache` contract and the
+/// bounded logical-to-physical gather for one transformer layer.
 final class PagedKVCache: KVCache, CustomDebugStringConvertible {
     let descriptor: PagedKVDescriptor
     let binding: PagedKVStorageBinding
@@ -105,7 +112,7 @@ final class PagedKVCache: KVCache, CustomDebugStringConvertible {
     }
 
     func update(keys: MLXArray, values: MLXArray) -> (MLXArray, MLXArray) {
-        // Controlled handling for this inert seam: never abort the host process on
+        // Controlled handling for the serving bridge: never abort the host process on
         // malformed/out-of-contract input. Guard the invariants and return safely instead
         // of `precondition`-crashing. The happy path (shape-consistent, within reserved
         // capacity) is unchanged. NOTE: KERNEL-SIDE (Metal) index/bounds validation is a
@@ -140,11 +147,9 @@ final class PagedKVCache: KVCache, CustomDebugStringConvertible {
         // arithmetic BEFORE launching the kernel. Any invalid or overflowing configuration
         // returns the logical tensor unchanged and does NOT launch the kernel.
         //
-        // IMPORTANT: these are SWIFT-SIDE guards only. KERNEL-SIDE (Metal) bounds validation
-        // — clamping/rejecting out-of-range block_ids and physical_token indices inside the
-        // shader before any `physical[...]` read — remains a REQUIRED before-runtime-enable
-        // gate item and is intentionally NOT added in this inert (non-serving) merge; the
-        // kernel source is frozen here because the seam regression test pins it.
+        // The same invariants are repeated in the shader before every physical read. This
+        // is intentional defense in depth: host-side validation prevents invalid launches,
+        // while the kernel remains safe if a future caller supplies malformed metadata.
         let blockSize = descriptor.blockSizeTokens
         guard logical.ndim == 4 else { return logical }
         let H = logical.dim(1)
@@ -198,6 +203,8 @@ final class PagedKVCache: KVCache, CustomDebugStringConvertible {
             logicalTokens: S,
             blockSizeTokens: blockSize,
             tokenStride: tokenStride,
+            physicalTokenCount: sPad * tokenStride,
+            blockCount: nBlocks,
             outputShape: [S, tokenStride],
             using: kernel
         )
@@ -219,7 +226,7 @@ final class PagedKVCache: KVCache, CustomDebugStringConvertible {
             return [keys, values]
         }
         set {
-            // Controlled handling (inert seam): ignore malformed state assignments rather
+            // Controlled handling: ignore malformed state assignments rather
             // than aborting the process. A well-formed [keys, values] pair with matching
             // sequence length is required; anything else is a no-op.
             guard newValue.count == 2 else { return }
@@ -242,7 +249,7 @@ final class PagedKVCache: KVCache, CustomDebugStringConvertible {
             ]
         }
         set {
-            // Controlled handling (inert seam): a mismatched meta_state marker is ignored
+            // Controlled handling: a mismatched meta_state marker is ignored
             // rather than aborting the process. The stored metadata is derived from the
             // descriptor/binding, so there is nothing to mutate on a valid marker either.
             guard newValue.first == "macprovider_paged_kv_v1" else { return }
@@ -267,6 +274,58 @@ final class PagedKVCache: KVCache, CustomDebugStringConvertible {
         let copied = PagedKVCache(descriptor: descriptor, binding: binding, gatherKernel: gatherKernel)
         copied.state = state
         return copied
+    }
+
+    /// Extract the current logical K/V tensors into the neutral FR-PKV10 byte
+    /// representation. The allocator validates the block table separately; this
+    /// method is deliberately limited to one layer and never invents shape/dtype
+    /// metadata.
+    func materializedByteLayer(layerIndex: Int) throws -> PagedKVMaterializedByteLayer {
+        guard layerIndex >= 0,
+              let keys = materialized(keyBlocks),
+              let values = materialized(valueBlocks),
+              keys.ndim == 4,
+              values.ndim == 4,
+              keys.shape == values.shape,
+              keys.dim(2) == offset,
+              keys.dtype == .float16,
+              values.dtype == .float16
+        else {
+            throw PagedKVAllocatorError.invalidBlockTable("paged cache state is not contiguous fp16 K/V")
+        }
+        let keyData = keys.asData()
+        let valueData = values.asData()
+        guard keyData.shape == valueData.shape,
+              keyData.dType == .float16,
+              valueData.dType == .float16
+        else {
+            throw PagedKVAllocatorError.invalidBlockTable("paged cache byte state mismatch")
+        }
+        return PagedKVMaterializedByteLayer(
+            layerIndex: layerIndex,
+            keyShape: keyData.shape,
+            valueShape: valueData.shape,
+            dtype: .fp16,
+            logicalTokenCount: offset,
+            keyBytes: keyData.data,
+            valueBytes: valueData.data
+        )
+    }
+
+    /// Rehydrate a layer from a validated FR-PKV10 contiguous snapshot. The
+    /// caller must validate the snapshot against the allocator's current table
+    /// before calling this method.
+    func inject(materialized layer: PagedKVMaterializedByteLayer) throws {
+        guard layer.dtype == .fp16,
+              layer.keyShape == layer.valueShape,
+              layer.keyShape.count == 4,
+              layer.keyShape[2] == layer.logicalTokenCount
+        else {
+            throw PagedKVAllocatorError.invalidBlockTable("invalid contiguous K/V layer")
+        }
+        let keys = MLXArray(layer.keyBytes, layer.keyShape, dtype: .float16)
+        let values = MLXArray(layer.valueBytes, layer.valueShape, dtype: .float16)
+        state = [keys, values]
     }
 
     func makeMask(

--- a/phase3-binary/Sources/macprovider-cli/PagedKVRuntimeBridge.swift
+++ b/phase3-binary/Sources/macprovider-cli/PagedKVRuntimeBridge.swift
@@ -1,0 +1,351 @@
+import Foundation
+import MLX
+import MLXLMCommon
+import MacProviderCore
+
+/// Errors owned by the provider-local bridge. The allocator remains the source
+/// of truth for block-table errors; these cases cover the bridge's cache/lifecycle
+/// invariants around that allocator.
+enum PagedKVRuntimeBridgeError: Error, Equatable {
+    case unavailable
+    case descriptorObservationMismatch
+    case noCacheLayers
+    case cacheLayerCountMismatch
+    case cacheStateMismatch
+    case logicalLengthMismatch
+    case retainedSequenceUnavailable
+}
+
+private final class PagedKVByteSnapshotStore: @unchecked Sendable, PagedKVContiguousCacheBridge {
+    private let lock = NSLock()
+    private var snapshots: [UUID: PagedKVMaterializedByteCache] = [:]
+
+    func store(_ snapshot: PagedKVMaterializedByteCache) {
+        lock.lock()
+        snapshots[snapshot.handle.handleID] = snapshot
+        lock.unlock()
+    }
+
+    func materializeContiguousByteCache(
+        handle: PagedKVBlockTableHandle,
+        table: PagedKVBlockTable
+    ) throws -> PagedKVMaterializedByteCache {
+        lock.lock()
+        defer { lock.unlock() }
+        guard let snapshot = snapshots[handle.handleID],
+              snapshot.handle == handle,
+              snapshot.blockTable == table
+        else { throw PagedKVRuntimeBridgeError.unavailable }
+        return snapshot
+    }
+
+    func remove(_ handle: PagedKVBlockTableHandle) {
+        lock.lock()
+        snapshots.removeValue(forKey: handle.handleID)
+        lock.unlock()
+    }
+}
+
+/// A request-scoped reservation. The scheduler owns the same allocator handle;
+/// model execution owns the `KVCache` objects created from this binding.
+final class PagedKVRequestAttachment: @unchecked Sendable {
+    let bridge: PagedKVRuntimeBridge
+    let handle: PagedKVBlockTableHandle
+    let binding: PagedKVStorageBinding
+    private(set) var cacheLayers: [PagedKVCache] = []
+
+    init(
+        bridge: PagedKVRuntimeBridge,
+        handle: PagedKVBlockTableHandle,
+        binding: PagedKVStorageBinding
+    ) {
+        self.bridge = bridge
+        self.handle = handle
+        self.binding = binding
+    }
+
+    func makeCacheLayers(count: Int) throws -> [PagedKVCache] {
+        guard count > 0 else { throw PagedKVRuntimeBridgeError.noCacheLayers }
+        guard cacheLayers.isEmpty else { throw PagedKVRuntimeBridgeError.cacheStateMismatch }
+        let layers = (0 ..< count).map { _ in
+            PagedKVCache(descriptor: bridge.descriptor, binding: binding)
+        }
+        cacheLayers = layers
+        bridge.register(layers: layers, for: handle)
+        return layers
+    }
+
+    func checkpoint() async throws -> PagedKVMaterializedByteCache {
+        guard !cacheLayers.isEmpty else { throw PagedKVRuntimeBridgeError.noCacheLayers }
+        return try await bridge.checkpoint(handle: handle, layers: cacheLayers)
+    }
+
+    func retain() async throws -> PagedKVRetainedSequence {
+        try await bridge.retain(handle: handle)
+    }
+
+    func release() async throws {
+        try await bridge.release(handle: handle)
+    }
+}
+
+/// Provider-local owner for a real SPEC-039 request attach.
+///
+/// The bridge is deliberately constructed from an observed runtime identity and
+/// an allocator. It never creates a descriptor from its own defaults. The caller
+/// must install the descriptor produced by `PagedKVAttachGate` before this bridge
+/// can create request caches.
+final class PagedKVRuntimeBridge: @unchecked Sendable, PagedKVContiguousCacheBridge {
+    let allocator: PagedKVBlockAllocator
+    let observation: PagedKVRuntimeObservation
+    let config: PagedKVConfig
+    private(set) var descriptor: PagedKVDescriptor
+
+    private let lock = NSLock()
+    private let byteSnapshotStore: PagedKVByteSnapshotStore
+    private var liveLayers: [UUID: [PagedKVCache]] = [:]
+    private var snapshots: [UUID: PagedKVMaterializedByteCache] = [:]
+
+    init(
+        config: PagedKVConfig,
+        observation: PagedKVRuntimeObservation,
+        descriptor: PagedKVDescriptor
+    ) throws {
+        guard observation.matches(config: config),
+              descriptor.blockSizeTokens == config.blockSizeTokens,
+              descriptor.maxPhysicalBlocks == config.maxPhysicalBlocks,
+              descriptor.supportedModelFamilies.contains(observation.modelFamily),
+              descriptor.admits(
+                  modelID: observation.modelID,
+                  modelSHA256: observation.modelSHA256,
+                  tokenizerSHA256: observation.tokenizerSHA256,
+                  chatTemplateSHA256: observation.chatTemplateSHA256,
+                  cacheClass: observation.cacheClass,
+                  kvDType: observation.kvDType,
+                  requiresMoE: observation.requiresMoEDispatch,
+                  hardwareClass: observation.hardwareClass ?? "",
+                  metallibSHA256: observation.metallibSHA256 ?? "",
+                  kernelIdentifier: observation.kernelIdentifier ?? "",
+                  parityLabel: observation.parityLabel ?? "",
+                  poolEpoch: observation.poolEpoch ?? -1
+              )
+        else {
+            throw PagedKVRuntimeBridgeError.descriptorObservationMismatch
+        }
+        let byteSnapshotStore = PagedKVByteSnapshotStore()
+        self.config = config
+        self.observation = observation
+        self.descriptor = descriptor
+        self.byteSnapshotStore = byteSnapshotStore
+        self.allocator = try PagedKVBlockAllocator(
+            blockSizeTokens: descriptor.blockSizeTokens,
+            maxPhysicalBlocks: descriptor.maxPhysicalBlocks,
+            poolEpoch: descriptor.poolEpoch,
+            contiguousCacheBridge: byteSnapshotStore
+        )
+    }
+
+    var isAttached: Bool {
+        observation.matches(config: config)
+    }
+
+    func reserve(
+        requestID: String,
+        maxTokens: Int,
+        initialTokens: Int = 0
+    ) async throws -> PagedKVRequestAttachment {
+        guard isAttached else { throw PagedKVRuntimeBridgeError.unavailable }
+        let handle = try await allocator.allocate(
+            conversationKey: requestID,
+            maxTokens: maxTokens,
+            initialTokens: initialTokens
+        )
+        let binding = try await allocator.binding(for: handle)
+        return PagedKVRequestAttachment(bridge: self, handle: handle, binding: binding)
+    }
+
+    func register(layers: [PagedKVCache], for handle: PagedKVBlockTableHandle) {
+        lock.lock()
+        liveLayers[handle.handleID] = layers
+        lock.unlock()
+    }
+
+    private func store(
+        _ snapshot: PagedKVMaterializedByteCache,
+        layers: [PagedKVCache]
+    ) {
+        lock.lock()
+        snapshots[snapshot.handle.handleID] = snapshot
+        liveLayers[snapshot.handle.handleID] = layers
+        lock.unlock()
+    }
+
+    /// Advances the allocator table to the cache's logical length, extracts the
+    /// physical sequence through the existing allocator bridge seam, and stores
+    /// the validated neutral snapshot for synchronous protocol access.
+    func checkpoint(
+        handle: PagedKVBlockTableHandle,
+        layers: [PagedKVCache]
+    ) async throws -> PagedKVMaterializedByteCache {
+        guard !layers.isEmpty else { throw PagedKVRuntimeBridgeError.noCacheLayers }
+        let logicalLengths = Set(layers.map(\.offset))
+        guard logicalLengths.count == 1,
+              let logicalLength = logicalLengths.first
+        else { throw PagedKVRuntimeBridgeError.logicalLengthMismatch }
+
+        let current = try await allocator.table(for: handle).logicalTokenCount
+        if logicalLength > current {
+            _ = try await allocator.extend(handle, by: logicalLength - current)
+        } else if logicalLength < current {
+            _ = try await allocator.trim(handle, toLogicalTokens: logicalLength)
+        }
+        let table = try await allocator.table(for: handle)
+        guard table.logicalTokenCount == logicalLength else {
+            throw PagedKVRuntimeBridgeError.logicalLengthMismatch
+        }
+
+        let materializedLayers = try layers.enumerated().map { index, layer in
+            try layer.materializedByteLayer(layerIndex: index)
+        }
+        guard materializedLayers.allSatisfy({ $0.logicalTokenCount == table.logicalTokenCount }) else {
+            throw PagedKVRuntimeBridgeError.logicalLengthMismatch
+        }
+        let snapshot = PagedKVMaterializedByteCache(
+            handle: handle,
+            blockTable: table,
+            layers: materializedLayers
+        )
+        store(snapshot, layers: layers)
+        byteSnapshotStore.store(snapshot)
+        return snapshot
+    }
+
+    /// The frozen engine protocol remains synchronous. It reads the last
+    /// request-scoped snapshot; the async `checkpoint` above is the only method
+    /// that publishes one, so a stale/mismatched table cannot be silently reused.
+    func materializeContiguousByteCache(
+        handle: PagedKVBlockTableHandle,
+        table: PagedKVBlockTable
+    ) throws -> PagedKVMaterializedByteCache {
+        lock.lock()
+        defer { lock.unlock() }
+        guard let snapshot = snapshots[handle.handleID],
+              snapshot.handle == handle,
+              snapshot.blockTable == table
+        else {
+            throw PagedKVRuntimeBridgeError.unavailable
+        }
+        return snapshot
+    }
+
+    /// Builds standalone `KVCacheSimple` layers from the validated contiguous
+    /// snapshot. This is the live FR-PKV10 handoff consumed by cold-tier and
+    /// cross-turn callers; it is not a byte-only placeholder.
+    func materializeContiguousKVCache(
+        handle: PagedKVBlockTableHandle
+    ) async throws -> [KVCache] {
+        let snapshot = try await allocator.materializeContiguousByteCache(handle)
+        return try snapshot.layers.sorted(by: { $0.layerIndex < $1.layerIndex }).map { layer in
+            guard layer.keyShape == layer.valueShape,
+                  layer.keyShape.count == 4,
+                  layer.keyShape[2] == snapshot.blockTable.logicalTokenCount
+            else { throw PagedKVRuntimeBridgeError.cacheStateMismatch }
+            let cache = KVCacheSimple()
+            cache.state = [
+                MLXArray(layer.keyBytes, layer.keyShape, dtype: .float16),
+                MLXArray(layer.valueBytes, layer.valueShape, dtype: .float16),
+            ]
+            return cache
+        }
+    }
+
+    /// Retains the allocator-owned blocks, then reattaches the same handle for a
+    /// later turn. The logical cache snapshot remains keyed by the same handle,
+    /// so a mid-block trim can be applied before new tokens are appended.
+    func retain(handle: PagedKVBlockTableHandle) async throws -> PagedKVRetainedSequence {
+        try await allocator.retain(handle)
+    }
+
+    func reattach(
+        _ retained: PagedKVRetainedSequence,
+        conversationKey: String,
+        layerCount: Int
+    ) async throws -> (PagedKVRequestAttachment, [PagedKVCache]) {
+        guard layerCount > 0 else { throw PagedKVRuntimeBridgeError.noCacheLayers }
+        let handle = try await allocator.reattach(retained, conversationKey: conversationKey)
+        let binding = try await allocator.binding(for: handle)
+        let attachment = PagedKVRequestAttachment(bridge: self, handle: handle, binding: binding)
+        let layers = try attachment.makeCacheLayers(count: layerCount)
+        let snapshot = try materializeContiguousByteCache(
+            handle: handle,
+            table: try await allocator.table(for: handle)
+        )
+        guard snapshot.layers.count == layerCount else {
+            throw PagedKVRuntimeBridgeError.cacheLayerCountMismatch
+        }
+        for layer in snapshot.layers {
+            guard layer.layerIndex < layers.count else {
+                throw PagedKVRuntimeBridgeError.cacheLayerCountMismatch
+            }
+            try layers[layer.layerIndex].inject(materialized: layer)
+        }
+        return (attachment, layers)
+    }
+
+    func release(handle: PagedKVBlockTableHandle) async throws {
+        try await allocator.release(handle)
+        remove(handle)
+    }
+
+    private func remove(_ handle: PagedKVBlockTableHandle) {
+        lock.lock()
+        liveLayers.removeValue(forKey: handle.handleID)
+        snapshots.removeValue(forKey: handle.handleID)
+        lock.unlock()
+        byteSnapshotStore.remove(handle)
+    }
+}
+
+/// The scheduler's backend-facing representation of a decode forward. The
+/// shape is part of the value so tests and the production driver can assert that
+/// one shared invocation receives exactly `[B, 1]`, rather than accidentally
+/// falling back to one hidden model call per row.
+struct PagedKVSharedForwardBatch: Sendable, Equatable {
+    let tokens: [Int]
+
+    var shape: [Int] { [tokens.count, 1] }
+}
+
+protocol PagedKVSharedForwardDriver: Sendable {
+    func prefill(rows: [ContinuousBatchPrefillInput]) async throws -> [ContinuousBatchPrefillOutput]
+    func decode(
+        batch: PagedKVSharedForwardBatch,
+        rows: [ContinuousBatchDecodeInput]
+    ) async throws -> [ContinuousBatchDecodeOutcome]
+    func cancelInFlight() async
+}
+
+/// Adapter from the SPEC-038 scheduler to a model driver. The scheduler still
+/// owns admission, block lifecycle, cancellation, and row isolation; this type
+/// only packages active row tokens as the shared `[B,1]` input and forwards the
+/// call once.
+struct PagedKVSharedForwardBackend: ContinuousBatchSchedulerBackend {
+    let driver: any PagedKVSharedForwardDriver
+
+    func prefill(rows: [ContinuousBatchPrefillInput]) async throws -> [ContinuousBatchPrefillOutput] {
+        try await driver.prefill(rows: rows)
+    }
+
+    func decode(rows: [ContinuousBatchDecodeInput]) async throws -> [ContinuousBatchDecodeOutcome] {
+        guard !rows.isEmpty else { return [] }
+        let batch = PagedKVSharedForwardBatch(tokens: rows.map(\.currentToken))
+        guard batch.shape == [rows.count, 1] else {
+            throw PagedKVRuntimeBridgeError.cacheStateMismatch
+        }
+        return try await driver.decode(batch: batch, rows: rows)
+    }
+
+    func cancelInFlight() async {
+        await driver.cancelInFlight()
+    }
+}

--- a/phase3-binary/Tests/macprovider-cliTests/PagedKVRuntimeBridgeTests.swift
+++ b/phase3-binary/Tests/macprovider-cliTests/PagedKVRuntimeBridgeTests.swift
@@ -1,0 +1,303 @@
+import Foundation
+import MLX
+import MLXLMCommon
+import XCTest
+
+@testable import MacProviderCore
+@testable import macprovider_cli
+
+final class PagedKVRuntimeBridgeTests: XCTestCase {
+    private func requireMLXMetalLibrary() throws {
+        let binaryURL = URL(fileURLWithPath: CommandLine.arguments[0])
+        let binaryDirectory = binaryURL.deletingLastPathComponent()
+        let candidates = [
+            binaryDirectory.appendingPathComponent("mlx.metallib"),
+            binaryDirectory.appendingPathComponent("default.metallib"),
+            binaryDirectory.appendingPathComponent("Resources/mlx.metallib"),
+            binaryDirectory.appendingPathComponent("Resources/default.metallib"),
+            binaryDirectory.appendingPathComponent("mlx-swift_Cmlx.bundle/default.metallib"),
+            binaryDirectory.appendingPathComponent("Contents/Resources/mlx-swift_Cmlx.bundle/default.metallib"),
+        ]
+        guard candidates.contains(where: { FileManager.default.fileExists(atPath: $0.path) }) else {
+            throw XCTSkip("MLX default metallib is not present in the test bundle")
+        }
+    }
+
+    private let modelID = "mlx-community/Qwen-Bridge-Test"
+    private let modelHash = String(repeating: "a", count: 64)
+    private let tokenizerHash = String(repeating: "b", count: 64)
+    private let templateHash = String(repeating: "c", count: 64)
+    private let metallibHash = String(repeating: "d", count: 64)
+
+    private func config() -> PagedKVConfig {
+        PagedKVConfig(enabled: true, blockSizeTokens: 4, maxPhysicalBlocks: 4)
+    }
+
+    private func observation(
+        parityLabel: String = "sdpa-parity-v1",
+        poolEpoch: Int = 1
+    ) -> PagedKVRuntimeObservation {
+        let proof = PagedKVHardwareSizingProof(
+            modelID: modelID,
+            modelSHA256: modelHash,
+            tokenizerSHA256: tokenizerHash,
+            chatTemplateSHA256: templateHash,
+            modelFamily: "qwen",
+            hardwareClass: "apple-silicon-test",
+            metallibSHA256: metallibHash,
+            kernelIdentifier: PagedKVGatherKernel.registeredKernelName,
+            blockSizeTokens: 4,
+            maxPhysicalBlocks: 4,
+            maxResidentTokens: 16,
+            poolEpoch: poolEpoch,
+            parityLabel: parityLabel
+        )
+        return PagedKVRuntimeObservation(
+            modelID: modelID,
+            modelSHA256: modelHash,
+            tokenizerSHA256: tokenizerHash,
+            chatTemplateSHA256: templateHash,
+            modelFamily: "qwen",
+            cacheClass: "KVCacheSimple",
+            requiresMoEDispatch: false,
+            hardwareClass: "apple-silicon-test",
+            metallibSHA256: metallibHash,
+            kernelIdentifier: PagedKVGatherKernel.registeredKernelName,
+            parityLabel: parityLabel,
+            poolEpoch: poolEpoch,
+            metallibAvailable: true,
+            kernelRegistered: true,
+            parityEstablished: true,
+            hardwareSizingProof: proof,
+            moeDispatchProven: false
+        )
+    }
+
+    private func descriptor(for observation: PagedKVRuntimeObservation) throws -> PagedKVDescriptor {
+        let decision = PagedKVAttachGate.decide(
+            config: config(),
+            runtimeCacheClass: observation.cacheClass,
+            kvBits: nil,
+            modelID: observation.modelID,
+            modelSHA256: observation.modelSHA256,
+            tokenizerSHA256: observation.tokenizerSHA256,
+            chatTemplateSHA256: observation.chatTemplateSHA256,
+            modelFamily: observation.modelFamily,
+            requiresMoEDispatch: observation.requiresMoEDispatch,
+            gates: observation.gates(config: config(), bridgeAvailable: true)
+        )
+        return try XCTUnwrap(decision.descriptor)
+    }
+
+    private func fp16Bytes(_ values: [Float16]) -> Data {
+        values.withUnsafeBytes { Data($0) }
+    }
+
+    func testObservedIdentityIsRequiredForAttachAndBatchCapability() async throws {
+        let good = observation()
+        let bad = observation(parityLabel: "unproven")
+        let trustedDescriptor = try descriptor(for: good)
+        XCTAssertTrue(good.matches(config: config()))
+        XCTAssertTrue(bad.matches(config: config()))
+        XCTAssertTrue(bad.gates(config: config(), bridgeAvailable: true).engineBridgeAvailable)
+
+        let badDecision = PagedKVAttachGate.decide(
+            config: config(),
+            runtimeCacheClass: bad.cacheClass,
+            kvBits: nil,
+            modelID: bad.modelID,
+            modelSHA256: bad.modelSHA256,
+            tokenizerSHA256: bad.tokenizerSHA256,
+            chatTemplateSHA256: bad.chatTemplateSHA256,
+            modelFamily: bad.modelFamily,
+            requiresMoEDispatch: bad.requiresMoEDispatch,
+            gates: bad.gates(config: config(), bridgeAvailable: true)
+        )
+        XCTAssertNotEqual(badDecision.descriptor, trustedDescriptor)
+
+        struct NoopDriver: PagedKVSharedForwardDriver {
+            func prefill(rows: [ContinuousBatchPrefillInput]) async throws -> [ContinuousBatchPrefillOutput] {
+                rows.map { ContinuousBatchPrefillOutput(requestID: $0.requestID) }
+            }
+
+            func decode(
+                batch: PagedKVSharedForwardBatch,
+                rows: [ContinuousBatchDecodeInput]
+            ) async throws -> [ContinuousBatchDecodeOutcome] {
+                XCTAssertEqual(batch.shape, [rows.count, 1])
+                return rows.map {
+                    .output(ContinuousBatchDecodeOutput(requestID: $0.requestID, token: $0.currentToken))
+                }
+            }
+
+            func cancelInFlight() async {}
+        }
+
+        let mismatchedRuntime = ModelRuntime(
+            modelID: bad.modelID,
+            modelHash: bad.modelSHA256,
+            pagedKVConfig: config(),
+            maxBatch: 2,
+            continuousBatchingMode: .canary,
+            pagedKVRuntimeObservation: bad,
+            pagedKVTrustedDescriptor: trustedDescriptor,
+            pagedKVSharedForwardDriver: NoopDriver(),
+            warmSwapEnabled: false,
+            loader: { _ in throw NSError(domain: "test", code: 1) }
+        )
+        let mismatchDecision = await mismatchedRuntime.pagedKVDecisionForTest()
+        XCTAssertNil(mismatchDecision.descriptor)
+
+        let untrustedRuntime = ModelRuntime(
+            modelID: good.modelID,
+            modelHash: good.modelSHA256,
+            pagedKVConfig: config(),
+            maxBatch: 2,
+            continuousBatchingMode: .canary,
+            pagedKVRuntimeObservation: good,
+            pagedKVSharedForwardDriver: NoopDriver(),
+            warmSwapEnabled: false,
+            loader: { _ in throw NSError(domain: "test", code: 1) }
+        )
+        let untrustedDecision = await untrustedRuntime.pagedKVDecisionForTest()
+        XCTAssertNil(untrustedDecision.descriptor)
+
+        let runtime = ModelRuntime(
+            modelID: good.modelID,
+            modelHash: good.modelSHA256,
+            pagedKVConfig: config(),
+            maxBatch: 2,
+            continuousBatchingMode: .canary,
+            pagedKVRuntimeObservation: good,
+            pagedKVTrustedDescriptor: trustedDescriptor,
+            pagedKVSharedForwardDriver: NoopDriver(),
+            warmSwapEnabled: false,
+            loader: { _ in throw NSError(domain: "test", code: 1) }
+        )
+        let capability = await runtime.continuousBatchingCapabilityForTest()
+        XCTAssertNotNil(capability.descriptor)
+        XCTAssertNil(capability.unsupportedReason)
+
+        let serialOnlyRuntime = ModelRuntime(
+            modelID: good.modelID,
+            modelHash: good.modelSHA256,
+            pagedKVConfig: config(),
+            maxBatch: 2,
+            continuousBatchingMode: .canary,
+            pagedKVRuntimeObservation: good,
+            pagedKVTrustedDescriptor: trustedDescriptor,
+            warmSwapEnabled: false,
+            loader: { _ in throw NSError(domain: "test", code: 1) }
+        )
+        let serialCapability = await serialOnlyRuntime.continuousBatchingCapabilityForTest()
+        XCTAssertEqual(serialCapability.unsupportedReason, .localCapabilityUnavailable)
+    }
+
+    func testLiveContiguousRoundTripRetainReattachAndTrimMidBlock() async throws {
+        try requireMLXMetalLibrary()
+        let observation = observation()
+        let descriptor = try descriptor(for: observation)
+        let bridge = try PagedKVRuntimeBridge(
+            config: config(), observation: observation, descriptor: descriptor
+        )
+        let attachment = try await bridge.reserve(
+            requestID: "bridge-test",
+            maxTokens: 16
+        )
+        let layers = try attachment.makeCacheLayers(count: 1)
+
+        let shape = [1, 1, 7, 2]
+        let keyValues = (0 ..< 14).map { Float16($0 + 1) }
+        let valueValues = (0 ..< 14).map { Float16(100 + $0) }
+        let source = PagedKVMaterializedByteLayer(
+            layerIndex: 0,
+            keyShape: shape,
+            valueShape: shape,
+            dtype: .fp16,
+            logicalTokenCount: 7,
+            keyBytes: fp16Bytes(keyValues),
+            valueBytes: fp16Bytes(valueValues)
+        )
+        try layers[0].inject(materialized: source)
+
+        let snapshot = try await attachment.checkpoint()
+        XCTAssertEqual(snapshot.blockTable.logicalTokenCount, 7)
+        XCTAssertEqual(snapshot.blockTable.tailValidTokenCount, 3)
+        let contiguous = try await bridge.materializeContiguousKVCache(handle: attachment.handle)
+        let contiguousState = try XCTUnwrap(contiguous.first?.state)
+        XCTAssertEqual(contiguous.first?.offset, 7)
+        XCTAssertEqual(contiguousState[0].asData().data, source.keyBytes)
+        XCTAssertEqual(contiguousState[1].asData().data, source.valueBytes)
+
+        let retained = try await attachment.retain()
+        let (reattached, reattachedLayers) = try await bridge.reattach(
+            retained,
+            conversationKey: "bridge-test",
+            layerCount: 1
+        )
+        XCTAssertEqual(reattachedLayers[0].offset, 7)
+
+        // Trim two tokens from a seven-token sequence: the allocator and live
+        // KVCache must agree on the five-token mid-block boundary.
+        XCTAssertEqual(reattachedLayers[0].trim(2), 2)
+        let trimmed = try await reattached.checkpoint()
+        XCTAssertEqual(trimmed.blockTable.logicalTokenCount, 5)
+        XCTAssertEqual(trimmed.blockTable.tailValidTokenCount, 1)
+        XCTAssertEqual(trimmed.layers[0].keyShape[2], 5)
+        XCTAssertEqual(trimmed.layers[0].keyBytes.count, 5 * 2 * MemoryLayout<Float16>.size)
+
+        try await reattached.release()
+    }
+
+    func testSharedForwardBackendCarriesOneTokenPerActiveRow() async throws {
+        struct Recorder: PagedKVSharedForwardDriver {
+            func prefill(rows: [ContinuousBatchPrefillInput]) async throws -> [ContinuousBatchPrefillOutput] { [] }
+
+            func decode(
+                batch: PagedKVSharedForwardBatch,
+                rows: [ContinuousBatchDecodeInput]
+            ) async throws -> [ContinuousBatchDecodeOutcome] {
+                XCTAssertEqual(batch.tokens, rows.map(\.currentToken))
+                XCTAssertEqual(batch.shape, [2, 1])
+                return rows.map {
+                    .output(ContinuousBatchDecodeOutput(requestID: $0.requestID, token: $0.currentToken))
+                }
+            }
+
+            func cancelInFlight() async {}
+        }
+
+        let handle = PagedKVBlockTableHandle(id: UUID(), conversationKey: "batch", poolEpoch: 1)
+        let table = PagedKVBlockTable(
+            handleID: handle.handleID,
+            blockSizeTokens: 4,
+            logicalTokenCount: 1,
+            physicalBlocks: [0],
+            tailValidTokenCount: 1,
+            poolEpoch: 1
+        )
+        let binding = PagedKVStorageBinding(
+            handle: handle,
+            blockSizeTokens: 4,
+            maxLogicalTokens: 8,
+            currentTable: table,
+            poolEpoch: 1
+        )
+        let rows = [
+            ContinuousBatchDecodeInput(
+                requestID: "a", currentToken: 11, generatedTokens: [], promptTokens: [1],
+                samplerSeed: 0, temperature: 0, topP: 1, presencePenalty: 0, frequencyPenalty: 0,
+                blockTable: table, committedKVTokenCount: 1, targetKVTokenCount: 2, samplerStep: 0
+            ),
+            ContinuousBatchDecodeInput(
+                requestID: "b", currentToken: 22, generatedTokens: [], promptTokens: [2],
+                samplerSeed: 0, temperature: 0, topP: 1, presencePenalty: 0, frequencyPenalty: 0,
+                blockTable: table, committedKVTokenCount: 1, targetKVTokenCount: 2, samplerStep: 0
+            ),
+        ]
+        let backend = PagedKVSharedForwardBackend(driver: Recorder())
+        let outcomes = try await backend.decode(rows: rows)
+        XCTAssertEqual(outcomes.count, 2)
+        _ = binding
+    }
+}


### PR DESCRIPTION
## SPEC-039 Phase-2 runtime bridge + FR-PKV10 (#887) — DRAFT, under independent audit

Implements the deferred runtime bridge that is *allowed* to activate the merged-but-inert paged engine (#814) and continuous-batching scheduler (#888).

**Safety posture (verified):** production never constructs a runtime observation, so `resolveDecisionAndBridge` fails closed and `schedulerBackendAvailable`/`engineBridgeAvailable` stay false — the feature is runtime-inert. Attach requires an observed-identity match against a trusted descriptor; `admits()` rejects empty/partial identity on all four fields (hardware/metallib/kernel/parity) + exact poolEpoch. No speculative-activation path.

**Scope:** Increment 1 (request-level attach + shared `[B,1]` forward adapter) + Increment 2 (FR-PKV10 contiguous KVCache extraction / reinjection / retain-reattach / mid-block trim).

**Status:** opened for CI + independent 3-lane codex audit. Real enable proof deferred to a >32GB Mac.

SPEC-GOVERNANCE-DECLARATION-BEGIN
{
  "schema_version": "spec-pr-governance-v1",
  "behavior_change": "yes",
  "contract_change": "none",
  "specs": ["SPEC-039"],
  "requirements": ["SPEC-039-R010"],
  "authority_domains": ["paged-kv-attention"],
  "arbitration": ["CODE_BUG"],
  "tests": ["swift test --filter PagedKVRuntimeBridgeTests", "swift test --filter PagedKVEngineTests"],
  "journeys": ["not-required"]
}
SPEC-GOVERNANCE-DECLARATION-END
