### PR TITLE
SPEC-042 gateway: pool authorization + capability handshake + X-MacProvider-Pool emit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -83,3 +83,5 @@ test/e2e/thermal-soak/*.ndjson
 
 # Local #615 audit artifacts (reports/diffs; keep out of PRs)
 scratchpad/615-audit/
+audits/2026-08-19/gateway-pool-auth-fulldiff.patch
+scratchpad-*.log

--- a/audits/2026-08-19/AUDIT_GATEWAY_POOL_AUTH_ARCHITECT_PROMPT.md
+++ b/audits/2026-08-19/AUDIT_GATEWAY_POOL_AUTH_ARCHITECT_PROMPT.md
@@ -1,0 +1,44 @@
+# Codex audit — SPEC-042 gateway pool auth/emit slice — ARCHITECT lane
+
+You are the architecture-review lane. Judge whether this slice is the right
+shape, sits at the right boundary, and composes correctly with the coordinator
+pool routing already merged in the base. Review the FULL slice diff as it lands.
+
+Diff: `audits/2026-08-19/gateway-pool-auth-fulldiff.patch` (base `c70f97ce`,
+which already contains coordinator pool ingestion/routing/isolation/settlement
+labels). Read changed files in the worktree. Spec:
+`specs/SPEC-042-pool-control-plane.md` (R002, R010). Design:
+`docs/design/spec-042-v0.1-slice-gateway-pool-auth.md`.
+
+## Context
+This is the gateway half of SPEC-042 Layer 2: credential->pool authorization +
+the positive coordinator↔gateway capability handshake (R010) + the
+`X-MacProvider-Pool` emit. Deliberately deferred (documented in the design):
+wallet-session pool selection (needs a SPEC-040 envelope amendment); per-API-key
+pool columns (this slice binds at account granularity via operator config); the
+provider-half capability advertisement; predicate-specific error codes.
+
+## Focus (Critical/High/Medium/Low/Info, with rationale)
+1. Boundary correctness: is authorization at the right layer (gateway, before
+   reservation/dispatch)? Is the capability handshake modeled correctly —
+   coordinator advertises, gateway refuses on absence — and does the division of
+   labor (gateway checks coordinator; coordinator enforces member-only routing;
+   provider-half deferred) leave any spill gap that is NOT fail-closed?
+2. Contract/compat: the coordinator advertisement is a shared wire contract
+   (`/internal/routing.pools.enabled`) consumed by the gateway. Is it
+   forward/backward compatible (old gateway ignores it; old coordinator omits
+   it -> gateway fails closed)? Does the emitted header contract match exactly
+   what the base coordinator honors (name, sanitization, auth gating)?
+3. Scope discipline: are the deferrals sound and safe (each fails closed, not
+   open)? Is the account-granularity config ceiling an acceptable MVP for the
+   credential binding, or does it create a trap when per-key scopes arrive?
+4. Is the feature genuinely default-off and the poolless path byte-identical?
+   Any global-traffic behavior change, latency, or new failure mode introduced
+   for non-pool requests (e.g., the capability fetch on the hot path)?
+5. Idiomatic fit: does the slice follow existing gateway patterns (feature
+   config, capability-metadata gating like sticky, error registration) or invent
+   a divergent one? Any abstraction that will not survive the next slice
+   (wallet-session selection, per-key scopes, provider-half handshake)?
+6. Anything under-specified that should block landing vs. safely follow up.
+
+Rank by severity with rationale. Report 0 findings if architecturally sound.

--- a/audits/2026-08-19/AUDIT_GATEWAY_POOL_AUTH_CODE_PROMPT.md
+++ b/audits/2026-08-19/AUDIT_GATEWAY_POOL_AUTH_CODE_PROMPT.md
@@ -1,0 +1,50 @@
+# Codex audit — SPEC-042 gateway pool auth/emit slice — CODE lane
+
+You are the code-review lane auditing a money-path/security change to the
+MacProvider gateway (phase5-gateway, Go) plus one small coordinator change
+(phase4-coordinator). Review the FULL diff of the slice as it will land.
+
+Diff: `audits/2026-08-19/gateway-pool-auth-fulldiff.patch` (base commit
+`c70f97ce`, which already contains the coordinator-side pool routing/isolation).
+Read the changed source files in the worktree for full context; the design is in
+`docs/design/spec-042-v0.1-slice-gateway-pool-auth.md` and the normative spec is
+`specs/SPEC-042-pool-control-plane.md` (esp. R002 and R010).
+
+## What the slice does
+The gateway authorizes a buyer credential to select a SPEC-042 Trusted Pool and,
+only for an authorized + capability-satisfied selection, emits the outbound
+`X-MacProvider-Pool: <pool_id>` header the coordinator honors. Poolless and
+feature-off traffic must be byte-identical (no header emitted).
+
+Key sites:
+- `phase5-gateway/internal/router/pool_selection.go` — `resolvePoolSelection`
+  decision table + error sentinels + header constants.
+- `phase5-gateway/internal/router/chat_proxy.go` — resolution call placement
+  (after parse, before quota reservation) + emit in `buildUpReq`.
+- `phase5-gateway/internal/config/config.go` — `TrustedPoolsConfig`, `Authorizes`,
+  `validateTrustedPoolsConfig`, `PoolIDHeaderSafe`.
+- `phase5-gateway/internal/router/disclosure.go` — `Pools` capability field.
+- `phase5-gateway/internal/router/server.go` — error-code registration.
+- `phase4-coordinator/internal/buyer/server.go` — `/internal/routing` advertises
+  `pools.enabled` gated on `trustPools != nil`.
+
+## Focus (report Critical/High/Medium/Low/Info with file:line and a concrete failing scenario)
+1. Correctness of the decision table: any input (body `pool`, header
+   `X-MacProvider-Pool-Select`, feature flag, authorized set, capability) that
+   yields a WRONG outcome — a pool emitted when it should not be, or a request
+   dropped to global when a pool was named (silent pool->global is forbidden).
+2. Ordering bugs: is authorization truly before quota reservation and before any
+   coordinator capability roundtrip? Is the emit guarded by both an authorized
+   selection AND the authenticated-account condition?
+3. The emit value round-trips the coordinator's opaque header sanitizer — any
+   value that would be dropped to empty (routed global) that is not rejected.
+4. Error taxonomy: codes/status/retryability match the SPEC R010 table; both new
+   codes are registered so the AST completeness guard passes; no code leaks pool
+   existence.
+5. Any resource leak, nil deref, unhandled error, concurrency issue, or context
+   misuse introduced. Retry/failover interaction with the emitted header.
+6. Test quality: do the tests actually prove non-dispatch on fail-closed paths
+   and byte-identical global, or do they pass vacuously?
+
+Be adversarial and concrete. If you assert a defect, give the exact input and
+the wrong result. Rank by severity. Report 0 findings if the slice is clean.

--- a/audits/2026-08-19/AUDIT_GATEWAY_POOL_AUTH_SECURITY_PROMPT.md
+++ b/audits/2026-08-19/AUDIT_GATEWAY_POOL_AUTH_SECURITY_PROMPT.md
@@ -1,0 +1,49 @@
+# Codex audit — SPEC-042 gateway pool auth/emit slice — SECURITY lane
+
+You are the security-review lane. This is a tenant-isolation authorization
+change on a money/security path. The product promise is that a Trusted Pool is a
+trust boundary: a buyer must not route into a pool it is not authorized for, and
+the error surface must not leak private-pool existence. Review the FULL slice
+diff as it will land.
+
+Diff: `audits/2026-08-19/gateway-pool-auth-fulldiff.patch` (base `c70f97ce`).
+Read changed files in the worktree. Normative spec: `specs/SPEC-042-pool-control-plane.md`
+(R002 selection authorization; R010 error taxonomy, timing-oracle rule, and
+positive capability negotiation). Design: `docs/design/spec-042-v0.1-slice-gateway-pool-auth.md`.
+
+## Threat model to attack
+- A buyer tries to route into a pool it is NOT authorized for (cross-tenant).
+- A buyer probes error responses/latency to learn whether a private pool exists
+  or is healthy (existence/timing oracle).
+- A buyer tries to smuggle the internal authority header `X-MacProvider-Pool`
+  (or spoof account/pool) directly to the gateway or through it to the
+  coordinator.
+- Version skew: a NEW gateway talking to an OLD coordinator that ignores
+  `pool_id` and would route pool traffic from the global snapshot (spill).
+- A misconfiguration or crafted value that makes the emitted header decode to
+  empty at the coordinator (routed global = silent pool->global spill).
+
+## Focus (Critical/High/Medium/Low/Info, file:line + concrete exploit)
+1. Authorization completeness: is EVERY pool-selection path gated by the
+   credential's authorized set? Can any input widen scope beyond the config
+   ceiling (narrow-only invariant)? Account-vs-key granularity risk.
+2. Non-disclosure: do unauthorized/unknown callers get exactly the generic
+   `pool_unavailable` (same code, status, retryable) with no cause distinction?
+   Does `pool_selection_invalid` ever confirm a pool exists?
+3. Timing oracle: is the credential-scope check strictly before and independent
+   of any coordinator existence/capability roundtrip, so an unauthorized caller's
+   latency does not depend on pool existence? (SPEC-042-R010.)
+4. Header trust: can a buyer's inbound headers reach the coordinator as authority
+   metadata? Confirm the outbound `X-MacProvider-Pool` is set only by the gateway
+   for an authenticated-account context and cannot be buyer-influenced except via
+   the authorized selector value. Check the inbound selector header cannot be
+   confused with the outbound one.
+5. Capability handshake: is the fail-closed default correct when the coordinator
+   omits/declines the advertisement, errors, or times out? Any path where a pool
+   request proceeds without positive advertisement?
+6. Spill guard: is the header-safe validation sufficient to prevent a
+   pool->global downgrade via a sanitizer-dropped value, at both config-load and
+   runtime?
+7. Any secret/credential logged or retained; any PII in URLs/logs.
+
+Give concrete exploit steps for any finding. Report 0 if genuinely clean.

--- a/docs/design/spec-042-v0.1-slice-gateway-pool-auth.md
+++ b/docs/design/spec-042-v0.1-slice-gateway-pool-auth.md
@@ -1,0 +1,200 @@
+# SPEC-042 v0.1 slice — gateway pool authorization + `X-MacProvider-Pool` emit
+
+Status: design → implementation. Slice owner: gateway (phase5) + a minimal
+coordinator advertisement half (phase4). Stacked on the coordinator pool-routing
+stack (`feat/spec-042-impl-stage-e`).
+
+## 1. What this slice delivers (SPEC-042 R002 + R010, gateway half)
+
+The coordinator already ingests an authorized `X-MacProvider-Pool` header,
+routes pool traffic to members only, fails closed on stale generation, and binds
+`pool_id` into the settlement record spine (#1069/#1072). But **nothing emits
+that header yet**, and the coordinator honors it only for an authenticated
+gateway context. This slice builds the emitting half:
+
+1. **Credential-bound pool authorization (R002).** A buyer request may name a
+   pool only from the set its credential is authorized for. The authoritative
+   set is the ceiling; a request selector picks one pool from it and can only
+   **narrow**, never widen.
+2. **Non-disclosing rejection (R010).** A request naming a pool the credential
+   is not authorized for is rejected with the generic `pool_unavailable`
+   (503, non-retryable) — never a "not authorized for pool X" signal, so the
+   error does not confirm the pool exists.
+3. **Positive capability negotiation (R010).** The gateway refuses to emit a
+   pool-required dispatch unless the coordinator *positively advertises* pool
+   support. An old coordinator ignores `pool_id` and would route from the global
+   snapshot (tenant spill); the gateway must not rely on it to fail closed. This
+   slice builds both halves of the coordinator↔gateway handshake.
+4. **The emit (R002).** For an authorized, capability-satisfied pool selection,
+   set `X-MacProvider-Pool: <pool_id>` on the coordinator-bound request, next to
+   the internal-bearer + `X-MacProvider-Account` pair the gateway already sends.
+5. **Default-off, byte-identical global (R010).** Feature disabled, or no pool
+   named → today's global behavior, unchanged. Feature disabled + pool named →
+   fail closed (`pool_unavailable`), never a silent pool→global downgrade.
+
+### Deliberately out of scope (documented, deferred)
+
+- **Wallet-session pool selection.** R002 requires the SPEC-040 semantic
+  signature to cover `pool_id` and the manifest core digest. That is a SPEC-040
+  wallet-envelope amendment (flagged in SPEC-042 R010). Until it lands, a
+  wallet-session request MUST NOT be able to select a pool; it stays global.
+- **Per-API-key pool columns.** API keys have no scope struct today (only
+  quota/concurrency class). This slice binds the authorized set at
+  **account** granularity via operator config (`account_id → [pool_id]`), which
+  is a safe superset-free binding (a key belongs to exactly one account).
+  Per-key granularity + a DB-backed authorized set is a follow-up.
+- **Provider-half capability advertisement.** R010's handshake also names the
+  selected provider. The gateway cannot see the chosen provider (the coordinator
+  selects it), so the gateway verifies the *coordinator's* advertisement here;
+  the coordinator enforces member-only routing (#1069). A provider pool-support
+  version advertised up to the coordinator, and coordinator refusal to route to
+  a non-advertising member, is a follow-up.
+- **Manifest/pool_status freshness, predicate errors** (`pool_policy_stale`,
+  `pool_attestation_unsatisfied`, …): coordinator-side, already partly present
+  or future slices. This slice adds only `pool_unavailable` and
+  `pool_selection_invalid` on the gateway.
+
+## 2. Selection resolution (pure decision table)
+
+The pool selector is a **control-plane HTTP header only** — the inbound buyer
+header `X-MacProvider-Pool-Select`, deliberately NOT a request-body field. The
+gateway does not define or honor a body `pool` field, so it introduces no pool
+control metadata into the data-plane body it forwards and needs no body mutation
+(arbitrary unknown body keys a buyer sends still follow the pre-existing
+OpenAI-compatible passthrough — this slice neither adds nor scrubs them). The
+header name is **distinct** from the outbound internal
+`X-MacProvider-Pool`, so the two never collide and a buyer cannot smuggle the
+internal header (`copyForwardHeaders` already allowlists only
+`Accept`/`X-MacProvider-Retry`/`Idempotency-Key`).
+
+Inputs: `selector` (the single distinct non-empty value of
+`X-MacProvider-Pool-Select`), `conflicting` (the header appeared with two
+different values), `poolSelectionAllowed` (the auth mode may select a pool —
+plain API-key only), `authorizedSet` (the account's configured pool set),
+`featureEnabled`, `coordinatorAdvertises`.
+
+Order matters — authorization precedes any coordinator interaction so latency
+cannot become an existence oracle (R010):
+
+| # | Condition | Result |
+|---|---|---|
+| 0 | `!poolSelectionAllowed` and a selector is present (wallet-session / demo) | `pool_unavailable` (503) — before authorization; non-disclosing |
+| 1 | `conflicting` (two distinct header values) | `pool_selection_invalid` (400) |
+| 2 | selector empty | **global** — emit nothing, byte-identical |
+| 3 | `!featureEnabled` (selector non-empty) | `pool_unavailable` (503) — fail-closed rollback, no silent pool→global |
+| 4 | selector ∉ `authorizedSet` (incl. account absent) | `pool_unavailable` (503) — non-disclosing; **no coordinator roundtrip** |
+| 5 | `!coordinatorAdvertises` (selector authorized) | `pool_unavailable` (503) — fail-closed, no spill |
+| 6 | otherwise | **pool `= selector`**; emit `X-MacProvider-Pool: <selector>` |
+
+Rows 0–4 are pure/local (no network). Only an *authorized* selection (row 5/6)
+consults the coordinator capability metadata, so an unauthorized caller's latency
+is independent of whether the named pool exists anywhere. The narrow-only
+invariant is enforced structurally by row 4's ⊆ check: a selector can only pick a
+pool already in the ceiling, never add one.
+
+Row 0 enforces the R002 deferral that only plain API-key credentials may select a
+pool: a **wallet session** (SPEC-040) must not, because its semantic signature
+does not yet cover `pool_id`/manifest digest and the selector header is not in
+its signed profile (honoring it would authorize a pool with no signed binding);
+**demo** traffic has no durable account scope. Row 0 rejects before the conflict
+and authorization checks, so it is also non-disclosing.
+
+`pool_selection_invalid` fires only on a conflicting/ambiguous selection (row 1),
+never on an out-of-scope pool (that is row 4's `pool_unavailable`), so the 400
+cannot confirm a pool exists.
+
+**Row 5 uses a FRESH capability fetch** (`coordinatorRoutingMetadataFresh`), not
+the 5s-cached sticky-hint metadata. A stale cached `true` would let pool dispatch
+continue for up to the TTL after a coordinator rollback/disable (`trustPools ==
+nil`), and the rolled-back coordinator would ignore the header and route globally
+— a pool→global spill the positive handshake exists to prevent. Fresh shrinks
+that window to the unavoidable in-request TOCTOU. Pool traffic is opt-in, so the
+extra roundtrip is acceptable.
+
+## 3. Placement
+
+`handleChatCompletions` (`internal/router/chat_proxy.go`): resolve the pool
+**right after `parseChatRequest`** (where `model`/`stream` are read) and
+**before any quota/concurrency reservation** — R002 requires authorization before
+reservation or dispatch. Store the resolved `poolID string` in the handler scope;
+`buildUpReq` sets the header when non-empty, guarded by the same
+`subject.AccountID != ""` condition that already guards the bearer + account pair.
+
+Capability metadata comes from `s.coordinatorRoutingMetadataFresh(upCtx)` — the
+same `/internal/routing` surface the sticky path reads, but the FRESH variant
+(see row 5 rationale above) so a rollback cannot be masked by a stale cached
+`true`.
+
+## 4. Coordinator advertisement (phase4, minimal)
+
+`handleInternalRouting` (`phase4-coordinator/internal/buyer/server.go`) adds one
+block to its JSON payload:
+
+```go
+"pools": map[string]any{"enabled": s.trustPools != nil},
+```
+
+`trustPools` is the existing pool-feature handle (`WithPoolMembership`, #1069):
+nil = feature off = advertise `false`. Old coordinators omit the block entirely;
+the gateway decodes a missing `pools` object to the zero value (`Enabled=false`)
+and fails closed. This is the positive-advertisement contract: absence ⇒ no pool
+support ⇒ gateway refuses.
+
+## 5. Config
+
+Add under `FeaturesConfig` (`internal/config/config.go`), default-off:
+
+```yaml
+features:
+  trusted_pools:
+    enabled: false
+    account_pools:            # account_id -> [pool_id, ...]
+      "acct_example": ["<pool_id>"]
+```
+
+`TrustedPoolsConfig{ Enabled bool; AccountPools map[string][]string }`, defaulted
+`{Enabled:false}` in `Default()`. At load, normalize into
+`map[string]map[string]bool` for O(1) membership. `Validate()` rejects a
+malformed entry only when `enabled` (an empty/absent map is valid — it just means
+no account may select any pool, the safe default).
+
+## 6. Errors (register to satisfy the AST guard)
+
+Both are non-retryable → add to `gatewayPermanentCodes` (`server.go`):
+
+- `pool_unavailable` → `writeError(w, 503, "service_unavailable", "pool_unavailable", "Pool unavailable")`. Single fixed (503, non-retryable) response for every cause (disabled, unauthorized, unknown, capability-absent) so neither status, code, nor the derived `retryable` flag distinguishes cause.
+- `pool_selection_invalid` → `writeError(w, 400, "invalid_request_error", "pool_selection_invalid", "Conflicting pool selection")`.
+
+## 7. Test plan (conformance-first)
+
+Pure unit (no http):
+- selector agreement/conflict (rows 1);
+- account authorization map lookup incl. account-absent (row 4), narrow-only.
+
+Handler-level (mirror `newTestHarnessConfig` + `roundTripFunc` fake coordinator,
+`server_test.go`):
+- **byte-identical global**: feature off, no `pool` field → request forwarded
+  with **no** `X-MacProvider-Pool` header (assert absent), unchanged status;
+- feature on, no selector → same (global, header absent);
+- feature off + selector → `pool_unavailable`, coordinator **never called**
+  for chat (reservation not taken);
+- authorized selector + coordinator advertises `pools.enabled:true` → forwarded
+  **with** `X-MacProvider-Pool: <pool_id>` (assert the fake coordinator saw it);
+- authorized selector + coordinator advertises `false` (or omits `pools`) →
+  `pool_unavailable`, chat **not** forwarded (no spill);
+- unauthorized selector → `pool_unavailable`, and assert the capability endpoint
+  was **not** consulted for this request (timing independence);
+- conflicting body vs header selector → `pool_selection_invalid` (400);
+- coordinator advertisement: `/internal/routing` includes
+  `pools.enabled=true` iff `trustPools != nil` (phase4 test).
+
+## 8. Compatibility
+
+- Feature off (default) and poolless requests: zero behavior change, no new
+  header, byte-identical forward path.
+- Old coordinator (no `pools` advertisement): gateway fails closed on any pool
+  selection; global traffic untouched.
+- The outbound `X-MacProvider-Pool` value is `base64url` `pool_id`
+  (`A-Za-z0-9-_`), which passes the coordinator's `sanitizeOpaqueHeader`
+  (1–128 bytes, no control chars) unchanged — verified against #1069's honor
+  path.

--- a/phase4-coordinator/internal/buyer/server.go
+++ b/phase4-coordinator/internal/buyer/server.go
@@ -846,6 +846,15 @@ func (s *Server) handleInternalRouting(w http.ResponseWriter, r *http.Request) {
 			"retry_per_attempt_timeout_s":   int(s.retryPerAttemptTimeout.Seconds()),
 			"max_providers_faulted_request": s.maxFaultedPerRequest,
 		},
+		// SPEC-042-R010 positive pool-capability advertisement. The gateway
+		// refuses to emit a pool-required dispatch unless this reads true, so
+		// an old coordinator (which omits the block and cannot understand
+		// pool_id) fails the gateway closed instead of silently routing pool
+		// traffic from the global snapshot. trustPools is the pool-feature
+		// handle (WithPoolMembership): nil = feature off = advertise false.
+		"pools": map[string]any{
+			"enabled": s.trustPools != nil,
+		},
 		"tier2": s.internalTier2Metadata(),
 	})
 }

--- a/phase4-coordinator/internal/buyer/spec042_pools_advertisement_test.go
+++ b/phase4-coordinator/internal/buyer/spec042_pools_advertisement_test.go
@@ -1,0 +1,65 @@
+package buyer_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/augstar/macprovider-coordinator/internal/buyer"
+	"github.com/augstar/macprovider-coordinator/internal/pool"
+	"github.com/augstar/macprovider-coordinator/internal/trustpool"
+	"github.com/rs/zerolog"
+)
+
+// SPEC-042-R010: the coordinator's /internal/routing metadata MUST positively
+// advertise pool support so a new gateway can refuse pool dispatch to an old
+// coordinator (fail-closed, no pool->global spill). The advertisement is true
+// iff the pool feature (WithPoolMembership) is armed.
+func TestInternalRoutingAdvertisesPoolCapability(t *testing.T) {
+	fetch := func(t *testing.T, server *buyer.Server) bool {
+		t.Helper()
+		req := httptest.NewRequest(http.MethodGet, "/internal/routing", nil)
+		req.Header.Set("Authorization", "Bearer operator-key")
+		rr := httptest.NewRecorder()
+		server.InternalHandler().ServeHTTP(rr, req)
+		if rr.Code != http.StatusOK {
+			t.Fatalf("status=%d body=%s", rr.Code, rr.Body.String())
+		}
+		var got struct {
+			Pools struct {
+				Enabled bool `json:"enabled"`
+			} `json:"pools"`
+		}
+		if err := json.Unmarshal(rr.Body.Bytes(), &got); err != nil {
+			t.Fatalf("json: %v body=%s", err, rr.Body.String())
+		}
+		return got.Pools.Enabled
+	}
+
+	t.Run("feature off advertises false", func(t *testing.T) {
+		server := buyer.NewServer(
+			pool.NewRegistry(nil),
+			zerolog.Nop(),
+			time.Unix(1716768000, 0),
+			buyer.WithGatewayServiceToken("operator-key"),
+		)
+		if fetch(t, server) {
+			t.Fatal("pools.enabled=true with no pool membership armed; want false")
+		}
+	})
+
+	t.Run("feature on advertises true", func(t *testing.T) {
+		server := buyer.NewServer(
+			pool.NewRegistry(nil),
+			zerolog.Nop(),
+			time.Unix(1716768000, 0),
+			buyer.WithGatewayServiceToken("operator-key"),
+			buyer.WithPoolMembership(trustpool.NewRegistry()),
+		)
+		if !fetch(t, server) {
+			t.Fatal("pools.enabled=false with pool membership armed; want true")
+		}
+	})
+}

--- a/phase5-gateway/internal/config/config.go
+++ b/phase5-gateway/internal/config/config.go
@@ -9,6 +9,7 @@ import (
 	"sort"
 	"strings"
 	"time"
+	"unicode/utf8"
 
 	"gopkg.in/yaml.v3"
 )
@@ -272,6 +273,35 @@ type FeaturesConfig struct {
 	ResponsesAPIEnabled      bool                     `yaml:"responses_api_enabled"`
 	AnthropicMessagesEnabled bool                     `yaml:"anthropic_messages_enabled"`
 	RelayBlindRequests       RelayBlindRequestsConfig `yaml:"relay_blind_requests"`
+	TrustedPools             TrustedPoolsConfig       `yaml:"trusted_pools"`
+}
+
+// TrustedPoolsConfig is the SPEC-042 Layer 2 gateway feature. Default-off.
+// AccountPools binds the authorized-pool ceiling to a buyer credential at
+// account granularity (a key belongs to exactly one account, so this is a
+// safe superset-free binding until per-key pool scopes land). A request may
+// select only a pool present in its account's list; an account absent from
+// the map authorizes no pool (fail-closed).
+type TrustedPoolsConfig struct {
+	Enabled      bool                `yaml:"enabled"`
+	AccountPools map[string][]string `yaml:"account_pools"`
+}
+
+// Authorizes reports whether accountID is configured to select poolID.
+// Fail-closed: empty inputs and accounts absent from account_pools authorize
+// nothing. This is a pure map lookup with no coordinator interaction, so it
+// runs before any capability roundtrip and cannot become an existence oracle
+// (SPEC-042-R010).
+func (t TrustedPoolsConfig) Authorizes(accountID, poolID string) bool {
+	if accountID == "" || poolID == "" {
+		return false
+	}
+	for _, p := range t.AccountPools[accountID] {
+		if p == poolID {
+			return true
+		}
+	}
+	return false
 }
 
 type RelayBlindRequestsConfig struct {
@@ -578,6 +608,9 @@ func (c Config) Validate() error {
 	if err := validateRelayBlindRequestsConfig(c); err != nil {
 		return err
 	}
+	if err := validateTrustedPoolsConfig(c); err != nil {
+		return err
+	}
 	if len(c.Auth.OAuth.CallbackAllowlist) == 0 {
 		return fmt.Errorf("auth.oauth.callback_allowlist must not be empty")
 	}
@@ -861,6 +894,76 @@ func validateWalletSessionsConfig(c Config) error {
 		return fmt.Errorf("auth.wallet_sessions wallet_fingerprint_secret rotation is not supported in v0.1")
 	}
 	return rejectWalletSessionSecretReuse(c)
+}
+
+// validateTrustedPoolsConfig enforces SPEC-042 gateway config hygiene. When
+// disabled (default) any account_pools content is inert and not validated.
+// When enabled, every account id and pool id MUST be non-empty and every pool
+// id MUST be safe to carry in the coordinator-bound X-MacProvider-Pool header
+// (1-128 bytes, no C0/DEL/C1 control bytes) — an id the coordinator's opaque
+// header sanitizer would reject decodes to empty there and would be routed as
+// GLOBAL, a silent pool->global spill (SPEC-042-R002 forbids that), so it is
+// rejected at config load instead.
+func validateTrustedPoolsConfig(c Config) error {
+	tp := c.Features.TrustedPools
+	if !tp.Enabled {
+		return nil
+	}
+	for accountID, pools := range tp.AccountPools {
+		if strings.TrimSpace(accountID) == "" {
+			return fmt.Errorf("features.trusted_pools.account_pools contains an empty account id")
+		}
+		for _, poolID := range pools {
+			if strings.TrimSpace(poolID) == "" {
+				return fmt.Errorf("features.trusted_pools.account_pools[%q] contains an empty pool id", accountID)
+			}
+			if !PoolIDHeaderSafe(poolID) {
+				return fmt.Errorf("features.trusted_pools.account_pools[%q] pool id %q is not a valid header value (1-128 bytes, no control characters)", accountID, poolID)
+			}
+			if !poolIDBase64URLShape(poolID) {
+				return fmt.Errorf("features.trusted_pools.account_pools[%q] pool id %q must be base64url (A-Za-z0-9-_); SPEC-042-R001 derives pool_id as base64url(SHA256(...))", accountID, poolID)
+			}
+		}
+	}
+	return nil
+}
+
+// poolIDBase64URLShape rejects pool ids outside the base64url alphabet
+// (A-Za-z0-9-_). SPEC-042-R001 derives pool_id as base64url(SHA256(identity
+// core)[0:16]); a value with spaces, punctuation, or non-ASCII cannot be a
+// canonical pool_id even though it may be header-safe. Length is NOT pinned to
+// 22 chars yet because the R001 derivation is not implemented and ids are
+// currently opaque operator strings; tighten to the exact decoded length when
+// derivation lands.
+func poolIDBase64URLShape(v string) bool {
+	if v == "" {
+		return false
+	}
+	for i := 0; i < len(v); i++ {
+		b := v[i]
+		if (b >= 'A' && b <= 'Z') || (b >= 'a' && b <= 'z') || (b >= '0' && b <= '9') || b == '-' || b == '_' {
+			continue
+		}
+		return false
+	}
+	return true
+}
+
+// PoolIDHeaderSafe mirrors the coordinator's sanitizeOpaqueHeader byte rules
+// (phase4 buyer/server.go): 1-128 bytes, valid UTF-8, no C0 (0x00-0x1f), DEL
+// (0x7f), or C1 (0x80-0x9f) bytes. A base64url pool_id (A-Za-z0-9-_) passes.
+// Kept here (not imported) because the two modules are intentionally separate.
+func PoolIDHeaderSafe(v string) bool {
+	if v == "" || len(v) > 128 || !utf8.ValidString(v) {
+		return false
+	}
+	for i := 0; i < len(v); i++ {
+		b := v[i]
+		if b < 0x20 || b == 0x7f || (b >= 0x80 && b <= 0x9f) {
+			return false
+		}
+	}
+	return true
 }
 
 func validateRelayBlindRequestsConfig(c Config) error {

--- a/phase5-gateway/internal/config/trusted_pools_test.go
+++ b/phase5-gateway/internal/config/trusted_pools_test.go
@@ -1,0 +1,127 @@
+package config
+
+import "testing"
+
+func TestTrustedPoolsAuthorizes(t *testing.T) {
+	tp := TrustedPoolsConfig{
+		Enabled: true,
+		AccountPools: map[string][]string{
+			"acct_a": {"poolone", "pooltwo"},
+			"acct_b": {"poolthree"},
+		},
+	}
+	cases := []struct {
+		account, pool string
+		want          bool
+	}{
+		{"acct_a", "poolone", true},
+		{"acct_a", "pooltwo", true},
+		{"acct_a", "poolthree", false}, // not in acct_a's list (no cross-account)
+		{"acct_b", "poolthree", true},
+		{"acct_b", "poolone", false},
+		{"acct_unknown", "poolone", false}, // account absent -> fail closed
+		{"", "poolone", false},             // empty account
+		{"acct_a", "", false},              // empty pool
+	}
+	for _, tc := range cases {
+		if got := tp.Authorizes(tc.account, tc.pool); got != tc.want {
+			t.Errorf("Authorizes(%q,%q)=%v want %v", tc.account, tc.pool, got, tc.want)
+		}
+	}
+	// A nil-map config authorizes nothing.
+	if (TrustedPoolsConfig{Enabled: true}).Authorizes("acct_a", "poolone") {
+		t.Error("nil AccountPools authorized a pool; want fail-closed")
+	}
+}
+
+func TestValidateTrustedPoolsConfig(t *testing.T) {
+	base := func(tp TrustedPoolsConfig) Config {
+		c := Default()
+		c.Features.TrustedPools = tp
+		return c
+	}
+
+	t.Run("disabled is inert even with junk", func(t *testing.T) {
+		cfg := base(TrustedPoolsConfig{Enabled: false, AccountPools: map[string][]string{
+			"": {"\x01bad"}, // not validated while disabled
+		}})
+		if err := validateTrustedPoolsConfig(cfg); err != nil {
+			t.Fatalf("disabled config rejected: %v", err)
+		}
+	})
+
+	t.Run("enabled accepts base64url ids", func(t *testing.T) {
+		cfg := base(TrustedPoolsConfig{Enabled: true, AccountPools: map[string][]string{
+			"acct_a": {"AbC-123_xyz"},
+		}})
+		if err := validateTrustedPoolsConfig(cfg); err != nil {
+			t.Fatalf("valid config rejected: %v", err)
+		}
+	})
+
+	t.Run("enabled rejects empty account id", func(t *testing.T) {
+		cfg := base(TrustedPoolsConfig{Enabled: true, AccountPools: map[string][]string{
+			"  ": {"poolone"},
+		}})
+		if err := validateTrustedPoolsConfig(cfg); err == nil {
+			t.Fatal("empty account id accepted")
+		}
+	})
+
+	t.Run("enabled rejects empty pool id", func(t *testing.T) {
+		cfg := base(TrustedPoolsConfig{Enabled: true, AccountPools: map[string][]string{
+			"acct_a": {""},
+		}})
+		if err := validateTrustedPoolsConfig(cfg); err == nil {
+			t.Fatal("empty pool id accepted")
+		}
+	})
+
+	t.Run("enabled rejects header-unsafe pool id (spill guard)", func(t *testing.T) {
+		// A control byte would be dropped to empty by the coordinator's opaque
+		// header sanitizer and routed as GLOBAL — a silent pool->global spill.
+		cfg := base(TrustedPoolsConfig{Enabled: true, AccountPools: map[string][]string{
+			"acct_a": {"pool\x01id"},
+		}})
+		if err := validateTrustedPoolsConfig(cfg); err == nil {
+			t.Fatal("header-unsafe pool id accepted")
+		}
+	})
+
+	t.Run("enabled rejects header-safe but non-base64url pool id", func(t *testing.T) {
+		// "pool.id" / "pool+id" pass the header-safety check (printable ASCII)
+		// but are outside the base64url alphabet, so they cannot be a canonical
+		// SPEC-042-R001 pool_id. This case fails ONLY because of the base64url
+		// shape check, not PoolIDHeaderSafe.
+		for _, bad := range []string{"pool.id", "pool+id", "pool one", "pool/id"} {
+			cfg := base(TrustedPoolsConfig{Enabled: true, AccountPools: map[string][]string{
+				"acct_a": {bad},
+			}})
+			if err := validateTrustedPoolsConfig(cfg); err == nil {
+				t.Fatalf("non-base64url pool id %q accepted", bad)
+			}
+		}
+	})
+}
+
+func TestPoolIDHeaderSafe(t *testing.T) {
+	if !PoolIDHeaderSafe("AbC-123_xyz") {
+		t.Error("base64url id rejected")
+	}
+	if PoolIDHeaderSafe("") {
+		t.Error("empty accepted")
+	}
+	if PoolIDHeaderSafe("pool\x01id") {
+		t.Error("C0 control byte accepted")
+	}
+	if PoolIDHeaderSafe("pool\x9bid") {
+		t.Error("C1 control byte accepted")
+	}
+	long := make([]byte, 129)
+	for i := range long {
+		long[i] = 'a'
+	}
+	if PoolIDHeaderSafe(string(long)) {
+		t.Error("over-128-byte id accepted")
+	}
+}

--- a/phase5-gateway/internal/router/chat_proxy.go
+++ b/phase5-gateway/internal/router/chat_proxy.go
@@ -272,6 +272,18 @@ func (s *Server) handleChatCompletions(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusBadRequest, "invalid_request_error", "n_must_be_1", "n must be 1")
 		return
 	}
+	// SPEC-042-R002: authorize any Trusted Pool selection BEFORE quota
+	// reservation or dispatch. Resolves to "" (global, byte-identical) when the
+	// feature is off or no pool is named; a typed rejection otherwise. The
+	// resolved id is emitted as X-MacProvider-Pool inside buildUpReq below.
+	// Only plain API-key credentials may select a pool; wallet sessions and
+	// demo traffic may not (see resolvePoolSelection row 0).
+	poolSelectionAllowed := !authn.Demo && authn.WalletSession == nil
+	poolID, poolErr := s.resolvePoolSelection(upCtx, r.Header, subject.AccountID, poolSelectionAllowed)
+	if poolErr != nil {
+		writeError(w, poolErr.status, poolErr.typ, poolErr.code, poolErr.message)
+		return
+	}
 	maxTokens := maxAllowed
 	if chat.MaxTokens != nil {
 		maxTokens = *chat.MaxTokens
@@ -321,6 +333,7 @@ func (s *Server) handleChatCompletions(w http.ResponseWriter, r *http.Request) {
 			subject.DemoTokenHash,
 			strings.TrimSpace(r.Header.Get("X-MacProvider-Conversation")),
 			strings.TrimSpace(r.Header.Get("X-MacProvider-Retry")),
+			poolID,
 			dedupeBody,
 		)
 		entry, adopted := s.idlessDedupe.claim(dedupeFingerprint, requestID(r), s.now(), dedupeWindow)
@@ -621,6 +634,15 @@ func (s *Server) handleChatCompletions(w http.ResponseWriter, r *http.Request) {
 		if subject.AccountID != "" {
 			upReq.Header.Set("Authorization", "Bearer "+s.cfg.Coordinator.UpstreamCoordinatorBearer())
 			upReq.Header.Set("X-MacProvider-Account", subject.AccountID)
+			// SPEC-042-R002 emit: the pool authority header is set ONLY for an
+			// authenticated account context (the coordinator honors it only
+			// under the service-token bearer + account, both set just above)
+			// and ONLY when resolvePoolSelection returned an authorized,
+			// capability-satisfied pool. Empty poolID (global) emits nothing,
+			// keeping the poolless path byte-identical.
+			if poolID != "" {
+				upReq.Header.Set(poolEmitHeader, poolID)
+			}
 		}
 		if internalConversation != "" {
 			// Authorization + X-MacProvider-Account are set

--- a/phase5-gateway/internal/router/cors.go
+++ b/phase5-gateway/internal/router/cors.go
@@ -4,7 +4,7 @@ import "net/http"
 
 const corsMaxAge = "3600"
 
-var corsAllowedHeaders = "Accept, Anthropic-Beta, Anthropic-Version, Authorization, Content-Type, Idempotency-Key, X-Api-Key, X-Demo-Token, X-MacProvider-Session-Signature, X-MacProvider-Session-Timestamp, X-Request-ID"
+var corsAllowedHeaders = "Accept, Anthropic-Beta, Anthropic-Version, Authorization, Content-Type, Idempotency-Key, X-Api-Key, X-Demo-Token, X-MacProvider-Pool-Select, X-MacProvider-Session-Signature, X-MacProvider-Session-Timestamp, X-Request-ID"
 
 func (s *Server) withCORS(method string, next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/phase5-gateway/internal/router/disclosure.go
+++ b/phase5-gateway/internal/router/disclosure.go
@@ -155,6 +155,12 @@ type coordinatorRoutingMetadata struct {
 		Enabled    bool `json:"enabled"`
 		TTLSeconds int  `json:"ttl_seconds"`
 	} `json:"sticky"`
+	// Pools is the SPEC-042-R010 positive pool-capability advertisement. An
+	// old coordinator omits it entirely, decoding to the zero value
+	// (Enabled=false) so the gateway fails pool dispatch closed.
+	Pools struct {
+		Enabled bool `json:"enabled"`
+	} `json:"pools"`
 	Tier2 struct {
 		Phase     any `json:"phase"`
 		ModelHash struct {

--- a/phase5-gateway/internal/router/idless_dedupe.go
+++ b/phase5-gateway/internal/router/idless_dedupe.go
@@ -37,7 +37,7 @@ const (
 	// idlessDedupeFingerprintVersion is mixed into every fingerprint so a
 	// future change to the keying inputs can never collide with entries
 	// computed by an older build.
-	idlessDedupeFingerprintVersion = "mpg-idless-v2"
+	idlessDedupeFingerprintVersion = "mpg-idless-v3"
 
 	idlessDedupeEntrypointChat      = "chat"
 	idlessDedupeEntrypointResponses = "responses"
@@ -96,7 +96,13 @@ const (
 //  6. retryHint — X-MacProvider-Retry, which copyForwardHeaders forwards to
 //     the coordinator where it changes retry/failover behaviour. Two requests
 //     that differ only in this header are NOT the same dispatch.
-//  7. SHA-256 of the raw body bytes.
+//  7. poolID — the resolved SPEC-042 Trusted Pool (X-MacProvider-Pool-Select).
+//     Because the pool selector is a header, not a body field, two requests
+//     with identical bodies but different pools (or pool vs global) would
+//     otherwise share a fingerprint and the second could replay the first —
+//     a silent pool<->global / cross-pool reassignment SPEC-042-R002 forbids.
+//     "" (global) is a distinct key from any named pool.
+//  8. SHA-256 of the raw body bytes.
 //
 // Everything else that changes the generated answer is inside those bytes
 // (model, messages, stream, max_tokens, response_format). Transport-level
@@ -106,10 +112,10 @@ const (
 // Adding a component is a keying change: bump idlessDedupeFingerprintVersion
 // when one is added to a build that is already deployed, so old and new
 // fingerprints cannot collide.
-func idlessRequestFingerprint(entrypoint, accountID, demoTokenHash, conversationTag, retryHint string, body []byte) string {
+func idlessRequestFingerprint(entrypoint, accountID, demoTokenHash, conversationTag, retryHint, poolID string, body []byte) string {
 	bodyDigest := sha256.Sum256(body)
 	h := sha256.New()
-	for _, part := range []string{idlessDedupeFingerprintVersion, entrypoint, accountID, demoTokenHash, conversationTag, retryHint} {
+	for _, part := range []string{idlessDedupeFingerprintVersion, entrypoint, accountID, demoTokenHash, conversationTag, retryHint, poolID} {
 		h.Write([]byte(part))
 		h.Write([]byte{0})
 	}

--- a/phase5-gateway/internal/router/idless_dedupe_test.go
+++ b/phase5-gateway/internal/router/idless_dedupe_test.go
@@ -1083,19 +1083,21 @@ func TestIdlessDedupeIndex_WaiterCapAndContextExpiry(t *testing.T) {
 }
 
 func TestIdlessRequestFingerprintIsKeyedOnEveryPart(t *testing.T) {
-	base := idlessRequestFingerprint(idlessDedupeEntrypointChat, "acct", "demo-hash", "thread-1", "", []byte(`{"a":1}`))
+	base := idlessRequestFingerprint(idlessDedupeEntrypointChat, "acct", "demo-hash", "thread-1", "", "", []byte(`{"a":1}`))
 	cases := map[string]string{
-		"same inputs":            idlessRequestFingerprint(idlessDedupeEntrypointChat, "acct", "demo-hash", "thread-1", "", []byte(`{"a":1}`)),
-		"other entrypoint":       idlessRequestFingerprint(idlessDedupeEntrypointResponses, "acct", "demo-hash", "thread-1", "", []byte(`{"a":1}`)),
-		"messages entrypoint":    idlessRequestFingerprint(idlessDedupeEntrypointMessages, "acct", "demo-hash", "thread-1", "", []byte(`{"a":1}`)),
-		"other account":       idlessRequestFingerprint(idlessDedupeEntrypointChat, "acct2", "demo-hash", "thread-1", "", []byte(`{"a":1}`)),
-		"other demo token":    idlessRequestFingerprint(idlessDedupeEntrypointChat, "acct", "demo-hash-2", "thread-1", "", []byte(`{"a":1}`)),
-		"other conversation":  idlessRequestFingerprint(idlessDedupeEntrypointChat, "acct", "demo-hash", "thread-2", "", []byte(`{"a":1}`)),
-		"retry hint present":  idlessRequestFingerprint(idlessDedupeEntrypointChat, "acct", "demo-hash", "thread-1", "1", []byte(`{"a":1}`)),
-		"other retry hint":    idlessRequestFingerprint(idlessDedupeEntrypointChat, "acct", "demo-hash", "thread-1", "2", []byte(`{"a":1}`)),
-		"other body":          idlessRequestFingerprint(idlessDedupeEntrypointChat, "acct", "demo-hash", "thread-1", "", []byte(`{"a":2}`)),
-		"whitespace in body":  idlessRequestFingerprint(idlessDedupeEntrypointChat, "acct", "demo-hash", "thread-1", "", []byte(`{"a": 1}`)),
-		"field-shifted parts": idlessRequestFingerprint(idlessDedupeEntrypointChat, "acc", "tdemo-hash", "thread-1", "", []byte(`{"a":1}`)),
+		"same inputs":         idlessRequestFingerprint(idlessDedupeEntrypointChat, "acct", "demo-hash", "thread-1", "", "", []byte(`{"a":1}`)),
+		"other entrypoint":    idlessRequestFingerprint(idlessDedupeEntrypointResponses, "acct", "demo-hash", "thread-1", "", "", []byte(`{"a":1}`)),
+		"messages entrypoint": idlessRequestFingerprint(idlessDedupeEntrypointMessages, "acct", "demo-hash", "thread-1", "", "", []byte(`{"a":1}`)),
+		"other account":       idlessRequestFingerprint(idlessDedupeEntrypointChat, "acct2", "demo-hash", "thread-1", "", "", []byte(`{"a":1}`)),
+		"other demo token":    idlessRequestFingerprint(idlessDedupeEntrypointChat, "acct", "demo-hash-2", "thread-1", "", "", []byte(`{"a":1}`)),
+		"other conversation":  idlessRequestFingerprint(idlessDedupeEntrypointChat, "acct", "demo-hash", "thread-2", "", "", []byte(`{"a":1}`)),
+		"retry hint present":  idlessRequestFingerprint(idlessDedupeEntrypointChat, "acct", "demo-hash", "thread-1", "1", "", []byte(`{"a":1}`)),
+		"other retry hint":    idlessRequestFingerprint(idlessDedupeEntrypointChat, "acct", "demo-hash", "thread-1", "2", "", []byte(`{"a":1}`)),
+		"pool selected":       idlessRequestFingerprint(idlessDedupeEntrypointChat, "acct", "demo-hash", "thread-1", "", "poolone", []byte(`{"a":1}`)),
+		"other pool":          idlessRequestFingerprint(idlessDedupeEntrypointChat, "acct", "demo-hash", "thread-1", "", "pooltwo", []byte(`{"a":1}`)),
+		"other body":          idlessRequestFingerprint(idlessDedupeEntrypointChat, "acct", "demo-hash", "thread-1", "", "", []byte(`{"a":2}`)),
+		"whitespace in body":  idlessRequestFingerprint(idlessDedupeEntrypointChat, "acct", "demo-hash", "thread-1", "", "", []byte(`{"a": 1}`)),
+		"field-shifted parts": idlessRequestFingerprint(idlessDedupeEntrypointChat, "acc", "tdemo-hash", "thread-1", "", "", []byte(`{"a":1}`)),
 	}
 	for name, got := range cases {
 		if name == "same inputs" {
@@ -1110,6 +1112,9 @@ func TestIdlessRequestFingerprintIsKeyedOnEveryPart(t *testing.T) {
 	}
 	if cases["retry hint present"] == cases["other retry hint"] {
 		t.Fatal("two different X-MacProvider-Retry values produced the same fingerprint")
+	}
+	if cases["pool selected"] == cases["other pool"] {
+		t.Fatal("two different pool selections produced the same fingerprint")
 	}
 }
 

--- a/phase5-gateway/internal/router/pool_selection.go
+++ b/phase5-gateway/internal/router/pool_selection.go
@@ -1,0 +1,161 @@
+package router
+
+import (
+	"context"
+	"net/http"
+	"strings"
+
+	"github.com/augstar/macprovider-gateway/internal/config"
+)
+
+const (
+	// poolSelectHeader is the inbound buyer-facing pool selector header. It is
+	// deliberately DISTINCT from poolEmitHeader so a buyer can never smuggle
+	// the internal authority header (copyForwardHeaders already allowlists only
+	// Accept / X-MacProvider-Retry / Idempotency-Key, so neither is forwarded
+	// verbatim — the gateway sets the outbound one explicitly).
+	poolSelectHeader = "X-MacProvider-Pool-Select"
+	// poolEmitHeader is the outbound authority header the coordinator honors
+	// (only under the gateway service-token bearer + authenticated account).
+	poolEmitHeader = "X-MacProvider-Pool"
+)
+
+// poolSelectionError is a typed pool-resolution rejection the handler maps to
+// writeError. Kept separate from the http layer so resolvePoolSelection stays
+// unit-testable.
+type poolSelectionError struct {
+	status  int
+	typ     string
+	code    string
+	message string
+}
+
+var (
+	// errPoolUnavailable is the single generic, non-disclosing rejection for
+	// EVERY pool-denial cause (feature disabled, unauthorized, unknown pool,
+	// coordinator without pool support). One fixed (503, non-retryable, same
+	// code/type) response so neither status, code, nor the derived retryable
+	// flag distinguishes cause and reveals private-pool existence
+	// (SPEC-042-R010).
+	errPoolUnavailable = &poolSelectionError{
+		status:  http.StatusServiceUnavailable,
+		typ:     "service_unavailable",
+		code:    "pool_unavailable",
+		message: "Pool unavailable",
+	}
+	// errPoolSelectionInvalid is returned ONLY for a syntactically conflicting
+	// selection (the selector header supplied more than once with different
+	// values). It never fires on an out-of-scope pool (that is
+	// errPoolUnavailable), so the 400 cannot confirm a pool exists
+	// (SPEC-042-R010).
+	errPoolSelectionInvalid = &poolSelectionError{
+		status:  http.StatusBadRequest,
+		typ:     "invalid_request_error",
+		code:    "pool_selection_invalid",
+		message: "Conflicting pool selection",
+	}
+)
+
+// resolvePoolSelection resolves the SPEC-042 pool for a chat request and
+// authorizes it against the request's credential (account granularity) and the
+// coordinator's advertised capability. The selector is a control-plane HTTP
+// header (poolSelectHeader) only — deliberately NOT a request-body field, so
+// the data-plane body forwarded to the coordinator/provider carries no pool
+// control metadata. It returns:
+//
+//   - ("", nil)        global (poolless) routing — emit no pool header, the
+//     byte-identical default (no selector, or feature off with
+//     no selector);
+//   - (poolID, nil)    an authorized, capability-satisfied pool to emit;
+//   - ("", selErr)     a typed rejection.
+//
+// Ordering is load-bearing (see the design doc decision table): the credential
+// authorization check (rows 0-4) is pure and local, so an unauthorized caller
+// is rejected BEFORE any coordinator capability roundtrip (row 5) and its
+// latency cannot reveal whether the named pool exists (SPEC-042-R010).
+func (s *Server) resolvePoolSelection(ctx context.Context, headers http.Header, accountID string, poolSelectionAllowed bool) (string, *poolSelectionError) {
+	tp := s.cfg.Features.TrustedPools
+
+	// Collect the distinct non-empty selector values. Multiple header values
+	// naming different pools is an ambiguous/conflicting selection.
+	var selector string
+	conflicting := false
+	for _, raw := range headers.Values(poolSelectHeader) {
+		v := strings.TrimSpace(raw)
+		if v == "" {
+			continue
+		}
+		if selector == "" {
+			selector = v
+		} else if v != selector {
+			conflicting = true
+		}
+	}
+
+	// Row 0: the auth mode must be permitted to select a pool. Only plain
+	// API-key credentials may. Wallet sessions (SPEC-040) MUST NOT select a
+	// pool until the wallet semantic signature covers pool_id + the manifest
+	// digest (SPEC-042-R002 explicit deferral) — the selector header is not in
+	// the signed profile, so honoring it would authorize a pool with no signed
+	// binding. Demo traffic has no durable account scope. Presenting a selector
+	// is rejected with the generic non-disclosing code, before authorization or
+	// the conflict check, so it also does not reveal pool existence.
+	if !poolSelectionAllowed && selector != "" {
+		return "", errPoolUnavailable
+	}
+
+	// Row 1: conflicting selection sources (multiple distinct header values).
+	if conflicting {
+		return "", errPoolSelectionInvalid
+	}
+
+	// Row 2: no selection -> global, byte-identical.
+	if selector == "" {
+		return "", nil
+	}
+
+	// Row 3: a pool is named but the feature is off. Fail closed rather than
+	// silently downgrade a pool request to global (SPEC-042-R002 forbids the
+	// silent pool->global reassignment); this is also the rollback behavior
+	// when pool config is disabled.
+	if !tp.Enabled {
+		return "", errPoolUnavailable
+	}
+
+	// Row 4: credential authorization. Pure map lookup, no coordinator call.
+	// An account absent from the config, or a pool outside its authorized set,
+	// is denied with the generic non-disclosing code. The narrow-only
+	// invariant is structural: the selector can only pick a pool already in
+	// the ceiling, never widen it.
+	if !tp.Authorizes(accountID, selector) {
+		return "", errPoolUnavailable
+	}
+
+	// Defense-in-depth: never emit a header value the coordinator's opaque
+	// sanitizer would drop to empty (which it would then route as GLOBAL — a
+	// silent pool->global spill). Config validation already rejects such ids
+	// when the feature is enabled; this guards programmatically-built configs
+	// that bypass Validate().
+	if !config.PoolIDHeaderSafe(selector) {
+		return "", errPoolUnavailable
+	}
+
+	// Row 5: positive pool-capability negotiation. Refuse unless the assigned
+	// coordinator advertises pool support; an old coordinator omits the block
+	// (decoding to Enabled=false) and would otherwise route pool traffic from
+	// the global snapshot (SPEC-042-R010). This uses the FRESH fetch, not the
+	// 5s-cached sticky-hint metadata: a stale cached "true" would let pool
+	// dispatch continue for up to the TTL after a coordinator rollback/disable
+	// (trustPools==nil), and the rolled-back coordinator would ignore the
+	// header and route globally — a pool->global spill the positive handshake
+	// exists to prevent. A fresh check per pool-required dispatch shrinks that
+	// window to the in-request TOCTOU that no gateway-side check can remove;
+	// the coordinator's own member-only routing is the second line when it is
+	// pool-aware. Pool traffic is opt-in, so the extra roundtrip is acceptable.
+	if md, ok := s.coordinatorRoutingMetadataFresh(ctx); !ok || !md.Pools.Enabled {
+		return "", errPoolUnavailable
+	}
+
+	// Row 6: authorized and capability-satisfied.
+	return selector, nil
+}

--- a/phase5-gateway/internal/router/pool_selection_test.go
+++ b/phase5-gateway/internal/router/pool_selection_test.go
@@ -1,0 +1,363 @@
+package router
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/augstar/macprovider-gateway/internal/config"
+)
+
+// poolChatOK is a minimal successful coordinator chat response.
+const poolChatOK = `{"id":"chatcmpl_1","object":"chat.completion","usage":{"prompt_tokens":3,"completion_tokens":4,"total_tokens":7},"choices":[{"index":0,"message":{"role":"assistant","content":"ok"},"finish_reason":"stop"}]}`
+
+const poolChatBody = `{"model":"llama","max_tokens":20,"messages":[{"role":"user","content":"hi"}]}`
+
+// poolCoordCapture records what the fake coordinator saw so a test can assert
+// whether the chat leg was dispatched, whether the capability endpoint was
+// consulted, and what pool header (if any) was forwarded.
+type poolCoordCapture struct {
+	chatHits    int
+	routingHits int
+	poolHeader  string
+	sawPool     bool
+}
+
+// newPoolHarness wires a gateway over a fake coordinator. routingBody is the
+// JSON returned by /internal/routing (use "" for an old coordinator that has no
+// /internal/routing — it 404s). The TrustedPools feature is enabled with
+// acct_pool authorized for "poolone" unless mutate overrides it.
+func newPoolHarness(t *testing.T, routingBody string, mutate func(*config.Config)) (http.Handler, *poolCoordCapture, string) {
+	t.Helper()
+	cap := &poolCoordCapture{}
+	client := &http.Client{Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+		switch r.URL.Path {
+		case "/internal/routing":
+			cap.routingHits++
+			if routingBody == "" {
+				return responseWithBody(http.StatusNotFound, nil, `{}`), nil
+			}
+			return responseWithBody(http.StatusOK, http.Header{"Content-Type": []string{"application/json"}}, routingBody), nil
+		case "/v1/chat/completions":
+			cap.chatHits++
+			if v := r.Header.Get("X-MacProvider-Pool"); v != "" {
+				cap.sawPool = true
+				cap.poolHeader = v
+			}
+			return responseWithBody(http.StatusOK, http.Header{"Content-Type": []string{"application/json"}}, poolChatOK), nil
+		default:
+			t.Fatalf("unexpected coordinator path %s", r.URL.Path)
+			return nil, nil
+		}
+	})}
+	h, st, _, cfg := newTestHarnessConfig(t, fakeOAuth{}, func(cfg *config.Config) {
+		cfg.Coordinator.BuyerURL = "http://coordinator.test"
+		cfg.Coordinator.OperatorURL = "http://operator.test"
+		cfg.Features.TrustedPools = config.TrustedPoolsConfig{
+			Enabled:      true,
+			AccountPools: map[string][]string{"acct_pool": {"poolone"}},
+		}
+		if mutate != nil {
+			mutate(cfg)
+		}
+	}, WithHTTPClient(client))
+	key := createAccountAndKey(t, st, cfg, "acct_pool")
+	return h, cap, key
+}
+
+// selectHeader is the buyer-facing pool selector header (control plane only —
+// never a request-body field, so nothing pool-related is forwarded to the
+// provider in the data-plane body).
+func selectHeader(pool string) map[string]string {
+	return map[string]string{"X-MacProvider-Pool-Select": pool}
+}
+
+// Authorized pool + coordinator advertises pool support -> forwarded WITH
+// X-MacProvider-Pool set to the selected pool_id (SPEC-042-R002).
+func TestPoolSelection_AuthorizedAndCapable_EmitsHeader(t *testing.T) {
+	h, cap, key := newPoolHarness(t, `{"pools":{"enabled":true}}`, nil)
+	resp := postChat(t, h, key, poolChatBody, selectHeader("poolone"))
+	if resp.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s", resp.Code, resp.Body.String())
+	}
+	if !cap.sawPool || cap.poolHeader != "poolone" {
+		t.Fatalf("forwarded pool header = %q (seen=%v), want poolone", cap.poolHeader, cap.sawPool)
+	}
+}
+
+// The capability check is FRESH per pool-required dispatch (not the 5s-cached
+// sticky-hint metadata), so a coordinator rollback cannot be masked by a stale
+// cached "true". Two authorized pool requests therefore each consult
+// /internal/routing.
+func TestPoolSelection_CapabilityCheckedFreshEachRequest(t *testing.T) {
+	h, cap, key := newPoolHarness(t, `{"pools":{"enabled":true}}`, nil)
+	for i := 0; i < 2; i++ {
+		resp := postChat(t, h, key, poolChatBody, selectHeader("poolone"))
+		if resp.Code != http.StatusOK {
+			t.Fatalf("request %d status=%d body=%s", i, resp.Code, resp.Body.String())
+		}
+	}
+	if cap.routingHits != 2 {
+		t.Fatalf("routingHits=%d, want 2 (fresh capability check per pool request, not cached)", cap.routingHits)
+	}
+}
+
+// Feature off (default) + no pool named -> byte-identical global: forwarded with
+// NO pool header.
+func TestPoolSelection_FeatureOffNoPool_GlobalNoHeader(t *testing.T) {
+	h, cap, key := newPoolHarness(t, `{"pools":{"enabled":true}}`, func(cfg *config.Config) {
+		cfg.Features.TrustedPools.Enabled = false
+	})
+	resp := postChat(t, h, key, poolChatBody, nil)
+	if resp.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s", resp.Code, resp.Body.String())
+	}
+	if cap.sawPool {
+		t.Fatalf("global request forwarded a pool header %q; want none", cap.poolHeader)
+	}
+	if cap.chatHits != 1 {
+		t.Fatalf("chatHits=%d, want 1", cap.chatHits)
+	}
+}
+
+// Feature on + no pool named -> still global, no header (the credential's
+// authorized set is a ceiling, not an automatic assignment; SPEC-042-R002).
+func TestPoolSelection_FeatureOnNoPool_GlobalNoHeader(t *testing.T) {
+	h, cap, key := newPoolHarness(t, `{"pools":{"enabled":true}}`, nil)
+	resp := postChat(t, h, key, poolChatBody, nil)
+	if resp.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s", resp.Code, resp.Body.String())
+	}
+	if cap.sawPool {
+		t.Fatalf("no-selector request forwarded a pool header %q; want none", cap.poolHeader)
+	}
+}
+
+// Feature off + a pool IS named -> fail closed (no silent pool->global). The
+// chat leg MUST NOT be dispatched.
+func TestPoolSelection_FeatureOffPoolNamed_FailsClosed(t *testing.T) {
+	h, cap, key := newPoolHarness(t, `{"pools":{"enabled":true}}`, func(cfg *config.Config) {
+		cfg.Features.TrustedPools.Enabled = false
+	})
+	resp := postChat(t, h, key, poolChatBody, selectHeader("poolone"))
+	if resp.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status=%d body=%s, want 503", resp.Code, resp.Body.String())
+	}
+	assertErrorCode(t, resp.Body.String(), "pool_unavailable")
+	if cap.chatHits != 0 {
+		t.Fatalf("chat dispatched under disabled pool feature (chatHits=%d)", cap.chatHits)
+	}
+}
+
+// Unauthorized pool -> generic non-disclosing pool_unavailable, chat NOT
+// dispatched, and — the timing-oracle guard (SPEC-042-R010) — the coordinator
+// capability endpoint is NEVER consulted, so latency cannot reveal existence.
+func TestPoolSelection_Unauthorized_FailsClosedWithoutCapabilityFetch(t *testing.T) {
+	h, cap, key := newPoolHarness(t, `{"pools":{"enabled":true}}`, nil)
+	resp := postChat(t, h, key, poolChatBody, selectHeader("pooUNKNOWN"))
+	if resp.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status=%d body=%s, want 503", resp.Code, resp.Body.String())
+	}
+	assertErrorCode(t, resp.Body.String(), "pool_unavailable")
+	if cap.chatHits != 0 {
+		t.Fatalf("chat dispatched for unauthorized pool (chatHits=%d)", cap.chatHits)
+	}
+	if cap.routingHits != 0 {
+		t.Fatalf("capability endpoint consulted for an unauthorized caller (routingHits=%d); timing oracle", cap.routingHits)
+	}
+}
+
+// Authorized pool but coordinator advertises pools.enabled=false -> fail closed
+// (no pool->global spill under version skew). Chat NOT dispatched.
+func TestPoolSelection_CoordinatorDeclinesCapability_FailsClosed(t *testing.T) {
+	h, cap, key := newPoolHarness(t, `{"pools":{"enabled":false}}`, nil)
+	resp := postChat(t, h, key, poolChatBody, selectHeader("poolone"))
+	if resp.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status=%d body=%s, want 503", resp.Code, resp.Body.String())
+	}
+	assertErrorCode(t, resp.Body.String(), "pool_unavailable")
+	if cap.chatHits != 0 {
+		t.Fatalf("chat dispatched despite coordinator declining pool support (chatHits=%d)", cap.chatHits)
+	}
+}
+
+// Old coordinator that omits the pools advertisement entirely -> fail closed.
+func TestPoolSelection_OldCoordinatorNoAdvertisement_FailsClosed(t *testing.T) {
+	h, cap, key := newPoolHarness(t, `{"sticky":{"enabled":false,"ttl_seconds":1800}}`, nil)
+	resp := postChat(t, h, key, poolChatBody, selectHeader("poolone"))
+	if resp.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status=%d body=%s, want 503", resp.Code, resp.Body.String())
+	}
+	assertErrorCode(t, resp.Body.String(), "pool_unavailable")
+	if cap.chatHits != 0 {
+		t.Fatalf("chat dispatched to a coordinator with no pool advertisement (chatHits=%d)", cap.chatHits)
+	}
+}
+
+// Conflicting selection sources (the selector header supplied twice with
+// different values) -> pool_selection_invalid (400), never confirming either
+// pool exists.
+func TestPoolSelection_ConflictingSources_Invalid(t *testing.T) {
+	h, cap, key := newPoolHarness(t, `{"pools":{"enabled":true}}`, nil)
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader(poolChatBody))
+	req.Header.Set("Authorization", "Bearer "+key)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Add("X-MacProvider-Pool-Select", "poolone")
+	req.Header.Add("X-MacProvider-Pool-Select", "poolother")
+	resp := httptest.NewRecorder()
+	h.ServeHTTP(resp, req)
+	if resp.Code != http.StatusBadRequest {
+		t.Fatalf("status=%d body=%s, want 400", resp.Code, resp.Body.String())
+	}
+	assertErrorCode(t, resp.Body.String(), "pool_selection_invalid")
+	if cap.chatHits != 0 {
+		t.Fatalf("chat dispatched under a conflicting selection (chatHits=%d)", cap.chatHits)
+	}
+}
+
+// Regression (money-path audit round 2): because the pool selector is a header,
+// not a body field, two id-less requests with IDENTICAL bodies that differ only
+// in pool selection MUST NOT share an id-less-dedupe fingerprint. Otherwise the
+// second would replay the first's attempt and never dispatch to the pool — a
+// silent pool<->global reassignment SPEC-042-R002 forbids. The fixed clock puts
+// the second request inside the first's dedupe window, so a collision would
+// replay.
+func TestPoolSelection_IdlessDedupeSeparatesPoolFromGlobal(t *testing.T) {
+	h, cap, key := newPoolHarness(t, `{"pools":{"enabled":true}}`, nil)
+	// First: global (no selector) — dispatches and publishes a dedupe entry.
+	r1 := postChat(t, h, key, poolChatBody, nil)
+	if r1.Code != http.StatusOK {
+		t.Fatalf("global status=%d body=%s", r1.Code, r1.Body.String())
+	}
+	// Second: identical body, now pool-selected, within the dedupe window.
+	r2 := postChat(t, h, key, poolChatBody, selectHeader("poolone"))
+	if r2.Code != http.StatusOK {
+		t.Fatalf("pool status=%d body=%s", r2.Code, r2.Body.String())
+	}
+	if cap.chatHits != 2 {
+		t.Fatalf("chatHits=%d, want 2 — the pool request replayed the global attempt via id-less dedupe", cap.chatHits)
+	}
+	if !cap.sawPool || cap.poolHeader != "poolone" {
+		t.Fatalf("pool request did not dispatch with X-MacProvider-Pool (dedupe replay masked it): seen=%v hdr=%q", cap.sawPool, cap.poolHeader)
+	}
+}
+
+// Demo traffic (like wallet sessions) may not select a pool even if the demo
+// account is authorized in config: the row-0 auth-mode gate rejects it before
+// authorization. This pins the `!authn.Demo` half of the gate independently.
+func TestPoolSelection_DemoCannotSelectPool(t *testing.T) {
+	cap := &poolCoordCapture{}
+	client := &http.Client{Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+		switch r.URL.Path {
+		case "/internal/routing":
+			cap.routingHits++
+			return responseWithBody(http.StatusOK, http.Header{"Content-Type": []string{"application/json"}}, `{"pools":{"enabled":true}}`), nil
+		case "/v1/chat/completions":
+			cap.chatHits++
+			if v := r.Header.Get("X-MacProvider-Pool"); v != "" {
+				cap.sawPool = true
+				cap.poolHeader = v
+			}
+			return responseWithBody(http.StatusOK, http.Header{"Content-Type": []string{"application/json"}}, poolChatOK), nil
+		default:
+			t.Fatalf("unexpected coordinator path %s", r.URL.Path)
+			return nil, nil
+		}
+	})}
+	h, _, _, _ := newTestHarnessConfig(t, fakeOAuth{}, func(cfg *config.Config) {
+		cfg.Coordinator.BuyerURL = "http://coordinator.test"
+		cfg.Coordinator.OperatorURL = "http://operator.test"
+		cfg.Quotas.DemoDailyTokensPerIP = 1000
+		cfg.Limits.DemoMaxTokensPerRequest = 100
+		// Even with the demo account explicitly authorized, row-0 must reject.
+		cfg.Features.TrustedPools = config.TrustedPoolsConfig{
+			Enabled:      true,
+			AccountPools: map[string][]string{"demo:1.2.3.4": {"poolone"}},
+		}
+	}, WithHTTPClient(client))
+	demo := issueDemoToken(t, h, "1.2.3.4")
+	resp := postChat(t, h, "", poolChatBody, map[string]string{
+		"X-Demo-Token":              demo,
+		"X-Real-IP":                 "1.2.3.4",
+		"X-MacProvider-Pool-Select": "poolone",
+	})
+	if resp.Code != http.StatusServiceUnavailable {
+		t.Fatalf("demo pool selection status=%d body=%s, want 503", resp.Code, resp.Body.String())
+	}
+	assertErrorCode(t, resp.Body.String(), "pool_unavailable")
+	if cap.chatHits != 0 {
+		t.Fatalf("demo pool request dispatched (chatHits=%d)", cap.chatHits)
+	}
+	if cap.sawPool {
+		t.Fatalf("demo request emitted pool header %q; want none", cap.poolHeader)
+	}
+}
+
+// SPEC-042-R002 deferral: a wallet-session credential MUST NOT select a pool
+// until the wallet semantic signature covers pool_id + the manifest digest.
+// Even when the account is authorized for the pool and the coordinator
+// advertises support, a wallet-session request presenting the (unsigned)
+// selector header is rejected before dispatch and emits no pool header.
+func TestPoolSelection_WalletSessionCannotSelectPool(t *testing.T) {
+	cap := &poolCoordCapture{}
+	client := &http.Client{Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+		if strings.HasSuffix(r.URL.Path, "/poolz") {
+			// Wallet-session registration validates its model allowlist against
+			// the coordinator model pool.
+			return responseWithBody(http.StatusOK, http.Header{"Content-Type": []string{"application/json"}},
+				`{"pool":[{"model_id":"llama","state":"ready","slots_free":1,"slots_total":1,"max_context_tokens":4096,"auth_state":"bearer_validated"}]}`), nil
+		}
+		switch r.URL.Path {
+		case "/internal/routing":
+			cap.routingHits++
+			return responseWithBody(http.StatusOK, http.Header{"Content-Type": []string{"application/json"}}, `{"pools":{"enabled":true}}`), nil
+		case "/v1/chat/completions":
+			cap.chatHits++
+			if v := r.Header.Get("X-MacProvider-Pool"); v != "" {
+				cap.sawPool = true
+				cap.poolHeader = v
+			}
+			return responseWithBody(http.StatusOK, http.Header{"Content-Type": []string{"application/json"}}, poolChatOK), nil
+		default:
+			t.Fatalf("unexpected coordinator path %s", r.URL.Path)
+			return nil, nil
+		}
+	})}
+	accountID := "acct_wallet_pool"
+	h, store, _, cfg := newTestHarnessConfig(t, fakeOAuth{}, func(cfg *config.Config) {
+		cfg.Public.BaseURL = "https://api.malibu.test"
+		cfg.Coordinator.BuyerURL = "http://coordinator.test"
+		cfg.Coordinator.OperatorURL = "http://operator.test"
+		cfg.Auth.WalletSessions.Enabled = true
+		cfg.Auth.WalletSessions.BearerHashKeys = map[string]string{"k1": strings.Repeat("b", 32)}
+		cfg.Auth.WalletSessions.CurrentBearerHashKeyID = "k1"
+		cfg.Auth.WalletSessions.WalletFingerprintSecret = strings.Repeat("f", 32)
+		cfg.Auth.WalletSessions.MetadataRequestsPerMinute = 100
+		cfg.Features.TrustedPools = config.TrustedPoolsConfig{
+			Enabled:      true,
+			AccountPools: map[string][]string{accountID: {"poolone"}},
+		}
+	}, WithHTTPClient(client))
+	apiKey := createAccountAndKey(t, store, cfg, accountID)
+	walletClient := registerWalletSessionViaAPIWithCaps(t, h, cfg, apiKey, accountID, []string{"llama"}, 100000, 4096)
+
+	req := signedWalletRequest(t, walletClient, http.MethodPost, "/v1/chat/completions", "/v1/chat/completions",
+		"018f7b7b-7c35-4cf0-8d4e-3f0ab1c2f929", []byte(poolChatBody))
+	// The selector header is NOT part of the wallet signed profile — appending
+	// it after signing is exactly the attack the row-0 gate blocks.
+	req.Header.Set("X-MacProvider-Pool-Select", "poolone")
+	resp := httptest.NewRecorder()
+	h.ServeHTTP(resp, req)
+
+	if resp.Code != http.StatusServiceUnavailable {
+		t.Fatalf("wallet pool selection status=%d body=%s, want 503", resp.Code, resp.Body.String())
+	}
+	assertErrorCode(t, resp.Body.String(), "pool_unavailable")
+	if cap.chatHits != 0 {
+		t.Fatalf("wallet-session pool request dispatched (chatHits=%d)", cap.chatHits)
+	}
+	if cap.sawPool {
+		t.Fatalf("wallet-session request emitted pool header %q; want none", cap.poolHeader)
+	}
+}

--- a/phase5-gateway/internal/router/server.go
+++ b/phase5-gateway/internal/router/server.go
@@ -1416,6 +1416,13 @@ var gatewayPermanentCodes = map[string]bool{
 	// from the buyer's perspective even though the underlying cause is a
 	// provider response.
 	"stream_malformed": true, "stream_output_exceeded": true, "stream_truncated": true,
+	// SPEC-042-R010 pool taxonomy. Both non-retryable: pool_unavailable is the
+	// generic non-disclosing denial (retrying the identical request cannot flip
+	// authorization/capability), and pool_selection_invalid is a deterministic
+	// client-side conflict. A 503 pool_unavailable carries no Retry-After
+	// (setGatewayRetryAfter only fires for retryable codes), matching the
+	// SPEC-042 R010 table (503 | no).
+	"pool_unavailable": true, "pool_selection_invalid": true,
 }
 
 func gatewayRetryable(code string) bool {


### PR DESCRIPTION
## SPEC-042 gateway: credential pool authorization + capability handshake + `X-MacProvider-Pool` emit

**Stacked on #1072** (`feat/spec-042-impl-stage-e`). Review the coordinator stack first (#1065 → #1069 → #1072); this is the gateway half that makes pool selection work end-to-end.

The coordinator already ingests an authorized `X-MacProvider-Pool` header, routes pool traffic to members only, and binds `pool_id` into the settlement spine — but **nothing emitted that header**. This slice builds the emitting half (SPEC-042 **R002** selection authorization + **R010** taxonomy and positive capability negotiation), coordinator-only + gateway-only, **default-off and byte-identical when off**.

### What it does
1. **Credential authorization (R002).** A buyer selects a pool via the control-plane header `X-MacProvider-Pool-Select` (never a body field — no pool metadata leaks into the provider-bound body). The pool must be in the credential's authorized set (`features.trusted_pools.account_pools`, account-scoped ceiling, narrow-only), checked **before** quota reservation. Emits `X-MacProvider-Pool: <pool_id>` only for an authorized, capability-satisfied selection.
2. **Non-disclosing rejection + no timing oracle (R010).** Every denial cause returns the same generic `pool_unavailable` (503, non-retryable); authorization is a pure local lookup that runs **before** any coordinator roundtrip, so an unauthorized caller's latency can't reveal pool existence. `pool_selection_invalid` (400) fires only on a conflicting selection (the header supplied twice with different values).
3. **Positive capability handshake (R010), both halves.** The coordinator advertises `pools.enabled` in `/internal/routing` (gated `trustPools != nil`); the gateway refuses to emit unless it reads a **fresh** `true` — so an old/rolled-back coordinator (which ignores `pool_id` and would route globally) fails the request closed instead of spilling pool traffic to global.
4. **Auth-mode gating (R002 deferral).** Only plain API-key credentials may select a pool. Wallet sessions may not (needs the SPEC-040 pool-aware envelope amendment — the selector isn't in the signed profile); demo traffic may not. Either presenting a selector → `pool_unavailable` before dispatch.
5. **Fail-closed everywhere.** Feature-off + pool named → rejected (never silent pool→global); config rejects header-unsafe / non-base64url pool ids (coordinator-sanitizer spill guard); id-less dedupe fingerprint keys on the resolved `poolID` so a pool request can't replay a global attempt (or vice-versa).

### Money-path audit — codex 3 lanes → 0 C/H/M
This landed clean only after **three audit rounds** that caught real defects:
- **R1:** wallet/demo could select pools despite the deferral (×3 lanes); stale 5s capability cache → pool→global spill during rollback (security). → fixed: row-0 auth-mode gate; fresh capability fetch.
- **R2:** moving the selector out of the body broke the id-less dedupe fingerprint (body-keyed) → identical-body pool vs global requests could replay across the boundary (code). → fixed: `poolID` threaded into the fingerprint (v2→v3) + regression test.
- **R3:** code **APPROVE** 0/0/0, security **PASS** 0/0/0 (verified no remaining replay/capability/smuggling/settlement bypass). Architect **PASS** 0/0/0 (R2). Only residual was a gofmt LOW, applied.

### Compatibility
- Default-off; poolless + feature-off requests are byte-identical (no new header, no capability fetch). Old coordinator (no `pools` advertisement) → gateway fails closed; global traffic untouched.
- Coordinator change is one advertisement block; gateway change is behind `features.trusted_pools`.

### Verification
Green: gateway `router`/`config`; coordinator `buyer`/`billing`/`requestlog`/`routing`/`trustpool`. New tests: coordinator advertisement toggle; config authorize/validate/base64url; gateway handler conformance (emit, fail-closed non-dispatch, capability-not-consulted-for-unauthorized, fresh-per-request capability, byte-identical global, conflict, wallet + demo rejection, id-less dedupe pool/global separation).

> **`spec-index / check` is advisory-red** here, same as #1069/#1072: the per-requirement CONFORMANCE records for SPEC-042 R001–R012 are deferred (skeleton R010 promotion checklist), so `SPEC-042-R002`/`R010` are honest but not yet registered. The check is advisory (not `ci-required`) and does not block merge.

### Deferred (documented, each fails closed)
Wallet-session pool selection (SPEC-040 envelope amendment); per-API-key pool columns (account-granularity is the MVP binding); provider-half capability advertisement; predicate-specific error codes. **Carried, not a slice defect:** go 1.26→1.26.6 stdlib vulns (`go.mod` untouched by this slice; tracked in #1055).

SPEC-GOVERNANCE-DECLARATION-BEGIN
{
  "schema_version": "spec-pr-governance-v1",
  "behavior_change": "yes",
  "contract_change": "none",
  "specs": ["SPEC-042"],
  "requirements": ["SPEC-042-R002", "SPEC-042-R010"],
  "authority_domains": ["pool-control-plane"],
  "arbitration": ["CODE_BUG"],
  "tests": ["phase5-gateway/internal/router/pool_selection_test.go"],
  "journeys": ["not-required"],
  "issue": "https://github.com/Augustas11/macprovider/issues/1053"
}
SPEC-GOVERNANCE-DECLARATION-END

🤖 Generated with [Claude Code](https://claude.com/claude-code)
