### PR TITLE
Keep dashboard Ready across coordinator socket blips

### DIFF
--- a/phase3-binary/Sources/macprovider-cli/HTTPServer.swift
+++ b/phase3-binary/Sources/macprovider-cli/HTTPServer.swift
@@ -1649,7 +1649,11 @@ final class RouterHandler: ChannelInboundHandler, @unchecked Sendable {
                 networkState = "local_donor"
             } else if (trustState == "live_verified"
                 || (trustState == "safe_offline_fallback" && snapshot.catalogCompatibilityConfirmed))
-                && localReady && snapshot.coordinatorConnected {
+                && localReady {
+                // Pool /v1/pool/check is the routing verdict. A WebSocket blip
+                // (NSPOSIX 54/57/60) must not rewrite that into catalog
+                // `live_verified`, which Malibu presents as "waiting for
+                // network approval" — a first-join phrase, not reconnect.
                 switch coordinatorBuyerServing {
                 case .some(true):
                     networkState = "buyer_serving"

--- a/phase3-binary/Sources/macprovider-cli/SelfUpdate.swift
+++ b/phase3-binary/Sources/macprovider-cli/SelfUpdate.swift
@@ -2608,7 +2608,7 @@ struct LocalStatusFormatter {
         if donorMode || networkState == "local_donor" {
             title = "Provider is running locally"
             nextStep = "Open Malibu when you are ready to join the network."
-        } else if networkState == "buyer_serving" && connected && modelLoaded && !["draining", "unavailable"].contains(localState) {
+        } else if networkState == "buyer_serving" && modelLoaded && !["draining", "unavailable"].contains(localState) {
             title = "Provider is ready"
             nextStep = nil
         } else if lifecycleReason == "autotune_evidence_required" {

--- a/phase3-binary/Tests/macprovider-cliTests/ProviderStatusTests.swift
+++ b/phase3-binary/Tests/macprovider-cliTests/ProviderStatusTests.swift
@@ -592,6 +592,46 @@ final class ProviderStatusTests: XCTestCase {
         XCTAssertEqual(rejected["buyer_serving_authority"] as? String, "coordinator")
     }
 
+    func testStatusKeepsPoolVerdictWhenCoordinatorSocketDrops() async {
+        let status = ProviderStatus(modelID: "m", modelLoaded: true, capacity: makeCapacity())
+        await status.setCoordinatorSession(connected: false, assignedID: "session-a")
+        let context = ProviderCatalogStatusContext(
+            trust: ServeCommand.CatalogRuntimeTrust(
+                state: "live_verified",
+                releaseID: "release-a",
+                digest: String(repeating: "a", count: 64),
+                signerKeyID: "signer-v5",
+                source: "coordinator"
+            ),
+            donorMode: false,
+            catalogKey: "model-key",
+            catalogModelID: "org/model",
+            modelRevision: nil,
+            artifactSHA256: nil,
+            configuredReleaseID: nil,
+            configuredCatalogDigest: nil
+        )
+
+        let serving = RouterHandler.statusResponse(
+            await status.snapshot(),
+            providerID: "provider-a",
+            coordinatorURL: "wss://coordinator.malibu.tech/ws/provider",
+            catalogStatus: context,
+            coordinatorBuyerServing: true
+        )
+        let unknown = RouterHandler.statusResponse(
+            await status.snapshot(),
+            providerID: "provider-a",
+            coordinatorURL: "wss://coordinator.malibu.tech/ws/provider",
+            catalogStatus: context
+        )
+
+        XCTAssertEqual(serving["network_state"] as? String, "buyer_serving")
+        XCTAssertEqual((serving["catalog"] as? [String: Any])?["state"] as? String, "live_verified")
+        XCTAssertEqual(unknown["network_state"] as? String, "buyer_serving_unknown")
+        XCTAssertNotEqual(unknown["network_state"] as? String, "live_verified")
+    }
+
     func testCoordinatorReadinessURLUsesPublicReadinessEndpoint() throws {
         let url = try XCTUnwrap(CoordinatorReadinessClient.readinessURL(
             coordinatorURL: "wss://coordinator.malibu.tech/v1/ws/provider?ignored=true",

--- a/phase3-binary/Tests/macprovider-cliTests/StatusCommandTests.swift
+++ b/phase3-binary/Tests/macprovider-cliTests/StatusCommandTests.swift
@@ -154,7 +154,7 @@ final class StatusCommandTests: XCTestCase {
             ("catalog_update_required", "ready", true, true, "This Mac is not currently eligible"),
             ("live_verified", "unavailable", true, false, "Model is preparing"),
             ("live_verified", "ready", false, true, "Provider is connecting"),
-            ("buyer_serving", "ready", false, true, "Provider is connecting"),
+            ("buyer_serving", "ready", false, true, "Provider is ready"),
         ]
 
         for (networkState, localState, connected, modelLoaded, expectedTitle) in cases {

--- a/phase3-binary/app/Sources/Malibu/Agent/AgentSnapshot.swift
+++ b/phase3-binary/app/Sources/Malibu/Agent/AgentSnapshot.swift
@@ -142,6 +142,10 @@ struct AgentSnapshot: Equatable {
     /// Canonical provider state reported by /v1/status. `buyer_serving` is the
     /// only state backed by the coordinator's routing-readiness verdict.
     var networkState: String?
+    /// Last time Malibu observed a current `buyer_serving` verdict. Holds the
+    /// dashboard on "Provider is ready" across WebSocket blips that rewrite
+    /// `network_state` to `live_verified` / `buyer_serving_unknown`.
+    var lastBuyerServingAt: Date? = nil
     var advertisedMaxConcurrency: Int?
     var catalogState: String?
     var catalogReleaseID: String?
@@ -185,6 +189,57 @@ struct AgentSnapshot: Equatable {
         networkState = "buyer_serving_unknown"
     }
 
+    mutating func updateBuyerServingHold(at now: Date = Date()) {
+        if isLocalStatusObservationCurrent(at: now), networkState == "buyer_serving" {
+            if lastBuyerServingAt == nil {
+                lastBuyerServingAt = now
+            }
+            return
+        }
+        if shouldClearBuyerServingHold {
+            lastBuyerServingAt = nil
+        }
+    }
+
+    var shouldClearBuyerServingHold: Bool {
+        if state == .paused || state == .idle || state == .error {
+            return true
+        }
+        switch networkState {
+        case "not_buyer_serving",
+             "catalog_update_required",
+             "compatibility_update_required",
+             "catalog_integrity_failure",
+             "safe_offline_fallback",
+             "local_donor",
+             "network_offline":
+            return true
+        default:
+            break
+        }
+        switch lifecycleReason {
+        case "autotune_evidence_required",
+             "autotune_evidence_invalid",
+             "autotune_evidence_binary_version_mismatch",
+             "autotune_model_cap_exceeded",
+             "autotune_model_uncatalogued":
+            return true
+        default:
+            return lifecycleState == "catalog_incompatible"
+        }
+    }
+
+    func isHoldingBuyerServingReady(at now: Date = Date()) -> Bool {
+        guard lastBuyerServingAt != nil, !shouldClearBuyerServingHold else { return false }
+        guard isLocalStatusObservationCurrent(at: now) else { return false }
+        switch networkState {
+        case "buyer_serving_unknown", "live_verified":
+            return true
+        default:
+            return false
+        }
+    }
+
     func isLocalStatusObservationCurrent(at now: Date = Date()) -> Bool {
         guard localStatusCapabilities.contains("status_observation_v1") else { return true }
         guard statusObservationFresh != false,
@@ -226,6 +281,7 @@ struct AgentSnapshot: Equatable {
     }
 
     mutating func invalidateLocalStatusObservation() {
+        lastBuyerServingAt = nil
         if localStatusCapabilities.contains("status_observation_v1") {
             statusObservationFresh = false
         }
@@ -666,7 +722,10 @@ enum AgentSnapshotPresenter {
 
     static func isNetworkReady(_ s: AgentSnapshot, at now: Date = Date()) -> Bool {
         guard s.state == .serving else { return false }
-        return s.isLocalStatusObservationCurrent(at: now) && s.networkState == "buyer_serving"
+        if s.isLocalStatusObservationCurrent(at: now) && s.networkState == "buyer_serving" {
+            return true
+        }
+        return s.isHoldingBuyerServingReady(at: now)
     }
 
     private static func isLocalOnly(_ s: AgentSnapshot) -> Bool {
@@ -845,6 +904,7 @@ enum AgentSnapshotPresenter {
     }
 
     private static func isWaitingForNetworkApproval(_ s: AgentSnapshot) -> Bool {
+        guard !s.isHoldingBuyerServingReady() else { return false }
         guard s.isLocalStatusObservationCurrent() else { return false }
         guard s.currentModelID != nil || s.state == .serving || s.state == .reconnecting else {
             return false
@@ -860,6 +920,7 @@ enum AgentSnapshotPresenter {
     }
 
     private static func isCheckingCustomerAvailability(_ s: AgentSnapshot) -> Bool {
+        guard !s.isHoldingBuyerServingReady() else { return false }
         guard s.state == .serving || s.state == .reconnecting else { return false }
         if s.networkState == nil { return true }
         return s.networkState == "buyer_serving_unknown"

--- a/phase3-binary/app/Sources/Malibu/Agent/MalibuAgent.swift
+++ b/phase3-binary/app/Sources/Malibu/Agent/MalibuAgent.swift
@@ -848,6 +848,7 @@ final class MalibuAgent: ObservableObject {
             snapshot.state = .paused
             snapshot.pauseAcknowledged = true
             snapshot.lastError = nil
+            snapshot.lastBuyerServingAt = nil
             return
         }
         if snapshot.state == .paused {
@@ -856,9 +857,11 @@ final class MalibuAgent: ObservableObject {
             snapshot.state = localReady ? .reconnecting : .starting
             snapshot.pauseAcknowledged = false
         }
+        snapshot.updateBuyerServingHold()
         let observationCurrent = snapshot.isLocalStatusObservationCurrent()
         let buyerServing = observationCurrent && snapshot.networkState == "buyer_serving"
-        if localReady && buyerServing {
+        let holdReady = snapshot.isHoldingBuyerServingReady()
+        if localReady && (buyerServing || holdReady) {
             snapshot.state = .serving
             snapshot.lastError = nil
             return
@@ -1322,6 +1325,7 @@ final class MalibuAgent: ObservableObject {
             if accepted {
                 snapshot.state = .paused
                 snapshot.pauseAcknowledged = true
+                snapshot.lastBuyerServingAt = nil
             } else {
                 snapshot.lastError = reason ?? "Pause was refused"
             }

--- a/phase3-binary/app/Tests/MalibuTests/AgentSnapshotPresenterTests.swift
+++ b/phase3-binary/app/Tests/MalibuTests/AgentSnapshotPresenterTests.swift
@@ -121,6 +121,92 @@ final class AgentSnapshotPresenterTests: XCTestCase {
         XCTAssertEqual(AgentSnapshotPresenter.publicStatus(ready).title, "Provider is ready")
     }
 
+    func testPublicStatusHoldsReadyAcrossTransientLiveVerifiedBlip() {
+        var snapshot = AgentSnapshot.empty
+        snapshot.state = .serving
+        snapshot.currentModelID = "qwen3-8b"
+        snapshot.networkState = "live_verified"
+        snapshot.coordinatorConnected = false
+        snapshot.lastBuyerServingAt = Date()
+        snapshot.localStatusCapabilities = ["status_observation_v1"]
+        snapshot.statusObservationID = "obs-hold"
+        snapshot.statusObservedAt = Date()
+        snapshot.statusObservationValidForMS = 5_000
+        snapshot.statusObservationFresh = true
+
+        XCTAssertTrue(AgentSnapshotPresenter.isNetworkReady(snapshot))
+        XCTAssertEqual(AgentSnapshotPresenter.publicStatus(snapshot).title, "Provider is ready")
+        XCTAssertEqual(AgentSnapshotPresenter.short(snapshot), "Serving")
+    }
+
+    func testPublicStatusHoldsReadyAcrossBuyerServingUnknown() {
+        var snapshot = AgentSnapshot.empty
+        snapshot.state = .serving
+        snapshot.currentModelID = "qwen3-8b"
+        snapshot.networkState = "buyer_serving_unknown"
+        snapshot.coordinatorConnected = true
+        snapshot.lastBuyerServingAt = Date()
+        snapshot.statusObservationFresh = true
+
+        XCTAssertEqual(AgentSnapshotPresenter.publicStatus(snapshot).title, "Provider is ready")
+    }
+
+    func testPublicStatusStillWaitsForApprovalOnFirstJoin() {
+        var snapshot = AgentSnapshot.empty
+        snapshot.state = .reconnecting
+        snapshot.currentModelID = "qwen3-8b"
+        snapshot.networkState = "live_verified"
+        snapshot.coordinatorConnected = true
+        snapshot.lastBuyerServingAt = nil
+
+        XCTAssertEqual(
+            AgentSnapshotPresenter.publicStatus(snapshot).title,
+            "Waiting for network approval"
+        )
+    }
+
+    func testBuyerServingHoldClearsOnCoordinatorNotServing() {
+        var snapshot = AgentSnapshot.empty
+        snapshot.state = .serving
+        snapshot.currentModelID = "qwen3-8b"
+        snapshot.networkState = "not_buyer_serving"
+        snapshot.lastBuyerServingAt = Date()
+        snapshot.updateBuyerServingHold()
+
+        XCTAssertNil(snapshot.lastBuyerServingAt)
+        XCTAssertEqual(
+            AgentSnapshotPresenter.publicStatus(snapshot).title,
+            "Customer availability is temporarily interrupted"
+        )
+    }
+
+    func testBuyerServingHoldClearsOnStatusInvalidation() {
+        var snapshot = buyerServingObservationSnapshot(observedAt: Date())
+        snapshot.updateBuyerServingHold()
+        XCTAssertNotNil(snapshot.lastBuyerServingAt)
+        XCTAssertTrue(AgentSnapshotPresenter.isNetworkReady(snapshot))
+
+        snapshot.invalidateLocalStatusObservation()
+
+        XCTAssertNil(snapshot.lastBuyerServingAt)
+        XCTAssertFalse(AgentSnapshotPresenter.isNetworkReady(snapshot))
+        XCTAssertNotEqual(AgentSnapshotPresenter.publicStatus(snapshot).title, "Provider is ready")
+    }
+
+    func testBuyerServingHoldRequiresCurrentObservation() {
+        var snapshot = buyerServingObservationSnapshot(
+            observedAt: Date().addingTimeInterval(
+                -(LocalStatusObservationPolicy.displayRetentionSeconds + 1)
+            )
+        )
+        snapshot.lastBuyerServingAt = Date().addingTimeInterval(-30)
+        snapshot.networkState = "live_verified"
+
+        XCTAssertFalse(snapshot.isLocalStatusObservationCurrent())
+        XCTAssertFalse(snapshot.isHoldingBuyerServingReady())
+        XCTAssertFalse(AgentSnapshotPresenter.isNetworkReady(snapshot))
+    }
+
     func testPublicStatusDistinguishesHardwareVerificationFromGenericReconnect() {
         var pending = AgentSnapshot.empty
         pending.state = .reconnecting


### PR DESCRIPTION
## Summary
- Stop mapping a provider WebSocket blip onto catalog `live_verified` as `network_state`. `/v1/pool/check` remains the routing verdict even when the socket is down; unknown stays `buyer_serving_unknown`.
- Malibu keeps **Provider is ready** through `live_verified` / `buyer_serving_unknown` only after a current `buyer_serving` observation in this process. **Waiting for network approval** is first-join only. Failed status refresh, pause, `not_buyer_serving`, and catalog/hardware demotions clear the latch.
- This is the Augustas Air 1.8.102 flap (ready → waiting for approval → ready) while Pearl stayed `routing_eligible` and jobs completed.

## Test plan
- [x] `swift test --filter ProviderStatusTests/testStatusKeepsPoolVerdictWhenCoordinatorSocketDrops`
- [x] `swift test --filter StatusCommandTests/testDefaultStatusUsesPublicLifecycleLanguage`
- [x] `xcodebuild test … -only-testing:MalibuTests/AgentSnapshotPresenterTests` (71 tests)
- [ ] CI green on this PR

SPEC-GOVERNANCE-DECLARATION-BEGIN
{
  "schema_version": "spec-pr-governance-v1",
  "behavior_change": "yes",
  "contract_change": "none",
  "specs": ["SPEC-001", "SPEC-025"],
  "requirements": ["SPEC-001-R001"],
  "authority_domains": ["provider-wire-protocol", "native-app-lifecycle"],
  "arbitration": ["CODE_BUG"],
  "tests": [
    "phase3-binary/Tests/macprovider-cliTests/ProviderStatusTests.swift",
    "phase3-binary/Tests/macprovider-cliTests/StatusCommandTests.swift",
    "phase3-binary/app/Tests/MalibuTests/AgentSnapshotPresenterTests.swift"
  ],
  "journeys": ["not-required"]
}
SPEC-GOVERNANCE-DECLARATION-END

Made with [Cursor](https://cursor.com)