### PR TITLE
Add MALIBU reward audit trail

### DIFF
--- a/frontdoor/provider-portal/dist/README.md
+++ b/frontdoor/provider-portal/dist/README.md
@@ -19,6 +19,10 @@ spec-owned doc.
   `include`d in EVERY `location` block because nginx `add_header` is
   all-or-nothing per level — any location-level `add_header` shadows ALL
   inherited add_headers (silent security-header regression if you forget).
+- `nginx-snippets/portal-shared.conf` — http-context `limit_req_zone`
+  declarations used by the portal vhost. Stage under `/etc/nginx/conf.d/`
+  before running `nginx -t`; nginx rejects `limit_req_zone` inside a
+  `server` block.
 
 ## Two deploy gotchas worth remembering
 
@@ -54,7 +58,9 @@ scp frontdoor/provider-portal/index.html root@$PEARL:/var/www/portal/
 scp portal-config.json root@$PEARL:/var/www/portal/
 ssh root@$PEARL 'chown www-data:www-data /var/www/portal/*; chmod 0644 /var/www/portal/*'
 
-# 2. Stage nginx config + security-headers snippet
+# 2. Stage nginx config + snippets
+scp frontdoor/provider-portal/dist/nginx-snippets/portal-shared.conf \
+  root@$PEARL:/etc/nginx/conf.d/portal-shared.conf
 scp frontdoor/provider-portal/dist/nginx-snippets/portal-security-headers.conf \
   root@$PEARL:/etc/nginx/snippets/portal-security-headers.conf
 scp frontdoor/provider-portal/dist/nginx-portal.malibu.tech.conf \

--- a/frontdoor/provider-portal/dist/nginx-portal.malibu.tech.conf
+++ b/frontdoor/provider-portal/dist/nginx-portal.malibu.tech.conf
@@ -15,8 +15,11 @@ server {
 # Reusable security headers — every location MUST `include` this because
 # nginx `add_header` is all-or-nothing per level: any add_header at
 # location level shadows ALL inherited add_headers from the server level.
-# (Snippet path: /etc/nginx/snippets/portal-security-headers.conf — staged
-# by the deploy script alongside this file.)
+# Security headers snippet path:
+# /etc/nginx/snippets/portal-security-headers.conf
+#
+# HTTP-context rate-limit snippet path:
+# /etc/nginx/conf.d/portal-shared.conf
 
 server {
     listen 443 ssl http2;
@@ -62,6 +65,8 @@ server {
     location = /v1/provider/malibu-reward-audit {
         include /etc/nginx/snippets/portal-security-headers.conf;
         add_header Cache-Control "no-store" always;
+        limit_req zone=portal_reward_audit_provider_rate burst=20 nodelay;
+        limit_req_status 429;
         proxy_pass http://127.0.0.1:8443/v1/provider/malibu-reward-audit$is_args$args;
         proxy_set_header Host $host;
         proxy_set_header Authorization $http_authorization;

--- a/frontdoor/provider-portal/dist/nginx-portal.malibu.tech.conf
+++ b/frontdoor/provider-portal/dist/nginx-portal.malibu.tech.conf
@@ -31,6 +31,7 @@ server {
 
     # SPEC-014 §3 / Open Q9: portal MUST be hosted on same origin as a
     # reverse proxy that forwards /v1/pool/check, /v1/provider/malibu-accrual,
+    # /v1/provider/malibu-reward-audit,
     # and /providers/{id}/earnings
     # to the coordinator. Note: these endpoints live on DIFFERENT coordinator
     # backend ports — buyer-mux 8443 owns /v1/pool/check; ws-mux 8444 owns
@@ -50,6 +51,18 @@ server {
         include /etc/nginx/snippets/portal-security-headers.conf;
         add_header Cache-Control "no-store" always;
         proxy_pass http://127.0.0.1:8443/v1/provider/malibu-accrual;
+        proxy_set_header Host $host;
+        proxy_set_header Authorization $http_authorization;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_read_timeout 10s;
+    }
+
+    location = /v1/provider/malibu-reward-audit {
+        include /etc/nginx/snippets/portal-security-headers.conf;
+        add_header Cache-Control "no-store" always;
+        proxy_pass http://127.0.0.1:8443/v1/provider/malibu-reward-audit$is_args$args;
         proxy_set_header Host $host;
         proxy_set_header Authorization $http_authorization;
         proxy_set_header X-Real-IP $remote_addr;

--- a/frontdoor/provider-portal/dist/nginx-snippets/portal-shared.conf
+++ b/frontdoor/provider-portal/dist/nginx-snippets/portal-shared.conf
@@ -1,0 +1,8 @@
+# provider-portal shared http-context declarations.
+#
+# Install this file at /etc/nginx/conf.d/portal-shared.conf before enabling
+# nginx-portal.malibu.tech.conf. `limit_req_zone` is valid only in the nginx
+# http context, so the portal site references this zone by name rather than
+# declaring it inside the server block.
+
+limit_req_zone $binary_remote_addr zone=portal_reward_audit_provider_rate:10m rate=60r/m;

--- a/phase4-coordinator/cmd/coordinator/main.go
+++ b/phase4-coordinator/cmd/coordinator/main.go
@@ -929,6 +929,7 @@ func main() {
 			DB:           rewardsDB,
 			OperatorKeys: cfg.Auth.OperatorKeys,
 		}))
+		providerMux.Handle("/admin/malibu-reward-audit", malibuRewardAuditAdminHandler(cfg, rewardsDB))
 	}
 
 	// SPEC-016 §4.1 — wire the payout package. Migrations + asserts
@@ -1099,6 +1100,7 @@ func main() {
 		hardwareEvidence,
 		enrollHandler,
 		malibuAccrualHandler(cfg, tokenStore, rewardsDB, rewards.NewPoolHeartbeatBridge(wsServer.PoolSnapshot)),
+		malibuRewardAuditHandler(cfg, tokenStore, rewardsDB),
 	)
 	if liveMDAService != nil {
 		buyerHandler = withMDMDeviceBinding(buyerHandler, liveMDAService.HandleDeviceBinding)
@@ -2278,7 +2280,7 @@ func operatorMetricsHandler(operatorKey string, registry *prom.Registry) http.Ha
 	})
 }
 
-func buyerHandlerWithOptionalProviderEndpoints(base http.Handler, enabled bool, register, hardwareEvidence, enroll http.HandlerFunc, malibuAccrual http.Handler) http.Handler {
+func buyerHandlerWithOptionalProviderEndpoints(base http.Handler, enabled bool, register, hardwareEvidence, enroll http.HandlerFunc, malibuAccrual, malibuRewardAudit http.Handler) http.Handler {
 	mux := http.NewServeMux()
 	if enabled {
 		mux.HandleFunc("/v1/providers/register", register)
@@ -2290,6 +2292,9 @@ func buyerHandlerWithOptionalProviderEndpoints(base http.Handler, enabled bool, 
 	}
 	if malibuAccrual != nil {
 		mux.Handle("/v1/provider/malibu-accrual", malibuAccrual)
+	}
+	if malibuRewardAudit != nil {
+		mux.Handle("/v1/provider/malibu-reward-audit", malibuRewardAudit)
 	}
 	mux.Handle("/", base)
 	return mux
@@ -2394,6 +2399,27 @@ func malibuAccrualHandler(cfg config.Config, tokenStore *auth.Store, rewardsDB *
 		RequireProviderTokens: cfg.Auth.RequireProviderTokens,
 		Config:                rewardsCfg,
 		Connectivity:          connectivity,
+	})
+}
+
+func malibuRewardAuditHandler(cfg config.Config, tokenStore *auth.Store, rewardsDB *sql.DB) http.Handler {
+	if rewardsDB == nil {
+		return nil
+	}
+	return rewards.NewRewardAuditHandler(rewards.AuditHandlerDeps{
+		DB:                    rewardsDB,
+		TokenStore:            tokenStore,
+		RequireProviderTokens: cfg.Auth.RequireProviderTokens,
+	})
+}
+
+func malibuRewardAuditAdminHandler(cfg config.Config, rewardsDB *sql.DB) http.Handler {
+	if rewardsDB == nil {
+		return nil
+	}
+	return rewards.NewRewardAuditAdminHandler(rewards.AuditHandlerDeps{
+		DB:          rewardsDB,
+		OperatorKey: cfg.Auth.OperatorKey,
 	})
 }
 

--- a/phase4-coordinator/cmd/coordinator/main_test.go
+++ b/phase4-coordinator/cmd/coordinator/main_test.go
@@ -224,7 +224,7 @@ func TestBuyerRegisterRouteFeatureGate(t *testing.T) {
 		w.WriteHeader(http.StatusAccepted)
 	})
 
-	disabled := buyerHandlerWithOptionalProviderEndpoints(base, false, register, hardwareEvidence, nil, nil)
+	disabled := buyerHandlerWithOptionalProviderEndpoints(base, false, register, hardwareEvidence, nil, nil, nil)
 	req := httptest.NewRequest(http.MethodPost, "/v1/providers/register", nil)
 	rr := httptest.NewRecorder()
 	disabled.ServeHTTP(rr, req)
@@ -245,7 +245,7 @@ func TestBuyerRegisterRouteFeatureGate(t *testing.T) {
 		t.Fatalf("disabled wallet route status=%d body=%s, want 501 wallet_change_requires_spec_027", rr.Code, rr.Body.String())
 	}
 
-	enabled := buyerHandlerWithOptionalProviderEndpoints(base, true, register, hardwareEvidence, nil, nil)
+	enabled := buyerHandlerWithOptionalProviderEndpoints(base, true, register, hardwareEvidence, nil, nil, nil)
 	rr = httptest.NewRecorder()
 	enabled.ServeHTTP(rr, req)
 	if rr.Code != http.StatusNoContent {
@@ -362,6 +362,34 @@ func TestNginxMalibuAccrualRouteBeforeV1CatchAll(t *testing.T) {
 	} {
 		if !strings.Contains(cfg[route:catchAll], needle) {
 			t.Fatalf("malibu-accrual route missing %q", needle)
+		}
+	}
+}
+
+func TestNginxMalibuRewardAuditRouteBeforeV1CatchAll(t *testing.T) {
+	body, err := os.ReadFile("../../dist/nginx-coordinator.malibu.tech.conf")
+	if err != nil {
+		t.Fatalf("read nginx config: %v", err)
+	}
+	cfg := string(body)
+	route := strings.Index(cfg, "location = /v1/provider/malibu-reward-audit")
+	catchAll := strings.Index(cfg, "location /v1/ {\n        return 404;")
+	if route < 0 {
+		t.Fatal("missing exact /v1/provider/malibu-reward-audit route")
+	}
+	if catchAll < 0 {
+		t.Fatal("missing /v1/ catch-all route")
+	}
+	if route > catchAll {
+		t.Fatal("/v1/provider/malibu-reward-audit route must appear before /v1/ catch-all")
+	}
+	for _, needle := range []string{
+		"proxy_pass http://127.0.0.1:8443/v1/provider/malibu-reward-audit;",
+		"proxy_set_header Authorization $http_authorization;",
+		"add_header Cache-Control \"no-store\" always;",
+	} {
+		if !strings.Contains(cfg[route:catchAll], needle) {
+			t.Fatalf("malibu-reward-audit route missing %q", needle)
 		}
 	}
 }

--- a/phase4-coordinator/cmd/coordinator/main_test.go
+++ b/phase4-coordinator/cmd/coordinator/main_test.go
@@ -384,6 +384,8 @@ func TestNginxMalibuRewardAuditRouteBeforeV1CatchAll(t *testing.T) {
 		t.Fatal("/v1/provider/malibu-reward-audit route must appear before /v1/ catch-all")
 	}
 	for _, needle := range []string{
+		"limit_req zone=reward_audit_provider_rate burst=20 nodelay;",
+		"limit_req_status 429;",
 		"proxy_pass http://127.0.0.1:8443/v1/provider/malibu-reward-audit;",
 		"proxy_set_header Authorization $http_authorization;",
 		"add_header Cache-Control \"no-store\" always;",

--- a/phase4-coordinator/dist/nginx-coordinator.malibu.tech.conf
+++ b/phase4-coordinator/dist/nginx-coordinator.malibu.tech.conf
@@ -478,6 +478,8 @@ server {
     # Lives on buyer_port (8443). Provider bearer auth.
     # ---------------------------------------------------------------------
     location = /v1/provider/malibu-reward-audit {
+        limit_req zone=reward_audit_provider_rate burst=20 nodelay;
+        limit_req_status 429;
         proxy_pass http://127.0.0.1:8443/v1/provider/malibu-reward-audit;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;

--- a/phase4-coordinator/dist/nginx-coordinator.malibu.tech.conf
+++ b/phase4-coordinator/dist/nginx-coordinator.malibu.tech.conf
@@ -474,6 +474,23 @@ server {
     }
 
     # ---------------------------------------------------------------------
+    # /v1/provider/malibu-reward-audit — provider-scoped MALIBU audit trail.
+    # Lives on buyer_port (8443). Provider bearer auth.
+    # ---------------------------------------------------------------------
+    location = /v1/provider/malibu-reward-audit {
+        proxy_pass http://127.0.0.1:8443/v1/provider/malibu-reward-audit;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header Authorization $http_authorization;
+        proxy_read_timeout 10s;
+        proxy_no_cache 1;
+        proxy_cache_bypass 1;
+        add_header Cache-Control "no-store" always;
+    }
+
+    # ---------------------------------------------------------------------
     # SPEC-017 v0.1.8 Step 4.B — /v1/stats/* allow-through. Public
     # Network Stats API endpoints, mounted on the coordinator's
     # provider port (8444) per main.go:525. The dedicated vhost

--- a/phase4-coordinator/dist/nginx-snippets/stats-shared.conf
+++ b/phase4-coordinator/dist/nginx-snippets/stats-shared.conf
@@ -39,6 +39,10 @@ limit_req_zone $public_rl_key zone=stats_health:10m      rate=60r/m;
 limit_req_zone $binary_remote_addr zone=referral_validate_rate:10m rate=30r/m;
 limit_req_zone $binary_remote_addr zone=referral_provider_rate:10m rate=60r/m;
 
+# Provider-authenticated reward audit pages still hit auth and reward stores,
+# so keep a cheap IP gate in nginx before the coordinator validates bearers.
+limit_req_zone $binary_remote_addr zone=reward_audit_provider_rate:10m rate=60r/m;
+
 # Cache for the public projection only. SECURITY r5 C1: paired
 # `proxy_no_cache $http_authorization` + `proxy_cache_bypass
 # $http_authorization` directives in every stats location keep the

--- a/phase4-coordinator/internal/rewards/audit.go
+++ b/phase4-coordinator/internal/rewards/audit.go
@@ -1,0 +1,375 @@
+package rewards
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+)
+
+const (
+	AuditEventMalibuAccrualInserted       = "malibu_accrual_inserted"
+	AuditEventMalibuHoldApplied           = "malibu_hold_applied"
+	AuditEventMalibuHoldCleared           = "malibu_hold_cleared"
+	AuditEventWalletDailyCapApplied       = "wallet_daily_cap_applied"
+	AuditEventWalletBindProjected         = "wallet_bind_projected"
+	AuditEventTrustTierPromoted           = "trust_tier_promoted"
+	AuditEventTrustTierDemoted            = "trust_tier_demoted"
+	AuditEventWithdrawalCandidateSelected = "withdrawal_candidate_selected"
+	AuditEventWithdrawalCandidateSkipped  = "withdrawal_candidate_skipped"
+	AuditEventEligibilityReasonChanged    = "eligibility_reason_changed"
+)
+
+const (
+	defaultAuditLimit = 25
+	maxAuditLimit     = 100
+)
+
+type auditWriter interface {
+	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+}
+
+type RewardAuditInsert struct {
+	ProviderID           string
+	OccurredAt           time.Time
+	EventType            string
+	LedgerID             sql.NullInt64
+	AmountMALIBU         sql.NullString
+	WithdrawalHoldReason sql.NullString
+	TrustTier            sql.NullString
+	SourceReason         sql.NullString
+	SafeSummary          string
+	OperatorCorrelation  map[string]string
+}
+
+type RewardAuditEvent struct {
+	ID                   int64             `json:"-"`
+	EventID              string            `json:"id"`
+	ProviderID           string            `json:"provider_id,omitempty"`
+	OccurredAt           time.Time         `json:"occurred_at"`
+	EventType            string            `json:"event_type"`
+	LedgerID             *int64            `json:"ledger_id,omitempty"`
+	AmountMALIBU         string            `json:"amount_malibu,omitempty"`
+	WithdrawalHoldReason string            `json:"withdrawal_hold_reason,omitempty"`
+	TrustTier            string            `json:"trust_tier,omitempty"`
+	SourceReason         string            `json:"source_reason,omitempty"`
+	SafeSummary          string            `json:"summary"`
+	OperatorCorrelation  map[string]string `json:"operator_correlation,omitempty"`
+}
+
+type RewardAuditPage struct {
+	Events       []RewardAuditEvent `json:"events"`
+	NextBeforeID string             `json:"next_before_id,omitempty"`
+}
+
+type RewardAuditQuery struct {
+	ProviderID      string
+	Limit           int
+	BeforeID        int64
+	IncludeProvider bool
+	IncludeOperator bool
+}
+
+func InsertRewardAuditEvent(ctx context.Context, db *sql.DB, evt RewardAuditInsert) error {
+	if db == nil {
+		return errors.New("reward audit db is required")
+	}
+	_, err := insertRewardAuditEvent(ctx, db, evt)
+	return err
+}
+
+func insertRewardAuditEvent(ctx context.Context, q auditWriter, evt RewardAuditInsert) (int64, error) {
+	if strings.TrimSpace(evt.ProviderID) == "" {
+		return 0, errors.New("provider_id is required")
+	}
+	if strings.TrimSpace(evt.EventType) == "" {
+		return 0, errors.New("event_type is required")
+	}
+	if strings.TrimSpace(evt.SafeSummary) == "" {
+		return 0, errors.New("safe_summary is required")
+	}
+	occurredAt := evt.OccurredAt
+	if occurredAt.IsZero() {
+		occurredAt = time.Now().UTC()
+	}
+	correlation := evt.OperatorCorrelation
+	if correlation == nil {
+		correlation = map[string]string{}
+	}
+	correlationJSON, err := json.Marshal(correlation)
+	if err != nil {
+		return 0, fmt.Errorf("marshal operator correlation: %w", err)
+	}
+	var id int64
+	err = q.QueryRowContext(ctx, `
+        INSERT INTO malibu_reward_audit_events
+            (provider_id, occurred_at, event_type, ledger_id, amount_malibu,
+             withdrawal_hold_reason, trust_tier, source_reason, safe_summary,
+             operator_correlation)
+        VALUES ($1, $2, $3, $4, $5::NUMERIC(24,8),
+                $6, $7, $8, $9, $10::jsonb)
+        RETURNING id
+    `, evt.ProviderID, occurredAt, evt.EventType, nullInt64(evt.LedgerID),
+		nullStringValue(evt.AmountMALIBU), nullStringValue(evt.WithdrawalHoldReason),
+		nullStringValue(evt.TrustTier), nullStringValue(evt.SourceReason),
+		evt.SafeSummary, string(correlationJSON)).Scan(&id)
+	if err != nil {
+		return 0, err
+	}
+	return id, nil
+}
+
+func QueryRewardAuditEvents(ctx context.Context, db *sql.DB, query RewardAuditQuery) (RewardAuditPage, error) {
+	if db == nil {
+		return RewardAuditPage{}, errors.New("reward audit db is required")
+	}
+	if strings.TrimSpace(query.ProviderID) == "" {
+		return RewardAuditPage{}, errors.New("provider_id is required")
+	}
+	limit := normalizeAuditLimit(query.Limit)
+	rows, err := db.QueryContext(ctx, `
+        SELECT id, provider_id, occurred_at, event_type, ledger_id,
+               amount_malibu::TEXT, withdrawal_hold_reason, trust_tier,
+               source_reason, safe_summary, operator_correlation::TEXT
+          FROM malibu_reward_audit_events
+         WHERE provider_id = $1
+           AND ($2::BIGINT = 0 OR id < $2)
+         ORDER BY id DESC
+         LIMIT $3
+    `, query.ProviderID, query.BeforeID, limit+1)
+	if err != nil {
+		return RewardAuditPage{}, err
+	}
+	defer rows.Close()
+
+	events := make([]RewardAuditEvent, 0, limit)
+	var nextBefore string
+	for rows.Next() {
+		var (
+			id              int64
+			providerID      string
+			occurredAt      time.Time
+			eventType       string
+			ledgerID        sql.NullInt64
+			amount          sql.NullString
+			hold            sql.NullString
+			tier            sql.NullString
+			source          sql.NullString
+			summary         string
+			correlationText string
+		)
+		if err := rows.Scan(&id, &providerID, &occurredAt, &eventType, &ledgerID,
+			&amount, &hold, &tier, &source, &summary, &correlationText); err != nil {
+			return RewardAuditPage{}, err
+		}
+		if len(events) == limit {
+			if len(events) > 0 {
+				nextBefore = auditEventID(events[len(events)-1].ID)
+			}
+			continue
+		}
+		evt := RewardAuditEvent{
+			ID:          id,
+			EventID:     auditEventID(id),
+			OccurredAt:  occurredAt.UTC(),
+			EventType:   eventType,
+			SafeSummary: summary,
+		}
+		if query.IncludeProvider {
+			evt.ProviderID = providerID
+		}
+		if ledgerID.Valid {
+			v := ledgerID.Int64
+			evt.LedgerID = &v
+		}
+		if amount.Valid {
+			evt.AmountMALIBU = amount.String
+		}
+		if hold.Valid {
+			evt.WithdrawalHoldReason = hold.String
+		}
+		if tier.Valid {
+			evt.TrustTier = tier.String
+		}
+		if source.Valid {
+			evt.SourceReason = source.String
+		}
+		if query.IncludeOperator {
+			var correlation map[string]string
+			if err := json.Unmarshal([]byte(correlationText), &correlation); err != nil {
+				return RewardAuditPage{}, fmt.Errorf("decode operator correlation: %w", err)
+			}
+			evt.OperatorCorrelation = correlation
+		}
+		events = append(events, evt)
+	}
+	if err := rows.Err(); err != nil {
+		return RewardAuditPage{}, err
+	}
+	return RewardAuditPage{Events: events, NextBeforeID: nextBefore}, nil
+}
+
+func normalizeAuditLimit(limit int) int {
+	if limit <= 0 {
+		return defaultAuditLimit
+	}
+	if limit > maxAuditLimit {
+		return maxAuditLimit
+	}
+	return limit
+}
+
+func ParseAuditLimit(raw string) (int, error) {
+	if strings.TrimSpace(raw) == "" {
+		return defaultAuditLimit, nil
+	}
+	limit, err := strconv.Atoi(strings.TrimSpace(raw))
+	if err != nil || limit <= 0 || limit > maxAuditLimit {
+		return 0, fmt.Errorf("limit must be an integer from 1 to %d", maxAuditLimit)
+	}
+	return limit, nil
+}
+
+func ParseAuditBeforeID(raw string) (int64, error) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return 0, nil
+	}
+	raw = strings.TrimPrefix(raw, "mra_")
+	id, err := strconv.ParseInt(raw, 10, 64)
+	if err != nil || id <= 0 {
+		return 0, errors.New("before_id must be a reward audit id")
+	}
+	return id, nil
+}
+
+func auditEventID(id int64) string {
+	return fmt.Sprintf("mra_%d", id)
+}
+
+func nullStringValue(ns sql.NullString) interface{} {
+	if ns.Valid {
+		return ns.String
+	}
+	return nil
+}
+
+func nullInt64(ns sql.NullInt64) interface{} {
+	if ns.Valid {
+		return ns.Int64
+	}
+	return nil
+}
+
+func auditAccrualInserted(ctx context.Context, tx *sql.Tx, providerID string, ledgerID int64, amount, hold, tier, reason, externalRef string, at time.Time) error {
+	correlation := auditCorrelation(ledgerID, reason, externalRef)
+	return auditWithHold(ctx, tx, RewardAuditInsert{
+		ProviderID:           providerID,
+		OccurredAt:           at,
+		EventType:            AuditEventMalibuAccrualInserted,
+		LedgerID:             sql.NullInt64{Int64: ledgerID, Valid: true},
+		AmountMALIBU:         sql.NullString{String: amount, Valid: amount != ""},
+		WithdrawalHoldReason: sql.NullString{String: hold, Valid: hold != ""},
+		TrustTier:            sql.NullString{String: tier, Valid: tier != ""},
+		SourceReason:         sql.NullString{String: reason, Valid: reason != ""},
+		SafeSummary:          fmt.Sprintf("MALIBU accrual recorded: %s MALIBU.", amount),
+		OperatorCorrelation:  correlation,
+	})
+}
+
+func auditHoldApplied(ctx context.Context, tx *sql.Tx, providerID string, ledgerID int64, amount, hold, tier, reason, externalRef string, at time.Time) error {
+	return auditWithHold(ctx, tx, RewardAuditInsert{
+		ProviderID:           providerID,
+		OccurredAt:           at,
+		EventType:            AuditEventMalibuHoldApplied,
+		LedgerID:             sql.NullInt64{Int64: ledgerID, Valid: true},
+		AmountMALIBU:         sql.NullString{String: amount, Valid: amount != ""},
+		WithdrawalHoldReason: sql.NullString{String: hold, Valid: true},
+		TrustTier:            sql.NullString{String: tier, Valid: tier != ""},
+		SourceReason:         sql.NullString{String: reason, Valid: reason != ""},
+		SafeSummary:          holdSummary(hold),
+		OperatorCorrelation:  auditCorrelation(ledgerID, reason, externalRef),
+	})
+}
+
+func auditWalletDailyCapApplied(ctx context.Context, tx *sql.Tx, providerID string, ledgerID int64, amount, hold, tier, reason, externalRef string, at time.Time) error {
+	return auditWithHold(ctx, tx, RewardAuditInsert{
+		ProviderID:           providerID,
+		OccurredAt:           at,
+		EventType:            AuditEventWalletDailyCapApplied,
+		LedgerID:             sql.NullInt64{Int64: ledgerID, Valid: true},
+		AmountMALIBU:         sql.NullString{String: amount, Valid: amount != ""},
+		WithdrawalHoldReason: sql.NullString{String: hold, Valid: true},
+		TrustTier:            sql.NullString{String: tier, Valid: tier != ""},
+		SourceReason:         sql.NullString{String: reason, Valid: reason != ""},
+		SafeSummary:          "Wallet daily cap applied; this accrual is visible but not withdrawable yet.",
+		OperatorCorrelation:  auditCorrelation(ledgerID, reason, externalRef),
+	})
+}
+
+func auditHoldCleared(ctx context.Context, tx *sql.Tx, providerID string, ledgerID int64, amount, hold, tier, reason string, at time.Time) error {
+	return auditWithHold(ctx, tx, RewardAuditInsert{
+		ProviderID:           providerID,
+		OccurredAt:           at,
+		EventType:            AuditEventMalibuHoldCleared,
+		LedgerID:             sql.NullInt64{Int64: ledgerID, Valid: true},
+		AmountMALIBU:         sql.NullString{String: amount, Valid: amount != ""},
+		WithdrawalHoldReason: sql.NullString{String: hold, Valid: hold != ""},
+		TrustTier:            sql.NullString{String: tier, Valid: tier != ""},
+		SourceReason:         sql.NullString{String: reason, Valid: reason != ""},
+		SafeSummary:          fmt.Sprintf("Reward hold cleared: %s.", hold),
+		OperatorCorrelation:  auditCorrelation(ledgerID, reason, ""),
+	})
+}
+
+func auditTrustTierChangedTx(ctx context.Context, tx *sql.Tx, providerID, tier string, at time.Time) error {
+	eventType := AuditEventTrustTierPromoted
+	summary := "Provider promoted to trusted; new eligible accruals can become withdrawable."
+	if tier == TierProvisional {
+		eventType = AuditEventTrustTierDemoted
+		summary = "Provider demoted to provisional; new accruals are held during requalification."
+	}
+	return auditWithHold(ctx, tx, RewardAuditInsert{
+		ProviderID:          providerID,
+		OccurredAt:          at,
+		EventType:           eventType,
+		TrustTier:           sql.NullString{String: tier, Valid: tier != ""},
+		SafeSummary:         summary,
+		OperatorCorrelation: map[string]string{"transition": eventType},
+	})
+}
+
+func auditWithHold(ctx context.Context, tx *sql.Tx, evt RewardAuditInsert) error {
+	_, err := insertRewardAuditEvent(ctx, tx, evt)
+	return err
+}
+
+func auditCorrelation(ledgerID int64, reason, externalRef string) map[string]string {
+	out := map[string]string{
+		"ledger_id": fmt.Sprintf("%d", ledgerID),
+	}
+	if reason != "" {
+		out["source_reason"] = reason
+	}
+	if externalRef != "" {
+		out["external_ref"] = externalRef
+	}
+	return out
+}
+
+func holdSummary(hold string) string {
+	switch hold {
+	case HoldTrustTierProvisional:
+		return "Reward hold applied because the provider is provisional."
+	case HoldPerWalletDailyCap:
+		return "Reward hold applied because the bound wallet reached the daily cap."
+	case HoldDemotionCooldown:
+		return "Reward hold applied during demotion cooldown."
+	default:
+		return "Reward hold applied."
+	}
+}

--- a/phase4-coordinator/internal/rewards/audit_limiter.go
+++ b/phase4-coordinator/internal/rewards/audit_limiter.go
@@ -1,0 +1,83 @@
+package rewards
+
+import (
+	"sync"
+	"time"
+)
+
+const rewardAuditLimiterTTL = 15 * time.Minute
+
+// RewardAuditLimiter bounds provider-scoped audit reads before they reach
+// PostgreSQL. Nginx handles unauthenticated IP floods; this guards the
+// authenticated provider dimension inside the coordinator process.
+type RewardAuditLimiter struct {
+	mu             sync.Mutex
+	perMinute      int
+	maxConcurrency int
+	buckets        map[string]*rewardAuditBucket
+}
+
+type rewardAuditBucket struct {
+	windowMinute int64
+	count        int
+	inflight     int
+	lastSeen     time.Time
+}
+
+func NewRewardAuditLimiter(perMinute, maxConcurrency int) *RewardAuditLimiter {
+	if perMinute <= 0 {
+		perMinute = 60
+	}
+	if maxConcurrency <= 0 {
+		maxConcurrency = 4
+	}
+	return &RewardAuditLimiter{
+		perMinute:      perMinute,
+		maxConcurrency: maxConcurrency,
+		buckets:        make(map[string]*rewardAuditBucket),
+	}
+}
+
+func (l *RewardAuditLimiter) Allow(providerID string, now time.Time) (func(), bool) {
+	if l == nil || providerID == "" {
+		return func() {}, true
+	}
+	now = now.UTC()
+	min := now.Unix() / 60
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	l.sweepLocked(now)
+	b := l.buckets[providerID]
+	if b == nil {
+		b = &rewardAuditBucket{windowMinute: min, lastSeen: now}
+		l.buckets[providerID] = b
+	}
+	if b.windowMinute != min {
+		b.windowMinute = min
+		b.count = 0
+	}
+	b.lastSeen = now
+	if b.count >= l.perMinute || b.inflight >= l.maxConcurrency {
+		return nil, false
+	}
+	b.count++
+	b.inflight++
+	return func() { l.release(providerID) }, true
+}
+
+func (l *RewardAuditLimiter) release(providerID string) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	if b := l.buckets[providerID]; b != nil && b.inflight > 0 {
+		b.inflight--
+	}
+}
+
+func (l *RewardAuditLimiter) sweepLocked(now time.Time) {
+	cutoff := now.Add(-rewardAuditLimiterTTL)
+	for providerID, b := range l.buckets {
+		if b.inflight == 0 && b.lastSeen.Before(cutoff) {
+			delete(l.buckets, providerID)
+		}
+	}
+}

--- a/phase4-coordinator/internal/rewards/audit_test.go
+++ b/phase4-coordinator/internal/rewards/audit_test.go
@@ -1,0 +1,76 @@
+package rewards
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+type fakeAuditTokens map[string]string
+
+func (f fakeAuditTokens) ValidateAndMarkTokenUsed(_ context.Context, raw string) (string, bool, error) {
+	providerID, ok := f[raw]
+	return providerID, ok, nil
+}
+
+func TestParseAuditPageBounds(t *testing.T) {
+	if got, err := ParseAuditLimit(""); err != nil || got != defaultAuditLimit {
+		t.Fatalf("default limit got (%d,%v)", got, err)
+	}
+	if got, err := ParseAuditLimit("100"); err != nil || got != 100 {
+		t.Fatalf("max limit got (%d,%v)", got, err)
+	}
+	for _, raw := range []string{"0", "-1", "101", "many"} {
+		if _, err := ParseAuditLimit(raw); err == nil {
+			t.Fatalf("ParseAuditLimit(%q) succeeded, want error", raw)
+		}
+	}
+	if got, err := ParseAuditBeforeID("mra_42"); err != nil || got != 42 {
+		t.Fatalf("before id got (%d,%v)", got, err)
+	}
+	for _, raw := range []string{"mra_0", "mra_bad", "-1"} {
+		if _, err := ParseAuditBeforeID(raw); err == nil {
+			t.Fatalf("ParseAuditBeforeID(%q) succeeded, want error", raw)
+		}
+	}
+}
+
+func TestRewardAuditHandlerAuthAndCursorValidation(t *testing.T) {
+	h := NewRewardAuditHandler(AuditHandlerDeps{
+		TokenStore:            fakeAuditTokens{"good": "provider-a"},
+		RequireProviderTokens: true,
+	})
+
+	unauth := httptest.NewRecorder()
+	h.ServeHTTP(unauth, httptest.NewRequest(http.MethodGet, "/v1/provider/malibu-reward-audit", nil))
+	if unauth.Code != http.StatusUnauthorized {
+		t.Fatalf("unauth code=%d", unauth.Code)
+	}
+
+	badLimit := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/v1/provider/malibu-reward-audit?limit=101", nil)
+	req.Header.Set("Authorization", "Bearer good")
+	h.ServeHTTP(badLimit, req)
+	if badLimit.Code != http.StatusBadRequest {
+		t.Fatalf("bad limit code=%d body=%s", badLimit.Code, badLimit.Body.String())
+	}
+}
+
+func TestRewardAuditAdminHandlerAuthAndProviderRequired(t *testing.T) {
+	h := NewRewardAuditAdminHandler(AuditHandlerDeps{OperatorKey: "operator"})
+
+	unauth := httptest.NewRecorder()
+	h.ServeHTTP(unauth, httptest.NewRequest(http.MethodGet, "/admin/malibu-reward-audit?provider_id=p", nil))
+	if unauth.Code != http.StatusUnauthorized {
+		t.Fatalf("unauth code=%d", unauth.Code)
+	}
+
+	missingProvider := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/admin/malibu-reward-audit", nil)
+	req.Header.Set("Authorization", "Bearer operator")
+	h.ServeHTTP(missingProvider, req)
+	if missingProvider.Code != http.StatusBadRequest {
+		t.Fatalf("missing provider code=%d body=%s", missingProvider.Code, missingProvider.Body.String())
+	}
+}

--- a/phase4-coordinator/internal/rewards/audit_test.go
+++ b/phase4-coordinator/internal/rewards/audit_test.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 )
 
 type fakeAuditTokens map[string]string
@@ -12,6 +13,22 @@ type fakeAuditTokens map[string]string
 func (f fakeAuditTokens) ValidateAndMarkTokenUsed(_ context.Context, raw string) (string, bool, error) {
 	providerID, ok := f[raw]
 	return providerID, ok, nil
+}
+
+type readOnlyAuditTokens struct {
+	providerID string
+	readOnly   int
+	marked     int
+}
+
+func (f *readOnlyAuditTokens) ValidateTokenReadOnly(context.Context, string) (string, bool, error) {
+	f.readOnly++
+	return f.providerID, true, nil
+}
+
+func (f *readOnlyAuditTokens) ValidateAndMarkTokenUsed(context.Context, string) (string, bool, error) {
+	f.marked++
+	return f.providerID, true, nil
 }
 
 func TestParseAuditPageBounds(t *testing.T) {
@@ -54,6 +71,71 @@ func TestRewardAuditHandlerAuthAndCursorValidation(t *testing.T) {
 	h.ServeHTTP(badLimit, req)
 	if badLimit.Code != http.StatusBadRequest {
 		t.Fatalf("bad limit code=%d body=%s", badLimit.Code, badLimit.Body.String())
+	}
+}
+
+func TestRewardAuditHandlerPrefersReadOnlyTokenValidation(t *testing.T) {
+	tokens := &readOnlyAuditTokens{providerID: "provider-a"}
+	h := NewRewardAuditHandler(AuditHandlerDeps{
+		TokenStore:            tokens,
+		RequireProviderTokens: true,
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/v1/provider/malibu-reward-audit?limit=101", nil)
+	req.Header.Set("Authorization", "Bearer good")
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("code=%d body=%s", rec.Code, rec.Body.String())
+	}
+	if tokens.readOnly != 1 || tokens.marked != 0 {
+		t.Fatalf("validation calls readOnly=%d marked=%d, want readOnly only", tokens.readOnly, tokens.marked)
+	}
+}
+
+func TestRewardAuditLimiterEnforcesProviderWindowAndConcurrency(t *testing.T) {
+	limiter := NewRewardAuditLimiter(2, 1)
+	now := time.Date(2026, 8, 17, 12, 0, 0, 0, time.UTC)
+
+	release, ok := limiter.Allow("provider-a", now)
+	if !ok {
+		t.Fatal("first request should be allowed")
+	}
+	if _, ok := limiter.Allow("provider-a", now); ok {
+		t.Fatal("second concurrent request should be rejected")
+	}
+	release()
+	release, ok = limiter.Allow("provider-a", now)
+	if !ok {
+		t.Fatal("second request after release should be allowed")
+	}
+	release()
+	if _, ok := limiter.Allow("provider-a", now); ok {
+		t.Fatal("third request in the same minute should be rate limited")
+	}
+	if release, ok := limiter.Allow("provider-a", now.Add(time.Minute)); !ok {
+		t.Fatal("next window should be allowed")
+	} else {
+		release()
+	}
+}
+
+func TestRewardAuditLimiterPreservesInflightAcrossMinuteRollover(t *testing.T) {
+	limiter := NewRewardAuditLimiter(10, 1)
+	now := time.Date(2026, 8, 17, 12, 0, 0, 0, time.UTC)
+
+	releaseA, ok := limiter.Allow("provider-a", now)
+	if !ok {
+		t.Fatal("first request should be allowed")
+	}
+	if _, ok := limiter.Allow("provider-a", now.Add(time.Minute)); ok {
+		t.Fatal("second request in next window must be rejected while first remains in flight")
+	}
+	releaseA()
+	if release, ok := limiter.Allow("provider-a", now.Add(time.Minute)); !ok {
+		t.Fatal("request after release should be allowed")
+	} else {
+		release()
 	}
 }
 

--- a/phase4-coordinator/internal/rewards/emission.go
+++ b/phase4-coordinator/internal/rewards/emission.go
@@ -123,7 +123,7 @@ func (r *Runner) accrueProviderReward(ctx context.Context, providerID string, am
 		}
 		remaining := r.cfg.ProviderDailyCapMALIBU - st.ProviderDayMALIBU
 		if remaining <= 0 {
-			return nil
+			return r.recordFullyCappedAccrual(ctx, tx, providerID, "", st.TrustTier, reason, externalRef)
 		}
 		accrue := math.Min(amount, remaining)
 		if accrue <= 0 {
@@ -139,7 +139,7 @@ func (r *Runner) accrueProviderReward(ctx context.Context, providerID string, am
 				return err
 			}
 			if walletAccrue <= 0 {
-				return nil
+				return r.recordFullyCappedAccrual(ctx, tx, providerID, HoldPerWalletDailyCap, st.TrustTier, reason, externalRef)
 			}
 			accrue = walletAccrue
 			if walletHeld {
@@ -209,6 +209,26 @@ func (r *Runner) accrueProviderReward(ctx context.Context, providerID string, am
 	})
 }
 
+func (r *Runner) recordFullyCappedAccrual(ctx context.Context, tx *sql.Tx, providerID, hold, tier, reason, externalRef string) error {
+	if externalRef == "" {
+		return nil
+	}
+	now := time.Now().UTC()
+	var ledgerID int64
+	if err := tx.QueryRowContext(ctx, `
+        INSERT INTO provider_rewards_ledger
+            (provider_id, unix_ts, amount_malibu, withdrawal_hold_reason, reason, external_ref)
+        VALUES ($1, $2, $3, $4, $5, $6)
+        RETURNING id
+    `, providerID, now.Unix(), formatMALIBU(0), sql.NullString{String: hold, Valid: hold != ""}, reason, externalRef).Scan(&ledgerID); err != nil {
+		return err
+	}
+	if hold == "" {
+		return auditAccrualInserted(ctx, tx, providerID, ledgerID, formatMALIBU(0), "", tier, reason, externalRef, now)
+	}
+	return auditWalletDailyCapApplied(ctx, tx, providerID, ledgerID, formatMALIBU(0), hold, tier, reason, externalRef, now)
+}
+
 func rewardExternalRefExists(ctx context.Context, tx *sql.Tx, externalRef string) (bool, error) {
 	var exists bool
 	err := tx.QueryRowContext(ctx, `
@@ -256,9 +276,7 @@ func applyWalletCap(ctx context.Context, tx *sql.Tx, wallet string, day time.Tim
 	}
 	remaining := cap - sum
 	if remaining <= 0 {
-		// Still accrue at zero? Spec says accrue with hold when cap hit.
-		// Accrue the requested amount but mark held — caller sets hold.
-		return true, want, nil
+		return true, 0, nil
 	}
 	if want > remaining {
 		return true, remaining, nil

--- a/phase4-coordinator/internal/rewards/emission.go
+++ b/phase4-coordinator/internal/rewards/emission.go
@@ -131,6 +131,7 @@ func (r *Runner) accrueProviderReward(ctx context.Context, providerID string, am
 		}
 
 		hold := holdReasonForState(st)
+		walletCapApplied := false
 		wallet := strings.ToLower(st.BoundWallet.String)
 		if wallet != "" && strings.HasPrefix(wallet, "0x") {
 			walletHeld, walletAccrue, err := applyWalletCap(ctx, tx, wallet, today, accrue, r.cfg.WalletDailyCapMALIBU, st.TrustTier)
@@ -142,6 +143,7 @@ func (r *Runner) accrueProviderReward(ctx context.Context, providerID string, am
 			}
 			accrue = walletAccrue
 			if walletHeld {
+				walletCapApplied = true
 				if hold == "" {
 					hold = HoldPerWalletDailyCap
 				}
@@ -158,12 +160,27 @@ func (r *Runner) accrueProviderReward(ctx context.Context, providerID string, am
 		}
 
 		now := time.Now().UTC()
-		if _, err := tx.ExecContext(ctx, `
+		var ledgerID int64
+		if err := tx.QueryRowContext(ctx, `
             INSERT INTO provider_rewards_ledger
                 (provider_id, unix_ts, amount_malibu, withdrawal_hold_reason, reason, external_ref)
             VALUES ($1, $2, $3, $4, $5, $6)
-        `, providerID, now.Unix(), formatMALIBU(accrue), holdArg, reason, refArg); err != nil {
+            RETURNING id
+        `, providerID, now.Unix(), formatMALIBU(accrue), holdArg, reason, refArg).Scan(&ledgerID); err != nil {
 			return err
+		}
+		if err := auditAccrualInserted(ctx, tx, providerID, ledgerID, formatMALIBU(accrue), hold, st.TrustTier, reason, externalRef, now); err != nil {
+			return err
+		}
+		if hold != "" {
+			if err := auditHoldApplied(ctx, tx, providerID, ledgerID, formatMALIBU(accrue), hold, st.TrustTier, reason, externalRef, now); err != nil {
+				return err
+			}
+		}
+		if walletCapApplied {
+			if err := auditWalletDailyCapApplied(ctx, tx, providerID, ledgerID, formatMALIBU(accrue), HoldPerWalletDailyCap, st.TrustTier, reason, externalRef, now); err != nil {
+				return err
+			}
 		}
 
 		newDayTotal := st.ProviderDayMALIBU + accrue
@@ -283,9 +300,12 @@ func bumpWalletDaily(ctx context.Context, tx *sql.Tx, wallet string, day time.Ti
 }
 
 type pendingReplayRow struct {
-	id   int64
-	amt  float64
-	tier string
+	id         int64
+	providerID string
+	amt        float64
+	amountText string
+	tier       string
+	reason     sql.NullString
 }
 
 func replayCapPending(ctx context.Context, tx *sql.Tx, wallet string, walletCap float64) error {
@@ -299,7 +319,8 @@ func replayCapPending(ctx context.Context, tx *sql.Tx, wallet string, walletCap 
 	// open desyncs the wire protocol (surfaces as
 	// `pq: unexpected Parse response "(C) CommandComplete"`).
 	rows, err := tx.QueryContext(ctx, `
-        SELECT prl.id, prl.amount_malibu::FLOAT8, pes.trust_tier
+        SELECT prl.id, prl.provider_id, prl.amount_malibu::FLOAT8, prl.amount_malibu::TEXT,
+               pes.trust_tier, prl.reason
           FROM provider_rewards_ledger prl
           JOIN provider_emission_state pes ON pes.provider_id = prl.provider_id
          WHERE pes.bound_wallet = $1
@@ -314,7 +335,7 @@ func replayCapPending(ctx context.Context, tx *sql.Tx, wallet string, walletCap 
 	var pending []pendingReplayRow
 	for rows.Next() {
 		var row pendingReplayRow
-		if err := rows.Scan(&row.id, &row.amt, &row.tier); err != nil {
+		if err := rows.Scan(&row.id, &row.providerID, &row.amt, &row.amountText, &row.tier, &row.reason); err != nil {
 			_ = rows.Close()
 			return err
 		}
@@ -344,6 +365,9 @@ func replayCapPending(ctx context.Context, tx *sql.Tx, wallet string, walletCap 
                    SET withdrawal_hold_reason = NULL
                  WHERE id = $1
             `, row.id); err != nil {
+				return err
+			}
+			if err := auditHoldCleared(ctx, tx, row.providerID, row.id, row.amountText, HoldPerWalletDailyCap, row.tier, row.reason.String, time.Now().UTC()); err != nil {
 				return err
 			}
 		}

--- a/phase4-coordinator/internal/rewards/emission_integration_test.go
+++ b/phase4-coordinator/internal/rewards/emission_integration_test.go
@@ -32,6 +32,14 @@ type pgFixture struct {
 	dbName    string
 }
 
+type testConnectivity struct {
+	ok bool
+}
+
+func (c *testConnectivity) HeartbeatOK(string, time.Time) bool {
+	return c.ok
+}
+
 func (f *pgFixture) adminDSN() string {
 	return fmt.Sprintf("postgres://postgres:%s@%s:%s/%s?sslmode=disable", roleAdminPassword, f.host, f.port, f.dbName)
 }
@@ -108,6 +116,20 @@ func testEmissionConfig(tickInterval time.Duration, providerCap, walletCap float
 	}
 }
 
+func testSQLitePayoutDBPath(t *testing.T) string {
+	t.Helper()
+	path := t.TempDir() + "/payout.db"
+	db, err := sql.Open("sqlite", path)
+	if err != nil {
+		t.Fatalf("open sqlite payout db: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+	if _, err := db.Exec("PRAGMA user_version = 1"); err != nil {
+		t.Fatalf("initialize sqlite payout db: %v", err)
+	}
+	return path
+}
+
 func TestProvisionalAccrualSetsWithdrawalHold(t *testing.T) {
 	fx, adminDB := startPostgres(t)
 	writerDB := openRewardsWriter(t, fx)
@@ -155,6 +177,176 @@ func TestProvisionalAccrualSetsWithdrawalHold(t *testing.T) {
 	}
 }
 
+func TestRewardAuditEventsAreProviderScopedPaginatedAndRedacted(t *testing.T) {
+	fx, _ := startPostgres(t)
+	writerDB := openRewardsWriter(t, fx)
+	ctx := context.Background()
+
+	for _, pid := range []string{"p_audit_a", "p_audit_b"} {
+		if _, err := writerDB.ExecContext(ctx, `
+            INSERT INTO provider_emission_state (provider_id, trust_tier)
+            VALUES ($1, 'provisional')
+        `, pid); err != nil {
+			t.Fatalf("seed state %s: %v", pid, err)
+		}
+	}
+
+	cfg := testEmissionConfig(time.Hour, 25, 100)
+	runner, err := rewards.New(writerDB, cfg, zerolog.Nop(), rewards.RunnerDeps{})
+	if err != nil {
+		t.Fatalf("new runner: %v", err)
+	}
+	if err := runner.RunEmissionTickOnce(ctx); err != nil {
+		t.Fatalf("emission tick: %v", err)
+	}
+
+	page, err := rewards.QueryRewardAuditEvents(ctx, writerDB, rewards.RewardAuditQuery{
+		ProviderID: "p_audit_a",
+		Limit:      1,
+	})
+	if err != nil {
+		t.Fatalf("query provider audit: %v", err)
+	}
+	if len(page.Events) != 1 {
+		t.Fatalf("events=%d want 1", len(page.Events))
+	}
+	firstID := page.Events[0].EventID
+	if page.Events[0].ProviderID != "" {
+		t.Fatalf("provider response leaked provider_id %q", page.Events[0].ProviderID)
+	}
+	if page.Events[0].OperatorCorrelation != nil {
+		t.Fatalf("provider response leaked operator correlation: %#v", page.Events[0].OperatorCorrelation)
+	}
+	if page.Events[0].EventID == "" || page.NextBeforeID == "" {
+		t.Fatalf("missing event id or next cursor: event=%q next=%q", page.Events[0].EventID, page.NextBeforeID)
+	}
+
+	beforeID, err := rewards.ParseAuditBeforeID(page.NextBeforeID)
+	if err != nil {
+		t.Fatalf("parse next cursor: %v", err)
+	}
+	nextPage, err := rewards.QueryRewardAuditEvents(ctx, writerDB, rewards.RewardAuditQuery{
+		ProviderID: "p_audit_a",
+		Limit:      10,
+		BeforeID:   beforeID,
+	})
+	if err != nil {
+		t.Fatalf("query next provider audit: %v", err)
+	}
+	if len(nextPage.Events) == 0 {
+		t.Fatal("expected older audit event on next page")
+	}
+	if nextPage.Events[0].EventID == firstID {
+		t.Fatalf("pagination repeated first event %q", firstID)
+	}
+
+	operatorPage, err := rewards.QueryRewardAuditEvents(ctx, writerDB, rewards.RewardAuditQuery{
+		ProviderID:      "p_audit_a",
+		Limit:           10,
+		IncludeProvider: true,
+		IncludeOperator: true,
+	})
+	if err != nil {
+		t.Fatalf("query operator audit: %v", err)
+	}
+	for _, evt := range operatorPage.Events {
+		if evt.ProviderID != "p_audit_a" {
+			t.Fatalf("operator event provider_id=%q want p_audit_a", evt.ProviderID)
+		}
+		if evt.OperatorCorrelation == nil || evt.OperatorCorrelation["ledger_id"] == "" {
+			t.Fatalf("operator event missing ledger correlation: %#v", evt.OperatorCorrelation)
+		}
+	}
+}
+
+func TestTrustTierTransitionsWriteRewardAuditEvents(t *testing.T) {
+	fx, _ := startPostgres(t)
+	writerDB := openRewardsWriter(t, fx)
+	ctx := context.Background()
+
+	providerID := "p_trust_audit"
+	windowOpen := time.Now().UTC().Add(-73 * time.Hour)
+	if _, err := writerDB.ExecContext(ctx, `
+        INSERT INTO provider_emission_state (provider_id, trust_tier)
+        VALUES ($1, 'provisional');
+
+        INSERT INTO provider_trust_eval_state
+            (provider_id, uptime_ok_since, unlock_pair_ok_since, last_eval_at, updated_at)
+        VALUES ($1, $2, $2, now(), now());
+
+        INSERT INTO provider_trust_operator_promotions
+            (provider_id, promoted_by, reason, pending_id)
+        VALUES ($1, 'integration-test', 'trust audit transition coverage', '00000000-0000-0000-0000-000000001021');
+    `, providerID, windowOpen); err != nil {
+		t.Fatalf("seed trust transition state: %v", err)
+	}
+
+	cfg := testEmissionConfig(time.Hour, 25, 100)
+	cfg.SQLitePayoutDBPath = testSQLitePayoutDBPath(t)
+	connectivity := &testConnectivity{ok: true}
+	runner, err := rewards.New(writerDB, cfg, zerolog.Nop(), rewards.RunnerDeps{
+		Connectivity: connectivity,
+	})
+	if err != nil {
+		t.Fatalf("new runner: %v", err)
+	}
+
+	if err := runner.RunUnlockEvalOnce(ctx); err != nil {
+		t.Fatalf("promote provider: %v", err)
+	}
+
+	connectivity.ok = false
+	if err := runner.RunUnlockEvalOnce(ctx); err != nil {
+		t.Fatalf("demote provider: %v", err)
+	}
+
+	if _, err := writerDB.ExecContext(ctx, `
+        UPDATE provider_emission_state
+           SET demotion_cooldown_until = now() - interval '1 hour'
+         WHERE provider_id = $1;
+
+        UPDATE provider_trust_eval_state
+           SET uptime_ok_since = $2,
+               unlock_pair_ok_since = $2,
+               updated_at = now()
+         WHERE provider_id = $1;
+    `, providerID, windowOpen); err != nil {
+		t.Fatalf("seed requalification window: %v", err)
+	}
+	connectivity.ok = true
+	if err := runner.RunUnlockEvalOnce(ctx); err != nil {
+		t.Fatalf("requalify provider: %v", err)
+	}
+
+	page, err := rewards.QueryRewardAuditEvents(ctx, writerDB, rewards.RewardAuditQuery{
+		ProviderID:      providerID,
+		Limit:           10,
+		IncludeProvider: true,
+		IncludeOperator: true,
+	})
+	if err != nil {
+		t.Fatalf("query trust audit events: %v", err)
+	}
+	got := make([]string, 0, len(page.Events))
+	for _, evt := range page.Events {
+		if evt.ProviderID != providerID {
+			t.Fatalf("event provider_id=%q want %q", evt.ProviderID, providerID)
+		}
+		if evt.OperatorCorrelation == nil || evt.OperatorCorrelation["transition"] != evt.EventType {
+			t.Fatalf("missing trust transition correlation for %s: %#v", evt.EventType, evt.OperatorCorrelation)
+		}
+		got = append(got, evt.EventType)
+	}
+	want := []string{
+		rewards.AuditEventTrustTierPromoted,
+		rewards.AuditEventTrustTierDemoted,
+		rewards.AuditEventTrustTierPromoted,
+	}
+	if fmt.Sprint(got) != fmt.Sprint(want) {
+		t.Fatalf("trust audit events = %v, want %v", got, want)
+	}
+}
+
 func TestWalletDailyCapAcrossProviders(t *testing.T) {
 	fx, adminDB := startPostgres(t)
 	writerDB := openRewardsWriter(t, fx)
@@ -191,6 +383,23 @@ func TestWalletDailyCapAcrossProviders(t *testing.T) {
 	}
 	if sum > 100.0001 {
 		t.Fatalf("wallet aggregate %v exceeds cap 100", sum)
+	}
+
+	page, err := rewards.QueryRewardAuditEvents(ctx, writerDB, rewards.RewardAuditQuery{
+		ProviderID: "p_b",
+		Limit:      50,
+	})
+	if err != nil {
+		t.Fatalf("query p_b audit: %v", err)
+	}
+	var sawWalletCap bool
+	for _, evt := range page.Events {
+		if evt.EventType == rewards.AuditEventWalletDailyCapApplied {
+			sawWalletCap = true
+		}
+	}
+	if !sawWalletCap {
+		t.Fatal("expected wallet_daily_cap_applied audit event even while provisional hold remains primary")
 	}
 }
 
@@ -489,5 +698,22 @@ func TestCapReplayPendingDoesNotDesyncConnection(t *testing.T) {
 	}
 	if capReplayPending {
 		t.Fatal("cap_replay_pending should be cleared after successful replay")
+	}
+
+	auditPage, err := rewards.QueryRewardAuditEvents(ctx, writerDB, rewards.RewardAuditQuery{
+		ProviderID: providerID,
+		Limit:      10,
+	})
+	if err != nil {
+		t.Fatalf("query audit events: %v", err)
+	}
+	var sawHoldCleared bool
+	for _, evt := range auditPage.Events {
+		if evt.EventType == rewards.AuditEventMalibuHoldCleared {
+			sawHoldCleared = true
+		}
+	}
+	if !sawHoldCleared {
+		t.Fatal("expected malibu_hold_cleared audit event after cap replay")
 	}
 }

--- a/phase4-coordinator/internal/rewards/emission_integration_test.go
+++ b/phase4-coordinator/internal/rewards/emission_integration_test.go
@@ -185,7 +185,10 @@ func TestZeroWalletCapMarkerDoesNotBecomePermanentHold(t *testing.T) {
 	if _, err := adminDB.ExecContext(ctx, `
         INSERT INTO provider_emission_state (provider_id, trust_tier, bound_wallet)
         VALUES ('p_zero_marker', 'trusted', '0xzero');
-
+    `); err != nil {
+		t.Fatalf("seed provider state: %v", err)
+	}
+	if _, err := adminDB.ExecContext(ctx, `
         INSERT INTO provider_rewards_ledger
             (provider_id, unix_ts, amount_malibu, withdrawal_hold_reason, reason, external_ref)
         VALUES
@@ -785,12 +788,23 @@ func TestCapReplayPendingDoesNotDesyncConnection(t *testing.T) {
 	}
 
 	heldUnixTS := time.Now().UTC().Add(-time.Hour).Unix()
-	if _, err := adminDB.ExecContext(ctx, `
+	var heldLedgerID int64
+	if err := adminDB.QueryRowContext(ctx, `
         INSERT INTO provider_rewards_ledger
             (provider_id, unix_ts, amount_malibu, withdrawal_hold_reason, reason)
         VALUES ($1, $2, 10, $3, 'malibu_bootstrap_tick')
-    `, providerID, heldUnixTS, rewards.HoldPerWalletDailyCap); err != nil {
+        RETURNING id
+    `, providerID, heldUnixTS, rewards.HoldPerWalletDailyCap).Scan(&heldLedgerID); err != nil {
 		t.Fatalf("seed held ledger row: %v", err)
+	}
+	if _, err := adminDB.ExecContext(ctx, `
+        INSERT INTO malibu_reward_audit_events
+            (provider_id, event_type, ledger_id, amount_malibu,
+             withdrawal_hold_reason, trust_tier, source_reason, safe_summary)
+        VALUES ($1, $2, $3, 10, $4, 'trusted', 'malibu_bootstrap_tick',
+                'Reward hit the per-wallet daily cap.')
+    `, providerID, rewards.AuditEventWalletDailyCapApplied, heldLedgerID, rewards.HoldPerWalletDailyCap); err != nil {
+		t.Fatalf("seed wallet cap audit event: %v", err)
 	}
 
 	cfg := testEmissionConfig(time.Hour, 25, 100)
@@ -852,5 +866,21 @@ func TestCapReplayPendingDoesNotDesyncConnection(t *testing.T) {
 	}
 	if !sawHoldCleared {
 		t.Fatal("expected malibu_hold_cleared audit event after cap replay")
+	}
+
+	bal, err := rewards.QueryAccrualBalance(ctx, writerDB, providerID, cfg)
+	if err != nil {
+		t.Fatalf("query accrual balance after cap replay: %v", err)
+	}
+	if testContainsString(bal.HoldReasons, rewards.HoldPerWalletDailyCap) {
+		t.Fatalf("hold reasons after cap replay = %v, want wallet cap cleared", bal.HoldReasons)
+	}
+	eligibility := rewards.RewardEligibilityFromBalanceAndTrust(bal, rewards.TrustCriteriaStatus{
+		WalletBound:          true,
+		VerifiedReceiptCount: 999,
+		AppAttested:          true,
+	})
+	if eligibility.PrimaryReason == rewards.ReasonHeldWalletDailyCap {
+		t.Fatalf("primary_reason after cap replay = %q, want wallet cap cleared", eligibility.PrimaryReason)
 	}
 }

--- a/phase4-coordinator/internal/rewards/emission_integration_test.go
+++ b/phase4-coordinator/internal/rewards/emission_integration_test.go
@@ -177,6 +177,41 @@ func TestProvisionalAccrualSetsWithdrawalHold(t *testing.T) {
 	}
 }
 
+func TestZeroWalletCapMarkerDoesNotBecomePermanentHold(t *testing.T) {
+	fx, adminDB := startPostgres(t)
+	writerDB := openRewardsWriter(t, fx)
+	ctx := context.Background()
+
+	if _, err := adminDB.ExecContext(ctx, `
+        INSERT INTO provider_emission_state (provider_id, trust_tier, bound_wallet)
+        VALUES ('p_zero_marker', 'trusted', '0xzero');
+
+        INSERT INTO provider_rewards_ledger
+            (provider_id, unix_ts, amount_malibu, withdrawal_hold_reason, reason, external_ref)
+        VALUES
+            ('p_zero_marker', extract(epoch from now() - interval '1 day')::BIGINT,
+             0, $1, $2, 'spec022:req-zero:0:p_zero_marker');
+    `, rewards.HoldPerWalletDailyCap, rewards.ReasonMalibuVerifiedUsefulWorkV02); err != nil {
+		t.Fatalf("seed zero marker: %v", err)
+	}
+
+	bal, err := rewards.QueryAccrualBalance(ctx, writerDB, "p_zero_marker", testEmissionConfig(time.Hour, 25, 100))
+	if err != nil {
+		t.Fatalf("query accrual balance: %v", err)
+	}
+	if testContainsString(bal.HoldReasons, rewards.HoldPerWalletDailyCap) {
+		t.Fatalf("hold reasons = %v, zero historical marker must not act as current cap", bal.HoldReasons)
+	}
+	eligibility := rewards.RewardEligibilityFromBalanceAndTrust(bal, rewards.TrustCriteriaStatus{
+		WalletBound:          true,
+		VerifiedReceiptCount: 999,
+		AppAttested:          true,
+	})
+	if eligibility.PrimaryReason == rewards.ReasonHeldWalletDailyCap {
+		t.Fatalf("primary_reason = %q, zero historical marker must not act as current cap", eligibility.PrimaryReason)
+	}
+}
+
 func TestRewardAuditEventsAreProviderScopedPaginatedAndRedacted(t *testing.T) {
 	fx, _ := startPostgres(t)
 	writerDB := openRewardsWriter(t, fx)
@@ -268,17 +303,23 @@ func TestTrustTierTransitionsWriteRewardAuditEvents(t *testing.T) {
 	windowOpen := time.Now().UTC().Add(-73 * time.Hour)
 	if _, err := writerDB.ExecContext(ctx, `
         INSERT INTO provider_emission_state (provider_id, trust_tier)
-        VALUES ($1, 'provisional');
-
+        VALUES ($1, 'provisional')
+    `, providerID); err != nil {
+		t.Fatalf("seed trust state: %v", err)
+	}
+	if _, err := writerDB.ExecContext(ctx, `
         INSERT INTO provider_trust_eval_state
             (provider_id, uptime_ok_since, unlock_pair_ok_since, last_eval_at, updated_at)
-        VALUES ($1, $2, $2, now(), now());
-
+        VALUES ($1, $2, $2, now(), now())
+    `, providerID, windowOpen); err != nil {
+		t.Fatalf("seed trust eval state: %v", err)
+	}
+	if _, err := writerDB.ExecContext(ctx, `
         INSERT INTO provider_trust_operator_promotions
             (provider_id, promoted_by, reason, pending_id)
-        VALUES ($1, 'integration-test', 'trust audit transition coverage', '00000000-0000-0000-0000-000000001021');
-    `, providerID, windowOpen); err != nil {
-		t.Fatalf("seed trust transition state: %v", err)
+        VALUES ($1, 'integration-test', 'trust audit transition coverage', '00000000-0000-0000-0000-000000001021')
+    `, providerID); err != nil {
+		t.Fatalf("seed operator promotion: %v", err)
 	}
 
 	cfg := testEmissionConfig(time.Hour, 25, 100)
@@ -303,13 +344,16 @@ func TestTrustTierTransitionsWriteRewardAuditEvents(t *testing.T) {
 	if _, err := writerDB.ExecContext(ctx, `
         UPDATE provider_emission_state
            SET demotion_cooldown_until = now() - interval '1 hour'
-         WHERE provider_id = $1;
-
+         WHERE provider_id = $1
+    `, providerID); err != nil {
+		t.Fatalf("seed requalification cooldown: %v", err)
+	}
+	if _, err := writerDB.ExecContext(ctx, `
         UPDATE provider_trust_eval_state
            SET uptime_ok_since = $2,
                unlock_pair_ok_since = $2,
                updated_at = now()
-         WHERE provider_id = $1;
+         WHERE provider_id = $1
     `, providerID, windowOpen); err != nil {
 		t.Fatalf("seed requalification window: %v", err)
 	}
@@ -362,15 +406,21 @@ func TestWalletDailyCapAcrossProviders(t *testing.T) {
 		}
 	}
 
-	cfg := testEmissionConfig(time.Minute, 1000, 100)
+	today := time.Now().UTC().Truncate(24 * time.Hour)
+	if _, err := writerDB.ExecContext(ctx, `
+        INSERT INTO wallet_daily_malibu_emission (bound_wallet, emission_day, sum_malibu, updated_at)
+        VALUES ($1, $2, 99, now())
+    `, wallet, today); err != nil {
+		t.Fatalf("seed wallet daily total: %v", err)
+	}
+
+	cfg := testEmissionConfig(time.Hour, 1000, 100)
 	runner, err := rewards.New(writerDB, cfg, zerolog.Nop(), rewards.RunnerDeps{})
 	if err != nil {
 		t.Fatalf("new runner: %v", err)
 	}
-	for i := 0; i < 12; i++ {
-		if err := runner.RunEmissionTickOnce(ctx); err != nil {
-			t.Fatalf("tick %d: %v", i, err)
-		}
+	if err := runner.RunEmissionTickOnce(ctx); err != nil {
+		t.Fatalf("emission tick: %v", err)
 	}
 
 	var sum float64
@@ -385,22 +435,60 @@ func TestWalletDailyCapAcrossProviders(t *testing.T) {
 		t.Fatalf("wallet aggregate %v exceeds cap 100", sum)
 	}
 
-	page, err := rewards.QueryRewardAuditEvents(ctx, writerDB, rewards.RewardAuditQuery{
-		ProviderID: "p_b",
-		Limit:      50,
-	})
-	if err != nil {
-		t.Fatalf("query p_b audit: %v", err)
-	}
-	var sawWalletCap bool
-	for _, evt := range page.Events {
-		if evt.EventType == rewards.AuditEventWalletDailyCapApplied {
-			sawWalletCap = true
+	var walletCapProvider string
+	for _, pid := range []string{"p_a", "p_b"} {
+		page, err := rewards.QueryRewardAuditEvents(ctx, writerDB, rewards.RewardAuditQuery{
+			ProviderID: pid,
+			Limit:      100,
+		})
+		if err != nil {
+			t.Fatalf("query %s audit: %v", pid, err)
+		}
+		for _, evt := range page.Events {
+			if evt.EventType == rewards.AuditEventWalletDailyCapApplied {
+				walletCapProvider = pid
+			}
 		}
 	}
-	if !sawWalletCap {
+	if walletCapProvider == "" {
 		t.Fatal("expected wallet_daily_cap_applied audit event even while provisional hold remains primary")
 	}
+	for _, pid := range []string{"p_a", "p_b"} {
+		bal, err := rewards.QueryAccrualBalance(ctx, writerDB, pid, cfg)
+		if err != nil {
+			t.Fatalf("query %s accrual balance: %v", pid, err)
+		}
+		hasWalletCap := testContainsString(bal.HoldReasons, rewards.HoldPerWalletDailyCap)
+		if pid == walletCapProvider && !hasWalletCap {
+			t.Fatalf("%s hold reasons = %v, want wallet cap hold", pid, bal.HoldReasons)
+		}
+		if pid != walletCapProvider && hasWalletCap {
+			t.Fatalf("%s hold reasons = %v, must not expose shared-wallet cap state", pid, bal.HoldReasons)
+		}
+		eligibility := rewards.RewardEligibilityFromBalanceAndTrust(bal, rewards.TrustCriteriaStatus{
+			WalletBound:          true,
+			VerifiedReceiptCount: 999,
+			AppAttested:          true,
+		})
+		if pid == walletCapProvider && eligibility.WithdrawalState != rewards.WithdrawalStateCapped {
+			t.Fatalf("%s withdrawal_state = %q, want %q", pid, eligibility.WithdrawalState, rewards.WithdrawalStateCapped)
+		}
+		if pid == walletCapProvider && eligibility.PrimaryReason != rewards.ReasonHeldWalletDailyCap {
+			t.Fatalf("%s primary_reason = %q, want %q", pid, eligibility.PrimaryReason, rewards.ReasonHeldWalletDailyCap)
+		}
+		if pid != walletCapProvider && eligibility.PrimaryReason == rewards.ReasonHeldWalletDailyCap {
+			t.Fatalf("%s primary_reason must not expose shared-wallet cap state", pid)
+		}
+	}
+}
+
+func testContainsString(values []string, want string) bool {
+	for _, value := range values {
+		if value == want {
+			return true
+		}
+	}
+	return false
 }
 
 func TestUsefulWorkAccrualVerifiedWorkCapsHoldsAndReplay(t *testing.T) {
@@ -540,7 +628,7 @@ func TestUsefulWorkAccrualVerifiedWorkCapsHoldsAndReplay(t *testing.T) {
 	}
 }
 
-func TestUsefulWorkAccrualSkipsProviderAtDailyCap(t *testing.T) {
+func TestUsefulWorkAccrualMarksProviderAtDailyCap(t *testing.T) {
 	fx, adminDB := startPostgres(t)
 	ctx := context.Background()
 
@@ -573,7 +661,7 @@ func TestUsefulWorkAccrualSkipsProviderAtDailyCap(t *testing.T) {
         SELECT 'req-capped-' || gs::TEXT, 0, 'p_capped',
                now() - interval '2 hours' + (gs || ' seconds')::interval,
                1000, TRUE
-          FROM generate_series(1, 501) AS gs;
+          FROM generate_series(1, 500) AS gs;
 
         INSERT INTO ledger_request_credits
             (request_id, attempt_n, provider_id, ts_utc, provider_credits, spec022_verified)
@@ -594,6 +682,44 @@ func TestUsefulWorkAccrualSkipsProviderAtDailyCap(t *testing.T) {
 		t.Fatalf("useful work accrual: %v", err)
 	}
 
+	var cappedCount int
+	var cappedSum string
+	if err := adminDB.QueryRowContext(ctx, `
+        SELECT COUNT(*), COALESCE(SUM(amount_malibu), 0)::TEXT
+          FROM provider_rewards_ledger
+         WHERE provider_id = 'p_capped'
+           AND reason = $1
+    `, rewards.ReasonMalibuVerifiedUsefulWorkV02).Scan(&cappedCount, &cappedSum); err != nil {
+		t.Fatalf("count capped rewards: %v", err)
+	}
+	if cappedCount != 500 {
+		t.Fatalf("p_capped terminal cap markers = %d, want 500", cappedCount)
+	}
+	if cappedSum != "0.00000000" {
+		t.Fatalf("p_capped capped sum = %q, want 0.00000000", cappedSum)
+	}
+	bal, err := rewards.QueryAccrualBalance(ctx, writerDB, "p_capped", cfg)
+	if err != nil {
+		t.Fatalf("query capped balance: %v", err)
+	}
+	if !bal.ProviderDailyCapped {
+		t.Fatal("p_capped should report provider daily cap active")
+	}
+	eligibility := rewards.RewardEligibilityFromBalanceAndTrust(bal, rewards.TrustCriteriaStatus{
+		WalletBound:          true,
+		VerifiedReceiptCount: 999,
+		AppAttested:          true,
+	})
+	if eligibility.WithdrawalState != rewards.WithdrawalStateCapped {
+		t.Fatalf("p_capped withdrawal_state = %q, want %q", eligibility.WithdrawalState, rewards.WithdrawalStateCapped)
+	}
+	if eligibility.PrimaryReason != rewards.ReasonHeldProviderDailyCap {
+		t.Fatalf("p_capped primary_reason = %q, want %q", eligibility.PrimaryReason, rewards.ReasonHeldProviderDailyCap)
+	}
+
+	if err := runner.RunUsefulWorkAccrualOnce(ctx); err != nil {
+		t.Fatalf("useful work accrual next batch: %v", err)
+	}
 	var laterCount int
 	if err := adminDB.QueryRowContext(ctx, `
         SELECT COUNT(*)
@@ -607,17 +733,28 @@ func TestUsefulWorkAccrualSkipsProviderAtDailyCap(t *testing.T) {
 		t.Fatalf("p_later useful work rewards = %d, want 1", laterCount)
 	}
 
-	var cappedCount int
+	if _, err := adminDB.ExecContext(ctx, `
+        UPDATE provider_emission_state
+           SET provider_day_malibu = 0,
+               emission_day = CURRENT_DATE - interval '1 day'
+         WHERE provider_id = 'p_capped'
+    `); err != nil {
+		t.Fatalf("simulate next day: %v", err)
+	}
+	if err := runner.RunUsefulWorkAccrualOnce(ctx); err != nil {
+		t.Fatalf("useful work accrual replay: %v", err)
+	}
+	var replayCount int
 	if err := adminDB.QueryRowContext(ctx, `
         SELECT COUNT(*)
           FROM provider_rewards_ledger
          WHERE provider_id = 'p_capped'
            AND reason = $1
-    `, rewards.ReasonMalibuVerifiedUsefulWorkV02).Scan(&cappedCount); err != nil {
-		t.Fatalf("count capped rewards: %v", err)
+    `, rewards.ReasonMalibuVerifiedUsefulWorkV02).Scan(&replayCount); err != nil {
+		t.Fatalf("count replay capped rewards: %v", err)
 	}
-	if cappedCount != 0 {
-		t.Fatalf("p_capped useful work rewards = %d, want 0", cappedCount)
+	if replayCount != cappedCount {
+		t.Fatalf("p_capped replay markers = %d, want unchanged %d", replayCount, cappedCount)
 	}
 }
 

--- a/phase4-coordinator/internal/rewards/endpoints.go
+++ b/phase4-coordinator/internal/rewards/endpoints.go
@@ -78,6 +78,7 @@ func NewAccrualHandler(deps AccrualHandlerDeps) http.Handler {
 			"held_malibu":             bal.HeldMALIBU,
 			"trust_tier":              bal.TrustTier,
 			"daily_cap_malibu":        bal.ProviderDailyCap,
+			"provider_daily_capped":   bal.ProviderDailyCapped,
 			"wallet_daily_cap_malibu": bal.WalletDailyCap,
 			"withdrawal_hold_reasons": bal.HoldReasons,
 			"trust_criteria_met":      trust.CriteriaMet,

--- a/phase4-coordinator/internal/rewards/endpoints.go
+++ b/phase4-coordinator/internal/rewards/endpoints.go
@@ -6,12 +6,17 @@ import (
 	"encoding/json"
 	"net/http"
 	"strings"
+	"time"
 
 	"github.com/augstar/macprovider-coordinator/internal/auth"
 )
 
 type tokenValidator interface {
 	ValidateAndMarkTokenUsed(ctx context.Context, raw string) (subject string, ok bool, err error)
+}
+
+type readOnlyTokenValidator interface {
+	ValidateTokenReadOnly(ctx context.Context, raw string) (subject string, ok bool, err error)
 }
 
 // AccrualHandlerDeps wires the provider MALIBU accrual endpoint.
@@ -99,10 +104,15 @@ type AuditHandlerDeps struct {
 	TokenStore            tokenValidator
 	RequireProviderTokens bool
 	OperatorKey           string
+	Limiter               *RewardAuditLimiter
 }
 
 // NewRewardAuditHandler serves GET /v1/provider/malibu-reward-audit.
 func NewRewardAuditHandler(deps AuditHandlerDeps) http.Handler {
+	limiter := deps.Limiter
+	if limiter == nil {
+		limiter = NewRewardAuditLimiter(60, 4)
+	}
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodGet {
 			w.Header().Set("Allow", http.MethodGet)
@@ -118,11 +128,18 @@ func NewRewardAuditHandler(deps AuditHandlerDeps) http.Handler {
 			writeAuditJSON(w, http.StatusUnauthorized, map[string]any{"error": "unauthorized"})
 			return
 		}
-		providerID, ok, err := deps.TokenStore.ValidateAndMarkTokenUsed(r.Context(), raw)
+		providerID, ok, err := validateAuditToken(r.Context(), deps.TokenStore, raw)
 		if err != nil || !ok || providerID == "" {
 			writeAuditJSON(w, http.StatusUnauthorized, map[string]any{"error": "unauthorized"})
 			return
 		}
+		release, ok := limiter.Allow(providerID, time.Now().UTC())
+		if !ok {
+			w.Header().Set("Retry-After", "1")
+			writeAuditJSON(w, http.StatusTooManyRequests, map[string]any{"error": "rate_limited"})
+			return
+		}
+		defer release()
 		limit, beforeID, ok := parseAuditPage(w, r)
 		if !ok {
 			return
@@ -138,6 +155,13 @@ func NewRewardAuditHandler(deps AuditHandlerDeps) http.Handler {
 		}
 		writeAuditJSON(w, http.StatusOK, page)
 	})
+}
+
+func validateAuditToken(ctx context.Context, store tokenValidator, raw string) (string, bool, error) {
+	if ro, ok := store.(readOnlyTokenValidator); ok {
+		return ro.ValidateTokenReadOnly(ctx, raw)
+	}
+	return store.ValidateAndMarkTokenUsed(ctx, raw)
 }
 
 // NewRewardAuditAdminHandler serves GET /admin/malibu-reward-audit?provider_id=...

--- a/phase4-coordinator/internal/rewards/endpoints.go
+++ b/phase4-coordinator/internal/rewards/endpoints.go
@@ -6,6 +6,8 @@ import (
 	"encoding/json"
 	"net/http"
 	"strings"
+
+	"github.com/augstar/macprovider-coordinator/internal/auth"
 )
 
 type tokenValidator interface {
@@ -88,6 +90,110 @@ func NewAccrualHandler(deps AccrualHandlerDeps) http.Handler {
 			"reward_eligibility":      eligibility,
 		})
 	})
+}
+
+// AuditHandlerDeps wires provider/operator MALIBU reward audit endpoints.
+type AuditHandlerDeps struct {
+	DB                    *sql.DB
+	TokenStore            tokenValidator
+	RequireProviderTokens bool
+	OperatorKey           string
+}
+
+// NewRewardAuditHandler serves GET /v1/provider/malibu-reward-audit.
+func NewRewardAuditHandler(deps AuditHandlerDeps) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			w.Header().Set("Allow", http.MethodGet)
+			writeAuditJSON(w, http.StatusMethodNotAllowed, map[string]any{"error": "method_not_allowed"})
+			return
+		}
+		if !deps.RequireProviderTokens {
+			writeAuditJSON(w, http.StatusServiceUnavailable, map[string]any{"error": "unavailable"})
+			return
+		}
+		raw := bearerToken(r.Header.Get("Authorization"))
+		if raw == "" || deps.TokenStore == nil {
+			writeAuditJSON(w, http.StatusUnauthorized, map[string]any{"error": "unauthorized"})
+			return
+		}
+		providerID, ok, err := deps.TokenStore.ValidateAndMarkTokenUsed(r.Context(), raw)
+		if err != nil || !ok || providerID == "" {
+			writeAuditJSON(w, http.StatusUnauthorized, map[string]any{"error": "unauthorized"})
+			return
+		}
+		limit, beforeID, ok := parseAuditPage(w, r)
+		if !ok {
+			return
+		}
+		page, err := QueryRewardAuditEvents(r.Context(), deps.DB, RewardAuditQuery{
+			ProviderID: providerID,
+			Limit:      limit,
+			BeforeID:   beforeID,
+		})
+		if err != nil {
+			writeAuditJSON(w, http.StatusInternalServerError, map[string]any{"error": "internal_error"})
+			return
+		}
+		writeAuditJSON(w, http.StatusOK, page)
+	})
+}
+
+// NewRewardAuditAdminHandler serves GET /admin/malibu-reward-audit?provider_id=...
+func NewRewardAuditAdminHandler(deps AuditHandlerDeps) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			w.Header().Set("Allow", http.MethodGet)
+			writeAuditJSON(w, http.StatusMethodNotAllowed, map[string]any{"error": "method_not_allowed"})
+			return
+		}
+		if deps.OperatorKey == "" || !auth.OperatorOnlyBearerMatches(r.Header, deps.OperatorKey) {
+			writeAuditJSON(w, http.StatusUnauthorized, map[string]any{"error": "unauthorized"})
+			return
+		}
+		providerID := strings.TrimSpace(r.URL.Query().Get("provider_id"))
+		if providerID == "" {
+			writeAuditJSON(w, http.StatusBadRequest, map[string]any{"error": "provider_id_required"})
+			return
+		}
+		limit, beforeID, ok := parseAuditPage(w, r)
+		if !ok {
+			return
+		}
+		page, err := QueryRewardAuditEvents(r.Context(), deps.DB, RewardAuditQuery{
+			ProviderID:      providerID,
+			Limit:           limit,
+			BeforeID:        beforeID,
+			IncludeProvider: true,
+			IncludeOperator: true,
+		})
+		if err != nil {
+			writeAuditJSON(w, http.StatusInternalServerError, map[string]any{"error": "internal_error"})
+			return
+		}
+		writeAuditJSON(w, http.StatusOK, page)
+	})
+}
+
+func parseAuditPage(w http.ResponseWriter, r *http.Request) (limit int, beforeID int64, ok bool) {
+	limit, err := ParseAuditLimit(r.URL.Query().Get("limit"))
+	if err != nil {
+		writeAuditJSON(w, http.StatusBadRequest, map[string]any{"error": "invalid_limit"})
+		return 0, 0, false
+	}
+	beforeID, err = ParseAuditBeforeID(r.URL.Query().Get("before_id"))
+	if err != nil {
+		writeAuditJSON(w, http.StatusBadRequest, map[string]any{"error": "invalid_before_id"})
+		return 0, 0, false
+	}
+	return limit, beforeID, true
+}
+
+func writeAuditJSON(w http.ResponseWriter, status int, payload any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("Cache-Control", "no-store")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(payload)
 }
 
 func bearerToken(header string) string {

--- a/phase4-coordinator/internal/rewards/read_model.go
+++ b/phase4-coordinator/internal/rewards/read_model.go
@@ -25,6 +25,7 @@ const (
 	ReasonEarningVerifiedWork              = "earning_verified_work"
 	ReasonEligibleIdleNoWork               = "eligible_idle_no_work"
 	ReasonHeldProvisionalTrustTier         = "held_provisional_trust_tier"
+	ReasonHeldProviderDailyCap             = "held_provider_daily_cap"
 	ReasonHeldWalletDailyCap               = "held_wallet_daily_cap"
 	ReasonHeldDemotionCooldown             = "held_demotion_cooldown"
 	ReasonWithdrawableBalanceAvailable     = "withdrawable_balance_available"
@@ -81,6 +82,7 @@ type MalibuRewardEligibilityFacts struct {
 	HeldMALIBU             string
 	TrustTier              string
 	WithdrawalHoldReasons  []string
+	ProviderDailyCapped    bool
 	WalletBound            bool
 	VerifiedReceiptCount   int
 	AppAttested            bool
@@ -98,6 +100,7 @@ func RewardEligibilityFromBalanceAndTrust(bal AccrualBalance, trust TrustCriteri
 		HeldMALIBU:            bal.HeldMALIBU,
 		TrustTier:             bal.TrustTier,
 		WithdrawalHoldReasons: bal.HoldReasons,
+		ProviderDailyCapped:   bal.ProviderDailyCapped,
 		WalletBound:           trust.WalletBound,
 		VerifiedReceiptCount:  trust.VerifiedReceiptCount,
 		AppAttested:           trust.AppAttested,
@@ -181,6 +184,9 @@ func orderedRewardReasons(f MalibuRewardEligibilityFacts) []string {
 			add(ReasonHeldProvisionalTrustTier)
 		}
 	}
+	if f.ProviderDailyCapped {
+		add(ReasonHeldProviderDailyCap)
+	}
 
 	if !f.WalletBound {
 		add(ReasonMissingWalletBinding)
@@ -227,7 +233,8 @@ func earningStateFor(f MalibuRewardEligibilityFacts, reasons []string) string {
 		containsReason(reasons, ReasonModelNotReady) {
 		return EarningStateIneligible
 	}
-	if containsReason(reasons, ReasonHeldWalletDailyCap) {
+	if containsReason(reasons, ReasonHeldWalletDailyCap) ||
+		containsReason(reasons, ReasonHeldProviderDailyCap) {
 		return EarningStateCapped
 	}
 	if containsReason(reasons, ReasonHeldProvisionalTrustTier) ||
@@ -247,7 +254,8 @@ func withdrawalStateFor(f MalibuRewardEligibilityFacts, reasons []string) string
 	if containsReason(reasons, ReasonProviderTokenUntrusted) {
 		return WithdrawalStateIneligible
 	}
-	if containsReason(reasons, ReasonHeldWalletDailyCap) {
+	if containsReason(reasons, ReasonHeldWalletDailyCap) ||
+		containsReason(reasons, ReasonHeldProviderDailyCap) {
 		return WithdrawalStateCapped
 	}
 	if containsReason(reasons, ReasonHeldProvisionalTrustTier) ||
@@ -269,6 +277,7 @@ func primaryRewardReason(withdrawalState, earningState string, reasons []string)
 		ReasonComputeIntegrityBlocked,
 		ReasonComputeIntegrityPending,
 		ReasonHeldWalletDailyCap,
+		ReasonHeldProviderDailyCap,
 		ReasonHeldDemotionCooldown,
 		ReasonHeldProvisionalTrustTier,
 		ReasonMissingWalletBinding,

--- a/phase4-coordinator/internal/rewards/read_model_test.go
+++ b/phase4-coordinator/internal/rewards/read_model_test.go
@@ -54,6 +54,31 @@ func TestRewardEligibilityWalletCapWinsOverProvisionalHold(t *testing.T) {
 	}
 }
 
+func TestRewardEligibilityProviderDailyCapIsCapped(t *testing.T) {
+	got := BuildMalibuRewardEligibility(MalibuRewardEligibilityFacts{
+		AccruedMALIBU:         "25.00000000",
+		WithdrawableMALIBU:    "25.00000000",
+		HeldMALIBU:            "0",
+		TrustTier:             TierTrusted,
+		ProviderDailyCapped:   true,
+		WalletBound:           true,
+		VerifiedReceiptCount:  minVerifiedReceipts,
+		AppAttested:           true,
+		HardwareEvidenceState: HardwareEvidenceStateVerified,
+		ComputeIntegrityState: ComputeIntegrityStateVerified,
+	})
+
+	if got.EarningState != EarningStateCapped {
+		t.Fatalf("earning_state = %q, want %q", got.EarningState, EarningStateCapped)
+	}
+	if got.WithdrawalState != WithdrawalStateCapped {
+		t.Fatalf("withdrawal_state = %q, want %q", got.WithdrawalState, WithdrawalStateCapped)
+	}
+	if got.PrimaryReason != ReasonHeldProviderDailyCap {
+		t.Fatalf("primary_reason = %q, want %q", got.PrimaryReason, ReasonHeldProviderDailyCap)
+	}
+}
+
 func TestRewardEligibilityComputeBlockedWinsOverPending(t *testing.T) {
 	got := BuildMalibuRewardEligibility(MalibuRewardEligibilityFacts{
 		AccruedMALIBU:         "0",

--- a/phase4-coordinator/internal/rewards/rewards.go
+++ b/phase4-coordinator/internal/rewards/rewards.go
@@ -287,12 +287,21 @@ func walletDailyCapAppliedToday(ctx context.Context, db *sql.DB, providerID stri
 	err := db.QueryRowContext(ctx, `
         SELECT EXISTS (
             SELECT 1
-              FROM malibu_reward_audit_events
-             WHERE provider_id = $1
-               AND event_type = $2
-               AND occurred_at >= $3
+              FROM malibu_reward_audit_events applied
+             WHERE applied.provider_id = $1
+               AND applied.event_type = $2
+               AND applied.occurred_at >= $3
+               AND NOT EXISTS (
+                   SELECT 1
+                     FROM malibu_reward_audit_events cleared
+                    WHERE cleared.provider_id = applied.provider_id
+                      AND cleared.ledger_id = applied.ledger_id
+                      AND cleared.event_type = $4
+                      AND cleared.withdrawal_hold_reason = $5
+                      AND cleared.id > applied.id
+               )
         )
-    `, providerID, AuditEventWalletDailyCapApplied, utcDay(time.Now().UTC())).Scan(&exists)
+    `, providerID, AuditEventWalletDailyCapApplied, utcDay(time.Now().UTC()), AuditEventMalibuHoldCleared, HoldPerWalletDailyCap).Scan(&exists)
 	return exists, err
 }
 

--- a/phase4-coordinator/internal/rewards/rewards.go
+++ b/phase4-coordinator/internal/rewards/rewards.go
@@ -181,13 +181,14 @@ func EnsureProviderState(ctx context.Context, db *sql.DB, providerID string) err
 
 // AccrualBalance returns total and withdrawable MALIBU for a provider.
 type AccrualBalance struct {
-	AccruedMALIBU      string
-	WithdrawableMALIBU string
-	HeldMALIBU         string
-	TrustTier          string
-	HoldReasons        []string
-	ProviderDailyCap   float64
-	WalletDailyCap     float64
+	AccruedMALIBU       string
+	WithdrawableMALIBU  string
+	HeldMALIBU          string
+	TrustTier           string
+	HoldReasons         []string
+	ProviderDailyCapped bool
+	ProviderDailyCap    float64
+	WalletDailyCap      float64
 }
 
 // QueryAccrualBalance reads ledger aggregates for the provider read API.
@@ -220,6 +221,7 @@ func QueryAccrualBalance(ctx context.Context, db *sql.DB, providerID string, cfg
           FROM provider_rewards_ledger
          WHERE provider_id = $1
            AND amount_malibu IS NOT NULL
+           AND amount_malibu > 0
            AND withdrawal_hold_reason IS NOT NULL
     `, providerID)
 	if err != nil {
@@ -238,16 +240,60 @@ func QueryAccrualBalance(ctx context.Context, db *sql.DB, providerID string, cfg
 		return AccrualBalance{}, err
 	}
 
+	walletCapAppliedToday, err := walletDailyCapAppliedToday(ctx, db, providerID)
+	if err != nil {
+		return AccrualBalance{}, fmt.Errorf("wallet cap audit state: %w", err)
+	}
+	if walletCapAppliedToday && !containsReason(holds, HoldPerWalletDailyCap) {
+		holds = append(holds, HoldPerWalletDailyCap)
+	}
+	providerDailyCapped, err := providerDailyCapActiveToday(ctx, db, providerID, cfg.ProviderDailyCapMALIBU)
+	if err != nil {
+		return AccrualBalance{}, fmt.Errorf("provider cap state: %w", err)
+	}
+
 	held := subtractDecimalStrings(accrued, withdrawable)
 	return AccrualBalance{
-		AccruedMALIBU:      accrued,
-		WithdrawableMALIBU: withdrawable,
-		HeldMALIBU:         held,
-		TrustTier:          tier,
-		HoldReasons:        holds,
-		ProviderDailyCap:   cfg.ProviderDailyCapMALIBU,
-		WalletDailyCap:     cfg.WalletDailyCapMALIBU,
+		AccruedMALIBU:       accrued,
+		WithdrawableMALIBU:  withdrawable,
+		HeldMALIBU:          held,
+		TrustTier:           tier,
+		HoldReasons:         holds,
+		ProviderDailyCapped: providerDailyCapped,
+		ProviderDailyCap:    cfg.ProviderDailyCapMALIBU,
+		WalletDailyCap:      cfg.WalletDailyCapMALIBU,
 	}, nil
+}
+
+func providerDailyCapActiveToday(ctx context.Context, db *sql.DB, providerID string, cap float64) (bool, error) {
+	if cap <= 0 {
+		return false, nil
+	}
+	var exists bool
+	err := db.QueryRowContext(ctx, `
+        SELECT EXISTS (
+            SELECT 1
+              FROM provider_emission_state
+             WHERE provider_id = $1
+               AND emission_day = $2
+               AND provider_day_malibu >= $3::NUMERIC(24,8)
+        )
+    `, providerID, utcDay(time.Now().UTC()), formatMALIBU(cap)).Scan(&exists)
+	return exists, err
+}
+
+func walletDailyCapAppliedToday(ctx context.Context, db *sql.DB, providerID string) (bool, error) {
+	var exists bool
+	err := db.QueryRowContext(ctx, `
+        SELECT EXISTS (
+            SELECT 1
+              FROM malibu_reward_audit_events
+             WHERE provider_id = $1
+               AND event_type = $2
+               AND occurred_at >= $3
+        )
+    `, providerID, AuditEventWalletDailyCapApplied, utcDay(time.Now().UTC())).Scan(&exists)
+	return exists, err
 }
 
 func subtractDecimalStrings(a, b string) string {

--- a/phase4-coordinator/internal/rewards/unlock.go
+++ b/phase4-coordinator/internal/rewards/unlock.go
@@ -314,7 +314,18 @@ func (r *Runner) persistTrustEvalState(ctx context.Context, providerID string, p
 }
 
 func (r *Runner) promoteProvider(ctx context.Context, providerID string, now time.Time) error {
-	if err := SetTrustTier(ctx, r.db, providerID, TierTrusted); err != nil {
+	tx, err := r.db.BeginTx(ctx, nil)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = tx.Rollback() }()
+	if err := setTrustTier(ctx, tx, providerID, TierTrusted); err != nil {
+		return err
+	}
+	if err := auditTrustTierChangedTx(ctx, tx, providerID, TierTrusted, now); err != nil {
+		return err
+	}
+	if err := tx.Commit(); err != nil {
 		return err
 	}
 	r.notifyTrustTierChanged(providerID, TierTrusted)
@@ -323,15 +334,26 @@ func (r *Runner) promoteProvider(ctx context.Context, providerID string, now tim
 }
 
 func (r *Runner) demoteProvider(ctx context.Context, providerID string, now time.Time) error {
-	if err := SetTrustTier(ctx, r.db, providerID, TierProvisional); err != nil {
+	tx, err := r.db.BeginTx(ctx, nil)
+	if err != nil {
 		return err
 	}
-	_, err := r.db.ExecContext(ctx, `
+	defer func() { _ = tx.Rollback() }()
+	if err := setTrustTier(ctx, tx, providerID, TierProvisional); err != nil {
+		return err
+	}
+	_, err = tx.ExecContext(ctx, `
         UPDATE provider_trust_eval_state
            SET unlock_pair_ok_since = NULL, updated_at = $2
          WHERE provider_id = $1
     `, providerID, now)
 	if err != nil {
+		return err
+	}
+	if err := auditTrustTierChangedTx(ctx, tx, providerID, TierProvisional, now); err != nil {
+		return err
+	}
+	if err := tx.Commit(); err != nil {
 		return err
 	}
 	r.notifyTrustTierChanged(providerID, TierProvisional)

--- a/phase4-coordinator/internal/rewards/useful_work.go
+++ b/phase4-coordinator/internal/rewards/useful_work.go
@@ -51,15 +51,8 @@ func (r *Runner) listUnrewardedUsefulWork(ctx context.Context, limit int) ([]use
 	rows, err := r.db.QueryContext(ctx, `
         SELECT lrc.request_id, lrc.attempt_n, lrc.provider_id, lrc.provider_credits
           FROM ledger_request_credits lrc
-          LEFT JOIN provider_emission_state pes ON pes.provider_id = lrc.provider_id
          WHERE COALESCE(lrc.spec022_verified, FALSE) = TRUE
            AND lrc.provider_credits > 0
-           AND (
-                pes.provider_id IS NULL
-                OR pes.emission_day IS NULL
-                OR pes.emission_day <> CURRENT_DATE
-                OR pes.provider_day_malibu < $2
-           )
            AND NOT EXISTS (
                 SELECT 1
                   FROM provider_rewards_ledger prl
@@ -68,7 +61,7 @@ func (r *Runner) listUnrewardedUsefulWork(ctx context.Context, limit int) ([]use
            )
          ORDER BY lrc.ts_utc ASC, lrc.id ASC
          LIMIT $1
-    `, limit, r.cfg.ProviderDailyCapMALIBU)
+    `, limit)
 	if err != nil {
 		return nil, err
 	}

--- a/phase4-coordinator/internal/rewards/wallet_mirror.go
+++ b/phase4-coordinator/internal/rewards/wallet_mirror.go
@@ -97,6 +97,19 @@ func (r *Runner) upsertProjection(ctx context.Context, addr PayoutAddress, now t
                 END,
                 updated_at = $5
         `, addr.ProviderID, TierProvisional, addr.Address, replay, now)
+		if err != nil {
+			return err
+		}
+		if !replay {
+			return nil
+		}
+		_, err = insertRewardAuditEvent(ctx, tx, RewardAuditInsert{
+			ProviderID:          addr.ProviderID,
+			OccurredAt:          now,
+			EventType:           AuditEventWalletBindProjected,
+			SafeSummary:         "Payout wallet projection updated; wallet-cap replay is pending.",
+			OperatorCorrelation: map[string]string{"chain": addr.Chain},
+		})
 		return err
 	})
 }

--- a/phase4-coordinator/internal/rewards/withdrawal.go
+++ b/phase4-coordinator/internal/rewards/withdrawal.go
@@ -47,12 +47,20 @@ func SelectWithdrawableMALIBU(ctx context.Context, db *sql.DB, providerID string
 
 // SetTrustTier updates provider trust tier (unlock/demotion path).
 func SetTrustTier(ctx context.Context, db *sql.DB, providerID, tier string) error {
+	return setTrustTier(ctx, db, providerID, tier)
+}
+
+type trustTierWriter interface {
+	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+}
+
+func setTrustTier(ctx context.Context, q trustTierWriter, providerID, tier string) error {
 	now := time.Now().UTC()
 	var cooldown interface{}
 	if tier == TierProvisional {
 		cooldown = now.Add(trustRequalifyWindow)
 	}
-	_, err := db.ExecContext(ctx, `
+	_, err := q.ExecContext(ctx, `
         INSERT INTO provider_emission_state (provider_id, trust_tier, demotion_cooldown_until, updated_at)
         VALUES ($1, $2, $3, $4)
         ON CONFLICT (provider_id) DO UPDATE SET

--- a/phase4-coordinator/internal/stats/migrations/023_malibu_reward_audit_events.up.sql
+++ b/phase4-coordinator/internal/stats/migrations/023_malibu_reward_audit_events.up.sql
@@ -1,0 +1,46 @@
+-- SPEC-021 v0.3.0 — append-only MALIBU reward audit events.
+
+CREATE TABLE IF NOT EXISTS malibu_reward_audit_events (
+    id                     BIGSERIAL PRIMARY KEY,
+    provider_id            TEXT NOT NULL,
+    occurred_at            TIMESTAMPTZ NOT NULL DEFAULT now(),
+    event_type             TEXT NOT NULL CHECK (event_type IN (
+                               'malibu_accrual_inserted',
+                               'malibu_hold_applied',
+                               'malibu_hold_cleared',
+                               'wallet_daily_cap_applied',
+                               'wallet_bind_projected',
+                               'trust_tier_promoted',
+                               'trust_tier_demoted',
+                               'withdrawal_candidate_selected',
+                               'withdrawal_candidate_skipped',
+                               'eligibility_reason_changed'
+                           )),
+    ledger_id              BIGINT NULL REFERENCES provider_rewards_ledger(id),
+    amount_malibu          NUMERIC(24,8) NULL CHECK (amount_malibu IS NULL OR amount_malibu >= 0),
+    withdrawal_hold_reason TEXT NULL CHECK (
+                               withdrawal_hold_reason IS NULL
+                               OR withdrawal_hold_reason IN (
+                                   'trust_tier_provisional',
+                                   'per_wallet_daily_cap',
+                                   'demotion_cooldown'
+                               )
+                           ),
+    trust_tier             TEXT NULL CHECK (trust_tier IS NULL OR trust_tier IN ('provisional', 'trusted')),
+    source_reason          TEXT NULL,
+    safe_summary           TEXT NOT NULL,
+    operator_correlation   JSONB NOT NULL DEFAULT '{}'::jsonb
+);
+
+CREATE INDEX IF NOT EXISTS malibu_reward_audit_events_provider_id_idx
+    ON malibu_reward_audit_events (provider_id, id DESC);
+
+CREATE INDEX IF NOT EXISTS malibu_reward_audit_events_ledger_id_idx
+    ON malibu_reward_audit_events (ledger_id)
+    WHERE ledger_id IS NOT NULL;
+
+GRANT SELECT, INSERT ON malibu_reward_audit_events TO rewards_writer;
+GRANT USAGE, SELECT ON SEQUENCE malibu_reward_audit_events_id_seq TO rewards_writer;
+
+-- Append-only by grant: rewards_writer intentionally receives no UPDATE,
+-- DELETE, TRUNCATE, or DDL privilege on the audit table.

--- a/phase4-coordinator/internal/stats/migrations/migrations_test.go
+++ b/phase4-coordinator/internal/stats/migrations/migrations_test.go
@@ -43,6 +43,7 @@ func TestEmbeddedMigrationsLoad(t *testing.T) {
 		{20, "waiting_trust_chip_profile_projection"},
 		{21, "malibu_emission_ledger_update_grant"},
 		{22, "malibu_useful_work_rewards"},
+		{23, "malibu_reward_audit_events"},
 	}
 	if len(all) != len(want) {
 		t.Fatalf("got %d migrations, want %d", len(all), len(want))

--- a/specs/CONFORMANCE.json
+++ b/specs/CONFORMANCE.json
@@ -591,7 +591,7 @@
     {
       "spec_id": "SPEC-021",
       "title": "MALIBU rewards emission ledger",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "path": "specs/SPEC-021-malibu-emission-ledger.md",
       "status": "draft",
       "owner": "@Augustas11",
@@ -610,7 +610,7 @@
       "last_reconciled_commit": null,
       "last_reconciled_at": null,
       "evidence": [],
-      "requirement_id_migration": "pending",
+      "requirement_id_migration": "complete",
       "gap": {
         "verdict": "UNKNOWN",
         "owner": "@Augustas11",
@@ -4365,6 +4365,102 @@
         "owner": "@Augustas11",
         "issue": "https://github.com/Augustas11/macprovider/issues/928",
         "rationale": "Gateway config validation, disabled compatibility, relay-blind metadata limiter, and replay storage DDL are implemented/tested locally; production enablement and signed journey-result evidence remain pending."
+      }
+    },
+    {
+      "requirement_id": "SPEC-021-R001",
+      "spec_id": "SPEC-021",
+      "state": "pending",
+      "implementation": [
+        "phase4-coordinator/internal/stats/migrations/023_malibu_reward_audit_events.up.sql:malibu_reward_audit_events",
+        "phase4-coordinator/internal/rewards/audit.go:InsertRewardAuditEvent",
+        "phase4-coordinator/internal/rewards/emission.go:func (r *Runner) accrueProviderReward",
+        "phase4-coordinator/internal/rewards/emission.go:func replayCapPending",
+        "phase4-coordinator/internal/rewards/wallet_mirror.go:func (r *Runner) upsertProjection",
+        "phase4-coordinator/internal/rewards/unlock.go:func (r *Runner) promoteProvider",
+        "phase4-coordinator/internal/rewards/unlock.go:func (r *Runner) demoteProvider"
+      ],
+      "tests": [
+        "phase4-coordinator/internal/rewards/emission_integration_test.go::TestRewardAuditEventsAreProviderScopedPaginatedAndRedacted",
+        "phase4-coordinator/internal/rewards/emission_integration_test.go::TestTrustTierTransitionsWriteRewardAuditEvents",
+        "phase4-coordinator/internal/rewards/emission_integration_test.go::TestCapReplayPendingDoesNotDesyncConnection"
+      ],
+      "journeys": [],
+      "evidence": [],
+      "gap": {
+        "verdict": "UNKNOWN",
+        "owner": "@Augustas11",
+        "issue": "https://github.com/Augustas11/macprovider/issues/1021",
+        "rationale": "Append-only audit persistence is implemented for accrual, holds, wallet projection, cap replay, and trust transitions; production migration/app evidence remains pending."
+      }
+    },
+    {
+      "requirement_id": "SPEC-021-R002",
+      "spec_id": "SPEC-021",
+      "state": "pending",
+      "implementation": [
+        "phase4-coordinator/internal/rewards/endpoints.go:NewRewardAuditHandler",
+        "phase4-coordinator/internal/rewards/audit.go:QueryRewardAuditEvents",
+        "phase4-coordinator/cmd/coordinator/main.go:malibuRewardAuditHandler",
+        "phase4-coordinator/dist/nginx-coordinator.malibu.tech.conf:/v1/provider/malibu-reward-audit",
+        "frontdoor/provider-portal/dist/nginx-portal.malibu.tech.conf:/v1/provider/malibu-reward-audit"
+      ],
+      "tests": [
+        "phase4-coordinator/internal/rewards/audit_test.go::TestParseAuditPageBounds",
+        "phase4-coordinator/internal/rewards/audit_test.go::TestRewardAuditHandlerAuthAndCursorValidation",
+        "phase4-coordinator/internal/rewards/emission_integration_test.go::TestRewardAuditEventsAreProviderScopedPaginatedAndRedacted",
+        "phase4-coordinator/cmd/coordinator/main_test.go::TestNginxMalibuRewardAuditRouteBeforeV1CatchAll"
+      ],
+      "journeys": [],
+      "evidence": [],
+      "gap": {
+        "verdict": "UNKNOWN",
+        "owner": "@Augustas11",
+        "issue": "https://github.com/Augustas11/macprovider/issues/1021",
+        "rationale": "Provider-token scoped audit API, bounded limits, stable cursors, and nginx allow-through are implemented/tested locally; live route evidence remains pending."
+      }
+    },
+    {
+      "requirement_id": "SPEC-021-R003",
+      "spec_id": "SPEC-021",
+      "state": "pending",
+      "implementation": [
+        "phase4-coordinator/internal/rewards/audit.go:RewardAuditEvent",
+        "phase4-coordinator/internal/rewards/audit.go:QueryRewardAuditEvents",
+        "phase4-coordinator/internal/rewards/endpoints.go:NewRewardAuditHandler"
+      ],
+      "tests": [
+        "phase4-coordinator/internal/rewards/emission_integration_test.go::TestRewardAuditEventsAreProviderScopedPaginatedAndRedacted"
+      ],
+      "journeys": [],
+      "evidence": [],
+      "gap": {
+        "verdict": "UNKNOWN",
+        "owner": "@Augustas11",
+        "issue": "https://github.com/Augustas11/macprovider/issues/1021",
+        "rationale": "Provider DTO redacts operator correlation and external refs while preserving safe summaries; live payload evidence remains pending."
+      }
+    },
+    {
+      "requirement_id": "SPEC-021-R004",
+      "spec_id": "SPEC-021",
+      "state": "pending",
+      "implementation": [
+        "phase4-coordinator/internal/rewards/endpoints.go:NewRewardAuditAdminHandler",
+        "phase4-coordinator/internal/rewards/audit.go:QueryRewardAuditEvents",
+        "phase4-coordinator/cmd/coordinator/main.go:malibuRewardAuditAdminHandler"
+      ],
+      "tests": [
+        "phase4-coordinator/internal/rewards/audit_test.go::TestRewardAuditAdminHandlerAuthAndProviderRequired",
+        "phase4-coordinator/internal/rewards/emission_integration_test.go::TestRewardAuditEventsAreProviderScopedPaginatedAndRedacted"
+      ],
+      "journeys": [],
+      "evidence": [],
+      "gap": {
+        "verdict": "UNKNOWN",
+        "owner": "@Augustas11",
+        "issue": "https://github.com/Augustas11/macprovider/issues/1021",
+        "rationale": "Operator-authenticated audit query exposes provider and correlation fields for support; live operator route evidence remains pending."
       }
     },
     {

--- a/specs/README.md
+++ b/specs/README.md
@@ -29,7 +29,7 @@ it can no longer drift. Do not hand-edit the table; edit each spec's
 | SPEC-018 | Agentic tool calling (provider-side response synthesis) | 0.2.7 | normative | pending | conformant: 1, pending: 1 | [SPEC-018-agentic-tool-calling.md](SPEC-018-agentic-tool-calling.md) |
 | SPEC-019 | Structured output (`response_format: json_schema`) | 0.2.5 | normative | pending | pending corpus migration | [SPEC-019-structured-output.md](SPEC-019-structured-output.md) |
 | SPEC-020 | Provider autoupdate | v0.1.11 | normative | pending | pending: 4 | [SPEC-020-provider-autoupdate.md](SPEC-020-provider-autoupdate.md) |
-| SPEC-021 | MALIBU rewards emission ledger | 0.2.0 | draft | pending | pending corpus migration | [SPEC-021-malibu-emission-ledger.md](SPEC-021-malibu-emission-ledger.md) |
+| SPEC-021 | MALIBU rewards emission ledger | 0.3.0 | draft | complete | pending: 4 | [SPEC-021-malibu-emission-ledger.md](SPEC-021-malibu-emission-ledger.md) |
 | SPEC-022 | Verified model settlement | v0.1.7 | draft | complete | pending: 11 | [SPEC-022-verified-model-settlement.md](SPEC-022-verified-model-settlement.md) |
 | SPEC-023 | Installer-Integrated Autotune Recommend | v0.9.3 | normative | pending | conformant: 2 | [SPEC-023-installer-autotune-recommend.md](SPEC-023-installer-autotune-recommend.md) |
 | SPEC-024 | Prefix-cache billing and provider-local cache isolation | 0.2.1 | normative | pending | pending corpus migration | [SPEC-024-prefix-cache-billing.md](SPEC-024-prefix-cache-billing.md) |

--- a/specs/SPEC-021-malibu-emission-ledger.md
+++ b/specs/SPEC-021-malibu-emission-ledger.md
@@ -1,8 +1,22 @@
 # SPEC-021 — MALIBU rewards emission ledger
 
-**Version:** 0.2.0 (2026-08-17, verified useful-work accrual)
+**Version:** 0.3.0 (2026-08-17, reward audit trail)
 **Status:** DRAFT — implementation target for Session C (`ops/runbooks/malibu-bootstrap-emission.md`)  
 **Depends on:** SPEC-026 v0.13 §5.1–§5.2, §5.5, §10 step 8; SPEC-017 v0.1.8 (`provider_rewards_ledger`); SPEC-016 v0.1.19 (`provider_payout_addresses` projection); SPEC-022 (verified-receipt-only USDC earnings)
+
+**Change log v0.3.0 (2026-08-17, reward audit trail):**
+- Adds append-only `malibu_reward_audit_events` rows for MALIBU accrual,
+  hold application/clearance, wallet projection, trust-tier transitions, and
+  reserved withdrawal/eligibility events.
+- Defines provider-token-authenticated `GET /v1/provider/malibu-reward-audit`
+  with stable event IDs, bounded cursor pagination, provider isolation, and a
+  provider-safe field allowlist.
+- Defines operator-authenticated `GET /admin/malibu-reward-audit` for
+  correlation to ledger IDs, source reasons, trust transitions, and external
+  idempotency references without exposing those fields in provider responses.
+- Pins retention and sensitive-field exclusions: raw prompts, raw outputs,
+  bearer tokens, request payloads, operator secrets, and arbitrary metadata
+  MUST NOT be serialized into provider-visible audit events.
 
 **Change log v0.2.0 (2026-08-17, verified useful-work accrual):**
 - Adds `malibu_verified_useful_work_v0_2` ledger rows derived only from
@@ -130,13 +144,59 @@ CREATE TABLE provider_payout_addresses_proj (
 
 Maintained by the wallet-mirror worker (§4.2). Staleness is monitored via mirror heartbeat, not row age alone.
 
-### 2.5 `rewards_writer` Postgres role
+### 2.5 `malibu_reward_audit_events`
+
+Append-only audit trail for MALIBU reward state:
+
+| Column | Type | Semantics |
+|--------|------|-----------|
+| `id` | `BIGSERIAL PRIMARY KEY` | Stable event identity. Provider/operator APIs render this as `mra_<id>`. |
+| `provider_id` | `TEXT NOT NULL` | Provider subject. Provider reads MUST derive this from bearer auth, never from query/body input. |
+| `occurred_at` | `TIMESTAMPTZ NOT NULL` | Event creation/transition time in UTC. |
+| `event_type` | `TEXT NOT NULL` | Closed vocabulary below. |
+| `ledger_id` | `BIGINT NULL` | Optional `provider_rewards_ledger.id` correlation for money-path rows. |
+| `amount_malibu` | `NUMERIC(24,8) NULL` | Reward amount when event concerns a ledger amount. |
+| `withdrawal_hold_reason` | `TEXT NULL` | Closed hold reason when event applies/clears a hold. |
+| `trust_tier` | `TEXT NULL` | Trust tier when event concerns trust state. |
+| `source_reason` | `TEXT NULL` | Ledger source reason such as `malibu_bootstrap_tick` or `malibu_verified_useful_work_v0_2`. |
+| `safe_summary` | `TEXT NOT NULL` | Provider-safe sentence; no secrets or raw prompt/output data. |
+| `operator_correlation` | `JSONB NOT NULL` | Operator-only correlation keys, e.g. ledger ID, source reason, and idempotency external-ref. |
+
+Closed `event_type` vocabulary:
+
+| Value | Meaning |
+|-------|---------|
+| `malibu_accrual_inserted` | A MALIBU ledger row was inserted. |
+| `malibu_hold_applied` | A withdrawal hold was applied to a reward row. |
+| `malibu_hold_cleared` | A withdrawal hold was cleared, e.g. cap replay. |
+| `wallet_daily_cap_applied` | A wallet daily cap hold was applied. |
+| `wallet_bind_projected` | A payout wallet projection changed and cap replay is pending. |
+| `trust_tier_promoted` | Provider trust tier transitioned to `trusted`. |
+| `trust_tier_demoted` | Provider trust tier transitioned to `provisional`. |
+| `withdrawal_candidate_selected` | Reserved for the withdrawal runner selecting a candidate row. |
+| `withdrawal_candidate_skipped` | Reserved for the withdrawal runner skipping a candidate row. |
+| `eligibility_reason_changed` | Reserved for future reward-eligibility reason transitions. |
+
+Provider-visible audit responses MUST NOT include `operator_correlation`,
+`external_ref`, raw request payloads, raw prompts, raw outputs, bearer tokens,
+operator secrets, full arbitrary metadata maps, or internal notes. Operator
+responses MAY include `operator_correlation`, but the column itself remains an
+allowlisted JSON object owned by this spec; it MUST NOT become a dump of
+unreviewed request/provider metadata.
+
+Retention: audit rows are append-only and retained for at least **180 days**.
+Any compaction/archive after that window MUST preserve `id`, `provider_id`,
+`occurred_at`, `event_type`, `ledger_id`, `withdrawal_hold_reason`, and
+`safe_summary` for dispute/support correlation.
+
+### 2.6 `rewards_writer` Postgres role
 
 Dedicated runtime role for emission writes:
 
 - `INSERT` on `provider_rewards_ledger`, `wallet_daily_malibu_emission`, `provider_emission_state`
 - `UPDATE` on `wallet_daily_malibu_emission`, `provider_emission_state`
-- `SELECT` on projection + ledger + state tables
+- `SELECT` on projection + ledger + state + audit tables
+- `INSERT` on `malibu_reward_audit_events`
 - **No** `DELETE`, `TRUNCATE`, or DDL
 - Emission transactions run at **`SERIALIZABLE`** isolation with **retry-on-40001** (max 5 attempts, exponential backoff 10–160ms)
 
@@ -295,7 +355,50 @@ USDC `ledger_payout_ready` runner is unchanged.
 
 `withdrawable_malibu` sums ledger rows where `withdrawal_hold_reason IS NULL`.
 
-### 5.1 `malibu_reward_eligibility.v1`
+### 5.1 Reward audit API
+
+`GET /v1/provider/malibu-reward-audit?limit=25&before_id=mra_123`
+(provider-token auth) returns recent provider-scoped audit events:
+
+```json
+{
+  "events": [
+    {
+      "id": "mra_42",
+      "occurred_at": "2026-08-17T12:00:00Z",
+      "event_type": "malibu_hold_applied",
+      "ledger_id": 917,
+      "amount_malibu": "0.26041667",
+      "withdrawal_hold_reason": "trust_tier_provisional",
+      "trust_tier": "provisional",
+      "source_reason": "malibu_bootstrap_tick",
+      "summary": "Reward hold applied because the provider is provisional."
+    }
+  ],
+  "next_before_id": "mra_41"
+}
+```
+
+Rules:
+
+- Provider identity MUST come from the bearer token. A provider request MUST
+  NOT accept `provider_id` as a query/body override.
+- `limit` defaults to 25 and MUST be bounded to 1..100.
+- Pagination is keyset pagination using `before_id`; cursors are stable
+  `mra_<id>` event IDs.
+- Provider events are ordered newest first.
+- Provider responses MUST use the field allowlist above and exclude
+  `operator_correlation` and `external_ref`.
+- Unknown event types under a known schema version MUST be rendered as
+  "reward status updated" copy and logged for client upgrade.
+
+`GET /admin/malibu-reward-audit?provider_id=<id>&limit=25&before_id=mra_123`
+(operator bearer auth) returns the same events plus `provider_id` and
+`operator_correlation`, allowing support and operators to correlate a provider
+visible event with the authoritative ledger row, trust transition, source
+reason, and useful-work idempotency key.
+
+### 5.2 `malibu_reward_eligibility.v1`
 
 `reward_eligibility` is the coordinator-owned provider read model for whether
 MALIBU is currently earnable, held, capped, withdrawable, ineligible, or
@@ -404,7 +507,18 @@ Coordinator → CLI metrics wiring is C3; this spec defines the read API in §5.
 
 ---
 
-## 8. Acceptance criteria
+## 8. Normative requirements
+
+| Requirement | Status | Text |
+|-------------|--------|------|
+| `SPEC-021-R001` | Draft | MALIBU reward mutations MUST persist append-only audit events for accrual insertion, hold application/clearance, wallet projection, and trust-tier promotion/demotion. |
+| `SPEC-021-R002` | Draft | Provider reward-audit reads MUST authenticate with provider bearer tokens, derive provider identity from the token, enforce provider isolation, and use bounded stable cursor pagination. |
+| `SPEC-021-R003` | Draft | Provider-visible reward-audit events MUST use a fixed safe field allowlist and MUST NOT expose operator correlation, external refs, raw prompts, raw outputs, bearer tokens, operator secrets, arbitrary metadata, or internal notes. |
+| `SPEC-021-R004` | Draft | Operator reward-audit reads MUST require operator auth and return enough correlation to map provider-visible events to ledger IDs, source reasons, trust transitions, and idempotency references. |
+
+---
+
+## 9. Acceptance criteria
 
 - [ ] Provisional provider accrues MALIBU with `withdrawal_hold_reason = trust_tier_provisional`
 - [ ] Second `provider_id` on same wallet cannot exceed 100 MALIBU/day wallet aggregate
@@ -413,12 +527,16 @@ Coordinator → CLI metrics wiring is C3; this spec defines the read API in §5.
 - [ ] Non-verified, missing-receipt, quarantined, or legacy/observe-only rows do not accrue v0.2 useful-work MALIBU
 - [ ] Duplicate settlement/mirror replay with the same `spec022:<request_id>:<attempt_n>:<provider_id>` external ref does not mint a second row or advance cap counters
 - [ ] Existing v0.1 `malibu_bootstrap_tick` balances remain readable and are not reclassified
+- [ ] Provider reward audit API returns recent events with stable IDs, bounded pagination, and no cross-provider leakage
+- [ ] Provider reward audit API excludes operator correlation, external refs, raw prompts/outputs, bearer tokens, and arbitrary metadata
+- [ ] Operator reward audit query returns provider/ledger/trust correlation for support and dispute investigation
+- [ ] Cap replay and trust demotion/promotion produce corresponding audit events
 - [ ] `rewards_writer` cannot SELECT from `partner_keys` or write `stats_*` rollup tables
 - [ ] Migration is idempotent; existing `amount_usd` leaderboard rollup continues to work
 
 ---
 
-## 9. Open questions
+## 10. Open questions
 
 1. Cohort telemetry may adjust 100 MALIBU/day wallet cap (SPEC-026 §13).
 2. Whether bootstrap tick remains permanently as an early-network floor or is disabled after demand reaches a stable threshold remains an operator policy choice.
@@ -426,4 +544,4 @@ Coordinator → CLI metrics wiring is C3; this spec defines the read API in §5.
 
 ---
 
-*End of SPEC-MALIBU-EMISSION-LEDGER v0.2.0.*
+*End of SPEC-MALIBU-EMISSION-LEDGER v0.3.0.*

--- a/specs/SPEC-021-malibu-emission-ledger.md
+++ b/specs/SPEC-021-malibu-emission-ledger.md
@@ -85,7 +85,7 @@ MALIBU rows with non-NULL `external_ref` are unique by `external_ref`.
 | Value | Meaning |
 |-------|---------|
 | `trust_tier_provisional` | Provider is Provisional; accrues but cannot withdraw MALIBU |
-| `per_wallet_daily_cap` | Wallet aggregate cap reached; accrual continues for visibility but is held |
+| `per_wallet_daily_cap` | Wallet aggregate cap reached on a partial boundary accrual; the accepted remainder is visible but not withdrawable |
 | `demotion_cooldown` | Provider demoted from Trusted; 72h requalification window (SPEC-026 §5.5) |
 
 Withdrawal selection: `WHERE withdrawal_hold_reason IS NULL AND amount_malibu IS NOT NULL AND amount_malibu > 0`.
@@ -213,7 +213,7 @@ Dedicated runtime role for emission writes:
 | v0.2 useful-work rate | **1 MALIBU / 1000 verified provider credits** |
 | Withdrawable | **No** until `trust_tier = trusted` |
 | Hold reason (provisional accrual) | `trust_tier_provisional` |
-| Hold reason (wallet cap exceeded) | `per_wallet_daily_cap` (accrue but non-withdrawable) |
+| Hold reason (wallet cap boundary reached) | `per_wallet_daily_cap` (accepted remainder is accrual-visible but non-withdrawable) |
 
 Trusted providers accrue with `withdrawal_hold_reason IS NULL` unless wallet cap applies (`per_wallet_daily_cap`).
 Provider and wallet daily caps are shared across v0.1 bootstrap tick rows and
@@ -234,7 +234,7 @@ v0.2 useful-work rows.
   2. Compute tick accrual: `provider_daily_cap / ticks_per_day`
   3. Under SERIALIZABLE txn + wallet/provider day counters:
      - If `provider_day_malibu + tick > provider_daily_cap`, accrue remainder only
-     - If bound wallet set and `wallet sum + accrual > wallet_daily_cap`, accrue remainder with `per_wallet_daily_cap` hold on overflow portion
+     - If bound wallet set and `wallet sum + accrual > wallet_daily_cap`, accrue only the remainder that fits under `wallet_daily_cap`, mark that accepted boundary amount with `per_wallet_daily_cap`, and skip any fully over-cap amount so the wallet aggregate never advances beyond the cap
      - Insert `provider_rewards_ledger` row
      - Upsert aggregates
 
@@ -254,6 +254,14 @@ only by `malibu_emission.enabled`; v0.2 does not reclassify them.
   - `provider_credits > 0`
   - no existing MALIBU ledger row for
     `external_ref = spec022:<request_id>:<attempt_n>:<provider_id>`
+- If the provider or wallet daily cap is already exhausted before a useful-work
+  row can accept any MALIBU, the coordinator writes a terminal ledger marker
+  with `amount_malibu = 0` and the useful-work `external_ref`. This marks the
+  source row processed without advancing provider or wallet daily aggregates.
+  Wallet-cap terminal markers use
+  `withdrawal_hold_reason = per_wallet_daily_cap` and a paired
+  `wallet_daily_cap_applied` audit event so the provider read model remains
+  capped for the UTC day.
 - Formula:
 
 ```text
@@ -337,6 +345,7 @@ USDC `ledger_payout_ready` runner is unchanged.
   "held_malibu": "12.50000000",
   "trust_tier": "provisional",
   "daily_cap_malibu": "25",
+  "provider_daily_capped": false,
   "wallet_daily_cap_malibu": "100",
   "withdrawal_hold_reasons": ["trust_tier_provisional"],
   "reward_eligibility": {
@@ -433,6 +442,7 @@ Reason vocabulary:
 | `earning_verified_work` | coordinator reward/read model | Recent verified work was observed by the reward owner and can be presented as active earning. |
 | `eligible_idle_no_work` | coordinator reward/read model | No blocking reward reason is known, but no current earning work is observed. |
 | `held_provisional_trust_tier` | MALIBU ledger/trust | Accrual is visible but held because the provider is not Trusted. Maps from `withdrawal_hold_reason = trust_tier_provisional`. |
+| `held_provider_daily_cap` | provider emission state | The provider has reached its UTC-day MALIBU cap. Maps from `provider_emission_state.provider_day_malibu >= daily_cap_malibu` for the current UTC day. |
 | `held_wallet_daily_cap` | MALIBU ledger | Accrual is held or capped by the bound-wallet daily MALIBU cap. Maps from `withdrawal_hold_reason = per_wallet_daily_cap`. |
 | `held_demotion_cooldown` | MALIBU ledger/trust | Accrual is held during post-demotion requalification. Maps from `withdrawal_hold_reason = demotion_cooldown`. |
 | `withdrawable_balance_available` | MALIBU ledger | At least one MALIBU ledger row is withdrawable. |
@@ -455,8 +465,11 @@ Precedence:
 
 1. `compute_integrity_blocked` outranks `compute_integrity_pending`; only a
    recognized positive compute state may omit both reasons.
-2. `held_wallet_daily_cap` outranks `held_provisional_trust_tier` when both are
-   present, so clients can render cap-specific copy.
+2. `held_wallet_daily_cap` and `held_provider_daily_cap` outrank
+   `held_provisional_trust_tier` when both are present, so clients can render
+   cap-specific copy. `held_wallet_daily_cap` MAY be derived from same-UTC-day
+   `wallet_daily_cap_applied` audit events when a provisional ledger row can
+   store only `trust_tier_provisional` as its primary hold.
 3. `missing_wallet_binding` blocks MALIBU withdrawal readiness and outranks raw
    withdrawable ledger balance and generic proof-source unavailable reasons for
    `primary_reason`.

--- a/specs/SPEC-021-malibu-emission-ledger.md
+++ b/specs/SPEC-021-malibu-emission-ledger.md
@@ -261,7 +261,8 @@ only by `malibu_emission.enabled`; v0.2 does not reclassify them.
   Wallet-cap terminal markers use
   `withdrawal_hold_reason = per_wallet_daily_cap` and a paired
   `wallet_daily_cap_applied` audit event so the provider read model remains
-  capped for the UTC day.
+  capped for the UTC day unless a later `malibu_hold_cleared` audit event
+  clears the same ledger row.
 - Formula:
 
 ```text
@@ -468,8 +469,8 @@ Precedence:
 2. `held_wallet_daily_cap` and `held_provider_daily_cap` outrank
    `held_provisional_trust_tier` when both are present, so clients can render
    cap-specific copy. `held_wallet_daily_cap` MAY be derived from same-UTC-day
-   `wallet_daily_cap_applied` audit events when a provisional ledger row can
-   store only `trust_tier_provisional` as its primary hold.
+   un-cleared `wallet_daily_cap_applied` audit events when a provisional ledger
+   row can store only `trust_tier_provisional` as its primary hold.
 3. `missing_wallet_binding` blocks MALIBU withdrawal readiness and outranks raw
    withdrawable ledger balance and generic proof-source unavailable reasons for
    `primary_reason`.


### PR DESCRIPTION
## Summary

- Add an append-only MALIBU reward audit event table and provider/admin query APIs.
- Record audit events for accruals, holds, wallet-cap decisions, wallet bind projection, cap replay clears, and trust tier transitions.
- Document SPEC-021 v0.3.0 requirements and conformance coverage for provider-safe audit visibility.

## Validation

- `go test ./...` from `phase4-coordinator`
- `python3 scripts/check_spec_governance.py --base-ref origin/main`
- `git diff --check origin/main`
- `python3 scripts/verify-agent-onboarding-skill.py`
- Native subagents: code/security/architect all reported 0 critical/high/medium findings

Not run locally:

- `go test -tags integration ./internal/rewards` is blocked on this machine because rootless Docker is unavailable.

SPEC-GOVERNANCE-DECLARATION-BEGIN
{
  "schema_version": "spec-pr-governance-v1",
  "behavior_change": "yes",
  "contract_change": "yes",
  "specs": ["SPEC-021"],
  "requirements": ["SPEC-021-R001", "SPEC-021-R002", "SPEC-021-R003", "SPEC-021-R004"],
  "authority_domains": ["malibu-emission-ledger"],
  "arbitration": ["CODE_BUG"],
  "tests": [
    "phase4-coordinator: go test ./...",
    "python3 scripts/check_spec_governance.py --base-ref origin/main",
    "git diff --check origin/main",
    "python3 scripts/verify-agent-onboarding-skill.py",
    "native subagents: code/security/architect 0 C/H/M"
  ],
  "journeys": ["not-required"],
  "issue": "https://github.com/Augustas11/macprovider/issues/1021"
}
SPEC-GOVERNANCE-DECLARATION-END

Closes #1021.
