### PR TITLE
Fix Malibu provider release publication and app versioning

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -222,6 +222,27 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
+          tag="${{ steps.release_source.outputs.tag }}"
+          version="${tag#v}"
+          [[ "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] || {
+            echo "::error::release tag does not contain a semantic Malibu version: $tag" >&2
+            exit 1
+          }
+          build="$(awk -v version="$version" '
+            $0 !~ /^[[:space:]]*#/ && NF >= 2 && $1 == version {
+              count += 1
+              value = $2
+            }
+            END {
+              if (count != 1 || value !~ /^[0-9]+$/) {
+                exit 1
+              }
+              print value
+            }
+          ' phase3-binary/app/release-builds.tsv)" || {
+            echo "::error::phase3-binary/app/release-builds.tsv must contain exactly one numeric build for Malibu $version" >&2
+            exit 1
+          }
           cd phase3-binary/app
           "$RUNNER_TEMP/xcodegen-2.45.4/xcodegen/bin/xcodegen" generate
           xcodebuild \
@@ -232,9 +253,17 @@ jobs:
             -archivePath "$RUNNER_TEMP/Malibu.xcarchive" \
             archive \
             ARCHS=arm64 \
-            CODE_SIGNING_ALLOWED=NO
+            CODE_SIGNING_ALLOWED=NO \
+            MARKETING_VERSION="$version" \
+            CURRENT_PROJECT_VERSION="$build"
           cp -R "$RUNNER_TEMP/Malibu.xcarchive/Products/Applications/Malibu.app" \
             "$RUNNER_TEMP/Malibu.app"
+          actual_version="$(/usr/libexec/PlistBuddy -c 'Print :CFBundleShortVersionString' "$RUNNER_TEMP/Malibu.app/Contents/Info.plist")"
+          actual_build="$(/usr/libexec/PlistBuddy -c 'Print :CFBundleVersion' "$RUNNER_TEMP/Malibu.app/Contents/Info.plist")"
+          [[ "$actual_version" = "$version" && "$actual_build" = "$build" ]] || {
+            echo "::error::Malibu.app Info.plist reports $actual_version/$actual_build, expected $version/$build" >&2
+            exit 1
+          }
 
       - name: Capture unsigned build artifact
         if: ${{ github.event.inputs.promote_run_id == '' }}
@@ -825,6 +854,28 @@ jobs:
             exit 1
           fi
           test -d "$APP"
+          version="${tag#v}"
+          build="$(awk -v version="$version" '
+            $0 !~ /^[[:space:]]*#/ && NF >= 2 && $1 == version {
+              count += 1
+              value = $2
+            }
+            END {
+              if (count != 1 || value !~ /^[0-9]+$/) {
+                exit 1
+              }
+              print value
+            }
+          ' phase3-binary/app/release-builds.tsv)" || {
+            echo "::error::phase3-binary/app/release-builds.tsv must contain exactly one numeric build for Malibu $version" >&2
+            exit 1
+          }
+          actual_version="$(/usr/libexec/PlistBuddy -c 'Print :CFBundleShortVersionString' "$APP/Contents/Info.plist")"
+          actual_build="$(/usr/libexec/PlistBuddy -c 'Print :CFBundleVersion' "$APP/Contents/Info.plist")"
+          [[ "$actual_version" = "$version" && "$actual_build" = "$build" ]] || {
+            echo "::error::Malibu.app Info.plist reports $actual_version/$actual_build, expected $version/$build" >&2
+            exit 1
+          }
 
           security list-keychains | grep -q build.keychain || {
             echo "::error::build.keychain absent; CLI signing step cleanup ran too early." >&2
@@ -1866,11 +1917,14 @@ jobs:
             "${release_assets[@]}" checksums.txt checksums.txt.sig
           cmp final-draft-manifest.json publication-manifest.json
 
-      - name: Publish one-time Malibu 1.8.32 bootstrap bridge to Pearl
-        if: needs.build.outputs.tag == 'v1.8.39' && needs.build.outputs.prerelease == 'false'
+      - name: Publish Malibu download alias to Pearl
+        if: needs.build.outputs.prerelease == 'false'
         env:
           MALIBU_DOWNLOAD_VPS_HOST: ${{ secrets.MALIBU_DOWNLOAD_VPS_HOST }}
           MALIBU_DOWNLOAD_SSH_KEY: ${{ secrets.MALIBU_DOWNLOAD_SSH_KEY }}
+          MALIBU_PUBLICATION_EXPECTED_REPOSITORY: ${{ github.repository }}
+          MALIBU_PUBLICATION_ALLOW_PREVIOUS_STABLE: "1.8.82"
+          MALIBU_PUBLICATION_STAGED_CANDIDATE: "1.8.88"
           OPENSSL_BIN: ${{ steps.protected_openssl.outputs.bin }}
         shell: bash
         run: |
@@ -1885,10 +1939,19 @@ jobs:
           chmod 600 "$key_file"
           export MALIBU_DOWNLOAD_SSH_KEY="$key_file"
           tag="${{ needs.build.outputs.tag }}"
+          if [ "$tag" = v1.8.39 ]; then
+            appcast="appcast.xml"
+          else
+            appcast="scripts/dist/malibu-frozen-bridge-appcast.xml"
+            if [ -e appcast.xml ]; then
+              echo "::error::current provider release must not publish a generated appcast asset" >&2
+              exit 1
+            fi
+          fi
           bash scripts/publish-malibu-latest-dmg.sh \
-            publication-manifest.json "Malibu-${tag}.dmg" appcast.xml \
+            publication-manifest.json "Malibu-${tag}.dmg" "$appcast" \
             compatibility-artifact-index.json checksums.txt checksums.txt.sig \
-            release-provenance.json
+            release-provenance.json macprovider-release-discovery.json
 
       - name: Verify published Tier-2 Release assets
         shell: bash

--- a/phase3-binary/app/project.yml
+++ b/phase3-binary/app/project.yml
@@ -23,8 +23,8 @@ settings:
     SWIFT_VERSION: "5.9"
     ENABLE_HARDENED_RUNTIME: YES
     CODE_SIGN_STYLE: Manual
-    MARKETING_VERSION: "1.8.50"
-    CURRENT_PROJECT_VERSION: "50"
+    MARKETING_VERSION: "1.8.88"
+    CURRENT_PROJECT_VERSION: "88"
     OTHER_SWIFT_FLAGS: "-strict-concurrency=complete"
 
 targets:

--- a/phase3-binary/app/release-builds.tsv
+++ b/phase3-binary/app/release-builds.tsv
@@ -2,8 +2,8 @@
 #
 # Append one strictly increasing entry for every Malibu release. The baseline
 # records the last correctly versioned release before this ledger was added;
-# releases v1.8.22-v1.8.25 reused stale app metadata and are intentionally not
-# represented as valid Malibu releases.
+# releases v1.8.22-v1.8.25 and v1.8.51-v1.8.87 reused stale app metadata and
+# are intentionally not represented as valid Malibu releases.
 1.8.21	20
 1.8.26	26
 1.8.27	27
@@ -28,3 +28,4 @@
 1.8.46	46
 1.8.47	47
 1.8.50	50
+1.8.88	88

--- a/scripts/capture-release-publication.py
+++ b/scripts/capture-release-publication.py
@@ -160,6 +160,13 @@ else:
     }
     if "appcast.xml" in local_assets:
         publication_content["appcast_sha256"] = local_assets["appcast.xml"][1]
+release_sequence = None
+if not runtime_only and "macprovider-release-discovery.json" in local_assets:
+    discovery = json.loads(local_assets["macprovider-release-discovery.json"][0].read_text(encoding="utf-8"))
+    release_sequence = discovery.get("signed", {}).get("release_sequence")
+    if type(release_sequence) is not int or release_sequence <= 0:
+        fail("release discovery sequence is invalid")
+    publication_content["release_sequence"] = release_sequence
 content = json.dumps(
     publication_content,
     sort_keys=True,
@@ -177,6 +184,8 @@ manifest = {
     "publication_id": publication_id,
     "assets": manifest_assets,
 }
+if release_sequence is not None:
+    manifest["release_sequence"] = release_sequence
 if body_sha256 is not None:
     manifest["title"] = expected_title
     manifest["body_sha256"] = body_sha256

--- a/scripts/dist/malibu-frozen-bridge-appcast.xml
+++ b/scripts/dist/malibu-frozen-bridge-appcast.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" standalone="yes"?>
+<rss xmlns:sparkle="http://www.andymatuschak.org/xml-namespaces/sparkle" version="2.0">
+    <channel>
+        <title>Malibu</title>
+        <item>
+            <title>1.8.39</title>
+            <pubDate>Wed, 15 Jul 2026 17:03:05 +0000</pubDate>
+            <sparkle:version>39</sparkle:version>
+            <sparkle:shortVersionString>1.8.39</sparkle:shortVersionString>
+            <sparkle:minimumSystemVersion>14.0</sparkle:minimumSystemVersion>
+            <enclosure url="https://download.malibu.tech/Malibu-v1.8.39.dmg" length="16255202" type="application/octet-stream" sparkle:edSignature="eal8O0OWZwgJfn0MLtpgonYB/VJbEf1raoVyZjnSBxSVfdnz1LDK6hscPo8TM/g2gHNtVKS+GUfautkXxmwLBw=="/>
+        </item>
+    </channel>
+</rss>

--- a/scripts/install-malibu-publication.sh
+++ b/scripts/install-malibu-publication.sh
@@ -38,6 +38,9 @@ import pathlib
 import stat
 import sys
 
+FROZEN_BRIDGE_APPCAST_SHA256 = "94ecf57584a2a203336d3219ea42dec1945bae2e123cfce0b1b39f8e0231d83c"
+EXPECTED_REPOSITORY = "Augustas11/macprovider"
+
 testing, trusted_uid, manifest_name, dmg_name, appcast_name, sha_name, tag, publication_id = sys.argv[1:]
 trusted_uid = int(trusted_uid)
 paths = [pathlib.Path(value) for value in (manifest_name, dmg_name, appcast_name, sha_name)]
@@ -53,16 +56,33 @@ for path in paths:
 manifest = json.loads(paths[0].read_text(encoding="utf-8"))
 if manifest.get("schema_version") != 1 or manifest.get("tag") != tag or manifest.get("publication_id") != publication_id:
     raise SystemExit("publication manifest identity mismatch")
+if manifest.get("repository") != EXPECTED_REPOSITORY:
+    raise SystemExit("publication repository is not the expected Malibu repository")
 if manifest.get("prerelease") is not False:
     raise SystemExit("prerelease must not publish the stable Malibu feed")
 assets = manifest.get("assets")
-expected_names = [f"Malibu-{tag}.dmg", "appcast.xml"]
-for path, name in zip(paths[1:3], expected_names):
-    row = assets.get(name) if isinstance(assets, dict) else None
-    digest = hashlib.sha256(path.read_bytes()).hexdigest()
-    if not isinstance(row, dict) or row.get("sha256") != digest or type(row.get("id")) is not int:
-        raise SystemExit(f"publication manifest does not bind {name}")
-expected_checksum = f"{hashlib.sha256(paths[1].read_bytes()).hexdigest()}  {expected_names[0]}\n"
+dmg_asset_name = f"Malibu-{tag}.dmg"
+dmg_digest = hashlib.sha256(paths[1].read_bytes()).hexdigest()
+appcast_digest = hashlib.sha256(paths[2].read_bytes()).hexdigest()
+dmg_row = assets.get(dmg_asset_name) if isinstance(assets, dict) else None
+if not isinstance(dmg_row, dict) or dmg_row.get("sha256") != dmg_digest or type(dmg_row.get("id")) is not int:
+    raise SystemExit(f"publication manifest does not bind {dmg_asset_name}")
+if tag == "v1.8.39":
+    appcast_row = assets.get("appcast.xml") if isinstance(assets, dict) else None
+    if not isinstance(appcast_row, dict) or appcast_row.get("sha256") != appcast_digest or type(appcast_row.get("id")) is not int:
+        raise SystemExit("publication manifest does not bind appcast.xml")
+else:
+    version_parts = tuple(int(part) for part in tag[1:].split("."))
+    if version_parts < (1, 8, 40):
+        raise SystemExit("current provider publication tag is below the frozen-appcast floor")
+    release_sequence = manifest.get("release_sequence")
+    if type(release_sequence) is not int or release_sequence <= 0:
+        raise SystemExit("current provider publication requires a release sequence")
+    if isinstance(assets, dict) and "appcast.xml" in assets:
+        raise SystemExit("current provider publication must not bind a release appcast asset")
+    if appcast_digest != FROZEN_BRIDGE_APPCAST_SHA256:
+        raise SystemExit("current provider publication must use the committed frozen bridge appcast")
+expected_checksum = f"{dmg_digest}  {dmg_asset_name}\n"
 if paths[3].read_text(encoding="utf-8") != expected_checksum:
     raise SystemExit("versioned DMG checksum file is invalid")
 PY
@@ -150,6 +170,39 @@ validate_node "$webroot" dir
 validate_node "$releases_dir" dir
 validate_node "$manifests_dir" dir
 
+if [[ -L "$current" ]]; then
+  validate_node "$current" link
+  [[ -f "$current/publication-manifest.json" ]] ||
+    die "current publication pointer lacks a manifest"
+  validate_node "$current/publication-manifest.json" file
+  python3 - "$manifest_source" "$current/publication-manifest.json" <<'PY'
+import json
+import pathlib
+import sys
+
+candidate = json.loads(pathlib.Path(sys.argv[1]).read_text(encoding="utf-8"))
+current = json.loads(pathlib.Path(sys.argv[2]).read_text(encoding="utf-8"))
+if candidate.get("publication_id") == current.get("publication_id"):
+    raise SystemExit(0)
+candidate_sequence = candidate.get("release_sequence")
+current_sequence = current.get("release_sequence")
+if candidate_sequence is None and candidate.get("tag") == current.get("tag") == "v1.8.39":
+    raise SystemExit(0)
+if type(candidate_sequence) is not int or candidate_sequence <= 0:
+    raise SystemExit("candidate publication sequence is invalid")
+if current_sequence is None and current.get("tag") == "v1.8.39":
+    current_sequence = 0
+if type(current_sequence) is not int or current_sequence < 0:
+    raise SystemExit("current publication sequence is invalid")
+if candidate_sequence <= current_sequence:
+    raise SystemExit("publication sequence did not advance")
+PY
+elif [[ -e "$current" ]]; then
+  die "atomic current pointer is not a symlink: $current"
+elif find "$manifests_dir" -mindepth 1 -maxdepth 1 -type f | grep -q .; then
+  die "publication history exists without current pointer"
+fi
+
 replace_symlink() {
   local target="$1" destination="$2" temporary
   temporary="${destination}.next.$$"
@@ -203,10 +256,6 @@ else
   temporary_manifest="${tag_manifest}.next.$$"
   install -o "$trusted_uid" -g "$trusted_gid" -m 0644 "$manifest_source" "$temporary_manifest"
   mv "$temporary_manifest" "$tag_manifest"
-fi
-
-if [[ -e "$current" && ! -L "$current" ]]; then
-  die "atomic current pointer is not a symlink: $current"
 fi
 
 # A legacy pair may be migrated only after an operator has made it part of the

--- a/scripts/publish-malibu-latest-dmg.sh
+++ b/scripts/publish-malibu-latest-dmg.sh
@@ -7,8 +7,8 @@ die() {
   exit 1
 }
 
-[[ "$#" == 7 ]] ||
-  die "usage: $0 MANIFEST DMG APPCAST ARTIFACT_INDEX CHECKSUMS SIGNATURE PROVENANCE"
+[[ "$#" == 7 || "$#" == 8 ]] ||
+  die "usage: $0 MANIFEST DMG APPCAST ARTIFACT_INDEX CHECKSUMS SIGNATURE PROVENANCE [DISCOVERY]"
 
 manifest="$1"
 asset="$2"
@@ -17,13 +17,17 @@ artifact_index="$4"
 checksums="$5"
 signature="$6"
 provenance="$7"
+discovery="${8:-}"
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 
-bash "$SCRIPT_DIR/verify-malibu-publication-set.sh" \
-  "$manifest" "$asset" "$appcast" "$artifact_index" \
+verification_args=(
+  "$manifest" "$asset" "$appcast" "$artifact_index"
   "$checksums" "$signature" "$provenance"
+)
+[[ -z "$discovery" ]] || verification_args+=("$discovery")
+bash "$SCRIPT_DIR/verify-malibu-publication-set.sh" "${verification_args[@]}"
 
-read -r tag commit release_number publication_id dmg_asset_id appcast_asset_id < <(
+read -r repository tag commit release_number publication_id dmg_asset_id appcast_asset_id < <(
   python3 - "$manifest" <<'PY'
 import json
 import pathlib
@@ -32,23 +36,36 @@ import sys
 manifest = json.loads(pathlib.Path(sys.argv[1]).read_text(encoding="utf-8"))
 tag = manifest["tag"]
 assets = manifest["assets"]
+dmg = assets[f"Malibu-{tag}.dmg"]
+appcast = assets.get("appcast.xml")
 print(
+    manifest["repository"],
     tag,
     manifest["commit"],
     manifest["release_id"],
     manifest["publication_id"],
-    assets[f"Malibu-{tag}.dmg"]["id"],
-    assets["appcast.xml"]["id"],
+    dmg["id"],
+    appcast["id"] if isinstance(appcast, dict) and type(appcast.get("id")) is int else "frozen-bridge",
 )
 PY
 )
+expected_publication_repository="${MALIBU_PUBLICATION_EXPECTED_REPOSITORY:-Augustas11/macprovider}"
+[[ "$expected_publication_repository" == "Augustas11/macprovider" ]] ||
+  die "Malibu publication is restricted to Augustas11/macprovider"
+[[ "$repository" == "$expected_publication_repository" ]] || die "manifest repository is invalid"
 [[ "$tag" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]] || die "manifest tag is invalid"
-[[ "$tag" == v1.8.39 ]] || die "legacy provider-coupled Malibu publisher is frozen to v1.8.39"
 [[ "$commit" =~ ^[0-9a-f]{40}$ ]] || die "manifest commit is invalid"
 [[ "$release_number" =~ ^[1-9][0-9]*$ ]] || die "manifest release id is invalid"
 [[ "$publication_id" =~ ^[0-9a-f]{64}$ ]] || die "manifest publication id is invalid"
-[[ "$dmg_asset_id" =~ ^[1-9][0-9]*$ && "$appcast_asset_id" =~ ^[1-9][0-9]*$ ]] ||
-  die "manifest publication asset ids are invalid"
+[[ "$dmg_asset_id" =~ ^[1-9][0-9]*$ ]] || die "manifest DMG asset id is invalid"
+if [[ "$tag" == v1.8.39 ]]; then
+  [[ "$appcast_asset_id" =~ ^[1-9][0-9]*$ ]] ||
+    die "legacy bridge publication requires a signed appcast release asset"
+else
+  [[ "$appcast_asset_id" == frozen-bridge ]] ||
+    die "current provider publication must use the committed frozen bridge appcast"
+  [[ -n "$discovery" ]] || die "current provider publication requires release discovery"
+fi
 
 VPS_HOST="${MALIBU_DOWNLOAD_VPS_HOST:-159.223.165.194}"
 SSH_KEY="${MALIBU_DOWNLOAD_SSH_KEY:-$HOME/.ssh/pearl_operator_ed25519}"

--- a/scripts/recover-malibu-publication.sh
+++ b/scripts/recover-malibu-publication.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Recover only the post-GitHub Pearl publication for the frozen v1.8.39 bridge.
+# Recover only the post-GitHub Pearl publication for a stable Malibu provider release.
 set -euo pipefail
 umask 077
 
@@ -12,9 +12,9 @@ usage() {
   cat >&2 <<'EOF'
 usage: recover-malibu-publication.sh RELEASE_ID
 
-RELEASE_ID must identify the immutable, stable v1.8.39 GitHub release. The
-helper discovers the required numeric asset IDs from that release and republishes
-only the already-signed Malibu bridge bytes to Pearl.
+RELEASE_ID must identify an immutable, stable GitHub release from
+Augustas11/macprovider. The helper discovers the required numeric asset IDs from
+that release and republishes only the already-signed Malibu bytes to Pearl.
 EOF
   exit 2
 }
@@ -59,20 +59,26 @@ import sys
 
 release_path, requested_release_id = pathlib.Path(sys.argv[1]), int(sys.argv[2])
 release = json.loads(release_path.read_text(encoding="utf-8"))
-tag = "v1.8.39"
+tag = release.get("tag_name")
+if not isinstance(tag, str) or not re.fullmatch(r"v\d+\.\d+\.\d+", tag):
+    raise SystemExit("numeric release tag is not a stable semantic tag")
+version = tuple(int(part) for part in tag[1:].split("."))
+if tag != "v1.8.39" and version < (1, 8, 40):
+    raise SystemExit("current Malibu publication recovery requires v1.8.40 or later")
 expected_names = [
     f"Malibu-{tag}.dmg",
-    "appcast.xml",
     "compatibility-artifact-index.json",
     "checksums.txt",
     "checksums.txt.sig",
     "release-provenance.json",
 ]
+if tag == "v1.8.39":
+    expected_names.insert(1, "appcast.xml")
+else:
+    expected_names.insert(2, "macprovider-release-discovery.json")
 
 if release.get("id") != requested_release_id:
     raise SystemExit("numeric release id differs from the requested recovery id")
-if release.get("tag_name") != tag:
-    raise SystemExit("legacy Malibu publication recovery is frozen to v1.8.39")
 commit = release.get("target_commitish")
 if not isinstance(commit, str) or not re.fullmatch(r"[0-9a-f]{40}", commit):
     raise SystemExit("numeric release target is not a full lowercase commit")
@@ -81,7 +87,7 @@ if release.get("draft") is not False:
 if release.get("immutable") is not True:
     raise SystemExit("numeric release is not immutable")
 if release.get("prerelease") is not False:
-    raise SystemExit("numeric release is not the stable v1.8.39 release")
+    raise SystemExit("numeric release is not stable")
 if release.get("name") != f"macprovider-cli {tag}":
     raise SystemExit("numeric release title differs from the reviewed release")
 
@@ -113,29 +119,38 @@ missing = [name for name in expected_names if name not in by_name]
 if missing:
     raise SystemExit(f"numeric release is missing required asset: {missing[0]}")
 
-print(commit, *(by_name[name]["id"] for name in expected_names))
+print(
+    tag,
+    commit,
+    by_name[f"Malibu-{tag}.dmg"]["id"],
+    by_name["appcast.xml"]["id"] if tag == "v1.8.39" else 0,
+    by_name["compatibility-artifact-index.json"]["id"],
+    by_name["macprovider-release-discovery.json"]["id"] if tag != "v1.8.39" else 0,
+    by_name["checksums.txt"]["id"],
+    by_name["checksums.txt.sig"]["id"],
+    by_name["release-provenance.json"]["id"],
+)
 PY
 }
 
 fetch_release "$release_json"
 validate_release "$release_json" >"$identity"
-read -r commit dmg_asset_id appcast_asset_id artifact_index_asset_id \
-  checksums_asset_id signature_asset_id provenance_asset_id <"$identity" ||
+read -r tag commit dmg_asset_id appcast_asset_id artifact_index_asset_id \
+  discovery_asset_id checksums_asset_id signature_asset_id provenance_asset_id <"$identity" ||
   die "could not read the validated release identity"
 
-[[ "$(git -C "$repo_root" rev-parse HEAD)" == "$commit" ]] ||
-  die "recovery must run from a clean worktree at the exact release commit $commit"
 git -C "$repo_root" fetch --quiet --no-tags origin \
   refs/heads/main:refs/remotes/origin/main ||
   die "could not refresh origin/main"
+git -C "$repo_root" merge-base --is-ancestor "$(git -C "$repo_root" rev-parse HEAD)" refs/remotes/origin/main ||
+  die "recovery control checkout is not reachable from fresh origin/main"
 git -C "$repo_root" merge-base --is-ancestor "$commit" refs/remotes/origin/main ||
   die "release commit is not reachable from fresh origin/main"
 bash "$repo_root/scripts/verify-release-tag-target.sh" \
-  v1.8.39 "$commit" origin --require-existing >/dev/null
+  "$tag" "$commit" origin --require-existing >/dev/null
 
 names=(
-  "Malibu-v1.8.39.dmg"
-  "appcast.xml"
+  "Malibu-${tag}.dmg"
   "compatibility-artifact-index.json"
   "checksums.txt"
   "checksums.txt.sig"
@@ -143,12 +158,18 @@ names=(
 )
 asset_ids=(
   "$dmg_asset_id"
-  "$appcast_asset_id"
   "$artifact_index_asset_id"
   "$checksums_asset_id"
   "$signature_asset_id"
   "$provenance_asset_id"
 )
+if [[ "$tag" == v1.8.39 ]]; then
+  names=("Malibu-${tag}.dmg" "appcast.xml" "${names[@]:1}")
+  asset_ids=("$dmg_asset_id" "$appcast_asset_id" "${asset_ids[@]:1}")
+else
+  names=("Malibu-${tag}.dmg" "compatibility-artifact-index.json" "macprovider-release-discovery.json" "${names[@]:2}")
+  asset_ids=("$dmg_asset_id" "$artifact_index_asset_id" "$discovery_asset_id" "${asset_ids[@]:2}")
+fi
 for index in "${!names[@]}"; do
   target="$work/${names[$index]}"
   gh api -H 'X-GitHub-Api-Version: 2026-03-10' \
@@ -168,16 +189,33 @@ cmp -s "$identity" "$identity_after_download" ||
   die "numeric release identity changed while recovery assets were downloaded"
 
 manifest="$work/publication-manifest.json"
-python3 "$repo_root/scripts/capture-release-publication.py" \
-  "$release_after_download_json" "$work/release-provenance.json" "$manifest" \
-  "$work/Malibu-v1.8.39.dmg" "$work/appcast.xml" \
-  "$work/compatibility-artifact-index.json" "$work/checksums.txt" \
-  "$work/checksums.txt.sig" "$work/release-provenance.json"
+if [[ "$tag" == v1.8.39 ]]; then
+  appcast="$work/appcast.xml"
+  python3 "$repo_root/scripts/capture-release-publication.py" \
+    "$release_after_download_json" "$work/release-provenance.json" "$manifest" \
+    "$work/Malibu-${tag}.dmg" "$work/appcast.xml" \
+    "$work/compatibility-artifact-index.json" \
+    "$work/checksums.txt" "$work/checksums.txt.sig" "$work/release-provenance.json"
+else
+  appcast="$repo_root/scripts/dist/malibu-frozen-bridge-appcast.xml"
+  python3 "$repo_root/scripts/capture-release-publication.py" \
+    "$release_after_download_json" "$work/release-provenance.json" "$manifest" \
+    "$work/Malibu-${tag}.dmg" "$work/compatibility-artifact-index.json" \
+    "$work/macprovider-release-discovery.json" "$work/checksums.txt" \
+    "$work/checksums.txt.sig" "$work/release-provenance.json"
+fi
+if [[ "$tag" == v1.8.88 ]]; then
+  export MALIBU_PUBLICATION_ALLOW_PREVIOUS_STABLE="${MALIBU_PUBLICATION_ALLOW_PREVIOUS_STABLE:-1.8.82}"
+  export MALIBU_PUBLICATION_STAGED_CANDIDATE="${MALIBU_PUBLICATION_STAGED_CANDIDATE:-1.8.88}"
+fi
 
-bash "$repo_root/scripts/publish-malibu-latest-dmg.sh" \
-  "$manifest" "$work/Malibu-v1.8.39.dmg" "$work/appcast.xml" \
-  "$work/compatibility-artifact-index.json" "$work/checksums.txt" \
+publish_args=(
+  "$manifest" "$work/Malibu-${tag}.dmg" "$appcast"
+  "$work/compatibility-artifact-index.json" "$work/checksums.txt"
   "$work/checksums.txt.sig" "$work/release-provenance.json"
+)
+[[ "$tag" == v1.8.39 ]] || publish_args+=("$work/macprovider-release-discovery.json")
+bash "$repo_root/scripts/publish-malibu-latest-dmg.sh" "${publish_args[@]}"
 
 printf '[recover-malibu-publication] ok: immutable release %s republished to Pearl\n' \
   "$release_id"

--- a/scripts/test-malibu-bootstrap-bridge.sh
+++ b/scripts/test-malibu-bootstrap-bridge.sh
@@ -15,6 +15,7 @@ public_verifier="$root/scripts/verify-malibu-bootstrap-publication.sh"
 ssh_helper="$root/scripts/malibu-download-ssh.sh"
 known_hosts="$root/scripts/dist/malibu-download-known_hosts"
 legacy_key="$root/scripts/dist/malibu-v1.8.32-sparkle-public-key"
+frozen_bridge_appcast="$root/scripts/dist/malibu-frozen-bridge-appcast.xml"
 
 fail() {
   printf 'FAIL: %s\n' "$*" >&2
@@ -27,7 +28,8 @@ for script in "$generator" "$set_verifier" "$current_set_verifier" "$publisher" 
 done
 PYTHONDONTWRITEBYTECODE=1 python3 -m py_compile \
   "$signature_verifier" "$trust_anchor_helper"
-[[ -f "$known_hosts" && -f "$legacy_key" ]] || fail "bridge trust anchors are missing"
+[[ -f "$known_hosts" && -f "$legacy_key" && -f "$frozen_bridge_appcast" ]] ||
+  fail "bridge trust anchors are missing"
 
 work="$(mktemp -d "${TMPDIR:-/tmp}/malibu-bootstrap-test.XXXXXX")"
 trap 'rm -rf "$work"' EXIT
@@ -222,10 +224,11 @@ grep -q 'verify-malibu-bootstrap-publication.sh' "$publisher" || fail "public by
 grep -q 'verify-malibu-bootstrap-publication.sh' "$independent_publisher" || fail "independent public bytes are not verified"
 grep -q 'verify-malibu-current-publication-set.sh' "$independent_publisher" ||
   fail "independent publication does not verify the current manifest"
-grep -q 'legacy provider-coupled Malibu publisher is frozen to v1.8.39' "$publisher" ||
-  fail "legacy provider-coupled publisher is not frozen"
-grep -q 'legacy provider-coupled Malibu publication is frozen to v1.8.39' "$set_verifier" ||
-  fail "legacy provider-coupled verifier is not frozen"
+grep -q 'frozen-bridge' "$publisher" || fail "current provider publisher lacks frozen appcast mode"
+grep -q 'malibu-frozen-bridge-appcast.xml' "$set_verifier" ||
+  fail "current provider verifier does not pin the frozen bridge appcast"
+grep -q 'current provider publication must not bind a release appcast asset' "$installer" ||
+  fail "current provider installer accepts release appcast drift"
 if grep -q -- '--resolve' "$public_verifier" || grep -q 'MALIBU_DOWNLOAD_RESOLVE_IP' "$publisher" || grep -q 'MALIBU_DOWNLOAD_RESOLVE_IP' "$independent_publisher"; then
   fail "public verification can bypass client DNS resolution"
 fi
@@ -329,6 +332,195 @@ if MALIBU_PUBLICATION_TESTING=1 bash "$installer" \
   fail "same-tag publication drift was accepted"
 fi
 grep -q 'same-tag publication drift refused' "$work/drift.out" || fail "drift rejection was unclear"
+
+mkdir -p "$work/provider-current"
+printf 'current provider dmg bytes\n' > "$work/provider-current/Malibu-v1.8.88.dmg"
+cp "$frozen_bridge_appcast" "$work/provider-current/appcast.xml"
+provider_dmg_sha="$(shasum -a 256 "$work/provider-current/Malibu-v1.8.88.dmg" | awk '{print $1}')"
+printf '%s  Malibu-v1.8.88.dmg\n' "$provider_dmg_sha" > "$work/provider-current/Malibu-v1.8.88.dmg.sha256"
+provider_publication_id="$(python3 - "$work/provider-current/publication-manifest.json" \
+  "$work/provider-current/Malibu-v1.8.88.dmg" <<'PY'
+import hashlib
+import json
+import pathlib
+import sys
+
+manifest_path, dmg_path = map(pathlib.Path, sys.argv[1:])
+tag = "v1.8.88"
+dmg_sha = hashlib.sha256(dmg_path.read_bytes()).hexdigest()
+identity = hashlib.sha256(json.dumps({
+    "compatibility_artifact_index_sha256": "0" * 64,
+    "dmg_sha256": dmg_sha,
+    "release_sequence": 188,
+}, sort_keys=True, separators=(",", ":")).encode()).hexdigest()
+manifest_path.write_text(json.dumps({
+    "schema_version": 1,
+    "repository": "Augustas11/macprovider",
+    "tag": tag,
+    "commit": "c" * 40,
+    "prerelease": False,
+    "release_id": 501,
+    "release_sequence": 188,
+    "publication_id": identity,
+    "assets": {
+        dmg_path.name: {"id": 601, "sha256": dmg_sha},
+    },
+}, sort_keys=True) + "\n")
+print(identity)
+PY
+)"
+
+MALIBU_PUBLICATION_TESTING=1 bash "$installer" \
+  "$work/provider-current-webroot" v1.8.88 "$provider_publication_id" \
+  "$work/provider-current/publication-manifest.json" "$work/provider-current/Malibu-v1.8.88.dmg" \
+  "$work/provider-current/appcast.xml" "$work/provider-current/Malibu-v1.8.88.dmg.sha256"
+[[ "$(cat "$work/provider-current-webroot/latest.dmg")" == 'current provider dmg bytes' ]] ||
+  fail "current provider latest DMG differs"
+cmp -s "$frozen_bridge_appcast" "$work/provider-current-webroot/appcast.xml" ||
+  fail "current provider appcast is not the frozen bridge appcast"
+
+printf 'older provider dmg bytes\n' > "$work/provider-current/Malibu-v1.8.87.dmg"
+older_provider_dmg_sha="$(shasum -a 256 "$work/provider-current/Malibu-v1.8.87.dmg" | awk '{print $1}')"
+printf '%s  Malibu-v1.8.87.dmg\n' "$older_provider_dmg_sha" > "$work/provider-current/Malibu-v1.8.87.dmg.sha256"
+older_provider_publication_id="$(python3 - "$work/provider-current/publication-manifest-older.json" \
+  "$work/provider-current/Malibu-v1.8.87.dmg" <<'PY'
+import hashlib
+import json
+import pathlib
+import sys
+
+manifest_path, dmg_path = map(pathlib.Path, sys.argv[1:])
+tag = "v1.8.87"
+dmg_sha = hashlib.sha256(dmg_path.read_bytes()).hexdigest()
+identity = hashlib.sha256(json.dumps({
+    "compatibility_artifact_index_sha256": "0" * 64,
+    "dmg_sha256": dmg_sha,
+    "release_sequence": 187,
+}, sort_keys=True, separators=(",", ":")).encode()).hexdigest()
+manifest_path.write_text(json.dumps({
+    "schema_version": 1,
+    "repository": "Augustas11/macprovider",
+    "tag": tag,
+    "commit": "d" * 40,
+    "prerelease": False,
+    "release_id": 500,
+    "release_sequence": 187,
+    "publication_id": identity,
+    "assets": {
+        dmg_path.name: {"id": 600, "sha256": dmg_sha},
+    },
+}, sort_keys=True) + "\n")
+print(identity)
+PY
+)"
+if MALIBU_PUBLICATION_TESTING=1 bash "$installer" \
+  "$work/provider-current-webroot" v1.8.87 "$older_provider_publication_id" \
+  "$work/provider-current/publication-manifest-older.json" "$work/provider-current/Malibu-v1.8.87.dmg" \
+  "$work/provider-current/appcast.xml" "$work/provider-current/Malibu-v1.8.87.dmg.sha256" \
+  >"$work/provider-current-replay.out" 2>&1; then
+  fail "current provider installer accepted a sequence rollback"
+fi
+grep -q 'publication sequence did not advance' "$work/provider-current-replay.out" ||
+  fail "current provider sequence rollback rejection was unclear"
+
+mkdir -p "$work/provider-history-webroot/.malibu-tag-manifests"
+printf '{}\n' > "$work/provider-history-webroot/.malibu-tag-manifests/v1.8.87.json"
+if MALIBU_PUBLICATION_TESTING=1 bash "$installer" \
+  "$work/provider-history-webroot" v1.8.88 "$provider_publication_id" \
+  "$work/provider-current/publication-manifest.json" "$work/provider-current/Malibu-v1.8.88.dmg" \
+  "$work/provider-current/appcast.xml" "$work/provider-current/Malibu-v1.8.88.dmg.sha256" \
+  >"$work/provider-history.out" 2>&1; then
+  fail "current provider installer accepted history without current pointer"
+fi
+grep -q 'publication history exists without current pointer' "$work/provider-history.out" ||
+  fail "history-without-current rejection was unclear"
+
+mkdir -p "$work/provider-dangling-webroot"
+ln -s .malibu-releases/missing "$work/provider-dangling-webroot/.malibu-current"
+if MALIBU_PUBLICATION_TESTING=1 bash "$installer" \
+  "$work/provider-dangling-webroot" v1.8.88 "$provider_publication_id" \
+  "$work/provider-current/publication-manifest.json" "$work/provider-current/Malibu-v1.8.88.dmg" \
+  "$work/provider-current/appcast.xml" "$work/provider-current/Malibu-v1.8.88.dmg.sha256" \
+  >"$work/provider-dangling.out" 2>&1; then
+  fail "current provider installer accepted dangling current pointer"
+fi
+grep -q 'current publication pointer lacks a manifest' "$work/provider-dangling.out" ||
+  fail "dangling-current rejection was unclear"
+
+printf 'current provider appcast drift\n' > "$work/provider-current/appcast-drift.xml"
+if MALIBU_PUBLICATION_TESTING=1 bash "$installer" \
+  "$work/provider-current-drift-webroot" v1.8.88 "$provider_publication_id" \
+  "$work/provider-current/publication-manifest.json" "$work/provider-current/Malibu-v1.8.88.dmg" \
+  "$work/provider-current/appcast-drift.xml" "$work/provider-current/Malibu-v1.8.88.dmg.sha256" \
+  >"$work/provider-current-drift.out" 2>&1; then
+  fail "current provider installer accepted appcast drift"
+fi
+grep -q 'current provider publication must use the committed frozen bridge appcast' \
+  "$work/provider-current-drift.out" || fail "current provider appcast drift rejection was unclear"
+
+mkdir -p "$work/frozen-public-bin"
+cat > "$work/frozen-public-bin/curl" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+out=""
+url=""
+while (($#)); do
+  case "$1" in
+    -o)
+      out="$2"
+      shift 2
+      ;;
+    http*)
+      url="$1"
+      shift
+      ;;
+    *)
+      shift
+      ;;
+  esac
+done
+printf '%s\n' "$url" >> "$MOCK_CURL_CALLS"
+case "$url" in
+  *appcast.xml*)
+    cp "$FROZEN_APPCAST_FIXTURE" "$out"
+    ;;
+  *Malibu-v1.8.88.dmg.sha256*)
+    cp "$CURRENT_SHA_FIXTURE" "$out"
+    ;;
+  *latest.dmg*|*Malibu-v1.8.88.dmg*)
+    cp "$CURRENT_DMG_FIXTURE" "$out"
+    ;;
+  *Malibu-v1.8.39.dmg*)
+    printf 'legacy bridge dmg bytes\n' > "$out"
+    ;;
+  *)
+    printf 'unexpected URL: %s\n' "$url" >&2
+    exit 1
+    ;;
+esac
+SH
+cat > "$work/frozen-public-bin/python3" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$*" >> "$MOCK_PYTHON_CALLS"
+[[ "$1" == *verify-malibu-sparkle-signature.py && "$2" == v1.8.39 ]]
+SH
+chmod +x "$work/frozen-public-bin/curl" "$work/frozen-public-bin/python3"
+MOCK_CURL_CALLS="$work/frozen-public-curl.calls" \
+MOCK_PYTHON_CALLS="$work/frozen-public-python.calls" \
+FROZEN_APPCAST_FIXTURE="$work/provider-current/appcast.xml" \
+CURRENT_DMG_FIXTURE="$work/provider-current/Malibu-v1.8.88.dmg" \
+CURRENT_SHA_FIXTURE="$work/provider-current/Malibu-v1.8.88.dmg.sha256" \
+MALIBU_DOWNLOAD_HOST=download.example.invalid \
+PATH="$work/frozen-public-bin:$PATH" \
+  bash "$public_verifier" v1.8.88 \
+    "$work/provider-current/Malibu-v1.8.88.dmg" \
+    "$work/provider-current/appcast.xml" \
+    "$work/provider-current/Malibu-v1.8.88.dmg.sha256"
+grep -q 'Malibu-v1.8.39.dmg' "$work/frozen-public-curl.calls" ||
+  fail "frozen public verifier does not fetch the legacy bridge DMG"
+grep -q ' v1.8.39 ' "$work/frozen-public-python.calls" ||
+  fail "frozen public verifier does not verify the legacy bridge signature"
 
 mkdir -p "$work/current"
 printf 'current signed dmg bytes\n' > "$work/current/Malibu-v1.8.65.dmg"

--- a/scripts/test-recover-malibu-publication.sh
+++ b/scripts/test-recover-malibu-publication.sh
@@ -17,9 +17,14 @@ fixture="$work/fixture"
 mock_bin="$work/bin"
 named_assets="$work/named-assets"
 api_assets="$work/api-assets"
-mkdir -p "$fixture/scripts" "$mock_bin" "$named_assets" "$api_assets" "$work/home/.ssh"
+current_named_assets="$work/current-named-assets"
+current_api_assets="$work/current-api-assets"
+mkdir -p "$fixture/scripts/dist" "$mock_bin" "$named_assets" "$api_assets" \
+  "$current_named_assets" "$current_api_assets" "$work/home/.ssh"
 cp "$recovery" "$fixture/scripts/recover-malibu-publication.sh"
 cp "$capture" "$fixture/scripts/capture-release-publication.py"
+cp "$root/scripts/dist/malibu-frozen-bridge-appcast.xml" \
+  "$fixture/scripts/dist/malibu-frozen-bridge-appcast.xml"
 
 commit=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
 release_id=701
@@ -99,11 +104,86 @@ release = {
 release_path.write_text(json.dumps(release), encoding="utf-8")
 PY
 
+current_release_json="$work/current-release.json"
+python3 - "$current_named_assets" "$current_api_assets" "$current_release_json" "$commit" "$release_id" <<'PY'
+import hashlib
+import json
+import pathlib
+import sys
+
+named, api, release_path = map(pathlib.Path, sys.argv[1:4])
+commit, release_id = sys.argv[4], int(sys.argv[5])
+tag = "v1.8.88"
+base = {
+    f"Malibu-{tag}.dmg": b"signed current provider dmg bytes\n",
+    "compatibility-artifact-index.json": b'{"schema_version":1}\n',
+    "macprovider-release-discovery.json": b'{"signed":{"release_sequence":188}}\n',
+}
+for name, content in base.items():
+    (named / name).write_bytes(content)
+signed_assets = {
+    name: hashlib.sha256(content).hexdigest() for name, content in base.items()
+}
+provenance = {
+    "schema_version": 1,
+    "repository": "Augustas11/macprovider",
+    "tag": tag,
+    "commit": commit,
+    "prerelease": False,
+    "toolchain": {},
+    "assets": signed_assets,
+}
+(named / "release-provenance.json").write_text(
+    json.dumps(provenance, sort_keys=True, separators=(",", ":")) + "\n",
+    encoding="utf-8",
+)
+checksum_names = [*base, "release-provenance.json"]
+(named / "checksums.txt").write_text(
+    "".join(
+        f"{hashlib.sha256((named / name).read_bytes()).hexdigest()}  {name}\n"
+        for name in checksum_names
+    ),
+    encoding="utf-8",
+)
+(named / "checksums.txt.sig").write_bytes(b"captured signature bytes\n")
+ordered = [
+    f"Malibu-{tag}.dmg",
+    "compatibility-artifact-index.json",
+    "macprovider-release-discovery.json",
+    "checksums.txt",
+    "checksums.txt.sig",
+    "release-provenance.json",
+]
+assets = []
+for asset_id, name in enumerate(ordered, 901):
+    content = (named / name).read_bytes()
+    (api / str(asset_id)).write_bytes(content)
+    assets.append(
+        {
+            "id": asset_id,
+            "name": name,
+            "state": "uploaded",
+            "digest": f"sha256:{hashlib.sha256(content).hexdigest()}",
+        }
+    )
+release = {
+    "id": release_id,
+    "tag_name": tag,
+    "target_commitish": commit,
+    "draft": False,
+    "immutable": True,
+    "prerelease": False,
+    "name": f"macprovider-cli {tag}",
+    "assets": assets,
+}
+release_path.write_text(json.dumps(release), encoding="utf-8")
+PY
+
 cat >"$fixture/scripts/verify-release-tag-target.sh" <<'SH'
 #!/usr/bin/env bash
 set -euo pipefail
 [[ "$#" == 4 ]]
-[[ "$1" == v1.8.39 ]]
+[[ "$1" == v1.8.39 || "$1" == v1.8.88 ]]
 [[ "$2" == aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa ]]
 [[ "$3" == origin && "$4" == --require-existing ]]
 printf '%s\n' verified >"$MOCK_TAG_MARKER"
@@ -112,26 +192,51 @@ SH
 cat >"$fixture/scripts/publish-malibu-latest-dmg.sh" <<'SH'
 #!/usr/bin/env bash
 set -euo pipefail
-[[ "$#" == 7 ]]
+[[ "$#" == 7 || "$#" == 8 ]]
 python3 - "$@" <<'PY'
 import json
+import os
 import pathlib
 import sys
 
-manifest_path, dmg, appcast, index, checksums, signature, provenance = map(pathlib.Path, sys.argv[1:])
+paths = list(map(pathlib.Path, sys.argv[1:]))
+manifest_path, dmg, appcast, index, checksums, signature, provenance = paths[:7]
+discovery = paths[7] if len(paths) == 8 else None
 manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
 assert manifest["release_id"] == 701
-assert manifest["tag"] == "v1.8.39"
 assert manifest["commit"] == "a" * 40
-assert [path.name for path in (dmg, appcast, index, checksums, signature, provenance)] == [
-    "Malibu-v1.8.39.dmg",
-    "appcast.xml",
-    "compatibility-artifact-index.json",
-    "checksums.txt",
-    "checksums.txt.sig",
-    "release-provenance.json",
-]
-assert manifest["assets"]["compatibility-artifact-index.json"]["id"] == 803
+if manifest["tag"] == "v1.8.39":
+    assert "release_sequence" not in manifest
+    assert discovery is None
+    assert [path.name for path in (dmg, appcast, index, checksums, signature, provenance)] == [
+        "Malibu-v1.8.39.dmg",
+        "appcast.xml",
+        "compatibility-artifact-index.json",
+        "checksums.txt",
+        "checksums.txt.sig",
+        "release-provenance.json",
+    ]
+    assert manifest["assets"]["compatibility-artifact-index.json"]["id"] == 803
+    assert "macprovider-release-discovery.json" not in manifest["assets"]
+elif manifest["tag"] == "v1.8.88":
+    assert discovery is not None
+    assert manifest["release_sequence"] == 188
+    assert os.environ["MALIBU_PUBLICATION_ALLOW_PREVIOUS_STABLE"] == "1.8.82"
+    assert os.environ["MALIBU_PUBLICATION_STAGED_CANDIDATE"] == "1.8.88"
+    assert [path.name for path in (dmg, appcast, index, checksums, signature, provenance, discovery)] == [
+        "Malibu-v1.8.88.dmg",
+        "malibu-frozen-bridge-appcast.xml",
+        "compatibility-artifact-index.json",
+        "checksums.txt",
+        "checksums.txt.sig",
+        "release-provenance.json",
+        "macprovider-release-discovery.json",
+    ]
+    assert "appcast.xml" not in manifest["assets"]
+    assert manifest["assets"]["compatibility-artifact-index.json"]["id"] == 902
+    assert manifest["assets"]["macprovider-release-discovery.json"]["id"] == 903
+else:
+    raise AssertionError(manifest["tag"])
 PY
 printf '%s\n' published >"$MOCK_PUBLISH_MARKER"
 SH
@@ -181,6 +286,9 @@ case "${1:-}" in
     ;;
   merge-base)
     [[ "${2:-}" == --is-ancestor ]] || exit 93
+    if [[ "${MOCK_CONTROL_UNREACHABLE:-0}" == 1 && "${3:-}" == "$MOCK_GIT_HEAD" ]]; then
+      exit 95
+    fi
     ;;
   *)
     printf 'unexpected git command: %s\n' "$*" >&2
@@ -199,6 +307,7 @@ run_recovery() (
   dirty="${4:-0}"
   selected_repo="${5:-Augustas11/macprovider}"
   selected_assets="${6:-$api_assets}"
+  control_unreachable="${7:-0}"
   rm -f "$work/release-call-count" "$work/publish.marker" "$work/tag.marker"
   export PATH="$mock_bin:$PATH"
   export GH_TOKEN=test-token
@@ -212,6 +321,7 @@ run_recovery() (
   export MOCK_ASSET_DIR="$selected_assets"
   export MOCK_GIT_HEAD="$selected_head"
   export MOCK_GIT_DIRTY="$dirty"
+  export MOCK_CONTROL_UNREACHABLE="$control_unreachable"
   if [[ -n "$second_release" ]]; then
     export MOCK_SECOND_RELEASE_JSON="$second_release"
   else
@@ -240,13 +350,20 @@ grep -q 'immutable release 701 republished to Pearl' "$work/success.out" ||
 [[ -f "$work/publish.marker" && -f "$work/tag.marker" ]] ||
   fail "successful recovery skipped tag verification or publication"
 
+run_recovery "$current_release_json" "" "$commit" 0 Augustas11/macprovider \
+  "$current_api_assets" >"$work/current-success.out" 2>&1
+grep -q 'immutable release 701 republished to Pearl' "$work/current-success.out" ||
+  { cat "$work/current-success.out" >&2; fail "current recovery did not report completion"; }
+[[ -f "$work/publish.marker" && -f "$work/tag.marker" ]] ||
+  fail "current recovery skipped tag verification or publication"
+
 python3 - "$release_json" "$work/release-wrong-tag.json" <<'PY'
 import json, pathlib, sys
 value = json.loads(pathlib.Path(sys.argv[1]).read_text())
 value["tag_name"] = "v1.8.40"
 pathlib.Path(sys.argv[2]).write_text(json.dumps(value))
 PY
-expect_failure wrong-tag 'frozen to v1.8.39' "$work/release-wrong-tag.json"
+expect_failure wrong-tag 'numeric release title differs from the reviewed release' "$work/release-wrong-tag.json"
 
 python3 - "$release_json" "$work/release-mutable.json" <<'PY'
 import json, pathlib, sys
@@ -291,8 +408,8 @@ printf 'tampered dmg bytes\n' >"$tampered_assets/801"
 expect_failure tampered-download 'GitHub digest differs from captured workflow asset' \
   "$release_json" '' "$commit" 0 Augustas11/macprovider "$tampered_assets"
 
-expect_failure wrong-head 'exact release commit' \
-  "$release_json" '' bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+expect_failure unreachable-control 'control checkout is not reachable from fresh origin/main' \
+  "$release_json" '' "$commit" 0 Augustas11/macprovider "$api_assets" 1
 expect_failure dirty-worktree 'tracked or staged changes' \
   "$release_json" '' "$commit" 1
 expect_failure wrong-repository 'restricted to Augustas11/macprovider' \

--- a/scripts/test-release-security-posture.sh
+++ b/scripts/test-release-security-posture.sh
@@ -203,6 +203,27 @@ MALIBU_BUILD_STEP = r'''        if: ${{ github.event.inputs.promote_run_id == ''
         shell: bash
         run: |
           set -euo pipefail
+          tag="${{ steps.release_source.outputs.tag }}"
+          version="${tag#v}"
+          [[ "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] || {
+            echo "::error::release tag does not contain a semantic Malibu version: $tag" >&2
+            exit 1
+          }
+          build="$(awk -v version="$version" '
+            $0 !~ /^[[:space:]]*#/ && NF >= 2 && $1 == version {
+              count += 1
+              value = $2
+            }
+            END {
+              if (count != 1 || value !~ /^[0-9]+$/) {
+                exit 1
+              }
+              print value
+            }
+          ' phase3-binary/app/release-builds.tsv)" || {
+            echo "::error::phase3-binary/app/release-builds.tsv must contain exactly one numeric build for Malibu $version" >&2
+            exit 1
+          }
           cd phase3-binary/app
           "$RUNNER_TEMP/xcodegen-2.45.4/xcodegen/bin/xcodegen" generate
           xcodebuild \
@@ -213,9 +234,17 @@ MALIBU_BUILD_STEP = r'''        if: ${{ github.event.inputs.promote_run_id == ''
             -archivePath "$RUNNER_TEMP/Malibu.xcarchive" \
             archive \
             ARCHS=arm64 \
-            CODE_SIGNING_ALLOWED=NO
+            CODE_SIGNING_ALLOWED=NO \
+            MARKETING_VERSION="$version" \
+            CURRENT_PROJECT_VERSION="$build"
           cp -R "$RUNNER_TEMP/Malibu.xcarchive/Products/Applications/Malibu.app" \
-            "$RUNNER_TEMP/Malibu.app"'''
+            "$RUNNER_TEMP/Malibu.app"
+          actual_version="$(/usr/libexec/PlistBuddy -c 'Print :CFBundleShortVersionString' "$RUNNER_TEMP/Malibu.app/Contents/Info.plist")"
+          actual_build="$(/usr/libexec/PlistBuddy -c 'Print :CFBundleVersion' "$RUNNER_TEMP/Malibu.app/Contents/Info.plist")"
+          [[ "$actual_version" = "$version" && "$actual_build" = "$build" ]] || {
+            echo "::error::Malibu.app Info.plist reports $actual_version/$actual_build, expected $version/$build" >&2
+            exit 1
+          }'''
 MALIBU_CAPTURE_STEP = r'''        if: ${{ github.event.inputs.promote_run_id == '' }}
         shell: bash
         run: |
@@ -314,7 +343,7 @@ PROTECTED_OPENSSL_CONSUMERS = (
     ("Require an advancing immutable discovery head", 2, 2),
     ("Create verified draft GitHub release", 1, 1),
     ("Publish only the revalidated numeric draft", 2, 2),
-    ("Publish one-time Malibu 1.8.32 bootstrap bridge to Pearl", 0, 0),
+    ("Publish Malibu download alias to Pearl", 0, 0),
 )
 
 
@@ -760,32 +789,43 @@ for requirement in (
         raise SystemExit(f"final Malibu artifact verification omits: {requirement}")
 if publish.count("Generate one-time Malibu 1.8.32 bootstrap bridge") != 1:
     raise SystemExit("release workflow must contain exactly one named bootstrap generator")
-if publish.count("Publish one-time Malibu 1.8.32 bootstrap bridge to Pearl") != 1:
-    raise SystemExit("release workflow must contain exactly one named bootstrap publisher")
+if publish.count("Publish Malibu download alias to Pearl") != 1:
+    raise SystemExit("release workflow must contain exactly one named Malibu alias publisher")
 bridge = publish.split("- name: Generate one-time Malibu 1.8.32 bootstrap bridge", 1)[1].split(
     "\n      - name:", 1
 )[0]
 pearl_bridge = publish.split(
-    "- name: Publish one-time Malibu 1.8.32 bootstrap bridge to Pearl", 1
+    "- name: Publish Malibu download alias to Pearl", 1
 )[1].split("\n      - name:", 1)[0]
 if "if: needs.build.outputs.tag == 'v1.8.39'" not in bridge:
     raise SystemExit("legacy appcast generation is not frozen to v1.8.39")
 if "SPARKLE_EDDSA_PRIVATE_KEY" not in bridge or "verify-malibu-sparkle-signature.py" not in bridge:
     raise SystemExit("legacy appcast lacks protected signing or frozen-key verification")
-if "if: needs.build.outputs.tag == 'v1.8.39' && needs.build.outputs.prerelease == 'false'" not in pearl_bridge:
-    raise SystemExit("Pearl bridge publication is not frozen to stable v1.8.39")
+if "if: needs.build.outputs.prerelease == 'false'" not in pearl_bridge:
+    raise SystemExit("Pearl Malibu alias publication is not stable-only")
+if "MALIBU_PUBLICATION_EXPECTED_REPOSITORY: ${{ github.repository }}" not in pearl_bridge:
+    raise SystemExit("Pearl Malibu alias publication is not bound to the workflow repository")
+if 'MALIBU_PUBLICATION_ALLOW_PREVIOUS_STABLE: "1.8.82"' not in pearl_bridge:
+    raise SystemExit("Pearl Malibu alias publication lacks staged previous-stable policy")
+if 'MALIBU_PUBLICATION_STAGED_CANDIDATE: "1.8.88"' not in pearl_bridge:
+    raise SystemExit("Pearl Malibu alias publication lacks staged candidate policy")
+if 'appcast="scripts/dist/malibu-frozen-bridge-appcast.xml"' not in pearl_bridge:
+    raise SystemExit("current provider publication does not use the frozen bridge appcast")
+if 'current provider release must not publish a generated appcast asset' not in pearl_bridge:
+    raise SystemExit("current provider publication does not reject generated appcast assets")
 for requirement in (
     "publish-malibu-latest-dmg.sh",
     "publication-manifest.json",
     "compatibility-artifact-index.json",
+    "macprovider-release-discovery.json",
     "checksums.txt.sig",
 ):
     if requirement not in pearl_bridge:
         raise SystemExit(f"Pearl bootstrap publication omits {requirement}")
-if publish.find("Publish one-time Malibu 1.8.32 bootstrap bridge to Pearl") < publish.find(
+if publish.find("Publish Malibu download alias to Pearl") < publish.find(
     "cmp final-draft-manifest.json publication-manifest.json"
 ):
-    raise SystemExit("Pearl bridge must publish only after immutable GitHub publication")
+    raise SystemExit("Pearl alias must publish only after immutable GitHub publication")
 team_requirement = (
     '-R="identifier \\"live.streamvc.macprovider.cli\\" and anchor apple generic '
     'and certificate leaf[subject.OU] = \\"$APPLE_NOTARY_TEAM_ID\\""'

--- a/scripts/verify-malibu-bootstrap-publication.sh
+++ b/scripts/verify-malibu-bootstrap-publication.sh
@@ -29,23 +29,39 @@ sha256_file() {
   fi
 }
 
+repo_root="$(cd "$(dirname "$0")/.." && pwd)"
+frozen_appcast="$repo_root/scripts/dist/malibu-frozen-bridge-appcast.xml"
+frozen_appcast_sha256="94ecf57584a2a203336d3219ea42dec1945bae2e123cfce0b1b39f8e0231d83c"
 expected_dmg_sha="$(sha256_file "$dmg")"
 expected_appcast_sha="$(sha256_file "$appcast")"
 expected_checksum_sha="$(sha256_file "$checksum")"
 expected_checksum_bytes="${expected_dmg_sha}  Malibu-${tag}.dmg"
 [[ "$(cat "$checksum")" == "$expected_checksum_bytes" ]] ||
   die "versioned DMG checksum file is invalid"
+frozen_mode=false
+if [[ "$tag" != v1.8.39 ]]; then
+  frozen_mode=true
+  [[ "$(sha256_file "$frozen_appcast")" == "$frozen_appcast_sha256" ]] ||
+    die "committed frozen bridge appcast hash changed"
+  cmp -s "$appcast" "$frozen_appcast" ||
+    die "current provider publication must use the committed frozen bridge appcast"
+fi
 curl_args=(
   --fail --show-error --silent --location --proto '=https' --tlsv1.2
   --connect-timeout 20 --max-time 240 --retry 3 --retry-delay 2
 )
 cache_key="publication=${expected_appcast_sha}"
+[[ "$frozen_mode" == false ]] || cache_key="publication=${expected_dmg_sha}"
 curl "${curl_args[@]}" -o "$work/appcast.xml" "${base}/appcast.xml?${cache_key}"
 curl "${curl_args[@]}" -o "$work/latest.dmg" "${base}/latest.dmg?${cache_key}"
 curl "${curl_args[@]}" -o "$work/Malibu-${tag}.dmg" \
   "${base}/Malibu-${tag}.dmg?${cache_key}"
 curl "${curl_args[@]}" -o "$work/Malibu-${tag}.dmg.sha256" \
   "${base}/Malibu-${tag}.dmg.sha256?${cache_key}"
+if [[ "$frozen_mode" == true ]]; then
+  curl "${curl_args[@]}" -o "$work/Malibu-v1.8.39.dmg" \
+    "${base}/Malibu-v1.8.39.dmg?${cache_key}"
+fi
 
 [[ "$(sha256_file "$work/appcast.xml")" == "$expected_appcast_sha" ]] ||
   die "public appcast bytes differ from the immutable release asset"
@@ -58,9 +74,14 @@ done
 [[ "$(cat "$work/Malibu-${tag}.dmg.sha256")" == "$expected_checksum_bytes" ]] ||
   die "public checksum contents do not match the immutable release DMG"
 
-repo_root="$(cd "$(dirname "$0")/.." && pwd)"
-python3 "$repo_root/scripts/verify-malibu-sparkle-signature.py" \
-  "$tag" "$work/latest.dmg" "$work/appcast.xml" \
-  "$repo_root/scripts/dist/malibu-v1.8.32-sparkle-public-key"
+if [[ "$frozen_mode" == false ]]; then
+  python3 "$repo_root/scripts/verify-malibu-sparkle-signature.py" \
+    "$tag" "$work/latest.dmg" "$work/appcast.xml" \
+    "$repo_root/scripts/dist/malibu-v1.8.32-sparkle-public-key"
+else
+  python3 "$repo_root/scripts/verify-malibu-sparkle-signature.py" \
+    v1.8.39 "$work/Malibu-v1.8.39.dmg" "$work/appcast.xml" \
+    "$repo_root/scripts/dist/malibu-v1.8.32-sparkle-public-key"
+fi
 
 printf '[verify-malibu-bootstrap-publication] ok: %s serves %s latest/appcast/checksum bytes\n' "$base" "$tag"

--- a/scripts/verify-malibu-publication-set.sh
+++ b/scripts/verify-malibu-publication-set.sh
@@ -6,7 +6,8 @@ die() {
   exit 1
 }
 
-[[ "$#" == 7 ]] || die "usage: MANIFEST DMG APPCAST ARTIFACT_INDEX CHECKSUMS SIGNATURE PROVENANCE"
+[[ "$#" == 7 || "$#" == 8 ]] ||
+  die "usage: MANIFEST DMG APPCAST ARTIFACT_INDEX CHECKSUMS SIGNATURE PROVENANCE [DISCOVERY]"
 openssl_bin="${OPENSSL_BIN:-}"
 [[ "$openssl_bin" == /* ]] ||
   die "OPENSSL_BIN must identify the absolute reviewed release verifier"
@@ -17,11 +18,20 @@ artifact_index="$4"
 checksums="$5"
 signature="$6"
 provenance="$7"
+discovery="${8:-}"
 repo_root="$(cd "$(dirname "$0")/.." && pwd)"
+frozen_appcast="$repo_root/scripts/dist/malibu-frozen-bridge-appcast.xml"
+frozen_appcast_sha256="94ecf57584a2a203336d3219ea42dec1945bae2e123cfce0b1b39f8e0231d83c"
+expected_publication_repository="${MALIBU_PUBLICATION_EXPECTED_REPOSITORY:-Augustas11/macprovider}"
+[[ "$expected_publication_repository" == "Augustas11/macprovider" ]] ||
+  die "Malibu publication is restricted to Augustas11/macprovider"
 
 for path in "$manifest" "$dmg" "$appcast" "$artifact_index" "$checksums" "$signature" "$provenance"; do
   [[ -f "$path" && ! -L "$path" ]] || die "publication input is not a regular file: $path"
 done
+if [[ -n "$discovery" ]]; then
+  [[ -f "$discovery" && ! -L "$discovery" ]] || die "publication input is not a regular file: $discovery"
+fi
 
 expected_identity="$(python3 - "$provenance" <<'PY'
 import json
@@ -33,22 +43,45 @@ print(value.get("repository", ""), value.get("tag", ""), value.get("commit", "")
 PY
 )"
 read -r expected_repository expected_tag expected_commit <<< "$expected_identity"
+[[ "$expected_repository" == "$expected_publication_repository" ]] ||
+  die "signed provenance repository is not the expected Malibu publication repository"
 [[ "$expected_tag" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]] || die "publication tag must be vX.Y.Z"
-[[ "$expected_tag" == v1.8.39 ]] || die "legacy provider-coupled Malibu publication is frozen to v1.8.39"
+sha256_file() {
+  if command -v shasum >/dev/null 2>&1; then
+    shasum -a 256 "$1" | awk '{print $1}'
+  else
+    sha256sum "$1" | awk '{print $1}'
+  fi
+}
+frozen_mode=false
+checksum_assets=("$dmg" "$appcast" "$artifact_index" "$provenance")
+[[ -z "$discovery" ]] || checksum_assets+=("$discovery")
+if [[ "$expected_tag" != v1.8.39 ]]; then
+  frozen_mode=true
+  [[ -n "$discovery" ]] || die "current provider publication requires release discovery"
+  [[ "$(sha256_file "$frozen_appcast")" == "$frozen_appcast_sha256" ]] ||
+    die "committed frozen bridge appcast hash changed"
+  cmp -s "$appcast" "$frozen_appcast" ||
+    die "current provider publication must use the committed frozen bridge appcast"
+  checksum_assets=("$dmg" "$artifact_index" "$discovery" "$provenance")
+fi
 bash "$repo_root/scripts/verify-release-checksums.sh" \
   --allow-partial --openssl "$openssl_bin" \
   "$checksums" "$signature" "$provenance" \
   "$expected_repository" "$expected_tag" "$expected_commit" \
-  "$dmg" "$appcast" "$artifact_index" "$provenance" >/dev/null
+  "${checksum_assets[@]}" >/dev/null
 
-publication_identity="$(python3 - "$manifest" "$dmg" "$appcast" "$artifact_index" "$checksums" "$signature" "$provenance" <<'PY'
+publication_identity="$(python3 - "$manifest" "$dmg" "$appcast" "$artifact_index" "$checksums" "$signature" "$provenance" "$frozen_mode" "$frozen_appcast_sha256" "${discovery:-}" <<'PY'
 import hashlib
 import json
 import pathlib
 import re
 import sys
 
-manifest_path, dmg_path, appcast_path, index_path, checksums_path, signature_path, provenance_path = map(pathlib.Path, sys.argv[1:])
+manifest_path, dmg_path, appcast_path, index_path, checksums_path, signature_path, provenance_path = map(pathlib.Path, sys.argv[1:8])
+frozen_mode = sys.argv[8] == "true"
+frozen_appcast_sha256 = sys.argv[9]
+discovery_path = pathlib.Path(sys.argv[10]) if sys.argv[10] else None
 manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
 provenance = json.loads(provenance_path.read_text(encoding="utf-8"))
 if manifest.get("schema_version") != 1 or provenance.get("schema_version") != 1:
@@ -58,6 +91,8 @@ for key in ("repository", "tag", "commit", "prerelease"):
         raise SystemExit(f"publication manifest and signed provenance disagree on {key}")
 if manifest.get("prerelease") is not False:
     raise SystemExit("prerelease must not publish the stable Malibu feed")
+if manifest.get("repository") != "Augustas11/macprovider":
+    raise SystemExit("publication repository is not the expected Malibu repository")
 tag = manifest.get("tag")
 commit = manifest.get("commit")
 if not isinstance(tag, str) or not re.fullmatch(r"v\d+\.\d+\.\d+", tag):
@@ -68,18 +103,54 @@ if type(manifest.get("release_id")) is not int or manifest["release_id"] <= 0:
     raise SystemExit("invalid numeric release id")
 
 paths = [dmg_path, appcast_path, index_path, checksums_path, signature_path, provenance_path]
+if discovery_path is not None:
+    paths.append(discovery_path)
 local = {path.name: hashlib.sha256(path.read_bytes()).hexdigest() for path in paths}
 dmg_name = f"Malibu-{tag}.dmg"
 if (
     dmg_path.name != dmg_name
-    or appcast_path.name != "appcast.xml"
     or index_path.name != "compatibility-artifact-index.json"
 ):
+    raise SystemExit("publication filenames do not match the tag")
+if not frozen_mode and appcast_path.name != "appcast.xml":
     raise SystemExit("publication filenames do not match the tag")
 assets = manifest.get("assets")
 if not isinstance(assets, dict):
     raise SystemExit("publication asset map is invalid")
-for name, digest in local.items():
+bound_names = [dmg_name, "compatibility-artifact-index.json", checksums_path.name, signature_path.name, provenance_path.name]
+if frozen_mode:
+    if discovery_path is None:
+        raise SystemExit("current provider publication requires release discovery")
+    if discovery_path.name != "macprovider-release-discovery.json":
+        raise SystemExit("release discovery filename is invalid")
+    if local[appcast_path.name] != frozen_appcast_sha256:
+        raise SystemExit("frozen bridge appcast digest changed")
+    if "appcast.xml" in assets:
+        raise SystemExit("current provider publication must not bind a release appcast asset")
+    discovery = json.loads(discovery_path.read_text(encoding="utf-8"))
+    release_sequence = discovery.get("signed", {}).get("release_sequence")
+    if type(release_sequence) is not int or release_sequence <= 0:
+        raise SystemExit("release discovery sequence is invalid")
+    if manifest.get("release_sequence") != release_sequence:
+        raise SystemExit("current provider publication requires a release sequence")
+    bound_names.append("macprovider-release-discovery.json")
+else:
+    bound_names.append("appcast.xml")
+    release_sequence = manifest.get("release_sequence")
+    if release_sequence is not None and (type(release_sequence) is not int or release_sequence <= 0):
+        raise SystemExit("publication release sequence is invalid")
+    if discovery_path is not None:
+        if discovery_path.name != "macprovider-release-discovery.json":
+            raise SystemExit("release discovery filename is invalid")
+        discovery = json.loads(discovery_path.read_text(encoding="utf-8"))
+        discovery_sequence = discovery.get("signed", {}).get("release_sequence")
+        if type(discovery_sequence) is not int or discovery_sequence <= 0:
+            raise SystemExit("release discovery sequence is invalid")
+        if release_sequence != discovery_sequence:
+            raise SystemExit("publication release sequence differs from release discovery")
+        bound_names.append("macprovider-release-discovery.json")
+for name in bound_names:
+    digest = local[name]
     row = assets.get(name)
     if not isinstance(row, dict) or type(row.get("id")) is not int or row.get("sha256") != digest:
         raise SystemExit(f"publication manifest does not bind the local {name}")
@@ -92,15 +163,15 @@ for name, digest in signed_assets.items():
     if not isinstance(row, dict) or row.get("sha256") != digest:
         raise SystemExit(f"signed provenance differs from publication manifest for {name}")
 
-content = json.dumps(
-    {
-        "appcast_sha256": local["appcast.xml"],
-        "compatibility_artifact_index_sha256": local["compatibility-artifact-index.json"],
-        "dmg_sha256": local[dmg_name],
-    },
-    sort_keys=True,
-    separators=(",", ":"),
-).encode()
+content_fields = {
+    "compatibility_artifact_index_sha256": local["compatibility-artifact-index.json"],
+    "dmg_sha256": local[dmg_name],
+}
+if not frozen_mode:
+    content_fields["appcast_sha256"] = local["appcast.xml"]
+if release_sequence is not None:
+    content_fields["release_sequence"] = release_sequence
+content = json.dumps(content_fields, sort_keys=True, separators=(",", ":")).encode()
 if manifest.get("publication_id") != hashlib.sha256(content).hexdigest():
     raise SystemExit("publication id is not the deterministic content digest")
 
@@ -111,10 +182,30 @@ read -r tag commit <<< "$publication_identity"
 [[ "$tag" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ && "$commit" =~ ^[0-9a-f]{40}$ ]] ||
   die "publication identity verification failed"
 
-bash "$repo_root/scripts/test-coordinator-advertised-version.sh" "$tag"
-python3 "$repo_root/scripts/verify-malibu-sparkle-signature.py" \
-  "$tag" "$dmg" "$appcast" \
-  "$repo_root/scripts/dist/malibu-v1.8.32-sparkle-public-key"
+coordinator_args=("$tag")
+staged_candidate="${MALIBU_PUBLICATION_STAGED_CANDIDATE:-}"
+allow_previous_stable="${MALIBU_PUBLICATION_ALLOW_PREVIOUS_STABLE:-}"
+if [[ -n "$staged_candidate" || -n "$allow_previous_stable" ]]; then
+  [[ -n "$staged_candidate" && -n "$allow_previous_stable" ]] ||
+    die "staged coordinator publication policy requires candidate and previous stable"
+  staged_candidate="${staged_candidate#v}"
+  [[ "$staged_candidate" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] ||
+    die "staged coordinator candidate must be a semantic version"
+  [[ "$allow_previous_stable" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] ||
+    die "previous stable coordinator allowance must be a semantic version"
+  if [[ "$tag" == "v$staged_candidate" ]]; then
+    coordinator_args+=(
+      "--allow-previous-stable=$allow_previous_stable"
+      "--staged-candidate=$staged_candidate"
+    )
+  fi
+fi
+bash "$repo_root/scripts/test-coordinator-advertised-version.sh" "${coordinator_args[@]}"
+if [[ "$frozen_mode" == false ]]; then
+  python3 "$repo_root/scripts/verify-malibu-sparkle-signature.py" \
+    "$tag" "$dmg" "$appcast" \
+    "$repo_root/scripts/dist/malibu-v1.8.32-sparkle-public-key"
+fi
 bash "$repo_root/scripts/verify-malibu-release-artifacts.sh" \
   "$dmg" --legacy-app-only-no-provider-tarball
 


### PR DESCRIPTION
## Summary

Fixes the Malibu provider release path so current stable provider releases can publish and recover the public `latest.dmg` alias without relying on stale bridge-era automation.

SPEC-GOVERNANCE-DECLARATION-BEGIN
{
  "schema_version": "spec-pr-governance-v1",
  "behavior_change": "yes",
  "contract_change": "none",
  "specs": [
    "SPEC-020",
    "SPEC-025"
  ],
  "requirements": [
    "SPEC-020-R001",
    "SPEC-020-R002",
    "SPEC-020-R003"
  ],
  "authority_domains": [
    "provider-autoupdate",
    "native-app-lifecycle"
  ],
  "arbitration": [
    "UNKNOWN"
  ],
  "tests": [
    "bash -n changed release scripts",
    "bash scripts/test-coordinator-advertised-version.sh v1.8.88 --allow-previous-stable=1.8.82 --staged-candidate=1.8.88",
    "bash scripts/test-malibu-bootstrap-bridge.sh",
    "bash scripts/test-recover-malibu-publication.sh",
    "bash scripts/test-release-security-posture.sh",
    "bash scripts/test-release-publication-provenance.sh",
    "bash scripts/test-coordinator-advertised-version-test.sh",
    "git diff --check",
    "git diff --cached --check"
  ],
  "journeys": [
    "not-required"
  ]
}
SPEC-GOVERNANCE-DECLARATION-END

## Root Cause

- `download.malibu.tech/latest.dmg` was stale at v1.8.53, so using it for recovery would re-install old bytes instead of the fixed provider build.
- The old publisher path was effectively locked around the v1.8.39 Sparkle bridge asset model.
- v1.8.88 shipped the fixed CLI path, but the Malibu app bundle metadata still reported 1.8.50 because the app build used stale version inputs.

## Changes

- Derive Malibu app marketing/build versions from the release tag and release build ledger, then validate the built bundle before signing.
- Add a committed frozen v1.8.39 bridge appcast and require newer provider releases to use release discovery plus signed publication manifests instead of generated provider appcasts.
- Bind publication, install, bootstrap, and recovery verification to `Augustas11/macprovider` and enforce anti-replay release sequence checks for non-legacy provider publications.
- Generalize Malibu publication recovery so v1.8.39 remains bridge-compatible while v1.8.88 and newer provider releases use frozen bridge assets plus release discovery.
- Extend release posture, bootstrap, and recovery tests for the stale alias, appcast drift, sequence rollback, and v1.8.88 staged coordinator cases.

## Validation

- `bash -n` on changed release scripts
- `bash scripts/test-coordinator-advertised-version.sh v1.8.88 --allow-previous-stable=1.8.82 --staged-candidate=1.8.88`
- `bash scripts/test-malibu-bootstrap-bridge.sh`
- `bash scripts/test-recover-malibu-publication.sh`
- `bash scripts/test-release-security-posture.sh`
- `bash scripts/test-release-publication-provenance.sh`
- `bash scripts/test-coordinator-advertised-version-test.sh`
- `git diff --check`
- `git diff --cached --check`
- 3-lane Codex code/security/architecture review reached C/H/M = 0 findings.

## Reviewer Notes

Known low-severity follow-ups from the final review pass:

- Frozen appcast SHA is duplicated across scripts.
- Recovery clean-checkout validation ignores untracked files in the control checkout.
- A future cross-minor release may need the trust-anchor build preflight relaxed away from patch-component build assumptions.
