### PR TITLE
Allow Pearl runtime-only healthz ahead of a staged CLI release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1873,6 +1873,8 @@ jobs:
           # source, tag, repository-posture, numeric-ID, and asset assertion
           # directly before changing draft=false. The coordinator may still
           # advertise the previous stable CLI until this release is public.
+          # Pearl /healthz may already be a runtime-only patch ahead of that
+          # advertisement; it must not be older than the advertised CLI.
           GITHUB_SHA="$commit" bash scripts/verify-release-source.sh \
             "$tag" "$commit" origin --require-existing
           GH_TOKEN="$RELEASE_POSTURE_TOKEN" \

--- a/scripts/test-live-coordinator-release-gate.sh
+++ b/scripts/test-live-coordinator-release-gate.sh
@@ -177,6 +177,7 @@ run_guard() {
 run_guard_phase() {
   local directory="$1"
   local phase="$2"
+  local previous="${3:-1.8.67}"
   python3 "$guard" \
     --tag v1.8.68 \
     --pearl-release-json "$directory/pearl-release.json" \
@@ -184,7 +185,7 @@ run_guard_phase() {
     --coordinator-url https://coordinator.fixture.invalid \
     --coordinator-dir "$directory/live" \
     --now 2026-07-30T12:05:00Z \
-    ${phase:+--expected-previous-recommendation 1.8.67} \
+    ${phase:+--expected-previous-recommendation "$previous"} \
     --publication-phase "$phase"
 }
 
@@ -238,9 +239,9 @@ grep -q 'recommended_binary_version is missing or not the expected previous stab
 
 make_fixture "$work/previous-recommended" v1.8.68 v1.8.68 2026-07-30T12:00:00Z 2026-07-30T12:00:00Z streamvc-autotune-static-v4 1.8.67
 if ! run_guard_phase "$work/previous-recommended" pre-publication >"$work/previous-recommended.out" 2>&1; then
-  fail "pre-publication gate rejected the previous stable recommendation"
+  fail "pre-publication gate rejected Pearl already on the candidate while still advertising the previous CLI"
 fi
-grep -q 'recommended_binary_version=1.8.67 publication_phase=pre-publication' \
+grep -q 'healthz_version=v1.8.68 recommended_binary_version=1.8.67 publication_phase=pre-publication' \
   "$work/previous-recommended.out"
 
 make_fixture "$work/previous-healthz-and-recommended" v1.8.68 v1.8.67 2026-07-30T12:00:00Z 2026-07-30T12:00:00Z streamvc-autotune-static-v4 1.8.67
@@ -254,8 +255,23 @@ make_fixture "$work/too-old-prepublication-healthz" v1.8.68 v1.8.66 2026-07-30T1
 if run_guard_phase "$work/too-old-prepublication-healthz" pre-publication >"$work/too-old-prepublication-healthz.out" 2>&1; then
   fail "pre-publication gate accepted a coordinator older than the previous stable version"
 fi
-grep -q "/healthz version 'v1.8.66' is older than release 1.8.68" \
+grep -q "/healthz version 'v1.8.66' is older than previous stable 1.8.67" \
   "$work/too-old-prepublication-healthz.out"
+
+make_fixture "$work/pearl-runtime-ahead" v1.8.68 v1.8.67 2026-07-30T12:00:00Z 2026-07-30T12:00:00Z streamvc-autotune-static-v4 1.8.66
+if ! run_guard_phase "$work/pearl-runtime-ahead" pre-publication 1.8.66 >"$work/pearl-runtime-ahead.out" 2>&1; then
+  fail "pre-publication gate rejected a Pearl runtime-only patch ahead of the advertised CLI"
+fi
+grep -q 'healthz_version=v1.8.67 recommended_binary_version=1.8.66 publication_phase=pre-publication' \
+  "$work/pearl-runtime-ahead.out"
+
+make_fixture "$work/pearl-runtime-ahead-wrong-recommendation" v1.8.68 v1.8.67 2026-07-30T12:00:00Z 2026-07-30T12:00:00Z streamvc-autotune-static-v4 1.8.67
+if run_guard_phase "$work/pearl-runtime-ahead-wrong-recommendation" pre-publication 1.8.66 \
+  >"$work/pearl-runtime-ahead-wrong-recommendation.out" 2>&1; then
+  fail "pre-publication gate accepted a Pearl-ahead healthz that also moved the advertised CLI"
+fi
+grep -q "/healthz recommended_binary_version '1.8.67' does not match expected previous stable 1.8.66" \
+  "$work/pearl-runtime-ahead-wrong-recommendation.out"
 
 make_fixture "$work/malformed-recommended" v1.8.68 v1.8.68 2026-07-30T12:00:00Z 2026-07-30T12:00:00Z streamvc-autotune-static-v4 latest
 if run_guard "$work/malformed-recommended" >"$work/malformed-recommended.out" 2>&1; then

--- a/scripts/verify-live-coordinator-release-gate.py
+++ b/scripts/verify-live-coordinator-release-gate.py
@@ -394,6 +394,9 @@ def main() -> int:
             fail(f"/healthz status is {healthz.get('status')!r}, expected 'ok'")
         live_version = parse_semver(healthz.get("version"), "/healthz version")
         required_version = parse_semver(expected_version, "release version")
+        # Pre-publication /healthz may already be at or above the candidate
+        # (Pearl deployed first). The branch below only constrains the case
+        # where Pearl is still older than the CLI being published.
         if live_version < required_version:
             previous_version = None
             if (
@@ -404,11 +407,19 @@ def main() -> int:
                     args.expected_previous_recommendation,
                     "expected previous recommendation",
                 )
-            if previous_version is None or live_version != previous_version:
+            if previous_version is None:
                 fail(
                     f"/healthz version {healthz.get('version')!r} is older than "
                     f"release {expected_version}"
                 )
+            if live_version < previous_version:
+                fail(
+                    f"/healthz version {healthz.get('version')!r} is older than "
+                    f"previous stable {args.expected_previous_recommendation}"
+                )
+            # previous_version <= live_version < required_version is allowed:
+            # Pearl runtime-only patches may advance /healthz without moving
+            # the advertised CLI recommendation.
         recommended_value = healthz.get("recommended_binary_version")
         if (
             args.publication_phase == "pre-publication"


### PR DESCRIPTION
## Summary

v1.8.104 sign/publish notarized, then failed closed: live Pearl `/healthz` is `v1.8.103` while coordinator still advertises `1.8.102`. The staged pre-publication gate required those two versions to be equal.

That equality conflates Pearl runtime with the advertised CLI. `v1.8.103` is a Pearl-only tag; we are not deploying the 1.8.104 coordinator (poolmanifest/rewards) just to unstick this CLI. Recommendation stays `1.8.102`.

- Allow `previous advertised CLI <= /healthz < candidate` at staged pre-publication.
- Keep `/healthz >= candidate` allowed (Pearl-first deploy, already tested).
- Reject `/healthz` older than the advertised CLI.
- Keep `recommended_binary_version` locked to the previous advertised CLI until post-publication.

The existing unpublished `v1.8.104` draft/tag still points at `a6a999b2` and cannot use this script. After merge: delete the unpublished draft, retag signed `v1.8.104` onto the new main, dispatch `release.yml` again. Do not `PATCH draft=false` on the current draft.

Live proof of the new gate against coordinator.malibu.tech (feeds + healthz `v1.8.103` + recommended `1.8.102`): pass.

Codex lanes: code 0/0/0, architect 0/0/0, security r2 0/0/0 (r1 MEDIUM was the already-allowed Pearl-first path).

SPEC-GOVERNANCE-DECLARATION-BEGIN
{
  "schema_version": "spec-pr-governance-v1",
  "behavior_change": "yes",
  "contract_change": "none",
  "specs": ["SPEC-020"],
  "requirements": ["SPEC-020-R001"],
  "authority_domains": ["provider-autoupdate"],
  "arbitration": ["CODE_BUG"],
  "tests": ["scripts/test-live-coordinator-release-gate.sh"],
  "journeys": ["not-required"],
  "issue": "https://github.com/Augustas11/macprovider/issues/614"
}
SPEC-GOVERNANCE-DECLARATION-END

Made with [Cursor](https://cursor.com)