### PR TITLE
fix(gateway): stop immediateTx from poisoning the writer connection (2026-08-07 quota-reservation outage)

### DIFF
--- a/phase5-gateway/internal/storage/sqlite/store.go
+++ b/phase5-gateway/internal/storage/sqlite/store.go
@@ -3,6 +3,7 @@ package sqlite
 import (
 	"context"
 	"database/sql"
+	"database/sql/driver"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -2103,12 +2104,54 @@ func (tx *immediateTx) QueryRowContext(ctx context.Context, query string, args .
 	return tx.conn.QueryRowContext(ctx, query, args...)
 }
 
+// immediateTxTerminalTimeout bounds each terminal COMMIT/ROLLBACK statement.
+const immediateTxTerminalTimeout = 5 * time.Second
+
+// execTerminal runs a single terminal statement (COMMIT or ROLLBACK) on its own
+// fresh, uncancellable context. It is deliberately NOT derived from tx.ctx (the
+// request/reconcile context): under an already-cancelled tx.ctx the statement
+// would fail without ending the SQLite transaction, and conn.Close() would then
+// return a connection with an OPEN transaction to the MaxOpenConns=1 pool —
+// poisoning every later writer with "cannot start a transaction within a
+// transaction" until restart (the 2026-08-07 gateway quota-reservation outage).
+// Each call gets its OWN context so a COMMIT that consumed its whole deadline on
+// a lock cannot hand an already-expired context to the compensating ROLLBACK.
+func execTerminal(conn *sql.Conn, stmt string) error {
+	ctx, cancel := context.WithTimeout(context.Background(), immediateTxTerminalTimeout)
+	defer cancel()
+	_, err := conn.ExecContext(ctx, stmt)
+	return err
+}
+
+// discardConn destroys the underlying driver connection so the pool opens a
+// fresh one next time instead of reusing this one. Returning driver.ErrBadConn
+// from Raw marks the driver connection bad; database/sql then drops it rather
+// than returning it to the MaxOpenConns=1 pool. Used only when a transaction
+// could not be cleanly terminated, so a connection that may still hold an open
+// transaction is never handed to the next borrower.
+func discardConn(conn *sql.Conn) {
+	_ = conn.Raw(func(any) error { return driver.ErrBadConn })
+	_ = conn.Close()
+}
+
 func (tx *immediateTx) Commit() error {
 	if tx.done {
 		return nil
 	}
 	tx.done = true
-	_, err := tx.conn.ExecContext(tx.ctx, "COMMIT")
+	err := execTerminal(tx.conn, "COMMIT")
+	if err != nil {
+		// COMMIT failed, so the transaction may still be open. Roll it back on
+		// a FRESH context (execTerminal), so a COMMIT that exhausted its own
+		// deadline cannot leave ROLLBACK unable to run.
+		if rbErr := execTerminal(tx.conn, "ROLLBACK"); rbErr != nil {
+			// Neither COMMIT nor ROLLBACK could end the transaction; the
+			// connection may still be mid-transaction. Discard it rather than
+			// return a poisoned connection to the pool.
+			discardConn(tx.conn)
+			return err
+		}
+	}
 	closeErr := tx.conn.Close()
 	if err != nil {
 		return err
@@ -2121,7 +2164,12 @@ func (tx *immediateTx) Rollback() {
 		return
 	}
 	tx.done = true
-	_, _ = tx.conn.ExecContext(tx.ctx, "ROLLBACK")
+	if err := execTerminal(tx.conn, "ROLLBACK"); err != nil {
+		// ROLLBACK could not end the transaction; do not return a possibly
+		// mid-transaction connection to the pool.
+		discardConn(tx.conn)
+		return
+	}
 	_ = tx.conn.Close()
 }
 
@@ -2131,7 +2179,11 @@ func (s *Store) beginImmediate(ctx context.Context) (*immediateTx, error) {
 		return nil, err
 	}
 	if _, err := conn.ExecContext(ctx, "BEGIN IMMEDIATE"); err != nil {
-		_ = conn.Close()
+		// Discard rather than return the connection to the pool: defends
+		// against a driver/runtime race where BEGIN IMMEDIATE started the
+		// transaction before reporting a cancellation, which a plain Close
+		// would hand back to the next borrower mid-transaction.
+		discardConn(conn)
 		return nil, err
 	}
 	return &immediateTx{ctx: ctx, conn: conn}, nil

--- a/phase5-gateway/internal/storage/sqlite/store_txhygiene_test.go
+++ b/phase5-gateway/internal/storage/sqlite/store_txhygiene_test.go
@@ -1,0 +1,89 @@
+package sqlite
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+// TestImmediateTxCommitDoesNotPoisonConnWhenContextCancelled reproduces the
+// 2026-08-07 gateway quota-reservation outage: the terminal COMMIT ran under the
+// caller's (already-cancelled) context, failed without ending the SQLite
+// transaction, and conn.Close() then returned a connection with an open
+// transaction to the MaxOpenConns=1 pool. Every subsequent writer — quota
+// reservation, settlement holds — failed with
+// "cannot start a transaction within a transaction" until the process restarted.
+func TestImmediateTxCommitDoesNotPoisonConnWhenContextCancelled(t *testing.T) {
+	store := newTestStore(t)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	tx, err := store.beginImmediate(ctx)
+	if err != nil {
+		t.Fatalf("beginImmediate: %v", err)
+	}
+	// The request/reconcile deadline fires before the terminal COMMIT runs.
+	cancel()
+	// Commit runs its terminal statement on a fresh uncancellable context, so a
+	// dead caller context must NOT prevent a clean commit.
+	if err := tx.Commit(); err != nil {
+		t.Fatalf("Commit under cancelled caller context: %v", err)
+	}
+
+	assertConnNotPoisoned(t, store)
+}
+
+// TestDiscardConnDropsPoisonedConnectionFromPool covers the last-resort cleanup
+// path: when a terminal COMMIT/ROLLBACK cannot end the transaction and the
+// connection is discarded, the MaxOpenConns=1 pool must open a fresh connection
+// rather than hand back the one still mid-transaction. Without discard, that
+// leftover open transaction is exactly the outage's poison.
+func TestDiscardConnDropsPoisonedConnectionFromPool(t *testing.T) {
+	store := newTestStore(t)
+
+	// Borrow the single pooled connection and leave a transaction open on it,
+	// standing in for a terminal statement that could not end the transaction.
+	conn, err := store.db.Conn(context.Background())
+	if err != nil {
+		t.Fatalf("Conn: %v", err)
+	}
+	if _, err := conn.ExecContext(context.Background(), "BEGIN IMMEDIATE"); err != nil {
+		t.Fatalf("BEGIN IMMEDIATE: %v", err)
+	}
+	discardConn(conn)
+
+	assertConnNotPoisoned(t, store)
+}
+
+// TestImmediateTxRollbackDoesNotPoisonConnWhenContextCancelled is the rollback
+// counterpart: a cancelled caller context must not prevent ROLLBACK from ending
+// the transaction before the connection is returned to the pool.
+func TestImmediateTxRollbackDoesNotPoisonConnWhenContextCancelled(t *testing.T) {
+	store := newTestStore(t)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	tx, err := store.beginImmediate(ctx)
+	if err != nil {
+		t.Fatalf("beginImmediate: %v", err)
+	}
+	cancel()
+	tx.Rollback()
+
+	assertConnNotPoisoned(t, store)
+}
+
+// assertConnNotPoisoned proves the single writer connection is not stuck mid
+// transaction: a fresh immediate transaction must open and commit rather than
+// fail with "cannot start a transaction within a transaction".
+func assertConnNotPoisoned(t *testing.T, store *Store) {
+	t.Helper()
+	tx, err := store.beginImmediate(context.Background())
+	if err != nil {
+		if strings.Contains(err.Error(), "transaction within a transaction") {
+			t.Fatalf("connection left poisoned by prior terminal statement: %v", err)
+		}
+		t.Fatalf("beginImmediate on recovered connection: %v", err)
+	}
+	if err := tx.Commit(); err != nil {
+		t.Fatalf("Commit on recovered connection: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

Durable fix for the **2026-08-07 gateway quota-reservation outage**. The Phase-5 buyer API gateway (SQLite, `SetMaxOpenConns(1)` single writer) returned `500 quota_reservation_failed` for **every** buyer request, and the SPEC-022 settlement reconciler failed every cycle with `SQL logic error: cannot start a transaction within a transaction (1)`. A process restart cleared it (relief already applied in prod); this PR removes the recurrence.

## Root cause

The hand-rolled `immediateTx` helper ran its terminal `COMMIT`/`ROLLBACK` via `tx.conn.ExecContext(tx.ctx, …)` — the **caller's** (request/reconcile) context. When that deadline was already exceeded, the terminal statement failed **without ending the SQLite transaction**, and the following `conn.Close()` returned a connection with an **open transaction** to the single-connection pool. Every subsequent `BEGIN IMMEDIATE` (quota reservation via `ReserveQuota`, settlement holds via the SPEC-022 reconciler) then failed with `cannot start a transaction within a transaction` until restart.

## Fix

- Each terminal statement (`COMMIT`, `ROLLBACK`) runs on its **own fresh, uncancellable** `context.Background()`-derived context (5s). An expired caller deadline can no longer strand the connection, and a `COMMIT` that exhausts its own deadline on a lock can no longer hand an already-dead context to the compensating `ROLLBACK`.
- If **neither** `COMMIT` nor `ROLLBACK` can end the transaction, the connection is **discarded** (`conn.Raw` → `driver.ErrBadConn`) so the pool opens a fresh one instead of reusing a poisoned one. `beginImmediate`'s `BEGIN`-error path discards likewise.
- Regression tests reproduce the poison (fail on the old code with the exact production error) and cover the discard-on-cleanup-failure path.

## Testing

- `go test ./internal/storage/sqlite/ ./internal/router/` — green
- `go test -race ./internal/storage/sqlite/` — green
- `go vet`, `go build ./...` — clean
- New: `store_txhygiene_test.go` (cancelled-caller poison + connection discard)

## Audit (3-lane codex, xhigh)

Prompts + artifacts under `audits/2026-08-07/`.

| Lane | R1 | R2 |
|---|---|---|
| Code | 1 HIGH (shared terminal context) | **0 C/H/M** |
| Security | 0 C/H/M | **0 C/H/M** |
| Architect | 1 MEDIUM (same root) + LOWs | **0 C/H/M — Approve** |

R1 HIGH/MEDIUM (COMMIT and its fallback ROLLBACK shared one 5s context) and both LOWs (discard on cleanup failure; harden `beginImmediate`; cover the failure path) are all addressed in the R2 revision above.

**Carried LOW (non-blocking):** the discard-path test exercises `discardConn` directly; a future edit that removed the `discardConn(tx.conn)` call from a `Commit`/`Rollback` failure branch while leaving the helper intact would not be caught (a deterministic forced-`COMMIT`-failure harness isn't practical). Documented per repo convention.

## Deploy note

The prod gateway was already restored via restart; this is the durable fix and must be built and deployed to Pearl (`macprovider-gateway.service`) per the gateway release/deploy runbook after merge.

SPEC-GOVERNANCE-DECLARATION-BEGIN
{
  "schema_version": "spec-pr-governance-v1",
  "behavior_change": "yes",
  "contract_change": "none",
  "specs": ["SPEC-022"],
  "requirements": ["SPEC-022-R007", "SPEC-022-R008"],
  "authority_domains": ["verified-model-settlement"],
  "arbitration": ["CODE_BUG"],
  "tests": ["phase5-gateway/internal/storage/sqlite/store_txhygiene_test.go"],
  "journeys": ["not-required"]
}
SPEC-GOVERNANCE-DECLARATION-END

🤖 Generated with [Claude Code](https://claude.com/claude-code)
