### PR TITLE
Keep rollout proof on reviewed OpenSSL

### DIFF
--- a/.github/workflows/verify-live-coordinator-release-rollout.yml
+++ b/.github/workflows/verify-live-coordinator-release-rollout.yml
@@ -21,7 +21,7 @@ concurrency:
 jobs:
   verify:
     name: Verify public release, Pearl recommendation, and discovery rollout
-    runs-on: macos-15
+    runs-on: macos-15-intel
     environment: production-release
     permissions:
       contents: write
@@ -33,10 +33,25 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
+      - name: Seal reviewed OpenSSL 3
+        id: protected_openssl
+        shell: bash
+        env:
+          HOMEBREW_NO_AUTO_UPDATE: "1"
+        run: |
+          set -euo pipefail
+          sealed_bin="$(
+            bash scripts/install-sealed-release-openssl.sh \
+              /private/var/macprovider-openssl-release-rollout
+          )"
+          "$sealed_bin" version | grep -E '^OpenSSL 3\.'
+          printf 'bin=%s\n' "$sealed_bin" >> "$GITHUB_OUTPUT"
+
       - name: Verify public immutable release and live rollout
         shell: bash
         env:
           GH_TOKEN: ${{ github.token }}
+          OPENSSL_BIN: ${{ steps.protected_openssl.outputs.bin }}
           TAG: ${{ inputs.tag }}
         run: |
           set -euo pipefail
@@ -121,6 +136,7 @@ jobs:
             --pearl-release-json "$assets/pearl-release.json" \
             --trusted-keys "$assets/trusted-keys.json" \
             --coordinator-url https://coordinator.streamvc.live \
+            --openssl "$OPENSSL_BIN" \
             --publication-phase post-publication
           transport_tag="$(python3 - "$assets/macprovider-release-discovery.json" <<'PY'
           import json
@@ -144,7 +160,7 @@ jobs:
             --transport-tag "$transport_tag" \
             --target-tag "$TAG" \
             --target-commit "$target_commit" \
-            --openssl "${OPENSSL_BIN:-openssl}" >/dev/null
+            --openssl "$OPENSSL_BIN" >/dev/null
           if git ls-remote --tags origin "$transport_tag" | grep -q .; then
             echo "discovery transport tag already exists: $transport_tag" >&2
             exit 1
@@ -174,6 +190,7 @@ jobs:
             --pearl-release-json "$assets/pearl-release.json" \
             --trusted-keys "$assets/trusted-keys.json" \
             --coordinator-url https://coordinator.streamvc.live \
+            --openssl "$OPENSSL_BIN" \
             --publication-phase post-publication
           notes="$RUNNER_TEMP/discovery-notes.md"
           printf 'Signed append-only discovery transport for %s.\n' "$TAG" > "$notes"
@@ -207,7 +224,7 @@ jobs:
             --target-tag "$TAG" \
             --target-commit "$target_commit" \
             --require-immutable \
-            --openssl "${OPENSSL_BIN:-openssl}" >/dev/null
+            --openssl "$OPENSSL_BIN" >/dev/null
           GITHUB_REPOSITORY="$GITHUB_REPOSITORY" \
             scripts/verify-anonymous-release-discovery.sh \
               "$TAG" "$target_commit" "$TAG" "$transport_tag"

--- a/scripts/test-live-coordinator-release-gate.sh
+++ b/scripts/test-live-coordinator-release-gate.sh
@@ -528,8 +528,20 @@ def require_rollout(workflow_path):
         raise SystemExit("post-publication rollout proof must share the production serialization")
     if "contents: write" not in workflow or "secrets." in workflow:
         raise SystemExit("post-publication rollout must have only GitHub contents publication authority")
-    if "runs-on: macos-15" not in workflow or "runs-on: ubuntu-" in workflow:
-        raise SystemExit("rollout anonymous discovery proof must run on the reviewed macOS runner")
+    if "runs-on: macos-15-intel" not in workflow or "runs-on: ubuntu-" in workflow:
+        raise SystemExit("rollout anonymous discovery proof must run on the reviewed Intel macOS runner")
+    for required in (
+        "- name: Seal reviewed OpenSSL 3",
+        "id: protected_openssl",
+        "scripts/install-sealed-release-openssl.sh",
+        "/private/var/macprovider-openssl-release-rollout",
+        'OPENSSL_BIN: ${{ steps.protected_openssl.outputs.bin }}',
+        "--openssl \"$OPENSSL_BIN\"",
+    ):
+        if required not in workflow:
+            raise SystemExit(f"rollout proof OpenSSL binding omits {required}")
+    if "${OPENSSL_BIN:-openssl}" in workflow:
+        raise SystemExit("rollout proof must not fall back to PATH-selected OpenSSL")
     if "ref: refs/heads/main" not in workflow or "fetch-depth: 0" not in workflow:
         raise SystemExit("rollout proof must check out the reviewed main branch with history")
     if "git fetch --no-tags origin refs/heads/main:refs/remotes/origin/main" not in workflow:

--- a/scripts/test-release-security-posture.sh
+++ b/scripts/test-release-security-posture.sh
@@ -1388,6 +1388,13 @@ if transport_verify < transport_publish or anonymous < transport_verify:
     raise SystemExit("rollout must verify immutable and anonymous discovery after publication")
 for requirement in (
     "contents: write",
+    "runs-on: macos-15-intel",
+    "- name: Seal reviewed OpenSSL 3",
+    "id: protected_openssl",
+    "scripts/install-sealed-release-openssl.sh",
+    "/private/var/macprovider-openssl-release-rollout",
+    'OPENSSL_BIN: ${{ steps.protected_openssl.outputs.bin }}',
+    '--openssl "$OPENSSL_BIN"',
     "ref: refs/heads/main",
     "fetch-depth: 0",
     "git fetch --no-tags origin refs/heads/main:refs/remotes/origin/main",
@@ -1400,6 +1407,8 @@ for requirement in (
 ):
     if requirement not in rollout:
         raise SystemExit(f"post-publication rollout omits: {requirement}")
+if "${OPENSSL_BIN:-openssl}" in rollout:
+    raise SystemExit("post-publication rollout falls back to PATH-selected OpenSSL")
 renewal = (workflow_dir / "renew-release-discovery-head.yml").read_text(
     encoding="utf-8"
 )


### PR DESCRIPTION
## Summary
- Move post-publication rollout proof to the reviewed Intel macOS runner.
- Seal OpenSSL 3 before live feed/discovery signature verification.
- Lock the OpenSSL binding in release gate/security posture regressions.

## Tests
- `bash scripts/test-live-coordinator-release-gate.sh`
- `bash scripts/test-release-security-posture.sh`

## Governance
CI/release-workflow-only change. The spec-index declaration check has no honest authority-domain mapping for this path and is advisory/non-required per `CLAUDE.md`; no fabricated declaration included.
