### PR TITLE
Repair provider software after HOME ACL autoupdate rejection

### DIFF
--- a/ops/macprovider-watchdog/watchdog.sh
+++ b/ops/macprovider-watchdog/watchdog.sh
@@ -441,7 +441,7 @@ def record_watchdog_recovery(marker, failure_class):
     except Exception as exc:
         log(f"lifecycle_transition_failed=watchdog_recovery error={type(exc).__name__}")
 
-def reject_path(path, must_exist=True):
+def reject_path(path, must_exist=True, allow_home_acl_write=False):
     try:
         st = os.lstat(path)
     except FileNotFoundError:
@@ -463,6 +463,8 @@ def reject_path(path, must_exist=True):
             if not re.match(r"^[0-9]+:", stripped):
                 continue
             if ("write" in stripped or "append" in stripped or "add_file" in stripped) and f"user:{provider_user.lower()}" not in stripped:
+                if allow_home_acl_write and os.path.normpath(path) == os.path.normpath(os.path.expanduser("~")):
+                    continue
                 raise RuntimeError(f"acl_write_rejected:{path}")
     except FileNotFoundError:
         pass
@@ -479,7 +481,10 @@ def verify_root():
         current = parent
     for path in reversed(parts):
         if os.path.exists(path):
-            st = reject_path(path)
+            st = reject_path(
+                path,
+                allow_home_acl_write=os.path.normpath(path) == os.path.normpath(os.path.expanduser("~")),
+            )
             if not stat.S_ISDIR(st.st_mode):
                 raise RuntimeError(f"not_directory:{path}")
 

--- a/phase3-binary/app/Sources/Malibu/Agent/AgentSnapshot.swift
+++ b/phase3-binary/app/Sources/Malibu/Agent/AgentSnapshot.swift
@@ -152,6 +152,9 @@ struct AgentSnapshot: Equatable {
     var latestReleaseVersion: String?
     var cliUpdateInProgress: Bool
     var cliUpdateLastError: String?
+    var providerSoftwareRepairRecommended: Bool
+    var providerSoftwareRepairInProgress: Bool
+    var providerSoftwareRepairLastError: String?
     /// Dashboard-triggered online recommend/apply/submit for #582 hello-gate recovery.
     var hardwareVerificationRetryInProgress: Bool = false
     var hardwareVerificationRetryLastError: String? = nil
@@ -278,6 +281,7 @@ struct AgentSnapshot: Equatable {
         compatibilitySetID = nil
         compatibilitySetSHA256 = nil
         coordinatorRecommendedVersion = nil
+        latestReleaseVersion = nil
         referralAvailability = .unsupported
         referralStatus = nil
         referralLastError = nil
@@ -393,6 +397,9 @@ struct AgentSnapshot: Equatable {
         latestReleaseVersion: nil,
         cliUpdateInProgress: false,
         cliUpdateLastError: nil,
+        providerSoftwareRepairRecommended: false,
+        providerSoftwareRepairInProgress: false,
+        providerSoftwareRepairLastError: nil,
         pauseAcknowledged: false
     )
 }
@@ -404,6 +411,7 @@ enum AgentSnapshotPresenter {
     enum ExecutableRecoveryAction: Equatable {
         case retryHardwareVerification
         case updateProviderSoftware
+        case repairProviderSoftware
         case repairCredential
         case repairAdmissionIdentity
         case exportDiagnostics
@@ -665,6 +673,21 @@ enum AgentSnapshotPresenter {
     }
 
     static func publicStatus(_ s: AgentSnapshot) -> PublicStatus {
+        if s.providerSoftwareRepairInProgress {
+            return PublicStatus(
+                title: "Repairing provider software",
+                detail: "Malibu is reinstalling the bundled provider software and watchdog. Keep Malibu open.",
+                safeNextAction: "Repair is in progress."
+            )
+        }
+        if canRepairProviderSoftware(s) {
+            return PublicStatus(
+                title: "Provider software repair available",
+                detail: "A permission on your home folder blocked automatic update recovery.",
+                safeNextAction: "Repair provider software. Malibu will reinstall the bundled provider software and watchdog. Your provider identity and downloaded models will be kept.",
+                executableAction: .repairProviderSoftware
+            )
+        }
         if s.state == .paused {
             return PublicStatus(
                 title: "Provider is paused",
@@ -710,7 +733,7 @@ enum AgentSnapshotPresenter {
             return PublicStatus(
                 title: "This Mac is not currently eligible",
                 detail: "Provider software must be updated before this Mac can receive customer work.",
-                safeNextAction: "Update provider software.",
+                safeNextAction: "Install latest provider software.",
                 executableAction: updateAvailable(s) ? .updateProviderSoftware : nil
             )
         }
@@ -753,17 +776,21 @@ enum AgentSnapshotPresenter {
         switch s.state {
         case .error:
             let action: String
-            if canRepairCredential(s) {
+            if canRepairProviderSoftware(s) {
+                action = "Repair provider software."
+            } else if canRepairCredential(s) {
                 action = "Repair saved access."
             } else if canRepairAdmissionIdentity(s) {
                 action = "\(admissionIdentityRepairButtonTitle(s))."
             } else if updateAvailable(s) {
-                action = "Update provider software."
+                action = "Install latest provider software."
             } else {
                 action = "Export diagnostics for support."
             }
             let executable: ExecutableRecoveryAction?
-            if canRepairCredential(s) {
+            if canRepairProviderSoftware(s) {
+                executable = .repairProviderSoftware
+            } else if canRepairCredential(s) {
                 executable = .repairCredential
             } else if canRepairAdmissionIdentity(s) {
                 executable = .repairAdmissionIdentity
@@ -1329,7 +1356,7 @@ enum AgentSnapshotPresenter {
         case "identity_migration_required":
             return "Use Repair network verification"
         case "catalog_incompatible":
-            return "Update provider software, then retry"
+            return "Install latest provider software, then retry"
         case "paused_by_operator":
             return "Choose Resume when ready"
         case "network_offline":
@@ -1576,6 +1603,12 @@ enum AgentSnapshotPresenter {
         updateTargetVersion(s) != nil || compatibilityRepairAvailable(s)
     }
 
+    static func canRepairProviderSoftware(_ s: AgentSnapshot) -> Bool {
+        s.providerSoftwareRepairRecommended
+            && !s.providerSoftwareRepairInProgress
+            && !s.cliUpdateInProgress
+    }
+
     /// A binary-only legacy update can report the latest CLI version while
     /// still lacking the signed compatibility-set resources. Only a fresh
     /// versioned status observation may expose that repair action; a transient
@@ -1621,7 +1654,13 @@ enum AgentSnapshotPresenter {
 
     static func cliUpdateStatusLine(_ s: AgentSnapshot) -> String? {
         if s.cliUpdateInProgress {
-            return "Updating provider software…"
+            return "Installing latest provider software…"
+        }
+        if s.providerSoftwareRepairInProgress {
+            return "Repairing provider software…"
+        }
+        if let error = s.providerSoftwareRepairLastError {
+            return publicErrorDetail(error)
         }
         if let error = s.cliUpdateLastError {
             return publicErrorDetail(error)

--- a/phase3-binary/app/Sources/Malibu/Agent/MalibuAgent.swift
+++ b/phase3-binary/app/Sources/Malibu/Agent/MalibuAgent.swift
@@ -48,6 +48,7 @@ final class MalibuAgent: ObservableObject {
     private var lastRequestsRateSample: (total: Int, date: Date)?
     private var latestReleaseFetchedAt: Date?
     private var cliUpdateTask: Task<Void, Never>?
+    private var providerSoftwareRepairTask: Task<Void, Never>?
     private var hardwareVerificationRetryTask: Task<Void, Never>?
     /// Set while corrective `--recover-hardware-admission` may have drained
     /// launchd and therefore owes a restore/bootstrap. Cleared on success.
@@ -329,6 +330,7 @@ final class MalibuAgent: ObservableObject {
 
     func updateCLINow() async {
         guard !snapshot.cliUpdateInProgress else { return }
+        guard !snapshot.providerSoftwareRepairInProgress else { return }
         guard AgentSnapshotPresenter.updateAvailable(snapshot) else { return }
         cliUpdateTask?.cancel()
         snapshot.cliUpdateInProgress = true
@@ -344,6 +346,7 @@ final class MalibuAgent: ObservableObject {
                     }
                 }
                 self.snapshot.cliUpdateLastError = nil
+                self.recordProviderSoftwareInstallHandledAutoupdateACL()
                 if let port = ProviderConfig.readHTTPPort() {
                     try? await Task.sleep(nanoseconds: 3_000_000_000)
                     await self.applyProviderSnapshot(port: port)
@@ -354,6 +357,80 @@ final class MalibuAgent: ObservableObject {
             self.snapshot.cliUpdateInProgress = false
         }
         await cliUpdateTask?.value
+    }
+
+    func repairProviderSoftware() async {
+        guard !isShuttingDown,
+              AgentSnapshotPresenter.canRepairProviderSoftware(snapshot) else { return }
+        if let previous = providerSoftwareRepairTask {
+            previous.cancel()
+            await previous.value
+        }
+        guard !isShuttingDown, !Task.isCancelled else { return }
+        snapshot.providerSoftwareRepairInProgress = true
+        snapshot.providerSoftwareRepairLastError = nil
+        providerSoftwareRepairTask = Task { [weak self] in
+            guard let self else { return }
+            defer {
+                if !self.isShuttingDown {
+                    self.snapshot.providerSoftwareRepairInProgress = false
+                }
+            }
+            do {
+                try await CLIInstallRunner.run(
+                    referralCode: nil,
+                    replacingIncumbentProvider: false,
+                    repairExistingInstall: true
+                ) { line in
+                    self.logLines.append(LogTailBuffer.redacted(line))
+                    if self.logLines.count > 400 {
+                        self.logLines.removeFirst(self.logLines.count - 400)
+                    }
+                }
+                guard !Task.isCancelled, !self.isShuttingDown else { return }
+                self.snapshot.providerSoftwareRepairLastError = nil
+                self.snapshot.providerSoftwareRepairRecommended = false
+                self.recordProviderSoftwareInstallHandledAutoupdateACL()
+                do {
+                    try await ProviderConfig.importExistingCLIConfig()
+                } catch {
+                    self.logLines.append("Provider import after repair will retry after provider restart.")
+                }
+                if let port = ProviderConfig.readHTTPPort() {
+                    try? await Task.sleep(nanoseconds: 3_000_000_000)
+                    guard !Task.isCancelled, !self.isShuttingDown else { return }
+                    await self.applyProviderSnapshot(port: port)
+                }
+            } catch is CancellationError {
+                return
+            } catch {
+                guard !Task.isCancelled, !self.isShuttingDown else { return }
+                self.snapshot.providerSoftwareRepairLastError = error.localizedDescription
+            }
+        }
+        await providerSoftwareRepairTask?.value
+    }
+
+    private func recordProviderSoftwareInstallHandledAutoupdateACL(paths: ProviderPaths = .current) {
+        do {
+            try FileManager.default.createDirectory(
+                at: paths.watchdogLog.deletingLastPathComponent(),
+                withIntermediateDirectories: true
+            )
+            let timestamp = ISO8601DateFormatter().string(from: Date())
+            let line = "[\(timestamp)] \(ProviderLogDiagnostics.providerSoftwareInstallHandledAutoupdateACLMarker)\n"
+            let data = Data(line.utf8)
+            if FileManager.default.fileExists(atPath: paths.watchdogLog.path) {
+                let handle = try FileHandle(forWritingTo: paths.watchdogLog)
+                try handle.seekToEnd()
+                try handle.write(contentsOf: data)
+                try handle.close()
+            } else {
+                try data.write(to: paths.watchdogLog, options: .atomic)
+            }
+        } catch {
+            logLines.append("Provider software repair marker could not be recorded; diagnostics may show an older update-recovery hint.")
+        }
     }
 
     func repairProviderCredential() async {
@@ -470,6 +547,10 @@ final class MalibuAgent: ObservableObject {
         reconnectTask?.cancel(); reconnectTask = nil
         healthPollTask?.cancel(); healthPollTask = nil
         cliUpdateTask?.cancel(); cliUpdateTask = nil
+        let repairSoftwareTask = providerSoftwareRepairTask
+        providerSoftwareRepairTask = nil
+        repairSoftwareTask?.cancel()
+        await repairSoftwareTask?.value
         referralStatusExpiryTask?.cancel(); referralStatusExpiryTask = nil
         let hardwareRetryTask = hardwareVerificationRetryTask
         hardwareVerificationRetryTask = nil
@@ -1440,6 +1521,8 @@ final class MalibuAgent: ObservableObject {
         watchdogLogTailCancellable = tail.$watchdogLines
             .sink { [weak self] lines in
                 self?.watchdogLogLines = lines
+                self?.snapshot.providerSoftwareRepairRecommended =
+                    ProviderLogDiagnostics.homeAutoupdateACLRejection(lines: lines) != nil
             }
         providerLogTail = tail
         tail.start(paths: paths)

--- a/phase3-binary/app/Sources/Malibu/Dashboard/DashboardWindow.swift
+++ b/phase3-binary/app/Sources/Malibu/Dashboard/DashboardWindow.swift
@@ -403,7 +403,12 @@ private struct DashboardView: View {
                             if let status = AgentSnapshotPresenter.cliUpdateStatusLine(agent.snapshot) {
                                 Text(status)
                                     .font(.caption)
-                                    .foregroundStyle(agent.snapshot.cliUpdateLastError == nil ? Color.secondary : Color.red)
+                                    .foregroundStyle(
+                                        agent.snapshot.cliUpdateLastError == nil
+                                            && agent.snapshot.providerSoftwareRepairLastError == nil
+                                            ? Color.secondary
+                                            : Color.red
+                                    )
                             }
                             if !agent.logLines.isEmpty {
                                 LogTailView(lines: agent.logLines)
@@ -512,11 +517,16 @@ private struct DashboardView: View {
             }
         case .updateProviderSoftware:
             if AgentSnapshotPresenter.updateAvailable(agent.snapshot) {
-                Button(agent.snapshot.cliUpdateInProgress ? "Updating provider software..." : "Update provider software") {
+                Button(agent.snapshot.cliUpdateInProgress ? "Installing latest provider software…" : "Install latest provider software") {
                     Task { await agent.updateCLINow() }
                 }
-                .disabled(agent.snapshot.cliUpdateInProgress)
+                .disabled(agent.snapshot.cliUpdateInProgress || agent.snapshot.providerSoftwareRepairInProgress)
             }
+        case .repairProviderSoftware:
+            Button(agent.snapshot.providerSoftwareRepairInProgress ? "Repairing provider software…" : "Repair provider software") {
+                Task { await agent.repairProviderSoftware() }
+            }
+            .disabled(agent.snapshot.providerSoftwareRepairInProgress || agent.snapshot.cliUpdateInProgress)
         case .repairCredential:
             Button("Repair saved access") {
                 Task { await agent.repairProviderCredential() }

--- a/phase3-binary/app/Sources/Malibu/MalibuApp.swift
+++ b/phase3-binary/app/Sources/Malibu/MalibuApp.swift
@@ -93,6 +93,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         case .pause: Task { await agent.pause() }
         case .resume: Task { await agent.resume() }
         case .checkForUpdates, .updateCLI: Task { await agent.updateCLINow() }
+        case .repairProviderSoftware: Task { await agent.repairProviderSoftware() }
         case .exportDiagnostics: exportDiagnostics()
         case .resetProviderService: resetProviderService()
         case .openSettings:

--- a/phase3-binary/app/Sources/Malibu/MenuBar/MenuBarController.swift
+++ b/phase3-binary/app/Sources/Malibu/MenuBar/MenuBarController.swift
@@ -10,6 +10,7 @@ final class MenuBarController {
         case resume
         case checkForUpdates
         case updateCLI
+        case repairProviderSoftware
         case exportDiagnostics
         case resetProviderService
         case openSettings
@@ -89,7 +90,13 @@ final class MenuBarController {
         cliVersionItem.isHidden = true
         menu.addItem(cliVersionItem)
 
-        let updateItem = action("Check for Updates…", key: "") { self.onAction(.checkForUpdates) }
+        let updateItem = action("Check for Updates…", key: "") {
+            if AgentSnapshotPresenter.canRepairProviderSoftware(self.latestSnapshot) {
+                self.onAction(.repairProviderSoftware)
+            } else {
+                self.onAction(.checkForUpdates)
+            }
+        }
         updateItem.identifier = .updateAction
         menu.addItem(updateItem)
 
@@ -172,14 +179,20 @@ final class MenuBarController {
         }
         if let updateItem = menu.item(withIdentifier: .updateAction) {
             updateItem.isHidden = false
-            updateItem.isEnabled = AgentSnapshotPresenter.updateAvailable(snapshot)
-                && !snapshot.cliUpdateInProgress
-            if AgentSnapshotPresenter.updateAvailable(snapshot) {
+            if snapshot.providerSoftwareRepairInProgress {
+                updateItem.title = "Repairing provider software…"
+                updateItem.isEnabled = false
+            } else if AgentSnapshotPresenter.canRepairProviderSoftware(snapshot) {
+                updateItem.title = "Repair provider software…"
+                updateItem.isEnabled = true
+            } else if AgentSnapshotPresenter.updateAvailable(snapshot) {
                 updateItem.title = snapshot.cliUpdateInProgress
-                    ? "Updating provider software…"
-                    : "Update provider software…"
+                    ? "Installing latest provider software…"
+                    : "Install latest provider software…"
+                updateItem.isEnabled = !snapshot.cliUpdateInProgress
             } else {
                 updateItem.title = "Provider software is current"
+                updateItem.isEnabled = false
             }
         }
         if let backlog = AgentSnapshotPresenter.backlogLine(snapshot),

--- a/phase3-binary/app/Sources/Malibu/System/ProviderLogDiagnostics.swift
+++ b/phase3-binary/app/Sources/Malibu/System/ProviderLogDiagnostics.swift
@@ -2,6 +2,9 @@ import Foundation
 
 /// Maps macprovider-cli stderr lines (launchd or Malibu-spawned) to operator-facing text.
 enum ProviderLogDiagnostics {
+    static let providerSoftwareInstallHandledAutoupdateACLMarker =
+        "autoupdate acl_home_repair_handled=malibu_provider_software_install_success"
+
     static let staleLaunchAgentMessage =
         "Provider setup is blocked by a previous installation. "
         + "Click Launch Provider to repair the background service. "
@@ -93,6 +96,42 @@ enum ProviderLogDiagnostics {
                 + "Update provider software and pick the recommended model again."
         ),
     ]
+
+    static func homeAutoupdateACLRejection(
+        lines: [String],
+        homeDirectory: URL = FileManager.default.homeDirectoryForCurrentUser
+    ) -> Finding? {
+        let needle = "autoupdate recovery_error=acl_write_rejected:"
+        let homePath = homeDirectory.standardizedFileURL.path
+        for line in lines.reversed() {
+            let lower = line.lowercased()
+            if lower.contains(providerSoftwareInstallHandledAutoupdateACLMarker)
+                || lower.contains("autoupdate lifecycle_transition=watchdog_recovery ") {
+                return nil
+            }
+            guard let range = lower.range(of: needle) else { continue }
+            let rawPath = String(line[range.upperBound...])
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+            if URL(fileURLWithPath: rawPath).standardizedFileURL.path == homePath {
+                return Finding(
+                    id: "autoupdate_home_acl_rejected",
+                    userMessage:
+                        "Provider software repair is needed. A macOS folder permission is blocking automatic update recovery; Malibu can repair the provider software while keeping your provider identity and downloaded model files.",
+                    matchedLine: line
+                )
+            }
+            let firstField = rawPath.split(whereSeparator: \.isWhitespace).first.map(String.init) ?? rawPath
+            let rejectedPath = URL(fileURLWithPath: firstField).standardizedFileURL.path
+            guard rejectedPath == homePath else { continue }
+            return Finding(
+                id: "autoupdate_home_acl_rejected",
+                userMessage:
+                    "Provider software repair is needed. A macOS folder permission is blocking automatic update recovery; Malibu can repair the provider software while keeping your provider identity and downloaded model files.",
+                matchedLine: line
+            )
+        }
+        return nil
+    }
 
     static func diagnose(lines: [String]) -> Finding? {
         for line in lines.reversed() {

--- a/phase3-binary/app/Tests/MalibuTests/AgentSnapshotPresenterTests.swift
+++ b/phase3-binary/app/Tests/MalibuTests/AgentSnapshotPresenterTests.swift
@@ -589,7 +589,7 @@ final class AgentSnapshotPresenterTests: XCTestCase {
 
         XCTAssertEqual(
             AgentSnapshotPresenter.lifecycleLine(snapshot),
-            "Provider software update required · startup catalog incompatible · Update provider software, then retry"
+            "Provider software update required · startup catalog incompatible · Install latest provider software, then retry"
         )
 
         snapshot.lifecycleState = "watchdog_recovery"
@@ -1156,6 +1156,120 @@ final class AgentSnapshotPresenterTests: XCTestCase {
         for term in prohibitedPublicTerms {
             XCTAssertFalse(publicStrings.contains(term), "\(term) leaked in:\n\(publicStrings)")
         }
+    }
+
+    func testProviderSoftwareRepairRecommendedTakesSoftwareUpdateAction() {
+        var snapshot = AgentSnapshot.empty
+        snapshot.state = .serving
+        snapshot.networkState = "catalog_update_required"
+        snapshot.cliVersion = "1.8.93"
+        snapshot.coordinatorRecommendedVersion = "1.8.101"
+        snapshot.providerSoftwareRepairRecommended = true
+
+        let status = AgentSnapshotPresenter.publicStatus(snapshot)
+
+        XCTAssertEqual(status.title, "Provider software repair available")
+        XCTAssertEqual(status.detail, "A permission on your home folder blocked automatic update recovery.")
+        XCTAssertEqual(
+            status.safeNextAction,
+            "Repair provider software. Malibu will reinstall the bundled provider software and watchdog. Your provider identity and downloaded models will be kept."
+        )
+        XCTAssertEqual(status.executableAction, .repairProviderSoftware)
+        XCTAssertTrue(AgentSnapshotPresenter.canRepairProviderSoftware(snapshot))
+    }
+
+    func testProviderSoftwareRepairRecommendedTakesReadyStateAction() {
+        var snapshot = AgentSnapshot.empty
+        snapshot.state = .serving
+        snapshot.networkState = "buyer_serving"
+        snapshot.localStatusCapabilities = ["status_observation_v1"]
+        snapshot.statusObservationFresh = true
+        snapshot.statusObservedAt = Date()
+        snapshot.statusObservationValidForMS = 5_000
+        snapshot.providerSoftwareRepairRecommended = true
+
+        let status = AgentSnapshotPresenter.publicStatus(snapshot)
+
+        XCTAssertEqual(status.title, "Provider software repair available")
+        XCTAssertEqual(status.executableAction, .repairProviderSoftware)
+    }
+
+    func testProviderSoftwareRepairRecommendedTakesPausedStateAction() {
+        var snapshot = AgentSnapshot.empty
+        snapshot.state = .paused
+        snapshot.providerSoftwareRepairRecommended = true
+
+        let status = AgentSnapshotPresenter.publicStatus(snapshot)
+
+        XCTAssertEqual(status.title, "Provider software repair available")
+        XCTAssertEqual(status.executableAction, .repairProviderSoftware)
+    }
+
+    func testProviderSoftwareRepairRecommendationSurvivesStatusInvalidation() {
+        var snapshot = AgentSnapshot.empty
+        snapshot.state = .serving
+        snapshot.networkState = "buyer_serving"
+        snapshot.localStatusCapabilities = ["status_observation_v1"]
+        snapshot.statusObservationFresh = true
+        snapshot.statusObservedAt = Date()
+        snapshot.statusObservationValidForMS = 5_000
+        snapshot.providerSoftwareRepairRecommended = true
+
+        snapshot.invalidateLocalStatusObservation()
+        let status = AgentSnapshotPresenter.publicStatus(snapshot)
+
+        XCTAssertEqual(status.title, "Provider software repair available")
+        XCTAssertEqual(status.executableAction, .repairProviderSoftware)
+        XCTAssertTrue(AgentSnapshotPresenter.canRepairProviderSoftware(snapshot))
+    }
+
+    func testProviderSoftwareUpdateInProgressSurvivesStatusInvalidation() {
+        var snapshot = AgentSnapshot.empty
+        snapshot.state = .serving
+        snapshot.networkState = "buyer_serving"
+        snapshot.localStatusCapabilities = ["status_observation_v1"]
+        snapshot.statusObservationFresh = true
+        snapshot.statusObservedAt = Date()
+        snapshot.statusObservationValidForMS = 5_000
+        snapshot.cliUpdateInProgress = true
+
+        snapshot.invalidateLocalStatusObservation()
+
+        XCTAssertTrue(snapshot.cliUpdateInProgress)
+        XCTAssertEqual(
+            AgentSnapshotPresenter.cliUpdateStatusLine(snapshot),
+            "Installing latest provider software…"
+        )
+    }
+
+    func testProviderSoftwareRepairInProgressKeepsRepairStatus() {
+        var snapshot = AgentSnapshot.empty
+        snapshot.state = .serving
+        snapshot.networkState = "catalog_update_required"
+        snapshot.cliVersion = "1.8.93"
+        snapshot.coordinatorRecommendedVersion = "1.8.101"
+        snapshot.providerSoftwareRepairRecommended = true
+        snapshot.providerSoftwareRepairInProgress = true
+
+        let status = AgentSnapshotPresenter.publicStatus(snapshot)
+
+        XCTAssertEqual(status.title, "Repairing provider software")
+        XCTAssertEqual(
+            status.detail,
+            "Malibu is reinstalling the bundled provider software and watchdog. Keep Malibu open."
+        )
+        XCTAssertEqual(status.safeNextAction, "Repair is in progress.")
+        XCTAssertNil(status.executableAction)
+    }
+
+    func testProviderSoftwareRepairStatusLine() {
+        var snapshot = AgentSnapshot.empty
+        snapshot.providerSoftwareRepairInProgress = true
+
+        XCTAssertEqual(
+            AgentSnapshotPresenter.cliUpdateStatusLine(snapshot),
+            "Repairing provider software…"
+        )
     }
 
     func testDefaultDashboardAndOnboardingStringsDoNotExposeInternalTerms() {

--- a/phase3-binary/app/Tests/MalibuTests/ProviderLogDiagnosticsTests.swift
+++ b/phase3-binary/app/Tests/MalibuTests/ProviderLogDiagnosticsTests.swift
@@ -26,6 +26,77 @@ final class ProviderLogDiagnosticsTests: XCTestCase {
         XCTAssertFalse(finding?.userMessage.contains("autotune --recommend --apply") == true)
     }
 
+    func testDetectsHomeAutoupdateACLRejection() {
+        let finding = ProviderLogDiagnostics.homeAutoupdateACLRejection(
+            lines: [
+                "[2026-08-19T01:05:42Z] autoupdate recovery_error=acl_write_rejected:/Users/provider"
+            ],
+            homeDirectory: URL(fileURLWithPath: "/Users/provider")
+        )
+
+        XCTAssertEqual(finding?.id, "autoupdate_home_acl_rejected")
+        XCTAssertTrue(finding?.userMessage.contains("macOS folder permission") == true)
+        XCTAssertFalse(finding?.userMessage.contains("/Users/provider") == true)
+    }
+
+    func testDetectsHomeAutoupdateACLRejectionWithSpaceInHomePath() {
+        let finding = ProviderLogDiagnostics.homeAutoupdateACLRejection(
+            lines: [
+                "[2026-08-19T01:05:42Z] autoupdate recovery_error=acl_write_rejected:/Users/provider name"
+            ],
+            homeDirectory: URL(fileURLWithPath: "/Users/provider name")
+        )
+
+        XCTAssertEqual(finding?.id, "autoupdate_home_acl_rejected")
+    }
+
+    func testIgnoresNonHomeAutoupdateACLRejection() {
+        let finding = ProviderLogDiagnostics.homeAutoupdateACLRejection(
+            lines: [
+                "[2026-08-19T01:05:42Z] autoupdate recovery_error=acl_write_rejected:/Users/provider/.local/share/macprovider/autoupdate"
+            ],
+            homeDirectory: URL(fileURLWithPath: "/Users/provider")
+        )
+
+        XCTAssertNil(finding)
+    }
+
+    func testIgnoresHomeAutoupdateACLRejectionBeforeSuccessfulBundledRepairMarker() {
+        let finding = ProviderLogDiagnostics.homeAutoupdateACLRejection(
+            lines: [
+                "[2026-08-19T01:05:42Z] autoupdate recovery_error=acl_write_rejected:/Users/provider",
+                "[2026-08-19T01:08:20Z] \(ProviderLogDiagnostics.providerSoftwareInstallHandledAutoupdateACLMarker)",
+            ],
+            homeDirectory: URL(fileURLWithPath: "/Users/provider")
+        )
+
+        XCTAssertNil(finding)
+    }
+
+    func testDetectsHomeAutoupdateACLRejectionAfterSuccessfulBundledRepairMarker() {
+        let finding = ProviderLogDiagnostics.homeAutoupdateACLRejection(
+            lines: [
+                "[2026-08-19T01:08:20Z] \(ProviderLogDiagnostics.providerSoftwareInstallHandledAutoupdateACLMarker)",
+                "[2026-08-19T01:09:42Z] autoupdate recovery_error=acl_write_rejected:/Users/provider",
+            ],
+            homeDirectory: URL(fileURLWithPath: "/Users/provider")
+        )
+
+        XCTAssertEqual(finding?.id, "autoupdate_home_acl_rejected")
+    }
+
+    func testIgnoresHomeAutoupdateACLRejectionBeforeWatchdogRecoverySuccess() {
+        let finding = ProviderLogDiagnostics.homeAutoupdateACLRejection(
+            lines: [
+                "[2026-08-19T01:05:42Z] autoupdate recovery_error=acl_write_rejected:/Users/provider",
+                "[2026-08-19T01:06:00Z] autoupdate lifecycle_transition=watchdog_recovery reason_code=watchdog_rollback_readiness",
+            ],
+            homeDirectory: URL(fileURLWithPath: "/Users/provider")
+        )
+
+        XCTAssertNil(finding)
+    }
+
     func testDiagnosePrefersMostRecentMatchingLine() {
         let finding = ProviderLogDiagnostics.diagnose(lines: [
             "model artifact hash mismatch for /tmp/old",

--- a/phase3-binary/dist/install.sh
+++ b/phase3-binary/dist/install.sh
@@ -9428,7 +9428,7 @@ def record_watchdog_recovery(marker, failure_class):
     except Exception as exc:
         log(f"lifecycle_transition_failed=watchdog_recovery error={type(exc).__name__}")
 
-def reject_path(path, must_exist=True):
+def reject_path(path, must_exist=True, allow_home_acl_write=False):
     try:
         st = os.lstat(path)
     except FileNotFoundError:
@@ -9450,6 +9450,8 @@ def reject_path(path, must_exist=True):
             if not re.match(r"^[0-9]+:", stripped):
                 continue
             if ("write" in stripped or "append" in stripped or "add_file" in stripped) and f"user:{provider_user.lower()}" not in stripped:
+                if allow_home_acl_write and os.path.normpath(path) == os.path.normpath(os.path.expanduser("~")):
+                    continue
                 raise RuntimeError(f"acl_write_rejected:{path}")
     except FileNotFoundError:
         pass
@@ -9466,7 +9468,10 @@ def verify_root():
         current = parent
     for path in reversed(parts):
         if os.path.exists(path):
-            st = reject_path(path)
+            st = reject_path(
+                path,
+                allow_home_acl_write=os.path.normpath(path) == os.path.normpath(os.path.expanduser("~")),
+            )
             if not stat.S_ISDIR(st.st_mode):
                 raise RuntimeError(f"not_directory:{path}")
 

--- a/phase3-binary/dist/test/watchdog_rollback_paths.test.sh
+++ b/phase3-binary/dist/test/watchdog_rollback_paths.test.sh
@@ -355,6 +355,21 @@ assert_loaded_service_accepts_nonzero_bootstrap() {
   grep -F "kickstart -k gui/" "$root/launchctl.log" >/dev/null
 }
 
+assert_home_acl_write_is_tolerated() {
+  script="$1"
+  root="$2"
+  if ! chmod +a "group:everyone allow add_file" "$root/home" 2>/dev/null; then
+    return 0
+  fi
+  invoke_reconcile "$script" "$root"
+  cmp -s "$root/bin/macprovider-cli" <(printf "old-binary")
+  [ ! -e "$root/home/.local/share/macprovider/autoupdate/pending.json" ]
+  if grep -F "recovery_error=acl_write_rejected:$root/home" "$root/logs/watchdog.log" >/dev/null; then
+    echo "watchdog must tolerate write ACLs on HOME while checking autoupdate descendants" >&2
+    return 1
+  fi
+}
+
 make_fixture "$TMP/standalone"
 run_reconcile "$STANDALONE" "$TMP/standalone"
 
@@ -397,6 +412,8 @@ for script_name in standalone inline; do
   make_fixture "$TMP/bootstrap-loaded-$script_name"
   assert_loaded_service_accepts_nonzero_bootstrap \
     "$script" "$TMP/bootstrap-loaded-$script_name"
+  make_fixture "$TMP/home-acl-$script_name"
+  assert_home_acl_write_is_tolerated "$script" "$TMP/home-acl-$script_name"
   for kind in hardlink fifo inner-readable outer-readable; do
     make_fixture "$TMP/unsafe-$script_name-$kind"
     assert_unsafe_lock_rejected "$script" "$TMP/unsafe-$script_name-$kind" "$kind"


### PR DESCRIPTION
## Summary

- Allow the watchdog to tolerate write-style ACLs only on the exact `$HOME` ancestor while keeping descendant autoupdate path checks strict.
- Teach Malibu to detect `acl_write_rejected:$HOME` watchdog recovery failures and offer an explicit provider software repair path.
- Route repair through the bundled installer artifacts and suppress stale repair prompts after successful bundled repair or watchdog recovery.

## Validation

- `git diff --check origin/main..HEAD`
- `bash scripts/test-watchdog-inline-drift.sh`
- `bash phase3-binary/dist/test/watchdog_rollback_paths.test.sh`
- `xcodebuild test -project Malibu.xcodeproj -scheme Malibu -configuration Debug -destination 'platform=macOS'` — 459 tests, 0 failures

## Audit gates

- Product design critic: 0 critical/high/medium findings
- Adversarial verifier: 0 critical/high/medium findings
- Code review audit: 0 critical/high/medium findings
- Security audit: 0 critical/high/medium findings
- Architecture audit: 0 critical/high/medium findings

SPEC-GOVERNANCE-DECLARATION-BEGIN
{
  "schema_version": "spec-pr-governance-v1",
  "behavior_change": "yes",
  "contract_change": "none",
  "specs": ["SPEC-020"],
  "requirements": ["SPEC-020-R003", "SPEC-020-R004"],
  "authority_domains": ["provider-autoupdate"],
  "arbitration": ["CODE_BUG"],
  "tests": [
    "bash scripts/test-watchdog-inline-drift.sh",
    "bash phase3-binary/dist/test/watchdog_rollback_paths.test.sh",
    "xcodebuild test -project Malibu.xcodeproj -scheme Malibu -configuration Debug -destination 'platform=macOS'"
  ],
  "journeys": ["not-required"],
  "issue": "https://github.com/Augustas11/macprovider/issues/614"
}
SPEC-GOVERNANCE-DECLARATION-END
