### PR TITLE
fix(rewards): stop lib/pq wire-protocol desync in cap-replay accrual path (mp-* accrual)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ test-coordinator:
 # Each stats case owns an isolated Postgres container; keep the package
 # deadline above the observed hosted-runner setup/teardown envelope.
 test-coordinator-integration:
-	cd phase4-coordinator && go test -tags=integration -timeout 10m ./internal/stats/... ./internal/onboarding/... ./cmd/coordinator/...
+	cd phase4-coordinator && go test -tags=integration -timeout 10m ./internal/stats/... ./internal/onboarding/... ./internal/rewards/... ./cmd/coordinator/...
 
 # SPEC-017 AC-16 — golangci-lint with depguard + forbidigo.
 # Pinned version so the target is hermetic on a fresh checkout.

--- a/phase4-coordinator/internal/rewards/emission.go
+++ b/phase4-coordinator/internal/rewards/emission.go
@@ -248,9 +248,22 @@ func bumpWalletDaily(ctx context.Context, tx *sql.Tx, wallet string, day time.Ti
 	return err
 }
 
+type pendingReplayRow struct {
+	id   int64
+	amt  float64
+	tier string
+}
+
 func replayCapPending(ctx context.Context, tx *sql.Tx, wallet string, walletCap float64) error {
 	// Oldest-first replay: for trusted providers, clear per_wallet_daily_cap
 	// holds where aggregate now permits withdrawal.
+	//
+	// The candidate rows are read to completion and the *sql.Rows is closed
+	// BEFORE any further statement runs on this tx/connection. lib/pq does
+	// not buffer query results like libpq does; issuing an Exec on the same
+	// connection while a Rows result set from an earlier Query is still
+	// open desyncs the wire protocol (surfaces as
+	// `pq: unexpected Parse response "(C) CommandComplete"`).
 	rows, err := tx.QueryContext(ctx, `
         SELECT prl.id, prl.amount_malibu::FLOAT8, pes.trust_tier
           FROM provider_rewards_ledger prl
@@ -264,39 +277,43 @@ func replayCapPending(ctx context.Context, tx *sql.Tx, wallet string, walletCap 
 	if err != nil {
 		return err
 	}
-	defer rows.Close()
-
-	day := utcDay(time.Now().UTC())
-	var running float64
-	if s, err := walletDaySum(ctx, tx, wallet, day); err != nil {
-		return err
-	} else {
-		running = s
-	}
-
+	var pending []pendingReplayRow
 	for rows.Next() {
-		var id int64
-		var amt float64
-		var tier string
-		if err := rows.Scan(&id, &amt, &tier); err != nil {
+		var row pendingReplayRow
+		if err := rows.Scan(&row.id, &row.amt, &row.tier); err != nil {
+			_ = rows.Close()
 			return err
 		}
-		if tier != TierTrusted {
+		pending = append(pending, row)
+	}
+	if err := rows.Err(); err != nil {
+		_ = rows.Close()
+		return err
+	}
+	if err := rows.Close(); err != nil {
+		return err
+	}
+
+	day := utcDay(time.Now().UTC())
+	running, err := walletDaySum(ctx, tx, wallet, day)
+	if err != nil {
+		return err
+	}
+
+	for _, row := range pending {
+		if row.tier != TierTrusted {
 			continue
 		}
-		if running+amt <= walletCap {
+		if running+row.amt <= walletCap {
 			if _, err := tx.ExecContext(ctx, `
                 UPDATE provider_rewards_ledger
                    SET withdrawal_hold_reason = NULL
                  WHERE id = $1
-            `, id); err != nil {
+            `, row.id); err != nil {
 				return err
 			}
 		}
-		running += amt
-	}
-	if err := rows.Err(); err != nil {
-		return err
+		running += row.amt
 	}
 
 	_, err = tx.ExecContext(ctx, `

--- a/phase4-coordinator/internal/rewards/emission_integration_test.go
+++ b/phase4-coordinator/internal/rewards/emission_integration_test.go
@@ -189,3 +189,89 @@ func TestWalletDailyCapAcrossProviders(t *testing.T) {
 		t.Fatalf("wallet aggregate %v exceeds cap 100", sum)
 	}
 }
+
+// TestCapReplayPendingDoesNotDesyncConnection is a regression test for the
+// hardware-track (mp-*) accrual failure: `pq: unexpected Parse response
+// "(C) CommandComplete"`. That error surfaced whenever a Trusted provider's
+// wallet had cap_replay_pending=true (set by the SPEC-016 payout-address
+// wallet mirror — a path mp-* providers exercise routinely) and an
+// already-held ledger row qualified for replay during an accrual tick.
+// replayCapPending used to run tx.ExecContext while its own tx.QueryContext
+// *sql.Rows was still open, which desyncs the lib/pq wire protocol (lib/pq
+// does not buffer results like libpq) and aborts the whole tick transaction
+// for that provider — silently, since runEmissionTick only logs a Warn.
+func TestCapReplayPendingDoesNotDesyncConnection(t *testing.T) {
+	fx, adminDB := startPostgres(t)
+	writerDB := openRewardsWriter(t, fx)
+	ctx := context.Background()
+
+	providerID := "mp-hw-test-1"
+	wallet := "0xdeadbeef"
+
+	if _, err := adminDB.ExecContext(ctx, `
+        INSERT INTO provider_emission_state
+            (provider_id, trust_tier, bound_wallet, cap_replay_pending, provider_day_malibu)
+        VALUES ($1, 'trusted', $2, TRUE, 0)
+    `, providerID, wallet); err != nil {
+		t.Fatalf("seed state: %v", err)
+	}
+
+	heldUnixTS := time.Now().UTC().Add(-time.Hour).Unix()
+	if _, err := adminDB.ExecContext(ctx, `
+        INSERT INTO provider_rewards_ledger
+            (provider_id, unix_ts, amount_malibu, withdrawal_hold_reason, reason)
+        VALUES ($1, $2, 10, $3, 'malibu_bootstrap_tick')
+    `, providerID, heldUnixTS, rewards.HoldPerWalletDailyCap); err != nil {
+		t.Fatalf("seed held ledger row: %v", err)
+	}
+
+	cfg := rewards.Config{
+		Enabled:                true,
+		TickInterval:           time.Hour,
+		ProviderDailyCapMALIBU: 25,
+		WalletDailyCapMALIBU:   100,
+		MaxSerializableRetries: 5,
+	}
+	runner, err := rewards.New(writerDB, cfg, zerolog.Nop(), rewards.RunnerDeps{})
+	if err != nil {
+		t.Fatalf("new runner: %v", err)
+	}
+	if err := runner.RunEmissionTickOnce(ctx); err != nil {
+		t.Fatalf("emission tick: %v", err)
+	}
+
+	// The tick transaction must have committed (not silently rolled back
+	// by a desynced connection): a new ledger row for this tick exists.
+	var rowCount int
+	if err := adminDB.QueryRowContext(ctx, `
+        SELECT COUNT(*) FROM provider_rewards_ledger WHERE provider_id = $1
+    `, providerID).Scan(&rowCount); err != nil {
+		t.Fatalf("count ledger rows: %v", err)
+	}
+	if rowCount != 2 {
+		t.Fatalf("ledger rows for %s = %d, want 2 (pre-existing held row + new tick row)", providerID, rowCount)
+	}
+
+	// The pre-existing held row must have been replayed (hold cleared)
+	// since running(0) + 10 <= walletCap(100).
+	var holdReason sql.NullString
+	if err := adminDB.QueryRowContext(ctx, `
+        SELECT withdrawal_hold_reason FROM provider_rewards_ledger
+         WHERE provider_id = $1 AND unix_ts = $2
+    `, providerID, heldUnixTS).Scan(&holdReason); err != nil {
+		t.Fatalf("query held row: %v", err)
+	}
+	if holdReason.Valid {
+		t.Fatalf("held row hold_reason = %q, want cleared (NULL)", holdReason.String)
+	}
+
+	var capReplayPending bool
+	if err := adminDB.QueryRowContext(ctx, `
+        SELECT cap_replay_pending FROM provider_emission_state WHERE provider_id = $1
+    `, providerID).Scan(&capReplayPending); err != nil {
+		t.Fatalf("query state: %v", err)
+	}
+	if capReplayPending {
+		t.Fatal("cap_replay_pending should be cleared after successful replay")
+	}
+}

--- a/phase4-coordinator/internal/rewards/emission_integration_test.go
+++ b/phase4-coordinator/internal/rewards/emission_integration_test.go
@@ -92,6 +92,22 @@ func openRewardsWriter(t *testing.T, fx *pgFixture) *sql.DB {
 	return db
 }
 
+// testEmissionConfig builds a valid rewards.Config for tests that call
+// rewards.New directly with an already-open *sql.DB. WriterDSN and
+// SQLitePayoutDBPath are required by Config.Validate() but unused by
+// RunEmissionTickOnce, which operates on the db passed to rewards.New.
+func testEmissionConfig(tickInterval time.Duration, providerCap, walletCap float64) rewards.Config {
+	return rewards.Config{
+		Enabled:                true,
+		WriterDSN:              "unused-in-test",
+		SQLitePayoutDBPath:     "/dev/null",
+		TickInterval:           tickInterval,
+		ProviderDailyCapMALIBU: providerCap,
+		WalletDailyCapMALIBU:   walletCap,
+		MaxSerializableRetries: 5,
+	}
+}
+
 func TestProvisionalAccrualSetsWithdrawalHold(t *testing.T) {
 	fx, adminDB := startPostgres(t)
 	writerDB := openRewardsWriter(t, fx)
@@ -104,13 +120,7 @@ func TestProvisionalAccrualSetsWithdrawalHold(t *testing.T) {
 		t.Fatalf("seed state: %v", err)
 	}
 
-	cfg := rewards.Config{
-		Enabled:                true,
-		TickInterval:           time.Hour,
-		ProviderDailyCapMALIBU: 25,
-		WalletDailyCapMALIBU:   100,
-		MaxSerializableRetries: 5,
-	}
+	cfg := testEmissionConfig(time.Hour, 25, 100)
 	runner, err := rewards.New(writerDB, cfg, zerolog.Nop(), rewards.RunnerDeps{})
 	if err != nil {
 		t.Fatalf("new runner: %v", err)
@@ -160,13 +170,7 @@ func TestWalletDailyCapAcrossProviders(t *testing.T) {
 		}
 	}
 
-	cfg := rewards.Config{
-		Enabled:                true,
-		TickInterval:           time.Minute,
-		ProviderDailyCapMALIBU: 1000,
-		WalletDailyCapMALIBU:   100,
-		MaxSerializableRetries: 5,
-	}
+	cfg := testEmissionConfig(time.Minute, 1000, 100)
 	runner, err := rewards.New(writerDB, cfg, zerolog.Nop(), rewards.RunnerDeps{})
 	if err != nil {
 		t.Fatalf("new runner: %v", err)
@@ -225,13 +229,7 @@ func TestCapReplayPendingDoesNotDesyncConnection(t *testing.T) {
 		t.Fatalf("seed held ledger row: %v", err)
 	}
 
-	cfg := rewards.Config{
-		Enabled:                true,
-		TickInterval:           time.Hour,
-		ProviderDailyCapMALIBU: 25,
-		WalletDailyCapMALIBU:   100,
-		MaxSerializableRetries: 5,
-	}
+	cfg := testEmissionConfig(time.Hour, 25, 100)
 	runner, err := rewards.New(writerDB, cfg, zerolog.Nop(), rewards.RunnerDeps{})
 	if err != nil {
 		t.Fatalf("new runner: %v", err)


### PR DESCRIPTION
## Summary
- Root cause of residual `mp-*` accrual failures on Pearl: `pq: unexpected Parse response "(C) CommandComplete"`.
- `replayCapPending` (cap-hold replay for Trusted providers) issued an `UPDATE` on the same transaction while its own `SELECT ... FOR UPDATE` `*sql.Rows` result set was still open. `lib/pq` doesn't buffer results like `libpq` does, so a new Parse/Bind/Execute on the same connection while a Rows set is unread desyncs the wire protocol.
- This path only fires when a Trusted provider's bound wallet has `cap_replay_pending=true` — set by the SPEC-016 payout-address wallet mirror whenever a payout address binds/changes. `mp-*` (hardware/CLI track) providers exercise that path routinely; `p_*` (App-track) providers rarely do, which is why only `mp-*` accrual ticks hit it. The whole tick transaction rolled back silently (`runEmissionTick` only logs a `Warn`), dropping that provider's accrual for the tick.
- Fix: fully drain and close the `Rows` before issuing any further statement on the same `tx` — standard `database/sql` + `lib/pq` usage.
- Also wires `internal/rewards` into `make test-coordinator-integration` (it was previously omitted, so the package's `testcontainers`-backed Postgres tests never ran in CI).

## Test plan
- [x] `go build ./...`, `go vet ./...` — clean
- [x] `go test ./...` (phase4-coordinator, non-integration) — all pass
- [x] `go vet -tags=integration ./internal/rewards/...` — compiles
- [x] New regression test `TestCapReplayPendingDoesNotDesyncConnection` reproduces the exact `mp-*` scenario (Trusted provider, bound wallet, `cap_replay_pending=true`, pre-existing held ledger row) and asserts the tick transaction commits (new ledger row exists) and the held row's hold is correctly replayed/cleared. Runs in CI via `coordinator-stats-integration` (testcontainers Postgres, no Docker available in this sandbox to run it locally).
- [ ] Pearl: confirm next `mp-*` emission tick has zero `unexpected Parse response` errors in coordinator logs after deploy.

Not armed: canary untouched. Pearl config untouched — this is a pure code fix in `phase4-coordinator/internal/rewards`.

SPEC-GOVERNANCE-DECLARATION-BEGIN
{
  "schema_version": "spec-pr-governance-v1",
  "behavior_change": "yes",
  "contract_change": "none",
  "specs": ["SPEC-017", "SPEC-021"],
  "requirements": ["SPEC-017-R001"],
  "authority_domains": ["network-stats", "malibu-emission-ledger"],
  "arbitration": ["CODE_BUG"],
  "tests": ["phase4-coordinator/internal/rewards"],
  "journeys": ["not-required"],
  "issue": "https://github.com/Augustas11/macprovider/issues/614"
}
SPEC-GOVERNANCE-DECLARATION-END
