### PR TITLE
Preflight stale provider-prebeta evidence before signing

### DIFF
--- a/.github/workflows/promote-signed-provider-prebeta-journey.yml
+++ b/.github/workflows/promote-signed-provider-prebeta-journey.yml
@@ -94,6 +94,18 @@ jobs:
             --output "$PAYLOAD" \
             "$REDACTED"
 
+      - name: Preflight selector freshness before signing
+        shell: bash
+        env:
+          SOURCE_SHA: ${{ steps.request.outputs.source_sha }}
+          REQUIREMENT_IDS: ${{ steps.request.outputs.requirement_ids }}
+        run: |
+          set -euo pipefail
+          python3 scripts/preflight-signed-journey-promotion.py \
+            --source-sha "$SOURCE_SHA" \
+            --requirement-ids "$REQUIREMENT_IDS" \
+            --journey-id JOURNEY-PROVIDER-PREBETA-ADMISSION
+
       - name: Verify protected environment and repository posture
         shell: bash
         env:

--- a/Makefile
+++ b/Makefile
@@ -66,6 +66,7 @@ test-dist:
 	bash scripts/test-signed-payout-journey-workflow.sh
 	bash scripts/test-signed-provider-prebeta-journey-workflow.sh
 	PYTHONDONTWRITEBYTECODE=1 python3 -m unittest -v scripts.tests.test_provider_prebeta_journey_result
+	PYTHONDONTWRITEBYTECODE=1 python3 -m unittest -v scripts.tests.test_journey_result_tools
 	bash scripts/test-acceptance-candidate-metadata.sh
 	bash scripts/test-acceptance-promotion.sh
 	bash scripts/test-release-toolchain.sh

--- a/scripts/preflight-signed-journey-promotion.py
+++ b/scripts/preflight-signed-journey-promotion.py
@@ -1,0 +1,140 @@
+#!/usr/bin/env python3
+"""Reject stale journey-result promotions before signing."""
+
+from __future__ import annotations
+
+import argparse
+import re
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+from check_spec_governance import (
+    ValidationResult,
+    _commit_mapping_selector_matches_current,
+    _load_json,
+    _mapping_file,
+    _mapping_selector,
+)
+
+
+COMMIT_RE = re.compile(r"^[0-9a-f]{40}$")
+REQUIREMENT_RE = re.compile(r"^SPEC-[0-9]{3}-R[0-9]{3}$")
+
+
+def die(message: str) -> None:
+    print(f"preflight-signed-journey-promotion: {message}", file=sys.stderr)
+    raise SystemExit(1)
+
+
+def load_object(path: Path, label: str) -> dict[str, Any]:
+    result = ValidationResult()
+    value = _load_json(path, result)
+    if result.errors:
+        for error in result.errors:
+            print(f"error: {error}", file=sys.stderr)
+        die(f"{label} rejected")
+    if not isinstance(value, dict):
+        die(f"{label} must be a JSON object")
+    return value
+
+
+def parse_requirement_ids(raw: str) -> list[str]:
+    values = [item.strip() for item in raw.split(",") if item.strip()]
+    if not values:
+        die("--requirement-ids must not be empty")
+    if len(set(values)) != len(values):
+        die("--requirement-ids must be unique")
+    invalid = [item for item in values if not REQUIREMENT_RE.fullmatch(item)]
+    if invalid:
+        die(f"invalid requirement id(s): {', '.join(invalid)}")
+    return values
+
+
+def require_reachable_commit(root: Path, commit: str) -> None:
+    completed = subprocess.run(
+        ["git", "cat-file", "-e", f"{commit}^{{commit}}"],
+        cwd=root,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        check=False,
+    )
+    if completed.returncode != 0:
+        die(f"--source-sha is not reachable: {commit}")
+
+
+def assert_commit_matches_current_selectors(
+    root: Path,
+    requirement: dict[str, Any],
+    source_sha: str,
+    *,
+    location: str,
+) -> list[str]:
+    errors: list[str] = []
+    mappings: list[str] = []
+    for key in ("implementation", "tests"):
+        values = requirement.get(key)
+        if isinstance(values, list):
+            mappings.extend(item for item in values if isinstance(item, str))
+    if not mappings:
+        errors.append(f"{location}: no implementation/test mappings to prove against {source_sha}")
+        return errors
+    for mapping in mappings:
+        if not _commit_mapping_selector_matches_current(root, source_sha, mapping):
+            errors.append(
+                f"{location}: commit evidence {source_sha} does not match current mapped selector "
+                f"fragment {_mapping_selector(mapping)!r} in {_mapping_file(mapping)!r}"
+            )
+    return errors
+
+
+def preflight(root: Path, source_sha: str, requirement_ids: list[str], journey_id: str | None) -> None:
+    if not COMMIT_RE.fullmatch(source_sha):
+        die("--source-sha must be a 40-character lowercase hex commit")
+    require_reachable_commit(root, source_sha)
+    conformance = load_object(root / "specs" / "CONFORMANCE.json", "spec conformance")
+    requirements = conformance.get("requirements")
+    if not isinstance(requirements, list):
+        die("specs/CONFORMANCE.json requirements must be an array")
+
+    errors: list[str] = []
+    for requirement_id in requirement_ids:
+        matches = [
+            item
+            for item in requirements
+            if isinstance(item, dict) and item.get("requirement_id") == requirement_id
+        ]
+        location = requirement_id
+        if len(matches) != 1:
+            errors.append(f"{location}: requirement must exist exactly once")
+            continue
+        requirement = matches[0]
+        if requirement.get("state") != "pending":
+            errors.append(f"{location}: requirement must still be pending before promotion")
+        journeys = requirement.get("journeys")
+        if journey_id is not None:
+            if not isinstance(journeys, list) or journey_id not in journeys:
+                errors.append(f"{location}: requirement is not mapped to {journey_id}")
+        errors.extend(assert_commit_matches_current_selectors(root, requirement, source_sha, location=location))
+
+    if errors:
+        for error in errors:
+            print(f"error: {error}", file=sys.stderr)
+        die("promotion preflight rejected")
+    print(f"preflight-signed-journey-promotion: {len(requirement_ids)} requirement(s) match current selectors at {source_sha}")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--root", default=".", help="repository root")
+    parser.add_argument("--source-sha", required=True, help="commit captured by the journey evidence")
+    parser.add_argument("--requirement-ids", required=True, help="comma-separated requirement IDs to promote")
+    parser.add_argument("--journey-id", default=None, help="required mapped journey id")
+    args = parser.parse_args(argv)
+    preflight(Path(args.root).resolve(), args.source_sha, parse_requirement_ids(args.requirement_ids), args.journey_id)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/test-signed-provider-prebeta-journey-workflow.sh
+++ b/scripts/test-signed-provider-prebeta-journey-workflow.sh
@@ -4,6 +4,7 @@ set -euo pipefail
 root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd -P)"
 workflow="$root/.github/workflows/promote-signed-provider-prebeta-journey.yml"
 builder="$root/scripts/build-provider-prebeta-journey-result.py"
+preflight="$root/scripts/preflight-signed-journey-promotion.py"
 
 fail() {
   printf '[test-signed-provider-prebeta-journey-workflow] ERROR: %s\n' "$*" >&2
@@ -12,6 +13,7 @@ fail() {
 
 [[ -f "$workflow" && ! -L "$workflow" ]] || fail "workflow is absent or unsafe"
 [[ -f "$builder" && ! -L "$builder" ]] || fail "builder is absent or unsafe"
+[[ -f "$preflight" && ! -L "$preflight" ]] || fail "preflight is absent or unsafe"
 
 python3 - "$workflow" "$builder" <<'PY'
 import pathlib
@@ -40,6 +42,9 @@ required_workflow = [
     'payload="$RUNNER_TEMP/provider-prebeta-journey-result-${requirement_slug}.unsigned.json"',
     "scripts/build-provider-prebeta-journey-result.py",
     '--evidence-sha "$EVIDENCE_SHA"',
+    "scripts/preflight-signed-journey-promotion.py",
+    "Preflight selector freshness before signing",
+    "--journey-id JOURNEY-PROVIDER-PREBETA-ADMISSION",
     "scripts/verify-github-release-posture.sh",
     "GH_TOKEN: ${{ secrets.RELEASE_POSTURE_TOKEN }}",
     "MACPROVIDER_ACCEPTANCE_SIGNING_KEY_PEM: ${{ secrets.MACPROVIDER_ACCEPTANCE_SIGNING_KEY_PEM }}",
@@ -74,9 +79,64 @@ if 'envelope="${REDACTED_EVIDENCE_INPUT%.redacted.json}.journey-result.signed.js
 if "pathlib.Path(\"journeys/evidence\").glob" not in workflow:
     raise SystemExit("workflow must check that non-promotable intermediates are absent")
 posture_index = workflow.find("scripts/verify-github-release-posture.sh")
+preflight_index = workflow.find("scripts/preflight-signed-journey-promotion.py")
 signing_key_index = workflow.find("MACPROVIDER_ACCEPTANCE_SIGNING_KEY_PEM")
 if posture_index == -1 or signing_key_index == -1 or posture_index > signing_key_index:
     raise SystemExit("workflow must verify release posture before importing the acceptance signing key")
+if preflight_index == -1 or signing_key_index == -1 or preflight_index > signing_key_index:
+    raise SystemExit("workflow must reject stale selector evidence before importing the acceptance signing key")
+
+def extract_step_blocks(text):
+    blocks = []
+    current = None
+    for line in text.splitlines():
+        match = re.match(r"^      - name: (.+)$", line)
+        if match:
+            if current is not None:
+                blocks.append(current)
+            current = {"name": match.group(1), "lines": [line]}
+        elif current is not None:
+            current["lines"].append(line)
+    if current is not None:
+        blocks.append(current)
+    return blocks
+
+
+steps = extract_step_blocks(workflow)
+step_by_name = {step["name"]: step for step in steps}
+step_names = [step["name"] for step in steps]
+if len(step_by_name) != len(step_names):
+    raise SystemExit("workflow step names must be unique for contract validation")
+preflight_name = "Preflight selector freshness before signing"
+posture_name = "Verify protected environment and repository posture"
+sign_name = "Sign journey-result payload"
+for required_step_name in (preflight_name, posture_name, sign_name):
+    if required_step_name not in step_by_name:
+        raise SystemExit(f"workflow step is missing: {required_step_name}")
+preflight_step = "\n".join(step_by_name[preflight_name]["lines"])
+posture_step = "\n".join(step_by_name[posture_name]["lines"])
+sign_step = "\n".join(step_by_name[sign_name]["lines"])
+if step_names.index(preflight_name) > step_names.index(sign_name):
+    raise SystemExit("preflight step must execute before the signing step")
+if "MACPROVIDER_ACCEPTANCE_SIGNING_KEY_PEM" in preflight_step:
+    raise SystemExit("preflight step must not receive the acceptance signing key")
+if "GH_TOKEN" in preflight_step:
+    raise SystemExit("preflight step must not receive the release posture token")
+if "MACPROVIDER_ACCEPTANCE_SIGNING_KEY_PEM" not in sign_step:
+    raise SystemExit("signing step must be the step that imports the acceptance signing key")
+if "GH_TOKEN" not in posture_step:
+    raise SystemExit("posture step must be the step that imports the release posture token")
+secret_owners = {
+    "MACPROVIDER_ACCEPTANCE_SIGNING_KEY_PEM": [sign_name],
+    "GH_TOKEN": [posture_name],
+}
+for secret_name, allowed_steps in secret_owners.items():
+    for step in steps:
+        if secret_name in "\n".join(step["lines"]) and step["name"] not in allowed_steps:
+            raise SystemExit(f"{secret_name} appears in unexpected step: {step['name']}")
+    first_step_index = workflow.find("\n      - name:")
+    if first_step_index == -1 or secret_name in workflow[:first_step_index]:
+        raise SystemExit(f"{secret_name} must not be declared before workflow steps")
 
 lines = workflow.splitlines()
 for index, line in enumerate(lines):

--- a/scripts/tests/test_journey_result_tools.py
+++ b/scripts/tests/test_journey_result_tools.py
@@ -28,6 +28,7 @@ from scripts.tests.test_spec_governance import (
 REPO_ROOT = Path(__file__).resolve().parents[2]
 SIGNER = REPO_ROOT / "scripts" / "sign-journey-result.py"
 PROMOTER = REPO_ROOT / "scripts" / "promote-signed-journey-result.py"
+PREFLIGHT = REPO_ROOT / "scripts" / "preflight-signed-journey-promotion.py"
 
 
 def generate_acceptance_key(root: Path) -> str:
@@ -574,6 +575,60 @@ class JourneyResultToolsTests(unittest.TestCase):
             self.assertNotEqual(0, completed.returncode)
             self.assertIn("duplicate JSON object key", completed.stderr)
             self.assertEqual(malformed, conformance_path.read_text(encoding="utf-8"))
+
+    def test_preflight_rejects_stale_selector_without_signing(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            write_repository(root, base_repository())
+            source_sha = subprocess.check_output(["git", "rev-parse", "HEAD"], cwd=root, text=True).strip()
+            (root / "src" / "example.py").write_text("def example():\n    return False\n", encoding="utf-8")
+            subprocess.run(["git", "add", "."], cwd=root, check=True)
+            subprocess.run(["git", "commit", "-qm", "change mapped selector"], cwd=root, check=True)
+
+            completed = subprocess.run(
+                [
+                    sys.executable,
+                    str(PREFLIGHT),
+                    "--root",
+                    str(root),
+                    "--source-sha",
+                    source_sha,
+                    "--requirement-ids",
+                    "SPEC-001-R001",
+                ],
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+
+            self.assertNotEqual(0, completed.returncode)
+            self.assertIn("promotion preflight rejected", completed.stderr)
+            self.assertIn("does not match current mapped selector fragment 'example'", completed.stderr)
+
+    def test_preflight_accepts_fresh_selector(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            write_repository(root, base_repository())
+            source_sha = subprocess.check_output(["git", "rev-parse", "HEAD"], cwd=root, text=True).strip()
+
+            completed = subprocess.run(
+                [
+                    sys.executable,
+                    str(PREFLIGHT),
+                    "--root",
+                    str(root),
+                    "--source-sha",
+                    source_sha,
+                    "--requirement-ids",
+                    "SPEC-001-R001",
+                ],
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+
+            self.assertEqual(0, completed.returncode, completed.stderr)
+            self.assertIn("match current selectors", completed.stdout)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- Add a pre-signing provider-prebeta promotion preflight that rejects stale selector evidence for pending journey-mapped requirements.
- Wire the new preflight checks into the protected provider-prebeta promotion workflow and `make test-dist`.
- Harden the workflow contract test so the preflight helper must be tracked, real, ordered before signing, and free of protected secret env ownership.

## Why

Run 31002150486 proved the current gate rejects stale SPEC-033-R001 selector evidence only after the workflow had already entered the signing path. The ledger validator is correct; this moves the same freshness failure earlier so stale evidence does not reach acceptance signing.

This does not promote any ledger rows and does not weaken signed journey-result validation. Fresh physical provider-prebeta evidence is still required before SPEC-023/SPEC-032/SPEC-033/SPEC-034 can move.

## Validation

- `python3 scripts/preflight-signed-journey-promotion.py --source-sha 6a2278f4f678abcc91361d0d6f008649e63b6fc3 --requirement-ids SPEC-033-R001 --journey-id JOURNEY-PROVIDER-PREBETA-ADMISSION` rejected stale evidence as expected.
- `python3 -m py_compile scripts/preflight-signed-journey-promotion.py`
- `python3 scripts/check_spec_governance.py --base-ref origin/main`
- `python3 scripts/gen_spec_index.py --check`
- `python3 -m unittest scripts.tests.test_spec_governance scripts.tests.test_provider_prebeta_journey_result scripts.tests.test_journey_result_tools`
- `bash scripts/test-signed-provider-prebeta-journey-workflow.sh`
- `git diff --check`

SPEC-GOVERNANCE-DECLARATION-BEGIN
{
  "schema_version": "spec-pr-governance-v1",
  "behavior_change": "yes",
  "contract_change": "none",
  "specs": ["SPEC-033"],
  "requirements": ["SPEC-033-R001"],
  "authority_domains": ["hardware-evidence-verifier"],
  "arbitration": ["CODE_BUG"],
  "tests": [
    "python3 scripts/preflight-signed-journey-promotion.py --source-sha 6a2278f4f678abcc91361d0d6f008649e63b6fc3 --requirement-ids SPEC-033-R001 --journey-id JOURNEY-PROVIDER-PREBETA-ADMISSION",
    "python3 -m py_compile scripts/preflight-signed-journey-promotion.py",
    "python3 scripts/check_spec_governance.py --base-ref origin/main",
    "python3 scripts/gen_spec_index.py --check",
    "python3 -m unittest scripts.tests.test_spec_governance scripts.tests.test_provider_prebeta_journey_result scripts.tests.test_journey_result_tools",
    "bash scripts/test-signed-provider-prebeta-journey-workflow.sh",
    "git diff --check"
  ],
  "journeys": ["JOURNEY-PROVIDER-PREBETA-ADMISSION"],
  "issue": "https://github.com/Augustas11/macprovider/issues/895"
}
SPEC-GOVERNANCE-DECLARATION-END
