### PR TITLE
Validate provider-prebeta evidence before signing

### DIFF
--- a/scripts/build-provider-prebeta-journey-result.py
+++ b/scripts/build-provider-prebeta-journey-result.py
@@ -15,7 +15,13 @@ from datetime import date
 from pathlib import Path
 from typing import Any
 
-from check_spec_governance import JOURNEY_RESULT_PAYLOAD_SCHEMA, _load_json, ValidationResult
+from check_spec_governance import (
+    DuplicateJSONKeyError,
+    JOURNEY_RESULT_PAYLOAD_SCHEMA,
+    ValidationResult,
+    _load_json,
+    _unique_json_object,
+)
 
 
 JOURNEY_ID = "JOURNEY-PROVIDER-PREBETA-ADMISSION"
@@ -47,6 +53,16 @@ FORBIDDEN_KEY_FRAGMENTS = (
     "secret_key",
     "wallet_private",
 )
+FORBIDDEN_SECRET_VALUE_PATTERNS = (
+    re.compile(r"-----BEGIN [A-Z0-9 ]*PRIVATE KEY-----"),
+    re.compile(r"(?i)\bauthorization\s*:\s*bearer\s+(?!redacted\b)[A-Za-z0-9._~+/=-]{8,}"),
+    re.compile(r"(?i)\bbearer\s+(?!redacted\b)[A-Za-z0-9._~+/=-]{20,}"),
+    re.compile(r"\bghp_[A-Za-z0-9_]{20,}\b"),
+    re.compile(r"\bgithub_pat_[A-Za-z0-9_]{20,}\b"),
+    re.compile(r"\bsk-[A-Za-z0-9]{20,}\b"),
+    re.compile(r"\bxox[baprs]-[A-Za-z0-9-]{20,}\b"),
+    re.compile(r"\bAKIA[0-9A-Z]{16}\b"),
+)
 
 
 def die(message: str) -> None:
@@ -64,6 +80,27 @@ def load_object(path: Path, label: str) -> dict[str, Any]:
     if not isinstance(value, dict):
         die(f"{label} must be a JSON object")
     return value
+
+
+def load_object_bytes(path: Path, label: str) -> tuple[dict[str, Any], bytes]:
+    try:
+        payload = path.read_bytes()
+        value = json.loads(payload.decode("utf-8"), object_pairs_hook=_unique_json_object)
+    except DuplicateJSONKeyError as exc:
+        print(f"error: {path}: duplicate JSON object key {exc.args[0]!r}", file=sys.stderr)
+        die(f"{label} rejected")
+    except UnicodeDecodeError as exc:
+        print(f"error: {path}: invalid UTF-8: {exc}", file=sys.stderr)
+        die(f"{label} rejected")
+    except json.JSONDecodeError as exc:
+        print(f"error: {path}: invalid JSON: {exc}", file=sys.stderr)
+        die(f"{label} rejected")
+    except OSError as exc:
+        print(f"error: {path}: cannot read: {exc}", file=sys.stderr)
+        die(f"{label} rejected")
+    if not isinstance(value, dict):
+        die(f"{label} must be a JSON object")
+    return value, payload
 
 
 def write_json_atomically(path: Path, value: dict[str, Any]) -> None:
@@ -96,10 +133,19 @@ def repository_relative(root: Path, value: str, label: str) -> str:
     return normalized
 
 
+def reject_symlink_components(root: Path, relative: str, label: str) -> None:
+    candidate = root
+    for component in Path(relative).parts:
+        candidate = candidate / component
+        if candidate.is_symlink():
+            die(f"{label} must not contain symlink components: {relative}")
+
+
 def require_evidence_source(root: Path, source: str) -> tuple[str, Path]:
     normalized = repository_relative(root, source, "redacted evidence source")
     if not normalized.startswith("journeys/evidence/provider-prebeta-admission-") or not normalized.endswith(".redacted.json"):
         die("redacted evidence source must be journeys/evidence/provider-prebeta-admission-*.redacted.json")
+    reject_symlink_components(root, normalized, "redacted evidence source")
     path = root / normalized
     if not path.is_file() or path.is_symlink():
         die(f"redacted evidence source is absent or unsafe: {normalized}")
@@ -185,11 +231,11 @@ def require_ancestor_commit(root: Path, ancestor: str, descendant: str) -> None:
         die("--source-sha must be an ancestor of --evidence-sha")
 
 
-def require_git_file_matches(root: Path, commit: str, source: str, path: Path) -> None:
+def require_git_file_matches(root: Path, commit: str, source: str, expected: bytes) -> None:
     completed = subprocess.run(["git", "show", f"{commit}:{source}"], cwd=root, capture_output=True, check=False)
     if completed.returncode != 0:
         die("redacted evidence source must exist at --evidence-sha")
-    if completed.stdout != path.read_bytes():
+    if completed.stdout != expected:
         die("redacted evidence source bytes must match --evidence-sha")
 
 
@@ -231,13 +277,16 @@ def reject_forbidden_secret_keys(value: Any, location: str = "$") -> None:
     elif isinstance(value, list):
         for index, item in enumerate(value):
             reject_forbidden_secret_keys(item, f"{location}[{index}]")
+    elif isinstance(value, str):
+        if any(pattern.search(value) for pattern in FORBIDDEN_SECRET_VALUE_PATTERNS):
+            die(f"{location} contains a forbidden secret-like value")
 
 
 def build_payload(root: Path, source: str, *, source_sha: str, evidence_sha: str, requirement_ids: str | None) -> dict[str, Any]:
     require_string(source_sha, COMMIT_RE, "--source-sha")
     require_string(evidence_sha, COMMIT_RE, "--evidence-sha")
     source, path = require_evidence_source(root, source)
-    evidence = load_object(path, "provider-prebeta redacted evidence")
+    evidence, evidence_bytes = load_object_bytes(path, "provider-prebeta redacted evidence")
     reject_forbidden_secret_keys(evidence)
     if evidence.get("schema_version") != EVIDENCE_SCHEMA:
         die(f"schema_version must equal {EVIDENCE_SCHEMA!r}")
@@ -252,7 +301,7 @@ def build_payload(root: Path, source: str, *, source_sha: str, evidence_sha: str
     evidence_source_sha = require_string(repository.get("commit"), COMMIT_RE, "repository.commit")
     if evidence_source_sha != source_sha:
         die("repository.commit must exactly match --source-sha")
-    require_git_file_matches(root, evidence_sha, source, path)
+    require_git_file_matches(root, evidence_sha, source, evidence_bytes)
 
     selected_requirements = parse_requirement_ids(requirement_ids, evidence)
     mapped = load_mapped_provider_requirements(root)
@@ -277,7 +326,7 @@ def build_payload(root: Path, source: str, *, source_sha: str, evidence_sha: str
         require_string(result.get("summary"), None, "result.summary")
     steps = require_steps(evidence.get("steps"))
     redaction = require_redaction(evidence.get("redaction"))
-    artifact_sha = hashlib.sha256(path.read_bytes()).hexdigest()
+    artifact_sha = hashlib.sha256(evidence_bytes).hexdigest()
     run_id = require_string(evidence.get("run_id"), None, "run_id")
 
     return {

--- a/scripts/test-signed-provider-prebeta-journey-workflow.sh
+++ b/scripts/test-signed-provider-prebeta-journey-workflow.sh
@@ -164,6 +164,7 @@ required_builder = [
     "redacted evidence source bytes must match --evidence-sha",
     "--source-sha must be an ancestor of --evidence-sha",
     "FORBIDDEN_KEY_FRAGMENTS",
+    "FORBIDDEN_SECRET_VALUE_PATTERNS",
 ]
 for value in required_builder:
     if value not in builder:

--- a/scripts/tests/test_provider_prebeta_journey_result.py
+++ b/scripts/tests/test_provider_prebeta_journey_result.py
@@ -15,6 +15,7 @@ from scripts.check_spec_governance import ValidationResult, _validate_signed_jou
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 BUILDER = REPO_ROOT / "scripts" / "build-provider-prebeta-journey-result.py"
+VALIDATOR = REPO_ROOT / "scripts" / "validate-provider-prebeta-evidence.py"
 SIGNER = REPO_ROOT / "scripts" / "sign-journey-result.py"
 EVIDENCE_SOURCE = "journeys/evidence/provider-prebeta-admission-demo.redacted.json"
 
@@ -59,6 +60,8 @@ def base_conformance() -> dict:
                 "state": "pending",
                 "evidence": [],
                 "journeys": ["JOURNEY-PROVIDER-PREBETA-ADMISSION"],
+                "implementation": ["provider_prebeta_contract.txt:provider-prebeta-current-selector"],
+                "tests": ["provider_prebeta_contract.txt:provider-prebeta-current-selector"],
                 "gap": {"verdict": "UNKNOWN", "owner": "@Augustas11", "issue": "https://github.com/Augustas11/macprovider/issues/895", "rationale": "pending physical evidence"},
             },
             {
@@ -123,10 +126,11 @@ class ProviderPrebetaJourneyResultTests(unittest.TestCase):
         if conformance_mutation is not None:
             conformance_mutation(conformance)
         (root / "specs" / "CONFORMANCE.json").write_text(json.dumps(conformance, indent=2) + "\n", encoding="utf-8")
+        (root / "provider_prebeta_contract.txt").write_text("provider-prebeta-current-selector\n", encoding="utf-8")
         run("git", "init", cwd=root)
         run("git", "config", "user.name", "test", cwd=root)
         run("git", "config", "user.email", "test@example.com", cwd=root)
-        run("git", "add", "specs/CONFORMANCE.json", cwd=root)
+        run("git", "add", "specs/CONFORMANCE.json", "provider_prebeta_contract.txt", cwd=root)
         run("git", "commit", "-m", "seed conformance", cwd=root)
         source_commit = run("git", "rev-parse", "HEAD", cwd=root).stdout.strip()
         evidence = base_evidence(source_commit)
@@ -137,6 +141,270 @@ class ProviderPrebetaJourneyResultTests(unittest.TestCase):
         run("git", "commit", "-m", "add provider evidence", cwd=root)
         evidence_commit = run("git", "rev-parse", "HEAD", cwd=root).stdout.strip()
         return directory, root, source_commit, evidence_commit
+
+    def test_validator_accepts_uncommitted_redacted_evidence(self) -> None:
+        directory, root, source_commit, _ = self.make_repo()
+        self.addCleanup(directory.cleanup)
+        evidence_path = root / EVIDENCE_SOURCE
+        evidence = json.loads(evidence_path.read_text(encoding="utf-8"))
+        evidence["observations"]["precommit_capture_marker"] = "redacted-current-run"
+        evidence_path.write_text(json.dumps(evidence, indent=2) + "\n", encoding="utf-8")
+
+        completed = subprocess.run(
+            [
+                sys.executable,
+                str(VALIDATOR),
+                "--root",
+                str(root),
+                "--source-sha",
+                source_commit,
+                "--requirement-ids",
+                "SPEC-010-R001",
+                EVIDENCE_SOURCE,
+            ],
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+
+        self.assertEqual(0, completed.returncode, completed.stderr)
+        self.assertIn("validate-provider-prebeta-evidence: ok", completed.stdout)
+        self.assertIn(hashlib.sha256(evidence_path.read_bytes()).hexdigest(), completed.stdout)
+
+    def test_validator_rejects_missing_physical_step(self) -> None:
+        directory, root, source_commit, _ = self.make_repo()
+        self.addCleanup(directory.cleanup)
+        evidence_path = root / EVIDENCE_SOURCE
+        evidence = json.loads(evidence_path.read_text(encoding="utf-8"))
+        evidence["steps"] = [step for step in evidence["steps"] if step["id"] != "step-05-hardware-evidence-verifier"]
+        evidence_path.write_text(json.dumps(evidence, indent=2) + "\n", encoding="utf-8")
+
+        completed = subprocess.run(
+            [
+                sys.executable,
+                str(VALIDATOR),
+                "--root",
+                str(root),
+                "--source-sha",
+                source_commit,
+                EVIDENCE_SOURCE,
+            ],
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+
+        self.assertNotEqual(0, completed.returncode)
+        self.assertIn("missing provider-prebeta step", completed.stderr)
+
+    def test_validator_rejects_secret_bearing_fields(self) -> None:
+        directory, root, source_commit, _ = self.make_repo()
+        self.addCleanup(directory.cleanup)
+        evidence_path = root / EVIDENCE_SOURCE
+        evidence = json.loads(evidence_path.read_text(encoding="utf-8"))
+        evidence["observations"]["bearer_token"] = "redacted-value"
+        evidence_path.write_text(json.dumps(evidence, indent=2) + "\n", encoding="utf-8")
+
+        completed = subprocess.run(
+            [
+                sys.executable,
+                str(VALIDATOR),
+                "--root",
+                str(root),
+                "--source-sha",
+                source_commit,
+                EVIDENCE_SOURCE,
+            ],
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+
+        self.assertNotEqual(0, completed.returncode)
+        self.assertIn("forbidden secret-bearing field name", completed.stderr)
+
+    def test_validator_rejects_secret_like_values(self) -> None:
+        directory, root, source_commit, _ = self.make_repo()
+        self.addCleanup(directory.cleanup)
+        evidence_path = root / EVIDENCE_SOURCE
+        evidence = json.loads(evidence_path.read_text(encoding="utf-8"))
+        evidence["observations"]["operator_note"] = "Authorization: Bearer abcdefghijklmnopqrstuvwxyz012345"
+        evidence_path.write_text(json.dumps(evidence, indent=2) + "\n", encoding="utf-8")
+
+        completed = subprocess.run(
+            [
+                sys.executable,
+                str(VALIDATOR),
+                "--root",
+                str(root),
+                "--source-sha",
+                source_commit,
+                EVIDENCE_SOURCE,
+            ],
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+
+        self.assertNotEqual(0, completed.returncode)
+        self.assertIn("forbidden secret-like value", completed.stderr)
+
+    def test_validator_rejects_expired_evidence(self) -> None:
+        directory, root, source_commit, _ = self.make_repo()
+        self.addCleanup(directory.cleanup)
+        evidence_path = root / EVIDENCE_SOURCE
+        evidence = json.loads(evidence_path.read_text(encoding="utf-8"))
+        evidence["expires_at"] = "2026-01-01"
+        evidence_path.write_text(json.dumps(evidence, indent=2) + "\n", encoding="utf-8")
+
+        completed = subprocess.run(
+            [
+                sys.executable,
+                str(VALIDATOR),
+                "--root",
+                str(root),
+                "--source-sha",
+                source_commit,
+                EVIDENCE_SOURCE,
+            ],
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+
+        self.assertNotEqual(0, completed.returncode)
+        self.assertIn("expires_at must not be in the past", completed.stderr)
+
+    def test_validator_rejects_evidence_path_traversal(self) -> None:
+        directory, root, source_commit, _ = self.make_repo()
+        self.addCleanup(directory.cleanup)
+
+        completed = subprocess.run(
+            [
+                sys.executable,
+                str(VALIDATOR),
+                "--root",
+                str(root),
+                "--source-sha",
+                source_commit,
+                "journeys/evidence/../evidence/provider-prebeta-admission-demo.redacted.json",
+            ],
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+
+        self.assertNotEqual(0, completed.returncode)
+        self.assertIn("must not contain parent traversal", completed.stderr)
+
+    def test_validator_rejects_symlinked_evidence_source(self) -> None:
+        directory, root, source_commit, _ = self.make_repo()
+        self.addCleanup(directory.cleanup)
+        symlink = root / "journeys" / "evidence" / "provider-prebeta-admission-symlink.redacted.json"
+        try:
+            symlink.symlink_to(root / EVIDENCE_SOURCE)
+        except OSError as exc:
+            raise unittest.SkipTest(f"symlinks are unavailable: {exc}") from exc
+
+        completed = subprocess.run(
+            [
+                sys.executable,
+                str(VALIDATOR),
+                "--root",
+                str(root),
+                "--source-sha",
+                source_commit,
+                "journeys/evidence/provider-prebeta-admission-symlink.redacted.json",
+            ],
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+
+        self.assertNotEqual(0, completed.returncode)
+        self.assertIn("must not contain symlink components", completed.stderr)
+
+    def test_validator_rejects_symlinked_evidence_parent(self) -> None:
+        directory, root, source_commit, _ = self.make_repo()
+        self.addCleanup(directory.cleanup)
+        real_evidence_dir = root / "real-evidence"
+        real_evidence_dir.mkdir()
+        target = real_evidence_dir / "provider-prebeta-admission-demo.redacted.json"
+        target.write_text((root / EVIDENCE_SOURCE).read_text(encoding="utf-8"), encoding="utf-8")
+        shutil.rmtree(root / "journeys" / "evidence")
+        try:
+            (root / "journeys" / "evidence").symlink_to(real_evidence_dir)
+        except OSError as exc:
+            raise unittest.SkipTest(f"symlinks are unavailable: {exc}") from exc
+
+        completed = subprocess.run(
+            [
+                sys.executable,
+                str(VALIDATOR),
+                "--root",
+                str(root),
+                "--source-sha",
+                source_commit,
+                EVIDENCE_SOURCE,
+            ],
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+
+        self.assertNotEqual(0, completed.returncode)
+        self.assertIn("must not contain symlink components", completed.stderr)
+
+    def test_validator_rejects_stale_current_selector(self) -> None:
+        directory, root, source_commit, _ = self.make_repo()
+        self.addCleanup(directory.cleanup)
+        (root / "provider_prebeta_contract.txt").write_text("provider-prebeta-current-selector changed\n", encoding="utf-8")
+
+        completed = subprocess.run(
+            [
+                sys.executable,
+                str(VALIDATOR),
+                "--root",
+                str(root),
+                "--source-sha",
+                source_commit,
+                EVIDENCE_SOURCE,
+            ],
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+
+        self.assertNotEqual(0, completed.returncode)
+        self.assertIn("does not match current mapped selector", completed.stderr)
+
+    def test_builder_rejects_secret_like_values(self) -> None:
+        def leak_secret_like_value(evidence: dict) -> None:
+            evidence["observations"]["operator_note"] = "Bearer abcdefghijklmnopqrstuvwxyz012345"
+
+        directory, root, source_commit, evidence_commit = self.make_repo(leak_secret_like_value)
+        self.addCleanup(directory.cleanup)
+        completed = subprocess.run(
+            [
+                sys.executable,
+                str(BUILDER),
+                "--root",
+                str(root),
+                "--source-sha",
+                source_commit,
+                "--evidence-sha",
+                evidence_commit,
+                "--output",
+                str(root / "payload.json"),
+                EVIDENCE_SOURCE,
+            ],
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+
+        self.assertNotEqual(0, completed.returncode)
+        self.assertIn("forbidden secret-like value", completed.stderr)
 
     def test_builder_emits_core_signed_payload(self) -> None:
         directory, root, source_commit, evidence_commit = self.make_repo()

--- a/scripts/validate-provider-prebeta-evidence.py
+++ b/scripts/validate-provider-prebeta-evidence.py
@@ -1,0 +1,177 @@
+#!/usr/bin/env python3
+"""Validate redacted provider-prebeta evidence before commit and signing."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import importlib.util
+import sys
+from datetime import date
+from pathlib import Path
+from types import ModuleType
+from typing import Any
+
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+BUILDER = SCRIPT_DIR / "build-provider-prebeta-journey-result.py"
+PREFLIGHT = SCRIPT_DIR / "preflight-signed-journey-promotion.py"
+
+
+def die(message: str) -> None:
+    print(f"validate-provider-prebeta-evidence: {message}", file=sys.stderr)
+    raise SystemExit(1)
+
+
+def load_builder() -> ModuleType:
+    spec = importlib.util.spec_from_file_location("build_provider_prebeta_journey_result", BUILDER)
+    if spec is None or spec.loader is None:
+        die("could not load provider-prebeta journey-result builder")
+    module = importlib.util.module_from_spec(spec)
+    sys.path.insert(0, str(SCRIPT_DIR))
+    try:
+        spec.loader.exec_module(module)
+    finally:
+        sys.path.pop(0)
+    return module
+
+
+def load_preflight() -> ModuleType:
+    spec = importlib.util.spec_from_file_location("preflight_signed_journey_promotion", PREFLIGHT)
+    if spec is None or spec.loader is None:
+        die("could not load signed journey-result promotion preflight")
+    module = importlib.util.module_from_spec(spec)
+    sys.path.insert(0, str(SCRIPT_DIR))
+    try:
+        spec.loader.exec_module(module)
+    finally:
+        sys.path.pop(0)
+    return module
+
+
+def assert_current_selectors(builder: ModuleType, preflight: ModuleType, root: Path, source_sha: str, requirement_ids: list[str]) -> None:
+    conformance = builder.load_object(root / "specs" / "CONFORMANCE.json", "spec conformance")
+    requirements = conformance.get("requirements")
+    if not isinstance(requirements, list):
+        die("specs/CONFORMANCE.json requirements must be an array")
+    errors: list[str] = []
+    for requirement_id in requirement_ids:
+        matches = [
+            item
+            for item in requirements
+            if isinstance(item, dict) and item.get("requirement_id") == requirement_id
+        ]
+        if len(matches) != 1:
+            errors.append(f"{requirement_id}: requirement must exist exactly once")
+            continue
+        errors.extend(
+            preflight.assert_commit_matches_current_selectors(
+                root,
+                matches[0],
+                source_sha,
+                location=requirement_id,
+            )
+        )
+    if errors:
+        for error in errors:
+            print(f"error: {error}", file=sys.stderr)
+        die("current selector validation rejected")
+
+
+def validate_redacted_evidence(
+    builder: ModuleType,
+    preflight: ModuleType,
+    root: Path,
+    source: str,
+    *,
+    source_sha: str | None,
+    requirement_ids: str | None,
+) -> dict[str, Any]:
+    source, path = builder.require_evidence_source(root, source)
+    evidence, evidence_bytes = builder.load_object_bytes(path, "provider-prebeta redacted evidence")
+    builder.reject_forbidden_secret_keys(evidence)
+    if evidence.get("schema_version") != builder.EVIDENCE_SCHEMA:
+        die(f"schema_version must equal {builder.EVIDENCE_SCHEMA!r}")
+    if evidence.get("journey_id") != builder.JOURNEY_ID:
+        die(f"journey_id must equal {builder.JOURNEY_ID!r}")
+
+    repository = builder.require_object(evidence.get("repository"), "repository")
+    if repository.get("name") != builder.REPOSITORY:
+        die(f"repository.name must equal {builder.REPOSITORY!r}")
+    evidence_source_sha = builder.require_string(repository.get("commit"), builder.COMMIT_RE, "repository.commit")
+    builder.require_reachable_commit(root, evidence_source_sha, "repository.commit")
+    if source_sha is not None:
+        builder.require_string(source_sha, builder.COMMIT_RE, "--source-sha")
+        builder.require_reachable_commit(root, source_sha, "--source-sha")
+        if evidence_source_sha != source_sha:
+            die("repository.commit must exactly match --source-sha")
+
+    selected_requirements = builder.parse_requirement_ids(requirement_ids, evidence)
+    mapped = builder.load_mapped_provider_requirements(root)
+    not_mapped = [item for item in selected_requirements if item not in mapped]
+    if not_mapped:
+        die(f"requirement_ids must be pending and mapped to {builder.JOURNEY_ID}: {', '.join(not_mapped)}")
+    assert_current_selectors(builder, preflight, root, evidence_source_sha, selected_requirements)
+
+    captured_at = builder.require_string(evidence.get("captured_at"), builder.DATETIME_Z_RE, "captured_at")
+    expires_at = builder.require_string(evidence.get("expires_at"), builder.DATE_RE, "expires_at")
+    if date.fromisoformat(expires_at) < date.today():
+        die("expires_at must not be in the past")
+    operator = builder.require_object(evidence.get("operator"), "operator")
+    builder.require_string(operator.get("role"), None, "operator.role")
+    builder.require_string(operator.get("identity_fingerprint"), builder.FINGERPRINT_RE, "operator.identity_fingerprint")
+    environment = builder.require_object(evidence.get("environment"), "environment")
+    for field in ("class", "hardware_profile", "candidate"):
+        builder.require_string(environment.get(field), None, f"environment.{field}")
+    result = builder.require_object(evidence.get("result"), "result")
+    if result.get("status") != "pass":
+        die("result.status must equal 'pass'")
+    if "summary" in result:
+        builder.require_string(result.get("summary"), None, "result.summary")
+    builder.require_steps(evidence.get("steps"))
+    builder.require_redaction(evidence.get("redaction"))
+    run_id = builder.require_string(evidence.get("run_id"), None, "run_id")
+
+    return {
+        "source": source,
+        "path": path,
+        "artifact_sha256": hashlib.sha256(evidence_bytes).hexdigest(),
+        "repository_commit": evidence_source_sha,
+        "captured_at": captured_at,
+        "expires_at": expires_at,
+        "requirement_ids": selected_requirements,
+        "run_id": run_id,
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("redacted_evidence_source", help="journeys/evidence/provider-prebeta-admission-*.redacted.json")
+    parser.add_argument("--root", default=".", help="repository root")
+    parser.add_argument("--source-sha", default=None, help="expected source/build commit captured by the evidence")
+    parser.add_argument("--requirement-ids", default=None, help="comma-separated pending requirement IDs to validate")
+    args = parser.parse_args(argv)
+
+    root = Path(args.root).resolve()
+    builder = load_builder()
+    preflight = load_preflight()
+    summary = validate_redacted_evidence(
+        builder,
+        preflight,
+        root,
+        args.redacted_evidence_source,
+        source_sha=args.source_sha,
+        requirement_ids=args.requirement_ids,
+    )
+    print(
+        "validate-provider-prebeta-evidence: ok: "
+        f"{len(summary['requirement_ids'])} requirement(s), "
+        f"source={summary['source']}, "
+        f"commit={summary['repository_commit']}, "
+        f"sha256={summary['artifact_sha256']}"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

- Add a local provider-prebeta redacted-evidence validator for pre-commit/pre-signing checks.
- Harden the provider-prebeta journey-result builder so unsafe evidence bytes fail consistently before unsigned payload generation.
- Cover stale selectors, expired evidence, secret-bearing keys/values, path traversal, symlinked evidence paths, and committed-byte parity with focused tests.

## Why

#614 keeps tripping when stale or unsafe physical evidence reaches the signed journey-result path. PR #921 moved stale selector rejection before signing inside the protected workflow. This follow-up gives us the same fail-fast check for the actual provider evidence artifact before it is committed or submitted to the signer, while preserving the signed result as the only ledger-promotion authority.

No ledger rows are promoted here. The old Air5/Qwen SPEC-033-R001 artifact still rejects because its mapped selector fragment no longer matches current main. Fresh physical provider-prebeta evidence is still required before any pending provider slice row can move.

## Validation

- `PYTHONDONTWRITEBYTECODE=1 python3 -m unittest -v scripts.tests.test_provider_prebeta_journey_result`
- `PYTHONDONTWRITEBYTECODE=1 python3 -m unittest -v scripts.tests.test_journey_result_tools`
- `bash scripts/test-signed-provider-prebeta-journey-workflow.sh`
- `python3 -m py_compile scripts/build-provider-prebeta-journey-result.py scripts/validate-provider-prebeta-evidence.py`
- `python3 scripts/check_spec_governance.py --base-ref origin/main`
- `python3 scripts/gen_spec_index.py --check`
- `git diff --check`
- `python3 scripts/validate-provider-prebeta-evidence.py --source-sha 6a2278f4f678abcc91361d0d6f008649e63b6fc3 --requirement-ids SPEC-033-R001 journeys/evidence/provider-prebeta-admission-air5-qwen-20260727T042339Z.redacted.json` rejected stale selector evidence as expected.
- 3-lane read-only audit: code, architecture/governance, and security all reported 0 CRITICAL/HIGH/MEDIUM findings on the final diff.

SPEC-GOVERNANCE-DECLARATION-BEGIN
{
  "schema_version": "spec-pr-governance-v1",
  "behavior_change": "yes",
  "contract_change": "none",
  "specs": ["SPEC-033"],
  "requirements": ["SPEC-033-R001"],
  "authority_domains": ["hardware-evidence-verifier"],
  "arbitration": ["CODE_BUG"],
  "tests": [
    "PYTHONDONTWRITEBYTECODE=1 python3 -m unittest -v scripts.tests.test_provider_prebeta_journey_result",
    "PYTHONDONTWRITEBYTECODE=1 python3 -m unittest -v scripts.tests.test_journey_result_tools",
    "bash scripts/test-signed-provider-prebeta-journey-workflow.sh",
    "python3 -m py_compile scripts/build-provider-prebeta-journey-result.py scripts/validate-provider-prebeta-evidence.py",
    "python3 scripts/check_spec_governance.py --base-ref origin/main",
    "python3 scripts/gen_spec_index.py --check",
    "git diff --check",
    "python3 scripts/validate-provider-prebeta-evidence.py --source-sha 6a2278f4f678abcc91361d0d6f008649e63b6fc3 --requirement-ids SPEC-033-R001 journeys/evidence/provider-prebeta-admission-air5-qwen-20260727T042339Z.redacted.json"
  ],
  "journeys": ["JOURNEY-PROVIDER-PREBETA-ADMISSION"],
  "issue": "https://github.com/Augustas11/macprovider/issues/895"
}
SPEC-GOVERNANCE-DECLARATION-END