### PR TITLE
Expose reward availability so providers can act on held MALIBU

### DIFF
--- a/frontdoor/provider-portal/README.md
+++ b/frontdoor/provider-portal/README.md
@@ -35,9 +35,12 @@ per [SPEC-014](../../specs/SPEC-014-provider-portal.md).
      fails loud per SPEC-014 v0.2 §10.
    The loader rejects any unknown top-level key.
 2. Host `index.html` alongside an operator-owned reverse proxy on the
-   SAME origin that forwards `/v1/pool/check` and
-   `/providers/{id}/earnings` to the coordinator (SPEC-014 §3 +
-   Open Q9). For GitHub auth mode, also forward `/v1/auth/github/*`,
+   SAME origin that forwards `/v1/pool/check`,
+   `/v1/provider/malibu-accrual`, and `/providers/{id}/earnings` to the
+   coordinator (SPEC-014 §3 + Open Q9). The MALIBU accrual route must
+   preserve the provider `Authorization` header and use the buyer-mux
+   coordinator port, as shown in `dist/nginx-portal.streamvc.live.conf`.
+   For GitHub auth mode, also forward `/v1/auth/github/*`,
    `/v1/auth/me/*`, `/v1/auth/logout`, and
    `/v1/install/pair/refresh`. If the proxy is missing, the portal
    renders a loud red banner naming §3 / Open Q9 and refuses to fall

--- a/frontdoor/provider-portal/dist/README.md
+++ b/frontdoor/provider-portal/dist/README.md
@@ -23,7 +23,7 @@ spec-owned doc.
 ## Two deploy gotchas worth remembering
 
 1. **Coordinator backend runs on TWO localhost ports.** `/v1/pool/check`
-   is on buyer-mux **port 8443** (per
+   and `/v1/provider/malibu-accrual` are on buyer-mux **port 8443** (per
    `phase4-coordinator/internal/buyer/server.go:397`).
    `/providers/{id}/earnings` is on ws-mux **port 8444** (billing
    endpoints registered on the ws-side http handler). The site config

--- a/frontdoor/provider-portal/dist/nginx-portal.streamvc.live.conf
+++ b/frontdoor/provider-portal/dist/nginx-portal.streamvc.live.conf
@@ -30,7 +30,8 @@ server {
     index index.html;
 
     # SPEC-014 §3 / Open Q9: portal MUST be hosted on same origin as a
-    # reverse proxy that forwards /v1/pool/check and /providers/{id}/earnings
+    # reverse proxy that forwards /v1/pool/check, /v1/provider/malibu-accrual,
+    # and /providers/{id}/earnings
     # to the coordinator. Note: these endpoints live on DIFFERENT coordinator
     # backend ports — buyer-mux 8443 owns /v1/pool/check; ws-mux 8444 owns
     # /providers/{id}/earnings (billing endpoints registered on the ws-side
@@ -39,6 +40,18 @@ server {
         include /etc/nginx/snippets/portal-security-headers.conf;
         proxy_pass http://127.0.0.1:8443/v1/pool/check$is_args$args;
         proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_read_timeout 10s;
+    }
+
+    location = /v1/provider/malibu-accrual {
+        include /etc/nginx/snippets/portal-security-headers.conf;
+        add_header Cache-Control "no-store" always;
+        proxy_pass http://127.0.0.1:8443/v1/provider/malibu-accrual;
+        proxy_set_header Host $host;
+        proxy_set_header Authorization $http_authorization;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;

--- a/frontdoor/provider-portal/index.html
+++ b/frontdoor/provider-portal/index.html
@@ -317,6 +317,13 @@
     .fiat-card h3 { margin:0 0 6px 0; font-size:13px; color:var(--muted); font-weight:500; text-transform:uppercase; letter-spacing:.5px; }
     .fiat-card .fiat-body { font-size:14px; }
     .fiat-card .fiat-cite { font-size:11px; color:var(--hint); margin-top:8px; }
+    .rewards-card { margin-top:18px; }
+    .rewards-card .reward-grid { display:grid; grid-template-columns:repeat(3, minmax(0, 1fr)); gap:12px; margin-top:12px; }
+    .rewards-card .reward-label { color:var(--muted); font-size:12px; }
+    .rewards-card .reward-value { font-size:18px; margin-top:3px; }
+    .rewards-card .reward-hold { color:var(--bad); margin-top:12px; font-size:13px; line-height:1.45; }
+    .rewards-card .reward-next { margin-top:6px; font-size:13px; line-height:1.45; }
+    @media (max-width: 620px) { .rewards-card .reward-grid { grid-template-columns:1fr; } }
     .monitor-card { background:var(--surface); border:1px dashed var(--border2); border-radius:10px; padding:16px 18px; }
     .monitor-card h3 { margin:0 0 10px 0; font-size:14px; }
     .monitor-card ul { margin:0; padding-left:18px; color:var(--muted); font-size:13px; line-height:1.6; }
@@ -370,6 +377,7 @@
     function earningsPath(providerId) {
       return "/providers/" + encodeURIComponent(providerId) + "/earnings";
     }
+    var MALIBU_ACCRUAL_PATH = "/v1/provider/malibu-accrual";
 
     var RELEASES_HOST = "https://api.github.com";
     var RELEASES_TTL_MS = 5 * 60 * 1000;
@@ -381,9 +389,11 @@
     var state = {
       cfg: null,
       session: null,
+      sessionGeneration: 0,
       route: "machine",
       pool: { data: null, ts: 0, err: null, inflight: false },
       earn: { data: null, ts: 0, err: null, inflight: false },
+      malibu: { data: null, ts: 0, err: null, inflight: false },
       authFailBySurface: {},
       proxyMissing: false,
       sidebarOpen: false,
@@ -538,11 +548,15 @@
       })
         .then(function (resp) {
           var surface = opts.surface;
+          var isCurrentSession = opts.sessionGeneration === undefined ||
+            opts.sessionGeneration === state.sessionGeneration;
           if (resp.ok) {
-            if (opts.auth && surface) state.authFailBySurface[surface] = 0;
+            if (isCurrentSession && opts.auth && surface) state.authFailBySurface[surface] = 0;
             return resp.json().then(function (j) { return { ok: true, status: resp.status, body: j }; });
           }
-          if (opts.auth && surface && (resp.status === 401 || resp.status === 403 || resp.status === 404)) {
+          if (isCurrentSession && opts.auth && surface &&
+              (resp.status === 401 || resp.status === 403 || resp.status === 404) &&
+              resp.status !== opts.ignoreAuthFailureStatus) {
             state.authFailBySurface[surface] = (state.authFailBySurface[surface] || 0) + 1;
           }
           return { ok: false, status: resp.status, body: null };
@@ -616,12 +630,14 @@
       state.pool.inflight = true;
       render();
       var pid = state.session.provider_id;
+      var sessionGeneration = state.sessionGeneration;
       var url = POOL_PATH + "?provider_id=" + encodeURIComponent(pid);
       var fetchResult = state.cfg && state.cfg.github_oauth_enabled
         ? cookieJSON(url, { method: "GET" })
-        : coordFetch(url, { auth: false });
+        : coordFetch(url, { auth: false, sessionGeneration: sessionGeneration });
       return fetchResult
         .then(function (r) {
+          if (sessionGeneration !== state.sessionGeneration) return;
           state.pool.inflight = false;
           if (r.ok) {
             state.pool.data = r.body;
@@ -633,6 +649,7 @@
           render();
         })
         .catch(function () {
+          if (sessionGeneration !== state.sessionGeneration) return;
           state.pool.inflight = false;
           render();
         });
@@ -652,11 +669,17 @@
       state.earn.inflight = true;
       render();
       var pid = state.session.provider_id;
+      var sessionGeneration = state.sessionGeneration;
       var fetchResult = state.cfg && state.cfg.github_oauth_enabled
         ? cookieJSON(earningsPath(pid), { method: "GET" })
-        : coordFetch(earningsPath(pid), { auth: true, surface: surface || "machine" });
+        : coordFetch(earningsPath(pid), {
+            auth: true,
+            surface: surface || "machine",
+            sessionGeneration: sessionGeneration
+          });
       return fetchResult
         .then(function (r) {
+          if (sessionGeneration !== state.sessionGeneration) return;
           state.earn.inflight = false;
           if (r.ok) {
             state.earn.data = r.body;
@@ -677,7 +700,56 @@
           render();
         })
         .catch(function () {
+          if (sessionGeneration !== state.sessionGeneration) return;
           state.earn.inflight = false;
+          render();
+        });
+    }
+
+    function malibuFetch(surface, opts) {
+      opts = opts || {};
+      if (!state.session || (state.cfg && state.cfg.github_oauth_enabled)) return Promise.resolve();
+      var sessionGeneration = state.sessionGeneration;
+      var now = Date.now();
+      if (!opts.force && state.malibu.data && (now - state.malibu.ts) < EARN_CACHE_TTL_MS) {
+        return Promise.resolve();
+      }
+      if (state.malibu.inflight) return Promise.resolve();
+      state.malibu.inflight = true;
+      render();
+      return coordFetch(MALIBU_ACCRUAL_PATH, {
+        auth: true,
+        surface: surface || "machine",
+        ignoreAuthFailureStatus: 404,
+        sessionGeneration: sessionGeneration
+      })
+        .then(function (r) {
+          if (sessionGeneration !== state.sessionGeneration) return;
+          state.malibu.inflight = false;
+          if (r.ok) {
+            state.malibu.data = r.body;
+            state.malibu.ts = Date.now();
+            state.malibu.err = null;
+            render();
+            return;
+          }
+          state.malibu.data = null;
+          state.malibu.ts = 0;
+          if (r.status === 401 || r.status === 403) {
+            handleAuthRejection(r.status, surface || "machine");
+            return;
+          }
+          state.malibu.err = {
+            status: r.status,
+            unavailable: r.status === 404
+          };
+          render();
+        })
+        .catch(function () {
+          if (sessionGeneration !== state.sessionGeneration) return;
+          state.malibu.inflight = false;
+          state.malibu.data = null;
+          state.malibu.ts = 0;
           render();
         });
     }
@@ -739,11 +811,13 @@
      * Auth rejection handling (§2.2 + §2.3 stale-config guard)
      * ===================================================================== */
     function handleAuthRejection(status, surface) {
+      state.sessionGeneration += 1;
       var failCount = state.authFailBySurface[surface] || 0;
       var misconfig = failCount >= 2;
       stopPollers();
       state.session = null;
       state.earn = { data: null, ts: 0, err: null, inflight: false };
+      state.malibu = { data: null, ts: 0, err: null, inflight: false };
       state.pool = { data: null, ts: 0, err: null, inflight: false };
       if (status === 401) {
         state.signinErr = signInRejectedCopy();
@@ -766,10 +840,14 @@
     function startPollers() {
       stopPollers();
       timers.pool = setInterval(function () { poolCheck(); }, POOL_POLL_MS);
-      timers.earn = setInterval(function () { earnFetch("machine"); }, EARN_POLL_MS);
+      timers.earn = setInterval(function () {
+        earnFetch("machine");
+        malibuFetch("machine");
+      }, EARN_POLL_MS);
       timers.stamp = setInterval(function () { renderStampOnly(); }, STAMP_TICK_MS);
       poolCheck();
       earnFetch("machine", { force: true });
+      malibuFetch("machine", { force: true });
     }
     function stopPollers() {
       if (timers.pool) { clearInterval(timers.pool); timers.pool = null; }
@@ -781,8 +859,22 @@
      * Sign-out
      * ===================================================================== */
     function signOut() {
+      state.sessionGeneration += 1;
       if (state.cfg && state.cfg.github_oauth_enabled) {
         stopPollers();
+        state.session = null;
+        state.githubAuthState = "signin";
+        state.pool = { data: null, ts: 0, err: null, inflight: false };
+        state.earn = { data: null, ts: 0, err: null, inflight: false };
+        state.malibu = { data: null, ts: 0, err: null, inflight: false };
+        state.releases = { list: null, ts: 0, err: null, inflight: false, rateLimited: false };
+        state.authFailBySurface = {};
+        state.proxyMissing = false;
+        state.signinErr = null;
+        state.signinMisconfigNotice = null;
+        state.route = "machine";
+        state.sidebarOpen = false;
+        render();
         cookieJSON("/v1/auth/logout", { method: "POST", body: "{}" })
           .catch(function () { return null; })
           .then(function () { location.reload(); });
@@ -792,6 +884,7 @@
       state.session = null;
       state.pool = { data: null, ts: 0, err: null, inflight: false };
       state.earn = { data: null, ts: 0, err: null, inflight: false };
+      state.malibu = { data: null, ts: 0, err: null, inflight: false };
       state.releases = { list: null, ts: 0, err: null, inflight: false, rateLimited: false };
       state.authFailBySurface = {};
       state.proxyMissing = false;
@@ -813,6 +906,7 @@
         render();
         return;
       }
+      state.sessionGeneration += 1;
       state.session = { provider_id: pid, provider_token: tok };
       state.signinErr = null;
       state.signinMisconfigNotice = null;
@@ -892,11 +986,13 @@
     }
 
     function selectGitHubProvider(providerId, pushRoute) {
+      state.sessionGeneration += 1;
       state.session = { provider_id: providerId, provider_token: null };
       state.githubAuthState = "dashboard";
       state.route = "machine";
       state.pool = { data: null, ts: 0, err: null, inflight: false };
       state.earn = { data: null, ts: 0, err: null, inflight: false };
+      state.malibu = { data: null, ts: 0, err: null, inflight: false };
       if (pushRoute) {
         history.pushState({}, "", "/?p=" + encodeURIComponent(providerId));
       }
@@ -905,6 +1001,7 @@
     }
 
     function githubSessionExpired(returnTo) {
+      state.sessionGeneration += 1;
       stopPollers();
       state.session = null;
       state.githubAuthState = "signin";
@@ -1337,6 +1434,8 @@
         " and ",
         el("code", null, "/providers/{id}/earnings"),
         ", plus ",
+        el("code", null, "/v1/provider/malibu-accrual"),
+        ", ",
         el("code", null, "/v1/auth/github/*"),
         ", ",
         el("code", null, "/v1/auth/me/*"),
@@ -1512,6 +1611,77 @@
       return el("div", { class: "release-card" }, cardKids);
     }
 
+    function formatMalibuAmount(value) {
+      if (value === null || value === undefined) return "n/a";
+      var n = Number(value);
+      return typeof n === "number" && isFinite(n) ? n.toFixed(2) + " MALIBU" : "n/a";
+    }
+
+    function malibuReasonCopy(reason) {
+      switch (reason) {
+        case "trust_tier_provisional": return "Trust verification is incomplete";
+        case "per_wallet_daily_cap": return "the wallet daily limit has been reached";
+        case "demotion_cooldown": return "a Trust cooldown is active";
+        default: return "payout eligibility is still being verified";
+      }
+    }
+
+    function malibuNextAction(data, reasons) {
+      var hasHoldReasons = Array.isArray(data.withdrawal_hold_reasons);
+      if (reasons.indexOf("trust_tier_provisional") !== -1 &&
+          typeof data.trust_criteria_met === "number" &&
+          typeof data.trust_criteria_required === "number" &&
+          data.trust_criteria_required > data.trust_criteria_met) {
+        return "Complete " + (data.trust_criteria_required - data.trust_criteria_met) + " more trust criteria to unlock withdrawals.";
+      }
+      if (reasons.indexOf("per_wallet_daily_cap") !== -1) return "The wallet cap resets at the next UTC day.";
+      if (reasons.indexOf("demotion_cooldown") !== -1) return "Re-qualify for Trusted to clear the cooldown.";
+      if (!hasHoldReasons) return "Hold status is unavailable; try again later.";
+      if (typeof data.held_malibu === "number" && isFinite(data.held_malibu) && data.held_malibu <= 0) {
+        return "No action needed; no withdrawal hold is reported.";
+      }
+      return "Review the hold reason above before withdrawing.";
+    }
+
+    function renderMalibuRewardsCard() {
+      var d = state.malibu.data;
+      var loading = state.malibu.inflight && !d;
+      if (!d && !loading && !state.malibu.err) return null;
+      if (!d) {
+        return el("div", { class: "fiat-card rewards-card" },
+          el("h3", null, "MALIBU rewards"),
+          el("div", { class: "fiat-body" }, loading ? "Loading reward availability…" : "MALIBU rewards unavailable."),
+          state.malibu.err ? el("div", { class: "fiat-cite" }, state.malibu.err.unavailable
+            ? "Reward availability is temporarily unavailable while the MALIBU projection route is being deployed."
+            : "Read-only projection returned HTTP " + state.malibu.err.status + ".") : null);
+      }
+      var reasons = Array.isArray(d.withdrawal_hold_reasons) ? d.withdrawal_hold_reasons : [];
+      var held = Number(d.held_malibu);
+      var hasHeld = typeof d.held_malibu === "number" && isFinite(d.held_malibu);
+      var holdText = reasons.length
+        ? reasons.map(malibuReasonCopy).join("; ")
+        : (hasHeld ? (held > 0 ? "A payout eligibility hold is active." : "No active hold.") : "Hold status unavailable.");
+      var capParts = [];
+      if (d.daily_cap_malibu !== null && d.daily_cap_malibu !== undefined) {
+        capParts.push("provider cap " + formatMalibuAmount(d.daily_cap_malibu) + "/day");
+      }
+      if (d.wallet_daily_cap_malibu !== null && d.wallet_daily_cap_malibu !== undefined) {
+        capParts.push("wallet cap " + formatMalibuAmount(d.wallet_daily_cap_malibu) + "/day");
+      }
+      return el("div", { class: "fiat-card rewards-card" },
+        el("h3", null, "MALIBU rewards"),
+        el("div", { class: "fiat-body" }, "Read-only reward availability"),
+        el("div", { class: "reward-grid" },
+          el("div", null, el("div", { class: "reward-label" }, "Accrued"), el("div", { class: "reward-value mono" }, formatMalibuAmount(d.accrued_malibu))),
+          el("div", null, el("div", { class: "reward-label" }, "Withdrawable"), el("div", { class: "reward-value mono" }, formatMalibuAmount(d.withdrawable_malibu))),
+          el("div", null, el("div", { class: "reward-label" }, "Held"), el("div", { class: "reward-value mono" }, formatMalibuAmount(d.held_malibu)))),
+        el("div", { class: "reward-next" }, "Trust tier: ",
+          typeof d.trust_tier === "string" && d.trust_tier.trim() ? d.trust_tier : "n/a"),
+        el("div", { class: "reward-hold" }, "Held because: ", holdText),
+        el("div", { class: "reward-next" }, "Next: ", malibuNextAction(d, reasons)),
+        capParts.length ? el("div", { class: "fiat-cite" }, capParts.join(" · ")) : null);
+    }
+
     /* ---- Surface C — Earn ---- */
     function renderEarn() {
       var d = state.earn.data;
@@ -1549,6 +1719,7 @@
         el("h1", { class: "surface-title" }, "Earn"),
         el("h2", { class: "section-h" }, "Credit totals"),
         creditsRow,
+        renderMalibuRewardsCard(),
         el("div", { style: "margin-top:18px;" },
           el("h2", { class: "section-h" }, "Payout status"),
           fiatCard));

--- a/phase3-binary/Sources/macprovider-cli/MalibuAccrualClient.swift
+++ b/phase3-binary/Sources/macprovider-cli/MalibuAccrualClient.swift
@@ -9,6 +9,9 @@ struct MalibuAccrualSummary: Decodable, Equatable, Sendable {
     let trustCriteriaMet: Int?
     let trustCriteriaRequired: Int?
     let walletBound: Bool?
+    let dailyCapMALIBU: Double?
+    let walletDailyCapMALIBU: Double?
+    let withdrawalHoldReasons: [String]
 
     enum CodingKeys: String, CodingKey {
         case accruedMALIBU = "accrued_malibu"
@@ -18,28 +21,75 @@ struct MalibuAccrualSummary: Decodable, Equatable, Sendable {
         case trustCriteriaMet = "trust_criteria_met"
         case trustCriteriaRequired = "trust_criteria_required"
         case walletBound = "wallet_bound"
+        case dailyCapMALIBU = "daily_cap_malibu"
+        case walletDailyCapMALIBU = "wallet_daily_cap_malibu"
+        case withdrawalHoldReasons = "withdrawal_hold_reasons"
     }
 
     init(from decoder: Decoder) throws {
         let c = try decoder.container(keyedBy: CodingKeys.self)
-        accruedMALIBU = try Self.decodeDecimal(c, key: .accruedMALIBU)
-        withdrawableMALIBU = try Self.decodeDecimal(c, key: .withdrawableMALIBU)
-        heldMALIBU = try Self.decodeDecimal(c, key: .heldMALIBU)
-        trustTier = try c.decodeIfPresent(String.self, forKey: .trustTier) ?? "provisional"
+        accruedMALIBU = try Self.decodeRequiredDecimal(c, key: .accruedMALIBU)
+        withdrawableMALIBU = try Self.decodeRequiredDecimal(c, key: .withdrawableMALIBU)
+        heldMALIBU = try Self.decodeRequiredDecimal(c, key: .heldMALIBU)
+        let rawTrustTier = try c.decode(String.self, forKey: .trustTier).lowercased()
+        guard rawTrustTier == "provisional" || rawTrustTier == "trusted" else {
+            throw DecodingError.dataCorruptedError(
+                forKey: .trustTier,
+                in: c,
+                debugDescription: "Invalid MALIBU trust tier"
+            )
+        }
+        trustTier = rawTrustTier
         trustCriteriaMet = try c.decodeIfPresent(Int.self, forKey: .trustCriteriaMet)
         trustCriteriaRequired = try c.decodeIfPresent(Int.self, forKey: .trustCriteriaRequired)
         walletBound = try c.decodeIfPresent(Bool.self, forKey: .walletBound)
+        dailyCapMALIBU = try Self.decodeOptionalDecimal(c, key: .dailyCapMALIBU)
+        walletDailyCapMALIBU = try Self.decodeOptionalDecimal(c, key: .walletDailyCapMALIBU)
+        withdrawalHoldReasons = try c.decodeIfPresent([String].self, forKey: .withdrawalHoldReasons) ?? []
     }
 
-    private static func decodeDecimal(_ c: KeyedDecodingContainer<CodingKeys>, key: CodingKeys) throws -> Double {
-        guard c.contains(key) else { return 0 }
-        if let value = try? c.decode(Double.self, forKey: key) {
+    private static func decodeRequiredDecimal(
+        _ c: KeyedDecodingContainer<CodingKeys>,
+        key: CodingKeys
+    ) throws -> Double {
+        guard c.contains(key) else {
+            throw DecodingError.keyNotFound(
+                key,
+                DecodingError.Context(
+                    codingPath: c.codingPath,
+                    debugDescription: "Missing required MALIBU amount"
+                )
+            )
+        }
+        if let value = try? c.decode(Double.self, forKey: key), value.isFinite {
             return value
         }
-        if let text = try? c.decode(String.self, forKey: key) {
-            return Double(text) ?? 0
+        if let text = try? c.decode(String.self, forKey: key),
+           let value = Double(text),
+           value.isFinite {
+            return value
         }
-        return 0
+        throw DecodingError.dataCorruptedError(
+            forKey: key,
+            in: c,
+            debugDescription: "Invalid MALIBU amount"
+        )
+    }
+
+    private static func decodeOptionalDecimal(
+        _ c: KeyedDecodingContainer<CodingKeys>,
+        key: CodingKeys
+    ) throws -> Double? {
+        guard c.contains(key) else { return nil }
+        if let value = try? c.decode(Double.self, forKey: key), value.isFinite {
+            return value
+        }
+        if let text = try? c.decode(String.self, forKey: key),
+           let value = Double(text),
+           value.isFinite {
+            return value
+        }
+        return nil
     }
 }
 

--- a/phase3-binary/Sources/macprovider-cli/ProviderEarningsClient.swift
+++ b/phase3-binary/Sources/macprovider-cli/ProviderEarningsClient.swift
@@ -16,6 +16,17 @@ public struct ProviderEarningsSummary: Codable, Equatable, Sendable {
     public let malibuAllTime: Double?
     public let trustCriteriaMet: Int?
     public let trustCriteriaRequired: Int?
+    public let malibuWithdrawable: Double?
+    public let malibuHeld: Double?
+    public let malibuHoldReasons: [String]
+    public let malibuDailyCap: Double?
+    public let malibuWalletDailyCap: Double?
+    /// True only when GET /providers/{id}/earnings returned this projection.
+    public let earningsProjectionFresh: Bool
+    /// True only when the companion MALIBU accrual projection was fetched in
+    /// the same metrics cycle. A provider-earnings response alone must not
+    /// authorize reward availability or trust copy.
+    public let malibuProjectionFresh: Bool
 
     enum CodingKeys: String, CodingKey {
         case walletBound = "wallet_bound"
@@ -30,6 +41,13 @@ public struct ProviderEarningsSummary: Codable, Equatable, Sendable {
         case malibuAllTime = "malibu_all_time"
         case trustCriteriaMet = "trust_criteria_met"
         case trustCriteriaRequired = "trust_criteria_required"
+        case malibuWithdrawable = "malibu_withdrawable"
+        case malibuHeld = "malibu_held"
+        case malibuHoldReasons = "malibu_hold_reasons"
+        case malibuDailyCap = "malibu_daily_cap"
+        case malibuWalletDailyCap = "malibu_wallet_daily_cap"
+        case malibuProjectionFresh = "malibu_projection_fresh"
+        case earningsProjectionFresh = "earnings_projection_fresh"
     }
 
     public init(from decoder: Decoder) throws {
@@ -52,6 +70,13 @@ public struct ProviderEarningsSummary: Codable, Equatable, Sendable {
         malibuAllTime = try container.decodeIfPresent(Double.self, forKey: .malibuAllTime)
         trustCriteriaMet = try container.decodeIfPresent(Int.self, forKey: .trustCriteriaMet)
         trustCriteriaRequired = try container.decodeIfPresent(Int.self, forKey: .trustCriteriaRequired)
+        malibuWithdrawable = try container.decodeIfPresent(Double.self, forKey: .malibuWithdrawable)
+        malibuHeld = try container.decodeIfPresent(Double.self, forKey: .malibuHeld)
+        malibuHoldReasons = try container.decodeIfPresent([String].self, forKey: .malibuHoldReasons) ?? []
+        malibuDailyCap = try container.decodeIfPresent(Double.self, forKey: .malibuDailyCap)
+        malibuWalletDailyCap = try container.decodeIfPresent(Double.self, forKey: .malibuWalletDailyCap)
+        malibuProjectionFresh = try container.decodeIfPresent(Bool.self, forKey: .malibuProjectionFresh) ?? false
+        earningsProjectionFresh = try container.decodeIfPresent(Bool.self, forKey: .earningsProjectionFresh) ?? false
     }
 
     public init(
@@ -66,7 +91,14 @@ public struct ProviderEarningsSummary: Codable, Equatable, Sendable {
         malibuToday: Double?,
         malibuAllTime: Double?,
         trustCriteriaMet: Int?,
-        trustCriteriaRequired: Int?
+        trustCriteriaRequired: Int?,
+        malibuWithdrawable: Double? = nil,
+        malibuHeld: Double? = nil,
+        malibuHoldReasons: [String] = [],
+        malibuDailyCap: Double? = nil,
+        malibuWalletDailyCap: Double? = nil,
+        malibuProjectionFresh: Bool = false,
+        earningsProjectionFresh: Bool = false
     ) {
         self.walletBound = walletBound
         self.trustTier = trustTier
@@ -80,6 +112,37 @@ public struct ProviderEarningsSummary: Codable, Equatable, Sendable {
         self.malibuAllTime = malibuAllTime
         self.trustCriteriaMet = trustCriteriaMet
         self.trustCriteriaRequired = trustCriteriaRequired
+        self.malibuWithdrawable = malibuWithdrawable
+        self.malibuHeld = malibuHeld
+        self.malibuHoldReasons = malibuHoldReasons
+        self.malibuDailyCap = malibuDailyCap
+        self.malibuWalletDailyCap = malibuWalletDailyCap
+        self.malibuProjectionFresh = malibuProjectionFresh
+        self.earningsProjectionFresh = earningsProjectionFresh
+    }
+
+    func markingEarningsProjectionFresh() -> ProviderEarningsSummary {
+        ProviderEarningsSummary(
+            walletBound: walletBound,
+            trustTier: trustTier,
+            unpaidLedgerBacklogUSDC: unpaidLedgerBacklogUSDC,
+            unpaidLedgerBacklogMALIBU: unpaidLedgerBacklogMALIBU,
+            usdcToday: usdcToday,
+            usdcWeek: usdcWeek,
+            usdcPending: usdcPending,
+            usdcLifetime: usdcLifetime,
+            malibuToday: malibuToday,
+            malibuAllTime: malibuAllTime,
+            trustCriteriaMet: trustCriteriaMet,
+            trustCriteriaRequired: trustCriteriaRequired,
+            malibuWithdrawable: malibuWithdrawable,
+            malibuHeld: malibuHeld,
+            malibuHoldReasons: malibuHoldReasons,
+            malibuDailyCap: malibuDailyCap,
+            malibuWalletDailyCap: malibuWalletDailyCap,
+            malibuProjectionFresh: false,
+            earningsProjectionFresh: true
+        )
     }
 
     func merging(accrual: MalibuAccrualSummary) -> ProviderEarningsSummary {
@@ -95,7 +158,14 @@ public struct ProviderEarningsSummary: Codable, Equatable, Sendable {
             malibuToday: malibuToday,
             malibuAllTime: accrual.accruedMALIBU,
             trustCriteriaMet: accrual.trustCriteriaMet ?? trustCriteriaMet,
-            trustCriteriaRequired: accrual.trustCriteriaRequired ?? trustCriteriaRequired
+            trustCriteriaRequired: accrual.trustCriteriaRequired ?? trustCriteriaRequired,
+            malibuWithdrawable: accrual.withdrawableMALIBU,
+            malibuHeld: accrual.heldMALIBU,
+            malibuHoldReasons: accrual.withdrawalHoldReasons,
+            malibuDailyCap: accrual.dailyCapMALIBU,
+            malibuWalletDailyCap: accrual.walletDailyCapMALIBU,
+            malibuProjectionFresh: true,
+            earningsProjectionFresh: earningsProjectionFresh
         )
     }
 
@@ -112,7 +182,14 @@ public struct ProviderEarningsSummary: Codable, Equatable, Sendable {
             malibuToday: nil,
             malibuAllTime: accrual.accruedMALIBU,
             trustCriteriaMet: accrual.trustCriteriaMet,
-            trustCriteriaRequired: accrual.trustCriteriaRequired
+            trustCriteriaRequired: accrual.trustCriteriaRequired,
+            malibuWithdrawable: accrual.withdrawableMALIBU,
+            malibuHeld: accrual.heldMALIBU,
+            malibuHoldReasons: accrual.withdrawalHoldReasons,
+            malibuDailyCap: accrual.dailyCapMALIBU,
+            malibuWalletDailyCap: accrual.walletDailyCapMALIBU,
+            malibuProjectionFresh: true,
+            earningsProjectionFresh: false
         )
     }
 }
@@ -192,6 +269,8 @@ struct ProviderEarningsClient: Sendable {
         guard (200..<300).contains(http.statusCode) else {
             throw ProviderEarningsClientError.httpStatus(http.statusCode)
         }
-        return try JSONDecoder().decode(ProviderEarningsSummary.self, from: data)
+        return try JSONDecoder()
+            .decode(ProviderEarningsSummary.self, from: data)
+            .markingEarningsProjectionFresh()
     }
 }

--- a/phase3-binary/Tests/macprovider-cliTests/MalibuAccrualClientTests.swift
+++ b/phase3-binary/Tests/macprovider-cliTests/MalibuAccrualClientTests.swift
@@ -22,7 +22,10 @@ final class MalibuAccrualClientTests: XCTestCase {
           "trust_tier": "provisional",
           "trust_criteria_met": 2,
           "trust_criteria_required": 4,
-          "wallet_bound": true
+          "wallet_bound": true,
+          "daily_cap_malibu": "25",
+          "wallet_daily_cap_malibu": 100,
+          "withdrawal_hold_reasons": ["trust_tier_provisional"]
         }
         """.data(using: .utf8)!
         let summary = try JSONDecoder().decode(MalibuAccrualSummary.self, from: json)
@@ -33,6 +36,30 @@ final class MalibuAccrualClientTests: XCTestCase {
         XCTAssertEqual(summary.trustCriteriaMet, 2)
         XCTAssertEqual(summary.trustCriteriaRequired, 4)
         XCTAssertEqual(summary.walletBound, true)
+        XCTAssertEqual(summary.dailyCapMALIBU, 25)
+        XCTAssertEqual(summary.walletDailyCapMALIBU, 100)
+        XCTAssertEqual(summary.withdrawalHoldReasons, ["trust_tier_provisional"])
+    }
+
+    func testMissingRequiredAmountFailsClosed() {
+        let json = Data(#"{"accrued_malibu":1.25,"withdrawable_malibu":0,"trust_tier":"provisional"}"#.utf8)
+        XCTAssertThrowsError(try JSONDecoder().decode(MalibuAccrualSummary.self, from: json))
+    }
+
+    func testMissingTrustTierFailsClosed() {
+        let json = Data(#"{"accrued_malibu":1.25,"withdrawable_malibu":0,"held_malibu":1.25}"#.utf8)
+        XCTAssertThrowsError(try JSONDecoder().decode(MalibuAccrualSummary.self, from: json))
+    }
+
+    func testNonFiniteAmountFailsClosed() {
+        let json = Data(#"{"accrued_malibu":1.25,"withdrawable_malibu":0,"held_malibu":"NaN","trust_tier":"provisional"}"#.utf8)
+        XCTAssertThrowsError(try JSONDecoder().decode(MalibuAccrualSummary.self, from: json))
+    }
+
+    func testNonFiniteOptionalCapFailsClosed() throws {
+        let json = Data(#"{"accrued_malibu":1.25,"withdrawable_malibu":0,"held_malibu":1.25,"trust_tier":"provisional","daily_cap_malibu":"NaN"}"#.utf8)
+        let summary = try JSONDecoder().decode(MalibuAccrualSummary.self, from: json)
+        XCTAssertNil(summary.dailyCapMALIBU)
     }
 
     func testFetchUsesBearerToken() async throws {

--- a/phase3-binary/Tests/macprovider-cliTests/ProviderEarningsClientTests.swift
+++ b/phase3-binary/Tests/macprovider-cliTests/ProviderEarningsClientTests.swift
@@ -39,7 +39,12 @@ final class ProviderEarningsClientTests: XCTestCase {
               "malibu_today": 4,
               "malibu_all_time": 200,
               "trust_criteria_met": 4,
-              "trust_criteria_required": 4
+              "trust_criteria_required": 4,
+              "malibu_withdrawable": 3.5,
+              "malibu_held": 0.5,
+              "malibu_hold_reasons": ["per_wallet_daily_cap"],
+              "malibu_daily_cap": 25,
+              "malibu_wallet_daily_cap": 100
             }
             """.utf8)
             return (response, body)
@@ -56,6 +61,13 @@ final class ProviderEarningsClientTests: XCTestCase {
         XCTAssertEqual(summary.trustTier, "trusted")
         XCTAssertEqual(summary.usdcToday, 3)
         XCTAssertEqual(summary.malibuAllTime, 200)
+        XCTAssertEqual(summary.malibuWithdrawable, 3.5)
+        XCTAssertEqual(summary.malibuHeld, 0.5)
+        XCTAssertEqual(summary.malibuHoldReasons, ["per_wallet_daily_cap"])
+        XCTAssertEqual(summary.malibuDailyCap, 25)
+        XCTAssertEqual(summary.malibuWalletDailyCap, 100)
+        XCTAssertTrue(summary.earningsProjectionFresh)
+        XCTAssertFalse(summary.malibuProjectionFresh)
     }
 
     func testCurrentCoordinatorPayloadDefaultsAbsentPresentationFields() throws {
@@ -75,6 +87,8 @@ final class ProviderEarningsClientTests: XCTestCase {
         XCTAssertEqual(summary.unpaidLedgerBacklogUSDC, 1.25)
         XCTAssertNil(summary.usdcToday)
         XCTAssertNil(summary.malibuAllTime)
+        XCTAssertFalse(summary.earningsProjectionFresh)
+        XCTAssertFalse(summary.malibuProjectionFresh)
     }
 
     func testAccrualProjectionFillsTrustAndMalibuWithoutInventingUSDC() throws {
@@ -92,7 +106,10 @@ final class ProviderEarningsClientTests: XCTestCase {
               "trust_tier": "provisional",
               "trust_criteria_met": 2,
               "trust_criteria_required": 4,
-              "wallet_bound": true
+              "wallet_bound": true,
+              "daily_cap_malibu": "25",
+              "wallet_daily_cap_malibu": "100",
+              "withdrawal_hold_reasons": ["trust_tier_provisional"]
             }
             """.utf8)
         )
@@ -102,6 +119,13 @@ final class ProviderEarningsClientTests: XCTestCase {
         XCTAssertEqual(merged.malibuAllTime, 12.5)
         XCTAssertEqual(merged.trustCriteriaMet, 2)
         XCTAssertNil(merged.usdcToday)
+        XCTAssertEqual(merged.malibuWithdrawable, 0)
+        XCTAssertEqual(merged.malibuHeld, 12.5)
+        XCTAssertEqual(merged.malibuHoldReasons, ["trust_tier_provisional"])
+        XCTAssertEqual(merged.malibuDailyCap, 25)
+        XCTAssertEqual(merged.malibuWalletDailyCap, 100)
+        XCTAssertTrue(merged.malibuProjectionFresh)
+        XCTAssertFalse(merged.earningsProjectionFresh)
     }
 }
 

--- a/phase3-binary/app/Sources/Malibu/Agent/AgentSnapshot.swift
+++ b/phase3-binary/app/Sources/Malibu/Agent/AgentSnapshot.swift
@@ -45,6 +45,16 @@ struct AgentSnapshot: Equatable {
     var earningsUsdcPending: Double?
     var earningsUsdcLifetime: Double?
     var malibuAccruedAllTime: Double?
+    var malibuWithdrawable: Double?
+    var malibuHeld: Double?
+    var malibuHoldReasons: [String]
+    var malibuDailyCap: Double?
+    var malibuWalletDailyCap: Double?
+    /// Freshness for the provider earnings endpoint.
+    var providerEarningsFresh: Bool
+    /// Reward-specific freshness. It is separate so a partial earnings frame
+    /// cannot authorize held/withdrawable/trust copy.
+    var malibuProjectionFresh: Bool
     var gpuUtilizationPct: Double?
     var gpuTemperatureC: Double?
     var latencyP50Ms: Int?
@@ -294,6 +304,13 @@ struct AgentSnapshot: Equatable {
         earningsUsdcPending: nil,
         earningsUsdcLifetime: nil,
         malibuAccruedAllTime: nil,
+        malibuWithdrawable: nil,
+        malibuHeld: nil,
+        malibuHoldReasons: [],
+        malibuDailyCap: nil,
+        malibuWalletDailyCap: nil,
+        providerEarningsFresh: false,
+        malibuProjectionFresh: false,
         gpuUtilizationPct: nil,
         gpuTemperatureC: nil,
         latencyP50Ms: nil,
@@ -669,6 +686,8 @@ enum AgentSnapshotPresenter {
         switch s.state {
         case .serving where !isNetworkReady(s):
             return status.detail
+        case .serving where !s.providerEarningsFresh:
+            return "Ready for customer work · earnings unavailable"
         case .serving where s.earningsUsdcToday == nil:
             return "Ready for customer work · waiting for the first paid job"
         case .serving:
@@ -716,23 +735,34 @@ enum AgentSnapshotPresenter {
     }
 
     static func earningsLine(_ s: AgentSnapshot) -> String {
+        if !s.providerEarningsFresh || !s.malibuProjectionFresh {
+            if s.earningsUsdcToday == nil, s.malibuAccruedToday == nil {
+                return isActive(s) ? "Today: reward status unavailable" : "Today: not running"
+            }
+            let usdc = s.providerEarningsFresh
+                ? s.earningsUsdcToday.map { String(format: "$%.2f", $0) } ?? "n/a"
+                : "n/a"
+            let malibu = s.malibuProjectionFresh
+                ? s.malibuAccruedToday.map { String(format: "%.2f", $0) } ?? "n/a"
+                : "n/a"
+            return "Today: \(usdc) USDC · \(malibu) MALIBU (reward status unavailable)"
+        }
         switch (s.earningsUsdcToday, s.malibuAccruedToday) {
         case (nil, nil):
-            if isActive(s) {
-                return "Today: $0.00 USDC · 0.00 MALIBU (no jobs yet)"
-            }
-            return "Today: not running"
+            return isActive(s) ? "Today: reward status unavailable" : "Today: not running"
         case let (usdc?, malibu?):
             return String(format: "Today: $%.2f USDC · %@", usdc, malibuDisplay(malibu, tier: s.trustTier))
         case let (usdc?, nil):
-            return String(format: "Today: $%.2f USDC · 0.00 MALIBU", usdc)
+            return String(format: "Today: $%.2f USDC · n/a MALIBU (reward status unavailable)", usdc)
         case let (nil, malibu?):
-            return "Today: $0.00 USDC · \(malibuDisplay(malibu, tier: s.trustTier))"
+            return "Today: n/a USDC · \(malibuDisplay(malibu, tier: s.trustTier))"
         }
     }
 
     static func backlogLine(_ s: AgentSnapshot) -> String? {
-        guard s.walletBound == false,
+        guard s.providerEarningsFresh,
+              s.malibuProjectionFresh,
+              s.walletBound == false,
               let usdc = s.unpaidLedgerBacklogUSDC,
               let malibu = s.unpaidLedgerBacklogMALIBU,
               usdc + malibu > 0 else {
@@ -1056,24 +1086,34 @@ enum AgentSnapshotPresenter {
     }
 
     static func usdcFullLine(_ s: AgentSnapshot) -> String {
-        let unset = isActive(s) ? "$0.00" : "n/a"
+        if !s.providerEarningsFresh {
+            let today = "n/a today"
+            return "\(today) · n/a wk · n/a pending · n/a life"
+        }
         return [
-            s.earningsUsdcToday.map { String(format: "$%.2f today", $0) } ?? "\(unset) today",
-            s.earningsUsdcWeek.map { String(format: "$%.2f wk", $0) } ?? "\(unset) wk",
-            s.earningsUsdcPending.map { String(format: "$%.2f pending", $0) } ?? "\(unset) pending",
-            s.earningsUsdcLifetime.map { String(format: "$%.2f life", $0) } ?? "\(unset) life"
+            s.earningsUsdcToday.map { String(format: "$%.2f today", $0) } ?? "n/a today",
+            s.earningsUsdcWeek.map { String(format: "$%.2f wk", $0) } ?? "n/a wk",
+            s.earningsUsdcPending.map { String(format: "$%.2f pending", $0) } ?? "n/a pending",
+            s.earningsUsdcLifetime.map { String(format: "$%.2f life", $0) } ?? "n/a life"
         ].joined(separator: " · ")
     }
 
     static func usdcTodayDisplay(_ s: AgentSnapshot) -> String {
-        s.earningsUsdcToday.map { String(format: "$%.2f", $0) } ?? (isActive(s) ? "$0.00" : "n/a")
+        guard s.providerEarningsFresh else {
+            return "n/a"
+        }
+        return s.earningsUsdcToday.map { String(format: "$%.2f", $0) } ?? "n/a"
     }
 
     static func malibuFullLine(_ s: AgentSnapshot) -> String {
+        if !s.malibuProjectionFresh {
+            let today = "n/a MALIBU today"
+            return "\(today) · n/a all-time"
+        }
         let today = s.malibuAccruedToday.map { malibuDisplay($0, tier: s.trustTier, compact: true) }
-            ?? (isActive(s) ? "0.00 MALIBU today" : "n/a MALIBU today")
+            ?? "n/a MALIBU today"
         let allTime = s.malibuAccruedAllTime.map { String(format: "%.2f all-time", $0) }
-            ?? (isActive(s) ? "0.00 all-time" : "n/a all-time")
+            ?? "n/a all-time"
         switch s.trustTier {
         case .trusted:
             return "\(today) · \(allTime)"
@@ -1082,7 +1122,35 @@ enum AgentSnapshotPresenter {
         }
     }
 
+    static func malibuAvailabilityLine(_ s: AgentSnapshot) -> String? {
+        guard s.malibuProjectionFresh,
+              s.malibuWithdrawable != nil || s.malibuHeld != nil else { return nil }
+        let withdrawable = s.malibuWithdrawable.map { String(format: "%.2f available", $0) } ?? "n/a available"
+        let held = s.malibuHeld.map { String(format: "%.2f held", $0) } ?? "n/a held"
+        return "MALIBU: \(withdrawable) · \(held)"
+    }
+
+    static func malibuHoldLine(_ s: AgentSnapshot) -> String? {
+        guard s.malibuProjectionFresh, !s.malibuHoldReasons.isEmpty else { return nil }
+        let reasons = s.malibuHoldReasons.map { malibuHoldReasonCopy($0) }
+        let nextAction: String
+        if s.malibuHoldReasons.contains("trust_tier_provisional"),
+           let met = s.trustCriteriaMet,
+           let required = s.trustCriteriaRequired,
+           required > met {
+            nextAction = "Complete \(required - met) more trust criteria to unlock withdrawals."
+        } else if s.malibuHoldReasons.contains("per_wallet_daily_cap") {
+            nextAction = "The wallet cap resets at the next UTC day."
+        } else if s.malibuHoldReasons.contains("demotion_cooldown") {
+            nextAction = "Re-qualify for Trusted to clear the cooldown."
+        } else {
+            nextAction = "Review the hold reason above before withdrawing."
+        }
+        return "Held because: \(reasons.joined(separator: "; ")) Next: \(nextAction)"
+    }
+
     static func trustLine(_ s: AgentSnapshot) -> String {
+        guard s.malibuProjectionFresh else { return "Trust status unavailable" }
         let tier = s.trustTier.rawValue.capitalized
         if let met = s.trustCriteriaMet, let required = s.trustCriteriaRequired {
             return "\(tier) — \(met) of \(required) criteria met · Unlock Trusted →"
@@ -1151,7 +1219,7 @@ enum AgentSnapshotPresenter {
     }
 
     static func unclaimedBacklogTotal(_ s: AgentSnapshot) -> Double? {
-        guard s.walletBound == false else { return nil }
+        guard s.providerEarningsFresh, s.malibuProjectionFresh, s.walletBound == false else { return nil }
         let total = (s.unpaidLedgerBacklogUSDC ?? 0) + (s.unpaidLedgerBacklogMALIBU ?? 0)
         return total > 0 ? total : nil
     }
@@ -1316,6 +1384,19 @@ enum AgentSnapshotPresenter {
                 return String(format: "%.2f MALIBU today (locked)", amount)
             }
             return String(format: "[locked] %.2f MALIBU (unlocks at Trusted)", amount)
+        }
+    }
+
+    private static func malibuHoldReasonCopy(_ reason: String) -> String {
+        switch reason {
+        case "trust_tier_provisional":
+            return "Trust verification is incomplete"
+        case "per_wallet_daily_cap":
+            return "the wallet's daily limit has been reached"
+        case "demotion_cooldown":
+            return "a Trust cooldown is active"
+        default:
+            return "payout eligibility is still being verified"
         }
     }
 

--- a/phase3-binary/app/Sources/Malibu/Agent/EarningsClient.swift
+++ b/phase3-binary/app/Sources/Malibu/Agent/EarningsClient.swift
@@ -15,6 +15,16 @@ struct ProviderEarnings: Codable, Equatable {
     let malibuAllTime: Double?
     let trustCriteriaMet: Int?
     let trustCriteriaRequired: Int?
+    let malibuWithdrawable: Double?
+    let malibuHeld: Double?
+    let malibuHoldReasons: [String]
+    let malibuDailyCap: Double?
+    let malibuWalletDailyCap: Double?
+    /// Set only when the CLI fetched the companion MALIBU accrual projection.
+    /// Missing/legacy wire data is intentionally not treated as fresh.
+    let malibuProjectionFresh: Bool
+    /// True only when the CLI fetched the provider earnings endpoint.
+    let earningsProjectionFresh: Bool
 
     enum CodingKeys: String, CodingKey {
         case walletBound = "wallet_bound"
@@ -29,6 +39,13 @@ struct ProviderEarnings: Codable, Equatable {
         case malibuAllTime = "malibu_all_time"
         case trustCriteriaMet = "trust_criteria_met"
         case trustCriteriaRequired = "trust_criteria_required"
+        case malibuWithdrawable = "malibu_withdrawable"
+        case malibuHeld = "malibu_held"
+        case malibuHoldReasons = "malibu_hold_reasons"
+        case malibuDailyCap = "malibu_daily_cap"
+        case malibuWalletDailyCap = "malibu_wallet_daily_cap"
+        case malibuProjectionFresh = "malibu_projection_fresh"
+        case earningsProjectionFresh = "earnings_projection_fresh"
     }
 
     init(from decoder: Decoder) throws {
@@ -45,6 +62,13 @@ struct ProviderEarnings: Codable, Equatable {
         malibuAllTime = try c.decodeIfPresent(Double.self, forKey: .malibuAllTime)
         trustCriteriaMet = try c.decodeIfPresent(Int.self, forKey: .trustCriteriaMet)
         trustCriteriaRequired = try c.decodeIfPresent(Int.self, forKey: .trustCriteriaRequired)
+        malibuWithdrawable = try c.decodeIfPresent(Double.self, forKey: .malibuWithdrawable)
+        malibuHeld = try c.decodeIfPresent(Double.self, forKey: .malibuHeld)
+        malibuHoldReasons = try c.decodeIfPresent([String].self, forKey: .malibuHoldReasons) ?? []
+        malibuDailyCap = try c.decodeIfPresent(Double.self, forKey: .malibuDailyCap)
+        malibuWalletDailyCap = try c.decodeIfPresent(Double.self, forKey: .malibuWalletDailyCap)
+        malibuProjectionFresh = try c.decodeIfPresent(Bool.self, forKey: .malibuProjectionFresh) ?? false
+        earningsProjectionFresh = try c.decodeIfPresent(Bool.self, forKey: .earningsProjectionFresh) ?? false
     }
 
     init(
@@ -59,7 +83,14 @@ struct ProviderEarnings: Codable, Equatable {
         malibuToday: Double?,
         malibuAllTime: Double?,
         trustCriteriaMet: Int?,
-        trustCriteriaRequired: Int?
+        trustCriteriaRequired: Int?,
+        malibuWithdrawable: Double? = nil,
+        malibuHeld: Double? = nil,
+        malibuHoldReasons: [String] = [],
+        malibuDailyCap: Double? = nil,
+        malibuWalletDailyCap: Double? = nil,
+        malibuProjectionFresh: Bool = false,
+        earningsProjectionFresh: Bool = false
     ) {
         self.walletBound = walletBound
         self.trustTier = trustTier
@@ -73,6 +104,13 @@ struct ProviderEarnings: Codable, Equatable {
         self.malibuAllTime = malibuAllTime
         self.trustCriteriaMet = trustCriteriaMet
         self.trustCriteriaRequired = trustCriteriaRequired
+        self.malibuWithdrawable = malibuWithdrawable
+        self.malibuHeld = malibuHeld
+        self.malibuHoldReasons = malibuHoldReasons
+        self.malibuDailyCap = malibuDailyCap
+        self.malibuWalletDailyCap = malibuWalletDailyCap
+        self.malibuProjectionFresh = malibuProjectionFresh
+        self.earningsProjectionFresh = earningsProjectionFresh
     }
 }
 

--- a/phase3-binary/app/Sources/Malibu/Agent/MalibuAgent.swift
+++ b/phase3-binary/app/Sources/Malibu/Agent/MalibuAgent.swift
@@ -40,6 +40,9 @@ final class MalibuAgent: ObservableObject {
     private var isShuttingDown: Bool = false
     private var healthPollTask: Task<Void, Never>?
     private var monitorsLaunchdProvider = false
+    /// Reward projections may become fresh only after the current provider
+    /// passes both the local readiness and service-identity checks.
+    private var providerProjectionEligible = false
     private var lastRequestsRateSample: (total: Int, date: Date)?
     private var latestReleaseFetchedAt: Date?
     private var cliUpdateTask: Task<Void, Never>?
@@ -54,8 +57,12 @@ final class MalibuAgent: ObservableObject {
     private var lastReferralRefreshRequestedAt: Date?
     private let latestReleaseTTL: TimeInterval = 3600
 
-    init(initialSnapshot: AgentSnapshot = .empty) {
+    init(
+        initialSnapshot: AgentSnapshot = .empty,
+        projectionEligibleForMetrics: Bool = false
+    ) {
         snapshot = initialSnapshot
+        providerProjectionEligible = projectionEligibleForMetrics
         thermalMonitor.$state
             .sink { [weak self] state in
                 self?.snapshot.thermalState = state
@@ -68,6 +75,7 @@ final class MalibuAgent: ObservableObject {
 
     func start() async {
         guard !isShuttingDown else { return }
+        invalidateProviderProjectionFreshness()
 
         guard ProviderConfig.readProviderID() != nil else {
             snapshot.state = .error
@@ -530,23 +538,30 @@ final class MalibuAgent: ObservableObject {
     /// this, onboarding can leave two macprovider-cli processes (different
     /// ports, same provider_id) running concurrently.
     private func releaseSpawnedChildForLaunchdMonitor() async {
-        guard child != nil else { return }
+        invalidateProviderProjectionFreshness()
         reconnectTask?.cancel()
         reconnectTask = nil
-        child?.markStopping()
-        try? await control?.send(.shutdownRequest(graceSeconds: 5))
-        await child?.stop(gracePeriod: 5)
+        let oldControl = control
         metricsPoller?.cancel()
         metricsPoller = nil
         eventStreamTask?.cancel()
         eventStreamTask = nil
-        await control?.close()
-        child = nil
         control = nil
+        if child != nil {
+            child?.markStopping()
+            try? await oldControl?.send(.shutdownRequest(graceSeconds: 5))
+            await child?.stop(gracePeriod: 5)
+        }
+        await oldControl?.close()
+        child = nil
+        invalidateProviderProjectionFreshness()
     }
 
     private func applyProviderSnapshot(port: Int) async {
         let localReady = await applyHealthSnapshot(port: port)
+        if !localReady {
+            invalidateProviderProjectionFreshness()
+        }
         if let status = await InstalledProviderMonitor.fetchStatus(port: port),
            let expectedProviderID = ProviderConfig.readProviderID(),
            InstalledProviderMonitor.serviceIdentityMatches(
@@ -609,6 +624,7 @@ final class MalibuAgent: ObservableObject {
             snapshot.coordinatorIdentityAdmissionMode = status.coordinatorIdentityAdmissionMode
             snapshot.coordinatorConnected = status.coordinatorConnected
             snapshot.networkState = status.networkState
+            providerProjectionEligible = localReady
             snapshot.advertisedMaxConcurrency = status.advertisedMaxConcurrency
             snapshot.catalogState = status.catalogState
             snapshot.catalogReleaseID = status.catalogReleaseID
@@ -639,6 +655,7 @@ final class MalibuAgent: ObservableObject {
             // Never carry a prior authoritative serving verdict across a
             // failed status/readiness refresh.
             snapshot.invalidateLocalStatusObservation()
+            invalidateProviderProjectionFreshness()
         }
         reconcileNetworkState(localReady: localReady)
         await refreshLatestReleaseIfNeeded()
@@ -835,6 +852,7 @@ final class MalibuAgent: ObservableObject {
                 } else if self.monitorsLaunchdProvider {
                     await MainActor.run {
                         self.snapshot.invalidateLocalStatusObservation()
+                        self.invalidateProviderProjectionFreshness()
                         if let failure = self.diagnosedProviderFailure() {
                             self.providerStartFailure = failure
                             self.snapshot.state = .error
@@ -871,6 +889,7 @@ final class MalibuAgent: ObservableObject {
             // unexpected exit so the user (or model-load recovery) can retry.
             snapshot.state = .error
             snapshot.lastError = "Control socket: \(error)"
+            invalidateProviderProjectionFreshness()
             child?.markStopping()
             await child?.stop(gracePeriod: 5)
             child = nil
@@ -886,7 +905,8 @@ final class MalibuAgent: ObservableObject {
 
         eventStreamTask = Task { [weak self] in
             for await frame in client.stream {
-                self?.consume(frame)
+                guard let self, !Task.isCancelled, self.control === client else { return }
+                self.consume(frame)
             }
             await client.close()
             guard let self, self.control === client else { return }
@@ -931,7 +951,8 @@ final class MalibuAgent: ObservableObject {
         eventStreamTask?.cancel()
         eventStreamTask = Task { [weak self] in
             for await frame in client.stream {
-                self?.consume(frame)
+                guard let self, !Task.isCancelled, self.control === client else { return }
+                self.consume(frame)
             }
             await client.close()
             guard let self, self.control === client else { return }
@@ -1100,6 +1121,7 @@ final class MalibuAgent: ObservableObject {
 
     private func markReferralControlDisconnected() {
         finishReferralAction()
+        invalidateProviderProjectionFreshness()
         referralStatusExpiryTask?.cancel()
         referralStatusExpiryTask = nil
         lastReferralRefreshRequestedAt = nil
@@ -1108,6 +1130,12 @@ final class MalibuAgent: ObservableObject {
         if snapshot.hasTrustedReferralBoundary() {
             snapshot.referralLastError = "Invite status is unavailable while Malibu reconnects to the provider."
         }
+    }
+
+    private func invalidateProviderProjectionFreshness() {
+        snapshot.providerEarningsFresh = false
+        snapshot.malibuProjectionFresh = false
+        providerProjectionEligible = false
     }
 
     func consume(_ frame: ControlFrame) {
@@ -1173,6 +1201,10 @@ final class MalibuAgent: ObservableObject {
                 snapshot.inputTokensAllTime = inputTokensAllTime
                 snapshot.outputTokensAllTime = outputTokensAllTime
             }
+            snapshot.malibuProjectionFresh = providerProjectionEligible
+                && providerEarnings?.malibuProjectionFresh == true
+            snapshot.providerEarningsFresh = providerProjectionEligible
+                && providerEarnings?.earningsProjectionFresh == true
             if let providerEarnings {
                 snapshot.walletBound = providerEarnings.walletBound
                 snapshot.trustTier = providerEarnings.trustTier
@@ -1184,6 +1216,11 @@ final class MalibuAgent: ObservableObject {
                 snapshot.earningsUsdcLifetime = providerEarnings.usdcLifetime
                 snapshot.malibuAccruedToday = providerEarnings.malibuToday
                 snapshot.malibuAccruedAllTime = providerEarnings.malibuAllTime
+                snapshot.malibuWithdrawable = providerEarnings.malibuWithdrawable
+                snapshot.malibuHeld = providerEarnings.malibuHeld
+                snapshot.malibuHoldReasons = providerEarnings.malibuHoldReasons
+                snapshot.malibuDailyCap = providerEarnings.malibuDailyCap
+                snapshot.malibuWalletDailyCap = providerEarnings.malibuWalletDailyCap
                 snapshot.trustCriteriaMet = providerEarnings.trustCriteriaMet
                 snapshot.trustCriteriaRequired = providerEarnings.trustCriteriaRequired
             }

--- a/phase3-binary/app/Sources/Malibu/Dashboard/DashboardWindow.swift
+++ b/phase3-binary/app/Sources/Malibu/Dashboard/DashboardWindow.swift
@@ -82,8 +82,22 @@ private struct DashboardView: View {
                         .foregroundStyle(.secondary)
                         .font(.callout)
                     Text(AgentSnapshotPresenter.malibuFullLine(agent.snapshot))
-                        .foregroundStyle(agent.snapshot.trustTier == .provisional ? MalibuBrand.coral : .secondary)
+                        .foregroundStyle(
+                            agent.snapshot.malibuProjectionFresh && agent.snapshot.trustTier == .provisional
+                                ? MalibuBrand.coral
+                                : .secondary
+                        )
                         .font(.callout)
+                    if let availability = AgentSnapshotPresenter.malibuAvailabilityLine(agent.snapshot) {
+                        Text(availability)
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+                    if let hold = AgentSnapshotPresenter.malibuHoldLine(agent.snapshot) {
+                        Text(hold)
+                            .font(.caption)
+                            .foregroundStyle(MalibuBrand.coral)
+                    }
                     if let backlog = AgentSnapshotPresenter.backlogLine(agent.snapshot) {
                         Text(backlog)
                             .font(.caption)

--- a/phase3-binary/app/Tests/MalibuTests/AgentSnapshotPresenterTests.swift
+++ b/phase3-binary/app/Tests/MalibuTests/AgentSnapshotPresenterTests.swift
@@ -23,11 +23,10 @@ final class AgentSnapshotPresenterTests: XCTestCase {
         "referral_bootstrap_v1",
     ]
 
-    func testEarningsLineShowsZeroWhenBothMetricsMissingWhileServing() {
+    func testEarningsLineShowsUnavailableWhenBothMetricsMissingWhileServing() {
         var s = AgentSnapshot.empty
         s.state = .serving
-        XCTAssertTrue(AgentSnapshotPresenter.earningsLine(s).contains("$0.00"))
-        XCTAssertTrue(AgentSnapshotPresenter.earningsLine(s).contains("no jobs yet"))
+        XCTAssertEqual(AgentSnapshotPresenter.earningsLine(s), "Today: reward status unavailable")
     }
 
     func testShortShowsServingWhenNoEarningsYet() {
@@ -282,6 +281,8 @@ final class AgentSnapshotPresenterTests: XCTestCase {
         s.earningsUsdcToday = 1
         s.malibuAccruedToday = 2
         s.trustTier = .provisional
+        s.providerEarningsFresh = true
+        s.malibuProjectionFresh = true
         XCTAssertTrue(AgentSnapshotPresenter.earningsLine(s).contains("[locked] 2.00 MALIBU"))
         XCTAssertTrue(AgentSnapshotPresenter.earningsLine(s).contains("unlocks at Trusted"))
     }
@@ -291,6 +292,8 @@ final class AgentSnapshotPresenterTests: XCTestCase {
         s.unpaidLedgerBacklogUSDC = 10
         s.unpaidLedgerBacklogMALIBU = 5
         s.walletBound = false
+        s.providerEarningsFresh = true
+        s.malibuProjectionFresh = true
         XCTAssertNotNil(AgentSnapshotPresenter.backlogLine(s))
         s.walletBound = true
         XCTAssertNil(AgentSnapshotPresenter.backlogLine(s))
@@ -795,6 +798,8 @@ final class AgentSnapshotPresenterTests: XCTestCase {
         s.walletBound = false
         s.unpaidLedgerBacklogUSDC = 9
         s.unpaidLedgerBacklogMALIBU = 0
+        s.providerEarningsFresh = true
+        s.malibuProjectionFresh = true
         XCTAssertEqual(AgentSnapshotPresenter.unclaimedBadge(s, dismissedThreshold: nil), "$1+")
         XCTAssertNil(AgentSnapshotPresenter.unclaimedBadge(s, dismissedThreshold: 10))
 
@@ -812,7 +817,12 @@ final class AgentSnapshotPresenterTests: XCTestCase {
           "wallet_bound": false,
           "trust_tier": "Trusted",
           "unpaid_ledger_backlog_usdc": 12.5,
-          "unpaid_ledger_backlog_malibu": 7.25
+          "unpaid_ledger_backlog_malibu": 7.25,
+          "malibu_withdrawable": 3.5,
+          "malibu_held": 0.5,
+          "malibu_hold_reasons": ["per_wallet_daily_cap"],
+          "malibu_daily_cap": 25,
+          "malibu_wallet_daily_cap": 100
         }
         """.utf8)
         let decoded = try JSONDecoder().decode(ProviderEarnings.self, from: data)
@@ -820,6 +830,37 @@ final class AgentSnapshotPresenterTests: XCTestCase {
         XCTAssertEqual(decoded.trustTier, .trusted)
         XCTAssertEqual(decoded.unpaidLedgerBacklogUSDC, 12.5)
         XCTAssertEqual(decoded.unpaidLedgerBacklogMALIBU, 7.25)
+        XCTAssertEqual(decoded.malibuWithdrawable, 3.5)
+        XCTAssertEqual(decoded.malibuHeld, 0.5)
+        XCTAssertEqual(decoded.malibuHoldReasons, ["per_wallet_daily_cap"])
+        XCTAssertEqual(decoded.malibuDailyCap, 25)
+        XCTAssertEqual(decoded.malibuWalletDailyCap, 100)
+        XCTAssertFalse(decoded.malibuProjectionFresh)
+        XCTAssertFalse(decoded.earningsProjectionFresh)
+    }
+
+    func testMalibuAvailabilityAndHoldCopyExplainWithdrawalState() {
+        var snapshot = AgentSnapshot.empty
+        snapshot.trustTier = .provisional
+        snapshot.providerEarningsFresh = true
+        snapshot.malibuProjectionFresh = true
+        snapshot.malibuWithdrawable = 0
+        snapshot.malibuHeld = 12.5
+        snapshot.malibuHoldReasons = ["trust_tier_provisional"]
+        snapshot.trustCriteriaMet = 2
+        snapshot.trustCriteriaRequired = 4
+
+        XCTAssertEqual(AgentSnapshotPresenter.malibuAvailabilityLine(snapshot), "MALIBU: 0.00 available · 12.50 held")
+        XCTAssertEqual(
+            AgentSnapshotPresenter.malibuHoldLine(snapshot),
+            "Held because: Trust verification is incomplete Next: Complete 2 more trust criteria to unlock withdrawals."
+        )
+
+        snapshot.malibuHoldReasons = ["per_wallet_daily_cap"]
+        XCTAssertEqual(
+            AgentSnapshotPresenter.malibuHoldLine(snapshot),
+            "Held because: the wallet's daily limit has been reached Next: The wallet cap resets at the next UTC day."
+        )
     }
 
     func testDefaultPresenterStringsDoNotExposeInternalTerms() {

--- a/phase3-binary/app/Tests/MalibuTests/ControlFrameCodecTests.swift
+++ b/phase3-binary/app/Tests/MalibuTests/ControlFrameCodecTests.swift
@@ -55,7 +55,14 @@ final class ControlFrameCodecTests: XCTestCase {
                 malibuToday: 3.5,
                 malibuAllTime: 42,
                 trustCriteriaMet: 4,
-                trustCriteriaRequired: 4
+                trustCriteriaRequired: 4,
+                malibuWithdrawable: 3,
+                malibuHeld: 0.5,
+                malibuHoldReasons: ["per_wallet_daily_cap"],
+                malibuDailyCap: 25,
+                malibuWalletDailyCap: 100,
+                malibuProjectionFresh: true,
+                earningsProjectionFresh: true
             ),
             gpuC: 48.2,
             gpuUtilizationPct: 62,
@@ -123,6 +130,158 @@ final class ControlFrameCodecTests: XCTestCase {
         } else {
             XCTFail("expected metricsResponse")
         }
+    }
+
+    @MainActor
+    func testMetricsFrameWithoutProviderEarningsHidesPriorRewardProjection() {
+        var initial = AgentSnapshot.empty
+        initial.providerEarningsFresh = true
+        initial.malibuProjectionFresh = true
+        initial.earningsUsdcToday = 4.12
+        initial.earningsUsdcWeek = 18.4
+        initial.earningsUsdcPending = 6.9
+        initial.earningsUsdcLifetime = 211
+        initial.malibuAccruedToday = 12
+        initial.malibuAccruedAllTime = 50
+        initial.unpaidLedgerBacklogUSDC = 1
+        initial.unpaidLedgerBacklogMALIBU = 2
+        initial.trustTier = .provisional
+        initial.trustCriteriaMet = 4
+        initial.trustCriteriaRequired = 4
+        initial.malibuWithdrawable = 3
+        initial.malibuHeld = 0.5
+        initial.malibuHoldReasons = ["per_wallet_daily_cap"]
+
+        let agent = MalibuAgent(initialSnapshot: initial)
+        agent.consume(.metricsResponse(
+            earningsUsdc: nil,
+            malibuAccrued: 7,
+            providerEarnings: nil,
+            gpuC: nil,
+            gpuUtilizationPct: nil,
+            latencyP50Ms: nil,
+            latencyP99Ms: nil,
+            queueDepth: nil,
+            requestsServedToday: nil,
+            requestsServedAllTime: nil,
+            requestsPerMinute: nil,
+            inputTokensToday: nil,
+            outputTokensToday: nil,
+            inputTokensAllTime: nil,
+            outputTokensAllTime: nil,
+            uptimeSec: nil
+        ))
+
+        XCTAssertFalse(agent.snapshot.providerEarningsFresh)
+        XCTAssertFalse(agent.snapshot.malibuProjectionFresh)
+        XCTAssertNil(AgentSnapshotPresenter.malibuAvailabilityLine(agent.snapshot))
+        XCTAssertNil(AgentSnapshotPresenter.malibuHoldLine(agent.snapshot))
+        XCTAssertFalse(AgentSnapshotPresenter.usdcFullLine(agent.snapshot).contains("$18.40"))
+        XCTAssertEqual(AgentSnapshotPresenter.malibuFullLine(agent.snapshot), "n/a MALIBU today · n/a all-time")
+        XCTAssertFalse(AgentSnapshotPresenter.earningsLine(agent.snapshot).contains("[locked]"))
+        XCTAssertFalse(AgentSnapshotPresenter.earningsLine(agent.snapshot).contains("Trusted"))
+        XCTAssertEqual(AgentSnapshotPresenter.trustLine(agent.snapshot), "Trust status unavailable")
+        XCTAssertNil(AgentSnapshotPresenter.backlogLine(agent.snapshot))
+    }
+
+    @MainActor
+    func testPartialProviderProjectionsKeepFreshnessSourceSpecific() {
+        let earningsOnly = ProviderEarnings(
+            walletBound: false,
+            trustTier: .provisional,
+            unpaidLedgerBacklogUSDC: 1,
+            unpaidLedgerBacklogMALIBU: 2,
+            usdcToday: 4,
+            usdcWeek: 8,
+            usdcPending: nil,
+            usdcLifetime: 20,
+            malibuToday: nil,
+            malibuAllTime: 30,
+            trustCriteriaMet: 2,
+            trustCriteriaRequired: 4,
+            malibuWithdrawable: nil,
+            malibuHeld: nil,
+            malibuProjectionFresh: false,
+            earningsProjectionFresh: true
+        )
+        var initialSnapshot = AgentSnapshot.empty
+        initialSnapshot.state = .serving
+        let agent = MalibuAgent(
+            initialSnapshot: initialSnapshot,
+            projectionEligibleForMetrics: true
+        )
+        agent.consume(.metricsResponse(
+            earningsUsdc: 4,
+            malibuAccrued: 9,
+            providerEarnings: earningsOnly,
+            gpuC: nil,
+            gpuUtilizationPct: nil,
+            latencyP50Ms: nil,
+            latencyP99Ms: nil,
+            queueDepth: nil,
+            requestsServedToday: nil,
+            requestsServedAllTime: nil,
+            requestsPerMinute: nil,
+            inputTokensToday: nil,
+            outputTokensToday: nil,
+            inputTokensAllTime: nil,
+            outputTokensAllTime: nil,
+            uptimeSec: 1
+        ))
+
+        XCTAssertTrue(agent.snapshot.providerEarningsFresh)
+        XCTAssertFalse(agent.snapshot.malibuProjectionFresh)
+        XCTAssertEqual(AgentSnapshotPresenter.usdcTodayDisplay(agent.snapshot), "$4.00")
+        XCTAssertNil(AgentSnapshotPresenter.malibuAvailabilityLine(agent.snapshot))
+        XCTAssertTrue(AgentSnapshotPresenter.earningsLine(agent.snapshot).contains("$4.00 USDC"))
+        XCTAssertTrue(AgentSnapshotPresenter.earningsLine(agent.snapshot).contains("n/a MALIBU"))
+
+        let accrualOnly = ProviderEarnings(
+            walletBound: false,
+            trustTier: .provisional,
+            unpaidLedgerBacklogUSDC: 0,
+            unpaidLedgerBacklogMALIBU: 0,
+            usdcToday: nil,
+            usdcWeek: nil,
+            usdcPending: nil,
+            usdcLifetime: nil,
+            malibuToday: nil,
+            malibuAllTime: 30,
+            trustCriteriaMet: 2,
+            trustCriteriaRequired: 4,
+            malibuWithdrawable: 1,
+            malibuHeld: 8,
+            malibuProjectionFresh: true,
+            earningsProjectionFresh: false
+        )
+        agent.consume(.metricsResponse(
+            earningsUsdc: nil,
+            malibuAccrued: 9,
+            providerEarnings: accrualOnly,
+            gpuC: nil,
+            gpuUtilizationPct: nil,
+            latencyP50Ms: nil,
+            latencyP99Ms: nil,
+            queueDepth: nil,
+            requestsServedToday: nil,
+            requestsServedAllTime: nil,
+            requestsPerMinute: nil,
+            inputTokensToday: nil,
+            outputTokensToday: nil,
+            inputTokensAllTime: nil,
+            outputTokensAllTime: nil,
+            uptimeSec: 1
+        ))
+
+        XCTAssertFalse(agent.snapshot.providerEarningsFresh)
+        XCTAssertTrue(agent.snapshot.malibuProjectionFresh)
+        XCTAssertEqual(AgentSnapshotPresenter.usdcTodayDisplay(agent.snapshot), "n/a")
+        XCTAssertEqual(
+            AgentSnapshotPresenter.malibuAvailabilityLine(agent.snapshot),
+            "MALIBU: 1.00 available · 8.00 held"
+        )
+        XCTAssertTrue(AgentSnapshotPresenter.malibuFullLine(agent.snapshot).contains("n/a MALIBU today"))
+        XCTAssertEqual(AgentSnapshotPresenter.earningsLine(agent.snapshot), "Today: reward status unavailable")
     }
 
     func testMetricsResponseDecodesGpuLatencyAndQueueDepth() throws {

--- a/phase3-binary/app/Tests/MalibuTests/DashboardViewTests.swift
+++ b/phase3-binary/app/Tests/MalibuTests/DashboardViewTests.swift
@@ -11,11 +11,24 @@ final class DashboardViewTests: XCTestCase {
         XCTAssertEqual(AgentSnapshotPresenter.modelLine(snapshot), "Connected")
         XCTAssertTrue(AgentSnapshotPresenter.requestsLine(snapshot).contains("0 today"))
         XCTAssertTrue(AgentSnapshotPresenter.tokenLine(snapshot).contains("0 in / 0 out today"))
-        XCTAssertTrue(AgentSnapshotPresenter.usdcFullLine(snapshot).contains("$0.00 today"))
-        XCTAssertEqual(AgentSnapshotPresenter.usdcTodayDisplay(snapshot), "$0.00")
+        XCTAssertEqual(AgentSnapshotPresenter.usdcFullLine(snapshot), "n/a today · n/a wk · n/a pending · n/a life")
+        XCTAssertEqual(AgentSnapshotPresenter.usdcTodayDisplay(snapshot), "n/a")
         XCTAssertEqual(AgentSnapshotPresenter.queueChip(snapshot), "0 queued")
         XCTAssertEqual(AgentSnapshotPresenter.thermalChip(snapshot), "Thermal OK")
         XCTAssertEqual(AgentSnapshotPresenter.dashboardHeadline(snapshot), "Provider is ready")
+        XCTAssertEqual(
+            AgentSnapshotPresenter.dashboardSubtitle(snapshot),
+            "Ready for customer work · earnings unavailable"
+        )
+    }
+
+    func testFreshServingWithoutEarningsWaitsForFirstPaidJob() {
+        var snapshot = AgentSnapshot.empty
+        snapshot.state = .serving
+        snapshot.coordinatorConnected = true
+        snapshot.networkState = "buyer_serving"
+        snapshot.providerEarningsFresh = true
+
         XCTAssertEqual(
             AgentSnapshotPresenter.dashboardSubtitle(snapshot),
             "Ready for customer work · waiting for the first paid job"
@@ -57,6 +70,8 @@ final class DashboardViewTests: XCTestCase {
         snapshot.malibuAccruedToday = 12
         snapshot.malibuAccruedAllTime = 50
         snapshot.trustTier = .provisional
+        snapshot.providerEarningsFresh = true
+        snapshot.malibuProjectionFresh = true
         snapshot.gpuUtilizationPct = 62
         snapshot.latencyP50Ms = 42
         snapshot.latencyP99Ms = 180

--- a/phase3-binary/app/Tests/MalibuTests/MenuBarBadgeThresholdTests.swift
+++ b/phase3-binary/app/Tests/MalibuTests/MenuBarBadgeThresholdTests.swift
@@ -28,6 +28,8 @@ final class MenuBarBadgeThresholdTests: XCTestCase {
         snapshot.walletBound = false
         snapshot.unpaidLedgerBacklogUSDC = 0.50
         snapshot.unpaidLedgerBacklogMALIBU = 0.50
+        snapshot.providerEarningsFresh = true
+        snapshot.malibuProjectionFresh = true
 
         XCTAssertEqual(AgentSnapshotPresenter.unclaimedBacklogTotal(snapshot), 1.0)
         XCTAssertEqual(AgentSnapshotPresenter.unclaimedBadge(snapshot, dismissedThreshold: nil), "$1+")

--- a/specs/SPEC-014-provider-portal.md
+++ b/specs/SPEC-014-provider-portal.md
@@ -244,8 +244,9 @@ explicit reason rooted in upstream specs:
 - Surface B static requirements grid + sizing card + setup steps +
   GitHub Releases-driven version feed (no installed-version
   overlay).
-- Surface C three aggregate credit cards + payout-rail-deferred
-  status card (no withdrawal UX).
+- Surface C three aggregate credit cards + a read-only MALIBU
+  availability card + payout-rail-deferred status card (no
+  withdrawal UX).
 - Surface D single placeholder card naming the deferred sub-cards
   and the Open Q each lives behind. Zero API calls.
 - Surface E identity card: `provider_id` (paste-bearer: pasted;
@@ -1196,6 +1197,19 @@ disposition as C.3; covered by Open Q4.
   `provider_id` (SPEC-005 §11.5).
 - Deployment-mode dependency: §2.4 above.
 
+**C.6 MALIBU reward availability projection (read-only).** The
+portal renders a provider-facing card from
+GET /v1/provider/malibu-accrual in paste-bearer mode. It uses
+the same FR-P12 bearer as C.1 and MUST render only accrued,
+withdrawable, held, trust, hold-reason, next-action, and cap
+information. It MUST NOT include a withdrawal, wallet mutation,
+or token-rotation action. GitHub-OAuth mode does not call this
+route because it has no provider bearer; completing that mode's
+economics access remains the §2.5.0 ownership/auth gap. A 401 or
+403 follows the normal sign-in rejection path; a 404 is treated
+as a temporarily unavailable optional projection and MUST NOT
+clear an otherwise valid portal session.
+
 ### 4.4 Surface D — Monitoring (placeholder)
 
 Every D-class signal (uptime ribbon, per-provider routing weight,
@@ -1292,6 +1306,12 @@ exactly one of them.
 | B.3 | rate-limit fallback notice | derived from the B.3 release-list response header `X-RateLimit-Remaining: 0` | n/a (header-derived); rendered as static notice text "GitHub API rate limit reached — release feed paused; refresh later." | re-evaluated on each B.3 fetch | in-memory; cleared on next non-zero remaining | GitHub Releases API rate-limit posture (Open Q2 records the 60 req/IP/hr cap) |
 | B.3 | CORS / fetch-failure notice | derived from a rejected B.3 release-list `fetch()` (TypeError / opaque response / other CORS-failure pathway) | n/a (fetch-rejection-derived); rendered as static notice text "GitHub Releases unavailable — release feed disabled; see SPEC-014 Open Q2." | re-evaluated on each B.3 fetch | in-memory; surfaced as a loud, user-visible failure (NOT silently hidden) | GitHub Releases CORS posture (Open Q2) |
 | C.1 | lifetime / window / last-payout credit cards | `GET /providers/{id}/earnings` | `total_credits`, `current_window_credits`, `last_payout_ready.{window_start_utc, window_end_utc, provider_credits}` | 60 s | in-memory; 60 s TTL | SPEC-005 §11.4 |
+| C.6 | accrued MALIBU | `GET /v1/provider/malibu-accrual` | `accrued_malibu` | 60 s | in-memory; 60 s TTL | SPEC-021 emission-ledger read model |
+| C.6 | withdrawable MALIBU | `GET /v1/provider/malibu-accrual` | `withdrawable_malibu` | 60 s | in-memory; 60 s TTL | SPEC-021 emission-ledger read model |
+| C.6 | held MALIBU | `GET /v1/provider/malibu-accrual` | `held_malibu` | 60 s | in-memory; 60 s TTL | SPEC-021 emission-ledger read model |
+| C.6 | trust tier | `GET /v1/provider/malibu-accrual` | `trust_tier` | 60 s | in-memory; 60 s TTL | SPEC-021 emission-ledger read model |
+| C.6 | hold reason copy and next action | `GET /v1/provider/malibu-accrual` | `withdrawal_hold_reasons`, `trust_criteria_met`, `trust_criteria_required` | 60 s | in-memory; 60 s TTL | SPEC-021 emission-ledger hold reasons; derived provider copy |
+| C.6 | provider and wallet daily caps | `GET /v1/provider/malibu-accrual` | `daily_cap_malibu`, `wallet_daily_cap_malibu` | 60 s | in-memory; 60 s TTL | SPEC-021 emission-ledger cap projection |
 | E.1 | tier badge | `GET /v1/pool/check?provider_id=<id>` | `tier` | 30 s + manual refresh | in-memory; invalidated on refresh | SPEC-002 §7.4 |
 | E.1 | state | `GET /v1/pool/check?provider_id=<id>` | `state` | 30 s + manual refresh | in-memory; invalidated on refresh | SPEC-002 §7.4 |
 | OAuth chooser (§2.5.5) | owned-provider rows: `provider_id`, `claimed_at`, `last_seen_at` | `GET /v1/auth/me/providers` (cookie) | `body.providers[]` (object-root `{"providers": <array \| null>}` envelope, NOT a bare array; empty owns → `null`, portal normalizes to `[]`, §2.5.2): `provider_id`, `claimed_at`, `last_seen_at` | on OAuth home load / popstate | in-memory | §2.5.2 SPEC-014 transport (reconciled v0.9); GitHub-OAuth mode only |
@@ -1371,6 +1391,7 @@ stale `unknown`/200 text — that spec needs its own reconciliation (§10.2). Th
 |---|---|---|---|---|
 | `/v1/pool/check` poll cadence | 30 s | new (portal-side; not configurable in v0.1) | portal author | not configurable in v0.1 — operator edits source if needed |
 | `/providers/{id}/earnings` poll cadence | 60 s | new (portal-side; not configurable in v0.1) | portal author | not configurable in v0.1 — operator edits source if needed |
+| `/v1/provider/malibu-accrual` poll cadence | 60 s | new (portal-side; not configurable in v0.1) | portal author | not configurable in v0.1 — operator edits source if needed |
 | Earnings cache TTL | 60 s | new (portal-side; not configurable in v0.1) | portal author | not configurable in v0.1 |
 | `/providers/{id}/earnings` rate-limit per provider | 60 / min | `endpoints.provider_earnings.rate_limit_per_minute` (SPEC-005 §13) | operator | coordinator config |
 | Releases-feed GitHub API cache TTL | 5 min | new (portal-side; not configurable in v0.1) | portal author | not configurable in v0.1 |
@@ -1512,6 +1533,13 @@ Layered, NOT a flat checklist. Six required groups.
 - [ ] C.2 contains no country selector, no "Link bank", no
       account-type picker, no Stripe button, no payout-now CTA.
 - [ ] C.3 and C.4 are not rendered.
+- [ ] C.6 renders the read-only MALIBU availability projection in
+      paste-bearer mode: accrued, withdrawable, held, trust tier,
+      provider-safe hold/next-action copy, and daily caps. It
+      renders no withdrawal or wallet mutation CTA. A 404 from
+      /v1/provider/malibu-accrual leaves the session signed in
+      and shows an unavailable projection notice; 401/403 follow
+      the sign-in rejection path.
 
 **Surface D (Monitoring).**
 
@@ -1540,23 +1568,28 @@ Layered, NOT a flat checklist. Six required groups.
       `/portal-config.json` fetch (verified by a network-panel
       observation or a spy on the fetch layer that asserts no
       calls to `/v1/pool/check`, `/providers/{id}/earnings`,
+      `/v1/provider/malibu-accrual`,
       `/v1/auth/*`, or the GitHub Releases host). This fail-closed check runs
       before mode selection, so it holds regardless of `github_oauth_enabled`.
 - [ ] On load with `portal-config.json.require_provider_tokens =
       false`, portal renders the unavailable-mode page AND makes
       ZERO network calls after the `/portal-config.json` fetch
       (verified by the same spy targets: `/v1/pool/check`,
-      `/providers/{id}/earnings`, `/v1/auth/*`, GitHub Releases). The public
+      `/providers/{id}/earnings`, `/v1/provider/malibu-accrual`,
+      `/v1/auth/*`, GitHub Releases). The public
       `/v1/pool/check` and the unauthenticated GitHub Releases
       endpoint MUST NOT be polled in either of the two
       unavailable-mode entry points.
 - [ ] **Paste-bearer mode** — authenticated call returning 401 → portal returns
       to the sign-in prompt; error message does not distinguish "missing"
       vs "malformed".
-- [ ] **Paste-bearer mode** — 403 → portal renders a
+- [ ] **Paste-bearer mode** — existing pool/earnings calls returning 403 → portal renders a
       "sign-in rejected" message identical to the 404 case; 404 → the same
       "sign-in rejected" message (does NOT reveal that the `provider_id` is
       unknown).
+      The optional C.6 MALIBU projection is the exception: its 404 remains
+      an in-session unavailable notice, while 401/403 still follow sign-in
+      rejection.
 - [ ] In `require_provider_tokens: true` **paste-bearer** mode, after **two
       consecutive authenticated provider-endpoint failures on
       the same surface** (the `authFailBySurface` counter resets on
@@ -1573,7 +1606,8 @@ Layered, NOT a flat checklist. Six required groups.
       `/admin/ledger` (matches the §10 dependency table). The check governs
       **network-call targets**, not informational literals: the only coordinator
       paths the bundle may **call** are the paste-mode data paths
-      (`/v1/pool/check`, `/providers/{id}/earnings`) and, for GitHub-OAuth mode,
+      (`/v1/pool/check`, `/providers/{id}/earnings`,
+      `/v1/provider/malibu-accrual`) and, for GitHub-OAuth mode,
       the §2.5.2 `/v1/auth/*` allowlist — no other `/v1/auth/*` or `/admin/*`. A
       **non-called informational literal** is permitted: the shipped misconfig
       banner mentions `/v1/install/pair/refresh` as text (reconciled v0.9), which the
@@ -1804,7 +1838,7 @@ not yet available.
 - **Who decides:** SPEC-005 author.
 - **Spec assumes:** no breakdown in v0.1.
 - **Portal renders if unanswered:** C.3 + C.4 not rendered;
-  Surface C is C.1 + C.2 only.
+  Surface C is C.1 + C.2 + C.6; C.3 + C.4 remain deferred.
 
 ### Q5 — Upstream-spec amendments omnibus
 
@@ -1990,9 +2024,12 @@ The user shared screenshots from a competitor seller portal
   diffs `portal-config.json.require_provider_tokens` against the
   coordinator's deploy config; both MUST match.
 - Reverse-proxy step (Open Q9 option a): operator nginx config
-  proxies the portal origin's `/v1/pool/check` and
-  `/providers/{id}/earnings` to the coordinator. Bundle MUST
-  fail loudly when the proxy is absent.
+  proxies the portal origin's `/v1/pool/check`,
+  `/providers/{id}/earnings`, and
+  `/v1/provider/malibu-accrual` to the coordinator. Bundle
+  MUST fail loudly when the proxy is absent; the optional
+  MALIBU projection renders an unavailable notice when its
+  route returns 404.
 - **GitHub-OAuth deployment prerequisites (reconciled v0.9 — required to
   turn `github_oauth_enabled:true` into a working mode; the reference
   `dist/nginx-portal.streamvc.live.conf` does NOT yet include these):**
@@ -2093,6 +2130,7 @@ this spec-only reconciliation.
 
 - Surface C.1 credit totals row.
 - Surface C.2 deferred-payout status card.
+- Surface C.6 read-only MALIBU reward availability projection.
 - Surface D placeholder card (zero API calls).
 - Surface E.1 identity card.
 - Sidebar nav + sign-out + mobile collapse.


### PR DESCRIPTION
## Summary

Implements the first, read-only UX slice of #929 so providers can see why MALIBU is accrued, held, or withdrawable and what action is needed next.

## Scope

- Exposes the existing provider MALIBU accrual projection in the CLI, Malibu app, and Provider Portal.
- Shows accrued, withdrawable, held, trust, cap, hold-reason, and next-action state.
- Adds source-specific freshness and fail-closed decoding so partial or stale data cannot authorize a misleading projection.
- Adds the authenticated same-origin portal proxy and documents the C.6 contract in SPEC-014.
- Leaves emission, ledger, and economic-rule changes for a later slice.

## Validation

- 70 focused Swift package tests.
- 69 focused Malibu app tests.
- Go rewards and Nginx route tests.
- Provider Portal JavaScript syntax and bundle checks.
- Three full-diff audit lanes: 0 CRITICAL/HIGH/MEDIUM findings.

Known unrelated baseline failures remain in the full SwiftPM and Malibu suites (SelfUpdate/MLX environment failures and one process-output timing test).

SPEC-GOVERNANCE-DECLARATION-BEGIN
{
  "schema_version": "spec-pr-governance-v1",
  "behavior_change": "yes",
  "contract_change": "yes",
  "specs": ["SPEC-014", "SPEC-021"],
  "requirements": ["SPEC-016-R002"],
  "authority_domains": ["provider-portal", "malibu-emission-ledger", "payout-lifecycle"],
  "arbitration": ["UNKNOWN"],
  "tests": ["focused Swift package tests", "focused Malibu app tests", "Go rewards and Nginx route tests", "Provider Portal syntax and bundle checks"],
  "journeys": ["not-required"],
  "issue": "https://github.com/Augustas11/macprovider/issues/929"
}
SPEC-GOVERNANCE-DECLARATION-END
