### PR TITLE
Gate ledger promotion on signed journey results

### DIFF
--- a/scripts/check_spec_governance.py
+++ b/scripts/check_spec_governance.py
@@ -13,6 +13,7 @@ import argparse
 import base64
 import hashlib
 import json
+import os
 import re
 import subprocess
 import sys
@@ -33,6 +34,24 @@ JOURNEY_RESULT_SIGNING_KEY_ID = "macprovider-acceptance-p256-v1"
 JOURNEY_RESULT_SIGNING_DOMAIN = b"macprovider.journey-result.v1\n"
 JOURNEY_RESULT_PUBLIC_KEY_PATH = "security/acceptance-candidate-signing-public.pem"
 JOURNEY_RESULT_PUBLIC_KEY_SHA256 = "849e9c9bc53db1fb8e28d3b46ab431089b12cb50b398c5317ced682d39bdbd38"
+TRUSTED_OPENSSL_CANDIDATES = (
+    "/usr/bin/openssl",
+    "/opt/homebrew/opt/openssl@3/bin/openssl",
+    "/opt/homebrew/bin/openssl",
+    "/usr/local/bin/openssl",
+)
+
+
+def _trusted_openssl_paths() -> set[Path]:
+    trusted: set[Path] = set()
+    for candidate in TRUSTED_OPENSSL_CANDIDATES:
+        try:
+            resolved = Path(candidate).resolve(strict=True)
+        except OSError:
+            continue
+        if resolved.is_file() and os.access(resolved, os.X_OK):
+            trusted.add(resolved)
+    return trusted
 SPEC_ID_RE = re.compile(r"^SPEC-\d{3}$")
 SPEC_PATH_RE = re.compile(r"^specs/SPEC-\d{3}-[a-z0-9-]+\.md$")
 REQUIREMENT_ID_RE = re.compile(r"^(SPEC-\d{3})-R\d{3}$")
@@ -129,6 +148,32 @@ def _load_json(path: Path, result: ValidationResult) -> Any | None:
     except OSError as exc:
         result.error(str(path), f"cannot read: {exc}")
     return None
+
+
+def resolve_trusted_openssl(path: str | None = None) -> str:
+    trusted_paths = _trusted_openssl_paths()
+    if path:
+        openssl = Path(path)
+        if not openssl.is_absolute():
+            raise ValueError("OpenSSL path must be absolute")
+        try:
+            resolved = openssl.resolve(strict=True)
+        except OSError:
+            raise ValueError(f"OpenSSL binary is absent or unsafe: {openssl}")
+        if resolved not in trusted_paths:
+            raise ValueError("OpenSSL path is not in the trusted allowlist")
+        return str(resolved)
+
+    candidates = list(TRUSTED_OPENSSL_CANDIDATES)
+    for value in candidates:
+        openssl = Path(value)
+        try:
+            resolved = openssl.resolve(strict=True)
+        except OSError:
+            continue
+        if resolved.is_file() and os.access(resolved, os.X_OK):
+            return str(resolved)
+    raise ValueError("could not resolve trusted OpenSSL binary")
 
 
 def _expect_object(value: Any, location: str, result: ValidationResult) -> bool:
@@ -363,6 +408,7 @@ def _verify_journey_result_signature(
     signed: dict[str, Any],
     signature: dict[str, Any],
     trusted_public_key_sha256: str,
+    openssl_bin: str,
     location: str,
     result: ValidationResult,
 ) -> bool:
@@ -406,7 +452,7 @@ def _verify_journey_result_signature(
         signature_path.write_bytes(signature_bytes)
         completed = subprocess.run(
             [
-                "openssl",
+                openssl_bin,
                 "dgst",
                 "-sha256",
                 "-verify",
@@ -420,6 +466,7 @@ def _verify_journey_result_signature(
             stderr=subprocess.PIPE,
             text=True,
             check=False,
+            env={"PATH": "/usr/bin:/bin"},
             timeout=20,
         )
     if completed.returncode != 0:
@@ -435,6 +482,7 @@ def _validate_signed_journey_result(
     journeys: list[str],
     evidence_commits: set[str],
     trusted_public_key_sha256: str,
+    openssl_bin: str,
     location: str,
     result: ValidationResult,
 ) -> bool:
@@ -477,7 +525,7 @@ def _validate_signed_journey_result(
             result.error(f"{loc}.signed_sha256", "does not match canonical signed payload SHA-256")
         _datetime_z(signature.get("verified_at"), f"{loc}.verified_at", result)
         _string(signature.get("verifier"), None, f"{loc}.verifier", result)
-        if digest == signed_digest and _verify_journey_result_signature(root, signed, signature, trusted_public_key_sha256, loc, result):
+        if digest == signed_digest and _verify_journey_result_signature(root, signed, signature, trusted_public_key_sha256, openssl_bin, loc, result):
             matching_verified_signature = True
     if not matching_verified_signature:
         result.error(location, "signed journey-result requires a verified signature over the signed payload")
@@ -638,6 +686,7 @@ def _signed_journey_result_satisfies(
     location: str,
     result: ValidationResult,
     trusted_public_key_sha256: str,
+    openssl_bin: str,
     emit_errors: bool = True,
 ) -> bool:
     requirement_id = requirement.get("requirement_id")
@@ -676,6 +725,7 @@ def _signed_journey_result_satisfies(
                 [item for item in journeys if isinstance(item, str)],
                 evidence_commits,
                 trusted_public_key_sha256,
+                openssl_bin,
                 f"{location}.evidence[{index}].source",
                 candidate_result,
             ):
@@ -769,7 +819,11 @@ def _validate_base_manifest_immutability(
         return
     base_authority = _git_show_json(root, base_ref, "specs/AUTHORITY.json")
     base_conformance = _git_show_json(root, base_ref, "specs/CONFORMANCE.json")
-    if not isinstance(base_authority, dict) or not isinstance(base_conformance, dict):
+    if not isinstance(base_authority, dict):
+        result.error("base-ref", f"cannot load specs/AUTHORITY.json from {base_ref!r}")
+        return
+    if not isinstance(base_conformance, dict):
+        result.error("base-ref", f"cannot load specs/CONFORMANCE.json from {base_ref!r}")
         return
 
     head_domains = {
@@ -1064,11 +1118,18 @@ def validate_repository(
     root: Path,
     base_ref: str | None = None,
     trusted_journey_result_public_key_sha256: str = JOURNEY_RESULT_PUBLIC_KEY_SHA256,
+    conformance_override: dict[str, Any] | None = None,
+    openssl_bin: str | None = None,
 ) -> ValidationResult:
     root = root.resolve()
     result = ValidationResult()
+    try:
+        trusted_openssl = resolve_trusted_openssl(openssl_bin)
+    except ValueError as exc:
+        result.error("openssl", str(exc))
+        return result
     authority = _load_json(root / "specs" / "AUTHORITY.json", result)
-    conformance = _load_json(root / "specs" / "CONFORMANCE.json", result)
+    conformance = conformance_override if conformance_override is not None else _load_json(root / "specs" / "CONFORMANCE.json", result)
     if authority is None or conformance is None:
         return result
 
@@ -1248,6 +1309,7 @@ def validate_repository(
                         str(item.get("requirement_id")),
                         result,
                         trusted_journey_result_public_key_sha256,
+                        trusted_openssl,
                         emit_errors=False,
                     )
                 ]
@@ -1272,6 +1334,7 @@ def validate_repository(
                         str(item.get("requirement_id")),
                         result,
                         trusted_journey_result_public_key_sha256,
+                        trusted_openssl,
                         emit_errors=False,
                     )
                 ]
@@ -1297,6 +1360,7 @@ def validate_repository(
                     requirement_id,
                     result,
                     trusted_journey_result_public_key_sha256,
+                    trusted_openssl,
                 ):
                     result.error(requirement_id, "sensitive conformant requirement requires valid signed journey-result evidence")
 
@@ -1307,8 +1371,9 @@ def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--root", default=".", help="repository root")
     parser.add_argument("--base-ref", default=None, help="trusted base ref for structured identity immutability checks")
+    parser.add_argument("--openssl-bin", default=None, help="absolute path to trusted OpenSSL")
     args = parser.parse_args(argv)
-    result = validate_repository(Path(args.root), args.base_ref)
+    result = validate_repository(Path(args.root), args.base_ref, openssl_bin=args.openssl_bin)
     if result.errors:
         for error in result.errors:
             print(f"error: {error}", file=sys.stderr)

--- a/scripts/promote-signed-journey-result.py
+++ b/scripts/promote-signed-journey-result.py
@@ -1,0 +1,218 @@
+#!/usr/bin/env python3
+"""Promote a requirement only when its signed journey-result validates."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import sys
+import tempfile
+from copy import deepcopy
+from pathlib import Path
+from typing import Any
+
+from check_spec_governance import (
+    JOURNEY_RESULT_ENVELOPE_SCHEMA,
+    JOURNEY_RESULT_PUBLIC_KEY_SHA256,
+    ValidationResult,
+    _load_json,
+    _source_under_journey_evidence,
+    _validate_signed_journey_result,
+    resolve_trusted_openssl,
+    validate_repository,
+)
+
+
+def die(message: str) -> None:
+    print(f"promote-signed-journey-result: {message}", file=sys.stderr)
+    raise SystemExit(1)
+
+
+def load_json_object(path: Path, label: str) -> dict[str, Any]:
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except OSError as exc:
+        die(f"cannot read {label}: {exc}")
+    except json.JSONDecodeError as exc:
+        die(f"{label} is not valid JSON: {exc}")
+    if not isinstance(value, dict):
+        die(f"{label} must be a JSON object")
+    return value
+
+
+def write_json_atomically(path: Path, value: dict[str, Any]) -> None:
+    payload = json.dumps(value, indent=2, sort_keys=False) + "\n"
+    with tempfile.NamedTemporaryFile("w", encoding="utf-8", dir=path.parent, prefix=f".{path.name}.", delete=False) as handle:
+        temporary = Path(handle.name)
+        handle.write(payload)
+    try:
+        os.replace(temporary, path)
+    finally:
+        if temporary.exists():
+            temporary.unlink()
+
+
+def require_relative_evidence_source(source: str) -> str:
+    candidate = Path(source)
+    if candidate.is_absolute():
+        die("signed evidence source must be repository-relative")
+    normalized = candidate.as_posix()
+    if normalized.startswith("../") or "/../" in normalized or normalized == "..":
+        die("signed evidence source must not contain parent traversal")
+    return normalized
+
+
+def require_signed_metadata(root: Path, source: str) -> tuple[str, str, str]:
+    if not _source_under_journey_evidence(root, source):
+        die("signed evidence source must be under journeys/evidence/")
+    envelope = load_json_object(root / source, "signed journey-result")
+    if envelope.get("schema_version") != JOURNEY_RESULT_ENVELOPE_SCHEMA:
+        die(f"signed evidence must use schema_version {JOURNEY_RESULT_ENVELOPE_SCHEMA!r}")
+    signed = envelope.get("signed")
+    if not isinstance(signed, dict):
+        die("signed evidence must contain a signed object")
+    repository = signed.get("repository")
+    if not isinstance(repository, dict) or not isinstance(repository.get("commit"), str):
+        die("signed evidence must bind repository.commit")
+    captured_at = signed.get("captured_at")
+    expires_at = signed.get("expires_at")
+    if not isinstance(captured_at, str) or len(captured_at) < 10:
+        die("signed evidence must bind captured_at")
+    if not isinstance(expires_at, str):
+        die("signed evidence must bind expires_at")
+    return repository["commit"], captured_at[:10], expires_at
+
+
+def require_valid_signed_result(
+    root: Path,
+    requirement: dict[str, Any],
+    evidence_source: str,
+    commit: str,
+    trusted_public_key_sha256: str,
+    openssl_bin: str,
+) -> None:
+    requirement_id = requirement.get("requirement_id")
+    journeys = requirement.get("journeys")
+    if not isinstance(requirement_id, str) or not isinstance(journeys, list):
+        die("target requirement must contain requirement_id and journeys")
+    result = ValidationResult()
+    if not _validate_signed_journey_result(
+        root,
+        evidence_source,
+        requirement_id,
+        [item for item in journeys if isinstance(item, str)],
+        {commit},
+        trusted_public_key_sha256,
+        openssl_bin,
+        f"{requirement_id}.signed_journey_result",
+        result,
+    ):
+        for error in result.errors:
+            print(f"error: {error}", file=sys.stderr)
+        die("signed journey-result rejected")
+
+
+def upsert_evidence(existing: list[Any], record: dict[str, Any]) -> list[Any]:
+    artifact = record["artifact"]
+    source = record["source"]
+    return [
+        item
+        for item in existing
+        if not (
+            isinstance(item, dict)
+            and (item.get("artifact") == artifact or (source is not None and item.get("source") == source))
+        )
+    ] + [record]
+
+
+def promote(
+    root: Path,
+    requirement_id: str,
+    evidence_source: str,
+    *,
+    base_ref: str,
+    trusted_public_key_sha256: str = JOURNEY_RESULT_PUBLIC_KEY_SHA256,
+    openssl_bin: str | None = None,
+) -> None:
+    try:
+        trusted_openssl = resolve_trusted_openssl(openssl_bin)
+    except ValueError as exc:
+        die(str(exc))
+    evidence_source = require_relative_evidence_source(evidence_source)
+    conformance_path = root / "specs" / "CONFORMANCE.json"
+    load_result = ValidationResult()
+    conformance = _load_json(conformance_path, load_result)
+    if load_result.errors:
+        for error in load_result.errors:
+            print(f"error: {error}", file=sys.stderr)
+        die("ledger promotion rejected")
+    if not isinstance(conformance, dict):
+        die("specs/CONFORMANCE.json must be a JSON object")
+    requirements = conformance.get("requirements")
+    if not isinstance(requirements, list):
+        die("specs/CONFORMANCE.json requirements must be an array")
+
+    matches = [item for item in requirements if isinstance(item, dict) and item.get("requirement_id") == requirement_id]
+    if len(matches) != 1:
+        die(f"requirement must exist exactly once: {requirement_id}")
+    requirement = matches[0]
+    commit, captured_at, expires_at = require_signed_metadata(root, evidence_source)
+    require_valid_signed_result(root, requirement, evidence_source, commit, trusted_public_key_sha256, trusted_openssl)
+    evidence_path = root / evidence_source
+    digest = hashlib.sha256(evidence_path.read_bytes()).hexdigest()
+
+    updated = deepcopy(requirement)
+    evidence = updated.get("evidence")
+    if not isinstance(evidence, list):
+        evidence = []
+    evidence = upsert_evidence(
+        evidence,
+        {
+            "artifact": f"commit:{commit}",
+            "source": None,
+            "captured_at": captured_at,
+            "expires_at": expires_at,
+        },
+    )
+    evidence = upsert_evidence(
+        evidence,
+        {
+            "artifact": f"sha256:{digest}",
+            "source": evidence_source,
+            "captured_at": captured_at,
+            "expires_at": expires_at,
+        },
+    )
+    updated["state"] = "conformant"
+    updated["evidence"] = evidence
+    updated["gap"] = None
+
+    requirement.clear()
+    requirement.update(updated)
+    result = validate_repository(root, base_ref, trusted_public_key_sha256, conformance_override=conformance, openssl_bin=trusted_openssl)
+    if result.errors:
+        for error in result.errors:
+            print(f"error: {error}", file=sys.stderr)
+        die("ledger promotion rejected")
+
+    write_json_atomically(conformance_path, conformance)
+    print(f"promote-signed-journey-result: promoted {requirement_id} with sha256:{digest}")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("requirement_id")
+    parser.add_argument("evidence_source", help="signed journey-result path under journeys/evidence/")
+    parser.add_argument("--root", default=".", help="repository root")
+    parser.add_argument("--base-ref", required=True, help="trusted base ref for governance validation")
+    parser.add_argument("--openssl-bin", default=None, help="absolute path to trusted OpenSSL")
+    args = parser.parse_args(argv)
+
+    promote(Path(args.root).resolve(), args.requirement_id, args.evidence_source, base_ref=args.base_ref, openssl_bin=args.openssl_bin)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/sign-journey-result.py
+++ b/scripts/sign-journey-result.py
@@ -1,0 +1,182 @@
+#!/usr/bin/env python3
+"""Sign a captured journey-result payload with the acceptance signing key."""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import json
+import os
+import subprocess
+import sys
+import tempfile
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from check_spec_governance import (
+    JOURNEY_RESULT_ENVELOPE_SCHEMA,
+    JOURNEY_RESULT_PAYLOAD_SCHEMA,
+    JOURNEY_RESULT_PUBLIC_KEY_PATH,
+    JOURNEY_RESULT_SIGNING_ALGORITHM,
+    JOURNEY_RESULT_SIGNING_DOMAIN,
+    JOURNEY_RESULT_SIGNING_KEY_ID,
+    ValidationResult,
+    _canonical_json_bytes,
+    _canonical_json_sha256,
+    _load_json,
+    resolve_trusted_openssl,
+)
+
+
+def die(message: str) -> None:
+    print(f"sign-journey-result: {message}", file=sys.stderr)
+    raise SystemExit(1)
+
+
+def load_object(path: Path, label: str) -> dict[str, Any]:
+    result = ValidationResult()
+    value = _load_json(path, result)
+    if result.errors:
+        for error in result.errors:
+            print(f"error: {error}", file=sys.stderr)
+        die(f"{label} rejected")
+    if not isinstance(value, dict):
+        die(f"{label} must be a JSON object")
+    return value
+
+
+def run_openssl(openssl_bin: str, args: list[str], *, input_bytes: bytes | None = None) -> bytes:
+    try:
+        completed = subprocess.run(
+            [openssl_bin, *args],
+            input=input_bytes,
+            capture_output=True,
+            check=False,
+            env={"PATH": "/usr/bin:/bin"},
+        )
+    except FileNotFoundError:
+        die("openssl is required")
+    if completed.returncode != 0:
+        detail = completed.stderr.decode("utf-8", errors="replace").strip()
+        die(detail or "openssl command failed")
+    return completed.stdout
+
+
+def read_private_key(env_name: str) -> str:
+    value = os.environ.get(env_name)
+    if not value:
+        die(f"protected signing key env var is required: {env_name}")
+    return value.rstrip("\n") + "\n"
+
+
+def safe_evidence_output_path(root: Path, output: str) -> Path:
+    requested = Path(output)
+    if not requested.is_absolute():
+        requested = root / requested
+    try:
+        evidence_root = (root / "journeys" / "evidence").resolve(strict=True)
+    except OSError as exc:
+        die(f"journey evidence directory is absent or unsafe: {exc}")
+    resolved = requested.resolve(strict=False)
+    try:
+        resolved.relative_to(evidence_root)
+    except ValueError:
+        die("output must be under journeys/evidence/")
+    if requested.exists() and requested.is_symlink():
+        die(f"output must not be a symlink: {requested}")
+    return resolved
+
+
+def write_json_atomically(path: Path, value: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    if path.parent.is_symlink():
+        die(f"output parent must not be a symlink: {path.parent}")
+    payload = json.dumps(value, indent=2, sort_keys=False) + "\n"
+    with tempfile.NamedTemporaryFile("w", encoding="utf-8", dir=path.parent, prefix=f".{path.name}.", delete=False) as handle:
+        temporary = Path(handle.name)
+        handle.write(payload)
+    try:
+        if path.exists() and path.is_symlink():
+            die(f"output must not be a symlink: {path}")
+        os.replace(temporary, path)
+    finally:
+        if temporary.exists():
+            temporary.unlink()
+
+
+def sign_payload(root: Path, signed: dict[str, Any], private_key_pem: str, verified_at: str, verifier: str, openssl_bin: str) -> dict[str, Any]:
+    if signed.get("schema_version") != JOURNEY_RESULT_PAYLOAD_SCHEMA:
+        die(f"signed.schema_version must equal {JOURNEY_RESULT_PAYLOAD_SCHEMA!r}")
+
+    public_key = root / JOURNEY_RESULT_PUBLIC_KEY_PATH
+    if not public_key.is_file() or public_key.is_symlink():
+        die(f"trusted public key is absent or unsafe: {JOURNEY_RESULT_PUBLIC_KEY_PATH}")
+
+    with tempfile.TemporaryDirectory(prefix="journey-result-signer.") as directory:
+        work = Path(directory)
+        private_path = work / "private.pem"
+        derived_public = work / "public.pem"
+        message = work / "message"
+        signature = work / "signature.der"
+
+        private_path.write_text(private_key_pem, encoding="utf-8")
+        private_path.chmod(0o600)
+        run_openssl(openssl_bin, ["pkey", "-in", str(private_path), "-pubout", "-out", str(derived_public)])
+        if derived_public.read_bytes() != public_key.read_bytes():
+            die("private signing key does not match the trusted journey-result public key")
+
+        message.write_bytes(JOURNEY_RESULT_SIGNING_DOMAIN + _canonical_json_bytes(signed))
+        run_openssl(openssl_bin, ["dgst", "-sha256", "-sign", str(private_path), "-out", str(signature), str(message)])
+        run_openssl(openssl_bin, ["dgst", "-sha256", "-verify", str(public_key), "-signature", str(signature), str(message)])
+        signature_b64 = base64.b64encode(signature.read_bytes()).decode("ascii")
+
+    return {
+        "schema_version": JOURNEY_RESULT_ENVELOPE_SCHEMA,
+        "signatures": [
+            {
+                "algorithm": JOURNEY_RESULT_SIGNING_ALGORITHM,
+                "key_id": JOURNEY_RESULT_SIGNING_KEY_ID,
+                "signature": signature_b64,
+                "signed_sha256": _canonical_json_sha256(signed),
+                "verified_at": verified_at,
+                "verifier": verifier,
+            }
+        ],
+        "signed": signed,
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--root", default=".", help="repository root")
+    parser.add_argument("--input", required=True, help="captured signed payload JSON")
+    parser.add_argument("--output", required=True, help="signed envelope output path")
+    parser.add_argument("--private-key-env", default="MACPROVIDER_ACCEPTANCE_SIGNING_KEY_PEM")
+    parser.add_argument("--openssl-bin", default=None, help="absolute path to trusted OpenSSL")
+    parser.add_argument("--verified-at", default=None, help="UTC timestamp, default: now")
+    parser.add_argument("--verifier", default="scripts/sign-journey-result.py")
+    parser.add_argument("--force", action="store_true", help="overwrite an existing output file")
+    args = parser.parse_args(argv)
+
+    root = Path(args.root).resolve()
+    input_path = Path(args.input)
+    if not input_path.is_absolute():
+        input_path = root / input_path
+    output_path = safe_evidence_output_path(root, args.output)
+    if output_path.exists() and not args.force:
+        die(f"output already exists: {output_path}")
+
+    verified_at = args.verified_at or datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+    try:
+        openssl_bin = resolve_trusted_openssl(args.openssl_bin)
+    except ValueError as exc:
+        die(str(exc))
+    envelope = sign_payload(root, load_object(input_path, "journey-result payload"), read_private_key(args.private_key_env), verified_at, args.verifier, openssl_bin)
+    write_json_atomically(output_path, envelope)
+    print(f"sign-journey-result: signed {output_path.relative_to(root)}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/tests/test_journey_result_tools.py
+++ b/scripts/tests/test_journey_result_tools.py
@@ -1,0 +1,508 @@
+from __future__ import annotations
+
+import hashlib
+import contextlib
+import io
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+import unittest
+import importlib.util
+from pathlib import Path
+
+from scripts.check_spec_governance import validate_repository
+from scripts.tests.test_spec_governance import (
+    signed_journey_envelope,
+    write_repository,
+    base_repository,
+)
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SIGNER = REPO_ROOT / "scripts" / "sign-journey-result.py"
+PROMOTER = REPO_ROOT / "scripts" / "promote-signed-journey-result.py"
+
+
+def generate_acceptance_key(root: Path) -> str:
+    openssl = shutil.which("openssl")
+    if openssl is None:
+        raise unittest.SkipTest("openssl is required")
+    security = root / "security"
+    security.mkdir(parents=True, exist_ok=True)
+    private_key = root / "private.pem"
+    public_key = security / "acceptance-candidate-signing-public.pem"
+    subprocess.run(
+        [openssl, "genpkey", "-algorithm", "EC", "-pkeyopt", "ec_paramgen_curve:P-256", "-out", str(private_key)],
+        check=True,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+    subprocess.run(
+        [openssl, "pkey", "-in", str(private_key), "-pubout", "-out", str(public_key)],
+        check=True,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+    return private_key.read_text(encoding="utf-8")
+
+
+def load_promoter_module():
+    spec = importlib.util.spec_from_file_location("promote_signed_journey_result", PROMOTER)
+    if spec is None or spec.loader is None:
+        raise AssertionError("could not load promoter module")
+    module = importlib.util.module_from_spec(spec)
+    sys.path.insert(0, str(REPO_ROOT / "scripts"))
+    try:
+        spec.loader.exec_module(module)
+    finally:
+        sys.path.pop(0)
+    return module
+
+
+class JourneyResultToolsTests(unittest.TestCase):
+    def test_signer_emits_validator_accepted_envelope(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            write_repository(root, base_repository())
+            commit = subprocess.check_output(["git", "rev-parse", "HEAD"], cwd=root, text=True).strip()
+            private_key = generate_acceptance_key(root)
+
+            payload_path = root / "journey-payload.json"
+            envelope = signed_journey_envelope(commit, signatures=[])
+            payload_path.write_text(json.dumps(envelope["signed"], indent=2) + "\n", encoding="utf-8")
+            evidence_path = root / "journeys" / "evidence" / "signed-result.json"
+            env = os.environ.copy()
+            env["MACPROVIDER_ACCEPTANCE_SIGNING_KEY_PEM"] = private_key
+            openssl = shutil.which("openssl")
+            if openssl is None:
+                raise unittest.SkipTest("openssl is required")
+
+            subprocess.run(
+                [
+                    sys.executable,
+                    str(SIGNER),
+                    "--root",
+                    str(root),
+                    "--input",
+                    str(payload_path),
+                    "--output",
+                    "journeys/evidence/signed-result.json",
+                    "--verified-at",
+                    "2026-01-01T00:00:01Z",
+                    "--openssl-bin",
+                    openssl,
+                ],
+                env=env,
+                check=True,
+                stdout=subprocess.DEVNULL,
+            )
+
+            conformance_path = root / "specs" / "CONFORMANCE.json"
+            conformance = json.loads(conformance_path.read_text(encoding="utf-8"))
+            requirement = conformance["requirements"][0]
+            requirement["state"] = "conformant"
+            requirement["gap"] = None
+            requirement["journeys"] = ["JOURNEY-BOOT"]
+            digest = hashlib.sha256(evidence_path.read_bytes()).hexdigest()
+            requirement["evidence"] = [
+                {
+                    "artifact": f"commit:{commit}",
+                    "source": None,
+                    "captured_at": "2026-01-01",
+                    "expires_at": "2027-01-01",
+                },
+                {
+                    "artifact": f"sha256:{digest}",
+                    "source": "journeys/evidence/signed-result.json",
+                    "captured_at": "2026-01-01",
+                    "expires_at": "2027-01-01",
+                },
+            ]
+            conformance_path.write_text(json.dumps(conformance, indent=2) + "\n", encoding="utf-8")
+            trusted_hash = hashlib.sha256((root / "security" / "acceptance-candidate-signing-public.pem").read_bytes()).hexdigest()
+
+            self.assertEqual([], validate_repository(root, trusted_journey_result_public_key_sha256=trusted_hash).errors)
+
+    def test_signer_rejects_duplicate_key_input(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            write_repository(root, base_repository())
+            private_key = generate_acceptance_key(root)
+            payload_path = root / "journey-payload.json"
+            payload_path.write_text(
+                '{"schema_version":"macprovider.journey-result.v1","schema_version":"macprovider.journey-result.v1"}\n',
+                encoding="utf-8",
+            )
+            env = os.environ.copy()
+            env["MACPROVIDER_ACCEPTANCE_SIGNING_KEY_PEM"] = private_key
+            openssl = shutil.which("openssl")
+            if openssl is None:
+                raise unittest.SkipTest("openssl is required")
+
+            completed = subprocess.run(
+                [
+                    sys.executable,
+                    str(SIGNER),
+                    "--root",
+                    str(root),
+                    "--input",
+                    str(payload_path),
+                    "--output",
+                    "journeys/evidence/signed-result.json",
+                    "--verified-at",
+                    "2026-01-01T00:00:01Z",
+                    "--openssl-bin",
+                    openssl,
+                ],
+                env=env,
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+
+            self.assertNotEqual(0, completed.returncode)
+            self.assertIn("duplicate JSON object key", completed.stderr)
+            self.assertFalse((root / "journeys" / "evidence" / "signed-result.json").exists())
+
+    def test_promoter_writes_only_after_signed_gate_accepts(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            write_repository(root, base_repository())
+            commit = subprocess.check_output(["git", "rev-parse", "HEAD"], cwd=root, text=True).strip()
+            private_key = generate_acceptance_key(root)
+            trusted_hash = hashlib.sha256((root / "security" / "acceptance-candidate-signing-public.pem").read_bytes()).hexdigest()
+            conformance_path = root / "specs" / "CONFORMANCE.json"
+            conformance = json.loads(conformance_path.read_text(encoding="utf-8"))
+            conformance["requirements"][0]["journeys"] = ["JOURNEY-BOOT"]
+            conformance_path.write_text(json.dumps(conformance, indent=2) + "\n", encoding="utf-8")
+            payload_path = root / "journey-payload.json"
+            envelope = signed_journey_envelope(commit, signatures=[])
+            payload_path.write_text(json.dumps(envelope["signed"], indent=2) + "\n", encoding="utf-8")
+            evidence_path = root / "journeys" / "evidence" / "signed-result.json"
+            env = os.environ.copy()
+            env["MACPROVIDER_ACCEPTANCE_SIGNING_KEY_PEM"] = private_key
+            openssl = shutil.which("openssl")
+            if openssl is None:
+                raise unittest.SkipTest("openssl is required")
+            subprocess.run(
+                [
+                    sys.executable,
+                    str(SIGNER),
+                    "--root",
+                    str(root),
+                    "--input",
+                    str(payload_path),
+                    "--output",
+                    "journeys/evidence/signed-result.json",
+                    "--verified-at",
+                    "2026-01-01T00:00:01Z",
+                    "--openssl-bin",
+                    openssl,
+                ],
+                env=env,
+                check=True,
+                stdout=subprocess.DEVNULL,
+            )
+
+            promoter = load_promoter_module()
+            with contextlib.redirect_stdout(io.StringIO()):
+                promoter.promote(
+                    root,
+                    "SPEC-001-R001",
+                    "journeys/evidence/signed-result.json",
+                    base_ref="HEAD",
+                    trusted_public_key_sha256=trusted_hash,
+                )
+
+            conformance = json.loads(conformance_path.read_text(encoding="utf-8"))
+            requirement = conformance["requirements"][0]
+            digest = hashlib.sha256(evidence_path.read_bytes()).hexdigest()
+            self.assertEqual("conformant", requirement["state"])
+            self.assertIsNone(requirement["gap"])
+            self.assertIn({"artifact": f"commit:{commit}", "source": None, "captured_at": "2026-01-01", "expires_at": "2027-01-01"}, requirement["evidence"])
+            self.assertIn(
+                {
+                    "artifact": f"sha256:{digest}",
+                    "source": "journeys/evidence/signed-result.json",
+                    "captured_at": "2026-01-01",
+                    "expires_at": "2027-01-01",
+                },
+                requirement["evidence"],
+            )
+            self.assertEqual([], validate_repository(root, trusted_journey_result_public_key_sha256=trusted_hash).errors)
+
+    def test_promoter_restores_ledger_when_gate_rejects(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            write_repository(root, base_repository())
+            commit = subprocess.check_output(["git", "rev-parse", "HEAD"], cwd=root, text=True).strip()
+            generate_acceptance_key(root)
+            evidence_path = root / "journeys" / "evidence" / "signed-result.json"
+            evidence_path.write_text(json.dumps(signed_journey_envelope(commit), indent=2) + "\n", encoding="utf-8")
+            conformance_path = root / "specs" / "CONFORMANCE.json"
+            original = conformance_path.read_text(encoding="utf-8")
+
+            completed = subprocess.run(
+                [
+                    sys.executable,
+                    str(PROMOTER),
+                    "--root",
+                    str(root),
+                    "--base-ref",
+                    "HEAD",
+                    "SPEC-001-R001",
+                    "journeys/evidence/signed-result.json",
+                ],
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+
+            self.assertNotEqual(0, completed.returncode)
+            self.assertIn("signed journey-result rejected", completed.stderr)
+            self.assertEqual(original, conformance_path.read_text(encoding="utf-8"))
+
+    def test_promoter_does_not_trust_path_hijacked_openssl(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            write_repository(root, base_repository())
+            conformance_path = root / "specs" / "CONFORMANCE.json"
+            conformance = json.loads(conformance_path.read_text(encoding="utf-8"))
+            conformance["requirements"][0]["journeys"] = ["JOURNEY-BOOT"]
+            conformance_path.write_text(json.dumps(conformance, indent=2) + "\n", encoding="utf-8")
+            commit = subprocess.check_output(["git", "rev-parse", "HEAD"], cwd=root, text=True).strip()
+            generate_acceptance_key(root)
+            evidence_path = root / "journeys" / "evidence" / "signed-result.json"
+            evidence_path.write_text(json.dumps(signed_journey_envelope(commit), indent=2) + "\n", encoding="utf-8")
+            fake_bin = root / "fake-bin"
+            fake_bin.mkdir()
+            fake_openssl = fake_bin / "openssl"
+            fake_openssl.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+            fake_openssl.chmod(0o755)
+            env = os.environ.copy()
+            env["PATH"] = f"{fake_bin}:{env.get('PATH', '')}"
+
+            completed = subprocess.run(
+                [
+                    sys.executable,
+                    str(PROMOTER),
+                    "--root",
+                    str(root),
+                    "--base-ref",
+                    "HEAD",
+                    "SPEC-001-R001",
+                    "journeys/evidence/signed-result.json",
+                ],
+                env=env,
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+
+            self.assertNotEqual(0, completed.returncode)
+            self.assertIn("signed journey-result rejected", completed.stderr)
+
+    def test_promoter_does_not_trust_ambient_openssl_bin(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            write_repository(root, base_repository())
+            conformance_path = root / "specs" / "CONFORMANCE.json"
+            conformance = json.loads(conformance_path.read_text(encoding="utf-8"))
+            conformance["requirements"][0]["journeys"] = ["JOURNEY-BOOT"]
+            conformance_path.write_text(json.dumps(conformance, indent=2) + "\n", encoding="utf-8")
+            commit = subprocess.check_output(["git", "rev-parse", "HEAD"], cwd=root, text=True).strip()
+            generate_acceptance_key(root)
+            evidence_path = root / "journeys" / "evidence" / "signed-result.json"
+            evidence_path.write_text(json.dumps(signed_journey_envelope(commit), indent=2) + "\n", encoding="utf-8")
+            fake_openssl = root / "fake-openssl"
+            fake_openssl.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+            fake_openssl.chmod(0o755)
+            env = os.environ.copy()
+            env["OPENSSL_BIN"] = str(fake_openssl)
+
+            completed = subprocess.run(
+                [
+                    sys.executable,
+                    str(PROMOTER),
+                    "--root",
+                    str(root),
+                    "--base-ref",
+                    "HEAD",
+                    "SPEC-001-R001",
+                    "journeys/evidence/signed-result.json",
+                ],
+                env=env,
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+
+            self.assertNotEqual(0, completed.returncode)
+            self.assertIn("signed journey-result rejected", completed.stderr)
+
+    def test_promoter_rejects_untrusted_openssl_override(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            write_repository(root, base_repository())
+            fake_openssl = root / "fake-openssl"
+            fake_openssl.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+            fake_openssl.chmod(0o755)
+
+            completed = subprocess.run(
+                [
+                    sys.executable,
+                    str(PROMOTER),
+                    "--root",
+                    str(root),
+                    "--base-ref",
+                    "HEAD",
+                    "--openssl-bin",
+                    str(fake_openssl),
+                    "SPEC-001-R001",
+                    "journeys/evidence/signed-result.json",
+                ],
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+
+            self.assertNotEqual(0, completed.returncode)
+            self.assertIn("trusted allowlist", completed.stderr)
+
+    def test_promoter_rejects_absolute_evidence_source(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            write_repository(root, base_repository())
+            source = root / "journeys" / "evidence" / "signed-result.json"
+            completed = subprocess.run(
+                [
+                    sys.executable,
+                    str(PROMOTER),
+                    "--root",
+                    str(root),
+                    "--base-ref",
+                    "HEAD",
+                    "SPEC-001-R001",
+                    str(source),
+                ],
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+
+            self.assertNotEqual(0, completed.returncode)
+            self.assertIn("repository-relative", completed.stderr)
+
+    def test_promoter_requires_base_ref(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            write_repository(root, base_repository())
+            completed = subprocess.run(
+                [
+                    sys.executable,
+                    str(PROMOTER),
+                    "--root",
+                    str(root),
+                    "SPEC-001-R001",
+                    "journeys/evidence/signed-result.json",
+                ],
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+
+            self.assertNotEqual(0, completed.returncode)
+            self.assertIn("--base-ref", completed.stderr)
+
+    def test_promoter_rejects_invalid_base_ref_without_rewrite(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            write_repository(root, base_repository())
+            commit = subprocess.check_output(["git", "rev-parse", "HEAD"], cwd=root, text=True).strip()
+            private_key = generate_acceptance_key(root)
+            trusted_hash = hashlib.sha256((root / "security" / "acceptance-candidate-signing-public.pem").read_bytes()).hexdigest()
+            conformance_path = root / "specs" / "CONFORMANCE.json"
+            conformance = json.loads(conformance_path.read_text(encoding="utf-8"))
+            conformance["requirements"][0]["journeys"] = ["JOURNEY-BOOT"]
+            conformance_path.write_text(json.dumps(conformance, indent=2) + "\n", encoding="utf-8")
+            original = conformance_path.read_text(encoding="utf-8")
+            payload_path = root / "journey-payload.json"
+            envelope = signed_journey_envelope(commit, signatures=[])
+            payload_path.write_text(json.dumps(envelope["signed"], indent=2) + "\n", encoding="utf-8")
+            env = os.environ.copy()
+            env["MACPROVIDER_ACCEPTANCE_SIGNING_KEY_PEM"] = private_key
+            openssl = shutil.which("openssl")
+            if openssl is None:
+                raise unittest.SkipTest("openssl is required")
+            subprocess.run(
+                [
+                    sys.executable,
+                    str(SIGNER),
+                    "--root",
+                    str(root),
+                    "--input",
+                    str(payload_path),
+                    "--output",
+                    "journeys/evidence/signed-result.json",
+                    "--verified-at",
+                    "2026-01-01T00:00:01Z",
+                    "--openssl-bin",
+                    openssl,
+                ],
+                env=env,
+                check=True,
+                stdout=subprocess.DEVNULL,
+            )
+
+            promoter = load_promoter_module()
+            stderr = io.StringIO()
+            with self.assertRaises(SystemExit), contextlib.redirect_stderr(stderr):
+                promoter.promote(
+                    root,
+                    "SPEC-001-R001",
+                    "journeys/evidence/signed-result.json",
+                    base_ref="definitely-not-a-real-ref",
+                    trusted_public_key_sha256=trusted_hash,
+                )
+
+            self.assertIn("cannot load specs/AUTHORITY.json", stderr.getvalue())
+            self.assertEqual(original, conformance_path.read_text(encoding="utf-8"))
+
+    def test_promoter_rejects_duplicate_key_ledger_without_rewrite(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            write_repository(root, base_repository())
+            conformance_path = root / "specs" / "CONFORMANCE.json"
+            malformed = conformance_path.read_text(encoding="utf-8").replace(
+                '"requirements": [',
+                '"requirements": [],\n  "requirements": [',
+                1,
+            )
+            conformance_path.write_text(malformed, encoding="utf-8")
+
+            completed = subprocess.run(
+                [
+                    sys.executable,
+                    str(PROMOTER),
+                    "--root",
+                    str(root),
+                    "--base-ref",
+                    "HEAD",
+                    "SPEC-001-R001",
+                    "journeys/evidence/signed-result.json",
+                ],
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+
+            self.assertNotEqual(0, completed.returncode)
+            self.assertIn("duplicate JSON object key", completed.stderr)
+            self.assertEqual(malformed, conformance_path.read_text(encoding="utf-8"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add a signed journey-result signer for retained journey payloads under journeys/evidence
- add a promotion helper that validates the signed result before updating CONFORMANCE.json
- harden governance validation against fake OpenSSL, duplicate-key JSON, invalid base refs, and write-before-validation promotion paths

## Provider pre-beta impact
This does not promote SPEC-016-R002 yet. It creates the executable gate for the payout-provider onboarding evidence slice: once the real payout-address registration journey produces a signed result artifact, run the promoter and the ledger moves only if that signed result validates.

## Validation
- python3 -m py_compile scripts/check_spec_governance.py scripts/sign-journey-result.py scripts/promote-signed-journey-result.py scripts/tests/test_journey_result_tools.py
- python3 -m unittest scripts.tests.test_journey_result_tools
- python3 -m unittest scripts.tests.test_spec_governance scripts.tests.test_journey_result_tools
- python3 scripts/check_spec_governance.py --base-ref origin/main
- python3 scripts/check_spec_governance.py
- go test ./internal/payout -run 'TestServePayoutAddress|TestServePayoutChallenge|TestVerifyEIP712|TestSelectReadyPayouts_FiltersByHotWalletAndCoolingOff' -count=1
- swift test --filter 'PayoutAddressClientTests|PayoutWalletFlowTests'
- code/security/architect audit lanes: 0 C/H/M

## Governance
- Issue: #897
- Parent governance: #614
- Ledger state: SPEC-016-R002 remains pending until signed payout-provider journey evidence validates

SPEC-GOVERNANCE-DECLARATION-BEGIN
{
  "schema_version": "spec-pr-governance-v1",
  "behavior_change": "yes",
  "contract_change": "none",
  "issue": "https://github.com/Augustas11/macprovider/issues/897",
  "specs": ["SPEC-016"],
  "requirements": ["SPEC-016-R002"],
  "authority_domains": ["payout-lifecycle"],
  "arbitration": ["UNKNOWN"],
  "tests": [
    "scripts/tests/test_journey_result_tools.py:JourneyResultToolsTests",
    "scripts/tests/test_spec_governance.py:GovernanceValidatorTests",
    "phase4-coordinator/internal/payout/addresses_test.go:TestServePayoutAddress_*",
    "phase4-coordinator/internal/payout/challenge_test.go:TestServePayoutChallenge_*",
    "phase4-coordinator/internal/payout/eip712_test.go:TestVerifyEIP712_*",
    "phase4-coordinator/internal/payout/attempts_test.go:TestSelectReadyPayouts_FiltersByHotWalletAndCoolingOff",
    "phase3-binary/Tests/macprovider-cliTests/PayoutAddressClientTests.swift:PayoutAddressClientTests",
    "phase3-binary/app/Tests/MalibuTests/PayoutWalletFlowTests.swift:PayoutWalletFlowTests"
  ],
  "journeys": ["JOURNEY-SPEC-016-PAYOUT-ADDRESS-REGISTRATION"]
}
SPEC-GOVERNANCE-DECLARATION-END
