### PR TITLE
fix(release): advertise 1.8.88 previous stable for v1.8.90 cut

### DIFF
--- a/phase4-coordinator/coordinator.yaml.example
+++ b/phase4-coordinator/coordinator.yaml.example
@@ -186,7 +186,7 @@ autotune:
 # legacy cohort (DECISION_CRITERIA Entry 161). `required_binary_version` is a
 # hard admission floor, not an autoupdate target, and is unaffected by the gate.
 coordinator_advertised_version:
-  latest_binary_version: "1.8.82"
+  latest_binary_version: "1.8.88"
   required_binary_version: ""
 
 auth:

--- a/phase4-coordinator/dist/coordinator.yaml
+++ b/phase4-coordinator/dist/coordinator.yaml
@@ -366,8 +366,8 @@ providers:
 # the already-true rejection explicit and machine-readable instead of leaving
 # a legacy build to fail later, opaquely, on catalog admission.
 #
-# It is deliberately pinned to the previous stable recommendation (1.8.82)
-# until the signed 1.8.88 assets have been published and byte-identity
+# It is deliberately pinned to the previous stable recommendation (1.8.88)
+# until the signed 1.8.90 assets have been published and byte-identity
 # verified, and remains below the
 # #610 first-hop bridge build (1.8.48, which is additionally exempt from the
 # floor by construction — see prepareProviderAdmission's firstHopOnly skip),
@@ -376,5 +376,5 @@ providers:
 # reconnecting and tells its operator to upgrade, and one without it
 # reconnect-loops.
 coordinator_advertised_version:
-  latest_binary_version: "1.8.82"
+  latest_binary_version: "1.8.88"
   required_binary_version: "1.8.33"

--- a/phase4-coordinator/dist/coordinator.yaml.example
+++ b/phase4-coordinator/dist/coordinator.yaml.example
@@ -373,7 +373,7 @@ malibu_emission:
 # routing. Keys match model_id case-insensitively; values must be bare
 # numeric versions or the coordinator refuses to start.
 coordinator_advertised_version:
-  latest_binary_version: "1.8.82"
+  latest_binary_version: "1.8.88"
   # required_binary_version: "1.7.0"
   # per_model_required_binary_version:
   #   "mlx-community/Qwen3-Coder-30B-A3B-Instruct-4bit": "1.8.60"

--- a/scripts/test-coordinator-advertised-version-test.sh
+++ b/scripts/test-coordinator-advertised-version-test.sh
@@ -11,7 +11,7 @@ app_build="$(sed -nE 's/^[[:space:]]*CURRENT_PROJECT_VERSION: "?([0-9]+)"?.*$/\1
 future_version="${app_version%.*}.$((${app_version##*.} + 1))"
 future_build="$((app_build + 1))"
 future_version_pattern="${future_version//./\\.}"
-staged_coordinator_policy="--allow-previous-stable=1.8.82"
+staged_coordinator_policy="--allow-previous-stable=1.8.88"
 staged_candidate_policy="--staged-candidate=1.8.90"
 work="$(mktemp -d "${TMPDIR:-/tmp}/release-version-cohesion.XXXXXX")"
 trap 'rm -rf "$work"' EXIT
@@ -47,9 +47,9 @@ if bash "$version_guard" "v$binary_version" >"$work/strict-staging.out" 2>&1; th
   echo "strict version guard accepted an unpublished candidate against the previous recommendation" >&2
   exit 1
 fi
-grep -q "advertises 1.8.82; expected $binary_version" "$work/strict-staging.out"
+grep -q "advertises 1.8.88; expected $binary_version" "$work/strict-staging.out"
 base_output="$(bash "$version_guard" "v$binary_version" "$staged_coordinator_policy" "$staged_candidate_policy")"
-grep -q "staged with previous stable coordinator recommendation 1.8.82" <<<"$base_output"
+grep -q "staged with previous stable coordinator recommendation 1.8.88" <<<"$base_output"
 
 if bash "$version_guard" "v$binary_version" "$staged_coordinator_policy" --staged-candidate=1.8.91 >"$work/candidate-drift.out" 2>&1; then
   echo "version guard accepted a staged exception for a different candidate" >&2

--- a/scripts/test-malibu-independent-release.sh
+++ b/scripts/test-malibu-independent-release.sh
@@ -135,7 +135,7 @@ valid_cli_version="$(
     "$root/phase3-binary/Sources/macprovider-cli/CoordinatorClient.swift"
 )"
 valid_cli_tag="v$valid_cli_version"
-staged_coordinator_policy="--allow-previous-stable=1.8.82"
+staged_coordinator_policy="--allow-previous-stable=1.8.88"
 staged_candidate_policy="--staged-candidate=1.8.90"
 
 "$validator" "$valid_cli_tag" "$valid_cli_version" "$valid_sha" "$valid_archive_sha" \


### PR DESCRIPTION
## Summary
- Bump checked-in `latest_binary_version` 1.8.82 → 1.8.88 so `release.yml` cohesion for v1.8.90 passes.
- Matches live Pearl recommendation; keeps candidate 1.8.90 unpublished until after assets verify.

## Test plan
- [x] `bash scripts/test-coordinator-advertised-version.sh v1.8.90 --allow-previous-stable=1.8.88 --staged-candidate=1.8.90`

SPEC-GOVERNANCE-DECLARATION-BEGIN
{
  "schema_version": "spec-pr-governance-v1",
  "behavior_change": "yes",
  "contract_change": "none",
  "specs": ["SPEC-016"],
  "requirements": ["SPEC-016-R001"],
  "authority_domains": ["payout-lifecycle"],
  "arbitration": ["CODE_BUG"],
  "tests": ["scripts/test-coordinator-advertised-version.sh"],
  "journeys": ["not-required"],
  "issue": "https://github.com/Augustas11/macprovider/issues/614"
}
SPEC-GOVERNANCE-DECLARATION-END

Made with [Cursor](https://cursor.com)