### PR TITLE
fix(release): allow staged prepublication coordinator health

### DIFF
--- a/scripts/test-live-coordinator-release-gate.sh
+++ b/scripts/test-live-coordinator-release-gate.sh
@@ -243,6 +243,20 @@ fi
 grep -q 'recommended_binary_version=1.8.67 publication_phase=pre-publication' \
   "$work/previous-recommended.out"
 
+make_fixture "$work/previous-healthz-and-recommended" v1.8.68 v1.8.67 2026-07-30T12:00:00Z 2026-07-30T12:00:00Z streamvc-autotune-static-v4 1.8.67
+if ! run_guard_phase "$work/previous-healthz-and-recommended" pre-publication >"$work/previous-healthz-and-recommended.out" 2>&1; then
+  fail "pre-publication gate rejected a live coordinator still pinned to the previous stable version"
+fi
+grep -q 'healthz_version=v1.8.67 recommended_binary_version=1.8.67 publication_phase=pre-publication' \
+  "$work/previous-healthz-and-recommended.out"
+
+make_fixture "$work/too-old-prepublication-healthz" v1.8.68 v1.8.66 2026-07-30T12:00:00Z 2026-07-30T12:00:00Z streamvc-autotune-static-v4 1.8.67
+if run_guard_phase "$work/too-old-prepublication-healthz" pre-publication >"$work/too-old-prepublication-healthz.out" 2>&1; then
+  fail "pre-publication gate accepted a coordinator older than the previous stable version"
+fi
+grep -q "/healthz version 'v1.8.66' is older than release 1.8.68" \
+  "$work/too-old-prepublication-healthz.out"
+
 make_fixture "$work/malformed-recommended" v1.8.68 v1.8.68 2026-07-30T12:00:00Z 2026-07-30T12:00:00Z streamvc-autotune-static-v4 latest
 if run_guard "$work/malformed-recommended" >"$work/malformed-recommended.out" 2>&1; then
   fail "accepted a malformed recommended_binary_version"

--- a/scripts/verify-live-coordinator-release-gate.py
+++ b/scripts/verify-live-coordinator-release-gate.py
@@ -395,10 +395,20 @@ def main() -> int:
         live_version = parse_semver(healthz.get("version"), "/healthz version")
         required_version = parse_semver(expected_version, "release version")
         if live_version < required_version:
-            fail(
-                f"/healthz version {healthz.get('version')!r} is older than "
-                f"release {expected_version}"
-            )
+            previous_version = None
+            if (
+                args.publication_phase == "pre-publication"
+                and args.expected_previous_recommendation is not None
+            ):
+                previous_version = parse_advertised_version(
+                    args.expected_previous_recommendation,
+                    "expected previous recommendation",
+                )
+            if previous_version is None or live_version != previous_version:
+                fail(
+                    f"/healthz version {healthz.get('version')!r} is older than "
+                    f"release {expected_version}"
+                )
         recommended_value = healthz.get("recommended_binary_version")
         if (
             args.publication_phase == "pre-publication"


### PR DESCRIPTION
## Summary
- Allow the pre-publication live coordinator gate to accept the previous stable `/healthz version` when the staged release policy also requires the previous stable `recommended_binary_version`.
- Keep post-publication strict: live `/healthz` and `recommended_binary_version` must still match the released version once publication/rollout completes.
- Add regression coverage for the v1.8.93 failure mode and for rejecting a coordinator older than the previous stable.

## Why this was stale
The v1.8.93 release run failed after creating the signed draft because the new dynamic staged policy correctly derived `expected_previous_recommendation=1.8.92`, but the live gate still had an older invariant that always required `/healthz version >= release`. During staged pre-publication, the coordinator is intentionally still on the previous stable binary (`v1.8.92`) until the new release is public, so the gate contradicted its own pre-publication staged recommendation policy.

## Verification
- `bash scripts/test-live-coordinator-release-gate.sh`
- `bash scripts/test-release-security-posture.sh`
- `python3 scripts/verify-live-coordinator-release-gate.py --tag v1.8.93 --pearl-release-json /tmp/v193-draft-assets/pearl-release.json --trusted-keys /tmp/v193-draft-assets/trusted-keys.json --coordinator-url https://coordinator.streamvc.live --expected-previous-recommendation 1.8.92 --publication-phase pre-publication`
- `make test`

SPEC-GOVERNANCE-DECLARATION-BEGIN
{
  "schema_version": "spec-pr-governance-v1",
  "behavior_change": "yes",
  "contract_change": "none",
  "specs": ["SPEC-020"],
  "requirements": ["SPEC-020-R002"],
  "authority_domains": ["provider-autoupdate"],
  "arbitration": ["CODE_BUG"],
  "tests": [
    "scripts/test-live-coordinator-release-gate.sh",
    "scripts/test-release-security-posture.sh",
    "make test"
  ],
  "journeys": ["not-required"]
}
SPEC-GOVERNANCE-DECLARATION-END
