### PR TITLE
Restore rewards trust through explicit operator approval

### DIFF
--- a/phase3-binary/app/Sources/Malibu/Agent/AgentSnapshot.swift
+++ b/phase3-binary/app/Sources/Malibu/Agent/AgentSnapshot.swift
@@ -641,6 +641,9 @@ enum AgentSnapshotPresenter {
             return "MALIBU trust telemetry not published yet"
         }
         let tier = s.trustTier.rawValue.capitalized
+        if hasDemotionCooldown(s) {
+            return "Trust: \(tier) · requalification cooldown active"
+        }
         if let met = s.trustCriteriaMet, let required = s.trustCriteriaRequired {
             return "Trust: \(tier) · \(met) of \(required) criteria met"
         }
@@ -648,6 +651,9 @@ enum AgentSnapshotPresenter {
     }
 
     private static func trustCriteriaAction(_ s: AgentSnapshot) -> String? {
+        if hasDemotionCooldown(s) {
+            return "Re-qualify for Trusted to clear the cooldown."
+        }
         guard let met = s.trustCriteriaMet,
               let required = s.trustCriteriaRequired,
               required > met else { return nil }
@@ -1519,6 +1525,9 @@ enum AgentSnapshotPresenter {
     static func trustLine(_ s: AgentSnapshot) -> String {
         guard s.malibuProjectionFresh else { return "MALIBU trust telemetry not published yet" }
         let tier = s.trustTier.rawValue.capitalized
+        if hasDemotionCooldown(s) {
+            return "\(tier) — requalification cooldown active"
+        }
         if let met = s.trustCriteriaMet, let required = s.trustCriteriaRequired {
             return "\(tier) — \(met) of \(required) criteria met · Unlock Trusted →"
         }
@@ -1824,6 +1833,16 @@ enum AgentSnapshotPresenter {
     private static func authoritativeRewardEligibility(_ s: AgentSnapshot) -> MalibuRewardEligibility? {
         guard s.malibuProjectionFresh else { return nil }
         return s.malibuRewardEligibility ?? MalibuRewardEligibility.unavailableForMissingObject()
+    }
+
+    private static func hasDemotionCooldown(_ s: AgentSnapshot) -> Bool {
+        guard s.trustTier == .provisional else {
+            return false
+        }
+        if s.malibuHoldReasons.contains("demotion_cooldown") {
+            return true
+        }
+        return authoritativeRewardEligibility(s)?.primaryReason == "held_demotion_cooldown"
     }
 
     private static func rewardEligibilityLine(_ eligibility: MalibuRewardEligibility) -> String {

--- a/phase3-binary/app/Tests/MalibuTests/DashboardViewTests.swift
+++ b/phase3-binary/app/Tests/MalibuTests/DashboardViewTests.swift
@@ -310,6 +310,18 @@ final class DashboardViewTests: XCTestCase {
             "Complete 2 more trust criteria to unlock withdrawals."
         )
 
+        provisional.malibuHoldReasons = ["demotion_cooldown"]
+        provisional.trustCriteriaMet = 2
+        provisional.trustCriteriaRequired = 2
+        let cooldownHealth = AgentSnapshotPresenter.miningHealth(provisional)
+        XCTAssertEqual(cooldownHealth.trustSummary, "Trust: Provisional · requalification cooldown active")
+        XCTAssertEqual(cooldownHealth.nextAction, "Re-qualify for Trusted to clear the cooldown.")
+        XCTAssertEqual(AgentSnapshotPresenter.trustLine(provisional), "Provisional — requalification cooldown active")
+
+        var trustedWithHistoricalHold = provisional
+        trustedWithHistoricalHold.trustTier = .trusted
+        XCTAssertEqual(AgentSnapshotPresenter.trustLine(trustedWithHistoricalHold), "Trusted — 2 of 2 criteria met · Unlock Trusted →")
+
         var walletCap = miningBase()
         walletCap.malibuHeld = 2
         walletCap.malibuHoldReasons = ["per_wallet_daily_cap"]

--- a/phase4-coordinator/cmd/coordinator/main.go
+++ b/phase4-coordinator/cmd/coordinator/main.go
@@ -934,8 +934,9 @@ func main() {
 	providerMux.Handle("/admin/ledger/", billingHandler)
 	if rewardsDB != nil {
 		providerMux.Handle("/admin/trust-promotion/", rewards.TrustPromotionMux(rewards.TrustAdminDeps{
-			DB:           rewardsDB,
-			OperatorKeys: cfg.Auth.OperatorKeys,
+			DB:            rewardsDB,
+			OperatorKeys:  cfg.Auth.OperatorKeys,
+			TrustObserver: rewards.TrustTierObserverFunc(func(providerID, tier string) { wsServer.ApplyRewardsTrustTier(providerID, tier) }),
 		}))
 		providerMux.Handle("/admin/malibu-reward-audit", malibuRewardAuditAdminHandler(cfg, rewardsDB))
 	}

--- a/phase4-coordinator/internal/rewards/unlock.go
+++ b/phase4-coordinator/internal/rewards/unlock.go
@@ -520,12 +520,29 @@ func ApproveTrustPromotion(ctx context.Context, db *sql.DB, pendingID, approvedB
 		return "", errors.New("approved_by must differ from requested_by")
 	}
 	now := time.Now().UTC()
+	trustTierChanged, err := commitTrustPromotionTx(ctx, tx, providerID, approvedBy, reason, pendingID, now)
+	if err != nil {
+		return "", err
+	}
+	if trustTierChanged {
+		if err := auditTrustTierChangedTx(ctx, tx, providerID, TierTrusted, now); err != nil {
+			return "", err
+		}
+	}
+	return providerID, tx.Commit()
+}
+
+func commitTrustPromotionTx(ctx context.Context, tx *sql.Tx, providerID, approvedBy, reason, pendingID string, now time.Time) (bool, error) {
+	previousTier, err := trustTierTx(ctx, tx, providerID)
+	if err != nil {
+		return false, err
+	}
 	if _, err := tx.ExecContext(ctx, `
         UPDATE provider_trust_promotion_pending
            SET status = 'committed', approved_by = $2, committed_at = $3
          WHERE pending_id = $1
     `, pendingID, approvedBy, now); err != nil {
-		return "", err
+		return false, err
 	}
 	if _, err := tx.ExecContext(ctx, `
         INSERT INTO provider_trust_operator_promotions
@@ -537,7 +554,23 @@ func ApproveTrustPromotion(ctx context.Context, db *sql.DB, pendingID, approvedB
             pending_id = EXCLUDED.pending_id,
             promoted_at = EXCLUDED.promoted_at
     `, providerID, approvedBy, reason, pendingID, now); err != nil {
-		return "", err
+		return false, err
 	}
-	return providerID, tx.Commit()
+	if err := setTrustTier(ctx, tx, providerID, TierTrusted); err != nil {
+		return false, err
+	}
+	return !strings.EqualFold(strings.TrimSpace(previousTier), TierTrusted), nil
+}
+
+func trustTierTx(ctx context.Context, tx *sql.Tx, providerID string) (string, error) {
+	var tier string
+	err := tx.QueryRowContext(ctx, `
+        SELECT trust_tier
+          FROM provider_emission_state
+         WHERE provider_id = $1
+    `, providerID).Scan(&tier)
+	if err == sql.ErrNoRows {
+		return TierProvisional, nil
+	}
+	return tier, err
 }

--- a/phase4-coordinator/internal/rewards/unlock_admin.go
+++ b/phase4-coordinator/internal/rewards/unlock_admin.go
@@ -22,8 +22,9 @@ import (
 // or the route fails closed. This mirrors the provider-auth-policy operator
 // model in internal/ws/admin_endpoints.go.
 type TrustAdminDeps struct {
-	DB           *sql.DB
-	OperatorKeys map[string]string
+	DB            *sql.DB
+	OperatorKeys  map[string]string
+	TrustObserver TrustTierObserver
 }
 
 // dualControlReady reports whether the configured operator keys can support
@@ -138,6 +139,9 @@ func NewTrustPromotionApproveHandler(deps TrustAdminDeps) http.Handler {
 		if err != nil {
 			writeTrustJSON(w, http.StatusBadRequest, map[string]any{"error": err.Error()})
 			return
+		}
+		if deps.TrustObserver != nil {
+			deps.TrustObserver.ProviderTrustTierChanged(providerID, TierTrusted)
 		}
 		writeTrustJSON(w, http.StatusOK, map[string]any{
 			"pending_id":  pendingID,

--- a/phase4-coordinator/internal/rewards/unlock_admin_test.go
+++ b/phase4-coordinator/internal/rewards/unlock_admin_test.go
@@ -1,11 +1,14 @@
 package rewards
 
 import (
+	"context"
+	"database/sql"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestDualControlReady(t *testing.T) {
@@ -167,5 +170,102 @@ func TestWriteTrustJSON_NoStore(t *testing.T) {
 	writeTrustJSON(rr, http.StatusOK, map[string]any{"ok": true})
 	if got := rr.Header().Get("Cache-Control"); !strings.Contains(got, "no-store") {
 		t.Fatalf("Cache-Control=%q", got)
+	}
+}
+
+func TestCommitTrustPromotionSetsTrustedAndClearsCooldown(t *testing.T) {
+	ctx := context.Background()
+	db, err := sql.Open("sqlite", ":memory:")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+	for _, stmt := range []string{
+		`CREATE TABLE provider_trust_promotion_pending (
+			pending_id TEXT PRIMARY KEY,
+			provider_id TEXT NOT NULL,
+			requested_by TEXT NOT NULL,
+			reason TEXT NOT NULL,
+			incident_id TEXT NULL,
+			created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+			committed_at TEXT NULL,
+			approved_by TEXT NULL,
+			status TEXT NOT NULL
+		)`,
+		`CREATE TABLE provider_trust_operator_promotions (
+			provider_id TEXT PRIMARY KEY,
+			promoted_by TEXT NOT NULL,
+			reason TEXT NOT NULL,
+			pending_id TEXT NOT NULL,
+			promoted_at TEXT NOT NULL
+		)`,
+		`CREATE TABLE provider_emission_state (
+			provider_id TEXT PRIMARY KEY,
+			trust_tier TEXT NOT NULL,
+			demotion_cooldown_until TEXT NULL,
+			updated_at TEXT NULL
+		)`,
+	} {
+		if _, err := db.ExecContext(ctx, stmt); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO provider_emission_state (provider_id, trust_tier, demotion_cooldown_until)
+		VALUES ('mac', 'provisional', '2026-08-22T14:55:27Z')
+	`); err != nil {
+		t.Fatal(err)
+	}
+
+	pendingID := "4d2644a7-fc82-4750-b43f-2d9f73abc62a"
+	if err := RequestTrustPromotion(ctx, db, pendingID, "mac", "operator:alice", "incident override", "INC-7"); err != nil {
+		t.Fatal(err)
+	}
+	tx, err := db.BeginTx(ctx, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = tx.Rollback() }()
+	trustTierChanged, err := commitTrustPromotionTx(ctx, tx, "mac", "operator:bob", "incident override", pendingID, time.Now().UTC())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !trustTierChanged {
+		t.Fatal("trust tier change not reported")
+	}
+	if err := tx.Commit(); err != nil {
+		t.Fatal(err)
+	}
+
+	var tier string
+	var cooldown sql.NullString
+	if err := db.QueryRowContext(ctx, `
+		SELECT trust_tier, demotion_cooldown_until
+		  FROM provider_emission_state
+		 WHERE provider_id = 'mac'
+	`).Scan(&tier, &cooldown); err != nil {
+		t.Fatal(err)
+	}
+	if tier != TierTrusted || cooldown.Valid {
+		t.Fatalf("trust state tier=%q cooldown=%v", tier, cooldown)
+	}
+
+	var promotedBy, status string
+	if err := db.QueryRowContext(ctx, `
+		SELECT promoted_by
+		  FROM provider_trust_operator_promotions
+		 WHERE provider_id = 'mac'
+	`).Scan(&promotedBy); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.QueryRowContext(ctx, `
+		SELECT status
+		  FROM provider_trust_promotion_pending
+		 WHERE pending_id = ?
+	`, pendingID).Scan(&status); err != nil {
+		t.Fatal(err)
+	}
+	if promotedBy != "operator:bob" || status != "committed" {
+		t.Fatalf("promotion promoted_by=%q status=%q", promotedBy, status)
 	}
 }


### PR DESCRIPTION
Fixes the rewards-trust recovery path after the Malibu provider incident.

- Keeps hardware/MDA/SE trust separate from rewards withdrawal trust.
- Makes explicit dual-control rewards approval set the durable rewards tier to trusted, clear demotion cooldown, emit the trust promotion audit event, and notify live routing.
- Fixes Malibu UI copy so current demotion cooldown is shown instead of misleading criteria-complete copy, without treating historical held rows as active cooldown.

SPEC-GOVERNANCE-DECLARATION-BEGIN
{
  "schema_version": "spec-pr-governance-v1",
  "behavior_change": "yes",
  "contract_change": "none",
  "specs": ["SPEC-021"],
  "requirements": ["SPEC-021-R001"],
  "authority_domains": ["malibu-emission-ledger"],
  "arbitration": ["CODE_BUG"],
  "tests": [
    "go test ./internal/ws ./internal/rewards ./cmd/coordinator",
    "xcodebuild test -project Malibu.xcodeproj -scheme Malibu -destination 'platform=macOS' -only-testing:MalibuTests/DashboardViewTests/testMiningHealthCoversIssue1017OperationalStates"
  ],
  "journeys": ["not-required"]
}
SPEC-GOVERNANCE-DECLARATION-END