### PR TITLE
Guard provider-prebeta signed evidence promotion

### DIFF
--- a/.github/workflows/promote-signed-provider-prebeta-journey.yml
+++ b/.github/workflows/promote-signed-provider-prebeta-journey.yml
@@ -1,0 +1,230 @@
+name: Build signed provider-prebeta journey promotion artifact
+
+on:
+  workflow_dispatch:
+    inputs:
+      source_sha:
+        description: "Exact source/build commit SHA captured by the redacted physical evidence"
+        required: true
+        type: string
+      redacted_evidence_path:
+        description: "journeys/evidence/provider-prebeta-admission-*.redacted.json"
+        required: true
+        type: string
+      requirement_ids:
+        description: "Comma-separated pending provider-prebeta requirement IDs covered by the evidence"
+        required: true
+        type: string
+      promotion_confirmed:
+        description: "Confirm provider-prebeta signed evidence promotion artifact should be built"
+        required: true
+        default: false
+        type: boolean
+
+permissions:
+  contents: read
+
+concurrency:
+  group: signed-provider-prebeta-journey-${{ github.event.inputs.source_sha }}
+  cancel-in-progress: false
+
+jobs:
+  promote:
+    name: Build, sign, validate, and export provider-prebeta promotion
+    runs-on: ubuntu-latest
+    environment: production-release
+    steps:
+      - name: Checkout reviewed main controls
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+        with:
+          ref: ${{ github.sha }}
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Validate exact main source
+        id: request
+        shell: bash
+        env:
+          SOURCE_SHA_INPUT: ${{ github.event.inputs.source_sha }}
+          REDACTED_EVIDENCE_INPUT: ${{ github.event.inputs.redacted_evidence_path }}
+          REQUIREMENT_IDS_INPUT: ${{ github.event.inputs.requirement_ids }}
+          PROMOTION_CONFIRMED_INPUT: ${{ github.event.inputs.promotion_confirmed || 'false' }}
+        run: |
+          set -euo pipefail
+          [[ "$GITHUB_EVENT_NAME" == workflow_dispatch ]] || { echo "::error::manual dispatch required" >&2; exit 1; }
+          [[ "$GITHUB_REF" == refs/heads/main ]] || { echo "::error::workflow must run from main" >&2; exit 1; }
+          [[ "$SOURCE_SHA_INPUT" =~ ^[0-9a-f]{40}$ ]] || { echo "::error::invalid source SHA" >&2; exit 1; }
+          [[ "$PROMOTION_CONFIRMED_INPUT" == true ]] || { echo "::error::promotion confirmation is required" >&2; exit 1; }
+          [[ "$REDACTED_EVIDENCE_INPUT" =~ ^journeys/evidence/provider-prebeta-admission-[A-Za-z0-9_.:-]+\.redacted\.json$ ]] || { echo "::error::invalid redacted evidence path" >&2; exit 1; }
+          [[ -f "$REDACTED_EVIDENCE_INPUT" && ! -L "$REDACTED_EVIDENCE_INPUT" ]] || { echo "::error::redacted evidence is absent or unsafe" >&2; exit 1; }
+          [[ "$REQUIREMENT_IDS_INPUT" =~ ^SPEC-[0-9]{3}-R[0-9]{3}(,SPEC-[0-9]{3}-R[0-9]{3})*$ ]] || { echo "::error::invalid requirement IDs" >&2; exit 1; }
+          git fetch --quiet origin refs/heads/main:refs/remotes/origin/main
+          main_sha="$(git rev-parse refs/remotes/origin/main)"
+          [[ "$main_sha" == "$GITHUB_SHA" ]] || { echo "::error::workflow commit is no longer origin/main" >&2; exit 1; }
+          git cat-file -e "${SOURCE_SHA_INPUT}^{commit}" || { echo "::error::source SHA is not reachable" >&2; exit 1; }
+          git merge-base --is-ancestor "$SOURCE_SHA_INPUT" "$GITHUB_SHA" || { echo "::error::source SHA must be an ancestor of the reviewed evidence commit" >&2; exit 1; }
+          envelope="${REDACTED_EVIDENCE_INPUT%.redacted.json}.journey-result.signed.json"
+          payload="$RUNNER_TEMP/provider-prebeta-journey-result.unsigned.json"
+          short_sha="${SOURCE_SHA_INPUT:0:12}"
+          printf 'source_sha=%s\n' "$SOURCE_SHA_INPUT" >> "$GITHUB_OUTPUT"
+          printf 'evidence_sha=%s\n' "$GITHUB_SHA" >> "$GITHUB_OUTPUT"
+          printf 'short_sha=%s\n' "$short_sha" >> "$GITHUB_OUTPUT"
+          printf 'redacted=%s\n' "$REDACTED_EVIDENCE_INPUT" >> "$GITHUB_OUTPUT"
+          printf 'requirement_ids=%s\n' "$REQUIREMENT_IDS_INPUT" >> "$GITHUB_OUTPUT"
+          printf 'payload=%s\n' "$payload" >> "$GITHUB_OUTPUT"
+          printf 'envelope=%s\n' "$envelope" >> "$GITHUB_OUTPUT"
+
+      - name: Build unsigned provider-prebeta journey-result payload
+        shell: bash
+        env:
+          SOURCE_SHA: ${{ steps.request.outputs.source_sha }}
+          EVIDENCE_SHA: ${{ steps.request.outputs.evidence_sha }}
+          REDACTED: ${{ steps.request.outputs.redacted }}
+          REQUIREMENT_IDS: ${{ steps.request.outputs.requirement_ids }}
+          PAYLOAD: ${{ steps.request.outputs.payload }}
+        run: |
+          set -euo pipefail
+          python3 scripts/build-provider-prebeta-journey-result.py \
+            --source-sha "$SOURCE_SHA" \
+            --evidence-sha "$EVIDENCE_SHA" \
+            --requirement-ids "$REQUIREMENT_IDS" \
+            --output "$PAYLOAD" \
+            "$REDACTED"
+
+      - name: Verify protected environment and repository posture
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_POSTURE_TOKEN }}
+        run: bash scripts/verify-github-release-posture.sh "$GITHUB_REPOSITORY" production-release 28995904
+
+      - name: Sign journey-result payload
+        shell: bash
+        env:
+          MACPROVIDER_ACCEPTANCE_SIGNING_KEY_PEM: ${{ secrets.MACPROVIDER_ACCEPTANCE_SIGNING_KEY_PEM }}
+          PAYLOAD: ${{ steps.request.outputs.payload }}
+          ENVELOPE: ${{ steps.request.outputs.envelope }}
+        run: |
+          set -euo pipefail
+          python3 scripts/sign-journey-result.py \
+            --input "$PAYLOAD" \
+            --output "$ENVELOPE" \
+            --verifier ".github/workflows/promote-signed-provider-prebeta-journey.yml:${GITHUB_RUN_ID}:${GITHUB_RUN_ATTEMPT}"
+
+      - name: Promote only after signed validation
+        shell: bash
+        env:
+          ENVELOPE: ${{ steps.request.outputs.envelope }}
+          REQUIREMENT_IDS: ${{ steps.request.outputs.requirement_ids }}
+        run: |
+          set -euo pipefail
+          python3 - "$REQUIREMENT_IDS" "$ENVELOPE" <<'PY'
+          import subprocess
+          import sys
+
+          requirement_ids = [item for item in sys.argv[1].split(",") if item]
+          envelope = sys.argv[2]
+          for requirement_id in requirement_ids:
+              subprocess.run(
+                  [
+                      "python3",
+                      "scripts/promote-signed-journey-result.py",
+                      "--base-ref",
+                      "origin/main",
+                      requirement_id,
+                      envelope,
+                  ],
+                  check=True,
+              )
+          PY
+
+      - name: Verify promoted ledger and committed artifact set
+        shell: bash
+        env:
+          REDACTED: ${{ steps.request.outputs.redacted }}
+          ENVELOPE: ${{ steps.request.outputs.envelope }}
+          REQUIREMENT_IDS: ${{ steps.request.outputs.requirement_ids }}
+        run: |
+          set -euo pipefail
+          python3 -m json.tool "$REDACTED" >/dev/null
+          python3 -m json.tool "$ENVELOPE" >/dev/null
+          python3 -m json.tool specs/CONFORMANCE.json >/dev/null
+          python3 scripts/check_spec_governance.py --base-ref origin/main
+          git diff --check
+          python3 - "$ENVELOPE" "$REQUIREMENT_IDS" <<'PY'
+          import json
+          import pathlib
+          import sys
+
+          envelope = pathlib.Path(sys.argv[1]).as_posix()
+          requirement_ids = [item for item in sys.argv[2].split(",") if item]
+          conformance = json.loads(pathlib.Path("specs/CONFORMANCE.json").read_text(encoding="utf-8"))
+          rows = {
+              item.get("requirement_id"): item
+              for item in conformance.get("requirements", [])
+              if isinstance(item, dict)
+          }
+          for requirement_id in requirement_ids:
+              requirement = rows.get(requirement_id)
+              if requirement is None:
+                  raise SystemExit(f"{requirement_id} missing from conformance ledger")
+              if requirement.get("state") != "conformant" or requirement.get("gap") is not None:
+                  raise SystemExit(f"{requirement_id} was not promoted to conformant")
+              evidence = requirement.get("evidence")
+              if not isinstance(evidence, list) or not any(item.get("source") == envelope for item in evidence if isinstance(item, dict)):
+                  raise SystemExit(f"{requirement_id} evidence does not reference the signed envelope")
+          prefix = pathlib.Path(envelope).name.removesuffix(".journey-result.signed.json")
+          for path in pathlib.Path("journeys/evidence").glob(f"{prefix}*"):
+              name = path.name
+              if name.endswith(".candidate.json") or name.endswith(".journey-result.unsigned.json"):
+                  raise SystemExit(f"non-promotable intermediate remains: {path}")
+          PY
+
+      - name: Export signed promotion artifact
+        shell: bash
+        env:
+          SOURCE_SHA: ${{ steps.request.outputs.source_sha }}
+          EVIDENCE_SHA: ${{ steps.request.outputs.evidence_sha }}
+          REDACTED: ${{ steps.request.outputs.redacted }}
+          ENVELOPE: ${{ steps.request.outputs.envelope }}
+          REQUIREMENT_IDS: ${{ steps.request.outputs.requirement_ids }}
+        run: |
+          set -euo pipefail
+          export_dir="$RUNNER_TEMP/signed-provider-prebeta-journey-promotion"
+          mkdir -p "$export_dir/journeys/evidence" "$export_dir/specs"
+          cp "$REDACTED" "$export_dir/$REDACTED"
+          cp "$ENVELOPE" "$export_dir/$ENVELOPE"
+          cp specs/CONFORMANCE.json "$export_dir/specs/CONFORMANCE.json"
+          python3 - "$export_dir/promotion-manifest.json" "$SOURCE_SHA" "$EVIDENCE_SHA" "$REDACTED" "$ENVELOPE" "$REQUIREMENT_IDS" <<'PY'
+          import hashlib
+          import json
+          import os
+          import pathlib
+          import sys
+
+          output, source_sha, evidence_sha, redacted, envelope, requirement_ids = sys.argv[1:]
+          root = pathlib.Path(".")
+          manifest = {
+              "schema_version": "macprovider.signed-provider-prebeta-journey-promotion.v1",
+              "source_sha": source_sha,
+              "evidence_sha": evidence_sha,
+              "requirement_ids": [item for item in requirement_ids.split(",") if item],
+              "journey_id": "JOURNEY-PROVIDER-PREBETA-ADMISSION",
+              "redacted_artifact": redacted,
+              "redacted_sha256": hashlib.sha256((root / redacted).read_bytes()).hexdigest(),
+              "signed_envelope": envelope,
+              "signed_envelope_sha256": hashlib.sha256((root / envelope).read_bytes()).hexdigest(),
+              "conformance_sha256": hashlib.sha256((root / "specs/CONFORMANCE.json").read_bytes()).hexdigest(),
+              "workflow_run_id": os.environ["GITHUB_RUN_ID"],
+              "workflow_run_attempt": os.environ["GITHUB_RUN_ATTEMPT"],
+          }
+          pathlib.Path(output).write_text(json.dumps(manifest, indent=2) + "\n", encoding="utf-8")
+          PY
+
+      - name: Upload signed promotion artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        with:
+          name: signed-provider-prebeta-journey-promotion-${{ steps.request.outputs.source_sha }}
+          path: ${{ runner.temp }}/signed-provider-prebeta-journey-promotion/
+          if-no-files-found: error
+          include-hidden-files: false
+          retention-days: 1

--- a/Makefile
+++ b/Makefile
@@ -64,6 +64,8 @@ test-dist:
 	bash scripts/test-recover-malibu-publication.sh
 	bash scripts/test-acceptance-candidate-security.sh
 	bash scripts/test-signed-payout-journey-workflow.sh
+	bash scripts/test-signed-provider-prebeta-journey-workflow.sh
+	PYTHONDONTWRITEBYTECODE=1 python3 -m unittest -v scripts.tests.test_provider_prebeta_journey_result
 	bash scripts/test-acceptance-candidate-metadata.sh
 	bash scripts/test-acceptance-promotion.sh
 	bash scripts/test-release-toolchain.sh

--- a/scripts/build-provider-prebeta-journey-result.py
+++ b/scripts/build-provider-prebeta-journey-result.py
@@ -1,0 +1,321 @@
+#!/usr/bin/env python3
+"""Build a promotable provider-prebeta journey-result payload from redacted evidence."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import re
+import subprocess
+import sys
+import tempfile
+from copy import deepcopy
+from datetime import date
+from pathlib import Path
+from typing import Any
+
+from check_spec_governance import JOURNEY_RESULT_PAYLOAD_SCHEMA, _load_json, ValidationResult
+
+
+JOURNEY_ID = "JOURNEY-PROVIDER-PREBETA-ADMISSION"
+EVIDENCE_SCHEMA = "macprovider.provider-prebeta-admission-evidence.v1"
+REPOSITORY = "Augustas11/macprovider"
+ARTIFACT_ID = "redacted-provider-prebeta-admission"
+REQUIREMENT_RE = re.compile(r"^SPEC-[0-9]{3}-R[0-9]{3}$")
+COMMIT_RE = re.compile(r"^[0-9a-f]{40}$")
+DATETIME_Z_RE = re.compile(r"^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$")
+DATE_RE = re.compile(r"^[0-9]{4}-[0-9]{2}-[0-9]{2}$")
+FINGERPRINT_RE = re.compile(r"^[0-9a-f]{64}$")
+STEP_IDS = (
+    "step-01-private-prebeta-authorization",
+    "step-02-install-launch-identity",
+    "step-03-provider-registration-admission",
+    "step-04-catalog-autotune-readiness",
+    "step-05-hardware-evidence-verifier",
+    "step-06-provider-runtime-routing",
+    "step-07-buyer-serving-smoke",
+    "step-08-redaction-and-correlation",
+)
+FORBIDDEN_KEY_FRAGMENTS = (
+    "authorization_header",
+    "bearer_token",
+    "private_key",
+    "raw_secret",
+    "raw_signature",
+    "raw_token",
+    "secret_key",
+    "wallet_private",
+)
+
+
+def die(message: str) -> None:
+    print(f"build-provider-prebeta-journey-result: {message}", file=sys.stderr)
+    raise SystemExit(1)
+
+
+def load_object(path: Path, label: str) -> dict[str, Any]:
+    result = ValidationResult()
+    value = _load_json(path, result)
+    if result.errors:
+        for error in result.errors:
+            print(f"error: {error}", file=sys.stderr)
+        die(f"{label} rejected")
+    if not isinstance(value, dict):
+        die(f"{label} must be a JSON object")
+    return value
+
+
+def write_json_atomically(path: Path, value: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    payload = json.dumps(value, indent=2, sort_keys=False) + "\n"
+    with tempfile.NamedTemporaryFile("w", encoding="utf-8", dir=path.parent, prefix=f".{path.name}.", delete=False) as handle:
+        temporary = Path(handle.name)
+        handle.write(payload)
+    try:
+        if path.exists() and path.is_symlink():
+            die(f"output must not be a symlink: {path}")
+        temporary.replace(path)
+    finally:
+        if temporary.exists():
+            temporary.unlink()
+
+
+def repository_relative(root: Path, value: str, label: str) -> str:
+    candidate = Path(value)
+    if candidate.is_absolute():
+        die(f"{label} must be repository-relative")
+    normalized = candidate.as_posix()
+    if normalized.startswith("../") or "/../" in normalized or normalized == "..":
+        die(f"{label} must not contain parent traversal")
+    resolved = (root / normalized).resolve(strict=False)
+    try:
+        resolved.relative_to(root)
+    except ValueError:
+        die(f"{label} must stay inside the repository")
+    return normalized
+
+
+def require_evidence_source(root: Path, source: str) -> tuple[str, Path]:
+    normalized = repository_relative(root, source, "redacted evidence source")
+    if not normalized.startswith("journeys/evidence/provider-prebeta-admission-") or not normalized.endswith(".redacted.json"):
+        die("redacted evidence source must be journeys/evidence/provider-prebeta-admission-*.redacted.json")
+    path = root / normalized
+    if not path.is_file() or path.is_symlink():
+        die(f"redacted evidence source is absent or unsafe: {normalized}")
+    return normalized, path
+
+
+def require_string(value: Any, pattern: re.Pattern[str] | None, location: str) -> str:
+    if not isinstance(value, str) or not value:
+        die(f"{location} must be a non-empty string")
+    if pattern is not None and not pattern.fullmatch(value):
+        die(f"{location} has invalid format")
+    return value
+
+
+def require_object(value: Any, location: str) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        die(f"{location} must be an object")
+    return value
+
+
+def require_redaction(value: Any) -> dict[str, bool]:
+    redaction = require_object(value, "redaction")
+    required = ("secrets_redacted", "operator_identity_redacted", "local_account_names_redacted")
+    for key in required:
+        if redaction.get(key) is not True:
+            die(f"redaction.{key} must be true")
+    return {key: True for key in required}
+
+
+def parse_requirement_id_values(source: Any, location: str) -> list[str]:
+    if isinstance(source, str):
+        values = [item.strip() for item in source.split(",") if item.strip()]
+    elif isinstance(source, list):
+        values = source
+    else:
+        die(f"{location} must be a comma-separated string or array")
+    if not values:
+        die(f"{location} must not be empty")
+    if len(set(values)) != len(values):
+        die(f"{location} must be unique")
+    for item in values:
+        require_string(item, REQUIREMENT_RE, f"{location}[]")
+    return list(values)
+
+
+def parse_requirement_ids(raw: str | None, evidence: dict[str, Any]) -> list[str]:
+    evidence_ids = parse_requirement_id_values(evidence.get("requirement_ids"), "evidence.requirement_ids")
+    if raw is None:
+        return evidence_ids
+    input_ids = parse_requirement_id_values(raw, "--requirement-ids")
+    if input_ids != evidence_ids:
+        die("--requirement-ids must exactly match evidence.requirement_ids")
+    return evidence_ids
+
+
+def load_mapped_provider_requirements(root: Path) -> set[str]:
+    conformance = load_object(root / "specs" / "CONFORMANCE.json", "spec conformance")
+    requirements = conformance.get("requirements")
+    if not isinstance(requirements, list):
+        die("specs/CONFORMANCE.json requirements must be an array")
+    mapped: set[str] = set()
+    for row in requirements:
+        if not isinstance(row, dict):
+            continue
+        journeys = row.get("journeys")
+        if isinstance(journeys, list) and JOURNEY_ID in journeys and row.get("state") == "pending":
+            requirement_id = row.get("requirement_id")
+            if isinstance(requirement_id, str):
+                mapped.add(requirement_id)
+    return mapped
+
+
+def require_reachable_commit(root: Path, commit: str, label: str) -> None:
+    completed = subprocess.run(["git", "cat-file", "-e", f"{commit}^{{commit}}"], cwd=root, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, check=False)
+    if completed.returncode != 0:
+        die(f"{label} is not a reachable commit")
+
+
+def require_ancestor_commit(root: Path, ancestor: str, descendant: str) -> None:
+    completed = subprocess.run(["git", "merge-base", "--is-ancestor", ancestor, descendant], cwd=root, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, check=False)
+    if completed.returncode != 0:
+        die("--source-sha must be an ancestor of --evidence-sha")
+
+
+def require_git_file_matches(root: Path, commit: str, source: str, path: Path) -> None:
+    completed = subprocess.run(["git", "show", f"{commit}:{source}"], cwd=root, capture_output=True, check=False)
+    if completed.returncode != 0:
+        die("redacted evidence source must exist at --evidence-sha")
+    if completed.stdout != path.read_bytes():
+        die("redacted evidence source bytes must match --evidence-sha")
+
+
+def require_steps(value: Any) -> list[dict[str, Any]]:
+    if not isinstance(value, list):
+        die("steps must be an array")
+    by_id: dict[str, dict[str, Any]] = {}
+    for index, item in enumerate(value):
+        step = require_object(item, f"steps[{index}]")
+        step_id = require_string(step.get("id"), None, f"steps[{index}].id")
+        if step_id in by_id:
+            die(f"duplicate step id: {step_id}")
+        if step.get("status") != "pass":
+            die(f"{step_id}.status must equal 'pass'")
+        assertion = require_string(step.get("assertion"), None, f"{step_id}.assertion")
+        artifacts = step.get("artifacts")
+        if artifacts is None:
+            artifacts = [ARTIFACT_ID]
+        if not isinstance(artifacts, list) or not artifacts or any(item != ARTIFACT_ID for item in artifacts):
+            die(f"{step_id}.artifacts must reference {ARTIFACT_ID}")
+        by_id[step_id] = {"id": step_id, "status": "pass", "assertion": assertion, "artifacts": [ARTIFACT_ID]}
+    missing = [step_id for step_id in STEP_IDS if step_id not in by_id]
+    extra = [step_id for step_id in by_id if step_id not in STEP_IDS]
+    if missing:
+        die(f"missing provider-prebeta step(s): {', '.join(missing)}")
+    if extra:
+        die(f"unknown provider-prebeta step(s): {', '.join(extra)}")
+    return [by_id[step_id] for step_id in STEP_IDS]
+
+
+def reject_forbidden_secret_keys(value: Any, location: str = "$") -> None:
+    if isinstance(value, dict):
+        for key, item in value.items():
+            lowered = key.lower()
+            if any(fragment in lowered for fragment in FORBIDDEN_KEY_FRAGMENTS):
+                if not (lowered.endswith("_redacted") and item is True):
+                    die(f"{location}.{key} uses a forbidden secret-bearing field name")
+            reject_forbidden_secret_keys(item, f"{location}.{key}")
+    elif isinstance(value, list):
+        for index, item in enumerate(value):
+            reject_forbidden_secret_keys(item, f"{location}[{index}]")
+
+
+def build_payload(root: Path, source: str, *, source_sha: str, evidence_sha: str, requirement_ids: str | None) -> dict[str, Any]:
+    require_string(source_sha, COMMIT_RE, "--source-sha")
+    require_string(evidence_sha, COMMIT_RE, "--evidence-sha")
+    source, path = require_evidence_source(root, source)
+    evidence = load_object(path, "provider-prebeta redacted evidence")
+    reject_forbidden_secret_keys(evidence)
+    if evidence.get("schema_version") != EVIDENCE_SCHEMA:
+        die(f"schema_version must equal {EVIDENCE_SCHEMA!r}")
+    if evidence.get("journey_id") != JOURNEY_ID:
+        die(f"journey_id must equal {JOURNEY_ID!r}")
+    require_reachable_commit(root, source_sha, "--source-sha")
+    require_reachable_commit(root, evidence_sha, "--evidence-sha")
+    require_ancestor_commit(root, source_sha, evidence_sha)
+    repository = require_object(evidence.get("repository"), "repository")
+    if repository.get("name") != REPOSITORY:
+        die(f"repository.name must equal {REPOSITORY!r}")
+    evidence_source_sha = require_string(repository.get("commit"), COMMIT_RE, "repository.commit")
+    if evidence_source_sha != source_sha:
+        die("repository.commit must exactly match --source-sha")
+    require_git_file_matches(root, evidence_sha, source, path)
+
+    selected_requirements = parse_requirement_ids(requirement_ids, evidence)
+    mapped = load_mapped_provider_requirements(root)
+    not_mapped = [item for item in selected_requirements if item not in mapped]
+    if not_mapped:
+        die(f"requirement_ids must be pending and mapped to {JOURNEY_ID}: {', '.join(not_mapped)}")
+
+    captured_at = require_string(evidence.get("captured_at"), DATETIME_Z_RE, "captured_at")
+    expires_at = require_string(evidence.get("expires_at"), DATE_RE, "expires_at")
+    if date.fromisoformat(expires_at) < date.today():
+        die("expires_at must not be in the past")
+    operator = deepcopy(require_object(evidence.get("operator"), "operator"))
+    require_string(operator.get("role"), None, "operator.role")
+    require_string(operator.get("identity_fingerprint"), FINGERPRINT_RE, "operator.identity_fingerprint")
+    environment = deepcopy(require_object(evidence.get("environment"), "environment"))
+    for field in ("class", "hardware_profile", "candidate"):
+        require_string(environment.get(field), None, f"environment.{field}")
+    result = deepcopy(require_object(evidence.get("result"), "result"))
+    if result.get("status") != "pass":
+        die("result.status must equal 'pass'")
+    if "summary" in result:
+        require_string(result.get("summary"), None, "result.summary")
+    steps = require_steps(evidence.get("steps"))
+    redaction = require_redaction(evidence.get("redaction"))
+    artifact_sha = hashlib.sha256(path.read_bytes()).hexdigest()
+    run_id = require_string(evidence.get("run_id"), None, "run_id")
+
+    return {
+        "schema_version": JOURNEY_RESULT_PAYLOAD_SCHEMA,
+        "journey_id": JOURNEY_ID,
+        "requirement_ids": selected_requirements,
+        "repository": {"name": REPOSITORY, "commit": source_sha},
+        "captured_at": captured_at,
+        "expires_at": expires_at,
+        "operator": operator,
+        "environment": environment,
+        "artifacts": [{"id": ARTIFACT_ID, "sha256": artifact_sha, "source": source}],
+        "result": result,
+        "steps": steps,
+        "redaction": redaction,
+        "run_id": run_id,
+        "execution_mode": "physical-provider-prebeta-admission",
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("redacted_evidence_source", help="journeys/evidence/provider-prebeta-admission-*.redacted.json")
+    parser.add_argument("--root", default=".", help="repository root")
+    parser.add_argument("--output", required=True, help="unsigned journey-result payload output path")
+    parser.add_argument("--source-sha", required=True, help="expected source/build commit captured by the evidence")
+    parser.add_argument("--evidence-sha", required=True, help="expected repository commit containing the redacted evidence")
+    parser.add_argument("--requirement-ids", default=None, help="comma-separated requirement IDs to cover")
+    args = parser.parse_args(argv)
+
+    root = Path(args.root).resolve()
+    output = Path(args.output)
+    if not output.is_absolute():
+        output = root / output
+    payload = build_payload(root, args.redacted_evidence_source, source_sha=args.source_sha, evidence_sha=args.evidence_sha, requirement_ids=args.requirement_ids)
+    write_json_atomically(output, payload)
+    print(f"build-provider-prebeta-journey-result: wrote {output}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check_spec_governance.py
+++ b/scripts/check_spec_governance.py
@@ -39,6 +39,20 @@ SPEC016_PAYOUT_SPEC_ID = "SPEC-016"
 SPEC016_PAYOUT_REQUIREMENT_ID = "SPEC-016-R002"
 SPEC016_PAYOUT_EXECUTION_MODE = "candidate-derived-handler-only-conformance-harness"
 SPEC016_PAYOUT_STEP_IDS = {f"step-{index:02d}" for index in range(1, 12)}
+PROVIDER_PREBETA_JOURNEY_ID = "JOURNEY-PROVIDER-PREBETA-ADMISSION"
+PROVIDER_PREBETA_EXECUTION_MODE = "physical-provider-prebeta-admission"
+PROVIDER_PREBETA_ARTIFACT_ID = "redacted-provider-prebeta-admission"
+PROVIDER_PREBETA_EVIDENCE_SCHEMA = "macprovider.provider-prebeta-admission-evidence.v1"
+PROVIDER_PREBETA_STEP_IDS = {
+    "step-01-private-prebeta-authorization",
+    "step-02-install-launch-identity",
+    "step-03-provider-registration-admission",
+    "step-04-catalog-autotune-readiness",
+    "step-05-hardware-evidence-verifier",
+    "step-06-provider-runtime-routing",
+    "step-07-buyer-serving-smoke",
+    "step-08-redaction-and-correlation",
+}
 TRUSTED_OPENSSL_CANDIDATES = (
     "/usr/bin/openssl",
     "/opt/homebrew/opt/openssl@3/bin/openssl",
@@ -514,6 +528,92 @@ def _validate_spec016_payout_artifact(root: Path, artifact: dict[str, Any], loca
         result.error(f"{location}.source", "SPEC-016 payout journey-result cannot promote candidate-only artifact content")
 
 
+def _validate_provider_prebeta_artifact(
+    root: Path,
+    artifact: dict[str, Any],
+    signed: dict[str, Any],
+    location: str,
+    result: ValidationResult,
+) -> None:
+    if artifact.get("id") != PROVIDER_PREBETA_ARTIFACT_ID:
+        result.error(f"{location}.id", f"must equal {PROVIDER_PREBETA_ARTIFACT_ID!r}")
+    source = artifact.get("source")
+    if not isinstance(source, str):
+        return
+    if not source.startswith("journeys/evidence/provider-prebeta-admission-") or not source.endswith(".redacted.json"):
+        result.error(f"{location}.source", "provider-prebeta journey-result artifact must be a provider-prebeta redacted evidence file")
+        return
+    artifact_path = _repository_path(root, source, f"{location}.source", result)
+    if artifact_path is None:
+        return
+    payload = _load_json(artifact_path, ValidationResult())
+    if not isinstance(payload, dict):
+        result.error(f"{location}.source", "provider-prebeta redacted evidence must be a JSON object")
+        return
+    if payload.get("schema_version") != PROVIDER_PREBETA_EVIDENCE_SCHEMA:
+        result.error(f"{location}.source.schema_version", f"must equal {PROVIDER_PREBETA_EVIDENCE_SCHEMA!r}")
+    if payload.get("journey_id") != PROVIDER_PREBETA_JOURNEY_ID:
+        result.error(f"{location}.source.journey_id", f"must equal {PROVIDER_PREBETA_JOURNEY_ID!r}")
+    payload_requirement_ids = _string_list(payload.get("requirement_ids"), f"{location}.source.requirement_ids", result, REQUIREMENT_ID_RE)
+    if payload_requirement_ids != signed.get("requirement_ids"):
+        result.error(f"{location}.source.requirement_ids", "must exactly match signed.requirement_ids")
+    repository = payload.get("repository")
+    signed_repository = signed.get("repository")
+    if _expect_object(repository, f"{location}.source.repository", result) and isinstance(signed_repository, dict):
+        _expect_keys(repository, {"name", "commit"}, {"name", "commit"}, f"{location}.source.repository", result)
+        if repository.get("name") != signed_repository.get("name"):
+            result.error(f"{location}.source.repository.name", "must match signed.repository.name")
+        if repository.get("commit") != signed_repository.get("commit"):
+            result.error(f"{location}.source.repository.commit", "must match signed.repository.commit")
+    if payload.get("captured_at") != signed.get("captured_at"):
+        result.error(f"{location}.source.captured_at", "must match signed.captured_at")
+    if payload.get("expires_at") != signed.get("expires_at"):
+        result.error(f"{location}.source.expires_at", "must match signed.expires_at")
+
+
+def _validate_provider_prebeta_journey_result(
+    root: Path,
+    signed: dict[str, Any],
+    journeys: list[str],
+    artifacts: list[Any],
+    steps: list[Any],
+    location: str,
+    result: ValidationResult,
+) -> None:
+    if signed.get("journey_id") != PROVIDER_PREBETA_JOURNEY_ID:
+        result.error(f"{location}.signed.journey_id", f"must equal {PROVIDER_PREBETA_JOURNEY_ID!r}")
+    if journeys != [PROVIDER_PREBETA_JOURNEY_ID]:
+        result.error(location, f"provider-prebeta requirement journeys must equal [{PROVIDER_PREBETA_JOURNEY_ID!r}]")
+    if signed.get("execution_mode") != PROVIDER_PREBETA_EXECUTION_MODE:
+        result.error(f"{location}.signed.execution_mode", f"must equal {PROVIDER_PREBETA_EXECUTION_MODE!r}")
+
+    observed_step_ids: set[str] = set()
+    valid_step_count = 0
+    for index, step in enumerate(steps):
+        if not isinstance(step, dict) or not isinstance(step.get("id"), str):
+            continue
+        valid_step_count += 1
+        step_id = step["id"]
+        if step_id in observed_step_ids:
+            result.error(f"{location}.signed.steps[{index}].id", f"duplicate provider-prebeta physical step {step_id!r}")
+        observed_step_ids.add(step_id)
+    missing_steps = PROVIDER_PREBETA_STEP_IDS - observed_step_ids
+    unexpected_steps = observed_step_ids - PROVIDER_PREBETA_STEP_IDS
+    if missing_steps:
+        result.error(f"{location}.signed.steps", f"missing provider-prebeta physical steps: {sorted(missing_steps)}")
+    if unexpected_steps:
+        result.error(f"{location}.signed.steps", f"unexpected provider-prebeta physical steps: {sorted(unexpected_steps)}")
+    if valid_step_count != len(PROVIDER_PREBETA_STEP_IDS):
+        result.error(f"{location}.signed.steps", f"must contain exactly {len(PROVIDER_PREBETA_STEP_IDS)} provider-prebeta physical steps")
+
+    valid_artifacts = [artifact for artifact in artifacts if isinstance(artifact, dict)]
+    if len(valid_artifacts) != 1:
+        result.error(f"{location}.signed.artifacts", "provider-prebeta journey-result must contain exactly one redacted evidence artifact")
+    for index, artifact in enumerate(artifacts):
+        if isinstance(artifact, dict):
+            _validate_provider_prebeta_artifact(root, artifact, signed, f"{location}.signed.artifacts[{index}]", result)
+
+
 def _validate_spec016_payout_journey_result(
     root: Path,
     signed: dict[str, Any],
@@ -922,6 +1022,8 @@ def _validate_signed_journey_result(
         if requirement_id != SPEC016_PAYOUT_REQUIREMENT_ID:
             result.error(f"{location}.signed.requirement_ids", f"SPEC-016 payout journey-result may only promote {SPEC016_PAYOUT_REQUIREMENT_ID}")
         _validate_spec016_payout_journey_result(root, signed, source, journeys, artifact_records, steps, location, result)
+    if journey_id == PROVIDER_PREBETA_JOURNEY_ID:
+        _validate_provider_prebeta_journey_result(root, signed, [item for item in journeys if isinstance(item, str)], artifact_records, steps, location, result)
 
     return len(result.errors) == before
 

--- a/scripts/test-signed-provider-prebeta-journey-workflow.sh
+++ b/scripts/test-signed-provider-prebeta-journey-workflow.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd -P)"
+workflow="$root/.github/workflows/promote-signed-provider-prebeta-journey.yml"
+builder="$root/scripts/build-provider-prebeta-journey-result.py"
+
+fail() {
+  printf '[test-signed-provider-prebeta-journey-workflow] ERROR: %s\n' "$*" >&2
+  exit 1
+}
+
+[[ -f "$workflow" && ! -L "$workflow" ]] || fail "workflow is absent or unsafe"
+[[ -f "$builder" && ! -L "$builder" ]] || fail "builder is absent or unsafe"
+
+python3 - "$workflow" "$builder" <<'PY'
+import pathlib
+import re
+import sys
+
+workflow = pathlib.Path(sys.argv[1]).read_text(encoding="utf-8")
+builder = pathlib.Path(sys.argv[2]).read_text(encoding="utf-8")
+
+required_workflow = [
+    "\n  workflow_dispatch:\n",
+    "environment: production-release",
+    "contents: read",
+    "redacted_evidence_path",
+    "requirement_ids",
+    '[[ "$GITHUB_REF" == refs/heads/main ]]',
+    '[[ "$PROMOTION_CONFIRMED_INPUT" == true ]]',
+    '[[ "$main_sha" == "$GITHUB_SHA" ]]',
+    'git cat-file -e "${SOURCE_SHA_INPUT}^{commit}"',
+    'git merge-base --is-ancestor "$SOURCE_SHA_INPUT" "$GITHUB_SHA"',
+    "evidence_sha=%s",
+    "scripts/build-provider-prebeta-journey-result.py",
+    '--evidence-sha "$EVIDENCE_SHA"',
+    "scripts/verify-github-release-posture.sh",
+    "GH_TOKEN: ${{ secrets.RELEASE_POSTURE_TOKEN }}",
+    "MACPROVIDER_ACCEPTANCE_SIGNING_KEY_PEM: ${{ secrets.MACPROVIDER_ACCEPTANCE_SIGNING_KEY_PEM }}",
+    "scripts/sign-journey-result.py",
+    "scripts/promote-signed-journey-result.py",
+    "scripts/check_spec_governance.py --base-ref origin/main",
+    "actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a",
+    "retention-days: 1",
+    "macprovider.signed-provider-prebeta-journey-promotion.v1",
+    "JOURNEY-PROVIDER-PREBETA-ADMISSION",
+]
+for value in required_workflow:
+    if value not in workflow:
+        raise SystemExit(f"workflow contract is missing: {value}")
+
+if "\n  push:" in workflow or "\n  pull_request:" in workflow:
+    raise SystemExit("workflow must be manual dispatch only")
+for forbidden in ("contents: write", "pull-requests: write", "git push", "gh pr create", "gh pr merge", "gh release"):
+    if forbidden in workflow:
+        raise SystemExit(f"workflow contains an unnecessary write/publication capability: {forbidden}")
+if "cat \"$MACPROVIDER_ACCEPTANCE_SIGNING_KEY_PEM\"" in workflow:
+    raise SystemExit("workflow must not print private key material")
+if re.search(r'echo .*MACPROVIDER_ACCEPTANCE_SIGNING_KEY_PEM', workflow):
+    raise SystemExit("workflow echoes the private key environment variable")
+if "cp \"$REDACTED\"" not in workflow or "cp \"$ENVELOPE\"" not in workflow or "cp specs/CONFORMANCE.json" not in workflow:
+    raise SystemExit("workflow must export only the redacted evidence, signed envelope, and ledger")
+if "journey-result.unsigned.json" not in workflow:
+    raise SystemExit("workflow must name the unsigned payload as non-committed runner-temp state")
+if "pathlib.Path(\"journeys/evidence\").glob" not in workflow:
+    raise SystemExit("workflow must check that non-promotable intermediates are absent")
+posture_index = workflow.find("scripts/verify-github-release-posture.sh")
+signing_key_index = workflow.find("MACPROVIDER_ACCEPTANCE_SIGNING_KEY_PEM")
+if posture_index == -1 or signing_key_index == -1 or posture_index > signing_key_index:
+    raise SystemExit("workflow must verify release posture before importing the acceptance signing key")
+
+lines = workflow.splitlines()
+for index, line in enumerate(lines):
+    match = re.match(r"^(\s*)run:\s*\|", line)
+    if not match:
+        continue
+    indent = len(match.group(1))
+    block = []
+    for candidate in lines[index + 1 :]:
+        if candidate.strip() and len(candidate) - len(candidate.lstrip()) <= indent:
+            break
+        block.append(candidate)
+    if any("${{" in row for row in block):
+        raise SystemExit("GitHub expression is interpolated directly into a shell block")
+
+required_builder = [
+    'JOURNEY_ID = "JOURNEY-PROVIDER-PREBETA-ADMISSION"',
+    'EVIDENCE_SCHEMA = "macprovider.provider-prebeta-admission-evidence.v1"',
+    'ARTIFACT_ID = "redacted-provider-prebeta-admission"',
+    "require_git_file_matches",
+    "must be pending and mapped",
+    "step-07-buyer-serving-smoke",
+    "redaction.{key} must be true",
+    "repository.commit must exactly match --source-sha",
+    "redacted evidence source bytes must match --evidence-sha",
+    "--source-sha must be an ancestor of --evidence-sha",
+    "FORBIDDEN_KEY_FRAGMENTS",
+]
+for value in required_builder:
+    if value not in builder:
+        raise SystemExit(f"builder contract is missing: {value}")
+
+print("[test-signed-provider-prebeta-journey-workflow] ok: protected provider-prebeta signer exports a short-lived artifact")
+PY

--- a/scripts/tests/test_provider_prebeta_journey_result.py
+++ b/scripts/tests/test_provider_prebeta_journey_result.py
@@ -1,0 +1,481 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+from scripts.check_spec_governance import ValidationResult, _validate_signed_journey_result
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+BUILDER = REPO_ROOT / "scripts" / "build-provider-prebeta-journey-result.py"
+SIGNER = REPO_ROOT / "scripts" / "sign-journey-result.py"
+EVIDENCE_SOURCE = "journeys/evidence/provider-prebeta-admission-demo.redacted.json"
+
+
+def run(*args: str, cwd: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run([*args], cwd=cwd, text=True, capture_output=True, check=False)
+
+
+def generate_acceptance_key(root: Path) -> str:
+    openssl = shutil.which("openssl")
+    if openssl is None:
+        raise unittest.SkipTest("openssl is required")
+    security = root / "security"
+    security.mkdir(parents=True, exist_ok=True)
+    private_key = root / "private.pem"
+    public_key = security / "acceptance-candidate-signing-public.pem"
+    subprocess.run(
+        [openssl, "genpkey", "-algorithm", "EC", "-pkeyopt", "ec_paramgen_curve:P-256", "-out", str(private_key)],
+        check=True,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+    subprocess.run(
+        [openssl, "pkey", "-in", str(private_key), "-pubout", "-out", str(public_key)],
+        check=True,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+    return private_key.read_text(encoding="utf-8")
+
+
+def base_conformance() -> dict:
+    return {
+        "$schema": "../schemas/spec-conformance-v1.schema.json",
+        "schema_version": "spec-conformance-v1",
+        "baseline": {"commit": "0" * 40, "captured_at": "2026-07-16"},
+        "specs": [],
+        "requirements": [
+            {
+                "requirement_id": "SPEC-010-R001",
+                "spec_id": "SPEC-010",
+                "state": "pending",
+                "evidence": [],
+                "journeys": ["JOURNEY-PROVIDER-PREBETA-ADMISSION"],
+                "gap": {"verdict": "UNKNOWN", "owner": "@Augustas11", "issue": "https://github.com/Augustas11/macprovider/issues/895", "rationale": "pending physical evidence"},
+            },
+            {
+                "requirement_id": "SPEC-010-R002",
+                "spec_id": "SPEC-010",
+                "state": "pending",
+                "evidence": [],
+                "journeys": [],
+                "gap": {"verdict": "UNKNOWN", "owner": "@Augustas11", "issue": "https://github.com/Augustas11/macprovider/issues/614", "rationale": "not mapped here"},
+            },
+        ],
+    }
+
+
+def base_evidence(source_commit: str) -> dict:
+    return {
+        "schema_version": "macprovider.provider-prebeta-admission-evidence.v1",
+        "journey_id": "JOURNEY-PROVIDER-PREBETA-ADMISSION",
+        "run_id": "provider-prebeta-admission-demo",
+        "requirement_ids": ["SPEC-010-R001"],
+        "repository": {"name": "Augustas11/macprovider", "commit": source_commit},
+        "captured_at": "2026-08-05T06:00:00Z",
+        "expires_at": "2027-08-05",
+        "operator": {"role": "provider-prebeta-operator", "identity_fingerprint": hashlib.sha256(b"operator").hexdigest()},
+        "environment": {
+            "class": "physical-provider-prebeta-admission",
+            "hardware_profile": "apple-silicon-redacted",
+            "candidate": "provider-cli:redacted-release-candidate",
+        },
+        "result": {"status": "pass", "summary": "Physical provider-prebeta admission evidence passed."},
+        "steps": [
+            {"id": "step-01-private-prebeta-authorization", "status": "pass", "assertion": "private prebeta authorization posture was captured"},
+            {"id": "step-02-install-launch-identity", "status": "pass", "assertion": "install, launchd state, and provider identity were captured"},
+            {"id": "step-03-provider-registration-admission", "status": "pass", "assertion": "coordinator registration and admission verdict were captured"},
+            {"id": "step-04-catalog-autotune-readiness", "status": "pass", "assertion": "catalog row and autotune model readiness were captured"},
+            {"id": "step-05-hardware-evidence-verifier", "status": "pass", "assertion": "hardware evidence submission and verifier verdict were captured"},
+            {"id": "step-06-provider-runtime-routing", "status": "pass", "assertion": "runtime health and routing eligibility were captured"},
+            {"id": "step-07-buyer-serving-smoke", "status": "pass", "assertion": "buyer smoke routed to the newly admitted provider"},
+            {"id": "step-08-redaction-and-correlation", "status": "pass", "assertion": "redaction preserves correlation without secrets"},
+        ],
+        "redaction": {
+            "secrets_redacted": True,
+            "operator_identity_redacted": True,
+            "local_account_names_redacted": True,
+            "private_keys_redacted": True,
+            "raw_signature_redacted": True,
+        },
+        "observations": {
+            "provider_identity": "provider:redacted-demo",
+            "buyer_smoke_request": "request:redacted-demo",
+        },
+    }
+
+
+class ProviderPrebetaJourneyResultTests(unittest.TestCase):
+    def make_repo(self, evidence_mutation=None, conformance_mutation=None) -> tuple[tempfile.TemporaryDirectory[str], Path, str, str]:
+        directory = tempfile.TemporaryDirectory()
+        root = Path(directory.name)
+        (root / "specs").mkdir()
+        (root / "journeys" / "evidence").mkdir(parents=True)
+        conformance = base_conformance()
+        if conformance_mutation is not None:
+            conformance_mutation(conformance)
+        (root / "specs" / "CONFORMANCE.json").write_text(json.dumps(conformance, indent=2) + "\n", encoding="utf-8")
+        run("git", "init", cwd=root)
+        run("git", "config", "user.name", "test", cwd=root)
+        run("git", "config", "user.email", "test@example.com", cwd=root)
+        run("git", "add", "specs/CONFORMANCE.json", cwd=root)
+        run("git", "commit", "-m", "seed conformance", cwd=root)
+        source_commit = run("git", "rev-parse", "HEAD", cwd=root).stdout.strip()
+        evidence = base_evidence(source_commit)
+        if evidence_mutation is not None:
+            evidence_mutation(evidence)
+        (root / EVIDENCE_SOURCE).write_text(json.dumps(evidence, indent=2) + "\n", encoding="utf-8")
+        run("git", "add", EVIDENCE_SOURCE, cwd=root)
+        run("git", "commit", "-m", "add provider evidence", cwd=root)
+        evidence_commit = run("git", "rev-parse", "HEAD", cwd=root).stdout.strip()
+        return directory, root, source_commit, evidence_commit
+
+    def test_builder_emits_core_signed_payload(self) -> None:
+        directory, root, source_commit, evidence_commit = self.make_repo()
+        self.addCleanup(directory.cleanup)
+        output = root / "payload.json"
+
+        completed = subprocess.run(
+            [
+                sys.executable,
+                str(BUILDER),
+                "--root",
+                str(root),
+                "--source-sha",
+                source_commit,
+                "--evidence-sha",
+                evidence_commit,
+                "--output",
+                str(output),
+                EVIDENCE_SOURCE,
+            ],
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+
+        self.assertEqual(0, completed.returncode, completed.stderr)
+        payload = json.loads(output.read_text(encoding="utf-8"))
+        self.assertEqual("macprovider.journey-result.v1", payload["schema_version"])
+        self.assertEqual("JOURNEY-PROVIDER-PREBETA-ADMISSION", payload["journey_id"])
+        self.assertEqual(["SPEC-010-R001"], payload["requirement_ids"])
+        self.assertEqual(source_commit, payload["repository"]["commit"])
+        self.assertEqual("physical-provider-prebeta-admission", payload["execution_mode"])
+        artifact = payload["artifacts"][0]
+        self.assertEqual("redacted-provider-prebeta-admission", artifact["id"])
+        self.assertEqual(EVIDENCE_SOURCE, artifact["source"])
+        self.assertEqual(hashlib.sha256((root / EVIDENCE_SOURCE).read_bytes()).hexdigest(), artifact["sha256"])
+        self.assertEqual("step-07-buyer-serving-smoke", payload["steps"][6]["id"])
+
+    def test_signed_provider_prebeta_payload_passes_canonical_validator(self) -> None:
+        directory, root, source_commit, evidence_commit = self.make_repo()
+        self.addCleanup(directory.cleanup)
+        private_key = generate_acceptance_key(root)
+        trusted_hash = hashlib.sha256((root / "security" / "acceptance-candidate-signing-public.pem").read_bytes()).hexdigest()
+        payload = root / "payload.json"
+        envelope = root / "journeys" / "evidence" / "provider-prebeta-admission-demo.journey-result.signed.json"
+        completed = subprocess.run(
+            [
+                sys.executable,
+                str(BUILDER),
+                "--root",
+                str(root),
+                "--source-sha",
+                source_commit,
+                "--evidence-sha",
+                evidence_commit,
+                "--output",
+                str(payload),
+                EVIDENCE_SOURCE,
+            ],
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+        self.assertEqual(0, completed.returncode, completed.stderr)
+        env = os.environ.copy()
+        env["MACPROVIDER_ACCEPTANCE_SIGNING_KEY_PEM"] = private_key
+        openssl = shutil.which("openssl")
+        if openssl is None:
+            raise unittest.SkipTest("openssl is required")
+        completed = subprocess.run(
+            [
+                sys.executable,
+                str(SIGNER),
+                "--root",
+                str(root),
+                "--input",
+                str(payload),
+                "--output",
+                str(envelope.relative_to(root)),
+                "--verified-at",
+                "2026-08-05T06:05:00Z",
+                "--openssl-bin",
+                openssl,
+            ],
+            env=env,
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+        self.assertEqual(0, completed.returncode, completed.stderr)
+
+        result = ValidationResult()
+        self.assertTrue(
+            _validate_signed_journey_result(
+                root,
+                str(envelope.relative_to(root)),
+                "SPEC-010-R001",
+                ["JOURNEY-PROVIDER-PREBETA-ADMISSION"],
+                {source_commit},
+                trusted_hash,
+                openssl,
+                "provider-prebeta",
+                result,
+            ),
+            result.errors,
+        )
+        self.assertEqual([], result.errors)
+
+    def test_canonical_validator_rejects_artifact_requirement_mismatch(self) -> None:
+        directory, root, source_commit, evidence_commit = self.make_repo()
+        self.addCleanup(directory.cleanup)
+        private_key = generate_acceptance_key(root)
+        trusted_hash = hashlib.sha256((root / "security" / "acceptance-candidate-signing-public.pem").read_bytes()).hexdigest()
+        payload_path = root / "payload.json"
+        completed = subprocess.run(
+            [
+                sys.executable,
+                str(BUILDER),
+                "--root",
+                str(root),
+                "--source-sha",
+                source_commit,
+                "--evidence-sha",
+                evidence_commit,
+                "--output",
+                str(payload_path),
+                EVIDENCE_SOURCE,
+            ],
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+        self.assertEqual(0, completed.returncode, completed.stderr)
+        payload = json.loads(payload_path.read_text(encoding="utf-8"))
+        payload["requirement_ids"] = ["SPEC-010-R001", "SPEC-010-R002"]
+        payload_path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+        envelope = root / "journeys" / "evidence" / "provider-prebeta-admission-demo.journey-result.signed.json"
+        env = os.environ.copy()
+        env["MACPROVIDER_ACCEPTANCE_SIGNING_KEY_PEM"] = private_key
+        openssl = shutil.which("openssl")
+        if openssl is None:
+            raise unittest.SkipTest("openssl is required")
+        completed = subprocess.run(
+            [
+                sys.executable,
+                str(SIGNER),
+                "--root",
+                str(root),
+                "--input",
+                str(payload_path),
+                "--output",
+                str(envelope.relative_to(root)),
+                "--verified-at",
+                "2026-08-05T06:05:00Z",
+                "--openssl-bin",
+                openssl,
+            ],
+            env=env,
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+        self.assertEqual(0, completed.returncode, completed.stderr)
+
+        result = ValidationResult()
+        self.assertFalse(
+            _validate_signed_journey_result(
+                root,
+                str(envelope.relative_to(root)),
+                "SPEC-010-R001",
+                ["JOURNEY-PROVIDER-PREBETA-ADMISSION"],
+                {source_commit},
+                trusted_hash,
+                openssl,
+                "provider-prebeta",
+                result,
+            )
+        )
+        self.assertTrue(any("must exactly match signed.requirement_ids" in error for error in result.errors), result.errors)
+
+    def test_builder_rejects_unmapped_requirement(self) -> None:
+        def claim_unmapped_requirement(evidence: dict) -> None:
+            evidence["requirement_ids"] = ["SPEC-010-R002"]
+
+        directory, root, source_commit, evidence_commit = self.make_repo(claim_unmapped_requirement)
+        self.addCleanup(directory.cleanup)
+        completed = subprocess.run(
+            [
+                sys.executable,
+                str(BUILDER),
+                "--root",
+                str(root),
+                "--source-sha",
+                source_commit,
+                "--evidence-sha",
+                evidence_commit,
+                "--output",
+                str(root / "payload.json"),
+                EVIDENCE_SOURCE,
+            ],
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+
+        self.assertNotEqual(0, completed.returncode)
+        self.assertIn("must be pending and mapped", completed.stderr)
+
+    def test_builder_rejects_requirement_input_that_overclaims_evidence(self) -> None:
+        def map_second_requirement(conformance: dict) -> None:
+            conformance["requirements"][1]["journeys"] = ["JOURNEY-PROVIDER-PREBETA-ADMISSION"]
+            conformance["requirements"][1]["gap"]["issue"] = "https://github.com/Augustas11/macprovider/issues/895"
+
+        directory, root, source_commit, evidence_commit = self.make_repo(conformance_mutation=map_second_requirement)
+        self.addCleanup(directory.cleanup)
+        completed = subprocess.run(
+            [
+                sys.executable,
+                str(BUILDER),
+                "--root",
+                str(root),
+                "--source-sha",
+                source_commit,
+                "--evidence-sha",
+                evidence_commit,
+                "--requirement-ids",
+                "SPEC-010-R002",
+                "--output",
+                str(root / "payload.json"),
+                EVIDENCE_SOURCE,
+            ],
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+
+        self.assertNotEqual(0, completed.returncode)
+        self.assertIn("must exactly match evidence.requirement_ids", completed.stderr)
+
+    def test_builder_rejects_source_sha_that_differs_from_evidence_commit(self) -> None:
+        directory, root, source_commit, evidence_commit = self.make_repo()
+        self.addCleanup(directory.cleanup)
+        completed = subprocess.run(
+            [
+                sys.executable,
+                str(BUILDER),
+                "--root",
+                str(root),
+                "--source-sha",
+                evidence_commit,
+                "--evidence-sha",
+                evidence_commit,
+                "--output",
+                str(root / "payload.json"),
+                EVIDENCE_SOURCE,
+            ],
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+
+        self.assertNotEqual(0, completed.returncode)
+        self.assertIn("repository.commit must exactly match --source-sha", completed.stderr)
+
+    def test_builder_rejects_non_ancestor_source_sha(self) -> None:
+        directory = tempfile.TemporaryDirectory()
+        self.addCleanup(directory.cleanup)
+        root = Path(directory.name)
+        (root / "specs").mkdir()
+        (root / "journeys" / "evidence").mkdir(parents=True)
+        (root / "specs" / "CONFORMANCE.json").write_text(json.dumps(base_conformance(), indent=2) + "\n", encoding="utf-8")
+        run("git", "init", cwd=root)
+        run("git", "config", "user.name", "test", cwd=root)
+        run("git", "config", "user.email", "test@example.com", cwd=root)
+        run("git", "add", "specs/CONFORMANCE.json", cwd=root)
+        run("git", "commit", "-m", "seed conformance", cwd=root)
+        base_branch = run("git", "branch", "--show-current", cwd=root).stdout.strip()
+        run("git", "checkout", "-b", "side-source", cwd=root)
+        (root / "side.txt").write_text("side source\n", encoding="utf-8")
+        run("git", "add", "side.txt", cwd=root)
+        run("git", "commit", "-m", "side source", cwd=root)
+        side_source_commit = run("git", "rev-parse", "HEAD", cwd=root).stdout.strip()
+        run("git", "checkout", base_branch, cwd=root)
+        evidence = base_evidence(side_source_commit)
+        (root / EVIDENCE_SOURCE).write_text(json.dumps(evidence, indent=2) + "\n", encoding="utf-8")
+        run("git", "add", EVIDENCE_SOURCE, cwd=root)
+        run("git", "commit", "-m", "add evidence on main", cwd=root)
+        evidence_commit = run("git", "rev-parse", "HEAD", cwd=root).stdout.strip()
+
+        completed = subprocess.run(
+            [
+                sys.executable,
+                str(BUILDER),
+                "--root",
+                str(root),
+                "--source-sha",
+                side_source_commit,
+                "--evidence-sha",
+                evidence_commit,
+                "--output",
+                str(root / "payload.json"),
+                EVIDENCE_SOURCE,
+            ],
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+
+        self.assertNotEqual(0, completed.returncode)
+        self.assertIn("must be an ancestor", completed.stderr)
+
+    def test_builder_rejects_missing_buyer_smoke_step(self) -> None:
+        def mutate(evidence: dict) -> None:
+            evidence["steps"] = [step for step in evidence["steps"] if step["id"] != "step-07-buyer-serving-smoke"]
+
+        directory, root, source_commit, evidence_commit = self.make_repo(mutate)
+        self.addCleanup(directory.cleanup)
+        completed = subprocess.run(
+            [
+                sys.executable,
+                str(BUILDER),
+                "--root",
+                str(root),
+                "--source-sha",
+                source_commit,
+                "--evidence-sha",
+                evidence_commit,
+                "--output",
+                str(root / "payload.json"),
+                EVIDENCE_SOURCE,
+            ],
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+
+        self.assertNotEqual(0, completed.returncode)
+        self.assertIn("step-07-buyer-serving-smoke", completed.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Adds the guarded provider-prebeta signed-result promotion path for #614/#895 without promoting any ledger rows.

This PR makes the next physical provider-prebeta evidence run promotable only after:

- the redacted artifact declares the exact requirement IDs it covers;
- any workflow-supplied requirement list exactly matches the artifact;
- the artifact's `repository.commit` matches the captured source/build commit;
- that source commit is an ancestor of the reviewed evidence commit on `main`;
- the signed journey-result passes canonical provider-prebeta semantic validation.

## Validation

- `PYTHONDONTWRITEBYTECODE=1 python3 -m unittest -v scripts.tests.test_provider_prebeta_journey_result`
- `PYTHONDONTWRITEBYTECODE=1 python3 -m unittest -v scripts.tests.test_journey_result_tools`
- `PYTHONDONTWRITEBYTECODE=1 python3 -m unittest -v scripts.tests.test_spec_governance`
- `bash scripts/test-signed-provider-prebeta-journey-workflow.sh && bash scripts/test-signed-payout-journey-workflow.sh && python3 scripts/check_spec_governance.py --base-ref origin/main && python3 scripts/gen_spec_index.py --check && git diff --check`

## Audit

Three read-only audit lanes were run against the full patch. Initial HIGH findings around requirement overclaim, source relabeling, and non-ancestor source commits were fixed. Final re-audit: 0 CRITICAL, 0 HIGH, 0 MEDIUM.

## Not included

- No provider-prebeta ledger row is marked conformant.
- No physical evidence artifact is added.
- No buyer/API/billing/settlement scope is added.

SPEC-GOVERNANCE-DECLARATION-BEGIN
{
  "schema_version": "spec-pr-governance-v1",
  "behavior_change": "yes",
  "contract_change": "none",
  "specs": ["SPEC-010", "SPEC-023", "SPEC-032", "SPEC-033", "SPEC-034"],
  "requirements": [
    "SPEC-010-R001",
    "SPEC-010-R002",
    "SPEC-010-R003",
    "SPEC-010-R004",
    "SPEC-010-R005",
    "SPEC-010-R006",
    "SPEC-023-R001",
    "SPEC-023-R002",
    "SPEC-032-R001",
    "SPEC-032-R002",
    "SPEC-032-R003",
    "SPEC-033-R001",
    "SPEC-034-R001"
  ],
  "authority_domains": [
    "model-catalog-identity",
    "installer-autotune-policy",
    "hardware-evidence-admission",
    "hardware-evidence-verifier",
    "referral-advocacy-policy"
  ],
  "arbitration": ["UNKNOWN", "CODE_BUG"],
  "tests": [
    "scripts/test-signed-provider-prebeta-journey-workflow.sh",
    "scripts.tests.test_provider_prebeta_journey_result",
    "scripts.tests.test_journey_result_tools",
    "scripts.tests.test_spec_governance",
    "scripts/check_spec_governance.py --base-ref origin/main",
    "scripts/gen_spec_index.py --check"
  ],
  "journeys": ["JOURNEY-PROVIDER-PREBETA-ADMISSION"],
  "issue": "https://github.com/Augustas11/macprovider/issues/895"
}
SPEC-GOVERNANCE-DECLARATION-END
