### PR TITLE
SPEC-045 Phase 2 local endpoint subset

### DIFF
--- a/phase3-binary/Sources/macprovider-cli/ConsumeCommand.swift
+++ b/phase3-binary/Sources/macprovider-cli/ConsumeCommand.swift
@@ -2,6 +2,7 @@ import ArgumentParser
 import CryptoKit
 import Darwin
 import Foundation
+import MacProviderCore
 import Security
 @preconcurrency import NIO
 @preconcurrency import NIOHTTP1
@@ -59,6 +60,7 @@ struct ConsumeRunCommand: AsyncParsableCommand {
             )
             let credentialSourceClass = credential.sourceClass.rawValue
             let credentialStatus = credential.status
+            let credentialCustody = ConsumeCredentialCustody(credential: credential)
             credential.zeroize()
             let descriptorStore = ConsumeActiveEndpointStore(
                 homeDirectory: homeDirectoryForTesting ?? FileManager.default.homeDirectoryForCurrentUser
@@ -80,7 +82,8 @@ struct ConsumeRunCommand: AsyncParsableCommand {
                 credentialSourceClass: credentialSourceClass,
                 credentialStatus: credentialStatus,
                 modelAllowlist: allowedModels,
-                tokenVerifier: token.verifier
+                tokenVerifier: token.verifier,
+                credentialCustody: credentialCustody
             )
             let server = ConsumeLocalServer(
                 bindAddress: normalizedBind,
@@ -935,9 +938,9 @@ struct ConsumeEndpointRuntime: Sendable {
     let boundURL: String
     let upstreamOrigin: String
     let credentialSourceClass: String
-    let credentialStatus: ConsumeCredentialStatus
     let modelAllowlist: [String]
     let tokenVerifier: ConsumeLocalTokenVerifier
+    let credentialCustody: ConsumeCredentialCustody
     let requestCounter: ConsumeEndpointRequestCounter
 
     init(
@@ -948,24 +951,45 @@ struct ConsumeEndpointRuntime: Sendable {
         credentialStatus: ConsumeCredentialStatus,
         modelAllowlist: [String],
         tokenVerifier: ConsumeLocalTokenVerifier,
+        credentialCustody: ConsumeCredentialCustody? = nil,
         requestCounter: ConsumeEndpointRequestCounter = ConsumeEndpointRequestCounter()
     ) {
         self.launchID = launchID
         self.boundURL = boundURL
         self.upstreamOrigin = upstreamOrigin
         self.credentialSourceClass = credentialSourceClass
-        self.credentialStatus = credentialStatus
         self.modelAllowlist = modelAllowlist
         self.tokenVerifier = tokenVerifier
+        self.credentialCustody = credentialCustody ?? ConsumeCredentialCustody(status: credentialStatus)
         self.requestCounter = requestCounter
     }
 
-    func beginRequest() {
+    func beginIncompleteConnection() -> Bool {
+        requestCounter.beginIncompleteConnection()
+    }
+
+    func completePreAuthConnection() {
+        requestCounter.completePreAuthConnection()
+    }
+
+    func endIncompleteConnection() {
+        requestCounter.endIncompleteConnection()
+    }
+
+    func beginRequest() -> Bool {
         requestCounter.begin()
     }
 
     func endRequest() {
         requestCounter.end()
+    }
+
+    func reserveBodyBytes(_ count: Int) -> Bool {
+        requestCounter.reserveBodyBytes(count)
+    }
+
+    func releaseBodyBytes(_ count: Int) {
+        requestCounter.releaseBodyBytes(count)
     }
 
     func statusPayload() -> [String: Any] {
@@ -975,7 +999,7 @@ struct ConsumeEndpointRuntime: Sendable {
             "bound_url": boundURL,
             "upstream_gateway_origin": upstreamOrigin,
             "credential_source_class": credentialSourceClass,
-            "credential_state": credentialStatus.currentState().rawValue,
+            "credential_state": credentialCustody.currentState().rawValue,
             "model_allowlist": modelAllowlist,
             "local_auth_state": "required",
             "pricing_trust_state": "unavailable",
@@ -994,19 +1018,121 @@ struct ConsumeEndpointRuntime: Sendable {
     }
 }
 
+final class ConsumeCredentialCustody: @unchecked Sendable {
+    private let lock = NSLock()
+    private let status: ConsumeCredentialStatus
+
+    init(credential: ConsumeCredential) {
+        self.status = credential.status
+    }
+
+    init(status: ConsumeCredentialStatus) {
+        self.status = status
+    }
+
+    func currentState() -> ConsumeCredentialState {
+        lock.lock()
+        defer { lock.unlock() }
+        return status.currentState()
+    }
+}
+
+enum ConsumeLocalLimits {
+    static let requestLineBytes = 8 * 1024
+    static let requestTargetBytes = 2 * 1024
+    static let headerCount = 96
+    static let headerBytes = 64 * 1024
+    static let bodyBytes = 1 * 1024 * 1024
+    static let headerReadTimeout: TimeAmount = .seconds(5)
+    static let requestReadTimeout: TimeAmount = .seconds(15)
+    static let bodyIdleTimeout: TimeAmount = .seconds(5)
+
+    static var httpDecoderLimitConfiguration: NIOHTTPDecoderLimitConfiguration {
+        var configuration = NIOHTTPDecoderLimitConfiguration()
+        configuration.maxHeaderFieldSize = headerBytes
+        configuration.maxHeaderListSize = headerBytes
+        configuration.maxHeaderFieldCount = headerCount
+        return configuration
+    }
+}
+
+enum ConsumeLocalEndpoint: Sendable {
+    case status
+    case models
+    case chatCompletions
+}
+
+struct ConsumeValidatedRequest {
+    let endpoint: ConsumeLocalEndpoint
+}
+
 final class ConsumeEndpointRequestCounter: @unchecked Sendable {
     private let lock = NSLock()
+    private let maxIncompleteConnections: Int
+    private let maxActiveRequests: Int
+    private let maxBufferedBodyBytes: Int
+    private var incompleteConnections = 0
     private var value = 0
+    private var bufferedBodyBytes = 0
 
-    func begin() {
+    init(
+        maxIncompleteConnections: Int = 16,
+        maxActiveRequests: Int = 32,
+        maxBufferedBodyBytes: Int = 8 * 1024 * 1024
+    ) {
+        self.maxIncompleteConnections = maxIncompleteConnections
+        self.maxActiveRequests = maxActiveRequests
+        self.maxBufferedBodyBytes = maxBufferedBodyBytes
+    }
+
+    func beginIncompleteConnection() -> Bool {
         lock.lock()
-        value += 1
+        defer { lock.unlock() }
+        guard incompleteConnections < maxIncompleteConnections else { return false }
+        incompleteConnections += 1
+        return true
+    }
+
+    func completePreAuthConnection() {
+        lock.lock()
+        if incompleteConnections > 0 {
+            incompleteConnections -= 1
+        }
         lock.unlock()
+    }
+
+    func endIncompleteConnection() {
+        completePreAuthConnection()
+    }
+
+    func begin() -> Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        guard value < maxActiveRequests else { return false }
+        value += 1
+        return true
     }
 
     func end() {
         lock.lock()
         value = max(0, value - 1)
+        lock.unlock()
+    }
+
+    func reserveBodyBytes(_ count: Int) -> Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        guard count >= 0,
+              bufferedBodyBytes <= maxBufferedBodyBytes - count else {
+            return false
+        }
+        bufferedBodyBytes += count
+        return true
+    }
+
+    func releaseBodyBytes(_ count: Int) {
+        lock.lock()
+        bufferedBodyBytes = max(0, bufferedBodyBytes - max(0, count))
         lock.unlock()
     }
 
@@ -1103,7 +1229,11 @@ struct ConsumeLocalServer {
             .serverChannelOption(ChannelOptions.backlog, value: 16)
             .serverChannelOption(ChannelOptions.socketOption(.so_reuseaddr), value: 0)
             .childChannelInitializer { channel in
-                channel.pipeline.configureHTTPServerPipeline().flatMap {
+                channel.pipeline.addHandler(ConsumeStartLineLimitHandler()).flatMap {
+                    channel.pipeline.configureHTTPServerPipeline(
+                        withDecoderLimitConfiguration: ConsumeLocalLimits.httpDecoderLimitConfiguration
+                    )
+                }.flatMap {
                     channel.pipeline.addHandler(ConsumeLocalHandler(runtime: runtime))
                 }
             }
@@ -1127,75 +1257,531 @@ struct ConsumeLocalServer {
     }
 }
 
+final class ConsumeStartLineLimitHandler: ChannelInboundHandler, @unchecked Sendable {
+    typealias InboundIn = ByteBuffer
+    typealias InboundOut = ByteBuffer
+
+    private var startLineComplete = false
+    private var bufferedBytes: [UInt8] = []
+
+    func channelRead(context: ChannelHandlerContext, data: NIOAny) {
+        guard !startLineComplete else {
+            context.fireChannelRead(data)
+            return
+        }
+        let bytes = Array(unwrapInboundIn(data).readableBytesView)
+        for (index, byte) in bytes.enumerated() {
+            bufferedBytes.append(byte)
+            guard bufferedBytes.count <= ConsumeLocalLimits.requestLineBytes || byte == 0x0A else {
+                context.close(promise: nil)
+                return
+            }
+            if byte == 0x0A {
+                var line = bufferedBytes
+                line.removeLast()
+                if line.last == 0x0D {
+                    line.removeLast()
+                }
+                guard Self.isAllowedStartLine(line) else {
+                    context.close(promise: nil)
+                    return
+                }
+                startLineComplete = true
+                if index + 1 < bytes.count {
+                    bufferedBytes.append(contentsOf: bytes[(index + 1)...])
+                }
+                var forwarded = context.channel.allocator.buffer(capacity: bufferedBytes.count)
+                forwarded.writeBytes(bufferedBytes)
+                bufferedBytes.removeAll(keepingCapacity: false)
+                context.fireChannelRead(wrapInboundOut(forwarded))
+                return
+            }
+        }
+    }
+
+    private static func isAllowedStartLine(_ line: [UInt8]) -> Bool {
+        guard line.count <= ConsumeLocalLimits.requestLineBytes,
+              let methodEnd = line.firstIndex(of: 0x20) else {
+            return false
+        }
+        let method = line[..<methodEnd]
+        guard !method.isEmpty,
+              method.allSatisfy(isMethodTokenByte) else {
+            return false
+        }
+        let targetStart = methodEnd + 1
+        guard targetStart < line.endIndex,
+              let targetEnd = line[targetStart...].firstIndex(of: 0x20),
+              targetEnd > targetStart,
+              targetEnd - targetStart <= ConsumeLocalLimits.requestTargetBytes else {
+            return false
+        }
+        let versionStart = targetEnd + 1
+        guard versionStart < line.endIndex,
+              !line[versionStart...].contains(0x20) else {
+            return false
+        }
+        return Array(line[versionStart...]) == Array("HTTP/1.0".utf8)
+            || Array(line[versionStart...]) == Array("HTTP/1.1".utf8)
+    }
+
+    private static func isMethodTokenByte(_ byte: UInt8) -> Bool {
+        switch byte {
+        case 0x41...0x5A:
+            return true
+        default:
+            return false
+        }
+    }
+}
+
 final class ConsumeLocalHandler: ChannelInboundHandler, @unchecked Sendable {
     typealias InboundIn = HTTPServerRequestPart
     typealias OutboundOut = HTTPServerResponsePart
 
     private let runtime: ConsumeEndpointRuntime
     private var requestHead: HTTPRequestHead?
+    private var validatedRequest: ConsumeValidatedRequest?
+    private var requestBody = Data()
+    private var connectionIsIncompletePreAuth = false
     private var requestIsActive = false
+    private var reservedBodyBytes = 0
+    private var responseStarted = false
+    private var headerDeadlineTask: Scheduled<Void>?
+    private var requestDeadlineTask: Scheduled<Void>?
+    private var bodyIdleDeadlineTask: Scheduled<Void>?
+    private var channelForDeadline: Channel?
 
     init(runtime: ConsumeEndpointRuntime) {
         self.runtime = runtime
     }
 
+    func channelActive(context: ChannelHandlerContext) {
+        guard runtime.beginIncompleteConnection() else {
+            context.close(promise: nil)
+            return
+        }
+        connectionIsIncompletePreAuth = true
+        channelForDeadline = context.channel
+        headerDeadlineTask = context.eventLoop.scheduleTask(in: ConsumeLocalLimits.headerReadTimeout) { [weak self] in
+            self?.closeIfHeaderMissing()
+        }
+        context.fireChannelActive()
+    }
+
     func channelRead(context: ChannelHandlerContext, data: NIOAny) {
         switch unwrapInboundIn(data) {
         case .head(let head):
+            headerDeadlineTask?.cancel()
+            headerDeadlineTask = nil
             requestHead = head
-            runtime.beginRequest()
+            completeIncompletePreAuthConnection()
+            guard runtime.beginRequest() else {
+                writeLocalError(context: context, status: .serviceUnavailable, code: "local_endpoint_busy")
+                return
+            }
             requestIsActive = true
-        case .body:
-            break
+            startRequestDeadline(context: context)
+            handleHead(head, context: context)
+        case .body(var buffer):
+            guard !responseStarted else { return }
+            guard requestBody.count + buffer.readableBytes <= ConsumeLocalLimits.bodyBytes else {
+                writeLocalError(context: context, status: .payloadTooLarge, code: "local_request_too_large")
+                return
+            }
+            let readableBytes = buffer.readableBytes
+            guard runtime.reserveBodyBytes(readableBytes) else {
+                writeLocalError(context: context, status: .serviceUnavailable, code: "local_endpoint_busy")
+                return
+            }
+            if let bytes = buffer.readBytes(length: buffer.readableBytes) {
+                requestBody.append(contentsOf: bytes)
+                reservedBodyBytes += bytes.count
+                refreshBodyIdleDeadline(context: context)
+            } else {
+                runtime.releaseBodyBytes(readableBytes)
+            }
         case .end:
+            cancelPostHeaderDeadlines()
             guard let head = requestHead else {
                 context.close(promise: nil)
                 return
             }
-            handle(head: head, context: context)
+            guard !responseStarted else {
+                endRequestIfNeeded()
+                return
+            }
+            handleEnd(head: head, context: context)
             endRequestIfNeeded()
         }
     }
 
     func channelInactive(context: ChannelHandlerContext) {
+        headerDeadlineTask?.cancel()
+        headerDeadlineTask = nil
+        cancelPostHeaderDeadlines()
+        channelForDeadline = nil
+        if connectionIsIncompletePreAuth {
+            runtime.endIncompleteConnection()
+            connectionIsIncompletePreAuth = false
+        }
         endRequestIfNeeded()
     }
 
-    private func handle(head: HTTPRequestHead, context: ChannelHandlerContext) {
+    private func handleHead(_ head: HTTPRequestHead, context: ChannelHandlerContext) {
         if head.method == .HEAD {
-            writeJSON(context: context, status: .methodNotAllowed, body: NSNull())
+            writeHeadOnly(context: context, status: .methodNotAllowed)
+            return
+        }
+        if let error = validatePreAuthBoundsAndFraming(head) {
+            writeLocalError(context: context, status: error.status, code: error.code)
+            return
+        }
+        if let error = validateBrowserOrigin(head) {
+            writeLocalError(context: context, status: error.status, code: error.code)
             return
         }
         let statusNoStore = head.method == .GET && head.uri == "/v1/status"
         guard runtime.tokenVerifier.verify(headers: head.headers) else {
-            writeJSON(
+            writeLocalError(
                 context: context,
                 status: .unauthorized,
-                body: errorEnvelope(code: "local_auth_required"),
+                code: "local_auth_required",
                 extraHeaders: statusNoStore ? [("cache-control", "no-store")] : []
             )
             return
         }
-        guard head.uri == "/v1/status" else {
-            writeJSON(context: context, status: .notFound, body: errorEnvelope(code: "local_endpoint_unsupported"))
+        do {
+            validatedRequest = try validateEndpoint(head)
+        } catch let error as ConsumeLocalValidationError {
+            writeLocalError(context: context, status: error.status, code: error.code)
+        } catch {
+            writeLocalError(context: context, status: .badRequest, code: "local_invalid_request")
+        }
+    }
+
+    private func handleEnd(head: HTTPRequestHead, context: ChannelHandlerContext) {
+        guard let validatedRequest else {
             return
         }
-        guard head.method == .GET else {
-            writeJSON(context: context, status: .methodNotAllowed, body: errorEnvelope(code: "local_endpoint_unsupported"))
-            return
+        switch validatedRequest.endpoint {
+        case .status:
+            guard requestBody.isEmpty else {
+                writeLocalError(context: context, status: .badRequest, code: "local_invalid_request")
+                return
+            }
+            writeJSON(
+                context: context,
+                status: .ok,
+                body: runtime.statusPayload(),
+                extraHeaders: [("cache-control", "no-store")]
+            )
+        case .models:
+            guard requestBody.isEmpty else {
+                writeLocalError(context: context, status: .badRequest, code: "local_invalid_request")
+                return
+            }
+            writeLocalModels(context: context)
+        case .chatCompletions:
+            guard validateLocalBody(head: head, body: requestBody, requiresJSONObject: true, context: context) else {
+                return
+            }
+            writeLocalError(context: context, status: .badRequest, code: "local_budget_required")
+        }
+    }
+
+    private func validatePreAuthBoundsAndFraming(_ head: HTTPRequestHead) -> ConsumeLocalValidationError? {
+        let requestLineBytes = "\(head.method.rawValue) \(head.uri) HTTP/\(head.version.major).\(head.version.minor)".utf8.count
+        guard requestLineBytes <= ConsumeLocalLimits.requestLineBytes,
+              head.uri.utf8.count <= ConsumeLocalLimits.requestTargetBytes else {
+            return ConsumeLocalValidationError(status: .payloadTooLarge, code: "local_request_too_large")
+        }
+        var headerBytes = 0
+        var headerCount = 0
+        for (name, value) in head.headers {
+            headerCount += 1
+            headerBytes += name.utf8.count + value.utf8.count + 4
+        }
+        guard headerCount <= ConsumeLocalLimits.headerCount,
+              headerBytes <= ConsumeLocalLimits.headerBytes else {
+            return ConsumeLocalValidationError(status: .payloadTooLarge, code: "local_request_too_large")
+        }
+        let contentLengths = head.headers["content-length"]
+        guard contentLengths.count <= 1 else {
+            return ConsumeLocalValidationError(status: .badRequest, code: "local_invalid_request")
+        }
+        for value in contentLengths {
+            let normalized = value.trimmingCharacters(in: .whitespaces)
+            guard normalized.range(of: #"^[0-9]+$"#, options: .regularExpression) != nil,
+                  !value.contains(","),
+                  let length = Int(normalized) else {
+                return ConsumeLocalValidationError(status: .badRequest, code: "local_invalid_request")
+            }
+            guard length <= ConsumeLocalLimits.bodyBytes else {
+                return ConsumeLocalValidationError(status: .payloadTooLarge, code: "local_request_too_large")
+            }
+        }
+        let transferTokens = head.headers["transfer-encoding"]
+            .flatMap { value in
+                value.split(separator: ",", omittingEmptySubsequences: false)
+                    .map { $0.trimmingCharacters(in: .whitespaces).lowercased() }
+            }
+        guard transferTokens.allSatisfy({ !$0.isEmpty }) else {
+            return ConsumeLocalValidationError(status: .badRequest, code: "local_invalid_request")
+        }
+        guard contentLengths.isEmpty || transferTokens.isEmpty else {
+            return ConsumeLocalValidationError(status: .badRequest, code: "local_invalid_request")
+        }
+        guard transferTokens.isEmpty || transferTokens == ["chunked"] else {
+            return ConsumeLocalValidationError(status: .badRequest, code: "local_invalid_request")
+        }
+        return nil
+    }
+
+    private func validateBrowserOrigin(_ head: HTTPRequestHead) -> ConsumeLocalValidationError? {
+        if head.method == .OPTIONS,
+           !head.headers[canonicalForm: "access-control-request-method"].isEmpty {
+            return ConsumeLocalValidationError(status: .badRequest, code: "local_invalid_request")
+        }
+        var origins: [String] = []
+        for (name, value) in head.headers where name.caseInsensitiveCompare("origin") == .orderedSame {
+            origins.append(value)
+        }
+        guard origins.count <= 1 else {
+            return ConsumeLocalValidationError(status: .badRequest, code: "local_invalid_request")
+        }
+        if let origin = origins.first {
+            let normalized = origin.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard normalized == origin,
+                  origin != "null",
+                  !origin.contains(","),
+                  origin == runtime.boundURL else {
+                return ConsumeLocalValidationError(status: .badRequest, code: "local_invalid_request")
+            }
+        }
+        for site in head.headers[canonicalForm: "sec-fetch-site"] {
+            let normalized = site.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+            guard normalized == "same-origin" || normalized == "none" else {
+                return ConsumeLocalValidationError(status: .badRequest, code: "local_invalid_request")
+            }
+        }
+        return nil
+    }
+
+    private func validateEndpoint(_ head: HTTPRequestHead) throws -> ConsumeValidatedRequest {
+        let target = try decodeExactRequestTarget(head.uri)
+        switch (head.method, target) {
+        case (.GET, "/v1/status"):
+            return ConsumeValidatedRequest(endpoint: .status)
+        case (.GET, "/v1/models"):
+            return ConsumeValidatedRequest(endpoint: .models)
+        case (.POST, "/v1/chat/completions"):
+            return ConsumeValidatedRequest(endpoint: .chatCompletions)
+        case (.POST, "/v1/status"), (.POST, "/v1/models"), (.GET, "/v1/chat/completions"):
+            throw ConsumeLocalValidationError(status: .methodNotAllowed, code: "local_endpoint_unsupported")
+        default:
+            throw ConsumeLocalValidationError(status: .notFound, code: "local_endpoint_unsupported")
+        }
+    }
+
+    private func decodeExactRequestTarget(_ rawTarget: String) throws -> String {
+        guard rawTarget.first == "/" else {
+            throw ConsumeLocalValidationError(status: .badRequest, code: "local_invalid_request")
+        }
+        if let hash = rawTarget.firstIndex(of: "#"), hash != rawTarget.endIndex {
+            throw ConsumeLocalValidationError(status: .badRequest, code: "local_invalid_request")
+        }
+        if let query = rawTarget.firstIndex(of: "?") {
+            let afterQuery = rawTarget.index(after: query)
+            guard afterQuery == rawTarget.endIndex else {
+                throw ConsumeLocalValidationError(status: .badRequest, code: "local_invalid_request")
+            }
+            throw ConsumeLocalValidationError(status: .badRequest, code: "local_invalid_request")
+        }
+        guard !rawTarget.contains("\\") else {
+            throw ConsumeLocalValidationError(status: .badRequest, code: "local_invalid_request")
+        }
+        let lowercase = rawTarget.lowercased()
+        guard !lowercase.contains("%2f"), !lowercase.contains("%5c") else {
+            throw ConsumeLocalValidationError(status: .badRequest, code: "local_invalid_request")
+        }
+        let decoded = try percentDecodePath(rawTarget)
+        guard decoded == rawTarget else {
+            throw ConsumeLocalValidationError(status: .badRequest, code: "local_invalid_request")
+        }
+        let components = decoded.split(separator: "/", omittingEmptySubsequences: false)
+        guard !decoded.contains("//"),
+              !components.contains("."),
+              !components.contains("..") else {
+            throw ConsumeLocalValidationError(status: .badRequest, code: "local_invalid_request")
+        }
+        guard decoded == "/v1/status" || decoded == "/v1/models" || decoded == "/v1/chat/completions" else {
+            return decoded
+        }
+        return decoded
+    }
+
+    private func percentDecodePath(_ rawPath: String) throws -> String {
+        var bytes: [UInt8] = []
+        bytes.reserveCapacity(rawPath.utf8.count)
+        var index = rawPath.utf8.startIndex
+        while index < rawPath.utf8.endIndex {
+            let byte = rawPath.utf8[index]
+            if byte == 0x25 {
+                let first = rawPath.utf8.index(after: index)
+                guard first < rawPath.utf8.endIndex else {
+                    throw ConsumeLocalValidationError(status: .badRequest, code: "local_invalid_request")
+                }
+                let second = rawPath.utf8.index(after: first)
+                guard second < rawPath.utf8.endIndex,
+                      let high = hex(rawPath.utf8[first]),
+                      let low = hex(rawPath.utf8[second]) else {
+                    throw ConsumeLocalValidationError(status: .badRequest, code: "local_invalid_request")
+                }
+                bytes.append(high << 4 | low)
+                index = rawPath.utf8.index(after: second)
+            } else {
+                bytes.append(byte)
+                index = rawPath.utf8.index(after: index)
+            }
+            guard bytes.count <= ConsumeLocalLimits.requestTargetBytes else {
+                throw ConsumeLocalValidationError(status: .payloadTooLarge, code: "local_request_too_large")
+            }
+        }
+        guard let decoded = String(bytes: bytes, encoding: .utf8) else {
+            throw ConsumeLocalValidationError(status: .badRequest, code: "local_invalid_request")
+        }
+        return decoded
+    }
+
+    private func hex(_ byte: UInt8) -> UInt8? {
+        switch byte {
+        case 48...57:
+            return byte - 48
+        case 65...70:
+            return byte - 55
+        case 97...102:
+            return byte - 87
+        default:
+            return nil
+        }
+    }
+
+    private func validateLocalBody(
+        head: HTTPRequestHead,
+        body: Data,
+        requiresJSONObject: Bool,
+        context: ChannelHandlerContext
+    ) -> Bool {
+        let encodings = head.headers[canonicalForm: "content-encoding"]
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() }
+        guard encodings.isEmpty || encodings == ["identity"] else {
+            writeLocalError(context: context, status: HTTPResponseStatus(statusCode: 415), code: "local_content_encoding_unsupported")
+            return false
+        }
+        guard body.count <= ConsumeLocalLimits.bodyBytes else {
+            writeLocalError(context: context, status: .payloadTooLarge, code: "local_request_too_large")
+            return false
+        }
+        guard !requiresJSONObject || !body.isEmpty,
+              let text = String(data: body, encoding: .utf8),
+              let parsed = try? StrictJSONParser.parse(text),
+              !requiresJSONObject || parsed.isObject else {
+            writeLocalError(context: context, status: .badRequest, code: "local_invalid_request")
+            return false
+        }
+        return true
+    }
+
+    private func writeLocalModels(context: ChannelHandlerContext) {
+        let models = runtime.modelAllowlist.map { modelID in
+            [
+                "id": modelID,
+                "object": "model",
+                "created": 0,
+                "owned_by": "macprovider",
+            ] as [String: Any]
         }
         writeJSON(
             context: context,
             status: .ok,
-            body: runtime.statusPayload(),
+            body: [
+                "object": "list",
+                "data": models,
+            ],
             extraHeaders: [("cache-control", "no-store")]
         )
     }
 
     private func endRequestIfNeeded() {
+        cancelPostHeaderDeadlines()
+        if reservedBodyBytes > 0 {
+            runtime.releaseBodyBytes(reservedBodyBytes)
+            reservedBodyBytes = 0
+        }
         guard requestIsActive else { return }
         requestIsActive = false
         runtime.endRequest()
+    }
+
+    private func completeIncompletePreAuthConnection() {
+        guard connectionIsIncompletePreAuth else { return }
+        connectionIsIncompletePreAuth = false
+        runtime.completePreAuthConnection()
+    }
+
+    private func closeIfHeaderMissing() {
+        guard requestHead == nil else { return }
+        channelForDeadline?.close(promise: nil)
+    }
+
+    private func startRequestDeadline(context: ChannelHandlerContext) {
+        requestDeadlineTask?.cancel()
+        requestDeadlineTask = context.eventLoop.scheduleTask(in: ConsumeLocalLimits.requestReadTimeout) { [weak self] in
+            self?.closeIfRequestIncomplete()
+        }
+        if shouldReadBody {
+            refreshBodyIdleDeadline(context: context)
+        }
+    }
+
+    private var shouldReadBody: Bool {
+        guard let endpoint = validatedRequest?.endpoint else { return true }
+        return endpoint == .chatCompletions
+    }
+
+    private func refreshBodyIdleDeadline(context: ChannelHandlerContext) {
+        bodyIdleDeadlineTask?.cancel()
+        bodyIdleDeadlineTask = context.eventLoop.scheduleTask(in: ConsumeLocalLimits.bodyIdleTimeout) { [weak self] in
+            self?.closeIfRequestIncomplete()
+        }
+    }
+
+    private func closeIfRequestIncomplete() {
+        guard requestIsActive, !responseStarted else { return }
+        channelForDeadline?.close(promise: nil)
+    }
+
+    private func cancelPostHeaderDeadlines() {
+        requestDeadlineTask?.cancel()
+        requestDeadlineTask = nil
+        bodyIdleDeadlineTask?.cancel()
+        bodyIdleDeadlineTask = nil
+    }
+
+    private func writeLocalError(
+        context: ChannelHandlerContext,
+        status: HTTPResponseStatus,
+        code: String,
+        forwardedUpstream: Bool = false,
+        extraHeaders: [(String, String)] = []
+    ) {
+        writeJSON(
+            context: context,
+            status: status,
+            body: errorEnvelope(code: code, forwardedUpstream: forwardedUpstream),
+            extraHeaders: extraHeaders
+        )
     }
 
     private func writeJSON(
@@ -1209,13 +1795,16 @@ final class ConsumeLocalHandler: ChannelInboundHandler, @unchecked Sendable {
                 ? Data()
                 : JSONSerialization.data(withJSONObject: body, options: [.withoutEscapingSlashes])
             var headers = HTTPHeaders()
-            headers.add(name: "content-type", value: "application/json")
+            if !(body is NSNull) {
+                headers.add(name: "content-type", value: "application/json")
+            }
             headers.add(name: "content-length", value: "\(data.count)")
             headers.add(name: "connection", value: "close")
             for (name, value) in extraHeaders {
                 headers.add(name: name, value: value)
             }
             let head = HTTPResponseHead(version: .http1_1, status: status, headers: headers)
+            responseStarted = true
             context.write(wrapOutboundOut(.head(head)), promise: nil)
             if !data.isEmpty {
                 var buffer = context.channel.allocator.buffer(capacity: data.count)
@@ -1229,16 +1818,39 @@ final class ConsumeLocalHandler: ChannelInboundHandler, @unchecked Sendable {
         }
     }
 
-    private func errorEnvelope(code: String) -> [String: Any] {
+    private func writeHeadOnly(context: ChannelHandlerContext, status: HTTPResponseStatus) {
+        var headers = HTTPHeaders()
+        headers.add(name: "content-length", value: "0")
+        headers.add(name: "connection", value: "close")
+        let head = HTTPResponseHead(version: .http1_1, status: status, headers: headers)
+        responseStarted = true
+        context.write(wrapOutboundOut(.head(head)), promise: nil)
+        context.writeAndFlush(wrapOutboundOut(.end(nil)), promise: nil)
+        context.close(promise: nil)
+    }
+
+    private func errorEnvelope(code: String, forwardedUpstream: Bool) -> [String: Any] {
         [
             "error": [
                 "message": code,
                 "type": "macprovider_local_error",
                 "param": NSNull(),
                 "code": code,
-                "macprovider": ["forwarded_upstream": false],
+                "macprovider": ["forwarded_upstream": forwardedUpstream],
             ],
         ]
+    }
+}
+
+struct ConsumeLocalValidationError: Error {
+    let status: HTTPResponseStatus
+    let code: String
+}
+
+private extension JSONValue {
+    var isObject: Bool {
+        if case .object = self { return true }
+        return false
     }
 }
 

--- a/phase3-binary/Tests/macprovider-cliTests/ConsumeCommandTests.swift
+++ b/phase3-binary/Tests/macprovider-cliTests/ConsumeCommandTests.swift
@@ -1,6 +1,7 @@
 import ArgumentParser
 import Darwin
 import Foundation
+import NIOCore
 import NIOEmbedded
 import NIOHTTP1
 import XCTest
@@ -320,7 +321,7 @@ final class ConsumeCommandTests: XCTestCase {
             modelAllowlist: ["llama-test"],
             tokenVerifier: token.verifier
         )
-        runtime.beginRequest()
+        XCTAssertTrue(runtime.beginRequest())
         defer { runtime.endRequest() }
 
         let missingAuthHeaders = HTTPHeaders()
@@ -363,7 +364,7 @@ final class ConsumeCommandTests: XCTestCase {
             from: runtime,
             head: HTTPRequestHead(version: .http1_1, method: .GET, uri: "/v1/chat/completions", headers: authorizedHeaders)
         )
-        XCTAssertEqual(wrongPath.status, HTTPResponseStatus.notFound)
+        XCTAssertEqual(wrongPath.status, HTTPResponseStatus.methodNotAllowed)
         let wrongPathError = try localError(from: wrongPath.body)
         XCTAssertEqual(wrongPathError["code"] as? String, "local_endpoint_unsupported")
         XCTAssertTrue(wrongPathError["param"] is NSNull)
@@ -391,9 +392,367 @@ final class ConsumeCommandTests: XCTestCase {
         XCTAssertEqual(head.body, "")
     }
 
+    func testPhase2RejectsUnsafeTargetsFramingAndBrowserOrigins() throws {
+        let token = try ConsumeLocalToken.generate()
+        let runtime = consumeRuntime(token: token)
+        var headers = HTTPHeaders()
+        headers.add(name: "Authorization", value: "Bearer \(token.value)")
+
+        let query = try response(
+            from: runtime,
+            head: HTTPRequestHead(version: .http1_1, method: .GET, uri: "/v1/models?limit=1", headers: headers)
+        )
+        XCTAssertEqual(query.status, .badRequest)
+        XCTAssertEqual(try localError(from: query.body)["code"] as? String, "local_invalid_request")
+
+        let encodedPath = try response(
+            from: runtime,
+            head: HTTPRequestHead(version: .http1_1, method: .GET, uri: "/v1/%6dodels", headers: headers)
+        )
+        XCTAssertEqual(encodedPath.status, .badRequest)
+        XCTAssertEqual(try localError(from: encodedPath.body)["code"] as? String, "local_invalid_request")
+
+        let encodedDot = try response(
+            from: runtime,
+            head: HTTPRequestHead(version: .http1_1, method: .GET, uri: "/v1/%2e/status", headers: headers)
+        )
+        XCTAssertEqual(encodedDot.status, .badRequest)
+
+        var duplicateLength = headers
+        duplicateLength.add(name: "Content-Length", value: "1")
+        duplicateLength.add(name: "Content-Length", value: "1")
+        let duplicateLengthResponse = try response(
+            from: runtime,
+            head: HTTPRequestHead(version: .http1_1, method: .POST, uri: "/v1/chat/completions", headers: duplicateLength),
+            body: Data("{}".utf8)
+        )
+        XCTAssertEqual(duplicateLengthResponse.status, .badRequest)
+
+        var commaLength = headers
+        commaLength.add(name: "Content-Length", value: "1,")
+        let commaLengthResponse = try response(
+            from: runtime,
+            head: HTTPRequestHead(version: .http1_1, method: .POST, uri: "/v1/chat/completions", headers: commaLength),
+            body: Data("{}".utf8)
+        )
+        XCTAssertEqual(commaLengthResponse.status, .badRequest)
+
+        var trailingTransferCoding = headers
+        trailingTransferCoding.add(name: "Transfer-Encoding", value: "chunked,")
+        let trailingTransferCodingResponse = try response(
+            from: runtime,
+            head: HTTPRequestHead(version: .http1_1, method: .POST, uri: "/v1/chat/completions", headers: trailingTransferCoding),
+            body: Data("{}".utf8)
+        )
+        XCTAssertEqual(trailingTransferCodingResponse.status, .badRequest)
+
+        var leadingTransferCoding = headers
+        leadingTransferCoding.add(name: "Transfer-Encoding", value: ",chunked")
+        let leadingTransferCodingResponse = try response(
+            from: runtime,
+            head: HTTPRequestHead(version: .http1_1, method: .POST, uri: "/v1/chat/completions", headers: leadingTransferCoding),
+            body: Data("{}".utf8)
+        )
+        XCTAssertEqual(leadingTransferCodingResponse.status, .badRequest)
+
+        var originNull = headers
+        originNull.add(name: "Origin", value: "null")
+        let nullOrigin = try response(
+            from: runtime,
+            head: HTTPRequestHead(version: .http1_1, method: .GET, uri: "/v1/status", headers: originNull)
+        )
+        XCTAssertEqual(nullOrigin.status, .badRequest)
+
+        var commaOrigin = headers
+        commaOrigin.add(name: "Origin", value: "http://127.0.0.1:11435, http://127.0.0.1:11436")
+        let commaOriginResponse = try response(
+            from: runtime,
+            head: HTTPRequestHead(version: .http1_1, method: .GET, uri: "/v1/status", headers: commaOrigin)
+        )
+        XCTAssertEqual(commaOriginResponse.status, .badRequest)
+
+        var leadingCommaOrigin = headers
+        leadingCommaOrigin.add(name: "Origin", value: ",http://127.0.0.1:11435")
+        let leadingCommaOriginResponse = try response(
+            from: runtime,
+            head: HTTPRequestHead(version: .http1_1, method: .GET, uri: "/v1/status", headers: leadingCommaOrigin)
+        )
+        XCTAssertEqual(leadingCommaOriginResponse.status, .badRequest)
+
+        var multipleOrigins = headers
+        multipleOrigins.add(name: "Origin", value: "http://127.0.0.1:11435")
+        multipleOrigins.add(name: "Origin", value: "http://127.0.0.1:11435")
+        let multipleOriginResponse = try response(
+            from: runtime,
+            head: HTTPRequestHead(version: .http1_1, method: .GET, uri: "/v1/status", headers: multipleOrigins)
+        )
+        XCTAssertEqual(multipleOriginResponse.status, .badRequest)
+
+        var exactOrigin = headers
+        exactOrigin.add(name: "Origin", value: "http://127.0.0.1:11435")
+        exactOrigin.add(name: "Sec-Fetch-Site", value: "same-origin")
+        let exactOriginResponse = try response(
+            from: runtime,
+            head: HTTPRequestHead(version: .http1_1, method: .GET, uri: "/v1/status", headers: exactOrigin)
+        )
+        XCTAssertEqual(exactOriginResponse.status, .ok)
+    }
+
+    func testPhase2NIOHTTPDecoderLimitsMatchLocalPolicy() {
+        let configuration = ConsumeLocalLimits.httpDecoderLimitConfiguration
+        XCTAssertEqual(configuration.maxHeaderFieldSize, ConsumeLocalLimits.headerBytes)
+        XCTAssertEqual(configuration.maxHeaderListSize, ConsumeLocalLimits.headerBytes)
+        XCTAssertEqual(configuration.maxHeaderFieldCount, ConsumeLocalLimits.headerCount)
+    }
+
+    func testPhase2RawPipelineRejectsOversizedStartLineBeforeHTTPDecoder() throws {
+        let token = try ConsumeLocalToken.generate()
+
+        let oversizedTargetRuntime = consumeRuntime(token: token)
+        let oversizedTargetChannel = try rawConsumeChannel(runtime: oversizedTargetRuntime)
+        let oversizedTarget = "/" + String(repeating: "a", count: ConsumeLocalLimits.requestTargetBytes + 1)
+        try writeRawRequest(
+            "GET \(oversizedTarget) HTTP/1.1\r\nHost: 127.0.0.1:11435\r\n\r\n",
+            to: oversizedTargetChannel
+        )
+        oversizedTargetChannel.embeddedEventLoop.run()
+        XCTAssertFalse(oversizedTargetChannel.isActive)
+        XCTAssertEqual(oversizedTargetRuntime.statusPayload()["active_request_count"] as? Int, 0)
+        XCTAssertNil(try oversizedTargetChannel.readOutbound(as: HTTPServerResponsePart.self))
+
+        let oversizedLineRuntime = consumeRuntime(token: token)
+        let oversizedLineChannel = try rawConsumeChannel(runtime: oversizedLineRuntime)
+        let oversizedLine = String(repeating: "A", count: ConsumeLocalLimits.requestLineBytes + 1)
+        try writeRawRequest(
+            "\(oversizedLine)\r\nHost: 127.0.0.1:11435\r\n\r\n",
+            to: oversizedLineChannel
+        )
+        oversizedLineChannel.embeddedEventLoop.run()
+        XCTAssertFalse(oversizedLineChannel.isActive)
+        XCTAssertEqual(oversizedLineRuntime.statusPayload()["active_request_count"] as? Int, 0)
+        XCTAssertNil(try oversizedLineChannel.readOutbound(as: HTTPServerResponsePart.self))
+
+        let splitLineRuntime = consumeRuntime(token: token)
+        let splitLineChannel = try rawConsumeChannel(runtime: splitLineRuntime)
+        try writeRawRequest(
+            "GET /" + String(repeating: "b", count: ConsumeLocalLimits.requestLineBytes - 6),
+            to: splitLineChannel
+        )
+        XCTAssertTrue(splitLineChannel.isActive)
+        XCTAssertEqual(splitLineRuntime.statusPayload()["active_request_count"] as? Int, 0)
+        try writeRawRequest("bb", to: splitLineChannel)
+        splitLineChannel.embeddedEventLoop.run()
+        XCTAssertFalse(splitLineChannel.isActive)
+        XCTAssertEqual(splitLineRuntime.statusPayload()["active_request_count"] as? Int, 0)
+        XCTAssertNil(try splitLineChannel.readOutbound(as: HTTPServerResponsePart.self))
+
+        let malformedVersionRuntime = consumeRuntime(token: token)
+        let malformedVersionChannel = try rawConsumeChannel(runtime: malformedVersionRuntime)
+        try writeRawRequest(
+            "GET /v1/status HTTP/2.0\r\nHost: 127.0.0.1:11435\r\n\r\n",
+            to: malformedVersionChannel
+        )
+        malformedVersionChannel.embeddedEventLoop.run()
+        XCTAssertFalse(malformedVersionChannel.isActive)
+        XCTAssertEqual(malformedVersionRuntime.statusPayload()["active_request_count"] as? Int, 0)
+
+        let malformedMethodRuntime = consumeRuntime(token: token)
+        let malformedMethodChannel = try rawConsumeChannel(runtime: malformedMethodRuntime)
+        try writeRawRequest(
+            "get /v1/status HTTP/1.1\r\nHost: 127.0.0.1:11435\r\n\r\n",
+            to: malformedMethodChannel
+        )
+        malformedMethodChannel.embeddedEventLoop.run()
+        XCTAssertFalse(malformedMethodChannel.isActive)
+        XCTAssertEqual(malformedMethodRuntime.statusPayload()["active_request_count"] as? Int, 0)
+    }
+
+    func testPhase2EnforcesLocalResourceCapsBeforeBuffering() throws {
+        let token = try ConsumeLocalToken.generate()
+        var headers = HTTPHeaders()
+        headers.add(name: "Authorization", value: "Bearer \(token.value)")
+
+        var declaredTooLarge = headers
+        declaredTooLarge.add(name: "Content-Length", value: "\(ConsumeLocalLimits.bodyBytes + 1)")
+        let declaredTooLargeResponse = try response(
+            from: consumeRuntime(token: token),
+            head: HTTPRequestHead(version: .http1_1, method: .POST, uri: "/v1/chat/completions", headers: declaredTooLarge)
+        )
+        XCTAssertEqual(declaredTooLargeResponse.status, .payloadTooLarge)
+        XCTAssertEqual(try localError(from: declaredTooLargeResponse.body)["code"] as? String, "local_request_too_large")
+
+        let activeSaturated = try response(
+            from: consumeRuntime(
+                token: token,
+                requestCounter: ConsumeEndpointRequestCounter(maxActiveRequests: 0)
+            ),
+            head: HTTPRequestHead(version: .http1_1, method: .GET, uri: "/v1/status", headers: headers)
+        )
+        XCTAssertEqual(activeSaturated.status, .serviceUnavailable)
+        XCTAssertEqual(try localError(from: activeSaturated.body)["code"] as? String, "local_endpoint_busy")
+
+        let bodyBufferSaturated = try response(
+            from: consumeRuntime(
+                token: token,
+                requestCounter: ConsumeEndpointRequestCounter(maxBufferedBodyBytes: 1)
+            ),
+            head: HTTPRequestHead(version: .http1_1, method: .POST, uri: "/v1/chat/completions", headers: headers),
+            body: Data("{}".utf8)
+        )
+        XCTAssertEqual(bodyBufferSaturated.status, .serviceUnavailable)
+        XCTAssertEqual(try localError(from: bodyBufferSaturated.body)["code"] as? String, "local_endpoint_busy")
+
+        let counter = ConsumeEndpointRequestCounter(maxIncompleteConnections: 1, maxActiveRequests: 1, maxBufferedBodyBytes: 2)
+        XCTAssertTrue(counter.beginIncompleteConnection())
+        XCTAssertFalse(counter.beginIncompleteConnection())
+        counter.completePreAuthConnection()
+        XCTAssertTrue(counter.beginIncompleteConnection())
+        counter.endIncompleteConnection()
+        XCTAssertTrue(counter.begin())
+        XCTAssertFalse(counter.begin())
+        counter.end()
+        XCTAssertTrue(counter.reserveBodyBytes(2))
+        XCTAssertFalse(counter.reserveBodyBytes(1))
+        counter.releaseBodyBytes(2)
+        XCTAssertTrue(counter.reserveBodyBytes(1))
+    }
+
+    func testPhase2PostHeaderIdleTimeoutReleasesActiveCapacity() throws {
+        let token = try ConsumeLocalToken.generate()
+        let counter = ConsumeEndpointRequestCounter(maxActiveRequests: 1)
+        let runtime = consumeRuntime(token: token, requestCounter: counter)
+        let channel = try rawConsumeChannel(runtime: runtime)
+
+        let request = "POST /v1/chat/completions HTTP/1.1\r\n"
+            + "Host: 127.0.0.1:11435\r\n"
+            + "Authorization: Bearer \(token.value)\r\n"
+            + "Content-Length: 2\r\n"
+            + "\r\n"
+        var buffer = channel.allocator.buffer(capacity: request.utf8.count)
+        buffer.writeString(request)
+        XCTAssertNoThrow(try channel.writeInbound(buffer))
+        XCTAssertEqual(runtime.statusPayload()["active_request_count"] as? Int, 1)
+
+        var headers = HTTPHeaders()
+        headers.add(name: "Authorization", value: "Bearer \(token.value)")
+        let saturated = try response(
+            from: runtime,
+            head: HTTPRequestHead(version: .http1_1, method: .GET, uri: "/v1/status", headers: headers)
+        )
+        XCTAssertEqual(saturated.status, .serviceUnavailable)
+
+        channel.embeddedEventLoop.advanceTime(by: ConsumeLocalLimits.bodyIdleTimeout)
+        channel.embeddedEventLoop.run()
+
+        XCTAssertFalse(channel.isActive)
+        XCTAssertEqual(runtime.statusPayload()["active_request_count"] as? Int, 0)
+
+        let recovered = try response(
+            from: runtime,
+            head: HTTPRequestHead(version: .http1_1, method: .GET, uri: "/v1/status", headers: headers)
+        )
+        XCTAssertEqual(recovered.status, .ok)
+    }
+
+    func testPhase2ChatValidatesBodyBeforeBudgetRequiredFailure() throws {
+        let token = try ConsumeLocalToken.generate()
+        let runtime = consumeRuntime(token: token)
+        var headers = HTTPHeaders()
+        headers.add(name: "Authorization", value: "Bearer \(token.value)")
+
+        let valid = try response(
+            from: runtime,
+            head: HTTPRequestHead(version: .http1_1, method: .POST, uri: "/v1/chat/completions", headers: headers),
+            body: Data(#"{"model":"llama-test","messages":[]}"#.utf8)
+        )
+        XCTAssertEqual(valid.status, .badRequest)
+        let validError = try localError(from: valid.body)
+        XCTAssertEqual(validError["code"] as? String, "local_budget_required")
+        XCTAssertEqual(try localForwardedFlag(from: valid.body), false)
+
+        let duplicateKey = try response(
+            from: runtime,
+            head: HTTPRequestHead(version: .http1_1, method: .POST, uri: "/v1/chat/completions", headers: headers),
+            body: Data(#"{"model":"a","model":"b"}"#.utf8)
+        )
+        XCTAssertEqual(duplicateKey.status, .badRequest)
+        XCTAssertEqual(try localError(from: duplicateKey.body)["code"] as? String, "local_invalid_request")
+
+        for invalidTopLevelJSON in ["[]", #""text""#, "true", "null"] {
+            let invalid = try response(
+                from: runtime,
+                head: HTTPRequestHead(version: .http1_1, method: .POST, uri: "/v1/chat/completions", headers: headers),
+                body: Data(invalidTopLevelJSON.utf8)
+            )
+            XCTAssertEqual(invalid.status, .badRequest, invalidTopLevelJSON)
+            XCTAssertEqual(try localError(from: invalid.body)["code"] as? String, "local_invalid_request")
+        }
+
+        var gzip = headers
+        gzip.add(name: "Content-Encoding", value: "gzip")
+        let compressed = try response(
+            from: runtime,
+            head: HTTPRequestHead(version: .http1_1, method: .POST, uri: "/v1/chat/completions", headers: gzip),
+            body: Data("{}".utf8)
+        )
+        XCTAssertEqual(compressed.status.code, 415)
+        XCTAssertEqual(try localError(from: compressed.body)["code"] as? String, "local_content_encoding_unsupported")
+    }
+
+    func testPhase2ModelsReturnsOnlyLocalAllowlistEntries() throws {
+        let token = try ConsumeLocalToken.generate()
+        let runtime = consumeRuntime(
+            token: token,
+            allowedModels: ["llama-test", "mistral-test"]
+        )
+        var headers = HTTPHeaders()
+        headers.add(name: "Authorization", value: "Bearer \(token.value)")
+        headers.add(name: "Cookie", value: "local=secret")
+        headers.add(name: "Forwarded", value: "for=127.0.0.1")
+
+        let models = try response(
+            from: runtime,
+            head: HTTPRequestHead(version: .http1_1, method: .GET, uri: "/v1/models", headers: headers)
+        )
+
+        XCTAssertEqual(models.status, .ok)
+        XCTAssertEqual(models.headers.first(name: "cache-control"), "no-store")
+        XCTAssertNil(models.headers.first(name: "set-cookie"))
+        let object = try XCTUnwrap(JSONSerialization.jsonObject(with: Data(models.body.utf8)) as? [String: Any])
+        XCTAssertEqual(object["object"] as? String, "list")
+        let data = try XCTUnwrap(object["data"] as? [[String: Any]])
+        XCTAssertEqual(data.compactMap { $0["id"] as? String }, ["llama-test", "mistral-test"])
+        XCTAssertEqual(data.compactMap { $0["object"] as? String }, ["model", "model"])
+    }
+
+    func testPhase2ModelsDefaultEmptyAllowlistReturnsEmptyList() throws {
+        let token = try ConsumeLocalToken.generate()
+        let runtime = consumeRuntime(
+            token: token,
+            allowedModels: []
+        )
+        var headers = HTTPHeaders()
+        headers.add(name: "Authorization", value: "Bearer \(token.value)")
+
+        let models = try response(
+            from: runtime,
+            head: HTTPRequestHead(version: .http1_1, method: .GET, uri: "/v1/models", headers: headers)
+        )
+
+        XCTAssertEqual(models.status, .ok)
+        let object = try XCTUnwrap(JSONSerialization.jsonObject(with: Data(models.body.utf8)) as? [String: Any])
+        let data = try XCTUnwrap(object["data"] as? [[String: Any]])
+        XCTAssertEqual(data.count, 0)
+    }
+
     private func localError(from body: String) throws -> [String: Any] {
         let object = try XCTUnwrap(JSONSerialization.jsonObject(with: Data(body.utf8)) as? [String: Any])
         return try XCTUnwrap(object["error"] as? [String: Any])
+    }
+
+    private func localForwardedFlag(from body: String) throws -> Bool {
+        let macprovider = try XCTUnwrap(localError(from: body)["macprovider"] as? [String: Any])
+        return try XCTUnwrap(macprovider["forwarded_upstream"] as? Bool)
     }
 
     private func writeCredential(_ value: String, under directory: URL, name: String) throws -> URL {
@@ -493,16 +852,57 @@ final class ConsumeCommandTests: XCTestCase {
         }
     }
 
+    private func consumeRuntime(
+        token: ConsumeLocalToken,
+        credentialStatus: ConsumeCredentialStatus = .missing,
+        allowedModels: [String] = ["llama-test"],
+        requestCounter: ConsumeEndpointRequestCounter = ConsumeEndpointRequestCounter()
+    ) -> ConsumeEndpointRuntime {
+        ConsumeEndpointRuntime(
+            launchID: "launch-phase2-test",
+            boundURL: "http://127.0.0.1:11435",
+            upstreamOrigin: "https://api.malibu.tech",
+            credentialSourceClass: credentialStatus.state == .loaded ? "environment" : "missing",
+            credentialStatus: credentialStatus,
+            modelAllowlist: allowedModels,
+            tokenVerifier: token.verifier,
+            requestCounter: requestCounter
+        )
+    }
+
+    private func rawConsumeChannel(runtime: ConsumeEndpointRuntime) throws -> EmbeddedChannel {
+        let channel = EmbeddedChannel()
+        try channel.pipeline.addHandler(ConsumeStartLineLimitHandler()).wait()
+        try channel.pipeline.configureHTTPServerPipeline(
+            withDecoderLimitConfiguration: ConsumeLocalLimits.httpDecoderLimitConfiguration
+        ).wait()
+        try channel.pipeline.addHandler(ConsumeLocalHandler(runtime: runtime)).wait()
+        try channel.connect(to: SocketAddress(ipAddress: "127.0.0.1", port: 11435)).wait()
+        return channel
+    }
+
+    private func writeRawRequest(_ request: String, to channel: EmbeddedChannel) throws {
+        var buffer = channel.allocator.buffer(capacity: request.utf8.count)
+        buffer.writeString(request)
+        try channel.writeInbound(buffer)
+    }
+
     private func response(
         from runtime: ConsumeEndpointRuntime,
-        head: HTTPRequestHead
+        head: HTTPRequestHead,
+        body requestBody: Data = Data()
     ) throws -> (status: HTTPResponseStatus, headers: HTTPHeaders, body: String) {
         let channel = EmbeddedChannel()
         try channel.pipeline.addHandler(ConsumeLocalHandler(runtime: runtime)).wait()
         var responseHead: HTTPResponseHead?
-        var body = Data()
+        var responseBody = Data()
 
         try channel.writeInbound(HTTPServerRequestPart.head(head))
+        if !requestBody.isEmpty {
+            var buffer = channel.allocator.buffer(capacity: requestBody.count)
+            buffer.writeBytes(requestBody)
+            try channel.writeInbound(HTTPServerRequestPart.body(buffer))
+        }
         try channel.writeInbound(HTTPServerRequestPart.end(nil))
 
         while let part = try channel.readOutbound(as: HTTPServerResponsePart.self) {
@@ -511,20 +911,20 @@ final class ConsumeCommandTests: XCTestCase {
                 responseHead = head
             case .body(.byteBuffer(var buffer)):
                 if let bytes = buffer.readBytes(length: buffer.readableBytes) {
-                    body.append(contentsOf: bytes)
+                    responseBody.append(contentsOf: bytes)
                 }
             case .end:
                 guard let responseHead else {
                     XCTFail("response head was not emitted")
                     return (.internalServerError, HTTPHeaders(), "")
                 }
-                return (responseHead.status, responseHead.headers, String(decoding: body, as: UTF8.self))
+                return (responseHead.status, responseHead.headers, String(decoding: responseBody, as: UTF8.self))
             default:
                 break
             }
         }
 
         XCTFail("response end was not emitted")
-        return (.internalServerError, HTTPHeaders(), String(decoding: body, as: UTF8.self))
+        return (.internalServerError, HTTPHeaders(), String(decoding: responseBody, as: UTF8.self))
     }
 }


### PR DESCRIPTION
## Summary

Implements the SPEC-045 Phase 2 local endpoint subset for `macprovider-cli consume` without upstream forwarding.

This PR intentionally keeps the endpoint fail-closed before proxy transport and budget admission land:

- `GET /v1/models` returns an OpenAI-compatible list from the local model allowlist, including the default empty list.
- `POST /v1/chat/completions` enforces local HTTP framing, path, browser-origin, body-size, content-encoding, and strict top-level JSON object validation, then returns `local_budget_required` locally.
- `GET /v1/status` remains local-only and `Cache-Control: no-store`.
- The production NIO pipeline now includes a pre-decoder start-line limiter for request-line and target caps, including split-buffer protection before `HTTPRequestHead` allocation.
- Runtime credential custody now retains status metadata only; loaded credential bytes are zeroized after setup and are not duplicated into the local-only endpoint runtime.

This is not full `BUILD_SPEC_045_PHASE_2_PROXY_SAFETY` or full SPEC-045 conformance. Upstream transport, connected-peer verification before upstream `Authorization`, model admission, budget ledger, response preservation, streaming proxying, and signed journey evidence remain deferred.

## Validation

- `git diff --check`
- `swift build --target macprovider-cli --skip-update --build-path /Users/augstar/macprovider-spec045-phase1/phase3-binary/.build`
- `swift test --filter ConsumeCommandTests --skip-update --build-path /Users/augstar/macprovider-spec045-phase1/phase3-binary/.build` - 27 tests passed
- `swift test --filter StrictJSONParserDepthTests --skip-update --build-path /Users/augstar/macprovider-spec045-phase1/phase3-binary/.build` - 3 tests passed
- Code/security/architecture audit lanes: 0 critical, 0 high, 0 medium findings

## Deferred

- Real upstream gateway proxying and response preservation
- Budget admission, reservations, durable ledger, and recovery UX
- Upstream-visible model intersection and chat model admission
- OpenAI SDK journey evidence against staging/production gateway

SPEC-GOVERNANCE-DECLARATION-BEGIN
{
  "schema_version": "spec-pr-governance-v1",
  "behavior_change": "yes",
  "contract_change": "none",
  "specs": ["SPEC-045"],
  "requirements": [
    "SPEC-045-R001",
    "SPEC-045-R002",
    "SPEC-045-R003",
    "SPEC-045-R004",
    "SPEC-045-R006",
    "SPEC-045-R007",
    "SPEC-045-R008"
  ],
  "authority_domains": ["local-consumer-endpoint"],
  "arbitration": ["DECISION_REQUIRED"],
  "tests": [
    "git diff --check",
    "swift build --target macprovider-cli --skip-update --build-path /Users/augstar/macprovider-spec045-phase1/phase3-binary/.build",
    "swift test --filter ConsumeCommandTests --skip-update --build-path /Users/augstar/macprovider-spec045-phase1/phase3-binary/.build",
    "swift test --filter StrictJSONParserDepthTests --skip-update --build-path /Users/augstar/macprovider-spec045-phase1/phase3-binary/.build"
  ],
  "journeys": ["not-required"],
  "issue": "https://github.com/Augustas11/macprovider/issues/927"
}
SPEC-GOVERNANCE-DECLARATION-END
