### PR TITLE
Keep release version guard arguments intact in Actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -105,10 +105,11 @@ jobs:
 
       - name: Verify release version cohesion
         shell: bash
-        run: bash scripts/test-coordinator-advertised-version.sh \
-          "${{ steps.release_source.outputs.tag }}" \
-          --allow-previous-stable=1.8.81 \
-          --staged-candidate=1.8.82
+        run: |
+          bash scripts/test-coordinator-advertised-version.sh \
+            "${{ steps.release_source.outputs.tag }}" \
+            --allow-previous-stable=1.8.81 \
+            --staged-candidate=1.8.82
 
       - name: Select and verify reviewed release toolchain
         shell: bash

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -105,6 +105,7 @@ jobs:
 
       - name: Verify release version cohesion
         shell: bash
+        # Keep this a literal block: YAML folds plain multiline scalars before Bash parses them.
         run: |
           bash scripts/test-coordinator-advertised-version.sh \
             "${{ steps.release_source.outputs.tag }}" \


### PR DESCRIPTION
The release workflow used a folded YAML run scalar for a multiline Bash invocation. Hosted runners therefore parsed escaped spaces as arguments, causing the v1.8.82 candidate gate to fail before build validation.

This changes only that step to a literal run block. Focused version-cohesion regression checks pass locally.

SPEC-GOVERNANCE-DECLARATION-BEGIN
{
  "schema_version": "spec-pr-governance-v1",
  "behavior_change": "yes",
  "contract_change": "yes",
  "specs": ["SPEC-010", "SPEC-020", "SPEC-023", "SPEC-032", "SPEC-033"],
  "requirements": ["SPEC-010-R001", "SPEC-020-R001", "SPEC-023-R001", "SPEC-032-R001", "SPEC-033-R001"],
  "authority_domains": ["model-catalog-identity", "provider-autoupdate", "installer-autotune-policy", "hardware-evidence-admission", "hardware-evidence-verifier"],
  "arbitration": ["UNKNOWN"],
  "tests": ["scripts/test-coordinator-advertised-version-test.sh"],
  "journeys": ["not-required"]
}
SPEC-GOVERNANCE-DECLARATION-END