### PR TITLE
SPEC-042: register per-requirement CONFORMANCE records R001-R012 (clear advisory check)

### DIFF
--- a/specs/CONFORMANCE.json
+++ b/specs/CONFORMANCE.json
@@ -1252,7 +1252,7 @@
       "last_reconciled_commit": null,
       "last_reconciled_at": null,
       "evidence": [],
-      "requirement_id_migration": "pending",
+      "requirement_id_migration": "complete",
       "gap": {
         "verdict": "DECISION_REQUIRED",
         "owner": "@Augustas11",
@@ -5097,6 +5097,219 @@
         "owner": "@Augustas11",
         "issue": "https://github.com/Augustas11/macprovider/issues/926",
         "rationale": "The repo now contains the Malibu-domain hosted agent onboarding skill source, discovery index, and drift validator; the requirement remains pending until the public get.malibu.tech route is published and byte-compared against the repo artifact."
+      }
+    },
+    {
+      "requirement_id": "SPEC-042-R001",
+      "spec_id": "SPEC-042",
+      "state": "pending",
+      "implementation": [],
+      "tests": [],
+      "journeys": [],
+      "evidence": [],
+      "gap": {
+        "verdict": "DECISION_REQUIRED",
+        "owner": "@Augustas11",
+        "issue": "https://github.com/Augustas11/macprovider/issues/1053",
+        "rationale": "Pool object + signed manifest + identity/rollback (pool_id as digest of a stable identity core; versioned policy core): NOT yet implemented. The signed manifest write/verify path is a future slice; pool state is seeded in-memory today (internal/trustpool). Gated in the SPEC-042 R010 v0.1 promotion checklist."
+      }
+    },
+    {
+      "requirement_id": "SPEC-042-R002",
+      "spec_id": "SPEC-042",
+      "state": "pending",
+      "implementation": [
+        "phase5-gateway/internal/router/pool_selection.go:func (s *Server) resolvePoolSelection",
+        "phase4-coordinator/internal/buyer/server.go:func (s *Server) selectProviderExcluding"
+      ],
+      "tests": [
+        "phase5-gateway/internal/router/pool_selection_test.go:TestPoolSelection_AuthorizedAndCapable_EmitsHeader"
+      ],
+      "journeys": [],
+      "evidence": [],
+      "gap": {
+        "verdict": "DECISION_REQUIRED",
+        "owner": "@Augustas11",
+        "issue": "https://github.com/Augustas11/macprovider/issues/1053",
+        "rationale": "pool_id authority threading + credential-bound selection authorization: implemented across gateway selection-auth and coordinator routing/record threading (#1069/#1072/#1076). Conformance promotion (signed journey-result evidence) deferred; per-key pool scope + wallet-session selection remain future slices."
+      }
+    },
+    {
+      "requirement_id": "SPEC-042-R003",
+      "spec_id": "SPEC-042",
+      "state": "pending",
+      "implementation": [
+        "phase4-coordinator/internal/trustpool/registry.go:func (r *Registry) Revoke",
+        "phase4-coordinator/internal/trustpool/registry.go:func (r *Registry) Snapshot"
+      ],
+      "tests": [
+        "phase4-coordinator/internal/trustpool/registry_test.go:TestRevoke_RemovesMemberAndBumpsGeneration",
+        "phase4-coordinator/internal/trustpool/registry_test.go:TestRevoke_IsDurableBlocklist"
+      ],
+      "journeys": [],
+      "evidence": [],
+      "gap": {
+        "verdict": "DECISION_REQUIRED",
+        "owner": "@Augustas11",
+        "issue": "https://github.com/Augustas11/macprovider/issues/1053",
+        "rationale": "Pool-scoped membership + durable revocation blocklist: in-memory registry with consistent snapshot + generation bump implemented (#1069). Durable, restart-surviving persistence (R003 durable ledger) and the manifest-driven write path are deferred to a later slice."
+      }
+    },
+    {
+      "requirement_id": "SPEC-042-R004",
+      "spec_id": "SPEC-042",
+      "state": "pending",
+      "implementation": [
+        "phase4-coordinator/internal/buyer/server.go:func poolBinaryFloorMet",
+        "phase4-coordinator/internal/buyer/server.go:func (c *eligibilityCtx) ProviderMeetsPoolBinaryFloor"
+      ],
+      "tests": [
+        "phase4-coordinator/internal/buyer/spec042_pool_binary_floor_test.go:TestPoolBinaryFloor_AllBelowFloor_FailsClosed"
+      ],
+      "journeys": [],
+      "evidence": [],
+      "gap": {
+        "verdict": "DECISION_REQUIRED",
+        "owner": "@Augustas11",
+        "issue": "https://github.com/Augustas11/macprovider/issues/1053",
+        "rationale": "Pool-enforceable fail-closed trust predicates: the minimum-binary-version predicate is implemented fail-closed on every dispatch path (#1079). Other R004 predicates (attestation-tier-as-pool-predicate, require_encrypted_leg, model-hash policy, hardware_mda) and SPEC-020 signed-version evidence are deferred; the binary floor keys off self-reported binary_version (documented carry)."
+      }
+    },
+    {
+      "requirement_id": "SPEC-042-R005",
+      "spec_id": "SPEC-042",
+      "state": "pending",
+      "implementation": [
+        "phase4-coordinator/internal/buyer/server.go:func (c *eligibilityCtx) ProviderInPool",
+        "phase4-coordinator/internal/buyer/server.go:func (s *Server) poolGenerationStale"
+      ],
+      "tests": [
+        "phase4-coordinator/internal/buyer/spec042_pool_isolation_test.go:TestPoolIsolation_PinnedNonMemberRejected"
+      ],
+      "journeys": [],
+      "evidence": [],
+      "gap": {
+        "verdict": "DECISION_REQUIRED",
+        "owner": "@Augustas11",
+        "issue": "https://github.com/Augustas11/macprovider/issues/1053",
+        "rationale": "Per-attempt pool-scoped tenant isolation + generation fence: implemented on the ordinary filter and every by-hand dispatch path with a select->dispatch generation fence (#1069). Conformance promotion (signed journey-result evidence) deferred."
+      }
+    },
+    {
+      "requirement_id": "SPEC-042-R006",
+      "spec_id": "SPEC-042",
+      "state": "pending",
+      "implementation": [
+        "phase4-coordinator/internal/billing/route_snapshot.go:func (s *Store) InsertRouteSnapshot",
+        "phase4-coordinator/internal/billing/route_snapshot.go:func (r RouteSnapshot) Value"
+      ],
+      "tests": [
+        "phase4-coordinator/internal/billing/route_snapshot_test.go:TestRouteSnapshotPoolID_DigestBinding",
+        "phase4-coordinator/internal/billing/route_snapshot_test.go:TestRouteSnapshotPoolID_RoundTripsThroughSettlementLoader"
+      ],
+      "journeys": [],
+      "evidence": [],
+      "gap": {
+        "verdict": "DECISION_REQUIRED",
+        "owner": "@Augustas11",
+        "issue": "https://github.com/Augustas11/macprovider/issues/1053",
+        "rationale": "Labels-only pool-scoped settlement bound to the route snapshot: pool_id is bound into the canonical route-snapshot digest and persisted (#1072). label_disputed mismatch handling and creator revenue-split (SPEC-005/016 V1) are deferred."
+      }
+    },
+    {
+      "requirement_id": "SPEC-042-R007",
+      "spec_id": "SPEC-042",
+      "state": "pending",
+      "implementation": [],
+      "tests": [],
+      "journeys": [],
+      "evidence": [],
+      "gap": {
+        "verdict": "DECISION_REQUIRED",
+        "owner": "@Augustas11",
+        "issue": "https://github.com/Augustas11/macprovider/issues/1053",
+        "rationale": "Pool-scoped observability + field-level retention matrix: NOT yet implemented (the retention-matrix field list is a deferred v0.1 detailed-design deliverable in the R010 promotion checklist)."
+      }
+    },
+    {
+      "requirement_id": "SPEC-042-R008",
+      "spec_id": "SPEC-042",
+      "state": "pending",
+      "implementation": [],
+      "tests": [],
+      "journeys": [],
+      "evidence": [],
+      "gap": {
+        "verdict": "DECISION_REQUIRED",
+        "owner": "@Augustas11",
+        "issue": "https://github.com/Augustas11/macprovider/issues/1053",
+        "rationale": "Buyer-verifiable pool_policy.json + coordinator-attested pool_status.json (closed schemas): NOT yet implemented; the JSON schemas are deferred v0.1 detailed-design deliverables."
+      }
+    },
+    {
+      "requirement_id": "SPEC-042-R009",
+      "spec_id": "SPEC-042",
+      "state": "pending",
+      "implementation": [],
+      "tests": [],
+      "journeys": [],
+      "evidence": [],
+      "gap": {
+        "verdict": "DECISION_REQUIRED",
+        "owner": "@Augustas11",
+        "issue": "https://github.com/Augustas11/macprovider/issues/1053",
+        "rationale": "Layer 3 compatibility fields + claim control + privacy binding: NOT yet implemented and blocked until SPEC-041/SPEC-040 are amended; SPEC-042 v0.1 makes no relay-blind/content-confidentiality claim."
+      }
+    },
+    {
+      "requirement_id": "SPEC-042-R010",
+      "spec_id": "SPEC-042",
+      "state": "pending",
+      "implementation": [
+        "phase5-gateway/internal/router/pool_selection.go:func (s *Server) resolvePoolSelection",
+        "phase5-gateway/internal/router/pool_selection.go:errPoolUnavailable"
+      ],
+      "tests": [
+        "phase4-coordinator/internal/buyer/spec042_pools_advertisement_test.go:TestInternalRoutingAdvertisesPoolCapability",
+        "phase5-gateway/internal/router/pool_selection_test.go:TestPoolSelection_CoordinatorDeclinesCapability_FailsClosed"
+      ],
+      "journeys": [],
+      "evidence": [],
+      "gap": {
+        "verdict": "DECISION_REQUIRED",
+        "owner": "@Augustas11",
+        "issue": "https://github.com/Augustas11/macprovider/issues/1053",
+        "rationale": "Config default-off, staged rollout, non-disclosing error taxonomy, and positive coordinator<->gateway capability negotiation: implemented (#1076). The provider-half full close (capability challenge) and predicate-specific error codes are deferred; per-requirement CONFORMANCE promotion pending signed journey-result evidence."
+      }
+    },
+    {
+      "requirement_id": "SPEC-042-R011",
+      "spec_id": "SPEC-042",
+      "state": "pending",
+      "implementation": [],
+      "tests": [],
+      "journeys": [],
+      "evidence": [],
+      "gap": {
+        "verdict": "DECISION_REQUIRED",
+        "owner": "@Augustas11",
+        "issue": "https://github.com/Augustas11/macprovider/issues/1053",
+        "rationale": "Pool lifecycle, provider migration, and failover/restart reconstruction: NOT yet implemented (lifecycle state machine + min_eligible_members readiness are future slices)."
+      }
+    },
+    {
+      "requirement_id": "SPEC-042-R012",
+      "spec_id": "SPEC-042",
+      "state": "pending",
+      "implementation": [],
+      "tests": [],
+      "journeys": [],
+      "evidence": [],
+      "gap": {
+        "verdict": "DECISION_REQUIRED",
+        "owner": "@Augustas11",
+        "issue": "https://github.com/Augustas11/macprovider/issues/1053",
+        "rationale": "Manifest authority + signer-set key lifecycle: NOT yet implemented; depends on the signed-manifest machinery (R001) which is a future slice."
       }
     }
   ]

--- a/specs/README.md
+++ b/specs/README.md
@@ -50,7 +50,7 @@ it can no longer drift. Do not hand-edit the table; edit each spec's
 | SPEC-039 | Paged KV / paged-attention engine | v0.1 | draft | complete | pending: 14 | [SPEC-039-paged-kv-attention-engine.md](SPEC-039-paged-kv-attention-engine.md) |
 | SPEC-040 | Wallet-Native Buyer Sessions | 0.1.8 | draft | complete | pending: 10 | [SPEC-040-wallet-native-buyer-sessions.md](SPEC-040-wallet-native-buyer-sessions.md) |
 | SPEC-041 | Relay-Blind Request Encryption | 0.1.0 | draft | complete | pending: 8 | [SPEC-041-relay-blind-request-encryption.md](SPEC-041-relay-blind-request-encryption.md) |
-| SPEC-042 | Pool Control Plane and Trusted-Pool Manifest | 0.0.7 | draft | pending | pending corpus migration | [SPEC-042-pool-control-plane.md](SPEC-042-pool-control-plane.md) |
+| SPEC-042 | Pool Control Plane and Trusted-Pool Manifest | 0.0.7 | draft | complete | pending: 12 | [SPEC-042-pool-control-plane.md](SPEC-042-pool-control-plane.md) |
 <!-- AUTOGEN:spec-index END -->
 
 **Version of record is each spec's own `**Version:**` header, not this table.**


### PR DESCRIPTION
## SPEC-042: register per-requirement CONFORMANCE records (clear the advisory `check`)

Registers structured requirement records for **SPEC-042-R001 … R012** in `specs/CONFORMANCE.json`. Until now these were unregistered, so the declaration validator (`check_spec_pr_declaration.py`) reported `unknown requirement 'SPEC-042-R00N'` and the `spec-index / check` job went **advisory-red on every PR in the SPEC-042 stack** (#1065/#1069/#1072/#1076/#1079). This completes the deferred "per-requirement CONFORMANCE records for R001–R012" item from the SPEC-042 R010 promotion checklist and clears that red for all future SPEC-042 work.

### What's in the records
- **State `pending`** for all 12 — SPEC-042 is still `draft`; conformance *promotion* (state `conformant`) requires signed journey-result evidence, which is deferred per the promotion checklist (#1053). Each record carries an owned, issue-linked `gap`.
- **Built requirements cite real implementation + test anchors** from the merged slices:
  - R002 (pool_id threading + selection auth), R003 (membership + durable revocation — in-memory, durable ledger deferred), R004 (fail-closed binary-version predicate — other predicates + signed evidence deferred), R005 (per-attempt isolation + generation fence), R006 (settlement route-snapshot pool_id binding), R010 (config/rollout/error taxonomy + capability handshake).
- **Unbuilt requirements** (R001 signed manifest, R007 retention matrix, R008 policy/status schemas, R009 Layer 3 binding — blocked on SPEC-041/040, R011 lifecycle, R012 key lifecycle) carry a gap describing what is deferred.
- SPEC-042 `requirement_id_migration` flipped `pending` → `complete`. `specs/README.md` regenerated.

### Verification
- `python3 scripts/gen_spec_index.py --check` → `ok: spec index is up to date`.
- `python3 scripts/check_spec_governance.py` → `SPEC governance validation passed`.
- `check_spec_pr_declaration.py` now accepts `SPEC-042-R002/R004/R010` (no `unknown requirement`).
- All 12 implementation/test mapping selectors resolve at the current commit.

Governance-only (`specs/**`), so `behavior_change: none`.

SPEC-GOVERNANCE-DECLARATION-BEGIN
{
  "schema_version": "spec-pr-governance-v1",
  "behavior_change": "none",
  "contract_change": "yes",
  "specs": ["SPEC-042"],
  "requirements": [],
  "authority_domains": ["pool-control-plane"],
  "arbitration": ["CODE_BUG"],
  "tests": [],
  "journeys": ["not-required"],
  "issue": "https://github.com/Augustas11/macprovider/issues/1053"
}
SPEC-GOVERNANCE-DECLARATION-END

🤖 Generated with [Claude Code](https://claude.com/claude-code)
