### PR TITLE
Advertise v1.8.102 after immutable publication

### DIFF
--- a/phase4-coordinator/coordinator.yaml.example
+++ b/phase4-coordinator/coordinator.yaml.example
@@ -188,7 +188,7 @@ autotune:
 # legacy cohort (DECISION_CRITERIA Entry 161). `required_binary_version` is a
 # hard admission floor, not an autoupdate target, and is unaffected by the gate.
 coordinator_advertised_version:
-  latest_binary_version: "1.8.101"
+  latest_binary_version: "1.8.102"
   required_binary_version: ""
 
 auth:

--- a/phase4-coordinator/dist/coordinator.yaml
+++ b/phase4-coordinator/dist/coordinator.yaml
@@ -378,5 +378,5 @@ providers:
 # reconnecting and tells its operator to upgrade, and one without it
 # reconnect-loops.
 coordinator_advertised_version:
-  latest_binary_version: "1.8.101"
+  latest_binary_version: "1.8.102"
   required_binary_version: "1.8.33"

--- a/phase4-coordinator/dist/coordinator.yaml.example
+++ b/phase4-coordinator/dist/coordinator.yaml.example
@@ -408,7 +408,7 @@ malibu_emission:
 # routing. Keys match model_id case-insensitively; values must be bare
 # numeric versions or the coordinator refuses to start.
 coordinator_advertised_version:
-  latest_binary_version: "1.8.101"
+  latest_binary_version: "1.8.102"
   # required_binary_version: "1.7.0"
   # per_model_required_binary_version:
   #   "mlx-community/Qwen3-Coder-30B-A3B-Instruct-4bit": "1.8.60"

--- a/scripts/test-coordinator-advertised-version-test.sh
+++ b/scripts/test-coordinator-advertised-version-test.sh
@@ -18,9 +18,31 @@ trap 'rm -rf "$work"' EXIT
 policy_file="$work/release-policy.env"
 bash "$policy_guard" "v$binary_version" > "$policy_file"
 source "$policy_file"
-[[ "$MACPROVIDER_RELEASE_STAGED" == true ]]
-staged_coordinator_policy="--allow-previous-stable=$MACPROVIDER_RELEASE_PREVIOUS_STABLE_VERSION"
-staged_candidate_policy="--staged-candidate=$MACPROVIDER_RELEASE_CANDIDATE_VERSION"
+if [[ "$MACPROVIDER_RELEASE_STAGED" == true ]]; then
+  staged_coordinator_policy="--allow-previous-stable=$MACPROVIDER_RELEASE_PREVIOUS_STABLE_VERSION"
+  staged_candidate_policy="--staged-candidate=$MACPROVIDER_RELEASE_CANDIDATE_VERSION"
+else
+  [[ -z "$MACPROVIDER_RELEASE_PREVIOUS_STABLE_VERSION" ]]
+  previous_patch="$(python3 - "$binary_version" <<'PY'
+import sys
+
+major, minor, patch = (int(part) for part in sys.argv[1].split("."))
+if patch <= 0:
+    raise SystemExit("cannot synthesize a previous stable patch version")
+print(f"{major}.{minor}.{patch - 1}")
+PY
+)"
+  staged_coordinator_policy="--allow-previous-stable=$previous_patch"
+  staged_candidate_policy="--staged-candidate=$binary_version"
+fi
+
+run_version_guard() {
+  if [[ "$MACPROVIDER_RELEASE_STAGED" == true ]]; then
+    bash "$version_guard" "v$binary_version" "$staged_coordinator_policy" "$staged_candidate_policy"
+  else
+    bash "$version_guard" "v$binary_version"
+  fi
+}
 
 fixture="$work/repo"
 reset_fixture() {
@@ -39,25 +61,59 @@ reset_fixture() {
   cp "$repo_root/phase4-coordinator/dist/coordinator.yaml.example" "$fixture/phase4-coordinator/dist/coordinator.yaml.example"
 }
 
+run_fixture_guard() {
+  if [[ "$MACPROVIDER_RELEASE_STAGED" == true ]]; then
+    bash "$fixture/scripts/test-coordinator-advertised-version.sh" "v$binary_version" "$staged_coordinator_policy" "$staged_candidate_policy"
+  else
+    bash "$fixture/scripts/test-coordinator-advertised-version.sh" "v$binary_version"
+  fi
+}
+
 expect_fixture_failure() {
   label="$1"
   pattern="$2"
-  if bash "$fixture/scripts/test-coordinator-advertised-version.sh" "v$binary_version" "$staged_coordinator_policy" "$staged_candidate_policy" >"$work/$label.out" 2>&1; then
+  if run_fixture_guard >"$work/$label.out" 2>&1; then
     echo "version guard accepted invalid fixture: $label" >&2
     exit 1
   fi
   grep -q "$pattern" "$work/$label.out"
 }
 
-if bash "$version_guard" "v$binary_version" >"$work/strict-staging.out" 2>&1; then
-  echo "strict version guard accepted an unpublished candidate against the previous recommendation" >&2
-  exit 1
-fi
-grep -q "advertises $MACPROVIDER_RELEASE_PREVIOUS_STABLE_VERSION; expected $binary_version" "$work/strict-staging.out"
-base_output="$(bash "$version_guard" "v$binary_version" "$staged_coordinator_policy" "$staged_candidate_policy")"
-grep -q "staged with previous stable coordinator recommendation $MACPROVIDER_RELEASE_PREVIOUS_STABLE_VERSION" <<<"$base_output"
+if [[ "$MACPROVIDER_RELEASE_STAGED" == true ]]; then
+  if bash "$version_guard" "v$binary_version" >"$work/strict-staging.out" 2>&1; then
+    echo "strict version guard accepted an unpublished candidate against the previous recommendation" >&2
+    exit 1
+  fi
+  grep -q "advertises $MACPROVIDER_RELEASE_PREVIOUS_STABLE_VERSION; expected $binary_version" "$work/strict-staging.out"
+  base_output="$(run_version_guard)"
+  grep -q "staged with previous stable coordinator recommendation $MACPROVIDER_RELEASE_PREVIOUS_STABLE_VERSION" <<<"$base_output"
+else
+  base_output="$(bash "$version_guard" "v$binary_version")"
+  grep -q "CLI and coordinator advertised versions are aligned at $binary_version" <<<"$base_output"
 
-if bash "$version_guard" "v$binary_version" "$staged_coordinator_policy" --staged-candidate=1.8.91 >"$work/candidate-drift.out" 2>&1; then
+  reset_fixture
+  for config in \
+    "$fixture/phase4-coordinator/dist/coordinator.yaml" \
+    "$fixture/phase4-coordinator/coordinator.yaml.example" \
+    "$fixture/phase4-coordinator/dist/coordinator.yaml.example"; do
+    sed "s/latest_binary_version: \"$binary_version\"/latest_binary_version: \"$previous_patch\"/" "$config" > "$config.next"
+    mv "$config.next" "$config"
+  done
+  if bash "$fixture/scripts/test-coordinator-advertised-version.sh" "v$binary_version" >"$work/strict-staging.out" 2>&1; then
+    echo "strict version guard accepted an unpublished candidate against the previous recommendation" >&2
+    exit 1
+  fi
+  grep -q "advertises $previous_patch; expected $binary_version" "$work/strict-staging.out"
+  staged_output="$(bash "$fixture/scripts/test-coordinator-advertised-version.sh" "v$binary_version" "$staged_coordinator_policy" "$staged_candidate_policy")"
+  grep -q "staged with previous stable coordinator recommendation $previous_patch" <<<"$staged_output"
+fi
+
+staged_fixture_guard="$version_guard"
+if [[ "$MACPROVIDER_RELEASE_STAGED" == false ]]; then
+  staged_fixture_guard="$fixture/scripts/test-coordinator-advertised-version.sh"
+fi
+
+if bash "$staged_fixture_guard" "v$binary_version" "$staged_coordinator_policy" --staged-candidate=1.8.91 >"$work/candidate-drift.out" 2>&1; then
   echo "version guard accepted a staged exception for a different candidate" >&2
   exit 1
 fi
@@ -92,13 +148,13 @@ expect_fixture_failure duplicate-build 'exactly one numeric CURRENT_PROJECT_VERS
 reset_fixture
 sed "s/$app_version/$future_version/g" "$fixture/phase3-binary/app/project.yml" > "$fixture/phase3-binary/app/project.yml.next"
 mv "$fixture/phase3-binary/app/project.yml.next" "$fixture/phase3-binary/app/project.yml"
-if bash "$fixture/scripts/test-coordinator-advertised-version.sh" "v$binary_version" "$staged_coordinator_policy" "$staged_candidate_policy" >"$work/future-missing-build.out" 2>&1; then
+if run_fixture_guard >"$work/future-missing-build.out" 2>&1; then
   echo "version guard accepted a future release without a release-build ledger entry" >&2
   exit 1
 fi
 grep -q "exactly one entry for $future_version" "$work/future-missing-build.out"
 printf '%s\t%s\n' "$future_version" "$app_build" >> "$fixture/phase3-binary/app/release-builds.tsv"
-if bash "$fixture/scripts/test-coordinator-advertised-version.sh" "v$binary_version" "$staged_coordinator_policy" "$staged_candidate_policy" >"$work/future-reused-build.out" 2>&1; then
+if run_fixture_guard >"$work/future-reused-build.out" 2>&1; then
   echo "version guard accepted a future release that reused build $app_build" >&2
   exit 1
 fi
@@ -107,6 +163,6 @@ sed "s/${future_version_pattern}[[:space:]]*$app_build/$future_version $future_b
 mv "$fixture/phase3-binary/app/release-builds.tsv.next" "$fixture/phase3-binary/app/release-builds.tsv"
 sed "s/CURRENT_PROJECT_VERSION: \"$app_build\"/CURRENT_PROJECT_VERSION: \"$future_build\"/" "$fixture/phase3-binary/app/project.yml" > "$fixture/phase3-binary/app/project.yml.next"
 mv "$fixture/phase3-binary/app/project.yml.next" "$fixture/phase3-binary/app/project.yml"
-bash "$fixture/scripts/test-coordinator-advertised-version.sh" "v$binary_version" "$staged_coordinator_policy" "$staged_candidate_policy"
+run_fixture_guard
 
 echo "independent Malibu and CLI release-version regression checks passed"

--- a/scripts/test-malibu-independent-release.sh
+++ b/scripts/test-malibu-independent-release.sh
@@ -139,14 +139,21 @@ valid_cli_tag="v$valid_cli_version"
 policy_file="$work/release-policy.env"
 bash "$root/scripts/release-staged-version-policy.sh" "$valid_cli_tag" > "$policy_file"
 source "$policy_file"
-staged_coordinator_policy="--allow-previous-stable=$MACPROVIDER_RELEASE_PREVIOUS_STABLE_VERSION"
-staged_candidate_policy="--staged-candidate=$MACPROVIDER_RELEASE_CANDIDATE_VERSION"
 
-"$validator" "$valid_cli_tag" "$valid_cli_version" "$valid_sha" "$valid_archive_sha" \
-  "$staged_coordinator_policy" "$staged_candidate_policy" >/dev/null
+run_validator() {
+  if [[ "$MACPROVIDER_RELEASE_STAGED" == true ]]; then
+    "$validator" "$@" \
+      "--allow-previous-stable=$MACPROVIDER_RELEASE_PREVIOUS_STABLE_VERSION" \
+      "--staged-candidate=$MACPROVIDER_RELEASE_CANDIDATE_VERSION"
+  else
+    "$validator" "$@"
+  fi
+}
+
+run_validator "$valid_cli_tag" "$valid_cli_version" "$valid_sha" "$valid_archive_sha" >/dev/null
 
 expect_failure() {
-  if "$validator" "$@" "$staged_coordinator_policy" "$staged_candidate_policy" >/dev/null 2>&1; then
+  if run_validator "$@" >/dev/null 2>&1; then
     echo "Malibu release CLI input validation unexpectedly succeeded: $*" >&2
     exit 1
   fi


### PR DESCRIPTION
Post-publication rollout bump for v1.8.102.

This moves the coordinator advertised provider CLI recommendation from the previous stable v1.8.101 to the now-published immutable v1.8.102 release, after the release asset/provenance and Malibu embedded-CLI byte-identity checks passed.

It also updates release regression tests so they validate both valid post-publication alignment and the staged previous-stable exception, instead of assuming every candidate branch is still pre-publication.

Validation:
- bash scripts/test-coordinator-advertised-version.sh v1.8.102
- bash scripts/test-coordinator-advertised-version-test.sh
- bash scripts/test-malibu-independent-release.sh
- bash scripts/test-live-coordinator-release-gate.sh
- go test ./internal/config ./internal/ws (phase4-coordinator)
- make test-dist
- git diff --check

SPEC-GOVERNANCE-DECLARATION-BEGIN
{
  "schema_version": "spec-pr-governance-v1",
  "behavior_change": "yes",
  "contract_change": "none",
  "specs": ["SPEC-020"],
  "requirements": ["SPEC-020-R001"],
  "authority_domains": ["provider-autoupdate"],
  "arbitration": ["CODE_BUG"],
  "tests": [
    "scripts/test-coordinator-advertised-version.sh v1.8.102",
    "scripts/test-coordinator-advertised-version-test.sh",
    "scripts/test-malibu-independent-release.sh",
    "scripts/test-live-coordinator-release-gate.sh",
    "go test ./internal/config ./internal/ws (phase4-coordinator)",
    "make test-dist",
    "git diff --check"
  ],
  "journeys": ["not-required"],
  "issue": "https://github.com/Augustas11/macprovider/issues/610"
}
SPEC-GOVERNANCE-DECLARATION-END
