### PR TITLE
SPEC-039 Phase-2 bridge + FR-PKV10 — revision (supersedes #889) (#887)

### DIFF
--- a/phase3-binary/Sources/MacProviderCore/PagedKVEngine.swift
+++ b/phase3-binary/Sources/MacProviderCore/PagedKVEngine.swift
@@ -75,7 +75,22 @@ public struct PagedKVDescriptor: Equatable, Sendable, Codable {
         parityLabel: String,
         poolEpoch: Int
     ) -> Bool {
-        self.modelID == modelID
+        guard let descriptorTokenizerSHA256 = self.tokenizerSHA256,
+              !descriptorTokenizerSHA256.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
+              let descriptorChatTemplateSHA256 = self.chatTemplateSHA256,
+              !descriptorChatTemplateSHA256.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
+              let tokenizerSHA256,
+              !tokenizerSHA256.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
+              let chatTemplateSHA256,
+              !chatTemplateSHA256.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
+              !modelID.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
+              !modelSHA256.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
+              !hardwareClass.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
+              !metallibSHA256.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
+              !kernelIdentifier.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
+              !parityLabel.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        else { return false }
+        return self.modelID == modelID
             && self.modelSHA256 == modelSHA256
             && self.tokenizerSHA256 == tokenizerSHA256
             && self.chatTemplateSHA256 == chatTemplateSHA256
@@ -109,6 +124,26 @@ public struct PagedKVHardwareSizingProof: Equatable, Sendable, Codable {
     public let blockSizeTokens: Int
     public let maxPhysicalBlocks: Int
     public let maxResidentTokens: Int
+    /// FR-PKV13 evidence for the live production 30B / 32 GiB envelope. These
+    /// values are supplied by the offline sizing run; the attach gate never
+    /// derives them from the requested pool configuration.
+    public let sizingModelClass: String
+    public let unifiedMemoryGB: Int
+    public let modelWeightsGB: Double
+    public let perRequestActivationGB: Double
+    public let pagedBlockPoolGB: Double
+    /// Aggregate fp16 K/V bytes per resident token across the model's layers,
+    /// measured by the sizing fixture. This binds the recorded pool budget to
+    /// the configured block capacity rather than treating it as decoration.
+    public let kvBytesPerToken: Int
+    /// A nil pair records the honest v0.1 batch-1 result that no differentiated
+    /// stock-vs-paged context envelope has been established yet.
+    public let stockContiguousMaxContextTokens: Int?
+    public let pagedMaxContextTokens: Int?
+    /// Measured gather overhead and the maximum accepted regression, both as
+    /// percentages versus the stock contiguous path.
+    public let measuredGatherOverheadPercent: Double
+    public let gatherOverheadCeilingPercent: Double
     public let poolEpoch: Int
     public let parityLabel: String
 
@@ -124,6 +159,16 @@ public struct PagedKVHardwareSizingProof: Equatable, Sendable, Codable {
         blockSizeTokens: Int,
         maxPhysicalBlocks: Int,
         maxResidentTokens: Int,
+        sizingModelClass: String,
+        unifiedMemoryGB: Int,
+        modelWeightsGB: Double,
+        perRequestActivationGB: Double,
+        pagedBlockPoolGB: Double,
+        kvBytesPerToken: Int,
+        stockContiguousMaxContextTokens: Int? = nil,
+        pagedMaxContextTokens: Int? = nil,
+        measuredGatherOverheadPercent: Double,
+        gatherOverheadCeilingPercent: Double,
         poolEpoch: Int = 1,
         parityLabel: String
     ) {
@@ -138,6 +183,16 @@ public struct PagedKVHardwareSizingProof: Equatable, Sendable, Codable {
         self.blockSizeTokens = blockSizeTokens
         self.maxPhysicalBlocks = maxPhysicalBlocks
         self.maxResidentTokens = maxResidentTokens
+        self.sizingModelClass = sizingModelClass
+        self.unifiedMemoryGB = unifiedMemoryGB
+        self.modelWeightsGB = modelWeightsGB
+        self.perRequestActivationGB = perRequestActivationGB
+        self.pagedBlockPoolGB = pagedBlockPoolGB
+        self.kvBytesPerToken = kvBytesPerToken
+        self.stockContiguousMaxContextTokens = stockContiguousMaxContextTokens
+        self.pagedMaxContextTokens = pagedMaxContextTokens
+        self.measuredGatherOverheadPercent = measuredGatherOverheadPercent
+        self.gatherOverheadCeilingPercent = gatherOverheadCeilingPercent
         self.poolEpoch = poolEpoch
         self.parityLabel = parityLabel
     }
@@ -155,7 +210,44 @@ public struct PagedKVHardwareSizingProof: Equatable, Sendable, Codable {
         observedParityLabel: String,
         poolEpoch: Int
     ) -> Bool {
-        self.modelID == modelID
+        guard let proofTokenizerSHA256 = self.tokenizerSHA256,
+              !proofTokenizerSHA256.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
+              let proofChatTemplateSHA256 = self.chatTemplateSHA256,
+              !proofChatTemplateSHA256.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
+              let tokenizerSHA256,
+              !tokenizerSHA256.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
+              let chatTemplateSHA256,
+              !chatTemplateSHA256.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
+              !modelID.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
+              !modelSHA256.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
+              sizingModelClass == Self.requiredSizingModelClass,
+              unifiedMemoryGB == Self.requiredUnifiedMemoryGB,
+              modelWeightsGB.isFinite,
+              perRequestActivationGB.isFinite,
+              pagedBlockPoolGB.isFinite,
+              modelWeightsGB > 0,
+              perRequestActivationGB > 0,
+              pagedBlockPoolGB > 0,
+              kvBytesPerToken > 0,
+              modelWeightsGB + perRequestActivationGB + pagedBlockPoolGB <= Double(unifiedMemoryGB),
+              measuredGatherOverheadPercent.isFinite,
+              gatherOverheadCeilingPercent.isFinite,
+              measuredGatherOverheadPercent >= 0,
+              gatherOverheadCeilingPercent > 0,
+              measuredGatherOverheadPercent <= gatherOverheadCeilingPercent,
+              (stockContiguousMaxContextTokens == nil && pagedMaxContextTokens == nil)
+                || (stockContiguousMaxContextTokens ?? -1 >= 0
+                    && (pagedMaxContextTokens ?? -1) > (stockContiguousMaxContextTokens ?? -1))
+        else { return false }
+        let (poolTokens, poolTokenOverflow) = config.blockSizeTokens
+            .multipliedReportingOverflow(by: config.maxPhysicalBlocks)
+        let (requiredPoolBytes, poolByteOverflow) = poolTokens
+            .multipliedReportingOverflow(by: kvBytesPerToken)
+        guard !poolTokenOverflow,
+              !poolByteOverflow,
+              Double(requiredPoolBytes) <= pagedBlockPoolGB * 1_073_741_824
+        else { return false }
+        return self.modelID == modelID
             && self.modelSHA256 == modelSHA256
             && self.tokenizerSHA256 == tokenizerSHA256
             && self.chatTemplateSHA256 == chatTemplateSHA256
@@ -173,6 +265,9 @@ public struct PagedKVHardwareSizingProof: Equatable, Sendable, Codable {
             && maxResidentTokens >= config.maxResidentTokens
             && self.poolEpoch == poolEpoch
     }
+
+    public static let requiredSizingModelClass = "live-production-30B"
+    public static let requiredUnifiedMemoryGB = 32
 }
 
 public struct PagedKVGates: Equatable, Sendable {
@@ -322,7 +417,11 @@ public struct PagedKVRuntimeObservation: Equatable, Sendable {
     /// Returns whether every observed identity field is complete and covered by
     /// the sizing proof for this exact configuration and allocator epoch.
     public func matches(config: PagedKVConfig) -> Bool {
-        guard let hardwareClass,
+        guard let tokenizerSHA256,
+              !tokenizerSHA256.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
+              let chatTemplateSHA256,
+              !chatTemplateSHA256.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
+              let hardwareClass,
               let metallibSHA256,
               let kernelIdentifier,
               let parityLabel,
@@ -428,6 +527,11 @@ public enum PagedKVAttachGate {
         guard kvBits == nil else { return fail(.quantized) }
         guard recognizedModelFamilies.contains(modelFamily) else { return fail(.identity) }
         guard gates.identityAvailable else { return fail(.identity) }
+        guard let tokenizerSHA256,
+              !tokenizerSHA256.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
+              let chatTemplateSHA256,
+              !chatTemplateSHA256.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        else { return fail(.identity) }
         guard allowedCacheClasses.contains(runtimeCacheClass) else { return fail(.cacheClass) }
         guard gates.metallibAvailable else { return fail(.metallib) }
         guard gates.kernelRegistered else { return fail(.kernel) }
@@ -437,6 +541,7 @@ public enum PagedKVAttachGate {
               let observedMetallibSHA256 = gates.observedMetallibSHA256,
               let observedKernelIdentifier = gates.observedKernelIdentifier,
               let observedParityLabel = gates.observedParityLabel,
+              let observedPoolEpoch = gates.observedPoolEpoch,
               sizingProof.covers(
                   config: config,
                   modelID: modelID,
@@ -448,7 +553,7 @@ public enum PagedKVAttachGate {
                   observedMetallibSHA256: observedMetallibSHA256,
                   observedKernelIdentifier: observedKernelIdentifier,
                   observedParityLabel: observedParityLabel,
-                  poolEpoch: gates.observedPoolEpoch ?? sizingProof.poolEpoch
+                  poolEpoch: observedPoolEpoch
               )
         else {
             return fail(.allocator)
@@ -525,6 +630,8 @@ public struct PagedKVRetainedSequence: Equatable, Sendable {
     public let handle: PagedKVBlockTableHandle
     let conversationKey: String
     public let logicalTokenCount: Int
+
+    public var conversationKeyForValidation: String { conversationKey }
 }
 
 public struct PagedKVStorageBinding: Equatable, Sendable {
@@ -532,7 +639,28 @@ public struct PagedKVStorageBinding: Equatable, Sendable {
     public let blockSizeTokens: Int
     public let maxLogicalTokens: Int
     public let currentTable: PagedKVBlockTable
+    /// All physical blocks reserved for this handle, including blocks that are
+    /// not live at the current logical length. Runtime caches use this allocator-
+    /// issued order as their physical backing; `currentTable` remains the live
+    /// block-table view used by materialization and validation.
+    public let reservedPhysicalBlocks: [Int]
     public let poolEpoch: Int
+
+    public init(
+        handle: PagedKVBlockTableHandle,
+        blockSizeTokens: Int,
+        maxLogicalTokens: Int,
+        currentTable: PagedKVBlockTable,
+        reservedPhysicalBlocks: [Int]? = nil,
+        poolEpoch: Int
+    ) {
+        self.handle = handle
+        self.blockSizeTokens = blockSizeTokens
+        self.maxLogicalTokens = maxLogicalTokens
+        self.currentTable = currentTable
+        self.reservedPhysicalBlocks = reservedPhysicalBlocks ?? currentTable.physicalBlocks
+        self.poolEpoch = poolEpoch
+    }
 }
 
 struct PagedKVPhysicalLayerBlocks: Equatable, Sendable {
@@ -858,6 +986,7 @@ public actor PagedKVBlockAllocator {
             blockSizeTokens: blockSizeTokens,
             maxLogicalTokens: state.maxLogicalTokens,
             currentTable: try validate(handle),
+            reservedPhysicalBlocks: state.reservedBlocks,
             poolEpoch: poolEpoch
         )
     }

--- a/phase3-binary/Sources/MacProviderCore/PagedKVEngine.swift
+++ b/phase3-binary/Sources/MacProviderCore/PagedKVEngine.swift
@@ -185,6 +185,10 @@ public struct PagedKVGates: Equatable, Sendable {
     public let observedMetallibSHA256: String?
     public let observedKernelIdentifier: String?
     public let observedParityLabel: String?
+    /// Pool epoch observed from the live allocator/runtime. Keeping this separate
+    /// from the sizing proof prevents a proof for epoch N from being reused after
+    /// the allocator has rolled to epoch N+1.
+    public let observedPoolEpoch: Int?
     public let moeDispatchProven: Bool
     public let engineBridgeAvailable: Bool
 
@@ -198,6 +202,7 @@ public struct PagedKVGates: Equatable, Sendable {
         observedMetallibSHA256: String? = nil,
         observedKernelIdentifier: String? = nil,
         observedParityLabel: String? = nil,
+        observedPoolEpoch: Int? = nil,
         moeDispatchProven: Bool = false,
         engineBridgeAvailable: Bool = false
     ) {
@@ -210,6 +215,7 @@ public struct PagedKVGates: Equatable, Sendable {
         self.observedMetallibSHA256 = observedMetallibSHA256
         self.observedKernelIdentifier = observedKernelIdentifier
         self.observedParityLabel = observedParityLabel
+        self.observedPoolEpoch = observedPoolEpoch
         self.moeDispatchProven = moeDispatchProven
         self.engineBridgeAvailable = engineBridgeAvailable
     }
@@ -224,6 +230,7 @@ public struct PagedKVGates: Equatable, Sendable {
         observedMetallibSHA256: nil,
         observedKernelIdentifier: nil,
         observedParityLabel: nil,
+        observedPoolEpoch: nil,
         moeDispatchProven: false,
         engineBridgeAvailable: false
     )
@@ -239,8 +246,131 @@ public struct PagedKVGates: Equatable, Sendable {
             observedMetallibSHA256: nil,
             observedKernelIdentifier: nil,
             observedParityLabel: nil,
+            observedPoolEpoch: nil,
             moeDispatchProven: false,
             engineBridgeAvailable: false
+        )
+    }
+}
+
+/// A provider-local observation of the runtime tuple used by SPEC-039 attach.
+///
+/// The values in this type are observations, not descriptor defaults. Callers
+/// must obtain them from the loaded model/runtime probe (or an offline fixture
+/// that represents that probe); the attach gate never derives them from the
+/// descriptor it is about to advertise.
+public struct PagedKVRuntimeObservation: Equatable, Sendable {
+    public let modelID: String
+    public let modelSHA256: String
+    public let tokenizerSHA256: String?
+    public let chatTemplateSHA256: String?
+    public let modelFamily: String
+    public let cacheClass: String
+    public let kvDType: PagedKVDType
+    public let requiresMoEDispatch: Bool
+    public let hardwareClass: String?
+    public let metallibSHA256: String?
+    public let kernelIdentifier: String?
+    public let parityLabel: String?
+    public let poolEpoch: Int?
+    public let metallibAvailable: Bool
+    public let kernelRegistered: Bool
+    public let parityEstablished: Bool
+    public let hardwareSizingProof: PagedKVHardwareSizingProof?
+    public let moeDispatchProven: Bool
+
+    public init(
+        modelID: String,
+        modelSHA256: String,
+        tokenizerSHA256: String?,
+        chatTemplateSHA256: String?,
+        modelFamily: String,
+        cacheClass: String,
+        kvDType: PagedKVDType = .fp16,
+        requiresMoEDispatch: Bool,
+        hardwareClass: String?,
+        metallibSHA256: String?,
+        kernelIdentifier: String?,
+        parityLabel: String?,
+        poolEpoch: Int?,
+        metallibAvailable: Bool,
+        kernelRegistered: Bool,
+        parityEstablished: Bool,
+        hardwareSizingProof: PagedKVHardwareSizingProof?,
+        moeDispatchProven: Bool
+    ) {
+        self.modelID = modelID
+        self.modelSHA256 = modelSHA256
+        self.tokenizerSHA256 = tokenizerSHA256
+        self.chatTemplateSHA256 = chatTemplateSHA256
+        self.modelFamily = modelFamily
+        self.cacheClass = cacheClass
+        self.kvDType = kvDType
+        self.requiresMoEDispatch = requiresMoEDispatch
+        self.hardwareClass = hardwareClass
+        self.metallibSHA256 = metallibSHA256
+        self.kernelIdentifier = kernelIdentifier
+        self.parityLabel = parityLabel
+        self.poolEpoch = poolEpoch
+        self.metallibAvailable = metallibAvailable
+        self.kernelRegistered = kernelRegistered
+        self.parityEstablished = parityEstablished
+        self.hardwareSizingProof = hardwareSizingProof
+        self.moeDispatchProven = moeDispatchProven
+    }
+
+    /// Returns whether every observed identity field is complete and covered by
+    /// the sizing proof for this exact configuration and allocator epoch.
+    public func matches(config: PagedKVConfig) -> Bool {
+        guard let hardwareClass,
+              let metallibSHA256,
+              let kernelIdentifier,
+              let parityLabel,
+              let poolEpoch,
+              let hardwareSizingProof
+        else { return false }
+        guard PagedKVAttachGate.recognizedModelFamilies.contains(modelFamily),
+              PagedKVAttachGate.allowedCacheClasses.contains(cacheClass),
+              !modelID.isEmpty,
+              !modelSHA256.isEmpty,
+              kvDType == .fp16,
+              metallibAvailable,
+              kernelRegistered,
+              parityEstablished,
+              !requiresMoEDispatch || moeDispatchProven
+        else { return false }
+        return hardwareSizingProof.covers(
+            config: config,
+            modelID: modelID,
+            modelSHA256: modelSHA256,
+            tokenizerSHA256: tokenizerSHA256,
+            chatTemplateSHA256: chatTemplateSHA256,
+            modelFamily: modelFamily,
+            observedHardwareClass: hardwareClass,
+            observedMetallibSHA256: metallibSHA256,
+            observedKernelIdentifier: kernelIdentifier,
+            observedParityLabel: parityLabel,
+            poolEpoch: poolEpoch
+        )
+    }
+
+    /// Converts a validated observation into the gate input consumed by the
+    /// existing attach decision. `bridgeAvailable` is deliberately supplied by
+    /// the runtime owner only after it has installed the request-level bridge.
+    public func gates(config: PagedKVConfig, bridgeAvailable: Bool) -> PagedKVGates {
+        PagedKVGates(
+            identityAvailable: !modelID.isEmpty && !modelSHA256.isEmpty,
+            observedHardwareClass: hardwareClass,
+            metallibAvailable: metallibAvailable,
+            kernelRegistered: kernelRegistered,
+            parityEstablished: parityEstablished,
+            hardwareSizingProof: hardwareSizingProof,
+            observedMetallibSHA256: metallibSHA256,
+            observedKernelIdentifier: kernelIdentifier,
+            observedParityLabel: parityLabel,
+            observedPoolEpoch: poolEpoch,
+            moeDispatchProven: moeDispatchProven,
+            engineBridgeAvailable: bridgeAvailable && matches(config: config)
         )
     }
 }
@@ -318,7 +448,7 @@ public enum PagedKVAttachGate {
                   observedMetallibSHA256: observedMetallibSHA256,
                   observedKernelIdentifier: observedKernelIdentifier,
                   observedParityLabel: observedParityLabel,
-                  poolEpoch: 1
+                  poolEpoch: gates.observedPoolEpoch ?? sizingProof.poolEpoch
               )
         else {
             return fail(.allocator)

--- a/phase3-binary/Sources/macprovider-cli/InferenceRelay.swift
+++ b/phase3-binary/Sources/macprovider-cli/InferenceRelay.swift
@@ -616,6 +616,11 @@ actor InferenceRelay {
             defer {
                 Task { await modelRuntime.unregisterInFlight(handle.registrationID) }
             }
+            // The paged preflight hook is the relay's capability boundary. The
+            // production runtime delegates it to full preflight (including
+            // prompt-plus-generation validation and prepared-input handoff)
+            // before this first buyer-visible SSE frame; test doubles may still
+            // provide their own rejection behavior through this hook.
             try await modelRuntime.pagedKVPreflight(request, with: handle)
             _ = buffer.enqueue(sseEvent(chatCompletionChunk(
                 id: id,

--- a/phase3-binary/Sources/macprovider-cli/ModelRuntime.swift
+++ b/phase3-binary/Sources/macprovider-cli/ModelRuntime.swift
@@ -597,6 +597,15 @@ actor ModelRuntime: ModelRuntimeServing {
     private let prefillStepSize: Int
     private let pagedKVConfig: PagedKVConfig
     private var pagedKVAttachDecision: PagedKVAttachDecision
+    /// An observed tuple is optional by design. Nil keeps the shipped path
+    /// fail-closed; it is never synthesized from the descriptor.
+    private var pagedKVRuntimeObservation: PagedKVRuntimeObservation?
+    /// The descriptor is supplied by the trusted packaging/probe layer. The
+    /// runtime attach path may compare an observation with it, but never
+    /// promotes a descriptor manufactured from that same observation.
+    private var pagedKVTrustedDescriptor: PagedKVDescriptor?
+    private var pagedKVRuntimeBridge: PagedKVRuntimeBridge?
+    private let pagedKVSharedForwardBackend: PagedKVSharedForwardBackend?
     private let conversationCache: ConversationCache
     /// SPEC-037 stage 5 — set once the serve process activates the encrypted disk
     /// cold tier (FR-KVP7). Gates all per-request cold-tier context construction;
@@ -724,7 +733,8 @@ actor ModelRuntime: ModelRuntimeServing {
         chatTemplateSHA256: String?,
         kvBitsOverride: Int?,
         runtimeCacheClass: String,
-        modelCapabilities: PagedKVRuntimeModelCapabilities? = nil
+        modelCapabilities: PagedKVRuntimeModelCapabilities? = nil,
+        gates: PagedKVGates? = nil
     ) -> PagedKVAttachDecision {
         let cacheClassForDecision = runtimeCacheClass == Self.pagedKVUnavailableCacheClass
             ? PagedKVAttachGate.allowedCacheClasses[0]
@@ -737,9 +747,91 @@ actor ModelRuntime: ModelRuntimeServing {
             chatTemplateSHA256: chatTemplateSHA256,
             kvBitsOverride: kvBitsOverride,
             runtimeCacheClass: cacheClassForDecision,
-            gates: .runtimeClosed(identityAvailable: modelHash?.isEmpty == false),
+            gates: gates ?? .runtimeClosed(identityAvailable: modelHash?.isEmpty == false),
             modelCapabilities: modelCapabilities
         )
+    }
+
+    /// Resolve the decision and bridge together. The bridge is created only
+    /// after a candidate descriptor exists, and a failed bridge construction
+    /// recomputes the decision with `engineBridgeAvailable == false`.
+    private nonisolated static func pagedKVRuntimeAttach(
+        config: PagedKVConfig,
+        modelID: String?,
+        modelHash: String?,
+        tokenizerSHA256: String?,
+        chatTemplateSHA256: String?,
+        kvBitsOverride: Int?,
+        runtimeCacheClass: String,
+        modelCapabilities: PagedKVRuntimeModelCapabilities,
+        observation: PagedKVRuntimeObservation?,
+        trustedDescriptor: PagedKVDescriptor?
+    ) -> (PagedKVAttachDecision, PagedKVRuntimeBridge?) {
+        let cacheClass = runtimeCacheClass == Self.pagedKVUnavailableCacheClass
+            ? PagedKVAttachGate.allowedCacheClasses[0]
+            : runtimeCacheClass
+        guard let observation, let trustedDescriptor else {
+            let closed = Self.pagedKVAttachDecision(
+                config: config,
+                modelID: modelID,
+                modelHash: modelHash,
+                tokenizerSHA256: tokenizerSHA256,
+                chatTemplateSHA256: chatTemplateSHA256,
+                kvBitsOverride: kvBitsOverride,
+                runtimeCacheClass: cacheClass,
+                gates: observation?.gates(config: config, bridgeAvailable: false)
+                    ?? .runtimeClosed(identityAvailable: modelHash?.isEmpty == false),
+                modelCapabilities: modelCapabilities
+            )
+            return (closed, nil)
+        }
+        let candidateGates = observation.gates(config: config, bridgeAvailable: true)
+        let candidate = Self.pagedKVAttachDecision(
+            config: config,
+            modelID: modelID,
+            modelHash: modelHash,
+            tokenizerSHA256: tokenizerSHA256,
+            chatTemplateSHA256: chatTemplateSHA256,
+            kvBitsOverride: kvBitsOverride,
+            runtimeCacheClass: cacheClass,
+            gates: candidateGates,
+            modelCapabilities: modelCapabilities
+        )
+        guard let candidateDescriptor = candidate.descriptor,
+              candidateDescriptor == trustedDescriptor
+        else {
+            let closed = Self.pagedKVAttachDecision(
+                config: config,
+                modelID: modelID,
+                modelHash: modelHash,
+                tokenizerSHA256: tokenizerSHA256,
+                chatTemplateSHA256: chatTemplateSHA256,
+                kvBitsOverride: kvBitsOverride,
+                runtimeCacheClass: cacheClass,
+                gates: observation.gates(config: config, bridgeAvailable: false),
+                modelCapabilities: modelCapabilities
+            )
+            return (closed, nil)
+        }
+        guard let bridge = try? PagedKVRuntimeBridge(
+            config: config,
+            observation: observation,
+            descriptor: trustedDescriptor
+        ) else {
+            let closed = Self.pagedKVAttachDecision(
+                config: config,
+                modelID: modelID,
+                modelHash: modelHash,
+                tokenizerSHA256: tokenizerSHA256,
+                chatTemplateSHA256: chatTemplateSHA256,
+                kvBitsOverride: kvBitsOverride,
+                runtimeCacheClass: cacheClass,
+                gates: observation.gates(config: config, bridgeAvailable: false),
+                modelCapabilities: modelCapabilities
+            )
+            return (closed, nil)
+        }
+        return (candidate, bridge)
     }
 
     private static let pagedKVUnavailableCacheClass = "unavailable"
@@ -846,11 +938,11 @@ actor ModelRuntime: ModelRuntimeServing {
         }
     }
 
-    nonisolated static func enforcePagedKVPreflight(_ decision: PagedKVAttachDecision) throws {
-        if case .attached = decision {
-            // This IMPL installs the default-off contract and attach gate only. Serving
-            // still requires a runtime owner that reserves a request lease, injects
-            // PagedKVCache, and releases/retains the handle around TokenIterator.
+    nonisolated static func enforcePagedKVPreflight(
+        _ decision: PagedKVAttachDecision,
+        bridgeAvailable: Bool = false
+    ) throws {
+        if case .attached = decision, !bridgeAvailable {
             throw APIError(
                 status: 503,
                 message: "Inference engine unavailable",
@@ -912,6 +1004,9 @@ actor ModelRuntime: ModelRuntimeServing {
         maxBatch: Int = 1,
         continuousBatchingMode: ContinuousBatchingMode = .off,
         continuousBatchQueueLimit: Int? = nil,
+        pagedKVRuntimeObservation: PagedKVRuntimeObservation? = nil,
+        pagedKVTrustedDescriptor: PagedKVDescriptor? = nil,
+        pagedKVSharedForwardDriver: (any PagedKVSharedForwardDriver)? = nil,
         warmSwapEnabled: Bool = false,
         swapDrainTimeoutSeconds: Int = 30,
         catalogModelIDAlias: String? = nil,
@@ -942,6 +1037,31 @@ actor ModelRuntime: ModelRuntimeServing {
             kvBitsOverride: kvBitsOverride,
             runtimeCacheClass: Self.pagedKVUnavailableCacheClass
         )
+        self.pagedKVRuntimeObservation = pagedKVRuntimeObservation
+        self.pagedKVTrustedDescriptor = pagedKVTrustedDescriptor
+        self.pagedKVRuntimeBridge = nil
+        self.pagedKVSharedForwardBackend = pagedKVSharedForwardDriver.map {
+            PagedKVSharedForwardBackend(driver: $0)
+        }
+        if let pagedKVRuntimeObservation {
+            let runtimeAttach = Self.pagedKVRuntimeAttach(
+                config: pagedKVConfig,
+                modelID: modelID,
+                modelHash: verifiedModelArtifactSHA256,
+                tokenizerSHA256: pagedKVRuntimeObservation.tokenizerSHA256,
+                chatTemplateSHA256: pagedKVRuntimeObservation.chatTemplateSHA256,
+                kvBitsOverride: kvBitsOverride,
+                runtimeCacheClass: pagedKVRuntimeObservation.cacheClass,
+                modelCapabilities: Self.pagedKVModelCapabilities(
+                    modelID: modelID,
+                    configJSONData: nil
+                ),
+                observation: pagedKVRuntimeObservation,
+                trustedDescriptor: pagedKVTrustedDescriptor
+            )
+            self.pagedKVAttachDecision = runtimeAttach.0
+            self.pagedKVRuntimeBridge = runtimeAttach.1
+        }
         self.conversationCache = ConversationCache()
         let boundedMaxBatch = min(max(1, maxBatch), ProviderCapacity.maxConcurrencyOverrideLimit)
         self.maxBatch = boundedMaxBatch
@@ -1013,7 +1133,7 @@ actor ModelRuntime: ModelRuntimeServing {
             )
             : Self.pagedKVUnavailableCacheClass
         let modelCapabilities = Self.pagedKVModelCapabilities(modelID: modelID, directory: directory)
-        self.pagedKVAttachDecision = Self.pagedKVRuntimeCapabilityDecision(
+        let runtimeAttach = Self.pagedKVRuntimeAttach(
             config: self.pagedKVConfig,
             modelID: modelID,
             modelHash: self.currentModelHash,
@@ -1021,8 +1141,12 @@ actor ModelRuntime: ModelRuntimeServing {
             chatTemplateSHA256: tokenizerHashes.template,
             kvBitsOverride: self.kvBitsOverride,
             runtimeCacheClass: runtimeCacheClass,
-            modelCapabilities: modelCapabilities
+            modelCapabilities: modelCapabilities,
+            observation: pagedKVRuntimeObservation,
+            trustedDescriptor: self.pagedKVTrustedDescriptor
         )
+        self.pagedKVAttachDecision = runtimeAttach.0
+        self.pagedKVRuntimeBridge = runtimeAttach.1
         Self.logPagedKVAttachDecision(self.pagedKVAttachDecision)
 
         if let draftModelID = normalizedDraftModelID {
@@ -1072,6 +1196,9 @@ actor ModelRuntime: ModelRuntimeServing {
         maxBatch: Int = 1,
         continuousBatchingMode: ContinuousBatchingMode = .off,
         continuousBatchQueueLimit: Int? = nil,
+        pagedKVRuntimeObservation: PagedKVRuntimeObservation? = nil,
+        pagedKVTrustedDescriptor: PagedKVDescriptor? = nil,
+        pagedKVSharedForwardDriver: (any PagedKVSharedForwardDriver)? = nil,
         warmSwapEnabled: Bool,
         swapDrainTimeoutSeconds: Int = 30,
         providerStatus: ProviderStatus? = nil,
@@ -1114,6 +1241,31 @@ actor ModelRuntime: ModelRuntimeServing {
             kvBitsOverride: kvBitsOverride,
             runtimeCacheClass: Self.pagedKVUnavailableCacheClass
         )
+        self.pagedKVRuntimeObservation = pagedKVRuntimeObservation
+        self.pagedKVTrustedDescriptor = pagedKVTrustedDescriptor
+        self.pagedKVRuntimeBridge = nil
+        self.pagedKVSharedForwardBackend = pagedKVSharedForwardDriver.map {
+            PagedKVSharedForwardBackend(driver: $0)
+        }
+        if let pagedKVRuntimeObservation {
+            let runtimeAttach = Self.pagedKVRuntimeAttach(
+                config: pagedKVConfig,
+                modelID: modelID,
+                modelHash: modelHash,
+                tokenizerSHA256: pagedKVRuntimeObservation.tokenizerSHA256,
+                chatTemplateSHA256: pagedKVRuntimeObservation.chatTemplateSHA256,
+                kvBitsOverride: kvBitsOverride,
+                runtimeCacheClass: pagedKVRuntimeObservation.cacheClass,
+                modelCapabilities: Self.pagedKVModelCapabilities(
+                    modelID: modelID,
+                    configJSONData: nil
+                ),
+                observation: pagedKVRuntimeObservation,
+                trustedDescriptor: pagedKVTrustedDescriptor
+            )
+            self.pagedKVAttachDecision = runtimeAttach.0
+            self.pagedKVRuntimeBridge = runtimeAttach.1
+        }
         self.conversationCache = ConversationCache()
         let boundedMaxBatch = min(max(1, maxBatch), ProviderCapacity.maxConcurrencyOverrideLimit)
         self.maxBatch = boundedMaxBatch
@@ -1361,10 +1513,31 @@ actor ModelRuntime: ModelRuntimeServing {
         stickyCacheEligible: Bool,
         requestStateRepresentable: Bool = true
     ) -> ContinuousBatchingCapability {
-        // The independently observed runtime tuple and scheduler backend are
-        // installed by the deferred SPEC-039 engine bridge. Do not manufacture
-        // a self-fulfilling tuple from the advertised descriptor.
-        let requestedTuple: ContinuousBatchingRequestedTuple? = nil
+        // Do not manufacture a self-fulfilling tuple from the advertised
+        // descriptor. The tuple is copied only from the independently observed
+        // runtime identity, and the backend must have been installed as well.
+        let requestedTuple: ContinuousBatchingRequestedTuple? = {
+            guard let observation = pagedKVRuntimeObservation,
+                  let bridge = pagedKVRuntimeBridge,
+                  bridge.isAttached
+            else { return nil }
+            return ContinuousBatchingRequestedTuple(
+                modelID: observation.modelID,
+                modelSHA256: observation.modelSHA256,
+                tokenizerSHA256: observation.tokenizerSHA256,
+                chatTemplateSHA256: observation.chatTemplateSHA256,
+                cacheClass: observation.cacheClass,
+                kvDType: observation.kvDType,
+                requiresMoE: observation.requiresMoEDispatch,
+                hardwareClass: observation.hardwareClass ?? "",
+                metallibSHA256: observation.metallibSHA256 ?? "",
+                kernelIdentifier: observation.kernelIdentifier ?? "",
+                parityLabel: observation.parityLabel ?? "",
+                poolEpoch: observation.poolEpoch ?? -1
+            )
+        }()
+        let schedulerBackendAvailable = pagedKVRuntimeBridge?.isAttached == true
+            && pagedKVSharedForwardBackend != nil
         return ContinuousBatchingPolicy.capability(
             mode: continuousBatchingMode,
             maxBatch: maxBatch,
@@ -1373,7 +1546,7 @@ actor ModelRuntime: ModelRuntimeServing {
             draftConfigured: draftConfigured,
             stickyCacheEligible: stickyCacheEligible,
             requestStateRepresentable: requestStateRepresentable,
-            schedulerBackendAvailable: false,
+            schedulerBackendAvailable: schedulerBackendAvailable,
             pagedKVDecision: pagedKVAttachDecision,
             requestedTuple: requestedTuple
         )
@@ -1556,7 +1729,12 @@ actor ModelRuntime: ModelRuntimeServing {
                 prefillStepSize: prefillStepSize
             )
             : Self.pagedKVUnavailableCacheClass
-        pagedKVAttachDecision = Self.pagedKVRuntimeCapabilityDecision(
+        let observationForTarget = pagedKVRuntimeObservation.flatMap { observation in
+            observation.modelID == modelID && observation.modelSHA256 == modelHash
+                ? observation
+                : nil
+        }
+        let runtimeAttach = Self.pagedKVRuntimeAttach(
             config: pagedKVConfig,
             modelID: modelID,
             modelHash: modelHash,
@@ -1564,8 +1742,22 @@ actor ModelRuntime: ModelRuntimeServing {
             chatTemplateSHA256: chatTemplateSHA256,
             kvBitsOverride: kvBitsOverride,
             runtimeCacheClass: runtimeCacheClass,
-            modelCapabilities: modelCapabilities
+            modelCapabilities: modelCapabilities,
+            observation: observationForTarget,
+            trustedDescriptor: pagedKVTrustedDescriptor.flatMap { descriptor in
+                descriptor.modelID == modelID && descriptor.modelSHA256 == modelHash
+                    ? descriptor
+                    : nil
+            }
         )
+        pagedKVRuntimeObservation = observationForTarget
+        pagedKVTrustedDescriptor = pagedKVTrustedDescriptor.flatMap { descriptor in
+            descriptor.modelID == modelID && descriptor.modelSHA256 == modelHash
+                ? descriptor
+                : nil
+        }
+        pagedKVAttachDecision = runtimeAttach.0
+        pagedKVRuntimeBridge = runtimeAttach.1
         Self.logPagedKVAttachDecision(pagedKVAttachDecision)
         currentDraftModelID = draftModelID
         currentDraftTargetModelID = draftModelID == nil ? nil : modelID
@@ -1711,7 +1903,10 @@ actor ModelRuntime: ModelRuntimeServing {
 
     func preflight(_ request: ChatCompletionRequest, with handle: RequestHandle) async throws {
         try applyContinuousBatchingPolicy(request: request, snapshot: handle.snapshot)
-        try Self.enforcePagedKVPreflight(pagedKVAttachDecision)
+        try Self.enforcePagedKVPreflight(
+            pagedKVAttachDecision,
+            bridgeAvailable: pagedKVRuntimeBridge?.isAttached == true
+        )
         try handle.drainCancelled.check()
         guard let container = handle.snapshot.container else {
             if testCompletion != nil {
@@ -1735,7 +1930,10 @@ actor ModelRuntime: ModelRuntimeServing {
 
     func pagedKVPreflight(_ request: ChatCompletionRequest, with handle: RequestHandle) async throws {
         try applyContinuousBatchingPolicy(request: request, snapshot: handle.snapshot)
-        try Self.enforcePagedKVPreflight(pagedKVAttachDecision)
+        try Self.enforcePagedKVPreflight(
+            pagedKVAttachDecision,
+            bridgeAvailable: pagedKVRuntimeBridge?.isAttached == true
+        )
         try handle.drainCancelled.check()
     }
 
@@ -1887,7 +2085,10 @@ actor ModelRuntime: ModelRuntimeServing {
         // emission for this request. (Streaming preflights first and suppresses
         // here to stay exactly-once.)
         try applyContinuousBatchingPolicy(request: request, snapshot: snapshot, emitTelemetry: true)
-        try Self.enforcePagedKVPreflight(pagedKVAttachDecision)
+        try Self.enforcePagedKVPreflight(
+            pagedKVAttachDecision,
+            bridgeAvailable: pagedKVRuntimeBridge?.isAttached == true
+        )
         try drainCancelled.check()
         if let testSpeculativeCompletion,
            Self.speculativeRoute(
@@ -1928,11 +2129,25 @@ actor ModelRuntime: ModelRuntimeServing {
         let inferenceGate = inferenceGate
         let blockingInferenceExecutor = blockingInferenceExecutor
         let stopTokenFilter = stopTokenFilter
-        let completion = try await Self.withDrainCancellation(drainCancelled) {
-            try await inferenceGate.withPermit {
-                try drainCancelled.check()
-                try Task.checkCancellation()
-                return try await container.perform { context in
+        let pagedAttachment: PagedKVRequestAttachment?
+        if let pagedBridge = pagedKVRuntimeBridge,
+           pagedBridge.isAttached,
+           case .attached = pagedKVAttachDecision,
+           request.conversationKey == nil {
+            pagedAttachment = try await pagedBridge.reserve(
+                requestID: "request-\(UUID().uuidString)",
+                maxTokens: maxContextTokens
+            )
+        } else {
+            pagedAttachment = nil
+        }
+        let completion: CompletionResult
+        do {
+            completion = try await Self.withDrainCancellation(drainCancelled) {
+                try await inferenceGate.withPermit {
+                    try drainCancelled.check()
+                    try Task.checkCancellation()
+                    return try await container.perform { context in
                     try drainCancelled.check()
                     try Task.checkCancellation()
                     let input = try Self.userInput(for: request)
@@ -1998,6 +2213,10 @@ actor ModelRuntime: ModelRuntimeServing {
                             if let reusableCache = lease?.reusableCache, let lcp = lease?.lcp {
                                 kvCache = reusableCache.layers
                                 iteratorInput = LMInput(tokens: MLXArray(Array(promptTokenIds[lcp...])))
+                            } else if let pagedAttachment {
+                                let layerCount = generationContext.model.newCache(parameters: nil).count
+                                kvCache = try pagedAttachment.makeCacheLayers(count: layerCount)
+                                iteratorInput = lmInput
                             } else {
                                 // SPEC-037 FR-KVP1: a tier-eligible request must run on a
                                 // KVCacheSimple so captureSnapshot can serialize it; keep the
@@ -2106,7 +2325,22 @@ actor ModelRuntime: ModelRuntimeServing {
                         }
                         throw error
                     }
+                    }
                 }
+            }
+        } catch {
+            if let pagedAttachment {
+                try? await pagedAttachment.release()
+            }
+            throw error
+        }
+        if let pagedAttachment {
+            do {
+                _ = try await pagedAttachment.checkpoint()
+                try await pagedAttachment.release()
+            } catch {
+                try? await pagedAttachment.release()
+                throw error
             }
         }
         return (completion, snapshot)
@@ -2302,7 +2536,10 @@ actor ModelRuntime: ModelRuntimeServing {
         let snapshot = handle.snapshot
         let drainCancelled = handle.drainCancelled
         try applyContinuousBatchingPolicy(request: request, snapshot: snapshot, emitTelemetry: false)
-        try Self.enforcePagedKVPreflight(pagedKVAttachDecision)
+        try Self.enforcePagedKVPreflight(
+            pagedKVAttachDecision,
+            bridgeAvailable: pagedKVRuntimeBridge?.isAttached == true
+        )
         let structuredAccumulator = StructuredStreamingContentAccumulator(enabled: Self.requiresStructuredValidation(request.responseFormat))
         let idleState = StructuredStreamingIdleState(enabled: Self.requiresStructuredValidation(request.responseFormat))
         if let testSpeculativeStream,

--- a/phase3-binary/Sources/macprovider-cli/ModelRuntime.swift
+++ b/phase3-binary/Sources/macprovider-cli/ModelRuntime.swift
@@ -261,6 +261,30 @@ public struct RequestHandle: @unchecked Sendable {
     public let snapshot: RuntimeSnapshot
     public let registrationID: Int
     let drainCancelled: DrainCancelToken
+    let preparedInput = PreparedRequestInput()
+}
+
+/// Request-local handoff from the bounded preflight to streaming inference.
+/// `LMInput` may contain more than token IDs (for example media tensors), so
+/// retain the complete prepared value rather than reconstructing it and
+/// invoking buyer-controlled tokenization a second time.
+final class PreparedRequestInput: @unchecked Sendable {
+    private let lock = NSLock()
+    private var value: LMInput?
+
+    func store(_ input: LMInput) {
+        lock.lock()
+        value = input
+        lock.unlock()
+    }
+
+    func take() -> LMInput? {
+        lock.lock()
+        defer { lock.unlock() }
+        let input = value
+        value = nil
+        return input
+    }
 }
 
 public struct WarmSwapDisabledError: Error, CustomStringConvertible {
@@ -736,9 +760,6 @@ actor ModelRuntime: ModelRuntimeServing {
         modelCapabilities: PagedKVRuntimeModelCapabilities? = nil,
         gates: PagedKVGates? = nil
     ) -> PagedKVAttachDecision {
-        let cacheClassForDecision = runtimeCacheClass == Self.pagedKVUnavailableCacheClass
-            ? PagedKVAttachGate.allowedCacheClasses[0]
-            : runtimeCacheClass
         return pagedKVAttachDecision(
             config: config,
             modelID: modelID,
@@ -746,7 +767,7 @@ actor ModelRuntime: ModelRuntimeServing {
             tokenizerSHA256: tokenizerSHA256,
             chatTemplateSHA256: chatTemplateSHA256,
             kvBitsOverride: kvBitsOverride,
-            runtimeCacheClass: cacheClassForDecision,
+            runtimeCacheClass: runtimeCacheClass,
             gates: gates ?? .runtimeClosed(identityAvailable: modelHash?.isEmpty == false),
             modelCapabilities: modelCapabilities
         )
@@ -767,9 +788,10 @@ actor ModelRuntime: ModelRuntimeServing {
         observation: PagedKVRuntimeObservation?,
         trustedDescriptor: PagedKVDescriptor?
     ) -> (PagedKVAttachDecision, PagedKVRuntimeBridge?) {
-        let cacheClass = runtimeCacheClass == Self.pagedKVUnavailableCacheClass
-            ? PagedKVAttachGate.allowedCacheClasses[0]
-            : runtimeCacheClass
+        // #889 deliberately keeps the production ServeCommand path inert until
+        // a signed capability installer supplies both the live observation and
+        // the matching trusted descriptor. Never synthesize either from model
+        // metadata or config: absent proof is an explicit closed decision.
         guard let observation, let trustedDescriptor else {
             let closed = Self.pagedKVAttachDecision(
                 config: config,
@@ -778,7 +800,7 @@ actor ModelRuntime: ModelRuntimeServing {
                 tokenizerSHA256: tokenizerSHA256,
                 chatTemplateSHA256: chatTemplateSHA256,
                 kvBitsOverride: kvBitsOverride,
-                runtimeCacheClass: cacheClass,
+                runtimeCacheClass: runtimeCacheClass,
                 gates: observation?.gates(config: config, bridgeAvailable: false)
                     ?? .runtimeClosed(identityAvailable: modelHash?.isEmpty == false),
                 modelCapabilities: modelCapabilities
@@ -793,7 +815,7 @@ actor ModelRuntime: ModelRuntimeServing {
             tokenizerSHA256: tokenizerSHA256,
             chatTemplateSHA256: chatTemplateSHA256,
             kvBitsOverride: kvBitsOverride,
-            runtimeCacheClass: cacheClass,
+            runtimeCacheClass: runtimeCacheClass,
             gates: candidateGates,
             modelCapabilities: modelCapabilities
         )
@@ -807,7 +829,7 @@ actor ModelRuntime: ModelRuntimeServing {
                 tokenizerSHA256: tokenizerSHA256,
                 chatTemplateSHA256: chatTemplateSHA256,
                 kvBitsOverride: kvBitsOverride,
-                runtimeCacheClass: cacheClass,
+                runtimeCacheClass: runtimeCacheClass,
                 gates: observation.gates(config: config, bridgeAvailable: false),
                 modelCapabilities: modelCapabilities
             )
@@ -825,7 +847,7 @@ actor ModelRuntime: ModelRuntimeServing {
                 tokenizerSHA256: tokenizerSHA256,
                 chatTemplateSHA256: chatTemplateSHA256,
                 kvBitsOverride: kvBitsOverride,
-                runtimeCacheClass: cacheClass,
+                runtimeCacheClass: runtimeCacheClass,
                 gates: observation.gates(config: config, bridgeAvailable: false),
                 modelCapabilities: modelCapabilities
             )
@@ -845,7 +867,7 @@ actor ModelRuntime: ModelRuntimeServing {
         guard let container else { return Self.pagedKVUnavailableCacheClass }
         do {
             return try await container.perform { context in
-                let parameters = Self.makeServeGenerateParameters(
+                var parameters = Self.makeServeGenerateParameters(
                     maxTokens: 1,
                     maxContextTokens: maxContextTokens,
                     kvBitsOverride: kvBitsOverride,
@@ -853,6 +875,12 @@ actor ModelRuntime: ModelRuntimeServing {
                     temperature: 0.0,
                     topP: 1.0
                 )
+                // Paged KV owns the admission/context ceiling through its
+                // allocator and preflight token-count gate. Passing maxKVSize here
+                // would make mlx-swift-lm manufacture RotatingKVCache, which is
+                // outside the paged v0.1 contract and would reject every valid
+                // capability before the first request.
+                parameters.maxKVSize = nil
                 return Self.pagedKVRuntimeCacheClass(model: context.model, baseParameters: parameters)
             }
         } catch {
@@ -861,7 +889,9 @@ actor ModelRuntime: ModelRuntimeServing {
     }
 
     nonisolated static func pagedKVRuntimeCacheClass(model: any LanguageModel, baseParameters: GenerateParameters) -> String {
-        let caches = model.newCache(parameters: baseParameters)
+        var pagedParameters = baseParameters
+        pagedParameters.maxKVSize = nil
+        let caches = model.newCache(parameters: pagedParameters)
         guard let first = caches.first else { return "empty" }
         let firstClass = String(describing: type(of: first))
         guard caches.allSatisfy({ String(describing: type(of: $0)) == firstClass }) else {
@@ -927,22 +957,96 @@ actor ModelRuntime: ModelRuntimeServing {
         return lower.range(of: #"(^|[-_/])a[0-9]+b($|[-_/])"#, options: .regularExpression) != nil
     }
 
-    nonisolated static func logPagedKVAttachDecision(_ decision: PagedKVAttachDecision) {
+    nonisolated static func pagedKVAttachDiagnosticLine(
+        _ decision: PagedKVAttachDecision,
+        sizingProof: PagedKVHardwareSizingProof? = nil
+    ) -> String {
         switch decision {
-        case .disabled, .attached:
-            return
+        case .disabled:
+            return ""
+        case .attached(let descriptor):
+            let hardware = descriptor.hardwareClass ?? "unknown"
+            let sizing = sizingProof.map { proof in
+                let stockContext = proof.stockContiguousMaxContextTokens.map(String.init) ?? "null"
+                let pagedContext = proof.pagedMaxContextTokens.map(String.init) ?? "null"
+                return " sizing_model_class=\(proof.sizingModelClass) unified_memory_gb=\(proof.unifiedMemoryGB) model_weights_gb=\(proof.modelWeightsGB) per_request_activation_gb=\(proof.perRequestActivationGB) paged_block_pool_gb=\(proof.pagedBlockPoolGB) kv_bytes_per_token=\(proof.kvBytesPerToken) stock_max_context_tokens=\(stockContext) paged_max_context_tokens=\(pagedContext) measured_gather_overhead_percent=\(proof.measuredGatherOverheadPercent) gather_overhead_ceiling_percent=\(proof.gatherOverheadCeilingPercent)"
+            } ?? " sizing_proof=unavailable"
+            return "event=paged_kv_attach status=attached block_size_tokens=\(descriptor.blockSizeTokens) max_physical_blocks=\(descriptor.maxPhysicalBlocks) hardware_class=\(hardware) kernel=\(descriptor.kernelIdentifier) parity=\(descriptor.parityLabel) pool_epoch=\(descriptor.poolEpoch)\(sizing)\n"
         case .fallback(let reason):
-            FileHandle.standardError.write(Data(("event=paged_kv_attach status=fallback reason=\(reason.rawValue)\n").utf8))
+            return "event=paged_kv_attach status=fallback reason=\(reason.rawValue)\n"
         case .rejected(let reason):
-            FileHandle.standardError.write(Data(("event=paged_kv_attach status=rejected reason=\(reason.rawValue)\n").utf8))
+            return "event=paged_kv_attach status=rejected reason=\(reason.rawValue)\n"
         }
+    }
+
+    nonisolated static func logPagedKVAttachDecision(
+        _ decision: PagedKVAttachDecision,
+        sizingProof: PagedKVHardwareSizingProof? = nil
+    ) {
+        let line = pagedKVAttachDiagnosticLine(decision, sizingProof: sizingProof)
+        guard !line.isEmpty else { return }
+        FileHandle.standardError.write(Data(line.utf8))
+    }
+
+    nonisolated static func logPagedKVStreamingDecision(status: String, detail: String) {
+        if status == "rejected" {
+            logPagedKVRequestDecision(status: status, reason: .preflightReject, detail: detail)
+        } else {
+            logPagedKVLifecycleFallback(detail: detail)
+        }
+    }
+
+    /// Endpoint lifecycle limitations are not allocator or Metal failures.
+    /// Keep them out of SPEC-039's closed fallback-reason enum rather than
+    /// misreporting a stock-route decision as a kernel fault.
+    nonisolated static func logPagedKVLifecycleFallback(detail: String) {
+        let line = "event=paged_kv_lifecycle status=fallback detail=\(detail)\n"
+        FileHandle.standardError.write(Data(line.utf8))
+    }
+
+    nonisolated static func logPagedKVRequestDecision(
+        status: String,
+        reason: PagedKVFallbackReason,
+        detail: String
+    ) {
+        let line = "event=paged_kv_request status=\(status) reason=\(reason.rawValue) detail=\(detail)\n"
+        FileHandle.standardError.write(Data(line.utf8))
+    }
+
+    /// Reclaim request-owned blocks a bounded number of times. If the allocator
+    /// still refuses release, the bridge latches unhealthy and future attaches
+    /// fail closed; the caller also emits an explicit unresolved-reclamation
+    /// event instead of silently leaking pool capacity.
+    nonisolated static func releasePagedKVAttachment(
+        _ attachment: PagedKVRequestAttachment,
+        detail: String
+    ) async {
+        for _ in 0..<2 {
+            do {
+                try await attachment.release()
+                return
+            } catch {
+                continue
+            }
+        }
+        logPagedKVRequestDecision(
+            status: "failed",
+            reason: .allocator,
+            detail: "\(detail)_reclamation_unresolved"
+        )
     }
 
     nonisolated static func enforcePagedKVPreflight(
         _ decision: PagedKVAttachDecision,
-        bridgeAvailable: Bool = false
+        bridgeAvailable: Bool = false,
+        bridgeFailureDetail: String = "bridge_unavailable"
     ) throws {
         if case .attached = decision, !bridgeAvailable {
+            logPagedKVRequestDecision(
+                status: "rejected",
+                reason: .preflightReject,
+                detail: bridgeFailureDetail
+            )
             throw APIError(
                 status: 503,
                 message: "Inference engine unavailable",
@@ -960,6 +1064,30 @@ actor ModelRuntime: ModelRuntimeServing {
                 code: "internal_error",
                 inferenceRan: false,
                 settlementRan: false
+            )
+        }
+    }
+
+    /// Once allocator reclamation fails, keep the paged decision closed for all
+    /// later requests. Permissive mode returns to the stock cache with an
+    /// allocator-coded event; strict mode rejects with the closed preflight code.
+    private func normalizePagedKVBridgeHealth() {
+        guard case .attached = pagedKVAttachDecision,
+              pagedKVRuntimeBridge?.isUnhealthy == true
+        else { return }
+        if pagedKVConfig.fallbackPolicy == .strict {
+            pagedKVAttachDecision = .rejected(.preflightReject)
+            Self.logPagedKVRequestDecision(
+                status: "rejected",
+                reason: .preflightReject,
+                detail: "bridge_unhealthy"
+            )
+        } else {
+            pagedKVAttachDecision = .fallback(.allocator)
+            Self.logPagedKVRequestDecision(
+                status: "fallback",
+                reason: .allocator,
+                detail: "bridge_unhealthy"
             )
         }
     }
@@ -1147,7 +1275,10 @@ actor ModelRuntime: ModelRuntimeServing {
         )
         self.pagedKVAttachDecision = runtimeAttach.0
         self.pagedKVRuntimeBridge = runtimeAttach.1
-        Self.logPagedKVAttachDecision(self.pagedKVAttachDecision)
+        Self.logPagedKVAttachDecision(
+            self.pagedKVAttachDecision,
+            sizingProof: self.pagedKVRuntimeObservation?.hardwareSizingProof
+        )
 
         if let draftModelID = normalizedDraftModelID {
             let (draftContainer, draftDirectory) = try await Self.loadLocalContainer(from: normalizedDraftModelLoadPath ?? draftModelID)
@@ -1758,7 +1889,10 @@ actor ModelRuntime: ModelRuntimeServing {
         }
         pagedKVAttachDecision = runtimeAttach.0
         pagedKVRuntimeBridge = runtimeAttach.1
-        Self.logPagedKVAttachDecision(pagedKVAttachDecision)
+        Self.logPagedKVAttachDecision(
+            pagedKVAttachDecision,
+            sizingProof: observationForTarget?.hardwareSizingProof
+        )
         currentDraftModelID = draftModelID
         currentDraftTargetModelID = draftModelID == nil ? nil : modelID
         currentDraftContainer = draftContainer
@@ -1902,11 +2036,16 @@ actor ModelRuntime: ModelRuntimeServing {
     }
 
     func preflight(_ request: ChatCompletionRequest, with handle: RequestHandle) async throws {
+        normalizePagedKVBridgeHealth()
         try applyContinuousBatchingPolicy(request: request, snapshot: handle.snapshot)
         try Self.enforcePagedKVPreflight(
             pagedKVAttachDecision,
-            bridgeAvailable: pagedKVRuntimeBridge?.isAttached == true
+            bridgeAvailable: pagedKVRuntimeBridge?.isAttached == true,
+            bridgeFailureDetail: pagedKVRuntimeBridge?.isUnhealthy == true ? "bridge_unhealthy" : "bridge_unavailable"
         )
+        try enforcePagedKVStreamingPreflight(request, emitTelemetry: true)
+        try enforcePagedKVStickyPreflight(request, emitTelemetry: true)
+        try enforcePagedKVSpeculativePreflight(request, snapshot: handle.snapshot, emitTelemetry: true)
         try handle.drainCancelled.check()
         guard let container = handle.snapshot.container else {
             if testCompletion != nil {
@@ -1923,18 +2062,96 @@ actor ModelRuntime: ModelRuntimeServing {
                 let input = try Self.userInput(for: request)
                 let lmInput = try await context.processor.prepare(input: input)
                 try handle.drainCancelled.check()
-                try Self.validatePromptTokenCount(lmInput.text.tokens.size, maxContextTokens: maxContextTokens)
+                try Self.validatePromptAndGenerationTokenCount(
+                    promptTokens: lmInput.text.tokens.size,
+                    requestedMaxTokens: request.maxTokens,
+                    maxContextTokens: maxContextTokens
+                )
+                handle.preparedInput.store(lmInput)
             }
         }
     }
 
     func pagedKVPreflight(_ request: ChatCompletionRequest, with handle: RequestHandle) async throws {
-        try applyContinuousBatchingPolicy(request: request, snapshot: handle.snapshot)
-        try Self.enforcePagedKVPreflight(
-            pagedKVAttachDecision,
-            bridgeAvailable: pagedKVRuntimeBridge?.isAttached == true
-        )
-        try handle.drainCancelled.check()
+        try await preflight(request, with: handle)
+    }
+
+    /// Streaming callers must perform this check before opening/enqueuing the first
+    /// SSE frame. The streaming iterator still uses the stock cache lifecycle, so an
+    /// attached paged decision is an explicit endpoint fallback (permissive) or a
+    /// preflight rejection (strict), never an implicit post-frame downgrade.
+    private func enforcePagedKVStreamingPreflight(
+        _ request: ChatCompletionRequest,
+        emitTelemetry: Bool
+    ) throws {
+        guard request.stream, case .attached = pagedKVAttachDecision else { return }
+        if pagedKVConfig.fallbackPolicy == .strict {
+            if emitTelemetry {
+                Self.logPagedKVStreamingDecision(status: "rejected", detail: "streaming_lifecycle_unavailable")
+            }
+            try Self.enforcePagedKVPreflight(.rejected(.preflightReject))
+        } else if emitTelemetry {
+            // Preserve the SPEC-039 closed reason enum while adding the endpoint
+            // detail operators need to distinguish this fallback from a kernel fault.
+            Self.logPagedKVStreamingDecision(status: "fallback", detail: "streaming_lifecycle_unavailable")
+        }
+    }
+
+    /// A keyed request needs the conversation cache's cross-turn ownership path.
+    /// Until that path is backed by `PagedKVRuntimeBridge.reattach`, an attached
+    /// paged decision must become an explicit stock fallback (or strict rejection)
+    /// before inference rather than silently taking `serveCache`.
+    private func enforcePagedKVStickyPreflight(
+        _ request: ChatCompletionRequest,
+        emitTelemetry: Bool
+    ) throws {
+        guard !request.stream,
+              request.conversationKey != nil,
+              case .attached = pagedKVAttachDecision
+        else { return }
+        if pagedKVConfig.fallbackPolicy == .strict {
+            if emitTelemetry {
+                Self.logPagedKVRequestDecision(
+                    status: "rejected",
+                    reason: .preflightReject,
+                    detail: "sticky_conversation_bridge_unavailable"
+                )
+            }
+            try Self.enforcePagedKVPreflight(.rejected(.preflightReject))
+        } else if emitTelemetry {
+            Self.logPagedKVLifecycleFallback(detail: "sticky_conversation_bridge_unavailable")
+        }
+    }
+
+    /// The speculative iterator has its own draft/target cache lifecycle and is
+    /// not yet backed by the paged bridge. Keep that limitation explicit at the
+    /// request boundary: permissive mode stock-routes with telemetry, while
+    /// strict mode rejects before inference or buyer-visible output.
+    private func enforcePagedKVSpeculativePreflight(
+        _ request: ChatCompletionRequest,
+        snapshot: RuntimeSnapshot,
+        emitTelemetry: Bool
+    ) throws {
+        guard !request.stream,
+              case .attached = pagedKVAttachDecision,
+              Self.speculativeRoute(
+                  for: request,
+                  draftLoaded: snapshot.hasTargetCompatibleDraft && snapshot.draftContainer != nil,
+                  numDraftTokens: snapshot.numDraftTokens
+              ) == .speculative
+        else { return }
+        if pagedKVConfig.fallbackPolicy == .strict {
+            if emitTelemetry {
+                Self.logPagedKVRequestDecision(
+                    status: "rejected",
+                    reason: .preflightReject,
+                    detail: "speculative_lifecycle_unavailable"
+                )
+            }
+            try Self.enforcePagedKVPreflight(.rejected(.preflightReject))
+        } else if emitTelemetry {
+            Self.logPagedKVLifecycleFallback(detail: "speculative_lifecycle_unavailable")
+        }
     }
 
     func complete(
@@ -2080,6 +2297,7 @@ actor ModelRuntime: ModelRuntimeServing {
         let completionStartedAt = Date()
         let snapshot = handle.snapshot
         let drainCancelled = handle.drainCancelled
+        normalizePagedKVBridgeHealth()
         // Non-streaming execution is a direct entry path with no preceding
         // preflight (HTTP + relay), so it OWNS the single serial-route telemetry
         // emission for this request. (Streaming preflights first and suppresses
@@ -2087,8 +2305,11 @@ actor ModelRuntime: ModelRuntimeServing {
         try applyContinuousBatchingPolicy(request: request, snapshot: snapshot, emitTelemetry: true)
         try Self.enforcePagedKVPreflight(
             pagedKVAttachDecision,
-            bridgeAvailable: pagedKVRuntimeBridge?.isAttached == true
+            bridgeAvailable: pagedKVRuntimeBridge?.isAttached == true,
+            bridgeFailureDetail: pagedKVRuntimeBridge?.isUnhealthy == true ? "bridge_unhealthy" : "bridge_unavailable"
         )
+        try enforcePagedKVStickyPreflight(request, emitTelemetry: true)
+        try enforcePagedKVSpeculativePreflight(request, snapshot: snapshot, emitTelemetry: true)
         try drainCancelled.check()
         if let testSpeculativeCompletion,
            Self.speculativeRoute(
@@ -2129,21 +2350,18 @@ actor ModelRuntime: ModelRuntimeServing {
         let inferenceGate = inferenceGate
         let blockingInferenceExecutor = blockingInferenceExecutor
         let stopTokenFilter = stopTokenFilter
-        let pagedAttachment: PagedKVRequestAttachment?
-        if let pagedBridge = pagedKVRuntimeBridge,
-           pagedBridge.isAttached,
-           case .attached = pagedKVAttachDecision,
-           request.conversationKey == nil {
-            pagedAttachment = try await pagedBridge.reserve(
-                requestID: "request-\(UUID().uuidString)",
-                maxTokens: maxContextTokens
-            )
-        } else {
-            pagedAttachment = nil
-        }
+        let pagedBridge = pagedKVRuntimeBridge
+        let pagedAttachDecision = pagedKVAttachDecision
+        let pagedFallbackPolicy = pagedKVConfig.fallbackPolicy
+        let usesSpeculativeRoute = Self.speculativeRoute(
+            for: request,
+            draftLoaded: snapshot.hasTargetCompatibleDraft && snapshot.draftContainer != nil,
+            numDraftTokens: snapshot.numDraftTokens
+        ) == .speculative
         let completion: CompletionResult
+        let pagedAttachment: PagedKVRequestAttachment?
         do {
-            completion = try await Self.withDrainCancellation(drainCancelled) {
+            (completion, pagedAttachment) = try await Self.withDrainCancellation(drainCancelled) {
                 try await inferenceGate.withPermit {
                     try drainCancelled.check()
                     try Task.checkCancellation()
@@ -2152,7 +2370,65 @@ actor ModelRuntime: ModelRuntimeServing {
                     try Task.checkCancellation()
                     let input = try Self.userInput(for: request)
                     let lmInput = try await context.processor.prepare(input: input)
-                    try Self.validatePromptTokenCount(lmInput.text.tokens.size, maxContextTokens: maxContextTokens)
+                    try Self.validatePromptAndGenerationTokenCount(
+                        promptTokens: lmInput.text.tokens.size,
+                        requestedMaxTokens: request.maxTokens,
+                        maxContextTokens: maxContextTokens
+                    )
+                    let generationCeiling = request.maxTokens ?? (maxContextTokens - lmInput.text.tokens.size)
+                    let pagedReservationTokens = lmInput.text.tokens.size + generationCeiling
+                    let pagedAttachment: PagedKVRequestAttachment?
+                    if let pagedBridge,
+                       case .attached = pagedAttachDecision,
+                       request.conversationKey == nil,
+                       !usesSpeculativeRoute {
+                        if !pagedBridge.isAttached {
+                            let detail = pagedBridge.isUnhealthy ? "bridge_unhealthy" : "bridge_unavailable"
+                            if pagedFallbackPolicy == .strict {
+                                Self.logPagedKVRequestDecision(
+                                    status: "rejected",
+                                    reason: .preflightReject,
+                                    detail: detail
+                                )
+                                try Self.enforcePagedKVPreflight(.rejected(.preflightReject))
+                            } else {
+                                Self.logPagedKVRequestDecision(
+                                    status: "fallback",
+                                    reason: .allocator,
+                                    detail: detail
+                                )
+                            }
+                            pagedAttachment = nil
+                        } else {
+                            do {
+                                // Reservation and preparation share the same bounded
+                                // admission permit; the checked prompt is reused by
+                                // generation below rather than tokenized twice.
+                                pagedAttachment = try await pagedBridge.reserve(
+                                    requestID: "request-\(UUID().uuidString)",
+                                    maxTokens: pagedReservationTokens
+                                )
+                            } catch {
+                                if pagedFallbackPolicy == .strict {
+                                    Self.logPagedKVRequestDecision(
+                                        status: "rejected",
+                                        reason: .preflightReject,
+                                        detail: "allocator_reservation_failed"
+                                    )
+                                    try Self.enforcePagedKVPreflight(.rejected(.preflightReject))
+                                } else {
+                                    Self.logPagedKVRequestDecision(
+                                        status: "fallback",
+                                        reason: .allocator,
+                                        detail: "allocator_reservation_failed"
+                                    )
+                                }
+                                pagedAttachment = nil
+                            }
+                        }
+                    } else {
+                        pagedAttachment = nil
+                    }
                     let parameters = Self.makeServeGenerateParameters(
                         maxTokens: request.maxTokens,
                         maxContextTokens: maxContextTokens,
@@ -2171,7 +2447,7 @@ actor ModelRuntime: ModelRuntimeServing {
                        let draftContainer = snapshot.draftContainer,
                        let numDraftTokens = snapshot.numDraftTokens {
                         do {
-                            return try await Self.runSpeculativeCompletion(
+                            let completion = try await Self.runSpeculativeCompletion(
                                 input: lmInput,
                                 parameters: parameters,
                                 targetContext: context,
@@ -2187,6 +2463,7 @@ actor ModelRuntime: ModelRuntimeServing {
                                 drainCancelled: drainCancelled,
                                 blockingInferenceExecutor: blockingInferenceExecutor
                             )
+                            return (completion, pagedAttachment)
                         } catch let error as DrainCancelledError {
                             throw error
                         } catch let error as CancellationError {
@@ -2244,6 +2521,9 @@ actor ModelRuntime: ModelRuntimeServing {
                                     }
                                     return GenerateDisposition.more
                                 })
+                            }
+                            if let pagedAttachment {
+                                try pagedAttachment.validate()
                             }
                             try drainCancelled.check()
                             try Task.checkCancellation()
@@ -2318,10 +2598,28 @@ actor ModelRuntime: ModelRuntimeServing {
                         if let lease {
                             await conversationCache.commit(lease, cache: ConversationCacheLayers(kvCache), fullTokens: promptTokenIds + resultTokenIDs.map(Int32.init), cold: coldContext)
                         }
-                        return completion
+                        return (completion, pagedAttachment)
                     } catch {
                         if let lease {
                             await conversationCache.abort(lease)
+                        }
+                        if let pagedAttachment {
+                            let detail: String
+                            if let bridgeError = error as? PagedKVRuntimeBridgeError,
+                               bridgeError == .cacheStateMismatch {
+                                detail = "cache_invariant_failure"
+                            } else {
+                                detail = "paged_inference_failed"
+                            }
+                            Self.logPagedKVRequestDecision(
+                                status: "failed",
+                                reason: detail == "cache_invariant_failure" ? .allocator : .kernel,
+                                detail: detail
+                            )
+                            await Self.releasePagedKVAttachment(
+                                pagedAttachment,
+                                detail: "inference_error"
+                            )
                         }
                         throw error
                     }
@@ -2329,9 +2627,6 @@ actor ModelRuntime: ModelRuntimeServing {
                 }
             }
         } catch {
-            if let pagedAttachment {
-                try? await pagedAttachment.release()
-            }
             throw error
         }
         if let pagedAttachment {
@@ -2339,8 +2634,27 @@ actor ModelRuntime: ModelRuntimeServing {
                 _ = try await pagedAttachment.checkpoint()
                 try await pagedAttachment.release()
             } catch {
-                try? await pagedAttachment.release()
-                throw error
+                // A paged response is not successful until its allocator state is
+                // checkpointed and released. Retry reclamation in the bounded
+                // helper, but never issue a success response/receipt while either
+                // postflight step is unresolved.
+                await Self.releasePagedKVAttachment(
+                    pagedAttachment,
+                    detail: "postflight_finalize"
+                )
+                Self.logPagedKVRequestDecision(
+                    status: "failed",
+                    reason: .allocator,
+                    detail: "postflight_finalize_failed"
+                )
+                throw APIError(
+                    status: 503,
+                    message: "Paged KV state could not be finalized",
+                    type: "server_error",
+                    code: "paged_kv_postflight_failed",
+                    inferenceRan: true,
+                    settlementRan: false
+                )
             }
         }
         return (completion, snapshot)
@@ -2535,11 +2849,18 @@ actor ModelRuntime: ModelRuntimeServing {
     ) async throws -> CompletionResult {
         let snapshot = handle.snapshot
         let drainCancelled = handle.drainCancelled
+        normalizePagedKVBridgeHealth()
         try applyContinuousBatchingPolicy(request: request, snapshot: snapshot, emitTelemetry: false)
         try Self.enforcePagedKVPreflight(
             pagedKVAttachDecision,
-            bridgeAvailable: pagedKVRuntimeBridge?.isAttached == true
+            bridgeAvailable: pagedKVRuntimeBridge?.isAttached == true,
+            bridgeFailureDetail: pagedKVRuntimeBridge?.isUnhealthy == true ? "bridge_unhealthy" : "bridge_unavailable"
         )
+        // External HTTP/relay callers perform the same check before opening or
+        // enqueueing the first SSE frame. Keep this lower-level guard for direct
+        // callers, but suppress telemetry here to avoid double-counting.
+        try enforcePagedKVStreamingPreflight(request, emitTelemetry: false)
+        try enforcePagedKVSpeculativePreflight(request, snapshot: snapshot, emitTelemetry: false)
         let structuredAccumulator = StructuredStreamingContentAccumulator(enabled: Self.requiresStructuredValidation(request.responseFormat))
         let idleState = StructuredStreamingIdleState(enabled: Self.requiresStructuredValidation(request.responseFormat))
         if let testSpeculativeStream,
@@ -2606,6 +2927,7 @@ actor ModelRuntime: ModelRuntimeServing {
         let inferenceGate = inferenceGate
         let blockingInferenceExecutor = blockingInferenceExecutor
         let stopTokenFilter = stopTokenFilter
+        let preparedInput = handle.preparedInput
         return try await Self.withDrainCancellation(drainCancelled) {
             try await Self.withStructuredStreamingIdleTimeout(
                 idleState: idleState,
@@ -2623,9 +2945,18 @@ actor ModelRuntime: ModelRuntimeServing {
                 return try await container.perform { context in
                     try drainCancelled.check()
                     try Task.checkCancellation()
-                    let input = try Self.userInput(for: request)
-                    let lmInput = try await context.processor.prepare(input: input)
-                    try Self.validatePromptTokenCount(lmInput.text.tokens.size, maxContextTokens: maxContextTokens)
+                    let lmInput: LMInput
+                    if let preparedInput = preparedInput.take() {
+                        lmInput = preparedInput
+                    } else {
+                        let input = try Self.userInput(for: request)
+                        lmInput = try await context.processor.prepare(input: input)
+                    }
+                    try Self.validatePromptAndGenerationTokenCount(
+                        promptTokens: lmInput.text.tokens.size,
+                        requestedMaxTokens: request.maxTokens,
+                        maxContextTokens: maxContextTokens
+                    )
                     let parameters = Self.makeServeGenerateParameters(
                         maxTokens: request.maxTokens,
                         maxContextTokens: maxContextTokens,
@@ -3467,6 +3798,26 @@ actor ModelRuntime: ModelRuntimeServing {
                 type: "context_length_exceeded",
                 code: "context_length_exceeded",
                 param: "messages"
+            )
+        }
+    }
+
+    static func validatePromptAndGenerationTokenCount(
+        promptTokens: Int,
+        requestedMaxTokens: Int?,
+        maxContextTokens: Int
+    ) throws {
+        try validatePromptTokenCount(promptTokens, maxContextTokens: maxContextTokens)
+        let availableCompletionTokens = maxContextTokens - promptTokens
+        let generationCeiling = requestedMaxTokens ?? availableCompletionTokens
+        let (total, overflow) = promptTokens.addingReportingOverflow(generationCeiling)
+        guard generationCeiling >= 0, !overflow, total <= maxContextTokens else {
+            throw APIError(
+                status: 400,
+                message: "Prompt plus requested completion exceeds this provider's safe context capacity.",
+                type: "context_length_exceeded",
+                code: "context_length_exceeded",
+                param: "max_tokens"
             )
         }
     }

--- a/phase3-binary/Sources/macprovider-cli/PagedKVCache.swift
+++ b/phase3-binary/Sources/macprovider-cli/PagedKVCache.swift
@@ -11,11 +11,18 @@ struct PagedKVGatherKernel {
         uint lane = elem - (logical_token * token_stride);
         uint logical_block = logical_token / block_size_tokens;
         uint within_block = logical_token - (logical_block * block_size_tokens);
-        uint physical_block = uint(block_ids[logical_block]);
-        uint physical_token = (physical_block * block_size_tokens) + within_block;
         if (logical_token >= logical_token_count || lane >= token_stride
-            || logical_block >= block_count || physical_block >= block_count
-            || physical_token >= physical_token_count) {
+            || logical_block >= logical_block_count) {
+            gathered[elem] = 0;
+            return;
+        }
+        uint physical_block = uint(block_ids[logical_block]);
+        if (physical_block >= physical_block_count) {
+            gathered[elem] = 0;
+            return;
+        }
+        uint physical_token = (physical_block * block_size_tokens) + within_block;
+        if (physical_token >= physical_token_count) {
             gathered[elem] = 0;
             return;
         }
@@ -39,7 +46,8 @@ struct PagedKVGatherKernel {
         blockSizeTokens: Int,
         tokenStride: Int,
         physicalTokenCount: Int,
-        blockCount: Int,
+        logicalBlockCount: Int,
+        physicalBlockCount: Int,
         outputShape: [Int],
         using kernel: MLXFast.MLXFastKernel
     ) -> MLXArray {
@@ -50,8 +58,9 @@ struct PagedKVGatherKernel {
                 ("block_size_tokens", blockSizeTokens),
                 ("token_stride", tokenStride),
                 ("logical_token_count", logicalTokens),
+                ("logical_block_count", logicalBlockCount),
                 ("physical_token_count", physicalTokenCount),
-                ("block_count", blockCount),
+                ("physical_block_count", physicalBlockCount),
             ],
             grid: (count, 1, 1),
             threadGroup: (min(count, 256), 1, 1),
@@ -66,15 +75,25 @@ struct PagedKVGatherKernel {
 /// bounded logical-to-physical gather for one transformer layer.
 final class PagedKVCache: KVCache, CustomDebugStringConvertible {
     let descriptor: PagedKVDescriptor
-    let binding: PagedKVStorageBinding
+    private(set) var binding: PagedKVStorageBinding
 
     private let gatherKernel: PagedKVGatherKernel
     /// Lazily-registered Metal gather kernel. Created on first `update()` so mere
     /// construction of the seam (the SPEC-038-facing metadata surface) still runs no
     /// Metal — only driving the cache through a real forward pass executes the kernel.
     private var registeredKernel: MLXFast.MLXFastKernel?
-    private var keyBlocks: [MLXArray] = []
-    private var valueBlocks: [MLXArray] = []
+    /// Physical K/V blocks keyed by allocator-issued block ID. Logical order is
+    /// reconstructed from `binding.reservedPhysicalBlocks` when a cache state is
+    /// read; the cache never invents its own physical permutation.
+    private var keyBlocks: [Int: MLXArray] = [:]
+    private var valueBlocks: [Int: MLXArray] = [:]
+    /// `KVCache.update` is nonthrowing, so latch malformed buyer-controlled
+    /// input and let the request bridge convert it into a request-local error.
+    private(set) var invariantFailure: String?
+    /// Stable non-sequence dimensions established by the first valid update.
+    /// Later K/V tensors must remain batch/head/width compatible before host
+    /// concatenation or block reshaping is attempted.
+    private var tensorShape: [Int]?
     var offset: Int
 
     /// Number of times the paged Metal gather kernel actually executed. Proof, for the
@@ -105,6 +124,20 @@ final class PagedKVCache: KVCache, CustomDebugStringConvertible {
         self.offset = binding.currentTable.logicalTokenCount
     }
 
+    /// Refresh the allocator-issued reservation/table after an extend, trim, or
+    /// retain/reattach transition. The K/V arrays remain owned by this cache;
+    /// only the authoritative physical binding changes.
+    func refresh(binding: PagedKVStorageBinding) {
+        guard binding.handle == self.binding.handle,
+              binding.blockSizeTokens == descriptor.blockSizeTokens,
+              binding.poolEpoch == descriptor.poolEpoch
+        else {
+            invariantViolation("allocator binding refresh mismatch")
+            return
+        }
+        self.binding = binding
+    }
+
     var maxSize: Int? { maxResidentTokens }
 
     func innerState() -> [MLXArray] {
@@ -112,81 +145,173 @@ final class PagedKVCache: KVCache, CustomDebugStringConvertible {
     }
 
     func update(keys: MLXArray, values: MLXArray) -> (MLXArray, MLXArray) {
-        // Controlled handling for the serving bridge: never abort the host process on
-        // malformed/out-of-contract input. Guard the invariants and return safely instead
-        // of `precondition`-crashing. The happy path (shape-consistent, within reserved
-        // capacity) is unchanged. NOTE: KERNEL-SIDE (Metal) index/bounds validation is a
-        // SEPARATE, still-REQUIRED before-runtime-enable gate item — these Swift-side guards
-        // do not substitute for in-shader bounds checks (see pagedGather()).
-        guard keys.ndim == 4, values.ndim == 4 else { return (keys, values) }
+        // KVCache.update cannot throw. Latch malformed or over-capacity updates and
+        // return the protocol-required tensors; the request bridge checks the latch
+        // before committing or returning the generated result. Kernel-side checks below
+        // remain defense in depth.
+        if invariantFailure != nil {
+            return (keys, values)
+        }
+        guard keys.ndim == 4,
+              values.ndim == 4,
+              keys.shape == values.shape,
+              keys.dtype == values.dtype,
+              keys.dtype == .float16,
+              keys.dim(0) == 1,
+              keys.dim(1) > 0,
+              keys.dim(2) > 0,
+              keys.dim(3) > 0
+        else {
+            invariantViolation("KV tensors have incompatible rank or shape")
+            return (keys, values)
+        }
+        let incomingTensorShape = [keys.dim(0), keys.dim(1), keys.dim(3)]
+        if let tensorShape, tensorShape != incomingTensorShape {
+            invariantViolation("KV tensor dimensions changed during request")
+            return (keys, values)
+        }
         let incomingTokens = keys.dim(2)
-        guard incomingTokens == values.dim(2) else { return (keys, values) }
+        guard incomingTokens == values.dim(2) else {
+            invariantViolation("key/value token counts differ")
+            return (keys, values)
+        }
         let (projectedOffset, offsetOverflow) = offset.addingReportingOverflow(incomingTokens)
-        guard !offsetOverflow, projectedOffset <= maxResidentTokens else { return (keys, values) }
+        guard !offsetOverflow, projectedOffset <= maxResidentTokens else {
+            invariantViolation("KV update exceeds reserved capacity")
+            return (keys, values)
+        }
 
         let mergedKeys = append(keys, to: keyBlocks)
         let mergedValues = append(values, to: valueBlocks)
-        offset += incomingTokens
-        keyBlocks = splitIntoBlocks(mergedKeys)
-        valueBlocks = splitIntoBlocks(mergedValues)
-        // Reconstruct the logical K/V through the REAL Metal gather over a non-identity
-        // (reversed) physical block order. The gather is a lossless permutation round-trip,
-        // so a correct paged reconstruction returns tensors identical to `mergedKeys/Values`
-        // — the parity fixtures gate exactly that (token-for-token argmax equality).
-        let gatheredKeys = pagedGather(mergedKeys)
-        let gatheredValues = pagedGather(mergedValues)
+        let nextOffset = projectedOffset
+        guard let newKeyBlocks = physicalBlocks(for: mergedKeys, logicalTokens: nextOffset),
+              let newValueBlocks = physicalBlocks(for: mergedValues, logicalTokens: nextOffset)
+        else {
+            invariantViolation("allocator block table cannot represent KV update")
+            return (keys, values)
+        }
+        offset = nextOffset
+        keyBlocks = newKeyBlocks
+        valueBlocks = newValueBlocks
+        tensorShape = incomingTensorShape
+        // Reconstruct the logical K/V through the REAL Metal gather using the
+        // allocator-issued physical block IDs and table order.
+        let gatheredKeys = pagedGather(mergedKeys, physicalBlocks: keyBlocks)
+        let gatheredValues = pagedGather(mergedValues, physicalBlocks: valueBlocks)
         return (gatheredKeys, gatheredValues)
     }
 
-    /// Split a contiguous logical `[1, H, S, D]` tensor into fixed-size blocks placed in
-    /// REVERSED physical order, then gather them back to logical order with the registered
-    /// `PagedKVGatherKernel` via a block table. Forces genuine physical non-contiguity so
-    /// the gather is exercised, not bypassed. Returns a tensor identical to the input.
-    private func pagedGather(_ logical: MLXArray) -> MLXArray {
+    /// Gather allocator-owned physical blocks back to logical `[1, H, S, D]`
+    /// order with the registered Metal kernel.
+    private func pagedGather(_ logical: MLXArray, physicalBlocks: [Int: MLXArray]) -> MLXArray {
         // Validate rank/dims and compute all shape/grid math with overflow-checked
-        // arithmetic BEFORE launching the kernel. Any invalid or overflowing configuration
-        // returns the logical tensor unchanged and does NOT launch the kernel.
+        // arithmetic BEFORE launching the kernel. An invalid attached configuration is
+        // latched; returning the logical tensor keeps the nonthrowing protocol well-formed
+        // while the request bridge prevents the request from succeeding.
         //
         // The same invariants are repeated in the shader before every physical read. This
         // is intentional defense in depth: host-side validation prevents invalid launches,
         // while the kernel remains safe if a future caller supplies malformed metadata.
         let blockSize = descriptor.blockSizeTokens
-        guard logical.ndim == 4 else { return logical }
+        guard logical.ndim == 4 else {
+            invariantViolation("logical KV tensor must be rank 4")
+            return logical
+        }
         let H = logical.dim(1)
         let S = logical.dim(2)
         let D = logical.dim(3)
-        guard blockSize > 0, H > 0, S > 0, D > 0 else { return logical }
+        guard blockSize > 0, H > 0, S > 0, D > 0 else {
+            invariantViolation("logical KV tensor has invalid dimensions")
+            return logical
+        }
 
-        let nBlocks = (S + blockSize - 1) / blockSize
+        let (roundedTokens, roundedOverflow) = S.addingReportingOverflow(blockSize - 1)
+        guard !roundedOverflow else {
+            invariantViolation("logical block count overflow")
+            return logical
+        }
+        let nBlocks = roundedTokens / blockSize
         let (sPad, sPadOverflow) = nBlocks.multipliedReportingOverflow(by: blockSize)
-        guard !sPadOverflow else { return logical }
+        guard !sPadOverflow else {
+            invariantViolation("padded token count overflow")
+            return logical
+        }
         let (tokenStride, strideOverflow) = H.multipliedReportingOverflow(by: D)
-        guard !strideOverflow, tokenStride > 0 else { return logical }
+        guard !strideOverflow, tokenStride > 0 else {
+            invariantViolation("KV token stride overflow")
+            return logical
+        }
         // Grid size the kernel will launch (materialize uses logicalTokens * tokenStride);
         // reject before launch if it overflows Int.
         let (gridCount, gridOverflow) = S.multipliedReportingOverflow(by: tokenStride)
-        guard !gridOverflow, gridCount > 0 else { return logical }
+        guard !gridOverflow, gridCount > 0 else {
+            invariantViolation("Metal grid size overflow")
+            return logical
+        }
         // Physical buffer element count must also be representable.
-        guard case (_, false) = sPad.multipliedReportingOverflow(by: tokenStride) else { return logical }
-
-        // [1, H, S, D] -> token-major [S, H*D]
-        var tokenMajor = logical.reshaped([H, S, D]).transposed(1, 0, 2).reshaped([S, tokenStride])
-        if sPad > S {
-            // Padding rows are never read (kernel only gathers the first S logical tokens).
-            let pad = MLXArray.zeros([sPad - S, tokenStride], dtype: logical.dtype)
-            tokenMajor = concatenated([tokenMajor, pad], axis: 0)
+        let (_, physicalElementOverflow) = sPad.multipliedReportingOverflow(by: tokenStride)
+        guard !physicalElementOverflow else {
+            invariantViolation("physical buffer size overflow")
+            return logical
         }
 
-        // Physical buffer: physical slot p holds logical block (nBlocks-1-p) → reversed order.
-        let physOrder = MLXArray((0 ..< nBlocks).reversed().map { Int32($0) })
-        let physical = tokenMajor
-            .reshaped([nBlocks, blockSize, tokenStride])
-            .take(physOrder, axis: 0)
-            .reshaped([sPad, tokenStride])
-        // block_ids[logicalBlock] = physical slot holding it = nBlocks-1-logicalBlock. By
-        // construction every id is in [0, nBlocks); assert the invariant before launch.
-        let blockIDValues = (0 ..< nBlocks).map { Int32(nBlocks - 1 - $0) }
-        guard blockIDValues.allSatisfy({ $0 >= 0 && $0 < Int32(nBlocks) }) else { return logical }
+        // The allocator, rather than this cache, owns physical placement. Resolve
+        // each allocator-issued physical ID into a launch-local dense arena in the
+        // exact reserved-table order. This preserves the authoritative physical
+        // mapping without allocating a buffer proportional to a sparse high ID.
+        let physicalIDs = Array(binding.reservedPhysicalBlocks.prefix(nBlocks))
+        guard physicalIDs.count == nBlocks,
+              Set(physicalIDs).count == nBlocks,
+              physicalIDs.allSatisfy({ $0 >= 0 && $0 < descriptor.maxPhysicalBlocks })
+        else {
+            invariantViolation("allocator physical table is invalid")
+            return logical
+        }
+        let physicalBlockCount = nBlocks
+        let (physicalTokenCount, physicalTokenOverflow) = physicalBlockCount.multipliedReportingOverflow(by: blockSize)
+        guard !physicalTokenOverflow, physicalTokenCount > 0 else {
+            invariantViolation("physical token count overflow")
+            return logical
+        }
+        let (physicalStorageElementCount, physicalStorageOverflow) = physicalTokenCount.multipliedReportingOverflow(by: tokenStride)
+        guard !physicalStorageOverflow else {
+            invariantViolation("physical storage size overflow")
+            return logical
+        }
+        // Keep the launch-local arena in a stable physical-slot order. The
+        // logical block table supplied to Metal then remains a real permutation
+        // of those dense slots instead of being erased by host-side reordering.
+        let densePhysicalIDs = physicalIDs.sorted()
+        let densePhysicalBlocks = densePhysicalIDs.compactMap { physicalBlocks[$0] }.map {
+            $0.reshaped([H, blockSize, D])
+                .transposed(1, 0, 2)
+                .reshaped([blockSize, tokenStride])
+        }
+        guard densePhysicalBlocks.count == nBlocks else {
+            invariantViolation("physical KV blocks are incomplete")
+            return logical
+        }
+        // Each dense block is already `[blockSize, H*D]`; concatenating on the
+        // token axis produces the exact rank-2 arena consumed by the Metal
+        // kernel. Do not append a differently-ranked sentinel or take rows by
+        // block index: that would select individual tokens and make the final
+        // reshape inconsistent whenever `blockSize > 1`.
+        let physical = concatenated(densePhysicalBlocks, axis: 0)
+        guard physical.shape == [physicalTokenCount, tokenStride],
+              physicalTokenCount * tokenStride == physicalStorageElementCount
+        else {
+            invariantViolation("physical KV arena shape is invalid")
+            return logical
+        }
+        let denseSlotByPhysicalID = Dictionary(
+            uniqueKeysWithValues: densePhysicalIDs.enumerated().map { ($1, Int32($0)) }
+        )
+        guard let blockIDValues = physicalIDs.compactMap({ denseSlotByPhysicalID[$0] }) as [Int32]?,
+              blockIDValues.count == nBlocks
+        else {
+            invariantViolation("physical KV block remap is incomplete")
+            return logical
+        }
         let blockIDs = MLXArray(blockIDValues)
 
         let kernel: MLXFast.MLXFastKernel
@@ -203,17 +328,26 @@ final class PagedKVCache: KVCache, CustomDebugStringConvertible {
             logicalTokens: S,
             blockSizeTokens: blockSize,
             tokenStride: tokenStride,
-            physicalTokenCount: sPad * tokenStride,
-            blockCount: nBlocks,
+            physicalTokenCount: physicalTokenCount,
+            logicalBlockCount: nBlocks,
+            physicalBlockCount: physicalBlockCount,
             outputShape: [S, tokenStride],
             using: kernel
         )
         PagedKVCache.gatherKernelCalls += 1
         PagedKVCache.maxLogicalBlocksObserved = max(PagedKVCache.maxLogicalBlocksObserved, nBlocks)
-        if nBlocks > 1 { PagedKVCache.observedNonIdentityPermutation = true }
+        if blockIDValues != Array(0 ..< nBlocks).map(Int32.init) {
+            PagedKVCache.observedNonIdentityPermutation = true
+        }
 
         // token-major [S, H*D] -> [1, H, S, D]
         return gathered.reshaped([S, H, D]).transposed(1, 0, 2).reshaped([1, H, S, D])
+    }
+
+    private func invariantViolation(_ message: String) {
+        if invariantFailure == nil {
+            invariantFailure = message
+        }
     }
 
     var state: [MLXArray] {
@@ -229,13 +363,49 @@ final class PagedKVCache: KVCache, CustomDebugStringConvertible {
             // Controlled handling: ignore malformed state assignments rather
             // than aborting the process. A well-formed [keys, values] pair with matching
             // sequence length is required; anything else is a no-op.
-            guard newValue.count == 2 else { return }
+            if newValue.isEmpty {
+                guard offset == 0, keyBlocks.isEmpty, valueBlocks.isEmpty else {
+                    invariantViolation("empty KV state is only valid before the first token")
+                    return
+                }
+                return
+            }
+            guard newValue.count == 2 else {
+                invariantViolation("KV state must contain key and value tensors")
+                return
+            }
             let keys = newValue[0]
             let values = newValue[1]
-            guard keys.ndim == 4, values.ndim == 4, keys.dim(2) == values.dim(2) else { return }
-            offset = keys.dim(2)
-            keyBlocks = splitIntoBlocks(keys)
-            valueBlocks = splitIntoBlocks(values)
+            guard keys.ndim == 4,
+                  values.ndim == 4,
+                  keys.shape == values.shape,
+                  keys.dtype == values.dtype,
+                  keys.dtype == .float16,
+                  keys.dim(0) == 1,
+                  keys.dim(1) > 0,
+                  keys.dim(2) > 0,
+                  keys.dim(3) > 0,
+                  keys.dim(2) == values.dim(2)
+            else {
+                invariantViolation("KV state has invalid shape")
+                return
+            }
+            let newTensorShape = [keys.dim(0), keys.dim(1), keys.dim(3)]
+            if let tensorShape, tensorShape != newTensorShape {
+                invariantViolation("KV state dimensions changed during request")
+                return
+            }
+            let nextOffset = keys.dim(2)
+            guard let newKeyBlocks = physicalBlocks(for: keys, logicalTokens: nextOffset),
+                  let newValueBlocks = physicalBlocks(for: values, logicalTokens: nextOffset)
+            else {
+                invariantViolation("KV state cannot be represented by allocator table")
+                return
+            }
+            offset = nextOffset
+            keyBlocks = newKeyBlocks
+            valueBlocks = newValueBlocks
+            tensorShape = newTensorShape
         }
     }
 
@@ -252,7 +422,10 @@ final class PagedKVCache: KVCache, CustomDebugStringConvertible {
             // Controlled handling: a mismatched meta_state marker is ignored
             // rather than aborting the process. The stored metadata is derived from the
             // descriptor/binding, so there is nothing to mutate on a valid marker either.
-            guard newValue.first == "macprovider_paged_kv_v1" else { return }
+            guard newValue.first == "macprovider_paged_kv_v1" else {
+                invariantViolation("KV meta_state marker mismatch")
+                return
+            }
         }
     }
 
@@ -263,9 +436,13 @@ final class PagedKVCache: KVCache, CustomDebugStringConvertible {
         let trimmed = min(offset, max(n, 0))
         guard trimmed > 0 else { return 0 }
         offset -= trimmed
-        if let keys = materialized(keyBlocks), let values = materialized(valueBlocks) {
-            keyBlocks = splitIntoBlocks(keys[.ellipsis, ..<offset, 0...])
-            valueBlocks = splitIntoBlocks(values[.ellipsis, ..<offset, 0...])
+        if let keys = materialized(keyBlocks), let values = materialized(valueBlocks),
+           let newKeyBlocks = physicalBlocks(for: keys[.ellipsis, ..<offset, 0...], logicalTokens: offset),
+           let newValueBlocks = physicalBlocks(for: values[.ellipsis, ..<offset, 0...], logicalTokens: offset) {
+            keyBlocks = newKeyBlocks
+            valueBlocks = newValueBlocks
+        } else if !keyBlocks.isEmpty || !valueBlocks.isEmpty {
+            invariantViolation("trimmed KV state cannot be represented by allocator table")
         }
         return trimmed
     }
@@ -273,6 +450,7 @@ final class PagedKVCache: KVCache, CustomDebugStringConvertible {
     func copy() -> any KVCache {
         let copied = PagedKVCache(descriptor: descriptor, binding: binding, gatherKernel: gatherKernel)
         copied.state = state
+        copied.invariantFailure = invariantFailure
         return copied
     }
 
@@ -346,32 +524,57 @@ final class PagedKVCache: KVCache, CustomDebugStringConvertible {
 
     private var maxResidentTokens: Int {
         let (value, overflow) = descriptor.blockSizeTokens.multipliedReportingOverflow(by: descriptor.maxPhysicalBlocks)
-        return overflow ? Int.max : value
+        let poolCapacity = overflow ? Int.max : value
+        return min(binding.maxLogicalTokens, poolCapacity)
     }
 
-    private func append(_ array: MLXArray, to blocks: [MLXArray]) -> MLXArray {
+    private func append(_ array: MLXArray, to blocks: [Int: MLXArray]) -> MLXArray {
         guard let current = materialized(blocks) else { return array }
         return concatenated([current, array], axis: 2)
     }
 
-    private func materialized(_ blocks: [MLXArray]) -> MLXArray? {
+    private func materialized(_ blocks: [Int: MLXArray]) -> MLXArray? {
         guard !blocks.isEmpty else { return nil }
-        // Storage retrieval only (logical accumulation). The paged Metal gather runs in
-        // `update()` via `pagedGather`, which reconstructs logical order from a non-identity
-        // physical block layout; this helper just returns the accumulated logical K/V.
         _ = gatherKernel
-        return blocks.count == 1 ? blocks[0] : concatenated(blocks, axis: 2)
+        let blockCount = max(1, (offset + descriptor.blockSizeTokens - 1) / descriptor.blockSizeTokens)
+        let orderedIDs = Array(binding.reservedPhysicalBlocks.prefix(blockCount))
+        let ordered = orderedIDs.compactMap { blocks[$0] }
+        guard ordered.count == blockCount else { return nil }
+        let joined = ordered.count == 1 ? ordered[0] : concatenated(ordered, axis: 2)
+        let logicalCount = min(offset, joined.dim(2))
+        return joined[.ellipsis, ..<logicalCount, 0...]
     }
 
-    private func splitIntoBlocks(_ array: MLXArray) -> [MLXArray] {
+    private func physicalBlocks(for array: MLXArray, logicalTokens: Int) -> [Int: MLXArray]? {
         let tokens = array.dim(2)
-        guard tokens > 0 else { return [] }
-        var blocks: [MLXArray] = []
+        guard tokens == logicalTokens else { return nil }
+        let blockCount = tokens == 0
+            ? 0
+            : (tokens + descriptor.blockSizeTokens - 1) / descriptor.blockSizeTokens
+        let physicalIDs = Array(binding.reservedPhysicalBlocks.prefix(blockCount))
+        guard physicalIDs.count == blockCount,
+              Set(physicalIDs).count == blockCount,
+              physicalIDs.allSatisfy({ $0 >= 0 && $0 < descriptor.maxPhysicalBlocks })
+        else { return nil }
+        guard blockCount > 0 else { return [:] }
+        var blocks: [Int: MLXArray] = [:]
         var start = 0
+        var blockIndex = 0
         while start < tokens {
             let end = min(start + descriptor.blockSizeTokens, tokens)
-            blocks.append(array[.ellipsis, start ..< end, 0...])
+            let block = array[.ellipsis, start ..< end, 0...]
+            let validTokens = end - start
+            if validTokens < descriptor.blockSizeTokens {
+                let pad = MLXArray.zeros(
+                    [array.dim(0), array.dim(1), descriptor.blockSizeTokens - validTokens, array.dim(3)],
+                    dtype: array.dtype
+                )
+                blocks[physicalIDs[blockIndex]] = concatenated([block, pad], axis: 2)
+            } else {
+                blocks[physicalIDs[blockIndex]] = block
+            }
             start = end
+            blockIndex += 1
         }
         return blocks
     }

--- a/phase3-binary/Sources/macprovider-cli/PagedKVCache.swift
+++ b/phase3-binary/Sources/macprovider-cli/PagedKVCache.swift
@@ -13,6 +13,12 @@ struct PagedKVGatherKernel {
         uint within_block = logical_token - (logical_block * block_size_tokens);
         uint physical_block = uint(block_ids[logical_block]);
         uint physical_token = (physical_block * block_size_tokens) + within_block;
+        if (logical_token >= logical_token_count || lane >= token_stride
+            || logical_block >= block_count || physical_block >= block_count
+            || physical_token >= physical_token_count) {
+            gathered[elem] = 0;
+            return;
+        }
         gathered[elem] = physical[physical_token * token_stride + lane];
     """
 
@@ -32,6 +38,8 @@ struct PagedKVGatherKernel {
         logicalTokens: Int,
         blockSizeTokens: Int,
         tokenStride: Int,
+        physicalTokenCount: Int,
+        blockCount: Int,
         outputShape: [Int],
         using kernel: MLXFast.MLXFastKernel
     ) -> MLXArray {
@@ -41,6 +49,9 @@ struct PagedKVGatherKernel {
             template: [
                 ("block_size_tokens", blockSizeTokens),
                 ("token_stride", tokenStride),
+                ("logical_token_count", logicalTokens),
+                ("physical_token_count", physicalTokenCount),
+                ("block_count", blockCount),
             ],
             grid: (count, 1, 1),
             threadGroup: (min(count, 256), 1, 1),
@@ -50,13 +61,9 @@ struct PagedKVGatherKernel {
     }
 }
 
-/// Compile-time `KVCache` seam for the future installed paged runtime bridge.
-///
-/// `ModelRuntime` deliberately never injects this class in the current merge:
-/// `engineBridgeAvailable` is false in runtime gates and `.attached` preflight
-/// fails closed. The class remains type-checked against `mlx-swift-lm` so the
-/// follow-up bridge can wire request-level reservation, real gather execution,
-/// and parity tests without changing public buyer behavior.
+/// Paged serving cache backed by the SPEC-039 block binding. The runtime bridge
+/// owns reservation/lifecycle; this cache owns the `KVCache` contract and the
+/// bounded logical-to-physical gather for one transformer layer.
 final class PagedKVCache: KVCache, CustomDebugStringConvertible {
     let descriptor: PagedKVDescriptor
     let binding: PagedKVStorageBinding
@@ -105,7 +112,7 @@ final class PagedKVCache: KVCache, CustomDebugStringConvertible {
     }
 
     func update(keys: MLXArray, values: MLXArray) -> (MLXArray, MLXArray) {
-        // Controlled handling for this inert seam: never abort the host process on
+        // Controlled handling for the serving bridge: never abort the host process on
         // malformed/out-of-contract input. Guard the invariants and return safely instead
         // of `precondition`-crashing. The happy path (shape-consistent, within reserved
         // capacity) is unchanged. NOTE: KERNEL-SIDE (Metal) index/bounds validation is a
@@ -140,11 +147,9 @@ final class PagedKVCache: KVCache, CustomDebugStringConvertible {
         // arithmetic BEFORE launching the kernel. Any invalid or overflowing configuration
         // returns the logical tensor unchanged and does NOT launch the kernel.
         //
-        // IMPORTANT: these are SWIFT-SIDE guards only. KERNEL-SIDE (Metal) bounds validation
-        // — clamping/rejecting out-of-range block_ids and physical_token indices inside the
-        // shader before any `physical[...]` read — remains a REQUIRED before-runtime-enable
-        // gate item and is intentionally NOT added in this inert (non-serving) merge; the
-        // kernel source is frozen here because the seam regression test pins it.
+        // The same invariants are repeated in the shader before every physical read. This
+        // is intentional defense in depth: host-side validation prevents invalid launches,
+        // while the kernel remains safe if a future caller supplies malformed metadata.
         let blockSize = descriptor.blockSizeTokens
         guard logical.ndim == 4 else { return logical }
         let H = logical.dim(1)
@@ -198,6 +203,8 @@ final class PagedKVCache: KVCache, CustomDebugStringConvertible {
             logicalTokens: S,
             blockSizeTokens: blockSize,
             tokenStride: tokenStride,
+            physicalTokenCount: sPad * tokenStride,
+            blockCount: nBlocks,
             outputShape: [S, tokenStride],
             using: kernel
         )
@@ -219,7 +226,7 @@ final class PagedKVCache: KVCache, CustomDebugStringConvertible {
             return [keys, values]
         }
         set {
-            // Controlled handling (inert seam): ignore malformed state assignments rather
+            // Controlled handling: ignore malformed state assignments rather
             // than aborting the process. A well-formed [keys, values] pair with matching
             // sequence length is required; anything else is a no-op.
             guard newValue.count == 2 else { return }
@@ -242,7 +249,7 @@ final class PagedKVCache: KVCache, CustomDebugStringConvertible {
             ]
         }
         set {
-            // Controlled handling (inert seam): a mismatched meta_state marker is ignored
+            // Controlled handling: a mismatched meta_state marker is ignored
             // rather than aborting the process. The stored metadata is derived from the
             // descriptor/binding, so there is nothing to mutate on a valid marker either.
             guard newValue.first == "macprovider_paged_kv_v1" else { return }
@@ -267,6 +274,58 @@ final class PagedKVCache: KVCache, CustomDebugStringConvertible {
         let copied = PagedKVCache(descriptor: descriptor, binding: binding, gatherKernel: gatherKernel)
         copied.state = state
         return copied
+    }
+
+    /// Extract the current logical K/V tensors into the neutral FR-PKV10 byte
+    /// representation. The allocator validates the block table separately; this
+    /// method is deliberately limited to one layer and never invents shape/dtype
+    /// metadata.
+    func materializedByteLayer(layerIndex: Int) throws -> PagedKVMaterializedByteLayer {
+        guard layerIndex >= 0,
+              let keys = materialized(keyBlocks),
+              let values = materialized(valueBlocks),
+              keys.ndim == 4,
+              values.ndim == 4,
+              keys.shape == values.shape,
+              keys.dim(2) == offset,
+              keys.dtype == .float16,
+              values.dtype == .float16
+        else {
+            throw PagedKVAllocatorError.invalidBlockTable("paged cache state is not contiguous fp16 K/V")
+        }
+        let keyData = keys.asData()
+        let valueData = values.asData()
+        guard keyData.shape == valueData.shape,
+              keyData.dType == .float16,
+              valueData.dType == .float16
+        else {
+            throw PagedKVAllocatorError.invalidBlockTable("paged cache byte state mismatch")
+        }
+        return PagedKVMaterializedByteLayer(
+            layerIndex: layerIndex,
+            keyShape: keyData.shape,
+            valueShape: valueData.shape,
+            dtype: .fp16,
+            logicalTokenCount: offset,
+            keyBytes: keyData.data,
+            valueBytes: valueData.data
+        )
+    }
+
+    /// Rehydrate a layer from a validated FR-PKV10 contiguous snapshot. The
+    /// caller must validate the snapshot against the allocator's current table
+    /// before calling this method.
+    func inject(materialized layer: PagedKVMaterializedByteLayer) throws {
+        guard layer.dtype == .fp16,
+              layer.keyShape == layer.valueShape,
+              layer.keyShape.count == 4,
+              layer.keyShape[2] == layer.logicalTokenCount
+        else {
+            throw PagedKVAllocatorError.invalidBlockTable("invalid contiguous K/V layer")
+        }
+        let keys = MLXArray(layer.keyBytes, layer.keyShape, dtype: .float16)
+        let values = MLXArray(layer.valueBytes, layer.valueShape, dtype: .float16)
+        state = [keys, values]
     }
 
     func makeMask(

--- a/phase3-binary/Sources/macprovider-cli/PagedKVRuntimeBridge.swift
+++ b/phase3-binary/Sources/macprovider-cli/PagedKVRuntimeBridge.swift
@@ -57,11 +57,13 @@ final class PagedKVRequestAttachment: @unchecked Sendable {
     init(
         bridge: PagedKVRuntimeBridge,
         handle: PagedKVBlockTableHandle,
-        binding: PagedKVStorageBinding
+        binding: PagedKVStorageBinding,
+        cacheLayers: [PagedKVCache] = []
     ) {
         self.bridge = bridge
         self.handle = handle
         self.binding = binding
+        self.cacheLayers = cacheLayers
     }
 
     func makeCacheLayers(count: Int) throws -> [PagedKVCache] {
@@ -80,12 +82,23 @@ final class PagedKVRequestAttachment: @unchecked Sendable {
         return try await bridge.checkpoint(handle: handle, layers: cacheLayers)
     }
 
+    func validate() throws {
+        try bridge.validate(layers: cacheLayers)
+    }
+
     func retain() async throws -> PagedKVRetainedSequence {
         try await bridge.retain(handle: handle)
     }
 
     func release() async throws {
         try await bridge.release(handle: handle)
+    }
+
+    func discardRetained(_ retained: PagedKVRetainedSequence) async throws {
+        try await bridge.discardRetained(
+            retained,
+            conversationKey: retained.conversationKeyForValidation
+        )
     }
 }
 
@@ -105,6 +118,10 @@ final class PagedKVRuntimeBridge: @unchecked Sendable, PagedKVContiguousCacheBri
     private let byteSnapshotStore: PagedKVByteSnapshotStore
     private var liveLayers: [UUID: [PagedKVCache]] = [:]
     private var snapshots: [UUID: PagedKVMaterializedByteCache] = [:]
+    /// A failed release leaves allocator-owned blocks unresolved. Stop accepting
+    /// new reservations until the process can be restarted with a fresh pool;
+    /// explicit release retries remain allowed for the failed handle.
+    private var unhealthy = false
 
     init(
         config: PagedKVConfig,
@@ -146,7 +163,16 @@ final class PagedKVRuntimeBridge: @unchecked Sendable, PagedKVContiguousCacheBri
     }
 
     var isAttached: Bool {
-        observation.matches(config: config)
+        lock.lock()
+        let healthy = !unhealthy
+        lock.unlock()
+        return healthy && observation.matches(config: config)
+    }
+
+    var isUnhealthy: Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        return unhealthy
     }
 
     func reserve(
@@ -160,7 +186,21 @@ final class PagedKVRuntimeBridge: @unchecked Sendable, PagedKVContiguousCacheBri
             maxTokens: maxTokens,
             initialTokens: initialTokens
         )
-        let binding = try await allocator.binding(for: handle)
+        guard isAttached else {
+            await releaseAllocatorHandle(handle)
+            throw PagedKVRuntimeBridgeError.unavailable
+        }
+        let binding: PagedKVStorageBinding
+        do {
+            binding = try await allocator.binding(for: handle)
+        } catch {
+            await releaseAllocatorHandle(handle)
+            throw error
+        }
+        guard isAttached else {
+            await releaseAllocatorHandle(handle)
+            throw PagedKVRuntimeBridgeError.unavailable
+        }
         return PagedKVRequestAttachment(bridge: self, handle: handle, binding: binding)
     }
 
@@ -188,6 +228,10 @@ final class PagedKVRuntimeBridge: @unchecked Sendable, PagedKVContiguousCacheBri
         layers: [PagedKVCache]
     ) async throws -> PagedKVMaterializedByteCache {
         guard !layers.isEmpty else { throw PagedKVRuntimeBridgeError.noCacheLayers }
+        guard layers.allSatisfy({ $0.binding.handle == handle }) else {
+            throw PagedKVRuntimeBridgeError.cacheStateMismatch
+        }
+        try validate(layers: layers)
         let logicalLengths = Set(layers.map(\.offset))
         guard logicalLengths.count == 1,
               let logicalLength = logicalLengths.first
@@ -202,6 +246,10 @@ final class PagedKVRuntimeBridge: @unchecked Sendable, PagedKVContiguousCacheBri
         let table = try await allocator.table(for: handle)
         guard table.logicalTokenCount == logicalLength else {
             throw PagedKVRuntimeBridgeError.logicalLengthMismatch
+        }
+        let binding = try await allocator.binding(for: handle)
+        for layer in layers {
+            layer.refresh(binding: binding)
         }
 
         let materializedLayers = try layers.enumerated().map { index, layer in
@@ -218,6 +266,13 @@ final class PagedKVRuntimeBridge: @unchecked Sendable, PagedKVContiguousCacheBri
         store(snapshot, layers: layers)
         byteSnapshotStore.store(snapshot)
         return snapshot
+    }
+
+    func validate(layers: [PagedKVCache]) throws {
+        guard !layers.isEmpty else { throw PagedKVRuntimeBridgeError.noCacheLayers }
+        guard layers.allSatisfy({ $0.invariantFailure == nil }) else {
+            throw PagedKVRuntimeBridgeError.cacheStateMismatch
+        }
     }
 
     /// The frozen engine protocol remains synchronous. It reads the last
@@ -239,8 +294,7 @@ final class PagedKVRuntimeBridge: @unchecked Sendable, PagedKVContiguousCacheBri
     }
 
     /// Builds standalone `KVCacheSimple` layers from the validated contiguous
-    /// snapshot. This is the live FR-PKV10 handoff consumed by cold-tier and
-    /// cross-turn callers; it is not a byte-only placeholder.
+    /// snapshot for callers that explicitly request a contiguous handoff.
     func materializeContiguousKVCache(
         handle: PagedKVBlockTableHandle
     ) async throws -> [KVCache] {
@@ -272,29 +326,84 @@ final class PagedKVRuntimeBridge: @unchecked Sendable, PagedKVContiguousCacheBri
         layerCount: Int
     ) async throws -> (PagedKVRequestAttachment, [PagedKVCache]) {
         guard layerCount > 0 else { throw PagedKVRuntimeBridgeError.noCacheLayers }
+        guard isAttached else { throw PagedKVRuntimeBridgeError.unavailable }
+        let retainedLayers = layers(for: retained.handle)
+        guard let retainedLayers, retainedLayers.count == layerCount else {
+            throw PagedKVRuntimeBridgeError.retainedSequenceUnavailable
+        }
+
+        // Reattach the still-live allocator/cache backing directly. A retained
+        // sequence must not round-trip through a contiguous byte snapshot: that
+        // path is reserved for explicit materialization/export only.
         let handle = try await allocator.reattach(retained, conversationKey: conversationKey)
-        let binding = try await allocator.binding(for: handle)
-        let attachment = PagedKVRequestAttachment(bridge: self, handle: handle, binding: binding)
-        let layers = try attachment.makeCacheLayers(count: layerCount)
-        let snapshot = try materializeContiguousByteCache(
+        guard isAttached else {
+            await releaseAllocatorHandle(handle)
+            remove(handle)
+            throw PagedKVRuntimeBridgeError.unavailable
+        }
+        let binding: PagedKVStorageBinding
+        do {
+            binding = try await allocator.binding(for: handle)
+        } catch {
+            // Reattach clears the allocator's retained bit before binding is
+            // read. Roll back the active handle so a partial reattach cannot
+            // strand its reserved blocks.
+            await releaseAllocatorHandle(handle)
+            remove(handle)
+            throw error
+        }
+        guard isAttached else {
+            await releaseAllocatorHandle(handle)
+            remove(handle)
+            throw PagedKVRuntimeBridgeError.unavailable
+        }
+        for layer in retainedLayers {
+            layer.refresh(binding: binding)
+        }
+        let attachment = PagedKVRequestAttachment(
+            bridge: self,
             handle: handle,
-            table: try await allocator.table(for: handle)
+            binding: binding,
+            cacheLayers: retainedLayers
         )
-        guard snapshot.layers.count == layerCount else {
-            throw PagedKVRuntimeBridgeError.cacheLayerCountMismatch
-        }
-        for layer in snapshot.layers {
-            guard layer.layerIndex < layers.count else {
-                throw PagedKVRuntimeBridgeError.cacheLayerCountMismatch
-            }
-            try layers[layer.layerIndex].inject(materialized: layer)
-        }
-        return (attachment, layers)
+        register(layers: retainedLayers, for: handle)
+        return (attachment, retainedLayers)
+    }
+
+    func discardRetained(
+        _ retained: PagedKVRetainedSequence,
+        conversationKey: String
+    ) async throws {
+        try await allocator.discardRetained(retained, conversationKey: conversationKey)
+        remove(retained.handle)
     }
 
     func release(handle: PagedKVBlockTableHandle) async throws {
-        try await allocator.release(handle)
-        remove(handle)
+        do {
+            try await allocator.release(handle)
+            remove(handle)
+        } catch {
+            markUnhealthy()
+            throw error
+        }
+    }
+
+    private func markUnhealthy() {
+        lock.lock()
+        unhealthy = true
+        lock.unlock()
+    }
+
+    private func releaseAllocatorHandle(_ handle: PagedKVBlockTableHandle) async {
+        for _ in 0..<2 {
+            do {
+                try await allocator.release(handle)
+                return
+            } catch {
+                continue
+            }
+        }
+        markUnhealthy()
     }
 
     private func remove(_ handle: PagedKVBlockTableHandle) {
@@ -303,6 +412,12 @@ final class PagedKVRuntimeBridge: @unchecked Sendable, PagedKVContiguousCacheBri
         snapshots.removeValue(forKey: handle.handleID)
         lock.unlock()
         byteSnapshotStore.remove(handle)
+    }
+
+    private func layers(for handle: PagedKVBlockTableHandle) -> [PagedKVCache]? {
+        lock.lock()
+        defer { lock.unlock() }
+        return liveLayers[handle.handleID]
     }
 }
 

--- a/phase3-binary/Sources/macprovider-cli/PagedKVRuntimeBridge.swift
+++ b/phase3-binary/Sources/macprovider-cli/PagedKVRuntimeBridge.swift
@@ -1,0 +1,351 @@
+import Foundation
+import MLX
+import MLXLMCommon
+import MacProviderCore
+
+/// Errors owned by the provider-local bridge. The allocator remains the source
+/// of truth for block-table errors; these cases cover the bridge's cache/lifecycle
+/// invariants around that allocator.
+enum PagedKVRuntimeBridgeError: Error, Equatable {
+    case unavailable
+    case descriptorObservationMismatch
+    case noCacheLayers
+    case cacheLayerCountMismatch
+    case cacheStateMismatch
+    case logicalLengthMismatch
+    case retainedSequenceUnavailable
+}
+
+private final class PagedKVByteSnapshotStore: @unchecked Sendable, PagedKVContiguousCacheBridge {
+    private let lock = NSLock()
+    private var snapshots: [UUID: PagedKVMaterializedByteCache] = [:]
+
+    func store(_ snapshot: PagedKVMaterializedByteCache) {
+        lock.lock()
+        snapshots[snapshot.handle.handleID] = snapshot
+        lock.unlock()
+    }
+
+    func materializeContiguousByteCache(
+        handle: PagedKVBlockTableHandle,
+        table: PagedKVBlockTable
+    ) throws -> PagedKVMaterializedByteCache {
+        lock.lock()
+        defer { lock.unlock() }
+        guard let snapshot = snapshots[handle.handleID],
+              snapshot.handle == handle,
+              snapshot.blockTable == table
+        else { throw PagedKVRuntimeBridgeError.unavailable }
+        return snapshot
+    }
+
+    func remove(_ handle: PagedKVBlockTableHandle) {
+        lock.lock()
+        snapshots.removeValue(forKey: handle.handleID)
+        lock.unlock()
+    }
+}
+
+/// A request-scoped reservation. The scheduler owns the same allocator handle;
+/// model execution owns the `KVCache` objects created from this binding.
+final class PagedKVRequestAttachment: @unchecked Sendable {
+    let bridge: PagedKVRuntimeBridge
+    let handle: PagedKVBlockTableHandle
+    let binding: PagedKVStorageBinding
+    private(set) var cacheLayers: [PagedKVCache] = []
+
+    init(
+        bridge: PagedKVRuntimeBridge,
+        handle: PagedKVBlockTableHandle,
+        binding: PagedKVStorageBinding
+    ) {
+        self.bridge = bridge
+        self.handle = handle
+        self.binding = binding
+    }
+
+    func makeCacheLayers(count: Int) throws -> [PagedKVCache] {
+        guard count > 0 else { throw PagedKVRuntimeBridgeError.noCacheLayers }
+        guard cacheLayers.isEmpty else { throw PagedKVRuntimeBridgeError.cacheStateMismatch }
+        let layers = (0 ..< count).map { _ in
+            PagedKVCache(descriptor: bridge.descriptor, binding: binding)
+        }
+        cacheLayers = layers
+        bridge.register(layers: layers, for: handle)
+        return layers
+    }
+
+    func checkpoint() async throws -> PagedKVMaterializedByteCache {
+        guard !cacheLayers.isEmpty else { throw PagedKVRuntimeBridgeError.noCacheLayers }
+        return try await bridge.checkpoint(handle: handle, layers: cacheLayers)
+    }
+
+    func retain() async throws -> PagedKVRetainedSequence {
+        try await bridge.retain(handle: handle)
+    }
+
+    func release() async throws {
+        try await bridge.release(handle: handle)
+    }
+}
+
+/// Provider-local owner for a real SPEC-039 request attach.
+///
+/// The bridge is deliberately constructed from an observed runtime identity and
+/// an allocator. It never creates a descriptor from its own defaults. The caller
+/// must install the descriptor produced by `PagedKVAttachGate` before this bridge
+/// can create request caches.
+final class PagedKVRuntimeBridge: @unchecked Sendable, PagedKVContiguousCacheBridge {
+    let allocator: PagedKVBlockAllocator
+    let observation: PagedKVRuntimeObservation
+    let config: PagedKVConfig
+    private(set) var descriptor: PagedKVDescriptor
+
+    private let lock = NSLock()
+    private let byteSnapshotStore: PagedKVByteSnapshotStore
+    private var liveLayers: [UUID: [PagedKVCache]] = [:]
+    private var snapshots: [UUID: PagedKVMaterializedByteCache] = [:]
+
+    init(
+        config: PagedKVConfig,
+        observation: PagedKVRuntimeObservation,
+        descriptor: PagedKVDescriptor
+    ) throws {
+        guard observation.matches(config: config),
+              descriptor.blockSizeTokens == config.blockSizeTokens,
+              descriptor.maxPhysicalBlocks == config.maxPhysicalBlocks,
+              descriptor.supportedModelFamilies.contains(observation.modelFamily),
+              descriptor.admits(
+                  modelID: observation.modelID,
+                  modelSHA256: observation.modelSHA256,
+                  tokenizerSHA256: observation.tokenizerSHA256,
+                  chatTemplateSHA256: observation.chatTemplateSHA256,
+                  cacheClass: observation.cacheClass,
+                  kvDType: observation.kvDType,
+                  requiresMoE: observation.requiresMoEDispatch,
+                  hardwareClass: observation.hardwareClass ?? "",
+                  metallibSHA256: observation.metallibSHA256 ?? "",
+                  kernelIdentifier: observation.kernelIdentifier ?? "",
+                  parityLabel: observation.parityLabel ?? "",
+                  poolEpoch: observation.poolEpoch ?? -1
+              )
+        else {
+            throw PagedKVRuntimeBridgeError.descriptorObservationMismatch
+        }
+        let byteSnapshotStore = PagedKVByteSnapshotStore()
+        self.config = config
+        self.observation = observation
+        self.descriptor = descriptor
+        self.byteSnapshotStore = byteSnapshotStore
+        self.allocator = try PagedKVBlockAllocator(
+            blockSizeTokens: descriptor.blockSizeTokens,
+            maxPhysicalBlocks: descriptor.maxPhysicalBlocks,
+            poolEpoch: descriptor.poolEpoch,
+            contiguousCacheBridge: byteSnapshotStore
+        )
+    }
+
+    var isAttached: Bool {
+        observation.matches(config: config)
+    }
+
+    func reserve(
+        requestID: String,
+        maxTokens: Int,
+        initialTokens: Int = 0
+    ) async throws -> PagedKVRequestAttachment {
+        guard isAttached else { throw PagedKVRuntimeBridgeError.unavailable }
+        let handle = try await allocator.allocate(
+            conversationKey: requestID,
+            maxTokens: maxTokens,
+            initialTokens: initialTokens
+        )
+        let binding = try await allocator.binding(for: handle)
+        return PagedKVRequestAttachment(bridge: self, handle: handle, binding: binding)
+    }
+
+    func register(layers: [PagedKVCache], for handle: PagedKVBlockTableHandle) {
+        lock.lock()
+        liveLayers[handle.handleID] = layers
+        lock.unlock()
+    }
+
+    private func store(
+        _ snapshot: PagedKVMaterializedByteCache,
+        layers: [PagedKVCache]
+    ) {
+        lock.lock()
+        snapshots[snapshot.handle.handleID] = snapshot
+        liveLayers[snapshot.handle.handleID] = layers
+        lock.unlock()
+    }
+
+    /// Advances the allocator table to the cache's logical length, extracts the
+    /// physical sequence through the existing allocator bridge seam, and stores
+    /// the validated neutral snapshot for synchronous protocol access.
+    func checkpoint(
+        handle: PagedKVBlockTableHandle,
+        layers: [PagedKVCache]
+    ) async throws -> PagedKVMaterializedByteCache {
+        guard !layers.isEmpty else { throw PagedKVRuntimeBridgeError.noCacheLayers }
+        let logicalLengths = Set(layers.map(\.offset))
+        guard logicalLengths.count == 1,
+              let logicalLength = logicalLengths.first
+        else { throw PagedKVRuntimeBridgeError.logicalLengthMismatch }
+
+        let current = try await allocator.table(for: handle).logicalTokenCount
+        if logicalLength > current {
+            _ = try await allocator.extend(handle, by: logicalLength - current)
+        } else if logicalLength < current {
+            _ = try await allocator.trim(handle, toLogicalTokens: logicalLength)
+        }
+        let table = try await allocator.table(for: handle)
+        guard table.logicalTokenCount == logicalLength else {
+            throw PagedKVRuntimeBridgeError.logicalLengthMismatch
+        }
+
+        let materializedLayers = try layers.enumerated().map { index, layer in
+            try layer.materializedByteLayer(layerIndex: index)
+        }
+        guard materializedLayers.allSatisfy({ $0.logicalTokenCount == table.logicalTokenCount }) else {
+            throw PagedKVRuntimeBridgeError.logicalLengthMismatch
+        }
+        let snapshot = PagedKVMaterializedByteCache(
+            handle: handle,
+            blockTable: table,
+            layers: materializedLayers
+        )
+        store(snapshot, layers: layers)
+        byteSnapshotStore.store(snapshot)
+        return snapshot
+    }
+
+    /// The frozen engine protocol remains synchronous. It reads the last
+    /// request-scoped snapshot; the async `checkpoint` above is the only method
+    /// that publishes one, so a stale/mismatched table cannot be silently reused.
+    func materializeContiguousByteCache(
+        handle: PagedKVBlockTableHandle,
+        table: PagedKVBlockTable
+    ) throws -> PagedKVMaterializedByteCache {
+        lock.lock()
+        defer { lock.unlock() }
+        guard let snapshot = snapshots[handle.handleID],
+              snapshot.handle == handle,
+              snapshot.blockTable == table
+        else {
+            throw PagedKVRuntimeBridgeError.unavailable
+        }
+        return snapshot
+    }
+
+    /// Builds standalone `KVCacheSimple` layers from the validated contiguous
+    /// snapshot. This is the live FR-PKV10 handoff consumed by cold-tier and
+    /// cross-turn callers; it is not a byte-only placeholder.
+    func materializeContiguousKVCache(
+        handle: PagedKVBlockTableHandle
+    ) async throws -> [KVCache] {
+        let snapshot = try await allocator.materializeContiguousByteCache(handle)
+        return try snapshot.layers.sorted(by: { $0.layerIndex < $1.layerIndex }).map { layer in
+            guard layer.keyShape == layer.valueShape,
+                  layer.keyShape.count == 4,
+                  layer.keyShape[2] == snapshot.blockTable.logicalTokenCount
+            else { throw PagedKVRuntimeBridgeError.cacheStateMismatch }
+            let cache = KVCacheSimple()
+            cache.state = [
+                MLXArray(layer.keyBytes, layer.keyShape, dtype: .float16),
+                MLXArray(layer.valueBytes, layer.valueShape, dtype: .float16),
+            ]
+            return cache
+        }
+    }
+
+    /// Retains the allocator-owned blocks, then reattaches the same handle for a
+    /// later turn. The logical cache snapshot remains keyed by the same handle,
+    /// so a mid-block trim can be applied before new tokens are appended.
+    func retain(handle: PagedKVBlockTableHandle) async throws -> PagedKVRetainedSequence {
+        try await allocator.retain(handle)
+    }
+
+    func reattach(
+        _ retained: PagedKVRetainedSequence,
+        conversationKey: String,
+        layerCount: Int
+    ) async throws -> (PagedKVRequestAttachment, [PagedKVCache]) {
+        guard layerCount > 0 else { throw PagedKVRuntimeBridgeError.noCacheLayers }
+        let handle = try await allocator.reattach(retained, conversationKey: conversationKey)
+        let binding = try await allocator.binding(for: handle)
+        let attachment = PagedKVRequestAttachment(bridge: self, handle: handle, binding: binding)
+        let layers = try attachment.makeCacheLayers(count: layerCount)
+        let snapshot = try materializeContiguousByteCache(
+            handle: handle,
+            table: try await allocator.table(for: handle)
+        )
+        guard snapshot.layers.count == layerCount else {
+            throw PagedKVRuntimeBridgeError.cacheLayerCountMismatch
+        }
+        for layer in snapshot.layers {
+            guard layer.layerIndex < layers.count else {
+                throw PagedKVRuntimeBridgeError.cacheLayerCountMismatch
+            }
+            try layers[layer.layerIndex].inject(materialized: layer)
+        }
+        return (attachment, layers)
+    }
+
+    func release(handle: PagedKVBlockTableHandle) async throws {
+        try await allocator.release(handle)
+        remove(handle)
+    }
+
+    private func remove(_ handle: PagedKVBlockTableHandle) {
+        lock.lock()
+        liveLayers.removeValue(forKey: handle.handleID)
+        snapshots.removeValue(forKey: handle.handleID)
+        lock.unlock()
+        byteSnapshotStore.remove(handle)
+    }
+}
+
+/// The scheduler's backend-facing representation of a decode forward. The
+/// shape is part of the value so tests and the production driver can assert that
+/// one shared invocation receives exactly `[B, 1]`, rather than accidentally
+/// falling back to one hidden model call per row.
+struct PagedKVSharedForwardBatch: Sendable, Equatable {
+    let tokens: [Int]
+
+    var shape: [Int] { [tokens.count, 1] }
+}
+
+protocol PagedKVSharedForwardDriver: Sendable {
+    func prefill(rows: [ContinuousBatchPrefillInput]) async throws -> [ContinuousBatchPrefillOutput]
+    func decode(
+        batch: PagedKVSharedForwardBatch,
+        rows: [ContinuousBatchDecodeInput]
+    ) async throws -> [ContinuousBatchDecodeOutcome]
+    func cancelInFlight() async
+}
+
+/// Adapter from the SPEC-038 scheduler to a model driver. The scheduler still
+/// owns admission, block lifecycle, cancellation, and row isolation; this type
+/// only packages active row tokens as the shared `[B,1]` input and forwards the
+/// call once.
+struct PagedKVSharedForwardBackend: ContinuousBatchSchedulerBackend {
+    let driver: any PagedKVSharedForwardDriver
+
+    func prefill(rows: [ContinuousBatchPrefillInput]) async throws -> [ContinuousBatchPrefillOutput] {
+        try await driver.prefill(rows: rows)
+    }
+
+    func decode(rows: [ContinuousBatchDecodeInput]) async throws -> [ContinuousBatchDecodeOutcome] {
+        guard !rows.isEmpty else { return [] }
+        let batch = PagedKVSharedForwardBatch(tokens: rows.map(\.currentToken))
+        guard batch.shape == [rows.count, 1] else {
+            throw PagedKVRuntimeBridgeError.cacheStateMismatch
+        }
+        return try await driver.decode(batch: batch, rows: rows)
+    }
+
+    func cancelInFlight() async {
+        await driver.cancelInFlight()
+    }
+}

--- a/phase3-binary/Tests/MacProviderCoreTests/PagedKVEngineTests.swift
+++ b/phase3-binary/Tests/MacProviderCoreTests/PagedKVEngineTests.swift
@@ -30,6 +30,14 @@ final class PagedKVEngineTests: XCTestCase {
             blockSizeTokens: blockSizeTokens,
             maxPhysicalBlocks: maxPhysicalBlocks,
             maxResidentTokens: blockSizeTokens * maxPhysicalBlocks,
+            sizingModelClass: PagedKVHardwareSizingProof.requiredSizingModelClass,
+            unifiedMemoryGB: 32,
+            modelWeightsGB: 20,
+            perRequestActivationGB: 4,
+            pagedBlockPoolGB: 4,
+            kvBytesPerToken: 1_024,
+            measuredGatherOverheadPercent: 2,
+            gatherOverheadCeilingPercent: 10,
             poolEpoch: poolEpoch,
             parityLabel: "sdpa-parity-v1"
         )
@@ -193,6 +201,7 @@ final class PagedKVEngineTests: XCTestCase {
                 observedMetallibSHA256: proof.metallibSHA256,
                 observedKernelIdentifier: proof.kernelIdentifier,
                 observedParityLabel: proof.parityLabel,
+                observedPoolEpoch: proof.poolEpoch,
                 moeDispatchProven: true
             )
         )
@@ -218,6 +227,7 @@ final class PagedKVEngineTests: XCTestCase {
                 observedMetallibSHA256: proof.metallibSHA256,
                 observedKernelIdentifier: proof.kernelIdentifier,
                 observedParityLabel: proof.parityLabel,
+                observedPoolEpoch: proof.poolEpoch,
                 moeDispatchProven: true,
                 engineBridgeAvailable: true
             )
@@ -236,6 +246,60 @@ final class PagedKVEngineTests: XCTestCase {
             kernelIdentifier: proof.kernelIdentifier,
             parityLabel: proof.parityLabel,
             poolEpoch: proof.poolEpoch
+        ))
+    }
+
+    func testAttachGateRequiresLiveObservedPoolEpoch() {
+        let config = PagedKVConfig(enabled: true, blockSizeTokens: 32, maxPhysicalBlocks: 64)
+        let proof = sizingProof(modelFamily: "qwen", blockSizeTokens: 32, maxPhysicalBlocks: 64)
+        let decision = decide(
+            config: config,
+            runtimeCacheClass: "KVCacheSimple",
+            kvBits: nil,
+            modelFamily: "qwen",
+            requiresMoEDispatch: false,
+            gates: PagedKVGates(
+                identityAvailable: true,
+                observedHardwareClass: "apple-silicon-test",
+                metallibAvailable: true,
+                kernelRegistered: true,
+                parityEstablished: true,
+                hardwareSizingProof: proof,
+                observedMetallibSHA256: proof.metallibSHA256,
+                observedKernelIdentifier: proof.kernelIdentifier,
+                observedParityLabel: proof.parityLabel,
+                engineBridgeAvailable: true
+            )
+        )
+        XCTAssertEqual(decision, .fallback(.allocator))
+    }
+
+    func testDescriptorRejectsBlankIndependentIdentity() {
+        let descriptor = PagedKVDescriptor(
+            blockSizeTokens: 4,
+            maxPhysicalBlocks: 4,
+            modelID: "model",
+            modelSHA256: "hash",
+            supportedModelFamilies: ["qwen"],
+            supportsMoEDispatch: false,
+            hardwareClass: "hardware",
+            metallibSHA256: "metallib",
+            kernelIdentifier: "kernel",
+            parityLabel: "parity"
+        )
+        XCTAssertFalse(descriptor.admits(
+            modelID: "model",
+            modelSHA256: "hash",
+            tokenizerSHA256: nil,
+            chatTemplateSHA256: nil,
+            cacheClass: "KVCacheSimple",
+            kvDType: .fp16,
+            requiresMoE: false,
+            hardwareClass: "",
+            metallibSHA256: "metallib",
+            kernelIdentifier: "kernel",
+            parityLabel: "parity",
+            poolEpoch: 1
         ))
     }
 
@@ -335,6 +399,7 @@ final class PagedKVEngineTests: XCTestCase {
                 observedMetallibSHA256: proof.metallibSHA256,
                 observedKernelIdentifier: proof.kernelIdentifier,
                 observedParityLabel: proof.parityLabel,
+                observedPoolEpoch: proof.poolEpoch,
                 moeDispatchProven: false
             )
         )
@@ -560,6 +625,33 @@ final class PagedKVEngineTests: XCTestCase {
         )
         XCTAssertEqual(ordered.layers[0].keyBytes, materialized.layers[0].keyBytes)
         XCTAssertEqual(ordered.layers[0].valueBytes, materialized.layers[0].valueBytes)
+    }
+
+    func testAllocatorBindingCarriesReservedPhysicalOrderForRuntimeCaches() async throws {
+        let allocator = try PagedKVBlockAllocator(
+            blockSizeTokens: 4,
+            maxPhysicalBlocks: 6,
+            physicalBlockOrder: [3, 1, 4, 0, 2, 5]
+        )
+        let handle = try await allocator.allocate(conversationKey: "conv:binding", maxTokens: 12)
+        let binding = try await allocator.binding(for: handle)
+        XCTAssertEqual(binding.currentTable.physicalBlocks, [])
+        XCTAssertEqual(binding.reservedPhysicalBlocks, [3, 1, 4])
+    }
+
+    func testRetainedByteLifecycleCanTrimAfterSameConversationReattach() async throws {
+        let allocator = try PagedKVBlockAllocator(
+            blockSizeTokens: 4,
+            maxPhysicalBlocks: 4,
+            physicalBlockOrder: [2, 0, 3, 1]
+        )
+        let handle = try await allocator.allocate(conversationKey: "conv:bytes", maxTokens: 12, initialTokens: 7)
+        let retained = try await allocator.retain(handle)
+        let reattached = try await allocator.reattach(retained, conversationKey: "conv:bytes")
+        let trimmed = try await allocator.trim(reattached, toLogicalTokens: 5)
+        XCTAssertEqual(trimmed.logicalTokenCount, 5)
+        XCTAssertEqual(trimmed.physicalBlocks, [2, 0])
+        XCTAssertEqual(trimmed.tailValidTokenCount, 1)
     }
 
     func testContiguousBridgeMaterializesValidEmptySequence() async throws {

--- a/phase3-binary/Tests/macprovider-cliTests/KVConversationColdTierTests.swift
+++ b/phase3-binary/Tests/macprovider-cliTests/KVConversationColdTierTests.swift
@@ -774,7 +774,7 @@ final class KVConversationColdTierTests: XCTestCase {
             "non-eligible params must select RotatingKVCache")
     }
 
-    func testPagedKVCacheClassProbeUsesUnforcedServeParameters() {
+    func testPagedKVCacheClassProbeUsesPagedCacheParameters() {
         let model = FakeDimensionModel(layers: 3)
         let base = GenerateParameters(
             maxTokens: 128, maxKVSize: 4096, kvBits: nil,
@@ -784,7 +784,8 @@ final class KVConversationColdTierTests: XCTestCase {
         XCTAssertNotNil(forced as? [KVCacheSimple])
 
         let observed = ModelRuntime.pagedKVRuntimeCacheClass(model: model, baseParameters: base)
-        XCTAssertEqual(observed, "RotatingKVCache")
+        XCTAssertEqual(observed, "KVCacheSimple",
+            "paged capability probing must use the actual paged KV cache contract")
     }
 
     func testPagedKVCacheSeamRegistersKernelWithoutExecutingMetal() async throws {
@@ -804,6 +805,14 @@ final class KVConversationColdTierTests: XCTestCase {
             blockSizeTokens: 2,
             maxPhysicalBlocks: 4,
             maxResidentTokens: 8,
+            sizingModelClass: PagedKVHardwareSizingProof.requiredSizingModelClass,
+            unifiedMemoryGB: 32,
+            modelWeightsGB: 20,
+            perRequestActivationGB: 4,
+            pagedBlockPoolGB: 4,
+            kvBytesPerToken: 1_024,
+            measuredGatherOverheadPercent: 2,
+            gatherOverheadCeilingPercent: 10,
             parityLabel: "sdpa-parity-v1"
         )
         let decision = PagedKVAttachGate.decide(
@@ -826,10 +835,15 @@ final class KVConversationColdTierTests: XCTestCase {
                 observedMetallibSHA256: proof.metallibSHA256,
                 observedKernelIdentifier: proof.kernelIdentifier,
                 observedParityLabel: proof.parityLabel,
+                observedPoolEpoch: proof.poolEpoch,
                 engineBridgeAvailable: true
             )
         )
         let descriptor = try XCTUnwrap(decision.descriptor)
+        let diagnostic = ModelRuntime.pagedKVAttachDiagnosticLine(decision, sizingProof: proof)
+        XCTAssertTrue(diagnostic.contains("unified_memory_gb=32"))
+        XCTAssertTrue(diagnostic.contains("paged_block_pool_gb=4.0"))
+        XCTAssertTrue(diagnostic.contains("measured_gather_overhead_percent=2.0"))
         let allocator = try PagedKVBlockAllocator(blockSizeTokens: 2, maxPhysicalBlocks: 4)
         let handle = try await allocator.allocate(conversationKey: "conv:paged", maxTokens: 8, initialTokens: 0)
         let binding = try await allocator.binding(for: handle)

--- a/phase3-binary/Tests/macprovider-cliTests/PagedKVParityTests.swift
+++ b/phase3-binary/Tests/macprovider-cliTests/PagedKVParityTests.swift
@@ -37,6 +37,22 @@ final class PagedKVParityTests: XCTestCase {
     private static let nNew = 40
     private static let prompt = "Explain in one paragraph why the sky appears blue during the day."
 
+    private func requireMLXMetalLibrary() throws {
+        let binaryURL = URL(fileURLWithPath: CommandLine.arguments[0])
+        let binaryDirectory = binaryURL.deletingLastPathComponent()
+        let candidates = [
+            binaryDirectory.appendingPathComponent("mlx.metallib"),
+            binaryDirectory.appendingPathComponent("default.metallib"),
+            binaryDirectory.appendingPathComponent("Resources/mlx.metallib"),
+            binaryDirectory.appendingPathComponent("Resources/default.metallib"),
+            binaryDirectory.appendingPathComponent("mlx-swift_Cmlx.bundle/default.metallib"),
+            binaryDirectory.appendingPathComponent("Contents/Resources/mlx-swift_Cmlx.bundle/default.metallib"),
+        ]
+        guard candidates.contains(where: { FileManager.default.fileExists(atPath: $0.path) }) else {
+            throw XCTSkip("MLX default metallib is not present in the test bundle")
+        }
+    }
+
     private func findSnapshotDir(_ modelName: String) -> String? {
         let base = ("~/.cache/huggingface/hub/models--mlx-community--\(modelName)/snapshots"
             as NSString).expandingTildeInPath
@@ -81,9 +97,8 @@ final class PagedKVParityTests: XCTestCase {
         return a.count == b.count ? nil : min(a.count, b.count)
     }
 
-    /// Generous descriptor/binding: metadata only (SPEC-038-facing surface). `update()`
-    /// holds K/V in-tensor and never touches the allocator, so a single value-type binding
-    /// is reused for every layer.
+    /// Generous descriptor/binding using an allocator-issued non-identity physical
+    /// order so the parity run exercises the real block-table mapping.
     private func makePagedCacheFactory(modelName: String, nLayers: Int) async throws -> () -> [KVCache] {
         let maxBlocks = 512
         let descriptor = PagedKVDescriptor(
@@ -97,7 +112,12 @@ final class PagedKVParityTests: XCTestCase {
             kernelIdentifier: PagedKVGatherKernel.registeredKernelName,
             parityLabel: "sdpa-parity-v1"
         )
-        let allocator = try PagedKVBlockAllocator(blockSizeTokens: Self.blockSize, maxPhysicalBlocks: maxBlocks)
+        let physicalOrder = [1, 0] + Array(2 ..< maxBlocks)
+        let allocator = try PagedKVBlockAllocator(
+            blockSizeTokens: Self.blockSize,
+            maxPhysicalBlocks: maxBlocks,
+            physicalBlockOrder: physicalOrder
+        )
         let handle = try await allocator.allocate(
             conversationKey: "parity-\(modelName)",
             maxTokens: Self.blockSize * maxBlocks,
@@ -105,6 +125,38 @@ final class PagedKVParityTests: XCTestCase {
         )
         let binding = try await allocator.binding(for: handle)
         return { (0 ..< nLayers).map { _ in PagedKVCache(descriptor: descriptor, binding: binding) } }
+    }
+
+    func testPagedKVCacheCopyPreservesLatchedInvariantFailure() async throws {
+        try requireMLXMetalLibrary()
+        let descriptor = PagedKVDescriptor(
+            blockSizeTokens: 4,
+            maxPhysicalBlocks: 4,
+            modelID: "copy-invariant-test",
+            modelSHA256: String(repeating: "0", count: 64),
+            supportedModelFamilies: ["qwen"],
+            supportsMoEDispatch: false,
+            metallibSHA256: String(repeating: "0", count: 64),
+            kernelIdentifier: PagedKVGatherKernel.registeredKernelName,
+            parityLabel: "copy-test"
+        )
+        let allocator = try PagedKVBlockAllocator(
+            blockSizeTokens: 4,
+            maxPhysicalBlocks: 4,
+            physicalBlockOrder: [1, 0, 2, 3]
+        )
+        let handle = try await allocator.allocate(
+            conversationKey: "copy-invariant-test",
+            maxTokens: 16
+        )
+        let binding = try await allocator.binding(for: handle)
+        let cache = PagedKVCache(descriptor: descriptor, binding: binding)
+        let invalid = MLXArray([Float32(0)]).reshaped([1, 1, 1, 1])
+        _ = cache.update(keys: invalid, values: invalid)
+        let failure = try XCTUnwrap(cache.invariantFailure)
+
+        let copied = try XCTUnwrap(cache.copy() as? PagedKVCache)
+        XCTAssertEqual(copied.invariantFailure, failure)
     }
 
     private struct ParityOutcome {

--- a/phase3-binary/Tests/macprovider-cliTests/PagedKVRuntimeBridgeTests.swift
+++ b/phase3-binary/Tests/macprovider-cliTests/PagedKVRuntimeBridgeTests.swift
@@ -1,0 +1,303 @@
+import Foundation
+import MLX
+import MLXLMCommon
+import XCTest
+
+@testable import MacProviderCore
+@testable import macprovider_cli
+
+final class PagedKVRuntimeBridgeTests: XCTestCase {
+    private func requireMLXMetalLibrary() throws {
+        let binaryURL = URL(fileURLWithPath: CommandLine.arguments[0])
+        let binaryDirectory = binaryURL.deletingLastPathComponent()
+        let candidates = [
+            binaryDirectory.appendingPathComponent("mlx.metallib"),
+            binaryDirectory.appendingPathComponent("default.metallib"),
+            binaryDirectory.appendingPathComponent("Resources/mlx.metallib"),
+            binaryDirectory.appendingPathComponent("Resources/default.metallib"),
+            binaryDirectory.appendingPathComponent("mlx-swift_Cmlx.bundle/default.metallib"),
+            binaryDirectory.appendingPathComponent("Contents/Resources/mlx-swift_Cmlx.bundle/default.metallib"),
+        ]
+        guard candidates.contains(where: { FileManager.default.fileExists(atPath: $0.path) }) else {
+            throw XCTSkip("MLX default metallib is not present in the test bundle")
+        }
+    }
+
+    private let modelID = "mlx-community/Qwen-Bridge-Test"
+    private let modelHash = String(repeating: "a", count: 64)
+    private let tokenizerHash = String(repeating: "b", count: 64)
+    private let templateHash = String(repeating: "c", count: 64)
+    private let metallibHash = String(repeating: "d", count: 64)
+
+    private func config() -> PagedKVConfig {
+        PagedKVConfig(enabled: true, blockSizeTokens: 4, maxPhysicalBlocks: 4)
+    }
+
+    private func observation(
+        parityLabel: String = "sdpa-parity-v1",
+        poolEpoch: Int = 1
+    ) -> PagedKVRuntimeObservation {
+        let proof = PagedKVHardwareSizingProof(
+            modelID: modelID,
+            modelSHA256: modelHash,
+            tokenizerSHA256: tokenizerHash,
+            chatTemplateSHA256: templateHash,
+            modelFamily: "qwen",
+            hardwareClass: "apple-silicon-test",
+            metallibSHA256: metallibHash,
+            kernelIdentifier: PagedKVGatherKernel.registeredKernelName,
+            blockSizeTokens: 4,
+            maxPhysicalBlocks: 4,
+            maxResidentTokens: 16,
+            poolEpoch: poolEpoch,
+            parityLabel: parityLabel
+        )
+        return PagedKVRuntimeObservation(
+            modelID: modelID,
+            modelSHA256: modelHash,
+            tokenizerSHA256: tokenizerHash,
+            chatTemplateSHA256: templateHash,
+            modelFamily: "qwen",
+            cacheClass: "KVCacheSimple",
+            requiresMoEDispatch: false,
+            hardwareClass: "apple-silicon-test",
+            metallibSHA256: metallibHash,
+            kernelIdentifier: PagedKVGatherKernel.registeredKernelName,
+            parityLabel: parityLabel,
+            poolEpoch: poolEpoch,
+            metallibAvailable: true,
+            kernelRegistered: true,
+            parityEstablished: true,
+            hardwareSizingProof: proof,
+            moeDispatchProven: false
+        )
+    }
+
+    private func descriptor(for observation: PagedKVRuntimeObservation) throws -> PagedKVDescriptor {
+        let decision = PagedKVAttachGate.decide(
+            config: config(),
+            runtimeCacheClass: observation.cacheClass,
+            kvBits: nil,
+            modelID: observation.modelID,
+            modelSHA256: observation.modelSHA256,
+            tokenizerSHA256: observation.tokenizerSHA256,
+            chatTemplateSHA256: observation.chatTemplateSHA256,
+            modelFamily: observation.modelFamily,
+            requiresMoEDispatch: observation.requiresMoEDispatch,
+            gates: observation.gates(config: config(), bridgeAvailable: true)
+        )
+        return try XCTUnwrap(decision.descriptor)
+    }
+
+    private func fp16Bytes(_ values: [Float16]) -> Data {
+        values.withUnsafeBytes { Data($0) }
+    }
+
+    func testObservedIdentityIsRequiredForAttachAndBatchCapability() async throws {
+        let good = observation()
+        let bad = observation(parityLabel: "unproven")
+        let trustedDescriptor = try descriptor(for: good)
+        XCTAssertTrue(good.matches(config: config()))
+        XCTAssertTrue(bad.matches(config: config()))
+        XCTAssertTrue(bad.gates(config: config(), bridgeAvailable: true).engineBridgeAvailable)
+
+        let badDecision = PagedKVAttachGate.decide(
+            config: config(),
+            runtimeCacheClass: bad.cacheClass,
+            kvBits: nil,
+            modelID: bad.modelID,
+            modelSHA256: bad.modelSHA256,
+            tokenizerSHA256: bad.tokenizerSHA256,
+            chatTemplateSHA256: bad.chatTemplateSHA256,
+            modelFamily: bad.modelFamily,
+            requiresMoEDispatch: bad.requiresMoEDispatch,
+            gates: bad.gates(config: config(), bridgeAvailable: true)
+        )
+        XCTAssertNotEqual(badDecision.descriptor, trustedDescriptor)
+
+        struct NoopDriver: PagedKVSharedForwardDriver {
+            func prefill(rows: [ContinuousBatchPrefillInput]) async throws -> [ContinuousBatchPrefillOutput] {
+                rows.map { ContinuousBatchPrefillOutput(requestID: $0.requestID) }
+            }
+
+            func decode(
+                batch: PagedKVSharedForwardBatch,
+                rows: [ContinuousBatchDecodeInput]
+            ) async throws -> [ContinuousBatchDecodeOutcome] {
+                XCTAssertEqual(batch.shape, [rows.count, 1])
+                return rows.map {
+                    .output(ContinuousBatchDecodeOutput(requestID: $0.requestID, token: $0.currentToken))
+                }
+            }
+
+            func cancelInFlight() async {}
+        }
+
+        let mismatchedRuntime = ModelRuntime(
+            modelID: bad.modelID,
+            modelHash: bad.modelSHA256,
+            pagedKVConfig: config(),
+            maxBatch: 2,
+            continuousBatchingMode: .canary,
+            pagedKVRuntimeObservation: bad,
+            pagedKVTrustedDescriptor: trustedDescriptor,
+            pagedKVSharedForwardDriver: NoopDriver(),
+            warmSwapEnabled: false,
+            loader: { _ in throw NSError(domain: "test", code: 1) }
+        )
+        let mismatchDecision = await mismatchedRuntime.pagedKVDecisionForTest()
+        XCTAssertNil(mismatchDecision.descriptor)
+
+        let untrustedRuntime = ModelRuntime(
+            modelID: good.modelID,
+            modelHash: good.modelSHA256,
+            pagedKVConfig: config(),
+            maxBatch: 2,
+            continuousBatchingMode: .canary,
+            pagedKVRuntimeObservation: good,
+            pagedKVSharedForwardDriver: NoopDriver(),
+            warmSwapEnabled: false,
+            loader: { _ in throw NSError(domain: "test", code: 1) }
+        )
+        let untrustedDecision = await untrustedRuntime.pagedKVDecisionForTest()
+        XCTAssertNil(untrustedDecision.descriptor)
+
+        let runtime = ModelRuntime(
+            modelID: good.modelID,
+            modelHash: good.modelSHA256,
+            pagedKVConfig: config(),
+            maxBatch: 2,
+            continuousBatchingMode: .canary,
+            pagedKVRuntimeObservation: good,
+            pagedKVTrustedDescriptor: trustedDescriptor,
+            pagedKVSharedForwardDriver: NoopDriver(),
+            warmSwapEnabled: false,
+            loader: { _ in throw NSError(domain: "test", code: 1) }
+        )
+        let capability = await runtime.continuousBatchingCapabilityForTest()
+        XCTAssertNotNil(capability.descriptor)
+        XCTAssertNil(capability.unsupportedReason)
+
+        let serialOnlyRuntime = ModelRuntime(
+            modelID: good.modelID,
+            modelHash: good.modelSHA256,
+            pagedKVConfig: config(),
+            maxBatch: 2,
+            continuousBatchingMode: .canary,
+            pagedKVRuntimeObservation: good,
+            pagedKVTrustedDescriptor: trustedDescriptor,
+            warmSwapEnabled: false,
+            loader: { _ in throw NSError(domain: "test", code: 1) }
+        )
+        let serialCapability = await serialOnlyRuntime.continuousBatchingCapabilityForTest()
+        XCTAssertEqual(serialCapability.unsupportedReason, .localCapabilityUnavailable)
+    }
+
+    func testLiveContiguousRoundTripRetainReattachAndTrimMidBlock() async throws {
+        try requireMLXMetalLibrary()
+        let observation = observation()
+        let descriptor = try descriptor(for: observation)
+        let bridge = try PagedKVRuntimeBridge(
+            config: config(), observation: observation, descriptor: descriptor
+        )
+        let attachment = try await bridge.reserve(
+            requestID: "bridge-test",
+            maxTokens: 16
+        )
+        let layers = try attachment.makeCacheLayers(count: 1)
+
+        let shape = [1, 1, 7, 2]
+        let keyValues = (0 ..< 14).map { Float16($0 + 1) }
+        let valueValues = (0 ..< 14).map { Float16(100 + $0) }
+        let source = PagedKVMaterializedByteLayer(
+            layerIndex: 0,
+            keyShape: shape,
+            valueShape: shape,
+            dtype: .fp16,
+            logicalTokenCount: 7,
+            keyBytes: fp16Bytes(keyValues),
+            valueBytes: fp16Bytes(valueValues)
+        )
+        try layers[0].inject(materialized: source)
+
+        let snapshot = try await attachment.checkpoint()
+        XCTAssertEqual(snapshot.blockTable.logicalTokenCount, 7)
+        XCTAssertEqual(snapshot.blockTable.tailValidTokenCount, 3)
+        let contiguous = try await bridge.materializeContiguousKVCache(handle: attachment.handle)
+        let contiguousState = try XCTUnwrap(contiguous.first?.state)
+        XCTAssertEqual(contiguous.first?.offset, 7)
+        XCTAssertEqual(contiguousState[0].asData().data, source.keyBytes)
+        XCTAssertEqual(contiguousState[1].asData().data, source.valueBytes)
+
+        let retained = try await attachment.retain()
+        let (reattached, reattachedLayers) = try await bridge.reattach(
+            retained,
+            conversationKey: "bridge-test",
+            layerCount: 1
+        )
+        XCTAssertEqual(reattachedLayers[0].offset, 7)
+
+        // Trim two tokens from a seven-token sequence: the allocator and live
+        // KVCache must agree on the five-token mid-block boundary.
+        XCTAssertEqual(reattachedLayers[0].trim(2), 2)
+        let trimmed = try await reattached.checkpoint()
+        XCTAssertEqual(trimmed.blockTable.logicalTokenCount, 5)
+        XCTAssertEqual(trimmed.blockTable.tailValidTokenCount, 1)
+        XCTAssertEqual(trimmed.layers[0].keyShape[2], 5)
+        XCTAssertEqual(trimmed.layers[0].keyBytes.count, 5 * 2 * MemoryLayout<Float16>.size)
+
+        try await reattached.release()
+    }
+
+    func testSharedForwardBackendCarriesOneTokenPerActiveRow() async throws {
+        struct Recorder: PagedKVSharedForwardDriver {
+            func prefill(rows: [ContinuousBatchPrefillInput]) async throws -> [ContinuousBatchPrefillOutput] { [] }
+
+            func decode(
+                batch: PagedKVSharedForwardBatch,
+                rows: [ContinuousBatchDecodeInput]
+            ) async throws -> [ContinuousBatchDecodeOutcome] {
+                XCTAssertEqual(batch.tokens, rows.map(\.currentToken))
+                XCTAssertEqual(batch.shape, [2, 1])
+                return rows.map {
+                    .output(ContinuousBatchDecodeOutput(requestID: $0.requestID, token: $0.currentToken))
+                }
+            }
+
+            func cancelInFlight() async {}
+        }
+
+        let handle = PagedKVBlockTableHandle(id: UUID(), conversationKey: "batch", poolEpoch: 1)
+        let table = PagedKVBlockTable(
+            handleID: handle.handleID,
+            blockSizeTokens: 4,
+            logicalTokenCount: 1,
+            physicalBlocks: [0],
+            tailValidTokenCount: 1,
+            poolEpoch: 1
+        )
+        let binding = PagedKVStorageBinding(
+            handle: handle,
+            blockSizeTokens: 4,
+            maxLogicalTokens: 8,
+            currentTable: table,
+            poolEpoch: 1
+        )
+        let rows = [
+            ContinuousBatchDecodeInput(
+                requestID: "a", currentToken: 11, generatedTokens: [], promptTokens: [1],
+                samplerSeed: 0, temperature: 0, topP: 1, presencePenalty: 0, frequencyPenalty: 0,
+                blockTable: table, committedKVTokenCount: 1, targetKVTokenCount: 2, samplerStep: 0
+            ),
+            ContinuousBatchDecodeInput(
+                requestID: "b", currentToken: 22, generatedTokens: [], promptTokens: [2],
+                samplerSeed: 0, temperature: 0, topP: 1, presencePenalty: 0, frequencyPenalty: 0,
+                blockTable: table, committedKVTokenCount: 1, targetKVTokenCount: 2, samplerStep: 0
+            ),
+        ]
+        let backend = PagedKVSharedForwardBackend(driver: Recorder())
+        let outcomes = try await backend.decode(rows: rows)
+        XCTAssertEqual(outcomes.count, 2)
+        _ = binding
+    }
+}

--- a/phase3-binary/Tests/macprovider-cliTests/PagedKVRuntimeBridgeTests.swift
+++ b/phase3-binary/Tests/macprovider-cliTests/PagedKVRuntimeBridgeTests.swift
@@ -49,6 +49,14 @@ final class PagedKVRuntimeBridgeTests: XCTestCase {
             blockSizeTokens: 4,
             maxPhysicalBlocks: 4,
             maxResidentTokens: 16,
+            sizingModelClass: PagedKVHardwareSizingProof.requiredSizingModelClass,
+            unifiedMemoryGB: 32,
+            modelWeightsGB: 20,
+            perRequestActivationGB: 4,
+            pagedBlockPoolGB: 4,
+            kvBytesPerToken: 1_024,
+            measuredGatherOverheadPercent: 2,
+            gatherOverheadCeilingPercent: 10,
             poolEpoch: poolEpoch,
             parityLabel: parityLabel
         )

--- a/phase3-binary/Tests/macprovider-cliTests/ServingKnobsConfigTests.swift
+++ b/phase3-binary/Tests/macprovider-cliTests/ServingKnobsConfigTests.swift
@@ -369,8 +369,8 @@ final class ServingKnobsConfigTests: XCTestCase {
         let proof = PagedKVHardwareSizingProof(
             modelID: "mlx-community/Qwen-Test",
             modelSHA256: String(repeating: "a", count: 64),
-            tokenizerSHA256: nil,
-            chatTemplateSHA256: nil,
+            tokenizerSHA256: String(repeating: "c", count: 64),
+            chatTemplateSHA256: String(repeating: "d", count: 64),
             modelFamily: "qwen",
             hardwareClass: "apple-silicon-test",
             metallibSHA256: String(repeating: "b", count: 64),
@@ -378,6 +378,14 @@ final class ServingKnobsConfigTests: XCTestCase {
             blockSizeTokens: 32,
             maxPhysicalBlocks: 64,
             maxResidentTokens: 2048,
+            sizingModelClass: PagedKVHardwareSizingProof.requiredSizingModelClass,
+            unifiedMemoryGB: 32,
+            modelWeightsGB: 20,
+            perRequestActivationGB: 4,
+            pagedBlockPoolGB: 4,
+            kvBytesPerToken: 1_024,
+            measuredGatherOverheadPercent: 2,
+            gatherOverheadCeilingPercent: 10,
             parityLabel: "sdpa-parity-v1"
         )
         let decision = PagedKVAttachGate.decide(
@@ -386,8 +394,8 @@ final class ServingKnobsConfigTests: XCTestCase {
             kvBits: nil,
             modelID: proof.modelID,
             modelSHA256: proof.modelSHA256,
-            tokenizerSHA256: nil,
-            chatTemplateSHA256: nil,
+            tokenizerSHA256: String(repeating: "c", count: 64),
+            chatTemplateSHA256: String(repeating: "d", count: 64),
             modelFamily: "qwen",
             requiresMoEDispatch: false,
             gates: PagedKVGates(
@@ -400,6 +408,7 @@ final class ServingKnobsConfigTests: XCTestCase {
                 observedMetallibSHA256: proof.metallibSHA256,
                 observedKernelIdentifier: proof.kernelIdentifier,
                 observedParityLabel: proof.parityLabel,
+                observedPoolEpoch: proof.poolEpoch,
                 engineBridgeAvailable: true
             )
         )
@@ -923,7 +932,7 @@ final class ServingKnobsConfigTests: XCTestCase {
             loader: { _ in throw TestRuntimeError.notExpected }
         )
         let decision = await runtime.pagedKVDecisionForTest()
-        XCTAssertEqual(decision, .fallback(.metallib))
+        XCTAssertEqual(decision, .fallback(.identity))
     }
 
     func testRuntimeStrictPagedKVRejectsBeforeCompletionRuns() async throws {


### PR DESCRIPTION
## SPEC-039 Phase-2 runtime bridge + FR-PKV10 (#887) — revision, supersedes #889

Revision of the SPEC-039 Phase-2 bridge after an independent 3-lane audit of the first cut (#889) found 1 CRITICAL + ~5 HIGH + ~4 MEDIUM (self-asserted provenance, unproven FR-CB6 parity overclaim, attach-path lifecycle bugs). This revision hardens the trust model (trusted-descriptor gate), reworks paged gather/remapping + lifecycle preflight + allocator health/rollback, and expands tests.

**Safety posture:** production never constructs a runtime observation → fail-closed → `schedulerBackendAvailable`/`engineBridgeAvailable` stay false → runtime-inert. Attach requires an observed-identity match against a trusted descriptor. Real FR-CB6 parity remains a >32GB-Mac enable-gate item.

Opened for CI + independent audit. Default-off / inert on merge.

SPEC-GOVERNANCE-DECLARATION-BEGIN
{
  "schema_version": "spec-pr-governance-v1",
  "behavior_change": "yes",
  "contract_change": "none",
  "specs": ["SPEC-039"],
  "requirements": ["SPEC-039-R010"],
  "authority_domains": ["paged-kv-attention"],
  "arbitration": ["CODE_BUG"],
  "tests": ["swift test --filter PagedKVRuntimeBridgeTests", "swift test --filter PagedKVEngineTests"],
  "journeys": ["not-required"]
}
SPEC-GOVERNANCE-DECLARATION-END
