### PR TITLE
Gate waiting-trust approvability on approval prerequisites

### DIFF
--- a/phase4-coordinator/internal/onboarding/store_pg.go
+++ b/phase4-coordinator/internal/onboarding/store_pg.go
@@ -151,6 +151,9 @@ func (s *PGStore) Smoke(ctx context.Context) error {
 	if _, err := s.db.ExecContext(timeout, `SELECT id, status, decision_reason, evidence_sha256 FROM hardware_verification_jobs LIMIT 1`); err != nil {
 		return fmt.Errorf("provider_onboarding smoke hardware_verification_jobs read: %w", err)
 	}
+	if _, err := s.db.ExecContext(timeout, `SELECT chip_normalized FROM chip_hardware_profiles LIMIT 0`); err != nil {
+		return fmt.Errorf("provider_onboarding smoke chip_hardware_profiles read: %w", err)
+	}
 	// FIX 7 (round-8, issue #582): exercise the FULL LatestVerified admission join
 	// shape, including the EXISTS on hardware_verification_trust that the round-6
 	// live-trust re-check added (internal/autotune/evidence_pg.go). Without the trust
@@ -743,6 +746,7 @@ type WaitingTrustJob struct {
 	UnifiedMemoryGB      int
 	HardwareIdentityHash string
 	DecisionReason       string
+	ChipProfilePresent   bool
 	SubmittedAt          time.Time
 }
 
@@ -860,12 +864,19 @@ func (s *PGStore) ListWaitingTrustJobs(ctx context.Context, afterID int64, limit
 		afterID = 0
 	}
 	rows, err := s.db.QueryContext(ctx, `
-SELECT id, provider_id, chip, chip_normalized, unified_memory_gb,
-       COALESCE(evidence #>> '{hardware,hardware_identity_hash}', ''), decision_reason, submitted_at
-  FROM hardware_verification_jobs
- WHERE status = 'waiting_trust'
-   AND id > $1
- ORDER BY id ASC
+SELECT j.id, j.provider_id, j.chip, j.chip_normalized, j.unified_memory_gb,
+       COALESCE(j.evidence #>> '{hardware,hardware_identity_hash}', ''),
+       j.decision_reason,
+       EXISTS (
+         SELECT 1
+           FROM chip_hardware_profiles ch
+          WHERE ch.chip_normalized = j.chip_normalized
+       ) AS chip_profile_present,
+       j.submitted_at
+  FROM hardware_verification_jobs j
+ WHERE j.status = 'waiting_trust'
+   AND j.id > $1
+ ORDER BY j.id ASC
  LIMIT $2`, afterID, limit)
 	if err != nil {
 		return nil, err
@@ -882,6 +893,7 @@ SELECT id, provider_id, chip, chip_normalized, unified_memory_gb,
 			&job.UnifiedMemoryGB,
 			&job.HardwareIdentityHash,
 			&job.DecisionReason,
+			&job.ChipProfilePresent,
 			&job.SubmittedAt,
 		); err != nil {
 			return nil, err

--- a/phase4-coordinator/internal/onboarding/store_pg_attempt_integration_test.go
+++ b/phase4-coordinator/internal/onboarding/store_pg_attempt_integration_test.go
@@ -8,6 +8,7 @@ import (
 	"crypto/rand"
 	"database/sql"
 	"net/url"
+	"os"
 	"strings"
 	"testing"
 	"time"
@@ -25,6 +26,19 @@ const (
 	referralAttemptPGPass  = "referral-attempt-test-password"
 )
 
+func skipOnMissingDocker(t *testing.T, err error) {
+	t.Helper()
+	msg := err.Error()
+	if strings.Contains(msg, "Docker not found") ||
+		strings.Contains(msg, "rootless Docker not found") ||
+		strings.Contains(msg, "Cannot connect to the Docker daemon") {
+		if os.Getenv("CI") == "true" || os.Getenv("GITHUB_ACTIONS") == "true" {
+			return
+		}
+		t.Skipf("skip local Postgres integration without Docker: %v", err)
+	}
+}
+
 func TestProviderRegistrationPreparedSurvivesNoncePrune(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 90*time.Second)
 	defer cancel()
@@ -35,6 +49,7 @@ func TestProviderRegistrationPreparedSurvivesNoncePrune(t *testing.T) {
 		tc.WithWaitStrategy(wait.ForLog("database system is ready to accept connections").WithOccurrence(2).WithStartupTimeout(60*time.Second)),
 	)
 	if err != nil {
+		skipOnMissingDocker(t, err)
 		t.Fatalf("start postgres: %v", err)
 	}
 	t.Cleanup(func() {
@@ -93,6 +108,7 @@ func TestProviderHardwareUpsertsRespectColumnLimitedGrants(t *testing.T) {
 		tc.WithWaitStrategy(wait.ForLog("database system is ready to accept connections").WithOccurrence(2).WithStartupTimeout(60*time.Second)),
 	)
 	if err != nil {
+		skipOnMissingDocker(t, err)
 		t.Fatalf("start postgres: %v", err)
 	}
 	t.Cleanup(func() {
@@ -199,5 +215,132 @@ func TestProviderHardwareUpsertsRespectColumnLimitedGrants(t *testing.T) {
 		t.Fatal("provider_onboarding unexpectedly gained direct source read")
 	} else if !strings.Contains(err.Error(), "permission denied") {
 		t.Fatalf("provider_onboarding source read error = %q, want permission denied", err)
+	}
+}
+
+func TestListWaitingTrustJobsReportsChipProfilePresenceWithRuntimeRole(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 90*time.Second)
+	defer cancel()
+	container, err := tcpg.Run(ctx, referralAttemptPGImage,
+		tcpg.WithDatabase("waiting_trust"),
+		tcpg.WithUsername("postgres"),
+		tcpg.WithPassword(referralAttemptPGPass),
+		tc.WithWaitStrategy(wait.ForLog("database system is ready to accept connections").WithOccurrence(2).WithStartupTimeout(60*time.Second)),
+	)
+	if err != nil {
+		skipOnMissingDocker(t, err)
+		t.Fatalf("start postgres: %v", err)
+	}
+	t.Cleanup(func() {
+		cleanup, cleanupCancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cleanupCancel()
+		_ = container.Terminate(cleanup)
+	})
+	adminDSN, err := container.ConnectionString(ctx, "sslmode=disable")
+	if err != nil {
+		t.Fatal(err)
+	}
+	adminDB, err := sql.Open("postgres", adminDSN)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = adminDB.Close() })
+	if err := statsmigrations.Apply(ctx, adminDB); err != nil {
+		t.Fatalf("apply migrations: %v", err)
+	}
+
+	const onboardingPassword = "waiting-trust-test-password"
+	if _, err := adminDB.ExecContext(ctx, `ALTER ROLE provider_onboarding PASSWORD '`+onboardingPassword+`'`); err != nil {
+		t.Fatalf("set provider_onboarding password: %v", err)
+	}
+	onboardingURL, err := url.Parse(adminDSN)
+	if err != nil {
+		t.Fatalf("parse admin DSN: %v", err)
+	}
+	onboardingURL.User = url.UserPassword("provider_onboarding", onboardingPassword)
+	onboardingDB, err := sql.Open("postgres", onboardingURL.String())
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = onboardingDB.Close() })
+	if err := onboardingDB.PingContext(ctx); err != nil {
+		t.Fatalf("connect as provider_onboarding: %v", err)
+	}
+
+	submitted := time.Now().UTC().Truncate(time.Second)
+	if _, err := adminDB.ExecContext(ctx, `
+INSERT INTO chip_hardware_profiles
+    (chip_normalized, display_chip, memory_bandwidth_gb_per_s, network_power_kw, gpu_cores, cpu_cores)
+VALUES
+    ('apple m4 pro', 'Apple M4 Pro', 273, 0.065, 20, 14)
+ON CONFLICT (chip_normalized) DO NOTHING`); err != nil {
+		t.Fatalf("seed chip profile: %v", err)
+	}
+	for _, job := range []struct {
+		providerID     string
+		chip           string
+		chipNormalized string
+		memoryGB       int
+		hash           string
+		evidenceSHA    string
+	}{
+		{"provider-present", "Apple M4 Pro", "apple m4 pro", 24, "hash-present", "sha-present"},
+		{"provider-missing", "Apple M6", "apple m6", 32, "hash-missing", "sha-missing"},
+	} {
+		if _, err := adminDB.ExecContext(ctx, `
+INSERT INTO hardware_verification_jobs (
+    provider_id,
+    source,
+    status,
+    chip,
+    chip_normalized,
+    unified_memory_gb,
+    generated_at,
+    submitted_at,
+    decision_reason,
+    evidence,
+    evidence_sha256
+) VALUES (
+    $1,
+    'autotune',
+    'waiting_trust',
+    $2,
+    $3,
+    $4,
+    $5,
+    $5,
+    'hardware-verifier.v2:missing_trusted_hardware_identity',
+    jsonb_build_object('hardware', jsonb_build_object('hardware_identity_hash', $6::text)),
+    $7
+)`, job.providerID, job.chip, job.chipNormalized, job.memoryGB, submitted, job.hash, job.evidenceSHA); err != nil {
+			t.Fatalf("seed waiting trust job %s: %v", job.providerID, err)
+		}
+	}
+
+	store := &PGStore{db: onboardingDB}
+	if err := store.Smoke(ctx); err != nil {
+		t.Fatalf("provider_onboarding smoke: %v", err)
+	}
+	jobs, err := store.ListWaitingTrustJobs(ctx, 0, WaitingTrustJobsPageCap)
+	if err != nil {
+		t.Fatalf("list waiting trust jobs: %v", err)
+	}
+	if len(jobs) != 2 {
+		t.Fatalf("waiting trust jobs length = %d, want 2: %+v", len(jobs), jobs)
+	}
+	got := map[string]bool{}
+	for _, job := range jobs {
+		got[job.ProviderID] = job.ChipProfilePresent
+	}
+	if got["provider-present"] != true {
+		t.Fatalf("provider-present ChipProfilePresent = %t, want true", got["provider-present"])
+	}
+	if got["provider-missing"] != false {
+		t.Fatalf("provider-missing ChipProfilePresent = %t, want false", got["provider-missing"])
+	}
+	if _, err := onboardingDB.QueryContext(ctx, `SELECT display_chip FROM chip_hardware_profiles LIMIT 1`); err == nil {
+		t.Fatal("provider_onboarding unexpectedly gained direct display_chip read")
+	} else if !strings.Contains(err.Error(), "permission denied") {
+		t.Fatalf("provider_onboarding display_chip read error = %q, want permission denied", err)
 	}
 }

--- a/phase4-coordinator/internal/stats/migrations/020_waiting_trust_chip_profile_projection.down.sql
+++ b/phase4-coordinator/internal/stats/migrations/020_waiting_trust_chip_profile_projection.down.sql
@@ -1,0 +1,18 @@
+-- Operator rollback artifact for migration 020. The embedded migration runner
+-- intentionally applies only *.up.sql; execute manually only when rolling back
+-- the waiting-trust chip-profile projection.
+
+\set ON_ERROR_STOP on
+
+BEGIN;
+
+DO $$
+BEGIN
+    IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'provider_onboarding') THEN
+        REVOKE SELECT (chip_normalized) ON chip_hardware_profiles FROM provider_onboarding;
+    END IF;
+END $$;
+
+DELETE FROM schema_migrations_spec017 WHERE version = 20;
+
+COMMIT;

--- a/phase4-coordinator/internal/stats/migrations/020_waiting_trust_chip_profile_projection.up.sql
+++ b/phase4-coordinator/internal/stats/migrations/020_waiting_trust_chip_profile_projection.up.sql
@@ -1,0 +1,5 @@
+-- Waiting-trust admin projection reads only chip_hardware_profiles.chip_normalized
+-- to report whether a parked job has the chip profile required by the hardware
+-- trust approval function. Keep provider_onboarding's access column-limited:
+-- the role still cannot write chip inventory or trust roots.
+GRANT SELECT (chip_normalized) ON chip_hardware_profiles TO provider_onboarding;

--- a/phase4-coordinator/internal/stats/migrations/migrations_test.go
+++ b/phase4-coordinator/internal/stats/migrations/migrations_test.go
@@ -40,6 +40,7 @@ func TestEmbeddedMigrationsLoad(t *testing.T) {
 		{17, "autotune_current_hardware_gate_grants"},
 		{18, "apptrack_register_attempts"},
 		{19, "hardware_trust_operator_approval"},
+		{20, "waiting_trust_chip_profile_projection"},
 	}
 	if len(all) != len(want) {
 		t.Fatalf("got %d migrations, want %d", len(all), len(want))
@@ -76,7 +77,7 @@ func TestEmbeddedSchemaShapesCorrect(t *testing.T) {
 	if err != nil {
 		t.Fatalf("All: %v", err)
 	}
-	var schema, bootstrap, spec026, hardware, hardwareJobs, authPolicyApproveFix, idlePrewarm, powW2HelloGateGrants, onboardingDecisionReason, hardwareMemoryReverification, autotuneCurrentHardwareGateGrants, hardwareTrustApproval string
+	var schema, bootstrap, spec026, hardware, hardwareJobs, authPolicyApproveFix, idlePrewarm, powW2HelloGateGrants, onboardingDecisionReason, hardwareMemoryReverification, autotuneCurrentHardwareGateGrants, hardwareTrustApproval, waitingTrustChipProfileProjection string
 	for _, m := range all {
 		switch m.Name {
 		case "stats_tables":
@@ -103,10 +104,15 @@ func TestEmbeddedSchemaShapesCorrect(t *testing.T) {
 			autotuneCurrentHardwareGateGrants = m.SQL
 		case "hardware_trust_operator_approval":
 			hardwareTrustApproval = m.SQL
+		case "waiting_trust_chip_profile_projection":
+			waitingTrustChipProfileProjection = m.SQL
 		}
 	}
 	if schema == "" {
 		t.Fatal("stats_tables migration body is empty")
+	}
+	if waitingTrustChipProfileProjection == "" {
+		t.Fatal("waiting_trust_chip_profile_projection migration body is empty")
 	}
 	// The forbidden-substring checks must scan code, not
 	// comments. The migration's prose comments document v0.1.7
@@ -592,6 +598,37 @@ func TestEmbeddedSchemaShapesCorrect(t *testing.T) {
 	// hardware_verification_trust (asserted positively above) so the LatestVerified
 	// admission gate can re-check live trust. The anti-fraud boundary is the WRITE
 	// grants only (mustNotContain above), never the read.
+	waitingTrustChipProfileProjectionCode := stripSQLComments(waitingTrustChipProfileProjection)
+	mustContain(t, waitingTrustChipProfileProjectionCode,
+		"GRANT SELECT (chip_normalized) ON chip_hardware_profiles TO provider_onboarding",
+		"waiting-trust projection can evaluate chip-profile presence with a column-limited runtime-role grant")
+	mustNotContain(t, waitingTrustChipProfileProjectionCode,
+		"GRANT SELECT ON chip_hardware_profiles TO provider_onboarding",
+		"provider_onboarding must not receive table-wide chip profile read")
+	mustNotContain(t, waitingTrustChipProfileProjectionCode,
+		"INSERT, UPDATE ON chip_hardware_profiles TO provider_onboarding",
+		"provider_onboarding must not receive chip profile writes")
+	mustNotContain(t, waitingTrustChipProfileProjectionCode,
+		"GRANT INSERT ON chip_hardware_profiles TO provider_onboarding",
+		"provider_onboarding must not receive chip profile inserts")
+	mustNotContain(t, waitingTrustChipProfileProjectionCode,
+		"GRANT UPDATE ON chip_hardware_profiles TO provider_onboarding",
+		"provider_onboarding must not receive chip profile updates")
+	waitingTrustChipProfileProjectionDown, err := os.ReadFile("020_waiting_trust_chip_profile_projection.down.sql")
+	if err != nil {
+		t.Fatalf("read waiting-trust chip-profile projection rollback artifact: %v", err)
+	}
+	waitingTrustChipProfileProjectionDownSQL := string(waitingTrustChipProfileProjectionDown)
+	for _, needle := range []string{
+		"\\set ON_ERROR_STOP on",
+		"BEGIN;",
+		"REVOKE SELECT (chip_normalized) ON chip_hardware_profiles FROM provider_onboarding",
+		"DELETE FROM schema_migrations_spec017 WHERE version = 20;",
+		"COMMIT;",
+	} {
+		mustContain(t, waitingTrustChipProfileProjectionDownSQL, needle, "waiting-trust chip-profile projection rollback artifact")
+	}
+
 	hardwareTrustApprovalDown, err := os.ReadFile("019_hardware_trust_operator_approval.down.sql")
 	if err != nil {
 		t.Fatalf("read hardware trust approval rollback artifact: %v", err)

--- a/phase4-coordinator/internal/ws/admin_hardware_trust.go
+++ b/phase4-coordinator/internal/ws/admin_hardware_trust.go
@@ -96,13 +96,14 @@ func (s *Server) handleHardwareTrustWaiting(w http.ResponseWriter, r *http.Reque
 			"unified_memory_gb":      job.UnifiedMemoryGB,
 			"hardware_identity_hash": job.HardwareIdentityHash,
 			"decision_reason":        job.DecisionReason,
-			// approvable tells the operator which waiting_trust jobs the request
-			// endpoint will accept: only missing_trusted_hardware_identity waits
-			// with a hardware_identity_hash can be unblocked by an operator_api
-			// trust root. missing_trusted_chip_profile waits are surfaced too, with
-			// approvable=false, so operators can see the full backlog (issue #582
-			// FIX 10).
-			"approvable":   hardwareTrustJobApprovable(job.DecisionReason, job.HardwareIdentityHash),
+			"chip_profile_present":   job.ChipProfilePresent,
+			// approvable tells the operator which waiting_trust jobs can complete
+			// the operator approval path: only missing_trusted_hardware_identity
+			// waits with a hardware_identity_hash and known chip profile can be
+			// unblocked by an operator_api trust root. missing chip-profile waits
+			// are surfaced too, with approvable=false, so operators can see the
+			// full backlog (issue #582 FIX 10).
+			"approvable":   hardwareTrustJobApprovable(job.DecisionReason, job.HardwareIdentityHash, job.ChipProfilePresent),
 			"submitted_at": job.SubmittedAt.Format(time.RFC3339),
 		})
 	}
@@ -420,15 +421,17 @@ func (s *Server) handleHardwareTrustRevoke(w http.ResponseWriter, r *http.Reques
 	})
 }
 
-// hardwareTrustJobApprovable reports whether a waiting_trust job can be unblocked
-// by the operator hardware-trust approval path — i.e. whether
-// request_hardware_trust_approval would accept it. The bound job must carry a
-// hardware_identity_hash and its decision_reason (stored version-prefixed, e.g.
-// "hardware-verifier.v2:missing_trusted_hardware_identity") must reduce to
-// missing_trusted_hardware_identity; a missing_trusted_chip_profile wait is
-// listed but not approvable (issue #582 FIX 10).
-func hardwareTrustJobApprovable(decisionReason, hardwareIdentityHash string) bool {
+// hardwareTrustJobApprovable reports whether a waiting_trust job can complete
+// the operator hardware-trust approval path. The bound job must carry a
+// hardware_identity_hash, a known chip profile, and its decision_reason (stored
+// version-prefixed, e.g. "hardware-verifier.v2:missing_trusted_hardware_identity")
+// must reduce to missing_trusted_hardware_identity; missing chip-profile waits
+// are listed but not approvable (issue #582 FIX 10).
+func hardwareTrustJobApprovable(decisionReason, hardwareIdentityHash string, chipProfilePresent bool) bool {
 	if strings.TrimSpace(hardwareIdentityHash) == "" {
+		return false
+	}
+	if !chipProfilePresent {
 		return false
 	}
 	bare := decisionReason

--- a/phase4-coordinator/internal/ws/admin_hardware_trust_test.go
+++ b/phase4-coordinator/internal/ws/admin_hardware_trust_test.go
@@ -324,6 +324,7 @@ func TestHardwareTrustWaitingListsParkedJobs(t *testing.T) {
 		UnifiedMemoryGB:      32,
 		HardwareIdentityHash: "hash-abc",
 		DecisionReason:       "waiting_trust",
+		ChipProfilePresent:   true,
 		SubmittedAt:          submitted,
 	}}}
 	h := newProviderHarnessWithServerOptions(t, nil, []providerws.Option{
@@ -368,6 +369,7 @@ func TestHardwareTrustWaitingMarksApprovability(t *testing.T) {
 			ProviderID:           "mac",
 			HardwareIdentityHash: "hash-abc",
 			DecisionReason:       "hardware-verifier.v2:missing_trusted_hardware_identity",
+			ChipProfilePresent:   true,
 			SubmittedAt:          submitted,
 		},
 		{
@@ -375,6 +377,7 @@ func TestHardwareTrustWaitingMarksApprovability(t *testing.T) {
 			ProviderID:           "air",
 			HardwareIdentityHash: "hash-def",
 			DecisionReason:       "hardware-verifier.v2:missing_trusted_chip_profile",
+			ChipProfilePresent:   false,
 			SubmittedAt:          submitted,
 		},
 		{
@@ -382,6 +385,15 @@ func TestHardwareTrustWaitingMarksApprovability(t *testing.T) {
 			ProviderID:           "studio",
 			HardwareIdentityHash: "",
 			DecisionReason:       "hardware-verifier.v2:missing_trusted_hardware_identity",
+			ChipProfilePresent:   true,
+			SubmittedAt:          submitted,
+		},
+		{
+			JobID:                10,
+			ProviderID:           "max",
+			HardwareIdentityHash: "hash-ghi",
+			DecisionReason:       "hardware-verifier.v2:missing_trusted_hardware_identity",
+			ChipProfilePresent:   false,
 			SubmittedAt:          submitted,
 		},
 	}}
@@ -404,10 +416,11 @@ func TestHardwareTrustWaitingMarksApprovability(t *testing.T) {
 	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
 		t.Fatal(err)
 	}
-	if len(out.WaitingTrust) != 3 {
-		t.Fatalf("waiting list length = %d, want 3", len(out.WaitingTrust))
+	if len(out.WaitingTrust) != 4 {
+		t.Fatalf("waiting list length = %d, want 4", len(out.WaitingTrust))
 	}
-	wantApprovable := map[float64]bool{7: true, 8: false, 9: false}
+	wantApprovable := map[float64]bool{7: true, 8: false, 9: false, 10: false}
+	wantChipProfile := map[float64]bool{7: true, 8: false, 9: true, 10: false}
 	for _, row := range out.WaitingTrust {
 		jobID, _ := row["job_id"].(float64)
 		approvable, ok := row["approvable"].(bool)
@@ -416,6 +429,13 @@ func TestHardwareTrustWaitingMarksApprovability(t *testing.T) {
 		}
 		if approvable != wantApprovable[jobID] {
 			t.Fatalf("job %v approvable = %t, want %t", jobID, approvable, wantApprovable[jobID])
+		}
+		chipProfilePresent, ok := row["chip_profile_present"].(bool)
+		if !ok {
+			t.Fatalf("row %v missing chip_profile_present bool: %#v", jobID, row)
+		}
+		if chipProfilePresent != wantChipProfile[jobID] {
+			t.Fatalf("job %v chip_profile_present = %t, want %t", jobID, chipProfilePresent, wantChipProfile[jobID])
 		}
 	}
 }


### PR DESCRIPTION
## Summary

- make `/admin/hardware-trust/waiting` expose `chip_profile_present` and report `approvable` only when the operator approval path can complete
- add migration 020 with a column-limited `provider_onboarding` grant for the chip-profile existence probe
- add startup smoke, unit coverage, migration-shape assertions, and a Docker-backed runtime-role integration test

Refs #614 and #895.

## Validation

- `git diff --check`
- `go test -count=1 ./internal/onboarding ./internal/ws ./internal/stats/migrations`
- `go vet ./internal/onboarding ./internal/ws ./internal/stats/migrations`
- `go test -v -tags=integration ./internal/onboarding -run TestListWaitingTrustJobsReportsChipProfilePresenceWithRuntimeRole -count=1` (skipped locally because rootless Docker is unavailable; CI should execute it)
- scoped code/security/architecture re-review: 0 C/H/M after migration 020

SPEC-GOVERNANCE-DECLARATION-BEGIN
{
  "schema_version": "spec-pr-governance-v1",
  "behavior_change": "yes",
  "contract_change": "none",
  "specs": ["SPEC-033"],
  "requirements": ["SPEC-033-R001"],
  "authority_domains": ["hardware-evidence-verifier"],
  "arbitration": ["CODE_BUG"],
  "tests": [
    "go test -count=1 ./internal/onboarding ./internal/ws ./internal/stats/migrations",
    "go vet ./internal/onboarding ./internal/ws ./internal/stats/migrations",
    "go test -tags=integration ./internal/onboarding -run TestListWaitingTrustJobsReportsChipProfilePresenceWithRuntimeRole -count=1"
  ],
  "journeys": ["JOURNEY-PROVIDER-PREBETA-ADMISSION"],
  "issue": "https://github.com/Augustas11/macprovider/issues/895"
}
SPEC-GOVERNANCE-DECLARATION-END
