### PR TITLE
Fix dependency debt for Pearl Go and payout fixture

### DIFF
--- a/.github/workflows/acceptance-candidate.yml
+++ b/.github/workflows/acceptance-candidate.yml
@@ -109,10 +109,25 @@ jobs:
           CANDIDATE_COMMIT: ${{ steps.source.outputs.candidate_commit }}
         run: bash candidate/scripts/verify-app-build-inputs.sh "$CANDIDATE_COMMIT"
 
+      - name: Verify candidate Pearl Go module parity
+        shell: bash
+        run: |
+          set -euo pipefail
+          coordinator_go="$(awk '$1 == "go" { print $2; exit }' candidate/phase4-coordinator/go.mod)"
+          gateway_go="$(awk '$1 == "go" { print $2; exit }' candidate/phase5-gateway/go.mod)"
+          if [ -z "$coordinator_go" ] || [ -z "$gateway_go" ]; then
+            echo "::error::candidate Pearl module is missing a Go directive" >&2
+            exit 1
+          fi
+          if [ "$coordinator_go" != "$gateway_go" ]; then
+            echo "::error::candidate Pearl Go module mismatch: coordinator=$coordinator_go gateway=$gateway_go" >&2
+            exit 1
+          fi
+
       - name: Setup Go for candidate Pearl binaries
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e
         with:
-          go-version: "1.26.5"
+          go-version-file: candidate/phase4-coordinator/go.mod
           cache-dependency-path: |
             candidate/phase4-coordinator/go.sum
             candidate/phase5-gateway/go.sum

--- a/phase4-coordinator/go.mod
+++ b/phase4-coordinator/go.mod
@@ -1,6 +1,6 @@
 module github.com/augstar/macprovider-coordinator
 
-go 1.26.5
+go 1.26.6
 
 require (
 	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.4.0
@@ -17,6 +17,7 @@ require (
 	golang.org/x/net v0.56.0
 	golang.org/x/text v0.40.0
 	gopkg.in/yaml.v3 v3.0.1
+	howett.net/plist v1.0.1
 	modernc.org/sqlite v1.52.0
 )
 
@@ -81,7 +82,6 @@ require (
 	go.yaml.in/yaml/v2 v2.4.2 // indirect
 	golang.org/x/sys v0.47.0 // indirect
 	google.golang.org/protobuf v1.36.8 // indirect
-	howett.net/plist v1.0.1 // indirect
 	modernc.org/libc v1.72.3 // indirect
 	modernc.org/mathutil v1.7.1 // indirect
 	modernc.org/memory v1.11.0 // indirect

--- a/phase4-coordinator/internal/payout/testdata/eip712_js/package-lock.json
+++ b/phase4-coordinator/internal/payout/testdata/eip712_js/package-lock.json
@@ -1,21 +1,20 @@
 {
-  "name": "eip712_js",
+  "name": "eip712-crosslang-fixture",
   "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "eip712_js",
+      "name": "eip712-crosslang-fixture",
       "version": "1.0.0",
-      "license": "ISC",
       "dependencies": {
-        "ethers": "^6.13.4"
+        "ethers": "6.17.0"
       }
     },
     "node_modules/@adraffy/ens-normalize": {
-      "version": "1.10.1",
-      "resolved": "https://registry.npmjs.org/@adraffy/ens-normalize/-/ens-normalize-1.10.1.tgz",
-      "integrity": "sha512-96Z2IP3mYmF1Xg2cDm8f1gWGf/HUVedQ3FMifV4kG/PQ4yEP51xDtRAEfhVNt5f/uzpNkZHwWQuUcu6D6K+Ekw==",
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@adraffy/ens-normalize/-/ens-normalize-1.11.1.tgz",
+      "integrity": "sha512-nhCBV3quEgesuf7c7KYfperqSS14T8bYuvJ8PcLJp6znkZpFc0AuW4qBtr8eKVyPPe/8RSr7sglCWPU5eaxwKQ==",
       "license": "MIT"
     },
     "node_modules/@noble/curves": {
@@ -58,9 +57,9 @@
       "license": "MIT"
     },
     "node_modules/ethers": {
-      "version": "6.13.4",
-      "resolved": "https://registry.npmjs.org/ethers/-/ethers-6.13.4.tgz",
-      "integrity": "sha512-21YtnZVg4/zKkCQPjrDj38B1r4nQvTZLopUGMLQ1ePU2zV/joCfDC3t3iKQjWRzjjjbzR+mdAIoikeBRNkdllA==",
+      "version": "6.17.0",
+      "resolved": "https://registry.npmjs.org/ethers/-/ethers-6.17.0.tgz",
+      "integrity": "sha512-BpyrpIPJ3ydEVow8zGaz1DuPS7YU8DcWxuBnY9a0UA/lvAPwrMr+EPXsfrul628SRaekPNeIM4UFh/91GWZang==",
       "funding": [
         {
           "type": "individual",
@@ -73,13 +72,13 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "@adraffy/ens-normalize": "1.10.1",
+        "@adraffy/ens-normalize": "1.11.1",
         "@noble/curves": "1.2.0",
         "@noble/hashes": "1.3.2",
         "@types/node": "22.7.5",
         "aes-js": "4.0.0-beta.5",
         "tslib": "2.7.0",
-        "ws": "8.17.1"
+        "ws": "8.21.0"
       },
       "engines": {
         "node": ">=14.0.0"
@@ -98,9 +97,9 @@
       "license": "MIT"
     },
     "node_modules/ws": {
-      "version": "8.17.1",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.1.tgz",
-      "integrity": "sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==",
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"

--- a/phase4-coordinator/internal/payout/testdata/eip712_js/package.json
+++ b/phase4-coordinator/internal/payout/testdata/eip712_js/package.json
@@ -1,5 +1,6 @@
 {
   "name": "eip712-crosslang-fixture",
+  "version": "1.0.0",
   "private": true,
   "type": "module",
   "scripts": {
@@ -7,6 +8,6 @@
     "sign": "node roundtrip_sign.mjs"
   },
   "dependencies": {
-    "ethers": "6.13.4"
+    "ethers": "6.17.0"
   }
 }

--- a/phase5-gateway/go.mod
+++ b/phase5-gateway/go.mod
@@ -1,6 +1,6 @@
 module github.com/augstar/macprovider-gateway
 
-go 1.26
+go 1.26.6
 
 require (
 	github.com/yuin/goldmark v1.8.2

--- a/scripts/test-acceptance-candidate-security.sh
+++ b/scripts/test-acceptance-candidate-security.sh
@@ -38,6 +38,18 @@ build = workflow.split("\n  build_candidate:\n", 1)[1].split("\n  sign_acceptanc
 protected = workflow.split("\n  sign_acceptance:\n", 1)[1]
 if "secrets." in build or "contents: write" in build or "environment:" in build:
     raise SystemExit("unprivileged candidate build gained a secret, write permission, or environment")
+if "go-version-file: candidate/phase4-coordinator/go.mod" not in build:
+    raise SystemExit("candidate Pearl build must derive Go from the candidate coordinator go.mod")
+if re.search(r'(?m)^\s*go-version\s*:', build):
+    raise SystemExit("candidate Pearl build must not hardcode a Go version")
+for value in (
+    "Verify candidate Pearl Go module parity",
+    "candidate/phase4-coordinator/go.mod",
+    "candidate/phase5-gateway/go.mod",
+    "candidate Pearl Go module mismatch",
+):
+    if value not in build:
+        raise SystemExit(f"candidate Pearl Go parity guard is incomplete: {value}")
 if "environment: production-release" not in protected:
     raise SystemExit("protected signer lacks the production-release environment gate")
 permissions = protected.split("    steps:\n", 1)[0]


### PR DESCRIPTION
## Summary

Fixes #1055.

- Bumps the production Pearl Go modules (`phase4-coordinator`, `phase5-gateway`) to `go 1.26.6`.
- Updates the payout EIP-712 JS fixture from `ethers 6.13.4` to `6.17.0`, which resolves the vulnerable `ws` transitive dependency to `8.21.0`.
- Keeps acceptance-candidate Pearl builds aligned with candidate module state by deriving setup-go from the candidate coordinator `go.mod` and checking coordinator/gateway Go directive parity before the `GOTOOLCHAIN=local` build.
- Extends the acceptance-candidate security guard so future hardcoded `go-version:` drift is rejected.

## Root cause

The dependency cleanup needed to update both the module-level toolchain declarations and the release workflow that builds those modules with `GOTOOLCHAIN=local`. The payout fixture also had an old exact `ethers` pin whose lockfile pulled the vulnerable `ws` version.

## Validation

- `go run golang.org/x/vuln/cmd/govulncheck@latest ./...` in `phase4-coordinator`: 0 reachable vulnerabilities; one uncalled module-level advisory remains for `x/crypto/openpgp`.
- `go run golang.org/x/vuln/cmd/govulncheck@latest ./...` in `phase5-gateway`: no vulnerabilities.
- `go test ./...` in `phase4-coordinator`.
- `go test ./...` in `phase5-gateway`.
- `npm audit --audit-level=high` in the EIP-712 fixture: 0 vulnerabilities.
- `npm audit signatures` in the EIP-712 fixture: registry signatures and attestations verified.
- `npm test` and `npm run sign` in the EIP-712 fixture.
- `go mod tidy -diff` clean in both Go modules.
- `scripts/test-acceptance-candidate-security.sh`.
- `scripts/test-release-security-posture.sh`.
- `scripts/test-pearl-runtime-release.sh`.
- `scripts/verify-pearl-go-binaries.py --self-test`.
- `git diff --check`.
- OMC audits: code-reviewer, security-reviewer, architect all reported 0 CRITICAL/HIGH/MEDIUM findings on the final full diff.

SPEC-GOVERNANCE-DECLARATION-BEGIN
{
  "schema_version": "spec-pr-governance-v1",
  "behavior_change": "yes",
  "contract_change": "none",
  "specs": ["SPEC-016", "SPEC-020"],
  "requirements": ["SPEC-016-R002", "SPEC-020-R001"],
  "authority_domains": ["payout-lifecycle", "provider-autoupdate"],
  "arbitration": ["CODE_BUG"],
  "tests": [
    "go run golang.org/x/vuln/cmd/govulncheck@latest ./... in phase4-coordinator",
    "go run golang.org/x/vuln/cmd/govulncheck@latest ./... in phase5-gateway",
    "go test ./... in phase4-coordinator",
    "go test ./... in phase5-gateway",
    "npm audit --audit-level=high in phase4-coordinator/internal/payout/testdata/eip712_js",
    "npm audit signatures in phase4-coordinator/internal/payout/testdata/eip712_js",
    "npm test and npm run sign in phase4-coordinator/internal/payout/testdata/eip712_js",
    "scripts/test-acceptance-candidate-security.sh",
    "scripts/test-release-security-posture.sh",
    "scripts/test-pearl-runtime-release.sh",
    "scripts/verify-pearl-go-binaries.py --self-test"
  ],
  "journeys": ["not-required"],
  "issue": "https://github.com/Augustas11/macprovider/issues/1055"
}
SPEC-GOVERNANCE-DECLARATION-END
