### PR TITLE
Let provider prebeta signed subsets coexist

### DIFF
--- a/.github/workflows/promote-signed-provider-prebeta-journey.yml
+++ b/.github/workflows/promote-signed-provider-prebeta-journey.yml
@@ -63,14 +63,17 @@ jobs:
           [[ "$main_sha" == "$GITHUB_SHA" ]] || { echo "::error::workflow commit is no longer origin/main" >&2; exit 1; }
           git cat-file -e "${SOURCE_SHA_INPUT}^{commit}" || { echo "::error::source SHA is not reachable" >&2; exit 1; }
           git merge-base --is-ancestor "$SOURCE_SHA_INPUT" "$GITHUB_SHA" || { echo "::error::source SHA must be an ancestor of the reviewed evidence commit" >&2; exit 1; }
-          envelope="${REDACTED_EVIDENCE_INPUT%.redacted.json}.journey-result.signed.json"
-          payload="$RUNNER_TEMP/provider-prebeta-journey-result.unsigned.json"
+          requirement_slug="$(printf '%s' "$REQUIREMENT_IDS_INPUT" | tr '[:upper:]' '[:lower:]' | tr ',' '-')"
+          [[ "$requirement_slug" =~ ^spec-[0-9]{3}-r[0-9]{3}(-spec-[0-9]{3}-r[0-9]{3})*$ ]] || { echo "::error::invalid requirement slug" >&2; exit 1; }
+          envelope="${REDACTED_EVIDENCE_INPUT%.redacted.json}.${requirement_slug}.journey-result.signed.json"
+          payload="$RUNNER_TEMP/provider-prebeta-journey-result-${requirement_slug}.unsigned.json"
           short_sha="${SOURCE_SHA_INPUT:0:12}"
           printf 'source_sha=%s\n' "$SOURCE_SHA_INPUT" >> "$GITHUB_OUTPUT"
           printf 'evidence_sha=%s\n' "$GITHUB_SHA" >> "$GITHUB_OUTPUT"
           printf 'short_sha=%s\n' "$short_sha" >> "$GITHUB_OUTPUT"
           printf 'redacted=%s\n' "$REDACTED_EVIDENCE_INPUT" >> "$GITHUB_OUTPUT"
           printf 'requirement_ids=%s\n' "$REQUIREMENT_IDS_INPUT" >> "$GITHUB_OUTPUT"
+          printf 'requirement_slug=%s\n' "$requirement_slug" >> "$GITHUB_OUTPUT"
           printf 'payload=%s\n' "$payload" >> "$GITHUB_OUTPUT"
           printf 'envelope=%s\n' "$envelope" >> "$GITHUB_OUTPUT"
 
@@ -187,6 +190,7 @@ jobs:
           REDACTED: ${{ steps.request.outputs.redacted }}
           ENVELOPE: ${{ steps.request.outputs.envelope }}
           REQUIREMENT_IDS: ${{ steps.request.outputs.requirement_ids }}
+          REQUIREMENT_SLUG: ${{ steps.request.outputs.requirement_slug }}
         run: |
           set -euo pipefail
           export_dir="$RUNNER_TEMP/signed-provider-prebeta-journey-promotion"
@@ -208,6 +212,7 @@ jobs:
               "source_sha": source_sha,
               "evidence_sha": evidence_sha,
               "requirement_ids": [item for item in requirement_ids.split(",") if item],
+              "requirement_slug": os.environ["REQUIREMENT_SLUG"],
               "journey_id": "JOURNEY-PROVIDER-PREBETA-ADMISSION",
               "redacted_artifact": redacted,
               "redacted_sha256": hashlib.sha256((root / redacted).read_bytes()).hexdigest(),
@@ -223,7 +228,7 @@ jobs:
       - name: Upload signed promotion artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
-          name: signed-provider-prebeta-journey-promotion-${{ steps.request.outputs.source_sha }}
+          name: signed-provider-prebeta-journey-promotion-${{ steps.request.outputs.source_sha }}-${{ steps.request.outputs.requirement_slug }}
           path: ${{ runner.temp }}/signed-provider-prebeta-journey-promotion/
           if-no-files-found: error
           include-hidden-files: false

--- a/scripts/test-signed-provider-prebeta-journey-workflow.sh
+++ b/scripts/test-signed-provider-prebeta-journey-workflow.sh
@@ -33,6 +33,11 @@ required_workflow = [
     'git cat-file -e "${SOURCE_SHA_INPUT}^{commit}"',
     'git merge-base --is-ancestor "$SOURCE_SHA_INPUT" "$GITHUB_SHA"',
     "evidence_sha=%s",
+    "requirement_slug=",
+    "tr '[:upper:]' '[:lower:]'",
+    "tr ',' '-'",
+    'envelope="${REDACTED_EVIDENCE_INPUT%.redacted.json}.${requirement_slug}.journey-result.signed.json"',
+    'payload="$RUNNER_TEMP/provider-prebeta-journey-result-${requirement_slug}.unsigned.json"',
     "scripts/build-provider-prebeta-journey-result.py",
     '--evidence-sha "$EVIDENCE_SHA"',
     "scripts/verify-github-release-posture.sh",
@@ -43,6 +48,7 @@ required_workflow = [
     "scripts/check_spec_governance.py --base-ref origin/main",
     "actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a",
     "retention-days: 1",
+    "signed-provider-prebeta-journey-promotion-${{ steps.request.outputs.source_sha }}-${{ steps.request.outputs.requirement_slug }}",
     "macprovider.signed-provider-prebeta-journey-promotion.v1",
     "JOURNEY-PROVIDER-PREBETA-ADMISSION",
 ]
@@ -63,6 +69,8 @@ if "cp \"$REDACTED\"" not in workflow or "cp \"$ENVELOPE\"" not in workflow or "
     raise SystemExit("workflow must export only the redacted evidence, signed envelope, and ledger")
 if "journey-result.unsigned.json" not in workflow:
     raise SystemExit("workflow must name the unsigned payload as non-committed runner-temp state")
+if 'envelope="${REDACTED_EVIDENCE_INPUT%.redacted.json}.journey-result.signed.json"' in workflow:
+    raise SystemExit("workflow must not reuse one signed envelope path for every provider-prebeta requirement subset")
 if "pathlib.Path(\"journeys/evidence\").glob" not in workflow:
     raise SystemExit("workflow must check that non-promotable intermediates are absent")
 posture_index = workflow.find("scripts/verify-github-release-posture.sh")


### PR DESCRIPTION
## Summary
- make provider-prebeta signed promotion envelopes requirement-scoped
- prevent later SPEC-010 subset promotions from colliding with earlier signed envelopes from the same redacted evidence
- lock the workflow contract test against the legacy shared envelope path

## Validation
- `bash scripts/test-signed-provider-prebeta-journey-workflow.sh`
- `python3 scripts/check_spec_governance.py --base-ref origin/main`
- `python3 -m unittest scripts.tests.test_spec_governance scripts.tests.test_provider_prebeta_journey_result scripts.tests.test_journey_result_tools`
- `git diff --check`

SPEC-GOVERNANCE-DECLARATION-BEGIN
{
  "schema_version": "spec-pr-governance-v1",
  "behavior_change": "yes",
  "contract_change": "none",
  "specs": ["SPEC-010"],
  "requirements": ["SPEC-010-R003"],
  "authority_domains": ["model-catalog-identity"],
  "arbitration": ["CODE_BUG"],
  "tests": [
    "bash scripts/test-signed-provider-prebeta-journey-workflow.sh",
    "python3 scripts/check_spec_governance.py --base-ref origin/main",
    "python3 -m unittest scripts.tests.test_spec_governance scripts.tests.test_provider_prebeta_journey_result scripts.tests.test_journey_result_tools",
    "git diff --check"
  ],
  "journeys": ["JOURNEY-PROVIDER-PREBETA-ADMISSION"]
}
SPEC-GOVERNANCE-DECLARATION-END
