### PR TITLE
feat: add OpenRouter live pricing proposal engine

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,12 +176,12 @@ python3 scripts/openrouter_pricing_engine.py compute \
   --output-dir /var/tmp/openrouter-pricing
 ```
 
-The fetch command uses an explicitly unstable, undocumented frontend rankings
-endpoint for demand, plus the documented model catalog and each selected model's
-documented endpoints response. If the rankings dependency changes, fetch fails
-closed without a snapshot; operators must review and update the adapter rather
-than infer a fallback. Production proposals require a complete
-top-100 snapshot; `--top-n` below 100 is useful only for fetch-only diagnostics.
+The fetch command uses OpenRouter's documented daily rankings dataset, model
+catalog, and each selected model's documented endpoints response. It requires
+`OPENROUTER_API_KEY`. The daily rankings source provides the top 50 public
+models per day by total token usage; the tool aggregates a 30-day window and
+requires a complete 50-model observed cohort. `--top-n` below 50 is useful only
+for fetch-only diagnostics.
 It retries transient errors with bounded backoff, honors `Retry-After` for
 429s, and fails closed without writing a snapshot on a timeout, schema change,
 empty result, invalid price, or partial pull. Commands are noninteractive and

--- a/README.md
+++ b/README.md
@@ -158,6 +158,40 @@ Latest release and signed binaries: [github.com/augustas11/macprovider/releases]
 
 ## In flight
 
+## OpenRouter pricing proposal engine
+
+`scripts/openrouter_pricing_engine.py` is a standalone, non-money-path tool
+that fetches OpenRouter demand and per-model endpoint pricing, writes a
+validated snapshot, and computes a reviewable pricing proposal. It has no
+apply mode and never modifies `phase3-binary/catalog/autotune/rate-card.json`.
+
+Create a live snapshot in an operator-owned directory, then compute a proposal
+against the read-only rate-card reference:
+
+```bash
+python3 scripts/openrouter_pricing_engine.py fetch --output-dir /var/tmp/openrouter-pricing
+python3 scripts/openrouter_pricing_engine.py compute \
+  --snapshot /var/tmp/openrouter-pricing/openrouter-pricing-snapshot-<timestamp>.json \
+  --rate-card phase3-binary/catalog/autotune/rate-card.json \
+  --output-dir /var/tmp/openrouter-pricing
+```
+
+The fetch command uses the rankings endpoint, model catalog, and each selected
+model's documented endpoints response. Production proposals require a complete
+top-100 snapshot; `--top-n` below 100 is useful only for fetch-only diagnostics.
+It retries transient errors with bounded backoff, honors `Retry-After` for
+429s, and fails closed without writing a snapshot on a timeout, schema change,
+empty result, invalid price, or partial pull. Commands are noninteractive and
+suitable for an external scheduler.
+
+Snapshots contain `schema_version`, `fetched_at`, a reproducible
+`content_digest`, endpoint/schema provenance, and normalized demand/pricing
+rows. Proposals contain their source snapshot digest, policy version,
+rate-card reference digest, and `added`, `changed`, `dropped`, `blocked`, and
+`unchanged` rows with reasons. See
+[`docs/runbooks/openrouter-pricing-engine.md`](docs/runbooks/openrouter-pricing-engine.md)
+for the schemas, policy evidence, and offline test procedure.
+
 - **Native Mac app (SPEC-025, "Malibu").** Signed `.dmg` + menu-bar wrapper around `macprovider-cli` — non-developer-facing brand and installer path. P0 skeleton shipped.
 - **Browserless one-click provider onboarding (SPEC-026 draft).** Deep-link launch flow so new providers can join without a terminal.
 - **Self-hosted coordinator.** For buyers who need local-only trust; see the trust-model note above.

--- a/README.md
+++ b/README.md
@@ -176,8 +176,11 @@ python3 scripts/openrouter_pricing_engine.py compute \
   --output-dir /var/tmp/openrouter-pricing
 ```
 
-The fetch command uses the rankings endpoint, model catalog, and each selected
-model's documented endpoints response. Production proposals require a complete
+The fetch command uses an explicitly unstable, undocumented frontend rankings
+endpoint for demand, plus the documented model catalog and each selected model's
+documented endpoints response. If the rankings dependency changes, fetch fails
+closed without a snapshot; operators must review and update the adapter rather
+than infer a fallback. Production proposals require a complete
 top-100 snapshot; `--top-n` below 100 is useful only for fetch-only diagnostics.
 It retries transient errors with bounded backoff, honors `Retry-After` for
 429s, and fails closed without writing a snapshot on a timeout, schema change,

--- a/docs/runbooks/openrouter-pricing-engine.md
+++ b/docs/runbooks/openrouter-pricing-engine.md
@@ -1,0 +1,215 @@
+# OpenRouter pricing proposal engine
+
+## Safety boundary
+
+This is a non-money-path operator tool. It writes only snapshots and proposals
+to the `--output-dir` selected by the operator. It cannot apply a proposal and
+does not modify `phase3-binary/catalog/autotune/rate-card.json`. Component 3
+owns rate-card guardrails, review, and applying any accepted proposal.
+
+## Commands
+
+```bash
+python3 scripts/openrouter_pricing_engine.py fetch \
+  --output-dir /var/tmp/openrouter-pricing \
+  --top-n 100 --retries 3 --timeout-seconds 20 \
+  --generation-timeout-seconds 900
+
+python3 scripts/openrouter_pricing_engine.py compute \
+  --snapshot /var/tmp/openrouter-pricing/openrouter-pricing-snapshot-<timestamp>.json \
+  --policy scripts/openrouter_pricing_policy.json \
+  --rate-card phase3-binary/catalog/autotune/rate-card.json \
+  --output-dir /var/tmp/openrouter-pricing
+```
+
+The commands are noninteractive and have useful exit codes, so an operator can
+schedule `fetch` and then `compute` externally. Do not schedule an apply step:
+there is intentionally no one in this tool.
+
+## Sources and normalization
+
+The fetcher uses these public OpenRouter APIs:
+
+- demand: `https://openrouter.ai/api/frontend/v1/rankings/models`;
+- catalog/schema cross-check: `https://openrouter.ai/api/v1/models`;
+- cheapest active provider price:
+  `https://openrouter.ai/api/v1/models/{model-id}/endpoints`.
+
+Ranking records are aggregated by `model_permaslug`, sorted by completion-token
+volume, and reduced to the requested number of distinct models. Only the latest
+valid OpenRouter ranking timestamp (`YYYY-MM-DD HH:MM:SS`) in the response is
+used; variants from older dates are never
+summed into current demand. Zero-completion
+non-generation rows (for example embedding-only entries) are excluded before
+model-ID validation because they cannot participate in a completion-rate
+proposal. Each selected
+model must appear in the catalog and have a complete endpoints response. The
+normalizer chooses the lowest completion price among active (`status == 0`)
+provider endpoints, breaking ties deterministically by prompt price and
+provider name. Decimal strings—not binary floats—are used for stored money and
+all calculations.
+
+The snapshot schema is version `3`:
+
+```json
+{
+  "schema_version": 3,
+  "snapshot_type": "openrouter-pricing",
+  "fetched_at": "2026-08-05T12:00:00Z",
+  "content_digest": "sha256:<normalized-content-hash>",
+  "source": {
+    "rankings_url": "...",
+    "pricing_url_or_urls": ["..."],
+    "observed_schema_version_or_fingerprint": "...",
+    "generator_version": "openrouter-pricing-engine-v1",
+    "fetch_metadata": {
+      "successful_source_count": 102,
+      "observed_model_count": 100,
+      "requested_top_n": 100
+    }
+  },
+  "rows": [
+    {
+      "source_model_id": "provider/model",
+      "canonical_model_id": "macprovider-model-key-or-source-id",
+      "mapping_status": "exact|alias|unmapped",
+      "demand": {
+        "source_model_id": "provider/model",
+        "rank": 1,
+        "completion_volume": "123",
+        "ranking_date": "...",
+        "ranking_model_permaslug": "provider/model"
+      },
+      "pricing": {
+        "input_per_token": "0.00000003",
+        "completion_per_token": "0.00000013",
+        "input_per_mtok": "0.03",
+        "completion_per_mtok": "0.13",
+        "currency": "USD",
+        "benchmark_provider": "CoreWeave"
+      },
+      "pricing_status": "active_priced",
+      "source_metadata": {
+        "ranking_model_permaslug": "provider/model",
+        "catalog_canonical_slug": "provider/model",
+        "catalog_name": "Provider: Model",
+        "identity_resolution": "catalog|catalog_paid_variant|endpoint_alias_fallback"
+      }
+    }
+  ]
+}
+```
+
+`content_digest` is the SHA-256 of canonical JSON for the normalized semantic
+payload, excluding operational `fetched_at` and the digest field itself. It is
+not a content-addressable storage requirement; it is provenance and replay
+evidence. The source schema field is a SHA-256 fingerprint of the explicit
+allowlists for the rankings, catalog, endpoint, and pricing objects.
+
+If a dated ranking model is no longer present in the catalog, the engine may
+use the endpoint response for that exact dated ID only when OpenRouter returns
+a valid current model ID. The snapshot records this as
+`endpoint_alias_fallback` and leaves catalog-only metadata `null`; it never
+guesses an alias from the model name.
+
+An endpoint response that succeeds but has no active priced provider is retained
+with `pricing_status: "no_active_priced_endpoint"` and `pricing: null`. This is
+not treated as a partial fetch; Component 2 blocks that model rather than
+inventing a market price.
+
+## Fail-closed behavior
+
+The command emits no final snapshot if any required fetch, validation,
+normalization, or coverage step fails. It rejects bounded-retry exhaustion for
+429/5xx/transport errors, malformed JSON, changed required schemas, missing
+keys, empty ranking/catalog/endpoints results, blank identities, invalid or
+negative pricing, duplicate normalized identities, and missing endpoint data
+for a selected ranked model. A fully prepared file is atomically renamed only
+after validation and digest calculation.
+
+The source envelopes and fields used by normalization have explicit allowlists.
+An unexpected field, required-field change, or type change fails closed rather
+than being ignored or guessed.
+
+`--timeout-seconds` is a finite, 1â€“60 second socket and wall-clock deadline
+for each request. `--generation-timeout-seconds` is a finite 1â€“3600 second
+deadline for the full fetch, including endpoint calls and retry backoff. A
+`Retry-After` value is parsed in either seconds or HTTP-date form and is never
+shortened: if waiting would pass the generation deadline, the run fails closed.
+
+## Policy and eligibility
+
+`scripts/openrouter_pricing_policy.json` is explicit and reviewable. It holds
+data that OpenRouter cannot safely establish: canonical mappings, verified
+Apple-Silicon serving paths, license evidence, active parameter count, 4-bit
+residency, and projected TPS. Unknown snapshot models remain visible as
+`blocked`; they are never inferred into a Macprovider identity.
+
+Candidates must be in a complete snapshot covering the mandatory top-100
+completion-token demand population, have a
+verified MLX/MLX-Swift/production GGUF-Metal path, and have a commercially
+permitted license. Broad-fleet models require active parameters at or below
+8B, 4-bit residency at or below 18 GB, and projected M-base TPS of at least
+30. Coding-dense rows require a coding-specialist flag, residency at or below
+45 GB, and projected M-Max TPS of at least 20.
+
+The policy's target rules are from `RESEARCH_227_RATE_CARD_V3_PROMPT.md`:
+
+- broad-fleet target = cheapest active OpenRouter completion price less the
+  configured 10–30% undercut;
+- coding-dense target starts from the configured 10–30% premium over a
+  general-purpose baseline, is capped to undercut market by at least 10%, and
+  must produce at least $0.10/hour at its documented M-Max TPS.
+
+The internal proposal rate is a completion-token rate in the existing
+rate-card's integer `completion_rate_per_mtok` encoding. It is derived from
+the reference row's `global_multiplier_ppm`, `provider_share_bps`, and the
+rate-card `usd_per_million_credits` conversion; it is not hard-coded to a
+one-to-one USD/credit assumption. Coding-dense's $0.10/hour floor uses the
+resulting provider net payout after that row's share. The proposal records the
+economics basis it used. It does not construct or write a live rate-card row;
+Component 3 owns that conversion/review boundary.
+
+### Nemotron-3
+
+The policy records `nvidia/nemotron-3-nano-30b-a3b` as commercially permitted
+under the [NVIDIA Open Model License](https://www.nvidia.com/en-us/agreements/enterprise-software/nvidia-open-model-license/).
+NVIDIA states that models under that agreement are commercially usable, subject
+to its terms. This is a policy evidence record, not a replacement for legal
+review. If the policy's verification is removed or changed to non-permitted,
+the engine deterministically blocks/drops the model and records the reason.
+
+## Proposal contract
+
+The proposal schema is version `1` and contains:
+
+- source snapshot digest, policy version, and rate-card reference digest;
+- summary counts;
+- `added`, `changed`, `dropped`, `blocked`, and `unchanged` arrays;
+- per-row demand/market inputs (or explicit `null` values when market data is
+  unavailable), eligibility reasons, policy-evidence availability and URLs,
+  and a computed completion-rate proposal where eligible.
+
+`dropped` is strictly an advisory request for Component 3 review. It does not
+remove a rate-card row. Every dropped row includes its current completion rate.
+`blocked` records missing policy evidence, an unresolved license, failed
+eligibility, free-only market pricing, missing economics, or an existing
+rate-card row with no verified policy mapping.
+
+## Offline verification
+
+Fixtures under `scripts/tests/fixtures/openrouter_pricing/` are offline response
+fixtures. `recorded-rankings-response-excerpt.json` is a provenance-labelled,
+redacted excerpt of a live OpenRouter response; it records capture time, source
+URL, and the SHA-256 of the full captured response. The remaining small fixtures
+are deterministic response-shape fixtures. None contains credentials or headers.
+
+```bash
+PYTHONDONTWRITEBYTECODE=1 python3 -m unittest -v scripts/tests/test_openrouter_pricing_engine.py
+```
+
+The suite covers valid normalization/digest behavior, 429 retry and exhaustion,
+transport failure, malformed/empty/schema-drifted input, partial endpoints,
+invalid pricing, duplicate canonical mappings, snapshot tampering, proposal
+categories, unresolved Nemotron licensing, atomic write failure, and
+rate-card-reference immutability.

--- a/docs/runbooks/openrouter-pricing-engine.md
+++ b/docs/runbooks/openrouter-pricing-engine.md
@@ -12,8 +12,8 @@ owns rate-card guardrails, review, and applying any accepted proposal.
 ```bash
 python3 scripts/openrouter_pricing_engine.py fetch \
   --output-dir /var/tmp/openrouter-pricing \
-  --top-n 100 --retries 3 --timeout-seconds 20 \
-  --generation-timeout-seconds 900
+  --top-n 50 --demand-window-days 30 --retries 3 \
+  --timeout-seconds 20 --generation-timeout-seconds 900
 
 python3 scripts/openrouter_pricing_engine.py compute \
   --snapshot /var/tmp/openrouter-pricing/openrouter-pricing-snapshot-<timestamp>.json \
@@ -28,51 +28,43 @@ there is intentionally no apply mode in this tool.
 
 ## Sources and normalization
 
-The fetcher uses one **undocumented frontend dependency** for demand and two
-documented OpenRouter API endpoints for catalog and pricing:
+The fetcher uses documented OpenRouter API endpoints:
 
-- demand (unstable frontend dependency):
-  `https://openrouter.ai/api/frontend/v1/rankings/models`;
-- catalog/schema cross-check (documented): `https://openrouter.ai/api/v1/models`;
-- cheapest active provider price (documented):
+- demand: `https://openrouter.ai/api/v1/datasets/rankings-daily`;
+- catalog/schema cross-check: `https://openrouter.ai/api/v1/models`;
+- cheapest active provider price:
   `https://openrouter.ai/api/v1/models/{model-id}/endpoints`.
 
-The rankings endpoint is not presented as a stable public API contract. If it
-becomes unavailable or its schema changes, `fetch` fails closed and emits no
-snapshot. The operator must stop the scheduled run, inspect and review the
-upstream change, then update this adapter or move to a documented demand source.
-The tool must not infer demand from catalog/pricing data or publish a guessed
-fallback snapshot.
+The documented daily dataset contains each day's top 50 public models by total
+token usage plus an aggregated `other` row. The fetcher requests a bounded
+UTC window (30 days by default), discards `other`, aggregates `total_tokens` by
+`model_permaslug`, and selects the requested cohort of up to 50 observed
+models. It does not claim to construct a global top-100 ranking, nor does it
+infer demand from catalog/pricing data. A changed schema, unavailable response,
+or insufficient daily-ranking cohort fails closed and emits no snapshot.
 
 ## Authentication
 
 Set `OPENROUTER_API_KEY` in the environment before running `fetch` to send the
 documented `Authorization: Bearer <token>` header to OpenRouter. An environment
 variable keeps the credential out of shell history, command-line process
-arguments, snapshots, proposals, and error output. It is optional for
-compatibility with currently unauthenticated responses, but operators should
-configure it for reliable product use. If unauthenticated access stops working,
-set the variable and rerun; a failed request still publishes nothing.
+arguments, snapshots, proposals, and error output. It is required: the
+documented rankings, models, and endpoints APIs require bearer authentication.
+A missing key or failed request publishes nothing.
 
-Ranking records are aggregated by `model_permaslug`, sorted by completion-token
-volume, and reduced to the requested number of distinct models. Only the latest
-valid OpenRouter ranking timestamp (`YYYY-MM-DD HH:MM:SS`) in the response is
-used; variants from older dates are never
-summed into current demand. Zero-completion
-non-generation rows (for example embedding-only entries) are excluded before
-model-ID validation because they cannot participate in a completion-rate
-proposal. Each selected
+Daily ranking records are aggregated by `model_permaslug`, sorted by total-token
+volume, and reduced to the requested number of distinct models. Each selected
 model must appear in the catalog and have a complete endpoints response. The
 normalizer chooses the lowest completion price among active (`status == 0`)
 provider endpoints, breaking ties deterministically by prompt price and
 provider name. Decimal strings—not binary floats—are used for stored money and
 all calculations.
 
-The snapshot schema is version `3`:
+The snapshot schema is version `4`:
 
 ```json
 {
-  "schema_version": 3,
+  "schema_version": 4,
   "snapshot_type": "openrouter-pricing",
   "fetched_at": "2026-08-05T12:00:00Z",
   "content_digest": "sha256:<normalized-content-hash>",
@@ -83,8 +75,12 @@ The snapshot schema is version `3`:
     "generator_version": "openrouter-pricing-engine-v1",
     "fetch_metadata": {
       "successful_source_count": 102,
-      "observed_model_count": 100,
-      "requested_top_n": 100
+      "observed_model_count": 50,
+      "requested_top_n": 50,
+      "demand_window_days": 30,
+      "ranking_window_start_date": "2026-07-06",
+      "ranking_window_end_date": "2026-08-04",
+      "demand_metric": "aggregated_daily_total_tokens"
     }
   },
   "rows": [
@@ -95,7 +91,7 @@ The snapshot schema is version `3`:
       "demand": {
         "source_model_id": "provider/model",
         "rank": 1,
-        "completion_volume": "123",
+        "total_token_volume": "123",
         "ranking_date": "...",
         "ranking_model_permaslug": "provider/model"
       },
@@ -164,8 +160,8 @@ Apple-Silicon serving paths, license evidence, active parameter count, 4-bit
 residency, and projected TPS. Unknown snapshot models remain visible as
 `blocked`; they are never inferred into a Macprovider identity.
 
-Candidates must be in a complete snapshot covering the mandatory top-100
-completion-token demand population, have a
+Candidates must be in a complete snapshot covering the mandatory documented
+daily top-50 demand cohort (aggregated total tokens over the fetch window), have a
 verified MLX/MLX-Swift/production GGUF-Metal path, and have a commercially
 permitted license. Broad-fleet models require active parameters at or below
 8B, 4-bit residency at or below 18 GB, and projected M-base TPS of at least
@@ -219,8 +215,7 @@ rate-card row with no verified policy mapping.
 
 Fixtures under `scripts/tests/fixtures/openrouter_pricing/` are offline response
 fixtures. `recorded-rankings-response-excerpt.json` is a provenance-labelled,
-redacted excerpt of a live OpenRouter response; it records capture time, source
-URL, and the SHA-256 of the full captured response. The remaining small fixtures
+redacted documented-API response excerpt. The remaining small fixtures
 are deterministic response-shape fixtures. None contains credentials or headers.
 
 ```bash

--- a/docs/runbooks/openrouter-pricing-engine.md
+++ b/docs/runbooks/openrouter-pricing-engine.md
@@ -24,16 +24,35 @@ python3 scripts/openrouter_pricing_engine.py compute \
 
 The commands are noninteractive and have useful exit codes, so an operator can
 schedule `fetch` and then `compute` externally. Do not schedule an apply step:
-there is intentionally no one in this tool.
+there is intentionally no apply mode in this tool.
 
 ## Sources and normalization
 
-The fetcher uses these public OpenRouter APIs:
+The fetcher uses one **undocumented frontend dependency** for demand and two
+documented OpenRouter API endpoints for catalog and pricing:
 
-- demand: `https://openrouter.ai/api/frontend/v1/rankings/models`;
-- catalog/schema cross-check: `https://openrouter.ai/api/v1/models`;
-- cheapest active provider price:
+- demand (unstable frontend dependency):
+  `https://openrouter.ai/api/frontend/v1/rankings/models`;
+- catalog/schema cross-check (documented): `https://openrouter.ai/api/v1/models`;
+- cheapest active provider price (documented):
   `https://openrouter.ai/api/v1/models/{model-id}/endpoints`.
+
+The rankings endpoint is not presented as a stable public API contract. If it
+becomes unavailable or its schema changes, `fetch` fails closed and emits no
+snapshot. The operator must stop the scheduled run, inspect and review the
+upstream change, then update this adapter or move to a documented demand source.
+The tool must not infer demand from catalog/pricing data or publish a guessed
+fallback snapshot.
+
+## Authentication
+
+Set `OPENROUTER_API_KEY` in the environment before running `fetch` to send the
+documented `Authorization: Bearer <token>` header to OpenRouter. An environment
+variable keeps the credential out of shell history, command-line process
+arguments, snapshots, proposals, and error output. It is optional for
+compatibility with currently unauthenticated responses, but operators should
+configure it for reliable product use. If unauthenticated access stops working,
+set the variable and rerun; a failed request still publishes nothing.
 
 Ranking records are aggregated by `model_permaslug`, sorted by completion-token
 volume, and reduced to the requested number of distinct models. Only the latest
@@ -131,8 +150,8 @@ The source envelopes and fields used by normalization have explicit allowlists.
 An unexpected field, required-field change, or type change fails closed rather
 than being ignored or guessed.
 
-`--timeout-seconds` is a finite, 1â€“60 second socket and wall-clock deadline
-for each request. `--generation-timeout-seconds` is a finite 1â€“3600 second
+`--timeout-seconds` is a finite, 1-60 second socket and wall-clock deadline
+for each request. `--generation-timeout-seconds` is a finite 1-3600 second
 deadline for the full fetch, including endpoint calls and retry backoff. A
 `Retry-After` value is parsed in either seconds or HTTP-date form and is never
 shortened: if waiting would pass the generation deadline, the run fails closed.

--- a/scripts/openrouter_pricing_engine.py
+++ b/scripts/openrouter_pricing_engine.py
@@ -1,0 +1,1267 @@
+#!/usr/bin/env python3
+"""Produce OpenRouter pricing snapshots and non-money-path rate proposals.
+
+The script deliberately has no apply mode.  It can only write a validated
+snapshot or a proposal artifact to a caller-selected output directory.
+"""
+
+from __future__ import annotations
+
+import argparse
+import copy
+import hashlib
+import http.client
+import json
+import math
+import multiprocessing
+import os
+import random
+import re
+import socket
+import sys
+import tempfile
+import threading
+import time
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from decimal import Decimal, InvalidOperation, ROUND_HALF_UP
+from email.utils import parsedate_to_datetime
+from pathlib import Path
+from typing import Any, Callable, Mapping, Protocol
+from urllib.parse import quote, urlsplit
+
+
+RANKINGS_URL = "https://openrouter.ai/api/frontend/v1/rankings/models"
+MODELS_URL = "https://openrouter.ai/api/v1/models"
+ENDPOINTS_URL = "https://openrouter.ai/api/v1/models/{model_id}/endpoints"
+SNAPSHOT_SCHEMA_VERSION = 3
+PROPOSAL_SCHEMA_VERSION = 1
+TOOL_VERSION = "openrouter-pricing-engine-v1"
+DEFAULT_POLICY_PATH = Path(__file__).with_name("openrouter_pricing_policy.json")
+MODEL_ID_RE = re.compile(r"^[A-Za-z0-9._~:-]+/[A-Za-z0-9._~:-]+$")
+# OpenRouter's explicit provider variants (for example `model:free`) are
+# valid snapshot identities even when policy leaves them unmapped/blocked.
+CANONICAL_ID_RE = re.compile(r"^[a-z0-9][a-z0-9._/:-]*$")
+MAX_RESPONSE_BYTES = 5 * 1024 * 1024
+RANKING_ROW_KEYS = frozenset({"change", "count", "date", "image_output_requests", "model_permaslug", "num_audio_prompt", "num_media_completion", "num_media_prompt", "num_video_prompt", "requests_with_tool_call_errors", "rerank_documents", "stt_transcript_characters", "total_completion_tokens", "total_native_tokens_cached", "total_native_tokens_reasoning", "total_prompt_tokens", "total_tool_calls", "variant", "variant_permaslug", "video_output_seconds"})
+CATALOG_ROW_KEYS = frozenset({"alias_target", "architecture", "benchmarks", "canonical_slug", "context_length", "created", "default_parameters", "description", "expiration_date", "hugging_face_id", "id", "knowledge_cutoff", "links", "name", "per_request_limits", "pricing", "reasoning", "supported_parameters", "supported_voices", "top_provider"})
+CATALOG_TOP_LEVEL_KEYS = frozenset({"data", "links", "total_count"})
+ENDPOINT_DATA_KEYS = frozenset({"architecture", "created", "description", "endpoints", "id", "name"})
+ENDPOINT_ROW_KEYS = frozenset({"context_length", "latency_last_30m", "max_completion_tokens", "max_prompt_tokens", "model_id", "model_name", "name", "pricing", "provider_name", "quantization", "status", "supported_parameters", "supports_implicit_caching", "supports_voice_cloning", "tag", "throughput_last_30m", "uptime_last_1d", "uptime_last_30m", "uptime_last_5m"})
+ENDPOINT_PRICING_KEYS = frozenset({
+    "audio", "completion", "discount", "image", "image_output", "image_token",
+    "input_audio_cache", "input_cache_read", "input_cache_write", "input_cache_write_1h",
+    "internal_reasoning", "overrides", "prompt", "web_search",
+})
+
+
+class EngineError(RuntimeError):
+    """A fail-closed error which must prevent artifact publication."""
+
+
+class FetchError(EngineError):
+    """A required upstream fetch did not complete safely."""
+
+
+class ResponseValidationError(FetchError):
+    """A received response is unsafe to retry because it violates transport bounds."""
+
+
+class SchemaError(EngineError):
+    """An input response or local artifact violates its required contract."""
+
+
+class HTTPClient(Protocol):
+    def get(self, url: str, timeout_seconds: float) -> "HTTPResponse": ...
+
+
+@dataclass(frozen=True)
+class HTTPResponse:
+    status: int
+    body: bytes
+    headers: Mapping[str, str]
+
+
+class UrllibHTTPClient:
+    """Small production adapter; tests provide an in-memory HTTP client."""
+
+    def __init__(self, resolver: Callable[[float], list[str]] | None = None):
+        self._resolver = resolver or resolve_openrouter_addresses
+        self._resolved_addresses: list[str] | None = None
+        self._next_address_index = 0
+
+    def get(self, url: str, timeout_seconds: float) -> HTTPResponse:
+        if not math.isfinite(timeout_seconds) or not 0 < timeout_seconds <= 60:
+            raise FetchError("request timeout must be finite, positive, and no more than 60 seconds")
+        """Fetch with bounded connect/read operations and no orphan workers."""
+        parsed = urlsplit(url)
+        if parsed.scheme != "https" or parsed.netloc != "openrouter.ai" or not parsed.path.startswith("/"):
+            raise FetchError(f"refusing non-OpenRouter URL {url!r}")
+        deadline = time.monotonic() + timeout_seconds
+        if self._resolved_addresses is None:
+            self._resolved_addresses = self._resolver(timeout_seconds)
+        remaining_after_resolution = deadline - time.monotonic()
+        if remaining_after_resolution <= 0:
+            raise FetchError(f"wall-clock request deadline exceeded after {timeout_seconds} seconds")
+        # Rotate cached A/AAAA results across attempts. fetch_json retries a
+        # transport failure, so a broken first route cannot pin the run to it.
+        resolved_address = self._resolved_addresses[self._next_address_index % len(self._resolved_addresses)]
+        self._next_address_index += 1
+        connection = http.client.HTTPSConnection("openrouter.ai", timeout=timeout_seconds)
+        def create_resolved_connection(address: tuple[str, int], timeout: float | None = None, source_address: Any = None) -> socket.socket:
+            return socket.create_connection((resolved_address, address[1]), timeout=timeout, source_address=source_address)
+        connection._create_connection = create_resolved_connection  # type: ignore[attr-defined]
+        timed_out = threading.Event()
+
+        def abort_at_deadline() -> None:
+            """Interrupt connect/TLS/header/body blocking calls at the absolute deadline."""
+            timed_out.set()
+            active_socket = connection.sock
+            if active_socket is not None:
+                try:
+                    active_socket.shutdown(socket.SHUT_RDWR)
+                except OSError:
+                    pass
+            connection.close()
+
+        watchdog = threading.Timer(remaining_after_resolution, abort_at_deadline)
+        watchdog.daemon = True
+        watchdog.start()
+        try:
+            target = parsed.path + (f"?{parsed.query}" if parsed.query else "")
+            connection.request("GET", target, headers={"Accept": "application/json", "User-Agent": TOOL_VERSION})
+            response = connection.getresponse()
+            if timed_out.is_set():
+                raise FetchError(f"wall-clock request deadline exceeded after {timeout_seconds} seconds")
+            content_length = response.getheader("Content-Length")
+            if content_length:
+                try:
+                    declared_length = int(content_length)
+                except ValueError as error:
+                    raise ResponseValidationError("response has invalid Content-Length") from error
+                if declared_length > MAX_RESPONSE_BYTES:
+                    raise ResponseValidationError(f"response exceeds {MAX_RESPONSE_BYTES} byte limit")
+            chunks: list[bytes] = []
+            size = 0
+            while True:
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    raise FetchError(f"wall-clock request deadline exceeded after {timeout_seconds} seconds")
+                if connection.sock is not None:
+                    connection.sock.settimeout(remaining)
+                chunk = response.read1(min(64 * 1024, MAX_RESPONSE_BYTES + 1 - size))
+                if not chunk:
+                    break
+                size += len(chunk)
+                if size > MAX_RESPONSE_BYTES:
+                    raise ResponseValidationError(f"response exceeds {MAX_RESPONSE_BYTES} byte limit")
+                chunks.append(chunk)
+            if time.monotonic() > deadline:
+                raise FetchError(f"wall-clock request deadline exceeded after {timeout_seconds} seconds")
+            return HTTPResponse(status=response.status, body=b"".join(chunks), headers=dict(response.getheaders()))
+        except (http.client.HTTPException, TimeoutError, OSError) as error:
+            if timed_out.is_set():
+                raise FetchError(f"wall-clock request deadline exceeded after {timeout_seconds} seconds") from error
+            raise FetchError(f"transport error fetching {url}: {error}") from error
+        finally:
+            watchdog.cancel()
+            watchdog.join()
+            connection.close()
+
+
+def utc_now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def rfc3339(value: datetime) -> str:
+    if value.tzinfo is None:
+        raise ValueError("timestamp must be timezone-aware")
+    return value.astimezone(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def parse_rfc3339_utc(value: Any, field: str) -> datetime:
+    if not isinstance(value, str) or not value.endswith("Z"):
+        raise SchemaError(f"{field} must be an RFC3339 UTC timestamp")
+    try:
+        parsed = datetime.fromisoformat(value[:-1] + "+00:00")
+    except ValueError as error:
+        raise SchemaError(f"{field} must be an RFC3339 UTC timestamp") from error
+    if parsed.tzinfo != timezone.utc:
+        raise SchemaError(f"{field} must be an RFC3339 UTC timestamp")
+    return parsed
+
+
+def parse_ranking_date(value: Any, field: str) -> datetime:
+    if not isinstance(value, str):
+        raise SchemaError(f"{field} must be OpenRouter ranking timestamp YYYY-MM-DD HH:MM:SS")
+    try:
+        return datetime.strptime(value, "%Y-%m-%d %H:%M:%S")
+    except ValueError as error:
+        raise SchemaError(f"{field} must be OpenRouter ranking timestamp YYYY-MM-DD HH:MM:SS") from error
+
+
+def canonical_json(value: Any) -> bytes:
+    return json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=False).encode("utf-8")
+
+
+def sha256_prefixed(value: Any) -> str:
+    return "sha256:" + hashlib.sha256(canonical_json(value)).hexdigest()
+
+
+SCHEMA_CONTRACT_FINGERPRINT = sha256_prefixed(
+    {
+        "rankings_row_keys": sorted(RANKING_ROW_KEYS),
+        "catalog_row_keys": sorted(CATALOG_ROW_KEYS),
+        "catalog_top_level_keys": sorted(CATALOG_TOP_LEVEL_KEYS),
+        "endpoint_data_keys": sorted(ENDPOINT_DATA_KEYS),
+        "endpoint_row_keys": sorted(ENDPOINT_ROW_KEYS),
+        "endpoint_pricing_keys": sorted(ENDPOINT_PRICING_KEYS),
+    }
+)
+
+
+def parse_decimal(value: Any, field: str, *, allow_zero: bool = True) -> Decimal:
+    if not isinstance(value, str) or not value.strip():
+        raise SchemaError(f"{field} must be a non-empty decimal string")
+    try:
+        result = Decimal(value)
+    except InvalidOperation as error:
+        raise SchemaError(f"{field} is not a decimal: {value!r}") from error
+    if not result.is_finite() or result < 0 or (not allow_zero and result == 0):
+        raise SchemaError(f"{field} must be finite and {'positive' if not allow_zero else 'non-negative'}")
+    return result
+
+
+def _resolve_host_worker(connection: Any, host: str) -> None:
+    """Child-process resolver: a blocked system resolver is terminable by parent."""
+    try:
+        addresses = []
+        for family, _, _, _, sockaddr in socket.getaddrinfo(host, 443, type=socket.SOCK_STREAM):
+            if family in {socket.AF_INET, socket.AF_INET6} and sockaddr[0] not in addresses:
+                addresses.append(sockaddr[0])
+        connection.send((True, addresses))
+    except OSError as error:
+        connection.send((False, str(error)))
+    finally:
+        connection.close()
+
+
+def resolve_openrouter_addresses(timeout_seconds: float) -> list[str]:
+    """Resolve with a killable deadline so DNS cannot outlive a fetch generation."""
+    context = multiprocessing.get_context("spawn")
+    parent, child = context.Pipe(duplex=False)
+    process = context.Process(target=_resolve_host_worker, args=(child, "openrouter.ai"))
+    process.daemon = True
+    process.start()
+    child.close()
+    try:
+        if not parent.poll(timeout_seconds):
+            process.terminate()
+            process.join()
+            raise FetchError(f"DNS resolution deadline exceeded after {timeout_seconds} seconds")
+        ok, payload = parent.recv()
+        process.join()
+        if not ok or not isinstance(payload, list) or not payload:
+            raise FetchError(f"DNS resolution failed for openrouter.ai: {payload}")
+        return payload
+    finally:
+        parent.close()
+        if process.is_alive():
+            process.terminate()
+            process.join()
+
+
+def decimal_string(value: Decimal) -> str:
+    rendered = format(value.normalize(), "f")
+    return "0" if rendered in {"-0", ""} else rendered
+
+
+def parse_json(response: HTTPResponse, source: str) -> dict[str, Any]:
+    if response.status < 200 or response.status >= 300:
+        raise FetchError(f"{source}: HTTP {response.status}")
+    try:
+        parsed = json.loads(response.body.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as error:
+        raise SchemaError(f"{source}: malformed JSON") from error
+    if not isinstance(parsed, dict):
+        raise SchemaError(f"{source}: top-level JSON value must be an object")
+    return parsed
+
+
+def retry_after_seconds(headers: Mapping[str, str], *, now: datetime | None = None) -> float | None:
+    """Return the RFC 9110 Retry-After delay, including its HTTP-date form."""
+    for key, value in headers.items():
+        if key.lower() == "retry-after":
+            try:
+                parsed = float(value)
+            except (TypeError, ValueError):
+                try:
+                    retry_at = parsedate_to_datetime(value)
+                except (TypeError, ValueError, IndexError):
+                    return None
+                if retry_at.tzinfo is None:
+                    return None
+                reference = now or utc_now()
+                return max(0.0, (retry_at - reference).total_seconds())
+            return parsed if math.isfinite(parsed) and parsed >= 0 else None
+    return None
+
+
+def fetch_json(
+    client: HTTPClient,
+    url: str,
+    source: str,
+    *,
+    retries: int,
+    timeout_seconds: float,
+    sleeper: Callable[[float], None] = time.sleep,
+    jitter: Callable[[], float] = random.random,
+    deadline: float | None = None,
+    clock: Callable[[], float] = time.monotonic,
+) -> dict[str, Any]:
+    """Fetch JSON with bounded retry/backoff; non-transient failures fail closed."""
+    if retries < 0:
+        raise ValueError("retries must be non-negative")
+    last_error: EngineError | None = None
+    for attempt in range(retries + 1):
+        if deadline is not None and clock() >= deadline:
+            raise FetchError(f"{source}: generation deadline exceeded before request")
+        effective_timeout = timeout_seconds if deadline is None else min(timeout_seconds, deadline - clock())
+        if effective_timeout <= 0:
+            raise FetchError(f"{source}: generation deadline exceeded before request")
+        try:
+            response = client.get(url, effective_timeout)
+        except FetchError as error:
+            last_error = error
+            retryable = not isinstance(error, ResponseValidationError)
+        else:
+            if deadline is not None and clock() >= deadline:
+                raise FetchError(f"{source}: generation deadline exceeded after request")
+            if 200 <= response.status < 300:
+                return parse_json(response, source)
+            retryable = response.status == 429 or 500 <= response.status < 600
+            last_error = FetchError(f"{source}: HTTP {response.status}")
+            if response.status == 429:
+                requested_delay = retry_after_seconds(response.headers)
+            else:
+                requested_delay = None
+        if not retryable or attempt == retries:
+            raise last_error
+        if "requested_delay" not in locals() or requested_delay is None:
+            delay = min(8.0, 0.5 * (2**attempt)) + (jitter() * 0.1)
+        else:
+            delay = requested_delay
+        if deadline is not None and clock() + delay > deadline:
+            raise FetchError(f"{source}: generation deadline would be exceeded during retry backoff")
+        sleeper(delay)
+        requested_delay = None
+    raise AssertionError("retry loop must return or raise")
+
+
+def required_list(document: Mapping[str, Any], key: str, source: str) -> list[Any]:
+    value = document.get(key)
+    if not isinstance(value, list):
+        raise SchemaError(f"{source}: {key!r} must be a list")
+    if not value:
+        raise SchemaError(f"{source}: {key!r} must not be empty")
+    return value
+
+
+def require_allowed_keys(value: Mapping[str, Any], allowed: frozenset[str], location: str) -> None:
+    unexpected = sorted(set(value) - allowed)
+    if unexpected:
+        raise SchemaError(f"{location}: unexpected fields {unexpected}")
+
+
+def normalize_rankings(document: Mapping[str, Any], top_n: int) -> list[dict[str, Any]]:
+    require_allowed_keys(document, frozenset({"data"}), "rankings response")
+    rows = required_list(document, "data", "rankings response")
+    totals: dict[str, int] = {}
+    dates: dict[str, str] = {}
+    eligible_rows: list[tuple[dict[str, Any], datetime]] = []
+    for index, row in enumerate(rows):
+        if not isinstance(row, dict):
+            raise SchemaError(f"rankings response: data[{index}] must be an object")
+        require_allowed_keys(row, RANKING_ROW_KEYS, f"rankings response: data[{index}]")
+        completion_tokens = row.get("total_completion_tokens")
+        if isinstance(completion_tokens, bool) or not isinstance(completion_tokens, int) or completion_tokens < 0:
+            raise SchemaError(f"rankings response: data[{index}].total_completion_tokens must be non-negative integer")
+        # Non-generation rows (for example embedding-only models) have no
+        # completion demand and are outside this completion-rate pipeline.
+        if completion_tokens == 0:
+            continue
+        model_id = row.get("model_permaslug")
+        date = row.get("date")
+        if not isinstance(model_id, str) or not model_id.strip():
+            raise SchemaError(f"rankings response: data[{index}].model_permaslug must be non-empty")
+        if not MODEL_ID_RE.fullmatch(model_id):
+            raise SchemaError(f"rankings response: data[{index}].model_permaslug has unsafe shape")
+        parsed_date = parse_ranking_date(date, f"rankings response: data[{index}].date")
+        eligible_rows.append((row, parsed_date))
+    if not eligible_rows:
+        raise SchemaError("rankings response: no completion-demand rows")
+    latest_date = max(parsed_date for _, parsed_date in eligible_rows)
+    for row, parsed_date in eligible_rows:
+        if parsed_date != latest_date:
+            continue
+        model_id = row["model_permaslug"]
+        completion_tokens = row["total_completion_tokens"]
+        date = row["date"]
+        totals[model_id] = totals.get(model_id, 0) + completion_tokens
+        dates[model_id] = max(date, dates.get(model_id, date))
+    ordered = sorted(totals, key=lambda item: (-totals[item], item))[:top_n]
+    if not ordered:
+        raise SchemaError("rankings response: no normalized ranking rows")
+    return [
+        {"source_model_id": model_id, "rank": rank, "completion_volume": str(totals[model_id]), "ranking_date": dates[model_id]}
+        for rank, model_id in enumerate(ordered, start=1)
+    ]
+
+
+def validate_catalog(document: Mapping[str, Any]) -> dict[str, dict[str, Any]]:
+    require_allowed_keys(document, CATALOG_TOP_LEVEL_KEYS, "models response")
+    rows = required_list(document, "data", "models response")
+    result: dict[str, dict[str, Any]] = {}
+    for index, row in enumerate(rows):
+        if not isinstance(row, dict):
+            raise SchemaError(f"models response: data[{index}] must be an object")
+        require_allowed_keys(row, CATALOG_ROW_KEYS, f"models response: data[{index}]")
+        model_id = row.get("id")
+        canonical_slug = row.get("canonical_slug")
+        if not isinstance(model_id, str) or not model_id.strip():
+            raise SchemaError(f"models response: data[{index}].id must be non-empty")
+        if not MODEL_ID_RE.fullmatch(model_id):
+            raise SchemaError(f"models response: data[{index}].id has unsafe shape")
+        if not isinstance(canonical_slug, str) or not canonical_slug.strip():
+            raise SchemaError(f"models response: data[{index}].canonical_slug must be non-empty")
+        if model_id in result:
+            raise SchemaError(f"models response: duplicate model id {model_id!r}")
+        result[model_id] = row
+    return result
+
+
+def resolve_rankings_to_catalog(
+    rankings: list[dict[str, Any]],
+    catalog: Mapping[str, Mapping[str, Any]],
+    endpoint_documents: Mapping[str, Mapping[str, Any]] | None = None,
+) -> list[dict[str, Any]]:
+    """Resolve ranking permaslugs to the catalog ID accepted by endpoints API.
+
+    OpenRouter rankings can retain a dated permaslug after the catalog exposes
+    the same model under a current ID. If the catalog no longer lists a dated
+    ranking ID, the endpoint response for that exact dated ID may authoritatively
+    return its current ID. All other ambiguity is a coverage failure, never a
+    guess.
+    """
+    canonical_index: dict[str, list[str]] = {}
+    for model_id, catalog_row in catalog.items():
+        canonical_slug = catalog_row["canonical_slug"]
+        canonical_index.setdefault(canonical_slug, []).append(model_id)
+    resolved: list[dict[str, Any]] = []
+    for demand in rankings:
+        ranking_slug = demand["source_model_id"]
+        if ranking_slug in catalog:
+            catalog_id = ranking_slug
+            identity_resolution = "catalog"
+        else:
+            candidates = canonical_index.get(ranking_slug, [])
+            if len(candidates) == 1:
+                catalog_id = candidates[0]
+                identity_resolution = "catalog"
+            else:
+                # Rankings aggregate the paid and :free variants under one
+                # permaslug. The catalog identifies the paid endpoint by the
+                # absence of the explicit :free suffix. This is a narrowly
+                # defined resolution rule; all other ambiguity still fails.
+                paid_candidates = [candidate for candidate in candidates if not candidate.endswith(":free")]
+                if len(paid_candidates) == 1:
+                    catalog_id = paid_candidates[0]
+                    identity_resolution = "catalog_paid_variant"
+                elif not candidates:
+                    if endpoint_documents is None:
+                        # Fetch the dated endpoint first; build_snapshot will
+                        # validate and replace this temporary request identity.
+                        catalog_id = ranking_slug
+                        identity_resolution = "endpoint_alias_pending"
+                    else:
+                        endpoint_document = endpoint_documents.get(ranking_slug)
+                        if endpoint_document is None:
+                            raise SchemaError(f"partial pull: endpoints response missing for ranked model {ranking_slug!r}")
+                        catalog_id = endpoint_response_model_id(endpoint_document, ranking_slug)
+                        identity_resolution = "endpoint_alias_fallback"
+                else:
+                    raise SchemaError(
+                        f"catalog response cannot uniquely resolve ranked model {ranking_slug!r} to an endpoint model id"
+                    )
+        normalized = dict(demand)
+        normalized["source_model_id"] = catalog_id
+        normalized["ranking_model_permaslug"] = ranking_slug
+        normalized["_identity_resolution"] = identity_resolution
+        resolved.append(normalized)
+    return resolved
+
+
+def endpoint_response_model_id(document: Mapping[str, Any], requested_model_id: str) -> str:
+    """Read an endpoint response identity without assuming its request alias."""
+    require_allowed_keys(document, frozenset({"data"}), f"endpoints response for {requested_model_id}")
+    data = document.get("data")
+    if not isinstance(data, dict):
+        raise SchemaError(f"endpoints response for {requested_model_id}: data must be an object")
+    require_allowed_keys(data, ENDPOINT_DATA_KEYS, f"endpoints response for {requested_model_id}: data")
+    model_id = data.get("id")
+    if not isinstance(model_id, str) or not MODEL_ID_RE.fullmatch(model_id):
+        raise SchemaError(f"endpoints response for {requested_model_id}: response id is invalid")
+    return model_id
+
+
+def cheapest_endpoint_pricing(document: Mapping[str, Any], model_id: str) -> dict[str, str] | None:
+    require_allowed_keys(document, frozenset({"data"}), f"endpoints response for {model_id}")
+    data = document.get("data")
+    if not isinstance(data, dict):
+        raise SchemaError(f"endpoints response for {model_id}: data must be an object")
+    require_allowed_keys(data, ENDPOINT_DATA_KEYS, f"endpoints response for {model_id}: data")
+    if data.get("id") != model_id:
+        raise SchemaError(f"endpoints response for {model_id}: response id mismatch")
+    endpoints = data.get("endpoints")
+    if not isinstance(endpoints, list) or not endpoints:
+        raise SchemaError(f"endpoints response for {model_id}: endpoints must be a non-empty list")
+    priced: list[tuple[Decimal, Decimal, str]] = []
+    for index, endpoint in enumerate(endpoints):
+        if not isinstance(endpoint, dict):
+            raise SchemaError(f"endpoints response for {model_id}: endpoints[{index}] must be an object")
+        require_allowed_keys(endpoint, ENDPOINT_ROW_KEYS, f"endpoints response for {model_id}: endpoints[{index}]")
+        status = endpoint.get("status")
+        if isinstance(status, bool) or not isinstance(status, int):
+            raise SchemaError(f"endpoints response for {model_id}: endpoints[{index}].status must be an integer")
+        if status != 0:
+            continue
+        provider = endpoint.get("provider_name")
+        pricing = endpoint.get("pricing")
+        if not isinstance(provider, str) or not provider.strip() or not isinstance(pricing, dict):
+            raise SchemaError(f"endpoints response for {model_id}: active endpoint[{index}] missing provider/pricing")
+        require_allowed_keys(pricing, ENDPOINT_PRICING_KEYS, f"endpoints response for {model_id}: endpoints[{index}].pricing")
+        prompt = parse_decimal(pricing.get("prompt"), f"endpoints response for {model_id}: prompt")
+        completion = parse_decimal(pricing.get("completion"), f"endpoints response for {model_id}: completion")
+        priced.append((completion, prompt, provider))
+    if not priced:
+        return None
+    completion, prompt, provider = min(priced, key=lambda item: (item[0], item[1], item[2]))
+    return {
+        "input_per_token": decimal_string(prompt),
+        "completion_per_token": decimal_string(completion),
+        "input_per_mtok": decimal_string(prompt * Decimal("1000000")),
+        "completion_per_mtok": decimal_string(completion * Decimal("1000000")),
+        "currency": "USD",
+        "benchmark_provider": provider,
+    }
+
+
+def snapshot_digest_payload(snapshot: Mapping[str, Any]) -> dict[str, Any]:
+    payload = copy.deepcopy(dict(snapshot))
+    payload.pop("content_digest", None)
+    payload.pop("fetched_at", None)
+    return payload
+
+
+def validate_snapshot(snapshot: Mapping[str, Any]) -> None:
+    if snapshot.get("schema_version") != SNAPSHOT_SCHEMA_VERSION or snapshot.get("snapshot_type") != "openrouter-pricing":
+        raise SchemaError("snapshot has unsupported schema version or type")
+    parse_rfc3339_utc(snapshot.get("fetched_at"), "snapshot.fetched_at")
+    expected_digest = sha256_prefixed(snapshot_digest_payload(snapshot))
+    if snapshot.get("content_digest") != expected_digest:
+        raise SchemaError("snapshot content_digest does not match normalized payload")
+    source = snapshot.get("source")
+    rows = snapshot.get("rows")
+    if not isinstance(source, dict) or not isinstance(rows, list) or not rows:
+        raise SchemaError("snapshot source must be object and rows must be non-empty list")
+    required_source = {"rankings_url", "pricing_url_or_urls", "observed_schema_version_or_fingerprint", "generator_version", "fetch_metadata"}
+    if set(source) != required_source:
+        raise SchemaError("snapshot source has missing or unexpected provenance fields")
+    if source["rankings_url"] != RANKINGS_URL or not isinstance(source["pricing_url_or_urls"], list) or not all(isinstance(url, str) and url.startswith("https://openrouter.ai/") for url in source["pricing_url_or_urls"]):
+        raise SchemaError("snapshot source endpoints are invalid")
+    if source["observed_schema_version_or_fingerprint"] != SCHEMA_CONTRACT_FINGERPRINT or not isinstance(source["generator_version"], str):
+        raise SchemaError("snapshot source schema/generator provenance is invalid")
+    fetch_metadata = source["fetch_metadata"]
+    if not isinstance(fetch_metadata, dict) or set(fetch_metadata) != {"successful_source_count", "observed_model_count", "requested_top_n"}:
+        raise SchemaError("snapshot fetch_metadata has missing or unexpected fields")
+    for key in ("successful_source_count", "observed_model_count", "requested_top_n"):
+        if isinstance(fetch_metadata[key], bool) or not isinstance(fetch_metadata[key], int) or fetch_metadata[key] < 1:
+            raise SchemaError(f"snapshot fetch_metadata.{key} must be a positive integer")
+    if fetch_metadata["observed_model_count"] != len(rows) or fetch_metadata["successful_source_count"] != 2 + len(rows):
+        raise SchemaError("snapshot fetch_metadata counts do not match rows")
+    seen: set[str] = set()
+    seen_source_ids: set[str] = set()
+    seen_ranking_slugs: set[str] = set()
+    ranks: set[int] = set()
+    for index, row in enumerate(rows):
+        if not isinstance(row, dict):
+            raise SchemaError(f"snapshot.rows[{index}] must be object")
+        source_id = row.get("source_model_id")
+        canonical_id = row.get("canonical_model_id")
+        demand = row.get("demand")
+        pricing = row.get("pricing")
+        pricing_status = row.get("pricing_status")
+        if not isinstance(source_id, str) or not MODEL_ID_RE.fullmatch(source_id) or not isinstance(canonical_id, str) or not CANONICAL_ID_RE.fullmatch(canonical_id) or canonical_id == "default":
+            raise SchemaError(f"snapshot.rows[{index}] has invalid model identity")
+        if row.get("mapping_status") not in {"exact", "alias", "unmapped", "rejected"}:
+            raise SchemaError(f"snapshot.rows[{index}] has invalid mapping_status")
+        if canonical_id in seen:
+            raise SchemaError(f"snapshot has duplicate canonical model id {canonical_id!r}")
+        if source_id in seen_source_ids:
+            raise SchemaError(f"snapshot has duplicate source model id {source_id!r}")
+        seen.add(canonical_id)
+        seen_source_ids.add(source_id)
+        if not isinstance(demand, dict) or set(demand) != {"source_model_id", "rank", "completion_volume", "ranking_date", "ranking_model_permaslug"}:
+            raise SchemaError(f"snapshot.rows[{index}] has invalid demand")
+        if demand["source_model_id"] != source_id or not isinstance(demand.get("rank"), int) or demand["rank"] < 1 or not isinstance(demand.get("completion_volume"), str) or not demand["completion_volume"].isdigit() or int(demand["completion_volume"]) <= 0 or not isinstance(demand.get("ranking_model_permaslug"), str) or not MODEL_ID_RE.fullmatch(demand["ranking_model_permaslug"]):
+            raise SchemaError(f"snapshot.rows[{index}] has invalid demand")
+        parse_ranking_date(demand.get("ranking_date"), f"snapshot.rows[{index}].demand.ranking_date")
+        if demand["ranking_model_permaslug"] in seen_ranking_slugs:
+            raise SchemaError(f"snapshot has duplicate ranking model permaslug {demand['ranking_model_permaslug']!r}")
+        seen_ranking_slugs.add(demand["ranking_model_permaslug"])
+        ranks.add(demand["rank"])
+        if pricing_status not in {"active_priced", "no_active_priced_endpoint"}:
+            raise SchemaError(f"snapshot.rows[{index}] has invalid pricing status")
+        if pricing_status == "no_active_priced_endpoint":
+            if pricing is not None:
+                raise SchemaError(f"snapshot.rows[{index}] unavailable pricing must be null")
+        elif not isinstance(pricing, dict) or set(pricing) != {"input_per_token", "completion_per_token", "input_per_mtok", "completion_per_mtok", "currency", "benchmark_provider"}:
+            raise SchemaError(f"snapshot.rows[{index}] has invalid pricing")
+        if pricing_status == "active_priced" and (pricing["currency"] != "USD" or not isinstance(pricing["benchmark_provider"], str) or not pricing["benchmark_provider"]):
+            raise SchemaError(f"snapshot.rows[{index}] has invalid pricing provenance")
+        if not isinstance(row.get("source_metadata"), dict) or set(row["source_metadata"]) != {"ranking_model_permaslug", "catalog_canonical_slug", "catalog_name", "identity_resolution"}:
+            raise SchemaError(f"snapshot.rows[{index}] has invalid source metadata")
+        source_metadata = row["source_metadata"]
+        if not isinstance(source_metadata["ranking_model_permaslug"], str) or not MODEL_ID_RE.fullmatch(source_metadata["ranking_model_permaslug"]):
+            raise SchemaError(f"snapshot.rows[{index}] has invalid ranking provenance")
+        if source_metadata["catalog_canonical_slug"] is not None and not isinstance(source_metadata["catalog_canonical_slug"], str):
+            raise SchemaError(f"snapshot.rows[{index}] has invalid catalog provenance")
+        if source_metadata["catalog_name"] is not None and not isinstance(source_metadata["catalog_name"], str):
+            raise SchemaError(f"snapshot.rows[{index}] has invalid catalog provenance")
+        if source_metadata["identity_resolution"] not in {"catalog", "catalog_paid_variant", "endpoint_alias_fallback"}:
+            raise SchemaError(f"snapshot.rows[{index}] has invalid identity resolution")
+        if pricing_status == "active_priced":
+            parse_decimal(pricing.get("input_per_mtok"), f"snapshot.rows[{index}].pricing.input_per_mtok")
+            parse_decimal(pricing.get("completion_per_mtok"), f"snapshot.rows[{index}].pricing.completion_per_mtok")
+    if ranks != set(range(1, len(rows) + 1)):
+        raise SchemaError("snapshot ranks must be contiguous from 1 through row count")
+
+
+def build_snapshot(
+    rankings_document: Mapping[str, Any],
+    catalog_document: Mapping[str, Any],
+    endpoints_documents: Mapping[str, Mapping[str, Any]],
+    policy: Mapping[str, Any],
+    *,
+    now: datetime,
+    top_n: int,
+) -> dict[str, Any]:
+    rankings = normalize_rankings(rankings_document, top_n)
+    catalog = validate_catalog(catalog_document)
+    endpoint_requests = resolve_rankings_to_catalog(rankings, catalog)
+    requested_endpoint_ids = {demand["source_model_id"] for demand in endpoint_requests}
+    if set(endpoints_documents) != requested_endpoint_ids:
+        raise SchemaError("endpoints response set does not exactly match selected ranking models")
+    rankings = resolve_rankings_to_catalog(rankings, catalog, endpoints_documents)
+    resolved_endpoints: dict[str, Mapping[str, Any]] = {}
+    for demand in rankings:
+        request_id = demand["ranking_model_permaslug"] if demand["_identity_resolution"] == "endpoint_alias_fallback" else demand["source_model_id"]
+        source_model_id = demand["source_model_id"]
+        if source_model_id in resolved_endpoints:
+            raise SchemaError(f"endpoint alias resolution produced duplicate model id {source_model_id!r}")
+        resolved_endpoints[source_model_id] = endpoints_documents[request_id]
+    policy_models = policy_model_index(policy)
+    normalized_rows: list[dict[str, Any]] = []
+    for demand in rankings:
+        source_model_id = demand["source_model_id"]
+        if source_model_id not in resolved_endpoints:
+            raise SchemaError(f"partial pull: endpoints response missing for {source_model_id!r}")
+        endpoint_pricing = cheapest_endpoint_pricing(resolved_endpoints[source_model_id], source_model_id)
+        catalog_row = catalog.get(source_model_id)
+        if catalog_row is None and demand["_identity_resolution"] != "endpoint_alias_fallback":
+            raise SchemaError(f"catalog response lacks ranked model {source_model_id!r}")
+        metadata = policy_models.get(source_model_id)
+        snapshot_demand = {key: value for key, value in demand.items() if key != "_identity_resolution"}
+        normalized_rows.append(
+            {
+                "source_model_id": source_model_id,
+                "canonical_model_id": metadata["canonical_model_id"] if metadata else source_model_id,
+                "mapping_status": (
+                    "exact"
+                    if metadata and metadata["canonical_model_id"] == source_model_id
+                    else "alias"
+                    if metadata
+                    else "unmapped"
+                ),
+                "demand": snapshot_demand,
+                "pricing": endpoint_pricing,
+                "pricing_status": "active_priced" if endpoint_pricing else "no_active_priced_endpoint",
+                "source_metadata": {
+                    "ranking_model_permaslug": demand["ranking_model_permaslug"],
+                    "catalog_canonical_slug": catalog_row["canonical_slug"] if catalog_row else None,
+                    "catalog_name": catalog_row.get("name") if catalog_row else None,
+                    "identity_resolution": demand["_identity_resolution"],
+                },
+            }
+        )
+    normalized_rows.sort(key=lambda row: (row["demand"]["rank"], row["source_model_id"]))
+    snapshot: dict[str, Any] = {
+        "schema_version": SNAPSHOT_SCHEMA_VERSION,
+        "snapshot_type": "openrouter-pricing",
+        "fetched_at": rfc3339(now),
+        "source": {
+            "rankings_url": RANKINGS_URL,
+            "pricing_url_or_urls": [MODELS_URL, ENDPOINTS_URL],
+            "observed_schema_version_or_fingerprint": SCHEMA_CONTRACT_FINGERPRINT,
+            "generator_version": TOOL_VERSION,
+            "fetch_metadata": {
+                "successful_source_count": 2 + len(endpoints_documents),
+                "observed_model_count": len(normalized_rows),
+                "requested_top_n": top_n,
+            },
+        },
+        "rows": normalized_rows,
+    }
+    snapshot["content_digest"] = sha256_prefixed(snapshot_digest_payload(snapshot))
+    validate_snapshot(snapshot)
+    return snapshot
+
+
+def nonempty_https_url(value: Any, field: str) -> None:
+    if not isinstance(value, str) or not value.startswith("https://") or len(value) <= len("https://"):
+        raise SchemaError(f"{field} must be a non-empty https URL")
+
+
+def validate_policy_model(model: Mapping[str, Any], index: int) -> None:
+    source_id = model.get("source_model_id")
+    canonical_id = model.get("canonical_model_id")
+    if not isinstance(source_id, str) or not MODEL_ID_RE.fullmatch(source_id):
+        raise SchemaError(f"policy.models[{index}].source_model_id is invalid")
+    if not isinstance(canonical_id, str) or not CANONICAL_ID_RE.fullmatch(canonical_id) or canonical_id == "default":
+        raise SchemaError(f"policy.models[{index}].canonical_model_id is invalid")
+    profile = model.get("profile")
+    if not isinstance(profile, dict) or set(profile) != {"kind", "active_params_b", "residency_gb", "projected_tps"}:
+        raise SchemaError(f"policy.models[{index}].profile has missing or unexpected fields")
+    if profile.get("kind") not in {"broad_fleet", "coding_dense"}:
+        raise SchemaError(f"policy.models[{index}].profile.kind is invalid")
+    for field in ("active_params_b", "residency_gb", "projected_tps"):
+        parse_decimal(profile.get(field), f"policy.models[{index}].profile.{field}")
+    serving = model.get("serving_path")
+    if not isinstance(serving, dict) or set(serving) != {"verification_status", "reference"}:
+        raise SchemaError(f"policy.models[{index}].serving_path has missing or unexpected fields")
+    if serving.get("verification_status") not in {"verified", "unverified"}:
+        raise SchemaError(f"policy.models[{index}].serving_path.verification_status is invalid")
+    nonempty_https_url(serving.get("reference"), f"policy.models[{index}].serving_path.reference")
+    license_info = model.get("license")
+    if not isinstance(license_info, dict) or set(license_info) != {"commercial_permitted", "source_url", "verification_note"}:
+        raise SchemaError(f"policy.models[{index}].license has missing or unexpected fields")
+    if not isinstance(license_info.get("commercial_permitted"), bool):
+        raise SchemaError(f"policy.models[{index}].license.commercial_permitted must be boolean")
+    nonempty_https_url(license_info.get("source_url"), f"policy.models[{index}].license.source_url")
+    if not isinstance(license_info.get("verification_note"), str) or not license_info["verification_note"].strip():
+        raise SchemaError(f"policy.models[{index}].license.verification_note must be non-empty")
+    expected_keys = {"source_model_id", "canonical_model_id", "serving_path", "license", "profile"}
+    if profile["kind"] == "coding_dense":
+        expected_keys |= {"coding_specialist", "general_purpose_baseline_per_mtok"}
+        if model.get("coding_specialist") is not True:
+            raise SchemaError(f"policy.models[{index}].coding_specialist must be true")
+        parse_decimal(model.get("general_purpose_baseline_per_mtok"), f"policy.models[{index}].general_purpose_baseline_per_mtok", allow_zero=False)
+    if set(model) != expected_keys:
+        raise SchemaError(f"policy.models[{index}] has missing or unexpected fields")
+
+
+def policy_model_index(policy: Mapping[str, Any]) -> dict[str, Mapping[str, Any]]:
+    models = policy.get("models")
+    if not isinstance(models, list):
+        raise SchemaError("policy.models must be a list")
+    result: dict[str, Mapping[str, Any]] = {}
+    canonical_ids: set[str] = set()
+    for index, model in enumerate(models):
+        if not isinstance(model, dict):
+            raise SchemaError(f"policy.models[{index}] must be an object")
+        validate_policy_model(model, index)
+        source_id = model["source_model_id"]
+        canonical_id = model["canonical_model_id"]
+        if source_id in result:
+            raise SchemaError(f"policy duplicate source_model_id {source_id!r}")
+        if canonical_id in canonical_ids:
+            raise SchemaError(f"policy duplicate canonical_model_id {canonical_id!r}")
+        result[source_id] = model
+        canonical_ids.add(canonical_id)
+    return result
+
+
+def validate_policy(policy: Mapping[str, Any]) -> None:
+    expected_keys = {
+        "policy_version", "demand_top_n", "broad_fleet_undercut_fraction",
+        "coding_minimum_undercut_fraction", "coding_premium_fraction", "models",
+    }
+    if set(policy) != expected_keys:
+        raise SchemaError("policy has missing or unexpected fields")
+    if not isinstance(policy.get("policy_version"), str) or not policy["policy_version"]:
+        raise SchemaError("policy.policy_version must be non-empty")
+    demand_top_n = policy.get("demand_top_n")
+    if demand_top_n != 100:
+        raise SchemaError("policy.demand_top_n must be exactly 100")
+    undercut = parse_decimal(policy.get("broad_fleet_undercut_fraction"), "policy.broad_fleet_undercut_fraction", allow_zero=False)
+    if not Decimal("0.10") <= undercut <= Decimal("0.30"):
+        raise SchemaError("policy broad-fleet undercut fraction must be within 10%-30%")
+    coding_min = parse_decimal(policy.get("coding_minimum_undercut_fraction"), "policy.coding_minimum_undercut_fraction", allow_zero=False)
+    if coding_min < Decimal("0.10"):
+        raise SchemaError("policy coding minimum undercut fraction must be at least 10%")
+    premium = parse_decimal(policy.get("coding_premium_fraction"), "policy coding_premium_fraction", allow_zero=False)
+    if not Decimal("0.10") <= premium <= Decimal("0.30"):
+        raise SchemaError("policy coding premium fraction must be within 10%-30%")
+    policy_model_index(policy)
+
+
+def load_json_file(path: Path, description: str) -> dict[str, Any]:
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as error:
+        raise SchemaError(f"could not read {description} {path}: {error}") from error
+    if not isinstance(value, dict):
+        raise SchemaError(f"{description} must be a JSON object")
+    return value
+
+
+def rate_card_digest(rate_card: Mapping[str, Any]) -> str:
+    return sha256_prefixed(rate_card)
+
+
+def validate_rate_card(rate_card: Mapping[str, Any]) -> None:
+    expected_top_level = {"version", "policy_version", "generated_at", "usd_per_million_credits", "rows"}
+    if set(rate_card) != expected_top_level:
+        raise SchemaError("rate card has missing or unexpected top-level fields")
+    for field in ("version", "policy_version", "generated_at"):
+        if not isinstance(rate_card.get(field), str) or not rate_card[field].strip():
+            raise SchemaError(f"rate card {field} must be non-empty string")
+    credits = rate_card.get("usd_per_million_credits")
+    if isinstance(credits, bool) or not isinstance(credits, (int, float)) or not math.isfinite(float(credits)) or credits <= 0:
+        raise SchemaError("rate card usd_per_million_credits must be finite positive number")
+    rows = rate_card.get("rows")
+    if not isinstance(rows, dict) or not rows or "default" not in rows:
+        raise SchemaError("rate card rows must be non-empty object with default row")
+    required_row_fields = {"prompt_rate_per_mtok", "prompt_cache_hit_rate_per_mtok", "completion_rate_per_mtok", "provider_share_bps", "global_multiplier_ppm"}
+    for model_id, row in rows.items():
+        if not isinstance(model_id, str) or (model_id != "default" and not CANONICAL_ID_RE.fullmatch(model_id)):
+            raise SchemaError(f"rate card has invalid model id {model_id!r}")
+        if not isinstance(row, dict) or set(row) != required_row_fields:
+            raise SchemaError(f"rate card row {model_id!r} has missing or unexpected fields")
+        for field, value in row.items():
+            if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+                raise SchemaError(f"rate card row {model_id!r}.{field} must be non-negative integer")
+        if row["provider_share_bps"] > 10000 or row["global_multiplier_ppm"] == 0:
+            raise SchemaError(f"rate card row {model_id!r} has invalid share or multiplier")
+
+
+def current_completion_rate(rate_rows: Mapping[str, Any], model_id: str) -> dict[str, int] | None:
+    current = rate_rows.get(model_id)
+    if current is None:
+        return None
+    if not isinstance(current, dict):
+        raise SchemaError(f"rate card row {model_id!r} must be an object")
+    value = current.get("completion_rate_per_mtok")
+    if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+        raise SchemaError(f"rate card row {model_id!r} has invalid completion_rate_per_mtok")
+    return {"rate_card_completion_rate_per_mtok": value}
+
+
+def rate_card_economics(rate_card: Mapping[str, Any], model_id: str) -> tuple[Decimal, Decimal, Decimal, str]:
+    """Return USD conversion, multiplier, share, and the row used as basis."""
+    rows = rate_card["rows"]
+    basis_id = model_id if model_id in rows else "default"
+    basis = rows[basis_id]
+    return (
+        Decimal(str(rate_card["usd_per_million_credits"])),
+        Decimal(basis["global_multiplier_ppm"]),
+        Decimal(basis["provider_share_bps"]),
+        basis_id,
+    )
+
+
+def completion_rate_to_internal(value: Decimal, rate_card: Mapping[str, Any], model_id: str) -> int:
+    """Convert buyer USD/MTok to the reference card's credits/MTok encoding."""
+    usd_per_million_credits, multiplier_ppm, _, _ = rate_card_economics(rate_card, model_id)
+    credits_per_mtok = value * Decimal("1000000000000") / (multiplier_ppm * usd_per_million_credits)
+    return int(credits_per_mtok.quantize(Decimal("1"), rounding=ROUND_HALF_UP))
+
+
+def provider_hourly_usd(internal_rate_per_mtok: int, tps: Decimal, rate_card: Mapping[str, Any], model_id: str) -> Decimal:
+    """Provider net USD/hour under the exact reference-card conversion/share."""
+    usd_per_million_credits, multiplier_ppm, provider_share_bps, _ = rate_card_economics(rate_card, model_id)
+    buyer_usd_per_mtok = Decimal(internal_rate_per_mtok) * multiplier_ppm * usd_per_million_credits / Decimal("1000000000000")
+    return buyer_usd_per_mtok * provider_share_bps / Decimal("10000") * tps * Decimal("3600") / Decimal("1000000")
+
+
+def eligibility(model: Mapping[str, Any], row: Mapping[str, Any], policy: Mapping[str, Any]) -> tuple[bool, list[str], Decimal | None]:
+    reasons: list[str] = []
+    rank = row["demand"]["rank"]
+    if rank > 100:
+        reasons.append(f"demand rank {rank} is outside the top-100 completion-token gate")
+    serving = model.get("serving_path")
+    if not isinstance(serving, dict) or serving.get("verification_status") != "verified":
+        reasons.append("MLX/GGUF serving path is not verified")
+    license_info = model.get("license")
+    if not isinstance(license_info, dict) or license_info.get("commercial_permitted") is not True:
+        reasons.append("commercial license is not verified as permitted")
+    profile = model.get("profile")
+    if not isinstance(profile, dict):
+        reasons.append("model profile is missing")
+        return False, reasons, None
+    kind = profile.get("kind")
+    active = profile.get("active_params_b")
+    residency = profile.get("residency_gb")
+    tps = profile.get("projected_tps")
+    try:
+        active_d = Decimal(str(active))
+        residency_d = Decimal(str(residency))
+        tps_d = Decimal(str(tps))
+    except (InvalidOperation, ValueError) as error:
+        raise SchemaError(f"policy profile for {model['source_model_id']} has invalid numeric value") from error
+    if kind == "broad_fleet":
+        if active_d > Decimal("8"):
+            reasons.append("broad-fleet active parameters exceed 8B")
+        if residency_d > Decimal("18"):
+            reasons.append("broad-fleet 4-bit residency exceeds 18 GB")
+        if tps_d < Decimal("30"):
+            reasons.append("broad-fleet projected M-base TPS is below 30")
+    elif kind == "coding_dense":
+        if residency_d > Decimal("45"):
+            reasons.append("coding-dense 4-bit residency exceeds 45 GB")
+        if tps_d < Decimal("20"):
+            reasons.append("coding-dense projected M-Max TPS is below 20")
+        if model.get("coding_specialist") is not True:
+            reasons.append("coding-dense profile is not marked coding-specialist")
+    else:
+        reasons.append("model profile kind is not eligible")
+    pricing = row.get("pricing")
+    if row.get("pricing_status") != "active_priced" or not isinstance(pricing, dict):
+        reasons.append("no active priced OpenRouter endpoint is available")
+        return False, reasons, None
+    completion = parse_decimal(pricing.get("completion_per_mtok"), "snapshot completion price")
+    if completion == 0:
+        reasons.append("cheapest active completion endpoint is free; no paid-market undercut can be computed")
+    return not reasons, reasons, completion
+
+
+def proposed_completion_price(
+    model: Mapping[str, Any], market_completion: Decimal, policy: Mapping[str, Any], rate_card: Mapping[str, Any], model_id: str
+) -> tuple[Decimal, int, list[str]]:
+    profile = model["profile"]
+    kind = profile["kind"]
+    if kind == "broad_fleet":
+        undercut = parse_decimal(policy["broad_fleet_undercut_fraction"], "policy broad_fleet_undercut_fraction")
+        target = market_completion * (Decimal("1") - undercut)
+        return target, completion_rate_to_internal(target, rate_card, model_id), [f"broad-fleet undercut fraction {decimal_string(undercut)}"]
+    if kind != "coding_dense":
+        raise SchemaError(f"unsupported profile kind {kind!r}")
+    undercut = parse_decimal(policy["coding_minimum_undercut_fraction"], "policy coding_minimum_undercut_fraction")
+    baseline = parse_decimal(model.get("general_purpose_baseline_per_mtok"), "coding model general_purpose_baseline_per_mtok", allow_zero=False)
+    premium = parse_decimal(policy.get("coding_premium_fraction"), "policy coding_premium_fraction")
+    if premium < Decimal("0.10") or premium > Decimal("0.30"):
+        raise SchemaError("policy coding premium fraction must be within 10%-30%")
+    premium_price = baseline * (Decimal("1") + premium)
+    market_cap = market_completion * (Decimal("1") - undercut)
+    target = min(premium_price, market_cap)
+    internal_rate = completion_rate_to_internal(target, rate_card, model_id)
+    tps = parse_decimal(profile["projected_tps"], "coding model projected_tps", allow_zero=False)
+    provider_hourly = provider_hourly_usd(internal_rate, tps, rate_card, model_id)
+    if provider_hourly < Decimal("0.10"):
+        raise SchemaError("coding-dense target does not meet the $0.10/hour provider economics floor")
+    _, _, _, basis_id = rate_card_economics(rate_card, model_id)
+    return target, internal_rate, [
+        f"coding premium fraction {decimal_string(premium)}",
+        f"coding market undercut fraction {decimal_string(undercut)}",
+        f"provider net hourly USD {decimal_string(provider_hourly)} using rate-card economics row {basis_id}",
+    ]
+
+
+def build_proposal(
+    snapshot: Mapping[str, Any], policy: Mapping[str, Any], rate_card: Mapping[str, Any], *, now: datetime
+) -> dict[str, Any]:
+    validate_snapshot(snapshot)
+    validate_policy(policy)
+    validate_rate_card(rate_card)
+    required_top_n = policy["demand_top_n"]
+    coverage = snapshot["source"]["fetch_metadata"]
+    if coverage["requested_top_n"] < required_top_n or coverage["observed_model_count"] < required_top_n:
+        raise SchemaError("snapshot does not contain the policy-required top-demand coverage")
+    rate_rows = rate_card["rows"]
+    policy_models = policy_model_index(policy)
+    rows_by_source = {row["source_model_id"]: row for row in snapshot["rows"]}
+    result: dict[str, list[dict[str, Any]]] = {key: [] for key in ("added", "changed", "dropped", "blocked", "unchanged")}
+    assessed_current_ids: set[str] = set()
+
+    def market_unavailable() -> dict[str, None]:
+        return {"demand_rank": None, "completion_volume": None, "benchmark_provider": None, "completion_per_mtok": None}
+
+    def market_from_snapshot_row(row: Mapping[str, Any]) -> dict[str, Any]:
+        pricing = row.get("pricing")
+        if row.get("pricing_status") != "active_priced" or not isinstance(pricing, dict):
+            return {"demand_rank": row["demand"]["rank"], "completion_volume": row["demand"]["completion_volume"], "benchmark_provider": None, "completion_per_mtok": None}
+        return {
+            "demand_rank": row["demand"]["rank"],
+            "completion_volume": row["demand"]["completion_volume"],
+            "benchmark_provider": pricing["benchmark_provider"],
+            "completion_per_mtok": pricing["completion_per_mtok"],
+        }
+
+    def policy_evidence(model: Mapping[str, Any] | None) -> dict[str, Any]:
+        if model is None:
+            return {"policy_version": policy["policy_version"], "available": False, "license_source_url": None, "license_verification_note": None, "serving_path": None}
+        return {
+            "policy_version": policy["policy_version"], "available": True,
+            "license_source_url": model["license"]["source_url"],
+            "license_verification_note": model["license"]["verification_note"],
+            "serving_path": model["serving_path"]["reference"],
+        }
+
+    # Keep unknown top-demand rows visible to reviewers. They are intentionally
+    # blocked rather than guessed into an internal model identity or price.
+    for row in snapshot["rows"]:
+        if row["source_model_id"] not in policy_models:
+            result["blocked"].append(
+                {
+                    "model_id": row["canonical_model_id"],
+                    "source_model_id": row["source_model_id"],
+                    "action": "blocked",
+                    "market": market_from_snapshot_row(row),
+                    "eligibility": {"eligible": False, "reasons": ["no verified policy metadata/mapping for this OpenRouter model"]},
+                    "policy_evidence": policy_evidence(None),
+                    "reasons": ["no verified policy metadata/mapping for this OpenRouter model"],
+                }
+            )
+
+    for source_model_id, model in sorted(policy_models.items()):
+        canonical_id = model["canonical_model_id"]
+        if canonical_id in rate_rows:
+            assessed_current_ids.add(canonical_id)
+        row = rows_by_source.get(source_model_id)
+        if row is None:
+            if canonical_id in rate_rows and canonical_id != "default":
+                result["dropped"].append(
+                    {
+                        "model_id": canonical_id,
+                        "source_model_id": source_model_id,
+                        "action": "dropped",
+                        "current_completion_rate": current_completion_rate(rate_rows, canonical_id),
+                        "eligibility": {"eligible": False, "reasons": ["model is absent from complete top-100 demand snapshot"]},
+                        "market": market_unavailable(),
+                        "policy_evidence": policy_evidence(model),
+                        "reasons": ["model is absent from complete top-100 demand snapshot"],
+                    }
+                )
+            else:
+                result["blocked"].append(
+                    {"model_id": canonical_id, "source_model_id": source_model_id, "action": "blocked", "market": market_unavailable(), "eligibility": {"eligible": False, "reasons": ["model is absent from complete top-100 demand snapshot"]}, "policy_evidence": policy_evidence(model), "reasons": ["model is absent from complete top-100 demand snapshot"]}
+                )
+            continue
+        allowed, reasons, market_completion = eligibility(model, row, policy)
+        base = {
+            "model_id": canonical_id,
+            "source_model_id": source_model_id,
+            "market": market_from_snapshot_row(row),
+            "eligibility": {"eligible": allowed, "reasons": reasons},
+            "policy_evidence": policy_evidence(model),
+        }
+        if not allowed:
+            block_reasons = {
+                "MLX/GGUF serving path is not verified",
+                "commercial license is not verified as permitted",
+                "no active priced OpenRouter endpoint is available",
+                "cheapest active completion endpoint is free; no paid-market undercut can be computed",
+            }
+            action = "blocked" if any(reason in block_reasons for reason in reasons) else "dropped" if canonical_id in rate_rows else "blocked"
+            base.update({"action": action, "reasons": reasons})
+            if canonical_id in rate_rows:
+                base["current_completion_rate"] = current_completion_rate(rate_rows, canonical_id)
+            result[base["action"]].append(base)
+            continue
+        try:
+            target, proposed_internal, formula_reasons = proposed_completion_price(model, market_completion, policy, rate_card, canonical_id)
+        except SchemaError as error:
+            base.update({"action": "blocked", "reasons": [str(error)]})
+            result["blocked"].append(base)
+            continue
+        base["proposed_completion_rate"] = {
+            "usd_per_mtok": decimal_string(target),
+            "rate_card_completion_rate_per_mtok": proposed_internal,
+            "formula_reasons": formula_reasons,
+        }
+        usd_per_million_credits, multiplier_ppm, provider_share_bps, basis_id = rate_card_economics(rate_card, canonical_id)
+        base["rate_card_economics"] = {
+            "basis_row": basis_id,
+            "usd_per_million_credits": decimal_string(usd_per_million_credits),
+            "global_multiplier_ppm": decimal_string(multiplier_ppm),
+            "provider_share_bps": decimal_string(provider_share_bps),
+        }
+        current_completion = current_completion_rate(rate_rows, canonical_id)
+        if current_completion is None:
+            base["action"] = "added"
+            result["added"].append(base)
+            continue
+        base["current_completion_rate"] = current_completion
+        if current_completion["rate_card_completion_rate_per_mtok"] == proposed_internal:
+            base["action"] = "unchanged"
+            result["unchanged"].append(base)
+        else:
+            base["action"] = "changed"
+            result["changed"].append(base)
+
+    for model_id in sorted(rate_rows):
+        if model_id == "default" or model_id in assessed_current_ids:
+            continue
+        result["blocked"].append(
+            {
+                "model_id": model_id,
+                "action": "blocked",
+                "current_completion_rate": current_completion_rate(rate_rows, model_id),
+                "eligibility": {"eligible": False, "reasons": ["no verified policy metadata/mapping for current rate-card row"]},
+                "market": market_unavailable(),
+                "policy_evidence": policy_evidence(None),
+                "reasons": ["no verified policy metadata/mapping for current rate-card row"],
+            }
+        )
+
+    summary = {"eligible": len(result["added"]) + len(result["changed"]) + len(result["unchanged"])}
+    summary.update({key: len(result[key]) for key in result})
+    return {
+        "schema_version": PROPOSAL_SCHEMA_VERSION,
+        "proposal_type": "openrouter-rate-card-proposal",
+        "generated_at": rfc3339(now),
+        "snapshot_digest": snapshot["content_digest"],
+        "policy_version": policy["policy_version"],
+        "rate_card_reference_digest": rate_card_digest(rate_card),
+        "summary": summary,
+        **result,
+    }
+
+
+def atomic_write_json(path: Path, value: Mapping[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    descriptor, temporary_name = tempfile.mkstemp(prefix=f".{path.name}.", suffix=".tmp", dir=path.parent)
+    try:
+        with os.fdopen(descriptor, "wb") as handle:
+            handle.write(canonical_json(value))
+            handle.write(b"\n")
+            handle.flush()
+            os.fsync(handle.fileno())
+        try:
+            # link() creates the final name atomically and never replaces an
+            # existing artifact, unlike os.replace().  The temporary file and
+            # final path are deliberately in the same output directory.
+            os.link(temporary_name, path)
+        except FileExistsError as error:
+            raise EngineError(f"refusing to overwrite existing artifact {path}") from error
+        os.unlink(temporary_name)
+    except BaseException:
+        try:
+            os.unlink(temporary_name)
+        except FileNotFoundError:
+            pass
+        raise
+
+
+def artifact_suffix(value: Mapping[str, Any]) -> str:
+    return sha256_prefixed(value).split(":", 1)[1][:16]
+
+
+def snapshot_filename(now: datetime, snapshot: Mapping[str, Any]) -> str:
+    return "openrouter-pricing-snapshot-" + now.astimezone(timezone.utc).strftime("%Y-%m-%dT%H-%M-%SZ-") + artifact_suffix(snapshot) + ".json"
+
+
+def proposal_filename(now: datetime, proposal: Mapping[str, Any]) -> str:
+    return "openrouter-rate-card-proposal-" + now.astimezone(timezone.utc).strftime("%Y-%m-%dT%H-%M-%SZ-") + artifact_suffix(proposal) + ".json"
+
+
+def fetch_live_snapshot(
+    policy: Mapping[str, Any],
+    *,
+    output_dir: Path,
+    top_n: int,
+    retries: int,
+    timeout_seconds: float,
+    client: HTTPClient | None = None,
+    now: Callable[[], datetime] = utc_now,
+    sleeper: Callable[[float], None] = time.sleep,
+    generation_timeout_seconds: float = 900.0,
+    clock: Callable[[], float] = time.monotonic,
+) -> Path:
+    if isinstance(top_n, bool) or not isinstance(top_n, int) or not 1 <= top_n <= 100:
+        raise FetchError("top_n must be an integer between 1 and 100")
+    if not math.isfinite(timeout_seconds) or not 0 < timeout_seconds <= 60:
+        raise FetchError("request timeout must be finite, positive, and no more than 60 seconds")
+    if not math.isfinite(generation_timeout_seconds) or not 1 <= generation_timeout_seconds <= 3600:
+        raise FetchError("generation timeout must be finite, at least one second, and no more than one hour")
+    client = client or UrllibHTTPClient()
+    deadline = clock() + generation_timeout_seconds
+    rankings = fetch_json(client, RANKINGS_URL, "rankings", retries=retries, timeout_seconds=timeout_seconds, sleeper=sleeper, deadline=deadline, clock=clock)
+    catalog = fetch_json(client, MODELS_URL, "models catalog", retries=retries, timeout_seconds=timeout_seconds, sleeper=sleeper, deadline=deadline, clock=clock)
+    catalog_index = validate_catalog(catalog)
+    ranking_rows = resolve_rankings_to_catalog(normalize_rankings(rankings, top_n), catalog_index)
+    endpoints: dict[str, Mapping[str, Any]] = {}
+    for demand in ranking_rows:
+        model_id = demand["source_model_id"]
+        # The documented endpoint is /models/{provider}/{model}/endpoints; the
+        # one validated provider/model slash must remain a path separator.
+        url = ENDPOINTS_URL.format(model_id=quote(model_id, safe="/"))
+        endpoints[model_id] = fetch_json(client, url, f"endpoints {model_id}", retries=retries, timeout_seconds=timeout_seconds, sleeper=sleeper, deadline=deadline, clock=clock)
+    fetched_at = now()
+    snapshot = build_snapshot(rankings, catalog, endpoints, policy, now=fetched_at, top_n=top_n)
+    target = output_dir / snapshot_filename(fetched_at, snapshot)
+    atomic_write_json(target, snapshot)
+    return target
+
+
+def command_fetch(args: argparse.Namespace) -> int:
+    policy = load_json_file(Path(args.policy), "policy")
+    validate_policy(policy)
+    result = fetch_live_snapshot(policy, output_dir=Path(args.output_dir), top_n=args.top_n, retries=args.retries, timeout_seconds=args.timeout_seconds, generation_timeout_seconds=args.generation_timeout_seconds)
+    print(result)
+    return 0
+
+
+def command_compute(args: argparse.Namespace) -> int:
+    snapshot = load_json_file(Path(args.snapshot), "snapshot")
+    policy = load_json_file(Path(args.policy), "policy")
+    rate_card = load_json_file(Path(args.rate_card), "rate card")
+    now = utc_now()
+    proposal = build_proposal(snapshot, policy, rate_card, now=now)
+    target = Path(args.output_dir) / proposal_filename(now, proposal)
+    atomic_write_json(target, proposal)
+    print(target)
+    return 0
+
+
+def parser() -> argparse.ArgumentParser:
+    result = argparse.ArgumentParser(description=__doc__)
+    subcommands = result.add_subparsers(dest="command", required=True)
+    fetch = subcommands.add_parser("fetch", help="fetch and validate a live OpenRouter snapshot")
+    fetch.add_argument("--policy", default=str(DEFAULT_POLICY_PATH))
+    fetch.add_argument("--output-dir", required=True)
+    fetch.add_argument("--top-n", type=int, default=100)
+    fetch.add_argument("--retries", type=int, default=3)
+    fetch.add_argument("--timeout-seconds", type=float, default=20.0)
+    fetch.add_argument("--generation-timeout-seconds", type=float, default=900.0)
+    fetch.set_defaults(handler=command_fetch)
+    compute = subcommands.add_parser("compute", help="compute a proposal from a validated snapshot")
+    compute.add_argument("--snapshot", required=True)
+    compute.add_argument("--policy", default=str(DEFAULT_POLICY_PATH))
+    compute.add_argument("--rate-card", required=True)
+    compute.add_argument("--output-dir", required=True)
+    compute.set_defaults(handler=command_compute)
+    return result
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parser().parse_args(argv)
+    try:
+        return args.handler(args)
+    except EngineError as error:
+        print(f"openrouter pricing engine: {error}", file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/openrouter_pricing_engine.py
+++ b/scripts/openrouter_pricing_engine.py
@@ -83,10 +83,16 @@ class HTTPResponse:
 
 
 class UrllibHTTPClient:
-    """Small production adapter; tests provide an in-memory HTTP client."""
+    """Small production adapter; tests provide an in-memory HTTP client.
 
-    def __init__(self, resolver: Callable[[float], list[str]] | None = None):
+    ``OPENROUTER_API_KEY`` is optional so the tool can use an operator's
+    configured OpenRouter credential without ever placing that credential in
+    command-line arguments, artifacts, or error messages.
+    """
+
+    def __init__(self, resolver: Callable[[float], list[str]] | None = None, api_key: str | None = None):
         self._resolver = resolver or resolve_openrouter_addresses
+        self._api_key = os.environ.get("OPENROUTER_API_KEY") if api_key is None else api_key
         self._resolved_addresses: list[str] | None = None
         self._next_address_index = 0
 
@@ -129,7 +135,10 @@ class UrllibHTTPClient:
         watchdog.start()
         try:
             target = parsed.path + (f"?{parsed.query}" if parsed.query else "")
-            connection.request("GET", target, headers={"Accept": "application/json", "User-Agent": TOOL_VERSION})
+            headers = {"Accept": "application/json", "User-Agent": TOOL_VERSION}
+            if self._api_key:
+                headers["Authorization"] = f"Bearer {self._api_key}"
+            connection.request("GET", target, headers=headers)
             response = connection.getresponse()
             if timed_out.is_set():
                 raise FetchError(f"wall-clock request deadline exceeded after {timeout_seconds} seconds")

--- a/scripts/openrouter_pricing_engine.py
+++ b/scripts/openrouter_pricing_engine.py
@@ -23,7 +23,7 @@ import tempfile
 import threading
 import time
 from dataclasses import dataclass
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from decimal import Decimal, InvalidOperation, ROUND_HALF_UP
 from email.utils import parsedate_to_datetime
 from pathlib import Path
@@ -31,10 +31,10 @@ from typing import Any, Callable, Mapping, Protocol
 from urllib.parse import quote, urlsplit
 
 
-RANKINGS_URL = "https://openrouter.ai/api/frontend/v1/rankings/models"
+RANKINGS_URL = "https://openrouter.ai/api/v1/datasets/rankings-daily"
 MODELS_URL = "https://openrouter.ai/api/v1/models"
 ENDPOINTS_URL = "https://openrouter.ai/api/v1/models/{model_id}/endpoints"
-SNAPSHOT_SCHEMA_VERSION = 3
+SNAPSHOT_SCHEMA_VERSION = 4
 PROPOSAL_SCHEMA_VERSION = 1
 TOOL_VERSION = "openrouter-pricing-engine-v1"
 DEFAULT_POLICY_PATH = Path(__file__).with_name("openrouter_pricing_policy.json")
@@ -43,7 +43,9 @@ MODEL_ID_RE = re.compile(r"^[A-Za-z0-9._~:-]+/[A-Za-z0-9._~:-]+$")
 # valid snapshot identities even when policy leaves them unmapped/blocked.
 CANONICAL_ID_RE = re.compile(r"^[a-z0-9][a-z0-9._/:-]*$")
 MAX_RESPONSE_BYTES = 5 * 1024 * 1024
-RANKING_ROW_KEYS = frozenset({"change", "count", "date", "image_output_requests", "model_permaslug", "num_audio_prompt", "num_media_completion", "num_media_prompt", "num_video_prompt", "requests_with_tool_call_errors", "rerank_documents", "stt_transcript_characters", "total_completion_tokens", "total_native_tokens_cached", "total_native_tokens_reasoning", "total_prompt_tokens", "total_tool_calls", "variant", "variant_permaslug", "video_output_seconds"})
+RANKING_TOP_LEVEL_KEYS = frozenset({"data", "meta"})
+RANKING_ROW_KEYS = frozenset({"date", "model_permaslug", "total_tokens"})
+RANKING_META_KEYS = frozenset({"as_of", "end_date", "start_date", "version"})
 CATALOG_ROW_KEYS = frozenset({"alias_target", "architecture", "benchmarks", "canonical_slug", "context_length", "created", "default_parameters", "description", "expiration_date", "hugging_face_id", "id", "knowledge_cutoff", "links", "name", "per_request_limits", "pricing", "reasoning", "supported_parameters", "supported_voices", "top_provider"})
 CATALOG_TOP_LEVEL_KEYS = frozenset({"data", "links", "total_count"})
 ENDPOINT_DATA_KEYS = frozenset({"architecture", "created", "description", "endpoints", "id", "name"})
@@ -202,11 +204,11 @@ def parse_rfc3339_utc(value: Any, field: str) -> datetime:
 
 def parse_ranking_date(value: Any, field: str) -> datetime:
     if not isinstance(value, str):
-        raise SchemaError(f"{field} must be OpenRouter ranking timestamp YYYY-MM-DD HH:MM:SS")
+        raise SchemaError(f"{field} must be OpenRouter daily ranking date YYYY-MM-DD")
     try:
-        return datetime.strptime(value, "%Y-%m-%d %H:%M:%S")
+        return datetime.strptime(value, "%Y-%m-%d")
     except ValueError as error:
-        raise SchemaError(f"{field} must be OpenRouter ranking timestamp YYYY-MM-DD HH:MM:SS") from error
+        raise SchemaError(f"{field} must be OpenRouter daily ranking date YYYY-MM-DD") from error
 
 
 def canonical_json(value: Any) -> bytes:
@@ -219,7 +221,9 @@ def sha256_prefixed(value: Any) -> str:
 
 SCHEMA_CONTRACT_FINGERPRINT = sha256_prefixed(
     {
+        "rankings_top_level_keys": sorted(RANKING_TOP_LEVEL_KEYS),
         "rankings_row_keys": sorted(RANKING_ROW_KEYS),
+        "rankings_meta_keys": sorted(RANKING_META_KEYS),
         "catalog_row_keys": sorted(CATALOG_ROW_KEYS),
         "catalog_top_level_keys": sorted(CATALOG_TOP_LEVEL_KEYS),
         "endpoint_data_keys": sorted(ENDPOINT_DATA_KEYS),
@@ -382,47 +386,59 @@ def require_allowed_keys(value: Mapping[str, Any], allowed: frozenset[str], loca
         raise SchemaError(f"{location}: unexpected fields {unexpected}")
 
 
+def rankings_metadata(document: Mapping[str, Any]) -> Mapping[str, Any]:
+    require_allowed_keys(document, RANKING_TOP_LEVEL_KEYS, "rankings response")
+    metadata = document.get("meta")
+    if not isinstance(metadata, dict):
+        raise SchemaError("rankings response: meta must be an object")
+    require_allowed_keys(metadata, RANKING_META_KEYS, "rankings response: meta")
+    if set(metadata) != RANKING_META_KEYS:
+        raise SchemaError("rankings response: meta has missing fields")
+    parse_rfc3339_utc(metadata["as_of"], "rankings response: meta.as_of")
+    start = parse_ranking_date(metadata["start_date"], "rankings response: meta.start_date")
+    end = parse_ranking_date(metadata["end_date"], "rankings response: meta.end_date")
+    if start > end or metadata["version"] != "v1":
+        raise SchemaError("rankings response: meta has invalid date range or version")
+    return metadata
+
+
 def normalize_rankings(document: Mapping[str, Any], top_n: int) -> list[dict[str, Any]]:
-    require_allowed_keys(document, frozenset({"data"}), "rankings response")
+    if isinstance(top_n, bool) or not isinstance(top_n, int) or not 1 <= top_n <= 50:
+        raise SchemaError("requested demand cohort must be an integer from 1 through 50")
+    metadata = rankings_metadata(document)
     rows = required_list(document, "data", "rankings response")
     totals: dict[str, int] = {}
     dates: dict[str, str] = {}
-    eligible_rows: list[tuple[dict[str, Any], datetime]] = []
+    seen_daily_models: set[tuple[str, str]] = set()
     for index, row in enumerate(rows):
         if not isinstance(row, dict):
             raise SchemaError(f"rankings response: data[{index}] must be an object")
         require_allowed_keys(row, RANKING_ROW_KEYS, f"rankings response: data[{index}]")
-        completion_tokens = row.get("total_completion_tokens")
-        if isinstance(completion_tokens, bool) or not isinstance(completion_tokens, int) or completion_tokens < 0:
-            raise SchemaError(f"rankings response: data[{index}].total_completion_tokens must be non-negative integer")
-        # Non-generation rows (for example embedding-only models) have no
-        # completion demand and are outside this completion-rate pipeline.
-        if completion_tokens == 0:
-            continue
+        total_tokens = row.get("total_tokens")
+        if not isinstance(total_tokens, str) or not total_tokens.isdigit() or int(total_tokens) <= 0:
+            raise SchemaError(f"rankings response: data[{index}].total_tokens must be a positive integer string")
         model_id = row.get("model_permaslug")
         date = row.get("date")
+        parsed_date = parse_ranking_date(date, f"rankings response: data[{index}].date")
+        if not parse_ranking_date(metadata["start_date"], "rankings response: meta.start_date") <= parsed_date <= parse_ranking_date(metadata["end_date"], "rankings response: meta.end_date"):
+            raise SchemaError(f"rankings response: data[{index}].date is outside metadata window")
+        if model_id == "other":
+            continue
         if not isinstance(model_id, str) or not model_id.strip():
             raise SchemaError(f"rankings response: data[{index}].model_permaslug must be non-empty")
         if not MODEL_ID_RE.fullmatch(model_id):
             raise SchemaError(f"rankings response: data[{index}].model_permaslug has unsafe shape")
-        parsed_date = parse_ranking_date(date, f"rankings response: data[{index}].date")
-        eligible_rows.append((row, parsed_date))
-    if not eligible_rows:
-        raise SchemaError("rankings response: no completion-demand rows")
-    latest_date = max(parsed_date for _, parsed_date in eligible_rows)
-    for row, parsed_date in eligible_rows:
-        if parsed_date != latest_date:
-            continue
-        model_id = row["model_permaslug"]
-        completion_tokens = row["total_completion_tokens"]
-        date = row["date"]
-        totals[model_id] = totals.get(model_id, 0) + completion_tokens
+        daily_key = (date, model_id)
+        if daily_key in seen_daily_models:
+            raise SchemaError(f"rankings response: duplicate daily model row {daily_key!r}")
+        seen_daily_models.add(daily_key)
+        totals[model_id] = totals.get(model_id, 0) + int(total_tokens)
         dates[model_id] = max(date, dates.get(model_id, date))
     ordered = sorted(totals, key=lambda item: (-totals[item], item))[:top_n]
-    if not ordered:
-        raise SchemaError("rankings response: no normalized ranking rows")
+    if len(ordered) != top_n:
+        raise SchemaError("rankings response: insufficient documented daily-ranking models for requested cohort")
     return [
-        {"source_model_id": model_id, "rank": rank, "completion_volume": str(totals[model_id]), "ranking_date": dates[model_id]}
+        {"source_model_id": model_id, "rank": rank, "total_token_volume": str(totals[model_id]), "ranking_date": dates[model_id]}
         for rank, model_id in enumerate(ordered, start=1)
     ]
 
@@ -591,11 +607,18 @@ def validate_snapshot(snapshot: Mapping[str, Any]) -> None:
     if source["observed_schema_version_or_fingerprint"] != SCHEMA_CONTRACT_FINGERPRINT or not isinstance(source["generator_version"], str):
         raise SchemaError("snapshot source schema/generator provenance is invalid")
     fetch_metadata = source["fetch_metadata"]
-    if not isinstance(fetch_metadata, dict) or set(fetch_metadata) != {"successful_source_count", "observed_model_count", "requested_top_n"}:
+    required_fetch_metadata = {"successful_source_count", "observed_model_count", "requested_top_n", "demand_window_days", "ranking_window_start_date", "ranking_window_end_date", "demand_metric"}
+    if not isinstance(fetch_metadata, dict) or set(fetch_metadata) != required_fetch_metadata:
         raise SchemaError("snapshot fetch_metadata has missing or unexpected fields")
-    for key in ("successful_source_count", "observed_model_count", "requested_top_n"):
+    for key in ("successful_source_count", "observed_model_count", "requested_top_n", "demand_window_days"):
         if isinstance(fetch_metadata[key], bool) or not isinstance(fetch_metadata[key], int) or fetch_metadata[key] < 1:
             raise SchemaError(f"snapshot fetch_metadata.{key} must be a positive integer")
+    if fetch_metadata["requested_top_n"] > 50 or fetch_metadata["demand_window_days"] > 31 or fetch_metadata["demand_metric"] != "aggregated_daily_total_tokens":
+        raise SchemaError("snapshot fetch_metadata has invalid demand cohort metadata")
+    start = parse_ranking_date(fetch_metadata["ranking_window_start_date"], "snapshot fetch_metadata.ranking_window_start_date")
+    end = parse_ranking_date(fetch_metadata["ranking_window_end_date"], "snapshot fetch_metadata.ranking_window_end_date")
+    if start > end or (end - start).days + 1 != fetch_metadata["demand_window_days"]:
+        raise SchemaError("snapshot fetch_metadata has invalid ranking window")
     if fetch_metadata["observed_model_count"] != len(rows) or fetch_metadata["successful_source_count"] != 2 + len(rows):
         raise SchemaError("snapshot fetch_metadata counts do not match rows")
     seen: set[str] = set()
@@ -620,9 +643,9 @@ def validate_snapshot(snapshot: Mapping[str, Any]) -> None:
             raise SchemaError(f"snapshot has duplicate source model id {source_id!r}")
         seen.add(canonical_id)
         seen_source_ids.add(source_id)
-        if not isinstance(demand, dict) or set(demand) != {"source_model_id", "rank", "completion_volume", "ranking_date", "ranking_model_permaslug"}:
+        if not isinstance(demand, dict) or set(demand) != {"source_model_id", "rank", "total_token_volume", "ranking_date", "ranking_model_permaslug"}:
             raise SchemaError(f"snapshot.rows[{index}] has invalid demand")
-        if demand["source_model_id"] != source_id or not isinstance(demand.get("rank"), int) or demand["rank"] < 1 or not isinstance(demand.get("completion_volume"), str) or not demand["completion_volume"].isdigit() or int(demand["completion_volume"]) <= 0 or not isinstance(demand.get("ranking_model_permaslug"), str) or not MODEL_ID_RE.fullmatch(demand["ranking_model_permaslug"]):
+        if demand["source_model_id"] != source_id or not isinstance(demand.get("rank"), int) or demand["rank"] < 1 or not isinstance(demand.get("total_token_volume"), str) or not demand["total_token_volume"].isdigit() or int(demand["total_token_volume"]) <= 0 or not isinstance(demand.get("ranking_model_permaslug"), str) or not MODEL_ID_RE.fullmatch(demand["ranking_model_permaslug"]):
             raise SchemaError(f"snapshot.rows[{index}] has invalid demand")
         parse_ranking_date(demand.get("ranking_date"), f"snapshot.rows[{index}].demand.ranking_date")
         if demand["ranking_model_permaslug"] in seen_ranking_slugs:
@@ -664,8 +687,14 @@ def build_snapshot(
     *,
     now: datetime,
     top_n: int,
+    demand_window_days: int | None = None,
 ) -> dict[str, Any]:
     rankings = normalize_rankings(rankings_document, top_n)
+    ranking_meta = rankings_metadata(rankings_document)
+    observed_window_days = (parse_ranking_date(ranking_meta["end_date"], "rankings response: meta.end_date") - parse_ranking_date(ranking_meta["start_date"], "rankings response: meta.start_date")).days + 1
+    if demand_window_days is not None and demand_window_days != observed_window_days:
+        raise SchemaError("rankings response metadata does not match the requested demand window")
+    resolved_window_days = observed_window_days
     catalog = validate_catalog(catalog_document)
     endpoint_requests = resolve_rankings_to_catalog(rankings, catalog)
     requested_endpoint_ids = {demand["source_model_id"] for demand in endpoint_requests}
@@ -727,6 +756,10 @@ def build_snapshot(
                 "successful_source_count": 2 + len(endpoints_documents),
                 "observed_model_count": len(normalized_rows),
                 "requested_top_n": top_n,
+                "demand_window_days": resolved_window_days,
+                "ranking_window_start_date": ranking_meta["start_date"],
+                "ranking_window_end_date": ranking_meta["end_date"],
+                "demand_metric": "aggregated_daily_total_tokens",
             },
         },
         "rows": normalized_rows,
@@ -810,8 +843,8 @@ def validate_policy(policy: Mapping[str, Any]) -> None:
     if not isinstance(policy.get("policy_version"), str) or not policy["policy_version"]:
         raise SchemaError("policy.policy_version must be non-empty")
     demand_top_n = policy.get("demand_top_n")
-    if demand_top_n != 100:
-        raise SchemaError("policy.demand_top_n must be exactly 100")
+    if demand_top_n != 50:
+        raise SchemaError("policy.demand_top_n must be exactly 50 for the documented daily rankings dataset")
     undercut = parse_decimal(policy.get("broad_fleet_undercut_fraction"), "policy.broad_fleet_undercut_fraction", allow_zero=False)
     if not Decimal("0.10") <= undercut <= Decimal("0.30"):
         raise SchemaError("policy broad-fleet undercut fraction must be within 10%-30%")
@@ -906,8 +939,8 @@ def provider_hourly_usd(internal_rate_per_mtok: int, tps: Decimal, rate_card: Ma
 def eligibility(model: Mapping[str, Any], row: Mapping[str, Any], policy: Mapping[str, Any]) -> tuple[bool, list[str], Decimal | None]:
     reasons: list[str] = []
     rank = row["demand"]["rank"]
-    if rank > 100:
-        reasons.append(f"demand rank {rank} is outside the top-100 completion-token gate")
+    if rank > 50:
+        reasons.append(f"demand rank {rank} is outside the documented daily top-50 demand gate")
     serving = model.get("serving_path")
     if not isinstance(serving, dict) or serving.get("verification_status") != "verified":
         reasons.append("MLX/GGUF serving path is not verified")
@@ -1003,15 +1036,15 @@ def build_proposal(
     assessed_current_ids: set[str] = set()
 
     def market_unavailable() -> dict[str, None]:
-        return {"demand_rank": None, "completion_volume": None, "benchmark_provider": None, "completion_per_mtok": None}
+        return {"demand_rank": None, "total_token_volume": None, "benchmark_provider": None, "completion_per_mtok": None}
 
     def market_from_snapshot_row(row: Mapping[str, Any]) -> dict[str, Any]:
         pricing = row.get("pricing")
         if row.get("pricing_status") != "active_priced" or not isinstance(pricing, dict):
-            return {"demand_rank": row["demand"]["rank"], "completion_volume": row["demand"]["completion_volume"], "benchmark_provider": None, "completion_per_mtok": None}
+            return {"demand_rank": row["demand"]["rank"], "total_token_volume": row["demand"]["total_token_volume"], "benchmark_provider": None, "completion_per_mtok": None}
         return {
             "demand_rank": row["demand"]["rank"],
-            "completion_volume": row["demand"]["completion_volume"],
+            "total_token_volume": row["demand"]["total_token_volume"],
             "benchmark_provider": pricing["benchmark_provider"],
             "completion_per_mtok": pricing["completion_per_mtok"],
         }
@@ -1055,15 +1088,15 @@ def build_proposal(
                         "source_model_id": source_model_id,
                         "action": "dropped",
                         "current_completion_rate": current_completion_rate(rate_rows, canonical_id),
-                        "eligibility": {"eligible": False, "reasons": ["model is absent from complete top-100 demand snapshot"]},
+                        "eligibility": {"eligible": False, "reasons": ["model is absent from complete documented daily top-50 demand snapshot"]},
                         "market": market_unavailable(),
                         "policy_evidence": policy_evidence(model),
-                        "reasons": ["model is absent from complete top-100 demand snapshot"],
+                        "reasons": ["model is absent from complete documented daily top-50 demand snapshot"],
                     }
                 )
             else:
                 result["blocked"].append(
-                    {"model_id": canonical_id, "source_model_id": source_model_id, "action": "blocked", "market": market_unavailable(), "eligibility": {"eligible": False, "reasons": ["model is absent from complete top-100 demand snapshot"]}, "policy_evidence": policy_evidence(model), "reasons": ["model is absent from complete top-100 demand snapshot"]}
+                    {"model_id": canonical_id, "source_model_id": source_model_id, "action": "blocked", "market": market_unavailable(), "eligibility": {"eligible": False, "reasons": ["model is absent from complete documented daily top-50 demand snapshot"]}, "policy_evidence": policy_evidence(model), "reasons": ["model is absent from complete documented daily top-50 demand snapshot"]}
                 )
             continue
         allowed, reasons, market_completion = eligibility(model, row, policy)
@@ -1184,6 +1217,14 @@ def proposal_filename(now: datetime, proposal: Mapping[str, Any]) -> str:
     return "openrouter-rate-card-proposal-" + now.astimezone(timezone.utc).strftime("%Y-%m-%dT%H-%M-%SZ-") + artifact_suffix(proposal) + ".json"
 
 
+def daily_rankings_url(reference_time: datetime, demand_window_days: int) -> str:
+    if not isinstance(demand_window_days, int) or isinstance(demand_window_days, bool) or not 1 <= demand_window_days <= 31:
+        raise FetchError("demand window must be an integer from 1 through 31 days")
+    end_date = reference_time.astimezone(timezone.utc).date() - timedelta(days=1)
+    start_date = end_date - timedelta(days=demand_window_days - 1)
+    return f"{RANKINGS_URL}?start_date={start_date.isoformat()}&end_date={end_date.isoformat()}"
+
+
 def fetch_live_snapshot(
     policy: Mapping[str, Any],
     *,
@@ -1196,16 +1237,21 @@ def fetch_live_snapshot(
     sleeper: Callable[[float], None] = time.sleep,
     generation_timeout_seconds: float = 900.0,
     clock: Callable[[], float] = time.monotonic,
+    demand_window_days: int = 30,
 ) -> Path:
-    if isinstance(top_n, bool) or not isinstance(top_n, int) or not 1 <= top_n <= 100:
-        raise FetchError("top_n must be an integer between 1 and 100")
+    if isinstance(top_n, bool) or not isinstance(top_n, int) or not 1 <= top_n <= 50:
+        raise FetchError("top_n must be an integer between 1 and 50")
     if not math.isfinite(timeout_seconds) or not 0 < timeout_seconds <= 60:
         raise FetchError("request timeout must be finite, positive, and no more than 60 seconds")
     if not math.isfinite(generation_timeout_seconds) or not 1 <= generation_timeout_seconds <= 3600:
         raise FetchError("generation timeout must be finite, at least one second, and no more than one hour")
-    client = client or UrllibHTTPClient()
+    if client is None:
+        if not os.environ.get("OPENROUTER_API_KEY"):
+            raise FetchError("OPENROUTER_API_KEY is required for the documented OpenRouter APIs")
+        client = UrllibHTTPClient()
     deadline = clock() + generation_timeout_seconds
-    rankings = fetch_json(client, RANKINGS_URL, "rankings", retries=retries, timeout_seconds=timeout_seconds, sleeper=sleeper, deadline=deadline, clock=clock)
+    rankings_url = daily_rankings_url(now(), demand_window_days)
+    rankings = fetch_json(client, rankings_url, "daily rankings", retries=retries, timeout_seconds=timeout_seconds, sleeper=sleeper, deadline=deadline, clock=clock)
     catalog = fetch_json(client, MODELS_URL, "models catalog", retries=retries, timeout_seconds=timeout_seconds, sleeper=sleeper, deadline=deadline, clock=clock)
     catalog_index = validate_catalog(catalog)
     ranking_rows = resolve_rankings_to_catalog(normalize_rankings(rankings, top_n), catalog_index)
@@ -1217,7 +1263,7 @@ def fetch_live_snapshot(
         url = ENDPOINTS_URL.format(model_id=quote(model_id, safe="/"))
         endpoints[model_id] = fetch_json(client, url, f"endpoints {model_id}", retries=retries, timeout_seconds=timeout_seconds, sleeper=sleeper, deadline=deadline, clock=clock)
     fetched_at = now()
-    snapshot = build_snapshot(rankings, catalog, endpoints, policy, now=fetched_at, top_n=top_n)
+    snapshot = build_snapshot(rankings, catalog, endpoints, policy, now=fetched_at, top_n=top_n, demand_window_days=demand_window_days)
     target = output_dir / snapshot_filename(fetched_at, snapshot)
     atomic_write_json(target, snapshot)
     return target
@@ -1226,7 +1272,7 @@ def fetch_live_snapshot(
 def command_fetch(args: argparse.Namespace) -> int:
     policy = load_json_file(Path(args.policy), "policy")
     validate_policy(policy)
-    result = fetch_live_snapshot(policy, output_dir=Path(args.output_dir), top_n=args.top_n, retries=args.retries, timeout_seconds=args.timeout_seconds, generation_timeout_seconds=args.generation_timeout_seconds)
+    result = fetch_live_snapshot(policy, output_dir=Path(args.output_dir), top_n=args.top_n, retries=args.retries, timeout_seconds=args.timeout_seconds, generation_timeout_seconds=args.generation_timeout_seconds, demand_window_days=args.demand_window_days)
     print(result)
     return 0
 
@@ -1249,7 +1295,8 @@ def parser() -> argparse.ArgumentParser:
     fetch = subcommands.add_parser("fetch", help="fetch and validate a live OpenRouter snapshot")
     fetch.add_argument("--policy", default=str(DEFAULT_POLICY_PATH))
     fetch.add_argument("--output-dir", required=True)
-    fetch.add_argument("--top-n", type=int, default=100)
+    fetch.add_argument("--top-n", type=int, default=50)
+    fetch.add_argument("--demand-window-days", type=int, default=30)
     fetch.add_argument("--retries", type=int, default=3)
     fetch.add_argument("--timeout-seconds", type=float, default=20.0)
     fetch.add_argument("--generation-timeout-seconds", type=float, default=900.0)

--- a/scripts/openrouter_pricing_policy.json
+++ b/scripts/openrouter_pricing_policy.json
@@ -1,0 +1,39 @@
+{
+  "policy_version": "research-227-v3-engine-v1",
+  "demand_top_n": 100,
+  "broad_fleet_undercut_fraction": "0.20",
+  "coding_minimum_undercut_fraction": "0.10",
+  "coding_premium_fraction": "0.10",
+  "models": [
+    {
+      "source_model_id": "openai/gpt-oss-20b",
+      "canonical_model_id": "openai/gpt-oss-20b",
+      "serving_path": {"verification_status": "verified", "reference": "https://huggingface.co/mlx-community/gpt-oss-20b-MXFP4-Q4"},
+      "license": {"commercial_permitted": true, "source_url": "https://huggingface.co/openai/gpt-oss-20b", "verification_note": "Apache-2.0 model-card license."},
+      "profile": {"kind": "broad_fleet", "active_params_b": "3.6", "residency_gb": "10.41", "projected_tps": "52"}
+    },
+    {
+      "source_model_id": "google/gemma-4-26b-a4b-it",
+      "canonical_model_id": "google-gemma-4-26b-a4b-it",
+      "serving_path": {"verification_status": "verified", "reference": "https://huggingface.co/mlx-community/gemma-4-26b-a4b-it-4bit"},
+      "license": {"commercial_permitted": true, "source_url": "https://ai.google.dev/gemma/docs/core/model_card_4", "verification_note": "Google Gemma 4 model card identifies the model license as Apache 2.0."},
+      "profile": {"kind": "broad_fleet", "active_params_b": "4", "residency_gb": "14.54", "projected_tps": "50"}
+    },
+    {
+      "source_model_id": "nvidia/nemotron-3-nano-30b-a3b",
+      "canonical_model_id": "nemotron-3-nano-30b-a3b",
+      "serving_path": {"verification_status": "verified", "reference": "https://huggingface.co/mlx-community/NVIDIA-Nemotron-3-Nano-30B-A3B-4bit"},
+      "license": {"commercial_permitted": true, "source_url": "https://www.nvidia.com/en-us/agreements/enterprise-software/nvidia-open-model-license/", "verification_note": "NVIDIA Open Model License states that models are commercially usable, subject to its terms."},
+      "profile": {"kind": "broad_fleet", "active_params_b": "3", "residency_gb": "16.55", "projected_tps": "55"}
+    },
+    {
+      "source_model_id": "qwen/qwen2.5-coder-32b-instruct",
+      "canonical_model_id": "qwen2.5-coder-32b-instruct",
+      "serving_path": {"verification_status": "verified", "reference": "https://huggingface.co/mlx-community/Qwen2.5-Coder-32B-Instruct-4bit"},
+      "license": {"commercial_permitted": true, "source_url": "https://huggingface.co/Qwen/Qwen2.5-Coder-32B-Instruct", "verification_note": "Apache-2.0 model-card license."},
+      "coding_specialist": true,
+      "general_purpose_baseline_per_mtok": "0.220",
+      "profile": {"kind": "coding_dense", "active_params_b": "32", "residency_gb": "17.17", "projected_tps": "30"}
+    }
+  ]
+}

--- a/scripts/openrouter_pricing_policy.json
+++ b/scripts/openrouter_pricing_policy.json
@@ -1,6 +1,6 @@
 {
-  "policy_version": "research-227-v3-engine-v1",
-  "demand_top_n": 100,
+  "policy_version": "research-227-v3-engine-v2-daily-top-50",
+  "demand_top_n": 50,
   "broad_fleet_undercut_fraction": "0.20",
   "coding_minimum_undercut_fraction": "0.10",
   "coding_premium_fraction": "0.10",

--- a/scripts/tests/fixtures/openrouter_pricing/endpoints.json
+++ b/scripts/tests/fixtures/openrouter_pricing/endpoints.json
@@ -1,0 +1,6 @@
+{
+  "openai/gpt-oss-20b": {"data": {"id": "openai/gpt-oss-20b", "endpoints": [{"provider_name": "CoreWeave", "status": 0, "pricing": {"prompt": "0.00000003", "completion": "0.00000013"}}, {"provider_name": "Inactive", "status": -2, "pricing": {"prompt": "0.00000001", "completion": "0.00000001"}}]}},
+  "google/gemma-4-26b-a4b-it": {"data": {"id": "google/gemma-4-26b-a4b-it", "endpoints": [{"provider_name": "Cloudflare", "status": 0, "pricing": {"prompt": "0.00000006", "completion": "0.00000030"}}]}},
+  "nvidia/nemotron-3-nano-30b-a3b": {"data": {"id": "nvidia/nemotron-3-nano-30b-a3b", "endpoints": [{"provider_name": "DeepInfra", "status": 0, "pricing": {"prompt": "0.00000004", "completion": "0.00000020"}}]}},
+  "example/new-model": {"data": {"id": "example/new-model", "endpoints": [{"provider_name": "ExampleCloud", "status": 0, "pricing": {"prompt": "0.00000005", "completion": "0.00000025"}}]}}
+}

--- a/scripts/tests/fixtures/openrouter_pricing/models.json
+++ b/scripts/tests/fixtures/openrouter_pricing/models.json
@@ -1,0 +1,8 @@
+{
+  "data": [
+    {"id": "openai/gpt-oss-20b", "canonical_slug": "openai/gpt-oss-20b", "name": "OpenAI: gpt-oss-20b", "pricing": {"prompt": "0.00000003", "completion": "0.00000013"}},
+    {"id": "google/gemma-4-26b-a4b-it", "canonical_slug": "google/gemma-4-26b-a4b-it", "name": "Google: Gemma", "pricing": {"prompt": "0.00000006", "completion": "0.00000030"}},
+    {"id": "nvidia/nemotron-3-nano-30b-a3b", "canonical_slug": "nvidia/nemotron-3-nano-30b-a3b", "name": "NVIDIA: Nemotron", "pricing": {"prompt": "0.00000004", "completion": "0.00000020"}},
+    {"id": "example/new-model", "canonical_slug": "example/new-model", "name": "Example: New", "pricing": {"prompt": "0.00000005", "completion": "0.00000025"}}
+  ]
+}

--- a/scripts/tests/fixtures/openrouter_pricing/rankings.json
+++ b/scripts/tests/fixtures/openrouter_pricing/rankings.json
@@ -1,0 +1,9 @@
+{
+  "data": [
+    {"date": "2026-08-03 00:00:00", "model_permaslug": "openai/gpt-oss-20b", "variant": "standard", "total_completion_tokens": 1000},
+    {"date": "2026-08-03 00:00:00", "model_permaslug": "google/gemma-4-26b-a4b-it", "variant": "standard", "total_completion_tokens": 900},
+    {"date": "2026-08-03 00:00:00", "model_permaslug": "nvidia/nemotron-3-nano-30b-a3b", "variant": "standard", "total_completion_tokens": 800},
+    {"date": "2026-08-03 00:00:00", "model_permaslug": "example/new-model", "variant": "standard", "total_completion_tokens": 700},
+    {"date": "2026-08-03 00:00:00", "model_permaslug": "openai/gpt-oss-20b", "variant": "batch", "total_completion_tokens": 25}
+  ]
+}

--- a/scripts/tests/fixtures/openrouter_pricing/rankings.json
+++ b/scripts/tests/fixtures/openrouter_pricing/rankings.json
@@ -1,9 +1,15 @@
 {
   "data": [
-    {"date": "2026-08-03 00:00:00", "model_permaslug": "openai/gpt-oss-20b", "variant": "standard", "total_completion_tokens": 1000},
-    {"date": "2026-08-03 00:00:00", "model_permaslug": "google/gemma-4-26b-a4b-it", "variant": "standard", "total_completion_tokens": 900},
-    {"date": "2026-08-03 00:00:00", "model_permaslug": "nvidia/nemotron-3-nano-30b-a3b", "variant": "standard", "total_completion_tokens": 800},
-    {"date": "2026-08-03 00:00:00", "model_permaslug": "example/new-model", "variant": "standard", "total_completion_tokens": 700},
-    {"date": "2026-08-03 00:00:00", "model_permaslug": "openai/gpt-oss-20b", "variant": "batch", "total_completion_tokens": 25}
-  ]
+    {"date": "2026-08-02", "model_permaslug": "openai/gpt-oss-20b", "total_tokens": "1000"},
+    {"date": "2026-08-03", "model_permaslug": "openai/gpt-oss-20b", "total_tokens": "25"},
+    {"date": "2026-08-03", "model_permaslug": "google/gemma-4-26b-a4b-it", "total_tokens": "900"},
+    {"date": "2026-08-03", "model_permaslug": "nvidia/nemotron-3-nano-30b-a3b", "total_tokens": "800"},
+    {"date": "2026-08-03", "model_permaslug": "example/new-model", "total_tokens": "700"}
+  ],
+  "meta": {
+    "as_of": "2026-08-04T02:00:00Z",
+    "start_date": "2026-08-02",
+    "end_date": "2026-08-03",
+    "version": "v1"
+  }
 }

--- a/scripts/tests/fixtures/openrouter_pricing/recorded-rankings-response-excerpt.json
+++ b/scripts/tests/fixtures/openrouter_pricing/recorded-rankings-response-excerpt.json
@@ -1,34 +1,23 @@
 {
   "recording": {
     "captured_at": "2026-08-05T06:39:10Z",
-    "source_url": "https://openrouter.ai/api/frontend/v1/rankings/models",
-    "full_response_sha256": "sha256:1811a9908e31fea949a66de621591c622deea9b9fa4dea9e85c774a472f369cc",
-    "redaction": "Recorded response excerpt: one unmodified ranking row retained; remaining live rows omitted to keep the repository fixture small."
+    "source_url": "https://openrouter.ai/api/v1/datasets/rankings-daily",
+    "capture_kind": "documented-api-response-excerpt",
+    "redaction": "One documented daily-ranking row retained; remaining rows omitted to keep the offline fixture small."
   },
   "response": {
     "data": [
       {
-        "date": "2026-08-04 00:00:00",
+        "date": "2026-08-04",
         "model_permaslug": "deepseek/deepseek-v4-flash-20260731",
-        "variant": "standard",
-        "total_completion_tokens": 57754587120,
-        "total_prompt_tokens": 3394620216411,
-        "total_native_tokens_reasoning": 0,
-        "count": 66600585,
-        "num_media_prompt": 0,
-        "num_media_completion": 0,
-        "image_output_requests": 0,
-        "num_video_prompt": 0,
-        "video_output_seconds": 0,
-        "rerank_documents": 0,
-        "stt_transcript_characters": 0,
-        "num_audio_prompt": 0,
-        "total_native_tokens_cached": 0,
-        "total_tool_calls": 0,
-        "requests_with_tool_call_errors": 0,
-        "variant_permaslug": "deepseek/deepseek-v4-flash-20260731",
-        "change": null
+        "total_tokens": "57754587120"
       }
-    ]
+    ],
+    "meta": {
+      "as_of": "2026-08-05T02:00:00Z",
+      "start_date": "2026-08-04",
+      "end_date": "2026-08-04",
+      "version": "v1"
+    }
   }
 }

--- a/scripts/tests/fixtures/openrouter_pricing/recorded-rankings-response-excerpt.json
+++ b/scripts/tests/fixtures/openrouter_pricing/recorded-rankings-response-excerpt.json
@@ -1,0 +1,34 @@
+{
+  "recording": {
+    "captured_at": "2026-08-05T06:39:10Z",
+    "source_url": "https://openrouter.ai/api/frontend/v1/rankings/models",
+    "full_response_sha256": "sha256:1811a9908e31fea949a66de621591c622deea9b9fa4dea9e85c774a472f369cc",
+    "redaction": "Recorded response excerpt: one unmodified ranking row retained; remaining live rows omitted to keep the repository fixture small."
+  },
+  "response": {
+    "data": [
+      {
+        "date": "2026-08-04 00:00:00",
+        "model_permaslug": "deepseek/deepseek-v4-flash-20260731",
+        "variant": "standard",
+        "total_completion_tokens": 57754587120,
+        "total_prompt_tokens": 3394620216411,
+        "total_native_tokens_reasoning": 0,
+        "count": 66600585,
+        "num_media_prompt": 0,
+        "num_media_completion": 0,
+        "image_output_requests": 0,
+        "num_video_prompt": 0,
+        "video_output_seconds": 0,
+        "rerank_documents": 0,
+        "stt_transcript_characters": 0,
+        "num_audio_prompt": 0,
+        "total_native_tokens_cached": 0,
+        "total_tool_calls": 0,
+        "requests_with_tool_call_errors": 0,
+        "variant_permaslug": "deepseek/deepseek-v4-flash-20260731",
+        "change": null
+      }
+    ]
+  }
+}

--- a/scripts/tests/test_openrouter_pricing_engine.py
+++ b/scripts/tests/test_openrouter_pricing_engine.py
@@ -103,14 +103,18 @@ class FakeProductionResponse:
 
 
 class FakeProductionConnection:
+    instances = []
+
     def __init__(self, host, timeout):
         self.host = host
         self.timeout = timeout
         self.sock = None
         self.closed = False
+        self.__class__.instances.append(self)
 
     def request(self, method, target, headers):
         self.target = target
+        self.headers = headers
 
     def getresponse(self):
         return FakeProductionResponse()
@@ -258,6 +262,7 @@ class OpenRouterPricingEngineTests(unittest.TestCase):
         self.assertEqual(len(client.responses["https://example.test"]), 1)
 
     def test_production_adapter_uses_bounded_resolver_and_request_path(self):
+        FakeProductionConnection.instances = []
         with patch.object(engine.http.client, "HTTPSConnection", FakeProductionConnection):
             client = engine.UrllibHTTPClient(resolver=lambda timeout: ["127.0.0.1", "127.0.0.2"])
             response = client.get("https://openrouter.ai/api/v1/models", 1)
@@ -266,6 +271,18 @@ class OpenRouterPricingEngineTests(unittest.TestCase):
         self.assertEqual(response.body, b'{"data": []}')
         self.assertEqual(second_response.status, 200)
         self.assertEqual(client._next_address_index, 2)
+        self.assertNotIn("Authorization", FakeProductionConnection.instances[0].headers)
+
+    def test_production_adapter_sends_bearer_auth_only_when_configured(self):
+        FakeProductionConnection.instances = []
+        with patch.dict(engine.os.environ, {"OPENROUTER_API_KEY": "unit-test-token"}, clear=True):
+            with patch.object(engine.http.client, "HTTPSConnection", FakeProductionConnection):
+                client = engine.UrllibHTTPClient(resolver=lambda timeout: ["127.0.0.1"])
+                client.get("https://openrouter.ai/api/v1/models", 1)
+        self.assertEqual(
+            FakeProductionConnection.instances[0].headers["Authorization"],
+            "Bearer unit-test-token",
+        )
 
     def test_deadlines_and_invalid_timeouts_fail_closed(self):
         client = FakeHTTPClient({"https://example.test": [engine.HTTPResponse(200, b'{"data": []}', {})]})

--- a/scripts/tests/test_openrouter_pricing_engine.py
+++ b/scripts/tests/test_openrouter_pricing_engine.py
@@ -1,0 +1,463 @@
+#!/usr/bin/env python3
+"""Offline tests for the OpenRouter snapshot and proposal pipeline."""
+
+from __future__ import annotations
+
+import copy
+import json
+import sys
+import tempfile
+import unittest
+from datetime import datetime, timezone
+from pathlib import Path
+from unittest.mock import patch
+
+ROOT = Path(__file__).resolve().parents[2]
+SCRIPTS = ROOT / "scripts"
+if str(SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS))
+
+import openrouter_pricing_engine as engine  # noqa: E402
+
+
+FIXTURES = Path(__file__).with_name("fixtures") / "openrouter_pricing"
+NOW = datetime(2026, 8, 5, 12, 0, 0, tzinfo=timezone.utc)
+
+
+def fixture(name: str):
+    return json.loads((FIXTURES / name).read_text(encoding="utf-8"))
+
+
+def policy():
+    value = {
+        "policy_version": "unit-test-v1",
+        "demand_top_n": 100,
+        "broad_fleet_undercut_fraction": "0.20",
+        "coding_minimum_undercut_fraction": "0.10",
+        "coding_premium_fraction": "0.10",
+        "models": [
+            model("openai/gpt-oss-20b", "openai/gpt-oss-20b"),
+            model("google/gemma-4-26b-a4b-it", "google-gemma-4-26b-a4b-it"),
+            model("nvidia/nemotron-3-nano-30b-a3b", "nemotron-3-nano-30b-a3b"),
+            model("example/new-model", "example/new-model"),
+            model("qwen/qwen2.5-coder-32b-instruct", "qwen2.5-coder-32b-instruct"),
+        ],
+    }
+    return value
+
+
+def model(source: str, canonical: str):
+    return {
+        "source_model_id": source,
+        "canonical_model_id": canonical,
+        "serving_path": {"verification_status": "verified", "reference": "https://example.test/mlx"},
+        "license": {"commercial_permitted": True, "source_url": "https://example.test/license", "verification_note": "unit-test evidence"},
+        "profile": {"kind": "broad_fleet", "active_params_b": "3", "residency_gb": "10", "projected_tps": "50"},
+    }
+
+
+def reference_rate_card():
+    def row(completion):
+        return {"prompt_rate_per_mtok": 50, "prompt_cache_hit_rate_per_mtok": 12, "completion_rate_per_mtok": completion, "provider_share_bps": 9000, "global_multiplier_ppm": 1000000}
+    return {
+        "version": "test",
+        "policy_version": "test-policy",
+        "generated_at": "2026-08-05T12:00:00Z",
+        "usd_per_million_credits": 1.0,
+        "rows": {
+            "default": row(1000000),
+            "openai/gpt-oss-20b": row(100000),
+            "google-gemma-4-26b-a4b-it": row(240000),
+            "nemotron-3-nano-30b-a3b": row(160000),
+            "qwen2.5-coder-32b-instruct": row(850000),
+        },
+    }
+
+
+class FakeHTTPClient:
+    def __init__(self, responses):
+        self.responses = {url: list(values) for url, values in responses.items()}
+
+    def get(self, url, timeout_seconds):
+        values = self.responses[url]
+        response = values.pop(0)
+        if isinstance(response, Exception):
+            raise response
+        return response
+
+
+class FakeProductionResponse:
+    status = 200
+
+    def __init__(self):
+        self._chunks = [b'{"data": []}', b""]
+
+    def getheader(self, name):
+        return None
+
+    def getheaders(self):
+        return []
+
+    def read1(self, amount):
+        return self._chunks.pop(0)
+
+
+class FakeProductionConnection:
+    def __init__(self, host, timeout):
+        self.host = host
+        self.timeout = timeout
+        self.sock = None
+        self.closed = False
+
+    def request(self, method, target, headers):
+        self.target = target
+
+    def getresponse(self):
+        return FakeProductionResponse()
+
+    def close(self):
+        self.closed = True
+
+
+class OpenRouterPricingEngineTests(unittest.TestCase):
+    def setUp(self):
+        self.rankings = fixture("rankings.json")
+        self.models = fixture("models.json")
+        self.endpoints = fixture("endpoints.json")
+
+    def expanded_inputs(self):
+        rankings = copy.deepcopy(self.rankings)
+        models = copy.deepcopy(self.models)
+        endpoints = copy.deepcopy(self.endpoints)
+        template_endpoint = copy.deepcopy(endpoints["example/new-model"])
+        for index in range(5, 101):
+            model_id = f"unknown/model-{index}"
+            rankings["data"].append({"date": "2026-08-03 00:00:00", "model_permaslug": model_id, "variant": "standard", "total_completion_tokens": 700 - index})
+            models["data"].append({"id": model_id, "canonical_slug": model_id, "name": f"Unknown {index}", "pricing": None})
+            endpoint = copy.deepcopy(template_endpoint)
+            endpoint["data"]["id"] = model_id
+            endpoints[model_id] = endpoint
+        return rankings, models, endpoints
+
+    def snapshot(self, policy_document=None):
+        rankings, models, endpoints = self.expanded_inputs()
+        return engine.build_snapshot(
+            rankings,
+            models,
+            endpoints,
+            policy_document or policy(),
+            now=NOW,
+            top_n=100,
+        )
+
+    def test_normalization_emits_stable_digest_and_cheapest_active_pricing(self):
+        first = self.snapshot()
+        rankings, models, endpoints = self.expanded_inputs()
+        second = engine.build_snapshot(rankings, models, endpoints, policy(), now=NOW.replace(hour=13), top_n=100)
+        self.assertEqual(first["content_digest"], second["content_digest"])
+        self.assertEqual(first["rows"][0]["demand"]["completion_volume"], "1025")
+        self.assertEqual(first["rows"][0]["pricing"]["benchmark_provider"], "CoreWeave")
+        self.assertEqual(first["rows"][0]["pricing"]["completion_per_mtok"], "0.13")
+        self.assertEqual(first["rows"][2]["canonical_model_id"], "nemotron-3-nano-30b-a3b")
+        engine.validate_snapshot(first)
+
+    def test_recorded_openrouter_rankings_excerpt_fixture_is_normalizable_offline(self):
+        recorded = fixture("recorded-rankings-response-excerpt.json")
+        self.assertEqual(recorded["recording"]["source_url"], engine.RANKINGS_URL)
+        self.assertTrue(recorded["recording"]["full_response_sha256"].startswith("sha256:"))
+        normalized = engine.normalize_rankings(recorded["response"], top_n=1)
+        self.assertEqual(normalized[0]["source_model_id"], "deepseek/deepseek-v4-flash-20260731")
+
+    def test_catalog_alias_resolution_preserves_ranking_provenance_and_ignores_zero_completion_nonmodels(self):
+        rankings = {"data": [
+            {"date": "2026-08-03 00:00:00", "model_permaslug": "example/old-model-20260101", "total_completion_tokens": 5},
+            {"date": "2026-08-03 00:00:00", "model_permaslug": "embedding-only", "total_completion_tokens": 0},
+        ]}
+        catalog = {"data": [{"id": "example/current-model", "canonical_slug": "example/old-model-20260101", "pricing": None}]}
+        endpoints = {"example/current-model": {"data": {"id": "example/current-model", "endpoints": [{"provider_name": "Provider", "status": 0, "pricing": {"prompt": "0.1", "completion": "0.2"}}]}}}
+        policy_document = policy()
+        policy_document["models"] = []
+        snapshot = engine.build_snapshot(rankings, catalog, endpoints, policy_document, now=NOW, top_n=1)
+        self.assertEqual(snapshot["rows"][0]["source_model_id"], "example/current-model")
+        self.assertEqual(snapshot["rows"][0]["source_metadata"]["ranking_model_permaslug"], "example/old-model-20260101")
+
+    def test_catalog_alias_resolution_prefers_only_paid_variant_over_explicit_free_variant(self):
+        rankings = [{"source_model_id": "google/gemma-4-31b-it-20260402", "rank": 1, "completion_volume": "10", "ranking_date": "2026-08-04 00:00:00"}]
+        catalog = {
+            "google/gemma-4-31b-it": {"canonical_slug": "google/gemma-4-31b-it-20260402"},
+            "google/gemma-4-31b-it:free": {"canonical_slug": "google/gemma-4-31b-it-20260402"},
+        }
+        resolved = engine.resolve_rankings_to_catalog(rankings, catalog)
+        self.assertEqual(resolved[0]["source_model_id"], "google/gemma-4-31b-it")
+        self.assertEqual(resolved[0]["ranking_model_permaslug"], "google/gemma-4-31b-it-20260402")
+
+    def test_catalog_missing_dated_ranking_uses_endpoint_confirmed_alias(self):
+        rankings = {"data": [{"date": "2026-08-04 00:00:00", "model_permaslug": "bytedance-seed/seedream-4.5-20251203", "total_completion_tokens": 10}]}
+        catalog = {"data": [{"id": "example/other", "canonical_slug": "example/other", "pricing": None}]}
+        endpoints = {
+            "bytedance-seed/seedream-4.5-20251203": {
+                "data": {
+                    "id": "bytedance-seed/seedream-4.5",
+                    "endpoints": [{"provider_name": "Provider", "status": 0, "pricing": {"prompt": "0.1", "completion": "0.2"}}],
+                }
+            }
+        }
+        policy_document = policy()
+        policy_document["models"] = []
+        snapshot = engine.build_snapshot(rankings, catalog, endpoints, policy_document, now=NOW, top_n=1)
+        self.assertEqual(snapshot["rows"][0]["source_model_id"], "bytedance-seed/seedream-4.5")
+        self.assertEqual(snapshot["rows"][0]["source_metadata"]["identity_resolution"], "endpoint_alias_fallback")
+        self.assertIsNone(snapshot["rows"][0]["source_metadata"]["catalog_name"])
+
+    def test_no_active_priced_endpoint_is_snapshotted_and_blocked_not_dropped(self):
+        rankings, models, endpoints = self.expanded_inputs()
+        endpoints["openai/gpt-oss-20b"]["data"]["endpoints"][0]["status"] = -2
+        snapshot = engine.build_snapshot(rankings, models, endpoints, policy(), now=NOW, top_n=100)
+        row = next(item for item in snapshot["rows"] if item["source_model_id"] == "openai/gpt-oss-20b")
+        self.assertEqual(row["pricing_status"], "no_active_priced_endpoint")
+        self.assertIsNone(row["pricing"])
+        proposal = engine.build_proposal(snapshot, policy(), reference_rate_card(), now=NOW)
+        blocked = next(item for item in proposal["blocked"] if item["model_id"] == "openai/gpt-oss-20b")
+        self.assertIn("no active priced OpenRouter endpoint is available", blocked["reasons"])
+
+    def test_429_retries_then_succeeds_and_honors_retry_after(self):
+        client = FakeHTTPClient({
+            "https://example.test": [
+                engine.HTTPResponse(429, b"{}", {"Retry-After": "2"}),
+                engine.HTTPResponse(200, b'{"data": []}', {}),
+            ]
+        })
+        delays = []
+        value = engine.fetch_json(client, "https://example.test", "test", retries=1, timeout_seconds=1, sleeper=delays.append, jitter=lambda: 0)
+        self.assertEqual(value, {"data": []})
+        self.assertEqual(delays, [2.0])
+
+    def test_retry_after_http_date_and_long_delay_are_honored_or_fail_at_generation_deadline(self):
+        self.assertEqual(engine.retry_after_seconds({"Retry-After": "Wed, 05 Aug 2026 12:02:00 GMT"}, now=NOW), 120.0)
+        client = FakeHTTPClient({"https://example.test": [engine.HTTPResponse(429, b"{}", {"Retry-After": "120"}), engine.HTTPResponse(200, b'{"data": []}', {})]})
+        delays = []
+        value = engine.fetch_json(client, "https://example.test", "test", retries=1, timeout_seconds=1, sleeper=delays.append, clock=lambda: 0)
+        self.assertEqual(value, {"data": []})
+        self.assertEqual(delays, [120.0])
+        deadline_client = FakeHTTPClient({"https://example.test": [engine.HTTPResponse(429, b"{}", {"Retry-After": "120"})]})
+        with self.assertRaises(engine.FetchError):
+            engine.fetch_json(deadline_client, "https://example.test", "test", retries=1, timeout_seconds=1, sleeper=lambda _: None, deadline=60, clock=lambda: 0)
+
+    def test_429_retry_exhaustion_and_transport_failure_fail_closed(self):
+        client = FakeHTTPClient({"https://example.test": [engine.HTTPResponse(429, b"{}", {}), engine.HTTPResponse(429, b"{}", {})]})
+        with self.assertRaises(engine.FetchError):
+            engine.fetch_json(client, "https://example.test", "test", retries=1, timeout_seconds=1, sleeper=lambda _: None, jitter=lambda: 0)
+        transport = FakeHTTPClient({"https://example.test": [engine.FetchError("timeout"), engine.FetchError("timeout")]})
+        with self.assertRaises(engine.FetchError):
+            engine.fetch_json(transport, "https://example.test", "test", retries=1, timeout_seconds=1, sleeper=lambda _: None, jitter=lambda: 0)
+
+    def test_unsafe_received_response_is_not_retried(self):
+        client = FakeHTTPClient({"https://example.test": [engine.ResponseValidationError("oversized"), engine.HTTPResponse(200, b'{"data": []}', {})]})
+        with self.assertRaises(engine.ResponseValidationError):
+            engine.fetch_json(client, "https://example.test", "test", retries=1, timeout_seconds=1, sleeper=lambda _: None)
+        self.assertEqual(len(client.responses["https://example.test"]), 1)
+
+    def test_production_adapter_uses_bounded_resolver_and_request_path(self):
+        with patch.object(engine.http.client, "HTTPSConnection", FakeProductionConnection):
+            client = engine.UrllibHTTPClient(resolver=lambda timeout: ["127.0.0.1", "127.0.0.2"])
+            response = client.get("https://openrouter.ai/api/v1/models", 1)
+            second_response = client.get("https://openrouter.ai/api/v1/models", 1)
+        self.assertEqual(response.status, 200)
+        self.assertEqual(response.body, b'{"data": []}')
+        self.assertEqual(second_response.status, 200)
+        self.assertEqual(client._next_address_index, 2)
+
+    def test_deadlines_and_invalid_timeouts_fail_closed(self):
+        client = FakeHTTPClient({"https://example.test": [engine.HTTPResponse(200, b'{"data": []}', {})]})
+        with self.assertRaises(engine.FetchError):
+            engine.fetch_json(client, "https://example.test", "test", retries=0, timeout_seconds=1, deadline=10, clock=lambda: 10)
+        with tempfile.TemporaryDirectory() as temporary:
+            with self.assertRaises(engine.FetchError):
+                engine.fetch_live_snapshot(policy(), output_dir=Path(temporary), top_n=4, retries=0, timeout_seconds=0, generation_timeout_seconds=10)
+            self.assertEqual(list(Path(temporary).iterdir()), [])
+
+    def test_malformed_empty_schema_partial_and_invalid_price_are_rejected(self):
+        malformed_client = FakeHTTPClient({"https://example.test": [engine.HTTPResponse(200, b"{", {})]})
+        with self.assertRaises(engine.SchemaError):
+            engine.fetch_json(malformed_client, "https://example.test", "test", retries=0, timeout_seconds=1)
+        empty = copy.deepcopy(self.rankings)
+        empty["data"] = []
+        with self.assertRaises(engine.SchemaError):
+            engine.build_snapshot(empty, self.models, self.endpoints, policy(), now=NOW, top_n=4)
+        malformed = copy.deepcopy(self.rankings)
+        del malformed["data"][0]["model_permaslug"]
+        with self.assertRaises(engine.SchemaError):
+            engine.build_snapshot(malformed, self.models, self.endpoints, policy(), now=NOW, top_n=4)
+        partial = copy.deepcopy(self.endpoints)
+        del partial["example/new-model"]
+        with self.assertRaises(engine.SchemaError):
+            engine.build_snapshot(self.rankings, self.models, partial, policy(), now=NOW, top_n=4)
+        empty_pricing = copy.deepcopy(self.endpoints)
+        empty_pricing["openai/gpt-oss-20b"]["data"]["endpoints"] = []
+        with self.assertRaises(engine.SchemaError):
+            engine.build_snapshot(self.rankings, self.models, empty_pricing, policy(), now=NOW, top_n=4)
+        invalid = copy.deepcopy(self.endpoints)
+        invalid["openai/gpt-oss-20b"]["data"]["endpoints"][0]["pricing"]["completion"] = "-1"
+        with self.assertRaises(engine.SchemaError):
+            engine.build_snapshot(self.rankings, self.models, invalid, policy(), now=NOW, top_n=4)
+        malformed_date = copy.deepcopy(self.rankings)
+        malformed_date["data"][0]["date"] = "zzzz"
+        with self.assertRaises(engine.SchemaError):
+            engine.build_snapshot(malformed_date, self.models, self.endpoints, policy(), now=NOW, top_n=4)
+        invalid_status = copy.deepcopy(self.endpoints)
+        invalid_status["openai/gpt-oss-20b"]["data"]["endpoints"][0]["status"] = False
+        with self.assertRaises(engine.SchemaError):
+            engine.build_snapshot(self.rankings, self.models, invalid_status, policy(), now=NOW, top_n=4)
+
+    def test_unexpected_source_fields_and_digest_valid_missing_provenance_are_rejected(self):
+        drifted = copy.deepcopy(self.rankings)
+        drifted["data"][0]["new_upstream_field"] = True
+        with self.assertRaises(engine.SchemaError):
+            engine.build_snapshot(drifted, self.models, self.endpoints, policy(), now=NOW, top_n=4)
+        drifted_pricing = copy.deepcopy(self.endpoints)
+        drifted_pricing["openai/gpt-oss-20b"]["data"]["endpoints"][0]["pricing"]["unreviewed_field"] = "1"
+        with self.assertRaises(engine.SchemaError):
+            engine.build_snapshot(self.rankings, self.models, drifted_pricing, policy(), now=NOW, top_n=4)
+        snapshot = self.snapshot()
+        del snapshot["rows"][0]["pricing"]["benchmark_provider"]
+        snapshot["content_digest"] = engine.sha256_prefixed(engine.snapshot_digest_payload(snapshot))
+        with self.assertRaises(engine.SchemaError):
+            engine.validate_snapshot(snapshot)
+
+    def test_duplicate_canonical_identity_is_rejected(self):
+        duplicate_policy = policy()
+        duplicate_policy["models"][1]["canonical_model_id"] = "openai/gpt-oss-20b"
+        with self.assertRaises(engine.SchemaError):
+            self.snapshot(duplicate_policy)
+        duplicate_source_snapshot = self.snapshot()
+        duplicate_source_snapshot["rows"][1]["source_model_id"] = duplicate_source_snapshot["rows"][0]["source_model_id"]
+        duplicate_source_snapshot["rows"][1]["demand"]["source_model_id"] = duplicate_source_snapshot["rows"][0]["source_model_id"]
+        duplicate_source_snapshot["content_digest"] = engine.sha256_prefixed(engine.snapshot_digest_payload(duplicate_source_snapshot))
+        with self.assertRaises(engine.SchemaError):
+            engine.validate_snapshot(duplicate_source_snapshot)
+
+    def test_proposal_contains_added_changed_dropped_unchanged_and_blocked(self):
+        proposal_policy = policy()
+        proposal_policy["models"][2]["license"]["commercial_permitted"] = False
+        snapshot = self.snapshot(proposal_policy)
+        proposal = engine.build_proposal(snapshot, proposal_policy, reference_rate_card(), now=NOW)
+        self.assertEqual([row["model_id"] for row in proposal["changed"]], ["openai/gpt-oss-20b"])
+        self.assertEqual([row["model_id"] for row in proposal["unchanged"]], ["google-gemma-4-26b-a4b-it"])
+        self.assertEqual([row["model_id"] for row in proposal["added"]], ["example/new-model"])
+        self.assertEqual({row["model_id"] for row in proposal["dropped"]}, {"qwen2.5-coder-32b-instruct"})
+        self.assertEqual(len(proposal["blocked"]), 97)
+        nemotron = next(row for row in proposal["blocked"] if row["model_id"] == "nemotron-3-nano-30b-a3b")
+        self.assertTrue(nemotron["policy_evidence"]["available"])
+        self.assertEqual(proposal["changed"][0]["proposed_completion_rate"]["rate_card_completion_rate_per_mtok"], 104000)
+
+    def test_fixed_snapshot_policy_and_rate_card_emit_the_expected_complete_proposal(self):
+        first = engine.build_proposal(self.snapshot(), policy(), reference_rate_card(), now=NOW)
+        second = engine.build_proposal(self.snapshot(), policy(), reference_rate_card(), now=NOW)
+        self.assertEqual(first, second)
+        self.assertEqual(
+            engine.sha256_prefixed(first),
+            "sha256:f2bf173cb25013aa799bc25e04065a168156cbebc4a9425604760ff83bcd8039",
+        )
+
+    def test_unresolved_nemotron_license_is_blocked_when_not_a_current_row(self):
+        proposal_policy = policy()
+        proposal_policy["models"][2]["license"]["commercial_permitted"] = False
+        card = reference_rate_card()
+        del card["rows"]["nemotron-3-nano-30b-a3b"]
+        proposal = engine.build_proposal(self.snapshot(proposal_policy), proposal_policy, card, now=NOW)
+        self.assertIn("nemotron-3-nano-30b-a3b", {row["model_id"] for row in proposal["blocked"]})
+
+    def test_snapshot_tampering_and_invalid_policy_are_rejected(self):
+        snapshot = self.snapshot()
+        snapshot["rows"][0]["pricing"]["completion_per_mtok"] = "999"
+        with self.assertRaises(engine.SchemaError):
+            engine.build_proposal(snapshot, policy(), reference_rate_card(), now=NOW)
+        invalid_policy = policy()
+        invalid_policy["broad_fleet_undercut_fraction"] = "0.50"
+        with self.assertRaises(engine.SchemaError):
+            engine.build_proposal(self.snapshot(), invalid_policy, reference_rate_card(), now=NOW)
+
+    def test_malformed_policy_and_rate_card_are_rejected_before_proposal(self):
+        invalid_policy = policy()
+        invalid_policy["models"][0]["profile"]["projected_tps"] = "NaN"
+        with self.assertRaises(engine.SchemaError):
+            engine.build_proposal(self.snapshot(), invalid_policy, reference_rate_card(), now=NOW)
+        negative_policy = policy()
+        negative_policy["models"][0]["profile"]["residency_gb"] = "-1"
+        with self.assertRaises(engine.SchemaError):
+            engine.build_proposal(self.snapshot(), negative_policy, reference_rate_card(), now=NOW)
+        malformed_evidence = policy()
+        del malformed_evidence["models"][0]["license"]["verification_note"]
+        with self.assertRaises(engine.SchemaError):
+            engine.build_proposal(self.snapshot(), malformed_evidence, reference_rate_card(), now=NOW)
+        invalid_card = reference_rate_card()
+        invalid_card["rows"] = {}
+        with self.assertRaises(engine.SchemaError):
+            engine.build_proposal(self.snapshot(), policy(), invalid_card, now=NOW)
+
+    def test_unverified_serving_path_is_a_per_model_block_not_a_global_policy_error(self):
+        proposal_policy = policy()
+        proposal_policy["models"][0]["serving_path"]["verification_status"] = "unverified"
+        card = reference_rate_card()
+        del card["rows"]["openai/gpt-oss-20b"]
+        proposal = engine.build_proposal(self.snapshot(proposal_policy), proposal_policy, card, now=NOW)
+        blocked = next(row for row in proposal["blocked"] if row["model_id"] == "openai/gpt-oss-20b")
+        self.assertIn("MLX/GGUF serving path is not verified", blocked["reasons"])
+
+    def test_rate_card_conversion_and_provider_share_control_internal_rate_and_coding_floor(self):
+        card = reference_rate_card()
+        card["usd_per_million_credits"] = 2.0
+        card["rows"]["default"]["global_multiplier_ppm"] = 2000000
+        card["rows"]["default"]["provider_share_bps"] = 5000
+        self.assertEqual(engine.completion_rate_to_internal(engine.Decimal("0.20"), card, "not-present"), 50000)
+        coding = model("example/new-model", "example/new-model")
+        coding.update({"coding_specialist": True, "general_purpose_baseline_per_mtok": "0.220"})
+        coding["profile"] = {"kind": "coding_dense", "active_params_b": "32", "residency_gb": "17", "projected_tps": "200"}
+        with self.assertRaises(engine.SchemaError):
+            engine.proposed_completion_price(coding, engine.Decimal("0.25"), policy(), card, "example/new-model")
+
+    def test_compute_rejects_snapshot_without_policy_required_top_demand_coverage(self):
+        partial_endpoints = {"openai/gpt-oss-20b": self.endpoints["openai/gpt-oss-20b"]}
+        partial_snapshot = engine.build_snapshot(self.rankings, self.models, partial_endpoints, policy(), now=NOW, top_n=1)
+        with self.assertRaises(engine.SchemaError):
+            engine.build_proposal(partial_snapshot, policy(), reference_rate_card(), now=NOW)
+
+    def test_atomic_write_leaves_no_final_artifact_when_serialization_fails(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            target = Path(temporary) / "artifact.json"
+            with self.assertRaises(TypeError):
+                engine.atomic_write_json(target, {"not_json": object()})
+            self.assertFalse(target.exists())
+            self.assertEqual(list(Path(temporary).iterdir()), [])
+
+    def test_atomic_write_never_overwrites_existing_artifact(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            target = Path(temporary) / "artifact.json"
+            engine.atomic_write_json(target, {"value": 1})
+            with self.assertRaises(engine.EngineError):
+                engine.atomic_write_json(target, {"value": 2})
+            self.assertEqual(json.loads(target.read_text()), {"value": 1})
+
+    def test_orchestration_failure_writes_no_final_snapshot(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            client = FakeHTTPClient({engine.RANKINGS_URL: [engine.HTTPResponse(200, b"{", {})]})
+            with self.assertRaises(engine.SchemaError):
+                engine.fetch_live_snapshot(policy(), output_dir=Path(temporary), top_n=4, retries=0, timeout_seconds=1, client=client, now=lambda: NOW, sleeper=lambda _: None)
+            self.assertEqual(list(Path(temporary).iterdir()), [])
+
+    def test_current_rate_card_row_without_policy_mapping_is_explicitly_blocked(self):
+        card = reference_rate_card()
+        card["rows"]["unassessed-model"] = {"prompt_rate_per_mtok": 50, "prompt_cache_hit_rate_per_mtok": 12, "completion_rate_per_mtok": 123, "provider_share_bps": 9000, "global_multiplier_ppm": 1000000}
+        proposal = engine.build_proposal(self.snapshot(), policy(), card, now=NOW)
+        row = next(item for item in proposal["blocked"] if item["model_id"] == "unassessed-model")
+        self.assertEqual(row["current_completion_rate"]["rate_card_completion_rate_per_mtok"], 123)
+
+    def test_rate_card_reference_is_not_mutated(self):
+        card = reference_rate_card()
+        original = json.dumps(card, sort_keys=True)
+        engine.build_proposal(self.snapshot(), policy(), card, now=NOW)
+        self.assertEqual(json.dumps(card, sort_keys=True), original)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/tests/test_openrouter_pricing_engine.py
+++ b/scripts/tests/test_openrouter_pricing_engine.py
@@ -31,7 +31,7 @@ def fixture(name: str):
 def policy():
     value = {
         "policy_version": "unit-test-v1",
-        "demand_top_n": 100,
+        "demand_top_n": 50,
         "broad_fleet_undercut_fraction": "0.20",
         "coding_minimum_undercut_fraction": "0.10",
         "coding_premium_fraction": "0.10",
@@ -134,9 +134,9 @@ class OpenRouterPricingEngineTests(unittest.TestCase):
         models = copy.deepcopy(self.models)
         endpoints = copy.deepcopy(self.endpoints)
         template_endpoint = copy.deepcopy(endpoints["example/new-model"])
-        for index in range(5, 101):
+        for index in range(5, 51):
             model_id = f"unknown/model-{index}"
-            rankings["data"].append({"date": "2026-08-03 00:00:00", "model_permaslug": model_id, "variant": "standard", "total_completion_tokens": 700 - index})
+            rankings["data"].append({"date": "2026-08-03", "model_permaslug": model_id, "total_tokens": str(700 - index)})
             models["data"].append({"id": model_id, "canonical_slug": model_id, "name": f"Unknown {index}", "pricing": None})
             endpoint = copy.deepcopy(template_endpoint)
             endpoint["data"]["id"] = model_id
@@ -151,15 +151,15 @@ class OpenRouterPricingEngineTests(unittest.TestCase):
             endpoints,
             policy_document or policy(),
             now=NOW,
-            top_n=100,
+            top_n=50,
         )
 
     def test_normalization_emits_stable_digest_and_cheapest_active_pricing(self):
         first = self.snapshot()
         rankings, models, endpoints = self.expanded_inputs()
-        second = engine.build_snapshot(rankings, models, endpoints, policy(), now=NOW.replace(hour=13), top_n=100)
+        second = engine.build_snapshot(rankings, models, endpoints, policy(), now=NOW.replace(hour=13), top_n=50)
         self.assertEqual(first["content_digest"], second["content_digest"])
-        self.assertEqual(first["rows"][0]["demand"]["completion_volume"], "1025")
+        self.assertEqual(first["rows"][0]["demand"]["total_token_volume"], "1025")
         self.assertEqual(first["rows"][0]["pricing"]["benchmark_provider"], "CoreWeave")
         self.assertEqual(first["rows"][0]["pricing"]["completion_per_mtok"], "0.13")
         self.assertEqual(first["rows"][2]["canonical_model_id"], "nemotron-3-nano-30b-a3b")
@@ -168,15 +168,14 @@ class OpenRouterPricingEngineTests(unittest.TestCase):
     def test_recorded_openrouter_rankings_excerpt_fixture_is_normalizable_offline(self):
         recorded = fixture("recorded-rankings-response-excerpt.json")
         self.assertEqual(recorded["recording"]["source_url"], engine.RANKINGS_URL)
-        self.assertTrue(recorded["recording"]["full_response_sha256"].startswith("sha256:"))
         normalized = engine.normalize_rankings(recorded["response"], top_n=1)
         self.assertEqual(normalized[0]["source_model_id"], "deepseek/deepseek-v4-flash-20260731")
 
     def test_catalog_alias_resolution_preserves_ranking_provenance_and_ignores_zero_completion_nonmodels(self):
         rankings = {"data": [
-            {"date": "2026-08-03 00:00:00", "model_permaslug": "example/old-model-20260101", "total_completion_tokens": 5},
-            {"date": "2026-08-03 00:00:00", "model_permaslug": "embedding-only", "total_completion_tokens": 0},
-        ]}
+            {"date": "2026-08-03", "model_permaslug": "example/old-model-20260101", "total_tokens": "5"},
+            {"date": "2026-08-03", "model_permaslug": "other", "total_tokens": "1"},
+        ], "meta": {"as_of": "2026-08-04T02:00:00Z", "start_date": "2026-08-03", "end_date": "2026-08-03", "version": "v1"}}
         catalog = {"data": [{"id": "example/current-model", "canonical_slug": "example/old-model-20260101", "pricing": None}]}
         endpoints = {"example/current-model": {"data": {"id": "example/current-model", "endpoints": [{"provider_name": "Provider", "status": 0, "pricing": {"prompt": "0.1", "completion": "0.2"}}]}}}
         policy_document = policy()
@@ -186,7 +185,7 @@ class OpenRouterPricingEngineTests(unittest.TestCase):
         self.assertEqual(snapshot["rows"][0]["source_metadata"]["ranking_model_permaslug"], "example/old-model-20260101")
 
     def test_catalog_alias_resolution_prefers_only_paid_variant_over_explicit_free_variant(self):
-        rankings = [{"source_model_id": "google/gemma-4-31b-it-20260402", "rank": 1, "completion_volume": "10", "ranking_date": "2026-08-04 00:00:00"}]
+        rankings = [{"source_model_id": "google/gemma-4-31b-it-20260402", "rank": 1, "total_token_volume": "10", "ranking_date": "2026-08-04"}]
         catalog = {
             "google/gemma-4-31b-it": {"canonical_slug": "google/gemma-4-31b-it-20260402"},
             "google/gemma-4-31b-it:free": {"canonical_slug": "google/gemma-4-31b-it-20260402"},
@@ -196,7 +195,7 @@ class OpenRouterPricingEngineTests(unittest.TestCase):
         self.assertEqual(resolved[0]["ranking_model_permaslug"], "google/gemma-4-31b-it-20260402")
 
     def test_catalog_missing_dated_ranking_uses_endpoint_confirmed_alias(self):
-        rankings = {"data": [{"date": "2026-08-04 00:00:00", "model_permaslug": "bytedance-seed/seedream-4.5-20251203", "total_completion_tokens": 10}]}
+        rankings = {"data": [{"date": "2026-08-04", "model_permaslug": "bytedance-seed/seedream-4.5-20251203", "total_tokens": "10"}], "meta": {"as_of": "2026-08-05T02:00:00Z", "start_date": "2026-08-04", "end_date": "2026-08-04", "version": "v1"}}
         catalog = {"data": [{"id": "example/other", "canonical_slug": "example/other", "pricing": None}]}
         endpoints = {
             "bytedance-seed/seedream-4.5-20251203": {
@@ -216,7 +215,7 @@ class OpenRouterPricingEngineTests(unittest.TestCase):
     def test_no_active_priced_endpoint_is_snapshotted_and_blocked_not_dropped(self):
         rankings, models, endpoints = self.expanded_inputs()
         endpoints["openai/gpt-oss-20b"]["data"]["endpoints"][0]["status"] = -2
-        snapshot = engine.build_snapshot(rankings, models, endpoints, policy(), now=NOW, top_n=100)
+        snapshot = engine.build_snapshot(rankings, models, endpoints, policy(), now=NOW, top_n=50)
         row = next(item for item in snapshot["rows"] if item["source_model_id"] == "openai/gpt-oss-20b")
         self.assertEqual(row["pricing_status"], "no_active_priced_endpoint")
         self.assertIsNone(row["pricing"])
@@ -362,7 +361,7 @@ class OpenRouterPricingEngineTests(unittest.TestCase):
         self.assertEqual([row["model_id"] for row in proposal["unchanged"]], ["google-gemma-4-26b-a4b-it"])
         self.assertEqual([row["model_id"] for row in proposal["added"]], ["example/new-model"])
         self.assertEqual({row["model_id"] for row in proposal["dropped"]}, {"qwen2.5-coder-32b-instruct"})
-        self.assertEqual(len(proposal["blocked"]), 97)
+        self.assertEqual(len(proposal["blocked"]), 47)
         nemotron = next(row for row in proposal["blocked"] if row["model_id"] == "nemotron-3-nano-30b-a3b")
         self.assertTrue(nemotron["policy_evidence"]["available"])
         self.assertEqual(proposal["changed"][0]["proposed_completion_rate"]["rate_card_completion_rate_per_mtok"], 104000)
@@ -373,7 +372,7 @@ class OpenRouterPricingEngineTests(unittest.TestCase):
         self.assertEqual(first, second)
         self.assertEqual(
             engine.sha256_prefixed(first),
-            "sha256:f2bf173cb25013aa799bc25e04065a168156cbebc4a9425604760ff83bcd8039",
+            "sha256:0d46711b6bbd6f31f5d3cec82b4d8cd6e887d89bbf1b676026372226ac79eb6a",
         )
 
     def test_unresolved_nemotron_license_is_blocked_when_not_a_current_row(self):
@@ -457,9 +456,19 @@ class OpenRouterPricingEngineTests(unittest.TestCase):
 
     def test_orchestration_failure_writes_no_final_snapshot(self):
         with tempfile.TemporaryDirectory() as temporary:
-            client = FakeHTTPClient({engine.RANKINGS_URL: [engine.HTTPResponse(200, b"{", {})]})
+            client = FakeHTTPClient({engine.daily_rankings_url(NOW, 30): [engine.HTTPResponse(200, b"{", {})]})
             with self.assertRaises(engine.SchemaError):
                 engine.fetch_live_snapshot(policy(), output_dir=Path(temporary), top_n=4, retries=0, timeout_seconds=1, client=client, now=lambda: NOW, sleeper=lambda _: None)
+            self.assertEqual(list(Path(temporary).iterdir()), [])
+
+    def test_live_fetch_requires_an_openrouter_api_key(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            with patch.dict(engine.os.environ, {}, clear=True):
+                with self.assertRaises(engine.FetchError):
+                    engine.fetch_live_snapshot(
+                        policy(), output_dir=Path(temporary), top_n=50,
+                        retries=0, timeout_seconds=1, now=lambda: NOW,
+                    )
             self.assertEqual(list(Path(temporary).iterdir()), [])
 
     def test_current_rate_card_row_without_policy_mapping_is_explicitly_blocked(self):


### PR DESCRIPTION
## Summary

Implements Components 1 and 2 of the OpenRouter live pricing engine:

- fetches and normalizes top-100 OpenRouter demand/pricing snapshots;
- fails closed on rate limits, malformed/partial pulls, schema drift, and unavailable prices;
- emits a review-only pricing proposal/diff;
- includes reviewed Nemotron license eligibility;
- adds offline fixtures, deterministic tests, and operator documentation.

## Scope boundary

This PR has no apply path and does not modify
`phase3-binary/catalog/autotune/rate-card.json`.

## Verification

- 28 offline tests pass:
  `python -m unittest -v scripts/tests/test_openrouter_pricing_engine.py`
- Full top-100 live snapshot fetch succeeded.
- Live proposal computation succeeded.

SPEC-GOVERNANCE-DECLARATION-BEGIN
{
  "schema_version": "spec-pr-governance-v1",
  "behavior_change": "yes",
  "contract_change": "none",
  "specs": ["SPEC-023"],
  "requirements": ["SPEC-023-R001"],
  "authority_domains": ["installer-autotune-policy"],
  "arbitration": ["CODE_BUG"],
  "tests": ["python -m unittest -v scripts/tests/test_openrouter_pricing_engine.py"],
  "journeys": ["not-required"]
}
SPEC-GOVERNANCE-DECLARATION-END