### PR TITLE
Gate provider evidence promotion on selector freshness

### DIFF
--- a/scripts/build-provider-prebeta-journey-result.py
+++ b/scripts/build-provider-prebeta-journey-result.py
@@ -150,9 +150,10 @@ def parse_requirement_ids(raw: str | None, evidence: dict[str, Any]) -> list[str
     if raw is None:
         return evidence_ids
     input_ids = parse_requirement_id_values(raw, "--requirement-ids")
-    if input_ids != evidence_ids:
-        die("--requirement-ids must exactly match evidence.requirement_ids")
-    return evidence_ids
+    overclaimed = [item for item in input_ids if item not in evidence_ids]
+    if overclaimed:
+        die(f"--requirement-ids must be covered by evidence.requirement_ids: {', '.join(overclaimed)}")
+    return input_ids
 
 
 def load_mapped_provider_requirements(root: Path) -> set[str]:

--- a/scripts/check_spec_governance.py
+++ b/scripts/check_spec_governance.py
@@ -10,6 +10,7 @@ meaning from rendered prose.
 from __future__ import annotations
 
 import argparse
+import ast
 import base64
 import hashlib
 import json
@@ -43,7 +44,7 @@ PROVIDER_PREBETA_JOURNEY_ID = "JOURNEY-PROVIDER-PREBETA-ADMISSION"
 PROVIDER_PREBETA_EXECUTION_MODE = "physical-provider-prebeta-admission"
 PROVIDER_PREBETA_ARTIFACT_ID = "redacted-provider-prebeta-admission"
 PROVIDER_PREBETA_EVIDENCE_SCHEMA = "macprovider.provider-prebeta-admission-evidence.v1"
-PROVIDER_PREBETA_STEP_IDS = {
+PROVIDER_PREBETA_STEP_ID_ORDER = (
     "step-01-private-prebeta-authorization",
     "step-02-install-launch-identity",
     "step-03-provider-registration-admission",
@@ -52,7 +53,8 @@ PROVIDER_PREBETA_STEP_IDS = {
     "step-06-provider-runtime-routing",
     "step-07-buyer-serving-smoke",
     "step-08-redaction-and-correlation",
-}
+)
+PROVIDER_PREBETA_STEP_IDS = set(PROVIDER_PREBETA_STEP_ID_ORDER)
 TRUSTED_OPENSSL_CANDIDATES = (
     "/usr/bin/openssl",
     "/opt/homebrew/opt/openssl@3/bin/openssl",
@@ -350,7 +352,7 @@ def _validate_mapping_paths(root: Path, mappings: list[str], location: str, resu
             except UnicodeDecodeError as exc:
                 result.error(f"{location}[{index}]", f"mapped file is not UTF-8 text: {exc}")
             else:
-                if selector not in text:
+                if _mapping_selector_resolves(text, selector, file_part) is None:
                     result.error(f"{location}[{index}]", f"mapping selector {selector!r} does not resolve in {file_part!r}")
 
 
@@ -528,6 +530,65 @@ def _validate_spec016_payout_artifact(root: Path, artifact: dict[str, Any], loca
         result.error(f"{location}.source", "SPEC-016 payout journey-result cannot promote candidate-only artifact content")
 
 
+def _provider_prebeta_normalized_redaction(value: Any, location: str, result: ValidationResult) -> dict[str, bool] | None:
+    if not _expect_object(value, location, result):
+        return None
+    required = ("secrets_redacted", "operator_identity_redacted", "local_account_names_redacted")
+    output: dict[str, bool] = {}
+    for key in required:
+        if value.get(key) is not True:
+            result.error(f"{location}.{key}", "must be true")
+        else:
+            output[key] = True
+    for key, item in value.items():
+        if key.endswith("_redacted") and item is not True:
+            result.error(f"{location}.{key}", "must be true")
+    return output
+
+
+def _provider_prebeta_normalized_steps(value: Any, location: str, result: ValidationResult) -> list[dict[str, Any]]:
+    if not isinstance(value, list):
+        result.error(location, "field 'steps' must be an array")
+        return []
+    by_id: dict[str, dict[str, Any]] = {}
+    for index, item in enumerate(value):
+        loc = f"{location}[{index}]"
+        if not _expect_object(item, loc, result):
+            continue
+        step_id = _string(item.get("id"), None, f"{loc}.id", result)
+        if step_id is None:
+            continue
+        if step_id in by_id:
+            result.error(f"{loc}.id", f"duplicate provider-prebeta physical step {step_id!r}")
+            continue
+        if step_id not in PROVIDER_PREBETA_STEP_IDS:
+            result.error(f"{loc}.id", f"unexpected provider-prebeta physical step {step_id!r}")
+        if item.get("status") != "pass":
+            result.error(f"{loc}.status", "must equal 'pass'")
+        assertion = _string(item.get("assertion"), None, f"{loc}.assertion", result)
+        artifacts = item.get("artifacts", [PROVIDER_PREBETA_ARTIFACT_ID])
+        artifact_ids = _string_list(artifacts, f"{loc}.artifacts", result)
+        if artifact_ids != [PROVIDER_PREBETA_ARTIFACT_ID]:
+            result.error(f"{loc}.artifacts", f"must reference {PROVIDER_PREBETA_ARTIFACT_ID!r}")
+        by_id[step_id] = {
+            "id": step_id,
+            "status": "pass",
+            "assertion": assertion,
+            "artifacts": [PROVIDER_PREBETA_ARTIFACT_ID],
+        }
+    missing_steps = PROVIDER_PREBETA_STEP_IDS - by_id.keys()
+    if missing_steps:
+        result.error(location, f"missing provider-prebeta physical steps: {sorted(missing_steps)}")
+    if len(by_id) != len(PROVIDER_PREBETA_STEP_IDS):
+        result.error(location, f"must contain exactly {len(PROVIDER_PREBETA_STEP_IDS)} provider-prebeta physical steps")
+    return [by_id[step_id] for step_id in PROVIDER_PREBETA_STEP_ID_ORDER if step_id in by_id]
+
+
+def _provider_prebeta_compare_signed_source(source_value: Any, signed_value: Any, location: str, result: ValidationResult) -> None:
+    if signed_value != source_value:
+        result.error(location, "must match provider-prebeta redacted evidence source")
+
+
 def _validate_provider_prebeta_artifact(
     root: Path,
     artifact: dict[str, Any],
@@ -555,8 +616,10 @@ def _validate_provider_prebeta_artifact(
     if payload.get("journey_id") != PROVIDER_PREBETA_JOURNEY_ID:
         result.error(f"{location}.source.journey_id", f"must equal {PROVIDER_PREBETA_JOURNEY_ID!r}")
     payload_requirement_ids = _string_list(payload.get("requirement_ids"), f"{location}.source.requirement_ids", result, REQUIREMENT_ID_RE)
-    if payload_requirement_ids != signed.get("requirement_ids"):
-        result.error(f"{location}.source.requirement_ids", "must exactly match signed.requirement_ids")
+    signed_requirement_ids = _string_list(signed.get("requirement_ids"), f"{location}.signed.requirement_ids", result, REQUIREMENT_ID_RE)
+    overclaimed = [item for item in signed_requirement_ids if item not in payload_requirement_ids]
+    if overclaimed:
+        result.error(f"{location}.source.requirement_ids", f"must cover every signed requirement ID: {overclaimed}")
     repository = payload.get("repository")
     signed_repository = signed.get("repository")
     if _expect_object(repository, f"{location}.source.repository", result) and isinstance(signed_repository, dict):
@@ -569,6 +632,27 @@ def _validate_provider_prebeta_artifact(
         result.error(f"{location}.source.captured_at", "must match signed.captured_at")
     if payload.get("expires_at") != signed.get("expires_at"):
         result.error(f"{location}.source.expires_at", "must match signed.expires_at")
+    _provider_prebeta_compare_signed_source(payload.get("run_id"), signed.get("run_id"), f"{location}.source.run_id", result)
+    for field_name in ("operator", "environment", "result"):
+        _provider_prebeta_compare_signed_source(
+            payload.get(field_name),
+            signed.get(field_name),
+            f"{location}.source.{field_name}",
+            result,
+        )
+    source_result = payload.get("result")
+    if _expect_object(source_result, f"{location}.source.result", result) and source_result.get("status") != "pass":
+        result.error(f"{location}.source.result.status", "must equal 'pass'")
+    source_steps = _provider_prebeta_normalized_steps(payload.get("steps"), f"{location}.source.steps", result)
+    signed_steps = _provider_prebeta_normalized_steps(signed.get("steps"), f"{location}.signed.steps", result)
+    _provider_prebeta_compare_signed_source(source_steps, signed_steps, f"{location}.source.steps", result)
+    source_redaction = _provider_prebeta_normalized_redaction(payload.get("redaction"), f"{location}.source.redaction", result)
+    signed_redaction = {
+        "secrets_redacted": signed.get("redaction", {}).get("secrets_redacted") if isinstance(signed.get("redaction"), dict) else None,
+        "operator_identity_redacted": signed.get("redaction", {}).get("operator_identity_redacted") if isinstance(signed.get("redaction"), dict) else None,
+        "local_account_names_redacted": signed.get("redaction", {}).get("local_account_names_redacted") if isinstance(signed.get("redaction"), dict) else None,
+    }
+    _provider_prebeta_compare_signed_source(source_redaction, signed_redaction, f"{location}.source.redaction", result)
 
 
 def _validate_provider_prebeta_journey_result(
@@ -1087,7 +1171,872 @@ def _signed_journey_result_satisfies(
     return False
 
 
-def _commit_file_matches_current(root: Path, commit: str, relative: str) -> bool:
+def _line_bounds(text: str, index: int) -> tuple[int, int]:
+    start = text.rfind("\n", 0, index) + 1
+    end = text.find("\n", index)
+    if end == -1:
+        end = len(text)
+    return start, end
+
+
+def _find_brace_block_end(text: str, open_brace: int) -> int | None:
+    depth = 0
+    index = open_brace
+    in_line_comment = False
+    in_block_comment = False
+    in_string: str | None = None
+    while index < len(text):
+        character = text[index]
+        next_character = text[index + 1] if index + 1 < len(text) else ""
+        if in_line_comment:
+            if character == "\n":
+                in_line_comment = False
+            index += 1
+            continue
+        if in_block_comment:
+            if character == "*" and next_character == "/":
+                in_block_comment = False
+                index += 2
+            else:
+                index += 1
+            continue
+        if in_string is not None:
+            if character == "\\" and in_string != "`":
+                index += 2
+                continue
+            if character == in_string:
+                in_string = None
+            index += 1
+            continue
+        if character == "/" and next_character == "/":
+            in_line_comment = True
+            index += 2
+            continue
+        if character == "/" and next_character == "*":
+            in_block_comment = True
+            index += 2
+            continue
+        if character in {'"', "'", "`"}:
+            in_string = character
+            index += 1
+            continue
+        if character == "{":
+            depth += 1
+        elif character == "}":
+            depth -= 1
+            if depth == 0:
+                line_end = text.find("\n", index)
+                return len(text) if line_end == -1 else line_end
+        index += 1
+    return None
+
+
+def _shell_uncommented_line(line: str) -> str:
+    index = 0
+    in_single = False
+    in_double = False
+    in_backtick = False
+    while index < len(line):
+        character = line[index]
+        if character == "\\" and not in_single:
+            index += 2
+            continue
+        if in_single:
+            if character == "'":
+                in_single = False
+            index += 1
+            continue
+        if in_double:
+            if character == '"':
+                in_double = False
+            elif character == "`":
+                in_backtick = not in_backtick
+            index += 1
+            continue
+        if in_backtick:
+            if character == "`":
+                in_backtick = False
+            index += 1
+            continue
+        if character == "'":
+            in_single = True
+        elif character == '"':
+            in_double = True
+        elif character == "`":
+            in_backtick = True
+        elif character == "#":
+            return line[:index]
+        index += 1
+    return line
+
+
+def _shell_mask_quoted(line: str) -> str:
+    chars = list(line)
+    index = 0
+    in_single = False
+    in_double = False
+    in_backtick = False
+    while index < len(chars):
+        character = chars[index]
+        if character == "\\" and not in_single:
+            if index + 1 < len(chars):
+                chars[index] = " "
+                chars[index + 1] = " "
+            index += 2
+            continue
+        if in_single:
+            if character == "'":
+                in_single = False
+            chars[index] = " "
+            index += 1
+            continue
+        if in_double:
+            if character == '"':
+                in_double = False
+            chars[index] = " "
+            index += 1
+            continue
+        if in_backtick:
+            if character == "`":
+                in_backtick = False
+            chars[index] = " "
+            index += 1
+            continue
+        if character == "'":
+            in_single = True
+            chars[index] = " "
+        elif character == '"':
+            in_double = True
+            chars[index] = " "
+        elif character == "`":
+            in_backtick = True
+            chars[index] = " "
+        index += 1
+    return "".join(chars)
+
+
+def _shell_heredoc_delimiters(line: str) -> list[tuple[str, bool]]:
+    delimiters: list[tuple[str, bool]] = []
+    for match in re.finditer(r"<<(-)?\s*(?:'([^']+)'|\"([^\"]+)\"|\\?([A-Za-z_][A-Za-z0-9_]*))", line):
+        delimiters.append((match.group(2) or match.group(3) or match.group(4), bool(match.group(1))))
+    return delimiters
+
+
+def _shell_line_continues(line: str) -> bool:
+    return _shell_uncommented_line(line).rstrip().endswith("\\")
+
+
+def _shell_invokes_python(command: str) -> bool:
+    active = _shell_uncommented_line(command)
+    for segment in re.split(r"(?:^|\$\(|[;|&({])", active):
+        words = re.findall(r"[A-Za-z_][A-Za-z0-9_./=-]*", segment)
+        index = 0
+        while index < len(words) and re.match(r"[A-Za-z_][A-Za-z0-9_]*=", words[index]):
+            index += 1
+        if index < len(words) and words[index] in {"exec", "command"}:
+            index += 1
+        if index < len(words) and re.fullmatch(r"(?:python|python3|python3\.[0-9]+)", Path(words[index]).name):
+            return True
+    return False
+
+
+def _shell_materializes_script(command: str) -> bool:
+    active = _shell_uncommented_line(command)
+    if ">" not in active or "<<" not in active:
+        return False
+    targets = [
+        match.group(1) or match.group(2) or match.group(3)
+        for match in re.finditer(r"(?:^|\s)(?:>|>>)\s*(?:\"([^\"]+)\"|'([^']+)'|([^\s<>&;|]+))", active)
+    ]
+    material_targets = [
+        target
+        for target in targets
+        if target not in {"/dev/null", "null"}
+        and (
+            "WATCHDOG_PATH" in target
+            or "watchdog" in target.lower()
+            or target.endswith((".sh", ".bash", ".zsh"))
+        )
+    ]
+    if not material_targets:
+        return False
+    for segment in re.split(r"(?:^|[;|&({])", active):
+        words = re.findall(r"[A-Za-z_][A-Za-z0-9_./=-]*", segment)
+        index = 0
+        while index < len(words) and re.match(r"[A-Za-z_][A-Za-z0-9_]*=", words[index]):
+            index += 1
+        if index < len(words) and words[index] == "cat":
+            return True
+    return False
+
+
+def _find_shell_brace_block_end(text: str, open_brace: int) -> int | None:
+    line_start = text.rfind("\n", 0, open_brace) + 1
+    cursor = line_start
+    depth = 0
+    heredocs: list[tuple[str, bool]] = []
+    while cursor < len(text):
+        line_end = text.find("\n", cursor)
+        if line_end == -1:
+            line_end = len(text)
+            line = text[cursor:line_end]
+            next_cursor = line_end
+        else:
+            line = text[cursor:line_end]
+            next_cursor = line_end + 1
+        if heredocs:
+            delimiter, strip_tabs = heredocs[0]
+            candidate = line.lstrip("\t") if strip_tabs else line
+            if candidate == delimiter:
+                heredocs.pop(0)
+            cursor = next_cursor
+            continue
+        active_line = _shell_uncommented_line(line)
+        segment_start = max(0, open_brace - cursor) if cursor == line_start else 0
+        segment = active_line[segment_start:]
+        masked_segment = _shell_mask_quoted(segment)
+        for offset, character in enumerate(masked_segment, start=segment_start):
+            if character == "{":
+                depth += 1
+            elif character == "}":
+                depth -= 1
+                if depth == 0:
+                    return line_end
+                if depth < 0:
+                    return None
+        heredocs.extend(_shell_heredoc_delimiters(active_line))
+        cursor = next_cursor
+    return None
+
+
+def _line_before(text: str, index: int) -> str:
+    return text[text.rfind("\n", 0, index) + 1:index].strip()
+
+
+def _block_kind_for_open_brace(text: str, open_brace: int, suffix: str) -> str:
+    line = _line_before(text, open_brace)
+    if suffix == ".swift":
+        modifiers = r"(?:(?:private|public|internal|fileprivate|static|mutating|nonisolated|final|lazy|override|open|required|convenience)\s+)*"
+        if re.match(rf"{modifiers}(?:struct|enum|actor|class|extension)\b", line):
+            return "type"
+        if re.match(rf"{modifiers}(?:func|init)\b", line):
+            return "function"
+    if suffix == ".go":
+        if re.match(r"func\s+(?:\([^)]*\)\s*)?[A-Za-z_][A-Za-z0-9_]*\s*\(", line):
+            return "function"
+        if re.match(r"type\s+[A-Za-z_][A-Za-z0-9_]*\s+(?:struct|interface)\b", line):
+            return "type"
+    return "block"
+
+
+def _block_stack_at(text: str, limit: int, suffix: str) -> list[str]:
+    stack: list[str] = []
+    index = 0
+    in_line_comment = False
+    in_block_comment = False
+    in_string: str | None = None
+    while index < limit:
+        character = text[index]
+        next_character = text[index + 1] if index + 1 < limit else ""
+        if in_line_comment:
+            if character == "\n":
+                in_line_comment = False
+            index += 1
+            continue
+        if in_block_comment:
+            if character == "*" and next_character == "/":
+                in_block_comment = False
+                index += 2
+            else:
+                index += 1
+            continue
+        if in_string is not None:
+            if character == "\\" and in_string != "`":
+                index += 2
+                continue
+            if character == in_string:
+                in_string = None
+            index += 1
+            continue
+        if character == "/" and next_character == "/":
+            in_line_comment = True
+            index += 2
+            continue
+        if character == "/" and next_character == "*":
+            in_block_comment = True
+            index += 2
+            continue
+        if character in {'"', "'", "`"}:
+            in_string = character
+            index += 1
+            continue
+        if character == "{":
+            stack.append(_block_kind_for_open_brace(text, index, suffix))
+        elif character == "}" and stack:
+            stack.pop()
+        index += 1
+    return stack
+
+
+def _inactive_line_starts(text: str, suffix: str) -> set[int]:
+    if suffix == ".sh":
+        return set()
+    inactive: set[int] = set()
+    line_start = 0
+    index = 0
+    in_line_comment = False
+    in_block_comment = False
+    in_string: str | None = None
+    swift_inactive_depth = 0
+    while index < len(text):
+        if index == line_start:
+            line_end = text.find("\n", index)
+            if line_end == -1:
+                line_end = len(text)
+            line_text = text[index:line_end].strip()
+            if suffix == ".swift":
+                if swift_inactive_depth:
+                    inactive.add(line_start)
+                    if re.match(r"#if\b", line_text):
+                        swift_inactive_depth += 1
+                    elif re.match(r"#endif\b", line_text):
+                        swift_inactive_depth -= 1
+                elif re.match(r"#if\s+false\b", line_text):
+                    inactive.add(line_start)
+                    swift_inactive_depth = 1
+            if in_block_comment or in_string is not None:
+                inactive.add(line_start)
+        character = text[index]
+        next_character = text[index + 1] if index + 1 < len(text) else ""
+        if in_line_comment:
+            if character == "\n":
+                in_line_comment = False
+                line_start = index + 1
+            index += 1
+            continue
+        if in_block_comment:
+            if character == "*" and next_character == "/":
+                in_block_comment = False
+                index += 2
+            else:
+                if character == "\n":
+                    line_start = index + 1
+                index += 1
+            continue
+        if in_string is not None:
+            if in_string == '"""' and text.startswith('"""', index):
+                in_string = None
+                index += 3
+                continue
+            if character == "\\" and in_string in {'"', "'"}:
+                index += 2
+                continue
+            if in_string != '"""' and character == in_string:
+                in_string = None
+            if character == "\n":
+                line_start = index + 1
+            index += 1
+            continue
+        if character == "/" and next_character == "/":
+            in_line_comment = True
+            index += 2
+            continue
+        if character == "/" and next_character == "*":
+            in_block_comment = True
+            index += 2
+            continue
+        if suffix == ".swift" and text.startswith('"""', index):
+            in_string = '"""'
+            index += 3
+            continue
+        if character in {'"', "'", "`"}:
+            in_string = character
+            index += 1
+            continue
+        if character == "\n":
+            line_start = index + 1
+        index += 1
+    return inactive
+
+
+def _declaration_scope_allows(text: str, cursor: int, suffix: str) -> bool:
+    stack = _block_stack_at(text, cursor, suffix)
+    if suffix == ".go":
+        return not stack or stack == ["type"]
+    if suffix == ".swift":
+        return not stack or stack == ["type"]
+    return True
+
+
+def _declaration_may_have_brace_body(line: str, suffix: str) -> bool:
+    stripped = line.strip()
+    if suffix == ".go":
+        return bool(re.match(r"(?:func|type)\b", stripped))
+    modifiers = r"(?:(?:private|public|internal|fileprivate|static|mutating|nonisolated|final|lazy|override|open|required|convenience)\s+)*"
+    return bool(re.match(rf"{modifiers}(?:func|init|struct|enum|actor|class|extension)\b", stripped))
+
+
+def _find_balanced_initializer_end(text: str, start: int, line_end: int) -> int | None:
+    assignment = text.find("=", start, line_end)
+    if assignment == -1:
+        return None
+    pairs = {"[": "]", "(": ")", "{": "}"}
+    closers = {value: key for key, value in pairs.items()}
+    stack: list[str] = []
+    index = assignment + 1
+    in_line_comment = False
+    in_block_comment = False
+    in_string: str | None = None
+    while index < len(text):
+        character = text[index]
+        next_character = text[index + 1] if index + 1 < len(text) else ""
+        if in_line_comment:
+            if character == "\n":
+                in_line_comment = False
+            index += 1
+            continue
+        if in_block_comment:
+            if character == "*" and next_character == "/":
+                in_block_comment = False
+                index += 2
+            else:
+                index += 1
+            continue
+        if in_string is not None:
+            if character == "\\" and in_string != "`":
+                index += 2
+                continue
+            if character == in_string:
+                in_string = None
+            index += 1
+            continue
+        if character == "/" and next_character == "/":
+            in_line_comment = True
+            index += 2
+            continue
+        if character == "/" and next_character == "*":
+            in_block_comment = True
+            index += 2
+            continue
+        if character in {'"', "'", "`"}:
+            in_string = character
+            index += 1
+            continue
+        if character in pairs:
+            stack.append(character)
+        elif character in closers:
+            if stack and stack[-1] == closers[character]:
+                stack.pop()
+                if not stack:
+                    end = text.find("\n", index)
+                    return len(text) if end == -1 else end
+            elif not stack:
+                return None
+        elif character == "\n" and not stack:
+            return None
+        index += 1
+    return None
+
+
+def _extract_indented_block(text: str, line_start: int, line_end: int) -> str:
+    line = text[line_start:line_end]
+    stripped = line.lstrip(" ")
+    if not stripped.startswith(("def ", "async def ", "class ")):
+        return line.rstrip()
+    indent = len(line) - len(stripped)
+    end = line_end
+    cursor = line_end + 1 if line_end < len(text) else len(text)
+    while cursor < len(text):
+        next_end = text.find("\n", cursor)
+        if next_end == -1:
+            next_end = len(text)
+        next_line = text[cursor:next_end]
+        if next_line.strip():
+            next_indent = len(next_line) - len(next_line.lstrip(" "))
+            if next_indent <= indent:
+                break
+        end = next_end
+        cursor = next_end + 1 if next_end < len(text) else len(text)
+    return text[line_start:end].rstrip()
+
+
+def _python_selector_names(selector: str) -> set[str]:
+    names: set[str] = set()
+    stripped = selector.strip()
+    for prefix in ("async def ", "def ", "class "):
+        if stripped.startswith(prefix):
+            match = re.match(rf"{re.escape(prefix)}([A-Za-z_][A-Za-z0-9_]*)", stripped)
+            if match:
+                names.add(match.group(1))
+    if re.fullmatch(r"[A-Za-z_][A-Za-z0-9_]*", stripped):
+        names.add(stripped)
+    return names
+
+
+def _python_node_source(lines: list[str], node: ast.AST) -> str | None:
+    start_lineno = getattr(node, "lineno", None)
+    end_lineno = getattr(node, "end_lineno", None)
+    if not isinstance(start_lineno, int) or not isinstance(end_lineno, int):
+        return None
+    decorator_lines = [decorator.lineno for decorator in getattr(node, "decorator_list", [])]
+    if decorator_lines:
+        start_lineno = min(start_lineno, *decorator_lines)
+    return "\n".join(lines[start_lineno - 1:end_lineno]).rstrip()
+
+
+def _python_assigned_names(node: ast.AST) -> set[str]:
+    targets: list[ast.AST] = []
+    if isinstance(node, ast.Assign):
+        targets = list(node.targets)
+    elif isinstance(node, ast.AnnAssign):
+        targets = [node.target]
+    elif isinstance(node, ast.AugAssign):
+        targets = [node.target]
+    names: set[str] = set()
+    for target in targets:
+        if isinstance(target, ast.Name):
+            names.add(target.id)
+    return names
+
+
+def _extract_embedded_python_mapping_fragments(text: str, selector: str, *, _depth: int = 0) -> list[str]:
+    selector_names = _python_selector_names(selector)
+    if not selector_names:
+        return []
+    stripped_selector = selector.strip()
+    if not stripped_selector.startswith(("def ", "async def ", "class ")):
+        return []
+    python_bodies: list[tuple[int, str]] = []
+    generated_shell_bodies: list[str] = []
+    logical_command_parts: list[str] = []
+    cursor = 0
+    heredocs: list[tuple[str, bool, bool, bool, int, list[str]]] = []
+    while cursor < len(text):
+        line_end = text.find("\n", cursor)
+        if line_end == -1:
+            line_end = len(text)
+        line = text[cursor:line_end]
+        next_cursor = line_end + 1 if line_end < len(text) else len(text)
+        if heredocs:
+            delimiter, strip_tabs, is_python, is_generated_shell, body_start, body_lines = heredocs[0]
+            candidate = line.lstrip("\t") if strip_tabs else line
+            if candidate == delimiter:
+                if is_python:
+                    python_bodies.append((body_start, "\n".join(body_lines)))
+                elif is_generated_shell:
+                    generated_shell_bodies.append("\n".join(body_lines))
+                heredocs.pop(0)
+            else:
+                body_lines.append(line)
+            cursor = next_cursor
+            continue
+        active_line = _shell_uncommented_line(line)
+        command_context = "\n".join([*logical_command_parts, active_line])
+        command_is_python = _shell_invokes_python(active_line) or _shell_invokes_python(command_context)
+        command_is_generated_shell = _shell_materializes_script(active_line) or _shell_materializes_script(command_context)
+        for delimiter, strip_tabs in _shell_heredoc_delimiters(active_line):
+            heredocs.append((delimiter, strip_tabs, command_is_python, command_is_generated_shell, next_cursor, []))
+        if _shell_line_continues(line):
+            logical_command_parts.append(active_line.rstrip()[:-1])
+        else:
+            logical_command_parts = []
+        cursor = next_cursor
+    fragments: list[str] = []
+    for body_start, body in python_bodies:
+        cursor = 0
+        while cursor < len(body):
+            line_end = body.find("\n", cursor)
+            if line_end == -1:
+                line_end = len(body)
+            line = body[cursor:line_end]
+            stripped = line.lstrip(" ")
+            if stripped.startswith(("def ", "async def ", "class ")):
+                match = re.match(r"(?:async\s+def|def|class)\s+([A-Za-z_][A-Za-z0-9_]*)", stripped)
+                if match and match.group(1) in selector_names:
+                    fragments.append(_extract_indented_block(body, cursor, line_end))
+            cursor = line_end + 1
+    if _depth < 3:
+        for shell_body in generated_shell_bodies:
+            fragments.extend(_extract_embedded_python_mapping_fragments(shell_body, selector, _depth=_depth + 1))
+    return fragments
+
+
+def _embedded_python_selector_requires_declaration(selector: str) -> bool:
+    return selector.strip().startswith(("def ", "async def ", "class "))
+
+
+def _extract_python_mapping_fragment(text: str, selector: str) -> str | None:
+    selector_names = _python_selector_names(selector)
+    if not selector_names:
+        return None
+    try:
+        tree = ast.parse(text)
+    except SyntaxError:
+        return None
+    lines = text.splitlines()
+    fragments: list[str] = []
+    for node in tree.body:
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)) and node.name in selector_names:
+            fragment = _python_node_source(lines, node)
+            if fragment is not None:
+                fragments.append(fragment)
+        if _python_assigned_names(node) & selector_names:
+            fragment = _python_node_source(lines, node)
+            if fragment is not None:
+                fragments.append(fragment)
+    if len(fragments) != 1:
+        return None
+    return fragments[0]
+
+
+def _selector_identifier(selector: str) -> str | None:
+    stripped = selector.strip()
+    for pattern in (
+        r"(?:func|type|var|const)\s+(?:\([^)]*\)\s*)?([A-Za-z_][A-Za-z0-9_]*)",
+        r"(?:static\s+)?(?:func|let|var|struct|enum|actor|class)\s+([A-Za-z_][A-Za-z0-9_]*)",
+        r"([A-Za-z_][A-Za-z0-9_]*)\s+[^=]+",
+    ):
+        match = re.search(pattern, stripped)
+        if match:
+            return match.group(1)
+    if re.fullmatch(r"[A-Za-z_][A-Za-z0-9_]*", stripped):
+        return stripped
+    return None
+
+
+def _go_build_context(text: str) -> str:
+    context: list[str] = []
+    cursor = 0
+    while cursor < len(text):
+        line_end = text.find("\n", cursor)
+        if line_end == -1:
+            line_end = len(text)
+        line = text[cursor:line_end]
+        stripped = line.strip()
+        if stripped.startswith("package "):
+            break
+        if stripped.startswith("//go:build ") or stripped.startswith("// +build "):
+            context.append(line.rstrip())
+        cursor = line_end + 1
+    return "\n".join(context)
+
+
+def _swift_conditional_context_at(text: str, limit: int) -> str:
+    inactive_lines = _inactive_line_starts(text, ".swift")
+    stack: list[str] = []
+    cursor = 0
+    while cursor < limit:
+        line_end = text.find("\n", cursor)
+        if line_end == -1 or line_end > limit:
+            line_end = limit
+        line = text[cursor:line_end]
+        stripped = line.strip()
+        if cursor not in inactive_lines and stripped.startswith("#"):
+            if re.match(r"#if\b", stripped):
+                stack.append(line.rstrip())
+            elif re.match(r"#(?:elseif|else)\b", stripped):
+                if stack:
+                    stack[-1] = line.rstrip()
+            elif re.match(r"#endif\b", stripped):
+                if stack:
+                    stack.pop()
+        if line_end >= limit or line_end == len(text):
+            break
+        cursor = line_end + 1
+    return "\n".join(stack)
+
+
+def _declaration_build_context(text: str, cursor: int, suffix: str) -> str:
+    if suffix == ".go":
+        return _go_build_context(text)
+    if suffix == ".swift":
+        return _swift_conditional_context_at(text, cursor)
+    return ""
+
+
+def _fragment_with_context(context: str, fragment: str) -> str:
+    if not context:
+        return fragment
+    return f"{context}\n{fragment}"
+
+
+def _go_declaration_line_matches(line: str, selector: str) -> bool:
+    stripped = line.strip()
+    if stripped.startswith(("//", "/*", "*")):
+        return False
+    selector_stripped = selector.strip()
+    if re.match(r"(?:func|type|var|const)\s+", selector_stripped):
+        return re.sub(r"\s+", " ", stripped).startswith(re.sub(r"\s+", " ", selector_stripped))
+    identifier = _selector_identifier(selector)
+    if identifier is None:
+        return False
+    escaped = re.escape(identifier)
+    return any(
+        re.match(pattern, stripped)
+        for pattern in (
+            rf"func\s+(?:\([^)]*\)\s*)?{escaped}\b\s*\(",
+            rf"type\s+{escaped}\b",
+            rf"(?:var|const)\s+{escaped}\b",
+            rf"{escaped}\b\s*=",
+            rf"{escaped}\b\s+[^=]+$",
+        )
+    )
+
+
+def _swift_declaration_line_matches(line: str, selector: str) -> bool:
+    stripped = line.strip()
+    if stripped.startswith(("//", "/*", "*")):
+        return False
+    selector_stripped = selector.strip()
+    modifiers = r"(?:(?:private|public|internal|fileprivate|static|mutating|nonisolated|final|lazy|override|open|required|convenience)\s+)*"
+    if re.match(rf"{modifiers}(?:func|let|var|struct|enum|actor|class)\s+", selector_stripped):
+        return re.sub(r"\s+", " ", stripped).startswith(re.sub(r"\s+", " ", selector_stripped))
+    identifier = _selector_identifier(selector)
+    if identifier is None:
+        return False
+    escaped = re.escape(identifier)
+    return any(
+        re.match(pattern, stripped)
+        for pattern in (
+            rf"{modifiers}func\s+{escaped}\b\s*\(",
+            rf"{modifiers}(?:let|var)\s+{escaped}\b",
+            rf"{modifiers}(?:struct|enum|actor|class)\s+{escaped}\b",
+        )
+    )
+
+
+def _extract_declaration_fragment(text: str, selector: str, relative: str) -> str | None:
+    suffix = Path(relative).suffix
+    matcher = _go_declaration_line_matches if suffix == ".go" else _swift_declaration_line_matches
+    inactive_lines = _inactive_line_starts(text, suffix)
+    fragments: list[str] = []
+    cursor = 0
+    while cursor < len(text):
+        line_end = text.find("\n", cursor)
+        if line_end == -1:
+            line_end = len(text)
+        line = text[cursor:line_end]
+        if cursor not in inactive_lines and matcher(line, selector) and _declaration_scope_allows(text, cursor, suffix):
+            context = _declaration_build_context(text, cursor, suffix)
+            if _declaration_may_have_brace_body(line, suffix):
+                declaration_window_end = min(len(text), line_end + 1024)
+                open_brace = text.find("{", cursor, declaration_window_end)
+                if open_brace != -1:
+                    block_end = _find_brace_block_end(text, open_brace)
+                    if block_end is not None:
+                        fragments.append(_fragment_with_context(context, text[cursor:block_end].rstrip()))
+                        cursor = line_end + 1
+                        continue
+            balanced_end = _find_balanced_initializer_end(text, cursor, line_end)
+            if balanced_end is not None:
+                fragments.append(_fragment_with_context(context, text[cursor:balanced_end].rstrip()))
+            else:
+                fragments.append(_fragment_with_context(context, line.rstrip()))
+        cursor = line_end + 1
+    if len(fragments) != 1:
+        return None
+    return fragments[0]
+
+
+def _shell_selector_name(selector: str) -> str | None:
+    stripped = selector.strip()
+    for pattern in (
+        r"function\s+([A-Za-z_][A-Za-z0-9_]*)",
+        r"([A-Za-z_][A-Za-z0-9_]*)\s*\(\s*\)",
+    ):
+        match = re.fullmatch(pattern, stripped)
+        if match:
+            return match.group(1)
+    if re.fullmatch(r"[A-Za-z_][A-Za-z0-9_]*", stripped):
+        return stripped
+    return None
+
+
+def _shell_selector_requires_function(selector: str) -> bool:
+    stripped = selector.strip()
+    return bool(re.fullmatch(r"function\s+[A-Za-z_][A-Za-z0-9_]*", stripped) or re.fullmatch(r"[A-Za-z_][A-Za-z0-9_]*\s*\(\s*\)", stripped))
+
+
+def _extract_shell_mapping_fragments(text: str, selector: str) -> list[str]:
+    name = _shell_selector_name(selector)
+    if name is None:
+        return []
+    inactive_lines = _inactive_line_starts(text, ".sh")
+    escaped = re.escape(name)
+    fragments: list[str] = []
+    cursor = 0
+    while cursor < len(text):
+        line_end = text.find("\n", cursor)
+        if line_end == -1:
+            line_end = len(text)
+        line = text[cursor:line_end]
+        stripped = line.strip()
+        if (
+            cursor not in inactive_lines
+            and not stripped.startswith("#")
+            and re.match(rf"(?:function\s+{escaped}\b|{escaped}\s*\(\s*\))", stripped)
+        ):
+            open_brace = text.find("{", cursor, min(len(text), line_end + 256))
+            if open_brace == -1:
+                fragments.append(line.rstrip())
+            else:
+                block_end = _find_shell_brace_block_end(text, open_brace)
+                if block_end is not None:
+                    fragments.append(text[cursor:block_end].rstrip())
+        cursor = line_end + 1
+    return fragments
+
+
+def _extract_shell_mapping_fragment(text: str, selector: str) -> str | None:
+    fragments = _extract_shell_mapping_fragments(text, selector)
+    if len(fragments) != 1:
+        return None
+    return fragments[0]
+
+
+def _extract_text_anchor_fragment(text: str, selector: str) -> str | None:
+    index = text.find(selector)
+    if index == -1:
+        return None
+    line_start, line_end = _line_bounds(text, index)
+    return text[line_start:line_end].rstrip()
+
+
+def _extract_mapping_fragment(text: str, selector: str, relative: str) -> str | None:
+    suffix = Path(relative).suffix
+    if suffix == ".py":
+        return _extract_python_mapping_fragment(text, selector)
+    if suffix in {".go", ".swift"}:
+        return _extract_declaration_fragment(text, selector, relative)
+    if suffix == ".sh":
+        function_fragments = _extract_shell_mapping_fragments(text, selector)
+        if len(function_fragments) == 1:
+            return function_fragments[0]
+        if function_fragments or _shell_selector_requires_function(selector):
+            return None
+        embedded_python_fragments = _extract_embedded_python_mapping_fragments(text, selector)
+        if len(embedded_python_fragments) == 1:
+            return embedded_python_fragments[0]
+        if embedded_python_fragments or _embedded_python_selector_requires_declaration(selector):
+            return None
+        return _extract_text_anchor_fragment(text, selector)
+    return _extract_text_anchor_fragment(text, selector)
+
+
+def _mapping_selector_resolves(text: str, selector: str, relative: str) -> str | None:
+    return _extract_mapping_fragment(text, selector, relative)
+
+
+def _commit_mapping_selector_matches_current(root: Path, commit: str, mapping: str) -> bool:
+    relative = _mapping_file(mapping)
+    selector = _mapping_selector(mapping)
+    if not selector:
+        return False
+    try:
+        current_path = (root / relative).resolve()
+        current_path.relative_to(root.resolve())
+    except (OSError, ValueError):
+        return False
     completed = subprocess.run(
         ["git", "show", f"{commit}:{relative}"],
         cwd=root,
@@ -1097,10 +2046,13 @@ def _commit_file_matches_current(root: Path, commit: str, relative: str) -> bool
     if completed.returncode != 0:
         return False
     try:
-        current = (root / relative).read_bytes()
-    except OSError:
+        committed = completed.stdout.decode("utf-8")
+        current = current_path.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError):
         return False
-    return completed.stdout == current
+    committed_fragment = _extract_mapping_fragment(committed, selector, relative)
+    current_fragment = _extract_mapping_fragment(current, selector, relative)
+    return committed_fragment is not None and committed_fragment == current_fragment
 
 
 def _validate_evidence_list(root: Path, value: Any, location: str, result: ValidationResult) -> None:
@@ -1457,8 +2409,9 @@ def _validate_conformance_schema(root: Path, conformance: Any, result: Validatio
             for commit in commits:
                 for mapping in implementation + tests:
                     mapped_file = _mapping_file(mapping)
-                    if not _commit_file_matches_current(root, commit, mapped_file):
-                        result.error(loc, f"commit evidence {commit} does not match current mapped file {mapped_file!r}")
+                    selector = _mapping_selector(mapping)
+                    if not _commit_mapping_selector_matches_current(root, commit, mapping):
+                        result.error(loc, f"commit evidence {commit} does not match current mapped selector fragment {selector!r} in {mapped_file!r}")
     return [item for item in specs if isinstance(item, dict)], [item for item in requirements if isinstance(item, dict)]
 
 

--- a/scripts/tests/fixtures/spec_governance/stale-commit-evidence.json
+++ b/scripts/tests/fixtures/spec_governance/stale-commit-evidence.json
@@ -1,1 +1,1 @@
-{"mutation":{"operation":"stale_commit_evidence"},"expected":"does not match current mapped file 'src/example.py'"}
+{"mutation":{"operation":"stale_commit_evidence"},"expected":"does not match current mapped selector fragment 'example' in 'src/example.py'"}

--- a/scripts/tests/test_provider_prebeta_journey_result.py
+++ b/scripts/tests/test_provider_prebeta_journey_result.py
@@ -175,6 +175,39 @@ class ProviderPrebetaJourneyResultTests(unittest.TestCase):
         self.assertEqual(hashlib.sha256((root / EVIDENCE_SOURCE).read_bytes()).hexdigest(), artifact["sha256"])
         self.assertEqual("step-07-buyer-serving-smoke", payload["steps"][6]["id"])
 
+    def test_builder_allows_requirement_subset_covered_by_evidence(self) -> None:
+        def evidence_covers_two_requirements(evidence: dict) -> None:
+            evidence["requirement_ids"] = ["SPEC-010-R001", "SPEC-010-R002"]
+
+        directory, root, source_commit, evidence_commit = self.make_repo(evidence_covers_two_requirements)
+        self.addCleanup(directory.cleanup)
+        output = root / "payload.json"
+
+        completed = subprocess.run(
+            [
+                sys.executable,
+                str(BUILDER),
+                "--root",
+                str(root),
+                "--source-sha",
+                source_commit,
+                "--evidence-sha",
+                evidence_commit,
+                "--requirement-ids",
+                "SPEC-010-R001",
+                "--output",
+                str(output),
+                EVIDENCE_SOURCE,
+            ],
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+
+        self.assertEqual(0, completed.returncode, completed.stderr)
+        payload = json.loads(output.read_text(encoding="utf-8"))
+        self.assertEqual(["SPEC-010-R001"], payload["requirement_ids"])
+
     def test_signed_provider_prebeta_payload_passes_canonical_validator(self) -> None:
         directory, root, source_commit, evidence_commit = self.make_repo()
         self.addCleanup(directory.cleanup)
@@ -315,7 +348,156 @@ class ProviderPrebetaJourneyResultTests(unittest.TestCase):
                 result,
             )
         )
-        self.assertTrue(any("must exactly match signed.requirement_ids" in error for error in result.errors), result.errors)
+        self.assertTrue(any("must cover every signed requirement ID" in error for error in result.errors), result.errors)
+
+    def test_canonical_validator_rejects_signed_pass_when_source_artifact_failed(self) -> None:
+        directory, root, source_commit, evidence_commit = self.make_repo()
+        self.addCleanup(directory.cleanup)
+        private_key = generate_acceptance_key(root)
+        trusted_hash = hashlib.sha256((root / "security" / "acceptance-candidate-signing-public.pem").read_bytes()).hexdigest()
+        payload_path = root / "payload.json"
+        completed = subprocess.run(
+            [
+                sys.executable,
+                str(BUILDER),
+                "--root",
+                str(root),
+                "--source-sha",
+                source_commit,
+                "--evidence-sha",
+                evidence_commit,
+                "--output",
+                str(payload_path),
+                EVIDENCE_SOURCE,
+            ],
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+        self.assertEqual(0, completed.returncode, completed.stderr)
+        evidence_path = root / EVIDENCE_SOURCE
+        evidence = json.loads(evidence_path.read_text(encoding="utf-8"))
+        evidence["result"]["status"] = "fail"
+        evidence["steps"][6]["status"] = "fail"
+        evidence_path.write_text(json.dumps(evidence, indent=2) + "\n", encoding="utf-8")
+        payload = json.loads(payload_path.read_text(encoding="utf-8"))
+        payload["artifacts"][0]["sha256"] = hashlib.sha256(evidence_path.read_bytes()).hexdigest()
+        payload_path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+        envelope = root / "journeys" / "evidence" / "provider-prebeta-admission-demo.journey-result.signed.json"
+        env = os.environ.copy()
+        env["MACPROVIDER_ACCEPTANCE_SIGNING_KEY_PEM"] = private_key
+        openssl = shutil.which("openssl")
+        if openssl is None:
+            raise unittest.SkipTest("openssl is required")
+        completed = subprocess.run(
+            [
+                sys.executable,
+                str(SIGNER),
+                "--root",
+                str(root),
+                "--input",
+                str(payload_path),
+                "--output",
+                str(envelope.relative_to(root)),
+                "--verified-at",
+                "2026-08-05T06:05:00Z",
+                "--openssl-bin",
+                openssl,
+            ],
+            env=env,
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+        self.assertEqual(0, completed.returncode, completed.stderr)
+
+        result = ValidationResult()
+        self.assertFalse(
+            _validate_signed_journey_result(
+                root,
+                str(envelope.relative_to(root)),
+                "SPEC-010-R001",
+                ["JOURNEY-PROVIDER-PREBETA-ADMISSION"],
+                {source_commit},
+                trusted_hash,
+                openssl,
+                "provider-prebeta",
+                result,
+            )
+        )
+        self.assertTrue(any("source.result.status" in error for error in result.errors), result.errors)
+        self.assertTrue(any("source.steps" in error for error in result.errors), result.errors)
+
+    def test_canonical_validator_rejects_false_extra_source_redaction_flag(self) -> None:
+        def extra_redaction_failed(evidence: dict) -> None:
+            evidence["redaction"]["private_keys_redacted"] = False
+
+        directory, root, source_commit, evidence_commit = self.make_repo(extra_redaction_failed)
+        self.addCleanup(directory.cleanup)
+        private_key = generate_acceptance_key(root)
+        trusted_hash = hashlib.sha256((root / "security" / "acceptance-candidate-signing-public.pem").read_bytes()).hexdigest()
+        payload = dict(base_evidence(source_commit))
+        payload.update({
+            "schema_version": "macprovider.journey-result.v1",
+            "artifacts": [
+                {
+                    "id": "redacted-provider-prebeta-admission",
+                    "sha256": hashlib.sha256((root / EVIDENCE_SOURCE).read_bytes()).hexdigest(),
+                    "source": EVIDENCE_SOURCE,
+                }
+            ],
+            "execution_mode": "physical-provider-prebeta-admission",
+        })
+        payload["redaction"] = {
+            "secrets_redacted": True,
+            "operator_identity_redacted": True,
+            "local_account_names_redacted": True,
+        }
+        payload_path = root / "payload.json"
+        payload_path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+        envelope = root / "journeys" / "evidence" / "provider-prebeta-admission-demo.journey-result.signed.json"
+        env = os.environ.copy()
+        env["MACPROVIDER_ACCEPTANCE_SIGNING_KEY_PEM"] = private_key
+        openssl = shutil.which("openssl")
+        if openssl is None:
+            raise unittest.SkipTest("openssl is required")
+        completed = subprocess.run(
+            [
+                sys.executable,
+                str(SIGNER),
+                "--root",
+                str(root),
+                "--input",
+                str(payload_path),
+                "--output",
+                str(envelope.relative_to(root)),
+                "--verified-at",
+                "2026-08-05T06:05:00Z",
+                "--openssl-bin",
+                openssl,
+            ],
+            env=env,
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+        self.assertEqual(0, completed.returncode, completed.stderr)
+
+        result = ValidationResult()
+        self.assertFalse(
+            _validate_signed_journey_result(
+                root,
+                str(envelope.relative_to(root)),
+                "SPEC-010-R001",
+                ["JOURNEY-PROVIDER-PREBETA-ADMISSION"],
+                {source_commit},
+                trusted_hash,
+                openssl,
+                "provider-prebeta",
+                result,
+            )
+        )
+        self.assertTrue(any("source.redaction.private_keys_redacted" in error for error in result.errors), result.errors)
 
     def test_builder_rejects_unmapped_requirement(self) -> None:
         def claim_unmapped_requirement(evidence: dict) -> None:
@@ -374,7 +556,7 @@ class ProviderPrebetaJourneyResultTests(unittest.TestCase):
         )
 
         self.assertNotEqual(0, completed.returncode)
-        self.assertIn("must exactly match evidence.requirement_ids", completed.stderr)
+        self.assertIn("must be covered by evidence.requirement_ids", completed.stderr)
 
     def test_builder_rejects_source_sha_that_differs_from_evidence_commit(self) -> None:
         directory, root, source_commit, evidence_commit = self.make_repo()

--- a/scripts/tests/test_spec_governance.py
+++ b/scripts/tests/test_spec_governance.py
@@ -9,7 +9,7 @@ import tempfile
 import unittest
 from pathlib import Path
 
-from scripts.check_spec_governance import validate_repository
+from scripts.check_spec_governance import _commit_mapping_selector_matches_current, _extract_mapping_fragment, validate_repository
 
 
 FIXTURES = Path(__file__).parent / "fixtures" / "spec_governance"
@@ -774,6 +774,579 @@ class GovernanceValidatorTests(unittest.TestCase):
             root = Path(directory)
             write_repository(root, base_repository())
             self.assertEqual([], validate_repository(root).errors)
+
+    def test_commit_evidence_allows_unrelated_file_changes_when_selectors_still_resolve(self) -> None:
+        repository = base_repository()
+        repository["authority"]["domains"][0]["requires_signed_journey_result"] = False
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            write_repository(root, repository)
+            commit = subprocess.check_output(["git", "rev-parse", "HEAD"], cwd=root, text=True).strip()
+            conformance_path = root / "specs" / "CONFORMANCE.json"
+            conformance = json.loads(conformance_path.read_text(encoding="utf-8"))
+            requirement = conformance["requirements"][0]
+            requirement["state"] = "conformant"
+            requirement["gap"] = None
+            requirement["evidence"] = [{
+                "artifact": f"commit:{commit}",
+                "source": None,
+                "captured_at": "2026-01-01",
+                "expires_at": "2027-01-01",
+            }]
+            conformance_path.write_text(json.dumps(conformance, indent=2, sort_keys=False) + "\n", encoding="utf-8")
+            (root / "src" / "example.py").write_text(
+                "def example():\n    return True\n\n\ndef unrelated_helper():\n    return False\n",
+                encoding="utf-8",
+            )
+
+            self.assertEqual([], validate_repository(root).errors)
+
+    def test_mapping_selector_does_not_resolve_from_comment_only_text(self) -> None:
+        repository = base_repository()
+        repository["files"]["src/example.py"] = "# selector text only: example\n"
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            write_repository(root, repository)
+
+            errors = "\n".join(validate_repository(root).errors)
+            self.assertIn("mapping selector 'example' does not resolve in 'src/example.py'", errors)
+
+    def test_go_mapping_selector_does_not_resolve_from_text_anchor_only(self) -> None:
+        cases = {
+            "comment": "// Foo only\n",
+            "call_site": "func caller() {\n\tFoo()\n}\n",
+            "prefix": "func FooBar() {\n\treturn\n}\n",
+        }
+        for name, source in cases.items():
+            with self.subTest(name=name):
+                repository = base_repository()
+                repository["files"]["src/example.go"] = source
+                repository["conformance"]["requirements"][0]["implementation"] = ["src/example.go:Foo"]
+                with tempfile.TemporaryDirectory() as directory:
+                    root = Path(directory)
+                    write_repository(root, repository)
+
+                    errors = "\n".join(validate_repository(root).errors)
+                    self.assertIn("mapping selector 'Foo' does not resolve in 'src/example.go'", errors)
+
+    def test_swift_mapping_selector_does_not_resolve_from_text_anchor_only(self) -> None:
+        cases = {
+            "comment": "// authInitialMessage only\n",
+            "call_site": "func caller() {\n    authInitialMessage()\n}\n",
+            "prefix": "func authInitialMessageV2() -> String {\n    \"new\"\n}\n",
+        }
+        for name, source in cases.items():
+            with self.subTest(name=name):
+                repository = base_repository()
+                repository["files"]["src/example.swift"] = source
+                repository["conformance"]["requirements"][0]["implementation"] = ["src/example.swift:authInitialMessage"]
+                with tempfile.TemporaryDirectory() as directory:
+                    root = Path(directory)
+                    write_repository(root, repository)
+
+                    errors = "\n".join(validate_repository(root).errors)
+                    self.assertIn(
+                        "mapping selector 'authInitialMessage' does not resolve in 'src/example.swift'",
+                        errors,
+                    )
+
+    def test_go_selector_fragment_prefers_declaration_over_comment_or_call_site(self) -> None:
+        text = (
+            "// ServePayoutAddress is mentioned before the handler.\n"
+            "func call() {\n"
+            "\tServePayoutAddress()\n"
+            "}\n\n"
+            "func (s *AddressesService) ServePayoutAddress(w http.ResponseWriter, r *http.Request) {\n"
+            "\treturn\n"
+            "}\n"
+        )
+
+        fragment = _extract_mapping_fragment(text, "ServePayoutAddress", "src/example.go")
+
+        self.assertIsNotNone(fragment)
+        assert fragment is not None
+        self.assertTrue(fragment.startswith("func (s *AddressesService) ServePayoutAddress"), fragment)
+
+    def test_swift_selector_fragment_prefers_exact_declaration_over_prefix_or_call_site(self) -> None:
+        text = (
+            "public enum PayoutAddressClientError: Error {}\n"
+            "func caller() {\n"
+            "    let initialMessage = await authInitialMessage(attempt: attempt)\n"
+            "}\n\n"
+            "public struct PayoutAddressClient {\n"
+            "    let baseURL: URL\n"
+            "}\n\n"
+            "func authInitialMessage(attempt: Int) async -> String {\n"
+            "    \"ok\"\n"
+            "}\n"
+        )
+
+        client = _extract_mapping_fragment(text, "PayoutAddressClient", "src/example.swift")
+        auth = _extract_mapping_fragment(text, "authInitialMessage", "src/example.swift")
+
+        self.assertIsNotNone(client)
+        self.assertIsNotNone(auth)
+        assert client is not None
+        assert auth is not None
+        self.assertTrue(client.startswith("public struct PayoutAddressClient"), client)
+        self.assertTrue(auth.startswith("func authInitialMessage"), auth)
+
+    def test_selector_fragment_rejects_prefix_declarations(self) -> None:
+        go_text = (
+            "func FooBar() {\n"
+            "\treturn\n"
+            "}\n\n"
+            "func Foo() {\n"
+            "\treturn\n"
+            "}\n"
+        )
+        swift_text = (
+            "func authInitialMessageV2() -> String {\n"
+            "    \"new\"\n"
+            "}\n\n"
+            "func authInitialMessage() -> String {\n"
+            "    \"old\"\n"
+            "}\n"
+        )
+
+        go_fragment = _extract_mapping_fragment(go_text, "Foo", "src/example.go")
+        swift_fragment = _extract_mapping_fragment(swift_text, "authInitialMessage", "src/example.swift")
+
+        self.assertIsNotNone(go_fragment)
+        self.assertIsNotNone(swift_fragment)
+        assert go_fragment is not None
+        assert swift_fragment is not None
+        self.assertTrue(go_fragment.startswith("func Foo()"), go_fragment)
+        self.assertTrue(swift_fragment.startswith("func authInitialMessage()"), swift_fragment)
+
+    def test_selector_fragment_does_not_fall_back_to_prefix_when_exact_declaration_is_absent(self) -> None:
+        go_text = "func FooBar() {\n\treturn\n}\n"
+        swift_text = "func authInitialMessageV2() -> String {\n    \"new\"\n}\n"
+
+        self.assertIsNone(_extract_mapping_fragment(go_text, "Foo", "src/example.go"))
+        self.assertIsNone(_extract_mapping_fragment(swift_text, "authInitialMessage", "src/example.swift"))
+
+    def test_selector_fragment_rejects_local_go_and_swift_bindings(self) -> None:
+        go_text = "func caller() {\n\tFoo = 1\n}\n"
+        swift_text = "func caller() {\n    let authInitialMessage = \"local\"\n}\n"
+
+        self.assertIsNone(_extract_mapping_fragment(go_text, "Foo", "src/example.go"))
+        self.assertIsNone(_extract_mapping_fragment(swift_text, "authInitialMessage", "src/example.swift"))
+
+    def test_selector_fragment_rejects_unparseable_go_and_swift_selector_text(self) -> None:
+        go_text = "func caller() {\n\tFoo()\n}\n"
+        swift_text = "func caller() {\n    authInitialMessage()\n}\n"
+
+        self.assertIsNone(_extract_mapping_fragment(go_text, "Foo()", "src/example.go"))
+        self.assertIsNone(_extract_mapping_fragment(swift_text, "authInitialMessage()", "src/example.swift"))
+
+    def test_go_selector_fragment_resolves_struct_field(self) -> None:
+        go_text = "type Provider struct {\n\tWeightsManifestSHA256 string\n}\n"
+
+        fragment = _extract_mapping_fragment(go_text, "WeightsManifestSHA256 string", "src/example.go")
+
+        self.assertEqual("\tWeightsManifestSHA256 string", fragment)
+
+    def test_go_selector_fragment_resolves_const_group_item(self) -> None:
+        go_text = (
+            "const (\n\tSnapshotManifestV1 = \"macprovider.snapshot-manifest.v1\"\n)\n\n"
+            "var sha256Pattern = regexp.MustCompile(`^[0-9a-f]{64}$`)\n"
+        )
+
+        fragment = _extract_mapping_fragment(go_text, "SnapshotManifestV1", "src/example.go")
+
+        self.assertEqual("SnapshotManifestV1 = \"macprovider.snapshot-manifest.v1\"", fragment.lstrip() if fragment else fragment)
+
+    def test_swift_selector_fragment_includes_multiline_initializer(self) -> None:
+        swift_text = (
+            "final class RouterHandler {\n"
+            "    static let localStatusCapabilities = [\n"
+            "        \"buyer_serving_authority_v1\",\n"
+            "        \"referral_fragment_links_v1\",\n"
+            "    ]\n"
+            "}\n"
+        )
+
+        fragment = _extract_mapping_fragment(swift_text, "localStatusCapabilities", "src/example.swift")
+
+        self.assertIsNotNone(fragment)
+        assert fragment is not None
+        self.assertIn("\"referral_fragment_links_v1\"", fragment)
+
+    def test_selector_fragment_rejects_inactive_go_and_swift_declarations(self) -> None:
+        go_comment = "/*\nfunc Foo() {\n\treturn\n}\n*/\n"
+        go_raw_string = "var doc = `\nfunc Foo() {\n\treturn\n}\n`\n"
+        swift_comment = "/*\nfunc authInitialMessage() -> String {\n    \"old\"\n}\n*/\n"
+        swift_inactive = "#if false\nfunc authInitialMessage() -> String {\n    \"old\"\n}\n#endif\n"
+        swift_multiline_string = 'let doc = """\nfunc authInitialMessage() -> String {\n    "old"\n}\n"""\n'
+
+        self.assertIsNone(_extract_mapping_fragment(go_comment, "Foo", "src/example.go"))
+        self.assertIsNone(_extract_mapping_fragment(go_raw_string, "Foo", "src/example.go"))
+        self.assertIsNone(_extract_mapping_fragment(swift_comment, "authInitialMessage", "src/example.swift"))
+        self.assertIsNone(_extract_mapping_fragment(swift_inactive, "authInitialMessage", "src/example.swift"))
+        self.assertIsNone(_extract_mapping_fragment(swift_multiline_string, "authInitialMessage", "src/example.swift"))
+
+    def test_selector_fragment_rejects_duplicate_go_or_swift_declarations(self) -> None:
+        go_text = "func Foo() {\n\treturn\n}\n\nfunc Foo() {\n\treturn\n}\n"
+        swift_text = "func authInitialMessage() -> String {\n    \"one\"\n}\n\nfunc authInitialMessage() -> String {\n    \"two\"\n}\n"
+
+        self.assertIsNone(_extract_mapping_fragment(go_text, "Foo", "src/example.go"))
+        self.assertIsNone(_extract_mapping_fragment(swift_text, "authInitialMessage", "src/example.swift"))
+
+    def test_selector_fragment_rejects_duplicate_python_declarations(self) -> None:
+        python_text = "def example():\n    return 'one'\n\n\ndef example():\n    return 'two'\n"
+
+        self.assertIsNone(_extract_mapping_fragment(python_text, "example", "src/example.py"))
+
+    def test_explicit_swift_declaration_selector_disambiguates_overloads(self) -> None:
+        swift_text = (
+            "func writeSuccessSentinel(binaryURL: URL, marker: AutoUpdatePendingMarker) throws {\n"
+            "    try write()\n"
+            "}\n\n"
+            "func writeSuccessSentinel(binaryURL: URL, updateID: String, targetVersion: String) throws {\n"
+            "    try write()\n"
+            "}\n"
+        )
+
+        fragment = _extract_mapping_fragment(
+            swift_text,
+            "func writeSuccessSentinel(binaryURL: URL, marker: AutoUpdatePendingMarker)",
+            "src/example.swift",
+        )
+
+        self.assertIsNotNone(fragment)
+        assert fragment is not None
+        self.assertIn("marker: AutoUpdatePendingMarker", fragment)
+        self.assertNotIn("targetVersion", fragment)
+
+    def test_commit_mapping_selector_rejects_inactive_declaration_forgery(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            write_repository(root, base_repository())
+            go_path = root / "src" / "example.go"
+            go_path.write_text("func Foo() {\n\treturn\n}\n", encoding="utf-8")
+            subprocess.run(["git", "add", "src/example.go"], cwd=root, check=True)
+            subprocess.run(["git", "commit", "-qm", "go fixture"], cwd=root, check=True)
+            commit = subprocess.check_output(["git", "rev-parse", "HEAD"], cwd=root, text=True).strip()
+            go_path.write_text(
+                "/*\nfunc Foo() {\n\treturn\n}\n*/\n\nfunc Foo() {\n\tpanic(\"changed\")\n}\n",
+                encoding="utf-8",
+            )
+
+            self.assertFalse(_commit_mapping_selector_matches_current(root, commit, "src/example.go:Foo"))
+
+    def test_commit_mapping_selector_rejects_go_build_constraint_forgery(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            write_repository(root, base_repository())
+            go_path = root / "src" / "example.go"
+            go_path.write_text("package example\n\nfunc Foo() {\n\treturn\n}\n", encoding="utf-8")
+            subprocess.run(["git", "add", "src/example.go"], cwd=root, check=True)
+            subprocess.run(["git", "commit", "-qm", "go fixture"], cwd=root, check=True)
+            commit = subprocess.check_output(["git", "rev-parse", "HEAD"], cwd=root, text=True).strip()
+            go_path.write_text("//go:build ignore\n\npackage example\n\nfunc Foo() {\n\treturn\n}\n", encoding="utf-8")
+
+            self.assertFalse(_commit_mapping_selector_matches_current(root, commit, "src/example.go:Foo"))
+
+    def test_commit_mapping_selector_rejects_inactive_swift_compilation_forgery(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            write_repository(root, base_repository())
+            swift_path = root / "src" / "example.swift"
+            swift_path.write_text("func authInitialMessage() -> String {\n    \"old\"\n}\n", encoding="utf-8")
+            subprocess.run(["git", "add", "src/example.swift"], cwd=root, check=True)
+            subprocess.run(["git", "commit", "-qm", "swift fixture"], cwd=root, check=True)
+            commit = subprocess.check_output(["git", "rev-parse", "HEAD"], cwd=root, text=True).strip()
+            swift_path.write_text(
+                "#if false\nfunc authInitialMessage() -> String {\n    \"old\"\n}\n#endif\n\n"
+                "func authInitialMessage() -> String {\n    \"new\"\n}\n",
+                encoding="utf-8",
+            )
+
+            self.assertFalse(
+                _commit_mapping_selector_matches_current(root, commit, "src/example.swift:authInitialMessage")
+            )
+
+    def test_commit_mapping_selector_rejects_nested_inactive_swift_compilation_forgery(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            write_repository(root, base_repository())
+            swift_path = root / "src" / "example.swift"
+            swift_path.write_text("func authInitialMessage() -> String {\n    \"old\"\n}\n", encoding="utf-8")
+            subprocess.run(["git", "add", "src/example.swift"], cwd=root, check=True)
+            subprocess.run(["git", "commit", "-qm", "swift fixture"], cwd=root, check=True)
+            commit = subprocess.check_output(["git", "rev-parse", "HEAD"], cwd=root, text=True).strip()
+            swift_path.write_text(
+                "#if false\n"
+                "#if os(macOS)\n"
+                "#endif\n"
+                "func authInitialMessage() -> String {\n    \"old\"\n}\n"
+                "#endif\n\n"
+                "func authInitialMessage() -> String {\n    \"new\"\n}\n",
+                encoding="utf-8",
+            )
+
+            self.assertFalse(
+                _commit_mapping_selector_matches_current(root, commit, "src/example.swift:authInitialMessage")
+            )
+
+    def test_commit_mapping_selector_rejects_swift_conditional_wrapper_forgery(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            write_repository(root, base_repository())
+            swift_path = root / "src" / "example.swift"
+            swift_path.write_text("func authInitialMessage() -> String {\n    \"old\"\n}\n", encoding="utf-8")
+            subprocess.run(["git", "add", "src/example.swift"], cwd=root, check=True)
+            subprocess.run(["git", "commit", "-qm", "swift fixture"], cwd=root, check=True)
+            commit = subprocess.check_output(["git", "rev-parse", "HEAD"], cwd=root, text=True).strip()
+            swift_path.write_text(
+                "#if SOME_UNDECLARED_FLAG\n"
+                "func authInitialMessage() -> String {\n    \"old\"\n}\n"
+                "#endif\n",
+                encoding="utf-8",
+            )
+
+            self.assertFalse(
+                _commit_mapping_selector_matches_current(root, commit, "src/example.swift:authInitialMessage")
+            )
+
+    def test_commit_mapping_selector_rejects_multiline_initializer_drift(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            write_repository(root, base_repository())
+            swift_path = root / "src" / "example.swift"
+            swift_path.write_text(
+                "final class RouterHandler {\n"
+                "    static let localStatusCapabilities = [\n"
+                "        \"buyer_serving_authority_v1\",\n"
+                "        \"referral_fragment_links_v1\",\n"
+                "    ]\n"
+                "}\n",
+                encoding="utf-8",
+            )
+            subprocess.run(["git", "add", "src/example.swift"], cwd=root, check=True)
+            subprocess.run(["git", "commit", "-qm", "swift fixture"], cwd=root, check=True)
+            commit = subprocess.check_output(["git", "rev-parse", "HEAD"], cwd=root, text=True).strip()
+            swift_path.write_text(
+                "final class RouterHandler {\n"
+                "    static let localStatusCapabilities = [\n"
+                "        \"buyer_serving_authority_v1\",\n"
+                "        \"referral_fragment_links_v2\",\n"
+                "    ]\n"
+                "}\n",
+                encoding="utf-8",
+            )
+
+            self.assertFalse(
+                _commit_mapping_selector_matches_current(root, commit, "src/example.swift:localStatusCapabilities")
+            )
+
+    def test_commit_mapping_selector_rejects_shell_function_body_drift(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            write_repository(root, base_repository())
+            shell_path = root / "src" / "example.sh"
+            shell_path.write_text("target() {\n    echo safe\n}\n", encoding="utf-8")
+            subprocess.run(["git", "add", "src/example.sh"], cwd=root, check=True)
+            subprocess.run(["git", "commit", "-qm", "shell fixture"], cwd=root, check=True)
+            commit = subprocess.check_output(["git", "rev-parse", "HEAD"], cwd=root, text=True).strip()
+            shell_path.write_text("target() {\n    echo evil\n}\n", encoding="utf-8")
+
+            self.assertFalse(_commit_mapping_selector_matches_current(root, commit, "src/example.sh:target"))
+
+    def test_commit_mapping_selector_rejects_shell_body_drift_after_comment_brace(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            write_repository(root, base_repository())
+            shell_path = root / "src" / "example.sh"
+            shell_path.write_text("target() {\n    # }\n    echo safe\n}\n", encoding="utf-8")
+            subprocess.run(["git", "add", "src/example.sh"], cwd=root, check=True)
+            subprocess.run(["git", "commit", "-qm", "shell fixture"], cwd=root, check=True)
+            commit = subprocess.check_output(["git", "rev-parse", "HEAD"], cwd=root, text=True).strip()
+            shell_path.write_text("target() {\n    # }\n    echo evil\n}\n", encoding="utf-8")
+
+            self.assertFalse(_commit_mapping_selector_matches_current(root, commit, "src/example.sh:target"))
+
+    def test_commit_mapping_selector_rejects_shell_body_drift_after_heredoc_brace(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            write_repository(root, base_repository())
+            shell_path = root / "src" / "example.sh"
+            shell_path.write_text(
+                "target() {\n"
+                "    cat <<EOF\n"
+                "}\n"
+                "EOF\n"
+                "    echo safe\n"
+                "}\n",
+                encoding="utf-8",
+            )
+            subprocess.run(["git", "add", "src/example.sh"], cwd=root, check=True)
+            subprocess.run(["git", "commit", "-qm", "shell fixture"], cwd=root, check=True)
+            commit = subprocess.check_output(["git", "rev-parse", "HEAD"], cwd=root, text=True).strip()
+            shell_path.write_text(
+                "target() {\n"
+                "    cat <<EOF\n"
+                "}\n"
+                "EOF\n"
+                "    echo evil\n"
+                "}\n",
+                encoding="utf-8",
+            )
+
+            self.assertFalse(_commit_mapping_selector_matches_current(root, commit, "src/example.sh:target"))
+
+    def test_commit_mapping_selector_rejects_duplicate_shell_function_forgery(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            write_repository(root, base_repository())
+            shell_path = root / "src" / "example.sh"
+            shell_path.write_text("target() {\n    echo safe\n}\n", encoding="utf-8")
+            subprocess.run(["git", "add", "src/example.sh"], cwd=root, check=True)
+            subprocess.run(["git", "commit", "-qm", "shell fixture"], cwd=root, check=True)
+            commit = subprocess.check_output(["git", "rev-parse", "HEAD"], cwd=root, text=True).strip()
+            shell_path.write_text("target() {\n    echo safe\n}\n\ntarget() {\n    echo evil\n}\n", encoding="utf-8")
+
+            self.assertFalse(_commit_mapping_selector_matches_current(root, commit, "src/example.sh:target"))
+
+    def test_commit_mapping_selector_rejects_embedded_python_body_drift_in_shell(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            write_repository(root, base_repository())
+            shell_path = root / "src" / "example.sh"
+            shell_path.write_text(
+                "#!/usr/bin/env bash\n"
+                "python3 <<'PY'\n"
+                "def fence_reload_helpers():\n"
+                "    return 'safe'\n"
+                "PY\n",
+                encoding="utf-8",
+            )
+            subprocess.run(["git", "add", "src/example.sh"], cwd=root, check=True)
+            subprocess.run(["git", "commit", "-qm", "shell fixture"], cwd=root, check=True)
+            commit = subprocess.check_output(["git", "rev-parse", "HEAD"], cwd=root, text=True).strip()
+            shell_path.write_text(
+                "#!/usr/bin/env bash\n"
+                "python3 <<'PY'\n"
+                "def fence_reload_helpers():\n"
+                "    return 'evil'\n"
+                "PY\n",
+                encoding="utf-8",
+            )
+
+            self.assertFalse(
+                _commit_mapping_selector_matches_current(root, commit, "src/example.sh:def fence_reload_helpers")
+            )
+
+    def test_commit_mapping_selector_rejects_inert_embedded_python_heredoc_forgery(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            write_repository(root, base_repository())
+            shell_path = root / "src" / "example.sh"
+            shell_path.write_text(
+                "#!/usr/bin/env bash\n"
+                "python3 <<'PY'\n"
+                "def fence_reload_helpers():\n"
+                "    return 'safe'\n"
+                "print(fence_reload_helpers())\n"
+                "PY\n",
+                encoding="utf-8",
+            )
+            subprocess.run(["git", "add", "src/example.sh"], cwd=root, check=True)
+            subprocess.run(["git", "commit", "-qm", "shell fixture"], cwd=root, check=True)
+            commit = subprocess.check_output(["git", "rev-parse", "HEAD"], cwd=root, text=True).strip()
+            shell_path.write_text(
+                "#!/usr/bin/env bash\n"
+                ": <<'PY'\n"
+                "def fence_reload_helpers():\n"
+                "    return 'safe'\n"
+                "PY\n"
+                "python3 <<'PY'\n"
+                "def fence_reload_helpers_v2():\n"
+                "    return 'evil'\n"
+                "print(fence_reload_helpers_v2())\n"
+                "PY\n",
+                encoding="utf-8",
+            )
+
+            self.assertFalse(
+                _commit_mapping_selector_matches_current(root, commit, "src/example.sh:def fence_reload_helpers")
+            )
+
+    def test_embedded_python_selector_resolves_from_continued_python_heredoc(self) -> None:
+        shell_text = (
+            "validated=\"$(python3 - \"$INSTALL_DIR\" \\\n"
+            "  \"$HOME\" <<'PY'\n"
+            "def fence_reload_helpers():\n"
+            "    return 'safe'\n"
+            "PY\n"
+            ")\"\n"
+        )
+
+        fragment = _extract_mapping_fragment(shell_text, "def fence_reload_helpers", "src/example.sh")
+
+        self.assertEqual("def fence_reload_helpers():\n    return 'safe'", fragment)
+
+    def test_embedded_python_selector_ignores_python_word_in_non_python_heredoc_command(self) -> None:
+        shell_text = (
+            "echo python3 <<'PY'\n"
+            "def fence_reload_helpers():\n"
+            "    return 'safe'\n"
+            "PY\n"
+        )
+
+        self.assertIsNone(_extract_mapping_fragment(shell_text, "def fence_reload_helpers", "src/example.sh"))
+
+    def test_embedded_python_selector_resolves_from_generated_shell_heredoc(self) -> None:
+        shell_text = (
+            "cat > \"$WATCHDOG_PATH\" <<'WATCHDOG_EOF'\n"
+            "#!/usr/bin/env bash\n"
+            "python3 <<'PY'\n"
+            "def fence_reload_helpers():\n"
+            "    return 'safe'\n"
+            "PY\n"
+            "WATCHDOG_EOF\n"
+        )
+
+        fragment = _extract_mapping_fragment(shell_text, "def fence_reload_helpers", "src/example.sh")
+
+        self.assertEqual("def fence_reload_helpers():\n    return 'safe'", fragment)
+
+    def test_embedded_python_selector_ignores_printf_stdin_heredoc(self) -> None:
+        shell_text = (
+            "printf '' > \"$WATCHDOG_PATH\" <<'WATCHDOG_EOF'\n"
+            "#!/usr/bin/env bash\n"
+            "python3 <<'PY'\n"
+            "def fence_reload_helpers():\n"
+            "    return 'safe'\n"
+            "PY\n"
+            "WATCHDOG_EOF\n"
+        )
+
+        self.assertIsNone(_extract_mapping_fragment(shell_text, "def fence_reload_helpers", "src/example.sh"))
+
+    def test_embedded_python_selector_ignores_generated_shell_sink_heredoc(self) -> None:
+        shell_text = (
+            "cat > /dev/null <<'WATCHDOG_EOF'\n"
+            "#!/usr/bin/env bash\n"
+            "python3 <<'PY'\n"
+            "def fence_reload_helpers():\n"
+            "    return 'safe'\n"
+            "PY\n"
+            "WATCHDOG_EOF\n"
+        )
+
+        self.assertIsNone(_extract_mapping_fragment(shell_text, "def fence_reload_helpers", "src/example.sh"))
+
+    def test_commit_mapping_selector_rejects_current_path_escape(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            write_repository(root, base_repository())
+            commit = subprocess.check_output(["git", "rev-parse", "HEAD"], cwd=root, text=True).strip()
+            outside = root.parent / "outside.py"
+            outside.write_text("def example():\n    return True\n", encoding="utf-8")
+
+            self.assertFalse(_commit_mapping_selector_matches_current(root, commit, "../outside.py:example"))
 
     def test_sensitive_conformant_with_signed_journey_result_passes(self) -> None:
         repository = base_repository()

--- a/specs/CONFORMANCE.json
+++ b/specs/CONFORMANCE.json
@@ -1173,7 +1173,7 @@
       "implementation": [
         "phase4-coordinator/internal/requestlog/store.go:Row",
         "phase4-coordinator/internal/buyer/phase_timing.go:requestLogTTFTMs",
-        "phase4-coordinator/internal/buyer/billing_recorder.go:record"
+        "phase4-coordinator/internal/buyer/billing_recorder.go:recordRow"
       ],
       "tests": [
         "phase4-coordinator/internal/requestlog/store_test.go::TestRequestLogMigratesExistingTable",
@@ -1240,7 +1240,7 @@
       "state": "pending",
       "implementation": [
         "phase3-binary/Sources/macprovider-cli/ModelArtifactIdentity.swift:static let snapshotManifestV1",
-        "phase3-binary/Sources/macprovider-cli/ModelRuntime.swift:verifiedModelArtifactSHA256",
+        "phase3-binary/Sources/macprovider-cli/ModelRuntime.swift:verifiedCatalogArtifactSHA256",
         "phase4-coordinator/internal/modelidentity/identity.go:SnapshotManifestV1"
       ],
       "tests": [
@@ -1290,7 +1290,7 @@
       "implementation": [
         "phase3-binary/Sources/macprovider-cli/ModelArtifactIdentity.swift:static let safetensorsManifestV1",
         "phase3-binary/Sources/macprovider-cli/ModelRuntime.swift:static func modelWeightArtifactManifestHash",
-        "phase4-coordinator/internal/pool/provider.go:WeightsManifestSHA256 string"
+        "phase4-coordinator/internal/pool/provider.go:func (r *Registry) applyHeartbeatLocked"
       ],
       "tests": [
         "phase3-binary/Tests/macprovider-cliTests/CoordinatorClientTests.swift::testCatalogWarmSwapBootTrustDoesNotCompareWeightManifestToCanonicalArtifactHash",
@@ -1522,11 +1522,11 @@
       "implementation": [
         "phase3-binary/Sources/macprovider-cli/SelfUpdate.swift:applyValidatedUpdate",
         "phase3-binary/Sources/macprovider-cli/SelfUpdate.swift:waitForLocalHealthIfManaged",
-        "phase3-binary/Sources/macprovider-cli/AutoUpdateMarker.swift:writeSuccessSentinel",
+        "phase3-binary/Sources/macprovider-cli/AutoUpdateMarker.swift:func writeSuccessSentinel(binaryURL: URL, marker: AutoUpdatePendingMarker)",
         "phase3-binary/Sources/macprovider-cli/AutoUpdateMarker.swift:readSuccessSentinel",
         "phase3-binary/Sources/macprovider-cli/CoordinatorClient.swift:localSignedSetRecoveryAllowed",
         "phase3-binary/Sources/macprovider-cli/CoordinatorClient.swift:commitPendingAutoupdateAfterServingProof",
-        "phase3-binary/Sources/macprovider-cli/CoordinatorClient.swift:runStartupAutoupdateRecovery"
+        "phase3-binary/Sources/macprovider-cli/CoordinatorClient.swift:private func runStartupAutoupdateRecovery()"
       ],
       "tests": [
         "phase3-binary/Tests/macprovider-cliTests/SelfUpdateTests.swift::testReadinessFailureRollsBackReplacement",
@@ -1569,7 +1569,7 @@
         "phase3-binary/Sources/macprovider-cli/CoordinatorClient.swift:waitForStableLocalAutoupdateHealth",
         "phase3-binary/Sources/macprovider-cli/MacProviderCLI.swift:fenceAuthorizedSelfUpdateReloadJobsAtStartup",
         "phase3-binary/Sources/macprovider-cli/ProviderLifecycleLease.swift:recoverAdoptedStartupHandoff",
-        "phase3-binary/Sources/macprovider-cli/ProviderLifecycleLease.swift:launchdServiceProcessID",
+        "phase3-binary/Sources/macprovider-cli/ProviderLifecycleLease.swift:static func launchdServiceProcessID",
         "phase3-binary/Sources/macprovider-cli/SelfUpdate.swift:fenceProviderReloadLaunchdJobs",
         "phase3-binary/Sources/macprovider-cli/SelfUpdate.swift:launchctlServiceLoadedOrThrow",
         "phase3-binary/Sources/macprovider-cli/SelfUpdate.swift:providerReloadLaunchAgentData",
@@ -1687,7 +1687,7 @@
         "phase3-binary/Sources/macprovider-cli/AutotuneRecommend.swift:var benchmarkedCount",
         "phase3-binary/Sources/macprovider-cli/AutotuneRecommend.swift:func humanTranscript",
         "phase3-binary/Sources/macprovider-cli/AutotuneCommand.swift:static func donorModeApplyWarning",
-        "phase3-binary/dist/install.sh:run_autotune_recommend_apply"
+        "phase3-binary/dist/install.sh:run_autotune_recommend_apply()"
       ],
       "tests": [
         "phase3-binary/Tests/macprovider-cliTests/AutotuneRecommendTests.swift::testRecommendationJSONCarriesBenchGateProvenanceAndDrift",
@@ -1829,7 +1829,7 @@
       "implementation": [
         "phase4-coordinator/internal/referralapi/xapi.go:parseJoinBaseURL",
         "phase4-coordinator/internal/referralapi/validate.go:ValidationHandler",
-        "phase3-binary/Sources/macprovider-cli/HTTPServer.swift:referral_fragment_links_v1",
+        "phase3-binary/Sources/macprovider-cli/HTTPServer.swift:localStatusCapabilities",
         "phase3-binary/app/Sources/Malibu/Agent/AgentSnapshot.swift:hasTrustedReferralBoundary"
       ],
       "tests": [
@@ -1984,7 +1984,7 @@
       "state": "pending",
       "implementation": [
         "phase3-binary/Sources/macprovider-cli/CoordinatorClient.swift:func diagnosticStatusPayloadForTest",
-        "phase3-binary/Sources/macprovider-cli/CoordinatorClient.swift:func sendDiagnosticStatus",
+        "phase3-binary/Sources/macprovider-cli/CoordinatorClient.swift:private func sendDiagnosticStatus",
         "phase4-coordinator/internal/ws/messages.go:func ParseDiagnosticStatus",
         "phase4-coordinator/internal/ws/server.go:func (s *Server) handleDiagnosticStatus",
         "phase4-coordinator/internal/providerevents/store.go:func (s *SQLiteStore) UpsertLastKnown",

--- a/specs/PROCESS.md
+++ b/specs/PROCESS.md
@@ -85,9 +85,13 @@ insufficient, a conformance state, and evidence. Allowed states are
 
 - `conformant` requires implementation mapping, a test or journey, reachable
   commit evidence for the code mappings, and current evidence with an expiry
-  date. Every mapped source and test file must still match that evidence
-  commit; a later file change invalidates the evidence even when its selector
-  text remains present.
+  date. Every mapped source and test selector fragment must match between the
+  evidence commit and the current tree. A later unrelated edit in the same file
+  does not invalidate evidence by itself, but selector body drift or removal
+  does.
+- A signed journey-result may promote a subset of requirement IDs covered by a
+  redacted physical evidence artifact. The signed IDs must all be present in
+  the source artifact; uncovered IDs are overclaims and fail validation.
 - `pending`, `blocked`, and `nonconformant` require an arbitration verdict,
   owner, and issue.
 - `not-applicable` requires a recorded rationale and owner.

--- a/specs/TEMPLATE.md
+++ b/specs/TEMPLATE.md
@@ -70,8 +70,11 @@ in `CONFORMANCE.json` and includes:
 Mappings use `path:symbol` or `path::test_name` and the selector must resolve in
 the named file. A `sha256:` evidence artifact also names its repository-relative
 source file; commit evidence uses `source: null`. Commit evidence remains
-current only while every mapped implementation and test file matches the
-evidence commit.
+current only while every mapped implementation and test selector fragment
+matches between the evidence commit and the current tree.
+For physical journey promotion, one redacted evidence artifact may cover a
+superset of requirements, but the signed journey-result may claim only IDs
+present in that artifact.
 
 ## 5. Open gaps
 


### PR DESCRIPTION
## Summary
- Replaces commit-evidence whole-file equality with selector-fragment equality, so valid signed physical evidence is not invalidated by unrelated file churn.
- Fails closed for stale selector evidence: comments, strings, duplicate declarations, inactive Swift/Go build context, shell body drift, inert heredocs, embedded Python body drift, and path escapes.
- Allows provider-prebeta signed journey-results to claim a subset covered by the redacted source artifact, while rejecting overclaims and source/signed contradictions.

## Provider-Prebeta Promotion Boundary
- Local selector preflight against July Air5/Qwen evidence commit `6a2278f4f678abcc91361d0d6f008649e63b6fc3` validates `SPEC-010-R002`.
- The same preflight rejects `SPEC-010-R003` because `phase4-coordinator/internal/pool/provider.go:func (r *Registry) applyHeartbeatLocked` has real selector drift. R003 should remain pending until fresh physical evidence exists.

## Validation
- `python3 -m unittest scripts.tests.test_spec_governance scripts.tests.test_provider_prebeta_journey_result scripts.tests.test_journey_result_tools`
- `python3 scripts/check_spec_governance.py --base-ref origin/main`
- `python3 scripts/gen_spec_index.py --check`
- `python3 -m py_compile scripts/check_spec_governance.py scripts/build-provider-prebeta-journey-result.py scripts/tests/test_spec_governance.py scripts/tests/test_provider_prebeta_journey_result.py`
- `bash scripts/test-signed-provider-prebeta-journey-workflow.sh`
- `git diff --check`
- `git diff --exit-code origin/main -- phase4-coordinator/internal/billing phase4-coordinator/internal/buyer/billing_recorder.go`

SPEC-GOVERNANCE-DECLARATION-BEGIN
{
  "schema_version": "spec-pr-governance-v1",
  "behavior_change": "yes",
  "contract_change": "yes",
  "specs": ["SPEC-010"],
  "requirements": ["SPEC-010-R002"],
  "authority_domains": ["model-catalog-identity"],
  "arbitration": ["UNKNOWN"],
  "tests": [
    "python3 -m unittest scripts.tests.test_spec_governance scripts.tests.test_provider_prebeta_journey_result scripts.tests.test_journey_result_tools",
    "python3 scripts/check_spec_governance.py --base-ref origin/main",
    "python3 scripts/gen_spec_index.py --check",
    "bash scripts/test-signed-provider-prebeta-journey-workflow.sh"
  ],
  "journeys": ["JOURNEY-PROVIDER-PREBETA-ADMISSION"],
  "issue": "https://github.com/Augustas11/macprovider/issues/614"
}
SPEC-GOVERNANCE-DECLARATION-END