### PR TITLE
Treat loaded legacy LaunchAgents as owned installer upgrades

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -86,6 +86,7 @@ test-dist:
 	bash scripts/test-agent-onboarding-publication.sh
 	bash scripts/test-release-discovery-head.sh
 	bash scripts/test-release-discovery-transport.sh
+	bash scripts/test-select-public-discovery-transport.sh
 	bash scripts/test-renew-release-discovery-head.sh
 	bash scripts/test-tier2-provider-artifact.sh
 	bash scripts/test-tier2-provider-release.sh

--- a/phase3-binary/dist/install.sh
+++ b/phase3-binary/dist/install.sh
@@ -111,18 +111,22 @@ INSTALL_TX_ACTIVE=0
 INSTALL_TX_COMMITTED=0
 INSTALL_TX_BACKUP=""
 INSTALL_TX_SERVICE_WAS_ACTIVE=0
+INSTALL_TX_LEGACY_SERVICE_WAS_ACTIVE=0
 INSTALL_TX_HAD_INSTALL_DIR=0
 INSTALL_TX_HAD_BINARY_PATH=0
 INSTALL_TX_HAD_CONFIG=0
 INSTALL_TX_HAD_PROVIDER_ID=0
 INSTALL_TX_HAD_RECOMMENDATION=0
 INSTALL_TX_HAD_PLIST=0
+INSTALL_TX_HAD_LEGACY_PLIST=0
 INSTALL_TX_HAD_WATCHDOG_DIR=0
 INSTALL_TX_HAD_WATCHDOG_PLIST=0
+INSTALL_TX_HAD_LEGACY_WATCHDOG_PLIST=0
 INSTALL_TX_HAD_MANIFEST=0
 INSTALL_TX_HAD_LIFECYCLE_STATE=0
 INSTALL_TX_SERVICE_WAS_DISABLED=0
 INSTALL_TX_WATCHDOG_WAS_ACTIVE=0
+INSTALL_TX_LEGACY_WATCHDOG_WAS_ACTIVE=0
 INSTALL_TX_WATCHDOG_WAS_DISABLED=0
 INSTALL_TX_ROLLING_BACK=0
 INSTALL_TX_BINARY_KIND="symlink"
@@ -2151,13 +2155,21 @@ write_install_recovery_artifacts() {
     printf 'REC_HAD_PROVIDER_ID=%q\n' "$INSTALL_TX_HAD_PROVIDER_ID"
     printf 'REC_HAD_RECOMMENDATION=%q\n' "$INSTALL_TX_HAD_RECOMMENDATION"
     printf 'REC_HAD_PLIST=%q\n' "$INSTALL_TX_HAD_PLIST"
+    printf 'REC_HAD_LEGACY_PLIST=%q\n' "$INSTALL_TX_HAD_LEGACY_PLIST"
     printf 'REC_HAD_WATCHDOG_DIR=%q\n' "$INSTALL_TX_HAD_WATCHDOG_DIR"
     printf 'REC_HAD_WATCHDOG_PLIST=%q\n' "$INSTALL_TX_HAD_WATCHDOG_PLIST"
+    printf 'REC_HAD_LEGACY_WATCHDOG_PLIST=%q\n' "$INSTALL_TX_HAD_LEGACY_WATCHDOG_PLIST"
     printf 'REC_HAD_MANIFEST=%q\n' "$INSTALL_TX_HAD_MANIFEST"
     printf 'REC_HAD_LIFECYCLE_STATE=%q\n' "$INSTALL_TX_HAD_LIFECYCLE_STATE"
     printf 'REC_SERVICE_WAS_ACTIVE=%q\n' "$INSTALL_TX_SERVICE_WAS_ACTIVE"
+    printf 'REC_LEGACY_SERVICE_WAS_ACTIVE=%q\n' "$INSTALL_TX_LEGACY_SERVICE_WAS_ACTIVE"
+    printf 'REC_LEGACY_PROVIDER_LABEL=%q\n' "$LEGACY_PROVIDER_LABEL"
+    printf 'REC_LEGACY_PLIST_PATH=%q\n' "$LEGACY_PLIST_PATH"
     printf 'REC_SERVICE_WAS_DISABLED=%q\n' "$INSTALL_TX_SERVICE_WAS_DISABLED"
     printf 'REC_WATCHDOG_WAS_ACTIVE=%q\n' "$INSTALL_TX_WATCHDOG_WAS_ACTIVE"
+    printf 'REC_LEGACY_WATCHDOG_WAS_ACTIVE=%q\n' "$INSTALL_TX_LEGACY_WATCHDOG_WAS_ACTIVE"
+    printf 'REC_LEGACY_WATCHDOG_LABEL=%q\n' "$LEGACY_WATCHDOG_LABEL"
+    printf 'REC_LEGACY_WATCHDOG_PLIST_PATH=%q\n' "$LEGACY_WATCHDOG_PLIST_PATH"
     printf 'REC_WATCHDOG_WAS_DISABLED=%q\n' "$INSTALL_TX_WATCHDOG_WAS_DISABLED"
     printf 'REC_BINARY_KIND=%q\n' "$INSTALL_TX_BINARY_KIND"
     printf 'REC_REFERRAL_REPLACE_INCUMBENT=%q\n' "$REFERRAL_REPLACE_INCUMBENT"
@@ -2244,6 +2256,14 @@ done
 # shellcheck disable=SC1091
 . "$RECOVERY_DIR/state.sh" || exit 70
 REC_PROVIDER_LABEL="${REC_PROVIDER_LABEL:-live.malibu.provider}"
+REC_LEGACY_PROVIDER_LABEL="${REC_LEGACY_PROVIDER_LABEL:-live.streamvc.macprovider}"
+REC_LEGACY_PLIST_PATH="${REC_LEGACY_PLIST_PATH:-$HOME/Library/LaunchAgents/live.streamvc.macprovider.plist}"
+REC_LEGACY_SERVICE_WAS_ACTIVE="${REC_LEGACY_SERVICE_WAS_ACTIVE:-0}"
+REC_HAD_LEGACY_PLIST="${REC_HAD_LEGACY_PLIST:-0}"
+REC_LEGACY_WATCHDOG_LABEL="${REC_LEGACY_WATCHDOG_LABEL:-live.streamvc.macprovider-watchdog}"
+REC_LEGACY_WATCHDOG_PLIST_PATH="${REC_LEGACY_WATCHDOG_PLIST_PATH:-$HOME/Library/LaunchAgents/live.streamvc.macprovider-watchdog.plist}"
+REC_LEGACY_WATCHDOG_WAS_ACTIVE="${REC_LEGACY_WATCHDOG_WAS_ACTIVE:-0}"
+REC_HAD_LEGACY_WATCHDOG_PLIST="${REC_HAD_LEGACY_WATCHDOG_PLIST:-0}"
 
 recovery_log() { printf '[macprovider-recovery] %s\n' "$*" >&2; }
 acquire_recovery_claim() {
@@ -4847,6 +4867,21 @@ if [ ! -e "$RECOVERY_DIR/cutover-started" ] && [ ! -L "$RECOVERY_DIR/cutover-sta
       "$REC_INSTALL_DIR/macprovider-cli" "$REC_BINARY_PATH" \
       || recovery_failed "pre-cutover provider service has an unexpected identity"
   fi
+  if [ "$REC_LEGACY_SERVICE_WAS_ACTIVE" -eq 1 ]; then
+    if ! launchctl print "gui/$REC_UID/$REC_LEGACY_PROVIDER_LABEL" >/dev/null 2>&1; then
+      [ "$REC_HAD_LEGACY_PLIST" -eq 1 ] \
+        || recovery_failed "the prior legacy provider service disappeared before cutover and no launchd plist was preserved"
+      paths_match "$RECOVERY_DIR/legacy-provider.plist" "$REC_LEGACY_PLIST_PATH" file \
+        || recovery_failed "the pre-cutover legacy provider plist changed after the recovery snapshot"
+      launchctl bootstrap "gui/$REC_UID" "$REC_LEGACY_PLIST_PATH" >/dev/null 2>&1 \
+        || recovery_failed "could not restore the unexpectedly inactive pre-cutover legacy provider service"
+      launchctl kickstart -k "gui/$REC_UID/$REC_LEGACY_PROVIDER_LABEL" >/dev/null 2>&1 \
+        || recovery_failed "could not start the unexpectedly inactive pre-cutover legacy provider service"
+    fi
+    service_identity_matches "$REC_LEGACY_PROVIDER_LABEL" "$REC_LEGACY_PLIST_PATH" \
+      "$REC_INSTALL_DIR/macprovider-cli" "$REC_BINARY_PATH" \
+      || recovery_failed "pre-cutover legacy provider service has an unexpected identity"
+  fi
   if [ "$REC_WATCHDOG_WAS_ACTIVE" -eq 1 ]; then
     if ! launchctl print "gui/$REC_UID/$REC_WATCHDOG_LABEL" >/dev/null 2>&1; then
       [ "$REC_HAD_WATCHDOG_PLIST" -eq 1 ] \
@@ -4861,6 +4896,21 @@ if [ ! -e "$RECOVERY_DIR/cutover-started" ] && [ ! -L "$RECOVERY_DIR/cutover-sta
     service_identity_matches "$REC_WATCHDOG_LABEL" "$REC_WATCHDOG_PLIST_PATH" \
       "$REC_WATCHDOG_DIR/macprovider-health-monitor" "$REC_WATCHDOG_DIR/watchdog.sh" \
       || recovery_failed "pre-cutover watchdog service has an unexpected identity"
+  fi
+  if [ "$REC_LEGACY_WATCHDOG_WAS_ACTIVE" -eq 1 ]; then
+    if ! launchctl print "gui/$REC_UID/$REC_LEGACY_WATCHDOG_LABEL" >/dev/null 2>&1; then
+      [ "$REC_HAD_LEGACY_WATCHDOG_PLIST" -eq 1 ] \
+        || recovery_failed "the prior legacy watchdog was active but no launchd plist was preserved"
+      paths_match "$RECOVERY_DIR/legacy-watchdog.plist" "$REC_LEGACY_WATCHDOG_PLIST_PATH" file \
+        || recovery_failed "the pre-cutover legacy watchdog plist changed after the recovery snapshot"
+      launchctl bootstrap "gui/$REC_UID" "$REC_LEGACY_WATCHDOG_PLIST_PATH" >/dev/null 2>&1 \
+        || recovery_failed "could not restore the pre-cutover legacy watchdog service"
+    fi
+    launchctl kickstart -k "gui/$REC_UID/$REC_LEGACY_WATCHDOG_LABEL" >/dev/null 2>&1 \
+      || recovery_failed "could not start the pre-cutover legacy watchdog service"
+    service_identity_matches "$REC_LEGACY_WATCHDOG_LABEL" "$REC_LEGACY_WATCHDOG_PLIST_PATH" \
+      "$REC_WATCHDOG_DIR/macprovider-health-monitor" "$REC_WATCHDOG_DIR/watchdog.sh" \
+      || recovery_failed "pre-cutover legacy watchdog service has an unexpected identity"
   fi
   recovery_log "Cutover never started; incumbent provider files and process were left untouched."
   exit 0
@@ -5032,8 +5082,10 @@ CONFIG_CANDIDATE="$RESTORE_STAGING_DIR/config.yaml"
 PROVIDER_ID_CANDIDATE="$RESTORE_STAGING_DIR/provider_id"
 RECOMMENDATION_CANDIDATE="$RESTORE_STAGING_DIR/last-recommendation.json"
 PLIST_CANDIDATE="$RESTORE_STAGING_DIR/provider.plist"
+LEGACY_PLIST_CANDIDATE="$RESTORE_STAGING_DIR/legacy-provider.plist"
 WATCHDOG_DIR_CANDIDATE="$RESTORE_STAGING_DIR/watchdog-dir"
 WATCHDOG_PLIST_CANDIDATE="$RESTORE_STAGING_DIR/watchdog.plist"
+LEGACY_WATCHDOG_PLIST_CANDIDATE="$RESTORE_STAGING_DIR/legacy-watchdog.plist"
 MANIFEST_CANDIDATE="$RESTORE_STAGING_DIR/install-manifest.json"
 FAILED_CURRENT_DIR="$RECOVERY_DIR/failed-current/$RUN_ID"
 
@@ -5057,11 +5109,17 @@ fi
 if [ "$REC_HAD_PLIST" -eq 1 ]; then
   stage_restore "$RECOVERY_DIR/provider.plist" "$PLIST_CANDIDATE" file || recovery_failed "could not stage and verify the previous launchd plist"
 fi
+if [ "$REC_HAD_LEGACY_PLIST" -eq 1 ]; then
+  stage_restore "$RECOVERY_DIR/legacy-provider.plist" "$LEGACY_PLIST_CANDIDATE" file || recovery_failed "could not stage and verify the previous legacy launchd plist"
+fi
 if [ "$REC_HAD_WATCHDOG_DIR" -eq 1 ]; then
   stage_restore "$RECOVERY_DIR/watchdog-dir" "$WATCHDOG_DIR_CANDIDATE" directory || recovery_failed "could not stage and verify the previous watchdog directory"
 fi
 if [ "$REC_HAD_WATCHDOG_PLIST" -eq 1 ]; then
   stage_restore "$RECOVERY_DIR/watchdog.plist" "$WATCHDOG_PLIST_CANDIDATE" file || recovery_failed "could not stage and verify the previous watchdog plist"
+fi
+if [ "$REC_HAD_LEGACY_WATCHDOG_PLIST" -eq 1 ]; then
+  stage_restore "$RECOVERY_DIR/legacy-watchdog.plist" "$LEGACY_WATCHDOG_PLIST_CANDIDATE" file || recovery_failed "could not stage and verify the previous legacy watchdog plist"
 fi
 if [ "$REC_HAD_MANIFEST" -eq 1 ]; then
   stage_restore "$RECOVERY_DIR/install-manifest.json" "$MANIFEST_CANDIDATE" file || recovery_failed "could not stage and verify the previous install manifest"
@@ -5111,6 +5169,12 @@ else
   fi
   service_loaded "$REC_PROVIDER_LABEL" && recovery_failed "provider service is active even though it was inactive before the failed install"
 fi
+if [ "$REC_LEGACY_SERVICE_WAS_ACTIVE" -eq 1 ]; then
+  [ "$REC_HAD_LEGACY_PLIST" -eq 1 ] || recovery_failed "the prior legacy provider service was active but no recoverable plist was preserved"
+  stop_loaded_service "$REC_LEGACY_PROVIDER_LABEL" "$REC_LEGACY_PLIST_PATH" \
+    "$REC_INSTALL_DIR/macprovider-cli" "$REC_BINARY_PATH" \
+    "the incumbent legacy provider service"
+fi
 if [ "$REC_WATCHDOG_WAS_ACTIVE" -eq 1 ]; then
   [ "$REC_HAD_WATCHDOG_PLIST" -eq 1 ] || recovery_failed "the prior watchdog was active but no recoverable plist was preserved"
   stop_loaded_service "$REC_WATCHDOG_LABEL" "$REC_WATCHDOG_PLIST_PATH" \
@@ -5123,6 +5187,12 @@ else
       "the transaction watchdog service"
   fi
   service_loaded "$REC_WATCHDOG_LABEL" && recovery_failed "watchdog service is active even though it was inactive before the failed install"
+fi
+if [ "$REC_LEGACY_WATCHDOG_WAS_ACTIVE" -eq 1 ]; then
+  [ "$REC_HAD_LEGACY_WATCHDOG_PLIST" -eq 1 ] || recovery_failed "the prior legacy watchdog was active but no recoverable plist was preserved"
+  stop_loaded_service "$REC_LEGACY_WATCHDOG_LABEL" "$REC_LEGACY_WATCHDOG_PLIST_PATH" \
+    "$REC_WATCHDOG_DIR/macprovider-health-monitor" "$REC_WATCHDOG_DIR/watchdog.sh" \
+    "the incumbent legacy watchdog service"
 fi
 # INSTALL_DIR intentionally permits unrelated support files. Stop all owners
 # first, then move the live directory to a stable private name before merging
@@ -5168,8 +5238,10 @@ else
     || recovery_failed "could not preserve the installer bootstrap identity through rollback"
 fi
 swap_restore provider.plist "$REC_PLIST_PATH" "$PLIST_CANDIDATE" "$REC_HAD_PLIST" || recovery_failed "could not restore the previous launchd plist"
+swap_restore legacy-provider.plist "$REC_LEGACY_PLIST_PATH" "$LEGACY_PLIST_CANDIDATE" "$REC_HAD_LEGACY_PLIST" || recovery_failed "could not restore the previous legacy launchd plist"
 swap_restore watchdog-dir "$REC_WATCHDOG_DIR" "$WATCHDOG_DIR_CANDIDATE" "$REC_HAD_WATCHDOG_DIR" || recovery_failed "could not restore the previous watchdog directory"
 swap_restore watchdog.plist "$REC_WATCHDOG_PLIST_PATH" "$WATCHDOG_PLIST_CANDIDATE" "$REC_HAD_WATCHDOG_PLIST" || recovery_failed "could not restore the previous watchdog plist"
+swap_restore legacy-watchdog.plist "$REC_LEGACY_WATCHDOG_PLIST_PATH" "$LEGACY_WATCHDOG_PLIST_CANDIDATE" "$REC_HAD_LEGACY_WATCHDOG_PLIST" || recovery_failed "could not restore the previous legacy watchdog plist"
 swap_restore install-manifest.json "$REC_MANIFEST_PATH" "$MANIFEST_CANDIDATE" "$REC_HAD_MANIFEST" || recovery_failed "could not restore the previous install manifest"
 # The lifecycle-state file is restored last so the transactional intermediate
 # state (rollback_in_progress) authored before recovery began stays observable
@@ -5198,9 +5270,19 @@ if [ "$REC_SERVICE_WAS_ACTIVE" -eq 1 ]; then
   service_identity_matches "$REC_PROVIDER_LABEL" "$REC_PLIST_PATH" \
     "$REC_INSTALL_DIR/macprovider-cli" "$REC_BINARY_PATH" \
     || recovery_failed "previous provider service has an unexpected identity"
+elif [ "$REC_LEGACY_SERVICE_WAS_ACTIVE" -eq 1 ]; then
+  [ "$REC_HAD_LEGACY_PLIST" -eq 1 ] || recovery_failed "previous legacy service was active but no previous plist was preserved"
+  launchctl bootstrap "gui/$REC_UID" "$REC_LEGACY_PLIST_PATH" >/dev/null 2>&1 || recovery_failed "could not bootstrap the previous legacy provider service"
+  launchctl kickstart -k "gui/$REC_UID/$REC_LEGACY_PROVIDER_LABEL" >/dev/null 2>&1 || recovery_failed "could not kickstart the previous legacy provider service"
+  service_identity_matches "$REC_LEGACY_PROVIDER_LABEL" "$REC_LEGACY_PLIST_PATH" \
+    "$REC_INSTALL_DIR/macprovider-cli" "$REC_BINARY_PATH" \
+    || recovery_failed "previous legacy provider service has an unexpected identity"
 else
   if launchctl print "gui/$REC_UID/$REC_PROVIDER_LABEL" >/dev/null 2>&1; then
     recovery_failed "provider service is active even though it was inactive before the failed install"
+  fi
+  if launchctl print "gui/$REC_UID/$REC_LEGACY_PROVIDER_LABEL" >/dev/null 2>&1; then
+    recovery_failed "legacy provider service is active even though it was inactive before the failed install"
   fi
 fi
 
@@ -5216,14 +5298,25 @@ if [ "$REC_WATCHDOG_WAS_ACTIVE" -eq 1 ]; then
   service_identity_matches "$REC_WATCHDOG_LABEL" "$REC_WATCHDOG_PLIST_PATH" \
     "$REC_WATCHDOG_DIR/macprovider-health-monitor" "$REC_WATCHDOG_DIR/watchdog.sh" \
     || recovery_failed "previous watchdog service has an unexpected identity"
+elif [ "$REC_LEGACY_WATCHDOG_WAS_ACTIVE" -eq 1 ]; then
+  [ "$REC_HAD_LEGACY_WATCHDOG_PLIST" -eq 1 ] || recovery_failed "previous legacy watchdog was active but no previous plist was preserved"
+  launchctl bootstrap "gui/$REC_UID" "$REC_LEGACY_WATCHDOG_PLIST_PATH" >/dev/null 2>&1 || recovery_failed "could not bootstrap the previous legacy watchdog service"
+  launchctl kickstart -k "gui/$REC_UID/$REC_LEGACY_WATCHDOG_LABEL" >/dev/null 2>&1 || recovery_failed "could not kickstart the previous legacy watchdog service"
+  service_identity_matches "$REC_LEGACY_WATCHDOG_LABEL" "$REC_LEGACY_WATCHDOG_PLIST_PATH" \
+    "$REC_WATCHDOG_DIR/macprovider-health-monitor" "$REC_WATCHDOG_DIR/watchdog.sh" \
+    || recovery_failed "previous legacy watchdog service has an unexpected identity"
 else
   if launchctl print "gui/$REC_UID/$REC_WATCHDOG_LABEL" >/dev/null 2>&1; then
     recovery_failed "watchdog service is active even though it was inactive before the failed install"
+  fi
+  if launchctl print "gui/$REC_UID/$REC_LEGACY_WATCHDOG_LABEL" >/dev/null 2>&1; then
+    recovery_failed "legacy watchdog service is active even though it was inactive before the failed install"
   fi
 fi
 
 if [ -s "$RECOVERY_DIR/manual-provider.json" ]; then
   [ "$REC_SERVICE_WAS_ACTIVE" -eq 0 ] || recovery_failed "manual provider record conflicts with an active prior launchd service"
+  [ "$REC_LEGACY_SERVICE_WAS_ACTIVE" -eq 0 ] || recovery_failed "manual provider record conflicts with an active prior legacy launchd service"
   mkdir -p "$REC_LOG_DIR" || recovery_failed "could not recreate the previous manual provider log directory"
   python3 - "$RECOVERY_DIR/manual-provider.json" "$REC_INSTALL_DIR/macprovider-cli" \
     "$REC_LOG_DIR/macprovider.out.log" "$REC_LOG_DIR/macprovider.err.log" \
@@ -5577,6 +5670,7 @@ capture_manual_provider_for_recovery() {
   manual_pid="$1"
   [ "$INSTALL_TX_ACTIVE" -eq 1 ] || die 70 "manual provider capture requires an active install transaction"
   [ "$INSTALL_TX_SERVICE_WAS_ACTIVE" -eq 0 ] || return 0
+  [ "$INSTALL_TX_LEGACY_SERVICE_WAS_ACTIVE" -eq 0 ] || return 0
   case "$manual_pid" in
     ''|*[!0-9]*) die 70 "manual provider pid is invalid" ;;
   esac
@@ -5849,14 +5943,44 @@ begin_install_transaction() {
   if [ "$INSTALL_TX_HAD_INSTALL_DIR" -eq 1 ] || [ "$INSTALL_TX_HAD_BINARY_PATH" -eq 1 ] || [ "$INSTALL_TX_HAD_MANIFEST" -eq 1 ]; then
     EXISTING_INSTALL_WAS_PRESENT=1
   fi
-  if launchctl print "gui/$UID/live.malibu.provider" >/dev/null 2>&1; then
+  if launchctl print "gui/$UID/$PROVIDER_LABEL" >/dev/null 2>&1; then
     INSTALL_TX_SERVICE_WAS_ACTIVE=1
   fi
-  if launchd_label_is_disabled "live.malibu.provider"; then
+  if launchctl print "gui/$UID/$LEGACY_PROVIDER_LABEL" >/dev/null 2>&1; then
+    INSTALL_TX_LEGACY_SERVICE_WAS_ACTIVE=1
+  fi
+  if [ "$INSTALL_TX_LEGACY_SERVICE_WAS_ACTIVE" -eq 1 ]; then
+    [ -f "$LEGACY_PLIST_PATH" ] \
+      || {
+        rm -rf -- "$recovery_staging" \
+          || die 70 "loaded legacy provider has no recoverable launchd plist and partial recovery data could not be removed"
+        die 70 "loaded legacy provider has no recoverable launchd plist; current install was not changed"
+      }
+    stage_install_tx_plist "$LEGACY_PLIST_PATH" "$recovery_staging/legacy-provider.plist" \
+      "$LEGACY_PROVIDER_LABEL" "$INSTALL_DIR/macprovider-cli" "$BINARY_PATH" \
+      || die 70 "could not stage and verify the previous legacy launchd plist; current install was not changed (partial recovery data: $recovery_staging)"
+    INSTALL_TX_HAD_LEGACY_PLIST=1
+  fi
+  if launchd_label_is_disabled "$PROVIDER_LABEL"; then
     INSTALL_TX_SERVICE_WAS_DISABLED=1
   fi
   if launchctl print "gui/$UID/$WATCHDOG_LABEL" >/dev/null 2>&1; then
     INSTALL_TX_WATCHDOG_WAS_ACTIVE=1
+  fi
+  if launchctl print "gui/$UID/$LEGACY_WATCHDOG_LABEL" >/dev/null 2>&1; then
+    INSTALL_TX_LEGACY_WATCHDOG_WAS_ACTIVE=1
+  fi
+  if [ "$INSTALL_TX_LEGACY_WATCHDOG_WAS_ACTIVE" -eq 1 ]; then
+    [ -f "$LEGACY_WATCHDOG_PLIST_PATH" ] \
+      || {
+        rm -rf -- "$recovery_staging" \
+          || die 70 "loaded legacy watchdog has no recoverable launchd plist and partial recovery data could not be removed"
+        die 70 "loaded legacy watchdog has no recoverable launchd plist; current install was not changed"
+      }
+    stage_install_tx_plist "$LEGACY_WATCHDOG_PLIST_PATH" "$recovery_staging/legacy-watchdog.plist" \
+      "$LEGACY_WATCHDOG_LABEL" "$WATCHDOG_PATH" "$WATCHDOG_DIR/watchdog.sh" \
+      || die 70 "could not stage and verify the previous legacy watchdog plist; current install was not changed (partial recovery data: $recovery_staging)"
+    INSTALL_TX_HAD_LEGACY_WATCHDOG_PLIST=1
   fi
   if launchd_label_is_disabled "$WATCHDOG_LABEL"; then
     INSTALL_TX_WATCHDOG_WAS_DISABLED=1
@@ -5869,10 +5993,20 @@ begin_install_transaction() {
       || die 70 "loaded provider has no recoverable launchd plist and partial recovery data could not be removed"
     die 70 "loaded provider has no recoverable launchd plist; current install was not changed"
   fi
+  if [ "$INSTALL_TX_LEGACY_SERVICE_WAS_ACTIVE" -eq 1 ] && [ "$INSTALL_TX_HAD_LEGACY_PLIST" -ne 1 ]; then
+    rm -rf -- "$recovery_staging" \
+      || die 70 "loaded legacy provider has no recoverable launchd plist and partial recovery data could not be removed"
+    die 70 "loaded legacy provider has no recoverable launchd plist; current install was not changed"
+  fi
   if [ "$INSTALL_TX_WATCHDOG_WAS_ACTIVE" -eq 1 ] && [ "$INSTALL_TX_HAD_WATCHDOG_PLIST" -ne 1 ]; then
     rm -rf -- "$recovery_staging" \
       || die 70 "loaded watchdog has no recoverable launchd plist and partial recovery data could not be removed"
     die 70 "loaded watchdog has no recoverable launchd plist; current install was not changed"
+  fi
+  if [ "$INSTALL_TX_LEGACY_WATCHDOG_WAS_ACTIVE" -eq 1 ] && [ "$INSTALL_TX_HAD_LEGACY_WATCHDOG_PLIST" -ne 1 ]; then
+    rm -rf -- "$recovery_staging" \
+      || die 70 "loaded legacy watchdog has no recoverable launchd plist and partial recovery data could not be removed"
+    die 70 "loaded legacy watchdog has no recoverable launchd plist; current install was not changed"
   fi
   write_install_recovery_artifacts "$recovery_staging" \
     || die 70 "could not create verified recovery instructions; current install was not changed (partial recovery data: $recovery_staging)"
@@ -5890,6 +6024,10 @@ begin_install_transaction() {
   if [ "$INSTALL_TX_WATCHDOG_WAS_ACTIVE" -eq 1 ]; then
     reclaim_launchd_service "$WATCHDOG_LABEL" \
       || die 70 "could not suspend the existing watchdog for the protected install transaction"
+  fi
+  if [ "$INSTALL_TX_LEGACY_WATCHDOG_WAS_ACTIVE" -eq 1 ]; then
+    reclaim_legacy_launchd_service "$LEGACY_WATCHDOG_LABEL" "$LEGACY_WATCHDOG_PLIST_PATH" "$WATCHDOG_PATH" "$WATCHDOG_DIR/watchdog.sh" \
+      || die 70 "could not suspend the existing legacy watchdog for the protected install transaction"
   fi
 }
 
@@ -6511,7 +6649,7 @@ ensure_port_free() {
       return
     fi
     log "Existing macprovider-cli holding port $PORT; stopping it for upgrade-in-place."
-    if [ "$INSTALL_TX_SERVICE_WAS_ACTIVE" -eq 0 ]; then
+    if [ "$INSTALL_TX_SERVICE_WAS_ACTIVE" -eq 0 ] && [ "$INSTALL_TX_LEGACY_SERVICE_WAS_ACTIVE" -eq 0 ]; then
       case "$holding_pids" in
         *$'\n'*) die 70 "multiple manual macprovider-cli processes hold port $PORT; refusing ambiguous recovery capture" ;;
       esac

--- a/phase3-binary/dist/test/install_launchd_migration.test.sh
+++ b/phase3-binary/dist/test/install_launchd_migration.test.sh
@@ -250,3 +250,85 @@ if grep -F 'launchctl bootout "gui/$REC_UID" "$REC_PLIST_PATH"' "$INSTALL_SH" >/
   exit 1
 fi
 echo "launchd migration reclaim ok"
+
+python3 - "$INSTALL_SH" > "$TMP/port-functions.sh" <<'PY'
+import sys
+
+names = [
+    "validate_port_value",
+    "ensure_port_free",
+    "reclaim_launchd_service",
+    "reclaim_legacy_launchd_service",
+]
+lines = open(sys.argv[1], encoding="utf-8").read().splitlines()
+for name in names:
+    for index, line in enumerate(lines):
+        if line != f"{name}() {{":
+            continue
+        depth = 0
+        while index < len(lines):
+            current = lines[index]
+            print(current)
+            depth += current.count("{") - current.count("}")
+            index += 1
+            if depth == 0:
+                break
+        break
+    else:
+        raise SystemExit(f"could not extract {name}")
+PY
+printf '%s\n' 'PROVIDER_LABEL="${PROVIDER_LABEL:-live.malibu.provider}"' >> "$TMP/port-functions.sh"
+printf '%s\n' 'LEGACY_PROVIDER_LABEL="${LEGACY_PROVIDER_LABEL:-live.streamvc.macprovider}"' >> "$TMP/port-functions.sh"
+printf '%s\n' 'LEGACY_PLIST_PATH="${LEGACY_PLIST_PATH:-$HOME/Library/LaunchAgents/live.streamvc.macprovider.plist}"' >> "$TMP/port-functions.sh"
+
+mkdir -p "$TMP/port-bin"
+cat > "$TMP/port-bin/lsof" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+case "$*" in
+  *"-d txt"*) printf 'p4242\nn%s/macprovider/macprovider-cli\n' "$HOME" ;;
+  *-t*)
+    if [ -f "$LSOF_T_SEEN" ]; then
+      exit 0
+    fi
+    : > "$LSOF_T_SEEN"
+    printf '4242\n'
+    ;;
+  *) printf "COMMAND PID\nmacprovider-cli 4242\n" ;;
+esac
+EOF
+chmod 0755 "$TMP/port-bin/lsof"
+: > "$TMP/legacy-upgrade.log"
+rm -f "$TMP/lsof-t-seen"
+HOME="$TMP/home" \
+  FUNCTION_PATH="$TMP/port-functions.sh" \
+  PATH="$TMP/port-bin:/usr/bin:/bin" \
+  LEGACY_UPGRADE_LOG="$TMP/legacy-upgrade.log" \
+  LSOF_T_SEEN="$TMP/lsof-t-seen" \
+  bash -c '
+    set -euo pipefail
+    die() { printf "ERR:%s\n" "$*" >&2; exit "$1"; }
+    log() { printf "LOG:%s\n" "$*" >&2; }
+    assert_install_lock_ownership() { :; }
+    capture_manual_provider_for_recovery() {
+      printf "captured\n" >> "$LEGACY_UPGRADE_LOG"
+      die 70 "manual capture should not run for a loaded legacy LaunchAgent"
+    }
+    DRY_RUN=0
+    PORT=18080
+    INSTALL_DIR="$HOME/macprovider"
+    BINARY_PATH="$HOME/.local/bin/macprovider-cli"
+    INSTALL_TX_SERVICE_WAS_ACTIVE=0
+    INSTALL_TX_LEGACY_SERVICE_WAS_ACTIVE=1
+    INSTALL_TX_ACTIVE=1
+    source "$FUNCTION_PATH"
+    reclaim_launchd_service() { printf "reclaim-current\n" >> "$LEGACY_UPGRADE_LOG"; }
+    reclaim_legacy_launchd_service() { printf "reclaim-legacy\n" >> "$LEGACY_UPGRADE_LOG"; }
+    ensure_port_free 1
+  '
+grep -Fx "reclaim-legacy" "$TMP/legacy-upgrade.log" >/dev/null
+if grep -Fx "captured" "$TMP/legacy-upgrade.log" >/dev/null; then
+  echo "legacy launchd upgrade captured a manual provider" >&2
+  exit 1
+fi
+echo "legacy launchd upgrade skips manual capture ok"

--- a/phase3-binary/dist/test/install_upgrade_evidence_rollback.test.sh
+++ b/phase3-binary/dist/test/install_upgrade_evidence_rollback.test.sh
@@ -574,19 +574,37 @@ case "$*" in
     service_file="$CASE_ROOT/recovery-service-active"
     disabled_file="$CASE_ROOT/recovery-service-disabled"
     ;;
+  *streamvc.macprovider-watchdog*)
+    service_file="$CASE_ROOT/legacy-watchdog-service-active"
+    disabled_file="$CASE_ROOT/legacy-watchdog-service-disabled"
+    ;;
   *macprovider-watchdog*|*malibu.provider-watchdog*)
     service_file="$CASE_ROOT/watchdog-service-active"
     disabled_file="$CASE_ROOT/watchdog-service-disabled"
+    ;;
+  *streamvc.macprovider*)
+    service_file="$CASE_ROOT/legacy-service-active"
+    disabled_file="$CASE_ROOT/legacy-service-disabled"
     ;;
 esac
 case "$1" in
   print)
     [ -f "$service_file" ] || exit 1
     case "$*" in
+      *streamvc.macprovider-watchdog*)
+        printf 'program = %s\npath = %s\n' \
+          "$CASE_ROOT/home/.local/share/macprovider-watchdog/macprovider-health-monitor" \
+          "$CASE_ROOT/home/Library/LaunchAgents/live.streamvc.macprovider-watchdog.plist"
+        ;;
       *macprovider-watchdog*|*malibu.provider-watchdog*)
         printf 'program = %s\npath = %s\n' \
           "$CASE_ROOT/home/.local/share/macprovider-watchdog/macprovider-health-monitor" \
           "$CASE_ROOT/home/Library/LaunchAgents/live.malibu.provider-watchdog.plist"
+        ;;
+      *streamvc.macprovider*)
+        printf 'program = %s\npath = %s\n' \
+          "$CASE_ROOT/home/macprovider/macprovider-cli" \
+          "$CASE_ROOT/home/Library/LaunchAgents/live.streamvc.macprovider.plist"
         ;;
       *)
         printf 'program = %s\npath = %s\n' \
@@ -908,6 +926,27 @@ run_case() {
     rm -f "$root/service-active"
     start_manual_fixture "$root"
   fi
+  if [ "$prior_state" = "legacy" ]; then
+    rm -f "$root/service-active" "$root/watchdog-service-active"
+    : > "$root/legacy-service-active"
+    : > "$root/legacy-watchdog-service-active"
+    printf '%s\n' \
+      '<?xml version="1.0" encoding="UTF-8"?>' \
+      '<plist version="1.0"><dict>' \
+      '<key>Label</key><string>live.streamvc.macprovider</string>' \
+      '<key>ProgramArguments</key><array>' \
+      "<string>$root/home/macprovider/macprovider-cli</string>" \
+      '</array><key>Comment</key><string>old-legacy-provider-plist</string>' \
+      '</dict></plist>' > "$root/home/Library/LaunchAgents/live.streamvc.macprovider.plist"
+    printf '%s\n' \
+      '<?xml version="1.0" encoding="UTF-8"?>' \
+      '<plist version="1.0"><dict>' \
+      '<key>Label</key><string>live.streamvc.macprovider-watchdog</string>' \
+      '<key>ProgramArguments</key><array>' \
+      "<string>$root/home/.local/share/macprovider-watchdog/macprovider-health-monitor</string>" \
+      '</array><key>Comment</key><string>old-legacy-watchdog-plist</string>' \
+      '</dict></plist>' > "$root/home/Library/LaunchAgents/live.streamvc.macprovider-watchdog.plist"
+  fi
   if [ "$install_phase" = "credential-self-test" ]; then
     printf 'model: old-model\n' > "$root/home/.config/macprovider/config.yaml"
   elif [ "$install_phase" = "ordinary-token-self-test" ]; then
@@ -973,20 +1012,24 @@ run_case() {
       INSTALL_TX_COMMITTED=0
       INSTALL_TX_BACKUP=""
       INSTALL_TX_SERVICE_WAS_ACTIVE=0
+      INSTALL_TX_LEGACY_SERVICE_WAS_ACTIVE=0
       INSTALL_TX_HAD_INSTALL_DIR=0
       INSTALL_TX_HAD_BINARY_PATH=0
       INSTALL_TX_HAD_CONFIG=0
       INSTALL_TX_HAD_PROVIDER_ID=0
       INSTALL_TX_HAD_RECOMMENDATION=0
       INSTALL_TX_HAD_PLIST=0
+      INSTALL_TX_HAD_LEGACY_PLIST=0
       INSTALL_TX_HAD_WATCHDOG_DIR=0
       INSTALL_TX_HAD_WATCHDOG_PLIST=0
+      INSTALL_TX_HAD_LEGACY_WATCHDOG_PLIST=0
       INSTALL_TX_HAD_MANIFEST=0
       INSTALL_TX_HAD_LIFECYCLE_STATE=0
       INSTALL_TX_LIFECYCLE_SNAPSHOT_WRITER=""
       INSTALL_TX_LIFECYCLE_SNAPSHOT_OPERATOR_PAUSED=false
       INSTALL_TX_SERVICE_WAS_DISABLED=0
       INSTALL_TX_WATCHDOG_WAS_ACTIVE=0
+      INSTALL_TX_LEGACY_WATCHDOG_WAS_ACTIVE=0
       INSTALL_TX_WATCHDOG_WAS_DISABLED=0
       INSTALL_TX_ROLLING_BACK=0
       INSTALL_TX_BINARY_KIND="symlink"
@@ -1142,6 +1185,9 @@ MANUAL
       && [ "$case_rc" -ne 9 ]; then
     cat "$root/stderr.log" >&2
   fi
+  if [ "$case_name" = "legacy_loaded_rollback" ] && [ "$case_rc" -ne 9 ]; then
+    cat "$root/stderr.log" >&2
+  fi
 }
 
 # Assert the non-lifecycle installation was rolled back. Cases whose snapshot is
@@ -1202,6 +1248,34 @@ assert_old_install "$TMP/success"
 [ -z "$(recovery_dir "$TMP/success")" ]
 grep -F 'bootstrap gui/' "$TMP/success/launchctl.log" >/dev/null
 grep -F 'kickstart -k gui/' "$TMP/success/launchctl.log" >/dev/null
+
+# A loaded live.streamvc.macprovider LaunchAgent is an owned upgrade, not a
+# manual process. Rollback after cutover must restore that legacy label.
+run_case legacy_loaded_rollback "" "" "" mutation legacy
+[ "$(cat "$TMP/legacy_loaded_rollback/rc")" -eq 9 ]
+assert_old_install "$TMP/legacy_loaded_rollback"
+[ -f "$TMP/legacy_loaded_rollback/legacy-service-active" ]
+[ -f "$TMP/legacy_loaded_rollback/legacy-watchdog-service-active" ]
+[ ! -f "$TMP/legacy_loaded_rollback/service-active" ]
+[ ! -f "$TMP/legacy_loaded_rollback/watchdog-service-active" ]
+grep -F 'old-legacy-provider-plist' \
+  "$TMP/legacy_loaded_rollback/home/Library/LaunchAgents/live.streamvc.macprovider.plist" >/dev/null
+grep -F 'old-legacy-watchdog-plist' \
+  "$TMP/legacy_loaded_rollback/home/Library/LaunchAgents/live.streamvc.macprovider-watchdog.plist" >/dev/null
+grep -F "bootstrap gui/$(id -u) $TMP/legacy_loaded_rollback/home/Library/LaunchAgents/live.streamvc.macprovider.plist" \
+  "$TMP/legacy_loaded_rollback/launchctl.log" >/dev/null
+grep -F "kickstart -k gui/$(id -u)/live.streamvc.macprovider" \
+  "$TMP/legacy_loaded_rollback/launchctl.log" >/dev/null
+grep -F "bootstrap gui/$(id -u) $TMP/legacy_loaded_rollback/home/Library/LaunchAgents/live.streamvc.macprovider-watchdog.plist" \
+  "$TMP/legacy_loaded_rollback/launchctl.log" >/dev/null
+grep -F "kickstart -k gui/$(id -u)/live.streamvc.macprovider-watchdog" \
+  "$TMP/legacy_loaded_rollback/launchctl.log" >/dev/null
+legacy_recovery="$(recovery_dir "$TMP/legacy_loaded_rollback" || true)"
+if [ -n "$legacy_recovery" ] && [ -f "$legacy_recovery/manual-provider.json" ]; then
+  echo "legacy launchd rollback captured a manual provider" >&2
+  exit 1
+fi
+[ -z "$(recovery_dir "$TMP/legacy_loaded_rollback")" ]
 
 # (a) Lifecycle-state rollback restores the exact prior contents byte-for-byte.
 # The mutation phase overwrote the file with an installer-written

--- a/scripts/select_public_discovery_transport.py
+++ b/scripts/select_public_discovery_transport.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+"""Select the highest public append-only discovery transport from a GitHub listing.
+
+Exit 0: the expected transport is the immutable public head.
+Exit 2: the listing has not yet caught up; the caller should retry.
+Exit 1: the listing shows a different or invalid head; fail closed.
+"""
+
+from __future__ import annotations
+
+import json
+import pathlib
+import re
+import sys
+
+
+RETRY = 2
+FAIL = 1
+
+
+def fail(message: str, code: int = FAIL) -> int:
+    print(message, file=sys.stderr)
+    return code
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) != 6:
+        return fail(
+            "usage: select_public_discovery_transport.py "
+            "RELEASES_JSON EXPECTED_TRANSPORT COMMIT REPOSITORY RELEASE_OUT ASSETS_OUT"
+        )
+    releases_path, expected_transport, commit, repository, release_output, assets_output = argv
+    expected_match = re.fullmatch(r"release-discovery-v1-([1-9][0-9]*)", expected_transport)
+    if expected_match is None:
+        return fail("invalid expected discovery transport tag")
+    expected_sequence = int(expected_match.group(1))
+    releases = json.loads(pathlib.Path(releases_path).read_text(encoding="utf-8"))
+    if not isinstance(releases, list):
+        return fail("public discovery listing is not an array")
+    candidates = []
+    expected_release = None
+    for release in releases:
+        if not isinstance(release, dict):
+            continue
+        tag_name = str(release.get("tag_name", ""))
+        match = re.fullmatch(r"release-discovery-v1-([1-9][0-9]*)", tag_name)
+        if match is None:
+            continue
+        sequence = int(match.group(1))
+        candidates.append((sequence, release))
+        if tag_name == expected_transport:
+            expected_release = release
+    if not candidates:
+        return fail("public discovery listing has no append-only transport", RETRY)
+    head_sequence, head = max(candidates, key=lambda item: item[0])
+    if expected_release is None:
+        if head_sequence < expected_sequence:
+            return fail("highest public discovery transport is not the promoted target", RETRY)
+        return fail("highest public discovery transport is not the promoted target")
+    if head.get("tag_name") != expected_transport:
+        return fail("highest public discovery transport is not the promoted target")
+    if expected_release.get("draft") is not False:
+        return fail("public discovery transport is not an immutable prerelease", RETRY)
+    if (
+        expected_release.get("target_commitish") != commit
+        or expected_release.get("prerelease") is not True
+        or expected_release.get("immutable") is not True
+    ):
+        return fail("public discovery transport is not an immutable prerelease")
+    required = {
+        "compatibility-artifact-index.json",
+        "macprovider-release-discovery.json",
+        "macprovider-release-discovery.json.sig",
+    }
+    rows = []
+    for name in sorted(required):
+        matches = [asset for asset in expected_release.get("assets", []) if asset.get("name") == name]
+        if len(matches) != 1:
+            return fail(f"public release does not contain exactly one {name}")
+        url = matches[0].get("browser_download_url")
+        expected_url = f"https://github.com/{repository}/releases/download/{expected_transport}/{name}"
+        if url != expected_url:
+            return fail(f"noncanonical public asset URL for {name}")
+        rows.append(f"{name}\t{url}\n")
+    pathlib.Path(release_output).write_text(json.dumps(expected_release), encoding="utf-8")
+    pathlib.Path(assets_output).write_text("".join(rows), encoding="ascii")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/scripts/test-install-launchd-enable.sh
+++ b/scripts/test-install-launchd-enable.sh
@@ -33,7 +33,11 @@ require_line 'Would enable launchd service: launchctl enable gui/$UID/$PROVIDER_
 require_line 'Installing as a background launchd service.' "automatic launchd install message"
 require_line 'MACPROVIDER_NO_LAUNCHD=1 expert/debug override' "explicit no-launchd escape hatch"
 require_line 'holding_executable="$(lsof -a -p "$holding_pid" -d txt -Fn' "listener executable identity lookup"
-require_line 'if [ "$holding_executable" = "$INSTALL_DIR/macprovider-cli" ]; then' "exact installed provider process recognition"
+require_line 'if [ "$INSTALL_TX_SERVICE_WAS_ACTIVE" -eq 0 ] && [ "$INSTALL_TX_LEGACY_SERVICE_WAS_ACTIVE" -eq 0 ]; then' \
+  "legacy launchd upgrades skip manual-process capture"
+require_line 'launchctl print "gui/$UID/$LEGACY_PROVIDER_LABEL"' "legacy LaunchAgent snapshot"
+require_line 'could not bootstrap the previous legacy provider service' "legacy LaunchAgent rollback restore"
+require_line 'could not bootstrap the previous legacy watchdog service' "legacy watchdog rollback restore"
 require_line '<key>MACPROVIDER_CONFIG</key>' "launchd absolute config env key"
 require_line '<string>$config_path</string>' "launchd absolute config env value"
 require_line 'Model download ${bar}' "model download progress bar"

--- a/scripts/test-select-public-discovery-transport.sh
+++ b/scripts/test-select-public-discovery-transport.sh
@@ -1,0 +1,150 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd -P)"
+selector="$root/scripts/select_public_discovery_transport.py"
+verifier="$root/scripts/verify-anonymous-release-discovery.sh"
+work="$(mktemp -d "${TMPDIR:-/tmp}/select-public-discovery-transport.XXXXXX")"
+trap 'rm -rf "$work"' EXIT
+
+fail() {
+  printf '[test-select-public-discovery-transport] ERROR: %s\n' "$*" >&2
+  exit 1
+}
+
+repository=Augustas11/macprovider
+commit=896359c7b0fc871d4ea372517f4de47ec19433bd
+expected=release-discovery-v1-2110220523208705
+older=release-discovery-v1-2103892340310017
+newer=release-discovery-v1-2110220523208706
+
+write_release() {
+  python3 - "$1" "$2" "$3" "$4" "$5" "$commit" "$repository" <<'PY'
+import json
+import pathlib
+import sys
+
+path, tag, draft, prerelease, immutable, commit, repository = sys.argv[1:]
+assets = [
+    {
+        "name": name,
+        "browser_download_url": f"https://github.com/{repository}/releases/download/{tag}/{name}",
+    }
+    for name in (
+        "compatibility-artifact-index.json",
+        "macprovider-release-discovery.json",
+        "macprovider-release-discovery.json.sig",
+    )
+]
+pathlib.Path(path).write_text(
+    json.dumps(
+        {
+            "tag_name": tag,
+            "target_commitish": commit,
+            "draft": draft == "true",
+            "prerelease": prerelease == "true",
+            "immutable": immutable == "true",
+            "assets": assets,
+        }
+    ),
+    encoding="utf-8",
+)
+PY
+}
+
+run_selector() {
+  python3 "$selector" \
+    "$1" \
+    "$expected" \
+    "$commit" \
+    "$repository" \
+    "$work/release.json" \
+    "$work/assets.tsv"
+}
+
+write_release "$work/expected.json" "$expected" false true true
+write_release "$work/older.json" "$older" false true true
+write_release "$work/newer.json" "$newer" false true true
+write_release "$work/draft.json" "$expected" true true true
+
+python3 - "$work/stale.json" "$work/older.json" <<'PY'
+import json
+import pathlib
+import sys
+pathlib.Path(sys.argv[1]).write_text(
+    json.dumps([json.loads(pathlib.Path(sys.argv[2]).read_text(encoding="utf-8"))]),
+    encoding="utf-8",
+)
+PY
+python3 - "$work/caught-up.json" "$work/older.json" "$work/expected.json" <<'PY'
+import json
+import pathlib
+import sys
+pathlib.Path(sys.argv[1]).write_text(
+    json.dumps(
+        [
+            json.loads(pathlib.Path(sys.argv[2]).read_text(encoding="utf-8")),
+            json.loads(pathlib.Path(sys.argv[3]).read_text(encoding="utf-8")),
+        ]
+    ),
+    encoding="utf-8",
+)
+PY
+python3 - "$work/newer-head.json" "$work/expected.json" "$work/newer.json" <<'PY'
+import json
+import pathlib
+import sys
+pathlib.Path(sys.argv[1]).write_text(
+    json.dumps(
+        [
+            json.loads(pathlib.Path(sys.argv[2]).read_text(encoding="utf-8")),
+            json.loads(pathlib.Path(sys.argv[3]).read_text(encoding="utf-8")),
+        ]
+    ),
+    encoding="utf-8",
+)
+PY
+python3 - "$work/draft-head.json" "$work/draft.json" <<'PY'
+import json
+import pathlib
+import sys
+pathlib.Path(sys.argv[1]).write_text(
+    json.dumps([json.loads(pathlib.Path(sys.argv[2]).read_text(encoding="utf-8"))]),
+    encoding="utf-8",
+)
+PY
+python3 - "$work/empty.json" <<'PY'
+import pathlib
+import sys
+pathlib.Path(sys.argv[1]).write_text("[]\n", encoding="utf-8")
+PY
+
+set +e
+run_selector "$work/stale.json"
+stale_status=$?
+run_selector "$work/empty.json"
+empty_status=$?
+run_selector "$work/draft-head.json"
+draft_status=$?
+run_selector "$work/newer-head.json"
+newer_status=$?
+run_selector "$work/caught-up.json"
+ok_status=$?
+set -e
+
+[ "$stale_status" -eq 2 ] || fail "stale listing must be retryable, got $stale_status"
+[ "$empty_status" -eq 2 ] || fail "empty listing must be retryable, got $empty_status"
+[ "$draft_status" -eq 2 ] || fail "draft head must be retryable, got $draft_status"
+[ "$newer_status" -eq 1 ] || fail "newer competing head must fail closed, got $newer_status"
+[ "$ok_status" -eq 0 ] || fail "caught-up listing must succeed, got $ok_status"
+grep -Fqx "$expected" <<<"$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1]))["tag_name"])' "$work/release.json")" \
+  || fail "successful selection did not persist the expected transport"
+
+grep -Fq 'scripts/select_public_discovery_transport.py' "$verifier" \
+  || fail "anonymous verifier must use the shared listing selector"
+grep -Fq 'releases?per_page=100' "$verifier" \
+  || fail "anonymous verifier must page enough public releases to observe the head"
+grep -Fq 'MACPROVIDER_DISCOVERY_LISTING_ATTEMPTS' "$verifier" \
+  || fail "anonymous verifier must retry a lagging public listing"
+
+printf '[test-select-public-discovery-transport] ok\n'

--- a/scripts/verify-anonymous-release-discovery.sh
+++ b/scripts/verify-anonymous-release-discovery.sh
@@ -28,46 +28,32 @@ curl_args=(
   --connect-timeout 20 --max-time 240 --retry 5 --retry-delay 2
 )
 api="https://api.github.com/repos/$repository"
-curl "${curl_args[@]}" "$api/releases?per_page=20" -o "$work/releases.json"
-
-python3 - "$work/releases.json" "$transport_tag" "$target_commit" "$repository" "$work/release.json" "$work/assets.tsv" <<'PY'
-import json
-import pathlib
-import re
-import sys
-
-releases_path, expected_transport, commit, repository, release_output, assets_output = sys.argv[1:]
-releases = json.loads(pathlib.Path(releases_path).read_text(encoding="utf-8"))
-candidates = []
-for release in releases:
-    match = re.fullmatch(r"release-discovery-v1-([1-9][0-9]*)", str(release.get("tag_name", "")))
-    if match:
-        candidates.append((int(match.group(1)), release))
-if not candidates:
-    raise SystemExit("public discovery listing has no append-only transport")
-_, release = max(candidates, key=lambda item: item[0])
-if release.get("tag_name") != expected_transport or release.get("target_commitish") != commit:
-    raise SystemExit("highest public discovery transport is not the promoted target")
-if release.get("draft") is not False or release.get("prerelease") is not True or release.get("immutable") is not True:
-    raise SystemExit("public discovery transport is not an immutable prerelease")
-required = {
-    "compatibility-artifact-index.json",
-    "macprovider-release-discovery.json",
-    "macprovider-release-discovery.json.sig",
-}
-rows = []
-for name in sorted(required):
-    matches = [asset for asset in release.get("assets", []) if asset.get("name") == name]
-    if len(matches) != 1:
-        raise SystemExit(f"public release does not contain exactly one {name}")
-    url = matches[0].get("browser_download_url")
-    expected = f"https://github.com/{repository}/releases/download/{expected_transport}/{name}"
-    if url != expected:
-        raise SystemExit(f"noncanonical public asset URL for {name}")
-    rows.append(f"{name}\t{url}\n")
-pathlib.Path(release_output).write_text(json.dumps(release), encoding="utf-8")
-pathlib.Path(assets_output).write_text("".join(rows), encoding="ascii")
-PY
+listing_attempts="${MACPROVIDER_DISCOVERY_LISTING_ATTEMPTS:-15}"
+listing_retry_seconds="${MACPROVIDER_DISCOVERY_LISTING_RETRY_SECONDS:-2}"
+[[ "$listing_attempts" =~ ^[1-9][0-9]*$ ]] || die "invalid discovery listing attempt budget"
+[[ "$listing_retry_seconds" =~ ^[1-9][0-9]*$ ]] || die "invalid discovery listing retry interval"
+listing_attempt=1
+while true; do
+  curl "${curl_args[@]}" "$api/releases?per_page=100" -o "$work/releases.json"
+  set +e
+  python3 "$root/scripts/select_public_discovery_transport.py" \
+    "$work/releases.json" \
+    "$transport_tag" \
+    "$target_commit" \
+    "$repository" \
+    "$work/release.json" \
+    "$work/assets.tsv"
+  listing_status=$?
+  set -e
+  if [ "$listing_status" -eq 0 ]; then
+    break
+  fi
+  if [ "$listing_status" -ne 2 ] || [ "$listing_attempt" -ge "$listing_attempts" ]; then
+    die "highest public discovery transport is not the promoted target"
+  fi
+  listing_attempt=$((listing_attempt + 1))
+  sleep "$listing_retry_seconds"
+done
 
 while IFS=$'\t' read -r name url; do
   curl "${curl_args[@]}" "$url" -o "$work/$name"


### PR DESCRIPTION
## Summary
- Treat a loaded `live.streamvc.macprovider` / `live.streamvc.macprovider-watchdog` LaunchAgent as an owned upgrade: snapshot, skip manual-provider capture, reclaim, and restore that label on rollback instead of fail-closing with installer exit 70.
- Wait for GitHub's public `/releases` listing to catch a just-published append-only discovery transport; retry only listing lag, fail closed on a competing newer head.
- Codex lanes on the full working-tree diff: code/security/architect all PASS (0 CRITICAL / 0 HIGH / 0 MEDIUM). Carried security LOW: `reclaim_legacy_launchd_service` still lacks the current-label snapshot-before-bootout guard.

## Test plan
- [x] `bash scripts/test-select-public-discovery-transport.sh`
- [x] `bash scripts/test-install-launchd-enable.sh`
- [x] `bash phase3-binary/dist/test/install_launchd_migration.test.sh`
- [x] `bash phase3-binary/dist/test/install_upgrade_evidence_rollback.test.sh`
- [x] `bash phase3-binary/dist/test/provider_upgrade_transaction.test.sh`

SPEC-GOVERNANCE-DECLARATION-BEGIN
{
  "schema_version": "spec-pr-governance-v1",
  "behavior_change": "yes",
  "contract_change": "none",
  "specs": ["SPEC-020"],
  "requirements": ["SPEC-020-R001"],
  "authority_domains": ["provider-autoupdate"],
  "arbitration": ["CODE_BUG"],
  "tests": ["scripts/test-select-public-discovery-transport.sh", "scripts/test-install-launchd-enable.sh", "phase3-binary/dist/test/install_launchd_migration.test.sh", "phase3-binary/dist/test/install_upgrade_evidence_rollback.test.sh"],
  "journeys": ["not-required"]
}
SPEC-GOVERNANCE-DECLARATION-END
