### PR TITLE
feat: prebeta provider UX — earnings card, trust wait, emission ops

### DIFF
--- a/ops/runbooks/README.md
+++ b/ops/runbooks/README.md
@@ -7,6 +7,9 @@
 | **A — OPoI Pearl** | [`opoi-pearl-deploy.md`](./opoi-pearl-deploy.md) | Pearl canary overlay deploy |
 | **C — $MALIBU bootstrap** | [`malibu-bootstrap-emission.md`](./malibu-bootstrap-emission.md) | Emission ledger, caps, Trusted unlock, Malibu UI |
 | **C — MALIBU Pearl** | [`malibu-pearl-deploy.md`](./malibu-pearl-deploy.md) | Session C4 Pearl migration + overlay |
+| **Prebeta P4 trust alert** | [`hardware-trust-pending-alert.md`](./hardware-trust-pending-alert.md) | Journal/BetterStack alert when waiting_trust parks |
+| **Prebeta P5 demand floor** | [`prebeta-demand-floor.md`](./prebeta-demand-floor.md) | Canary re-enable gated by #584 |
+| **Prebeta P6 stats honesty** | [`prebeta-stats-honesty.md`](./prebeta-stats-honesty.md) | nodes_hardware_attested vs Trusted; download pin |
 | **Catalog release + provider upgrade** | [`catalog-release-provider-upgrade.md`](./catalog-release-provider-upgrade.md) | Signed publication, coordinator activation, provider transaction, rollback |
 | **#608 Llama Tier-2 republish** | [`608-llama-tier2-republish.md`](./608-llama-tier2-republish.md) | Reviewed `stage-tier2-republish` staging for the live Llama-3.2 autotune/Tier-2 CONFLICT; Pearl apply steps not yet executed |
 | **B — Entry 172 referrals** | [`entry-172-referral-activation.md`](./entry-172-referral-activation.md) | Reversible private-prebeta referral activation checklist |

--- a/ops/runbooks/hardware-trust-pending-alert.md
+++ b/ops/runbooks/hardware-trust-pending-alert.md
@@ -1,0 +1,40 @@
+# Hardware trust pending — operator alert (prebeta P4)
+
+**Goal:** Cut trust-grant latency from “whenever an operator next looks” to minutes.
+
+## Signals
+
+### A. Journal line (preferred)
+
+`stats-hardware-verifier` emits when a job is parked `waiting_trust`:
+
+```text
+hardware_trust_waiting_new job_id=123 provider_id=mp-… reason=missing_trusted_hardware_identity
+```
+
+**BetterStack (or journald ingest):** match `hardware_trust_waiting_new`, dedupe on `job_id`, page on-call.
+
+### B. Admin poll (backup)
+
+```bash
+curl -sS -H "Authorization: Bearer $OPERATOR_TOKEN" \
+  https://coordinator.streamvc.live/admin/hardware-trust/waiting | jq '.count, .waiting_trust'
+```
+
+Cron every 5 minutes; alert when `count > 0` for >5 minutes.
+
+## In-app copy (Malibu)
+
+Pending state: **“Hardware verification pending — usually under an hour.”**
+
+## Grant path (unchanged trust model)
+
+1. `GET /admin/hardware-trust/waiting`
+2. Dual-control request + approve (`POST …/approve`, `POST …/approve/{id}/approve`)
+3. Do **not** auto-grant; alert + visible ETA only
+
+## Related
+
+- Issue #838 (fatal install path closed; wait remains)
+- `phase4-coordinator/internal/stats/hardwareverify/verify.go`
+- `phase4-coordinator/internal/ws/admin_hardware_trust.go`

--- a/ops/runbooks/malibu-pearl-deploy.md
+++ b/ops/runbooks/malibu-pearl-deploy.md
@@ -179,6 +179,14 @@ Only after §4 passes and operator accepts stance **(b) accrual-only**:
 
 **Do not** enable withdrawable MALIBU until C1+C2 lab verification is complete on production data.
 
+### 5.1 Pearl promotion record (prebeta P2)
+
+- **When:** 2026-08-07T13:53:29Z
+- **Action:** `malibu_emission.enabled: false → true` in `/etc/macprovider/coordinator.pearl-overlays.yaml`; coordinator restarted
+- **Evidence:** journal `SPEC-MALIBU-EMISSION-LEDGER accrual runner started`
+- **Backup:** `coordinator.pearl-overlays.yaml.bak-pre-emission-*` on Pearl
+- **Rollback:** set `enabled: false` and restart (keep overlay drop-in)
+
 ---
 
 ## 6. Rollback

--- a/ops/runbooks/prebeta-demand-floor.md
+++ b/ops/runbooks/prebeta-demand-floor.md
@@ -1,0 +1,48 @@
+# Prebeta demand floor (P5) — gated by #584
+
+**Status:** Prepared, **not armed** on Pearl.
+
+## Why gated
+
+Production exception `exc-canary-disabled-enable-gate` (#584) keeps:
+
+- `/var/lib/macprovider-canary-buyer/DISABLED` present
+- `/etc/macprovider-canary-buyer/enabled` absent
+- `pool.canary_enabled: false`
+- `canary-buyer.timer` disabled
+
+Until #584 physical baselines + signed go/no-go land, do **not** remove `DISABLED` or create the enable gate.
+
+## What “demand floor” means for provider UX
+
+Every online eligible provider should see a buyer request at least every few minutes so Malibu request + USD counters move. At ~45 req/day, most of a 5-node fleet sits idle for hours.
+
+## Re-enable checklist (after #584 approval)
+
+```bash
+# 1. Confirm signed go/no-go + physical baselines on record
+# 2. Coordinator overlay
+ssh pearl 'sudo sed -i "s/canary_enabled: false/canary_enabled: true/" /etc/macprovider/coordinator.pearl-overlays.yaml'
+# 3. Remove emergency sentinel, install enable gate
+ssh pearl 'sudo rm -f /var/lib/macprovider-canary-buyer/DISABLED
+  && sudo install -d -o root -g root -m 0755 /etc/macprovider-canary-buyer
+  && sudo touch /etc/macprovider-canary-buyer/enabled
+  && sudo systemctl daemon-reload
+  && sudo systemctl enable --now canary-buyer.timer'
+# 4. Watch pool health for 1h; emergency rollback:
+#    ops/runbooks/584-emergency-disable-drill.md
+```
+
+Keep canary in **liveness** budgets only (≤4 req / 32 tokens / 90s); `CANARY_DEGRADED_RETRIES=0`.
+
+## Interim (until canary returns)
+
+- **P1** adaptive USD + eligibility copy (ready/$0 honesty)
+- **P2** MALIBU emission ticks (counter motion without buyer demand)
+- Do not invent a second unapproved buyer probe that bypasses #584
+
+## Related
+
+- `ops/exceptions/production-exceptions.json` → `exc-canary-disabled-enable-gate`
+- `ops/runbooks/584-physical-baseline-matrix.md`
+- `test/e2e/canary-buyer/README.md`

--- a/ops/runbooks/prebeta-stats-honesty.md
+++ b/ops/runbooks/prebeta-stats-honesty.md
@@ -1,0 +1,36 @@
+# Prebeta public-stats + download pin honesty (P6)
+
+## `nodes_hardware_attested` == 0
+
+Live overview (2026-08-07): `nodes_online=4`, `nodes_hardware_attested=0`.
+
+This is **not** a rollup bug. Pool counting (SPEC-017) requires
+`AttestationStatusAttested` **and** `AttestationTierHardware` (SE hardware
+attestation). Operator **Trusted** hardware-trust grants (#582 dual-control)
+do **not** set SE `AttestationTierHardware`. Self-signed SE keys also do not
+count (by design — see `poolsnapshot` tests).
+
+**Do not** treat this field as “Trusted providers online.” Until SE hardware
+attestation is productized, expect `0` even with Trusted Macs serving.
+
+**Marketing / dashboard:** prefer `nodes_online` (and request/token totals).
+Do not cite `nodes_hardware_attested` as the live fleet size.
+
+Optional follow-up (separate SPEC): add `nodes_trusted` from the rewards/trust
+store if product needs a public Trusted count.
+
+## Malibu public download pin
+
+Checked `https://github.com/.../malibu` `host/index.html` CTA:
+
+- Pin: `…/releases/download/v1.8.69/Malibu-v1.8.69.dmg` — asset **exists** (HTTP 302).
+- Latest GitHub release titled “Malibu 1.8.50” also has `Malibu-v1.8.50.dmg`.
+
+Pin is an immutable release URL (SPEC-025), not `latest.dmg` — good. Drift to
+watch: marketing pin (`1.8.69`) vs newest Malibu release listing (`1.8.50`).
+Confirm which build outside providers should install before changing the pin.
+
+## Per-request earnings tick
+
+Deferred polish on P1: dashboard line like `+$0.0004 · 412 tok` when a credit
+lands. Not required for counter motion once adaptive precision ships.

--- a/phase3-binary/Sources/macprovider-cli/ProviderEarningsClient.swift
+++ b/phase3-binary/Sources/macprovider-cli/ProviderEarningsClient.swift
@@ -1,5 +1,34 @@
 import Foundation
 
+/// Provider-visible last-hour idle-prewarm projection, mirrored from
+/// `statsprewarm.Summary` (phase4-coordinator/internal/stats/prewarm/reader.go)
+/// as returned under `idle_prewarm` on GET /providers/{provider_id}/earnings.
+public struct ProviderIdlePrewarmSummary: Codable, Equatable, Sendable {
+    public let eventsLast1h: [String: Int64]
+    public let skipsByReasonLast1h: [String: Int64]
+
+    public static let empty = ProviderIdlePrewarmSummary(eventsLast1h: [:], skipsByReasonLast1h: [:])
+
+    enum CodingKeys: String, CodingKey {
+        case eventsLast1h = "events_last_1h"
+        case skipsByReasonLast1h = "skips_by_reason_last_1h"
+    }
+
+    public init(eventsLast1h: [String: Int64] = [:], skipsByReasonLast1h: [String: Int64] = [:]) {
+        self.eventsLast1h = eventsLast1h
+        self.skipsByReasonLast1h = skipsByReasonLast1h
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        eventsLast1h = try container.decodeIfPresent([String: Int64].self, forKey: .eventsLast1h) ?? [:]
+        skipsByReasonLast1h = try container.decodeIfPresent(
+            [String: Int64].self,
+            forKey: .skipsByReasonLast1h
+        ) ?? [:]
+    }
+}
+
 /// Provider-facing read model returned by GET /providers/{provider_id}/earnings.
 /// The CLI owns the provider bearer and exposes this non-secret projection to
 /// same-user local clients over the 0600 control socket.
@@ -21,6 +50,10 @@ public struct ProviderEarningsSummary: Codable, Equatable, Sendable {
     public let malibuHoldReasons: [String]
     public let malibuDailyCap: Double?
     public let malibuWalletDailyCap: Double?
+    /// Last-hour idle-prewarm event/skip counts, used to explain why a
+    /// serving provider is not currently earning (on battery, thermal
+    /// throttle, model not loaded). Display-only.
+    public let idlePrewarm: ProviderIdlePrewarmSummary
     /// True only when GET /providers/{id}/earnings returned this projection.
     public let earningsProjectionFresh: Bool
     /// True only when the companion MALIBU accrual projection was fetched in
@@ -46,6 +79,7 @@ public struct ProviderEarningsSummary: Codable, Equatable, Sendable {
         case malibuHoldReasons = "malibu_hold_reasons"
         case malibuDailyCap = "malibu_daily_cap"
         case malibuWalletDailyCap = "malibu_wallet_daily_cap"
+        case idlePrewarm = "idle_prewarm"
         case malibuProjectionFresh = "malibu_projection_fresh"
         case earningsProjectionFresh = "earnings_projection_fresh"
     }
@@ -75,6 +109,10 @@ public struct ProviderEarningsSummary: Codable, Equatable, Sendable {
         malibuHoldReasons = try container.decodeIfPresent([String].self, forKey: .malibuHoldReasons) ?? []
         malibuDailyCap = try container.decodeIfPresent(Double.self, forKey: .malibuDailyCap)
         malibuWalletDailyCap = try container.decodeIfPresent(Double.self, forKey: .malibuWalletDailyCap)
+        idlePrewarm = try container.decodeIfPresent(
+            ProviderIdlePrewarmSummary.self,
+            forKey: .idlePrewarm
+        ) ?? .empty
         malibuProjectionFresh = try container.decodeIfPresent(Bool.self, forKey: .malibuProjectionFresh) ?? false
         earningsProjectionFresh = try container.decodeIfPresent(Bool.self, forKey: .earningsProjectionFresh) ?? false
     }
@@ -97,6 +135,7 @@ public struct ProviderEarningsSummary: Codable, Equatable, Sendable {
         malibuHoldReasons: [String] = [],
         malibuDailyCap: Double? = nil,
         malibuWalletDailyCap: Double? = nil,
+        idlePrewarm: ProviderIdlePrewarmSummary = .empty,
         malibuProjectionFresh: Bool = false,
         earningsProjectionFresh: Bool = false
     ) {
@@ -117,6 +156,7 @@ public struct ProviderEarningsSummary: Codable, Equatable, Sendable {
         self.malibuHoldReasons = malibuHoldReasons
         self.malibuDailyCap = malibuDailyCap
         self.malibuWalletDailyCap = malibuWalletDailyCap
+        self.idlePrewarm = idlePrewarm
         self.malibuProjectionFresh = malibuProjectionFresh
         self.earningsProjectionFresh = earningsProjectionFresh
     }
@@ -140,6 +180,7 @@ public struct ProviderEarningsSummary: Codable, Equatable, Sendable {
             malibuHoldReasons: malibuHoldReasons,
             malibuDailyCap: malibuDailyCap,
             malibuWalletDailyCap: malibuWalletDailyCap,
+            idlePrewarm: idlePrewarm,
             malibuProjectionFresh: false,
             earningsProjectionFresh: true
         )
@@ -164,6 +205,7 @@ public struct ProviderEarningsSummary: Codable, Equatable, Sendable {
             malibuHoldReasons: accrual.withdrawalHoldReasons,
             malibuDailyCap: accrual.dailyCapMALIBU,
             malibuWalletDailyCap: accrual.walletDailyCapMALIBU,
+            idlePrewarm: idlePrewarm,
             malibuProjectionFresh: true,
             earningsProjectionFresh: earningsProjectionFresh
         )
@@ -188,6 +230,7 @@ public struct ProviderEarningsSummary: Codable, Equatable, Sendable {
             malibuHoldReasons: accrual.withdrawalHoldReasons,
             malibuDailyCap: accrual.dailyCapMALIBU,
             malibuWalletDailyCap: accrual.walletDailyCapMALIBU,
+            idlePrewarm: .empty,
             malibuProjectionFresh: true,
             earningsProjectionFresh: false
         )

--- a/phase3-binary/Tests/macprovider-cliTests/ProviderEarningsClientTests.swift
+++ b/phase3-binary/Tests/macprovider-cliTests/ProviderEarningsClientTests.swift
@@ -44,7 +44,11 @@ final class ProviderEarningsClientTests: XCTestCase {
               "malibu_held": 0.5,
               "malibu_hold_reasons": ["per_wallet_daily_cap"],
               "malibu_daily_cap": 25,
-              "malibu_wallet_daily_cap": 100
+              "malibu_wallet_daily_cap": 100,
+              "idle_prewarm": {
+                "events_last_1h": {"idle_prewarm_started": 6, "idle_prewarm_completed": 5},
+                "skips_by_reason_last_1h": {"on_battery": 2}
+              }
             }
             """.utf8)
             return (response, body)
@@ -66,6 +70,8 @@ final class ProviderEarningsClientTests: XCTestCase {
         XCTAssertEqual(summary.malibuHoldReasons, ["per_wallet_daily_cap"])
         XCTAssertEqual(summary.malibuDailyCap, 25)
         XCTAssertEqual(summary.malibuWalletDailyCap, 100)
+        XCTAssertEqual(summary.idlePrewarm.eventsLast1h["idle_prewarm_started"], 6)
+        XCTAssertEqual(summary.idlePrewarm.skipsByReasonLast1h["on_battery"], 2)
         XCTAssertTrue(summary.earningsProjectionFresh)
         XCTAssertFalse(summary.malibuProjectionFresh)
     }
@@ -87,6 +93,7 @@ final class ProviderEarningsClientTests: XCTestCase {
         XCTAssertEqual(summary.unpaidLedgerBacklogUSDC, 1.25)
         XCTAssertNil(summary.usdcToday)
         XCTAssertNil(summary.malibuAllTime)
+        XCTAssertEqual(summary.idlePrewarm, .empty)
         XCTAssertFalse(summary.earningsProjectionFresh)
         XCTAssertFalse(summary.malibuProjectionFresh)
     }
@@ -94,7 +101,15 @@ final class ProviderEarningsClientTests: XCTestCase {
     func testAccrualProjectionFillsTrustAndMalibuWithoutInventingUSDC() throws {
         let earnings = try JSONDecoder().decode(
             ProviderEarningsSummary.self,
-            from: Data("{\"unpaid_ledger_backlog_usdc\":2}".utf8)
+            from: Data("""
+            {
+              "unpaid_ledger_backlog_usdc": 2,
+              "idle_prewarm": {
+                "events_last_1h": {},
+                "skips_by_reason_last_1h": {"model_not_loaded": 3}
+              }
+            }
+            """.utf8)
         )
         let accrual = try JSONDecoder().decode(
             MalibuAccrualSummary.self,
@@ -124,6 +139,7 @@ final class ProviderEarningsClientTests: XCTestCase {
         XCTAssertEqual(merged.malibuHoldReasons, ["trust_tier_provisional"])
         XCTAssertEqual(merged.malibuDailyCap, 25)
         XCTAssertEqual(merged.malibuWalletDailyCap, 100)
+        XCTAssertEqual(merged.idlePrewarm.skipsByReasonLast1h["model_not_loaded"], 3)
         XCTAssertTrue(merged.malibuProjectionFresh)
         XCTAssertFalse(merged.earningsProjectionFresh)
     }

--- a/phase3-binary/app/Sources/Malibu/Agent/AgentSnapshot.swift
+++ b/phase3-binary/app/Sources/Malibu/Agent/AgentSnapshot.swift
@@ -50,6 +50,10 @@ struct AgentSnapshot: Equatable {
     var malibuHoldReasons: [String]
     var malibuDailyCap: Double?
     var malibuWalletDailyCap: Double?
+    /// Last-hour idle-prewarm event/skip counts from the provider earnings
+    /// endpoint. Gated by `providerEarningsFresh`, same as the other fields
+    /// sourced from that projection.
+    var idlePrewarmSummary: ProviderIdlePrewarmSummary = .empty
     /// Freshness for the provider earnings endpoint.
     var providerEarningsFresh: Bool
     /// Reward-specific freshness. It is separate so a partial earnings frame
@@ -456,8 +460,8 @@ enum AgentSnapshotPresenter {
         if isPendingHardwareVerification(s) {
             return PublicStatus(
                 title: "Pending hardware verification",
-                detail: "Network hardware verification is incomplete. Retry provider setup while online so fresh evidence can be submitted; recently submitted evidence may still be awaiting operator approval.",
-                safeNextAction: "Retry provider setup while online.",
+                detail: "Hardware verification pending — usually under an hour. Stay online so fresh evidence can be submitted; recently submitted evidence may still be awaiting network approval.",
+                safeNextAction: "Keep Malibu online · retry setup if this lasts more than an hour.",
                 executableAction: .retryHardwareVerification
             )
         }
@@ -647,7 +651,7 @@ enum AgentSnapshotPresenter {
         case .starting: return "Starting"
         case .serving:
             guard isNetworkReady(s, at: now) else { return "Connected" }
-            if let usdc = s.earningsUsdcToday { return String(format: "$%.2f", usdc) }
+            if let usdc = s.earningsUsdcToday { return formatUSDC(usdc) }
             return "Serving"
         case .paused:         return "Paused"
         case .reconnecting:
@@ -740,7 +744,7 @@ enum AgentSnapshotPresenter {
                 return isActive(s) ? "Today: reward status unavailable" : "Today: not running"
             }
             let usdc = s.providerEarningsFresh
-                ? s.earningsUsdcToday.map { String(format: "$%.2f", $0) } ?? "n/a"
+                ? s.earningsUsdcToday.map { formatUSDC($0) } ?? "n/a"
                 : "n/a"
             let malibu = s.malibuProjectionFresh
                 ? s.malibuAccruedToday.map { String(format: "%.2f", $0) } ?? "n/a"
@@ -751,12 +755,34 @@ enum AgentSnapshotPresenter {
         case (nil, nil):
             return isActive(s) ? "Today: reward status unavailable" : "Today: not running"
         case let (usdc?, malibu?):
-            return String(format: "Today: $%.2f USDC · %@", usdc, malibuDisplay(malibu, tier: s.trustTier))
+            return "Today: \(formatUSDC(usdc)) USDC · \(malibuDisplay(malibu, tier: s.trustTier))"
         case let (usdc?, nil):
-            return String(format: "Today: $%.2f USDC · n/a MALIBU (reward status unavailable)", usdc)
+            return "Today: \(formatUSDC(usdc)) USDC · n/a MALIBU (reward status unavailable)"
         case let (nil, malibu?):
             return "Today: n/a USDC · \(malibuDisplay(malibu, tier: s.trustTier))"
         }
+    }
+
+    /// Priority-ordered explanation for why a serving provider is not
+    /// currently earning, sourced from the last-hour idle-prewarm skip
+    /// counts. Gated by `providerEarningsFresh` since idle-prewarm data
+    /// arrives on the same projection as the other earnings fields.
+    static func eligibilityLine(_ s: AgentSnapshot) -> String? {
+        guard s.providerEarningsFresh else { return nil }
+        let skips = s.idlePrewarmSummary.skipsByReasonLast1h
+        if (skips["on_battery"] ?? 0) > 0 {
+            return "On battery — plug in to earn"
+        }
+        if (skips["thermal_pressure"] ?? 0) > 0 {
+            return "Thermal throttle — waiting to cool before earning"
+        }
+        if (skips["model_not_loaded"] ?? 0) > 0 {
+            return "Model is preparing — earning starts when ready"
+        }
+        if isNetworkReady(s) || s.state == .serving {
+            return "Eligible, waiting for work"
+        }
+        return nil
     }
 
     static func backlogLine(_ s: AgentSnapshot) -> String? {
@@ -969,7 +995,7 @@ enum AgentSnapshotPresenter {
 
     private static func hardwareOnboardingLifecycleLine(_ s: AgentSnapshot) -> String? {
         if isPendingHardwareVerification(s) {
-            return "Pending hardware verification · Retry provider setup while online"
+            return "Pending hardware verification · Usually under an hour · keep online"
         }
         if isHardwareEvidenceRejected(s) {
             if s.lifecycleReason == "autotune_model_cap_exceeded" {
@@ -1088,21 +1114,28 @@ enum AgentSnapshotPresenter {
     static func usdcFullLine(_ s: AgentSnapshot) -> String {
         if !s.providerEarningsFresh {
             let today = "n/a today"
-            return "\(today) · n/a wk · n/a pending · n/a life"
+            return "\(today) · n/a wk · n/a accrued · n/a life"
         }
         return [
-            s.earningsUsdcToday.map { String(format: "$%.2f today", $0) } ?? "n/a today",
-            s.earningsUsdcWeek.map { String(format: "$%.2f wk", $0) } ?? "n/a wk",
-            s.earningsUsdcPending.map { String(format: "$%.2f pending", $0) } ?? "n/a pending",
-            s.earningsUsdcLifetime.map { String(format: "$%.2f life", $0) } ?? "n/a life"
+            s.earningsUsdcToday.map { "\(formatUSDC($0)) today" } ?? "n/a today",
+            s.earningsUsdcWeek.map { "\(formatUSDC($0)) wk" } ?? "n/a wk",
+            s.earningsUsdcPending.map { "\(formatUSDC($0)) accrued" } ?? "n/a accrued",
+            s.earningsUsdcLifetime.map { "\(formatUSDC($0)) life" } ?? "n/a life"
         ].joined(separator: " · ")
+    }
+
+    /// Caption for the accrued amount in `usdcFullLine`, kept on its own line
+    /// so the full line stays scannable.
+    static func usdcAccrualCaption(_ s: AgentSnapshot) -> String? {
+        guard s.providerEarningsFresh, s.earningsUsdcPending != nil else { return nil }
+        return "Accrued — payouts open in beta"
     }
 
     static func usdcTodayDisplay(_ s: AgentSnapshot) -> String {
         guard s.providerEarningsFresh else {
             return "n/a"
         }
-        return s.earningsUsdcToday.map { String(format: "$%.2f", $0) } ?? "n/a"
+        return s.earningsUsdcToday.map { formatUSDC($0) } ?? "n/a"
     }
 
     static func malibuFullLine(_ s: AgentSnapshot) -> String {
@@ -1373,6 +1406,16 @@ enum AgentSnapshotPresenter {
             return redacted
         }
         return "Details are available in Advanced diagnostics."
+    }
+
+    /// Adaptive USDC precision: sub-cent amounts (e.g. per-token accrual)
+    /// render as `$0.00` at two decimals, hiding real earnings. Show 4
+    /// decimals only for nonzero amounts under a cent; otherwise `$%.2f`.
+    private static func formatUSDC(_ amount: Double) -> String {
+        if amount != 0 && abs(amount) < 0.01 {
+            return String(format: "$%.4f", amount)
+        }
+        return String(format: "$%.2f", amount)
     }
 
     private static func malibuDisplay(_ amount: Double, tier: AgentSnapshot.TrustTier, compact: Bool = false) -> String {

--- a/phase3-binary/app/Sources/Malibu/Agent/EarningsClient.swift
+++ b/phase3-binary/app/Sources/Malibu/Agent/EarningsClient.swift
@@ -1,5 +1,32 @@
 import Foundation
 
+/// Provider-visible last-hour idle-prewarm projection. Mirrors
+/// `ProviderIdlePrewarmSummary` in
+/// `Sources/macprovider-cli/ProviderEarningsClient.swift` — duplicated for P0
+/// (see the ControlSocketFrame note above on consolidating the wire mirrors).
+struct ProviderIdlePrewarmSummary: Codable, Equatable {
+    let eventsLast1h: [String: Int64]
+    let skipsByReasonLast1h: [String: Int64]
+
+    static let empty = ProviderIdlePrewarmSummary(eventsLast1h: [:], skipsByReasonLast1h: [:])
+
+    enum CodingKeys: String, CodingKey {
+        case eventsLast1h = "events_last_1h"
+        case skipsByReasonLast1h = "skips_by_reason_last_1h"
+    }
+
+    init(eventsLast1h: [String: Int64] = [:], skipsByReasonLast1h: [String: Int64] = [:]) {
+        self.eventsLast1h = eventsLast1h
+        self.skipsByReasonLast1h = skipsByReasonLast1h
+    }
+
+    init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        eventsLast1h = try c.decodeIfPresent([String: Int64].self, forKey: .eventsLast1h) ?? [:]
+        skipsByReasonLast1h = try c.decodeIfPresent([String: Int64].self, forKey: .skipsByReasonLast1h) ?? [:]
+    }
+}
+
 /// Non-secret earnings projection received from the CLI over the same-user
 /// control socket. Malibu never receives or stores the provider bearer.
 struct ProviderEarnings: Codable, Equatable {
@@ -20,6 +47,9 @@ struct ProviderEarnings: Codable, Equatable {
     let malibuHoldReasons: [String]
     let malibuDailyCap: Double?
     let malibuWalletDailyCap: Double?
+    /// Last-hour idle-prewarm event/skip counts, used to explain why a
+    /// serving provider is not currently earning. Display-only.
+    let idlePrewarm: ProviderIdlePrewarmSummary
     /// Set only when the CLI fetched the companion MALIBU accrual projection.
     /// Missing/legacy wire data is intentionally not treated as fresh.
     let malibuProjectionFresh: Bool
@@ -44,6 +74,7 @@ struct ProviderEarnings: Codable, Equatable {
         case malibuHoldReasons = "malibu_hold_reasons"
         case malibuDailyCap = "malibu_daily_cap"
         case malibuWalletDailyCap = "malibu_wallet_daily_cap"
+        case idlePrewarm = "idle_prewarm"
         case malibuProjectionFresh = "malibu_projection_fresh"
         case earningsProjectionFresh = "earnings_projection_fresh"
     }
@@ -67,6 +98,7 @@ struct ProviderEarnings: Codable, Equatable {
         malibuHoldReasons = try c.decodeIfPresent([String].self, forKey: .malibuHoldReasons) ?? []
         malibuDailyCap = try c.decodeIfPresent(Double.self, forKey: .malibuDailyCap)
         malibuWalletDailyCap = try c.decodeIfPresent(Double.self, forKey: .malibuWalletDailyCap)
+        idlePrewarm = try c.decodeIfPresent(ProviderIdlePrewarmSummary.self, forKey: .idlePrewarm) ?? .empty
         malibuProjectionFresh = try c.decodeIfPresent(Bool.self, forKey: .malibuProjectionFresh) ?? false
         earningsProjectionFresh = try c.decodeIfPresent(Bool.self, forKey: .earningsProjectionFresh) ?? false
     }
@@ -89,6 +121,7 @@ struct ProviderEarnings: Codable, Equatable {
         malibuHoldReasons: [String] = [],
         malibuDailyCap: Double? = nil,
         malibuWalletDailyCap: Double? = nil,
+        idlePrewarm: ProviderIdlePrewarmSummary = .empty,
         malibuProjectionFresh: Bool = false,
         earningsProjectionFresh: Bool = false
     ) {
@@ -109,6 +142,7 @@ struct ProviderEarnings: Codable, Equatable {
         self.malibuHoldReasons = malibuHoldReasons
         self.malibuDailyCap = malibuDailyCap
         self.malibuWalletDailyCap = malibuWalletDailyCap
+        self.idlePrewarm = idlePrewarm
         self.malibuProjectionFresh = malibuProjectionFresh
         self.earningsProjectionFresh = earningsProjectionFresh
     }

--- a/phase3-binary/app/Sources/Malibu/Agent/MalibuAgent.swift
+++ b/phase3-binary/app/Sources/Malibu/Agent/MalibuAgent.swift
@@ -1223,6 +1223,7 @@ final class MalibuAgent: ObservableObject {
                 snapshot.malibuWalletDailyCap = providerEarnings.malibuWalletDailyCap
                 snapshot.trustCriteriaMet = providerEarnings.trustCriteriaMet
                 snapshot.trustCriteriaRequired = providerEarnings.trustCriteriaRequired
+                snapshot.idlePrewarmSummary = providerEarnings.idlePrewarm
             }
         case let .pauseAck(accepted, reason):
             if accepted {

--- a/phase3-binary/app/Sources/Malibu/Dashboard/DashboardWindow.swift
+++ b/phase3-binary/app/Sources/Malibu/Dashboard/DashboardWindow.swift
@@ -81,6 +81,11 @@ private struct DashboardView: View {
                     Text(AgentSnapshotPresenter.usdcFullLine(agent.snapshot))
                         .foregroundStyle(.secondary)
                         .font(.callout)
+                    if let caption = AgentSnapshotPresenter.usdcAccrualCaption(agent.snapshot) {
+                        Text(caption)
+                            .font(.caption2)
+                            .foregroundStyle(.secondary)
+                    }
                     Text(AgentSnapshotPresenter.malibuFullLine(agent.snapshot))
                         .foregroundStyle(
                             agent.snapshot.malibuProjectionFresh && agent.snapshot.trustTier == .provisional
@@ -102,6 +107,11 @@ private struct DashboardView: View {
                         Text(backlog)
                             .font(.caption)
                             .foregroundStyle(MalibuBrand.coral)
+                    }
+                    if let eligibility = AgentSnapshotPresenter.eligibilityLine(agent.snapshot) {
+                        Text(eligibility)
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
                     }
                     if let address = agent.snapshot.payoutRegisteredAddress {
                         Text("Payout wallet \(PayoutWalletFlow.truncateAddress(address))")

--- a/phase3-binary/app/Tests/MalibuTests/AgentSnapshotPresenterTests.swift
+++ b/phase3-binary/app/Tests/MalibuTests/AgentSnapshotPresenterTests.swift
@@ -87,15 +87,19 @@ final class AgentSnapshotPresenterTests: XCTestCase {
 
         let pendingStatus = AgentSnapshotPresenter.publicStatus(pending)
         XCTAssertEqual(pendingStatus.title, "Pending hardware verification")
-        XCTAssertEqual(pendingStatus.safeNextAction, "Retry provider setup while online.")
+        XCTAssertEqual(
+            pendingStatus.safeNextAction,
+            "Keep Malibu online · retry setup if this lasts more than an hour."
+        )
         XCTAssertEqual(pendingStatus.executableAction, .retryHardwareVerification)
         XCTAssertFalse(pendingStatus.safeNextAction?.contains("macprovider-cli") == true)
+        XCTAssertTrue(pendingStatus.detail?.contains("usually under an hour") == true)
         XCTAssertFalse(pendingStatus.detail?.contains("wait for operator approval") == true)
         XCTAssertEqual(AgentSnapshotPresenter.short(pending), "Pending")
         XCTAssertEqual(AgentSnapshotPresenter.modelLine(pending), "llama")
         XCTAssertEqual(
             AgentSnapshotPresenter.lifecycleLine(pending),
-            "Pending hardware verification · Retry provider setup while online"
+            "Pending hardware verification · Usually under an hour · keep online"
         )
 
         var rejected = AgentSnapshot.empty

--- a/phase3-binary/app/Tests/MalibuTests/ControlFrameCodecTests.swift
+++ b/phase3-binary/app/Tests/MalibuTests/ControlFrameCodecTests.swift
@@ -61,6 +61,10 @@ final class ControlFrameCodecTests: XCTestCase {
                 malibuHoldReasons: ["per_wallet_daily_cap"],
                 malibuDailyCap: 25,
                 malibuWalletDailyCap: 100,
+                idlePrewarm: ProviderIdlePrewarmSummary(
+                    eventsLast1h: ["idle_prewarm_started": 4],
+                    skipsByReasonLast1h: ["on_battery": 2]
+                ),
                 malibuProjectionFresh: true,
                 earningsProjectionFresh: true
             ),
@@ -282,6 +286,55 @@ final class ControlFrameCodecTests: XCTestCase {
         )
         XCTAssertTrue(AgentSnapshotPresenter.malibuFullLine(agent.snapshot).contains("n/a MALIBU today"))
         XCTAssertEqual(AgentSnapshotPresenter.earningsLine(agent.snapshot), "Today: reward status unavailable")
+    }
+
+    @MainActor
+    func testMetricsResponseAppliesIdlePrewarmSummaryToSnapshot() {
+        var initialSnapshot = AgentSnapshot.empty
+        initialSnapshot.state = .serving
+        let agent = MalibuAgent(
+            initialSnapshot: initialSnapshot,
+            projectionEligibleForMetrics: true
+        )
+        let providerEarnings = ProviderEarnings(
+            walletBound: false,
+            trustTier: .provisional,
+            unpaidLedgerBacklogUSDC: 0,
+            unpaidLedgerBacklogMALIBU: 0,
+            usdcToday: 4,
+            usdcWeek: nil,
+            usdcPending: nil,
+            usdcLifetime: nil,
+            malibuToday: nil,
+            malibuAllTime: nil,
+            trustCriteriaMet: nil,
+            trustCriteriaRequired: nil,
+            idlePrewarm: ProviderIdlePrewarmSummary(skipsByReasonLast1h: ["on_battery": 1]),
+            malibuProjectionFresh: false,
+            earningsProjectionFresh: true
+        )
+        agent.consume(.metricsResponse(
+            earningsUsdc: 4,
+            malibuAccrued: nil,
+            providerEarnings: providerEarnings,
+            gpuC: nil,
+            gpuUtilizationPct: nil,
+            latencyP50Ms: nil,
+            latencyP99Ms: nil,
+            queueDepth: nil,
+            requestsServedToday: nil,
+            requestsServedAllTime: nil,
+            requestsPerMinute: nil,
+            inputTokensToday: nil,
+            outputTokensToday: nil,
+            inputTokensAllTime: nil,
+            outputTokensAllTime: nil,
+            uptimeSec: 1
+        ))
+
+        XCTAssertTrue(agent.snapshot.providerEarningsFresh)
+        XCTAssertEqual(agent.snapshot.idlePrewarmSummary.skipsByReasonLast1h["on_battery"], 1)
+        XCTAssertEqual(AgentSnapshotPresenter.eligibilityLine(agent.snapshot), "On battery — plug in to earn")
     }
 
     func testMetricsResponseDecodesGpuLatencyAndQueueDepth() throws {

--- a/phase3-binary/app/Tests/MalibuTests/DashboardViewTests.swift
+++ b/phase3-binary/app/Tests/MalibuTests/DashboardViewTests.swift
@@ -11,7 +11,7 @@ final class DashboardViewTests: XCTestCase {
         XCTAssertEqual(AgentSnapshotPresenter.modelLine(snapshot), "Connected")
         XCTAssertTrue(AgentSnapshotPresenter.requestsLine(snapshot).contains("0 today"))
         XCTAssertTrue(AgentSnapshotPresenter.tokenLine(snapshot).contains("0 in / 0 out today"))
-        XCTAssertEqual(AgentSnapshotPresenter.usdcFullLine(snapshot), "n/a today · n/a wk · n/a pending · n/a life")
+        XCTAssertEqual(AgentSnapshotPresenter.usdcFullLine(snapshot), "n/a today · n/a wk · n/a accrued · n/a life")
         XCTAssertEqual(AgentSnapshotPresenter.usdcTodayDisplay(snapshot), "n/a")
         XCTAssertEqual(AgentSnapshotPresenter.queueChip(snapshot), "0 queued")
         XCTAssertEqual(AgentSnapshotPresenter.thermalChip(snapshot), "Thermal OK")
@@ -81,11 +81,79 @@ final class DashboardViewTests: XCTestCase {
         XCTAssertEqual(AgentSnapshotPresenter.modelLine(snapshot), "Llama-3.1-8B · Q4_K_M · 4.2GB")
         XCTAssertEqual(AgentSnapshotPresenter.requestsLine(snapshot), "142 today · 8,204 all-time · 3.1 req/min")
         XCTAssertTrue(AgentSnapshotPresenter.tokenLine(snapshot).contains("1.2M in / 3.8M out today"))
-        XCTAssertEqual(AgentSnapshotPresenter.usdcFullLine(snapshot), "$4.12 today · $18.40 wk · $6.90 pending · $211.00 life")
+        XCTAssertEqual(AgentSnapshotPresenter.usdcFullLine(snapshot), "$4.12 today · $18.40 wk · $6.90 accrued · $211.00 life")
+        XCTAssertEqual(AgentSnapshotPresenter.usdcAccrualCaption(snapshot), "Accrued — payouts open in beta")
         XCTAssertTrue(AgentSnapshotPresenter.malibuFullLine(snapshot).contains("[locked] unlocks at Trusted"))
         XCTAssertEqual(AgentSnapshotPresenter.gpuChip(snapshot), "GPU 62%")
         XCTAssertEqual(AgentSnapshotPresenter.latencyChip(snapshot), "p50 42ms · p99 180ms")
         XCTAssertEqual(AgentSnapshotPresenter.queueChip(snapshot), "3 queued")
         XCTAssertEqual(AgentSnapshotPresenter.thermalChip(snapshot), "Serious")
+    }
+
+    func testUsdcAdaptivePrecisionShowsFourDecimalsUnderACentAndTwoOtherwise() {
+        var snapshot = AgentSnapshot.empty
+        snapshot.state = .serving
+        snapshot.providerEarningsFresh = true
+
+        snapshot.earningsUsdcToday = 0.0047
+        XCTAssertEqual(AgentSnapshotPresenter.usdcTodayDisplay(snapshot), "$0.0047")
+
+        snapshot.earningsUsdcToday = -0.0047
+        XCTAssertEqual(AgentSnapshotPresenter.usdcTodayDisplay(snapshot), "$-0.0047")
+
+        snapshot.earningsUsdcToday = 0
+        XCTAssertEqual(AgentSnapshotPresenter.usdcTodayDisplay(snapshot), "$0.00")
+
+        snapshot.earningsUsdcToday = 0.01
+        XCTAssertEqual(AgentSnapshotPresenter.usdcTodayDisplay(snapshot), "$0.01")
+
+        snapshot.earningsUsdcToday = 4.5
+        XCTAssertEqual(AgentSnapshotPresenter.usdcTodayDisplay(snapshot), "$4.50")
+
+        snapshot.earningsUsdcToday = 0.0047
+        snapshot.earningsUsdcWeek = 0.02
+        snapshot.earningsUsdcPending = 6.90
+        snapshot.earningsUsdcLifetime = 211
+        XCTAssertEqual(
+            AgentSnapshotPresenter.usdcFullLine(snapshot),
+            "$0.0047 today · $0.02 wk · $6.90 accrued · $211.00 life"
+        )
+    }
+
+    func testEligibilityLinePrioritizesIdlePrewarmSkipReasons() {
+        var snapshot = AgentSnapshot.empty
+        snapshot.state = .serving
+        snapshot.coordinatorConnected = true
+        snapshot.networkState = "buyer_serving"
+        snapshot.providerEarningsFresh = true
+
+        XCTAssertNil(AgentSnapshotPresenter.eligibilityLine(AgentSnapshot.empty))
+
+        snapshot.idlePrewarmSummary = ProviderIdlePrewarmSummary(
+            skipsByReasonLast1h: ["on_battery": 3, "thermal_pressure": 1]
+        )
+        XCTAssertEqual(AgentSnapshotPresenter.eligibilityLine(snapshot), "On battery — plug in to earn")
+
+        snapshot.idlePrewarmSummary = ProviderIdlePrewarmSummary(
+            skipsByReasonLast1h: ["thermal_pressure": 1, "model_not_loaded": 2]
+        )
+        XCTAssertEqual(
+            AgentSnapshotPresenter.eligibilityLine(snapshot),
+            "Thermal throttle — waiting to cool before earning"
+        )
+
+        snapshot.idlePrewarmSummary = ProviderIdlePrewarmSummary(
+            skipsByReasonLast1h: ["model_not_loaded": 2]
+        )
+        XCTAssertEqual(
+            AgentSnapshotPresenter.eligibilityLine(snapshot),
+            "Model is preparing — earning starts when ready"
+        )
+
+        snapshot.idlePrewarmSummary = .empty
+        XCTAssertEqual(AgentSnapshotPresenter.eligibilityLine(snapshot), "Eligible, waiting for work")
+
+        snapshot.providerEarningsFresh = false
+        XCTAssertNil(AgentSnapshotPresenter.eligibilityLine(snapshot))
     }
 }

--- a/phase4-coordinator/coordinator.malibu-emission-overlay.yaml
+++ b/phase4-coordinator/coordinator.malibu-emission-overlay.yaml
@@ -5,6 +5,7 @@
 # (e.g. OPoI canaries) before install — deploy script does this automatically.
 #
 # Promotion (after C4 verification): set enabled: true and restart coordinator.
+# Pearl production: enabled:true as of 2026-08-07 (prebeta P2 — accrual ticks on).
 # Rollback: set enabled: false or remove this overlay block.
 
 malibu_emission:

--- a/phase4-coordinator/internal/stats/hardwareverify/verify.go
+++ b/phase4-coordinator/internal/stats/hardwareverify/verify.go
@@ -246,6 +246,14 @@ SELECT j.id, j.provider_id, j.chip, j.chip_normalized, j.unified_memory_gb,
 				return Processed{}, err
 			}
 			processed.Waiting++
+			// Structured line for BetterStack / journald operator paging (prebeta P4).
+			// Dedup alerts on job_id in the ingest rule.
+			fmt.Printf(
+				"hardware_trust_waiting_new job_id=%d provider_id=%s reason=%s\n",
+				job.ID,
+				job.ProviderID,
+				decision.Reason,
+			)
 			continue
 		}
 		if err := rejectJob(ctx, tx, job.ID, decision.Reason); err != nil {


### PR DESCRIPTION
## Summary
- **P1 Malibu earnings card:** adaptive sub-cent USDC (`$0.0047`), `idle_prewarm` eligibility line (battery/thermal/preparing/waiting), `pending` → `accrued` with payouts-open-in-beta caption.
- **P2 Pearl:** `malibu_emission.enabled: true` live (2026-08-07); accrual runner started; overlay backup on Pearl; runbook promotion record.
- **P4 Trust wait:** in-app “usually under an hour” copy; `hardware_trust_waiting_new` journal line from verifier for BetterStack paging.
- **P5 Demand floor:** runbook prepared; **not armed** — blocked by `#584` / `exc-canary-disabled-enable-gate`.
- **P6 Honesty:** document `nodes_hardware_attested` SE-tier semantics (0 is expected); verified Malibu download pin asset exists; tick polish deferred.
- **P3 #941:** intentionally out of scope (landing from `fix/941-malibu-launchagent-migration`).

## Test plan
- [x] MalibuTests DashboardViewTests + hardware-pending presenter test
- [x] CLI ProviderEarningsClientTests / ControlSocketTests (prior lane)
- [x] `go test ./internal/stats/hardwareverify/`
- [x] Pearl journal: `SPEC-MALIBU-EMISSION-LEDGER accrual runner started`
- [ ] BetterStack rule for `hardware_trust_waiting_new` (ops follow-up)
- [ ] Malibu.app release so outside providers get P1/P4 UI

SPEC-GOVERNANCE-DECLARATION-BEGIN
{
  "schema_version": "spec-pr-governance-v1",
  "behavior_change": "yes",
  "contract_change": "none",
  "specs": ["SPEC-016", "SPEC-017"],
  "requirements": ["SPEC-016-R001", "SPEC-017-R001"],
  "authority_domains": ["payout-lifecycle", "network-stats"],
  "arbitration": ["CODE_BUG"],
  "tests": ["phase3-binary/app/Tests/MalibuTests/DashboardViewTests.swift", "phase4-coordinator/internal/stats/hardwareverify"],
  "journeys": ["not-required"],
  "issue": "https://github.com/Augustas11/macprovider/issues/895"
}
SPEC-GOVERNANCE-DECLARATION-END