### PR TITLE
Bind promoted releases to their signed tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,6 +57,10 @@ jobs:
         # when upgrading the action rather than trusting a mutable tag.
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
         with:
+          # A promoted candidate is bound to the already-created signed tag.
+          # Checkout that immutable source commit while the workflow itself
+          # remains dispatched from fresh main; candidate builds use main.
+          ref: ${{ github.event.inputs.promote_run_id != '' && github.event.inputs.version || github.ref }}
           persist-credentials: false
 
       - name: Verify reviewed release source
@@ -93,7 +97,10 @@ jobs:
               exit 1
             fi
           fi
-          bash scripts/verify-release-source.sh \
+          # The checkout above is the immutable tagged source for promoted
+          # candidates, so bind the guard to that checked-out commit rather
+          # than the workflow dispatch SHA on main.
+          GITHUB_SHA="$commit" bash scripts/verify-release-source.sh \
             "$tag" "$commit" origin "$absence_policy"
           echo "tag=$tag" >> "$GITHUB_OUTPUT"
           echo "commit=$commit" >> "$GITHUB_OUTPUT"
@@ -449,7 +456,7 @@ jobs:
         run: |
           set -euo pipefail
           tag="${{ needs.build.outputs.tag }}"
-          bash scripts/verify-release-source.sh \
+          GITHUB_SHA="${{ needs.build.outputs.commit }}" bash scripts/verify-release-source.sh \
             "$tag" "${{ needs.build.outputs.commit }}" origin --require-existing
           unsigned_dir="$RUNNER_TEMP/unsigned-release-inputs"
           unsigned_assets=(
@@ -1706,7 +1713,7 @@ jobs:
           set -euo pipefail
           tag="${{ needs.build.outputs.tag }}"
           release_commit="${{ needs.build.outputs.commit }}"
-          bash scripts/verify-release-source.sh \
+          GITHUB_SHA="$release_commit" bash scripts/verify-release-source.sh \
             "$tag" "$release_commit" origin --require-existing
           GH_TOKEN="$RELEASE_POSTURE_TOKEN" \
             bash scripts/verify-github-release-posture.sh \
@@ -1796,7 +1803,7 @@ jobs:
           # source, tag, repository-posture, numeric-ID, and asset assertion
           # directly before changing draft=false. The coordinator may still
           # advertise the previous stable CLI until this release is public.
-          bash scripts/verify-release-source.sh \
+          GITHUB_SHA="$commit" bash scripts/verify-release-source.sh \
             "$tag" "$commit" origin --require-existing
           GH_TOKEN="$RELEASE_POSTURE_TOKEN" \
             bash scripts/verify-github-release-posture.sh \

--- a/scripts/test-release-security-posture.sh
+++ b/scripts/test-release-security-posture.sh
@@ -103,6 +103,29 @@ provider_runtime = text.split("\n  verify_provider_runtime:\n", 1)[1].split(
 )[0]
 publish = text.split("\n  sign_publish:\n", 1)[1]
 
+TAGGED_PROMOTION_CHECKOUT = (
+    "          ref: ${{ github.event.inputs.promote_run_id != '' "
+    "&& github.event.inputs.version || github.ref }}"
+)
+if TAGGED_PROMOTION_CHECKOUT not in build:
+    raise SystemExit(
+        "promoted releases must checkout the immutable requested tag while candidate builds use main"
+    )
+if build.count('GITHUB_SHA="$commit" bash scripts/verify-release-source.sh') != 1:
+    raise SystemExit(
+        "build source verification must bind GITHUB_SHA to the checked-out release commit"
+    )
+if publish.count(
+    'GITHUB_SHA="${{ needs.build.outputs.commit }}" bash scripts/verify-release-source.sh'
+) != 1 or publish.count(
+    'GITHUB_SHA="$release_commit" bash scripts/verify-release-source.sh'
+) != 1 or publish.count(
+    'GITHUB_SHA="$commit" bash scripts/verify-release-source.sh'
+) != 1:
+    raise SystemExit(
+        "protected publication source gates must bind GITHUB_SHA to the captured release commit"
+    )
+
 
 def unique_step(job, name):
     marker = f"\n      - name: {name}\n"


### PR DESCRIPTION
## Outcome

Allow production to reuse the verified v1.8.82 candidate after a later main merge without moving the signed tag or rebuilding from a different source.

## Change

- Promoted runs check out the requested immutable tag while candidate runs continue from main.
- Source gates bind GITHUB_SHA to the checked-out/captured release commit.
- The release-security posture test asserts the tag-bound checkout and all protected source gates.

## Validation

- bash scripts/test-release-security-posture.sh
- bash scripts/test-release-tag-target.sh
- git diff --check

Constraint: v1.8.82 is already signed and must remain immutable.
Rejected: moving the tag to the later workflow-fix merge | it would break candidate artifact identity.

SPEC-GOVERNANCE-DECLARATION-BEGIN
{
  "schema_version": "spec-pr-governance-v1",
  "behavior_change": "yes",
  "contract_change": "yes",
  "specs": ["SPEC-010", "SPEC-020", "SPEC-023", "SPEC-032", "SPEC-033"],
  "requirements": ["SPEC-010-R001", "SPEC-020-R001", "SPEC-023-R001", "SPEC-032-R001", "SPEC-033-R001"],
  "authority_domains": ["model-catalog-identity", "provider-autoupdate", "installer-autotune-policy", "hardware-evidence-admission", "hardware-evidence-verifier"],
  "arbitration": ["UNKNOWN"],
  "tests": ["scripts/test-release-security-posture.sh", "scripts/test-release-tag-target.sh"],
  "journeys": ["not-required"]
}
SPEC-GOVERNANCE-DECLARATION-END
