### PR TITLE
fix(release): tolerate legacy Malibu publication sequence

### DIFF
--- a/scripts/install-malibu-publication.sh
+++ b/scripts/install-malibu-publication.sh
@@ -182,6 +182,18 @@ import sys
 
 candidate = json.loads(pathlib.Path(sys.argv[1]).read_text(encoding="utf-8"))
 current = json.loads(pathlib.Path(sys.argv[2]).read_text(encoding="utf-8"))
+def tag_version(row, label):
+    tag = row.get("tag")
+    if not isinstance(tag, str) or not tag.startswith("v"):
+        raise SystemExit(f"{label} publication tag is invalid")
+    try:
+        version = tuple(int(part) for part in tag[1:].split("."))
+    except ValueError:
+        raise SystemExit(f"{label} publication tag is invalid")
+    if len(version) != 3:
+        raise SystemExit(f"{label} publication tag is invalid")
+    return version
+
 if candidate.get("publication_id") == current.get("publication_id"):
     raise SystemExit(0)
 candidate_sequence = candidate.get("release_sequence")
@@ -191,6 +203,10 @@ if candidate_sequence is None and candidate.get("tag") == current.get("tag") == 
 if type(candidate_sequence) is not int or candidate_sequence <= 0:
     raise SystemExit("candidate publication sequence is invalid")
 if current_sequence is None and current.get("tag") == "v1.8.39":
+    current_sequence = 0
+elif current_sequence is None:
+    if tag_version(candidate, "candidate") <= tag_version(current, "current"):
+        raise SystemExit("publication sequence did not advance")
     current_sequence = 0
 if type(current_sequence) is not int or current_sequence < 0:
     raise SystemExit("current publication sequence is invalid")

--- a/scripts/test-malibu-bootstrap-bridge.sh
+++ b/scripts/test-malibu-bootstrap-bridge.sh
@@ -379,6 +379,59 @@ MALIBU_PUBLICATION_TESTING=1 bash "$installer" \
 cmp -s "$frozen_bridge_appcast" "$work/provider-current-webroot/appcast.xml" ||
   fail "current provider appcast is not the frozen bridge appcast"
 
+python3 - "$work/provider-current-webroot/.malibu-current/publication-manifest.json" \
+  "$work/provider-current-webroot/.malibu-tag-manifests/v1.8.88.json" <<'PY'
+import json
+import pathlib
+import sys
+
+for raw_path in sys.argv[1:]:
+    path = pathlib.Path(raw_path)
+    manifest = json.loads(path.read_text())
+    manifest.pop("release_sequence", None)
+    path.write_text(json.dumps(manifest, sort_keys=True) + "\n")
+PY
+printf 'newer provider dmg bytes\n' > "$work/provider-current/Malibu-v1.8.89.dmg"
+newer_provider_dmg_sha="$(shasum -a 256 "$work/provider-current/Malibu-v1.8.89.dmg" | awk '{print $1}')"
+printf '%s  Malibu-v1.8.89.dmg\n' "$newer_provider_dmg_sha" > "$work/provider-current/Malibu-v1.8.89.dmg.sha256"
+newer_provider_publication_id="$(python3 - "$work/provider-current/publication-manifest-newer.json" \
+  "$work/provider-current/Malibu-v1.8.89.dmg" <<'PY'
+import hashlib
+import json
+import pathlib
+import sys
+
+manifest_path, dmg_path = map(pathlib.Path, sys.argv[1:])
+tag = "v1.8.89"
+dmg_sha = hashlib.sha256(dmg_path.read_bytes()).hexdigest()
+identity = hashlib.sha256(json.dumps({
+    "compatibility_artifact_index_sha256": "0" * 64,
+    "dmg_sha256": dmg_sha,
+    "release_sequence": 189,
+}, sort_keys=True, separators=(",", ":")).encode()).hexdigest()
+manifest_path.write_text(json.dumps({
+    "schema_version": 1,
+    "repository": "Augustas11/macprovider",
+    "tag": tag,
+    "commit": "e" * 40,
+    "prerelease": False,
+    "release_id": 502,
+    "release_sequence": 189,
+    "publication_id": identity,
+    "assets": {
+        dmg_path.name: {"id": 602, "sha256": dmg_sha},
+    },
+}, sort_keys=True) + "\n")
+print(identity)
+PY
+)"
+MALIBU_PUBLICATION_TESTING=1 bash "$installer" \
+  "$work/provider-current-webroot" v1.8.89 "$newer_provider_publication_id" \
+  "$work/provider-current/publication-manifest-newer.json" "$work/provider-current/Malibu-v1.8.89.dmg" \
+  "$work/provider-current/appcast.xml" "$work/provider-current/Malibu-v1.8.89.dmg.sha256"
+[[ "$(cat "$work/provider-current-webroot/latest.dmg")" == 'newer provider dmg bytes' ]] ||
+  fail "legacy current sequence fallback did not publish the newer provider DMG"
+
 printf 'older provider dmg bytes\n' > "$work/provider-current/Malibu-v1.8.87.dmg"
 older_provider_dmg_sha="$(shasum -a 256 "$work/provider-current/Malibu-v1.8.87.dmg" | awk '{print $1}')"
 printf '%s  Malibu-v1.8.87.dmg\n' "$older_provider_dmg_sha" > "$work/provider-current/Malibu-v1.8.87.dmg.sha256"


### PR DESCRIPTION
## Summary
- Make the Malibu publication installer tolerate a legacy current manifest that is missing `release_sequence` when the candidate's semantic tag advances.
- Keep rollback protection: same/older semantic tags without a valid current sequence still fail with `publication sequence did not advance`.
- Add a regression for the v1.8.93 production failure where the current v1.8.88 manual recovery manifest lacked `release_sequence`.

## Root cause
The v1.8.93 release made the GitHub release public, then failed while publishing the Malibu download alias because Pearl's current v1.8.88 manual recovery manifest did not include `release_sequence`. The helper only special-cased the old v1.8.39 bridge and treated any later sequence-less current manifest as invalid, so a stale/manual recovery record could block the next valid Malibu publication.

## Verification
- `bash scripts/test-malibu-bootstrap-bridge.sh`
- `bash scripts/test-malibu-independent-release.sh`
- `bash scripts/test-release-security-posture.sh`
- `git diff --check`

SPEC-GOVERNANCE-DECLARATION-BEGIN
{
  "schema_version": "spec-pr-governance-v1",
  "behavior_change": "yes",
  "contract_change": "none",
  "specs": ["SPEC-020"],
  "requirements": ["SPEC-020-R002"],
  "authority_domains": ["provider-autoupdate"],
  "arbitration": ["CODE_BUG"],
  "tests": [
    "scripts/test-malibu-bootstrap-bridge.sh",
    "scripts/test-malibu-independent-release.sh",
    "scripts/test-release-security-posture.sh"
  ],
  "journeys": ["not-required"]
}
SPEC-GOVERNANCE-DECLARATION-END
