### PR TITLE
Build signed payout journey promotion artifact

### DIFF
--- a/.github/workflows/promote-signed-payout-journey.yml
+++ b/.github/workflows/promote-signed-payout-journey.yml
@@ -1,0 +1,224 @@
+name: Build signed payout journey promotion artifact
+
+on:
+  workflow_dispatch:
+    inputs:
+      source_sha:
+        description: "Exact origin/main commit SHA to capture and promote"
+        required: true
+        type: string
+      promotion_confirmed:
+        description: "Confirm SPEC-016-R002 signed evidence promotion artifact should be built"
+        required: true
+        default: false
+        type: boolean
+
+permissions:
+  contents: read
+
+concurrency:
+  group: signed-payout-journey-${{ github.event.inputs.source_sha }}
+  cancel-in-progress: false
+
+jobs:
+  promote:
+    name: Capture, sign, validate, and export SPEC-016-R002 promotion
+    runs-on: ubuntu-latest
+    environment: production-release
+    steps:
+      - name: Checkout reviewed main controls
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+        with:
+          ref: ${{ github.sha }}
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Validate exact main source
+        id: request
+        shell: bash
+        env:
+          SOURCE_SHA_INPUT: ${{ github.event.inputs.source_sha }}
+          PROMOTION_CONFIRMED_INPUT: ${{ github.event.inputs.promotion_confirmed || 'false' }}
+        run: |
+          set -euo pipefail
+          [[ "$GITHUB_EVENT_NAME" == workflow_dispatch ]] || { echo "::error::manual dispatch required" >&2; exit 1; }
+          [[ "$GITHUB_REF" == refs/heads/main ]] || { echo "::error::workflow must run from main" >&2; exit 1; }
+          [[ "$SOURCE_SHA_INPUT" =~ ^[0-9a-f]{40}$ ]] || { echo "::error::invalid source SHA" >&2; exit 1; }
+          [[ "$SOURCE_SHA_INPUT" == "$GITHUB_SHA" ]] || { echo "::error::source SHA must equal the reviewed workflow commit" >&2; exit 1; }
+          [[ "$PROMOTION_CONFIRMED_INPUT" == true ]] || { echo "::error::promotion confirmation is required" >&2; exit 1; }
+          git fetch --quiet origin refs/heads/main:refs/remotes/origin/main
+          main_sha="$(git rev-parse refs/remotes/origin/main)"
+          [[ "$main_sha" == "$SOURCE_SHA_INPUT" ]] || { echo "::error::source SHA is no longer origin/main" >&2; exit 1; }
+          short_sha="${SOURCE_SHA_INPUT:0:12}"
+          printf 'source_sha=%s\n' "$SOURCE_SHA_INPUT" >> "$GITHUB_OUTPUT"
+          printf 'short_sha=%s\n' "$short_sha" >> "$GITHUB_OUTPUT"
+
+      - name: Set up Go
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e
+        with:
+          go-version-file: phase4-coordinator/go.mod
+          cache-dependency-path: phase4-coordinator/go.sum
+
+      - name: Capture payout journey payload
+        shell: bash
+        run: |
+          set -euo pipefail
+          (
+            cd phase4-coordinator
+            MACPROVIDER_CAPTURE_PAYOUT_JOURNEY=1 \
+              go test ./internal/payout -run TestPayoutAddressRegistrationJourneyEvidence -count=1 -v
+          )
+
+      - name: Bind generated artifact paths
+        id: generated
+        shell: bash
+        run: |
+          set -euo pipefail
+          python3 - "$GITHUB_OUTPUT" <<'PY'
+          import pathlib
+          import sys
+
+          root = pathlib.Path("journeys/evidence")
+          payloads = sorted(root.glob("spec016-r002-payout-address-*.journey-result.unsigned.json"))
+          if len(payloads) != 1:
+              raise SystemExit(f"expected exactly one unsigned payload, found {len(payloads)}")
+          payload = payloads[0]
+          prefix = payload.name.removesuffix(".journey-result.unsigned.json")
+          redacted = root / f"{prefix}.redacted.json"
+          candidate = root / f"{prefix}.candidate.json"
+          envelope = root / f"{prefix}.journey-result.signed.json"
+          for path in (redacted, candidate):
+              if not path.is_file():
+                  raise SystemExit(f"missing generated artifact: {path}")
+          with open(sys.argv[1], "a", encoding="ascii") as output:
+              output.write(f"payload={payload.as_posix()}\n")
+              output.write(f"redacted={redacted.as_posix()}\n")
+              output.write(f"candidate={candidate.as_posix()}\n")
+              output.write(f"envelope={envelope.as_posix()}\n")
+              output.write(f"prefix={prefix}\n")
+          PY
+
+      - name: Sign journey-result payload
+        shell: bash
+        env:
+          MACPROVIDER_ACCEPTANCE_SIGNING_KEY_PEM: ${{ secrets.MACPROVIDER_ACCEPTANCE_SIGNING_KEY_PEM }}
+          PAYLOAD: ${{ steps.generated.outputs.payload }}
+          ENVELOPE: ${{ steps.generated.outputs.envelope }}
+        run: |
+          set -euo pipefail
+          python3 scripts/sign-journey-result.py \
+            --input "$PAYLOAD" \
+            --output "$ENVELOPE" \
+            --verifier ".github/workflows/promote-signed-payout-journey.yml:${GITHUB_RUN_ID}:${GITHUB_RUN_ATTEMPT}"
+
+      - name: Promote only after signed validation
+        shell: bash
+        env:
+          ENVELOPE: ${{ steps.generated.outputs.envelope }}
+        run: |
+          set -euo pipefail
+          python3 scripts/promote-signed-journey-result.py \
+            --base-ref origin/main \
+            SPEC-016-R002 \
+            "$ENVELOPE"
+
+      - name: Drop non-promotable intermediates
+        shell: bash
+        env:
+          PAYLOAD: ${{ steps.generated.outputs.payload }}
+          CANDIDATE: ${{ steps.generated.outputs.candidate }}
+        run: |
+          set -euo pipefail
+          python3 - "$PAYLOAD" "$CANDIDATE" <<'PY'
+          import pathlib
+          import sys
+
+          for value in sys.argv[1:]:
+              path = pathlib.Path(value)
+              if path.suffix != ".json" or "journeys/evidence/" not in path.as_posix():
+                  raise SystemExit(f"refusing to remove unexpected path: {path}")
+              path.unlink()
+          PY
+
+      - name: Verify promoted ledger and committed artifact set
+        shell: bash
+        env:
+          REDACTED: ${{ steps.generated.outputs.redacted }}
+          ENVELOPE: ${{ steps.generated.outputs.envelope }}
+        run: |
+          set -euo pipefail
+          python3 -m json.tool "$REDACTED" >/dev/null
+          python3 -m json.tool "$ENVELOPE" >/dev/null
+          python3 -m json.tool specs/CONFORMANCE.json >/dev/null
+          python3 scripts/check_spec_governance.py --base-ref origin/main
+          git diff --check
+          python3 - "$ENVELOPE" <<'PY'
+          import json
+          import pathlib
+          import sys
+
+          envelope = pathlib.Path(sys.argv[1]).as_posix()
+          conformance = json.loads(pathlib.Path("specs/CONFORMANCE.json").read_text(encoding="utf-8"))
+          matches = [
+              item for item in conformance.get("requirements", [])
+              if isinstance(item, dict) and item.get("requirement_id") == "SPEC-016-R002"
+          ]
+          if len(matches) != 1:
+              raise SystemExit("SPEC-016-R002 must exist exactly once")
+          requirement = matches[0]
+          if requirement.get("state") != "conformant" or requirement.get("gap") is not None:
+              raise SystemExit("SPEC-016-R002 was not promoted to conformant")
+          evidence = requirement.get("evidence")
+          if not isinstance(evidence, list) or not any(item.get("source") == envelope for item in evidence if isinstance(item, dict)):
+              raise SystemExit("SPEC-016-R002 evidence does not reference the signed envelope")
+          for path in pathlib.Path("journeys/evidence").glob("spec016-r002-payout-address-*"):
+              name = path.name
+              if name.endswith(".candidate.json") or name.endswith(".journey-result.unsigned.json"):
+                  raise SystemExit(f"non-promotable intermediate remains: {path}")
+          PY
+
+      - name: Export signed promotion artifact
+        shell: bash
+        env:
+          SOURCE_SHA: ${{ steps.request.outputs.source_sha }}
+          REDACTED: ${{ steps.generated.outputs.redacted }}
+          ENVELOPE: ${{ steps.generated.outputs.envelope }}
+        run: |
+          set -euo pipefail
+          export_dir="$RUNNER_TEMP/signed-payout-journey-promotion"
+          mkdir -p "$export_dir/journeys/evidence" "$export_dir/specs"
+          cp "$REDACTED" "$export_dir/$REDACTED"
+          cp "$ENVELOPE" "$export_dir/$ENVELOPE"
+          cp specs/CONFORMANCE.json "$export_dir/specs/CONFORMANCE.json"
+          python3 - "$export_dir/promotion-manifest.json" "$SOURCE_SHA" "$REDACTED" "$ENVELOPE" <<'PY'
+          import hashlib
+          import json
+          import pathlib
+          import sys
+
+          output, source_sha, redacted, envelope = sys.argv[1:]
+          root = pathlib.Path(".")
+          manifest = {
+              "schema_version": "macprovider.signed-payout-journey-promotion.v1",
+              "source_sha": source_sha,
+              "requirement_id": "SPEC-016-R002",
+              "journey_id": "JOURNEY-SPEC-016-PAYOUT-ADDRESS-REGISTRATION",
+              "redacted_artifact": redacted,
+              "redacted_sha256": hashlib.sha256((root / redacted).read_bytes()).hexdigest(),
+              "signed_envelope": envelope,
+              "signed_envelope_sha256": hashlib.sha256((root / envelope).read_bytes()).hexdigest(),
+              "conformance_sha256": hashlib.sha256((root / "specs/CONFORMANCE.json").read_bytes()).hexdigest(),
+              "workflow_run_id": __import__("os").environ["GITHUB_RUN_ID"],
+              "workflow_run_attempt": __import__("os").environ["GITHUB_RUN_ATTEMPT"],
+          }
+          pathlib.Path(output).write_text(json.dumps(manifest, indent=2) + "\n", encoding="utf-8")
+          PY
+
+      - name: Upload signed promotion artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        with:
+          name: signed-payout-journey-promotion-${{ steps.request.outputs.source_sha }}
+          path: ${{ runner.temp }}/signed-payout-journey-promotion/
+          if-no-files-found: error
+          include-hidden-files: false
+          retention-days: 1

--- a/.github/workflows/promote-signed-payout-journey.yml
+++ b/.github/workflows/promote-signed-payout-journey.yml
@@ -98,6 +98,12 @@ jobs:
               output.write(f"prefix={prefix}\n")
           PY
 
+      - name: Verify protected environment and repository posture
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_POSTURE_TOKEN }}
+        run: bash scripts/verify-github-release-posture.sh "$GITHUB_REPOSITORY" production-release 28995904
+
       - name: Sign journey-result payload
         shell: bash
         env:

--- a/Makefile
+++ b/Makefile
@@ -63,6 +63,7 @@ test-dist:
 	bash scripts/test-malibu-bootstrap-bridge.sh
 	bash scripts/test-recover-malibu-publication.sh
 	bash scripts/test-acceptance-candidate-security.sh
+	bash scripts/test-signed-payout-journey-workflow.sh
 	bash scripts/test-acceptance-candidate-metadata.sh
 	bash scripts/test-acceptance-promotion.sh
 	bash scripts/test-release-toolchain.sh

--- a/scripts/test-signed-payout-journey-workflow.sh
+++ b/scripts/test-signed-payout-journey-workflow.sh
@@ -22,6 +22,8 @@ required = [
     "\n  workflow_dispatch:\n",
     "environment: production-release",
     "contents: read",
+    "GH_TOKEN: ${{ secrets.RELEASE_POSTURE_TOKEN }}",
+    'scripts/verify-github-release-posture.sh "$GITHUB_REPOSITORY" production-release 28995904',
     "MACPROVIDER_ACCEPTANCE_SIGNING_KEY_PEM: ${{ secrets.MACPROVIDER_ACCEPTANCE_SIGNING_KEY_PEM }}",
     '[[ "$GITHUB_REF" == refs/heads/main ]]',
     '[[ "$SOURCE_SHA_INPUT" == "$GITHUB_SHA" ]]',
@@ -56,6 +58,10 @@ if "candidate.json" not in workflow or "journey-result.unsigned.json" not in wor
     raise SystemExit("workflow must explicitly detect non-promotable intermediates")
 if "path.unlink()" not in workflow:
     raise SystemExit("workflow must remove non-promotable intermediates before artifact export")
+posture_index = workflow.find("scripts/verify-github-release-posture.sh")
+signing_key_index = workflow.find("MACPROVIDER_ACCEPTANCE_SIGNING_KEY_PEM")
+if posture_index == -1 or signing_key_index == -1 or posture_index > signing_key_index:
+    raise SystemExit("workflow must verify release posture before importing the acceptance signing key")
 
 lines = workflow.splitlines()
 for index, line in enumerate(lines):

--- a/scripts/test-signed-payout-journey-workflow.sh
+++ b/scripts/test-signed-payout-journey-workflow.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd -P)"
+workflow="$root/.github/workflows/promote-signed-payout-journey.yml"
+
+fail() {
+  printf '[test-signed-payout-journey-workflow] ERROR: %s\n' "$*" >&2
+  exit 1
+}
+
+[[ -f "$workflow" && ! -L "$workflow" ]] || fail "workflow is absent or unsafe"
+
+python3 - "$workflow" <<'PY'
+import pathlib
+import re
+import sys
+
+workflow = pathlib.Path(sys.argv[1]).read_text(encoding="utf-8")
+
+required = [
+    "\n  workflow_dispatch:\n",
+    "environment: production-release",
+    "contents: read",
+    "MACPROVIDER_ACCEPTANCE_SIGNING_KEY_PEM: ${{ secrets.MACPROVIDER_ACCEPTANCE_SIGNING_KEY_PEM }}",
+    '[[ "$GITHUB_REF" == refs/heads/main ]]',
+    '[[ "$SOURCE_SHA_INPUT" == "$GITHUB_SHA" ]]',
+    '[[ "$PROMOTION_CONFIRMED_INPUT" == true ]]',
+    '[[ "$main_sha" == "$SOURCE_SHA_INPUT" ]]',
+    "MACPROVIDER_CAPTURE_PAYOUT_JOURNEY=1",
+    "scripts/sign-journey-result.py",
+    "scripts/promote-signed-journey-result.py",
+    "scripts/check_spec_governance.py --base-ref origin/main",
+    "actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a",
+    "retention-days: 1",
+    "macprovider.signed-payout-journey-promotion.v1",
+]
+for value in required:
+    if value not in workflow:
+        raise SystemExit(f"workflow contract is missing: {value}")
+
+if "\n  push:" in workflow or "\n  pull_request:" in workflow:
+    raise SystemExit("workflow must be manual dispatch only")
+if "git push origin main" in workflow or "HEAD:refs/heads/main" in workflow:
+    raise SystemExit("workflow must not push directly to main")
+for forbidden in ("contents: write", "pull-requests: write", "git push", "gh pr create", "gh pr merge", "gh release"):
+    if forbidden in workflow:
+        raise SystemExit(f"workflow contains an unnecessary write/publication capability: {forbidden}")
+if "cat \"$MACPROVIDER_ACCEPTANCE_SIGNING_KEY_PEM\"" in workflow:
+    raise SystemExit("workflow must not print private key material")
+if re.search(r'echo .*MACPROVIDER_ACCEPTANCE_SIGNING_KEY_PEM', workflow):
+    raise SystemExit("workflow echoes the private key environment variable")
+if "cp \"$REDACTED\"" not in workflow or "cp \"$ENVELOPE\"" not in workflow or "cp specs/CONFORMANCE.json" not in workflow:
+    raise SystemExit("workflow must export only the signed evidence, redacted artifact, and ledger")
+if "candidate.json" not in workflow or "journey-result.unsigned.json" not in workflow:
+    raise SystemExit("workflow must explicitly detect non-promotable intermediates")
+if "path.unlink()" not in workflow:
+    raise SystemExit("workflow must remove non-promotable intermediates before artifact export")
+
+lines = workflow.splitlines()
+for index, line in enumerate(lines):
+    match = re.match(r"^(\s*)run:\s*\|", line)
+    if not match:
+        continue
+    indent = len(match.group(1))
+    block = []
+    for candidate in lines[index + 1 :]:
+        if candidate.strip() and len(candidate) - len(candidate.lstrip()) <= indent:
+            break
+        block.append(candidate)
+    if any("${{" in row for row in block):
+        raise SystemExit("GitHub expression is interpolated directly into a shell block")
+
+print("[test-signed-payout-journey-workflow] ok: protected manual signer exports a short-lived artifact")
+PY


### PR DESCRIPTION
## Summary
- adds a manual, production-release-environment workflow to capture, sign, validate, and export SPEC-016-R002 payout journey promotion artifacts
- keeps the workflow read-only: it uploads a one-day artifact instead of pushing to main or opening a PR with GITHUB_TOKEN
- adds a regression test and wires it into `test-dist`

## Validation
- `bash scripts/test-signed-payout-journey-workflow.sh`
- `bash -n scripts/test-signed-payout-journey-workflow.sh`
- PyYAML parse of `.github/workflows/promote-signed-payout-journey.yml`
- `python3 scripts/check_spec_governance.py --base-ref origin/main`
- `MACPROVIDER_CAPTURE_PAYOUT_JOURNEY=1 go test ./internal/payout -run TestPayoutAddressRegistrationJourneyEvidence -count=1 -v`
- `python3 -m unittest scripts.tests.test_spec_pr_declaration scripts.tests.test_spec_governance scripts.tests.test_journey_result_tools`
- `git diff --check`

SPEC-GOVERNANCE-DECLARATION-BEGIN
{
  "schema_version": "spec-pr-governance-v1",
  "issue": "https://github.com/Augustas11/macprovider/issues/614",
  "behavior_change": "yes",
  "contract_change": "none",
  "specs": ["SPEC-016"],
  "requirements": ["SPEC-016-R002"],
  "authority_domains": ["payout-lifecycle"],
  "arbitration": ["UNKNOWN"],
  "tests": [
    "scripts/test-signed-payout-journey-workflow.sh",
    "scripts/check_spec_governance.py --base-ref origin/main",
    "phase4-coordinator/internal/payout::TestPayoutAddressRegistrationJourneyEvidence",
    "scripts.tests.test_spec_pr_declaration",
    "scripts.tests.test_spec_governance",
    "scripts.tests.test_journey_result_tools"
  ],
  "journeys": ["JOURNEY-SPEC-016-PAYOUT-ADDRESS-REGISTRATION"]
}
SPEC-GOVERNANCE-DECLARATION-END
