### PR TITLE
Expose mining health without changing reward contracts

### DIFF
--- a/frontdoor/provider-portal/README.md
+++ b/frontdoor/provider-portal/README.md
@@ -15,6 +15,9 @@ per [SPEC-014](../../specs/SPEC-014-provider-portal.md).
   isolation) + AC 8(f) (single-machine copy hygiene). Exits 0 on
   clean bundle, 1 on prohibited match, 2 if `index.html` is missing.
   CI MUST run this before serving the file (see "CI" below).
+- `mining-health.test.mjs` — Node smoke tests for the portal's local
+  Mining Health reason-code adapter and unavailable-vs-zero reward
+  rendering.
 - `README.md` — this file.
 
 ## Operator deploy
@@ -54,6 +57,37 @@ CI MUST run `frontdoor/provider-portal/check-bundle.sh` on any PR
 that touches files under `frontdoor/provider-portal/`. The repo's
 CI hook lives outside this directory and is added in a follow-up
 operator step (see SPEC-014 §10.4 operator runbook).
+Run `node --test frontdoor/provider-portal/mining-health.test.mjs`
+when changing the Earn / Mining Health mapping.
+
+## Mining Health vocabulary
+
+The Earn surface maps current portal projections to the same local
+Mining Health reason codes Malibu.app renders from `AgentSnapshot`.
+Portal inference is best-effort because the portal does not have
+Malibu.app's local lifecycle snapshot. These codes are intentionally
+small and backend-ready:
+
+- `earning`
+- `idle_no_work`
+- `not_running`
+- `provider_paused`
+- `provider_error`
+- `local_on_battery`
+- `local_thermal_pressure`
+- `local_model_preparing`
+- `reward_projection_unavailable`
+- `wallet_missing`
+- `trust_tier_provisional`
+- `wallet_daily_cap_held`
+- `rewards_held`
+- `trusted_withdrawable`
+- `eligible_waiting_settlement`
+- `customer_availability_pending`
+
+When a future backend eligibility reason model becomes authoritative,
+keep this UI map as the adapter boundary and prefer stable backend
+codes over local inference.
 
 ## Auth model summary
 

--- a/frontdoor/provider-portal/index.html
+++ b/frontdoor/provider-portal/index.html
@@ -323,6 +323,12 @@
     .rewards-card .reward-value { font-size:18px; margin-top:3px; }
     .rewards-card .reward-hold { color:var(--bad); margin-top:12px; font-size:13px; line-height:1.45; }
     .rewards-card .reward-next { margin-top:6px; font-size:13px; line-height:1.45; }
+    .mining-health-card { margin-bottom:18px; border-left:2px solid var(--accent); }
+    .mining-health-card .mh-status { font-size:20px; font-weight:600; margin-top:2px; }
+    .mining-health-card .mh-grid { display:grid; grid-template-columns:repeat(2, minmax(0, 1fr)); gap:12px; margin-top:12px; }
+    .mining-health-card .mh-label { color:var(--muted); font-size:12px; }
+    .mining-health-card .mh-value { font-size:13px; margin-top:3px; line-height:1.45; }
+    @media (max-width: 720px) { .mining-health-card .mh-grid { grid-template-columns:1fr; } }
     @media (max-width: 620px) { .rewards-card .reward-grid { grid-template-columns:1fr; } }
     .monitor-card { background:var(--surface); border:1px dashed var(--border2); border-radius:10px; padding:16px 18px; }
     .monitor-card h3 { margin:0 0 10px 0; font-size:14px; }
@@ -1634,6 +1640,14 @@
           data.trust_criteria_required > data.trust_criteria_met) {
         return "Complete " + (data.trust_criteria_required - data.trust_criteria_met) + " more trust criteria to unlock withdrawals.";
       }
+      if (data.trust_tier === "provisional") {
+        if (typeof data.trust_criteria_met === "number" &&
+            typeof data.trust_criteria_required === "number" &&
+            data.trust_criteria_required > data.trust_criteria_met) {
+          return "Complete " + (data.trust_criteria_required - data.trust_criteria_met) + " more trust criteria to unlock withdrawals.";
+        }
+        return "Complete trust criteria to unlock withdrawals.";
+      }
       if (reasons.indexOf("per_wallet_daily_cap") !== -1) return "The wallet cap resets at the next UTC day.";
       if (reasons.indexOf("demotion_cooldown") !== -1) return "Re-qualify for Trusted to clear the cooldown.";
       if (!hasHoldReasons) return "Hold status is unavailable; try again later.";
@@ -1641,6 +1655,204 @@
         return "No action needed; no withdrawal hold is reported.";
       }
       return "Review the hold reason above before withdrawing.";
+    }
+
+    function miningReasonVocabulary(code) {
+      switch (code) {
+        case "earning":
+          return {
+            status: "Earning",
+            reason: "Paid work or rewards have settled in the current window.",
+            action: "No local action needed.",
+          };
+        case "idle_no_work":
+          return {
+            status: "Eligible, idle",
+            reason: "This machine is eligible, but the network is quiet right now.",
+            action: "Keep the provider online.",
+          };
+        case "not_running":
+          return {
+            status: "Not running",
+            reason: "The provider is not ready for customer work.",
+            action: "Start or repair the provider.",
+          };
+        case "provider_paused":
+          return {
+            status: "Paused",
+            reason: "This machine will not receive customer work while paused.",
+            action: "Resume the provider when ready.",
+          };
+        case "provider_error":
+          return {
+            status: "Needs attention",
+            reason: "The provider reported an error.",
+            action: "Export diagnostics or repair the provider.",
+          };
+        case "local_on_battery":
+          return {
+            status: "Blocked locally",
+            reason: "This machine is on battery.",
+            action: "Plug in power to earn.",
+          };
+        case "local_thermal_pressure":
+          return {
+            status: "Blocked locally",
+            reason: "Thermal pressure is limiting local work.",
+            action: "Let this machine cool before earning resumes.",
+          };
+        case "local_model_preparing":
+          return {
+            status: "Preparing",
+            reason: "The model is still loading or checking local setup.",
+            action: "Keep the provider online while setup continues.",
+          };
+        case "reward_projection_unavailable":
+          return {
+            status: "Reward status unavailable",
+            reason: "Fresh earnings or MALIBU reward telemetry is not available yet.",
+            action: "Refresh after the read-only projections update.",
+          };
+        case "wallet_missing":
+          return {
+            status: "Missing wallet",
+            reason: "Rewards are visible, but no payout wallet is bound.",
+            action: "Add a payout wallet in Malibu.",
+          };
+        case "trust_tier_provisional":
+          return {
+            status: "Locked until Trusted",
+            reason: "MALIBU is accruing, but withdrawals are locked until Trusted.",
+            action: "Complete trust criteria to unlock withdrawals.",
+          };
+        case "wallet_daily_cap_held":
+          return {
+            status: "Wallet cap held",
+            reason: "MALIBU above the wallet daily cap is held.",
+            action: "Wait for the next UTC day or use a wallet below the cap.",
+          };
+        case "rewards_held":
+          return {
+            status: "Rewards held",
+            reason: "Some MALIBU is held while payout eligibility is being verified.",
+            action: "Review the hold reason before withdrawing.",
+          };
+        case "trusted_withdrawable":
+          return {
+            status: "Withdrawable",
+            reason: "Trusted reward projection reports withdrawable MALIBU.",
+            action: "No local action needed.",
+          };
+        case "eligible_waiting_settlement":
+          return {
+            status: "Waiting for settlement",
+            reason: "Work ran in this window; paid credits appear when jobs settle.",
+            action: "No local action needed.",
+          };
+        default:
+          return {
+            status: "Checking availability",
+            reason: "Customer availability is still being checked.",
+            action: "Refresh after status updates.",
+          };
+      }
+    }
+
+    function computePortalMiningHealth() {
+      var earn = state.earn.data;
+      var malibu = state.malibu.data;
+      var pool = state.pool.data;
+      var idle = earn && earn.idle_prewarm ? earn.idle_prewarm : null;
+      var skips = idle && idle.skips_by_reason_last_1h ? idle.skips_by_reason_last_1h : {};
+      var reasons = malibu && Array.isArray(malibu.withdrawal_hold_reasons)
+        ? malibu.withdrawal_hold_reasons : [];
+      var code;
+      if (pool && pool.state && pool.state !== "ready" && pool.state !== "draining") {
+        code = "not_running";
+      } else if (!earn || !malibu) {
+        code = state.earn.inflight || state.malibu.inflight
+          ? "customer_availability_pending" : "reward_projection_unavailable";
+      } else if ((skips.on_battery || 0) > 0) {
+        code = "local_on_battery";
+      } else if ((skips.thermal_pressure || 0) > 0) {
+        code = "local_thermal_pressure";
+      } else if ((skips.model_not_loaded || 0) > 0) {
+        code = "local_model_preparing";
+      } else if (malibu.wallet_bound === false) {
+        code = "wallet_missing";
+      } else if (reasons.indexOf("per_wallet_daily_cap") !== -1) {
+        code = "wallet_daily_cap_held";
+      } else if (malibu.trust_tier === "provisional" ||
+                 reasons.indexOf("trust_tier_provisional") !== -1) {
+        code = "trust_tier_provisional";
+      } else if (reasons.length || Number(malibu.held_malibu) > 0) {
+        code = "rewards_held";
+      } else if (Number(malibu.withdrawable_malibu) > 0) {
+        code = "trusted_withdrawable";
+      } else if (typeof earn.current_window_credits === "number" && earn.current_window_credits > 0) {
+        code = "earning";
+      } else if (pool && (pool.state === "ready" || pool.state === "draining")) {
+        code = "idle_no_work";
+      } else if (pool) {
+        code = "not_running";
+      } else {
+        code = "customer_availability_pending";
+      }
+      var vocab = miningReasonVocabulary(code);
+      var credits = earn && typeof earn.current_window_credits === "number"
+        ? "Credits current window: " + fmtInt(earn.current_window_credits)
+        : "Credits unavailable";
+      var rewardSummary = credits + " · " + (malibu
+        ? "MALIBU: " + formatMalibuAmount(malibu.withdrawable_malibu) + " withdrawable / " +
+            formatMalibuAmount(malibu.held_malibu) + " held"
+        : "MALIBU unavailable");
+      var trustSummary = "Trust status unavailable";
+      if (malibu) {
+        trustSummary = "Trust: " + (
+          typeof malibu.trust_tier === "string" && malibu.trust_tier.trim()
+            ? malibu.trust_tier : "n/a"
+        );
+        if (typeof malibu.trust_criteria_met === "number" &&
+            typeof malibu.trust_criteria_required === "number") {
+          trustSummary += " · " + malibu.trust_criteria_met + " of " +
+            malibu.trust_criteria_required + " criteria met";
+        }
+      }
+      var action = vocab.action;
+      if (malibu && (reasons.length ||
+          code === "trust_tier_provisional" ||
+          code === "wallet_daily_cap_held")) {
+        action = malibuNextAction(malibu, reasons);
+      }
+      return {
+        code: code,
+        status: vocab.status,
+        reason: vocab.reason,
+        action: action,
+        rewardSummary: rewardSummary,
+        trustSummary: trustSummary,
+      };
+    }
+
+    function renderMiningHealthCard() {
+      var health = computePortalMiningHealth();
+      return el("div", { class: "fiat-card mining-health-card" },
+        el("h3", null, "Mining Health"),
+        el("div", { class: "mh-status" }, health.status),
+        el("div", { class: "mh-grid" },
+          el("div", null,
+            el("div", { class: "mh-label" }, "Reason"),
+            el("div", { class: "mh-value" }, health.reason)),
+          el("div", null,
+            el("div", { class: "mh-label" }, "Rewards"),
+            el("div", { class: "mh-value" }, health.rewardSummary)),
+          el("div", null,
+            el("div", { class: "mh-label" }, "Eligibility"),
+            el("div", { class: "mh-value" }, health.trustSummary)),
+          el("div", null,
+            el("div", { class: "mh-label" }, "Next safe action"),
+            el("div", { class: "mh-value" }, health.action))),
+        el("div", { class: "fiat-cite mono" }, "reason_code: " + health.code));
     }
 
     function renderMalibuRewardsCard() {
@@ -1717,6 +1929,7 @@
         el("div", { class: "fiat-cite" }, "SPEC-005 §1.3 / §2.1 D1; SPEC-014 Open Q3."));
       return el("div", null,
         el("h1", { class: "surface-title" }, "Earn"),
+        renderMiningHealthCard(),
         el("h2", { class: "section-h" }, "Credit totals"),
         creditsRow,
         renderMalibuRewardsCard(),

--- a/frontdoor/provider-portal/mining-health.test.mjs
+++ b/frontdoor/provider-portal/mining-health.test.mjs
@@ -1,0 +1,139 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import test from "node:test";
+import vm from "node:vm";
+
+function loadPortalContext() {
+  const html = fs.readFileSync(new URL("./index.html", import.meta.url), "utf8");
+  const scripts = [...html.matchAll(/<script[^>]*>([\s\S]*?)<\/script>/gi)].map((m) => m[1]);
+  const context = {
+    console,
+    Date,
+    URL,
+    Promise,
+    setInterval() { return 0; },
+    clearInterval() {},
+    setTimeout() { return 0; },
+    clearTimeout() {},
+    location: { pathname: "/", href: "https://portal.example/" },
+    history: { replaceState() {} },
+    document: {
+      readyState: "loading",
+      getElementById() { return null; },
+      createElement(tag) {
+        return {
+          tagName: tag,
+          classList: { contains() { return false; }, add() {}, remove() {} },
+          style: {},
+          appendChild() {},
+          setAttribute() {},
+          addEventListener() {},
+        };
+      },
+      createTextNode(text) { return { textContent: text }; },
+      addEventListener() {},
+    },
+    addEventListener() {},
+  };
+  context.window = context;
+  vm.createContext(context);
+  for (const script of scripts) {
+    vm.runInContext(script, context);
+  }
+  return context;
+}
+
+function baseState(context) {
+  context.state.pool = { data: { state: "ready" }, ts: Date.now(), err: null, inflight: false };
+  context.state.earn = {
+    data: { current_window_credits: 0, idle_prewarm: { skips_by_reason_last_1h: {} } },
+    ts: Date.now(),
+    err: null,
+    inflight: false,
+  };
+  context.state.malibu = {
+    data: {
+      wallet_bound: true,
+      trust_tier: "trusted",
+      withdrawable_malibu: 0,
+      held_malibu: 0,
+      withdrawal_hold_reasons: [],
+    },
+    ts: Date.now(),
+    err: null,
+    inflight: false,
+  };
+}
+
+test("portal mining health does not render unavailable rewards as zero", () => {
+  const context = loadPortalContext();
+  context.state.pool = { data: { state: "ready" }, ts: Date.now(), err: null, inflight: false };
+  context.state.earn = { data: null, ts: 0, err: { status: 503 }, inflight: false };
+  context.state.malibu = { data: null, ts: 0, err: { status: 503 }, inflight: false };
+
+  const health = vm.runInContext("computePortalMiningHealth()", context);
+
+  assert.equal(health.code, "reward_projection_unavailable");
+  assert.equal(health.rewardSummary, "Credits unavailable · MALIBU unavailable");
+}
+);
+
+test("portal mining health prioritizes offline pool before missing rewards", () => {
+  const context = loadPortalContext();
+  context.state.pool = { data: { state: "unavailable" }, ts: Date.now(), err: null, inflight: false };
+  context.state.earn = { data: null, ts: 0, err: { status: 503 }, inflight: false };
+  context.state.malibu = { data: null, ts: 0, err: { status: 503 }, inflight: false };
+
+  const health = vm.runInContext("computePortalMiningHealth()", context);
+
+  assert.equal(health.code, "not_running");
+  assert.equal(health.status, "Not running");
+}
+);
+
+test("portal mining health distinguishes fresh zero from unavailable", () => {
+  const context = loadPortalContext();
+  baseState(context);
+
+  const health = vm.runInContext("computePortalMiningHealth()", context);
+
+  assert.equal(health.code, "idle_no_work");
+  assert.equal(
+    health.rewardSummary,
+    "Credits current window: 0 · MALIBU: 0.00 MALIBU withdrawable / 0.00 MALIBU held"
+  );
+}
+);
+
+test("portal mining health prioritizes local blockers and reward holds", () => {
+  const context = loadPortalContext();
+  baseState(context);
+
+  context.state.earn.data.idle_prewarm.skips_by_reason_last_1h = { on_battery: 2 };
+  assert.equal(vm.runInContext("computePortalMiningHealth().code", context), "local_on_battery");
+
+  context.state.earn.data.idle_prewarm.skips_by_reason_last_1h = { thermal_pressure: 1 };
+  assert.equal(vm.runInContext("computePortalMiningHealth().code", context), "local_thermal_pressure");
+
+  context.state.earn.data.idle_prewarm.skips_by_reason_last_1h = {};
+  context.state.malibu.data.wallet_bound = false;
+  assert.equal(vm.runInContext("computePortalMiningHealth().code", context), "wallet_missing");
+
+  context.state.malibu.data.wallet_bound = true;
+  context.state.malibu.data.trust_tier = "provisional";
+  context.state.malibu.data.withdrawal_hold_reasons = [];
+  context.state.malibu.data.trust_criteria_met = 1;
+  context.state.malibu.data.trust_criteria_required = 3;
+  const provisional = vm.runInContext("computePortalMiningHealth()", context);
+  assert.equal(provisional.code, "trust_tier_provisional");
+  assert.equal(provisional.action, "Complete 2 more trust criteria to unlock withdrawals.");
+
+  context.state.malibu.data.trust_tier = "trusted";
+  context.state.malibu.data.withdrawal_hold_reasons = ["per_wallet_daily_cap"];
+  assert.equal(vm.runInContext("computePortalMiningHealth().code", context), "wallet_daily_cap_held");
+
+  context.state.malibu.data.withdrawal_hold_reasons = ["manual_review"];
+  context.state.malibu.data.held_malibu = 2;
+  assert.equal(vm.runInContext("computePortalMiningHealth().code", context), "rewards_held");
+}
+);

--- a/phase3-binary/app/Sources/Malibu/Agent/AgentSnapshot.swift
+++ b/phase3-binary/app/Sources/Malibu/Agent/AgentSnapshot.swift
@@ -426,6 +426,204 @@ enum AgentSnapshotPresenter {
         }
     }
 
+    struct MiningHealth: Equatable {
+        let status: String
+        let reasonCode: String
+        let reason: String
+        let nextAction: String
+        let rewardSummary: String
+        let trustSummary: String
+    }
+
+    static func miningHealth(_ s: AgentSnapshot) -> MiningHealth {
+        func result(
+            status: String,
+            code: String,
+            reason: String,
+            action: String
+        ) -> MiningHealth {
+            MiningHealth(
+                status: status,
+                reasonCode: code,
+                reason: reason,
+                nextAction: action,
+                rewardSummary: miningRewardSummary(s),
+                trustSummary: miningTrustSummary(s)
+            )
+        }
+
+        if s.state == .idle {
+            return result(
+                status: "Not running",
+                code: "not_running",
+                reason: "The provider service is stopped.",
+                action: "Start provider setup."
+            )
+        }
+        if s.state == .paused {
+            return result(
+                status: "Paused",
+                code: "provider_paused",
+                reason: "This Mac will not receive customer work while paused.",
+                action: "Choose Resume when ready."
+            )
+        }
+        if s.state == .error {
+            return result(
+                status: "Needs attention",
+                code: "provider_error",
+                reason: publicErrorDetail(s.lastError) ?? "The provider reported an error.",
+                action: publicStatus(s).safeNextAction ?? "Export diagnostics for support."
+            )
+        }
+        if miningSkipCount(s, "on_battery") > 0 {
+            return result(
+                status: "Blocked locally",
+                code: "local_on_battery",
+                reason: "This Mac is on battery.",
+                action: "Plug in power to earn."
+            )
+        }
+        if miningSkipCount(s, "thermal_pressure") > 0 {
+            return result(
+                status: "Blocked locally",
+                code: "local_thermal_pressure",
+                reason: "Thermal pressure is limiting local work.",
+                action: "Let this Mac cool before earning resumes."
+            )
+        }
+        if miningSkipCount(s, "model_not_loaded") > 0 || isModelPreparing(s) {
+            return result(
+                status: "Preparing",
+                code: "local_model_preparing",
+                reason: "The model is still loading or checking local setup.",
+                action: "Keep Malibu open while setup continues."
+            )
+        }
+        if !s.providerEarningsFresh || !s.malibuProjectionFresh {
+            return result(
+                status: "Reward status unavailable",
+                code: "reward_projection_unavailable",
+                reason: "Fresh earnings or MALIBU reward telemetry is not available yet.",
+                action: isActive(s) ? "Keep Malibu open while reward status refreshes." : "Start the provider to refresh reward status."
+            )
+        }
+        if s.walletBound == false {
+            return result(
+                status: "Missing wallet",
+                code: "wallet_missing",
+                reason: "Rewards are visible, but no payout wallet is bound.",
+                action: "Add a payout wallet."
+            )
+        }
+        if s.malibuHoldReasons.contains("per_wallet_daily_cap") {
+            return result(
+                status: "Wallet cap held",
+                code: "wallet_daily_cap_held",
+                reason: "MALIBU above the wallet daily cap is held.",
+                action: "Wait for the next UTC day or use a wallet below the cap."
+            )
+        }
+        if s.trustTier == .provisional || s.malibuHoldReasons.contains("trust_tier_provisional") {
+            return result(
+                status: "Locked until Trusted",
+                code: "trust_tier_provisional",
+                reason: "MALIBU is accruing, but withdrawals are locked until Trusted.",
+                action: trustCriteriaAction(s) ?? "Complete trust criteria to unlock withdrawals."
+            )
+        }
+        if !s.malibuHoldReasons.isEmpty || (s.malibuHeld ?? 0) > 0 {
+            return result(
+                status: "Rewards held",
+                code: "rewards_held",
+                reason: "Some MALIBU is held while payout eligibility is being verified.",
+                action: "Review the hold reason before withdrawing."
+            )
+        }
+        if s.trustTier == .trusted, let withdrawable = s.malibuWithdrawable, withdrawable > 0 {
+            return result(
+                status: "Withdrawable",
+                code: "trusted_withdrawable",
+                reason: "Trusted reward projection reports withdrawable MALIBU.",
+                action: "No local action needed."
+            )
+        }
+        if hasMiningEarningsActivity(s) {
+            return result(
+                status: "Earning",
+                code: "earning",
+                reason: "Paid work or rewards have settled in the current window.",
+                action: "No local action needed."
+            )
+        }
+        if (s.requestsServedToday ?? 0) > 0 {
+            return result(
+                status: "Waiting for settlement",
+                code: "eligible_waiting_settlement",
+                reason: "Work ran today; paid credits appear when jobs settle.",
+                action: "No local action needed."
+            )
+        }
+        if isNetworkReady(s) {
+            return result(
+                status: "Eligible, idle",
+                code: "idle_no_work",
+                reason: "This Mac is eligible, but the network is quiet right now.",
+                action: "Keep Malibu online."
+            )
+        }
+        return result(
+            status: publicStatus(s).title,
+            code: "customer_availability_pending",
+            reason: publicStatus(s).detail ?? "Customer availability is still being checked.",
+            action: publicStatus(s).safeNextAction ?? "Keep Malibu open while status updates."
+        )
+    }
+
+    private static func miningSkipCount(_ s: AgentSnapshot, _ reason: String) -> Int64 {
+        guard s.providerEarningsFresh else { return 0 }
+        return s.idlePrewarmSummary.skipsByReasonLast1h[reason] ?? 0
+    }
+
+    private static func hasMiningEarningsActivity(_ s: AgentSnapshot) -> Bool {
+        (s.requestsPerMinute ?? 0) > 0
+            || (s.earningsUsdcToday ?? 0) > 0
+            || (s.malibuAccruedToday ?? 0) > 0
+    }
+
+    private static func miningRewardSummary(_ s: AgentSnapshot) -> String {
+        let usdc = s.providerEarningsFresh
+            ? s.earningsUsdcToday.map { "\(formatUSDC($0)) USDC today" } ?? "n/a USDC today"
+            : "USDC unavailable"
+        let malibu: String
+        if s.malibuProjectionFresh {
+            let withdrawable = s.malibuWithdrawable.map { String(format: "%.2f withdrawable", $0) }
+                ?? "n/a withdrawable"
+            let held = s.malibuHeld.map { String(format: "%.2f held", $0) }
+                ?? "n/a held"
+            malibu = "MALIBU \(withdrawable) / \(held)"
+        } else {
+            malibu = "MALIBU unavailable"
+        }
+        return "\(usdc) · \(malibu)"
+    }
+
+    private static func miningTrustSummary(_ s: AgentSnapshot) -> String {
+        guard s.malibuProjectionFresh else { return "Trust status unavailable" }
+        let tier = s.trustTier.rawValue.capitalized
+        if let met = s.trustCriteriaMet, let required = s.trustCriteriaRequired {
+            return "Trust: \(tier) · \(met) of \(required) criteria met"
+        }
+        return "Trust: \(tier)"
+    }
+
+    private static func trustCriteriaAction(_ s: AgentSnapshot) -> String? {
+        guard let met = s.trustCriteriaMet,
+              let required = s.trustCriteriaRequired,
+              required > met else { return nil }
+        return "Complete \(required - met) more trust criteria to unlock withdrawals."
+    }
+
     private static func isActive(_ s: AgentSnapshot) -> Bool {
         s.state == .serving || s.state == .paused || isLocalOnly(s)
     }

--- a/phase3-binary/app/Sources/Malibu/Dashboard/DashboardWindow.swift
+++ b/phase3-binary/app/Sources/Malibu/Dashboard/DashboardWindow.swift
@@ -27,6 +27,10 @@ enum DashboardCopy {
     static let currentStateTitle = "Current state"
     static let meaningTitle = "What this means"
     static let nextActionTitle = "Next safe action"
+    static let miningHealthTitle = "Mining Health"
+    static let miningReasonTitle = "Reason"
+    static let miningRewardsTitle = "Rewards"
+    static let miningEligibilityTitle = "Eligibility"
     static let resetProviderTitle = "Reset provider service"
     static let exportDiagnosticsTitle = "Export diagnostics…"
     static let recoveryHelpTitle = "If something is stuck"
@@ -44,6 +48,7 @@ enum DashboardCopy {
 
     static func defaultPublicStrings(_ snapshot: AgentSnapshot) -> [String] {
         let publicStatus = AgentSnapshotPresenter.publicStatus(snapshot)
+        let mining = AgentSnapshotPresenter.miningHealth(snapshot)
         return [
             currentStateTitle,
             publicStatus.title,
@@ -51,6 +56,15 @@ enum DashboardCopy {
             publicStatus.detail,
             nextActionTitle,
             publicStatus.safeNextAction,
+            miningHealthTitle,
+            mining.status,
+            miningReasonTitle,
+            mining.reason,
+            miningRewardsTitle,
+            mining.rewardSummary,
+            miningEligibilityTitle,
+            mining.trustSummary,
+            mining.nextAction,
         ].compactMap { $0 }
     }
 
@@ -182,6 +196,8 @@ private struct DashboardView: View {
                 .background(RoundedRectangle(cornerRadius: 8).fill(Color.accentColor.opacity(0.09)))
                 .accessibilityElement(children: .contain)
             }
+
+            miningHealthPanel
 
             HStack(alignment: .top, spacing: 16) {
                 panel {
@@ -378,6 +394,43 @@ private struct DashboardView: View {
                 peer: MalibuModelPeerEvidence(snapshot: agent.snapshot)
             )
             await modelStore.startBackgroundCheckIfEligible(thermalState: agent.snapshot.thermalState)
+        }
+    }
+
+    private var miningHealthPanel: some View {
+        let mining = AgentSnapshotPresenter.miningHealth(agent.snapshot)
+        return VStack(alignment: .leading, spacing: 10) {
+            HStack(alignment: .firstTextBaseline) {
+                Text(DashboardCopy.miningHealthTitle)
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(.secondary)
+                Spacer()
+                Text(mining.status)
+                    .font(.callout.weight(.semibold))
+                    .foregroundStyle(miningTone(mining.reasonCode))
+            }
+            VStack(alignment: .leading, spacing: 8) {
+                MetricRow(title: DashboardCopy.miningReasonTitle, value: mining.reason)
+                MetricRow(title: DashboardCopy.miningRewardsTitle, value: mining.rewardSummary)
+                MetricRow(title: DashboardCopy.miningEligibilityTitle, value: mining.trustSummary)
+                MetricRow(title: DashboardCopy.nextActionTitle, value: mining.nextAction)
+            }
+        }
+        .padding(12)
+        .background(panelBackground)
+        .accessibilityElement(children: .contain)
+    }
+
+    private func miningTone(_ reasonCode: String) -> Color {
+        switch reasonCode {
+        case "earning", "trusted_withdrawable":
+            return .green
+        case "idle_no_work", "eligible_waiting_settlement", "customer_availability_pending":
+            return .secondary
+        case "not_running", "provider_paused", "reward_projection_unavailable":
+            return MalibuBrand.sunnyYellow
+        default:
+            return MalibuBrand.coral
         }
     }
 

--- a/phase3-binary/app/Tests/MalibuTests/DashboardViewTests.swift
+++ b/phase3-binary/app/Tests/MalibuTests/DashboardViewTests.swift
@@ -227,6 +227,125 @@ final class DashboardViewTests: XCTestCase {
         XCTAssertNil(AgentSnapshotPresenter.eligibilityLine(snapshot))
     }
 
+    func testMiningHealthCoversIssue1017OperationalStates() {
+        var earning = miningBase()
+        earning.earningsUsdcToday = 0.04
+        XCTAssertEqual(AgentSnapshotPresenter.miningHealth(earning).reasonCode, "earning")
+
+        var idle = miningBase()
+        idle.earningsUsdcToday = 0
+        XCTAssertEqual(AgentSnapshotPresenter.miningHealth(idle).reasonCode, "idle_no_work")
+
+        var pendingAvailability = miningBase()
+        pendingAvailability.earningsUsdcToday = 0
+        pendingAvailability.networkState = "buyer_serving_unknown"
+        XCTAssertEqual(
+            AgentSnapshotPresenter.miningHealth(pendingAvailability).reasonCode,
+            "customer_availability_pending"
+        )
+
+        var notRunning = AgentSnapshot.empty
+        notRunning.state = .idle
+        XCTAssertEqual(AgentSnapshotPresenter.miningHealth(notRunning).reasonCode, "not_running")
+
+        var battery = miningBase()
+        battery.idlePrewarmSummary = ProviderIdlePrewarmSummary(skipsByReasonLast1h: ["on_battery": 1])
+        XCTAssertEqual(AgentSnapshotPresenter.miningHealth(battery).reasonCode, "local_on_battery")
+
+        var thermal = miningBase()
+        thermal.idlePrewarmSummary = ProviderIdlePrewarmSummary(skipsByReasonLast1h: ["thermal_pressure": 1])
+        XCTAssertEqual(AgentSnapshotPresenter.miningHealth(thermal).reasonCode, "local_thermal_pressure")
+
+        var preparing = AgentSnapshot.empty
+        preparing.state = .starting
+        preparing.lifecycleState = "loading_model"
+        XCTAssertEqual(AgentSnapshotPresenter.miningHealth(preparing).reasonCode, "local_model_preparing")
+
+        var unavailable = AgentSnapshot.empty
+        unavailable.state = .serving
+        unavailable.networkState = "buyer_serving"
+        unavailable.earningsUsdcToday = 0
+        unavailable.malibuWithdrawable = 0
+        let unavailableHealth = AgentSnapshotPresenter.miningHealth(unavailable)
+        XCTAssertEqual(unavailableHealth.reasonCode, "reward_projection_unavailable")
+        XCTAssertEqual(unavailableHealth.rewardSummary, "USDC unavailable · MALIBU unavailable")
+
+        var missingWallet = miningBase()
+        missingWallet.walletBound = false
+        XCTAssertEqual(AgentSnapshotPresenter.miningHealth(missingWallet).reasonCode, "wallet_missing")
+
+        var provisional = miningBase()
+        provisional.trustTier = .provisional
+        provisional.malibuHoldReasons = ["trust_tier_provisional"]
+        provisional.trustCriteriaMet = 1
+        provisional.trustCriteriaRequired = 3
+        let provisionalHealth = AgentSnapshotPresenter.miningHealth(provisional)
+        XCTAssertEqual(provisionalHealth.reasonCode, "trust_tier_provisional")
+        XCTAssertEqual(provisionalHealth.nextAction, "Complete 2 more trust criteria to unlock withdrawals.")
+
+        provisional.malibuHoldReasons = []
+        XCTAssertEqual(AgentSnapshotPresenter.miningHealth(provisional).reasonCode, "trust_tier_provisional")
+        XCTAssertEqual(
+            AgentSnapshotPresenter.miningHealth(provisional).nextAction,
+            "Complete 2 more trust criteria to unlock withdrawals."
+        )
+
+        var walletCap = miningBase()
+        walletCap.malibuHeld = 2
+        walletCap.malibuHoldReasons = ["per_wallet_daily_cap"]
+        XCTAssertEqual(AgentSnapshotPresenter.miningHealth(walletCap).reasonCode, "wallet_daily_cap_held")
+
+        var genericHold = miningBase()
+        genericHold.malibuHeld = 2
+        genericHold.malibuHoldReasons = ["manual_review"]
+        XCTAssertEqual(AgentSnapshotPresenter.miningHealth(genericHold).reasonCode, "rewards_held")
+
+        var withdrawable = miningBase()
+        withdrawable.malibuWithdrawable = 2
+        XCTAssertEqual(AgentSnapshotPresenter.miningHealth(withdrawable).reasonCode, "trusted_withdrawable")
+    }
+
+    func testMiningHealthDistinguishesFreshPartialAndUnavailableRewards() {
+        var fresh = miningBase()
+        fresh.earningsUsdcToday = nil
+        fresh.malibuWithdrawable = 0
+        fresh.malibuHeld = 0
+        let freshHealth = AgentSnapshotPresenter.miningHealth(fresh)
+        XCTAssertEqual(freshHealth.reasonCode, "idle_no_work")
+        XCTAssertEqual(freshHealth.rewardSummary, "n/a USDC today · MALIBU 0.00 withdrawable / 0.00 held")
+
+        var partial = miningBase()
+        partial.malibuProjectionFresh = false
+        partial.earningsUsdcToday = 0.04
+        let partialHealth = AgentSnapshotPresenter.miningHealth(partial)
+        XCTAssertEqual(partialHealth.reasonCode, "reward_projection_unavailable")
+        XCTAssertEqual(partialHealth.rewardSummary, "$0.04 USDC today · MALIBU unavailable")
+
+        var stale = miningBase()
+        stale.providerEarningsFresh = false
+        stale.malibuProjectionFresh = false
+        stale.earningsUsdcToday = 0
+        stale.malibuWithdrawable = 0
+        let staleHealth = AgentSnapshotPresenter.miningHealth(stale)
+        XCTAssertEqual(staleHealth.reasonCode, "reward_projection_unavailable")
+        XCTAssertFalse(staleHealth.rewardSummary.contains("$0.00"))
+        XCTAssertFalse(staleHealth.rewardSummary.contains("0.00 MALIBU"))
+    }
+
+    private func miningBase() -> AgentSnapshot {
+        var snapshot = AgentSnapshot.empty
+        snapshot.state = .serving
+        snapshot.coordinatorConnected = true
+        snapshot.networkState = "buyer_serving"
+        snapshot.providerEarningsFresh = true
+        snapshot.malibuProjectionFresh = true
+        snapshot.walletBound = true
+        snapshot.trustTier = .trusted
+        snapshot.malibuWithdrawable = 0
+        snapshot.malibuHeld = 0
+        return snapshot
+    }
+
     func testRecoveryCopyIsOnTheDashboardSurface() {
         XCTAssertEqual(DashboardCopy.resetProviderTitle, "Reset provider service")
         XCTAssertEqual(DashboardCopy.exportDiagnosticsTitle, "Export diagnostics…")


### PR DESCRIPTION
## Summary

Closes #1017.

Adds a compact Mining Health surface for providers in Malibu.app and the provider portal, using existing reward, trust, wallet, and local runtime telemetry without changing coordinator reward contracts.

## What changed

- Added a Malibu `MiningHealth` presenter model and dashboard section for current earning status, blockers, reward availability, and trust/hold state.
- Added provider portal Mining Health rendering with the same operational reason vocabulary.
- Added portal smoke tests for unavailable-vs-zero rewards, offline pool priority, local blockers, wallet/trust holds, and generic held rewards.
- Added dashboard tests for the new Mining Health states and reward freshness cases.

## Validation

- `node --test frontdoor/provider-portal/mining-health.test.mjs`
- `bash frontdoor/provider-portal/check-bundle.sh`
- `git diff --check origin/main...HEAD`
- changed-scope prohibited-term scan
- `xcodebuild test -project phase3-binary/app/Malibu.xcodeproj -scheme Malibu -configuration Debug -destination platform=macOS -only-testing:MalibuTests/DashboardViewTests`

Local Xcode emitted a CoreSimulator version warning while running a macOS target, but the selected macOS test target completed successfully: 13 tests, 0 failures.

## Audit

Final local 3-lane auditor pass on the issue branch reported:

- Code: 0 Critical / 0 High / 0 Medium
- Security/privacy: 0 Critical / 0 High / 0 Medium
- Architecture/scope: 0 Critical / 0 High / 0 Medium

SPEC-GOVERNANCE-DECLARATION-BEGIN
{
  "schema_version": "spec-pr-governance-v1",
  "behavior_change": "yes",
  "contract_change": "none",
  "issue": "https://github.com/Augustas11/macprovider/issues/1017",
  "specs": [
    "SPEC-002",
    "SPEC-014",
    "SPEC-016",
    "SPEC-017",
    "SPEC-021",
    "SPEC-022"
  ],
  "requirements": [
    "SPEC-002-R002",
    "SPEC-016-R002",
    "SPEC-017-R001",
    "SPEC-022-R007"
  ],
  "authority_domains": [
    "coordinator-admission-routing",
    "provider-portal",
    "payout-lifecycle",
    "network-stats",
    "malibu-emission-ledger",
    "verified-model-settlement"
  ],
  "arbitration": [
    "UNKNOWN"
  ],
  "tests": [
    "node --test frontdoor/provider-portal/mining-health.test.mjs",
    "bash frontdoor/provider-portal/check-bundle.sh",
    "xcodebuild test -project phase3-binary/app/Malibu.xcodeproj -scheme Malibu -configuration Debug -destination platform=macOS -only-testing:MalibuTests/DashboardViewTests"
  ],
  "journeys": [
    "not-required"
  ]
}
SPEC-GOVERNANCE-DECLARATION-END
