### PR TITLE
fix(stats): rewards_writer UPDATE grant for MALIBU emission

### DIFF
--- a/phase4-coordinator/internal/stats/migrations/021_malibu_emission_ledger_update_grant.up.sql
+++ b/phase4-coordinator/internal/stats/migrations/021_malibu_emission_ledger_update_grant.up.sql
@@ -1,0 +1,5 @@
+-- Emission tick uses SELECT … FOR UPDATE / UPDATE on provider_rewards_ledger
+-- (cap-hold replay). Migration 012 only granted SELECT, INSERT to rewards_writer,
+-- which surfaces as permission denied (42501) once those paths run.
+GRANT SELECT, INSERT, UPDATE ON provider_rewards_ledger TO rewards_writer;
+GRANT USAGE, SELECT ON SEQUENCE provider_rewards_ledger_id_seq TO rewards_writer;

--- a/phase4-coordinator/internal/stats/migrations/migrations_test.go
+++ b/phase4-coordinator/internal/stats/migrations/migrations_test.go
@@ -41,6 +41,7 @@ func TestEmbeddedMigrationsLoad(t *testing.T) {
 		{18, "apptrack_register_attempts"},
 		{19, "hardware_trust_operator_approval"},
 		{20, "waiting_trust_chip_profile_projection"},
+		{21, "malibu_emission_ledger_update_grant"},
 	}
 	if len(all) != len(want) {
 		t.Fatalf("got %d migrations, want %d", len(all), len(want))


### PR DESCRIPTION
## Summary
- Migration `021_malibu_emission_ledger_update_grant`: `GRANT SELECT, INSERT, UPDATE ON provider_rewards_ledger TO rewards_writer`.
- Fixes Pearl prebeta P2: accrual runner started but some providers failed with `pq: permission denied for table provider_rewards_ledger` (cap-hold replay needs `UPDATE` / `FOR UPDATE`).
- Pearl already hotfixed + recorded version 21; this lands the durable migration.

## Test plan
- [x] `go test ./internal/stats/migrations/`
- [x] Pearl: UPDATE privilege true; App-track `p_*` MALIBU rows already accruing
- [ ] Confirm next emission tick has zero `accrual failed` permission errors

SPEC-GOVERNANCE-DECLARATION-BEGIN
{
  "schema_version": "spec-pr-governance-v1",
  "behavior_change": "yes",
  "contract_change": "none",
  "specs": ["SPEC-017"],
  "requirements": ["SPEC-017-R001"],
  "authority_domains": ["network-stats"],
  "arbitration": ["CODE_BUG"],
  "tests": ["phase4-coordinator/internal/stats/migrations"],
  "journeys": ["not-required"],
  "issue": "https://github.com/Augustas11/macprovider/issues/614"
}
SPEC-GOVERNANCE-DECLARATION-END

Made with [Cursor](https://cursor.com)