### PR TITLE
Keep anonymous rollout smoke stable under CI throttling

### DIFF
--- a/.github/workflows/verify-live-coordinator-release-rollout.yml
+++ b/.github/workflows/verify-live-coordinator-release-rollout.yml
@@ -273,6 +273,7 @@ jobs:
       - name: Verify anonymous discovery through released arm64 client
         shell: bash
         env:
+          MACPROVIDER_RELEASE_FIXTURE_GITHUB_TOKEN: ${{ github.token }}
           TAG: ${{ needs.verify.outputs.tag }}
           TARGET_COMMIT: ${{ needs.verify.outputs.target_commit }}
           TRANSPORT_TAG: ${{ needs.verify.outputs.transport_tag }}

--- a/scripts/test-live-coordinator-release-gate.sh
+++ b/scripts/test-live-coordinator-release-gate.sh
@@ -603,6 +603,7 @@ def require_rollout(workflow_path):
         'cp "$existing_transport_json" "$transport_release_json"',
         "needs: verify",
         "target_commit: ${{ steps.rollout.outputs.target_commit }}",
+        'MACPROVIDER_RELEASE_FIXTURE_GITHUB_TOKEN: ${{ github.token }}',
         "TRANSPORT_TAG: ${{ needs.verify.outputs.transport_tag }}",
         'ref: ${{ github.sha }}',
     ):

--- a/scripts/test-release-security-posture.sh
+++ b/scripts/test-release-security-posture.sh
@@ -31,11 +31,34 @@ work="$(mktemp -d "${TMPDIR:-/tmp}/release-security-posture.XXXXXX")"
 trap 'rm -rf "$work"' EXIT
 
 bash -n "$sealed_openssl_installer" "$sealed_openssl_wrapper" "$anonymous_discovery_verifier"
-grep -Fq "HOME=\"\$work/home\" CFFIXED_USER_HOME=\"\$work/home\" \"\$client\" update --check" \
-  "$anonymous_discovery_verifier" || {
-    echo "anonymous release discovery must isolate both shell and Foundation homes" >&2
-    exit 1
-  }
+for requirement in \
+  'HOME="$work/home"' \
+  'CFFIXED_USER_HOME="$work/home"' \
+  'RUNNER_TEMP="$work/client-tmp"' \
+  'TMPDIR="$work/client-tmp"' \
+  '"$client" update --check' \
+  '-u MACPROVIDER_RELEASE_FIXTURE_GITHUB_TOKEN' \
+  '-u GITHUB_TOKEN' \
+  '-u GH_TOKEN' \
+  '-u RELEASE_POSTURE_TOKEN'
+do
+  grep -Fq -- "$requirement" "$anonymous_discovery_verifier" || {
+      echo "anonymous release discovery must isolate homes and remove GitHub token variables" >&2
+      exit 1
+    }
+done
+token_cleanup="$(grep -Fn 'rm -f -- "$github_api_curl_config"' "$anonymous_discovery_verifier" | cut -d: -f1)"
+env_cleanup="$(grep -Fn 'MACPROVIDER_RELEASE_FIXTURE_GITHUB_TOKEN \' "$anonymous_discovery_verifier" | cut -d: -f1 | head -n 1)"
+asset_download="$(grep -Fn 'curl "${curl_args[@]}" "$url"' "$anonymous_discovery_verifier" | cut -d: -f1)"
+client_exec="$(grep -Fn '"$client" update --check' "$anonymous_discovery_verifier" | cut -d: -f1)"
+if [[ ! "$token_cleanup" =~ ^[1-9][0-9]*$ || ! "$asset_download" =~ ^[1-9][0-9]*$ || "$token_cleanup" -ge "$asset_download" ]]; then
+  echo "anonymous release discovery must delete fixture auth config before post-listing downloads" >&2
+  exit 1
+fi
+if [[ ! "$env_cleanup" =~ ^[1-9][0-9]*$ || "$env_cleanup" -ge "$asset_download" || ! "$client_exec" =~ ^[1-9][0-9]*$ ]]; then
+  echo "anonymous release discovery must unset fixture token env before post-listing downloads" >&2
+  exit 1
+fi
 printf '%s\n' ": > \"\$BASH_ENV_PROBE\"" > "$work/injected-bash-env"
 if BASH_ENV="$work/injected-bash-env" BASH_ENV_PROBE="$work/bash-env-ran" \
   "$sealed_openssl_wrapper" >"$work/wrapper.out" 2>&1; then
@@ -1466,6 +1489,7 @@ for requirement in (
     'cp "$existing_transport_json" "$transport_release_json"',
     "needs: verify",
     "target_commit: ${{ steps.rollout.outputs.target_commit }}",
+    'MACPROVIDER_RELEASE_FIXTURE_GITHUB_TOKEN: ${{ github.token }}',
     "TRANSPORT_TAG: ${{ needs.verify.outputs.transport_tag }}",
     'ref: ${{ github.sha }}',
 ):

--- a/scripts/test-select-public-discovery-transport.sh
+++ b/scripts/test-select-public-discovery-transport.sh
@@ -146,5 +146,19 @@ grep -Fq 'releases?per_page=100' "$verifier" \
   || fail "anonymous verifier must page enough public releases to observe the head"
 grep -Fq 'MACPROVIDER_DISCOVERY_LISTING_ATTEMPTS' "$verifier" \
   || fail "anonymous verifier must retry a lagging public listing"
+grep -Fq 'MACPROVIDER_RELEASE_FIXTURE_GITHUB_TOKEN' "$verifier" \
+  || fail "anonymous verifier must allow authenticated fixture setup in CI"
+grep -Fq -- '-u MACPROVIDER_RELEASE_FIXTURE_GITHUB_TOKEN' "$verifier" \
+  || fail "anonymous verifier must remove fixture tokens before running the client"
+grep -Fq -- '-u GITHUB_TOKEN' "$verifier" \
+  || fail "anonymous verifier must remove GitHub tokens before running the client"
+grep -Fq -- '-u RELEASE_POSTURE_TOKEN' "$verifier" \
+  || fail "anonymous verifier must remove release posture tokens before running the client"
+grep -Fq 'rm -f -- "$github_api_curl_config"' "$verifier" \
+  || fail "anonymous verifier must delete fixture auth config before running the client"
+grep -Fq 'unset \' "$verifier" \
+  || fail "anonymous verifier must unset fixture auth environment after listing"
+grep -Fq 'MACPROVIDER_RELEASE_FIXTURE_GITHUB_TOKEN \' "$verifier" \
+  || fail "anonymous verifier must unset fixture auth token after listing"
 
 printf '[test-select-public-discovery-transport] ok\n'

--- a/scripts/verify-anonymous-release-discovery.sh
+++ b/scripts/verify-anonymous-release-discovery.sh
@@ -27,6 +27,21 @@ curl_args=(
   --fail --show-error --silent --location --proto '=https' --tlsv1.2
   --connect-timeout 20 --max-time 240 --retry 5 --retry-delay 2
 )
+github_api_curl_args=(
+  "${curl_args[@]}"
+  -H "Accept: application/vnd.github+json"
+  -H "User-Agent: macprovider-release-verifier"
+)
+fixture_github_token="${MACPROVIDER_RELEASE_FIXTURE_GITHUB_TOKEN:-}"
+github_api_curl_config=
+if [ -n "$fixture_github_token" ]; then
+  github_api_curl_config="$work/github-api-curl.conf"
+  old_umask="$(umask)"
+  umask 077
+  printf 'header = "Authorization: Bearer %s"\n' "$fixture_github_token" > "$github_api_curl_config"
+  umask "$old_umask"
+  github_api_curl_args+=(--config "$github_api_curl_config")
+fi
 api="https://api.github.com/repos/$repository"
 listing_attempts="${MACPROVIDER_DISCOVERY_LISTING_ATTEMPTS:-15}"
 listing_retry_seconds="${MACPROVIDER_DISCOVERY_LISTING_RETRY_SECONDS:-2}"
@@ -34,7 +49,7 @@ listing_retry_seconds="${MACPROVIDER_DISCOVERY_LISTING_RETRY_SECONDS:-2}"
 [[ "$listing_retry_seconds" =~ ^[1-9][0-9]*$ ]] || die "invalid discovery listing retry interval"
 listing_attempt=1
 while true; do
-  curl "${curl_args[@]}" "$api/releases?per_page=100" -o "$work/releases.json"
+  curl "${github_api_curl_args[@]}" "$api/releases?per_page=100" -o "$work/releases.json"
   set +e
   python3 "$root/scripts/select_public_discovery_transport.py" \
     "$work/releases.json" \
@@ -54,6 +69,17 @@ while true; do
   listing_attempt=$((listing_attempt + 1))
   sleep "$listing_retry_seconds"
 done
+if [ -n "$github_api_curl_config" ]; then
+  rm -f -- "$github_api_curl_config"
+fi
+unset \
+  MACPROVIDER_RELEASE_FIXTURE_GITHUB_TOKEN \
+  GITHUB_TOKEN \
+  GH_TOKEN \
+  RELEASE_POSTURE_TOKEN \
+  fixture_github_token \
+  github_api_curl_config \
+  github_api_curl_args
 
 while IFS=$'\t' read -r name url; do
   curl "${curl_args[@]}" "$url" -o "$work/$name"
@@ -91,8 +117,19 @@ client="$work/client/macprovider-cli"
 codesign --verify --strict --verbose=2 "$client"
 [[ "$("$client" --version)" == "${client_tag#v}" ]] || die "client binary version differs"
 
-mkdir "$work/home"
-output="$(HOME="$work/home" CFFIXED_USER_HOME="$work/home" "$client" update --check 2>&1)" || {
+mkdir "$work/home" "$work/client-tmp"
+output="$(
+  env \
+    -u MACPROVIDER_RELEASE_FIXTURE_GITHUB_TOKEN \
+    -u GITHUB_TOKEN \
+    -u GH_TOKEN \
+    -u RELEASE_POSTURE_TOKEN \
+    HOME="$work/home" \
+    CFFIXED_USER_HOME="$work/home" \
+    RUNNER_TEMP="$work/client-tmp" \
+    TMPDIR="$work/client-tmp" \
+    "$client" update --check 2>&1
+)" || {
   printf '%s\n' "$output" >&2
   die "$client_tag could not discover $target_tag anonymously"
 }


### PR DESCRIPTION
## Summary
- harden the live rollout anonymous discovery smoke against GitHub Actions shared-IP unauthenticated API 403s
- use the workflow read token only for verifier fixture listing/setup
- explicitly remove GitHub token variables before executing the released `macprovider-cli update --check` in an isolated home

## Verification
- `bash -n scripts/verify-anonymous-release-discovery.sh scripts/test-live-coordinator-release-gate.sh scripts/test-release-security-posture.sh scripts/test-select-public-discovery-transport.sh`
- `scripts/test-live-coordinator-release-gate.sh`
- `scripts/test-release-security-posture.sh`
- `scripts/test-select-public-discovery-transport.sh`
- `git diff --check`
- `MACPROVIDER_RELEASE_FIXTURE_GITHUB_TOKEN=$(gh auth token -u Augustas11) GITHUB_REPOSITORY=Augustas11/macprovider scripts/verify-anonymous-release-discovery.sh v1.8.102 a0c73fb260dc0d342bc305bfab706dfd44a703dc v1.8.102 release-discovery-v1-2113453086670849`

SPEC-GOVERNANCE-DECLARATION-BEGIN
{
  "schema_version": "spec-pr-governance-v1",
  "behavior_change": "yes",
  "contract_change": "none",
  "specs": ["SPEC-020"],
  "requirements": ["SPEC-020-R001"],
  "authority_domains": ["provider-autoupdate"],
  "arbitration": ["CODE_BUG"],
  "tests": [
    "scripts/test-live-coordinator-release-gate.sh",
    "scripts/test-release-security-posture.sh",
    "scripts/test-select-public-discovery-transport.sh",
    "scripts/verify-anonymous-release-discovery.sh v1.8.102"
  ],
  "journeys": ["provider-release-rollout"],
  "issue": "https://github.com/Augustas11/macprovider/issues/585"
}
SPEC-GOVERNANCE-DECLARATION-END
