### PR TITLE
fix(openrouter): retain served rate-card rows absent from demand cohort instead of dropping

### DIFF
--- a/docs/runbooks/openrouter-pricing-engine.md
+++ b/docs/runbooks/openrouter-pricing-engine.md
@@ -221,24 +221,39 @@ under the **NVIDIA Nemotron Open Model License** identified by the
 The card describes the model as ready for commercial use subject to those
 governing terms. This is a policy evidence record, not a replacement for legal
 review. If the policy's verification is removed or changed to non-permitted,
-the engine deterministically blocks/drops the model and records the reason.
+the engine deterministically blocks the model (never drops it) and records the
+reason.
 
 ## Proposal contract
 
-The proposal schema is version `1` and contains:
+The proposal schema is version `2` and contains:
 
 - source snapshot digest, policy version, and rate-card reference digest;
 - summary counts;
-- `added`, `changed`, `dropped`, `blocked`, and `unchanged` arrays;
+- `added`, `changed`, `dropped`, `retained`, `blocked`, and `unchanged` arrays;
 - per-row demand/market inputs (or explicit `null` values when market data is
   unavailable), eligibility reasons, policy-evidence availability and URLs,
   and a computed completion-rate proposal where eligible.
 
-`dropped` is strictly an advisory request for Component 3 review. It does not
-remove a rate-card row. Every dropped row includes its current completion rate.
+`retained` (new in schema v2) means "keep this currently-served rate-card row
+unchanged": there is no demand signal to reprice it (it is absent from the
+cohort, or observed but ineligible only on demand-rank/fleet-profile grounds)
+and no fatal serving/license failure. It carries the current completion rate and
+no proposed replacement. Component 3 takes no action on a `retained` row.
+
+`dropped` is reserved for an explicit positive delisting determination that this
+engine does not derive from demand data; it is empty in practice. A served model
+is never placed in `dropped` merely for being absent from the OpenRouter demand
+cohort (that was the schema-v1 defect this contract fixes).
+
 `blocked` records missing policy evidence, an unresolved license, failed
-eligibility, free-only market pricing, missing economics, or an existing
-rate-card row with no verified policy mapping.
+eligibility, free-only market pricing, missing economics, an existing rate-card
+row with no verified policy mapping, or an absent served row whose serving path
+or commercial license is no longer verified (a fatal failure that must be
+surfaced for review rather than retained).
+
+Schema v1 proposals (five buckets, no `retained`) are not forward-compatible
+with a v2 consumer; regenerate any archived v1 proposal evidence under v2.
 
 ## Offline verification
 

--- a/scripts/openrouter_pricing_engine.py
+++ b/scripts/openrouter_pricing_engine.py
@@ -35,7 +35,7 @@ RANKINGS_URL = "https://openrouter.ai/api/v1/datasets/rankings-daily"
 MODELS_URL = "https://openrouter.ai/api/v1/models"
 ENDPOINTS_URL = "https://openrouter.ai/api/v1/models/{model_id}/endpoints"
 SNAPSHOT_SCHEMA_VERSION = 5
-PROPOSAL_SCHEMA_VERSION = 1
+PROPOSAL_SCHEMA_VERSION = 2
 TOOL_VERSION = "openrouter-pricing-engine-v1"
 DEFAULT_POLICY_PATH = Path(__file__).with_name("openrouter_pricing_policy.json")
 MODEL_ID_RE = re.compile(r"^[A-Za-z0-9._~:-]+/[A-Za-z0-9._~:-]+$")
@@ -1008,6 +1008,24 @@ def provider_hourly_usd(internal_rate_per_mtok: int, tps: Decimal, rate_card: Ma
     return buyer_usd_per_mtok * provider_share_bps / Decimal("10000") * tps * Decimal("3600") / Decimal("1000000")
 
 
+def static_policy_block_reasons(model: Mapping[str, Any]) -> list[str]:
+    """Serving/license failures that block a row regardless of demand observation.
+
+    These are the same fatal, market-independent conditions eligibility() checks,
+    extracted so the cohort-absence branch can also honour them: a served model
+    whose serving path or commercial license is no longer verified must be
+    surfaced for human intervention (blocked), never silently retained.
+    """
+    reasons: list[str] = []
+    serving = model.get("serving_path")
+    if not isinstance(serving, dict) or serving.get("verification_status") != "verified":
+        reasons.append("MLX/GGUF serving path is not verified")
+    license_info = model.get("license")
+    if not isinstance(license_info, dict) or license_info.get("commercial_permitted") is not True:
+        reasons.append("commercial license is not verified as permitted")
+    return reasons
+
+
 def eligibility(model: Mapping[str, Any], row: Mapping[str, Any], policy: Mapping[str, Any]) -> tuple[bool, list[str], Decimal | None]:
     reasons: list[str] = []
     rank = row["demand"]["rank"]
@@ -1107,7 +1125,7 @@ def build_proposal(
     rate_rows = rate_card["rows"]
     policy_models = policy_model_index(policy)
     rows_by_source = {row["source_model_id"]: row for row in snapshot["rows"]}
-    result: dict[str, list[dict[str, Any]]] = {key: [] for key in ("added", "changed", "dropped", "blocked", "unchanged")}
+    result: dict[str, list[dict[str, Any]]] = {key: [] for key in ("added", "changed", "dropped", "retained", "blocked", "unchanged")}
     assessed_current_ids: set[str] = set()
 
     def market_unavailable() -> dict[str, None]:
@@ -1161,22 +1179,49 @@ def build_proposal(
             assessed_current_ids.add(canonical_id)
         row = rows_by_source.get(source_model_id)
         if row is None:
-            if canonical_id in rate_rows and canonical_id != "default":
-                result["dropped"].append(
+            # Absence from the daily top-50 demand cohort is NOT evidence that a
+            # served model should be delisted. OpenRouter's demand chart is
+            # dominated by frontier and oversized models the fleet cannot serve,
+            # so the fleet's small-open catalog is routinely absent from it. A
+            # currently-served rate-card row is therefore RETAINED unchanged, never
+            # dropped, on cohort absence: there is simply no demand signal to
+            # reprice it. Dropping a served row requires an explicit, positive
+            # delisting determination this engine does not derive from demand data.
+            absent_reason = "absent from the documented daily top-50 demand cohort; no demand signal to reprice, and absence is not evidence to delist a served model"
+            # A fatal serving/license failure blocks even an absent served row:
+            # "retained" means keep-unchanged, which must not silently preserve a
+            # served model whose serving path or license is no longer verified.
+            static_blockers = static_policy_block_reasons(model)
+            if canonical_id in rate_rows and canonical_id != "default" and not static_blockers:
+                result["retained"].append(
                     {
                         "model_id": canonical_id,
                         "source_model_id": source_model_id,
-                        "action": "dropped",
+                        "action": "retained",
                         "current_completion_rate": current_completion_rate(rate_rows, canonical_id),
-                        "eligibility": {"eligible": False, "reasons": ["model is absent from complete documented daily top-50 demand snapshot"]},
+                        "eligibility": {"eligible": False, "reasons": [absent_reason]},
                         "market": market_unavailable(),
                         "policy_evidence": policy_evidence(model),
-                        "reasons": ["model is absent from complete documented daily top-50 demand snapshot"],
+                        "reasons": [absent_reason],
+                    }
+                )
+            elif canonical_id in rate_rows and canonical_id != "default":
+                blocked_reasons = static_blockers + [absent_reason]
+                result["blocked"].append(
+                    {
+                        "model_id": canonical_id,
+                        "source_model_id": source_model_id,
+                        "action": "blocked",
+                        "current_completion_rate": current_completion_rate(rate_rows, canonical_id),
+                        "eligibility": {"eligible": False, "reasons": blocked_reasons},
+                        "market": market_unavailable(),
+                        "policy_evidence": policy_evidence(model),
+                        "reasons": blocked_reasons,
                     }
                 )
             else:
                 result["blocked"].append(
-                    {"model_id": canonical_id, "source_model_id": source_model_id, "action": "blocked", "market": market_unavailable(), "eligibility": {"eligible": False, "reasons": ["model is absent from complete documented daily top-50 demand snapshot"]}, "policy_evidence": policy_evidence(model), "reasons": ["model is absent from complete documented daily top-50 demand snapshot"]}
+                    {"model_id": canonical_id, "source_model_id": source_model_id, "action": "blocked", "market": market_unavailable(), "eligibility": {"eligible": False, "reasons": [absent_reason]}, "policy_evidence": policy_evidence(model), "reasons": [absent_reason]}
                 )
             continue
         allowed, reasons, market_completion = eligibility(model, row, policy)
@@ -1195,7 +1240,11 @@ def build_proposal(
                 "OpenRouter reports no provider endpoints after bounded confirmation",
                 "cheapest active completion endpoint is free; no paid-market undercut can be computed",
             }
-            action = "blocked" if any(reason in block_reasons for reason in reasons) else "dropped" if canonical_id in rate_rows else "blocked"
+            # A served row observed in the cohort but ineligible only on
+            # demand-rank or fleet-profile grounds (not a market/serving/license
+            # block) is RETAINED, never dropped: those are not positive delisting
+            # evidence for a model the fleet already serves.
+            action = "blocked" if any(reason in block_reasons for reason in reasons) else "retained" if (canonical_id in rate_rows and canonical_id != "default") else "blocked"
             base.update({"action": action, "reasons": reasons})
             if canonical_id in rate_rows:
                 base["current_completion_rate"] = current_completion_rate(rate_rows, canonical_id)

--- a/scripts/tests/test_openrouter_pricing_engine.py
+++ b/scripts/tests/test_openrouter_pricing_engine.py
@@ -420,7 +420,7 @@ class OpenRouterPricingEngineTests(unittest.TestCase):
         with self.assertRaises(engine.SchemaError):
             engine.validate_snapshot(duplicate_source_snapshot)
 
-    def test_proposal_contains_added_changed_dropped_unchanged_and_blocked(self):
+    def test_proposal_contains_added_changed_retained_unchanged_and_blocked(self):
         proposal_policy = policy()
         proposal_policy["models"][2]["license"]["commercial_permitted"] = False
         snapshot = self.snapshot(proposal_policy)
@@ -428,11 +428,72 @@ class OpenRouterPricingEngineTests(unittest.TestCase):
         self.assertEqual([row["model_id"] for row in proposal["changed"]], ["openai/gpt-oss-20b"])
         self.assertEqual([row["model_id"] for row in proposal["unchanged"]], ["google-gemma-4-26b-a4b-it"])
         self.assertEqual([row["model_id"] for row in proposal["added"]], ["example/new-model"])
-        self.assertEqual({row["model_id"] for row in proposal["dropped"]}, {"qwen2.5-coder-32b-instruct"})
+        # A served row absent from the demand cohort is RETAINED, never dropped:
+        # cohort absence is not evidence to delist a model the fleet serves.
+        self.assertEqual(proposal["dropped"], [])
+        self.assertEqual({row["model_id"] for row in proposal["retained"]}, {"qwen2.5-coder-32b-instruct"})
+        retained = proposal["retained"][0]
+        self.assertEqual(retained["action"], "retained")
+        self.assertIsNone(retained["market"]["completion_per_mtok"])
+        self.assertEqual(retained["current_completion_rate"]["rate_card_completion_rate_per_mtok"], 850000)
         self.assertEqual(len(proposal["blocked"]), 47)
         nemotron = next(row for row in proposal["blocked"] if row["model_id"] == "nemotron-3-nano-30b-a3b")
         self.assertTrue(nemotron["policy_evidence"]["available"])
         self.assertEqual(proposal["changed"][0]["proposed_completion_rate"]["rate_card_completion_rate_per_mtok"], 104000)
+
+    def test_served_row_is_never_dropped_by_the_proposal(self):
+        # Regression lock for the false-drop fix: across the fixed fixture, no
+        # currently-served rate-card row may ever appear under "dropped". Drops
+        # require positive delisting evidence the engine does not derive from the
+        # OpenRouter demand cohort.
+        card = reference_rate_card()
+        served = set(card["rows"]) - {"default"}
+        proposal = engine.build_proposal(self.snapshot(), policy(), card, now=NOW)
+        self.assertEqual(proposal["dropped"], [])
+        dropped_ids = {row.get("model_id") for row in proposal["dropped"]}
+        self.assertEqual(dropped_ids & served, set())
+
+    def test_absent_served_row_routing_matrix(self):
+        # A served row absent from the cohort is retained ONLY while its policy
+        # serving/license evidence is still valid. A fatal serving/license failure
+        # routes it to blocked (surfaced for a human), never silently retained --
+        # and never dropped.
+        QWEN = "qwen2.5-coder-32b-instruct"  # the absent-from-cohort served row
+
+        def proposal_for(mutate):
+            pol = policy()
+            mutate(pol["models"][4])
+            return engine.build_proposal(self.snapshot(pol), pol, reference_rate_card(), now=NOW)
+
+        def ids(prop, bucket):
+            return {r["model_id"] for r in prop[bucket]}
+
+        valid = proposal_for(lambda m: None)
+        self.assertIn(QWEN, ids(valid, "retained"))
+        self.assertNotIn(QWEN, ids(valid, "blocked"))
+        self.assertEqual(valid["dropped"], [])
+
+        revoked_license = proposal_for(lambda m: m["license"].__setitem__("commercial_permitted", False))
+        self.assertIn(QWEN, ids(revoked_license, "blocked"))
+        self.assertNotIn(QWEN, ids(revoked_license, "retained"))
+        self.assertEqual(revoked_license["dropped"], [])
+
+        unverified_serving = proposal_for(lambda m: m["serving_path"].__setitem__("verification_status", "unverified"))
+        self.assertIn(QWEN, ids(unverified_serving, "blocked"))
+        self.assertNotIn(QWEN, ids(unverified_serving, "retained"))
+        self.assertEqual(unverified_serving["dropped"], [])
+
+    def test_proposal_schema_is_v2_with_retained_bucket(self):
+        proposal = engine.build_proposal(self.snapshot(), policy(), reference_rate_card(), now=NOW)
+        self.assertEqual(engine.PROPOSAL_SCHEMA_VERSION, 2)
+        self.assertEqual(proposal["schema_version"], 2)
+        for bucket in ("added", "changed", "dropped", "retained", "blocked", "unchanged"):
+            self.assertIn(bucket, proposal)
+            self.assertIn(bucket, proposal["summary"])
+        self.assertEqual(
+            proposal["summary"]["eligible"],
+            len(proposal["added"]) + len(proposal["changed"]) + len(proposal["unchanged"]),
+        )
 
     def test_fixed_snapshot_policy_and_rate_card_emit_the_expected_complete_proposal(self):
         first = engine.build_proposal(self.snapshot(), policy(), reference_rate_card(), now=NOW)
@@ -440,7 +501,7 @@ class OpenRouterPricingEngineTests(unittest.TestCase):
         self.assertEqual(first, second)
         self.assertEqual(
             engine.sha256_prefixed(first),
-            "sha256:e271bc7da8e7697d574882ff0174cdb1407eb00ac7730ea5aced1b5a3cfc1c9d",
+            "sha256:2434950d405790c92b75ed20ad15eb9abf8eae57ada61e4554c0552a18a8d9da",
         )
 
     def test_unresolved_nemotron_license_is_blocked_when_not_a_current_row(self):


### PR DESCRIPTION
## What

Fix a false-delisting defect in the OpenRouter pricing **proposal engine** (`scripts/openrouter_pricing_engine.py`), a non-money-path operator tool that emits a review-only pricing proposal for a human-gated Component 3 to apply. The engine never writes the live rate-card.

### The bug
A currently-served rate-card row that was **absent from the OpenRouter daily top-50 demand cohort** (or observed but ineligible only on demand-rank / fleet-profile grounds) was emitted with `action: "dropped"` — i.e. the proposal recommended **delisting a model the fleet actively serves**, with null market data, purely because it was not trending on OpenRouter that day. The live run flagged served production models `openai/gpt-oss-20b` and `qwen2.5-coder-32b-instruct` for dropping. OpenRouter's demand chart is dominated by frontier/closed and giant-open models the fleet can't serve, so the fleet's small-open catalog is *routinely* absent — absence is not a delist signal.

### The fix
- New `retained` bucket: a currently-served row with no demand signal to reprice (cohort-absent, or ineligible only on demand-rank/fleet-profile grounds) is **retained unchanged**, never dropped.
- `dropped` now requires an explicit positive delisting determination the engine does not derive from demand data → it is empty in practice. A served model can no longer be auto-dropped by any path.
- **Fatal serving/license failures still block**: an absent served row whose serving path or commercial license is no longer verified routes to `blocked` (surfaced for human intervention), not silently retained (`static_policy_block_reasons`).
- Proposal schema bumped **v1 → v2** (new `retained` bucket + summary key); runbook updated to document the v2 contract.

## Tests
- `test_served_row_is_never_dropped_by_the_proposal` — regression lock: no served row ever appears under `dropped`.
- `test_absent_served_row_routing_matrix` — table-driven: absent served × {valid → retained, license-revoked → blocked, serving-unverified → blocked}, all asserting `dropped == []`.
- `test_proposal_schema_is_v2_with_retained_bucket` — schema version + all six bucket/summary keys.
- Golden-hash and existing suite updated. **42/42 pass.** Proven on the real committed snapshot: `dropped 3 → 0`.

## Audit
Independent 3-lane codex audit (code / security / architect) over the full diff, iterated to convergence. This PR's engine change was judged **0 CRITICAL / 0 HIGH / 0 MEDIUM by all three lanes** (rounds 2 and 3); money-path invariant (no served row can reach `dropped`; eligible-row pricing math unchanged) confirmed.

## Notes
- Non-money-path: the engine emits a proposal artifact; Component 3 owns the guarded rate-card apply. No rate-card write in this diff.
- The `spec-index / check` job is advisory (non-required). This is non-governance tooling (`scripts/`, `docs/runbooks/`) with no governing authority domain, so there is no honest spec declaration to cite; merge gate is `ci-required` + 1 approval.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
