### PR TITLE
Promote signed SPEC-010 R006 evidence

### DIFF
--- a/journeys/evidence/provider-prebeta-admission-air5-llama-warmswap-spec010-r006-20260810T111538Z.spec-010-r006.journey-result.signed.json
+++ b/journeys/evidence/provider-prebeta-admission-air5-llama-warmswap-spec010-r006-20260810T111538Z.spec-010-r006.journey-result.signed.json
@@ -1,0 +1,119 @@
+{
+  "schema_version": "macprovider.journey-result-envelope.v1",
+  "signatures": [
+    {
+      "algorithm": "ecdsa-p256-sha256",
+      "key_id": "macprovider-acceptance-p256-v1",
+      "signature": "MEUCICXw8k8Mpuw4MTfVNpTmyIObJNVE5YV0a/jMNdEW7xT2AiEAgKIOZ6wFYPnUb+ygDXIcQga5LpmcB6cZ5FTqChtFAgs=",
+      "signed_sha256": "4b349e39ab1f5a519f77f132e907723753c29f4c3bebf4758f17c5c2f07847d4",
+      "verified_at": "2026-08-10T11:39:02Z",
+      "verifier": ".github/workflows/promote-signed-provider-prebeta-journey.yml:31384352882:1"
+    }
+  ],
+  "signed": {
+    "schema_version": "macprovider.journey-result.v1",
+    "journey_id": "JOURNEY-PROVIDER-PREBETA-ADMISSION",
+    "requirement_ids": [
+      "SPEC-010-R006"
+    ],
+    "repository": {
+      "name": "Augustas11/macprovider",
+      "commit": "4f4ef46d62051889dc2cd1cb3bc5e44bec4f4e71"
+    },
+    "captured_at": "2026-08-10T11:15:38Z",
+    "expires_at": "2026-11-10",
+    "operator": {
+      "role": "provider-prebeta-operator",
+      "identity_fingerprint": "6814fc63f6a471df4e22611f2d6ebc037b67395268d127dded7fda292c88b973"
+    },
+    "environment": {
+      "class": "physical-provider-prebeta-admission",
+      "hardware_profile": "apple-silicon-32gb-air5-warmswap-redacted",
+      "candidate": "provider-cli:v1.8.92"
+    },
+    "artifacts": [
+      {
+        "id": "redacted-provider-prebeta-admission",
+        "sha256": "8f85fe47df94e4b70b85eb4141ddf4079919808f1835d94173629ae5c13340eb",
+        "source": "journeys/evidence/provider-prebeta-admission-air5-llama-warmswap-spec010-r006-20260810T111538Z.redacted.json"
+      }
+    ],
+    "result": {
+      "status": "pass",
+      "summary": "SPEC-010-R006 passed on Pearl production-equivalent provider-prebeta evidence: the CLI generated and validated a signed Llama catalog target, rejected a non-adoptable recommendation without mutation, applied a separately authorized warm-swap from Qwen to Llama through model_adoption_event.v1 phases, verified the complete target snapshot digest before completion, and reached buyer_serving only after restart with the signed Llama catalog key, row identity, digest, and snapshot-manifest algorithm."
+    },
+    "steps": [
+      {
+        "id": "step-01-private-prebeta-authorization",
+        "status": "pass",
+        "assertion": "The run used the existing private-prebeta operator path and a separately authorized SPEC-010-R006 warm-swap evidence run on the physical Air5 provider; it does not promote any public referral, payout, or operator-pushed enablement claim.",
+        "artifacts": [
+          "redacted-provider-prebeta-admission"
+        ]
+      },
+      {
+        "id": "step-02-install-launch-identity",
+        "status": "pass",
+        "assertion": "The provider was updated to provider-cli v1.8.92 before the R006 run; the installed source commit 4f4ef46d62051889dc2cd1cb3bc5e44bec4f4e71 is reachable from the evidence branch and the local service advertised model switch/adoption capabilities.",
+        "artifacts": [
+          "redacted-provider-prebeta-admission"
+        ]
+      },
+      {
+        "id": "step-03-provider-registration-admission",
+        "status": "pass",
+        "assertion": "After adoption and launch-config reconciliation, Pearl production health was ok, the local provider was coordinator-connected, and network_state=buyer_serving for the signed Llama catalog key rather than the prior Qwen row.",
+        "artifacts": [
+          "redacted-provider-prebeta-admission"
+        ]
+      },
+      {
+        "id": "step-04-catalog-autotune-readiness",
+        "status": "pass",
+        "assertion": "The signed Llama target was bound to catalog key meta-llama/llama-3.2-3b-instruct, model ID mlx-community/Llama-3.2-3B-Instruct-4bit, revision 7f0dc925e0d0afb0322d96f9255cfddf2ba5636e, catalog hash 56c4c20a8d0b3a1944ff0539829d0f517097c5189f22d7f1453c8e491dff1720, and snapshot digest e7e5bff4248768b4db7a53afb3b514ba5867b800f63d1abd0330eaf08e54aa90.",
+        "artifacts": [
+          "redacted-provider-prebeta-admission"
+        ]
+      },
+      {
+        "id": "step-05-hardware-evidence-verifier",
+        "status": "pass",
+        "assertion": "Post-swap local safety telemetry reported model_loaded=true, nominal runtime readiness through buyer_serving state, model_hash=e7e5bff4248768b4db7a53afb3b514ba5867b800f63d1abd0330eaf08e54aa90, model_hash_algorithm=macprovider.snapshot-manifest.v1, and weights_manifest_sha256=0baf13715db1eeb56e6d0806b0d764aa1c44497aaaaf8d2ba90c21128d9fe2fe.",
+        "artifacts": [
+          "redacted-provider-prebeta-admission"
+        ]
+      },
+      {
+        "id": "step-06-provider-runtime-routing",
+        "status": "pass",
+        "assertion": "model_adoption_event.v1 completed the warm-swap from qwen3-8b to the Llama target after preparing the artifact, applying config, loading, draining, and verifying config; no failed or cancelled terminal event was emitted for the accepted adoption transaction.",
+        "artifacts": [
+          "redacted-provider-prebeta-admission"
+        ]
+      },
+      {
+        "id": "step-07-buyer-serving-smoke",
+        "status": "pass",
+        "assertion": "The final post-restart status had coordinator.connected=true and network_state=buyer_serving with current_model_id=meta-llama/llama-3.2-3b-instruct, warm_swap_available=true, and the warm row weights_present_locally=true.",
+        "artifacts": [
+          "redacted-provider-prebeta-admission"
+        ]
+      },
+      {
+        "id": "step-08-redaction-and-correlation",
+        "status": "pass",
+        "assertion": "The artifact omits raw provider IDs, session IDs, request IDs, tokens, local account names, operator credentials, prompts, response bodies, and local backup paths while retaining stable hashes and catalog identifiers needed to correlate recommendation, adoption, runtime status, and Pearl health.",
+        "artifacts": [
+          "redacted-provider-prebeta-admission"
+        ]
+      }
+    ],
+    "redaction": {
+      "secrets_redacted": true,
+      "operator_identity_redacted": true,
+      "local_account_names_redacted": true
+    },
+    "run_id": "provider-prebeta-admission-air5-llama-warmswap-spec010-r006-20260810T111538Z",
+    "execution_mode": "physical-provider-prebeta-admission"
+  }
+}

--- a/specs/CONFORMANCE.json
+++ b/specs/CONFORMANCE.json
@@ -1403,7 +1403,7 @@
     {
       "requirement_id": "SPEC-010-R006",
       "spec_id": "SPEC-010",
-      "state": "pending",
+      "state": "conformant",
       "implementation": [
         "phase3-binary/Sources/macprovider-cli/ModelRuntime.swift:beginSwap",
         "phase3-binary/Sources/macprovider-cli/CoordinatorClient.swift:catalogRuntimeMatches"
@@ -1416,13 +1416,21 @@
       "journeys": [
         "JOURNEY-PROVIDER-PREBETA-ADMISSION"
       ],
-      "evidence": [],
-      "gap": {
-        "verdict": "UNKNOWN",
-        "owner": "@Augustas11",
-        "issue": "https://github.com/Augustas11/macprovider/issues/957",
-        "rationale": "Issue #609 fails closed when a warm-swap target lacks an exact signed row. The core provider-prebeta journey under #895 proved startup model readiness only. Issue #957 owns a separately approved production-equivalent warm-swap run proving atomic target row, digest, algorithm, and model publication; operator-pushed production enablement remains outside this slice unless explicitly authorized."
-      }
+      "evidence": [
+        {
+          "artifact": "commit:4f4ef46d62051889dc2cd1cb3bc5e44bec4f4e71",
+          "source": null,
+          "captured_at": "2026-08-10",
+          "expires_at": "2026-11-10"
+        },
+        {
+          "artifact": "sha256:dff0d65ef3bfa481b05d289b05af9215a442753ea1638f03996205db81cb4f55",
+          "source": "journeys/evidence/provider-prebeta-admission-air5-llama-warmswap-spec010-r006-20260810T111538Z.spec-010-r006.journey-result.signed.json",
+          "captured_at": "2026-08-10",
+          "expires_at": "2026-11-10"
+        }
+      ],
+      "gap": null
     },
     {
       "requirement_id": "SPEC-018-R001",

--- a/specs/README.md
+++ b/specs/README.md
@@ -18,7 +18,7 @@ it can no longer drift. Do not hand-edit the table; edit each spec's
 | SPEC-007 | Internal Operator Protocol Explorer | 0.5.1 | normative | pending | pending corpus migration | [SPEC-007-explorer.md](SPEC-007-explorer.md) |
 | SPEC-008 | Tier-2 Trust Layer | 0.5.1 | normative | pending | pending: 1 | [SPEC-008-tier2.md](SPEC-008-tier2.md) |
 | SPEC-009 | MacProvider Console v2 | 0.1 | normative | pending | pending corpus migration | [SPEC-009-console-v2.md](SPEC-009-console-v2.md) |
-| SPEC-010 | Provider Model Catalog | 1.6 | normative | pending | conformant: 5, pending: 1 | [SPEC-010-model-catalog.md](SPEC-010-model-catalog.md) |
+| SPEC-010 | Provider Model Catalog | 1.6 | normative | pending | conformant: 6 | [SPEC-010-model-catalog.md](SPEC-010-model-catalog.md) |
 | SPEC-011 | Operator-Pushed Warm Swap | 0.5 | normative | pending | pending corpus migration | [SPEC-011-operator-pushed-warm-swap.md](SPEC-011-operator-pushed-warm-swap.md) |
 | SPEC-012 | Coordinator Demand-Pull Model Swap and Buyer Cold-Model Visibility | 0.3 | draft | pending | pending corpus migration | [SPEC-012-coordinator-demand-pull.md](SPEC-012-coordinator-demand-pull.md) |
 | SPEC-013 | `macprovider-cli autotune` subcommand | 0.3.1 | normative | pending | pending corpus migration | [SPEC-013-cli-autotune.md](SPEC-013-cli-autotune.md) |


### PR DESCRIPTION
Promotes SPEC-010-R006 to conformant using the protected provider-prebeta signing workflow output from run 31384352882.

This lands the signed warm-swap journey-result envelope for the separately authorized R006 evidence run and updates the generated SPEC index summary so SPEC-010 now has all six requirements conformant.

Validation:
- python3 scripts/gen_spec_index.py
- python3 -m json.tool specs/CONFORMANCE.json
- python3 -m json.tool journeys/evidence/provider-prebeta-admission-air5-llama-warmswap-spec010-r006-20260810T111538Z.spec-010-r006.journey-result.signed.json
- python3 scripts/check_spec_governance.py --base-ref origin/main
- git diff --check
- sha256 matched downloaded workflow artifact for specs/CONFORMANCE.json and signed envelope

SPEC-GOVERNANCE-DECLARATION-BEGIN
{
  "schema_version": "spec-pr-governance-v1",
  "behavior_change": "yes",
  "contract_change": "yes",
  "specs": ["SPEC-010"],
  "requirements": ["SPEC-010-R006"],
  "authority_domains": ["model-catalog-identity"],
  "arbitration": ["UNKNOWN"],
  "tests": [
    "python3 scripts/gen_spec_index.py",
    "python3 -m json.tool specs/CONFORMANCE.json",
    "python3 -m json.tool journeys/evidence/provider-prebeta-admission-air5-llama-warmswap-spec010-r006-20260810T111538Z.spec-010-r006.journey-result.signed.json",
    "python3 scripts/check_spec_governance.py --base-ref origin/main",
    "git diff --check"
  ],
  "journeys": ["JOURNEY-PROVIDER-PREBETA-ADMISSION"],
  "issue": "https://github.com/Augustas11/macprovider/issues/957"
}
SPEC-GOVERNANCE-DECLARATION-END