### PR TITLE
Let discovery renewal create protected transport tags

### DIFF
--- a/.github/workflows/renew-release-discovery-head.yml
+++ b/.github/workflows/renew-release-discovery-head.yml
@@ -314,7 +314,7 @@ jobs:
         id: publish
         shell: bash
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ secrets.RELEASE_POSTURE_TOKEN }}
           OPENSSL_BIN: ${{ steps.protected_openssl.outputs.bin }}
           TAG: ${{ steps.target.outputs.tag }}
           COMMIT: ${{ steps.target.outputs.commit }}

--- a/scripts/test-renew-release-discovery-head.sh
+++ b/scripts/test-renew-release-discovery-head.sh
@@ -80,6 +80,8 @@ if 'gh release create "release-discovery"' in publish or "gh release upload" in 
     raise SystemExit("renewal must not publish to the fixed release-discovery tag")
 if "gh release create \"$TRANSPORT_TAG\"" not in publish:
     raise SystemExit("renewal must create an append-only transport tag")
+if "GH_TOKEN: ${{ secrets.RELEASE_POSTURE_TOKEN }}" not in publish:
+    raise SystemExit("renewal publish must use the protected release token")
 top_level, _, rest = workflow.partition("\njobs:\n")
 if "contents: write" in top_level:
     raise SystemExit("top-level renewal permissions must remain read-only")


### PR DESCRIPTION
## Summary

- Use the protected release token for the renewal workflow publish step that creates the append-only `release-discovery-v1-*` transport tag.
- Keep top-level workflow permissions read-only and keep the anonymous public verifier free of protected secrets.
- Extend the renewal workflow structural test so this credential boundary stays locked.

## Root Cause

Run `32093708961` signed and verified a renewed discovery head, then failed creating the new transport release with `HTTP 403: Resource not accessible by integration`. The renewal path creates a brand-new protected tag, unlike the numeric release path that publishes an already-created tag.

## Validation

- `bash scripts/test-renew-release-discovery-head.sh`

## Governance Note

This is an infra/release-workflow-only change under `.github/workflows`. Per repo guidance, there is no honest SPEC governance declaration for this path; the advisory `spec-index / check` may be red and is not a required merge check.
