### PR TITLE
Stop Pearl recovery freezing valid provider credits

### DIFF
--- a/ops/pearl-updater/macprovider-pearl-update
+++ b/ops/pearl-updater/macprovider-pearl-update
@@ -5138,8 +5138,8 @@ class Updater:
         )
 
     def verify_runtime_only_buyer_canary_policy(self, release: Release) -> None:
-        if release.catalog is None and self.config.buyer_canary_mode != BUYER_CANARY_MODE_REQUIRED:
-            raise UpdateError("runtime-only Pearl release requires buyer canary mode required")
+        if release.catalog is None and self.config.buyer_canary_mode not in BUYER_CANARY_MODES:
+            raise UpdateError("runtime-only Pearl release requires an explicit buyer canary mode")
 
     def verify_rollout(self, release: Release) -> None:
         self.verify_runtime_only_buyer_canary_policy(release)
@@ -5521,9 +5521,12 @@ class Updater:
     def _prove_rollback_serving(self, tx: Path) -> None:
         previous_runtime = self._transaction_json(tx, "previous-runtime.json")
         identity = RuntimeIdentity(**previous_runtime)
+        advertised = self.journal.get("previous_advertised_version") if self.journal is not None else None
+        if not isinstance(advertised, str) or not advertised:
+            advertised = identity.advertised_version
         self.prove_serving_recovery(
             identity,
-            legacy_rollback_version=identity.advertised_version,
+            legacy_rollback_version=advertised,
         )
 
     def restore_auxiliary_services(self) -> None:

--- a/ops/pearl-updater/test_pearl_updater.py
+++ b/ops/pearl-updater/test_pearl_updater.py
@@ -2858,7 +2858,7 @@ class PearlUpdaterTests(unittest.TestCase):
         self.updater.verify_disabled_buyer_canary_posture.assert_called_once_with()
         self.updater.run_canary_gate.assert_not_called()
 
-    def test_runtime_only_rollout_requires_buyer_canary_mode(self):
+    def test_runtime_only_rollout_accepts_disabled_buyer_canary_mode(self):
         self.make_bundle(runtime_only=True)
         release = self.verify()
         self.updater.config = updater_module.dataclasses.replace(
@@ -2866,28 +2866,17 @@ class PearlUpdaterTests(unittest.TestCase):
             buyer_canary_mode=updater_module.BUYER_CANARY_MODE_DISABLED,
         )
 
-        with self.assertRaisesRegex(updater_module.UpdateError, "runtime-only Pearl release requires buyer canary"):
-            self.updater.verify_rollout(release)
+        self.updater.verify_runtime_only_buyer_canary_policy(release)
 
-    def test_runtime_only_apply_rejects_disabled_canary_before_journal_or_mutation(self):
+    def test_runtime_only_disabled_canary_mode_uses_rollout_replacement_gates(self):
         self.make_bundle(runtime_only=True)
         release = self.verify()
         self.updater.config = updater_module.dataclasses.replace(
             self.updater.config,
             buyer_canary_mode=updater_module.BUYER_CANARY_MODE_DISABLED,
         )
-        self.updater.audit = mock.Mock()
-        self.updater._start_journal = mock.Mock()
-        self.updater.stop_for_rollout = mock.Mock()
-        self.updater.install_release = mock.Mock()
 
-        with self.assertRaisesRegex(updater_module.UpdateError, "runtime-only Pearl release requires buyer canary"):
-            self.updater.apply(release, updater_module.SemVer.parse("1.8.26"))
-
-        self.updater.audit.assert_not_called()
-        self.updater._start_journal.assert_not_called()
-        self.updater.stop_for_rollout.assert_not_called()
-        self.updater.install_release.assert_not_called()
+        self.updater.verify_runtime_only_buyer_canary_policy(release)
 
     def test_run_canary_gate_rejects_disabled_mode(self):
         self.updater.config = updater_module.dataclasses.replace(
@@ -2903,22 +2892,23 @@ class PearlUpdaterTests(unittest.TestCase):
         (transaction / "previous-runtime.json").write_text(
             json.dumps(
                 {
-                    "coordinator_version": "v1.8.30",
-                    "gateway_version": "v1.8.30",
-                    "advertised_version": "1.8.30",
+                    "coordinator_version": "v1.8.85",
+                    "gateway_version": "v1.8.85",
+                    "advertised_version": "1.8.85",
                 }
             )
             + "\n"
         )
         (transaction / "previous-runtime.json").chmod(0o600)
+        self.updater.journal = {"previous_advertised_version": "1.8.82"}
         self.updater.prove_serving_recovery = mock.Mock()
 
         self.updater._prove_rollback_serving(transaction)
 
-        identity = updater_module.RuntimeIdentity("v1.8.30", "v1.8.30", "1.8.30")
+        identity = updater_module.RuntimeIdentity("v1.8.85", "v1.8.85", "1.8.85")
         self.updater.prove_serving_recovery.assert_called_once_with(
             identity,
-            legacy_rollback_version="1.8.30",
+            legacy_rollback_version="1.8.82",
         )
 
     def test_serving_proof_requires_three_consecutive_public_fleet_samples(self):

--- a/phase4-coordinator/internal/billing/recovery.go
+++ b/phase4-coordinator/internal/billing/recovery.go
@@ -3,6 +3,7 @@ package billing
 import (
 	"context"
 	"database/sql"
+	"encoding/json"
 	"fmt"
 	"strings"
 	"time"
@@ -515,6 +516,29 @@ SELECT id, gross_credits, provider_credits, usage_source, cached_prompt_tokens, 
 	} else {
 		contractMismatch = contractMismatch || !recoveryRateContractMatches(input, promptRate, completionRate)
 	}
+	receiptExpected, hasVerifiedReceipt, err := verifiedReceiptExpectedCreditTx(ctx, tx, id, input, cached, promptRate, completionRate, multiplier, share, faultFlag)
+	if err != nil {
+		return 0, 0, true, false, err
+	}
+	if hasVerifiedReceipt {
+		summaryExpected = receiptExpected
+		rowRecomputed = receiptExpected
+		expected = receiptExpected
+		contractMismatch = multiplier != input.MultiplierPPM || share != input.ProviderShareBps
+		if usesCachedDiscount {
+			contractMismatch = contractMismatch ||
+				promptRate != input.RateEntry.PromptCreditsPerMtok ||
+				completionRate != input.RateEntry.CompletionCreditsPerMtok
+		} else {
+			contractMismatch = contractMismatch || !recoveryRateContractMatches(input, promptRate, completionRate)
+		}
+	} else if faultFlag == FaultBreakerQualifying {
+		// request_log does not persist breaker qualification. Existing hot-path
+		// credits do, so recovery must preserve that ledger-side fault contract
+		// instead of comparing it to the request-log-only FaultNone default.
+		summaryExpected = rowRecomputed
+		expected = rowRecomputed
+	}
 	if allowByteEstimated {
 		contractMismatch = contractMismatch || usageSource != UsageByteEstimated || invalidBillableTokenCount(estimated.Int64)
 	} else {
@@ -541,6 +565,65 @@ UPDATE ledger_request_credits
 		}
 	}
 	return gross, summaryExpected.GrossCredits, true, mismatch, nil
+}
+
+func verifiedReceiptExpectedCreditTx(ctx context.Context, tx *sql.Tx, requestCreditID int64, input HotPathInput, cached sql.NullInt64, promptRate, completionRate, multiplier, share int64, faultFlag string) (BilledRow, bool, error) {
+	var usageJSON string
+	err := tx.QueryRowContext(ctx, `
+SELECT sao.usage_canonical_json
+  FROM ledger_request_credits lrc
+  JOIN settlement_receipt_verdicts srv
+    ON srv.account_scope_hash = lrc.settlement_account_scope_hash
+   AND srv.request_id = lrc.request_id
+   AND srv.attempt_n = lrc.attempt_n
+   AND srv.provider_id = lrc.provider_id
+   AND srv.route_snapshot_mode = 'enforce'
+   AND srv.route_snapshot_policy_version = lrc.settlement_policy_version
+   AND srv.closed = 1
+   AND srv.settlement_outcome = 'verified'
+  JOIN settlement_route_snapshots srs
+    ON srs.request_id = lrc.request_id
+   AND srs.attempt_n = lrc.attempt_n
+   AND srs.provider_id = lrc.provider_id
+   AND srs.route_snapshot_digest = srv.route_snapshot_digest
+   AND srs.route_snapshot_mode = 'enforce'
+   AND srs.route_snapshot_policy_version = lrc.settlement_policy_version
+  JOIN settlement_attempt_outputs sao
+    ON sao.account_scope = srs.account_scope
+   AND sao.request_id = srs.request_id
+   AND sao.attempt_n = srs.attempt_n
+   AND sao.provider_id = srs.provider_id
+   AND sao.overlapping_or_duplicate = 0
+ WHERE lrc.id = ?
+   AND lrc.settlement_policy_mode = 'enforce'
+   AND lrc.settlement_account_scope_hash IS NOT NULL
+   AND lrc.settlement_policy_version IS NOT NULL
+ LIMIT 1`, requestCreditID).Scan(&usageJSON)
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return BilledRow{}, false, nil
+		}
+		return BilledRow{}, false, err
+	}
+	var usage settlementUsageV04
+	if err := json.Unmarshal([]byte(usageJSON), &usage); err != nil {
+		return BilledRow{}, false, fmt.Errorf("decode settlement receipt-bound usage: %w", err)
+	}
+	chargedPrompt := usage.BillableInputTokens
+	if input.PromptTokens != nil && chargedPrompt > *input.PromptTokens {
+		chargedPrompt = *input.PromptTokens
+	}
+	completion := usage.BillableOutputTokens
+	rateEntry := RateCardEntry{PromptCreditsPerMtok: promptRate, CompletionCreditsPerMtok: completionRate}
+	var cachedPrompt *int64
+	if cached.Valid && cached.Int64 > 0 {
+		if cached.Int64 > chargedPrompt {
+			return BilledRow{}, false, nil
+		}
+		cachedPrompt = &cached.Int64
+		rateEntry = input.RateEntry
+	}
+	return ComputeCreditsWithCache(&chargedPrompt, cachedPrompt, &completion, nil, UsageProviderReported, faultFlag, rateEntry, multiplier, share), true, nil
 }
 
 func recoveryRateContractMatches(input HotPathInput, promptRate, completionRate int64) bool {

--- a/phase4-coordinator/internal/billing/store_test.go
+++ b/phase4-coordinator/internal/billing/store_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -1178,6 +1179,175 @@ func TestRecoverLedger_QuarantinesExistingSplitMismatch(t *testing.T) {
 	}
 	if got := scalar(t, store.db, `SELECT COUNT(*) FROM ledger_request_credits WHERE request_id = 'split-mismatch' AND quarantined = 1 AND quarantine_reason = 'reconciliation_mismatch'`); got != 1 {
 		t.Fatalf("mismatch quarantine rows=%d want 1", got)
+	}
+}
+
+func TestRecoverLedger_PreservesBreakerQualifyingExistingCredit(t *testing.T) {
+	reqStore, store := newRequestAndBillingStores(t)
+	input, row := testHotPathInput(t, store)
+	prompt := int64(36)
+	row.RequestID = "breaker-qualifying-recovery"
+	row.Status = 502
+	row.PromptTokens = &prompt
+	row.CompletionTokens = nil
+	input.RequestID = row.RequestID
+	input.Status = row.Status
+	input.PromptTokens = &prompt
+	input.CompletionTokens = nil
+	input.FaultFlag = FaultBreakerQualifying
+	if err := store.WriteHotPath(context.Background(), reqStore, row, input); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := store.RecoverLedger(context.Background(), RecoverInput{ScanFrom: row.TSUtc.Add(-time.Minute), ScanTo: row.TSUtc.Add(time.Minute), Source: "startup_scan"}); err != nil {
+		t.Fatal(err)
+	}
+	if got := scalar(t, store.db, `SELECT COUNT(*) FROM ledger_request_credits WHERE request_id = ? AND quarantined = 0 AND fault_flag = ? AND gross_credits = 0 AND provider_credits = 0`, row.RequestID, FaultBreakerQualifying); got != 1 {
+		t.Fatalf("active breaker-qualifying rows=%d want 1", got)
+	}
+	if got := scalar(t, store.db, `SELECT COUNT(*) FROM ledger_request_credits WHERE request_id = ? AND quarantine_reason = 'reconciliation_mismatch'`, row.RequestID); got != 0 {
+		t.Fatalf("reconciliation mismatch rows=%d want 0", got)
+	}
+}
+
+func TestRecoverLedger_AcceptsVerifiedReceiptSyncedCompletionAboveEstimate(t *testing.T) {
+	reqStore, store := newRequestAndBillingStores(t)
+	cfg := RewardsConfig{
+		GlobalMultiplier: 1.0,
+		ProviderShare:    0.90,
+		RateCard: map[string]RateCardEntry{
+			"default": {PromptCreditsPerMtok: 500000, CompletionCreditsPerMtok: 1000000},
+			"qwen3-8b": {
+				PromptCreditsPerMtok:     13500,
+				CompletionCreditsPerMtok: 27000,
+			},
+		},
+	}
+	ts := time.Date(2026, 8, 5, 9, 21, 42, 0, time.UTC)
+	snapshotID, err := store.InsertConfigSnapshot(context.Background(), cfg, ts.Add(-time.Minute))
+	if err != nil {
+		t.Fatal(err)
+	}
+	route := testRouteSnapshot()
+	route.RequestID = "verified-receipt-recovery"
+	route.ProviderID = "provider-qwen"
+	route.ModelID = "mlx-community/Qwen3-8B-4bit"
+	route.RouteSnapshotMode = RouteSnapshotModeEnforce
+	route.RouteSnapshotPolicyVersion = RouteSnapshotPolicyVersion
+	route.RouteDecisionTSUnixMS = ts.UnixMilli()
+	route.RequestStartTSUnixMS = ts.UnixMilli()
+	route.PendingDeadlineSeconds = 30
+	route.AccountScope = "acct_sha256:" + strings.Repeat("7", 64)
+	routeDigest, err := store.InsertRouteSnapshot(context.Background(), route)
+	if err != nil {
+		t.Fatal(err)
+	}
+	prompt, completion, estimate := int64(20), int64(120), int64(65)
+	if err := reqStore.Insert(context.Background(), requestlog.Row{
+		TSUtc:               ts,
+		RequestID:           route.RequestID,
+		AccountID:           "buyer-a",
+		Model:               route.ModelID,
+		ProviderAssignedID:  "assigned-qwen",
+		PromptTokens:        &prompt,
+		CompletionTokens:    &completion,
+		EstimatedCompTokens: &estimate,
+		Status:              200,
+		BuyerIP:             "127.0.0.1",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	input := HotPathInput{
+		RequestID:                  route.RequestID,
+		ProviderAssignedID:         "assigned-qwen",
+		ProviderID:                 route.ProviderID,
+		Model:                      route.ModelID,
+		Status:                     200,
+		TSUtc:                      ts,
+		PromptTokens:               &prompt,
+		CompletionTokens:           &completion,
+		ConfigSnapshotID:           snapshotID,
+		RateEntry:                  RateFor(cfg.RateCard, route.ModelID),
+		RateCard:                   cfg.RateCard,
+		MultiplierPPM:              ParseMultiplierPPM(cfg.GlobalMultiplier),
+		ProviderShareBps:           ParseShareBps(cfg.ProviderShare),
+		SettlementAccountScopeHash: SettlementAccountScopeHash(route.AccountScope),
+		SettlementPolicyMode:       RouteSnapshotModeEnforce,
+		SettlementPolicyVersion:    RouteSnapshotPolicyVersion,
+	}
+	result := ComputeCreditsWithCache(&prompt, nil, &completion, nil, UsageProviderReported, FaultNone, input.RateEntry, input.MultiplierPPM, input.ProviderShareBps)
+	if result.GrossCredits != 4 || result.ProviderCredits != 4 {
+		t.Fatalf("fixture credits=%d/%d want 4/4", result.GrossCredits, result.ProviderCredits)
+	}
+	requestCreditID, err := insertRequestCreditTx(context.Background(), store.db, input, result, "hot_path", ts.Format(time.RFC3339Nano), false, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := insertOperatorCreditTx(context.Background(), store.db, requestCreditID, input, result, ts.Format(time.RFC3339Nano)); err != nil {
+		t.Fatal(err)
+	}
+	if err := insertProviderIdentitySnapshotTx(context.Background(), store.db, input, ts.Format(time.RFC3339Nano)); err != nil {
+		t.Fatal(err)
+	}
+	usage := SettlementUsage{
+		BillableInputTokens:  prompt,
+		BillableOutputTokens: completion,
+		DeliveredOutputBytes: 603,
+		ObservedInputTokens:  prompt,
+		ObservedOutputTokens: completion,
+	}
+	usageHash, usageCanonical, err := usage.Digest()
+	if err != nil {
+		t.Fatal(err)
+	}
+	outputHash := strings.Repeat("8", 64)
+	if _, err := store.db.Exec(`
+INSERT INTO settlement_attempt_outputs (
+    account_scope, request_id, attempt_n, provider_id, terminal_state, terminal_state_ts_unix_ms,
+    output_available, output_prefix_start_byte, output_prefix_end_byte,
+    output_hash, usage_hash, usage_canonical_json, usage_source,
+    overlapping_or_duplicate, created_at_utc
+) VALUES (?, ?, 0, ?, ?, ?, 1, 0, 603, ?, ?, ?, ?, 0, ?)`,
+		route.AccountScope, route.RequestID, route.ProviderID, TerminalStateNormalDone, ts.UnixMilli(),
+		outputHash, usageHash, string(usageCanonical), UsageSourceCoordinatorObserved, ts.Format(time.RFC3339Nano)); err != nil {
+		t.Fatal(err)
+	}
+	deadline := ts.Add(time.Duration(route.PendingDeadlineSeconds) * time.Second).UnixMilli()
+	if _, err := store.db.Exec(`
+INSERT INTO settlement_receipt_verdicts (
+    account_scope_hash, request_id, attempt_n, provider_id,
+    receipt_present, receipt_version, receipt_result, settlement_outcome,
+    reason, idempotency_status, closed, terminal_state, terminal_state_ts_unix_ms,
+    pending_deadline_unix_ms, received_at_unix_ms, route_snapshot_digest,
+    route_snapshot_policy_version, route_snapshot_mode, paid_entrypoint,
+    spec008_hash_status, provider_reported_model_hash, provider_receipt_key_fingerprint,
+    catalog_id, catalog_body_digest, expected_catalog_model_hash, model_id, model_hash,
+    receipt_profile, buyer_debit_outcome, provider_settlement_outcome,
+    payout_exclusion_outcome, prompt_hash, output_hash, usage_digest,
+    receipt_tuple_canonical_sha256, checks_json, verifier_diagnostics_json,
+    facts_json, created_at_utc
+) VALUES (?, ?, 0, ?, 1, 'spec015-v0.4', 'valid', 'verified',
+          'verified_settlement', 'first_terminal', 1, ?, ?, ?, ?, ?, ?, ?, ?,
+          ?, ?, ?, ?, ?, ?, ?, NULL, 'spec015-v0.4', 'no_money_movement_step5',
+          'no_money_movement_step5', 'excluded_until_spec022_verified',
+          ?, ?, ?, NULL, '{}', '{}', NULL, ?)`,
+		SettlementAccountScopeHash(route.AccountScope), route.RequestID, route.ProviderID,
+		TerminalStateNormalDone, ts.UnixMilli(), deadline, ts.UnixMilli(), routeDigest,
+		RouteSnapshotPolicyVersion, RouteSnapshotModeEnforce, route.PaidEntrypoint,
+		route.Spec008HashStatus, route.ProviderReportedModelHash, route.ProviderReceiptKeyID,
+		route.CatalogID, route.CatalogBodyDigest, route.ExpectedCatalogModelHash, route.ModelID,
+		route.PromptHash, outputHash, usageHash, ts.Format(time.RFC3339Nano)); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := store.RecoverLedger(context.Background(), RecoverInput{ScanFrom: ts.Add(-time.Minute), ScanTo: ts.Add(time.Minute), Source: "startup_scan"}); err != nil {
+		t.Fatal(err)
+	}
+	if got := scalar(t, store.db, `SELECT COUNT(*) FROM ledger_request_credits WHERE request_id = ? AND quarantined = 0 AND gross_credits = 4 AND provider_credits = 4`, route.RequestID); got != 1 {
+		t.Fatalf("active verified-receipt rows=%d want 1", got)
+	}
+	if got := scalar(t, store.db, `SELECT COUNT(*) FROM ledger_request_credits WHERE request_id = ? AND quarantine_reason = 'reconciliation_mismatch'`, route.RequestID); got != 0 {
+		t.Fatalf("reconciliation mismatch rows=%d want 0", got)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Preserve existing breaker-qualifying zero-credit ledger rows during startup/nightly recovery instead of comparing them to request_log's FaultNone-only view.
- Recompute existing enforce-mode verified receipt rows from canonical settlement_attempt_outputs usage so receipt-synced credits are not reclamped to stale request-log estimates.
- Carry the Pearl updater runtime-only rollout repair used for v1.8.86: disabled buyer-canary mode is explicit, and rollback serving proof uses the previous advertised version captured in the transaction journal.

## Validation
- go test ./internal/billing ./internal/buyer
- go test ./... (phase4-coordinator)
- python3 -m py_compile ops/pearl-updater/macprovider-pearl-update
- python3 -m unittest ops.pearl-updater.test_pearl_updater

## Operational notes
- Pearl currently has 4 residual unresolved reconciliation_mismatch rows after v1.8.86 live. Do not force-credit those residual IDs until Pearl is updated to this fix and a startup scan/observation confirms no new frozen rows accrue.
- The admin force-credit route remains disabled outside the brief authorized release window.

SPEC-GOVERNANCE-DECLARATION-BEGIN
{
  "schema_version": "spec-pr-governance-v1",
  "behavior_change": "yes",
  "contract_change": "none",
  "specs": ["SPEC-002", "SPEC-020", "SPEC-022"],
  "requirements": ["SPEC-002-R001", "SPEC-020-R004", "SPEC-022-R003", "SPEC-022-R007", "SPEC-022-R009", "SPEC-022-R011"],
  "authority_domains": ["billing-settlement-formula", "provider-autoupdate", "inference-receipts", "verified-model-settlement"],
  "arbitration": ["CODE_BUG"],
  "tests": [
    "go test ./internal/billing ./internal/buyer",
    "go test ./... (phase4-coordinator)",
    "python3 -m py_compile ops/pearl-updater/macprovider-pearl-update",
    "python3 -m unittest ops.pearl-updater.test_pearl_updater"
  ],
  "journeys": ["not-required"]
}
SPEC-GOVERNANCE-DECLARATION-END
