### PR TITLE
Fix independent Malibu appcast publication drift

### DIFF
--- a/.github/workflows/malibu-release.yml
+++ b/.github/workflows/malibu-release.yml
@@ -283,6 +283,8 @@ jobs:
           signing_id="$(security find-identity -v -p codesigning build.keychain | awk -F'"' '/Developer ID Application/ {print $2; exit}')"
           test -n "$signing_id"
 
+          python3 scripts/prepare-malibu-bootstrap-trust-anchor.py prepare \
+            "v${APP_VERSION}" "$app" scripts/dist/malibu-v1.8.32-sparkle-public-key
           cp "$payload_dir/macprovider-cli" "$app/Contents/MacOS/macprovider-cli"
           chmod 755 "$app/Contents/MacOS/macprovider-cli"
           cp "$payload_dir/mlx.metallib" "$app/Contents/MacOS/mlx.metallib"
@@ -314,6 +316,8 @@ jobs:
           /usr/libexec/PlistBuddy -c \
             'Set :MalibuBundledReferralBootstrapV1 true' \
             "$app/Contents/Info.plist"
+          python3 scripts/prepare-malibu-bootstrap-trust-anchor.py verify \
+            "$app" scripts/dist/malibu-v1.8.32-sparkle-public-key
           embedded_cli="$app/Contents/MacOS/macprovider-cli"
           test "$(shasum -a 256 "$embedded_cli" | awk '{print $1}')" = "$CLI_SHA256"
 
@@ -661,6 +665,22 @@ jobs:
           cleanup_mount
           trap - EXIT
 
+      - name: Generate verified Malibu appcast
+        shell: bash
+        env:
+          APP_VERSION: ${{ inputs.version }}
+          SPARKLE_EDDSA_PRIVATE_KEY: ${{ secrets.SPARKLE_EDDSA_PRIVATE_KEY }}
+        run: |
+          set -euo pipefail
+          test -n "$SPARKLE_EDDSA_PRIVATE_KEY"
+          candidate="$RUNNER_TEMP/candidate"
+          dmg="$candidate/Malibu-v${APP_VERSION}.dmg"
+          DMG="$dmg" APPCAST_OUT="$candidate/appcast.xml" \
+            bash scripts/generate-malibu-appcast.sh "v${APP_VERSION}"
+          python3 scripts/verify-malibu-sparkle-signature.py \
+            "v${APP_VERSION}" "$dmg" "$candidate/appcast.xml" \
+            scripts/dist/malibu-v1.8.32-sparkle-public-key
+
       - name: Create and verify draft Malibu release
         id: draft
         shell: bash
@@ -692,6 +712,7 @@ jobs:
             "$candidate/Malibu-v${APP_VERSION}.dmg" \
             "$candidate/Malibu-v${APP_VERSION}.dmg.sha256" \
             "$candidate/candidate-manifest.json" \
+            "$candidate/appcast.xml" \
             --repo "$GITHUB_REPOSITORY" \
             --title "Malibu ${APP_VERSION}" \
             --notes-file "$RUNNER_TEMP/release-notes.md" \
@@ -704,7 +725,8 @@ jobs:
           jq -e --arg tag "$tag" --arg commit "$SOURCE_COMMIT" \
             '.isDraft == true and .tagName == $tag and .targetCommitish == $commit and
              ([.assets[].name] | sort) == (["Malibu-v" + env.APP_VERSION + ".dmg",
-               "Malibu-v" + env.APP_VERSION + ".dmg.sha256", "candidate-manifest.json"] | sort)' \
+               "Malibu-v" + env.APP_VERSION + ".dmg.sha256", "candidate-manifest.json",
+               "appcast.xml"] | sort)' \
             "$RUNNER_TEMP/draft.json" >/dev/null
           draft_id="$(jq -r .databaseId "$RUNNER_TEMP/draft.json")"
           [[ "$draft_id" =~ ^[1-9][0-9]*$ ]]
@@ -715,6 +737,7 @@ jobs:
             "Malibu-v${APP_VERSION}.dmg.sha256" candidate-manifest.json; do
             cmp -s "$candidate/$asset" "$RUNNER_TEMP/draft-download/$asset"
           done
+          cmp -s "$candidate/appcast.xml" "$RUNNER_TEMP/draft-download/appcast.xml"
           echo "release_id=$draft_id" >> "$GITHUB_OUTPUT"
 
       - name: Publish only the revalidated draft
@@ -756,7 +779,7 @@ jobs:
 
           by_id_path, cli_path, candidate_path, release_id, tag, commit, version = sys.argv[1:]
           candidate = pathlib.Path(candidate_path)
-          names = [f"Malibu-v{version}.dmg", f"Malibu-v{version}.dmg.sha256", "candidate-manifest.json"]
+          names = [f"Malibu-v{version}.dmg", f"Malibu-v{version}.dmg.sha256", "candidate-manifest.json", "appcast.xml"]
           expected_digests = {
               name: "sha256:" + hashlib.sha256((candidate / name).read_bytes()).hexdigest()
               for name in names
@@ -800,7 +823,7 @@ jobs:
 
           by_id_path, by_tag_path, candidate_path, release_id, tag, commit, version = sys.argv[1:]
           candidate = pathlib.Path(candidate_path)
-          names = [f"Malibu-v{version}.dmg", f"Malibu-v{version}.dmg.sha256", "candidate-manifest.json"]
+          names = [f"Malibu-v{version}.dmg", f"Malibu-v{version}.dmg.sha256", "candidate-manifest.json", "appcast.xml"]
           expected_digests = {
               name: "sha256:" + hashlib.sha256((candidate / name).read_bytes()).hexdigest()
               for name in names
@@ -826,7 +849,80 @@ jobs:
           gh release download "$tag" --repo "$GITHUB_REPOSITORY" \
             --dir "$RUNNER_TEMP/public-download"
           for asset in "Malibu-v${APP_VERSION}.dmg" \
-            "Malibu-v${APP_VERSION}.dmg.sha256" candidate-manifest.json; do
+            "Malibu-v${APP_VERSION}.dmg.sha256" candidate-manifest.json appcast.xml; do
             cmp -s "$candidate/$asset" "$RUNNER_TEMP/public-download/$asset"
           done
           gh release view "$tag" --repo "$GITHUB_REPOSITORY" --json url,isDraft,tagName,assets
+
+      - name: Publish current Malibu appcast to Pearl
+        shell: bash
+        env:
+          APP_VERSION: ${{ inputs.version }}
+          SOURCE_COMMIT: ${{ inputs.source_commit }}
+          EXPECTED_CLI_SHA256: ${{ inputs.cli_sha256 }}
+          MALIBU_DOWNLOAD_VPS_HOST: ${{ secrets.MALIBU_DOWNLOAD_VPS_HOST }}
+          MALIBU_DOWNLOAD_SSH_KEY: ${{ secrets.MALIBU_DOWNLOAD_SSH_KEY }}
+        run: |
+          set -euo pipefail
+          test -n "$MALIBU_DOWNLOAD_SSH_KEY" || {
+            echo "::error::MALIBU_DOWNLOAD_SSH_KEY is required for Malibu publication" >&2
+            exit 1
+          }
+          candidate="$RUNNER_TEMP/candidate"
+          release_json="$RUNNER_TEMP/immutable-release-by-id.json"
+          manifest="$RUNNER_TEMP/malibu-publication-manifest.json"
+          tag="v${APP_VERSION}"
+          dmg="$candidate/Malibu-v${APP_VERSION}.dmg"
+          appcast="$candidate/appcast.xml"
+          checksum="$candidate/Malibu-v${APP_VERSION}.dmg.sha256"
+          python3 - "$release_json" "$manifest" "$dmg" "$appcast" "$checksum" "$tag" "$SOURCE_COMMIT" <<'PY'
+          import hashlib
+          import json
+          import pathlib
+          import sys
+
+          release_path, manifest_path, dmg_path, appcast_path, checksum_path = map(pathlib.Path, sys.argv[1:6])
+          tag, commit = sys.argv[6:8]
+          release = json.loads(release_path.read_text(encoding="utf-8"))
+          if release.get("tag_name") != tag or release.get("target_commitish") != commit:
+              raise SystemExit("release identity mismatch")
+          by_name = {
+              asset.get("name"): asset
+              for asset in release.get("assets", [])
+              if isinstance(asset, dict)
+          }
+          names = [dmg_path.name, appcast_path.name, checksum_path.name]
+          digests = {path.name: hashlib.sha256(path.read_bytes()).hexdigest() for path in (dmg_path, appcast_path, checksum_path)}
+          content = json.dumps(
+              {
+                  "appcast_sha256": digests[appcast_path.name],
+                  "dmg_sha256": digests[dmg_path.name],
+                  "sha256_sidecar_sha256": digests[checksum_path.name],
+              },
+              sort_keys=True,
+              separators=(",", ":"),
+          ).encode()
+          manifest = {
+              "schema_version": 1,
+              "repository": "Augustas11/macprovider",
+              "tag": tag,
+              "commit": commit,
+              "prerelease": False,
+              "release_id": release["id"],
+              "publication_id": hashlib.sha256(content).hexdigest(),
+              "assets": {},
+          }
+          for name in names:
+              row = by_name.get(name)
+              if not isinstance(row, dict) or row.get("digest") != f"sha256:{digests[name]}":
+                  raise SystemExit(f"release asset mismatch for {name}")
+              manifest["assets"][name] = {"id": row["id"], "sha256": digests[name]}
+          manifest_path.write_text(json.dumps(manifest, sort_keys=True, indent=2) + "\n", encoding="utf-8")
+          PY
+          key_file="$(mktemp "$RUNNER_TEMP/malibu-download-key.XXXXXX")"
+          trap 'rm -f "$key_file"' EXIT
+          printf '%s\n' "$MALIBU_DOWNLOAD_SSH_KEY" > "$key_file"
+          chmod 600 "$key_file"
+          export MALIBU_DOWNLOAD_SSH_KEY="$key_file"
+          bash scripts/publish-independent-malibu-latest-dmg.sh \
+            "$release_json" "$manifest" "$dmg" "$appcast" "$checksum"

--- a/phase3-binary/dist/release-signing-runbook.md
+++ b/phase3-binary/dist/release-signing-runbook.md
@@ -191,7 +191,7 @@ select the `production-release` environment and add these environment secrets:
 | `APPLE_NOTARY_TEAM_ID` | The Team ID from step 5 |
 | `MACPROVIDER_RELEASE_SIGNING_KEY_PEM` | P-256 private key matching the public key embedded in `phase3-binary/dist/install.sh` |
 | `MACPROVIDER_ACCEPTANCE_SIGNING_KEY_PEM` | Dedicated P-256 private key matching `security/acceptance-candidate-signing-public.pem`; provision with `scripts/provision-acceptance-signing-key.sh` |
-| `SPARKLE_EDDSA_PRIVATE_KEY` | Base64 Ed25519 seed matching `scripts/dist/malibu-v1.8.32-sparkle-public-key`; used only to generate the frozen stable `v1.8.39` bootstrap appcast |
+| `SPARKLE_EDDSA_PRIVATE_KEY` | Base64 Ed25519 seed matching `scripts/dist/malibu-v1.8.32-sparkle-public-key`; used only to generate the signed Malibu appcast |
 | `MALIBU_DOWNLOAD_SSH_KEY` | Complete OpenSSH private-key contents for the root Pearl publication account; the workflow writes it to a mode-0600 temporary file |
 | `MALIBU_DOWNLOAD_VPS_HOST` | Pearl publication IPv4 address (`159.223.165.194` unless the host is deliberately migrated) |
 | `RELEASE_POSTURE_TOKEN` | Fine-grained token with repository Administration read and Actions read access |
@@ -440,11 +440,8 @@ MALIBU_BUILD="$(defaults read "$MALIBU_APP/Contents/Info" CFBundleVersion)"
 awk -F '\t' -v version="$MALIBU_VERSION" -v build="$MALIBU_BUILD" \
   '$1 == version && $2 == build { found = 1 } END { exit !found }' \
   phase3-binary/app/release-builds.tsv
-if test "$TAG" = v1.8.39; then
-  test "$MALIBU_VERSION/$MALIBU_BUILD" = 1.8.39/39
-else
-  test "$MALIBU_VERSION" != 1.8.39
-fi
+test "v$MALIBU_VERSION" = "$TAG"
+test "$MALIBU_BUILD" = "${TAG##*.}"
 xcrun stapler validate "$MALIBU_APP"
 spctl -a -t exec "$MALIBU_APP"
 cmp "$HOME/macprovider/compatibility-set.json" \
@@ -490,11 +487,10 @@ gh workflow run release.yml --repo Augustas11/macprovider --ref main \
 
 Wait until the unsigned `build` job succeeds and `sign_publish` is waiting for
 the independent `production-release` environment review. Do not approve yet.
-The candidate build preflights Malibu's bundle identity, path shape, frozen
-bridge key, absence of legacy update keys, and absence of a Sparkle runtime
-before capturing unsigned inputs. Malibu remains independently versioned; only
-the frozen v1.8.39 bridge release requires the app version/build to match
-1.8.39/39.
+The candidate build preflights Malibu's bundle identity, path shape, absence of
+legacy update keys, and absence of a Sparkle runtime before capturing unsigned
+inputs. Malibu remains independently versioned; the app version/build must match
+the requested `vX.Y.Z` tag as `X.Y.Z/Z`.
 Recheck that `origin/main` is still the captured commit, create the signed
 annotated tag at that exact commit, push it, and verify the peeled remote target:
 
@@ -910,26 +906,25 @@ without `xattr -d`.
 
 ## Publication recovery
 
-GitHub's immutable numeric release remains the release authority. One narrow
-exception exists for the Malibu 1.8.32 installed cohort: stable `v1.8.39`
-includes `appcast.xml`, signed with the existing Sparkle EdDSA secret and
-verified against `scripts/dist/malibu-v1.8.32-sparkle-public-key`. Only after
-the numeric GitHub release is immutable does the protected workflow atomically
-publish that exact appcast and `Malibu-v1.8.39.dmg` to Pearl. The workflow then
-downloads `appcast.xml`, `latest.dmg`, and the versioned DMG over HTTPS and
-requires their hashes and EdDSA signature to match the immutable release.
+GitHub's immutable numeric release remains the release authority. Independent
+Malibu releases include `appcast.xml`, signed with the existing Sparkle EdDSA
+secret and verified against
+`scripts/dist/malibu-v1.8.32-sparkle-public-key`. Only after the numeric GitHub
+release is immutable does the protected workflow atomically publish the exact
+appcast, `latest.dmg`, versioned `Malibu-vX.Y.Z.dmg`, and versioned SHA-256
+sidecar to Pearl. The workflow then downloads `appcast.xml`, `latest.dmg`, the
+versioned DMG, and the versioned SHA-256 sidecar over HTTPS and requires their
+hashes, checksum contents, and EdDSA signature to match the immutable release.
 
-This is a bootstrap bridge, not a restored update subsystem. Malibu 1.8.39 has
-no Sparkle package/framework, `SUFeedURL`, automatic-check setting, or updater
-runtime. Its final signed bundle does retain the exact frozen `SUPublicEDKey`
-from Malibu 1.8.32 because Sparkle 2.6.4 rejects a target that removes the old
-key after extraction. The protected workflow injects that inert public trust
-anchor before protected bundle writes, re-verifies the completed bundle before
-codesigning, and requires the exact key with no Sparkle runtime or feed in the
-final DMG. Later app updates are
-owned by the signed CLI compatibility transaction, and every later Malibu build
-must omit the key. The generator, verifier, remote installer, workflow
-conditions, and regression tests all reject bridge tags other than `v1.8.39`.
+This is an old-client compatibility surface, not a restored update subsystem.
+Malibu has no Sparkle package/framework, `SUFeedURL`, automatic-check setting,
+or updater runtime. Its final signed bundle retains the exact frozen
+`SUPublicEDKey` from Malibu 1.8.32 because Sparkle 2.6.4 rejects a target that
+removes the old key after extraction. The protected workflow injects that inert
+public trust anchor before protected bundle writes, re-verifies the completed
+bundle before codesigning, and requires the exact key with no Sparkle runtime or
+feed in the final DMG. Later provider/CLI updates are owned by the signed CLI
+compatibility transaction.
 
 If publication stops before draft-to-public transition, inspect or delete the
 numeric draft and rerun from the same reviewed tag. If GitHub is immutable but
@@ -941,7 +936,7 @@ exact release commit:
 
 ```bash
 export REPO=Augustas11/macprovider
-export TAG=v1.8.39
+export TAG=vX.Y.Z
 export GH_TOKEN="$(gh auth token -u Augustas11)"
 export RELEASE_ID="$(
   gh api -H 'X-GitHub-Api-Version: 2026-03-10' \
@@ -955,29 +950,28 @@ export RELEASE_COMMIT="$(
 [[ "$RELEASE_COMMIT" =~ ^[0-9a-f]{40}$ ]]
 
 git fetch origin main
-export RECOVERY_WORKTREE=../macprovider-v1839-publication-recovery
+export RECOVERY_WORKTREE=../macprovider-malibu-publication-recovery
 test ! -e "$RECOVERY_WORKTREE"
 git worktree add --detach "$RECOVERY_WORKTREE" "$RELEASE_COMMIT"
 cd "$RECOVERY_WORKTREE"
 
 MALIBU_DOWNLOAD_VPS_HOST=159.223.165.194 \
 MALIBU_DOWNLOAD_SSH_KEY="$HOME/.ssh/pearl_operator_ed25519" \
-  bash scripts/recover-malibu-publication.sh "$RELEASE_ID"
+  bash scripts/recover-independent-malibu-publication.sh "$RELEASE_ID"
 ```
 
 For local recovery, `MALIBU_DOWNLOAD_SSH_KEY` is a path to a regular private-key
 file; the Actions environment secret with the same name stores the key contents.
 `GH_TOKEN` needs only repository contents read access. The helper accepts no tag,
-commit, or asset-ID overrides: it requires the immutable stable `v1.8.39` numeric
-release, discovers the six required uploaded assets by exact name (including
-`compatibility-artifact-index.json`), revalidates their numeric identities after
-download, verifies the clean checkout and protected remote tag, reconstructs the
-publication manifest through `capture-release-publication.py`, and invokes the
-same signed-set verifier and atomic Pearl publisher as the protected workflow.
+commit, or asset-ID overrides: it requires an immutable stable numeric release,
+discovers the three independent Malibu publication assets by exact name, requires
+the recovery checkout to be at the release commit, reconstructs the publication
+manifest from GitHub's release JSON, and invokes the same current-publication
+verifier plus atomic Pearl publisher as the protected workflow.
 
 The command is idempotent for the same immutable publication. Never regenerate
-checksums, replace a public asset, pass hand-copied asset IDs, or construct a
-partial compatibility set.
+checksums, replace a public asset, pass hand-copied asset IDs, or publish only
+one member of the DMG/appcast/checksum set.
 
 ## Related
 

--- a/scripts/dist/malibu-v1.8.32-sparkle-public-key
+++ b/scripts/dist/malibu-v1.8.32-sparkle-public-key
@@ -1,3 +1,3 @@
 # Frozen SUPublicEDKey shipped by Malibu 1.8.32.
-# This trust anchor exists only for the one-time v1.8.39 appcast and target bundle.
+# This trust anchor supports old-client appcast validation for signed Malibu targets.
 JkTDWnRJfOI3YIlpfJKvasWkxb0O1j/7ObGYiIA7big=

--- a/scripts/generate-malibu-appcast.sh
+++ b/scripts/generate-malibu-appcast.sh
@@ -1,14 +1,15 @@
 #!/usr/bin/env bash
-# Build the one-time Sparkle bootstrap appcast for Malibu v1.8.32 clients.
+# Build the signed Sparkle appcast for Malibu clients that still read the
+# public appcast surface.
 #
 # Requires:
 #   - Malibu-{tag}.dmg at phase3-binary/app/dist/ (or pass DMG=...)
 #   - SPARKLE_EDDSA_PRIVATE_KEY (base64 Ed25519 seed) or SPARKLE_PRIVATE_KEY_FILE
 #   - curl + tar (reviewed Sparkle release tools downloaded on demand)
 #
-# The current Malibu app remains free of Sparkle runtime and feeds. Its signed
-# v1.8.39 target retains only the old public trust anchor required by Sparkle's
-# post-extraction policy. This signer is locked to that one bridge tag.
+# Malibu remains free of Sparkle runtime and feed URLs. Release signing injects
+# only the frozen SUPublicEDKey so older Sparkle clients can validate the target
+# bundle after extraction and then land on the CLI-owned update path.
 
 set -euo pipefail
 
@@ -17,12 +18,6 @@ tag="${1:-}"
   echo "usage: $0 vX.Y.Z" >&2
   exit 2
 }
-bridge_tag="v1.8.39"
-[[ "$tag" == "$bridge_tag" ]] || {
-  echo "legacy Malibu Sparkle bootstrap is frozen to $bridge_tag" >&2
-  exit 1
-}
-
 repo_root="$(cd "$(dirname "$0")/.." && pwd)"
 dmg="${DMG:-$repo_root/phase3-binary/app/dist/Malibu-${tag}.dmg}"
 [[ -f "$dmg" && ! -L "$dmg" ]] || {
@@ -83,7 +78,8 @@ EOF
   --download-url-prefix "https://download.malibu.tech/" \
   "$work"
 
-out="$repo_root/phase3-binary/app/dist/appcast.xml"
+out="${APPCAST_OUT:-$repo_root/phase3-binary/app/dist/appcast.xml}"
+mkdir -p "$(dirname "$out")"
 cp "$work/appcast.xml" "$out"
 [[ -f "$out" && ! -L "$out" ]] || {
   echo "generated appcast is not a regular file" >&2

--- a/scripts/install-malibu-publication.sh
+++ b/scripts/install-malibu-publication.sh
@@ -18,7 +18,6 @@ sha_source="$7"
 [[ "$webroot" == /* ]] || die "webroot must be an absolute path"
 [[ "$webroot" =~ ^/[A-Za-z0-9._/-]+$ && "$webroot" != *'/../'* && "$webroot" != */.. ]] || die "unsafe webroot"
 [[ "$tag" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]] || die "tag must be vX.Y.Z"
-[[ "$tag" == v1.8.39 ]] || die "legacy Malibu publication is frozen to v1.8.39"
 [[ "$release_id" =~ ^[0-9a-f]{64}$ ]] || die "publication id must be a full content digest"
 
 testing="${MALIBU_PUBLICATION_TESTING:-0}"

--- a/scripts/prepare-malibu-bootstrap-trust-anchor.py
+++ b/scripts/prepare-malibu-bootstrap-trust-anchor.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Prepare or verify Malibu's one-time Sparkle trust-continuity anchor."""
+"""Prepare or verify Malibu's Sparkle trust-continuity anchor."""
 
 from __future__ import annotations
 
@@ -14,9 +14,6 @@ import stat
 import tempfile
 
 
-BRIDGE_TAG = "v1.8.39"
-BRIDGE_VERSION = "1.8.39"
-BRIDGE_BUILD = "39"
 EXPECTED_PUBLIC_KEY = "JkTDWnRJfOI3YIlpfJKvasWkxb0O1j/7ObGYiIA7big="
 TAG_PATTERN = re.compile(r"^v[0-9]+\.[0-9]+\.[0-9]+$")
 
@@ -127,6 +124,12 @@ def validate_identity(document: dict[str, object], expected_tag: str | None) -> 
         fail("CFBundleVersion is not a positive decimal build")
     if expected_tag is not None and expected_tag != f"v{version}":
         fail(f"bundle version {version} does not match release tag {expected_tag}")
+    expected_build = str(int(version.rsplit(".", 1)[1]))
+    if build != expected_build:
+        fail(
+            f"release {version} requires bundle version/build "
+            f"{version}/{expected_build}, got {version}/{build}"
+        )
     return version, build
 
 
@@ -177,24 +180,10 @@ def preflight(
     key = load_frozen_key(key_path)
     info = contents / "Info.plist"
     document, plist_format, mode = load_plist(info)
-    version, build = validate_identity(
-        document,
-        tag if tag == BRIDGE_TAG else None,
-    )
+    version, build = validate_identity(document, tag)
     found = legacy_update_keys(document)
     if found:
         fail("source Malibu app unexpectedly contains legacy update keys: " + ", ".join(found))
-
-    if tag == BRIDGE_TAG and (version != BRIDGE_VERSION or build != BRIDGE_BUILD):
-        fail(
-            f"{BRIDGE_TAG} trust anchor requires bundle version/build "
-            f"{BRIDGE_VERSION}/{BRIDGE_BUILD}, got {version}/{build}"
-        )
-    if tag != BRIDGE_TAG and version == BRIDGE_VERSION:
-        fail(
-            f"bundle version {BRIDGE_VERSION} is reserved for the "
-            f"{BRIDGE_TAG} trust-anchor release"
-        )
     print(
         f"preflighted Malibu {version}/{build} for {tag} without legacy "
         "app-update authority"
@@ -209,14 +198,10 @@ def prepare(tag: str, app: pathlib.Path, key_path: pathlib.Path) -> None:
         key_path,
     )
 
-    if tag != BRIDGE_TAG:
-        print(f"Malibu {tag} remains free of legacy app-update authority")
-        return
-
     document["SUPublicEDKey"] = key
     atomic_write_plist(contents / "Info.plist", document, plist_format, mode)
     verify(app, key_path)
-    print(f"injected frozen Malibu v1.8.32 trust anchor into {BRIDGE_TAG}")
+    print(f"injected frozen Malibu Sparkle trust anchor into {tag}")
 
 
 def verify(app: pathlib.Path, key_path: pathlib.Path) -> None:
@@ -226,26 +211,12 @@ def verify(app: pathlib.Path, key_path: pathlib.Path) -> None:
     version, build = validate_identity(document, None)
     found = legacy_update_keys(document)
 
-    if version == BRIDGE_VERSION:
-        if build != BRIDGE_BUILD:
-            fail(
-                f"bundle version {BRIDGE_VERSION} must use bridge build {BRIDGE_BUILD}, "
-                f"got {build}"
-            )
-        if found != ["SUPublicEDKey"] or document.get("SUPublicEDKey") != key:
-            fail(
-                f"Malibu {BRIDGE_VERSION} must contain only the exact frozen "
-                "SUPublicEDKey trust anchor"
-            )
-        print(f"verified one-time Malibu {BRIDGE_VERSION} trust anchor")
-        return
-
-    if found:
+    if found != ["SUPublicEDKey"] or document.get("SUPublicEDKey") != key:
         fail(
-            f"Malibu {version} must not retain legacy app-update keys: "
-            + ", ".join(found)
+            f"Malibu {version} must contain only the exact frozen "
+            "SUPublicEDKey trust anchor"
         )
-    print(f"verified Malibu {version} has no legacy app-update keys")
+    print(f"verified Malibu {version} Sparkle trust anchor")
 
 
 def parse_args() -> argparse.Namespace:

--- a/scripts/publish-independent-malibu-latest-dmg.sh
+++ b/scripts/publish-independent-malibu-latest-dmg.sh
@@ -1,40 +1,34 @@
 #!/usr/bin/env bash
-# Publish a locally captured, signed Malibu release set to Pearl.
+# Publish an independently versioned Malibu release to download.malibu.tech.
 set -euo pipefail
 
 die() {
-  printf '[publish-malibu-latest-dmg] ERROR: %s\n' "$*" >&2
+  printf '[publish-independent-malibu-latest-dmg] ERROR: %s\n' "$*" >&2
   exit 1
 }
 
-[[ "$#" == 7 ]] ||
-  die "usage: $0 MANIFEST DMG APPCAST ARTIFACT_INDEX CHECKSUMS SIGNATURE PROVENANCE"
-
-manifest="$1"
-asset="$2"
-appcast="$3"
-artifact_index="$4"
-checksums="$5"
-signature="$6"
-provenance="$7"
+[[ "$#" == 5 ]] || die "usage: RELEASE_JSON MANIFEST DMG APPCAST SHA256"
+release_json="$1"
+manifest="$2"
+asset="$3"
+appcast="$4"
+checksum="$5"
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 
-bash "$SCRIPT_DIR/verify-malibu-publication-set.sh" \
-  "$manifest" "$asset" "$appcast" "$artifact_index" \
-  "$checksums" "$signature" "$provenance"
+bash "$SCRIPT_DIR/verify-malibu-current-publication-set.sh" \
+  "$release_json" "$manifest" "$asset" "$appcast" "$checksum"
 
-read -r tag commit release_number publication_id dmg_asset_id appcast_asset_id < <(
+read -r tag release_number publication_id dmg_asset_id appcast_asset_id < <(
   python3 - "$manifest" <<'PY'
 import json
 import pathlib
 import sys
 
 manifest = json.loads(pathlib.Path(sys.argv[1]).read_text(encoding="utf-8"))
-tag = manifest["tag"]
 assets = manifest["assets"]
+tag = manifest["tag"]
 print(
     tag,
-    manifest["commit"],
     manifest["release_id"],
     manifest["publication_id"],
     assets[f"Malibu-{tag}.dmg"]["id"],
@@ -43,8 +37,6 @@ print(
 PY
 )
 [[ "$tag" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]] || die "manifest tag is invalid"
-[[ "$tag" == v1.8.39 ]] || die "legacy provider-coupled Malibu publisher is frozen to v1.8.39"
-[[ "$commit" =~ ^[0-9a-f]{40}$ ]] || die "manifest commit is invalid"
 [[ "$release_number" =~ ^[1-9][0-9]*$ ]] || die "manifest release id is invalid"
 [[ "$publication_id" =~ ^[0-9a-f]{64}$ ]] || die "manifest publication id is invalid"
 [[ "$dmg_asset_id" =~ ^[1-9][0-9]*$ && "$appcast_asset_id" =~ ^[1-9][0-9]*$ ]] ||
@@ -69,8 +61,6 @@ sha256_file() {
 }
 
 dmg_name="Malibu-${tag}.dmg"
-checksum_file="$(mktemp "${RUNNER_TEMP:-${TMPDIR:-/tmp}}/Malibu-${tag}.XXXXXX.sha256")"
-printf '%s  %s\n' "$(sha256_file "$asset")" "$dmg_name" >"$checksum_file"
 
 # Resolved relative to this script at runtime.
 # shellcheck disable=SC1091
@@ -78,14 +68,13 @@ source "$SCRIPT_DIR/malibu-download-ssh.sh"
 
 remote_stage=""
 cleanup() {
-  rm -f "$checksum_file"
   if [[ -n "$remote_stage" && "$remote_stage" =~ ^/root/\.malibu-publish/stage\.[A-Za-z0-9]+$ ]]; then
     malibu_download_ssh "rm -rf -- '$remote_stage'" >/dev/null 2>&1 || true
   fi
 }
 trap cleanup EXIT
 
-# This block intentionally expands only on Pearl.
+# Remote variables must expand on Pearl, not in this local shell.
 # shellcheck disable=SC2016
 remote_stage="$(malibu_download_ssh 'set -eu
   umask 077
@@ -98,7 +87,7 @@ remote_stage="$(malibu_download_ssh 'set -eu
   die "Pearl returned an unsafe staging path"
 
 helper="$SCRIPT_DIR/install-malibu-publication.sh"
-declare -a local_paths=("$manifest" "$asset" "$appcast" "$checksum_file" "$helper")
+declare -a local_paths=("$manifest" "$asset" "$appcast" "$checksum" "$helper")
 declare -a remote_names=(publication-manifest.json "$dmg_name" appcast.xml "${dmg_name}.sha256" install-helper)
 declare -a expected_hashes=()
 for index in "${!local_paths[@]}"; do
@@ -149,7 +138,7 @@ malibu_download_ssh "set -euo pipefail
 remote_stage=""
 
 bash "$SCRIPT_DIR/verify-malibu-bootstrap-publication.sh" \
-  "$tag" "$asset" "$appcast" "$checksum_file"
+  "$tag" "$asset" "$appcast" "$checksum"
 
-printf '[publish-malibu-latest-dmg] ok: %s/%s + latest.dmg on Pearl (release=%s assets=%s,%s commit=%s)\n' \
-  "$WEBROOT" "$dmg_name" "$release_number" "$dmg_asset_id" "$appcast_asset_id" "$commit"
+printf '[publish-independent-malibu-latest-dmg] ok: %s/%s + latest.dmg/appcast.xml on Pearl (release=%s assets=%s,%s)\n' \
+  "$WEBROOT" "$dmg_name" "$release_number" "$dmg_asset_id" "$appcast_asset_id"

--- a/scripts/recover-independent-malibu-publication.sh
+++ b/scripts/recover-independent-malibu-publication.sh
@@ -1,0 +1,131 @@
+#!/usr/bin/env bash
+# Recover only the post-GitHub Pearl publication for an independent Malibu release.
+set -euo pipefail
+
+die() {
+  printf '[recover-independent-malibu-publication] ERROR: %s\n' "$*" >&2
+  exit 1
+}
+
+[[ "$#" == 1 ]] || die "usage: RELEASE_ID"
+release_id="$1"
+[[ "$release_id" =~ ^[1-9][0-9]*$ ]] || die "release id must be numeric"
+repo="${REPO:-Augustas11/macprovider}"
+[[ "$repo" =~ ^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$ ]] || die "repository must be owner/name"
+[[ -n "${GH_TOKEN:-}" ]] || die "GH_TOKEN is required"
+
+script_dir="$(cd "$(dirname "$0")" && pwd)"
+repo_root="$(cd "$script_dir/.." && pwd)"
+work="$(mktemp -d "${TMPDIR:-/tmp}/malibu-independent-publication-recovery.XXXXXX")"
+trap 'rm -rf "$work"' EXIT
+
+release_json="$work/release.json"
+manifest="$work/publication-manifest.json"
+asset_dir="$work/assets"
+mkdir -p "$asset_dir"
+
+gh api -H 'X-GitHub-Api-Version: 2026-03-10' \
+  "repos/$repo/releases/$release_id" > "$release_json"
+
+identity="$(
+  python3 - "$release_json" "$release_id" "$repo" <<'PY'
+import json
+import pathlib
+import re
+import sys
+
+release_path, release_id, repo = sys.argv[1:]
+release = json.loads(pathlib.Path(release_path).read_text(encoding="utf-8"))
+tag = release.get("tag_name")
+commit = release.get("target_commitish")
+if release.get("id") != int(release_id):
+    raise SystemExit("release id mismatch")
+if release.get("draft") is not False or release.get("prerelease") is not False:
+    raise SystemExit("release must be public stable")
+if release.get("immutable") is not True:
+    raise SystemExit("release must be immutable before Pearl recovery")
+if not isinstance(tag, str) or not re.fullmatch(r"v\d+\.\d+\.\d+", tag):
+    raise SystemExit("release tag must be vX.Y.Z")
+if not isinstance(commit, str) or not re.fullmatch(r"[0-9a-f]{40}", commit):
+    raise SystemExit("release commit is invalid")
+required = {f"Malibu-{tag}.dmg", f"Malibu-{tag}.dmg.sha256", "appcast.xml"}
+assets = release.get("assets")
+if not isinstance(assets, list):
+    raise SystemExit("release assets are invalid")
+names = {asset.get("name") for asset in assets if isinstance(asset, dict)}
+if not required.issubset(names):
+    raise SystemExit("release omits independent Malibu publication assets")
+print(tag, commit)
+PY
+)"
+read -r tag commit <<< "$identity"
+[[ "$tag" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ && "$commit" =~ ^[0-9a-f]{40}$ ]] ||
+  die "release identity verification failed"
+
+if git -C "$repo_root" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+  [[ -z "$(git -C "$repo_root" status --porcelain --untracked-files=no)" ]] ||
+    die "recovery worktree has tracked or staged changes"
+  head_commit="$(git -C "$repo_root" rev-parse HEAD)"
+  [[ "$head_commit" == "$commit" ]] ||
+    die "recovery must run from the exact release commit $commit (current $head_commit)"
+fi
+
+gh release download "$tag" --repo "$repo" --dir "$asset_dir" \
+  --pattern "Malibu-${tag}.dmg" \
+  --pattern "Malibu-${tag}.dmg.sha256" \
+  --pattern "appcast.xml"
+
+dmg="$asset_dir/Malibu-${tag}.dmg"
+checksum="$asset_dir/Malibu-${tag}.dmg.sha256"
+appcast="$asset_dir/appcast.xml"
+
+python3 - "$release_json" "$manifest" "$dmg" "$appcast" "$checksum" "$repo" <<'PY'
+import hashlib
+import json
+import pathlib
+import sys
+
+release_path, manifest_path, dmg_path, appcast_path, checksum_path, repo = sys.argv[1:]
+release = json.loads(pathlib.Path(release_path).read_text(encoding="utf-8"))
+dmg = pathlib.Path(dmg_path)
+appcast = pathlib.Path(appcast_path)
+checksum = pathlib.Path(checksum_path)
+tag = release["tag_name"]
+digests = {path.name: hashlib.sha256(path.read_bytes()).hexdigest() for path in (dmg, appcast, checksum)}
+content = json.dumps(
+    {
+        "appcast_sha256": digests[appcast.name],
+        "dmg_sha256": digests[dmg.name],
+        "sha256_sidecar_sha256": digests[checksum.name],
+    },
+    sort_keys=True,
+    separators=(",", ":"),
+).encode()
+by_name = {
+    asset.get("name"): asset
+    for asset in release.get("assets", [])
+    if isinstance(asset, dict)
+}
+manifest = {
+    "schema_version": 1,
+    "repository": repo,
+    "tag": tag,
+    "commit": release["target_commitish"],
+    "prerelease": False,
+    "release_id": release["id"],
+    "publication_id": hashlib.sha256(content).hexdigest(),
+    "assets": {},
+}
+for name, digest in digests.items():
+    row = by_name.get(name)
+    if not isinstance(row, dict) or row.get("digest") != f"sha256:{digest}":
+        raise SystemExit(f"release asset digest mismatch for {name}")
+    manifest["assets"][name] = {"id": row["id"], "sha256": digest}
+pathlib.Path(manifest_path).write_text(
+    json.dumps(manifest, sort_keys=True, indent=2) + "\n",
+    encoding="utf-8",
+)
+PY
+
+bash "$script_dir/publish-independent-malibu-latest-dmg.sh" \
+  "$release_json" "$manifest" "$dmg" "$appcast" "$checksum"

--- a/scripts/test-malibu-bootstrap-bridge.sh
+++ b/scripts/test-malibu-bootstrap-bridge.sh
@@ -6,7 +6,10 @@ generator="$root/scripts/generate-malibu-appcast.sh"
 signature_verifier="$root/scripts/verify-malibu-sparkle-signature.py"
 trust_anchor_helper="$root/scripts/prepare-malibu-bootstrap-trust-anchor.py"
 set_verifier="$root/scripts/verify-malibu-publication-set.sh"
+current_set_verifier="$root/scripts/verify-malibu-current-publication-set.sh"
 publisher="$root/scripts/publish-malibu-latest-dmg.sh"
+independent_publisher="$root/scripts/publish-independent-malibu-latest-dmg.sh"
+independent_recovery="$root/scripts/recover-independent-malibu-publication.sh"
 installer="$root/scripts/install-malibu-publication.sh"
 public_verifier="$root/scripts/verify-malibu-bootstrap-publication.sh"
 ssh_helper="$root/scripts/malibu-download-ssh.sh"
@@ -18,7 +21,7 @@ fail() {
   exit 1
 }
 
-for script in "$generator" "$set_verifier" "$publisher" "$installer" "$public_verifier" "$ssh_helper"; do
+for script in "$generator" "$set_verifier" "$current_set_verifier" "$publisher" "$independent_publisher" "$independent_recovery" "$installer" "$public_verifier" "$ssh_helper"; do
   [[ -f "$script" ]] || fail "missing $script"
   bash -n "$script"
 done
@@ -102,8 +105,9 @@ expect_anchor_failure() {
   grep -q "$pattern" "$work/$label.out" || fail "$label rejection was unclear"
 }
 
-# The released v1.8.39 target must carry exactly the old client's public key,
-# while source and every later app remain free of Sparkle update authority.
+# Released targets must carry exactly the old client's public key so Sparkle
+# can validate the extracted bundle, while source remains free of Sparkle
+# runtime and feed authority.
 create_test_app "$work/bridge.app" 1.8.39 39
 python3 "$trust_anchor_helper" prepare v1.8.39 \
   "$work/bridge.app" "$legacy_key" >/dev/null
@@ -124,7 +128,7 @@ assert document["SUPublicEDKey"] == values[0]
 assert sorted(key for key in document if key.startswith("SU")) == ["SUPublicEDKey"]
 PY
 
-create_test_app "$work/later.app" 1.8.45 45
+create_test_app "$work/later.app" 1.8.65 65
 cp "$work/later.app/Contents/Info.plist" "$work/later.Info.plist"
 python3 "$trust_anchor_helper" preflight v1.8.65 \
   "$work/later.app" "$legacy_key" >/dev/null
@@ -132,18 +136,26 @@ cmp "$work/later.Info.plist" "$work/later.app/Contents/Info.plist" ||
   fail "candidate preflight mutated independently versioned Malibu"
 python3 "$trust_anchor_helper" prepare v1.8.65 \
   "$work/later.app" "$legacy_key" >/dev/null
-cmp "$work/later.Info.plist" "$work/later.app/Contents/Info.plist" ||
-  fail "non-bridge preparation mutated independently versioned Malibu"
 python3 "$trust_anchor_helper" verify \
   "$work/later.app" "$legacy_key" >/dev/null
+python3 - "$work/later.app/Contents/Info.plist" "$legacy_key" <<'PY'
+import pathlib
+import plistlib
+import sys
+
+document = plistlib.loads(pathlib.Path(sys.argv[1]).read_bytes())
+values = [
+    line.strip()
+    for line in pathlib.Path(sys.argv[2]).read_text(encoding="ascii").splitlines()
+    if line.strip() and not line.lstrip().startswith("#")
+]
+assert document["SUPublicEDKey"] == values[0]
+assert sorted(key for key in document if key.startswith("SU")) == ["SUPublicEDKey"]
+PY
 
 create_test_app "$work/wrong-bridge-version.app" 1.8.45 45
 expect_anchor_failure wrong-bridge-version 'bundle version 1.8.45 does not match release tag v1.8.39' \
   preflight v1.8.39 "$work/wrong-bridge-version.app" "$legacy_key"
-
-create_test_app "$work/reserved-bridge-version.app" 1.8.39 39
-expect_anchor_failure reserved-bridge-version 'reserved for the v1.8.39 trust-anchor release' \
-  preflight v1.8.65 "$work/reserved-bridge-version.app" "$legacy_key"
 
 create_test_app "$work/missing-anchor.app" 1.8.39 39
 expect_anchor_failure missing-anchor 'must contain only the exact frozen' \
@@ -203,9 +215,18 @@ expect_anchor_failure symlink-key 'regular non-symlink file' \
 grep -q 'StrictHostKeyChecking=yes' "$ssh_helper" || fail "Pearl SSH must fail closed"
 grep -q 'malibu-download-known_hosts' "$ssh_helper" || fail "Pearl SSH host key is not pinned"
 grep -q '/root/\.malibu-publish/stage\.XXXXXXXX' "$publisher" || fail "remote staging is predictable"
+grep -q '/root/\.malibu-publish/stage\.XXXXXXXX' "$independent_publisher" || fail "independent remote staging is predictable"
 grep -q "stat -c '%u:%g:%a:%h:%F'" "$publisher" || fail "remote transfer metadata is not verified"
+grep -q "stat -c '%u:%g:%a:%h:%F'" "$independent_publisher" || fail "independent remote transfer metadata is not verified"
 grep -q 'verify-malibu-bootstrap-publication.sh' "$publisher" || fail "public bytes are not verified"
-if grep -q -- '--resolve' "$public_verifier" || grep -q 'MALIBU_DOWNLOAD_RESOLVE_IP' "$publisher"; then
+grep -q 'verify-malibu-bootstrap-publication.sh' "$independent_publisher" || fail "independent public bytes are not verified"
+grep -q 'verify-malibu-current-publication-set.sh' "$independent_publisher" ||
+  fail "independent publication does not verify the current manifest"
+grep -q 'legacy provider-coupled Malibu publisher is frozen to v1.8.39' "$publisher" ||
+  fail "legacy provider-coupled publisher is not frozen"
+grep -q 'legacy provider-coupled Malibu publication is frozen to v1.8.39' "$set_verifier" ||
+  fail "legacy provider-coupled verifier is not frozen"
+if grep -q -- '--resolve' "$public_verifier" || grep -q 'MALIBU_DOWNLOAD_RESOLVE_IP' "$publisher" || grep -q 'MALIBU_DOWNLOAD_RESOLVE_IP' "$independent_publisher"; then
   fail "public verification can bypass client DNS resolution"
 fi
 grep -q 'same-tag publication drift refused' "$installer" || fail "same-tag drift is not refused"
@@ -216,6 +237,8 @@ mkdir -p "$work/input" "$work/webroot"
 printf 'signed dmg bytes\n' > "$work/input/Malibu-v1.8.39.dmg"
 printf 'signed appcast bytes\n' > "$work/input/appcast.xml"
 printf 'artifact index bytes\n' > "$work/input/compatibility-artifact-index.json"
+dmg_sha="$(shasum -a 256 "$work/input/Malibu-v1.8.39.dmg" | awk '{print $1}')"
+printf '%s  Malibu-v1.8.39.dmg\n' "$dmg_sha" > "$work/input/Malibu-v1.8.39.dmg.sha256"
 
 # Public DNS/HTTPS is part of the client path. A failed ordinary fetch must
 # fail the gate instead of retrying against a forced origin address.
@@ -231,6 +254,7 @@ if MOCK_CURL_CALLS="$work/no-dns-curl.calls" \
   PATH="$work/no-dns-bin:$PATH" \
   bash "$public_verifier" v1.8.39 \
     "$work/input/Malibu-v1.8.39.dmg" "$work/input/appcast.xml" \
+    "$work/input/Malibu-v1.8.39.dmg.sha256" \
     >"$work/no-dns.out" 2>&1; then
   fail "public verifier accepted failed DNS/client routing"
 fi
@@ -280,8 +304,6 @@ publication_id="$(create_manifest \
   "$work/input/publication-manifest.json" \
   "$work/input/Malibu-v1.8.39.dmg" "$work/input/appcast.xml" \
   "$work/input/compatibility-artifact-index.json" false)"
-dmg_sha="$(shasum -a 256 "$work/input/Malibu-v1.8.39.dmg" | awk '{print $1}')"
-printf '%s  Malibu-v1.8.39.dmg\n' "$dmg_sha" > "$work/input/Malibu-v1.8.39.dmg.sha256"
 
 MALIBU_PUBLICATION_TESTING=1 bash "$installer" \
   "$work/webroot" v1.8.39 "$publication_id" \
@@ -308,6 +330,67 @@ if MALIBU_PUBLICATION_TESTING=1 bash "$installer" \
 fi
 grep -q 'same-tag publication drift refused' "$work/drift.out" || fail "drift rejection was unclear"
 
+mkdir -p "$work/current"
+printf 'current signed dmg bytes\n' > "$work/current/Malibu-v1.8.65.dmg"
+printf 'current signed appcast bytes\n' > "$work/current/appcast.xml"
+current_dmg_sha="$(shasum -a 256 "$work/current/Malibu-v1.8.65.dmg" | awk '{print $1}')"
+printf '%s  Malibu-v1.8.65.dmg\n' "$current_dmg_sha" > "$work/current/Malibu-v1.8.65.dmg.sha256"
+python3 - "$work/current/release.json" "$work/current/publication-manifest.json" \
+  "$work/current/Malibu-v1.8.65.dmg" "$work/current/appcast.xml" \
+  "$work/current/Malibu-v1.8.65.dmg.sha256" <<'PY'
+import hashlib
+import json
+import pathlib
+import sys
+
+release_path, manifest_path, dmg_path, appcast_path, checksum_path = map(pathlib.Path, sys.argv[1:])
+tag = "v1.8.65"
+commit = "b" * 40
+local = {path.name: hashlib.sha256(path.read_bytes()).hexdigest() for path in (dmg_path, appcast_path, checksum_path)}
+identity = hashlib.sha256(json.dumps({
+    "appcast_sha256": local["appcast.xml"],
+    "dmg_sha256": local[dmg_path.name],
+    "sha256_sidecar_sha256": local[checksum_path.name],
+}, sort_keys=True, separators=(",", ":")).encode()).hexdigest()
+assets = [
+    {"id": 401, "name": dmg_path.name, "digest": "sha256:" + local[dmg_path.name]},
+    {"id": 402, "name": "appcast.xml", "digest": "sha256:" + local["appcast.xml"]},
+    {"id": 403, "name": checksum_path.name, "digest": "sha256:" + local[checksum_path.name]},
+]
+release_path.write_text(json.dumps({
+    "id": 301,
+    "tag_name": tag,
+    "target_commitish": commit,
+    "draft": False,
+    "prerelease": False,
+    "immutable": True,
+    "assets": assets,
+}, sort_keys=True) + "\n")
+manifest_path.write_text(json.dumps({
+    "schema_version": 1,
+    "repository": "Augustas11/macprovider",
+    "tag": tag,
+    "commit": commit,
+    "prerelease": False,
+    "release_id": 301,
+    "publication_id": identity,
+    "assets": {
+        asset["name"]: {"id": asset["id"], "sha256": local[asset["name"]]}
+        for asset in assets
+    },
+}, sort_keys=True) + "\n")
+PY
+printf 'stale current appcast bytes\n' > "$work/current/appcast.xml"
+if bash "$current_set_verifier" \
+  "$work/current/release.json" "$work/current/publication-manifest.json" \
+  "$work/current/Malibu-v1.8.65.dmg" "$work/current/appcast.xml" \
+  "$work/current/Malibu-v1.8.65.dmg.sha256" \
+  >"$work/current-drift.out" 2>&1; then
+  fail "current Malibu verifier accepted stale appcast bytes"
+fi
+grep -q 'publication manifest does not bind appcast.xml' "$work/current-drift.out" ||
+  fail "current stale appcast rejection was unclear"
+
 create_manifest "$work/input/prerelease.json" \
   "$work/input/Malibu-v1.8.39.dmg" "$work/input/appcast.xml" \
   "$work/input/compatibility-artifact-index.json" true >/dev/null
@@ -325,13 +408,13 @@ if MALIBU_PUBLICATION_TESTING=1 bash "$installer" \
   "$work/input/publication-manifest.json" "$work/input/Malibu-v1.8.39.dmg" \
   "$work/input/appcast.xml" "$work/input/Malibu-v1.8.39.dmg.sha256" \
   >"$work/tag.out" 2>&1; then
-  fail "bridge installer accepted a later tag"
+  fail "installer accepted mismatched publication identity"
 fi
-grep -q 'frozen to v1.8.39' "$work/tag.out" || fail "tag rejection was unclear"
+grep -q 'publication manifest identity mismatch' "$work/tag.out" || fail "tag rejection was unclear"
 
 if bash "$generator" v1.8.40 >"$work/generator.out" 2>&1; then
-  fail "bridge generator accepted a later tag"
+  fail "generator accepted a missing later DMG"
 fi
-grep -q 'frozen to v1.8.39' "$work/generator.out" || fail "generator tag rejection was unclear"
+grep -q 'missing dmg:' "$work/generator.out" || fail "generator later-tag path was unclear"
 
 echo 'Malibu bootstrap bridge regression checks passed'

--- a/scripts/test-release-security-posture.sh
+++ b/scripts/test-release-security-posture.sh
@@ -3,6 +3,7 @@ set -euo pipefail
 
 root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 workflow="$root/.github/workflows/release.yml"
+malibu_workflow="$root/.github/workflows/malibu-release.yml"
 guard="$root/scripts/verify-github-release-posture.sh"
 input_guard="$root/scripts/validate-release-inputs.sh"
 checksums_guard="$root/scripts/verify-release-checksums.sh"
@@ -23,6 +24,9 @@ decision_log="$root/beta/DECISION_CRITERIA.md"
 ci_workflow="$root/.github/workflows/ci.yml"
 sparkle_validator_integration="$root/scripts/test-malibu-sparkle-validator-integration.sh"
 sparkle_validator_patch="$root/scripts/fixtures/SUUpdateValidator-2.6.4-ephemeral.patch"
+current_publication_verifier="$root/scripts/verify-malibu-current-publication-set.sh"
+independent_publisher="$root/scripts/publish-independent-malibu-latest-dmg.sh"
+independent_recovery="$root/scripts/recover-independent-malibu-publication.sh"
 work="$(mktemp -d "${TMPDIR:-/tmp}/release-security-posture.XXXXXX")"
 trap 'rm -rf "$work"' EXIT
 
@@ -727,15 +731,14 @@ for requirement in (
     if requirement not in app_sign:
         raise SystemExit(f"Malibu signing omits trust-continuity guard: {requirement}")
 for requirement in (
-    'BRIDGE_TAG = "v1.8.39"',
-    'BRIDGE_VERSION = "1.8.39"',
-    'BRIDGE_BUILD = "39"',
     'EXPECTED_PUBLIC_KEY = "JkTDWnRJfOI3YIlpfJKvasWkxb0O1j/7ObGYiIA7big="',
-    "tag if tag == BRIDGE_TAG else None",
-    "tag != BRIDGE_TAG and version == BRIDGE_VERSION",
+    'TAG_PATTERN = re.compile(r"^v[0-9]+\\.[0-9]+\\.[0-9]+$")',
+    "TAG_PATTERN.fullmatch(tag)",
+    "validate_identity(document, tag)",
     'subparsers.add_parser("preflight")',
     'key.startswith("SU")',
     'document["SUPublicEDKey"] = key',
+    'found != ["SUPublicEDKey"]',
     "os.replace(temporary_path, path)",
     "stat.S_ISREG",
     "candidate.is_symlink()",
@@ -1738,8 +1741,10 @@ if xcodegen_digest not in xcodegen or xcodegen.find("shasum -a 256") > xcodegen.
 sparkle_digest = "50612a06038abc931f16011d7903b8326a362c1074dabccb718404ce8e585f0b"
 if sparkle_digest not in sparkle or sparkle.find("shasum -a 256") > sparkle.find("tar -xJf"):
     raise SystemExit("legacy Sparkle tools must be digest-pinned before extraction")
-if 'bridge_tag="v1.8.39"' not in sparkle or "SPARKLE_VERSION" in sparkle:
-    raise SystemExit("legacy appcast generator is not frozen to one tag and tool version")
+if '"$tag" =~ ^v[0-9]+\\.[0-9]+\\.[0-9]+$' not in sparkle or 'bridge_tag="v1.8.39"' in sparkle:
+    raise SystemExit("Malibu appcast generator must support current semver tags")
+if "sparkle_version=\"2.6.4\"" not in sparkle or "50612a06038abc931f16011d7903b8326a362c1074dabccb718404ce8e585f0b" not in sparkle:
+    raise SystemExit("Malibu appcast generator is not pinned to the reviewed Sparkle tool")
 key_lines = [line.strip() for line in legacy_key.splitlines() if line.strip() and not line.startswith("#")]
 if key_lines != ["JkTDWnRJfOI3YIlpfJKvasWkxb0O1j/7ObGYiIA7big="]:
     raise SystemExit("legacy public key differs from the SUPublicEDKey shipped in Malibu v1.8.32")
@@ -1977,5 +1982,87 @@ if PATH="$work/bin:$PATH" FIXTURE_DIR="$work/fixtures" GH_TOKEN=test \
   exit 1
 fi
 grep -q 'must allow only the main branch' "$work/policies.out"
+
+python3 - "$malibu_workflow" "$current_publication_verifier" "$independent_publisher" "$independent_recovery" "$release_runbook" "$root/specs/SPEC-025-native-mac-app.md" <<'PY'
+import pathlib
+import sys
+
+workflow = pathlib.Path(sys.argv[1]).read_text(encoding="utf-8")
+current_verifier = pathlib.Path(sys.argv[2]).read_text(encoding="utf-8")
+independent_publisher = pathlib.Path(sys.argv[3]).read_text(encoding="utf-8")
+independent_recovery = pathlib.Path(sys.argv[4]).read_text(encoding="utf-8")
+runbook = pathlib.Path(sys.argv[5]).read_text(encoding="utf-8")
+spec = pathlib.Path(sys.argv[6]).read_text(encoding="utf-8")
+
+required_workflow_markers = (
+    "prepare-malibu-bootstrap-trust-anchor.py prepare",
+    "prepare-malibu-bootstrap-trust-anchor.py verify",
+    "Generate verified Malibu appcast",
+    "SPARKLE_EDDSA_PRIVATE_KEY: ${{ secrets.SPARKLE_EDDSA_PRIVATE_KEY }}",
+    "DMG=\"$dmg\" APPCAST_OUT=\"$candidate/appcast.xml\"",
+    "scripts/generate-malibu-appcast.sh \"v${APP_VERSION}\"",
+    "scripts/verify-malibu-sparkle-signature.py",
+    '"appcast.xml"] | sort)',
+    "cmp -s \"$candidate/appcast.xml\" \"$RUNNER_TEMP/draft-download/appcast.xml\"",
+    "Publish current Malibu appcast to Pearl",
+    "MALIBU_DOWNLOAD_SSH_KEY: ${{ secrets.MALIBU_DOWNLOAD_SSH_KEY }}",
+    "scripts/publish-independent-malibu-latest-dmg.sh",
+)
+for marker in required_workflow_markers:
+    if marker not in workflow:
+        raise SystemExit(f"independent Malibu workflow omits appcast control: {marker}")
+reverify = workflow.split("- name: Reverify exact accepted bytes", 1)[1].split("\n      - name:", 1)[0]
+appcast_generation = workflow.split("- name: Generate verified Malibu appcast", 1)[1].split("\n      - name:", 1)[0]
+if "SPARKLE_EDDSA_PRIVATE_KEY" in reverify:
+    raise SystemExit("Sparkle signing key must not be scoped to candidate executable verification")
+if "SPARKLE_EDDSA_PRIVATE_KEY" not in appcast_generation:
+    raise SystemExit("appcast generation must be the only independent release step with the Sparkle signing key")
+if workflow.find("Publish current Malibu appcast to Pearl") < workflow.find("Publish only the revalidated draft"):
+    raise SystemExit("independent Malibu appcast must publish only after immutable GitHub publication")
+for marker in (
+    'release.get("immutable") is not True',
+    '"appcast_sha256": local["appcast.xml"]',
+    '"sha256_sidecar_sha256"',
+    'checksum_path.name != f"{dmg_name}.sha256"',
+    "verify-malibu-sparkle-signature.py",
+    "verify-malibu-release-artifacts.sh",
+):
+    if marker not in current_verifier:
+        raise SystemExit(f"current Malibu publication verifier omits: {marker}")
+for marker in (
+    "verify-malibu-current-publication-set.sh",
+    "install-malibu-publication.sh",
+    "verify-malibu-bootstrap-publication.sh",
+    '"$tag" "$asset" "$appcast" "$checksum"',
+    "stat -c '%u:%g:%a:%h:%F'",
+):
+    if marker not in independent_publisher:
+        raise SystemExit(f"independent Malibu publisher omits: {marker}")
+for marker in (
+    "release.get(\"immutable\") is not True",
+    "gh release download \"$tag\"",
+    "publish-independent-malibu-latest-dmg.sh",
+    "recovery must run from the exact release commit",
+    "release asset digest mismatch",
+):
+    if marker not in independent_recovery:
+        raise SystemExit(f"independent Malibu recovery omits: {marker}")
+for marker in (
+    "recover-independent-malibu-publication.sh",
+    "versioned SHA-256 sidecar",
+    "one member of the DMG/appcast/checksum set",
+):
+    if marker not in runbook:
+        raise SystemExit(f"release runbook omits independent appcast recovery control: {marker}")
+for stale in (
+    "Later app updates are\nowned by the signed CLI compatibility transaction",
+    "every later Malibu build\nmust omit the key",
+    "version must omit the key again",
+    "the `download.malibu.tech` endpoint is retired",
+    "a retired mutable endpoint",
+):
+    if stale in spec or stale in runbook:
+        raise SystemExit(f"Malibu appcast contract still contains stale v1.8.39-only wording: {stale}")
+PY
 
 echo "release security posture regression checks passed"

--- a/scripts/verify-malibu-bootstrap-publication.sh
+++ b/scripts/verify-malibu-bootstrap-publication.sh
@@ -6,12 +6,13 @@ die() {
   exit 1
 }
 
-[[ "$#" == 3 ]] || die "usage: TAG DMG APPCAST"
+[[ "$#" == 4 ]] || die "usage: TAG DMG APPCAST SHA256"
 tag="$1"
 dmg="$2"
 appcast="$3"
-[[ "$tag" == v1.8.39 ]] || die "legacy Malibu publication is frozen to v1.8.39"
-for path in "$dmg" "$appcast"; do
+checksum="$4"
+[[ "$tag" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]] || die "tag must be vX.Y.Z"
+for path in "$dmg" "$appcast" "$checksum"; do
   [[ -f "$path" && ! -L "$path" ]] || die "expected a regular publication input: $path"
 done
 
@@ -30,6 +31,10 @@ sha256_file() {
 
 expected_dmg_sha="$(sha256_file "$dmg")"
 expected_appcast_sha="$(sha256_file "$appcast")"
+expected_checksum_sha="$(sha256_file "$checksum")"
+expected_checksum_bytes="${expected_dmg_sha}  Malibu-${tag}.dmg"
+[[ "$(cat "$checksum")" == "$expected_checksum_bytes" ]] ||
+  die "versioned DMG checksum file is invalid"
 curl_args=(
   --fail --show-error --silent --location --proto '=https' --tlsv1.2
   --connect-timeout 20 --max-time 240 --retry 3 --retry-delay 2
@@ -39,6 +44,8 @@ curl "${curl_args[@]}" -o "$work/appcast.xml" "${base}/appcast.xml?${cache_key}"
 curl "${curl_args[@]}" -o "$work/latest.dmg" "${base}/latest.dmg?${cache_key}"
 curl "${curl_args[@]}" -o "$work/Malibu-${tag}.dmg" \
   "${base}/Malibu-${tag}.dmg?${cache_key}"
+curl "${curl_args[@]}" -o "$work/Malibu-${tag}.dmg.sha256" \
+  "${base}/Malibu-${tag}.dmg.sha256?${cache_key}"
 
 [[ "$(sha256_file "$work/appcast.xml")" == "$expected_appcast_sha" ]] ||
   die "public appcast bytes differ from the immutable release asset"
@@ -46,10 +53,14 @@ for published_dmg in "$work/latest.dmg" "$work/Malibu-${tag}.dmg"; do
   [[ "$(sha256_file "$published_dmg")" == "$expected_dmg_sha" ]] ||
     die "public DMG bytes differ from the immutable release asset: $published_dmg"
 done
+[[ "$(sha256_file "$work/Malibu-${tag}.dmg.sha256")" == "$expected_checksum_sha" ]] ||
+  die "public checksum bytes differ from the immutable release asset"
+[[ "$(cat "$work/Malibu-${tag}.dmg.sha256")" == "$expected_checksum_bytes" ]] ||
+  die "public checksum contents do not match the immutable release DMG"
 
 repo_root="$(cd "$(dirname "$0")/.." && pwd)"
 python3 "$repo_root/scripts/verify-malibu-sparkle-signature.py" \
   "$tag" "$work/latest.dmg" "$work/appcast.xml" \
   "$repo_root/scripts/dist/malibu-v1.8.32-sparkle-public-key"
 
-printf '[verify-malibu-bootstrap-publication] ok: %s is the exact v1.8.39 bridge\n' "$base"
+printf '[verify-malibu-bootstrap-publication] ok: %s serves %s latest/appcast/checksum bytes\n' "$base" "$tag"

--- a/scripts/verify-malibu-current-publication-set.sh
+++ b/scripts/verify-malibu-current-publication-set.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+die() {
+  printf '[verify-malibu-current-publication-set] ERROR: %s\n' "$*" >&2
+  exit 1
+}
+
+[[ "$#" == 5 ]] || die "usage: RELEASE_JSON MANIFEST DMG APPCAST SHA256"
+release_json="$1"
+manifest="$2"
+dmg="$3"
+appcast="$4"
+checksum="$5"
+repo_root="$(cd "$(dirname "$0")/.." && pwd)"
+
+for path in "$release_json" "$manifest" "$dmg" "$appcast" "$checksum"; do
+  [[ -f "$path" && ! -L "$path" ]] || die "publication input is not a regular file: $path"
+done
+
+identity="$(
+  python3 - "$release_json" "$manifest" "$dmg" "$appcast" "$checksum" <<'PY'
+import hashlib
+import json
+import pathlib
+import re
+import sys
+
+release_path, manifest_path, dmg_path, appcast_path, checksum_path = map(pathlib.Path, sys.argv[1:])
+release = json.loads(release_path.read_text(encoding="utf-8"))
+manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+if manifest.get("schema_version") != 1:
+    raise SystemExit("unsupported manifest schema")
+if manifest.get("repository") != "Augustas11/macprovider":
+    raise SystemExit("publication manifest repository mismatch")
+tag = manifest.get("tag")
+commit = manifest.get("commit")
+if not isinstance(tag, str) or not re.fullmatch(r"v\d+\.\d+\.\d+", tag):
+    raise SystemExit("invalid publication tag")
+if not isinstance(commit, str) or not re.fullmatch(r"[0-9a-f]{40}", commit):
+    raise SystemExit("invalid publication commit")
+if manifest.get("prerelease") is not False:
+    raise SystemExit("prerelease must not publish the stable Malibu feed")
+release_id = manifest.get("release_id")
+if type(release_id) is not int or release_id <= 0:
+    raise SystemExit("invalid numeric release id")
+if (
+    release.get("id") != release_id
+    or release.get("tag_name") != tag
+    or release.get("target_commitish") != commit
+    or release.get("draft") is not False
+    or release.get("prerelease") is not False
+    or release.get("immutable") is not True
+):
+    raise SystemExit("GitHub release does not match the immutable Malibu publication")
+
+dmg_name = f"Malibu-{tag}.dmg"
+if dmg_path.name != dmg_name or appcast_path.name != "appcast.xml" or checksum_path.name != f"{dmg_name}.sha256":
+    raise SystemExit("publication filenames do not match the tag")
+local = {
+    dmg_path.name: hashlib.sha256(dmg_path.read_bytes()).hexdigest(),
+    appcast_path.name: hashlib.sha256(appcast_path.read_bytes()).hexdigest(),
+    checksum_path.name: hashlib.sha256(checksum_path.read_bytes()).hexdigest(),
+}
+if checksum_path.read_text(encoding="utf-8") != f"{local[dmg_path.name]}  {dmg_path.name}\n":
+    raise SystemExit("versioned DMG checksum file is invalid")
+assets = manifest.get("assets")
+if not isinstance(assets, dict):
+    raise SystemExit("publication asset map is invalid")
+release_assets = release.get("assets")
+if not isinstance(release_assets, list):
+    raise SystemExit("release asset list is invalid")
+release_by_name = {asset.get("name"): asset for asset in release_assets if isinstance(asset, dict)}
+for name, digest in local.items():
+    row = assets.get(name)
+    release_row = release_by_name.get(name)
+    if not isinstance(row, dict) or type(row.get("id")) is not int or row.get("sha256") != digest:
+        raise SystemExit(f"publication manifest does not bind {name}")
+    if not isinstance(release_row, dict) or release_row.get("id") != row["id"]:
+        raise SystemExit(f"release asset id mismatch for {name}")
+    if release_row.get("digest") != f"sha256:{digest}":
+        raise SystemExit(f"release asset digest mismatch for {name}")
+content = json.dumps(
+    {
+        "appcast_sha256": local["appcast.xml"],
+        "dmg_sha256": local[dmg_name],
+        "sha256_sidecar_sha256": local[f"{dmg_name}.sha256"],
+    },
+    sort_keys=True,
+    separators=(",", ":"),
+).encode()
+if manifest.get("publication_id") != hashlib.sha256(content).hexdigest():
+    raise SystemExit("publication id is not the deterministic content digest")
+print(tag, commit)
+PY
+)"
+read -r tag commit <<< "$identity"
+
+python3 "$repo_root/scripts/verify-malibu-sparkle-signature.py" \
+  "$tag" "$dmg" "$appcast" \
+  "$repo_root/scripts/dist/malibu-v1.8.32-sparkle-public-key"
+if [[ -n "${EXPECTED_CLI_SHA256:-}" ]]; then
+  bash "$repo_root/scripts/verify-malibu-release-artifacts.sh" \
+    "$dmg" --expected-cli-sha256 "$EXPECTED_CLI_SHA256"
+fi
+
+printf '[verify-malibu-current-publication-set] ok: release %s (%s)\n' "$tag" "$commit"

--- a/scripts/verify-malibu-publication-set.sh
+++ b/scripts/verify-malibu-publication-set.sh
@@ -33,7 +33,8 @@ print(value.get("repository", ""), value.get("tag", ""), value.get("commit", "")
 PY
 )"
 read -r expected_repository expected_tag expected_commit <<< "$expected_identity"
-[[ "$expected_tag" == v1.8.39 ]] || die "legacy Malibu publication is frozen to v1.8.39"
+[[ "$expected_tag" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]] || die "publication tag must be vX.Y.Z"
+[[ "$expected_tag" == v1.8.39 ]] || die "legacy provider-coupled Malibu publication is frozen to v1.8.39"
 bash "$repo_root/scripts/verify-release-checksums.sh" \
   --allow-partial --openssl "$openssl_bin" \
   "$checksums" "$signature" "$provenance" \
@@ -61,8 +62,6 @@ tag = manifest.get("tag")
 commit = manifest.get("commit")
 if not isinstance(tag, str) or not re.fullmatch(r"v\d+\.\d+\.\d+", tag):
     raise SystemExit("invalid publication tag")
-if tag != "v1.8.39":
-    raise SystemExit("legacy Malibu publication is frozen to v1.8.39")
 if not isinstance(commit, str) or not re.fullmatch(r"[0-9a-f]{40}", commit):
     raise SystemExit("invalid publication commit")
 if type(manifest.get("release_id")) is not int or manifest["release_id"] <= 0:

--- a/scripts/verify-malibu-sparkle-signature.py
+++ b/scripts/verify-malibu-sparkle-signature.py
@@ -18,8 +18,13 @@ tag, dmg_name, appcast_name, public_key_name = sys.argv[1:]
 dmg = pathlib.Path(dmg_name)
 appcast = pathlib.Path(appcast_name)
 public_key_path = pathlib.Path(public_key_name)
-if tag != "v1.8.39":
-    fail("legacy Malibu bootstrap is frozen to v1.8.39")
+if not tag.startswith("v"):
+    fail("tag must use a v prefix")
+short_version = tag[1:]
+parts = short_version.split(".")
+if len(parts) != 3 or not all(part.isdigit() for part in parts):
+    fail("tag must be vX.Y.Z")
+build_version = str(int(parts[2]))
 if any(
     not path.is_file() or path.is_symlink()
     for path in (dmg, appcast, public_key_path)
@@ -35,11 +40,11 @@ items = root.findall("./channel/item")
 if len(items) != 1:
     fail("appcast must contain exactly one item")
 short_versions = items[0].findall(f"{{{namespace}}}shortVersionString")
-if len(short_versions) != 1 or (short_versions[0].text or "").strip() != "1.8.39":
-    fail("appcast short version differs from the bootstrap target")
+if len(short_versions) != 1 or (short_versions[0].text or "").strip() != short_version:
+    fail("appcast short version differs from the release target")
 build_versions = items[0].findall(f"{{{namespace}}}version")
-if len(build_versions) != 1 or (build_versions[0].text or "").strip() != "39":
-    fail("appcast build version differs from the bootstrap target")
+if len(build_versions) != 1 or (build_versions[0].text or "").strip() != build_version:
+    fail("appcast build version differs from the release target")
 enclosures = items[0].findall("enclosure")
 if len(enclosures) != 1:
     fail("appcast must contain exactly one enclosure")

--- a/specs/SPEC-025-native-mac-app.md
+++ b/specs/SPEC-025-native-mac-app.md
@@ -6,7 +6,8 @@ Status: DRAFT v0.22 · Owner: augstar · Target: 2026 Q3
 public **Download for Mac** button to the immutable versioned GitHub release asset
 for the accepted release, matching §6 step 11 and the v0.13 removal of `latest.dmg`
 authority. §10 previously still specified `https://download.malibu.tech/latest.dmg`,
-a retired mutable endpoint; the shipped page combined that stale button with a
+which is retained only for old-client compatibility and retired as the primary
+landing-page download authority; the shipped page combined that stale button with a
 version and SHA-256 fetched live from the GitHub API, so it advertised the current
 release's digest while serving v1.8.53 bytes. The tag, digest, and link MUST now all
 resolve from one pinned accepted release. P4 in §11 is reconciled to match.
@@ -80,15 +81,14 @@ protocol capabilities and schema versions, not marketing-version equality,
 govern referral UI availability.
 
 **Change log v0.14 (2026-07-15, issue #585 bootstrap trust continuity).**
-Stable Malibu 1.8.39 is the only CLI-owned build whose signed app bundle retains
-the exact `SUPublicEDKey` shipped by Malibu 1.8.32. Sparkle 2.6.4 rejects an
-otherwise valid update when the target bundle removes that key, so the protected
-release injects the frozen public key after unsigned app construction, before
-protected bundle writes, and re-verifies it after bundling before codesigning. The
-target still contains no Sparkle package/framework, feed URL, automatic-check
-setting, or updater runtime; the key is inert trust metadata for the one legacy
-hop. Final-DMG verification requires that exact posture, and every later Malibu
-version must omit the key again.
+Malibu 1.8.39 was the first CLI-owned build whose signed app bundle retained the
+exact `SUPublicEDKey` shipped by Malibu 1.8.32. Sparkle 2.6.4 rejects an
+otherwise valid update when the target bundle removes that key, so protected
+Malibu releases inject the frozen public key after unsigned app construction,
+before protected bundle writes, and re-verify it after bundling before
+codesigning. The target still contains no Sparkle package/framework, feed URL,
+automatic-check setting, or updater runtime; the key is inert trust metadata for
+old-client compatibility. Final-DMG verification requires that exact posture.
 
 **Change log v0.13 (2026-07-14, issue #585 Option 2 completion).** The
 launchd-managed CLI is the sole provider lifecycle, credential, admission-identity,
@@ -98,10 +98,12 @@ control-socket projection for CLI-authenticated earnings, and invokes only the s
 installed CLI's typed repair/update/uninstall transactions. A legacy App-Keychain
 bearer may be read once as migration input, but is deleted only after fresh CLI custody
 is proven; production Malibu cannot create a provider bearer, register an identity, or
-sign coordinator admission. Sparkle, appcast publication, `latest.dmg`, and independent
-App update ownership are removed. The signed compatibility set binds Malibu.app, the
-CLI, launchd definitions, watchdog, catalog/resources, coordinator admission metadata,
-and rollback plan. v0.18 supersedes v0.13's target-admission commit gate with
+sign coordinator admission. Sparkle runtime/feed ownership and independent App update
+ownership are removed; later old-client compatibility publication may still use a
+signed appcast/`latest.dmg` surface as distribution metadata, not as Malibu-owned update
+authority. The signed compatibility set binds Malibu.app, the CLI, launchd definitions,
+watchdog, catalog/resources, coordinator admission metadata, and rollback plan. v0.18
+supersedes v0.13's target-admission commit gate with
 SPEC-020's local signed-set/health commit and separate network-readiness result.
 Auto-update opt-out applies to the entire set while explicit user update remains
 available. **Every older statement below that assigns credentials, identity,
@@ -500,10 +502,11 @@ time (60–240 s for the first model) in the background.
 - The launchd CLI owns both scheduled and user-requested updates. Malibu's menu and
   dashboard invoke `macprovider-cli update`; they do not download or replace artifacts.
   Removing the Sparkle dependency/runtime and feed settings eliminates the prior
-  second update authority. Stable v1.8.39 alone retains the frozen 1.8.32
-  `SUPublicEDKey` in its signed target bundle because Sparkle 2.6.4 requires key
-  continuity after extraction; without Sparkle code or a feed, this public key cannot
-  initiate an update. Later builds must omit it.
+  second update authority. Independent Malibu release publication still emits a signed
+  public appcast and `latest.dmg` compatibility surface for already-installed Sparkle
+  clients. Every signed Malibu target retains only the frozen 1.8.32 `SUPublicEDKey`
+  because Sparkle 2.6.4 requires key continuity after extraction; without Sparkle code
+  or a feed URL in the target bundle, this public key cannot initiate future updates.
 - The updater acquires the maintenance lease, persists a phase journal and exact
   typed rollback plan, stages and validates the target, drains buyer work,
   installs the whole set, restarts launchd, and commits only after exact signed
@@ -716,9 +719,11 @@ Runs on the same macOS runner as the existing job, after the CLI binary is signe
 10. Build the exact compatibility-set manifest and typed rollback plan, then place the
     DMG and every provider runtime/policy artifact in the signed
     `compatibility-artifact-index.json`.
-11. Publish only immutable versioned GitHub release artifacts; the updater discovers
-    the signed exact set through the coordinator/catalog trust path. There is no mutable
-    `latest.dmg` or appcast authority.
+11. Publish immutable versioned GitHub release artifacts, including `appcast.xml` for
+    old-client compatibility, then atomically publish the exact DMG, SHA-256 sidecar,
+    and appcast bytes to `download.malibu.tech`. The updater discovers signed provider
+    sets through the coordinator/catalog trust path; the appcast is not a second CLI
+    update authority.
 
 Reuse `cleanup_signing_material` trap from the existing job.
 
@@ -864,9 +869,9 @@ try SMAppService.mainApp.register()   // the APP login item, not the CLI daemon
 - The CLI verifies the catalog/release trust chain, artifact-index signature, exact set
   identity, per-role uniqueness, hashes, Developer ID identity/team where applicable,
   launchd labels, and target coordinator policy before any drain or replacement.
-- Malibu carries no feed URL or independent discovery channel. Stable v1.8.39
-  alone carries the frozen v1.8.32 public key as inert trust-continuity metadata;
-  it has no Sparkle runtime, and later builds carry no app-update public key.
+- Malibu carries no feed URL or independent in-app discovery channel. Signed
+  release targets carry the frozen v1.8.32 public key as inert trust-continuity
+  metadata for old Sparkle clients; they have no Sparkle runtime or feed URL.
   Failure to verify or fetch any required member leaves the current set running and
   emits a typed redacted update state. A staged target that fails exact signed-set
   identity, launch, or local provider health enters SPEC-020 rollback recovery.
@@ -906,7 +911,7 @@ model (run `install.sh`, monitor over HTTP). See §3.1 and §5 for the shipped f
 | **P1 — Onboarding** (1 wk) | `malibu://` URL scheme; portal deep-link flow; wallet paste; hardware autotune call; `SMAppService.register()`; dashboard read-only. | 5 friendly testers install by drag-drop and start earning without CLI. |
 | **P2 — `.app`/`.dmg` signing** (0.5 wk) | **Extend** existing `release.yml` "Sign + notarize binary" step with the App-track substeps in §6.2. Verify entitlements + hardened runtime. No new secrets except `SPARKLE_EDDSA_PRIVATE_KEY`. | Gatekeeper accepts `.dmg` on a fresh macOS 14 install (no `xattr -d`); `stapler validate` passes. |
 | **P3 — Sparkle + updates** (0.5 wk) | Appcast, EdDSA signing key, delta patches, phased rollout. | Live `v0.1 → v0.2` update on 5 test Macs, one via delta patch. |
-| **P4 — Landing page swap** (0.5 wk) | Redesigned `host/index.html` pinned to the immutable release asset (the `download.malibu.tech` endpoint is retired, superseded v0.22), SHA-256 sidecar, troubleshoot page. | 50/50 A/B against current curl page for 1 wk on `malibu.tech/host`. |
+| **P4 — Landing page swap** (0.5 wk) | Redesigned `host/index.html` pinned to immutable release assets so the landing-page primary download no longer depends on mutable `latest.dmg`; `download.malibu.tech` remains the old-client compatibility appcast/DMG surface. | 50/50 A/B against current curl page for 1 wk on `malibu.tech/host`. |
 | **P5 — WalletConnect** (1 wk) | Alongside paste flow; opens Rainbow / MetaMask / Coinbase Wallet via deep link; nonce signature bound to provider_id server-side. | 3 wallets verified round-trip. |
 | **P6 — Homebrew Cask** (0.5 wk) | `brew install --cask malibu` pulls the same signed `.dmg`. | `brew audit --cask malibu` clean, install / uninstall round-trip. |
 


### PR DESCRIPTION
## Summary

Fixes #922.

This makes the independent Malibu release path generate and verify a current signed `appcast.xml`, include it in the immutable GitHub release asset set, and publish `latest.dmg`, the versioned DMG, the versioned SHA-256 sidecar, and appcast bytes to Pearl as one verified publication.

Key changes:
- Generalize appcast generation/signature verification from the historical `v1.8.39` bridge to current semver Malibu releases.
- Inject and verify the frozen `SUPublicEDKey` in signed Malibu targets so old Sparkle clients can validate the extracted target, while preserving no Sparkle runtime/feed URL.
- Add `verify-malibu-current-publication-set.sh`, `publish-independent-malibu-latest-dmg.sh`, and `recover-independent-malibu-publication.sh` for the independent Malibu path.
- Keep the older provider-coupled Malibu publisher/verifier frozen to `v1.8.39` so operators do not get a second current publication path.
- Update SPEC-025 and the release runbook to describe the current compatibility appcast/latest surface and post-immutable Pearl recovery.

## Validation

- `bash -n` on changed shell scripts
- `shellcheck` on changed shell scripts
- `PYTHONDONTWRITEBYTECODE=1 python3 -m py_compile scripts/prepare-malibu-bootstrap-trust-anchor.py scripts/verify-malibu-sparkle-signature.py`
- YAML parse for `.github/workflows/malibu-release.yml`
- `git diff --check`
- `bash scripts/test-malibu-bootstrap-bridge.sh`
- `bash scripts/test-release-security-posture.sh`
- `bash scripts/test-malibu-independent-release.sh`
- `bash scripts/test-release-publication-provenance.sh`
- `bash scripts/test-malibu-sparkle-generator-integration.sh`
- `bash scripts/test-malibu-sparkle-validator-integration.sh`

## Audits

Ran three Codex lanes on the full diff until zero Critical/High/Medium findings:
- code correctness: zero findings
- security: zero findings
- architecture: zero findings after recovery/spec follow-ups

## Not tested

- Live GitHub release publication and live Pearl SSH upload were not executed from this branch.

SPEC-GOVERNANCE-DECLARATION-BEGIN
{
  "schema_version": "spec-pr-governance-v1",
  "behavior_change": "yes",
  "contract_change": "yes",
  "specs": ["SPEC-020", "SPEC-025"],
  "requirements": ["SPEC-020-R001", "SPEC-020-R002"],
  "authority_domains": ["provider-autoupdate", "native-app-lifecycle"],
  "arbitration": ["CODE_BUG"],
  "tests": [
    "scripts/test-malibu-bootstrap-bridge.sh",
    "scripts/test-release-security-posture.sh",
    "scripts/test-malibu-independent-release.sh",
    "scripts/test-release-publication-provenance.sh",
    "scripts/test-malibu-sparkle-generator-integration.sh",
    "scripts/test-malibu-sparkle-validator-integration.sh"
  ],
  "journeys": ["not-required"],
  "issue": "https://github.com/Augustas11/macprovider/issues/922"
}
SPEC-GOVERNANCE-DECLARATION-END
