### PR TITLE
SPEC-042 Stage E: pool_id into settlement route-snapshot digest + request_log (money-path)

### DIFF
--- a/docs/design/spec-042-v0.1-slice-e-record-threading.md
+++ b/docs/design/spec-042-v0.1-slice-e-record-threading.md
@@ -1,0 +1,51 @@
+# SPEC-042 v0.1 — Build slice E: pool_id record-site threading (money-path)
+
+Status: design (drives the Stage E implementation). Tests-first. Money-path →
+must pass the codex three-lane audit (code/security/architect) to 0 C/H/M
+before merge. Stacks on the R002/R005 impl (PR #1069). Reference:
+`specs/SPEC-042-pool-control-plane.md` R002/R006. Tracks #1053.
+
+## Scope
+Record the selected `pool_id` (nullable; "" = global) into the two coordinator
+DB records R002 names, without changing money-path arithmetic or global
+behavior:
+
+1. `request_log.pool_id` — pure observability label (additive nullable column).
+2. `settlement_route_snapshots.pool_id` — the settlement/route-snapshot context
+   binding (SPEC-042 R006), so a pool request's settlement record carries and
+   is bound to its pool.
+
+Out of scope: creator revenue-split execution (deferred to the SPEC-005/016
+V1), the provider-signed v0.4 receipt tuple (unchanged — R002 binds
+route-snapshot/settlement context only, NOT the receipt tuple, unless SPEC-015
+is revised), gateway auth/emit.
+
+## Hard invariants (the audit will check these)
+- **Global (poolless) rows are byte-identical**, including the route_snapshot
+  canonical digest. A new field enters the digest ONLY when `pool_id != ""`
+  (the exact conditional-field precedent already used for the
+  `*_model_hash_algorithm` fields in RouteSnapshot.Value()).
+- **Digest round-trip integrity.** DECISION GATE (from the flow map): if the
+  route_snapshot digest is ever recomputed from the stored row, then `pool_id`
+  MUST be persisted as its own column AND read back into the reconstructed
+  RouteSnapshot before any re-derivation, or the digest binding is unsafe and
+  must be dropped in favor of a plain non-canonical label column. Confirm the
+  recompute-on-read answer before binding into Value().
+- **Additive migration only** — nullable columns via the existing
+  ensureColumns/ALTER pattern; the immutable-row trigger must still hold.
+- No change to billing arithmetic, settlement mode, or payout.
+
+## Test matrix (write FIRST)
+| # | Test | Assertion |
+|---|---|---|
+| E1 | RouteSnapshot.Value()/Digest() with PoolID=="" | byte-identical to pre-change (golden digest regression) |
+| E2 | RouteSnapshot.Value() with PoolID="P" | canonical value/digest includes pool_id |
+| E3 | InsertRouteSnapshot + read-back with PoolID="P" | pool_id persisted and round-trips; digest re-derivation (if any) matches |
+| E4 | requestlog Insert with PoolID="P" then read | pool_id column persisted |
+| E5 | requestlog Insert with PoolID="" (global) | pool_id NULL; row otherwise unchanged |
+| E6 | buyer hot path: pool request | state.poolID flows into both records |
+
+## Deferred-decision note
+`pool_id` mismatch-rejection at settlement (SPEC-042 R006 "reject the entry
+before payout accounting on mismatch") is only meaningful once payouts execute;
+for v0.1 labels-only it is recorded and, if bound into the digest, tamper-evident.

--- a/phase4-coordinator/internal/billing/route_snapshot.go
+++ b/phase4-coordinator/internal/billing/route_snapshot.go
@@ -218,7 +218,7 @@ func (s *Store) InsertRouteSnapshot(ctx context.Context, snapshot RouteSnapshot)
 	_, err = s.db.ExecContext(ctx, `
 INSERT INTO settlement_route_snapshots (
     account_scope, request_id, attempt_n, provider_id,
-    provider_session_id, provider_generation_id, paid_entrypoint,
+    provider_session_id, provider_generation_id, pool_id, paid_entrypoint,
     provider_receipt_key_id, provider_receipt_key_source,
     model_id, provider_reported_model_hash, expected_catalog_model_hash,
     catalog_id, catalog_body_digest, catalog_signature_key_id,
@@ -231,7 +231,7 @@ INSERT INTO settlement_route_snapshots (
     route_snapshot_canonical_json, created_at_utc
 ) VALUES (
     ?, ?, ?, ?,
-    ?, ?, ?,
+    ?, ?, ?, ?,
     ?, ?,
     ?, ?, ?,
     ?, ?, ?,
@@ -242,7 +242,7 @@ INSERT INTO settlement_route_snapshots (
     ?, ?, ?, strftime('%Y-%m-%dT%H:%M:%fZ','now')
 )`,
 		snapshot.AccountScope, snapshot.RequestID, snapshot.AttemptN, snapshot.ProviderID,
-		nullableString(snapshot.ProviderSessionID), nullableString(snapshot.ProviderGenerationID), snapshot.PaidEntrypoint,
+		nullableString(snapshot.ProviderSessionID), nullableString(snapshot.ProviderGenerationID), nullString(snapshot.PoolID), snapshot.PaidEntrypoint,
 		snapshot.ProviderReceiptKeyID, snapshot.ProviderReceiptKeySource,
 		snapshot.ModelID, snapshot.ProviderReportedModelHash, snapshot.ExpectedCatalogModelHash,
 		snapshot.CatalogID, snapshot.CatalogBodyDigest, snapshot.CatalogSignatureKeyID,

--- a/phase4-coordinator/internal/billing/route_snapshot.go
+++ b/phase4-coordinator/internal/billing/route_snapshot.go
@@ -62,9 +62,16 @@ type RouteSnapshot struct {
 	PendingDeadlineSeconds             int64   `json:"pending_deadline_seconds"`
 	PromptHashBasis                    string  `json:"prompt_hash_basis"`
 	PromptHash                         string  `json:"prompt_hash"`
-	ComputeIntegrityCaptureRequired    bool    `json:"-"`
-	ComputeIntegritySamplingCovered    bool    `json:"-"`
-	ComputeIntegrityHardwareDigest     string  `json:"-"`
+	// PoolID is the SPEC-042 Trusted Pool that served this request ("" for
+	// global). It binds into the canonical route-snapshot digest / settlement
+	// context (SPEC-042 R006) but ONLY when non-empty, so poolless snapshots
+	// keep byte-identical digests. Like the *_model_hash_algorithm fields it
+	// is carried in route_snapshot_json (not a dedicated column) and recovered
+	// on the settlement recompute path so insert-digest == recompute-digest.
+	PoolID                          string `json:"pool_id"`
+	ComputeIntegrityCaptureRequired bool   `json:"-"`
+	ComputeIntegritySamplingCovered bool   `json:"-"`
+	ComputeIntegrityHardwareDigest  string `json:"-"`
 }
 
 func ReceiptKeyID(pubkey []byte) (string, error) {
@@ -106,6 +113,12 @@ func (r RouteSnapshot) Value() map[string]any {
 	if r.ProviderReportedModelHashAlgorithm != "" || r.ExpectedCatalogModelHashAlgorithm != "" {
 		value["provider_reported_model_hash_algorithm"] = r.ProviderReportedModelHashAlgorithm
 		value["expected_catalog_model_hash_algorithm"] = r.ExpectedCatalogModelHashAlgorithm
+	}
+	// SPEC-042 R006: bind pool_id into the canonical route-snapshot digest,
+	// but only when a pool served the request — a poolless snapshot omits it
+	// and keeps a byte-identical digest to pre-SPEC-042.
+	if r.PoolID != "" {
+		value["pool_id"] = r.PoolID
 	}
 	return value
 }

--- a/phase4-coordinator/internal/billing/route_snapshot_test.go
+++ b/phase4-coordinator/internal/billing/route_snapshot_test.go
@@ -69,6 +69,70 @@ func TestRouteSnapshotStrictKeysAndDigestSensitivity(t *testing.T) {
 	}
 }
 
+func TestRouteSnapshotPoolID_DigestBinding(t *testing.T) {
+	// SPEC-042 R006: pool_id binds into the canonical digest only when a pool
+	// served the request; a poolless snapshot omits it and keeps a
+	// byte-identical value/digest.
+	global := testRouteSnapshot() // PoolID == ""
+	gv := global.Value()
+	if _, present := gv["pool_id"]; present {
+		t.Fatalf("poolless snapshot must NOT carry pool_id in Value(): %#v", gv)
+	}
+	gd, _, err := global.Digest()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	pooled := testRouteSnapshot()
+	pooled.PoolID = "pool-abc"
+	pv := pooled.Value()
+	if pv["pool_id"] != "pool-abc" {
+		t.Fatalf("pool snapshot must carry pool_id in Value(), got %v", pv["pool_id"])
+	}
+	pd, _, err := pooled.Digest()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if pd == gd {
+		t.Fatal("pool_id must change the canonical digest")
+	}
+}
+
+func TestRouteSnapshotPoolID_RoundTripsThroughSettlementLoader(t *testing.T) {
+	// The money-path hazard test (map: settlement_receipts.go:844): the digest
+	// is RECOMPUTED from the stored row at settlement time. Inserting a
+	// snapshot with pool_id and loading it back MUST recover pool_id (from
+	// route_snapshot_json) so recompute-digest == insert-digest — otherwise the
+	// loader returns "settlement route snapshot digest mismatch".
+	_, store := newRequestAndBillingStores(t)
+	snap := testRouteSnapshot()
+	snap.PoolID = "pool-abc"
+	insertDigest, err := store.InsertRouteSnapshot(context.Background(), snap)
+	if err != nil {
+		t.Fatal(err)
+	}
+	conn, err := store.db.Conn(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer conn.Close()
+	loaded, loadedDigest, err := loadSettlementRouteSnapshotConn(context.Background(), conn, SettlementReceiptIdentity{
+		AccountScope: snap.AccountScope,
+		RequestID:    snap.RequestID,
+		AttemptN:     snap.AttemptN,
+		ProviderID:   snap.ProviderID,
+	})
+	if err != nil {
+		t.Fatalf("loader returned error (missing pool_id read-back would cause a digest mismatch): %v", err)
+	}
+	if loaded.PoolID != "pool-abc" {
+		t.Fatalf("loader did not recover pool_id, got %q", loaded.PoolID)
+	}
+	if loadedDigest != insertDigest {
+		t.Fatalf("recompute digest %q != insert digest %q", loadedDigest, insertDigest)
+	}
+}
+
 func TestInsertRouteSnapshotPersistsCanonicalDigestAndRejectsRewrite(t *testing.T) {
 	_, store := newRequestAndBillingStores(t)
 	snapshot := testRouteSnapshot()

--- a/phase4-coordinator/internal/billing/settlement_receipts.go
+++ b/phase4-coordinator/internal/billing/settlement_receipts.go
@@ -827,15 +827,21 @@ WHERE account_scope = ? AND request_id = ? AND attempt_n = ? AND provider_id = ?
 	if providerGeneration.Valid {
 		r.ProviderGenerationID = &providerGeneration.String
 	}
-	var algorithms struct {
+	var recovered struct {
 		ProviderReported string `json:"provider_reported_model_hash_algorithm"`
 		ExpectedCatalog  string `json:"expected_catalog_model_hash_algorithm"`
+		// SPEC-042 R006: pool_id is carried in route_snapshot_json (not a
+		// column), so it MUST be recovered here before the digest recompute
+		// below, or a pool snapshot's recompute-digest would omit pool_id and
+		// mismatch the stored insert-digest.
+		PoolID string `json:"pool_id"`
 	}
-	if err := json.Unmarshal([]byte(routeSnapshotJSON), &algorithms); err != nil {
+	if err := json.Unmarshal([]byte(routeSnapshotJSON), &recovered); err != nil {
 		return RouteSnapshot{}, "", fmt.Errorf("settlement route snapshot identity metadata invalid: %w", err)
 	}
-	r.ProviderReportedModelHashAlgorithm = algorithms.ProviderReported
-	r.ExpectedCatalogModelHashAlgorithm = algorithms.ExpectedCatalog
+	r.ProviderReportedModelHashAlgorithm = recovered.ProviderReported
+	r.ExpectedCatalogModelHashAlgorithm = recovered.ExpectedCatalog
+	r.PoolID = recovered.PoolID
 	r.ComputeIntegrityCaptureRequired = computeIntegrityCaptureRequired == 1
 	r.ComputeIntegritySamplingCovered = computeIntegritySamplingCovered == 1
 	if computeIntegrityHardwareDigest.Valid {

--- a/phase4-coordinator/internal/billing/store.go
+++ b/phase4-coordinator/internal/billing/store.go
@@ -207,6 +207,7 @@ CREATE TABLE IF NOT EXISTS settlement_route_snapshots (
     provider_id TEXT NOT NULL,
     provider_session_id TEXT NULL,
     provider_generation_id TEXT NULL,
+    pool_id TEXT NULL,
     paid_entrypoint TEXT NOT NULL,
     provider_receipt_key_id TEXT NOT NULL CHECK(length(provider_receipt_key_id) = 79 AND substr(provider_receipt_key_id, 1, 15) = 'ed25519-sha256:' AND substr(provider_receipt_key_id, 16) NOT GLOB '*[^0-9a-f]*'),
     provider_receipt_key_source TEXT NOT NULL CHECK(provider_receipt_key_source IN ('auth_session','rotation_grace','operator_pin')),
@@ -410,6 +411,7 @@ func (s *Store) ensureSettlementRouteSnapshotComputeIntegrityColumns(ctx context
 		name string
 		sql  string
 	}{
+		{"pool_id", `ALTER TABLE settlement_route_snapshots ADD COLUMN pool_id TEXT NULL`},
 		{"compute_integrity_capture_required", `ALTER TABLE settlement_route_snapshots ADD COLUMN compute_integrity_capture_required INTEGER NOT NULL DEFAULT 0 CHECK(compute_integrity_capture_required IN (0,1))`},
 		{"compute_integrity_sampling_profile_covered", `ALTER TABLE settlement_route_snapshots ADD COLUMN compute_integrity_sampling_profile_covered INTEGER NOT NULL DEFAULT 0 CHECK(compute_integrity_sampling_profile_covered IN (0,1))`},
 		{"compute_integrity_hardware_runtime_class_digest", `ALTER TABLE settlement_route_snapshots ADD COLUMN compute_integrity_hardware_runtime_class_digest TEXT NULL CHECK(compute_integrity_hardware_runtime_class_digest IS NULL OR (length(compute_integrity_hardware_runtime_class_digest) = 71 AND substr(compute_integrity_hardware_runtime_class_digest, 1, 7) = 'sha256:' AND substr(compute_integrity_hardware_runtime_class_digest, 8) NOT GLOB '*[^0-9a-f]*'))`},

--- a/phase4-coordinator/internal/buyer/billing_recorder.go
+++ b/phase4-coordinator/internal/buyer/billing_recorder.go
@@ -313,6 +313,7 @@ func (b *billingRecorder) recordRow(
 		RequestID:             b.requestID,
 		ExternalRequestID:     b.externalRequestID,
 		AccountID:             b.accountID,
+		PoolID:                b.state.poolID, // SPEC-042 R002 per-pool attribution ("" = global)
 		Model:                 sanitizeRequestLogText(b.model),
 		ProviderAssignedID:    providerAssignedID,
 		PromptTokens:          promptTok,

--- a/phase4-coordinator/internal/buyer/forward_with_failover.go
+++ b/phase4-coordinator/internal/buyer/forward_with_failover.go
@@ -68,6 +68,21 @@ func (s *Server) forwardWithFailover(
 ) (shouldFallThroughToHTTP bool) {
 	failoverAttempted := false
 	for {
+		// SPEC-042 R005 generation fence — checked before EVERY dispatch, not
+		// just the initial one. advanceToNextProvider (retry) and
+		// failoverCandidate (failover) re-select and refresh state.poolGeneration
+		// then loop back here; a membership/revocation change between that
+		// selection and this dispatch means state.provider may no longer be a
+		// pool member. Fail closed with retryable pool_state_stale and force
+		// fresh selection rather than dispatch a stale candidate. Fires before
+		// tx.dispatch, while the response is still uncommitted (failover only
+		// occurs pre-commit). Inert for global requests / feature-off.
+		if s.poolGenerationStale(state) {
+			s.releaseQueuedSlotReservation(state)
+			rec.logRow("", http.StatusServiceUnavailable, nil, nil, "pool membership changed during routing", "", 0)
+			writeError(w, http.StatusServiceUnavailable, "pool_state_stale", "Pool membership changed during routing; please retry")
+			return false
+		}
 		// Reset the per-attempt dispatched flag before every attempt so the
 		// item-18 no-charge marker reflects only THIS attempt's dispatch
 		// (providerCredited separately carries billed credit from prior

--- a/phase4-coordinator/internal/buyer/forward_with_failover.go
+++ b/phase4-coordinator/internal/buyer/forward_with_failover.go
@@ -79,8 +79,10 @@ func (s *Server) forwardWithFailover(
 		// occurs pre-commit). Inert for global requests / feature-off.
 		if s.poolGenerationStale(state) {
 			s.releaseQueuedSlotReservation(state)
-			rec.logRow("", http.StatusServiceUnavailable, nil, nil, "pool membership changed during routing", "", 0)
-			writeError(w, http.StatusServiceUnavailable, "pool_state_stale", "Pool membership changed during routing; please retry")
+			// HTTP 409 per the SPEC-042 R010 error table (retryable): the
+			// reservation's fenced pool generation conflicts with current state.
+			rec.logRow("", http.StatusConflict, nil, nil, "pool membership changed during routing", "", 0)
+			writeError(w, http.StatusConflict, "pool_state_stale", "Pool membership changed during routing; please retry")
 			return false
 		}
 		// Reset the per-attempt dispatched flag before every attempt so the

--- a/phase4-coordinator/internal/buyer/route_snapshot.go
+++ b/phase4-coordinator/internal/buyer/route_snapshot.go
@@ -121,6 +121,9 @@ func (b *billingRecorder) recordRouteSnapshot(providerBody []byte, provider pool
 		PendingDeadlineSeconds:             int64(pendingDeadline),
 		PromptHashBasis:                    promptHashBasisCoordinatorV1,
 		PromptHash:                         promptHash,
+		// SPEC-042 R006: label the settlement route-snapshot with the pool
+		// that served the request ("" for global -> omitted from the digest).
+		PoolID: b.state.poolID,
 	}
 	computeIntegrityRequired, computeIntegrityCovered, computeIntegrityHardwareDigest, err := computeIntegrityRouteBinding(provider, routeMode)
 	if err != nil {

--- a/phase4-coordinator/internal/buyer/server.go
+++ b/phase4-coordinator/internal/buyer/server.go
@@ -1979,12 +1979,15 @@ func (s *Server) handleChatCompletions(w http.ResponseWriter, r *http.Request) {
 	rec.setModel(req.Model)
 	rec.setStream(req.Stream)
 	// SPEC-042 R002: honor the authorized pool selection header only when the
-	// pool feature is configured. The gateway emits X-MacProvider-Pool only
-	// for a credential-authorized pool (narrow-only, R002); the coordinator
-	// trusts that authority stamp like X-MacProvider-Account. With no registry
-	// the header is ignored (global routing), so default deployments are
-	// byte-identical.
-	if s.trustPools != nil {
+	// pool feature is configured AND the request carries an authenticated
+	// (gateway-context) account. The gateway emits X-MacProvider-Pool only for
+	// a credential-authorized pool (narrow-only, R002); the coordinator trusts
+	// that gateway authority stamp like X-MacProvider-Account. Defense in depth:
+	// X-MacProvider-Pool is also in hasInternalRoutingHeader, so an unauthorized
+	// buyer-port request carrying it is rejected before routing. With no
+	// registry the header is ignored (global routing), so default deployments
+	// are byte-identical.
+	if s.trustPools != nil && hasAuthenticatedAccount {
 		req.poolID = sanitizeAccountID(r.Header.Get("X-MacProvider-Pool"))
 	}
 	if idempotencyKey := normalizeIdempotencyKey(r.Header.Get("Idempotency-Key")); idempotencyKey != "" {
@@ -2091,15 +2094,9 @@ func (s *Server) handleChatCompletions(w http.ResponseWriter, r *http.Request) {
 	state.routingDone = s.now()
 	state.phaseTiming.markCoordRoutingDone(state.routingDone)
 	state.provider = provider
-	// SPEC-042 R005 generation fence: if pool membership changed between
-	// selection and here, re-select against fresh membership instead of
-	// dispatching a possibly-stale candidate. Retryable and fail-closed.
-	if s.poolGenerationStale(state) {
-		s.releaseQueuedSlotReservation(state)
-		rec.logRow("", http.StatusServiceUnavailable, nil, nil, "pool membership changed during routing", "", 0)
-		writeError(w, http.StatusServiceUnavailable, "pool_state_stale", "Pool membership changed during routing; please retry")
-		return
-	}
+	// SPEC-042 R005 generation fence is enforced centrally at the top of the
+	// forwardWithFailover dispatch loop (covering initial, retry, and failover
+	// dispatches) — see forward_with_failover.go.
 	defer s.releaseQueuedSlotReservation(state)
 	// M2-1c: the three transport loops (streaming, WS-non-streaming, HTTP)
 	// previously duplicated the retry/failover/busy-marking decision tree.
@@ -5689,6 +5686,17 @@ func (s *Server) selectProviderExcluding(ctx context.Context, requestID string, 
 		if result.Counts[routing.ReasonModelVersionFloor] > 0 {
 			return pool.Provider{}, &routeError{status: http.StatusServiceUnavailable, code: "model_version_floor_unmet", message: "No provider running a new enough binary is available for model `" + req.Model + "`.", typ: "server_error"}
 		}
+		// SPEC-042 R005/R010: a pool request whose candidates were all dropped
+		// for non-membership surfaces the non-retryable pool_no_eligible_member,
+		// not the retryable generic no_provider_available (which would let
+		// clients/gateways retry a condition the SPEC marks terminal). Placed
+		// AFTER the member-specific gate errors above (quota/context/tier2/
+		// version) so an actual pool MEMBER that failed a specific gate — the
+		// pool gate is first in the filter, so those counts are members only —
+		// still yields its specific, actionable error.
+		if poolActive && result.Counts[routing.ReasonPoolNotMember] > 0 {
+			return pool.Provider{}, &routeError{status: http.StatusServiceUnavailable, code: "pool_no_eligible_member", message: "No eligible member is available for the selected pool"}
+		}
 		return pool.Provider{}, &routeError{status: http.StatusServiceUnavailable, code: "no_provider_available", message: "No provider available for model " + req.Model}
 	}
 	objective := s.objectiveForRequest(headers, class)
@@ -6159,6 +6167,8 @@ func routeKeyedFilterCounts(counts map[routing.RejectionReason]int) map[string]i
 			key = "quota_blocked"
 		case routing.ReasonReceiptKeyMissing:
 			key = "receipt_key_missing"
+		case routing.ReasonPoolNotMember:
+			key = "pool_not_member" // SPEC-042 R005: distinct so pool-isolation drops are observable, not "other"
 		default:
 			key = "other"
 		}
@@ -6326,7 +6336,11 @@ func modelClassMembers(class *config.ModelClassConfig) []string {
 func hasInternalRoutingHeader(headers http.Header) bool {
 	for key, values := range headers {
 		lowerKey := strings.ToLower(key)
-		if lowerKey != "x-macprovider-account" && !strings.HasPrefix(lowerKey, "x-macprovider-internal-") {
+		// SPEC-042 R002: X-MacProvider-Pool is gateway-owned authority metadata
+		// (like X-MacProvider-Account) — it selects Trusted Pool routing and
+		// MUST NOT be honored on direct buyer traffic that lacks the internal
+		// gateway bearer, or a client could self-select pool capacity.
+		if lowerKey != "x-macprovider-account" && lowerKey != "x-macprovider-pool" && !strings.HasPrefix(lowerKey, "x-macprovider-internal-") {
 			continue
 		}
 		for _, value := range values {

--- a/phase4-coordinator/internal/buyer/server.go
+++ b/phase4-coordinator/internal/buyer/server.go
@@ -5562,10 +5562,12 @@ func (s *Server) selectProviderExcluding(ctx context.Context, requestID string, 
 	// (s.trustPools == nil) or the request is poolless (req.poolID == "")
 	// nothing here changes and selection stays byte-identical.
 	var poolMembers map[string]bool
+	var poolGen uint64
 	poolActive := s.trustPools != nil && req.poolID != ""
 	if poolActive {
 		snap := s.trustPools.Snapshot(req.poolID)
 		poolMembers = snap.Members
+		poolGen = snap.Generation
 		if state != nil {
 			state.poolID = req.poolID
 			state.poolMembers = snap.Members
@@ -5634,7 +5636,7 @@ func (s *Server) selectProviderExcluding(ctx context.Context, requestID string, 
 	if poolActive {
 		checker.poolID = req.poolID
 		checker.poolMembers = poolMembers
-		checker.poolGeneration = state.poolGeneration
+		checker.poolGeneration = poolGen // local snapshot value; avoids a nil-state deref
 	}
 	result := routing.EligibleCandidates(providers, exSet, pool.Provider.SortKey, checker)
 	candidates := result.Eligible

--- a/phase4-coordinator/internal/buyer/spec042_pool_isolation_test.go
+++ b/phase4-coordinator/internal/buyer/spec042_pool_isolation_test.go
@@ -3,10 +3,13 @@ package buyer
 import (
 	"context"
 	"net/http"
+	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/augstar/macprovider-coordinator/internal/pool"
+	"github.com/augstar/macprovider-coordinator/internal/requestlog"
 	"github.com/augstar/macprovider-coordinator/internal/routing"
 	"github.com/augstar/macprovider-coordinator/internal/trustpool"
 	"github.com/rs/zerolog"
@@ -152,6 +155,58 @@ func TestPoolIsolation_SlotQueuePollExcludesNonMember(t *testing.T) {
 	state := &forwardState{poolID: "P", poolMembers: tp.Snapshot("P").Members}
 	if _, status := s.pollQueuedProvider(w, "model-a", nil, 100, state); status != queuedProviderTerminal {
 		t.Fatalf("poll status = %v, want terminal (non-member off the queue)", status)
+	}
+}
+
+// T2-ordinary (R005/R010): a non-pinned pool request whose only providers are
+// non-members fails closed with the NON-RETRYABLE pool_no_eligible_member, not
+// the retryable generic no_provider_available (which would let clients retry a
+// terminal condition).
+func TestPoolIsolation_OrdinaryNoMember_ReturnsPoolNoEligibleMember(t *testing.T) {
+	s, registry, tp := poolIsolationServer(t)
+	z := poolProvider("nonmember-z")
+	registry.Register(&z, nil)
+	tp.AddPool("P") // pool P exists but has no members; z is a global non-member
+	_, routeErr := s.selectProviderExcluding(context.Background(), "rid", poolChatReq("P"), http.Header{}, nil, "2024-01-01", &forwardState{})
+	if routeErr == nil || routeErr.code != "pool_no_eligible_member" {
+		t.Fatalf("ordinary all-non-member: want pool_no_eligible_member, got %+v", routeErr)
+	}
+	if spec018RetryableByCode[routeErr.code] {
+		t.Fatalf("pool_no_eligible_member must be non-retryable")
+	}
+}
+
+// T7-loop (generation fence, R005): the fence is enforced at the top of the
+// forwardWithFailover dispatch loop, so a stale pool generation is rejected
+// BEFORE any dispatch — covering the retry/failover re-dispatch windows, not
+// just the initial selection.
+func TestPoolIsolation_LoopFenceRejectsStaleBeforeDispatch(t *testing.T) {
+	s, _, tp := poolIsolationServer(t)
+	tp.AddMember("P", "member-x")
+	startedAt := time.Unix(1716768000, 0)
+	// Selection captured generation g; membership then advances -> stale.
+	state := &forwardState{poolID: "P", poolGeneration: tp.Generation("P"), poolGenSet: true, faultedRoutes: map[string]struct{}{}}
+	tp.Revoke("P", "member-x")
+	state.phaseTiming.init(startedAt)
+	r := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", nil)
+	w := httptest.NewRecorder()
+	rec := s.newBillingRecorder(r, state, startedAt, "rid", "", "", requestlog.AuthenticatedAccount{}, false)
+	dispatched := false
+	tx := transportCallbacks{
+		dispatch: func(http.ResponseWriter, *http.Request, chatRequest, string, string, time.Time, *forwardState, *billingRecorder) (dispatchedAttempt, bool) {
+			dispatched = true
+			return dispatchedAttempt{}, false
+		},
+	}
+	s.forwardWithFailover(w, r, poolChatReq("P"), "rid", "rid", startedAt, state, nil, rec, tx)
+	if dispatched {
+		t.Fatal("dispatch ran under a stale pool generation; the loop fence did not fire")
+	}
+	if w.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status=%d, want 503", w.Code)
+	}
+	if !strings.Contains(w.Body.String(), "pool_state_stale") {
+		t.Fatalf("body=%s, want pool_state_stale", w.Body.String())
 	}
 }
 

--- a/phase4-coordinator/internal/buyer/spec042_pool_isolation_test.go
+++ b/phase4-coordinator/internal/buyer/spec042_pool_isolation_test.go
@@ -202,8 +202,8 @@ func TestPoolIsolation_LoopFenceRejectsStaleBeforeDispatch(t *testing.T) {
 	if dispatched {
 		t.Fatal("dispatch ran under a stale pool generation; the loop fence did not fire")
 	}
-	if w.Code != http.StatusServiceUnavailable {
-		t.Fatalf("status=%d, want 503", w.Code)
+	if w.Code != http.StatusConflict {
+		t.Fatalf("status=%d, want 409 (SPEC-042 R010 pool_state_stale)", w.Code)
 	}
 	if !strings.Contains(w.Body.String(), "pool_state_stale") {
 		t.Fatalf("body=%s, want pool_state_stale", w.Body.String())

--- a/phase4-coordinator/internal/requestlog/store.go
+++ b/phase4-coordinator/internal/requestlog/store.go
@@ -65,7 +65,11 @@ type Row struct {
 	// across two accounts cannot be attributed back to the correct
 	// gateway account (issue #211, follow-up to #196). Empty for
 	// direct legacy buyer calls without the header.
-	AccountID             string
+	AccountID string
+	// PoolID is the SPEC-042 Trusted Pool that served this request ("" ->
+	// NULL for global). Recorded for per-pool attribution/observability
+	// (SPEC-042 R002); a pure label column, not part of any digest.
+	PoolID                string
 	Model                 string
 	ProviderAssignedID    string
 	PromptTokens          *int64
@@ -187,6 +191,7 @@ CREATE TABLE IF NOT EXISTS request_log (
     request_id           TEXT    NOT NULL,
     external_request_id  TEXT    NULL,
     account_id           TEXT    NULL,
+    pool_id              TEXT    NULL,
     model                TEXT    NOT NULL,
     provider_assigned_id TEXT    NULL,
     prompt_tokens        INTEGER NULL,
@@ -470,6 +475,7 @@ INSERT INTO request_log (
     request_id,
     external_request_id,
     account_id,
+    pool_id,
     model,
     provider_assigned_id,
     prompt_tokens,
@@ -492,11 +498,12 @@ INSERT INTO request_log (
     provider_header,
     retried,
     attempt_n
-) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 		sqliteTimeText(row.TSUtc),
 		row.RequestID,
 		nullString(row.ExternalRequestID),
 		nullString(row.AccountID),
+		nullString(row.PoolID),
 		row.Model,
 		nullString(row.ProviderAssignedID),
 		nullInt64(row.PromptTokens),
@@ -536,6 +543,7 @@ func (s *Store) ensureColumns(ctx context.Context) error {
 		name string
 		sql  string
 	}{
+		{name: "pool_id", sql: `ALTER TABLE request_log ADD COLUMN pool_id TEXT NULL`},
 		{name: "provider_assigned_id", sql: `ALTER TABLE request_log ADD COLUMN provider_assigned_id TEXT NULL`},
 		{name: "prompt_tokens", sql: `ALTER TABLE request_log ADD COLUMN prompt_tokens INTEGER NULL`},
 		{name: "cached_prompt_tokens", sql: `ALTER TABLE request_log ADD COLUMN cached_prompt_tokens INTEGER NULL`},

--- a/phase4-coordinator/internal/requestlog/store_test.go
+++ b/phase4-coordinator/internal/requestlog/store_test.go
@@ -12,6 +12,33 @@ import (
 	"time"
 )
 
+func TestRequestLogPoolIDPersistsAndNullForGlobal(t *testing.T) {
+	// SPEC-042 R002: pool_id is recorded per request; global (poolless)
+	// requests store NULL, so existing rows/behaviour are unchanged.
+	store := openTestStore(t)
+	defer store.Close()
+	ctx := context.Background()
+	if err := store.Insert(ctx, Row{TSUtc: time.Now().UTC(), RequestID: "req-pool", PoolID: "pool-abc", Model: "model-a", Status: 200, BuyerIP: "127.0.0.1:1"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.Insert(ctx, Row{TSUtc: time.Now().UTC(), RequestID: "req-global", Model: "model-a", Status: 200, BuyerIP: "127.0.0.1:1"}); err != nil {
+		t.Fatal(err)
+	}
+	var poolID sql.NullString
+	if err := store.DB().QueryRow(`SELECT pool_id FROM request_log WHERE request_id='req-pool'`).Scan(&poolID); err != nil {
+		t.Fatal(err)
+	}
+	if !poolID.Valid || poolID.String != "pool-abc" {
+		t.Fatalf("pool request pool_id = %v, want pool-abc", poolID)
+	}
+	if err := store.DB().QueryRow(`SELECT pool_id FROM request_log WHERE request_id='req-global'`).Scan(&poolID); err != nil {
+		t.Fatal(err)
+	}
+	if poolID.Valid {
+		t.Fatalf("global request pool_id = %q, want NULL", poolID.String)
+	}
+}
+
 func TestRequestLogInsertAndRead(t *testing.T) {
 	store := openTestStore(t)
 	defer store.Close()


### PR DESCRIPTION
## SPEC-042 Stage E — `pool_id` into the settlement record spine (money-path)

**Stacked on #1069** (`feat/spec-042-impl-r002-r005`). Review that first; this diff is only the record-persistence layer on top of it.

Threads the selected `pool_id` (R002) into the durable money-path records so a settled receipt is provably bound to the pool it was routed within (R006), and pool membership becomes queryable after the fact — **without changing any global (poolless) behavior byte-for-byte**.

### What this adds
- **`route_snapshot` canonical digest** now carries `pool_id` — but *only when non-empty*, so the global digest is unchanged. Critically, `pool_id` is **recovered from `route_snapshot_json` before the settlement-time digest recompute** (settlement recomputes the digest from the stored row and compares it to the stored/receipt digest; this mirrors the existing `*_algorithm` field precedent). A loader round-trip test pins insert-digest == recompute-digest == receipt-digest.
- **`settlement_route_snapshots.pool_id`** column (nullable) + ALTER migration — queryable settlement binding.
- **`request_log.pool_id`** column (nullable) + ALTER migration — queryable request-time pool.

### Isolation invariant (unchanged from #1069, retested here)
All by-hand routing paths re-check membership against a consistent per-attempt snapshot; the generation fence at the top of the `forwardWithFailover` dispatch loop rejects stale membership (`pool_state_stale`, HTTP 409) before *any* dispatch — covering retry/failover, not just initial selection.

### Compatibility
- Poolless traffic: `pool_id` empty → digest identical, columns NULL. Feature-gated on `WithPoolMembership`.
- Coordinator-only (phase4). No gateway/provider changes.

### Verification
- Affected suites green: `billing`, `buyer`, `routing`, `requestlog`, `trustpool`.
- **Codex 3-lane money-path audit → 0 Critical / 0 High / 0 Medium** (code APPROVE, security PASS, architect PASS). Round-1 found a real fence-scope defect (initial-dispatch-only) and a header-auth gap — both fixed and re-audited clean. Round-2 LOWs closed (`pool_state_stale` 503→409 per the SPEC R010 table; nil-state cleanup).

### Deferred (documented, not defects)
Gateway credential→pool authorization + `X-MacProvider-Pool` emit; creator revenue-split (SPEC-005/016 V1); `routing_decision`-log `pool_id` (observability follow-up — the load-bearing R002 record sites, `request_log` + `route_snapshot`, carry it).

SPEC-GOVERNANCE-DECLARATION-BEGIN
{
  "schema_version": "spec-pr-governance-v1",
  "behavior_change": "yes",
  "contract_change": "none",
  "specs": ["SPEC-042"],
  "requirements": ["SPEC-042-R002", "SPEC-042-R006"],
  "authority_domains": ["pool-control-plane"],
  "arbitration": ["CODE_BUG"],
  "tests": ["phase4-coordinator/internal/buyer/spec042_pool_isolation_test.go"],
  "journeys": ["not-required"],
  "issue": "https://github.com/Augustas11/macprovider/issues/1053"
}
SPEC-GOVERNANCE-DECLARATION-END

🤖 Generated with [Claude Code](https://claude.com/claude-code)
