### PR TITLE
Provision Go for promoted release verification

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -120,9 +120,11 @@ jobs:
           bash scripts/verify-release-toolchain.sh "$RUNNER_TEMP/release-toolchain.json"
 
       - name: Setup Go for Pearl binaries
-        if: ${{ github.event.inputs.promote_run_id == '' }}
         # Pinned to actions/setup-go v7.0.0. Linux binaries are cross-compiled
         # without CGO and carried as unsigned inputs into the protected signer.
+        # The promoted-candidate path still runs the final embedded-build-info
+        # verifier, so it needs the same pinned Go toolchain even though it
+        # does not compile the binaries again.
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e
         with:
           go-version-file: phase4-coordinator/go.mod

--- a/scripts/test-release-security-posture.sh
+++ b/scripts/test-release-security-posture.sh
@@ -389,8 +389,11 @@ def validate_pearl_toolchain(job):
     sealed_go_path = str(pathlib.PurePosixPath(SEALED_GO_EXECUTABLE).parent.parent)
     if job.count(sealed_go_path) != PEARL_GO_SEAL_STEP.count(sealed_go_path):
         raise SystemExit("sealed Go verifier path must appear only in the exact seal step")
+    if SLOW_BUILD_SKIP_GUARD in setup_go:
+        raise SystemExit(
+            "Setup Go for Pearl binaries must remain available when promoting a candidate artifact"
+        )
     for name, step in (
-        ("Setup Go for Pearl binaries", setup_go),
         ("Build Pearl linux-amd64 binaries", pearl_build),
         ("Build package", package_build),
     ):


### PR DESCRIPTION
## Outcome

Provision the pinned Go toolchain on every release build path so a promoted v1.8.82 candidate can pass embedded-build-info verification before protected signing.

## Change

The production reuse path no longer skips setup-go. Compilation remains candidate-build-only; promoted releases now have the same verifier environment used by the candidate build.

## Verification

- git diff --check
- python3 scripts/verify-pearl-go-binaries.py --self-test
- staged v1.8.82 version-cohesion check
- candidate artifact independently verified as ELF Go binaries with embedded revision fc89b4a76261f9565b340c0a1e6d4de97b2abd91

Constraint: promoted production releases must verify exact candidate bytes before protected signing.

SPEC-GOVERNANCE-DECLARATION-BEGIN
{
  "schema_version": "spec-pr-governance-v1",
  "behavior_change": "yes",
  "contract_change": "yes",
  "specs": ["SPEC-010", "SPEC-020", "SPEC-023", "SPEC-032", "SPEC-033"],
  "requirements": ["SPEC-010-R001", "SPEC-020-R001", "SPEC-023-R001", "SPEC-032-R001", "SPEC-033-R001"],
  "authority_domains": ["model-catalog-identity", "provider-autoupdate", "installer-autotune-policy", "hardware-evidence-admission", "hardware-evidence-verifier"],
  "arbitration": ["UNKNOWN"],
  "tests": ["scripts/verify-pearl-go-binaries.py --self-test", "scripts/test-coordinator-advertised-version.sh"],
  "journeys": ["not-required"]
}
SPEC-GOVERNANCE-DECLARATION-END
