### PR TITLE
Restore MacProvider skill manifest discovery

### DIFF
--- a/docs/agent-onboarding/.well-known/skills/index.json
+++ b/docs/agent-onboarding/.well-known/skills/index.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "https://get.malibu.tech/.well-known/skills/index.v1",
-  "updated_at": "2026-08-16",
+  "updated_at": "2026-08-17",
   "skills": [
     {
       "id": "macprovider-agent-onboarding",
@@ -9,7 +9,7 @@
       "url": "https://get.malibu.tech/skill.md",
       "source_path": "docs/agent-onboarding/SKILL.md",
       "content_type": "text/markdown; charset=utf-8",
-      "sha256": "12053c20a33f4c49b9eab1d1a3eeed867bdcec0944b8845a1c1eb172a3f3a4fa"
+      "sha256": "7aa3b6ab5c0501d4830a3c0546bd53475bf05fc8b12e55f476abd77ea2d67e54"
     }
   ]
 }

--- a/docs/agent-onboarding/SKILL.md
+++ b/docs/agent-onboarding/SKILL.md
@@ -1,9 +1,14 @@
+---
+name: macprovider-agent-onboarding
+description: Use when helping providers install, repair, inspect, update, or uninstall MacProvider, or when helping buyers use MacProvider through OpenAI-compatible SDKs.
+---
+
 # MacProvider Agent Onboarding Skill
 
 Canonical publication URL: `https://get.malibu.tech/skill.md`
 Discovery index publication URL: `https://get.malibu.tech/.well-known/skills/index.json`
 Source path: `docs/agent-onboarding/SKILL.md`
-Last updated: 2026-08-16
+Last updated: 2026-08-17
 
 Use this skill when an agent needs to help a provider install, repair,
 inspect, update, or uninstall MacProvider, or when a buyer wants to use

--- a/scripts/verify-agent-onboarding-skill.py
+++ b/scripts/verify-agent-onboarding-skill.py
@@ -137,6 +137,43 @@ def validate_urls(text: str) -> None:
         require(normalized in ALLOWED_URLS, f"URL is not allowlisted: {raw}")
 
 
+def validate_frontmatter(skill: str) -> None:
+    lines = skill.splitlines()
+    require(lines and lines[0] == "---", "SKILL.md missing YAML front matter")
+    closing_index = None
+    for index, line in enumerate(lines[1:], start=1):
+        if line == "---":
+            closing_index = index
+            break
+    require(closing_index is not None, "SKILL.md front matter is not closed")
+
+    metadata: dict[str, str] = {}
+    for line in lines[1:closing_index]:
+        if not line.strip():
+            continue
+        require(":" in line, f"front matter line is not key/value: {line}")
+        key, value = line.split(":", 1)
+        key = key.strip()
+        value = value.strip().strip('"').strip("'")
+        require(key, f"front matter key is empty: {line}")
+        require(value, f"front matter value is empty: {key}")
+        metadata[key] = value
+
+    name = metadata.get("name", "")
+    description = metadata.get("description", "")
+    require(name == "macprovider-agent-onboarding", "front matter name drifted")
+    require(
+        re.fullmatch(r"[a-z0-9-]{1,64}", name) is not None,
+        "front matter name must be lowercase letters, digits, and hyphens",
+    )
+    require(description, "front matter description missing")
+    require("MacProvider" in description, "front matter description must mention MacProvider")
+    require(
+        "install" in description.lower() and "OpenAI-compatible SDKs" in description,
+        "front matter description must cover provider install and buyer SDK use cases",
+    )
+
+
 def validate_files(
     skill_path: Path = SKILL_PATH,
     index_path: Path = INDEX_PATH,
@@ -148,6 +185,7 @@ def validate_files(
     require(len(skill_bytes) <= 20_000, "SKILL.md must stay compact for agent ingestion")
     skill = read_text(skill_path)
     index_text = read_text(index_path)
+    validate_frontmatter(skill)
 
     combined = f"{skill}\n{index_text}"
     for forbidden in FORBIDDEN_LITERAL_SNIPPETS:
@@ -202,6 +240,22 @@ def run_negative_tests() -> None:
         index = temp / "index.json"
         skill.write_text(SKILL_PATH.read_text(encoding="utf-8"), encoding="utf-8")
         index.write_text(INDEX_PATH.read_text(encoding="utf-8"), encoding="utf-8")
+        source_skill = SKILL_PATH.read_text(encoding="utf-8")
+        without_manifest = re.sub(r"\A---\n.*?\n---\n\n?", "", source_skill, count=1, flags=re.S)
+        skill.write_text(without_manifest, encoding="utf-8")
+        index_payload = json.loads(INDEX_PATH.read_text(encoding="utf-8"))
+        index_payload["skills"][0]["sha256"] = hashlib.sha256(without_manifest.encode()).hexdigest()
+        index.write_text(json.dumps(index_payload, indent=2) + "\n", encoding="utf-8")
+        SUPPRESS_FAILURE_OUTPUT = True
+        try:
+            validate_files(skill, index)
+        except SystemExit as exc:
+            SUPPRESS_FAILURE_OUTPUT = False
+            require(exc.code == 1, f"negative test missing_manifest exited unexpectedly: {exc.code}")
+        else:
+            SUPPRESS_FAILURE_OUTPUT = False
+            fail("negative test did not fail: missing_manifest")
+
         mutations = {
             "legacy_http": "\nhttps://streamvc.live/install.sh\n",
             "legacy_mixed_case": "\nhttps://Get.StreamVC.Live/skill.md\n",


### PR DESCRIPTION
## Summary

- add required `name`/`description` YAML front matter to `docs/agent-onboarding/SKILL.md`
- update the public discovery index digest/date
- extend validation to reject missing or drifted skill manifest metadata before publication

## Production

Published with `bash scripts/publish-agent-onboarding-skill.sh`; hosted verifier confirmed `https://get.malibu.tech` serves the corrected skill/index bytes.

## Tests

- `python3 scripts/verify-agent-onboarding-skill.py --skill docs/agent-onboarding/SKILL.md --index docs/agent-onboarding/.well-known/skills/index.json`
- `bash scripts/test-agent-onboarding-skill.sh`
- `bash scripts/test-agent-onboarding-publication.sh`
- `bash scripts/publish-agent-onboarding-skill.sh`
- `bash scripts/verify-agent-onboarding-hosted.sh docs/agent-onboarding/SKILL.md docs/agent-onboarding/.well-known/skills/index.json`
- `curl -fsSL --proto '=https' --tlsv1.2 https://get.malibu.tech/skill.md`
- `curl -fsSL --proto '=https' --tlsv1.2 https://get.malibu.tech/.well-known/skills/index.json`

SPEC-GOVERNANCE-DECLARATION-BEGIN
{
  "schema_version": "spec-pr-governance-v1",
  "behavior_change": "yes",
  "contract_change": "none",
  "specs": ["SPEC-003"],
  "requirements": ["SPEC-003-R001"],
  "authority_domains": ["provider-onboarding-identity"],
  "arbitration": ["CODE_BUG"],
  "tests": [
    "python3 scripts/verify-agent-onboarding-skill.py --skill docs/agent-onboarding/SKILL.md --index docs/agent-onboarding/.well-known/skills/index.json",
    "bash scripts/test-agent-onboarding-skill.sh",
    "bash scripts/test-agent-onboarding-publication.sh",
    "bash scripts/publish-agent-onboarding-skill.sh",
    "bash scripts/verify-agent-onboarding-hosted.sh docs/agent-onboarding/SKILL.md docs/agent-onboarding/.well-known/skills/index.json"
  ],
  "journeys": ["not-required"],
  "issue": "https://github.com/Augustas11/macprovider/issues/926"
}
SPEC-GOVERNANCE-DECLARATION-END
