### PR TITLE
Expose unavailable compute-integrity status to buyers

### DIFF
--- a/phase4-coordinator/internal/buyer/server.go
+++ b/phase4-coordinator/internal/buyer/server.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/augstar/macprovider-coordinator/internal/auth"
 	"github.com/augstar/macprovider-coordinator/internal/billing"
+	"github.com/augstar/macprovider-coordinator/internal/computeintegrity"
 	"github.com/augstar/macprovider-coordinator/internal/config"
 	"github.com/augstar/macprovider-coordinator/internal/pool"
 	"github.com/augstar/macprovider-coordinator/internal/providerhttp"
@@ -1633,17 +1634,28 @@ type modelsResponse struct {
 }
 
 type modelEntry struct {
-	ID               string            `json:"id"`
-	Object           string            `json:"object"`
-	Created          int64             `json:"created"`
-	OwnedBy          string            `json:"owned_by"`
-	ProviderCount    int               `json:"provider_count"`
-	MaxContextTokens int               `json:"max_context_tokens"`
-	TotalSlots       int               `json:"total_slots"`
-	Objective        string            `json:"objective,omitempty"`
-	Members          []string          `json:"members,omitempty"`
-	HashVerified     interface{}       `json:"hash_verified,omitempty"`
-	HashVerification *hashVerification `json:"hash_verification,omitempty"`
+	ID               string                      `json:"id"`
+	Object           string                      `json:"object"`
+	Created          int64                       `json:"created"`
+	OwnedBy          string                      `json:"owned_by"`
+	ProviderCount    int                         `json:"provider_count"`
+	MaxContextTokens int                         `json:"max_context_tokens"`
+	TotalSlots       int                         `json:"total_slots"`
+	Objective        string                      `json:"objective,omitempty"`
+	Members          []string                    `json:"members,omitempty"`
+	ComputeIntegrity modelComputeIntegrityStatus `json:"compute_integrity"`
+	HashVerified     interface{}                 `json:"hash_verified,omitempty"`
+	HashVerification *hashVerification           `json:"hash_verification,omitempty"`
+}
+
+type modelComputeIntegrityStatus struct {
+	SchemaVersion          string `json:"schema_version"`
+	Status                 string `json:"status"`
+	Mode                   string `json:"mode"`
+	SettlementEffect       string `json:"settlement_effect"`
+	LiveTelemetryAvailable bool   `json:"live_telemetry_available"`
+	Reason                 string `json:"reason"`
+	Disclosure             string `json:"disclosure"`
 }
 
 type hashVerification struct {
@@ -1653,6 +1665,20 @@ type hashVerification struct {
 	MismatchProviderCount     int    `json:"mismatch_provider_count"`
 	InvalidProviderCount      int    `json:"invalid_provider_count"`
 	Catalogued                bool   `json:"catalogued"`
+}
+
+const buyerComputeIntegrityUnavailableDisclosure = computeintegrity.StatusCopyV1 + " Per-model buyer status is unavailable until live sanitized telemetry is wired; this field is not derived from static spec/package availability."
+
+func unavailableModelComputeIntegrityStatus() modelComputeIntegrityStatus {
+	return modelComputeIntegrityStatus{
+		SchemaVersion:          "buyer_compute_integrity_status_v1",
+		Status:                 "unavailable",
+		Mode:                   "unavailable",
+		SettlementEffect:       "not_evaluated",
+		LiveTelemetryAvailable: false,
+		Reason:                 "live_status_source_unavailable",
+		Disclosure:             buyerComputeIntegrityUnavailableDisclosure,
+	}
 }
 
 func (s *Server) handleModels(w http.ResponseWriter, r *http.Request) {
@@ -1672,10 +1698,11 @@ func (s *Server) handleModels(w http.ResponseWriter, r *http.Request) {
 		entry := models[p.ModelID]
 		if entry.ID == "" {
 			entry = modelEntry{
-				ID:      p.ModelID,
-				Object:  "model",
-				Created: s.createdAt,
-				OwnedBy: "macprovider",
+				ID:               p.ModelID,
+				Object:           "model",
+				Created:          s.createdAt,
+				OwnedBy:          "macprovider",
+				ComputeIntegrity: unavailableModelComputeIntegrityStatus(),
 			}
 		}
 		if !excluded {
@@ -1696,6 +1723,7 @@ func (s *Server) handleModels(w http.ResponseWriter, r *http.Request) {
 		data = append(data, modelEntry{
 			ID: name, Object: "model", Created: s.createdAt, OwnedBy: "macprovider",
 			Objective: class.Objective, Members: append([]string(nil), modelClassMembers(&class)...),
+			ComputeIntegrity: unavailableModelComputeIntegrityStatus(),
 		})
 	}
 	if pillarAActive {

--- a/phase4-coordinator/internal/buyer/server_test.go
+++ b/phase4-coordinator/internal/buyer/server_test.go
@@ -509,6 +509,67 @@ func TestModelsDefaultHasNoTier2HashFields(t *testing.T) {
 	}
 }
 
+func TestModelsIncludesComputeIntegrityUnavailableStatus(t *testing.T) {
+	registry := pool.NewRegistry([]config.ProviderConfig{{ProviderID: "p1", EndpointURL: "https://p1.example"}})
+	register(registry, "p1", "session-1", "model-a", pool.StateReady, 20000, 1)
+	server := buyer.NewServer(registry, zerolog.Nop(), time.Unix(1716768000, 0))
+	req := httptest.NewRequest(http.MethodGet, "/v1/models", nil)
+	rr := httptest.NewRecorder()
+
+	server.Handler().ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rr.Code)
+	}
+	var got struct {
+		Data []struct {
+			ID               string `json:"id"`
+			ComputeIntegrity struct {
+				SchemaVersion          string `json:"schema_version"`
+				Status                 string `json:"status"`
+				Mode                   string `json:"mode"`
+				SettlementEffect       string `json:"settlement_effect"`
+				LiveTelemetryAvailable bool   `json:"live_telemetry_available"`
+				Reason                 string `json:"reason"`
+				Disclosure             string `json:"disclosure"`
+			} `json:"compute_integrity"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(rr.Body.Bytes(), &got); err != nil {
+		t.Fatalf("json: %v", err)
+	}
+	if len(got.Data) != 1 {
+		t.Fatalf("data len = %d, want 1; body=%s", len(got.Data), rr.Body.String())
+	}
+	status := got.Data[0].ComputeIntegrity
+	if got.Data[0].ID != "model-a" ||
+		status.SchemaVersion != "buyer_compute_integrity_status_v1" ||
+		status.Status != "unavailable" ||
+		status.Mode != "unavailable" ||
+		status.SettlementEffect != "not_evaluated" ||
+		status.LiveTelemetryAvailable ||
+		status.Reason != "live_status_source_unavailable" {
+		t.Fatalf("compute_integrity unavailable status mismatch: %+v body=%s", status, rr.Body.String())
+	}
+	for _, want := range []string{
+		"overt distribution-drift readiness signal",
+		"not cryptographic proof of honest computation",
+		"not hardware integrity",
+		"not runtime binary integrity",
+		"not derived from static spec/package availability",
+	} {
+		if !strings.Contains(status.Disclosure, want) {
+			t.Fatalf("compute_integrity disclosure missing %q: %q", want, status.Disclosure)
+		}
+	}
+	raw := rr.Body.String()
+	for _, forbidden := range []string{"provider_id", "assigned_id", "prompt", "output"} {
+		if strings.Contains(raw, forbidden) {
+			t.Fatalf("compute_integrity response leaked %s: %s", forbidden, raw)
+		}
+	}
+}
+
 func TestModelsDefaultIncludesReadyProvidersWithoutFreeSlots(t *testing.T) {
 	registry := pool.NewRegistry([]config.ProviderConfig{{ProviderID: "p1", EndpointURL: "https://p1.example"}})
 	registerWithHashStatusSlots(registry, "p1", "session-1", "model-a", pool.StateReady, 20000, 0, 1, "https://p1.example", "")

--- a/phase5-gateway/internal/router/disclosure.go
+++ b/phase5-gateway/internal/router/disclosure.go
@@ -20,6 +20,7 @@ type tier1Disclosure struct {
 	RelayBlindRequestEncryption *relayBlindRequestEncryptionDisclosure `json:"relay_blind_request_encryption,omitempty"`
 	ModelVerificationLimit      string                                 `json:"model_verification_limit"`
 	VerifiedModelSettlement     verifiedModelSettlementDisclosure      `json:"verified_model_settlement"`
+	ComputeIntegrity            computeIntegrityDisclosure             `json:"compute_integrity"`
 	ModelHashVerified           string                                 `json:"model_hash_verified,omitempty"`
 	ProviderLegEncryption       string                                 `json:"provider_leg_encryption,omitempty"`
 	UntrustedProviderSafety     string                                 `json:"untrusted_provider_safety,omitempty"`
@@ -110,6 +111,37 @@ type settlementOutcomeDisclosure struct {
 	ZeroSettled string `json:"zero_settled"`
 }
 
+type computeIntegrityDisclosure struct {
+	SchemaVersion          string                        `json:"schema_version"`
+	CurrentStatus          string                        `json:"current_status"`
+	CurrentMode            string                        `json:"current_mode"`
+	StatusSource           string                        `json:"status_source"`
+	LiveTelemetryAvailable bool                          `json:"live_telemetry_available"`
+	SettlementEffect       string                        `json:"settlement_effect"`
+	Labels                 computeIntegrityLabelGlossary `json:"labels"`
+	Disclosure             string                        `json:"disclosure"`
+}
+
+type computeIntegrityLabelGlossary struct {
+	Unavailable  string `json:"unavailable"`
+	Observing    string `json:"observing"`
+	WarnOnly     string `json:"warn_only"`
+	Enforcing    string `json:"enforcing"`
+	Quarantined  string `json:"quarantined"`
+	Blocked      string `json:"blocked"`
+	StaleExpired string `json:"stale_expired"`
+}
+
+type modelComputeIntegrityStatus struct {
+	SchemaVersion          string `json:"schema_version"`
+	Status                 string `json:"status"`
+	Mode                   string `json:"mode"`
+	SettlementEffect       string `json:"settlement_effect"`
+	LiveTelemetryAvailable bool   `json:"live_telemetry_available"`
+	Reason                 string `json:"reason"`
+	Disclosure             string `json:"disclosure"`
+}
+
 type coordinatorRoutingMetadata struct {
 	Sticky struct {
 		Enabled    bool `json:"enabled"`
@@ -140,28 +172,30 @@ func (m coordinatorEncryptedLegMetadata) active() bool {
 }
 
 func (m coordinatorEncryptedLegMetadata) disclosureState() string {
-	if !m.active() {
+	switch m.State {
+	case "all":
+		return "all"
+	case "partial":
+		return "partial"
+	default:
 		return "none"
 	}
-	if m.State == "all" {
-		return "all"
-	}
-	return "partial"
 }
 
 func (m coordinatorEncryptedLegMetadata) toDisclosure() encryptedLegDisclosure {
-	if !m.active() {
+	state := m.disclosureState()
+	if state == "none" {
 		return encryptedLegDisclosure{State: "none", Scope: "coordinator_to_provider_only"}
 	}
 	scope := m.Scope
-	if scope == "" {
+	if scope != "coordinator_to_provider_only" {
 		scope = "coordinator_to_provider_only"
 	}
 	return encryptedLegDisclosure{
-		State:                    m.State,
+		State:                    state,
 		EncryptedProviderCount:   m.EncryptedProviderCount,
 		UnencryptedProviderCount: m.UnencryptedProviderCount,
-		Mixed:                    m.Mixed || m.State == "partial",
+		Mixed:                    m.Mixed || state == "partial",
 		Scope:                    scope,
 	}
 }
@@ -187,14 +221,15 @@ func (m coordinatorAttestationMetadata) disclosureState() string {
 }
 
 func (m coordinatorAttestationMetadata) toDisclosure() attestationDisclosure {
-	if !m.active() {
+	state := m.disclosureState()
+	if state == "none" {
 		return attestationDisclosure{State: "none"}
 	}
 	return attestationDisclosure{
-		State:                    m.State,
+		State:                    state,
 		AttestedProviderCount:    m.AttestedProviderCount,
 		UnsupportedProviderCount: m.UnsupportedProviderCount,
-		Mixed:                    m.Mixed || m.State == "partial",
+		Mixed:                    m.Mixed || state == "partial",
 	}
 }
 
@@ -210,21 +245,23 @@ func (m coordinatorBehavioralSafetyMetadata) active() bool {
 }
 
 func (m coordinatorBehavioralSafetyMetadata) disclosureState() string {
-	if !m.active() {
+	switch m.State {
+	case "enforced":
+		return "enforced"
+	case "partial":
+		return "partial"
+	default:
 		return "none"
 	}
-	if m.State == "enforced" {
-		return "enforced"
-	}
-	return "partial"
 }
 
 func (m coordinatorBehavioralSafetyMetadata) toDisclosure() behavioralSafetyDisclosure {
-	if !m.active() {
+	state := m.disclosureState()
+	if state == "none" {
 		return behavioralSafetyDisclosure{State: "none"}
 	}
 	return behavioralSafetyDisclosure{
-		State:              m.State,
+		State:              state,
 		SizeCap:            m.SizeCap,
 		EncodingValidation: m.EncodingValidation,
 		TTFTAnomalyLogging: m.TTFTAnomalyLogging,
@@ -246,6 +283,41 @@ const settlementZeroSettledOutcomeDisclosure = "zero_settled: not charged becaus
 const settlementPartialChargeDisclosure = "Buyer cancel, gateway timeout, provider error, or upstream disconnect can create a partial charge only when a settlement-capable receipt binds the delivered output prefix and partial usage."
 const settlementStreamingFailoverDisclosure = "Streaming failover is transparent only before response bytes are committed. After the first buyer-visible SSE event, a provider disconnect terminates the stream with provider_disconnected and the buyer may retry as a new request. That retry is a separate billable request with its own reservation and settlement; cross-request overlapping output is not deduplicated. Settlement remains limited to delivered, receipt-verified output prefixes and must not double-charge overlapping output if a future resume or failover protocol spans multiple provider attempts; verified here means receipt-bound under the provider-reported-hash caveat above."
 const settlementBuyerReceiptStatusDisclosure = "Buyer receipt and status surfaces expose pending, verified, quarantined, and zero_settled labels without raw prompts or raw outputs."
+const computeIntegrityDisclosureCopy = "SPEC-036 compute-integrity is sampled/overt distribution-drift readiness telemetry against approved references. It is unavailable here until live sanitized telemetry backs the per-model status. It is not proof of honest computation, hardware integrity, runtime binary integrity, private inference, or malicious-provider resistance."
+const modelComputeIntegrityUnavailableDisclosure = "SPEC-036 v0.1 is an overt distribution-drift readiness signal against approved references. It is not cryptographic proof of honest computation, not hardware integrity, not runtime binary integrity, and not covert attestation. Per-model buyer status is unavailable until live sanitized telemetry is wired; this field is not derived from static spec/package availability."
+
+func makeModelComputeIntegrityUnavailableStatus() modelComputeIntegrityStatus {
+	return modelComputeIntegrityStatus{
+		SchemaVersion:          "buyer_compute_integrity_status_v1",
+		Status:                 "unavailable",
+		Mode:                   "unavailable",
+		SettlementEffect:       "not_evaluated",
+		LiveTelemetryAvailable: false,
+		Reason:                 "live_status_source_unavailable",
+		Disclosure:             modelComputeIntegrityUnavailableDisclosure,
+	}
+}
+
+func makeComputeIntegrityDisclosure() computeIntegrityDisclosure {
+	return computeIntegrityDisclosure{
+		SchemaVersion:          "buyer_compute_integrity_disclosure_v1",
+		CurrentStatus:          "unavailable",
+		CurrentMode:            "unavailable",
+		StatusSource:           "live_telemetry_unavailable",
+		LiveTelemetryAvailable: false,
+		SettlementEffect:       "not_evaluated",
+		Labels: computeIntegrityLabelGlossary{
+			Unavailable:  "no live sanitized telemetry currently backs buyer-visible per-model compute-integrity status",
+			Observing:    "live telemetry is sampled/overt observation only and does not affect settlement",
+			WarnOnly:     "live telemetry reports warn readiness without blocking paid admission",
+			Enforcing:    "policy-backed live telemetry may affect covered SPEC-022 settlement/admission gates",
+			Quarantined:  "live telemetry/adjudication marked compute drift or a related adverse state",
+			Blocked:      "covered paid admission is blocked for the affected compute-integrity scope",
+			StaleExpired: "previous live telemetry is stale or expired and needs fresh evidence",
+		},
+		Disclosure: computeIntegrityDisclosureCopy,
+	}
+}
 
 func makeVerifiedModelSettlementDisclosure(includeResponses, includeAnthropicMessages bool) verifiedModelSettlementDisclosure {
 	included := []string{"POST /v1/chat/completions"}
@@ -338,6 +410,7 @@ func (s *Server) makeTier1Disclosure(ctxs ...context.Context) tier1Disclosure {
 		Tier2Milestone:          "future",
 		ModelVerificationLimit:  modelVerificationLimitDisclosure,
 		VerifiedModelSettlement: makeVerifiedModelSettlementDisclosure(s.cfg.Features.ResponsesAPIEnabled, s.cfg.Features.AnthropicMessagesEnabled),
+		ComputeIntegrity:        makeComputeIntegrityDisclosure(),
 		StickyAffinity: &stickyAffinityDisclosure{
 			Enabled: false, TTLSeconds: 0,
 			Description: "Sticky affinity is disabled; related requests are not preferentially routed to the same provider.",

--- a/phase5-gateway/internal/router/server.go
+++ b/phase5-gateway/internal/router/server.go
@@ -369,6 +369,7 @@ func (s *Server) handleModels(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusBadGateway, "api_error", "coordinator_models_error", "Coordinator models error")
 		return
 	}
+	sanitizeModelsResponse(body)
 	disclosure, ok := s.tier1DisclosureForModels(body, r.Context())
 	if !ok {
 		writeError(w, http.StatusBadGateway, "api_error", "tier2_metadata_unavailable", "Coordinator Tier-2 metadata unavailable")
@@ -380,6 +381,301 @@ func (s *Server) handleModels(w http.ResponseWriter, r *http.Request) {
 	}
 	copyCleanHeaders(w.Header(), resp.Header)
 	writeJSON(w, http.StatusOK, body)
+}
+
+func sanitizeModelsResponse(body map[string]any) {
+	for key, value := range body {
+		if sanitized, ok := sanitizeModelsTopLevelValue(key, value); ok {
+			body[key] = sanitized
+		} else {
+			delete(body, key)
+		}
+	}
+	data, ok := body["data"].([]any)
+	if !ok {
+		body["data"] = []any{}
+		return
+	}
+	candidates := make([]sanitizedModelCandidate, 0, len(data))
+	modelIDs := make(map[string]struct{}, len(data))
+	for _, item := range data {
+		model, ok := item.(map[string]any)
+		if !ok {
+			continue
+		}
+		clean := make(map[string]any, len(model)+1)
+		var rawMembers any
+		for key, value := range model {
+			if key == "members" {
+				rawMembers = value
+				continue
+			}
+			if sanitizedValue, ok := sanitizeModelEntryValue(key, value); ok {
+				clean[key] = sanitizedValue
+			}
+		}
+		id, ok := sanitizedModelEntryID(clean)
+		if !ok {
+			continue
+		}
+		clean["compute_integrity"] = makeModelComputeIntegrityUnavailableStatus()
+		modelIDs[id] = struct{}{}
+		candidates = append(candidates, sanitizedModelCandidate{entry: clean, rawMembers: rawMembers})
+	}
+	sanitized := make([]any, 0, len(candidates))
+	for _, candidate := range candidates {
+		if members, ok := sanitizeMemberReferences(candidate.rawMembers, modelIDs); ok {
+			candidate.entry["members"] = members
+		}
+		sanitized = append(sanitized, candidate.entry)
+	}
+	body["data"] = sanitized
+}
+
+type sanitizedModelCandidate struct {
+	entry      map[string]any
+	rawMembers any
+}
+
+func sanitizedModelEntryID(entry map[string]any) (string, bool) {
+	id, ok := entry["id"].(string)
+	if !ok || !isPublicModelID(id) {
+		return "", false
+	}
+	return id, true
+}
+
+func sanitizeModelsTopLevelValue(key string, value any) (any, bool) {
+	switch key {
+	case "object":
+		return value, valueIsStringEnum(value, "list")
+	case "data":
+		return value, true
+	case "tier2":
+		return sanitizeTier2Metadata(value)
+	case "provider_count", "total_slots":
+		return value, valueIsJSONNumber(value)
+	default:
+		return nil, false
+	}
+}
+
+func sanitizeModelEntryValue(key string, value any) (any, bool) {
+	switch key {
+	case "id":
+		return value, valueIsPublicModelID(value)
+	case "object":
+		return value, valueIsStringEnum(value, "model")
+	case "owned_by":
+		return value, valueIsStringEnum(value, "macprovider")
+	case "objective":
+		return value, valueIsStringEnum(value, "fast", "balanced", "accurate")
+	case "created", "provider_count", "max_context_tokens", "total_slots":
+		return value, valueIsJSONNumber(value)
+	case "hash_verified":
+		return sanitizeHashVerified(value)
+	case "hash_verification":
+		return sanitizeHashVerification(value)
+	case "degraded":
+		return value, valueIsBool(value)
+	default:
+		return nil, false
+	}
+}
+
+func sanitizeHashVerified(value any) (any, bool) {
+	if valueIsBool(value) {
+		return value, true
+	}
+	if s, ok := value.(string); ok && s == "uncatalogued" {
+		return value, true
+	}
+	return nil, false
+}
+
+func sanitizeHashVerification(value any) (any, bool) {
+	raw, ok := value.(map[string]any)
+	if !ok {
+		return nil, false
+	}
+	clean := map[string]any{}
+	for key, child := range raw {
+		switch key {
+		case "status":
+			if valueIsStringEnum(child, "all_uncatalogued", "catalog_unavailable", "mismatch", "all_verified", "partial") {
+				clean[key] = child
+			}
+		case "verified_provider_count", "uncatalogued_provider_count", "mismatch_provider_count", "invalid_provider_count":
+			if valueIsJSONNumber(child) {
+				clean[key] = child
+			}
+		case "catalogued":
+			if valueIsBool(child) {
+				clean[key] = child
+			}
+		}
+	}
+	return clean, len(clean) > 0
+}
+
+func sanitizeTier2Metadata(value any) (any, bool) {
+	raw, ok := value.(map[string]any)
+	if !ok {
+		return nil, false
+	}
+	clean := map[string]any{}
+	for key, child := range raw {
+		switch key {
+		case "phase":
+			if valueIsTier2Phase(child) {
+				clean[key] = child
+			}
+		case "model_hash":
+			if modelHash, ok := sanitizeMapFields(child, map[string]func(any) bool{
+				"active":                      valueIsBool,
+				"state":                       func(v any) bool { return valueIsStringEnum(v, "none", "required", "all", "partial") },
+				"verified_count":              valueIsJSONNumber,
+				"uncatalogued_count":          valueIsJSONNumber,
+				"require_verified":            valueIsBool,
+				"catalog_available":           valueIsBool,
+				"catalog_load_failed":         valueIsBool,
+				"verified_provider_count":     valueIsJSONNumber,
+				"uncatalogued_provider_count": valueIsJSONNumber,
+			}); ok {
+				clean[key] = modelHash
+			}
+		case "encrypted_leg":
+			if encryptedLeg, ok := sanitizeMapFields(child, map[string]func(any) bool{
+				"state":                      func(v any) bool { return valueIsStringEnum(v, "none", "all", "partial") },
+				"encrypted_provider_count":   valueIsJSONNumber,
+				"unencrypted_provider_count": valueIsJSONNumber,
+				"mixed":                      valueIsBool,
+				"scope":                      func(v any) bool { return valueIsStringEnum(v, "coordinator_to_provider_only") },
+			}); ok {
+				clean[key] = encryptedLeg
+			}
+		case "attestation":
+			if attestation, ok := sanitizeMapFields(child, map[string]func(any) bool{
+				"state":                      func(v any) bool { return valueIsStringEnum(v, "none", "all", "partial", "unsupported") },
+				"attested_provider_count":    valueIsJSONNumber,
+				"unsupported_provider_count": valueIsJSONNumber,
+				"mixed":                      valueIsBool,
+			}); ok {
+				clean[key] = attestation
+			}
+		case "behavioral_safety":
+			if behavioralSafety, ok := sanitizeMapFields(child, map[string]func(any) bool{
+				"state":                func(v any) bool { return valueIsStringEnum(v, "none", "partial", "enforced") },
+				"size_cap":             valueIsBool,
+				"encoding_validation":  valueIsBool,
+				"ttft_anomaly_logging": valueIsBool,
+			}); ok {
+				clean[key] = behavioralSafety
+			}
+		}
+	}
+	return clean, len(clean) > 0
+}
+
+func sanitizeMapFields(value any, validators map[string]func(any) bool) (map[string]any, bool) {
+	raw, ok := value.(map[string]any)
+	if !ok {
+		return nil, false
+	}
+	clean := map[string]any{}
+	for key, child := range raw {
+		if valid, ok := validators[key]; ok && valid(child) {
+			clean[key] = child
+		}
+	}
+	return clean, len(clean) > 0
+}
+
+func sanitizeMemberReferences(value any, modelIDs map[string]struct{}) (any, bool) {
+	raw, ok := value.([]any)
+	if !ok {
+		return nil, false
+	}
+	clean := make([]any, 0, len(raw))
+	for _, item := range raw {
+		member, ok := item.(string)
+		if !ok || !isPublicModelID(member) {
+			continue
+		}
+		if _, ok := modelIDs[member]; ok {
+			clean = append(clean, member)
+		}
+	}
+	return clean, len(clean) > 0
+}
+
+func valueIsStringEnum(value any, allowed ...string) bool {
+	s, ok := value.(string)
+	if !ok {
+		return false
+	}
+	for _, candidate := range allowed {
+		if s == candidate {
+			return true
+		}
+	}
+	return false
+}
+
+func valueIsPublicModelID(value any) bool {
+	s, ok := value.(string)
+	return ok && isPublicModelID(s)
+}
+
+func isPublicModelID(s string) bool {
+	if s == "" || len(s) > 512 || strings.TrimSpace(s) != s {
+		return false
+	}
+	for _, r := range s {
+		switch {
+		case r >= 'a' && r <= 'z':
+		case r >= 'A' && r <= 'Z':
+		case r >= '0' && r <= '9':
+		case r == '-' || r == '_' || r == '.' || r == '/' || r == ':' || r == '@' || r == '+':
+		default:
+			return false
+		}
+	}
+	return true
+}
+
+func valueIsTier2Phase(value any) bool {
+	switch v := value.(type) {
+	case string:
+		return v == "mixed"
+	case float64:
+		return v == 0 || v == 1 || v == 2 || v == 3
+	case json.Number:
+		i, err := v.Int64()
+		return err == nil && i >= 0 && i <= 3
+	case int:
+		return v >= 0 && v <= 3
+	case int64:
+		return v >= 0 && v <= 3
+	case uint64:
+		return v <= 3
+	default:
+		return false
+	}
+}
+
+func valueIsBool(value any) bool {
+	_, ok := value.(bool)
+	return ok
+}
+
+func valueIsJSONNumber(value any) bool {
+	switch value.(type) {
+	case float64, json.Number, int, int64, uint64:
+		return true
+	default:
+		return false
+	}
 }
 
 func (s *Server) handleHealthz(w http.ResponseWriter, r *http.Request) {

--- a/phase5-gateway/internal/router/server_test.go
+++ b/phase5-gateway/internal/router/server_test.go
@@ -180,10 +180,38 @@ func TestModelsResponseIncludesTier1Disclosure(t *testing.T) {
 	client := &http.Client{Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
 		return responseWithBody(http.StatusOK, http.Header{"Content-Type": []string{"application/json"}}, `{
 			"object":"list",
-			"data":[],
+			"data":[{
+				"id":"model-a",
+				"object":"model",
+				"created":1716768000,
+				"owned_by":"macprovider",
+				"provider_count":1,
+				"provider_id":"provider-secret",
+				"assigned_id":"session-secret",
+				"raw_prompt":"secret prompt",
+				"raw_output":"secret output",
+				"members":["model-b","provider_id=p1 raw_prompt=secret","hardware integrity proven",{"provider_id":"nested-member"}],
+				"compute_integrity":{
+					"schema_version":"evil",
+					"status":"enforcing",
+					"mode":"enforce",
+					"settlement_effect":"admits_when_other_gates_pass",
+					"live_telemetry_available":true,
+					"reason":"static_package_present",
+					"provider_id":"nested-provider-secret",
+					"disclosure":"proves honest computation and private inference"
+				},
+				"unexpected_nested":{"provider_id":"nested"}
+			},{
+				"id":"model-b",
+				"object":"model",
+				"created":1716768000,
+				"owned_by":"macprovider"
+			}],
+			"provider_id":"top-level-provider-secret",
 			"provider_count":2,
 			"total_slots":4,
-			"tier2":{"phase":0,"model_hash":{"active":false,"state":"none"}},
+			"tier2":{"phase":0,"model_hash":{"active":false,"state":"none","provider_id":"tier2-provider-secret"}},
 			"tier1_disclosure":{"version":"evil","plaintext_to_provider":false,"model_identity":"claimed","hardware_attestation":"claimed","tier2_milestone":"now"}
 		}`), nil
 	})}
@@ -194,8 +222,9 @@ func TestModelsResponseIncludesTier1Disclosure(t *testing.T) {
 	fullKey := createAccountAndKey(t, store, cfg, "acct_models_disclosure")
 	resp := assertStatus(t, h, http.MethodGet, "/v1/models", fullKey, "", "1.2.3.4", http.StatusOK)
 	var body struct {
-		Tier1Disclosure tier1Disclosure `json:"tier1_disclosure"`
-		Tier2           map[string]any  `json:"tier2"`
+		Tier1Disclosure tier1Disclosure  `json:"tier1_disclosure"`
+		Tier2           map[string]any   `json:"tier2"`
+		Data            []map[string]any `json:"data"`
 	}
 	if err := json.Unmarshal(resp.Body.Bytes(), &body); err != nil {
 		t.Fatalf("models json: %v", err)
@@ -206,9 +235,94 @@ func TestModelsResponseIncludesTier1Disclosure(t *testing.T) {
 	if body.Tier2["phase"].(float64) != 0 {
 		t.Fatalf("tier2 phase=%v want 0", body.Tier2["phase"])
 	}
+	modelHash, ok := body.Tier2["model_hash"].(map[string]any)
+	if !ok || modelHash["active"] != false || modelHash["state"] != "none" {
+		t.Fatalf("tier2 model_hash sanitized incorrectly: %+v", body.Tier2["model_hash"])
+	}
+	if _, ok := modelHash["provider_id"]; ok {
+		t.Fatalf("gateway forwarded forbidden tier2 provider_id: %+v", modelHash)
+	}
 	want := (&Server{}).makeTier1Disclosure()
 	if !reflect.DeepEqual(body.Tier1Disclosure, want) {
 		t.Fatalf("tier1_disclosure=%+v want %+v", body.Tier1Disclosure, want)
+	}
+	if len(body.Data) != 2 || body.Data[0]["id"] != "model-a" || body.Data[1]["id"] != "model-b" {
+		t.Fatalf("gateway sanitized data mismatch: %+v body=%s", body.Data, resp.Body.String())
+	}
+	entry := body.Data[0]
+	for _, forbidden := range []string{"provider_id", "assigned_id", "raw_prompt", "raw_output", "unexpected_nested"} {
+		if _, ok := entry[forbidden]; ok {
+			t.Fatalf("gateway forwarded forbidden model entry field %q: %+v", forbidden, entry)
+		}
+	}
+	members, ok := entry["members"].([]any)
+	if !ok || len(members) != 1 || members[0] != "model-b" {
+		t.Fatalf("gateway did not sanitize members: %+v", entry["members"])
+	}
+	memberJSON := fmt.Sprint(entry["members"])
+	for _, forbidden := range []string{"provider_id", "raw_prompt", "hardware integrity proven"} {
+		if strings.Contains(memberJSON, forbidden) {
+			t.Fatalf("gateway preserved hostile member string %q: %+v", forbidden, entry["members"])
+		}
+	}
+	var raw map[string]any
+	if err := json.Unmarshal(resp.Body.Bytes(), &raw); err != nil {
+		t.Fatalf("models json map: %v", err)
+	}
+	if _, ok := raw["provider_id"]; ok {
+		t.Fatalf("gateway forwarded forbidden top-level provider_id: %s", resp.Body.String())
+	}
+	modelCI, ok := entry["compute_integrity"].(map[string]any)
+	if !ok {
+		t.Fatalf("compute_integrity missing or wrong type: %+v", entry["compute_integrity"])
+	}
+	if modelCI["schema_version"] != "buyer_compute_integrity_status_v1" ||
+		modelCI["status"] != "unavailable" ||
+		modelCI["mode"] != "unavailable" ||
+		modelCI["settlement_effect"] != "not_evaluated" ||
+		modelCI["live_telemetry_available"] != false ||
+		modelCI["reason"] != "live_status_source_unavailable" {
+		t.Fatalf("gateway did not normalize per-model compute_integrity status: %+v body=%s", modelCI, resp.Body.String())
+	}
+	for _, forbidden := range []string{"provider_id", "proves honest computation", "private inference"} {
+		if strings.Contains(fmt.Sprint(modelCI), forbidden) {
+			t.Fatalf("gateway preserved hostile compute_integrity claim %q: %+v", forbidden, modelCI)
+		}
+	}
+	ci := body.Tier1Disclosure.ComputeIntegrity
+	if ci.SchemaVersion != "buyer_compute_integrity_disclosure_v1" ||
+		ci.CurrentStatus != "unavailable" ||
+		ci.CurrentMode != "unavailable" ||
+		ci.StatusSource != "live_telemetry_unavailable" ||
+		ci.LiveTelemetryAvailable ||
+		ci.SettlementEffect != "not_evaluated" {
+		t.Fatalf("compute_integrity disclosure status mismatch: %+v", ci)
+	}
+	for _, got := range []string{
+		ci.Labels.Unavailable,
+		ci.Labels.Observing,
+		ci.Labels.WarnOnly,
+		ci.Labels.Enforcing,
+		ci.Labels.Quarantined,
+		ci.Labels.Blocked,
+		ci.Labels.StaleExpired,
+	} {
+		if got == "" {
+			t.Fatalf("compute_integrity label glossary has empty field: %+v", ci.Labels)
+		}
+	}
+	for _, want := range []string{
+		"sampled/overt distribution-drift readiness telemetry",
+		"until live sanitized telemetry backs the per-model status",
+		"not proof of honest computation",
+		"hardware integrity",
+		"runtime binary integrity",
+		"private inference",
+		"malicious-provider resistance",
+	} {
+		if !strings.Contains(ci.Disclosure, want) {
+			t.Fatalf("compute_integrity disclosure missing %q: %q", want, ci.Disclosure)
+		}
 	}
 	if !strings.Contains(body.Tier1Disclosure.ModelVerificationLimit, "provider-reported request-start model hash") ||
 		!strings.Contains(body.Tier1Disclosure.ModelVerificationLimit, "do not detect a provider falsifying") {
@@ -258,6 +372,214 @@ func TestModelsResponseIncludesTier1Disclosure(t *testing.T) {
 	}
 	if strings.Contains(settlement.StreamingFailover, "Transparent streaming failover bills") {
 		t.Fatalf("settlement disclosure overclaims post-commit transparent failover: %q", settlement.StreamingFailover)
+	}
+}
+
+func TestModelsResponseNormalizesMalformedDataShape(t *testing.T) {
+	client := &http.Client{Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+		return responseWithBody(http.StatusOK, http.Header{"Content-Type": []string{"application/json"}}, `{
+			"object":"list",
+			"data":{"provider_id":"provider-secret","raw_prompt":"secret prompt","compute_integrity":{"status":"enforcing"}},
+			"tier1_disclosure":{"version":"evil"}
+		}`), nil
+	})}
+	h, store, _, cfg := newTestHarnessConfig(t, fakeOAuth{}, func(cfg *config.Config) {
+		cfg.Coordinator.BuyerURL = "http://coordinator.test"
+	}, WithHTTPClient(client))
+	fullKey := createAccountAndKey(t, store, cfg, "acct_models_malformed_data")
+	resp := assertStatus(t, h, http.MethodGet, "/v1/models", fullKey, "", "1.2.3.4", http.StatusOK)
+
+	var body struct {
+		Data []any `json:"data"`
+	}
+	if err := json.Unmarshal(resp.Body.Bytes(), &body); err != nil {
+		t.Fatalf("models json: %v", err)
+	}
+	if len(body.Data) != 0 {
+		t.Fatalf("malformed data shape should normalize to empty array: %+v body=%s", body.Data, resp.Body.String())
+	}
+	var raw map[string]any
+	if err := json.Unmarshal(resp.Body.Bytes(), &raw); err != nil {
+		t.Fatalf("models json map: %v", err)
+	}
+	dataJSON := fmt.Sprint(raw["data"])
+	for _, forbidden := range []string{"provider_id", "raw_prompt", "enforcing"} {
+		if strings.Contains(dataJSON, forbidden) {
+			t.Fatalf("gateway forwarded malformed data field %q: %s", forbidden, dataJSON)
+		}
+	}
+	for _, forbidden := range []string{"provider_id", "raw_prompt"} {
+		if strings.Contains(resp.Body.String(), forbidden) {
+			t.Fatalf("gateway forwarded malformed data field %q: %s", forbidden, resp.Body.String())
+		}
+	}
+}
+
+func TestModelsResponseDropsMalformedModelArrayEntries(t *testing.T) {
+	client := &http.Client{Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+		return responseWithBody(http.StatusOK, http.Header{"Content-Type": []string{"application/json"}}, `{
+			"object":"list",
+			"data":[
+				{"provider_id":"provider-secret"},
+				{"id":123,"object":"model","provider_id":"provider-secret"},
+				{"id":"   ","object":"model","assigned_id":"session-secret"},
+				{"id":"hardware integrity proven","object":"model"},
+				{"id":"model-a","object":"model","provider_id":"provider-secret","compute_integrity":{"status":"enforcing"}}
+			],
+			"tier1_disclosure":{"version":"evil"}
+		}`), nil
+	})}
+	h, store, _, cfg := newTestHarnessConfig(t, fakeOAuth{}, func(cfg *config.Config) {
+		cfg.Coordinator.BuyerURL = "http://coordinator.test"
+	}, WithHTTPClient(client))
+	fullKey := createAccountAndKey(t, store, cfg, "acct_models_bad_array_entries")
+	resp := assertStatus(t, h, http.MethodGet, "/v1/models", fullKey, "", "1.2.3.4", http.StatusOK)
+
+	var body struct {
+		Data []map[string]any `json:"data"`
+	}
+	if err := json.Unmarshal(resp.Body.Bytes(), &body); err != nil {
+		t.Fatalf("models json: %v", err)
+	}
+	if len(body.Data) != 1 || body.Data[0]["id"] != "model-a" {
+		t.Fatalf("malformed model rows should be dropped: %+v body=%s", body.Data, resp.Body.String())
+	}
+	if _, ok := body.Data[0]["provider_id"]; ok {
+		t.Fatalf("gateway forwarded forbidden provider_id: %+v", body.Data[0])
+	}
+	modelCI, ok := body.Data[0]["compute_integrity"].(map[string]any)
+	if !ok || modelCI["status"] != "unavailable" || modelCI["live_telemetry_available"] != false {
+		t.Fatalf("gateway did not normalize surviving compute_integrity: %+v", body.Data[0]["compute_integrity"])
+	}
+}
+
+func TestSanitizeModelsResponseNormalizesNestedPublicMetadata(t *testing.T) {
+	body := map[string]any{
+		"object": "list",
+		"data": []any{map[string]any{
+			"id":      "model-a",
+			"object":  "model",
+			"created": float64(1716768000),
+			"hash_verification": map[string]any{
+				"status":                  "partial",
+				"verified_provider_count": float64(1),
+				"provider_id":             "provider-secret",
+				"raw_prompt":              "secret prompt",
+			},
+		}},
+	}
+
+	sanitizeModelsResponse(body)
+
+	data := body["data"].([]any)
+	entry := data[0].(map[string]any)
+	hashVerification, ok := entry["hash_verification"].(map[string]any)
+	if !ok ||
+		hashVerification["status"] != "partial" ||
+		hashVerification["verified_provider_count"] != float64(1) {
+		t.Fatalf("gateway did not preserve public hash_verification fields: %+v", entry["hash_verification"])
+	}
+	for _, forbidden := range []string{"provider_id", "raw_prompt"} {
+		if _, ok := hashVerification[forbidden]; ok {
+			t.Fatalf("gateway forwarded forbidden hash_verification field %q: %+v", forbidden, hashVerification)
+		}
+	}
+}
+
+func TestSanitizeModelsResponseRejectsHostileStringValues(t *testing.T) {
+	body := map[string]any{
+		"object": "list",
+		"data": []any{
+			map[string]any{
+				"id":        "model-a",
+				"object":    "model",
+				"owned_by":  "macprovider",
+				"objective": "fast",
+				"members": []any{
+					"model-b",
+					"provider_id=p1",
+					"hardware integrity proven",
+				},
+				"hash_verification": map[string]any{
+					"status":                  "hardware integrity proven",
+					"verified_provider_count": float64(1),
+				},
+			},
+			map[string]any{
+				"id":       "model-b",
+				"object":   "model",
+				"owned_by": "macprovider",
+			},
+		},
+		"tier2": map[string]any{
+			"phase": "provider_id=p1",
+			"model_hash": map[string]any{
+				"active": true,
+				"state":  "hardware integrity proven",
+			},
+			"encrypted_leg": map[string]any{
+				"state": "enforcing",
+				"scope": "raw_prompt=secret",
+			},
+			"attestation": map[string]any{
+				"state": "hardware integrity proven",
+				"mixed": true,
+			},
+			"behavioral_safety": map[string]any{
+				"state":                "private inference",
+				"encoding_validation":  true,
+				"ttft_anomaly_logging": true,
+			},
+		},
+	}
+
+	sanitizeModelsResponse(body)
+
+	data := body["data"].([]any)
+	entry := data[0].(map[string]any)
+	members, ok := entry["members"].([]any)
+	if !ok || len(members) != 1 || members[0] != "model-b" {
+		t.Fatalf("members should retain only surviving model IDs: %+v", entry["members"])
+	}
+	hashVerification := entry["hash_verification"].(map[string]any)
+	if _, ok := hashVerification["status"]; ok {
+		t.Fatalf("hostile hash_verification status survived: %+v", hashVerification)
+	}
+	tier2Metadata := body["tier2"].(map[string]any)
+	if _, ok := tier2Metadata["phase"]; ok {
+		t.Fatalf("hostile tier2 phase survived: %+v", tier2Metadata)
+	}
+	modelHash := tier2Metadata["model_hash"].(map[string]any)
+	if _, ok := modelHash["state"]; ok {
+		t.Fatalf("hostile model_hash state survived: %+v", modelHash)
+	}
+	if encryptedLeg, ok := tier2Metadata["encrypted_leg"].(map[string]any); ok {
+		if _, ok := encryptedLeg["state"]; ok {
+			t.Fatalf("hostile encrypted_leg state survived: %+v", encryptedLeg)
+		}
+		if _, ok := encryptedLeg["scope"]; ok {
+			t.Fatalf("hostile encrypted_leg scope survived: %+v", encryptedLeg)
+		}
+	}
+	attestation := tier2Metadata["attestation"].(map[string]any)
+	if _, ok := attestation["state"]; ok {
+		t.Fatalf("hostile attestation state survived: %+v", attestation)
+	}
+	behavioralSafety := tier2Metadata["behavioral_safety"].(map[string]any)
+	if _, ok := behavioralSafety["state"]; ok {
+		t.Fatalf("hostile behavioral_safety state survived: %+v", behavioralSafety)
+	}
+	forbiddenJSON := fmt.Sprint(entry["members"]) + fmt.Sprint(hashVerification) + fmt.Sprint(tier2Metadata)
+	for _, forbidden := range []string{
+		"provider_id=p1",
+		"raw_prompt=secret",
+		"hardware integrity proven",
+		"private inference",
+		"enforcing",
+	} {
+		if strings.Contains(forbiddenJSON, forbidden) {
+			t.Fatalf("hostile string %q survived sanitized body: %+v", forbidden, body)
+		}
 	}
 }
 
@@ -439,6 +761,79 @@ func TestModelsDisclosureUsesTier2MetadataWhenNoHashRows(t *testing.T) {
 	}
 	if disclosure.Tier2 == nil || disclosure.Tier2.Phase != "mixed" || disclosure.Tier2.ModelHash.VerifiedProviderCount != 0 || disclosure.Tier2.ModelHash.UncataloguedProviderCount != 0 {
 		t.Fatalf("tier2 detail wrong: %+v", disclosure.Tier2)
+	}
+}
+
+func TestModelsDisclosureRejectsHostileTier2MetadataStrings(t *testing.T) {
+	client := &http.Client{Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+		switch r.URL.Path {
+		case "/v1/models":
+			return responseWithBody(http.StatusOK, http.Header{"Content-Type": []string{"application/json"}}, `{
+				"object":"list",
+				"data":[{"id":"model-a","object":"model","owned_by":"macprovider"}],
+				"tier2":{
+					"phase":"raw_prompt=secret",
+					"model_hash":{"active":true,"state":"hardware integrity proven"},
+					"encrypted_leg":{"state":"partial","scope":"provider_id=p1 raw_prompt=secret"},
+					"attestation":{"state":"private inference","mixed":true},
+					"behavioral_safety":{"state":"malicious-provider resistance","size_cap":true}
+				}
+			}`), nil
+		case "/internal/routing":
+			return responseWithBody(http.StatusOK, http.Header{"Content-Type": []string{"application/json"}}, `{
+				"sticky":{"enabled":false,"ttl_seconds":1800},
+				"tier2":{
+					"phase":"raw_prompt=secret",
+					"model_hash":{"active":true,"state":"hardware integrity proven"},
+					"encrypted_leg":{"state":"partial","scope":"provider_id=p1 raw_prompt=secret"},
+					"attestation":{"state":"private inference","mixed":true},
+					"behavioral_safety":{"state":"malicious-provider resistance","size_cap":true}
+				}
+			}`), nil
+		default:
+			t.Fatalf("unexpected request path %s", r.URL.Path)
+			return nil, nil
+		}
+	})}
+	h, store, _, cfg := newTestHarnessConfig(t, fakeOAuth{}, func(cfg *config.Config) {
+		cfg.Coordinator.BuyerURL = "http://coordinator.test"
+		cfg.Coordinator.OperatorURL = "http://operator.test"
+	}, WithHTTPClient(client))
+	fullKey := createAccountAndKey(t, store, cfg, "acct_models_hostile_tier2_strings")
+	resp := assertStatus(t, h, http.MethodGet, "/v1/models", fullKey, "", "1.2.3.4", http.StatusOK)
+
+	var body struct {
+		Tier1Disclosure tier1Disclosure `json:"tier1_disclosure"`
+		Tier2           map[string]any  `json:"tier2"`
+	}
+	if err := json.Unmarshal(resp.Body.Bytes(), &body); err != nil {
+		t.Fatalf("models json: %v", err)
+	}
+	disclosure := body.Tier1Disclosure
+	if disclosure.Tier2 == nil {
+		t.Fatalf("tier2 disclosure missing: %+v", disclosure)
+	}
+	if disclosure.ModelHashVerified != "none" ||
+		disclosure.ProviderLegEncryption != "partial" ||
+		disclosure.HardwareAttestation != "none" ||
+		disclosure.UntrustedProviderSafety != "none" ||
+		disclosure.Tier2.EncryptedLeg.State != "partial" ||
+		disclosure.Tier2.EncryptedLeg.Scope != "coordinator_to_provider_only" ||
+		disclosure.Tier2.Attestation.State != "none" ||
+		disclosure.Tier2.BehavioralSafety.State != "none" {
+		t.Fatalf("hostile tier2 metadata was not normalized: %+v", disclosure)
+	}
+	forbiddenJSON := fmt.Sprint(body.Tier2) + fmt.Sprint(disclosure.Tier2)
+	for _, forbidden := range []string{
+		"raw_prompt=secret",
+		"provider_id=p1",
+		"hardware integrity proven",
+		"private inference",
+		"malicious-provider resistance",
+	} {
+		if strings.Contains(forbiddenJSON, forbidden) {
+			t.Fatalf("hostile metadata string %q survived models response: %s", forbidden, resp.Body.String())
+		}
 	}
 }
 

--- a/phase5-gateway/internal/router/templates/docs.md
+++ b/phase5-gateway/internal/router/templates/docs.md
@@ -142,6 +142,8 @@ Streaming failover is transparent only before response bytes are committed. Afte
 
 `GET /v1/models` returns the current provider-reported model list plus `tier1_disclosure`. The disclosure separates provider-reported model IDs, catalog-known hash status, and settlement-enforced receipt matching.
 
+Each model includes `compute_integrity`. Until live sanitized telemetry is wired into the buyer models surface, the status is explicitly `unavailable` with `live_telemetry_available: false` and `settlement_effect: not_evaluated`. SPEC-036 compute-integrity is sampled/overt distribution-drift readiness telemetry; it is not proof of honest computation, hardware integrity, runtime binary integrity, private inference, or malicious-provider resistance.
+
 ### Usage
 
 `GET /v1/usage` returns account quota, key, model, rating summary, and `settlement_disclosure` fields for signed-in API-key users. `daily_tokens_reserved` can include pending verification reservations after a request completes; non-verified terminal outcomes release or refund that reservation.

--- a/specs/CONFORMANCE.json
+++ b/specs/CONFORMANCE.json
@@ -150,7 +150,7 @@
     {
       "spec_id": "SPEC-006",
       "title": "Buyer API Gateway: Mac Provider's first public buyer surface",
-      "version": "0.9.15",
+      "version": "0.9.16",
       "path": "specs/SPEC-006-buyer-api.md",
       "status": "normative",
       "owner": "@Augustas11",
@@ -2687,6 +2687,11 @@
       "state": "pending",
       "implementation": [
         "phase4-coordinator/internal/computeintegrity/status.go:StatusForKey",
+        "phase4-coordinator/internal/buyer/server.go:modelComputeIntegrityStatus",
+        "phase4-coordinator/internal/buyer/server.go:handleModels",
+        "phase5-gateway/internal/router/server.go:sanitizeModelsResponse",
+        "phase5-gateway/internal/router/disclosure.go:computeIntegrityDisclosure",
+        "phase5-gateway/internal/router/disclosure.go:makeComputeIntegrityDisclosure",
         "phase4-coordinator/internal/ws/compute_integrity_status.go:handleAdminComputeIntegrity",
         "phase4-coordinator/internal/ws/compute_integrity_status.go:handleProviderComputeIntegrity"
       ],
@@ -2694,6 +2699,8 @@
         "phase4-coordinator/internal/computeintegrity/status_test.go:TestStatusForKeyCoversAbsentWarnExpiredAndBlockedStates",
         "phase4-coordinator/internal/computeintegrity/status_test.go:TestStatusForKeyDoesNotMutateState",
         "phase4-coordinator/internal/computeintegrity/status_test.go:TestStatusSnapshotOmitsRawPromptAndOutputFields",
+        "phase4-coordinator/internal/buyer/server_test.go:TestModelsIncludesComputeIntegrityUnavailableStatus",
+        "phase5-gateway/internal/router/server_test.go:TestModelsResponseIncludesTier1Disclosure",
         "phase4-coordinator/internal/ws/compute_integrity_status_test.go:TestComputeIntegrityStatusOperatorAndProviderEndpoints",
         "phase4-coordinator/internal/ws/compute_integrity_status_test.go:TestComputeIntegrityProviderEndpointRequiresTokenAndSource",
         "phase4-coordinator/internal/ws/compute_integrity_status_test.go:TestComputeIntegrityProviderEndpointUsesReadOnlyTokenValidation",
@@ -2704,8 +2711,8 @@
       "gap": {
         "verdict": "UNKNOWN",
         "owner": "@Augustas11",
-        "issue": "https://github.com/Augustas11/macprovider/issues/1008",
-        "rationale": "Operator/provider status surfaces now expose SPEC-036 readiness with approved no-proof/no-attestation copy and sanitized digest-only metadata. Conformance remains pending until live status-source wiring, policy-bound copy version/digest serving, and the remaining buyer/public/auditor disclosure surfaces are complete."
+        "issue": "https://github.com/Augustas11/macprovider/issues/1010",
+        "rationale": "Operator/provider status surfaces expose SPEC-036 readiness with approved no-proof/no-attestation copy and sanitized digest-only metadata. Buyer /v1/models now exposes an explicit unavailable per-model status and label glossary until live sanitized telemetry backs the public surface. Conformance remains pending until production live evidence, policy-bound copy version/digest serving, and the receipt-binding decision tracked in #1010 are complete."
       }
     },
     {

--- a/specs/README.md
+++ b/specs/README.md
@@ -14,7 +14,7 @@ it can no longer drift. Do not hand-edit the table; edit each spec's
 | SPEC-003 | Open Onboarding: Distribution, Lifecycle & Onboarding UX | 0.11.1 | normative | pending | pending: 1 | [SPEC-003-open-onboarding.md](SPEC-003-open-onboarding.md) |
 | SPEC-004 | Smart Router | 0.3.3 | normative | pending | pending corpus migration | [SPEC-004-smart-router.md](SPEC-004-smart-router.md) |
 | SPEC-005 | Billing, Settlement, and Provider Rewards | 0.6.1 | normative | pending | pending corpus migration | [SPEC-005-billing.md](SPEC-005-billing.md) |
-| SPEC-006 | Buyer API Gateway: Mac Provider's first public buyer surface | 0.9.15 | normative | pending | pending corpus migration | [SPEC-006-buyer-api.md](SPEC-006-buyer-api.md) |
+| SPEC-006 | Buyer API Gateway: Mac Provider's first public buyer surface | 0.9.16 | normative | pending | pending corpus migration | [SPEC-006-buyer-api.md](SPEC-006-buyer-api.md) |
 | SPEC-007 | Internal Operator Protocol Explorer | 0.5.1 | normative | pending | pending corpus migration | [SPEC-007-explorer.md](SPEC-007-explorer.md) |
 | SPEC-008 | Tier-2 Trust Layer | 0.5.1 | normative | pending | pending: 1 | [SPEC-008-tier2.md](SPEC-008-tier2.md) |
 | SPEC-009 | MacProvider Console v2 | 0.1 | normative | pending | pending corpus migration | [SPEC-009-console-v2.md](SPEC-009-console-v2.md) |

--- a/specs/SPEC-006-buyer-api.md
+++ b/specs/SPEC-006-buyer-api.md
@@ -1,7 +1,11 @@
 # SPEC-006 - Buyer API Gateway: Mac Provider's first public buyer surface
 
-**Version:** 0.9.15 (2026-08-17, streaming failover disclosure boundary)
+**Version:** 0.9.16 (2026-08-17, buyer compute-integrity unavailable status)
 **Depends on:** SPEC-001 v1.2.4, SPEC-002 v1.5.4, SPEC-003 v0.7, SPEC-004 v0.3.2
+
+**Change log v0.9.16 (2026-08-17, issue #1009 — buyer compute-integrity unavailable status):**
+- §5.3 and §5.3.1 now include buyer-visible compute-integrity status fields for `/v1/models`. Because no live per-model telemetry source is wired into the buyer models surface yet, entries MUST expose `compute_integrity.status: "unavailable"` with `live_telemetry_available: false` rather than deriving observing, warn-only, enforcing, quarantined, blocked, stale, or expired states from static spec/package availability.
+- The disclosure vocabulary distinguishes unavailable, observing, warn-only, enforcing, quarantined, blocked, and stale/expired labels while preserving the SPEC-036 boundary: sampled/overt distribution-drift readiness telemetry is not proof of honest computation, hardware integrity, runtime binary integrity, private inference, or malicious-provider resistance.
 
 **Change log v0.9.15 (2026-08-17, issue #969 — streaming failover disclosure boundary):**
 - §1.6, `/v1/models`, `/v1/usage`, and docs disclosure examples now state the shipped streaming boundary explicitly: failover is transparent only before response bytes are committed; after the first buyer-visible SSE event, a provider disconnect terminates the stream with `provider_disconnected` and the buyer may retry as a new request that is independently billable with its own reservation and settlement.
@@ -1165,6 +1169,24 @@ Response shape:
       "streaming_failover": "Streaming failover is transparent only before response bytes are committed. After the first buyer-visible SSE event, a provider disconnect terminates the stream with provider_disconnected and the buyer may retry as a new request. That retry is a separate billable request with its own reservation and settlement; cross-request overlapping output is not deduplicated. Settlement remains limited to delivered, receipt-verified output prefixes and must not double-charge overlapping output if a future resume or failover protocol spans multiple provider attempts; verified here means receipt-bound under the provider-reported-hash caveat above.",
       "buyer_receipt_status": "Buyer receipt and status surfaces expose pending, verified, quarantined, and zero_settled labels without raw prompts or raw outputs."
     },
+    "compute_integrity": {
+      "schema_version": "buyer_compute_integrity_disclosure_v1",
+      "current_status": "unavailable",
+      "current_mode": "unavailable",
+      "status_source": "live_telemetry_unavailable",
+      "live_telemetry_available": false,
+      "settlement_effect": "not_evaluated",
+      "labels": {
+        "unavailable": "no live sanitized telemetry currently backs buyer-visible per-model compute-integrity status",
+        "observing": "live telemetry is sampled/overt observation only and does not affect settlement",
+        "warn_only": "live telemetry reports warn readiness without blocking paid admission",
+        "enforcing": "policy-backed live telemetry may affect covered SPEC-022 settlement/admission gates",
+        "quarantined": "live telemetry/adjudication marked compute drift or a related adverse state",
+        "blocked": "covered paid admission is blocked for the affected compute-integrity scope",
+        "stale_expired": "previous live telemetry is stale or expired and needs fresh evidence"
+      },
+      "disclosure": "SPEC-036 compute-integrity is sampled/overt distribution-drift readiness telemetry against approved references. It is unavailable here until live sanitized telemetry backs the per-model status. It is not proof of honest computation, hardware integrity, runtime binary integrity, private inference, or malicious-provider resistance."
+    },
     "sticky_affinity": {
       "enabled": false,
       "ttl_seconds": 0,
@@ -1180,6 +1202,15 @@ Response shape:
       "provider_count": 3,
       "total_slots": 5,
       "max_context_tokens": 8192,
+      "compute_integrity": {
+        "schema_version": "buyer_compute_integrity_status_v1",
+        "status": "unavailable",
+        "mode": "unavailable",
+        "settlement_effect": "not_evaluated",
+        "live_telemetry_available": false,
+        "reason": "live_status_source_unavailable",
+        "disclosure": "SPEC-036 v0.1 is an overt distribution-drift readiness signal against approved references. It is not cryptographic proof of honest computation, not hardware integrity, not runtime binary integrity, and not covert attestation. Per-model buyer status is unavailable until live sanitized telemetry is wired; this field is not derived from static spec/package availability."
+      },
       "degraded": false
     }
   ]
@@ -1191,6 +1222,10 @@ The gateway MUST aggregate providers by case-insensitive model identifier.
 The gateway MUST preserve the canonical model ID spelling returned by the coordinator.
 
 The `id` field returned by `/v1/models` reflects the model identifier as advertised by the serving provider binary. `/v1/models` may also expose catalog-known hash status and settlement-enforced receipt matching for covered enforce-mode traffic. Buyers SHOULD treat `id` as provider-reported and SHOULD NOT treat catalog or settlement fields as hardware attestation, runtime binary attestation, malicious-output prevention, private inference, or detection of a provider falsifying its own loaded-model hash measurement.
+
+Each model entry MUST include `compute_integrity`. Until live sanitized compute-integrity telemetry backs the buyer models surface, implementations MUST return `status: "unavailable"`, `mode: "unavailable"`, `live_telemetry_available: false`, and `settlement_effect: "not_evaluated"`. Implementations MUST NOT derive observing, warn-only, enforcing, quarantined, blocked, stale, or expired buyer-visible status from static SPEC text, package availability, binary presence, or configured intent alone. When a future live source is wired, labels MUST preserve the distinction between sampled/overt observation, warn-only telemetry, enforcement that can affect covered SPEC-022 settlement/admission gates, quarantined/blocked states, and stale/expired evidence.
+
+Gateways MUST allowlist public model-entry fields and MUST replace upstream per-model `compute_integrity` with the gateway-approved unavailable object until a trusted live status source exists. A coordinator or cached snapshot MUST NOT be able to inject provider identifiers, raw prompt/output material, false live-telemetry flags, enforcement labels, or prohibited proof/attestation/private-inference claims into buyer-visible model entries.
 
 The gateway MUST tolerate `/` and `\/` escaped model IDs.
 
@@ -1240,6 +1275,24 @@ The `/v1/models` response MUST include a top-level field:
     "streaming_failover": "Streaming failover is transparent only before response bytes are committed. After the first buyer-visible SSE event, a provider disconnect terminates the stream with provider_disconnected and the buyer may retry as a new request. That retry is a separate billable request with its own reservation and settlement; cross-request overlapping output is not deduplicated. Settlement remains limited to delivered, receipt-verified output prefixes and must not double-charge overlapping output if a future resume or failover protocol spans multiple provider attempts; verified here means receipt-bound under the provider-reported-hash caveat above.",
     "buyer_receipt_status": "Buyer receipt and status surfaces expose pending, verified, quarantined, and zero_settled labels without raw prompts or raw outputs."
   },
+  "compute_integrity": {
+    "schema_version": "buyer_compute_integrity_disclosure_v1",
+    "current_status": "unavailable",
+    "current_mode": "unavailable",
+    "status_source": "live_telemetry_unavailable",
+    "live_telemetry_available": false,
+    "settlement_effect": "not_evaluated",
+    "labels": {
+      "unavailable": "no live sanitized telemetry currently backs buyer-visible per-model compute-integrity status",
+      "observing": "live telemetry is sampled/overt observation only and does not affect settlement",
+      "warn_only": "live telemetry reports warn readiness without blocking paid admission",
+      "enforcing": "policy-backed live telemetry may affect covered SPEC-022 settlement/admission gates",
+      "quarantined": "live telemetry/adjudication marked compute drift or a related adverse state",
+      "blocked": "covered paid admission is blocked for the affected compute-integrity scope",
+      "stale_expired": "previous live telemetry is stale or expired and needs fresh evidence"
+    },
+    "disclosure": "SPEC-036 compute-integrity is sampled/overt distribution-drift readiness telemetry against approved references. It is unavailable here until live sanitized telemetry backs the per-model status. It is not proof of honest computation, hardware integrity, runtime binary integrity, private inference, or malicious-provider resistance."
+  },
   "sticky_affinity": {
     "enabled": false,
     "ttl_seconds": 0,
@@ -1253,6 +1306,10 @@ Buyers consuming this field SHOULD display its content in human-readable form be
 Gateway implementations MUST set this field automatically.
 
 Operator override is forbidden; there MUST be no config opt-out.
+
+The `compute_integrity` sub-object MUST be present in `tier1_disclosure`. Its label glossary MUST distinguish `unavailable`, `observing`, `warn_only`, `enforcing`, `quarantined`, `blocked`, and `stale_expired` states. Until a live sanitized telemetry source backs per-model buyer status, `current_status` and `current_mode` MUST be `unavailable`, `status_source` MUST be `live_telemetry_unavailable`, `live_telemetry_available` MUST be `false`, and `settlement_effect` MUST be `not_evaluated`. The disclosure MUST describe SPEC-036 as sampled/overt distribution-drift readiness telemetry and MUST NOT claim proof of honest computation, hardware integrity, runtime binary integrity, private inference, or malicious-provider resistance.
+
+Gateway-owned disclosure and per-model status values are authoritative for this unavailable phase. The gateway MUST overwrite hostile, stale, or same-named upstream fields rather than forwarding them verbatim.
 
 The `sticky_affinity` sub-object MUST be present. When `routing.sticky_enabled: false`, implementations MUST return `enabled: false`, `ttl_seconds: 0`, and a description that states no sticky routing is active. When `routing.sticky_enabled: true`, implementations MUST return `enabled: true`, `ttl_seconds` equal to the coordinator's effective SPEC-004 v0.2 `routing.sticky_ttl_s`, and this plain-language privacy tradeoff in substantively equivalent form: "Related requests with the same conversation tag are preferentially routed to one provider for up to this many seconds, so that provider can observe and correlate more of your traffic than under default routing."
 

--- a/specs/SPEC-036-compute-integrity-receipt.md
+++ b/specs/SPEC-036-compute-integrity-receipt.md
@@ -2326,6 +2326,6 @@ default holds unless maintainers record a stricter value in the LOCK PR or
 - Proving runtime binary integrity.
 - Proving malicious-provider honesty under overt probes.
 - Adding buyer-facing canary issuance.
-- Changing buyer API request or response schema.
+- Changing buyer inference, usage, receipt, or settlement request/response schema; additive buyer catalog disclosure fields remain owned by SPEC-006.
 - Changing SPEC-015 v0.4 receipt shape.
 - Changing SPEC-022 outcome enum in v0.1.


### PR DESCRIPTION
## Summary

- Adds explicit buyer-facing `compute_integrity` status objects to coordinator and gateway `/v1/models`, currently hard-coded to unavailable/non-live/settlement-neutral until trusted live sanitized telemetry exists.
- Makes the gateway own the public `/v1/models` disclosure boundary: unknown fields are stripped, hostile upstream per-model `compute_integrity` is overwritten, malformed model data is normalized/dropped, model IDs and member references are constrained, and Tier-2 string metadata uses closed public vocabularies.
- Updates SPEC-006, SPEC-036, docs, and CONFORMANCE to document the unavailable phase and keep future live evidence/receipt-binding work in #1010.

Closes #1009.

## Why

Issue #1009 requires buyer-visible compute-integrity status labels without implying SPEC-036 live enforcement or proof of provider honesty. The safe current state is an explicit unavailable status backed by no-proof disclosure language, not promotion from static package/spec/config availability.

## Validation

- `go test -count=1 ./internal/router` (phase5-gateway)
- `go test -count=1 ./...` (phase5-gateway)
- `go test -count=1 ./internal/buyer` (phase4-coordinator)
- `go test -count=1 ./...` (phase4-coordinator, clean retry; earlier unrelated billing timing failure passed focused/package reruns)
- `python3 -m json.tool specs/CONFORMANCE.json >/dev/null`
- `python3 scripts/gen_spec_index.py --check`
- `python3 scripts/gen_spec_index.py --lint`
- `python3 scripts/check_spec_governance.py --base-ref origin/main`
- `git diff --check -- .`
- Three-lane Codex audits: code/security/architecture all CLEAR, 0 C/H/M findings.

## SPEC Governance

SPEC-GOVERNANCE-DECLARATION-BEGIN
{
  "schema_version": "spec-pr-governance-v1",
  "behavior_change": "yes",
  "contract_change": "yes",
  "specs": ["SPEC-006", "SPEC-036"],
  "requirements": ["SPEC-036-R015"],
  "authority_domains": ["buyer-api-error-contract", "compute-integrity-settlement"],
  "arbitration": ["CODE_BUG"],
  "tests": ["phase5-gateway/internal/router", "phase4-coordinator/internal/buyer", "scripts/check_spec_governance.py"],
  "journeys": ["buyer-model-catalog"],
  "issue": "https://github.com/Augustas11/macprovider/issues/1009"
}
SPEC-GOVERNANCE-DECLARATION-END
