### PR TITLE
Let providers earn bounded repeat X invite bonuses

### DIFF
--- a/phase3-binary/Sources/macprovider-cli/HTTPServer.swift
+++ b/phase3-binary/Sources/macprovider-cli/HTTPServer.swift
@@ -231,6 +231,7 @@ final class RouterHandler: ChannelInboundHandler, @unchecked Sendable {
         "referral_bootstrap_v1",
         "referral_status_v1",
         "referral_advocacy_v1",
+        "referral_repeatable_advocacy_v1",
         "referral_fragment_links_v1",
         "provider_safety_telemetry_v2",
     ]

--- a/phase3-binary/Sources/macprovider-cli/ReferralCoordinatorClient.swift
+++ b/phase3-binary/Sources/macprovider-cli/ReferralCoordinatorClient.swift
@@ -22,6 +22,7 @@ public struct ReferralStatusSnapshot: Codable, Equatable, Sendable {
     public let firstServingSeen: Bool
     public let joinLinksEnabled: Bool
     public let socialBonusEnabled: Bool
+    public let socialBonusGrantsRemaining: Int?
     public let inviteCode: String?
     public let inviteURL: String?
     public let observedAt: String
@@ -39,6 +40,7 @@ public struct ReferralStatusSnapshot: Codable, Equatable, Sendable {
         case firstServingSeen = "first_serving_seen"
         case joinLinksEnabled = "join_links_enabled"
         case socialBonusEnabled = "social_bonus_enabled"
+        case socialBonusGrantsRemaining = "social_bonus_grants_remaining"
         case inviteCode = "invite_code"
         case inviteURL = "invite_url"
         case observedAt = "observed_at"
@@ -58,6 +60,7 @@ public struct ReferralStatusSnapshot: Codable, Equatable, Sendable {
             firstServingSeen: firstServingSeen,
             joinLinksEnabled: joinLinksEnabled,
             socialBonusEnabled: socialBonusEnabled,
+            socialBonusGrantsRemaining: socialBonusGrantsRemaining,
             inviteCode: inviteCode,
             inviteURL: inviteURL,
             observedAt: observedAt,
@@ -330,6 +333,15 @@ struct ReferralCoordinatorClient: Sendable {
         } else if inviteURL != nil {
             throw control(.invalidResponse)
         }
+        let socialBonusGrantsRemaining: Int?
+        if object["social_bonus_grants_remaining"] != nil {
+            guard let value = count("social_bonus_grants_remaining", in: object) else {
+                throw control(.invalidResponse)
+            }
+            socialBonusGrantsRemaining = value
+        } else {
+            socialBonusGrantsRemaining = nil
+        }
         return ReferralStatusSnapshot(
             campaign: campaign,
             joinBaseURL: joinBaseURL,
@@ -342,6 +354,7 @@ struct ReferralCoordinatorClient: Sendable {
             firstServingSeen: firstServingSeen,
             joinLinksEnabled: joinLinksEnabled,
             socialBonusEnabled: socialBonusEnabled,
+            socialBonusGrantsRemaining: socialBonusGrantsRemaining,
             inviteCode: inviteCode,
             inviteURL: inviteURL,
             observedAt: formatDate(observedAt),
@@ -676,10 +689,9 @@ actor ReferralCoordinatorService {
             try store.clear()
             return status
         }
-        // `pending` means the coordinator durably accepted verification and
-        // consumed the challenge. It also covers response-loss recovery: a
-        // later status read clears the now-terminal local secret.
-        guard status.socialState == "eligible" else {
+        // Keep the local challenge only while the coordinator can still accept
+        // or reopen an X verification for this provider.
+        guard Self.canAttemptSocialChallenge(status) else {
             try store.clear()
             return status
         }
@@ -704,7 +716,7 @@ actor ReferralCoordinatorService {
                 terminalVerify: false
             )
         }
-        guard ["eligible", "failed"].contains(current.socialState),
+        guard Self.canAttemptSocialChallenge(current),
               let inviteCode = current.inviteCode,
               let inviteURL = current.inviteURL else {
             throw ReferralCoordinatorClientError.control(
@@ -739,7 +751,7 @@ actor ReferralCoordinatorService {
                 terminalVerify: false
             )
         }
-        guard current.socialState == "eligible",
+        guard Self.canAttemptSocialChallenge(current),
               let payload = try store.load(providerID: client.providerID, now: now()),
               current.inviteURL == payload.inviteURL,
               let intentURL = URL(string: payload.intentURL),
@@ -752,6 +764,14 @@ actor ReferralCoordinatorService {
             )
         }
         return ReferralPendingAdvocacy(expiresAt: payload.expiresAtWire)
+    }
+
+    private static func canAttemptSocialChallenge(_ status: ReferralStatusSnapshot) -> Bool {
+        guard ["eligible", "failed", "matured"].contains(status.socialState) else { return false }
+        if status.socialState == "matured" {
+            return (status.socialBonusGrantsRemaining ?? 0) > 0
+        }
+        return true
     }
 
     func verify(postURL: String) async throws -> ReferralStatusSnapshot {

--- a/phase3-binary/Tests/macprovider-cliTests/ControlSocketTests.swift
+++ b/phase3-binary/Tests/macprovider-cliTests/ControlSocketTests.swift
@@ -198,6 +198,7 @@ final class ControlSocketTests: XCTestCase {
             firstServingSeen: true,
             joinLinksEnabled: true,
             socialBonusEnabled: true,
+            socialBonusGrantsRemaining: 5,
             inviteCode: "invite-1",
             inviteURL: "https://join.example/j#/invite-1",
             observedAt: "2027-01-15T08:00:00.000Z",

--- a/phase3-binary/Tests/macprovider-cliTests/ProviderStatusTests.swift
+++ b/phase3-binary/Tests/macprovider-cliTests/ProviderStatusTests.swift
@@ -115,6 +115,7 @@ final class ProviderStatusTests: XCTestCase {
         XCTAssertTrue(capabilities.contains("referral_bootstrap_v1"))
         XCTAssertTrue(capabilities.contains("referral_status_v1"))
         XCTAssertTrue(capabilities.contains("referral_advocacy_v1"))
+        XCTAssertTrue(capabilities.contains("referral_repeatable_advocacy_v1"))
         XCTAssertTrue(capabilities.contains("referral_fragment_links_v1"))
 
         let observation = try XCTUnwrap(body["observation"] as? [String: Any])

--- a/phase3-binary/Tests/macprovider-cliTests/ReferralCoordinatorClientTests.swift
+++ b/phase3-binary/Tests/macprovider-cliTests/ReferralCoordinatorClientTests.swift
@@ -32,6 +32,7 @@ final class ReferralCoordinatorClientTests: XCTestCase {
         XCTAssertEqual(status.remaining, 1)
         XCTAssertEqual(status.inviteCode, "invite-1")
         XCTAssertTrue(status.joinLinksEnabled)
+        XCTAssertEqual(status.socialBonusGrantsRemaining, 5)
         XCTAssertEqual(status.observedAt, "2027-01-15T08:00:00.000Z")
         XCTAssertNil(status.pendingChallenge)
     }
@@ -129,6 +130,38 @@ final class ReferralCoordinatorClientTests: XCTestCase {
         XCTAssertGreaterThan(expires, now)
     }
 
+    func testMaturedStatusCanCreateFreshXChallenge() async throws {
+        let challenge = String(repeating: "9", count: 64)
+        let share = "https://malibu.tech/j#/invite-1?c=\(challenge)"
+        let intent = "https://twitter.com/intent/tweet?text=" + share.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed)!
+        let challengeBody = """
+        {"intent_url":"\(intent)","share_url":"\(share)","expires_at":"2027-01-15T08:10:00Z"}
+        """
+        let maturedStatus = statusJSON
+            .replacingOccurrences(of: #""social_state":"eligible""#, with: #""social_state":"matured""#)
+            .replacingOccurrences(of: #""bonus_capacity":0"#, with: #""bonus_capacity":2"#)
+            .replacingOccurrences(of: #""remaining":1"#, with: #""remaining":3"#)
+        let client = try makeClient(session: mockSession { request in
+            self.response(
+                request,
+                status: 200,
+                body: request.httpMethod == "GET" ? maturedStatus : challengeBody
+            )
+        })
+        let openedURL = LockedBox<String?>(nil)
+        let service = ReferralCoordinatorService(
+            client: client,
+            store: ReferralChallengeStore(url: temporaryStoreURL()),
+            now: { self.now },
+            openIntent: { url in openedURL.set(url.absoluteString); return true }
+        )
+
+        let pending = try await service.challenge()
+
+        XCTAssertEqual(openedURL.get(), intent)
+        XCTAssertEqual(pending.expiresAt, "2027-01-15T08:10:00.000Z")
+    }
+
     func testStatusRestoresOnlySafePendingProjectionAcrossServiceRestart() async throws {
         let challenge = String(repeating: "b", count: 64)
         let intent = safeIntent(challenge: challenge)
@@ -182,12 +215,41 @@ final class ReferralCoordinatorClientTests: XCTestCase {
         }
     }
 
-    func testStatusClearsChallengeOutsideEligibleState() async throws {
-        for state in ["locked_until_first_serving", "failed"] {
+    func testStatusRestoresPendingProjectionAcrossRetryableStates() async throws {
+        for state in ["eligible", "failed", "matured"] {
             let store = ReferralChallengeStore(url: temporaryStoreURL())
             try store.save(
                 providerID: "provider-1",
-                payload: payload(challenge: String(repeating: state == "failed" ? "4" : "5", count: 64))
+                payload: payload(challenge: String(repeating: state == "failed" ? "4" : state == "matured" ? "5" : "6", count: 64))
+            )
+            let client = try makeClient(session: mockSession { request in
+                self.response(
+                    request,
+                    status: 200,
+                    body: self.statusJSON.replacingOccurrences(of: "eligible", with: state)
+                )
+            })
+            let service = ReferralCoordinatorService(
+                client: client,
+                store: store,
+                now: { self.now },
+                openIntent: { _ in true }
+            )
+
+            let status = try await service.status()
+            XCTAssertEqual(status.pendingChallenge, ReferralPendingAdvocacy(
+                expiresAt: "2027-01-15T08:10:00.000Z"
+            ), "state=\(state)")
+            XCTAssertTrue(FileManager.default.fileExists(atPath: store.url.path), "state=\(state)")
+        }
+    }
+
+    func testStatusClearsChallengeOutsideRetryableStates() async throws {
+        for state in ["locked_until_first_serving", "pending", "revoked"] {
+            let store = ReferralChallengeStore(url: temporaryStoreURL())
+            try store.save(
+                providerID: "provider-1",
+                payload: payload(challenge: String(repeating: state == "pending" ? "7" : state == "revoked" ? "8" : "9", count: 64))
             )
             let client = try makeClient(session: mockSession { request in
                 self.response(
@@ -207,6 +269,34 @@ final class ReferralCoordinatorClientTests: XCTestCase {
             XCTAssertNil(status.pendingChallenge, "state=\(state)")
             XCTAssertFalse(FileManager.default.fileExists(atPath: store.url.path), "state=\(state)")
         }
+    }
+
+    func testStatusClearsMaturedChallengeWhenRepeatGrantCapReached() async throws {
+        let store = ReferralChallengeStore(url: temporaryStoreURL())
+        try store.save(
+            providerID: "provider-1",
+            payload: payload(challenge: String(repeating: "0", count: 64))
+        )
+        let cappedMatured = statusJSON
+            .replacingOccurrences(of: #""social_state":"eligible""#, with: #""social_state":"matured""#)
+            .replacingOccurrences(of: #""bonus_capacity":0"#, with: #""bonus_capacity":2"#)
+            .replacingOccurrences(of: #""remaining":1"#, with: #""remaining":3"#)
+            .replacingOccurrences(of: #""social_bonus_grants_remaining":5"#, with: #""social_bonus_grants_remaining":0"#)
+        let client = try makeClient(session: mockSession { request in
+            self.response(request, status: 200, body: cappedMatured)
+        })
+        let service = ReferralCoordinatorService(
+            client: client,
+            store: store,
+            now: { self.now },
+            openIntent: { _ in true }
+        )
+
+        let status = try await service.status()
+
+        XCTAssertEqual(status.socialState, "matured")
+        XCTAssertNil(status.pendingChallenge)
+        XCTAssertFalse(FileManager.default.fileExists(atPath: store.url.path))
     }
 
     func testVerifyReadsChallengeInsideCLIAndClearsItAfterSuccess() async throws {
@@ -448,7 +538,7 @@ final class ReferralCoordinatorClientTests: XCTestCase {
     }
 
     private var statusJSON: String {
-        #"{"campaign":"prebeta","join_base_url":"https://malibu.tech/j","social_state":"eligible","base_capacity":1,"configured_bonus_capacity":2,"bonus_capacity":0,"redemptions":0,"remaining":1,"first_serving_seen":true,"join_links_enabled":true,"social_bonus_enabled":true,"invite_code":"invite-1","invite_url":"https://malibu.tech/j#/invite-1"}"#
+        #"{"campaign":"prebeta","join_base_url":"https://malibu.tech/j","social_state":"eligible","base_capacity":1,"configured_bonus_capacity":2,"bonus_capacity":0,"redemptions":0,"remaining":1,"first_serving_seen":true,"join_links_enabled":true,"social_bonus_enabled":true,"social_bonus_grants_remaining":5,"invite_code":"invite-1","invite_url":"https://malibu.tech/j#/invite-1"}"#
     }
 
     private func makeClient(session: URLSession) throws -> ReferralCoordinatorClient {

--- a/phase3-binary/app/Sources/Malibu/Agent/ControlSocketFrame.swift
+++ b/phase3-binary/app/Sources/Malibu/Agent/ControlSocketFrame.swift
@@ -297,6 +297,9 @@ enum ControlCodec {
             "social_bonus_enabled": status.socialBonusEnabled,
             "observed_at": ISO8601DateFormatter().string(from: status.observedAt),
         ]
+        if let remaining = status.socialBonusGrantsRemaining {
+            payload["social_bonus_grants_remaining"] = remaining
+        }
         if let inviteCode = status.inviteCode { payload["invite_code"] = inviteCode }
         if let inviteURL = status.inviteURL { payload["invite_url"] = inviteURL.absoluteString }
         if let challenge = status.pendingChallenge {
@@ -332,6 +335,7 @@ enum ControlCodec {
         } else {
             inviteURL = nil
         }
+        let socialBonusGrantsRemaining = intValue(dict["social_bonus_grants_remaining"])
         let pending: ReferralPendingChallengeProjection?
         if let raw = dict["pending_challenge"] as? [String: Any] {
             guard let expiresWire = raw["expires_at"] as? String,
@@ -354,6 +358,7 @@ enum ControlCodec {
             firstServingSeen: firstServingSeen,
             joinLinksEnabled: joinLinksEnabled,
             socialBonusEnabled: socialBonusEnabled,
+            socialBonusGrantsRemaining: socialBonusGrantsRemaining,
             inviteCode: inviteCode,
             inviteURL: inviteURL,
             observedAt: observedAt,

--- a/phase3-binary/app/Sources/Malibu/Dashboard/DashboardWindow.swift
+++ b/phase3-binary/app/Sources/Malibu/Dashboard/DashboardWindow.swift
@@ -501,17 +501,14 @@ private struct ReferralPanel: View {
                     .disabled(!status.isCurrent() || status.availableInviteURL == nil)
 
                     if status.canStartSocialChallenge,
-                       agent.snapshot.localStatusCapabilities.contains("referral_advocacy_v1") {
+                       agent.snapshot.localStatusCapabilities.contains("referral_advocacy_v1"),
+                       (status.socialState != ReferralStatusProjection.matured
+                        || (agent.snapshot.localStatusCapabilities.contains("referral_repeatable_advocacy_v1")
+                            && (status.socialBonusGrantsRemaining ?? 0) > 0)) {
                         Button("Share on X for \(ReferralPanelPresenter.invitePhrase(status.configuredBonusCapacity))") {
                             Task { await agent.startReferralChallenge() }
                         }
                         .disabled(agent.snapshot.referralActionInProgress)
-                    } else if status.socialState == ReferralStatusProjection.matured,
-                              status.socialBonusEnabled,
-                              status.bonusCapacity > 0 {
-                        Text("X bonus already awarded")
-                            .font(.caption)
-                            .foregroundStyle(.secondary)
                     }
                 }
 

--- a/phase3-binary/app/Sources/Malibu/Dashboard/ReferralProjection.swift
+++ b/phase3-binary/app/Sources/Malibu/Dashboard/ReferralProjection.swift
@@ -70,6 +70,7 @@ struct ReferralStatusProjection: Equatable, Sendable {
     let firstServingSeen: Bool
     let joinLinksEnabled: Bool
     let socialBonusEnabled: Bool
+    let socialBonusGrantsRemaining: Int?
     let inviteCode: String?
     let inviteURL: URL?
     let observedAt: Date
@@ -87,6 +88,7 @@ struct ReferralStatusProjection: Equatable, Sendable {
         firstServingSeen: Bool,
         joinLinksEnabled: Bool,
         socialBonusEnabled: Bool,
+        socialBonusGrantsRemaining: Int?,
         inviteCode: String?,
         inviteURL: URL?,
         observedAt: Date,
@@ -99,6 +101,9 @@ struct ReferralStatusProjection: Equatable, Sendable {
               counts.allSatisfy({ (0...1_000_000).contains($0) }),
               remaining == max(0, baseCapacity + bonusCapacity - redemptions),
               observedAt <= Date().addingTimeInterval(60) else {
+            return nil
+        }
+        if let socialBonusGrantsRemaining, !(0...1_000_000).contains(socialBonusGrantsRemaining) {
             return nil
         }
         if let inviteCode, !Self.isSafeInviteCode(inviteCode) { return nil }
@@ -128,6 +133,7 @@ struct ReferralStatusProjection: Equatable, Sendable {
         self.firstServingSeen = firstServingSeen
         self.joinLinksEnabled = joinLinksEnabled
         self.socialBonusEnabled = socialBonusEnabled
+        self.socialBonusGrantsRemaining = socialBonusGrantsRemaining
         self.inviteCode = inviteCode
         self.inviteURL = inviteURL
         self.observedAt = observedAt
@@ -149,12 +155,28 @@ struct ReferralStatusProjection: Equatable, Sendable {
         return inviteURL
     }
 
+    var socialChallengeInviteURL: URL? {
+        guard firstServingSeen,
+              joinLinksEnabled,
+              socialState != Self.locked,
+              socialState != Self.revoked,
+              let inviteCode,
+              !inviteCode.isEmpty,
+              let inviteURL,
+              Self.isCanonicalInvite(inviteURL, code: inviteCode, joinBaseURL: joinBaseURL) else {
+            return nil
+        }
+        return inviteURL
+    }
+
     var canStartSocialChallenge: Bool {
-        socialBonusEnabled
+        let grantsAvailable = socialBonusGrantsRemaining.map { $0 > 0 } ?? (socialState != Self.matured)
+        return socialBonusEnabled
+            && grantsAvailable
             && configuredBonusCapacity > 0
-            && [Self.eligible, Self.failed].contains(socialState)
+            && [Self.eligible, Self.failed, Self.matured].contains(socialState)
             && pendingChallenge == nil
-            && availableInviteURL != nil
+            && socialChallengeInviteURL != nil
     }
 
     func withPendingChallenge(_ challenge: ReferralPendingChallengeProjection?) -> Self? {
@@ -170,6 +192,7 @@ struct ReferralStatusProjection: Equatable, Sendable {
             firstServingSeen: firstServingSeen,
             joinLinksEnabled: joinLinksEnabled,
             socialBonusEnabled: socialBonusEnabled,
+            socialBonusGrantsRemaining: socialBonusGrantsRemaining,
             inviteCode: inviteCode,
             inviteURL: inviteURL,
             observedAt: observedAt,
@@ -190,6 +213,7 @@ struct ReferralStatusProjection: Equatable, Sendable {
             firstServingSeen: firstServingSeen,
             joinLinksEnabled: joinLinksEnabled,
             socialBonusEnabled: enabled,
+            socialBonusGrantsRemaining: enabled ? socialBonusGrantsRemaining : nil,
             inviteCode: inviteCode,
             inviteURL: inviteURL,
             observedAt: observedAt,
@@ -233,9 +257,9 @@ struct ReferralStatusProjection: Equatable, Sendable {
 
 enum ReferralPanelPresenter {
     /// Persistent chrome clarifying SPEC-034's two-step earn path: base from
-    /// first verified buyer-serving settlement, optional exactly-once X bonus.
+    /// first verified buyer-serving settlement, then repeatable X bonuses.
     static let pathChrome =
-        "Base unlocks after first paid serve · Optional X post adds bonus invites"
+        "Base unlocks after first paid serve · Each X post can add bonus invites"
 
     static func headline(availability: ReferralAvailability, status: ReferralStatusProjection?) -> String {
         switch availability {
@@ -324,7 +348,10 @@ enum ReferralPanelPresenter {
         let base = "\(status.baseCapacity) base from serving"
         let bonus = "\(status.bonusCapacity) from X bonus"
         if status.remaining > 0, status.availableInviteURL != nil {
-            return "\(base) · \(bonus). Remaining invites stay copyable — X is not required to invite."
+            if status.canStartSocialChallenge {
+                return "\(base) · \(bonus). Copy invites anytime, or share another X post for \(invitePhrase(status.configuredBonusCapacity))."
+            }
+            return "\(base) · \(bonus). Remaining invites stay copyable; X is not required to invite."
         }
         if status.remaining > 0 {
             return "\(base) · \(bonus). Remaining capacity is preserved; invite link unavailable right now."

--- a/phase3-binary/app/Tests/MalibuTests/ControlFrameCodecTests.swift
+++ b/phase3-binary/app/Tests/MalibuTests/ControlFrameCodecTests.swift
@@ -31,6 +31,7 @@ final class ControlFrameCodecTests: XCTestCase {
             firstServingSeen: true,
             joinLinksEnabled: true,
             socialBonusEnabled: true,
+            socialBonusGrantsRemaining: 5,
             inviteCode: "invite-123",
             inviteURL: URL(string: "https://malibu.tech/j#/invite-123"),
             observedAt: observedAt,

--- a/phase3-binary/app/Tests/MalibuTests/ReferralProjectionTests.swift
+++ b/phase3-binary/app/Tests/MalibuTests/ReferralProjectionTests.swift
@@ -36,7 +36,7 @@ final class ReferralProjectionTests: XCTestCase {
                 .contains("base invite")
         )
         XCTAssertTrue(ReferralPanelPresenter.pathChrome.contains("first paid serve"))
-        XCTAssertTrue(ReferralPanelPresenter.pathChrome.contains("Optional X"))
+        XCTAssertTrue(ReferralPanelPresenter.pathChrome.contains("Each X"))
     }
 
     func testEligibleStatusUsesExactCoordinatorCapacity() throws {
@@ -58,7 +58,18 @@ final class ReferralProjectionTests: XCTestCase {
         XCTAssertTrue(status.canStartSocialChallenge)
     }
 
-    func testMaturedStatusShowsBaseAndXBonusSplit() throws {
+    func testExhaustedProviderCanStartXChallengeWithoutCopyableInvite() throws {
+        let status = try XCTUnwrap(makeStatus(
+            redemptions: 1,
+            remaining: 0
+        ))
+
+        XCTAssertNil(status.availableInviteURL)
+        XCTAssertEqual(status.socialChallengeInviteURL?.absoluteString, "https://malibu.tech/j#/CODE")
+        XCTAssertTrue(status.canStartSocialChallenge)
+    }
+
+    func testMaturedStatusShowsBaseAndXBonusSplitAndCanStartAgain() throws {
         let status = try XCTUnwrap(makeStatus(
             socialState: ReferralStatusProjection.matured,
             remaining: 3,
@@ -72,13 +83,28 @@ final class ReferralProjectionTests: XCTestCase {
         let detail = ReferralPanelPresenter.detail(availability: .available, status: status)
         XCTAssertTrue(detail.contains("1 base from serving"))
         XCTAssertTrue(detail.contains("2 from X bonus"))
-        XCTAssertTrue(detail.contains("X is not required to invite"))
+        XCTAssertTrue(detail.contains("share another X post"))
         XCTAssertEqual(
             ReferralPanelPresenter.capacity(status),
             "3 remaining · 0 redeemed · 1 base + 2 X bonus (3 total)"
         )
-        XCTAssertFalse(status.canStartSocialChallenge)
+        XCTAssertTrue(status.canStartSocialChallenge)
         XCTAssertNotNil(status.availableInviteURL)
+    }
+
+    func testMaturedLegacyStatusWithoutGrantCapCannotStartAgain() throws {
+        let status = try XCTUnwrap(makeStatus(
+            socialState: ReferralStatusProjection.matured,
+            remaining: 3,
+            bonusCapacity: 2,
+            socialBonusGrantsRemaining: nil
+        ))
+
+        XCTAssertFalse(status.canStartSocialChallenge)
+        XCTAssertFalse(
+            ReferralPanelPresenter.detail(availability: .available, status: status)
+                .contains("share another X post")
+        )
     }
 
     func testCapacityDoesNotAdvertiseXBonusOutsideActionableStates() throws {
@@ -128,6 +154,7 @@ final class ReferralProjectionTests: XCTestCase {
             firstServingSeen: true,
             joinLinksEnabled: true,
             socialBonusEnabled: true,
+            socialBonusGrantsRemaining: 5,
             inviteCode: nil,
             inviteURL: nil,
             observedAt: Date(),
@@ -158,6 +185,7 @@ final class ReferralProjectionTests: XCTestCase {
             firstServingSeen: true,
             joinLinksEnabled: true,
             socialBonusEnabled: true,
+            socialBonusGrantsRemaining: 5,
             inviteCode: nil,
             inviteURL: nil,
             observedAt: Date(),
@@ -374,6 +402,13 @@ final class ReferralProjectionTests: XCTestCase {
         XCTAssertFalse(rolledBack.canStartSocialChallenge)
     }
 
+    func testSocialGrantCapSuppressesAdvocacyActions() throws {
+        let status = try XCTUnwrap(makeStatus(socialBonusGrantsRemaining: 0))
+
+        XCTAssertNotNil(status.socialChallengeInviteURL)
+        XCTAssertFalse(status.canStartSocialChallenge)
+    }
+
     func testReferralBoundaryNegotiatesByCapabilityNotMarketingVersion() {
         var snapshot = AgentSnapshot.empty
         snapshot.cliVersion = "99.1"
@@ -404,6 +439,7 @@ final class ReferralProjectionTests: XCTestCase {
         snapshot.localStatusCapabilities = [
             "referral_status_v1",
             "referral_advocacy_v1",
+            "referral_repeatable_advocacy_v1",
             "referral_fragment_links_v1",
             "service_instance_v1",
             "status_observation_v1",
@@ -422,6 +458,7 @@ final class ReferralProjectionTests: XCTestCase {
         bonusCapacity: Int = 0,
         joinBaseURL: URL = URL(string: "https://malibu.tech/j")!,
         joinLinksEnabled: Bool = true,
+        socialBonusGrantsRemaining: Int? = 5,
         inviteURL: URL? = URL(string: "https://malibu.tech/j#/CODE"),
         observedAt: Date = Date()
     ) -> ReferralStatusProjection? {
@@ -437,6 +474,7 @@ final class ReferralProjectionTests: XCTestCase {
             firstServingSeen: firstServingSeen,
             joinLinksEnabled: joinLinksEnabled,
             socialBonusEnabled: true,
+            socialBonusGrantsRemaining: socialBonusGrantsRemaining,
             inviteCode: "CODE",
             inviteURL: inviteURL,
             observedAt: observedAt,

--- a/phase4-coordinator/cmd/coordinator/main.go
+++ b/phase4-coordinator/cmd/coordinator/main.go
@@ -495,6 +495,7 @@ func main() {
 		HMACKeys:                cfg.Referrals.HMACKeys,
 		ProviderBaseUses:        cfg.Referrals.ProviderBaseUses,
 		SocialBonusUses:         cfg.Referrals.SocialBonusUses,
+		SocialBonusMaxGrants:    cfg.Referrals.SocialBonusMaxGrants,
 		ChallengeTTL:            time.Duration(cfg.Referrals.ChallengeTTLS) * time.Second,
 		SocialVerificationDwell: time.Duration(cfg.Referrals.SocialVerificationDwellS) * time.Second,
 	}

--- a/phase4-coordinator/dist/coordinator.yaml
+++ b/phase4-coordinator/dist/coordinator.yaml
@@ -126,6 +126,7 @@ referrals:
     k1: env:MAL_REFERRAL_HMAC_K1
   provider_base_uses: 1
   social_bonus_uses: 2
+  social_bonus_max_grants_per_provider: 5
   challenge_ttl_s: 900
   social_verification_dwell_s: 1800
   join_base_url: "https://malibu.tech/j"

--- a/phase4-coordinator/internal/auth/referrals_core.go
+++ b/phase4-coordinator/internal/auth/referrals_core.go
@@ -44,6 +44,7 @@ type ReferralPolicy struct {
 	HMACKeys                map[string]string
 	ProviderBaseUses        int
 	SocialBonusUses         int
+	SocialBonusMaxGrants    int
 	ChallengeTTL            time.Duration
 	SocialVerificationDwell time.Duration
 }
@@ -73,8 +74,8 @@ func (p ReferralPolicy) Validate() error {
 	if p.ProviderBaseUses <= 0 {
 		return fmt.Errorf("referral provider capacity must be positive")
 	}
-	if p.EnableSocialBonus && (p.SocialBonusUses <= 0 || p.ChallengeTTL <= 0 || p.SocialVerificationDwell <= 0) {
-		return fmt.Errorf("referral social capacity, challenge ttl, and verification dwell must be positive")
+	if p.EnableSocialBonus && (p.SocialBonusUses <= 0 || p.SocialBonusMaxGrants <= 0 || p.ChallengeTTL <= 0 || p.SocialVerificationDwell <= 0) {
+		return fmt.Errorf("referral social capacity, max grants, challenge ttl, and verification dwell must be positive")
 	}
 	return nil
 }

--- a/phase4-coordinator/internal/auth/referrals_social.go
+++ b/phase4-coordinator/internal/auth/referrals_social.go
@@ -47,16 +47,17 @@ var socialAuditTokenPattern = regexp.MustCompile(`^[a-z][a-z0-9_]{0,47}$`)
 // ProviderReferral is the authoritative provider-invite snapshot. Capacity is
 // redemption-only: no public hold or reservation state is represented here.
 type ProviderReferral struct {
-	Code             string
-	Campaign         string
-	IssuerID         string
-	BaseCapacity     int
-	BonusCapacity    int
-	Redemptions      int
-	Remaining        int
-	SocialState      string
-	FirstServingSeen bool
-	Revoked          bool
+	Code                       string
+	Campaign                   string
+	IssuerID                   string
+	BaseCapacity               int
+	BonusCapacity              int
+	Redemptions                int
+	Remaining                  int
+	SocialState                string
+	SocialBonusGrantsRemaining int
+	FirstServingSeen           bool
+	Revoked                    bool
 }
 
 type SocialChallenge struct {
@@ -135,7 +136,7 @@ func referralSocialSchemaStatements() []string {
 			submitted_at TEXT NOT NULL,
 			pending_since TEXT NOT NULL,
 			granted_at TEXT,
-			failed_at TEXT NOT NULL,
+			failed_at TEXT,
 			archived_at TEXT NOT NULL
 		)`,
 		`CREATE TABLE IF NOT EXISTS referral_social_grants (
@@ -325,6 +326,16 @@ SELECT i.issuer_id, i.key_id, i.base_capacity, i.bonus_capacity, q.evidence_at, 
 	if out.Remaining < 0 {
 		out.Remaining = 0
 	}
+	grantCount, err := s.socialGrantCount(ctx, policy.Campaign, providerID)
+	if err != nil {
+		return ProviderReferral{}, err
+	}
+	if policy.EnableSocialBonus {
+		out.SocialBonusGrantsRemaining = policy.SocialBonusMaxGrants - grantCount
+		if out.SocialBonusGrantsRemaining < 0 {
+			out.SocialBonusGrantsRemaining = 0
+		}
+	}
 	out.Code, err = EncodeReferralCode(policy, ReferralTypeProvider, keyID, out.IssuerID)
 	if err != nil {
 		return ProviderReferral{}, err
@@ -347,7 +358,11 @@ SELECT EXISTS(
 		if terminalFailure {
 			out.SocialState = SocialStateFailed
 		} else {
-			out.SocialState = SocialStateEligible
+			if grantCount > 0 {
+				out.SocialState = SocialStateMatured
+			} else {
+				out.SocialState = SocialStateEligible
+			}
 		}
 	case err != nil:
 		return ProviderReferral{}, err
@@ -445,12 +460,19 @@ SELECT i.issuer_id, i.key_id
 		case errors.Is(err, sql.ErrNoRows):
 		case err != nil:
 			return err
-		case grantedAt.Valid || !failedAt.Valid:
+		case !grantedAt.Valid && !failedAt.Valid:
 			return ErrSocialChallenge
 		default:
-			if err := archiveFailedVerificationTx(ctx, conn, providerID, policy.Campaign, now); err != nil {
+			if err := archiveTerminalVerificationTx(ctx, conn, providerID, policy.Campaign, now); err != nil {
 				return err
 			}
+		}
+		grantCount, err := socialGrantCountTx(ctx, conn, policy.Campaign, providerID)
+		if err != nil {
+			return err
+		}
+		if grantCount >= policy.SocialBonusMaxGrants {
+			return ErrSocialChallenge
 		}
 		if _, err := conn.ExecContext(ctx, `
 DELETE FROM referral_social_failures
@@ -477,16 +499,37 @@ VALUES (?, ?, ?, ?, ?, ?)`, digestText, providerID, policy.Campaign, issuerID, t
 	return SocialChallenge{Cleartext: cleartext, ExpiresAt: expiresAt, Code: code}, nil
 }
 
-func archiveFailedVerificationTx(ctx context.Context, conn *sql.Conn, providerID, campaign string, now time.Time) error {
+func (s *Store) socialGrantCount(ctx context.Context, campaign, providerID string) (int, error) {
+	var count int
+	err := s.db.QueryRowContext(ctx, `
+SELECT COUNT(1)
+  FROM referral_social_grants
+ WHERE campaign = ? AND provider_id = ?
+   AND (bonus_kind = ? OR bonus_kind GLOB ?)`, campaign, providerID, socialGrantKind, socialGrantKind+":*").Scan(&count)
+	return count, err
+}
+
+func socialGrantCountTx(ctx context.Context, conn *sql.Conn, campaign, providerID string) (int, error) {
+	var count int
+	err := conn.QueryRowContext(ctx, `
+SELECT COUNT(1)
+  FROM referral_social_grants
+ WHERE campaign = ? AND provider_id = ?
+   AND (bonus_kind = ? OR bonus_kind GLOB ?)`, campaign, providerID, socialGrantKind, socialGrantKind+":*").Scan(&count)
+	return count, err
+}
+
+func archiveTerminalVerificationTx(ctx context.Context, conn *sql.Conn, providerID, campaign string, now time.Time) error {
 	result, err := conn.ExecContext(ctx, `
 INSERT INTO referral_social_verification_history (
     provider_id, campaign, issuer_id, challenge_hash, post_id, author_id, share_url_hash,
     verification_method, submitted_at, pending_since, granted_at, failed_at, archived_at
 )
 SELECT provider_id, campaign, issuer_id, challenge_hash, post_id, author_id, share_url_hash,
-       verification_method, submitted_at, pending_since, granted_at, failed_at, ?
+       verification_method, submitted_at, pending_since, granted_at,
+       COALESCE(failed_at, granted_at, ?), ?
   FROM referral_social_verifications
- WHERE provider_id = ? AND campaign = ? AND failed_at IS NOT NULL`, timeText(now.UTC()), providerID, campaign)
+ WHERE provider_id = ? AND campaign = ? AND (granted_at IS NOT NULL OR failed_at IS NOT NULL)`, timeText(now.UTC()), timeText(now.UTC()), providerID, campaign)
 	if err != nil {
 		return err
 	}
@@ -494,7 +537,7 @@ SELECT provider_id, campaign, issuer_id, challenge_hash, post_id, author_id, sha
 	if err != nil || changed != 1 {
 		return ErrSocialChallenge
 	}
-	result, err = conn.ExecContext(ctx, `DELETE FROM referral_social_verifications WHERE provider_id = ? AND campaign = ? AND failed_at IS NOT NULL`, providerID, campaign)
+	result, err = conn.ExecContext(ctx, `DELETE FROM referral_social_verifications WHERE provider_id = ? AND campaign = ? AND (granted_at IS NOT NULL OR failed_at IS NOT NULL)`, providerID, campaign)
 	if err != nil {
 		return err
 	}
@@ -865,6 +908,25 @@ UPDATE referral_social_verifications SET failed_at = ?, lease_token = NULL, leas
 			return recordSocialAuditTx(ctx, conn, policy.Campaign, claim.providerID, claim.issuerID, "recheck", "terminal", hashSocialSubject(claim.postID), "external_rejection", now)
 		}
 
+		grantCount, err := socialGrantCountTx(ctx, conn, policy.Campaign, claim.providerID)
+		if err != nil {
+			return err
+		}
+		if grantCount >= policy.SocialBonusMaxGrants {
+			result, err := conn.ExecContext(ctx, `
+UPDATE referral_social_verifications SET failed_at = ?, lease_token = NULL, lease_until = NULL
+ WHERE provider_id = ? AND campaign = ? AND issuer_id = ? AND lease_token = ?
+   AND granted_at IS NULL AND failed_at IS NULL`, timeText(now.UTC()), claim.providerID, policy.Campaign, claim.issuerID, claim.leaseToken)
+			if err != nil {
+				return err
+			}
+			changed, err := result.RowsAffected()
+			if err != nil || changed == 0 {
+				return err
+			}
+			return recordSocialAuditTx(ctx, conn, policy.Campaign, claim.providerID, claim.issuerID, "recheck", "terminal", hashSocialSubject(claim.postID), "cap_reached", now)
+		}
+
 		result, err := conn.ExecContext(ctx, `
 INSERT INTO referral_social_grants (campaign, provider_id, bonus_kind, issuer_id, verification_post_hash, amount, granted_at)
 SELECT ?, ?, ?, ?, ?, ?, ?
@@ -878,7 +940,7 @@ SELECT ?, ?, ?, ?, ?, ?, ?
        JOIN referral_issuers i ON i.issuer_id = q.issuer_id
         WHERE q.provider_id = ? AND q.campaign = ? AND q.issuer_id = ? AND i.revoked_at IS NULL
    )
-ON CONFLICT(campaign, provider_id, bonus_kind) DO NOTHING`, policy.Campaign, claim.providerID, socialGrantKind, claim.issuerID, hashSocialSubject(claim.postID), policy.SocialBonusUses, timeText(now.UTC()), claim.providerID, policy.Campaign, claim.issuerID, claim.leaseToken, claim.providerID, policy.Campaign, claim.issuerID)
+ON CONFLICT(campaign, provider_id, bonus_kind) DO NOTHING`, policy.Campaign, claim.providerID, socialGrantKindForPost(claim.postID), claim.issuerID, hashSocialSubject(claim.postID), policy.SocialBonusUses, timeText(now.UTC()), claim.providerID, policy.Campaign, claim.issuerID, claim.leaseToken, claim.providerID, policy.Campaign, claim.issuerID)
 		if err != nil {
 			return err
 		}
@@ -967,6 +1029,10 @@ VALUES (?, ?, NULLIF(?, ''), ?, ?, ?, ?, ?)`, campaign, providerID, issuerID, ev
 func hashSocialSubject(value string) string {
 	digest := sha256.Sum256([]byte(value))
 	return fmt.Sprintf("%x", digest[:])
+}
+
+func socialGrantKindForPost(postID string) string {
+	return socialGrantKind + ":" + hashSocialSubject(postID)
 }
 
 func randomReferralID() (string, error) {

--- a/phase4-coordinator/internal/auth/referrals_social_test.go
+++ b/phase4-coordinator/internal/auth/referrals_social_test.go
@@ -18,6 +18,7 @@ func socialReferralPolicy() ReferralPolicy {
 	policy := coreReferralPolicy()
 	policy.EnableSocialBonus = true
 	policy.SocialBonusUses = 2
+	policy.SocialBonusMaxGrants = 5
 	policy.ChallengeTTL = 15 * time.Minute
 	policy.SocialVerificationDwell = 30 * time.Minute
 	return policy
@@ -351,6 +352,91 @@ func TestParallelPromotersGrantBonusExactlyOnce(t *testing.T) {
 	}
 	if _, err := first.db.Exec(`DELETE FROM referral_social_grants`); err == nil {
 		t.Fatal("grant delete unexpectedly succeeded")
+	}
+}
+
+func TestVerifiedProviderCanEarnRepeatedXPostBonuses(t *testing.T) {
+	store := openSocialStore(t)
+	policy := socialReferralPolicy()
+	now := time.Date(2026, 7, 13, 10, 0, 0, 0, time.UTC)
+	providerID := "provider-repeat"
+	createPendingSocialVerification(t, store, policy, providerID, "444", now)
+
+	firstMature := now.Add(policy.SocialVerificationDwell)
+	if granted, err := store.PromoteMaturedSocialVerifications(context.Background(), policy, firstMature, func(context.Context, string, string, string) error { return nil }); err != nil || granted != 1 {
+		t.Fatalf("first grant=%d err=%v", granted, err)
+	}
+	firstStatus, err := store.ProviderReferralStatus(context.Background(), policy, providerID)
+	if err != nil || firstStatus.SocialState != SocialStateMatured || firstStatus.BonusCapacity != policy.SocialBonusUses {
+		t.Fatalf("first status=%+v err=%v", firstStatus, err)
+	}
+	if firstStatus.SocialBonusGrantsRemaining != policy.SocialBonusMaxGrants-1 {
+		t.Fatalf("first grants remaining=%d", firstStatus.SocialBonusGrantsRemaining)
+	}
+
+	secondChallenge, err := store.CreateSocialChallenge(context.Background(), policy, providerID, firstMature.Add(time.Minute))
+	if err != nil {
+		t.Fatalf("second challenge err=%v", err)
+	}
+	if _, err := store.CompleteSocialVerification(context.Background(), policy, providerID, secondChallenge.Cleartext, "444", "456", strings.Repeat("b", 64), "x_api", firstMature.Add(2*time.Minute)); !errors.Is(err, ErrSocialChallenge) {
+		t.Fatalf("post reuse err=%v", err)
+	}
+	secondStatus, err := store.CompleteSocialVerification(context.Background(), policy, providerID, secondChallenge.Cleartext, "555", "456", strings.Repeat("b", 64), "x_api", firstMature.Add(3*time.Minute))
+	if err != nil || secondStatus.SocialState != SocialStatePending {
+		t.Fatalf("second submission status=%+v err=%v", secondStatus, err)
+	}
+
+	secondMature := firstMature.Add(3 * time.Minute).Add(policy.SocialVerificationDwell)
+	if granted, err := store.PromoteMaturedSocialVerifications(context.Background(), policy, secondMature, func(context.Context, string, string, string) error { return nil }); err != nil || granted != 1 {
+		t.Fatalf("second grant=%d err=%v", granted, err)
+	}
+	finalStatus, err := store.ProviderReferralStatus(context.Background(), policy, providerID)
+	if err != nil || finalStatus.SocialState != SocialStateMatured || finalStatus.BonusCapacity != 2*policy.SocialBonusUses {
+		t.Fatalf("final status=%+v err=%v", finalStatus, err)
+	}
+	if finalStatus.SocialBonusGrantsRemaining != policy.SocialBonusMaxGrants-2 {
+		t.Fatalf("final grants remaining=%d", finalStatus.SocialBonusGrantsRemaining)
+	}
+
+	var grants, history int
+	if err := store.db.QueryRow(`SELECT COUNT(1) FROM referral_social_grants WHERE campaign = ? AND provider_id = ?`, policy.Campaign, providerID).Scan(&grants); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.db.QueryRow(`SELECT COUNT(1) FROM referral_social_verification_history WHERE provider_id = ?`, providerID).Scan(&history); err != nil {
+		t.Fatal(err)
+	}
+	if grants != 2 || history != 1 {
+		t.Fatalf("grants=%d history=%d", grants, history)
+	}
+}
+
+func TestSocialChallengeStopsAtProviderGrantCap(t *testing.T) {
+	store := openSocialStore(t)
+	policy := socialReferralPolicy()
+	policy.SocialBonusMaxGrants = 2
+	now := time.Date(2026, 7, 13, 10, 0, 0, 0, time.UTC)
+	providerID := "provider-cap"
+	qualifyProvider(t, store, policy, providerID, now.Add(-time.Minute))
+
+	for i, postID := range []string{"601", "602"} {
+		challenge, err := store.CreateSocialChallenge(context.Background(), policy, providerID, now.Add(time.Duration(i)*time.Hour))
+		if err != nil {
+			t.Fatalf("challenge %d err=%v", i, err)
+		}
+		if _, err := store.CompleteSocialVerification(context.Background(), policy, providerID, challenge.Cleartext, postID, "456", testSocialShareURLHash, "x_api", now.Add(time.Duration(i)*time.Hour+time.Minute)); err != nil {
+			t.Fatalf("complete %d err=%v", i, err)
+		}
+		if granted, err := store.PromoteMaturedSocialVerifications(context.Background(), policy, now.Add(time.Duration(i)*time.Hour+time.Minute).Add(policy.SocialVerificationDwell), func(context.Context, string, string, string) error { return nil }); err != nil || granted != 1 {
+			t.Fatalf("promote %d granted=%d err=%v", i, granted, err)
+		}
+	}
+
+	status, err := store.ProviderReferralStatus(context.Background(), policy, providerID)
+	if err != nil || status.SocialBonusGrantsRemaining != 0 || status.BonusCapacity != 2*policy.SocialBonusUses {
+		t.Fatalf("status=%+v err=%v", status, err)
+	}
+	if _, err := store.CreateSocialChallenge(context.Background(), policy, providerID, now.Add(3*time.Hour)); !errors.Is(err, ErrSocialChallenge) {
+		t.Fatalf("cap challenge err=%v", err)
 	}
 }
 

--- a/phase4-coordinator/internal/config/config.go
+++ b/phase4-coordinator/internal/config/config.go
@@ -954,6 +954,7 @@ type ReferralConfig struct {
 	HMACKeys                 map[string]string `yaml:"hmac_keys"`
 	ProviderBaseUses         int               `yaml:"provider_base_uses"`
 	SocialBonusUses          int               `yaml:"social_bonus_uses"`
+	SocialBonusMaxGrants     int               `yaml:"social_bonus_max_grants_per_provider"`
 	ChallengeTTLS            int               `yaml:"challenge_ttl_s"`
 	SocialVerificationDwellS int               `yaml:"social_verification_dwell_s"`
 	JoinBaseURL              string            `yaml:"join_base_url"`
@@ -1387,6 +1388,7 @@ func Default() Config {
 		Referrals: ReferralConfig{
 			ProviderBaseUses:         1,
 			SocialBonusUses:          2,
+			SocialBonusMaxGrants:     5,
 			ChallengeTTLS:            900,
 			SocialVerificationDwellS: 1800,
 			JoinBaseURL:              "https://malibu.tech/j",
@@ -2537,8 +2539,8 @@ func (c Config) validateReferrals() error {
 		return fmt.Errorf("referrals.provider_base_uses must be > 0")
 	}
 	if r.EnableSocialInviteBonus {
-		if r.SocialBonusUses <= 0 || r.ChallengeTTLS <= 0 || r.SocialVerificationDwellS <= 0 {
-			return fmt.Errorf("referrals social_bonus_uses, challenge_ttl_s, and social_verification_dwell_s must be > 0")
+		if r.SocialBonusUses <= 0 || r.SocialBonusMaxGrants <= 0 || r.ChallengeTTLS <= 0 || r.SocialVerificationDwellS <= 0 {
+			return fmt.Errorf("referrals social_bonus_uses, social_bonus_max_grants_per_provider, challenge_ttl_s, and social_verification_dwell_s must be > 0")
 		}
 		if strings.TrimSpace(r.XAPIBearerToken) == "" {
 			return fmt.Errorf("referrals.x_api_bearer_token must be set when social invite bonus is enabled")

--- a/phase4-coordinator/internal/referralapi/advocacy.go
+++ b/phase4-coordinator/internal/referralapi/advocacy.go
@@ -329,6 +329,9 @@ func (h *AdvocacyHandler) writeStatus(w http.ResponseWriter, status auth.Provide
 		"join_links_enabled":        h.JoinLinksEnabled,
 		"social_bonus_enabled":      h.Policy.EnableSocialBonus,
 	}
+	if h.Policy.EnableSocialBonus {
+		body["social_bonus_grants_remaining"] = status.SocialBonusGrantsRemaining
+	}
 	if status.Code != "" {
 		body["invite_code"] = status.Code
 	}

--- a/phase4-coordinator/internal/referralapi/advocacy_test.go
+++ b/phase4-coordinator/internal/referralapi/advocacy_test.go
@@ -61,6 +61,7 @@ func advocacyPolicy() auth.ReferralPolicy {
 		HMACKeys:                map[string]string{"k1": strings.Repeat("s", 32)},
 		ProviderBaseUses:        1,
 		SocialBonusUses:         2,
+		SocialBonusMaxGrants:    5,
 		ChallengeTTL:            15 * time.Minute,
 		SocialVerificationDwell: 30 * time.Minute,
 	}

--- a/specs/SPEC-034-referral-gated-prebeta.md
+++ b/specs/SPEC-034-referral-gated-prebeta.md
@@ -45,8 +45,8 @@ Changelog:
 
 A new provider can redeem a referral through the installed CLI, become
 buyer-serving, earn invite capacity from coordinator-authoritative serving
-evidence, refer another provider, and optionally earn an exactly-once bonus for
-a server-verified X post.
+evidence, refer another provider, and optionally earn bounded repeat bonuses
+for distinct server-verified X posts.
 
 The coordinator is authoritative for code validity, redemption, attribution,
 invite balances, serving qualification, social decisions, grants, and audit.
@@ -167,7 +167,7 @@ one-time Air exception as #613 conformance.
 | X submission | Coordinator | Positively verified canonical post ID/URL digest and provider/campaign/challenge binding; terminal failures use a separate provider-scoped failure row | Verification/recheck worker, audit, status | Verified post ID is globally unique; terminal failure uses `(campaign, provider_id, challenge_digest, post_id)` without reserving the post globally | Duplicate same submission converges; a positively verified reused post or author mismatch rejects; an unverified rejected post cannot deny another provider's later legitimate verification | `pending`, `failed`, or `matured` with truthful reason | Success, bad URL, wrong author, wrong link, replay, cross-provider rejected-post reuse, and rate-limit cases |
 | X verification decision | Coordinator server-side verifier | Current verification or terminal-failure row plus append-only social decision audit | Bonus transaction, status, security/operator review | Verification attempt/event UUID and expected prior state | External transient failure is retryable; terminal failure is stable and response-loss safe without claiming global ownership of unverified evidence; redirects and untrusted origins fail closed | Pending/retryable/terminal failure separated | Audit records challenge, submit, recheck, decision, and redacted cause |
 | X observed-author binding | Coordinator records the positive X API result | Numeric `author_id` in the pending verification and immutable history/audit | Recheck worker and security/operator review | Globally unique positively verified post ID + initial numeric author ID | This is continuity of the observed post author, not proof the provider owns an X account; recheck must return the same nonempty numeric author or fail terminally | No ownership badge; only pending/failed/matured reward state | Empty/non-numeric author rejects; changed author on recheck fails; exact author continuity may mature |
-| Bonus grant | Coordinator | Conditional verification `granted_at` plus issuer bonus or dedicated grant row and audit event | Status and operator audit | `(campaign, provider_id, bonus_kind)` | Transactional conditional grant makes parallel rechecks no-ops after one winner | `matured` and exact bonus/remaining counts | Concurrent promotion grants capacity exactly once |
+| Bonus grant | Coordinator | Conditional verification `granted_at` plus issuer bonus or dedicated grant row and audit event | Status and operator audit | `(campaign, provider_id, bonus_kind)` where repeatable grants bind `bonus_kind` to the positive post digest | Transactional conditional grant makes parallel rechecks no-ops after one winner; configured provider/campaign max-grant cap prevents unbounded minting | `matured` and exact bonus/remaining counts, plus repeat grants remaining when social bonus is enabled | Concurrent promotion grants capacity once per distinct verified post and never above the provider cap |
 | Operator mutation | Coordinator CLI/admin path | Append-only audit with actor, reason, target, expected prior state, result | Operators/security review | Audit event UUID + compare-and-swap expectation | Dry-run and expected-value checks prevent stale writes; rollback is explicit | Not exposed as provider success until committed | Seed, adjust, replace, revoke, and raced mutation audit tests |
 | Malibu referral projection | CLI writes sanitized status from coordinator authority | Versioned local status/control response; no App-side policy database | Malibu only | Capability name + schema version + coordinator revision | Unsupported older/newer CLI renders unavailable and suppresses actions | Truthful disabled/locked/pending/failed/matured/exhausted/revoked/unavailable states | Independent Malibu/CLI marketing versions negotiate by capability, not equality |
 
@@ -290,7 +290,17 @@ interface. The CLI owns all authenticated coordinator calls and exposes only a
 sanitized owner-only control-socket projection under `referral_status_v1`.
 Typed challenge/verify/cancel/reopen actions additionally require
 `referral_advocacy_v1`; a status-capable CLI without that capability remains
-read-only. All referral projection and actions additionally require
+read-only for advocacy. Repeat actions after an already matured X bonus
+additionally require `referral_repeatable_advocacy_v1` and coordinator status
+field `social_bonus_grants_remaining > 0`; without that repeatable capability,
+Malibu MUST suppress post-maturity X actions even when the old advocacy
+capability is present. A repeatable grant is bounded by
+`social_bonus_max_grants_per_provider` for the campaign and is keyed by the
+verified post digest, so a distinct post can grant once and the campaign cap
+prevents unbounded invite minting. The share/challenge invite URL is a canonical
+binding target and may remain present even when `remaining == 0`; Malibu MUST
+separately gate copyable invites on positive remaining capacity.
+All referral projection and actions additionally require
 `referral_fragment_links_v1`; its absence suppresses referral UI rather than
 falling back to the legacy path/query grammar. Malibu and CLI marketing versions are independent;
 compatibility is negotiated by advertised protocol capabilities and schema


### PR DESCRIPTION
## Summary

Closes #914.

This adds a visible Malibu X-share path for provider invites and makes social rewards repeatable within a coordinator-enforced campaign cap. Exhausted providers can still open the X challenge flow using the canonical invite binding URL, while copyable private invites remain gated on positive remaining capacity.

## What Changed

- Malibu now separates copyable invite availability from the X challenge invite binding, so providers with `remaining == 0` can still earn more invites.
- CLI/coordinator status now carries `social_bonus_grants_remaining` and advertises `referral_repeatable_advocacy_v1` for post-maturity repeat actions.
- Coordinator grants are keyed per verified post digest and bounded by `social_bonus_max_grants_per_provider`.
- SPEC-034 now documents bounded repeat advocacy rewards and the repeat capability/status contract.

## Validation

- `go test ./internal/auth ./internal/referralapi ./internal/config ./internal/buyer ./internal/billing`
- `swift test --filter ReferralCoordinatorClientTests`
- `swift test --filter ProviderStatusTests`
- `swift test --filter ControlSocketTests`
- `xcodegen generate && xcodebuild test -project Malibu.xcodeproj -scheme Malibu -only-testing:MalibuTests/ReferralProjectionTests -only-testing:MalibuTests/ControlFrameCodecTests -quiet`
- `git diff --check`
- Final code/security/architect review lanes: 0 C/H/M findings

SPEC-GOVERNANCE-DECLARATION-BEGIN
{
  "schema_version": "spec-pr-governance-v1",
  "behavior_change": "yes",
  "contract_change": "yes",
  "specs": ["SPEC-034"],
  "requirements": ["SPEC-034-R001"],
  "authority_domains": ["referral-advocacy-policy"],
  "arbitration": ["CODE_BUG"],
  "tests": [
    "go test ./internal/auth ./internal/referralapi ./internal/config ./internal/buyer ./internal/billing",
    "swift test --filter ReferralCoordinatorClientTests",
    "swift test --filter ProviderStatusTests",
    "swift test --filter ControlSocketTests",
    "xcodebuild Malibu ReferralProjectionTests ControlFrameCodecTests"
  ],
  "journeys": ["not-required"],
  "issue": "https://github.com/Augustas11/macprovider/issues/914"
}
SPEC-GOVERNANCE-DECLARATION-END