### PR TITLE
Require signed journey-result proof before sensitive promotion

### DIFF
--- a/schemas/journey-result-v1.schema.json
+++ b/schemas/journey-result-v1.schema.json
@@ -1,0 +1,148 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/Augustas11/macprovider/schemas/journey-result-v1.schema.json",
+  "title": "Macprovider signed journey-result envelope",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema_version", "signatures", "signed"],
+  "properties": {
+    "schema_version": {"const": "macprovider.journey-result-envelope.v1"},
+    "signatures": {
+      "type": "array",
+      "minItems": 1,
+      "items": {"$ref": "#/$defs/signature"}
+    },
+    "signed": {"$ref": "#/$defs/signed"}
+  },
+  "$defs": {
+    "signature": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["algorithm", "key_id", "signature", "signed_sha256", "verified_at", "verifier"],
+      "properties": {
+        "algorithm": {"const": "ecdsa-p256-sha256"},
+        "key_id": {"const": "macprovider-acceptance-p256-v1"},
+        "signature": {"type": "string", "pattern": "^[A-Za-z0-9+/]+={0,2}$"},
+        "signed_sha256": {"type": "string", "pattern": "^[0-9a-f]{64}$"},
+        "verified_at": {
+          "type": "string",
+          "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$"
+        },
+        "verifier": {"type": "string", "minLength": 1}
+      }
+    },
+    "signed": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "schema_version",
+        "journey_id",
+        "requirement_ids",
+        "repository",
+        "captured_at",
+        "expires_at",
+        "operator",
+        "environment",
+        "artifacts",
+        "result",
+        "steps",
+        "redaction"
+      ],
+      "properties": {
+        "schema_version": {"const": "macprovider.journey-result.v1"},
+        "journey_id": {"type": "string", "pattern": "^JOURNEY-[A-Z0-9]+(?:-[A-Z0-9]+)*$"},
+        "requirement_ids": {
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": {"type": "string", "pattern": "^SPEC-[0-9]{3}-R[0-9]{3}$"}
+        },
+        "repository": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["name", "commit"],
+          "properties": {
+            "name": {"const": "Augustas11/macprovider"},
+            "commit": {"type": "string", "pattern": "^[0-9a-f]{40}$"}
+          }
+        },
+        "captured_at": {
+          "type": "string",
+          "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$"
+        },
+        "expires_at": {"type": "string", "format": "date"},
+        "operator": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["role", "identity_fingerprint"],
+          "properties": {
+            "role": {"type": "string", "minLength": 1},
+            "identity_fingerprint": {"type": "string", "pattern": "^[0-9a-f]{64}$"}
+          }
+        },
+        "environment": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["class", "hardware_profile", "candidate"],
+          "properties": {
+            "class": {"type": "string", "minLength": 1},
+            "hardware_profile": {"type": "string", "minLength": 1},
+            "candidate": {"type": "string", "minLength": 1}
+          }
+        },
+        "artifacts": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["id", "sha256", "source"],
+            "properties": {
+              "id": {"type": "string", "minLength": 1},
+              "sha256": {"type": "string", "pattern": "^[0-9a-f]{64}$"},
+              "source": {"type": "string", "pattern": "^journeys/evidence/.+"}
+            }
+          }
+        },
+        "result": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["status"],
+          "properties": {
+            "status": {"const": "pass"},
+            "summary": {"type": "string", "minLength": 1}
+          }
+        },
+        "steps": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["id", "status", "artifacts"],
+            "properties": {
+              "id": {"type": "string", "minLength": 1},
+              "status": {"const": "pass"},
+              "assertion": {"type": "string", "minLength": 1},
+              "artifacts": {
+                "type": "array",
+                "minItems": 1,
+                "items": {"type": "string", "minLength": 1}
+              }
+            }
+          }
+        },
+        "redaction": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["secrets_redacted", "operator_identity_redacted", "local_account_names_redacted"],
+          "properties": {
+            "secrets_redacted": {"const": true},
+            "operator_identity_redacted": {"const": true},
+            "local_account_names_redacted": {"const": true}
+          }
+        }
+      }
+    }
+  }
+}

--- a/scripts/check_spec_governance.py
+++ b/scripts/check_spec_governance.py
@@ -10,19 +10,29 @@ meaning from rendered prose.
 from __future__ import annotations
 
 import argparse
+import base64
 import hashlib
 import json
 import re
 import subprocess
 import sys
+import tempfile
 from dataclasses import dataclass, field
-from datetime import date
+from datetime import date, datetime, timezone
 from pathlib import Path
 from typing import Any
 
 
 AUTHORITY_SCHEMA_PATH = "../schemas/spec-authority-v1.schema.json"
 CONFORMANCE_SCHEMA_PATH = "../schemas/spec-conformance-v1.schema.json"
+JOURNEY_RESULT_SCHEMA_ID = "https://github.com/Augustas11/macprovider/schemas/journey-result-v1.schema.json"
+JOURNEY_RESULT_ENVELOPE_SCHEMA = "macprovider.journey-result-envelope.v1"
+JOURNEY_RESULT_PAYLOAD_SCHEMA = "macprovider.journey-result.v1"
+JOURNEY_RESULT_SIGNING_ALGORITHM = "ecdsa-p256-sha256"
+JOURNEY_RESULT_SIGNING_KEY_ID = "macprovider-acceptance-p256-v1"
+JOURNEY_RESULT_SIGNING_DOMAIN = b"macprovider.journey-result.v1\n"
+JOURNEY_RESULT_PUBLIC_KEY_PATH = "security/acceptance-candidate-signing-public.pem"
+JOURNEY_RESULT_PUBLIC_KEY_SHA256 = "849e9c9bc53db1fb8e28d3b46ab431089b12cb50b398c5317ced682d39bdbd38"
 SPEC_ID_RE = re.compile(r"^SPEC-\d{3}$")
 SPEC_PATH_RE = re.compile(r"^specs/SPEC-\d{3}-[a-z0-9-]+\.md$")
 REQUIREMENT_ID_RE = re.compile(r"^(SPEC-\d{3})-R\d{3}$")
@@ -32,7 +42,9 @@ ISSUE_RE = re.compile(r"^https://github\.com/Augustas11/macprovider/issues/\d+$"
 COMMIT_RE = re.compile(r"^[0-9a-f]{40}$")
 ARTIFACT_RE = re.compile(r"^(?:commit:[0-9a-f]{40}|sha256:[0-9a-f]{64})$")
 SHA256_RE = re.compile(r"^sha256:([0-9a-f]{64})$")
+SHA256_HEX_RE = re.compile(r"^[0-9a-f]{64}$")
 JOURNEY_RE = re.compile(r"^JOURNEY-[A-Z0-9]+(?:-[A-Z0-9]+)*$")
+DATETIME_Z_RE = re.compile(r"^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$")
 TITLE_RE = re.compile(r"^#\s+(SPEC-\d{3})\s*[—–:-]\s*(.+)$")
 VERSION_RE = re.compile(r"^Version\s*:\s*(\S+)", re.IGNORECASE)
 STATUS_VERSION_RE = re.compile(r"^Status\b.*?\b(v?\d+\.\d+(?:\.\d+)?)", re.IGNORECASE)
@@ -183,6 +195,16 @@ def _date(value: Any, location: str, result: ValidationResult) -> date | None:
         return None
 
 
+def _datetime_z(value: Any, location: str, result: ValidationResult) -> datetime | None:
+    if not isinstance(value, str) or not DATETIME_Z_RE.fullmatch(value):
+        result.error(location, "must be an ISO UTC timestamp like 2026-08-04T12:34:56Z")
+        return None
+    parsed = datetime.strptime(value, "%Y-%m-%dT%H:%M:%SZ").replace(tzinfo=timezone.utc)
+    if parsed > datetime.now(timezone.utc):
+        result.error(location, f"timestamp is in the future: {value}")
+    return parsed
+
+
 def _validate_baseline(value: Any, location: str, result: ValidationResult) -> None:
     if not _expect_object(value, location, result):
         return
@@ -309,6 +331,362 @@ def _source_under_journey_evidence(root: Path, source: str) -> bool:
     except (OSError, ValueError):
         return False
     return True
+
+
+def _canonical_json_sha256(value: Any) -> str:
+    return hashlib.sha256(_canonical_json_bytes(value)).hexdigest()
+
+
+def _canonical_json_bytes(value: Any) -> bytes:
+    return (json.dumps(value, sort_keys=True, separators=(",", ":")) + "\n").encode("utf-8")
+
+
+def _reachable_commit(root: Path, commit: str) -> bool:
+    return subprocess.run(
+        ["git", "cat-file", "-e", f"{commit}^{{commit}}"],
+        cwd=root,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    ).returncode == 0
+
+
+def _looks_like_signed_journey_result(root: Path, source: str) -> bool:
+    path = _repository_path(root, source, source, ValidationResult())
+    if path is None:
+        return False
+    probe = _load_json(path, ValidationResult())
+    return isinstance(probe, dict) and probe.get("schema_version") == JOURNEY_RESULT_ENVELOPE_SCHEMA
+
+
+def _verify_journey_result_signature(
+    root: Path,
+    signed: dict[str, Any],
+    signature: dict[str, Any],
+    trusted_public_key_sha256: str,
+    location: str,
+    result: ValidationResult,
+) -> bool:
+    if signature.get("algorithm") != JOURNEY_RESULT_SIGNING_ALGORITHM:
+        result.error(f"{location}.algorithm", f"must equal {JOURNEY_RESULT_SIGNING_ALGORITHM!r}")
+    if signature.get("key_id") != JOURNEY_RESULT_SIGNING_KEY_ID:
+        result.error(f"{location}.key_id", f"must equal {JOURNEY_RESULT_SIGNING_KEY_ID!r}")
+    encoded = signature.get("signature")
+    if not isinstance(encoded, str) or not encoded:
+        result.error(f"{location}.signature", "must be a non-empty base64 DER ECDSA signature")
+        return False
+    try:
+        signature_bytes = base64.b64decode(encoded.encode("ascii"), validate=True)
+    except (UnicodeEncodeError, ValueError) as exc:
+        result.error(f"{location}.signature", f"invalid base64: {exc}")
+        return False
+    if base64.b64encode(signature_bytes).decode("ascii") != encoded:
+        result.error(f"{location}.signature", "must use canonical base64 encoding")
+        return False
+    if not 64 <= len(signature_bytes) <= 80:
+        result.error(f"{location}.signature", "invalid P-256 DER signature length")
+        return False
+    public_key = root / JOURNEY_RESULT_PUBLIC_KEY_PATH
+    if not public_key.exists():
+        result.error(location, f"trusted public key missing: {JOURNEY_RESULT_PUBLIC_KEY_PATH}")
+        return False
+    try:
+        public_key_bytes = public_key.read_bytes()
+    except OSError as exc:
+        result.error(location, f"cannot read trusted public key: {exc}")
+        return False
+    public_key_sha256 = hashlib.sha256(public_key_bytes).hexdigest()
+    if public_key_sha256 != trusted_public_key_sha256:
+        result.error(location, "trusted public key does not match pinned journey-result trust anchor")
+        return False
+    with tempfile.TemporaryDirectory(prefix="journey-result-verify.") as directory:
+        tmp = Path(directory)
+        message = tmp / "message"
+        signature_path = tmp / "signature.der"
+        message.write_bytes(JOURNEY_RESULT_SIGNING_DOMAIN + _canonical_json_bytes(signed))
+        signature_path.write_bytes(signature_bytes)
+        completed = subprocess.run(
+            [
+                "openssl",
+                "dgst",
+                "-sha256",
+                "-verify",
+                str(public_key),
+                "-signature",
+                str(signature_path),
+                str(message),
+            ],
+            cwd=root,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.PIPE,
+            text=True,
+            check=False,
+            timeout=20,
+        )
+    if completed.returncode != 0:
+        result.error(f"{location}.signature", "cryptographic verification failed")
+        return False
+    return True
+
+
+def _validate_signed_journey_result(
+    root: Path,
+    source: str,
+    requirement_id: str,
+    journeys: list[str],
+    evidence_commits: set[str],
+    trusted_public_key_sha256: str,
+    location: str,
+    result: ValidationResult,
+) -> bool:
+    before = len(result.errors)
+    path = _repository_path(root, source, location, result)
+    if path is None:
+        return False
+    envelope = _load_json(path, result)
+    if not _expect_object(envelope, location, result):
+        return False
+    _expect_keys(envelope, {"schema_version", "signatures", "signed"}, {"schema_version", "signatures", "signed"}, location, result)
+    if envelope.get("schema_version") != JOURNEY_RESULT_ENVELOPE_SCHEMA:
+        result.error(f"{location}.schema_version", f"must equal {JOURNEY_RESULT_ENVELOPE_SCHEMA!r}")
+
+    signed = envelope.get("signed")
+    if not _expect_object(signed, f"{location}.signed", result):
+        signed = {}
+    signed_digest = _canonical_json_sha256(signed)
+
+    signatures = envelope.get("signatures")
+    matching_verified_signature = False
+    if not isinstance(signatures, list):
+        result.error(f"{location}.signatures", "field 'signatures' must be an array")
+        signatures = []
+    if not signatures:
+        result.error(f"{location}.signatures", "signed journey-result requires at least one signature")
+    for index, signature in enumerate(signatures):
+        loc = f"{location}.signatures[{index}]"
+        if not _expect_object(signature, loc, result):
+            continue
+        _expect_keys(
+            signature,
+            {"algorithm", "key_id", "signature", "signed_sha256", "verified_at", "verifier"},
+            {"algorithm", "key_id", "signature", "signed_sha256", "verified_at", "verifier"},
+            loc,
+            result,
+        )
+        digest = _string(signature.get("signed_sha256"), SHA256_HEX_RE, f"{loc}.signed_sha256", result)
+        if digest and digest != signed_digest:
+            result.error(f"{loc}.signed_sha256", "does not match canonical signed payload SHA-256")
+        _datetime_z(signature.get("verified_at"), f"{loc}.verified_at", result)
+        _string(signature.get("verifier"), None, f"{loc}.verifier", result)
+        if digest == signed_digest and _verify_journey_result_signature(root, signed, signature, trusted_public_key_sha256, loc, result):
+            matching_verified_signature = True
+    if not matching_verified_signature:
+        result.error(location, "signed journey-result requires a verified signature over the signed payload")
+
+    _expect_keys(
+        signed,
+        {
+            "schema_version",
+            "journey_id",
+            "requirement_ids",
+            "repository",
+            "captured_at",
+            "expires_at",
+            "operator",
+            "environment",
+            "artifacts",
+            "result",
+            "steps",
+            "redaction",
+        },
+        {
+            "schema_version",
+            "journey_id",
+            "requirement_ids",
+            "repository",
+            "captured_at",
+            "expires_at",
+            "operator",
+            "environment",
+            "artifacts",
+            "result",
+            "steps",
+            "redaction",
+        },
+        f"{location}.signed",
+        result,
+    )
+    if signed.get("schema_version") != JOURNEY_RESULT_PAYLOAD_SCHEMA:
+        result.error(f"{location}.signed.schema_version", f"must equal {JOURNEY_RESULT_PAYLOAD_SCHEMA!r}")
+    journey_id = _string(signed.get("journey_id"), JOURNEY_RE, f"{location}.signed.journey_id", result)
+    if journey_id and journey_id not in journeys:
+        result.error(f"{location}.signed.journey_id", f"does not match mapped journeys {journeys}")
+    requirement_ids = _string_list(signed.get("requirement_ids"), f"{location}.signed.requirement_ids", result, REQUIREMENT_ID_RE)
+    if requirement_id not in requirement_ids:
+        result.error(f"{location}.signed.requirement_ids", f"does not cover requirement {requirement_id}")
+    _datetime_z(signed.get("captured_at"), f"{location}.signed.captured_at", result)
+    expires_at = _date(signed.get("expires_at"), f"{location}.signed.expires_at", result)
+    if expires_at and expires_at < date.today():
+        result.error(f"{location}.signed.expires_at", f"signed journey-result expired on {expires_at.isoformat()}")
+
+    operator = signed.get("operator")
+    if _expect_object(operator, f"{location}.signed.operator", result):
+        _expect_keys(operator, {"role", "identity_fingerprint"}, {"role", "identity_fingerprint"}, f"{location}.signed.operator", result)
+        _string(operator.get("role"), None, f"{location}.signed.operator.role", result)
+        _string(operator.get("identity_fingerprint"), SHA256_HEX_RE, f"{location}.signed.operator.identity_fingerprint", result)
+
+    environment = signed.get("environment")
+    if _expect_object(environment, f"{location}.signed.environment", result):
+        _expect_keys(
+            environment,
+            {"class", "hardware_profile", "candidate"},
+            {"class", "hardware_profile", "candidate"},
+            f"{location}.signed.environment",
+            result,
+        )
+        _string(environment.get("class"), None, f"{location}.signed.environment.class", result)
+        _string(environment.get("hardware_profile"), None, f"{location}.signed.environment.hardware_profile", result)
+        _string(environment.get("candidate"), None, f"{location}.signed.environment.candidate", result)
+
+    repository = signed.get("repository")
+    if _expect_object(repository, f"{location}.signed.repository", result):
+        _expect_keys(repository, {"name", "commit"}, {"name", "commit"}, f"{location}.signed.repository", result)
+        if repository.get("name") != "Augustas11/macprovider":
+            result.error(f"{location}.signed.repository.name", "must equal 'Augustas11/macprovider'")
+        commit = _string(repository.get("commit"), COMMIT_RE, f"{location}.signed.repository.commit", result)
+        if commit and not _reachable_commit(root, commit):
+            result.error(f"{location}.signed.repository.commit", f"commit is not reachable: {commit}")
+        if commit and evidence_commits and commit not in evidence_commits:
+            result.error(f"{location}.signed.repository.commit", "must match this requirement's commit evidence")
+
+    artifact_ids: set[str] = set()
+    artifacts = signed.get("artifacts")
+    if not isinstance(artifacts, list):
+        result.error(f"{location}.signed.artifacts", "field 'artifacts' must be an array")
+        artifacts = []
+    if not artifacts:
+        result.error(f"{location}.signed.artifacts", "must contain at least one hash-bound artifact")
+    for index, artifact in enumerate(artifacts):
+        loc = f"{location}.signed.artifacts[{index}]"
+        if not _expect_object(artifact, loc, result):
+            continue
+        _expect_keys(artifact, {"id", "sha256", "source"}, {"id", "sha256", "source"}, loc, result)
+        artifact_id = _string(artifact.get("id"), None, f"{loc}.id", result)
+        if artifact_id:
+            if artifact_id in artifact_ids:
+                result.error(f"{loc}.id", f"duplicate artifact id {artifact_id!r}")
+            artifact_ids.add(artifact_id)
+        expected_sha = _string(artifact.get("sha256"), SHA256_HEX_RE, f"{loc}.sha256", result)
+        artifact_source = _string(artifact.get("source"), None, f"{loc}.source", result)
+        if artifact_source:
+            if not _source_under_journey_evidence(root, artifact_source):
+                result.error(f"{loc}.source", "must be under journeys/evidence/")
+            artifact_path = _repository_path(root, artifact_source, f"{loc}.source", result)
+            if artifact_path is not None:
+                try:
+                    actual_sha = hashlib.sha256(artifact_path.read_bytes()).hexdigest()
+                except OSError as exc:
+                    result.error(f"{loc}.source", f"cannot read artifact source: {exc}")
+                else:
+                    if expected_sha and actual_sha != expected_sha:
+                        result.error(f"{loc}.sha256", "does not match artifact source bytes")
+
+    run_result = signed.get("result")
+    if _expect_object(run_result, f"{location}.signed.result", result):
+        _expect_keys(run_result, {"status"}, {"status", "summary"}, f"{location}.signed.result", result)
+        if run_result.get("status") != "pass":
+            result.error(f"{location}.signed.result.status", "must equal 'pass'")
+        if "summary" in run_result:
+            _string(run_result.get("summary"), None, f"{location}.signed.result.summary", result)
+
+    steps = signed.get("steps")
+    if not isinstance(steps, list):
+        result.error(f"{location}.signed.steps", "field 'steps' must be an array")
+        steps = []
+    if not steps:
+        result.error(f"{location}.signed.steps", "must contain at least one result entry")
+    for index, step in enumerate(steps):
+        loc = f"{location}.signed.steps[{index}]"
+        if not _expect_object(step, loc, result):
+            continue
+        _expect_keys(step, {"id", "status", "artifacts"}, {"id", "status", "artifacts", "assertion"}, loc, result)
+        _string(step.get("id"), None, f"{loc}.id", result)
+        if step.get("status") != "pass":
+            result.error(f"{loc}.status", "must equal 'pass'")
+        artifacts = _string_list(step.get("artifacts"), f"{loc}.artifacts", result)
+        if not artifacts:
+            result.error(f"{loc}.artifacts", "must contain at least one artifact reference")
+        for artifact_id in artifacts:
+            if artifact_ids and artifact_id not in artifact_ids:
+                result.error(f"{loc}.artifacts", f"unknown artifact reference {artifact_id!r}")
+        if "assertion" in step:
+            _string(step.get("assertion"), None, f"{loc}.assertion", result)
+
+    redaction = signed.get("redaction")
+    if _expect_object(redaction, f"{location}.signed.redaction", result):
+        required_redactions = {"secrets_redacted", "operator_identity_redacted", "local_account_names_redacted"}
+        _expect_keys(redaction, required_redactions, required_redactions, f"{location}.signed.redaction", result)
+        for field_name in sorted(required_redactions):
+            if redaction.get(field_name) is not True:
+                result.error(f"{location}.signed.redaction.{field_name}", "must be true")
+
+    return len(result.errors) == before
+
+
+def _signed_journey_result_satisfies(
+    root: Path,
+    requirement: dict[str, Any],
+    location: str,
+    result: ValidationResult,
+    trusted_public_key_sha256: str,
+    emit_errors: bool = True,
+) -> bool:
+    requirement_id = requirement.get("requirement_id")
+    journeys = requirement.get("journeys")
+    if not isinstance(requirement_id, str) or not isinstance(journeys, list):
+        return False
+    evidence_items = requirement.get("evidence", []) if isinstance(requirement.get("evidence"), list) else []
+    evidence_commits = {
+        evidence.get("artifact", "").split(":", 1)[1]
+        for evidence in evidence_items
+        if isinstance(evidence, dict)
+        and isinstance(evidence.get("artifact"), str)
+        and evidence["artifact"].startswith("commit:")
+    }
+    candidate_errors: list[str] = []
+    saw_candidate = False
+    for index, evidence in enumerate(evidence_items):
+        if not isinstance(evidence, dict):
+            continue
+        artifact = evidence.get("artifact")
+        source = evidence.get("source")
+        if (
+            isinstance(artifact, str)
+            and artifact.startswith("sha256:")
+            and isinstance(source, str)
+            and _source_under_journey_evidence(root, source)
+        ):
+            if not _looks_like_signed_journey_result(root, source):
+                continue
+            saw_candidate = True
+            candidate_result = ValidationResult()
+            if _validate_signed_journey_result(
+                root,
+                source,
+                requirement_id,
+                [item for item in journeys if isinstance(item, str)],
+                evidence_commits,
+                trusted_public_key_sha256,
+                f"{location}.evidence[{index}].source",
+                candidate_result,
+            ):
+                return True
+            candidate_errors.extend(candidate_result.errors)
+    if emit_errors:
+        if candidate_errors:
+            result.errors.extend(candidate_errors)
+        elif not saw_candidate:
+            result.error(location, "sensitive conformant requirement requires sha256 signed journey-result evidence under journeys/evidence/")
+    return False
 
 
 def _commit_file_matches_current(root: Path, commit: str, relative: str) -> bool:
@@ -682,7 +1060,11 @@ def _validate_conformance_schema(root: Path, conformance: Any, result: Validatio
     return [item for item in specs if isinstance(item, dict)], [item for item in requirements if isinstance(item, dict)]
 
 
-def validate_repository(root: Path, base_ref: str | None = None) -> ValidationResult:
+def validate_repository(
+    root: Path,
+    base_ref: str | None = None,
+    trusted_journey_result_public_key_sha256: str = JOURNEY_RESULT_PUBLIC_KEY_SHA256,
+) -> ValidationResult:
     root = root.resolve()
     result = ValidationResult()
     authority = _load_json(root / "specs" / "AUTHORITY.json", result)
@@ -694,11 +1076,20 @@ def validate_repository(root: Path, base_ref: str | None = None) -> ValidationRe
     specs, requirements = _validate_conformance_schema(root, conformance, result)
     schema_authority = _load_json(root / "schemas" / "spec-authority-v1.schema.json", result)
     schema_conformance = _load_json(root / "schemas" / "spec-conformance-v1.schema.json", result)
+    schema_journey_result = _load_json(root / "schemas" / "journey-result-v1.schema.json", result)
     schema_pr = _load_json(root / "schemas" / "spec-pr-governance-v1.schema.json", result)
     if isinstance(schema_authority, dict) and schema_authority.get("$id") != "https://github.com/Augustas11/macprovider/schemas/spec-authority-v1.schema.json":
         result.error("schemas/spec-authority-v1.schema.json.$id", "unexpected schema id")
     if isinstance(schema_conformance, dict) and schema_conformance.get("$id") != "https://github.com/Augustas11/macprovider/schemas/spec-conformance-v1.schema.json":
         result.error("schemas/spec-conformance-v1.schema.json.$id", "unexpected schema id")
+    if isinstance(schema_journey_result, dict) and schema_journey_result.get("$id") != JOURNEY_RESULT_SCHEMA_ID:
+        result.error("schemas/journey-result-v1.schema.json.$id", "unexpected schema id")
+    if isinstance(schema_journey_result, dict):
+        schema_signature = schema_journey_result.get("$defs", {}).get("signature", {}).get("properties", {})
+        if schema_signature.get("algorithm", {}).get("const") != JOURNEY_RESULT_SIGNING_ALGORITHM:
+            result.error("schemas/journey-result-v1.schema.json.$defs.signature.properties.algorithm.const", "does not match validator signing algorithm")
+        if schema_signature.get("key_id", {}).get("const") != JOURNEY_RESULT_SIGNING_KEY_ID:
+            result.error("schemas/journey-result-v1.schema.json.$defs.signature.properties.key_id.const", "does not match validator signing key id")
     if isinstance(schema_pr, dict) and schema_pr.get("$id") != "https://github.com/Augustas11/macprovider/schemas/spec-pr-governance-v1.schema.json":
         result.error("schemas/spec-pr-governance-v1.schema.json.$id", "unexpected schema id")
 
@@ -831,10 +1222,38 @@ def validate_repository(root: Path, base_ref: str | None = None) -> ValidationRe
             ]
             if nonconformant:
                 result.error(spec_id, "implementation_status implemented requires every owned requirement to be conformant")
+        requires_signed_result = any(
+            domain_records.get(domain_id, {}).get("requires_signed_journey_result") is True
+            for domain_id in spec.get("authority_domains", [])
+            if isinstance(domain_id, str)
+        )
         if spec.get("production_status") == "physically-verified":
-            result.error(spec_id, "production_status physically-verified requires signed journey-result contract before promotion")
+            if not owned_requirements:
+                result.error(spec_id, "production_status physically-verified requires at least one owned requirement")
+            nonconformant = [
+                item.get("requirement_id")
+                for item in owned_requirements
+                if item.get("state") != "conformant"
+            ]
+            if nonconformant:
+                result.error(spec_id, "production_status physically-verified requires every owned requirement to be conformant")
+            if requires_signed_result:
+                missing_signed = [
+                    item.get("requirement_id")
+                    for item in owned_requirements
+                    if item.get("state") == "conformant"
+                    and not _signed_journey_result_satisfies(
+                        root,
+                        item,
+                        str(item.get("requirement_id")),
+                        result,
+                        trusted_journey_result_public_key_sha256,
+                        emit_errors=False,
+                    )
+                ]
+                if missing_signed:
+                    result.error(spec_id, "production_status physically-verified requires valid signed journey-result evidence for every owned requirement")
         if spec.get("status") == "physically-verified":
-            result.error(spec_id, "physically-verified requires signed journey-result contract before promotion")
             nonconformant = [
                 item.get("requirement_id")
                 for item in owned_requirements
@@ -842,6 +1261,22 @@ def validate_repository(root: Path, base_ref: str | None = None) -> ValidationRe
             ]
             if nonconformant:
                 result.error(spec_id, "physically-verified requires every owned requirement to be conformant")
+            if requires_signed_result:
+                missing_signed = [
+                    item.get("requirement_id")
+                    for item in owned_requirements
+                    if item.get("state") == "conformant"
+                    and not _signed_journey_result_satisfies(
+                        root,
+                        item,
+                        str(item.get("requirement_id")),
+                        result,
+                        trusted_journey_result_public_key_sha256,
+                        emit_errors=False,
+                    )
+                ]
+                if missing_signed:
+                    result.error(spec_id, "physically-verified requires valid signed journey-result evidence for every owned requirement")
 
     for requirement_id, requirement in requirements_by_id.items():
         for mapping_key in ("implementation", "tests"):
@@ -854,24 +1289,16 @@ def validate_repository(root: Path, base_ref: str | None = None) -> ValidationRe
                 domain.get("requires_signed_journey_result") is True
                 and requirement.get("state") == "conformant"
             ):
-                result.error(requirement_id, "sensitive conformant requirement requires signed journey-result contract before promotion")
                 if not requirement.get("journeys"):
                     result.error(requirement_id, "sensitive conformant requirement requires a physical journey mapping")
-                has_physical_artifact = False
-                for evidence in requirement.get("evidence", []):
-                    if not isinstance(evidence, dict):
-                        continue
-                    source = evidence.get("source")
-                    artifact = evidence.get("artifact")
-                    if (
-                        isinstance(source, str)
-                        and _source_under_journey_evidence(root, source)
-                        and isinstance(artifact, str)
-                        and artifact.startswith("sha256:")
-                    ):
-                        has_physical_artifact = True
-                if not has_physical_artifact:
-                    result.error(requirement_id, "sensitive conformant requirement requires sha256 journey evidence under journeys/evidence/")
+                if not _signed_journey_result_satisfies(
+                    root,
+                    requirement,
+                    requirement_id,
+                    result,
+                    trusted_journey_result_public_key_sha256,
+                ):
+                    result.error(requirement_id, "sensitive conformant requirement requires valid signed journey-result evidence")
 
     return result
 

--- a/scripts/check_spec_pr_declaration.py
+++ b/scripts/check_spec_pr_declaration.py
@@ -48,6 +48,7 @@ GOVERNANCE_ONLY_PATHS = (
     "beta/DECISION_CRITERIA.md",
     "docs/spec-governance-foundation.md",
     "docs/spec-history/",
+    "schemas/journey-",
     "schemas/spec-",
     "scripts/check_spec_governance.py",
     "scripts/check_spec_pr_declaration.py",

--- a/scripts/tests/fixtures/spec_governance/physical-evidence-path-traversal.json
+++ b/scripts/tests/fixtures/spec_governance/physical-evidence-path-traversal.json
@@ -1,4 +1,4 @@
 {
   "mutation": {"operation": "physical_evidence_path_traversal"},
-  "expected": "requires sha256 journey evidence under journeys/evidence/"
+  "expected": "requires valid signed journey-result evidence"
 }

--- a/scripts/tests/fixtures/spec_governance/physically-verified-without-proof.json
+++ b/scripts/tests/fixtures/spec_governance/physically-verified-without-proof.json
@@ -1,1 +1,1 @@
-{"mutation":{"operation":"physically_verified_without_proof"},"expected":"physically-verified requires signed journey-result contract before promotion"}
+{"mutation":{"operation":"physically_verified_without_proof"},"expected":"physically-verified requires every owned requirement to be conformant"}

--- a/scripts/tests/fixtures/spec_governance/production-physically-verified-with-pending-requirement.json
+++ b/scripts/tests/fixtures/spec_governance/production-physically-verified-with-pending-requirement.json
@@ -1,0 +1,1 @@
+{"mutation":{"operation":"production_physically_verified_with_pending_requirement"},"expected":"production_status physically-verified requires every owned requirement to be conformant"}

--- a/scripts/tests/fixtures/spec_governance/production-physically-verified-without-requirements.json
+++ b/scripts/tests/fixtures/spec_governance/production-physically-verified-without-requirements.json
@@ -1,0 +1,1 @@
+{"mutation":{"operation":"production_physically_verified_without_requirements"},"expected":"production_status physically-verified requires at least one owned requirement"}

--- a/scripts/tests/fixtures/spec_governance/production-physically-verified-without-signed-result.json
+++ b/scripts/tests/fixtures/spec_governance/production-physically-verified-without-signed-result.json
@@ -1,1 +1,1 @@
-{"mutation":{"operation":"production_physically_verified_without_signed_result"},"expected":"production_status physically-verified requires signed journey-result contract before promotion"}
+{"mutation":{"operation":"production_physically_verified_without_signed_result"},"expected":"production_status physically-verified requires every owned requirement to be conformant"}

--- a/scripts/tests/fixtures/spec_governance/sensitive-conformant-without-signed-result.json
+++ b/scripts/tests/fixtures/spec_governance/sensitive-conformant-without-signed-result.json
@@ -1,1 +1,1 @@
-{"mutation":{"operation":"sensitive_conformant_without_signed_result"},"expected":"sensitive conformant requirement requires signed journey-result contract before promotion"}
+{"mutation":{"operation":"sensitive_conformant_without_signed_result"},"expected":"sensitive conformant requirement requires valid signed journey-result evidence"}

--- a/scripts/tests/fixtures/spec_governance/signed-journey-result-bad-signature.json
+++ b/scripts/tests/fixtures/spec_governance/signed-journey-result-bad-signature.json
@@ -1,0 +1,1 @@
+{"mutation":{"operation":"signed_journey_result_bad_signature"},"expected":"cryptographic verification failed"}

--- a/scripts/tests/fixtures/spec_governance/signed-journey-result-commit-mismatch.json
+++ b/scripts/tests/fixtures/spec_governance/signed-journey-result-commit-mismatch.json
@@ -1,0 +1,1 @@
+{"mutation":{"operation":"signed_journey_result_commit_mismatch"},"expected":"must match this requirement's commit evidence"}

--- a/scripts/tests/fixtures/spec_governance/signed-journey-result-empty-artifacts.json
+++ b/scripts/tests/fixtures/spec_governance/signed-journey-result-empty-artifacts.json
@@ -1,0 +1,1 @@
+{"mutation":{"operation":"signed_journey_result_empty_artifacts"},"expected":"artifacts: must contain at least one artifact reference"}

--- a/scripts/tests/fixtures/spec_governance/signed-journey-result-failed-step.json
+++ b/scripts/tests/fixtures/spec_governance/signed-journey-result-failed-step.json
@@ -1,0 +1,1 @@
+{"mutation":{"operation":"signed_journey_result_failed_step"},"expected":"signed.steps[0].status: must equal 'pass'"}

--- a/scripts/tests/fixtures/spec_governance/signed-journey-result-future-capture.json
+++ b/scripts/tests/fixtures/spec_governance/signed-journey-result-future-capture.json
@@ -1,0 +1,1 @@
+{"mutation":{"operation":"signed_journey_result_future_capture"},"expected":"timestamp is in the future"}

--- a/scripts/tests/fixtures/spec_governance/signed-journey-result-hash-mismatch.json
+++ b/scripts/tests/fixtures/spec_governance/signed-journey-result-hash-mismatch.json
@@ -1,0 +1,1 @@
+{"mutation":{"operation":"signed_journey_result_hash_mismatch"},"expected":"does not match canonical signed payload SHA-256"}

--- a/scripts/tests/fixtures/spec_governance/signed-journey-result-missing-signature.json
+++ b/scripts/tests/fixtures/spec_governance/signed-journey-result-missing-signature.json
@@ -1,0 +1,1 @@
+{"mutation":{"operation":"signed_journey_result_missing_signature"},"expected":"signed journey-result requires at least one signature"}

--- a/scripts/tests/fixtures/spec_governance/signed-journey-result-wrong-requirement.json
+++ b/scripts/tests/fixtures/spec_governance/signed-journey-result-wrong-requirement.json
@@ -1,0 +1,1 @@
+{"mutation":{"operation":"signed_journey_result_wrong_requirement"},"expected":"does not cover requirement SPEC-001-R001"}

--- a/scripts/tests/test_spec_governance.py
+++ b/scripts/tests/test_spec_governance.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import base64
 import copy
 import hashlib
 import json
@@ -12,11 +13,136 @@ from scripts.check_spec_governance import validate_repository
 
 
 FIXTURES = Path(__file__).parent / "fixtures" / "spec_governance"
+JOURNEY_RESULT_SIGNING_DOMAIN = b"macprovider.journey-result.v1\n"
 GAP = {
     "verdict": "UNKNOWN",
     "owner": "@owner",
     "issue": "https://github.com/Augustas11/macprovider/issues/614",
 }
+
+
+def canonical_json_bytes(value: object) -> bytes:
+    return (json.dumps(value, sort_keys=True, separators=(",", ":")) + "\n").encode("utf-8")
+
+
+def signed_journey_envelope(
+    commit: str,
+    *,
+    requirement_ids: list[str] | None = None,
+    journey_id: str = "JOURNEY-BOOT",
+    result_status: str = "pass",
+    step_status: str = "pass",
+    artifacts: list[str] | None = None,
+    artifact_records: list[dict[str, str]] | None = None,
+    captured_at: str = "2026-01-01T00:00:00Z",
+    signed_sha256: str | None = None,
+    signatures: list[dict[str, object]] | None = None,
+) -> dict[str, object]:
+    signed = {
+        "schema_version": "macprovider.journey-result.v1",
+        "journey_id": journey_id,
+        "requirement_ids": requirement_ids or ["SPEC-001-R001"],
+        "repository": {
+            "name": "Augustas11/macprovider",
+            "commit": commit,
+        },
+        "captured_at": captured_at,
+        "expires_at": "2027-01-01",
+        "operator": {
+            "role": "fixture-operator",
+            "identity_fingerprint": "a" * 64,
+        },
+        "environment": {
+            "class": "fixture-physical-provider",
+            "hardware_profile": "fixture-apple-silicon",
+            "candidate": "fixture-candidate",
+        },
+        "artifacts": artifact_records or [
+            {
+                "id": "proof",
+                "sha256": hashlib.sha256(b"proof\n").hexdigest(),
+                "source": "journeys/evidence/proof.txt",
+            }
+        ],
+        "result": {
+            "status": result_status,
+            "summary": "fixture journey passed",
+        },
+        "steps": [
+            {
+                "id": "step-1",
+                "status": step_status,
+                "assertion": "fixture assertion",
+                "artifacts": ["proof"] if artifacts is None else artifacts,
+            }
+        ],
+        "redaction": {
+            "secrets_redacted": True,
+            "operator_identity_redacted": True,
+            "local_account_names_redacted": True,
+        },
+    }
+    digest = hashlib.sha256(canonical_json_bytes(signed)).hexdigest()
+    envelope_signatures = signatures
+    if envelope_signatures is None:
+        envelope_signatures = [
+            {
+                "algorithm": "ecdsa-p256-sha256",
+                "key_id": "macprovider-acceptance-p256-v1",
+                "signature": "unsigned-fixture",
+                "signed_sha256": signed_sha256 or digest,
+                "verified_at": "2026-01-01T00:00:01Z",
+                "verifier": "fixture-verifier",
+            }
+        ]
+    return {
+        "schema_version": "macprovider.journey-result-envelope.v1",
+        "signatures": envelope_signatures,
+        "signed": signed,
+    }
+
+
+def sign_journey_envelope(root: Path, envelope: dict[str, object], *, corrupt_signature: bool = False) -> None:
+    security = root / "security"
+    security.mkdir(parents=True, exist_ok=True)
+    with tempfile.TemporaryDirectory() as directory:
+        work = Path(directory)
+        private_key = work / "private.pem"
+        public_key = security / "acceptance-candidate-signing-public.pem"
+        message = work / "message"
+        signature = work / "signature.der"
+        subprocess.run(
+            ["openssl", "ecparam", "-name", "prime256v1", "-genkey", "-noout", "-out", str(private_key)],
+            check=True,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+        subprocess.run(
+            ["openssl", "ec", "-in", str(private_key), "-pubout", "-out", str(public_key)],
+            check=True,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+        message.write_bytes(JOURNEY_RESULT_SIGNING_DOMAIN + canonical_json_bytes(envelope["signed"]))
+        subprocess.run(
+            ["openssl", "dgst", "-sha256", "-sign", str(private_key), "-out", str(signature), str(message)],
+            check=True,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+        signature_bytes = bytearray(signature.read_bytes())
+        if corrupt_signature:
+            signature_bytes[-1] ^= 0x01
+        encoded = base64.b64encode(bytes(signature_bytes)).decode("ascii")
+    envelope["signatures"][0]["signature"] = encoded
+
+
+def validate_repository_with_fixture_key(root: Path) -> list[str]:
+    public_key = root / "security" / "acceptance-candidate-signing-public.pem"
+    if not public_key.exists():
+        return validate_repository(root).errors
+    trusted_hash = hashlib.sha256(public_key.read_bytes()).hexdigest()
+    return validate_repository(root, trusted_journey_result_public_key_sha256=trusted_hash).errors
 
 
 def base_repository() -> dict[str, object]:
@@ -33,6 +159,17 @@ def base_repository() -> dict[str, object]:
             }),
             "schemas/spec-conformance-v1.schema.json": json.dumps({
                 "$id": "https://github.com/Augustas11/macprovider/schemas/spec-conformance-v1.schema.json"
+            }),
+            "schemas/journey-result-v1.schema.json": json.dumps({
+                "$id": "https://github.com/Augustas11/macprovider/schemas/journey-result-v1.schema.json",
+                "$defs": {
+                    "signature": {
+                        "properties": {
+                            "algorithm": {"const": "ecdsa-p256-sha256"},
+                            "key_id": {"const": "macprovider-acceptance-p256-v1"},
+                        }
+                    }
+                },
             }),
             "schemas/spec-pr-governance-v1.schema.json": json.dumps({
                 "$id": "https://github.com/Augustas11/macprovider/schemas/spec-pr-governance-v1.schema.json"
@@ -190,6 +327,83 @@ def apply_post_write_mutation(root: Path, repository: dict[str, object]) -> None
                 "expires_at": "2027-01-01",
             },
         ]
+    elif operation in {
+        "valid_signed_journey_result",
+        "signed_journey_result_missing_signature",
+        "signed_journey_result_hash_mismatch",
+        "signed_journey_result_failed_step",
+        "signed_journey_result_wrong_requirement",
+        "signed_journey_result_empty_artifacts",
+        "signed_journey_result_future_capture",
+        "signed_journey_result_bad_signature",
+        "signed_journey_result_commit_mismatch",
+        "signed_journey_result_mixed_physical_evidence",
+        "production_physically_verified_with_pending_requirement",
+    }:
+        if operation == "signed_journey_result_missing_signature":
+            envelope = signed_journey_envelope(commit, signatures=[])
+        elif operation == "signed_journey_result_hash_mismatch":
+            envelope = signed_journey_envelope(commit, signed_sha256="0" * 64)
+        elif operation == "signed_journey_result_failed_step":
+            envelope = signed_journey_envelope(commit, step_status="fail")
+        elif operation == "signed_journey_result_wrong_requirement":
+            envelope = signed_journey_envelope(commit, requirement_ids=["SPEC-001-R999"])
+        elif operation == "signed_journey_result_empty_artifacts":
+            envelope = signed_journey_envelope(commit, artifacts=[])
+        elif operation == "signed_journey_result_future_capture":
+            envelope = signed_journey_envelope(commit, captured_at="2099-01-01T00:00:00Z")
+        elif operation == "signed_journey_result_bad_signature":
+            envelope = signed_journey_envelope(commit)
+        elif operation == "signed_journey_result_commit_mismatch":
+            older_commit = commit
+            (root / "src" / "example.py").write_text("def example():\n    return True\n\n", encoding="utf-8")
+            subprocess.run(["git", "add", "."], cwd=root, check=True)
+            subprocess.run(["git", "commit", "-qm", "new implementation evidence"], cwd=root, check=True)
+            commit = subprocess.check_output(["git", "rev-parse", "HEAD"], cwd=root, text=True).strip()
+            envelope = signed_journey_envelope(older_commit)
+        elif operation == "production_physically_verified_with_pending_requirement":
+            conformance["requirements"].append({
+                "requirement_id": "SPEC-001-R002",
+                "spec_id": "SPEC-001",
+                "state": "pending",
+                "implementation": ["src/example.py:example"],
+                "tests": ["tests/test_example.py::test_example"],
+                "journeys": [],
+                "evidence": [],
+                "gap": copy.deepcopy(GAP),
+            })
+            conformance["specs"][0]["production_status"] = "physically-verified"
+            envelope = signed_journey_envelope(commit)
+        else:
+            envelope = signed_journey_envelope(commit)
+        if envelope["signatures"]:
+            sign_journey_envelope(root, envelope, corrupt_signature=operation == "signed_journey_result_bad_signature")
+        evidence_path = root / "journeys" / "evidence" / "signed-result.json"
+        evidence_path.write_text(json.dumps(envelope, indent=2, sort_keys=False) + "\n", encoding="utf-8")
+        digest = hashlib.sha256(evidence_path.read_bytes()).hexdigest()
+        requirement["journeys"] = ["JOURNEY-BOOT"]
+        requirement["evidence"] = [
+            {
+                "artifact": f"commit:{commit}",
+                "source": None,
+                "captured_at": "2026-01-01",
+                "expires_at": "2027-01-01",
+            },
+            {
+                "artifact": f"sha256:{digest}",
+                "source": "journeys/evidence/signed-result.json",
+                "captured_at": "2026-01-01",
+                "expires_at": "2027-01-01",
+            },
+        ]
+        if operation == "signed_journey_result_mixed_physical_evidence":
+            proof_digest = hashlib.sha256((root / "journeys" / "evidence" / "proof.txt").read_bytes()).hexdigest()
+            requirement["evidence"].append({
+                "artifact": f"sha256:{proof_digest}",
+                "source": "journeys/evidence/proof.txt",
+                "captured_at": "2026-01-01",
+                "expires_at": "2027-01-01",
+            })
     else:
         raise AssertionError(f"unknown post-write fixture operation {operation!r}")
 
@@ -240,6 +454,8 @@ def apply_mutation(repository: dict[str, object], mutation: dict[str, object]) -
         specs[0]["status"] = "physically-verified"
     elif operation == "production_physically_verified_without_signed_result":
         specs[0]["production_status"] = "physically-verified"
+    elif operation == "production_physically_verified_without_requirements":
+        specs[1]["production_status"] = "physically-verified"
     elif operation == "stale_evidence":
         digest = hashlib.sha256(b"proof\n").hexdigest()
         requirements[0]["state"] = "conformant"
@@ -279,6 +495,28 @@ def apply_mutation(repository: dict[str, object], mutation: dict[str, object]) -
         repository["_post_write_operation"] = "stale_commit_evidence"
     elif operation == "sensitive_conformant_without_signed_result":
         repository["_post_write_operation"] = "sensitive_conformant_without_signed_result"
+    elif operation == "valid_signed_journey_result":
+        repository["_post_write_operation"] = "valid_signed_journey_result"
+    elif operation == "signed_journey_result_missing_signature":
+        repository["_post_write_operation"] = "signed_journey_result_missing_signature"
+    elif operation == "signed_journey_result_hash_mismatch":
+        repository["_post_write_operation"] = "signed_journey_result_hash_mismatch"
+    elif operation == "signed_journey_result_failed_step":
+        repository["_post_write_operation"] = "signed_journey_result_failed_step"
+    elif operation == "signed_journey_result_wrong_requirement":
+        repository["_post_write_operation"] = "signed_journey_result_wrong_requirement"
+    elif operation == "signed_journey_result_empty_artifacts":
+        repository["_post_write_operation"] = "signed_journey_result_empty_artifacts"
+    elif operation == "signed_journey_result_future_capture":
+        repository["_post_write_operation"] = "signed_journey_result_future_capture"
+    elif operation == "signed_journey_result_bad_signature":
+        repository["_post_write_operation"] = "signed_journey_result_bad_signature"
+    elif operation == "signed_journey_result_commit_mismatch":
+        repository["_post_write_operation"] = "signed_journey_result_commit_mismatch"
+    elif operation == "signed_journey_result_mixed_physical_evidence":
+        repository["_post_write_operation"] = "signed_journey_result_mixed_physical_evidence"
+    elif operation == "production_physically_verified_with_pending_requirement":
+        repository["_post_write_operation"] = "production_physically_verified_with_pending_requirement"
     elif operation == "mismatched_spec_header_id":
         repository["files"]["specs/SPEC-001-one.md"] = (
             "# SPEC-999 - One\n\n**Version:** 0.1.0\n\nHuman contract text.\n"
@@ -330,6 +568,34 @@ class GovernanceValidatorTests(unittest.TestCase):
             write_repository(root, base_repository())
             self.assertEqual([], validate_repository(root).errors)
 
+    def test_sensitive_conformant_with_signed_journey_result_passes(self) -> None:
+        repository = base_repository()
+        apply_mutation(repository, {"operation": "valid_signed_journey_result"})
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            write_repository(root, repository)
+            apply_post_write_mutation(root, repository)
+            self.assertEqual([], validate_repository_with_fixture_key(root))
+
+    def test_signed_journey_result_can_coexist_with_other_physical_evidence(self) -> None:
+        repository = base_repository()
+        apply_mutation(repository, {"operation": "signed_journey_result_mixed_physical_evidence"})
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            write_repository(root, repository)
+            apply_post_write_mutation(root, repository)
+            self.assertEqual([], validate_repository_with_fixture_key(root))
+
+    def test_signed_journey_result_rejects_unpinned_public_key(self) -> None:
+        repository = base_repository()
+        apply_mutation(repository, {"operation": "valid_signed_journey_result"})
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            write_repository(root, repository)
+            apply_post_write_mutation(root, repository)
+            errors = "\n".join(validate_repository(root).errors)
+            self.assertIn("trusted public key does not match pinned journey-result trust anchor", errors)
+
     def test_real_spec_corpus_passes(self) -> None:
         root = Path(__file__).resolve().parents[2]
         self.assertEqual([], validate_repository(root).errors)
@@ -344,7 +610,7 @@ class GovernanceValidatorTests(unittest.TestCase):
                     root = Path(directory)
                     write_repository(root, repository)
                     apply_post_write_mutation(root, repository)
-                    errors = validate_repository(root).errors
+                    errors = validate_repository_with_fixture_key(root)
                 self.assertIn(payload["expected"], "\n".join(errors))
 
     def test_duplicate_json_object_keys_are_rejected(self) -> None:

--- a/specs/PROCESS.md
+++ b/specs/PROCESS.md
@@ -97,12 +97,22 @@ insufficient, a conformance state, and evidence. Allowed states are
 - Every journey ID resolves to `journeys/JOURNEY-NAME.md`; an invented ID is
   not evidence. Sensitive conformant requirements also carry a recomputable
   SHA-256 artifact under `journeys/evidence/`.
-- The governance foundation deliberately rejects `physically-verified` and
-  `production_status: physically-verified` promotion until Phase 5 defines
-  and validates a structured signed journey-result contract. Authority domains
-  that require that contract set `requires_signed_journey_result: true` in
-  `AUTHORITY.json`; requirements in those domains cannot become `conformant`
-  until the contract exists. A Markdown journey description or digest alone
+- Authority domains that require a signed physical result set
+  `requires_signed_journey_result: true` in `AUTHORITY.json`. Requirements in
+  those domains can become `conformant` only when a mapped journey has a
+  SHA-256 evidence artifact under `journeys/evidence/` whose bytes reproduce
+  the digest and whose signed envelope has the shape defined by
+  `schemas/journey-result-v1.schema.json`. The governance validator is the
+  normative enforcement path for semantic checks the schema cannot prove by
+  itself: an `ecdsa-p256-sha256` signature over
+  `macprovider.journey-result.v1\n` plus canonical sorted compact JSON,
+  verified against the pinned
+  `security/acceptance-candidate-signing-public.pem` trust anchor, the mapped
+  journey ID, the promoted requirement ID, a repository commit matching the
+  requirement's commit evidence, operator and environment bindings, a passing
+  run result, passing step results that reference hash-bound artifacts, current
+  expiry, and explicit redaction confirmations. A Markdown journey description,
+  arbitrary digest, mutable public key, or self-asserted signature status alone
   cannot promote lifecycle state.
 - Evidence records the proving reachable commit or an immutable artifact whose
   repository source bytes reproduce its SHA-256 digest, plus capture date and


### PR DESCRIPTION
## Summary

Closes #896.

Implements issue #896 for the accepted #614 provider pre-beta slice: sensitive provider conformance can only promote from a signed journey-result envelope, and physical production promotion requires every owned requirement to be conformant with valid signed evidence when its authority domain requires it.

The contract now has:
- `schemas/journey-result-v1.schema.json` for the closed envelope/payload shape.
- Validator-owned semantic enforcement for domain-separated ECDSA verification, pinned public-key trust anchor, signed commit binding, mapped journey/requirement coverage, hash-bound artifacts, passing steps, expiry, and redaction confirmations.
- Regression fixtures for forged signatures, public-key drift, hash mismatch, wrong requirement, commit mismatch, empty artifacts, failed steps, future capture timestamps, mixed legacy physical evidence, and production physical promotion gaps.

## Validation

- `python3 scripts/check_spec_governance.py --base-ref origin/main`
- `python3 scripts/gen_spec_index.py --check`
- `python3 -m unittest scripts.tests.test_spec_governance scripts.tests.test_spec_pr_declaration`
- `python3 -m py_compile scripts/check_spec_governance.py scripts/check_spec_pr_declaration.py scripts/tests/test_spec_governance.py`
- `jq empty schemas/journey-result-v1.schema.json`
- `git diff --check`
- Final code/security/architecture audit: 0 critical, 0 high, 0 medium findings

SPEC-GOVERNANCE-DECLARATION-BEGIN
{
  "schema_version": "spec-pr-governance-v1",
  "behavior_change": "none",
  "contract_change": "none",
  "issue": "https://github.com/Augustas11/macprovider/issues/896",
  "specs": ["SPEC-016", "SPEC-020"],
  "requirements": ["SPEC-016-R002", "SPEC-020-R001"],
  "authority_domains": ["provider-wire-protocol"],
  "arbitration": [],
  "tests": [
    "python3 scripts/check_spec_governance.py --base-ref origin/main",
    "python3 scripts/gen_spec_index.py --check",
    "python3 -m unittest scripts.tests.test_spec_governance scripts.tests.test_spec_pr_declaration",
    "python3 -m py_compile scripts/check_spec_governance.py scripts/check_spec_pr_declaration.py scripts/tests/test_spec_governance.py",
    "jq empty schemas/journey-result-v1.schema.json",
    "git diff --check"
  ],
  "journeys": ["not-required"]
}
SPEC-GOVERNANCE-DECLARATION-END
