### PR TITLE
Record clean-tree crash-recovery and enforce evidence without promotion

### DIFF
--- a/journeys/evidence/buyer-crash-recovery-20260818T065904Z.redacted.json
+++ b/journeys/evidence/buyer-crash-recovery-20260818T065904Z.redacted.json
@@ -1,0 +1,156 @@
+{
+  "captured_at": "2026-08-18T06:59:04Z",
+  "environment": {
+    "candidate": "commit:caa6ae4aec712c5d6353a3d307aab551911bea65",
+    "class": "isolated-candidate-crash-recovery",
+    "hardware_profile": "local-macos-redacted"
+  },
+  "expires_at": "2026-09-17",
+  "harness": {
+    "execution_mode": "isolated-candidate-crash-recovery",
+    "id": "test/integration:TestJourneyBuyerCrashRecoveryIsolatedCandidate",
+    "isolated_sqlite": true,
+    "production_side_effects": false,
+    "real_binaries": true,
+    "settlement_runner": false
+  },
+  "journey_id": "JOURNEY-BUYER-CRASH-RECOVERY",
+  "observations": {
+    "idempotent_rescan": true,
+    "identity_fallback_recovered": true,
+    "isolated_environment": true,
+    "job_enabled": false,
+    "missing_credit_rows_created": 1,
+    "orphan_credit_rows_quarantined": 1,
+    "orphan_quarantined": true,
+    "payout_ready_mutated": false,
+    "planted_at": "2026-08-18T06:57:03.731795Z",
+    "production_pearl": false,
+    "production_side_effects": false,
+    "recovery_source": "startup_scan",
+    "settlement_mode": "observe",
+    "start_job_enabled": false,
+    "start_mode": "observe"
+  },
+  "operator": {
+    "identity_fingerprint": "be58592d53b5b222fca8a50f59960f5c4be6a594ecbfbc9b7d52fab5fc109cab",
+    "role": "acceptance-operator"
+  },
+  "redaction": {
+    "local_account_names_redacted": true,
+    "operator_identity_redacted": true,
+    "secrets_redacted": true
+  },
+  "repository": {
+    "commit": "caa6ae4aec712c5d6353a3d307aab551911bea65",
+    "name": "Augustas11/macprovider"
+  },
+  "requirement_ids": [
+    "SPEC-005-R003"
+  ],
+  "result": {
+    "status": "pass",
+    "summary": "isolated candidate crash-recovery journey recovered identity-fallback credits without double credit or payout-ready mutation"
+  },
+  "run_id": "buyer-crash-recovery-20260818T065904Z",
+  "schema_version": "macprovider.buyer-crash-recovery-evidence.v1",
+  "steps": [
+    {
+      "id": "step-01-capture-config",
+      "status": "pass",
+      "assertion": "isolated candidate captured in observe mode with settlement job disabled",
+      "artifacts": [
+        "redacted-buyer-crash-recovery"
+      ],
+      "details": {
+        "isolated_sqlite": true,
+        "job_enabled": false,
+        "settlement_mode": "observe"
+      }
+    },
+    {
+      "id": "step-02-stop-coordinator",
+      "status": "pass",
+      "assertion": "coordinator process stopped against the same isolated SQLite file",
+      "artifacts": [
+        "redacted-buyer-crash-recovery"
+      ],
+      "details": {
+        "coordinator_stopped": true
+      }
+    },
+    {
+      "id": "step-03-plant-identity-fallback",
+      "status": "pass",
+      "assertion": "identity-fallback request_log and provider snapshot planted with no credit row",
+      "artifacts": [
+        "redacted-buyer-crash-recovery"
+      ],
+      "details": {
+        "credit_count": 0,
+        "request_id": "crash-recovery-identity-fallback"
+      }
+    },
+    {
+      "id": "step-04-plant-orphan-credit",
+      "status": "pass",
+      "assertion": "orphan ledger_request_credits row planted without matching request_log",
+      "artifacts": [
+        "redacted-buyer-crash-recovery"
+      ],
+      "details": {
+        "orphan_request_id": "crash-recovery-orphan-credit"
+      }
+    },
+    {
+      "id": "step-05-startup-scan-recover",
+      "status": "pass",
+      "assertion": "startup_scan recovered exactly one non-quarantined credit for the planted request",
+      "artifacts": [
+        "redacted-buyer-crash-recovery"
+      ],
+      "details": {
+        "missing_credit_rows_created": 1,
+        "recovered_credits": 1,
+        "recovery_source": "startup_scan",
+        "startup_scan_status": "complete"
+      }
+    },
+    {
+      "id": "step-06-orphan-quarantine",
+      "status": "pass",
+      "assertion": "planted orphan credit was quarantined missing_request_log",
+      "artifacts": [
+        "redacted-buyer-crash-recovery"
+      ],
+      "details": {
+        "orphan_quarantined": 1,
+        "quarantine_reason": "missing_request_log"
+      }
+    },
+    {
+      "id": "step-07-idempotent-rescan",
+      "status": "pass",
+      "assertion": "second startup scan did not double-credit the recovered request",
+      "artifacts": [
+        "redacted-buyer-crash-recovery"
+      ],
+      "details": {
+        "credits_after_rescan": 1
+      }
+    },
+    {
+      "id": "step-08-no-payout",
+      "status": "pass",
+      "assertion": "settlement job stayed disabled and no payout-ready rows were created",
+      "artifacts": [
+        "redacted-buyer-crash-recovery"
+      ],
+      "details": {
+        "job_enabled": false,
+        "payout_ready_count": 0,
+        "settlement_mode": "observe"
+      }
+    }
+  ]
+}

--- a/journeys/evidence/buyer-enforce-20260818T065941Z.redacted.json
+++ b/journeys/evidence/buyer-enforce-20260818T065941Z.redacted.json
@@ -1,0 +1,161 @@
+{
+  "captured_at": "2026-08-18T06:59:41Z",
+  "environment": {
+    "candidate": "commit:caa6ae4aec712c5d6353a3d307aab551911bea65",
+    "class": "isolated-candidate-enforce",
+    "hardware_profile": "local-macos-redacted"
+  },
+  "expires_at": "2026-09-17",
+  "harness": {
+    "execution_mode": "isolated-candidate-enforce",
+    "id": "test/integration:TestJourneyBuyerEnforceIsolatedCandidate",
+    "isolated_sqlite": true,
+    "production_pearl": false,
+    "production_side_effects": false,
+    "real_binaries": true,
+    "settlement_runner": false
+  },
+  "journey_id": "JOURNEY-BUYER-ENFORCE",
+  "observations": {
+    "enforce_activated": true,
+    "isolated_environment": true,
+    "job_enabled": false,
+    "payout_ready_mutated": false,
+    "production_pearl": false,
+    "production_side_effects": false,
+    "raw_prompt_output_redacted": true,
+    "settlement_mode_end": "observe",
+    "settlement_mode_start": "enforce",
+    "start_job_enabled": false
+  },
+  "operator": {
+    "identity_fingerprint": "36f99b7bd0ed27f09c26023e50341e9044b5786b9bdba2bc55a02986716ff7a6",
+    "role": "acceptance-operator"
+  },
+  "redaction": {
+    "local_account_names_redacted": true,
+    "operator_identity_redacted": true,
+    "secrets_redacted": true
+  },
+  "repository": {
+    "commit": "caa6ae4aec712c5d6353a3d307aab551911bea65",
+    "name": "Augustas11/macprovider"
+  },
+  "requirement_ids": [
+    "SPEC-022-R007",
+    "SPEC-022-R008",
+    "SPEC-022-R009",
+    "SPEC-022-R011"
+  ],
+  "result": {
+    "status": "pass",
+    "summary": "isolated candidate enforce journey passed without payout-ready mutation or Pearl flip"
+  },
+  "run_id": "buyer-enforce-20260818T065941Z",
+  "schema_version": "macprovider.buyer-enforce-evidence.v1",
+  "steps": [
+    {
+      "id": "step-01-capture-config",
+      "status": "pass",
+      "assertion": "isolated candidate captured in enforce mode with an API-key subject and no settlement runner",
+      "artifacts": [
+        "redacted-buyer-enforce"
+      ],
+      "details": {
+        "auth_subject": "api_key",
+        "demo_token_used": false,
+        "enforce_activated": true,
+        "isolated_sqlite": true,
+        "job_enabled": false,
+        "pending_deadline_s": 1,
+        "production_pearl": false,
+        "settlement_mode": "enforce",
+        "wallet_session_used": false
+      }
+    },
+    {
+      "id": "step-02-verified-debit",
+      "status": "pass",
+      "assertion": "reservation-first debit settled only after a verified settlement-capable receipt",
+      "artifacts": [
+        "redacted-buyer-enforce"
+      ],
+      "details": {
+        "http_status": 200,
+        "reservation_status": "settled",
+        "settled_tokens": 20,
+        "settlement_outcome": "verified",
+        "settlement_policy_mode": "enforce",
+        "usage_outcome": "spec022_verified"
+      }
+    },
+    {
+      "id": "step-03-payout-exclusion",
+      "status": "pass",
+      "assertion": "job_enabled stayed false and verified enforce traffic created no payout-ready rows",
+      "artifacts": [
+        "redacted-buyer-enforce"
+      ],
+      "details": {
+        "job_enabled": false,
+        "payout_exclusion_outcome": "excluded_until_spec022_verified",
+        "payout_ready_count": 0
+      }
+    },
+    {
+      "id": "step-04-missing-receipt-quarantine",
+      "status": "pass",
+      "assertion": "deadline quarantine released the buyer reservation and kept payout exclusion",
+      "artifacts": [
+        "redacted-buyer-enforce"
+      ],
+      "details": {
+        "payout_ready_count": 0,
+        "reason": "missing_receipt_deadline_elapsed",
+        "receipt_present": 0,
+        "reservation_status": "refunded",
+        "settlement_outcome": "quarantined"
+      }
+    },
+    {
+      "id": "step-05-policy-pinning",
+      "status": "pass",
+      "assertion": "observe rollback did not rewrite already-enforced ledger or verdict rows",
+      "artifacts": [
+        "redacted-buyer-enforce"
+      ],
+      "details": {
+        "credit_count": 2,
+        "pinned_policy_mode": "enforce",
+        "pinned_route_snapshot": "enforce",
+        "yaml_mode_after_rewrite": "observe"
+      }
+    },
+    {
+      "id": "step-06-audit",
+      "status": "pass",
+      "assertion": "per-attempt settlement audit is structured and omits raw prompts, outputs, and secrets",
+      "artifacts": [
+        "redacted-buyer-enforce"
+      ],
+      "details": {
+        "raw_prompt_output_redacted": true,
+        "verdict_audit_events": 3
+      }
+    },
+    {
+      "id": "step-07-restore-config",
+      "status": "pass",
+      "assertion": "settlement job stayed disabled and production Pearl was not touched",
+      "artifacts": [
+        "redacted-buyer-enforce"
+      ],
+      "details": {
+        "job_enabled": false,
+        "payout_ready_mutated": false,
+        "production_pearl": false,
+        "yaml_mode": "observe"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- Record redacted evidence from clean `origin/main` `caa6ae4aec712c5d6353a3d307aab551911bea65`: crash-recovery (8 physical steps) and isolated enforce (7 physical steps, YAML enforce with `job_enabled: false`).
- Do not promote any CONFORMANCE row. A local capture is not a signed journey-result. Pearl stays unflipped.
- After merge, dispatch `promote-signed-buyer-crash-recovery-journey.yml` (`SPEC-005-R003`) and `promote-signed-buyer-enforce-journey.yml` (`SPEC-022-R007,SPEC-022-R008,SPEC-022-R009,SPEC-022-R011`) from main.

## Test plan
- [x] Captured from a clean tree at `caa6ae4a` (`MACPROVIDER_CAPTURE_BUYER_CRASH_RECOVERY=1` then `MACPROVIDER_CAPTURE_BUYER_ENFORCE=1`, moving the first file aside between captures)
- [x] Crash: 8 steps, observe, `job_enabled: false`, `production_pearl: false`
- [x] Enforce: 7 steps, isolated enforce start, `job_enabled: false`, `production_pearl: false`
- [x] 3-lane `omc ask codex` 0 CRITICAL / 0 HIGH / 0 MEDIUM
- [ ] CI green

Related: https://github.com/Augustas11/macprovider/issues/1044

SPEC-GOVERNANCE-DECLARATION-BEGIN
{
  "schema_version": "spec-pr-governance-v1",
  "behavior_change": "yes",
  "contract_change": "none",
  "specs": ["SPEC-005", "SPEC-022"],
  "requirements": ["SPEC-005-R003", "SPEC-022-R007", "SPEC-022-R008", "SPEC-022-R009", "SPEC-022-R011"],
  "authority_domains": ["billing-settlement-formula", "verified-model-settlement"],
  "arbitration": ["UNKNOWN"],
  "tests": ["test/integration/buyer_crash_recovery_journey_test.go:TestJourneyBuyerCrashRecoveryIsolatedCandidate", "test/integration/buyer_enforce_journey_test.go:TestJourneyBuyerEnforceIsolatedCandidate"],
  "journeys": ["JOURNEY-BUYER-CRASH-RECOVERY", "JOURNEY-BUYER-ENFORCE"],
  "issue": "https://github.com/Augustas11/macprovider/issues/1043"
}
SPEC-GOVERNANCE-DECLARATION-END

Made with [Cursor](https://cursor.com)