### PR TITLE
Explain autotune recommendation evidence

### DIFF
--- a/phase3-binary/Sources/macprovider-cli/AutotuneCommand.swift
+++ b/phase3-binary/Sources/macprovider-cli/AutotuneCommand.swift
@@ -1207,16 +1207,29 @@ struct AutotuneCommand: AsyncParsableCommand {
     static func disclosingInstalledOnlyEstimate(_ result: AutotuneRecommendResult) -> AutotuneRecommendResult {
         var disclosed = result
         func disclose(_ candidate: AutotuneCandidateScore) -> AutotuneCandidateScore {
-            guard candidate.eligible else { return candidate }
             var updated = candidate
             updated.confidence = "catalog_estimate"
-            updated.why = "\(candidate.model) is the strongest verified installed candidate from signed catalog estimates and current hardware fit."
+            updated.explanation.throughputSource = "catalog_estimate"
+            updated.explanation.confidence = "catalog_estimate"
+            if candidate.eligible {
+                updated.explanation.warningState = "advisory"
+            }
+            if candidate.catalogKey == result.selectedCandidate?.catalogKey {
+                updated.why = "\(candidate.model) is the strongest verified installed candidate from signed catalog estimates and current hardware fit."
+                updated.explanation.summary = "Selected from signed catalog estimates and current hardware fit; no local throughput benchmark was run."
+            } else if candidate.eligible {
+                updated.why = "\(candidate.model) is a verified installed alternative from signed catalog estimates and current hardware fit."
+                updated.explanation.summary = "Eligible installed alternative from signed catalog estimates; no local throughput benchmark was run."
+            }
             return updated
         }
         disclosed.candidates = disclosed.candidates.map(disclose)
         disclosed.allCandidates = disclosed.allCandidates.map(disclose)
         if let selectedKey = disclosed.selectedCandidate?.catalogKey {
             disclosed.selectedCandidate = disclosed.candidates.first { $0.catalogKey == selectedKey }
+        }
+        if let fallbackKey = disclosed.donorFallbackCandidate?.catalogKey {
+            disclosed.donorFallbackCandidate = disclosed.allCandidates.first { $0.catalogKey == fallbackKey }
         }
         return disclosed
     }

--- a/phase3-binary/Sources/macprovider-cli/AutotuneRecommend.swift
+++ b/phase3-binary/Sources/macprovider-cli/AutotuneRecommend.swift
@@ -1655,6 +1655,32 @@ struct AutotuneCandidateScore: Equatable {
     var benchGateProvenance: CandidateCatalog.BenchGate.Provenance
     var benchGateDrift: [String]
     var buyerTTFTCeilingExceeded: Bool
+    var explanation: AutotuneCandidateExplanation
+}
+
+struct AutotuneCandidateExplanation: Equatable {
+    var summary: String
+    var warningState: String
+    var measuredTPS: Double
+    var throughputSource: String
+    var memoryRequiredGB: Int
+    var memoryTotalGB: Int
+    var memorySafetyMarginGB: Int
+    var memoryHeadroomGB: Double
+    var demandRank: Int?
+    var demandWeight: Double
+    var demandRecommendable: Bool
+    var minProviderTarget: Int
+    var readyProviderCount: Int?
+    var supplyDeficitMultiplier: Double
+    var promptRateUSDPerMillionTokens: Double
+    var completionRateUSDPerMillionTokens: Double
+    var providerShareBPS: Int64
+    var providerCompletionPayoutUSDPerMillionTokens: Double
+    var expectedEarningPotentialScore: Double
+    var localHealthWarnings: [String]
+    var confidence: String
+    var lostReason: String
 }
 
 struct AutotuneRecommendResult: Equatable {
@@ -1752,11 +1778,19 @@ struct AutotuneRecommendEngine {
         }
 
         let scored = request.candidateCatalog.rows.keys.sorted().compactMap { modelKey -> AutotuneCandidateScore? in
-            guard let candidate = request.candidateCatalog.rows[modelKey],
-                  let demand = request.demandRank.rows[modelKey]
-            else {
+            guard let candidate = request.candidateCatalog.rows[modelKey] else {
                 return nil
             }
+            let demandAvailable = request.demandRank.rows[modelKey] != nil
+            let demand = request.demandRank.rows[modelKey] ?? DemandRank.Row(
+                demandWeight: 0,
+                rank: nil,
+                recommendable: false,
+                minProviderTarget: 0,
+                readyProviderCount: nil,
+                supplyDeficitMultiplier: nil,
+                minDwellHours: nil
+            )
             let rateMatch = request.rateCard.rowForRecommendation(modelKey: modelKey)
             let benchmark = request.benchmarks[modelKey]
             let eligible = isEligible(
@@ -1769,6 +1803,7 @@ struct AutotuneRecommendEngine {
             )
             let measuredTPS = benchmark?.sustainedTPS ?? 0
             let tps = measuredTPS.isFinite ? measuredTPS : 0
+            let throughputSource = Self.throughputSource(benchmark)
             let benchGateDrift = benchmark.map {
                 Self.advisoryBenchmarkWarnings($0, candidate: candidate)
                     .map(\.rawValue)
@@ -1781,10 +1816,11 @@ struct AutotuneRecommendEngine {
             let rateRow = rateMatch?.row
             let promptUSD = rateRow?.usdPerMillionPromptTokens(creditsPerMillion: request.rateCard.usdPerMillionCredits) ?? 0
             let completionUSD = rateRow?.usdPerMillionCompletionTokens(creditsPerMillion: request.rateCard.usdPerMillionCredits) ?? 0
-            let providerShare = Double(rateRow?.providerShareBPS ?? 0) / 10_000.0
+            let providerShareBPS = rateRow?.providerShareBPS ?? 0
+            let providerShare = Double(providerShareBPS) / 10_000.0
             let payoutScore = Double(rateRow?.completionRatePerMtok ?? 0) * providerShare
-            let demandScore = max(demand.demandWeight, request.demandRank.coldStartFloor)
-            let shortageScore = demand.effectiveSupplyDeficitMultiplier
+            let demandScore = demandAvailable ? max(demand.demandWeight, request.demandRank.coldStartFloor) : 0
+            let shortageScore = demandAvailable ? demand.effectiveSupplyDeficitMultiplier : 0
             let expectedEarningsScore = payoutScore * max(tps, 0) * demandScore * shortageScore
             let headroom = Double(request.hardware.memoryGB - Self.safetyMarginGB - candidate.minRAMGB)
             let servedModel = rateMatch.map {
@@ -1795,6 +1831,32 @@ struct AutotuneRecommendEngine {
                 candidateWarnings.insert(.rateCardDefaultTierUsed)
             }
             let confidence = confidence(warnings: candidateWarnings, benchmark: benchmark, benchGateDrift: benchGateDrift)
+            let localHealthWarnings = Self.localHealthWarnings(
+                benchmark: benchmark,
+                buyerTTFTCeilingExceeded: buyerTTFTCeilingExceeded
+            )
+            let lostReason = Self.lostReason(
+                modelKey: modelKey,
+                candidate: candidate,
+                demand: demand,
+                rateCardRow: rateRow,
+                benchmark: benchmark,
+                request: request,
+                buyerTTFTCeilingExceeded: buyerTTFTCeilingExceeded,
+                eligible: eligible,
+                demandAvailable: demandAvailable
+            )
+            let warningState = Self.warningState(
+                eligible: eligible,
+                confidence: confidence,
+                localHealthWarnings: localHealthWarnings,
+                candidateWarnings: candidateWarnings
+            )
+            let summary = Self.explanationSummary(
+                modelKey: modelKey,
+                eligible: eligible,
+                lostReason: lostReason
+            )
             return AutotuneCandidateScore(
                 rank: 0,
                 catalogKey: modelKey,
@@ -1815,7 +1877,31 @@ struct AutotuneRecommendEngine {
                 rawScore: expectedEarningsScore.rounded6,
                 benchGateProvenance: candidate.benchGate.provenance,
                 benchGateDrift: benchGateDrift,
-                buyerTTFTCeilingExceeded: buyerTTFTCeilingExceeded
+                buyerTTFTCeilingExceeded: buyerTTFTCeilingExceeded,
+                explanation: AutotuneCandidateExplanation(
+                    summary: summary,
+                    warningState: warningState,
+                    measuredTPS: tps.rounded6,
+                    throughputSource: throughputSource,
+                    memoryRequiredGB: candidate.minRAMGB,
+                    memoryTotalGB: request.hardware.memoryGB,
+                    memorySafetyMarginGB: Self.safetyMarginGB,
+                    memoryHeadroomGB: headroom.rounded6,
+                    demandRank: demand.rank,
+                    demandWeight: demand.demandWeight.rounded6,
+                    demandRecommendable: demand.recommendable,
+                    minProviderTarget: demand.minProviderTarget,
+                    readyProviderCount: demand.readyProviderCount,
+                    supplyDeficitMultiplier: shortageScore.rounded6,
+                    promptRateUSDPerMillionTokens: promptUSD.rounded6,
+                    completionRateUSDPerMillionTokens: completionUSD.rounded6,
+                    providerShareBPS: providerShareBPS,
+                    providerCompletionPayoutUSDPerMillionTokens: (completionUSD * providerShare).rounded6,
+                    expectedEarningPotentialScore: expectedEarningsScore.rounded6,
+                    localHealthWarnings: localHealthWarnings,
+                    confidence: confidence,
+                    lostReason: lostReason
+                )
             )
         }
         .sorted { a, b in
@@ -1831,6 +1917,14 @@ struct AutotuneRecommendEngine {
         .map { offset, value in
             var next = value
             next.rank = offset + 1
+            if next.eligible {
+                next.explanation.lostReason = offset == 0
+                    ? "selected_best_expected_earning_potential"
+                    : "lower_expected_earning_potential"
+                next.explanation.summary = offset == 0
+                    ? "Selected for the best estimated earning potential on this Mac."
+                    : "Eligible, but another model has stronger estimated earning potential on this Mac."
+            }
             return next
         }
 
@@ -1880,7 +1974,11 @@ struct AutotuneRecommendEngine {
             warnings.insert(.swapObservedUnderLoad)
         }
 
-        let resultCandidates = eligible.isEmpty ? Array(scored.prefix(5)) : Array(eligible.prefix(5))
+        var resultCandidates = eligible.isEmpty ? Array(scored.prefix(5)) : Array(eligible.prefix(5))
+        if let donorFallback,
+           !resultCandidates.contains(where: { $0.catalogKey == donorFallback.catalogKey }) {
+            resultCandidates.append(donorFallback)
+        }
         let benchmarkedCount = scored.reduce(0) { count, score in
             request.benchmarks[score.catalogKey] == nil ? count : count + 1
         }
@@ -2051,6 +2149,114 @@ struct AutotuneRecommendEngine {
         return "high"
     }
 
+    private static func localHealthWarnings(
+        benchmark: CandidateBenchmark?,
+        buyerTTFTCeilingExceeded: Bool
+    ) -> [String] {
+        var warnings: [String] = []
+        if benchmark?.thermalThrottleDetected == true {
+            warnings.append("thermal_throttle_detected")
+        }
+        if benchmark?.swapDetected == true {
+            warnings.append("swap_observed_under_load")
+        }
+        if buyerTTFTCeilingExceeded {
+            warnings.append("buyer_ttft_ceiling_exceeded")
+        }
+        return warnings
+    }
+
+    private static func throughputSource(_ benchmark: CandidateBenchmark?) -> String {
+        guard let benchmark else { return "unavailable" }
+        if benchmark.benchmarkID?.hasPrefix("installed-only-") == true {
+            return "catalog_estimate"
+        }
+        return "measured"
+    }
+
+    private static func warningState(
+        eligible: Bool,
+        confidence: String,
+        localHealthWarnings: [String],
+        candidateWarnings: Set<AutotuneRecommendWarning>
+    ) -> String {
+        if !eligible { return "blocked" }
+        if !localHealthWarnings.isEmpty || confidence != "high" || !candidateWarnings.isEmpty {
+            return "advisory"
+        }
+        return "ready"
+    }
+
+    private static func explanationSummary(
+        modelKey: String,
+        eligible: Bool,
+        lostReason: String
+    ) -> String {
+        if eligible {
+            return "\(modelKey) is eligible and will be ranked by earning potential.".prefixString(160)
+        }
+        switch lostReason {
+        case "paid_trust_blocked":
+            return "Paid recommendation is unavailable until signed inputs are trusted.".prefixString(160)
+        case "demand_not_recommendable":
+            return "\(modelKey) is not currently marked recommendable by demand signal.".prefixString(160)
+        case "demand_signal_unavailable":
+            return "\(modelKey) has no trusted demand signal for earning estimates.".prefixString(160)
+        case "runtime_not_recommendable":
+            return "\(modelKey) is not in recommendable runtime status.".prefixString(160)
+        case "rate_card_unavailable":
+            return "\(modelKey) has no trusted rate-card row for earning estimates.".prefixString(160)
+        case "missing_model_artifact_identity":
+            return "\(modelKey) is missing release-pinned model artifact identity.".prefixString(160)
+        case "insufficient_memory_headroom":
+            return "\(modelKey) does not fit with the local memory safety margin.".prefixString(160)
+        case "bandwidth_tier_below_minimum":
+            return "\(modelKey) needs a higher memory-bandwidth tier than this Mac advertises.".prefixString(160)
+        case "benchmark_unavailable":
+            return "\(modelKey) has no current local throughput benchmark.".prefixString(160)
+        case "thermal_throttle_detected":
+            return "\(modelKey) was blocked by thermal throttling during the probe.".prefixString(160)
+        case "swap_observed_under_load":
+            return "\(modelKey) was blocked because swap was observed under probe load.".prefixString(160)
+        case "buyer_ttft_ceiling_exceeded":
+            return "\(modelKey) was blocked by the buyer latency ceiling.".prefixString(160)
+        case "benchmark_evidence_stale_or_mismatched":
+            return "\(modelKey) needs fresh local benchmark evidence.".prefixString(160)
+        default:
+            return "\(modelKey) did not clear one or more recommendation gates.".prefixString(160)
+        }
+    }
+
+    private static func lostReason(
+        modelKey: String,
+        candidate: CandidateCatalog.Row,
+        demand: DemandRank.Row,
+        rateCardRow: RateCardProjection.Row?,
+        benchmark: CandidateBenchmark?,
+        request: AutotuneRecommendRequest,
+        buyerTTFTCeilingExceeded: Bool,
+        eligible: Bool,
+        demandAvailable: Bool
+    ) -> String {
+        if eligible { return "selected_or_lower_expected_earning_potential" }
+        if !paidTrustBlockingWarnings.isDisjoint(with: request.warnings) { return "paid_trust_blocked" }
+        if !demandAvailable { return "demand_signal_unavailable" }
+        if !demand.recommendable { return "demand_not_recommendable" }
+        if candidate.runtimeStatus != "recommendable" { return "runtime_not_recommendable" }
+        if rateCardRow == nil { return "rate_card_unavailable" }
+        if candidate.modelRevision == nil || candidate.modelSHA256 == nil { return "missing_model_artifact_identity" }
+        if candidate.minRAMGB > request.hardware.memoryGB - safetyMarginGB { return "insufficient_memory_headroom" }
+        if !request.hardware.bandwidthTier.satisfies(minimum: candidate.minBandwidthTier) { return "bandwidth_tier_below_minimum" }
+        guard let benchmark else { return "benchmark_unavailable" }
+        if benchmark.thermalThrottleDetected { return "thermal_throttle_detected" }
+        if benchmark.swapDetected { return "swap_observed_under_load" }
+        if buyerTTFTCeilingExceeded { return "buyer_ttft_ceiling_exceeded" }
+        if !cachedBenchmarkAdmitted(benchmark, request: request, modelKey: modelKey) {
+            return "benchmark_evidence_stale_or_mismatched"
+        }
+        return "unknown_recommendation_gate"
+    }
+
     private func why(
         modelKey: String,
         candidate: CandidateCatalog.Row,
@@ -2085,8 +2291,17 @@ extension AutotuneRecommendResult {
         let warningsJSON = warnings.map { "\"\($0.rawValue)\"" }.joined(separator: ",")
         let candidatesJSON = candidates.map(Self.candidateJSON).joined(separator: ",")
         let serveConfigJSON = serveConfig.map { Self.serveConfigJSON($0, donorMode: donorMode) } ?? "null"
+        let selectedExplanationJSON = selectedCandidate.map { Self.explanationJSON($0.explanation) } ?? "null"
+        let alternativeExplanations = candidates
+            .filter { candidate in
+                guard let recommendedModel else { return true }
+                return candidate.model != recommendedModel
+            }
+            .map(Self.alternativeExplanationJSON)
+            .joined(separator: ",")
+        let donorFallbackExplanationJSON = donorFallbackCandidate.map { Self.explanationJSON($0.explanation) } ?? "null"
         return """
-        {"schema_version":"autotune_recommend.v1","generated_at":\(ISO8601DateFormatter.autotuneInternet.string(from: generatedAt).jsonEscaped),"hardware":{"machine":\(hardware.machine?.jsonEscaped ?? "null"),"chip":\(hardware.chip.jsonEscaped),"memory_gb":\(hardware.memoryGB),"bandwidth_tier":\(hardware.bandwidthTier.rawValue.jsonEscaped),"detected":\(hardware.detected),"os_version":\(hardware.osVersion.jsonEscaped),"binary_version":\(hardware.binaryVersion.jsonEscaped)},"inputs":{"rate_card_version":\(rateCardVersion.jsonEscaped),"demand_rank_version":\(demandRankVersion.jsonEscaped),"candidate_catalog_version":\(candidateCatalogVersion.jsonEscaped)},"recommended_model":\(recommendedModel?.jsonEscaped ?? "null"),"prompt_rate_usd_per_million_tokens":\(promptRatePerMillionTokens?.jsonNumber ?? "null"),"completion_rate_usd_per_million_tokens":\(completionRatePerMillionTokens?.jsonNumber ?? "null"),"serve_config":\(serveConfigJSON),"candidates":[\(candidatesJSON)],"warnings":[\(warningsJSON)]}
+        {"schema_version":"autotune_recommend.v1","generated_at":\(ISO8601DateFormatter.autotuneInternet.string(from: generatedAt).jsonEscaped),"hardware":{"machine":\(hardware.machine?.jsonEscaped ?? "null"),"chip":\(hardware.chip.jsonEscaped),"memory_gb":\(hardware.memoryGB),"bandwidth_tier":\(hardware.bandwidthTier.rawValue.jsonEscaped),"detected":\(hardware.detected),"os_version":\(hardware.osVersion.jsonEscaped),"binary_version":\(hardware.binaryVersion.jsonEscaped)},"inputs":{"rate_card_version":\(rateCardVersion.jsonEscaped),"demand_rank_version":\(demandRankVersion.jsonEscaped),"candidate_catalog_version":\(candidateCatalogVersion.jsonEscaped)},"recommended_model":\(recommendedModel?.jsonEscaped ?? "null"),"prompt_rate_usd_per_million_tokens":\(promptRatePerMillionTokens?.jsonNumber ?? "null"),"completion_rate_usd_per_million_tokens":\(completionRatePerMillionTokens?.jsonNumber ?? "null"),"serve_config":\(serveConfigJSON),"candidates":[\(candidatesJSON)],"warnings":[\(warningsJSON)],"selected_explanation":\(selectedExplanationJSON),"alternative_explanations":[\(alternativeExplanations)],"donor_fallback_explanation":\(donorFallbackExplanationJSON)}
         """
     }
 
@@ -2099,7 +2314,22 @@ extension AutotuneRecommendResult {
     private static func candidateJSON(_ candidate: AutotuneCandidateScore) -> String {
         let driftJSON = candidate.benchGateDrift.map(\.jsonEscaped).joined(separator: ",")
         return """
-        {"rank":\(candidate.rank),"model":\(candidate.model.jsonEscaped),"eligible":\(candidate.eligible),"prompt_rate_usd_per_million_tokens":\(candidate.promptRateUSDPerMillionTokens.jsonNumber),"completion_rate_usd_per_million_tokens":\(candidate.completionRateUSDPerMillionTokens.jsonNumber),"tokens_per_second":\(candidate.tokensPerSecond.jsonNumber),"memory_headroom_gb":\(candidate.memoryHeadroomGB.jsonNumber),"confidence":\(candidate.confidence.jsonEscaped),"why":\(candidate.why.jsonEscaped),"raw_score":\(candidate.rawScore.jsonNumber),"bench_gate_provenance":\(benchGateProvenanceJSON(candidate.benchGateProvenance)),"bench_gate_drift":[\(driftJSON)],"buyer_ttft_ceiling_exceeded":\(candidate.buyerTTFTCeilingExceeded)}
+        {"rank":\(candidate.rank),"model":\(candidate.model.jsonEscaped),"eligible":\(candidate.eligible),"prompt_rate_usd_per_million_tokens":\(candidate.promptRateUSDPerMillionTokens.jsonNumber),"completion_rate_usd_per_million_tokens":\(candidate.completionRateUSDPerMillionTokens.jsonNumber),"tokens_per_second":\(candidate.tokensPerSecond.jsonNumber),"memory_headroom_gb":\(candidate.memoryHeadroomGB.jsonNumber),"confidence":\(candidate.confidence.jsonEscaped),"why":\(candidate.why.jsonEscaped),"raw_score":\(candidate.rawScore.jsonNumber),"explanation":\(explanationJSON(candidate.explanation)),"bench_gate_provenance":\(benchGateProvenanceJSON(candidate.benchGateProvenance)),"bench_gate_drift":[\(driftJSON)],"buyer_ttft_ceiling_exceeded":\(candidate.buyerTTFTCeilingExceeded)}
+        """
+    }
+
+    private static func alternativeExplanationJSON(_ candidate: AutotuneCandidateScore) -> String {
+        """
+        {"rank":\(candidate.rank),"model":\(candidate.model.jsonEscaped),"eligible":\(candidate.eligible),"lost_reason":\(candidate.explanation.lostReason.jsonEscaped),"summary":\(candidate.explanation.summary.jsonEscaped),"expected_earning_potential_score":\(candidate.explanation.expectedEarningPotentialScore.jsonNumber)}
+        """
+    }
+
+    private static func explanationJSON(_ explanation: AutotuneCandidateExplanation) -> String {
+        let rankJSON = explanation.demandRank.map(String.init) ?? "null"
+        let readyJSON = explanation.readyProviderCount.map(String.init) ?? "null"
+        let localWarningsJSON = explanation.localHealthWarnings.map(\.jsonEscaped).joined(separator: ",")
+        return """
+        {"summary":\(explanation.summary.jsonEscaped),"warning_state":\(explanation.warningState.jsonEscaped),"measured_tps":\(explanation.measuredTPS.jsonNumber),"throughput_source":\(explanation.throughputSource.jsonEscaped),"memory_fit":{"required_gb":\(explanation.memoryRequiredGB),"total_gb":\(explanation.memoryTotalGB),"safety_margin_gb":\(explanation.memorySafetyMarginGB),"headroom_gb":\(explanation.memoryHeadroomGB.jsonNumber)},"demand_signal":{"rank":\(rankJSON),"weight":\(explanation.demandWeight.jsonNumber),"recommendable":\(explanation.demandRecommendable),"min_provider_target":\(explanation.minProviderTarget),"ready_provider_count":\(readyJSON),"supply_deficit_multiplier":\(explanation.supplyDeficitMultiplier.jsonNumber)},"rate_signal":{"prompt_rate_usd_per_million_tokens":\(explanation.promptRateUSDPerMillionTokens.jsonNumber),"completion_rate_usd_per_million_tokens":\(explanation.completionRateUSDPerMillionTokens.jsonNumber),"provider_share_bps":\(explanation.providerShareBPS),"provider_completion_payout_usd_per_million_tokens":\(explanation.providerCompletionPayoutUSDPerMillionTokens.jsonNumber)},"earning_potential":{"score":\(explanation.expectedEarningPotentialScore.jsonNumber),"kind":"relative_ranking_score","note":"Estimated earning potential only; actual rewards depend on buyer demand, uptime, accepted work, and settlement."},"local_health":{"warnings":[\(localWarningsJSON)]},"confidence":\(explanation.confidence.jsonEscaped),"lost_reason":\(explanation.lostReason.jsonEscaped)}
         """
     }
 

--- a/phase3-binary/Tests/macprovider-cliTests/AutotuneRecommendTests.swift
+++ b/phase3-binary/Tests/macprovider-cliTests/AutotuneRecommendTests.swift
@@ -300,6 +300,58 @@ final class AutotuneRecommendTests: XCTestCase {
         XCTAssertTrue(root["serve_config"] is NSNull)
     }
 
+    func testRecommendationJSONCarriesStructuredEarningExplanation() throws {
+        var request = try makeMultiCandidateRequest(modelKeys: [
+            "qwen3-coder-30b-a3b-instruct",
+            "meta-llama/llama-3.2-3b-instruct",
+        ])
+        request.demandRank.rows["qwen3-coder-30b-a3b-instruct"]?.supplyDeficitMultiplier = 2
+        request.demandRank.rows["qwen3-coder-30b-a3b-instruct"]?.readyProviderCount = 3
+        request.demandRank.rows["qwen3-coder-30b-a3b-instruct"]?.minProviderTarget = 12
+
+        let result = AutotuneRecommendEngine().recommend(request)
+        let selected = try XCTUnwrap(result.selectedCandidate)
+        let root = try XCTUnwrap(JSONSerialization.jsonObject(with: Data(result.jsonString().utf8)) as? [String: Any])
+        let selectedExplanation = try XCTUnwrap(root["selected_explanation"] as? [String: Any])
+        let candidate = try XCTUnwrap((root["candidates"] as? [[String: Any]])?.first)
+        let candidateExplanation = try XCTUnwrap(candidate["explanation"] as? [String: Any])
+        let memory = try XCTUnwrap(selectedExplanation["memory_fit"] as? [String: Any])
+        let demand = try XCTUnwrap(selectedExplanation["demand_signal"] as? [String: Any])
+        let rate = try XCTUnwrap(selectedExplanation["rate_signal"] as? [String: Any])
+        let earning = try XCTUnwrap(selectedExplanation["earning_potential"] as? [String: Any])
+        let alternatives = try XCTUnwrap(root["alternative_explanations"] as? [[String: Any]])
+
+        XCTAssertEqual(selectedExplanation["measured_tps"] as? Double, selected.tokensPerSecond)
+        XCTAssertEqual(memory["total_gb"] as? Int, request.hardware.memoryGB)
+        XCTAssertEqual(memory["safety_margin_gb"] as? Int, AutotuneRecommendEngine.safetyMarginGB)
+        XCTAssertEqual(memory["headroom_gb"] as? Double, selected.memoryHeadroomGB)
+        XCTAssertEqual(demand["supply_deficit_multiplier"] as? Double, 2)
+        XCTAssertEqual(demand["ready_provider_count"] as? Int, 3)
+        XCTAssertEqual(demand["min_provider_target"] as? Int, 12)
+        XCTAssertEqual(rate["provider_share_bps"] as? Int, Int(request.rateCard.rows[selected.catalogKey]?.providerShareBPS ?? 0))
+        XCTAssertEqual(earning["kind"] as? String, "relative_ranking_score")
+        XCTAssertTrue((earning["note"] as? String)?.contains("actual rewards depend") == true)
+        XCTAssertEqual(selectedExplanation["throughput_source"] as? String, "measured")
+        XCTAssertEqual(selectedExplanation["lost_reason"] as? String, "selected_best_expected_earning_potential")
+        XCTAssertEqual(candidateExplanation["summary"] as? String, selectedExplanation["summary"] as? String)
+        let explanationData = try JSONSerialization.data(withJSONObject: selectedExplanation)
+        let explanationPayload = try XCTUnwrap(String(data: explanationData, encoding: .utf8))
+        for forbiddenField in [
+            "model_artifact_path",
+            "model_artifact_sha256",
+            "provider_id",
+            "provider_identity",
+            "hardware_identity_hash",
+            "daily_income",
+            "daily_usd",
+            "guaranteed_income",
+        ] {
+            XCTAssertFalse(explanationPayload.contains(forbiddenField), "\(forbiddenField) leaked into explanation payload")
+        }
+        XCTAssertFalse(alternatives.isEmpty)
+        XCTAssertEqual(alternatives.first?["lost_reason"] as? String, "lower_expected_earning_potential")
+    }
+
     func testInstalledOnlyRecommendationUsesOnlyExistingVerifiedArtifacts() throws {
         var request = try makeRequest()
         let modelKey = try XCTUnwrap(request.candidateCatalog.rows.keys.sorted().first)
@@ -347,6 +399,44 @@ final class AutotuneRecommendTests: XCTestCase {
         XCTAssertEqual(disclosed.selectedCandidate?.confidence, "catalog_estimate")
         XCTAssertTrue(disclosed.selectedCandidate?.why.contains("signed catalog estimates") == true)
         XCTAssertFalse(disclosed.selectedCandidate?.why.contains("measured throughput") == true)
+        let root = try XCTUnwrap(JSONSerialization.jsonObject(with: Data(disclosed.jsonString().utf8)) as? [String: Any])
+        let explanation = try XCTUnwrap(root["selected_explanation"] as? [String: Any])
+        XCTAssertEqual(explanation["throughput_source"] as? String, "catalog_estimate")
+        XCTAssertEqual(explanation["warning_state"] as? String, "advisory")
+        XCTAssertEqual(explanation["confidence"] as? String, "catalog_estimate")
+    }
+
+    func testInstalledOnlyDisclosureDoesNotCallAlternativesSelected() throws {
+        let request = try makeMultiCandidateRequest(modelKeys: [
+            "qwen3-coder-30b-a3b-instruct",
+            "meta-llama/llama-3.2-3b-instruct",
+        ])
+        let result = AutotuneRecommendEngine().recommend(request)
+
+        let disclosed = AutotuneCommand.disclosingInstalledOnlyEstimate(result)
+        let root = try XCTUnwrap(JSONSerialization.jsonObject(with: Data(disclosed.jsonString().utf8)) as? [String: Any])
+        let alternatives = try XCTUnwrap(root["alternative_explanations"] as? [[String: Any]])
+        let summary = try XCTUnwrap(alternatives.first?["summary"] as? String)
+
+        XCTAssertFalse(summary.contains("Selected from signed catalog estimates"))
+        XCTAssertTrue(summary.contains("Eligible installed alternative"))
+    }
+
+    func testInstalledOnlyDisclosureLabelsBlockedCandidateAsCatalogEstimate() throws {
+        var request = try makeRequest()
+        let modelKey = "qwen3-coder-30b-a3b-instruct"
+        request.demandRank.rows = [:]
+
+        let result = AutotuneRecommendEngine().recommend(request)
+        let disclosed = AutotuneCommand.disclosingInstalledOnlyEstimate(result)
+        let root = try XCTUnwrap(JSONSerialization.jsonObject(with: Data(disclosed.jsonString().utf8)) as? [String: Any])
+        let candidate = try XCTUnwrap((root["candidates"] as? [[String: Any]])?.first)
+        let explanation = try XCTUnwrap(candidate["explanation"] as? [String: Any])
+
+        XCTAssertEqual(candidate["model"] as? String, modelKey)
+        XCTAssertEqual(explanation["throughput_source"] as? String, "catalog_estimate")
+        XCTAssertEqual(explanation["warning_state"] as? String, "blocked")
+        XCTAssertEqual(explanation["confidence"] as? String, "catalog_estimate")
     }
 
     func testRecommendApplyServeConfigUsesHardwareDerivedMaxBatch() throws {
@@ -487,12 +577,18 @@ final class AutotuneRecommendTests: XCTestCase {
         let result = AutotuneRecommendEngine().recommend(request)
 
         XCTAssertNil(result.recommendedModel)
-        XCTAssertEqual(result.candidates.count, 5)
-        XCTAssertFalse(result.candidates.contains { $0.catalogKey == donorKey })
+        XCTAssertEqual(result.candidates.count, 6)
+        XCTAssertTrue(result.candidates.contains { $0.catalogKey == donorKey })
         XCTAssertEqual(result.donorFallbackModel, donorKey)
         XCTAssertEqual(result.donorFallbackCandidate?.catalogKey, donorKey)
         XCTAssertFalse(result.jsonString().contains("donorFallbackCandidate"))
         XCTAssertFalse(result.jsonString().contains("donor_fallback_candidate"))
+        let root = try XCTUnwrap(JSONSerialization.jsonObject(with: Data(result.jsonString().utf8)) as? [String: Any])
+        let fallback = try XCTUnwrap(root["donor_fallback_explanation"] as? [String: Any])
+        XCTAssertEqual(fallback["warning_state"] as? String, "blocked")
+        XCTAssertEqual(fallback["lost_reason"] as? String, "demand_not_recommendable")
+        let earning = try XCTUnwrap(fallback["earning_potential"] as? [String: Any])
+        XCTAssertEqual(earning["kind"] as? String, "relative_ranking_score")
     }
 
     func testDonorModeRejectsBlockedRows() throws {
@@ -1194,8 +1290,13 @@ final class AutotuneRecommendTests: XCTestCase {
         XCTAssertLessThan(try XCTUnwrap(json.range(of: #""hardware":"#)?.lowerBound), try XCTUnwrap(json.range(of: #""inputs":"#)?.lowerBound))
         XCTAssertLessThan(try XCTUnwrap(json.range(of: #""inputs":"#)?.lowerBound), try XCTUnwrap(json.range(of: #""recommended_model":"#)?.lowerBound))
         XCTAssertLessThan(try XCTUnwrap(json.range(of: #""recommended_model":"#)?.lowerBound), try XCTUnwrap(json.range(of: #""prompt_rate_usd_per_million_tokens":"#)?.lowerBound))
-        XCTAssertLessThan(try XCTUnwrap(json.range(of: #""prompt_rate_usd_per_million_tokens":"#)?.lowerBound), try XCTUnwrap(json.range(of: #""candidates":"#)?.lowerBound))
+        XCTAssertLessThan(try XCTUnwrap(json.range(of: #""prompt_rate_usd_per_million_tokens":"#)?.lowerBound), try XCTUnwrap(json.range(of: #""completion_rate_usd_per_million_tokens":"#)?.lowerBound))
+        XCTAssertLessThan(try XCTUnwrap(json.range(of: #""completion_rate_usd_per_million_tokens":"#)?.lowerBound), try XCTUnwrap(json.range(of: #""serve_config":"#)?.lowerBound))
+        XCTAssertLessThan(try XCTUnwrap(json.range(of: #""serve_config":"#)?.lowerBound), try XCTUnwrap(json.range(of: #""candidates":"#)?.lowerBound))
         XCTAssertLessThan(try XCTUnwrap(json.range(of: #""candidates":"#)?.lowerBound), try XCTUnwrap(json.range(of: #""warnings":"#)?.lowerBound))
+        XCTAssertLessThan(try XCTUnwrap(json.range(of: #""warnings":"#)?.lowerBound), try XCTUnwrap(json.range(of: #""selected_explanation":"#)?.lowerBound))
+        XCTAssertLessThan(try XCTUnwrap(json.range(of: #""selected_explanation":"#)?.lowerBound), try XCTUnwrap(json.range(of: #""alternative_explanations":"#)?.lowerBound))
+        XCTAssertLessThan(try XCTUnwrap(json.range(of: #""alternative_explanations":"#)?.lowerBound), try XCTUnwrap(json.range(of: #""donor_fallback_explanation":"#)?.lowerBound))
     }
 
     func testSignedStaticFallbackAndStaleWarnings() async throws {
@@ -2973,6 +3074,74 @@ final class AutotuneRecommendTests: XCTestCase {
             result.allCandidates.contains { $0.catalogKey == modelKey && !$0.eligible && $0.why.localizedCaseInsensitiveContains("swap") }
         )
         XCTAssertTrue(result.humanTranscript().localizedCaseInsensitiveContains("swap"))
+        let root = try XCTUnwrap(JSONSerialization.jsonObject(with: Data(result.jsonString().utf8)) as? [String: Any])
+        let jsonCandidate = try XCTUnwrap((root["candidates"] as? [[String: Any]])?.first)
+        let explanation = try XCTUnwrap(jsonCandidate["explanation"] as? [String: Any])
+        let health = try XCTUnwrap(explanation["local_health"] as? [String: Any])
+        XCTAssertEqual(explanation["warning_state"] as? String, "blocked")
+        XCTAssertEqual(explanation["lost_reason"] as? String, "swap_observed_under_load")
+        XCTAssertEqual(health["warnings"] as? [String], ["swap_observed_under_load"])
+    }
+
+    func testUnavailableRateCardInputExplainsNonEarningRecommendation() throws {
+        var request = try makeRequest()
+        let modelKey = "qwen3-coder-30b-a3b-instruct"
+        request.rateCard.rows = [:]
+
+        let result = AutotuneRecommendEngine().recommend(request)
+        let root = try XCTUnwrap(JSONSerialization.jsonObject(with: Data(result.jsonString().utf8)) as? [String: Any])
+        let jsonCandidate = try XCTUnwrap((root["candidates"] as? [[String: Any]])?.first)
+        let explanation = try XCTUnwrap(jsonCandidate["explanation"] as? [String: Any])
+        let rate = try XCTUnwrap(explanation["rate_signal"] as? [String: Any])
+
+        XCTAssertNil(result.recommendedModel)
+        XCTAssertTrue(result.warnings.contains(.noEligibleModel))
+        XCTAssertEqual(jsonCandidate["model"] as? String, modelKey)
+        XCTAssertEqual(explanation["warning_state"] as? String, "blocked")
+        XCTAssertEqual(explanation["lost_reason"] as? String, "rate_card_unavailable")
+        XCTAssertEqual(rate["provider_share_bps"] as? Int, 0)
+        XCTAssertEqual(rate["provider_completion_payout_usd_per_million_tokens"] as? Double, 0)
+    }
+
+    func testUnavailableDemandInputExplainsNonEarningRecommendation() throws {
+        var request = try makeRequest()
+        let modelKey = "qwen3-coder-30b-a3b-instruct"
+        request.demandRank.rows = [:]
+
+        let result = AutotuneRecommendEngine().recommend(request)
+        let root = try XCTUnwrap(JSONSerialization.jsonObject(with: Data(result.jsonString().utf8)) as? [String: Any])
+        let jsonCandidate = try XCTUnwrap((root["candidates"] as? [[String: Any]])?.first)
+        let explanation = try XCTUnwrap(jsonCandidate["explanation"] as? [String: Any])
+        let demand = try XCTUnwrap(explanation["demand_signal"] as? [String: Any])
+        let earning = try XCTUnwrap(explanation["earning_potential"] as? [String: Any])
+
+        XCTAssertNil(result.recommendedModel)
+        XCTAssertTrue(result.warnings.contains(.noEligibleModel))
+        XCTAssertEqual(jsonCandidate["model"] as? String, modelKey)
+        XCTAssertEqual(explanation["warning_state"] as? String, "blocked")
+        XCTAssertEqual(explanation["lost_reason"] as? String, "demand_signal_unavailable")
+        XCTAssertEqual(demand["weight"] as? Double, 0)
+        XCTAssertEqual(demand["recommendable"] as? Bool, false)
+        XCTAssertEqual(demand["supply_deficit_multiplier"] as? Double, 0)
+        XCTAssertEqual(earning["score"] as? Double, 0)
+    }
+
+    func testMissingBenchmarkExplainsThroughputUnavailable() throws {
+        var request = try makeRequest()
+        let modelKey = "qwen3-coder-30b-a3b-instruct"
+        request.benchmarks = [:]
+
+        let result = AutotuneRecommendEngine().recommend(request)
+        let root = try XCTUnwrap(JSONSerialization.jsonObject(with: Data(result.jsonString().utf8)) as? [String: Any])
+        let candidate = try XCTUnwrap((root["candidates"] as? [[String: Any]])?.first)
+        let explanation = try XCTUnwrap(candidate["explanation"] as? [String: Any])
+
+        XCTAssertNil(result.recommendedModel)
+        XCTAssertEqual(candidate["model"] as? String, modelKey)
+        XCTAssertEqual(explanation["warning_state"] as? String, "blocked")
+        XCTAssertEqual(explanation["lost_reason"] as? String, "benchmark_unavailable")
+        XCTAssertEqual(explanation["throughput_source"] as? String, "unavailable")
+        XCTAssertEqual(explanation["measured_tps"] as? Double, 0)
     }
 
     /// AC-1/AC-2/AC-5 for #742: replay the recorded 2026-07-23 M5/32 GB

--- a/phase3-binary/app/Sources/Malibu/Dashboard/DashboardWindow.swift
+++ b/phase3-binary/app/Sources/Malibu/Dashboard/DashboardWindow.swift
@@ -145,18 +145,26 @@ private struct DashboardView: View {
             .padding(12)
             .background(RoundedRectangle(cornerRadius: 8).fill(Color.gray.opacity(0.08)))
 
-            if let recommendation = modelStore.recommendation,
-               let target = recommendation.recommendedModel {
+            if let recommendation = modelStore.recommendation {
                 VStack(alignment: .leading, spacing: 7) {
-                    Text(String(localized: "Recommended installed model", comment: "Dashboard recommendation title"))
+                    Text(recommendation.isRecommendationResult
+                        ? String(localized: "Recommended installed model", comment: "Dashboard recommendation title")
+                        : String(localized: "No installed model recommendation", comment: "Dashboard no recommendation title"))
                         .font(.caption.weight(.semibold))
-                    Text(target)
-                        .font(.body.monospaced())
-                        .lineLimit(2)
-                        .truncationMode(.middle)
-                    if let why = recommendation.recommendedCandidate?.why {
-                        Text(why)
+                    if let target = recommendation.displayModelID {
+                        Text(target)
+                            .font(.body.monospaced())
+                            .lineLimit(2)
+                            .truncationMode(.middle)
+                    }
+                    if let rationale = recommendation.displayRationale {
+                        Text(rationale)
                             .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+                    ForEach(recommendation.displayEvidenceLines, id: \.self) { line in
+                        Text(line)
+                            .font(.caption2)
                             .foregroundStyle(.secondary)
                     }
                     Text(String(localized: "Scope: signed catalog \(recommendation.inputs.candidateCatalogVersion) for \(recommendation.hardware.chip), \(recommendation.hardware.memoryGB) GB.", comment: "Recommendation evidence scope"))
@@ -180,12 +188,14 @@ private struct DashboardView: View {
                             .fixedSize(horizontal: false, vertical: true)
                     }
                     HStack {
-                        Button(String(localized: "Adopt", comment: "Dashboard recommendation action")) {
-                            Task { await modelStore.adoptRecommendation() }
-                        }
-                        .disabled(!modelStore.canAdoptRecommendation)
-                        Button(String(localized: "Not now", comment: "Dashboard recommendation snooze")) {
-                            modelStore.snoozeRecommendation()
+                        if recommendation.isRecommendationResult {
+                            Button(String(localized: "Adopt", comment: "Dashboard recommendation action")) {
+                                Task { await modelStore.adoptRecommendation() }
+                            }
+                            .disabled(!modelStore.canAdoptRecommendation)
+                            Button(String(localized: "Not now", comment: "Dashboard recommendation snooze")) {
+                                modelStore.snoozeRecommendation()
+                            }
                         }
                         Button(String(localized: "Stop background recommendations", comment: "Dashboard recommendation opt-out")) {
                             modelStore.stopBackgroundRecommendations()

--- a/phase3-binary/app/Sources/Malibu/ModelManagement/ModelManagement.swift
+++ b/phase3-binary/app/Sources/Malibu/ModelManagement/ModelManagement.swift
@@ -1305,11 +1305,13 @@ final class ModelManagementStore: ObservableObject {
                 recommendationLine = String(localized: "Recommended installed model: \(target)", comment: "Recommendation available")
                 MalibuAccessibility.announce(String(localized: "A new installed model recommendation is available for \(target).", comment: "Recommendation VoiceOver announcement"))
             } else {
-                recommendation = nil
+                recommendation = document.hasVisibleWhyNotFeedback ? document : nil
                 recommendationJSON = nil
                 if let identity = document.identity(currentModelID: currentModelID),
                    recommendationSchedule.suppresses(identity: identity, at: now) {
                     recommendationLine = String(localized: "The current recommendation is hidden until its inputs change or the 24-hour snooze ends.", comment: "Recommendation identity snoozed")
+                } else if document.hasVisibleWhyNotFeedback {
+                    recommendationLine = String(localized: "Checked installed models; no installed model is recommended right now.", comment: "No recommendation with explanation result")
                 } else {
                     recommendationLine = String(localized: "Checked installed models; no new recommendation is available.", comment: "No recommendation result")
                 }

--- a/phase3-binary/app/Sources/Malibu/ModelManagement/ModelManagementViews.swift
+++ b/phase3-binary/app/Sources/Malibu/ModelManagement/ModelManagementViews.swift
@@ -75,9 +75,8 @@ struct ModelSwitcherSheet: View {
                 .fixedSize(horizontal: false, vertical: true)
                 .accessibilityAddTraits(.updatesFrequently)
 
-            if let recommendation = store.recommendation,
-               let target = recommendation.recommendedModel {
-                recommendationCallout(recommendation, target: target)
+            if let recommendation = store.recommendation {
+                recommendationCallout(recommendation)
             }
 
             if store.listState == .checking {
@@ -156,21 +155,28 @@ struct ModelSwitcherSheet: View {
         store.canPerformModelAction
     }
 
-    private func recommendationCallout(
-        _ recommendation: MalibuRecommendationDocument,
-        target: String
-    ) -> some View {
+    private func recommendationCallout(_ recommendation: MalibuRecommendationDocument) -> some View {
         VStack(alignment: .leading, spacing: 8) {
-            Text(ModelFeatureUI.recommended)
+            Text(recommendation.isRecommendationResult
+                ? ModelFeatureUI.recommended
+                : String(localized: "No installed model recommendation", comment: "No recommendation callout title"))
                 .font(.headline)
-            Text(target)
-                .font(.body.monospaced())
-                .lineLimit(2)
-                .truncationMode(.middle)
-                .textSelection(.enabled)
-            if let why = recommendation.recommendedCandidate?.why {
-                Text(why)
+            if let target = recommendation.displayModelID {
+                Text(target)
+                    .font(.body.monospaced())
+                    .lineLimit(2)
+                    .truncationMode(.middle)
+                    .textSelection(.enabled)
+            }
+            if let rationale = recommendation.displayRationale {
+                Text(rationale)
                     .font(.callout)
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+            ForEach(recommendation.displayEvidenceLines, id: \.self) { line in
+                Text(line)
+                    .font(.caption)
                     .foregroundStyle(.secondary)
                     .fixedSize(horizontal: false, vertical: true)
             }
@@ -189,13 +195,17 @@ struct ModelSwitcherSheet: View {
                     .foregroundStyle(.orange)
             }
             HStack {
-                Button(ModelFeatureUI.adopt) {
-                    Task { await store.adoptRecommendation() }
+                if recommendation.isRecommendationResult {
+                    Button(ModelFeatureUI.adopt) {
+                        Task { await store.adoptRecommendation() }
+                    }
+                    .disabled(!store.canAdoptRecommendation)
+                    .keyboardShortcut(.defaultAction)
+                    .accessibilityHint(Text(String(localized: "The provider validates, applies, switches, and verifies this recommendation as one transaction.", comment: "Adopt accessibility hint")))
+                    Button(ModelFeatureUI.notNow) {
+                        store.snoozeRecommendation()
+                    }
                 }
-                .disabled(!store.canAdoptRecommendation)
-                .keyboardShortcut(.defaultAction)
-                .accessibilityHint(Text(String(localized: "The provider validates, applies, switches, and verifies this recommendation as one transaction.", comment: "Adopt accessibility hint")))
-                Button(ModelFeatureUI.notNow) { store.snoozeRecommendation() }
                 Button(ModelFeatureUI.stopBackground) { store.stopBackgroundRecommendations() }
             }
             if let unavailableReason = store.recommendationAdoptionUnavailableReason {

--- a/phase3-binary/app/Sources/Malibu/ModelManagement/RecommendationManagement.swift
+++ b/phase3-binary/app/Sources/Malibu/ModelManagement/RecommendationManagement.swift
@@ -75,11 +75,116 @@ struct MalibuRecommendationDocument: Decodable, Equatable, Sendable {
         let why: String
         let promptRateUSDPerMillionTokens: Double?
         let completionRateUSDPerMillionTokens: Double?
+        let tokensPerSecond: Double?
+        let memoryHeadroomGB: Double?
+        let rawScore: Double?
+        let explanation: Explanation?
 
         enum CodingKeys: String, CodingKey {
             case rank, model, eligible, confidence, why
             case promptRateUSDPerMillionTokens = "prompt_rate_usd_per_million_tokens"
             case completionRateUSDPerMillionTokens = "completion_rate_usd_per_million_tokens"
+            case tokensPerSecond = "tokens_per_second"
+            case memoryHeadroomGB = "memory_headroom_gb"
+            case rawScore = "raw_score"
+            case explanation
+        }
+    }
+
+    struct Explanation: Decodable, Equatable, Sendable {
+        struct MemoryFit: Decodable, Equatable, Sendable {
+            let requiredGB: Int
+            let totalGB: Int
+            let safetyMarginGB: Int
+            let headroomGB: Double
+
+            enum CodingKeys: String, CodingKey {
+                case requiredGB = "required_gb"
+                case totalGB = "total_gb"
+                case safetyMarginGB = "safety_margin_gb"
+                case headroomGB = "headroom_gb"
+            }
+        }
+
+        struct DemandSignal: Decodable, Equatable, Sendable {
+            let rank: Int?
+            let weight: Double
+            let recommendable: Bool
+            let minProviderTarget: Int
+            let readyProviderCount: Int?
+            let supplyDeficitMultiplier: Double
+
+            enum CodingKeys: String, CodingKey {
+                case rank, weight, recommendable
+                case minProviderTarget = "min_provider_target"
+                case readyProviderCount = "ready_provider_count"
+                case supplyDeficitMultiplier = "supply_deficit_multiplier"
+            }
+        }
+
+        struct RateSignal: Decodable, Equatable, Sendable {
+            let promptRateUSDPerMillionTokens: Double
+            let completionRateUSDPerMillionTokens: Double
+            let providerShareBPS: Int
+            let providerCompletionPayoutUSDPerMillionTokens: Double
+
+            enum CodingKeys: String, CodingKey {
+                case promptRateUSDPerMillionTokens = "prompt_rate_usd_per_million_tokens"
+                case completionRateUSDPerMillionTokens = "completion_rate_usd_per_million_tokens"
+                case providerShareBPS = "provider_share_bps"
+                case providerCompletionPayoutUSDPerMillionTokens = "provider_completion_payout_usd_per_million_tokens"
+            }
+        }
+
+        struct EarningPotential: Decodable, Equatable, Sendable {
+            let score: Double
+            let kind: String
+            let note: String
+        }
+
+        struct LocalHealth: Decodable, Equatable, Sendable {
+            let warnings: [String]
+        }
+
+        let summary: String
+        let warningState: String
+        let measuredTPS: Double
+        let throughputSource: String
+        let memoryFit: MemoryFit
+        let demandSignal: DemandSignal
+        let rateSignal: RateSignal
+        let earningPotential: EarningPotential
+        let localHealth: LocalHealth
+        let confidence: String
+        let lostReason: String
+
+        enum CodingKeys: String, CodingKey {
+            case summary
+            case warningState = "warning_state"
+            case measuredTPS = "measured_tps"
+            case throughputSource = "throughput_source"
+            case memoryFit = "memory_fit"
+            case demandSignal = "demand_signal"
+            case rateSignal = "rate_signal"
+            case earningPotential = "earning_potential"
+            case localHealth = "local_health"
+            case confidence
+            case lostReason = "lost_reason"
+        }
+    }
+
+    struct AlternativeExplanation: Decodable, Equatable, Sendable {
+        let rank: Int
+        let model: String
+        let eligible: Bool
+        let lostReason: String
+        let summary: String
+        let expectedEarningPotentialScore: Double
+
+        enum CodingKeys: String, CodingKey {
+            case rank, model, eligible, summary
+            case lostReason = "lost_reason"
+            case expectedEarningPotentialScore = "expected_earning_potential_score"
         }
     }
 
@@ -91,6 +196,9 @@ struct MalibuRecommendationDocument: Decodable, Equatable, Sendable {
     let promptRateUSDPerMillionTokens: Double?
     let completionRateUSDPerMillionTokens: Double?
     let serveConfig: ServeConfig?
+    let selectedExplanation: Explanation?
+    let alternativeExplanations: [AlternativeExplanation]
+    let donorFallbackExplanation: Explanation?
     let candidates: [Candidate]
     let warnings: [String]
 
@@ -102,7 +210,27 @@ struct MalibuRecommendationDocument: Decodable, Equatable, Sendable {
         case promptRateUSDPerMillionTokens = "prompt_rate_usd_per_million_tokens"
         case completionRateUSDPerMillionTokens = "completion_rate_usd_per_million_tokens"
         case serveConfig = "serve_config"
+        case selectedExplanation = "selected_explanation"
+        case alternativeExplanations = "alternative_explanations"
+        case donorFallbackExplanation = "donor_fallback_explanation"
         case candidates, warnings
+    }
+
+    init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        schemaVersion = try c.decode(String.self, forKey: .schemaVersion)
+        generatedAt = try c.decode(String.self, forKey: .generatedAt)
+        hardware = try c.decode(Hardware.self, forKey: .hardware)
+        inputs = try c.decode(Inputs.self, forKey: .inputs)
+        recommendedModel = try c.decodeIfPresent(String.self, forKey: .recommendedModel)
+        promptRateUSDPerMillionTokens = try c.decodeIfPresent(Double.self, forKey: .promptRateUSDPerMillionTokens)
+        completionRateUSDPerMillionTokens = try c.decodeIfPresent(Double.self, forKey: .completionRateUSDPerMillionTokens)
+        serveConfig = try c.decodeIfPresent(ServeConfig.self, forKey: .serveConfig)
+        selectedExplanation = try c.decodeIfPresent(Explanation.self, forKey: .selectedExplanation)
+        alternativeExplanations = try c.decodeIfPresent([AlternativeExplanation].self, forKey: .alternativeExplanations) ?? []
+        donorFallbackExplanation = try c.decodeIfPresent(Explanation.self, forKey: .donorFallbackExplanation)
+        candidates = try c.decode([Candidate].self, forKey: .candidates)
+        warnings = try c.decode([String].self, forKey: .warnings)
     }
 
     func validated(now: Date = Date()) throws -> MalibuRecommendationDocument {
@@ -111,36 +239,71 @@ struct MalibuRecommendationDocument: Decodable, Equatable, Sendable {
               generated <= now.addingTimeInterval(60),
               now.timeIntervalSince(generated) <= 7 * 24 * 60 * 60,
               hardware.memoryGB > 0,
-              !hardware.chip.isEmpty,
-              !hardware.binaryVersion.isEmpty,
-              !inputs.rateCardVersion.isEmpty,
-              !inputs.demandRankVersion.isEmpty,
-              !inputs.candidateCatalogVersion.isEmpty else {
+              Self.isSafeDisplayText(hardware.chip, maxLength: 128),
+              hardware.machine.map({ Self.isSafeDisplayText($0, maxLength: 64) }) ?? true,
+              Self.isSafeDisplayText(hardware.bandwidthTier, maxLength: 32),
+              Self.isSafeDisplayText(hardware.osVersion, maxLength: 64),
+              Self.isSafeDisplayText(hardware.binaryVersion, maxLength: 64),
+              Self.isSafeDisplayText(inputs.rateCardVersion, maxLength: 128),
+              Self.isSafeDisplayText(inputs.demandRankVersion, maxLength: 128),
+              Self.isSafeDisplayText(inputs.candidateCatalogVersion, maxLength: 128),
+              Self.validateOptionalRate(promptRateUSDPerMillionTokens),
+              Self.validateOptionalRate(completionRateUSDPerMillionTokens) else {
             throw MalibuRecommendationError.invalidDocument
         }
-        guard let recommendedModel else { return self }
-        guard isSafeRecommendationID(recommendedModel),
+        let structuredExplanations = candidates.compactMap(\.explanation)
+            + [selectedExplanation, donorFallbackExplanation].compactMap { $0 }
+        guard structuredExplanations.allSatisfy(Self.validateExplanation),
+              alternativeExplanations.allSatisfy(Self.validateAlternativeExplanation),
+              Self.validateAlternativeEvidence(alternativeExplanations, candidates: candidates, selectedModel: recommendedModel),
+              Self.validateDonorFallbackEvidence(donorFallbackExplanation, candidates: candidates),
+              candidates.allSatisfy(Self.validateCandidate),
+              candidates.allSatisfy({ Self.validateCandidateEvidence($0, hardware: hardware) }),
+              warnings.allSatisfy(Self.validateRootWarning) else {
+            throw MalibuRecommendationError.invalidDocument
+        }
+        guard let recommendedModel else {
+            guard selectedExplanation == nil,
+                  promptRateUSDPerMillionTokens == nil,
+                  completionRateUSDPerMillionTokens == nil,
+                  serveConfig.map(Self.validateDonorServeConfig) ?? true,
+                  candidates.allSatisfy(Self.validateNoRecommendationCandidate) else {
+                throw MalibuRecommendationError.invalidDocument
+            }
+            return self
+        }
+        let selectedCandidates = candidates.filter { $0.model == recommendedModel }
+        guard Self.isSafeVisibleRecommendationID(recommendedModel),
+              selectedCandidates.count == 1,
               let serveConfig,
               serveConfig.model == recommendedModel,
-              isSafeRecommendationID(serveConfig.model),
-              !serveConfig.modelArtifactPath.isEmpty,
-              serveConfig.modelArtifactPath.hasPrefix("/"),
-              Self.isLowerHex(serveConfig.modelArtifactSHA256, count: 64),
-              !serveConfig.modelCatalogKey.isEmpty,
-              isSafeRecommendationID(serveConfig.modelCatalogModelID),
+              !serveConfig.donorMode,
+              Self.validateServeConfig(serveConfig),
               serveConfig.modelCatalogModelID == recommendedModel,
-              !serveConfig.modelCatalogRevision.isEmpty,
-              Self.isLowerHex(serveConfig.modelCatalogSHA256, count: 64),
-              !serveConfig.modelCatalogVersion.isEmpty,
-              Self.isLowerHex(serveConfig.modelCatalogHash, count: 64),
-              serveConfig.maxContextOverride > 0,
-              serveConfig.maxConcurrencyOverride > 0,
-              (serveConfig.draftModel == nil) == (serveConfig.draftModelArtifactSHA256 == nil) else {
+              Self.validateRecommendedCandidateSemantics(
+                  selectedCandidates[0],
+                  selectedExplanation: selectedExplanation
+              ),
+              Self.selectedRatesAreBound(
+                  candidate: selectedCandidates[0],
+                  selectedExplanation: selectedExplanation,
+                  promptRate: promptRateUSDPerMillionTokens,
+                  completionRate: completionRateUSDPerMillionTokens
+              ) else {
+            throw MalibuRecommendationError.invalidDocument
+        }
+        let candidateExplanation = selectedCandidates[0].explanation
+        switch (selectedExplanation, candidateExplanation) {
+        case (nil, nil):
+            throw MalibuRecommendationError.invalidDocument
+        case (let selected?, let candidate?) where selected == candidate:
+            break
+        default:
             throw MalibuRecommendationError.invalidDocument
         }
         if let draftModel = serveConfig.draftModel,
            let draftHash = serveConfig.draftModelArtifactSHA256 {
-            guard isSafeRecommendationID(draftModel),
+            guard Self.isSafeVisibleRecommendationID(draftModel),
                   Self.isLowerHex(draftHash, count: 64) else {
                 throw MalibuRecommendationError.invalidDocument
             }
@@ -149,11 +312,7 @@ struct MalibuRecommendationDocument: Decodable, Equatable, Sendable {
     }
 
     var isActionable: Bool {
-        guard let recommendedModel, let serveConfig else { return false }
-        return serveConfig.draftModel == nil
-            && serveConfig.draftModelArtifactSHA256 == nil
-            && Self.adoptionBlockingWarnings.isDisjoint(with: Set(warnings))
-            && candidates.contains(where: { $0.model == recommendedModel && $0.eligible })
+        false
     }
 
     var adoptionAdvisoryReason: String? {
@@ -172,7 +331,125 @@ struct MalibuRecommendationDocument: Decodable, Equatable, Sendable {
 
     var recommendedCandidate: Candidate? {
         guard let recommendedModel else { return nil }
-        return candidates.first { $0.model == recommendedModel }
+        let selectedCandidates = candidates.filter { $0.model == recommendedModel }
+        guard selectedCandidates.count == 1 else { return nil }
+        return selectedCandidates[0]
+    }
+
+    var selectedRationale: String? {
+        selectedExplanation?.summary ?? recommendedCandidate?.explanation?.summary
+    }
+
+    var selectedEvidenceLines: [String] {
+        guard let explanation = selectedExplanation ?? recommendedCandidate?.explanation else {
+            return []
+        }
+        return evidenceLines(for: explanation)
+    }
+
+    var hasVisibleRecommendationFeedback: Bool {
+        recommendedModel != nil || hasVisibleWhyNotFeedback
+    }
+
+    var hasVisibleWhyNotFeedback: Bool {
+        recommendedModel == nil
+            && (primaryDisplayExplanation != nil
+            || recommendedCandidate != nil
+        )
+    }
+
+    var displayModelID: String? {
+        recommendedModel ?? primaryDisplayCandidate?.model
+    }
+
+    var displayRationale: String? {
+        selectedRationale
+            ?? primaryDisplayExplanation?.summary
+            ?? primaryDisplayCandidate?.why
+    }
+
+    var displayEvidenceLines: [String] {
+        guard let explanation = selectedExplanation ?? primaryDisplayExplanation else {
+            return []
+        }
+        return evidenceLines(for: explanation)
+    }
+
+    var isRecommendationResult: Bool {
+        recommendedModel != nil
+    }
+
+    private var primaryDisplayCandidate: Candidate? {
+        donorFallbackDisplayCandidate
+            ?? candidates.sorted { $0.rank < $1.rank }.first { $0.explanation != nil }
+            ?? candidates.sorted { $0.rank < $1.rank }.first
+    }
+
+    private var primaryDisplayExplanation: Explanation? {
+        donorFallbackDisplayCandidate?.explanation
+            ?? primaryDisplayCandidate?.explanation
+    }
+
+    private var donorFallbackDisplayCandidate: Candidate? {
+        guard let donorFallbackExplanation else { return nil }
+        return candidates.sorted { $0.rank < $1.rank }.first { $0.explanation == donorFallbackExplanation }
+    }
+
+    private func evidenceLines(for explanation: Explanation) -> [String] {
+        let memory = explanation.memoryFit
+        let demand = explanation.demandSignal
+        let rate = explanation.rateSignal
+        let demandRank = demand.rank.map { "#\($0)" } ?? "unranked"
+        let providerShare = Double(rate.providerShareBPS) / 100.0
+        let throughputLabel: String
+        switch explanation.throughputSource {
+        case "catalog_estimate":
+            throughputLabel = "Catalog estimate"
+        case "unavailable":
+            throughputLabel = "Throughput unavailable"
+        case "measured":
+            throughputLabel = "Measured"
+        default:
+            throughputLabel = "Throughput"
+        }
+        let throughputLine = explanation.throughputSource == "unavailable"
+            ? String(
+                format: "%@; memory headroom %.1f GB after %d GB safety margin.",
+                throughputLabel,
+                memory.headroomGB,
+                memory.safetyMarginGB
+            )
+            : String(
+                format: "%@ %.2f tok/s; memory headroom %.1f GB after %d GB safety margin.",
+                throughputLabel,
+                explanation.measuredTPS,
+                memory.headroomGB,
+                memory.safetyMarginGB
+            )
+        var lines = [
+            "State \(explanation.warningState); confidence \(explanation.confidence).",
+            throughputLine,
+            String(
+                format: "Demand %@, weight %.2f, supply %.2fx, ready %@/%d.",
+                demandRank,
+                demand.weight,
+                demand.supplyDeficitMultiplier,
+                demand.readyProviderCount.map(String.init) ?? "unknown",
+                demand.minProviderTarget
+            ),
+            String(
+                format: "Provider share %.2f%%; earning potential score %.2f, not accrued rewards.",
+                providerShare,
+                explanation.earningPotential.score
+            ),
+        ]
+        if !explanation.localHealth.warnings.isEmpty {
+            lines.append("Local health: \(explanation.localHealth.warnings.joined(separator: ", ")).")
+        }
+        for alternative in alternativeExplanations.prefix(3) {
+            lines.append("Alternative \(alternative.rank): \(alternative.model) - \(alternative.summary)")
+        }
+        return lines
     }
 
     func identity(currentModelID: String?) -> MalibuRecommendationIdentity? {
@@ -202,6 +479,395 @@ struct MalibuRecommendationDocument: Decodable, Equatable, Sendable {
         "thermal_throttle_detected",
         "thermal_throttled",
     ]
+
+    private static let knownRootWarnings: Set<String> = [
+        "candidate_catalog_fallback_used",
+        "candidate_catalog_integrity_failure",
+        "candidate_catalog_update_required",
+        "candidate_catalog_stale",
+        "demand_rank_fallback_used",
+        "demand_rank_integrity_failure",
+        "demand_rank_update_required",
+        "demand_rank_stale",
+        "hardware_tier_unknown",
+        "rate_card_fallback_used",
+        "rate_card_integrity_failure",
+        "rate_card_update_required",
+        "rate_card_stale",
+        "no_eligible_model",
+        "rate_card_default_tier_used",
+        "swap_observed_under_load",
+        "tps_below_gate",
+        "ttft_above_gate",
+        "buyer_ttft_ceiling_exceeded",
+        "thermal_throttle_detected",
+        "thermal_throttled",
+    ]
+
+    private static let knownThroughputSources: Set<String> = [
+        "measured",
+        "catalog_estimate",
+        "unavailable",
+    ]
+
+    private static let noRecommendationLostReasons: Set<String> = [
+        "paid_trust_blocked",
+        "demand_not_recommendable",
+        "demand_signal_unavailable",
+        "runtime_not_recommendable",
+        "rate_card_unavailable",
+        "missing_model_artifact_identity",
+        "insufficient_memory_headroom",
+        "bandwidth_tier_below_minimum",
+        "benchmark_unavailable",
+        "thermal_throttle_detected",
+        "swap_observed_under_load",
+        "buyer_ttft_ceiling_exceeded",
+        "benchmark_evidence_stale_or_mismatched",
+        "unknown_recommendation_gate",
+    ]
+
+    private static let knownWarningStates: Set<String> = [
+        "ready",
+        "advisory",
+        "blocked",
+    ]
+
+    private static let knownConfidenceValues: Set<String> = [
+        "high",
+        "medium",
+        "low",
+        "catalog_estimate",
+    ]
+
+    private static let knownLocalHealthWarnings: Set<String> = [
+        "thermal_throttle_detected",
+        "thermal_throttled",
+        "swap_observed_under_load",
+        "buyer_ttft_ceiling_exceeded",
+    ]
+
+    private static let forbiddenDisplayFragments = [
+        "/private/",
+        "/users/",
+        "/var/",
+        "/tmp/",
+        "file://",
+        "model_artifact_path",
+        "model_artifact_sha256",
+        "artifact_path",
+        "artifact_sha",
+        "provider_id",
+        "provider id",
+        "provider_identity",
+        "hardware_identity",
+        "hardware identity",
+        "hardware_identity_hash",
+        "hmac",
+        "private key",
+        "daily_income",
+        "daily income",
+        "daily_usd",
+        "usd/day",
+        "/day",
+        "per day",
+        "per week",
+        "every 24 hours",
+        "every week",
+        "will pay",
+        "will earn",
+        "regardless of demand",
+        "hourly",
+        "guaranteed",
+        "guarantee",
+        "$",
+    ]
+
+    private static func validateExplanation(_ explanation: Explanation) -> Bool {
+        let memory = explanation.memoryFit
+        let demand = explanation.demandSignal
+        let rate = explanation.rateSignal
+        let earning = explanation.earningPotential
+
+        return isSafeDisplayText(explanation.summary, maxLength: 200)
+            && knownWarningStates.contains(explanation.warningState)
+            && explanation.measuredTPS.isFinite
+            && explanation.measuredTPS >= 0
+            && knownThroughputSources.contains(explanation.throughputSource)
+            && memory.requiredGB > 0
+            && memory.requiredGB <= 1_024
+            && memory.totalGB > 0
+            && memory.totalGB <= 1_024
+            && memory.safetyMarginGB >= 0
+            && memory.safetyMarginGB <= 1_024
+            && memory.headroomGB.isFinite
+            && demand.weight.isFinite
+            && demand.weight >= 0
+            && demand.minProviderTarget >= 0
+            && (demand.readyProviderCount == nil || demand.readyProviderCount! >= 0)
+            && demand.supplyDeficitMultiplier.isFinite
+            && demand.supplyDeficitMultiplier >= 0
+            && rate.promptRateUSDPerMillionTokens.isFinite
+            && rate.promptRateUSDPerMillionTokens >= 0
+            && rate.completionRateUSDPerMillionTokens.isFinite
+            && rate.completionRateUSDPerMillionTokens >= 0
+            && (0...10_000).contains(rate.providerShareBPS)
+            && rate.providerCompletionPayoutUSDPerMillionTokens.isFinite
+            && rate.providerCompletionPayoutUSDPerMillionTokens >= 0
+            && earning.score.isFinite
+            && earning.score >= 0
+            && earning.kind == "relative_ranking_score"
+            && earning.note == "Estimated earning potential only; actual rewards depend on buyer demand, uptime, accepted work, and settlement."
+            && explanation.localHealth.warnings.allSatisfy { knownLocalHealthWarnings.contains($0) }
+            && knownConfidenceValues.contains(explanation.confidence)
+            && isSafeSlug(explanation.lostReason, maxLength: 96)
+    }
+
+    private static func validateAlternativeExplanation(_ explanation: AlternativeExplanation) -> Bool {
+        explanation.rank > 0
+            && isSafeVisibleRecommendationID(explanation.model)
+            && isSafeSlug(explanation.lostReason, maxLength: 96)
+            && isSafeDisplayText(explanation.summary, maxLength: 240)
+            && explanation.expectedEarningPotentialScore.isFinite
+            && explanation.expectedEarningPotentialScore >= 0
+    }
+
+    private static func validateCandidate(_ candidate: Candidate) -> Bool {
+        candidate.rank > 0
+            && isSafeVisibleRecommendationID(candidate.model)
+            && knownConfidenceValues.contains(candidate.confidence)
+            && isSafeDisplayText(candidate.why, maxLength: 320)
+            && validateOptionalRate(candidate.promptRateUSDPerMillionTokens)
+            && validateOptionalRate(candidate.completionRateUSDPerMillionTokens)
+            && validateOptionalRate(candidate.tokensPerSecond)
+            && (candidate.memoryHeadroomGB.map { $0.isFinite } ?? true)
+            && validateOptionalRate(candidate.rawScore)
+    }
+
+    private static func validateNoRecommendationCandidate(_ candidate: Candidate) -> Bool {
+        guard !candidate.eligible,
+              isNoRecommendationDisplayText(candidate.why) else {
+            return false
+        }
+        guard let explanation = candidate.explanation else { return true }
+        return explanation.warningState == "blocked"
+            && noRecommendationLostReasons.contains(explanation.lostReason)
+            && isNoRecommendationDisplayText(explanation.summary)
+    }
+
+    private static func validateRecommendedCandidateSemantics(
+        _ candidate: Candidate,
+        selectedExplanation: Explanation?
+    ) -> Bool {
+        guard let selectedExplanation,
+              candidate.eligible,
+              candidate.confidence == selectedExplanation.confidence,
+              selectedExplanation.demandSignal.recommendable,
+              selectedExplanation.lostReason == "selected_best_expected_earning_potential" else {
+            return false
+        }
+        if selectedExplanation.warningState == "ready" {
+            return selectedExplanation.confidence == "high"
+                && selectedExplanation.throughputSource == "measured"
+                && selectedExplanation.localHealth.warnings.isEmpty
+        }
+        return selectedExplanation.warningState == "advisory"
+    }
+
+    private static func validateCandidateEvidence(_ candidate: Candidate, hardware: Hardware) -> Bool {
+        guard let explanation = candidate.explanation else { return true }
+        guard let tokensPerSecond = candidate.tokensPerSecond,
+              let memoryHeadroomGB = candidate.memoryHeadroomGB,
+              let rawScore = candidate.rawScore,
+              tokensPerSecond.isFinite,
+              tokensPerSecond >= 0,
+              memoryHeadroomGB.isFinite,
+              rawScore.isFinite,
+              rawScore >= 0,
+              isKnownExplanationSummary(explanation.summary) else {
+            return false
+        }
+        let afterMargin = explanation.memoryFit.totalGB
+            .subtractingReportingOverflow(explanation.memoryFit.safetyMarginGB)
+        guard !afterMargin.overflow else { return false }
+        let afterRequired = afterMargin.partialValue
+            .subtractingReportingOverflow(explanation.memoryFit.requiredGB)
+        guard !afterRequired.overflow else { return false }
+        let expectedHeadroom = Double(afterRequired.partialValue)
+        return sameRate(explanation.measuredTPS, tokensPerSecond)
+            && sameRate(explanation.memoryFit.headroomGB, memoryHeadroomGB)
+            && sameRate(explanation.memoryFit.headroomGB, expectedHeadroom)
+            && explanation.memoryFit.totalGB == hardware.memoryGB
+            && sameRate(explanation.earningPotential.score, rawScore)
+    }
+
+    private static func isNoRecommendationDisplayText(_ value: String) -> Bool {
+        guard isKnownExplanationSummary(value) else { return false }
+        let normalized = value.lowercased()
+        let selectedFragments = [
+            "selected for",
+            "best measured provider score",
+            "best estimated earning potential",
+            "best expected provider earnings",
+            "eligible and will be ranked",
+            "eligible, but another model",
+            "stronger estimated earning potential",
+        ]
+        return selectedFragments.allSatisfy { !normalized.contains($0) }
+    }
+
+    private static func isKnownExplanationSummary(_ value: String) -> Bool {
+        if knownExactExplanationSummaries.contains(value) { return true }
+        return knownBlockedSummarySuffixes.contains { suffix in
+            guard value.hasSuffix(suffix) else { return false }
+            return isSafeSummaryModelKey(String(value.dropLast(suffix.count)))
+        }
+    }
+
+    private static let knownExactExplanationSummaries: Set<String> = [
+        "Selected for the best estimated earning potential on this Mac.",
+        "Eligible, but another model has stronger estimated earning potential on this Mac.",
+        "Selected from signed catalog estimates and current hardware fit; no local throughput benchmark was run.",
+        "Eligible installed alternative from signed catalog estimates; no local throughput benchmark was run.",
+        "No paid recommendation is available for this Mac right now.",
+        "No paid recommendation is available for this row.",
+        "No paid recommendation is available; this donor fallback remains advisory.",
+        "Paid recommendation is unavailable until signed inputs are trusted.",
+    ]
+
+    private static let knownBlockedSummarySuffixes = [
+        " is eligible and will be ranked by earning potential.",
+        " is not currently marked recommendable by demand signal.",
+        " has no trusted demand signal for earning estimates.",
+        " is not in recommendable runtime status.",
+        " has no trusted rate-card row for earning estimates.",
+        " is missing release-pinned model artifact identity.",
+        " does not fit with the local memory safety margin.",
+        " needs a higher memory-bandwidth tier than this Mac advertises.",
+        " has no current local throughput benchmark.",
+        " was blocked by thermal throttling during the probe.",
+        " was blocked because swap was observed under probe load.",
+        " was blocked by the buyer latency ceiling.",
+        " needs fresh local benchmark evidence.",
+        " did not clear one or more recommendation gates.",
+    ]
+
+    private static func isSafeSummaryModelKey(_ value: String) -> Bool {
+        guard !value.isEmpty, value.count <= 256 else { return false }
+        return value.unicodeScalars.allSatisfy { scalar in
+            (0x30...0x39).contains(scalar.value)
+                || (0x41...0x5A).contains(scalar.value)
+                || (0x61...0x7A).contains(scalar.value)
+                || scalar == "-"
+                || scalar == "_"
+                || scalar == "."
+                || scalar == "/"
+                || scalar == ":"
+        }
+    }
+
+    private static func selectedRatesAreBound(
+        candidate: Candidate,
+        selectedExplanation: Explanation?,
+        promptRate: Double?,
+        completionRate: Double?
+    ) -> Bool {
+        guard let promptRate,
+              let completionRate,
+              let candidatePrompt = candidate.promptRateUSDPerMillionTokens,
+              let candidateCompletion = candidate.completionRateUSDPerMillionTokens,
+              sameRate(promptRate, candidatePrompt),
+              sameRate(completionRate, candidateCompletion) else {
+            return false
+        }
+        guard let selectedExplanation else { return true }
+        return sameRate(promptRate, selectedExplanation.rateSignal.promptRateUSDPerMillionTokens)
+            && sameRate(completionRate, selectedExplanation.rateSignal.completionRateUSDPerMillionTokens)
+    }
+
+    private static func validateDonorServeConfig(_ serveConfig: ServeConfig) -> Bool {
+        serveConfig.donorMode && validateServeConfig(serveConfig)
+    }
+
+    private static func validateServeConfig(_ serveConfig: ServeConfig) -> Bool {
+        isSafeVisibleRecommendationID(serveConfig.model)
+            && !serveConfig.modelArtifactPath.isEmpty
+            && serveConfig.modelArtifactPath.hasPrefix("/")
+            && isLowerHex(serveConfig.modelArtifactSHA256, count: 64)
+            && isSafeDisplayText(serveConfig.modelCatalogKey, maxLength: 128)
+            && isSafeVisibleRecommendationID(serveConfig.modelCatalogModelID)
+            && isSafeDisplayText(serveConfig.modelCatalogRevision, maxLength: 128)
+            && isLowerHex(serveConfig.modelCatalogSHA256, count: 64)
+            && isSafeDisplayText(serveConfig.modelCatalogVersion, maxLength: 128)
+            && isLowerHex(serveConfig.modelCatalogHash, count: 64)
+            && serveConfig.maxContextOverride > 0
+            && serveConfig.maxConcurrencyOverride > 0
+            && (serveConfig.draftModel == nil) == (serveConfig.draftModelArtifactSHA256 == nil)
+            && (serveConfig.draftModel.map(isSafeVisibleRecommendationID) ?? true)
+            && (serveConfig.draftModelArtifactSHA256.map { isLowerHex($0, count: 64) } ?? true)
+    }
+
+    private static func validateOptionalRate(_ value: Double?) -> Bool {
+        guard let value else { return true }
+        return value.isFinite && value >= 0
+    }
+
+    private static func sameRate(_ lhs: Double, _ rhs: Double) -> Bool {
+        abs(lhs - rhs) < 0.000_000_5
+    }
+
+    private static func validateAlternativeEvidence(
+        _ alternatives: [AlternativeExplanation],
+        candidates: [Candidate],
+        selectedModel: String?
+    ) -> Bool {
+        alternatives.allSatisfy { alternative in
+            let matches = candidates.filter { $0.model == alternative.model }
+            guard matches.count == 1,
+                  alternative.model != selectedModel,
+                  let candidateExplanation = matches[0].explanation else {
+                return false
+            }
+            return candidateExplanation.summary == alternative.summary
+                && candidateExplanation.lostReason == alternative.lostReason
+                && candidateExplanation.earningPotential.score == alternative.expectedEarningPotentialScore
+        }
+    }
+
+    private static func validateDonorFallbackEvidence(
+        _ donorFallbackExplanation: Explanation?,
+        candidates: [Candidate]
+    ) -> Bool {
+        guard let donorFallbackExplanation else { return true }
+        return candidates.filter { $0.explanation == donorFallbackExplanation }.count == 1
+    }
+
+    private static func validateRootWarning(_ warning: String) -> Bool {
+        knownRootWarnings.contains(warning)
+            && isSafeSlug(warning, maxLength: 96)
+    }
+
+    private static func isSafeDisplayText(_ value: String, maxLength: Int) -> Bool {
+        let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty, trimmed.count <= maxLength else { return false }
+        guard trimmed.unicodeScalars.allSatisfy({
+            !CharacterSet.controlCharacters.contains($0)
+                && !CharacterSet.newlines.contains($0)
+        }) else { return false }
+        let lowercased = trimmed.lowercased()
+        return !forbiddenDisplayFragments.contains { lowercased.contains($0) }
+    }
+
+    private static func isSafeVisibleRecommendationID(_ value: String) -> Bool {
+        isSafeRecommendationID(value)
+            && isSafeDisplayText(value, maxLength: 256)
+    }
+
+    private static func isSafeSlug(_ value: String, maxLength: Int) -> Bool {
+        !value.isEmpty
+            && value.count <= maxLength
+            && value.allSatisfy { ("a"..."z").contains($0) || ("0"..."9").contains($0) || $0 == "_" }
+    }
 
     private static func parseTimestamp(_ value: String) -> Date? {
         let formatter = ISO8601DateFormatter()

--- a/phase3-binary/app/Tests/MalibuTests/ModelManagementTests.swift
+++ b/phase3-binary/app/Tests/MalibuTests/ModelManagementTests.swift
@@ -296,6 +296,489 @@ final class ModelManagementTests: XCTestCase {
         XCTAssertNoThrow(try document.validated(now: ModelTestTimestamp.date))
         XCTAssertEqual(document.recommendedModel, "mlx-community/Qwen3-8B-4bit")
         XCTAssertEqual(document.recommendedCandidate?.confidence, "high")
+        XCTAssertEqual(document.selectedExplanation?.measuredTPS, 42.5)
+        XCTAssertEqual(document.selectedExplanation?.memoryFit.headroomGB, 12)
+        XCTAssertEqual(document.selectedExplanation?.demandSignal.supplyDeficitMultiplier, 1.5)
+        XCTAssertEqual(document.selectedExplanation?.rateSignal.providerShareBPS, 9000)
+        XCTAssertTrue(document.selectedRationale?.contains("best estimated earning potential") == true)
+        XCTAssertTrue(document.selectedEvidenceLines.contains { $0.contains("State ready; confidence high") })
+        XCTAssertTrue(document.selectedEvidenceLines.contains { $0.contains("Measured 42.50 tok/s") })
+        XCTAssertTrue(document.selectedEvidenceLines.contains { $0.contains("not accrued rewards") })
+        XCTAssertEqual(document.alternativeExplanations.first?.lostReason, "lower_expected_earning_potential")
+    }
+
+    func testRecommendationValidationRejectsMismatchedSelectedExplanation() throws {
+        let json = recommendationJSON()
+            .replacingOccurrences(
+                of: #""selected_explanation":\#(Self.explanationJSON())"#,
+                with: #""selected_explanation":\#(Self.explanationJSON(summary: "Different model rationale."))"#
+            )
+        let document = try JSONDecoder().decode(MalibuRecommendationDocument.self, from: Data(json.utf8))
+
+        XCTAssertThrowsError(try document.validated(now: ModelTestTimestamp.date))
+    }
+
+    func testRecommendationValidationRejectsUnpairedSelectedExplanation() throws {
+        let json = recommendationJSON()
+            .replacingOccurrences(of: #","explanation":\#(Self.explanationJSON())"#, with: "")
+        let document = try JSONDecoder().decode(MalibuRecommendationDocument.self, from: Data(json.utf8))
+
+        XCTAssertThrowsError(try document.validated(now: ModelTestTimestamp.date))
+    }
+
+    func testRecommendationValidationRejectsCandidateOnlySelectedExplanation() throws {
+        let json = recommendationJSON()
+            .replacingOccurrences(of: #","selected_explanation":\#(Self.explanationJSON())"#, with: "")
+        let document = try JSONDecoder().decode(MalibuRecommendationDocument.self, from: Data(json.utf8))
+
+        XCTAssertThrowsError(try document.validated(now: ModelTestTimestamp.date))
+    }
+
+    func testRecommendationEvidenceLabelsCatalogEstimateThroughput() throws {
+        let json = recommendationJSON()
+            .replacingOccurrences(of: #""throughput_source":"measured""#, with: #""throughput_source":"catalog_estimate""#)
+            .replacingOccurrences(of: #""warning_state":"ready""#, with: #""warning_state":"advisory""#)
+            .replacingOccurrences(of: #""confidence":"high""#, with: #""confidence":"catalog_estimate""#)
+        let document = try JSONDecoder().decode(MalibuRecommendationDocument.self, from: Data(json.utf8))
+
+        XCTAssertNoThrow(try document.validated(now: ModelTestTimestamp.date))
+        XCTAssertTrue(document.selectedEvidenceLines.contains { $0.contains("Catalog estimate 42.50 tok/s") })
+        XCTAssertFalse(document.isActionable)
+    }
+
+    func testRecommendationEvidenceLabelsUnavailableThroughput() throws {
+        let json = recommendationJSON()
+            .replacingOccurrences(of: #""throughput_source":"measured""#, with: #""throughput_source":"unavailable""#)
+            .replacingOccurrences(of: #""warning_state":"ready""#, with: #""warning_state":"advisory""#)
+            .replacingOccurrences(of: #""confidence":"high""#, with: #""confidence":"low""#)
+        let document = try JSONDecoder().decode(MalibuRecommendationDocument.self, from: Data(json.utf8))
+
+        XCTAssertNoThrow(try document.validated(now: ModelTestTimestamp.date))
+        XCTAssertTrue(document.selectedEvidenceLines.contains { $0.contains("Throughput unavailable; memory headroom") })
+        XCTAssertFalse(document.selectedEvidenceLines.contains { $0.contains("Throughput unavailable 42.50 tok/s") })
+        XCTAssertFalse(document.selectedEvidenceLines.contains { $0.contains("Measured 42.50 tok/s") })
+        XCTAssertFalse(document.isActionable)
+    }
+
+    func testRecommendationActionabilityRequiresReadyHighMeasuredExplanation() throws {
+        let advisoryJSON = recommendationJSON()
+            .replacingOccurrences(of: #""warning_state":"ready""#, with: #""warning_state":"advisory""#)
+        let advisory = try JSONDecoder().decode(MalibuRecommendationDocument.self, from: Data(advisoryJSON.utf8))
+        XCTAssertNoThrow(try advisory.validated(now: ModelTestTimestamp.date))
+        XCTAssertFalse(advisory.isActionable)
+
+        let lowConfidenceJSON = recommendationJSON()
+            .replacingOccurrences(of: #""confidence":"high""#, with: #""confidence":"medium""#)
+        let lowConfidence = try JSONDecoder().decode(MalibuRecommendationDocument.self, from: Data(lowConfidenceJSON.utf8))
+        XCTAssertThrowsError(try lowConfidence.validated(now: ModelTestTimestamp.date))
+        XCTAssertFalse(lowConfidence.isActionable)
+    }
+
+    func testRecommendationActionabilityRejectsExplanationContradictions() throws {
+        let localWarningJSON = recommendationJSON()
+            .replacingOccurrences(
+                of: #""local_health":{"warnings":[]},"confidence":"high""#,
+                with: #""local_health":{"warnings":["swap_observed_under_load"]},"confidence":"high""#
+            )
+        let localWarning = try JSONDecoder().decode(MalibuRecommendationDocument.self, from: Data(localWarningJSON.utf8))
+        XCTAssertThrowsError(try localWarning.validated(now: ModelTestTimestamp.date))
+        XCTAssertFalse(localWarning.isActionable)
+
+        let confidenceMismatchJSON = recommendationJSON()
+            .replacingOccurrences(
+                of: #""eligible":true,"confidence":"high","why":"Best measured provider score.""#,
+                with: #""eligible":true,"confidence":"medium","why":"Best measured provider score.""#
+            )
+        let confidenceMismatch = try JSONDecoder().decode(MalibuRecommendationDocument.self, from: Data(confidenceMismatchJSON.utf8))
+        XCTAssertThrowsError(try confidenceMismatch.validated(now: ModelTestTimestamp.date))
+        XCTAssertFalse(confidenceMismatch.isActionable)
+    }
+
+    func testRecommendationValidationRejectsCandidateEvidenceMismatch() throws {
+        let json = recommendationJSON()
+            .replacingOccurrences(of: #""tokens_per_second":42.5"#, with: #""tokens_per_second":420.0"#)
+        let document = try JSONDecoder().decode(MalibuRecommendationDocument.self, from: Data(json.utf8))
+
+        XCTAssertThrowsError(try document.validated(now: ModelTestTimestamp.date))
+        XCTAssertFalse(document.isActionable)
+    }
+
+    func testRecommendationValidationRejectsCoordinatedForgedEvidence() throws {
+        let json = recommendationJSON()
+            .replacingOccurrences(of: #""recommendable":true"#, with: #""recommendable":false"#)
+            .replacingOccurrences(
+                of: #""lost_reason":"selected_best_expected_earning_potential""#,
+                with: #""lost_reason":"demand_not_recommendable""#
+            )
+        let document = try JSONDecoder().decode(MalibuRecommendationDocument.self, from: Data(json.utf8))
+
+        XCTAssertThrowsError(try document.validated(now: ModelTestTimestamp.date))
+        XCTAssertFalse(document.isActionable)
+    }
+
+    func testRecommendationValidationRejectsExplanationWithoutThroughputSource() throws {
+        let json = recommendationJSON()
+            .replacingOccurrences(of: #""throughput_source":"measured","#, with: "")
+
+        XCTAssertThrowsError(try JSONDecoder().decode(MalibuRecommendationDocument.self, from: Data(json.utf8)))
+    }
+
+    func testRecommendationValidationRejectsUnknownThroughputSource() throws {
+        let json = recommendationJSON()
+            .replacingOccurrences(of: #""throughput_source":"measured""#, with: #""throughput_source":"untrusted_probe""#)
+        let document = try JSONDecoder().decode(MalibuRecommendationDocument.self, from: Data(json.utf8))
+
+        XCTAssertThrowsError(try document.validated(now: ModelTestTimestamp.date))
+    }
+
+    func testRecommendationValidationRejectsUnsafeExplanationDisplayText() throws {
+        let json = recommendationJSON()
+            .replacingOccurrences(
+                of: #""summary":"Selected for the best estimated earning potential on this Mac.""#,
+                with: #""summary":"Guaranteed $100/day from /private/cache/provider_id.""#
+            )
+        let document = try JSONDecoder().decode(MalibuRecommendationDocument.self, from: Data(json.utf8))
+
+        XCTAssertThrowsError(try document.validated(now: ModelTestTimestamp.date))
+    }
+
+    func testRecommendationValidationRejectsParaphrasedIncomeClaim() throws {
+        let json = recommendationJSON()
+            .replacingOccurrences(
+                of: #"Selected for the best estimated earning potential on this Mac."#,
+                with: #"This model will pay 100 USD every 24 hours regardless of demand."#
+            )
+        let document = try JSONDecoder().decode(MalibuRecommendationDocument.self, from: Data(json.utf8))
+
+        XCTAssertThrowsError(try document.validated(now: ModelTestTimestamp.date))
+    }
+
+    func testRecommendationValidationRejectsSmuggledIncomeClaimTemplate() throws {
+        let json = recommendationJSON()
+            .replacingOccurrences(
+                of: #"Selected for the best estimated earning potential on this Mac."#,
+                with: #"This model will pay 100 USD every week; qwen is eligible and will be ranked by earning potential."#
+            )
+        let document = try JSONDecoder().decode(MalibuRecommendationDocument.self, from: Data(json.utf8))
+
+        XCTAssertThrowsError(try document.validated(now: ModelTestTimestamp.date))
+    }
+
+    func testRecommendationValidationRejectsOverflowMemoryFit() throws {
+        let json = recommendationJSON()
+            .replacingOccurrences(of: #""required_gb":8"#, with: #""required_gb":9223372036854775807"#)
+            .replacingOccurrences(of: #""safety_margin_gb":4"#, with: #""safety_margin_gb":9223372036854775807"#)
+        let document = try JSONDecoder().decode(MalibuRecommendationDocument.self, from: Data(json.utf8))
+
+        XCTAssertThrowsError(try document.validated(now: ModelTestTimestamp.date))
+    }
+
+    func testRecommendationValidationRejectsControlCharactersInDisplayText() throws {
+        let json = recommendationJSON()
+            .replacingOccurrences(
+                of: #""summary":"Selected for the best estimated earning potential on this Mac.""#,
+                with: #""summary":"Selected for this Mac.\nApprove now.""#
+            )
+        let document = try JSONDecoder().decode(MalibuRecommendationDocument.self, from: Data(json.utf8))
+
+        XCTAssertThrowsError(try document.validated(now: ModelTestTimestamp.date))
+    }
+
+    func testRecommendationValidationRejectsUnknownExplanationState() throws {
+        let json = recommendationJSON()
+            .replacingOccurrences(of: #""warning_state":"ready""#, with: #""warning_state":"trusted""#)
+        let document = try JSONDecoder().decode(MalibuRecommendationDocument.self, from: Data(json.utf8))
+
+        XCTAssertThrowsError(try document.validated(now: ModelTestTimestamp.date))
+    }
+
+    func testRecommendationValidationRejectsUnsafeAlternativeExplanation() throws {
+        let json = recommendationJSON()
+            .replacingOccurrences(
+                of: #""summary":"Eligible, but another model has stronger estimated earning potential on this Mac.""#,
+                with: #""summary":"Guaranteed hourly provider_identity payout.""#
+            )
+        let document = try JSONDecoder().decode(MalibuRecommendationDocument.self, from: Data(json.utf8))
+
+        XCTAssertThrowsError(try document.validated(now: ModelTestTimestamp.date))
+    }
+
+    func testRecommendationValidationRejectsUnsafeAlternativeModelID() throws {
+        let json = recommendationJSON()
+            .replacingOccurrences(
+                of: #""model":"mlx-community/Other-Model-4bit""#,
+                with: #""model":"/private/cache/provider_id""#
+            )
+        let document = try JSONDecoder().decode(MalibuRecommendationDocument.self, from: Data(json.utf8))
+
+        XCTAssertThrowsError(try document.validated(now: ModelTestTimestamp.date))
+    }
+
+    func testRecommendationValidationRejectsUnboundAlternativeExplanation() throws {
+        let json = recommendationJSON()
+            .replacingOccurrences(
+                of: #""alternative_explanations":[\#(Self.alternativeJSON())]"#,
+                with: #""alternative_explanations":[\#(Self.alternativeJSON(model: "mlx-community/Missing-Model-4bit"))]"#
+            )
+        let document = try JSONDecoder().decode(MalibuRecommendationDocument.self, from: Data(json.utf8))
+
+        XCTAssertThrowsError(try document.validated(now: ModelTestTimestamp.date))
+    }
+
+    func testRecommendationValidationRejectsUnboundDonorFallbackExplanation() throws {
+        let json = recommendationJSON()
+            .replacingOccurrences(
+                of: #""donor_fallback_explanation":null"#,
+                with: #""donor_fallback_explanation":\#(Self.explanationJSON(summary: "Fallback model would be advisory only.", lostReason: "donor_mode_fallback"))"#
+            )
+        let document = try JSONDecoder().decode(MalibuRecommendationDocument.self, from: Data(json.utf8))
+
+        XCTAssertThrowsError(try document.validated(now: ModelTestTimestamp.date))
+    }
+
+    func testRecommendationValidationRejectsUnknownRootWarning() throws {
+        let json = recommendationJSON()
+            .replacingOccurrences(
+                of: #""warnings":[]}"#,
+                with: #""warnings":["candidate_catalog_integrity_failure "]}"#
+            )
+        let document = try JSONDecoder().decode(MalibuRecommendationDocument.self, from: Data(json.utf8))
+
+        XCTAssertThrowsError(try document.validated(now: ModelTestTimestamp.date))
+        XCTAssertFalse(document.isActionable)
+    }
+
+    func testRecommendationValidationRejectsUnsafeRootWarningText() throws {
+        let json = recommendationJSON()
+            .replacingOccurrences(
+                of: #""warnings":[]}"#,
+                with: #""warnings":["/private/cache/provider_id"]}"#
+            )
+        let document = try JSONDecoder().decode(MalibuRecommendationDocument.self, from: Data(json.utf8))
+
+        XCTAssertThrowsError(try document.validated(now: ModelTestTimestamp.date))
+        XCTAssertFalse(document.isActionable)
+    }
+
+    func testRecommendationValidationRejectsUnsafeVisibleMetadata() throws {
+        let json = recommendationJSON()
+            .replacingOccurrences(
+                of: #""chip":"Apple M4 Pro""#,
+                with: #""chip":"/private/cache/provider_id""#
+            )
+        let document = try JSONDecoder().decode(MalibuRecommendationDocument.self, from: Data(json.utf8))
+
+        XCTAssertThrowsError(try document.validated(now: ModelTestTimestamp.date))
+    }
+
+    func testRecommendationValidationRejectsNegativeTopLevelRates() throws {
+        let json = recommendationJSON()
+            .replacingOccurrences(
+                of: #""recommended_model":"mlx-community/Qwen3-8B-4bit","prompt_rate_usd_per_million_tokens":0.2"#,
+                with: #""recommended_model":"mlx-community/Qwen3-8B-4bit","prompt_rate_usd_per_million_tokens":-1"#
+            )
+        let document = try JSONDecoder().decode(MalibuRecommendationDocument.self, from: Data(json.utf8))
+
+        XCTAssertThrowsError(try document.validated(now: ModelTestTimestamp.date))
+    }
+
+    func testRecommendationValidationRejectsTopLevelRateMismatch() throws {
+        let json = recommendationJSON()
+            .replacingOccurrences(
+                of: #""prompt_rate_usd_per_million_tokens":0.2,"completion_rate_usd_per_million_tokens":0.4,"serve_config""#,
+                with: #""prompt_rate_usd_per_million_tokens":0.2,"completion_rate_usd_per_million_tokens":9.9,"serve_config""#
+            )
+        let document = try JSONDecoder().decode(MalibuRecommendationDocument.self, from: Data(json.utf8))
+
+        XCTAssertThrowsError(try document.validated(now: ModelTestTimestamp.date))
+    }
+
+    func testRecommendationValidationRejectsSelectedExplanationWithoutRecommendedModel() throws {
+        let json = recommendationJSON()
+            .replacingOccurrences(
+                of: #""recommended_model":"mlx-community/Qwen3-8B-4bit""#,
+                with: #""recommended_model":null"#
+            )
+        let document = try JSONDecoder().decode(MalibuRecommendationDocument.self, from: Data(json.utf8))
+
+        XCTAssertThrowsError(try document.validated(now: ModelTestTimestamp.date))
+    }
+
+    func testRecommendationValidationAcceptsDonorServeConfigWithoutRecommendedModel() throws {
+        let json = recommendationJSON()
+            .replacingOccurrences(
+                of: #""recommended_model":"mlx-community/Qwen3-8B-4bit","prompt_rate_usd_per_million_tokens":0.2,"completion_rate_usd_per_million_tokens":0.4"#,
+                with: #""recommended_model":null,"prompt_rate_usd_per_million_tokens":null,"completion_rate_usd_per_million_tokens":null"#
+            )
+            .replacingOccurrences(of: #""donor_mode":false"#, with: #""donor_mode":true"#)
+            .replacingOccurrences(of: #","selected_explanation":\#(Self.explanationJSON())"#, with: "")
+            .replacingOccurrences(of: #""eligible":true"#, with: #""eligible":false"#)
+            .replacingOccurrences(of: #""warning_state":"ready""#, with: #""warning_state":"blocked""#)
+            .replacingOccurrences(of: #"selected_best_expected_earning_potential"#, with: #"demand_not_recommendable"#)
+            .replacingOccurrences(of: #"lower_expected_earning_potential"#, with: #"demand_not_recommendable"#)
+            .replacingOccurrences(
+                of: #"Selected for the best estimated earning potential on this Mac."#,
+                with: #"No paid recommendation is available; this donor fallback remains advisory."#
+            )
+            .replacingOccurrences(
+                of: #"Eligible, but another model has stronger estimated earning potential on this Mac."#,
+                with: #"No paid recommendation is available for this row."#
+            )
+            .replacingOccurrences(
+                of: #"Best measured provider score."#,
+                with: #"No paid recommendation is available for this row."#
+            )
+        let document = try JSONDecoder().decode(MalibuRecommendationDocument.self, from: Data(json.utf8))
+
+        XCTAssertNoThrow(try document.validated(now: ModelTestTimestamp.date))
+        XCTAssertFalse(document.isActionable)
+        XCTAssertTrue(document.hasVisibleRecommendationFeedback)
+    }
+
+    func testRecommendationValidationRejectsNonDonorServeConfigWithoutRecommendedModel() throws {
+        let json = recommendationJSON()
+            .replacingOccurrences(
+                of: #""recommended_model":"mlx-community/Qwen3-8B-4bit","prompt_rate_usd_per_million_tokens":0.2,"completion_rate_usd_per_million_tokens":0.4"#,
+                with: #""recommended_model":null,"prompt_rate_usd_per_million_tokens":null,"completion_rate_usd_per_million_tokens":null"#
+            )
+            .replacingOccurrences(of: #","selected_explanation":\#(Self.explanationJSON())"#, with: "")
+        let document = try JSONDecoder().decode(MalibuRecommendationDocument.self, from: Data(json.utf8))
+
+        XCTAssertThrowsError(try document.validated(now: ModelTestTimestamp.date))
+    }
+
+    func testNoRecommendationDocumentKeepsWhyNotDisplayFeedback() throws {
+        let json = recommendationJSON()
+            .replacingOccurrences(
+                of: #""recommended_model":"mlx-community/Qwen3-8B-4bit","prompt_rate_usd_per_million_tokens":0.2,"completion_rate_usd_per_million_tokens":0.4,"serve_config":{"#,
+                with: #""recommended_model":null,"prompt_rate_usd_per_million_tokens":null,"completion_rate_usd_per_million_tokens":null,"serve_config":null,"_removed":{"#
+            )
+            .replacingOccurrences(of: #","selected_explanation":\#(Self.explanationJSON())"#, with: "")
+            .replacingOccurrences(of: #""eligible":true"#, with: #""eligible":false"#)
+            .replacingOccurrences(of: #""warning_state":"ready""#, with: #""warning_state":"blocked""#)
+            .replacingOccurrences(of: #"selected_best_expected_earning_potential"#, with: #"demand_not_recommendable"#)
+            .replacingOccurrences(of: #"lower_expected_earning_potential"#, with: #"demand_not_recommendable"#)
+            .replacingOccurrences(
+                of: #"Selected for the best estimated earning potential on this Mac."#,
+                with: #"No paid recommendation is available for this Mac right now."#
+            )
+            .replacingOccurrences(
+                of: #"Eligible, but another model has stronger estimated earning potential on this Mac."#,
+                with: #"No paid recommendation is available for this row."#
+            )
+            .replacingOccurrences(
+                of: #"Best measured provider score."#,
+                with: #"No paid recommendation is available for this row."#
+            )
+        let document = try JSONDecoder().decode(MalibuRecommendationDocument.self, from: Data(json.utf8))
+
+        XCTAssertNoThrow(try document.validated(now: ModelTestTimestamp.date))
+        XCTAssertTrue(document.hasVisibleRecommendationFeedback)
+        XCTAssertNil(document.recommendedModel)
+        XCTAssertFalse(document.isActionable)
+        XCTAssertTrue(document.displayRationale?.contains("No paid recommendation is available") == true)
+        XCTAssertTrue(document.displayEvidenceLines.contains { $0.contains("State blocked") })
+    }
+
+    func testNoRecommendationDocumentRejectsSelectedLookingFeedback() throws {
+        let json = recommendationJSON()
+            .replacingOccurrences(
+                of: #""recommended_model":"mlx-community/Qwen3-8B-4bit","prompt_rate_usd_per_million_tokens":0.2,"completion_rate_usd_per_million_tokens":0.4,"serve_config":{"#,
+                with: #""recommended_model":null,"prompt_rate_usd_per_million_tokens":null,"completion_rate_usd_per_million_tokens":null,"serve_config":null,"_removed":{"#
+            )
+            .replacingOccurrences(of: #","selected_explanation":\#(Self.explanationJSON())"#, with: "")
+            .replacingOccurrences(of: #""eligible":true"#, with: #""eligible":false"#)
+            .replacingOccurrences(of: #""warning_state":"ready""#, with: #""warning_state":"blocked""#)
+            .replacingOccurrences(of: #"selected_best_expected_earning_potential"#, with: #"demand_not_recommendable"#)
+            .replacingOccurrences(of: #"lower_expected_earning_potential"#, with: #"demand_not_recommendable"#)
+            .replacingOccurrences(
+                of: #"Eligible, but another model has stronger estimated earning potential on this Mac."#,
+                with: #"No paid recommendation is available for this row."#
+            )
+        let document = try JSONDecoder().decode(MalibuRecommendationDocument.self, from: Data(json.utf8))
+
+        XCTAssertThrowsError(try document.validated(now: ModelTestTimestamp.date))
+    }
+
+    func testNoRecommendationDocumentRejectsLegacySelectedLookingWhy() throws {
+        let json = recommendationJSON()
+            .replacingOccurrences(
+                of: #""recommended_model":"mlx-community/Qwen3-8B-4bit","prompt_rate_usd_per_million_tokens":0.2,"completion_rate_usd_per_million_tokens":0.4,"serve_config":{"#,
+                with: #""recommended_model":null,"prompt_rate_usd_per_million_tokens":null,"completion_rate_usd_per_million_tokens":null,"serve_config":null,"_removed":{"#
+            )
+            .replacingOccurrences(of: #","selected_explanation":\#(Self.explanationJSON())"#, with: "")
+            .replacingOccurrences(of: #","alternative_explanations":[\#(Self.alternativeJSON())]"#, with: #","alternative_explanations":[]"#)
+            .replacingOccurrences(of: #","explanation":\#(Self.explanationJSON())"#, with: "")
+            .replacingOccurrences(of: #","explanation":\#(Self.alternativeCandidateExplanationJSON())"#, with: "")
+            .replacingOccurrences(
+                of: #",{"rank":2,"model":"mlx-community/Other-Model-4bit","eligible":true,"confidence":"medium","why":"Eligible, but another model has stronger estimated earning potential on this Mac.","prompt_rate_usd_per_million_tokens":0.15,"completion_rate_usd_per_million_tokens":0.25}"#,
+                with: ""
+            )
+            .replacingOccurrences(of: #""eligible":true"#, with: #""eligible":false"#)
+        let document = try JSONDecoder().decode(MalibuRecommendationDocument.self, from: Data(json.utf8))
+
+        XCTAssertThrowsError(try document.validated(now: ModelTestTimestamp.date))
+    }
+
+    func testRecommendationValidationRejectsDuplicateRecommendedCandidates() throws {
+        let duplicateCandidate = #","#
+            + #"{"rank":2,"model":"mlx-community/Qwen3-8B-4bit","eligible":true,"confidence":"high","why":"Duplicate provider score.","prompt_rate_usd_per_million_tokens":0.2,"completion_rate_usd_per_million_tokens":0.4,"explanation":\#(Self.explanationJSON())}"#
+        let json = recommendationJSON()
+            .replacingOccurrences(of: #"}],"warnings":[]}"#, with: #"}\#(duplicateCandidate)],"warnings":[]}"#)
+        let document = try JSONDecoder().decode(MalibuRecommendationDocument.self, from: Data(json.utf8))
+
+        XCTAssertThrowsError(try document.validated(now: ModelTestTimestamp.date))
+        XCTAssertFalse(document.isActionable)
+        XCTAssertNil(document.recommendedCandidate)
+    }
+
+    func testRecommendationValidationRejectsOlderRecommendationWithoutExplanation() throws {
+        let json = recommendationJSON()
+            .replacingOccurrences(of: #","selected_explanation":\#(Self.explanationJSON())"#, with: "")
+            .replacingOccurrences(of: #","alternative_explanations":[\#(Self.alternativeJSON())]"#, with: "")
+            .replacingOccurrences(of: #","donor_fallback_explanation":null"#, with: "")
+            .replacingOccurrences(of: #","explanation":\#(Self.explanationJSON())"#, with: "")
+            .replacingOccurrences(of: #","explanation":\#(Self.alternativeCandidateExplanationJSON())"#, with: "")
+        let document = try JSONDecoder().decode(MalibuRecommendationDocument.self, from: Data(json.utf8))
+
+        XCTAssertThrowsError(try document.validated(now: ModelTestTimestamp.date))
+        XCTAssertNil(document.selectedExplanation)
+        XCTAssertNil(document.selectedRationale)
+        XCTAssertTrue(document.selectedEvidenceLines.isEmpty)
+        XCTAssertFalse(document.isActionable)
+    }
+
+    func testRecommendationValidationRejectsLegacyWeeklyEarnClaim() throws {
+        let json = recommendationJSON()
+            .replacingOccurrences(of: #","selected_explanation":\#(Self.explanationJSON())"#, with: "")
+            .replacingOccurrences(of: #","alternative_explanations":[\#(Self.alternativeJSON())]"#, with: "")
+            .replacingOccurrences(of: #","donor_fallback_explanation":null"#, with: "")
+            .replacingOccurrences(of: #","explanation":\#(Self.explanationJSON())"#, with: "")
+            .replacingOccurrences(of: #","explanation":\#(Self.alternativeCandidateExplanationJSON())"#, with: "")
+            .replacingOccurrences(
+                of: #""why":"Best measured provider score.""#,
+                with: #""why":"Earn 100 USD weekly with this model.""#
+            )
+        let document = try JSONDecoder().decode(MalibuRecommendationDocument.self, from: Data(json.utf8))
+
+        XCTAssertThrowsError(try document.validated(now: ModelTestTimestamp.date))
+        XCTAssertNil(document.selectedRationale)
+    }
+
+    func testRecommendationValidationRejectsUnsafeLegacyWhyText() throws {
+        let json = recommendationJSON()
+            .replacingOccurrences(of: #","selected_explanation":\#(Self.explanationJSON())"#, with: "")
+            .replacingOccurrences(of: #","alternative_explanations":[\#(Self.alternativeJSON())]"#, with: "")
+            .replacingOccurrences(of: #","donor_fallback_explanation":null"#, with: "")
+            .replacingOccurrences(of: #","explanation":\#(Self.explanationJSON())"#, with: "")
+            .replacingOccurrences(of: #","explanation":\#(Self.alternativeCandidateExplanationJSON())"#, with: "")
+            .replacingOccurrences(
+                of: #""why":"Best measured provider score.""#,
+                with: #""why":"Guaranteed $100/day from /private/cache/provider_id.""#
+            )
+        let document = try JSONDecoder().decode(MalibuRecommendationDocument.self, from: Data(json.utf8))
+
+        XCTAssertThrowsError(try document.validated(now: ModelTestTimestamp.date))
     }
 
     func testRecommendationValidationKeepsUnsupportedDraftAdvisory() throws {
@@ -311,22 +794,49 @@ final class ModelManagementTests: XCTestCase {
     }
 
     func testRecommendationValidationKeepsThermalOrSwapWarningAdvisory() throws {
-        let json = recommendationJSON().replacingOccurrences(
-            of: "\"warnings\":[]",
-            with: "\"warnings\":[\"swap_observed_under_load\"]"
-        )
+        let json = recommendationJSON()
+            .replacingOccurrences(of: "\"warning_state\":\"ready\"", with: "\"warning_state\":\"advisory\"")
+            .replacingOccurrences(
+                of: "\"warnings\":[]",
+                with: "\"warnings\":[\"swap_observed_under_load\"]"
+            )
         let document = try JSONDecoder().decode(MalibuRecommendationDocument.self, from: Data(json.utf8))
 
         XCTAssertNoThrow(try document.validated(now: ModelTestTimestamp.date))
         XCTAssertFalse(document.isActionable)
 
-        let thermalJSON = recommendationJSON().replacingOccurrences(
-            of: "\"warnings\":[]",
-            with: "\"warnings\":[\"thermal_throttled\"]"
-        )
+        let thermalJSON = recommendationJSON()
+            .replacingOccurrences(of: "\"warning_state\":\"ready\"", with: "\"warning_state\":\"advisory\"")
+            .replacingOccurrences(
+                of: "\"warnings\":[]",
+                with: "\"warnings\":[\"thermal_throttled\"]"
+            )
         let thermal = try JSONDecoder().decode(MalibuRecommendationDocument.self, from: Data(thermalJSON.utf8))
         XCTAssertNoThrow(try thermal.validated(now: ModelTestTimestamp.date))
         XCTAssertFalse(thermal.isActionable)
+    }
+
+    func testRecommendationValidationKeepsAnyRootWarningAdvisoryOnly() throws {
+        for warning in [
+            "candidate_catalog_fallback_used",
+            "candidate_catalog_stale",
+            "demand_rank_fallback_used",
+            "demand_rank_stale",
+            "hardware_tier_unknown",
+            "rate_card_default_tier_used",
+            "rate_card_fallback_used",
+            "rate_card_stale",
+        ] {
+            let json = recommendationJSON().replacingOccurrences(
+                of: #"}],"warnings":[]}"#,
+                with: #"}],"warnings":["\#(warning)"]}"#
+            )
+            let document = try JSONDecoder().decode(MalibuRecommendationDocument.self, from: Data(json.utf8))
+
+            XCTAssertNoThrow(try document.validated(now: ModelTestTimestamp.date), warning)
+            XCTAssertFalse(document.isActionable, warning)
+            XCTAssertNotNil(document.adoptionAdvisoryReason, warning)
+        }
     }
 
     func testRecommendationValidationRejectsCatalogModelIdentityMismatch() throws {
@@ -464,7 +974,33 @@ final class ModelManagementTests: XCTestCase {
         let hashB = String(repeating: "b", count: 64)
         let hashC = String(repeating: "c", count: 64)
         return """
-        {"schema_version":"autotune_recommend.v1","generated_at":"2026-08-09T00:00:00Z","hardware":{"machine":"Mac15,6","chip":"Apple M4 Pro","memory_gb":24,"bandwidth_tier":"B","detected":true,"os_version":"15.6","binary_version":"1.8.91"},"inputs":{"rate_card_version":"rates-v1","demand_rank_version":"demand-v1","candidate_catalog_version":"catalog-v1"},"recommended_model":"mlx-community/Qwen3-8B-4bit","prompt_rate_usd_per_million_tokens":0.2,"completion_rate_usd_per_million_tokens":0.4,"serve_config":{"model":"mlx-community/Qwen3-8B-4bit","model_artifact_path":"/private/cache/qwen3","model_artifact_sha256":"\(hashA)","model_catalog_key":"qwen3-8b","model_catalog_model_id":"mlx-community/Qwen3-8B-4bit","model_catalog_revision":"revision","model_catalog_sha256":"\(hashB)","model_catalog_version":"catalog-v1","model_catalog_hash":"\(hashC)","kv_bits":4,"max_context_override":4096,"max_concurrency_override":1,"donor_mode":false,"draft_model":null,"draft_model_artifact_sha256":null},"candidates":[{"rank":1,"model":"mlx-community/Qwen3-8B-4bit","eligible":true,"confidence":"high","why":"Best measured provider score.","prompt_rate_usd_per_million_tokens":0.2,"completion_rate_usd_per_million_tokens":0.4}],"warnings":[]}
+        {"schema_version":"autotune_recommend.v1","generated_at":"2026-08-09T00:00:00Z","hardware":{"machine":"Mac15,6","chip":"Apple M4 Pro","memory_gb":24,"bandwidth_tier":"B","detected":true,"os_version":"15.6","binary_version":"1.8.91"},"inputs":{"rate_card_version":"rates-v1","demand_rank_version":"demand-v1","candidate_catalog_version":"catalog-v1"},"recommended_model":"mlx-community/Qwen3-8B-4bit","prompt_rate_usd_per_million_tokens":0.2,"completion_rate_usd_per_million_tokens":0.4,"serve_config":{"model":"mlx-community/Qwen3-8B-4bit","model_artifact_path":"/private/cache/qwen3","model_artifact_sha256":"\(hashA)","model_catalog_key":"qwen3-8b","model_catalog_model_id":"mlx-community/Qwen3-8B-4bit","model_catalog_revision":"revision","model_catalog_sha256":"\(hashB)","model_catalog_version":"catalog-v1","model_catalog_hash":"\(hashC)","kv_bits":4,"max_context_override":4096,"max_concurrency_override":1,"donor_mode":false,"draft_model":null,"draft_model_artifact_sha256":null},"selected_explanation":\(Self.explanationJSON()),"alternative_explanations":[\(Self.alternativeJSON())],"donor_fallback_explanation":null,"candidates":[{"rank":1,"model":"mlx-community/Qwen3-8B-4bit","eligible":true,"confidence":"high","why":"Best measured provider score.","prompt_rate_usd_per_million_tokens":0.2,"completion_rate_usd_per_million_tokens":0.4,"tokens_per_second":42.5,"memory_headroom_gb":12,"raw_score":38250,"explanation":\(Self.explanationJSON())},{"rank":2,"model":"mlx-community/Other-Model-4bit","eligible":true,"confidence":"medium","why":"Eligible, but another model has stronger estimated earning potential on this Mac.","prompt_rate_usd_per_million_tokens":0.15,"completion_rate_usd_per_million_tokens":0.25,"tokens_per_second":42.5,"memory_headroom_gb":12,"raw_score":1000,"explanation":\(Self.alternativeCandidateExplanationJSON())}],"warnings":[]}
+        """
+    }
+
+    private static func explanationJSON(
+        summary: String = "Selected for the best estimated earning potential on this Mac.",
+        score: Double = 38_250,
+        lostReason: String = "selected_best_expected_earning_potential",
+        confidence: String = "high"
+    ) -> String {
+        """
+        {"summary":"\(summary)","warning_state":"ready","measured_tps":42.5,"throughput_source":"measured","memory_fit":{"required_gb":8,"total_gb":24,"safety_margin_gb":4,"headroom_gb":12},"demand_signal":{"rank":7,"weight":0.65,"recommendable":true,"min_provider_target":10,"ready_provider_count":4,"supply_deficit_multiplier":1.5},"rate_signal":{"prompt_rate_usd_per_million_tokens":0.2,"completion_rate_usd_per_million_tokens":0.4,"provider_share_bps":9000,"provider_completion_payout_usd_per_million_tokens":0.36},"earning_potential":{"score":\(score),"kind":"relative_ranking_score","note":"Estimated earning potential only; actual rewards depend on buyer demand, uptime, accepted work, and settlement."},"local_health":{"warnings":[]},"confidence":"\(confidence)","lost_reason":"\(lostReason)"}
+        """
+    }
+
+    private static func alternativeCandidateExplanationJSON() -> String {
+        explanationJSON(
+            summary: "Eligible, but another model has stronger estimated earning potential on this Mac.",
+            score: 1_000,
+            lostReason: "lower_expected_earning_potential",
+            confidence: "medium"
+        )
+    }
+
+    private static func alternativeJSON(model: String = "mlx-community/Other-Model-4bit") -> String {
+        """
+        {"rank":2,"model":"\(model)","eligible":true,"lost_reason":"lower_expected_earning_potential","summary":"Eligible, but another model has stronger estimated earning potential on this Mac.","expected_earning_potential_score":1000}
         """
     }
 

--- a/specs/SPEC-023-installer-autotune-recommend.md
+++ b/specs/SPEC-023-installer-autotune-recommend.md
@@ -589,7 +589,7 @@ Constants locked in v0.6:
 | `diversification_band` | `0.85` | Retained in demand-rank JSON schema for forward compatibility; **not used for recommendation pick in v0.5**. Re-enable when supply exceeds demand. |
 | `provider_share` | `0.90` | Represented by rate-card row `provider_share_bps = 9000`; the row value is authoritative, but v0.5 rows are expected to use 0.90. |
 | `tier_weight` | `1.0` | Applies to all rows and tiers in v0.5. Tier-specific calibration is deferred to v0.2 follow-up. |
-| ranked output length | `5` | The JSON `candidates[]` array defaults to the top 5 rows after ranking, including eligible rows first and then selected ineligible diagnostic rows only when no eligible row exists. |
+| ranked output length | `5 (+1 donor fallback)` | The JSON `candidates[]` array defaults to the top 5 rows after ranking, including eligible rows first and then selected ineligible diagnostic rows only when no eligible row exists. When `donor_fallback_explanation` is present for a fallback outside those 5 rows, emit that donor fallback as one additional displayed candidate so the explanation remains bound to a visible model. |
 | `diversification_id` | HMAC-derived stable ID | Used for recommendation-cache identity only in v0.5; does not alter `recommended_model` selection. |
 
 **Real provider earnings** are recorded after tokens are served:
@@ -645,7 +645,7 @@ In v0.4, there is no paid financial gate. All eligible rows proceed to recommend
 
 ## 6. Output JSON contract (`autotune --recommend`)
 
-`autotune --recommend --json` MUST emit deterministic field order exactly as shown below. Unknown optional data uses `null`; fields are not reordered, renamed, or omitted in v0.4.
+`autotune --recommend --json` MUST emit deterministic field order exactly as shown below. Unknown optional data uses `null`; fields are not reordered, renamed, or omitted. The explanation fields are additive `autotune_recommend.v1` extensions. Older v1 documents without them remain schema-decodable by Malibu for compatibility, but they are not valid recommendation display/adoption evidence for a non-null `recommended_model`; Malibu MUST reject recommended documents that lack selected/candidate explanation parity rather than rendering legacy free-text rationale as trusted recommendation evidence. Malibu treats this document family as advisory display evidence unless a later schema adds verifiable adoption authority; explanation parity alone is not one-click adoption authority.
 
 ```json
 {
@@ -681,6 +681,42 @@ In v0.4, there is no paid financial gate. All eligible rows proceed to recommend
       "confidence": "low",
       "why": "<one-line reason>",
       "raw_score": 0.0,
+      "explanation": {
+        "summary": "<safe one-line rationale>",
+        "warning_state": "ready",
+        "measured_tps": 0.0,
+        "throughput_source": "measured",
+        "memory_fit": {
+          "required_gb": 0,
+          "total_gb": 0,
+          "safety_margin_gb": 4,
+          "headroom_gb": 0.0
+        },
+        "demand_signal": {
+          "rank": null,
+          "weight": 0.0,
+          "recommendable": false,
+          "min_provider_target": 0,
+          "ready_provider_count": null,
+          "supply_deficit_multiplier": 0.0
+        },
+        "rate_signal": {
+          "prompt_rate_usd_per_million_tokens": 0.0,
+          "completion_rate_usd_per_million_tokens": 0.0,
+          "provider_share_bps": 0,
+          "provider_completion_payout_usd_per_million_tokens": 0.0
+        },
+        "earning_potential": {
+          "score": 0.0,
+          "kind": "relative_ranking_score",
+          "note": "Estimated earning potential only; actual rewards depend on buyer demand, uptime, accepted work, and settlement."
+        },
+        "local_health": {
+          "warnings": []
+        },
+        "confidence": "low",
+        "lost_reason": "<machine_reason_slug>"
+      },
       "bench_gate_provenance": {
         "source": "policy",
         "notes": "#744 audit: gate set by operator policy to broaden eligibility."
@@ -689,7 +725,19 @@ In v0.4, there is no paid financial gate. All eligible rows proceed to recommend
       "buyer_ttft_ceiling_exceeded": false
     }
   ],
-  "warnings": []
+  "warnings": [],
+  "selected_explanation": null,
+  "alternative_explanations": [
+    {
+      "rank": 2,
+      "model": "<model_key>",
+      "eligible": true,
+      "lost_reason": "lower_expected_earning_potential",
+      "summary": "<safe one-line rationale>",
+      "expected_earning_potential_score": 0.0
+    }
+  ],
+  "donor_fallback_explanation": null
 }
 ```
 
@@ -702,9 +750,24 @@ Schema rules:
 - `recommended_model` is a model key string when at least one eligible row exists; otherwise `null`.
 - `prompt_rate_usd_per_million_tokens` and `completion_rate_usd_per_million_tokens` are USD/M rates for the selected recommendation, derived from rate-card credits and `usd_per_million_credits`. Both are `null` when `recommended_model` is `null`.
 - `serve_config` is `null` in recommendation-only output when no apply-ready serving configuration has been attached. When present, it is the exact model/knob payload the installer can apply for the selected recommendation; donor outcomes keep `donor_mode = true`.
-- `candidates[]` default length is at most 5. It is sorted by eligibility first, then `raw_score` descending, then `model` lexicographically for deterministic ties.
+- `candidates[]` default length is at most 5. It is sorted by eligibility first, then `raw_score` descending, then `model` lexicographically for deterministic ties. It MAY contain one additional donor fallback candidate when `donor_fallback_explanation` is present and the fallback is outside the default 5 rows.
 - Candidate `prompt_rate_usd_per_million_tokens` and `completion_rate_usd_per_million_tokens` are USD display rates from the rate-card row used for that candidate.
+- Top-level `prompt_rate_usd_per_million_tokens` and `completion_rate_usd_per_million_tokens` MUST be finite, non-negative, and equal to the selected candidate's candidate-level rates. When `selected_explanation` is present, they MUST also equal `selected_explanation.rate_signal.prompt_rate_usd_per_million_tokens` and `selected_explanation.rate_signal.completion_rate_usd_per_million_tokens`.
 - `raw_score` is rounded to 6 decimal places in JSON.
+- Candidate `explanation` is optional for legacy v1 decoding but MUST be present in newly emitted output for every displayed candidate. A Malibu consumer that displays a non-null `recommended_model` as recommendation evidence MUST require the selected candidate explanation and top-level `selected_explanation` to be present and semantically equal. Its fields are display-safe, machine-readable evidence for the candidate's rank and eligibility. `summary` is a safe one-line rationale from the CLI-owned template set and MUST NOT contain local paths, provider identity material, hardware identity material, HMAC/key material, or guaranteed/daily/hourly/weekly income claims.
+- Candidate `explanation.measured_tps`, `explanation.memory_fit.headroom_gb`, `explanation.memory_fit.total_gb`, and `explanation.earning_potential.score` MUST match the candidate's `tokens_per_second`, `memory_headroom_gb`, detected `hardware.memory_gb`, and `raw_score` respectively. Consumers MUST reject contradictory explanation/candidate evidence rather than trying to reconcile it.
+- `explanation.warning_state` is one of `ready`, `advisory`, or `blocked`.
+- `explanation.throughput_source` is one of `measured`, `catalog_estimate`, or `unavailable`; `catalog_estimate` MUST be used when installed-only disclosure uses signed catalog estimates instead of a local throughput benchmark.
+- `explanation.memory_fit` reports signed candidate memory requirement, detected total memory, the local safety margin, and computed headroom in GB.
+- `explanation.demand_signal` reports the signed demand rank inputs used for relative ranking. Missing demand uses `rank = null`, `recommendable = false`, and `weight = 0.0`; it must be described as unavailable, not as live demand.
+- `explanation.rate_signal` reports the rate-card row used for relative ranking. Provider payout values are per-million-token rates and MUST NOT be described as accrued rewards.
+- `explanation.earning_potential.kind` is exactly `relative_ranking_score`. `explanation.earning_potential.note` is exactly `Estimated earning potential only; actual rewards depend on buyer demand, uptime, accepted work, and settlement.`
+- `explanation.local_health.warnings` contains only stable local probe warning slugs such as `thermal_throttle_detected`, `thermal_throttled`, `swap_observed_under_load`, and `buyer_ttft_ceiling_exceeded`.
+- `explanation.confidence` uses the same values as candidate `confidence`; installed-only catalog estimate disclosure may use `catalog_estimate`.
+- `explanation.lost_reason` is a lowercase machine slug explaining why the candidate is selected, lower-ranked, or blocked.
+- `selected_explanation` is `null` when there is no selected candidate. When present, it MUST be byte-for-byte semantically equal to the selected candidate's `explanation`.
+- `alternative_explanations[]` is optional for legacy readers but newly emitted output SHOULD include non-selected displayed candidates. Each alternative explanation MUST bind to exactly one non-selected candidate with the same `model`, `lost_reason`, `summary`, and `earning_potential.score`.
+- `donor_fallback_explanation` is `null` unless a donor fallback candidate is selected for display; when present it has the same object shape and safety constraints as candidate `explanation` and MUST bind to exactly one displayed candidate with a semantically equal candidate `explanation`.
 - `bench_gate_provenance` is copied from the signed candidate catalog row for the displayed candidate. Missing signed-catalog provenance is a catalog integrity failure, not a display fallback, except for the exact A4 transition-pinned July 10 live fetch where clients may derive the display-only #744 provenance classification while retaining the original signed bytes as the selected catalog hash.
 - When `bench_gate_provenance.source == "omlx_seeded"`, JSON and human output MUST make the provisional status explicit. The rendered text MUST state that the gate is oMLX-seeded, not macprovider-verified, and not eligible for paid-default recommendation until verified provider autotune promotion replaces the seed per §12.
 - `bench_gate_drift` is a sorted array containing `tps_below_gate` and/or `ttft_above_gate` when local measured benchmark results diverge from the advisory catalog target.


### PR DESCRIPTION
Closes #1020

## Summary
- add structured autotune recommendation explanations for selected, alternative, and donor fallback candidates
- render advisory-only rationale/evidence in Malibu dashboard and model management surfaces
- validate explanation parity, rate binding, display safety, and legacy document boundaries in Malibu
- update SPEC-023 for the explanation contract and deterministic JSON field order

## Verification
- git diff --check
- swift test --package-path phase3-binary --filter AutotuneRecommendTests
- xcodebuild test -project Malibu.xcodeproj -scheme Malibu -configuration Debug -destination 'platform=macOS' -only-testing:MalibuTests/ModelManagementTests
- native subagent audits: code/security/architect all C=0 H=0 M=0

## Carried Low
- recommendation card rendering remains duplicated between dashboard and model management sheet; acceptable for this PR, extract if this UI changes again

SPEC-GOVERNANCE-DECLARATION-BEGIN
{
  "schema_version": "spec-pr-governance-v1",
  "behavior_change": "yes",
  "contract_change": "yes",
  "specs": ["SPEC-023"],
  "requirements": ["SPEC-023-R001"],
  "authority_domains": ["installer-autotune-policy"],
  "arbitration": ["CODE_BUG"],
  "tests": ["swift test --package-path phase3-binary --filter AutotuneRecommendTests", "xcodebuild test -project Malibu.xcodeproj -scheme Malibu -configuration Debug -destination 'platform=macOS' -only-testing:MalibuTests/ModelManagementTests"],
  "journeys": ["not-required"],
  "issue": "https://github.com/Augustas11/macprovider/issues/1020"
}
SPEC-GOVERNANCE-DECLARATION-END
