### PR TITLE
fix: stabilize Malibu settings and cancellation errors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -358,11 +358,13 @@ jobs:
   dist-tooling:
     name: deploy tooling (check-deploy-config gate)
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: 10
     # Guards the fail-closed C2 pre-deploy gate
     # (phase4-coordinator/dist/check-deploy-config.sh), also invoked by
     # phase5-gateway/dist/deploy-pearl-vps.sh. Bash + python3 only — no Go
-    # build — so it stays a fast, isolated job. Closes the 2026-06-17
+    # build — so it stays isolated. The full dist shell/e2e matrix now runs
+    # just over five minutes on hosted runners, so keep a 10-minute cap rather
+    # than canceling a passing regression suite near completion. Closes the 2026-06-17
     # regression where an env:NAME-indirected operator_key false-failed the
     # gate and pushed operators into SKIP_C2_CHECK=1. Catalog release tests now
     # authenticate Tier-2 with the reviewed Go verifier, so install the pinned

--- a/phase3-binary/app/Sources/Malibu/Agent/AgentSnapshot.swift
+++ b/phase3-binary/app/Sources/Malibu/Agent/AgentSnapshot.swift
@@ -761,9 +761,9 @@ enum AgentSnapshotPresenter {
                 ? s.earningsUsdcToday.map { formatUSDC($0) } ?? "n/a"
                 : "n/a"
             let malibu = s.malibuProjectionFresh
-                ? s.malibuAccruedToday.map { String(format: "%.2f", $0) } ?? "n/a"
-                : "n/a"
-            return "Today: \(usdc) USDC · \(malibu) MALIBU (reward status unavailable)"
+                ? malibuTodayLine(s, compact: false)
+                : "MALIBU reward status unavailable"
+            return "Today: \(usdc) USDC · \(malibu)"
         }
         switch (s.earningsUsdcToday, s.malibuAccruedToday) {
         case (nil, nil):
@@ -771,7 +771,7 @@ enum AgentSnapshotPresenter {
         case let (usdc?, malibu?):
             return "Today: \(formatUSDC(usdc)) USDC · \(malibuDisplay(malibu, tier: s.trustTier))"
         case let (usdc?, nil):
-            return "Today: \(formatUSDC(usdc)) USDC · n/a MALIBU (reward status unavailable)"
+            return "Today: \(formatUSDC(usdc)) USDC · \(malibuTodayLine(s, compact: false))"
         case let (nil, malibu?):
             return "Today: n/a USDC · \(malibuDisplay(malibu, tier: s.trustTier))"
         }
@@ -1157,8 +1157,7 @@ enum AgentSnapshotPresenter {
             let today = "n/a MALIBU today"
             return "\(today) · n/a all-time"
         }
-        let today = s.malibuAccruedToday.map { malibuDisplay($0, tier: s.trustTier, compact: true) }
-            ?? "n/a MALIBU today"
+        let today = malibuTodayLine(s, compact: true)
         let allTime = s.malibuAccruedAllTime.map { String(format: "%.2f all-time", $0) }
             ?? "n/a all-time"
         switch s.trustTier {
@@ -1167,6 +1166,16 @@ enum AgentSnapshotPresenter {
         case .provisional:
             return "\(today) · \(allTime) · [locked] unlocks at Trusted"
         }
+    }
+
+    private static func malibuTodayLine(_ s: AgentSnapshot, compact: Bool) -> String {
+        if let malibu = s.malibuAccruedToday {
+            return malibuDisplay(malibu, tier: s.trustTier, compact: compact)
+        }
+        if s.malibuAccruedAllTime != nil || s.malibuWithdrawable != nil || s.malibuHeld != nil {
+            return "MALIBU daily not reported yet"
+        }
+        return compact ? "n/a MALIBU today" : "n/a MALIBU"
     }
 
     static func malibuAvailabilityLine(_ s: AgentSnapshot) -> String? {
@@ -1208,9 +1217,9 @@ enum AgentSnapshotPresenter {
     static func uptimeLine(_ s: AgentSnapshot) -> String {
         var parts: [String] = []
         if let sec = s.uptimeSec, isActive(s) {
-            parts.append("\(formatDuration(sec)) up")
+            parts.append("\(formatDuration(sec)) current run")
         } else if isActive(s) {
-            parts.append("uptime n/a")
+            parts.append("current run n/a")
         }
         if let pct = s.uptime7dPct {
             parts.append(String(format: "%.1f%% uptime (7d)", pct))

--- a/phase3-binary/app/Sources/Malibu/Agent/MalibuAgent.swift
+++ b/phase3-binary/app/Sources/Malibu/Agent/MalibuAgent.swift
@@ -1108,24 +1108,7 @@ final class MalibuAgent: ObservableObject {
     }
 
     private static func payoutErrorMessage(_ error: PayoutWalletFlowError) -> String {
-        switch error {
-        case .cliNotFound:
-            return "Provider software is not installed."
-        case let .challengeFailed(msg), let .registerFailed(msg), let .loopbackFailed(msg):
-            return msg
-        case .timedOut:
-            return "Wallet signing timed out. Open Add wallet and try again."
-        case .cancelled:
-            return "Wallet registration was cancelled."
-        case .invalidCallback:
-            return "The signature from the browser was incomplete or mismatched."
-        case .missingResources:
-            return "The bundled wallet signer page is missing from this app build."
-        case .missingProviderID:
-            return "Provider identity is not configured on this Mac."
-        case .rngFailure:
-            return "Secure random generation failed. Please try again."
-        }
+        PayoutWalletFlow.publicErrorMessage(error)
     }
 
     private func finishReferralAction() {

--- a/phase3-binary/app/Sources/Malibu/Dashboard/DashboardWindow.swift
+++ b/phase3-binary/app/Sources/Malibu/Dashboard/DashboardWindow.swift
@@ -26,6 +26,13 @@ enum DashboardCopy {
     static let meaningTitle = "What this means"
     static let nextActionTitle = "Next safe action"
 
+    static func modelRowStatusLine(currentModelID: String?, switcherStatusLine: String) -> String {
+        if currentModelID != nil {
+            return String(localized: "Current model shown. Change Model shows switching availability.", comment: "Dashboard stable current-model status")
+        }
+        return switcherStatusLine
+    }
+
     static func defaultPublicStrings(_ snapshot: AgentSnapshot) -> [String] {
         let publicStatus = AgentSnapshotPresenter.publicStatus(snapshot)
         return [
@@ -88,7 +95,10 @@ private struct DashboardView: View {
                         .truncationMode(.middle)
                         .textSelection(.enabled)
                         .accessibilityLabel(Text(String(localized: "Current provider model", comment: "Dashboard model accessibility label")))
-                    Text(modelStore.statusLine)
+                    Text(DashboardCopy.modelRowStatusLine(
+                        currentModelID: modelStore.currentModelID ?? agent.snapshot.currentModelID,
+                        switcherStatusLine: modelStore.statusLine
+                    ))
                         .font(.caption2)
                         .foregroundStyle(.secondary)
                         .lineLimit(2)
@@ -101,7 +111,7 @@ private struct DashboardView: View {
                 .accessibilityHint(Text(String(localized: "Opens the model switcher and shows provider guards before any action.", comment: "Dashboard model action hint")))
                 Menu {
                     Button(String(localized: "Settings…", comment: "Dashboard settings action")) {
-                        NSApp.sendAction(Selector(("showSettingsWindow:")), to: nil, from: nil)
+                        SettingsWindowPresenter.shared.present()
                     }
                 } label: {
                     Image(systemName: "ellipsis.circle")
@@ -324,7 +334,7 @@ private struct DashboardView: View {
                             }
                             MetricRow(title: "Requests", value: AgentSnapshotPresenter.requestsLine(agent.snapshot))
                             MetricRow(title: "Tokens", value: AgentSnapshotPresenter.tokenLine(agent.snapshot))
-                            MetricRow(title: "Uptime", value: AgentSnapshotPresenter.uptimeLine(agent.snapshot))
+                            MetricRow(title: "Current run", value: AgentSnapshotPresenter.uptimeLine(agent.snapshot))
                             HStack(spacing: 8) {
                                 MetricChip(text: AgentSnapshotPresenter.queueChip(agent.snapshot), tone: queueTone)
                                 MetricChip(text: AgentSnapshotPresenter.thermalChip(agent.snapshot), tone: thermalTone)

--- a/phase3-binary/app/Sources/Malibu/Dashboard/PayoutWalletFlow.swift
+++ b/phase3-binary/app/Sources/Malibu/Dashboard/PayoutWalletFlow.swift
@@ -104,6 +104,36 @@ enum PayoutWalletFlow {
     static let chain = "base-mainnet"
     static let chainID: UInt64 = 8453
 
+    static func publicErrorMessage(_ error: PayoutWalletFlowError) -> String {
+        switch error {
+        case .cliNotFound:
+            return "Provider software is not installed."
+        case let .challengeFailed(msg), let .registerFailed(msg), let .loopbackFailed(msg):
+            if isRawCancellationMessage(msg) {
+                return publicErrorMessage(.cancelled)
+            }
+            return msg
+        case .timedOut:
+            return "Wallet signing timed out. Open Add wallet and try again."
+        case .cancelled:
+            return "Wallet registration was cancelled."
+        case .invalidCallback:
+            return "The signature from the browser was incomplete or mismatched."
+        case .missingResources:
+            return "The bundled wallet signer page is missing from this app build."
+        case .missingProviderID:
+            return "Provider identity is not configured on this Mac."
+        case .rngFailure:
+            return "Secure random generation failed. Please try again."
+        }
+    }
+
+    private static func isRawCancellationMessage(_ message: String) -> Bool {
+        let lower = message.lowercased()
+        return lower.contains("swift.cancellationerror")
+            || (lower.contains("operation couldn") && lower.contains("error 1"))
+    }
+
     static func isSupportedChallengeChain(chainID: UInt64, chain: String) -> Bool {
         chainID == self.chainID && chain == self.chain
     }

--- a/phase3-binary/app/Sources/Malibu/MalibuApp.swift
+++ b/phase3-binary/app/Sources/Malibu/MalibuApp.swift
@@ -95,7 +95,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         case .checkForUpdates, .updateCLI: Task { await agent.updateCLINow() }
         case .exportDiagnostics: exportDiagnostics()
         case .openSettings:
-            NSApp.sendAction(Selector(("showSettingsWindow:")), to: nil, from: nil)
+            SettingsWindowPresenter.shared.present()
         case .quitAndUninstall:
             guard uninstallTask == nil else { return }
             guard confirmUninstall() else { return }

--- a/phase3-binary/app/Sources/Malibu/ModelManagement/SettingsWindowPresenter.swift
+++ b/phase3-binary/app/Sources/Malibu/ModelManagement/SettingsWindowPresenter.swift
@@ -1,0 +1,28 @@
+import AppKit
+import SwiftUI
+
+@MainActor
+final class SettingsWindowPresenter {
+    static let shared = SettingsWindowPresenter()
+
+    private var window: NSWindow?
+
+    @discardableResult
+    func present() -> NSWindow {
+        let window = window ?? makeWindow()
+        self.window = window
+        window.makeKeyAndOrderFront(nil)
+        NSApp.activate(ignoringOtherApps: true)
+        return window
+    }
+
+    private func makeWindow() -> NSWindow {
+        let window = NSWindow(contentViewController: NSHostingController(rootView: ModelSettingsView()))
+        window.title = "Malibu Settings"
+        window.styleMask = [.titled, .closable, .miniaturizable, .resizable]
+        window.isReleasedWhenClosed = false
+        window.setContentSize(NSSize(width: 560, height: 520))
+        window.center()
+        return window
+    }
+}

--- a/phase3-binary/app/Tests/MalibuTests/AgentSnapshotPresenterTests.swift
+++ b/phase3-binary/app/Tests/MalibuTests/AgentSnapshotPresenterTests.swift
@@ -29,6 +29,41 @@ final class AgentSnapshotPresenterTests: XCTestCase {
         XCTAssertEqual(AgentSnapshotPresenter.earningsLine(s), "Today: reward status unavailable")
     }
 
+    func testMalibuDailyMissingExplainsProjectionInsteadOfShowingNA() {
+        var s = AgentSnapshot.empty
+        s.state = .serving
+        s.providerEarningsFresh = true
+        s.malibuProjectionFresh = true
+        s.earningsUsdcToday = 0.04
+        s.malibuAccruedToday = nil
+        s.malibuAccruedAllTime = 12.5
+        s.malibuHeld = 12.5
+        s.trustTier = .provisional
+
+        XCTAssertEqual(
+            AgentSnapshotPresenter.earningsLine(s),
+            "Today: $0.04 USDC · MALIBU daily not reported yet"
+        )
+        XCTAssertEqual(
+            AgentSnapshotPresenter.malibuFullLine(s),
+            "MALIBU daily not reported yet · 12.50 all-time · [locked] unlocks at Trusted"
+        )
+    }
+
+    func testUptimeLineLabelsProviderProcessRuntimeAsCurrentRun() {
+        var s = AgentSnapshot.empty
+        s.state = .serving
+        s.uptimeSec = 75
+        s.uptime7dPct = 99.5
+        s.declinedRequests = 0
+        s.restartCount = 2
+
+        XCTAssertEqual(
+            AgentSnapshotPresenter.uptimeLine(s),
+            "1m current run · 99.5% uptime (7d) · 0 declined · 2 restarts"
+        )
+    }
+
     func testShortShowsServingWhenNoEarningsYet() {
         var s = AgentSnapshot.empty
         s.state = .serving

--- a/phase3-binary/app/Tests/MalibuTests/ControlFrameCodecTests.swift
+++ b/phase3-binary/app/Tests/MalibuTests/ControlFrameCodecTests.swift
@@ -238,7 +238,7 @@ final class ControlFrameCodecTests: XCTestCase {
         XCTAssertEqual(AgentSnapshotPresenter.usdcTodayDisplay(agent.snapshot), "$4.00")
         XCTAssertNil(AgentSnapshotPresenter.malibuAvailabilityLine(agent.snapshot))
         XCTAssertTrue(AgentSnapshotPresenter.earningsLine(agent.snapshot).contains("$4.00 USDC"))
-        XCTAssertTrue(AgentSnapshotPresenter.earningsLine(agent.snapshot).contains("n/a MALIBU"))
+        XCTAssertTrue(AgentSnapshotPresenter.earningsLine(agent.snapshot).contains("MALIBU reward status unavailable"))
 
         let accrualOnly = ProviderEarnings(
             walletBound: false,
@@ -284,7 +284,7 @@ final class ControlFrameCodecTests: XCTestCase {
             AgentSnapshotPresenter.malibuAvailabilityLine(agent.snapshot),
             "MALIBU: 1.00 available · 8.00 held"
         )
-        XCTAssertTrue(AgentSnapshotPresenter.malibuFullLine(agent.snapshot).contains("n/a MALIBU today"))
+        XCTAssertTrue(AgentSnapshotPresenter.malibuFullLine(agent.snapshot).contains("MALIBU daily not reported yet"))
         XCTAssertEqual(AgentSnapshotPresenter.earningsLine(agent.snapshot), "Today: reward status unavailable")
     }
 

--- a/phase3-binary/app/Tests/MalibuTests/DashboardViewTests.swift
+++ b/phase3-binary/app/Tests/MalibuTests/DashboardViewTests.swift
@@ -2,6 +2,23 @@ import XCTest
 @testable import Malibu
 
 final class DashboardViewTests: XCTestCase {
+    func testDashboardModelSubtitleDoesNotEchoSwitcherFreshnessFlapping() {
+        XCTAssertEqual(
+            DashboardCopy.modelRowStatusLine(
+                currentModelID: "meta-llama/llama-3.2-3b-instruct",
+                switcherStatusLine: "Model controls ready."
+            ),
+            "Current model shown. Change Model shows switching availability."
+        )
+        XCTAssertEqual(
+            DashboardCopy.modelRowStatusLine(
+                currentModelID: "meta-llama/llama-3.2-3b-instruct",
+                switcherStatusLine: "Provider status is stale. Refresh the provider before switching models."
+            ),
+            "Current model shown. Change Model shows switching availability."
+        )
+    }
+
     func testOptionalDashboardFieldsRenderFriendlyZerosWhenServing() {
         var snapshot = AgentSnapshot.empty
         snapshot.state = .serving

--- a/phase3-binary/app/Tests/MalibuTests/PayoutWalletFlowTests.swift
+++ b/phase3-binary/app/Tests/MalibuTests/PayoutWalletFlowTests.swift
@@ -121,6 +121,22 @@ final class PayoutWalletFlowTests: XCTestCase {
         XCTAssertEqual(loaded?.pendingUntilUTC, "2026-01-09T00:00:00Z")
     }
 
+    func testRawSwiftCancellationErrorIsPresentedAsFriendlyWalletCancellation() {
+        let raw = "The operation couldn’t be completed. (Swift.CancellationError error 1.)"
+
+        XCTAssertEqual(
+            PayoutWalletFlow.publicErrorMessage(.challengeFailed(raw)),
+            "Wallet registration was cancelled."
+        )
+        XCTAssertEqual(
+            PayoutWalletFlow.publicErrorMessage(.registerFailed(raw)),
+            "Wallet registration was cancelled."
+        )
+        XCTAssertFalse(
+            PayoutWalletFlow.publicErrorMessage(.loopbackFailed(raw)).contains("Swift.CancellationError")
+        )
+    }
+
     // MARK: - M1: exact structural ts_utc decoding (JSONDecoder)
 
     func testCallbackBodyDecodesTimestampExactly() {

--- a/phase3-binary/app/Tests/MalibuTests/SettingsWindowPresenterTests.swift
+++ b/phase3-binary/app/Tests/MalibuTests/SettingsWindowPresenterTests.swift
@@ -1,0 +1,20 @@
+import XCTest
+import SwiftUI
+@testable import Malibu
+
+@MainActor
+final class SettingsWindowPresenterTests: XCTestCase {
+    func testSettingsPresenterCreatesReusableVisibleWindow() {
+        let presenter = SettingsWindowPresenter()
+
+        let first = presenter.present()
+        XCTAssertTrue(first.isVisible)
+        XCTAssertEqual(first.title, "Malibu Settings")
+        XCTAssertTrue(first.contentViewController is NSHostingController<ModelSettingsView>)
+
+        let second = presenter.present()
+        XCTAssertTrue(first === second, "Settings should reuse and foreground the existing window instead of depending on the fragile SwiftUI settings selector.")
+
+        first.close()
+    }
+}


### PR DESCRIPTION
## Summary
- Replace Malibu’s fragile SwiftUI/AppKit `showSettingsWindow:` selector dispatch with an explicit reusable settings window presenter used by both the menu-bar Settings action and dashboard Settings button.
- Centralize payout-wallet public error text and sanitize raw Swift task cancellation failures so users see “Wallet registration was cancelled.” instead of `Swift.CancellationError error 1`.
- Rename the advanced “Uptime” metric to “Current run” and render it as current provider-process runtime, so providers do not read an expected update/restart timer reset as lost provider history.
- Replace provider-facing `n/a MALIBU today` with `MALIBU daily not reported yet` when Malibu has fresh all-time/held MALIBU data but no daily MALIBU projection for the current UTC window.
- Keep the dashboard Model row stable when the provider status lease flips between ready/stale; the passive row now says `Current model shown. Change Model shows switching availability.` while the Change Model sheet still owns operational switching guards.
- Add regression tests for the Settings window presenter, the exact 1.8.92 cancellation text, the current-run wording, the missing daily MALIBU projection copy, and the Model-row wording flapping reported by a provider.
- Raise the deploy-tooling CI job timeout from 5 to 10 minutes after this PR showed `make test-dist` passes but now needs just over five minutes on hosted runners.

## Test Plan
- [x] `xcodegen generate && xcodebuild test -project Malibu.xcodeproj -scheme Malibu -configuration Debug CODE_SIGNING_ALLOWED=NO` — passed, 368 tests / 0 failures.
- [x] `make test` — passed.
- [x] `/usr/bin/time -p make test-dist` — passed locally in 330.38s; confirms the CI deploy-tooling failure was the 5-minute timeout, not a test failure.
- [x] `git diff --check` — passed.
- [ ] `make check` — blocked by existing unrelated repo artifact issue: `phase5-gateway/dist/gateway.yaml` is missing, so `phase4-coordinator/dist/check-deploy-config.sh phase4-coordinator/dist/coordinator.yaml phase5-gateway/dist/gateway.yaml` fails with `FileNotFoundError` before this Malibu app change is evaluated.

## Release/User Impact
- Addresses the Malibu 1.8.92 provider reports where the app displayed `The operation couldn’t be completed. (Swift.CancellationError error 1.)`, the visible Settings button did not open anything, “uptime” appeared to reset after a provider software update, MALIBU “Today” stayed as `N/A` while all-time MALIBU increased, and the Model row repeatedly changed wording between “Model controls ready” and stale-status guidance.
- No coordinator, gateway, billing, or payout contract behavior is changed; this is a Malibu app presentation/windowing fix plus focused regression coverage.

SPEC-GOVERNANCE-DECLARATION-BEGIN
{
  "schema_version": "spec-pr-governance-v1",
  "behavior_change": "yes",
  "contract_change": "none",
  "specs": ["SPEC-016"],
  "requirements": ["SPEC-016-R002"],
  "authority_domains": ["payout-lifecycle"],
  "arbitration": ["CODE_BUG"],
  "tests": [
    "xcodegen generate && xcodebuild test -project Malibu.xcodeproj -scheme Malibu -configuration Debug CODE_SIGNING_ALLOWED=NO",
    "make test",
    "/usr/bin/time -p make test-dist",
    "git diff --check"
  ],
  "journeys": ["not-required"]
}
SPEC-GOVERNANCE-DECLARATION-END
