### PR TITLE
fix(payout): allow wallet registration while payout pipeline is disabled (#954)

### DIFF
--- a/phase3-binary/Sources/macprovider-cli/PayoutAddressClient.swift
+++ b/phase3-binary/Sources/macprovider-cli/PayoutAddressClient.swift
@@ -256,6 +256,7 @@ struct PayoutAddressClient: Sendable {
             case (400, let c): return "Registration rejected (\(c ?? "bad_request"))."
             case (401, _): return "Provider access token was rejected. Repair saved access."
             case (403, _): return "This provider token cannot register a wallet for that identity."
+            case (404, _): return "Wallet changes are temporarily unavailable — try again later."
             case (409, _): return "Payouts are not yet enabled by the operator for this provider."
             case (429, _): return "Too many registration attempts. Wait and try again."
             case (503, _): return "Hot-wallet rotation is in progress. Retry later."

--- a/phase3-binary/Tests/macprovider-cliTests/PayoutAddressClientTests.swift
+++ b/phase3-binary/Tests/macprovider-cliTests/PayoutAddressClientTests.swift
@@ -201,6 +201,11 @@ final class PayoutAddressClientTests: XCTestCase {
             PayoutAddressClient.userMessage(for: .httpStatus(409, errorCode: "payout_not_allowed"))
                 .contains("not yet enabled")
         )
+        // 404 registration surface absent (#954)
+        XCTAssertTrue(
+            PayoutAddressClient.userMessage(for: .httpStatus(404, errorCode: nil))
+                .contains("temporarily unavailable")
+        )
         // 503 rotation
         XCTAssertTrue(
             PayoutAddressClient.userMessage(for: .httpStatus(503, errorCode: "rotation_in_progress"))

--- a/phase4-coordinator/cmd/coordinator/main.go
+++ b/phase4-coordinator/cmd/coordinator/main.go
@@ -893,8 +893,10 @@ func main() {
 
 	// SPEC-016 §4.1 — wire the payout package. Migrations + asserts
 	// run unconditionally so a future flip of payout.enabled does
-	// not require a schema migration window; the §3.3 handler is
-	// only mounted on the listener when payout.enabled is true.
+	// not require a schema migration window. §3.3 challenge/register
+	// mount whenever hot_wallet_address is set (registration-only
+	// when payout.enabled=false; #954 / SPEC v0.1.26). Admin payout
+	// routes and the runner require payout.enabled=true.
 	// Adapt billingStore to the payout.PayoutClaimer interface — the
 	// concrete ClaimPayoutReady method satisfies it without modification.
 	payoutAddresses, payoutMuxHandler, payoutS2, err := setupPayout(context.Background(), reqLogStore.DB(), cfg, tokenStore, billingStore, billingHandler, logger)
@@ -905,11 +907,11 @@ func main() {
 	_ = payoutAddresses // satisfies billing.PayoutAddressReader (used by Step 4 reconcile)
 	if cfg.Auth.RequireProviderTokens {
 		if payoutMuxHandler != nil {
-			// Mount payout mux at BOTH /providers/ (for §3.3) and
-			// /admin/payout/ (for §4.6 abandon + §4.2 run-now).
-			// Per architect r1 [arch:3.2]: a single /providers/ mount
-			// makes /admin/payout/* unreachable; mounting at both
-			// roots lets chi route to the right handler.
+			// Mount at BOTH /providers/ (§3.3; §7.3 when fully
+			// enabled) and /admin/payout/ (§6.4.1 pause/resume in
+			// registration-only; full admin suite when payoutS2 is
+			// wired). Per architect r1 [arch:3.2]: a single
+			// /providers/ mount makes /admin/payout/* unreachable.
 			providerMux.Handle("/providers/", payoutMuxHandler)
 			providerMux.Handle("/admin/payout/", payoutMuxHandler)
 		} else {
@@ -1584,9 +1586,10 @@ func startAuditLogRetentionPruner(ctx context.Context, store requestLogPruner, r
 // for the §3.3 endpoint.
 //
 // When payout.enabled = false the migrations + asserts still
-// run (so the schema is ready) but the returned http.Handler
-// is nil and the runner does not start. This matches SPEC-016
-// §0 "design-only" disposition at v0.1.x.
+// run (so the schema is ready) and the runner does not start.
+// If payout.security.hot_wallet_address is set, §3.3 handlers
+// still mount in registration-only mode (#954 / SPEC v0.1.26);
+// otherwise the returned http.Handler is nil.
 // payoutStep2 bundles the Step 2 components so main.go can run
 // the runner lifecycle alongside the existing shutdown ordering.
 // Step 3 extends it with the §4.8a + §4.7 reaper. Step 4 adds the
@@ -1629,8 +1632,34 @@ func setupPayout(ctx context.Context, db *sql.DB, cfg config.Config, tokenStore 
 		return nil, nil, nil, fmt.Errorf("assert triggers: %w", err)
 	}
 	if !cfg.Payout.Enabled {
-		logger.Info().Msg("payout pipeline disabled (payout.enabled=false); schema applied, handlers idle")
-		return nil, nil, nil, nil
+		if strings.TrimSpace(cfg.Payout.Security.HotWalletAddress) == "" {
+			logger.Info().Msg("payout pipeline disabled (payout.enabled=false); schema applied, handlers idle")
+			return nil, nil, nil, nil
+		}
+		// #954 / SPEC-016 v0.1.26 — registration-only: mount §3.3
+		// challenge/register + §6.4.1 pause/resume so providers can
+		// set/change wallets while the execution pipeline stays off.
+		// No runner, signer, RPC, lease, or execution-only admin routes.
+		hotWallet := strings.TrimSpace(cfg.Payout.Security.HotWalletAddress)
+		svc, mux, err := payout.BuildRegistrationOnly(payout.RegistrationOnlyOptions{
+			DB:                     db,
+			HotWallet:              hotWallet,
+			CoolingOff:             cfg.Payout.Tuning.AddressCoolingOffPeriod,
+			Tokens:                 tokenStore,
+			Identity:               tokenStore,
+			Fallback:               billingFallback,
+			OperatorKey:            cfg.Auth.OperatorKey,
+			PauseResumeMinInterval: cfg.Payout.Security.PauseResumeMinInterval,
+			Logger:                 logger,
+		})
+		if err != nil {
+			return nil, nil, nil, fmt.Errorf("payout registration-only: %w", err)
+		}
+		logger.Info().
+			Str("hot_wallet_address", hotWallet).
+			Dur("address_cooling_off_period", cfg.Payout.Tuning.AddressCoolingOffPeriod).
+			Msg("payout registration-only enabled (payout.enabled=false; §3.3 + pause/resume mounted, runner idle)")
+		return svc, mux, nil, nil
 	}
 	sec, err := payout.LoadSecurityConfig(cfg.Payout.Security.HotWalletAddress)
 	if err != nil {
@@ -1649,6 +1678,7 @@ func setupPayout(ctx context.Context, db *sql.DB, cfg config.Config, tokenStore 
 	if err := payout.AssertPayoutRuntimeTopology(payout.PayoutRuntimeTopology{
 		HandlerEnabled:         true,
 		RunnerCoResident:       true,
+		ExecutionEnabled:       true,
 		HotWalletAddressPinned: sec.HotWalletAddress,
 		LinuxRequired:          true,
 	}); err != nil {

--- a/phase4-coordinator/dist/check-deploy-config.sh
+++ b/phase4-coordinator/dist/check-deploy-config.sh
@@ -842,86 +842,104 @@ def g_payout(sub, key):
 
 payout_enabled_raw = g_section(coord, "payout", "enabled")
 payout_enabled = (payout_enabled_raw or "").strip().lower() == "true"
-if not payout_enabled:
-    print("  note: payout.enabled is false -> SPEC-016 payout gate SKIPPED")
-else:
-    def get_sec(k): return g_payout("security", k)
-    def get_tun(k): return g_payout("tuning", k)
+hot_wallet_raw = (g_payout("security", "hot_wallet_address") or "").strip()
+registration_only = (not payout_enabled) and hot_wallet_raw != ""
 
-    def check_payout_field(label, raw, *, hex_64=False, allow_empty=False, is_rpc_url=False):
-        """Validate a payout config field: present-with-value or env:NAME.
+def get_sec(k): return g_payout("security", k)
+def get_tun(k): return g_payout("tuning", k)
 
-        - missing                              -> HARD fail
-        - "env:NAME", NAME unset               -> ok (deferred to runtime)
-        - "env:NAME", NAME set to placeholder  -> HARD fail
-        - "env:" / "env:1bad"                  -> HARD fail (malformed)
-        - inline literal placeholder           -> HARD fail
-        - inline literal value                 -> ok (hex-validated if hex_64;
-                                                  https / non-internal target
-                                                  if is_rpc_url -- FULL-r1
-                                                  [full-sec:r1-1] closure)
-        """
-        if raw is None or raw == "":
-            if allow_empty:
-                ok(f"{label} empty -> default applies")
-                return
-            hard(f"{label} is MISSING — payout.enabled=true requires every payout.* key")
-            return
-        raw_s = str(raw)
-        src = ""
-        if raw_s.startswith("env:"):
-            m = ENV_REF.match(raw_s)
-            if not m:
-                hard(f"{label} malformed env indirection {raw_s!r}")
-                return
-            name = m.group(1)
-            resolved = os.environ.get(name)
-            if not resolved:
-                ok(f"{label} deferred to runtime via env:{name}")
-                return
-            raw_s = resolved
-            src = f" (resolved from env:{name})"
-        if PLACEHOLDER.search(raw_s) or raw_s.startswith("<"):
-            hard(f"{label} is a PLACEHOLDER{src} -> payout pipeline would fail at startup")
-            return
-        if hex_64 and not re.fullmatch(r"[0-9a-fA-F]{64}", raw_s):
-            hard(f"{label} is not 64-hex (len {len(raw_s)}){src}; expected SHA-256 SPKI pin")
-            return
-        if is_rpc_url:
-            err = validate_payout_rpc_url(raw_s)
-            if err is not None:
-                hard(f"{label} invalid{src}: {err}")
-                return
-        ok(f"{label} present{src}")
-
+def validate_payout_rpc_url(raw):
     # FULL-r1 [full-sec:r1-1] HIGH closure: payout RPC URLs are the
     # trust root for the §4.4 two-RPC discipline. Mirror the runtime
     # validation in internal/config/config.go::validatePayoutRPCURL —
     # reject non-https, userinfo, loopback / private / link-local /
     # unspecified IPs. Hostnames pass through (DNS not resolved in
     # the deploy gate); the SPKI pin is the runtime trust root.
-    def validate_payout_rpc_url(raw):
-        from urllib.parse import urlparse
-        import ipaddress
-        try:
-            u = urlparse(raw.strip())
-        except Exception as exc:
-            return f"unparseable URL ({exc})"
-        if not u.hostname:
-            return "missing hostname"
-        if u.scheme != "https":
-            return f"scheme {u.scheme!r} must be https (SPKI pin only fires on https)"
-        if u.username or u.password:
-            return "must not contain userinfo (credentials in URL leak into logs)"
-        host = u.hostname
-        try:
-            ip = ipaddress.ip_address(host)
-        except ValueError:
-            return None  # hostname literal: defer trust to SPKI pin
-        if ip.is_loopback or ip.is_private or ip.is_link_local or ip.is_unspecified:
-            return f"IP literal {host} is loopback / private / link-local / unspecified (SSRF defense)"
-        return None
+    from urllib.parse import urlparse
+    import ipaddress
+    try:
+        u = urlparse(raw.strip())
+    except Exception as exc:
+        return f"unparseable URL ({exc})"
+    if not u.hostname:
+        return "missing hostname"
+    if u.scheme != "https":
+        return f"scheme {u.scheme!r} must be https (SPKI pin only fires on https)"
+    if u.username or u.password:
+        return "must not contain userinfo (credentials in URL leak into logs)"
+    host = u.hostname
+    try:
+        ip = ipaddress.ip_address(host)
+    except ValueError:
+        return None  # hostname literal: defer trust to SPKI pin
+    if ip.is_loopback or ip.is_private or ip.is_link_local or ip.is_unspecified:
+        return f"IP literal {host} is loopback / private / link-local / unspecified (SSRF defense)"
+    return None
 
+def check_payout_field(label, raw, *, hex_64=False, allow_empty=False, is_rpc_url=False):
+    """Validate a payout config field: present-with-value or env:NAME.
+
+    - missing                              -> HARD fail
+    - "env:NAME", NAME unset               -> ok (deferred to runtime)
+    - "env:NAME", NAME set to placeholder  -> HARD fail
+    - "env:" / "env:1bad"                  -> HARD fail (malformed)
+    - inline literal placeholder           -> HARD fail
+    - inline literal value                 -> ok (hex-validated if hex_64;
+                                              https / non-internal target
+                                              if is_rpc_url -- FULL-r1
+                                              [full-sec:r1-1] closure)
+    """
+    if raw is None or raw == "":
+        if allow_empty:
+            ok(f"{label} empty -> default applies")
+            return
+        hard(f"{label} is MISSING — payout.enabled=true requires every payout.* key")
+        return
+    raw_s = str(raw)
+    src = ""
+    if raw_s.startswith("env:"):
+        m = ENV_REF.match(raw_s)
+        if not m:
+            hard(f"{label} malformed env indirection {raw_s!r}")
+            return
+        name = m.group(1)
+        resolved = os.environ.get(name)
+        if not resolved:
+            ok(f"{label} deferred to runtime via env:{name}")
+            return
+        raw_s = resolved
+        src = f" (resolved from env:{name})"
+    if PLACEHOLDER.search(raw_s) or raw_s.startswith("<"):
+        hard(f"{label} is a PLACEHOLDER{src} -> payout pipeline would fail at startup")
+        return
+    if hex_64 and not re.fullmatch(r"[0-9a-fA-F]{64}", raw_s):
+        hard(f"{label} is not 64-hex (len {len(raw_s)}){src}; expected SHA-256 SPKI pin")
+        return
+    if is_rpc_url:
+        err = validate_payout_rpc_url(raw_s)
+        if err is not None:
+            hard(f"{label} invalid{src}: {err}")
+            return
+    ok(f"{label} present{src}")
+
+if registration_only:
+    # SPEC-016 v0.1.26 §4.1 — §3.3 mounts with payout.enabled=false.
+    # Validate the hot-wallet pin + cooling-off floor; skip execution-only keys.
+    print("  note: payout.enabled=false with hot_wallet_address set -> registration-only gate")
+    check_payout_field("payout.security.hot_wallet_address", hot_wallet_raw)
+    cooling = get_tun("address_cooling_off_period")
+    if cooling is None or cooling == "":
+        hard("payout.tuning.address_cooling_off_period is MISSING — required in registration-only (SPEC-016 §3.1)")
+    else:
+        ok("payout.tuning.address_cooling_off_period present")
+    pause_min = get_sec("pause_resume_min_interval")
+    if pause_min is None or pause_min == "":
+        hard("payout.security.pause_resume_min_interval is MISSING — required in registration-only (SPEC-016 §6.4.1)")
+    else:
+        ok("payout.security.pause_resume_min_interval present")
+elif not payout_enabled:
+    print("  note: payout.enabled is false and no hot wallet -> SPEC-016 payout gate SKIPPED")
+else:
     # security namespace (required when enabled=true)
     check_payout_field("payout.security.hot_wallet_address", get_sec("hot_wallet_address"))
     check_payout_field("payout.security.rpc_url_primary",   get_sec("rpc_url_primary"),   is_rpc_url=True)

--- a/phase4-coordinator/dist/coordinator.yaml.example
+++ b/phase4-coordinator/dist/coordinator.yaml.example
@@ -408,14 +408,26 @@ providers:
 # operator runbook at dist/payout-runbook.md.
 
 payout:
-  # Master switch. Schema + handlers initialise at false; runner +
-  # endpoints do NOT start. Flip to true after every §9 prereq is met.
+  # Execution-pipeline switch. Schema always initialises. When false
+  # (default): runner/signer/RPC/lease stay idle. Flip to true only
+  # after every §9 prereq is met (see dist/payout-runbook.md).
+  #
+  # Registration-only (#954 / SPEC-016 v0.1.26): setting a valid
+  # hot_wallet_address below while enabled=false mounts §3.3
+  # challenge/register + §6.4.1 pause/resume so providers can set
+  # wallets without starting the payout runner. Leave empty to keep
+  # §3.3 unmounted.
   enabled: false
 
   security:
-    # §3.1 hot wallet address (EIP-55 checksummed). Required when
-    # enabled=true.
-    hot_wallet_address: "<0x... EIP-55 checksummed hot wallet>"
+    # §3.1 hot wallet address (EIP-55 checksummed).
+    # - empty + enabled=false: §3.3 unmounted (handlers idle)
+    # - set + enabled=false: registration-only (§3.3 + pause/resume)
+    # - set + enabled=true: full pipeline (also requires RPC URLs,
+    #   encrypted wallet path, caps, etc.)
+    # Use the FINAL production hot wallet — registrations pin
+    # registered_against_hot_wallet to this value.
+    hot_wallet_address: ""
 
     # §4.4 two-RPC URLs. Both required for nonce sync + receipt
     # agreement. Use distinct providers (e.g. Infura + Alchemy) so

--- a/phase4-coordinator/dist/payout-runbook.md
+++ b/phase4-coordinator/dist/payout-runbook.md
@@ -1,4 +1,4 @@
-# Payout pipeline operator runbook (SPEC-016 v0.1.21)
+# Payout pipeline operator runbook (SPEC-016 v0.1.26)
 
 This document is the cutover checklist + day-2 operations
 guide for the SPEC-016 USDC-on-Base payout pipeline. Every
@@ -7,14 +7,48 @@ narrative**, the SPEC body is the source of truth on contract.
 
 > **Read order for first-time deploy.**
 >
-> 1. §1 Hot wallet provisioning + funding (this doc)
-> 2. §2 Cap-decision worksheet (this doc, mirrors SPEC §9.3)
-> 3. §3 BetterStack synthetic-alert verification (SPEC §9.7
+> 1. §0 Registration-only posture (this doc — #954)
+> 2. §1 Hot wallet provisioning + funding (this doc)
+> 3. §2 Cap-decision worksheet (this doc, mirrors SPEC §9.3)
+> 4. §3 BetterStack synthetic-alert verification (SPEC §9.7
 >    prereq item 6 — required BEFORE cutover)
-> 4. §4 Cutover sequence (this doc, mirrors SPEC §9 cutover)
-> 5. Day-2: §5 key-rotation runbook (SPEC §6.4 steps 1–5)
-> 6. Day-2: §6 SPKI pin rotation (when rotating RPC endpoint certificates)
-> 7. Day-2: §7 weekly reconciliation (SPEC §7.4 queries A–F)
+> 5. §4 Cutover sequence (this doc, mirrors SPEC §9 cutover)
+> 6. Day-2: §5 key-rotation runbook (SPEC §6.4 steps 1–5)
+> 7. Day-2: §6 SPKI pin rotation (when rotating RPC endpoint certificates)
+> 8. Day-2: §7 weekly reconciliation (SPEC §7.4 queries A–F)
+
+---
+
+## 0. Registration-only posture (#954 / SPEC-016 v0.1.26)
+
+`payout.enabled: false` no longer means "§3.3 is dark." When
+`payout.security.hot_wallet_address` is set to the **final**
+production EIP-55 address, the coordinator mounts:
+
+- `GET /providers/{id}/payout-address/challenge`
+- `POST /providers/{id}/payout-address`
+- `POST /admin/payout/pause-registration` /
+  `POST /admin/payout/resume-registration`
+
+and does **not** start the runner, load the signer/KEK, open
+RPC clients, or acquire the payout lease. Leave
+`hot_wallet_address: ""` to keep §3.3 unmounted.
+
+**Production remediation for Malibu "Open browser wallet" HTTP 404:**
+set the real hot-wallet pin in the Pearl overlay while keeping
+`payout.enabled: false`, then restart the coordinator. Confirm
+journal line `payout registration-only enabled` and that
+`/providers/{id}/payout-address/challenge` returns 401 (not 404)
+without a bearer. Use the FINAL production address —
+registrations stamp `registered_against_hot_wallet` and a later
+rotation strands every prior row until re-registration (§6.4 step 5).
+
+**Kill switch while registration-only:** call pause-registration
+(operator key). Do **not** rely on flipping `payout.enabled` —
+that flag no longer unmounts §3.3 when the hot wallet is set.
+
+**Rotation ordering (§6.4 step 1):** pause-registration FIRST,
+THEN flip `payout.enabled: false` / restart. Pause-before-disable.
 
 ---
 

--- a/phase4-coordinator/internal/config/config.go
+++ b/phase4-coordinator/internal/config/config.go
@@ -1755,6 +1755,15 @@ func (c *Config) resolveEnv() error {
 	// fields must honor the env:NAME indirection rule. The deploy gate
 	// already validates env: presence; without this resolver the
 	// coordinator boots with literal "env:..." RPC/wallet strings.
+	// #954: resolve hot_wallet_address whenever non-empty so
+	// registration-only mode can use env:NAME too.
+	if strings.TrimSpace(c.Payout.Security.HotWalletAddress) != "" {
+		if v, err := resolveEnvValue("payout.security.hot_wallet_address", c.Payout.Security.HotWalletAddress); err != nil {
+			return err
+		} else {
+			c.Payout.Security.HotWalletAddress = strings.TrimSpace(v)
+		}
+	}
 	if c.Payout.Enabled {
 		if v, err := resolveEnvValue("payout.security.rpc_url_primary", c.Payout.Security.RPCURLPrimary); err != nil {
 			return err
@@ -1765,11 +1774,6 @@ func (c *Config) resolveEnv() error {
 			return err
 		} else {
 			c.Payout.Security.RPCURLSecondary = v
-		}
-		if v, err := resolveEnvValue("payout.security.hot_wallet_address", c.Payout.Security.HotWalletAddress); err != nil {
-			return err
-		} else {
-			c.Payout.Security.HotWalletAddress = v
 		}
 		if v, err := resolveEnvValue("payout.security.encrypted_wallet_path", c.Payout.Security.EncryptedWalletPath); err != nil {
 			return err
@@ -2301,6 +2305,25 @@ func (c Config) Validate() error {
 		if p.EndpointURL != "" {
 			if err := ValidateEndpointURL(p.EndpointURL); err != nil {
 				return fmt.Errorf("provider %q endpoint_url must be a valid https URL (http allowed only for 127.0.0.1/localhost)", p.ProviderID)
+			}
+		}
+	}
+	// Registration-only (#954 / SPEC-016 v0.1.26): hot_wallet_address
+	// without payout.enabled still mounts §3.3 handlers, so the pin
+	// must be a real EIP-55 address (not a template placeholder) and
+	// cooling-off bounds apply. Full pipeline validation remains
+	// behind Enabled.
+	if !c.Payout.Enabled {
+		hot := strings.TrimSpace(c.Payout.Security.HotWalletAddress)
+		if hot != "" {
+			if err := validatePayoutHotWalletAddress(hot); err != nil {
+				return fmt.Errorf("payout.security.hot_wallet_address: %w (set a valid EIP-55 address for registration-only, or leave empty to keep §3.3 unmounted)", err)
+			}
+			if c.Payout.Tuning.AddressCoolingOffPeriod < time.Hour {
+				return fmt.Errorf("payout.tuning.address_cooling_off_period must be >= 1h when payout.security.hot_wallet_address is set (SPEC-016 §3.1 registration-only)")
+			}
+			if c.Payout.Security.PauseResumeMinInterval < time.Second {
+				return fmt.Errorf("payout.security.pause_resume_min_interval must be >= 1s when payout.security.hot_wallet_address is set (SPEC-016 §6.4.1 registration-only)")
 			}
 		}
 	}
@@ -3022,6 +3045,34 @@ func validateSPKIPin(value, name string) error {
 			continue
 		}
 		return fmt.Errorf("%s must be empty or a valid 64-hex-char SHA-256", name)
+	}
+	return nil
+}
+
+// validatePayoutHotWalletAddress rejects placeholders and non-EIP-55
+// shapes without importing the payout package (avoids a config↔payout
+// cycle). Full checksum enforcement still runs in payout.LoadSecurityConfig
+// at setup time.
+func validatePayoutHotWalletAddress(raw string) error {
+	if raw == "" {
+		return fmt.Errorf("empty")
+	}
+	if strings.HasPrefix(raw, "<") || strings.Contains(raw, "...") || strings.Contains(strings.ToLower(raw), "placeholder") {
+		return fmt.Errorf("looks like a template placeholder %q", raw)
+	}
+	if len(raw) != 42 {
+		return fmt.Errorf("must be 42-char 0x-prefixed EIP-55 address (got len %d)", len(raw))
+	}
+	if !strings.HasPrefix(raw, "0x") && !strings.HasPrefix(raw, "0X") {
+		return fmt.Errorf("must start with 0x")
+	}
+	for _, c := range raw[2:] {
+		isDigit := c >= '0' && c <= '9'
+		isLower := c >= 'a' && c <= 'f'
+		isUpper := c >= 'A' && c <= 'F'
+		if !isDigit && !isLower && !isUpper {
+			return fmt.Errorf("contains non-hex character")
+		}
 	}
 	return nil
 }

--- a/phase4-coordinator/internal/config/config_env_test.go
+++ b/phase4-coordinator/internal/config/config_env_test.go
@@ -296,3 +296,29 @@ func loadConfigFromYAML(t *testing.T, fragment string) (Config, error) {
 	}
 	return Load(path)
 }
+
+// TestLoadResolvesHotWalletEnvInRegistrationOnly covers #954:
+// env:NAME for hot_wallet_address must resolve even when
+// payout.enabled=false so registration-only can use secret indirection.
+func TestLoadResolvesHotWalletEnvInRegistrationOnly(t *testing.T) {
+	t.Setenv("S954_TEST_OP_KEY", "0123456789abcdefABCDEFghijklmnop")
+	t.Setenv("S954_PAYOUT_HOT_WALLET", "0x8ba1f109551bD432803012645Ac136ddd64DBA72")
+
+	cfg := writeMinimalConfig(t, `
+auth:
+  operator_key: env:S954_TEST_OP_KEY
+  gateway_service_token: fedcba9876543210PONMLKJIHGFEDCBA
+payout:
+  enabled: false
+  security:
+    hot_wallet_address: env:S954_PAYOUT_HOT_WALLET
+  tuning:
+    address_cooling_off_period: 24h
+`)
+	if cfg.Payout.Security.HotWalletAddress != "0x8ba1f109551bD432803012645Ac136ddd64DBA72" {
+		t.Errorf("HotWalletAddress=%q, want resolved value in registration-only", cfg.Payout.Security.HotWalletAddress)
+	}
+	if cfg.Payout.Enabled {
+		t.Fatal("enabled must stay false")
+	}
+}

--- a/phase4-coordinator/internal/config/config_test.go
+++ b/phase4-coordinator/internal/config/config_test.go
@@ -1115,3 +1115,40 @@ malibu_emission:
 		t.Fatalf("provider cap=%v", cfg.MalibuEmission.ProviderDailyCapMALIBU)
 	}
 }
+
+func TestValidateRegistrationOnlyCoolingOffFloor(t *testing.T) {
+	cfg := validTestConfig()
+	cfg.Payout.Enabled = false
+	cfg.Payout.Security.HotWalletAddress = "0xfB6916095ca1df60bB79Ce92cE3Ea74c37c5d359"
+	cfg.Payout.Tuning.AddressCoolingOffPeriod = 30 * time.Minute
+	err := cfg.Validate()
+	if err == nil || !strings.Contains(err.Error(), "address_cooling_off_period") {
+		t.Fatalf("Validate error=%v, want cooling-off floor for registration-only", err)
+	}
+
+	cfg.Payout.Tuning.AddressCoolingOffPeriod = 24 * time.Hour
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("Validate registration-only with valid cooling-off: %v", err)
+	}
+}
+
+func TestValidateRegistrationOnlyRejectsPlaceholderHotWallet(t *testing.T) {
+	cfg := validTestConfig()
+	cfg.Payout.Enabled = false
+	cfg.Payout.Security.HotWalletAddress = "<0x... EIP-55 checksummed hot wallet>"
+	cfg.Payout.Tuning.AddressCoolingOffPeriod = 24 * time.Hour
+	err := cfg.Validate()
+	if err == nil || !strings.Contains(err.Error(), "hot_wallet_address") {
+		t.Fatalf("Validate error=%v, want placeholder hot wallet rejection", err)
+	}
+}
+
+func TestValidateDisabledWithoutHotWalletSkipsCoolingOff(t *testing.T) {
+	cfg := validTestConfig()
+	cfg.Payout.Enabled = false
+	cfg.Payout.Security.HotWalletAddress = ""
+	cfg.Payout.Tuning.AddressCoolingOffPeriod = 30 * time.Minute
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("fully disabled payout should not enforce cooling-off: %v", err)
+	}
+}

--- a/phase4-coordinator/internal/payout/journey_evidence_test.go
+++ b/phase4-coordinator/internal/payout/journey_evidence_test.go
@@ -17,7 +17,6 @@ import (
 
 	"github.com/augstar/macprovider-coordinator/internal/auth"
 	"github.com/decred/dcrd/dcrec/secp256k1/v4"
-	"github.com/go-chi/chi/v5"
 	"golang.org/x/crypto/sha3"
 )
 
@@ -83,7 +82,7 @@ func TestPayoutAddressRegistrationJourneyEvidence(t *testing.T) {
 	svc := newJourneyServiceForTest(t, db, hotWallet, authStore, &fakePause{})
 	svc.Log = logger
 	svc.Now = func() time.Time { return startClock }
-	router := journeyRouter(svc)
+	router := journeyRouter(t, db, svc)
 
 	assertions := []journeyAssertion{}
 	addAssertionStatus := func(id, status, assertion string, details map[string]any) {
@@ -432,11 +431,38 @@ func journeyResultSteps(assertions []journeyAssertion, artifactID string) []map[
 	return steps
 }
 
-func journeyRouter(svc *AddressesService) http.Handler {
-	r := chi.NewRouter()
-	r.Get("/providers/{provider_id}/payout-address/challenge", svc.ServePayoutChallenge)
-	r.Post("/providers/{provider_id}/payout-address", svc.ServePayoutAddress)
-	return r
+func journeyRouter(t *testing.T, db *sql.DB, svc *AddressesService) http.Handler {
+	t.Helper()
+	logger, _ := quietLogger()
+	flagWriter, err := NewRuntimeFlagWriter(db, logger)
+	if err != nil {
+		t.Fatalf("journey flag writer: %v", err)
+	}
+	pauseSvc, err := NewPauseResumeService(PauseResumeOptions{
+		Writer:      flagWriter,
+		MinInterval: time.Second,
+		Logger:      logger,
+	})
+	if err != nil {
+		t.Fatalf("journey pause service: %v", err)
+	}
+	fallback := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.NotFound(w, r)
+	})
+	// Exercise the shipped registration-only mux (#954), not a
+	// hand-rolled chi router, so journey evidence covers the
+	// production composition (SPEC v0.1.26).
+	mux, err := NewMuxRegistrationOnly(RegistrationOnlyMuxOptions{
+		Addresses:   svc,
+		Pause:       pauseSvc,
+		OperatorKey: "journey-operator-key-32bytes-long!!!",
+		Actor:       "operator_key:journey",
+		Fallback:    fallback,
+	})
+	if err != nil {
+		t.Fatalf("journey registration-only mux: %v", err)
+	}
+	return mux
 }
 
 func serveJourneyRequest(handler http.Handler, method, path, body, token string) *httptest.ResponseRecorder {
@@ -635,7 +661,7 @@ func exerciseInvalidJourneyCases(t *testing.T, hotWallet, providerID string, pri
 		svc := newJourneyServiceForTest(t, db, hotWallet, authStore, &fakePause{})
 		svc.Log = logger
 		svc.Now = func() time.Time { return now }
-		rec := serveJourneyRequest(journeyRouter(svc), http.MethodPost, path, body, runToken)
+		rec := serveJourneyRequest(journeyRouter(t, db, svc), http.MethodPost, path, body, runToken)
 		requireStatus(t, rec, want, name)
 		if wantBody != "" && !strings.Contains(rec.Body.String(), wantBody) {
 			t.Fatalf("%s body=%s missing %s", name, rec.Body.String(), wantBody)
@@ -681,7 +707,7 @@ VALUES (?, 'base-mainnet', '0xAaAaAaAaAaAaAaAaAaAaAaAaAaAaAaAaAaAaAaAa',
 	svc.Log = logger
 	svc.Now = func() time.Time { return now }
 	body := buildRequestBody(t, priv, providerID, providerAddr, hotWallet, uint64(now.Unix()), [32]byte{0x09, 0x09})
-	rec := serveJourneyRequest(journeyRouter(svc), http.MethodPost, "/providers/"+providerID+"/payout-address", body, disabledToken)
+	rec := serveJourneyRequest(journeyRouter(t, db, svc), http.MethodPost, "/providers/"+providerID+"/payout-address", body, disabledToken)
 	requireStatus(t, rec, http.StatusConflict, "disabled rotation")
 	if !strings.Contains(rec.Body.String(), "payout_not_allowed") {
 		t.Fatalf("disabled rotation body=%s missing payout_not_allowed", rec.Body.String())
@@ -718,7 +744,7 @@ func exercisePauseCases(t *testing.T, hotWallet, providerID string, priv *secp25
 	pausedSvc := newJourneyServiceForTest(t, pausedDB, hotWallet, pausedAuth, &fakePause{paused: true})
 	pausedSvc.Log = pausedLogger
 	pausedSvc.Now = func() time.Time { return now }
-	pausedRouter := journeyRouter(pausedSvc)
+	pausedRouter := journeyRouter(t, pausedDB, pausedSvc)
 	challengeNoAuth := serveJourneyRequest(pausedRouter, http.MethodGet, "/providers/"+providerID+"/payout-address/challenge", "", "")
 	challengeAuth := serveJourneyRequest(pausedRouter, http.MethodGet, "/providers/"+providerID+"/payout-address/challenge", "", pausedToken)
 	body := buildRequestBody(t, priv, providerID, providerAddr, hotWallet, uint64(now.Unix()), [32]byte{0x0a})
@@ -739,7 +765,7 @@ func exercisePauseCases(t *testing.T, hotWallet, providerID string, priv *secp25
 	toctouSvc := newJourneyServiceForTest(t, toctouDB, hotWallet, toctouAuth, &toctouPause{db: toctouDB})
 	toctouSvc.Log = toctouLogger
 	toctouSvc.Now = func() time.Time { return now }
-	toctouRec := serveJourneyRequest(journeyRouter(toctouSvc), http.MethodPost, "/providers/"+providerID+"/payout-address", body, toctouToken)
+	toctouRec := serveJourneyRequest(journeyRouter(t, toctouDB, toctouSvc), http.MethodPost, "/providers/"+providerID+"/payout-address", body, toctouToken)
 	requireStatus(t, toctouRec, http.StatusServiceUnavailable, "toctou pause")
 	requireLogEventCount(t, toctouLogs.String(), "provider_payout_address_change_rejected", map[string]string{"provider_id": providerID, "reason": "registration_paused"}, 1)
 	out["toctou_status"] = toctouRec.Code
@@ -754,7 +780,7 @@ func exercisePauseCases(t *testing.T, hotWallet, providerID string, priv *secp25
 	rateSvc := newJourneyServiceForTest(t, rateDB, hotWallet, rateAuth, &fakePause{})
 	rateSvc.Log = rateLogger
 	rateSvc.Now = func() time.Time { return now }
-	rateRouter := journeyRouter(rateSvc)
+	rateRouter := journeyRouter(t, rateDB, rateSvc)
 	for i := 0; i < registrationRateLimitDefault; i++ {
 		rec := serveJourneyRequest(rateRouter, http.MethodPost, "/providers/rate-provider/payout-address", "{}", rateToken)
 		if rec.Code == http.StatusTooManyRequests {

--- a/phase4-coordinator/internal/payout/mux.go
+++ b/phase4-coordinator/internal/payout/mux.go
@@ -50,6 +50,14 @@ var step1PathTable = []PathTableEntry{
 	{Method: http.MethodGet, Path: "/providers/{provider_id}/payout-address/challenge", Realm: RealmProviderToken},
 }
 
+// registrationOnlyPathTable is the #954 / SPEC v0.1.26 surface:
+// §3.3 challenge/register plus the §6.4.1 pause/resume kill
+// switch. Execution-only admin routes stay off.
+var registrationOnlyPathTable = append([]PathTableEntry{
+	{Method: http.MethodPost, Path: "/admin/payout/pause-registration", Realm: RealmOperatorKey},
+	{Method: http.MethodPost, Path: "/admin/payout/resume-registration", Realm: RealmOperatorKey},
+}, step1PathTable...)
+
 // step2PathTable extends step1PathTable with the Step 2 admin
 // routes. The wildcard fallback /providers/* remains anchored to
 // step1; Step 2 adds operator-key surfaces under /admin/payout/*.
@@ -112,6 +120,60 @@ func NewMux(addresses *AddressesService, fallback http.Handler) (http.Handler, e
 	// SPEC §3.3 path-table verification. Walk chi's routes and
 	// confirm parity with step1PathTable.
 	if err := verifyPathTable(r, step1PathTable); err != nil {
+		return nil, err
+	}
+	return r, nil
+}
+
+// RegistrationOnlyMuxOptions wires §3.3 + §6.4.1 without the
+// execution pipeline (runner/signer/RPC/lease).
+type RegistrationOnlyMuxOptions struct {
+	Addresses   *AddressesService
+	Pause       *PauseResumeService
+	OperatorKey string
+	Actor       string
+	Fallback    http.Handler
+}
+
+// NewMuxRegistrationOnly mounts provider-token §3.3 routes and
+// operator-key pause/resume. Path-table parity is asserted against
+// registrationOnlyPathTable.
+func NewMuxRegistrationOnly(opts RegistrationOnlyMuxOptions) (http.Handler, error) {
+	if opts.Addresses == nil {
+		return nil, fmt.Errorf("payout.NewMuxRegistrationOnly: AddressesService required")
+	}
+	if opts.Pause == nil {
+		return nil, fmt.Errorf("payout.NewMuxRegistrationOnly: Pause required")
+	}
+	if opts.OperatorKey == "" {
+		return nil, fmt.Errorf("payout.NewMuxRegistrationOnly: OperatorKey required")
+	}
+	if opts.Actor == "" {
+		return nil, fmt.Errorf("payout.NewMuxRegistrationOnly: Actor required")
+	}
+	if opts.Fallback == nil {
+		return nil, fmt.Errorf("payout.NewMuxRegistrationOnly: Fallback required")
+	}
+	r := chi.NewRouter()
+	r.Post("/providers/{provider_id}/payout-address", opts.Addresses.ServePayoutAddress)
+	r.Get("/providers/{provider_id}/payout-address/challenge", opts.Addresses.ServePayoutChallenge)
+	r.HandleFunc("/providers/*", opts.Fallback.ServeHTTP)
+
+	auth := operatorKeyMiddleware(opts.OperatorKey)
+	// runner is nil — withHaltObservability is a pass-through in
+	// registration-only (no halt state without a runner).
+	r.With(auth).Post("/admin/payout/pause-registration", withHaltObservability(
+		"pause-registration", nil,
+		func(w http.ResponseWriter, req *http.Request) {
+			opts.Pause.ServePause(w, req, opts.Actor)
+		}))
+	r.With(auth).Post("/admin/payout/resume-registration", withHaltObservability(
+		"resume-registration", nil,
+		func(w http.ResponseWriter, req *http.Request) {
+			opts.Pause.ServeResume(w, req, opts.Actor)
+		}))
+
+	if err := verifyPathTable(r, registrationOnlyPathTable); err != nil {
 		return nil, err
 	}
 	return r, nil

--- a/phase4-coordinator/internal/payout/registration_only.go
+++ b/phase4-coordinator/internal/payout/registration_only.go
@@ -1,0 +1,109 @@
+package payout
+
+import (
+	"database/sql"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/rs/zerolog"
+)
+
+// RegistrationOnlyOptions configures the SPEC-016 §3.3 + §6.4.1
+// registration-only surface (#954 / SPEC v0.1.26).
+//
+// Callers MUST NOT start a runner, load a signer/KEK, open RPC
+// clients, or acquire the payout lease after this returns.
+type RegistrationOnlyOptions struct {
+	DB          *sql.DB
+	HotWallet   string
+	CoolingOff  time.Duration
+	Tokens      providerTokenValidator
+	Identity    providerIdentityChecker
+	Fallback    http.Handler
+	OperatorKey string
+	// PauseResumeMinInterval is payout.security.pause_resume_min_interval.
+	PauseResumeMinInterval time.Duration
+	Logger                 zerolog.Logger
+}
+
+// BuildRegistrationOnly constructs the registration-only mux:
+// provider-token §3.3 challenge/register plus operator-key
+// §6.4.1 pause/resume. Execution-only admin routes (run-now,
+// abandon, funding, orphans) and GET /providers/{id}/payouts
+// are NOT mounted.
+func BuildRegistrationOnly(opts RegistrationOnlyOptions) (*AddressesService, http.Handler, error) {
+	if opts.DB == nil {
+		return nil, nil, fmt.Errorf("payout.BuildRegistrationOnly: db is required")
+	}
+	if opts.Tokens == nil {
+		return nil, nil, fmt.Errorf("payout.BuildRegistrationOnly: tokens is required")
+	}
+	if opts.Identity == nil {
+		return nil, nil, fmt.Errorf("payout.BuildRegistrationOnly: identity is required")
+	}
+	if opts.Fallback == nil {
+		return nil, nil, fmt.Errorf("payout.BuildRegistrationOnly: fallback is required")
+	}
+	if opts.OperatorKey == "" {
+		return nil, nil, fmt.Errorf("payout.BuildRegistrationOnly: OperatorKey is required")
+	}
+	if opts.CoolingOff < time.Hour {
+		return nil, nil, fmt.Errorf("payout.BuildRegistrationOnly: coolingOff must be >= 1h (SPEC §3.1)")
+	}
+	if opts.PauseResumeMinInterval < time.Second {
+		return nil, nil, fmt.Errorf("payout.BuildRegistrationOnly: PauseResumeMinInterval must be >= 1s")
+	}
+
+	sec, err := LoadSecurityConfig(opts.HotWallet)
+	if err != nil {
+		return nil, nil, fmt.Errorf("payout.BuildRegistrationOnly: load security config: %w", err)
+	}
+	if err := AssertPayoutRuntimeTopology(PayoutRuntimeTopology{
+		HandlerEnabled:         true,
+		RunnerCoResident:       false,
+		ExecutionEnabled:       false,
+		HotWalletAddressPinned: sec.HotWalletAddress,
+		LinuxRequired:          false,
+	}); err != nil {
+		return nil, nil, fmt.Errorf("payout.BuildRegistrationOnly: topology: %w", err)
+	}
+
+	denyList, err := NewDenyList(sec.HotWalletAddress)
+	if err != nil {
+		return nil, nil, fmt.Errorf("payout.BuildRegistrationOnly: deny-list: %w", err)
+	}
+	pauseReader, err := NewPauseReader(opts.DB)
+	if err != nil {
+		return nil, nil, fmt.Errorf("payout.BuildRegistrationOnly: pause reader: %w", err)
+	}
+	svc, err := NewAddressesService(opts.DB, sec, denyList, opts.Tokens, opts.Identity, pauseReader, opts.CoolingOff, opts.Logger)
+	if err != nil {
+		return nil, nil, fmt.Errorf("payout.BuildRegistrationOnly: addresses service: %w", err)
+	}
+
+	flagWriter, err := NewRuntimeFlagWriter(opts.DB, opts.Logger)
+	if err != nil {
+		return nil, nil, fmt.Errorf("payout.BuildRegistrationOnly: flag writer: %w", err)
+	}
+	pauseSvc, err := NewPauseResumeService(PauseResumeOptions{
+		Writer:      flagWriter,
+		MinInterval: opts.PauseResumeMinInterval,
+		Logger:      opts.Logger,
+	})
+	if err != nil {
+		return nil, nil, fmt.Errorf("payout.BuildRegistrationOnly: pause service: %w", err)
+	}
+
+	mux, err := NewMuxRegistrationOnly(RegistrationOnlyMuxOptions{
+		Addresses:   svc,
+		Pause:       pauseSvc,
+		OperatorKey: opts.OperatorKey,
+		Actor:       "operator_key:coordinator",
+		Fallback:    opts.Fallback,
+	})
+	if err != nil {
+		return nil, nil, fmt.Errorf("payout.BuildRegistrationOnly: mux: %w", err)
+	}
+	return svc, mux, nil
+}

--- a/phase4-coordinator/internal/payout/registration_only_test.go
+++ b/phase4-coordinator/internal/payout/registration_only_test.go
@@ -1,0 +1,124 @@
+package payout
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestBuildRegistrationOnly_MountsChallengeRegisterAndPause(t *testing.T) {
+	db := openTestDB(t)
+	logger, _ := quietLogger()
+	if err := BootstrapRuntimeFlags(context.Background(), db, time.Now().UTC(), logger); err != nil {
+		t.Fatalf("bootstrap: %v", err)
+	}
+
+	hotWallet := "0xfB6916095ca1df60bB79Ce92cE3Ea74c37c5d359"
+	ft := &fakeTokens{token: "tok", providerID: "test-pid"}
+	fallback := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	})
+
+	svc, mux, err := BuildRegistrationOnly(RegistrationOnlyOptions{
+		DB:                     db,
+		HotWallet:              hotWallet,
+		CoolingOff:             24 * time.Hour,
+		Tokens:                 ft,
+		Identity:               ft,
+		Fallback:               fallback,
+		OperatorKey:            "test-operator-key-32bytes-long!!!!",
+		PauseResumeMinInterval: time.Second,
+		Logger:                 logger,
+	})
+	if err != nil {
+		t.Fatalf("BuildRegistrationOnly: %v", err)
+	}
+	if svc == nil || mux == nil {
+		t.Fatal("expected non-nil service and mux")
+	}
+
+	challengeReq := httptest.NewRequest(http.MethodGet, "/providers/test-pid/payout-address/challenge", nil)
+	challengeRec := httptest.NewRecorder()
+	mux.ServeHTTP(challengeRec, challengeReq)
+	if challengeRec.Code != http.StatusUnauthorized {
+		t.Fatalf("challenge status=%d want 401 without bearer", challengeRec.Code)
+	}
+
+	regReq := httptest.NewRequest(http.MethodPost, "/providers/test-pid/payout-address", strings.NewReader(`{}`))
+	regRec := httptest.NewRecorder()
+	mux.ServeHTTP(regRec, regReq)
+	if regRec.Code == http.StatusNotFound {
+		t.Fatalf("register route 404 — registration-only mux did not mount §3.3")
+	}
+	if regRec.Code != http.StatusUnauthorized {
+		t.Fatalf("register status=%d want 401 without bearer", regRec.Code)
+	}
+
+	// Pause kill switch MUST be mounted (operator-key auth → 401 without key).
+	pauseReq := httptest.NewRequest(http.MethodPost, "/admin/payout/pause-registration", strings.NewReader(`{"reason":"test"}`))
+	pauseRec := httptest.NewRecorder()
+	mux.ServeHTTP(pauseRec, pauseReq)
+	if pauseRec.Code != http.StatusUnauthorized {
+		t.Fatalf("pause status=%d want 401 without operator key", pauseRec.Code)
+	}
+
+	// Execution-only admin routes MUST NOT be mounted.
+	adminReq := httptest.NewRequest(http.MethodPost, "/admin/payout/run-now", nil)
+	adminRec := httptest.NewRecorder()
+	mux.ServeHTTP(adminRec, adminReq)
+	if adminRec.Code != http.StatusNotFound {
+		t.Fatalf("admin run-now status=%d want 404 in registration-only", adminRec.Code)
+	}
+
+	payoutsReq := httptest.NewRequest(http.MethodGet, "/providers/test-pid/payouts", nil)
+	payoutsRec := httptest.NewRecorder()
+	mux.ServeHTTP(payoutsRec, payoutsReq)
+	if payoutsRec.Code != http.StatusNoContent {
+		t.Fatalf("payouts path status=%d want fallback 204", payoutsRec.Code)
+	}
+}
+
+func TestBuildRegistrationOnly_RequiresHotWallet(t *testing.T) {
+	db := openTestDB(t)
+	logger, _ := quietLogger()
+	ft := &fakeTokens{token: "tok", providerID: "test-pid"}
+	fallback := http.HandlerFunc(func(http.ResponseWriter, *http.Request) {})
+	_, _, err := BuildRegistrationOnly(RegistrationOnlyOptions{
+		DB:                     db,
+		HotWallet:              "",
+		CoolingOff:             24 * time.Hour,
+		Tokens:                 ft,
+		Identity:               ft,
+		Fallback:               fallback,
+		OperatorKey:            "test-operator-key-32bytes-long!!!!",
+		PauseResumeMinInterval: time.Second,
+		Logger:                 logger,
+	})
+	if err == nil {
+		t.Fatal("expected error for empty hot wallet")
+	}
+}
+
+func TestBuildRegistrationOnly_RequiresCoolingOffFloor(t *testing.T) {
+	db := openTestDB(t)
+	logger, _ := quietLogger()
+	ft := &fakeTokens{token: "tok", providerID: "test-pid"}
+	fallback := http.HandlerFunc(func(http.ResponseWriter, *http.Request) {})
+	_, _, err := BuildRegistrationOnly(RegistrationOnlyOptions{
+		DB:                     db,
+		HotWallet:              "0xfB6916095ca1df60bB79Ce92cE3Ea74c37c5d359",
+		CoolingOff:             30 * time.Minute,
+		Tokens:                 ft,
+		Identity:               ft,
+		Fallback:               fallback,
+		OperatorKey:            "test-operator-key-32bytes-long!!!!",
+		PauseResumeMinInterval: time.Second,
+		Logger:                 logger,
+	})
+	if err == nil {
+		t.Fatal("expected error for coolingOff < 1h")
+	}
+}

--- a/phase4-coordinator/internal/payout/topology.go
+++ b/phase4-coordinator/internal/payout/topology.go
@@ -6,45 +6,32 @@ import (
 )
 
 // PayoutRuntimeTopology captures the SPEC-016 §3.3 normative
-// requirement that the §3.3 registration handler and the §4.3
-// runner share ONE process (same clock, same `*sql.DB` pool).
-// SPEC §3.3 line 625-629:
+// requirement that, when the execution pipeline is enabled, the
+// §3.3 registration handler and the §4.3 runner share ONE process
+// (same clock, same `*sql.DB` pool). SPEC §3.3 (v0.1.26+):
 //
-//	"the registration handler and the runner are co-resident
-//	in the same coordinator process per §4.1; IMPL MUST assert
-//	this co-residency at startup (e.g. a deployment-mode check
-//	that fails-fast if the runner is configured to a different
-//	process or host) and MUST NOT honor any clock-skew tolerance
-//	when comparing pending_until_utc to :now."
+//	"When payout.enabled = true, the registration handler and the
+//	runner MUST be co-resident in the same coordinator process…
+//	When payout.enabled = false (registration-only), no runner
+//	exists; the co-residency assertion is vacuously satisfied."
 //
-// At Step 1 the runner has not been wired yet, so the topology
-// hook only asserts what Step 1 can prove: (a) we are on Linux
-// per §6.3 OS-restriction (§6.3 actually only requires Linux for
-// the Step 2 runner — at Step 1 we tolerate non-Linux for the
-// handler-only mode); (b) the `payout.security.hot_wallet_address`
-// is set; (c) the shared `*sql.DB` handle is non-nil and the same
-// instance the handler will use.
-//
-// Step 2 will extend this struct with a `RunnerEnabled` field that
-// asserts the runner goroutine is launched in the same process by
-// observing a sentinel set inside the runner's bootstrap. Closes
-// codex round-1 [arch:1.3] MEDIUM and turns the prior
-// "co-residency assertion lives in main.go" code comment in
-// addresses.go (which was a lie at Step 1 commit time) into an
-// executable check.
+// Registration-only mode (#954) mounts the §3.3 handlers with
+// ExecutionEnabled=false so providers can register wallets while
+// the runner/signer/RPC/lease stay idle.
 type PayoutRuntimeTopology struct {
 	// HandlerEnabled is true when the §3.3 handler is mounted on
-	// the listener. Step 1 sets this true iff payout.enabled is
-	// true. Step 2's extension will require RunnerEnabled=true
-	// iff HandlerEnabled=true so a split-process deployment
-	// fails-fast.
+	// the listener (full pipeline OR registration-only).
 	HandlerEnabled bool
 
-	// RunnerCoResident is a forward-compatible flag. Step 2 will
-	// set it true when the runner goroutine is launched in the
-	// same process as the handler. Step 1 leaves it false (the
-	// runner is not present yet).
+	// RunnerCoResident is true when the runner goroutine is
+	// launched in the same process as the handler. Required only
+	// when ExecutionEnabled is true.
 	RunnerCoResident bool
+
+	// ExecutionEnabled is true when payout.enabled=true — the
+	// full pipeline (runner, signer, RPC, lease, admin routes).
+	// False for registration-only and fully-disabled postures.
+	ExecutionEnabled bool
 
 	// HotWalletAddressPinned is the canonical EIP-55 form of the
 	// operator's hot wallet, captured at process start. Used to
@@ -52,9 +39,9 @@ type PayoutRuntimeTopology struct {
 	// security namespace post-startup.
 	HotWalletAddressPinned string
 
-	// LinuxRequired is the §6.3 / §4.3 OS gate. Step 1 leaves it
-	// off (handler-only mode can run on any host); Step 2's
-	// runner introduction will flip it on.
+	// LinuxRequired is the §6.3 / §4.3 OS gate. Required when the
+	// execution pipeline is enabled; registration-only leaves it
+	// false so macOS dev hosts can serve §3.3.
 	LinuxRequired bool
 }
 
@@ -63,15 +50,9 @@ type PayoutRuntimeTopology struct {
 // function returns an error on any invariant violation; main.go
 // MUST treat the error as terminal and refuse to start the
 // listener.
-//
-// Step 2 audit MUST extend the test corpus to drive
-// RunnerCoResident=false + HandlerEnabled=true through this
-// function and assert the error.
 func AssertPayoutRuntimeTopology(topo PayoutRuntimeTopology) error {
 	if !topo.HandlerEnabled {
 		// Handler disabled — topology is trivially satisfied.
-		// Step 1's setupPayout returns the disabled posture
-		// when payout.enabled=false.
 		return nil
 	}
 	if topo.HotWalletAddressPinned == "" {
@@ -83,14 +64,16 @@ func AssertPayoutRuntimeTopology(topo PayoutRuntimeTopology) error {
 	if topo.LinuxRequired && runtime.GOOS != "linux" {
 		return fmt.Errorf("payout.AssertPayoutRuntimeTopology: SPEC §6.3 requires runtime.GOOS=linux (got %q)", runtime.GOOS)
 	}
-	// Step 2 tightening (per architect r2 recommendation): the
-	// runner MUST be co-resident with the handler. A deployment
-	// that enables the handler but not the runner is a SPEC §3.3
-	// violation — the runner produces the chain confirmations
-	// that the handler's pending_until_utc rows are eventually
-	// paid from.
-	if topo.HandlerEnabled && !topo.RunnerCoResident {
-		return fmt.Errorf("payout.AssertPayoutRuntimeTopology: HandlerEnabled=true but RunnerCoResident=false — split-process deployment rejected (SPEC §3.3)")
+	// Cross-constrain flags so a future caller cannot silently
+	// drop §6.3 Linux or §3.3 co-residency by omitting a field.
+	if topo.ExecutionEnabled && !topo.RunnerCoResident {
+		return fmt.Errorf("payout.AssertPayoutRuntimeTopology: ExecutionEnabled=true but RunnerCoResident=false — split-process deployment rejected (SPEC §3.3)")
+	}
+	if topo.ExecutionEnabled && !topo.LinuxRequired {
+		return fmt.Errorf("payout.AssertPayoutRuntimeTopology: ExecutionEnabled=true requires LinuxRequired=true (SPEC §6.3)")
+	}
+	if topo.RunnerCoResident && !topo.ExecutionEnabled {
+		return fmt.Errorf("payout.AssertPayoutRuntimeTopology: RunnerCoResident=true but ExecutionEnabled=false — runner present in a registration-only posture")
 	}
 	return nil
 }

--- a/phase4-coordinator/internal/payout/topology_test.go
+++ b/phase4-coordinator/internal/payout/topology_test.go
@@ -37,40 +37,81 @@ func TestAssertPayoutRuntimeTopology_InvalidHotWalletPinRejected(t *testing.T) {
 	}
 }
 
-func TestAssertPayoutRuntimeTopology_HappyPath_Step2Posture(t *testing.T) {
-	// Step 2 posture (post-tightening): HandlerEnabled=true,
-	// RunnerCoResident=true, LinuxRequired toggleable.
-	if err := AssertPayoutRuntimeTopology(PayoutRuntimeTopology{
+func TestAssertPayoutRuntimeTopology_HappyPath_FullExecution(t *testing.T) {
+	err := AssertPayoutRuntimeTopology(PayoutRuntimeTopology{
 		HandlerEnabled:         true,
 		RunnerCoResident:       true,
+		ExecutionEnabled:       true,
 		HotWalletAddressPinned: "0xfB6916095ca1df60bB79Ce92cE3Ea74c37c5d359",
-		LinuxRequired:          false,
-	}); err != nil {
-		t.Fatalf("Step 2 happy-path posture should pass: %v", err)
+		LinuxRequired:          true,
+	})
+	if runtime.GOOS != "linux" {
+		if err == nil {
+			t.Fatalf("full execution posture must reject on %s", runtime.GOOS)
+		}
+		return
+	}
+	if err != nil {
+		t.Fatalf("full execution posture should pass on linux: %v", err)
 	}
 }
 
-func TestAssertPayoutRuntimeTopology_HandlerWithoutRunnerRejected(t *testing.T) {
-	// Step 2 tightening: handler enabled but runner missing is
-	// rejected.
+func TestAssertPayoutRuntimeTopology_ExecutionWithoutRunnerRejected(t *testing.T) {
 	err := AssertPayoutRuntimeTopology(PayoutRuntimeTopology{
 		HandlerEnabled:         true,
 		RunnerCoResident:       false,
+		ExecutionEnabled:       true,
 		HotWalletAddressPinned: "0xfB6916095ca1df60bB79Ce92cE3Ea74c37c5d359",
+		LinuxRequired:          true,
 	})
 	if err == nil {
-		t.Fatal("expected error when HandlerEnabled but RunnerCoResident=false")
+		t.Fatal("expected error when ExecutionEnabled but RunnerCoResident=false")
 	}
 }
 
-// FULL-r1 [full-arch:r1-1] MEDIUM closure: setupPayout now passes
-// LinuxRequired=true when payout.enabled=true. Verify the gate:
-// on non-linux the topology MUST reject; on linux it MUST accept.
-// Same test body covers both — the assertion branches on runtime.GOOS.
+func TestAssertPayoutRuntimeTopology_ExecutionWithoutLinuxRequiredRejected(t *testing.T) {
+	err := AssertPayoutRuntimeTopology(PayoutRuntimeTopology{
+		HandlerEnabled:         true,
+		RunnerCoResident:       true,
+		ExecutionEnabled:       true,
+		HotWalletAddressPinned: "0xfB6916095ca1df60bB79Ce92cE3Ea74c37c5d359",
+		LinuxRequired:          false,
+	})
+	if err == nil || !strings.Contains(err.Error(), "LinuxRequired") {
+		t.Fatalf("expected LinuxRequired cross-check error, got %v", err)
+	}
+}
+
+func TestAssertPayoutRuntimeTopology_RunnerWithoutExecutionRejected(t *testing.T) {
+	err := AssertPayoutRuntimeTopology(PayoutRuntimeTopology{
+		HandlerEnabled:         true,
+		RunnerCoResident:       true,
+		ExecutionEnabled:       false,
+		HotWalletAddressPinned: "0xfB6916095ca1df60bB79Ce92cE3Ea74c37c5d359",
+		LinuxRequired:          false,
+	})
+	if err == nil || !strings.Contains(err.Error(), "registration-only") {
+		t.Fatalf("expected runner-in-registration-only error, got %v", err)
+	}
+}
+
+func TestAssertPayoutRuntimeTopology_RegistrationOnlyOK(t *testing.T) {
+	if err := AssertPayoutRuntimeTopology(PayoutRuntimeTopology{
+		HandlerEnabled:         true,
+		RunnerCoResident:       false,
+		ExecutionEnabled:       false,
+		HotWalletAddressPinned: "0xfB6916095ca1df60bB79Ce92cE3Ea74c37c5d359",
+		LinuxRequired:          false,
+	}); err != nil {
+		t.Fatalf("registration-only posture should pass: %v", err)
+	}
+}
+
 func TestAssertPayoutRuntimeTopology_LinuxRequiredGate(t *testing.T) {
 	err := AssertPayoutRuntimeTopology(PayoutRuntimeTopology{
 		HandlerEnabled:         true,
 		RunnerCoResident:       true,
+		ExecutionEnabled:       true,
 		HotWalletAddressPinned: "0xfB6916095ca1df60bB79Ce92cE3Ea74c37c5d359",
 		LinuxRequired:          true,
 	})

--- a/specs/CONFORMANCE.json
+++ b/specs/CONFORMANCE.json
@@ -426,7 +426,7 @@
     {
       "spec_id": "SPEC-016",
       "title": "Provider payout pipeline (USDC on Base)",
-      "version": "0.1.25",
+      "version": "0.1.26",
       "path": "specs/SPEC-016-payout-pipeline.md",
       "status": "draft",
       "owner": "@Augustas11",
@@ -462,7 +462,7 @@
         "verdict": "UNKNOWN",
         "owner": "@Augustas11",
         "issue": "https://github.com/Augustas11/macprovider/issues/614",
-        "rationale": "PR #164 merged the SPEC-016 USDC-on-Base payout implementation, PR #827 repaired the spec-index drift, and PR #882 added the provider-facing Add Wallet registration flow. R002 now has canonical implementation/test anchors and a contract-only physical journey; the runner remains default-off and no production activation claim is made. Exhaustive clause-level requirement ID migration, signed journey evidence, §9 operator prerequisites, production deployment, and the remaining per-requirement reconciliations remain pending under the payout-lifecycle domain."
+        "rationale": "PR #164 merged the SPEC-016 USDC-on-Base payout implementation, PR #827 repaired the spec-index drift, and PR #882 added the provider-facing Add Wallet registration flow. SPEC-016 v0.1.26 (#954) mounts §3.3 registration while payout.enabled=false when hot_wallet_address is set; the runner remains default-off and no production activation claim is made. Exhaustive clause-level requirement ID migration, signed journey evidence, §9 operator prerequisites, production deployment, and the remaining per-requirement reconciliations remain pending under the payout-lifecycle domain."
       }
     },
     {

--- a/specs/CONFORMANCE.json
+++ b/specs/CONFORMANCE.json
@@ -3156,10 +3156,12 @@
         "phase4-coordinator/internal/payout/addresses.go:AddressesService",
         "phase4-coordinator/internal/payout/addresses.go:ServePayoutChallenge",
         "phase4-coordinator/internal/payout/addresses.go:ServePayoutAddress",
+        "phase4-coordinator/internal/payout/registration_only.go:BuildRegistrationOnly",
         "phase3-binary/Sources/macprovider-cli/PayoutAddressClient.swift:PayoutAddressClient",
         "phase3-binary/app/Sources/Malibu/Dashboard/PayoutWalletFlow.swift:PayoutWalletFlow"
       ],
       "tests": [
+        "phase4-coordinator/internal/payout/registration_only_test.go:TestBuildRegistrationOnly_MountsChallengeRegisterAndPause",
         "phase4-coordinator/internal/payout/addresses_test.go:TestServePayoutAddress_HappyPath_FirstRegistration",
         "phase4-coordinator/internal/payout/addresses_test.go:TestServePayoutAddress_AntiReplay_SecondNonceRejected",
         "phase4-coordinator/internal/payout/addresses_test.go:TestServePayoutAddress_RotationPreservesPayoutAllowed_Zero",
@@ -3192,10 +3194,10 @@
       ],
       "evidence": [
         {
-          "artifact": "commit:57d9813957b1421199b59e5b3f09488f7c9644cd",
+          "artifact": "commit:9d92c02c294381b5987f320795a158e03e377e9c",
           "source": null,
-          "captured_at": "2026-08-05",
-          "expires_at": "2026-09-05"
+          "captured_at": "2026-08-08",
+          "expires_at": "2026-09-08"
         },
         {
           "artifact": "sha256:cce4916a7a89b4edccb350b53cb6c1d48bb0a0e0d4479446d63634d4c8f8c90d",

--- a/specs/CONFORMANCE.json
+++ b/specs/CONFORMANCE.json
@@ -462,7 +462,7 @@
         "verdict": "UNKNOWN",
         "owner": "@Augustas11",
         "issue": "https://github.com/Augustas11/macprovider/issues/614",
-        "rationale": "PR #164 merged the SPEC-016 USDC-on-Base payout implementation, PR #827 repaired the spec-index drift, and PR #882 added the provider-facing Add Wallet registration flow. SPEC-016 v0.1.26 (#954) mounts §3.3 registration while payout.enabled=false when hot_wallet_address is set; the runner remains default-off and no production activation claim is made. Exhaustive clause-level requirement ID migration, signed journey evidence, §9 operator prerequisites, production deployment, and the remaining per-requirement reconciliations remain pending under the payout-lifecycle domain."
+        "rationale": "PR #164 merged the SPEC-016 USDC-on-Base payout implementation, PR #827 repaired the spec-index drift, and PR #882 added the provider-facing Add Wallet registration flow. SPEC-016 v0.1.26 (#954) mounts \u00a73.3 registration while payout.enabled=false when hot_wallet_address is set; the runner remains default-off and no production activation claim is made. Exhaustive clause-level requirement ID migration, signed journey evidence, \u00a79 operator prerequisites, production deployment, and the remaining per-requirement reconciliations remain pending under the payout-lifecycle domain."
       }
     },
     {
@@ -1163,7 +1163,7 @@
         "verdict": "CODE_BUG",
         "owner": "@Augustas11",
         "issue": "https://github.com/Augustas11/macprovider/issues/854",
-        "rationale": "Provider serving continuity across coordinator disconnect, reconnect backoff, and coordinator drain (§6.5 / FR-13 / FR-15 / AC-16): PR #853 binds the macOS sleep assertion to serving intent under regression tests, but production physical uptime evidence remains pending."
+        "rationale": "Provider serving continuity across coordinator disconnect, reconnect backoff, and coordinator drain (\u00a76.5 / FR-13 / FR-15 / AC-16): PR #853 binds the macOS sleep assertion to serving intent under regression tests, but production physical uptime evidence remains pending."
       }
     },
     {
@@ -2128,7 +2128,7 @@
         "verdict": "UNKNOWN",
         "owner": "@Augustas11",
         "issue": "https://github.com/Augustas11/macprovider/issues/614",
-        "rationale": "FR-KVP3 (snapshot-at-commit, write ordering, durability events) plus the §5a Format v1 normative encoding it publishes; normative in SPEC-037 v0.1.0; implementation and tests land in the follow-up IMPL PR."
+        "rationale": "FR-KVP3 (snapshot-at-commit, write ordering, durability events) plus the \u00a75a Format v1 normative encoding it publishes; normative in SPEC-037 v0.1.0; implementation and tests land in the follow-up IMPL PR."
       }
     },
     {
@@ -2143,7 +2143,7 @@
         "verdict": "UNKNOWN",
         "owner": "@Augustas11",
         "issue": "https://github.com/Augustas11/macprovider/issues/614",
-        "rationale": "FR-KVP4 (four-category envelope validation, full-envelope AAD projection per §5a): normative in SPEC-037 v0.1.0; implementation and tests land in the follow-up IMPL PR."
+        "rationale": "FR-KVP4 (four-category envelope validation, full-envelope AAD projection per \u00a75a): normative in SPEC-037 v0.1.0; implementation and tests land in the follow-up IMPL PR."
       }
     },
     {
@@ -3145,7 +3145,7 @@
         "verdict": "UNKNOWN",
         "owner": "@Augustas11",
         "issue": "https://github.com/Augustas11/macprovider/issues/614",
-        "rationale": "Default-off rail scope, USDC-on-Base operator prerequisites, and activation boundary (§1, §2, §9): preliminary anchor for the existing obligation area; implementation merged default-off by PR #164, but production enablement and §9 operator prerequisite evidence remain pending."
+        "rationale": "Default-off rail scope, USDC-on-Base operator prerequisites, and activation boundary (\u00a71, \u00a72, \u00a79): preliminary anchor for the existing obligation area; implementation merged default-off by PR #164, but production enablement and \u00a79 operator prerequisite evidence remain pending."
       }
     },
     {
@@ -3156,12 +3156,9 @@
         "phase4-coordinator/internal/payout/addresses.go:AddressesService",
         "phase4-coordinator/internal/payout/addresses.go:ServePayoutChallenge",
         "phase4-coordinator/internal/payout/addresses.go:ServePayoutAddress",
-        "phase4-coordinator/internal/payout/registration_only.go:BuildRegistrationOnly",
-        "phase3-binary/Sources/macprovider-cli/PayoutAddressClient.swift:PayoutAddressClient",
         "phase3-binary/app/Sources/Malibu/Dashboard/PayoutWalletFlow.swift:PayoutWalletFlow"
       ],
       "tests": [
-        "phase4-coordinator/internal/payout/registration_only_test.go:TestBuildRegistrationOnly_MountsChallengeRegisterAndPause",
         "phase4-coordinator/internal/payout/addresses_test.go:TestServePayoutAddress_HappyPath_FirstRegistration",
         "phase4-coordinator/internal/payout/addresses_test.go:TestServePayoutAddress_AntiReplay_SecondNonceRejected",
         "phase4-coordinator/internal/payout/addresses_test.go:TestServePayoutAddress_RotationPreservesPayoutAllowed_Zero",
@@ -3186,7 +3183,6 @@
         "phase4-coordinator/internal/payout/eip712_fixture_gen_test.go:TestEIP712DigestFixture_MatchesCommitted",
         "phase4-coordinator/internal/payout/eip712_fixture_gen_test.go:TestEIP712DigestFixture_RoundTripJSSignature",
         "phase4-coordinator/internal/payout/attempts_test.go:TestSelectReadyPayouts_FiltersByHotWalletAndCoolingOff",
-        "phase3-binary/Tests/macprovider-cliTests/PayoutAddressClientTests.swift:PayoutAddressClientTests",
         "phase3-binary/app/Tests/MalibuTests/PayoutWalletFlowTests.swift:PayoutWalletFlowTests"
       ],
       "journeys": [
@@ -3194,10 +3190,10 @@
       ],
       "evidence": [
         {
-          "artifact": "commit:9d92c02c294381b5987f320795a158e03e377e9c",
+          "artifact": "commit:57d9813957b1421199b59e5b3f09488f7c9644cd",
           "source": null,
-          "captured_at": "2026-08-08",
-          "expires_at": "2026-09-08"
+          "captured_at": "2026-08-05",
+          "expires_at": "2026-09-05"
         },
         {
           "artifact": "sha256:cce4916a7a89b4edccb350b53cb6c1d48bb0a0e0d4479446d63634d4c8f8c90d",
@@ -3220,7 +3216,7 @@
         "verdict": "UNKNOWN",
         "owner": "@Augustas11",
         "issue": "https://github.com/Augustas11/macprovider/issues/614",
-        "rationale": "Payout package boundary, read surfaces, handler inventory, and import-graph ownership (§3.4, §4.1, §7.3): preliminary anchor for the existing obligation area; implementation exists in the coordinator payout package and wiring, but mappings/tests are not yet reconciled to conformant."
+        "rationale": "Payout package boundary, read surfaces, handler inventory, and import-graph ownership (\u00a73.4, \u00a74.1, \u00a77.3): preliminary anchor for the existing obligation area; implementation exists in the coordinator payout package and wiring, but mappings/tests are not yet reconciled to conformant."
       }
     },
     {
@@ -3235,7 +3231,7 @@
         "verdict": "UNKNOWN",
         "owner": "@Augustas11",
         "issue": "https://github.com/Augustas11/macprovider/issues/614",
-        "rationale": "Runner selection, signing, broadcast, two-RPC confirmation, and ClaimPayoutReady finalization (§4.3): preliminary anchor for the existing obligation area; runner implementation merged default-off, but production activation, mapped tests, and journey evidence remain pending."
+        "rationale": "Runner selection, signing, broadcast, two-RPC confirmation, and ClaimPayoutReady finalization (\u00a74.3): preliminary anchor for the existing obligation area; runner implementation merged default-off, but production activation, mapped tests, and journey evidence remain pending."
       }
     },
     {
@@ -3250,7 +3246,7 @@
         "verdict": "UNKNOWN",
         "owner": "@Augustas11",
         "issue": "https://github.com/Augustas11/macprovider/issues/614",
-        "rationale": "Payout attempt schema, idempotent retry, nonce-gap fill, cancel self-transfer, and abandon-attempt recovery (§4.5, §4.6): preliminary anchor for the existing obligation area; implementation merged default-off, but conformance mappings and evidence remain pending."
+        "rationale": "Payout attempt schema, idempotent retry, nonce-gap fill, cancel self-transfer, and abandon-attempt recovery (\u00a74.5, \u00a74.6): preliminary anchor for the existing obligation area; implementation merged default-off, but conformance mappings and evidence remain pending."
       }
     },
     {
@@ -3265,7 +3261,7 @@
         "verdict": "UNKNOWN",
         "owner": "@Augustas11",
         "issue": "https://github.com/Augustas11/macprovider/issues/614",
-        "rationale": "Reorg polling, orphan recording, compensation, and funding-recording admin flows (§4.7, §4.9): preliminary anchor for the existing obligation area; implementation merged default-off, but operator runbook evidence and signed journey-result support remain pending."
+        "rationale": "Reorg polling, orphan recording, compensation, and funding-recording admin flows (\u00a74.7, \u00a74.9): preliminary anchor for the existing obligation area; implementation merged default-off, but operator runbook evidence and signed journey-result support remain pending."
       }
     },
     {
@@ -3280,7 +3276,7 @@
         "verdict": "UNKNOWN",
         "owner": "@Augustas11",
         "issue": "https://github.com/Augustas11/macprovider/issues/614",
-        "rationale": "Runtime flags, pause/resume, runner lease, self-fencing, and crash-safe audit outboxes (§4.8, §4.8a, §4.8b, §4.8c, §6.4.1): preliminary anchor for the existing obligation area; implementation merged default-off, but conformance mappings and production evidence remain pending."
+        "rationale": "Runtime flags, pause/resume, runner lease, self-fencing, and crash-safe audit outboxes (\u00a74.8, \u00a74.8a, \u00a74.8b, \u00a74.8c, \u00a76.4.1): preliminary anchor for the existing obligation area; implementation merged default-off, but conformance mappings and production evidence remain pending."
       }
     },
     {
@@ -3295,7 +3291,7 @@
         "verdict": "UNKNOWN",
         "owner": "@Augustas11",
         "issue": "https://github.com/Augustas11/macprovider/issues/614",
-        "rationale": "Payout caps, hot-wallet balances, gas accounting, and conservation reconciliation (§5, §6.2, §7.4): preliminary anchor for the existing obligation area; implementation merged default-off, but funded-wallet operation and reconciliation evidence remain pending."
+        "rationale": "Payout caps, hot-wallet balances, gas accounting, and conservation reconciliation (\u00a75, \u00a76.2, \u00a77.4): preliminary anchor for the existing obligation area; implementation merged default-off, but funded-wallet operation and reconciliation evidence remain pending."
       }
     },
     {
@@ -3310,7 +3306,7 @@
         "verdict": "UNKNOWN",
         "owner": "@Augustas11",
         "issue": "https://github.com/Augustas11/macprovider/issues/614",
-        "rationale": "Signer custody, Linux-only process hardening, two-RPC discipline, SPKI pinning, and reload boundaries (§6.3, §6.4, §6.5): preliminary anchor for the existing obligation area; implementation merged default-off, but production host evidence and signed journey-result support remain pending."
+        "rationale": "Signer custody, Linux-only process hardening, two-RPC discipline, SPKI pinning, and reload boundaries (\u00a76.3, \u00a76.4, \u00a76.5): preliminary anchor for the existing obligation area; implementation merged default-off, but production host evidence and signed journey-result support remain pending."
       }
     },
     {
@@ -3325,7 +3321,7 @@
         "verdict": "UNKNOWN",
         "owner": "@Augustas11",
         "issue": "https://github.com/Augustas11/macprovider/issues/614",
-        "rationale": "Structured audit events, retention, operator queries, BetterStack alert filters, and runbook obligations (§7, §9): preliminary anchor for the existing obligation area; implementation and runbook artifacts merged, but alert verification and production evidence remain pending."
+        "rationale": "Structured audit events, retention, operator queries, BetterStack alert filters, and runbook obligations (\u00a77, \u00a79): preliminary anchor for the existing obligation area; implementation and runbook artifacts merged, but alert verification and production evidence remain pending."
       }
     },
     {
@@ -3340,7 +3336,7 @@
         "verdict": "UNKNOWN",
         "owner": "@Augustas11",
         "issue": "https://github.com/Augustas11/macprovider/issues/614",
-        "rationale": "Provider-token custody and compliance payout eligibility (§8, v0.1.20 Wave-2 custody gate): preliminary anchor for the existing obligation area; normative custody gate retained through v0.1.23, but provider eligibility policy and production evidence remain pending."
+        "rationale": "Provider-token custody and compliance payout eligibility (\u00a78, v0.1.20 Wave-2 custody gate): preliminary anchor for the existing obligation area; normative custody gate retained through v0.1.23, but provider eligibility policy and production evidence remain pending."
       }
     }
   ]

--- a/specs/README.md
+++ b/specs/README.md
@@ -24,7 +24,7 @@ it can no longer drift. Do not hand-edit the table; edit each spec's
 | SPEC-013 | `macprovider-cli autotune` subcommand | 0.3.1 | normative | pending | pending corpus migration | [SPEC-013-cli-autotune.md](SPEC-013-cli-autotune.md) |
 | SPEC-014 | Provider Portal (seller-facing web surface) | 0.9 | draft | pending | pending corpus migration | [SPEC-014-provider-portal.md](SPEC-014-provider-portal.md) |
 | SPEC-015 | Verifiable inference receipts | 0.4.2 | normative | pending | pending corpus migration | [SPEC-015-receipts.md](SPEC-015-receipts.md) |
-| SPEC-016 | Provider payout pipeline (USDC on Base) | 0.1.25 | draft | pending | conformant: 1, pending: 10 | [SPEC-016-payout-pipeline.md](SPEC-016-payout-pipeline.md) |
+| SPEC-016 | Provider payout pipeline (USDC on Base) | 0.1.26 | draft | pending | conformant: 1, pending: 10 | [SPEC-016-payout-pipeline.md](SPEC-016-payout-pipeline.md) |
 | SPEC-017 | Network Stats API | 0.1.9 | normative | pending | pending: 1 | [SPEC-017-network-stats-api.md](SPEC-017-network-stats-api.md) |
 | SPEC-018 | Agentic tool calling (provider-side response synthesis) | 0.2.7 | normative | pending | conformant: 1, pending: 1 | [SPEC-018-agentic-tool-calling.md](SPEC-018-agentic-tool-calling.md) |
 | SPEC-019 | Structured output (`response_format: json_schema`) | 0.2.5 | normative | pending | pending corpus migration | [SPEC-019-structured-output.md](SPEC-019-structured-output.md) |

--- a/specs/SPEC-016-payout-pipeline.md
+++ b/specs/SPEC-016-payout-pipeline.md
@@ -1,17 +1,17 @@
 # SPEC-016 — Provider payout pipeline (USDC on Base)
 
-**Version:** 0.1.25 (2026-08-01, draft — §9.5b.1 assertion-set reconciliation
-to the merged SPEC-005 `POST /admin/ledger/payout-ready` IMPL: canonical
-idempotency_key requirement (leading-zero-alias double-pay defense), replay
-precedence, `payout_attempts` join with `is_cancel_self_transfer = 0`
-non-compensable carve-out, `resolved_at_utc IS NULL` unresolved filter, and
-`ambiguous_orphan` multiplicity guard. Documentation of enforced endpoint
-behavior; no runner activation, production deployment, or §9 prerequisite
-state changes. Prior: 0.1.24 (2026-07-31, preliminary conformance-unit
-anchors for the default-off payout implementation merged by PR #164).)
+**Version:** 0.1.26 (2026-08-08, draft — #954 registration-only carve-out:
+mount SPEC-016 §3.3 payout-address challenge/register routes whenever
+`payout.security.hot_wallet_address` is configured, even when
+`payout.enabled=false`. Execution pipeline (runner, signer/KEK, RPC,
+lease, admin `/admin/payout/*`, provider `/providers/{id}/payouts`) remains
+gated on `payout.enabled=true`. Prior: 0.1.25 (2026-08-01, §9.5b.1
+assertion-set reconciliation to SPEC-005 `POST /admin/ledger/payout-ready`).)
 **Status:** Draft (IMPL merged via PR #164, default-off — `payout.enabled=false`
 everywhere until the operator funds the hot wallet and discharges the eight
-§9 prerequisites; flipping the flag is an operator decision gated on §9).
+§9 prerequisites; flipping the flag is an operator decision gated on §9.
+Providers MAY register/change payout wallets while the execution pipeline
+is disabled, provided the hot-wallet pin is configured.)
 **Depends on:** SPEC-005 v0.3 (§5.1 unit definition; §10.1 WAL
 mode + synchronous=FULL requirement; §11.4 earnings endpoint;
 §2.1 D1 donation-only / no-custodial framing),
@@ -66,6 +66,21 @@ git-history-only). The change-log entries below are one-liners per
 version pointing at the corresponding audit file. Per
 [[feedback-spec-audit-file-convention]], audit narrative does NOT
 live in this SPEC body.
+
+**v0.1.26 (2026-08-08, draft — #954 registration-only carve-out):**
+Normative: `payout.enabled` gates the **execution pipeline** only
+(runner, signer/KEK load, RPC clients, lease, execution-only admin
+routes, `GET /providers/{id}/payouts`). The two provider-token §3.3
+routes plus §6.4.1 pause/resume MUST mount whenever
+`payout.security.hot_wallet_address` is configured, regardless of
+`payout.enabled`. Registration-only mode MUST NOT start the runner,
+load the signer/KEK, open RPC connections, or acquire the payout
+lease. Cooling-off, EIP-712 verification, denylist, pause-registration,
+and audit/alert emission behave identically in both modes. §6.4
+rotation step 1 mandates pause-before-disable. Co-residency of
+handler + runner is required only when `payout.enabled=true`.
+Closes the production defect where Change-wallet returned HTTP 404
+while the pipeline was deliberately disabled.
 
 **v0.1.24 (2026-07-31, draft — #614 preliminary conformance anchors):**
 Editorial, non-normative reconciliation after the PR #164 payout implementation
@@ -539,15 +554,18 @@ for reorg orphans live at the SPEC-005 layer with their own
 
 **Linux-only constraint when `payout.enabled = true`.** §6.3
 requires the runner process to run on Linux (Crashreporter on
-macOS bypasses `RLIMIT_CORE`). §3.3 requires the registration
-handler + runner to be co-resident in the same coordinator
-process (clock authority). Therefore enabling
-`payout.enabled = true` constrains the ENTIRE coordinator
-process — including SPEC-005 settlement + SPEC-014 portal
-endpoints + buyer-mux + ws-mux — to Linux. macOS dev
-environments cannot run a payout-enabled coordinator. This is
-a deliberate cut; the dev workflow on macOS continues to work
-with `payout.enabled = false` (default).
+macOS bypasses `RLIMIT_CORE`). When `payout.enabled = true`,
+§3.3 requires the registration handler + runner to be
+co-resident in the same coordinator process (clock authority).
+Therefore enabling `payout.enabled = true` constrains the
+ENTIRE coordinator process — including SPEC-005 settlement +
+SPEC-014 portal endpoints + buyer-mux + ws-mux — to Linux.
+macOS dev environments cannot run a payout-**execution**-enabled
+coordinator. Registration-only mode (`payout.enabled = false`
+with `payout.security.hot_wallet_address` set) MAY run on any
+OS: it mounts the §3.3 handlers without the runner, so the
+Linux-only + co-residency gates do not apply. This is a
+deliberate cut; the default remains `payout.enabled = false`.
 
 ## 3 Provider payout-address registration (FR-P1)
 
@@ -793,15 +811,20 @@ on the realm the path-table declared.
 
 **Clock authority.** Both `pending_until_utc` (set at
 registration) and `:now` (read at §4.3 step 1) MUST come
-from the SAME coordinator process clock. The registration
-handler and the runner are co-resident in the same
-coordinator process per §4.1; IMPL MUST assert this
-co-residency at startup (e.g. a deployment-mode check that
-fails-fast if the runner is configured to a different
-process or host) and MUST NOT honor any clock-skew tolerance
-when comparing `pending_until_utc` to `:now`. This makes the
-cooling-off boundary non-bypassable by multi-host
-deployment expansion.
+from the SAME coordinator process clock. When
+`payout.enabled = true`, the registration handler and the
+runner MUST be co-resident in the same coordinator process
+per §4.1; IMPL MUST assert this co-residency at startup
+(e.g. a deployment-mode check that fails-fast if the runner
+is configured to a different process or host) and MUST NOT
+honor any clock-skew tolerance when comparing
+`pending_until_utc` to `:now`. This makes the cooling-off
+boundary non-bypassable by multi-host deployment expansion.
+When `payout.enabled = false` (registration-only), no runner
+exists; the co-residency assertion is vacuously satisfied and
+MUST NOT reject the handler-only posture. Cooling-off still
+uses the registration process clock; the runner, when later
+enabled, MUST share that same process.
 
 ```
 POST /providers/{provider_id}/payout-address
@@ -1029,6 +1052,33 @@ this.
 The runner starts from `cmd/coordinator/main.go` only when
 config explicitly enables it (`payout.enabled: true`).
 Default config ships `payout.enabled: false`.
+
+**Registration-only mode (`payout.enabled: false`).** When
+`payout.security.hot_wallet_address` is configured, IMPL MUST
+still mount the two provider-token §3.3 routes
+(`GET /providers/{provider_id}/payout-address/challenge`,
+`POST /providers/{provider_id}/payout-address`) so providers
+can register or rotate payout wallets while the execution
+pipeline is off. Registration-only mode MUST ALSO mount the
+§6.4.1 operator-key kill switch
+(`POST /admin/payout/pause-registration`,
+`POST /admin/payout/resume-registration`) so
+`runtime.registration_paused` remains writable whenever the
+§3.3 write surface is live. Registration-only mode MUST NOT:
+
+- start the §4.3 runner or reorg/reaper/chain-balance workers;
+- load the settlement signer or KEK;
+- open payout RPC connections;
+- acquire the payout runner lease;
+- mount execution-only admin routes (`run-now`, `abandon-attempt`,
+  `record-funding`, `record-orphan`) or `GET /providers/{id}/payouts`.
+
+Cooling-off, EIP-712 verification, denylist, `runtime.registration_paused`
+(read + write via §6.4.1), rate limits, and §3.4 audit/alert
+emission MUST behave identically to the fully-enabled posture.
+When `payout.security.hot_wallet_address` is empty AND
+`payout.enabled` is false, IMPL MUST leave §3.3 handlers
+unmounted (schema migrations may still apply).
 
 ### 4.2 Cadence
 
@@ -3574,12 +3624,16 @@ build/broadcast from step 5 to step 6.)
 
 Procedure (manual, operator-driven):
 
-1. **Halt the runner AND pause the registration handler.**
-   Flip `payout.enabled: false` + flip the in-process flag
-   `runtime.registration_paused: true` (per §6.5 the
-   `runtime.*` namespace carves out in-process flags that
-   are neither security nor tuning config keys — set via
-   the §6.4.1 endpoint below). The §3.3 handler returns
+1. **Pause the registration handler, THEN halt the runner.**
+   Call `POST /admin/payout/pause-registration` FIRST (while
+   `payout.enabled` is still true OR while registration-only
+   mode is live — §6.4.1 is mounted in both postures per
+   §4.1) to flip `runtime.registration_paused: true`. Only
+   AFTER the pause returns 200 MAY the operator flip
+   `payout.enabled: false` and restart. Ordering matters:
+   disabling first and restarting into registration-only
+   without a prior pause leaves §3.3 writable against the
+   old hot wallet. The §3.3 handler returns
    `503 Service Unavailable {"error":"rotation_in_progress"}`
    for the rotation duration. Without this, a provider who
    registers during steps 2–3 stamps
@@ -3689,9 +3743,11 @@ defect was caused by exactly that. The buckets:
   backed by `coordinator.toml`. Mutated via authenticated
   admin endpoints (e.g. `runtime.registration_paused`
   toggled by §6.4.1 pause/resume endpoints; v0.1.x also
-  keeps `payout.enabled` as a singleton master switch
-  separate from this bucket because it gates whether the
-  namespace loaders run at all). Persistence: every
+  keeps `payout.enabled` as a singleton execution-pipeline
+  switch separate from this bucket — it gates runner/signer/
+  RPC/lease/admin surfaces, NOT the §3.3 registration
+  handlers when `payout.security.hot_wallet_address` is set;
+  see §4.1 registration-only mode). Persistence: every
   `runtime.*` flag MUST persist across coordinator
   restarts via the `runtime_flags` SQLite table defined in
   §4.8a (same database file as `payout_runner_state` per


### PR DESCRIPTION
## Summary
- Mount SPEC-016 §3.3 payout-address challenge/register (and §6.4.1 pause/resume) whenever `payout.security.hot_wallet_address` is set, even when `payout.enabled=false` — closes Malibu Change-wallet HTTP 404 (#954).
- Keep the execution pipeline (runner, signer/KEK, RPC, lease, run-now/abandon/funding/orphans, `GET /providers/{id}/payouts`) behind `payout.enabled=true`.
- Amend SPEC-016 to v0.1.26 (registration-only carve-out + pause-before-disable rotation ordering); tighten config/deploy-gate validation; friendlier CLI 404 copy for Malibu.

## Test plan
- [x] `go test ./internal/payout/ ./internal/config/`
- [x] `go build ./cmd/coordinator/`
- [x] `python3 scripts/check_spec_governance.py` / `gen_spec_index.py --check`
- [ ] Pearl: set final hot wallet in overlay with `payout.enabled=false`, restart, confirm journal `payout registration-only enabled` and challenge returns 401 (not 404)
- [ ] Malibu Change-wallet opens browser signer against production coordinator

SPEC-GOVERNANCE-DECLARATION-BEGIN
{
  "schema_version": "spec-pr-governance-v1",
  "behavior_change": "yes",
  "contract_change": "yes",
  "specs": ["SPEC-016"],
  "requirements": ["SPEC-016-R002"],
  "authority_domains": ["payout-lifecycle"],
  "arbitration": ["CODE_BUG", "SPEC_BUG"],
  "tests": ["phase4-coordinator/internal/payout/registration_only_test.go"],
  "journeys": ["JOURNEY-SPEC-016-PAYOUT-ADDRESS-REGISTRATION"],
  "issue": "https://github.com/Augustas11/macprovider/issues/954"
}
SPEC-GOVERNANCE-DECLARATION-END