### PR TITLE
Fix MicroMDM list-devices POST + live-MDA overlay classification

### DIFF
--- a/ops/pearl/config/source-of-truth.yaml
+++ b/ops/pearl/config/source-of-truth.yaml
@@ -485,6 +485,37 @@ pearl_overlay_classifications:
     category: Evidence
     classification: overlay-owned Pearl production setting
     expected_type: number
+  - path: tier2.mdm.enrollment_base_url
+    owner: pearl_production_overlay
+    category: Evidence
+    classification: overlay-owned Pearl production setting
+    expected_type: string
+  - path: tier2.mdm.push_topic
+    owner: pearl_production_overlay
+    category: Evidence
+    classification: overlay-owned Pearl production setting
+    expected_type: string
+  - path: tier2.mdm.api_url
+    owner: pearl_production_overlay
+    category: Evidence
+    classification: overlay-owned Pearl production setting
+    expected_type: string
+  - path: tier2.mdm.api_token
+    owner: pearl_operator_secrets
+    category: Evidence
+    classification: secrets/env-owned setting
+    require_env_reference: true
+    message: live MicroMDM API token reference is classified; value=<MASKED>
+  - path: tier2.mdm.live_mda_enabled
+    owner: pearl_production_overlay
+    category: Evidence
+    classification: overlay-owned Pearl production setting
+    expected_type: boolean
+  - path: tier2.mdm.mda_refresh_interval_hours
+    owner: pearl_production_overlay
+    category: Evidence
+    classification: overlay-owned Pearl production setting
+    expected_type: integer
 
 provider_rows:
   tracked_static_provider_ids:
@@ -530,6 +561,7 @@ env_key_names:
     - OPERATOR_KEY
     - COORDINATOR_PARTNER_KEYS_ADMIN_DSN
     - MAL_REFERRAL_HMAC_K1
+    - MICROMDM_API_TOKEN
     - STATS_PARTNER_KEYS_WRITER_DSN
     - STATS_READER_DSN
     - STATS_ROLLUP_DSN

--- a/phase4-coordinator/dist/coordinator.yaml.example
+++ b/phase4-coordinator/dist/coordinator.yaml.example
@@ -301,6 +301,7 @@ tier2:
   #   # live_mda_enabled: false          # flip to true after APNs cert + MicroMDM deploy
   #   # mda_refresh_interval_hours: 168  # 7 days default; when live_mda_enabled, values below 168 are clamped to 168
   #   # command_webhook_secret: "env:MICROMDM_COMMAND_WEBHOOK_SECRET"
+  #   # MicroMDM list-devices is POST /v1/devices (GET 404s).
   #   # MicroMDM: -command-webhook-url http://127.0.0.1:8444/internal/mdm/command-webhook
   #   # (loopback OK without secret; set secret + X-MDM-Webhook-Secret if not loopback)
 

--- a/phase4-coordinator/dist/systemd/micromdm-serve.sh
+++ b/phase4-coordinator/dist/systemd/micromdm-serve.sh
@@ -12,4 +12,5 @@ exec /opt/micromdm/bin/micromdm serve \
   -tls=false \
   -http-proxy-headers=true \
   -homepage=false \
-  -log-time=true
+  -log-time=true \
+  -command-webhook-url http://127.0.0.1:8444/internal/mdm/command-webhook

--- a/phase4-coordinator/internal/mdm/client.go
+++ b/phase4-coordinator/internal/mdm/client.go
@@ -64,11 +64,13 @@ type listDevicesResponse struct {
 }
 
 // ListDevices returns all devices enrolled in MicroMDM.
+// MicroMDM's HTTP API only accepts POST /v1/devices (GET is 404).
 func (c *Client) ListDevices(ctx context.Context) ([]Device, error) {
-	req, err := c.newRequest(ctx, http.MethodGet, "/v1/devices", nil)
+	req, err := c.newRequest(ctx, http.MethodPost, "/v1/devices", bytes.NewReader([]byte("{}")))
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Content-Type", "application/json")
 	var resp listDevicesResponse
 	if err := c.doJSON(req, &resp); err != nil {
 		return nil, fmt.Errorf("mdm list devices: %w", err)

--- a/phase4-coordinator/internal/mdm/client_test.go
+++ b/phase4-coordinator/internal/mdm/client_test.go
@@ -31,6 +31,12 @@ func TestListDevices(t *testing.T) {
 		if r.URL.Path != "/v1/devices" {
 			t.Errorf("unexpected path %q", r.URL.Path)
 		}
+		if r.Method != http.MethodPost {
+			t.Errorf("unexpected method %q want POST", r.Method)
+		}
+		if ct := r.Header.Get("Content-Type"); !strings.Contains(ct, "json") {
+			t.Errorf("Content-Type=%q want json", ct)
+		}
 		user, pass, ok := r.BasicAuth()
 		if !ok || user != "micromdm" || pass != "test-token" {
 			t.Errorf("bad basic auth: user=%q pass=%q ok=%v", user, pass, ok)


### PR DESCRIPTION
## Summary
- Coordinator `ListDevices` now **POST** `/v1/devices` with `{}` (this MicroMDM 404s GET; that blocked Phase 3 device bind on v1.8.95).
- Persist MicroMDM `-command-webhook-url` in `micromdm-serve.sh`.
- Classify Pearl overlay `tier2.mdm.*` and allow `MICROMDM_API_TOKEN` in source-of-truth.

Pearl already has live MDA observe + bind on v1.8.95 via a loopback GET→POST nginx translator on `:8081`. This PR lets the next runtime talk to MicroMDM directly.

spec-index authority domain: `tier2-trust-evidence` (SPEC-008 owner in AUTHORITY.json).

## Test plan
- [x] `go test ./internal/mdm/ -count=1`
- [x] `python3 ops/pearl/config/test_pearl_config_reconcile.py`
- [ ] After merge + runtime: point `tier2.mdm.api_url` back at `http://127.0.0.1:8080` and remove the `:8081` translator

## Audits
Three Codex lanes via `omc ask codex`. Code + architect: 0 C/H/M APPROVE. Security REJECT with 1 MEDIUM **pre-existing** `go1.26.5` stdlib govulncheck findings (not in this diff; same CI toolchain pin as v1.8.95). Carried explicitly.

SPEC-GOVERNANCE-DECLARATION-BEGIN
{
  "schema_version": "spec-pr-governance-v1",
  "behavior_change": "yes",
  "contract_change": "none",
  "specs": ["SPEC-008"],
  "requirements": ["SPEC-008-R001"],
  "authority_domains": ["tier2-trust-evidence"],
  "arbitration": ["CODE_BUG"],
  "tests": ["phase4-coordinator/internal/mdm/client_test.go"],
  "journeys": ["not-required"],
  "issue": "https://github.com/Augustas11/macprovider/issues/1033"
}
SPEC-GOVERNANCE-DECLARATION-END

Made with [Cursor](https://cursor.com)