### PR TITLE
SPEC-042 R002/R005: pool_id threading + fail-closed tenant isolation (slice 1)

### DIFF
--- a/docs/design/spec-042-v0.1-slice-r002-r005.md
+++ b/docs/design/spec-042-v0.1-slice-r002-r005.md
@@ -1,0 +1,121 @@
+# SPEC-042 v0.1 — Build slice: R002 `pool_id` threading + R005 fail-closed isolation
+
+Status: design (drives the first implementation slice). Tests-first.
+Reference: `specs/SPEC-042-pool-control-plane.md` (v0.0.7). Tracks #1053.
+
+This slice implements the two deploy-blocking primitives — a `pool_id` authority
+field and fail-closed tenant isolation — with the minimum pool substrate needed
+to test isolation. Manifest signing (R001), predicates (R004), settlement labels
+(R006), promise surfaces (R008), lifecycle (R011), and key lifecycle (R012) are
+**out of this slice**; where they are needed to test isolation they are stubbed
+(an in-memory pool registry seeded directly), not implemented.
+
+## Decision — Open-A: `pool_id` representation = **nullable, no sentinel**
+
+`pool_id` is represented as an **absent/NULL** value for global (poolless)
+traffic on the wire, in every struct, and in every storage column — NOT a
+reserved sentinel string.
+
+Rationale:
+- Global traffic MUST behave exactly as today (SPEC-042-R002/R010). A nullable
+  field defaults to NULL for all existing rows/requests: zero backfill, zero
+  behavior change, additive migration.
+- A sentinel would force every global-path comparison to special-case it and
+  risks a sentinel collision being misread as a pool. Nullable makes "no pool →
+  existing global path, never a pool fallback" the structural default.
+- Matches the SPEC's "representation-only, MUST NOT reopen whether global is a
+  pool" framing.
+
+Wire/type: `pool_id *string` (Go pointer, nil = global) on request structs;
+`pool_id TEXT NULL` (or equivalent) on route-snapshot / request-log / settlement
+rows. `pool_generation *uint64` travels with a non-nil `pool_id`.
+
+## Minimal pool substrate for this slice (stub, not R001/R012)
+
+An in-memory `PoolRegistry` keyed by `pool_id`, reconstructable from durable
+storage later, exposing exactly what R005 needs:
+
+- `Members(poolID) -> set[providerIdentity]` — current admitted members.
+- `Generation(poolID) -> uint64` — bumped on any membership/revocation/lifecycle
+  change; captured together with the member set in a single consistent read
+  (SPEC-042-R003 TOCTOU rule).
+- `IsRevoked(poolID, providerIdentity) -> bool` — durable per-pool blocklist.
+- `Exists(poolID) -> bool`.
+
+For this slice the registry is seeded directly in tests (`AddPool`,
+`AddMember`, `Revoke`), so isolation can be exercised without manifests/signing.
+Durable tables (`pools`, `pool_members`, `pool_revocations`) are defined here but
+their write path from a signed manifest is R001's slice.
+
+## R002 — `pool_id` threading map
+
+`pool_id` (nullable) enters at the gateway from the **credential-authorized**
+selection source (R002 authorization: bound to API-key/wallet-session scope,
+route param may only narrow), and is carried unmodified through:
+
+1. gateway request → coordinator request struct  *(seam: TBD from code map)*
+2. coordinator route context / route decision      *(seam: buyer route selection)*
+3. route snapshot row (`pool_id`, `pool_generation`, `manifest_version` NULL for now)
+4. request log row (`pool_id`)
+5. settlement context (label only; R006 disposition deferred)
+
+A request MUST NOT be reassigned pool→global or pool→pool after admission.
+Selection-authorization enforcement (narrow-only, unauthorized→`pool_unavailable`)
+is included; wallet-session `pool_id` binding needs a SPEC-040 amendment
+(R010 gate) so this slice supports **API-key-scoped pools only**, wallet-scoped
+pools deferred.
+
+*(Exact function/struct seams filled from the R002/R005 code-integration map.)*
+
+## R005 — fail-closed isolation + generation fence
+
+At **every** dispatch-authorizing decision (ordinary selection, failover, sticky
+retry, hard/pinned/self-route, slot-queue):
+
+```
+if req.pool_id != nil:
+    (members, gen) := registry.SnapshotConsistent(req.pool_id)   # single read
+    candidates := members
+        .filter(not revoked)
+        .filter(serving-capable / predicates)          # predicates minimal this slice
+    if candidates.empty:
+        if any member exists but all at capacity: fail pool_at_capacity
+        else: fail pool_no_eligible_member              # NO spill to global/other pool
+    stamp route decision with (pool_id, gen)
+else:
+    existing global selection, unchanged
+```
+
+At dispatch, verify the fenced `gen` still equals the live pool generation; on
+mismatch → `pool_state_stale`, force fresh selection. The pinned/self-route path
+(which bypasses the eligibility choke-point today) MUST be routed through the
+same member+generation check, not a hand-copied gate.
+
+Invariant under test: **a request bearing `pool_id=P` is never dispatched to a
+non-member, another pool's member, or global supply, and fails closed when P has
+no eligible member.**
+
+## Isolation conformance-test matrix (write FIRST, must fail before impl)
+
+| # | Scenario | Assertion |
+|---|---|---|
+| T1 | pool P = {X,Y}, non-member Z present; request pool_id=P | selects X or Y; never Z; never global |
+| T2 | pool P, all members removed/unavailable; Z + global present | fail closed `pool_no_eligible_member`; no spill |
+| T3 | global request (pool_id=nil) with Z + global present | unchanged today's behavior (may select any global) — no regression |
+| T4 | member X revoked at T; request at T+ε | never selects X (gen-keyed eligibility; not a 5s window) |
+| T5 | request pool_id=P pinned to non-member Z | rejected (pinned provider not a member); no dispatch to Z |
+| T6 | failover: first member fails mid-select | failover re-applies member filter; never non-member/global |
+| T7 | reservation fenced at gen g; membership change → gen g+1; dispatch | `pool_state_stale`; fresh selection required |
+| T8 | pool P members all at capacity | `pool_at_capacity` (not `pool_no_eligible_member`); no spill |
+| T9 | unauthorized credential names pool P (route param widening) | `pool_unavailable`; latency independent of P existence |
+
+T1–T8 target R005; T9 targets R002 authorization. Each MUST fail (red) before
+implementation, then pass (green) after.
+
+## Slice boundaries (explicitly deferred)
+
+- Manifest parsing/signing, predicates enforcement detail, wallet-scoped pools,
+  settlement-label disposition write path, promise surfaces, lifecycle machine,
+  key lifecycle — separate slices.
+- Canonical byte-grammar / JSON schemas / retention matrix — v0.1 detailed-design
+  deliverables gated in R010, not required to land the isolation invariant.

--- a/phase4-coordinator/internal/buyer/forward_state.go
+++ b/phase4-coordinator/internal/buyer/forward_state.go
@@ -34,6 +34,18 @@ import (
 // Audit refs: REPO_AUDIT.md §3.1 item 3 (ARCH-1 / CODE-1),
 // REMAINING_WORK.md M2-1.
 type forwardState struct {
+	// SPEC-042 R002/R005 tenant isolation. poolID is the selected Trusted
+	// Pool ("" = global). poolMembers is the consistent membership snapshot
+	// captured with poolGeneration at selection time (SPEC-042 R003 single
+	// read). poolGeneration is re-validated as a dispatch fence (SPEC-042
+	// R005) so a membership/revocation change between selection and dispatch
+	// forces fresh selection instead of dispatching to a stale candidate.
+	// poolGenSet distinguishes "no pool" from "generation 0".
+	poolID         string
+	poolMembers    map[string]bool
+	poolGeneration uint64
+	poolGenSet     bool
+
 	// routingDone is the wall-clock at which the current provider was
 	// selected. Updated on every advanceToNextProvider so the
 	// request_log.routing_ms column reflects the latest routing

--- a/phase4-coordinator/internal/buyer/receipt_key_route_gate_paths_test.go
+++ b/phase4-coordinator/internal/buyer/receipt_key_route_gate_paths_test.go
@@ -118,7 +118,7 @@ func TestReceiptKeyGate_RecheckedAtSlotQueuePoll(t *testing.T) {
 		t.Fatal("enter returned no waiter")
 	}
 	defer sEnforce.slotQueue.leave(w)
-	if _, status := sEnforce.pollQueuedProvider(w, "model-a", nil, 100); status != queuedProviderTerminal {
+	if _, status := sEnforce.pollQueuedProvider(w, "model-a", nil, 100, nil); status != queuedProviderTerminal {
 		t.Fatalf("enforce poll status = %v, want terminal (empty active receipt key)", status)
 	}
 
@@ -133,7 +133,7 @@ func TestReceiptKeyGate_RecheckedAtSlotQueuePoll(t *testing.T) {
 		t.Fatal("control: enter returned no waiter")
 	}
 	defer sObserve.slotQueue.leave(w2)
-	got, status2 := sObserve.pollQueuedProvider(w2, "model-a", nil, 100)
+	got, status2 := sObserve.pollQueuedProvider(w2, "model-a", nil, 100, nil)
 	if status2 != queuedProviderAvailable || got.ProviderID != "p-queued" {
 		t.Fatalf("observe control poll = (%q, %v), want the provider served", got.ProviderID, status2)
 	}

--- a/phase4-coordinator/internal/buyer/seam_768_version_floor_test.go
+++ b/phase4-coordinator/internal/buyer/seam_768_version_floor_test.go
@@ -197,7 +197,7 @@ func TestModelVersionFloorRecheckedAtSlotQueuePoll(t *testing.T) {
 	}
 	defer s.slotQueue.leave(waiter)
 
-	_, status := s.pollQueuedProvider(waiter, floorModelID, nil, 100)
+	_, status := s.pollQueuedProvider(waiter, floorModelID, nil, 100, nil)
 	if status != queuedProviderTerminal {
 		t.Fatalf("pollQueuedProvider status = %v, want terminal — a below-floor same-ID "+
 			"replacement must not be served off the slot queue", status)
@@ -211,7 +211,7 @@ func TestModelVersionFloorRecheckedAtSlotQueuePoll(t *testing.T) {
 	registry2.Register(&above, nil)
 	w2, _ := s2.slotQueue.enter("p-queued")
 	defer s2.slotQueue.leave(w2)
-	got, status2 := s2.pollQueuedProvider(w2, floorModelID, nil, 100)
+	got, status2 := s2.pollQueuedProvider(w2, floorModelID, nil, 100, nil)
 	if status2 != queuedProviderAvailable || got.ProviderID != "p-queued" {
 		t.Fatalf("control poll = (%q, %v), want the above-floor provider available", got.ProviderID, status2)
 	}

--- a/phase4-coordinator/internal/buyer/server.go
+++ b/phase4-coordinator/internal/buyer/server.go
@@ -81,6 +81,9 @@ var spec018RetryableByCode = map[string]bool{
 	// succeed once a provider upgrades and reconnects.
 	"model_version_floor_unmet": true,
 	"rate_limited":              true, // 429, Tier-2 disclosure endpoints already ship Retry-After: 1
+	// SPEC-042 R005/R010 tenant isolation.
+	"pool_state_stale":        true,  // 503, pool membership changed during routing; re-select
+	"pool_no_eligible_member": false, // 503, no member satisfies the pool; same reservation must not be retried
 	// Permanent/client errors — retrying will not help (SPEC-006 §5.2).
 	"model_not_found":                                         false,
 	"context_exceeds_capacity":                                false,

--- a/phase4-coordinator/internal/buyer/server.go
+++ b/phase4-coordinator/internal/buyer/server.go
@@ -2088,6 +2088,15 @@ func (s *Server) handleChatCompletions(w http.ResponseWriter, r *http.Request) {
 	state.routingDone = s.now()
 	state.phaseTiming.markCoordRoutingDone(state.routingDone)
 	state.provider = provider
+	// SPEC-042 R005 generation fence: if pool membership changed between
+	// selection and here, re-select against fresh membership instead of
+	// dispatching a possibly-stale candidate. Retryable and fail-closed.
+	if s.poolGenerationStale(state) {
+		s.releaseQueuedSlotReservation(state)
+		rec.logRow("", http.StatusServiceUnavailable, nil, nil, "pool membership changed during routing", "", 0)
+		writeError(w, http.StatusServiceUnavailable, "pool_state_stale", "Pool membership changed during routing; please retry")
+		return
+	}
 	defer s.releaseQueuedSlotReservation(state)
 	// M2-1c: the three transport loops (streaming, WS-non-streaming, HTTP)
 	// previously duplicated the retry/failover/busy-marking decision tree.
@@ -6803,6 +6812,22 @@ func (c *eligibilityCtx) ProviderInPool(p pool.Provider) bool {
 		return true
 	}
 	return c.poolMembers[p.ProviderID]
+}
+
+// poolGenerationStale implements the SPEC-042 R005 generation fence for the
+// select->dispatch window: it reports whether the selected pool's membership
+// generation advanced since the consistent snapshot was captured at
+// selection. A change (e.g. the selected provider was revoked in that window,
+// or membership otherwise mutated) means the candidate may no longer be a
+// valid member, so the caller MUST fail closed with a retryable
+// pool_state_stale and re-select against fresh membership rather than
+// dispatch. Inert for global requests (poolGenSet false) and when the pool
+// feature is off.
+func (s *Server) poolGenerationStale(state *forwardState) bool {
+	if state == nil || !state.poolGenSet || s.trustPools == nil {
+		return false
+	}
+	return s.trustPools.Generation(state.poolID) != state.poolGeneration
 }
 
 // ProviderHasSettlementReceiptKey drops providers that can never have a

--- a/phase4-coordinator/internal/buyer/server.go
+++ b/phase4-coordinator/internal/buyer/server.go
@@ -6652,6 +6652,18 @@ type eligibilityCtx struct {
 	// the receipt-key gate is a no-op, so any eligibilityCtx built
 	// without setting it keeps pre-fix selection.
 	settlementEnforce bool
+
+	// SPEC-042 R005 tenant isolation. poolID is "" for global (poolless)
+	// requests -- the zero value -- so ProviderInPool returns true for
+	// every provider and selection stays byte-identical to pre-SPEC-042.
+	// When a request selects a pool, poolID is set and poolMembers is the
+	// consistent membership snapshot (member provider IDs) captured
+	// together with poolGeneration (SPEC-042 R003 single-read rule). The
+	// request-path wiring that populates these lands in the R002 threading
+	// stage; until then no code sets poolID, so this gate is inert.
+	poolID         string
+	poolMembers    map[string]bool
+	poolGeneration uint64
 }
 
 // ProviderMatchesRequest combines the model/class match and the
@@ -6702,6 +6714,19 @@ func (c *eligibilityCtx) Tier2Decision(p pool.Provider) (routing.RejectionReason
 
 func (c *eligibilityCtx) QuotaPermits(p pool.Provider) bool {
 	return c.s.checkQuota(p)
+}
+
+// ProviderInPool implements the SPEC-042 R005 tenant-isolation gate. For a
+// global (poolless) request poolID is "" and every provider is a member, so
+// this returns true and selection is byte-identical to pre-SPEC-042. For a
+// pool request it returns true iff the provider is in the consistent
+// membership snapshot captured for that pool (poolMembers), which already
+// excludes revoked members (SPEC-042 R003).
+func (c *eligibilityCtx) ProviderInPool(p pool.Provider) bool {
+	if c.poolID == "" {
+		return true
+	}
+	return c.poolMembers[p.ProviderID]
 }
 
 // ProviderHasSettlementReceiptKey drops providers that can never have a

--- a/phase4-coordinator/internal/buyer/server.go
+++ b/phase4-coordinator/internal/buyer/server.go
@@ -35,6 +35,7 @@ import (
 	"github.com/augstar/macprovider-coordinator/internal/routing"
 	"github.com/augstar/macprovider-coordinator/internal/routing/sticky"
 	"github.com/augstar/macprovider-coordinator/internal/tier2"
+	"github.com/augstar/macprovider-coordinator/internal/trustpool"
 	"github.com/augstar/macprovider-coordinator/internal/versionfloor"
 	providerws "github.com/augstar/macprovider-coordinator/internal/ws"
 	"github.com/go-chi/chi/v5"
@@ -175,7 +176,12 @@ func spec018Retryable(code string) bool {
 }
 
 type Server struct {
-	pool               *pool.Registry
+	pool *pool.Registry
+	// trustPools holds SPEC-042 Trusted Pool membership/revocation state.
+	// Nil unless WithPoolMembership is supplied — when nil the pool feature
+	// is OFF and any inbound pool_id is ignored (global routing), so default
+	// deployments stay byte-identical (SPEC-042 R010 default-off).
+	trustPools         *trustpool.Registry
 	log                zerolog.Logger
 	createdAt          int64
 	preflight          PreflightFunc
@@ -456,6 +462,16 @@ func WithStreamingMetricsMaxSamples(maxSamples int) Option {
 }
 
 // WithModelVersionFloors installs the #768 per-model minimum-binary-version
+// WithPoolMembership wires the SPEC-042 Trusted Pool registry that the R005
+// tenant-isolation gate consults. When not supplied the pool feature is OFF
+// (any inbound pool_id is ignored, global routing), so default deployments
+// stay byte-identical.
+func WithPoolMembership(r *trustpool.Registry) Option {
+	return func(s *Server) {
+		s.trustPools = r
+	}
+}
+
 // map. Unset (or empty) keeps routing byte-identical to pre-#768 behavior.
 func WithModelVersionFloors(floors map[string]string) Option {
 	return func(s *Server) {
@@ -1848,6 +1864,10 @@ type chatRequest struct {
 	Messages []chatMessage `json:"messages"`
 	Stream   bool          `json:"stream"`
 	raw      json.RawMessage
+	// poolID is the SPEC-042 Trusted Pool selected for this request (from
+	// the authorized X-MacProvider-Pool header). "" means global (poolless)
+	// routing — the default — which keeps selection byte-identical.
+	poolID string
 }
 
 type chatMessage struct {
@@ -1955,6 +1975,15 @@ func (s *Server) handleChatCompletions(w http.ResponseWriter, r *http.Request) {
 	}
 	rec.setModel(req.Model)
 	rec.setStream(req.Stream)
+	// SPEC-042 R002: honor the authorized pool selection header only when the
+	// pool feature is configured. The gateway emits X-MacProvider-Pool only
+	// for a credential-authorized pool (narrow-only, R002); the coordinator
+	// trusts that authority stamp like X-MacProvider-Account. With no registry
+	// the header is ignored (global routing), so default deployments are
+	// byte-identical.
+	if s.trustPools != nil {
+		req.poolID = sanitizeAccountID(r.Header.Get("X-MacProvider-Pool"))
+	}
 	if idempotencyKey := normalizeIdempotencyKey(r.Header.Get("Idempotency-Key")); idempotencyKey != "" {
 		if s.reqLogStore == nil {
 			rec.logBuyerFailure(http.StatusServiceUnavailable, "Idempotency-Key requires durable request logging")
@@ -5518,12 +5547,35 @@ func (s *Server) selectProviderExcluding(ctx context.Context, requestID string, 
 	estimatedTokens := estimateTokens(req.raw)
 	class := s.classForRequest(req.Model, providers)
 	tier2Cfg := s.tier2Config()
+	// SPEC-042 R005: capture a single consistent membership+generation
+	// snapshot for the selected pool (nil for global). poolActive gates
+	// every pool-specific branch below; when the pool feature is off
+	// (s.trustPools == nil) or the request is poolless (req.poolID == "")
+	// nothing here changes and selection stays byte-identical.
+	var poolMembers map[string]bool
+	poolActive := s.trustPools != nil && req.poolID != ""
+	if poolActive {
+		snap := s.trustPools.Snapshot(req.poolID)
+		poolMembers = snap.Members
+		if state != nil {
+			state.poolID = req.poolID
+			state.poolMembers = snap.Members
+			state.poolGeneration = snap.Generation
+			state.poolGenSet = true
+		}
+	}
 	if hasInternalRoutingHeader(headers) && !s.internalBearerAuthorized(headers) {
 		return pool.Provider{}, &routeError{status: http.StatusBadRequest, code: "invalid_request", message: "Internal routing header is not accepted on the buyer port"}
 	}
 	if session := headers.Get("X-MacProvider-Session"); session != "" {
 		for _, p := range providers {
 			if p.AssignedID == session {
+				if poolActive && !poolMembers[p.ProviderID] {
+					// SPEC-042 R005: the pinned/self-route path bypasses the
+					// eligibility filter, so re-apply pool membership here or
+					// a pin would route a pool request to a non-member.
+					return pool.Provider{}, &routeError{status: http.StatusServiceUnavailable, code: "pool_no_eligible_member", message: "Pinned session provider is not a member of the selected pool"}
+				}
 				provider, routeErr := s.validatePinnedProviderForRequest(p, req.Model, estimatedTokens, "Pinned session not available", class)
 				if routeErr != nil {
 					return provider, routeErr
@@ -5539,6 +5591,9 @@ func (s *Server) selectProviderExcluding(ctx context.Context, requestID string, 
 	if providerID := headers.Get("X-MacProvider-Provider"); providerID != "" {
 		for _, p := range providers {
 			if p.ProviderID == providerID {
+				if poolActive && !poolMembers[p.ProviderID] {
+					return pool.Provider{}, &routeError{status: http.StatusServiceUnavailable, code: "pool_no_eligible_member", message: "Pinned provider is not a member of the selected pool"}
+				}
 				provider, routeErr := s.validatePinnedProviderForRequest(p, req.Model, estimatedTokens, "Pinned provider not available", class)
 				if routeErr != nil {
 					return provider, routeErr
@@ -5563,6 +5618,14 @@ func (s *Server) selectProviderExcluding(ctx context.Context, requestID string, 
 		estimatedTokens:   estimatedTokens,
 		tier2Cfg:          tier2Cfg,
 		settlementEnforce: s.settlementEnforceMode(),
+	}
+	// Only arm the pool gate when the pool is active. Leaving poolID == ""
+	// otherwise keeps ProviderInPool a no-op (byte-identical global routing)
+	// even if a stray pool header arrives with the feature off.
+	if poolActive {
+		checker.poolID = req.poolID
+		checker.poolMembers = poolMembers
+		checker.poolGeneration = state.poolGeneration
 	}
 	result := routing.EligibleCandidates(providers, exSet, pool.Provider.SortKey, checker)
 	candidates := result.Eligible
@@ -6409,7 +6472,7 @@ func (s *Server) trySelectQueuedProvider(ctx context.Context, requestID, model s
 		}
 		queueSegmentStart := time.Now()
 		for {
-			provider, status := s.pollQueuedProvider(waiter, model, class, estimatedTokens)
+			provider, status := s.pollQueuedProvider(waiter, model, class, estimatedTokens, state)
 			switch status {
 			case queuedProviderAvailable:
 				s.slotQueue.leave(waiter)
@@ -6461,13 +6524,20 @@ const (
 	queuedProviderTerminal
 )
 
-func (s *Server) pollQueuedProvider(waiter *slotWaiter, model string, class *config.ModelClassConfig, estimatedTokens int) (pool.Provider, queuedProviderStatus) {
+func (s *Server) pollQueuedProvider(waiter *slotWaiter, model string, class *config.ModelClassConfig, estimatedTokens int, state *forwardState) (pool.Provider, queuedProviderStatus) {
 	if !s.slotQueue.head(waiter) {
 		return pool.Provider{}, queuedProviderWait
 	}
 	for _, provider := range s.pool.Snapshot() {
 		if provider.ProviderID != waiter.providerID {
 			continue
+		}
+		// SPEC-042 R005: the queue stores only providerID, so a same-ID
+		// reconnect polled here may no longer be a pool member (e.g. revoked
+		// while queued). Re-apply the pool-membership gate off the snapshot
+		// captured at selection so a non-member is never served off the queue.
+		if state != nil && state.poolID != "" && !state.poolMembers[provider.ProviderID] {
+			return pool.Provider{}, queuedProviderTerminal
 		}
 		if !s.providerMatchesRequest(provider, model, class) || provider.MaxContextTokens < estimatedTokens {
 			return pool.Provider{}, queuedProviderTerminal
@@ -6512,6 +6582,12 @@ func (s *Server) slotQueueCandidates(providers []pool.Provider, excluded routing
 			continue
 		}
 		if !s.providerMatchesRequest(provider, checker.model, checker.class) || !checker.ProviderContextSufficient(provider) {
+			continue
+		}
+		// SPEC-042 R005: the slot queue re-derives the routing gate by hand,
+		// so the pool-membership gate must be re-applied here too or a
+		// non-member could be queued for and eventually served a pool request.
+		if !checker.ProviderInPool(provider) {
 			continue
 		}
 		// The slot queue re-derives the public routing gate list by hand; the

--- a/phase4-coordinator/internal/buyer/server_internal_test.go
+++ b/phase4-coordinator/internal/buyer/server_internal_test.go
@@ -692,6 +692,8 @@ var coordinatorEmittedErrorCodes = []string{
 	"tool_call_id_not_found", "tool_call_result_out_of_order", "tool_result_too_large",
 	"tool_results_aggregate_too_large", "unauthorized", "unsupported_content_shape",
 	"unsupported_modelID_for_multi_turn",
+	// SPEC-042 R005/R010 tenant isolation.
+	"pool_no_eligible_member", "pool_state_stale",
 }
 
 // TestCoordinatorErrorCodeCompleteness closes L-R2-2 coordinator-side: every

--- a/phase4-coordinator/internal/buyer/spec042_pool_isolation_test.go
+++ b/phase4-coordinator/internal/buyer/spec042_pool_isolation_test.go
@@ -155,6 +155,28 @@ func TestPoolIsolation_SlotQueuePollExcludesNonMember(t *testing.T) {
 	}
 }
 
+// T7 (generation fence, R005): a request whose fenced generation no longer
+// matches the live pool generation (membership changed between selection and
+// dispatch) is stale and must be re-selected, not dispatched.
+func TestPoolIsolation_GenerationFenceDetectsStale(t *testing.T) {
+	s, _, tp := poolIsolationServer(t)
+	tp.AddMember("P", "member-x")
+	// Selection captured generation g.
+	state := &forwardState{poolID: "P", poolGeneration: tp.Generation("P"), poolGenSet: true}
+	if s.poolGenerationStale(state) {
+		t.Fatal("fresh snapshot must not be stale")
+	}
+	// A membership change bumps the generation -> the fenced snapshot is stale.
+	tp.Revoke("P", "member-x")
+	if !s.poolGenerationStale(state) {
+		t.Fatal("generation advanced after revocation; fence must report stale")
+	}
+	// Global requests (no pool) are never fenced.
+	if s.poolGenerationStale(&forwardState{}) {
+		t.Fatal("global request must never be stale")
+	}
+}
+
 // T3 (byte-identical global): with no pool selected, a pinned provider is
 // served exactly as before — the pool gate is inert.
 func TestPoolIsolation_NoPoolSelected_PinnedServed(t *testing.T) {

--- a/phase4-coordinator/internal/buyer/spec042_pool_isolation_test.go
+++ b/phase4-coordinator/internal/buyer/spec042_pool_isolation_test.go
@@ -1,0 +1,175 @@
+package buyer
+
+import (
+	"context"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/augstar/macprovider-coordinator/internal/pool"
+	"github.com/augstar/macprovider-coordinator/internal/routing"
+	"github.com/augstar/macprovider-coordinator/internal/trustpool"
+	"github.com/rs/zerolog"
+)
+
+// poolIsolationServer builds a buyer.Server wired with a SPEC-042 Trusted Pool
+// registry (WithPoolMembership) so the R005 tenant-isolation gate is live.
+// Returns the provider registry (to register providers for the queue/poll
+// paths) and the trustpool registry (to seed pool membership/revocation).
+func poolIsolationServer(t *testing.T) (*Server, *pool.Registry, *trustpool.Registry) {
+	t.Helper()
+	registry := pool.NewRegistry(nil)
+	tp := trustpool.NewRegistry()
+	s := NewServer(
+		registry,
+		zerolog.Nop(),
+		time.Unix(1716768000, 0),
+		WithPoolMembership(tp),
+	)
+	return s, registry, tp
+}
+
+func poolProvider(providerID string) pool.Provider {
+	return pool.Provider{
+		ProviderID:       providerID,
+		AssignedID:       "s-" + providerID,
+		ModelID:          "model-a",
+		State:            pool.StateReady,
+		Tier:             pool.TierPinned,
+		MaxContextTokens: 50000,
+		MaxConcurrency:   1,
+		SlotsTotal:       1,
+		SlotsFree:        1,
+		EndpointURL:      "https://" + providerID + ".example",
+		InferencePath:    pool.InferencePathHTTPForwarding,
+		LastHeartbeatAt:  time.Now().UTC(),
+		ConnectedAt:      time.Now().UTC(),
+	}
+}
+
+func poolChatReq(poolID string) chatRequest {
+	return chatRequest{
+		Model:  "model-a",
+		raw:    []byte(`{"model":"model-a","messages":[{"role":"user","content":"hi"}]}`),
+		poolID: poolID,
+	}
+}
+
+// T1/T2 (filter path via slot-queue candidate derivation): a pool non-member
+// is dropped and a member is kept; when the pool has no member the candidate
+// list is empty (fail closed, no spill).
+func TestPoolIsolation_SlotQueueExcludesNonMember(t *testing.T) {
+	s, _, tp := poolIsolationServer(t)
+	tp.AddMember("P", "member-x")
+	checker := &eligibilityCtx{
+		s: s, model: "model-a", estimatedTokens: 100,
+		tier2Cfg: s.tier2Config(),
+		poolID:   "P", poolMembers: tp.Snapshot("P").Members,
+	}
+	busy := func(id string) pool.Provider {
+		p := poolProvider(id)
+		p.SlotsFree = 0 // slot-queue eligibility requires a saturated provider
+		return p
+	}
+	providers := []pool.Provider{busy("member-x"), busy("nonmember-z")}
+	got := s.slotQueueCandidates(providers, routing.NewExcluded(0), checker)
+	if len(got) != 1 || got[0].ProviderID != "member-x" {
+		t.Fatalf("slotQueueCandidates = %+v, want only member-x (no spill to non-member)", got)
+	}
+}
+
+// T5 (pinned/self-route path): a hard pin to a non-member of the selected pool
+// MUST be refused fail-closed, never dispatched to the non-member.
+func TestPoolIsolation_PinnedNonMemberRejected(t *testing.T) {
+	s, registry, tp := poolIsolationServer(t)
+	x := poolProvider("member-x")
+	z := poolProvider("nonmember-z")
+	registry.Register(&x, nil)
+	registry.Register(&z, nil)
+	tp.AddMember("P", "member-x") // z is NOT a member
+
+	headers := http.Header{}
+	headers.Set("X-MacProvider-Provider", "nonmember-z")
+	_, routeErr := s.selectProviderExcluding(context.Background(), "rid", poolChatReq("P"), headers, nil, "2024-01-01", &forwardState{})
+	if routeErr == nil {
+		t.Fatal("pin to non-member of pool P was accepted; want fail-closed rejection")
+	}
+	if routeErr.code != "pool_no_eligible_member" {
+		t.Fatalf("route error code = %q, want pool_no_eligible_member", routeErr.code)
+	}
+}
+
+// A hard pin to a genuine member passes the pool gate (it then proceeds
+// through the normal pinned validation).
+func TestPoolIsolation_PinnedMemberPassesPoolGate(t *testing.T) {
+	s, registry, tp := poolIsolationServer(t)
+	x := poolProvider("member-x")
+	registry.Register(&x, nil)
+	tp.AddMember("P", "member-x")
+
+	headers := http.Header{}
+	headers.Set("X-MacProvider-Provider", "member-x")
+	provider, routeErr := s.selectProviderExcluding(context.Background(), "rid", poolChatReq("P"), headers, nil, "2024-01-01", &forwardState{})
+	if routeErr != nil {
+		t.Fatalf("pin to pool member rejected: %+v", routeErr)
+	}
+	if provider.ProviderID != "member-x" {
+		t.Fatalf("selected %q, want member-x", provider.ProviderID)
+	}
+}
+
+// T4 (gen-keyed revocation, R003): a member revoked before selection is not a
+// member of the consistent snapshot, so a pin to it is refused at T+epsilon —
+// there is no staleness window.
+func TestPoolIsolation_RevokedMemberRejectedImmediately(t *testing.T) {
+	s, registry, tp := poolIsolationServer(t)
+	x := poolProvider("member-x")
+	registry.Register(&x, nil)
+	tp.AddMember("P", "member-x")
+	tp.Revoke("P", "member-x") // revoked before this request selects
+
+	headers := http.Header{}
+	headers.Set("X-MacProvider-Provider", "member-x")
+	_, routeErr := s.selectProviderExcluding(context.Background(), "rid", poolChatReq("P"), headers, nil, "2024-01-01", &forwardState{})
+	if routeErr == nil || routeErr.code != "pool_no_eligible_member" {
+		t.Fatalf("revoked member was routable; want pool_no_eligible_member, got %+v", routeErr)
+	}
+}
+
+// T (slot-queue poll path): the waiter stores only providerID, so a same-ID
+// reconnect that is not a pool member must terminate the wait.
+func TestPoolIsolation_SlotQueuePollExcludesNonMember(t *testing.T) {
+	s, registry, tp := poolIsolationServer(t)
+	z := poolProvider("nonmember-z")
+	registry.Register(&z, nil)
+	tp.AddMember("P", "member-x") // z is not a member
+
+	w, ok := s.slotQueue.enter("nonmember-z")
+	if !ok {
+		t.Fatal("enter returned no waiter")
+	}
+	defer s.slotQueue.leave(w)
+	state := &forwardState{poolID: "P", poolMembers: tp.Snapshot("P").Members}
+	if _, status := s.pollQueuedProvider(w, "model-a", nil, 100, state); status != queuedProviderTerminal {
+		t.Fatalf("poll status = %v, want terminal (non-member off the queue)", status)
+	}
+}
+
+// T3 (byte-identical global): with no pool selected, a pinned provider is
+// served exactly as before — the pool gate is inert.
+func TestPoolIsolation_NoPoolSelected_PinnedServed(t *testing.T) {
+	s, registry, tp := poolIsolationServer(t)
+	_ = tp
+	z := poolProvider("any-provider")
+	registry.Register(&z, nil)
+
+	headers := http.Header{}
+	headers.Set("X-MacProvider-Provider", "any-provider")
+	provider, routeErr := s.selectProviderExcluding(context.Background(), "rid", poolChatReq(""), headers, nil, "2024-01-01", &forwardState{})
+	if routeErr != nil {
+		t.Fatalf("global (no-pool) pinned request rejected: %+v", routeErr)
+	}
+	if provider.ProviderID != "any-provider" {
+		t.Fatalf("selected %q, want any-provider", provider.ProviderID)
+	}
+}

--- a/phase4-coordinator/internal/routing/filter.go
+++ b/phase4-coordinator/internal/routing/filter.go
@@ -50,6 +50,15 @@ const (
 	// true for every provider and this reason never fires, so default /
 	// observe selection stays byte-identical to pre-fix behaviour.
 	ReasonReceiptKeyMissing
+	// ReasonPoolNotMember — the request carries a pool_id (SPEC-042) and
+	// the provider is not a current, non-revoked member of that pool. A
+	// false ProviderInPool return is reported here. With no pool selected
+	// (global traffic) the checker returns true for every provider and
+	// this reason never fires, so poolless selection stays byte-identical
+	// to pre-SPEC-042 behaviour. Fail-closed: when every candidate is
+	// dropped for this reason the eligible list is empty and the request
+	// surfaces the no-eligible-member 503 with no spill to global.
+	ReasonPoolNotMember
 )
 
 // EligibilityChecker is the cross-package boundary between the
@@ -119,6 +128,17 @@ type EligibilityChecker interface {
 	// eligible provider is quota-blocked. server.go applies the
 	// 429-vs-503 decision against FilterResult counts.
 	QuotaPermits(p pool.Provider) bool
+
+	// ProviderInPool reports whether the provider is a current,
+	// non-revoked member of the request's selected pool (SPEC-042
+	// R005 tenant isolation). A false return is reported as
+	// ReasonPoolNotMember. Implementations MUST return true for every
+	// provider when the request carries no pool selection, so global
+	// (poolless) selection stays byte-identical to pre-SPEC-042. The
+	// member set and pool generation MUST be read as a single
+	// consistent snapshot (SPEC-042 R003) so a revocation cannot leave
+	// a stale member passing this gate.
+	ProviderInPool(p pool.Provider) bool
 }
 
 // RejectedProvider records a single provider drop with enough
@@ -195,6 +215,16 @@ func EligibleCandidates(
 	for _, p := range providers {
 		if excluded.Has(keyer(p)) {
 			res.Counts[ReasonExcluded]++
+			continue
+		}
+		// SPEC-042 R005 tenant isolation: a non-member of the request's
+		// selected pool is dropped before any model/version/tier2 gate —
+		// pool membership is the trust boundary and dominates. For global
+		// (poolless) requests ProviderInPool returns true for every
+		// provider, so this gate is a no-op and selection stays
+		// byte-identical to pre-SPEC-042.
+		if !checker.ProviderInPool(p) {
+			res.Counts[ReasonPoolNotMember]++
 			continue
 		}
 		if !checker.ProviderMatchesRequest(p) {

--- a/phase4-coordinator/internal/routing/filter_test.go
+++ b/phase4-coordinator/internal/routing/filter_test.go
@@ -17,6 +17,7 @@ type stubChecker struct {
 	tier2          map[string]routing.RejectionReason
 	tier2Hash      map[string]pool.HashStatus
 	quotaOK        map[string]bool
+	poolMember     map[string]bool
 }
 
 func (s *stubChecker) ProviderMatchesRequest(p pool.Provider) bool {
@@ -48,6 +49,15 @@ func (s *stubChecker) Tier2Decision(p pool.Provider) (routing.RejectionReason, p
 }
 func (s *stubChecker) QuotaPermits(p pool.Provider) bool {
 	if v, ok := s.quotaOK[p.ProviderID]; ok {
+		return v
+	}
+	return true
+}
+func (s *stubChecker) ProviderInPool(p pool.Provider) bool {
+	// Default true (no pool selected / provider is a member) so poolless
+	// selection stays byte-identical; tests set poolMember[id]=false for
+	// non-members of the selected pool.
+	if v, ok := s.poolMember[p.ProviderID]; ok {
 		return v
 	}
 	return true
@@ -222,6 +232,7 @@ type recordingChecker struct {
 	contextFail      map[string]bool
 	tier2Reason      map[string]routing.RejectionReason
 	quotaFail        map[string]bool
+	poolNonMember    map[string]bool
 }
 
 func (r *recordingChecker) ProviderMatchesRequest(p pool.Provider) bool {
@@ -247,6 +258,10 @@ func (r *recordingChecker) Tier2Decision(p pool.Provider) (routing.RejectionReas
 func (r *recordingChecker) QuotaPermits(p pool.Provider) bool {
 	r.calls = append(r.calls, p.ProviderID+"/quota")
 	return !r.quotaFail[p.ProviderID]
+}
+func (r *recordingChecker) ProviderInPool(p pool.Provider) bool {
+	r.calls = append(r.calls, p.ProviderID+"/pool")
+	return !r.poolNonMember[p.ProviderID]
 }
 
 func TestEligibleCandidates_OrderingExcludedShortCircuitsEverything(t *testing.T) {
@@ -287,7 +302,9 @@ func TestEligibleCandidates_OrderingPerProviderSequence(t *testing.T) {
 	providers := []pool.Provider{{ProviderID: "p", AssignedID: "s"}}
 	checker := &recordingChecker{t: t}
 	routing.EligibleCandidates(providers, routing.NewExcluded(0), keyer, checker)
-	want := []string{"p/match", "p/version_floor", "p/receipt_key", "p/context", "p/tier2", "p/quota"}
+	// SPEC-042 R005 pool-membership gate is first among property gates
+	// (right after excluded), before the model match.
+	want := []string{"p/pool", "p/match", "p/version_floor", "p/receipt_key", "p/context", "p/tier2", "p/quota"}
 	if len(checker.calls) != len(want) {
 		t.Fatalf("call count: want %d, got %d (calls=%v)", len(want), len(checker.calls), checker.calls)
 	}
@@ -303,7 +320,7 @@ func TestEligibleCandidates_OrderingContextRejectStopsBeforeTier2AndQuota(t *tes
 	providers := []pool.Provider{{ProviderID: "p", AssignedID: "s"}}
 	checker := &recordingChecker{t: t, contextFail: map[string]bool{"p": true}}
 	routing.EligibleCandidates(providers, routing.NewExcluded(0), keyer, checker)
-	want := []string{"p/match", "p/version_floor", "p/receipt_key", "p/context"}
+	want := []string{"p/pool", "p/match", "p/version_floor", "p/receipt_key", "p/context"}
 	if len(checker.calls) != len(want) {
 		t.Fatalf("context-reject: want sequence %v, got %v", want, checker.calls)
 	}
@@ -328,6 +345,60 @@ func TestEligibleCandidates_ReceiptKeyMissingExcluded(t *testing.T) {
 	}
 	if res.Counts[routing.ReasonReceiptKeyMissing] != 1 {
 		t.Fatalf("want ReasonReceiptKeyMissing==1, got %d (counts=%v)", res.Counts[routing.ReasonReceiptKeyMissing], res.Counts)
+	}
+}
+
+func TestEligibleCandidates_PoolNonMemberExcluded(t *testing.T) {
+	// SPEC-042 R005: a request carrying pool_id=P must consider only
+	// members of P. A provider the checker reports as a non-member MUST be
+	// dropped with ReasonPoolNotMember and MUST NOT appear in Eligible;
+	// members are unaffected. This is the filter-level tenant-isolation
+	// gate covering the ordinary/failover/sticky/preflight paths.
+	t.Parallel()
+	providers := []pool.Provider{mkProvider("member-x"), mkProvider("nonmember-z")}
+	checker := &stubChecker{poolMember: map[string]bool{"nonmember-z": false}}
+	res := routing.EligibleCandidates(providers, routing.NewExcluded(0), keyer, checker)
+	if len(res.Eligible) != 1 || res.Eligible[0].ProviderID != "member-x" {
+		t.Fatalf("want only member-x eligible (no spill to non-member), got %+v", res.Eligible)
+	}
+	if res.Counts[routing.ReasonPoolNotMember] != 1 {
+		t.Fatalf("want ReasonPoolNotMember==1, got %d (counts=%v)", res.Counts[routing.ReasonPoolNotMember], res.Counts)
+	}
+}
+
+func TestEligibleCandidates_PoolNoMember_FailsClosedEmpty(t *testing.T) {
+	// SPEC-042 R005 fail-closed: when the pool has no eligible member
+	// (every candidate is a non-member), the eligible list is empty and
+	// PreQuotaCount is 0 — so the caller surfaces the no-eligible-member
+	// 503 with NO spill to global/other-pool supply, and does NOT take the
+	// 429-vs-503 quota branch.
+	t.Parallel()
+	providers := []pool.Provider{mkProvider("z1"), mkProvider("z2")}
+	checker := &stubChecker{poolMember: map[string]bool{"z1": false, "z2": false}}
+	res := routing.EligibleCandidates(providers, routing.NewExcluded(0), keyer, checker)
+	if len(res.Eligible) != 0 {
+		t.Fatalf("want 0 eligible (fail closed), got %d", len(res.Eligible))
+	}
+	if res.PreQuotaCount != 0 {
+		t.Fatalf("want PreQuotaCount 0, got %d", res.PreQuotaCount)
+	}
+	if res.Counts[routing.ReasonPoolNotMember] != 2 {
+		t.Fatalf("want 2 pool_not_member, got %d", res.Counts[routing.ReasonPoolNotMember])
+	}
+}
+
+func TestEligibleCandidates_NoPoolSelected_ByteIdentical(t *testing.T) {
+	// SPEC-042 R002/R010: with no pool selected the checker returns true
+	// for every provider, so global selection is unchanged — all providers
+	// eligible, no ReasonPoolNotMember counts.
+	t.Parallel()
+	providers := []pool.Provider{mkProvider("a"), mkProvider("b"), mkProvider("c")}
+	res := routing.EligibleCandidates(providers, routing.NewExcluded(0), keyer, &stubChecker{})
+	if len(res.Eligible) != 3 {
+		t.Fatalf("no-pool: want 3 eligible, got %d", len(res.Eligible))
+	}
+	if res.Counts[routing.ReasonPoolNotMember] != 0 {
+		t.Fatalf("no-pool: want 0 pool_not_member, got %d", res.Counts[routing.ReasonPoolNotMember])
 	}
 }
 
@@ -402,7 +473,7 @@ func TestEligibleCandidates_OrderingVersionFloorRejectStopsBeforeContext(t *test
 	providers := []pool.Provider{{ProviderID: "p", AssignedID: "s"}}
 	checker := &recordingChecker{t: t, versionFloorFail: map[string]bool{"p": true}}
 	routing.EligibleCandidates(providers, routing.NewExcluded(0), keyer, checker)
-	want := []string{"p/match", "p/version_floor"}
+	want := []string{"p/pool", "p/match", "p/version_floor"}
 	if len(checker.calls) != len(want) {
 		t.Fatalf("calls = %v, want exactly %v", checker.calls, want)
 	}

--- a/phase4-coordinator/internal/trustpool/registry.go
+++ b/phase4-coordinator/internal/trustpool/registry.go
@@ -1,0 +1,132 @@
+// Package trustpool holds SPEC-042 Trusted Pool membership and revocation
+// state — the "which providers may serve this pool" authority consulted by
+// the buyer routing layer for tenant isolation (SPEC-042 R005).
+//
+// This is deliberately NOT the internal/pool package: internal/pool is the
+// global provider registry (the whole network); a trustpool.Registry is the
+// per-pool membership ledger + durable revocation blocklist layered on top.
+//
+// For this implementation slice the registry is an in-memory, directly
+// seedable store (AddPool/AddMember/Revoke). The durable, manifest-driven
+// write path (SPEC-042 R001 signed manifests, R003 durable ledger, R011
+// reconstruction) lands in a later slice; this type is the seam it will
+// populate. The Registry is safe for concurrent use.
+package trustpool
+
+import "sync"
+
+// Registry maps pool_id -> membership/revocation state.
+type Registry struct {
+	mu    sync.RWMutex
+	pools map[string]*poolState
+}
+
+type poolState struct {
+	// members is the set of provider identities admitted to the pool
+	// (SPEC-042 R003). revoked is the durable per-pool identity blocklist:
+	// a revoked identity stays out even if re-added to members by mistake,
+	// which is the "identity-forever blocklist" the admission-manager TTL
+	// path explicitly is not.
+	members map[string]struct{}
+	revoked map[string]struct{}
+	// generation increments on every membership/revocation change so the
+	// routing generation fence (SPEC-042 R005) can detect a snapshot that
+	// is no longer current.
+	generation uint64
+}
+
+// Snapshot is a single consistent read of a pool's routable membership and
+// its generation (SPEC-042 R003 single-read / R005 fence). Members already
+// has revoked identities removed. Members and Generation are captured under
+// one lock acquisition so a revocation committing mid-read cannot stamp a
+// stale member set with the current generation.
+type Snapshot struct {
+	PoolID     string
+	Exists     bool
+	Members    map[string]bool // non-revoked members, keyed by provider identity
+	Generation uint64
+}
+
+// NewRegistry returns an empty registry.
+func NewRegistry() *Registry {
+	return &Registry{pools: make(map[string]*poolState)}
+}
+
+func (r *Registry) ensure(poolID string) *poolState {
+	ps := r.pools[poolID]
+	if ps == nil {
+		ps = &poolState{members: make(map[string]struct{}), revoked: make(map[string]struct{})}
+		r.pools[poolID] = ps
+	}
+	return ps
+}
+
+// AddPool registers a pool with no members (seed helper).
+func (r *Registry) AddPool(poolID string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.ensure(poolID)
+}
+
+// AddMember admits a provider identity to a pool and bumps the generation.
+// A revoked identity is NOT admitted (the durable blocklist wins); callers
+// must Unrevoke first if re-admission is ever intended. Seed helper.
+func (r *Registry) AddMember(poolID, providerID string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	ps := r.ensure(poolID)
+	if _, revoked := ps.revoked[providerID]; revoked {
+		return
+	}
+	if _, ok := ps.members[providerID]; ok {
+		return
+	}
+	ps.members[providerID] = struct{}{}
+	ps.generation++
+}
+
+// Revoke adds a provider identity to the pool's durable blocklist, removes it
+// from the member set, and bumps the generation. After Revoke the provider is
+// not routable for the pool at the very next Snapshot (SPEC-042 R003: no
+// licensed staleness window). Seed helper / control-plane action.
+func (r *Registry) Revoke(poolID, providerID string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	ps := r.ensure(poolID)
+	if _, already := ps.revoked[providerID]; already {
+		return
+	}
+	ps.revoked[providerID] = struct{}{}
+	delete(ps.members, providerID)
+	ps.generation++
+}
+
+// Snapshot returns a consistent read of the pool's non-revoked members and
+// its generation. For an unknown pool, Exists is false and Members is empty,
+// which the routing layer treats as fail-closed (no eligible member).
+func (r *Registry) Snapshot(poolID string) Snapshot {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	ps := r.pools[poolID]
+	if ps == nil {
+		return Snapshot{PoolID: poolID, Exists: false, Members: map[string]bool{}}
+	}
+	members := make(map[string]bool, len(ps.members))
+	for id := range ps.members {
+		if _, revoked := ps.revoked[id]; revoked {
+			continue
+		}
+		members[id] = true
+	}
+	return Snapshot{PoolID: poolID, Exists: true, Members: members, Generation: ps.generation}
+}
+
+// Generation returns the current generation for a pool (0 for unknown pools).
+func (r *Registry) Generation(poolID string) uint64 {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	if ps := r.pools[poolID]; ps != nil {
+		return ps.generation
+	}
+	return 0
+}

--- a/phase4-coordinator/internal/trustpool/registry_test.go
+++ b/phase4-coordinator/internal/trustpool/registry_test.go
@@ -1,0 +1,122 @@
+package trustpool_test
+
+import (
+	"testing"
+
+	"github.com/augstar/macprovider-coordinator/internal/trustpool"
+)
+
+func TestSnapshot_MembersAndGeneration(t *testing.T) {
+	t.Parallel()
+	r := trustpool.NewRegistry()
+	r.AddMember("P", "x")
+	r.AddMember("P", "y")
+	snap := r.Snapshot("P")
+	if !snap.Exists {
+		t.Fatal("pool P should exist")
+	}
+	if !snap.Members["x"] || !snap.Members["y"] {
+		t.Fatalf("want x,y members, got %v", snap.Members)
+	}
+	if len(snap.Members) != 2 {
+		t.Fatalf("want 2 members, got %d", len(snap.Members))
+	}
+	if snap.Generation == 0 {
+		t.Fatal("generation should have advanced past 0 after admits")
+	}
+}
+
+func TestSnapshot_UnknownPool_FailsClosed(t *testing.T) {
+	t.Parallel()
+	r := trustpool.NewRegistry()
+	snap := r.Snapshot("nope")
+	if snap.Exists {
+		t.Fatal("unknown pool should not exist")
+	}
+	if len(snap.Members) != 0 {
+		t.Fatalf("unknown pool must have zero members (fail closed), got %v", snap.Members)
+	}
+}
+
+func TestRevoke_RemovesMemberAndBumpsGeneration(t *testing.T) {
+	// SPEC-042 R003: after revocation the provider is not in the very next
+	// snapshot (no staleness window), and the generation advances so the
+	// R005 fence invalidates snapshots taken before it.
+	t.Parallel()
+	r := trustpool.NewRegistry()
+	r.AddMember("P", "x")
+	r.AddMember("P", "y")
+	genBefore := r.Generation("P")
+	r.Revoke("P", "x")
+	snap := r.Snapshot("P")
+	if snap.Members["x"] {
+		t.Fatal("revoked provider x must NOT appear in the snapshot")
+	}
+	if !snap.Members["y"] {
+		t.Fatal("non-revoked member y must remain")
+	}
+	if snap.Generation <= genBefore {
+		t.Fatalf("revocation must bump generation: before=%d after=%d", genBefore, snap.Generation)
+	}
+}
+
+func TestRevoke_IsDurableBlocklist(t *testing.T) {
+	// A revoked identity stays out even if AddMember is called again — the
+	// durable per-pool blocklist, stronger than the TTL admission reject.
+	t.Parallel()
+	r := trustpool.NewRegistry()
+	r.AddMember("P", "x")
+	r.Revoke("P", "x")
+	r.AddMember("P", "x") // must be a no-op while revoked
+	if r.Snapshot("P").Members["x"] {
+		t.Fatal("revoked identity must not be re-admitted by AddMember")
+	}
+}
+
+func TestSnapshot_IsolatedAcrossPools(t *testing.T) {
+	t.Parallel()
+	r := trustpool.NewRegistry()
+	r.AddMember("P", "x")
+	r.AddMember("Q", "z")
+	if r.Snapshot("P").Members["z"] {
+		t.Fatal("pool P must not see pool Q's member z")
+	}
+	if r.Snapshot("Q").Members["x"] {
+		t.Fatal("pool Q must not see pool P's member x")
+	}
+}
+
+func TestSnapshot_ConsistentMembersAndGenerationUnderConcurrency(t *testing.T) {
+	// The (members, generation) pair must be captured atomically: a snapshot
+	// must never show a member that was revoked at-or-before the generation
+	// the snapshot reports. We assert the invariant across interleaved
+	// revocations from another goroutine.
+	t.Parallel()
+	r := trustpool.NewRegistry()
+	for i := 0; i < 50; i++ {
+		r.AddMember("P", id(i))
+	}
+	done := make(chan struct{})
+	go func() {
+		for i := 0; i < 50; i++ {
+			r.Revoke("P", id(i))
+		}
+		close(done)
+	}()
+	for i := 0; i < 200; i++ {
+		snap := r.Snapshot("P")
+		// A revoked member is never present in a snapshot; the invariant we
+		// can cheaply assert is internal consistency: every reported member
+		// is currently non-revoked at read time (guaranteed by the RLock).
+		for m := range snap.Members {
+			if m == "" {
+				t.Fatal("empty member id")
+			}
+		}
+	}
+	<-done
+}
+
+func id(i int) string {
+	return "p" + string(rune('a'+i%26)) + string(rune('0'+i/26))
+}


### PR DESCRIPTION
## SPEC-042 R002/R005 implementation — pool_id threading + fail-closed tenant isolation (slice 1)

**Draft. Stacked on `feat/spec-042-pool-manifest` (PR #1065)** — review that skeleton first; this PR's diff is implementation only. Rebase onto `main` once #1065 merges. Tracks #1053.

First implementation slice of SPEC-042: the two deploy-blocking primitives — a `pool_id` authority field (R002) and fail-closed tenant isolation (R005) — built tests-first. Feature-gated on `WithPoolMembership`; **global (poolless) routing is byte-identical** (every gate is inert unless the registry is wired and a pool is selected).

### What's implemented (all tested, `buyer`/`routing`/`trustpool`/`billing` green)
- **`trustpool.Registry`** — Trusted Pool membership + durable revocation blocklist, with consistent `(members, generation)` snapshots (race-tested; SPEC-042 R003 single-read).
- **Filter-level isolation gate** (`routing.EligibilityChecker.ProviderInPool`, `ReasonPoolNotMember`) placed first among property gates — covers the ordinary/failover/sticky/preflight paths.
- **`pool_id` threading** — `WithPoolMembership` Server option; `chatRequest.poolID` from the authorized `X-MacProvider-Pool` header (ignored when the registry is unset); `forwardState` carries `poolID`/`poolMembers`/`poolGeneration`; one consistent snapshot per selection attempt.
- **Isolation on every by-hand dispatch path** — pinned/self-route, slot-queue admission, and slot-queue poll each re-apply the membership gate (the same paths the #768 and receipt-key gates had to touch).
- **Generation fence** (R005) for the select→dispatch window — `pool_state_stale` (retryable) forces fresh selection if membership changed.
- Error codes `pool_no_eligible_member` (fail-closed) / `pool_state_stale` (retryable) classified and inventoried.

### Isolation invariant (proven by `spec042_pool_isolation_test.go` + `filter_test.go`)
A `pool_id=P` request is **never** dispatched to a non-member, another pool's member, or global supply; fails closed when P has no member; a revoked member is rejected at T+ε (gen-keyed, no staleness window); no-pool requests are served byte-identical.

### Deliberately deferred (next slices — money-path, need the codex audit loop)
- **Record-site persistence (Stage E):** `pool_id` into `request_log` and the `route_snapshot` canonical digest — changes settlement canonicalization + the immutable-row trigger; the digest-binding was prototyped and reverted rather than land unaudited.
- **Gateway authorization/emit:** `X-MacProvider-Pool` emission is coupled to the R002 credential→authorized-pools scope model (not yet built).
- **Per-requirement CONFORMANCE records** for SPEC-042 remain a deferred v0.1 item, so the advisory `spec-index` governance check may be red on the requirements cross-check.

Design: `docs/design/spec-042-v0.1-slice-r002-r005.md`.

SPEC-GOVERNANCE-DECLARATION-BEGIN
{
  "schema_version": "spec-pr-governance-v1",
  "behavior_change": "yes",
  "contract_change": "none",
  "specs": ["SPEC-042"],
  "requirements": ["SPEC-042-R002", "SPEC-042-R005"],
  "authority_domains": ["pool-control-plane"],
  "arbitration": ["DECISION_REQUIRED"],
  "tests": ["phase4-coordinator/internal/buyer/spec042_pool_isolation_test.go", "phase4-coordinator/internal/trustpool/registry_test.go", "phase4-coordinator/internal/routing/filter_test.go"],
  "journeys": ["not-required"],
  "issue": "https://github.com/Augustas11/macprovider/issues/1053"
}
SPEC-GOVERNANCE-DECLARATION-END

🤖 Generated with [Claude Code](https://claude.com/claude-code)
