### PR TITLE
Prove and reopen Malibu after app updates

### DIFF
--- a/phase3-binary/app/Sources/Malibu/Agent/MalibuAgent.swift
+++ b/phase3-binary/app/Sources/Malibu/Agent/MalibuAgent.swift
@@ -56,15 +56,32 @@ final class MalibuAgent: ObservableObject {
     private var admissionIdentityRecoveryTask: Task<Void, Never>?
     private var referralStatusExpiryTask: Task<Void, Never>?
     private let referralActionWatchdog = ReferralActionWatchdog()
+    private let cliUpdateRunner: @Sendable (
+        _ installedVersion: String?,
+        _ compatibilitySetID: String?,
+        _ onLogLine: @escaping @Sendable @MainActor (String) -> Void
+    ) async throws -> Void
     private var lastReferralRefreshRequestedAt: Date?
     private let latestReleaseTTL: TimeInterval = 3600
 
     init(
         initialSnapshot: AgentSnapshot = .empty,
-        projectionEligibleForMetrics: Bool = false
+        projectionEligibleForMetrics: Bool = false,
+        cliUpdateRunner: @escaping @Sendable (
+            _ installedVersion: String?,
+            _ compatibilitySetID: String?,
+            _ onLogLine: @escaping @Sendable @MainActor (String) -> Void
+        ) async throws -> Void = { installedVersion, compatibilitySetID, onLogLine in
+            try await CLIUpdateRunner.run(
+                installedVersion: installedVersion,
+                compatibilitySetID: compatibilitySetID,
+                onLogLine: onLogLine
+            )
+        }
     ) {
         snapshot = initialSnapshot
         providerProjectionEligible = projectionEligibleForMetrics
+        self.cliUpdateRunner = cliUpdateRunner
         thermalMonitor.$state
             .sink { [weak self] state in
                 self?.snapshot.thermalState = state
@@ -320,10 +337,7 @@ final class MalibuAgent: ObservableObject {
         cliUpdateTask = Task { [weak self] in
             guard let self else { return }
             do {
-                try await CLIUpdateRunner.run(
-                    installedVersion: installedVersion,
-                    compatibilitySetID: compatibilitySetID
-                ) { line in
+                try await self.cliUpdateRunner(installedVersion, compatibilitySetID) { line in
                     self.logLines.append(LogTailBuffer.redacted(line))
                     if self.logLines.count > 400 {
                         self.logLines.removeFirst(self.logLines.count - 400)

--- a/phase3-binary/app/Sources/Malibu/System/CLIUpdateRunner.swift
+++ b/phase3-binary/app/Sources/Malibu/System/CLIUpdateRunner.swift
@@ -1,4 +1,7 @@
+import AppKit
+import CryptoKit
 import Foundation
+import Security
 
 enum CLIUpdateRunner {
     // Legacy repair pins exactly the CLI version this app shipped as. The
@@ -14,16 +17,51 @@ enum CLIUpdateRunner {
         case pinnedInstaller(version: String)
     }
 
+    struct RunningAppSnapshot: Equatable {
+        let bundleURL: URL
+        let version: String?
+        let build: String?
+    }
+
+    struct UpdatedAppRelaunchPlan: Equatable {
+        let bundleURL: URL
+        let previousVersion: String?
+        let previousBuild: String?
+        let installedVersion: String
+        let installedBuild: String?
+        let expectedVersion: String
+    }
+
+    struct ExpectedAppIdentity: Equatable {
+        let version: String
+        let compatibilitySetID: String?
+        let compatibilityManifestBytes: Data?
+
+        init(
+            version: String,
+            compatibilitySetID: String? = nil,
+            compatibilityManifestBytes: Data? = nil
+        ) {
+            self.version = version
+            self.compatibilitySetID = compatibilitySetID
+            self.compatibilityManifestBytes = compatibilityManifestBytes
+        }
+    }
+
     enum Error: Swift.Error, LocalizedError {
         case cliNotFound
         case invalidInstalledVersion(String?)
         case legacyBootstrapUnavailable(appVersion: String?)
         case legacyBootstrapWouldDowngrade(installedVersion: String)
+        case appBundleDidNotUpdate(expectedVersion: String, installedVersion: String?)
+        case appBundleSignatureInvalid
+        case appUpdateProofUnavailable
         case nonZeroExit(Int32)
         case rollbackRestored(Int32)
         case rollbackFailed(Int32)
         case readinessFailed
         case launchFailed(String)
+        case appRelaunchFailed(String)
 
         var errorDescription: String? {
             switch self {
@@ -35,6 +73,12 @@ enum CLIUpdateRunner {
                 return "This provider requires Malibu v\(legacyBootstrapTarget) to install the required provider software (running \(appVersion.map { "v\($0)" } ?? "an unknown app version"))."
             case let .legacyBootstrapWouldDowngrade(installedVersion):
                 return "Malibu v\(legacyBootstrapTarget) will not downgrade provider software v\(installedVersion)."
+            case let .appBundleDidNotUpdate(expectedVersion, installedVersion):
+                return "Provider software update completed, but Malibu.app did not update to v\(expectedVersion) (installed \(installedVersion.map { "v\($0)" } ?? "version unknown")). Reopen Malibu from Applications and run Update again."
+            case .appBundleSignatureInvalid:
+                return "Provider software update completed, but the updated Malibu.app could not be verified. Reopen Malibu from Applications and run Update again."
+            case .appUpdateProofUnavailable:
+                return "Provider software update completed, but Malibu.app update proof could not be verified. Reopen Malibu from Applications and run Update again."
             case let .nonZeroExit(code):
                 return "Provider software update failed (exit \(code))."
             case let .rollbackRestored(code):
@@ -45,6 +89,8 @@ enum CLIUpdateRunner {
                 return "Provider update installed but did not become ready for customer work."
             case let .launchFailed(message):
                 return "Could not start provider software update: \(message)"
+            case let .appRelaunchFailed(message):
+                return "Malibu updated, but could not reopen the new app: \(message)"
             }
         }
     }
@@ -104,18 +150,20 @@ enum CLIUpdateRunner {
     static func run(
         installedVersion: String?,
         compatibilitySetID: String?,
+        relaunchUpdatedApp: @escaping @Sendable @MainActor (UpdatedAppRelaunchPlan) async throws -> Void = { plan in
+            try await defaultRelaunchUpdatedApp(plan)
+        },
         onLogLine: @escaping @Sendable @MainActor (String) -> Void
     ) async throws {
         let appVersion = Bundle.main.object(
             forInfoDictionaryKey: "CFBundleShortVersionString"
         ) as? String
-        let selectedStrategy = try strategy(
+        let runningApp = runningAppSnapshot()
+        try await runForTest(
             installedVersion: installedVersion,
             compatibilitySetID: compatibilitySetID,
-            bundledAppVersion: appVersion
-        )
-        try await runStrategyForTest(
-            strategy: selectedStrategy,
+            bundledAppVersion: appVersion,
+            runningApp: runningApp,
             installedUpdate: {
                 let executable = try resolveExecutableURL()
                 try await runCommand(
@@ -133,8 +181,69 @@ enum CLIUpdateRunner {
                     onLogLine: onLogLine
                 )
             },
-            readinessCheck: { await waitForBuyerServing() }
+            readinessCheck: { await waitForBuyerServing() },
+            expectedAppIdentityAfterUpdate: { strategy, runningApp in
+                try CLIUpdateRunner.expectedAppIdentityAfterUpdate(
+                    strategy: strategy,
+                    runningApp: runningApp
+                )
+            },
+            isUpdaterOwnedInstall: { url in
+                isUpdaterOwnedMalibuInstall(url)
+            },
+            validateAppSignature: { url in
+                validateMalibuAppCodeSignature(at: url)
+            },
+            relaunchUpdatedApp: relaunchUpdatedApp,
+            onLogLine: onLogLine
         )
+    }
+
+    static func runForTest(
+        installedVersion: String?,
+        compatibilitySetID: String?,
+        bundledAppVersion: String?,
+        runningApp: RunningAppSnapshot?,
+        installedUpdate: @escaping @Sendable () async throws -> Void,
+        pinnedInstall: @escaping @Sendable (String) async throws -> Void,
+        readinessCheck: @escaping @Sendable () async -> Bool,
+        expectedAppIdentityAfterUpdate: @escaping @Sendable (Strategy, RunningAppSnapshot?) throws -> ExpectedAppIdentity?,
+        isUpdaterOwnedInstall: @escaping @Sendable (URL) -> Bool = { _ in true },
+        validateAppSignature: @escaping @Sendable (URL) -> Bool = { _ in true },
+        relaunchUpdatedApp: @escaping @Sendable @MainActor (UpdatedAppRelaunchPlan) async throws -> Void,
+        onLogLine: @escaping @Sendable @MainActor (String) -> Void
+    ) async throws {
+        let selectedStrategy = try strategy(
+            installedVersion: installedVersion,
+            compatibilitySetID: compatibilitySetID,
+            bundledAppVersion: bundledAppVersion
+        )
+        try await runStrategyForTest(
+            strategy: selectedStrategy,
+            installedUpdate: installedUpdate,
+            pinnedInstall: pinnedInstall,
+            readinessCheck: readinessCheck
+        )
+        let expectedAppIdentity = try expectedAppIdentityAfterUpdate(
+            selectedStrategy,
+            runningApp
+        )
+        try validatePostUpdateCompatibilitySetAdvanced(
+            strategy: selectedStrategy,
+            previousCompatibilitySetID: compatibilitySetID,
+            expectedIdentity: expectedAppIdentity
+        )
+        if let relaunchPlan = try updatedAppRelaunchPlan(
+            runningApp: runningApp,
+            expectedIdentity: expectedAppIdentity,
+            isUpdaterOwnedInstall: isUpdaterOwnedInstall,
+            validateAppSignature: validateAppSignature
+        ) {
+            await onLogLine(
+                "[Malibu] Malibu.app v\(relaunchPlan.installedVersion) build \(relaunchPlan.installedBuild ?? "unknown") installed; reopening the updated app."
+            )
+            try await relaunchUpdatedApp(relaunchPlan)
+        }
     }
 
     static func runStrategyForTest(
@@ -256,6 +365,446 @@ enum CLIUpdateRunner {
                 "LC_ALL": "C",
             ]
         )
+    }
+
+    static func expectedAppIdentityFromManifestForTest(
+        manifestURL: URL,
+        publicKeyPEM: String
+    ) throws -> ExpectedAppIdentity {
+        try signedCompatibilitySetMalibuIdentity(from: manifestURL, publicKeyPEM: publicKeyPEM)
+    }
+
+    static func expectedAppIdentityFromInstalledProviderManifestForTest(
+        executableURL: URL,
+        publicKeyPEM: String
+    ) throws -> ExpectedAppIdentity {
+        try expectedAppIdentityFromInstalledProviderManifest(
+            executableURL: executableURL,
+            publicKeyPEM: publicKeyPEM
+        )
+    }
+
+    static func runningAppSnapshot(bundle: Bundle = .main) -> RunningAppSnapshot? {
+        guard bundle.bundleIdentifier == "tech.malibu.app",
+              bundle.bundleURL.lastPathComponent == "Malibu.app" else {
+            return nil
+        }
+        return RunningAppSnapshot(
+            bundleURL: bundle.bundleURL,
+            version: bundle.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String,
+            build: bundle.object(forInfoDictionaryKey: "CFBundleVersion") as? String
+        )
+    }
+
+    static func updatedAppRelaunchPlanForTest(
+        runningApp: RunningAppSnapshot?,
+        expectedIdentity: ExpectedAppIdentity?,
+        isUpdaterOwnedInstall: @escaping @Sendable (URL) -> Bool = { _ in true },
+        validateAppSignature: @escaping @Sendable (URL) -> Bool = { _ in true }
+    ) throws -> UpdatedAppRelaunchPlan? {
+        try updatedAppRelaunchPlan(
+            runningApp: runningApp,
+            expectedIdentity: expectedIdentity,
+            isUpdaterOwnedInstall: isUpdaterOwnedInstall,
+            validateAppSignature: validateAppSignature
+        )
+    }
+
+    private static func updatedAppRelaunchPlan(
+        runningApp: RunningAppSnapshot?,
+        expectedIdentity: ExpectedAppIdentity?,
+        isUpdaterOwnedInstall: @escaping @Sendable (URL) -> Bool = { url in
+            isUpdaterOwnedMalibuInstall(url)
+        },
+        validateAppSignature: @escaping @Sendable (URL) -> Bool = { url in
+            validateMalibuAppCodeSignature(at: url)
+        }
+    ) throws -> UpdatedAppRelaunchPlan? {
+        guard let runningApp else { return nil }
+        guard isUpdaterOwnedInstall(runningApp.bundleURL) else { return nil }
+        guard let expectedIdentity,
+              let expectedVersion = ProviderCLIVersion.strictNormalize(expectedIdentity.version) else {
+            return nil
+        }
+        guard let installed = readInstalledMalibuAppIdentity(at: runningApp.bundleURL) else {
+            throw Error.appBundleDidNotUpdate(
+                expectedVersion: expectedVersion,
+                installedVersion: nil
+            )
+        }
+        guard validateAppSignature(runningApp.bundleURL) else {
+            throw Error.appBundleSignatureInvalid
+        }
+        guard let normalizedInstalled = ProviderCLIVersion.strictNormalize(installed.version),
+              normalizedInstalled == expectedVersion else {
+            throw Error.appBundleDidNotUpdate(
+                expectedVersion: expectedVersion,
+                installedVersion: ProviderCLIVersion.strictNormalize(installed.version) ?? installed.version
+            )
+        }
+        try validateEmbeddedCompatibilityManifest(
+            in: runningApp.bundleURL,
+            expectedIdentity: expectedIdentity
+        )
+
+        let normalizedRunning = runningApp.version.flatMap(ProviderCLIVersion.strictNormalize)
+        let installedIsNewer = normalizedRunning.map {
+            ProviderCLIVersion.compare($0, normalizedInstalled) == .ascending
+        } ?? true
+        let buildIsNewer = normalizedRunning == normalizedInstalled && buildIsNewerOrChanged(
+            installed: installed.build,
+            running: runningApp.build
+        )
+        guard installedIsNewer || buildIsNewer else { return nil }
+        return UpdatedAppRelaunchPlan(
+            bundleURL: runningApp.bundleURL,
+            previousVersion: normalizedRunning ?? runningApp.version,
+            previousBuild: runningApp.build,
+            installedVersion: normalizedInstalled,
+            installedBuild: installed.build,
+            expectedVersion: expectedVersion
+        )
+    }
+
+    private static func readInstalledMalibuAppIdentity(
+        at bundleURL: URL,
+        fileManager: FileManager = .default
+    ) -> (version: String, build: String?)? {
+        let standardized = bundleURL.standardizedFileURL
+        guard standardized.lastPathComponent == "Malibu.app" else { return nil }
+        var info = stat()
+        guard lstat(standardized.path, &info) == 0,
+              (info.st_mode & S_IFMT) == S_IFDIR else {
+            return nil
+        }
+        let infoURL = standardized.appendingPathComponent("Contents/Info.plist")
+        guard fileManager.fileExists(atPath: infoURL.path),
+              let plistData = try? readRegularFile(infoURL, maximumBytes: 64 * 1_024),
+              let plist = try? PropertyListSerialization.propertyList(
+                from: plistData,
+                format: nil
+              ) as? [String: Any],
+              plist["CFBundleIdentifier"] as? String == "tech.malibu.app",
+              let version = plist["CFBundleShortVersionString"] as? String,
+              !version.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            return nil
+        }
+        return (version, plist["CFBundleVersion"] as? String)
+    }
+
+    private static func validateEmbeddedCompatibilityManifest(
+        in bundleURL: URL,
+        expectedIdentity: ExpectedAppIdentity
+    ) throws {
+        guard let expectedBytes = expectedIdentity.compatibilityManifestBytes else { return }
+        let embeddedManifestURL = bundleURL.standardizedFileURL
+            .appendingPathComponent("Contents/Resources/compatibility-set.json")
+        let embeddedBytes = try readRegularFile(
+            embeddedManifestURL,
+            maximumBytes: 1_048_576
+        )
+        guard embeddedBytes == expectedBytes else {
+            throw Error.appUpdateProofUnavailable
+        }
+    }
+
+    private static func expectedAppIdentityAfterUpdate(
+        strategy: Strategy,
+        runningApp: RunningAppSnapshot?
+    ) throws -> ExpectedAppIdentity? {
+        guard case .installedCompatibilityCLI = strategy,
+              let runningApp,
+              isUpdaterOwnedMalibuInstall(runningApp.bundleURL) else {
+            return nil
+        }
+        do {
+            let installedExecutable = try installedProviderExecutableForAppProof()
+            return try expectedAppIdentityFromInstalledProviderManifest(
+                executableURL: installedExecutable
+            )
+        } catch let error as Error {
+            throw error
+        } catch {
+            throw Error.appUpdateProofUnavailable
+        }
+    }
+
+    private static func expectedAppIdentityFromInstalledProviderManifest(
+        executableURL: URL,
+        publicKeyPEM: String = releasePublicKeyPEM
+    ) throws -> ExpectedAppIdentity {
+        let payloadDirectory = try installedProviderPayloadDirectory(for: executableURL)
+        return try signedCompatibilitySetMalibuIdentity(
+            from: payloadDirectory.appendingPathComponent("compatibility-set.json"),
+            publicKeyPEM: publicKeyPEM
+        )
+    }
+
+    private static func installedProviderExecutableForAppProof() throws -> URL {
+        let executable = URL(fileURLWithPath: installedCLIPath()).standardizedFileURL
+        _ = try installedProviderPayloadDirectory(for: executable)
+        return executable
+    }
+
+    private static func installedProviderPayloadDirectory(for executableURL: URL) throws -> URL {
+        let executable = executableURL.standardizedFileURL
+        guard executable.lastPathComponent == "macprovider-cli" else {
+            throw Error.appUpdateProofUnavailable
+        }
+        var info = stat()
+        guard lstat(executable.path, &info) == 0,
+              (info.st_mode & S_IFMT) == S_IFREG,
+              info.st_size > 0,
+              access(executable.path, X_OK) == 0 else {
+            throw Error.appUpdateProofUnavailable
+        }
+        return executable.deletingLastPathComponent()
+    }
+
+    private static func signedCompatibilitySetMalibuIdentity(
+        from manifestURL: URL,
+        publicKeyPEM: String = releasePublicKeyPEM
+    ) throws -> ExpectedAppIdentity {
+        let data = try readRegularFile(manifestURL, maximumBytes: 1_048_576)
+        guard let envelope = try JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            throw Error.appUpdateProofUnavailable
+        }
+        guard Set(envelope.keys) == Set(["schema_version", "signatures", "signed"]),
+              envelope["schema_version"] as? String == "macprovider.compatibility-set-envelope.v1",
+              canonicalEnvelopeBytes(envelope) == data else {
+            throw Error.appUpdateProofUnavailable
+        }
+        guard let signatures = envelope["signatures"] as? [Any],
+              signatures.count == 1,
+              let signature = signatures.first as? [String: Any],
+              Set(signature.keys) == Set(["algorithm", "key_id", "signature"]),
+              signature["algorithm"] as? String == "ecdsa-p256-sha256",
+              signature["key_id"] as? String == "macprovider-release-p256-v1",
+              let encodedSignature = signature["signature"] as? String,
+              let signatureData = Data(base64Encoded: encodedSignature),
+              signatureData.base64EncodedString() == encodedSignature,
+              (64...80).contains(signatureData.count),
+              let signed = envelope["signed"] as? [String: Any],
+              let signedBytes = signedCanonicalBytes(signed),
+              signatureIsValid(
+                signatureData: signatureData,
+                signedBytes: signedBytes,
+                publicKeyPEM: publicKeyPEM
+              ) else {
+            throw Error.appUpdateProofUnavailable
+        }
+        guard signed["schema_version"] as? String == "macprovider.compatibility-set.v1",
+              let compatibilitySetID = signed["compatibility_set_id"] as? String,
+              isValidCompatibilitySetID(compatibilitySetID),
+              let components = signed["components"] as? [String: Any],
+              let malibuApp = components["malibu_app"] as? [String: Any],
+              Set(malibuApp.keys) == Set([
+                "activation", "bundle_id", "compatibility_handoff",
+                "minimum_status_reader", "version",
+              ]),
+              malibuApp["activation"] as? String == "cli_owned_if_installed",
+              malibuApp["bundle_id"] as? String == "tech.malibu.app",
+              (malibuApp["minimum_status_reader"] as? NSNumber)?.intValue == 1,
+              let handoff = malibuApp["compatibility_handoff"] as? [String: Any],
+              Set(handoff.keys) == Set([
+                "delivery", "embedded_manifest_path", "provider_mutation", "reader_compatibility",
+              ]),
+              handoff["delivery"] as? String == "signed_dmg_transaction_member",
+              handoff["embedded_manifest_path"] as? String == "Contents/Resources/compatibility-set.json",
+              handoff["provider_mutation"] as? String == "forbidden",
+              handoff["reader_compatibility"] as? String == "backward_compatible",
+              let version = malibuApp["version"] as? String,
+              ProviderCLIVersion.strictNormalize(version) == version else {
+            throw Error.appUpdateProofUnavailable
+        }
+        return ExpectedAppIdentity(
+            version: version,
+            compatibilitySetID: compatibilitySetID,
+            compatibilityManifestBytes: data
+        )
+    }
+
+    private static func validatePostUpdateCompatibilitySetAdvanced(
+        strategy: Strategy,
+        previousCompatibilitySetID: String?,
+        expectedIdentity: ExpectedAppIdentity?
+    ) throws {
+        guard case .installedCompatibilityCLI = strategy else { return }
+        guard let previous = previousCompatibilitySetID?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !previous.isEmpty else {
+            return
+        }
+        guard let next = expectedIdentity?.compatibilitySetID,
+              isValidCompatibilitySetID(next),
+              next != previous else {
+            throw Error.appUpdateProofUnavailable
+        }
+    }
+
+    private static func isValidCompatibilitySetID(_ value: String) -> Bool {
+        let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard trimmed == value,
+              !value.isEmpty,
+              value.utf8.count <= 512 else {
+            return false
+        }
+        return value.range(
+            of: #"^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+:v[0-9]+\.[0-9]+\.[0-9]+@[0-9a-f]{40}$"#,
+            options: .regularExpression
+        ) != nil
+    }
+
+    private static func readRegularFile(_ url: URL, maximumBytes: Int) throws -> Data {
+        var info = stat()
+        guard lstat(url.path, &info) == 0,
+              (info.st_mode & S_IFMT) == S_IFREG,
+              info.st_size >= 0,
+              info.st_size <= maximumBytes else {
+            throw Error.appUpdateProofUnavailable
+        }
+        let descriptor = open(url.path, O_RDONLY | O_CLOEXEC | O_NOFOLLOW)
+        guard descriptor >= 0 else { throw Error.appUpdateProofUnavailable }
+        defer { close(descriptor) }
+        var opened = stat()
+        guard fstat(descriptor, &opened) == 0,
+              opened.st_dev == info.st_dev,
+              opened.st_ino == info.st_ino,
+              (opened.st_mode & S_IFMT) == S_IFREG,
+              opened.st_size >= 0,
+              opened.st_size <= maximumBytes else {
+            throw Error.appUpdateProofUnavailable
+        }
+        var data = Data()
+        data.reserveCapacity(Int(opened.st_size))
+        var buffer = [UInt8](repeating: 0, count: 16 * 1_024)
+        while true {
+            let count = read(descriptor, &buffer, buffer.count)
+            if count < 0, errno == EINTR { continue }
+            guard count >= 0 else { throw Error.appUpdateProofUnavailable }
+            if count == 0 { break }
+            guard data.count + count <= maximumBytes else {
+                throw Error.appUpdateProofUnavailable
+            }
+            data.append(buffer, count: count)
+        }
+        return data
+    }
+
+    private static func signedCanonicalBytes(_ signed: [String: Any]) -> Data? {
+        guard var signedBytes = canonicalJSON(signed) else { return nil }
+        signedBytes.append(0x0a)
+        return signedBytes
+    }
+
+    private static func canonicalEnvelopeBytes(_ envelope: [String: Any]) -> Data? {
+        guard var envelopeBytes = canonicalJSON(envelope) else { return nil }
+        envelopeBytes.append(0x0a)
+        return envelopeBytes
+    }
+
+    private static func canonicalJSON(_ object: Any) -> Data? {
+        try? JSONSerialization.data(
+            withJSONObject: object,
+            options: [.sortedKeys, .withoutEscapingSlashes]
+        )
+    }
+
+    private static let releasePublicKeyPEM = """
+        -----BEGIN PUBLIC KEY-----
+        MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEwwd0Vzj35OP8DlZU+0lUa8vI9gHK
+        09J48LDizWScsH6rutnZLkKnGQ4X5Q8lT9L5mglF8Ba0DDoUXKrFfSAX4Q==
+        -----END PUBLIC KEY-----
+        """
+
+    private static func signatureIsValid(
+        signatureData: Data,
+        signedBytes: Data,
+        publicKeyPEM: String
+    ) -> Bool {
+        do {
+            let publicKey = try P256.Signing.PublicKey(pemRepresentation: publicKeyPEM)
+            let signature = try P256.Signing.ECDSASignature(derRepresentation: signatureData)
+            return publicKey.isValidSignature(signature, for: SHA256.hash(data: signedBytes))
+        } catch {
+            return false
+        }
+    }
+
+    private static func isUpdaterOwnedMalibuInstall(_ url: URL) -> Bool {
+        let standardized = url.standardizedFileURL
+        let perUser = FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent("Applications/Malibu.app", isDirectory: true)
+            .standardizedFileURL
+        let system = URL(fileURLWithPath: "/Applications/Malibu.app", isDirectory: true)
+            .standardizedFileURL
+        return standardized == system || standardized == perUser
+    }
+
+    private static func validateMalibuAppCodeSignature(at appURL: URL) -> Bool {
+        var staticCode: SecStaticCode?
+        guard SecStaticCodeCreateWithPath(appURL as CFURL, [], &staticCode) == errSecSuccess,
+              let staticCode else {
+            return false
+        }
+        let requirementText = "identifier \"tech.malibu.app\" and anchor apple generic and certificate leaf[subject.OU] = \"YF7XNRJUG4\""
+        var requirement: SecRequirement?
+        guard SecRequirementCreateWithString(requirementText as CFString, [], &requirement) == errSecSuccess,
+              let requirement else {
+            return false
+        }
+        return SecStaticCodeCheckValidity(
+            staticCode,
+            SecCSFlags(rawValue: kSecCSStrictValidate | kSecCSCheckAllArchitectures),
+            requirement
+        ) == errSecSuccess
+    }
+
+    private static func buildIsNewerOrChanged(installed: String?, running: String?) -> Bool {
+        guard let installed = installed?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !installed.isEmpty else {
+            return false
+        }
+        guard let running = running?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !running.isEmpty else {
+            return true
+        }
+        if let installedNumber = Int(installed), let runningNumber = Int(running) {
+            return installedNumber > runningNumber
+        }
+        return installed != running
+    }
+
+    @MainActor
+    private static func defaultRelaunchUpdatedApp(_ plan: UpdatedAppRelaunchPlan) async throws {
+        guard validateMalibuAppCodeSignature(at: plan.bundleURL) else {
+            throw Error.appBundleSignatureInvalid
+        }
+        try await openUpdatedApp(at: plan.bundleURL)
+        NSApp.terminate(nil)
+    }
+
+    private static func openUpdatedApp(at bundleURL: URL) async throws {
+        try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Swift.Error>) in
+            DispatchQueue.global(qos: .userInitiated).async {
+                let process = Process()
+                process.executableURL = URL(fileURLWithPath: "/usr/bin/open")
+                process.arguments = ["-n", bundleURL.path]
+                do {
+                    try process.run()
+                } catch {
+                    continuation.resume(throwing: Error.appRelaunchFailed(error.localizedDescription))
+                    return
+                }
+                process.waitUntilExit()
+                guard process.terminationStatus == 0 else {
+                    continuation.resume(
+                        throwing: Error.appRelaunchFailed("open exited \(process.terminationStatus)")
+                    )
+                    return
+                }
+                continuation.resume(returning: ())
+            }
+        }
     }
 
     private static func waitForBuyerServing(timeout: TimeInterval = 90) async -> Bool {

--- a/phase3-binary/app/Tests/MalibuTests/CLIUpdateRunnerTests.swift
+++ b/phase3-binary/app/Tests/MalibuTests/CLIUpdateRunnerTests.swift
@@ -1,3 +1,4 @@
+import CryptoKit
 import Foundation
 import XCTest
 @testable import Malibu
@@ -260,6 +261,456 @@ final class CLIUpdateRunnerTests: XCTestCase {
             readinessCheck: { true }
         )
     }
+
+    func testRunHandoffInvokesRelaunchAfterInstalledCompatibilityUpdate() async throws {
+        let manifestBytes = Data("signed compatibility set".utf8)
+        let app = try makeTemporaryMalibuApp(
+            version: "1.8.93",
+            build: "930",
+            embeddedCompatibilityManifestData: manifestBytes
+        )
+        let running = CLIUpdateRunner.RunningAppSnapshot(
+            bundleURL: app,
+            version: "1.8.92",
+            build: "920"
+        )
+        let recorder = CLIUpdateRunRecorder()
+
+        try await CLIUpdateRunner.runForTest(
+            installedVersion: "1.8.33",
+            compatibilitySetID: "Augustas11/macprovider:v1.8.33@abc123",
+            bundledAppVersion: "1.8.92",
+            runningApp: running,
+            installedUpdate: { recorder.recordInstalledUpdate() },
+            pinnedInstall: { version in recorder.recordPinnedInstall(version) },
+            readinessCheck: {
+                recorder.recordReadiness()
+                return true
+            },
+            expectedAppIdentityAfterUpdate: { strategy, runningApp in
+                recorder.recordExpectedProof(strategy: strategy, runningApp: runningApp)
+                return .init(
+                    version: "1.8.93",
+                    compatibilitySetID: "Augustas11/macprovider:v1.8.93@0123456789abcdef0123456789abcdef01234567",
+                    compatibilityManifestBytes: manifestBytes
+                )
+            },
+            relaunchUpdatedApp: { plan in recorder.recordRelaunch(plan) },
+            onLogLine: { line in recorder.recordLog(line) }
+        )
+
+        let result = recorder.snapshot()
+        XCTAssertEqual(result.installedUpdates, 1)
+        XCTAssertEqual(result.pinnedVersions, [])
+        XCTAssertEqual(result.readinessChecks, 1)
+        XCTAssertEqual(result.proofStrategies, [.installedCompatibilityCLI])
+        XCTAssertEqual(result.proofSnapshots, [running])
+        XCTAssertEqual(result.relaunchPlans, [
+            .init(
+                bundleURL: app,
+                previousVersion: "1.8.92",
+                previousBuild: "920",
+                installedVersion: "1.8.93",
+                installedBuild: "930",
+                expectedVersion: "1.8.93"
+            ),
+        ])
+        XCTAssertEqual(
+            result.logLines,
+            ["[Malibu] Malibu.app v1.8.93 build 930 installed; reopening the updated app."]
+        )
+    }
+
+    func testRunHandoffRejectsStalePostUpdateManifestInsteadOfSilentNoop() async throws {
+        let app = try makeTemporaryMalibuApp(version: "1.8.92", build: "920")
+        let running = CLIUpdateRunner.RunningAppSnapshot(
+            bundleURL: app,
+            version: "1.8.92",
+            build: "920"
+        )
+
+        do {
+            try await CLIUpdateRunner.runForTest(
+                installedVersion: "1.8.33",
+                compatibilitySetID: "Augustas11/macprovider:v1.8.92@aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+                bundledAppVersion: "1.8.92",
+                runningApp: running,
+                installedUpdate: {},
+                pinnedInstall: { _ in XCTFail("installed strategy should not call pinned installer") },
+                readinessCheck: { true },
+                expectedAppIdentityAfterUpdate: { _, _ in
+                    .init(
+                        version: "1.8.92",
+                        compatibilitySetID: "Augustas11/macprovider:v1.8.92@aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+                    )
+                },
+                relaunchUpdatedApp: { _ in XCTFail("stale manifest must not relaunch or silently succeed") },
+                onLogLine: { _ in }
+            )
+            XCTFail("stale post-update manifest unexpectedly returned success")
+        } catch let error as CLIUpdateRunner.Error {
+            XCTAssertEqual(
+                error.localizedDescription,
+                "Provider software update completed, but Malibu.app update proof could not be verified. Reopen Malibu from Applications and run Update again."
+            )
+        }
+    }
+
+    @MainActor
+    func testAgentUpdateCLINowInvokesUpdateRunnerFromPublicAction() async throws {
+        var snapshot = AgentSnapshot.empty
+        snapshot.cliVersion = "1.8.92"
+        snapshot.latestReleaseVersion = "1.8.93"
+        snapshot.compatibilitySetID = "Augustas11/macprovider:v1.8.92@aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+        let recorder = CLIUpdateAgentRecorder()
+        let agent = MalibuAgent(
+            initialSnapshot: snapshot,
+            cliUpdateRunner: { installedVersion, compatibilitySetID, onLogLine in
+                recorder.recordInvocation(
+                    installedVersion: installedVersion,
+                    compatibilitySetID: compatibilitySetID
+                )
+                await onLogLine("provider update started")
+            }
+        )
+
+        await agent.updateCLINow()
+
+        XCTAssertEqual(recorder.snapshot(), [
+            .init(
+                installedVersion: "1.8.92",
+                compatibilitySetID: "Augustas11/macprovider:v1.8.92@aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+            ),
+        ])
+        XCTAssertEqual(agent.logLines, ["provider update started"])
+        XCTAssertFalse(agent.snapshot.cliUpdateInProgress)
+        XCTAssertNil(agent.snapshot.cliUpdateLastError)
+    }
+
+    func testExpectedManifestAppVersionMismatchFailsInsteadOfSilentNoop() throws {
+        let app = try makeTemporaryMalibuApp(version: "1.8.92", build: "92")
+        let running = CLIUpdateRunner.RunningAppSnapshot(
+            bundleURL: app,
+            version: "1.8.92",
+            build: "92"
+        )
+
+        XCTAssertThrowsError(
+            try CLIUpdateRunner.updatedAppRelaunchPlanForTest(
+                runningApp: running,
+                expectedIdentity: .init(version: "1.8.93")
+            )
+        ) { error in
+            XCTAssertEqual(
+                error.localizedDescription,
+                "Provider software update completed, but Malibu.app did not update to v1.8.93 (installed v1.8.92). Reopen Malibu from Applications and run Update again."
+            )
+        }
+    }
+
+    func testNewlyInstalledAppVersionPlansRelaunch() throws {
+        let app = try makeTemporaryMalibuApp(version: "1.8.93", build: "930")
+        let running = CLIUpdateRunner.RunningAppSnapshot(
+            bundleURL: app,
+            version: "1.8.92",
+            build: "920"
+        )
+
+        let plan = try XCTUnwrap(CLIUpdateRunner.updatedAppRelaunchPlanForTest(
+            runningApp: running,
+            expectedIdentity: .init(version: "1.8.93")
+        ))
+        XCTAssertEqual(plan.bundleURL, app.standardizedFileURL)
+        XCTAssertEqual(plan.previousVersion, "1.8.92")
+        XCTAssertEqual(plan.previousBuild, "920")
+        XCTAssertEqual(plan.installedVersion, "1.8.93")
+        XCTAssertEqual(plan.installedBuild, "930")
+        XCTAssertEqual(plan.expectedVersion, "1.8.93")
+    }
+
+    func testSameVersionNewerBuildPlansRelaunch() throws {
+        let app = try makeTemporaryMalibuApp(version: "1.8.93", build: "931")
+        let running = CLIUpdateRunner.RunningAppSnapshot(
+            bundleURL: app,
+            version: "1.8.93",
+            build: "930"
+        )
+
+        let plan = try XCTUnwrap(CLIUpdateRunner.updatedAppRelaunchPlanForTest(
+            runningApp: running,
+            expectedIdentity: .init(version: "1.8.93")
+        ))
+        XCTAssertEqual(plan.previousVersion, "1.8.93")
+        XCTAssertEqual(plan.previousBuild, "930")
+        XCTAssertEqual(plan.installedVersion, "1.8.93")
+        XCTAssertEqual(plan.installedBuild, "931")
+    }
+
+    func testCurrentAppVersionDoesNotRelaunchWithoutExpectedTarget() throws {
+        let app = try makeTemporaryMalibuApp(version: "1.8.93", build: "930")
+        let running = CLIUpdateRunner.RunningAppSnapshot(
+            bundleURL: app,
+            version: "1.8.93",
+            build: "930"
+        )
+
+        XCTAssertNil(try CLIUpdateRunner.updatedAppRelaunchPlanForTest(
+            runningApp: running,
+            expectedIdentity: nil
+        ))
+    }
+
+    func testNonUpdaterOwnedAppPathDoesNotEnforceRelaunch() throws {
+        let app = try makeTemporaryMalibuApp(version: "1.8.92", build: "92")
+        let running = CLIUpdateRunner.RunningAppSnapshot(
+            bundleURL: app,
+            version: "1.8.92",
+            build: "92"
+        )
+
+        XCTAssertNil(try CLIUpdateRunner.updatedAppRelaunchPlanForTest(
+            runningApp: running,
+            expectedIdentity: .init(version: "1.8.93"),
+            isUpdaterOwnedInstall: { _ in false }
+        ))
+    }
+
+    func testUnverifiedUpdatedAppFailsBeforeRelaunch() throws {
+        let app = try makeTemporaryMalibuApp(version: "1.8.93", build: "930")
+        let running = CLIUpdateRunner.RunningAppSnapshot(
+            bundleURL: app,
+            version: "1.8.92",
+            build: "920"
+        )
+
+        XCTAssertThrowsError(
+            try CLIUpdateRunner.updatedAppRelaunchPlanForTest(
+                runningApp: running,
+                expectedIdentity: .init(version: "1.8.93"),
+                validateAppSignature: { _ in false }
+            )
+        ) { error in
+            XCTAssertEqual(
+                error.localizedDescription,
+                "Provider software update completed, but the updated Malibu.app could not be verified. Reopen Malibu from Applications and run Update again."
+            )
+        }
+    }
+
+    func testMissingEmbeddedCompatibilityManifestFailsBeforeRelaunch() throws {
+        let app = try makeTemporaryMalibuApp(version: "1.8.93", build: "930")
+        let running = CLIUpdateRunner.RunningAppSnapshot(
+            bundleURL: app,
+            version: "1.8.92",
+            build: "920"
+        )
+
+        XCTAssertThrowsError(
+            try CLIUpdateRunner.updatedAppRelaunchPlanForTest(
+                runningApp: running,
+                expectedIdentity: .init(
+                    version: "1.8.93",
+                    compatibilitySetID: "Augustas11/macprovider:v1.8.93@0123456789abcdef0123456789abcdef01234567",
+                    compatibilityManifestBytes: Data("expected manifest".utf8)
+                )
+            )
+        ) { error in
+            XCTAssertEqual(
+                error.localizedDescription,
+                "Provider software update completed, but Malibu.app update proof could not be verified. Reopen Malibu from Applications and run Update again."
+            )
+        }
+    }
+
+    func testMismatchedEmbeddedCompatibilityManifestFailsBeforeRelaunch() throws {
+        let app = try makeTemporaryMalibuApp(
+            version: "1.8.93",
+            build: "930",
+            embeddedCompatibilityManifestData: Data("different manifest".utf8)
+        )
+        let running = CLIUpdateRunner.RunningAppSnapshot(
+            bundleURL: app,
+            version: "1.8.92",
+            build: "920"
+        )
+
+        XCTAssertThrowsError(
+            try CLIUpdateRunner.updatedAppRelaunchPlanForTest(
+                runningApp: running,
+                expectedIdentity: .init(
+                    version: "1.8.93",
+                    compatibilitySetID: "Augustas11/macprovider:v1.8.93@0123456789abcdef0123456789abcdef01234567",
+                    compatibilityManifestBytes: Data("expected manifest".utf8)
+                )
+            )
+        ) { error in
+            XCTAssertEqual(
+                error.localizedDescription,
+                "Provider software update completed, but Malibu.app update proof could not be verified. Reopen Malibu from Applications and run Update again."
+            )
+        }
+    }
+
+    func testSignedCompatibilityManifestProvidesExpectedAppVersion() throws {
+        let fixture = try makeSignedCompatibilityManifest(malibuVersion: "1.8.94")
+        let manifestBytes = try Data(contentsOf: fixture.manifest)
+
+        let identity = try CLIUpdateRunner.expectedAppIdentityFromManifestForTest(
+            manifestURL: fixture.manifest,
+            publicKeyPEM: fixture.publicKeyPEM
+        )
+
+        XCTAssertEqual(
+            identity,
+            .init(
+                version: "1.8.94",
+                compatibilitySetID: "Augustas11/macprovider:v1.8.94@0123456789abcdef0123456789abcdef01234567",
+                compatibilityManifestBytes: manifestBytes
+            )
+        )
+    }
+
+    func testMissingCompatibilityManifestFailsClosed() throws {
+        let signingKey = P256.Signing.PrivateKey()
+        let missing = FileManager.default.temporaryDirectory
+            .appendingPathComponent("missing-compatibility-set-\(UUID().uuidString).json")
+
+        XCTAssertThrowsError(
+            try CLIUpdateRunner.expectedAppIdentityFromManifestForTest(
+                manifestURL: missing,
+                publicKeyPEM: signingKey.publicKey.pemRepresentation
+            )
+        ) { error in
+            XCTAssertEqual(
+                error.localizedDescription,
+                "Provider software update completed, but Malibu.app update proof could not be verified. Reopen Malibu from Applications and run Update again."
+            )
+        }
+    }
+
+    func testUnsignedCompatibilityManifestFailsClosed() throws {
+        let fixture = try makeSignedCompatibilityManifest(malibuVersion: "1.8.94")
+        try rewriteManifest(fixture.manifest) { envelope in envelope["signatures"] = [] }
+
+        XCTAssertThrowsError(
+            try CLIUpdateRunner.expectedAppIdentityFromManifestForTest(
+                manifestURL: fixture.manifest,
+                publicKeyPEM: fixture.publicKeyPEM
+            )
+        ) { error in
+            XCTAssertEqual(
+                error.localizedDescription,
+                "Provider software update completed, but Malibu.app update proof could not be verified. Reopen Malibu from Applications and run Update again."
+            )
+        }
+    }
+
+    func testTamperedCompatibilityManifestFailsClosed() throws {
+        let fixture = try makeSignedCompatibilityManifest(malibuVersion: "1.8.94")
+        try rewriteManifest(fixture.manifest) { envelope in
+            guard var signed = envelope["signed"] as? [String: Any],
+                  var components = signed["components"] as? [String: Any],
+                  var malibuApp = components["malibu_app"] as? [String: Any] else {
+                return XCTFail("fixture missing signed Malibu app section")
+            }
+            malibuApp["version"] = "1.8.95"
+            components["malibu_app"] = malibuApp
+            signed["components"] = components
+            envelope["signed"] = signed
+        }
+
+        XCTAssertThrowsError(
+            try CLIUpdateRunner.expectedAppIdentityFromManifestForTest(
+                manifestURL: fixture.manifest,
+                publicKeyPEM: fixture.publicKeyPEM
+            )
+        ) { error in
+            XCTAssertEqual(
+                error.localizedDescription,
+                "Provider software update completed, but Malibu.app update proof could not be verified. Reopen Malibu from Applications and run Update again."
+            )
+        }
+    }
+
+    func testWrongCompatibilityManifestKeyFailsClosed() throws {
+        let fixture = try makeSignedCompatibilityManifest(malibuVersion: "1.8.94")
+        let wrongKey = P256.Signing.PrivateKey()
+
+        XCTAssertThrowsError(
+            try CLIUpdateRunner.expectedAppIdentityFromManifestForTest(
+                manifestURL: fixture.manifest,
+                publicKeyPEM: wrongKey.publicKey.pemRepresentation
+            )
+        ) { error in
+            XCTAssertEqual(
+                error.localizedDescription,
+                "Provider software update completed, but Malibu.app update proof could not be verified. Reopen Malibu from Applications and run Update again."
+            )
+        }
+    }
+
+    func testWrongCompatibilityHandoffMetadataFailsClosed() throws {
+        let fixture = try makeSignedCompatibilityManifest(
+            malibuVersion: "1.8.94",
+            handoffDelivery: "zip"
+        )
+
+        XCTAssertThrowsError(
+            try CLIUpdateRunner.expectedAppIdentityFromManifestForTest(
+                manifestURL: fixture.manifest,
+                publicKeyPEM: fixture.publicKeyPEM
+            )
+        ) { error in
+            XCTAssertEqual(
+                error.localizedDescription,
+                "Provider software update completed, but Malibu.app update proof could not be verified. Reopen Malibu from Applications and run Update again."
+            )
+        }
+    }
+
+    func testInstalledManifestProofRequiresInstalledProviderPayload() throws {
+        let fixture = try makeSignedCompatibilityManifest(malibuVersion: "1.8.94")
+        let manifestBytes = try Data(contentsOf: fixture.manifest)
+        let executable = fixture.manifest.deletingLastPathComponent()
+            .appendingPathComponent("macprovider-cli")
+        try Data("#!/bin/sh\n".utf8).write(to: executable)
+        try FileManager.default.setAttributes(
+            [.posixPermissions: 0o755],
+            ofItemAtPath: executable.path
+        )
+
+        let identity = try CLIUpdateRunner.expectedAppIdentityFromInstalledProviderManifestForTest(
+            executableURL: executable,
+            publicKeyPEM: fixture.publicKeyPEM
+        )
+
+        XCTAssertEqual(
+            identity,
+            .init(
+                version: "1.8.94",
+                compatibilitySetID: "Augustas11/macprovider:v1.8.94@0123456789abcdef0123456789abcdef01234567",
+                compatibilityManifestBytes: manifestBytes
+            )
+        )
+    }
+
+    func testInstalledManifestProofRejectsMissingProviderExecutable() throws {
+        let fixture = try makeSignedCompatibilityManifest(malibuVersion: "1.8.94")
+        let missingExecutable = fixture.manifest.deletingLastPathComponent()
+            .appendingPathComponent("macprovider-cli")
+
+        XCTAssertThrowsError(
+            try CLIUpdateRunner.expectedAppIdentityFromInstalledProviderManifestForTest(
+                executableURL: missingExecutable,
+                publicKeyPEM: fixture.publicKeyPEM
+            )
+        ) { error in
+            XCTAssertEqual(
+                error.localizedDescription,
+                "Provider software update completed, but Malibu.app update proof could not be verified. Reopen Malibu from Applications and run Update again."
+            )
+        }
+    }
 }
 
 private actor CLIUpdateInvocationRecorder {
@@ -281,5 +732,202 @@ private actor CLIUpdateInvocationRecorder {
 
     func snapshot() -> (installedUpdates: Int, pinnedVersions: [String], readinessChecks: Int) {
         (installedUpdates, pinnedVersions, readinessChecks)
+    }
+}
+
+private final class CLIUpdateRunRecorder: @unchecked Sendable {
+    private let lock = NSLock()
+    private var installedUpdates = 0
+    private var pinnedVersions: [String] = []
+    private var readinessChecks = 0
+    private var proofStrategies: [CLIUpdateRunner.Strategy] = []
+    private var proofSnapshots: [CLIUpdateRunner.RunningAppSnapshot?] = []
+    private var relaunchPlans: [CLIUpdateRunner.UpdatedAppRelaunchPlan] = []
+    private var logLines: [String] = []
+
+    func recordInstalledUpdate() {
+        lock.withLock { installedUpdates += 1 }
+    }
+
+    func recordPinnedInstall(_ version: String) {
+        lock.withLock { pinnedVersions.append(version) }
+    }
+
+    func recordReadiness() {
+        lock.withLock { readinessChecks += 1 }
+    }
+
+    func recordExpectedProof(
+        strategy: CLIUpdateRunner.Strategy,
+        runningApp: CLIUpdateRunner.RunningAppSnapshot?
+    ) {
+        lock.withLock {
+            proofStrategies.append(strategy)
+            proofSnapshots.append(runningApp)
+        }
+    }
+
+    func recordRelaunch(_ plan: CLIUpdateRunner.UpdatedAppRelaunchPlan) {
+        lock.withLock { relaunchPlans.append(plan) }
+    }
+
+    func recordLog(_ line: String) {
+        lock.withLock { logLines.append(line) }
+    }
+
+    func snapshot() -> (
+        installedUpdates: Int,
+        pinnedVersions: [String],
+        readinessChecks: Int,
+        proofStrategies: [CLIUpdateRunner.Strategy],
+        proofSnapshots: [CLIUpdateRunner.RunningAppSnapshot?],
+        relaunchPlans: [CLIUpdateRunner.UpdatedAppRelaunchPlan],
+        logLines: [String]
+    ) {
+        lock.withLock {
+            (
+                installedUpdates,
+                pinnedVersions,
+                readinessChecks,
+                proofStrategies,
+                proofSnapshots,
+                relaunchPlans,
+                logLines
+            )
+        }
+    }
+}
+
+private final class CLIUpdateAgentRecorder: @unchecked Sendable {
+    struct Invocation: Equatable {
+        let installedVersion: String?
+        let compatibilitySetID: String?
+    }
+
+    private let lock = NSLock()
+    private var invocations: [Invocation] = []
+
+    func recordInvocation(installedVersion: String?, compatibilitySetID: String?) {
+        lock.withLock {
+            invocations.append(
+                .init(
+                    installedVersion: installedVersion,
+                    compatibilitySetID: compatibilitySetID
+                )
+            )
+        }
+    }
+
+    func snapshot() -> [Invocation] {
+        lock.withLock { invocations }
+    }
+}
+
+private extension XCTestCase {
+    func makeTemporaryMalibuApp(
+        version: String,
+        build: String,
+        embeddedCompatibilityManifestData: Data? = nil
+    ) throws -> URL {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("malibu-update-test-\(UUID().uuidString)", isDirectory: true)
+        let app = root.appendingPathComponent("Malibu.app", isDirectory: true).standardizedFileURL
+        let contents = app.appendingPathComponent("Contents", isDirectory: true)
+        try FileManager.default.createDirectory(at: contents, withIntermediateDirectories: true)
+        let info = try PropertyListSerialization.data(
+            fromPropertyList: [
+                "CFBundleIdentifier": "tech.malibu.app",
+                "CFBundleShortVersionString": version,
+                "CFBundleVersion": build,
+                "CFBundleExecutable": "Malibu",
+            ],
+            format: .xml,
+            options: 0
+        )
+        try info.write(to: contents.appendingPathComponent("Info.plist"))
+        if let embeddedCompatibilityManifestData {
+            let resources = contents.appendingPathComponent("Resources", isDirectory: true)
+            try FileManager.default.createDirectory(at: resources, withIntermediateDirectories: true)
+            try embeddedCompatibilityManifestData.write(
+                to: resources.appendingPathComponent("compatibility-set.json")
+            )
+        }
+        addTeardownBlock {
+            try? FileManager.default.removeItem(at: root)
+        }
+        return app
+    }
+
+    func makeSignedCompatibilityManifest(
+        malibuVersion: String,
+        compatibilitySetID: String? = nil,
+        handoffDelivery: String = "signed_dmg_transaction_member"
+    ) throws -> (manifest: URL, publicKeyPEM: String) {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("malibu-manifest-test-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        let signingKey = P256.Signing.PrivateKey()
+        let setID = compatibilitySetID
+            ?? "Augustas11/macprovider:v\(malibuVersion)@0123456789abcdef0123456789abcdef01234567"
+        let signed: [String: Any] = [
+            "schema_version": "macprovider.compatibility-set.v1",
+            "compatibility_set_id": setID,
+            "components": [
+                "malibu_app": [
+                    "activation": "cli_owned_if_installed",
+                    "bundle_id": "tech.malibu.app",
+                    "compatibility_handoff": [
+                        "delivery": handoffDelivery,
+                        "embedded_manifest_path": "Contents/Resources/compatibility-set.json",
+                        "provider_mutation": "forbidden",
+                        "reader_compatibility": "backward_compatible",
+                    ],
+                    "minimum_status_reader": 1,
+                    "version": malibuVersion,
+                ],
+            ],
+        ]
+        var signedData = try JSONSerialization.data(
+            withJSONObject: signed,
+            options: [.sortedKeys, .withoutEscapingSlashes]
+        )
+        signedData.append(0x0a)
+        let signature = try signingKey.signature(for: SHA256.hash(data: signedData))
+        let envelope: [String: Any] = [
+            "schema_version": "macprovider.compatibility-set-envelope.v1",
+            "signatures": [[
+                "algorithm": "ecdsa-p256-sha256",
+                "key_id": "macprovider-release-p256-v1",
+                "signature": signature.derRepresentation.base64EncodedString(),
+            ]],
+            "signed": signed,
+        ]
+        var envelopeData = try JSONSerialization.data(
+            withJSONObject: envelope,
+            options: [.sortedKeys, .withoutEscapingSlashes]
+        )
+        envelopeData.append(0x0a)
+        let manifest = root.appendingPathComponent("compatibility-set.json")
+        try envelopeData.write(to: manifest)
+        addTeardownBlock {
+            try? FileManager.default.removeItem(at: root)
+        }
+        return (manifest, signingKey.publicKey.pemRepresentation)
+    }
+
+    func rewriteManifest(
+        _ manifest: URL,
+        mutateEnvelope: (inout [String: Any]) throws -> Void
+    ) throws {
+        var envelope = try XCTUnwrap(
+            JSONSerialization.jsonObject(with: Data(contentsOf: manifest)) as? [String: Any]
+        )
+        try mutateEnvelope(&envelope)
+        var data = try JSONSerialization.data(
+            withJSONObject: envelope,
+            options: [.sortedKeys, .withoutEscapingSlashes]
+        )
+        data.append(0x0a)
+        try data.write(to: manifest)
     }
 }


### PR DESCRIPTION
## Summary

Fixes #989 by making Malibu's Update action prove and reopen the updated app after the provider CLI updater completes.

Changes:
- Adds an injectable `MalibuAgent` runner seam so the public update action is covered by regression tests.
- After an installed compatibility-aware CLI update, verifies the signed installed compatibility manifest and requires the compatibility-set ID to advance.
- Validates the installed `Malibu.app` bundle identity, version/build, Team ID code signature, and byte-identical embedded `Contents/Resources/compatibility-set.json` before relaunch.
- Reopens the updated app when the app version/build advanced; stale, missing, unsigned, tampered, mismatched, or unverified proofs fail closed.

## Root cause

The Update button delegated to the provider CLI updater, which could replace the installed app bundle, but the running Malibu process stayed on the old executable and the app-side handoff did not independently prove or reopen the updated `Malibu.app`.

## Validation

- `git diff --check`
- `xcodebuild test -project Malibu.xcodeproj -scheme Malibu -configuration Debug -destination 'platform=macOS' -only-testing:MalibuTests/CLIUpdateRunnerTests` — 35 tests, 0 failures
- `xcodebuild test -project Malibu.xcodeproj -scheme Malibu -configuration Debug -destination 'platform=macOS'` — 387 tests, 0 failures
- 3-lane Codex audit:
  - Code: 0 CRITICAL / 0 HIGH / 0 MEDIUM
  - Security: 0 CRITICAL / 0 HIGH / 0 MEDIUM; 2 LOW hardening notes carried
  - Architecture: 0 CRITICAL / 0 HIGH / 0 MEDIUM

## Release gate not completed in this PR

This is code-level and unit/integration test proof. Issue #989 still requires packaged release/E2E proof before the next Malibu release is cut: previous-stable-to-candidate signed DMG update, byte identity between standalone and embedded CLIs, `macprovider-cli update --check`, and live reopen/dashboard verification.

SPEC-GOVERNANCE-DECLARATION-BEGIN
{
  "schema_version": "spec-pr-governance-v1",
  "behavior_change": "yes",
  "contract_change": "none",
  "specs": ["SPEC-020"],
  "requirements": ["SPEC-020-R003", "SPEC-020-R004"],
  "authority_domains": ["provider-autoupdate"],
  "arbitration": ["CODE_BUG"],
  "tests": [
    "xcodebuild test -project Malibu.xcodeproj -scheme Malibu -configuration Debug -destination 'platform=macOS' -only-testing:MalibuTests/CLIUpdateRunnerTests",
    "xcodebuild test -project Malibu.xcodeproj -scheme Malibu -configuration Debug -destination 'platform=macOS'"
  ],
  "journeys": ["not-required"],
  "issue": "https://github.com/Augustas11/macprovider/issues/989"
}
SPEC-GOVERNANCE-DECLARATION-END
