### PR TITLE
feat(openrouter): payout x MLX-servability candidate resolver (review-only)

### DIFF
--- a/scripts/openrouter_mlx_candidates.py
+++ b/scripts/openrouter_mlx_candidates.py
@@ -1,0 +1,473 @@
+#!/usr/bin/env python3
+"""Rank OpenRouter demand rows by (payout x MLX-servability), review-only.
+
+Non-money-path operator tool. It reads a committed OpenRouter pricing snapshot,
+takes the demand rows NOT already in the pricing policy, and for each asks
+HuggingFace whether a fleet-fitting MLX text-generation build exists. It emits a
+review-only candidate list so additions are driven by real market payout and
+MLX-servability, not a hand-curated allowlist.
+
+It has NO apply mode. It never writes the pricing policy or the rate card, and
+it refuses --output targets that would overwrite an input or a money-path file.
+A candidate here is a proposal for human verification; the money-path apply stays
+with Component 3.
+
+Fail-closed like the pricing fetcher: any network error, schema drift, missing
+size, loose identity match, or unconfirmable serving path yields "unresolved" (a
+human check) or "not_servable" (positively disqualified) -- never a false
+"servable". Heuristic evidence (name match, architecture suffix, weight bytes)
+never yields a clean "servable" on its own: a null-pipeline causal-LM build is
+downgraded to "review", and residency is gated with a conservative runtime
+headroom rather than raw weight bytes.
+
+Verdicts (the strongest positive outcome is a review CANDIDATE -- HF metadata
+cannot certify servability, only loading on hardware can, so the tool nominates
+and a human confirms the serving path before Component 3 prices it):
+  review        canonical MLX build fits the band and is plausibly a text model;
+                a human must confirm the serving path before pricing.
+  not_servable  no MLX build / oversized / closed-weight / wrong modality (ASR).
+  unresolved    a build exists and fits, but text-servability or identity could
+                not be positively confirmed (ambiguous match, adapter/LoRA-only,
+                multimodal architecture, unrecognised quant, or a fetch failure).
+  skipped       no paid OpenRouter payout, so no undercut market to price against.
+
+The network layer is an injectable ``client`` callable (url -> parsed JSON) so
+the core is deterministic and unit-testable offline.
+"""
+
+from __future__ import annotations
+
+import argparse
+import http.client
+import json
+import math
+import re
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+from decimal import Decimal, InvalidOperation
+from pathlib import Path
+from typing import Callable
+
+HF_API = "https://huggingface.co/api/models"
+MLX_NAMESPACE = "mlx-community"
+Client = Callable[[str], object]
+
+# Vendors whose flagship rows are closed-weight API models with no possible
+# local build. Every other vendor is probed and fails closed if no build exists,
+# so open-weight lines from mixed vendors (openai/gpt-oss, google/gemma) are not
+# pre-excluded here -- only the fully-closed houses are.
+CLOSED_WEIGHT_VENDORS = frozenset({"anthropic", "x-ai"})
+# MLX-loadable text quant tags, in fleet preference order.
+MLX_QUANT_TAGS = ("4bit", "mxfp4", "5bit", "6bit", "8bit")
+# Repo-name tokens that mark a repo as NOT the canonical base model -- reject it
+# entirely rather than price a re-headed or partial derivative.
+DISQUALIFYING_TOKENS = frozenset({"lora", "adapter", "merge", "draft", "abliterated", "uncensored", "heretic"})
+# ALLOWLIST: repo-name tokens (after the model stem) that are recognised as pure
+# packaging/quantization/canonical-variant metadata. A clean "servable" verdict
+# requires EVERY residual token to be recognised here (or a numeric/size/version
+# token). Any unrecognised token means the build is an unknown derivative, not
+# provably the canonical model, so it is downgraded to review. This is a positive
+# allowlist by design: a denylist cannot prove an unknown suffix is canonical.
+PACKAGING_TOKENS = frozenset({
+    "4bit", "5bit", "6bit", "8bit", "3bit", "2bit", "mxfp4", "nvfp4", "mixed",
+    "bf16", "fp16", "fp32", "f16", "f32", "q4", "q5", "q6", "q8", "dwq", "gs",
+    "it", "instruct", "chat", "mlx", "hf", "text",
+})
+TEXT_PIPELINE_TAGS = frozenset({"text-generation"})
+# Multimodal tags that DO emit text but are not a pure text serving path.
+VISION_TEXT_PIPELINE_TAGS = frozenset({"image-text-to-text", "any-to-any"})
+# Architecture / model-type substrings that mark a multimodal (non-text-only)
+# model even when the class name ends in ForCausalLM (e.g. LlavaLlamaForCausalLM,
+# FuyuForCausalLM). A match here refuses the causal-LM text fallback.
+MULTIMODAL_ARCH_MARKERS = frozenset({"llava", "fuyu", "vision", "clip", "whisper", "audio", "speech", "mllama", "idefics", "pixtral", "molmo", "aria"})
+# Compound architecture suffixes that mark a multimodal model even when the class
+# name ends in ForCausalLM and carries no name marker (e.g. Qwen2VLForCausalLM,
+# ...OmniForCausalLM, ...AudioForCausalLM).
+MULTIMODAL_ARCH_PATTERNS = ("vlfor", "omnifor", "audiofor", "visionfor", "speechfor", "imagefor")
+CAUSAL_LM_ARCH_SUFFIX = "forcausallm"
+# Conservative multiplier over safetensors weight bytes to cover loader,
+# activation, and KV-cache residency (weight bytes are file size, not runtime RAM).
+RESIDENCY_OVERHEAD = Decimal("1.3")
+
+
+class ResolveError(Exception):
+    """Fail-closed condition while resolving a single candidate row."""
+
+
+def real_client(timeout: float) -> Client:
+    def fetch(url: str) -> object:
+        request = urllib.request.Request(url, headers={"Accept": "application/json", "User-Agent": "macprovider-mlx-candidates"})
+        try:
+            with urllib.request.urlopen(request, timeout=timeout) as response:
+                if response.status != 200:
+                    raise ResolveError(f"HuggingFace returned HTTP {response.status}")
+                payload = response.read()
+        except (urllib.error.URLError, http.client.HTTPException, TimeoutError, OSError) as error:
+            raise ResolveError(f"HuggingFace request failed: {error}") from error
+        try:
+            return json.loads(payload)
+        except json.JSONDecodeError as error:
+            raise ResolveError(f"HuggingFace response was not valid JSON: {error}") from error
+    return fetch
+
+
+def model_stem(source_model_id: str) -> str:
+    """The model portion of an OpenRouter slug, minus any :free/:batch variant."""
+    tail = source_model_id.split("/", 1)[-1]
+    return tail.split(":", 1)[0]
+
+
+def repo_owner(repo_id: str) -> str:
+    return repo_id.split("/", 1)[0] if "/" in repo_id else ""
+
+
+def repo_name(repo_id: str) -> str:
+    return repo_id.split("/", 1)[-1]
+
+
+def anchored_match(name: str, stem: str) -> bool:
+    """True only if name begins with the complete stem at a token boundary.
+
+    'gemma-4-31b-it' matches 'gemma-4-31b-it-4bit' but not 'other-gemma-4-31b-it-4bit'
+    (prefixed different model) nor 'gemma-4-31b-it2' (different suffix). An anchored
+    prefix match is required so a repository whose name merely CONTAINS the stem
+    cannot be mistaken for the model; ambiguous/prefixed names fail closed.
+    """
+    lowered_name = name.lower()
+    lowered_stem = stem.lower()
+    if not lowered_name.startswith(lowered_stem):
+        return False
+    after = lowered_name[len(lowered_stem)] if len(lowered_name) > len(lowered_stem) else ""
+    # The stem must be followed by a repo separator or end of name. A version
+    # continuation like '.' (glm-5 vs glm-5.2) or an alphanumeric (glm-5 vs
+    # glm-50b) is a DIFFERENT model and must not alias.
+    return after in ("", "-", "_")
+
+
+def quant_of(repo_id: str) -> str | None:
+    # Match a quant tag only as a whole hyphen/underscore-delimited token, so
+    # 'foo-14bit' or 'foo-4bitten' are NOT read as a '4bit' build.
+    tokens = set(re.split(r"[^0-9a-z]+", repo_id.lower()))
+    for tag in MLX_QUANT_TAGS:
+        if tag in tokens:
+            return tag
+    return None
+
+
+def is_protected_component(target: Path) -> bool:
+    """True if any path component names a rate-card file/dir, case/underscore-insensitively."""
+    return any("rate-card" in component.casefold().replace("_", "-") for component in target.parts)
+
+
+def validated_residency(raw: str) -> Decimal:
+    """Parse --max-residency-gb, rejecting non-finite or non-positive ceilings.
+
+    Infinity would pass every model; NaN would raise mid-comparison. Both must be
+    rejected before any classification runs.
+    """
+    try:
+        value = Decimal(str(raw))
+    except InvalidOperation as error:
+        raise SystemExit(f"--max-residency-gb must be a number: {raw!r}") from error
+    if not value.is_finite() or value <= 0:
+        raise SystemExit(f"--max-residency-gb must be a finite positive number: {raw!r}")
+    return value
+
+
+def search_builds(stem: str, client: Client) -> list[dict]:
+    query = urllib.parse.urlencode({"author": MLX_NAMESPACE, "search": stem, "limit": "30"})
+    result = client(f"{HF_API}?{query}")
+    if not isinstance(result, list):
+        raise ResolveError("HuggingFace search response was not a list")
+    return [item for item in result if isinstance(item, dict)]
+
+
+def _is_packaging_token(token: str) -> bool:
+    """True for recognised packaging/quant/size/version tokens (allowlist)."""
+    if token in PACKAGING_TOKENS:
+        return True
+    if token.isdigit():  # date/version like 2407, or a bare number
+        return True
+    if re.fullmatch(r"v?\d+(\.\d+)*", token):  # v0.1, 3.1, v2
+        return True
+    if re.fullmatch(r"\d+(\.\d+)?[bmk]", token):  # 7b, 30b, 3.6b, 500m sizes
+        return True
+    return False
+
+
+def unrecognised_suffix_tokens(name: str, stem: str) -> list[str]:
+    """Residual repo-name tokens after the stem that are NOT recognised packaging.
+
+    Empty means the suffix is pure packaging/quant/version metadata and the build
+    is provably the canonical model. Any element means an unknown derivative
+    ('...-math-...', '...-coder-...', '...-base-...') -- never a clean servable.
+    """
+    residual = (token for token in re.split(r"[^0-9a-z]+", name.lower()[len(stem.lower()):]) if token)
+    return [token for token in residual if not _is_packaging_token(token)]
+
+
+def pick_canonical_build(builds: list[dict], stem: str) -> tuple[dict | None, bool]:
+    """Choose the most canonical fleet-quant build, or None with a matched flag.
+
+    Requires the mlx-community namespace and an anchored (prefix) identity match,
+    rejects adapter/LoRA/merge/modified derivatives outright, and orders the rest
+    by fewest variant tokens, then fleet quant preference, then shortest name.
+    Records the selected build's variant tokens so a variant-only match is never
+    reported as a clean canonical "servable". Returns (picked_or_None, matched_any)
+    so the caller can distinguish "no build at all" from "matched but nothing usable".
+    """
+    matched_any = False
+    scored: list[tuple] = []
+    for item in builds:
+        repo_id = item.get("modelId") or item.get("id") or ""
+        if not isinstance(repo_id, str) or repo_owner(repo_id).lower() != MLX_NAMESPACE:
+            continue
+        name = repo_name(repo_id).lower()
+        if not anchored_match(name, stem):
+            continue
+        matched_any = True
+        if any(token in name for token in DISQUALIFYING_TOKENS):
+            continue
+        quant = quant_of(repo_id)
+        if quant is None:
+            continue
+        variant = unrecognised_suffix_tokens(name, stem)
+        scored.append((len(variant), MLX_QUANT_TAGS.index(quant), len(name), repo_id, quant, item.get("pipeline_tag"), variant))
+    if not scored:
+        return None, matched_any
+    scored.sort()
+    _, _, _, repo_id, quant, list_pipeline_tag, variant = scored[0]
+    return {"repo": repo_id, "quant": quant, "list_pipeline_tag": list_pipeline_tag, "variant_tokens": variant}, matched_any
+
+
+def build_residency_and_pipeline(repo_id: str, client: Client) -> tuple[Decimal, str | None, dict | None]:
+    detail = client(f"{HF_API}/{repo_id}?{urllib.parse.urlencode({'blobs': 'true'})}")
+    if not isinstance(detail, dict):
+        raise ResolveError(f"{repo_id}: detail response was not an object")
+    siblings = detail.get("siblings")
+    if not isinstance(siblings, list) or not siblings:
+        raise ResolveError(f"{repo_id}: no file listing")
+    filenames = [s.get("rfilename") for s in siblings if isinstance(s, dict)]
+    if any(name == "adapter_config.json" for name in filenames if isinstance(name, str)):
+        raise ResolveError(f"{repo_id}: PEFT/LoRA adapter repository (adapter_config.json present), not a base checkpoint")
+    weight_bytes = 0
+    saw_full_checkpoint = False
+    for sibling in siblings:
+        if not isinstance(sibling, dict):
+            raise ResolveError(f"{repo_id}: malformed file entry")
+        name = sibling.get("rfilename")
+        if not isinstance(name, str):
+            raise ResolveError(f"{repo_id}: malformed file name")
+        if name.endswith(".safetensors"):
+            size = sibling.get("size")
+            if not isinstance(size, int) or isinstance(size, bool) or size < 0:
+                raise ResolveError(f"{repo_id}: missing or invalid safetensors size (fail closed)")
+            if "adapter" in name.lower():
+                continue  # adapter shard, not a full checkpoint -- do not count it
+            saw_full_checkpoint = True
+            weight_bytes += size
+    if not saw_full_checkpoint or weight_bytes <= 0:
+        raise ResolveError(f"{repo_id}: no complete (non-adapter) safetensors checkpoint")
+    pipeline_tag = detail.get("pipeline_tag")
+    if pipeline_tag is not None and not isinstance(pipeline_tag, str):
+        raise ResolveError(f"{repo_id}: pipeline_tag is not a string")
+    config = detail.get("config")
+    return Decimal(weight_bytes) / Decimal(10 ** 9), pipeline_tag, config if isinstance(config, dict) else None
+
+
+def _arch_blob(config: dict | None) -> str:
+    architectures = (config or {}).get("architectures")
+    parts = [arch for arch in architectures if isinstance(arch, str)] if isinstance(architectures, list) else []
+    model_type = (config or {}).get("model_type")
+    if isinstance(model_type, str):
+        parts.append(model_type)
+    return " ".join(parts).lower()
+
+
+def is_multimodal_arch(config: dict | None) -> bool:
+    blob = _arch_blob(config)
+    if any(marker in blob for marker in MULTIMODAL_ARCH_MARKERS):
+        return True
+    return any(pattern in blob for pattern in MULTIMODAL_ARCH_PATTERNS)
+
+
+def is_causal_lm(config: dict | None) -> bool:
+    architectures = (config or {}).get("architectures")
+    if not isinstance(architectures, list):
+        return False
+    return any(isinstance(arch, str) and arch.lower().endswith(CAUSAL_LM_ARCH_SUFFIX) for arch in architectures)
+
+
+def classify(repo_id: str, quant: str | None, residency_gb: Decimal, pipeline_tag: str | None, config: dict | None, max_residency: Decimal, variant_tokens: list[str] | tuple = ()) -> dict:
+    required_gb = residency_gb * RESIDENCY_OVERHEAD
+    evidence = {"mlx_repo": repo_id, "quant": quant, "residency_gb": f"{residency_gb:.1f}", "required_gb": f"{required_gb:.1f}", "pipeline_tag": pipeline_tag}
+    architectures = (config or {}).get("architectures")
+    if required_gb > max_residency:
+        return {**evidence, "verdict": "not_servable", "reasons": [f"conservative runtime residency {required_gb:.1f} GB (weights {residency_gb:.1f} GB x {RESIDENCY_OVERHEAD} headroom) exceeds the {max_residency} GB fleet band"]}
+    # Architecture evidence VETOES a clean text verdict: a multimodal-shaped
+    # architecture conflicts with a text-only serving path even when the HF
+    # pipeline_tag claims text-generation (stale/mistagged repositories exist).
+    if is_multimodal_arch(config):
+        return {**evidence, "verdict": "unresolved", "reasons": [f"config architecture {architectures} is multimodal-shaped and conflicts with any text-only serving path (pipeline_tag {pipeline_tag!r})"]}
+    # The strongest positive verdict this tool emits is "review": HuggingFace
+    # metadata cannot PROVE a build serves text on the fleet (only loading it on
+    # hardware can), so a build that fits and is plausibly a text model is
+    # nominated as a review candidate for a human to confirm the serving path
+    # before Component 3 prices it. There is deliberately no "servable" verdict --
+    # that removes any path to a false clean claim from remote metadata.
+    has_arch_metadata = isinstance(architectures, list) and any(isinstance(arch, str) for arch in architectures)
+    if pipeline_tag in TEXT_PIPELINE_TAGS:
+        if has_arch_metadata and not is_causal_lm(config):
+            return {**evidence, "verdict": "unresolved", "reasons": [f"pipeline_tag text-generation but config architecture {architectures} is not a recognised causal-LM text form; cannot confirm a text-only serving path"]}
+        reason = "mlx-community text-generation build fits the fleet residency band; confirm the serving path before pricing"
+    elif pipeline_tag in VISION_TEXT_PIPELINE_TAGS:
+        # A vision-language pipeline is not positive evidence of a text-only serving
+        # path, so it is not nominated as a review candidate: it is unresolved,
+        # visible in the audit trail for a human to investigate a text-tower path.
+        return {**evidence, "verdict": "unresolved", "reasons": [f"pipeline_tag {pipeline_tag!r} is a vision-language pipeline, not a confirmed text-only serving path"]}
+    elif pipeline_tag is None and is_causal_lm(config):
+        reason = f"no HF pipeline_tag; config architecture {architectures} is a causal LM; confirm the text-only serving path before pricing"
+    elif pipeline_tag is None:
+        return {**evidence, "verdict": "unresolved", "reasons": ["no pipeline_tag and no causal-LM architecture in config; cannot confirm the text serving path"]}
+    else:
+        return {**evidence, "verdict": "not_servable", "reasons": [f"pipeline_tag {pipeline_tag!r} is not a text-generation serving path"]}
+    # A build reachable only through a non-canonical variant repo (unrecognised
+    # suffix tokens) is a different derivative -- keep it a review candidate but
+    # flag the identity question explicitly.
+    if variant_tokens:
+        reason = f"candidate via a non-canonical variant repo (unrecognised tokens {list(variant_tokens)}); confirm base-model identity AND the serving path before pricing"
+    return {**evidence, "verdict": "review", "reasons": [reason]}
+
+
+def resolve_row(source_model_id: str, max_residency: Decimal, client: Client) -> dict:
+    vendor = source_model_id.split("/", 1)[0].lower()
+    if vendor in CLOSED_WEIGHT_VENDORS:
+        return {"verdict": "not_servable", "reasons": [f"{vendor} publishes closed-weight API models; no local MLX build is possible"]}
+    stem = model_stem(source_model_id)
+    builds = search_builds(stem, client)
+    picked, matched_any = pick_canonical_build(builds, stem)
+    if picked is None:
+        if matched_any:
+            return {"verdict": "unresolved", "reasons": [f"mlx-community has {stem!r} builds but only adapter/LoRA/merge/modified or unrecognised-quant repositories; none is a canonical fleet build"]}
+        return {"verdict": "not_servable", "reasons": [f"no mlx-community build matches {stem!r}"]}
+    residency_gb, pipeline_tag, config = build_residency_and_pipeline(picked["repo"], client)
+    return classify(picked["repo"], picked["quant"], residency_gb, pipeline_tag, config, max_residency, picked["variant_tokens"])
+
+
+def payout_decimal(row: dict) -> Decimal:
+    pricing = row.get("pricing")
+    if isinstance(pricing, dict) and pricing.get("completion_per_mtok") is not None:
+        try:
+            return Decimal(str(pricing["completion_per_mtok"]))
+        except (InvalidOperation, ValueError):
+            return Decimal(0)
+    return Decimal(0)
+
+
+def rank_key(candidate: dict) -> tuple:
+    payout = Decimal(candidate["payout_completion_per_mtok"])
+    rank = candidate.get("demand_rank") or 999
+    # Higher payout and stronger demand (lower rank) sort first.
+    return (-(payout * (Decimal(1000) / Decimal(rank))), rank)
+
+
+def build_candidates(snapshot: dict, policy: dict, max_residency: Decimal, client: Client) -> dict:
+    if not isinstance(snapshot, dict) or not isinstance(snapshot.get("rows"), list):
+        raise ResolveError("snapshot must be an object with a rows array")
+    if not isinstance(policy, dict) or not isinstance(policy.get("models"), list):
+        raise ResolveError("policy must be an object with a models array")
+    mapped = {model.get("source_model_id") for model in policy["models"] if isinstance(model, dict)}
+    candidates: list[dict] = []
+    for row in snapshot["rows"]:
+        if not isinstance(row, dict):
+            raise ResolveError("snapshot row must be an object")
+        source_model_id = row.get("source_model_id")
+        if source_model_id in mapped:
+            continue
+        payout = payout_decimal(row)
+        demand = row.get("demand") if isinstance(row.get("demand"), dict) else {}
+        record = {"source_model_id": source_model_id, "demand_rank": demand.get("rank"), "payout_completion_per_mtok": str(payout)}
+        if payout <= 0:
+            record.update({"verdict": "skipped", "reasons": ["no paid completion payout on OpenRouter; no undercut market to price against"]})
+        else:
+            try:
+                record.update(resolve_row(source_model_id, max_residency, client))
+            except ResolveError as error:
+                record.update({"verdict": "unresolved", "reasons": [str(error)]})
+        candidates.append(record)
+
+    candidates.sort(key=lambda c: (c["source_model_id"] or ""))
+    buckets = ("review", "not_servable", "unresolved", "skipped")
+    summary = {"probed": len(candidates)}
+    summary.update({bucket: sum(1 for c in candidates if c["verdict"] == bucket) for bucket in buckets})
+    return {
+        "schema_version": 1,
+        "artifact_type": "openrouter-mlx-candidates",
+        "max_residency_gb": str(max_residency),
+        "policy_version": policy.get("policy_version"),
+        "snapshot_digest": snapshot.get("content_digest"),
+        "summary": summary,
+        "review": sorted([c for c in candidates if c["verdict"] == "review"], key=rank_key),
+        "candidates": candidates,
+    }
+
+
+def render(result: dict) -> str:
+    summary = result["summary"]
+    lines = [f"probed {summary['probed']} unmapped demand rows -> "
+             f"{summary['review']} review candidate(s), {summary['unresolved']} unresolved", ""]
+    for c in result["review"]:
+        lines.append(f"  REVIEW  rank {str(c['demand_rank']):>3}  ${c['payout_completion_per_mtok']}/Mtok  {c['source_model_id']}")
+        lines.append(f"          {c.get('mlx_repo')}  ({c.get('quant')}, {c.get('residency_gb')} GB weights / {c.get('required_gb')} GB required, {c.get('pipeline_tag')})")
+        for reason in c["reasons"]:
+            lines.append(f"          - {reason}")
+    lines.append("\n--- not_servable / unresolved / skipped (audit trail) ---")
+    for c in result["candidates"]:
+        if c["verdict"] != "review":
+            lines.append(f"  {c['verdict']:12} rank {str(c['demand_rank']):>3}  {c['source_model_id']}  :: {c['reasons'][0]}")
+    return "\n".join(lines)
+
+
+def main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(description="Rank OpenRouter demand rows by payout x MLX-servability (review-only).")
+    parser.add_argument("--snapshot", required=True)
+    parser.add_argument("--policy", required=True)
+    parser.add_argument("--max-residency-gb", default="45", help="fleet residency band ceiling in GB (default 45 = coding/M-Max tier)")
+    parser.add_argument("--timeout-seconds", type=float, default=20.0)
+    parser.add_argument("--output", help="optional path to write the review-only candidate JSON artifact (refuses inputs and money-path files, never overwrites)")
+    args = parser.parse_args(argv)
+
+    with open(args.snapshot, encoding="utf-8") as handle:
+        snapshot = json.load(handle)
+    with open(args.policy, encoding="utf-8") as handle:
+        policy = json.load(handle)
+    # Operationally, reuse the pricing engine's strict snapshot/policy validators
+    # so a malformed or untrusted input cannot reach the servability logic.
+    sys.path.insert(0, str(Path(__file__).resolve().parent))
+    import openrouter_pricing_engine as engine
+    engine.validate_snapshot(snapshot)
+    engine.validate_policy(policy)
+
+    max_residency = validated_residency(args.max_residency_gb)
+    timeout = args.timeout_seconds
+    if not (isinstance(timeout, (int, float)) and math.isfinite(timeout) and timeout > 0):
+        raise SystemExit(f"--timeout-seconds must be a finite positive number: {timeout!r}")
+    result = build_candidates(snapshot, policy, max_residency, real_client(timeout))
+    print(render(result))
+    if args.output:
+        target = Path(args.output).resolve()
+        protected = {Path(args.snapshot).resolve(), Path(args.policy).resolve()}
+        if target in protected or is_protected_component(target):
+            raise SystemExit("refusing to write to an input or protected money-path file")
+        if target.exists():
+            raise SystemExit(f"refusing to overwrite existing file: {target}")
+        with open(target, "x", encoding="utf-8") as handle:
+            json.dump(result, handle, sort_keys=True, indent=2)
+            handle.write("\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/scripts/tests/test_openrouter_mlx_candidates.py
+++ b/scripts/tests/test_openrouter_mlx_candidates.py
@@ -1,0 +1,353 @@
+#!/usr/bin/env python3
+
+import importlib.util
+import sys
+import unittest
+import urllib.parse
+from decimal import Decimal
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[2]
+SCRIPT = REPO / "scripts" / "openrouter_mlx_candidates.py"
+sys.path.insert(0, str(REPO / "scripts"))
+SPEC = importlib.util.spec_from_file_location("openrouter_mlx_candidates", SCRIPT)
+mlx = importlib.util.module_from_spec(SPEC)
+assert SPEC.loader is not None
+SPEC.loader.exec_module(mlx)
+
+GB = 10 ** 9
+
+
+def detail(size_gb, pipeline_tag=None, architectures=None, drop_size=False):
+    sibling = {"rfilename": "model.safetensors"}
+    if not drop_size:
+        sibling["size"] = int(size_gb * GB)
+    out = {"siblings": [sibling, {"rfilename": "config.json"}], "pipeline_tag": pipeline_tag}
+    if architectures is not None:
+        out["config"] = {"architectures": architectures}
+    return out
+
+
+class FakeHF:
+    """Deterministic offline stand-in for the HuggingFace models API."""
+
+    def __init__(self, searches, details, raise_on=frozenset()):
+        self.searches = searches
+        self.details = details
+        self.raise_on = raise_on
+        self.calls = []
+
+    def __call__(self, url):
+        self.calls.append(url)
+        parsed = urllib.parse.urlparse(url)
+        if any(token in url for token in self.raise_on):
+            raise mlx.ResolveError("simulated HuggingFace failure")
+        if parsed.path == "/api/models":  # search
+            stem = urllib.parse.parse_qs(parsed.query).get("search", [""])[0]
+            return self.searches.get(stem, [])
+        repo = parsed.path.split("/api/models/", 1)[-1]  # detail
+        if repo not in self.details:
+            raise mlx.ResolveError(f"no detail fixture for {repo}")
+        return self.details[repo]
+
+
+def row(source_model_id, rank, completion):
+    pricing = None if completion is None else {"completion_per_mtok": completion}
+    return {"source_model_id": source_model_id, "demand": {"rank": rank, "total_token_volume": 1}, "pricing": pricing}
+
+
+POLICY = {"policy_version": "test-v1", "models": [{"source_model_id": "openai/gpt-oss-20b"}]}
+
+
+def build(rows, searches, details, raise_on=frozenset(), band="45"):
+    snapshot = {"content_digest": "sha256:test", "rows": rows}
+    client = FakeHF(searches, details, raise_on)
+    result = mlx.build_candidates(snapshot, POLICY, Decimal(band), client)
+    by_id = {c["source_model_id"]: c for c in result["candidates"]}
+    return result, by_id, client
+
+
+class MLXCandidateTests(unittest.TestCase):
+    def test_vision_language_base_is_unresolved_and_picks_canonical_build(self):
+        # gemma-4-31b: the canonical build is a VLM (image-text-to-text). It picks
+        # the plain build (not the OptiQ recipe) but a vision pipeline is NOT
+        # positive text evidence, so it is unresolved, not a review candidate.
+        searches = {"gemma-4-31b-it": [
+            {"modelId": "mlx-community/gemma-4-31b-it-4bit", "pipeline_tag": "image-text-to-text"},
+            {"modelId": "mlx-community/gemma-4-31B-it-OptiQ-4bit", "pipeline_tag": "text-generation"},
+        ]}
+        details = {"mlx-community/gemma-4-31b-it-4bit": detail(18.4, "image-text-to-text")}
+        _, by_id, _ = build([row("google/gemma-4-31b-it", 30, 0.34)], searches, details)
+        c = by_id["google/gemma-4-31b-it"]
+        self.assertEqual(c["verdict"], "unresolved")
+        self.assertEqual(c["mlx_repo"], "mlx-community/gemma-4-31b-it-4bit")
+
+    def test_adapter_config_repository_is_unresolved(self):
+        # A repo carrying adapter_config.json is a PEFT/LoRA adapter, not a base model.
+        searches = {"foo": [{"modelId": "mlx-community/foo-4bit", "pipeline_tag": "text-generation"}]}
+        adapter = {"siblings": [
+            {"rfilename": "model.safetensors", "size": int(0.2 * GB)},
+            {"rfilename": "adapter_config.json"},
+        ], "pipeline_tag": "text-generation"}
+        _, by_id, _ = build([row("vendor/foo", 5, 1.0)], searches, {"mlx-community/foo-4bit": adapter})
+        self.assertEqual(by_id["vendor/foo"]["verdict"], "unresolved")
+
+    def test_vl_causal_arch_is_unresolved_under_text_pipeline(self):
+        # Qwen2VLForCausalLM ends in ForCausalLM and has no name marker, but the
+        # 'vlfor' compound pattern marks it multimodal -> unresolved even with a
+        # text-generation pipeline tag.
+        searches = {"qwen2-vl-7b": [{"modelId": "mlx-community/qwen2-vl-7b-4bit", "pipeline_tag": "text-generation"}]}
+        details = {"mlx-community/qwen2-vl-7b-4bit": detail(5.0, "text-generation", ["Qwen2VLForCausalLM"])}
+        _, by_id, _ = build([row("qwen/qwen2-vl-7b", 20, 1.0)], searches, details)
+        self.assertEqual(by_id["qwen/qwen2-vl-7b"]["verdict"], "unresolved")
+
+    def test_null_pipeline_causal_lm_is_review_not_servable(self):
+        # A null-pipeline build confirmed only by a causal-LM config architecture
+        # is downgraded to review -- heuristic metadata never yields clean servable.
+        searches = {"mistral-nemo": [
+            {"modelId": "mlx-community/Mistral-Nemo-Instruct-2407-4bit", "pipeline_tag": None},
+            {"modelId": "mlx-community/Mistral-Nemo-Base-2407-4bit", "pipeline_tag": None},
+            {"modelId": "mlx-community/Dolphin-2.9.3-Mistral-Nemo-12b-4bit", "pipeline_tag": None},
+        ]}
+        details = {"mlx-community/Mistral-Nemo-Instruct-2407-4bit": detail(7.0, None, ["MistralForCausalLM"])}
+        _, by_id, _ = build([row("mistralai/mistral-nemo", 43, 0.03)], searches, details)
+        c = by_id["mistralai/mistral-nemo"]
+        self.assertEqual(c["verdict"], "review")
+        # canonical: Instruct beats Base/Dolphin (Base penalised, Dolphin disqualified).
+        self.assertEqual(c["mlx_repo"], "mlx-community/Mistral-Nemo-Instruct-2407-4bit")
+
+    def test_multimodal_causal_lm_arch_is_unresolved(self):
+        # LlavaLlamaForCausalLM ends in ForCausalLM but is a VLM: must not pass.
+        searches = {"llava-next": [{"modelId": "mlx-community/llava-next-4bit", "pipeline_tag": None}]}
+        details = {"mlx-community/llava-next-4bit": detail(8.0, None, ["LlavaLlamaForCausalLM"])}
+        _, by_id, _ = build([row("vendor/llava-next", 20, 1.0)], searches, details)
+        self.assertEqual(by_id["vendor/llava-next"]["verdict"], "unresolved")
+
+    def test_boundary_collision_is_not_a_match(self):
+        # stem 'foo-7b' must not match 'notfoo-7b-4bit'.
+        searches = {"foo-7b": [{"modelId": "mlx-community/notfoo-7b-4bit", "pipeline_tag": "text-generation"}]}
+        details = {"mlx-community/notfoo-7b-4bit": detail(4.0, "text-generation")}
+        _, by_id, _ = build([row("vendor/foo-7b", 15, 1.0)], searches, details)
+        self.assertEqual(by_id["vendor/foo-7b"]["verdict"], "not_servable")
+
+    def test_wrong_namespace_is_not_selected(self):
+        searches = {"foo-7b": [{"modelId": "attacker/foo-7b-4bit", "pipeline_tag": "text-generation"}]}
+        details = {"attacker/foo-7b-4bit": detail(4.0, "text-generation")}
+        _, by_id, _ = build([row("vendor/foo-7b", 15, 1.0)], searches, details)
+        self.assertEqual(by_id["vendor/foo-7b"]["verdict"], "not_servable")
+
+    def test_adapter_and_modified_only_repos_are_unresolved(self):
+        # Only a LoRA/abliterated repo matches -> disqualified -> unresolved, not servable.
+        searches = {"qwen3-8b": [{"modelId": "mlx-community/qwen3-8b-abliterated-lora-4bit", "pipeline_tag": "text-generation"}]}
+        _, by_id, _ = build([row("vendor/qwen3-8b", 12, 1.0)], searches, {})
+        self.assertEqual(by_id["vendor/qwen3-8b"]["verdict"], "unresolved")
+
+    def test_adapter_only_checkpoint_fails_closed(self):
+        searches = {"foo": [{"modelId": "mlx-community/foo-4bit", "pipeline_tag": "text-generation"}]}
+        adapter_detail = {"siblings": [{"rfilename": "adapter_model.safetensors", "size": int(0.2 * GB)}], "pipeline_tag": "text-generation"}
+        _, by_id, _ = build([row("vendor/foo", 5, 1.0)], searches, {"mlx-community/foo-4bit": adapter_detail})
+        self.assertEqual(by_id["vendor/foo"]["verdict"], "unresolved")
+
+    def test_list_valued_pipeline_tag_fails_closed(self):
+        searches = {"foo": [{"modelId": "mlx-community/foo-4bit", "pipeline_tag": "4bit"}]}
+        bad = {"siblings": [{"rfilename": "model.safetensors", "size": int(4 * GB)}], "pipeline_tag": ["text-generation"]}
+        _, by_id, _ = build([row("vendor/foo", 5, 1.0)], searches, {"mlx-community/foo-4bit": bad})
+        self.assertEqual(by_id["vendor/foo"]["verdict"], "unresolved")
+
+    def test_residency_headroom_rejects_near_threshold_model(self):
+        # 40 GB of weights x 1.3 headroom = 52 GB > 45 GB band -> not_servable.
+        searches = {"big": [{"modelId": "mlx-community/big-4bit", "pipeline_tag": "text-generation"}]}
+        details = {"mlx-community/big-4bit": detail(40.0, "text-generation")}
+        _, by_id, _ = build([row("vendor/big", 6, 1.0)], searches, details)
+        self.assertEqual(by_id["vendor/big"]["verdict"], "not_servable")
+
+    def test_speech_model_is_not_servable(self):
+        searches = {"mimo-v2.5": [{"modelId": "mlx-community/MiMo-V2.5-ASR-MLX-4bit", "pipeline_tag": "automatic-speech-recognition"}]}
+        details = {"mlx-community/MiMo-V2.5-ASR-MLX-4bit": detail(5.0, "automatic-speech-recognition")}
+        _, by_id, _ = build([row("xiaomi/mimo-v2.5", 1, 0.28)], searches, details)
+        self.assertEqual(by_id["xiaomi/mimo-v2.5"]["verdict"], "not_servable")
+        self.assertIn("not a text-generation serving path", by_id["xiaomi/mimo-v2.5"]["reasons"][0])
+
+    def test_oversized_build_is_not_servable(self):
+        searches = {"deepseek-v4-flash": [{"modelId": "mlx-community/DeepSeek-V4-Flash-4bit", "pipeline_tag": "text-generation"}]}
+        details = {"mlx-community/DeepSeek-V4-Flash-4bit": detail(92.8, "text-generation", ["DeepseekV4ForCausalLM"])}
+        _, by_id, _ = build([row("deepseek/deepseek-v4-flash", 2, 0.168)], searches, details)
+        c = by_id["deepseek/deepseek-v4-flash"]
+        self.assertEqual(c["verdict"], "not_servable")
+        self.assertIn("exceeds", c["reasons"][0])
+
+    def test_plain_text_build_within_band_is_review_candidate(self):
+        searches = {"qwen3-8b": [{"modelId": "mlx-community/Qwen3-8B-4bit", "pipeline_tag": "text-generation"}]}
+        details = {"mlx-community/Qwen3-8B-4bit": detail(4.5, "text-generation", ["Qwen3ForCausalLM"])}
+        _, by_id, _ = build([row("qwen/qwen3-8b", 12, 0.2)], searches, details)
+        self.assertEqual(by_id["qwen/qwen3-8b"]["verdict"], "review")
+
+    def test_no_servable_verdict_or_bucket_exists(self):
+        # The tool never certifies servability; there is no servable verdict/bucket.
+        searches = {"qwen3-8b": [{"modelId": "mlx-community/Qwen3-8B-4bit", "pipeline_tag": "text-generation"}]}
+        details = {"mlx-community/Qwen3-8B-4bit": detail(4.5, "text-generation", ["Qwen3ForCausalLM"])}
+        result, _, _ = build([row("qwen/qwen3-8b", 12, 0.2)], searches, details)
+        self.assertNotIn("servable", result)
+        self.assertNotIn("servable", result["summary"])
+        self.assertNotIn("servable", {c["verdict"] for c in result["candidates"]})
+
+    def test_version_suffix_is_not_aliased(self):
+        # 'glm-5' must not match 'glm-5.2-4bit' (a different version).
+        searches = {"glm-5": [{"modelId": "mlx-community/glm-5.2-4bit", "pipeline_tag": "text-generation"}]}
+        details = {"mlx-community/glm-5.2-4bit": detail(4.0, "text-generation")}
+        _, by_id, _ = build([row("z-ai/glm-5", 5, 1.0)], searches, details)
+        self.assertEqual(by_id["z-ai/glm-5"]["verdict"], "not_servable")
+
+    def test_text_pipeline_non_causal_arch_is_unresolved(self):
+        # text-generation tag but a seq2seq/conditional-generation arch -> cannot
+        # positively confirm a causal-LM text-only path.
+        searches = {"some-t5": [{"modelId": "mlx-community/some-t5-4bit", "pipeline_tag": "text-generation"}]}
+        details = {"mlx-community/some-t5-4bit": detail(4.0, "text-generation", ["T5ForConditionalGeneration"])}
+        _, by_id, _ = build([row("vendor/some-t5", 8, 1.0)], searches, details)
+        self.assertEqual(by_id["vendor/some-t5"]["verdict"], "unresolved")
+
+    def test_unknown_suffix_derivative_is_review(self):
+        # 'foo-7b-math-4bit': 'math' is not recognised packaging -> variant -> review.
+        searches = {"foo-7b": [{"modelId": "mlx-community/foo-7b-math-4bit", "pipeline_tag": "text-generation"}]}
+        details = {"mlx-community/foo-7b-math-4bit": detail(4.0, "text-generation")}
+        _, by_id, _ = build([row("vendor/foo-7b", 5, 1.0)], searches, details)
+        self.assertEqual(by_id["vendor/foo-7b"]["verdict"], "review")
+        self.assertIn("variant", by_id["vendor/foo-7b"]["reasons"][0])
+
+    def test_no_mlx_build_is_not_servable(self):
+        _, by_id, _ = build([row("openai/gpt-5.6-sol", 26, 15.0)], {}, {})
+        c = by_id["openai/gpt-5.6-sol"]
+        self.assertEqual(c["verdict"], "not_servable")
+        self.assertIn("no mlx-community build", c["reasons"][0])
+
+    def test_closed_vendor_is_not_servable_without_network(self):
+        _, by_id, client = build([row("anthropic/claude-opus-5", 22, 25.0)], {}, {})
+        self.assertEqual(by_id["anthropic/claude-opus-5"]["verdict"], "not_servable")
+        self.assertEqual(client.calls, [])  # no HF probe for a closed house
+
+    def test_build_without_recognised_quant_is_unresolved(self):
+        searches = {"kimi-k3": [{"modelId": "mlx-community/Kimi-K3-bf16-DWQ", "pipeline_tag": None}]}
+        _, by_id, _ = build([row("moonshotai/kimi-k3", 13, 14.0)], searches, {})
+        self.assertEqual(by_id["moonshotai/kimi-k3"]["verdict"], "unresolved")
+        self.assertIn("unrecognised-quant", by_id["moonshotai/kimi-k3"]["reasons"][0])
+
+    def test_non_causal_config_without_pipeline_is_unresolved(self):
+        searches = {"some-t5": [{"modelId": "mlx-community/some-t5-4bit", "pipeline_tag": None}]}
+        details = {"mlx-community/some-t5-4bit": detail(5.0, None, ["T5ForConditionalGeneration"])}
+        _, by_id, _ = build([row("vendor/some-t5", 40, 0.5)], searches, details)
+        self.assertEqual(by_id["vendor/some-t5"]["verdict"], "unresolved")
+
+    def test_network_failure_fails_closed_to_unresolved(self):
+        searches = {"boom-model": [{"modelId": "mlx-community/boom-model-4bit", "pipeline_tag": "text-generation"}]}
+        _, by_id, _ = build([row("vendor/boom-model", 5, 1.0)], searches, {}, raise_on={"boom-model"})
+        self.assertEqual(by_id["vendor/boom-model"]["verdict"], "unresolved")
+        self.assertIn("simulated HuggingFace failure", by_id["vendor/boom-model"]["reasons"][0])
+
+    def test_missing_safetensors_size_fails_closed(self):
+        searches = {"nosize": [{"modelId": "mlx-community/nosize-4bit", "pipeline_tag": "text-generation"}]}
+        details = {"mlx-community/nosize-4bit": detail(0, "text-generation", ["LlamaForCausalLM"], drop_size=True)}
+        _, by_id, _ = build([row("vendor/nosize", 8, 2.0)], searches, details)
+        self.assertEqual(by_id["vendor/nosize"]["verdict"], "unresolved")
+        self.assertIn("safetensors size", by_id["vendor/nosize"]["reasons"][0])
+
+    def test_free_row_is_skipped_without_network(self):
+        _, by_id, client = build([row("tencent/hy3", 4, None)], {}, {})
+        self.assertEqual(by_id["tencent/hy3"]["verdict"], "skipped")
+        self.assertEqual(client.calls, [])
+
+    def test_policy_mapped_rows_are_excluded(self):
+        result, by_id, _ = build([row("openai/gpt-oss-20b", 9, 0.1), row("vendor/x", 10, None)], {}, {})
+        self.assertNotIn("openai/gpt-oss-20b", by_id)
+        self.assertEqual(result["summary"]["probed"], 1)
+
+    def test_review_candidates_ranked_by_payout_and_demand(self):
+        searches = {
+            "a-model": [{"modelId": "mlx-community/a-model-4bit", "pipeline_tag": "text-generation"}],
+            "b-model": [{"modelId": "mlx-community/b-model-4bit", "pipeline_tag": "text-generation"}],
+        }
+        details = {
+            "mlx-community/a-model-4bit": detail(5.0, "text-generation"),
+            "mlx-community/b-model-4bit": detail(5.0, "text-generation"),
+        }
+        result, _, _ = build([row("v/a-model", 40, 0.10), row("v/b-model", 5, 1.00)], searches, details)
+        self.assertEqual([c["source_model_id"] for c in result["review"]], ["v/b-model", "v/a-model"])
+
+    def test_prefixed_different_model_is_not_matched(self):
+        # 'glm-5' must not match 'other-glm-5-4bit' (a different, prefixed model).
+        searches = {"glm-5": [{"modelId": "mlx-community/other-glm-5-4bit", "pipeline_tag": "text-generation"}]}
+        details = {"mlx-community/other-glm-5-4bit": detail(4.0, "text-generation")}
+        _, by_id, _ = build([row("z-ai/glm-5", 5, 1.0)], searches, details)
+        self.assertEqual(by_id["z-ai/glm-5"]["verdict"], "not_servable")
+
+    def test_suffix_boundary_prevents_wrong_size_match(self):
+        # 'glm-5' must not match 'glm-50b-4bit'.
+        searches = {"glm-5": [{"modelId": "mlx-community/glm-50b-4bit", "pipeline_tag": "text-generation"}]}
+        details = {"mlx-community/glm-50b-4bit": detail(4.0, "text-generation")}
+        _, by_id, _ = build([row("z-ai/glm-5", 5, 1.0)], searches, details)
+        self.assertEqual(by_id["z-ai/glm-5"]["verdict"], "not_servable")
+
+    def test_text_pipeline_with_multimodal_arch_is_unresolved(self):
+        # A text-generation tag must not override a multimodal architecture.
+        searches = {"foo": [{"modelId": "mlx-community/foo-4bit", "pipeline_tag": "text-generation"}]}
+        details = {"mlx-community/foo-4bit": detail(4.0, "text-generation", ["LlavaLlamaForCausalLM"])}
+        _, by_id, _ = build([row("vendor/foo", 5, 1.0)], searches, details)
+        self.assertEqual(by_id["vendor/foo"]["verdict"], "unresolved")
+
+    def test_variant_only_build_is_review_not_servable(self):
+        # If the only anchored build is a coder/distilled/base derivative, it is a
+        # different model -> review, never a clean canonical servable.
+        searches = {"foo-7b": [{"modelId": "mlx-community/foo-7b-coder-4bit", "pipeline_tag": "text-generation"}]}
+        details = {"mlx-community/foo-7b-coder-4bit": detail(4.0, "text-generation")}
+        _, by_id, _ = build([row("vendor/foo-7b", 5, 1.0)], searches, details)
+        self.assertEqual(by_id["vendor/foo-7b"]["verdict"], "review")
+
+    def test_plain_build_preferred_over_variant(self):
+        searches = {"foo-7b": [
+            {"modelId": "mlx-community/foo-7b-coder-4bit", "pipeline_tag": "text-generation"},
+            {"modelId": "mlx-community/foo-7b-4bit", "pipeline_tag": "text-generation"},
+        ]}
+        details = {
+            "mlx-community/foo-7b-coder-4bit": detail(4.0, "text-generation"),
+            "mlx-community/foo-7b-4bit": detail(4.0, "text-generation"),
+        }
+        _, by_id, _ = build([row("vendor/foo-7b", 5, 1.0)], searches, details)
+        c = by_id["vendor/foo-7b"]
+        self.assertEqual(c["verdict"], "review")
+        self.assertEqual(c["mlx_repo"], "mlx-community/foo-7b-4bit")
+        # the plain build's reason does not carry the variant caveat
+        self.assertNotIn("variant", c["reasons"][0])
+
+    def test_quant_tag_matches_only_whole_tokens(self):
+        # 'foo-14bit' / 'foo-4bitten' are not '4bit' builds -> no usable build.
+        searches = {"foo": [
+            {"modelId": "mlx-community/foo-14bit", "pipeline_tag": "text-generation"},
+            {"modelId": "mlx-community/foo-4bitten", "pipeline_tag": "text-generation"},
+        ]}
+        _, by_id, _ = build([row("vendor/foo", 5, 1.0)], searches, {})
+        self.assertEqual(by_id["vendor/foo"]["verdict"], "unresolved")
+
+    def test_validated_residency_rejects_non_finite_and_non_positive(self):
+        for bad in ("Infinity", "-Infinity", "NaN", "0", "-5", "not-a-number"):
+            with self.assertRaises(SystemExit):
+                mlx.validated_residency(bad)
+        self.assertEqual(mlx.validated_residency("45"), Decimal("45"))
+
+    def test_output_guard_rejects_rate_card_variants(self):
+        from pathlib import Path
+        for name in ("rate-card.json", "Rate-Card.json", "rate_card.json"):
+            self.assertTrue(mlx.is_protected_component(Path("/tmp") / name))
+        self.assertTrue(mlx.is_protected_component(Path("/repo/rate-card/out.json")))
+        self.assertFalse(mlx.is_protected_component(Path("/tmp/candidates.json")))
+
+    def test_render_is_stable_and_lists_buckets(self):
+        searches = {"z": [{"modelId": "mlx-community/z-4bit", "pipeline_tag": "text-generation"}]}
+        details = {"mlx-community/z-4bit": detail(5.0, "text-generation")}
+        result, _, _ = build([row("v/z", 3, 1.0), row("anthropic/claude-x", 1, 9.0)], searches, details)
+        text = mlx.render(result)
+        self.assertEqual(text, mlx.render(result))  # deterministic
+        self.assertIn("REVIEW", text)
+        self.assertIn("audit trail", text)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What

A new **non-money-path, review-only** operator tool (`scripts/openrouter_mlx_candidates.py`) that answers "which OpenRouter demand rows could the fleet actually serve?" so model additions are driven by **payout × MLX-servability**, not a hand-curated policy allowlist.

Given a committed OpenRouter pricing snapshot + the pricing policy, for each demand row **not already in the policy** it probes HuggingFace for a fleet-fitting MLX text build and emits a ranked candidate list. It has **no apply mode** and never writes the policy or rate-card — a candidate is a nomination for human verification; the money-path apply stays with Component 3.

### Design: nominate, never certify
HuggingFace metadata cannot *prove* a model serves text on the fleet (only loading it on hardware can), so the strongest verdict is **`review`** (a candidate a human confirms before pricing) — there is deliberately **no "servable" verdict**, which removes any path to a false clean claim from remote metadata. Verdicts: `review`, `not_servable`, `unresolved`, `skipped`.

Every positive (`review`) nomination rests on positive, non-conflicting evidence:
- **Identity**: anchored `mlx-community/` prefix match at a token boundary (rejects `glm-5` ⊂ `glm-5.2`/`other-glm-5`/`glm-50b`); adapter/LoRA/merge/abliterated repos and `adapter_config.json` repos rejected; a **positive packaging allowlist** — any unrecognised suffix token (`math`, `coder`, `base`, …) flags a non-canonical variant.
- **Modality**: text-generation pipeline with (no arch metadata or a confirmed `*ForCausalLM`), or null pipeline + `*ForCausalLM`; a multimodal architecture (name markers + `vlfor`/`omnifor`/`audiofor` compound patterns) or a vision pipeline → `unresolved`; a non-causal `*ForConditionalGeneration` under a text tag → `unresolved`.
- **Residency**: weight bytes × 1.3 conservative runtime/KV headroom vs a finite positive fleet band; adapter-only checkpoints rejected.
- **Inputs/output**: reuses the pricing engine's `validate_snapshot`/`validate_policy`; finite `--max-residency-gb`/`--timeout-seconds`; `--output` refuses inputs, any `rate-card`-named path component, and existing files (exclusive create).

### Live result
Over the current snapshot's 49 unmapped demand rows: **1 review candidate** (`mistralai/mistral-nemo`), with `gemma-4-31b-it` in `unresolved` (VLM base). Everything else is `not_servable` — the demand chart is dominated by frontier/closed and giant-open (glm-5.2 ≈ 418 GB, deepseek-v4-pro ≈ 837 GB) models the fleet can't serve. This confirms the demand × MLX gate works and that fleet-servable demand is currently sparse.

## Tests
36 offline unit tests via an injectable fake HuggingFace client (no network): identity collisions/version-aliasing/namespace, adapter & variant rejection, multimodal veto (name + compound arch + vision pipeline), residency headroom, finite-input guards, output guard, fail-closed on network/schema errors, and "no servable verdict exists". **All pass.**

## Audit
Independent 4-round 3-lane codex audit (code / security / architect). Final round: **security 0 C/0 H/0 M (LOW risk, passes bar)**; the false-certification defect eliminated by construction (all lanes, 0 CRIT/0 HIGH). Remaining code-lane items were review-bucket inclusiveness on human-gated nominations — addressed by moving borderline cases (VLM pipeline, `Qwen2VL*` arch, `adapter_config`) to `unresolved` (strictly more conservative; cannot introduce a false positive).

## Notes
- Independent of #990 — depends only on `validate_snapshot`/`validate_policy`, already on `main`.
- `spec-index / check` is advisory (non-required); non-governance tooling with no governing authority domain, so no honest spec declaration to cite. Merge gate is `ci-required` + 1 approval.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
