### PR TITLE
Add verified agent onboarding skill publication

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -75,6 +75,8 @@ test-dist:
 	bash scripts/test-release-publication-provenance.sh
 	bash scripts/test-compatibility-set-manifest.sh
 	bash scripts/test-compatibility-artifact-index.sh
+	bash scripts/test-agent-onboarding-skill.sh
+	bash scripts/test-agent-onboarding-publication.sh
 	bash scripts/test-release-discovery-head.sh
 	bash scripts/test-release-discovery-transport.sh
 	bash scripts/test-renew-release-discovery-head.sh

--- a/README.md
+++ b/README.md
@@ -103,6 +103,8 @@ bash install.sh
 
 The binary is checksum-verified against a signed release manifest. macOS quarantine (`xattr`) is cleared with your approval during install. Developer ID signing and notarization are planned for a future release.
 
+Agent-readable onboarding source lives in [docs/agent-onboarding/SKILL.md](docs/agent-onboarding/SKILL.md). The canonical publication targets are [get.malibu.tech/skill.md](https://get.malibu.tech/skill.md) and [get.malibu.tech/.well-known/skills/index.json](https://get.malibu.tech/.well-known/skills/index.json).
+
 ## For Buyers
 
 Base URL: `https://api.malibu.tech`

--- a/docs/agent-onboarding/.well-known/skills/index.json
+++ b/docs/agent-onboarding/.well-known/skills/index.json
@@ -1,0 +1,15 @@
+{
+  "schema_version": "https://get.malibu.tech/.well-known/skills/index.v1",
+  "updated_at": "2026-08-16",
+  "skills": [
+    {
+      "id": "macprovider-agent-onboarding",
+      "name": "MacProvider Agent Onboarding",
+      "description": "Agent-readable MacProvider provider onboarding, recovery, uninstall, and buyer SDK compatibility guidance.",
+      "url": "https://get.malibu.tech/skill.md",
+      "source_path": "docs/agent-onboarding/SKILL.md",
+      "content_type": "text/markdown; charset=utf-8",
+      "sha256": "12053c20a33f4c49b9eab1d1a3eeed867bdcec0944b8845a1c1eb172a3f3a4fa"
+    }
+  ]
+}

--- a/docs/agent-onboarding/SKILL.md
+++ b/docs/agent-onboarding/SKILL.md
@@ -1,0 +1,168 @@
+# MacProvider Agent Onboarding Skill
+
+Canonical publication URL: `https://get.malibu.tech/skill.md`
+Discovery index publication URL: `https://get.malibu.tech/.well-known/skills/index.json`
+Source path: `docs/agent-onboarding/SKILL.md`
+Last updated: 2026-08-16
+
+Use this skill when an agent needs to help a provider install, repair,
+inspect, update, or uninstall MacProvider, or when a buyer wants to use
+MacProvider through an OpenAI-compatible SDK.
+
+## Safety Rules
+
+- Never print secrets. Redact provider tokens, buyer API keys, Keychain values,
+  signing keys, coordinator environment values, SSH keys, and release signing
+  material.
+- Default to non-production local smoke checks. Production coordinator changes,
+  release publication, billing, payout, auth, operator key, and live deployment
+  work require explicit operator approval.
+- Do not run destructive commands such as uninstall, credential rotation,
+  release promotion, or production deploy scripts unless the operator asked for
+  that exact action.
+- Do not inspect `d-inference` source. It is outside the clean-room boundary.
+- Use `malibu.tech` URLs. Do not introduce legacy `streamvc.live` URLs.
+
+## Provider Install
+
+Target host: Apple Silicon Mac, macOS 14 or newer.
+
+Inspect the installer first when possible:
+
+```bash
+tmp_install="$(mktemp "${TMPDIR:-/tmp}/macprovider-install.XXXXXX")"
+chmod 600 "$tmp_install"
+curl -fsSL --proto '=https' --tlsv1.2 --remove-on-error https://get.malibu.tech/install.sh -o "$tmp_install" &&
+  less "$tmp_install" &&
+  bash "$tmp_install"
+rm -f "$tmp_install"
+```
+
+For unattended local smoke checks only, use documented installer environment
+variables such as `MACPROVIDER_NO_PROMPT=1`, `MACPROVIDER_NO_LAUNCHD=1`,
+`MACPROVIDER_MODEL=...`, and `MACPROVIDER_COORDINATOR_URL=...`. Do not use
+non-interactive install mode against production credentials unless explicitly
+authorized.
+
+## Provider Status And Recovery
+
+Use the installed CLI before changing files by hand. These commands are
+read-only diagnostics:
+
+```bash
+macprovider-cli --version
+macprovider-cli status
+macprovider-cli status --json
+macprovider-cli status --advanced
+macprovider-cli update --check
+```
+
+Run the mutating updater only when the operator explicitly asks to update this
+provider, after `update --check` reports the target and after noting whether a
+launchd-managed service may restart:
+
+```bash
+macprovider-cli update
+macprovider-cli --version
+macprovider-cli status --advanced
+```
+
+If the CLI cannot reach the coordinator and reports an old public version,
+the public installer can perform an upgrade-in-place after it verifies signed
+release metadata and artifacts. Treat this as a mutating update path: run it
+only when the operator explicitly asks to update this provider, after noting
+the target version and whether a launchd-managed service may restart.
+
+```bash
+tmp_install="$(mktemp "${TMPDIR:-/tmp}/macprovider-install.XXXXXX")"
+chmod 600 "$tmp_install"
+curl -fsSL --proto '=https' --tlsv1.2 --remove-on-error https://get.malibu.tech/install.sh -o "$tmp_install" &&
+  bash "$tmp_install"
+rm -f "$tmp_install"
+```
+
+Useful local paths:
+
+- Config: `~/.config/macprovider/config.yaml`
+- Install directory: `~/macprovider`
+- LaunchAgent: `~/Library/LaunchAgents/live.malibu.provider.plist`
+- Logs: `~/Library/Logs/macprovider/`
+
+Do not print raw logs into a chat, ticket, or agent transcript. Logs may contain
+tokens, prompts, headers, local paths, and request/response bodies. Prefer the
+status commands above. If logs are required, use a maintained project redactor
+or a narrow local extractor that emits only allowlisted status fields.
+
+## Provider Uninstall
+
+Download the uninstaller once, inspect it, then run the same local bytes for
+dry-run and approved removal. Do not execute a second mutable network fetch for
+the real uninstall.
+
+```bash
+tmp_uninstall="$(mktemp "${TMPDIR:-/tmp}/macprovider-uninstall.XXXXXX")"
+chmod 600 "$tmp_uninstall"
+curl -fsSL --proto '=https' --tlsv1.2 --remove-on-error https://get.malibu.tech/uninstall.sh -o "$tmp_uninstall" &&
+  uninstall_sha="$(shasum -a 256 "$tmp_uninstall" | awk '{print $1}')" &&
+  less "$tmp_uninstall" &&
+  bash "$tmp_uninstall" --dry-run
+```
+
+Only remove the provider when the operator explicitly asks:
+
+```bash
+printf '%s  %s\n' "$uninstall_sha" "$tmp_uninstall" | shasum -a 256 -c -
+bash "$tmp_uninstall"
+rm -f "$tmp_uninstall"
+```
+
+## Buyer SDK Compatibility
+
+MacProvider is OpenAI-compatible. There is no separate `macprovider` SDK.
+
+Python:
+
+```python
+from openai import OpenAI
+
+client = OpenAI(
+    base_url="https://api.malibu.tech/v1",
+    api_key="<your-macprovider-api-key>",
+)
+```
+
+TypeScript:
+
+```typescript
+import OpenAI from "openai";
+
+const client = new OpenAI({
+  baseURL: "https://api.malibu.tech/v1",
+  apiKey: process.env.MACPROVIDER_API_KEY,
+});
+```
+
+Get a buyer API key at `https://api.malibu.tech/auth/github/start`.
+
+## Local Smoke Stop Condition
+
+A non-production onboarding smoke is complete when:
+
+1. `macprovider-cli --version` prints the installed version.
+2. `macprovider-cli status` or `macprovider-cli status --json` reaches the local
+   status endpoint.
+3. The provider either appears connected or reports a specific recoverable
+   coordinator/version/config error.
+4. No secret material was printed.
+5. No production deploy, release promotion, or credential mutation was run.
+
+## Authoritative References
+
+- `README.md`
+- `docs/using-macprovider-with-openai-sdk.md`
+- `docs/runbooks/provider-cli-release-verification.md`
+- `ops/runbooks/entry-610-first-hop-recovery.md`
+- `specs/SPEC-003-open-onboarding.md`
+- `specs/SPEC-006-buyer-api.md`
+- `specs/SPEC-020-provider-autoupdate.md`
+- `specs/SPEC-035-provider-connection-diagnostics.md`

--- a/scripts/install-agent-onboarding-publication.sh
+++ b/scripts/install-agent-onboarding-publication.sh
@@ -1,0 +1,194 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+die() {
+  printf '[install-agent-onboarding-publication] ERROR: %s\n' "$*" >&2
+  exit 1
+}
+
+[[ "$#" == 4 ]] || die "usage: WEBROOT SKILL INDEX VALIDATOR"
+webroot="$1"
+skill_source="$2"
+index_source="$3"
+validator="$4"
+
+[[ "$webroot" == /* ]] || die "webroot must be an absolute path"
+[[ "$webroot" =~ ^/[A-Za-z0-9._/-]+$ && "$webroot" != *'/../'* && "$webroot" != */.. ]] ||
+  die "unsafe webroot"
+
+testing="${MALIBU_PUBLICATION_TESTING:-0}"
+if [[ "$testing" == 1 ]]; then
+  trusted_uid="$(id -u)"
+  trusted_gid="$(id -g)"
+else
+  [[ "$(id -u)" == 0 ]] || die "production publication helper must run as root"
+  trusted_uid=0
+  trusted_gid=0
+fi
+
+for path in "$skill_source" "$index_source" "$validator"; do
+  [[ -f "$path" && ! -L "$path" ]] || die "expected regular staged input: $path"
+done
+
+PYTHONDONTWRITEBYTECODE=1 python3 "$validator" \
+  --skill "$skill_source" --index "$index_source" --no-reference-existence
+
+publication_id="$(python3 - "$testing" "$trusted_uid" "$skill_source" "$index_source" "$validator" <<'PY'
+import hashlib
+import json
+import pathlib
+import stat
+import sys
+
+testing, trusted_uid, skill_name, index_name, validator_name = sys.argv[1:]
+trusted_uid = int(trusted_uid)
+paths = [pathlib.Path(value) for value in (skill_name, index_name, validator_name)]
+for path in paths:
+    row = path.lstat()
+    if not stat.S_ISREG(row.st_mode) or row.st_uid != trusted_uid or row.st_nlink != 1:
+        raise SystemExit(f"unsafe staged input: {path}")
+    if stat.S_IMODE(row.st_mode) & 0o022:
+        raise SystemExit(f"staged input is group/world-writable: {path}")
+    if testing != "1" and stat.S_IMODE(row.st_mode) != 0o600:
+        raise SystemExit(f"staged input mode is not 0600: {path}")
+identity = {
+    "skill_sha256": hashlib.sha256(paths[0].read_bytes()).hexdigest(),
+    "index_sha256": hashlib.sha256(paths[1].read_bytes()).hexdigest(),
+}
+print(hashlib.sha256(json.dumps(identity, sort_keys=True, separators=(",", ":")).encode()).hexdigest())
+PY
+)"
+
+releases_dir="$webroot/.agent-onboarding-releases"
+release_dir="$releases_dir/$publication_id"
+stage="$releases_dir/.${publication_id}.stage.$$"
+current="$webroot/.agent-onboarding-current"
+temporary_links=()
+
+cleanup() {
+  rm -rf "$stage"
+  if ((${#temporary_links[@]})); then
+    rm -f "${temporary_links[@]}"
+  fi
+}
+trap cleanup EXIT
+
+validate_node() {
+  python3 - "$trusted_uid" "$trusted_gid" "$1" "$2" <<'PY'
+import pathlib
+import stat
+import sys
+
+uid, gid, raw_path, kind = int(sys.argv[1]), int(sys.argv[2]), sys.argv[3], sys.argv[4]
+path = pathlib.Path(raw_path)
+row = path.lstat()
+if row.st_uid != uid or row.st_gid != gid:
+    raise SystemExit(f"publication node has wrong owner: {path}")
+if kind == "dir":
+    if not stat.S_ISDIR(row.st_mode) or stat.S_IMODE(row.st_mode) != 0o755:
+        raise SystemExit(f"publication directory is not mode 0755: {path}")
+elif kind == "file":
+    if not stat.S_ISREG(row.st_mode) or row.st_nlink != 1 or stat.S_IMODE(row.st_mode) != 0o644:
+        raise SystemExit(f"publication file is not regular mode 0644: {path}")
+elif kind == "link":
+    if not stat.S_ISLNK(row.st_mode):
+        raise SystemExit(f"publication pointer is not a symlink: {path}")
+else:
+    raise SystemExit("invalid validation kind")
+PY
+}
+
+preflight_current_pointer() {
+  if [[ -L "$current" ]]; then
+    validate_node "$current" link
+    local target
+    target="$(readlink "$current")"
+    [[ "$target" =~ ^\.agent-onboarding-releases/[0-9a-f]{64}$ ]] ||
+      die "$current has an unexpected symlink target"
+    local target_dir="$webroot/$target"
+    [[ -d "$target_dir" && ! -L "$target_dir" ]] || die "current target is not an immutable release directory"
+    validate_node "$target_dir" dir
+    validate_node "$target_dir/skill.md" file
+    validate_node "$target_dir/.well-known" dir
+    validate_node "$target_dir/.well-known/skills" dir
+    validate_node "$target_dir/.well-known/skills/index.json" file
+  elif [[ -e "$current" ]]; then
+    die "$current is not a symlink"
+  fi
+}
+
+preflight_public_link() {
+  local path="$1" expected_target="$2"
+  if [[ -L "$path" ]]; then
+    validate_node "$path" link
+    [[ "$(readlink "$path")" == "$expected_target" ]] ||
+      die "$path has an unexpected symlink target"
+  elif [[ -e "$path" ]]; then
+    die "$path is not a symlink"
+  fi
+}
+
+preflight_existing_webroot() {
+  [[ -e "$webroot" ]] || return 0
+  validate_node "$webroot" dir
+  if [[ -e "$releases_dir" || -L "$releases_dir" ]]; then
+    validate_node "$releases_dir" dir
+  fi
+  if [[ -e "$webroot/.well-known" || -L "$webroot/.well-known" ]]; then
+    validate_node "$webroot/.well-known" dir
+  fi
+  if [[ -e "$webroot/.well-known/skills" || -L "$webroot/.well-known/skills" ]]; then
+    validate_node "$webroot/.well-known/skills" dir
+  fi
+  preflight_current_pointer
+  preflight_public_link "$webroot/skill.md" ".agent-onboarding-current/skill.md"
+  preflight_public_link "$webroot/.well-known/skills/index.json" \
+    "../../.agent-onboarding-current/.well-known/skills/index.json"
+}
+
+replace_symlink() {
+  local target="$1" destination="$2" temporary
+  temporary="${destination}.next.$$"
+  temporary_links+=("$temporary")
+  rm -f "$temporary"
+  ln -s "$target" "$temporary"
+  chown -h "$trusted_uid:$trusted_gid" "$temporary"
+  if mv --help 2>&1 | grep -q -- '--no-target-directory'; then
+    mv -Tf "$temporary" "$destination"
+  else
+    mv -fh "$temporary" "$destination"
+  fi
+}
+
+preflight_existing_webroot
+install -d -o "$trusted_uid" -g "$trusted_gid" -m 0755 \
+  "$webroot" "$releases_dir" "$webroot/.well-known" "$webroot/.well-known/skills"
+validate_node "$webroot" dir
+validate_node "$releases_dir" dir
+validate_node "$webroot/.well-known" dir
+validate_node "$webroot/.well-known/skills" dir
+
+install -d -o "$trusted_uid" -g "$trusted_gid" -m 0755 "$stage" "$stage/.well-known" "$stage/.well-known/skills"
+install -o "$trusted_uid" -g "$trusted_gid" -m 0644 "$skill_source" "$stage/skill.md"
+install -o "$trusted_uid" -g "$trusted_gid" -m 0644 "$index_source" "$stage/.well-known/skills/index.json"
+
+if [[ -d "$release_dir" && ! -L "$release_dir" ]]; then
+  validate_node "$release_dir/skill.md" file
+  validate_node "$release_dir/.well-known/skills/index.json" file
+  cmp -s "$stage/skill.md" "$release_dir/skill.md" ||
+    die "immutable agent skill release differs"
+  cmp -s "$stage/.well-known/skills/index.json" "$release_dir/.well-known/skills/index.json" ||
+    die "immutable agent index release differs"
+  rm -rf "$stage"
+elif [[ -e "$release_dir" || -L "$release_dir" ]]; then
+  die "agent release path is not an immutable directory: $release_dir"
+else
+  mv "$stage" "$release_dir"
+fi
+
+replace_symlink ".agent-onboarding-releases/$publication_id" "$current"
+replace_symlink ".agent-onboarding-current/skill.md" "$webroot/skill.md"
+replace_symlink "../../.agent-onboarding-current/.well-known/skills/index.json" \
+  "$webroot/.well-known/skills/index.json"
+
+printf '[install-agent-onboarding-publication] ok: %s -> %s\n' "$current" "$publication_id"

--- a/scripts/publish-agent-onboarding-skill.sh
+++ b/scripts/publish-agent-onboarding-skill.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+die() {
+  printf '[publish-agent-onboarding-skill] ERROR: %s\n' "$*" >&2
+  exit 1
+}
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+skill="${1:-$REPO_ROOT/docs/agent-onboarding/SKILL.md}"
+index="${2:-$REPO_ROOT/docs/agent-onboarding/.well-known/skills/index.json}"
+validator="$SCRIPT_DIR/verify-agent-onboarding-skill.py"
+helper="$SCRIPT_DIR/install-agent-onboarding-publication.sh"
+WEBROOT="${MALIBU_GET_WEBROOT:-/var/www/malibu-get}"
+GET_HOST="${MALIBU_GET_HOST:-get.malibu.tech}"
+VPS_HOST="${MALIBU_GET_VPS_HOST:-${MALIBU_DOWNLOAD_VPS_HOST:-159.223.165.194}}"
+SSH_KEY="${MALIBU_GET_SSH_KEY:-${MALIBU_DOWNLOAD_SSH_KEY:-$HOME/.ssh/pearl_operator_ed25519}}"
+VPS_USER="${MALIBU_GET_VPS_USER:-${MALIBU_DOWNLOAD_VPS_USER:-root}}"
+MALIBU_DOWNLOAD_KNOWN_HOSTS="${MALIBU_GET_KNOWN_HOSTS:-${MALIBU_DOWNLOAD_KNOWN_HOSTS:-$SCRIPT_DIR/dist/malibu-download-known_hosts}}"
+
+[[ "$WEBROOT" =~ ^/[A-Za-z0-9._/-]+$ && "$WEBROOT" != *'/../'* && "$WEBROOT" != */.. ]] ||
+  die "unsafe get webroot"
+[[ "$GET_HOST" == "get.malibu.tech" ]] || die "unexpected get host: $GET_HOST"
+[[ "$VPS_USER" == root ]] || die "get publication requires the root SSH account"
+[[ -f "$SSH_KEY" && ! -L "$SSH_KEY" ]] ||
+  die "SSH key missing or symlinked: $SSH_KEY (refusing partial get publication)"
+
+PYTHONDONTWRITEBYTECODE=1 python3 "$validator" --skill "$skill" --index "$index"
+
+# shellcheck source=scripts/malibu-download-ssh.sh
+source "$SCRIPT_DIR/malibu-download-ssh.sh"
+
+sha256_file() {
+  if command -v shasum >/dev/null 2>&1; then
+    shasum -a 256 "$1" | awk '{print $1}'
+  else
+    sha256sum "$1" | awk '{print $1}'
+  fi
+}
+
+remote_stage="$(malibu_download_ssh 'set -eu
+  umask 077
+  install -d -o root -g root -m 0700 /root/.malibu-agent-onboarding-publish
+  stage="$(mktemp -d /root/.malibu-agent-onboarding-publish/stage.XXXXXXXX)"
+  chown root:root "$stage"
+  chmod 0700 "$stage"
+  printf "%s\n" "$stage"')"
+[[ "$remote_stage" =~ ^/root/\.malibu-agent-onboarding-publish/stage\.[A-Za-z0-9]+$ ]] ||
+  die "Pearl returned an unsafe staging path"
+
+cleanup() {
+  if [[ -n "${remote_stage:-}" ]]; then
+    malibu_download_ssh "rm -rf -- '$remote_stage'" >/dev/null 2>&1 || true
+  fi
+}
+trap cleanup EXIT
+
+declare -a local_paths=("$skill" "$index" "$validator" "$helper")
+declare -a remote_names=(skill.md index.json validator.py install-helper)
+declare -a expected_hashes=()
+for i in "${!local_paths[@]}"; do
+  expected_hashes+=("$(sha256_file "${local_paths[$i]}")")
+  malibu_download_scp \
+    "${local_paths[$i]}" \
+    "$VPS_USER@$VPS_HOST:$remote_stage/${remote_names[$i]}" >/dev/null
+done
+
+specs=""
+for i in "${!remote_names[@]}"; do
+  mode=0600
+  [[ "${remote_names[$i]}" == install-helper ]] && mode=0700
+  specs+=" '${remote_names[$i]}:${expected_hashes[$i]}:$mode'"
+done
+
+malibu_download_ssh "set -euo pipefail
+  stage='$remote_stage'
+  cleanup_remote() { rm -rf -- \"\$stage\"; }
+  trap cleanup_remote EXIT
+  for spec in$specs; do
+    name=\"\${spec%%:*}\"
+    rest=\"\${spec#*:}\"
+    expected=\"\${rest%%:*}\"
+    mode=\"\${rest##*:}\"
+    path=\"\$stage/\$name\"
+    chown root:root \"\$path\"
+    chmod \"\$mode\" \"\$path\"
+    meta=\"\$(stat -c '%u:%g:%a:%h:%F' \"\$path\")\"
+    expected_meta=\"0:0:\${mode#0}:1:regular file\"
+    [ \"\$meta\" = \"\$expected_meta\" ] || {
+      echo \"unsafe transferred file \$path: \$meta\" >&2
+      exit 1
+    }
+    actual=\"\$(sha256sum \"\$path\" | awk '{print \$1}')\"
+    [ \"\$actual\" = \"\$expected\" ] || {
+      echo \"transferred sha256 mismatch for \$path\" >&2
+      exit 1
+    }
+  done
+  PYTHONDONTWRITEBYTECODE=1 python3 \"\$stage/validator.py\" \
+    --skill \"\$stage/skill.md\" \
+    --index \"\$stage/index.json\" \
+    --no-reference-existence
+  \"\$stage/install-helper\" '$WEBROOT' \
+    \"\$stage/skill.md\" \"\$stage/index.json\" \"\$stage/validator.py\"
+"
+remote_stage=""
+
+MALIBU_AGENT_ONBOARDING_HOST="$GET_HOST" \
+  bash "$SCRIPT_DIR/verify-agent-onboarding-hosted.sh" "$skill" "$index"
+
+printf '[publish-agent-onboarding-skill] ok: %s/skill.md\n' "$GET_HOST"

--- a/scripts/test-agent-onboarding-publication.sh
+++ b/scripts/test-agent-onboarding-publication.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+helper="$root/scripts/install-agent-onboarding-publication.sh"
+publisher="$root/scripts/publish-agent-onboarding-skill.sh"
+validator="$root/scripts/verify-agent-onboarding-skill.py"
+hosted_verifier="$root/scripts/verify-agent-onboarding-hosted.sh"
+skill="$root/docs/agent-onboarding/SKILL.md"
+index="$root/docs/agent-onboarding/.well-known/skills/index.json"
+
+fail() {
+  printf 'FAIL: %s\n' "$*" >&2
+  exit 1
+}
+
+for path in "$helper" "$publisher" "$validator" "$hosted_verifier" "$skill" "$index"; do
+  [[ -f "$path" && ! -L "$path" ]] || fail "missing regular input: $path"
+done
+bash -n "$helper"
+bash -n "$publisher"
+bash -n "$hosted_verifier"
+PYTHONDONTWRITEBYTECODE=1 python3 -m py_compile "$validator"
+if grep -F '?artifact=' "$hosted_verifier" >/dev/null; then
+  fail "hosted verifier must fetch canonical no-query URLs"
+fi
+
+work="$(mktemp -d "${TMPDIR:-/tmp}/agent-onboarding-publication.XXXXXX")"
+trap 'rm -rf "$work"' EXIT
+
+printf 'test ssh key\n' > "$work/test-ssh-key"
+chmod 600 "$work/test-ssh-key"
+SCRIPT_DIR="$root/scripts" \
+SSH_KEY="$work/test-ssh-key" \
+VPS_USER=root \
+VPS_HOST=127.0.0.1 \
+MALIBU_DOWNLOAD_KNOWN_HOSTS="$root/scripts/dist/malibu-download-known_hosts" \
+  bash -c 'source "$SCRIPT_DIR/malibu-download-ssh.sh"; type malibu_download_ssh >/dev/null'
+
+MALIBU_PUBLICATION_TESTING=1 bash "$helper" "$work/webroot" "$skill" "$index" "$validator"
+cmp -s "$skill" "$work/webroot/skill.md" || fail "published skill differs"
+cmp -s "$index" "$work/webroot/.well-known/skills/index.json" ||
+  fail "published discovery index differs"
+[[ -L "$work/webroot/skill.md" &&
+   "$(readlink "$work/webroot/skill.md")" == ".agent-onboarding-current/skill.md" ]] ||
+  fail "skill public entry is not current-pointer backed"
+[[ -L "$work/webroot/.well-known/skills/index.json" &&
+   "$(readlink "$work/webroot/.well-known/skills/index.json")" == "../../.agent-onboarding-current/.well-known/skills/index.json" ]] ||
+  fail "index public entry is not current-pointer backed"
+
+hostile="$work/hostile-webroot"
+mkdir -p "$hostile/.agent-onboarding-current/.well-known/skills" "$hostile/.well-known/skills"
+printf 'UNVALIDATED-SKILL\n' > "$hostile/.agent-onboarding-current/skill.md"
+printf 'UNVALIDATED-INDEX\n' > "$hostile/.agent-onboarding-current/.well-known/skills/index.json"
+ln -s ".agent-onboarding-current/skill.md" "$hostile/skill.md"
+ln -s "../../.agent-onboarding-current/.well-known/skills/index.json" \
+  "$hostile/.well-known/skills/index.json"
+if MALIBU_PUBLICATION_TESTING=1 bash "$helper" "$hostile" "$skill" "$index" "$validator" \
+  >"$work/hostile.out" 2>&1; then
+  fail "hostile existing current directory was accepted"
+fi
+grep -q '.agent-onboarding-current is not a symlink' "$work/hostile.out" ||
+  fail "hostile topology failure reason was unclear"
+grep -q 'UNVALIDATED-SKILL' "$hostile/skill.md" ||
+  fail "hostile topology changed public skill bytes"
+
+hostile_file="$work/hostile-file-webroot"
+mkdir -p "$hostile_file"
+printf 'UNVALIDATED-SKILL\n' > "$hostile_file/skill.md"
+if MALIBU_PUBLICATION_TESTING=1 bash "$helper" "$hostile_file" "$skill" "$index" "$validator" \
+  >"$work/hostile-file.out" 2>&1; then
+  fail "hostile existing public file was accepted"
+fi
+grep -q 'skill.md is not a symlink' "$work/hostile-file.out" ||
+  fail "hostile public file failure reason was unclear"
+[[ ! -e "$hostile_file/.agent-onboarding-releases" ]] ||
+  fail "hostile public file preflight created releases directory"
+[[ ! -e "$hostile_file/.well-known" ]] ||
+  fail "hostile public file preflight created well-known directory"
+grep -q 'UNVALIDATED-SKILL' "$hostile_file/skill.md" ||
+  fail "hostile public file bytes changed"
+
+cp "$skill" "$work/bad-skill.md"
+cp "$index" "$work/bad-index.json"
+printf '\ncurl -fsSL https://get.malibu.tech/install.sh | bash\n' >> "$work/bad-skill.md"
+python3 - "$work/bad-skill.md" "$work/bad-index.json" <<'PY'
+import hashlib
+import json
+import pathlib
+import sys
+
+skill, index = map(pathlib.Path, sys.argv[1:])
+payload = json.loads(index.read_text(encoding="utf-8"))
+payload["skills"][0]["sha256"] = hashlib.sha256(skill.read_bytes()).hexdigest()
+index.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+PY
+before="$(readlink "$work/webroot/.agent-onboarding-current")"
+if MALIBU_PUBLICATION_TESTING=1 bash "$helper" \
+  "$work/webroot" "$work/bad-skill.md" "$work/bad-index.json" "$validator" \
+  >"$work/bad.out" 2>&1; then
+  fail "unsafe agent onboarding publication was accepted"
+fi
+after="$(readlink "$work/webroot/.agent-onboarding-current")"
+[[ "$before" == "$after" ]] || fail "failed unsafe publication changed current pointer"
+grep -q 'forbidden pattern present:' "$work/bad.out" ||
+  fail "unsafe publication failure reason was unclear"
+
+printf 'Agent onboarding publication regression checks passed\n'

--- a/scripts/test-agent-onboarding-skill.sh
+++ b/scripts/test-agent-onboarding-skill.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PYTHONDONTWRITEBYTECODE=1 python3 "$REPO_ROOT/scripts/verify-agent-onboarding-skill.py" --self-test-negatives

--- a/scripts/verify-agent-onboarding-hosted.sh
+++ b/scripts/verify-agent-onboarding-hosted.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+die() {
+  printf '[verify-agent-onboarding-hosted] ERROR: %s\n' "$*" >&2
+  exit 1
+}
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+skill="${1:-$repo_root/docs/agent-onboarding/SKILL.md}"
+index="${2:-$repo_root/docs/agent-onboarding/.well-known/skills/index.json}"
+host="${MALIBU_AGENT_ONBOARDING_HOST:-get.malibu.tech}"
+base="https://${host}"
+
+[[ "$host" == "get.malibu.tech" ]] || die "unexpected agent onboarding host: $host"
+for path in "$skill" "$index"; do
+  [[ -f "$path" && ! -L "$path" ]] || die "expected regular local artifact: $path"
+done
+
+PYTHONDONTWRITEBYTECODE=1 python3 "$repo_root/scripts/verify-agent-onboarding-skill.py" \
+  --skill "$skill" --index "$index"
+
+work="$(mktemp -d "${RUNNER_TEMP:-${TMPDIR:-/tmp}}/agent-onboarding-public.XXXXXX")"
+trap 'rm -rf "$work"' EXIT
+
+curl_args=(
+  --fail --show-error --silent --location --proto '=https' --tlsv1.2
+  --connect-timeout 20 --max-time 120 --retry 3 --retry-delay 2
+)
+curl "${curl_args[@]}" -o "$work/skill.md" "${base}/skill.md"
+curl "${curl_args[@]}" -o "$work/index.json" \
+  "${base}/.well-known/skills/index.json"
+
+cmp -s "$skill" "$work/skill.md" ||
+  die "hosted skill bytes differ from repo source"
+cmp -s "$index" "$work/index.json" ||
+  die "hosted discovery index bytes differ from repo source"
+
+printf '[verify-agent-onboarding-hosted] ok: %s serves skill/index bytes\n' "$base"

--- a/scripts/verify-agent-onboarding-skill.py
+++ b/scripts/verify-agent-onboarding-skill.py
@@ -1,0 +1,281 @@
+#!/usr/bin/env python3
+"""Validate the hosted MacProvider agent onboarding skill source."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+import sys
+import tempfile
+import argparse
+from pathlib import Path
+from urllib.parse import urlparse
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SKILL_PATH = ROOT / "docs" / "agent-onboarding" / "SKILL.md"
+INDEX_PATH = ROOT / "docs" / "agent-onboarding" / ".well-known" / "skills" / "index.json"
+
+CANONICAL_SKILL_URL = "https://get.malibu.tech/skill.md"
+CANONICAL_INDEX_URL = "https://get.malibu.tech/.well-known/skills/index.json"
+
+REQUIRED_REFERENCES = [
+    "README.md",
+    "docs/using-macprovider-with-openai-sdk.md",
+    "docs/runbooks/provider-cli-release-verification.md",
+    "ops/runbooks/entry-610-first-hop-recovery.md",
+    "specs/SPEC-003-open-onboarding.md",
+    "specs/SPEC-006-buyer-api.md",
+    "specs/SPEC-020-provider-autoupdate.md",
+    "specs/SPEC-035-provider-connection-diagnostics.md",
+]
+
+REQUIRED_SKILL_SNIPPETS = [
+    CANONICAL_SKILL_URL,
+    CANONICAL_INDEX_URL,
+    "https://get.malibu.tech/install.sh",
+    "https://get.malibu.tech/uninstall.sh",
+    "https://api.malibu.tech/v1",
+    'tmp_install="$(mktemp "${TMPDIR:-/tmp}/macprovider-install.XXXXXX")',
+    "--remove-on-error https://get.malibu.tech/install.sh",
+    'bash "$tmp_install"',
+    "macprovider-cli status --json",
+    "macprovider-cli status --advanced",
+    "macprovider-cli update --check",
+    "--remove-on-error https://get.malibu.tech/uninstall.sh",
+    'uninstall_sha="$(shasum -a 256 "$tmp_uninstall"',
+    'bash "$tmp_uninstall" --dry-run',
+    "shasum -a 256 -c -",
+    'bash "$tmp_uninstall"',
+    "base_url=\"https://api.malibu.tech/v1\"",
+    "baseURL: \"https://api.malibu.tech/v1\"",
+]
+
+REQUIRED_GUARDRAILS = [
+    "never print secrets",
+    "non-production local smoke",
+    "explicit operator approval",
+    "do not run destructive commands",
+    "do not inspect `d-inference` source",
+    "do not introduce legacy `streamvc.live` urls",
+]
+
+FORBIDDEN_LITERAL_SNIPPETS = [
+    "sk-",
+    "ghp_",
+    "BEGIN PRIVATE KEY",
+    "bash <(",
+    "$(curl",
+    "`curl",
+    "bash -c",
+]
+
+FORBIDDEN_PATTERNS = [
+    re.compile(r"\|\s*(?:/usr/bin/env\s+)?(?:/bin/)?(?:bash|sh|zsh)(?:\s|$)"),
+]
+
+ALLOWED_URLS = {
+    "https://get.malibu.tech/skill.md",
+    "https://get.malibu.tech/.well-known/skills/index.json",
+    "https://get.malibu.tech/.well-known/skills/index.v1",
+    "https://get.malibu.tech/install.sh",
+    "https://get.malibu.tech/uninstall.sh",
+    "https://api.malibu.tech/v1",
+    "https://api.malibu.tech/auth/github/start",
+}
+URI_RE = re.compile(r"(?:\b[A-Za-z][A-Za-z0-9+.-]*:[^\s`<>\")]+|//[^\s`<>\")]+)")
+SUPPRESS_FAILURE_OUTPUT = False
+
+
+def fail(message: str) -> None:
+    if not SUPPRESS_FAILURE_OUTPUT:
+        print(f"verify-agent-onboarding-skill: ERROR: {message}", file=sys.stderr)
+    sys.exit(1)
+
+
+def require(condition: bool, message: str) -> None:
+    if not condition:
+        fail(message)
+
+
+def display_path(path: Path) -> str:
+    try:
+        return str(path.relative_to(ROOT))
+    except ValueError:
+        return str(path)
+
+
+def read_text(path: Path) -> str:
+    try:
+        return path.read_text(encoding="utf-8")
+    except FileNotFoundError:
+        fail(f"missing {display_path(path)}")
+    except UnicodeDecodeError as exc:
+        fail(f"{display_path(path)} is not valid UTF-8: {exc}")
+
+
+def validate_urls(text: str) -> None:
+    for match in URI_RE.finditer(text):
+        raw = match.group(0).rstrip("`').,")
+        if re.match(r"^[A-Za-z_][A-Za-z0-9_]*:-", raw):
+            continue
+        require(not raw.startswith("//"), f"protocol-relative URL forbidden: {raw}")
+        parsed = urlparse(raw)
+        require(parsed.scheme, f"URL scheme missing: {raw}")
+        host = (parsed.hostname or "").lower()
+        require(parsed.scheme.lower() == "https", f"URL must use https: {raw}")
+        require(parsed.username is None and parsed.password is None, f"URL must not contain userinfo: {raw}")
+        try:
+            port = parsed.port
+        except ValueError:
+            fail(f"URL has an invalid port: {raw}")
+        require(port is None, f"URL must not contain an explicit port: {raw}")
+        require(not parsed.params and not parsed.query and not parsed.fragment, f"URL must be canonical without params/query/fragment: {raw}")
+        require(not (host == "streamvc.live" or host.endswith(".streamvc.live")), f"legacy host forbidden: {raw}")
+        normalized = f"{parsed.scheme.lower()}://{host}{parsed.path}"
+        require(normalized in ALLOWED_URLS, f"URL is not allowlisted: {raw}")
+
+
+def validate_files(
+    skill_path: Path = SKILL_PATH,
+    index_path: Path = INDEX_PATH,
+    *,
+    require_reference_paths: bool = True,
+) -> str:
+    skill_bytes = skill_path.read_bytes() if skill_path.exists() else b""
+    require(skill_bytes, f"missing {display_path(skill_path)}")
+    require(len(skill_bytes) <= 20_000, "SKILL.md must stay compact for agent ingestion")
+    skill = read_text(skill_path)
+    index_text = read_text(index_path)
+
+    combined = f"{skill}\n{index_text}"
+    for forbidden in FORBIDDEN_LITERAL_SNIPPETS:
+        require(forbidden not in combined, f"forbidden snippet present: {forbidden}")
+    for pattern in FORBIDDEN_PATTERNS:
+        require(not pattern.search(combined), f"forbidden pattern present: {pattern.pattern}")
+    validate_urls(combined)
+
+    for snippet in REQUIRED_SKILL_SNIPPETS:
+        require(snippet in skill, f"SKILL.md missing required snippet: {snippet}")
+
+    lower_skill = skill.lower()
+    for snippet in REQUIRED_GUARDRAILS:
+        require(snippet in lower_skill, f"SKILL.md missing guardrail phrase: {snippet}")
+
+    for rel in REQUIRED_REFERENCES:
+        require(rel in skill, f"SKILL.md missing reference: {rel}")
+        if require_reference_paths:
+            require((ROOT / rel).exists(), f"referenced path does not exist: {rel}")
+
+    try:
+        index = json.loads(index_text)
+    except json.JSONDecodeError as exc:
+        fail(f"index JSON is invalid: {exc}")
+
+    require(
+        index.get("schema_version") == "https://get.malibu.tech/.well-known/skills/index.v1",
+        "index schema_version drifted",
+    )
+    skills = index.get("skills")
+    require(isinstance(skills, list) and len(skills) == 1, "index must contain exactly one skill")
+    entry = skills[0]
+    require(isinstance(entry, dict), "index skill entry must be an object")
+    require(entry.get("id") == "macprovider-agent-onboarding", "index skill id drifted")
+    require(entry.get("url") == CANONICAL_SKILL_URL, "index skill URL drifted")
+    require(entry.get("source_path") == "docs/agent-onboarding/SKILL.md", "index source path drifted")
+    require(
+        entry.get("content_type") == "text/markdown; charset=utf-8",
+        "index content_type drifted",
+    )
+
+    digest = hashlib.sha256(skill_bytes).hexdigest()
+    require(entry.get("sha256") == digest, "index sha256 does not match SKILL.md")
+    return digest
+
+
+def run_negative_tests() -> None:
+    global SUPPRESS_FAILURE_OUTPUT
+    with tempfile.TemporaryDirectory(prefix="agent-skill-negative.") as raw:
+        temp = Path(raw)
+        skill = temp / "SKILL.md"
+        index = temp / "index.json"
+        skill.write_text(SKILL_PATH.read_text(encoding="utf-8"), encoding="utf-8")
+        index.write_text(INDEX_PATH.read_text(encoding="utf-8"), encoding="utf-8")
+        mutations = {
+            "legacy_http": "\nhttps://streamvc.live/install.sh\n",
+            "legacy_mixed_case": "\nhttps://Get.StreamVC.Live/skill.md\n",
+            "unexpected_host": "\nhttps://evil.example/install.sh\n",
+            "uppercase_scheme_unexpected_host": "\nHTTPS://evil.example/install.sh\n",
+            "ssh_legacy_host": "\nssh://streamvc.live/root\n",
+            "ftp_unexpected_host": "\nftp://evil.example/install.sh\n",
+            "protocol_relative_host": "\n//evil.example/install.sh\n",
+            "explicit_port": "\nhttps://get.malibu.tech:444/skill.md\n",
+            "userinfo": "\nhttps://user:pass@get.malibu.tech/install.sh\n",
+            "query": "\nhttps://get.malibu.tech/skill.md?x=1\n",
+            "fragment": "\nhttps://get.malibu.tech/skill.md#install\n",
+            "pipe_bash": "\ncurl -fsSL https://get.malibu.tech/install.sh | bash\n",
+            "pipe_bash_spaces": "\ncurl -fsSL https://get.malibu.tech/install.sh |  bash\n",
+            "pipe_bash_tab": "\ncurl -fsSL https://get.malibu.tech/install.sh |\tbash\n",
+            "pipe_bin_bash": "\ncurl -fsSL https://get.malibu.tech/install.sh | /bin/bash\n",
+            "pipe_env_bash": "\ncurl -fsSL https://get.malibu.tech/install.sh | /usr/bin/env bash\n",
+            "pipe_sh": "\ncurl -fsSL https://get.malibu.tech/install.sh | sh\n",
+            "bash_c_curl": "\nbash -c \"$(curl -fsSL https://get.malibu.tech/install.sh)\"\n",
+            "process_substitution": "\nbash <(curl -fsSL https://get.malibu.tech/uninstall.sh)\n",
+        }
+        for name, addition in mutations.items():
+            mutated = SKILL_PATH.read_text(encoding="utf-8") + addition
+            skill.write_text(mutated, encoding="utf-8")
+            index_payload = json.loads(INDEX_PATH.read_text(encoding="utf-8"))
+            index_payload["skills"][0]["sha256"] = hashlib.sha256(mutated.encode()).hexdigest()
+            index.write_text(json.dumps(index_payload, indent=2) + "\n", encoding="utf-8")
+            SUPPRESS_FAILURE_OUTPUT = True
+            try:
+                validate_files(skill, index)
+            except SystemExit as exc:
+                SUPPRESS_FAILURE_OUTPUT = False
+                require(exc.code == 1, f"negative test {name} exited unexpectedly: {exc.code}")
+            else:
+                SUPPRESS_FAILURE_OUTPUT = False
+                fail(f"negative test did not fail: {name}")
+
+        mixed_case_canonical = SKILL_PATH.read_text(encoding="utf-8") + (
+            "\nHTTPS://GET.MALIBU.TECH/skill.md\n"
+        )
+        skill.write_text(mixed_case_canonical, encoding="utf-8")
+        index_payload = json.loads(INDEX_PATH.read_text(encoding="utf-8"))
+        index_payload["skills"][0]["sha256"] = hashlib.sha256(
+            mixed_case_canonical.encode()
+        ).hexdigest()
+        index.write_text(json.dumps(index_payload, indent=2) + "\n", encoding="utf-8")
+        validate_files(skill, index)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--skill", type=Path, default=SKILL_PATH)
+    parser.add_argument("--index", type=Path, default=INDEX_PATH)
+    parser.add_argument("--no-reference-existence", action="store_true")
+    parser.add_argument("--self-test-negatives", action="store_true")
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    digest = validate_files(
+        args.skill,
+        args.index,
+        require_reference_paths=not args.no_reference_existence,
+    )
+    if args.self_test_negatives:
+        run_negative_tests()
+    print(
+        "verify-agent-onboarding-skill: ok "
+        f"skill={display_path(args.skill)} "
+        f"index={display_path(args.index)} "
+        f"sha256={digest}"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/specs/CONFORMANCE.json
+++ b/specs/CONFORMANCE.json
@@ -62,7 +62,7 @@
     {
       "spec_id": "SPEC-003",
       "title": "Open Onboarding: Distribution, Lifecycle & Onboarding UX",
-      "version": "0.11.0",
+      "version": "0.11.1",
       "path": "specs/SPEC-003-open-onboarding.md",
       "status": "normative",
       "owner": "@Augustas11",
@@ -4045,6 +4045,32 @@
         "owner": "@Augustas11",
         "issue": "https://github.com/Augustas11/macprovider/issues/928",
         "rationale": "Gateway config validation, disabled compatibility, relay-blind metadata limiter, and replay storage DDL are implemented/tested locally; production enablement and signed journey-result evidence remain pending."
+      }
+    },
+    {
+      "requirement_id": "SPEC-003-R001",
+      "spec_id": "SPEC-003",
+      "state": "pending",
+      "implementation": [
+        "docs/agent-onboarding/SKILL.md:MacProvider Agent Onboarding Skill",
+        "docs/agent-onboarding/.well-known/skills/index.json:macprovider-agent-onboarding",
+        "scripts/verify-agent-onboarding-skill.py:REQUIRED_SKILL_SNIPPETS",
+        "scripts/install-agent-onboarding-publication.sh:agent-onboarding-current",
+        "scripts/publish-agent-onboarding-skill.sh:MALIBU_GET_WEBROOT"
+      ],
+      "tests": [
+        "scripts/test-agent-onboarding-skill.sh:verify-agent-onboarding-skill.py",
+        "scripts/test-agent-onboarding-publication.sh:unsafe agent onboarding publication was accepted",
+        "scripts/verify-agent-onboarding-hosted.sh:hosted skill bytes differ from repo source",
+        "Makefile:test-dist"
+      ],
+      "journeys": [],
+      "evidence": [],
+      "gap": {
+        "verdict": "UNKNOWN",
+        "owner": "@Augustas11",
+        "issue": "https://github.com/Augustas11/macprovider/issues/926",
+        "rationale": "The repo now contains the Malibu-domain hosted agent onboarding skill source, discovery index, and drift validator; the requirement remains pending until the public get.malibu.tech route is published and byte-compared against the repo artifact."
       }
     }
   ]

--- a/specs/README.md
+++ b/specs/README.md
@@ -11,7 +11,7 @@ it can no longer drift. Do not hand-edit the table; edit each spec's
 |---|---|---|---|---|---|---|
 | SPEC-001 | Phase 3 Binary: Mac Provider Inference CLI | 1.9.2 | normative | pending | pending: 1 | [SPEC-001-phase3-binary.md](SPEC-001-phase3-binary.md) |
 | SPEC-002 | Phase 4 Coordinator: Mac Provider Request Router | 1.5.8 | normative | pending | pending: 2 | [SPEC-002-coordinator.md](SPEC-002-coordinator.md) |
-| SPEC-003 | Open Onboarding: Distribution, Lifecycle & Onboarding UX | 0.11.0 | normative | pending | pending corpus migration | [SPEC-003-open-onboarding.md](SPEC-003-open-onboarding.md) |
+| SPEC-003 | Open Onboarding: Distribution, Lifecycle & Onboarding UX | 0.11.1 | normative | pending | pending: 1 | [SPEC-003-open-onboarding.md](SPEC-003-open-onboarding.md) |
 | SPEC-004 | Smart Router | 0.3.3 | normative | pending | pending corpus migration | [SPEC-004-smart-router.md](SPEC-004-smart-router.md) |
 | SPEC-005 | Billing, Settlement, and Provider Rewards | 0.6.1 | normative | pending | pending corpus migration | [SPEC-005-billing.md](SPEC-005-billing.md) |
 | SPEC-006 | Buyer API Gateway: Mac Provider's first public buyer surface | 0.9.14 | normative | pending | pending corpus migration | [SPEC-006-buyer-api.md](SPEC-006-buyer-api.md) |

--- a/specs/SPEC-003-open-onboarding.md
+++ b/specs/SPEC-003-open-onboarding.md
@@ -1,6 +1,17 @@
 # SPEC-003 — Open Onboarding: Distribution, Lifecycle & Onboarding UX
 
-**Version:** 0.11.0 (2026-07-16, referral-gated CLI bootstrap integration)
+**Version:** 0.11.1 (2026-08-16, hosted agent onboarding skill)
+
+**Change log v0.11.1:** Adds FR-C1b and AC-6 for the hosted
+agent-readable onboarding skill requested in issue #926. The canonical public
+URLs are `https://get.malibu.tech/skill.md` and
+`https://get.malibu.tech/.well-known/skills/index.json`; `streamvc.live` is not
+a supported onboarding domain. The repo source lives under
+`docs/agent-onboarding/`, and `make test-dist` now validates URL drift, index
+checksum drift, command coverage, reference coverage, and secret/production
+guardrails. The dedicated get-host publication helper installs the skill and
+index into the root-owned `get.malibu.tech` webroot, and the hosted verifier
+byte-compares both public URLs against the repo artifacts.
 
 **Change log v0.11.0:** Adds FR-C9.7 as the open-onboarding integration point
 for SPEC-034. A referral code is optional WS bootstrap input when enforcement is
@@ -313,6 +324,50 @@ intentional architecture property:
 
 The release tarball MUST NOT contain `install.sh`. Re-bundling it would
 reintroduce the slow-iterate path and is explicitly out of scope.
+
+**FR-C1b. Hosted agent onboarding skill.**
+MacProvider MUST publish a compact, agent-readable onboarding skill at
+`https://get.malibu.tech/skill.md`. The optional discovery index MUST be served
+at `https://get.malibu.tech/.well-known/skills/index.json` when the hosting
+surface supports well-known discovery. The repository source of truth is
+`docs/agent-onboarding/SKILL.md`, with discovery metadata in
+`docs/agent-onboarding/.well-known/skills/index.json`.
+
+The skill is a distribution artifact, not a new runtime protocol. It MUST:
+
+1. Use `malibu.tech` canonical URLs and MUST NOT point agents at legacy
+   `streamvc.live` onboarding URLs.
+2. Cover provider install, status, recovery, update, and uninstall commands
+   using the public installer/uninstaller and the existing `macprovider-cli`
+   surfaces.
+3. Cover buyer SDK compatibility by pointing OpenAI-compatible clients at
+   `https://api.malibu.tech/v1`.
+4. Include guardrails that prevent agents from printing secrets, mutating
+   production, running destructive commands, or crossing the `d-inference`
+   clean-room boundary without explicit authority.
+5. Link to the authoritative repo docs/specs instead of duplicating full
+   operational policy: `README.md`, the OpenAI SDK guide, release verification
+   runbook, first-hop recovery runbook, SPEC-003, SPEC-006, SPEC-020, and
+   SPEC-035.
+
+`scripts/test-agent-onboarding-skill.sh` MUST run in `make test-dist` and fail
+when the skill source and discovery index drift. The validation MUST include at
+least URL/domain checks, SHA-256 index checksum verification, core command
+coverage, reference existence checks, negative tests for unsafe URL/remote
+execution mutations, and secret/production guardrail checks.
+
+The get-host static publication path MUST stage `docs/agent-onboarding/SKILL.md`
+and `docs/agent-onboarding/.well-known/skills/index.json` as root-owned,
+non-writable inputs, install them into the immutable publication directory as
+`skill.md` and `.well-known/skills/index.json`, and expose the public paths via
+current-pointer-backed symlinks. `scripts/publish-agent-onboarding-skill.sh`
+MUST use `MALIBU_GET_WEBROOT` (default `/var/www/malibu-get`), validate the
+exact local artifacts before upload, validate the exact transferred bytes before
+switching the public pointer, and then run `scripts/verify-agent-onboarding-hosted.sh`.
+After publication, `scripts/verify-agent-onboarding-hosted.sh` MUST fetch
+`https://get.malibu.tech/skill.md` and
+`https://get.malibu.tech/.well-known/skills/index.json` and byte-compare them
+to the repo artifacts before the operator can claim the hosted route is live.
 
 **FR-C2. install.sh contract.**
 The install script at `https://get.malibu.tech/install.sh` is the
@@ -1056,7 +1111,7 @@ Defined in FR-C1. Summary:
 | Dependency | Purpose | License | Notes |
 |---|---|---|---|
 | GitHub API | Release discovery, download | N/A (public API) | No API key needed for public repos. Rate limit: 60 req/hr unauthenticated. `install.sh` makes 2 API calls; `update` makes 1-2. |
-| Cloudflare Pages | Hosting `get.malibu.tech` | Free tier | Static site. Only serves `install.sh` and a landing page. |
+| Cloudflare Pages / static nginx | Hosting `get.malibu.tech` | Free tier / Pearl static host | Static site serving `install.sh`, `uninstall.sh`, the landing page, and agent onboarding artifacts. |
 | `huggingface-cli` | Model download | Apache-2.0 | NOT a hard dependency. `install.sh` prints manual download instructions if not installed. |
 | `shasum` / `sha256sum` | Checksum verification | OS-provided | macOS ships `shasum` (BSD). Fallback to `openssl dgst -sha256` if neither found. |
 
@@ -1212,6 +1267,34 @@ green install retest.
 **Expected:** Existing config port is reused; own `macprovider-cli` port holders are stopped while foreign holders still exit 6; launchd invokes the real binary path; warm-cache waits remain 5 minutes; cold-cache waits are 20 minutes with progress; mixed-state directories warn and continue.
 
 **How to verify:** Manual upgrade on existing partner-shaped install plus local mixed-directory simulation.
+
+---
+
+**AC-6. Hosted agent onboarding skill.**
+
+**Setup:** Fresh checkout of `main`, with the hosted static surface configured
+to serve repo artifacts under `get.malibu.tech`.
+
+**Action:** Fetch `https://get.malibu.tech/skill.md` and
+`https://get.malibu.tech/.well-known/skills/index.json`, then compare them to
+`docs/agent-onboarding/SKILL.md` and
+`docs/agent-onboarding/.well-known/skills/index.json`.
+
+**Expected:**
+1. The hosted skill is a compact Markdown artifact that a fresh agent can use
+   to perform a non-production local onboarding smoke.
+2. The discovery index points at `https://get.malibu.tech/skill.md` and its
+   `sha256` matches the repo skill source.
+3. The skill uses only `malibu.tech` onboarding URLs.
+4. Secret handling, production mutation, destructive command, and clean-room
+   guardrails are present.
+5. Core provider install/status/update/uninstall commands and buyer
+   OpenAI-compatible `https://api.malibu.tech/v1` examples are present.
+
+**How to verify:** `bash scripts/test-agent-onboarding-skill.sh` for repo drift,
+`bash scripts/test-agent-onboarding-publication.sh` for static publication wiring,
+and `bash scripts/verify-agent-onboarding-hosted.sh` after publishing or
+changing the static route.
 
 ---
 


### PR DESCRIPTION
## Summary

- Adds the repo-source MacProvider agent onboarding skill and well-known discovery index for `get.malibu.tech` publication.
- Adds validated get-host publication tooling, hosted byte comparison, and local fail-closed publication regressions.
- Updates SPEC-003 and CONFORMANCE to make this a SPEC-backed feature with pending live verification, not docs-only.

## Audit Gate

Three-lane Codex audit on the final committed diff `cbc30f65`:

- Code: 0 Critical / 0 High / 0 Medium
- Security/release-safety: 0 Critical / 0 High / 0 Medium
- Architecture: 0 Critical / 0 High / 0 Medium

## Validation

- `bash scripts/test-agent-onboarding-skill.sh`
- `bash scripts/test-agent-onboarding-publication.sh`
- `bash scripts/test-malibu-bootstrap-bridge.sh`
- `bash scripts/test-release-security-posture.sh`
- `python3 scripts/check_spec_governance.py`
- `python3 scripts/gen_spec_index.py --check`
- `git diff --check`

Live hosted verification remains intentionally pending until the get-host artifacts are published and `scripts/verify-agent-onboarding-hosted.sh` passes against public bytes.

SPEC-GOVERNANCE-DECLARATION-BEGIN
{
  "schema_version": "spec-pr-governance-v1",
  "behavior_change": "yes",
  "contract_change": "yes",
  "specs": [
    "SPEC-003"
  ],
  "requirements": [
    "SPEC-003-R001"
  ],
  "authority_domains": [
    "provider-onboarding-identity"
  ],
  "arbitration": [
    "UNKNOWN"
  ],
  "tests": [
    "bash scripts/test-agent-onboarding-skill.sh",
    "bash scripts/test-agent-onboarding-publication.sh",
    "python3 scripts/check_spec_governance.py"
  ],
  "journeys": [
    "not-required"
  ],
  "issue": "https://github.com/Augustas11/macprovider/issues/926"
}
SPEC-GOVERNANCE-DECLARATION-END
