### PR TITLE
fix: relax Pearl heartbeat readiness

### DIFF
--- a/ops/pearl/config/source-of-truth.yaml
+++ b/ops/pearl/config/source-of-truth.yaml
@@ -116,7 +116,7 @@ known_config_drift:
     owner: pearl_production_overlay
     category: Evidence
     classification: intentional Pearl production posture
-    rationale: Current Pearl runtime posture; PR C should migrate it field-scope into the overlay.
+    rationale: Pearl base config may retain the pre-overlay 1s value, but production runtime must override it through /etc/macprovider/coordinator.pearl-overlays.yaml to the reviewed 30s heartbeat cadence.
   - path: coordinator_advertised_version.latest_binary_version
     drift_kind: value_mismatch
     tracked: "1.8.66"
@@ -266,6 +266,16 @@ pearl_overlay_classifications:
     category: Evidence
     classification: overlay-owned Pearl production setting
     expected_type: boolean
+  - path: pool.heartbeat_interval_s
+    owner: pearl_production_overlay
+    category: Evidence
+    classification: overlay-owned Pearl production setting
+    expected_type: integer
+  - path: pool.heartbeat_miss_threshold_s
+    owner: pearl_production_overlay
+    category: Evidence
+    classification: overlay-owned Pearl production setting
+    expected_type: integer
   - path: pool.canary_cold_start_grace_s
     owner: pearl_production_overlay
     category: Evidence

--- a/ops/pearl/config/test_pearl_config_reconcile.py
+++ b/ops/pearl/config/test_pearl_config_reconcile.py
@@ -43,6 +43,9 @@ class PearlConfigReconcileTest(unittest.TestCase):
         self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
         self.assertIn("Evidence:", result.stdout)
         self.assertIn("pool.heartbeat_interval_s: value_mismatch: tracked=30 live=1", result.stdout)
+        self.assertIn("production_overlay.pool.heartbeat_interval_s", result.stdout)
+        self.assertIn("production_overlay.pool.heartbeat_miss_threshold_s", result.stdout)
+        self.assertNotIn("pool.heartbeat_miss_threshold_s: value_mismatch", result.stdout)
         self.assertNotIn("pool.warmup_gate_enabled", result.stdout)
         self.assertIn(
             "coordinator_advertised_version.latest_binary_version: "

--- a/ops/pearl/config/testdata/known-drift-overlay.yaml
+++ b/ops/pearl/config/testdata/known-drift-overlay.yaml
@@ -4,6 +4,8 @@ coordinator:
     accepted_ids:
       - "Augustas11/macprovider:v1.8.61@example"
 pool:
+  heartbeat_interval_s: 30
+  heartbeat_miss_threshold_s: 90
   canary_enabled: false
   canary_interval_s: 300
   canary_timeout_s: 30

--- a/phase3-binary/Sources/macprovider-cli/CoordinatorReadinessClient.swift
+++ b/phase3-binary/Sources/macprovider-cli/CoordinatorReadinessClient.swift
@@ -124,7 +124,13 @@ enum CoordinatorReadinessClient {
         else {
             return nil
         }
-        if http.statusCode == 404 { return false }
+        // A 404 here usually means the coordinator no longer has the specific
+        // assigned session the app last observed (for example immediately after
+        // a coordinator drain/restart or provider reconnect). Treat that as an
+        // indeterminate readiness refresh instead of authoritative
+        // not_buyer_serving so Malibu does not tell a verified provider it is
+        // ineligible during assigned_id churn.
+        if http.statusCode == 404 { return nil }
         guard (200 ..< 300).contains(http.statusCode),
               let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
               object["provider_id"] as? String == providerID,

--- a/phase3-binary/Sources/macprovider-cli/SelfUpdate.swift
+++ b/phase3-binary/Sources/macprovider-cli/SelfUpdate.swift
@@ -2605,8 +2605,8 @@ struct LocalStatusFormatter {
                 ? "Run `macprovider-cli autotune --recommend --recover-hardware-admission` while online."
                 : "Run `macprovider-cli update`, or choose a catalog-supported model."
         } else if networkState == "not_buyer_serving" {
-            title = "This Mac is not currently eligible"
-            nextStep = "Open Malibu to review the recommended next step."
+            title = "Customer availability is temporarily interrupted"
+            nextStep = "Keep Malibu open while the coordinator refreshes this Mac's routing status."
         } else if !modelLoaded || ["draining", "unavailable"].contains(localState) {
             title = "Model is preparing"
             nextStep = "Keep this Mac awake while preparation completes."

--- a/phase3-binary/Tests/macprovider-cliTests/ProviderStatusTests.swift
+++ b/phase3-binary/Tests/macprovider-cliTests/ProviderStatusTests.swift
@@ -651,6 +651,15 @@ final class ProviderStatusTests: XCTestCase {
         XCTAssertNil(CoordinatorReadinessClient.verdict(
             data: body(mode: "current"), response: redirected, requestURL: requestURL, providerID: "provider-a", assignedID: "session-a"
         ))
+        let staleAssignedSession = try XCTUnwrap(HTTPURLResponse(
+            url: requestURL,
+            statusCode: 404,
+            httpVersion: nil,
+            headerFields: nil
+        ))
+        XCTAssertNil(CoordinatorReadinessClient.verdict(
+            data: Data(), response: staleAssignedSession, requestURL: requestURL, providerID: "provider-a", assignedID: "session-a"
+        ))
         XCTAssertEqual(CoordinatorReadinessClient.verdict(
             data: body(mode: "legacy", serving: false), response: response, requestURL: requestURL, providerID: "provider-a", assignedID: "session-a"
         ), false)

--- a/phase3-binary/Tests/macprovider-cliTests/StatusCommandTests.swift
+++ b/phase3-binary/Tests/macprovider-cliTests/StatusCommandTests.swift
@@ -149,7 +149,7 @@ final class StatusCommandTests: XCTestCase {
         let prohibited = policy.terms.map(\.internalTerm)
         let cases: [(String, String, Bool, Bool, String)] = [
             ("buyer_serving", "ready", true, true, "Provider is ready"),
-            ("not_buyer_serving", "ready", true, true, "This Mac is not currently eligible"),
+            ("not_buyer_serving", "ready", true, true, "Customer availability is temporarily interrupted"),
             ("buyer_serving_unknown", "ready", true, true, "Waiting for network approval"),
             ("catalog_update_required", "ready", true, true, "This Mac is not currently eligible"),
             ("live_verified", "unavailable", true, false, "Model is preparing"),
@@ -184,7 +184,7 @@ final class StatusCommandTests: XCTestCase {
         let output = LocalStatusFormatter.format(payload)
 
         XCTAssertEqual(output.components(separatedBy: "Next step:").count - 1, 1, output)
-        XCTAssertTrue(output.contains("Open Malibu to review the recommended next step."), output)
+        XCTAssertTrue(output.contains("Keep Malibu open while the coordinator refreshes this Mac's routing status."), output)
     }
 
     func testDefaultStatusSurfacesHardwareVerificationLifecycle() {

--- a/phase3-binary/app/Sources/Malibu/Agent/AgentSnapshot.swift
+++ b/phase3-binary/app/Sources/Malibu/Agent/AgentSnapshot.swift
@@ -494,6 +494,13 @@ enum AgentSnapshotPresenter {
                 executableAction: updateAvailable(s) ? .updateProviderSoftware : nil
             )
         }
+        if isTemporarilyNotBuyerServing(s) {
+            return PublicStatus(
+                title: "Customer availability is temporarily interrupted",
+                detail: "The coordinator is not routing customer work to this Mac right now, often during reconnect or maintenance windows.",
+                safeNextAction: "Keep Malibu open while status updates."
+            )
+        }
         if isIneligibleForCustomerWork(s) {
             return PublicStatus(
                 title: "This Mac is not currently eligible",
@@ -606,6 +613,11 @@ enum AgentSnapshotPresenter {
             && (s.statusObservationFresh == false || !s.isLocalStatusObservationCurrent())
     }
 
+    private static func isTemporarilyNotBuyerServing(_ s: AgentSnapshot) -> Bool {
+        guard s.state == .serving || s.state == .reconnecting else { return false }
+        return s.networkState == "not_buyer_serving"
+    }
+
     private static func isSoftwareUpdateRequired(_ s: AgentSnapshot) -> Bool {
         // Reason-specific #582 outcomes reuse catalog_incompatible on the v1
         // wire; do not collapse them into generic software-update guidance.
@@ -640,7 +652,7 @@ enum AgentSnapshotPresenter {
 
     private static func isIneligibleForCustomerWork(_ s: AgentSnapshot) -> Bool {
         switch s.networkState {
-        case "not_buyer_serving", "local_donor", "safe_offline_fallback", "catalog_integrity_failure":
+        case "local_donor", "safe_offline_fallback", "catalog_integrity_failure":
             return true
         default:
             return false

--- a/phase3-binary/app/Tests/MalibuTests/AgentSnapshotPresenterTests.swift
+++ b/phase3-binary/app/Tests/MalibuTests/AgentSnapshotPresenterTests.swift
@@ -60,11 +60,14 @@ final class AgentSnapshotPresenterTests: XCTestCase {
         waiting.networkState = "live_verified"
         XCTAssertEqual(AgentSnapshotPresenter.publicStatus(waiting).title, "Waiting for network approval")
 
-        var ineligible = AgentSnapshot.empty
-        ineligible.state = .reconnecting
-        ineligible.currentModelID = "llama"
-        ineligible.networkState = "not_buyer_serving"
-        XCTAssertEqual(AgentSnapshotPresenter.publicStatus(ineligible).title, "This Mac is not currently eligible")
+        var interrupted = AgentSnapshot.empty
+        interrupted.state = .reconnecting
+        interrupted.currentModelID = "llama"
+        interrupted.networkState = "not_buyer_serving"
+        XCTAssertEqual(
+            AgentSnapshotPresenter.publicStatus(interrupted).title,
+            "Customer availability is temporarily interrupted"
+        )
 
         var preparing = AgentSnapshot.empty
         preparing.state = .starting
@@ -663,7 +666,7 @@ final class AgentSnapshotPresenterTests: XCTestCase {
         XCTAssertFalse(AgentSnapshotPresenter.isNetworkReady(snapshot))
         XCTAssertEqual(
             AgentSnapshotPresenter.publicStatus(snapshot).title,
-            "This Mac is not currently eligible"
+            "Customer availability is temporarily interrupted"
         )
     }
 
@@ -713,7 +716,7 @@ final class AgentSnapshotPresenterTests: XCTestCase {
         XCTAssertFalse(AgentSnapshotPresenter.isNetworkReady(snapshot, at: now))
         XCTAssertEqual(
             AgentSnapshotPresenter.publicStatus(snapshot).title,
-            "This Mac is not currently eligible"
+            "Customer availability is temporarily interrupted"
         )
 
         // Coordinator disconnect while still within retention: authoritative


### PR DESCRIPTION
## Summary

- Make Pearl heartbeat tolerance durable by classifying the production overlay-owned heartbeat values (`heartbeat_interval_s: 30`, `heartbeat_miss_threshold_s: 90`) in source-of-truth config and drift tests.
- Treat transient `/v1/pool/check` assigned-session misses as unknown readiness instead of authoritative `not_buyer_serving`, avoiding false “not eligible” UI demotion during coordinator drain/reconnect windows.
- Update CLI/app status copy so temporary buyer-serving interruptions read as customer-availability interruptions rather than blaming the Mac/provider.

## Live validation

- Pearl live coordinator restarted with `/etc/macprovider/coordinator.pearl-overlays.yaml` containing:
  - `heartbeat_interval_s: 30`
  - `heartbeat_miss_threshold_s: 90`
- Confirmed affected provider `mp-1962fb3ccb9fa0d227767c3a77b54fbe` with current assigned ID `12719b71-c9c7-4541-8502-5fdc3edb1e2c`:
  - `state: ready`
  - `buyer_serving: true`
  - `catalog_admission_mode: current`
- Post-stabilization coordinator logs after `2026-08-10T09:27Z` for that provider:
  - `provider heartbeat stale=0`
  - `pool check miss=0`
  - `degraded=0`
  - `websocket read failed=0`
  - `draining=0`
- Local `tech.malibu.buyer-runner` launch agent is disabled; Pearl `canary-buyer.timer/service` inactive/disabled.

## Test plan

- [x] `python3 -m unittest ops.pearl.config.test_pearl_config_reconcile` — 26 tests OK
- [x] `swift test --filter ProviderStatusTests` — 40 tests OK
- [x] `xcodebuild test -project Malibu.xcodeproj -scheme Malibu -only-testing:MalibuTests/AgentSnapshotPresenterTests -configuration Debug CODE_SIGNING_ALLOWED=NO` — 49 tests OK
- [x] `git diff --check`
- [x] `make test` — full root test gate passed
- [x] `make fmt` — passed, but unrelated pre-existing gofmt drift was reverted to keep this diff scoped
- [ ] `make check` — blocked by unrelated missing tracked artifact `phase5-gateway/dist/gateway.yaml`; verified `phase4-coordinator/dist/coordinator.yaml` exists in `HEAD`, but `phase5-gateway/dist/gateway.yaml` does not. Did not invent a production config file to satisfy the gate.

## Not included

- Provider app/CLI update for the affected Mac; DB still reports app version `1.8.88`.
- Shipping the app copy change to providers; this PR only lands the code/config changes.

---

SPEC-GOVERNANCE-DECLARATION-BEGIN
{
  "schema_version": "spec-pr-governance-v1",
  "behavior_change": "yes",
  "contract_change": "none",
  "specs": ["SPEC-002"],
  "requirements": ["SPEC-002-R001"],
  "authority_domains": ["coordinator-admission-routing"],
  "arbitration": ["CODE_BUG"],
  "tests": [
    "python3 -m unittest ops.pearl.config.test_pearl_config_reconcile",
    "swift test --filter ProviderStatusTests",
    "xcodebuild test -project Malibu.xcodeproj -scheme Malibu -only-testing:MalibuTests/AgentSnapshotPresenterTests -configuration Debug CODE_SIGNING_ALLOWED=NO",
    "make test"
  ],
  "journeys": ["live-pearl-provider-readiness-check"]
}
SPEC-GOVERNANCE-DECLARATION-END
