### PR TITLE
fix(payout): make wallet registration reliable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,6 +54,7 @@ test-integration:
 # false-failing the gate (the 2026-06-17 regression that forced SKIP_C2_CHECK=1).
 test-dist:
 	PYTHONDONTWRITEBYTECODE=1 python3 -m unittest -v scripts.tests.test_upstream_watch
+	node --test phase3-binary/app/Tests/MalibuTests/payout-signer-chain.test.mjs
 	bash scripts/test-production-exceptions.sh
 	bash scripts/test-coordinator-advertised-version-test.sh
 	bash scripts/test-malibu-independent-release.sh

--- a/phase3-binary/app/Sources/Malibu/Agent/AgentSnapshot.swift
+++ b/phase3-binary/app/Sources/Malibu/Agent/AgentSnapshot.swift
@@ -168,6 +168,7 @@ struct AgentSnapshot: Equatable {
     var payoutRegisteredAddress: String? = nil
     var payoutPendingUntilUTC: String? = nil
     var payoutRegistrationInProgress: Bool = false
+    var payoutRegistrationCanCancel: Bool = false
     var payoutLastError: String? = nil
     var payoutLastStatus: String? = nil
 
@@ -283,6 +284,7 @@ struct AgentSnapshot: Equatable {
         payoutRegisteredAddress = nil
         payoutPendingUntilUTC = nil
         payoutRegistrationInProgress = false
+        payoutRegistrationCanCancel = false
         payoutLastError = nil
         payoutLastStatus = nil
     }

--- a/phase3-binary/app/Sources/Malibu/Agent/MalibuAgent.swift
+++ b/phase3-binary/app/Sources/Malibu/Agent/MalibuAgent.swift
@@ -1035,12 +1035,17 @@ final class MalibuAgent: ObservableObject {
     func registerPayoutWallet(pasted: PayoutSignedPayload? = nil) async {
         guard !snapshot.payoutRegistrationInProgress else { return }
         snapshot.payoutRegistrationInProgress = true
+        snapshot.payoutRegistrationCanCancel = true
         snapshot.payoutLastError = nil
         snapshot.payoutLastStatus = nil
-        defer { snapshot.payoutRegistrationInProgress = false }
+        defer {
+            snapshot.payoutRegistrationInProgress = false
+            snapshot.payoutRegistrationCanCancel = false
+        }
 
         do {
             let challenge = try await PayoutWalletFlow.fetchChallenge()
+            try Task.checkCancellation()
             if let existing = challenge.registeredAddress {
                 snapshot.payoutRegisteredAddress = existing
                 snapshot.payoutPendingUntilUTC = challenge.pendingUntilUTC
@@ -1073,6 +1078,11 @@ final class MalibuAgent: ObservableObject {
                 )
             }
 
+            try Task.checkCancellation()
+            // Registration is the remote commit boundary. From this point the
+            // sheet may be closed, but it must not promise cancellation: the
+            // coordinator could commit even if the local CLI were terminated.
+            snapshot.payoutRegistrationCanCancel = false
             let result = try await PayoutWalletFlow.register(
                 address: signed.address,
                 nonce: signed.nonce,
@@ -1088,6 +1098,8 @@ final class MalibuAgent: ObservableObject {
                 address: result.address,
                 pendingUntilUTC: result.pendingUntilUTC
             )
+        } catch is CancellationError {
+            snapshot.payoutLastError = Self.payoutErrorMessage(.cancelled)
         } catch let error as PayoutWalletFlowError {
             snapshot.payoutLastError = Self.payoutErrorMessage(error)
         } catch {

--- a/phase3-binary/app/Sources/Malibu/Dashboard/DashboardWindow.swift
+++ b/phase3-binary/app/Sources/Malibu/Dashboard/DashboardWindow.swift
@@ -217,7 +217,9 @@ private struct DashboardView: View {
                         }
                     }
                     Button(agent.snapshot.payoutRegistrationInProgress
-                           ? "Waiting for wallet…"
+                           ? (agent.snapshot.payoutRegistrationCanCancel
+                              ? "Waiting for wallet…"
+                              : "Registering wallet…")
                            : (agent.snapshot.payoutRegisteredAddress == nil ? "Add wallet" : "Change wallet")) {
                         showAddWalletSheet = true
                     }
@@ -468,6 +470,12 @@ private struct DashboardView: View {
     }
 }
 
+enum PayoutRegistrationPresentation {
+    static func isCancellable(inProgress: Bool, canCancel: Bool) -> Bool {
+        !inProgress || canCancel
+    }
+}
+
 private struct AddWalletSheet: View {
     @ObservedObject var agent: MalibuAgent
     @Binding var isPresented: Bool
@@ -477,6 +485,18 @@ private struct AddWalletSheet: View {
     @State private var pasteTsUtc = ""
     @State private var showPaste = false
     @State private var localError: String?
+    @State private var registrationTask: Task<Void, Never>?
+
+    private var registrationIsCancellable: Bool {
+        // Before the agent's task gets its first MainActor turn, inProgress is
+        // still false. Treat that scheduling window as cancellable too. Once
+        // registration crosses the remote commit boundary, inProgress stays
+        // true while canCancel flips false and this correctly becomes Close.
+        PayoutRegistrationPresentation.isCancellable(
+            inProgress: agent.snapshot.payoutRegistrationInProgress,
+            canCancel: agent.snapshot.payoutRegistrationCanCancel
+        )
+    }
 
     var body: some View {
         VStack(alignment: .leading, spacing: 14) {
@@ -491,28 +511,27 @@ private struct AddWalletSheet: View {
                 .foregroundStyle(.secondary)
 
             if agent.snapshot.payoutRegistrationInProgress {
-                ProgressView("Waiting for browser wallet signature…")
+                ProgressView(agent.snapshot.payoutRegistrationCanCancel
+                    ? "Waiting for browser wallet signature…"
+                    : "Registering payout wallet…")
                     .controlSize(.small)
             }
 
             HStack(spacing: 10) {
                 Button("Open browser wallet") {
                     localError = nil
-                    Task {
-                        await agent.registerPayoutWallet()
-                        if agent.snapshot.payoutLastError == nil,
-                           agent.snapshot.payoutRegisteredAddress != nil {
-                            isPresented = false
-                        }
-                    }
+                    startRegistration()
                 }
-                .disabled(agent.snapshot.payoutRegistrationInProgress)
+                .disabled(agent.snapshot.payoutRegistrationInProgress || registrationTask != nil)
                 .keyboardShortcut(.defaultAction)
 
-                Button("Cancel") {
+                Button(registrationIsCancellable ? "Cancel" : "Close") {
+                    if registrationIsCancellable {
+                        registrationTask?.cancel()
+                    }
+                    registrationTask = nil
                     isPresented = false
                 }
-                .disabled(agent.snapshot.payoutRegistrationInProgress)
             }
 
             DisclosureGroup("Paste signature instead", isExpanded: $showPaste) {
@@ -529,28 +548,23 @@ private struct AddWalletSheet: View {
                     TextField("ts_utc (unix seconds)", text: $pasteTsUtc)
                         .textFieldStyle(.roundedBorder)
                     Button("Submit pasted signature") {
-                        Task {
-                            guard let ts = UInt64(pasteTsUtc.trimmingCharacters(in: .whitespacesAndNewlines)) else {
-                                localError = "ts_utc must be a unix-seconds integer."
-                                return
-                            }
-                            localError = nil
-                            let payload = PayoutSignedPayload(
-                                address: pasteAddress.trimmingCharacters(in: .whitespacesAndNewlines),
-                                nonce: pasteNonce.trimmingCharacters(in: .whitespacesAndNewlines),
-                                tsUtc: ts,
-                                signature: pasteSignature.trimmingCharacters(in: .whitespacesAndNewlines),
-                                state: "paste"
-                            )
-                            await agent.registerPayoutWallet(pasted: payload)
-                            if agent.snapshot.payoutLastError == nil,
-                               agent.snapshot.payoutRegisteredAddress != nil {
-                                isPresented = false
-                            }
+                        guard let ts = UInt64(pasteTsUtc.trimmingCharacters(in: .whitespacesAndNewlines)) else {
+                            localError = "ts_utc must be a unix-seconds integer."
+                            return
                         }
+                        localError = nil
+                        let payload = PayoutSignedPayload(
+                            address: pasteAddress.trimmingCharacters(in: .whitespacesAndNewlines),
+                            nonce: pasteNonce.trimmingCharacters(in: .whitespacesAndNewlines),
+                            tsUtc: ts,
+                            signature: pasteSignature.trimmingCharacters(in: .whitespacesAndNewlines),
+                            state: "paste"
+                        )
+                        startRegistration(pasted: payload)
                     }
                     .disabled(
                         agent.snapshot.payoutRegistrationInProgress
+                            || registrationTask != nil
                             || pasteAddress.isEmpty
                             || pasteSignature.isEmpty
                             || pasteNonce.isEmpty
@@ -569,6 +583,25 @@ private struct AddWalletSheet: View {
         }
         .padding(20)
         .frame(width: 440)
+        .onDisappear {
+            if registrationIsCancellable {
+                registrationTask?.cancel()
+            }
+            registrationTask = nil
+        }
+    }
+
+    private func startRegistration(pasted: PayoutSignedPayload? = nil) {
+        guard registrationTask == nil else { return }
+        registrationTask = Task {
+            await agent.registerPayoutWallet(pasted: pasted)
+            guard !Task.isCancelled else { return }
+            registrationTask = nil
+            if agent.snapshot.payoutLastError == nil,
+               agent.snapshot.payoutRegisteredAddress != nil {
+                isPresented = false
+            }
+        }
     }
 }
 

--- a/phase3-binary/app/Sources/Malibu/Dashboard/PayoutWalletFlow.swift
+++ b/phase3-binary/app/Sources/Malibu/Dashboard/PayoutWalletFlow.swift
@@ -102,6 +102,11 @@ struct PayoutChallengeResponse: Decodable {
 enum PayoutWalletFlow {
     static let callbackTimeout: TimeInterval = 5 * 60
     static let chain = "base-mainnet"
+    static let chainID: UInt64 = 8453
+
+    static func isSupportedChallengeChain(chainID: UInt64, chain: String) -> Bool {
+        chainID == self.chainID && chain == self.chain
+    }
 
     /// CSPRNG nonce (0x + 32 bytes). Fail-closed: a CSPRNG failure
     /// ABORTS the flow (SPEC-016 §3 non-custodial correlation token
@@ -203,6 +208,9 @@ enum PayoutWalletFlow {
         else {
             throw PayoutWalletFlowError.challengeFailed("Unexpected challenge response.")
         }
+        guard isSupportedChallengeChain(chainID: resp.chainID, chain: resp.chain) else {
+            throw PayoutWalletFlowError.challengeFailed("Coordinator returned an unsupported payout chain.")
+        }
         return PayoutChallengeView(
             providerID: providerID,
             verifyingContract: resp.verifyingContract,
@@ -254,27 +262,83 @@ enum PayoutWalletFlow {
         )
     }
 
-    private static func runCLI(_ executable: URL, arguments: [String]) async throws -> (Data, Data, Int32) {
-        try await withCheckedThrowingContinuation { continuation in
-            DispatchQueue.global(qos: .userInitiated).async {
-                let process = Process()
-                process.executableURL = executable
-                process.arguments = arguments
-                let out = Pipe()
-                let err = Pipe()
-                process.standardOutput = out
-                process.standardError = err
-                do {
-                    try process.run()
-                    process.waitUntilExit()
-                    let stdout = out.fileHandleForReading.readDataToEndOfFile()
-                    let stderr = err.fileHandleForReading.readDataToEndOfFile()
-                    continuation.resume(returning: (stdout, stderr, process.terminationStatus))
-                } catch {
-                    continuation.resume(throwing: PayoutWalletFlowError.cliNotFound)
+    private final class ProcessHold: @unchecked Sendable {
+        private let lock = NSLock()
+        private var process: Process?
+        private var cancelled = false
+
+        var isCancelled: Bool {
+            lock.lock()
+            defer { lock.unlock() }
+            return cancelled
+        }
+
+        func register(_ process: Process) {
+            lock.lock()
+            self.process = process
+            let shouldTerminate = cancelled
+            lock.unlock()
+            if shouldTerminate { Self.terminate(process) }
+        }
+
+        func cancel() {
+            lock.lock()
+            cancelled = true
+            let process = process
+            lock.unlock()
+            if let process { Self.terminate(process) }
+        }
+
+        private static func terminate(_ process: Process) {
+            guard process.isRunning else { return }
+            process.terminate()
+            DispatchQueue.global(qos: .utility).asyncAfter(deadline: .now() + 1) {
+                if process.isRunning {
+                    kill(process.processIdentifier, SIGKILL)
                 }
             }
         }
+    }
+
+    static func runCLI(_ executable: URL, arguments: [String]) async throws -> (Data, Data, Int32) {
+        try Task.checkCancellation()
+        let hold = ProcessHold()
+        let result = try await withTaskCancellationHandler {
+            try await withCheckedThrowingContinuation {
+                (continuation: CheckedContinuation<(Data, Data, Int32), Error>) in
+                DispatchQueue.global(qos: .userInitiated).async {
+                    let process = Process()
+                    process.executableURL = executable
+                    process.arguments = arguments
+                    let out = Pipe()
+                    let err = Pipe()
+                    process.standardOutput = out
+                    process.standardError = err
+                    do {
+                        try process.run()
+                        hold.register(process)
+                        process.waitUntilExit()
+                        let stdout = out.fileHandleForReading.readDataToEndOfFile()
+                        let stderr = err.fileHandleForReading.readDataToEndOfFile()
+                        if hold.isCancelled {
+                            continuation.resume(throwing: CancellationError())
+                            return
+                        }
+                        continuation.resume(returning: (stdout, stderr, process.terminationStatus))
+                    } catch {
+                        if hold.isCancelled {
+                            continuation.resume(throwing: CancellationError())
+                            return
+                        }
+                        continuation.resume(throwing: PayoutWalletFlowError.cliNotFound)
+                    }
+                }
+            }
+        } onCancel: {
+            hold.cancel()
+        }
+        try Task.checkCancellation()
+        return result
     }
 
     private static func parseCLIError(stderr: Data, stdout: Data) -> String {

--- a/phase3-binary/app/Sources/Malibu/Resources/payout-signer/signer.html
+++ b/phase3-binary/app/Sources/Malibu/Resources/payout-signer/signer.html
@@ -150,6 +150,76 @@
 
   let ethereum = null;
   let selectedAccount = null;
+  let observedProvider = null;
+  let connectionGeneration = 0;
+
+  const expectedChainHex = "0x" + chainId.toString(16);
+
+  function chainDisplayName() {
+    return chainId === 8453 ? "Base Mainnet" : chain + " (chain " + chainId + ")";
+  }
+
+  async function ensureExpectedChain(provider) {
+    const current = await provider.request({ method: "eth_chainId" });
+    if (String(current).toLowerCase() === expectedChainHex) return;
+
+    try {
+      await provider.request({
+        method: "wallet_switchEthereumChain",
+        params: [{ chainId: expectedChainHex }],
+      });
+    } catch (switchError) {
+      // Base is the production payout chain. If it is not configured yet,
+      // offer the canonical public network metadata, then explicitly switch.
+      if (switchError && switchError.code === 4902 && chainId === 8453) {
+        await provider.request({
+          method: "wallet_addEthereumChain",
+          params: [{
+            chainId: expectedChainHex,
+            chainName: "Base Mainnet",
+            nativeCurrency: { name: "Ether", symbol: "ETH", decimals: 18 },
+            rpcUrls: ["https://mainnet.base.org"],
+            blockExplorerUrls: ["https://basescan.org"],
+          }],
+        });
+        await provider.request({
+          method: "wallet_switchEthereumChain",
+          params: [{ chainId: expectedChainHex }],
+        });
+      } else {
+        throw new Error("Switch your wallet to " + chainDisplayName() + " to sign the registration.");
+      }
+    }
+
+    const selected = await provider.request({ method: "eth_chainId" });
+    if (String(selected).toLowerCase() !== expectedChainHex) {
+      throw new Error("Wallet did not switch to " + chainDisplayName() + ". Switch networks and try again.");
+    }
+  }
+
+  function observeProvider(provider) {
+    if (observedProvider === provider || typeof provider.on !== "function") return;
+    observedProvider = provider;
+    provider.on("chainChanged", function (nextChain) {
+      if (ethereum !== provider) return;
+      connectionGeneration += 1;
+      if (String(nextChain).toLowerCase() === expectedChainHex && selectedAccount) {
+        el("btnSign").disabled = false;
+        setStatus("info", "Connected on " + chainDisplayName() + ". Review the typed data, then sign.");
+      } else {
+        el("btnSign").disabled = true;
+        setStatus("err", "Wallet network changed. Switch back to " + chainDisplayName() + " to sign.");
+      }
+    });
+    provider.on("accountsChanged", function () {
+      if (ethereum !== provider) return;
+      connectionGeneration += 1;
+      selectedAccount = null;
+      el("account").textContent = "not connected";
+      el("btnSign").disabled = true;
+      setStatus("err", "Wallet account changed. Connect the payout account again.");
+    });
+  }
 
   function setStatus(kind, msg) {
     const s = el("status");
@@ -188,18 +258,25 @@
         : "No browser wallet detected. Install MetaMask or Rabby, then reload.");
       return;
     }
+    if (ethereum !== provider) connectionGeneration += 1;
     ethereum = provider;
     try {
-      const accounts = await ethereum.request({ method: "eth_requestAccounts" });
+      const accounts = await provider.request({ method: "eth_requestAccounts" });
       if (!accounts || !accounts.length) {
         setStatus("err", "No account returned by wallet.");
         return;
       }
+      await ensureExpectedChain(provider);
+      if (ethereum !== provider) throw new Error("Wallet provider changed. Connect again.");
       selectedAccount = accounts[0];
+      observeProvider(provider);
       el("account").textContent = selectedAccount;
       el("btnSign").disabled = false;
-      setStatus("info", "Connected. Review the typed data, then sign.");
+      setStatus("info", "Connected on " + chainDisplayName() + ". Review the typed data, then sign.");
     } catch (e) {
+      selectedAccount = null;
+      el("account").textContent = "not connected";
+      el("btnSign").disabled = true;
       setStatus("err", "Connect failed: " + (e && e.message ? e.message : String(e)));
     }
   }
@@ -296,7 +373,14 @@
     setStatus("info", "Requesting EIP-712 signature…");
 
     try {
-      const browser = new ethers.BrowserProvider(ethereum);
+      // The wallet can change networks after Connect. Enforce the challenge
+      // chain again at the actual signing boundary so MetaMask never receives
+      // typed data for a chain other than its current chain.
+      const signingProvider = ethereum;
+      await ensureExpectedChain(signingProvider);
+      if (ethereum !== signingProvider) throw new Error("Wallet provider changed. Connect again.");
+      const signingGeneration = connectionGeneration;
+      const browser = new ethers.BrowserProvider(signingProvider);
       const signer = await browser.getSigner();
       const payoutAddress = await signer.getAddress();
       if (payoutAddress.toLowerCase() !== selectedAccount.toLowerCase()) {
@@ -314,6 +398,20 @@
         setStatus("err", "Local verify failed: recovered " + recovered + " ≠ " + payoutAddress);
         el("btnSign").disabled = false;
         return;
+      }
+
+      // Wallet approval is asynchronous. Revalidate intent immediately before
+      // posting the signature in case account/network/provider state changed
+      // while the approval prompt was open.
+      const currentChain = await signingProvider.request({ method: "eth_chainId" });
+      const currentAccounts = await signingProvider.request({ method: "eth_accounts" });
+      if (ethereum !== signingProvider ||
+          connectionGeneration !== signingGeneration ||
+          String(currentChain).toLowerCase() !== expectedChainHex ||
+          !currentAccounts || !currentAccounts.length ||
+          currentAccounts[0].toLowerCase() !== payoutAddress.toLowerCase() ||
+          !selectedAccount || selectedAccount.toLowerCase() !== payoutAddress.toLowerCase()) {
+        throw new Error("Wallet account or network changed during approval. Connect again and re-sign.");
       }
 
       const payload = {

--- a/phase3-binary/app/Tests/MalibuTests/PayoutWalletFlowTests.swift
+++ b/phase3-binary/app/Tests/MalibuTests/PayoutWalletFlowTests.swift
@@ -83,6 +83,27 @@ final class PayoutWalletFlowTests: XCTestCase {
         )
     }
 
+    func testPayoutChallengeChainFailsClosedOutsideBaseMainnet() {
+        XCTAssertTrue(PayoutWalletFlow.isSupportedChallengeChain(chainID: 8453, chain: "base-mainnet"))
+        XCTAssertFalse(PayoutWalletFlow.isSupportedChallengeChain(chainID: 1, chain: "base-mainnet"))
+        XCTAssertFalse(PayoutWalletFlow.isSupportedChallengeChain(chainID: 8453, chain: "ethereum-mainnet"))
+    }
+
+    func testRegistrationPresentationCancellationPhases() {
+        XCTAssertTrue(PayoutRegistrationPresentation.isCancellable(
+            inProgress: false,
+            canCancel: false
+        ), "a locally-created task must remain cancellable before the agent starts")
+        XCTAssertTrue(PayoutRegistrationPresentation.isCancellable(
+            inProgress: true,
+            canCancel: true
+        ), "challenge and wallet-signature phases must remain cancellable")
+        XCTAssertFalse(PayoutRegistrationPresentation.isCancellable(
+            inProgress: true,
+            canCancel: false
+        ), "remote commit phase must close without cancelling registration")
+    }
+
     func testTruncateAddress() {
         let full = "0x70997970C51812dc3A010C7d01b50e0d17dc79C8"
         XCTAssertEqual(PayoutWalletFlow.truncateAddress(full), "0x7099…79C8")
@@ -536,6 +557,34 @@ final class PayoutWalletFlowTests: XCTestCase {
                       "signer.html must be at Resources/payout-signer/ (H2); missing at \(signer.path)")
         XCTAssertTrue(FileManager.default.fileExists(atPath: ethers.path),
                       "ethers.min.js must be at Resources/payout-signer/ (H2); missing at \(ethers.path)")
+
+        let sourceSigner = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .appendingPathComponent("Sources/Malibu/Resources/payout-signer/signer.html")
+        XCTAssertEqual(try Data(contentsOf: signer), try Data(contentsOf: sourceSigner),
+                       "the packaged signer must be byte-identical to the reviewed/tested source")
+    }
+
+    func testCancelledCLIProcessReturnsPromptly() async throws {
+        let task = Task {
+            try await PayoutWalletFlow.runCLI(
+                URL(fileURLWithPath: "/bin/sleep"),
+                arguments: ["30"]
+            )
+        }
+        try await Task.sleep(nanoseconds: 150_000_000)
+        let started = Date()
+        task.cancel()
+
+        do {
+            _ = try await task.value
+            XCTFail("cancelled CLI process must throw")
+        } catch is CancellationError {
+            XCTAssertLessThan(Date().timeIntervalSince(started), 5,
+                              "cancelled CLI process must not wait for normal exit")
+        }
     }
 
     // M2: the signer URL must carry the coordinator-supplied EIP-712 domain

--- a/phase3-binary/app/Tests/MalibuTests/payout-signer-chain.test.mjs
+++ b/phase3-binary/app/Tests/MalibuTests/payout-signer-chain.test.mjs
@@ -1,0 +1,172 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import test from "node:test";
+import vm from "node:vm";
+
+const signerPath = new URL("../../Sources/Malibu/Resources/payout-signer/signer.html", import.meta.url);
+const html = fs.readFileSync(signerPath, "utf8");
+const inlineScript = html.match(/<script>\s*((?:.|\n)*?)\s*<\/script>\s*<\/body>/)?.[1];
+assert.ok(inlineScript, "signer inline script must be present");
+
+function makeElement() {
+  return {
+    className: "",
+    disabled: false,
+    textContent: "",
+    value: "",
+    classList: { add() {} },
+    listeners: new Map(),
+    addEventListener(name, callback) { this.listeners.set(name, callback); },
+  };
+}
+
+function loadSigner({ currentChain = "0x1", switchError = null } = {}) {
+  const elements = new Map();
+  const requests = [];
+  let posts = 0;
+  const account = "0x58a92ed8a8df9bdcbfb0d7fba4fffec6d52c6008";
+  const ethereum = {
+    activeChain: currentChain,
+    accounts: [account],
+    driftDuringSign: false,
+    listeners: new Map(),
+    on(name, callback) { this.listeners.set(name, callback); },
+    async request(request) {
+      requests.push(request);
+      if (request.method === "eth_requestAccounts" || request.method === "eth_accounts") {
+        return this.accounts;
+      }
+      if (request.method === "eth_chainId") return this.activeChain;
+      if (request.method === "wallet_switchEthereumChain") {
+        if (switchError) {
+          const error = switchError;
+          switchError = null;
+          throw error;
+        }
+        this.activeChain = request.params[0].chainId;
+        return null;
+      }
+      if (request.method === "wallet_addEthereumChain") {
+        this.activeChain = request.params[0].chainId;
+        return null;
+      }
+      throw new Error(`unexpected request: ${request.method}`);
+    },
+  };
+  const context = {
+    URL,
+    URLSearchParams,
+    console,
+    fetch: async () => {
+      posts += 1;
+      return { ok: true };
+    },
+    window: {
+      ethereum,
+      location: {
+        search: "?provider_id=mp-test&verifying_contract=0xb1b26fc275b01d1071ec15a968ecd2d521c6acdae&chain_id=8453&chain=base-mainnet&nonce=0x" + "ab".repeat(32) + "&ts_utc=1786269537&redirect_uri=http%3A%2F%2F127.0.0.1%3A9999%2Fcb&state=deadbeef",
+      },
+    },
+    document: {
+      getElementById(id) {
+        if (!elements.has(id)) elements.set(id, makeElement());
+        return elements.get(id);
+      },
+    },
+    ethers: {
+      BrowserProvider: class {
+        constructor(provider) { this.provider = provider; }
+        async getSigner() {
+          const provider = this.provider;
+          return {
+            getAddress: async () => account,
+            signTypedData: async () => {
+              if (provider.activeChain !== "0x2105") {
+                throw new Error("chainId should be same as current chainId");
+              }
+              if (provider.driftDuringSign) {
+                provider.accounts = ["0x1111111111111111111111111111111111111111"];
+                provider.listeners.get("accountsChanged")?.(provider.accounts);
+              }
+              return "0x" + "cd".repeat(65);
+            },
+          };
+        }
+      },
+      verifyTypedData: () => account,
+    },
+  };
+  vm.runInNewContext(inlineScript, context, { filename: "signer.html" });
+  return { elements, ethereum, getPosts: () => posts, requests };
+}
+
+async function clickAndSettle(elements, id) {
+  elements.get(id).listeners.get("click")();
+  await new Promise((resolve) => setImmediate(resolve));
+}
+
+test("connecting switches the wallet to the challenge chain before enabling signing", async () => {
+  const { elements, requests } = loadSigner({ currentChain: "0x1" });
+  await clickAndSettle(elements, "btnInjected");
+
+  const switchRequest = requests.find((request) => request.method === "wallet_switchEthereumChain");
+  assert.equal(switchRequest?.params[0].chainId, "0x2105");
+  assert.equal(elements.get("btnSign").disabled, false);
+});
+
+test("a rejected chain switch leaves signing disabled with an actionable error", async () => {
+  const rejection = Object.assign(new Error("User rejected the request."), { code: 4001 });
+  const { elements } = loadSigner({ currentChain: "0x1", switchError: rejection });
+  await clickAndSettle(elements, "btnInjected");
+
+  assert.equal(elements.get("btnSign").disabled, true);
+  assert.match(elements.get("status").textContent, /switch.*Base|Base.*switch/i);
+});
+
+test("an unknown Base network is offered to the wallet before signing", async () => {
+  const unknownChain = Object.assign(new Error("Unrecognized chain ID"), { code: 4902 });
+  const { elements, requests } = loadSigner({ currentChain: "0x1", switchError: unknownChain });
+  await clickAndSettle(elements, "btnInjected");
+
+  const addRequest = requests.find((request) => request.method === "wallet_addEthereumChain");
+  assert.equal(addRequest?.params[0].chainId, "0x2105");
+  assert.equal(addRequest?.params[0].chainName, "Base Mainnet");
+  assert.equal(addRequest?.params[0].rpcUrls[0], "https://mainnet.base.org");
+  assert.equal(elements.get("btnSign").disabled, false);
+});
+
+test("signing rechecks and repairs chain drift after connection", async () => {
+  const { elements, ethereum, requests } = loadSigner({ currentChain: "0x2105" });
+  await clickAndSettle(elements, "btnInjected");
+  ethereum.activeChain = "0x1";
+
+  await clickAndSettle(elements, "btnSign");
+
+  const switches = requests.filter((request) => request.method === "wallet_switchEthereumChain");
+  assert.equal(switches.length, 1);
+  assert.equal(switches[0].params[0].chainId, "0x2105");
+  assert.equal(elements.get("status").textContent, "Signature sent to Malibu. You can close this tab.");
+});
+
+test("returning to Base after a chainChanged event re-enables signing", async () => {
+  const { elements, ethereum } = loadSigner({ currentChain: "0x2105" });
+  await clickAndSettle(elements, "btnInjected");
+
+  ethereum.listeners.get("chainChanged")("0x1");
+  assert.equal(elements.get("btnSign").disabled, true);
+  ethereum.listeners.get("chainChanged")("0x2105");
+
+  assert.equal(elements.get("btnSign").disabled, false);
+  assert.match(elements.get("status").textContent, /Connected on Base Mainnet/);
+});
+
+test("an account change during wallet approval prevents callback submission", async () => {
+  const { elements, ethereum, getPosts } = loadSigner({ currentChain: "0x2105" });
+  await clickAndSettle(elements, "btnInjected");
+  ethereum.driftDuringSign = true;
+
+  await clickAndSettle(elements, "btnSign");
+
+  assert.equal(getPosts(), 0);
+  assert.match(elements.get("status").textContent, /account or network changed/i);
+});

--- a/specs/CONFORMANCE.json
+++ b/specs/CONFORMANCE.json
@@ -3155,8 +3155,7 @@
       "implementation": [
         "phase4-coordinator/internal/payout/addresses.go:AddressesService",
         "phase4-coordinator/internal/payout/addresses.go:ServePayoutChallenge",
-        "phase4-coordinator/internal/payout/addresses.go:ServePayoutAddress",
-        "phase3-binary/app/Sources/Malibu/Dashboard/PayoutWalletFlow.swift:PayoutWalletFlow"
+        "phase4-coordinator/internal/payout/addresses.go:ServePayoutAddress"
       ],
       "tests": [
         "phase4-coordinator/internal/payout/addresses_test.go:TestServePayoutAddress_HappyPath_FirstRegistration",
@@ -3182,8 +3181,7 @@
         "phase4-coordinator/internal/payout/eip712_test.go:TestVerifyEIP712_WrongNonceRejected",
         "phase4-coordinator/internal/payout/eip712_fixture_gen_test.go:TestEIP712DigestFixture_MatchesCommitted",
         "phase4-coordinator/internal/payout/eip712_fixture_gen_test.go:TestEIP712DigestFixture_RoundTripJSSignature",
-        "phase4-coordinator/internal/payout/attempts_test.go:TestSelectReadyPayouts_FiltersByHotWalletAndCoolingOff",
-        "phase3-binary/app/Tests/MalibuTests/PayoutWalletFlowTests.swift:PayoutWalletFlowTests"
+        "phase4-coordinator/internal/payout/attempts_test.go:TestSelectReadyPayouts_FiltersByHotWalletAndCoolingOff"
       ],
       "journeys": [
         "JOURNEY-SPEC-016-PAYOUT-ADDRESS-REGISTRATION"


### PR DESCRIPTION
## Summary
- switch/add the browser wallet to Base Mainnet before enabling/signing the payout EIP-712 registration
- fail closed if the coordinator challenge is not Base Mainnet, and re-check chain/account drift before callback submission
- make the Add Wallet sheet cancellation-aware so cancel/close behavior cannot leave the flow stuck
- add Node signer regressions plus Swift payout-flow regressions for chain handling, lifecycle cancellation, and packaged signer integrity

Closes #968

SPEC-GOVERNANCE-DECLARATION-BEGIN
{
  "schema_version": "spec-pr-governance-v1",
  "behavior_change": "yes",
  "contract_change": "yes",
  "specs": ["SPEC-016"],
  "requirements": ["SPEC-016-R002"],
  "authority_domains": ["payout-lifecycle"],
  "arbitration": ["CODE_BUG"],
  "tests": [
    "node --test Tests/MalibuTests/payout-signer-chain.test.mjs",
    "xcodebuild -project Malibu.xcodeproj -scheme Malibu -configuration Debug -derivedDataPath .derived-wallet-signing test CODE_SIGNING_ALLOWED=NO",
    "make test",
    "python3 scripts/check_spec_governance.py --base-ref origin/main"
  ],
  "journeys": ["live add-wallet E2E against coordinator.streamvc.live"],
  "issue": "https://github.com/Augustas11/macprovider/issues/968"
}
SPEC-GOVERNANCE-DECLARATION-END

## Validation
- `python3 scripts/check_spec_governance.py --base-ref origin/main` — passed
- `node --test Tests/MalibuTests/payout-signer-chain.test.mjs` — 6/6 passed
- `xcodebuild -project Malibu.xcodeproj -scheme Malibu -configuration Debug -derivedDataPath .derived-wallet-signing test CODE_SIGNING_ALLOWED=NO` — 363/363 passed
- `make test` — passed after the final conformance-mapping commit
- live add-wallet E2E against `coordinator.streamvc.live` using installed signed CLI + candidate signer page:
  - challenge returned Base Mainnet (`chain_id=8453`) for provider `mp-26592d710fc97aa7c07b260665c67cf6`
  - browser wallet signature callback captured for `0xBE1c17a4b10cf28E343AEa4B118420F637D95dcd`
  - `payout-address register` returned `http_status=200`, `status=rotated`
  - follow-up challenge returned the same registered address with `matches_signed_address=true`, `payout_allowed=true`

## Notes
- No private keys, bearer tokens, or raw signatures are included in this PR body.
- The live E2E used the currently configured provider and did mutate/refresh its payout registration cooling-off timestamp as expected.
