### PR TITLE
Promote signed SPEC-022-R007/R008/R009/R011 via protected enforce envelope

### DIFF
--- a/journeys/evidence/buyer-enforce-20260818T065941Z.spec-022-r007-spec-022-r008-spec-022-r009-spec-022-r011.journey-result.signed.json
+++ b/journeys/evidence/buyer-enforce-20260818T065941Z.spec-022-r007-spec-022-r008-spec-022-r009-spec-022-r011.journey-result.signed.json
@@ -1,0 +1,126 @@
+{
+  "schema_version": "macprovider.journey-result-envelope.v1",
+  "signatures": [
+    {
+      "algorithm": "ecdsa-p256-sha256",
+      "key_id": "macprovider-acceptance-p256-v1",
+      "signature": "MEUCIB8SiSi/7UcSqo8ubBPIMI8QEWZ2MaWDV0RE/fWOPFMFAiEA8rJheN8cW0Dn8+YJAMPPPjCJpQikleIrB04ZA+BzOv0=",
+      "signed_sha256": "9ca4c9192e1ecaf0b3fb21955c4321a674b8fa05d52949d9e457aa9ae561fc67",
+      "verified_at": "2026-08-18T07:54:45Z",
+      "verifier": ".github/workflows/promote-signed-buyer-enforce-journey.yml:32110816602:1"
+    }
+  ],
+  "signed": {
+    "schema_version": "macprovider.journey-result.v1",
+    "journey_id": "JOURNEY-BUYER-ENFORCE",
+    "requirement_ids": [
+      "SPEC-022-R007",
+      "SPEC-022-R008",
+      "SPEC-022-R009",
+      "SPEC-022-R011"
+    ],
+    "repository": {
+      "name": "Augustas11/macprovider",
+      "commit": "caa6ae4aec712c5d6353a3d307aab551911bea65"
+    },
+    "captured_at": "2026-08-18T06:59:41Z",
+    "expires_at": "2026-09-17",
+    "operator": {
+      "identity_fingerprint": "36f99b7bd0ed27f09c26023e50341e9044b5786b9bdba2bc55a02986716ff7a6",
+      "role": "acceptance-operator"
+    },
+    "environment": {
+      "candidate": "commit:caa6ae4aec712c5d6353a3d307aab551911bea65",
+      "class": "isolated-candidate-enforce",
+      "hardware_profile": "local-macos-redacted"
+    },
+    "artifacts": [
+      {
+        "id": "redacted-buyer-enforce",
+        "sha256": "051a36b0a680e1a67abf0c54b747b8b498307d70780add3d1e54e3dabe845fff",
+        "source": "journeys/evidence/buyer-enforce-20260818T065941Z.redacted.json"
+      }
+    ],
+    "result": {
+      "status": "pass",
+      "summary": "isolated candidate enforce journey passed without payout-ready mutation or Pearl flip"
+    },
+    "steps": [
+      {
+        "id": "step-01-capture-config",
+        "status": "pass",
+        "assertion": "isolated candidate captured in enforce mode with an API-key subject and no settlement runner",
+        "artifacts": [
+          "redacted-buyer-enforce"
+        ]
+      },
+      {
+        "id": "step-02-verified-debit",
+        "status": "pass",
+        "assertion": "reservation-first debit settled only after a verified settlement-capable receipt",
+        "artifacts": [
+          "redacted-buyer-enforce"
+        ]
+      },
+      {
+        "id": "step-03-payout-exclusion",
+        "status": "pass",
+        "assertion": "job_enabled stayed false and verified enforce traffic created no payout-ready rows",
+        "artifacts": [
+          "redacted-buyer-enforce"
+        ]
+      },
+      {
+        "id": "step-04-missing-receipt-quarantine",
+        "status": "pass",
+        "assertion": "deadline quarantine released the buyer reservation and kept payout exclusion",
+        "artifacts": [
+          "redacted-buyer-enforce"
+        ]
+      },
+      {
+        "id": "step-05-policy-pinning",
+        "status": "pass",
+        "assertion": "observe rollback did not rewrite already-enforced ledger or verdict rows",
+        "artifacts": [
+          "redacted-buyer-enforce"
+        ]
+      },
+      {
+        "id": "step-06-audit",
+        "status": "pass",
+        "assertion": "per-attempt settlement audit is structured and omits raw prompts, outputs, and secrets",
+        "artifacts": [
+          "redacted-buyer-enforce"
+        ]
+      },
+      {
+        "id": "step-07-restore-config",
+        "status": "pass",
+        "assertion": "settlement job stayed disabled and production Pearl was not touched",
+        "artifacts": [
+          "redacted-buyer-enforce"
+        ]
+      }
+    ],
+    "redaction": {
+      "local_account_names_redacted": true,
+      "operator_identity_redacted": true,
+      "secrets_redacted": true
+    },
+    "run_id": "buyer-enforce-20260818T065941Z",
+    "execution_mode": "isolated-candidate-enforce",
+    "observations": {
+      "enforce_activated": true,
+      "isolated_environment": true,
+      "job_enabled": false,
+      "payout_ready_mutated": false,
+      "production_pearl": false,
+      "production_side_effects": false,
+      "raw_prompt_output_redacted": true,
+      "settlement_mode_end": "observe",
+      "settlement_mode_start": "enforce",
+      "start_job_enabled": false
+    }
+  }
+}

--- a/specs/CONFORMANCE.json
+++ b/specs/CONFORMANCE.json
@@ -4310,7 +4310,7 @@
     {
       "requirement_id": "SPEC-022-R007",
       "spec_id": "SPEC-022",
-      "state": "pending",
+      "state": "conformant",
       "implementation": [
         "phase4-coordinator/internal/billing/settlement_receipts.go:IngestSettlementReceipt",
         "phase4-coordinator/internal/billing/settlement.go:RunSettlement"
@@ -4324,18 +4324,26 @@
       "journeys": [
         "JOURNEY-BUYER-ENFORCE"
       ],
-      "evidence": [],
-      "gap": {
-        "verdict": "UNKNOWN",
-        "owner": "@Augustas11",
-        "issue": "https://github.com/Augustas11/macprovider/issues/1044",
-        "rationale": "R-7 settlement, quarantine, and payout exclusion. Isolated JOURNEY-BUYER-ENFORCE exercises enforce-mode verified debit plus missing-receipt deadline quarantine with reservation refund and no payout-ready rows. JOURNEY-BUYER-PAID-PATH must not promote this row from observe mode. A passing local harness is not signed promotion evidence. Physical evidence is #1044. Production Pearl is not flipped."
-      }
+      "evidence": [
+        {
+          "artifact": "commit:caa6ae4aec712c5d6353a3d307aab551911bea65",
+          "source": null,
+          "captured_at": "2026-08-18",
+          "expires_at": "2026-09-17"
+        },
+        {
+          "artifact": "sha256:5ede794fefc03470f1e3e5c0c401e95c8b9842c2c4aa0ac0fb7fcefd0ee39e14",
+          "source": "journeys/evidence/buyer-enforce-20260818T065941Z.spec-022-r007-spec-022-r008-spec-022-r009-spec-022-r011.journey-result.signed.json",
+          "captured_at": "2026-08-18",
+          "expires_at": "2026-09-17"
+        }
+      ],
+      "gap": null
     },
     {
       "requirement_id": "SPEC-022-R008",
       "spec_id": "SPEC-022",
-      "state": "pending",
+      "state": "conformant",
       "implementation": [
         "phase5-gateway/internal/storage/sqlite/store.go:ReserveQuota",
         "phase5-gateway/internal/storage/sqlite/store.go:SettleReservation",
@@ -4349,18 +4357,26 @@
       "journeys": [
         "JOURNEY-BUYER-ENFORCE"
       ],
-      "evidence": [],
-      "gap": {
-        "verdict": "UNKNOWN",
-        "owner": "@Augustas11",
-        "issue": "https://github.com/Augustas11/macprovider/issues/1044",
-        "rationale": "R-8 buyer debit semantics. Isolated JOURNEY-BUYER-ENFORCE proves reservation-first gateway debit after verified receipts and reservation refund after deadline quarantine. Observe-mode JOURNEY-BUYER-PAID-PATH must not promote this row. A passing local harness is not signed promotion evidence. Physical evidence is #1044."
-      }
+      "evidence": [
+        {
+          "artifact": "commit:caa6ae4aec712c5d6353a3d307aab551911bea65",
+          "source": null,
+          "captured_at": "2026-08-18",
+          "expires_at": "2026-09-17"
+        },
+        {
+          "artifact": "sha256:5ede794fefc03470f1e3e5c0c401e95c8b9842c2c4aa0ac0fb7fcefd0ee39e14",
+          "source": "journeys/evidence/buyer-enforce-20260818T065941Z.spec-022-r007-spec-022-r008-spec-022-r009-spec-022-r011.journey-result.signed.json",
+          "captured_at": "2026-08-18",
+          "expires_at": "2026-09-17"
+        }
+      ],
+      "gap": null
     },
     {
       "requirement_id": "SPEC-022-R009",
       "spec_id": "SPEC-022",
-      "state": "pending",
+      "state": "conformant",
       "implementation": [
         "phase4-coordinator/internal/billing/recovery.go:RecoverLedger"
       ],
@@ -4372,13 +4388,21 @@
       "journeys": [
         "JOURNEY-BUYER-ENFORCE"
       ],
-      "evidence": [],
-      "gap": {
-        "verdict": "UNKNOWN",
-        "owner": "@Augustas11",
-        "issue": "https://github.com/Augustas11/macprovider/issues/1044",
-        "rationale": "R-9 rollout, migration, and rollback. Isolated JOURNEY-BUYER-ENFORCE pins enforce-mode ledger rows, then rewrites YAML to observe and restarts the coordinator; already-enforced rows retain settlement_policy_mode=enforce. A passing local harness is not signed promotion evidence. Physical evidence is #1044. Production Pearl is not flipped."
-      }
+      "evidence": [
+        {
+          "artifact": "commit:caa6ae4aec712c5d6353a3d307aab551911bea65",
+          "source": null,
+          "captured_at": "2026-08-18",
+          "expires_at": "2026-09-17"
+        },
+        {
+          "artifact": "sha256:5ede794fefc03470f1e3e5c0c401e95c8b9842c2c4aa0ac0fb7fcefd0ee39e14",
+          "source": "journeys/evidence/buyer-enforce-20260818T065941Z.spec-022-r007-spec-022-r008-spec-022-r009-spec-022-r011.journey-result.signed.json",
+          "captured_at": "2026-08-18",
+          "expires_at": "2026-09-17"
+        }
+      ],
+      "gap": null
     },
     {
       "requirement_id": "SPEC-022-R010",
@@ -4414,7 +4438,7 @@
     {
       "requirement_id": "SPEC-022-R011",
       "spec_id": "SPEC-022",
-      "state": "pending",
+      "state": "conformant",
       "implementation": [
         "phase4-coordinator/internal/billing/settlement_receipts.go:insertSettlementReceiptVerdictAuditConn"
       ],
@@ -4425,13 +4449,21 @@
       "journeys": [
         "JOURNEY-BUYER-ENFORCE"
       ],
-      "evidence": [],
-      "gap": {
-        "verdict": "UNKNOWN",
-        "owner": "@Augustas11",
-        "issue": "https://github.com/Augustas11/macprovider/issues/1044",
-        "rationale": "R-11 audit and observability. Isolated JOURNEY-BUYER-ENFORCE reads settlement_receipt_verdict audit_log rows and asserts structured outcome fields without raw prompts, outputs, or API keys. A passing local harness is not signed promotion evidence. Physical evidence is #1044."
-      }
+      "evidence": [
+        {
+          "artifact": "commit:caa6ae4aec712c5d6353a3d307aab551911bea65",
+          "source": null,
+          "captured_at": "2026-08-18",
+          "expires_at": "2026-09-17"
+        },
+        {
+          "artifact": "sha256:5ede794fefc03470f1e3e5c0c401e95c8b9842c2c4aa0ac0fb7fcefd0ee39e14",
+          "source": "journeys/evidence/buyer-enforce-20260818T065941Z.spec-022-r007-spec-022-r008-spec-022-r009-spec-022-r011.journey-result.signed.json",
+          "captured_at": "2026-08-18",
+          "expires_at": "2026-09-17"
+        }
+      ],
+      "gap": null
     },
     {
       "requirement_id": "SPEC-016-R001",

--- a/specs/README.md
+++ b/specs/README.md
@@ -30,7 +30,7 @@ it can no longer drift. Do not hand-edit the table; edit each spec's
 | SPEC-019 | Structured output (`response_format: json_schema`) | 0.2.5 | normative | pending | pending corpus migration | [SPEC-019-structured-output.md](SPEC-019-structured-output.md) |
 | SPEC-020 | Provider autoupdate | v0.1.11 | normative | pending | pending: 4 | [SPEC-020-provider-autoupdate.md](SPEC-020-provider-autoupdate.md) |
 | SPEC-021 | MALIBU rewards emission ledger | 0.3.0 | draft | complete | pending: 4 | [SPEC-021-malibu-emission-ledger.md](SPEC-021-malibu-emission-ledger.md) |
-| SPEC-022 | Verified model settlement | v0.1.7 | draft | complete | conformant: 7, pending: 4 | [SPEC-022-verified-model-settlement.md](SPEC-022-verified-model-settlement.md) |
+| SPEC-022 | Verified model settlement | v0.1.7 | draft | complete | conformant: 11 | [SPEC-022-verified-model-settlement.md](SPEC-022-verified-model-settlement.md) |
 | SPEC-023 | Installer-Integrated Autotune Recommend | v0.9.3 | normative | pending | conformant: 2 | [SPEC-023-installer-autotune-recommend.md](SPEC-023-installer-autotune-recommend.md) |
 | SPEC-024 | Prefix-cache billing and provider-local cache isolation | 0.2.1 | normative | pending | pending corpus migration | [SPEC-024-prefix-cache-billing.md](SPEC-024-prefix-cache-billing.md) |
 | SPEC-025 | Native Mac App (signed `.dmg` + menu bar wrapper) | v0.22 | draft | pending | pending corpus migration | [SPEC-025-native-mac-app.md](SPEC-025-native-mac-app.md) |


### PR DESCRIPTION
## Summary
- Promote `SPEC-022-R007`, `SPEC-022-R008`, `SPEC-022-R009`, `SPEC-022-R011` to conformant using the protected signed buyer-enforce envelope built from evidence `buyer-enforce-20260818T065941Z.redacted.json`.
- This PR adds `journeys/evidence/...journey-result.signed.json` and updates `specs/CONFORMANCE.json` only.

## Test plan
- [x] `python3 scripts/promote-signed-journey-result.py SPEC-022-R007 journeys/evidence/buyer-enforce-20260818T065941Z.spec-022-r007-spec-022-r008-spec-022-r009-spec-022-r011.journey-result.signed.json --base-ref origin/main`
- [x] `python3 scripts/check_spec_governance.py --base-ref origin/main`

SPEC-GOVERNANCE-DECLARATION-BEGIN
{
  "schema_version": "spec-pr-governance-v1",
  "behavior_change": "yes",
  "contract_change": "yes",
  "specs": ["SPEC-022"],
  "requirements": ["SPEC-022-R007", "SPEC-022-R008", "SPEC-022-R009", "SPEC-022-R011"],
  "authority_domains": ["billing-settlement-formula", "verified-model-settlement"],
  "arbitration": ["UNKNOWN"],
  "tests": ["python3 scripts/check_spec_governance.py --base-ref origin/main"],
  "journeys": ["JOURNEY-BUYER-ENFORCE"],
  "issue": "https://github.com/Augustas11/macprovider/issues/1044"
}
SPEC-GOVERNANCE-DECLARATION-END

Made with [Cursor](https://cursor.com)