### PR TITLE
feat(ops): hardware-trust monitor alert + #584 NO-GO + Pearl drain fix

### DIFF
--- a/ops/pearl-updater/catalog-canary-proof.py
+++ b/ops/pearl-updater/catalog-canary-proof.py
@@ -23,6 +23,8 @@ CATALOG_FILES = (
     "release.json",
     "trusted-keys.json",
     "tier2-catalog.json",
+    "rate-card.json",
+    "rate-card.json.sig",
     "autotune-candidates.json",
     "autotune-candidates.json.sig",
     "demand-rank.json",

--- a/ops/pearl-updater/macprovider-pearl-update
+++ b/ops/pearl-updater/macprovider-pearl-update
@@ -3535,8 +3535,11 @@ class Updater:
                 "sqlite3",
                 "-bail",
                 str(self.gateway_db),
+                # Settlement holds (settlement_hold=1) are post-stream quota finality
+                # state, not in-flight buyer work. Counting them blocked Pearl drain
+                # forever while concurrency was already zero (v1.8.90 apply 2026-08-07).
                 "SELECT (SELECT COUNT(*) FROM concurrency_reservations WHERE status='active') + "
-                "(SELECT COUNT(*) FROM quota_reservations WHERE status='active');",
+                "(SELECT COUNT(*) FROM quota_reservations WHERE status='active' AND settlement_hold = 0);",
             ],
             check=False,
             timeout=10,

--- a/ops/runbooks/584-demand-floor-go-nogo-2026-08-07.md
+++ b/ops/runbooks/584-demand-floor-go-nogo-2026-08-07.md
@@ -1,0 +1,43 @@
+# #584 demand-floor go/no-go — 2026-08-07
+
+**Verdict: NO-GO** — leave canary disabled; do not arm the demand floor.
+
+## Decision
+
+| Gate | Status |
+|------|--------|
+| Issue #584 redesign merged (hermetic FR-CAN22/23, budgets, correlation) | Pass (code closed 2026-07-23) |
+| Production exception `exc-canary-disabled-enable-gate` | Still **active** |
+| Physical per-tier baselines (`584-physical-baseline-matrix.md`) | **Missing** — no signed floor records on file |
+| Emergency-disable drill evidence on Pearl | Not re-run for this window |
+| Operator-signed go for timer / enable-gate / `pool.canary_enabled` | **Not granted** |
+
+Until physical baselines + signed acceptance exist, Pearl stays:
+
+- `/var/lib/macprovider-canary-buyer/DISABLED` present
+- `/etc/macprovider-canary-buyer/enabled` absent
+- `pool.canary_enabled: false`
+- `canary-buyer.timer` disabled
+- `PEARL_UPDATER_BUYER_CANARY_MODE=disabled` (updater apply path)
+
+## Why this is still NO-GO after issue close
+
+Closing #584 sealed the **redesign package**, not a production re-enable.
+The exception register’s removal condition is explicit: reviewed physical
+evidence + approval. Prebeta P5 (demand floor) remains gated on that same bar.
+
+## Interim provider UX (already shipped)
+
+- MALIBU emission ticks (counter motion without buyer demand)
+- Adaptive USD + eligibility copy on Malibu earnings card
+- Do **not** invent a second unapproved buyer probe
+
+## Re-open criteria (next go/no-go)
+
+1. Fill `ops/runbooks/584-physical-baseline-matrix.md` cells for fleet tiers present on Pearl
+2. One operator-approved liveness-only day behind the enable gate (still budgets-only)
+3. Update `exc-canary-disabled-enable-gate` evidence + flip status when signed
+4. Only then follow `ops/runbooks/prebeta-demand-floor.md` re-enable checklist
+
+**Approver for this NO-GO:** operator session 2026-08-07 (prebeta follow-ups).
+Not a canary arm authorization.

--- a/ops/runbooks/hardware-trust-pending-alert.md
+++ b/ops/runbooks/hardware-trust-pending-alert.md
@@ -4,7 +4,7 @@
 
 ## Signals
 
-### A. Journal line (preferred)
+### A. Journal line
 
 `stats-hardware-verifier` emits when a job is parked `waiting_trust`:
 
@@ -12,16 +12,35 @@
 hardware_trust_waiting_new job_id=123 provider_id=mp-… reason=missing_trusted_hardware_identity
 ```
 
-**BetterStack (or journald ingest):** match `hardware_trust_waiting_new`, dedupe on `job_id`, page on-call.
+### B. Pearl Gmail monitor (live path)
 
-### B. Admin poll (backup)
+BetterStack is **not** the live Pearl page path. Pearl pages via
+`macprovider-monitor` → Gmail (`/etc/macprovider/monitor.env`, timer every 3 min).
+
+`phase4-coordinator/dist/monitor/macprovider-monitor.py` polls
+`GET /admin/hardware-trust/waiting` with `OPERATOR_KEY` and emails kind
+`hardware_trust` (not in the default mute list) when:
+
+1. A **new** `job_id` appears → `hardware_trust_waiting_new …`
+2. Backlog persists ≥ `HARDWARE_TRUST_WAITING_STALE_MINUTES` (default 5) →
+   `hardware_trust_waiting_stale count=…`
+
+Deploy: copy the updated `macprovider-monitor.py` to the unit’s `ExecStart`
+path, then `systemctl start macprovider-monitor.service` once to verify.
+
+Optional env:
+
+```bash
+HARDWARE_TRUST_WAITING_ENABLED=1
+HARDWARE_TRUST_WAITING_STALE_MINUTES=5
+```
+
+### C. Manual admin poll
 
 ```bash
 curl -sS -H "Authorization: Bearer $OPERATOR_TOKEN" \
   https://coordinator.streamvc.live/admin/hardware-trust/waiting | jq '.count, .waiting_trust'
 ```
-
-Cron every 5 minutes; alert when `count > 0` for >5 minutes.
 
 ## In-app copy (Malibu)
 
@@ -38,3 +57,4 @@ Pending state: **“Hardware verification pending — usually under an hour.”*
 - Issue #838 (fatal install path closed; wait remains)
 - `phase4-coordinator/internal/stats/hardwareverify/verify.go`
 - `phase4-coordinator/internal/ws/admin_hardware_trust.go`
+- `scripts/test-macprovider-monitor-hardware-trust.py`

--- a/ops/runbooks/hardware-trust-pending-alert.md
+++ b/ops/runbooks/hardware-trust-pending-alert.md
@@ -18,7 +18,7 @@ BetterStack is **not** the live Pearl page path. Pearl pages via
 `macprovider-monitor` → Gmail (`/etc/macprovider/monitor.env`, timer every 3 min).
 
 `phase4-coordinator/dist/monitor/macprovider-monitor.py` polls
-`GET /admin/hardware-trust/waiting` with `OPERATOR_KEY` and emails kind
+`GET /admin/hardware-trust/waiting` with `OPERATOR_AUTH_POLICY_A` (or `_B`) and emails kind
 `hardware_trust` (not in the default mute list) when:
 
 1. A **new** `job_id` appears → `hardware_trust_waiting_new …`

--- a/ops/runbooks/prebeta-demand-floor.md
+++ b/ops/runbooks/prebeta-demand-floor.md
@@ -2,6 +2,12 @@
 
 **Status:** Prepared, **not armed** on Pearl.
 
+**2026-08-07 go/no-go:** **NO-GO** — see
+[`584-demand-floor-go-nogo-2026-08-07.md`](./584-demand-floor-go-nogo-2026-08-07.md).
+Issue #584 is closed for the redesign package; production exception
+`exc-canary-disabled-enable-gate` remains **active** until physical baselines
+and a signed enable approval land.
+
 ## Why gated
 
 Production exception `exc-canary-disabled-enable-gate` (#584) keeps:

--- a/phase4-coordinator/dist/monitor/macprovider-monitor.py
+++ b/phase4-coordinator/dist/monitor/macprovider-monitor.py
@@ -7,9 +7,9 @@ provider-removal (circuit-breaker degrade, warm-up-gate failure), repeated
 auth/config/liveness failures, and pool-empty / service-down conditions surface
 without a human SSHing into journals.
 
-Zero provider load: it reads /healthz, /poolz, /admin/providers*, /v1/status
-only — it does NOT send inference. (A synthetic canary can be added later if
-desired.)
+Zero provider load: it reads /healthz, /poolz, /admin/providers*,
+/admin/hardware-trust/waiting, /v1/status only — it does NOT send inference.
+(A synthetic canary can be added later if desired.)
 
 Alerts go to stdout (captured by journald) ALWAYS, and to email if
 /etc/macprovider/monitor.env provides Gmail submission creds. Run on a
@@ -34,6 +34,8 @@ Config (/etc/macprovider/monitor.env, optional, KEY=VALUE lines):
   PROVIDER_DIAGNOSTICS_WINDOW_MINUTES=15           # optional #535 window
   PROVIDER_DIAGNOSTICS_MIN_FAILURES=3              # optional burst threshold
   EXPECTED_PROVIDER_IDS=augustass-macbook-air,air5 # optional missing-auth watch
+  HARDWARE_TRUST_WAITING_ENABLED=1                # optional; poll waiting_trust
+  HARDWARE_TRUST_WAITING_STALE_MINUTES=5          # email when backlog persists
 """
 
 import json
@@ -55,6 +57,7 @@ STATE_FILE = os.path.join(
 HEALTHZ = "http://127.0.0.1:8444/healthz"
 POOLZ = "http://127.0.0.1:8444/poolz"
 ADMIN_PROVIDERS = "http://127.0.0.1:8444/admin/providers"
+ADMIN_HARDWARE_TRUST_WAITING = "http://127.0.0.1:8444/admin/hardware-trust/waiting"
 GW_STATUS = "http://127.0.0.1:9443/v1/status"
 ANONYMOUS_PROVIDER_ID = "_anonymous"
 STATIC_FEEDS = (
@@ -79,6 +82,7 @@ KIND_POOL = "pool"                    # pool ready-count emptied / recovered
 KIND_GATEWAY_STATUS = "gateway_status"  # gateway self-reported idle/degraded/down
 KIND_SERVICE = "service"              # coordinator/gateway endpoint unreachable
 KIND_STATIC_FEED = "static_feed"      # SPEC-023 signed static feeds
+KIND_HARDWARE_TRUST = "hardware_trust"  # waiting_trust backlog / new jobs
 ALERT_KINDS = (
     KIND_PROVIDER,
     KIND_PROVIDER_DIAGNOSTICS,
@@ -87,6 +91,7 @@ ALERT_KINDS = (
     KIND_GATEWAY_STATUS,
     KIND_SERVICE,
     KIND_STATIC_FEED,
+    KIND_HARDWARE_TRUST,
 )
 # Provider churn and liveness noise on a small fleet are journal-only by
 # default; the kinds that mean "the Pearl-side services themselves are down"
@@ -264,6 +269,95 @@ def diagnostic_dedupe_key(provider_id, key, cursor):
     if provider_id == ANONYMOUS_PROVIDER_ID:
         return f"{key}:active"
     return f"{key}:{cursor or 'no-events'}"
+
+
+def hardware_trust_waiting_alerts(env, prev_state, payload, now=None):
+    """Alert on new waiting_trust jobs and a persistent backlog.
+
+    Returns (alerts, next_state_fragment). Email is intentionally not muted for
+    KIND_HARDWARE_TRUST — trust grants are operator-actionable.
+    """
+    now = now or datetime.now(timezone.utc)
+    alerts = []
+    prev = prev_state.get("hardware_trust_waiting", {}) if isinstance(prev_state, dict) else {}
+    if not isinstance(prev, dict):
+        prev = {}
+
+    jobs = payload.get("waiting_trust", []) if isinstance(payload, dict) else []
+    if not isinstance(jobs, list):
+        jobs = []
+
+    job_ids = []
+    for job in jobs:
+        if not isinstance(job, dict):
+            continue
+        job_id = job.get("job_id")
+        if isinstance(job_id, int) or (isinstance(job_id, str) and job_id.isdigit()):
+            job_ids.append(int(job_id))
+    job_ids = sorted(set(job_ids))
+    prev_ids = []
+    for raw in prev.get("job_ids", []) if isinstance(prev.get("job_ids"), list) else []:
+        try:
+            prev_ids.append(int(raw))
+        except (TypeError, ValueError):
+            continue
+    prev_ids_set = set(prev_ids)
+    new_ids = [jid for jid in job_ids if jid not in prev_ids_set]
+
+    by_id = {}
+    for job in jobs:
+        if isinstance(job, dict) and job.get("job_id") is not None:
+            try:
+                by_id[int(job["job_id"])] = job
+            except (TypeError, ValueError):
+                continue
+
+    for jid in new_ids:
+        job = by_id.get(jid, {})
+        provider_id = job.get("provider_id", "?")
+        reason = job.get("decision_reason", "?")
+        approvable = job.get("approvable")
+        alerts.append((
+            "WARN",
+            KIND_HARDWARE_TRUST,
+            f"hardware_trust_waiting_new job_id={jid} provider_id={provider_id} "
+            f"reason={reason} approvable={approvable}",
+        ))
+
+    first_seen_raw = prev.get("first_seen_utc")
+    first_seen = parse_utc(first_seen_raw) if isinstance(first_seen_raw, str) else None
+    if job_ids:
+        if first_seen is None:
+            first_seen = now
+    else:
+        first_seen = None
+
+    stale_minutes = bounded_int(env, "HARDWARE_TRUST_WAITING_STALE_MINUTES", 5, 1, 1440)
+    stale_alerted = bool(prev.get("stale_alerted"))
+    if job_ids and first_seen is not None:
+        age = now - first_seen
+        if age >= timedelta(minutes=stale_minutes) and not stale_alerted:
+            sample = ", ".join(str(jid) for jid in job_ids[:8])
+            more = "" if len(job_ids) <= 8 else f" (+{len(job_ids) - 8} more)"
+            alerts.append((
+                "WARN",
+                KIND_HARDWARE_TRUST,
+                f"hardware_trust_waiting_stale count={len(job_ids)} "
+                f"age_min={int(age.total_seconds() // 60)} job_ids={sample}{more}",
+            ))
+            stale_alerted = True
+        elif not job_ids:
+            stale_alerted = False
+    else:
+        stale_alerted = False
+
+    next_state = {
+        "job_ids": job_ids,
+        "first_seen_utc": first_seen.strftime("%Y-%m-%dT%H:%M:%SZ") if first_seen else None,
+        "stale_alerted": stale_alerted,
+        "count": len(job_ids),
+    }
+    return alerts, next_state
 
 
 def provider_diagnostic_alerts(env, state, admin_provider_list, events_by_provider, now=None, failed_provider_ids=None):
@@ -503,6 +597,26 @@ def main():
     elif coord_up and diagnostics_enabled and not op_key:
         print("[INFO] provider diagnostics alerts disabled until OPERATOR_KEY is available", flush=True)
 
+    # --- hardware trust waiting_trust backlog (prebeta P4) ---
+    hardware_trust_state = prev.get("hardware_trust_waiting", {})
+    hardware_trust_enabled = env.get("HARDWARE_TRUST_WAITING_ENABLED", "1").strip().lower() not in (
+        "0",
+        "false",
+        "no",
+        "off",
+    )
+    if coord_up and hardware_trust_enabled and op_key:
+        try:
+            waiting = get_json(ADMIN_HARDWARE_TRUST_WAITING, bearer=op_key)
+            ht_alerts, hardware_trust_state = hardware_trust_waiting_alerts(
+                env, prev, waiting if isinstance(waiting, dict) else {},
+            )
+            alerts.extend(ht_alerts)
+        except Exception as e:  # noqa: BLE001
+            alerts.append(("WARN", KIND_HARDWARE_TRUST, f"hardware-trust waiting read failed: {e}"))
+    elif coord_up and hardware_trust_enabled and not op_key:
+        print("[INFO] hardware-trust waiting alerts disabled until OPERATOR_KEY is available", flush=True)
+
     # --- transition detection vs last poll ---
     prev_pool = prev.get("pool", {})
     prev_ready = prev.get("ready")
@@ -574,6 +688,7 @@ def main():
         "gw_status": gw_status,
         "static_ok": static_ok,
         "provider_diagnostics": diagnostics_state.get("provider_diagnostics", {}),
+        "hardware_trust_waiting": hardware_trust_state,
     }
     # Muted alerts still count as alerting transitions: muting changes where
     # an alert is delivered, not whether the condition happened.

--- a/phase4-coordinator/dist/monitor/macprovider-monitor.py
+++ b/phase4-coordinator/dist/monitor/macprovider-monitor.py
@@ -159,6 +159,20 @@ def operator_key():
     return os.environ.get("OPERATOR_KEY", "")
 
 
+def hardware_trust_operator_key():
+    """Bearer for /admin/hardware-trust/* (auth-policy dual-control keys).
+
+    Waiting/approve routes use authorizedProviderAuthPolicyOperator, which
+    accepts OPERATOR_AUTH_POLICY_A/B — not the general OPERATOR_KEY used for
+    /poolz and /admin/providers.
+    """
+    for name in ("OPERATOR_AUTH_POLICY_A", "OPERATOR_AUTH_POLICY_B"):
+        value = os.environ.get(name, "").strip()
+        if value:
+            return value
+    return ""
+
+
 def bounded_int(env, key, default, min_value, max_value):
     raw = env.get(key)
     if raw is None or raw.strip() == "":
@@ -605,17 +619,22 @@ def main():
         "no",
         "off",
     )
-    if coord_up and hardware_trust_enabled and op_key:
+    ht_key = hardware_trust_operator_key()
+    if coord_up and hardware_trust_enabled and ht_key:
         try:
-            waiting = get_json(ADMIN_HARDWARE_TRUST_WAITING, bearer=op_key)
+            waiting = get_json(ADMIN_HARDWARE_TRUST_WAITING, bearer=ht_key)
             ht_alerts, hardware_trust_state = hardware_trust_waiting_alerts(
                 env, prev, waiting if isinstance(waiting, dict) else {},
             )
             alerts.extend(ht_alerts)
         except Exception as e:  # noqa: BLE001
             alerts.append(("WARN", KIND_HARDWARE_TRUST, f"hardware-trust waiting read failed: {e}"))
-    elif coord_up and hardware_trust_enabled and not op_key:
-        print("[INFO] hardware-trust waiting alerts disabled until OPERATOR_KEY is available", flush=True)
+    elif coord_up and hardware_trust_enabled and not ht_key:
+        print(
+            "[INFO] hardware-trust waiting alerts disabled until "
+            "OPERATOR_AUTH_POLICY_A/B is available",
+            flush=True,
+        )
 
     # --- transition detection vs last poll ---
     prev_pool = prev.get("pool", {})

--- a/scripts/test-macprovider-monitor-hardware-trust.py
+++ b/scripts/test-macprovider-monitor-hardware-trust.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+"""Hermetic tests for hardware-trust waiting alerts in macprovider-monitor."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+import tempfile
+import unittest
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+MONITOR_PATH = ROOT / "phase4-coordinator/dist/monitor/macprovider-monitor.py"
+
+
+def load_monitor():
+    spec = importlib.util.spec_from_file_location("macprovider_monitor", MONITOR_PATH)
+    mod = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(mod)
+    return mod
+
+
+class HardwareTrustWaitingAlertsTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.m = load_monitor()
+
+    def test_new_job_emits_waiting_new(self):
+        now = datetime(2026, 8, 7, 12, 0, tzinfo=timezone.utc)
+        alerts, state = self.m.hardware_trust_waiting_alerts(
+            {},
+            {"hardware_trust_waiting": {"job_ids": []}},
+            {
+                "waiting_trust": [
+                    {
+                        "job_id": 42,
+                        "provider_id": "mp-abc",
+                        "decision_reason": "missing_trusted_hardware_identity",
+                        "approvable": True,
+                    }
+                ],
+                "count": 1,
+            },
+            now=now,
+        )
+        self.assertEqual(len(alerts), 1)
+        sev, kind, msg = alerts[0]
+        self.assertEqual(sev, "WARN")
+        self.assertEqual(kind, self.m.KIND_HARDWARE_TRUST)
+        self.assertIn("hardware_trust_waiting_new", msg)
+        self.assertIn("job_id=42", msg)
+        self.assertEqual(state["job_ids"], [42])
+        self.assertEqual(state["first_seen_utc"], "2026-08-07T12:00:00Z")
+        self.assertFalse(state["stale_alerted"])
+
+    def test_stale_backlog_alerts_once(self):
+        now = datetime(2026, 8, 7, 12, 10, tzinfo=timezone.utc)
+        prev = {
+            "hardware_trust_waiting": {
+                "job_ids": [7],
+                "first_seen_utc": "2026-08-07T12:00:00Z",
+                "stale_alerted": False,
+            }
+        }
+        payload = {
+            "waiting_trust": [
+                {
+                    "job_id": 7,
+                    "provider_id": "p_one",
+                    "decision_reason": "missing_trusted_hardware_identity",
+                    "approvable": True,
+                }
+            ]
+        }
+        alerts, state = self.m.hardware_trust_waiting_alerts({}, prev, payload, now=now)
+        self.assertEqual(len(alerts), 1)
+        self.assertIn("hardware_trust_waiting_stale", alerts[0][2])
+        self.assertTrue(state["stale_alerted"])
+
+        alerts2, state2 = self.m.hardware_trust_waiting_alerts({}, {"hardware_trust_waiting": state}, payload, now=now + timedelta(minutes=3))
+        self.assertEqual(alerts2, [])
+        self.assertTrue(state2["stale_alerted"])
+
+    def test_kind_not_muted_by_default(self):
+        muted = self.m.muted_kinds({})
+        self.assertNotIn(self.m.KIND_HARDWARE_TRUST, muted)
+
+
+if __name__ == "__main__":
+    with tempfile.TemporaryDirectory() as _:
+        raise SystemExit(unittest.main(verbosity=2))


### PR DESCRIPTION
## Summary
- Pearl `macprovider-monitor` polls `/admin/hardware-trust/waiting` and emails kind `hardware_trust` on new jobs / stale backlog (prebeta P4 live path is Gmail, not BetterStack).
- Records **#584 demand-floor NO-GO** (exception stays active; canary not armed).
- Pearl updater drain no longer counts `quota_reservations` with `settlement_hold=1` as in-flight buyer work (unblocked v1.8.90 apply).

## Test plan
- [x] `python3 scripts/test-macprovider-monitor-hardware-trust.py`
- [ ] Deploy updated `macprovider-monitor.py` to Pearl and run one timer tick
- [ ] Confirm no canary enable / `DISABLED` sentinel untouched

SPEC-GOVERNANCE-DECLARATION-BEGIN
{
  "schema_version": "spec-pr-governance-v1",
  "behavior_change": "yes",
  "contract_change": "none",
  "specs": ["SPEC-016"],
  "requirements": ["SPEC-016-R001"],
  "authority_domains": ["payout-lifecycle"],
  "arbitration": ["CODE_BUG"],
  "tests": ["scripts/test-macprovider-monitor-hardware-trust.py"],
  "journeys": ["not-required"],
  "issue": "https://github.com/Augustas11/macprovider/issues/584"
}
SPEC-GOVERNANCE-DECLARATION-END

Note: `spec-index / check` may stay advisory-red if the governance mapping is imperfect; `ci-required` is the merge gate.

Made with [Cursor](https://cursor.com)