### PR TITLE
SPEC-045 Phase 3B trusted rate-card admission

### DIFF
--- a/phase3-binary/Sources/macprovider-cli/AutotuneRecommend.swift
+++ b/phase3-binary/Sources/macprovider-cli/AutotuneRecommend.swift
@@ -1058,8 +1058,8 @@ struct CandidateCatalog: Decodable, Equatable {
     ]
 }
 
-struct RateCardProjection: Decodable, Equatable {
-    struct Row: Decodable, Equatable {
+struct RateCardProjection: Decodable, Equatable, Sendable {
+    struct Row: Decodable, Equatable, Sendable {
         var promptRatePerMtok: Int64
         var promptCacheHitRatePerMtok: Int64
         var completionRatePerMtok: Int64
@@ -1135,6 +1135,9 @@ struct RateCardProjection: Decodable, Equatable {
             throw AutotuneRecommendError.invalidRateCard("version/usd_per_million_credits")
         }
         for (key, row) in rows {
+            guard Self.validRateCardModelKey(key) else {
+                throw AutotuneRecommendError.invalidRateCard("invalid model key \(key)")
+            }
             guard row.promptRatePerMtok >= 0,
                   row.promptCacheHitRatePerMtok >= 0,
                   row.completionRatePerMtok >= 0,
@@ -1149,6 +1152,30 @@ struct RateCardProjection: Decodable, Equatable {
             throw AutotuneRecommendError.invalidRateCard("version must equal projection hash")
         }
         return self
+    }
+
+    private static func validRateCardModelKey(_ key: String) -> Bool {
+        if key == "default" {
+            return true
+        }
+        let scalars = Array(key.unicodeScalars)
+        guard !scalars.isEmpty, scalars.count <= 128 else {
+            return false
+        }
+        guard Self.isLowercaseASCIILetterOrDigit(scalars[0]) else {
+            return false
+        }
+        return scalars.allSatisfy { scalar in
+            Self.isLowercaseASCIILetterOrDigit(scalar)
+                || scalar.value == 0x2e
+                || scalar.value == 0x5f
+                || scalar.value == 0x2f
+                || scalar.value == 0x2d
+        }
+    }
+
+    private static func isLowercaseASCIILetterOrDigit(_ scalar: UnicodeScalar) -> Bool {
+        (scalar.value >= 0x61 && scalar.value <= 0x7a) || (scalar.value >= 0x30 && scalar.value <= 0x39)
     }
 
     var projectionHash: String {

--- a/phase3-binary/Sources/macprovider-cli/ConsumeCommand.swift
+++ b/phase3-binary/Sources/macprovider-cli/ConsumeCommand.swift
@@ -55,6 +55,7 @@ struct ConsumeRunCommand: AsyncParsableCommand {
     var environmentForTesting: [String: String]?
     var homeDirectoryForTesting: URL?
     var startupDirectoryForTesting: URL?
+    var skipTrustedPricingLoadForTesting: Bool = false
 
     func run() async throws {
         try await run(stopAfterListeningForTesting: false)
@@ -79,6 +80,12 @@ struct ConsumeRunCommand: AsyncParsableCommand {
                 homeDirectory: homeDirectoryForTesting ?? FileManager.default.homeDirectoryForCurrentUser,
                 startupDirectory: startupDirectoryForTesting ?? URL(fileURLWithPath: FileManager.default.currentDirectoryPath, isDirectory: true)
             )
+            let trustedPricing: ConsumeTrustedPricingState
+            if budgetConfig.mode == .unconfigured || skipTrustedPricingLoadForTesting {
+                trustedPricing = .notLoaded
+            } else {
+                trustedPricing = await ConsumeTrustedPricingLoader().load(from: origin)
+            }
             var credential = try ConsumeCredentialLoader.load(
                 explicitCredentialFile: credentialFile,
                 environment: environmentForTesting ?? ProcessInfo.processInfo.environment,
@@ -110,7 +117,8 @@ struct ConsumeRunCommand: AsyncParsableCommand {
                 modelAllowlist: allowedModels,
                 tokenVerifier: token.verifier,
                 credentialCustody: credentialCustody,
-                budget: budgetConfig
+                budget: budgetConfig,
+                trustedPricing: trustedPricing
             )
             let server = ConsumeLocalServer(
                 bindAddress: normalizedBind,
@@ -405,7 +413,7 @@ struct ConsumeBudgetConfig: @unchecked Sendable {
         )
     }
 
-    func statusFields() -> [String: Any] {
+    func statusFields(trustedPricing: ConsumeTrustedPricingState = .notLoaded) -> [String: Any] {
         let summary: ConsumeBudgetLedgerSummary?
         if let ledger {
             summary = try? ledger.summary()
@@ -447,14 +455,17 @@ struct ConsumeBudgetConfig: @unchecked Sendable {
         let ledgerClass: Any = ledgerPathClass ?? NSNull()
         let ledgerState: Any = ledger == nil ? NSNull() : (ledgerIsHealthy ? "available" : "unavailable")
         let pricingState: String
+        let pricingWarnings: [String]
         if case .unconfigured = mode {
             pricingState = "unavailable"
+            pricingWarnings = []
         } else {
-            pricingState = ledgerIsHealthy ? pricingTrustState : "unavailable"
+            pricingState = ledgerIsHealthy ? pricingTrustState(trustedPricing: trustedPricing) : "unavailable"
+            pricingWarnings = ledgerIsHealthy ? pricingWarningCodes(trustedPricing: trustedPricing) : []
         }
         return [
             "pricing_trust_state": pricingState,
-            "pricing_warning_codes": pricingWarningCodes,
+            "pricing_warning_codes": pricingWarnings,
             "unpriced_override": allowUnpriced,
             "no_budget": noBudget,
             "budget_configured_micro_usd": configured,
@@ -466,13 +477,14 @@ struct ConsumeBudgetConfig: @unchecked Sendable {
         ]
     }
 
-    var pricingTrustState: String {
-        if allowUnpriced { return "unpriced_override" }
+    func pricingTrustState(trustedPricing: ConsumeTrustedPricingState) -> String {
+        if case .available = trustedPricing { return trustedPricing.statusState }
+        if allowUnpriced, case .budget = mode { return "unpriced_override" }
         return "unavailable"
     }
 
-    var pricingWarningCodes: [String] {
-        []
+    func pricingWarningCodes(trustedPricing: ConsumeTrustedPricingState) -> [String] {
+        trustedPricing.warningCodes
     }
 
     var localWarningTokens: [String] {
@@ -2034,6 +2046,8 @@ struct ConsumeEndpointRuntime: Sendable {
     let tokenVerifier: ConsumeLocalTokenVerifier
     let credentialCustody: ConsumeCredentialCustody
     let budget: ConsumeBudgetConfig
+    let trustedPricing: ConsumeTrustedPricingStore
+    let now: @Sendable () -> Date
     let requestCounter: ConsumeEndpointRequestCounter
 
     init(
@@ -2046,6 +2060,8 @@ struct ConsumeEndpointRuntime: Sendable {
         tokenVerifier: ConsumeLocalTokenVerifier,
         credentialCustody: ConsumeCredentialCustody? = nil,
         budget: ConsumeBudgetConfig = .unconfigured,
+        trustedPricing: ConsumeTrustedPricingState = .notLoaded,
+        now: @escaping @Sendable () -> Date = { Date() },
         requestCounter: ConsumeEndpointRequestCounter = ConsumeEndpointRequestCounter()
     ) {
         self.launchID = launchID
@@ -2056,6 +2072,8 @@ struct ConsumeEndpointRuntime: Sendable {
         self.tokenVerifier = tokenVerifier
         self.credentialCustody = credentialCustody ?? ConsumeCredentialCustody(status: credentialStatus)
         self.budget = budget
+        self.trustedPricing = ConsumeTrustedPricingStore(trustedPricing)
+        self.now = now
         self.requestCounter = requestCounter
     }
 
@@ -2101,10 +2119,27 @@ struct ConsumeEndpointRuntime: Sendable {
             "last_successful_upstream_contact_at": NSNull(),
             "error_ring": [],
         ]
-        for (key, value) in budget.statusFields() {
+        for (key, value) in budget.statusFields(trustedPricing: trustedPricing.revalidated(now: now())) {
             payload[key] = value
         }
         return payload
+    }
+}
+
+final class ConsumeTrustedPricingStore: @unchecked Sendable {
+    private let lock = NSLock()
+    private var state: ConsumeTrustedPricingState
+
+    init(_ state: ConsumeTrustedPricingState) {
+        self.state = state
+    }
+
+    func revalidated(now: Date) -> ConsumeTrustedPricingState {
+        lock.lock()
+        defer { lock.unlock() }
+        let revalidated = state.revalidated(now: now)
+        state = revalidated
+        return revalidated
     }
 }
 
@@ -2584,7 +2619,7 @@ final class ConsumeLocalHandler: ChannelInboundHandler, @unchecked Sendable {
                 writeLocalError(context: context, status: .badRequest, code: "local_model_not_allowed")
                 return
             }
-            writeLocalChatAdmissionFailure(context: context)
+            writeLocalChatAdmissionFailure(model: model, context: context)
         }
     }
 
@@ -2800,18 +2835,45 @@ final class ConsumeLocalHandler: ChannelInboundHandler, @unchecked Sendable {
         return parsed
     }
 
-    private func writeLocalChatAdmissionFailure(context: ChannelHandlerContext) {
+    private func writeLocalChatAdmissionFailure(model: String, context: ChannelHandlerContext) {
+        let trustedPricing = runtime.trustedPricing.revalidated(now: runtime.now())
+        let pricingMatch = trustedPricing.match(model: model)
+        let trustedPricingWarnings = trustedPricing.warningCodes(match: pricingMatch)
+        let pricingAdmitsCurrentRequest: Bool
+        if let pricingMatch {
+            pricingAdmitsCurrentRequest = pricingMatch.source != .defaultFallback
+        } else {
+            pricingAdmitsCurrentRequest = false
+        }
         switch runtime.budget.mode {
         case .unconfigured:
             writeLocalError(context: context, status: .badRequest, code: "local_budget_required")
         case .noBudget:
+            guard pricingAdmitsCurrentRequest else {
+                writeLocalError(
+                    context: context,
+                    status: .serviceUnavailable,
+                    code: "local_pricing_unavailable",
+                    extraHeaders: warningHeaders(runtime.budget.localWarningTokens)
+                )
+                return
+            }
             writeLocalError(
                 context: context,
                 status: .serviceUnavailable,
-                code: "local_pricing_unavailable",
-                extraHeaders: warningHeaders(runtime.budget.localWarningTokens)
+                code: "local_upstream_unavailable",
+                extraHeaders: warningHeaders(runtime.budget.localWarningTokens + trustedPricingWarnings)
             )
         case .budget:
+            if pricingAdmitsCurrentRequest {
+                writeLocalError(
+                    context: context,
+                    status: .serviceUnavailable,
+                    code: "local_upstream_unavailable",
+                    extraHeaders: warningHeaders(runtime.budget.localWarningTokens + trustedPricingWarnings)
+                )
+                return
+            }
             guard runtime.budget.allowUnpriced else {
                 writeLocalError(context: context, status: .serviceUnavailable, code: "local_pricing_unavailable")
                 return

--- a/phase3-binary/Sources/macprovider-cli/ConsumeTrustedPricing.swift
+++ b/phase3-binary/Sources/macprovider-cli/ConsumeTrustedPricing.swift
@@ -1,0 +1,429 @@
+import CryptoKit
+import Foundation
+
+enum ConsumeTrustedPricingUnavailableReason: String, Sendable {
+    case notLoaded = "not_loaded"
+    case fetchFailed = "fetch_failed"
+    case oversizedRateCard = "oversized_rate_card"
+    case oversizedSidecar = "oversized_sidecar"
+    case invalidSidecar = "invalid_sidecar"
+    case invalidSignature = "invalid_signature"
+    case invalidRateCard = "invalid_rate_card"
+    case policyMismatch = "policy_mismatch"
+    case olderThanBaked = "older_than_baked"
+    case futureSkew = "future_skew"
+    case expired = "expired"
+}
+
+enum ConsumeTrustedPricingState: Equatable, Sendable {
+    case unavailable(reason: ConsumeTrustedPricingUnavailableReason)
+    case available(ConsumeTrustedRateCard)
+
+    static let notLoaded = ConsumeTrustedPricingState.unavailable(reason: .notLoaded)
+
+    var statusState: String {
+        switch self {
+        case .available:
+            return "trusted"
+        case .unavailable:
+            return "unavailable"
+        }
+    }
+
+    var warningCodes: [String] {
+        switch self {
+        case .available(let rateCard):
+            return rateCard.statusWarningCodes
+        case .unavailable:
+            return []
+        }
+    }
+
+    func match(model: String) -> ConsumeTrustedRateCardMatch? {
+        switch self {
+        case .available(let rateCard):
+            return rateCard.match(model: model)
+        case .unavailable:
+            return nil
+        }
+    }
+
+    func warningCodes(match: ConsumeTrustedRateCardMatch?) -> [String] {
+        switch self {
+        case .available(let rateCard):
+            return rateCard.warningCodes(match: match)
+        case .unavailable:
+            return []
+        }
+    }
+
+    func revalidated(now: Date) -> ConsumeTrustedPricingState {
+        switch self {
+        case .available(let rateCard):
+            return rateCard.revalidated(now: now)
+        case .unavailable:
+            return self
+        }
+    }
+}
+
+struct ConsumeTrustedRateCard: Equatable, Sendable {
+    let version: String
+    let policyVersion: String
+    let generatedAt: Date
+    let signerKeyID: String
+    let projection: RateCardProjection
+    let stale: Bool
+
+    var statusWarningCodes: [String] {
+        stale ? ["stale_pricing"] : []
+    }
+
+    func match(model: String) -> ConsumeTrustedRateCardMatch? {
+        if let row = projection.rows[model] {
+            return ConsumeTrustedRateCardMatch(rateCardKey: model, row: row, source: .exact)
+        }
+        let normalized = AutotuneModelKeyNormalizer.normalize(model)
+        if normalized != model, normalized != "default", let row = projection.rows[normalized] {
+            return ConsumeTrustedRateCardMatch(rateCardKey: normalized, row: row, source: .normalized)
+        }
+        guard let row = projection.rows["default"] else {
+            return nil
+        }
+        let source: ConsumeTrustedRateCardMatch.Source = model == "default" ? .exact : .defaultFallback
+        return ConsumeTrustedRateCardMatch(rateCardKey: "default", row: row, source: source)
+    }
+
+    func warningCodes(match: ConsumeTrustedRateCardMatch?) -> [String] {
+        var warnings = statusWarningCodes
+        if match?.source == .defaultFallback {
+            warnings.append("default_pricing_tier_used")
+        }
+        return warnings
+    }
+
+    func revalidated(now current: Date) -> ConsumeTrustedPricingState {
+        guard generatedAt <= current.addingTimeInterval(ConsumeTrustedPricingLoader.maxFutureSkew) else {
+            return .unavailable(reason: .futureSkew)
+        }
+        guard current.timeIntervalSince(generatedAt) <= ConsumeTrustedPricingLoader.maxAge else {
+            return .unavailable(reason: .expired)
+        }
+        let currentlyStale = current.timeIntervalSince(generatedAt) >= ConsumeTrustedPricingLoader.staleAge
+        guard currentlyStale != stale else {
+            return .available(self)
+        }
+        return .available(ConsumeTrustedRateCard(
+            version: version,
+            policyVersion: policyVersion,
+            generatedAt: generatedAt,
+            signerKeyID: signerKeyID,
+            projection: projection,
+            stale: currentlyStale
+        ))
+    }
+}
+
+struct ConsumeTrustedRateCardMatch: Equatable, Sendable {
+    enum Source: Equatable, Sendable {
+        case exact
+        case normalized
+        case defaultFallback
+    }
+
+    let rateCardKey: String
+    let row: RateCardProjection.Row
+    let source: Source
+}
+
+struct ConsumeTrustedPricingLoader: Sendable {
+    static let maxRateCardBytes = 4 * 1024 * 1024
+    static let maxSidecarBytes = 16 * 1024
+    static let maxResponseHeaderBytes = 32 * 1024
+    static let maxResponseHeaderCount = 64
+    static let maxFutureSkew: TimeInterval = 10 * 60
+    static let staleAge: TimeInterval = 14 * 24 * 3600
+    static let maxAge: TimeInterval = 30 * 24 * 3600
+
+    var fetch: @Sendable (URL) async throws -> Data
+    var trustedPublicKeys: [String: String]
+    var expectedPolicyVersion: String
+    var minimumGeneratedAt: Date
+    var now: @Sendable () -> Date
+
+    init(
+        fetch: @escaping @Sendable (URL) async throws -> Data = { url in
+            try await ConsumeTrustedPricingLoader.defaultFetch(url)
+        },
+        trustedPublicKeys: [String: String] = AutotuneStaticInputs.defaultTrustedPublicKeys,
+        expectedPolicyVersion: String = Self.defaultExpectedPolicyVersion(),
+        minimumGeneratedAt: Date = Self.defaultMinimumGeneratedAt(),
+        now: @escaping @Sendable () -> Date = { Date() }
+    ) {
+        self.fetch = fetch
+        self.trustedPublicKeys = trustedPublicKeys
+        self.expectedPolicyVersion = expectedPolicyVersion
+        self.minimumGeneratedAt = minimumGeneratedAt
+        self.now = now
+    }
+
+    func load(from upstreamOrigin: String) async -> ConsumeTrustedPricingState {
+        guard let bodyURL = URL(string: "\(upstreamOrigin)/v1/rate-card"),
+              let sidecarURL = URL(string: "\(upstreamOrigin)/v1/rate-card.sig")
+        else {
+            return .unavailable(reason: .fetchFailed)
+        }
+        do {
+            let body = try await fetch(bodyURL)
+            guard body.count <= Self.maxRateCardBytes else {
+                return .unavailable(reason: .oversizedRateCard)
+            }
+            let sidecar = try await fetch(sidecarURL)
+            guard sidecar.count <= Self.maxSidecarBytes else {
+                return .unavailable(reason: .oversizedSidecar)
+            }
+            return try .available(verify(rateCardBytes: body, sidecarBytes: sidecar))
+        } catch let error as ConsumeTrustedPricingError {
+            return .unavailable(reason: error.reason)
+        } catch {
+            return .unavailable(reason: .fetchFailed)
+        }
+    }
+
+    func verify(rateCardBytes: Data, sidecarBytes: Data) throws -> ConsumeTrustedRateCard {
+        guard rateCardBytes.count <= Self.maxRateCardBytes else {
+            throw ConsumeTrustedPricingError(.oversizedRateCard)
+        }
+        guard sidecarBytes.count <= Self.maxSidecarBytes else {
+            throw ConsumeTrustedPricingError(.oversizedSidecar)
+        }
+        let sidecar = try parseSidecar(sidecarBytes)
+        guard signatureIsValid(rateCardBytes: rateCardBytes, sidecar: sidecar) else {
+            throw ConsumeTrustedPricingError(.invalidSignature)
+        }
+        let projection: RateCardProjection
+        do {
+            projection = try AutotuneStaticInputs.decodeRateCard(rateCardBytes)
+        } catch {
+            throw ConsumeTrustedPricingError(.invalidRateCard)
+        }
+        guard !expectedPolicyVersion.isEmpty, projection.policyVersion == expectedPolicyVersion else {
+            throw ConsumeTrustedPricingError(.policyMismatch)
+        }
+        guard projection.generatedAt >= minimumGeneratedAt else {
+            throw ConsumeTrustedPricingError(.olderThanBaked)
+        }
+        let current = now()
+        guard projection.generatedAt <= current.addingTimeInterval(Self.maxFutureSkew) else {
+            throw ConsumeTrustedPricingError(.futureSkew)
+        }
+        guard current.timeIntervalSince(projection.generatedAt) <= Self.maxAge else {
+            throw ConsumeTrustedPricingError(.expired)
+        }
+        return ConsumeTrustedRateCard(
+            version: projection.version,
+            policyVersion: projection.policyVersion,
+            generatedAt: projection.generatedAt,
+            signerKeyID: sidecar.keyID,
+            projection: projection,
+            stale: current.timeIntervalSince(projection.generatedAt) >= Self.staleAge
+        )
+    }
+
+    private static func defaultFetch(_ url: URL) async throws -> Data {
+        try await fetch(url, session: defaultURLSession())
+    }
+
+    static func defaultURLSession(protocolClasses: [AnyClass]? = nil) -> URLSession {
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.timeoutIntervalForRequest = 5
+        configuration.timeoutIntervalForResource = 10
+        configuration.requestCachePolicy = .reloadIgnoringLocalAndRemoteCacheData
+        configuration.urlCache = nil
+        configuration.httpCookieStorage = nil
+        configuration.httpCookieAcceptPolicy = .never
+        configuration.httpAdditionalHeaders = nil
+        configuration.connectionProxyDictionary = [:]
+        configuration.waitsForConnectivity = false
+        configuration.protocolClasses = protocolClasses
+        return URLSession(configuration: configuration, delegate: NoRedirectURLSessionDelegate(), delegateQueue: nil)
+    }
+
+    static func fetch(_ url: URL, session: URLSession) async throws -> Data {
+        defer { session.invalidateAndCancel() }
+        let limit = url.path.hasSuffix(".sig") ? Self.maxSidecarBytes : Self.maxRateCardBytes
+        var request = URLRequest(url: url)
+        request.httpMethod = "GET"
+        request.cachePolicy = .reloadIgnoringLocalAndRemoteCacheData
+        request.setValue("identity", forHTTPHeaderField: "Accept-Encoding")
+        let (bytes, response) = try await session.bytes(for: request)
+        guard let http = response as? HTTPURLResponse else {
+            throw ConsumeTrustedPricingError(.fetchFailed)
+        }
+        guard Self.responseHeadersAreBounded(http) else {
+            throw ConsumeTrustedPricingError(.fetchFailed)
+        }
+        guard (200 ..< 300).contains(http.statusCode) else {
+            throw ConsumeTrustedPricingError(.fetchFailed)
+        }
+        if response.expectedContentLength > Int64(limit) {
+            throw ConsumeTrustedPricingError(url.path.hasSuffix(".sig") ? .oversizedSidecar : .oversizedRateCard)
+        }
+        var data = Data()
+        data.reserveCapacity(min(limit, max(0, Int(response.expectedContentLength))))
+        for try await byte in bytes {
+            data.append(byte)
+            if data.count > limit {
+                throw ConsumeTrustedPricingError(url.path.hasSuffix(".sig") ? .oversizedSidecar : .oversizedRateCard)
+            }
+        }
+        return data
+    }
+
+    private static func defaultExpectedPolicyVersion() -> String {
+        (try? AutotuneStaticInputs.decodeRateCard(Data(AutotuneStaticInputs.bakedRateCardJSON.utf8)).policyVersion) ?? ""
+    }
+
+    private static func defaultMinimumGeneratedAt() -> Date {
+        (try? AutotuneStaticInputs.decodeRateCard(Data(AutotuneStaticInputs.bakedRateCardJSON.utf8)).generatedAt) ?? .distantFuture
+    }
+
+    private struct SignatureSidecar: Sendable {
+        let keyID: String
+        let signature: Data
+    }
+
+    private func parseSidecar(_ data: Data) throws -> SignatureSidecar {
+        var parser = FlatJSONStringObjectParser(data: data)
+        guard let object = try? parser.parse(),
+              Set(object.keys) == Set(["key_id", "alg", "signature"]),
+              let keyID = object["key_id"],
+              keyID == keyID.trimmingCharacters(in: CharacterSet.whitespacesAndNewlines),
+              !keyID.isEmpty,
+              trustedPublicKeys[keyID] != nil,
+              object["alg"] == "ed25519",
+              let encodedSignature = object["signature"],
+              let signature = Data(base64Encoded: encodedSignature),
+              signature.count == 64,
+              signature.base64EncodedString() == encodedSignature
+        else {
+            throw ConsumeTrustedPricingError(.invalidSidecar)
+        }
+        return SignatureSidecar(keyID: keyID, signature: signature)
+    }
+
+    private static func responseHeadersAreBounded(_ response: HTTPURLResponse) -> Bool {
+        guard response.allHeaderFields.count <= maxResponseHeaderCount else {
+            return false
+        }
+        var total = 0
+        for (rawName, rawValue) in response.allHeaderFields {
+            total += String(describing: rawName).utf8.count
+            total += String(describing: rawValue).utf8.count
+            if total > maxResponseHeaderBytes {
+                return false
+            }
+        }
+        return true
+    }
+
+    private func signatureIsValid(rateCardBytes: Data, sidecar: SignatureSidecar) -> Bool {
+        guard let encodedPublicKey = trustedPublicKeys[sidecar.keyID],
+              let publicKeyBytes = Data(base64Encoded: encodedPublicKey),
+              publicKeyBytes.count == 32,
+              publicKeyBytes.base64EncodedString() == encodedPublicKey,
+              let publicKey = try? Curve25519.Signing.PublicKey(rawRepresentation: publicKeyBytes)
+        else {
+            return false
+        }
+        return publicKey.isValidSignature(sidecar.signature, for: rateCardBytes)
+    }
+}
+
+private struct FlatJSONStringObjectParser {
+    private let bytes: [UInt8]
+    private var index = 0
+
+    init(data: Data) {
+        bytes = Array(data)
+    }
+
+    mutating func parse() throws -> [String: String] {
+        skipWhitespace()
+        guard consume(0x7B) else { throw ConsumeTrustedPricingError(.invalidSidecar) }
+        skipWhitespace()
+        var object: [String: String] = [:]
+        if consume(0x7D) { return object }
+        while true {
+            guard index < bytes.count, bytes[index] == 0x22 else {
+                throw ConsumeTrustedPricingError(.invalidSidecar)
+            }
+            let key = try parseString()
+            guard object[key] == nil else {
+                throw ConsumeTrustedPricingError(.invalidSidecar)
+            }
+            skipWhitespace()
+            guard consume(0x3A) else { throw ConsumeTrustedPricingError(.invalidSidecar) }
+            skipWhitespace()
+            guard index < bytes.count, bytes[index] == 0x22 else {
+                throw ConsumeTrustedPricingError(.invalidSidecar)
+            }
+            object[key] = try parseString()
+            skipWhitespace()
+            if consume(0x7D) { break }
+            guard consume(0x2C) else { throw ConsumeTrustedPricingError(.invalidSidecar) }
+            skipWhitespace()
+        }
+        skipWhitespace()
+        guard index == bytes.count else {
+            throw ConsumeTrustedPricingError(.invalidSidecar)
+        }
+        return object
+    }
+
+    private mutating func parseString() throws -> String {
+        let start = index
+        index += 1
+        var escaped = false
+        while index < bytes.count {
+            let byte = bytes[index]
+            index += 1
+            if escaped {
+                escaped = false
+                continue
+            }
+            if byte == 0x5C {
+                escaped = true
+            } else if byte == 0x22 {
+                let token = Data(bytes[start ..< index])
+                guard let decoded = try? JSONDecoder().decode(String.self, from: token) else {
+                    throw ConsumeTrustedPricingError(.invalidSidecar)
+                }
+                return decoded
+            } else if byte < 0x20 {
+                throw ConsumeTrustedPricingError(.invalidSidecar)
+            }
+        }
+        throw ConsumeTrustedPricingError(.invalidSidecar)
+    }
+
+    private mutating func skipWhitespace() {
+        while index < bytes.count, [0x20, 0x09, 0x0A, 0x0D].contains(bytes[index]) {
+            index += 1
+        }
+    }
+
+    private mutating func consume(_ byte: UInt8) -> Bool {
+        guard index < bytes.count, bytes[index] == byte else { return false }
+        index += 1
+        return true
+    }
+}
+
+struct ConsumeTrustedPricingError: Error {
+    let reason: ConsumeTrustedPricingUnavailableReason
+
+    init(_ reason: ConsumeTrustedPricingUnavailableReason) {
+        self.reason = reason
+    }
+}

--- a/phase3-binary/Tests/macprovider-cliTests/ConsumeCommandTests.swift
+++ b/phase3-binary/Tests/macprovider-cliTests/ConsumeCommandTests.swift
@@ -824,6 +824,7 @@ final class ConsumeCommandTests: XCTestCase {
         command.environmentForTesting = [:]
         command.homeDirectoryForTesting = home
         command.startupDirectoryForTesting = home
+        command.skipTrustedPricingLoadForTesting = true
 
         let capture = await captureStatusOutput {
             try await command.run(stopAfterListeningForTesting: true)
@@ -852,6 +853,227 @@ final class ConsumeCommandTests: XCTestCase {
         XCTAssertEqual(try localError(from: response.body)["code"] as? String, "local_model_not_allowed")
     }
 
+    func testPhase3BTrustedPricingAdmitsNoBudgetRequestButStillFailsClosedBeforeForwarding() throws {
+        let token = try ConsumeLocalToken.generate()
+        let trustedPricing = ConsumeTrustedPricingState.available(phase3BTrustedRateCard(generatedAt: "2026-08-01T00:00:00Z"))
+        let budget = ConsumeBudgetConfig(
+            mode: .noBudget,
+            maxRequestMicroUSD: nil,
+            allowUnpriced: false,
+            ledger: nil,
+            ledgerPathClass: nil
+        )
+        let runtime = consumeRuntime(
+            token: token,
+            budget: budget,
+            trustedPricing: trustedPricing,
+            now: { ISO8601DateFormatter.autotuneInternet.date(from: "2026-08-10T00:00:00Z")! }
+        )
+        var headers = HTTPHeaders()
+        headers.add(name: "Authorization", value: "Bearer \(token.value)")
+
+        let response = try response(
+            from: runtime,
+            head: HTTPRequestHead(version: .http1_1, method: .POST, uri: "/v1/chat/completions", headers: headers),
+            body: Data(#"{"model":"llama-test","messages":[]}"#.utf8)
+        )
+
+        XCTAssertEqual(response.status, .serviceUnavailable)
+        let error = try localError(from: response.body)
+        XCTAssertEqual(error["code"] as? String, "local_upstream_unavailable")
+        XCTAssertFalse(try localForwardedFlag(from: response.body))
+        XCTAssertEqual(response.headers.first(name: "x-macprovider-warning"), "no_budget")
+    }
+
+    func testPhase3BDefaultTierDoesNotAdmitWithoutTrustedModelVisibility() throws {
+        let token = try ConsumeLocalToken.generate()
+        let trustedPricing = ConsumeTrustedPricingState.available(phase3BTrustedRateCard(generatedAt: "2026-08-01T00:00:00Z"))
+        let budget = ConsumeBudgetConfig(
+            mode: .noBudget,
+            maxRequestMicroUSD: nil,
+            allowUnpriced: false,
+            ledger: nil,
+            ledgerPathClass: nil
+        )
+        let runtime = consumeRuntime(
+            token: token,
+            allowedModels: ["missing-but-allowed"],
+            budget: budget,
+            trustedPricing: trustedPricing,
+            now: { ISO8601DateFormatter.autotuneInternet.date(from: "2026-08-10T00:00:00Z")! }
+        )
+        var headers = HTTPHeaders()
+        headers.add(name: "Authorization", value: "Bearer \(token.value)")
+
+        let response = try response(
+            from: runtime,
+            head: HTTPRequestHead(version: .http1_1, method: .POST, uri: "/v1/chat/completions", headers: headers),
+            body: Data(#"{"model":"missing-but-allowed","messages":[]}"#.utf8)
+        )
+
+        XCTAssertEqual(response.status, .serviceUnavailable)
+        XCTAssertEqual(try localError(from: response.body)["code"] as? String, "local_pricing_unavailable")
+        XCTAssertEqual(response.headers.first(name: "x-macprovider-warning"), "no_budget")
+    }
+
+    func testPhase3BUnavailableTrustedPricingKeepsPricingUnavailableFailure() throws {
+        let token = try ConsumeLocalToken.generate()
+        let budget = ConsumeBudgetConfig(
+            mode: .noBudget,
+            maxRequestMicroUSD: nil,
+            allowUnpriced: false,
+            ledger: nil,
+            ledgerPathClass: nil
+        )
+        let runtime = consumeRuntime(
+            token: token,
+            budget: budget,
+            trustedPricing: .unavailable(reason: .invalidSignature)
+        )
+        var headers = HTTPHeaders()
+        headers.add(name: "Authorization", value: "Bearer \(token.value)")
+
+        let response = try response(
+            from: runtime,
+            head: HTTPRequestHead(version: .http1_1, method: .POST, uri: "/v1/chat/completions", headers: headers),
+            body: Data(#"{"model":"llama-test","messages":[]}"#.utf8)
+        )
+
+        XCTAssertEqual(response.status, .serviceUnavailable)
+        XCTAssertEqual(try localError(from: response.body)["code"] as? String, "local_pricing_unavailable")
+        XCTAssertEqual(response.headers.first(name: "x-macprovider-warning"), "no_budget")
+    }
+
+    func testPhase3BExpiredTrustedPricingIsDemotedAtAdmissionTime() throws {
+        let token = try ConsumeLocalToken.generate()
+        let trustedPricing = ConsumeTrustedPricingState.available(phase3BTrustedRateCard(generatedAt: "2026-08-01T00:00:00Z"))
+        let budget = ConsumeBudgetConfig(
+            mode: .noBudget,
+            maxRequestMicroUSD: nil,
+            allowUnpriced: false,
+            ledger: nil,
+            ledgerPathClass: nil
+        )
+        let runtime = consumeRuntime(
+            token: token,
+            budget: budget,
+            trustedPricing: trustedPricing,
+            now: { ISO8601DateFormatter.autotuneInternet.date(from: "2026-09-01T00:00:01Z")! }
+        )
+        var headers = HTTPHeaders()
+        headers.add(name: "Authorization", value: "Bearer \(token.value)")
+
+        let response = try response(
+            from: runtime,
+            head: HTTPRequestHead(version: .http1_1, method: .POST, uri: "/v1/chat/completions", headers: headers),
+            body: Data(#"{"model":"llama-test","messages":[]}"#.utf8)
+        )
+
+        XCTAssertEqual(response.status, .serviceUnavailable)
+        XCTAssertEqual(try localError(from: response.body)["code"] as? String, "local_pricing_unavailable")
+        XCTAssertEqual(response.headers.first(name: "x-macprovider-warning"), "no_budget")
+        XCTAssertEqual(runtime.statusPayload()["pricing_trust_state"] as? String, "unavailable")
+    }
+
+    func testPhase3BExpiredTrustedPricingStaysUnavailableAfterClockRollback() throws {
+        let token = try ConsumeLocalToken.generate()
+        let trustedPricing = ConsumeTrustedPricingState.available(phase3BTrustedRateCard(generatedAt: "2026-08-01T00:00:00Z"))
+        let budget = ConsumeBudgetConfig(
+            mode: .noBudget,
+            maxRequestMicroUSD: nil,
+            allowUnpriced: false,
+            ledger: nil,
+            ledgerPathClass: nil
+        )
+        var currentDate = ISO8601DateFormatter.autotuneInternet.date(from: "2026-09-01T00:00:01Z")!
+        let runtime = consumeRuntime(
+            token: token,
+            budget: budget,
+            trustedPricing: trustedPricing,
+            now: { currentDate }
+        )
+        var headers = HTTPHeaders()
+        headers.add(name: "Authorization", value: "Bearer \(token.value)")
+
+        let expiredResponse = try response(
+            from: runtime,
+            head: HTTPRequestHead(version: .http1_1, method: .POST, uri: "/v1/chat/completions", headers: headers),
+            body: Data(#"{"model":"llama-test","messages":[]}"#.utf8)
+        )
+        currentDate = ISO8601DateFormatter.autotuneInternet.date(from: "2026-08-10T00:00:00Z")!
+        let rolledBackResponse = try response(
+            from: runtime,
+            head: HTTPRequestHead(version: .http1_1, method: .POST, uri: "/v1/chat/completions", headers: headers),
+            body: Data(#"{"model":"llama-test","messages":[]}"#.utf8)
+        )
+
+        XCTAssertEqual(expiredResponse.status, .serviceUnavailable)
+        XCTAssertEqual(try localError(from: expiredResponse.body)["code"] as? String, "local_pricing_unavailable")
+        XCTAssertEqual(rolledBackResponse.status, .serviceUnavailable)
+        XCTAssertEqual(try localError(from: rolledBackResponse.body)["code"] as? String, "local_pricing_unavailable")
+        XCTAssertEqual(runtime.statusPayload()["pricing_trust_state"] as? String, "unavailable")
+    }
+
+    func testPhase3BStaleTrustedPricingIsMarkedAtAdmissionTime() throws {
+        let token = try ConsumeLocalToken.generate()
+        let trustedPricing = ConsumeTrustedPricingState.available(phase3BTrustedRateCard(generatedAt: "2026-08-01T00:00:00Z"))
+        let budget = ConsumeBudgetConfig(
+            mode: .noBudget,
+            maxRequestMicroUSD: nil,
+            allowUnpriced: false,
+            ledger: nil,
+            ledgerPathClass: nil
+        )
+        let runtime = consumeRuntime(
+            token: token,
+            budget: budget,
+            trustedPricing: trustedPricing,
+            now: { ISO8601DateFormatter.autotuneInternet.date(from: "2026-08-20T00:00:00Z")! }
+        )
+        var headers = HTTPHeaders()
+        headers.add(name: "Authorization", value: "Bearer \(token.value)")
+
+        let response = try response(
+            from: runtime,
+            head: HTTPRequestHead(version: .http1_1, method: .POST, uri: "/v1/chat/completions", headers: headers),
+            body: Data(#"{"model":"llama-test","messages":[]}"#.utf8)
+        )
+
+        XCTAssertEqual(response.status, .serviceUnavailable)
+        XCTAssertEqual(try localError(from: response.body)["code"] as? String, "local_upstream_unavailable")
+        XCTAssertEqual(response.headers.first(name: "x-macprovider-warning"), "no_budget,stale_pricing")
+        XCTAssertEqual(runtime.statusPayload()["pricing_warning_codes"] as? [String], ["stale_pricing"])
+    }
+
+    func testPhase3BStatusReportsTrustedPricingAvailabilityAndWarnings() throws {
+        let token = try ConsumeLocalToken.generate()
+        var trustedRateCard = phase3BTrustedRateCard(generatedAt: "2026-08-01T00:00:00Z")
+        trustedRateCard = ConsumeTrustedRateCard(
+            version: trustedRateCard.version,
+            policyVersion: trustedRateCard.policyVersion,
+            generatedAt: trustedRateCard.generatedAt,
+            signerKeyID: trustedRateCard.signerKeyID,
+            projection: trustedRateCard.projection,
+            stale: true
+        )
+        let budget = ConsumeBudgetConfig(
+            mode: .noBudget,
+            maxRequestMicroUSD: nil,
+            allowUnpriced: false,
+            ledger: nil,
+            ledgerPathClass: nil
+        )
+        let runtime = consumeRuntime(
+            token: token,
+            budget: budget,
+            trustedPricing: .available(trustedRateCard)
+        )
+        let status = runtime.statusPayload()
+
+        XCTAssertEqual(status["pricing_trust_state"] as? String, "trusted")
+        XCTAssertEqual(status["pricing_warning_codes"] as? [String], ["stale_pricing"])
+    }
+
     func testPhase3NoBudgetStatusUsesNullBudgetAmounts() throws {
         let token = try ConsumeLocalToken.generate()
         let budget = ConsumeBudgetConfig(
@@ -870,6 +1092,23 @@ final class ConsumeCommandTests: XCTestCase {
         XCTAssertTrue(status["budget_held_micro_usd"] is NSNull)
         XCTAssertTrue(status["budget_remaining_micro_usd"] is NSNull)
         XCTAssertTrue(status["pricing_warning_codes"] as? [String] == [])
+    }
+
+    func testPhase3NoBudgetStatusDoesNotTrustIneffectiveAllowUnpriced() throws {
+        let token = try ConsumeLocalToken.generate()
+        let budget = ConsumeBudgetConfig(
+            mode: .noBudget,
+            maxRequestMicroUSD: nil,
+            allowUnpriced: true,
+            ledger: nil,
+            ledgerPathClass: nil
+        )
+        let runtime = consumeRuntime(token: token, budget: budget)
+        let status = runtime.statusPayload()
+
+        XCTAssertEqual(status["no_budget"] as? Bool, true)
+        XCTAssertEqual(status["unpriced_override"] as? Bool, true)
+        XCTAssertEqual(status["pricing_trust_state"] as? String, "unavailable")
     }
 
     func testPhase3UnconfiguredStatusDoesNotTrustAllowUnpriced() throws {
@@ -1538,6 +1777,8 @@ final class ConsumeCommandTests: XCTestCase {
         credentialStatus: ConsumeCredentialStatus = .missing,
         allowedModels: [String] = ["llama-test"],
         budget: ConsumeBudgetConfig = .unconfigured,
+        trustedPricing: ConsumeTrustedPricingState = .notLoaded,
+        now: @escaping @Sendable () -> Date = { Date() },
         requestCounter: ConsumeEndpointRequestCounter = ConsumeEndpointRequestCounter()
     ) -> ConsumeEndpointRuntime {
         ConsumeEndpointRuntime(
@@ -1549,7 +1790,45 @@ final class ConsumeCommandTests: XCTestCase {
             modelAllowlist: allowedModels,
             tokenVerifier: token.verifier,
             budget: budget,
+            trustedPricing: trustedPricing,
+            now: now,
             requestCounter: requestCounter
+        )
+    }
+
+    private func phase3BTrustedRateCard(generatedAt: String) -> ConsumeTrustedRateCard {
+        let generatedDate = ISO8601DateFormatter.autotuneInternet.date(from: generatedAt)!
+        let rows: [String: RateCardProjection.Row] = [
+            "default": RateCardProjection.Row(
+                promptRatePerMtok: 500_000,
+                promptCacheHitRatePerMtok: 125_000,
+                completionRatePerMtok: 1_000_000,
+                providerShareBPS: 9_000,
+                globalMultiplierPPM: 1_000_000
+            ),
+            "llama-test": RateCardProjection.Row(
+                promptRatePerMtok: 10,
+                promptCacheHitRatePerMtok: 5,
+                completionRatePerMtok: 20,
+                providerShareBPS: 9_000,
+                globalMultiplierPPM: 1_000_000
+            ),
+        ]
+        var projection = RateCardProjection(
+            version: "",
+            policyVersion: "consume-test-policy",
+            generatedAt: generatedDate,
+            usdPerMillionCredits: 1.0,
+            rows: rows
+        )
+        projection.version = projection.projectionHash
+        return ConsumeTrustedRateCard(
+            version: projection.version,
+            policyVersion: projection.policyVersion,
+            generatedAt: generatedDate,
+            signerKeyID: "consume-test-key",
+            projection: projection,
+            stale: false
         )
     }
 

--- a/phase3-binary/Tests/macprovider-cliTests/ConsumeTrustedPricingTests.swift
+++ b/phase3-binary/Tests/macprovider-cliTests/ConsumeTrustedPricingTests.swift
@@ -1,0 +1,294 @@
+import CryptoKit
+import Foundation
+import XCTest
+@testable import macprovider_cli
+
+final class ConsumeTrustedPricingTests: XCTestCase {
+    func testValidSignedRateCardIsAdmittedAndMatchesExactNormalizedDefaultRows() throws {
+        let fixture = try SignedRateCardFixture(generatedAt: "2026-08-01T00:00:00Z")
+        let loader = fixture.loader(now: "2026-08-10T00:00:00Z")
+
+        let trusted = try loader.verify(rateCardBytes: fixture.body, sidecarBytes: fixture.sidecar)
+
+        XCTAssertEqual(trusted.policyVersion, fixture.policyVersion)
+        XCTAssertEqual(trusted.signerKeyID, fixture.keyID)
+        XCTAssertFalse(trusted.stale)
+        XCTAssertEqual(trusted.match(model: "llama-test")?.source, .exact)
+        XCTAssertEqual(trusted.match(model: "mlx-community/qwen3-32b")?.rateCardKey, "qwen3-32b")
+        XCTAssertEqual(trusted.match(model: "unknown-model")?.source, .defaultFallback)
+        XCTAssertEqual(trusted.warningCodes(match: trusted.match(model: "unknown-model")), ["default_pricing_tier_used"])
+    }
+
+    func testInvalidSidecarSignatureAndPolicyFailClosed() throws {
+        let fixture = try SignedRateCardFixture(generatedAt: "2026-08-01T00:00:00Z")
+        let loader = fixture.loader(now: "2026-08-10T00:00:00Z")
+
+        let duplicateSidecar = Data("""
+        {"key_id":"\(fixture.keyID)","key_id":"\(fixture.keyID)","alg":"ed25519","signature":"AAAA"}
+        """.utf8)
+        XCTAssertEqual(try verifyFailure(loader, body: fixture.body, sidecar: duplicateSidecar), .invalidSidecar)
+
+        var tamperedBody = fixture.body
+        tamperedBody.append(0x20)
+        XCTAssertEqual(try verifyFailure(loader, body: tamperedBody, sidecar: fixture.sidecar), .invalidSignature)
+
+        let policyMismatch = fixture.loader(now: "2026-08-10T00:00:00Z", expectedPolicyVersion: "other-policy")
+        XCTAssertEqual(try verifyFailure(policyMismatch, body: fixture.body, sidecar: fixture.sidecar), .policyMismatch)
+    }
+
+    func testNestedSidecarShapeFailsClosedWithoutRecursiveParsing() throws {
+        let fixture = try SignedRateCardFixture(generatedAt: "2026-08-01T00:00:00Z")
+        let loader = fixture.loader(now: "2026-08-10T00:00:00Z")
+        let nestedValue = String(repeating: "[", count: 256) + String(repeating: "]", count: 256)
+        let nestedSidecar = Data("""
+        {"key_id":\(nestedValue),"alg":"ed25519","signature":"AAAA"}
+        """.utf8)
+
+        XCTAssertEqual(try verifyFailure(loader, body: fixture.body, sidecar: nestedSidecar), .invalidSidecar)
+    }
+
+    func testSignedRateCardWithInvalidModelKeyFailsClosed() throws {
+        let invalidRows = SignedRateCardFixture.defaultRows.merging([
+            "Bad Key": RateCardProjection.Row(
+                promptRatePerMtok: 1,
+                promptCacheHitRatePerMtok: 1,
+                completionRatePerMtok: 1,
+                providerShareBPS: 9_000,
+                globalMultiplierPPM: 1_000_000
+            ),
+        ]) { current, _ in current }
+        let fixture = try SignedRateCardFixture(generatedAt: "2026-08-01T00:00:00Z", rows: invalidRows)
+        let loader = fixture.loader(now: "2026-08-10T00:00:00Z")
+
+        XCTAssertEqual(try verifyFailure(loader, body: fixture.body, sidecar: fixture.sidecar), .invalidRateCard)
+    }
+
+    func testFreshnessBoundariesFailClosedOrWarnWhenStale() throws {
+        let fresh = try SignedRateCardFixture(generatedAt: "2026-08-01T00:00:00Z")
+        let staleLoader = fresh.loader(now: "2026-08-20T00:00:00Z")
+        let stale = try staleLoader.verify(rateCardBytes: fresh.body, sidecarBytes: fresh.sidecar)
+        XCTAssertTrue(stale.stale)
+        XCTAssertEqual(stale.statusWarningCodes, ["stale_pricing"])
+
+        let expiredLoader = fresh.loader(now: "2026-09-01T00:00:01Z")
+        XCTAssertEqual(try verifyFailure(expiredLoader, body: fresh.body, sidecar: fresh.sidecar), .expired)
+
+        let future = try SignedRateCardFixture(generatedAt: "2026-08-01T00:11:00Z")
+        let futureLoader = future.loader(now: "2026-08-01T00:00:00Z")
+        XCTAssertEqual(try verifyFailure(futureLoader, body: future.body, sidecar: future.sidecar), .futureSkew)
+
+        let replayed = try SignedRateCardFixture(generatedAt: "2026-07-01T00:00:00Z")
+        let replayedLoader = replayed.loader(
+            now: "2026-07-10T00:00:00Z",
+            minimumGeneratedAt: SignedRateCardFixture.date("2026-07-29T08:45:00Z")
+        )
+        XCTAssertEqual(try verifyFailure(replayedLoader, body: replayed.body, sidecar: replayed.sidecar), .olderThanBaked)
+    }
+
+    func testLoaderFetchesCanonicalEndpointsAndFailsClosedWithoutFallback() async throws {
+        let fixture = try SignedRateCardFixture(generatedAt: "2026-08-01T00:00:00Z")
+        let loader = ConsumeTrustedPricingLoader(
+            fetch: { url in
+                switch url.path {
+                case "/v1/rate-card":
+                    return fixture.body
+                case "/v1/rate-card.sig":
+                    return fixture.sidecar
+                default:
+                    throw ConsumeTrustedPricingError(.fetchFailed)
+                }
+            },
+            trustedPublicKeys: fixture.trustedPublicKeys,
+            expectedPolicyVersion: fixture.policyVersion,
+            now: { SignedRateCardFixture.date("2026-08-10T00:00:00Z") }
+        )
+
+        let loaded = await loader.load(from: "https://api.example.test")
+        XCTAssertEqual(loaded, .available(try loader.verify(rateCardBytes: fixture.body, sidecarBytes: fixture.sidecar)))
+
+        let failingLoader = ConsumeTrustedPricingLoader(
+            fetch: { _ in throw ConsumeTrustedPricingError(.fetchFailed) },
+            trustedPublicKeys: fixture.trustedPublicKeys,
+            expectedPolicyVersion: fixture.policyVersion,
+            now: { SignedRateCardFixture.date("2026-08-10T00:00:00Z") }
+        )
+        let failed = await failingLoader.load(from: "https://api.example.test")
+        XCTAssertEqual(failed, .unavailable(reason: .fetchFailed))
+    }
+
+    func testDefaultFetchRejectsUnboundedHeadersStatusAndOversizedMetadata() async throws {
+        defer { ConsumeTrustedPricingMockURLProtocol.requestHandler = nil }
+        let url = URL(string: "https://api.example.test/v1/rate-card.sig")!
+
+        ConsumeTrustedPricingMockURLProtocol.requestHandler = { request in
+            XCTAssertEqual(request.value(forHTTPHeaderField: "Accept-Encoding"), "identity")
+            var headers: [String: String] = [:]
+            for index in 0 ... ConsumeTrustedPricingLoader.maxResponseHeaderCount {
+                headers["X-Test-\(index)"] = "v"
+            }
+            return Self.response(for: request, status: 200, headers: headers, data: Data())
+        }
+        let headerFailure = try await fetchFailure(url)
+        XCTAssertEqual(headerFailure, .fetchFailed)
+
+        ConsumeTrustedPricingMockURLProtocol.requestHandler = { request in
+            Self.response(
+                for: request,
+                status: 200,
+                headers: ["Content-Length": "\(ConsumeTrustedPricingLoader.maxSidecarBytes + 1)"],
+                data: Data()
+            )
+        }
+        let sizeFailure = try await fetchFailure(url)
+        XCTAssertEqual(sizeFailure, .oversizedSidecar)
+
+        ConsumeTrustedPricingMockURLProtocol.requestHandler = { request in
+            Self.response(for: request, status: 500, headers: [:], data: Data("nope".utf8))
+        }
+        let statusFailure = try await fetchFailure(url)
+        XCTAssertEqual(statusFailure, .fetchFailed)
+    }
+
+    private func verifyFailure(
+        _ loader: ConsumeTrustedPricingLoader,
+        body: Data,
+        sidecar: Data
+    ) throws -> ConsumeTrustedPricingUnavailableReason {
+        do {
+            _ = try loader.verify(rateCardBytes: body, sidecarBytes: sidecar)
+            XCTFail("verification unexpectedly succeeded")
+            return .notLoaded
+        } catch let error as ConsumeTrustedPricingError {
+            return error.reason
+        }
+    }
+
+    private func fetchFailure(_ url: URL) async throws -> ConsumeTrustedPricingUnavailableReason {
+        do {
+            let session = ConsumeTrustedPricingLoader.defaultURLSession(protocolClasses: [ConsumeTrustedPricingMockURLProtocol.self])
+            _ = try await ConsumeTrustedPricingLoader.fetch(url, session: session)
+            XCTFail("fetch unexpectedly succeeded")
+            return .notLoaded
+        } catch let error as ConsumeTrustedPricingError {
+            return error.reason
+        }
+    }
+
+    private static func response(
+        for request: URLRequest,
+        status: Int,
+        headers: [String: String],
+        data: Data
+    ) -> (HTTPURLResponse, Data) {
+        (
+            HTTPURLResponse(url: request.url!, statusCode: status, httpVersion: "HTTP/1.1", headerFields: headers)!,
+            data
+        )
+    }
+}
+
+private final class ConsumeTrustedPricingMockURLProtocol: URLProtocol {
+    static var requestHandler: ((URLRequest) throws -> (HTTPURLResponse, Data))?
+
+    override class func canInit(with request: URLRequest) -> Bool { true }
+
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+
+    override func startLoading() {
+        guard let requestHandler = Self.requestHandler else {
+            client?.urlProtocol(self, didFailWithError: URLError(.badServerResponse))
+            return
+        }
+        do {
+            let (response, data) = try requestHandler(request)
+            client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+            client?.urlProtocol(self, didLoad: data)
+            client?.urlProtocolDidFinishLoading(self)
+        } catch {
+            client?.urlProtocol(self, didFailWithError: error)
+        }
+    }
+
+    override func stopLoading() {}
+}
+
+private struct SignedRateCardFixture {
+    let keyID = "consume-test-key"
+    let policyVersion = "consume-test-policy"
+    let body: Data
+    let sidecar: Data
+    let trustedPublicKeys: [String: String]
+
+    init(generatedAt: String, rows: [String: RateCardProjection.Row]? = nil) throws {
+        let privateKey = Curve25519.Signing.PrivateKey()
+        trustedPublicKeys = [keyID: privateKey.publicKey.rawRepresentation.base64EncodedString()]
+        body = Self.rateCardBody(generatedAt: generatedAt, policyVersion: policyVersion, rows: rows ?? Self.defaultRows)
+        let signature = try privateKey.signature(for: body).base64EncodedString()
+        sidecar = Data("""
+        {"key_id":"\(keyID)","alg":"ed25519","signature":"\(signature)"}
+        """.utf8)
+    }
+
+    func loader(
+        now rawNow: String,
+        expectedPolicyVersion: String? = nil,
+        minimumGeneratedAt: Date = .distantPast
+    ) -> ConsumeTrustedPricingLoader {
+        ConsumeTrustedPricingLoader(
+            trustedPublicKeys: trustedPublicKeys,
+            expectedPolicyVersion: expectedPolicyVersion ?? policyVersion,
+            minimumGeneratedAt: minimumGeneratedAt,
+            now: { Self.date(rawNow) }
+        )
+    }
+
+    static func date(_ raw: String) -> Date {
+        ISO8601DateFormatter.autotuneInternet.date(from: raw)!
+    }
+
+    static var defaultRows: [String: RateCardProjection.Row] {
+        [
+            "default": RateCardProjection.Row(
+                promptRatePerMtok: 500_000,
+                promptCacheHitRatePerMtok: 125_000,
+                completionRatePerMtok: 1_000_000,
+                providerShareBPS: 9_000,
+                globalMultiplierPPM: 1_000_000
+            ),
+            "llama-test": RateCardProjection.Row(
+                promptRatePerMtok: 10,
+                promptCacheHitRatePerMtok: 5,
+                completionRatePerMtok: 20,
+                providerShareBPS: 9_000,
+                globalMultiplierPPM: 1_000_000
+            ),
+            "qwen3-32b": RateCardProjection.Row(
+                promptRatePerMtok: 30,
+                promptCacheHitRatePerMtok: 15,
+                completionRatePerMtok: 60,
+                providerShareBPS: 9_000,
+                globalMultiplierPPM: 1_000_000
+            ),
+        ]
+    }
+
+    private static func rateCardBody(generatedAt: String, policyVersion: String, rows: [String: RateCardProjection.Row]) -> Data {
+        let generatedDate = date(generatedAt)
+        let projection = RateCardProjection(
+            version: "",
+            policyVersion: policyVersion,
+            generatedAt: generatedDate,
+            usdPerMillionCredits: 1.0,
+            rows: rows
+        )
+        let rowsJSON = rows.keys.sorted().map { key -> String in
+            let row = rows[key]!
+            return """
+            "\(key)":{"prompt_rate_per_mtok":\(row.promptRatePerMtok),"prompt_cache_hit_rate_per_mtok":\(row.promptCacheHitRatePerMtok),"completion_rate_per_mtok":\(row.completionRatePerMtok),"provider_share_bps":\(row.providerShareBPS),"global_multiplier_ppm":\(row.globalMultiplierPPM)}
+            """
+        }.joined(separator: ",")
+        return Data("""
+        {"version":"\(projection.projectionHash)","policy_version":"\(policyVersion)","generated_at":"\(generatedAt)","usd_per_million_credits":1.0,"rows":{\(rowsJSON)}}
+        """.utf8)
+    }
+}


### PR DESCRIPTION
## Summary
- Add trusted rate-card loading for local consume mode using canonical `/v1/rate-card` plus `/v1/rate-card.sig` with SPEC-023 Ed25519 detached-sidecar verification.
- Wire trusted pricing state into local admission/status so exact or normalized signed rows admit the current non-forwarding primitive, while default fallback remains lookup-only and untrusted/unavailable pricing fails closed.
- Add fetch, freshness, replay, sidecar, model-key, admission, sticky-demotion, and status coverage for the Phase 3B slice.

## Validation
- `git diff --check origin/main...HEAD`
- `swift test --filter ConsumeCommandTests/testPhase3B --skip-update`
- `swift test --filter ConsumeTrustedPricingTests --skip-update`
- `swift test --filter Consume --skip-update` (66 tests, 0 failures)
- `swift build --target macprovider-cli --skip-update`

## Audit
Round 4 Codex gate: 0 Critical / 0 High / 0 Medium findings across code, security, and architecture lanes.

Carried LOW/INFO from security lane:
- LOW: rate-card body decoding still uses permissive `JSONDecoder`; duplicate/unknown-field exactness can be tightened in a later slice.
- LOW: trusted pricing fetch validates literal hosts but not DNS result or connected peer; impact is limited by fixed HTTPS endpoints and signature verification.
- LOW: stale-warning state can clear after local clock rollback, while expired/future-skew unavailable demotion remains terminal.
- INFO: this PR establishes trusted rate-card row visibility only; future forwarding work must add the full forwarding/settlement gate.

SPEC-GOVERNANCE-DECLARATION-BEGIN
{
  "schema_version": "spec-pr-governance-v1",
  "behavior_change": "yes",
  "contract_change": "none",
  "specs": ["SPEC-045"],
  "requirements": ["SPEC-045-R004", "SPEC-045-R006", "SPEC-045-R008"],
  "authority_domains": ["local-consumer-endpoint"],
  "arbitration": ["DECISION_REQUIRED"],
  "tests": [
    "git diff --check origin/main...HEAD",
    "swift test --filter ConsumeCommandTests/testPhase3B --skip-update",
    "swift test --filter ConsumeTrustedPricingTests --skip-update",
    "swift test --filter Consume --skip-update",
    "swift build --target macprovider-cli --skip-update"
  ],
  "journeys": ["not-required"],
  "issue": "https://github.com/Augustas11/macprovider/issues/927"
}
SPEC-GOVERNANCE-DECLARATION-END
