### PR TITLE
Record clean-tree buyer journey evidence without promoting it

### DIFF
--- a/journeys/evidence/buyer-crash-recovery-20260818T051826Z.redacted.json
+++ b/journeys/evidence/buyer-crash-recovery-20260818T051826Z.redacted.json
@@ -1,0 +1,25 @@
+{
+  "captured_at": "2026-08-18T05:18:26Z",
+  "journey_id": "JOURNEY-BUYER-CRASH-RECOVERY",
+  "observations": {
+    "idempotent_rescan": true,
+    "identity_fallback_recovered": true,
+    "job_enabled": false,
+    "missing_credit_rows_created": 1,
+    "orphan_credit_rows_quarantined": 1,
+    "orphan_quarantined": true,
+    "payout_ready_mutated": false,
+    "planted_at": "2026-08-18T05:16:26.024891Z",
+    "recovery_source": "startup_scan",
+    "settlement_mode": "observe"
+  },
+  "repository": {
+    "commit": "f6c61a785347c4dcd61a42f3925cd1cd161d0480",
+    "name": "Augustas11/macprovider"
+  },
+  "requirement_ids": [
+    "SPEC-005-R003"
+  ],
+  "run_id": "buyer-crash-recovery-20260818T051826Z",
+  "schema_version": "macprovider.buyer-crash-recovery-evidence.v1"
+}

--- a/journeys/evidence/buyer-enforce-20260818T051838Z.redacted.json
+++ b/journeys/evidence/buyer-enforce-20260818T051838Z.redacted.json
@@ -1,0 +1,158 @@
+{
+  "captured_at": "2026-08-18T05:18:38Z",
+  "environment": {
+    "candidate": "commit:f6c61a785347c4dcd61a42f3925cd1cd161d0480",
+    "class": "isolated-candidate-enforce"
+  },
+  "expires_at": "2026-09-17",
+  "harness": {
+    "execution_mode": "isolated-candidate-enforce",
+    "id": "test/integration:TestJourneyBuyerEnforceIsolatedCandidate",
+    "isolated_sqlite": true,
+    "production_pearl": false,
+    "production_side_effects": false,
+    "real_binaries": true,
+    "settlement_runner": false
+  },
+  "journey_id": "JOURNEY-BUYER-ENFORCE",
+  "observations": {
+    "enforce_activated": true,
+    "isolated_environment": true,
+    "payout_ready_mutated": false,
+    "production_pearl": false,
+    "production_side_effects": false,
+    "raw_prompt_output_redacted": true,
+    "settlement_mode_end": "observe",
+    "settlement_mode_start": "enforce"
+  },
+  "operator": {
+    "identity_fingerprint": "36f99b7bd0ed27f09c26023e50341e9044b5786b9bdba2bc55a02986716ff7a6",
+    "role": "acceptance-operator"
+  },
+  "redaction": {
+    "local_account_names_redacted": true,
+    "operator_identity_redacted": true,
+    "secrets_redacted": true
+  },
+  "repository": {
+    "commit": "f6c61a785347c4dcd61a42f3925cd1cd161d0480",
+    "name": "Augustas11/macprovider"
+  },
+  "requirement_ids": [
+    "SPEC-022-R007",
+    "SPEC-022-R008",
+    "SPEC-022-R009",
+    "SPEC-022-R011"
+  ],
+  "result": {
+    "status": "pass",
+    "summary": "isolated candidate enforce journey passed without payout-ready mutation or Pearl flip"
+  },
+  "run_id": "buyer-enforce-20260818T051838Z",
+  "schema_version": "macprovider.buyer-enforce-evidence.v1",
+  "steps": [
+    {
+      "id": "step-01-capture-config",
+      "status": "pass",
+      "assertion": "isolated candidate captured in enforce mode with an API-key subject and no settlement runner",
+      "artifacts": [
+        "redacted-buyer-enforce"
+      ],
+      "details": {
+        "auth_subject": "api_key",
+        "demo_token_used": false,
+        "enforce_activated": true,
+        "isolated_sqlite": true,
+        "job_enabled": false,
+        "pending_deadline_s": 1,
+        "production_pearl": false,
+        "settlement_mode": "enforce",
+        "wallet_session_used": false
+      }
+    },
+    {
+      "id": "step-02-verified-debit",
+      "status": "pass",
+      "assertion": "reservation-first debit settled only after a verified settlement-capable receipt",
+      "artifacts": [
+        "redacted-buyer-enforce"
+      ],
+      "details": {
+        "http_status": 200,
+        "reservation_status": "settled",
+        "settled_tokens": 20,
+        "settlement_outcome": "verified",
+        "settlement_policy_mode": "enforce",
+        "usage_outcome": "spec022_verified"
+      }
+    },
+    {
+      "id": "step-03-payout-exclusion",
+      "status": "pass",
+      "assertion": "job_enabled stayed false and verified enforce traffic created no payout-ready rows",
+      "artifacts": [
+        "redacted-buyer-enforce"
+      ],
+      "details": {
+        "job_enabled": false,
+        "payout_exclusion_outcome": "excluded_until_spec022_verified",
+        "payout_ready_count": 0
+      }
+    },
+    {
+      "id": "step-04-missing-receipt-quarantine",
+      "status": "pass",
+      "assertion": "deadline quarantine released the buyer reservation and kept payout exclusion",
+      "artifacts": [
+        "redacted-buyer-enforce"
+      ],
+      "details": {
+        "payout_ready_count": 0,
+        "reason": "missing_receipt_deadline_elapsed",
+        "receipt_present": 0,
+        "reservation_status": "refunded",
+        "settlement_outcome": "quarantined"
+      }
+    },
+    {
+      "id": "step-05-policy-pinning",
+      "status": "pass",
+      "assertion": "observe rollback did not rewrite already-enforced ledger or verdict rows",
+      "artifacts": [
+        "redacted-buyer-enforce"
+      ],
+      "details": {
+        "credit_count": 2,
+        "pinned_policy_mode": "enforce",
+        "pinned_route_snapshot": "enforce",
+        "yaml_mode_after_rewrite": "observe"
+      }
+    },
+    {
+      "id": "step-06-audit",
+      "status": "pass",
+      "assertion": "per-attempt settlement audit is structured and omits raw prompts, outputs, and secrets",
+      "artifacts": [
+        "redacted-buyer-enforce"
+      ],
+      "details": {
+        "raw_prompt_output_redacted": true,
+        "verdict_audit_events": 3
+      }
+    },
+    {
+      "id": "step-07-restore-config",
+      "status": "pass",
+      "assertion": "settlement job stayed disabled and production Pearl was not touched",
+      "artifacts": [
+        "redacted-buyer-enforce"
+      ],
+      "details": {
+        "job_enabled": false,
+        "payout_ready_mutated": false,
+        "production_pearl": false,
+        "yaml_mode": "observe"
+      }
+    }
+  ]
+}

--- a/journeys/evidence/buyer-paid-path-20260818T051813Z.redacted.json
+++ b/journeys/evidence/buyer-paid-path-20260818T051813Z.redacted.json
@@ -1,0 +1,255 @@
+{
+  "candidate_identity": {
+    "autotune_catalog_sha256": "56c4c20a8d0b3a1944ff0539829d0f517097c5189f22d7f1453c8e491dff1720",
+    "autotune_catalog_version": "published-2026-07-29-inband-provenance-v1",
+    "coordinator_config_sha256": "6333076467455453e544ea06ef295d21ccb45005a7de93ca74b75ebc297b5494",
+    "gateway_base_url_sha256": "ed7e63747c22cd0a04ba95821616d69c3cc6ff7cbbab912d21d5f86e7afb729e",
+    "rate_card_matched_key": "default",
+    "rate_card_sha256": "68eb8794a2388cd73727b23db7e13adee8ae2c8e30bc0eeef5ad887223398cd3",
+    "rate_card_version": "51d4eb9d29024e759c8e41610ad3f13614253e52f47bc032c92f46adb599ad42",
+    "signed_catalog_id": "integration-catalog",
+    "signed_catalog_key_id": "integration-catalog-key",
+    "verified_model_sha256": "e7e5bff4248768b4db7a53afb3b514ba5867b800f63d1abd0330eaf08e54aa90"
+  },
+  "captured_at": "2026-08-18T05:18:13Z",
+  "environment": {
+    "candidate": "commit:f6c61a785347c4dcd61a42f3925cd1cd161d0480",
+    "class": "isolated-candidate-paid-path",
+    "hardware_profile": "local-macos-redacted"
+  },
+  "expires_at": "2026-09-17",
+  "harness": {
+    "execution_mode": "isolated-candidate-paid-path",
+    "id": "test/integration:TestJourneyBuyerPaidPathIsolatedCandidate",
+    "isolated_sqlite": true,
+    "production_side_effects": false,
+    "real_binaries": true,
+    "settlement_runner": false
+  },
+  "journey_id": "JOURNEY-BUYER-PAID-PATH",
+  "observations": {
+    "bearer_tokens_redacted": true,
+    "buyer_receipt_retrieval_exposed": true,
+    "enforce_activated": false,
+    "isolated_environment": true,
+    "payout_ready_mutated": false,
+    "production_side_effects": false,
+    "raw_prompt_output_redacted": true,
+    "settlement_mode": "observe"
+  },
+  "operator": {
+    "identity_fingerprint": "19fc9a8b5b9134d581ac7089082d4d6da1f4ea4e3049c6c52bd963be62e93295",
+    "role": "acceptance-operator"
+  },
+  "quota": {
+    "ending": 999960,
+    "starting": 1000000
+  },
+  "redaction": {
+    "local_account_names_redacted": true,
+    "operator_identity_redacted": true,
+    "secrets_redacted": true
+  },
+  "repository": {
+    "commit": "f6c61a785347c4dcd61a42f3925cd1cd161d0480",
+    "name": "Augustas11/macprovider"
+  },
+  "requirement_ids": [
+    "SPEC-005-R001",
+    "SPEC-005-R002",
+    "SPEC-006-R001",
+    "SPEC-006-R002",
+    "SPEC-006-R003",
+    "SPEC-015-R001",
+    "SPEC-022-R001",
+    "SPEC-022-R002",
+    "SPEC-022-R003",
+    "SPEC-022-R004",
+    "SPEC-022-R005",
+    "SPEC-022-R006",
+    "SPEC-022-R010"
+  ],
+  "result": {
+    "status": "pass",
+    "summary": "isolated candidate paid-path journey passed in observe mode without payout-ready mutation"
+  },
+  "run_id": "buyer-paid-path-20260818T051813Z",
+  "schema_version": "macprovider.buyer-paid-path-evidence.v1",
+  "steps": [
+    {
+      "id": "step-01-capture-config",
+      "status": "pass",
+      "assertion": "isolated candidate captured in observe mode with an API-key subject and no settlement runner",
+      "artifacts": [
+        "redacted-buyer-paid-path"
+      ],
+      "details": {
+        "account_fingerprint": "3c322b917279e230578a9806fc302df0ab7a98aeda2d4520b367485af0d5dafd",
+        "auth_subject": "api_key",
+        "demo_token_used": false,
+        "enforce_activated": false,
+        "isolated_sqlite": true,
+        "job_enabled": false,
+        "settlement_mode": "observe",
+        "starting_quota": 1000000,
+        "wallet_session_used": false
+      }
+    },
+    {
+      "id": "step-02-nonstream-chat",
+      "status": "pass",
+      "assertion": "API-key non-streaming chat returned 200 with OpenAI-compatible usage",
+      "artifacts": [
+        "redacted-buyer-paid-path"
+      ],
+      "details": {
+        "gateway_request_sha256": "bd7662a5eeb41614e720d477abfcb2272e19a8a70a93b7e3bc8560d44ad326e9",
+        "http_status": 200,
+        "usage_present": true
+      }
+    },
+    {
+      "id": "step-03-quota-settlement",
+      "status": "pass",
+      "assertion": "gateway quota reservation settled after the 200 and did not leak",
+      "artifacts": [
+        "redacted-buyer-paid-path"
+      ],
+      "details": {
+        "not_r008_evidence": true,
+        "observe_mode_debit": true,
+        "remaining_quota": 999980,
+        "reservation_status": "settled",
+        "settled_tokens": 20
+      }
+    },
+    {
+      "id": "step-04-ledger-credit",
+      "status": "pass",
+      "assertion": "coordinator ledger wrote a payable observe-mode credit whose persisted rates reproduce the default rate-card split",
+      "artifacts": [
+        "redacted-buyer-paid-path"
+      ],
+      "details": {
+        "completion_rate_per_mtok": 1000000,
+        "completion_tokens": 12,
+        "credit_id_fingerprint": "6b86b273ff34fce19d6b804eff5a3f5747ada4eaa22f1d49c01e52ddb7875b4b",
+        "global_multiplier_ppm": 1000000,
+        "gross_credits": 16,
+        "prompt_rate_per_mtok": 500000,
+        "prompt_tokens": 8,
+        "provider_credits": 14,
+        "provider_share_bps": 9000,
+        "rate_card_matched_key": "default",
+        "settled_flag": 0,
+        "settlement_policy_mode": "observe"
+      }
+    },
+    {
+      "id": "step-05-receipt-ingest",
+      "status": "pass",
+      "assertion": "SPEC-015 v0.4 settlement receipt was ingested and verified in observe mode",
+      "artifacts": [
+        "redacted-buyer-paid-path"
+      ],
+      "details": {
+        "buyer_debit_outcome": "no_money_movement_step5",
+        "provider_settlement_outcome": "no_money_movement_step5",
+        "raw_prompt_output_absent": true,
+        "receipt_result": "valid",
+        "receipt_version": "4",
+        "settlement_outcome": "verified"
+      }
+    },
+    {
+      "id": "step-06-streaming-chat",
+      "status": "pass",
+      "assertion": "streaming chat terminated cleanly; settled completion tokens equal the 12-token fixture prefix, not a byte-length estimate",
+      "artifacts": [
+        "redacted-buyer-paid-path"
+      ],
+      "details": {
+        "completion_tokens": 12,
+        "delivered_prefix_sha256": "077e71d22e9003f3ce6b3bf2039d0441efb517870edc0fe849ec594fd6dcee47",
+        "done_marker": true,
+        "http_status": 200,
+        "reservation_status": "settled",
+        "settled_tokens": 20,
+        "stream_ledger": true
+      }
+    },
+    {
+      "id": "step-07-failure-refund",
+      "status": "pass",
+      "assertion": "pre-dispatch failure returned a buyer error envelope and refunded quota with no provider credit",
+      "artifacts": [
+        "redacted-buyer-paid-path"
+      ],
+      "details": {
+        "error_code": "model_not_found",
+        "error_retryable": false,
+        "http_status": 404,
+        "ledger_row_count": 2,
+        "quota_status": "refunded"
+      }
+    },
+    {
+      "id": "step-08-disclosure",
+      "status": "pass",
+      "assertion": "buyer models disclosure names paid entrypoints and observe-mode prose; it does not claim currently enforcing",
+      "artifacts": [
+        "redacted-buyer-paid-path"
+      ],
+      "details": {
+        "chat_included": true,
+        "enforce_claimed": false,
+        "excluded_named": true,
+        "http_status": 200,
+        "observe_mode": true
+      }
+    },
+    {
+      "id": "step-09-receipt-retrieval",
+      "status": "pass",
+      "assertion": "owner GET /v1/receipts/{id} returns metadata-only 200; missing is 404; unauthenticated is 401",
+      "artifacts": [
+        "redacted-buyer-paid-path"
+      ],
+      "details": {
+        "buyer_receipt_retrieval_exposed": true,
+        "http_status": 200,
+        "missing_http_status": 404,
+        "surface": "metadata",
+        "unauthenticated_http_status": 401
+      }
+    },
+    {
+      "id": "step-10-redaction",
+      "status": "pass",
+      "assertion": "retained artifacts contain fingerprints only; bearer tokens, private keys, and raw prompt/output are absent",
+      "artifacts": [
+        "redacted-buyer-paid-path"
+      ],
+      "details": {
+        "bearer_tokens_redacted": true,
+        "payout_ready_mutated": false,
+        "raw_prompt_output_redacted": true
+      }
+    },
+    {
+      "id": "step-11-restore-config",
+      "status": "pass",
+      "assertion": "settlement mode remained observe, no payout-ready mutation, and enforce was not activated",
+      "artifacts": [
+        "redacted-buyer-paid-path"
+      ],
+      "details": {
+        "ending_quota": 999960,
+        "enforce_activated": false,
+        "job_enabled": false,
+        "payout_ready_mutated": false,
+        "settlement_mode": "observe"
+      }
+    }
+  ]
+}

--- a/scripts/build-buyer-paid-path-journey-result.py
+++ b/scripts/build-buyer-paid-path-journey-result.py
@@ -16,6 +16,7 @@ from pathlib import Path
 from typing import Any
 
 from check_spec_governance import (
+    BUYER_PAID_PATH_CONDITIONAL_REQUIREMENT_IDS,
     BUYER_PAID_PATH_EXECUTION_MODE,
     BUYER_PAID_PATH_JOURNEY_ID,
     BUYER_PAID_PATH_PROMOTABLE_REQUIREMENT_IDS,
@@ -170,7 +171,11 @@ def parse_requirement_ids(raw: str | None, evidence: dict[str, Any]) -> list[str
     overclaimed = [item for item in input_ids if item not in covered]
     if overclaimed:
         die(f"--requirement-ids must be covered by evidence.requirement_ids: {', '.join(overclaimed)}")
-    forbidden = [item for item in input_ids if item not in BUYER_PAID_PATH_PROMOTABLE_REQUIREMENT_IDS]
+    allowed = set(BUYER_PAID_PATH_PROMOTABLE_REQUIREMENT_IDS)
+    observations = evidence.get("observations")
+    if isinstance(observations, dict) and observations.get("buyer_receipt_retrieval_exposed") is True:
+        allowed |= BUYER_PAID_PATH_CONDITIONAL_REQUIREMENT_IDS
+    forbidden = [item for item in input_ids if item not in allowed]
     if forbidden:
         die(f"paid-path journey-result cannot promote {', '.join(forbidden)}")
     return input_ids

--- a/scripts/tests/test_buyer_paid_path_journey_result.py
+++ b/scripts/tests/test_buyer_paid_path_journey_result.py
@@ -228,6 +228,21 @@ class BuyerPaidPathJourneyResultTests(unittest.TestCase):
         with self.assertRaises(SystemExit):
             builder.parse_requirement_ids("SPEC-005-R003", {"requirement_ids": ["SPEC-005-R003"]})
         with self.assertRaises(SystemExit):
+            builder.parse_requirement_ids(
+                "SPEC-022-R006",
+                {"requirement_ids": ["SPEC-022-R006"]},
+            )
+        self.assertEqual(
+            builder.parse_requirement_ids(
+                "SPEC-022-R006",
+                {
+                    "requirement_ids": ["SPEC-022-R006"],
+                    "observations": {"buyer_receipt_retrieval_exposed": True},
+                },
+            ),
+            ["SPEC-022-R006"],
+        )
+        with self.assertRaises(SystemExit):
             builder.require_observations({"settlement_mode": "enforce"})
         with self.assertRaises(SystemExit):
             builder.require_candidate_identity({"rate_card_matched_key": "default"})


### PR DESCRIPTION
## Summary
- Record redacted evidence from clean `origin/main` `f6c61a785347c4dcd61a42f3925cd1cd161d0480`: paid-path (`buyer_receipt_retrieval_exposed=true`), crash-recovery, and isolated enforce.
- Allow `build-buyer-paid-path-journey-result.py` to select `SPEC-022-R006` only when retrieval is exposed. R007/R008 stay rejected on paid-path.
- Do not promote any CONFORMANCE row. A local capture is not a signed journey-result.

## Test plan
- [x] `MACPROVIDER_CAPTURE_BUYER_PAID_PATH=1` / crash / enforce isolated journey tests on a clean tree
- [x] `python3 -m unittest scripts.tests.test_buyer_paid_path_journey_result`
- [x] 3-lane `omc ask codex` 0 CRITICAL / 0 HIGH / 0 MEDIUM
- [ ] CI green
- [ ] After merge: dispatch `promote-signed-buyer-paid-path-journey.yml` from main with `requirement_ids=SPEC-022-R006` only

SPEC-GOVERNANCE-DECLARATION-BEGIN
{
  "schema_version": "spec-pr-governance-v1",
  "behavior_change": "yes",
  "contract_change": "none",
  "specs": ["SPEC-005", "SPEC-022"],
  "requirements": ["SPEC-005-R003", "SPEC-022-R006", "SPEC-022-R007", "SPEC-022-R008", "SPEC-022-R009", "SPEC-022-R011"],
  "authority_domains": ["billing-settlement-formula", "verified-model-settlement"],
  "arbitration": ["UNKNOWN"],
  "tests": ["test/integration/buyer_paid_path_journey_test.go:TestJourneyBuyerPaidPathIsolatedCandidate", "test/integration/buyer_crash_recovery_journey_test.go:TestJourneyBuyerCrashRecoveryIsolatedCandidate", "test/integration/buyer_enforce_journey_test.go:TestJourneyBuyerEnforceIsolatedCandidate", "scripts/tests/test_buyer_paid_path_journey_result.py"],
  "journeys": ["JOURNEY-BUYER-PAID-PATH", "JOURNEY-BUYER-CRASH-RECOVERY", "JOURNEY-BUYER-ENFORCE"],
  "issue": "https://github.com/Augustas11/macprovider/issues/1042"
}
SPEC-GOVERNANCE-DECLARATION-END

Made with [Cursor](https://cursor.com)