### PR TITLE
Live-wire SPEC-036 compute-integrity settlement gate

### DIFF
--- a/phase4-coordinator/internal/billing/route_snapshot.go
+++ b/phase4-coordinator/internal/billing/route_snapshot.go
@@ -62,6 +62,9 @@ type RouteSnapshot struct {
 	PendingDeadlineSeconds             int64   `json:"pending_deadline_seconds"`
 	PromptHashBasis                    string  `json:"prompt_hash_basis"`
 	PromptHash                         string  `json:"prompt_hash"`
+	ComputeIntegrityCaptureRequired    bool    `json:"-"`
+	ComputeIntegritySamplingCovered    bool    `json:"-"`
+	ComputeIntegrityHardwareDigest     string  `json:"-"`
 }
 
 func ReceiptKeyID(pubkey []byte) (string, error) {
@@ -176,6 +179,14 @@ func (r RouteSnapshot) Validate() error {
 	if r.PendingDeadlineSeconds <= 0 || r.PendingDeadlineSeconds > MaxPendingReceiptDeadlineSeconds {
 		return fmt.Errorf("route snapshot pending_deadline_seconds must be between 1 and %d", MaxPendingReceiptDeadlineSeconds)
 	}
+	if r.ComputeIntegrityCaptureRequired {
+		if r.RouteSnapshotMode != RouteSnapshotModeEnforce {
+			return fmt.Errorf("compute integrity capture requires enforce route snapshot mode")
+		}
+		if !computeIntegrityDigestPattern.MatchString(r.ComputeIntegrityHardwareDigest) {
+			return fmt.Errorf("compute integrity hardware runtime class digest invalid")
+		}
+	}
 	return nil
 }
 
@@ -201,7 +212,9 @@ INSERT INTO settlement_route_snapshots (
     catalog_signature_pubkey_fingerprint, catalog_expires_at_unix_ms,
     spec008_hash_status, route_snapshot_policy_version, route_snapshot_mode,
     route_decision_ts_unix_ms, request_start_ts_unix_ms, pending_deadline_seconds,
-    prompt_hash_basis, prompt_hash, route_snapshot_digest, route_snapshot_json,
+    prompt_hash_basis, prompt_hash, compute_integrity_capture_required,
+    compute_integrity_sampling_profile_covered, compute_integrity_hardware_runtime_class_digest,
+    route_snapshot_digest, route_snapshot_json,
     route_snapshot_canonical_json, created_at_utc
 ) VALUES (
     ?, ?, ?, ?,
@@ -212,8 +225,8 @@ INSERT INTO settlement_route_snapshots (
     ?, ?,
     ?, ?, ?,
     ?, ?, ?,
-    ?, ?, ?, ?,
-    ?, strftime('%Y-%m-%dT%H:%M:%fZ','now')
+    ?, ?, ?, ?, ?,
+    ?, ?, ?, strftime('%Y-%m-%dT%H:%M:%fZ','now')
 )`,
 		snapshot.AccountScope, snapshot.RequestID, snapshot.AttemptN, snapshot.ProviderID,
 		nullableString(snapshot.ProviderSessionID), nullableString(snapshot.ProviderGenerationID), snapshot.PaidEntrypoint,
@@ -223,7 +236,9 @@ INSERT INTO settlement_route_snapshots (
 		snapshot.CatalogSignaturePubkeyFingerprint, snapshot.CatalogExpiresAtUnixMS,
 		snapshot.Spec008HashStatus, snapshot.RouteSnapshotPolicyVersion, snapshot.RouteSnapshotMode,
 		snapshot.RouteDecisionTSUnixMS, snapshot.RequestStartTSUnixMS, snapshot.PendingDeadlineSeconds,
-		snapshot.PromptHashBasis, snapshot.PromptHash, digest, string(rendered),
+		snapshot.PromptHashBasis, snapshot.PromptHash,
+		boolInt(snapshot.ComputeIntegrityCaptureRequired), boolInt(snapshot.ComputeIntegritySamplingCovered), nullString(snapshot.ComputeIntegrityHardwareDigest),
+		digest, string(rendered),
 		string(canonical),
 	)
 	if err != nil {

--- a/phase4-coordinator/internal/billing/route_snapshot_test.go
+++ b/phase4-coordinator/internal/billing/route_snapshot_test.go
@@ -104,6 +104,23 @@ WHERE account_scope = ? AND request_id = ? AND attempt_n = ? AND provider_id = ?
 	}
 }
 
+func TestSettlementRouteSnapshotIsImmutable(t *testing.T) {
+	_, store := newRequestAndBillingStores(t)
+	snapshot := testRouteSnapshot()
+	if _, err := store.InsertRouteSnapshot(context.Background(), snapshot); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := store.db.Exec(`
+UPDATE settlement_route_snapshots
+   SET compute_integrity_capture_required = 1
+ WHERE account_scope = ? AND request_id = ? AND attempt_n = ? AND provider_id = ?`,
+		snapshot.AccountScope, snapshot.RequestID, snapshot.AttemptN, snapshot.ProviderID)
+	if err == nil || !strings.Contains(err.Error(), "settlement route snapshot is immutable") {
+		t.Fatalf("err=%v, want immutable route snapshot trigger", err)
+	}
+}
+
 func TestRouteSnapshotRejectsInvalidModeAndDeadline(t *testing.T) {
 	snapshot := testRouteSnapshot()
 	snapshot.RouteSnapshotMode = "shadow"

--- a/phase4-coordinator/internal/billing/settlement_compute_integrity.go
+++ b/phase4-coordinator/internal/billing/settlement_compute_integrity.go
@@ -1,0 +1,168 @@
+package billing
+
+import (
+	"bytes"
+	"context"
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"regexp"
+	"time"
+
+	"github.com/augstar/macprovider-coordinator/internal/computeintegrity"
+)
+
+var computeIntegrityDigestPattern = regexp.MustCompile(`^sha256:[0-9a-f]{64}$`)
+
+// InsertComputeIntegrityCapture persists the immutable SPEC-036 request-start
+// capture for a route snapshot that explicitly requires compute-integrity gating.
+func (s *Store) InsertComputeIntegrityCapture(ctx context.Context, id SettlementReceiptIdentity, capture computeintegrity.Capture, requestSamplingProfileCovered bool, routeSnapshotHardwareClassDigest string) (string, error) {
+	if s == nil {
+		return "", fmt.Errorf("billing store is nil")
+	}
+	if err := id.validate(); err != nil {
+		return "", err
+	}
+	if !computeIntegrityDigestPattern.MatchString(routeSnapshotHardwareClassDigest) {
+		return "", fmt.Errorf("compute integrity route snapshot hardware class digest invalid")
+	}
+	raw, err := json.Marshal(capture)
+	if err != nil {
+		return "", err
+	}
+	digest, err := computeintegrity.RequestStartSnapshotDigest(capture)
+	if err != nil {
+		return "", err
+	}
+	if capture.CapturedAtUnixMS <= 0 {
+		return "", fmt.Errorf("compute integrity captured_at must be positive")
+	}
+	_, err = s.db.ExecContext(ctx, `
+INSERT INTO settlement_compute_integrity_captures (
+    account_scope, request_id, attempt_n, provider_id,
+    capture_required, request_sampling_profile_covered, route_snapshot_hardware_class_digest,
+    capture_json, request_start_snapshot_digest, captured_at_unix_ms, created_at_utc
+) VALUES (?, ?, ?, ?, 1, ?, ?, ?, ?, ?, ?)
+`,
+		id.AccountScope, id.RequestID, id.AttemptN, id.ProviderID,
+		boolInt(requestSamplingProfileCovered), routeSnapshotHardwareClassDigest,
+		string(raw), digest, capture.CapturedAtUnixMS, time.Now().UTC().Format(time.RFC3339Nano),
+	)
+	if err != nil {
+		return "", err
+	}
+	return digest, nil
+}
+
+// MarkComputeIntegrityCaptureRequired records that a covered enforce row required
+// SPEC-036 request-start capture, but capture material was unavailable/unreadable.
+// Settlement consumes this marker as fail-closed compute_integrity_unreadable.
+func (s *Store) MarkComputeIntegrityCaptureRequired(ctx context.Context, id SettlementReceiptIdentity, requestSamplingProfileCovered bool, routeSnapshotHardwareClassDigest string) error {
+	if s == nil {
+		return fmt.Errorf("billing store is nil")
+	}
+	if err := id.validate(); err != nil {
+		return err
+	}
+	if !computeIntegrityDigestPattern.MatchString(routeSnapshotHardwareClassDigest) {
+		return fmt.Errorf("compute integrity route snapshot hardware class digest invalid")
+	}
+	_, err := s.db.ExecContext(ctx, `
+INSERT INTO settlement_compute_integrity_captures (
+    account_scope, request_id, attempt_n, provider_id,
+    capture_required, request_sampling_profile_covered, route_snapshot_hardware_class_digest,
+    capture_json, request_start_snapshot_digest, captured_at_unix_ms, created_at_utc
+) VALUES (?, ?, ?, ?, 1, ?, ?, NULL, NULL, NULL, ?)
+`,
+		id.AccountScope, id.RequestID, id.AttemptN, id.ProviderID,
+		boolInt(requestSamplingProfileCovered), routeSnapshotHardwareClassDigest,
+		time.Now().UTC().Format(time.RFC3339Nano),
+	)
+	return err
+}
+
+func loadComputeIntegrityCaptureConn(ctx context.Context, conn *sql.Conn, id SettlementReceiptIdentity, route RouteSnapshot) (*computeintegrity.Capture, error) {
+	if route.RouteSnapshotMode != RouteSnapshotModeEnforce || !route.ComputeIntegrityCaptureRequired {
+		return nil, nil
+	}
+	var captureRequired, samplingCovered int
+	var routeSnapshotHardwareDigest string
+	var raw, storedDigest sql.NullString
+	err := conn.QueryRowContext(ctx, `
+SELECT capture_required, request_sampling_profile_covered, route_snapshot_hardware_class_digest,
+       capture_json, request_start_snapshot_digest
+FROM settlement_compute_integrity_captures
+WHERE account_scope = ? AND request_id = ? AND attempt_n = ? AND provider_id = ?`,
+		id.AccountScope, id.RequestID, id.AttemptN, id.ProviderID,
+	).Scan(&captureRequired, &samplingCovered, &routeSnapshotHardwareDigest, &raw, &storedDigest)
+	if err != nil {
+		if err == sql.ErrNoRows {
+			capture := computeintegrity.Capture{Unreadable: true}
+			capture.RequestSamplingProfileCovered = route.ComputeIntegritySamplingCovered
+			capture.RouteSnapshotHardwareClassDigest = route.ComputeIntegrityHardwareDigest
+			return &capture, nil
+		}
+		return nil, err
+	}
+	var capture computeintegrity.Capture
+	if captureRequired != 1 || !raw.Valid {
+		capture = computeintegrity.Capture{Unreadable: true}
+		capture.RequestSamplingProfileCovered = route.ComputeIntegritySamplingCovered
+		capture.RouteSnapshotHardwareClassDigest = route.ComputeIntegrityHardwareDigest
+		return &capture, nil
+	}
+	capture, ok := decodeComputeIntegrityCapture(raw.String)
+	if !ok {
+		capture = computeintegrity.Capture{Unreadable: true}
+	}
+	capture.RequestSamplingProfileCovered = route.ComputeIntegritySamplingCovered
+	capture.RouteSnapshotHardwareClassDigest = route.ComputeIntegrityHardwareDigest
+	routeDigest, _, routeErr := route.Digest()
+	if routeErr != nil ||
+		samplingCovered != boolInt(route.ComputeIntegritySamplingCovered) ||
+		routeSnapshotHardwareDigest != route.ComputeIntegrityHardwareDigest ||
+		capture.ProviderID != route.ProviderID ||
+		capture.ModelID != route.ModelID ||
+		capture.TargetModelHash != route.ProviderReportedModelHash ||
+		capture.TargetModelHash != route.ExpectedCatalogModelHash ||
+		capture.SignedCatalogDigest != "sha256:"+route.CatalogBodyDigest ||
+		capture.CapturedAtUnixMS != route.RequestStartTSUnixMS ||
+		capture.Spec022PolicyVersion != route.RouteSnapshotPolicyVersion ||
+		capture.Spec022PolicyMode != route.RouteSnapshotMode ||
+		!capture.Spec022EffectiveEnforce ||
+		capture.Spec022RouteSnapshotDigest != routeDigest {
+		capture.Unreadable = true
+	}
+	if !storedDigest.Valid {
+		capture.Unreadable = true
+		return &capture, nil
+	}
+	computed, digestErr := computeintegrity.RequestStartSnapshotDigest(capture)
+	if digestErr != nil || computed != storedDigest.String {
+		capture.Unreadable = true
+	}
+	return &capture, nil
+}
+
+func decodeComputeIntegrityCapture(raw string) (computeintegrity.Capture, bool) {
+	var fields map[string]json.RawMessage
+	dec := json.NewDecoder(bytes.NewReader([]byte(raw)))
+	dec.UseNumber()
+	if err := dec.Decode(&fields); err != nil {
+		return computeintegrity.Capture{}, false
+	}
+	if len(fields) == 0 {
+		return computeintegrity.Capture{}, false
+	}
+	dec = json.NewDecoder(bytes.NewReader([]byte(raw)))
+	dec.UseNumber()
+	dec.DisallowUnknownFields()
+	var capture computeintegrity.Capture
+	if err := dec.Decode(&capture); err != nil {
+		return computeintegrity.Capture{}, false
+	}
+	if _, ok := fields["circuit_breaker_active"]; ok {
+		capture.BreakerFieldsPresent = true
+	}
+	return capture, true
+}

--- a/phase4-coordinator/internal/billing/settlement_compute_integrity_test.go
+++ b/phase4-coordinator/internal/billing/settlement_compute_integrity_test.go
@@ -1,0 +1,362 @@
+package billing
+
+import (
+	"context"
+	"crypto/ed25519"
+	"crypto/rand"
+	"encoding/base64"
+	"strings"
+	"testing"
+
+	"github.com/augstar/macprovider-coordinator/internal/computeintegrity"
+)
+
+const computeIntegrityTestHardwareDigest = "sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+
+func TestComputeIntegrityDriftQuarantinesVerifiedSettlementAndExcludesPayout(t *testing.T) {
+	fixtures := loadSettlementVerifierFixtures(t)
+	input := computeIntegritySettlementInput(t, fixtures, firstSettlementTupleWithTerminal(t, fixtures, "normal_done"), RouteSnapshotModeEnforce)
+	_, store := newRequestAndBillingStores(t)
+	createSettlementReceiptAuditLog(t, store.db)
+	seedSettlementReceiptEvidence(t, store, input)
+	insertSPEC022LedgerCredit(t, store.db, input, 700)
+	capture := computeIntegrityCaptureForInput(t, input, computeintegrity.StateQuarantinedDrift)
+	if _, err := store.InsertComputeIntegrityCapture(context.Background(), settlementIdentityFromInput(input), capture, true, computeIntegrityTestHardwareDigest); err != nil {
+		t.Fatal(err)
+	}
+
+	state, err := store.IngestSettlementReceipt(context.Background(), SettlementReceiptIngestionInput{
+		SettlementReceiptIdentity: settlementIdentityFromInput(input),
+		Header:                    input.Header,
+		ProviderReceiptPubkey:     input.ProviderReceiptPubkey,
+		receiptReceivedUnixMS:     input.ReceiptReceivedUnixMS,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if state.SettlementOutcome != SettlementOutcomeQuarantined || state.Reason != string(computeintegrity.ReasonDriftQuarantined) || !state.Closed {
+		t.Fatalf("state=%#v, want quarantined/%s", state, computeintegrity.ReasonDriftQuarantined)
+	}
+	if got := scalar(t, store.db, `SELECT COUNT(*) FROM spec022_payable_request_credits WHERE request_id=?`, input.RequestID); got != 0 {
+		t.Fatalf("payable rows=%d want 0", got)
+	}
+	if got := scalar(t, store.db, `SELECT COUNT(*) FROM ledger_payout_ready`); got != 0 {
+		t.Fatalf("payout rows=%d want 0", got)
+	}
+}
+
+func TestComputeIntegrityCleanCaptureDoesNotPromoteZeroSettledSPEC022(t *testing.T) {
+	fixtures := loadSettlementVerifierFixtures(t)
+	input := computeIntegritySettlementInput(t, fixtures, firstSettlementTupleWithTerminal(t, fixtures, "provider_error"), RouteSnapshotModeEnforce)
+	_, store := newRequestAndBillingStores(t)
+	createSettlementReceiptAuditLog(t, store.db)
+	seedSettlementReceiptEvidence(t, store, input)
+	capture := computeIntegrityCaptureForInput(t, input, computeintegrity.StateVerified)
+	if _, err := store.InsertComputeIntegrityCapture(context.Background(), settlementIdentityFromInput(input), capture, true, computeIntegrityTestHardwareDigest); err != nil {
+		t.Fatal(err)
+	}
+
+	state, err := store.IngestSettlementReceipt(context.Background(), SettlementReceiptIngestionInput{
+		SettlementReceiptIdentity: settlementIdentityFromInput(input),
+		Header:                    input.Header,
+		ProviderReceiptPubkey:     input.ProviderReceiptPubkey,
+		receiptReceivedUnixMS:     input.ReceiptReceivedUnixMS,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if state.SettlementOutcome != SettlementOutcomeZeroSettled || state.Reason != "verified_zero_settlement" {
+		t.Fatalf("state=%#v, want SPEC-022 zero_settled preserved", state)
+	}
+}
+
+func TestComputeIntegrityCaptureRouteMismatchFailsClosed(t *testing.T) {
+	fixtures := loadSettlementVerifierFixtures(t)
+	for _, tc := range []struct {
+		name   string
+		mutate func(*computeintegrity.Capture)
+	}{
+		{
+			name: "spec022-not-effective-enforce",
+			mutate: func(c *computeintegrity.Capture) {
+				c.Spec022EffectiveEnforce = false
+			},
+		},
+		{
+			name: "provider-id",
+			mutate: func(c *computeintegrity.Capture) {
+				c.ProviderID = "other-provider"
+			},
+		},
+		{
+			name: "model-id",
+			mutate: func(c *computeintegrity.Capture) {
+				c.ModelID = "other-model"
+			},
+		},
+		{
+			name: "target-model-hash",
+			mutate: func(c *computeintegrity.Capture) {
+				c.TargetModelHash = strings.Repeat("9", 64)
+			},
+		},
+		{
+			name: "signed-catalog-digest",
+			mutate: func(c *computeintegrity.Capture) {
+				c.SignedCatalogDigest = "sha256:" + strings.Repeat("9", 64)
+			},
+		},
+		{
+			name: "captured-at",
+			mutate: func(c *computeintegrity.Capture) {
+				c.CapturedAtUnixMS++
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			input := computeIntegritySettlementInput(t, fixtures, firstSettlementTupleWithTerminal(t, fixtures, "normal_done"), RouteSnapshotModeEnforce)
+			_, store := newRequestAndBillingStores(t)
+			createSettlementReceiptAuditLog(t, store.db)
+			seedSettlementReceiptEvidence(t, store, input)
+			capture := computeIntegrityCaptureForInput(t, input, computeintegrity.StateVerified)
+			tc.mutate(&capture)
+			if _, err := store.InsertComputeIntegrityCapture(context.Background(), settlementIdentityFromInput(input), capture, true, computeIntegrityTestHardwareDigest); err != nil {
+				t.Fatal(err)
+			}
+
+			state, err := store.IngestSettlementReceipt(context.Background(), SettlementReceiptIngestionInput{
+				SettlementReceiptIdentity: settlementIdentityFromInput(input),
+				Header:                    input.Header,
+				ProviderReceiptPubkey:     input.ProviderReceiptPubkey,
+				receiptReceivedUnixMS:     input.ReceiptReceivedUnixMS,
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if state.SettlementOutcome != SettlementOutcomeQuarantined || state.Reason != string(computeintegrity.ReasonUnreadable) {
+				t.Fatalf("state=%#v, want quarantined/%s", state, computeintegrity.ReasonUnreadable)
+			}
+		})
+	}
+}
+
+func TestComputeIntegrityMissingOrUnreadableCaptureFailsClosed(t *testing.T) {
+	fixtures := loadSettlementVerifierFixtures(t)
+	for _, tc := range []struct {
+		name string
+		mark func(t *testing.T, store *Store, input SettlementVerifyInput)
+	}{
+		{
+			name: "no-capture-row",
+			mark: func(t *testing.T, store *Store, input SettlementVerifyInput) {
+				t.Helper()
+			},
+		},
+		{
+			name: "missing",
+			mark: func(t *testing.T, store *Store, input SettlementVerifyInput) {
+				t.Helper()
+				if err := store.MarkComputeIntegrityCaptureRequired(context.Background(), settlementIdentityFromInput(input), true, computeIntegrityTestHardwareDigest); err != nil {
+					t.Fatal(err)
+				}
+			},
+		},
+		{
+			name: "unreadable",
+			mark: func(t *testing.T, store *Store, input SettlementVerifyInput) {
+				t.Helper()
+				_, err := store.db.Exec(`
+	INSERT INTO settlement_compute_integrity_captures (
+	    account_scope, request_id, attempt_n, provider_id,
+	    capture_required, request_sampling_profile_covered, route_snapshot_hardware_class_digest,
+	    capture_json, request_start_snapshot_digest, captured_at_unix_ms, created_at_utc
+	) VALUES (?, ?, ?, ?, 1, 1, ?, ?, NULL, NULL, strftime('%Y-%m-%dT%H:%M:%fZ','now'))`,
+					input.AccountScope, input.RequestID, input.AttemptN, input.ProviderID,
+					computeIntegrityTestHardwareDigest, `{"compute_integrity_state":`)
+				if err != nil {
+					t.Fatal(err)
+				}
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			input := computeIntegritySettlementInput(t, fixtures, firstSettlementTupleWithTerminal(t, fixtures, "normal_done"), RouteSnapshotModeEnforce)
+			_, store := newRequestAndBillingStores(t)
+			createSettlementReceiptAuditLog(t, store.db)
+			seedSettlementReceiptEvidence(t, store, input)
+			tc.mark(t, store, input)
+
+			state, err := store.IngestSettlementReceipt(context.Background(), SettlementReceiptIngestionInput{
+				SettlementReceiptIdentity: settlementIdentityFromInput(input),
+				Header:                    input.Header,
+				ProviderReceiptPubkey:     input.ProviderReceiptPubkey,
+				receiptReceivedUnixMS:     input.ReceiptReceivedUnixMS,
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if state.SettlementOutcome != SettlementOutcomeQuarantined || state.Reason != string(computeintegrity.ReasonUnreadable) {
+				t.Fatalf("state=%#v, want quarantined/%s", state, computeintegrity.ReasonUnreadable)
+			}
+		})
+	}
+}
+
+func TestComputeIntegrityCaptureIsImmutable(t *testing.T) {
+	fixtures := loadSettlementVerifierFixtures(t)
+	input := computeIntegritySettlementInput(t, fixtures, firstSettlementTupleWithTerminal(t, fixtures, "normal_done"), RouteSnapshotModeEnforce)
+	_, store := newRequestAndBillingStores(t)
+	seedSettlementReceiptEvidence(t, store, input)
+	capture := computeIntegrityCaptureForInput(t, input, computeintegrity.StateVerified)
+	if _, err := store.InsertComputeIntegrityCapture(context.Background(), settlementIdentityFromInput(input), capture, true, computeIntegrityTestHardwareDigest); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := store.db.Exec(`UPDATE settlement_compute_integrity_captures SET capture_json = capture_json || ' ' WHERE request_id = ?`, input.RequestID)
+	if err == nil || !strings.Contains(err.Error(), "settlement compute integrity capture is immutable") {
+		t.Fatalf("err=%v, want immutable capture trigger", err)
+	}
+}
+
+func TestComputeIntegrityObserveRouteDoesNotChangeMoneyOutcome(t *testing.T) {
+	fixtures := loadSettlementVerifierFixtures(t)
+	input := computeIntegritySettlementInput(t, fixtures, firstSettlementTupleWithTerminal(t, fixtures, "normal_done"), RouteSnapshotModeObserve)
+	_, store := newRequestAndBillingStores(t)
+	createSettlementReceiptAuditLog(t, store.db)
+	seedSettlementReceiptEvidence(t, store, input)
+	capture := computeIntegrityCaptureForInput(t, input, computeintegrity.StateQuarantinedDrift)
+	capture.Spec022EffectiveEnforce = false
+	if _, err := store.InsertComputeIntegrityCapture(context.Background(), settlementIdentityFromInput(input), capture, true, computeIntegrityTestHardwareDigest); err != nil {
+		t.Fatal(err)
+	}
+
+	state, err := store.IngestSettlementReceipt(context.Background(), SettlementReceiptIngestionInput{
+		SettlementReceiptIdentity: settlementIdentityFromInput(input),
+		Header:                    input.Header,
+		ProviderReceiptPubkey:     input.ProviderReceiptPubkey,
+		receiptReceivedUnixMS:     input.ReceiptReceivedUnixMS,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if state.SettlementOutcome != SettlementOutcomeVerified || state.Reason != "verified_settlement" {
+		t.Fatalf("state=%#v, want SPEC-036 dormant on observe route", state)
+	}
+}
+
+func computeIntegritySettlementInput(t *testing.T, fixtures settlementVerifierFixtures, tuple settlementVerifierTupleFixture, routeMode string) SettlementVerifyInput {
+	t.Helper()
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	input := settlementVerifierInputFromFixture(t, fixtures, tuple, pub)
+	keyID, err := ReceiptKeyID(pub)
+	if err != nil {
+		t.Fatal(err)
+	}
+	input.ProviderReceiptKeyID = keyID
+	input.RouteSnapshot.ProviderReceiptKeyID = keyID
+	input.RouteSnapshot.ProviderReceiptKeySource = "auth_session"
+	input.RouteSnapshot.RouteSnapshotMode = routeMode
+	if routeMode == RouteSnapshotModeEnforce {
+		input.RouteSnapshot.ComputeIntegrityCaptureRequired = true
+		input.RouteSnapshot.ComputeIntegritySamplingCovered = true
+		input.RouteSnapshot.ComputeIntegrityHardwareDigest = computeIntegrityTestHardwareDigest
+	}
+	input.ProviderReceiptPubkey = pub
+	input.Header = signedSettlementReceiptForInputWithKey(t, input, priv)
+	return input
+}
+
+func signedSettlementReceiptForInputWithKey(t *testing.T, input SettlementVerifyInput, priv ed25519.PrivateKey) string {
+	t.Helper()
+	routeDigest, _, err := input.RouteSnapshot.Digest()
+	if err != nil {
+		t.Fatal(err)
+	}
+	tuple := map[string]any{
+		"account_scope":                 input.AccountScope,
+		"attempt_n":                     input.AttemptN,
+		"catalog_body_digest":           input.RouteSnapshot.CatalogBodyDigest,
+		"catalog_id":                    input.RouteSnapshot.CatalogID,
+		"expected_catalog_model_hash":   input.RouteSnapshot.ExpectedCatalogModelHash,
+		"issued_at_unix_ms":             input.TerminalStateTSUnixMS,
+		"model_hash":                    input.RouteSnapshot.ProviderReportedModelHash,
+		"model_id":                      input.RouteSnapshot.ModelID,
+		"output_hash":                   input.OutputHash,
+		"output_prefix_end_byte":        input.OutputPrefixEndByte,
+		"output_prefix_start_byte":      input.OutputPrefixStartByte,
+		"prompt_hash":                   input.RouteSnapshot.PromptHash,
+		"provider_id":                   input.ProviderID,
+		"provider_receipt_key_id":       input.ProviderReceiptKeyID,
+		"receipt_version":               "4",
+		"request_id":                    input.RequestID,
+		"route_snapshot_digest":         routeDigest,
+		"route_snapshot_mode":           input.RouteSnapshot.RouteSnapshotMode,
+		"route_snapshot_policy_version": input.RouteSnapshot.RouteSnapshotPolicyVersion,
+		"signature_key_alg":             "Ed25519",
+		"terminal_state":                input.TerminalState,
+		"terminal_state_ts_unix_ms":     input.TerminalStateTSUnixMS,
+		"usage": map[string]any{
+			"billable_input_tokens":  input.ExpectedUsage.BillableInputTokens,
+			"billable_output_tokens": input.ExpectedUsage.BillableOutputTokens,
+			"delivered_output_bytes": input.ExpectedUsage.DeliveredOutputBytes,
+			"observed_input_tokens":  input.ExpectedUsage.ObservedInputTokens,
+			"observed_output_tokens": input.ExpectedUsage.ObservedOutputTokens,
+		},
+	}
+	canonical, err := CanonicalJSON(tuple)
+	if err != nil {
+		t.Fatal(err)
+	}
+	sig := ed25519.Sign(priv, canonical)
+	return base64.StdEncoding.EncodeToString(canonical) + "." + base64.StdEncoding.EncodeToString(sig)
+}
+
+func computeIntegrityCaptureForInput(t *testing.T, input SettlementVerifyInput, state computeintegrity.State) computeintegrity.Capture {
+	t.Helper()
+	routeDigest, _, err := input.RouteSnapshot.Digest()
+	if err != nil {
+		t.Fatal(err)
+	}
+	return computeintegrity.Capture{
+		StableProviderIdentity:           "stable-" + input.ProviderID,
+		ProviderID:                       input.ProviderID,
+		AssignedID:                       "assigned-" + input.ProviderID,
+		ModelID:                          input.RouteSnapshot.ModelID,
+		TargetModelHash:                  input.RouteSnapshot.ProviderReportedModelHash,
+		TokenizerIdentity:                "tokenizer-v1",
+		SamplerStage:                     computeintegrity.SamplerStagePostSampler,
+		SamplingProfile:                  "temp-0.7",
+		CorpusVersion:                    "corpus-v1",
+		ThresholdVersion:                 "threshold-v1",
+		HardwareRuntimeClass:             "m3-max",
+		TargetGeneration:                 1,
+		SamplingProfileCoverageMode:      computeintegrity.CoveragePerProfile,
+		RequestSamplingProfileCovered:    true,
+		HardwareRuntimeClassDigest:       computeIntegrityTestHardwareDigest,
+		RouteSnapshotHardwareClassDigest: computeIntegrityTestHardwareDigest,
+		Spec022PolicyVersion:             input.RouteSnapshot.RouteSnapshotPolicyVersion,
+		Spec022PolicyMode:                input.RouteSnapshot.RouteSnapshotMode,
+		Spec022EffectiveEnforce:          input.RouteSnapshot.RouteSnapshotMode == RouteSnapshotModeEnforce,
+		Spec022CoverageDigest:            "sha256:" + strings.Repeat("a", 64),
+		Spec022RouteSnapshotDigest:       routeDigest,
+		ComputeIntegrityPolicyVersion:    "ci-v1",
+		ComputeIntegrityPolicyMode:       computeintegrity.ModeEnforce,
+		ComputeIntegrityPolicyDigest:     "sha256:" + strings.Repeat("b", 64),
+		State:                            state,
+		AdjudicationOrigin:               computeintegrity.OriginEnforcePreserved,
+		ReferenceSetAdmissibilityStatus:  computeintegrity.AdmissibilityAdmissible,
+		ReferenceSetAdmissibilityDigest:  "sha256:" + strings.Repeat("d", 64),
+		ReferenceFaultCheckVersion:       "ref-fault-v1",
+		ReferenceSetID:                   "refset-v1",
+		ReferenceEventDigests:            []string{"sha256:ref-a", "sha256:ref-b"},
+		ReferenceQuorumCount:             2,
+		BreakerFieldsPresent:             true,
+		CircuitBreakerActive:             false,
+		WindowID:                         "window-v1",
+		SignedCatalogDigest:              "sha256:" + input.RouteSnapshot.CatalogBodyDigest,
+		CapturedAtUnixMS:                 input.RouteSnapshot.RequestStartTSUnixMS,
+	}
+}

--- a/phase4-coordinator/internal/billing/settlement_receipts.go
+++ b/phase4-coordinator/internal/billing/settlement_receipts.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/augstar/macprovider-coordinator/internal/computeintegrity"
 	"github.com/augstar/macprovider-coordinator/internal/sqliteutil"
 )
 
@@ -120,10 +121,11 @@ type SettlementReceiptAuthorization struct {
 }
 
 type settlementEvidence struct {
-	route      RouteSnapshot
-	routeHash  string
-	attempt    settlementAttemptEvidence
-	deadlineMS int64
+	route                   RouteSnapshot
+	routeHash               string
+	attempt                 settlementAttemptEvidence
+	deadlineMS              int64
+	computeIntegrityCapture *computeintegrity.Capture
 }
 
 type settlementAttemptEvidence struct {
@@ -183,6 +185,7 @@ func (s *Store) IngestSettlementReceipt(ctx context.Context, input SettlementRec
 			NowUnixMS:                receivedAt,
 			CanonicalHashesAvailable: evidence.attempt.OutputAvailable && evidence.attempt.OutputHash != "",
 			TerminalOutcomeFinal:     alreadyTerminal,
+			ComputeIntegrityCapture:  evidence.computeIntegrityCapture,
 		})
 	})
 }
@@ -217,6 +220,7 @@ func (s *Store) RecordMissingSettlementReceipt(ctx context.Context, input Settle
 			ReceiptMissing:           true,
 			CanonicalHashesAvailable: evidence.attempt.OutputAvailable && evidence.attempt.OutputHash != "",
 			TerminalOutcomeFinal:     alreadyTerminal,
+			ComputeIntegrityCapture:  evidence.computeIntegrityCapture,
 		})
 	})
 }
@@ -759,19 +763,26 @@ func loadSettlementEvidenceConn(ctx context.Context, conn *sql.Conn, id Settleme
 	if err != nil {
 		return settlementEvidence{}, err
 	}
+	computeIntegrityCapture, err := loadComputeIntegrityCaptureConn(ctx, conn, id, route)
+	if err != nil {
+		return settlementEvidence{}, err
+	}
 	return settlementEvidence{
-		route:      route,
-		routeHash:  routeHash,
-		attempt:    attempt,
-		deadlineMS: attempt.TerminalStateTSUnixMS + route.PendingDeadlineSeconds*1000,
+		route:                   route,
+		routeHash:               routeHash,
+		attempt:                 attempt,
+		deadlineMS:              attempt.TerminalStateTSUnixMS + route.PendingDeadlineSeconds*1000,
+		computeIntegrityCapture: computeIntegrityCapture,
 	}, nil
 }
 
 func loadSettlementRouteSnapshotConn(ctx context.Context, conn *sql.Conn, id SettlementReceiptIdentity) (RouteSnapshot, string, error) {
 	var r RouteSnapshot
 	var providerSession, providerGeneration sql.NullString
+	var computeIntegrityHardwareDigest sql.NullString
 	var digest string
 	var routeSnapshotJSON string
+	var computeIntegrityCaptureRequired, computeIntegritySamplingCovered int
 	err := conn.QueryRowContext(ctx, `
 SELECT provider_session_id, provider_generation_id, paid_entrypoint,
        provider_receipt_key_id, provider_receipt_key_source, model_id,
@@ -781,6 +792,8 @@ SELECT provider_session_id, provider_generation_id, paid_entrypoint,
        spec008_hash_status, route_snapshot_policy_version, route_snapshot_mode,
        route_decision_ts_unix_ms, request_start_ts_unix_ms,
        pending_deadline_seconds, prompt_hash_basis, prompt_hash,
+       compute_integrity_capture_required, compute_integrity_sampling_profile_covered,
+       compute_integrity_hardware_runtime_class_digest,
        route_snapshot_digest, route_snapshot_json
 FROM settlement_route_snapshots
 WHERE account_scope = ? AND request_id = ? AND attempt_n = ? AND provider_id = ?`,
@@ -794,6 +807,8 @@ WHERE account_scope = ? AND request_id = ? AND attempt_n = ? AND provider_id = ?
 		&r.Spec008HashStatus, &r.RouteSnapshotPolicyVersion, &r.RouteSnapshotMode,
 		&r.RouteDecisionTSUnixMS, &r.RequestStartTSUnixMS,
 		&r.PendingDeadlineSeconds, &r.PromptHashBasis, &r.PromptHash,
+		&computeIntegrityCaptureRequired, &computeIntegritySamplingCovered,
+		&computeIntegrityHardwareDigest,
 		&digest, &routeSnapshotJSON,
 	)
 	if err != nil {
@@ -821,6 +836,11 @@ WHERE account_scope = ? AND request_id = ? AND attempt_n = ? AND provider_id = ?
 	}
 	r.ProviderReportedModelHashAlgorithm = algorithms.ProviderReported
 	r.ExpectedCatalogModelHashAlgorithm = algorithms.ExpectedCatalog
+	r.ComputeIntegrityCaptureRequired = computeIntegrityCaptureRequired == 1
+	r.ComputeIntegritySamplingCovered = computeIntegritySamplingCovered == 1
+	if computeIntegrityHardwareDigest.Valid {
+		r.ComputeIntegrityHardwareDigest = computeIntegrityHardwareDigest.String
+	}
 	computed, _, err := r.Digest()
 	if err != nil {
 		return RouteSnapshot{}, "", err

--- a/phase4-coordinator/internal/billing/settlement_verifier.go
+++ b/phase4-coordinator/internal/billing/settlement_verifier.go
@@ -12,6 +12,8 @@ import (
 	"io"
 	"sort"
 	"strings"
+
+	"github.com/augstar/macprovider-coordinator/internal/computeintegrity"
 )
 
 const (
@@ -74,6 +76,7 @@ type SettlementVerifyInput struct {
 	CanonicalHashesAvailable   bool
 	AlreadyDeadlineQuarantined bool
 	TerminalOutcomeFinal       bool
+	ComputeIntegrityCapture    *computeintegrity.Capture
 }
 
 type SettlementVerifyResult struct {
@@ -113,18 +116,26 @@ type SettlementReceiptFacts struct {
 }
 
 type SettlementVerificationChecks struct {
-	SignatureVerified    bool `json:"signature_verified"`
-	RouteSnapshotMatched bool `json:"route_snapshot_matched"`
-	PromptHashMatched    bool `json:"prompt_hash_matched"`
-	OutputHashMatched    bool `json:"output_hash_matched"`
-	UsageMatched         bool `json:"usage_matched"`
-	UsageCrossChecked    bool `json:"usage_cross_checked"`
-	NoOverlap            bool `json:"no_overlap"`
-	TerminalStateMatched bool `json:"terminal_state_matched"`
-	TimestampWindowValid bool `json:"timestamp_window_valid"`
+	SignatureVerified              bool   `json:"signature_verified"`
+	RouteSnapshotMatched           bool   `json:"route_snapshot_matched"`
+	PromptHashMatched              bool   `json:"prompt_hash_matched"`
+	OutputHashMatched              bool   `json:"output_hash_matched"`
+	UsageMatched                   bool   `json:"usage_matched"`
+	UsageCrossChecked              bool   `json:"usage_cross_checked"`
+	NoOverlap                      bool   `json:"no_overlap"`
+	TerminalStateMatched           bool   `json:"terminal_state_matched"`
+	TimestampWindowValid           bool   `json:"timestamp_window_valid"`
+	ComputeIntegrityGate           bool   `json:"compute_integrity_gate"`
+	ComputeIntegrityPayable        bool   `json:"compute_integrity_payable"`
+	ComputeIntegrityReason         string `json:"compute_integrity_reason,omitempty"`
+	ComputeIntegritySnapshotDigest string `json:"compute_integrity_request_start_snapshot_digest,omitempty"`
 }
 
 func VerifySettlementReceipt(input SettlementVerifyInput) SettlementVerifyResult {
+	return applyComputeIntegrityGate(input, verifySettlementReceiptSPEC022(input))
+}
+
+func verifySettlementReceiptSPEC022(input SettlementVerifyInput) SettlementVerifyResult {
 	if input.AlreadyDeadlineQuarantined {
 		return settlementQuarantined("deadline_quarantined", "")
 	}
@@ -186,6 +197,34 @@ func VerifySettlementReceipt(input SettlementVerifyInput) SettlementVerifyResult
 		return SettlementVerifyResult{Outcome: SettlementOutcomeZeroSettled, ReceiptResult: SettlementReceiptResultValid, Reason: "verified_zero_settlement", ReceiptVersion: tuple.ReceiptVersion, Facts: facts, Checks: checks}
 	}
 	return SettlementVerifyResult{Outcome: SettlementOutcomeVerified, ReceiptResult: SettlementReceiptResultValid, Reason: "verified_settlement", ReceiptVersion: tuple.ReceiptVersion, Facts: facts, Checks: checks}
+}
+
+func applyComputeIntegrityGate(input SettlementVerifyInput, result SettlementVerifyResult) SettlementVerifyResult {
+	if input.ComputeIntegrityCapture == nil {
+		return result
+	}
+	capture := *input.ComputeIntegrityCapture
+	var snapshotDigest string
+	if !capture.Unreadable {
+		var err error
+		snapshotDigest, err = computeintegrity.RequestStartSnapshotDigest(capture)
+		if err != nil {
+			capture.Unreadable = true
+		}
+	}
+	decision := computeintegrity.Evaluate(capture)
+	outcome, reason := computeintegrity.ApplyGate(result.Outcome, result.Reason, decision)
+	result.Outcome = outcome
+	result.Reason = reason
+	result.Checks.ComputeIntegrityGate = decision.Applies
+	result.Checks.ComputeIntegrityPayable = decision.Payable
+	if decision.Reason != "" {
+		result.Checks.ComputeIntegrityReason = string(decision.Reason)
+	}
+	if snapshotDigest != "" {
+		result.Checks.ComputeIntegritySnapshotDigest = snapshotDigest
+	}
+	return result
 }
 
 func (input SettlementVerifyInput) deadlineUnixMS() int64 {

--- a/phase4-coordinator/internal/billing/store.go
+++ b/phase4-coordinator/internal/billing/store.go
@@ -226,6 +226,9 @@ CREATE TABLE IF NOT EXISTS settlement_route_snapshots (
     pending_deadline_seconds INTEGER NOT NULL CHECK(pending_deadline_seconds BETWEEN 1 AND 900),
     prompt_hash_basis TEXT NOT NULL,
     prompt_hash TEXT NOT NULL CHECK(length(prompt_hash) = 64 AND prompt_hash NOT GLOB '*[^0-9a-f]*'),
+    compute_integrity_capture_required INTEGER NOT NULL DEFAULT 0 CHECK(compute_integrity_capture_required IN (0,1)),
+    compute_integrity_sampling_profile_covered INTEGER NOT NULL DEFAULT 0 CHECK(compute_integrity_sampling_profile_covered IN (0,1)),
+    compute_integrity_hardware_runtime_class_digest TEXT NULL CHECK(compute_integrity_hardware_runtime_class_digest IS NULL OR (length(compute_integrity_hardware_runtime_class_digest) = 71 AND substr(compute_integrity_hardware_runtime_class_digest, 1, 7) = 'sha256:' AND substr(compute_integrity_hardware_runtime_class_digest, 8) NOT GLOB '*[^0-9a-f]*')),
     route_snapshot_digest TEXT NOT NULL CHECK(length(route_snapshot_digest) = 64 AND route_snapshot_digest NOT GLOB '*[^0-9a-f]*'),
     route_snapshot_json TEXT NOT NULL,
     route_snapshot_canonical_json TEXT NOT NULL,
@@ -235,6 +238,46 @@ CREATE TABLE IF NOT EXISTS settlement_route_snapshots (
 CREATE INDEX IF NOT EXISTS idx_srs_request ON settlement_route_snapshots(account_scope, request_id, attempt_n);
 CREATE INDEX IF NOT EXISTS idx_srs_provider ON settlement_route_snapshots(provider_id, created_at_utc);
 CREATE INDEX IF NOT EXISTS idx_srs_digest ON settlement_route_snapshots(route_snapshot_digest);
+CREATE TRIGGER IF NOT EXISTS trg_srs_immutable
+BEFORE UPDATE ON settlement_route_snapshots
+BEGIN
+    SELECT RAISE(ABORT, 'settlement route snapshot is immutable');
+END;
+
+CREATE TABLE IF NOT EXISTS settlement_compute_integrity_captures (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    account_scope TEXT NOT NULL,
+    request_id TEXT NOT NULL,
+    attempt_n INTEGER NOT NULL CHECK(attempt_n >= 0),
+    provider_id TEXT NOT NULL,
+    capture_required INTEGER NOT NULL DEFAULT 1 CHECK(capture_required IN (0,1)),
+    request_sampling_profile_covered INTEGER NOT NULL CHECK(request_sampling_profile_covered IN (0,1)),
+    route_snapshot_hardware_class_digest TEXT NOT NULL CHECK(length(route_snapshot_hardware_class_digest) = 71 AND substr(route_snapshot_hardware_class_digest, 1, 7) = 'sha256:' AND substr(route_snapshot_hardware_class_digest, 8) NOT GLOB '*[^0-9a-f]*'),
+    capture_json TEXT NULL,
+    request_start_snapshot_digest TEXT NULL CHECK(request_start_snapshot_digest IS NULL OR (length(request_start_snapshot_digest) = 71 AND substr(request_start_snapshot_digest, 1, 7) = 'sha256:' AND substr(request_start_snapshot_digest, 8) NOT GLOB '*[^0-9a-f]*')),
+    captured_at_unix_ms INTEGER NULL CHECK(captured_at_unix_ms IS NULL OR captured_at_unix_ms > 0),
+    created_at_utc TEXT NOT NULL,
+    UNIQUE(account_scope, request_id, attempt_n, provider_id),
+    FOREIGN KEY(account_scope, request_id, attempt_n, provider_id)
+        REFERENCES settlement_route_snapshots(account_scope, request_id, attempt_n, provider_id)
+        ON DELETE RESTRICT
+);
+CREATE INDEX IF NOT EXISTS idx_scic_request ON settlement_compute_integrity_captures(account_scope, request_id, attempt_n);
+CREATE INDEX IF NOT EXISTS idx_scic_digest ON settlement_compute_integrity_captures(request_start_snapshot_digest);
+CREATE TRIGGER IF NOT EXISTS trg_scic_capture_immutable
+BEFORE UPDATE OF capture_required, request_sampling_profile_covered,
+                 route_snapshot_hardware_class_digest, capture_json,
+                 request_start_snapshot_digest, captured_at_unix_ms
+ON settlement_compute_integrity_captures
+WHEN OLD.capture_required != NEW.capture_required
+  OR OLD.request_sampling_profile_covered != NEW.request_sampling_profile_covered
+  OR OLD.route_snapshot_hardware_class_digest != NEW.route_snapshot_hardware_class_digest
+  OR COALESCE(OLD.capture_json, '') != COALESCE(NEW.capture_json, '')
+  OR COALESCE(OLD.request_start_snapshot_digest, '') != COALESCE(NEW.request_start_snapshot_digest, '')
+  OR COALESCE(OLD.captured_at_unix_ms, -1) != COALESCE(NEW.captured_at_unix_ms, -1)
+BEGIN
+    SELECT RAISE(ABORT, 'settlement compute integrity capture is immutable');
+END;
 
 CREATE TABLE IF NOT EXISTS settlement_attempt_outputs (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -344,6 +387,9 @@ CREATE INDEX IF NOT EXISTS idx_lqr_request_latest ON ledger_quarantine_resolutio
 	if err := s.ensureLedgerRequestCreditSettlementColumns(ctx); err != nil {
 		return err
 	}
+	if err := s.ensureSettlementRouteSnapshotComputeIntegrityColumns(ctx); err != nil {
+		return err
+	}
 	if err := s.normalizeBillingTimeTextColumns(ctx); err != nil {
 		return err
 	}
@@ -357,6 +403,30 @@ CREATE INDEX IF NOT EXISTS idx_lqr_request_latest ON ledger_quarantine_resolutio
 		return err
 	}
 	return s.validateRequestLog(ctx)
+}
+
+func (s *Store) ensureSettlementRouteSnapshotComputeIntegrityColumns(ctx context.Context) error {
+	add := []struct {
+		name string
+		sql  string
+	}{
+		{"compute_integrity_capture_required", `ALTER TABLE settlement_route_snapshots ADD COLUMN compute_integrity_capture_required INTEGER NOT NULL DEFAULT 0 CHECK(compute_integrity_capture_required IN (0,1))`},
+		{"compute_integrity_sampling_profile_covered", `ALTER TABLE settlement_route_snapshots ADD COLUMN compute_integrity_sampling_profile_covered INTEGER NOT NULL DEFAULT 0 CHECK(compute_integrity_sampling_profile_covered IN (0,1))`},
+		{"compute_integrity_hardware_runtime_class_digest", `ALTER TABLE settlement_route_snapshots ADD COLUMN compute_integrity_hardware_runtime_class_digest TEXT NULL CHECK(compute_integrity_hardware_runtime_class_digest IS NULL OR (length(compute_integrity_hardware_runtime_class_digest) = 71 AND substr(compute_integrity_hardware_runtime_class_digest, 1, 7) = 'sha256:' AND substr(compute_integrity_hardware_runtime_class_digest, 8) NOT GLOB '*[^0-9a-f]*'))`},
+	}
+	for _, col := range add {
+		exists, err := s.columnExists(ctx, "settlement_route_snapshots", col.name)
+		if err != nil {
+			return err
+		}
+		if exists {
+			continue
+		}
+		if _, err := s.db.ExecContext(ctx, col.sql); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func (s *Store) ensureLedgerRequestCreditSettlementColumns(ctx context.Context) error {

--- a/phase4-coordinator/internal/buyer/route_snapshot.go
+++ b/phase4-coordinator/internal/buyer/route_snapshot.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/augstar/macprovider-coordinator/internal/billing"
 	"github.com/augstar/macprovider-coordinator/internal/catalogbind"
+	"github.com/augstar/macprovider-coordinator/internal/computeintegrity"
 	"github.com/augstar/macprovider-coordinator/internal/config"
 	"github.com/augstar/macprovider-coordinator/internal/modelidentity"
 	"github.com/augstar/macprovider-coordinator/internal/pool"
@@ -121,6 +122,13 @@ func (b *billingRecorder) recordRouteSnapshot(providerBody []byte, provider pool
 		PromptHashBasis:                    promptHashBasisCoordinatorV1,
 		PromptHash:                         promptHash,
 	}
+	computeIntegrityRequired, computeIntegrityCovered, computeIntegrityHardwareDigest, err := computeIntegrityRouteBinding(provider, routeMode)
+	if err != nil {
+		return nil, err
+	}
+	snapshot.ComputeIntegrityCaptureRequired = computeIntegrityRequired
+	snapshot.ComputeIntegritySamplingCovered = computeIntegrityCovered
+	snapshot.ComputeIntegrityHardwareDigest = computeIntegrityHardwareDigest
 	ctx, cancel := context.WithTimeout(context.Background(), requestLogWriteTimeout)
 	defer cancel()
 	digest, err := store.InsertRouteSnapshot(ctx, snapshot)
@@ -160,6 +168,56 @@ func isLowerHex64(value string) bool {
 		}
 	}
 	return true
+}
+
+func computeIntegrityRouteBinding(provider pool.Provider, routeMode string) (required bool, samplingProfileCovered bool, hardwareDigest string, err error) {
+	if routeMode != billing.RouteSnapshotModeEnforce {
+		return false, false, "", nil
+	}
+	policy := computeintegrity.NewDefaultPolicy()
+	deps := computeintegrity.ActivationDeps{
+		SPEC022Enforce:             true,
+		SPEC022CoverageSubset:      true,
+		AllModelsSignedCatalog:     true,
+		SettlementStorageReady:     true,
+		BillingExcludesNonVerified: true,
+	}
+	// SPEC-036 v0.1 enforce is explicitly maintainer-gated. Until an
+	// authoritative compute_integrity_settlement policy and activation dependency
+	// source are wired here, the safe default policy remains observe-only and
+	// production route snapshots stay dormant.
+	if policy.Mode != computeintegrity.ModeEnforce || !computeintegrity.CanActivateEnforce(policy, deps) {
+		return false, false, "", nil
+	}
+	value := map[string]any{
+		"schema_version":               "compute_integrity_route_hardware_runtime_class_v1",
+		"provider_id":                  provider.ProviderID,
+		"assigned_id":                  provider.AssignedID,
+		"model_id":                     provider.ModelID,
+		"binary_version":               provider.BinaryVersion,
+		"attestation_tier":             provider.AttestationTier,
+		"admitted_chip_normalized":     provider.AdmittedChipNormalized,
+		"admitted_unified_memory_gb":   provider.AdmittedUnifiedMemoryGB,
+		"max_admitted_model_key":       provider.MaxAdmittedModelKey,
+		"max_admitted_model_id":        provider.MaxAdmittedModelID,
+		"max_admitted_min_ram_gb":      provider.MaxAdmittedMinRAMGB,
+		"provider_reported_model_hash": strings.TrimSpace(provider.ModelHash),
+		"provider_reported_capacity":   nil,
+	}
+	if provider.HardwareCapacity != nil {
+		value["provider_reported_capacity"] = map[string]any{
+			"chip":               provider.HardwareCapacity.Chip,
+			"bandwidth_gb_per_s": provider.HardwareCapacity.BandwidthGBPerSec,
+			"network_power_kw":   provider.HardwareCapacity.NetworkPowerKW,
+			"gpu_cores_total":    provider.HardwareCapacity.GPUCoresTotal,
+			"cpu_cores_total":    provider.HardwareCapacity.CPUCoresTotal,
+		}
+	}
+	digest, _, err := billing.CanonicalSHA256Hex(value)
+	if err != nil {
+		return false, false, "", fmt.Errorf("compute integrity route hardware digest: %w", err)
+	}
+	return true, true, "sha256:" + digest, nil
 }
 
 func accountScopeForSettlement(accountID string) string {

--- a/phase4-coordinator/internal/buyer/route_snapshot_test.go
+++ b/phase4-coordinator/internal/buyer/route_snapshot_test.go
@@ -122,6 +122,9 @@ func TestRouteSnapshotsPersistBeforeDispatchAndRetryAttempts(t *testing.T) {
 		if row.Mode != billing.RouteSnapshotModeEnforce {
 			t.Fatalf("route_snapshot_mode=%q want enforce", row.Mode)
 		}
+		if row.ComputeIntegrityCaptureRequired != 0 || row.ComputeIntegritySamplingCovered != 0 || row.ComputeIntegrityHardwareDigest != "" {
+			t.Fatalf("compute integrity activated without explicit SPEC-036 enforce gate: %#v", row)
+		}
 		if len(row.Digest) != 64 || len(row.PromptHash) != 64 {
 			t.Fatalf("digest/prompt hash lengths invalid: %#v", row)
 		}
@@ -165,8 +168,11 @@ func TestRouteSnapshotsPersistBeforeDispatchAndRetryAttempts(t *testing.T) {
 	}
 	for _, verdict := range verdicts {
 		if verdict.ReceiptPresent != 0 || verdict.ReceiptResult != billing.SettlementReceiptResultInconclusive || verdict.SettlementOutcome != billing.SettlementOutcomePending {
-			t.Fatalf("verdict=%#v, want missing receipt pending/inconclusive", verdict)
+			t.Fatalf("verdict=%#v, want SPEC-036 dormant missing receipt pending/inconclusive", verdict)
 		}
+	}
+	if got := computeIntegrityCaptureMarkerCount(t, dbPath); got != 0 {
+		t.Fatalf("compute integrity capture markers=%d want 0 without explicit SPEC-036 activation", got)
 	}
 	ledgerPolicies := queryLedgerSettlementPolicies(t, dbPath)
 	if len(ledgerPolicies) != 2 {
@@ -999,12 +1005,15 @@ func TestUnavailableOutputAfterPrefixKeepsEmptyRange(t *testing.T) {
 }
 
 type routeSnapshotRow struct {
-	AttemptN   int
-	ProviderID string
-	Status     string
-	Mode       string
-	Digest     string
-	PromptHash string
+	AttemptN                        int
+	ProviderID                      string
+	Status                          string
+	Mode                            string
+	Digest                          string
+	PromptHash                      string
+	ComputeIntegrityCaptureRequired int
+	ComputeIntegritySamplingCovered int
+	ComputeIntegrityHardwareDigest  string
 }
 
 type settlementAttemptOutputRow struct {
@@ -1099,9 +1108,11 @@ func queryRouteSnapshots(t *testing.T, dbPath string) []routeSnapshotRow {
 	}
 	defer db.Close()
 	rows, err := db.Query(`
-SELECT attempt_n, provider_id, spec008_hash_status, route_snapshot_mode, route_snapshot_digest, prompt_hash
-FROM settlement_route_snapshots
-ORDER BY attempt_n ASC`)
+	SELECT attempt_n, provider_id, spec008_hash_status, route_snapshot_mode, route_snapshot_digest, prompt_hash,
+	       compute_integrity_capture_required, compute_integrity_sampling_profile_covered,
+	       COALESCE(compute_integrity_hardware_runtime_class_digest, '')
+	FROM settlement_route_snapshots
+	ORDER BY attempt_n ASC`)
 	if err != nil {
 		t.Fatalf("query snapshots: %v", err)
 	}
@@ -1109,7 +1120,7 @@ ORDER BY attempt_n ASC`)
 	var got []routeSnapshotRow
 	for rows.Next() {
 		var row routeSnapshotRow
-		if err := rows.Scan(&row.AttemptN, &row.ProviderID, &row.Status, &row.Mode, &row.Digest, &row.PromptHash); err != nil {
+		if err := rows.Scan(&row.AttemptN, &row.ProviderID, &row.Status, &row.Mode, &row.Digest, &row.PromptHash, &row.ComputeIntegrityCaptureRequired, &row.ComputeIntegritySamplingCovered, &row.ComputeIntegrityHardwareDigest); err != nil {
 			t.Fatalf("scan snapshots: %v", err)
 		}
 		got = append(got, row)
@@ -1156,6 +1167,25 @@ func payoutReadyCount(t *testing.T, dbPath string) int {
 	var count int
 	if err := db.QueryRow(`SELECT COUNT(*) FROM ledger_payout_ready`).Scan(&count); err != nil {
 		t.Fatalf("count payout-ready: %v", err)
+	}
+	return count
+}
+
+func computeIntegrityCaptureMarkerCount(t *testing.T, dbPath string) int {
+	t.Helper()
+	db, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer db.Close()
+	var count int
+	if err := db.QueryRow(`
+SELECT COUNT(*)
+  FROM settlement_compute_integrity_captures
+ WHERE capture_required = 1
+   AND capture_json IS NULL
+   AND request_start_snapshot_digest IS NULL`).Scan(&count); err != nil {
+		t.Fatalf("count compute integrity capture markers: %v", err)
 	}
 	return count
 }

--- a/phase4-coordinator/internal/computeintegrity/settlement.go
+++ b/phase4-coordinator/internal/computeintegrity/settlement.go
@@ -115,6 +115,9 @@ type Decision struct {
 // Evaluate resolves the SPEC-036 gate decision for a captured request-start state
 // (FR-3, FR-4). Settlement is a pure function of the immutable capture.
 func Evaluate(c Capture) Decision {
+	if c.Unreadable {
+		return Decision{Applies: true, Payable: false, Reason: ReasonUnreadable}
+	}
 	// A missing/unreadable composite SPEC-022 binding fails closed BEFORE the not-enforce
 	// early return (FR-4): a malformed capture whose binding is absent must not be paid
 	// through as if SPEC-022 were legitimately not enforcing.

--- a/phase4-coordinator/internal/computeintegrity/settlement_test.go
+++ b/phase4-coordinator/internal/computeintegrity/settlement_test.go
@@ -357,6 +357,16 @@ func TestAC16_ClosedReasonPrecedence(t *testing.T) {
 		}
 	})
 
+	t.Run("an explicitly unreadable capture fails closed before false enforce passthrough", func(t *testing.T) {
+		c := payableCapture()
+		c.Spec022EffectiveEnforce = false
+		c.Unreadable = true
+		d := Evaluate(c)
+		if !d.Applies || d.Payable || d.Reason != ReasonUnreadable {
+			t.Fatalf("explicit unreadable capture must fail closed unreadable, got %+v", d)
+		}
+	})
+
 	t.Run("swap_laundering outranks manual_review outranks reference outranks drift", func(t *testing.T) {
 		order := []struct {
 			state  State

--- a/specs/CONFORMANCE.json
+++ b/specs/CONFORMANCE.json
@@ -1452,7 +1452,7 @@
     {
       "requirement_id": "SPEC-010-R004",
       "spec_id": "SPEC-010",
-      "state": "conformant",
+      "state": "pending",
       "implementation": [
         "phase4-coordinator/internal/ws/server.go:expectedAdmissionModelHash",
         "phase4-coordinator/internal/ws/server.go:expectedProviderModelHash",
@@ -1483,7 +1483,12 @@
           "expires_at": "2026-11-10"
         }
       ],
-      "gap": null
+      "gap": {
+        "verdict": "UNKNOWN",
+        "owner": "@Augustas11",
+        "issue": "https://github.com/Augustas11/macprovider/issues/1007",
+        "rationale": "This change updates the buyer route snapshot selector that was covered by historical commit evidence; current conformance requires a new post-change signed provider prebeta journey."
+      }
     },
     {
       "requirement_id": "SPEC-010-R005",
@@ -2465,42 +2470,75 @@
       "requirement_id": "SPEC-036-R002",
       "spec_id": "SPEC-036",
       "state": "pending",
-      "implementation": [],
-      "tests": [],
+      "implementation": [
+        "phase4-coordinator/internal/buyer/route_snapshot.go:computeIntegrityRouteBinding",
+        "phase4-coordinator/internal/billing/route_snapshot.go:RouteSnapshot",
+        "phase4-coordinator/internal/billing/settlement_verifier.go:verifySettlementReceiptSPEC022",
+        "phase4-coordinator/internal/billing/settlement_compute_integrity.go:loadComputeIntegrityCaptureConn"
+      ],
+      "tests": [
+        "phase4-coordinator/internal/billing/settlement_compute_integrity_test.go:TestComputeIntegrityObserveRouteDoesNotChangeMoneyOutcome",
+        "phase4-coordinator/internal/billing/settlement_compute_integrity_test.go:signedSettlementReceiptForInputWithKey"
+      ],
       "journeys": [],
       "evidence": [],
       "gap": {
         "verdict": "UNKNOWN",
         "owner": "@Augustas11",
-        "issue": "https://github.com/Augustas11/macprovider/issues/614"
+        "issue": "https://github.com/Augustas11/macprovider/issues/1007",
+        "rationale": "Code and tests preserve SPEC-015 v0.4 receipt/usage shape while adding SPEC-036 as out-of-band settlement context; conformant state is pending signed journey and commit evidence."
       }
     },
     {
       "requirement_id": "SPEC-036-R003",
       "spec_id": "SPEC-036",
       "state": "pending",
-      "implementation": [],
-      "tests": [],
+      "implementation": [
+        "phase4-coordinator/internal/billing/settlement_verifier.go:applyComputeIntegrityGate",
+        "phase4-coordinator/internal/computeintegrity/settlement.go:Evaluate",
+        "phase4-coordinator/internal/computeintegrity/settlement.go:ApplyGate"
+      ],
+      "tests": [
+        "phase4-coordinator/internal/billing/settlement_compute_integrity_test.go:TestComputeIntegrityDriftQuarantinesVerifiedSettlementAndExcludesPayout",
+        "phase4-coordinator/internal/billing/settlement_compute_integrity_test.go:TestComputeIntegrityCleanCaptureDoesNotPromoteZeroSettledSPEC022",
+        "phase4-coordinator/internal/billing/settlement_compute_integrity_test.go:TestComputeIntegrityObserveRouteDoesNotChangeMoneyOutcome",
+        "phase4-coordinator/internal/computeintegrity/settlement_test.go:TestAC05_SettlementOutcomeMapping"
+      ],
       "journeys": [],
       "evidence": [],
       "gap": {
         "verdict": "UNKNOWN",
         "owner": "@Augustas11",
-        "issue": "https://github.com/Augustas11/macprovider/issues/614"
+        "issue": "https://github.com/Augustas11/macprovider/issues/1007",
+        "rationale": "Settlement now composes computeintegrity.Evaluate/ApplyGate over SPEC-022 finality and payout readiness still reads only verified settlement rows; conformant state is pending signed journey and commit evidence."
       }
     },
     {
       "requirement_id": "SPEC-036-R004",
       "spec_id": "SPEC-036",
       "state": "pending",
-      "implementation": [],
-      "tests": [],
+      "implementation": [
+        "phase4-coordinator/internal/buyer/route_snapshot.go:recordRouteSnapshot",
+        "phase4-coordinator/internal/billing/route_snapshot.go:InsertRouteSnapshot",
+        "phase4-coordinator/internal/billing/store.go:ensureSettlementRouteSnapshotComputeIntegrityColumns",
+        "phase4-coordinator/internal/billing/settlement_compute_integrity.go:InsertComputeIntegrityCapture",
+        "phase4-coordinator/internal/billing/settlement_compute_integrity.go:MarkComputeIntegrityCaptureRequired",
+        "phase4-coordinator/internal/billing/settlement_compute_integrity.go:loadComputeIntegrityCaptureConn"
+      ],
+      "tests": [
+        "phase4-coordinator/internal/billing/settlement_compute_integrity_test.go:TestComputeIntegrityMissingOrUnreadableCaptureFailsClosed",
+        "phase4-coordinator/internal/billing/settlement_compute_integrity_test.go:TestComputeIntegrityCaptureRouteMismatchFailsClosed",
+        "phase4-coordinator/internal/billing/settlement_compute_integrity_test.go:TestComputeIntegrityCaptureIsImmutable",
+        "phase4-coordinator/internal/billing/settlement_compute_integrity_test.go:TestComputeIntegrityDriftQuarantinesVerifiedSettlementAndExcludesPayout",
+        "phase4-coordinator/internal/buyer/route_snapshot_test.go:TestRouteSnapshotsPersistBeforeDispatchAndRetryAttempts"
+      ],
       "journeys": [],
       "evidence": [],
       "gap": {
         "verdict": "UNKNOWN",
         "owner": "@Augustas11",
-        "issue": "https://github.com/Augustas11/macprovider/issues/614"
+        "issue": "https://github.com/Augustas11/macprovider/issues/1007",
+        "rationale": "Billing now persists a keyed immutable request-start capture/required marker and loads only that stored capture during settlement; conformant state is pending signed journey and commit evidence."
       }
     },
     {

--- a/specs/README.md
+++ b/specs/README.md
@@ -18,7 +18,7 @@ it can no longer drift. Do not hand-edit the table; edit each spec's
 | SPEC-007 | Internal Operator Protocol Explorer | 0.5.1 | normative | pending | pending corpus migration | [SPEC-007-explorer.md](SPEC-007-explorer.md) |
 | SPEC-008 | Tier-2 Trust Layer | 0.5.1 | normative | pending | pending: 1 | [SPEC-008-tier2.md](SPEC-008-tier2.md) |
 | SPEC-009 | MacProvider Console v2 | 0.1 | normative | pending | pending corpus migration | [SPEC-009-console-v2.md](SPEC-009-console-v2.md) |
-| SPEC-010 | Provider Model Catalog | 1.6 | normative | pending | conformant: 6 | [SPEC-010-model-catalog.md](SPEC-010-model-catalog.md) |
+| SPEC-010 | Provider Model Catalog | 1.6 | normative | pending | conformant: 5, pending: 1 | [SPEC-010-model-catalog.md](SPEC-010-model-catalog.md) |
 | SPEC-011 | Operator-Pushed Warm Swap | 0.5 | normative | pending | pending corpus migration | [SPEC-011-operator-pushed-warm-swap.md](SPEC-011-operator-pushed-warm-swap.md) |
 | SPEC-012 | Coordinator Demand-Pull Model Swap and Buyer Cold-Model Visibility | 0.3 | draft | pending | pending corpus migration | [SPEC-012-coordinator-demand-pull.md](SPEC-012-coordinator-demand-pull.md) |
 | SPEC-013 | `macprovider-cli autotune` subcommand | 0.3.1 | normative | pending | pending corpus migration | [SPEC-013-cli-autotune.md](SPEC-013-cli-autotune.md) |


### PR DESCRIPTION
## Summary

Live-wires SPEC-036 compute-integrity settlement storage into the coordinator settlement path without making SPEC-036 active for production traffic until its own explicit activation gate passes.

- Persists out-of-band compute-integrity route/capture state for settlement without changing the SPEC-015/SPEC-022 route digest preimage.
- Loads immutable request-start capture evidence during settlement and composes `computeintegrity.Evaluate` / `ApplyGate` as a subordinate AND-gate on SPEC-022.
- Fails closed for covered enforce rows with missing, unreadable, malformed, or route-mismatched capture evidence.
- Keeps production SPEC-036 dormant under the default observe/unactivated policy, so SPEC-022 enforce alone does not alter money outcomes or preinsert missing-capture markers.
- Reconciles CONFORMANCE evidence honestly and moves SPEC-010-R004 back to pending re-verification because this patch changes its previously evidenced buyer route snapshot selector.

## Audit

3-lane Codex audit over `git diff --cached origin/main` completed with 0 C/H/M findings:

- Code lane: C/H/M findings: 0
- Security lane: C/H/M findings: 0
- Architecture lane: C/H/M findings: 0

Low advisory retained: the missing-capture marker helper remains available for test/future wiring, but production currently has no caller; future activation must write the real request-start capture first and mark missing only after capture is definitively unavailable.

## Validation

- `go test ./internal/buyer -count=1`
- `go test ./internal/billing -count=1`
- `go test ./internal/computeintegrity -count=1`
- `go test ./...` from `phase4-coordinator`
- `go vet ./internal/buyer ./internal/billing ./internal/computeintegrity`
- `python3 scripts/check_spec_governance.py`
- `python3 scripts/gen_spec_index.py --check`
- `git diff --cached --check`

SPEC-GOVERNANCE-DECLARATION-BEGIN
{
  "schema_version": "spec-pr-governance-v1",
  "behavior_change": "yes",
  "contract_change": "yes",
  "specs": ["SPEC-010", "SPEC-022", "SPEC-036"],
  "requirements": ["SPEC-010-R004", "SPEC-036-R002", "SPEC-036-R003", "SPEC-036-R004"],
  "authority_domains": ["model-catalog-identity", "verified-model-settlement", "compute-integrity-settlement"],
  "arbitration": ["CODE_BUG"],
  "tests": [
    "go test ./internal/buyer -count=1",
    "go test ./internal/billing -count=1",
    "go test ./internal/computeintegrity -count=1",
    "go test ./... (phase4-coordinator)",
    "go vet ./internal/buyer ./internal/billing ./internal/computeintegrity",
    "python3 scripts/check_spec_governance.py"
  ],
  "journeys": ["not-required"],
  "issue": "https://github.com/Augustas11/macprovider/issues/1007"
}
SPEC-GOVERNANCE-DECLARATION-END

Closes #1007
