### PR TITLE
Make the #540 physical rekey proof correlate admitted work

### DIFF
--- a/ops/runbooks/540-aead-rekey-oneshot.md
+++ b/ops/runbooks/540-aead-rekey-oneshot.md
@@ -136,17 +136,20 @@ python3 test/e2e/aead-rekey-oneshot/aead_rekey_oneshot.py \
 ```
 
 For G-req, the harness sends exactly `threshold - 1` successful warmups, starts
-one bounded sentinel, observes the provider Busy, and then starts the trigger.
+one bounded streaming sentinel, observes its first response bytes as direct
+admission evidence, and then starts the trigger while that sentinel remains
+active.
 For G-age, it derives the deadline from `/poolz.connected_at`, starts the
-sentinel two seconds before the configured age by default, observes Busy, and
-starts the trigger only after the threshold is due. If the provider is already
+streaming sentinel two seconds before the configured age by default, records
+its admission before the deadline, and starts the trigger only after the
+threshold is due. If the provider is already
 too near the age deadline, stop and restart only the isolated setup; do not
 improvise on Pearl. The tracked age overlay uses 30 seconds to leave setup
 margin while remaining a bounded one-shot drill.
 
 The process returns 0 only when the isolated SQLite request log maps the
-harness trigger to the internal rekey `request_id`, records the provider Busy
-with a distinct sentinel before trigger dispatch, proves that successful
+harness trigger to the internal rekey `request_id`, records a distinct
+streaming sentinel as admitted before trigger dispatch, proves that successful
 sentinel remained outstanding when `aead_rekey` started, and proves the trigger
 remained outstanding through commit,
 records one expected rekey and commit, distinct old/new KIDs, unchanged

--- a/phase3-binary/Tests/macprovider-cliTests/CoordinatorClientTests.swift
+++ b/phase3-binary/Tests/macprovider-cliTests/CoordinatorClientTests.swift
@@ -3299,6 +3299,7 @@ final class CoordinatorClientTests: XCTestCase {
             "status": "accepted",
             "assigned_id": "assigned-v2",
             "heartbeat_interval_s": 30,
+            "compatibility_policy": "unconfigured",
             "tier2_session": [
                 "encrypted_leg": [
                     "enabled": true,

--- a/test/e2e/aead-rekey-oneshot/README.md
+++ b/test/e2e/aead-rekey-oneshot/README.md
@@ -13,9 +13,10 @@ The live runner is intentionally narrow:
 - it validates the exact coordinator base and startup overlay named on the
   running coordinator process, plus the exact gateway config, both executable
   digests, and the PIDs that own all three loopback listener ports;
-- it requires an isolated SQLite `request_log`, generates its own external
-  request IDs, and proves the logged internal trigger ID is the one on
-  `aead_rekey` while a distinct admitted sentinel drains before commit;
+- it requires an isolated SQLite `request_log`, generates gateway-valid UUIDv4
+  external request IDs, and proves the logged internal trigger ID is the one on
+  `aead_rekey` while a distinct streaming sentinel admitted before the trigger
+  drains before commit;
 - it requires gateway `retry_503.enabled: false` and consumes each gate-specific
   approval once in a mode-0600 local ledger before buyer traffic begins;
 - it requires the operator-approved coordinator/gateway executable SHA-256

--- a/test/e2e/aead-rekey-oneshot/aead_rekey_oneshot.py
+++ b/test/e2e/aead-rekey-oneshot/aead_rekey_oneshot.py
@@ -19,11 +19,12 @@ import subprocess
 import sys
 import threading
 import time
-from typing import Any
+import uuid
+from typing import Any, Callable
 from urllib.parse import urlsplit
 
 
-HARNESS_VERSION = "1.1.0"
+HARNESS_VERSION = "1.2.0"
 BUYER_TOKEN_ENV = "MACPROVIDER_REKEY_BUYER_TOKEN"
 OPERATOR_TOKEN_ENV = "MACPROVIDER_REKEY_OPERATOR_TOKEN"
 MAX_REQUESTS = 100
@@ -64,6 +65,14 @@ def parse_utc(value: Any) -> float | None:
         return datetime.fromisoformat(candidate).timestamp()
     except ValueError:
         return None
+
+
+def is_canonical_uuid_v4(value: str) -> bool:
+    try:
+        parsed = uuid.UUID(value)
+    except (ValueError, AttributeError):
+        return False
+    return parsed.version == 4 and str(parsed) == value
 
 
 def regular_file(path_text: str, label: str) -> Path:
@@ -249,6 +258,7 @@ def http_once(
     headers: dict[str, str],
     body: bytes | None,
     timeout_seconds: float,
+    on_first_body_bytes: Callable[[int, dict[str, str]], None] | None = None,
 ) -> tuple[int, dict[str, str], bytes]:
     """Issue exactly one request: no redirect handling and no retry loop."""
     parsed = urlsplit(url)
@@ -269,19 +279,25 @@ def http_once(
         connection.request(method, path, body=body, headers=headers)
         apply_remaining_timeout()
         response = connection.getresponse()
+        response_headers = {key.lower(): value for key, value in response.getheaders()}
         chunks: list[bytes] = []
         bytes_read = 0
+        first_body_bytes_observed = False
         while True:
             apply_remaining_timeout()
             chunk = response.read1(min(65536, MAX_RESPONSE_BYTES + 1 - bytes_read))
             if not chunk:
                 break
+            if not first_body_bytes_observed:
+                first_body_bytes_observed = True
+                if on_first_body_bytes is not None:
+                    on_first_body_bytes(response.status, response_headers)
             chunks.append(chunk)
             bytes_read += len(chunk)
             if bytes_read > MAX_RESPONSE_BYTES:
                 raise HarnessError(f"{method} {path} response exceeded {MAX_RESPONSE_BYTES} bytes")
         payload = b"".join(chunks)
-        return response.status, {key.lower(): value for key, value in response.getheaders()}, payload
+        return response.status, response_headers, payload
     finally:
         connection.close()
 
@@ -714,7 +730,7 @@ def evaluate_capture(capture: dict[str, Any]) -> dict[str, Any]:
     trigger_request_id = ""
     sentinel_request_id = ""
     admitted_old_epoch_survived = False
-    sentinel_busy_before_trigger = False
+    sentinel_admitted_before_trigger = False
     bounds = capture.get("bounds") if isinstance(capture.get("bounds"), dict) else {}
     required_post_commit = int(bounds.get("post_commit_successes", 1))
     if start_time is not None and commit_time is not None:
@@ -744,11 +760,16 @@ def evaluate_capture(capture: dict[str, Any]) -> dict[str, Any]:
             if not isinstance(row, dict):
                 continue
             rows_by_external.setdefault(str(row.get("external_request_id", "")), []).append(row)
-        harness_external_ids = [
-            str(request.get("external_request_id", ""))
-            for request in requests
-            if isinstance(request, dict)
-        ]
+        harness_external_ids = []
+        for request in requests:
+            if not isinstance(request, dict):
+                continue
+            external_id = str(request.get("external_request_id", ""))
+            harness_external_ids.append(external_id)
+            if not is_canonical_uuid_v4(external_id):
+                add_reason(reasons, f"buyer request ID is not canonical UUIDv4: {external_id or '<missing>'}")
+            if str(request.get("accepted_request_id", "")) != external_id:
+                add_reason(reasons, f"gateway did not preserve buyer request ID {external_id or '<missing>'}")
         if not harness_external_ids or any(not item for item in harness_external_ids):
             add_reason(reasons, "buyer request correlation IDs are missing")
         for external_id in harness_external_ids:
@@ -776,6 +797,7 @@ def evaluate_capture(capture: dict[str, Any]) -> dict[str, Any]:
             trigger_http_start = parse_utc(trigger_requests[0].get("started_at"))
             trigger_http_end = parse_utc(trigger_requests[0].get("ended_at"))
             sentinel_http_start = parse_utc(sentinel_requests[0].get("started_at"))
+            sentinel_admitted_at = parse_utc(sentinel_requests[0].get("admitted_at"))
             if (
                 trigger_http_start is None
                 or trigger_http_end is None
@@ -783,23 +805,14 @@ def evaluate_capture(capture: dict[str, Any]) -> dict[str, Any]:
                 or trigger_http_end < commit_time
             ):
                 add_reason(reasons, "trigger buyer request did not remain outstanding across the rekey commit")
-            for sample in samples:
-                if not isinstance(sample, dict):
-                    continue
-                observed = parse_utc(sample.get("observed_at"))
-                provider = target_from_sample(sample, provider_id)
-                if (
-                    observed is not None
-                    and sentinel_http_start is not None
-                    and trigger_http_start is not None
-                    and sentinel_http_start <= observed <= trigger_http_start
-                    and provider is not None
-                    and provider.get("state") == "busy"
-                ):
-                    sentinel_busy_before_trigger = True
-                    break
-            if not sentinel_busy_before_trigger:
-                add_reason(reasons, "provider Busy was not recorded after sentinel admission and before trigger dispatch")
+            sentinel_admitted_before_trigger = bool(
+                sentinel_http_start is not None
+                and sentinel_admitted_at is not None
+                and trigger_http_start is not None
+                and sentinel_http_start <= sentinel_admitted_at <= trigger_http_start
+            )
+            if not sentinel_admitted_before_trigger:
+                add_reason(reasons, "streaming sentinel admission was not recorded before trigger dispatch")
             trigger_rows = rows_by_external.get(trigger_external, [])
             sentinel_rows = rows_by_external.get(sentinel_external, [])
             if len(trigger_rows) == 1:
@@ -862,7 +875,7 @@ def evaluate_capture(capture: dict[str, Any]) -> dict[str, Any]:
             "rekey_window_overlapping_requests": overlapping_requests,
             "successful_requests_completed_after_commit": successful_after_commit,
             "admitted_old_epoch_survived": admitted_old_epoch_survived,
-            "sentinel_busy_before_trigger": sentinel_busy_before_trigger,
+            "sentinel_admitted_before_trigger": sentinel_admitted_before_trigger,
             "pool_samples": len(samples),
             "pool_states_observed": sorted(set(pool_states)),
         },
@@ -893,6 +906,7 @@ def evaluate_capture(capture: dict[str, Any]) -> dict[str, Any]:
             "ready_or_busy_throughout": bool(pool_states) and all(state in ALLOWED_PROVIDER_STATES for state in pool_states),
             "trigger_bound_to_rekey": bool(trigger_request_id and len(starts) == 1 and trigger_request_id == starts[0].get("request_id")),
             "admitted_old_epoch_survived": admitted_old_epoch_survived,
+            "sentinel_admitted_before_trigger": sentinel_admitted_before_trigger,
         },
     }
 
@@ -965,7 +979,9 @@ def sanitized_capture(capture: dict[str, Any]) -> dict[str, Any]:
                     "request_index",
                     "role",
                     "external_request_id",
+                    "accepted_request_id",
                     "started_at",
+                    "admitted_at",
                     "ended_at",
                     "http_status",
                     "outcome",
@@ -1120,6 +1136,7 @@ class LiveState:
         self.next_request = 0
         self.commit_observed = False
         self.commit_event = threading.Event()
+        self.sentinel_admitted_event = threading.Event()
 
     def fail(self, message: str) -> None:
         with self.lock:
@@ -1216,7 +1233,7 @@ def issue_buyer_once(
             return
         request_index = state.next_request
         state.next_request += 1
-    external_request_id = f"rekey-oneshot-{os.getpid()}-{request_index}"
+    external_request_id = str(uuid.uuid4())
     record: dict[str, Any] = {
         "request_index": request_index,
         "role": role,
@@ -1237,16 +1254,30 @@ def issue_buyer_once(
         {
             "model": args.model,
             "messages": [{"role": "user", "content": instruction}],
-            "stream": False,
+            "stream": sentinel,
             "max_tokens": max_tokens,
         },
         separators=(",", ":"),
     ).encode("utf-8")
+
+    def mark_sentinel_admitted(status: int, response_headers: dict[str, str]) -> None:
+        if not sentinel or state.sentinel_admitted_event.is_set():
+            return
+        if status != 200:
+            raise HarnessError(f"buyer sentinel returned HTTP {status} before admission")
+        content_type = response_headers.get("content-type", "").split(";", 1)[0].strip().lower()
+        if content_type != "text/event-stream":
+            raise HarnessError("buyer sentinel response was not text/event-stream")
+        if response_headers.get("x-request-id", "") != external_request_id:
+            raise HarnessError("gateway did not preserve the sentinel UUIDv4 X-Request-ID")
+        record["admitted_at"] = utc_now()
+        state.sentinel_admitted_event.set()
+
     try:
         remaining_run_seconds = deadline_monotonic - time.monotonic()
         if remaining_run_seconds <= 0:
             raise TimeoutError("one-shot wall-clock cap reached before buyer dispatch")
-        status, _, response_body = http_once(
+        status, response_headers, response_body = http_once(
             args.buyer_url,
             "POST",
             {
@@ -1257,20 +1288,29 @@ def issue_buyer_once(
             },
             body,
             min(args.request_timeout_seconds, remaining_run_seconds),
+            mark_sentinel_admitted if sentinel else None,
         )
         record["http_status"] = status
+        record["accepted_request_id"] = response_headers.get("x-request-id", "")
         excerpt = response_body[:512].decode("utf-8", "replace")
         record["response_excerpt"] = excerpt
         if status != 200:
             record["outcome"] = "http_error"
             state.fail(f"buyer request {request_index} returned HTTP {status}")
         else:
-            try:
-                decoded = json.loads(response_body)
-            except json.JSONDecodeError as exc:
-                raise HarnessError("buyer returned invalid JSON") from exc
-            if not isinstance(decoded, dict) or not isinstance(decoded.get("choices"), list) or not decoded["choices"]:
-                raise HarnessError("buyer response lacked a non-empty choices array")
+            if record["accepted_request_id"] != external_request_id:
+                raise HarnessError("gateway did not preserve the UUIDv4 X-Request-ID")
+            if sentinel:
+                if response_headers.get("content-type", "").split(";", 1)[0].strip().lower() != "text/event-stream":
+                    raise HarnessError("buyer sentinel response was not text/event-stream")
+                validate_streaming_buyer_response(response_body)
+            else:
+                try:
+                    decoded = json.loads(response_body)
+                except json.JSONDecodeError as exc:
+                    raise HarnessError("buyer returned invalid JSON") from exc
+                if not isinstance(decoded, dict) or not isinstance(decoded.get("choices"), list) or not decoded["choices"]:
+                    raise HarnessError("buyer response lacked a non-empty choices array")
             record["outcome"] = "ok"
     except Exception as exc:  # one attempt only
         record["error"] = str(exc)
@@ -1281,23 +1321,50 @@ def issue_buyer_once(
             state.requests.append(record)
 
 
-def wait_for_provider_busy(state: LiveState, deadline_monotonic: float) -> bool:
+def validate_streaming_buyer_response(response_body: bytes) -> None:
+    saw_choices = False
+    saw_done = False
+    try:
+        response_text = response_body.decode("utf-8")
+    except UnicodeDecodeError as exc:
+        raise HarnessError("buyer returned invalid UTF-8 streaming data") from exc
+    for raw_line in response_text.splitlines():
+        line = raw_line.strip()
+        if not line.startswith("data:"):
+            continue
+        payload = line[5:].strip()
+        if payload == "[DONE]":
+            saw_done = True
+            continue
+        if not payload:
+            continue
+        try:
+            decoded = json.loads(payload)
+        except json.JSONDecodeError as exc:
+            raise HarnessError("buyer returned invalid streaming JSON") from exc
+        if isinstance(decoded, dict) and isinstance(decoded.get("error"), dict):
+            raise HarnessError("buyer returned a streaming error object")
+        choices = decoded.get("choices") if isinstance(decoded, dict) else None
+        if isinstance(choices, list):
+            saw_choices = saw_choices or any(
+                isinstance(choice, dict)
+                and (
+                    isinstance(choice.get("delta"), dict)
+                    or isinstance(choice.get("message"), dict)
+                    or isinstance(choice.get("text"), str)
+                    or choice.get("finish_reason") is not None
+                )
+                for choice in choices
+            )
+    if not saw_choices or not saw_done:
+        raise HarnessError("buyer stream lacked choices data or the terminal [DONE] marker")
+
+
+def wait_for_sentinel_admission(state: LiveState, deadline_monotonic: float) -> bool:
     while time.monotonic() < deadline_monotonic and not state.dispatch_stop.is_set():
-        with state.lock:
-            for sample in reversed(state.pool_samples):
-                provider = target_from_sample(sample, str(sample.get("expected_provider_id", "")))
-                if provider and provider.get("state") == "busy":
-                    return True
-            samples = list(state.pool_samples)
-        for sample in reversed(samples):
-            poolz = sample.get("poolz") if isinstance(sample, dict) else None
-            pool = poolz.get("pool") if isinstance(poolz, dict) else None
-            if isinstance(pool, list) and any(
-                isinstance(item, dict) and item.get("state") == "busy" for item in pool
-            ):
-                return True
-        time.sleep(0.02)
-    state.fail("sentinel request was not observed Busy before the trigger")
+        if state.sentinel_admitted_event.wait(0.02):
+            return True
+    state.fail("sentinel did not begin streaming before the rekey trigger deadline")
     return False
 
 
@@ -1436,10 +1503,13 @@ def run_live(args: argparse.Namespace) -> tuple[dict[str, Any], dict[str, Any]]:
         name="rekey-buyer-sentinel",
     )
     sentinel_thread.start()
-    busy_deadline = deadline
+    admission_deadline = deadline
     if age_deadline_utc is not None:
-        busy_deadline = min(busy_deadline, time.monotonic() + max(0.0, age_deadline_utc - time.time()))
-    wait_for_provider_busy(state, busy_deadline)
+        admission_deadline = min(
+            admission_deadline,
+            time.monotonic() + max(0.0, age_deadline_utc - time.time()),
+        )
+    wait_for_sentinel_admission(state, admission_deadline)
     if not sentinel_thread.is_alive():
         state.fail("sentinel completed before the rekey trigger was dispatched")
     if age_deadline_utc is not None:

--- a/test/e2e/aead-rekey-oneshot/test_aead_rekey_oneshot.py
+++ b/test/e2e/aead-rekey-oneshot/test_aead_rekey_oneshot.py
@@ -10,7 +10,12 @@ import sqlite3
 import subprocess
 import sys
 import tempfile
+import threading
+import time
+from types import SimpleNamespace
+from typing import Any
 import unittest
+import uuid
 
 
 MODULE_PATH = Path(__file__).with_name("aead_rekey_oneshot.py")
@@ -18,6 +23,9 @@ SPEC = importlib.util.spec_from_file_location("aead_rekey_oneshot", MODULE_PATH)
 assert SPEC and SPEC.loader
 HARNESS = importlib.util.module_from_spec(SPEC)
 SPEC.loader.exec_module(HARNESS)
+
+SENTINEL_EXTERNAL_ID = "11111111-1111-4111-8111-111111111111"
+TRIGGER_EXTERNAL_ID = "22222222-2222-4222-8222-222222222222"
 
 
 def ts(second: int) -> str:
@@ -51,8 +59,10 @@ def passing_capture(gate: str = "request_threshold") -> dict:
             {
                 "request_index": 0,
                 "role": "sentinel",
-                "external_request_id": "external-sentinel",
+                "external_request_id": SENTINEL_EXTERNAL_ID,
+                "accepted_request_id": SENTINEL_EXTERNAL_ID,
                 "started_at": ts(1),
+                "admitted_at": ts(1),
                 "ended_at": ts(4),
                 "http_status": 200,
                 "outcome": "ok",
@@ -61,7 +71,8 @@ def passing_capture(gate: str = "request_threshold") -> dict:
             {
                 "request_index": 1,
                 "role": "trigger",
-                "external_request_id": "external-trigger",
+                "external_request_id": TRIGGER_EXTERNAL_ID,
+                "accepted_request_id": TRIGGER_EXTERNAL_ID,
                 "started_at": ts(2),
                 "ended_at": ts(7),
                 "http_status": 200,
@@ -73,7 +84,7 @@ def passing_capture(gate: str = "request_threshold") -> dict:
             {
                 "ts_utc": ts(4),
                 "request_id": "old-epoch-sentinel",
-                "external_request_id": "external-sentinel",
+                "external_request_id": SENTINEL_EXTERNAL_ID,
                 "provider_assigned_id": "assigned-one",
                 "latency_ms": 3000,
                 "queue_wait_ms": 0,
@@ -85,7 +96,7 @@ def passing_capture(gate: str = "request_threshold") -> dict:
             {
                 "ts_utc": ts(7),
                 "request_id": "buyer-0",
-                "external_request_id": "external-trigger",
+                "external_request_id": TRIGGER_EXTERNAL_ID,
                 "provider_assigned_id": "assigned-one",
                 "latency_ms": 5000,
                 "queue_wait_ms": 2000,
@@ -96,12 +107,9 @@ def passing_capture(gate: str = "request_threshold") -> dict:
             },
         ],
         "pool_samples": [
-            {"observed_at": ts(1), "poolz": {"pool": [provider], "summary": {"ready": 1}}},
-            {
-                "observed_at": ts(2),
-                "poolz": {"pool": [dict(provider, state="busy")], "summary": {"busy": 1}},
-            },
-            {"observed_at": ts(7), "poolz": {"pool": [provider], "summary": {"ready": 1}}},
+            {"observed_at": ts(1), "poolz": {"pool": [dict(provider)], "summary": {"ready": 1}}},
+            {"observed_at": ts(2), "poolz": {"pool": [dict(provider)], "summary": {"ready": 1}}},
+            {"observed_at": ts(7), "poolz": {"pool": [dict(provider)], "summary": {"ready": 1}}},
         ],
         "events": [
             {
@@ -138,6 +146,8 @@ class EvaluateCaptureTests(unittest.TestCase):
         self.assertEqual(result["rekey"]["old_kid"], "old-kid")
         self.assertEqual(result["rekey"]["new_kid"], "new-kid")
         self.assertEqual(result["metrics"]["rekey_window_overlapping_requests"], 2)
+        self.assertTrue(result["metrics"]["sentinel_admitted_before_trigger"])
+        self.assertEqual(result["metrics"]["pool_states_observed"], ["ready"])
 
     def test_age_handoff_uses_same_analyzer(self) -> None:
         result = HARNESS.evaluate_capture(passing_capture("age_threshold"))
@@ -205,6 +215,22 @@ class EvaluateCaptureTests(unittest.TestCase):
         self.assertEqual(result["verdict"], "FAIL")
         self.assertTrue(any("harness trigger" in reason for reason in result["reasons"]))
 
+    def test_request_ids_must_be_canonical_uuid_v4(self) -> None:
+        capture = passing_capture()
+        capture["requests"][0]["external_request_id"] = "not-a-uuid"
+        capture["requests"][0]["accepted_request_id"] = "not-a-uuid"
+        capture["request_log"][0]["external_request_id"] = "not-a-uuid"
+        result = HARNESS.evaluate_capture(capture)
+        self.assertEqual(result["verdict"], "FAIL")
+        self.assertTrue(any("canonical UUIDv4" in reason for reason in result["reasons"]))
+
+    def test_gateway_must_echo_the_external_request_id(self) -> None:
+        capture = passing_capture()
+        capture["requests"][0]["accepted_request_id"] = TRIGGER_EXTERNAL_ID
+        result = HARNESS.evaluate_capture(capture)
+        self.assertEqual(result["verdict"], "FAIL")
+        self.assertTrue(any("did not preserve" in reason for reason in result["reasons"]))
+
     def test_old_epoch_sentinel_must_drain_before_commit(self) -> None:
         capture = passing_capture()
         capture["request_log"][0]["ts_utc"] = ts(2)
@@ -212,6 +238,13 @@ class EvaluateCaptureTests(unittest.TestCase):
         result = HARNESS.evaluate_capture(capture)
         self.assertEqual(result["verdict"], "FAIL")
         self.assertTrue(any("old-epoch" in reason for reason in result["reasons"]))
+
+    def test_sentinel_admission_must_precede_trigger(self) -> None:
+        capture = passing_capture()
+        capture["requests"][0]["admitted_at"] = ts(3)
+        result = HARNESS.evaluate_capture(capture)
+        self.assertEqual(result["verdict"], "FAIL")
+        self.assertTrue(any("admission" in reason for reason in result["reasons"]))
 
     def test_dry_run_cli_writes_json_and_markdown(self) -> None:
         with tempfile.TemporaryDirectory() as temp_text:
@@ -346,6 +379,125 @@ class RequestLogTests(unittest.TestCase):
             rows = HARNESS.read_request_log(db, ["external"])
             self.assertEqual(rows[0]["request_id"], "internal")
             self.assertNotIn("buyer_ip", rows[0])
+
+
+class LiveDispatchTests(unittest.TestCase):
+    def test_streaming_sentinel_signals_admission_and_uses_uuid_v4(self) -> None:
+        state = HARNESS.LiveState()
+        args = SimpleNamespace(
+            buyer_url="http://127.0.0.1:19443/v1/chat/completions",
+            max_requests=20,
+            max_tokens=16,
+            model="model-a",
+            request_timeout_seconds=30,
+            sentinel_max_tokens=128,
+        )
+        release_response = threading.Event()
+        observed: dict[str, Any] = {}
+
+        def fake_http_once(url, method, headers, body, timeout_seconds, on_first_body_bytes=None):
+            observed["url"] = url
+            observed["method"] = method
+            observed["headers"] = headers
+            observed["body"] = json.loads(body)
+            observed["timeout_seconds"] = timeout_seconds
+            if on_first_body_bytes is not None:
+                on_first_body_bytes(
+                    200,
+                    {
+                        "content-type": "text/event-stream; charset=utf-8",
+                        "x-request-id": headers["X-Request-Id"],
+                    },
+                )
+            release_response.wait(2)
+            return (
+                200,
+                {
+                    "content-type": "text/event-stream; charset=utf-8",
+                    "x-request-id": headers["X-Request-Id"],
+                },
+                b'data: {"choices":[{"delta":{"content":"ok"}}]}\n\ndata: [DONE]\n\n',
+            )
+
+        original_http_once = HARNESS.http_once
+        HARNESS.http_once = fake_http_once
+        try:
+            thread = threading.Thread(
+                target=HARNESS.issue_buyer_once,
+                args=("sentinel", args, "buyer-token", time.monotonic() + 5, state),
+            )
+            thread.start()
+            self.assertTrue(state.sentinel_admitted_event.wait(1))
+            self.assertTrue(thread.is_alive())
+            release_response.set()
+            thread.join(2)
+        finally:
+            release_response.set()
+            HARNESS.http_once = original_http_once
+
+        self.assertFalse(thread.is_alive())
+        request_id = observed["headers"]["X-Request-Id"]
+        self.assertEqual(uuid.UUID(request_id).version, 4)
+        self.assertTrue(observed["body"]["stream"])
+        self.assertEqual(len(state.requests), 1)
+        self.assertIn("admitted_at", state.requests[0])
+        self.assertEqual(state.requests[0]["outcome"], "ok")
+
+    def test_streaming_sentinel_rejects_invalid_admission_headers(self) -> None:
+        state = HARNESS.LiveState()
+        args = SimpleNamespace(
+            buyer_url="http://127.0.0.1:19443/v1/chat/completions",
+            max_requests=20,
+            max_tokens=16,
+            model="model-a",
+            request_timeout_seconds=30,
+            sentinel_max_tokens=128,
+        )
+
+        def fake_http_once(url, method, headers, body, timeout_seconds, on_first_body_bytes=None):
+            if on_first_body_bytes is not None:
+                on_first_body_bytes(
+                    200,
+                    {
+                        "content-type": "application/json",
+                        "x-request-id": headers["X-Request-Id"],
+                    },
+                )
+            return 200, {}, b"{}"
+
+        original_http_once = HARNESS.http_once
+        HARNESS.http_once = fake_http_once
+        try:
+            HARNESS.issue_buyer_once(
+                "sentinel", args, "buyer-token", time.monotonic() + 5, state
+            )
+        finally:
+            HARNESS.http_once = original_http_once
+
+        self.assertFalse(state.sentinel_admitted_event.is_set())
+        self.assertTrue(state.dispatch_stop.is_set())
+        self.assertEqual(state.requests[0]["outcome"], "transport_error")
+        self.assertIn("not text/event-stream", state.requests[0]["error"])
+
+    def test_streaming_response_requires_choices_and_done(self) -> None:
+        with self.assertRaisesRegex(HARNESS.HarnessError, "terminal"):
+            HARNESS.validate_streaming_buyer_response(b'data: {"choices":[]}\n\n')
+
+    def test_streaming_response_rejects_empty_choice_object(self) -> None:
+        with self.assertRaisesRegex(HARNESS.HarnessError, "choices"):
+            HARNESS.validate_streaming_buyer_response(
+                b'data: {"choices":[{}]}\n\ndata: [DONE]\n\n'
+            )
+
+    def test_streaming_response_rejects_error_object(self) -> None:
+        with self.assertRaisesRegex(HARNESS.HarnessError, "error object"):
+            HARNESS.validate_streaming_buyer_response(
+                b'data: {"error":{"code":"provider_failed"}}\n\ndata: [DONE]\n\n'
+            )
+
+    def test_streaming_response_rejects_invalid_utf8(self) -> None:
+        with self.assertRaisesRegex(HARNESS.HarnessError, "UTF-8"):
+            HARNESS.validate_streaming_buyer_response(b"data: \xff\n\ndata: [DONE]\n\n")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- replace pool `Busy` polling with a bounded streaming sentinel whose first validated response bytes prove admission
- generate canonical UUIDv4 buyer request IDs and require exact gateway/request-log preservation
- fail closed on malformed/error SSE evidence and update the runbook plus hermetic fixtures
- repair the provider-side rekey test fixture to declare the now-required compatibility policy

## Root cause

G-req attempt 004 exercised the product successfully, but the evidence harness failed for two harness-only reasons. With provider concurrency 2, one active sentinel correctly left the provider `ready`, so `Busy` was not an admission signal. The harness also supplied non-UUID request IDs, which the gateway correctly replaced, breaking request-log correlation.

The request-threshold sequencing remains unchanged: `threshold - 1` completed warmups plus the admitted sentinel reach the threshold; the trigger then initiates rekey while old-epoch work is active.

## Validation

- 27 Python harness tests
- Python bytecode compilation and `git diff --check`
- four coordinator request/age threshold continuity and drain-barrier tests
- four gateway UUID/request-ID/streaming tests
- Swift `testInBandAEADRekeyProvesFreshKeysBeforeSameSessionCutover`
- independent full-diff code review: no findings

## Boundary

This PR does not authorize or execute another physical gate. Attempt 004 remains consumed; G-req attempt 005 and G-age each require separate explicit one-shot approval.

SPEC-GOVERNANCE-DECLARATION-BEGIN
{
  "schema_version": "spec-pr-governance-v1",
  "behavior_change": "yes",
  "contract_change": "none",
  "specs": ["SPEC-008"],
  "requirements": [],
  "authority_domains": ["provider-wire-protocol", "tier2-trust-evidence"],
  "arbitration": ["CODE_BUG"],
  "tests": [
    "test/e2e/aead-rekey-oneshot/test_aead_rekey_oneshot.py",
    "phase4-coordinator/internal/ws/relay_test.go",
    "phase4-coordinator/internal/ws/server_test.go",
    "phase3-binary/Tests/macprovider-cliTests/CoordinatorClientTests.swift"
  ],
  "journeys": ["not-required"],
  "issue": "https://github.com/Augustas11/macprovider/issues/540"
}
SPEC-GOVERNANCE-DECLARATION-END

No tracked conformance requirement currently represents SPEC-008 AC-B-7, so `requirements` is intentionally empty rather than citing unrelated `SPEC-008-R001`. The advisory governance check may reject that honest gap.

Refs #540