### PR TITLE
Preserve provider terminal detail for evidence

### DIFF
--- a/phase4-coordinator/internal/buyer/server.go
+++ b/phase4-coordinator/internal/buyer/server.go
@@ -3002,11 +3002,11 @@ func (s *Server) forwardWSNonStreaming(w http.ResponseWriter, r *http.Request, r
 				status := wsEndHTTPStatus(end.Status)
 				if end.Status == "error_queue_full" {
 					markProviderDone()
-					return wsForwardQueueFull, requestLogAttempt{Status: status, Error: endErrorMessage(end), ErrorCode: end.Status}
+					return wsForwardQueueFull, requestLogAttempt{Status: status, Error: requestLogEndErrorMessage(end), ErrorCode: end.Status}
 				}
 				markProviderDone()
 				writeWSEndError(w, end)
-				attempt := requestLogAttempt{Status: status, Error: endErrorMessage(end), ErrorCode: spec001EndStatus(end.Status)}
+				attempt := requestLogAttempt{Status: status, Error: requestLogEndErrorMessage(end), ErrorCode: spec001EndStatus(end.Status)}
 				if isSpec019ProviderDetailCode(attempt.ErrorCode) {
 					attempt.FaultFlag = billing.FaultBreakerQualifying
 				}
@@ -3285,10 +3285,10 @@ func (s *Server) forwardWSStreaming(w http.ResponseWriter, r *http.Request, requ
 				status := wsEndHTTPStatus(end.Status)
 				if end.Status == "error_queue_full" {
 					markProviderDone()
-					return wsForwardQueueFull, requestLogAttempt{Status: status, Error: endErrorMessage(end), ErrorCode: end.Status}
+					return wsForwardQueueFull, requestLogAttempt{Status: status, Error: requestLogEndErrorMessage(end), ErrorCode: end.Status}
 				}
 				markProviderDone()
-				return wsForwardFailed, requestLogAttempt{Status: status, Error: endErrorMessage(end), ErrorCode: spec001EndStatus(end.Status)}
+				return wsForwardFailed, requestLogAttempt{Status: status, Error: requestLogEndErrorMessage(end), ErrorCode: spec001EndStatus(end.Status)}
 			}
 			markProviderDone()
 			commit()
@@ -3353,7 +3353,7 @@ func (s *Server) forwardWSStreaming(w http.ResponseWriter, r *http.Request, requ
 				if toolFinal.toolOpened && s.streamingDowngrade != nil {
 					s.streamingDowngrade.recordMalformed(streamingBuyer, provider.ProviderID, s.now())
 				}
-				attempt.Error = endErrorMessage(end)
+				attempt.Error = requestLogEndErrorMessage(end)
 				attempt.ErrorCode = spec001EndStatus(end.Status)
 				attempt.FaultFlag = billing.FaultBreakerQualifying
 				attempt.SettlementOutput = settlementTracker.outputAt(terminalStateFromAttempt(http.StatusOK, attempt.Error, attempt.ErrorCode), terminalTS)
@@ -3487,7 +3487,7 @@ func (s *Server) forwardWSStreamingBuffered(w http.ResponseWriter, r *http.Reque
 					s.streamingDowngrade.recordMalformed(streamingBuyer, provider.ProviderID, s.now())
 				}
 				markProviderDone()
-				return wsForwardFailed, requestLogAttempt{Status: wsEndHTTPStatus(end.Status), Error: endErrorMessage(end), ErrorCode: spec001EndStatus(end.Status), FaultFlag: billing.FaultBreakerQualifying, SettlementOutput: settlementOutputUnavailableFor(billing.TerminalStateProviderError)}
+				return wsForwardFailed, requestLogAttempt{Status: wsEndHTTPStatus(end.Status), Error: requestLogEndErrorMessage(end), ErrorCode: spec001EndStatus(end.Status), FaultFlag: billing.FaultBreakerQualifying, SettlementOutput: settlementOutputUnavailableFor(billing.TerminalStateProviderError)}
 			}
 			if !toolFinal.finalCloseOK() {
 				if s.streamingDowngrade != nil {
@@ -7126,6 +7126,18 @@ func endErrorMessage(end providerws.InferenceResponseEnd) string {
 		return end.Status
 	}
 	return "Provider failed during inference"
+}
+
+func requestLogEndErrorMessage(end providerws.InferenceResponseEnd) string {
+	status := endErrorMessage(end)
+	detail := sanitizeRequestLogText(end.Error)
+	if detail == "" {
+		return status
+	}
+	if status == "" || status == "Provider failed during inference" {
+		return detail
+	}
+	return status + ": " + detail
 }
 
 func requestIDForBuyerRequest() string {

--- a/phase4-coordinator/internal/buyer/server_test.go
+++ b/phase4-coordinator/internal/buyer/server_test.go
@@ -3073,6 +3073,64 @@ func TestRequestLogBuyerErrorCodePopulation(t *testing.T) {
 	}
 }
 
+func TestRequestLogPreservesProviderEndErrorDetail(t *testing.T) {
+	const requestID = "provider-detail-req"
+	const providerDetail = "runtime worker timed out waiting for first token"
+	var relayRequestID string
+	reqLog, dbPath := openBuyerRequestLog(t)
+	defer reqLog.Close()
+	registry := pool.NewRegistry(nil)
+	registerWithPath(registry, "p1", "s1", "model-a", pool.StateReady, 20000, 1, "", 20, pool.TierProvisional, pool.InferencePathWSTunneled)
+	server := buyer.NewServer(
+		registry,
+		zerolog.Nop(),
+		time.Unix(1716768000, 0),
+		buyer.WithRequestLog(reqLog),
+		buyer.WithRelay(func(ctx context.Context, provider pool.Provider, gotRequestID string, body []byte, stream bool) (*providerws.RelayStream, error) {
+			relayRequestID = gotRequestID
+			chunks := make(chan providerws.InferenceResponseChunk, 1)
+			done := make(chan providerws.InferenceResponseEnd, 1)
+			errs := make(chan error, 1)
+			done <- providerws.InferenceResponseEnd{
+				Type:      "inference_response_end",
+				RequestID: gotRequestID,
+				Status:    "error_internal",
+				Error:     providerDetail,
+			}
+			return &providerws.RelayStream{RequestID: gotRequestID, Chunks: chunks, Done: done, Errors: errs}, nil
+		}, time.Second),
+	)
+
+	rr := postChat(t, server, []byte(`{"model":"model-a","messages":[{"role":"user","content":"hello"}]}`), http.Header{
+		"X-Request-ID": []string{requestID},
+	})
+
+	if rr.Code != http.StatusBadGateway {
+		t.Fatalf("status=%d body=%s", rr.Code, rr.Body.String())
+	}
+	if strings.Contains(rr.Body.String(), providerDetail) {
+		t.Fatalf("buyer response leaked provider detail: %s", rr.Body.String())
+	}
+	if !strings.Contains(rr.Body.String(), `"code":"provider_error"`) {
+		t.Fatalf("buyer response missing generic provider_error: %s", rr.Body.String())
+	}
+	var loggedError, loggedCode sql.NullString
+	db, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatalf("open request log db: %v", err)
+	}
+	defer db.Close()
+	if err := db.QueryRow(`SELECT error, error_code FROM request_log WHERE request_id = ?`, relayRequestID).Scan(&loggedError, &loggedCode); err != nil {
+		t.Fatalf("query request_log detail: %v", err)
+	}
+	if !loggedError.Valid || loggedError.String != "error_internal: "+providerDetail {
+		t.Fatalf("request_log error=%#v, want provider detail", loggedError)
+	}
+	if !loggedCode.Valid || loggedCode.String != "error_internal" {
+		t.Fatalf("request_log error_code=%#v, want error_internal", loggedCode)
+	}
+}
+
 func TestRequestLogBuyerValidationFailure(t *testing.T) {
 	const requestID = "33333333-3333-4333-8333-333333333333"
 	reqLog, dbPath := openBuyerRequestLog(t)


### PR DESCRIPTION
## Summary

This keeps buyer-facing provider failures generic, but preserves sanitized `inference_response_end.error` detail in `request_log.error` for failed WS-tunneled provider attempts.

Root cause: the provider end frame already carries an optional `error` field, but coordinator request-log attempts used `endErrorMessage`, which collapses recognized SPEC-001 terminal statuses to only the status code. That made live provider-slice evidence for issue #614 indistinguishable when the attempt ended as opaque `error_internal`.

## Impact

- Buyer HTTP/SSE envelopes remain unchanged and do not expose provider internals.
- Internal `request_log.error` now records `status: sanitized detail` when the provider supplies terminal detail.
- This is diagnostic evidence only. It does not promote ledger/spec status by itself.

## Validation

- `go test ./internal/buyer`
- `go test ./...` from `phase4-coordinator`
- `python3 scripts/check_spec_governance.py --base-ref origin/main`
- `python3 scripts/gen_spec_index.py --check`
- `git diff --check`

SPEC-GOVERNANCE-DECLARATION-BEGIN
{
  "schema_version": "spec-pr-governance-v1",
  "behavior_change": "yes",
  "contract_change": "none",
  "specs": ["SPEC-002", "SPEC-006"],
  "requirements": ["SPEC-002-R001"],
  "authority_domains": ["coordinator-admission-routing", "buyer-api-error-contract"],
  "arbitration": ["CODE_BUG"],
  "tests": ["go test ./internal/buyer", "go test ./... from phase4-coordinator", "python3 scripts/check_spec_governance.py --base-ref origin/main", "python3 scripts/gen_spec_index.py --check", "git diff --check"],
  "journeys": ["not-required: diagnostic request-log preservation only; signed provider journey remains pending until live evidence validates"],
  "issue": "https://github.com/Augustas11/macprovider/issues/614"
}
SPEC-GOVERNANCE-DECLARATION-END
