### PR TITLE
Guard SPEC-016 payout journey promotion

### DIFF
--- a/schemas/journey-result-v1.schema.json
+++ b/schemas/journey-result-v1.schema.json
@@ -141,8 +141,241 @@
             "operator_identity_redacted": {"const": true},
             "local_account_names_redacted": {"const": true}
           }
+        },
+        "spec_id": {"type": "string", "pattern": "^SPEC-[0-9]{3}$"},
+        "run_id": {"type": "string", "minLength": 1},
+        "execution_mode": {"type": "string", "minLength": 1},
+        "harness": {"type": "object"},
+        "config_before": {"type": "object"},
+        "config_after": {"type": "object"},
+        "restoration": {"type": "object"},
+        "observations": {"type": "object"},
+        "eip712": {"type": "object"},
+        "candidate": {"type": "object"},
+        "signer": {"type": "object"}
+      },
+      "allOf": [
+        {
+          "if": {
+            "anyOf": [
+              {
+                "properties": {
+                  "journey_id": {"const": "JOURNEY-SPEC-016-PAYOUT-ADDRESS-REGISTRATION"}
+                },
+                "required": ["journey_id"]
+              },
+              {
+                "properties": {
+                  "requirement_ids": {"contains": {"const": "SPEC-016-R002"}}
+                },
+                "required": ["requirement_ids"]
+              }
+            ]
+          },
+          "then": {
+            "required": [
+              "spec_id",
+              "run_id",
+              "execution_mode",
+              "harness",
+              "config_before",
+              "config_after",
+              "restoration",
+              "observations",
+              "eip712",
+              "candidate",
+              "signer"
+            ],
+            "properties": {
+              "journey_id": {"const": "JOURNEY-SPEC-016-PAYOUT-ADDRESS-REGISTRATION"},
+              "spec_id": {"const": "SPEC-016"},
+              "requirement_ids": {"const": ["SPEC-016-R002"]},
+              "run_id": {"type": "string", "pattern": "^spec016-r002-payout-address-[A-Za-z0-9_.:-]+$"},
+              "execution_mode": {"const": "candidate-derived-handler-only-conformance-harness"},
+              "harness": {
+                "type": "object",
+                "additionalProperties": false,
+                "required": [
+                  "id",
+                  "version",
+                  "execution_mode",
+                  "isolated_sqlite",
+                  "real_provider_token_check",
+                  "real_pause_validation",
+                  "controlled_dependencies",
+                  "production_runner_built",
+                  "external_rpc_client_built",
+                  "settlement_signer_built",
+                  "release_promotion_attempted"
+                ],
+                "properties": {
+                  "id": {"type": "string", "minLength": 1},
+                  "version": {"type": "string", "minLength": 1},
+                  "execution_mode": {"const": "candidate-derived-handler-only-conformance-harness"},
+                  "isolated_sqlite": {"const": true},
+                  "real_provider_token_check": {"const": true},
+                  "real_pause_validation": {"const": true},
+                  "controlled_dependencies": {"const": true},
+                  "production_runner_built": {"const": false},
+                  "external_rpc_client_built": {"const": false},
+                  "settlement_signer_built": {"const": false},
+                  "release_promotion_attempted": {"const": false}
+                }
+              },
+              "config_before": {
+                "type": "object",
+                "additionalProperties": false,
+                "required": ["payout_enabled", "runner_started", "external_rpc_started", "settlement_signer_started"],
+                "properties": {
+                  "payout_enabled": {"const": false},
+                  "runner_started": {"const": false},
+                  "external_rpc_started": {"const": false},
+                  "settlement_signer_started": {"const": false}
+                }
+              },
+              "config_after": {
+                "type": "object",
+                "additionalProperties": false,
+                "required": [
+                  "payout_enabled",
+                  "runner_started",
+                  "external_rpc_started",
+                  "settlement_signer_started",
+                  "settlement_attempted",
+                  "production_side_effects"
+                ],
+                "properties": {
+                  "payout_enabled": {"const": false},
+                  "runner_started": {"const": false},
+                  "external_rpc_started": {"const": false},
+                  "settlement_signer_started": {"const": false},
+                  "settlement_attempted": {"const": false},
+                  "production_side_effects": {"const": false}
+                }
+              },
+              "restoration": {
+                "type": "object",
+                "additionalProperties": false,
+                "required": ["result"],
+                "properties": {
+                  "result": {"type": "string", "minLength": 1}
+                }
+              },
+              "observations": {
+                "type": "object",
+                "additionalProperties": false,
+                "required": [
+                  "provider_id_sha256",
+                  "hot_wallet_sha256",
+                  "first_address_sha256",
+                  "eip712_digest_sha256",
+                  "raw_signature_redacted",
+                  "provider_token_redacted",
+                  "private_keys_redacted"
+                ],
+                "properties": {
+                  "provider_id_sha256": {"type": "string", "pattern": "^[0-9a-f]{64}$"},
+                  "hot_wallet_sha256": {"type": "string", "pattern": "^[0-9a-f]{64}$"},
+                  "first_address_sha256": {"type": "string", "pattern": "^[0-9a-f]{64}$"},
+                  "rotated_address_sha256": {"type": "string", "pattern": "^[0-9a-f]{64}$"},
+                  "eip712_digest_sha256": {"type": "string", "pattern": "^[0-9a-f]{64}$"},
+                  "cooling_off_hours": {"type": "integer"},
+                  "raw_signature_redacted": {"const": true},
+                  "provider_token_redacted": {"const": true},
+                  "private_keys_redacted": {"const": true}
+                }
+              },
+              "eip712": {
+                "type": "object",
+                "additionalProperties": false,
+                "required": [
+                  "typed_data_artifact_sha256",
+                  "digest_sha256",
+                  "signer_address_sha256",
+                  "verifier",
+                  "verification_result",
+                  "raw_signature_access_controlled"
+                ],
+                "properties": {
+                  "typed_data_artifact_sha256": {"type": "string", "pattern": "^[0-9a-f]{64}$"},
+                  "digest_sha256": {"type": "string", "pattern": "^[0-9a-f]{64}$"},
+                  "signer_address_sha256": {"type": "string", "pattern": "^[0-9a-f]{64}$"},
+                  "verifier": {"type": "string", "minLength": 1},
+                  "verification_result": {"const": "pass"},
+                  "raw_signature_access_controlled": {"const": true}
+                }
+              },
+              "candidate": {
+                "type": "object",
+                "additionalProperties": false,
+                "required": ["payout_address_client_sha256"],
+                "properties": {
+                  "coordinator_sha256": {"type": "string", "pattern": "^[0-9a-f]{64}$"},
+                  "malibu_sha256": {"type": "string", "pattern": "^[0-9a-f]{64}$"},
+                  "addresses_go_sha256": {"type": "string", "pattern": "^[0-9a-f]{64}$"},
+                  "eip712_go_sha256": {"type": "string", "pattern": "^[0-9a-f]{64}$"},
+                  "attempts_go_sha256": {"type": "string", "pattern": "^[0-9a-f]{64}$"},
+                  "payout_address_client_sha256": {"type": "string", "pattern": "^[0-9a-f]{64}$"},
+                  "payout_wallet_flow_sha256": {"type": "string", "pattern": "^[0-9a-f]{64}$"},
+                  "payout_signer_resource_sha256": {"type": "string", "pattern": "^[0-9a-f]{64}$"}
+                },
+                "allOf": [
+                  {
+                    "anyOf": [
+                      {"required": ["coordinator_sha256"]},
+                      {"required": ["addresses_go_sha256", "eip712_go_sha256", "attempts_go_sha256"]}
+                    ]
+                  },
+                  {
+                    "anyOf": [
+                      {"required": ["malibu_sha256"]},
+                      {"required": ["payout_wallet_flow_sha256", "payout_signer_resource_sha256"]}
+                    ]
+                  }
+                ]
+              },
+              "signer": {
+                "type": "object",
+                "additionalProperties": false,
+                "required": ["key_id", "identity_fingerprint", "trust_root_sha256", "verification_result"],
+                "properties": {
+                  "key_id": {"type": "string", "minLength": 1},
+                  "identity_fingerprint": {"type": "string", "pattern": "^[0-9a-f]{64}$"},
+                  "trust_root_sha256": {"type": "string", "pattern": "^[0-9a-f]{64}$"},
+                  "verification_result": {"const": "pass"}
+                }
+              },
+              "artifacts": {
+                "items": {
+                  "not": {
+                    "properties": {
+                      "source": {"pattern": "\\.candidate\\.json$"}
+                    },
+                    "required": ["source"]
+                  }
+                }
+              },
+              "steps": {
+                "minItems": 11,
+                "maxItems": 11,
+                "allOf": [
+                  {"contains": {"properties": {"id": {"const": "step-01"}}, "required": ["id"]}, "minContains": 1, "maxContains": 1},
+                  {"contains": {"properties": {"id": {"const": "step-02"}}, "required": ["id"]}, "minContains": 1, "maxContains": 1},
+                  {"contains": {"properties": {"id": {"const": "step-03"}}, "required": ["id"]}, "minContains": 1, "maxContains": 1},
+                  {"contains": {"properties": {"id": {"const": "step-04"}}, "required": ["id"]}, "minContains": 1, "maxContains": 1},
+                  {"contains": {"properties": {"id": {"const": "step-05"}}, "required": ["id"]}, "minContains": 1, "maxContains": 1},
+                  {"contains": {"properties": {"id": {"const": "step-06"}}, "required": ["id"]}, "minContains": 1, "maxContains": 1},
+                  {"contains": {"properties": {"id": {"const": "step-07"}}, "required": ["id"]}, "minContains": 1, "maxContains": 1},
+                  {"contains": {"properties": {"id": {"const": "step-08"}}, "required": ["id"]}, "minContains": 1, "maxContains": 1},
+                  {"contains": {"properties": {"id": {"const": "step-09"}}, "required": ["id"]}, "minContains": 1, "maxContains": 1},
+                  {"contains": {"properties": {"id": {"const": "step-10"}}, "required": ["id"]}, "minContains": 1, "maxContains": 1},
+                  {"contains": {"properties": {"id": {"const": "step-11"}}, "required": ["id"]}, "minContains": 1, "maxContains": 1}
+                ]
+              }
+            }
+          }
         }
-      }
+      ]
     }
   }
 }

--- a/scripts/check_spec_governance.py
+++ b/scripts/check_spec_governance.py
@@ -34,6 +34,11 @@ JOURNEY_RESULT_SIGNING_KEY_ID = "macprovider-acceptance-p256-v1"
 JOURNEY_RESULT_SIGNING_DOMAIN = b"macprovider.journey-result.v1\n"
 JOURNEY_RESULT_PUBLIC_KEY_PATH = "security/acceptance-candidate-signing-public.pem"
 JOURNEY_RESULT_PUBLIC_KEY_SHA256 = "849e9c9bc53db1fb8e28d3b46ab431089b12cb50b398c5317ced682d39bdbd38"
+SPEC016_PAYOUT_JOURNEY_ID = "JOURNEY-SPEC-016-PAYOUT-ADDRESS-REGISTRATION"
+SPEC016_PAYOUT_SPEC_ID = "SPEC-016"
+SPEC016_PAYOUT_REQUIREMENT_ID = "SPEC-016-R002"
+SPEC016_PAYOUT_EXECUTION_MODE = "candidate-derived-handler-only-conformance-harness"
+SPEC016_PAYOUT_STEP_IDS = {f"step-{index:02d}" for index in range(1, 12)}
 TRUSTED_OPENSSL_CANDIDATES = (
     "/usr/bin/openssl",
     "/opt/homebrew/opt/openssl@3/bin/openssl",
@@ -204,6 +209,13 @@ def _string(value: Any, pattern: re.Pattern[str] | None, location: str, result: 
         result.error(location, f"invalid value {value!r}")
         return None
     return value
+
+
+def _bool_value(value: Any, location: str, result: ValidationResult) -> bool | None:
+    if isinstance(value, bool):
+        return value
+    result.error(location, "must be a boolean")
+    return None
 
 
 def _nullable_string(value: Any, pattern: re.Pattern[str], location: str, result: ValidationResult) -> str | None:
@@ -475,6 +487,224 @@ def _verify_journey_result_signature(
     return True
 
 
+def _require_false(mapping: dict[str, Any], field: str, location: str, result: ValidationResult) -> None:
+    value = _bool_value(mapping.get(field), f"{location}.{field}", result)
+    if value is not None and value is not False:
+        result.error(f"{location}.{field}", "must be false for SPEC-016 contract-only payout evidence")
+
+
+def _require_sha_field(mapping: dict[str, Any], field: str, location: str, result: ValidationResult) -> None:
+    _string(mapping.get(field), SHA256_HEX_RE, f"{location}.{field}", result)
+
+
+def _validate_spec016_payout_artifact(root: Path, artifact: dict[str, Any], location: str, result: ValidationResult) -> None:
+    source = artifact.get("source")
+    if not isinstance(source, str):
+        return
+    if source.endswith(".candidate.json"):
+        result.error(f"{location}.source", "SPEC-016 payout journey-result cannot promote candidate-only artifact files")
+        return
+    artifact_path = _repository_path(root, source, f"{location}.source", result)
+    if artifact_path is None:
+        return
+    payload = _load_json(artifact_path, ValidationResult())
+    if not isinstance(payload, dict):
+        return
+    if payload.get("schema_version") == "macprovider.journey-result-candidate.v1" or payload.get("promotion_ready") is False:
+        result.error(f"{location}.source", "SPEC-016 payout journey-result cannot promote candidate-only artifact content")
+
+
+def _validate_spec016_payout_journey_result(
+    root: Path,
+    signed: dict[str, Any],
+    source: str,
+    journeys: list[str],
+    artifacts: list[Any],
+    steps: list[Any],
+    location: str,
+    result: ValidationResult,
+) -> None:
+    if signed.get("journey_id") != SPEC016_PAYOUT_JOURNEY_ID:
+        result.error(f"{location}.signed.journey_id", f"must equal {SPEC016_PAYOUT_JOURNEY_ID!r}")
+    if journeys != [SPEC016_PAYOUT_JOURNEY_ID]:
+        result.error(location, f"SPEC-016 payout requirement journeys must equal [{SPEC016_PAYOUT_JOURNEY_ID!r}]")
+    if signed.get("spec_id") != SPEC016_PAYOUT_SPEC_ID:
+        result.error(f"{location}.signed.spec_id", f"must equal {SPEC016_PAYOUT_SPEC_ID!r}")
+    if signed.get("requirement_ids") != [SPEC016_PAYOUT_REQUIREMENT_ID]:
+        result.error(f"{location}.signed.requirement_ids", f"must equal [{SPEC016_PAYOUT_REQUIREMENT_ID!r}]")
+    if source.endswith(".candidate.json"):
+        result.error(location, "SPEC-016 payout journey-result cannot promote candidate-only artifact files")
+    _string(signed.get("run_id"), re.compile(r"^spec016-r002-payout-address-[A-Za-z0-9_.:-]+$"), f"{location}.signed.run_id", result)
+    if signed.get("execution_mode") != SPEC016_PAYOUT_EXECUTION_MODE:
+        result.error(f"{location}.signed.execution_mode", f"must equal {SPEC016_PAYOUT_EXECUTION_MODE!r}")
+
+    harness = signed.get("harness")
+    if _expect_object(harness, f"{location}.signed.harness", result):
+        allowed_harness = {
+            "id",
+            "version",
+            "execution_mode",
+            "isolated_sqlite",
+            "real_provider_token_check",
+            "real_pause_validation",
+            "controlled_dependencies",
+            "production_runner_built",
+            "external_rpc_client_built",
+            "settlement_signer_built",
+            "release_promotion_attempted",
+        }
+        _expect_keys(harness, allowed_harness, allowed_harness, f"{location}.signed.harness", result)
+        _string(harness.get("id"), None, f"{location}.signed.harness.id", result)
+        _string(harness.get("version"), None, f"{location}.signed.harness.version", result)
+        if harness.get("execution_mode") != SPEC016_PAYOUT_EXECUTION_MODE:
+            result.error(f"{location}.signed.harness.execution_mode", f"must equal {SPEC016_PAYOUT_EXECUTION_MODE!r}")
+        for field_name in (
+            "isolated_sqlite",
+            "real_provider_token_check",
+            "real_pause_validation",
+            "controlled_dependencies",
+        ):
+            value = _bool_value(harness.get(field_name), f"{location}.signed.harness.{field_name}", result)
+            if value is not None and value is not True:
+                result.error(f"{location}.signed.harness.{field_name}", "must be true")
+        for field_name in (
+            "production_runner_built",
+            "external_rpc_client_built",
+            "settlement_signer_built",
+            "release_promotion_attempted",
+        ):
+            _require_false(harness, field_name, f"{location}.signed.harness", result)
+
+    config_before = signed.get("config_before")
+    if _expect_object(config_before, f"{location}.signed.config_before", result):
+        required_config_before = {"payout_enabled", "runner_started", "external_rpc_started", "settlement_signer_started"}
+        _expect_keys(config_before, required_config_before, required_config_before, f"{location}.signed.config_before", result)
+        for field_name in sorted(required_config_before):
+            _require_false(config_before, field_name, f"{location}.signed.config_before", result)
+
+    config_after = signed.get("config_after")
+    if _expect_object(config_after, f"{location}.signed.config_after", result):
+        required_config_after = {
+            "payout_enabled",
+            "runner_started",
+            "external_rpc_started",
+            "settlement_signer_started",
+            "settlement_attempted",
+            "production_side_effects",
+        }
+        _expect_keys(config_after, required_config_after, required_config_after, f"{location}.signed.config_after", result)
+        for field_name in sorted(required_config_after):
+            _require_false(config_after, field_name, f"{location}.signed.config_after", result)
+
+    restoration = signed.get("restoration")
+    if _expect_object(restoration, f"{location}.signed.restoration", result):
+        _expect_keys(restoration, {"result"}, {"result"}, f"{location}.signed.restoration", result)
+        _string(restoration.get("result"), None, f"{location}.signed.restoration.result", result)
+
+    observations = signed.get("observations")
+    if _expect_object(observations, f"{location}.signed.observations", result):
+        required_observations = {
+            "provider_id_sha256",
+            "hot_wallet_sha256",
+            "first_address_sha256",
+            "eip712_digest_sha256",
+            "raw_signature_redacted",
+            "provider_token_redacted",
+            "private_keys_redacted",
+        }
+        allowed_observations = required_observations | {"rotated_address_sha256", "cooling_off_hours"}
+        _expect_keys(observations, required_observations, allowed_observations, f"{location}.signed.observations", result)
+        for field_name in ("provider_id_sha256", "hot_wallet_sha256", "first_address_sha256", "eip712_digest_sha256"):
+            _require_sha_field(observations, field_name, f"{location}.signed.observations", result)
+        if "rotated_address_sha256" in observations:
+            _require_sha_field(observations, "rotated_address_sha256", f"{location}.signed.observations", result)
+        if "cooling_off_hours" in observations and not isinstance(observations.get("cooling_off_hours"), int):
+            result.error(f"{location}.signed.observations.cooling_off_hours", "must be an integer")
+        for field_name in ("raw_signature_redacted", "provider_token_redacted", "private_keys_redacted"):
+            value = _bool_value(observations.get(field_name), f"{location}.signed.observations.{field_name}", result)
+            if value is not None and value is not True:
+                result.error(f"{location}.signed.observations.{field_name}", "must be true")
+
+    eip712 = signed.get("eip712")
+    if _expect_object(eip712, f"{location}.signed.eip712", result):
+        required_eip712 = {
+            "typed_data_artifact_sha256",
+            "digest_sha256",
+            "signer_address_sha256",
+            "verifier",
+            "verification_result",
+            "raw_signature_access_controlled",
+        }
+        _expect_keys(eip712, required_eip712, required_eip712, f"{location}.signed.eip712", result)
+        for field_name in ("typed_data_artifact_sha256", "digest_sha256", "signer_address_sha256"):
+            _require_sha_field(eip712, field_name, f"{location}.signed.eip712", result)
+        _string(eip712.get("verifier"), None, f"{location}.signed.eip712.verifier", result)
+        if eip712.get("verification_result") != "pass":
+            result.error(f"{location}.signed.eip712.verification_result", "must equal 'pass'")
+        value = _bool_value(eip712.get("raw_signature_access_controlled"), f"{location}.signed.eip712.raw_signature_access_controlled", result)
+        if value is not None and value is not True:
+            result.error(f"{location}.signed.eip712.raw_signature_access_controlled", "must be true")
+
+    candidate = signed.get("candidate")
+    if _expect_object(candidate, f"{location}.signed.candidate", result):
+        allowed_candidate = {
+            "coordinator_sha256",
+            "malibu_sha256",
+            "addresses_go_sha256",
+            "eip712_go_sha256",
+            "attempts_go_sha256",
+            "payout_address_client_sha256",
+            "payout_wallet_flow_sha256",
+            "payout_signer_resource_sha256",
+        }
+        _expect_keys(candidate, {"payout_address_client_sha256"}, allowed_candidate, f"{location}.signed.candidate", result)
+        coordinator_hash_fields = ("addresses_go_sha256", "eip712_go_sha256", "attempts_go_sha256")
+        if "coordinator_sha256" in candidate:
+            _require_sha_field(candidate, "coordinator_sha256", f"{location}.signed.candidate", result)
+        else:
+            for field_name in coordinator_hash_fields:
+                _require_sha_field(candidate, field_name, f"{location}.signed.candidate", result)
+        _require_sha_field(candidate, "payout_address_client_sha256", f"{location}.signed.candidate", result)
+        if "malibu_sha256" in candidate:
+            _require_sha_field(candidate, "malibu_sha256", f"{location}.signed.candidate", result)
+        else:
+            _require_sha_field(candidate, "payout_wallet_flow_sha256", f"{location}.signed.candidate", result)
+            _require_sha_field(candidate, "payout_signer_resource_sha256", f"{location}.signed.candidate", result)
+
+    signer = signed.get("signer")
+    if _expect_object(signer, f"{location}.signed.signer", result):
+        required_signer = {"key_id", "identity_fingerprint", "trust_root_sha256", "verification_result"}
+        _expect_keys(signer, required_signer, required_signer, f"{location}.signed.signer", result)
+        _string(signer.get("key_id"), None, f"{location}.signed.signer.key_id", result)
+        _require_sha_field(signer, "identity_fingerprint", f"{location}.signed.signer", result)
+        _require_sha_field(signer, "trust_root_sha256", f"{location}.signed.signer", result)
+        if signer.get("verification_result") != "pass":
+            result.error(f"{location}.signed.signer.verification_result", "must equal 'pass'")
+
+    observed_step_ids: set[str] = set()
+    valid_step_count = 0
+    for index, step in enumerate(steps):
+        if not isinstance(step, dict) or not isinstance(step.get("id"), str):
+            continue
+        valid_step_count += 1
+        step_id = step["id"]
+        if step_id in observed_step_ids:
+            result.error(f"{location}.signed.steps[{index}].id", f"duplicate SPEC-016 payout physical step {step_id!r}")
+        observed_step_ids.add(step_id)
+    missing_steps = SPEC016_PAYOUT_STEP_IDS - observed_step_ids
+    unexpected_steps = observed_step_ids - SPEC016_PAYOUT_STEP_IDS
+    if missing_steps:
+        result.error(f"{location}.signed.steps", f"missing SPEC-016 payout physical steps: {sorted(missing_steps)}")
+    if unexpected_steps:
+        result.error(f"{location}.signed.steps", f"unexpected SPEC-016 payout physical steps: {sorted(unexpected_steps)}")
+    if valid_step_count != len(SPEC016_PAYOUT_STEP_IDS):
+        result.error(f"{location}.signed.steps", f"must contain exactly {len(SPEC016_PAYOUT_STEP_IDS)} SPEC-016 payout physical steps")
+
+    for index, artifact in enumerate(artifacts):
+        if isinstance(artifact, dict):
+            _validate_spec016_payout_artifact(root, artifact, f"{location}.signed.artifacts[{index}]", result)
+
+
 def _validate_signed_journey_result(
     root: Path,
     source: str,
@@ -559,6 +789,17 @@ def _validate_signed_journey_result(
             "result",
             "steps",
             "redaction",
+            "spec_id",
+            "run_id",
+            "execution_mode",
+            "harness",
+            "config_before",
+            "config_after",
+            "restoration",
+            "observations",
+            "eip712",
+            "candidate",
+            "signer",
         },
         f"{location}.signed",
         result,
@@ -607,13 +848,13 @@ def _validate_signed_journey_result(
             result.error(f"{location}.signed.repository.commit", "must match this requirement's commit evidence")
 
     artifact_ids: set[str] = set()
-    artifacts = signed.get("artifacts")
-    if not isinstance(artifacts, list):
+    artifact_records = signed.get("artifacts")
+    if not isinstance(artifact_records, list):
         result.error(f"{location}.signed.artifacts", "field 'artifacts' must be an array")
-        artifacts = []
-    if not artifacts:
+        artifact_records = []
+    if not artifact_records:
         result.error(f"{location}.signed.artifacts", "must contain at least one hash-bound artifact")
-    for index, artifact in enumerate(artifacts):
+    for index, artifact in enumerate(artifact_records):
         loc = f"{location}.signed.artifacts[{index}]"
         if not _expect_object(artifact, loc, result):
             continue
@@ -660,10 +901,10 @@ def _validate_signed_journey_result(
         _string(step.get("id"), None, f"{loc}.id", result)
         if step.get("status") != "pass":
             result.error(f"{loc}.status", "must equal 'pass'")
-        artifacts = _string_list(step.get("artifacts"), f"{loc}.artifacts", result)
-        if not artifacts:
+        step_artifacts = _string_list(step.get("artifacts"), f"{loc}.artifacts", result)
+        if not step_artifacts:
             result.error(f"{loc}.artifacts", "must contain at least one artifact reference")
-        for artifact_id in artifacts:
+        for artifact_id in step_artifacts:
             if artifact_ids and artifact_id not in artifact_ids:
                 result.error(f"{loc}.artifacts", f"unknown artifact reference {artifact_id!r}")
         if "assertion" in step:
@@ -676,6 +917,11 @@ def _validate_signed_journey_result(
         for field_name in sorted(required_redactions):
             if redaction.get(field_name) is not True:
                 result.error(f"{location}.signed.redaction.{field_name}", "must be true")
+
+    if journey_id == SPEC016_PAYOUT_JOURNEY_ID or requirement_id == SPEC016_PAYOUT_REQUIREMENT_ID:
+        if requirement_id != SPEC016_PAYOUT_REQUIREMENT_ID:
+            result.error(f"{location}.signed.requirement_ids", f"SPEC-016 payout journey-result may only promote {SPEC016_PAYOUT_REQUIREMENT_ID}")
+        _validate_spec016_payout_journey_result(root, signed, source, journeys, artifact_records, steps, location, result)
 
     return len(result.errors) == before
 

--- a/scripts/tests/fixtures/spec_governance/spec016_payout_signed_journey_result_candidate_artifact.json
+++ b/scripts/tests/fixtures/spec_governance/spec016_payout_signed_journey_result_candidate_artifact.json
@@ -1,0 +1,6 @@
+{
+  "mutation": {
+    "operation": "spec016_payout_signed_journey_result_candidate_artifact"
+  },
+  "expected": "SPEC-016 payout journey-result cannot promote candidate-only artifact files"
+}

--- a/scripts/tests/fixtures/spec_governance/spec016_payout_signed_journey_result_duplicate_step.json
+++ b/scripts/tests/fixtures/spec_governance/spec016_payout_signed_journey_result_duplicate_step.json
@@ -1,0 +1,6 @@
+{
+  "mutation": {
+    "operation": "spec016_payout_signed_journey_result_duplicate_step"
+  },
+  "expected": "duplicate SPEC-016 payout physical step 'step-01'"
+}

--- a/scripts/tests/fixtures/spec_governance/spec016_payout_signed_journey_result_extra_secret_field.json
+++ b/scripts/tests/fixtures/spec_governance/spec016_payout_signed_journey_result_extra_secret_field.json
@@ -1,0 +1,6 @@
+{
+  "mutation": {
+    "operation": "spec016_payout_signed_journey_result_extra_secret_field"
+  },
+  "expected": "SPEC-016-R002.evidence[1].source.signed.observations: unexpected field 'provider_token_raw'"
+}

--- a/scripts/tests/fixtures/spec_governance/spec016_payout_signed_journey_result_missing_contract_fields.json
+++ b/scripts/tests/fixtures/spec_governance/spec016_payout_signed_journey_result_missing_contract_fields.json
@@ -1,0 +1,6 @@
+{
+  "mutation": {
+    "operation": "spec016_payout_signed_journey_result_missing_contract_fields"
+  },
+  "expected": "SPEC-016-R002.evidence[1].source.signed.spec_id: must equal 'SPEC-016'"
+}

--- a/scripts/tests/fixtures/spec_governance/spec016_payout_signed_journey_result_wrong_journey.json
+++ b/scripts/tests/fixtures/spec_governance/spec016_payout_signed_journey_result_wrong_journey.json
@@ -1,0 +1,6 @@
+{
+  "mutation": {
+    "operation": "spec016_payout_signed_journey_result_wrong_journey"
+  },
+  "expected": "SPEC-016 payout requirement journeys must equal ['JOURNEY-SPEC-016-PAYOUT-ADDRESS-REGISTRATION']"
+}

--- a/scripts/tests/test_journey_result_tools.py
+++ b/scripts/tests/test_journey_result_tools.py
@@ -15,6 +15,10 @@ from pathlib import Path
 
 from scripts.check_spec_governance import validate_repository
 from scripts.tests.test_spec_governance import (
+    SPEC016_PAYOUT_JOURNEY_ID,
+    SPEC016_PAYOUT_RUN_ID,
+    apply_mutation,
+    spec016_payout_signed_envelope,
     signed_journey_envelope,
     write_repository,
     base_repository,
@@ -263,6 +267,74 @@ class JourneyResultToolsTests(unittest.TestCase):
 
             self.assertNotEqual(0, completed.returncode)
             self.assertIn("signed journey-result rejected", completed.stderr)
+            self.assertEqual(original, conformance_path.read_text(encoding="utf-8"))
+
+    def test_promoter_rejects_spec016_candidate_only_artifact_without_rewrite(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            repository = base_repository()
+            apply_mutation(repository, {"operation": "valid_spec016_payout_signed_journey_result"})
+            write_repository(root, repository)
+            commit = subprocess.check_output(["git", "rev-parse", "HEAD"], cwd=root, text=True).strip()
+            private_key = generate_acceptance_key(root)
+            trusted_hash = hashlib.sha256((root / "security" / "acceptance-candidate-signing-public.pem").read_bytes()).hexdigest()
+            candidate_path = root / "journeys" / "evidence" / "spec016-payout.candidate.json"
+            candidate_path.write_text(
+                json.dumps({
+                    "schema_version": "macprovider.journey-result-candidate.v1",
+                    "journey_id": SPEC016_PAYOUT_JOURNEY_ID,
+                    "run_id": SPEC016_PAYOUT_RUN_ID,
+                    "promotion_ready": False,
+                }, indent=2) + "\n",
+                encoding="utf-8",
+            )
+            artifact_record = {
+                "id": "redacted-payout-address-journey",
+                "sha256": hashlib.sha256(candidate_path.read_bytes()).hexdigest(),
+                "source": "journeys/evidence/spec016-payout.candidate.json",
+            }
+            payload_path = root / "journey-payload.json"
+            envelope = spec016_payout_signed_envelope(commit, artifact_record)
+            payload_path.write_text(json.dumps(envelope["signed"], indent=2) + "\n", encoding="utf-8")
+            env = os.environ.copy()
+            env["MACPROVIDER_ACCEPTANCE_SIGNING_KEY_PEM"] = private_key
+            openssl = shutil.which("openssl")
+            if openssl is None:
+                raise unittest.SkipTest("openssl is required")
+            subprocess.run(
+                [
+                    sys.executable,
+                    str(SIGNER),
+                    "--root",
+                    str(root),
+                    "--input",
+                    str(payload_path),
+                    "--output",
+                    "journeys/evidence/signed-result.json",
+                    "--verified-at",
+                    "2026-01-01T00:00:01Z",
+                    "--openssl-bin",
+                    openssl,
+                ],
+                env=env,
+                check=True,
+                stdout=subprocess.DEVNULL,
+            )
+            conformance_path = root / "specs" / "CONFORMANCE.json"
+            original = conformance_path.read_text(encoding="utf-8")
+
+            promoter = load_promoter_module()
+            stderr = io.StringIO()
+            with self.assertRaises(SystemExit), contextlib.redirect_stderr(stderr):
+                promoter.promote(
+                    root,
+                    "SPEC-016-R002",
+                    "journeys/evidence/signed-result.json",
+                    base_ref="HEAD",
+                    trusted_public_key_sha256=trusted_hash,
+                )
+
+            self.assertIn("SPEC-016 payout journey-result cannot promote candidate-only artifact files", stderr.getvalue())
             self.assertEqual(original, conformance_path.read_text(encoding="utf-8"))
 
     def test_promoter_does_not_trust_path_hijacked_openssl(self) -> None:

--- a/scripts/tests/test_spec_governance.py
+++ b/scripts/tests/test_spec_governance.py
@@ -19,6 +19,8 @@ GAP = {
     "owner": "@owner",
     "issue": "https://github.com/Augustas11/macprovider/issues/614",
 }
+SPEC016_PAYOUT_JOURNEY_ID = "JOURNEY-SPEC-016-PAYOUT-ADDRESS-REGISTRATION"
+SPEC016_PAYOUT_RUN_ID = "spec016-r002-payout-address-20260101T000000Z"
 
 
 def canonical_json_bytes(value: object) -> bytes:
@@ -100,6 +102,93 @@ def signed_journey_envelope(
         "signatures": envelope_signatures,
         "signed": signed,
     }
+
+
+def spec016_payout_signed_envelope(commit: str, artifact_record: dict[str, str]) -> dict[str, object]:
+    envelope = signed_journey_envelope(
+        commit,
+        requirement_ids=["SPEC-016-R002"],
+        journey_id=SPEC016_PAYOUT_JOURNEY_ID,
+        artifact_records=[artifact_record],
+        artifacts=[artifact_record["id"]],
+    )
+    signed = envelope["signed"]
+    assert isinstance(signed, dict)
+    signed.update({
+        "spec_id": "SPEC-016",
+        "run_id": SPEC016_PAYOUT_RUN_ID,
+        "execution_mode": "candidate-derived-handler-only-conformance-harness",
+        "harness": {
+            "id": "phase4-coordinator/internal/payout:TestPayoutAddressRegistrationJourneyEvidence",
+            "version": "v1",
+            "execution_mode": "candidate-derived-handler-only-conformance-harness",
+            "isolated_sqlite": True,
+            "real_provider_token_check": True,
+            "real_pause_validation": True,
+            "controlled_dependencies": True,
+            "production_runner_built": False,
+            "external_rpc_client_built": False,
+            "settlement_signer_built": False,
+            "release_promotion_attempted": False,
+        },
+        "config_before": {
+            "payout_enabled": False,
+            "runner_started": False,
+            "external_rpc_started": False,
+            "settlement_signer_started": False,
+        },
+        "config_after": {
+            "payout_enabled": False,
+            "runner_started": False,
+            "external_rpc_started": False,
+            "settlement_signer_started": False,
+            "settlement_attempted": False,
+            "production_side_effects": False,
+        },
+        "restoration": {"result": "isolated SQLite tempdir removed by test cleanup"},
+        "observations": {
+            "provider_id_sha256": "b" * 64,
+            "hot_wallet_sha256": "c" * 64,
+            "first_address_sha256": "d" * 64,
+            "eip712_digest_sha256": "e" * 64,
+            "raw_signature_redacted": True,
+            "provider_token_redacted": True,
+            "private_keys_redacted": True,
+        },
+        "eip712": {
+            "typed_data_artifact_sha256": "1" * 64,
+            "digest_sha256": "2" * 64,
+            "signer_address_sha256": "3" * 64,
+            "verifier": "fixture-eip712-verifier",
+            "verification_result": "pass",
+            "raw_signature_access_controlled": True,
+        },
+        "candidate": {
+            "addresses_go_sha256": "4" * 64,
+            "eip712_go_sha256": "5" * 64,
+            "attempts_go_sha256": "6" * 64,
+            "payout_address_client_sha256": "7" * 64,
+            "payout_wallet_flow_sha256": "8" * 64,
+            "payout_signer_resource_sha256": "9" * 64,
+        },
+        "signer": {
+            "key_id": "macprovider-acceptance-p256-v1",
+            "identity_fingerprint": "a" * 64,
+            "trust_root_sha256": "f" * 64,
+            "verification_result": "pass",
+        },
+        "steps": [
+            {
+                "id": f"step-{index:02d}",
+                "status": "pass",
+                "assertion": f"fixture SPEC-016 payout assertion {index:02d}",
+                "artifacts": [artifact_record["id"]],
+            }
+            for index in range(1, 12)
+        ],
+    })
+    envelope["signatures"][0]["signed_sha256"] = hashlib.sha256(canonical_json_bytes(signed)).hexdigest()
+    return envelope
 
 
 def sign_journey_envelope(root: Path, envelope: dict[str, object], *, corrupt_signature: bool = False) -> None:
@@ -339,6 +428,12 @@ def apply_post_write_mutation(root: Path, repository: dict[str, object]) -> None
         "signed_journey_result_commit_mismatch",
         "signed_journey_result_mixed_physical_evidence",
         "production_physically_verified_with_pending_requirement",
+        "valid_spec016_payout_signed_journey_result",
+        "spec016_payout_signed_journey_result_missing_contract_fields",
+        "spec016_payout_signed_journey_result_candidate_artifact",
+        "spec016_payout_signed_journey_result_wrong_journey",
+        "spec016_payout_signed_journey_result_duplicate_step",
+        "spec016_payout_signed_journey_result_extra_secret_field",
     }:
         if operation == "signed_journey_result_missing_signature":
             envelope = signed_journey_envelope(commit, signatures=[])
@@ -374,6 +469,77 @@ def apply_post_write_mutation(root: Path, repository: dict[str, object]) -> None
             })
             conformance["specs"][0]["production_status"] = "physically-verified"
             envelope = signed_journey_envelope(commit)
+        elif operation in {
+            "valid_spec016_payout_signed_journey_result",
+            "spec016_payout_signed_journey_result_missing_contract_fields",
+            "spec016_payout_signed_journey_result_candidate_artifact",
+            "spec016_payout_signed_journey_result_wrong_journey",
+            "spec016_payout_signed_journey_result_duplicate_step",
+            "spec016_payout_signed_journey_result_extra_secret_field",
+        }:
+            redacted_path = root / "journeys" / "evidence" / "spec016-payout-redacted.json"
+            redacted_path.write_text(
+                json.dumps({
+                    "schema_version": "macprovider.payout-address-journey-evidence.v1",
+                    "journey_id": SPEC016_PAYOUT_JOURNEY_ID,
+                    "run_id": SPEC016_PAYOUT_RUN_ID,
+                    "redacted": True,
+                }, indent=2) + "\n",
+                encoding="utf-8",
+            )
+            artifact_record = {
+                "id": "redacted-payout-address-journey",
+                "sha256": hashlib.sha256(redacted_path.read_bytes()).hexdigest(),
+                "source": "journeys/evidence/spec016-payout-redacted.json",
+            }
+            if operation == "spec016_payout_signed_journey_result_candidate_artifact":
+                candidate_path = root / "journeys" / "evidence" / "spec016-payout.candidate.json"
+                candidate_path.write_text(
+                    json.dumps({
+                        "schema_version": "macprovider.journey-result-candidate.v1",
+                        "journey_id": SPEC016_PAYOUT_JOURNEY_ID,
+                        "run_id": SPEC016_PAYOUT_RUN_ID,
+                        "promotion_ready": False,
+                    }, indent=2) + "\n",
+                    encoding="utf-8",
+                )
+                artifact_record = {
+                    "id": "redacted-payout-address-journey",
+                    "sha256": hashlib.sha256(candidate_path.read_bytes()).hexdigest(),
+                    "source": "journeys/evidence/spec016-payout.candidate.json",
+                }
+            if operation == "spec016_payout_signed_journey_result_wrong_journey":
+                envelope = signed_journey_envelope(
+                    commit,
+                    requirement_ids=["SPEC-016-R002"],
+                    journey_id="JOURNEY-BOOT",
+                    artifact_records=[artifact_record],
+                    artifacts=[artifact_record["id"]],
+                )
+            elif operation == "spec016_payout_signed_journey_result_missing_contract_fields":
+                envelope = signed_journey_envelope(
+                    commit,
+                    requirement_ids=["SPEC-016-R002"],
+                    journey_id=SPEC016_PAYOUT_JOURNEY_ID,
+                    artifact_records=[artifact_record],
+                    artifacts=[artifact_record["id"]],
+                )
+            else:
+                envelope = spec016_payout_signed_envelope(commit, artifact_record)
+                if operation == "spec016_payout_signed_journey_result_duplicate_step":
+                    signed = envelope["signed"]
+                    assert isinstance(signed, dict)
+                    steps = signed["steps"]
+                    assert isinstance(steps, list)
+                    steps.append(copy.deepcopy(steps[0]))
+                    envelope["signatures"][0]["signed_sha256"] = hashlib.sha256(canonical_json_bytes(signed)).hexdigest()
+                elif operation == "spec016_payout_signed_journey_result_extra_secret_field":
+                    signed = envelope["signed"]
+                    assert isinstance(signed, dict)
+                    observations = signed["observations"]
+                    assert isinstance(observations, dict)
+                    observations["provider_token_raw"] = "secret-token-would-leak"
+                    envelope["signatures"][0]["signed_sha256"] = hashlib.sha256(canonical_json_bytes(signed)).hexdigest()
         else:
             envelope = signed_journey_envelope(commit)
         if envelope["signatures"]:
@@ -381,7 +547,19 @@ def apply_post_write_mutation(root: Path, repository: dict[str, object]) -> None
         evidence_path = root / "journeys" / "evidence" / "signed-result.json"
         evidence_path.write_text(json.dumps(envelope, indent=2, sort_keys=False) + "\n", encoding="utf-8")
         digest = hashlib.sha256(evidence_path.read_bytes()).hexdigest()
-        requirement["journeys"] = ["JOURNEY-BOOT"]
+        if operation in {
+            "valid_spec016_payout_signed_journey_result",
+            "spec016_payout_signed_journey_result_missing_contract_fields",
+            "spec016_payout_signed_journey_result_candidate_artifact",
+            "spec016_payout_signed_journey_result_wrong_journey",
+            "spec016_payout_signed_journey_result_duplicate_step",
+            "spec016_payout_signed_journey_result_extra_secret_field",
+        }:
+            requirement["journeys"] = [SPEC016_PAYOUT_JOURNEY_ID]
+            if operation == "spec016_payout_signed_journey_result_wrong_journey":
+                requirement["journeys"] = ["JOURNEY-BOOT"]
+        else:
+            requirement["journeys"] = ["JOURNEY-BOOT"]
         requirement["evidence"] = [
             {
                 "artifact": f"commit:{commit}",
@@ -497,6 +675,35 @@ def apply_mutation(repository: dict[str, object], mutation: dict[str, object]) -
         repository["_post_write_operation"] = "sensitive_conformant_without_signed_result"
     elif operation == "valid_signed_journey_result":
         repository["_post_write_operation"] = "valid_signed_journey_result"
+    elif operation in {
+        "valid_spec016_payout_signed_journey_result",
+        "spec016_payout_signed_journey_result_missing_contract_fields",
+        "spec016_payout_signed_journey_result_candidate_artifact",
+        "spec016_payout_signed_journey_result_wrong_journey",
+        "spec016_payout_signed_journey_result_duplicate_step",
+        "spec016_payout_signed_journey_result_extra_secret_field",
+    }:
+        repository["files"]["specs/SPEC-016-payout-pipeline.md"] = "# SPEC-016 - Payout Pipeline\n\n**Version:** 0.1.0\n\nHuman contract text.\n"
+        repository["files"][f"journeys/{SPEC016_PAYOUT_JOURNEY_ID}.md"] = f"# {SPEC016_PAYOUT_JOURNEY_ID}\n"
+        del repository["files"]["specs/SPEC-001-one.md"]
+        authority["domains"][0].update({
+            "id": "payout-lifecycle",
+            "owner_spec": "SPEC-016",
+            "consumers": [],
+        })
+        specs[0].update({
+            "spec_id": "SPEC-016",
+            "title": "Payout Pipeline",
+            "path": "specs/SPEC-016-payout-pipeline.md",
+            "authority_domains": ["payout-lifecycle"],
+            "depends_on": [],
+        })
+        requirements[0].update({
+            "requirement_id": "SPEC-016-R002",
+            "spec_id": "SPEC-016",
+            "journeys": [SPEC016_PAYOUT_JOURNEY_ID],
+        })
+        repository["_post_write_operation"] = operation
     elif operation == "signed_journey_result_missing_signature":
         repository["_post_write_operation"] = "signed_journey_result_missing_signature"
     elif operation == "signed_journey_result_hash_mismatch":
@@ -580,6 +787,15 @@ class GovernanceValidatorTests(unittest.TestCase):
     def test_signed_journey_result_can_coexist_with_other_physical_evidence(self) -> None:
         repository = base_repository()
         apply_mutation(repository, {"operation": "signed_journey_result_mixed_physical_evidence"})
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            write_repository(root, repository)
+            apply_post_write_mutation(root, repository)
+            self.assertEqual([], validate_repository_with_fixture_key(root))
+
+    def test_spec016_payout_signed_journey_result_passes_when_contract_complete(self) -> None:
+        repository = base_repository()
+        apply_mutation(repository, {"operation": "valid_spec016_payout_signed_journey_result"})
         with tempfile.TemporaryDirectory() as directory:
             root = Path(directory)
             write_repository(root, repository)


### PR DESCRIPTION
## Summary
- gate SPEC-016-R002 promotion on the canonical payout journey-result, not a generic signed envelope
- reject candidate-only payout evidence, wrong journey mappings, duplicate/missing physical steps, mixed requirement payloads, and unexpected secret-bearing nested fields
- add retained governance/promoter regressions for the payout promotion guard

## Validation
- `python3 -m unittest scripts.tests.test_spec_pr_declaration scripts.tests.test_spec_governance scripts.tests.test_journey_result_tools`
- `python3 -m json.tool schemas/journey-result-v1.schema.json`
- `python3 scripts/check_spec_governance.py --base-ref origin/main`
- `python3 -m py_compile scripts/check_spec_governance.py scripts/sign-journey-result.py scripts/promote-signed-journey-result.py scripts/tests/test_spec_governance.py scripts/tests/test_journey_result_tools.py`

Not run: executable JSON Schema validation with `jsonschema`/AJV because neither package is installed locally.

SPEC-GOVERNANCE-DECLARATION-BEGIN
{
  "schema_version": "spec-pr-governance-v1",
  "behavior_change": "none",
  "contract_change": "none",
  "specs": ["SPEC-016"],
  "requirements": ["SPEC-016-R002"],
  "authority_domains": ["payout-lifecycle"],
  "arbitration": ["UNKNOWN"],
  "tests": [
    "python3 -m unittest scripts.tests.test_spec_pr_declaration scripts.tests.test_spec_governance scripts.tests.test_journey_result_tools",
    "python3 -m json.tool schemas/journey-result-v1.schema.json",
    "python3 scripts/check_spec_governance.py --base-ref origin/main",
    "python3 -m py_compile scripts/check_spec_governance.py scripts/sign-journey-result.py scripts/promote-signed-journey-result.py scripts/tests/test_spec_governance.py scripts/tests/test_journey_result_tools.py"
  ],
  "journeys": ["JOURNEY-SPEC-016-PAYOUT-ADDRESS-REGISTRATION"],
  "issue": "https://github.com/Augustas11/macprovider/issues/897"
}
SPEC-GOVERNANCE-DECLARATION-END
