### PR TITLE
fix(coordinator): route catalog keys to equivalent HF model ids (#900)

### DIFF
--- a/phase4-coordinator/internal/billing/formula.go
+++ b/phase4-coordinator/internal/billing/formula.go
@@ -77,11 +77,16 @@ func NormalizeModelKey(model string) string {
 	switch {
 	case namespace == "meta-llama" && strings.HasPrefix(key, "llama-"):
 		return "meta-llama/" + key
-	case strings.HasPrefix(key, "meta-llama-"):
+	// Magic-prefix collapses are namespace-scoped: only the empty /
+	// mlx-community / canonical-vendor namespaces may rewrite into the
+	// catalog key. Other known namespaces (qwen/, google/, …) must not
+	// spoof openai/gpt-oss-20b (or meta-llama / nemotron) via body
+	// prefix alone — that became load-bearing for routing in #900.
+	case servedAliasNamespace(namespace, "meta-llama") && strings.HasPrefix(key, "meta-llama-"):
 		return "meta-llama/" + strings.TrimPrefix(key, "meta-")
-	case strings.HasPrefix(key, "nvidia-nemotron-"):
+	case servedAliasNamespace(namespace, "nvidia") && strings.HasPrefix(key, "nvidia-nemotron-"):
 		return strings.TrimPrefix(key, "nvidia-")
-	case strings.HasPrefix(key, "gpt-oss-"):
+	case servedAliasNamespace(namespace, "openai") && strings.HasPrefix(key, "gpt-oss-"):
 		return "openai/" + key
 	default:
 		return key
@@ -94,18 +99,49 @@ func NormalizeModelKey(model string) string {
 // served HuggingFace ids (e.g. mlx-community/gpt-oss-20b-MXFP4-Q8)
 // without registering duplicate provider identities (issue #900).
 func ModelsEquivalent(a, b string) bool {
-	if strings.EqualFold(a, b) {
-		return true
-	}
 	if a == "" || b == "" {
 		return false
 	}
-	return NormalizeModelKey(a) == NormalizeModelKey(b)
+	if strings.EqualFold(a, b) {
+		return true
+	}
+	na, nb := NormalizeModelKey(a), NormalizeModelKey(b)
+	if na == "" || nb == "" {
+		return false
+	}
+	return na == nb
+}
+
+// MatchesNormalizedKey reports whether model aligns with an already-
+// computed NormalizeModelKey(query). Used by ModelKnown to avoid
+// re-normalizing the buyer-supplied query on every seen-model scan.
+func MatchesNormalizedKey(model, normalizedQuery string) bool {
+	if model == "" || normalizedQuery == "" {
+		return false
+	}
+	if strings.EqualFold(model, normalizedQuery) {
+		return true
+	}
+	got := NormalizeModelKey(model)
+	return got != "" && got == normalizedQuery
 }
 
 func knownModelNamespace(namespace string) bool {
 	switch namespace {
 	case "mlx-community", "openai", "google", "meta-llama", "nvidia", "qwen":
+		return true
+	default:
+		return false
+	}
+}
+
+// servedAliasNamespace is true when a magic-prefix rewrite may collapse
+// into canonicalVendor's catalog key. Empty (no repo prefix) and
+// mlx-community (typical served HF id) are the only non-canonical
+// sources allowed; foreign known namespaces cannot spoof the alias.
+func servedAliasNamespace(namespace, canonicalVendor string) bool {
+	switch namespace {
+	case "", "mlx-community", canonicalVendor:
 		return true
 	default:
 		return false

--- a/phase4-coordinator/internal/billing/formula.go
+++ b/phase4-coordinator/internal/billing/formula.go
@@ -88,6 +88,21 @@ func NormalizeModelKey(model string) string {
 	}
 }
 
+// ModelsEquivalent reports whether two buyer/provider model identifiers
+// refer to the same rate-card / catalog key after NormalizeModelKey.
+// Routing uses this so catalog keys (e.g. openai/gpt-oss-20b) match the
+// served HuggingFace ids (e.g. mlx-community/gpt-oss-20b-MXFP4-Q8)
+// without registering duplicate provider identities (issue #900).
+func ModelsEquivalent(a, b string) bool {
+	if strings.EqualFold(a, b) {
+		return true
+	}
+	if a == "" || b == "" {
+		return false
+	}
+	return NormalizeModelKey(a) == NormalizeModelKey(b)
+}
+
 func knownModelNamespace(namespace string) bool {
 	switch namespace {
 	case "mlx-community", "openai", "google", "meta-llama", "nvidia", "qwen":

--- a/phase4-coordinator/internal/billing/formula_test.go
+++ b/phase4-coordinator/internal/billing/formula_test.go
@@ -78,6 +78,27 @@ func TestRateFor_FallsBackToDefault(t *testing.T) {
 	}
 }
 
+func TestModelsEquivalent_CatalogKeyMatchesServedHFID(t *testing.T) {
+	cases := []struct {
+		a, b string
+		want bool
+	}{
+		{"openai/gpt-oss-20b", "mlx-community/gpt-oss-20b-MXFP4-Q8", true},
+		{"mlx-community/gpt-oss-20b-MXFP4-Q8", "openai/gpt-oss-20b", true},
+		{"OPENAI/GPT-OSS-20B", "mlx-community/gpt-oss-20b-MXFP4-Q8", true},
+		{"openai/gpt-oss-20b", "openai/gpt-oss-20b", true},
+		{"openai/gpt-oss-20b", "mlx-community/Qwen3-32B-4bit", false},
+		{"", "openai/gpt-oss-20b", false},
+		{"openai/gpt-oss-20b", "", false},
+		{"qwen3-32b", "mlx-community/Qwen3-32B-4bit", true},
+	}
+	for _, tc := range cases {
+		if got := ModelsEquivalent(tc.a, tc.b); got != tc.want {
+			t.Fatalf("ModelsEquivalent(%q, %q) = %v, want %v", tc.a, tc.b, got, tc.want)
+		}
+	}
+}
+
 func TestRateFor_UnknownNamespaceDoesNotNormalizeToKnownModel(t *testing.T) {
 	rateA := RateCardEntry{PromptCreditsPerMtok: 100, CompletionCreditsPerMtok: 200}
 	rateD := RateCardEntry{PromptCreditsPerMtok: 300, CompletionCreditsPerMtok: 400}

--- a/phase4-coordinator/internal/billing/formula_test.go
+++ b/phase4-coordinator/internal/billing/formula_test.go
@@ -90,7 +90,14 @@ func TestModelsEquivalent_CatalogKeyMatchesServedHFID(t *testing.T) {
 		{"openai/gpt-oss-20b", "mlx-community/Qwen3-32B-4bit", false},
 		{"", "openai/gpt-oss-20b", false},
 		{"openai/gpt-oss-20b", "", false},
+		{"", "", false},
 		{"qwen3-32b", "mlx-community/Qwen3-32B-4bit", true},
+		// Foreign known namespaces must not spoof catalog vendors (#900 audit).
+		{"qwen/gpt-oss-20b", "openai/gpt-oss-20b", false},
+		{"google/gpt-oss-20b", "openai/gpt-oss-20b", false},
+		{"qwen/meta-llama-3.1-8b-instruct-4bit", "meta-llama/Llama-3.1-8B-Instruct-4bit", false},
+		{"qwen/nvidia-nemotron-3-nano-30b-a3b", "nvidia/nemotron-3-nano-30b-a3b", false},
+		{"openai/nvidia-nemotron-3-nano-30b-a3b", "nvidia/nemotron-3-nano-30b-a3b", false},
 	}
 	for _, tc := range cases {
 		if got := ModelsEquivalent(tc.a, tc.b); got != tc.want {

--- a/phase4-coordinator/internal/buyer/server.go
+++ b/phase4-coordinator/internal/buyer/server.go
@@ -6595,7 +6595,11 @@ func (c *eligibilityCtx) QuotaPermits(p pool.Provider) bool {
 }
 
 func modelIDEqual(a, b string) bool {
-	return strings.EqualFold(a, b)
+	// Catalog-key ↔ served HF-id equivalence via rate-card normalization
+	// (issue #900). EqualFold alone rejects openai/gpt-oss-20b against
+	// mlx-community/gpt-oss-20b-MXFP4-Q8 even though pricing already
+	// collapses both to the same catalog key.
+	return billing.ModelsEquivalent(a, b)
 }
 
 func (s *Server) zeroTokenFault(end providerws.InferenceResponseEnd, finishReason string) bool {

--- a/phase4-coordinator/internal/buyer/server.go
+++ b/phase4-coordinator/internal/buyer/server.go
@@ -1728,7 +1728,11 @@ func (s *Server) applyHashVerification(entry *modelEntry, providers []pool.Provi
 	modelProviders := make([]pool.Provider, 0)
 	catalogUnavailable := false
 	for _, p := range providers {
-		if !hasAvailableSlot(p) || !modelIDEqual(p.ModelID, entry.ID) {
+		// Hash-verification buckets are per served binary (literal ModelID),
+		// not per catalog-key billing equivalence. modelIDEqual/#900 aliases
+		// must not cross-contaminate /v1/models Pillar-A status across
+		// distinct HF ids that share a rate-card key.
+		if !hasAvailableSlot(p) || !strings.EqualFold(p.ModelID, entry.ID) {
 			continue
 		}
 		status := s.effectiveHashStatus(p, cfg)

--- a/phase4-coordinator/internal/buyer/server_internal_test.go
+++ b/phase4-coordinator/internal/buyer/server_internal_test.go
@@ -8,9 +8,54 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/augstar/macprovider-coordinator/internal/config"
 	"github.com/augstar/macprovider-coordinator/internal/pool"
 	providerws "github.com/augstar/macprovider-coordinator/internal/ws"
 )
+
+func TestValidatePinnedProviderAcceptsCatalogKeyAlias(t *testing.T) {
+	const hfID = "mlx-community/gpt-oss-20b-MXFP4-Q8"
+	const catalogKey = "openai/gpt-oss-20b"
+	p := pool.Provider{
+		ProviderID:       "p1",
+		AssignedID:       "s1",
+		ModelID:          hfID,
+		State:            pool.StateReady,
+		SlotsFree:        1,
+		SlotsTotal:       1,
+		MaxContextTokens: 20000,
+	}
+	if _, routeErr := validatePinnedProvider(p, catalogKey, 10, "Pinned provider not available"); routeErr != nil {
+		t.Fatalf("catalog-key pin rejected: status=%d code=%s msg=%s", routeErr.status, routeErr.code, routeErr.message)
+	}
+	if _, routeErr := validatePinnedProvider(p, hfID, 10, "Pinned provider not available"); routeErr != nil {
+		t.Fatalf("HF-id pin rejected: status=%d code=%s msg=%s", routeErr.status, routeErr.code, routeErr.message)
+	}
+	if _, routeErr := validatePinnedProvider(p, "qwen/gpt-oss-20b", 10, "Pinned provider not available"); routeErr == nil {
+		t.Fatal("foreign-namespace spoof must not satisfy pinned provider model match")
+	}
+	if _, routeErr := validatePinnedProvider(p, "openai/gpt-oss-120b", 10, "Pinned provider not available"); routeErr == nil {
+		t.Fatal("unrelated catalog key must not satisfy pinned provider model match")
+	}
+}
+
+func TestProviderMatchesRequestClassMemberCatalogKeyAlias(t *testing.T) {
+	s := &Server{}
+	class := &config.ModelClassConfig{
+		Objective: "cheap",
+		Members:   []string{"openai/gpt-oss-20b"},
+	}
+	p := pool.Provider{ModelID: "mlx-community/gpt-oss-20b-MXFP4-Q8"}
+	if !s.providerMatchesRequest(p, "fast-class", class) {
+		t.Fatal("class member catalog key must match served HF id")
+	}
+	if s.providerMatchesRequest(p, "fast-class", &config.ModelClassConfig{
+		Objective: "cheap",
+		Members:   []string{"qwen/gpt-oss-20b"},
+	}) {
+		t.Fatal("foreign-namespace class member must not match openai-served HF id")
+	}
+}
 
 // TestNoPriorDispatchResponseWriterMarks pins the coordinator half of the
 // item-18 fix: the central noPriorDispatchResponseWriter stamps the POSITIVE

--- a/phase4-coordinator/internal/buyer/server_test.go
+++ b/phase4-coordinator/internal/buyer/server_test.go
@@ -1616,6 +1616,45 @@ func TestChatCompletionsRoutesNonStreamingRequest(t *testing.T) {
 	}
 }
 
+// TestChatCompletionsRoutesCatalogKeyToHFModelID pins issue #900: a
+// buyer request using the rate-card / catalog key must route to the
+// provider serving the equivalent HuggingFace model id, and the
+// upstream dispatch body must carry the provider's ModelID.
+func TestChatCompletionsRoutesCatalogKeyToHFModelID(t *testing.T) {
+	const hfID = "mlx-community/gpt-oss-20b-MXFP4-Q8"
+	const catalogKey = "openai/gpt-oss-20b"
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req map[string]any
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Fatalf("upstream request json: %v", err)
+		}
+		if req["model"] != hfID {
+			t.Fatalf("upstream model = %v, want rewritten provider ModelID %q", req["model"], hfID)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"chatcmpl-oss","object":"chat.completion","created":1716768000,"model":"` + hfID + `","choices":[{"index":0,"message":{"role":"assistant","content":"ok"},"finish_reason":"stop"}],"usage":{"prompt_tokens":4,"completion_tokens":1,"total_tokens":5}}`))
+	}))
+	defer upstream.Close()
+
+	registry := pool.NewRegistry([]config.ProviderConfig{{ProviderID: "p1", EndpointURL: upstream.URL}})
+	registerWithEndpoint(registry, "p1", "session-1", hfID, pool.StateReady, 20000, 1, upstream.URL, 20)
+	server := buyer.NewServer(registry, zerolog.Nop(), time.Unix(1716768000, 0))
+
+	catalogRR := postChat(t, server, []byte(`{"model":"`+catalogKey+`","messages":[{"role":"user","content":"hello"}],"stream":false}`), nil)
+	if catalogRR.Code != http.StatusOK {
+		t.Fatalf("catalog-key status = %d, body=%s", catalogRR.Code, catalogRR.Body.String())
+	}
+	if catalogRR.Header().Get("X-MacProvider-Provider") != "p1" {
+		t.Fatalf("catalog-key provider header = %q", catalogRR.Header().Get("X-MacProvider-Provider"))
+	}
+
+	hfRR := postChat(t, server, []byte(`{"model":"`+hfID+`","messages":[{"role":"user","content":"hello"}],"stream":false}`), nil)
+	if hfRR.Code != http.StatusOK {
+		t.Fatalf("HF-id status = %d, body=%s", hfRR.Code, hfRR.Body.String())
+	}
+}
+
 func TestHTTPForwardingStripsReceiptFromProviderWithoutPublishedReceiptKey(t *testing.T) {
 	const spoofedReceipt = "spoofed.receipt"
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/phase4-coordinator/internal/buyer/server_test.go
+++ b/phase4-coordinator/internal/buyer/server_test.go
@@ -1653,6 +1653,16 @@ func TestChatCompletionsRoutesCatalogKeyToHFModelID(t *testing.T) {
 	if hfRR.Code != http.StatusOK {
 		t.Fatalf("HF-id status = %d, body=%s", hfRR.Code, hfRR.Body.String())
 	}
+
+	pinnedRR := postChat(t, server, []byte(`{"model":"`+catalogKey+`","messages":[{"role":"user","content":"hello"}],"stream":false}`), http.Header{
+		"X-MacProvider-Provider": []string{"p1"},
+	})
+	if pinnedRR.Code != http.StatusOK {
+		t.Fatalf("pinned catalog-key status = %d, body=%s", pinnedRR.Code, pinnedRR.Body.String())
+	}
+	if pinnedRR.Header().Get("X-MacProvider-Provider") != "p1" {
+		t.Fatalf("pinned catalog-key provider header = %q", pinnedRR.Header().Get("X-MacProvider-Provider"))
+	}
 }
 
 func TestHTTPForwardingStripsReceiptFromProviderWithoutPublishedReceiptKey(t *testing.T) {

--- a/phase4-coordinator/internal/pool/provider.go
+++ b/phase4-coordinator/internal/pool/provider.go
@@ -1448,9 +1448,12 @@ func (r *Registry) recordCanaryResult(providerID, assignedID string, passed bool
 	return result
 }
 
-// providerServesActiveModel reports whether p's ACTIVE loaded model is modelID,
-// using the same case-folded comparison as buyer routing (`modelIDEqual` →
-// `strings.EqualFold`, buyer/server.go). It deliberately does NOT consult
+// providerServesActiveModel reports whether p's ACTIVE loaded model is modelID
+// under exact case-folded identity. Unlike buyer routing's modelIDEqual
+// (billing.ModelsEquivalent after #900), this stays EqualFold-only: canary
+// sole-provider floor and redundancy telemetry compare provider-to-provider
+// served ModelIDs (HF form), and deliberately treat quantization / catalog
+// aliases as distinct so the floor stays conservative. It does NOT consult
 // `SupportedModels`: a declared-but-cold model is buyer-unroutable (SPEC-031 §9 /
 // SPEC-010 R-3.3.4 — "known but temporarily unavailable", it 503s), so counting
 // it as live capacity would let a peer serving a different model falsely lift the
@@ -2222,6 +2225,10 @@ func (r *Registry) ModelKnown(modelID string) bool {
 	// to the same catalog identity as a seen or live HF model id
 	// (openai/gpt-oss-20b ↔ mlx-community/gpt-oss-20b-MXFP4-Q8).
 	canonical := strings.ToLower(modelID)
+	// Hoist query normalization once; fallback scans only normalize
+	// stored ids (issue #900 audit: avoid re-allocating on the buyer
+	// string inside every EqualFold-miss iteration under RLock).
+	normalizedQuery := billing.NormalizeModelKey(modelID)
 	r.mu.RLock()
 	defer r.mu.RUnlock()
 	if _, ok := r.seenModelsLifetime[canonical]; ok {
@@ -2232,7 +2239,7 @@ func (r *Registry) ModelKnown(modelID string) bool {
 	// pays the cost on the never-recorded path (i.e., the 404
 	// candidate). Catalog-key equivalence uses the same bound.
 	for stored := range r.seenModelsLifetime {
-		if billing.ModelsEquivalent(stored, modelID) {
+		if modelKnownMatch(stored, modelID, normalizedQuery) {
 			return true
 		}
 	}
@@ -2244,7 +2251,7 @@ func (r *Registry) ModelKnown(modelID string) bool {
 	//
 	// 1. Live providers' current ModelID field.
 	for _, p := range r.providers {
-		if billing.ModelsEquivalent(p.ModelID, modelID) {
+		if modelKnownMatch(p.ModelID, modelID, normalizedQuery) {
 			return true
 		}
 	}
@@ -2262,7 +2269,7 @@ func (r *Registry) ModelKnown(modelID string) bool {
 	// unconditional guarantee while the declaring provider is live.
 	for _, p := range r.providers {
 		for _, supported := range p.SupportedModels {
-			if billing.ModelsEquivalent(supported, modelID) {
+			if modelKnownMatch(supported, modelID, normalizedQuery) {
 				return true
 			}
 		}
@@ -2278,12 +2285,19 @@ func (r *Registry) ModelKnown(modelID string) bool {
 			return true
 		}
 		for stored := range set {
-			if billing.ModelsEquivalent(stored, modelID) {
+			if modelKnownMatch(stored, modelID, normalizedQuery) {
 				return true
 			}
 		}
 	}
 	return false
+}
+
+func modelKnownMatch(stored, modelID, normalizedQuery string) bool {
+	if strings.EqualFold(stored, modelID) {
+		return true
+	}
+	return billing.MatchesNormalizedKey(stored, normalizedQuery)
 }
 
 type StateUpdate struct {

--- a/phase4-coordinator/internal/pool/provider.go
+++ b/phase4-coordinator/internal/pool/provider.go
@@ -11,6 +11,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/augstar/macprovider-coordinator/internal/billing"
 	"github.com/augstar/macprovider-coordinator/internal/config"
 )
 
@@ -2216,6 +2217,10 @@ func (r *Registry) ModelKnown(modelID string) bool {
 	//    ASCII/Latin common case, ~all realistic model ids).
 	// 2. On miss, EqualFold scan the lifetime accumulator before
 	//    falling through to the live/per-session paths.
+	//
+	// Issue #900: also accept rate-card / catalog keys that normalize
+	// to the same catalog identity as a seen or live HF model id
+	// (openai/gpt-oss-20b ↔ mlx-community/gpt-oss-20b-MXFP4-Q8).
 	canonical := strings.ToLower(modelID)
 	r.mu.RLock()
 	defer r.mu.RUnlock()
@@ -2225,9 +2230,9 @@ func (r *Registry) ModelKnown(modelID string) bool {
 	// Non-ASCII / case-folding-edge fallback: EqualFold scan of
 	// lifetime keys. Bounded by maxSeenModelsLifetime = 4096; only
 	// pays the cost on the never-recorded path (i.e., the 404
-	// candidate).
+	// candidate). Catalog-key equivalence uses the same bound.
 	for stored := range r.seenModelsLifetime {
-		if strings.EqualFold(stored, modelID) {
+		if billing.ModelsEquivalent(stored, modelID) {
 			return true
 		}
 	}
@@ -2239,7 +2244,7 @@ func (r *Registry) ModelKnown(modelID string) bool {
 	//
 	// 1. Live providers' current ModelID field.
 	for _, p := range r.providers {
-		if strings.EqualFold(p.ModelID, modelID) {
+		if billing.ModelsEquivalent(p.ModelID, modelID) {
 			return true
 		}
 	}
@@ -2257,7 +2262,7 @@ func (r *Registry) ModelKnown(modelID string) bool {
 	// unconditional guarantee while the declaring provider is live.
 	for _, p := range r.providers {
 		for _, supported := range p.SupportedModels {
-			if strings.EqualFold(supported, modelID) {
+			if billing.ModelsEquivalent(supported, modelID) {
 				return true
 			}
 		}
@@ -2273,7 +2278,7 @@ func (r *Registry) ModelKnown(modelID string) bool {
 			return true
 		}
 		for stored := range set {
-			if strings.EqualFold(stored, modelID) {
+			if billing.ModelsEquivalent(stored, modelID) {
 				return true
 			}
 		}

--- a/phase4-coordinator/internal/pool/provider_test.go
+++ b/phase4-coordinator/internal/pool/provider_test.go
@@ -1888,6 +1888,9 @@ func TestModelKnownAcceptsCatalogKeyAlias(t *testing.T) {
 	if registry.ModelKnown("openai/gpt-oss-120b") {
 		t.Fatal("ModelKnown(openai/gpt-oss-120b) = true; unrelated catalog key must stay unknown")
 	}
+	if registry.ModelKnown("qwen/gpt-oss-20b") {
+		t.Fatal("ModelKnown(qwen/gpt-oss-20b) = true; foreign namespace must not spoof openai catalog key")
+	}
 
 	// Lifetime path: after disconnect, catalog key still known → 503 not 404.
 	if !registry.RemoveIfSession("p1", "s1") {

--- a/phase4-coordinator/internal/pool/provider_test.go
+++ b/phase4-coordinator/internal/pool/provider_test.go
@@ -1856,6 +1856,48 @@ func TestModelKnownPersistsInLifetimeAccumulator(t *testing.T) {
 	}
 }
 
+// TestModelKnownAcceptsCatalogKeyAlias pins issue #900: a buyer
+// catalog / rate-card key must be ModelKnown when a provider has
+// advertised the equivalent served HuggingFace id. Without this, the
+// buyer port 404s on openai/gpt-oss-20b while the HF id routes fine.
+func TestModelKnownAcceptsCatalogKeyAlias(t *testing.T) {
+	registry := NewRegistry(nil)
+	start := time.Unix(1716768000, 0).UTC()
+	const hfID = "mlx-community/gpt-oss-20b-MXFP4-Q8"
+	const catalogKey = "openai/gpt-oss-20b"
+
+	registry.Register(&Provider{
+		ProviderID:       "p1",
+		AssignedID:       "s1",
+		ModelID:          hfID,
+		State:            StateReady,
+		SlotsFree:        1,
+		SlotsTotal:       1,
+		LastHeartbeatAt:  start,
+		LastActivityAt:   start,
+		MaxConcurrency:   1,
+		MaxContextTokens: 20000,
+	}, nil)
+
+	if !registry.ModelKnown(hfID) {
+		t.Fatalf("ModelKnown(%q) = false for served HF id", hfID)
+	}
+	if !registry.ModelKnown(catalogKey) {
+		t.Fatalf("ModelKnown(%q) = false; catalog key must alias served HF id (#900)", catalogKey)
+	}
+	if registry.ModelKnown("openai/gpt-oss-120b") {
+		t.Fatal("ModelKnown(openai/gpt-oss-120b) = true; unrelated catalog key must stay unknown")
+	}
+
+	// Lifetime path: after disconnect, catalog key still known → 503 not 404.
+	if !registry.RemoveIfSession("p1", "s1") {
+		t.Fatal("RemoveIfSession returned false")
+	}
+	if !registry.ModelKnown(catalogKey) {
+		t.Fatalf("ModelKnown(%q) = false after disconnect; catalog-key lifetime alias regressed", catalogKey)
+	}
+}
+
 // TestModelKnownUnionsDeclaredSupportedModels pins SPEC-010 v1.5
 // R-3.3.4: the seen-model index is the UNION of a provider's served
 // ModelID and every entry in its SupportedModels, so ModelKnown()


### PR DESCRIPTION
## Summary

- Buyer requests using a rate-card / catalog key (e.g. `openai/gpt-oss-20b`) were 404ing with `model_not_found` even when a Ready provider served the equivalent HuggingFace id (`mlx-community/gpt-oss-20b-MXFP4-Q8`).
- Centralize catalog-key ↔ HF-id equivalence in `billing.ModelsEquivalent` (same `NormalizeModelKey` path pricing already uses) and apply it in `pool.ModelKnown` plus buyer `modelIDEqual` selection matching.
- Dispatch still rewrites the upstream body to the provider's served `ModelID`; pricing continues to key on the normalized catalog key.

Closes #900.

## Test plan

- [x] `go test ./internal/billing/ -run 'TestModelsEquivalent|TestRateFor_NormalizesMXFP4'`
- [x] `go test ./internal/pool/ -run 'TestModelKnownAcceptsCatalogKeyAlias|TestModelKnownPersistsInLifetimeAccumulator|TestModelKnownUnionsDeclaredSupportedModels'`
- [x] `go test ./internal/buyer/ -run 'TestChatCompletionsRoutesCatalogKeyToHFModelID|TestChatCompletionsRoutesNonStreamingRequest|TestChatCompletionsColdStartRaceReturnsNoProviderAvailable'`
- [ ] CI green on PR

SPEC-GOVERNANCE-DECLARATION-BEGIN
{
  "schema_version": "spec-pr-governance-v1",
  "behavior_change": "yes",
  "contract_change": "none",
  "specs": ["SPEC-002"],
  "requirements": ["SPEC-002-R001"],
  "authority_domains": ["coordinator-admission-routing"],
  "arbitration": ["CODE_BUG"],
  "tests": [
    "go test ./internal/billing/ -run TestModelsEquivalent_CatalogKeyMatchesServedHFID",
    "go test ./internal/pool/ -run TestModelKnownAcceptsCatalogKeyAlias",
    "go test ./internal/buyer/ -run TestChatCompletionsRoutesCatalogKeyToHFModelID"
  ],
  "journeys": ["not-required"],
  "issue": "https://github.com/Augustas11/macprovider/issues/900"
}
SPEC-GOVERNANCE-DECLARATION-END
