### PR TITLE
Gate MALIBU rewards on verified useful work

### DIFF
--- a/phase4-coordinator/cmd/coordinator/main.go
+++ b/phase4-coordinator/cmd/coordinator/main.go
@@ -442,16 +442,19 @@ func main() {
 			sqlitePath = cfg.Storage.DBPath
 		}
 		rewardsCfg := rewards.Config{
-			Enabled:                true,
-			WriterDSN:              cfg.MalibuEmission.WriterDSN,
-			TickInterval:           time.Duration(cfg.MalibuEmission.TickIntervalSeconds) * time.Second,
-			ProviderDailyCapMALIBU: cfg.MalibuEmission.ProviderDailyCapMALIBU,
-			WalletDailyCapMALIBU:   cfg.MalibuEmission.WalletDailyCapMALIBU,
-			SQLitePayoutDBPath:     sqlitePath,
-			WalletMirrorInterval:   time.Duration(cfg.MalibuEmission.WalletMirrorIntervalSeconds) * time.Second,
-			UnlockEvalInterval:     time.Duration(cfg.MalibuEmission.UnlockEvalIntervalSeconds) * time.Second,
-			MaxSerializableRetries: cfg.MalibuEmission.MaxSerializableRetries,
-			BaseUSDCBalanceRPCURLs: cfg.MalibuEmission.BaseUSDCBalanceRPCURLs,
+			Enabled:                      true,
+			WriterDSN:                    cfg.MalibuEmission.WriterDSN,
+			TickInterval:                 time.Duration(cfg.MalibuEmission.TickIntervalSeconds) * time.Second,
+			UsefulWorkEnabled:            cfg.MalibuEmission.UsefulWorkEnabled,
+			UsefulWorkInterval:           time.Duration(cfg.MalibuEmission.UsefulWorkIntervalSeconds) * time.Second,
+			ProviderDailyCapMALIBU:       cfg.MalibuEmission.ProviderDailyCapMALIBU,
+			WalletDailyCapMALIBU:         cfg.MalibuEmission.WalletDailyCapMALIBU,
+			UsefulWorkMALIBUPer1KCredits: cfg.MalibuEmission.UsefulWorkMALIBUPer1KCredits,
+			SQLitePayoutDBPath:           sqlitePath,
+			WalletMirrorInterval:         time.Duration(cfg.MalibuEmission.WalletMirrorIntervalSeconds) * time.Second,
+			UnlockEvalInterval:           time.Duration(cfg.MalibuEmission.UnlockEvalIntervalSeconds) * time.Second,
+			MaxSerializableRetries:       cfg.MalibuEmission.MaxSerializableRetries,
+			BaseUSDCBalanceRPCURLs:       cfg.MalibuEmission.BaseUSDCBalanceRPCURLs,
 		}
 		var err error
 		rewardsRunner, err = rewards.New(rewardsDB, rewardsCfg, logger.With().Str("subsystem", "malibu_emission").Logger(), rewards.RunnerDeps{})
@@ -2342,9 +2345,10 @@ func malibuAccrualHandler(cfg config.Config, tokenStore *auth.Store, rewardsDB *
 		return nil
 	}
 	rewardsCfg := rewards.Config{
-		ProviderDailyCapMALIBU: cfg.MalibuEmission.ProviderDailyCapMALIBU,
-		WalletDailyCapMALIBU:   cfg.MalibuEmission.WalletDailyCapMALIBU,
-		SQLitePayoutDBPath:     cfg.MalibuEmission.SQLitePayoutDBPath,
+		ProviderDailyCapMALIBU:       cfg.MalibuEmission.ProviderDailyCapMALIBU,
+		WalletDailyCapMALIBU:         cfg.MalibuEmission.WalletDailyCapMALIBU,
+		UsefulWorkMALIBUPer1KCredits: cfg.MalibuEmission.UsefulWorkMALIBUPer1KCredits,
+		SQLitePayoutDBPath:           cfg.MalibuEmission.SQLitePayoutDBPath,
 	}
 	if rewardsCfg.SQLitePayoutDBPath == "" {
 		rewardsCfg.SQLitePayoutDBPath = cfg.Storage.DBPath

--- a/phase4-coordinator/coordinator.malibu-emission-overlay.yaml
+++ b/phase4-coordinator/coordinator.malibu-emission-overlay.yaml
@@ -5,15 +5,19 @@
 # (e.g. OPoI canaries) before install — deploy script does this automatically.
 #
 # Promotion (after C4 verification): set enabled: true and restart coordinator.
-# Pearl production: enabled:true as of 2026-08-07 (prebeta P2 — accrual ticks on).
+# Useful-work v0.2 rewards remain separately gated by useful_work_enabled.
+# Pearl production: enabled:true as of 2026-08-07 (prebeta P2 — bootstrap accrual ticks on).
 # Rollback: set enabled: false or remove this overlay block.
 
 malibu_emission:
   enabled: false
   writer_dsn: env:MALIBU_EMISSION_WRITER_DSN
   tick_interval_seconds: 900
+  useful_work_enabled: false
+  useful_work_interval_seconds: 900
   provider_daily_cap_malibu: 25
   wallet_daily_cap_malibu: 100
+  useful_work_malibu_per_1000_provider_credits: 1
   wallet_mirror_interval_seconds: 300
   unlock_eval_interval_seconds: 3600
   max_serializable_retries: 5

--- a/phase4-coordinator/dist/stats-billing-mirror-bootstrap.sql
+++ b/phase4-coordinator/dist/stats-billing-mirror-bootstrap.sql
@@ -22,7 +22,9 @@ CREATE TABLE IF NOT EXISTS ledger_request_credits (
     usage_source TEXT NOT NULL DEFAULT 'provider_reported' CHECK (usage_source IN ('provider_reported','byte_estimated','null_error')),
     provider_credits BIGINT NOT NULL DEFAULT 0 CHECK (provider_credits >= 0),
     fault_flag TEXT NOT NULL DEFAULT 'none' CHECK (fault_flag IN ('none','breaker_qualifying','null_usage_error')),
-    quarantined BOOLEAN NOT NULL DEFAULT FALSE
+    quarantined BOOLEAN NOT NULL DEFAULT FALSE,
+    settlement_policy_mode TEXT NOT NULL DEFAULT 'legacy' CHECK (settlement_policy_mode IN ('legacy','observe','enforce')),
+    spec022_verified BOOLEAN NOT NULL DEFAULT FALSE
 );
 ALTER TABLE ledger_request_credits ADD COLUMN IF NOT EXISTS sqlite_lrc_id BIGINT;
 ALTER TABLE ledger_request_credits ADD COLUMN IF NOT EXISTS request_id TEXT;
@@ -38,6 +40,11 @@ ALTER TABLE ledger_request_credits ADD COLUMN IF NOT EXISTS usage_source TEXT DE
 ALTER TABLE ledger_request_credits ADD COLUMN IF NOT EXISTS provider_credits BIGINT DEFAULT 0;
 ALTER TABLE ledger_request_credits ADD COLUMN IF NOT EXISTS fault_flag TEXT DEFAULT 'none';
 ALTER TABLE ledger_request_credits ADD COLUMN IF NOT EXISTS quarantined BOOLEAN DEFAULT FALSE;
+ALTER TABLE ledger_request_credits ADD COLUMN IF NOT EXISTS settlement_policy_mode TEXT DEFAULT 'legacy';
+ALTER TABLE ledger_request_credits ADD COLUMN IF NOT EXISTS spec022_verified BOOLEAN DEFAULT FALSE;
+
+UPDATE ledger_request_credits SET settlement_policy_mode = 'legacy' WHERE settlement_policy_mode IS NULL;
+UPDATE ledger_request_credits SET spec022_verified = FALSE WHERE spec022_verified IS NULL;
 
 DO $$
 BEGIN
@@ -62,10 +69,31 @@ BEGIN
     IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'lrc_mirror_fault_flag_enum') THEN
         ALTER TABLE ledger_request_credits ADD CONSTRAINT lrc_mirror_fault_flag_enum CHECK (fault_flag IN ('none','breaker_qualifying','null_usage_error'));
     END IF;
+    IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'lrc_mirror_settlement_policy_mode_enum') THEN
+        ALTER TABLE ledger_request_credits ADD CONSTRAINT lrc_mirror_settlement_policy_mode_enum CHECK (settlement_policy_mode IN ('legacy','observe','enforce'));
+    END IF;
+    IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'lrc_mirror_spec022_verified_not_null') THEN
+        ALTER TABLE ledger_request_credits ADD CONSTRAINT lrc_mirror_spec022_verified_not_null CHECK (spec022_verified IS NOT NULL);
+    END IF;
+    IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'lrc_mirror_spec022_verified_enforce_check') THEN
+        ALTER TABLE ledger_request_credits ADD CONSTRAINT lrc_mirror_spec022_verified_enforce_check CHECK (spec022_verified = FALSE OR settlement_policy_mode = 'enforce');
+    END IF;
 END $$;
 
 CREATE UNIQUE INDEX IF NOT EXISTS idx_lrc_mirror_unique_attempt ON ledger_request_credits(request_id, attempt_n, provider_id);
 CREATE INDEX IF NOT EXISTS idx_lrc_mirror_provider_ts ON ledger_request_credits(provider_id, ts_utc);
+
+CREATE TABLE IF NOT EXISTS ledger_request_credit_spec022_verified_audit (
+    request_id TEXT NOT NULL,
+    attempt_n INTEGER NOT NULL,
+    provider_id TEXT NOT NULL,
+    sqlite_lrc_id BIGINT,
+    provider_credits BIGINT NOT NULL,
+    settlement_policy_mode TEXT NOT NULL CHECK (settlement_policy_mode = 'enforce'),
+    source TEXT NOT NULL DEFAULT 'stats_billing_mirror',
+    mirrored_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    PRIMARY KEY (request_id, attempt_n, provider_id)
+);
 
 CREATE TABLE IF NOT EXISTS provider_tokens (
     id BIGSERIAL PRIMARY KEY,
@@ -161,21 +189,46 @@ CREATE OR REPLACE FUNCTION stats_billing_mirror_upsert_request_credit(
     p_usage_source TEXT,
     p_provider_credits BIGINT,
     p_fault_flag TEXT,
-    p_quarantined BOOLEAN
+    p_quarantined BOOLEAN,
+    p_settlement_policy_mode TEXT,
+    p_spec022_verified BOOLEAN
 )
 RETURNS void
-LANGUAGE sql
+LANGUAGE plpgsql
 SECURITY DEFINER
 SET search_path = public
 AS $$
+DECLARE
+    v_settlement_policy_mode TEXT := COALESCE(NULLIF(p_settlement_policy_mode, ''), 'legacy');
+    v_spec022_verified BOOLEAN;
+    v_was_spec022_verified BOOLEAN;
+BEGIN
+    IF v_settlement_policy_mode NOT IN ('legacy','observe','enforce') THEN
+        RAISE EXCEPTION 'invalid settlement_policy_mode: %', v_settlement_policy_mode;
+    END IF;
+
+    v_spec022_verified :=
+        v_settlement_policy_mode = 'enforce'
+        AND COALESCE(p_spec022_verified, FALSE)
+        AND COALESCE(p_provider_credits, 0) > 0
+        AND NOT COALESCE(p_quarantined, FALSE);
+
+    SELECT spec022_verified
+      INTO v_was_spec022_verified
+      FROM ledger_request_credits
+     WHERE request_id = p_request_id
+       AND attempt_n = p_attempt_n
+       AND provider_id = p_provider_id
+     FOR UPDATE;
+
     INSERT INTO ledger_request_credits (
         sqlite_lrc_id, request_id, attempt_n, provider_id, ts_utc, created_at_utc, updated_at_utc,
         prompt_tokens, completion_tokens, estimated_completion_tokens, usage_source,
-        provider_credits, fault_flag, quarantined
+        provider_credits, fault_flag, quarantined, settlement_policy_mode, spec022_verified
     ) VALUES (
         p_sqlite_lrc_id, p_request_id, p_attempt_n, p_provider_id, p_ts_utc, p_created_at_utc, p_updated_at_utc,
         p_prompt_tokens, p_completion_tokens, p_estimated_completion_tokens, p_usage_source,
-        p_provider_credits, p_fault_flag, p_quarantined
+        p_provider_credits, p_fault_flag, COALESCE(p_quarantined, FALSE), v_settlement_policy_mode, v_spec022_verified
     )
     ON CONFLICT (request_id, attempt_n, provider_id) DO UPDATE SET
         sqlite_lrc_id = EXCLUDED.sqlite_lrc_id,
@@ -188,7 +241,21 @@ AS $$
         usage_source = EXCLUDED.usage_source,
         provider_credits = EXCLUDED.provider_credits,
         fault_flag = EXCLUDED.fault_flag,
-        quarantined = EXCLUDED.quarantined;
+        quarantined = EXCLUDED.quarantined,
+        settlement_policy_mode = EXCLUDED.settlement_policy_mode,
+        spec022_verified = EXCLUDED.spec022_verified;
+
+    IF v_spec022_verified AND NOT COALESCE(v_was_spec022_verified, FALSE) THEN
+        INSERT INTO ledger_request_credit_spec022_verified_audit (
+            request_id, attempt_n, provider_id, sqlite_lrc_id,
+            provider_credits, settlement_policy_mode
+        ) VALUES (
+            p_request_id, p_attempt_n, p_provider_id, p_sqlite_lrc_id,
+            p_provider_credits, v_settlement_policy_mode
+        )
+        ON CONFLICT (request_id, attempt_n, provider_id) DO NOTHING;
+    END IF;
+END;
 $$;
 
 DO $$
@@ -200,18 +267,36 @@ BEGIN
         GRANT SELECT ON ledger_request_credits TO stats_rollup;
         GRANT SELECT ON provider_tokens TO stats_rollup;
     END IF;
+    IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'rewards_writer') THEN
+        GRANT SELECT ON ledger_request_credits TO rewards_writer;
+    END IF;
 END $$;
 
 GRANT USAGE ON SCHEMA public TO stats_billing_mirror_writer;
 REVOKE ALL ON ledger_request_credits FROM stats_billing_mirror_writer;
 REVOKE ALL ON provider_tokens FROM stats_billing_mirror_writer;
 REVOKE ALL ON stats_billing_mirror_state FROM stats_billing_mirror_writer;
+REVOKE ALL ON ledger_request_credit_spec022_verified_audit FROM stats_billing_mirror_writer;
 REVOKE ALL ON FUNCTION stats_billing_mirror_load_state(TEXT) FROM PUBLIC;
 REVOKE ALL ON FUNCTION stats_billing_mirror_save_state(TEXT, BIGINT, BIGINT) FROM PUBLIC;
 REVOKE ALL ON FUNCTION stats_billing_mirror_ensure_provider(TEXT, TEXT, TEXT, TIMESTAMPTZ, TIMESTAMPTZ) FROM PUBLIC;
-REVOKE ALL ON FUNCTION stats_billing_mirror_upsert_request_credit(BIGINT, TEXT, INTEGER, TEXT, TIMESTAMPTZ, TIMESTAMPTZ, TIMESTAMPTZ, BIGINT, BIGINT, BIGINT, TEXT, BIGINT, TEXT, BOOLEAN) FROM PUBLIC;
+REVOKE ALL ON FUNCTION stats_billing_mirror_upsert_request_credit(BIGINT, TEXT, INTEGER, TEXT, TIMESTAMPTZ, TIMESTAMPTZ, TIMESTAMPTZ, BIGINT, BIGINT, BIGINT, TEXT, BIGINT, TEXT, BOOLEAN, TEXT, BOOLEAN) FROM PUBLIC;
+
+DO $$
+BEGIN
+    IF EXISTS (
+        SELECT 1
+          FROM pg_proc p
+          JOIN pg_namespace n ON n.oid = p.pronamespace
+         WHERE n.nspname = 'public'
+           AND p.proname = 'stats_billing_mirror_upsert_request_credit'
+           AND p.pronargs = 14
+    ) THEN
+        REVOKE ALL ON FUNCTION stats_billing_mirror_upsert_request_credit(BIGINT, TEXT, INTEGER, TEXT, TIMESTAMPTZ, TIMESTAMPTZ, TIMESTAMPTZ, BIGINT, BIGINT, BIGINT, TEXT, BIGINT, TEXT, BOOLEAN) FROM PUBLIC;
+    END IF;
+END $$;
 
 GRANT EXECUTE ON FUNCTION stats_billing_mirror_load_state(TEXT) TO stats_billing_mirror_writer;
 GRANT EXECUTE ON FUNCTION stats_billing_mirror_save_state(TEXT, BIGINT, BIGINT) TO stats_billing_mirror_writer;
 GRANT EXECUTE ON FUNCTION stats_billing_mirror_ensure_provider(TEXT, TEXT, TEXT, TIMESTAMPTZ, TIMESTAMPTZ) TO stats_billing_mirror_writer;
-GRANT EXECUTE ON FUNCTION stats_billing_mirror_upsert_request_credit(BIGINT, TEXT, INTEGER, TEXT, TIMESTAMPTZ, TIMESTAMPTZ, TIMESTAMPTZ, BIGINT, BIGINT, BIGINT, TEXT, BIGINT, TEXT, BOOLEAN) TO stats_billing_mirror_writer;
+GRANT EXECUTE ON FUNCTION stats_billing_mirror_upsert_request_credit(BIGINT, TEXT, INTEGER, TEXT, TIMESTAMPTZ, TIMESTAMPTZ, TIMESTAMPTZ, BIGINT, BIGINT, BIGINT, TEXT, BIGINT, TEXT, BOOLEAN, TEXT, BOOLEAN) TO stats_billing_mirror_writer;

--- a/phase4-coordinator/dist/test/check_stats_billing_mirror_deploy_test.sh
+++ b/phase4-coordinator/dist/test/check_stats_billing_mirror_deploy_test.sh
@@ -80,6 +80,14 @@ grep -qF 'runs with --ensure-schema=false' "$ENV_EXAMPLE" ||
   fail "env example must document bootstrap-before-service contract"
 grep -qF 'CREATE TABLE IF NOT EXISTS ledger_request_credits' "$BOOTSTRAP_SQL" ||
   fail "bootstrap SQL must create ledger_request_credits"
+grep -qF 'settlement_policy_mode TEXT' "$BOOTSTRAP_SQL" ||
+  fail "bootstrap SQL must carry settlement policy mode column"
+grep -qF 'spec022_verified BOOLEAN' "$BOOTSTRAP_SQL" ||
+  fail "bootstrap SQL must carry SPEC-022 verified column"
+grep -qF 'lrc_mirror_spec022_verified_enforce_check' "$BOOTSTRAP_SQL" ||
+  fail "bootstrap SQL must constrain SPEC-022 verified rows to enforce mode"
+grep -qF 'CREATE TABLE IF NOT EXISTS ledger_request_credit_spec022_verified_audit' "$BOOTSTRAP_SQL" ||
+  fail "bootstrap SQL must create SPEC-022 verified audit table"
 if grep -qF "PASSWORD 'REPLACE_ME'" "$BOOTSTRAP_SQL"; then
   fail "bootstrap SQL must not create a known default password"
 fi
@@ -89,11 +97,15 @@ grep -qF 'CREATE TABLE IF NOT EXISTS provider_tokens' "$BOOTSTRAP_SQL" ||
   fail "bootstrap SQL must create provider_tokens"
 grep -qF 'GRANT SELECT ON ledger_request_credits TO stats_rollup' "$BOOTSTRAP_SQL" ||
   fail "bootstrap SQL must grant rollup read access"
+grep -qF 'GRANT SELECT ON ledger_request_credits TO rewards_writer' "$BOOTSTRAP_SQL" ||
+  fail "bootstrap SQL must grant rewards writer read access"
 grep -qF 'REVOKE ALL ON ledger_request_credits FROM stats_billing_mirror_writer' "$BOOTSTRAP_SQL" ||
   fail "bootstrap SQL must revoke direct writer table DML"
+grep -qF 'REVOKE ALL ON ledger_request_credit_spec022_verified_audit FROM stats_billing_mirror_writer' "$BOOTSTRAP_SQL" ||
+  fail "bootstrap SQL must revoke direct writer audit table DML"
 grep -qF 'REVOKE ALL ON FUNCTION stats_billing_mirror_upsert_request_credit' "$BOOTSTRAP_SQL" ||
   fail "bootstrap SQL must revoke public function execute"
-grep -qF 'GRANT EXECUTE ON FUNCTION stats_billing_mirror_upsert_request_credit' "$BOOTSTRAP_SQL" ||
+grep -qF 'GRANT EXECUTE ON FUNCTION stats_billing_mirror_upsert_request_credit(BIGINT, TEXT, INTEGER, TEXT, TIMESTAMPTZ, TIMESTAMPTZ, TIMESTAMPTZ, BIGINT, BIGINT, BIGINT, TEXT, BIGINT, TEXT, BOOLEAN, TEXT, BOOLEAN) TO stats_billing_mirror_writer' "$BOOTSTRAP_SQL" ||
   fail "bootstrap SQL must grant constrained upsert function"
 grep -qF 'CHECK (usage_source IN' "$BOOTSTRAP_SQL" ||
   fail "bootstrap SQL must carry source billing enum constraints"

--- a/phase4-coordinator/internal/config/config.go
+++ b/phase4-coordinator/internal/config/config.go
@@ -347,16 +347,19 @@ type OnboardingConfig struct {
 // MalibuEmissionConfig gates SPEC-MALIBU-EMISSION-LEDGER bootstrap accrual.
 // Default-off; money-path changes require PR + audit.
 type MalibuEmissionConfig struct {
-	Enabled                     bool     `yaml:"enabled"`
-	WriterDSN                   string   `yaml:"writer_dsn"`
-	TickIntervalSeconds         int      `yaml:"tick_interval_seconds"`
-	ProviderDailyCapMALIBU      float64  `yaml:"provider_daily_cap_malibu"`
-	WalletDailyCapMALIBU        float64  `yaml:"wallet_daily_cap_malibu"`
-	SQLitePayoutDBPath          string   `yaml:"sqlite_payout_db_path"`
-	WalletMirrorIntervalSeconds int      `yaml:"wallet_mirror_interval_seconds"`
-	UnlockEvalIntervalSeconds   int      `yaml:"unlock_eval_interval_seconds"`
-	MaxSerializableRetries      int      `yaml:"max_serializable_retries"`
-	BaseUSDCBalanceRPCURLs      []string `yaml:"base_usdc_balance_rpc_urls"`
+	Enabled                      bool     `yaml:"enabled"`
+	WriterDSN                    string   `yaml:"writer_dsn"`
+	TickIntervalSeconds          int      `yaml:"tick_interval_seconds"`
+	UsefulWorkEnabled            bool     `yaml:"useful_work_enabled"`
+	UsefulWorkIntervalSeconds    int      `yaml:"useful_work_interval_seconds"`
+	ProviderDailyCapMALIBU       float64  `yaml:"provider_daily_cap_malibu"`
+	WalletDailyCapMALIBU         float64  `yaml:"wallet_daily_cap_malibu"`
+	UsefulWorkMALIBUPer1KCredits float64  `yaml:"useful_work_malibu_per_1000_provider_credits"`
+	SQLitePayoutDBPath           string   `yaml:"sqlite_payout_db_path"`
+	WalletMirrorIntervalSeconds  int      `yaml:"wallet_mirror_interval_seconds"`
+	UnlockEvalIntervalSeconds    int      `yaml:"unlock_eval_interval_seconds"`
+	MaxSerializableRetries       int      `yaml:"max_serializable_retries"`
+	BaseUSDCBalanceRPCURLs       []string `yaml:"base_usdc_balance_rpc_urls"`
 }
 
 // AutotuneFeedsConfig points at the signed SPEC-023 recommendation feeds
@@ -1377,13 +1380,16 @@ func Default() Config {
 			CoordinatorDomain:       "coordinator.malibu.tech",
 		},
 		MalibuEmission: MalibuEmissionConfig{
-			Enabled:                     false,
-			TickIntervalSeconds:         900,
-			ProviderDailyCapMALIBU:      25,
-			WalletDailyCapMALIBU:        100,
-			WalletMirrorIntervalSeconds: 300,
-			UnlockEvalIntervalSeconds:   3600,
-			MaxSerializableRetries:      5,
+			Enabled:                      false,
+			TickIntervalSeconds:          900,
+			UsefulWorkEnabled:            false,
+			UsefulWorkIntervalSeconds:    900,
+			ProviderDailyCapMALIBU:       25,
+			WalletDailyCapMALIBU:         100,
+			UsefulWorkMALIBUPer1KCredits: 1,
+			WalletMirrorIntervalSeconds:  300,
+			UnlockEvalIntervalSeconds:    3600,
+			MaxSerializableRetries:       5,
 		},
 		Explorer: ExplorerConfig{
 			Enabled:                       false,
@@ -2814,11 +2820,17 @@ func (c Config) validateMalibuEmission() error {
 	if m.TickIntervalSeconds <= 0 {
 		return fmt.Errorf("malibu_emission.tick_interval_seconds must be > 0")
 	}
+	if m.UsefulWorkIntervalSeconds <= 0 {
+		return fmt.Errorf("malibu_emission.useful_work_interval_seconds must be > 0")
+	}
 	if m.ProviderDailyCapMALIBU <= 0 {
 		return fmt.Errorf("malibu_emission.provider_daily_cap_malibu must be > 0")
 	}
 	if m.WalletDailyCapMALIBU <= 0 {
 		return fmt.Errorf("malibu_emission.wallet_daily_cap_malibu must be > 0")
+	}
+	if m.UsefulWorkMALIBUPer1KCredits <= 0 {
+		return fmt.Errorf("malibu_emission.useful_work_malibu_per_1000_provider_credits must be > 0")
 	}
 	if m.WalletMirrorIntervalSeconds <= 0 {
 		return fmt.Errorf("malibu_emission.wallet_mirror_interval_seconds must be > 0")

--- a/phase4-coordinator/internal/rewards/emission.go
+++ b/phase4-coordinator/internal/rewards/emission.go
@@ -12,6 +12,11 @@ import (
 	"github.com/lib/pq"
 )
 
+const (
+	ReasonMalibuBootstrapTick         = "malibu_bootstrap_tick"
+	ReasonMalibuVerifiedUsefulWorkV02 = "malibu_verified_useful_work_v0_2"
+)
+
 // RunEmissionTickOnce runs a single accrual tick (test/export hook).
 func (r *Runner) RunEmissionTickOnce(ctx context.Context) error {
 	return r.runEmissionTick(ctx)
@@ -84,10 +89,23 @@ type providerState struct {
 }
 
 func (r *Runner) accrueProvider(ctx context.Context, providerID string, tickAmount float64) error {
-	if tickAmount <= 0 {
+	return r.accrueProviderReward(ctx, providerID, tickAmount, ReasonMalibuBootstrapTick, "")
+}
+
+func (r *Runner) accrueProviderReward(ctx context.Context, providerID string, amount float64, reason, externalRef string) error {
+	if amount <= 0 {
 		return nil
 	}
 	return r.withSerializableRetry(ctx, func(tx *sql.Tx) error {
+		if externalRef != "" {
+			exists, err := rewardExternalRefExists(ctx, tx, externalRef)
+			if err != nil {
+				return err
+			}
+			if exists {
+				return nil
+			}
+		}
 		if _, err := tx.ExecContext(ctx, `
             INSERT INTO provider_emission_state (provider_id, trust_tier)
             VALUES ($1, $2)
@@ -107,7 +125,7 @@ func (r *Runner) accrueProvider(ctx context.Context, providerID string, tickAmou
 		if remaining <= 0 {
 			return nil
 		}
-		accrue := math.Min(tickAmount, remaining)
+		accrue := math.Min(amount, remaining)
 		if accrue <= 0 {
 			return nil
 		}
@@ -134,13 +152,17 @@ func (r *Runner) accrueProvider(ctx context.Context, providerID string, tickAmou
 		if hold != "" {
 			holdArg = sql.NullString{String: hold, Valid: true}
 		}
+		var refArg sql.NullString
+		if externalRef != "" {
+			refArg = sql.NullString{String: externalRef, Valid: true}
+		}
 
 		now := time.Now().UTC()
 		if _, err := tx.ExecContext(ctx, `
             INSERT INTO provider_rewards_ledger
-                (provider_id, unix_ts, amount_malibu, withdrawal_hold_reason, reason)
-            VALUES ($1, $2, $3, $4, 'malibu_bootstrap_tick')
-        `, providerID, now.Unix(), formatMALIBU(accrue), holdArg); err != nil {
+                (provider_id, unix_ts, amount_malibu, withdrawal_hold_reason, reason, external_ref)
+            VALUES ($1, $2, $3, $4, $5, $6)
+        `, providerID, now.Unix(), formatMALIBU(accrue), holdArg, reason, refArg); err != nil {
 			return err
 		}
 
@@ -168,6 +190,18 @@ func (r *Runner) accrueProvider(ctx context.Context, providerID string, tickAmou
 		}
 		return nil
 	})
+}
+
+func rewardExternalRefExists(ctx context.Context, tx *sql.Tx, externalRef string) (bool, error) {
+	var exists bool
+	err := tx.QueryRowContext(ctx, `
+        SELECT EXISTS (
+            SELECT 1 FROM provider_rewards_ledger
+             WHERE external_ref = $1
+               AND amount_malibu IS NOT NULL
+        )
+    `, externalRef).Scan(&exists)
+	return exists, err
 }
 
 func holdReasonForState(st providerState) string {

--- a/phase4-coordinator/internal/rewards/emission_integration_test.go
+++ b/phase4-coordinator/internal/rewards/emission_integration_test.go
@@ -194,6 +194,224 @@ func TestWalletDailyCapAcrossProviders(t *testing.T) {
 	}
 }
 
+func TestUsefulWorkAccrualVerifiedWorkCapsHoldsAndReplay(t *testing.T) {
+	fx, adminDB := startPostgres(t)
+	ctx := context.Background()
+
+	if _, err := adminDB.ExecContext(ctx, `
+        CREATE TABLE ledger_request_credits (
+            id BIGSERIAL PRIMARY KEY,
+            request_id TEXT NOT NULL,
+            attempt_n INTEGER NOT NULL,
+            provider_id TEXT NOT NULL,
+            ts_utc TIMESTAMPTZ NOT NULL,
+            provider_credits BIGINT NOT NULL,
+            settlement_policy_mode TEXT NOT NULL DEFAULT 'enforce',
+            spec022_verified BOOLEAN NOT NULL DEFAULT FALSE,
+            UNIQUE(request_id, attempt_n, provider_id)
+        );
+        GRANT SELECT ON ledger_request_credits TO rewards_writer;
+    `); err != nil {
+		t.Fatalf("seed useful work mirror table: %v", err)
+	}
+
+	writerDB := openRewardsWriter(t, fx)
+	wallet := "0xusefulwork"
+	for _, seed := range []struct {
+		providerID string
+		tier       string
+		wallet     string
+	}{
+		{"p_verified", rewards.TierTrusted, wallet},
+		{"p_overflow", rewards.TierTrusted, wallet},
+		{"p_provisional", rewards.TierProvisional, ""},
+		{"p_unverified", rewards.TierTrusted, ""},
+	} {
+		if _, err := adminDB.ExecContext(ctx, `
+            INSERT INTO provider_emission_state (provider_id, trust_tier, bound_wallet)
+            VALUES ($1, $2, NULLIF($3, ''))
+        `, seed.providerID, seed.tier, seed.wallet); err != nil {
+			t.Fatalf("seed state %s: %v", seed.providerID, err)
+		}
+	}
+	if _, err := adminDB.ExecContext(ctx, `
+        INSERT INTO ledger_request_credits
+            (request_id, attempt_n, provider_id, ts_utc, provider_credits, spec022_verified)
+        VALUES
+            ('req-verified', 0, 'p_verified', now() - interval '4 minutes', 2000, TRUE),
+            ('req-overflow', 0, 'p_overflow', now() - interval '3 minutes', 2000, TRUE),
+            ('req-provisional', 0, 'p_provisional', now() - interval '2 minutes', 1000, TRUE),
+            ('req-unverified', 0, 'p_unverified', now() - interval '1 minute', 9000, FALSE)
+    `); err != nil {
+		t.Fatalf("seed useful work rows: %v", err)
+	}
+
+	cfg := testEmissionConfig(time.Hour, 25, 3)
+	cfg.UsefulWorkEnabled = true
+	cfg.UsefulWorkMALIBUPer1KCredits = 1
+	runner, err := rewards.New(writerDB, cfg, zerolog.Nop(), rewards.RunnerDeps{})
+	if err != nil {
+		t.Fatalf("new runner: %v", err)
+	}
+	if err := runner.RunUsefulWorkAccrualOnce(ctx); err != nil {
+		t.Fatalf("useful work accrual: %v", err)
+	}
+	if err := runner.RunUsefulWorkAccrualOnce(ctx); err != nil {
+		t.Fatalf("useful work replay accrual: %v", err)
+	}
+
+	var verifiedCount int
+	if err := adminDB.QueryRowContext(ctx, `
+        SELECT COUNT(*)
+          FROM provider_rewards_ledger
+         WHERE reason = $1
+    `, rewards.ReasonMalibuVerifiedUsefulWorkV02).Scan(&verifiedCount); err != nil {
+		t.Fatalf("count useful rows: %v", err)
+	}
+	if verifiedCount != 3 {
+		t.Fatalf("useful work ledger rows = %d, want 3 (verified, overflow, provisional only)", verifiedCount)
+	}
+
+	var amount, ref string
+	if err := adminDB.QueryRowContext(ctx, `
+        SELECT amount_malibu::TEXT, external_ref
+          FROM provider_rewards_ledger
+         WHERE provider_id = 'p_verified'
+    `).Scan(&amount, &ref); err != nil {
+		t.Fatalf("query verified reward: %v", err)
+	}
+	if amount != "2.00000000" {
+		t.Fatalf("verified amount = %q, want 2.00000000", amount)
+	}
+	if ref != "spec022:req-verified:0:p_verified" {
+		t.Fatalf("external_ref = %q", ref)
+	}
+
+	var overflowHold string
+	var overflowAmount string
+	if err := adminDB.QueryRowContext(ctx, `
+        SELECT withdrawal_hold_reason, amount_malibu::TEXT
+          FROM provider_rewards_ledger
+         WHERE provider_id = 'p_overflow'
+    `).Scan(&overflowHold, &overflowAmount); err != nil {
+		t.Fatalf("query overflow reward: %v", err)
+	}
+	if overflowHold != rewards.HoldPerWalletDailyCap {
+		t.Fatalf("overflow hold = %q, want %q", overflowHold, rewards.HoldPerWalletDailyCap)
+	}
+	if overflowAmount != "1.00000000" {
+		t.Fatalf("overflow amount = %q, want 1.00000000", overflowAmount)
+	}
+
+	var provisionalHold string
+	if err := adminDB.QueryRowContext(ctx, `
+        SELECT withdrawal_hold_reason
+          FROM provider_rewards_ledger
+         WHERE provider_id = 'p_provisional'
+    `).Scan(&provisionalHold); err != nil {
+		t.Fatalf("query provisional reward: %v", err)
+	}
+	if provisionalHold != rewards.HoldTrustTierProvisional {
+		t.Fatalf("provisional hold = %q, want %q", provisionalHold, rewards.HoldTrustTierProvisional)
+	}
+
+	withdrawable, err := rewards.SelectWithdrawableMALIBU(ctx, writerDB, "p_verified", 10)
+	if err != nil {
+		t.Fatalf("withdrawable verified: %v", err)
+	}
+	if len(withdrawable) != 1 {
+		t.Fatalf("trusted useful work withdrawable rows = %d, want 1", len(withdrawable))
+	}
+	provisionalWithdrawable, err := rewards.SelectWithdrawableMALIBU(ctx, writerDB, "p_provisional", 10)
+	if err != nil {
+		t.Fatalf("withdrawable provisional: %v", err)
+	}
+	if len(provisionalWithdrawable) != 0 {
+		t.Fatalf("provisional useful work withdrawable rows = %d, want 0", len(provisionalWithdrawable))
+	}
+}
+
+func TestUsefulWorkAccrualSkipsProviderAtDailyCap(t *testing.T) {
+	fx, adminDB := startPostgres(t)
+	ctx := context.Background()
+
+	if _, err := adminDB.ExecContext(ctx, `
+        CREATE TABLE ledger_request_credits (
+            id BIGSERIAL PRIMARY KEY,
+            request_id TEXT NOT NULL,
+            attempt_n INTEGER NOT NULL,
+            provider_id TEXT NOT NULL,
+            ts_utc TIMESTAMPTZ NOT NULL,
+            provider_credits BIGINT NOT NULL,
+            settlement_policy_mode TEXT NOT NULL DEFAULT 'enforce',
+            spec022_verified BOOLEAN NOT NULL DEFAULT FALSE,
+            UNIQUE(request_id, attempt_n, provider_id)
+        );
+        GRANT SELECT ON ledger_request_credits TO rewards_writer;
+    `); err != nil {
+		t.Fatalf("seed useful work mirror table: %v", err)
+	}
+
+	if _, err := adminDB.ExecContext(ctx, `
+        INSERT INTO provider_emission_state
+            (provider_id, trust_tier, provider_day_malibu, emission_day)
+        VALUES
+            ('p_capped', 'trusted', 1, CURRENT_DATE),
+            ('p_later', 'trusted', 0, CURRENT_DATE);
+
+        INSERT INTO ledger_request_credits
+            (request_id, attempt_n, provider_id, ts_utc, provider_credits, spec022_verified)
+        SELECT 'req-capped-' || gs::TEXT, 0, 'p_capped',
+               now() - interval '2 hours' + (gs || ' seconds')::interval,
+               1000, TRUE
+          FROM generate_series(1, 501) AS gs;
+
+        INSERT INTO ledger_request_credits
+            (request_id, attempt_n, provider_id, ts_utc, provider_credits, spec022_verified)
+        VALUES ('req-later', 0, 'p_later', now(), 1000, TRUE);
+    `); err != nil {
+		t.Fatalf("seed capped useful work rows: %v", err)
+	}
+
+	writerDB := openRewardsWriter(t, fx)
+	cfg := testEmissionConfig(time.Hour, 1, 100)
+	cfg.UsefulWorkEnabled = true
+	cfg.UsefulWorkMALIBUPer1KCredits = 1
+	runner, err := rewards.New(writerDB, cfg, zerolog.Nop(), rewards.RunnerDeps{})
+	if err != nil {
+		t.Fatalf("new runner: %v", err)
+	}
+	if err := runner.RunUsefulWorkAccrualOnce(ctx); err != nil {
+		t.Fatalf("useful work accrual: %v", err)
+	}
+
+	var laterCount int
+	if err := adminDB.QueryRowContext(ctx, `
+        SELECT COUNT(*)
+          FROM provider_rewards_ledger
+         WHERE provider_id = 'p_later'
+           AND reason = $1
+    `, rewards.ReasonMalibuVerifiedUsefulWorkV02).Scan(&laterCount); err != nil {
+		t.Fatalf("count later reward: %v", err)
+	}
+	if laterCount != 1 {
+		t.Fatalf("p_later useful work rewards = %d, want 1", laterCount)
+	}
+
+	var cappedCount int
+	if err := adminDB.QueryRowContext(ctx, `
+        SELECT COUNT(*)
+          FROM provider_rewards_ledger
+         WHERE provider_id = 'p_capped'
+           AND reason = $1
+    `, rewards.ReasonMalibuVerifiedUsefulWorkV02).Scan(&cappedCount); err != nil {
+		t.Fatalf("count capped rewards: %v", err)
+	}
+	if cappedCount != 0 {
+		t.Fatalf("p_capped useful work rewards = %d, want 0", cappedCount)
+	}
+}
+
 // TestCapReplayPendingDoesNotDesyncConnection is a regression test for the
 // hardware-track (mp-*) accrual failure: `pq: unexpected Parse response
 // "(C) CommandComplete"`. That error surfaced whenever a Trusted provider's

--- a/phase4-coordinator/internal/rewards/rewards.go
+++ b/phase4-coordinator/internal/rewards/rewards.go
@@ -29,16 +29,19 @@ const (
 
 // Config is the operator-tunable malibu_emission block.
 type Config struct {
-	Enabled                bool
-	WriterDSN              string
-	TickInterval           time.Duration
-	ProviderDailyCapMALIBU float64
-	WalletDailyCapMALIBU   float64
-	SQLitePayoutDBPath     string
-	WalletMirrorInterval   time.Duration
-	UnlockEvalInterval     time.Duration
-	MaxSerializableRetries int
-	BaseUSDCBalanceRPCURLs []string
+	Enabled                      bool
+	WriterDSN                    string
+	TickInterval                 time.Duration
+	UsefulWorkEnabled            bool
+	UsefulWorkInterval           time.Duration
+	ProviderDailyCapMALIBU       float64
+	WalletDailyCapMALIBU         float64
+	UsefulWorkMALIBUPer1KCredits float64
+	SQLitePayoutDBPath           string
+	WalletMirrorInterval         time.Duration
+	UnlockEvalInterval           time.Duration
+	MaxSerializableRetries       int
+	BaseUSDCBalanceRPCURLs       []string
 }
 
 // DefaultsApplied fills zero values with spec defaults.
@@ -47,11 +50,17 @@ func (c Config) DefaultsApplied() Config {
 	if out.TickInterval <= 0 {
 		out.TickInterval = 15 * time.Minute
 	}
+	if out.UsefulWorkInterval <= 0 {
+		out.UsefulWorkInterval = out.TickInterval
+	}
 	if out.ProviderDailyCapMALIBU <= 0 {
 		out.ProviderDailyCapMALIBU = 25
 	}
 	if out.WalletDailyCapMALIBU <= 0 {
 		out.WalletDailyCapMALIBU = 100
+	}
+	if out.UsefulWorkMALIBUPer1KCredits <= 0 {
+		out.UsefulWorkMALIBUPer1KCredits = 1
 	}
 	if out.WalletMirrorInterval <= 0 {
 		out.WalletMirrorInterval = 5 * time.Minute
@@ -134,6 +143,9 @@ func (r *Runner) SetTrustTierObserver(observer TrustTierObserver) {
 // Start launches background goroutines until ctx is cancelled.
 func (r *Runner) Start(ctx context.Context) {
 	go r.loop(ctx, r.cfg.TickInterval, "emission_tick", r.runEmissionTick)
+	if r.cfg.UsefulWorkEnabled {
+		go r.loop(ctx, r.cfg.UsefulWorkInterval, "useful_work_accrual", r.runUsefulWorkAccrual)
+	}
 	go r.loop(ctx, r.cfg.WalletMirrorInterval, "wallet_mirror", r.runWalletMirror)
 	go r.loop(ctx, r.cfg.UnlockEvalInterval, "unlock_eval", r.runUnlockEval)
 }

--- a/phase4-coordinator/internal/rewards/useful_work.go
+++ b/phase4-coordinator/internal/rewards/useful_work.go
@@ -1,0 +1,99 @@
+package rewards
+
+import (
+	"context"
+	"fmt"
+)
+
+const usefulWorkBatchLimit = 500
+
+type usefulWorkRewardRow struct {
+	RequestID       string
+	AttemptN        int
+	ProviderID      string
+	ProviderCredits int64
+}
+
+// RunUsefulWorkAccrualOnce runs one verified-useful-work accrual pass.
+func (r *Runner) RunUsefulWorkAccrualOnce(ctx context.Context) error {
+	return r.runUsefulWorkAccrual(ctx)
+}
+
+func (r *Runner) runUsefulWorkAccrual(ctx context.Context) error {
+	if !r.cfg.UsefulWorkEnabled {
+		return nil
+	}
+	rows, err := r.listUnrewardedUsefulWork(ctx, usefulWorkBatchLimit)
+	if err != nil {
+		return err
+	}
+	for _, row := range rows {
+		amount := r.usefulWorkMALIBU(row.ProviderCredits)
+		if amount <= 0 {
+			continue
+		}
+		if err := r.accrueProviderReward(ctx, row.ProviderID, amount, ReasonMalibuVerifiedUsefulWorkV02, usefulWorkExternalRef(row)); err != nil {
+			r.logger.Warn().
+				Err(err).
+				Str("provider_id", row.ProviderID).
+				Str("request_id", row.RequestID).
+				Int("attempt_n", row.AttemptN).
+				Msg("useful work reward accrual failed")
+		}
+	}
+	return nil
+}
+
+func (r *Runner) listUnrewardedUsefulWork(ctx context.Context, limit int) ([]usefulWorkRewardRow, error) {
+	if limit <= 0 {
+		limit = usefulWorkBatchLimit
+	}
+	rows, err := r.db.QueryContext(ctx, `
+        SELECT lrc.request_id, lrc.attempt_n, lrc.provider_id, lrc.provider_credits
+          FROM ledger_request_credits lrc
+          LEFT JOIN provider_emission_state pes ON pes.provider_id = lrc.provider_id
+         WHERE COALESCE(lrc.spec022_verified, FALSE) = TRUE
+           AND lrc.provider_credits > 0
+           AND (
+                pes.provider_id IS NULL
+                OR pes.emission_day IS NULL
+                OR pes.emission_day <> CURRENT_DATE
+                OR pes.provider_day_malibu < $2
+           )
+           AND NOT EXISTS (
+                SELECT 1
+                  FROM provider_rewards_ledger prl
+                 WHERE prl.external_ref = 'spec022:' || lrc.request_id || ':' || lrc.attempt_n::TEXT || ':' || lrc.provider_id
+                   AND prl.amount_malibu IS NOT NULL
+           )
+         ORDER BY lrc.ts_utc ASC, lrc.id ASC
+         LIMIT $1
+    `, limit, r.cfg.ProviderDailyCapMALIBU)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var out []usefulWorkRewardRow
+	for rows.Next() {
+		var row usefulWorkRewardRow
+		if err := rows.Scan(&row.RequestID, &row.AttemptN, &row.ProviderID, &row.ProviderCredits); err != nil {
+			return nil, err
+		}
+		out = append(out, row)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (r *Runner) usefulWorkMALIBU(providerCredits int64) float64 {
+	if providerCredits <= 0 || r.cfg.UsefulWorkMALIBUPer1KCredits <= 0 {
+		return 0
+	}
+	return (float64(providerCredits) / 1000.0) * r.cfg.UsefulWorkMALIBUPer1KCredits
+}
+
+func usefulWorkExternalRef(row usefulWorkRewardRow) string {
+	return fmt.Sprintf("spec022:%s:%d:%s", row.RequestID, row.AttemptN, row.ProviderID)
+}

--- a/phase4-coordinator/internal/rewards/useful_work_test.go
+++ b/phase4-coordinator/internal/rewards/useful_work_test.go
@@ -1,0 +1,22 @@
+package rewards
+
+import "testing"
+
+func TestUsefulWorkRewardFormulaAndExternalRef(t *testing.T) {
+	runner := &Runner{cfg: Config{UsefulWorkMALIBUPer1KCredits: 2.5}.DefaultsApplied()}
+	if got := runner.usefulWorkMALIBU(2400); got != 6 {
+		t.Fatalf("usefulWorkMALIBU(2400) = %v, want 6", got)
+	}
+	if got := runner.usefulWorkMALIBU(0); got != 0 {
+		t.Fatalf("usefulWorkMALIBU(0) = %v, want 0", got)
+	}
+
+	ref := usefulWorkExternalRef(usefulWorkRewardRow{
+		RequestID:  "req-1",
+		AttemptN:   2,
+		ProviderID: "provider-a",
+	})
+	if ref != "spec022:req-1:2:provider-a" {
+		t.Fatalf("external ref = %q", ref)
+	}
+}

--- a/phase4-coordinator/internal/stats/billingmirror/mirror.go
+++ b/phase4-coordinator/internal/stats/billingmirror/mirror.go
@@ -66,6 +66,8 @@ type RequestCredit struct {
 	ProviderCredits           int64
 	FaultFlag                 string
 	Quarantined               bool
+	SettlementPolicyMode      string
+	Spec022Verified           bool
 }
 
 type ProviderIdentity struct {
@@ -267,15 +269,11 @@ func OpenPostgres(dsn string) (*sql.DB, error) {
 }
 
 func FetchRequestCredits(ctx context.Context, db *sql.DB, startID int64, limit int) ([]RequestCredit, error) {
-	const q = `
-SELECT id, request_id, attempt_n, provider_id, ts_utc, created_at_utc, updated_at_utc,
-       prompt_tokens, completion_tokens, estimated_completion_tokens, usage_source,
-       provider_credits, fault_flag, quarantined
-  FROM ledger_request_credits
- WHERE id > ?
- ORDER BY id
- LIMIT ?`
-	return scanRequestCredits(ctx, db, q, startID, limit)
+	caps, err := detectRequestCreditSourceCapabilities(ctx, db)
+	if err != nil {
+		return nil, err
+	}
+	return scanRequestCredits(ctx, db, requestCreditsQuery(caps, false), startID, limit)
 }
 
 func FetchMaxRequestCreditID(ctx context.Context, db *sql.DB) (int64, error) {
@@ -290,16 +288,94 @@ func FetchMaxRequestCreditID(ctx context.Context, db *sql.DB) (int64, error) {
 }
 
 func FetchRequestCreditsThrough(ctx context.Context, db *sql.DB, startID, endID int64, limit int) ([]RequestCredit, error) {
-	const q = `
-SELECT id, request_id, attempt_n, provider_id, ts_utc, created_at_utc, updated_at_utc,
-       prompt_tokens, completion_tokens, estimated_completion_tokens, usage_source,
-       provider_credits, fault_flag, quarantined
-  FROM ledger_request_credits
- WHERE id > ?
-   AND id <= ?
- ORDER BY id
- LIMIT ?`
-	return scanRequestCredits(ctx, db, q, startID, endID, limit)
+	caps, err := detectRequestCreditSourceCapabilities(ctx, db)
+	if err != nil {
+		return nil, err
+	}
+	return scanRequestCredits(ctx, db, requestCreditsQuery(caps, true), startID, endID, limit)
+}
+
+type requestCreditSourceCapabilities struct {
+	HasSettlementPolicyMode bool
+	HasSpec022PayableView   bool
+}
+
+func detectRequestCreditSourceCapabilities(ctx context.Context, db *sql.DB) (requestCreditSourceCapabilities, error) {
+	hasPolicy, err := sqliteColumnExists(ctx, db, "ledger_request_credits", "settlement_policy_mode")
+	if err != nil {
+		return requestCreditSourceCapabilities{}, err
+	}
+	hasPayable, err := sqliteObjectExists(ctx, db, "spec022_payable_request_credits")
+	if err != nil {
+		return requestCreditSourceCapabilities{}, err
+	}
+	return requestCreditSourceCapabilities{
+		HasSettlementPolicyMode: hasPolicy,
+		HasSpec022PayableView:   hasPayable,
+	}, nil
+}
+
+func requestCreditsQuery(caps requestCreditSourceCapabilities, bounded bool) string {
+	policyExpr := "'legacy'"
+	if caps.HasSettlementPolicyMode {
+		policyExpr = "COALESCE(lrc.settlement_policy_mode, 'legacy')"
+	}
+	verifiedExpr := "0"
+	if caps.HasSpec022PayableView {
+		verifiedExpr = fmt.Sprintf(`CASE
+           WHEN %s = 'enforce'
+            AND EXISTS (SELECT 1 FROM spec022_payable_request_credits payable WHERE payable.id = lrc.id)
+           THEN 1 ELSE 0
+       END`, policyExpr)
+	}
+	where := "WHERE lrc.id > ?"
+	if bounded {
+		where += "\n   AND lrc.id <= ?"
+	}
+	return fmt.Sprintf(`
+SELECT lrc.id, lrc.request_id, lrc.attempt_n, lrc.provider_id, lrc.ts_utc, lrc.created_at_utc, lrc.updated_at_utc,
+       lrc.prompt_tokens, lrc.completion_tokens, lrc.estimated_completion_tokens, lrc.usage_source,
+       lrc.provider_credits, lrc.fault_flag, lrc.quarantined,
+       %s AS settlement_policy_mode,
+       %s AS spec022_verified
+  FROM ledger_request_credits lrc
+ %s
+ ORDER BY lrc.id
+ LIMIT ?`, policyExpr, verifiedExpr, where)
+}
+
+func sqliteColumnExists(ctx context.Context, db *sql.DB, table, column string) (bool, error) {
+	rows, err := db.QueryContext(ctx, `PRAGMA table_info(`+table+`)`)
+	if err != nil {
+		return false, fmt.Errorf("inspect sqlite table %s: %w", table, err)
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var cid int
+		var name, typ string
+		var notNull int
+		var defaultValue sql.NullString
+		var pk int
+		if err := rows.Scan(&cid, &name, &typ, &notNull, &defaultValue, &pk); err != nil {
+			return false, err
+		}
+		if name == column {
+			return true, nil
+		}
+	}
+	return false, rows.Err()
+}
+
+func sqliteObjectExists(ctx context.Context, db *sql.DB, name string) (bool, error) {
+	var exists bool
+	err := db.QueryRowContext(ctx, `
+        SELECT EXISTS (
+            SELECT 1 FROM sqlite_master
+             WHERE name = ?
+               AND type IN ('table', 'view')
+        )
+    `, name).Scan(&exists)
+	return exists, err
 }
 
 func scanRequestCredits(ctx context.Context, db *sql.DB, q string, args ...any) ([]RequestCredit, error) {
@@ -313,12 +389,13 @@ func scanRequestCredits(ctx context.Context, db *sql.DB, q string, args ...any) 
 		var row RequestCredit
 		var ts, created sql.NullString
 		var updated sql.NullString
-		var quarantined int
+		var quarantined, spec022Verified int
 		if err := cur.Scan(
 			&row.SQLiteID, &row.RequestID, &row.AttemptN, &row.ProviderID,
 			&ts, &created, &updated,
 			&row.PromptTokens, &row.CompletionTokens, &row.EstimatedCompletionTokens,
 			&row.UsageSource, &row.ProviderCredits, &row.FaultFlag, &quarantined,
+			&row.SettlementPolicyMode, &spec022Verified,
 		); err != nil {
 			return nil, fmt.Errorf("scan ledger_request_credits: %w", err)
 		}
@@ -335,6 +412,7 @@ func scanRequestCredits(ctx context.Context, db *sql.DB, q string, args ...any) 
 			return nil, fmt.Errorf("updated_at_utc: %w", err)
 		}
 		row.Quarantined = quarantined != 0
+		row.Spec022Verified = spec022Verified != 0
 		out = append(out, row)
 	}
 	if err := cur.Err(); err != nil {
@@ -459,11 +537,11 @@ func upsertRequestCredit(ctx context.Context, tx *sql.Tx, row RequestCredit) err
 	if _, err := tx.ExecContext(ctx, `SELECT stats_billing_mirror_upsert_request_credit(
     $1, $2, $3, $4, $5, $6, $7,
     $8, $9, $10, $11,
-    $12, $13, $14
+    $12, $13, $14, $15, $16
 )`,
 		row.SQLiteID, row.RequestID, row.AttemptN, row.ProviderID, row.TSUTC, row.CreatedAtUTC, nullTimeArg(row.UpdatedAtUTC),
 		nullInt64Arg(row.PromptTokens), nullInt64Arg(row.CompletionTokens), nullInt64Arg(row.EstimatedCompletionTokens),
-		row.UsageSource, row.ProviderCredits, row.FaultFlag, row.Quarantined); err != nil {
+		row.UsageSource, row.ProviderCredits, row.FaultFlag, row.Quarantined, row.SettlementPolicyMode, row.Spec022Verified); err != nil {
 		return fmt.Errorf("upsert request credit %q/%d/%q: %w", row.RequestID, row.AttemptN, row.ProviderID, err)
 	}
 	return nil
@@ -581,7 +659,9 @@ var schemaStatements = []string{
     usage_source TEXT NOT NULL DEFAULT 'provider_reported' CHECK (usage_source IN ('provider_reported','byte_estimated','null_error')),
     provider_credits BIGINT NOT NULL DEFAULT 0 CHECK (provider_credits >= 0),
     fault_flag TEXT NOT NULL DEFAULT 'none' CHECK (fault_flag IN ('none','breaker_qualifying','null_usage_error')),
-    quarantined BOOLEAN NOT NULL DEFAULT FALSE
+    quarantined BOOLEAN NOT NULL DEFAULT FALSE,
+    settlement_policy_mode TEXT NOT NULL DEFAULT 'legacy' CHECK (settlement_policy_mode IN ('legacy','observe','enforce')),
+    spec022_verified BOOLEAN NOT NULL DEFAULT FALSE
 )`,
 	`ALTER TABLE ledger_request_credits ADD COLUMN IF NOT EXISTS sqlite_lrc_id BIGINT`,
 	`ALTER TABLE ledger_request_credits ADD COLUMN IF NOT EXISTS request_id TEXT`,
@@ -597,6 +677,10 @@ var schemaStatements = []string{
 	`ALTER TABLE ledger_request_credits ADD COLUMN IF NOT EXISTS provider_credits BIGINT DEFAULT 0`,
 	`ALTER TABLE ledger_request_credits ADD COLUMN IF NOT EXISTS fault_flag TEXT DEFAULT 'none'`,
 	`ALTER TABLE ledger_request_credits ADD COLUMN IF NOT EXISTS quarantined BOOLEAN DEFAULT FALSE`,
+	`ALTER TABLE ledger_request_credits ADD COLUMN IF NOT EXISTS settlement_policy_mode TEXT DEFAULT 'legacy'`,
+	`ALTER TABLE ledger_request_credits ADD COLUMN IF NOT EXISTS spec022_verified BOOLEAN DEFAULT FALSE`,
+	`UPDATE ledger_request_credits SET settlement_policy_mode = 'legacy' WHERE settlement_policy_mode IS NULL`,
+	`UPDATE ledger_request_credits SET spec022_verified = FALSE WHERE spec022_verified IS NULL`,
 	`DO $$
 BEGIN
     IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'lrc_mirror_attempt_nonnegative') THEN
@@ -620,9 +704,29 @@ BEGIN
     IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'lrc_mirror_fault_flag_enum') THEN
         ALTER TABLE ledger_request_credits ADD CONSTRAINT lrc_mirror_fault_flag_enum CHECK (fault_flag IN ('none','breaker_qualifying','null_usage_error'));
     END IF;
+    IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'lrc_mirror_settlement_policy_mode_enum') THEN
+        ALTER TABLE ledger_request_credits ADD CONSTRAINT lrc_mirror_settlement_policy_mode_enum CHECK (settlement_policy_mode IN ('legacy','observe','enforce'));
+    END IF;
+    IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'lrc_mirror_spec022_verified_not_null') THEN
+        ALTER TABLE ledger_request_credits ADD CONSTRAINT lrc_mirror_spec022_verified_not_null CHECK (spec022_verified IS NOT NULL);
+    END IF;
+    IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'lrc_mirror_spec022_verified_enforce_check') THEN
+        ALTER TABLE ledger_request_credits ADD CONSTRAINT lrc_mirror_spec022_verified_enforce_check CHECK (spec022_verified = FALSE OR settlement_policy_mode = 'enforce');
+    END IF;
 END $$`,
 	`CREATE UNIQUE INDEX IF NOT EXISTS idx_lrc_mirror_unique_attempt ON ledger_request_credits(request_id, attempt_n, provider_id)`,
 	`CREATE INDEX IF NOT EXISTS idx_lrc_mirror_provider_ts ON ledger_request_credits(provider_id, ts_utc)`,
+	`CREATE TABLE IF NOT EXISTS ledger_request_credit_spec022_verified_audit (
+    request_id TEXT NOT NULL,
+    attempt_n INTEGER NOT NULL,
+    provider_id TEXT NOT NULL,
+    sqlite_lrc_id BIGINT,
+    provider_credits BIGINT NOT NULL,
+    settlement_policy_mode TEXT NOT NULL CHECK (settlement_policy_mode = 'enforce'),
+    source TEXT NOT NULL DEFAULT 'stats_billing_mirror',
+    mirrored_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    PRIMARY KEY (request_id, attempt_n, provider_id)
+)`,
 	`CREATE TABLE IF NOT EXISTS provider_tokens (
     id BIGSERIAL PRIMARY KEY,
     token_hash TEXT NOT NULL UNIQUE,
@@ -712,21 +816,46 @@ $$`,
     p_usage_source TEXT,
     p_provider_credits BIGINT,
     p_fault_flag TEXT,
-    p_quarantined BOOLEAN
+    p_quarantined BOOLEAN,
+    p_settlement_policy_mode TEXT,
+    p_spec022_verified BOOLEAN
 )
 RETURNS void
-LANGUAGE sql
+LANGUAGE plpgsql
 SECURITY DEFINER
 SET search_path = public
 AS $$
+DECLARE
+    v_settlement_policy_mode TEXT := COALESCE(NULLIF(p_settlement_policy_mode, ''), 'legacy');
+    v_spec022_verified BOOLEAN;
+    v_was_spec022_verified BOOLEAN;
+BEGIN
+    IF v_settlement_policy_mode NOT IN ('legacy','observe','enforce') THEN
+        RAISE EXCEPTION 'invalid settlement_policy_mode: %', v_settlement_policy_mode;
+    END IF;
+
+    v_spec022_verified :=
+        v_settlement_policy_mode = 'enforce'
+        AND COALESCE(p_spec022_verified, FALSE)
+        AND COALESCE(p_provider_credits, 0) > 0
+        AND NOT COALESCE(p_quarantined, FALSE);
+
+    SELECT spec022_verified
+      INTO v_was_spec022_verified
+      FROM ledger_request_credits
+     WHERE request_id = p_request_id
+       AND attempt_n = p_attempt_n
+       AND provider_id = p_provider_id
+     FOR UPDATE;
+
     INSERT INTO ledger_request_credits (
         sqlite_lrc_id, request_id, attempt_n, provider_id, ts_utc, created_at_utc, updated_at_utc,
         prompt_tokens, completion_tokens, estimated_completion_tokens, usage_source,
-        provider_credits, fault_flag, quarantined
+        provider_credits, fault_flag, quarantined, settlement_policy_mode, spec022_verified
     ) VALUES (
         p_sqlite_lrc_id, p_request_id, p_attempt_n, p_provider_id, p_ts_utc, p_created_at_utc, p_updated_at_utc,
         p_prompt_tokens, p_completion_tokens, p_estimated_completion_tokens, p_usage_source,
-        p_provider_credits, p_fault_flag, p_quarantined
+        p_provider_credits, p_fault_flag, COALESCE(p_quarantined, FALSE), v_settlement_policy_mode, v_spec022_verified
     )
     ON CONFLICT (request_id, attempt_n, provider_id) DO UPDATE SET
         sqlite_lrc_id = EXCLUDED.sqlite_lrc_id,
@@ -739,7 +868,21 @@ AS $$
         usage_source = EXCLUDED.usage_source,
         provider_credits = EXCLUDED.provider_credits,
         fault_flag = EXCLUDED.fault_flag,
-        quarantined = EXCLUDED.quarantined;
+        quarantined = EXCLUDED.quarantined,
+        settlement_policy_mode = EXCLUDED.settlement_policy_mode,
+        spec022_verified = EXCLUDED.spec022_verified;
+
+    IF v_spec022_verified AND NOT COALESCE(v_was_spec022_verified, FALSE) THEN
+        INSERT INTO ledger_request_credit_spec022_verified_audit (
+            request_id, attempt_n, provider_id, sqlite_lrc_id,
+            provider_credits, settlement_policy_mode
+        ) VALUES (
+            p_request_id, p_attempt_n, p_provider_id, p_sqlite_lrc_id,
+            p_provider_credits, v_settlement_policy_mode
+        )
+        ON CONFLICT (request_id, attempt_n, provider_id) DO NOTHING;
+    END IF;
+END;
 $$`,
 	`DO $$
 BEGIN
@@ -747,18 +890,32 @@ BEGIN
         GRANT SELECT ON ledger_request_credits TO stats_rollup;
         GRANT SELECT ON provider_tokens TO stats_rollup;
     END IF;
+    IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'rewards_writer') THEN
+        GRANT SELECT ON ledger_request_credits TO rewards_writer;
+    END IF;
+    REVOKE ALL ON FUNCTION stats_billing_mirror_load_state(TEXT) FROM PUBLIC;
+    REVOKE ALL ON FUNCTION stats_billing_mirror_save_state(TEXT, BIGINT, BIGINT) FROM PUBLIC;
+    REVOKE ALL ON FUNCTION stats_billing_mirror_ensure_provider(TEXT, TEXT, TEXT, TIMESTAMPTZ, TIMESTAMPTZ) FROM PUBLIC;
+    IF EXISTS (
+        SELECT 1
+          FROM pg_proc p
+          JOIN pg_namespace n ON n.oid = p.pronamespace
+         WHERE n.nspname = 'public'
+           AND p.proname = 'stats_billing_mirror_upsert_request_credit'
+           AND p.pronargs = 14
+    ) THEN
+        REVOKE ALL ON FUNCTION stats_billing_mirror_upsert_request_credit(BIGINT, TEXT, INTEGER, TEXT, TIMESTAMPTZ, TIMESTAMPTZ, TIMESTAMPTZ, BIGINT, BIGINT, BIGINT, TEXT, BIGINT, TEXT, BOOLEAN) FROM PUBLIC;
+    END IF;
+    REVOKE ALL ON FUNCTION stats_billing_mirror_upsert_request_credit(BIGINT, TEXT, INTEGER, TEXT, TIMESTAMPTZ, TIMESTAMPTZ, TIMESTAMPTZ, BIGINT, BIGINT, BIGINT, TEXT, BIGINT, TEXT, BOOLEAN, TEXT, BOOLEAN) FROM PUBLIC;
     IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'stats_billing_mirror_writer') THEN
         REVOKE ALL ON ledger_request_credits FROM stats_billing_mirror_writer;
         REVOKE ALL ON provider_tokens FROM stats_billing_mirror_writer;
         REVOKE ALL ON stats_billing_mirror_state FROM stats_billing_mirror_writer;
-        REVOKE ALL ON FUNCTION stats_billing_mirror_load_state(TEXT) FROM PUBLIC;
-        REVOKE ALL ON FUNCTION stats_billing_mirror_save_state(TEXT, BIGINT, BIGINT) FROM PUBLIC;
-        REVOKE ALL ON FUNCTION stats_billing_mirror_ensure_provider(TEXT, TEXT, TEXT, TIMESTAMPTZ, TIMESTAMPTZ) FROM PUBLIC;
-        REVOKE ALL ON FUNCTION stats_billing_mirror_upsert_request_credit(BIGINT, TEXT, INTEGER, TEXT, TIMESTAMPTZ, TIMESTAMPTZ, TIMESTAMPTZ, BIGINT, BIGINT, BIGINT, TEXT, BIGINT, TEXT, BOOLEAN) FROM PUBLIC;
+        REVOKE ALL ON ledger_request_credit_spec022_verified_audit FROM stats_billing_mirror_writer;
         GRANT EXECUTE ON FUNCTION stats_billing_mirror_load_state(TEXT) TO stats_billing_mirror_writer;
         GRANT EXECUTE ON FUNCTION stats_billing_mirror_save_state(TEXT, BIGINT, BIGINT) TO stats_billing_mirror_writer;
         GRANT EXECUTE ON FUNCTION stats_billing_mirror_ensure_provider(TEXT, TEXT, TEXT, TIMESTAMPTZ, TIMESTAMPTZ) TO stats_billing_mirror_writer;
-        GRANT EXECUTE ON FUNCTION stats_billing_mirror_upsert_request_credit(BIGINT, TEXT, INTEGER, TEXT, TIMESTAMPTZ, TIMESTAMPTZ, TIMESTAMPTZ, BIGINT, BIGINT, BIGINT, TEXT, BIGINT, TEXT, BOOLEAN) TO stats_billing_mirror_writer;
+        GRANT EXECUTE ON FUNCTION stats_billing_mirror_upsert_request_credit(BIGINT, TEXT, INTEGER, TEXT, TIMESTAMPTZ, TIMESTAMPTZ, TIMESTAMPTZ, BIGINT, BIGINT, BIGINT, TEXT, BIGINT, TEXT, BOOLEAN, TEXT, BOOLEAN) TO stats_billing_mirror_writer;
     END IF;
 END $$`,
 }

--- a/phase4-coordinator/internal/stats/billingmirror/mirror_test.go
+++ b/phase4-coordinator/internal/stats/billingmirror/mirror_test.go
@@ -68,6 +68,12 @@ func TestFetchRequestCreditsParsesEffectiveStatsColumns(t *testing.T) {
 	if first.Quarantined {
 		t.Fatal("first.Quarantined = true, want false")
 	}
+	if first.SettlementPolicyMode != "enforce" {
+		t.Fatalf("first settlement policy = %q, want enforce", first.SettlementPolicyMode)
+	}
+	if !first.Spec022Verified {
+		t.Fatal("first.Spec022Verified = false, want true")
+	}
 	second := rows[1]
 	if second.UsageSource != "byte_estimated" {
 		t.Fatalf("second usage source = %q, want byte_estimated", second.UsageSource)
@@ -80,6 +86,32 @@ func TestFetchRequestCreditsParsesEffectiveStatsColumns(t *testing.T) {
 	}
 	if !second.Quarantined {
 		t.Fatal("second.Quarantined = false, want true")
+	}
+	if second.Spec022Verified {
+		t.Fatal("second.Spec022Verified = true, want false")
+	}
+}
+
+func TestFetchRequestCreditsSupportsLegacySourceSchema(t *testing.T) {
+	dbPath := seedLegacySQLite(t)
+	db, err := OpenSQLite(dbPath)
+	if err != nil {
+		t.Fatalf("OpenSQLite() error = %v", err)
+	}
+	defer db.Close()
+
+	rows, err := FetchRequestCredits(context.Background(), db, 0, 10)
+	if err != nil {
+		t.Fatalf("FetchRequestCredits() error = %v", err)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("len(rows) = %d, want 1", len(rows))
+	}
+	if got := rows[0].SettlementPolicyMode; got != "legacy" {
+		t.Fatalf("SettlementPolicyMode = %q, want legacy", got)
+	}
+	if rows[0].Spec022Verified {
+		t.Fatal("Spec022Verified = true, want false for legacy source schema")
 	}
 }
 
@@ -232,8 +264,14 @@ CREATE TABLE ledger_request_credits (
     usage_source TEXT NOT NULL,
     provider_credits INTEGER NOT NULL,
     fault_flag TEXT NOT NULL,
-    quarantined INTEGER NOT NULL
+    quarantined INTEGER NOT NULL,
+    settlement_policy_mode TEXT NOT NULL DEFAULT 'legacy'
 );
+CREATE VIEW spec022_payable_request_credits AS
+SELECT *
+  FROM ledger_request_credits
+ WHERE quarantined = 0
+   AND settlement_policy_mode = 'enforce';
 CREATE TABLE provider_tokens (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
     token_hash TEXT NOT NULL UNIQUE,
@@ -247,12 +285,12 @@ CREATE TABLE provider_tokens (
 INSERT INTO ledger_request_credits (
     request_id, attempt_n, provider_id, ts_utc, created_at_utc, updated_at_utc,
     prompt_tokens, completion_tokens, estimated_completion_tokens, usage_source,
-    provider_credits, fault_flag, quarantined
+    provider_credits, fault_flag, quarantined, settlement_policy_mode
 ) VALUES
     ('req-1', 0, 'provider-a', '2026-07-05T08:59:00Z', '2026-07-05T08:59:01Z', NULL,
-     100, 200, NULL, 'provider_reported', 300, 'none', 0),
+     100, 200, NULL, 'provider_reported', 300, 'none', 0, 'enforce'),
     ('req-2', 0, 'provider-a', '2026-07-05T09:01:00Z', '2026-07-05T09:01:01Z', '2026-07-05T09:02:00Z',
-     33, NULL, 44, 'byte_estimated', 0, 'none', 1);
+     33, NULL, 44, 'byte_estimated', 0, 'none', 1, 'enforce');
 INSERT INTO provider_tokens (token_hash, token_prefix, provider_id, provider_name, created_at, last_used_at)
 VALUES ('hash-a', 'hash-a', 'provider-a', 'Provider A', '2026-07-05T08:00:00Z', '2026-07-05T09:00:00Z');
 `); err != nil {
@@ -263,6 +301,51 @@ VALUES ('hash-a', 'hash-a', 'provider-a', 'Provider A', '2026-07-05T08:00:00Z', 
 	}
 	if _, err := os.Stat(path); err != nil {
 		t.Fatalf("stat seed sqlite: %v", err)
+	}
+	return path
+}
+
+func seedLegacySQLite(t *testing.T) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "legacy-request-log.sqlite")
+	db, err := sql.Open("sqlite", path)
+	if err != nil {
+		t.Fatalf("open legacy sqlite seed db: %v", err)
+	}
+	defer db.Close()
+	if _, err := db.Exec(`
+CREATE TABLE ledger_request_credits (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    request_id TEXT NOT NULL,
+    attempt_n INTEGER NOT NULL,
+    provider_id TEXT NOT NULL,
+    ts_utc TEXT NOT NULL,
+    created_at_utc TEXT NOT NULL,
+    updated_at_utc TEXT NULL,
+    prompt_tokens INTEGER NULL,
+    completion_tokens INTEGER NULL,
+    estimated_completion_tokens INTEGER NULL,
+    usage_source TEXT NOT NULL,
+    provider_credits INTEGER NOT NULL,
+    fault_flag TEXT NOT NULL,
+    quarantined INTEGER NOT NULL
+);
+INSERT INTO ledger_request_credits (
+    request_id, attempt_n, provider_id, ts_utc, created_at_utc, updated_at_utc,
+    prompt_tokens, completion_tokens, estimated_completion_tokens, usage_source,
+    provider_credits, fault_flag, quarantined
+) VALUES (
+    'legacy-req', 0, 'provider-legacy', '2026-07-05T08:59:00Z', '2026-07-05T08:59:01Z', NULL,
+    10, 20, NULL, 'provider_reported', 30, 'none', 0
+);
+`); err != nil {
+		t.Fatalf("seed legacy sqlite: %v", err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatalf("close legacy sqlite seed db: %v", err)
+	}
+	if _, err := os.Stat(path); err != nil {
+		t.Fatalf("stat legacy seed sqlite: %v", err)
 	}
 	return path
 }

--- a/phase4-coordinator/internal/stats/migrations/022_malibu_useful_work_rewards.up.sql
+++ b/phase4-coordinator/internal/stats/migrations/022_malibu_useful_work_rewards.up.sql
@@ -1,0 +1,159 @@
+-- SPEC-021 v0.2.0 — verified useful-work MALIBU reward source.
+-- Keeps v0.1 bootstrap rows readable while adding an idempotent source
+-- reference for settlement-derived reward rows.
+
+CREATE UNIQUE INDEX IF NOT EXISTS provider_rewards_ledger_malibu_external_ref_idx
+    ON provider_rewards_ledger (external_ref)
+    WHERE amount_malibu IS NOT NULL AND external_ref IS NOT NULL;
+
+ALTER TABLE IF EXISTS ledger_request_credits
+    ADD COLUMN IF NOT EXISTS settlement_policy_mode TEXT NOT NULL DEFAULT 'legacy',
+    ADD COLUMN IF NOT EXISTS spec022_verified BOOLEAN NOT NULL DEFAULT FALSE;
+
+DO $$
+BEGIN
+    IF to_regclass('public.ledger_request_credits') IS NOT NULL THEN
+        UPDATE ledger_request_credits
+           SET settlement_policy_mode = 'legacy'
+         WHERE settlement_policy_mode IS NULL;
+
+        UPDATE ledger_request_credits
+           SET spec022_verified = FALSE
+         WHERE spec022_verified IS NULL;
+
+        IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'lrc_mirror_settlement_policy_mode_enum') THEN
+            ALTER TABLE ledger_request_credits
+                ADD CONSTRAINT lrc_mirror_settlement_policy_mode_enum
+                CHECK (settlement_policy_mode IN ('legacy','observe','enforce'));
+        END IF;
+        IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'lrc_mirror_spec022_verified_not_null') THEN
+            ALTER TABLE ledger_request_credits
+                ADD CONSTRAINT lrc_mirror_spec022_verified_not_null
+                CHECK (spec022_verified IS NOT NULL);
+        END IF;
+        IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'lrc_mirror_spec022_verified_enforce_check') THEN
+            ALTER TABLE ledger_request_credits
+                ADD CONSTRAINT lrc_mirror_spec022_verified_enforce_check
+                CHECK (spec022_verified = FALSE OR settlement_policy_mode = 'enforce');
+        END IF;
+
+        GRANT SELECT ON ledger_request_credits TO rewards_writer;
+    END IF;
+END
+$$;
+
+CREATE TABLE IF NOT EXISTS ledger_request_credit_spec022_verified_audit (
+    request_id TEXT NOT NULL,
+    attempt_n INTEGER NOT NULL,
+    provider_id TEXT NOT NULL,
+    sqlite_lrc_id BIGINT,
+    provider_credits BIGINT NOT NULL,
+    settlement_policy_mode TEXT NOT NULL CHECK (settlement_policy_mode = 'enforce'),
+    source TEXT NOT NULL DEFAULT 'stats_billing_mirror',
+    mirrored_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    PRIMARY KEY (request_id, attempt_n, provider_id)
+);
+
+CREATE OR REPLACE FUNCTION stats_billing_mirror_upsert_request_credit(
+    p_sqlite_lrc_id BIGINT,
+    p_request_id TEXT,
+    p_attempt_n INTEGER,
+    p_provider_id TEXT,
+    p_ts_utc TIMESTAMPTZ,
+    p_created_at_utc TIMESTAMPTZ,
+    p_updated_at_utc TIMESTAMPTZ,
+    p_prompt_tokens BIGINT,
+    p_completion_tokens BIGINT,
+    p_estimated_completion_tokens BIGINT,
+    p_usage_source TEXT,
+    p_provider_credits BIGINT,
+    p_fault_flag TEXT,
+    p_quarantined BOOLEAN,
+    p_settlement_policy_mode TEXT,
+    p_spec022_verified BOOLEAN
+)
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+    v_settlement_policy_mode TEXT := COALESCE(NULLIF(p_settlement_policy_mode, ''), 'legacy');
+    v_spec022_verified BOOLEAN;
+    v_was_spec022_verified BOOLEAN;
+BEGIN
+    IF v_settlement_policy_mode NOT IN ('legacy','observe','enforce') THEN
+        RAISE EXCEPTION 'invalid settlement_policy_mode: %', v_settlement_policy_mode;
+    END IF;
+
+    v_spec022_verified :=
+        v_settlement_policy_mode = 'enforce'
+        AND COALESCE(p_spec022_verified, FALSE)
+        AND COALESCE(p_provider_credits, 0) > 0
+        AND NOT COALESCE(p_quarantined, FALSE);
+
+    SELECT spec022_verified
+      INTO v_was_spec022_verified
+      FROM ledger_request_credits
+     WHERE request_id = p_request_id
+       AND attempt_n = p_attempt_n
+       AND provider_id = p_provider_id
+     FOR UPDATE;
+
+    INSERT INTO ledger_request_credits (
+        sqlite_lrc_id, request_id, attempt_n, provider_id, ts_utc, created_at_utc, updated_at_utc,
+        prompt_tokens, completion_tokens, estimated_completion_tokens, usage_source,
+        provider_credits, fault_flag, quarantined, settlement_policy_mode, spec022_verified
+    ) VALUES (
+        p_sqlite_lrc_id, p_request_id, p_attempt_n, p_provider_id, p_ts_utc, p_created_at_utc, p_updated_at_utc,
+        p_prompt_tokens, p_completion_tokens, p_estimated_completion_tokens, p_usage_source,
+        p_provider_credits, p_fault_flag, COALESCE(p_quarantined, FALSE), v_settlement_policy_mode, v_spec022_verified
+    )
+    ON CONFLICT (request_id, attempt_n, provider_id) DO UPDATE SET
+        sqlite_lrc_id = EXCLUDED.sqlite_lrc_id,
+        ts_utc = EXCLUDED.ts_utc,
+        created_at_utc = EXCLUDED.created_at_utc,
+        updated_at_utc = EXCLUDED.updated_at_utc,
+        prompt_tokens = EXCLUDED.prompt_tokens,
+        completion_tokens = EXCLUDED.completion_tokens,
+        estimated_completion_tokens = EXCLUDED.estimated_completion_tokens,
+        usage_source = EXCLUDED.usage_source,
+        provider_credits = EXCLUDED.provider_credits,
+        fault_flag = EXCLUDED.fault_flag,
+        quarantined = EXCLUDED.quarantined,
+        settlement_policy_mode = EXCLUDED.settlement_policy_mode,
+        spec022_verified = EXCLUDED.spec022_verified;
+
+    IF v_spec022_verified AND NOT COALESCE(v_was_spec022_verified, FALSE) THEN
+        INSERT INTO ledger_request_credit_spec022_verified_audit (
+            request_id, attempt_n, provider_id, sqlite_lrc_id,
+            provider_credits, settlement_policy_mode
+        ) VALUES (
+            p_request_id, p_attempt_n, p_provider_id, p_sqlite_lrc_id,
+            p_provider_credits, v_settlement_policy_mode
+        )
+        ON CONFLICT (request_id, attempt_n, provider_id) DO NOTHING;
+    END IF;
+END;
+$$;
+
+DO $$
+BEGIN
+    IF EXISTS (
+        SELECT 1
+          FROM pg_proc p
+          JOIN pg_namespace n ON n.oid = p.pronamespace
+         WHERE n.nspname = 'public'
+           AND p.proname = 'stats_billing_mirror_upsert_request_credit'
+           AND p.pronargs = 14
+    ) THEN
+        REVOKE ALL ON FUNCTION stats_billing_mirror_upsert_request_credit(BIGINT, TEXT, INTEGER, TEXT, TIMESTAMPTZ, TIMESTAMPTZ, TIMESTAMPTZ, BIGINT, BIGINT, BIGINT, TEXT, BIGINT, TEXT, BOOLEAN) FROM PUBLIC;
+    END IF;
+    REVOKE ALL ON FUNCTION stats_billing_mirror_upsert_request_credit(BIGINT, TEXT, INTEGER, TEXT, TIMESTAMPTZ, TIMESTAMPTZ, TIMESTAMPTZ, BIGINT, BIGINT, BIGINT, TEXT, BIGINT, TEXT, BOOLEAN, TEXT, BOOLEAN) FROM PUBLIC;
+
+    IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'stats_billing_mirror_writer') THEN
+        REVOKE ALL ON ledger_request_credit_spec022_verified_audit FROM stats_billing_mirror_writer;
+        GRANT EXECUTE ON FUNCTION stats_billing_mirror_upsert_request_credit(BIGINT, TEXT, INTEGER, TEXT, TIMESTAMPTZ, TIMESTAMPTZ, TIMESTAMPTZ, BIGINT, BIGINT, BIGINT, TEXT, BIGINT, TEXT, BOOLEAN, TEXT, BOOLEAN) TO stats_billing_mirror_writer;
+    END IF;
+END
+$$;

--- a/phase4-coordinator/internal/stats/migrations/migrations_test.go
+++ b/phase4-coordinator/internal/stats/migrations/migrations_test.go
@@ -42,6 +42,7 @@ func TestEmbeddedMigrationsLoad(t *testing.T) {
 		{19, "hardware_trust_operator_approval"},
 		{20, "waiting_trust_chip_profile_projection"},
 		{21, "malibu_emission_ledger_update_grant"},
+		{22, "malibu_useful_work_rewards"},
 	}
 	if len(all) != len(want) {
 		t.Fatalf("got %d migrations, want %d", len(all), len(want))

--- a/specs/CONFORMANCE.json
+++ b/specs/CONFORMANCE.json
@@ -590,8 +590,8 @@
     },
     {
       "spec_id": "SPEC-021",
-      "title": "MALIBU bootstrap rewards emission ledger",
-      "version": "0.1.1",
+      "title": "MALIBU rewards emission ledger",
+      "version": "0.2.0",
       "path": "specs/SPEC-021-malibu-emission-ledger.md",
       "status": "draft",
       "owner": "@Augustas11",

--- a/specs/README.md
+++ b/specs/README.md
@@ -29,7 +29,7 @@ it can no longer drift. Do not hand-edit the table; edit each spec's
 | SPEC-018 | Agentic tool calling (provider-side response synthesis) | 0.2.7 | normative | pending | conformant: 1, pending: 1 | [SPEC-018-agentic-tool-calling.md](SPEC-018-agentic-tool-calling.md) |
 | SPEC-019 | Structured output (`response_format: json_schema`) | 0.2.5 | normative | pending | pending corpus migration | [SPEC-019-structured-output.md](SPEC-019-structured-output.md) |
 | SPEC-020 | Provider autoupdate | v0.1.11 | normative | pending | pending: 4 | [SPEC-020-provider-autoupdate.md](SPEC-020-provider-autoupdate.md) |
-| SPEC-021 | MALIBU bootstrap rewards emission ledger | 0.1.1 | draft | pending | pending corpus migration | [SPEC-021-malibu-emission-ledger.md](SPEC-021-malibu-emission-ledger.md) |
+| SPEC-021 | MALIBU rewards emission ledger | 0.2.0 | draft | pending | pending corpus migration | [SPEC-021-malibu-emission-ledger.md](SPEC-021-malibu-emission-ledger.md) |
 | SPEC-022 | Verified model settlement | v0.1.7 | draft | complete | pending: 11 | [SPEC-022-verified-model-settlement.md](SPEC-022-verified-model-settlement.md) |
 | SPEC-023 | Installer-Integrated Autotune Recommend | v0.9.3 | normative | pending | conformant: 2 | [SPEC-023-installer-autotune-recommend.md](SPEC-023-installer-autotune-recommend.md) |
 | SPEC-024 | Prefix-cache billing and provider-local cache isolation | 0.2.1 | normative | pending | pending corpus migration | [SPEC-024-prefix-cache-billing.md](SPEC-024-prefix-cache-billing.md) |

--- a/specs/SPEC-021-malibu-emission-ledger.md
+++ b/specs/SPEC-021-malibu-emission-ledger.md
@@ -1,8 +1,23 @@
-# SPEC-021 — MALIBU bootstrap rewards emission ledger
+# SPEC-021 — MALIBU rewards emission ledger
 
-**Version:** 0.1.1 (2026-08-17, reward eligibility reason read model)
+**Version:** 0.2.0 (2026-08-17, verified useful-work accrual)
 **Status:** DRAFT — implementation target for Session C (`ops/runbooks/malibu-bootstrap-emission.md`)  
 **Depends on:** SPEC-026 v0.13 §5.1–§5.2, §5.5, §10 step 8; SPEC-017 v0.1.8 (`provider_rewards_ledger`); SPEC-016 v0.1.19 (`provider_payout_addresses` projection); SPEC-022 (verified-receipt-only USDC earnings)
+
+**Change log v0.2.0 (2026-08-17, verified useful-work accrual):**
+- Adds `malibu_verified_useful_work_v0_2` ledger rows derived only from
+  mirrored SPEC-022 enforce-mode request credits with verified settlement
+  evidence.
+- Defines the v0.2 accrual formula as normalized provider credits converted to
+  MALIBU by `useful_work_malibu_per_1000_provider_credits`; provider credits
+  are the billing-owned model/rate-card/token weighted unit, so MALIBU does not
+  re-price models independently.
+- Pins idempotency to `external_ref = spec022:<request_id>:<attempt_n>:<provider_id>`
+  with a unique MALIBU external-ref index. Duplicate settlement replay MUST NOT
+  mint another row or advance daily cap aggregates.
+- Keeps v0.1 `malibu_bootstrap_tick` rows readable as historical/bootstrap
+  accrual. No row is silently reclassified; any future backfill MUST use an
+  explicit migration rule.
 
 **Change log v0.1.1 (2026-08-17, reward eligibility reason read model):**
 - Defines `malibu_reward_eligibility.v1`, the provider-token-authenticated read
@@ -26,7 +41,9 @@ Accrue **$MALIBU** for early Malibu providers to bootstrap network growth, with 
 - Per-wallet daily cap applies across all `provider_id`s sharing a bound payout address.
 - Withdrawal runners MUST filter on `withdrawal_hold_reason IS NULL`.
 
-USDC payout semantics remain in SPEC-016; this spec owns MALIBU accrual only.
+USDC payout semantics remain in SPEC-016/SPEC-022; this spec owns MALIBU
+accrual only. v0.2 useful-work rewards consume settlement evidence as an input
+but do not alter buyer debit, USDC payout readiness, or the billing ledger.
 
 ---
 
@@ -43,8 +60,11 @@ Migration extends the existing table:
 | `amount_usd` | `NUMERIC(18,2) NULL` | Legacy operator USD rewards; nullable after migration |
 | `amount_malibu` | `NUMERIC(24,8) NULL` | MALIBU accrual for this row; NULL for USD-only rows |
 | `withdrawal_hold_reason` | `TEXT NULL` | When non-NULL, row is accrual-visible but **not** withdrawable |
+| `reason` | `TEXT NULL` | Reward source, including `malibu_bootstrap_tick` and `malibu_verified_useful_work_v0_2` |
+| `external_ref` | `TEXT NULL` | Idempotency reference for external sources. v0.2 useful-work rows use `spec022:<request_id>:<attempt_n>:<provider_id>` |
 
 Constraint: at least one of `amount_usd`, `amount_malibu` MUST be non-NULL.
+MALIBU rows with non-NULL `external_ref` are unique by `external_ref`.
 
 **Hold reason vocabulary (closed set):**
 
@@ -130,11 +150,14 @@ Dedicated runtime role for emission writes:
 |------|-------------------------|
 | Per-provider daily accrual cap | **25 MALIBU / provider_id / UTC day** |
 | Per-wallet daily aggregate cap | **100 MALIBU / bound wallet / UTC day** |
+| v0.2 useful-work rate | **1 MALIBU / 1000 verified provider credits** |
 | Withdrawable | **No** until `trust_tier = trusted` |
 | Hold reason (provisional accrual) | `trust_tier_provisional` |
 | Hold reason (wallet cap exceeded) | `per_wallet_daily_cap` (accrue but non-withdrawable) |
 
 Trusted providers accrue with `withdrawal_hold_reason IS NULL` unless wallet cap applies (`per_wallet_daily_cap`).
+Provider and wallet daily caps are shared across v0.1 bootstrap tick rows and
+v0.2 useful-work rows.
 
 **Retroactive unlock rule:** Tier transition to Trusted clears holds on **new** accrual rows only. Existing ledger rows retain their original `withdrawal_hold_reason`; operators MAY run a one-shot reconciliation job to clear holds on pre-unlock rows (out of v0.1 scope).
 
@@ -142,9 +165,9 @@ Trusted providers accrue with `withdrawal_hold_reason IS NULL` unless wallet cap
 
 ## 4. Workers
 
-### 4.1 Emission tick (periodic)
+### 4.1 Bootstrap emission tick (periodic)
 
-- Default interval: **15 minutes** (`malibu_emission.tick_interval`)
+- Default interval: **15 minutes** (`malibu_emission.tick_interval_seconds`)
 - Gated by `malibu_emission.enabled` (default `false`)
 - Per tick, per eligible `provider_id`:
   1. Resolve `bound_wallet` from `provider_payout_addresses_proj` (NULL if unbound — per-provider cap still applies; wallet cap skipped)
@@ -157,9 +180,44 @@ Trusted providers accrue with `withdrawal_hold_reason IS NULL` unless wallet cap
 
 Eligibility: provider MUST exist in `provider_emission_state` (seeded at App-track register and lazily on first tick for legacy CLI providers).
 
-Optional gate (hook only, v0.1): when `opoi_liveness_ok = false` for a canary cohort, skip accrual for that provider (Session A integration point).
+Bootstrap tick rows use `reason = malibu_bootstrap_tick`. They remain enabled
+only by `malibu_emission.enabled`; v0.2 does not reclassify them.
 
-### 4.2 Wallet-bind mirror
+### 4.2 Verified useful-work accrual (v0.2)
+
+- Default interval: **15 minutes** (`malibu_emission.useful_work_interval_seconds`)
+- Gated by both `malibu_emission.enabled` and
+  `malibu_emission.useful_work_enabled` (default `false`)
+- Source table: Postgres-mirrored `ledger_request_credits`
+- Eligibility gate:
+  - `spec022_verified = TRUE`
+  - `provider_credits > 0`
+  - no existing MALIBU ledger row for
+    `external_ref = spec022:<request_id>:<attempt_n>:<provider_id>`
+- Formula:
+
+```text
+malibu = provider_credits / 1000 * useful_work_malibu_per_1000_provider_credits
+```
+
+`provider_credits` is billing-owned normalized useful-work weight. It already
+captures verified request count (one eligible row per verified request),
+verified billable tokens, served model/rate-card price, and provider share.
+MALIBU MUST NOT independently re-price models from raw model IDs or client copy.
+Uptime/liveness and proof multipliers are reserved for a later explicit
+multiplier version; v0.2 may use proof state for eligibility/copy but not as a
+hidden amount multiplier.
+
+The worker inserts `provider_rewards_ledger` rows with
+`reason = malibu_verified_useful_work_v0_2` and the external-ref idempotency key
+above. Duplicate settlement replay or mirror overlap MUST be a no-op: no second
+row and no daily cap counter advance.
+
+The same provider cap, wallet cap, provisional hold, demotion hold, and trusted
+withdrawable rules from §3 apply. Non-verified, missing-receipt, quarantined, or
+legacy/observe-only rows are excluded from v0.2 MALIBU useful-work accrual.
+
+### 4.3 Wallet-bind mirror
 
 Periodic poll of SQLite `provider_payout_addresses` (same DB as `ledger_payout_ready` per SPEC-016 §3.1) into `provider_payout_addresses_proj`.
 
@@ -168,7 +226,7 @@ On first bind for a `provider_id`:
 1. Set `provider_emission_state.bound_wallet`
 2. Set `cap_replay_pending = TRUE`
 
-### 4.3 Cap replay at wallet bind
+### 4.4 Cap replay at wallet bind
 
 When `cap_replay_pending = TRUE`, under the same SERIALIZABLE lock as live emissions:
 
@@ -176,7 +234,7 @@ When `cap_replay_pending = TRUE`, under the same SERIALIZABLE lock as live emiss
 2. Re-evaluate against wallet cap; clear `per_wallet_daily_cap` hold where cap now permits withdrawal (Trusted tier only)
 3. Clear `cap_replay_pending`
 
-### 4.4 Trusted unlock evaluator (Phase C2)
+### 4.5 Trusted unlock evaluator (Phase C2)
 
 Coordinator job evaluates SPEC-026 §5.2 criteria on `unlock_eval_interval`:
 
@@ -196,7 +254,7 @@ Coordinator job evaluates SPEC-026 §5.2 criteria on `unlock_eval_interval`:
 - On demotion (§5.5): `trust_tier → provisional`, set `demotion_cooldown_until = now() + 72h`, new rows get `demotion_cooldown` hold until cooldown elapses
 - Post-demotion requalification: pairing must co-hold continuously for 72h before reinstatement
 
-### 4.5 Withdrawal runner filter
+### 4.6 Withdrawal runner filter
 
 Any MALIBU withdrawal query (future SPEC-016 extension or dedicated runner) MUST include:
 
@@ -318,12 +376,15 @@ boolean.
 malibu_emission:
   enabled: false
   writer_dsn: ""                    # rewards_writer role; env override MALIBU_EMISSION_WRITER_DSN
-  tick_interval: 15m
+  tick_interval_seconds: 900
+  useful_work_enabled: false
+  useful_work_interval_seconds: 900
   provider_daily_cap_malibu: 25
   wallet_daily_cap_malibu: 100
+  useful_work_malibu_per_1000_provider_credits: 1
   sqlite_payout_db_path: ""         # defaults to storage.db_path; SPEC-016 payout table source
-  wallet_mirror_interval: 5m
-  unlock_eval_interval: 1h
+  wallet_mirror_interval_seconds: 300
+  unlock_eval_interval_seconds: 3600
   max_serializable_retries: 5
 ```
 
@@ -343,11 +404,15 @@ Coordinator → CLI metrics wiring is C3; this spec defines the read API in §5.
 
 ---
 
-## 8. Acceptance criteria (Phase C1)
+## 8. Acceptance criteria
 
 - [ ] Provisional provider accrues MALIBU with `withdrawal_hold_reason = trust_tier_provisional`
 - [ ] Second `provider_id` on same wallet cannot exceed 100 MALIBU/day wallet aggregate
 - [ ] Withdrawal helper returns zero rows for held accrual
+- [ ] Verified useful-work rows accrue only when `spec022_verified = TRUE`
+- [ ] Non-verified, missing-receipt, quarantined, or legacy/observe-only rows do not accrue v0.2 useful-work MALIBU
+- [ ] Duplicate settlement/mirror replay with the same `spec022:<request_id>:<attempt_n>:<provider_id>` external ref does not mint a second row or advance cap counters
+- [ ] Existing v0.1 `malibu_bootstrap_tick` balances remain readable and are not reclassified
 - [ ] `rewards_writer` cannot SELECT from `partner_keys` or write `stats_*` rollup tables
 - [ ] Migration is idempotent; existing `amount_usd` leaderboard rollup continues to work
 
@@ -356,9 +421,9 @@ Coordinator → CLI metrics wiring is C3; this spec defines the read API in §5.
 ## 9. Open questions
 
 1. Cohort telemetry may adjust 100 MALIBU/day wallet cap (SPEC-026 §13).
-2. Event-driven accrual (per verified receipt) vs periodic tick — v0.1 uses tick; receipt-gated accrual is v0.2 candidate.
+2. Whether bootstrap tick remains permanently as an early-network floor or is disabled after demand reaches a stable threshold remains an operator policy choice.
 3. On-chain MALIBU withdrawal rail — out of scope; this spec is ledger-only.
 
 ---
 
-*End of SPEC-MALIBU-EMISSION-LEDGER v0.1.1.*
+*End of SPEC-MALIBU-EMISSION-LEDGER v0.2.0.*


### PR DESCRIPTION
## Summary
- Add default-off v0.2 useful-work MALIBU accrual from mirrored SPEC-022 verified request credits.
- Reuse existing provider/wallet daily caps and hold semantics, with idempotency via provider_rewards_ledger.external_ref.
- Extend the billing mirror, stats migration, config, overlay, and SPEC-021 contract for verified useful-work rewards.

## Audit Gate
- code-reviewer OMC re-audit: 0 Critical, 0 High, 0 Medium.
- security-reviewer OMC re-audit: 0 Critical, 0 High, 0 Medium.
- architect OMC re-audit: 0 Critical, 0 High, 0 Medium. LOW carried: deprecated 14-arg mirror upsert overload may remain role-callable on previously migrated installs; it cannot set `spec022_verified` and does not mint useful-work rewards.

## Validation
- `go test -count=1 ./internal/rewards ./internal/stats/billingmirror ./internal/stats/migrations ./internal/config ./cmd/coordinator`
- `bash phase4-coordinator/dist/test/check_stats_billing_mirror_deploy_test.sh`
- `python3 scripts/check_spec_governance.py --base-ref origin/main`
- `git diff --check`
- `go test -count=1 -tags integration ./internal/rewards -run 'TestUsefulWorkAccrual'` was attempted, but local testcontainers could not start: rootless Docker not found.

SPEC-GOVERNANCE-DECLARATION-BEGIN
{
  "schema_version": "spec-pr-governance-v1",
  "behavior_change": "yes",
  "contract_change": "yes",
  "specs": ["SPEC-021", "SPEC-022"],
  "requirements": ["SPEC-022-R007"],
  "authority_domains": ["malibu-emission-ledger", "verified-model-settlement"],
  "arbitration": ["DECISION_REQUIRED"],
  "tests": [
    "go test -count=1 ./internal/rewards ./internal/stats/billingmirror ./internal/stats/migrations ./internal/config ./cmd/coordinator",
    "bash phase4-coordinator/dist/test/check_stats_billing_mirror_deploy_test.sh",
    "python3 scripts/check_spec_governance.py --base-ref origin/main"
  ],
  "journeys": ["not-required"],
  "issue": "https://github.com/Augustas11/macprovider/issues/1019"
}
SPEC-GOVERNANCE-DECLARATION-END

Closes #1019
