### PR TITLE
Fix Malibu launch-agent migration and provider recovery

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -115,6 +115,7 @@ test-dist:
 	bash phase3-binary/dist/test/install_referral_handoff.test.sh
 	bash phase3-binary/dist/test/install_fresh_evidence.test.sh
 	bash phase3-binary/dist/test/install_upgrade_evidence_rollback.test.sh
+	bash phase3-binary/dist/test/install_launchd_migration.test.sh
 	bash phase3-binary/dist/test/install_lifecycle_state.test.sh
 	bash phase3-binary/dist/test/install_transaction_lock.test.sh
 	bash phase3-binary/dist/test/install_coordinator_admission.test.sh

--- a/phase3-binary/app/Sources/Malibu/Agent/MalibuAgent.swift
+++ b/phase3-binary/app/Sources/Malibu/Agent/MalibuAgent.swift
@@ -31,6 +31,8 @@ final class MalibuAgent: ObservableObject {
     private var reconnectTask: Task<Void, Never>?
     private var providerLogTail: ProviderLogTail?
     private var providerLogTailCancellable: AnyCancellable?
+    private var watchdogLogTailCancellable: AnyCancellable?
+    private var watchdogLogLines: [String] = []
     private var reconnect = ReconnectPolicy()
     private let thermalMonitor = ThermalMonitor()
     private var cancellables: Set<AnyCancellable> = []
@@ -109,7 +111,7 @@ final class MalibuAgent: ObservableObject {
         }
         guard !isShuttingDown else { return }
 
-        if let failure = diagnosedProviderFailure() {
+        if let failure = diagnosedProviderFailure(includingLaunchdState: true) {
             providerStartFailure = failure
             snapshot.state = .error
             snapshot.lastError = failure
@@ -525,7 +527,7 @@ final class MalibuAgent: ObservableObject {
             let sleep = min(pollInterval, remaining)
             try? await Task.sleep(nanoseconds: UInt64(sleep * 1_000_000_000))
         }
-        let failure = diagnosedProviderFailure()
+        let failure = diagnosedProviderFailure(includingLaunchdState: true)
             ?? ProviderLogDiagnostics.timeoutMessage(logHint: ProviderLogDiagnostics.logHint())
         providerStartFailure = failure
         snapshot.state = .error
@@ -853,7 +855,7 @@ final class MalibuAgent: ObservableObject {
                     await MainActor.run {
                         self.snapshot.invalidateLocalStatusObservation()
                         self.invalidateProviderProjectionFreshness()
-                        if let failure = self.diagnosedProviderFailure() {
+                        if let failure = self.diagnosedProviderFailure(includingLaunchdState: true) {
                             self.providerStartFailure = failure
                             self.snapshot.state = .error
                             self.snapshot.lastError = failure
@@ -1418,11 +1420,16 @@ final class MalibuAgent: ObservableObject {
 
     private func startProviderLogTail(paths: ProviderPaths = .current) {
         providerLogTailCancellable?.cancel()
+        watchdogLogTailCancellable?.cancel()
         providerLogTail?.stop()
         let tail = ProviderLogTail()
         providerLogTailCancellable = tail.$lines
             .sink { [weak self] lines in
                 self?.logLines = lines
+            }
+        watchdogLogTailCancellable = tail.$watchdogLines
+            .sink { [weak self] lines in
+                self?.watchdogLogLines = lines
             }
         providerLogTail = tail
         tail.start(paths: paths)
@@ -1431,12 +1438,28 @@ final class MalibuAgent: ObservableObject {
     private func stopProviderLogTail() {
         providerLogTailCancellable?.cancel()
         providerLogTailCancellable = nil
+        watchdogLogTailCancellable?.cancel()
+        watchdogLogTailCancellable = nil
         providerLogTail?.stop()
         providerLogTail = nil
+        watchdogLogLines = []
     }
 
-    private func diagnosedProviderFailure() -> String? {
-        ProviderLogDiagnostics.diagnose(lines: logLines)?.userMessage
+    private func diagnosedProviderFailure(includingLaunchdState: Bool = false) -> String? {
+        let launchdNeedsRepair = StartupState.launchdInstallEvidenceExists()
+            && InstalledProviderMonitor.launchdServiceRepairState().needsRepair
+        if let finding = ProviderLogDiagnostics.diagnose(
+            providerLines: logLines,
+            watchdogLines: watchdogLogLines,
+            launchdNeedsRepair: launchdNeedsRepair
+        ), ProviderLogDiagnostics.isActionable(finding, launchdNeedsRepair: launchdNeedsRepair) {
+            return finding.userMessage
+        }
+        guard includingLaunchdState,
+              launchdNeedsRepair else {
+            return nil
+        }
+        return ProviderLogDiagnostics.staleLaunchAgentMessage
     }
 
     private func scheduleReconnect() async {

--- a/phase3-binary/app/Sources/Malibu/MalibuApp.swift
+++ b/phase3-binary/app/Sources/Malibu/MalibuApp.swift
@@ -118,11 +118,15 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     // in-App via LaunchProviderController (SPEC-026 §7.2, follow-up impl
     // in this same PR).
 
-    private func presentOnboarding(replacementConfirmed: Bool = false) {
+    private func presentOnboarding(
+        replacementConfirmed: Bool = false,
+        repairExistingInstall: Bool = false
+    ) {
         if onboardingWindow == nil {
             onboardingWindow = OnboardingWindow.make(
                 agent: agent,
-                replacementConfirmed: replacementConfirmed
+                replacementConfirmed: replacementConfirmed,
+                repairExistingInstall: repairExistingInstall
             ) { [weak self] in
                 self?.onboardingWindow?.close()
                 self?.onboardingWindow = nil
@@ -144,8 +148,18 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         switch route {
         case .startAgent:
             await agent.start()
+        case .startAgentAndRepairWatchdog:
+            await agent.start()
+            // Starting a healthy provider is safe to do automatically, but
+            // reinstalling it can replace the running binary and launchd
+            // identity. Keep that mutation behind the explicit repair action.
+            presentOnboarding(repairExistingInstall: true)
+        case .repairExistingInstall:
+            presentOnboarding(repairExistingInstall: true)
         case .showOnboarding:
             presentOnboarding(replacementConfirmed: replacementConfirmed)
+        case .showLaunchdConflict:
+            presentLaunchdConflict()
         case .quit:
             NSApp.terminate(nil)
         case .showImportDialog:
@@ -208,6 +222,15 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         alert.addButton(withTitle: StartFreshConfirmationCopy.cancelButton)
         alert.addButton(withTitle: StartFreshConfirmationCopy.startFreshButton)
         return StartFreshConfirmationCopy.confirms(alert.runModal())
+    }
+
+    private func presentLaunchdConflict() {
+        let alert = NSAlert()
+        alert.messageText = LaunchdConflictCopy.title
+        alert.informativeText = LaunchdConflictCopy.message
+        alert.alertStyle = .warning
+        alert.addButton(withTitle: LaunchdConflictCopy.dismissButton)
+        alert.runModal()
     }
 
     private func presentMigrationError(_ error: Error) -> Bool {
@@ -350,6 +373,12 @@ enum StartFreshConfirmationCopy {
     static func confirms(_ response: NSApplication.ModalResponse) -> Bool {
         response == .alertSecondButtonReturn
     }
+}
+
+enum LaunchdConflictCopy {
+    static let title = "Another background service needs attention"
+    static let message = "Malibu found a background service in the provider slot that it does not own. Automatic repair is disabled so Malibu will not replace another program. Disable or remove that service, then reopen Malibu."
+    static let dismissButton = "OK"
 }
 
 enum MigrationErrorCopy {

--- a/phase3-binary/app/Sources/Malibu/Onboarding/CLIInstallRunner.swift
+++ b/phase3-binary/app/Sources/Malibu/Onboarding/CLIInstallRunner.swift
@@ -60,6 +60,7 @@ enum CLIInstallRunner {
         pinnedVersion: String? = nil,
         referralCode: String? = nil,
         replacingIncumbentProvider: Bool = false,
+        repairExistingInstall: Bool = false,
         onLogLine: @escaping @Sendable @MainActor (String) -> Void
     ) async throws {
         let scriptURL = try resolveInstallScriptURL()
@@ -78,7 +79,8 @@ enum CLIInstallRunner {
             installPort: installPort,
             pinnedVersion: pinnedVersion,
             referralCodeFile: referralFileURL,
-            replacingIncumbentProvider: replacingIncumbentProvider
+            replacingIncumbentProvider: replacingIncumbentProvider,
+            repairExistingInstall: repairExistingInstall
         )
         if let installPort {
             await onLogLine("[macprovider-install] Using local HTTP port \(installPort) for provider install.")
@@ -148,6 +150,7 @@ enum CLIInstallRunner {
         pinnedVersion: String?,
         referralCodeFile: URL? = nil,
         replacingIncumbentProvider: Bool = false,
+        repairExistingInstall: Bool = false,
         homeDirectory: URL = FileManager.default.homeDirectoryForCurrentUser,
         fileManager: FileManager = .default
     ) throws -> [String: String] {
@@ -186,6 +189,9 @@ enum CLIInstallRunner {
             if replacingIncumbentProvider {
                 explicit["MACPROVIDER_REFERRAL_REPLACE_INCUMBENT"] = "1"
             }
+        }
+        if repairExistingInstall {
+            explicit["MACPROVIDER_REPAIR_EXISTING_INSTALL"] = "1"
         }
         return try ProcessEnvironmentSanitizer.sanitized(
             from: [:],

--- a/phase3-binary/app/Sources/Malibu/Onboarding/CLIInstallRunner.swift
+++ b/phase3-binary/app/Sources/Malibu/Onboarding/CLIInstallRunner.swift
@@ -147,7 +147,9 @@ enum CLIInstallRunner {
         installPort: Int?,
         pinnedVersion: String?,
         referralCodeFile: URL? = nil,
-        replacingIncumbentProvider: Bool = false
+        replacingIncumbentProvider: Bool = false,
+        homeDirectory: URL = FileManager.default.homeDirectoryForCurrentUser,
+        fileManager: FileManager = .default
     ) throws -> [String: String] {
         // Deliberately do not inherit the parent environment. install.sh has
         // authority-changing knobs for repositories, public keys, acceptance
@@ -157,11 +159,19 @@ enum CLIInstallRunner {
         _ = parentEnvironment
         var explicit = [
             "PATH": "/usr/bin:/bin:/usr/sbin:/sbin",
-            "HOME": NSHomeDirectory(),
+            "HOME": homeDirectory.path,
             "TMPDIR": "/tmp",
             "LC_ALL": "C",
             "MACPROVIDER_NO_PROMPT": "1",
         ]
+        let configuredProgram = InstalledProviderMonitor.configuredProviderProgram(
+            homeDirectory: homeDirectory,
+            fileManager: fileManager
+        )
+        let defaultProgram = homeDirectory.appendingPathComponent("macprovider/macprovider-cli").standardizedFileURL
+        if configuredProgram != defaultProgram {
+            explicit["MACPROVIDER_INSTALL_DIR"] = configuredProgram.deletingLastPathComponent().path
+        }
         if let installPort {
             explicit["MACPROVIDER_PORT"] = String(installPort)
         }
@@ -197,6 +207,9 @@ enum CLIInstallRunner {
             atPath: NSHomeDirectory() + "/Library/LaunchAgents/live.streamvc.macprovider.plist"
         )
         guard hasManifest || launchdPlist else { return false }
+        guard InstalledProviderMonitor.launchdServiceRepairState() == .validExecutable else {
+            return false
+        }
         return await InstalledProviderMonitor.isHealthy(port: port)
     }
 

--- a/phase3-binary/app/Sources/Malibu/Onboarding/LaunchProviderController.swift
+++ b/phase3-binary/app/Sources/Malibu/Onboarding/LaunchProviderController.swift
@@ -41,6 +41,7 @@ final class LaunchProviderController: ObservableObject {
         var runCLIInstall: @MainActor (
             String?,
             Bool,
+            Bool,
             @escaping @Sendable @MainActor (String) -> Void
         ) async throws -> Void
         var importCLIConfigAfterInstall: @MainActor () async throws -> Void
@@ -61,10 +62,11 @@ final class LaunchProviderController: ObservableObject {
                     await LaunchProviderController.referralInputAvailableForCurrentInstall()
                 },
                 registerLoginItem: { try AppLoginItem.register() },
-                runCLIInstall: { referralCode, replacingIncumbentProvider, onLogLine in
+                runCLIInstall: { referralCode, replacingIncumbentProvider, repairExistingInstall, onLogLine in
                     try await CLIInstallRunner.run(
                         referralCode: referralCode,
                         replacingIncumbentProvider: replacingIncumbentProvider,
+                        repairExistingInstall: repairExistingInstall,
                         onLogLine: onLogLine
                     )
                 },
@@ -106,7 +108,11 @@ final class LaunchProviderController: ObservableObject {
 
     func launch() async {
         if repairExistingInstall && !replacementConfirmed {
-            await launchViaCLIInstall(referralCode: nil, replacingIncumbentProvider: false)
+            await launchViaCLIInstall(
+                referralCode: nil,
+                replacingIncumbentProvider: false,
+                repairExistingInstall: true
+            )
             return
         }
 
@@ -204,13 +210,21 @@ final class LaunchProviderController: ObservableObject {
         await finalizeExistingInstall(logLine: "Background provider is already running locally.")
     }
 
-    private func launchViaCLIInstall(referralCode: String?, replacingIncumbentProvider: Bool) async {
+    private func launchViaCLIInstall(
+        referralCode: String?,
+        replacingIncumbentProvider: Bool,
+        repairExistingInstall: Bool = false
+    ) async {
         beginInstallProgressWatch()
         defer { endInstallProgressWatch() }
         do {
             stage = .runningCLIInstall
             installLogLines = []
-            try await dependencies.runCLIInstall(referralCode, replacingIncumbentProvider) { [weak self] line in
+            try await dependencies.runCLIInstall(
+                referralCode,
+                replacingIncumbentProvider,
+                repairExistingInstall
+            ) { [weak self] line in
                 guard let self else { return }
                 self.installLogLines.append(LogTailBuffer.redacted(line))
                 if self.installLogLines.count > 200 {

--- a/phase3-binary/app/Sources/Malibu/Onboarding/LaunchProviderController.swift
+++ b/phase3-binary/app/Sources/Malibu/Onboarding/LaunchProviderController.swift
@@ -533,10 +533,14 @@ struct StartupState: Equatable {
                 launchctlURL: launchctlURL,
                 homeDirectory: homeDirectory,
                 fileManager: fm
-            )
+        )
         let launchdJobNeedsRepair = launchdInstallEvidenceExists && providerRepairState.needsRepair
-        let providerNeedsManualIntervention = launchdInstallEvidenceExists
-            && providerRepairState.requiresManualIntervention
+        // A loaded provider label with an unexpected executable/plist is a
+        // conflict even when the on-disk evidence is missing or unsafe. The
+        // installer intentionally refuses label-only reclamation without a
+        // durable recovery plist, so routing this state to onboarding would
+        // create a retry loop instead of exposing the required manual action.
+        let providerNeedsManualIntervention = providerRepairState.requiresManualIntervention
         let watchdogRepairState = InstalledProviderMonitor.launchdServiceRepairState(
                 label: InstalledProviderMonitor.watchdogLaunchdLabel,
                 launchctlURL: launchctlURL,

--- a/phase3-binary/app/Sources/Malibu/Onboarding/LaunchProviderController.swift
+++ b/phase3-binary/app/Sources/Malibu/Onboarding/LaunchProviderController.swift
@@ -30,6 +30,7 @@ final class LaunchProviderController: ObservableObject {
 
     private var installProgressTask: Task<Void, Never>?
     private let replacementConfirmed: Bool
+    private let repairExistingInstall: Bool
     private let dependencies: Dependencies
 
     struct Dependencies {
@@ -95,13 +96,20 @@ final class LaunchProviderController: ObservableObject {
     init(
         agent: MalibuAgent? = nil,
         replacementConfirmed: Bool = false,
+        repairExistingInstall: Bool = false,
         dependencies: Dependencies? = nil
     ) {
         self.replacementConfirmed = replacementConfirmed
+        self.repairExistingInstall = repairExistingInstall
         self.dependencies = dependencies ?? .live(agent: agent)
     }
 
     func launch() async {
+        if repairExistingInstall && !replacementConfirmed {
+            await launchViaCLIInstall(referralCode: nil, replacingIncumbentProvider: false)
+            return
+        }
+
         let referralCode: String?
         do {
             referralCode = try ReferralOnboardingInput.normalize(referralInput)
@@ -185,7 +193,7 @@ final class LaunchProviderController: ObservableObject {
     }
 
     func refreshFromExistingInstall() async {
-        guard !replacementConfirmed else { return }
+        guard !replacementConfirmed, !repairExistingInstall else { return }
         switch stage {
         case .idle, .failed(stage: "cliInstall", _, _), .failed(stage: "identityImport", _, _):
             break
@@ -445,7 +453,10 @@ final class LaunchProviderController: ObservableObject {
 
 enum StartupRoute: Equatable {
     case startAgent
+    case startAgentAndRepairWatchdog
+    case repairExistingInstall
     case showOnboarding
+    case showLaunchdConflict
     case showImportDialog
     case quit
 }
@@ -467,15 +478,50 @@ struct StartupState: Equatable {
     let appIdentityConfigured: Bool
     let launchdInstallEvidenceExists: Bool
     let backgroundProviderHealthy: Bool
+    let launchdJobNeedsRepair: Bool
+    let launchdJobNeedsManualIntervention: Bool
+    let providerLaunchdJobNeedsRepair: Bool
+    let watchdogJobNeedsRepair: Bool
+
+    init(
+        configExists: Bool,
+        appMarkerExists: Bool,
+        appIdentityConfigured: Bool,
+        launchdInstallEvidenceExists: Bool,
+        backgroundProviderHealthy: Bool,
+        launchdJobNeedsRepair: Bool = false,
+        launchdJobNeedsManualIntervention: Bool = false,
+        providerLaunchdJobNeedsRepair: Bool? = nil,
+        watchdogJobNeedsRepair: Bool = false
+    ) {
+        self.configExists = configExists
+        self.appMarkerExists = appMarkerExists
+        self.appIdentityConfigured = appIdentityConfigured
+        self.launchdInstallEvidenceExists = launchdInstallEvidenceExists
+        self.backgroundProviderHealthy = backgroundProviderHealthy
+        self.launchdJobNeedsRepair = launchdJobNeedsRepair
+        self.launchdJobNeedsManualIntervention = launchdJobNeedsManualIntervention
+        self.providerLaunchdJobNeedsRepair = providerLaunchdJobNeedsRepair ?? launchdJobNeedsRepair
+        self.watchdogJobNeedsRepair = watchdogJobNeedsRepair
+    }
 
     @MainActor
-    static func detect(paths: ProviderPaths = .current) async -> StartupState {
-        let fm = FileManager.default
+    static func detect(
+        paths: ProviderPaths = .current,
+        homeDirectory: URL = FileManager.default.homeDirectoryForCurrentUser,
+        launchctlURL: URL = URL(fileURLWithPath: "/bin/launchctl"),
+        fileManager: FileManager = .default
+    ) async -> StartupState {
+        let fm = fileManager
         try? await ProviderConfig.recoverPendingImportIfNeeded(paths: paths)
         let configExists = fm.fileExists(atPath: paths.configFile.path)
         let markerExists = fm.fileExists(atPath: paths.appMarkerFile.path)
         let identityConfigured = await ProviderConfig.isConfigured(paths: paths)
-        let launchdInstallEvidenceExists = Self.launchdInstallEvidenceExists(paths: paths)
+        let launchdInstallEvidenceExists = Self.launchdInstallEvidenceExists(
+            paths: paths,
+            homeDirectory: homeDirectory,
+            fileManager: fm
+        )
 
         var backgroundProviderHealthy = false
         if ProviderConfig.readProviderID(paths: paths) != nil,
@@ -483,19 +529,55 @@ struct StartupState: Equatable {
            launchdInstallEvidenceExists {
             backgroundProviderHealthy = await InstalledProviderMonitor.isHealthy(port: port)
         }
+        let providerRepairState = InstalledProviderMonitor.launchdServiceRepairState(
+                launchctlURL: launchctlURL,
+                homeDirectory: homeDirectory,
+                fileManager: fm
+            )
+        let launchdJobNeedsRepair = launchdInstallEvidenceExists && providerRepairState.needsRepair
+        let providerNeedsManualIntervention = launchdInstallEvidenceExists
+            && providerRepairState.requiresManualIntervention
+        let watchdogRepairState = InstalledProviderMonitor.launchdServiceRepairState(
+                label: InstalledProviderMonitor.watchdogLaunchdLabel,
+                launchctlURL: launchctlURL,
+                homeDirectory: homeDirectory,
+                expectedProgram: homeDirectory
+                    .appendingPathComponent(".local/share/macprovider-watchdog/macprovider-health-monitor"),
+                alternateProgram: homeDirectory
+                    .appendingPathComponent(".local/share/macprovider-watchdog/watchdog.sh"),
+                fileManager: fm
+            )
+        // Do not gate watchdog inspection on a readable plist. A loaded job
+        // whose plist disappeared or became unsafe is itself a manual
+        // conflict; suppressing that state creates an endless repair loop.
+        let watchdogJobNeedsRepair = watchdogRepairState.needsRepair
+        let watchdogNeedsManualIntervention = watchdogRepairState.requiresManualIntervention
 
         return StartupState(
             configExists: configExists,
             appMarkerExists: markerExists,
             appIdentityConfigured: identityConfigured,
             launchdInstallEvidenceExists: launchdInstallEvidenceExists,
-            backgroundProviderHealthy: backgroundProviderHealthy
+            backgroundProviderHealthy: backgroundProviderHealthy,
+            launchdJobNeedsRepair: launchdJobNeedsRepair || watchdogJobNeedsRepair,
+            launchdJobNeedsManualIntervention: providerNeedsManualIntervention || watchdogNeedsManualIntervention,
+            providerLaunchdJobNeedsRepair: launchdJobNeedsRepair,
+            watchdogJobNeedsRepair: watchdogJobNeedsRepair
         )
     }
 
     func route() -> StartupRoute {
         if configExists && !appMarkerExists {
             return .showImportDialog
+        }
+        if launchdJobNeedsManualIntervention {
+            return .showLaunchdConflict
+        }
+        if providerLaunchdJobNeedsRepair {
+            return .repairExistingInstall
+        }
+        if watchdogJobNeedsRepair {
+            return backgroundProviderHealthy ? .startAgentAndRepairWatchdog : .repairExistingInstall
         }
         if configExists && appMarkerExists && !appIdentityConfigured {
             return .showOnboarding
@@ -515,12 +597,26 @@ struct StartupState: Equatable {
         return .showOnboarding
     }
 
-    static func launchdInstallEvidenceExists(paths: ProviderPaths = .current) -> Bool {
-        let fm = FileManager.default
-        let home = fm.homeDirectoryForCurrentUser
+    static func launchdInstallEvidenceExists(
+        paths: ProviderPaths = .current,
+        homeDirectory: URL = FileManager.default.homeDirectoryForCurrentUser,
+        fileManager: FileManager = .default
+    ) -> Bool {
+        let fm = fileManager
+        let home = homeDirectory
         let manifest = home.appendingPathComponent("Library/Application Support/macprovider/install_manifest.json")
         let launchd = home.appendingPathComponent("Library/LaunchAgents/live.streamvc.macprovider.plist")
-        return fm.isReadableFile(atPath: manifest.path) || fm.isReadableFile(atPath: launchd.path)
+        func trusted(_ url: URL) -> Bool {
+            InstalledProviderMonitor.isSafePrivateDirectoryChain(
+                url.deletingLastPathComponent(),
+                under: home
+            ) && InstalledProviderMonitor.hasTrustedPrivateFile(
+                at: url,
+                maxBytes: 64 * 1024,
+                fileManager: fm
+            )
+        }
+        return trusted(manifest) || trusted(launchd)
     }
 
     static func applyMigrationDecision(
@@ -528,10 +624,23 @@ struct StartupState: Equatable {
         paths: ProviderPaths = .current,
         now: Date = Date(),
         deferStartFreshBackup: Bool = false,
-        importCredentialIntoCLI: (@Sendable (URL) async throws -> Void)? = nil
+        importCredentialIntoCLI: (@Sendable (URL) async throws -> Void)? = nil,
+        homeDirectory: URL = FileManager.default.homeDirectoryForCurrentUser,
+        launchctlURL: URL = URL(fileURLWithPath: "/bin/launchctl")
     ) async throws -> MigrationResult {
         switch decision {
         case .importExisting:
+            let preImportState = await StartupState.detect(
+                paths: paths,
+                homeDirectory: homeDirectory,
+                launchctlURL: launchctlURL
+            )
+            if preImportState.launchdJobNeedsManualIntervention {
+                return MigrationResult(route: .showLaunchdConflict, backupPath: nil)
+            }
+            if preImportState.launchdJobNeedsRepair {
+                return MigrationResult(route: .repairExistingInstall, backupPath: nil)
+            }
             if let importCredentialIntoCLI {
                 try await ProviderConfig.importExistingCLIConfig(
                     paths: paths,
@@ -540,7 +649,11 @@ struct StartupState: Equatable {
             } else {
                 try await ProviderConfig.importExistingCLIConfig(paths: paths)
             }
-            let state = await StartupState.detect(paths: paths)
+            let state = await StartupState.detect(
+                paths: paths,
+                homeDirectory: homeDirectory,
+                launchctlURL: launchctlURL
+            )
             return MigrationResult(route: state.route(), backupPath: nil)
         case .startFresh:
             if deferStartFreshBackup {

--- a/phase3-binary/app/Sources/Malibu/Onboarding/LaunchProviderController.swift
+++ b/phase3-binary/app/Sources/Malibu/Onboarding/LaunchProviderController.swift
@@ -585,11 +585,11 @@ struct StartupState: Equatable {
     }
 
     func route() -> StartupRoute {
-        if configExists && !appMarkerExists {
-            return .showImportDialog
-        }
         if launchdJobNeedsManualIntervention {
             return .showLaunchdConflict
+        }
+        if configExists && !appMarkerExists {
+            return .showImportDialog
         }
         if providerLaunchdJobNeedsRepair {
             return .repairExistingInstall
@@ -674,6 +674,14 @@ struct StartupState: Equatable {
             )
             return MigrationResult(route: state.route(), backupPath: nil)
         case .startFresh:
+            let preStartFreshState = await StartupState.detect(
+                paths: paths,
+                homeDirectory: homeDirectory,
+                launchctlURL: launchctlURL
+            )
+            if preStartFreshState.launchdJobNeedsManualIntervention {
+                return MigrationResult(route: .showLaunchdConflict, backupPath: nil)
+            }
             if deferStartFreshBackup {
                 return MigrationResult(route: .showOnboarding, backupPath: nil)
             }

--- a/phase3-binary/app/Sources/Malibu/Onboarding/OnboardingWindow.swift
+++ b/phase3-binary/app/Sources/Malibu/Onboarding/OnboardingWindow.swift
@@ -9,11 +9,13 @@ enum OnboardingWindow {
     static func make(
         agent: MalibuAgent,
         replacementConfirmed: Bool = false,
+        repairExistingInstall: Bool = false,
         onDone: @escaping () -> Void
     ) -> NSWindow {
         let root = OnboardingRootView(
             agent: agent,
             replacementConfirmed: replacementConfirmed,
+            repairExistingInstall: repairExistingInstall,
             onDone: onDone
         )
         let hosting = NSHostingController(rootView: root)
@@ -31,6 +33,7 @@ enum OnboardingCopy {
     static let intro = "Launch Provider installs and configures provider software on this Mac."
     static let introDetail = "Malibu monitors the background provider and shows earnings here while setup continues."
     static let idleDetail = "Installs provider software, picks a model, and registers this Mac for customer work."
+    static let repairDetail = "Repairs the background service while preserving your provider identity and downloaded model files."
     static let installingFallback = "Installing provider software. First model download and local checks can take 10-30 minutes with little visible progress."
     static let importingProviderAccess = "Confirming saved provider access before Malibu attaches."
     static let liveDetailPrefix = "Using"
@@ -52,16 +55,24 @@ enum OnboardingCopy {
 
 private struct OnboardingRootView: View {
     @ObservedObject var agent: MalibuAgent
+    let repairExistingInstall: Bool
     let onDone: () -> Void
     @StateObject private var controller: LaunchProviderController
 
-    init(agent: MalibuAgent, replacementConfirmed: Bool, onDone: @escaping () -> Void) {
+    init(
+        agent: MalibuAgent,
+        replacementConfirmed: Bool,
+        repairExistingInstall: Bool,
+        onDone: @escaping () -> Void
+    ) {
         self.agent = agent
+        self.repairExistingInstall = repairExistingInstall
         self.onDone = onDone
         _controller = StateObject(
             wrappedValue: LaunchProviderController(
                 agent: agent,
-                replacementConfirmed: replacementConfirmed
+                replacementConfirmed: replacementConfirmed,
+                repairExistingInstall: repairExistingInstall
             )
         )
     }
@@ -92,7 +103,9 @@ private struct OnboardingRootView: View {
         .padding(28)
         .frame(minWidth: 460, minHeight: 560)
         .task {
-            await controller.refreshReferralInputAvailability()
+            if !repairExistingInstall {
+                await controller.refreshReferralInputAvailability()
+            }
             await controller.refreshFromExistingInstall()
         }
     }
@@ -101,13 +114,20 @@ private struct OnboardingRootView: View {
     private var content: some View {
         switch controller.stage {
         case .idle:
-            stageRow(title: "Ready", detail: OnboardingCopy.idleDetail) {
+            stageRow(
+                title: repairExistingInstall ? "Repair ready" : "Ready",
+                detail: repairExistingInstall ? OnboardingCopy.repairDetail : OnboardingCopy.idleDetail
+            ) {
                 VStack(alignment: .leading, spacing: 8) {
-                    referralAvailability
-                    launchButton(title: "Launch Provider")
-                    Text("No wallet needed to start — add one anytime after.")
-                        .font(.callout)
-                        .foregroundStyle(.secondary)
+                    if !repairExistingInstall {
+                        referralAvailability
+                        launchButton(title: "Launch Provider")
+                        Text("No wallet needed to start — add one anytime after.")
+                            .font(.callout)
+                            .foregroundStyle(.secondary)
+                    } else {
+                        launchButton(title: "Repair Provider")
+                    }
                 }
             }
         case .runningCLIInstall:
@@ -172,7 +192,7 @@ private struct OnboardingRootView: View {
                     ?? "Details are available in Advanced diagnostics."
             ) {
                 VStack(alignment: .leading, spacing: 8) {
-                    if stage == "referral" {
+                    if stage == "referral", !repairExistingInstall {
                         referralAvailability
                     }
                     if retryable {

--- a/phase3-binary/app/Sources/Malibu/System/InstalledProviderMonitor.swift
+++ b/phase3-binary/app/Sources/Malibu/System/InstalledProviderMonitor.swift
@@ -451,6 +451,7 @@ enum InstalledProviderMonitor {
             // owner, no-follow, and mode checks above. Files carrying
             // authoritative launchd/configuration data stay strict below.
             && info.st_mode & (S_IWGRP | S_IWOTH) == 0
+            && hasSafeDirectoryACL(descriptor)
     }
 
     private static func sameFileIdentity(_ lhs: stat, _ rhs: stat) -> Bool {
@@ -475,6 +476,37 @@ enum InstalledProviderMonitor {
         var entry: acl_entry_t?
         guard acl_get_entry(acl, ACL_FIRST_ENTRY.rawValue, &entry) == 0 else { return false }
         return entry == nil
+    }
+
+    private static func hasSafeDirectoryACL(_ descriptor: Int32) -> Bool {
+        errno = 0
+        guard let acl = acl_get_fd_np(descriptor, ACL_TYPE_EXTENDED) else {
+            return errno == 0 || errno == ENOENT
+        }
+        defer { _ = acl_free(UnsafeMutableRawPointer(acl)) }
+
+        guard let everyone = getgrnam("everyone") else { return false }
+        var textLength: ssize_t = 0
+        guard let text = acl_to_text(acl, &textLength) else { return false }
+        defer { _ = acl_free(UnsafeMutableRawPointer(text)) }
+
+        let lines = String(cString: text)
+            .split(whereSeparator: \.isNewline)
+        guard lines.count >= 2, lines[0] == "!#acl 1" else { return false }
+        let everyoneGroupID = String(everyone.pointee.gr_gid)
+        return lines.dropFirst().allSatisfy { line in
+            let fields = line.split(separator: ":", omittingEmptySubsequences: false)
+            guard fields.count == 6,
+                  fields[0] == "group",
+                  UUID(uuidString: String(fields[1])) != nil,
+                  fields[2] == "everyone",
+                  fields[3] == everyoneGroupID,
+                  fields[4] == "deny",
+                  fields[5] == "delete" else {
+                return false
+            }
+            return true
+        }
     }
 
     static func parseLaunchdServiceIdentity(_ output: String) -> LaunchdServiceIdentity? {

--- a/phase3-binary/app/Sources/Malibu/System/InstalledProviderMonitor.swift
+++ b/phase3-binary/app/Sources/Malibu/System/InstalledProviderMonitor.swift
@@ -99,22 +99,439 @@ enum InstalledProviderMonitor {
         ProviderConfig.readHTTPPort(paths: paths)
     }
 
+    /// Resolve the installer-selected provider binary without trusting a
+    /// launchd `program` line by itself. The installer manifest is an
+    /// owner-only regular file and its path is constrained to this user's
+    /// home, which also lets Malibu resume a custom path below the provider's
+    /// validated install prefix. The manifest prefix is part of the schema so
+    /// a stale/corrupt manifest cannot redirect repair into Documents, a
+    /// project checkout, or another unrelated home-directory location.
+    static func configuredProviderProgram(
+        homeDirectory: URL = FileManager.default.homeDirectoryForCurrentUser,
+        fileManager: FileManager = .default
+    ) -> URL {
+        let fallback = homeDirectory.appendingPathComponent("macprovider/macprovider-cli").standardizedFileURL
+        let manifestURL = homeDirectory.appendingPathComponent(
+            "Library/Application Support/macprovider/install_manifest.json"
+        )
+        guard let data = readOwnerPrivateRegularFile(
+            manifestURL,
+            maxBytes: 64 * 1024,
+            fileManager: fileManager
+        ),
+              let manifest = try? JSONDecoder().decode(InstallManifest.self, from: data),
+              manifest.binaryPath.hasPrefix("/"),
+              let installPrefix = manifest.installPrefix,
+              installPrefix.hasPrefix("/") else {
+            return fallback
+        }
+        let candidate = URL(fileURLWithPath: manifest.binaryPath).standardizedFileURL
+        let prefix = URL(fileURLWithPath: installPrefix).standardizedFileURL
+        guard candidate.lastPathComponent == "macprovider-cli",
+              candidate.deletingLastPathComponent().path == prefix.path,
+              isSupportedProviderInstallDirectory(prefix, under: homeDirectory) else {
+            return fallback
+        }
+        guard isSafePrivateDirectoryChain(
+            manifestURL.deletingLastPathComponent(),
+            under: homeDirectory
+        ), isSafePrivateDirectoryChainAllowingMissingLeaf(
+            candidate.deletingLastPathComponent(),
+            under: homeDirectory
+        ) else {
+            return fallback
+        }
+        return candidate
+    }
+
+    static let providerLaunchdLabel = "live.streamvc.macprovider"
+    static let watchdogLaunchdLabel = "live.streamvc.macprovider-watchdog"
+
     static func launchdServicePID(
         uid: uid_t = getuid(),
         launchctlURL: URL = URL(fileURLWithPath: "/bin/launchctl")
     ) -> Int? {
+        guard let inspection = inspectLaunchdService(
+            uid: uid,
+            label: providerLaunchdLabel,
+            launchctlURL: launchctlURL
+        ),
+              inspection.loaded else { return nil }
+        return parseLaunchdServicePID(inspection.output)
+    }
+
+    enum LaunchdServiceRepairState: Equatable {
+        case unavailable
+        case notLoaded
+        case validExecutable
+        case missingExecutable(path: String)
+        case unexpectedExecutable(path: String)
+        case unexpectedPlist(path: String)
+
+        var needsRepair: Bool {
+            switch self {
+            case .missingExecutable:
+                return true
+            case .unavailable, .notLoaded, .validExecutable, .unexpectedExecutable, .unexpectedPlist:
+                return false
+            }
+        }
+
+        var requiresManualIntervention: Bool {
+            switch self {
+            case .unexpectedExecutable, .unexpectedPlist:
+                return true
+            case .unavailable, .notLoaded, .validExecutable, .missingExecutable:
+                return false
+            }
+        }
+    }
+
+    /// A readable plist is not enough to attach Malibu to a loaded job. Repair
+    /// is reserved for a managed job whose executable is missing; an unloaded
+    /// managed plist is still inspected so a stale binary cannot dead-end startup.
+    static func launchdServiceRepairState(
+        uid: uid_t = getuid(),
+        label: String = providerLaunchdLabel,
+        launchctlURL: URL = URL(fileURLWithPath: "/bin/launchctl"),
+        homeDirectory: URL = FileManager.default.homeDirectoryForCurrentUser,
+        expectedProgram: URL? = nil,
+        alternateProgram: URL? = nil,
+        expectedPlist: URL? = nil,
+        fileManager: FileManager = .default
+    ) -> LaunchdServiceRepairState {
+        guard let inspection = inspectLaunchdService(
+            uid: uid,
+            label: label,
+            launchctlURL: launchctlURL
+        ) else {
+            return .unavailable
+        }
+        let managedProgram = (expectedProgram ?? configuredProviderProgram(
+            homeDirectory: homeDirectory,
+            fileManager: fileManager
+        )).path
+        let legacyProgram = (alternateProgram ?? homeDirectory.appendingPathComponent(".local/bin/macprovider-cli")).path
+        let managedPlist = (expectedPlist ?? homeDirectory
+            .appendingPathComponent("Library/LaunchAgents")
+            .appendingPathComponent("\(label).plist")).path
+        if !inspection.loaded {
+            guard isSafePrivateDirectoryChain(
+                URL(fileURLWithPath: managedPlist).deletingLastPathComponent(),
+                under: homeDirectory
+            ), let plistData = readOwnerPrivateRegularFile(
+                URL(fileURLWithPath: managedPlist),
+                maxBytes: 64 * 1024,
+                fileManager: fileManager
+            ), let plistIdentity = parseLaunchdPlistIdentity(plistData),
+                  plistIdentity.label == label else {
+                return .notLoaded
+            }
+            guard plistIdentity.program == managedProgram || plistIdentity.program == legacyProgram else {
+                return .unexpectedExecutable(path: plistIdentity.program)
+            }
+            guard isOwnerPrivateExecutable(atPath: plistIdentity.program) else {
+                return .missingExecutable(path: plistIdentity.program)
+            }
+            return .notLoaded
+        }
+        guard let identity = parseLaunchdServiceIdentity(inspection.output) else {
+            return .unavailable
+        }
+        guard identity.path == managedPlist else {
+            return .unexpectedPlist(path: identity.path)
+        }
+        // launchctl's textual identity is not sufficient evidence that the
+        // on-disk plist is still the managed, owner-private file. Re-read the
+        // expected path without following symlinks and bind its label/program
+        // to the loaded job before considering repair.
+        guard isSafePrivateDirectoryChain(
+            URL(fileURLWithPath: managedPlist).deletingLastPathComponent(),
+            under: homeDirectory
+        ), let plistData = readOwnerPrivateRegularFile(
+            URL(fileURLWithPath: managedPlist),
+            maxBytes: 64 * 1024,
+            fileManager: fileManager
+        ), let plistIdentity = parseLaunchdPlistIdentity(plistData),
+              plistIdentity.label == label,
+              plistIdentity.program == identity.program else {
+            return .unexpectedPlist(path: managedPlist)
+        }
+        guard identity.program == managedProgram || identity.program == legacyProgram else {
+            return .unexpectedExecutable(path: identity.program)
+        }
+        guard isOwnerPrivateExecutable(atPath: identity.program) else {
+            return .missingExecutable(path: identity.program)
+        }
+        return .validExecutable
+    }
+
+    struct LaunchdServiceIdentity: Equatable {
+        let program: String
+        let path: String
+    }
+
+    private struct InstallManifest: Decodable {
+        let binaryPath: String
+        let installPrefix: String?
+
+        enum CodingKeys: String, CodingKey {
+            case binaryPath = "binary_path"
+            case installPrefix = "install_prefix"
+        }
+    }
+
+    private struct LaunchdPlistIdentity {
+        let label: String
+        let program: String
+    }
+
+    static func readOwnerPrivateRegularFile(
+        _ url: URL,
+        maxBytes: Int,
+        fileManager: FileManager
+    ) -> Data? {
+        let descriptor = url.path.withCString {
+            Darwin.open($0, O_RDONLY | O_CLOEXEC | O_NOFOLLOW)
+        }
+        guard descriptor >= 0 else { return nil }
+        defer { _ = Darwin.close(descriptor) }
+
+        var info = stat()
+        guard Darwin.fstat(descriptor, &info) == 0,
+              (info.st_mode & S_IFMT) == S_IFREG,
+              info.st_uid == getuid(),
+              info.st_nlink == 1,
+              info.st_mode & (S_IWGRP | S_IWOTH) == 0,
+              info.st_size >= 0,
+              info.st_size <= off_t(maxBytes),
+              hasNoExtendedACL(descriptor) else {
+            return nil
+        }
+        let initialIdentity = info
+        var data = Data()
+        data.reserveCapacity(Int(info.st_size))
+        var buffer = [UInt8](repeating: 0, count: min(64 * 1024, maxBytes))
+        while data.count < Int(info.st_size) {
+            let count = buffer.withUnsafeMutableBytes { storage in
+                Darwin.read(descriptor, storage.baseAddress, storage.count)
+            }
+            guard count > 0 else { return nil }
+            data.append(buffer, count: count)
+        }
+        guard data.count == Int(initialIdentity.st_size) else { return nil }
+
+        var finalIdentity = stat()
+        guard Darwin.fstat(descriptor, &finalIdentity) == 0,
+              sameFileIdentity(initialIdentity, finalIdentity),
+              hasNoExtendedACL(descriptor) else {
+            return nil
+        }
+        var pathIdentity = stat()
+        guard Darwin.lstat(url.path, &pathIdentity) == 0,
+              sameFileIdentity(finalIdentity, pathIdentity) else {
+            return nil
+        }
+        _ = fileManager // Keep the injected boundary explicit for callers/tests.
+        return data
+    }
+
+    private static func parseLaunchdPlistIdentity(_ data: Data) -> LaunchdPlistIdentity? {
+        guard let object = try? PropertyListSerialization.propertyList(
+            from: data,
+            options: [],
+            format: nil
+        ), let plist = object as? [String: Any],
+              let label = plist["Label"] as? String,
+              !label.isEmpty else {
+            return nil
+        }
+        let program = (plist["Program"] as? String)
+            ?? (plist["ProgramArguments"] as? [String])?.first
+        guard let program, !program.isEmpty else { return nil }
+        return LaunchdPlistIdentity(label: label, program: program)
+    }
+
+    static func isOwnerPrivateExecutable(atPath path: String) -> Bool {
+        let descriptor = path.withCString {
+            Darwin.open($0, O_RDONLY | O_CLOEXEC | O_NOFOLLOW)
+        }
+        guard descriptor >= 0 else { return false }
+        defer { _ = Darwin.close(descriptor) }
+
+        var info = stat()
+        guard Darwin.fstat(descriptor, &info) == 0,
+              (info.st_mode & S_IFMT) == S_IFREG,
+              info.st_uid == getuid(),
+              info.st_nlink == 1,
+              info.st_mode & S_IXUSR != 0,
+              info.st_mode & (S_IWGRP | S_IWOTH) == 0,
+              hasNoExtendedACL(descriptor) else {
+            return false
+        }
+        return true
+    }
+
+    static func isSafePrivateDirectoryChain(_ directory: URL, under home: URL) -> Bool {
+        let homePath = home.standardizedFileURL.path
+        let directoryPath = directory.standardizedFileURL.path
+        guard directoryPath == homePath || directoryPath.hasPrefix(homePath + "/") else {
+            return false
+        }
+
+        let relativePath = String(directoryPath.dropFirst(homePath.count))
+        var current = URL(fileURLWithPath: homePath, isDirectory: true)
+        guard isSafePrivateDirectory(atPath: current.path) else { return false }
+        for component in relativePath.split(separator: "/") {
+            current.appendPathComponent(String(component), isDirectory: true)
+            guard isSafePrivateDirectory(atPath: current.path) else { return false }
+        }
+        return true
+    }
+
+    static func isSafePrivateDirectoryChainAllowingMissingLeaf(
+        _ directory: URL,
+        under home: URL
+    ) -> Bool {
+        let homePath = home.standardizedFileURL.path
+        let directoryPath = directory.standardizedFileURL.path
+        guard directoryPath == homePath || directoryPath.hasPrefix(homePath + "/") else {
+            return false
+        }
+
+        let relativePath = String(directoryPath.dropFirst(homePath.count))
+        var current = URL(fileURLWithPath: homePath, isDirectory: true)
+        guard isSafePrivateDirectory(atPath: current.path) else { return false }
+        for component in relativePath.split(separator: "/") {
+            current.appendPathComponent(String(component), isDirectory: true)
+            if isSafePrivateDirectory(atPath: current.path) {
+                continue
+            }
+            var identity = stat()
+            guard Darwin.lstat(current.path, &identity) != 0, errno == ENOENT else {
+                return false
+            }
+            return true
+        }
+        return true
+    }
+
+    static func isSupportedProviderInstallDirectory(
+        _ directory: URL,
+        under home: URL
+    ) -> Bool {
+        let homePath = home.standardizedFileURL.path
+        let providerRoot = home.appendingPathComponent("macprovider", isDirectory: true)
+            .standardizedFileURL.path
+        let directoryPath = directory.standardizedFileURL.path
+        return directoryPath == providerRoot || directoryPath.hasPrefix(providerRoot + "/")
+            && directoryPath != homePath
+    }
+
+    private static func isSafePrivateDirectory(atPath path: String) -> Bool {
+        let descriptor = path.withCString {
+            Darwin.open($0, O_RDONLY | O_DIRECTORY | O_CLOEXEC | O_NOFOLLOW)
+        }
+        guard descriptor >= 0 else { return false }
+        defer { _ = Darwin.close(descriptor) }
+
+        var info = stat()
+        return Darwin.fstat(descriptor, &info) == 0
+            && (info.st_mode & S_IFMT) == S_IFDIR
+            && info.st_uid == getuid()
+            && info.st_nlink >= 1
+            && info.st_mode & (S_IWGRP | S_IWOTH) == 0
+            && hasNoExtendedACL(descriptor)
+    }
+
+    private static func sameFileIdentity(_ lhs: stat, _ rhs: stat) -> Bool {
+        lhs.st_dev == rhs.st_dev
+            && lhs.st_ino == rhs.st_ino
+            && lhs.st_mode == rhs.st_mode
+            && lhs.st_uid == rhs.st_uid
+            && lhs.st_nlink == rhs.st_nlink
+            && lhs.st_size == rhs.st_size
+            && lhs.st_mtimespec.tv_sec == rhs.st_mtimespec.tv_sec
+            && lhs.st_mtimespec.tv_nsec == rhs.st_mtimespec.tv_nsec
+            && lhs.st_ctimespec.tv_sec == rhs.st_ctimespec.tv_sec
+            && lhs.st_ctimespec.tv_nsec == rhs.st_ctimespec.tv_nsec
+    }
+
+    private static func hasNoExtendedACL(_ descriptor: Int32) -> Bool {
+        errno = 0
+        guard let acl = acl_get_fd_np(descriptor, ACL_TYPE_EXTENDED) else {
+            return errno == 0 || errno == ENOENT
+        }
+        defer { _ = acl_free(UnsafeMutableRawPointer(acl)) }
+        var entry: acl_entry_t?
+        guard acl_get_entry(acl, ACL_FIRST_ENTRY.rawValue, &entry) == 0 else { return false }
+        return entry == nil
+    }
+
+    static func parseLaunchdServiceIdentity(_ output: String) -> LaunchdServiceIdentity? {
+        let programLines = output.split(separator: "\n").compactMap { line -> String? in
+            let trimmed = line.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard trimmed.hasPrefix("program = ") else { return nil }
+            let program = String(trimmed.dropFirst("program = ".count))
+            return program.isEmpty ? nil : program
+        }
+        let pathLines = output.split(separator: "\n").compactMap { line -> String? in
+            let trimmed = line.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard trimmed.hasPrefix("path = ") else { return nil }
+            let path = String(trimmed.dropFirst("path = ".count))
+            return path.isEmpty ? nil : path
+        }
+        guard programLines.count == 1, pathLines.count == 1 else { return nil }
+        return LaunchdServiceIdentity(program: programLines[0], path: pathLines[0])
+    }
+
+    static func parseLaunchdServiceProgramPath(_ output: String) -> String? {
+        for line in output.split(separator: "\n") {
+            let trimmed = line.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard trimmed.hasPrefix("program = ") else { continue }
+            let path = String(trimmed.dropFirst("program = ".count))
+            return path.isEmpty ? nil : path
+        }
+        return nil
+    }
+
+    static func hasTrustedPrivateFile(
+        at url: URL,
+        maxBytes: Int = 64 * 1024,
+        fileManager: FileManager = .default
+    ) -> Bool {
+        readOwnerPrivateRegularFile(url, maxBytes: maxBytes, fileManager: fileManager) != nil
+    }
+
+    private struct LaunchdServiceInspection {
+        let loaded: Bool
+        let output: String
+    }
+
+    private static func inspectLaunchdService(
+        uid: uid_t,
+        label: String,
+        launchctlURL: URL
+    ) -> LaunchdServiceInspection? {
         let process = Process()
         let stdout = Pipe()
         process.executableURL = launchctlURL
-        process.arguments = ["print", "gui/\(uid)/live.streamvc.macprovider"]
+        process.arguments = ["print", "gui/\(uid)/\(label)"]
         process.standardOutput = stdout
         process.standardError = FileHandle.nullDevice
         do {
             try process.run()
-            let data = stdout.fileHandleForReading.readDataToEndOfFile()
+            let data = stdout.fileHandleForReading.readData(ofLength: 64 * 1024 + 1)
+            if data.count > 64 * 1024 {
+                process.terminate()
+                process.waitUntilExit()
+                return nil
+            }
             process.waitUntilExit()
-            guard process.terminationStatus == 0, data.count <= 64 * 1024 else { return nil }
-            return parseLaunchdServicePID(String(decoding: data, as: UTF8.self))
+            return LaunchdServiceInspection(
+                loaded: process.terminationStatus == 0,
+                output: String(decoding: data, as: UTF8.self)
+            )
         } catch {
             return nil
         }

--- a/phase3-binary/app/Sources/Malibu/System/InstalledProviderMonitor.swift
+++ b/phase3-binary/app/Sources/Malibu/System/InstalledProviderMonitor.swift
@@ -421,11 +421,16 @@ enum InstalledProviderMonitor {
         under home: URL
     ) -> Bool {
         let homePath = home.standardizedFileURL.path
-        let providerRoot = home.appendingPathComponent("macprovider", isDirectory: true)
-            .standardizedFileURL.path
+        let rawComponents = directory.path.split(separator: "/", omittingEmptySubsequences: false)
+        guard !rawComponents.contains(where: { $0 == "." || $0 == ".." }) else {
+            return false
+        }
         let directoryPath = directory.standardizedFileURL.path
-        return directoryPath == providerRoot || directoryPath.hasPrefix(providerRoot + "/")
-            && directoryPath != homePath
+        guard directoryPath != homePath,
+              directoryPath.hasPrefix(homePath + "/") else {
+            return false
+        }
+        return isSafePrivateDirectoryChainAllowingMissingLeaf(directory, under: home)
     }
 
     private static func isSafePrivateDirectory(atPath path: String) -> Bool {
@@ -440,8 +445,12 @@ enum InstalledProviderMonitor {
             && (info.st_mode & S_IFMT) == S_IFDIR
             && info.st_uid == getuid()
             && info.st_nlink >= 1
+            // macOS commonly adds a deny-delete ACL to user directory
+            // ancestors (including $HOME and ~/Library). It does not grant
+            // write access, so directory-chain trust remains based on the
+            // owner, no-follow, and mode checks above. Files carrying
+            // authoritative launchd/configuration data stay strict below.
             && info.st_mode & (S_IWGRP | S_IWOTH) == 0
-            && hasNoExtendedACL(descriptor)
     }
 
     private static func sameFileIdentity(_ lhs: stat, _ rhs: stat) -> Bool {

--- a/phase3-binary/app/Sources/Malibu/System/LogTailReader.swift
+++ b/phase3-binary/app/Sources/Malibu/System/LogTailReader.swift
@@ -1,4 +1,5 @@
 import Combine
+import Darwin
 import Foundation
 
 struct LogTailBuffer: Equatable {
@@ -139,9 +140,23 @@ final class LogTailReader: ObservableObject {
         maxReadBytes: UInt64,
         maxPendingFragmentCharacters: Int
     ) -> ReadResult? {
-        guard let handle = try? FileHandle(forReadingFrom: fileURL) else { return nil }
-        defer { try? handle.close() }
-        let size = (try? FileManager.default.attributesOfItem(atPath: fileURL.path)[.size] as? UInt64) ?? 0
+        guard maxReadBytes <= UInt64(Int.max) else { return nil }
+        let descriptor = fileURL.path.withCString {
+            Darwin.open($0, O_RDONLY | O_CLOEXEC | O_NOFOLLOW | O_NONBLOCK)
+        }
+        guard descriptor >= 0 else { return nil }
+        defer { _ = Darwin.close(descriptor) }
+
+        var fileInfo = stat()
+        guard Darwin.fstat(descriptor, &fileInfo) == 0,
+              (fileInfo.st_mode & S_IFMT) == S_IFREG,
+              fileInfo.st_uid == getuid(),
+              Int(fileInfo.st_nlink) == 1,
+              fileInfo.st_size >= 0 else {
+            return nil
+        }
+
+        let size = UInt64(fileInfo.st_size)
         var offset = previousOffset
         var pendingFragment = previousFragment
         var startedInsideExistingFile = false
@@ -160,25 +175,28 @@ final class LogTailReader: ObservableObject {
             startedInsideExistingFile = true
         }
 
-        do {
-            try handle.seek(toOffset: offset)
-            let data = try handle.read(upToCount: Int(maxReadBytes)) ?? Data()
-            let nextOffset = offset + UInt64(data.count)
-            guard !data.isEmpty, var chunk = String(data: data, encoding: .utf8) else {
-                return ReadResult(offset: nextOffset, pendingFragment: pendingFragment, lines: [])
-            }
-            if startedInsideExistingFile, let newline = chunk.firstIndex(where: \.isNewline) {
-                chunk = String(chunk[chunk.index(after: newline)...])
-            }
-            let parsed = parseChunk(
-                chunk,
-                pendingFragment: pendingFragment,
-                maxPendingFragmentCharacters: maxPendingFragmentCharacters
-            )
-            return ReadResult(offset: nextOffset, pendingFragment: parsed.pendingFragment, lines: parsed.lines)
-        } catch {
-            return nil
+        guard Darwin.lseek(descriptor, off_t(offset), SEEK_SET) != -1 else { return nil }
+        var bytes = [UInt8](repeating: 0, count: Int(maxReadBytes))
+        let bytesRead = bytes.withUnsafeMutableBytes { buffer in
+            Darwin.read(descriptor, buffer.baseAddress, buffer.count)
         }
+        guard bytesRead >= 0 else { return nil }
+
+        let nextOffset = offset + UInt64(bytesRead)
+        guard bytesRead > 0,
+              let data = String(bytes: bytes.prefix(bytesRead), encoding: .utf8) else {
+            return ReadResult(offset: nextOffset, pendingFragment: pendingFragment, lines: [])
+        }
+        var chunk = data
+        if startedInsideExistingFile, let newline = chunk.firstIndex(where: \.isNewline) {
+            chunk = String(chunk[chunk.index(after: newline)...])
+        }
+        let parsed = parseChunk(
+            chunk,
+            pendingFragment: pendingFragment,
+            maxPendingFragmentCharacters: maxPendingFragmentCharacters
+        )
+        return ReadResult(offset: nextOffset, pendingFragment: parsed.pendingFragment, lines: parsed.lines)
     }
 
     nonisolated private static func parseChunk(

--- a/phase3-binary/app/Sources/Malibu/System/ProviderCredentialHandoffRunner.swift
+++ b/phase3-binary/app/Sources/Malibu/System/ProviderCredentialHandoffRunner.swift
@@ -150,9 +150,11 @@ enum ProviderCredentialHandoffRunner {
 
     private struct InstallManifest: Decodable {
         let binaryPath: String
+        let installPrefix: String?
 
         enum CodingKeys: String, CodingKey {
             case binaryPath = "binary_path"
+            case installPrefix = "install_prefix"
         }
     }
 
@@ -864,21 +866,46 @@ enum ProviderCredentialHandoffRunner {
         if fileManager.fileExists(atPath: manifestURL.path) {
             let manifest: InstallManifest
             do {
-                manifest = try JSONDecoder().decode(InstallManifest.self, from: Data(contentsOf: manifestURL))
+                guard let data = InstalledProviderMonitor.readOwnerPrivateRegularFile(
+                    manifestURL,
+                    maxBytes: 64 * 1024,
+                    fileManager: fileManager
+                ) else {
+                    throw Error.invalidCLI("install manifest is not a trusted private file")
+                }
+                manifest = try JSONDecoder().decode(InstallManifest.self, from: data)
             } catch {
                 throw Error.invalidCLI("install manifest is malformed")
             }
-            guard manifest.binaryPath.hasPrefix("/") else {
+            guard manifest.binaryPath.hasPrefix("/"),
+                  let installPrefix = manifest.installPrefix,
+                  installPrefix.hasPrefix("/") else {
                 throw Error.invalidCLI("install manifest binary_path is not absolute")
             }
-            candidate = URL(fileURLWithPath: manifest.binaryPath).standardizedFileURL
+            let prefix = URL(fileURLWithPath: installPrefix).standardizedFileURL
+            let manifestDirectory = manifestURL.deletingLastPathComponent()
+            guard InstalledProviderMonitor.isSafePrivateDirectoryChain(
+                manifestDirectory,
+                under: home
+            ), InstalledProviderMonitor.isSupportedProviderInstallDirectory(
+                prefix,
+                under: home
+            ) else {
+                throw Error.invalidCLI("install manifest install_prefix is not trusted")
+            }
+            let resolved = URL(fileURLWithPath: manifest.binaryPath).standardizedFileURL
+            guard resolved.deletingLastPathComponent().path == prefix.path else {
+                throw Error.invalidCLI("install manifest binary_path does not match install_prefix")
+            }
+            candidate = resolved
         } else {
             candidate = home.appendingPathComponent("macprovider/macprovider-cli").standardizedFileURL
         }
         guard candidate.lastPathComponent == "macprovider-cli" else {
             throw Error.invalidCLI("unexpected executable name")
         }
-        guard fileManager.isExecutableFile(atPath: candidate.path) else {
+        guard InstalledProviderMonitor.isOwnerPrivateExecutable(atPath: candidate.path),
+              fileManager.isExecutableFile(atPath: candidate.path) else {
             throw Error.cliNotFound
         }
         return candidate

--- a/phase3-binary/app/Sources/Malibu/System/ProviderDiagnosticsBundle.swift
+++ b/phase3-binary/app/Sources/Malibu/System/ProviderDiagnosticsBundle.swift
@@ -122,12 +122,14 @@ enum ProviderDiagnosticsBundle {
     }
 
     static func readRedactedTail(_ url: URL) -> [String] {
-        let descriptor = open(url.path, O_RDONLY | O_CLOEXEC | O_NOFOLLOW)
+        let descriptor = open(url.path, O_RDONLY | O_CLOEXEC | O_NOFOLLOW | O_NONBLOCK)
         guard descriptor >= 0 else { return [] }
         defer { close(descriptor) }
         var info = stat()
         guard fstat(descriptor, &info) == 0,
               (info.st_mode & S_IFMT) == S_IFREG,
+              info.st_uid == getuid(),
+              Int(info.st_nlink) == 1,
               info.st_size >= 0 else {
             return []
         }

--- a/phase3-binary/app/Sources/Malibu/System/ProviderLogDiagnostics.swift
+++ b/phase3-binary/app/Sources/Malibu/System/ProviderLogDiagnostics.swift
@@ -2,10 +2,19 @@ import Foundation
 
 /// Maps macprovider-cli stderr lines (launchd or Malibu-spawned) to operator-facing text.
 enum ProviderLogDiagnostics {
+    static let staleLaunchAgentMessage =
+        "Provider setup is blocked by a previous installation. "
+        + "Click Launch Provider to repair the background service. "
+        + "Your provider identity and model files will be kept."
+
     struct Finding: Equatable {
         let id: String
         let userMessage: String
         let matchedLine: String
+    }
+
+    static func isActionable(_ finding: Finding, launchdNeedsRepair: Bool) -> Bool {
+        finding.id != "stale_launch_agent" || launchdNeedsRepair
     }
 
     private struct Rule {
@@ -15,6 +24,11 @@ enum ProviderLogDiagnostics {
     }
 
     private static let rules: [Rule] = [
+        Rule(
+            id: "stale_launch_agent",
+            needle: "provider process unhealthy: launchd service live.streamvc.macprovider has no validated pid at",
+            userMessage: staleLaunchAgentMessage
+        ),
         Rule(
             id: "stale_model_catalog",
             needle: "model catalog provenance envelope is stale",
@@ -92,11 +106,30 @@ enum ProviderLogDiagnostics {
         return nil
     }
 
+    /// Provider stdout/stderr and watchdog logs have independent tails, so
+    /// their array order is not a chronology. Provider diagnostics take
+    /// precedence; a stale watchdog hint must not hide a newer provider error.
+    static func diagnose(
+        providerLines: [String],
+        watchdogLines: [String],
+        launchdNeedsRepair: Bool = false
+    ) -> Finding? {
+        if launchdNeedsRepair,
+           let staleFinding = diagnose(
+               lines: (providerLines + watchdogLines).filter {
+                   $0.lowercased().contains("provider process unhealthy: launchd service live.streamvc.macprovider has no validated pid at")
+               }
+           ) {
+            return staleFinding
+        }
+        return diagnose(lines: providerLines) ?? diagnose(lines: watchdogLines)
+    }
+
     static func timeoutMessage(logHint: String) -> String {
         "Background provider did not become healthy in time. \(logHint)"
     }
 
     static func logHint(paths: ProviderPaths = .current) -> String {
-        "Check \(paths.launchdStderrLog.path) and \(paths.launchdStdoutLog.path)."
+        "Check \(paths.launchdStderrLog.path), \(paths.launchdStdoutLog.path), and \(paths.watchdogLog.path)."
     }
 }

--- a/phase3-binary/app/Sources/Malibu/System/ProviderLogTail.swift
+++ b/phase3-binary/app/Sources/Malibu/System/ProviderLogTail.swift
@@ -1,14 +1,16 @@
 import Combine
 import Foundation
 
-/// Tails launchd provider stdout/stderr logs into one redacted line buffer for UI + diagnostics.
+/// Tails provider stdout/stderr and watchdog logs with separate source buffers.
 @MainActor
 final class ProviderLogTail: ObservableObject {
     @Published private(set) var lines: [String] = []
+    @Published private(set) var watchdogLines: [String] = []
 
     private let capacity: Int
     private var stderrReader: LogTailReader?
     private var stdoutReader: LogTailReader?
+    private var watchdogReader: LogTailReader?
     private var cancellables: Set<AnyCancellable> = []
 
     init(capacity: Int = 200) {
@@ -19,9 +21,11 @@ final class ProviderLogTail: ObservableObject {
         stop()
         stderrReader = attachReader(fileURL: paths.launchdStderrLog)
         stdoutReader = attachReader(fileURL: paths.launchdStdoutLog)
+        watchdogReader = attachReader(fileURL: paths.watchdogLog)
         Task { @MainActor [weak self] in
             await self?.stderrReader?.readAvailable()
             await self?.stdoutReader?.readAvailable()
+            await self?.watchdogReader?.readAvailable()
             self?.mergePublishedLines()
         }
     }
@@ -30,8 +34,12 @@ final class ProviderLogTail: ObservableObject {
         cancellables.removeAll()
         stderrReader?.stop()
         stdoutReader?.stop()
+        watchdogReader?.stop()
         stderrReader = nil
         stdoutReader = nil
+        watchdogReader = nil
+        lines = []
+        watchdogLines = []
     }
 
     @discardableResult
@@ -54,5 +62,6 @@ final class ProviderLogTail: ObservableObject {
             merged.removeFirst(merged.count - capacity)
         }
         lines = merged
+        watchdogLines = watchdogReader?.lines ?? []
     }
 }

--- a/phase3-binary/app/Tests/MalibuTests/AgentSnapshotPresenterTests.swift
+++ b/phase3-binary/app/Tests/MalibuTests/AgentSnapshotPresenterTests.swift
@@ -978,6 +978,15 @@ final class AgentSnapshotPresenterTests: XCTestCase {
         XCTAssertEqual(LogTailBuffer.redacted(raw), raw)
     }
 
+    func testStaleLaunchAgentRecoveryMessageRemainsUserVisible() {
+        let message =
+            "Provider setup is blocked by a previous installation. "
+            + "Click Launch Provider to repair the background service. "
+            + "Your provider identity and model files will be kept."
+
+        XCTAssertEqual(AgentSnapshotPresenter.publicErrorDetail(message), message)
+    }
+
     func testOnboardingAdvancedFailureDiagnosticsKeepsRedactedDetails() {
         let details = OnboardingCopy.advancedFailureDiagnostics(
             message: "coordinator join requires model_artifact_sha256 in /tmp/macprovider.err.log",

--- a/phase3-binary/app/Tests/MalibuTests/InstalledProviderMonitorTests.swift
+++ b/phase3-binary/app/Tests/MalibuTests/InstalledProviderMonitorTests.swift
@@ -381,6 +381,43 @@ final class InstalledProviderMonitorTests: XCTestCase {
         )
     }
 
+    func testSafePrivateDirectoryChainAllowsMacOSDenyDeleteACL() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("malibu-launchd-acl-tests-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: false)
+        defer {
+            _ = Self.runChmod(arguments: ["-a", "group:everyone deny delete", root.path])
+            try? FileManager.default.removeItem(at: root)
+        }
+
+        guard Self.runChmod(arguments: ["+a", "group:everyone deny delete", root.path]) else {
+            throw XCTSkip("macOS ACL mutation is unavailable in this test environment")
+        }
+
+        XCTAssertTrue(
+            InstalledProviderMonitor.isSafePrivateDirectoryChain(root, under: root),
+            "a deny-delete ACL on an owned ancestor must not turn managed launchd state into a conflict"
+        )
+    }
+
+    func testSupportedProviderInstallDirectoryAllowsSafeCustomHomePath() throws {
+        let home = FileManager.default.temporaryDirectory
+            .appendingPathComponent("malibu-custom-install-home-\(UUID().uuidString)")
+        let prefix = home.appendingPathComponent("provider-support/bin")
+        try FileManager.default.createDirectory(at: prefix, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: home) }
+
+        XCTAssertTrue(
+            InstalledProviderMonitor.isSupportedProviderInstallDirectory(prefix, under: home)
+        )
+        XCTAssertFalse(
+            InstalledProviderMonitor.isSupportedProviderInstallDirectory(
+                home.appendingPathComponent("../outside"),
+                under: home
+            )
+        )
+    }
+
     func testLaunchdRepairRejectsSymlinkAndDirectoryAtManagedExecutablePath() throws {
         let root = FileManager.default.temporaryDirectory
             .appendingPathComponent("malibu-launchd-executable-tests-(UUID().uuidString)")
@@ -419,6 +456,19 @@ final class InstalledProviderMonitorTests: XCTestCase {
                 homeDirectory: root
             )
             XCTAssertEqual(state, .missingExecutable(path: program.path), replacement)
+        }
+    }
+
+    private static func runChmod(arguments: [String]) -> Bool {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/bin/chmod")
+        process.arguments = arguments
+        do {
+            try process.run()
+            process.waitUntilExit()
+            return process.terminationStatus == 0
+        } catch {
+            return false
         }
     }
 

--- a/phase3-binary/app/Tests/MalibuTests/InstalledProviderMonitorTests.swift
+++ b/phase3-binary/app/Tests/MalibuTests/InstalledProviderMonitorTests.swift
@@ -400,6 +400,27 @@ final class InstalledProviderMonitorTests: XCTestCase {
         )
     }
 
+    func testSafePrivateDirectoryChainRejectsDirectoryWriteGrantACL() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("malibu-launchd-acl-write-tests-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: false)
+        defer {
+            _ = Self.runChmod(arguments: ["-a", "group:everyone allow add_file,add_subdirectory", root.path])
+            try? FileManager.default.removeItem(at: root)
+        }
+
+        guard Self.runChmod(
+            arguments: ["+a", "group:everyone allow add_file,add_subdirectory", root.path]
+        ) else {
+            throw XCTSkip("macOS ACL mutation is unavailable in this test environment")
+        }
+
+        XCTAssertFalse(
+            InstalledProviderMonitor.isSafePrivateDirectoryChain(root, under: root),
+            "a directory ACL granting everyone file creation must fail closed"
+        )
+    }
+
     func testSupportedProviderInstallDirectoryAllowsSafeCustomHomePath() throws {
         let home = FileManager.default.temporaryDirectory
             .appendingPathComponent("malibu-custom-install-home-\(UUID().uuidString)")

--- a/phase3-binary/app/Tests/MalibuTests/InstalledProviderMonitorTests.swift
+++ b/phase3-binary/app/Tests/MalibuTests/InstalledProviderMonitorTests.swift
@@ -316,6 +316,140 @@ final class InstalledProviderMonitorTests: XCTestCase {
         XCTAssertNil(InstalledProviderMonitor.parseLaunchdServicePID("pid = 4321\npid = 9999"))
     }
 
+    func testParseLaunchdServiceProgramPath() {
+        let output = """
+        gui/501/live.streamvc.macprovider = {
+            program = /Users/provider/macprovider/macprovider-cli
+            pid = 123
+        }
+        """
+
+        XCTAssertEqual(
+            InstalledProviderMonitor.parseLaunchdServiceProgramPath(output),
+            "/Users/provider/macprovider/macprovider-cli"
+        )
+        XCTAssertNil(InstalledProviderMonitor.parseLaunchdServiceProgramPath("pid = 123"))
+    }
+
+    func testParseLaunchdServiceIdentityRequiresOneProgramAndCanonicalPathField() {
+        let output = """
+        gui/501/live.streamvc.macprovider = {
+            program = /Users/provider/macprovider/macprovider-cli
+            path = /Users/provider/Library/LaunchAgents/live.streamvc.macprovider.plist
+        }
+        """
+
+        XCTAssertEqual(
+            InstalledProviderMonitor.parseLaunchdServiceIdentity(output),
+            InstalledProviderMonitor.LaunchdServiceIdentity(
+                program: "/Users/provider/macprovider/macprovider-cli",
+                path: "/Users/provider/Library/LaunchAgents/live.streamvc.macprovider.plist"
+            )
+        )
+        XCTAssertNil(
+            InstalledProviderMonitor.parseLaunchdServiceIdentity(
+                "program = /Users/provider/macprovider/macprovider-cli"
+            )
+        )
+        XCTAssertNil(
+            InstalledProviderMonitor.parseLaunchdServiceIdentity(
+                "program = /Users/provider/macprovider/macprovider-cli\n"
+                    + "program = /Users/other/macprovider-cli\n"
+                    + "path = /Users/provider/Library/LaunchAgents/live.streamvc.macprovider.plist"
+            )
+        )
+    }
+
+    func testLaunchdRepairStateSeparatesManagedRepairFromForeignIdentity() {
+        XCTAssertFalse(InstalledProviderMonitor.LaunchdServiceRepairState.unavailable.needsRepair)
+        XCTAssertFalse(InstalledProviderMonitor.LaunchdServiceRepairState.notLoaded.needsRepair)
+        XCTAssertFalse(InstalledProviderMonitor.LaunchdServiceRepairState.validExecutable.needsRepair)
+        XCTAssertTrue(
+            InstalledProviderMonitor.LaunchdServiceRepairState.missingExecutable(path: "/missing").needsRepair
+        )
+        XCTAssertFalse(
+            InstalledProviderMonitor.LaunchdServiceRepairState.unexpectedExecutable(path: "/other").needsRepair
+        )
+        XCTAssertTrue(
+            InstalledProviderMonitor.LaunchdServiceRepairState.unexpectedExecutable(path: "/other").requiresManualIntervention
+        )
+        XCTAssertFalse(
+            InstalledProviderMonitor.LaunchdServiceRepairState.unexpectedPlist(path: "/other.plist").needsRepair
+        )
+        XCTAssertTrue(
+            InstalledProviderMonitor.LaunchdServiceRepairState.unexpectedPlist(path: "/other.plist").requiresManualIntervention
+        )
+    }
+
+    func testLaunchdRepairRejectsSymlinkAndDirectoryAtManagedExecutablePath() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("malibu-launchd-executable-tests-(UUID().uuidString)")
+        let providerDirectory = root.appendingPathComponent("macprovider")
+        let launchAgents = root.appendingPathComponent("Library/LaunchAgents")
+        let program = providerDirectory.appendingPathComponent("macprovider-cli")
+        let plist = launchAgents.appendingPathComponent("live.streamvc.macprovider.plist")
+        let launchctl = root.appendingPathComponent("launchctl")
+        try FileManager.default.createDirectory(at: providerDirectory, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: launchAgents, withIntermediateDirectories: true)
+        try """
+        <?xml version="1.0" encoding="UTF-8"?>
+        <plist version="1.0"><dict>
+        <key>Label</key><string>live.streamvc.macprovider</string>
+        <key>ProgramArguments</key><array><string>\(program.path)</string></array>
+        </dict></plist>
+        """.write(to: plist, atomically: true, encoding: .utf8)
+        try "#!/bin/sh\nprintf 'program = %s\\npath = %s\\n' '\(program.path)' '\(plist.path)'\n"
+            .write(to: launchctl, atomically: true, encoding: .utf8)
+        try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: launchctl.path)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        for replacement in ["symlink", "directory"] {
+            try? FileManager.default.removeItem(at: program)
+            if replacement == "symlink" {
+                let target = root.appendingPathComponent("foreign-provider")
+                try "#!/bin/sh\n".write(to: target, atomically: true, encoding: .utf8)
+                try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: target.path)
+                try FileManager.default.createSymbolicLink(at: program, withDestinationURL: target)
+            } else {
+                try FileManager.default.createDirectory(at: program, withIntermediateDirectories: false)
+            }
+
+            let state = InstalledProviderMonitor.launchdServiceRepairState(
+                launchctlURL: launchctl,
+                homeDirectory: root
+            )
+            XCTAssertEqual(state, .missingExecutable(path: program.path), replacement)
+        }
+    }
+
+    func testLaunchdRepairInspectsManagedPlistWhenServiceIsNotLoaded() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("malibu-launchd-unloaded-tests-\(UUID().uuidString)")
+        let launchAgents = root.appendingPathComponent("Library/LaunchAgents")
+        let program = root.appendingPathComponent("macprovider/macprovider-cli")
+        let plist = launchAgents.appendingPathComponent("live.streamvc.macprovider.plist")
+        let launchctl = root.appendingPathComponent("launchctl")
+        try FileManager.default.createDirectory(at: launchAgents, withIntermediateDirectories: true)
+        try """
+        <?xml version="1.0" encoding="UTF-8"?>
+        <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+        <plist version="1.0"><dict>
+          <key>Label</key><string>live.streamvc.macprovider</string>
+          <key>ProgramArguments</key><array><string>\(program.path)</string></array>
+        </dict></plist>
+        """.write(to: plist, atomically: true, encoding: .utf8)
+        try "#!/bin/sh\nexit 1\n".write(to: launchctl, atomically: true, encoding: .utf8)
+        try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: launchctl.path)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let state = InstalledProviderMonitor.launchdServiceRepairState(
+            launchctlURL: launchctl,
+            homeDirectory: root
+        )
+
+        XCTAssertEqual(state, .missingExecutable(path: program.path))
+    }
+
     func testStatusSnapshotKeepsOlderCLIReadableWithoutTrustFields() throws {
         let json = """
         {

--- a/phase3-binary/app/Tests/MalibuTests/LaunchProviderControllerTests.swift
+++ b/phase3-binary/app/Tests/MalibuTests/LaunchProviderControllerTests.swift
@@ -89,6 +89,39 @@ final class LaunchProviderControllerTests: XCTestCase {
         XCTAssertEqual(controller.stage, .live(model: harness.configModel, tier: .provisional))
     }
 
+    func testRepairExistingInstallRunsInstallerWithoutReferralWhenBinaryIsMissing() async {
+        let harness = Harness()
+        harness.localInstallSucceeded = true
+        harness.restartSafeIncumbentPresent = false
+        let controller = LaunchProviderController(
+            repairExistingInstall: true,
+            dependencies: harness.dependencies()
+        )
+
+        await controller.launch()
+
+        XCTAssertEqual(harness.cliInstallRuns, 1)
+        XCTAssertEqual(harness.cliImportRuns, 1)
+        XCTAssertNil(harness.installedReferralCode)
+        XCTAssertFalse(harness.installedReplacingIncumbentProvider)
+        XCTAssertEqual(controller.stage, .live(model: harness.configModel, tier: .provisional))
+    }
+
+    func testRepairExistingInstallIgnoresMalformedReferralInput() async {
+        let harness = Harness()
+        let controller = LaunchProviderController(
+            repairExistingInstall: true,
+            dependencies: harness.dependencies()
+        )
+        controller.referralInput = "not-an-invite"
+
+        await controller.launch()
+
+        XCTAssertEqual(harness.cliInstallRuns, 1)
+        XCTAssertNil(harness.installedReferralCode)
+        XCTAssertEqual(controller.stage, .live(model: harness.configModel, tier: .provisional))
+    }
+
     func testReferralOnRestartSafeIncumbentDoesNotReplaceWithoutConfirmation() async {
         let harness = Harness()
         harness.restartSafeIncumbentPresent = true

--- a/phase3-binary/app/Tests/MalibuTests/LaunchProviderControllerTests.swift
+++ b/phase3-binary/app/Tests/MalibuTests/LaunchProviderControllerTests.swift
@@ -104,6 +104,7 @@ final class LaunchProviderControllerTests: XCTestCase {
         XCTAssertEqual(harness.cliImportRuns, 1)
         XCTAssertNil(harness.installedReferralCode)
         XCTAssertFalse(harness.installedReplacingIncumbentProvider)
+        XCTAssertTrue(harness.installedRepairExistingInstall)
         XCTAssertEqual(controller.stage, .live(model: harness.configModel, tier: .provisional))
     }
 
@@ -562,6 +563,7 @@ final class LaunchProviderControllerTests: XCTestCase {
         var emittedInstallLogLines: [String] = ["install.sh finished"]
         var installedReferralCode: String?
         var installedReplacingIncumbentProvider = false
+        var installedRepairExistingInstall = false
 
         func dependencies() -> LaunchProviderController.Dependencies {
             LaunchProviderController.Dependencies(
@@ -573,10 +575,11 @@ final class LaunchProviderControllerTests: XCTestCase {
                 registerLoginItem: {
                     self.loginItemRegistrations += 1
                 },
-                runCLIInstall: { referralCode, replacingIncumbentProvider, onLogLine in
+                runCLIInstall: { referralCode, replacingIncumbentProvider, repairExistingInstall, onLogLine in
                     self.cliInstallRuns += 1
                     self.installedReferralCode = referralCode
                     self.installedReplacingIncumbentProvider = replacingIncumbentProvider
+                    self.installedRepairExistingInstall = repairExistingInstall
                     if let error = self.cliInstallError { throw error }
                     self.localInstallSucceededAfterInstall = self.markLocalInstallSucceededAfterInstall
                     for line in self.emittedInstallLogLines {

--- a/phase3-binary/app/Tests/MalibuTests/LogTailReaderTests.swift
+++ b/phase3-binary/app/Tests/MalibuTests/LogTailReaderTests.swift
@@ -1,3 +1,4 @@
+import Darwin
 import XCTest
 @testable import Malibu
 
@@ -90,5 +91,29 @@ final class LogTailReaderTests: XCTestCase {
 
         XCTAssertEqual(reader.lines.first?.count, 16)
         XCTAssertEqual(reader.lines.last, "finished")
+    }
+
+    @MainActor
+    func testReaderRejectsSymlinkHardlinkAndFIFO() async throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let source = directory.appendingPathComponent("source.log")
+        try Data("secret-line\n".utf8).write(to: source)
+
+        let symlink = directory.appendingPathComponent("symlink.log")
+        try FileManager.default.createSymbolicLink(at: symlink, withDestinationURL: source)
+        let hardlink = directory.appendingPathComponent("hardlink.log")
+        XCTAssertEqual(Darwin.link(source.path, hardlink.path), 0)
+        let fifo = directory.appendingPathComponent("fifo.log")
+        XCTAssertEqual(Darwin.mkfifo(fifo.path, mode_t(0o600)), 0)
+
+        for path in [symlink, hardlink, fifo] {
+            let reader = LogTailReader(fileURL: path, capacity: 10)
+            await reader.readAvailable()
+            XCTAssertTrue(reader.lines.isEmpty, "unsafe log path was read: \(path.path)")
+        }
     }
 }

--- a/phase3-binary/app/Tests/MalibuTests/ProviderCredentialHandoffRunnerTests.swift
+++ b/phase3-binary/app/Tests/MalibuTests/ProviderCredentialHandoffRunnerTests.swift
@@ -125,7 +125,7 @@ final class ProviderCredentialHandoffRunnerTests: XCTestCase {
         let home = FileManager.default.temporaryDirectory
             .appendingPathComponent("credential-handoff-home-\(UUID().uuidString)")
         defer { try? FileManager.default.removeItem(at: home) }
-        let executable = home.appendingPathComponent("macprovider/custom/bin/macprovider-cli")
+        let executable = home.appendingPathComponent("custom/bin/macprovider-cli")
         try FileManager.default.createDirectory(
             at: executable.deletingLastPathComponent(),
             withIntermediateDirectories: true

--- a/phase3-binary/app/Tests/MalibuTests/ProviderCredentialHandoffRunnerTests.swift
+++ b/phase3-binary/app/Tests/MalibuTests/ProviderCredentialHandoffRunnerTests.swift
@@ -125,7 +125,7 @@ final class ProviderCredentialHandoffRunnerTests: XCTestCase {
         let home = FileManager.default.temporaryDirectory
             .appendingPathComponent("credential-handoff-home-\(UUID().uuidString)")
         defer { try? FileManager.default.removeItem(at: home) }
-        let executable = home.appendingPathComponent("custom/bin/macprovider-cli")
+        let executable = home.appendingPathComponent("macprovider/custom/bin/macprovider-cli")
         try FileManager.default.createDirectory(
             at: executable.deletingLastPathComponent(),
             withIntermediateDirectories: true
@@ -139,7 +139,10 @@ final class ProviderCredentialHandoffRunnerTests: XCTestCase {
             at: manifest.deletingLastPathComponent(),
             withIntermediateDirectories: true
         )
-        try JSONSerialization.data(withJSONObject: ["binary_path": executable.path])
+        try JSONSerialization.data(withJSONObject: [
+            "install_prefix": executable.deletingLastPathComponent().path,
+            "binary_path": executable.path,
+        ])
             .write(to: manifest)
 
         XCTAssertEqual(

--- a/phase3-binary/app/Tests/MalibuTests/ProviderLogDiagnosticsTests.swift
+++ b/phase3-binary/app/Tests/MalibuTests/ProviderLogDiagnosticsTests.swift
@@ -2,6 +2,17 @@ import XCTest
 @testable import Malibu
 
 final class ProviderLogDiagnosticsTests: XCTestCase {
+    func testDiagnoseStaleLaunchAgent() {
+        let finding = ProviderLogDiagnostics.diagnose(lines: [
+            "provider process unhealthy: launchd service live.streamvc.macprovider has no validated PID at /Users/provider/macprovider-cli",
+        ])
+
+        XCTAssertEqual(finding?.id, "stale_launch_agent")
+        XCTAssertTrue(finding?.userMessage.hasPrefix("Provider setup is blocked") == true)
+        XCTAssertTrue(finding?.userMessage.contains("Click Launch Provider") == true)
+        XCTAssertTrue(finding?.userMessage.contains("identity and model files") == true)
+    }
+
     func testDiagnoseStaleCatalogProvenance() {
         let finding = ProviderLogDiagnostics.diagnose(lines: [
             "loading config",
@@ -22,6 +33,41 @@ final class ProviderLogDiagnosticsTests: XCTestCase {
         ])
 
         XCTAssertEqual(finding?.id, "stale_model_catalog")
+    }
+
+    func testDiagnoseProviderLogsBeforeWatchdogLogs() {
+        let finding = ProviderLogDiagnostics.diagnose(
+            providerLines: ["model artifact hash mismatch for /tmp/current"],
+            watchdogLines: [
+                "provider process unhealthy: launchd service live.streamvc.macprovider has no validated PID at /Users/provider/macprovider-cli"
+            ]
+        )
+
+        XCTAssertEqual(finding?.id, "artifact_hash_mismatch")
+    }
+
+    func testCurrentLaunchdRepairTakesPrecedenceOverGenericProviderFinding() {
+        let finding = ProviderLogDiagnostics.diagnose(
+            providerLines: [
+                "provider process unhealthy: launchd service live.streamvc.macprovider has no validated PID at /Users/provider/macprovider-cli",
+                "model artifact hash mismatch for /tmp/current"
+            ],
+            watchdogLines: [],
+            launchdNeedsRepair: true
+        )
+
+        XCTAssertEqual(finding?.id, "stale_launch_agent")
+    }
+
+    func testHistoricalStaleLaunchAgentFindingRequiresCurrentRepairState() {
+        let finding = ProviderLogDiagnostics.Finding(
+            id: "stale_launch_agent",
+            userMessage: ProviderLogDiagnostics.staleLaunchAgentMessage,
+            matchedLine: "historical stale launchd evidence"
+        )
+
+        XCTAssertFalse(ProviderLogDiagnostics.isActionable(finding, launchdNeedsRepair: false))
+        XCTAssertTrue(ProviderLogDiagnostics.isActionable(finding, launchdNeedsRepair: true))
     }
 
     func testDiagnoseReturnsNilForUnrecognizedLines() {
@@ -47,5 +93,12 @@ final class ProviderLogDiagnosticsTests: XCTestCase {
 
         XCTAssertTrue(message.contains("/tmp/macprovider.err.log"))
         XCTAssertTrue(message.contains("/tmp/macprovider.out.log"))
+        XCTAssertTrue(message.contains("/tmp/watchdog.log"))
+    }
+
+    func testStaleRuleDoesNotMatchUnrelatedPIDValidation() {
+        XCTAssertNil(ProviderLogDiagnostics.diagnose(lines: [
+            "unrelated component has no validated PID",
+        ]))
     }
 }

--- a/phase3-binary/app/Tests/MalibuTests/ProviderLogTailTests.swift
+++ b/phase3-binary/app/Tests/MalibuTests/ProviderLogTailTests.swift
@@ -3,7 +3,7 @@ import XCTest
 
 @MainActor
 final class ProviderLogTailTests: XCTestCase {
-    func testMergedTailIncludesStderrAndStdout() async throws {
+    func testTailKeepsProviderAndWatchdogLogsSeparate() async throws {
         let root = FileManager.default.temporaryDirectory
             .appendingPathComponent(UUID().uuidString, isDirectory: true)
         try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
@@ -11,8 +11,10 @@ final class ProviderLogTailTests: XCTestCase {
 
         let stderr = root.appendingPathComponent("macprovider.err.log")
         let stdout = root.appendingPathComponent("macprovider.out.log")
+        let watchdog = root.appendingPathComponent("watchdog.log")
         try "stderr-line\n".data(using: .utf8)?.write(to: stderr)
         try "stdout-line\n".data(using: .utf8)?.write(to: stdout)
+        try "watchdog-line\n".data(using: .utf8)?.write(to: watchdog)
 
         let paths = ProviderPaths(
             configFile: root.appendingPathComponent("config.yaml"),
@@ -32,5 +34,7 @@ final class ProviderLogTailTests: XCTestCase {
 
         XCTAssertTrue(tail.lines.contains("stderr-line"))
         XCTAssertTrue(tail.lines.contains("stdout-line"))
+        XCTAssertFalse(tail.lines.contains("watchdog-line"))
+        XCTAssertTrue(tail.watchdogLines.contains("watchdog-line"))
     }
 }

--- a/phase3-binary/app/Tests/MalibuTests/ReferralOnboardingTests.swift
+++ b/phase3-binary/app/Tests/MalibuTests/ReferralOnboardingTests.swift
@@ -154,6 +154,23 @@ final class ReferralOnboardingTests: XCTestCase {
         XCTAssertNil(noReferralEnvironment["MACPROVIDER_REFERRAL_REPLACE_INCUMBENT"])
     }
 
+    func testInstallerEnvironmentPassesRepairIntentOnlyWhenRequested() throws {
+        let repairEnvironment = try CLIInstallRunner.installerEnvironment(
+            parentEnvironment: ["MACPROVIDER_REPAIR_EXISTING_INSTALL": "1"],
+            installPort: nil,
+            pinnedVersion: nil,
+            repairExistingInstall: true
+        )
+        XCTAssertEqual(repairEnvironment["MACPROVIDER_REPAIR_EXISTING_INSTALL"], "1")
+
+        let normalEnvironment = try CLIInstallRunner.installerEnvironment(
+            parentEnvironment: ["MACPROVIDER_REPAIR_EXISTING_INSTALL": "1"],
+            installPort: nil,
+            pinnedVersion: nil
+        )
+        XCTAssertNil(normalEnvironment["MACPROVIDER_REPAIR_EXISTING_INSTALL"])
+    }
+
     func testInstallerEnvironmentCarriesManifestSelectedInstallDirectory() throws {
         let home = FileManager.default.temporaryDirectory
             .appendingPathComponent("installer-custom-home-\(UUID().uuidString)")

--- a/phase3-binary/app/Tests/MalibuTests/ReferralOnboardingTests.swift
+++ b/phase3-binary/app/Tests/MalibuTests/ReferralOnboardingTests.swift
@@ -154,6 +154,38 @@ final class ReferralOnboardingTests: XCTestCase {
         XCTAssertNil(noReferralEnvironment["MACPROVIDER_REFERRAL_REPLACE_INCUMBENT"])
     }
 
+    func testInstallerEnvironmentCarriesManifestSelectedInstallDirectory() throws {
+        let home = FileManager.default.temporaryDirectory
+            .appendingPathComponent("installer-custom-home-\(UUID().uuidString)")
+        let manifest = home.appendingPathComponent(
+            "Library/Application Support/macprovider/install_manifest.json"
+        )
+        try FileManager.default.createDirectory(
+            at: manifest.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        let customProgram = home.appendingPathComponent("macprovider/provider-support/macprovider-cli")
+        try JSONSerialization.data(withJSONObject: [
+            "install_prefix": customProgram.deletingLastPathComponent().path,
+            "binary_path": customProgram.path,
+        ])
+            .write(to: manifest)
+        defer { try? FileManager.default.removeItem(at: home) }
+
+        let environment = try CLIInstallRunner.installerEnvironment(
+            parentEnvironment: [:],
+            installPort: nil,
+            pinnedVersion: nil,
+            homeDirectory: home
+        )
+
+        XCTAssertEqual(
+            environment["MACPROVIDER_INSTALL_DIR"],
+            customProgram.deletingLastPathComponent().path
+        )
+        XCTAssertEqual(environment["HOME"], home.path)
+    }
+
     func testBundledInstallerEnablesReceiptsOnlyForFreshReferralBootstrap() throws {
         let scriptURL = try CLIInstallRunner.resolveInstallScriptURL()
         let script = try String(contentsOf: scriptURL, encoding: .utf8)

--- a/phase3-binary/app/Tests/MalibuTests/ReferralOnboardingTests.swift
+++ b/phase3-binary/app/Tests/MalibuTests/ReferralOnboardingTests.swift
@@ -164,7 +164,7 @@ final class ReferralOnboardingTests: XCTestCase {
             at: manifest.deletingLastPathComponent(),
             withIntermediateDirectories: true
         )
-        let customProgram = home.appendingPathComponent("macprovider/provider-support/macprovider-cli")
+        let customProgram = home.appendingPathComponent("provider-support/macprovider-cli")
         try JSONSerialization.data(withJSONObject: [
             "install_prefix": customProgram.deletingLastPathComponent().path,
             "binary_path": customProgram.path,

--- a/phase3-binary/app/Tests/MalibuTests/StartupRouteTests.swift
+++ b/phase3-binary/app/Tests/MalibuTests/StartupRouteTests.swift
@@ -22,6 +22,10 @@ final class StartupRouteTests: XCTestCase {
         let cases: [(String, StartupState, StartupRoute)] = [
             ("healthy-launchd", state(config: true, marker: true, launchd: true, healthy: true), .startAgent),
             ("launchd-config-starting", state(config: true, marker: true, launchd: true, healthy: false), .startAgent),
+            ("stale-launchd-repair", state(config: true, marker: true, launchd: true, healthy: false, needsRepair: true), .repairExistingInstall),
+            ("stale-launchd-repair-before-import", state(config: true, marker: false, launchd: true, healthy: false, needsRepair: true), .showImportDialog),
+            ("healthy-provider-repairs-watchdog-in-background", state(config: true, marker: true, launchd: true, healthy: true, needsRepair: true, providerNeedsRepair: false, watchdogNeedsRepair: true), .startAgentAndRepairWatchdog),
+            ("foreign-launchd-conflict", state(config: true, marker: true, launchd: true, healthy: false, manualIntervention: true), .showLaunchdConflict),
             ("legacy-app-config", state(config: true, marker: true, launchd: false, healthy: false), .showOnboarding),
             ("cli-owned", state(config: true, marker: false, launchd: false, healthy: false), .showImportDialog),
             ("launchd-cli-owned-healthy", state(config: true, marker: false, launchd: true, healthy: true), .showImportDialog),
@@ -37,9 +41,135 @@ final class StartupRouteTests: XCTestCase {
         }
     }
 
+    func testDetectRoutesForeignWatchdogToManualConflictWithoutUsingRealHome() async throws {
+        let paths = try makeTempPaths()
+        let root = paths.appSupport.deletingLastPathComponent()
+        let watchdogPlist = root.appendingPathComponent(
+            "Library/LaunchAgents/live.streamvc.macprovider-watchdog.plist"
+        )
+        let launchctl = root.appendingPathComponent("launchctl")
+        try FileManager.default.createDirectory(
+            at: watchdogPlist.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        try "<plist/>\n".write(to: watchdogPlist, atomically: true, encoding: .utf8)
+        try "#!/bin/sh\nprintf 'program = %s\\npath = %s\\n' '\(root.path)/unexpected-watchdog' '\(watchdogPlist.path)'\n"
+            .write(to: launchctl, atomically: true, encoding: .utf8)
+        try FileManager.default.setAttributes(
+            [.posixPermissions: 0o755],
+            ofItemAtPath: launchctl.path
+        )
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let state = await StartupState.detect(
+            paths: paths,
+            homeDirectory: root,
+            launchctlURL: launchctl
+        )
+
+        XCTAssertTrue(state.launchdJobNeedsManualIntervention)
+        XCTAssertEqual(state.route(), .showLaunchdConflict)
+    }
+
+    func testDetectAcceptsLegacyWatchdogIdentityWithoutRepair() async throws {
+        let paths = try makeTempPaths()
+        let root = paths.appSupport.deletingLastPathComponent()
+        let watchdogPlist = root.appendingPathComponent(
+            "Library/LaunchAgents/live.streamvc.macprovider-watchdog.plist"
+        )
+        let legacyWatchdog = root.appendingPathComponent(
+            ".local/share/macprovider-watchdog/watchdog.sh"
+        )
+        let launchctl = root.appendingPathComponent("launchctl")
+        try FileManager.default.createDirectory(
+            at: watchdogPlist.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        try FileManager.default.createDirectory(
+            at: legacyWatchdog.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        try "<plist/>\n".write(to: watchdogPlist, atomically: true, encoding: .utf8)
+        try "#!/bin/sh\n".write(to: legacyWatchdog, atomically: true, encoding: .utf8)
+        try FileManager.default.setAttributes(
+            [.posixPermissions: 0o755],
+            ofItemAtPath: legacyWatchdog.path
+        )
+        try "#!/bin/sh\nprintf 'program = %s\\npath = %s\\n' '\(legacyWatchdog.path)' '\(watchdogPlist.path)'\n"
+            .write(to: launchctl, atomically: true, encoding: .utf8)
+        try FileManager.default.setAttributes(
+            [.posixPermissions: 0o755],
+            ofItemAtPath: launchctl.path
+        )
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let state = await StartupState.detect(
+            paths: paths,
+            homeDirectory: root,
+            launchctlURL: launchctl
+        )
+
+        XCTAssertFalse(state.launchdJobNeedsRepair)
+    }
+
+    func testDetectAcceptsManifestSelectedCustomProviderIdentityWithoutRepair() async throws {
+        let paths = try makeTempPaths()
+        let root = paths.appSupport.deletingLastPathComponent()
+        let providerPlist = root.appendingPathComponent(
+            "Library/LaunchAgents/live.streamvc.macprovider.plist"
+        )
+        let customProgram = root.appendingPathComponent("macprovider/provider-support/macprovider-cli")
+        let manifest = root.appendingPathComponent(
+            "Library/Application Support/macprovider/install_manifest.json"
+        )
+        let launchctl = root.appendingPathComponent("launchctl")
+        try FileManager.default.createDirectory(
+            at: providerPlist.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        try FileManager.default.createDirectory(
+            at: customProgram.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        try FileManager.default.createDirectory(
+            at: manifest.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        try "<plist/>\n".write(to: providerPlist, atomically: true, encoding: .utf8)
+        try "#!/bin/sh\n".write(to: customProgram, atomically: true, encoding: .utf8)
+        try FileManager.default.setAttributes(
+            [.posixPermissions: 0o755],
+            ofItemAtPath: customProgram.path
+        )
+        try JSONSerialization.data(withJSONObject: [
+            "install_prefix": customProgram.deletingLastPathComponent().path,
+            "binary_path": customProgram.path,
+        ])
+            .write(to: manifest)
+        try "#!/bin/sh\nprintf 'program = %s\\npath = %s\\n' '\(customProgram.path)' '\(providerPlist.path)'\n"
+            .write(to: launchctl, atomically: true, encoding: .utf8)
+        try FileManager.default.setAttributes(
+            [.posixPermissions: 0o755],
+            ofItemAtPath: launchctl.path
+        )
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let state = await StartupState.detect(
+            paths: paths,
+            homeDirectory: root,
+            launchctlURL: launchctl
+        )
+
+        XCTAssertFalse(state.launchdJobNeedsRepair)
+    }
+
     func testMigrationImportWithoutLaunchdRoutesToOnboarding() async throws {
         let paths = try makeTempPaths()
+        let root = paths.appSupport.deletingLastPathComponent()
+        let launchctl = root.appendingPathComponent("launchctl")
         try paths.ensureDirectories()
+        try "#!/bin/sh\nexit 1\n".write(to: launchctl, atomically: true, encoding: .utf8)
+        try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: launchctl.path)
         try "provider_id: p_import\nprovider_token: secret-token\nmodel: test\n".write(to: paths.configFile, atomically: true, encoding: .utf8)
         defer { try? FileManager.default.removeItem(at: paths.appSupport.deletingLastPathComponent()) }
         defer { try? FileManager.default.removeItem(at: paths.configFile.deletingLastPathComponent()) }
@@ -50,9 +180,15 @@ final class StartupRouteTests: XCTestCase {
             paths: paths,
             importCredentialIntoCLI: { snapshot in
                 XCTAssertTrue(try String(contentsOf: snapshot).contains("provider_token: secret-token"))
-            }
+            },
+            homeDirectory: root,
+            launchctlURL: launchctl
         )
-        let state = await StartupState.detect(paths: paths)
+        let state = await StartupState.detect(
+            paths: paths,
+            homeDirectory: root,
+            launchctlURL: launchctl
+        )
         let expectedRoute: StartupRoute = state.launchdInstallEvidenceExists ? .startAgent : .showOnboarding
         XCTAssertEqual(result.route, expectedRoute)
         XCTAssertNil(result.backupPath)
@@ -267,14 +403,22 @@ final class StartupRouteTests: XCTestCase {
         marker: Bool,
         configured: Bool? = nil,
         launchd: Bool,
-        healthy: Bool
+        healthy: Bool,
+        needsRepair: Bool = false,
+        manualIntervention: Bool = false,
+        providerNeedsRepair: Bool? = nil,
+        watchdogNeedsRepair: Bool = false
     ) -> StartupState {
         StartupState(
             configExists: config,
             appMarkerExists: marker,
             appIdentityConfigured: configured ?? marker,
             launchdInstallEvidenceExists: launchd,
-            backgroundProviderHealthy: healthy
+            backgroundProviderHealthy: healthy,
+            launchdJobNeedsRepair: needsRepair,
+            launchdJobNeedsManualIntervention: manualIntervention,
+            providerLaunchdJobNeedsRepair: providerNeedsRepair,
+            watchdogJobNeedsRepair: watchdogNeedsRepair
         )
     }
 

--- a/phase3-binary/app/Tests/MalibuTests/StartupRouteTests.swift
+++ b/phase3-binary/app/Tests/MalibuTests/StartupRouteTests.swift
@@ -26,6 +26,7 @@ final class StartupRouteTests: XCTestCase {
             ("stale-launchd-repair-before-import", state(config: true, marker: false, launchd: true, healthy: false, needsRepair: true), .showImportDialog),
             ("healthy-provider-repairs-watchdog-in-background", state(config: true, marker: true, launchd: true, healthy: true, needsRepair: true, providerNeedsRepair: false, watchdogNeedsRepair: true), .startAgentAndRepairWatchdog),
             ("foreign-launchd-conflict", state(config: true, marker: true, launchd: true, healthy: false, manualIntervention: true), .showLaunchdConflict),
+            ("foreign-launchd-conflict-before-import", state(config: true, marker: false, launchd: true, healthy: false, manualIntervention: true), .showLaunchdConflict),
             ("legacy-app-config", state(config: true, marker: true, launchd: false, healthy: false), .showOnboarding),
             ("cli-owned", state(config: true, marker: false, launchd: false, healthy: false), .showImportDialog),
             ("launchd-cli-owned-healthy", state(config: true, marker: false, launchd: true, healthy: true), .showImportDialog),
@@ -247,6 +248,30 @@ final class StartupRouteTests: XCTestCase {
         XCTAssertTrue(FileManager.default.fileExists(atPath: result.backupPath!))
         let attrs = try FileManager.default.attributesOfItem(atPath: result.backupPath!)
         XCTAssertEqual((attrs[.posixPermissions] as? NSNumber)?.intValue, 0o600)
+    }
+
+    func testMigrationStartFreshStopsOnManualLaunchdConflict() async throws {
+        let paths = try makeTempPaths()
+        let root = paths.appSupport.deletingLastPathComponent()
+        let launchctl = root.appendingPathComponent("launchctl")
+        try paths.ensureDirectories()
+        try "provider_id: p_old\nprovider_token: old-token\n".write(to: paths.configFile, atomically: true, encoding: .utf8)
+        try "#!/bin/sh\nprintf 'program = %s\\npath = %s\\n' '\(root.path)/unexpected-provider' '\(root.path)/Library/LaunchAgents/live.streamvc.macprovider.plist'\n"
+            .write(to: launchctl, atomically: true, encoding: .utf8)
+        try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: launchctl.path)
+        defer { try? FileManager.default.removeItem(atPath: root.path) }
+
+        let result = try await StartupState.applyMigrationDecision(
+            .startFresh,
+            paths: paths,
+            deferStartFreshBackup: true,
+            homeDirectory: root,
+            launchctlURL: launchctl
+        )
+
+        XCTAssertEqual(result.route, .showLaunchdConflict)
+        XCTAssertNil(result.backupPath)
+        XCTAssertTrue(FileManager.default.fileExists(atPath: paths.configFile.path))
     }
 
     func testConfirmedReplacementDefersConfigBackupToInstallerTransaction() async throws {

--- a/phase3-binary/app/Tests/MalibuTests/StartupRouteTests.swift
+++ b/phase3-binary/app/Tests/MalibuTests/StartupRouteTests.swift
@@ -118,7 +118,7 @@ final class StartupRouteTests: XCTestCase {
         let providerPlist = root.appendingPathComponent(
             "Library/LaunchAgents/live.streamvc.macprovider.plist"
         )
-        let customProgram = root.appendingPathComponent("macprovider/provider-support/macprovider-cli")
+        let customProgram = root.appendingPathComponent("provider-support/macprovider-cli")
         let manifest = root.appendingPathComponent(
             "Library/Application Support/macprovider/install_manifest.json"
         )

--- a/phase3-binary/app/Tests/MalibuTests/StartupRouteTests.swift
+++ b/phase3-binary/app/Tests/MalibuTests/StartupRouteTests.swift
@@ -71,6 +71,34 @@ final class StartupRouteTests: XCTestCase {
         XCTAssertEqual(state.route(), .showLaunchdConflict)
     }
 
+    func testDetectRoutesLoadedProviderWithMissingPlistToManualConflict() async throws {
+        let paths = try makeTempPaths()
+        let root = paths.appSupport.deletingLastPathComponent()
+        let expectedPlist = root.appendingPathComponent(
+            "Library/LaunchAgents/live.streamvc.macprovider.plist"
+        )
+        let expectedProgram = root.appendingPathComponent("macprovider/macprovider-cli")
+        let launchctl = root.appendingPathComponent("launchctl")
+        try FileManager.default.createDirectory(at: launchctl.deletingLastPathComponent(), withIntermediateDirectories: true)
+        try "#!/bin/sh\nprintf 'program = %s\\npath = %s\\n' '\(expectedProgram.path)' '\(expectedPlist.path)'\n"
+            .write(to: launchctl, atomically: true, encoding: .utf8)
+        try FileManager.default.setAttributes(
+            [.posixPermissions: 0o755],
+            ofItemAtPath: launchctl.path
+        )
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let state = await StartupState.detect(
+            paths: paths,
+            homeDirectory: root,
+            launchctlURL: launchctl
+        )
+
+        XCTAssertFalse(state.launchdInstallEvidenceExists)
+        XCTAssertTrue(state.launchdJobNeedsManualIntervention)
+        XCTAssertEqual(state.route(), .showLaunchdConflict)
+    }
+
     func testDetectAcceptsLegacyWatchdogIdentityWithoutRepair() async throws {
         let paths = try makeTempPaths()
         let root = paths.appSupport.deletingLastPathComponent()

--- a/phase3-binary/dist/install.sh
+++ b/phase3-binary/dist/install.sh
@@ -180,14 +180,11 @@ home = os.path.normpath(raw_home)
 target = os.path.normpath(raw)
 if target == home:
     raise SystemExit("install directory must not be HOME itself")
-provider_root = os.path.join(home, "macprovider")
 try:
     if os.path.commonpath([home, target]) != home:
         raise SystemExit("install directory must be inside HOME")
-    if os.path.commonpath([provider_root, target]) != provider_root:
-        raise SystemExit("install directory must be under HOME/macprovider")
 except ValueError:
-    raise SystemExit("install directory must be under HOME/macprovider")
+    raise SystemExit("install directory must be inside HOME")
 
 uid = os.getuid()
 current = home

--- a/phase3-binary/dist/install.sh
+++ b/phase3-binary/dist/install.sh
@@ -62,6 +62,7 @@ LIFECYCLE_LEASE_PATH="$MANIFEST_DIR/lifecycle/lease.json"
 LIFECYCLE_STATE_LOCK_PATH="$MANIFEST_DIR/lifecycle/.state-v1.json.lock"
 LIFECYCLE_LEASE_LOCK_PATH="$MANIFEST_DIR/lifecycle/.lease.json.lock"
 EXISTING_INSTALL_WAS_PRESENT=0
+PROVIDER_LABEL="live.streamvc.macprovider"
 PLIST_PATH="$HOME/Library/LaunchAgents/live.streamvc.macprovider.plist"
 LOG_DIR="$HOME/Library/Logs/macprovider"
 # Issue #191: ship the macprovider-watchdog LaunchAgent alongside
@@ -179,11 +180,14 @@ home = os.path.normpath(raw_home)
 target = os.path.normpath(raw)
 if target == home:
     raise SystemExit("install directory must not be HOME itself")
+provider_root = os.path.join(home, "macprovider")
 try:
     if os.path.commonpath([home, target]) != home:
         raise SystemExit("install directory must be inside HOME")
+    if os.path.commonpath([provider_root, target]) != provider_root:
+        raise SystemExit("install directory must be under HOME/macprovider")
 except ValueError:
-    raise SystemExit("install directory must be inside HOME")
+    raise SystemExit("install directory must be under HOME/macprovider")
 
 uid = os.getuid()
 current = home
@@ -944,10 +948,321 @@ stage_install_tx_path() {
   case "$path_kind" in
     directory) cp -R "$source_path" "$copied_path" ;;
     symlink) cp -P "$source_path" "$copied_path" ;;
-    file) cp -p "$source_path" "$copied_path" ;;
+    file)
+      # Recovery inputs are authoritative. Copy them through descriptors so a
+      # pathname replacement cannot turn the snapshot into attacker-selected
+      # content, and publish the destination atomically with a private mode.
+      python3 - "$source_path" "$copied_path" <<'PY'
+import ctypes
+import errno
+import os
+import stat
+import sys
+
+source_path, copied_path = sys.argv[1:]
+uid = os.getuid()
+max_bytes = 1024 * 1024
+nofollow = getattr(os, "O_NOFOLLOW", 0)
+
+
+def no_acl(fd):
+    if sys.platform != "darwin":
+        return True
+    try:
+        libc = ctypes.CDLL(None, use_errno=True)
+        get_acl = libc.acl_get_fd_np
+        get_acl.argtypes = [ctypes.c_int, ctypes.c_int]
+        get_acl.restype = ctypes.c_void_p
+        free_acl = libc.acl_free
+        free_acl.argtypes = [ctypes.c_void_p]
+        free_acl.restype = ctypes.c_int
+    except (AttributeError, OSError):
+        return False
+    ctypes.set_errno(0)
+    acl = get_acl(fd, 0x00000100)
+    if acl:
+        free_acl(acl)
+        return False
+    return ctypes.get_errno() in (0, errno.ENOENT)
+
+
+def safe_regular(fd, info, label):
+    if (
+        not stat.S_ISREG(info.st_mode)
+        or info.st_uid != uid
+        or info.st_nlink != 1
+        or info.st_mode & (stat.S_IWGRP | stat.S_IWOTH)
+        or info.st_size < 0
+        or info.st_size > max_bytes
+        or not no_acl(fd)
+    ):
+        raise SystemExit(f"unsafe recovery snapshot {label}")
+
+
+source_fd = os.open(source_path, os.O_RDONLY | nofollow)
+try:
+    before = os.fstat(source_fd)
+    safe_regular(source_fd, before, source_path)
+    payload = bytearray()
+    while len(payload) < before.st_size:
+        chunk = os.read(source_fd, min(65536, before.st_size - len(payload)))
+        if not chunk:
+            raise SystemExit("recovery snapshot was truncated")
+        payload.extend(chunk)
+    after = os.fstat(source_fd)
+    path_info = os.lstat(source_path)
+    if (
+        (after.st_dev, after.st_ino, after.st_size, after.st_mtime_ns, after.st_ctime_ns)
+        != (before.st_dev, before.st_ino, before.st_size, before.st_mtime_ns, before.st_ctime_ns)
+        or stat.S_ISLNK(path_info.st_mode)
+        or (path_info.st_dev, path_info.st_ino) != (before.st_dev, before.st_ino)
+    ):
+        raise SystemExit("recovery snapshot changed during copy")
+finally:
+    os.close(source_fd)
+
+parent_path = os.path.dirname(copied_path)
+parent_fd = os.open(parent_path, os.O_RDONLY | os.O_DIRECTORY | nofollow)
+temporary_name = ".%s.restore-%s" % (os.path.basename(copied_path), os.urandom(16).hex())
+temporary_fd = None
+try:
+    parent_info = os.fstat(parent_fd)
+    if (
+        not stat.S_ISDIR(parent_info.st_mode)
+        or parent_info.st_uid != uid
+        or parent_info.st_mode & (stat.S_IWGRP | stat.S_IWOTH)
+        or not no_acl(parent_fd)
+    ):
+        raise SystemExit("unsafe recovery snapshot destination")
+    temporary_fd = os.open(
+        temporary_name,
+        os.O_WRONLY | os.O_CREAT | os.O_EXCL | nofollow,
+        0o600,
+        dir_fd=parent_fd,
+    )
+    offset = 0
+    while offset < len(payload):
+        offset += os.write(temporary_fd, payload[offset:])
+    os.fsync(temporary_fd)
+    os.close(temporary_fd)
+    temporary_fd = None
+    os.replace(temporary_name, os.path.basename(copied_path), src_dir_fd=parent_fd, dst_dir_fd=parent_fd)
+    temporary_name = None
+    os.fsync(parent_fd)
+    verify_fd = os.open(os.path.basename(copied_path), os.O_RDONLY | nofollow, dir_fd=parent_fd)
+    try:
+        verify_info = os.fstat(verify_fd)
+        safe_regular(verify_fd, verify_info, copied_path)
+        if os.read(verify_fd, len(payload) + 1) != payload:
+            raise SystemExit("recovery snapshot destination changed")
+    finally:
+        os.close(verify_fd)
+finally:
+    if temporary_fd is not None:
+        os.close(temporary_fd)
+    if temporary_name is not None:
+        try:
+            os.unlink(temporary_name, dir_fd=parent_fd)
+        except FileNotFoundError:
+            pass
+    os.close(parent_fd)
+PY
+      ;;
     *) return 1 ;;
   esac
   install_tx_path_matches "$source_path" "$copied_path" "$path_kind"
+}
+
+# Launchd plists identify the service being displaced, so snapshot them with
+# descriptor-backed checks rather than a path-following cp. A plist that is a
+# symlink, hard link, non-regular file, foreign-owned file, oversized file, or
+# replaced while it is being copied is not safe recovery input.
+stage_install_tx_plist() {
+  source_path="$1"
+  copied_path="$2"
+  expected_label="$3"
+  expected_program="$4"
+  alternate_program="$5"
+  python3 - "$source_path" "$copied_path" "$expected_label" "$expected_program" "$alternate_program" <<'PY'
+import os
+import plistlib
+import stat
+import subprocess
+import sys
+import ctypes
+import errno
+
+source_path, copied_path, expected_label, expected_program, alternate_program = sys.argv[1:]
+uid = os.getuid()
+max_bytes = 1024 * 1024
+nofollow = getattr(os, "O_NOFOLLOW", 0)
+
+
+def fail(message):
+    sys.stderr.write("plist_snapshot_failed:%s\n" % message)
+    raise SystemExit(1)
+
+
+def read_bounded(fd):
+    data = bytearray()
+    while len(data) <= max_bytes:
+        chunk = os.read(fd, 65536)
+        if not chunk:
+            return bytes(data)
+        data.extend(chunk)
+    fail("oversized")
+
+
+source_fd = os.open(source_path, os.O_RDONLY | nofollow)
+destination_created = False
+try:
+    before = os.fstat(source_fd)
+    if not stat.S_ISREG(before.st_mode):
+        fail("not_regular")
+    if before.st_uid != uid:
+        fail("not_owned")
+    if before.st_nlink != 1:
+        fail("hardlinked")
+    if before.st_mode & (stat.S_IWGRP | stat.S_IWOTH):
+        fail("group_or_world_writable")
+    if before.st_size > max_bytes:
+        fail("oversized")
+    payload = read_bounded(source_fd)
+    if len(payload) != before.st_size:
+        fail("source_size_changed")
+
+    def source_identity(info):
+        return (
+            info.st_dev,
+            info.st_ino,
+            info.st_mode,
+            info.st_uid,
+            info.st_nlink,
+            info.st_size,
+            info.st_mtime_ns,
+            info.st_ctime_ns,
+        )
+
+    before_identity = source_identity(before)
+
+    def verify_source():
+        current = os.fstat(source_fd)
+        if source_identity(current) != before_identity:
+            fail("source_metadata_changed")
+        os.lseek(source_fd, 0, os.SEEK_SET)
+        if read_bounded(source_fd) != payload:
+            fail("source_contents_changed")
+        path_info = os.lstat(source_path)
+        if stat.S_ISLNK(path_info.st_mode) or source_identity(path_info) != before_identity:
+            fail("source_path_replaced")
+
+    def verify_acl():
+        if sys.platform == "darwin":
+            try:
+                libc = ctypes.CDLL(None, use_errno=True)
+                acl_get_fd_np = libc.acl_get_fd_np
+                acl_get_fd_np.argtypes = [ctypes.c_int, ctypes.c_int]
+                acl_get_fd_np.restype = ctypes.c_void_p
+                acl_free = libc.acl_free
+                acl_free.argtypes = [ctypes.c_void_p]
+                acl_free.restype = ctypes.c_int
+            except (AttributeError, OSError):
+                fail("acl_uninspectable")
+            ctypes.set_errno(0)
+            acl = acl_get_fd_np(source_fd, 0x00000100)  # ACL_TYPE_EXTENDED
+            if acl:
+                acl_free(acl)
+                fail("acl_present")
+            if ctypes.get_errno() != errno.ENOENT:
+                fail("acl_uninspectable")
+            return
+
+        # Keep the non-Darwin diagnostic harness fail-closed while preserving
+        # the descriptor binding. Production macOS uses acl_get_fd_np above.
+        acl_probe = subprocess.run(
+            ["/bin/ls", "-ldeH", "/dev/fd/%d" % source_fd],
+            check=False,
+            capture_output=True,
+            text=True,
+            pass_fds=(source_fd,),
+        )
+        if acl_probe.returncode != 0 or not acl_probe.stdout.splitlines():
+            fail("acl_uninspectable")
+        permissions = acl_probe.stdout.splitlines()[0].split(None, 1)[0]
+        if permissions.endswith("+"):
+            fail("acl_present")
+
+    verify_acl()
+    try:
+        plist = plistlib.loads(payload)
+    except Exception:
+        fail("invalid_plist")
+    if not isinstance(plist, dict) or plist.get("Label") != expected_label:
+        fail("unexpected_label")
+    program = plist.get("Program")
+    if "Program" in plist and (not isinstance(program, str) or not program):
+        fail("invalid_program")
+    arguments = plist.get("ProgramArguments")
+    if "ProgramArguments" in plist:
+        if (
+            not isinstance(arguments, list)
+            or not arguments
+            or not all(isinstance(argument, str) and argument for argument in arguments)
+        ):
+            fail("invalid_program_arguments")
+    if program is None and arguments is None:
+        fail("missing_program_identity")
+    effective_program = program if program is not None else arguments[0]
+    if effective_program not in (expected_program, alternate_program):
+        fail("unexpected_program")
+
+    previous_umask = os.umask(0o077)
+    try:
+        destination_fd = os.open(
+            copied_path,
+            os.O_RDWR | os.O_CREAT | os.O_EXCL | nofollow,
+            0o600,
+        )
+    finally:
+        os.umask(previous_umask)
+    destination_created = True
+    try:
+        written = 0
+        while written < len(payload):
+            progress = os.write(destination_fd, payload[written:])
+            if progress <= 0:
+                fail("destination_write")
+            written += progress
+        os.fchmod(destination_fd, stat.S_IMODE(before.st_mode) & ~0o022)
+        os.fsync(destination_fd)
+        verify_source()
+        verify_acl()
+        destination_info = os.fstat(destination_fd)
+        if (
+            not stat.S_ISREG(destination_info.st_mode)
+            or destination_info.st_uid != uid
+            or destination_info.st_nlink != 1
+            or destination_info.st_size != len(payload)
+        ):
+            fail("destination_unsafe")
+        os.lseek(destination_fd, 0, os.SEEK_SET)
+        if read_bounded(destination_fd) != payload:
+            fail("destination_mismatch")
+    finally:
+        os.close(destination_fd)
+
+    verify_source()
+    verify_acl()
+finally:
+    os.close(source_fd)
+    if destination_created:
+        try:
+            final_info = os.lstat(copied_path)
+            if not stat.S_ISREG(final_info.st_mode) or final_info.st_nlink != 1:
+                os.unlink(copied_path)
+        except FileNotFoundError:
+            pass
+PY
 }
 
 # Snapshot the CLI-owned lifecycle-state file into the recovery staging area
@@ -1202,6 +1517,54 @@ finally:
 PY
 }
 
+secure_private_directory() {
+  directory_path="$1"
+  python3 - "$directory_path" <<'PY'
+import ctypes
+import errno
+import os
+import stat
+import sys
+
+path = sys.argv[1]
+fd = os.open(
+    path,
+    os.O_RDONLY | getattr(os, "O_DIRECTORY", 0) | getattr(os, "O_NOFOLLOW", 0),
+)
+try:
+    os.fchmod(fd, 0o700)
+    info = os.fstat(fd)
+    if (
+        not stat.S_ISDIR(info.st_mode)
+        or info.st_uid != os.getuid()
+        or info.st_nlink < 1
+        or info.st_mode & (stat.S_IWGRP | stat.S_IWOTH)
+    ):
+        raise SystemExit("private directory is unsafe")
+    if sys.platform == "darwin":
+        try:
+            libc = ctypes.CDLL(None, use_errno=True)
+            acl_get_fd_np = libc.acl_get_fd_np
+            acl_get_fd_np.argtypes = [ctypes.c_int, ctypes.c_int]
+            acl_get_fd_np.restype = ctypes.c_void_p
+            acl_free = libc.acl_free
+            acl_free.argtypes = [ctypes.c_void_p]
+            acl_free.restype = ctypes.c_int
+        except (AttributeError, OSError):
+            raise SystemExit("private directory ACL API is unavailable")
+        ctypes.set_errno(0)
+        acl = acl_get_fd_np(fd, 0x00000100)  # ACL_TYPE_EXTENDED
+        if acl:
+            acl_free(acl)
+            raise SystemExit("private directory has an extended ACL")
+        if ctypes.get_errno() != errno.ENOENT:
+            raise SystemExit("private directory ACL verification failed")
+    os.fsync(fd)
+finally:
+    os.close(fd)
+PY
+}
+
 write_install_recovery_artifacts() {
   recovery_dir="$1"
   state_path="$recovery_dir/state.sh"
@@ -1213,6 +1576,7 @@ write_install_recovery_artifacts() {
     printf 'REC_CONFIG_PATH=%q\n' "$CONFIG_PATH"
     printf 'REC_PROVIDER_ID_PATH=%q\n' "$PROVIDER_ID_PATH"
     printf 'REC_RECOMMENDATION_PATH=%q\n' "$RECOMMENDATION_PATH"
+    printf 'REC_PROVIDER_LABEL=%q\n' "$PROVIDER_LABEL"
     printf 'REC_PLIST_PATH=%q\n' "$PLIST_PATH"
     printf 'REC_WATCHDOG_DIR=%q\n' "$WATCHDOG_DIR"
     printf 'REC_WATCHDOG_PLIST_PATH=%q\n' "$WATCHDOG_PLIST_PATH"
@@ -1249,15 +1613,86 @@ write_install_recovery_artifacts() {
     printf 'REC_WATCHDOG_WAS_DISABLED=%q\n' "$INSTALL_TX_WATCHDOG_WAS_DISABLED"
     printf 'REC_BINARY_KIND=%q\n' "$INSTALL_TX_BINARY_KIND"
     printf 'REC_REFERRAL_REPLACE_INCUMBENT=%q\n' "$REFERRAL_REPLACE_INCUMBENT"
-  } > "$state_path" || return 1
+  } | write_atomic_install_file "$state_path" 0600 || return 1
 
-  cat > "$recovery_script" <<'RECOVERY_SCRIPT'
+  write_atomic_install_file "$recovery_script" 0700 <<'RECOVERY_SCRIPT'
 #!/usr/bin/env bash
 set -u
 
 RECOVERY_DIR="$(cd "$(dirname "$0")" && pwd)" || exit 70
+verify_recovery_artifact() {
+  artifact_path="$1"
+  expected_payload="${2-}"
+  python3 - "$artifact_path" "$expected_payload" <<'PY'
+import ctypes
+import errno
+import os
+import stat
+import sys
+
+path, expected = sys.argv[1:]
+max_bytes = 1024 * 1024
+fd = os.open(path, os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0))
+try:
+    before = os.fstat(fd)
+    if (
+        not stat.S_ISREG(before.st_mode)
+        or before.st_uid != os.getuid()
+        or before.st_nlink != 1
+        or before.st_mode & (stat.S_IWGRP | stat.S_IWOTH)
+        or before.st_size > max_bytes
+    ):
+        raise SystemExit("recovery artifact is unsafe")
+    if sys.platform == "darwin":
+        try:
+            libc = ctypes.CDLL(None, use_errno=True)
+            acl_get_fd_np = libc.acl_get_fd_np
+            acl_get_fd_np.argtypes = [ctypes.c_int, ctypes.c_int]
+            acl_get_fd_np.restype = ctypes.c_void_p
+            acl_free = libc.acl_free
+            acl_free.argtypes = [ctypes.c_void_p]
+            acl_free.restype = ctypes.c_int
+        except (AttributeError, OSError):
+            raise SystemExit("recovery artifact ACL API is unavailable")
+        ctypes.set_errno(0)
+        acl = acl_get_fd_np(fd, 0x00000100)  # ACL_TYPE_EXTENDED
+        if acl:
+            acl_free(acl)
+            raise SystemExit("recovery artifact has an extended ACL")
+        if ctypes.get_errno() != errno.ENOENT:
+            raise SystemExit("recovery artifact ACL verification failed")
+    data = os.read(fd, before.st_size + 1)
+    if len(data) != before.st_size:
+        raise SystemExit("recovery artifact was truncated")
+    after = os.fstat(fd)
+    if (after.st_dev, after.st_ino, after.st_size, after.st_mtime_ns, after.st_ctime_ns) != (
+        before.st_dev, before.st_ino, before.st_size, before.st_mtime_ns, before.st_ctime_ns
+    ):
+        raise SystemExit("recovery artifact changed during verification")
+    path_info = os.lstat(path)
+    if stat.S_ISLNK(path_info.st_mode) or (path_info.st_dev, path_info.st_ino) != (before.st_dev, before.st_ino):
+        raise SystemExit("recovery artifact path was replaced")
+    if expected and data != (expected + "\n").encode("utf-8"):
+        raise SystemExit("recovery marker payload is invalid")
+finally:
+    os.close(fd)
+PY
+}
+verify_recovery_artifact "$RECOVERY_DIR/state.sh" || exit 70
+verify_recovery_artifact "$RECOVERY_DIR/recover.sh" || exit 70
+for recovery_marker in cutover-started provider-service-created watchdog-service-created new-manual.pid; do
+  if [ -e "$RECOVERY_DIR/$recovery_marker" ] || [ -L "$RECOVERY_DIR/$recovery_marker" ]; then
+    case "$recovery_marker" in
+      cutover-started) recovery_marker_payload="cutover-started" ;;
+      provider-service-created|watchdog-service-created) recovery_marker_payload="transaction-created" ;;
+      new-manual.pid) recovery_marker_payload="" ;;
+    esac
+    verify_recovery_artifact "$RECOVERY_DIR/$recovery_marker" "$recovery_marker_payload" || exit 70
+  fi
+done
 # shellcheck disable=SC1091
 . "$RECOVERY_DIR/state.sh" || exit 70
+REC_PROVIDER_LABEL="${REC_PROVIDER_LABEL:-live.streamvc.macprovider}"
 
 recovery_log() { printf '[macprovider-recovery] %s\n' "$*" >&2; }
 acquire_recovery_claim() {
@@ -1415,16 +1850,180 @@ paths_match() {
     *) return 1 ;;
   esac
 }
+stage_restore_file() {
+  source_path="$1"
+  candidate_path="$2"
+  python3 - "$source_path" "$candidate_path" <<'PY'
+import ctypes
+import errno
+import os
+import stat
+import sys
+
+source_path, candidate_path = sys.argv[1:]
+uid = os.getuid()
+nofollow = getattr(os, "O_NOFOLLOW", 0)
+max_bytes = 1024 * 1024
+
+
+def no_acl(fd):
+    if sys.platform != "darwin":
+        return True
+    try:
+        libc = ctypes.CDLL(None, use_errno=True)
+        get_acl = libc.acl_get_fd_np
+        get_acl.argtypes = [ctypes.c_int, ctypes.c_int]
+        get_acl.restype = ctypes.c_void_p
+        free_acl = libc.acl_free
+        free_acl.argtypes = [ctypes.c_void_p]
+        free_acl.restype = ctypes.c_int
+    except (AttributeError, OSError):
+        return False
+    ctypes.set_errno(0)
+    acl = get_acl(fd, 0x00000100)
+    if acl:
+        free_acl(acl)
+        return False
+    return ctypes.get_errno() in (0, errno.ENOENT)
+
+
+def validate(fd, info):
+    if (
+        not stat.S_ISREG(info.st_mode)
+        or info.st_uid != uid
+        or info.st_nlink != 1
+        or info.st_mode & (stat.S_IWGRP | stat.S_IWOTH)
+        or info.st_size < 0
+        or info.st_size > max_bytes
+        or not no_acl(fd)
+    ):
+        raise SystemExit("unsafe restore file")
+
+
+source_fd = os.open(source_path, os.O_RDONLY | nofollow)
+try:
+    before = os.fstat(source_fd)
+    validate(source_fd, before)
+    payload = bytearray()
+    while len(payload) < before.st_size:
+        chunk = os.read(source_fd, min(65536, before.st_size - len(payload)))
+        if not chunk:
+            raise SystemExit("restore source was truncated")
+        payload.extend(chunk)
+    after = os.fstat(source_fd)
+    path_info = os.lstat(source_path)
+    if (
+        (after.st_dev, after.st_ino, after.st_size, after.st_mtime_ns, after.st_ctime_ns)
+        != (before.st_dev, before.st_ino, before.st_size, before.st_mtime_ns, before.st_ctime_ns)
+        or stat.S_ISLNK(path_info.st_mode)
+        or (path_info.st_dev, path_info.st_ino) != (before.st_dev, before.st_ino)
+    ):
+        raise SystemExit("restore source changed during copy")
+finally:
+    os.close(source_fd)
+
+parent_fd = os.open(os.path.dirname(candidate_path), os.O_RDONLY | os.O_DIRECTORY | nofollow)
+temporary_name = ".%s.restore-%s" % (os.path.basename(candidate_path), os.urandom(16).hex())
+temporary_fd = None
+try:
+    parent_info = os.fstat(parent_fd)
+    if (
+        not stat.S_ISDIR(parent_info.st_mode)
+        or parent_info.st_uid != uid
+        or parent_info.st_mode & (stat.S_IWGRP | stat.S_IWOTH)
+        or not no_acl(parent_fd)
+    ):
+        raise SystemExit("unsafe restore destination")
+    temporary_fd = os.open(
+        temporary_name,
+        os.O_WRONLY | os.O_CREAT | os.O_EXCL | nofollow,
+        0o600,
+        dir_fd=parent_fd,
+    )
+    offset = 0
+    while offset < len(payload):
+        offset += os.write(temporary_fd, payload[offset:])
+    os.fsync(temporary_fd)
+    os.close(temporary_fd)
+    temporary_fd = None
+    os.replace(temporary_name, os.path.basename(candidate_path), src_dir_fd=parent_fd, dst_dir_fd=parent_fd)
+    temporary_name = None
+    os.fsync(parent_fd)
+    verify_fd = os.open(os.path.basename(candidate_path), os.O_RDONLY | nofollow, dir_fd=parent_fd)
+    try:
+        verify = os.fstat(verify_fd)
+        validate(verify_fd, verify)
+        if os.read(verify_fd, len(payload) + 1) != payload:
+            raise SystemExit("restore destination changed")
+    finally:
+        os.close(verify_fd)
+finally:
+    if temporary_fd is not None:
+        os.close(temporary_fd)
+    if temporary_name is not None:
+        try:
+            os.unlink(temporary_name, dir_fd=parent_fd)
+        except FileNotFoundError:
+            pass
+    os.close(parent_fd)
+PY
+}
+stage_restore_symlink() {
+  source_path="$1"
+  candidate_path="$2"
+  python3 - "$source_path" "$candidate_path" <<'PY'
+import os
+import stat
+import sys
+
+source_path, candidate_path = sys.argv[1:]
+source_info = os.lstat(source_path)
+if not stat.S_ISLNK(source_info.st_mode) or source_info.st_uid != os.getuid():
+    raise SystemExit("unsafe restore symlink")
+target = os.readlink(source_path)
+parent_fd = os.open(os.path.dirname(candidate_path), os.O_RDONLY | os.O_DIRECTORY | getattr(os, "O_NOFOLLOW", 0))
+temporary_name = ".%s.restore-%s" % (os.path.basename(candidate_path), os.urandom(16).hex())
+try:
+    os.symlink(target, temporary_name, dir_fd=parent_fd)
+    os.replace(temporary_name, os.path.basename(candidate_path), src_dir_fd=parent_fd, dst_dir_fd=parent_fd)
+    temporary_name = None
+    os.fsync(parent_fd)
+    if os.readlink(os.path.join(os.path.dirname(candidate_path), os.path.basename(candidate_path))) != target:
+        raise SystemExit("restore symlink changed")
+finally:
+    if temporary_name is not None:
+        try:
+            os.unlink(temporary_name, dir_fd=parent_fd)
+        except FileNotFoundError:
+            pass
+    os.close(parent_fd)
+PY
+}
+stage_restore_directory() {
+  source_path="$1"
+  candidate_path="$2"
+  python3 - "$source_path" "$candidate_path" <<'PY'
+import os
+import shutil
+import stat
+import sys
+
+source_path, candidate_path = sys.argv[1:]
+source_info = os.lstat(source_path)
+if not stat.S_ISDIR(source_info.st_mode) or source_info.st_uid != os.getuid():
+    raise SystemExit("unsafe restore directory")
+shutil.copytree(source_path, candidate_path, symlinks=True)
+os.chmod(candidate_path, 0o700)
+PY
+}
 stage_restore() {
   source_path="$1"
   candidate_path="$2"
   path_kind="$3"
-  parent_path="$(dirname "$candidate_path")" || return 1
-  mkdir -p "$parent_path" || return 1
   case "$path_kind" in
-    directory) cp -R "$source_path" "$candidate_path" || return 1 ;;
-    symlink) cp -P "$source_path" "$candidate_path" || return 1 ;;
-    file) cp -p "$source_path" "$candidate_path" || return 1 ;;
+    directory) stage_restore_directory "$source_path" "$candidate_path" || return 1 ;;
+    symlink) stage_restore_symlink "$source_path" "$candidate_path" || return 1 ;;
+    file) stage_restore_file "$source_path" "$candidate_path" || return 1 ;;
     *) return 1 ;;
   esac
   paths_match "$source_path" "$candidate_path" "$path_kind"
@@ -3029,6 +3628,39 @@ recovery_failed() {
   recovery_log "Recovery data was preserved. Retry exactly: bash '$RECOVERY_DIR/recover.sh'"
   exit 70
 }
+service_loaded() {
+  launchctl print "gui/$REC_UID/$1" >/dev/null 2>&1
+}
+service_identity_matches() {
+  service_label="$1"
+  expected_path="$2"
+  expected_program="$3"
+  alternate_program="$4"
+  service_details="$(launchctl print "gui/$REC_UID/$service_label" 2>/dev/null | head -c 65537)" || return 1
+  [ "${#service_details}" -le 65536 ] || return 1
+  program_count="$(printf '%s\n' "$service_details" | awk '/^[[:space:]]*program = / { count++ } END { print count + 0 }')"
+  path_count="$(printf '%s\n' "$service_details" | awk '/^[[:space:]]*path = / { count++ } END { print count + 0 }')"
+  [ "$program_count" -eq 1 ] || return 1
+  [ "$path_count" -eq 1 ] || return 1
+  service_program="$(printf '%s\n' "$service_details" | sed -n 's/^[[:space:]]*program = //p')"
+  service_path="$(printf '%s\n' "$service_details" | sed -n 's/^[[:space:]]*path = //p')"
+  [ "$service_path" = "$expected_path" ] || return 1
+  [ "$service_program" = "$expected_program" ] || [ "$service_program" = "$alternate_program" ]
+}
+stop_loaded_service() {
+  service_label="$1"
+  expected_path="$2"
+  expected_program="$3"
+  alternate_program="$4"
+  failure_message="$5"
+  if ! service_loaded "$service_label"; then
+    return 0
+  fi
+  service_identity_matches "$service_label" "$expected_path" "$expected_program" "$alternate_program" \
+    || recovery_failed "$failure_message has an unexpected launchd identity"
+  launchctl bootout "gui/$REC_UID/$service_label" >/dev/null 2>&1 \
+    || recovery_failed "$failure_message could not be stopped"
+}
 
 # Before the durable cutover marker exists, the installer has not touched the
 # provider binary, config, launchd service, or manual process. Only the
@@ -3036,16 +3668,17 @@ recovery_failed() {
 # guard service without booting out or replacing the healthy incumbent.
 if [ ! -e "$RECOVERY_DIR/cutover-started" ] && [ ! -L "$RECOVERY_DIR/cutover-started" ]; then
   if [ "$REC_SERVICE_WAS_ACTIVE" -eq 1 ]; then
-    if ! launchctl print "gui/$REC_UID/live.streamvc.macprovider" >/dev/null 2>&1; then
+    if ! launchctl print "gui/$REC_UID/$REC_PROVIDER_LABEL" >/dev/null 2>&1; then
       [ "$REC_HAD_PLIST" -eq 1 ] \
         || recovery_failed "the prior provider service disappeared before cutover and no launchd plist was preserved"
       launchctl bootstrap "gui/$REC_UID" "$REC_PLIST_PATH" >/dev/null 2>&1 \
         || recovery_failed "could not restore the unexpectedly inactive pre-cutover provider service"
-      launchctl kickstart -k "gui/$REC_UID/live.streamvc.macprovider" >/dev/null 2>&1 \
+      launchctl kickstart -k "gui/$REC_UID/$REC_PROVIDER_LABEL" >/dev/null 2>&1 \
         || recovery_failed "could not start the unexpectedly inactive pre-cutover provider service"
     fi
-    launchctl print "gui/$REC_UID/live.streamvc.macprovider" >/dev/null 2>&1 \
-      || recovery_failed "pre-cutover provider service is not active"
+    service_identity_matches "$REC_PROVIDER_LABEL" "$REC_PLIST_PATH" \
+      "$REC_INSTALL_DIR/macprovider-cli" "$REC_BINARY_PATH" \
+      || recovery_failed "pre-cutover provider service has an unexpected identity"
   fi
   if [ "$REC_WATCHDOG_WAS_ACTIVE" -eq 1 ]; then
     if ! launchctl print "gui/$REC_UID/$REC_WATCHDOG_LABEL" >/dev/null 2>&1; then
@@ -3056,8 +3689,9 @@ if [ ! -e "$RECOVERY_DIR/cutover-started" ] && [ ! -L "$RECOVERY_DIR/cutover-sta
     fi
     launchctl kickstart -k "gui/$REC_UID/$REC_WATCHDOG_LABEL" >/dev/null 2>&1 \
       || recovery_failed "could not start the pre-cutover watchdog service"
-    launchctl print "gui/$REC_UID/$REC_WATCHDOG_LABEL" >/dev/null 2>&1 \
-      || recovery_failed "pre-cutover watchdog service is not active"
+    service_identity_matches "$REC_WATCHDOG_LABEL" "$REC_WATCHDOG_PLIST_PATH" \
+      "$REC_WATCHDOG_DIR/macprovider-health-monitor" "$REC_WATCHDOG_DIR/watchdog.sh" \
+      || recovery_failed "pre-cutover watchdog service has an unexpected identity"
   fi
   recovery_log "Cutover never started; incumbent provider files and process were left untouched."
   exit 0
@@ -3217,16 +3851,21 @@ for directory in {parent, provider_id_parent}:
 PY
 }
 
-RUN_ID="$(date -u +%Y%m%dT%H%M%SZ)-$$" || recovery_failed "could not create recovery run id"
-INSTALL_CANDIDATE="${REC_INSTALL_DIR}.macprovider-restore.$$"
-BINARY_CANDIDATE="${REC_BINARY_PATH}.macprovider-restore.$$"
-CONFIG_CANDIDATE="${REC_CONFIG_PATH}.macprovider-restore.$$"
-PROVIDER_ID_CANDIDATE="${REC_PROVIDER_ID_PATH}.macprovider-restore.$$"
-RECOMMENDATION_CANDIDATE="${REC_RECOMMENDATION_PATH}.macprovider-restore.$$"
-PLIST_CANDIDATE="${REC_PLIST_PATH}.macprovider-restore.$$"
-WATCHDOG_DIR_CANDIDATE="${REC_WATCHDOG_DIR}.macprovider-restore.$$"
-WATCHDOG_PLIST_CANDIDATE="${REC_WATCHDOG_PLIST_PATH}.macprovider-restore.$$"
-MANIFEST_CANDIDATE="${REC_MANIFEST_PATH}.macprovider-restore.$$"
+RUN_ID="$(python3 -c 'import secrets; print(secrets.token_hex(16))')" \
+  || recovery_failed "could not create recovery run id"
+RESTORE_STAGING_DIR="$(mktemp -d "$RECOVERY_DIR/restore.XXXXXX")" \
+  || recovery_failed "could not create randomized restore staging directory"
+chmod 700 "$RESTORE_STAGING_DIR" \
+  || recovery_failed "could not secure randomized restore staging directory"
+INSTALL_CANDIDATE="$RESTORE_STAGING_DIR/install-dir"
+BINARY_CANDIDATE="$RESTORE_STAGING_DIR/binary-path"
+CONFIG_CANDIDATE="$RESTORE_STAGING_DIR/config.yaml"
+PROVIDER_ID_CANDIDATE="$RESTORE_STAGING_DIR/provider_id"
+RECOMMENDATION_CANDIDATE="$RESTORE_STAGING_DIR/last-recommendation.json"
+PLIST_CANDIDATE="$RESTORE_STAGING_DIR/provider.plist"
+WATCHDOG_DIR_CANDIDATE="$RESTORE_STAGING_DIR/watchdog-dir"
+WATCHDOG_PLIST_CANDIDATE="$RESTORE_STAGING_DIR/watchdog.plist"
+MANIFEST_CANDIDATE="$RESTORE_STAGING_DIR/install-manifest.json"
 FAILED_CURRENT_DIR="$RECOVERY_DIR/failed-current/$RUN_ID"
 
 # Prove every requested restore can be copied byte-for-byte before touching the
@@ -3264,11 +3903,37 @@ fi
 
 mkdir -p "$FAILED_CURRENT_DIR" || recovery_failed "could not create durable failed-install storage"
 chmod 700 "$RECOVERY_DIR/failed-current" "$FAILED_CURRENT_DIR" || recovery_failed "could not secure durable failed-install storage"
-if launchctl print "gui/$REC_UID/live.streamvc.macprovider" >/dev/null 2>&1; then
-  launchctl bootout "gui/$REC_UID" "$REC_PLIST_PATH" >/dev/null 2>&1 || recovery_failed "could not stop the current provider service"
+if [ "$REC_SERVICE_WAS_ACTIVE" -eq 1 ]; then
+  [ "$REC_HAD_PLIST" -eq 1 ] || recovery_failed "the prior provider service was active but no recoverable plist was preserved"
+  if [ -f "$RECOVERY_DIR/provider-service-created" ] && [ ! -L "$RECOVERY_DIR/provider-service-created" ]; then
+    stop_loaded_service "$REC_PROVIDER_LABEL" "$REC_PLIST_PATH" \
+      "$REC_INSTALL_DIR/macprovider-cli" "$REC_BINARY_PATH" \
+      "the transaction provider service"
+  else
+    stop_loaded_service "$REC_PROVIDER_LABEL" "$REC_PLIST_PATH" \
+      "$REC_INSTALL_DIR/macprovider-cli" "$REC_BINARY_PATH" \
+      "the incumbent provider service"
+  fi
+else
+  if [ -f "$RECOVERY_DIR/provider-service-created" ] && [ ! -L "$RECOVERY_DIR/provider-service-created" ]; then
+    stop_loaded_service "$REC_PROVIDER_LABEL" "$REC_PLIST_PATH" \
+      "$REC_INSTALL_DIR/macprovider-cli" "$REC_BINARY_PATH" \
+      "the transaction provider service"
+  fi
+  service_loaded "$REC_PROVIDER_LABEL" && recovery_failed "provider service is active even though it was inactive before the failed install"
 fi
-if launchctl print "gui/$REC_UID/$REC_WATCHDOG_LABEL" >/dev/null 2>&1; then
-  launchctl bootout "gui/$REC_UID" "$REC_WATCHDOG_PLIST_PATH" >/dev/null 2>&1 || recovery_failed "could not stop the current watchdog service"
+if [ "$REC_WATCHDOG_WAS_ACTIVE" -eq 1 ]; then
+  [ "$REC_HAD_WATCHDOG_PLIST" -eq 1 ] || recovery_failed "the prior watchdog was active but no recoverable plist was preserved"
+  stop_loaded_service "$REC_WATCHDOG_LABEL" "$REC_WATCHDOG_PLIST_PATH" \
+    "$REC_WATCHDOG_DIR/macprovider-health-monitor" "$REC_WATCHDOG_DIR/watchdog.sh" \
+    "the transaction watchdog service"
+else
+  if [ -f "$RECOVERY_DIR/watchdog-service-created" ] && [ ! -L "$RECOVERY_DIR/watchdog-service-created" ]; then
+    stop_loaded_service "$REC_WATCHDOG_LABEL" "$REC_WATCHDOG_PLIST_PATH" \
+      "$REC_WATCHDOG_DIR/macprovider-health-monitor" "$REC_WATCHDOG_DIR/watchdog.sh" \
+      "the transaction watchdog service"
+  fi
+  service_loaded "$REC_WATCHDOG_LABEL" && recovery_failed "watchdog service is active even though it was inactive before the failed install"
 fi
 if [ -s "$RECOVERY_DIR/new-manual.pid" ]; then
   NEW_MANUAL_PID="$(cat "$RECOVERY_DIR/new-manual.pid")"
@@ -3312,17 +3977,19 @@ restore_lifecycle_state || recovery_failed "could not restore the previous lifec
 reconcile_lifecycle_lease || recovery_failed "could not reconcile the lifecycle lease after rollback"
 
 if [ "$REC_SERVICE_WAS_DISABLED" -eq 1 ]; then
-  launchctl disable "gui/$REC_UID/live.streamvc.macprovider" >/dev/null 2>&1 || recovery_failed "could not restore the disabled provider service state"
+  launchctl disable "gui/$REC_UID/$REC_PROVIDER_LABEL" >/dev/null 2>&1 || recovery_failed "could not restore the disabled provider service state"
 else
-  launchctl enable "gui/$REC_UID/live.streamvc.macprovider" >/dev/null 2>&1 || recovery_failed "could not restore the enabled provider service state"
+  launchctl enable "gui/$REC_UID/$REC_PROVIDER_LABEL" >/dev/null 2>&1 || recovery_failed "could not restore the enabled provider service state"
 fi
 if [ "$REC_SERVICE_WAS_ACTIVE" -eq 1 ]; then
   [ "$REC_HAD_PLIST" -eq 1 ] || recovery_failed "previous service was active but no previous plist was preserved"
   launchctl bootstrap "gui/$REC_UID" "$REC_PLIST_PATH" >/dev/null 2>&1 || recovery_failed "could not bootstrap the previous provider service"
-  launchctl kickstart -k "gui/$REC_UID/live.streamvc.macprovider" >/dev/null 2>&1 || recovery_failed "could not kickstart the previous provider service"
-  launchctl print "gui/$REC_UID/live.streamvc.macprovider" >/dev/null 2>&1 || recovery_failed "previous provider service did not become active"
+  launchctl kickstart -k "gui/$REC_UID/$REC_PROVIDER_LABEL" >/dev/null 2>&1 || recovery_failed "could not kickstart the previous provider service"
+  service_identity_matches "$REC_PROVIDER_LABEL" "$REC_PLIST_PATH" \
+    "$REC_INSTALL_DIR/macprovider-cli" "$REC_BINARY_PATH" \
+    || recovery_failed "previous provider service has an unexpected identity"
 else
-  if launchctl print "gui/$REC_UID/live.streamvc.macprovider" >/dev/null 2>&1; then
+  if launchctl print "gui/$REC_UID/$REC_PROVIDER_LABEL" >/dev/null 2>&1; then
     recovery_failed "provider service is active even though it was inactive before the failed install"
   fi
 fi
@@ -3336,7 +4003,9 @@ if [ "$REC_WATCHDOG_WAS_ACTIVE" -eq 1 ]; then
   [ "$REC_HAD_WATCHDOG_PLIST" -eq 1 ] || recovery_failed "previous watchdog was active but no previous plist was preserved"
   launchctl bootstrap "gui/$REC_UID" "$REC_WATCHDOG_PLIST_PATH" >/dev/null 2>&1 || recovery_failed "could not bootstrap the previous watchdog service"
   launchctl kickstart -k "gui/$REC_UID/$REC_WATCHDOG_LABEL" >/dev/null 2>&1 || recovery_failed "could not kickstart the previous watchdog service"
-  launchctl print "gui/$REC_UID/$REC_WATCHDOG_LABEL" >/dev/null 2>&1 || recovery_failed "previous watchdog service did not become active"
+  service_identity_matches "$REC_WATCHDOG_LABEL" "$REC_WATCHDOG_PLIST_PATH" \
+    "$REC_WATCHDOG_DIR/macprovider-health-monitor" "$REC_WATCHDOG_DIR/watchdog.sh" \
+    || recovery_failed "previous watchdog service has an unexpected identity"
 else
   if launchctl print "gui/$REC_UID/$REC_WATCHDOG_LABEL" >/dev/null 2>&1; then
     recovery_failed "watchdog service is active even though it was inactive before the failed install"
@@ -3508,12 +4177,12 @@ PY
 fi
 
 recovery_log "Previous provider, recommendation, watchdog, manifest, service, and manual-process states were restored and verified."
+rm -rf "$RESTORE_STAGING_DIR" || recovery_failed "could not retire randomized restore staging directory"
 exit 0
 RECOVERY_SCRIPT
-  chmod 700 "$recovery_script" || return 1
   bash -n "$recovery_script" || return 1
   observer_script="$recovery_dir/observe.sh"
-  cat > "$observer_script" <<'OBSERVER_SCRIPT'
+  write_atomic_install_file "$observer_script" 0700 <<'OBSERVER_SCRIPT'
 #!/usr/bin/env bash
 set -u
 
@@ -3575,7 +4244,6 @@ finally:
     os.close(lock_fd)
 PY
 OBSERVER_SCRIPT
-  chmod 700 "$observer_script" || return 1
   bash -n "$observer_script" || return 1
   [ -s "$state_path" ] && [ -s "$recovery_script" ] && [ -s "$observer_script" ]
 }
@@ -3589,14 +4257,14 @@ arm_install_recovery_agent() {
   [ -n "$INSTALL_TX_BACKUP" ] && [ -x "$INSTALL_TX_BACKUP/observe.sh" ] || return 70
   mkdir -p "$(dirname "$INSTALL_RECOVERY_PLIST_PATH")" || return 70
   disarm_install_recovery_agent || return 70
-  plist_temp="${INSTALL_RECOVERY_PLIST_PATH}.tmp.$$"
-  python3 - "$plist_temp" "$INSTALL_RECOVERY_LABEL" "$INSTALL_TX_BACKUP/observe.sh" \
-    "$INSTALL_TX_BACKUP/recovery-observer.out.log" "$INSTALL_TX_BACKUP/recovery-observer.err.log" <<'PY'
-import os
+  python3 - "$INSTALL_RECOVERY_LABEL" "$INSTALL_TX_BACKUP/observe.sh" \
+    "$INSTALL_TX_BACKUP/recovery-observer.out.log" "$INSTALL_TX_BACKUP/recovery-observer.err.log" <<'PY' \
+    | write_atomic_install_file "$INSTALL_RECOVERY_PLIST_PATH" 0600 \
+    || return 70
 import plistlib
 import sys
 
-path, label, observer, stdout_path, stderr_path = sys.argv[1:]
+label, observer, stdout_path, stderr_path = sys.argv[1:]
 payload = {
     "Label": label,
     "ProgramArguments": ["/bin/bash", observer],
@@ -3605,13 +4273,8 @@ payload = {
     "StandardOutPath": stdout_path,
     "StandardErrorPath": stderr_path,
 }
-with open(path, "wb") as handle:
-    plistlib.dump(payload, handle, fmt=plistlib.FMT_XML, sort_keys=True)
-    handle.flush()
-    os.fsync(handle.fileno())
-os.chmod(path, 0o600)
+sys.stdout.buffer.write(plistlib.dumps(payload, fmt=plistlib.FMT_XML, sort_keys=True))
 PY
-  mv "$plist_temp" "$INSTALL_RECOVERY_PLIST_PATH" || return 70
   launchctl bootstrap "gui/$UID" "$INSTALL_RECOVERY_PLIST_PATH" >/dev/null 2>&1 || return 70
   launchctl kickstart -k "gui/$UID/$INSTALL_RECOVERY_LABEL" >/dev/null 2>&1 || return 70
 }
@@ -3821,7 +4484,7 @@ begin_install_transaction() {
   INSTALL_TX_BACKUP="$CONFIG_DIR/install-recovery-$recovery_id"
   mkdir -p "$CONFIG_DIR" || die 70 "could not create config directory for durable install recovery"
   mkdir "$recovery_staging" || die 70 "could not create durable install recovery staging directory: $recovery_staging"
-  chmod 700 "$recovery_staging" \
+  secure_private_directory "$recovery_staging" \
     || die 70 "could not secure durable install recovery staging directory: $recovery_staging"
   if [ -d "$INSTALL_DIR" ]; then
     stage_install_tx_path "$INSTALL_DIR" "$recovery_staging/install-dir" directory \
@@ -3856,7 +4519,8 @@ begin_install_transaction() {
     INSTALL_TX_HAD_RECOMMENDATION=1
   fi
   if [ -f "$PLIST_PATH" ]; then
-    stage_install_tx_path "$PLIST_PATH" "$recovery_staging/provider.plist" file \
+    stage_install_tx_plist "$PLIST_PATH" "$recovery_staging/provider.plist" \
+      "$PROVIDER_LABEL" "$INSTALL_DIR/macprovider-cli" "$BINARY_PATH" \
       || die 70 "could not stage and verify the previous launchd plist; current install was not changed (partial recovery data: $recovery_staging)"
     INSTALL_TX_HAD_PLIST=1
   fi
@@ -3866,7 +4530,8 @@ begin_install_transaction() {
     INSTALL_TX_HAD_WATCHDOG_DIR=1
   fi
   if [ -f "$WATCHDOG_PLIST_PATH" ]; then
-    stage_install_tx_path "$WATCHDOG_PLIST_PATH" "$recovery_staging/watchdog.plist" file \
+    stage_install_tx_plist "$WATCHDOG_PLIST_PATH" "$recovery_staging/watchdog.plist" \
+      "$WATCHDOG_LABEL" "$WATCHDOG_PATH" "$WATCHDOG_DIR/watchdog.sh" \
       || die 70 "could not stage and verify the previous watchdog plist; current install was not changed (partial recovery data: $recovery_staging)"
     INSTALL_TX_HAD_WATCHDOG_PLIST=1
   fi
@@ -3913,7 +4578,7 @@ begin_install_transaction() {
   arm_install_recovery_agent \
     || die 70 "could not arm independent interrupted-install recovery before live mutation"
   if [ "$INSTALL_TX_WATCHDOG_WAS_ACTIVE" -eq 1 ]; then
-    launchctl bootout "gui/$UID" "$WATCHDOG_PLIST_PATH" >/dev/null 2>&1 \
+    reclaim_launchd_service "$WATCHDOG_LABEL" \
       || die 70 "could not suspend the existing watchdog for the protected install transaction"
   fi
 }
@@ -3923,30 +4588,84 @@ mark_install_cutover_started() {
   [ "$INSTALL_TX_ACTIVE" -eq 1 ] && [ -n "$INSTALL_TX_BACKUP" ] \
     || die 70 "install cutover cannot start without durable recovery"
   assert_install_lock_ownership
-  python3 - "$INSTALL_TX_BACKUP/cutover-started" <<'PY' \
+  write_install_tx_marker "$INSTALL_TX_BACKUP/cutover-started" "cutover-started" \
     || die 70 "could not durably mark install cutover before live provider mutation"
+  CUTOVER_STARTED=1
+}
+
+write_install_tx_marker() {
+  marker_path="$1"
+  marker_payload="${2:-transaction-created}"
+  python3 - "$marker_path" "$marker_payload" <<'PY'
+import ctypes
+import errno
 import os
 import stat
 import sys
 
-path = sys.argv[1]
+path, payload_text = sys.argv[1:]
+parent_path = os.path.dirname(path)
+marker_name = os.path.basename(path)
+directory_fd = os.open(
+    parent_path,
+    os.O_RDONLY | getattr(os, "O_DIRECTORY", 0) | getattr(os, "O_NOFOLLOW", 0),
+)
+directory_info = os.fstat(directory_fd)
+if (
+    not stat.S_ISDIR(directory_info.st_mode)
+    or directory_info.st_uid != os.getuid()
+    or directory_info.st_mode & (stat.S_IWGRP | stat.S_IWOTH)
+):
+    os.close(directory_fd)
+    raise RuntimeError("unsafe install transaction marker parent")
+if sys.platform == "darwin":
+    try:
+        libc = ctypes.CDLL(None, use_errno=True)
+        acl_get_fd_np = libc.acl_get_fd_np
+        acl_get_fd_np.argtypes = [ctypes.c_int, ctypes.c_int]
+        acl_get_fd_np.restype = ctypes.c_void_p
+        acl_free = libc.acl_free
+        acl_free.argtypes = [ctypes.c_void_p]
+        acl_free.restype = ctypes.c_int
+    except (AttributeError, OSError):
+        os.close(directory_fd)
+        raise RuntimeError("install transaction marker ACL API is unavailable")
+    ctypes.set_errno(0)
+    acl = acl_get_fd_np(directory_fd, 0x00000100)  # ACL_TYPE_EXTENDED
+    if acl:
+        acl_free(acl)
+        os.close(directory_fd)
+        raise RuntimeError("install transaction marker parent has an extended ACL")
+    if ctypes.get_errno() != errno.ENOENT:
+        os.close(directory_fd)
+        raise RuntimeError("install transaction marker parent ACL verification failed")
+
 flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL | getattr(os, "O_NOFOLLOW", 0)
-fd = os.open(path, flags, 0o600)
+fd = os.open(marker_name, flags, 0o600, dir_fd=directory_fd)
 try:
     info = os.fstat(fd)
-    if not stat.S_ISREG(info.st_mode) or info.st_uid != os.getuid() or info.st_nlink != 1:
-        raise RuntimeError("unsafe cutover marker")
-    os.write(fd, b"cutover-started\n")
+    if (
+        not stat.S_ISREG(info.st_mode)
+        or info.st_uid != os.getuid()
+        or info.st_nlink != 1
+        or info.st_mode & (stat.S_IWGRP | stat.S_IWOTH)
+    ):
+        raise RuntimeError("unsafe install transaction marker")
+    payload = (payload_text + "\n").encode("utf-8")
+    written = 0
+    while written < len(payload):
+        progress = os.write(fd, payload[written:])
+        if progress <= 0:
+            raise RuntimeError("install transaction marker write made no progress")
+        written += progress
     os.fsync(fd)
 finally:
     os.close(fd)
-directory_fd = os.open(os.path.dirname(path), os.O_RDONLY)
 try:
     os.fsync(directory_fd)
 finally:
     os.close(directory_fd)
 PY
-  CUTOVER_STARTED=1
 }
 
 discard_install_transaction_before_cutover() {
@@ -4252,7 +4971,8 @@ ensure_port_free() {
       esac
       capture_manual_provider_for_recovery "$holding_pids"
     fi
-    launchctl bootout "gui/$UID" "$PLIST_PATH" 2>/dev/null || true
+    reclaim_launchd_service "$PROVIDER_LABEL" \
+      || die 5 "could not reclaim existing provider launchd service"
     sleep 2
     if lsof -nP -iTCP:"$PORT" -sTCP:LISTEN -t 2>/dev/null | grep -q .; then
       log "Port $PORT still held after launchctl bootout; stopping each revalidated macprovider-cli PID."
@@ -4275,6 +4995,85 @@ ensure_port_free() {
   log "Note: env var must be on the bash side of the pipe, not the curl side:"
   log "  curl -fsSL https://get.streamvc.live/install.sh | MACPROVIDER_PORT=18080 bash"
   die 6 "port $PORT busy; macprovider-cli cannot bind"
+}
+
+# Reclaim by launchd service target rather than plist path. A standalone
+# install and Malibu share the provider label, so an older loaded job can
+# continue to own the label even after its plist path has been replaced.
+# A label-wide bootout is only allowed inside a durable install transaction
+# with an owner-validated prior plist snapshot. The print record is bounded
+# and its executable must be one of the provider/watchdog paths emitted by
+# this installer; otherwise an unrelated job cannot be stopped accidentally.
+reclaim_launchd_service() {
+  local label="$1"
+  local service_target="gui/$UID/$label"
+  local expected_program
+  local legacy_program
+  local expected_plist
+  local had_plist
+  case "$label" in
+    "$PROVIDER_LABEL")
+      expected_program="$INSTALL_DIR/macprovider-cli"
+      legacy_program="$BINARY_PATH"
+      expected_plist="$PLIST_PATH"
+      had_plist="${INSTALL_TX_HAD_PLIST:-0}"
+      ;;
+    "$WATCHDOG_LABEL")
+      expected_program="$WATCHDOG_PATH"
+      legacy_program="$WATCHDOG_DIR/watchdog.sh"
+      expected_plist="$WATCHDOG_PLIST_PATH"
+      had_plist="${INSTALL_TX_HAD_WATCHDOG_PLIST:-0}"
+      ;;
+    *)
+      log "Refusing to reclaim unknown launchd label: $label"
+      return 1
+      ;;
+  esac
+  local service_details
+  if ! service_details="$(launchctl print "$service_target" 2>/dev/null | head -c 65537)"; then
+    if [ -n "$service_details" ]; then
+      log "Refusing to reclaim $label because its launchd identity exceeded the inspection limit."
+      return 1
+    fi
+    # A fresh install has no incumbent plist. Absence of the label is safe;
+    # only a loaded incumbent requires a durable snapshot before bootout.
+    return 0
+  fi
+  [ -n "$service_details" ] || return 1
+  if [ "${#service_details}" -gt 65536 ]; then
+    log "Refusing to reclaim $label because its launchd identity exceeded the inspection limit."
+    return 1
+  fi
+  if [ "${INSTALL_TX_ACTIVE:-0}" -ne 1 ] || [ "$had_plist" -ne 1 ]; then
+    log "Refusing to reclaim loaded $label without a durable owner-safe recovery plist."
+    return 1
+  fi
+  local program_line
+  program_line="$(printf '%s\n' "$service_details" | sed -n 's/^[[:space:]]*program = //p' | head -n 1)"
+  if [ -z "$program_line" ]; then
+    log "Refusing to reclaim $label because launchd did not provide an executable identity."
+    return 1
+  fi
+  local program_count
+  program_count="$(printf '%s\n' "$service_details" | awk '/^[[:space:]]*program = / { count++ } END { print count + 0 }')"
+  if [ "$program_count" -ne 1 ]; then
+    log "Refusing to reclaim $label because launchd returned an ambiguous executable identity."
+    return 1
+  fi
+  local plist_path
+  plist_path="$(printf '%s\n' "$service_details" | sed -n 's/^[[:space:]]*path = //p' | head -n 1)"
+  local plist_path_count
+  plist_path_count="$(printf '%s\n' "$service_details" | awk '/^[[:space:]]*path = / { count++ } END { print count + 0 }')"
+  if [ "$plist_path_count" -ne 1 ] || [ "$plist_path" != "$expected_plist" ]; then
+    log "Refusing to reclaim $label because launchd plist identity is unexpected: ${plist_path:-<missing>}"
+    return 1
+  fi
+  if [ "$program_line" != "$expected_program" ] && [ "$program_line" != "$legacy_program" ]; then
+    log "Refusing to reclaim $label with unexpected executable: $program_line"
+    return 1
+  fi
+  log "Reclaiming existing $label launchd service before replacing its plist."
+  launchctl bootout "$service_target" >/dev/null 2>&1
 }
 
 prompt_yes_no() {
@@ -5596,7 +6395,7 @@ prepare_staged_config() {
 }
 
 activate_staged_config() {
-  if [ "${INSTALL_TX_ACTIVE:-0}" -eq 1 ]; then
+  if [ "${INSTALL_TX_ACTIVE:-0}" -eq 1 ] && [ -n "${INSTALL_TX_BACKUP:-}" ]; then
     assert_install_lock_ownership
   fi
   [ -n "$STAGED_CONFIG_PATH" ] && [ -f "$STAGED_CONFIG_PATH" ] \
@@ -6124,7 +6923,7 @@ use_fresh_recommendation_if_available() {
 }
 
 install_binary() {
-  if [ "${INSTALL_TX_ACTIVE:-0}" -eq 1 ]; then
+  if [ "${INSTALL_TX_ACTIVE:-0}" -eq 1 ] && [ -n "${INSTALL_TX_BACKUP:-}" ]; then
     assert_install_lock_ownership
   fi
   run mkdir -p "$BIN_DIR" "$INSTALL_DIR"
@@ -6239,6 +7038,125 @@ clear_quarantine() {
   fi
 }
 
+write_atomic_install_file() {
+  destination_path="$1"
+  destination_mode="${2:-0600}"
+  python3 - "$destination_path" "$destination_mode" 3<&0 <<'PY'
+import os
+import stat
+import sys
+import ctypes
+import errno
+
+destination_path, destination_mode = sys.argv[1:]
+payload = bytearray()
+while len(payload) <= 1024 * 1024:
+    chunk = os.read(3, 65536)
+    if not chunk:
+        break
+    payload.extend(chunk)
+if len(payload) > 1024 * 1024:
+    raise SystemExit("atomic install file is oversized")
+parent_path = os.path.dirname(destination_path)
+destination_name = os.path.basename(destination_path)
+directory_fd = os.open(
+    parent_path,
+    os.O_RDONLY | getattr(os, "O_DIRECTORY", 0) | getattr(os, "O_NOFOLLOW", 0),
+)
+directory_info = os.fstat(directory_fd)
+
+
+def verify_no_extended_acl(descriptor, label):
+    if sys.platform != "darwin":
+        return
+    try:
+        libc = ctypes.CDLL(None, use_errno=True)
+        acl_get_fd_np = libc.acl_get_fd_np
+        acl_get_fd_np.argtypes = [ctypes.c_int, ctypes.c_int]
+        acl_get_fd_np.restype = ctypes.c_void_p
+        acl_free = libc.acl_free
+        acl_free.argtypes = [ctypes.c_void_p]
+        acl_free.restype = ctypes.c_int
+    except (AttributeError, OSError):
+        raise SystemExit("atomic install file ACL API is unavailable")
+    ctypes.set_errno(0)
+    acl = acl_get_fd_np(descriptor, 0x00000100)  # ACL_TYPE_EXTENDED
+    if acl:
+        acl_free(acl)
+        raise SystemExit("%s has an extended ACL" % label)
+    if ctypes.get_errno() != errno.ENOENT:
+        raise SystemExit("%s ACL verification failed" % label)
+
+
+if (
+    not stat.S_ISDIR(directory_info.st_mode)
+    or directory_info.st_uid != os.getuid()
+    or directory_info.st_nlink < 1
+    or directory_info.st_mode & (stat.S_IWGRP | stat.S_IWOTH)
+):
+    os.close(directory_fd)
+    raise SystemExit("atomic install file parent is unsafe")
+verify_no_extended_acl(directory_fd, "atomic install file parent")
+
+temporary_name = ".%s.install-%s" % (destination_name, os.urandom(16).hex())
+flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL | getattr(os, "O_NOFOLLOW", 0)
+temporary_fd = None
+
+try:
+    temporary_fd = os.open(temporary_name, flags, 0o600, dir_fd=directory_fd)
+    try:
+        os.fchmod(temporary_fd, int(destination_mode, 8) & ~0o022)
+        written = 0
+        while written < len(payload):
+            progress = os.write(temporary_fd, payload[written:])
+            if progress <= 0:
+                raise SystemExit("atomic install file write made no progress")
+            written += progress
+        verify_no_extended_acl(temporary_fd, "atomic install file temporary")
+        os.fsync(temporary_fd)
+    finally:
+        os.close(temporary_fd)
+        temporary_fd = None
+    os.replace(
+        temporary_name,
+        destination_name,
+        src_dir_fd=directory_fd,
+        dst_dir_fd=directory_fd,
+    )
+    temporary_name = None
+    os.fsync(directory_fd)
+    verify_fd = os.open(
+        destination_name,
+        os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0),
+        dir_fd=directory_fd,
+    )
+    try:
+        info = os.fstat(verify_fd)
+        if (
+            not stat.S_ISREG(info.st_mode)
+            or info.st_uid != os.getuid()
+            or info.st_nlink != 1
+            or info.st_mode & (stat.S_IWGRP | stat.S_IWOTH)
+            or info.st_size != len(payload)
+        ):
+            raise SystemExit("atomic install file verification failed")
+        verify_no_extended_acl(verify_fd, "atomic install file destination")
+        if os.read(verify_fd, len(payload) + 1) != payload:
+            raise SystemExit("atomic install file contents changed")
+    finally:
+        os.close(verify_fd)
+finally:
+    if temporary_fd is not None:
+        os.close(temporary_fd)
+    if temporary_name is not None:
+        try:
+            os.unlink(temporary_name, dir_fd=directory_fd)
+        except FileNotFoundError:
+            pass
+    os.close(directory_fd)
+PY
+}
+
 install_plist() {
   if [ "${INSTALL_TX_ACTIVE:-0}" -eq 1 ]; then
     assert_install_lock_ownership
@@ -6255,16 +7173,23 @@ install_plist() {
   run mkdir -p "$(dirname "$PLIST_PATH")" "$LOG_DIR"
   if [ "$DRY_RUN" -eq 1 ]; then
     log "Would render launchd plist to $PLIST_PATH"
-    log "Would enable launchd service: launchctl enable gui/$UID/live.streamvc.macprovider"
+    log "Would enable launchd service: launchctl enable gui/$UID/$PROVIDER_LABEL"
     log "Would bootstrap with: launchctl bootstrap gui/$UID $PLIST_PATH"
     return
   fi
 
-  render_plist "$model" "$provider_id" "$coordinator_url" > "$PLIST_PATH"
+  reclaim_launchd_service "$PROVIDER_LABEL" \
+    || die 5 "could not reclaim existing provider launchd service"
+  render_plist "$model" "$provider_id" "$coordinator_url" \
+    | write_atomic_install_file "$PLIST_PATH" \
+    || die 5 "could not publish rendered launchd plist safely"
 
   plutil -lint "$PLIST_PATH" >/dev/null || die 5 "rendered launchd plist is invalid"
-  launchctl bootout "gui/$UID" "$PLIST_PATH" >/dev/null 2>&1 || true
-  launchctl enable "gui/$UID/live.streamvc.macprovider" || die 5 "failed to enable launchd service"
+  launchctl enable "gui/$UID/$PROVIDER_LABEL" || die 5 "failed to enable launchd service"
+  if [ "${INSTALL_TX_ACTIVE:-0}" -eq 1 ] && [ -n "${INSTALL_TX_BACKUP:-}" ]; then
+    write_install_tx_marker "$INSTALL_TX_BACKUP/provider-service-created" \
+      || die 70 "could not durably record the provider launchd mutation"
+  fi
   launchctl bootstrap "gui/$UID" "$PLIST_PATH" || die 5 "failed to load launchd service"
   LAUNCHD_INSTALLED=1
 }
@@ -6329,7 +7254,7 @@ EOF
 # / blank-line normalization) with `ops/macprovider-watchdog/watchdog.sh`.
 # `scripts/test-watchdog-inline-drift.sh` enforces this in CI.
 write_watchdog_script() {
-  cat <<'WATCHDOG_EOF' > "$WATCHDOG_PATH"
+  write_atomic_install_file "$WATCHDOG_PATH" 0755 <<'WATCHDOG_EOF'
 #!/usr/bin/env bash
 # macprovider-watchdog: local provider liveness monitor plus
 # auto-update rollback observer.
@@ -7818,7 +8743,6 @@ main() {
 
 main "$@"
 WATCHDOG_EOF
-  chmod 0755 "$WATCHDOG_PATH"
 }
 
 render_watchdog_plist() {
@@ -7896,17 +8820,24 @@ install_watchdog() {
   fi
   log "Installing watchdog LaunchAgent (operator-visibility safety net for iss-189-class wedges)."
   mkdir -p "$WATCHDOG_DIR" "$LOG_DIR" "$(dirname "$WATCHDOG_PLIST_PATH")"
+  reclaim_launchd_service "$WATCHDOG_LABEL" \
+    || die 5 "could not reclaim existing watchdog launchd service"
   legacy_watchdog="$WATCHDOG_DIR/watchdog.sh"
   if [ -f "$legacy_watchdog" ] && [ "$legacy_watchdog" != "$WATCHDOG_PATH" ]; then
     rm -f "$legacy_watchdog"
   fi
   write_watchdog_script
-  render_watchdog_plist "$coordinator_url" > "$WATCHDOG_PLIST_PATH"
+  render_watchdog_plist "$coordinator_url" \
+    | write_atomic_install_file "$WATCHDOG_PLIST_PATH" \
+    || die 5 "could not publish rendered watchdog plist safely"
   plutil -lint "$WATCHDOG_PLIST_PATH" >/dev/null \
     || die 5 "rendered watchdog plist is invalid"
-  launchctl bootout "gui/$UID" "$WATCHDOG_PLIST_PATH" >/dev/null 2>&1 || true
   launchctl enable "gui/$UID/$WATCHDOG_LABEL" \
     || die 5 "failed to enable watchdog launchd service"
+  if [ "${INSTALL_TX_ACTIVE:-0}" -eq 1 ] && [ -n "${INSTALL_TX_BACKUP:-}" ]; then
+    write_install_tx_marker "$INSTALL_TX_BACKUP/watchdog-service-created" \
+      || die 70 "could not durably record the watchdog launchd mutation"
+  fi
   launchctl bootstrap "gui/$UID" "$WATCHDOG_PLIST_PATH" \
     || die 5 "failed to load watchdog launchd service"
   WATCHDOG_INSTALLED=1
@@ -7931,7 +8862,7 @@ write_install_manifest() {
   elif [ "$WATCHDOG_INSTALLED" -eq 1 ]; then
     labels_json='["live.streamvc.macprovider-watchdog"]'
   fi
-  cat > "$MANIFEST_PATH" <<EOF
+  write_atomic_install_file "$MANIFEST_PATH" 0600 <<EOF
 {
   "install_prefix": $(json_escape "$INSTALL_DIR"),
   "binary_path": $(json_escape "$INSTALL_DIR/macprovider-cli"),
@@ -7949,7 +8880,6 @@ write_install_manifest() {
   "version": $(json_escape "$version")
 }
 EOF
-  chmod 600 "$MANIFEST_PATH" 2>/dev/null || true
 }
 
 start_manual_service() {
@@ -7972,10 +8902,8 @@ start_manual_service() {
   ) > "$TMPDIR_PATH/manual.pid"
   MANUAL_PID="$(cat "$TMPDIR_PATH/manual.pid")"
   if [ "$INSTALL_TX_ACTIVE" -eq 1 ]; then
-    printf '%s\n' "$MANUAL_PID" > "$INSTALL_TX_BACKUP/new-manual.pid" \
+    printf '%s\n' "$MANUAL_PID" | write_atomic_install_file "$INSTALL_TX_BACKUP/new-manual.pid" 0600 \
       || die 70 "could not durably record the manual provider process for rollback"
-    chmod 600 "$INSTALL_TX_BACKUP/new-manual.pid" \
-      || die 70 "could not secure the manual provider rollback record"
   fi
 }
 

--- a/phase3-binary/dist/install.sh
+++ b/phase3-binary/dist/install.sh
@@ -169,6 +169,10 @@ validate_install_dir() {
 import os
 import stat
 import sys
+import ctypes
+import errno
+import grp
+import re
 
 raw, raw_home = sys.argv[1:]
 if not raw.startswith("/"):
@@ -187,6 +191,70 @@ except ValueError:
     raise SystemExit("install directory must be inside HOME")
 
 uid = os.getuid()
+
+def safe_directory_acl(path):
+    if sys.platform != "darwin":
+        return True
+    try:
+        libc = ctypes.CDLL(None, use_errno=True)
+        acl_get_fd_np = libc.acl_get_fd_np
+        acl_get_fd_np.argtypes = [ctypes.c_int, ctypes.c_int]
+        acl_get_fd_np.restype = ctypes.c_void_p
+        acl_to_text = libc.acl_to_text
+        acl_to_text.argtypes = [ctypes.c_void_p, ctypes.POINTER(ctypes.c_long)]
+        acl_to_text.restype = ctypes.c_void_p
+        acl_free = libc.acl_free
+        acl_free.argtypes = [ctypes.c_void_p]
+        acl_free.restype = ctypes.c_int
+    except (AttributeError, OSError):
+        return False
+
+    directory_fd = os.open(
+        path,
+        os.O_RDONLY | getattr(os, "O_DIRECTORY", 0) | getattr(os, "O_NOFOLLOW", 0),
+    )
+    try:
+        ctypes.set_errno(0)
+        acl = acl_get_fd_np(directory_fd, 0x00000100)  # ACL_TYPE_EXTENDED
+        if not acl:
+            return ctypes.get_errno() in (0, errno.ENOENT)
+        try:
+            text_length = ctypes.c_long()
+            text_pointer = acl_to_text(acl, ctypes.byref(text_length))
+            if not text_pointer:
+                return False
+            try:
+                lines = ctypes.string_at(text_pointer, text_length.value).decode(
+                    "utf-8", errors="strict"
+                ).splitlines()
+            finally:
+                acl_free(text_pointer)
+
+            everyone_gid = grp.getgrnam("everyone").gr_gid
+            if len(lines) < 2 or lines[0] != "!#acl 1":
+                return False
+            uuid_pattern = re.compile(
+                r"^[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-"
+                r"[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}$"
+            )
+            for line in lines[1:]:
+                fields = line.split(":")
+                if (
+                    len(fields) != 6
+                    or fields[0] != "group"
+                    or not uuid_pattern.fullmatch(fields[1])
+                    or fields[2] != "everyone"
+                    or fields[3] != str(everyone_gid)
+                    or fields[4] != "deny"
+                    or fields[5] != "delete"
+                ):
+                    return False
+            return True
+        finally:
+            acl_free(acl)
+    finally:
+        os.close(directory_fd)
+
 current = home
 relative = os.path.relpath(target, home)
 for component in ["."] + relative.split(os.sep):
@@ -203,6 +271,8 @@ for component in ["."] + relative.split(os.sep):
         raise SystemExit(f"install path component is not owned by the installing user: {current}")
     if info.st_mode & (stat.S_IWGRP | stat.S_IWOTH):
         raise SystemExit(f"install path component is group/world-writable: {current}")
+    if not safe_directory_acl(current):
+        raise SystemExit(f"install path component has an unsafe ACL: {current}")
 
 print(target)
 PY

--- a/phase3-binary/dist/install.sh
+++ b/phase3-binary/dist/install.sh
@@ -18,9 +18,11 @@ REFERRAL_CODE_SOURCE_FILE="${MACPROVIDER_REFERRAL_CODE_FILE:-}"
 CREATED_REFERRAL_CODE_SOURCE_FILE=0
 FRESH_REFERRAL_BOOTSTRAP=0
 REFERRAL_REPLACE_INCUMBENT="${MACPROVIDER_REFERRAL_REPLACE_INCUMBENT:-0}"
+REPAIR_EXISTING_INSTALL="${MACPROVIDER_REPAIR_EXISTING_INSTALL:-0}"
 REFERRAL_BOOTSTRAP_COMPLETED=0
 unset MACPROVIDER_REFERRAL_CODE_FILE
 unset MACPROVIDER_REFERRAL_REPLACE_INCUMBENT
+unset MACPROVIDER_REPAIR_EXISTING_INSTALL
 
 GITHUB_REPO="${MACPROVIDER_GITHUB_REPO:-Augustas11/macprovider}"
 MACPROVIDER_MIN_SUPPORTED_VERSION="v1.7.11"
@@ -4870,6 +4872,139 @@ restart_safe_incumbent_present() {
   [ -f "$MANIFEST_PATH" ] && [ -f "$PLIST_PATH" ]
 }
 
+# Malibu may request repair after the provider executable was removed while
+# the owner-private config, provider identity, manifest, and LaunchAgent plist
+# survived. This bypasses only referral admission; the evidence itself is
+# revalidated descriptor-first and must identify this install's provider label
+# and executable paths. The later transaction snapshots the same files again
+# before any live mutation.
+repair_safe_incumbent_present() {
+  existing_provider_id="$(read_config_provider_id || true)"
+  [ -n "$existing_provider_id" ] || return 1
+  [ -f "$PROVIDER_ID_PATH" ] || return 1
+  saved_provider_id="$(cat "$PROVIDER_ID_PATH" 2>/dev/null || true)"
+  [ "$saved_provider_id" = "$existing_provider_id" ] || return 1
+  python3 - \
+    "$CONFIG_PATH" \
+    "$PROVIDER_ID_PATH" \
+    "$MANIFEST_PATH" \
+    "$PLIST_PATH" \
+    "$INSTALL_DIR" \
+    "$BINARY_PATH" \
+    "$PROVIDER_LABEL" \
+    "$existing_provider_id" <<'PY' 2>/dev/null
+import ctypes
+import errno
+import json
+import os
+import plistlib
+import re
+import stat
+import sys
+
+config_path, provider_id_path, manifest_path, plist_path, install_dir, binary_path, label, expected_provider_id = sys.argv[1:]
+uid = os.getuid()
+nofollow = getattr(os, "O_NOFOLLOW", 0)
+max_bytes = 1024 * 1024
+
+
+def no_acl(fd):
+    if sys.platform != "darwin":
+        return True
+    try:
+        libc = ctypes.CDLL(None, use_errno=True)
+        acl_get_fd_np = libc.acl_get_fd_np
+        acl_get_fd_np.argtypes = [ctypes.c_int, ctypes.c_int]
+        acl_get_fd_np.restype = ctypes.c_void_p
+        acl_free = libc.acl_free
+        acl_free.argtypes = [ctypes.c_void_p]
+        acl_free.restype = ctypes.c_int
+    except (AttributeError, OSError):
+        return False
+    ctypes.set_errno(0)
+    acl = acl_get_fd_np(fd, 0x00000100)  # ACL_TYPE_EXTENDED
+    if acl:
+        acl_free(acl)
+        return False
+    return ctypes.get_errno() in (0, errno.ENOENT)
+
+
+def read_owned(path):
+    fd = os.open(path, os.O_RDONLY | nofollow)
+    try:
+        before = os.fstat(fd)
+        if (
+            not stat.S_ISREG(before.st_mode)
+            or before.st_uid != uid
+            or before.st_nlink != 1
+            or stat.S_IMODE(before.st_mode) & 0o077
+            or before.st_size < 0
+            or before.st_size > max_bytes
+            or not no_acl(fd)
+        ):
+            raise RuntimeError("unsafe repair evidence")
+        payload = bytearray()
+        while len(payload) < before.st_size:
+            chunk = os.read(fd, min(65536, before.st_size - len(payload)))
+            if not chunk:
+                raise RuntimeError("repair evidence truncated")
+            payload.extend(chunk)
+        after = os.fstat(fd)
+        path_info = os.lstat(path)
+        if (
+            (after.st_dev, after.st_ino, after.st_size, after.st_mtime_ns, after.st_ctime_ns)
+            != (before.st_dev, before.st_ino, before.st_size, before.st_mtime_ns, before.st_ctime_ns)
+            or stat.S_ISLNK(path_info.st_mode)
+            or (path_info.st_dev, path_info.st_ino) != (before.st_dev, before.st_ino)
+        ):
+            raise RuntimeError("repair evidence changed during read")
+        return bytes(payload)
+    finally:
+        os.close(fd)
+
+
+config = read_owned(config_path).decode("utf-8")
+provider_id = read_owned(provider_id_path).decode("utf-8").strip()
+if provider_id != expected_provider_id:
+    raise SystemExit(1)
+config_ids = []
+for line in config.splitlines():
+    match = re.match(r'^provider_id:\s*"?([^"\s]+)"?\s*$', line)
+    if match:
+        config_ids.append(match.group(1))
+if config_ids != [expected_provider_id]:
+    raise SystemExit(1)
+
+manifest = json.loads(read_owned(manifest_path).decode("utf-8"))
+labels = manifest.get("launchd_labels") if isinstance(manifest, dict) else None
+plists = manifest.get("launchd_plists") if isinstance(manifest, dict) else None
+if (
+    not isinstance(manifest, dict)
+    or manifest.get("install_prefix") != install_dir
+    or manifest.get("binary_path") != os.path.join(install_dir, "macprovider-cli")
+    or not isinstance(labels, list)
+    or not all(isinstance(value, str) for value in labels)
+    or label not in labels
+    or not isinstance(plists, list)
+    or not all(isinstance(value, str) for value in plists)
+    or plist_path not in plists
+):
+    raise SystemExit(1)
+
+plist = plistlib.loads(read_owned(plist_path))
+if not isinstance(plist, dict) or plist.get("Label") != label:
+    raise SystemExit(1)
+program = plist.get("Program")
+arguments = plist.get("ProgramArguments")
+if program is None:
+    if not isinstance(arguments, list) or not arguments:
+        raise SystemExit(1)
+    program = arguments[0]
+if program not in (os.path.join(install_dir, "macprovider-cli"), binary_path):
+    raise SystemExit(1)
+PY
+}
+
 validate_supplied_referral_code_file() {
   referral_source_rc=0
   python3 - "$REFERRAL_CODE_SOURCE_FILE" <<'PY' || referral_source_rc=$?
@@ -4935,6 +5070,16 @@ prepare_fresh_referral_code() {
   case "$REFERRAL_REPLACE_INCUMBENT" in
     0|1) ;;
     *) die 7 "MACPROVIDER_REFERRAL_REPLACE_INCUMBENT must be 0 or 1" ;;
+  esac
+  case "$REPAIR_EXISTING_INSTALL" in
+    0) ;;
+    1)
+      repair_safe_incumbent_present \
+        || die 20 "trusted existing-install evidence is required for Malibu repair"
+      log "Trusted existing-install evidence found; repairing without a referral code."
+      return 0
+      ;;
+    *) die 7 "MACPROVIDER_REPAIR_EXISTING_INSTALL must be 0 or 1" ;;
   esac
   if restart_safe_incumbent_present; then
     if [ "$REFERRAL_REPLACE_INCUMBENT" != "1" ]; then

--- a/phase3-binary/dist/test/install_launchd_migration.test.sh
+++ b/phase3-binary/dist/test/install_launchd_migration.test.sh
@@ -1,0 +1,229 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/../../.." && pwd)"
+INSTALL_SH="$REPO_ROOT/phase3-binary/dist/install.sh"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+python3 - "$INSTALL_SH" > "$TMP/functions.sh" <<'PY'
+import sys
+
+names = [
+    "xml_escape",
+    "write_atomic_install_file",
+    "reclaim_launchd_service",
+    "render_plist",
+    "render_watchdog_plist",
+    "install_plist",
+    "install_watchdog",
+]
+lines = open(sys.argv[1], encoding="utf-8").read().splitlines()
+for name in names:
+    for index, line in enumerate(lines):
+        if line != f"{name}() {{":
+            continue
+        depth = 0
+        while index < len(lines):
+            current = lines[index]
+            print(current)
+            depth += current.count("{") - current.count("}")
+            index += 1
+            if depth == 0:
+                break
+        break
+    else:
+        raise SystemExit(f"could not extract {name}")
+PY
+
+mkdir -p "$TMP/bin"
+cat > "$TMP/bin/launchctl" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+case "${1:-}" in
+  print)
+    if [ ! -f "$LAUNCHD_STATE" ]; then
+      exit 1
+    fi
+    case "$2" in
+      *live.streamvc.macprovider-watchdog*)
+        printf 'gui/%s/live.streamvc.macprovider-watchdog = {\n  program = %s\n  path = %s\n}\n' \
+          "$(id -u)" "$WATCHDOG_PROGRAM" "${PRINTED_PLIST_PATH:-$WATCHDOG_PLIST_PATH}"
+        ;;
+      *)
+        printf 'gui/%s/live.streamvc.macprovider = {\n  program = %s\n  path = %s\n}\n' \
+          "$(id -u)" "$PROVIDER_PROGRAM" "${PRINTED_PLIST_PATH:-$PLIST_PATH}"
+        ;;
+    esac
+    ;;
+  bootout)
+    printf '%s\n' "$*" >> "$LAUNCHD_LOG"
+    if [ "${BOOTOUT_FAIL:-0}" -eq 1 ]; then
+      exit 1
+    fi
+    rm -f "$LAUNCHD_STATE"
+    ;;
+  enable|disable)
+    printf '%s\n' "$*" >> "$LAUNCHD_LOG"
+    ;;
+  bootstrap)
+    printf '%s\n' "$*" >> "$LAUNCHD_LOG"
+    touch "$LAUNCHD_STATE"
+    ;;
+  *)
+    exit 0
+    ;;
+esac
+EOF
+chmod 0755 "$TMP/bin/launchctl"
+
+run_reclaim() {
+  LAUNCHD_STATE="$TMP/launchd-state"
+  LAUNCHD_LOG="$TMP/launchd.log"
+  FUNCTION_PATH="$TMP/functions.sh" \
+    PROVIDER_LABEL="live.streamvc.macprovider" \
+    WATCHDOG_LABEL="live.streamvc.macprovider-watchdog" \
+    INSTALL_DIR="$TMP/home/macprovider" \
+    BINARY_PATH="$TMP/home/.local/bin/macprovider-cli" \
+    WATCHDOG_DIR="$TMP/home/.local/share/macprovider-watchdog" \
+    WATCHDOG_PATH="$TMP/home/.local/share/macprovider-watchdog/macprovider-health-monitor" \
+    PLIST_PATH="$TMP/home/Library/LaunchAgents/live.streamvc.macprovider.plist" \
+    WATCHDOG_PLIST_PATH="$TMP/home/Library/LaunchAgents/live.streamvc.macprovider-watchdog.plist" \
+    PROVIDER_PROGRAM="$TMP/home/.local/bin/macprovider-cli" \
+    WATCHDOG_PROGRAM="$TMP/home/.local/share/macprovider-watchdog/watchdog.sh" \
+    PATH="$TMP/bin:$PATH" \
+    LAUNCHD_STATE="$LAUNCHD_STATE" \
+    LAUNCHD_LOG="$LAUNCHD_LOG" \
+    PRINTED_PLIST_PATH="${PRINTED_PLIST_PATH:-}" \
+    BOOTOUT_FAIL="${1:-0}" \
+    bash -c '
+      set -euo pipefail
+      log() { :; }
+      run() { "$@"; }
+      die() { return "$1"; }
+      write_watchdog_script() { :; }
+    INSTALL_TX_ACTIVE=1
+    INSTALL_TX_HAD_PLIST=1
+    INSTALL_TX_HAD_WATCHDOG_PLIST=1
+    DRY_RUN=0
+    NO_LAUNCHD=0
+    NO_WATCHDOG=0
+    LAUNCHD_INSTALLED=0
+    WATCHDOG_INSTALLED=0
+    source "$FUNCTION_PATH"
+      reclaim_launchd_service "$PROVIDER_LABEL"
+    '
+}
+
+touch "$TMP/launchd-state"
+run_reclaim
+grep -Fx "bootout gui/$(id -u)/live.streamvc.macprovider" "$TMP/launchd.log" >/dev/null
+[ ! -f "$TMP/launchd-state" ]
+
+rm -f "$TMP/launchd-state" "$TMP/launchd.log"
+run_reclaim
+[ ! -s "$TMP/launchd.log" ]
+
+touch "$TMP/launchd-state"
+set +e
+run_reclaim 1
+reclaim_rc=$?
+set -e
+[ "$reclaim_rc" -ne 0 ]
+[ -f "$TMP/launchd-state" ]
+
+rm -f "$TMP/launchd.log"
+set +e
+PRINTED_PLIST_PATH="$TMP/home/Library/LaunchAgents/unexpected.plist" run_reclaim
+reclaim_rc=$?
+set -e
+[ "$reclaim_rc" -ne 0 ]
+[ -f "$TMP/launchd-state" ]
+
+rm -f "$TMP/launchd-state" "$TMP/launchd.log"
+mkdir -p "$TMP/home/Library/LaunchAgents" "$TMP/home/.local/bin" "$TMP/home/.local/share/macprovider-watchdog"
+printf '<plist>old</plist>\n' > "$TMP/home/Library/LaunchAgents/live.streamvc.macprovider.plist"
+printf '<plist>old-watchdog</plist>\n' > "$TMP/home/Library/LaunchAgents/live.streamvc.macprovider-watchdog.plist"
+touch "$TMP/launchd-state"
+HOME="$TMP/home" \
+  FUNCTION_PATH="$TMP/functions.sh" \
+  PROVIDER_PROGRAM="$TMP/home/.local/bin/macprovider-cli" \
+  WATCHDOG_PROGRAM="$TMP/home/.local/share/macprovider-watchdog/watchdog.sh" \
+  PATH="$TMP/bin:$PATH" \
+  LAUNCHD_STATE="$TMP/launchd-state" \
+  LAUNCHD_LOG="$TMP/launchd.log" \
+  bash -c '
+    set -euo pipefail
+    log() { :; }
+    run() { "$@"; }
+    die() { return "$1"; }
+    assert_install_lock_ownership() { :; }
+    write_watchdog_script() { printf "watchdog\n" > "$WATCHDOG_PATH"; }
+    source "$FUNCTION_PATH"
+    INSTALL_DIR="$HOME/macprovider"
+    BINARY_PATH="$HOME/.local/bin/macprovider-cli"
+    WATCHDOG_DIR="$HOME/.local/share/macprovider-watchdog"
+    WATCHDOG_PATH="$WATCHDOG_DIR/macprovider-health-monitor"
+    CONFIG_PATH="$HOME/.config/macprovider/config.yaml"
+    LOG_DIR="$HOME/Library/Logs/macprovider"
+    PLIST_PATH="$HOME/Library/LaunchAgents/live.streamvc.macprovider.plist"
+    WATCHDOG_PLIST_PATH="$HOME/Library/LaunchAgents/live.streamvc.macprovider-watchdog.plist"
+    PROVIDER_LABEL="live.streamvc.macprovider"
+    WATCHDOG_LABEL="live.streamvc.macprovider-watchdog"
+    DRY_RUN=0
+    NO_LAUNCHD=0
+    NO_WATCHDOG=0
+    LAUNCHD_INSTALLED=0
+    WATCHDOG_INSTALLED=0
+    PROVIDER_PROGRAM="$BINARY_PATH"
+    WATCHDOG_PROGRAM="$WATCHDOG_DIR/watchdog.sh"
+    INSTALL_TX_ACTIVE=1
+    INSTALL_TX_HAD_PLIST=1
+    INSTALL_TX_HAD_WATCHDOG_PLIST=1
+    install_plist "mlx-community/Qwen" "provider" "https://coordinator.example"
+    [ "$LAUNCHD_INSTALLED" -eq 1 ]
+    install_watchdog "https://coordinator.example"
+    [ "$WATCHDOG_INSTALLED" -eq 1 ]
+  '
+grep -F 'enable gui/' "$TMP/launchd.log" | grep -F 'live.streamvc.macprovider' >/dev/null
+grep -F 'bootstrap gui/' "$TMP/launchd.log" | grep -F 'live.streamvc.macprovider.plist' >/dev/null
+grep -F 'enable gui/' "$TMP/launchd.log" | grep -F 'live.streamvc.macprovider-watchdog' >/dev/null
+grep -F 'bootstrap gui/' "$TMP/launchd.log" | grep -F 'live.streamvc.macprovider-watchdog.plist' >/dev/null
+
+rm -f "$TMP/launchd-state" "$TMP/launchd.log"
+touch "$TMP/launchd-state"
+set +e
+FUNCTION_PATH="$TMP/functions.sh" \
+  PROVIDER_LABEL="live.streamvc.macprovider" \
+  WATCHDOG_LABEL="live.streamvc.macprovider-watchdog" \
+  INSTALL_DIR="$TMP/home/macprovider" \
+  BINARY_PATH="$TMP/home/.local/bin/macprovider-cli" \
+  WATCHDOG_DIR="$TMP/home/.local/share/macprovider-watchdog" \
+  WATCHDOG_PATH="$TMP/home/.local/share/macprovider-watchdog/macprovider-health-monitor" \
+  PLIST_PATH="$TMP/home/Library/LaunchAgents/live.streamvc.macprovider.plist" \
+  WATCHDOG_PLIST_PATH="$TMP/home/Library/LaunchAgents/live.streamvc.macprovider-watchdog.plist" \
+  PROVIDER_PROGRAM="$TMP/unexpected-provider" \
+  WATCHDOG_PROGRAM="$TMP/home/.local/share/macprovider-watchdog/watchdog.sh" \
+  PATH="$TMP/bin:$PATH" LAUNCHD_STATE="$TMP/launchd-state" LAUNCHD_LOG="$TMP/launchd.log" \
+  bash -c '
+    set -euo pipefail
+    log() { :; }
+    source "$FUNCTION_PATH"
+    INSTALL_TX_ACTIVE=1; INSTALL_TX_HAD_PLIST=1; INSTALL_TX_HAD_WATCHDOG_PLIST=1
+    reclaim_launchd_service "$PROVIDER_LABEL"
+  '
+unexpected_rc=$?
+set -e
+[ "$unexpected_rc" -ne 0 ]
+[ -f "$TMP/launchd-state" ]
+
+grep -F 'reclaim_launchd_service "$PROVIDER_LABEL"' "$INSTALL_SH" >/dev/null
+grep -F 'reclaim_launchd_service "$WATCHDOG_LABEL"' "$INSTALL_SH" >/dev/null
+grep -F 'service_identity_matches' "$INSTALL_SH" >/dev/null
+grep -F 'launchctl bootout "gui/$REC_UID/$service_label"' "$INSTALL_SH" >/dev/null
+if grep -F 'launchctl bootout "gui/$REC_UID" "$REC_PLIST_PATH"' "$INSTALL_SH" >/dev/null; then
+  echo "recovery still uses path-based provider bootout" >&2
+  exit 1
+fi
+echo "launchd migration reclaim ok"

--- a/phase3-binary/dist/test/install_upgrade_evidence_rollback.test.sh
+++ b/phase3-binary/dist/test/install_upgrade_evidence_rollback.test.sh
@@ -29,8 +29,9 @@ trap cleanup_test_processes EXIT
 python3 - "$INSTALL_SH" > "$TMP/functions.sh" <<'PY'
 import sys
 names = {
-    "cleanup", "install_tx_path_matches", "stage_install_tx_path",
+    "cleanup", "install_tx_path_matches", "stage_install_tx_path", "stage_install_tx_plist",
     "stage_lifecycle_snapshot",
+    "secure_private_directory", "write_atomic_install_file", "write_install_tx_marker",
     "write_install_recovery_artifacts", "begin_install_transaction",
     "mark_install_cutover_started", "discard_install_transaction_before_cutover",
     "rollback_install_transaction", "commit_install_transaction",
@@ -38,7 +39,7 @@ names = {
     "release_install_lock",
     "launchd_label_is_disabled", "capture_manual_provider_for_recovery",
     "pid_is_live_non_zombie", "stop_owned_manual_provider",
-    "validate_port_value", "ensure_port_free",
+    "validate_port_value", "ensure_port_free", "reclaim_launchd_service",
 }
 lines = open(sys.argv[1], encoding="utf-8").read().splitlines()
 i = 0
@@ -495,9 +496,23 @@ make_case() {
   printf 'model: old-model\nprovider_id: upgrade-provider\n' > "$home/.config/macprovider/config.yaml"
   printf 'upgrade-provider\n' > "$home/.config/macprovider/provider_id"
   printf '{"model_id":"old-model","generated_at":"old"}\n' > "$home/.config/macprovider/last-recommendation.json"
-  printf '<plist>old</plist>\n' > "$home/Library/LaunchAgents/live.streamvc.macprovider.plist"
+  printf '%s\n' \
+    '<?xml version="1.0" encoding="UTF-8"?>' \
+    '<plist version="1.0"><dict>' \
+    '<key>Label</key><string>live.streamvc.macprovider</string>' \
+    '<key>ProgramArguments</key><array>' \
+    "<string>$home/macprovider/macprovider-cli</string>" \
+    '</array><key>Comment</key><string>old-provider-plist</string>' \
+    '</dict></plist>' > "$home/Library/LaunchAgents/live.streamvc.macprovider.plist"
   printf 'old-watchdog\n' > "$home/.local/share/macprovider-watchdog/macprovider-health-monitor"
-  printf '<plist>old-watchdog</plist>\n' > "$home/Library/LaunchAgents/live.streamvc.macprovider-watchdog.plist"
+  printf '%s\n' \
+    '<?xml version="1.0" encoding="UTF-8"?>' \
+    '<plist version="1.0"><dict>' \
+    '<key>Label</key><string>live.streamvc.macprovider-watchdog</string>' \
+    '<key>ProgramArguments</key><array>' \
+    "<string>$home/.local/share/macprovider-watchdog/macprovider-health-monitor</string>" \
+    '</array><key>Comment</key><string>old-watchdog-plist</string>' \
+    '</dict></plist>' > "$home/Library/LaunchAgents/live.streamvc.macprovider-watchdog.plist"
   printf '{"version":"old"}\n' > "$home/Library/Application Support/macprovider/install_manifest.json"
   # Seed a prior lifecycle-state file by default so rollback must restore its
   # exact prior contents; the lifecycle_absent_* cases delete it to exercise the
@@ -536,6 +551,18 @@ esac
 case "$1" in
   print)
     [ -f "$service_file" ] || exit 1
+    case "$*" in
+      *macprovider-watchdog*)
+        printf 'program = %s\npath = %s\n' \
+          "$CASE_ROOT/home/.local/share/macprovider-watchdog/macprovider-health-monitor" \
+          "$CASE_ROOT/home/Library/LaunchAgents/live.streamvc.macprovider-watchdog.plist"
+        ;;
+      *)
+        printf 'program = %s\npath = %s\n' \
+          "$CASE_ROOT/home/macprovider/macprovider-cli" \
+          "$CASE_ROOT/home/Library/LaunchAgents/live.streamvc.macprovider.plist"
+        ;;
+    esac
     ;;
   print-disabled)
     printf 'disabled services = {\n'
@@ -869,8 +896,10 @@ run_case() {
       INSTALL_LOCK_PATH="$CONFIG_DIR/install.lock"
       INSTALL_RECOVERY_LABEL="live.streamvc.macprovider-install-recovery"
       INSTALL_RECOVERY_PLIST_PATH="$HOME/Library/LaunchAgents/${INSTALL_RECOVERY_LABEL}.plist"
+      PROVIDER_LABEL="live.streamvc.macprovider"
       PLIST_PATH="$HOME/Library/LaunchAgents/live.streamvc.macprovider.plist"
       WATCHDOG_DIR="$HOME/.local/share/macprovider-watchdog"
+      WATCHDOG_PATH="$WATCHDOG_DIR/macprovider-health-monitor"
       WATCHDOG_PLIST_PATH="$HOME/Library/LaunchAgents/live.streamvc.macprovider-watchdog.plist"
       WATCHDOG_LABEL="live.streamvc.macprovider-watchdog"
       MANIFEST_PATH="$HOME/Library/Application Support/macprovider/install_manifest.json"
@@ -1027,6 +1056,8 @@ MANUAL
           launchctl bootout "gui/$UID" "$WATCHDOG_PLIST_PATH" >/dev/null 2>&1 || true
           launchctl enable "gui/$UID/live.streamvc.macprovider"
           launchctl enable "gui/$UID/$WATCHDOG_LABEL"
+          printf "transaction-created\n" > "$INSTALL_TX_BACKUP/provider-service-created"
+          printf "transaction-created\n" > "$INSTALL_TX_BACKUP/watchdog-service-created"
           launchctl bootstrap "gui/$UID" "$PLIST_PATH"
           launchctl kickstart -k "gui/$UID/live.streamvc.macprovider"
           launchctl bootstrap "gui/$UID" "$WATCHDOG_PLIST_PATH"
@@ -1071,9 +1102,9 @@ assert_old_install_files() {
   grep -F 'model: old-model' "$home/.config/macprovider/config.yaml" >/dev/null
   grep -F 'upgrade-provider' "$home/.config/macprovider/provider_id" >/dev/null
   grep -F '"model_id":"old-model"' "$home/.config/macprovider/last-recommendation.json" >/dev/null
-  grep -F '<plist>old</plist>' "$home/Library/LaunchAgents/live.streamvc.macprovider.plist" >/dev/null
+  grep -F 'old-provider-plist' "$home/Library/LaunchAgents/live.streamvc.macprovider.plist" >/dev/null
   grep -F 'old-watchdog' "$home/.local/share/macprovider-watchdog/macprovider-health-monitor" >/dev/null
-  grep -F '<plist>old-watchdog</plist>' "$home/Library/LaunchAgents/live.streamvc.macprovider-watchdog.plist" >/dev/null
+  grep -F 'old-watchdog-plist' "$home/Library/LaunchAgents/live.streamvc.macprovider-watchdog.plist" >/dev/null
   grep -F '"version":"old"' "$home/Library/Application Support/macprovider/install_manifest.json" >/dev/null
   [ "$(readlink "$home/.local/bin/macprovider-cli")" = "$home/macprovider/macprovider-cli" ]
 }
@@ -1301,7 +1332,7 @@ grep -F 'provider_id: "mp-0123456789abcdef0123456789abcdef"' \
 grep -F 'provider_token: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa' \
   "$root/home/.config/macprovider/config.yaml" >/dev/null
 [ "$(cat "$root/home/.config/macprovider/provider_id")" = 'mp-0123456789abcdef0123456789abcdef' ]
-grep -F '<plist>old</plist>' "$root/home/Library/LaunchAgents/live.streamvc.macprovider.plist" >/dev/null
+grep -F 'old-provider-plist' "$root/home/Library/LaunchAgents/live.streamvc.macprovider.plist" >/dev/null
 grep -F 'old-watchdog' "$root/home/.local/share/macprovider-watchdog/macprovider-health-monitor" >/dev/null
 grep -F '"version":"old"' "$root/home/Library/Application Support/macprovider/install_manifest.json" >/dev/null
 [ -z "$(recovery_dir "$root")" ]

--- a/phase3-binary/dist/test/install_upgrade_evidence_rollback.test.sh
+++ b/phase3-binary/dist/test/install_upgrade_evidence_rollback.test.sh
@@ -610,12 +610,21 @@ for arg in "$@"; do last="$arg"; done
 if [ -f "$CASE_ROOT/fail-backup-cp" ] && printf '%s' "$last" | grep -q '\.staging/install-dir$'; then
   exit 51
 fi
-if [ -f "$CASE_ROOT/fail-restore-cp" ] && printf '%s' "$last" | grep -q '\.macprovider-restore\.'; then
-  exit 52
-fi
 exec /bin/cp "$@"
 EOF
   chmod +x "$root/bin/cp"
+
+  cat > "$root/bin/cmp" <<'EOF'
+#!/usr/bin/env bash
+if [ -f "$CASE_ROOT/fail-restore-cp" ] && printf '%s' "$*" | grep -Eq '/restore\.[A-Za-z0-9]+/'; then
+  # Recovery now stages through descriptor-backed Python copies, so inject the
+  # legacy restore-copy failure at candidate byte verification instead of
+  # relying on an obsolete predictable temporary path.
+  exit 52
+fi
+exec /usr/bin/cmp "$@"
+EOF
+  chmod +x "$root/bin/cmp"
 
   cat > "$root/bin/mv" <<'EOF'
 #!/usr/bin/env bash

--- a/phase3-binary/dist/test/provider_upgrade_transaction.test.sh
+++ b/phase3-binary/dist/test/provider_upgrade_transaction.test.sh
@@ -21,6 +21,9 @@ extract_function() {
 
 for function_name in \
   validate_install_dir validate_port_value \
+  read_config_provider_id read_config_provider_token_line \
+  installed_provider_binary_path restart_safe_incumbent_present \
+  repair_safe_incumbent_present prepare_fresh_referral_code \
   prepare_staged_config activate_staged_config select_autotune_benchmark_port \
   semantic_merge_config restore_existing_provider_if_start_skipped \
   prefetch_upgrade_autotune_model own_macprovider_cli_holds_live_port \
@@ -99,6 +102,91 @@ mkdir -m 777 "$HOME/shared"
 chmod 777 "$HOME/shared"
 if (INSTALL_DIR="$HOME/shared/provider"; validate_install_dir); then
   echo "world-writable install ancestor unexpectedly passed" >&2
+  exit 1
+fi
+
+# Malibu repair must be able to recover the exact #941 state where the old
+# provider executable is gone but owner-private identity/configuration and
+# launchd evidence remain. The evidence gate must suppress referral admission
+# only for that validated state, and must fail closed when the manifest is
+# missing.
+REPAIR_HOME="$TMP/repair-home"
+mkdir -m 700 -p \
+  "$REPAIR_HOME/.config/macprovider" \
+  "$REPAIR_HOME/Library/Application Support/macprovider" \
+  "$REPAIR_HOME/Library/LaunchAgents"
+REPAIR_INSTALL_DIR="$REPAIR_HOME/macprovider"
+REPAIR_CONFIG_PATH="$REPAIR_HOME/.config/macprovider/config.yaml"
+REPAIR_PROVIDER_ID_PATH="$REPAIR_HOME/.config/macprovider/provider_id"
+REPAIR_MANIFEST_PATH="$REPAIR_HOME/Library/Application Support/macprovider/install_manifest.json"
+REPAIR_PLIST_PATH="$REPAIR_HOME/Library/LaunchAgents/live.streamvc.macprovider.plist"
+REPAIR_BINARY_PATH="$REPAIR_HOME/.local/bin/macprovider-cli"
+REPAIR_PROVIDER_ID="mp-0123456789abcdef0123456789abcdef"
+cat > "$REPAIR_CONFIG_PATH" <<EOF
+model: "seed"
+provider_id: "$REPAIR_PROVIDER_ID"
+coordinator_url: "wss://coordinator.example/ws/provider"
+EOF
+printf '%s\n' "$REPAIR_PROVIDER_ID" > "$REPAIR_PROVIDER_ID_PATH"
+cat > "$REPAIR_MANIFEST_PATH" <<EOF
+{
+  "install_prefix": "$REPAIR_INSTALL_DIR",
+  "binary_path": "$REPAIR_INSTALL_DIR/macprovider-cli",
+  "launchd_labels": ["live.streamvc.macprovider"],
+  "launchd_plists": ["$REPAIR_PLIST_PATH"]
+}
+EOF
+cat > "$REPAIR_PLIST_PATH" <<EOF
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0"><dict>
+<key>Label</key><string>live.streamvc.macprovider</string>
+<key>Program</key><string>$REPAIR_INSTALL_DIR/macprovider-cli</string>
+</dict></plist>
+EOF
+chmod 600 "$REPAIR_CONFIG_PATH" "$REPAIR_PROVIDER_ID_PATH" "$REPAIR_MANIFEST_PATH" "$REPAIR_PLIST_PATH"
+(
+  INSTALL_DIR="$REPAIR_INSTALL_DIR"
+  BINARY_PATH="$REPAIR_BINARY_PATH"
+  CONFIG_PATH="$REPAIR_CONFIG_PATH"
+  PROVIDER_ID_PATH="$REPAIR_PROVIDER_ID_PATH"
+  MANIFEST_PATH="$REPAIR_MANIFEST_PATH"
+  PLIST_PATH="$REPAIR_PLIST_PATH"
+  PROVIDER_LABEL="live.streamvc.macprovider"
+  DRY_RUN=0
+  EMERGENCY_ROLLBACK=0
+  REFERRAL_REPLACE_INCUMBENT=0
+  REPAIR_EXISTING_INSTALL=1
+  REFERRAL_CODE_SOURCE_FILE=""
+  FRESH_REFERRAL_BOOTSTRAP=0
+  NO_PROMPT=1
+  log() { :; }
+  die() { exit "$1"; }
+  prepare_fresh_referral_code
+  [ -z "$REFERRAL_CODE_SOURCE_FILE" ]
+  [ "$FRESH_REFERRAL_BOOTSTRAP" -eq 0 ]
+)
+rm -f "$REPAIR_MANIFEST_PATH"
+if (
+  INSTALL_DIR="$REPAIR_INSTALL_DIR"
+  BINARY_PATH="$REPAIR_BINARY_PATH"
+  CONFIG_PATH="$REPAIR_CONFIG_PATH"
+  PROVIDER_ID_PATH="$REPAIR_PROVIDER_ID_PATH"
+  MANIFEST_PATH="$REPAIR_MANIFEST_PATH"
+  PLIST_PATH="$REPAIR_PLIST_PATH"
+  PROVIDER_LABEL="live.streamvc.macprovider"
+  DRY_RUN=0
+  EMERGENCY_ROLLBACK=0
+  REFERRAL_REPLACE_INCUMBENT=0
+  REPAIR_EXISTING_INSTALL=1
+  REFERRAL_CODE_SOURCE_FILE=""
+  FRESH_REFERRAL_BOOTSTRAP=0
+  NO_PROMPT=1
+  log() { :; }
+  die() { exit "$1"; }
+  prepare_fresh_referral_code
+); then
+  echo "repair bypassed referral admission without complete evidence" >&2
   exit 1
 fi
 

--- a/phase3-binary/dist/test/provider_upgrade_transaction.test.sh
+++ b/phase3-binary/dist/test/provider_upgrade_transaction.test.sh
@@ -90,6 +90,11 @@ if (INSTALL_DIR="$HOME/link/provider"; validate_install_dir); then
   echo "symlinked install path unexpectedly passed" >&2
   exit 1
 fi
+mkdir -m 700 "$HOME/custom"
+if ! (INSTALL_DIR="$HOME/custom/bin"; validate_install_dir); then
+  echo "owner-private custom install path unexpectedly failed" >&2
+  exit 1
+fi
 mkdir -m 777 "$HOME/shared"
 chmod 777 "$HOME/shared"
 if (INSTALL_DIR="$HOME/shared/provider"; validate_install_dir); then

--- a/scripts/test-install-launchd-enable.sh
+++ b/scripts/test-install-launchd-enable.sh
@@ -25,10 +25,11 @@ line_number() {
   awk -v pattern="$pattern" 'index($0, pattern) { print NR; exit }' "$INSTALL_SH"
 }
 
-require_line 'launchctl bootout "gui/$UID" "$PLIST_PATH"' "launchd bootout before replacement"
-require_line 'launchctl enable "gui/$UID/live.streamvc.macprovider"' "launchd enable before bootstrap"
+require_line 'launchctl bootout "$service_target"' "label-target launchd bootout"
+require_line 'reclaim_launchd_service "$PROVIDER_LABEL"' "provider launchd reclaim before replacement"
+require_line 'launchctl enable "gui/$UID/$PROVIDER_LABEL"' "launchd enable before bootstrap"
 require_line 'launchctl bootstrap "gui/$UID" "$PLIST_PATH"' "launchd bootstrap"
-require_line 'Would enable launchd service: launchctl enable gui/$UID/live.streamvc.macprovider' "dry-run enable hint"
+require_line 'Would enable launchd service: launchctl enable gui/$UID/$PROVIDER_LABEL' "dry-run enable hint"
 require_line 'Installing as a background launchd service.' "automatic launchd install message"
 require_line 'MACPROVIDER_NO_LAUNCHD=1 expert/debug override' "explicit no-launchd escape hatch"
 require_line 'holding_executable="$(lsof -a -p "$holding_pid" -d txt -Fn' "listener executable identity lookup"
@@ -101,16 +102,24 @@ case "$cache_classification_output" in
     ;;
 esac
 
-bootout_line="$(line_number 'launchctl bootout "gui/$UID" "$PLIST_PATH"')"
-enable_line="$(line_number 'launchctl enable "gui/$UID/live.streamvc.macprovider"')"
-bootstrap_line="$(line_number 'launchctl bootstrap "gui/$UID" "$PLIST_PATH"')"
+install_plist_line="$(line_number 'install_plist() {')"
+line_number_after() {
+  local start_line="$1"
+  local pattern="$2"
+  awk -v start_line="$start_line" -v pattern="$pattern" \
+    'NR > start_line && index($0, pattern) { print NR; exit }' "$INSTALL_SH"
+}
 
-[ -n "$bootout_line" ] || die "could not locate bootout line"
+reclaim_line="$(line_number_after "$install_plist_line" 'reclaim_launchd_service "$PROVIDER_LABEL"')"
+enable_line="$(line_number_after "$install_plist_line" 'launchctl enable "gui/$UID/$PROVIDER_LABEL"')"
+bootstrap_line="$(line_number_after "$install_plist_line" 'launchctl bootstrap "gui/$UID" "$PLIST_PATH"')"
+
+[ -n "$reclaim_line" ] || die "could not locate provider reclaim line"
 [ -n "$enable_line" ] || die "could not locate enable line"
 [ -n "$bootstrap_line" ] || die "could not locate bootstrap line"
 
-if [ "$bootout_line" -ge "$enable_line" ] || [ "$enable_line" -ge "$bootstrap_line" ]; then
-  die "launchd sequence must be bootout -> enable -> bootstrap; got $bootout_line -> $enable_line -> $bootstrap_line"
+if [ "$reclaim_line" -ge "$enable_line" ] || [ "$enable_line" -ge "$bootstrap_line" ]; then
+  die "launchd sequence must be reclaim -> enable -> bootstrap; got $reclaim_line -> $enable_line -> $bootstrap_line"
 fi
 
 printf '[install-launchd-test] install.sh launchd enable sequencing ok\n'

--- a/scripts/test-watchdog-inline-drift.sh
+++ b/scripts/test-watchdog-inline-drift.sh
@@ -25,11 +25,11 @@ INSTALLER="$REPO_ROOT/phase3-binary/dist/install.sh"
 [ -f "$INSTALLER" ] || { echo "missing $INSTALLER" >&2; exit 1; }
 
 # Extract the heredoc body. The marker pair is
-#   cat <<'WATCHDOG_EOF' > "$WATCHDOG_PATH"
+#   write_atomic_install_file "$WATCHDOG_PATH" <<'WATCHDOG_EOF'
 #   ...body...
 #   WATCHDOG_EOF
 extracted_inline="$(awk '
-  /cat <<.WATCHDOG_EOF. > "\$WATCHDOG_PATH"/ { inside=1; next }
+  /WATCHDOG_EOF/ && /WATCHDOG_PATH/ && (/cat/ || /write_atomic_install_file/) { inside=1; next }
   inside && /^WATCHDOG_EOF$/ { exit }
   inside { print }
 ' "$INSTALLER")"


### PR DESCRIPTION
## Summary

Closes #941.

This change makes Malibu's provider startup and migration flow safely handle standalone launchd installs, including stale services, custom install locations, missing provider binaries, unsafe filesystem ownership/ACLs, and unrecoverable loaded-provider conflicts.

## What changed

- Reclaims only launchd services whose labels and executable paths match the expected provider installation.
- Preserves safe custom provider install locations during migration.
- Adds a trusted-evidence repair path for missing provider binaries without silently adopting untrusted state.
- Rejects unsafe directory/file ownership, permissions, links, and ACL grants.
- Routes unrecoverable loaded-provider and manual launchd conflicts to explicit user intervention.
- Adds transaction, rollback, launchd migration, startup-route, ACL, and repair-intent regression coverage.

## Validation

- `bash -n phase3-binary/dist/install.sh`
- `bash phase3-binary/dist/test/install_launchd_migration.test.sh`
- `bash phase3-binary/dist/test/provider_upgrade_transaction.test.sh`
- `bash scripts/test-install-launchd-enable.sh`
- `bash scripts/test-watchdog-inline-drift.sh`
- `bash phase3-binary/dist/test/install_upgrade_evidence_rollback.test.sh`
- Full macOS `xcodebuild test` suite: passed
- Three-lane code, security, and architect audit: C/H/M = 0/0/0