### PR TITLE
Preserve hot-path served-alias rate contracts

### DIFF
--- a/phase4-coordinator/internal/billing/hotpath.go
+++ b/phase4-coordinator/internal/billing/hotpath.go
@@ -115,7 +115,7 @@ func (s *Store) writeHotPath(ctx context.Context, reqLogStore *requestlog.Store,
 						in.EstimatedCompTokens,
 						usageFor(in.ErrorCode, in.EstimatedCompTokens),
 						in.FaultFlag,
-						in.RateEntry,
+						hotPathRateEntry(in),
 						in.MultiplierPPM,
 						in.ProviderShareBps,
 					)
@@ -158,7 +158,7 @@ func (s *Store) writeHotPath(ctx context.Context, reqLogStore *requestlog.Store,
 				in.EstimatedCompTokens,
 				usageFor(in.ErrorCode, in.EstimatedCompTokens),
 				in.FaultFlag,
-				in.RateEntry,
+				hotPathRateEntry(in),
 				in.MultiplierPPM,
 				in.ProviderShareBps,
 			)
@@ -179,7 +179,7 @@ func (s *Store) writeHotPath(ctx context.Context, reqLogStore *requestlog.Store,
 			in.EstimatedCompTokens,
 			usageFor(in.ErrorCode, in.EstimatedCompTokens),
 			in.FaultFlag,
-			in.RateEntry,
+			hotPathRateEntry(in),
 			in.MultiplierPPM,
 			in.ProviderShareBps,
 		)
@@ -209,6 +209,13 @@ func (s *Store) writeHotPath(ctx context.Context, reqLogStore *requestlog.Store,
 		}
 		return nil
 	})
+}
+
+func hotPathRateEntry(in HotPathInput) RateCardEntry {
+	if in.RateCard != nil {
+		return RateFor(in.RateCard, in.Model)
+	}
+	return in.RateEntry
 }
 
 func normalizeCachedPromptTokens(in *HotPathInput) string {

--- a/phase4-coordinator/internal/billing/store_test.go
+++ b/phase4-coordinator/internal/billing/store_test.go
@@ -306,6 +306,77 @@ SELECT prompt_tokens, charged_prompt_tokens, provider_reported_prompt_tokens, gr
 	}
 }
 
+func TestWriteHotPath_UsesFullRateCardForServedAlias(t *testing.T) {
+	reqStore, store := newRequestAndBillingStores(t)
+	cfg := testRewards()
+	cfg.RateCard = map[string]RateCardEntry{
+		"qwen3-8b": {
+			PromptCreditsPerMtok:     13500,
+			CompletionCreditsPerMtok: 27000,
+		},
+		"default": {
+			PromptCreditsPerMtok:     500000,
+			CompletionCreditsPerMtok: 1000000,
+		},
+	}
+	ts := recoveryLegacyDefaultRateCutoffUTC.Add(time.Hour)
+	snapshotID, err := store.InsertConfigSnapshot(context.Background(), cfg, ts.Add(-time.Minute))
+	if err != nil {
+		t.Fatal(err)
+	}
+	prompt, completion := int64(12), int64(8)
+	row := requestlog.Row{
+		TSUtc:              ts,
+		RequestID:          "hotpath-served-alias-rate-card",
+		AccountID:          "buyer-a",
+		Model:              "mlx-community/Qwen3-8B-4bit",
+		ProviderAssignedID: "assigned-a",
+		PromptTokens:       &prompt,
+		CompletionTokens:   &completion,
+		Status:             200,
+		BuyerIP:            "127.0.0.1",
+	}
+	input := HotPathInput{
+		RequestID:                  row.RequestID,
+		AttemptN:                   0,
+		ProviderAssignedID:         row.ProviderAssignedID,
+		ProviderID:                 "provider-a",
+		Model:                      row.Model,
+		Status:                     row.Status,
+		TSUtc:                      ts,
+		PromptTokens:               &prompt,
+		CompletionTokens:           &completion,
+		ConfigSnapshotID:           snapshotID,
+		RateEntry:                  cfg.RateCard["default"],
+		RateCard:                   cfg.RateCard,
+		MultiplierPPM:              ParseMultiplierPPM(cfg.GlobalMultiplier),
+		ProviderShareBps:           ParseShareBps(cfg.ProviderShare),
+		SettlementAccountScopeHash: SettlementAccountScopeHash(AccountScopeForSettlement(row.AccountID)),
+		SettlementPolicyMode:       RouteSnapshotModeEnforce,
+		SettlementPolicyVersion:    RouteSnapshotPolicyVersion,
+	}
+	if err := store.WriteHotPath(context.Background(), reqStore, row, input); err != nil {
+		t.Fatal(err)
+	}
+	var promptRate, completionRate int64
+	if err := store.db.QueryRow(`
+SELECT prompt_rate_per_mtok, completion_rate_per_mtok
+  FROM ledger_request_credits
+ WHERE request_id = ? AND quarantined = 0`, row.RequestID).Scan(&promptRate, &completionRate); err != nil {
+		t.Fatal(err)
+	}
+	if promptRate != 13500 || completionRate != 27000 {
+		t.Fatalf("stored rates=%d/%d want normalized qwen3-8b 13500/27000", promptRate, completionRate)
+	}
+
+	if err := store.RecoverLedger(context.Background(), RecoverInput{ScanFrom: ts.Add(-time.Minute), ScanTo: ts.Add(time.Minute), Source: "startup_scan"}); err != nil {
+		t.Fatal(err)
+	}
+	if got := scalar(t, store.db, `SELECT COUNT(*) FROM ledger_request_credits WHERE request_id = ? AND quarantined = 1`, row.RequestID); got != 0 {
+		t.Fatalf("quarantined rows after recovery=%d want 0", got)
+	}
+}
+
 func TestRunSettlementUsesNanosecondOrderedTimestampText(t *testing.T) {
 	reqStore, store := newRequestAndBillingStores(t)
 	input, row := testHotPathInput(t, store)

--- a/phase4-coordinator/internal/buyer/billing_recorder.go
+++ b/phase4-coordinator/internal/buyer/billing_recorder.go
@@ -392,6 +392,7 @@ func (b *billingRecorder) recordRow(
 			StickyMissReason:           b.state.stickyMissReason,
 			ConfigSnapshotID:           billingSnapshotID,
 			RateEntry:                  billing.RateFor(billingCfg.RateCard, row.Model),
+			RateCard:                   billingCfg.RateCard,
 			MultiplierPPM:              billing.ParseMultiplierPPM(billingCfg.GlobalMultiplier),
 			ProviderShareBps:           billing.ParseShareBps(billingCfg.ProviderShare),
 			SettlementAccountScopeHash: billing.SettlementAccountScopeHash(accountScope),


### PR DESCRIPTION
## What changed

- Pass the full billing rate card from the buyer billing recorder into `HotPathInput`.
- Make `WriteHotPath` derive the effective rate from that full card when available, keeping `RateEntry` as the legacy fallback.
- Add a regression for served `mlx-community/...-4bit` aliases where a normalized rate-card key must be persisted and survive startup recovery.

## Why

Pearl `v1.8.84` fixed historical recovery drift, but the buyer canary produced two new hot-path credits that startup recovery quarantined as `reconciliation_mismatch`. The hot path still had only a stale/default `RateEntry`, so post-cutoff normalized model rows persisted default rates while recovery expected the normalized rate contract.

## Validation

- `go test ./internal/buyer`
- `go test ./internal/billing`

SPEC-GOVERNANCE-DECLARATION-BEGIN
{
  "schema_version": "spec-pr-governance-v1",
  "behavior_change": "yes",
  "contract_change": "none",
  "specs": ["SPEC-005", "SPEC-022"],
  "requirements": ["SPEC-022-R007", "SPEC-022-R009", "SPEC-022-R011"],
  "authority_domains": ["billing-settlement-formula", "verified-model-settlement"],
  "arbitration": ["CODE_BUG"],
  "tests": [
    "phase4-coordinator/internal/billing/store_test.go::TestWriteHotPath_UsesFullRateCardForServedAlias",
    "phase4-coordinator::go test ./internal/billing",
    "phase4-coordinator::go test ./internal/buyer"
  ],
  "journeys": ["not-required"]
}
SPEC-GOVERNANCE-DECLARATION-END
