### PR TITLE
SPEC-042 R004/R010: pool provider binary-version floor (handshake provider half)

### DIFF
--- a/audits/2026-08-19/AUDIT_POOL_BINARY_FLOOR_ARCHITECT_PROMPT.md
+++ b/audits/2026-08-19/AUDIT_POOL_BINARY_FLOOR_ARCHITECT_PROMPT.md
@@ -1,0 +1,40 @@
+# Codex audit — SPEC-042 pool binary-version floor — ARCHITECT lane
+
+Judge whether this slice is the right shape and composes correctly with the
+merged SPEC-042 Layer 2 stack. Review the FULL slice diff as it will land.
+
+Diff: `audits/2026-08-19/pool-binary-floor-fulldiff.patch`. Read changed files.
+Spec: `specs/SPEC-042-pool-control-plane.md` (R004, R010, R005). Design:
+`docs/design/spec-042-v0.1-slice-pool-binary-floor.md`.
+
+## Context
+This completes the R010 positive capability handshake end-to-end. The gateway
+already verifies the coordinator advertises pool support (#1076); this adds the
+provider half inside the coordinator (the gateway can't see the selected
+provider). It reuses the provider's existing `binary_version` handshake rather
+than adding a dedicated `pool_support_version` field (Option A). Deferred: a
+dedicated capability field decoupled from binary version; the signed manifest
+(R001) as the floor source; other R004 predicates (encrypted-leg, attestation).
+
+## Focus (Critical/High/Medium/Low/Info + rationale)
+1. Boundary: is enforcing the floor inside the coordinator's eligibility gate the
+   right layer? Is keying "pool support" off `binary_version` a sound proxy for
+   the R010 "provider advertises pool support at the required version", or does
+   it conflate concerns in a way that will hurt later?
+2. Floor home: per-pool `minBinaryVersion` in the trustpool snapshot (rather than
+   a global option). Correct call for consistency with the generation fence and
+   R004's per-pool model? Any drift risk?
+3. Composition: does the new gate slot cleanly alongside the existing
+   membership/model-floor/receipt-key gates without double-counting or reordering
+   hazards? Is the envelope precedence (pool_binary_too_old vs
+   pool_no_eligible_member vs model_version_floor) sensible?
+4. Scope discipline: are the deferrals sound and fail-closed (each defaults to
+   no-floor = inert, which is fail-OPEN for the binary dimension when a pool is
+   operated without setting a floor)? Is "floor unset = inert" the right default,
+   or should operating a pool require a floor? Flag if this is a trap for the
+   enable path.
+5. Default-off / byte-identical: any global-traffic or latency change; any
+   abstraction that won't survive the manifest (R001) or a dedicated capability
+   field later.
+
+Rank by severity with rationale. Report 0 findings if architecturally sound.

--- a/audits/2026-08-19/AUDIT_POOL_BINARY_FLOOR_CODE_PROMPT.md
+++ b/audits/2026-08-19/AUDIT_POOL_BINARY_FLOOR_CODE_PROMPT.md
@@ -1,0 +1,33 @@
+# Codex audit — SPEC-042 pool binary-version floor — CODE lane
+
+Money-path/tenant-isolation change to the MacProvider coordinator (phase4, Go).
+Review the FULL slice diff as it will land.
+
+Diff: `audits/2026-08-19/pool-binary-floor-fulldiff.patch` (base = the commit
+before this slice; the slice is one commit on current main). Read the changed
+source in the worktree. Design: `docs/design/spec-042-v0.1-slice-pool-binary-floor.md`.
+Spec: `specs/SPEC-042-pool-control-plane.md` (R004 predicates, R010 taxonomy +
+positive capability handshake, R005 fence).
+
+## What the slice does
+Completes the R010 handshake provider half: a pool request must never be routed
+to a pool member whose `binary_version` is below the pool's configured minimum.
+Under-version members are excluded on every dispatch-authorizing path; if none
+remain the request fails closed with `pool_binary_too_old` (503, non-retryable),
+never spilling to an under-version or global provider. Coordinator-only; reuses
+the provider's existing `binary_version` handshake.
+
+Key sites:
+- `internal/trustpool/registry.go` — per-pool `minBinaryVersion`, `Snapshot.MinBinaryVersion`, `SetMinBinaryVersion` (bumps generation).
+- `internal/routing/filter.go` — `ReasonPoolBinaryTooOld` + `ProviderMeetsPoolBinaryFloor` gate (after `ProviderInPool`, before model gates).
+- `internal/buyer/server.go` — `eligibilityCtx`/`forwardState` carry the floor; the gate is re-applied on the pinned-session, pinned/self-route, slot-queue-enter, and slot-queue-poll by-hand paths; `poolBinaryFloorMet` helper; envelope + error registration.
+
+## Focus (Critical/High/Medium/Low/Info, file:line + concrete failing scenario)
+1. Correctness of `poolBinaryFloorMet`: any version pair (empty, `v`-prefixed, malformed, extra components, floor==provider) where the verdict is WRONG — a below-floor member served, or an at/above-floor member wrongly excluded. Confirm empty/unparseable is fail-safe (excluded) and floor=="" is a strict no-op.
+2. **Path coverage** — is the floor applied on EVERY dispatch-authorizing path, matching the isolation gate exactly? Any path (retry, failover, sticky, preflight replacement, mid-request provider loss) where an under-version member can still be dispatched. A miss here is the whole point of the slice.
+3. Snapshot consistency: floor read from the SAME snapshot as members/generation; `SetMinBinaryVersion` bumps generation so a raised floor invalidates fenced reservations. Any TOCTOU where the floor and membership diverge.
+4. Error taxonomy: `pool_binary_too_old` 503/non-retryable matches the R010 table; registered so the AST guard passes; envelope precedence vs `pool_no_eligible_member` and the model floor is correct (member-but-under-version vs no-member vs model-floor); membership dominates (a non-member is never reported too-old).
+5. Any nil-deref, concurrency issue (registry lock), or global/poolless behavior change introduced.
+6. Test adequacy: do the tests actually prove non-dispatch on the fail-closed paths and byte-identical global/floorless, or pass vacuously?
+
+Be adversarial and concrete. State the exact input and wrong result for any finding. Report 0 findings if clean.

--- a/audits/2026-08-19/AUDIT_POOL_BINARY_FLOOR_SECURITY_PROMPT.md
+++ b/audits/2026-08-19/AUDIT_POOL_BINARY_FLOOR_SECURITY_PROMPT.md
@@ -1,0 +1,40 @@
+# Codex audit — SPEC-042 pool binary-version floor — SECURITY lane
+
+Tenant-isolation change on a money/security path. The product promise: a pool
+request is never served by a pool-blind (under-version) provider. Review the
+FULL slice diff as it will land.
+
+Diff: `audits/2026-08-19/pool-binary-floor-fulldiff.patch`. Read changed files in
+the worktree. Spec: `specs/SPEC-042-pool-control-plane.md` (R004 fail-closed
+predicates, R010 positive capability handshake + taxonomy, R005 generation
+fence). Design: `docs/design/spec-042-v0.1-slice-pool-binary-floor.md`.
+
+## Threat model to attack
+- A buyer / operator tries to get a pool request served by a member whose binary
+  is below the pool's floor (mixed-binary rollout spill): via the ordinary
+  filter, a hard pin (session/provider header), or the slot queue / a same-ID
+  reconnect after selection.
+- A revocation-style race: floor raised mid-flight; can an in-flight reservation
+  fenced to the old generation still dispatch to a now-under-version member?
+- An empty or crafted `binary_version` that bypasses the floor (Compare returns
+  ok=false — is that treated as excluded everywhere, or does any path fail open?).
+- Does `pool_binary_too_old` leak anything it shouldn't? (It is authorized-only
+  visibility — returned only for a credential-authorized pool selection.)
+
+## Focus (Critical/High/Medium/Low/Info, file:line + concrete exploit)
+1. Fail-closed completeness: is EVERY dispatch-authorizing path gated (filter,
+   pinned session, pinned/self-route, slot-queue enter, slot-queue poll, and any
+   retry/failover re-dispatch)? Give a concrete path if one is missed.
+2. Fail-open on malformed input: empty/`v`-prefixed/garbage `binary_version`
+   while a floor is in force MUST be excluded. Any path returning true on
+   Compare-not-ok?
+3. Snapshot/fence integrity: floor + members + generation captured atomically;
+   `SetMinBinaryVersion` bumps generation; the fence rejects a stale-generation
+   dispatch. Any window where a raised floor is not enforced.
+4. No global/poolless regression: the gate is a strict no-op when poolID=="" or
+   floor=="". Confirm no behavior change for non-pool traffic.
+5. Any secret/PII logged; any concurrency hazard on the trustpool lock.
+
+Give concrete exploit steps for any finding. The go 1.26 stdlib toolchain
+finding (if govulncheck flags it) is pre-existing (#1055), not a slice defect —
+note but do not score it. Report 0 if genuinely clean.

--- a/audits/2026-08-19/pool-binary-floor-fulldiff.patch
+++ b/audits/2026-08-19/pool-binary-floor-fulldiff.patch
@@ -1,0 +1,772 @@
+diff --git a/docs/design/spec-042-v0.1-slice-pool-binary-floor.md b/docs/design/spec-042-v0.1-slice-pool-binary-floor.md
+new file mode 100644
+index 00000000..04bb70ca
+--- /dev/null
++++ b/docs/design/spec-042-v0.1-slice-pool-binary-floor.md
+@@ -0,0 +1,114 @@
++# SPEC-042 v0.1 slice — pool provider binary-version floor (R010 handshake, provider half)
++
++Status: design → implementation. Coordinator-only (phase4). Stacked on main
++(the SPEC-042 Layer 2 stack landed 2026-08-19).
++
++## 1. What this slice delivers (SPEC-042 R010 provider half + R004 min-binary predicate)
++
++R010 requires a **positive pool-capability negotiation**: a pool-required request
++MUST NOT be served unless BOTH the coordinator AND the selected provider
++positively support pools at the required version — otherwise a mixed-binary
++rollout can spill pool traffic to a pool-blind provider. The gateway slice
++(#1076) built the coordinator-advertises-to-gateway half. This slice builds the
++provider half, entirely inside the coordinator (the gateway can't see the
++selected provider, so the coordinator must enforce it).
++
++A provider already advertises its capability: it sends `binary_version` in the
++WebSocket `hello` handshake, landing on `pool.Provider.BinaryVersion`. So the
++provider half is an **eligibility gate**, not a new wire protocol:
++
++> A pool member is eligible for pool *P*'s traffic only if its `binary_version`
++> meets *P*'s configured minimum. A member below the floor is excluded from pool
++> routing on **every** dispatch-authorizing path; if that leaves no eligible
++> member, the request fails closed with `pool_binary_too_old` (503,
++> non-retryable) — never spilling to an under-version or global provider.
++
++This is the SPEC-042-R004 "minimum signed provider binary version" predicate,
++enforced fail-closed, satisfying the R010 provider advertisement (a provider's
++binary version *is* its capability signal). No provider/Swift change, no release.
++
++### Out of scope (deferred, documented)
++- A dedicated `pool_support_version` handshake field decoupled from binary
++  version (Option B) — only needed if pool-protocol support must rev
++  independently of the binary. Not needed while binary version is the capability.
++- The signed manifest as the floor source (R001) — the floor is per-pool
++  registry state now; it moves into the manifest policy core when R001 lands.
++- Other R004 predicates (encrypted-leg, attestation tier, model-hash) — separate
++  slices; this one is binary-version only.
++
++## 2. Where the floor lives — per-pool, in the consistent snapshot
++
++The floor is a per-pool value on `trustpool` `poolState.minBinaryVersion`,
++exposed on `Snapshot.MinBinaryVersion`, read under the **same single lock** as
++`Members`/`Generation`. Rationale: it must be part of the R003 consistent
++snapshot so a route attempt evaluates membership AND floor against one coherent
++view. A new `SetMinBinaryVersion(poolID, version)` **bumps the generation** (like
++`AddMember`/`Revoke`), so raising a pool's floor invalidates in-flight
++reservations via the existing generation fence — the raised floor applies at
++once instead of leaking a TTL window of under-version dispatch.
++
++`selectProviderExcluding` reads `snap.MinBinaryVersion` alongside `poolMembers`
++/`poolGeneration` (server.go ~5577) and threads it into `eligibilityCtx` and
++`forwardState`, exactly mirroring the membership threading.
++
++## 3. The gate (pure, fail-safe)
++
++```
++func meetsPoolBinaryFloor(providerVersion, floor string) bool {
++    if floor == "" { return true }                 // no floor configured → inert
++    cmp, ok := versionfloor.Compare(providerVersion, floor)
++    return ok && cmp >= 0                            // empty/malformed version → excluded
++}
++```
++
++- `floor == ""` (no minimum configured for the pool) → **total no-op**, byte-identical to today.
++- Empty or non-numeric `BinaryVersion` while a floor is in force → `Compare` returns `ok=false` → **excluded** (fail-safe, mirroring the #768 malformed-version posture and the global admission floor at `ws/server.go:2417`).
++- `versionfloor.Compare` is the coordinator's single canonical comparator (dotted numeric, optional `v` prefix). The configured floor is validated with `versionfloor.Valid` at seed time.
++
++## 4. Enforcement on every dispatch-authorizing path
++
++Membership dominates: a non-member is reported `pool_not_member` and never also
++evaluated for the floor. Placement mirrors the isolation gate exactly.
++
++| Path | Site | Add |
++|---|---|---|
++| Ordinary filter | `routing/filter.go` after the `ProviderInPool` stanza | `if !checker.ProviderMeetsPoolBinaryFloor(p) { Counts[ReasonPoolBinaryTooOld]++; continue }` |
++| Pinned session | `server.go` ~5593 (after member check) | `else if poolActive && !meetsFloor(p) { return pool_binary_too_old }` |
++| Pinned/self-route | `server.go` ~5614 | same |
++| Slot-queue enter (`slotQueueCandidates`) | uses the checker | add `&& checker.ProviderMeetsPoolBinaryFloor(provider)` |
++| Slot-queue poll (`pollQueuedProvider`) | ~6576 (uses `state.poolMembers`) | also check the floor from `state.poolMinBinaryVersion` |
++
++New checker method `ProviderMeetsPoolBinaryFloor(p pool.Provider) bool` on
++`EligibilityChecker`; `eligibilityCtx` impl returns true when
++`poolID == "" || poolMinBinaryVersion == ""`, else the gate above.
++
++## 5. Error taxonomy — `pool_binary_too_old` (R010)
++
++503, **non-retryable**, authorized-only visibility (returned only for a
++credential-authorized pool selection, so revealing "binary too old" is fine).
++Register identically to the two existing pool codes:
++- `spec018RetryableByCode`: `"pool_binary_too_old": false`
++- `coordinatorEmittedErrorCodes` (test inventory): append
++- The AST guard then passes automatically once the literal is emitted.
++
++Ordinary-path reason→envelope mapping: when the filter leaves no candidate and
++`Counts[ReasonPoolBinaryTooOld] > 0` (members exist but all under-version) →
++`pool_binary_too_old`; a pool with no members at all stays
++`pool_no_eligible_member`. `pool_binary_too_old` is ordered after the
++member-specific check, before the generic no-provider error.
++
++## 6. Compatibility
++- No pool floor configured → gate is a strict no-op; pool routing unchanged.
++- Global (poolless) traffic → `poolActive` false → untouched, byte-identical.
++- Provider binary/handshake → **unchanged** (reuses the existing `binary_version`).
++- Default-off preserved: `trustPools == nil` → no pool paths execute at all.
++
++## 7. Test plan (conformance-first, mirror `spec042_pool_isolation_test.go`)
++- `poolProvider` variant that sets `BinaryVersion`; below-floor member excluded on the filter path, the pinned path, and the slot-queue path.
++- All-members-under-floor → `pool_binary_too_old`, non-retryable, no spill (no dispatch).
++- At/above-floor member → served (passes the gate).
++- Empty `BinaryVersion` under a configured floor → excluded (fail-safe).
++- No floor configured (`""`) → gate inert, member served regardless of version.
++- Global (no pool) request → floor never consulted; byte-identical.
++- `SetMinBinaryVersion` bumps the generation → an in-flight reservation fenced to the old generation is stale (`poolGenerationStale`), so a raised floor re-selects.
++- Membership dominates: a non-member under floor reports `pool_not_member` (not `pool_binary_too_old`).
+diff --git a/phase4-coordinator/internal/buyer/forward_state.go b/phase4-coordinator/internal/buyer/forward_state.go
+index 1321ece9..6c091463 100644
+--- a/phase4-coordinator/internal/buyer/forward_state.go
++++ b/phase4-coordinator/internal/buyer/forward_state.go
+@@ -45,6 +45,11 @@ type forwardState struct {
+ 	poolMembers    map[string]bool
+ 	poolGeneration uint64
+ 	poolGenSet     bool
++	// poolMinBinaryVersion is the selected pool's binary-version floor
++	// (SPEC-042 R004), captured with the membership snapshot so the by-hand
++	// dispatch paths (pinned/self-route/slot-queue) apply the same floor as
++	// the ordinary filter. "" means no floor.
++	poolMinBinaryVersion string
+ 
+ 	// routingDone is the wall-clock at which the current provider was
+ 	// selected. Updated on every advanceToNextProvider so the
+diff --git a/phase4-coordinator/internal/buyer/server.go b/phase4-coordinator/internal/buyer/server.go
+index 1081b18c..15143da8 100644
+--- a/phase4-coordinator/internal/buyer/server.go
++++ b/phase4-coordinator/internal/buyer/server.go
+@@ -84,6 +84,7 @@ var spec018RetryableByCode = map[string]bool{
+ 	// SPEC-042 R005/R010 tenant isolation.
+ 	"pool_state_stale":        true,  // 503, pool membership changed during routing; re-select
+ 	"pool_no_eligible_member": false, // 503, no member satisfies the pool; same reservation must not be retried
++	"pool_binary_too_old":     false, // 503, members exist but all below the pool binary floor; retry cannot make a binary newer
+ 	// Permanent/client errors — retrying will not help (SPEC-006 §5.2).
+ 	"model_not_found":                                         false,
+ 	"context_exceeds_capacity":                                false,
+@@ -5572,15 +5573,18 @@ func (s *Server) selectProviderExcluding(ctx context.Context, requestID string,
+ 	// nothing here changes and selection stays byte-identical.
+ 	var poolMembers map[string]bool
+ 	var poolGen uint64
++	var poolMin string
+ 	poolActive := s.trustPools != nil && req.poolID != ""
+ 	if poolActive {
+ 		snap := s.trustPools.Snapshot(req.poolID)
+ 		poolMembers = snap.Members
+ 		poolGen = snap.Generation
++		poolMin = snap.MinBinaryVersion
+ 		if state != nil {
+ 			state.poolID = req.poolID
+ 			state.poolMembers = snap.Members
+ 			state.poolGeneration = snap.Generation
++			state.poolMinBinaryVersion = snap.MinBinaryVersion
+ 			state.poolGenSet = true
+ 		}
+ 	}
+@@ -5596,6 +5600,11 @@ func (s *Server) selectProviderExcluding(ctx context.Context, requestID string,
+ 					// a pin would route a pool request to a non-member.
+ 					return pool.Provider{}, &routeError{status: http.StatusServiceUnavailable, code: "pool_no_eligible_member", message: "Pinned session provider is not a member of the selected pool"}
+ 				}
++				if poolActive && !poolBinaryFloorMet(p.BinaryVersion, poolMin) {
++					// SPEC-042 R004/R010: same reason the filter drops an
++					// under-version member — a pin must not bypass the floor.
++					return pool.Provider{}, &routeError{status: http.StatusServiceUnavailable, code: "pool_binary_too_old", message: "Pinned session provider is below the pool minimum binary version"}
++				}
+ 				provider, routeErr := s.validatePinnedProviderForRequest(p, req.Model, estimatedTokens, "Pinned session not available", class)
+ 				if routeErr != nil {
+ 					return provider, routeErr
+@@ -5614,6 +5623,9 @@ func (s *Server) selectProviderExcluding(ctx context.Context, requestID string,
+ 				if poolActive && !poolMembers[p.ProviderID] {
+ 					return pool.Provider{}, &routeError{status: http.StatusServiceUnavailable, code: "pool_no_eligible_member", message: "Pinned provider is not a member of the selected pool"}
+ 				}
++				if poolActive && !poolBinaryFloorMet(p.BinaryVersion, poolMin) {
++					return pool.Provider{}, &routeError{status: http.StatusServiceUnavailable, code: "pool_binary_too_old", message: "Pinned provider is below the pool minimum binary version"}
++				}
+ 				provider, routeErr := s.validatePinnedProviderForRequest(p, req.Model, estimatedTokens, "Pinned provider not available", class)
+ 				if routeErr != nil {
+ 					return provider, routeErr
+@@ -5646,6 +5658,7 @@ func (s *Server) selectProviderExcluding(ctx context.Context, requestID string,
+ 		checker.poolID = req.poolID
+ 		checker.poolMembers = poolMembers
+ 		checker.poolGeneration = poolGen // local snapshot value; avoids a nil-state deref
++		checker.poolMinBinaryVersion = poolMin
+ 	}
+ 	result := routing.EligibleCandidates(providers, exSet, pool.Provider.SortKey, checker)
+ 	candidates := result.Eligible
+@@ -5705,6 +5718,14 @@ func (s *Server) selectProviderExcluding(ctx context.Context, requestID string,
+ 		// version) so an actual pool MEMBER that failed a specific gate — the
+ 		// pool gate is first in the filter, so those counts are members only —
+ 		// still yields its specific, actionable error.
++		// SPEC-042 R004/R010: the pool HAS members, they are just below the
++		// pool's minimum binary version. Checked before pool_no_eligible_member
++		// because a present-but-under-version member is a more specific,
++		// actionable signal (upgrade the provider) than "no member". Non-
++		// retryable — retrying cannot make an old binary new.
++		if poolActive && result.Counts[routing.ReasonPoolBinaryTooOld] > 0 {
++			return pool.Provider{}, &routeError{status: http.StatusServiceUnavailable, code: "pool_binary_too_old", message: "No pool member meets the minimum binary version for the selected pool"}
++		}
+ 		if poolActive && result.Counts[routing.ReasonPoolNotMember] > 0 {
+ 			return pool.Provider{}, &routeError{status: http.StatusServiceUnavailable, code: "pool_no_eligible_member", message: "No eligible member is available for the selected pool"}
+ 		}
+@@ -6180,6 +6201,8 @@ func routeKeyedFilterCounts(counts map[routing.RejectionReason]int) map[string]i
+ 			key = "receipt_key_missing"
+ 		case routing.ReasonPoolNotMember:
+ 			key = "pool_not_member" // SPEC-042 R005: distinct so pool-isolation drops are observable, not "other"
++		case routing.ReasonPoolBinaryTooOld:
++			key = "pool_binary_too_old" // SPEC-042 R004/R010: under-version pool member, observable distinctly
+ 		default:
+ 			key = "other"
+ 		}
+@@ -6576,6 +6599,12 @@ func (s *Server) pollQueuedProvider(waiter *slotWaiter, model string, class *con
+ 		if state != nil && state.poolID != "" && !state.poolMembers[provider.ProviderID] {
+ 			return pool.Provider{}, queuedProviderTerminal
+ 		}
++		// SPEC-042 R004/R010: same reason as the #768 per-model floor below —
++		// a same-ID reconnect below the pool's binary floor must not be served
++		// off the queue. Uses the floor from the selection snapshot.
++		if state != nil && state.poolID != "" && !poolBinaryFloorMet(provider.BinaryVersion, state.poolMinBinaryVersion) {
++			return pool.Provider{}, queuedProviderTerminal
++		}
+ 		if !s.providerMatchesRequest(provider, model, class) || provider.MaxContextTokens < estimatedTokens {
+ 			return pool.Provider{}, queuedProviderTerminal
+ 		}
+@@ -6627,6 +6656,11 @@ func (s *Server) slotQueueCandidates(providers []pool.Provider, excluded routing
+ 		if !checker.ProviderInPool(provider) {
+ 			continue
+ 		}
++		// SPEC-042 R004/R010: re-apply the pool binary floor by hand too, so an
++		// under-version member is never queued for the pool's traffic.
++		if !checker.ProviderMeetsPoolBinaryFloor(provider) {
++			continue
++		}
+ 		// The slot queue re-derives the public routing gate list by hand; the
+ 		// #768 floor has to be re-applied here or a below-floor provider would
+ 		// still be queued for (and eventually served) the model it is too old
+@@ -6777,6 +6811,11 @@ type eligibilityCtx struct {
+ 	poolID         string
+ 	poolMembers    map[string]bool
+ 	poolGeneration uint64
++	// poolMinBinaryVersion is the selected pool's minimum provider binary
++	// version floor (SPEC-042 R004), captured from the SAME consistent
++	// snapshot as poolMembers/poolGeneration. "" means no floor -> the
++	// ProviderMeetsPoolBinaryFloor gate is inert.
++	poolMinBinaryVersion string
+ }
+ 
+ // ProviderMatchesRequest combines the model/class match and the
+@@ -6842,6 +6881,33 @@ func (c *eligibilityCtx) ProviderInPool(p pool.Provider) bool {
+ 	return c.poolMembers[p.ProviderID]
+ }
+ 
++// ProviderMeetsPoolBinaryFloor implements the SPEC-042 R004/R010 provider-half
++// gate: a pool member is eligible only if its reported binary_version meets the
++// pool's minimum. Inert for global requests (poolID == "") and for pools with
++// no floor configured (poolMinBinaryVersion == ""), so poolless/floorless
++// selection is byte-identical. Evaluated only after ProviderInPool, so a
++// non-member is never reported here (membership dominates).
++func (c *eligibilityCtx) ProviderMeetsPoolBinaryFloor(p pool.Provider) bool {
++	if c.poolID == "" {
++		return true
++	}
++	return poolBinaryFloorMet(p.BinaryVersion, c.poolMinBinaryVersion)
++}
++
++// poolBinaryFloorMet reports whether providerVersion satisfies a pool binary
++// floor. An empty floor is inert (always met). A non-empty floor requires the
++// provider version to parse and be >= the floor via the coordinator's single
++// canonical comparator; an empty or unparseable provider version is treated as
++// below the floor (fail-safe, mirroring the #768 malformed-version posture and
++// the global admission floor).
++func poolBinaryFloorMet(providerVersion, floor string) bool {
++	if floor == "" {
++		return true
++	}
++	cmp, ok := versionfloor.Compare(providerVersion, floor)
++	return ok && cmp >= 0
++}
++
+ // poolGenerationStale implements the SPEC-042 R005 generation fence for the
+ // select->dispatch window: it reports whether the selected pool's membership
+ // generation advanced since the consistent snapshot was captured at
+diff --git a/phase4-coordinator/internal/buyer/server_internal_test.go b/phase4-coordinator/internal/buyer/server_internal_test.go
+index 63e673a0..4054030f 100644
+--- a/phase4-coordinator/internal/buyer/server_internal_test.go
++++ b/phase4-coordinator/internal/buyer/server_internal_test.go
+@@ -693,7 +693,7 @@ var coordinatorEmittedErrorCodes = []string{
+ 	"tool_results_aggregate_too_large", "unauthorized", "unsupported_content_shape",
+ 	"unsupported_modelID_for_multi_turn",
+ 	// SPEC-042 R005/R010 tenant isolation.
+-	"pool_no_eligible_member", "pool_state_stale",
++	"pool_no_eligible_member", "pool_state_stale", "pool_binary_too_old",
+ }
+ 
+ // TestCoordinatorErrorCodeCompleteness closes L-R2-2 coordinator-side: every
+diff --git a/phase4-coordinator/internal/buyer/spec042_pool_binary_floor_test.go b/phase4-coordinator/internal/buyer/spec042_pool_binary_floor_test.go
+new file mode 100644
+index 00000000..8bab85a6
+--- /dev/null
++++ b/phase4-coordinator/internal/buyer/spec042_pool_binary_floor_test.go
+@@ -0,0 +1,254 @@
++package buyer
++
++import (
++	"context"
++	"net/http"
++	"testing"
++
++	"github.com/augstar/macprovider-coordinator/internal/pool"
++	"github.com/augstar/macprovider-coordinator/internal/routing"
++)
++
++// poolProviderVer is poolProvider with an explicit binary_version, for the
++// SPEC-042 R004/R010 pool binary-floor gate.
++func poolProviderVer(providerID, version string) pool.Provider {
++	p := poolProvider(providerID)
++	p.BinaryVersion = version
++	return p
++}
++
++// Ordinary filter path: a pool whose only member is below the floor fails
++// closed with the non-retryable pool_binary_too_old — never spilling to the
++// under-version member or to global (SPEC-042 R004/R010).
++func TestPoolBinaryFloor_AllBelowFloor_FailsClosed(t *testing.T) {
++	s, registry, tp := poolIsolationServer(t)
++	old := poolProviderVer("member-old", "1.7.0")
++	registry.Register(&old, nil)
++	tp.AddMember("P", "member-old")
++	tp.SetMinBinaryVersion("P", "1.8.0")
++
++	_, routeErr := s.selectProviderExcluding(context.Background(), "rid", poolChatReq("P"), http.Header{}, nil, "2024-01-01", &forwardState{})
++	if routeErr == nil || routeErr.code != "pool_binary_too_old" {
++		t.Fatalf("under-version member: want pool_binary_too_old, got %+v", routeErr)
++	}
++	if spec018RetryableByCode[routeErr.code] {
++		t.Fatal("pool_binary_too_old must be non-retryable")
++	}
++}
++
++// A member at/above the floor passes the gate and is served.
++func TestPoolBinaryFloor_AtOrAboveFloor_Served(t *testing.T) {
++	s, registry, tp := poolIsolationServer(t)
++	newp := poolProviderVer("member-new", "1.8.0") // exactly the floor
++	registry.Register(&newp, nil)
++	tp.AddMember("P", "member-new")
++	tp.SetMinBinaryVersion("P", "1.8.0")
++
++	provider, routeErr := s.selectProviderExcluding(context.Background(), "rid", poolChatReq("P"), http.Header{}, nil, "2024-01-01", &forwardState{})
++	if routeErr != nil {
++		t.Fatalf("at-floor member rejected: %+v", routeErr)
++	}
++	if provider.ProviderID != "member-new" {
++		t.Fatalf("selected %q, want member-new", provider.ProviderID)
++	}
++}
++
++// The floor selects the eligible member and drops the under-version one.
++func TestPoolBinaryFloor_MixedSelectsEligible(t *testing.T) {
++	s, registry, tp := poolIsolationServer(t)
++	old := poolProviderVer("member-old", "1.7.9")
++	newp := poolProviderVer("member-new", "1.8.1")
++	registry.Register(&old, nil)
++	registry.Register(&newp, nil)
++	tp.AddMember("P", "member-old")
++	tp.AddMember("P", "member-new")
++	tp.SetMinBinaryVersion("P", "1.8.0")
++
++	provider, routeErr := s.selectProviderExcluding(context.Background(), "rid", poolChatReq("P"), http.Header{}, nil, "2024-01-01", &forwardState{})
++	if routeErr != nil {
++		t.Fatalf("mixed pool rejected: %+v", routeErr)
++	}
++	if provider.ProviderID != "member-new" {
++		t.Fatalf("selected %q, want member-new (member-old is below floor)", provider.ProviderID)
++	}
++}
++
++// An empty/unparseable binary_version while a floor is in force is treated as
++// below the floor (fail-safe), so such a member is excluded.
++func TestPoolBinaryFloor_EmptyVersionExcluded(t *testing.T) {
++	s, registry, tp := poolIsolationServer(t)
++	blank := poolProviderVer("member-blank", "") // no version reported
++	registry.Register(&blank, nil)
++	tp.AddMember("P", "member-blank")
++	tp.SetMinBinaryVersion("P", "1.8.0")
++
++	_, routeErr := s.selectProviderExcluding(context.Background(), "rid", poolChatReq("P"), http.Header{}, nil, "2024-01-01", &forwardState{})
++	if routeErr == nil || routeErr.code != "pool_binary_too_old" {
++		t.Fatalf("empty-version member: want pool_binary_too_old, got %+v", routeErr)
++	}
++}
++
++// No floor configured for the pool -> the gate is a strict no-op; a member is
++// served regardless of its (low) binary version.
++func TestPoolBinaryFloor_NoFloorInert(t *testing.T) {
++	s, registry, tp := poolIsolationServer(t)
++	old := poolProviderVer("member-old", "1.0.0")
++	registry.Register(&old, nil)
++	tp.AddMember("P", "member-old") // no SetMinBinaryVersion -> floor ""
++
++	provider, routeErr := s.selectProviderExcluding(context.Background(), "rid", poolChatReq("P"), http.Header{}, nil, "2024-01-01", &forwardState{})
++	if routeErr != nil {
++		t.Fatalf("floorless pool rejected a member: %+v", routeErr)
++	}
++	if provider.ProviderID != "member-old" {
++		t.Fatalf("selected %q, want member-old (no floor configured)", provider.ProviderID)
++	}
++}
++
++// Global (poolless) request: the floor is never consulted; a low-version
++// provider is served exactly as before (byte-identical).
++func TestPoolBinaryFloor_GlobalUnaffected(t *testing.T) {
++	s, registry, tp := poolIsolationServer(t)
++	_ = tp
++	old := poolProviderVer("any-provider", "1.0.0")
++	registry.Register(&old, nil)
++
++	provider, routeErr := s.selectProviderExcluding(context.Background(), "rid", poolChatReq(""), http.Header{}, nil, "2024-01-01", &forwardState{})
++	if routeErr != nil {
++		t.Fatalf("global request rejected: %+v", routeErr)
++	}
++	if provider.ProviderID != "any-provider" {
++		t.Fatalf("selected %q, want any-provider", provider.ProviderID)
++	}
++}
++
++// Pinned/self-route path: a hard pin to an under-version member is refused with
++// pool_binary_too_old (a pin must not bypass the floor).
++func TestPoolBinaryFloor_PinnedBelowFloorRejected(t *testing.T) {
++	s, registry, tp := poolIsolationServer(t)
++	old := poolProviderVer("member-old", "1.7.0")
++	registry.Register(&old, nil)
++	tp.AddMember("P", "member-old")
++	tp.SetMinBinaryVersion("P", "1.8.0")
++
++	headers := http.Header{}
++	headers.Set("X-MacProvider-Provider", "member-old")
++	_, routeErr := s.selectProviderExcluding(context.Background(), "rid", poolChatReq("P"), headers, nil, "2024-01-01", &forwardState{})
++	if routeErr == nil || routeErr.code != "pool_binary_too_old" {
++		t.Fatalf("pin to under-version member: want pool_binary_too_old, got %+v", routeErr)
++	}
++}
++
++// Pinned member at/above the floor passes the gate.
++func TestPoolBinaryFloor_PinnedAboveFloorServed(t *testing.T) {
++	s, registry, tp := poolIsolationServer(t)
++	newp := poolProviderVer("member-new", "1.9.0")
++	registry.Register(&newp, nil)
++	tp.AddMember("P", "member-new")
++	tp.SetMinBinaryVersion("P", "1.8.0")
++
++	headers := http.Header{}
++	headers.Set("X-MacProvider-Provider", "member-new")
++	provider, routeErr := s.selectProviderExcluding(context.Background(), "rid", poolChatReq("P"), headers, nil, "2024-01-01", &forwardState{})
++	if routeErr != nil {
++		t.Fatalf("pin to above-floor member rejected: %+v", routeErr)
++	}
++	if provider.ProviderID != "member-new" {
++		t.Fatalf("selected %q, want member-new", provider.ProviderID)
++	}
++}
++
++// Slot-queue candidate derivation drops an under-version member and keeps the
++// eligible one (the by-hand path must apply the same floor).
++func TestPoolBinaryFloor_SlotQueueExcludesBelowFloor(t *testing.T) {
++	s, _, tp := poolIsolationServer(t)
++	tp.AddMember("P", "member-old")
++	tp.AddMember("P", "member-new")
++	tp.SetMinBinaryVersion("P", "1.8.0")
++	snap := tp.Snapshot("P")
++	checker := &eligibilityCtx{
++		s: s, model: "model-a", estimatedTokens: 100,
++		tier2Cfg:             s.tier2Config(),
++		poolID:               "P",
++		poolMembers:          snap.Members,
++		poolMinBinaryVersion: snap.MinBinaryVersion,
++	}
++	busy := func(id, ver string) pool.Provider {
++		p := poolProviderVer(id, ver)
++		p.SlotsFree = 0 // slot-queue eligibility requires a saturated provider
++		return p
++	}
++	providers := []pool.Provider{busy("member-old", "1.7.0"), busy("member-new", "1.8.2")}
++	got := s.slotQueueCandidates(providers, routing.NewExcluded(0), checker)
++	if len(got) != 1 || got[0].ProviderID != "member-new" {
++		t.Fatalf("slotQueueCandidates = %+v, want only member-new (under-version dropped)", got)
++	}
++}
++
++// Slot-queue poll: a same-ID reconnect below the floor is terminated off the
++// queue (the poll path re-checks the floor from the selection snapshot).
++func TestPoolBinaryFloor_SlotQueuePollExcludesBelowFloor(t *testing.T) {
++	s, registry, tp := poolIsolationServer(t)
++	old := poolProviderVer("member-old", "1.7.0")
++	registry.Register(&old, nil)
++	tp.AddMember("P", "member-old")
++	tp.SetMinBinaryVersion("P", "1.8.0")
++
++	w, ok := s.slotQueue.enter("member-old")
++	if !ok {
++		t.Fatal("enter returned no waiter")
++	}
++	defer s.slotQueue.leave(w)
++	snap := tp.Snapshot("P")
++	state := &forwardState{poolID: "P", poolMembers: snap.Members, poolMinBinaryVersion: snap.MinBinaryVersion}
++	if _, status := s.pollQueuedProvider(w, "model-a", nil, 100, state); status != queuedProviderTerminal {
++		t.Fatalf("poll status = %v, want terminal (under-version member off the queue)", status)
++	}
++}
++
++// Membership dominates: a NON-member (whatever its version) is reported
++// pool_no_eligible_member, never pool_binary_too_old — the floor is evaluated
++// only for actual members.
++func TestPoolBinaryFloor_MembershipDominates(t *testing.T) {
++	s, registry, tp := poolIsolationServer(t)
++	member := poolProviderVer("member-new", "1.9.0")
++	nonmember := poolProviderVer("nonmember-z", "1.0.0")
++	registry.Register(&member, nil)
++	registry.Register(&nonmember, nil)
++	tp.AddMember("P", "member-new") // z is not a member
++	tp.SetMinBinaryVersion("P", "1.8.0")
++
++	headers := http.Header{}
++	headers.Set("X-MacProvider-Provider", "nonmember-z")
++	_, routeErr := s.selectProviderExcluding(context.Background(), "rid", poolChatReq("P"), headers, nil, "2024-01-01", &forwardState{})
++	if routeErr == nil || routeErr.code != "pool_no_eligible_member" {
++		t.Fatalf("pin to non-member: want pool_no_eligible_member (membership dominates), got %+v", routeErr)
++	}
++}
++
++// SetMinBinaryVersion bumps the pool generation, so a route attempt fenced to
++// the prior generation is stale — a raised floor invalidates in-flight
++// reservations via the existing R005 fence rather than leaking under-version
++// dispatch for a TTL.
++func TestPoolBinaryFloor_SetMinBumpsGeneration(t *testing.T) {
++	s, _, tp := poolIsolationServer(t)
++	tp.AddMember("P", "member-x")
++	gen0 := tp.Generation("P")
++	state := &forwardState{poolID: "P", poolGeneration: gen0, poolGenSet: true}
++	if s.poolGenerationStale(state) {
++		t.Fatal("fresh snapshot must not be stale")
++	}
++	tp.SetMinBinaryVersion("P", "1.8.0")
++	if tp.Generation("P") <= gen0 {
++		t.Fatalf("SetMinBinaryVersion did not bump generation: gen0=%d now=%d", gen0, tp.Generation("P"))
++	}
++	if !s.poolGenerationStale(state) {
++		t.Fatal("generation advanced after a floor change; fence must report stale")
++	}
++	// Setting the same floor again is a no-op (no generation churn).
++	genAfter := tp.Generation("P")
++	tp.SetMinBinaryVersion("P", "1.8.0")
++	if tp.Generation("P") != genAfter {
++		t.Fatal("setting the same floor bumped the generation; want no-op")
++	}
++}
+diff --git a/phase4-coordinator/internal/routing/filter.go b/phase4-coordinator/internal/routing/filter.go
+index a265a085..3dc1f644 100644
+--- a/phase4-coordinator/internal/routing/filter.go
++++ b/phase4-coordinator/internal/routing/filter.go
+@@ -59,6 +59,20 @@ const (
+ 	// dropped for this reason the eligible list is empty and the request
+ 	// surfaces the no-eligible-member 503 with no spill to global.
+ 	ReasonPoolNotMember
++	// ReasonPoolBinaryTooOld — the request carries a pool_id (SPEC-042) and
++	// the provider IS a current member, but its reported binary_version is
++	// below the pool's configured minimum (SPEC-042 R004 predicate), so it
++	// cannot safely serve the pool's traffic under a mixed-binary rollout
++	// (SPEC-042 R010, the provider half of the positive capability handshake).
++	// A false ProviderMeetsPoolBinaryFloor return is reported here. Membership
++	// dominates: a non-member is reported ReasonPoolNotMember and never also
++	// evaluated for the floor. With no pool selected, or no floor configured
++	// for the pool, the checker returns true for every provider and this
++	// reason never fires — poolless and floorless selection stay byte-identical.
++	// Fail-closed: when members exist but all are dropped for this reason the
++	// request surfaces pool_binary_too_old (503) with no spill to an
++	// under-version or global provider.
++	ReasonPoolBinaryTooOld
+ )
+ 
+ // EligibilityChecker is the cross-package boundary between the
+@@ -139,6 +153,19 @@ type EligibilityChecker interface {
+ 	// consistent snapshot (SPEC-042 R003) so a revocation cannot leave
+ 	// a stale member passing this gate.
+ 	ProviderInPool(p pool.Provider) bool
++
++	// ProviderMeetsPoolBinaryFloor reports whether a pool MEMBER's reported
++	// binary_version satisfies the selected pool's minimum version floor
++	// (SPEC-042 R004 / R010 provider half). A false return is reported as
++	// ReasonPoolBinaryTooOld. This is evaluated only after ProviderInPool
++	// (membership dominates). Implementations MUST return true for every
++	// provider when the request carries no pool selection OR the pool has no
++	// floor configured, so poolless and floorless selection stay
++	// byte-identical. The floor MUST come from the SAME consistent snapshot as
++	// membership/generation (SPEC-042 R003), and an empty/unparseable
++	// binary_version while a floor is in force MUST be treated as below the
++	// floor (fail-safe, mirroring the #768 malformed-version posture).
++	ProviderMeetsPoolBinaryFloor(p pool.Provider) bool
+ }
+ 
+ // RejectedProvider records a single provider drop with enough
+@@ -227,6 +254,15 @@ func EligibleCandidates(
+ 			res.Counts[ReasonPoolNotMember]++
+ 			continue
+ 		}
++		// SPEC-042 R004/R010 provider half: a pool MEMBER whose binary_version
++		// is below the pool's configured floor cannot serve the pool's traffic
++		// under a mixed-binary rollout. Evaluated after membership (which
++		// dominates). No-op for global requests and for pools with no floor,
++		// so poolless/floorless selection stays byte-identical.
++		if !checker.ProviderMeetsPoolBinaryFloor(p) {
++			res.Counts[ReasonPoolBinaryTooOld]++
++			continue
++		}
+ 		if !checker.ProviderMatchesRequest(p) {
+ 			res.Counts[ReasonModelMismatch]++
+ 			continue
+diff --git a/phase4-coordinator/internal/routing/filter_test.go b/phase4-coordinator/internal/routing/filter_test.go
+index 6442350d..f1d0c5a7 100644
+--- a/phase4-coordinator/internal/routing/filter_test.go
++++ b/phase4-coordinator/internal/routing/filter_test.go
+@@ -18,6 +18,7 @@ type stubChecker struct {
+ 	tier2Hash      map[string]pool.HashStatus
+ 	quotaOK        map[string]bool
+ 	poolMember     map[string]bool
++	poolBinaryOK   map[string]bool
+ }
+ 
+ func (s *stubChecker) ProviderMatchesRequest(p pool.Provider) bool {
+@@ -62,6 +63,14 @@ func (s *stubChecker) ProviderInPool(p pool.Provider) bool {
+ 	}
+ 	return true
+ }
++func (s *stubChecker) ProviderMeetsPoolBinaryFloor(p pool.Provider) bool {
++	// Default true (no floor / member meets it); tests set
++	// poolBinaryOK[id]=false for under-version members.
++	if v, ok := s.poolBinaryOK[p.ProviderID]; ok {
++		return v
++	}
++	return true
++}
+ 
+ func keyer(p pool.Provider) string { return p.ProviderID + "|" + p.AssignedID }
+ 
+@@ -233,6 +242,7 @@ type recordingChecker struct {
+ 	tier2Reason      map[string]routing.RejectionReason
+ 	quotaFail        map[string]bool
+ 	poolNonMember    map[string]bool
++	poolBinaryFail   map[string]bool
+ }
+ 
+ func (r *recordingChecker) ProviderMatchesRequest(p pool.Provider) bool {
+@@ -263,6 +273,10 @@ func (r *recordingChecker) ProviderInPool(p pool.Provider) bool {
+ 	r.calls = append(r.calls, p.ProviderID+"/pool")
+ 	return !r.poolNonMember[p.ProviderID]
+ }
++func (r *recordingChecker) ProviderMeetsPoolBinaryFloor(p pool.Provider) bool {
++	r.calls = append(r.calls, p.ProviderID+"/pool_binary")
++	return !r.poolBinaryFail[p.ProviderID]
++}
+ 
+ func TestEligibleCandidates_OrderingExcludedShortCircuitsEverything(t *testing.T) {
+ 	t.Parallel()
+@@ -304,7 +318,7 @@ func TestEligibleCandidates_OrderingPerProviderSequence(t *testing.T) {
+ 	routing.EligibleCandidates(providers, routing.NewExcluded(0), keyer, checker)
+ 	// SPEC-042 R005 pool-membership gate is first among property gates
+ 	// (right after excluded), before the model match.
+-	want := []string{"p/pool", "p/match", "p/version_floor", "p/receipt_key", "p/context", "p/tier2", "p/quota"}
++	want := []string{"p/pool", "p/pool_binary", "p/match", "p/version_floor", "p/receipt_key", "p/context", "p/tier2", "p/quota"}
+ 	if len(checker.calls) != len(want) {
+ 		t.Fatalf("call count: want %d, got %d (calls=%v)", len(want), len(checker.calls), checker.calls)
+ 	}
+@@ -320,7 +334,7 @@ func TestEligibleCandidates_OrderingContextRejectStopsBeforeTier2AndQuota(t *tes
+ 	providers := []pool.Provider{{ProviderID: "p", AssignedID: "s"}}
+ 	checker := &recordingChecker{t: t, contextFail: map[string]bool{"p": true}}
+ 	routing.EligibleCandidates(providers, routing.NewExcluded(0), keyer, checker)
+-	want := []string{"p/pool", "p/match", "p/version_floor", "p/receipt_key", "p/context"}
++	want := []string{"p/pool", "p/pool_binary", "p/match", "p/version_floor", "p/receipt_key", "p/context"}
+ 	if len(checker.calls) != len(want) {
+ 		t.Fatalf("context-reject: want sequence %v, got %v", want, checker.calls)
+ 	}
+@@ -473,7 +487,7 @@ func TestEligibleCandidates_OrderingVersionFloorRejectStopsBeforeContext(t *test
+ 	providers := []pool.Provider{{ProviderID: "p", AssignedID: "s"}}
+ 	checker := &recordingChecker{t: t, versionFloorFail: map[string]bool{"p": true}}
+ 	routing.EligibleCandidates(providers, routing.NewExcluded(0), keyer, checker)
+-	want := []string{"p/pool", "p/match", "p/version_floor"}
++	want := []string{"p/pool", "p/pool_binary", "p/match", "p/version_floor"}
+ 	if len(checker.calls) != len(want) {
+ 		t.Fatalf("calls = %v, want exactly %v", checker.calls, want)
+ 	}
+diff --git a/phase4-coordinator/internal/trustpool/registry.go b/phase4-coordinator/internal/trustpool/registry.go
+index c7d2348f..082ae8e1 100644
+--- a/phase4-coordinator/internal/trustpool/registry.go
++++ b/phase4-coordinator/internal/trustpool/registry.go
+@@ -29,7 +29,14 @@ type poolState struct {
+ 	// path explicitly is not.
+ 	members map[string]struct{}
+ 	revoked map[string]struct{}
+-	// generation increments on every membership/revocation change so the
++	// minBinaryVersion is the pool's minimum provider binary version
++	// (SPEC-042 R004 predicate). A member whose binary_version is below this
++	// floor is not eligible for the pool's traffic (SPEC-042 R010
++	// pool_binary_too_old). "" means no floor is configured — the gate is a
++	// strict no-op. The floor rides this consistent snapshot so a route
++	// attempt evaluates membership AND floor against one coherent view.
++	minBinaryVersion string
++	// generation increments on every membership/revocation/floor change so the
+ 	// routing generation fence (SPEC-042 R005) can detect a snapshot that
+ 	// is no longer current.
+ 	generation uint64
+@@ -44,7 +51,11 @@ type Snapshot struct {
+ 	PoolID     string
+ 	Exists     bool
+ 	Members    map[string]bool // non-revoked members, keyed by provider identity
+-	Generation uint64
++	// MinBinaryVersion is the pool's minimum provider binary version floor
++	// (SPEC-042 R004), captured under the same lock as Members/Generation.
++	// "" means no floor — the eligibility gate is inert.
++	MinBinaryVersion string
++	Generation       uint64
+ }
+ 
+ // NewRegistry returns an empty registry.
+@@ -101,9 +112,27 @@ func (r *Registry) Revoke(poolID, providerID string) {
+ 	ps.generation++
+ }
+ 
+-// Snapshot returns a consistent read of the pool's non-revoked members and
+-// its generation. For an unknown pool, Exists is false and Members is empty,
+-// which the routing layer treats as fail-closed (no eligible member).
++// SetMinBinaryVersion sets the pool's minimum provider binary version floor
++// (SPEC-042 R004) and bumps the generation. Bumping the generation means a
++// raised floor invalidates in-flight reservations fenced to the prior
++// generation (SPEC-042 R005), so the new floor applies at the very next
++// dispatch rather than leaking a window of under-version routing. "" clears
++// the floor. Seed helper / control-plane action.
++func (r *Registry) SetMinBinaryVersion(poolID, version string) {
++	r.mu.Lock()
++	defer r.mu.Unlock()
++	ps := r.ensure(poolID)
++	if ps.minBinaryVersion == version {
++		return
++	}
++	ps.minBinaryVersion = version
++	ps.generation++
++}
++
++// Snapshot returns a consistent read of the pool's non-revoked members, its
++// binary-version floor, and its generation. For an unknown pool, Exists is
++// false and Members is empty, which the routing layer treats as fail-closed
++// (no eligible member).
+ func (r *Registry) Snapshot(poolID string) Snapshot {
+ 	r.mu.RLock()
+ 	defer r.mu.RUnlock()
+@@ -118,7 +147,7 @@ func (r *Registry) Snapshot(poolID string) Snapshot {
+ 		}
+ 		members[id] = true
+ 	}
+-	return Snapshot{PoolID: poolID, Exists: true, Members: members, Generation: ps.generation}
++	return Snapshot{PoolID: poolID, Exists: true, Members: members, MinBinaryVersion: ps.minBinaryVersion, Generation: ps.generation}
+ }
+ 
+ // Generation returns the current generation for a pool (0 for unknown pools).

--- a/docs/design/spec-042-v0.1-slice-pool-binary-floor.md
+++ b/docs/design/spec-042-v0.1-slice-pool-binary-floor.md
@@ -1,0 +1,114 @@
+# SPEC-042 v0.1 slice — pool provider binary-version floor (R010 handshake, provider half)
+
+Status: design → implementation. Coordinator-only (phase4). Stacked on main
+(the SPEC-042 Layer 2 stack landed 2026-08-19).
+
+## 1. What this slice delivers (SPEC-042 R010 provider half + R004 min-binary predicate)
+
+R010 requires a **positive pool-capability negotiation**: a pool-required request
+MUST NOT be served unless BOTH the coordinator AND the selected provider
+positively support pools at the required version — otherwise a mixed-binary
+rollout can spill pool traffic to a pool-blind provider. The gateway slice
+(#1076) built the coordinator-advertises-to-gateway half. This slice builds the
+provider half, entirely inside the coordinator (the gateway can't see the
+selected provider, so the coordinator must enforce it).
+
+A provider already advertises its capability: it sends `binary_version` in the
+WebSocket `hello` handshake, landing on `pool.Provider.BinaryVersion`. So the
+provider half is an **eligibility gate**, not a new wire protocol:
+
+> A pool member is eligible for pool *P*'s traffic only if its `binary_version`
+> meets *P*'s configured minimum. A member below the floor is excluded from pool
+> routing on **every** dispatch-authorizing path; if that leaves no eligible
+> member, the request fails closed with `pool_binary_too_old` (503,
+> non-retryable) — never spilling to an under-version or global provider.
+
+This is the SPEC-042-R004 "minimum signed provider binary version" predicate,
+enforced fail-closed, satisfying the R010 provider advertisement (a provider's
+binary version *is* its capability signal). No provider/Swift change, no release.
+
+### Out of scope (deferred, documented)
+- A dedicated `pool_support_version` handshake field decoupled from binary
+  version (Option B) — only needed if pool-protocol support must rev
+  independently of the binary. Not needed while binary version is the capability.
+- The signed manifest as the floor source (R001) — the floor is per-pool
+  registry state now; it moves into the manifest policy core when R001 lands.
+- Other R004 predicates (encrypted-leg, attestation tier, model-hash) — separate
+  slices; this one is binary-version only.
+
+## 2. Where the floor lives — per-pool, in the consistent snapshot
+
+The floor is a per-pool value on `trustpool` `poolState.minBinaryVersion`,
+exposed on `Snapshot.MinBinaryVersion`, read under the **same single lock** as
+`Members`/`Generation`. Rationale: it must be part of the R003 consistent
+snapshot so a route attempt evaluates membership AND floor against one coherent
+view. A new `SetMinBinaryVersion(poolID, version)` **bumps the generation** (like
+`AddMember`/`Revoke`), so raising a pool's floor invalidates in-flight
+reservations via the existing generation fence — the raised floor applies at
+once instead of leaking a TTL window of under-version dispatch.
+
+`selectProviderExcluding` reads `snap.MinBinaryVersion` alongside `poolMembers`
+/`poolGeneration` (server.go ~5577) and threads it into `eligibilityCtx` and
+`forwardState`, exactly mirroring the membership threading.
+
+## 3. The gate (pure, fail-safe)
+
+```
+func meetsPoolBinaryFloor(providerVersion, floor string) bool {
+    if floor == "" { return true }                 // no floor configured → inert
+    cmp, ok := versionfloor.Compare(providerVersion, floor)
+    return ok && cmp >= 0                            // empty/malformed version → excluded
+}
+```
+
+- `floor == ""` (no minimum configured for the pool) → **total no-op**, byte-identical to today.
+- Empty or non-numeric `BinaryVersion` while a floor is in force → `Compare` returns `ok=false` → **excluded** (fail-safe, mirroring the #768 malformed-version posture and the global admission floor at `ws/server.go:2417`).
+- `versionfloor.Compare` is the coordinator's single canonical comparator (dotted numeric, optional `v` prefix). The configured floor is validated with `versionfloor.Valid` at seed time.
+
+## 4. Enforcement on every dispatch-authorizing path
+
+Membership dominates: a non-member is reported `pool_not_member` and never also
+evaluated for the floor. Placement mirrors the isolation gate exactly.
+
+| Path | Site | Add |
+|---|---|---|
+| Ordinary filter | `routing/filter.go` after the `ProviderInPool` stanza | `if !checker.ProviderMeetsPoolBinaryFloor(p) { Counts[ReasonPoolBinaryTooOld]++; continue }` |
+| Pinned session | `server.go` ~5593 (after member check) | `else if poolActive && !meetsFloor(p) { return pool_binary_too_old }` |
+| Pinned/self-route | `server.go` ~5614 | same |
+| Slot-queue enter (`slotQueueCandidates`) | uses the checker | add `&& checker.ProviderMeetsPoolBinaryFloor(provider)` |
+| Slot-queue poll (`pollQueuedProvider`) | ~6576 (uses `state.poolMembers`) | also check the floor from `state.poolMinBinaryVersion` |
+
+New checker method `ProviderMeetsPoolBinaryFloor(p pool.Provider) bool` on
+`EligibilityChecker`; `eligibilityCtx` impl returns true when
+`poolID == "" || poolMinBinaryVersion == ""`, else the gate above.
+
+## 5. Error taxonomy — `pool_binary_too_old` (R010)
+
+503, **non-retryable**, authorized-only visibility (returned only for a
+credential-authorized pool selection, so revealing "binary too old" is fine).
+Register identically to the two existing pool codes:
+- `spec018RetryableByCode`: `"pool_binary_too_old": false`
+- `coordinatorEmittedErrorCodes` (test inventory): append
+- The AST guard then passes automatically once the literal is emitted.
+
+Ordinary-path reason→envelope mapping: when the filter leaves no candidate and
+`Counts[ReasonPoolBinaryTooOld] > 0` (members exist but all under-version) →
+`pool_binary_too_old`; a pool with no members at all stays
+`pool_no_eligible_member`. `pool_binary_too_old` is ordered after the
+member-specific check, before the generic no-provider error.
+
+## 6. Compatibility
+- No pool floor configured → gate is a strict no-op; pool routing unchanged.
+- Global (poolless) traffic → `poolActive` false → untouched, byte-identical.
+- Provider binary/handshake → **unchanged** (reuses the existing `binary_version`).
+- Default-off preserved: `trustPools == nil` → no pool paths execute at all.
+
+## 7. Test plan (conformance-first, mirror `spec042_pool_isolation_test.go`)
+- `poolProvider` variant that sets `BinaryVersion`; below-floor member excluded on the filter path, the pinned path, and the slot-queue path.
+- All-members-under-floor → `pool_binary_too_old`, non-retryable, no spill (no dispatch).
+- At/above-floor member → served (passes the gate).
+- Empty `BinaryVersion` under a configured floor → excluded (fail-safe).
+- No floor configured (`""`) → gate inert, member served regardless of version.
+- Global (no pool) request → floor never consulted; byte-identical.
+- `SetMinBinaryVersion` bumps the generation → an in-flight reservation fenced to the old generation is stale (`poolGenerationStale`), so a raised floor re-selects.
+- Membership dominates: a non-member under floor reports `pool_not_member` (not `pool_binary_too_old`).

--- a/docs/design/spec-042-v0.1-slice-pool-binary-floor.md
+++ b/docs/design/spec-042-v0.1-slice-pool-binary-floor.md
@@ -103,7 +103,50 @@ member-specific check, before the generic no-provider error.
 - Provider binary/handshake → **unchanged** (reuses the existing `binary_version`).
 - Default-off preserved: `trustPools == nil` → no pool paths execute at all.
 
-## 7. Test plan (conformance-first, mirror `spec042_pool_isolation_test.go`)
+## 7. Known limitations (money-path audit — accepted, documented carries)
+
+Two HIGH findings from the codex money-path audit (security + architect lanes)
+are **intentional scope boundaries of Option A**, accepted and documented rather
+than resolved in this slice. Both are recorded here so no one over-reads the
+guarantee, and both have a clean, localized upgrade path.
+
+1. **`binary_version` is an unauthenticated advertisement, not signed evidence
+   (security + architect).** The gate compares against the provider's
+   self-reported `binary_version` from the WebSocket `hello` handshake, which is
+   not cryptographically bound to the running binary. R004 literally requires a
+   *signed* minimum provider binary version, and R004's own answer is
+   coordinator-held SPEC-020 release evidence. So a **compromised, already-admitted
+   pool member** could spoof a high `binary_version` to pass the floor while
+   running old code. Why this is accepted for the MVP: (a) it reuses the *exact*
+   signal the pre-existing #768 model-version floor and the global-admission
+   `RequiredBinaryVersion` floor already trust — the slice does **not worsen** the
+   coordinator's version-trust model, it extends it; (b) the primary trust
+   boundary, pool **membership**, is an authenticated SPEC-003 identity explicitly
+   admitted by the pool creator, so the spoof threat is bounded to a
+   creator-admitted-then-compromised member, not an arbitrary provider; (c) there
+   is **no** coordinator-held verified binary evidence today (attestation binds
+   the SE key/tier, not the version; there is no SPEC-020 evidence store), so a
+   real fix is a separate, sizeable build; (d) the feature is default-off and
+   unenabled — no live exposure. **Upgrade path (localized):** when a
+   coordinator-held verified/attested binary version bound to provider identity
+   exists (SPEC-020 release evidence), change only what `poolBinaryFloorMet`
+   compares against (`p.BinaryVersion` → the verified field). The enforcement
+   rails (all dispatch paths, fail-safe, fence) are unchanged.
+
+2. **Floorless pools are inert (architect).** A pool with no floor configured
+   applies no binary gate, so an under-version member can serve its traffic. This
+   is spec-legitimate — R004's binary-version predicate is **optional** (a pool
+   MAY require it) — and is not a live isolation break today because the provider
+   does nothing pool-specific at serve time (pool trust is coordinator-enforced in
+   routing/settlement). Enforcing per-pool policy completeness (require a floor,
+   or advertise per-pool readiness before routing) belongs to the **enable path**
+   and the signed manifest / `pool_status.json` readiness (R001/R008/R011), which
+   are separate slices. Until then, operating a pool that requires the binary
+   predicate is the operator's responsibility to configure via
+   `SetMinBinaryVersion`. The default (no floor = inert) preserves byte-identical
+   behavior for the unenabled feature.
+
+## 8. Test plan (conformance-first, mirror `spec042_pool_isolation_test.go`)
 - `poolProvider` variant that sets `BinaryVersion`; below-floor member excluded on the filter path, the pinned path, and the slot-queue path.
 - All-members-under-floor → `pool_binary_too_old`, non-retryable, no spill (no dispatch).
 - At/above-floor member → served (passes the gate).

--- a/phase4-coordinator/internal/buyer/forward_state.go
+++ b/phase4-coordinator/internal/buyer/forward_state.go
@@ -45,6 +45,11 @@ type forwardState struct {
 	poolMembers    map[string]bool
 	poolGeneration uint64
 	poolGenSet     bool
+	// poolMinBinaryVersion is the selected pool's binary-version floor
+	// (SPEC-042 R004), captured with the membership snapshot so the by-hand
+	// dispatch paths (pinned/self-route/slot-queue) apply the same floor as
+	// the ordinary filter. "" means no floor.
+	poolMinBinaryVersion string
 
 	// routingDone is the wall-clock at which the current provider was
 	// selected. Updated on every advanceToNextProvider so the

--- a/phase4-coordinator/internal/buyer/server.go
+++ b/phase4-coordinator/internal/buyer/server.go
@@ -6900,6 +6900,16 @@ func (c *eligibilityCtx) ProviderMeetsPoolBinaryFloor(p pool.Provider) bool {
 // canonical comparator; an empty or unparseable provider version is treated as
 // below the floor (fail-safe, mirroring the #768 malformed-version posture and
 // the global admission floor).
+//
+// TRUST NOTE (money-path audit, accepted carry): providerVersion is the
+// provider's self-reported binary_version from the hello handshake — an
+// unauthenticated advertisement, the SAME signal the #768 model-version floor
+// already trusts. It is NOT the SPEC-020 signed release evidence R004 ultimately
+// requires, so a compromised already-admitted member could spoof it. Membership
+// (authenticated SPEC-003 identity, creator-admitted) is the primary boundary;
+// this floor is a secondary predicate. When coordinator-held verified binary
+// evidence exists, swap the compared value here — the rails are unchanged. See
+// docs/design/spec-042-v0.1-slice-pool-binary-floor.md §7.
 func poolBinaryFloorMet(providerVersion, floor string) bool {
 	if floor == "" {
 		return true

--- a/phase4-coordinator/internal/buyer/server.go
+++ b/phase4-coordinator/internal/buyer/server.go
@@ -84,6 +84,7 @@ var spec018RetryableByCode = map[string]bool{
 	// SPEC-042 R005/R010 tenant isolation.
 	"pool_state_stale":        true,  // 503, pool membership changed during routing; re-select
 	"pool_no_eligible_member": false, // 503, no member satisfies the pool; same reservation must not be retried
+	"pool_binary_too_old":     false, // 503, members exist but all below the pool binary floor; retry cannot make a binary newer
 	// Permanent/client errors — retrying will not help (SPEC-006 §5.2).
 	"model_not_found":                                         false,
 	"context_exceeds_capacity":                                false,
@@ -5572,15 +5573,18 @@ func (s *Server) selectProviderExcluding(ctx context.Context, requestID string, 
 	// nothing here changes and selection stays byte-identical.
 	var poolMembers map[string]bool
 	var poolGen uint64
+	var poolMin string
 	poolActive := s.trustPools != nil && req.poolID != ""
 	if poolActive {
 		snap := s.trustPools.Snapshot(req.poolID)
 		poolMembers = snap.Members
 		poolGen = snap.Generation
+		poolMin = snap.MinBinaryVersion
 		if state != nil {
 			state.poolID = req.poolID
 			state.poolMembers = snap.Members
 			state.poolGeneration = snap.Generation
+			state.poolMinBinaryVersion = snap.MinBinaryVersion
 			state.poolGenSet = true
 		}
 	}
@@ -5595,6 +5599,11 @@ func (s *Server) selectProviderExcluding(ctx context.Context, requestID string, 
 					// eligibility filter, so re-apply pool membership here or
 					// a pin would route a pool request to a non-member.
 					return pool.Provider{}, &routeError{status: http.StatusServiceUnavailable, code: "pool_no_eligible_member", message: "Pinned session provider is not a member of the selected pool"}
+				}
+				if poolActive && !poolBinaryFloorMet(p.BinaryVersion, poolMin) {
+					// SPEC-042 R004/R010: same reason the filter drops an
+					// under-version member — a pin must not bypass the floor.
+					return pool.Provider{}, &routeError{status: http.StatusServiceUnavailable, code: "pool_binary_too_old", message: "Pinned session provider is below the pool minimum binary version"}
 				}
 				provider, routeErr := s.validatePinnedProviderForRequest(p, req.Model, estimatedTokens, "Pinned session not available", class)
 				if routeErr != nil {
@@ -5613,6 +5622,9 @@ func (s *Server) selectProviderExcluding(ctx context.Context, requestID string, 
 			if p.ProviderID == providerID {
 				if poolActive && !poolMembers[p.ProviderID] {
 					return pool.Provider{}, &routeError{status: http.StatusServiceUnavailable, code: "pool_no_eligible_member", message: "Pinned provider is not a member of the selected pool"}
+				}
+				if poolActive && !poolBinaryFloorMet(p.BinaryVersion, poolMin) {
+					return pool.Provider{}, &routeError{status: http.StatusServiceUnavailable, code: "pool_binary_too_old", message: "Pinned provider is below the pool minimum binary version"}
 				}
 				provider, routeErr := s.validatePinnedProviderForRequest(p, req.Model, estimatedTokens, "Pinned provider not available", class)
 				if routeErr != nil {
@@ -5646,6 +5658,7 @@ func (s *Server) selectProviderExcluding(ctx context.Context, requestID string, 
 		checker.poolID = req.poolID
 		checker.poolMembers = poolMembers
 		checker.poolGeneration = poolGen // local snapshot value; avoids a nil-state deref
+		checker.poolMinBinaryVersion = poolMin
 	}
 	result := routing.EligibleCandidates(providers, exSet, pool.Provider.SortKey, checker)
 	candidates := result.Eligible
@@ -5705,6 +5718,14 @@ func (s *Server) selectProviderExcluding(ctx context.Context, requestID string, 
 		// version) so an actual pool MEMBER that failed a specific gate — the
 		// pool gate is first in the filter, so those counts are members only —
 		// still yields its specific, actionable error.
+		// SPEC-042 R004/R010: the pool HAS members, they are just below the
+		// pool's minimum binary version. Checked before pool_no_eligible_member
+		// because a present-but-under-version member is a more specific,
+		// actionable signal (upgrade the provider) than "no member". Non-
+		// retryable — retrying cannot make an old binary new.
+		if poolActive && result.Counts[routing.ReasonPoolBinaryTooOld] > 0 {
+			return pool.Provider{}, &routeError{status: http.StatusServiceUnavailable, code: "pool_binary_too_old", message: "No pool member meets the minimum binary version for the selected pool"}
+		}
 		if poolActive && result.Counts[routing.ReasonPoolNotMember] > 0 {
 			return pool.Provider{}, &routeError{status: http.StatusServiceUnavailable, code: "pool_no_eligible_member", message: "No eligible member is available for the selected pool"}
 		}
@@ -6180,6 +6201,8 @@ func routeKeyedFilterCounts(counts map[routing.RejectionReason]int) map[string]i
 			key = "receipt_key_missing"
 		case routing.ReasonPoolNotMember:
 			key = "pool_not_member" // SPEC-042 R005: distinct so pool-isolation drops are observable, not "other"
+		case routing.ReasonPoolBinaryTooOld:
+			key = "pool_binary_too_old" // SPEC-042 R004/R010: under-version pool member, observable distinctly
 		default:
 			key = "other"
 		}
@@ -6576,6 +6599,12 @@ func (s *Server) pollQueuedProvider(waiter *slotWaiter, model string, class *con
 		if state != nil && state.poolID != "" && !state.poolMembers[provider.ProviderID] {
 			return pool.Provider{}, queuedProviderTerminal
 		}
+		// SPEC-042 R004/R010: same reason as the #768 per-model floor below —
+		// a same-ID reconnect below the pool's binary floor must not be served
+		// off the queue. Uses the floor from the selection snapshot.
+		if state != nil && state.poolID != "" && !poolBinaryFloorMet(provider.BinaryVersion, state.poolMinBinaryVersion) {
+			return pool.Provider{}, queuedProviderTerminal
+		}
 		if !s.providerMatchesRequest(provider, model, class) || provider.MaxContextTokens < estimatedTokens {
 			return pool.Provider{}, queuedProviderTerminal
 		}
@@ -6625,6 +6654,11 @@ func (s *Server) slotQueueCandidates(providers []pool.Provider, excluded routing
 		// so the pool-membership gate must be re-applied here too or a
 		// non-member could be queued for and eventually served a pool request.
 		if !checker.ProviderInPool(provider) {
+			continue
+		}
+		// SPEC-042 R004/R010: re-apply the pool binary floor by hand too, so an
+		// under-version member is never queued for the pool's traffic.
+		if !checker.ProviderMeetsPoolBinaryFloor(provider) {
 			continue
 		}
 		// The slot queue re-derives the public routing gate list by hand; the
@@ -6777,6 +6811,11 @@ type eligibilityCtx struct {
 	poolID         string
 	poolMembers    map[string]bool
 	poolGeneration uint64
+	// poolMinBinaryVersion is the selected pool's minimum provider binary
+	// version floor (SPEC-042 R004), captured from the SAME consistent
+	// snapshot as poolMembers/poolGeneration. "" means no floor -> the
+	// ProviderMeetsPoolBinaryFloor gate is inert.
+	poolMinBinaryVersion string
 }
 
 // ProviderMatchesRequest combines the model/class match and the
@@ -6840,6 +6879,33 @@ func (c *eligibilityCtx) ProviderInPool(p pool.Provider) bool {
 		return true
 	}
 	return c.poolMembers[p.ProviderID]
+}
+
+// ProviderMeetsPoolBinaryFloor implements the SPEC-042 R004/R010 provider-half
+// gate: a pool member is eligible only if its reported binary_version meets the
+// pool's minimum. Inert for global requests (poolID == "") and for pools with
+// no floor configured (poolMinBinaryVersion == ""), so poolless/floorless
+// selection is byte-identical. Evaluated only after ProviderInPool, so a
+// non-member is never reported here (membership dominates).
+func (c *eligibilityCtx) ProviderMeetsPoolBinaryFloor(p pool.Provider) bool {
+	if c.poolID == "" {
+		return true
+	}
+	return poolBinaryFloorMet(p.BinaryVersion, c.poolMinBinaryVersion)
+}
+
+// poolBinaryFloorMet reports whether providerVersion satisfies a pool binary
+// floor. An empty floor is inert (always met). A non-empty floor requires the
+// provider version to parse and be >= the floor via the coordinator's single
+// canonical comparator; an empty or unparseable provider version is treated as
+// below the floor (fail-safe, mirroring the #768 malformed-version posture and
+// the global admission floor).
+func poolBinaryFloorMet(providerVersion, floor string) bool {
+	if floor == "" {
+		return true
+	}
+	cmp, ok := versionfloor.Compare(providerVersion, floor)
+	return ok && cmp >= 0
 }
 
 // poolGenerationStale implements the SPEC-042 R005 generation fence for the

--- a/phase4-coordinator/internal/buyer/server_internal_test.go
+++ b/phase4-coordinator/internal/buyer/server_internal_test.go
@@ -693,7 +693,7 @@ var coordinatorEmittedErrorCodes = []string{
 	"tool_results_aggregate_too_large", "unauthorized", "unsupported_content_shape",
 	"unsupported_modelID_for_multi_turn",
 	// SPEC-042 R005/R010 tenant isolation.
-	"pool_no_eligible_member", "pool_state_stale",
+	"pool_no_eligible_member", "pool_state_stale", "pool_binary_too_old",
 }
 
 // TestCoordinatorErrorCodeCompleteness closes L-R2-2 coordinator-side: every

--- a/phase4-coordinator/internal/buyer/spec042_pool_binary_floor_test.go
+++ b/phase4-coordinator/internal/buyer/spec042_pool_binary_floor_test.go
@@ -1,0 +1,254 @@
+package buyer
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/augstar/macprovider-coordinator/internal/pool"
+	"github.com/augstar/macprovider-coordinator/internal/routing"
+)
+
+// poolProviderVer is poolProvider with an explicit binary_version, for the
+// SPEC-042 R004/R010 pool binary-floor gate.
+func poolProviderVer(providerID, version string) pool.Provider {
+	p := poolProvider(providerID)
+	p.BinaryVersion = version
+	return p
+}
+
+// Ordinary filter path: a pool whose only member is below the floor fails
+// closed with the non-retryable pool_binary_too_old — never spilling to the
+// under-version member or to global (SPEC-042 R004/R010).
+func TestPoolBinaryFloor_AllBelowFloor_FailsClosed(t *testing.T) {
+	s, registry, tp := poolIsolationServer(t)
+	old := poolProviderVer("member-old", "1.7.0")
+	registry.Register(&old, nil)
+	tp.AddMember("P", "member-old")
+	tp.SetMinBinaryVersion("P", "1.8.0")
+
+	_, routeErr := s.selectProviderExcluding(context.Background(), "rid", poolChatReq("P"), http.Header{}, nil, "2024-01-01", &forwardState{})
+	if routeErr == nil || routeErr.code != "pool_binary_too_old" {
+		t.Fatalf("under-version member: want pool_binary_too_old, got %+v", routeErr)
+	}
+	if spec018RetryableByCode[routeErr.code] {
+		t.Fatal("pool_binary_too_old must be non-retryable")
+	}
+}
+
+// A member at/above the floor passes the gate and is served.
+func TestPoolBinaryFloor_AtOrAboveFloor_Served(t *testing.T) {
+	s, registry, tp := poolIsolationServer(t)
+	newp := poolProviderVer("member-new", "1.8.0") // exactly the floor
+	registry.Register(&newp, nil)
+	tp.AddMember("P", "member-new")
+	tp.SetMinBinaryVersion("P", "1.8.0")
+
+	provider, routeErr := s.selectProviderExcluding(context.Background(), "rid", poolChatReq("P"), http.Header{}, nil, "2024-01-01", &forwardState{})
+	if routeErr != nil {
+		t.Fatalf("at-floor member rejected: %+v", routeErr)
+	}
+	if provider.ProviderID != "member-new" {
+		t.Fatalf("selected %q, want member-new", provider.ProviderID)
+	}
+}
+
+// The floor selects the eligible member and drops the under-version one.
+func TestPoolBinaryFloor_MixedSelectsEligible(t *testing.T) {
+	s, registry, tp := poolIsolationServer(t)
+	old := poolProviderVer("member-old", "1.7.9")
+	newp := poolProviderVer("member-new", "1.8.1")
+	registry.Register(&old, nil)
+	registry.Register(&newp, nil)
+	tp.AddMember("P", "member-old")
+	tp.AddMember("P", "member-new")
+	tp.SetMinBinaryVersion("P", "1.8.0")
+
+	provider, routeErr := s.selectProviderExcluding(context.Background(), "rid", poolChatReq("P"), http.Header{}, nil, "2024-01-01", &forwardState{})
+	if routeErr != nil {
+		t.Fatalf("mixed pool rejected: %+v", routeErr)
+	}
+	if provider.ProviderID != "member-new" {
+		t.Fatalf("selected %q, want member-new (member-old is below floor)", provider.ProviderID)
+	}
+}
+
+// An empty/unparseable binary_version while a floor is in force is treated as
+// below the floor (fail-safe), so such a member is excluded.
+func TestPoolBinaryFloor_EmptyVersionExcluded(t *testing.T) {
+	s, registry, tp := poolIsolationServer(t)
+	blank := poolProviderVer("member-blank", "") // no version reported
+	registry.Register(&blank, nil)
+	tp.AddMember("P", "member-blank")
+	tp.SetMinBinaryVersion("P", "1.8.0")
+
+	_, routeErr := s.selectProviderExcluding(context.Background(), "rid", poolChatReq("P"), http.Header{}, nil, "2024-01-01", &forwardState{})
+	if routeErr == nil || routeErr.code != "pool_binary_too_old" {
+		t.Fatalf("empty-version member: want pool_binary_too_old, got %+v", routeErr)
+	}
+}
+
+// No floor configured for the pool -> the gate is a strict no-op; a member is
+// served regardless of its (low) binary version.
+func TestPoolBinaryFloor_NoFloorInert(t *testing.T) {
+	s, registry, tp := poolIsolationServer(t)
+	old := poolProviderVer("member-old", "1.0.0")
+	registry.Register(&old, nil)
+	tp.AddMember("P", "member-old") // no SetMinBinaryVersion -> floor ""
+
+	provider, routeErr := s.selectProviderExcluding(context.Background(), "rid", poolChatReq("P"), http.Header{}, nil, "2024-01-01", &forwardState{})
+	if routeErr != nil {
+		t.Fatalf("floorless pool rejected a member: %+v", routeErr)
+	}
+	if provider.ProviderID != "member-old" {
+		t.Fatalf("selected %q, want member-old (no floor configured)", provider.ProviderID)
+	}
+}
+
+// Global (poolless) request: the floor is never consulted; a low-version
+// provider is served exactly as before (byte-identical).
+func TestPoolBinaryFloor_GlobalUnaffected(t *testing.T) {
+	s, registry, tp := poolIsolationServer(t)
+	_ = tp
+	old := poolProviderVer("any-provider", "1.0.0")
+	registry.Register(&old, nil)
+
+	provider, routeErr := s.selectProviderExcluding(context.Background(), "rid", poolChatReq(""), http.Header{}, nil, "2024-01-01", &forwardState{})
+	if routeErr != nil {
+		t.Fatalf("global request rejected: %+v", routeErr)
+	}
+	if provider.ProviderID != "any-provider" {
+		t.Fatalf("selected %q, want any-provider", provider.ProviderID)
+	}
+}
+
+// Pinned/self-route path: a hard pin to an under-version member is refused with
+// pool_binary_too_old (a pin must not bypass the floor).
+func TestPoolBinaryFloor_PinnedBelowFloorRejected(t *testing.T) {
+	s, registry, tp := poolIsolationServer(t)
+	old := poolProviderVer("member-old", "1.7.0")
+	registry.Register(&old, nil)
+	tp.AddMember("P", "member-old")
+	tp.SetMinBinaryVersion("P", "1.8.0")
+
+	headers := http.Header{}
+	headers.Set("X-MacProvider-Provider", "member-old")
+	_, routeErr := s.selectProviderExcluding(context.Background(), "rid", poolChatReq("P"), headers, nil, "2024-01-01", &forwardState{})
+	if routeErr == nil || routeErr.code != "pool_binary_too_old" {
+		t.Fatalf("pin to under-version member: want pool_binary_too_old, got %+v", routeErr)
+	}
+}
+
+// Pinned member at/above the floor passes the gate.
+func TestPoolBinaryFloor_PinnedAboveFloorServed(t *testing.T) {
+	s, registry, tp := poolIsolationServer(t)
+	newp := poolProviderVer("member-new", "1.9.0")
+	registry.Register(&newp, nil)
+	tp.AddMember("P", "member-new")
+	tp.SetMinBinaryVersion("P", "1.8.0")
+
+	headers := http.Header{}
+	headers.Set("X-MacProvider-Provider", "member-new")
+	provider, routeErr := s.selectProviderExcluding(context.Background(), "rid", poolChatReq("P"), headers, nil, "2024-01-01", &forwardState{})
+	if routeErr != nil {
+		t.Fatalf("pin to above-floor member rejected: %+v", routeErr)
+	}
+	if provider.ProviderID != "member-new" {
+		t.Fatalf("selected %q, want member-new", provider.ProviderID)
+	}
+}
+
+// Slot-queue candidate derivation drops an under-version member and keeps the
+// eligible one (the by-hand path must apply the same floor).
+func TestPoolBinaryFloor_SlotQueueExcludesBelowFloor(t *testing.T) {
+	s, _, tp := poolIsolationServer(t)
+	tp.AddMember("P", "member-old")
+	tp.AddMember("P", "member-new")
+	tp.SetMinBinaryVersion("P", "1.8.0")
+	snap := tp.Snapshot("P")
+	checker := &eligibilityCtx{
+		s: s, model: "model-a", estimatedTokens: 100,
+		tier2Cfg:             s.tier2Config(),
+		poolID:               "P",
+		poolMembers:          snap.Members,
+		poolMinBinaryVersion: snap.MinBinaryVersion,
+	}
+	busy := func(id, ver string) pool.Provider {
+		p := poolProviderVer(id, ver)
+		p.SlotsFree = 0 // slot-queue eligibility requires a saturated provider
+		return p
+	}
+	providers := []pool.Provider{busy("member-old", "1.7.0"), busy("member-new", "1.8.2")}
+	got := s.slotQueueCandidates(providers, routing.NewExcluded(0), checker)
+	if len(got) != 1 || got[0].ProviderID != "member-new" {
+		t.Fatalf("slotQueueCandidates = %+v, want only member-new (under-version dropped)", got)
+	}
+}
+
+// Slot-queue poll: a same-ID reconnect below the floor is terminated off the
+// queue (the poll path re-checks the floor from the selection snapshot).
+func TestPoolBinaryFloor_SlotQueuePollExcludesBelowFloor(t *testing.T) {
+	s, registry, tp := poolIsolationServer(t)
+	old := poolProviderVer("member-old", "1.7.0")
+	registry.Register(&old, nil)
+	tp.AddMember("P", "member-old")
+	tp.SetMinBinaryVersion("P", "1.8.0")
+
+	w, ok := s.slotQueue.enter("member-old")
+	if !ok {
+		t.Fatal("enter returned no waiter")
+	}
+	defer s.slotQueue.leave(w)
+	snap := tp.Snapshot("P")
+	state := &forwardState{poolID: "P", poolMembers: snap.Members, poolMinBinaryVersion: snap.MinBinaryVersion}
+	if _, status := s.pollQueuedProvider(w, "model-a", nil, 100, state); status != queuedProviderTerminal {
+		t.Fatalf("poll status = %v, want terminal (under-version member off the queue)", status)
+	}
+}
+
+// Membership dominates: a NON-member (whatever its version) is reported
+// pool_no_eligible_member, never pool_binary_too_old — the floor is evaluated
+// only for actual members.
+func TestPoolBinaryFloor_MembershipDominates(t *testing.T) {
+	s, registry, tp := poolIsolationServer(t)
+	member := poolProviderVer("member-new", "1.9.0")
+	nonmember := poolProviderVer("nonmember-z", "1.0.0")
+	registry.Register(&member, nil)
+	registry.Register(&nonmember, nil)
+	tp.AddMember("P", "member-new") // z is not a member
+	tp.SetMinBinaryVersion("P", "1.8.0")
+
+	headers := http.Header{}
+	headers.Set("X-MacProvider-Provider", "nonmember-z")
+	_, routeErr := s.selectProviderExcluding(context.Background(), "rid", poolChatReq("P"), headers, nil, "2024-01-01", &forwardState{})
+	if routeErr == nil || routeErr.code != "pool_no_eligible_member" {
+		t.Fatalf("pin to non-member: want pool_no_eligible_member (membership dominates), got %+v", routeErr)
+	}
+}
+
+// SetMinBinaryVersion bumps the pool generation, so a route attempt fenced to
+// the prior generation is stale — a raised floor invalidates in-flight
+// reservations via the existing R005 fence rather than leaking under-version
+// dispatch for a TTL.
+func TestPoolBinaryFloor_SetMinBumpsGeneration(t *testing.T) {
+	s, _, tp := poolIsolationServer(t)
+	tp.AddMember("P", "member-x")
+	gen0 := tp.Generation("P")
+	state := &forwardState{poolID: "P", poolGeneration: gen0, poolGenSet: true}
+	if s.poolGenerationStale(state) {
+		t.Fatal("fresh snapshot must not be stale")
+	}
+	tp.SetMinBinaryVersion("P", "1.8.0")
+	if tp.Generation("P") <= gen0 {
+		t.Fatalf("SetMinBinaryVersion did not bump generation: gen0=%d now=%d", gen0, tp.Generation("P"))
+	}
+	if !s.poolGenerationStale(state) {
+		t.Fatal("generation advanced after a floor change; fence must report stale")
+	}
+	// Setting the same floor again is a no-op (no generation churn).
+	genAfter := tp.Generation("P")
+	tp.SetMinBinaryVersion("P", "1.8.0")
+	if tp.Generation("P") != genAfter {
+		t.Fatal("setting the same floor bumped the generation; want no-op")
+	}
+}

--- a/phase4-coordinator/internal/buyer/spec042_pool_binary_floor_test.go
+++ b/phase4-coordinator/internal/buyer/spec042_pool_binary_floor_test.go
@@ -17,6 +17,60 @@ func poolProviderVer(providerID, version string) pool.Provider {
 	return p
 }
 
+// poolBinaryFloorMet must delegate to the coordinator's canonical
+// versionfloor.Compare so the pool gate keeps identical version semantics
+// (v-prefix tolerated, pre-release/extra-component rejected, empty floor
+// inert, empty/malformed provider version fail-safe excluded).
+func TestPoolBinaryFloorMet(t *testing.T) {
+	cases := []struct {
+		version, floor string
+		want           bool
+	}{
+		{"1.8.0", "1.8.0", true},   // equal meets
+		{"1.8.1", "1.8.0", true},   // above meets
+		{"1.7.9", "1.8.0", false},  // below excluded
+		{"v1.8.0", "1.8.0", true},  // v-prefix tolerated by the comparator
+		{"1.8.0", "v1.8.0", true},  // v-prefix on the floor too
+		{"2", "1.8.0", true},       // short form, above
+		{"1.8", "1.8.0", true},     // short form, equal (zero-fill)
+		{"1.8.0-rc1", "1.8.0", false}, // pre-release unparseable -> excluded (fail-safe)
+		{"1.2.3.4", "1.8.0", false},   // too many components -> excluded (fail-safe)
+		{"", "1.8.0", false},          // empty provider version -> excluded (fail-safe)
+		{"garbage", "1.8.0", false},   // non-numeric -> excluded (fail-safe)
+		{"1.0.0", "", true},           // empty floor -> inert (always met)
+		{"", "", true},                // no floor, no version -> inert
+	}
+	for _, tc := range cases {
+		if got := poolBinaryFloorMet(tc.version, tc.floor); got != tc.want {
+			t.Errorf("poolBinaryFloorMet(%q,%q)=%v want %v", tc.version, tc.floor, got, tc.want)
+		}
+	}
+}
+
+// A malformed floor is rejected at set time (SetMinBinaryVersion returns an
+// error and does not store it), so a config typo cannot brick a pool with a
+// stored-but-unparseable floor that fails every provider.
+func TestPoolBinaryFloor_SetRejectsMalformedFloor(t *testing.T) {
+	_, _, tp := poolIsolationServer(t)
+	for _, bad := range []string{"latest", "1.8.0.1", "1.8.0-rc1", "v", "1.x"} {
+		if err := tp.SetMinBinaryVersion("P", bad); err == nil {
+			t.Fatalf("SetMinBinaryVersion(%q) accepted a malformed floor", bad)
+		}
+	}
+	// A valid floor and clearing ("") are accepted.
+	if err := tp.SetMinBinaryVersion("P", "1.8.0"); err != nil {
+		t.Fatalf("valid floor rejected: %v", err)
+	}
+	if err := tp.SetMinBinaryVersion("P", ""); err != nil {
+		t.Fatalf("clearing floor rejected: %v", err)
+	}
+	// A rejected floor left no floor stored -> a low-version member is still
+	// served (the bad set was a no-op, not a silent brick).
+	if tp.Snapshot("P").MinBinaryVersion != "" {
+		t.Fatalf("rejected/cleared floor left a stored value: %q", tp.Snapshot("P").MinBinaryVersion)
+	}
+}
+
 // Ordinary filter path: a pool whose only member is below the floor fails
 // closed with the non-retryable pool_binary_too_old — never spilling to the
 // under-version member or to global (SPEC-042 R004/R010).

--- a/phase4-coordinator/internal/routing/filter.go
+++ b/phase4-coordinator/internal/routing/filter.go
@@ -59,6 +59,20 @@ const (
 	// dropped for this reason the eligible list is empty and the request
 	// surfaces the no-eligible-member 503 with no spill to global.
 	ReasonPoolNotMember
+	// ReasonPoolBinaryTooOld — the request carries a pool_id (SPEC-042) and
+	// the provider IS a current member, but its reported binary_version is
+	// below the pool's configured minimum (SPEC-042 R004 predicate), so it
+	// cannot safely serve the pool's traffic under a mixed-binary rollout
+	// (SPEC-042 R010, the provider half of the positive capability handshake).
+	// A false ProviderMeetsPoolBinaryFloor return is reported here. Membership
+	// dominates: a non-member is reported ReasonPoolNotMember and never also
+	// evaluated for the floor. With no pool selected, or no floor configured
+	// for the pool, the checker returns true for every provider and this
+	// reason never fires — poolless and floorless selection stay byte-identical.
+	// Fail-closed: when members exist but all are dropped for this reason the
+	// request surfaces pool_binary_too_old (503) with no spill to an
+	// under-version or global provider.
+	ReasonPoolBinaryTooOld
 )
 
 // EligibilityChecker is the cross-package boundary between the
@@ -139,6 +153,19 @@ type EligibilityChecker interface {
 	// consistent snapshot (SPEC-042 R003) so a revocation cannot leave
 	// a stale member passing this gate.
 	ProviderInPool(p pool.Provider) bool
+
+	// ProviderMeetsPoolBinaryFloor reports whether a pool MEMBER's reported
+	// binary_version satisfies the selected pool's minimum version floor
+	// (SPEC-042 R004 / R010 provider half). A false return is reported as
+	// ReasonPoolBinaryTooOld. This is evaluated only after ProviderInPool
+	// (membership dominates). Implementations MUST return true for every
+	// provider when the request carries no pool selection OR the pool has no
+	// floor configured, so poolless and floorless selection stay
+	// byte-identical. The floor MUST come from the SAME consistent snapshot as
+	// membership/generation (SPEC-042 R003), and an empty/unparseable
+	// binary_version while a floor is in force MUST be treated as below the
+	// floor (fail-safe, mirroring the #768 malformed-version posture).
+	ProviderMeetsPoolBinaryFloor(p pool.Provider) bool
 }
 
 // RejectedProvider records a single provider drop with enough
@@ -225,6 +252,15 @@ func EligibleCandidates(
 		// byte-identical to pre-SPEC-042.
 		if !checker.ProviderInPool(p) {
 			res.Counts[ReasonPoolNotMember]++
+			continue
+		}
+		// SPEC-042 R004/R010 provider half: a pool MEMBER whose binary_version
+		// is below the pool's configured floor cannot serve the pool's traffic
+		// under a mixed-binary rollout. Evaluated after membership (which
+		// dominates). No-op for global requests and for pools with no floor,
+		// so poolless/floorless selection stays byte-identical.
+		if !checker.ProviderMeetsPoolBinaryFloor(p) {
+			res.Counts[ReasonPoolBinaryTooOld]++
 			continue
 		}
 		if !checker.ProviderMatchesRequest(p) {

--- a/phase4-coordinator/internal/routing/filter_test.go
+++ b/phase4-coordinator/internal/routing/filter_test.go
@@ -18,6 +18,7 @@ type stubChecker struct {
 	tier2Hash      map[string]pool.HashStatus
 	quotaOK        map[string]bool
 	poolMember     map[string]bool
+	poolBinaryOK   map[string]bool
 }
 
 func (s *stubChecker) ProviderMatchesRequest(p pool.Provider) bool {
@@ -58,6 +59,14 @@ func (s *stubChecker) ProviderInPool(p pool.Provider) bool {
 	// selection stays byte-identical; tests set poolMember[id]=false for
 	// non-members of the selected pool.
 	if v, ok := s.poolMember[p.ProviderID]; ok {
+		return v
+	}
+	return true
+}
+func (s *stubChecker) ProviderMeetsPoolBinaryFloor(p pool.Provider) bool {
+	// Default true (no floor / member meets it); tests set
+	// poolBinaryOK[id]=false for under-version members.
+	if v, ok := s.poolBinaryOK[p.ProviderID]; ok {
 		return v
 	}
 	return true
@@ -233,6 +242,7 @@ type recordingChecker struct {
 	tier2Reason      map[string]routing.RejectionReason
 	quotaFail        map[string]bool
 	poolNonMember    map[string]bool
+	poolBinaryFail   map[string]bool
 }
 
 func (r *recordingChecker) ProviderMatchesRequest(p pool.Provider) bool {
@@ -262,6 +272,10 @@ func (r *recordingChecker) QuotaPermits(p pool.Provider) bool {
 func (r *recordingChecker) ProviderInPool(p pool.Provider) bool {
 	r.calls = append(r.calls, p.ProviderID+"/pool")
 	return !r.poolNonMember[p.ProviderID]
+}
+func (r *recordingChecker) ProviderMeetsPoolBinaryFloor(p pool.Provider) bool {
+	r.calls = append(r.calls, p.ProviderID+"/pool_binary")
+	return !r.poolBinaryFail[p.ProviderID]
 }
 
 func TestEligibleCandidates_OrderingExcludedShortCircuitsEverything(t *testing.T) {
@@ -304,7 +318,7 @@ func TestEligibleCandidates_OrderingPerProviderSequence(t *testing.T) {
 	routing.EligibleCandidates(providers, routing.NewExcluded(0), keyer, checker)
 	// SPEC-042 R005 pool-membership gate is first among property gates
 	// (right after excluded), before the model match.
-	want := []string{"p/pool", "p/match", "p/version_floor", "p/receipt_key", "p/context", "p/tier2", "p/quota"}
+	want := []string{"p/pool", "p/pool_binary", "p/match", "p/version_floor", "p/receipt_key", "p/context", "p/tier2", "p/quota"}
 	if len(checker.calls) != len(want) {
 		t.Fatalf("call count: want %d, got %d (calls=%v)", len(want), len(checker.calls), checker.calls)
 	}
@@ -320,7 +334,7 @@ func TestEligibleCandidates_OrderingContextRejectStopsBeforeTier2AndQuota(t *tes
 	providers := []pool.Provider{{ProviderID: "p", AssignedID: "s"}}
 	checker := &recordingChecker{t: t, contextFail: map[string]bool{"p": true}}
 	routing.EligibleCandidates(providers, routing.NewExcluded(0), keyer, checker)
-	want := []string{"p/pool", "p/match", "p/version_floor", "p/receipt_key", "p/context"}
+	want := []string{"p/pool", "p/pool_binary", "p/match", "p/version_floor", "p/receipt_key", "p/context"}
 	if len(checker.calls) != len(want) {
 		t.Fatalf("context-reject: want sequence %v, got %v", want, checker.calls)
 	}
@@ -473,7 +487,7 @@ func TestEligibleCandidates_OrderingVersionFloorRejectStopsBeforeContext(t *test
 	providers := []pool.Provider{{ProviderID: "p", AssignedID: "s"}}
 	checker := &recordingChecker{t: t, versionFloorFail: map[string]bool{"p": true}}
 	routing.EligibleCandidates(providers, routing.NewExcluded(0), keyer, checker)
-	want := []string{"p/pool", "p/match", "p/version_floor"}
+	want := []string{"p/pool", "p/pool_binary", "p/match", "p/version_floor"}
 	if len(checker.calls) != len(want) {
 		t.Fatalf("calls = %v, want exactly %v", checker.calls, want)
 	}

--- a/phase4-coordinator/internal/trustpool/registry.go
+++ b/phase4-coordinator/internal/trustpool/registry.go
@@ -13,7 +13,12 @@
 // populate. The Registry is safe for concurrent use.
 package trustpool
 
-import "sync"
+import (
+	"fmt"
+	"sync"
+
+	"github.com/augstar/macprovider-coordinator/internal/versionfloor"
+)
 
 // Registry maps pool_id -> membership/revocation state.
 type Registry struct {
@@ -118,15 +123,26 @@ func (r *Registry) Revoke(poolID, providerID string) {
 // generation (SPEC-042 R005), so the new floor applies at the very next
 // dispatch rather than leaking a window of under-version routing. "" clears
 // the floor. Seed helper / control-plane action.
-func (r *Registry) SetMinBinaryVersion(poolID, version string) {
+//
+// The floor MUST be a version the coordinator's canonical comparator can parse
+// (versionfloor.Valid); a malformed floor is REJECTED here rather than stored,
+// because a stored-but-unparseable floor makes versionfloor.Compare fail for
+// every provider and bricks the whole pool with pool_binary_too_old (an
+// avoidable, confusing pool-wide outage from a config typo). Invalid input is a
+// no-op that returns an error and does not bump the generation.
+func (r *Registry) SetMinBinaryVersion(poolID, version string) error {
+	if version != "" && !versionfloor.Valid(version) {
+		return fmt.Errorf("trustpool: invalid pool min binary version %q for pool %q", version, poolID)
+	}
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	ps := r.ensure(poolID)
 	if ps.minBinaryVersion == version {
-		return
+		return nil
 	}
 	ps.minBinaryVersion = version
 	ps.generation++
+	return nil
 }
 
 // Snapshot returns a consistent read of the pool's non-revoked members, its

--- a/phase4-coordinator/internal/trustpool/registry.go
+++ b/phase4-coordinator/internal/trustpool/registry.go
@@ -29,7 +29,14 @@ type poolState struct {
 	// path explicitly is not.
 	members map[string]struct{}
 	revoked map[string]struct{}
-	// generation increments on every membership/revocation change so the
+	// minBinaryVersion is the pool's minimum provider binary version
+	// (SPEC-042 R004 predicate). A member whose binary_version is below this
+	// floor is not eligible for the pool's traffic (SPEC-042 R010
+	// pool_binary_too_old). "" means no floor is configured — the gate is a
+	// strict no-op. The floor rides this consistent snapshot so a route
+	// attempt evaluates membership AND floor against one coherent view.
+	minBinaryVersion string
+	// generation increments on every membership/revocation/floor change so the
 	// routing generation fence (SPEC-042 R005) can detect a snapshot that
 	// is no longer current.
 	generation uint64
@@ -44,7 +51,11 @@ type Snapshot struct {
 	PoolID     string
 	Exists     bool
 	Members    map[string]bool // non-revoked members, keyed by provider identity
-	Generation uint64
+	// MinBinaryVersion is the pool's minimum provider binary version floor
+	// (SPEC-042 R004), captured under the same lock as Members/Generation.
+	// "" means no floor — the eligibility gate is inert.
+	MinBinaryVersion string
+	Generation       uint64
 }
 
 // NewRegistry returns an empty registry.
@@ -101,9 +112,27 @@ func (r *Registry) Revoke(poolID, providerID string) {
 	ps.generation++
 }
 
-// Snapshot returns a consistent read of the pool's non-revoked members and
-// its generation. For an unknown pool, Exists is false and Members is empty,
-// which the routing layer treats as fail-closed (no eligible member).
+// SetMinBinaryVersion sets the pool's minimum provider binary version floor
+// (SPEC-042 R004) and bumps the generation. Bumping the generation means a
+// raised floor invalidates in-flight reservations fenced to the prior
+// generation (SPEC-042 R005), so the new floor applies at the very next
+// dispatch rather than leaking a window of under-version routing. "" clears
+// the floor. Seed helper / control-plane action.
+func (r *Registry) SetMinBinaryVersion(poolID, version string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	ps := r.ensure(poolID)
+	if ps.minBinaryVersion == version {
+		return
+	}
+	ps.minBinaryVersion = version
+	ps.generation++
+}
+
+// Snapshot returns a consistent read of the pool's non-revoked members, its
+// binary-version floor, and its generation. For an unknown pool, Exists is
+// false and Members is empty, which the routing layer treats as fail-closed
+// (no eligible member).
 func (r *Registry) Snapshot(poolID string) Snapshot {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
@@ -118,7 +147,7 @@ func (r *Registry) Snapshot(poolID string) Snapshot {
 		}
 		members[id] = true
 	}
-	return Snapshot{PoolID: poolID, Exists: true, Members: members, Generation: ps.generation}
+	return Snapshot{PoolID: poolID, Exists: true, Members: members, MinBinaryVersion: ps.minBinaryVersion, Generation: ps.generation}
 }
 
 // Generation returns the current generation for a pool (0 for unknown pools).


### PR DESCRIPTION
## SPEC-042 R004/R010: pool provider binary-version floor (handshake provider half)

Completes the SPEC-042 R010 positive capability handshake **end-to-end**. The gateway already verifies the coordinator advertises pool support (#1076); this adds the **provider half** inside the coordinator: a pool request is never routed to a member whose `binary_version` is below the pool's configured minimum (a pool-blind provider under a mixed-binary rollout). Coordinator-only; reuses the provider's existing `binary_version` handshake, so **no provider/Swift change and no release** (Option A).

### What it does
- **Per-pool floor in the consistent snapshot.** `trustpool` `poolState.minBinaryVersion` → `Snapshot.MinBinaryVersion`, read under the same lock as members/generation. `SetMinBinaryVersion` **bumps the generation**, so raising a floor invalidates in-flight reservations via the existing R005 fence (validated with `versionfloor.Valid`, rejects a malformed floor rather than bricking the pool).
- **Gate on every dispatch-authorizing path.** New `ProviderMeetsPoolBinaryFloor` filter gate (after membership, which dominates) + by-hand re-checks on the pinned-session, pinned/self-route, slot-queue-enter, and slot-queue-poll paths — same discipline as the isolation gate, so a pin can't bypass the floor.
- **Fail-safe + fail-closed.** Empty/malformed `binary_version` under a floor → excluded (`versionfloor.Compare` not-ok); all-under-version → `pool_binary_too_old` (503, non-retryable), no spill. Floor `""` is a strict no-op; global/poolless byte-identical.
- **Error taxonomy.** `pool_binary_too_old` registered in `spec018RetryableByCode` + `coordinatorEmittedErrorCodes`; envelope maps it before `pool_no_eligible_member` (present-but-under-version is a more specific signal than no-member); reason surfaced distinctly in the routing-decision log.

### Money-path audit — codex 3 lanes
- **Code:** round 1 found 1 Medium (floor validation) + 1 Low (comparator tests) → **both fixed**, re-verified.
- **Security + Architect:** confirmed the enforcement is solid — every dispatch path gated, malformed fails closed, floorless/poolless inert — and both raised the same **HIGH: the floor compares against self-reported `binary_version`, not SPEC-020 signed release evidence** (R004's literal "signed" requirement). This is an **accepted, documented carry** (owner-decided):
  - It reuses the *exact* signal the pre-existing #768 model-version floor and global-admission floor already trust — **not a new/worsened trust assumption**.
  - The primary boundary, pool **membership**, is an authenticated SPEC-003 identity explicitly admitted by the pool creator; the spoof threat is bounded to a creator-admitted-then-compromised member.
  - There is **no** coordinator-held verified binary evidence today (attestation binds the SE key/tier, not the version; no SPEC-020 evidence store) — a real fix is a separate, sizeable build.
  - The feature is **default-off / unenabled** — no live exposure.
  - **Upgrade path is localized:** when verified binary evidence exists, swap only what `poolBinaryFloorMet` compares against; the rails are unchanged.
  - Documented in `docs/design/spec-042-v0.1-slice-pool-binary-floor.md` §7 and a code trust-note.
- **Architect** also carried a second HIGH: **floorless pools are inert** — R004's binary predicate is *optional*; per-pool policy completeness (require a floor / advertise per-pool readiness) belongs to the enable path + manifest (R001/R008/R011). Documented in §7.

### Verification
`buyer` / `routing` / `trustpool` green (incl. the error-code AST guard and the existing pool-isolation tests). New conformance tests: all four dispatch paths exclude under-version members; all-below-floor fails closed non-retryable; at/above served; empty/malformed version fail-safe excluded; no-floor inert; global unaffected; membership dominates; `SetMinBinaryVersion` bumps generation + rejects malformed floors; comparator table tests.

### Compatibility / scope
- Default-off; global/poolless/floorless paths byte-identical. Provider handshake unchanged. Coordinator-only (phase4).
- Deferred (documented, each fails closed or inert by design): SPEC-020 signed release evidence as the trust source; the signed manifest (R001) as the floor source; a dedicated `pool_support_version` field; other R004 predicates (encrypted-leg, attestation).

> **`spec-index / check` is advisory-red** (SPEC-042 per-requirement CONFORMANCE records R001–R012 are still deferred), same as the rest of the SPEC-042 stack. Advisory, not merge-blocking.

SPEC-GOVERNANCE-DECLARATION-BEGIN
{
  "schema_version": "spec-pr-governance-v1",
  "behavior_change": "yes",
  "contract_change": "none",
  "specs": ["SPEC-042"],
  "requirements": ["SPEC-042-R004", "SPEC-042-R010"],
  "authority_domains": ["pool-control-plane"],
  "arbitration": ["CODE_BUG"],
  "tests": ["phase4-coordinator/internal/buyer/spec042_pool_binary_floor_test.go"],
  "journeys": ["not-required"],
  "issue": "https://github.com/Augustas11/macprovider/issues/1053"
}
SPEC-GOVERNANCE-DECLARATION-END

🤖 Generated with [Claude Code](https://claude.com/claude-code)
