### PR TITLE
Phase 2 P2-B — MicroMDM nginx routes + Pearl install

### DIFF
--- a/docs/runbooks/apple-mdm-partner-registration.md
+++ b/docs/runbooks/apple-mdm-partner-registration.md
@@ -139,7 +139,7 @@ Also note any **Apple Developer Enterprise Program** status (yes/no). Needed onl
 
 ## What eng will do after you hand off (not your job)
 
-- Install push cert + key on Pearl MicroMDM
+- Install push cert + key on Pearl MicroMDM — see [`docs/runbooks/pearl-micromdm-install.md`](./pearl-micromdm-install.md)
 - Set `tier2.mdm.push_topic` (and enroll URLs) on the coordinator
 - Wire nginx `/v1/enroll` + MDM routes
 - Run `macprovider-cli enroll` on a test Mac and confirm check-in + push wake

--- a/docs/runbooks/hardware-attestation-phases.md
+++ b/docs/runbooks/hardware-attestation-phases.md
@@ -292,6 +292,7 @@ Script auto-restores config backup on verification failure. Manual: set `require
 | 2026-07-09 | **Phase 1 merged** — PR #477 squash-merged to main (`001fb405`). Augustas11 approved (PR author was antfleet-ops). |
 | 2026-07-09 | **Phase 2 started** — worktree `/Users/augstar/macprovider-attest-phase2`, branch `fix/attestation-phase2`. Operator registering Apple MDM push cert in parallel. |
 | 2026-08-07 | Partner ABM + identity.apple.com instructions added: `docs/runbooks/apple-mdm-partner-registration.md`. P2-A/P2-C already on main via PR #509. |
+| 2026-08-17 | APNs push cert issued (topic `com.apple.mgmt.External.b3ba8c97-…`). P2-B: nginx `/v1/enroll`+`/mdm/`+`/scep`, MicroMDM Pearl install — see `docs/runbooks/pearl-micromdm-install.md`. |
 
 ## Phase 2 — IN PROGRESS
 

--- a/docs/runbooks/pearl-micromdm-install.md
+++ b/docs/runbooks/pearl-micromdm-install.md
@@ -1,0 +1,85 @@
+# Pearl MicroMDM install + enroll cutover
+
+**Status:** engineering + ops  
+**Depends on:** APNs push cert vaulted (see `docs/runbooks/apple-mdm-partner-registration.md`)  
+**Host:** Pearl (`coordinator.malibu.tech` → 159.223.165.194)
+
+## Goal
+
+Run MicroMDM on Pearl (loopback `:8080`), terminate TLS at nginx, serve:
+
+| Path | Upstream |
+|------|----------|
+| `POST /v1/enroll` | coordinator buyer mux `:8443` |
+| `/mdm/*` | MicroMDM `:8080` |
+| `/scep` | MicroMDM `:8080` |
+
+Enrollment base URL: `https://coordinator.malibu.tech`
+
+## Install MicroMDM + APNs cert
+
+From a machine with the vaulted push cert:
+
+```bash
+bash phase4-coordinator/dist/install-micromdm-pearl.sh \
+  --push-cert ~/Secrets/macprovider-mdm-apns/MDM_push_certificate.pem \
+  --push-key  ~/Secrets/macprovider-mdm-apns/mdmcert.download.push.key \
+  --push-key-password-file ~/Secrets/macprovider-mdm-apns/.push-password \
+  --apply-nginx
+```
+
+Omit `--apply-nginx` if nginx will land via the normal coordinator Pearl deploy that installs `dist/nginx-coordinator.malibu.tech.conf`.
+
+## Coordinator overlay (`tier2.mdm`)
+
+MDM config is **startup-only**. Add to `/etc/macprovider/coordinator.pearl-overlays.yaml`:
+
+```yaml
+tier2:
+  mdm:
+    enrollment_base_url: "https://coordinator.malibu.tech"
+    push_topic: "com.apple.mgmt.External.b3ba8c97-af5f-4feb-8d06-d9fd839c241b"
+```
+
+Then restart the coordinator (provider reconnect expected):
+
+```bash
+ssh pearl 'systemctl restart macprovider-coordinator'
+# confirm mount log:
+ssh pearl 'journalctl -u macprovider-coordinator -n 50 --no-pager | grep -i enroll'
+```
+
+Push topic must match the issued APNs cert. Renewals: Apple ID `augstar@gmail.com` at identity.apple.com — renew, do not create a new cert.
+
+## Smoke tests
+
+```bash
+# Profile generation
+curl -fsS -X POST 'https://coordinator.malibu.tech/v1/enroll' \
+  -H 'content-type: application/json' \
+  -d '{"serial_number":"C02TESTSERIAL"}' \
+  -o /tmp/test.mobileconfig
+file /tmp/test.mobileconfig
+plutil -p /tmp/test.mobileconfig | head
+
+# MicroMDM reachable via nginx (expect non-404)
+curl -sI 'https://coordinator.malibu.tech/scep' | head -5
+curl -sI 'https://coordinator.malibu.tech/mdm/checkin' | head -5
+
+# Provider CLI (on Apple Silicon Mac)
+macprovider-cli enroll status
+macprovider-cli enroll run
+```
+
+After `enroll run`, confirm device check-in:
+
+```bash
+ssh pearl '/opt/micromdm/bin/mdmctl get devices'
+```
+
+## Security notes
+
+- MicroMDM HTTP API stays on `127.0.0.1:8080`. Public `/v1/` remains 404 except exact allowlisted routes (including `/v1/enroll`).
+- API key: `/etc/micromdm/api-key` (mode 600).
+- APNs material: `/etc/micromdm/apns/` (mode 600).
+- Do not commit push private keys or API keys to git.

--- a/phase4-coordinator/dist/coordinator.yaml.example
+++ b/phase4-coordinator/dist/coordinator.yaml.example
@@ -277,6 +277,21 @@ tier2:
   # When empty, /poolz falls back to scheme + request Host. For Pearl:
   public_catalog_base_url: "https://coordinator.malibu.tech"
 
+  # Phase 2 MDM enrollment (P2-A/P2-B). Startup-only — not hot-reloadable.
+  # When enrollment_base_url is non-empty, POST /v1/enroll is mounted on the
+  # buyer mux. Live Pearl values belong in
+  # /etc/macprovider/coordinator.pearl-overlays.yaml (preserve-live), not in
+  # tracked dist/coordinator.yaml secrets.
+  # mdm:
+  #   enrollment_base_url: "https://coordinator.malibu.tech"
+  #   # Optional overrides (default: {base}/mdm/connect and {base}/scep):
+  #   # mdm_server_url: "https://coordinator.malibu.tech/mdm/connect"
+  #   # scep_url: "https://coordinator.malibu.tech/scep"
+  #   push_topic: "com.apple.mgmt.External.<uuid-from-apns-cert>"
+  #   # Optional CMS profile signing (unsigned profiles are OK for enroll):
+  #   # profile_signer_cert_path: "/etc/macprovider/mdm/profile-signer.crt"
+  #   # profile_signer_key_path: "/etc/macprovider/mdm/profile-signer.key"
+
 # SPEC-017 Network Stats API.
 #
 # Production `dist/coordinator.yaml` enables this block for

--- a/phase4-coordinator/dist/install-micromdm-pearl.sh
+++ b/phase4-coordinator/dist/install-micromdm-pearl.sh
@@ -77,6 +77,7 @@ log "ensuring API key + directories on Pearl"
 set -euo pipefail
 install -d -m 0755 /opt/micromdm/bin
 install -d -m 0700 /var/lib/micromdm
+install -d -m 0700 /var/lib/micromdm/repo
 install -d -m 0700 /etc/micromdm
 install -d -m 0700 /etc/micromdm/apns
 if [[ ! -f /etc/micromdm/api-key ]]; then
@@ -105,8 +106,12 @@ install -m 0755 "$WORKDIR/extract/build/linux/micromdm" "$WORKDIR/micromdm"
 install -m 0755 "$WORKDIR/extract/build/linux/mdmctl" "$WORKDIR/mdmctl"
 
 log "installing binaries + unit"
-"${SCP[@]}" "$WORKDIR/micromdm" "$WORKDIR/mdmctl" "$VPS_USER@$VPS_HOST:/opt/micromdm/bin/"
+install -m 0755 "$SCRIPT_DIR/systemd/micromdm-serve.sh" "$WORKDIR/micromdm-serve.sh"
+"${SCP[@]}" "$WORKDIR/micromdm" "$WORKDIR/mdmctl" "$WORKDIR/micromdm-serve.sh" \
+  "$VPS_USER@$VPS_HOST:/opt/micromdm/bin/"
+"${SSH[@]}" 'chmod 0755 /opt/micromdm/bin/micromdm /opt/micromdm/bin/mdmctl /opt/micromdm/bin/micromdm-serve.sh'
 "${SCP[@]}" "$UNIT_SRC" "$VPS_USER@$VPS_HOST:/etc/systemd/system/micromdm.service"
+
 
 # Write server-url into a drop-in so DOMAIN is configurable without editing the unit in git.
 "${SSH[@]}" bash -s -- "$SERVER_URL" <<'REMOTE'
@@ -143,23 +148,23 @@ API_KEY="$(cat /etc/micromdm/api-key)"
 export HOME=/root
 install -d -m 0700 /root/.micromdm
 
-# Prefer an unencrypted key for upload (avoids mdmctl password flag variance).
-KEY_UPLOAD=/etc/micromdm/apns/PushPrivateKey.unencrypted.key
+# Prefer traditional RSA PEM for mdmctl (rejects PKCS#8).
+KEY_UPLOAD=/etc/micromdm/apns/PushPrivateKey.rsa.pem
 if [[ -f /etc/micromdm/apns/PushPrivateKey.password ]]; then
   openssl rsa \
     -in /etc/micromdm/apns/PushPrivateKey.key \
     -passin file:/etc/micromdm/apns/PushPrivateKey.password \
+    -traditional \
     -out "$KEY_UPLOAD"
 else
-  cp /etc/micromdm/apns/PushPrivateKey.key "$KEY_UPLOAD"
+  openssl rsa -in /etc/micromdm/apns/PushPrivateKey.key -traditional -out "$KEY_UPLOAD"
 fi
 chmod 600 "$KEY_UPLOAD"
 
 /opt/micromdm/bin/mdmctl config set \
   -name pearl \
-  -api-url "http://127.0.0.1:8080" \
-  -api-key "$API_KEY" \
-  -server-url "$SERVER_URL"
+  -server-url "http://127.0.0.1:8080" \
+  -api-token "$API_KEY"
 /opt/micromdm/bin/mdmctl config switch -name pearl
 /opt/micromdm/bin/mdmctl mdmcert upload \
   -cert /etc/micromdm/apns/PushCertificate.pem \

--- a/phase4-coordinator/dist/install-micromdm-pearl.sh
+++ b/phase4-coordinator/dist/install-micromdm-pearl.sh
@@ -1,0 +1,188 @@
+#!/usr/bin/env bash
+# install-micromdm-pearl.sh — install MicroMDM on Pearl behind coordinator nginx.
+#
+# Idempotent. Does NOT restart the coordinator. Does NOT overwrite live nginx
+# unless --apply-nginx is passed (prefers deploying nginx via the normal Pearl
+# deploy that installs dist/nginx-coordinator.malibu.tech.conf).
+#
+# Prerequisites:
+#   - SSH as root to Pearl (same key as deploy-pearl-vps.sh)
+#   - MDM APNs push cert + matching private key available locally
+#
+# Usage (from repo root or this directory):
+#   bash phase4-coordinator/dist/install-micromdm-pearl.sh \
+#     --push-cert ~/Secrets/macprovider-mdm-apns/MDM_push_certificate.pem \
+#     --push-key  ~/Secrets/macprovider-mdm-apns/mdmcert.download.push.key \
+#     --push-key-password-file ~/Secrets/macprovider-mdm-apns/.push-password
+#
+# Environment:
+#   SSH_KEY   default: ~/.ssh/pearl_operator_ed25519
+#   VPS_HOST  default: 159.223.165.194
+#   VPS_USER  default: root
+#   DOMAIN    default: coordinator.malibu.tech
+#   MICROMDM_VERSION default: v1.13.1
+
+set -euo pipefail
+
+SSH_KEY="${SSH_KEY:-$HOME/.ssh/pearl_operator_ed25519}"
+VPS_HOST="${VPS_HOST:-159.223.165.194}"
+VPS_USER="${VPS_USER:-root}"
+DOMAIN="${DOMAIN:-coordinator.malibu.tech}"
+MICROMDM_VERSION="${MICROMDM_VERSION:-v1.13.1}"
+SERVER_URL="https://${DOMAIN}"
+
+PUSH_CERT=""
+PUSH_KEY=""
+PUSH_KEY_PASSWORD_FILE=""
+APPLY_NGINX=0
+SKIP_APNS_UPLOAD=0
+
+usage() {
+  sed -n '2,25p' "$0" | sed 's/^# \{0,1\}//'
+  exit 2
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --push-cert) PUSH_CERT="$2"; shift 2 ;;
+    --push-key) PUSH_KEY="$2"; shift 2 ;;
+    --push-key-password-file) PUSH_KEY_PASSWORD_FILE="$2"; shift 2 ;;
+    --apply-nginx) APPLY_NGINX=1; shift ;;
+    --skip-apns-upload) SKIP_APNS_UPLOAD=1; shift ;;
+    -h|--help) usage ;;
+    *) echo "unknown arg: $1" >&2; usage ;;
+  esac
+done
+
+if [[ -z "$PUSH_CERT" || -z "$PUSH_KEY" ]]; then
+  echo "error: --push-cert and --push-key are required" >&2
+  exit 1
+fi
+[[ -f "$PUSH_CERT" ]] || { echo "missing cert: $PUSH_CERT" >&2; exit 1; }
+[[ -f "$PUSH_KEY" ]] || { echo "missing key: $PUSH_KEY" >&2; exit 1; }
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+UNIT_SRC="$SCRIPT_DIR/systemd/micromdm.service"
+NGINX_SRC="$SCRIPT_DIR/nginx-coordinator.malibu.tech.conf"
+[[ -f "$UNIT_SRC" ]] || { echo "missing unit: $UNIT_SRC" >&2; exit 1; }
+
+SSH=(ssh -i "$SSH_KEY" -o ConnectTimeout=10 -o BatchMode=yes -p 22 "$VPS_USER@$VPS_HOST")
+SCP=(scp -i "$SSH_KEY" -o ConnectTimeout=10 -o BatchMode=yes -P 22)
+
+log() { printf '[micromdm-install] %s\n' "$*"; }
+
+# Generate or reuse API key on Pearl.
+log "ensuring API key + directories on Pearl"
+"${SSH[@]}" bash -s <<'REMOTE'
+set -euo pipefail
+install -d -m 0755 /opt/micromdm/bin
+install -d -m 0700 /var/lib/micromdm
+install -d -m 0700 /etc/micromdm
+install -d -m 0700 /etc/micromdm/apns
+if [[ ! -f /etc/micromdm/api-key ]]; then
+  umask 077
+  openssl rand -hex 32 > /etc/micromdm/api-key
+  chmod 600 /etc/micromdm/api-key
+fi
+if [[ ! -f /etc/micromdm/env ]]; then
+  umask 077
+  cat > /etc/micromdm/env <<EOF
+MICROMDM_API_KEY=$(cat /etc/micromdm/api-key)
+EOF
+  chmod 600 /etc/micromdm/env
+fi
+REMOTE
+
+WORKDIR="$(mktemp -d "${TMPDIR:-/tmp}/micromdm-pearl.XXXXXX")"
+cleanup() { rm -rf "$WORKDIR"; }
+trap cleanup EXIT
+
+log "downloading MicroMDM ${MICROMDM_VERSION}"
+curl -fsSL -o "$WORKDIR/micromdm.zip" \
+  "https://github.com/micromdm/micromdm/releases/download/${MICROMDM_VERSION}/micromdm_${MICROMDM_VERSION}.zip"
+unzip -qo "$WORKDIR/micromdm.zip" -d "$WORKDIR/extract"
+install -m 0755 "$WORKDIR/extract/build/linux/micromdm" "$WORKDIR/micromdm"
+install -m 0755 "$WORKDIR/extract/build/linux/mdmctl" "$WORKDIR/mdmctl"
+
+log "installing binaries + unit"
+"${SCP[@]}" "$WORKDIR/micromdm" "$WORKDIR/mdmctl" "$VPS_USER@$VPS_HOST:/opt/micromdm/bin/"
+"${SCP[@]}" "$UNIT_SRC" "$VPS_USER@$VPS_HOST:/etc/systemd/system/micromdm.service"
+
+# Write server-url into a drop-in so DOMAIN is configurable without editing the unit in git.
+"${SSH[@]}" bash -s -- "$SERVER_URL" <<'REMOTE'
+set -euo pipefail
+SERVER_URL="$1"
+install -d -m 0755 /etc/systemd/system/micromdm.service.d
+cat > /etc/systemd/system/micromdm.service.d/override.conf <<EOF
+[Service]
+Environment=MICROMDM_SERVER_URL=${SERVER_URL}
+EOF
+chmod 644 /etc/systemd/system/micromdm.service.d/override.conf
+systemctl daemon-reload
+systemctl enable micromdm.service
+systemctl restart micromdm.service
+systemctl --no-pager --full status micromdm.service | head -20
+REMOTE
+
+log "uploading APNs push cert + key"
+"${SCP[@]}" "$PUSH_CERT" "$VPS_USER@$VPS_HOST:/etc/micromdm/apns/PushCertificate.pem"
+"${SCP[@]}" "$PUSH_KEY" "$VPS_USER@$VPS_HOST:/etc/micromdm/apns/PushPrivateKey.key"
+if [[ -n "$PUSH_KEY_PASSWORD_FILE" ]]; then
+  [[ -f "$PUSH_KEY_PASSWORD_FILE" ]] || { echo "missing password file" >&2; exit 1; }
+  "${SCP[@]}" "$PUSH_KEY_PASSWORD_FILE" "$VPS_USER@$VPS_HOST:/etc/micromdm/apns/PushPrivateKey.password"
+  "${SSH[@]}" 'chmod 600 /etc/micromdm/apns/PushPrivateKey.password'
+fi
+"${SSH[@]}" 'chmod 600 /etc/micromdm/apns/PushCertificate.pem /etc/micromdm/apns/PushPrivateKey.key'
+
+if [[ "$SKIP_APNS_UPLOAD" -eq 0 ]]; then
+  log "configuring mdmctl + uploading push cert into MicroMDM"
+  "${SSH[@]}" bash -s -- "$SERVER_URL" <<'REMOTE'
+set -euo pipefail
+SERVER_URL="$1"
+API_KEY="$(cat /etc/micromdm/api-key)"
+export HOME=/root
+install -d -m 0700 /root/.micromdm
+
+# Prefer an unencrypted key for upload (avoids mdmctl password flag variance).
+KEY_UPLOAD=/etc/micromdm/apns/PushPrivateKey.unencrypted.key
+if [[ -f /etc/micromdm/apns/PushPrivateKey.password ]]; then
+  openssl rsa \
+    -in /etc/micromdm/apns/PushPrivateKey.key \
+    -passin file:/etc/micromdm/apns/PushPrivateKey.password \
+    -out "$KEY_UPLOAD"
+else
+  cp /etc/micromdm/apns/PushPrivateKey.key "$KEY_UPLOAD"
+fi
+chmod 600 "$KEY_UPLOAD"
+
+/opt/micromdm/bin/mdmctl config set \
+  -name pearl \
+  -api-url "http://127.0.0.1:8080" \
+  -api-key "$API_KEY" \
+  -server-url "$SERVER_URL"
+/opt/micromdm/bin/mdmctl config switch -name pearl
+/opt/micromdm/bin/mdmctl mdmcert upload \
+  -cert /etc/micromdm/apns/PushCertificate.pem \
+  -private-key "$KEY_UPLOAD"
+echo "APNs push certificate uploaded"
+REMOTE
+fi
+
+if [[ "$APPLY_NGINX" -eq 1 ]]; then
+  log "installing nginx site from tracked dist (nginx -t && reload)"
+  [[ -f "$NGINX_SRC" ]] || { echo "missing nginx conf: $NGINX_SRC" >&2; exit 1; }
+  "${SCP[@]}" "$NGINX_SRC" "$VPS_USER@$VPS_HOST:/etc/nginx/sites-available/coordinator.malibu.tech"
+  "${SSH[@]}" 'nginx -t && systemctl reload nginx'
+fi
+
+log "smoke: local MicroMDM version + public scep/mdm path presence"
+"${SSH[@]}" bash -s <<'REMOTE'
+set -euo pipefail
+curl -fsS -o /dev/null -w 'local_version_http=%{http_code}\n' http://127.0.0.1:8080/version || true
+ss -lntp | grep -E ':8080\b' || { echo 'micromdm not listening on 8080' >&2; exit 1; }
+REMOTE
+
+log "done. Next:"
+log "  1) Ensure nginx has /v1/enroll + /mdm/ + /scep (deploy or --apply-nginx)"
+log "  2) Set tier2.mdm in /etc/macprovider/coordinator.pearl-overlays.yaml and restart coordinator"
+log "  3) POST /v1/enroll smoke + macprovider-cli enroll on a test Mac"

--- a/phase4-coordinator/dist/nginx-coordinator.malibu.tech.conf
+++ b/phase4-coordinator/dist/nginx-coordinator.malibu.tech.conf
@@ -582,6 +582,27 @@ server {
     }
 
     # ---------------------------------------------------------------------
+    # /v1/enroll — Phase 2 MDM enrollment profile download (P2-A/P2-B).
+    # Public POST on the buyer mux (8443). Serial-only body; no auth.
+    # Enabled in coordinator only when tier2.mdm.enrollment_base_url is set.
+    # MUST be declared BEFORE the /v1/ catch-all 404.
+    # ---------------------------------------------------------------------
+    location = /v1/enroll {
+        limit_req zone=ws_provider_rate burst=5 nodelay;
+        limit_req_status 429;
+        proxy_pass http://127.0.0.1:8443/v1/enroll;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_read_timeout 30s;
+        proxy_no_cache 1;
+        proxy_cache_bypass 1;
+        client_max_body_size 4k;
+        add_header Cache-Control "no-store" always;
+    }
+
+    # ---------------------------------------------------------------------
     # /v1/* is intentionally not exposed on the coordinator hostname.
     # Buyer API traffic must enter through the gateway so account auth,
     # quota enforcement, demo restrictions, and header allowlisting apply.
@@ -589,9 +610,52 @@ server {
     # verifier MUST be able to fetch trust-root pubkeys without operator
     # credentials. The SPEC-023 signed-feed and release-identity exceptions
     # and the /v1/stats/* exceptions above are public read-only surfaces.
+    # /v1/enroll is the MDM enrollment exception (exact location above).
     # ---------------------------------------------------------------------
     location /v1/ {
         return 404;
+    }
+
+    # ---------------------------------------------------------------------
+    # MicroMDM device protocol (Phase 2 P2-B) — local MicroMDM on :8080.
+    # Profiles from /v1/enroll point at {enrollment_base_url}/mdm/* and /scep.
+    # Do NOT proxy MicroMDM's /v1 API publicly; keep API on loopback + api-key.
+    # ---------------------------------------------------------------------
+    location /mdm/ {
+        proxy_pass http://127.0.0.1:8080;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Forwarded-Host $host;
+        proxy_read_timeout 120s;
+        proxy_connect_timeout 10s;
+        client_max_body_size 10m;
+        proxy_request_buffering off;
+    }
+
+    location = /scep {
+        proxy_pass http://127.0.0.1:8080/scep;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Forwarded-Host $host;
+        proxy_read_timeout 120s;
+        proxy_connect_timeout 10s;
+        client_max_body_size 10m;
+    }
+
+    location /scep/ {
+        proxy_pass http://127.0.0.1:8080/scep/;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Forwarded-Host $host;
+        proxy_read_timeout 120s;
+        proxy_connect_timeout 10s;
+        client_max_body_size 10m;
     }
 
     # ---------------------------------------------------------------------

--- a/phase4-coordinator/dist/systemd/micromdm-serve.sh
+++ b/phase4-coordinator/dist/systemd/micromdm-serve.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+# micromdm-serve.sh — launched by micromdm.service
+set -euo pipefail
+: "${MICROMDM_SERVER_URL:?MICROMDM_SERVER_URL unset}"
+API_KEY="$(cat /etc/micromdm/api-key)"
+exec /opt/micromdm/bin/micromdm serve \
+  -server-url "${MICROMDM_SERVER_URL}" \
+  -api-key "${API_KEY}" \
+  -config-path /var/lib/micromdm \
+  -filerepo /var/lib/micromdm/repo \
+  -http-addr 127.0.0.1:8080 \
+  -tls=false \
+  -http-proxy-headers=true \
+  -homepage=false \
+  -log-time=true

--- a/phase4-coordinator/dist/systemd/micromdm.service
+++ b/phase4-coordinator/dist/systemd/micromdm.service
@@ -9,20 +9,12 @@ Type=simple
 User=root
 EnvironmentFile=-/etc/micromdm/env
 # MICROMDM_SERVER_URL comes from /etc/systemd/system/micromdm.service.d/override.conf
-ExecStart=/opt/micromdm/bin/micromdm serve \
-  -server-url ${MICROMDM_SERVER_URL} \
-  -api-key ${MICROMDM_API_KEY} \
-  -config-path /var/lib/micromdm \
-  -filerepo /var/lib/micromdm/repo \
-  -http-addr 127.0.0.1:8080 \
-  -tls=false \
-  -http-proxy-headers=true \
-  -homepage=false \
-  -log-time=true
+# Wrapper keeps the API key out of the unit file text (still visible in process
+# argv — regenerate /etc/micromdm/api-key if it ever leaks via status logs).
+ExecStart=/opt/micromdm/bin/micromdm-serve.sh
 Restart=on-failure
 RestartSec=3
 LimitNOFILE=65536
-# Secrets stay mode 600 under /etc/micromdm
 NoNewPrivileges=true
 ProtectSystem=full
 ProtectHome=true

--- a/phase4-coordinator/dist/systemd/micromdm.service
+++ b/phase4-coordinator/dist/systemd/micromdm.service
@@ -1,0 +1,33 @@
+[Unit]
+Description=MicroMDM (macprovider hardware attestation MDM)
+Documentation=https://github.com/micromdm/micromdm
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=root
+EnvironmentFile=-/etc/micromdm/env
+# MICROMDM_SERVER_URL comes from /etc/systemd/system/micromdm.service.d/override.conf
+ExecStart=/opt/micromdm/bin/micromdm serve \
+  -server-url ${MICROMDM_SERVER_URL} \
+  -api-key ${MICROMDM_API_KEY} \
+  -config-path /var/lib/micromdm \
+  -filerepo /var/lib/micromdm/repo \
+  -http-addr 127.0.0.1:8080 \
+  -tls=false \
+  -http-proxy-headers=true \
+  -homepage=false \
+  -log-time=true
+Restart=on-failure
+RestartSec=3
+LimitNOFILE=65536
+# Secrets stay mode 600 under /etc/micromdm
+NoNewPrivileges=true
+ProtectSystem=full
+ProtectHome=true
+PrivateTmp=true
+ReadWritePaths=/var/lib/micromdm /etc/micromdm
+
+[Install]
+WantedBy=multi-user.target

--- a/phase4-coordinator/dist/test/check_nginx_mdm_enroll_routes_test.sh
+++ b/phase4-coordinator/dist/test/check_nginx_mdm_enroll_routes_test.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+config="$root/dist/nginx-coordinator.malibu.tech.conf"
+
+test "$(grep -c 'location = /v1/enroll' "$config")" -eq 1
+enroll_block="$(grep -A18 'location = /v1/enroll' "$config")"
+grep -q 'proxy_pass http://127.0.0.1:8443/v1/enroll;' <<<"$enroll_block"
+grep -q 'client_max_body_size 4k;' <<<"$enroll_block"
+grep -q 'add_header Cache-Control "no-store" always;' <<<"$enroll_block"
+
+enroll_line="$(grep -nE '^[[:space:]]*location = /v1/enroll' "$config" | cut -d: -f1)"
+catchall_line="$(grep -nE '^[[:space:]]*location[[:space:]]+/v1/[[:space:]]*[{]' "$config" | cut -d: -f1)"
+test "$enroll_line" -lt "$catchall_line"
+
+test "$(grep -c 'location /mdm/' "$config")" -eq 1
+mdm_block="$(grep -A14 'location /mdm/' "$config")"
+grep -q 'proxy_pass http://127.0.0.1:8080;' <<<"$mdm_block"
+grep -q 'proxy_set_header X-Forwarded-Proto \$scheme;' <<<"$mdm_block"
+
+test "$(grep -c 'location = /scep' "$config")" -eq 1
+scep_block="$(grep -A12 'location = /scep' "$config")"
+grep -q 'proxy_pass http://127.0.0.1:8080/scep;' <<<"$scep_block"
+
+echo "nginx MDM enroll route checks passed"


### PR DESCRIPTION
## Summary
- Exact nginx `location = /v1/enroll` → buyer mux `:8443`, plus `/mdm/` and `/scep` → local MicroMDM `:8080`
- `tier2.mdm` block documented in `coordinator.yaml.example` (live values via Pearl overlay)
- Idempotent `install-micromdm-pearl.sh` + `micromdm.service` + runbook
- Nginx route regression test

## Live Pearl (already applied from this branch)
- MicroMDM active on `127.0.0.1:8080` with APNs cert uploaded
- nginx routes live; overlay `tier2.mdm` set; coordinator restarted
- `POST /v1/enroll` returns `.mobileconfig` with push topic `com.apple.mgmt.External.b3ba8c97-af5f-4feb-8d06-d9fd839c241b`
- Remaining: operator `macprovider-cli enroll run` + approve profile in System Settings, then `mdmctl get devices`

## Test plan
- [x] `bash phase4-coordinator/dist/test/check_nginx_mdm_enroll_routes_test.sh`
- [x] MicroMDM install + APNs upload on Pearl
- [x] `tier2.mdm` overlay + coordinator restart
- [x] `curl POST /v1/enroll` returns `.mobileconfig`
- [ ] `macprovider-cli enroll run` on a test Mac → `mdmctl get devices`

SPEC-GOVERNANCE-DECLARATION-BEGIN
{
  "schema_version": "spec-pr-governance-v1",
  "behavior_change": "yes",
  "contract_change": "none",
  "specs": ["SPEC-008"],
  "requirements": ["SPEC-008-R001"],
  "authority_domains": ["tier2-trust-evidence"],
  "arbitration": ["CODE_BUG"],
  "tests": ["phase4-coordinator/dist/test/check_nginx_mdm_enroll_routes_test.sh"],
  "journeys": ["not-required"],
  "issue": "https://github.com/Augustas11/macprovider/issues/608"
}
SPEC-GOVERNANCE-DECLARATION-END