### PR TITLE
Implement SPEC-045 Phase 1 local consumer endpoint shell

### DIFF
--- a/phase3-binary/Package.swift
+++ b/phase3-binary/Package.swift
@@ -90,6 +90,7 @@ let package = Package(
                 .product(name: "MLXLMCommon", package: "mlx-swift-lm"),
                 .product(name: "MLXHuggingFace", package: "mlx-swift-lm"),
                 .product(name: "Tokenizers", package: "swift-transformers"),
+                .product(name: "NIOEmbedded", package: "swift-nio"),
             ],
             path: "Tests/macprovider-cliTests",
             resources: [

--- a/phase3-binary/Sources/macprovider-cli/ConsumeCommand.swift
+++ b/phase3-binary/Sources/macprovider-cli/ConsumeCommand.swift
@@ -1,0 +1,1305 @@
+import ArgumentParser
+import CryptoKit
+import Darwin
+import Foundation
+import Security
+@preconcurrency import NIO
+@preconcurrency import NIOHTTP1
+
+struct ConsumeCommand: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "consume",
+        abstract: "Start a loopback-only local consumer endpoint.",
+        subcommands: [ConsumeRunCommand.self, ConsumeStatusCommand.self],
+        defaultSubcommand: ConsumeRunCommand.self
+    )
+}
+
+struct ConsumeRunCommand: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "run",
+        abstract: "Start the local consumer endpoint shell."
+    )
+
+    @Option(help: "Loopback address to bind. Default 127.0.0.1.")
+    var bind: String = "127.0.0.1"
+
+    @Option(help: "Local HTTP port to bind. Default 11435; port 0 is rejected.")
+    var port: Int = 11435
+
+    @Option(name: .customLong("credential-file"), help: "User-private buyer API key file.")
+    var credentialFile: String?
+
+    @Option(name: .customLong("upstream-gateway-url"), help: "HTTPS gateway origin. Default https://api.malibu.tech.")
+    var upstreamGatewayURL: String = ConsumeEndpointDefaults.upstreamGatewayOrigin
+
+    @Option(name: .customLong("allow-model"), parsing: .upToNextOption, help: "Allowed model id. Repeat for multiple models.")
+    var allowedModels: [String] = []
+
+    var environmentForTesting: [String: String]?
+    var homeDirectoryForTesting: URL?
+
+    func run() async throws {
+        try await run(stopAfterListeningForTesting: false)
+    }
+
+    func run(stopAfterListeningForTesting: Bool) async throws {
+        do {
+            let normalizedBind = try ConsumeEndpointConfig.normalizeBindAddress(bind)
+            let origin = try ConsumeEndpointConfig.normalizeUpstreamOrigin(upstreamGatewayURL)
+            guard port != 0, (1...65_535).contains(port) else {
+                throw ConsumeStartupError(code: "local_bind_rejected")
+            }
+            let launchID = UUID().uuidString.lowercased()
+            let token = try ConsumeLocalToken.generate()
+            var credential = try ConsumeCredentialLoader.load(
+                explicitCredentialFile: credentialFile,
+                environment: environmentForTesting ?? ProcessInfo.processInfo.environment,
+                homeDirectory: homeDirectoryForTesting ?? FileManager.default.homeDirectoryForCurrentUser
+            )
+            let credentialSourceClass = credential.sourceClass.rawValue
+            let credentialStatus = credential.status
+            credential.zeroize()
+            let descriptorStore = ConsumeActiveEndpointStore(
+                homeDirectory: homeDirectoryForTesting ?? FileManager.default.homeDirectoryForCurrentUser
+            )
+            let descriptorLock = try descriptorStore.acquireLock()
+            let boundURL = ConsumeEndpointConfig.localBaseURL(bindAddress: normalizedBind, port: port)
+            let descriptor = ConsumeEndpointDescriptor(
+                boundURL: boundURL,
+                processID: Int(getpid()),
+                launchID: launchID,
+                startedAt: ConsumeEndpointStatus.iso8601(Date()),
+                ledgerPathClass: nil,
+                localToken: token.value
+            )
+            let runtime = ConsumeEndpointRuntime(
+                launchID: launchID,
+                boundURL: descriptor.boundURL,
+                upstreamOrigin: origin,
+                credentialSourceClass: credentialSourceClass,
+                credentialStatus: credentialStatus,
+                modelAllowlist: allowedModels,
+                tokenVerifier: token.verifier
+            )
+            let server = ConsumeLocalServer(
+                bindAddress: normalizedBind,
+                port: port,
+                runtime: runtime,
+                onListening: {
+                    try descriptorStore.writeDescriptor(descriptor, lock: descriptorLock)
+                    ConsumeEndpointStatus.writeStartup(
+                        boundURL: descriptor.boundURL,
+                        localToken: token.value,
+                        upstreamOrigin: origin,
+                        modelAllowlist: allowedModels,
+                        credentialSourceClass: credentialSourceClass,
+                        credentialState: credentialStatus.state.rawValue
+                    )
+                }
+            )
+            defer {
+                try? descriptorStore.removeDescriptor(lock: descriptorLock)
+            }
+            try server.run(stopAfterListening: stopAfterListeningForTesting)
+        } catch let error as ConsumeStartupError {
+            ConsumeEndpointStatus.writeStderr("\(error.code)\n")
+            throw error.exitCode
+        } catch let error as ConsumeCredentialError {
+            ConsumeEndpointStatus.writeStderr("\(error.redactedCode)\n")
+            throw error.exitCode
+        }
+    }
+}
+
+struct ConsumeStatusCommand: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "status",
+        abstract: "Print redacted local consumer endpoint status."
+    )
+
+    var homeDirectoryForTesting: URL?
+
+    func run() async throws {
+        let store = ConsumeActiveEndpointStore(
+            homeDirectory: homeDirectoryForTesting ?? FileManager.default.homeDirectoryForCurrentUser
+        )
+        guard let descriptor = try store.readLiveDescriptor() else {
+            ConsumeEndpointStatus.writeStderr("local_endpoint_not_running\n")
+            throw ExitCode(4)
+        }
+        do {
+            let status = try await ConsumeStatusClient.fetch(descriptor: descriptor)
+            try StatusCommand.writeJSON(status)
+        } catch {
+            ConsumeEndpointStatus.writeStderr("local_endpoint_not_running\n")
+            throw ExitCode(4)
+        }
+    }
+}
+
+enum ConsumeEndpointDefaults {
+    static let upstreamGatewayOrigin = "https://api.malibu.tech"
+}
+
+struct ConsumeStartupError: Error {
+    let code: String
+    var exitCode: ExitCode { ExitCode(2) }
+}
+
+enum ConsumeACL {
+    static func hasExtendedACLEntry(fd: Int32) throws -> Bool {
+        errno = 0
+        guard let acl = acl_get_fd_np(fd, ACL_TYPE_EXTENDED) else {
+            if errno == 0 || errno == ENOENT { return false }
+            throw POSIXError(.init(rawValue: errno) ?? .EIO)
+        }
+        defer { _ = acl_free(UnsafeMutableRawPointer(acl)) }
+        var entry: acl_entry_t?
+        let result = acl_get_entry(acl, ACL_FIRST_ENTRY.rawValue, &entry)
+        guard result >= 0 else {
+            throw POSIXError(.init(rawValue: errno) ?? .EIO)
+        }
+        return entry != nil
+    }
+
+    static func hasExtendedAllowEntry(fd: Int32) throws -> Bool {
+        errno = 0
+        guard let acl = acl_get_fd_np(fd, ACL_TYPE_EXTENDED) else {
+            if errno == 0 || errno == ENOENT { return false }
+            throw POSIXError(.init(rawValue: errno) ?? .EIO)
+        }
+        defer { _ = acl_free(UnsafeMutableRawPointer(acl)) }
+        var length: ssize_t = 0
+        guard let rawText = acl_to_text(acl, &length) else {
+            throw POSIXError(.init(rawValue: errno) ?? .EIO)
+        }
+        defer { _ = acl_free(UnsafeMutableRawPointer(rawText)) }
+        return String(cString: rawText).lowercased().contains("allow")
+    }
+}
+
+struct ConsumeEndpointConfig {
+    static func normalizeBindAddress(_ raw: String) throws -> String {
+        let value = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        if value == "localhost" { return "127.0.0.1" }
+        if value == "::1" { return "::1" }
+        let parts = value.split(separator: ".", omittingEmptySubsequences: false)
+        guard parts.count == 4,
+              let first = UInt8(parts[0]),
+              first == 127,
+              parts.dropFirst().allSatisfy({ UInt8($0) != nil }) else {
+            throw ConsumeStartupError(code: "local_bind_rejected")
+        }
+        return value
+    }
+
+    static func normalizeUpstreamOrigin(_ raw: String) throws -> String {
+        guard let components = URLComponents(string: raw),
+              components.scheme == "https",
+              let host = components.host,
+              !host.isEmpty,
+              isGlobalUpstreamHost(host),
+              components.user == nil,
+              components.password == nil,
+              components.query == nil,
+              components.fragment == nil,
+              components.path.isEmpty || components.path == "/" else {
+            throw ConsumeStartupError(code: "local_upstream_url_rejected")
+        }
+        var normalized = "https://\(host)"
+        if let port = components.port {
+            normalized += ":\(port)"
+        }
+        return normalized
+    }
+
+    private static func isGlobalUpstreamHost(_ host: String) -> Bool {
+        let normalized = host.trimmingCharacters(in: CharacterSet(charactersIn: "[]")).lowercased()
+        guard !normalized.isEmpty,
+              normalized != "localhost",
+              !normalized.hasSuffix(".localhost"),
+              !normalized.hasSuffix(".local"),
+              normalized != "*" else {
+            return false
+        }
+        if let bytes = ipv4Bytes(normalized) {
+            return isGlobalIPv4(bytes)
+        }
+        if let bytes = ipv6Bytes(normalized) {
+            if bytes[0..<10].allSatisfy({ $0 == 0 }) && bytes[10] == 0xff && bytes[11] == 0xff {
+                return isGlobalIPv4(Array(bytes[12..<16]))
+            }
+            return isGlobalIPv6(bytes)
+        }
+        return true
+    }
+
+    private static func ipv4Bytes(_ host: String) -> [UInt8]? {
+        var address = in_addr()
+        guard inet_pton(AF_INET, host, &address) == 1 else { return nil }
+        return withUnsafeBytes(of: &address.s_addr) { Array($0) }
+    }
+
+    private static func ipv6Bytes(_ host: String) -> [UInt8]? {
+        var address = in6_addr()
+        guard inet_pton(AF_INET6, host, &address) == 1 else { return nil }
+        return withUnsafeBytes(of: &address) { Array($0) }
+    }
+
+    private static func isGlobalIPv4(_ bytes: [UInt8]) -> Bool {
+        guard bytes.count == 4 else { return false }
+        let first = bytes[0]
+        let second = bytes[1]
+        switch first {
+        case 0, 10, 127:
+            return false
+        case 100 where (64...127).contains(second):
+            return false
+        case 169 where second == 254:
+            return false
+        case 172 where (16...31).contains(second):
+            return false
+        case 192 where second == 0 || second == 2 || second == 168:
+            return false
+        case 198 where second == 18 || second == 19 || second == 51:
+            return false
+        case 203 where second == 0 && bytes[2] == 113:
+            return false
+        case 224...255:
+            return false
+        default:
+            return true
+        }
+    }
+
+    private static func isGlobalIPv6(_ bytes: [UInt8]) -> Bool {
+        guard bytes.count == 16 else { return false }
+        if bytes.allSatisfy({ $0 == 0 }) { return false }
+        if bytes[0..<15].allSatisfy({ $0 == 0 }) && bytes[15] == 1 { return false }
+        if bytes[0] == 0xfc || bytes[0] == 0xfd { return false }
+        if bytes[0] == 0xfe && (bytes[1] & 0xc0) == 0x80 { return false }
+        if bytes[0] == 0xff { return false }
+        if bytes[0] == 0x20 && bytes[1] == 0x01 && bytes[2] == 0x0d && bytes[3] == 0xb8 { return false }
+        return true
+    }
+
+    static func localBaseURL(bindAddress: String, port: Int) -> String {
+        if bindAddress.contains(":") {
+            return "http://[\(bindAddress)]:\(port)"
+        }
+        return "http://\(bindAddress):\(port)"
+    }
+}
+
+struct ConsumeLocalToken: Equatable {
+    let value: String
+    let verifier: ConsumeLocalTokenVerifier
+
+    static func generate() throws -> ConsumeLocalToken {
+        let tokenBytes = try randomBytes(count: 32)
+        let verifierKey = try randomBytes(count: 32)
+        let value = base64URL(tokenBytes)
+        return ConsumeLocalToken(
+            value: value,
+            verifier: ConsumeLocalTokenVerifier(expectedToken: value, key: verifierKey)
+        )
+    }
+
+    private static func randomBytes(count: Int) throws -> Data {
+        var bytes = [UInt8](repeating: 0, count: count)
+        guard SecRandomCopyBytes(kSecRandomDefault, bytes.count, &bytes) == errSecSuccess else {
+            throw ConsumeStartupError(code: "local_random_unavailable")
+        }
+        return Data(bytes)
+    }
+
+    private static func base64URL(_ data: Data) -> String {
+        data.base64EncodedString()
+            .replacingOccurrences(of: "+", with: "-")
+            .replacingOccurrences(of: "/", with: "_")
+            .replacingOccurrences(of: "=", with: "")
+    }
+}
+
+struct ConsumeLocalTokenVerifier: Equatable, Sendable {
+    private let expectedDigest: Data
+    private let key: Data
+
+    init(expectedToken: String, key: Data) {
+        self.key = key
+        self.expectedDigest = Self.digest(token: expectedToken, key: key)
+    }
+
+    func verify(headers: HTTPHeaders) -> Bool {
+        let candidates = acceptedTokenCandidates(headers: headers)
+        guard candidates.count == 1 else { return false }
+        let presentedDigest = Self.digest(token: candidates[0], key: key)
+        return Self.constantTimeEqual(expectedDigest, presentedDigest)
+    }
+
+    private func acceptedTokenCandidates(headers: HTTPHeaders) -> [String] {
+        var candidates: [String] = []
+        for value in headers[canonicalForm: "authorization"] {
+            guard value.hasPrefix("Bearer "), value.dropFirst("Bearer ".count).contains(" ") == false else {
+                return ["", ""]
+            }
+            candidates.append(String(value.dropFirst("Bearer ".count)))
+        }
+        candidates.append(contentsOf: headers[canonicalForm: "api-key"].map(String.init))
+        candidates.append(contentsOf: headers[canonicalForm: "x-api-key"].map(String.init))
+        return candidates.filter { !$0.isEmpty }
+    }
+
+    private static func digest(token: String, key: Data) -> Data {
+        let symmetricKey = SymmetricKey(data: key)
+        let mac = HMAC<SHA256>.authenticationCode(for: Data(token.utf8), using: symmetricKey)
+        return Data(mac)
+    }
+
+    private static func constantTimeEqual(_ lhs: Data, _ rhs: Data) -> Bool {
+        let count = max(lhs.count, rhs.count)
+        var difference = UInt8(lhs.count ^ rhs.count)
+        for index in 0..<count {
+            let l = index < lhs.count ? lhs[index] : 0
+            let r = index < rhs.count ? rhs[index] : 0
+            difference |= l ^ r
+        }
+        return difference == 0
+    }
+}
+
+enum ConsumeCredentialSourceClass: String {
+    case explicitFile = "explicit_file"
+    case defaultConfigFile = "default_config_file"
+    case environment
+    case missing
+}
+
+enum ConsumeCredentialState: String {
+    case missing
+    case loaded
+}
+
+struct ConsumeCredential: Equatable {
+    var bytes: Data
+    let sourceClass: ConsumeCredentialSourceClass
+    let status: ConsumeCredentialStatus
+
+    mutating func zeroize() {
+        bytes.resetBytes(in: 0..<bytes.count)
+    }
+}
+
+struct ConsumeCredentialStatus: Equatable, Sendable {
+    let state: ConsumeCredentialState
+    let fileIdentity: ConsumeFileIdentity?
+
+    static let missing = ConsumeCredentialStatus(state: .missing, fileIdentity: nil)
+    static let environmentLoaded = ConsumeCredentialStatus(state: .loaded, fileIdentity: nil)
+
+    func currentState() -> ConsumeCredentialState {
+        guard let fileIdentity else { return state }
+        return fileIdentity.isStillSafe() ? .loaded : .missing
+    }
+}
+
+struct ConsumeFileIdentity: Equatable, Sendable {
+    let path: String
+    let device: UInt64
+    let inode: UInt64
+    let size: Int64
+    let modifiedSeconds: Int64
+    let modifiedNanoseconds: Int64
+    let mode: UInt16
+    let uid: UInt32
+
+    init(path: String, info: stat) {
+        self.path = path
+        self.device = UInt64(info.st_dev)
+        self.inode = UInt64(info.st_ino)
+        self.size = Int64(info.st_size)
+        self.modifiedSeconds = Int64(info.st_mtimespec.tv_sec)
+        self.modifiedNanoseconds = Int64(info.st_mtimespec.tv_nsec)
+        self.mode = UInt16(info.st_mode & UInt16.max)
+        self.uid = UInt32(info.st_uid)
+    }
+
+    func isStillSafe() -> Bool {
+        do {
+            return try ConsumeCredentialLoader.currentFileIdentity(path: path) == self
+        } catch {
+            return false
+        }
+    }
+}
+
+enum ConsumeCredentialError: Error {
+    case unsafeFile(sourceClass: ConsumeCredentialSourceClass, reason: String)
+    case readFailed(sourceClass: ConsumeCredentialSourceClass)
+    case rawFlagRejected
+
+    var redactedCode: String {
+        switch self {
+        case .unsafeFile:
+            return "local_credential_file_rejected"
+        case .readFailed:
+            return "local_credential_missing"
+        case .rawFlagRejected:
+            return "local_credential_flag_rejected"
+        }
+    }
+
+    var exitCode: ExitCode { ExitCode(3) }
+}
+
+struct ConsumeCredentialLoader {
+    static func load(
+        explicitCredentialFile: String?,
+        environment: [String: String],
+        homeDirectory: URL
+    ) throws -> ConsumeCredential {
+        if let explicitCredentialFile {
+            guard !looksLikeRawCredentialFlag(explicitCredentialFile) else {
+                throw ConsumeCredentialError.rawFlagRejected
+            }
+            return try loadFile(path: explicitCredentialFile, sourceClass: .explicitFile)
+        }
+        if let envFile = nonEmpty(environment["MACPROVIDER_HTTP2_API_KEY_FILE"]) {
+            return try loadFile(path: envFile, sourceClass: .explicitFile)
+        }
+        let defaultFile = homeDirectory
+            .appendingPathComponent(".config/macprovider/buyer-api-key")
+        if FileManager.default.fileExists(atPath: defaultFile.path) {
+            return try loadFile(path: defaultFile.path, sourceClass: .defaultConfigFile)
+        }
+        for key in ["MACPROVIDER_HTTP2_API_KEY", "MP_API_KEY", "BUYER_TOKEN"] {
+            if let value = nonEmpty(environment[key]) {
+                return ConsumeCredential(bytes: Data(value.utf8), sourceClass: .environment, status: .environmentLoaded)
+            }
+        }
+        return ConsumeCredential(bytes: Data(), sourceClass: .missing, status: .missing)
+    }
+
+    private static func nonEmpty(_ value: String?) -> String? {
+        guard let trimmed = value?.trimmingCharacters(in: .whitespacesAndNewlines), !trimmed.isEmpty else {
+            return nil
+        }
+        return trimmed
+    }
+
+    private static func looksLikeRawCredentialFlag(_ value: String) -> Bool {
+        let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.contains("/"), !trimmed.contains("\\") else { return false }
+        if trimmed.hasPrefix("sk-") || trimmed.hasPrefix("mp_") || trimmed.hasPrefix("malibu_") {
+            return true
+        }
+        return trimmed.count >= 32 && trimmed.range(of: #"^[A-Za-z0-9_\-=.]+$"#, options: .regularExpression) != nil
+    }
+
+    private static func currentFileIdentity(path: String, sourceClass: ConsumeCredentialSourceClass) throws -> ConsumeFileIdentity {
+        let opened = try openCredentialFile(path: path, sourceClass: sourceClass)
+        close(opened.fd)
+        return opened.identity
+    }
+
+    static func currentFileIdentity(path: String) throws -> ConsumeFileIdentity {
+        try currentFileIdentity(path: path, sourceClass: .explicitFile)
+    }
+
+    private static func openCredentialFile(
+        path: String,
+        sourceClass: ConsumeCredentialSourceClass
+    ) throws -> (fd: Int32, identity: ConsumeFileIdentity) {
+        try validatePathHasNoSymlinkAndSafeParents(URL(fileURLWithPath: path), sourceClass: sourceClass)
+        let fd = open(path, O_RDONLY | O_CLOEXEC | O_NOFOLLOW)
+        guard fd >= 0 else {
+            throw ConsumeCredentialError.readFailed(sourceClass: sourceClass)
+        }
+
+        var opened = stat()
+        guard fstat(fd, &opened) == 0,
+              (opened.st_mode & S_IFMT) == S_IFREG,
+              opened.st_uid == geteuid(),
+              (opened.st_mode & (S_IRWXG | S_IRWXO)) == 0,
+              (opened.st_mode & S_IRUSR) != 0 else {
+            close(fd)
+            throw ConsumeCredentialError.unsafeFile(sourceClass: sourceClass, reason: "permission_class")
+        }
+        do {
+            try rejectExtendedACL(fd: fd, sourceClass: sourceClass, reason: "file_acl")
+        } catch {
+            close(fd)
+            throw error
+        }
+        var named = stat()
+        guard lstat(path, &named) == 0,
+              named.st_dev == opened.st_dev,
+              named.st_ino == opened.st_ino else {
+            close(fd)
+            throw ConsumeCredentialError.unsafeFile(sourceClass: sourceClass, reason: "file_identity_changed")
+        }
+        return (fd, ConsumeFileIdentity(path: path, info: opened))
+    }
+
+    private static func loadFile(path: String, sourceClass: ConsumeCredentialSourceClass) throws -> ConsumeCredential {
+        let opened = try openCredentialFile(path: path, sourceClass: sourceClass)
+        let fd = opened.fd
+        defer { close(fd) }
+
+        var data = Data()
+        defer { data.resetBytes(in: 0..<data.count) }
+        var buffer = [UInt8](repeating: 0, count: 4096)
+        defer {
+            for index in buffer.indices {
+                buffer[index] = 0
+            }
+        }
+        while true {
+            let count = read(fd, &buffer, buffer.count)
+            if count < 0, errno == EINTR { continue }
+            guard count >= 0 else {
+                throw ConsumeCredentialError.readFailed(sourceClass: sourceClass)
+            }
+            if count == 0 { break }
+            data.append(buffer, count: count)
+            guard data.count <= 16 * 1024 else {
+                throw ConsumeCredentialError.unsafeFile(sourceClass: sourceClass, reason: "too_large")
+            }
+        }
+        trimASCIIWhitespace(&data)
+        guard !data.isEmpty else {
+            throw ConsumeCredentialError.readFailed(sourceClass: sourceClass)
+        }
+        var credentialBytes = Data()
+        credentialBytes.append(data)
+        return ConsumeCredential(
+            bytes: credentialBytes,
+            sourceClass: sourceClass,
+            status: ConsumeCredentialStatus(state: .loaded, fileIdentity: opened.identity)
+        )
+    }
+
+    private static func trimASCIIWhitespace(_ data: inout Data) {
+        while let first = data.first, first == 0x20 || first == 0x09 || first == 0x0a || first == 0x0d {
+            data.removeFirst()
+        }
+        while let last = data.last, last == 0x20 || last == 0x09 || last == 0x0a || last == 0x0d {
+            data.removeLast()
+        }
+    }
+
+    private static func validatePathHasNoSymlinkAndSafeParents(_ url: URL, sourceClass: ConsumeCredentialSourceClass) throws {
+        let standardized = url.standardizedFileURL
+        let components = standardized.pathComponents
+        var current = components.first == "/" ? URL(fileURLWithPath: "/") : URL(fileURLWithPath: ".")
+        for component in components.dropFirst() {
+            current.appendPathComponent(component)
+            var info = stat()
+            if lstat(current.path, &info) != 0 {
+                if current.path == standardized.path { return }
+                throw ConsumeCredentialError.unsafeFile(sourceClass: sourceClass, reason: "parent_missing")
+            }
+            guard (info.st_mode & S_IFMT) != S_IFLNK else {
+                throw ConsumeCredentialError.unsafeFile(sourceClass: sourceClass, reason: "symlink_ambiguous")
+            }
+	            if current.path != standardized.path {
+	                guard (info.st_mode & S_IFMT) == S_IFDIR,
+	                      (info.st_uid == geteuid() || info.st_uid == 0),
+	                      (info.st_mode & (S_IWGRP | S_IWOTH)) == 0 else {
+	                    throw ConsumeCredentialError.unsafeFile(sourceClass: sourceClass, reason: "unsafe_parent")
+	                }
+                let fd = open(current.path, O_RDONLY | O_CLOEXEC | O_NOFOLLOW)
+                guard fd >= 0 else {
+                    throw ConsumeCredentialError.unsafeFile(sourceClass: sourceClass, reason: "unsafe_parent")
+                }
+                defer { close(fd) }
+                var opened = stat()
+                guard fstat(fd, &opened) == 0,
+                      opened.st_dev == info.st_dev,
+                      opened.st_ino == info.st_ino,
+                      (opened.st_mode & S_IFMT) == S_IFDIR,
+                      (opened.st_uid == geteuid() || opened.st_uid == 0),
+                      (opened.st_mode & (S_IWGRP | S_IWOTH)) == 0,
+                      (try? !ConsumeACL.hasExtendedAllowEntry(fd: fd)) == true else {
+                    throw ConsumeCredentialError.unsafeFile(sourceClass: sourceClass, reason: "unsafe_parent")
+                }
+	            }
+	        }
+	    }
+
+	    private static func rejectExtendedACL(fd: Int32, sourceClass: ConsumeCredentialSourceClass, reason: String) throws {
+	        guard (try? !ConsumeACL.hasExtendedACLEntry(fd: fd)) == true else {
+	            throw ConsumeCredentialError.unsafeFile(sourceClass: sourceClass, reason: reason)
+	        }
+	    }
+}
+
+struct ConsumeEndpointDescriptor: Codable, Equatable {
+    static let schemaVersion = "local_consumer_endpoint.descriptor.v1"
+
+    let schemaVersion: String
+    let boundURL: String
+    let processID: Int
+    let launchID: String
+    let startedAt: String
+    let ledgerPathClass: String?
+    let localToken: String
+
+    init(
+        boundURL: String,
+        processID: Int,
+        launchID: String,
+        startedAt: String,
+        ledgerPathClass: String?,
+        localToken: String
+    ) {
+        self.schemaVersion = Self.schemaVersion
+        self.boundURL = boundURL
+        self.processID = processID
+        self.launchID = launchID
+        self.startedAt = startedAt
+        self.ledgerPathClass = ledgerPathClass
+        self.localToken = localToken
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case schemaVersion = "schema_version"
+        case boundURL = "bound_url"
+        case processID = "process_id"
+        case launchID = "process_launch_id"
+        case startedAt = "started_at"
+        case ledgerPathClass = "ledger_path_class"
+        case localToken = "local_token"
+    }
+}
+
+final class ConsumeActiveEndpointLock: @unchecked Sendable {
+    let fd: Int32
+    let rootFD: Int32
+    let url: URL
+
+    init(fd: Int32, rootFD: Int32, url: URL) {
+        self.fd = fd
+        self.rootFD = rootFD
+        self.url = url
+    }
+
+    deinit {
+        _ = flock(fd, LOCK_UN)
+        close(fd)
+        close(rootFD)
+    }
+}
+
+struct ConsumeActiveEndpointStore {
+    let root: URL
+
+    init(homeDirectory: URL = FileManager.default.homeDirectoryForCurrentUser) {
+        self.root = homeDirectory
+            .appendingPathComponent("Library/Application Support/macprovider/consume", isDirectory: true)
+    }
+
+    var descriptorURL: URL { root.appendingPathComponent("active-endpoint.json") }
+    var lockURL: URL { root.appendingPathComponent("active-endpoint.lock") }
+
+    func acquireLock() throws -> ConsumeActiveEndpointLock {
+        try ensurePrivateRoot()
+        let rootFD = try openValidatedRootFD()
+        let fd = openat(rootFD, "active-endpoint.lock", O_CREAT | O_RDWR | O_CLOEXEC | O_NOFOLLOW, S_IRUSR | S_IWUSR)
+        guard fd >= 0 else {
+            close(rootFD)
+            throw ConsumeStartupError(code: "local_active_endpoint_exists")
+        }
+        var result: Int32
+        repeat {
+            result = flock(fd, LOCK_EX | LOCK_NB)
+        } while result != 0 && errno == EINTR
+        guard result == 0 else {
+            close(fd)
+            close(rootFD)
+            throw ConsumeStartupError(code: "local_active_endpoint_exists")
+        }
+        guard fchmod(fd, S_IRUSR | S_IWUSR) == 0,
+              activeEndpointFileIsPrivate(fd: fd),
+              rejectExtendedACL(fd: fd) else {
+            close(fd)
+            close(rootFD)
+            throw ConsumeStartupError(code: "local_active_endpoint_exists")
+        }
+        return ConsumeActiveEndpointLock(fd: fd, rootFD: rootFD, url: lockURL)
+    }
+
+    func writeDescriptor(_ descriptor: ConsumeEndpointDescriptor, lock: ConsumeActiveEndpointLock) throws {
+        guard lock.url == lockURL else {
+            throw ConsumeStartupError(code: "local_active_endpoint_exists")
+        }
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys]
+        var data = try encoder.encode(descriptor)
+        data.append(0x0a)
+        let temporaryName = ".active-endpoint.json.tmp-\(UUID().uuidString.lowercased())"
+        let fd = openat(lock.rootFD, temporaryName, O_CREAT | O_EXCL | O_WRONLY | O_CLOEXEC | O_NOFOLLOW, S_IRUSR | S_IWUSR)
+        guard fd >= 0 else {
+            throw ConsumeStartupError(code: "local_active_endpoint_exists")
+        }
+        var shouldRemove = true
+        defer {
+            close(fd)
+            if shouldRemove { unlinkat(lock.rootFD, temporaryName, 0) }
+        }
+        try data.withUnsafeBytes { raw in
+            var offset = 0
+            while offset < raw.count {
+                let written = write(fd, raw.baseAddress!.advanced(by: offset), raw.count - offset)
+                if written < 0, errno == EINTR { continue }
+                guard written > 0 else { throw ConsumeStartupError(code: "local_active_endpoint_exists") }
+                offset += written
+            }
+        }
+        guard fchmod(fd, S_IRUSR | S_IWUSR) == 0,
+              activeEndpointFileIsPrivate(fd: fd),
+              rejectExtendedACL(fd: fd),
+              fsync(fd) == 0 else {
+            throw ConsumeStartupError(code: "local_active_endpoint_exists")
+        }
+        guard renameat(lock.rootFD, temporaryName, lock.rootFD, "active-endpoint.json") == 0 else {
+            throw ConsumeStartupError(code: "local_active_endpoint_exists")
+        }
+        shouldRemove = false
+        try fsyncRoot(fd: lock.rootFD)
+    }
+
+    func removeDescriptor(lock: ConsumeActiveEndpointLock) throws {
+        guard lock.url == lockURL else { return }
+        _ = unlinkat(lock.rootFD, "active-endpoint.json", 0)
+    }
+
+    func readLiveDescriptor() throws -> ConsumeEndpointDescriptor? {
+        guard let descriptor = try readDescriptor() else { return nil }
+        guard activeEndpointLockIsHeld() else {
+            return nil
+        }
+        guard processAppearsLive(pid: descriptor.processID) else {
+            return nil
+        }
+        return descriptor
+    }
+
+    private func readDescriptor() throws -> ConsumeEndpointDescriptor? {
+        try ensurePrivateRoot()
+        let rootFD = try openValidatedRootFD()
+        defer { close(rootFD) }
+        let fd = openat(rootFD, "active-endpoint.json", O_RDONLY | O_CLOEXEC | O_NOFOLLOW)
+        guard fd >= 0 else {
+            if errno == ENOENT { return nil }
+            throw ConsumeStartupError(code: "local_endpoint_not_running")
+        }
+        defer { close(fd) }
+        var info = stat()
+        guard fstat(fd, &info) == 0,
+              (info.st_mode & S_IFMT) == S_IFREG,
+              activeEndpointFileIsPrivate(fd: fd),
+              rejectExtendedACL(fd: fd) else {
+            throw ConsumeStartupError(code: "local_endpoint_not_running")
+        }
+        var data = Data()
+        var buffer = [UInt8](repeating: 0, count: 4096)
+        while true {
+            let count = read(fd, &buffer, buffer.count)
+            if count < 0, errno == EINTR { continue }
+            guard count >= 0 else { throw ConsumeStartupError(code: "local_endpoint_not_running") }
+            if count == 0 { break }
+            data.append(buffer, count: count)
+            guard data.count <= 16 * 1024 else { throw ConsumeStartupError(code: "local_endpoint_not_running") }
+        }
+        return try JSONDecoder().decode(ConsumeEndpointDescriptor.self, from: data)
+    }
+
+    private func ensurePrivateRoot() throws {
+        if !FileManager.default.fileExists(atPath: root.path) {
+            try FileManager.default.createDirectory(
+                at: root,
+                withIntermediateDirectories: true,
+                attributes: [.posixPermissions: 0o700]
+            )
+        }
+        try validatePrivateRootAncestry()
+        let fd = try openValidatedRootFD()
+        close(fd)
+    }
+
+    private func validatePrivateRootAncestry() throws {
+        let standardized = root.standardizedFileURL
+        let components = standardized.pathComponents
+        var current = components.first == "/" ? URL(fileURLWithPath: "/") : URL(fileURLWithPath: ".")
+        for component in components.dropFirst() {
+            current.appendPathComponent(component)
+            var info = stat()
+            guard lstat(current.path, &info) == 0,
+                  (info.st_mode & S_IFMT) != S_IFLNK,
+                  (info.st_mode & S_IFMT) == S_IFDIR,
+                  (info.st_uid == geteuid() || info.st_uid == 0),
+                  (info.st_mode & (S_IWGRP | S_IWOTH)) == 0 else {
+                throw ConsumeStartupError(code: "local_active_endpoint_exists")
+            }
+            let fd = open(current.path, O_RDONLY | O_CLOEXEC | O_NOFOLLOW)
+            guard fd >= 0 else {
+                throw ConsumeStartupError(code: "local_active_endpoint_exists")
+            }
+            defer { close(fd) }
+            var opened = stat()
+            guard fstat(fd, &opened) == 0,
+                  opened.st_dev == info.st_dev,
+                  opened.st_ino == info.st_ino,
+                  (opened.st_mode & S_IFMT) == S_IFDIR,
+                  (opened.st_uid == geteuid() || opened.st_uid == 0),
+                  (opened.st_mode & (S_IWGRP | S_IWOTH)) == 0,
+                  (try? !ConsumeACL.hasExtendedAllowEntry(fd: fd)) == true else {
+                throw ConsumeStartupError(code: "local_active_endpoint_exists")
+            }
+        }
+    }
+
+    private func fsyncRoot(fd: Int32) throws {
+        guard fsync(fd) == 0 else { throw ConsumeStartupError(code: "local_active_endpoint_exists") }
+    }
+
+    private func activeEndpointLockIsHeld() -> Bool {
+        guard let rootFD = try? openValidatedRootFD() else { return false }
+        defer { close(rootFD) }
+        let fd = openat(rootFD, "active-endpoint.lock", O_RDONLY | O_CLOEXEC | O_NOFOLLOW)
+        guard fd >= 0 else { return false }
+        defer { close(fd) }
+        guard activeEndpointFileIsPrivate(fd: fd),
+              rejectExtendedACL(fd: fd) else {
+            return false
+        }
+        var result: Int32
+        repeat {
+            result = flock(fd, LOCK_SH | LOCK_NB)
+        } while result != 0 && errno == EINTR
+        if result == 0 {
+            _ = flock(fd, LOCK_UN)
+            return false
+        }
+        return errno == EWOULDBLOCK || errno == EAGAIN
+    }
+
+    private func openValidatedRootFD() throws -> Int32 {
+        var named = stat()
+        guard lstat(root.path, &named) == 0,
+              (named.st_mode & S_IFMT) == S_IFDIR,
+              named.st_uid == geteuid(),
+              (named.st_mode & 0o777) == S_IRWXU else {
+            throw ConsumeStartupError(code: "local_active_endpoint_exists")
+        }
+        let fd = open(root.path, O_RDONLY | O_CLOEXEC | O_NOFOLLOW)
+        guard fd >= 0 else { throw ConsumeStartupError(code: "local_active_endpoint_exists") }
+        var opened = stat()
+        guard fstat(fd, &opened) == 0,
+              opened.st_dev == named.st_dev,
+              opened.st_ino == named.st_ino,
+              (opened.st_mode & S_IFMT) == S_IFDIR,
+              opened.st_uid == geteuid(),
+              (opened.st_mode & 0o777) == S_IRWXU,
+              rejectExtendedACL(fd: fd) else {
+            close(fd)
+            throw ConsumeStartupError(code: "local_active_endpoint_exists")
+        }
+        return fd
+    }
+
+    private func activeEndpointFileIsPrivate(fd: Int32) -> Bool {
+        var info = stat()
+        return fstat(fd, &info) == 0 &&
+            (info.st_mode & S_IFMT) == S_IFREG &&
+            info.st_uid == geteuid() &&
+            (info.st_mode & (S_IRWXG | S_IRWXO)) == 0 &&
+            info.st_nlink == 1
+    }
+
+    private func rejectExtendedACL(fd: Int32) -> Bool {
+        (try? !ConsumeACL.hasExtendedACLEntry(fd: fd)) == true
+    }
+
+    private func processAppearsLive(pid: Int) -> Bool {
+        guard pid > 0 else { return false }
+        if kill(pid_t(pid), 0) == 0 { return true }
+        return errno == EPERM
+    }
+}
+
+struct ConsumeEndpointRuntime: Sendable {
+    let launchID: String
+    let boundURL: String
+    let upstreamOrigin: String
+    let credentialSourceClass: String
+    let credentialStatus: ConsumeCredentialStatus
+    let modelAllowlist: [String]
+    let tokenVerifier: ConsumeLocalTokenVerifier
+    let requestCounter: ConsumeEndpointRequestCounter
+
+    init(
+        launchID: String,
+        boundURL: String,
+        upstreamOrigin: String,
+        credentialSourceClass: String,
+        credentialStatus: ConsumeCredentialStatus,
+        modelAllowlist: [String],
+        tokenVerifier: ConsumeLocalTokenVerifier,
+        requestCounter: ConsumeEndpointRequestCounter = ConsumeEndpointRequestCounter()
+    ) {
+        self.launchID = launchID
+        self.boundURL = boundURL
+        self.upstreamOrigin = upstreamOrigin
+        self.credentialSourceClass = credentialSourceClass
+        self.credentialStatus = credentialStatus
+        self.modelAllowlist = modelAllowlist
+        self.tokenVerifier = tokenVerifier
+        self.requestCounter = requestCounter
+    }
+
+    func beginRequest() {
+        requestCounter.begin()
+    }
+
+    func endRequest() {
+        requestCounter.end()
+    }
+
+    func statusPayload() -> [String: Any] {
+        [
+            "schema_version": "local_consumer_endpoint.status.v1",
+            "process_launch_id": launchID,
+            "bound_url": boundURL,
+            "upstream_gateway_origin": upstreamOrigin,
+            "credential_source_class": credentialSourceClass,
+            "credential_state": credentialStatus.currentState().rawValue,
+            "model_allowlist": modelAllowlist,
+            "local_auth_state": "required",
+            "pricing_trust_state": "unavailable",
+            "pricing_warning_codes": [],
+            "unpriced_override": false,
+            "no_budget": false,
+            "budget_configured_micro_usd": NSNull(),
+            "budget_used_micro_usd": NSNull(),
+            "budget_held_micro_usd": NSNull(),
+            "budget_remaining_micro_usd": NSNull(),
+            "ledger_path_class": NSNull(),
+            "active_request_count": requestCounter.current(),
+            "last_successful_upstream_contact_at": NSNull(),
+            "error_ring": [],
+        ]
+    }
+}
+
+final class ConsumeEndpointRequestCounter: @unchecked Sendable {
+    private let lock = NSLock()
+    private var value = 0
+
+    func begin() {
+        lock.lock()
+        value += 1
+        lock.unlock()
+    }
+
+    func end() {
+        lock.lock()
+        value = max(0, value - 1)
+        lock.unlock()
+    }
+
+    func current() -> Int {
+        lock.lock()
+        defer { lock.unlock() }
+        return value
+    }
+}
+
+struct ConsumeEndpointStatus {
+    private static let testStderrSink = ConsumeEndpointStatusSink()
+
+    static func writeStartup(
+        boundURL: String,
+        localToken: String,
+        upstreamOrigin: String,
+        modelAllowlist: [String],
+        credentialSourceClass: String,
+        credentialState: String
+    ) {
+        let sample = modelAllowlist.prefix(5).joined(separator: ",")
+        let allowlistSummary = modelAllowlist.isEmpty
+            ? "count=0 warning=empty_model_allowlist"
+            : "count=\(modelAllowlist.count) sample=\(sample)"
+        writeStderr(
+            [
+                "local_consumer_endpoint=started",
+                "base_url=\(boundURL)",
+                "local_token=\(localToken)",
+                "upstream_gateway_origin=\(upstreamOrigin)",
+                "model_allowlist=\(allowlistSummary)",
+                "budget_mode=unconfigured",
+                "unpriced_override=false",
+                "credential_source_class=\(credentialSourceClass)",
+                "credential_state=\(credentialState)",
+            ].joined(separator: " ") + "\n"
+        )
+    }
+
+    static func writeStderr(_ text: String) {
+        if testStderrSink.write(text) {
+            return
+        }
+        FileHandle.standardError.write(Data(text.utf8))
+    }
+
+    static func replaceStderrSinkForTesting(_ sink: ((String) -> Void)?) -> (() -> Void) {
+        let previous = testStderrSink.replace(sink)
+        return {
+            _ = testStderrSink.replace(previous)
+        }
+    }
+
+    static func iso8601(_ date: Date) -> String {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        return formatter.string(from: date)
+    }
+}
+
+final class ConsumeEndpointStatusSink: @unchecked Sendable {
+    private let lock = NSLock()
+    private var sink: ((String) -> Void)?
+
+    func replace(_ next: ((String) -> Void)?) -> ((String) -> Void)? {
+        lock.lock()
+        defer { lock.unlock() }
+        let previous = sink
+        sink = next
+        return previous
+    }
+
+    func write(_ text: String) -> Bool {
+        lock.lock()
+        let current = sink
+        lock.unlock()
+        guard let current else { return false }
+        current(text)
+        return true
+    }
+}
+
+struct ConsumeLocalServer {
+    let bindAddress: String
+    let port: Int
+    let runtime: ConsumeEndpointRuntime
+    let onListening: @Sendable () throws -> Void
+
+    func run(stopAfterListening: Bool = false) throws {
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+        defer { try? group.syncShutdownGracefully() }
+        let bootstrap = ServerBootstrap(group: group)
+            .serverChannelOption(ChannelOptions.backlog, value: 16)
+            .serverChannelOption(ChannelOptions.socketOption(.so_reuseaddr), value: 0)
+            .childChannelInitializer { channel in
+                channel.pipeline.configureHTTPServerPipeline().flatMap {
+                    channel.pipeline.addHandler(ConsumeLocalHandler(runtime: runtime))
+                }
+            }
+        let channel: Channel
+        do {
+            channel = try bootstrap.bind(host: bindAddress, port: port).wait()
+        } catch {
+            throw ConsumeStartupError(code: "local_bind_rejected")
+        }
+        do {
+            try onListening()
+        } catch {
+            try? channel.close().wait()
+            throw error
+        }
+        if stopAfterListening {
+            try channel.close().wait()
+            return
+        }
+        try channel.closeFuture.wait()
+    }
+}
+
+final class ConsumeLocalHandler: ChannelInboundHandler, @unchecked Sendable {
+    typealias InboundIn = HTTPServerRequestPart
+    typealias OutboundOut = HTTPServerResponsePart
+
+    private let runtime: ConsumeEndpointRuntime
+    private var requestHead: HTTPRequestHead?
+    private var requestIsActive = false
+
+    init(runtime: ConsumeEndpointRuntime) {
+        self.runtime = runtime
+    }
+
+    func channelRead(context: ChannelHandlerContext, data: NIOAny) {
+        switch unwrapInboundIn(data) {
+        case .head(let head):
+            requestHead = head
+            runtime.beginRequest()
+            requestIsActive = true
+        case .body:
+            break
+        case .end:
+            guard let head = requestHead else {
+                context.close(promise: nil)
+                return
+            }
+            handle(head: head, context: context)
+            endRequestIfNeeded()
+        }
+    }
+
+    func channelInactive(context: ChannelHandlerContext) {
+        endRequestIfNeeded()
+    }
+
+    private func handle(head: HTTPRequestHead, context: ChannelHandlerContext) {
+        if head.method == .HEAD {
+            writeJSON(context: context, status: .methodNotAllowed, body: NSNull())
+            return
+        }
+        let statusNoStore = head.method == .GET && head.uri == "/v1/status"
+        guard runtime.tokenVerifier.verify(headers: head.headers) else {
+            writeJSON(
+                context: context,
+                status: .unauthorized,
+                body: errorEnvelope(code: "local_auth_required"),
+                extraHeaders: statusNoStore ? [("cache-control", "no-store")] : []
+            )
+            return
+        }
+        guard head.uri == "/v1/status" else {
+            writeJSON(context: context, status: .notFound, body: errorEnvelope(code: "local_endpoint_unsupported"))
+            return
+        }
+        guard head.method == .GET else {
+            writeJSON(context: context, status: .methodNotAllowed, body: errorEnvelope(code: "local_endpoint_unsupported"))
+            return
+        }
+        writeJSON(
+            context: context,
+            status: .ok,
+            body: runtime.statusPayload(),
+            extraHeaders: [("cache-control", "no-store")]
+        )
+    }
+
+    private func endRequestIfNeeded() {
+        guard requestIsActive else { return }
+        requestIsActive = false
+        runtime.endRequest()
+    }
+
+    private func writeJSON(
+        context: ChannelHandlerContext,
+        status: HTTPResponseStatus,
+        body: Any,
+        extraHeaders: [(String, String)] = []
+    ) {
+        do {
+            let data = try body is NSNull
+                ? Data()
+                : JSONSerialization.data(withJSONObject: body, options: [.withoutEscapingSlashes])
+            var headers = HTTPHeaders()
+            headers.add(name: "content-type", value: "application/json")
+            headers.add(name: "content-length", value: "\(data.count)")
+            headers.add(name: "connection", value: "close")
+            for (name, value) in extraHeaders {
+                headers.add(name: name, value: value)
+            }
+            let head = HTTPResponseHead(version: .http1_1, status: status, headers: headers)
+            context.write(wrapOutboundOut(.head(head)), promise: nil)
+            if !data.isEmpty {
+                var buffer = context.channel.allocator.buffer(capacity: data.count)
+                buffer.writeBytes(data)
+                context.write(wrapOutboundOut(.body(.byteBuffer(buffer))), promise: nil)
+            }
+            context.writeAndFlush(wrapOutboundOut(.end(nil)), promise: nil)
+            context.close(promise: nil)
+        } catch {
+            context.close(promise: nil)
+        }
+    }
+
+    private func errorEnvelope(code: String) -> [String: Any] {
+        [
+            "error": [
+                "message": code,
+                "type": "macprovider_local_error",
+                "param": NSNull(),
+                "code": code,
+                "macprovider": ["forwarded_upstream": false],
+            ],
+        ]
+    }
+}
+
+struct ConsumeStatusClient {
+    static func fetch(descriptor: ConsumeEndpointDescriptor) async throws -> [String: Any] {
+        guard let url = statusURL(from: descriptor.boundURL) else {
+            throw ConsumeStartupError(code: "local_endpoint_not_running")
+        }
+        var request = URLRequest(url: url)
+        request.httpMethod = "GET"
+        request.setValue("Bearer \(descriptor.localToken)", forHTTPHeaderField: "Authorization")
+        request.cachePolicy = .reloadIgnoringLocalAndRemoteCacheData
+        let session = directLoopbackSession()
+        defer { session.invalidateAndCancel() }
+        let (data, response) = try await session.data(for: request)
+        guard let http = response as? HTTPURLResponse,
+              http.statusCode == 200,
+              let object = try JSONSerialization.jsonObject(with: data) as? [String: Any],
+              object["process_launch_id"] as? String == descriptor.launchID else {
+            throw ConsumeStartupError(code: "local_endpoint_not_running")
+        }
+        return object
+    }
+
+    private static func statusURL(from boundURL: String) -> URL? {
+        guard var components = URLComponents(string: boundURL),
+              components.scheme == "http",
+              components.user == nil,
+              components.password == nil,
+              components.query == nil,
+              components.fragment == nil,
+              components.path.isEmpty || components.path == "/",
+              let host = components.host,
+              isLoopbackLiteral(host),
+              components.port.map({ (1...65535).contains($0) }) ?? false else {
+            return nil
+        }
+        components.path = "/v1/status"
+        return components.url
+    }
+
+    private static func isLoopbackLiteral(_ host: String) -> Bool {
+        let normalized = host.trimmingCharacters(in: CharacterSet(charactersIn: "[]")).lowercased()
+        if normalized == "::1" { return true }
+        let parts = normalized.split(separator: ".", omittingEmptySubsequences: false)
+        return parts.count == 4 &&
+            UInt8(parts[0]) == 127 &&
+            parts.dropFirst().allSatisfy { UInt8($0) != nil }
+    }
+
+    private static func directLoopbackSession() -> URLSession {
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.timeoutIntervalForRequest = 3
+        configuration.timeoutIntervalForResource = 5
+        configuration.requestCachePolicy = .reloadIgnoringLocalAndRemoteCacheData
+        configuration.urlCache = nil
+        configuration.httpCookieStorage = nil
+        configuration.httpCookieAcceptPolicy = .never
+        configuration.httpAdditionalHeaders = nil
+        configuration.connectionProxyDictionary = [:]
+        configuration.waitsForConnectivity = false
+        return URLSession(configuration: configuration, delegate: NoRedirectURLSessionDelegate(), delegateQueue: nil)
+    }
+}

--- a/phase3-binary/Sources/macprovider-cli/MacProviderCLI.swift
+++ b/phase3-binary/Sources/macprovider-cli/MacProviderCLI.swift
@@ -40,7 +40,7 @@ struct MacProviderCLI: AsyncParsableCommand {
         commandName: "macprovider-cli",
         abstract: "OpenAI-compatible Mac Provider inference CLI.",
         version: CoordinatorClient.binaryVersion,
-        subcommands: [ServeCommand.self, SelfTestCommand.self, StatusCommand.self, ClaimCommand.self, UpdateCommand.self, UninstallCommand.self, ModelsCommand.self, AutotuneCommand.self, BootstrapAuthCommand.self, RotateKeyCommand.self, CredentialsCommand.self, LifecycleStateCommand.self, LifecycleLeaseCommand.self, Spec028CanaryCommand.self, Spec028BenchmarkCommand.self, LegacySpec028CanaryCommand.self, LegacySpec028BenchmarkCommand.self, DecodeBenchCommand.self, EnrollCommand.self, ReleasePayloadPreflightCommand.self, KVCacheCommand.self, DoctorCommand.self, PayoutAddressCommand.self],
+        subcommands: [ServeCommand.self, SelfTestCommand.self, StatusCommand.self, ClaimCommand.self, UpdateCommand.self, UninstallCommand.self, ModelsCommand.self, AutotuneCommand.self, BootstrapAuthCommand.self, RotateKeyCommand.self, CredentialsCommand.self, LifecycleStateCommand.self, LifecycleLeaseCommand.self, Spec028CanaryCommand.self, Spec028BenchmarkCommand.self, LegacySpec028CanaryCommand.self, LegacySpec028BenchmarkCommand.self, DecodeBenchCommand.self, EnrollCommand.self, ReleasePayloadPreflightCommand.self, KVCacheCommand.self, DoctorCommand.self, PayoutAddressCommand.self, ConsumeCommand.self],
         defaultSubcommand: ServeCommand.self
     )
 }

--- a/phase3-binary/Tests/macprovider-cliTests/ConsumeCommandTests.swift
+++ b/phase3-binary/Tests/macprovider-cliTests/ConsumeCommandTests.swift
@@ -1,0 +1,530 @@
+import ArgumentParser
+import Darwin
+import Foundation
+import NIOEmbedded
+import NIOHTTP1
+import XCTest
+@testable import macprovider_cli
+
+final class ConsumeCommandTests: XCTestCase {
+    func testBindValidationAcceptsLoopbackAndRejectsPublicInputs() throws {
+        XCTAssertEqual(try ConsumeEndpointConfig.normalizeBindAddress("127.0.0.1"), "127.0.0.1")
+        XCTAssertEqual(try ConsumeEndpointConfig.normalizeBindAddress("127.0.0.2"), "127.0.0.2")
+        XCTAssertEqual(try ConsumeEndpointConfig.normalizeBindAddress("localhost"), "127.0.0.1")
+        XCTAssertEqual(try ConsumeEndpointConfig.normalizeBindAddress("::1"), "::1")
+        XCTAssertEqual(ConsumeEndpointConfig.localBaseURL(bindAddress: "::1", port: 11435), "http://[::1]:11435")
+        XCTAssertEqual(ConsumeEndpointConfig.localBaseURL(bindAddress: "127.0.0.1", port: 11435), "http://127.0.0.1:11435")
+        XCTAssertThrowsError(try ConsumeEndpointConfig.normalizeBindAddress("0.0.0.0"))
+        XCTAssertThrowsError(try ConsumeEndpointConfig.normalizeBindAddress("192.168.1.10"))
+        XCTAssertThrowsError(try ConsumeEndpointConfig.normalizeBindAddress("example.com"))
+    }
+
+    func testUpstreamOriginValidationRejectsNonOrigins() throws {
+        XCTAssertEqual(
+            try ConsumeEndpointConfig.normalizeUpstreamOrigin("https://api.malibu.tech/"),
+            "https://api.malibu.tech"
+        )
+        XCTAssertThrowsError(try ConsumeEndpointConfig.normalizeUpstreamOrigin("http://api.malibu.tech"))
+        XCTAssertThrowsError(try ConsumeEndpointConfig.normalizeUpstreamOrigin("https://user:pass@api.malibu.tech"))
+        XCTAssertThrowsError(try ConsumeEndpointConfig.normalizeUpstreamOrigin("https://api.malibu.tech/v1"))
+        XCTAssertThrowsError(try ConsumeEndpointConfig.normalizeUpstreamOrigin("https://api.malibu.tech?x=1"))
+        XCTAssertThrowsError(try ConsumeEndpointConfig.normalizeUpstreamOrigin("https://localhost"))
+        XCTAssertThrowsError(try ConsumeEndpointConfig.normalizeUpstreamOrigin("https://127.0.0.1"))
+        XCTAssertThrowsError(try ConsumeEndpointConfig.normalizeUpstreamOrigin("https://10.1.2.3"))
+        XCTAssertThrowsError(try ConsumeEndpointConfig.normalizeUpstreamOrigin("https://172.16.0.1"))
+        XCTAssertThrowsError(try ConsumeEndpointConfig.normalizeUpstreamOrigin("https://192.168.1.10"))
+        XCTAssertThrowsError(try ConsumeEndpointConfig.normalizeUpstreamOrigin("https://169.254.1.1"))
+        XCTAssertThrowsError(try ConsumeEndpointConfig.normalizeUpstreamOrigin("https://100.64.0.1"))
+        XCTAssertThrowsError(try ConsumeEndpointConfig.normalizeUpstreamOrigin("https://192.0.2.1"))
+        XCTAssertThrowsError(try ConsumeEndpointConfig.normalizeUpstreamOrigin("https://224.0.0.1"))
+        XCTAssertThrowsError(try ConsumeEndpointConfig.normalizeUpstreamOrigin("https://[::1]"))
+        XCTAssertThrowsError(try ConsumeEndpointConfig.normalizeUpstreamOrigin("https://[fc00::1]"))
+        XCTAssertThrowsError(try ConsumeEndpointConfig.normalizeUpstreamOrigin("https://[fe80::1]"))
+        XCTAssertThrowsError(try ConsumeEndpointConfig.normalizeUpstreamOrigin("https://[2001:db8::1]"))
+        XCTAssertThrowsError(try ConsumeEndpointConfig.normalizeUpstreamOrigin("https://[::ffff:192.168.1.10]"))
+    }
+
+    func testLocalTokenVerifierAcceptsOnlyOneAcceptedHeader() throws {
+        let token = try ConsumeLocalToken.generate()
+        var headers = HTTPHeaders()
+        headers.add(name: "Authorization", value: "Bearer \(token.value)")
+        XCTAssertTrue(token.verifier.verify(headers: headers))
+
+        headers.add(name: "api-key", value: token.value)
+        XCTAssertFalse(token.verifier.verify(headers: headers))
+
+        var apiKey = HTTPHeaders()
+        apiKey.add(name: "api-key", value: token.value)
+        XCTAssertTrue(token.verifier.verify(headers: apiKey))
+
+        var malformed = HTTPHeaders()
+        malformed.add(name: "Authorization", value: "Bearer \(token.value) trailing")
+        XCTAssertFalse(token.verifier.verify(headers: malformed))
+    }
+
+    func testCredentialSourceOrderPrefersExplicitThenEnvFileThenDefaultThenEnvironment() throws {
+        let home = try makeTemporaryDirectory()
+        let explicit = try writeCredential("explicit", under: home, name: "explicit.key")
+        let envFile = try writeCredential("env-file", under: home, name: "env.key")
+        let defaultDir = home.appendingPathComponent(".config/macprovider", isDirectory: true)
+        try FileManager.default.createDirectory(at: defaultDir, withIntermediateDirectories: true, attributes: [.posixPermissions: 0o700])
+        let defaultFile = defaultDir.appendingPathComponent("buyer-api-key")
+        try Data("default\n".utf8).write(to: defaultFile)
+        chmod(defaultFile.path, 0o600)
+
+        let env = [
+            "MACPROVIDER_HTTP2_API_KEY_FILE": envFile.path,
+            "MACPROVIDER_HTTP2_API_KEY": "raw-env",
+            "MP_API_KEY": "mp-env",
+            "BUYER_TOKEN": "buyer-env",
+        ]
+
+        XCTAssertEqual(
+            try ConsumeCredentialLoader.load(explicitCredentialFile: explicit.path, environment: env, homeDirectory: home).sourceClass,
+            .explicitFile
+        )
+        let envLoaded = try ConsumeCredentialLoader.load(explicitCredentialFile: nil, environment: env, homeDirectory: home)
+        XCTAssertEqual(envLoaded.sourceClass, .explicitFile)
+        XCTAssertEqual(String(decoding: envLoaded.bytes, as: UTF8.self), "env-file")
+
+        let defaultLoaded = try ConsumeCredentialLoader.load(
+            explicitCredentialFile: nil,
+            environment: ["MACPROVIDER_HTTP2_API_KEY": "raw-env"],
+            homeDirectory: home
+        )
+        XCTAssertEqual(defaultLoaded.sourceClass, .defaultConfigFile)
+        XCTAssertEqual(String(decoding: defaultLoaded.bytes, as: UTF8.self), "default")
+
+        try FileManager.default.removeItem(at: defaultFile)
+        let rawLoaded = try ConsumeCredentialLoader.load(
+            explicitCredentialFile: nil,
+            environment: ["MP_API_KEY": "mp-env", "BUYER_TOKEN": "buyer-env"],
+            homeDirectory: home
+        )
+        XCTAssertEqual(rawLoaded.sourceClass, .environment)
+        XCTAssertEqual(String(decoding: rawLoaded.bytes, as: UTF8.self), "mp-env")
+    }
+
+    func testCredentialFileRejectsRawCredentialFlagValues() throws {
+        XCTAssertThrowsError(
+            try ConsumeCredentialLoader.load(
+                explicitCredentialFile: "sk-abcdefghijklmnopqrstuvwxyz123456",
+                environment: [:],
+                homeDirectory: try makeTemporaryDirectory()
+            )
+        ) { error in
+            XCTAssertEqual((error as? ConsumeCredentialError)?.redactedCode, "local_credential_flag_rejected")
+        }
+    }
+
+    func testCredentialFileRejectsGroupReadableFileAndSymlink() throws {
+        let home = try makeTemporaryDirectory()
+        let unsafe = home.appendingPathComponent("unsafe.key")
+        try Data("secret".utf8).write(to: unsafe)
+        chmod(unsafe.path, 0o640)
+        XCTAssertThrowsError(try ConsumeCredentialLoader.load(explicitCredentialFile: unsafe.path, environment: [:], homeDirectory: home))
+
+        let safe = try writeCredential("secret", under: home, name: "safe.key")
+        let link = home.appendingPathComponent("link.key")
+        symlink(safe.path, link.path)
+        XCTAssertThrowsError(try ConsumeCredentialLoader.load(explicitCredentialFile: link.path, environment: [:], homeDirectory: home))
+
+        let groupWritableParent = home.appendingPathComponent("group-writable", isDirectory: true)
+        try FileManager.default.createDirectory(at: groupWritableParent, withIntermediateDirectories: false, attributes: [.posixPermissions: 0o770])
+        let grouped = try writeCredential("secret", under: groupWritableParent, name: "grouped.key")
+        XCTAssertThrowsError(try ConsumeCredentialLoader.load(explicitCredentialFile: grouped.path, environment: [:], homeDirectory: home))
+        chmod(groupWritableParent.path, 0o700)
+
+        let aclParent = home.appendingPathComponent("acl-parent", isDirectory: true)
+        try FileManager.default.createDirectory(at: aclParent, withIntermediateDirectories: false, attributes: [.posixPermissions: 0o700])
+        try addReadACLEntry(to: aclParent)
+        let aclParentCredential = try writeCredential("secret", under: aclParent, name: "credential.key")
+        XCTAssertThrowsError(try ConsumeCredentialLoader.load(explicitCredentialFile: aclParentCredential.path, environment: [:], homeDirectory: home))
+    }
+
+    func testCredentialFileRejectsExtendedACLAndRevalidatesDeletion() throws {
+        let home = try makeTemporaryDirectory()
+        let credential = try writeCredential("secret", under: home, name: "credential.key")
+        let loaded = try ConsumeCredentialLoader.load(explicitCredentialFile: credential.path, environment: [:], homeDirectory: home)
+        XCTAssertEqual(loaded.status.currentState(), .loaded)
+        try FileManager.default.removeItem(at: credential)
+        XCTAssertEqual(loaded.status.currentState(), .missing)
+
+        let aclCredential = try writeCredential("secret", under: home, name: "acl.key")
+        try addReadACLEntry(to: aclCredential)
+        XCTAssertThrowsError(try ConsumeCredentialLoader.load(explicitCredentialFile: aclCredential.path, environment: [:], homeDirectory: home))
+    }
+
+    func testDescriptorWriteIsUserPrivateAndStatusPayloadIsRedacted() throws {
+        let home = try makeTemporaryDirectory()
+        let store = ConsumeActiveEndpointStore(homeDirectory: home)
+        let lock = try store.acquireLock()
+        let token = "local-token-secret"
+        let descriptor = ConsumeEndpointDescriptor(
+            boundURL: "http://127.0.0.1:11435",
+            processID: Int(getpid()),
+            launchID: UUID().uuidString.lowercased(),
+            startedAt: ConsumeEndpointStatus.iso8601(Date()),
+            ledgerPathClass: nil,
+            localToken: token
+        )
+
+        try store.writeDescriptor(descriptor, lock: lock)
+        XCTAssertEqual(octalMode(store.root), 0o700)
+        XCTAssertEqual(octalMode(store.descriptorURL), 0o600)
+        XCTAssertEqual(try store.readLiveDescriptor(), descriptor)
+
+        let runtime = ConsumeEndpointRuntime(
+            launchID: descriptor.launchID,
+            boundURL: descriptor.boundURL,
+            upstreamOrigin: "https://api.malibu.tech",
+            credentialSourceClass: "missing",
+            credentialStatus: .missing,
+            modelAllowlist: [],
+            tokenVerifier: ConsumeLocalTokenVerifier(expectedToken: token, key: Data("key".utf8))
+        )
+        let status = runtime.statusPayload()
+        let data = try JSONSerialization.data(withJSONObject: status, options: [.sortedKeys])
+        let json = String(decoding: data, as: UTF8.self)
+        XCTAssertFalse(json.contains(token))
+        XCTAssertTrue(json.contains("local_consumer_endpoint.status.v1"))
+    }
+
+    func testReadLiveDescriptorReturnsNilWhenDescriptorIsMissing() throws {
+        let store = ConsumeActiveEndpointStore(homeDirectory: try makeTemporaryDirectory())
+        XCTAssertNil(try store.readLiveDescriptor())
+    }
+
+    func testRunCommandStartsThenStopsWithRedactedSetupOutput() async throws {
+        let home = try makeTemporaryDirectory()
+        let port = try nextLoopbackPort()
+        var command = try ConsumeRunCommand.parse(["--port", "\(port)", "--allow-model", "llama-test"])
+        command.environmentForTesting = [:]
+        command.homeDirectoryForTesting = home
+
+        let capture = await captureStatusOutput {
+            try await command.run(stopAfterListeningForTesting: true)
+        }
+
+        XCTAssertNil(capture.error)
+        XCTAssertTrue(capture.stderr.contains("local_consumer_endpoint=started"), capture.stderr)
+        XCTAssertTrue(capture.stderr.contains("base_url=http://127.0.0.1:\(port)"), capture.stderr)
+        XCTAssertTrue(capture.stderr.contains("local_token="), capture.stderr)
+        XCTAssertTrue(capture.stderr.contains("upstream_gateway_origin=https://api.malibu.tech"), capture.stderr)
+        XCTAssertTrue(capture.stderr.contains("model_allowlist=count=1 sample=llama-test"), capture.stderr)
+        XCTAssertTrue(capture.stderr.contains("credential_source_class=missing"), capture.stderr)
+        XCTAssertFalse(capture.stderr.contains(home.path), capture.stderr)
+
+        let store = ConsumeActiveEndpointStore(homeDirectory: home)
+        XCTAssertNil(try store.readLiveDescriptor())
+    }
+
+    func testRunCommandPortCollisionUsesRedactedBindError() async throws {
+        let reserved = try reserveLoopbackPort()
+        defer { close(reserved.fd) }
+        var command = try ConsumeRunCommand.parse(["--port", "\(reserved.port)"])
+        command.environmentForTesting = [:]
+        command.homeDirectoryForTesting = try makeTemporaryDirectory()
+
+        let capture = await captureStatusOutput {
+            try await command.run(stopAfterListeningForTesting: true)
+        }
+
+        XCTAssertEqual(capture.error as? ExitCode, ExitCode(2))
+        XCTAssertEqual(capture.stderr, "local_bind_rejected\n")
+    }
+
+    func testStatusCommandNoEndpointUsesRedactedError() async throws {
+        var command = ConsumeStatusCommand()
+        command.homeDirectoryForTesting = try makeTemporaryDirectory()
+
+        let capture = await captureStatusOutput {
+            try await command.run()
+        }
+
+        XCTAssertEqual(capture.error as? ExitCode, ExitCode(4))
+        XCTAssertEqual(capture.stderr, "local_endpoint_not_running\n")
+    }
+
+    func testActiveDescriptorLockSerializesInstances() throws {
+        let store = ConsumeActiveEndpointStore(homeDirectory: try makeTemporaryDirectory())
+        let lock = try store.acquireLock()
+        XCTAssertThrowsError(try store.acquireLock())
+        _ = lock
+    }
+
+    func testActiveDescriptorRejectsGroupWritableParent() throws {
+        let home = try makeTemporaryDirectory()
+        chmod(home.path, 0o770)
+        defer { chmod(home.path, 0o700) }
+        let store = ConsumeActiveEndpointStore(homeDirectory: home)
+        XCTAssertThrowsError(try store.acquireLock())
+    }
+
+    func testActiveDescriptorRejectsExtendedACLOnPrivateRoot() throws {
+        let home = try makeTemporaryDirectory()
+        let store = ConsumeActiveEndpointStore(homeDirectory: home)
+        var lock: ConsumeActiveEndpointLock? = try store.acquireLock()
+        XCTAssertNotNil(lock)
+        lock = nil
+        try addReadACLEntry(to: store.root)
+        XCTAssertThrowsError(try store.acquireLock())
+    }
+
+    func testActiveDescriptorRejectsExtendedACLOnParentDirectory() throws {
+        let home = try makeTemporaryDirectory()
+        try addReadACLEntry(to: home)
+        let store = ConsumeActiveEndpointStore(homeDirectory: home)
+        XCTAssertThrowsError(try store.acquireLock())
+    }
+
+    func testStaleDescriptorWithDeadProcessIsIgnored() throws {
+        let store = ConsumeActiveEndpointStore(homeDirectory: try makeTemporaryDirectory())
+        let lock = try store.acquireLock()
+        let descriptor = ConsumeEndpointDescriptor(
+            boundURL: "http://127.0.0.1:11435",
+            processID: Int(Int32.max),
+            launchID: UUID().uuidString.lowercased(),
+            startedAt: ConsumeEndpointStatus.iso8601(Date()),
+            ledgerPathClass: nil,
+            localToken: "local-token"
+        )
+        try store.writeDescriptor(descriptor, lock: lock)
+        XCTAssertNil(try store.readLiveDescriptor())
+    }
+
+    func testDescriptorWithLivePIDButReleasedLockIsIgnored() throws {
+        let store = ConsumeActiveEndpointStore(homeDirectory: try makeTemporaryDirectory())
+        var lock: ConsumeActiveEndpointLock? = try store.acquireLock()
+        let descriptor = ConsumeEndpointDescriptor(
+            boundURL: "http://127.0.0.1:11435",
+            processID: Int(getpid()),
+            launchID: UUID().uuidString.lowercased(),
+            startedAt: ConsumeEndpointStatus.iso8601(Date()),
+            ledgerPathClass: nil,
+            localToken: "local-token"
+        )
+        try store.writeDescriptor(descriptor, lock: lock!)
+        lock = nil
+        XCTAssertNil(try store.readLiveDescriptor())
+    }
+
+    func testStatusHandlerRequiresAuthSetsNoStoreAndRedacts() throws {
+        let token = try ConsumeLocalToken.generate()
+        let runtime = ConsumeEndpointRuntime(
+            launchID: "launch-status-test",
+            boundURL: "http://127.0.0.1:11435",
+            upstreamOrigin: "https://api.malibu.tech",
+            credentialSourceClass: "environment",
+            credentialStatus: .environmentLoaded,
+            modelAllowlist: ["llama-test"],
+            tokenVerifier: token.verifier
+        )
+        runtime.beginRequest()
+        defer { runtime.endRequest() }
+
+        let missingAuthHeaders = HTTPHeaders()
+        let unauthorized = try response(
+            from: runtime,
+            head: HTTPRequestHead(version: .http1_1, method: .GET, uri: "/v1/status", headers: missingAuthHeaders)
+        )
+        XCTAssertEqual(unauthorized.status, HTTPResponseStatus.unauthorized)
+        XCTAssertEqual(unauthorized.headers.first(name: "cache-control"), "no-store")
+        XCTAssertFalse(unauthorized.body.contains(token.value))
+        XCTAssertFalse(unauthorized.body.contains("llama-test"))
+        let unauthorizedError = try localError(from: unauthorized.body)
+        XCTAssertEqual(unauthorizedError["code"] as? String, "local_auth_required")
+        XCTAssertTrue(unauthorizedError["param"] is NSNull)
+
+        let unauthorizedHead = try response(
+            from: runtime,
+            head: HTTPRequestHead(version: .http1_1, method: .HEAD, uri: "/v1/status", headers: HTTPHeaders())
+        )
+        XCTAssertEqual(unauthorizedHead.status, HTTPResponseStatus.methodNotAllowed)
+        XCTAssertEqual(unauthorizedHead.headers.first(name: "content-length"), "0")
+        XCTAssertEqual(unauthorizedHead.body, "")
+
+        var authorizedHeaders = HTTPHeaders()
+        authorizedHeaders.add(name: "Authorization", value: "Bearer \(token.value)")
+        let authorized = try response(
+            from: runtime,
+            head: HTTPRequestHead(version: .http1_1, method: .GET, uri: "/v1/status", headers: authorizedHeaders)
+        )
+        XCTAssertEqual(authorized.status, HTTPResponseStatus.ok)
+        XCTAssertEqual(authorized.headers.first(name: "cache-control"), "no-store")
+        XCTAssertTrue(authorized.body.contains("\"process_launch_id\":\"launch-status-test\""), authorized.body)
+        XCTAssertTrue(authorized.body.contains("\"model_allowlist\":[\"llama-test\"]"), authorized.body)
+        XCTAssertTrue(authorized.body.contains("\"active_request_count\":2"), authorized.body)
+        XCTAssertFalse(authorized.body.contains(token.value))
+        let object = try XCTUnwrap(JSONSerialization.jsonObject(with: Data(authorized.body.utf8)) as? [String: Any])
+        XCTAssertNotNil(object["error_ring"] as? [Any])
+
+        let wrongPath = try response(
+            from: runtime,
+            head: HTTPRequestHead(version: .http1_1, method: .GET, uri: "/v1/chat/completions", headers: authorizedHeaders)
+        )
+        XCTAssertEqual(wrongPath.status, HTTPResponseStatus.notFound)
+        let wrongPathError = try localError(from: wrongPath.body)
+        XCTAssertEqual(wrongPathError["code"] as? String, "local_endpoint_unsupported")
+        XCTAssertTrue(wrongPathError["param"] is NSNull)
+
+        let wrongPathHead = try response(
+            from: runtime,
+            head: HTTPRequestHead(version: .http1_1, method: .HEAD, uri: "/v1/chat/completions", headers: authorizedHeaders)
+        )
+        XCTAssertEqual(wrongPathHead.status, HTTPResponseStatus.methodNotAllowed)
+        XCTAssertEqual(wrongPathHead.headers.first(name: "content-length"), "0")
+        XCTAssertEqual(wrongPathHead.body, "")
+
+        let wrongMethod = try response(
+            from: runtime,
+            head: HTTPRequestHead(version: .http1_1, method: .POST, uri: "/v1/status", headers: authorizedHeaders)
+        )
+        XCTAssertEqual(wrongMethod.status, HTTPResponseStatus.methodNotAllowed)
+
+        let head = try response(
+            from: runtime,
+            head: HTTPRequestHead(version: .http1_1, method: .HEAD, uri: "/v1/status", headers: authorizedHeaders)
+        )
+        XCTAssertEqual(head.status, HTTPResponseStatus.methodNotAllowed)
+        XCTAssertEqual(head.headers.first(name: "content-length"), "0")
+        XCTAssertEqual(head.body, "")
+    }
+
+    private func localError(from body: String) throws -> [String: Any] {
+        let object = try XCTUnwrap(JSONSerialization.jsonObject(with: Data(body.utf8)) as? [String: Any])
+        return try XCTUnwrap(object["error"] as? [String: Any])
+    }
+
+    private func writeCredential(_ value: String, under directory: URL, name: String) throws -> URL {
+        let url = directory.appendingPathComponent(name)
+        try Data((value + "\n").utf8).write(to: url)
+        chmod(url.path, 0o600)
+        return url
+    }
+
+    private func makeTemporaryDirectory() throws -> URL {
+        let base = URL(fileURLWithPath: FileManager.default.currentDirectoryPath, isDirectory: true)
+            .appendingPathComponent(".build/mp-consume-tests", isDirectory: true)
+        try FileManager.default.createDirectory(at: base, withIntermediateDirectories: true, attributes: [.posixPermissions: 0o700])
+        chmod(base.path, 0o700)
+        let dir = base
+            .appendingPathComponent("mp-consume-\(getpid())-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: false, attributes: [.posixPermissions: 0o700])
+        return dir
+    }
+
+    private func octalMode(_ url: URL) -> Int {
+        var info = stat()
+        guard lstat(url.path, &info) == 0 else { return -1 }
+        return Int(info.st_mode & 0o777)
+    }
+
+    private struct CapturedStatusOutput {
+        let stderr: String
+        let error: Error?
+    }
+
+    private func captureStatusOutput(_ body: () async throws -> Void) async -> CapturedStatusOutput {
+        var stderr = ""
+        let restore = ConsumeEndpointStatus.replaceStderrSinkForTesting { stderr += $0 }
+        defer { restore() }
+        let error: Error?
+        do {
+            try await body()
+            error = nil
+        } catch let caught {
+            error = caught
+        }
+        return CapturedStatusOutput(stderr: stderr, error: error)
+    }
+
+    private func nextLoopbackPort() throws -> Int {
+        let reserved = try reserveLoopbackPort()
+        close(reserved.fd)
+        return reserved.port
+    }
+
+    private func reserveLoopbackPort() throws -> (fd: Int32, port: Int) {
+        let fd = socket(AF_INET, SOCK_STREAM, IPPROTO_TCP)
+        guard fd >= 0 else { throw POSIXError(.init(rawValue: errno) ?? .EIO) }
+        var address = sockaddr_in()
+        address.sin_len = UInt8(MemoryLayout<sockaddr_in>.size)
+        address.sin_family = sa_family_t(AF_INET)
+        address.sin_port = 0
+        guard inet_pton(AF_INET, "127.0.0.1", &address.sin_addr) == 1 else {
+            close(fd)
+            throw POSIXError(.EIO)
+        }
+        let bindResult = withUnsafePointer(to: &address) { pointer in
+            pointer.withMemoryRebound(to: sockaddr.self, capacity: 1) {
+                Darwin.bind(fd, $0, socklen_t(MemoryLayout<sockaddr_in>.size))
+            }
+        }
+        guard bindResult == 0, Darwin.listen(fd, 1) == 0 else {
+            let code = errno
+            close(fd)
+            throw POSIXError(.init(rawValue: code) ?? .EIO)
+        }
+        var length = socklen_t(MemoryLayout<sockaddr_in>.size)
+        let nameResult = withUnsafeMutablePointer(to: &address) { pointer in
+            pointer.withMemoryRebound(to: sockaddr.self, capacity: 1) {
+                getsockname(fd, $0, &length)
+            }
+        }
+        guard nameResult == 0 else {
+            let code = errno
+            close(fd)
+            throw POSIXError(.init(rawValue: code) ?? .EIO)
+        }
+        return (fd, Int(UInt16(bigEndian: address.sin_port)))
+    }
+
+    private func addReadACLEntry(to url: URL) throws {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/bin/chmod")
+        process.arguments = ["+a", "everyone allow read", url.path]
+        process.standardOutput = Pipe()
+        process.standardError = Pipe()
+        try process.run()
+        process.waitUntilExit()
+        guard process.terminationStatus == 0 else {
+            throw POSIXError(.EIO)
+        }
+    }
+
+    private func response(
+        from runtime: ConsumeEndpointRuntime,
+        head: HTTPRequestHead
+    ) throws -> (status: HTTPResponseStatus, headers: HTTPHeaders, body: String) {
+        let channel = EmbeddedChannel()
+        try channel.pipeline.addHandler(ConsumeLocalHandler(runtime: runtime)).wait()
+        var responseHead: HTTPResponseHead?
+        var body = Data()
+
+        try channel.writeInbound(HTTPServerRequestPart.head(head))
+        try channel.writeInbound(HTTPServerRequestPart.end(nil))
+
+        while let part = try channel.readOutbound(as: HTTPServerResponsePart.self) {
+            switch part {
+            case .head(let head):
+                responseHead = head
+            case .body(.byteBuffer(var buffer)):
+                if let bytes = buffer.readBytes(length: buffer.readableBytes) {
+                    body.append(contentsOf: bytes)
+                }
+            case .end:
+                guard let responseHead else {
+                    XCTFail("response head was not emitted")
+                    return (.internalServerError, HTTPHeaders(), "")
+                }
+                return (responseHead.status, responseHead.headers, String(decoding: body, as: UTF8.self))
+            default:
+                break
+            }
+        }
+
+        XCTFail("response end was not emitted")
+        return (.internalServerError, HTTPHeaders(), String(decoding: body, as: UTF8.self))
+    }
+}


### PR DESCRIPTION
## Summary

Implements SPEC-045 Phase 1 local consumer endpoint shell:
- adds `macprovider-cli consume run` and `macprovider-cli consume status`
- starts a loopback-only HTTP/1.1 status shell with per-run local token auth
- loads buyer credentials through the SPEC-045 source order without exposing credential material
- writes a user-private active endpoint descriptor and redacted status payload
- rejects non-global upstream origins, unsafe credential/state paths, unsupported paths/methods, and shared ambient status-client transport

This slice intentionally does not proxy chat completions, models, budget, or ledger behavior. Those remain later BUILD SPEC phases.

## Validation

- `swift test --filter ConsumeCommandTests` (19 passed)
- `swift build --target macprovider-cli`
- `git diff --check origin/main...HEAD`
- 3-lane Codex audits on full Phase 1 diff:
  - CODE AUDIT CLEAR: 0 CRITICAL / 0 HIGH / 0 MEDIUM
  - SECURITY AUDIT CLEAR: 0 CRITICAL / 0 HIGH / 0 MEDIUM
  - ARCHITECTURE AUDIT CLEAR: 0 CRITICAL / 0 HIGH / 0 MEDIUM

Not tested: full `phase3-binary` `swift test`; it reaches an unrelated MLX default metallib loading failure later in the existing suite.

SPEC-GOVERNANCE-DECLARATION-BEGIN
{
  "schema_version": "spec-pr-governance-v1",
  "behavior_change": "yes",
  "contract_change": "none",
  "specs": ["SPEC-045"],
  "requirements": [
    "SPEC-045-R001",
    "SPEC-045-R002",
    "SPEC-045-R003",
    "SPEC-045-R006",
    "SPEC-045-R007"
  ],
  "authority_domains": ["local-consumer-endpoint"],
  "arbitration": ["CODE_BUG"],
  "tests": [
    "swift test --filter ConsumeCommandTests",
    "swift build --target macprovider-cli",
    "git diff --check origin/main...HEAD",
    "3-lane Codex audit gate: code/security/architecture 0 C/H/M"
  ],
  "journeys": ["not-required"],
  "issue": "https://github.com/Augustas11/macprovider/issues/927"
}
SPEC-GOVERNANCE-DECLARATION-END
