### PR TITLE
Reserve priced local consume exposure

### DIFF
--- a/phase3-binary/Sources/macprovider-cli/ConsumeCommand.swift
+++ b/phase3-binary/Sources/macprovider-cli/ConsumeCommand.swift
@@ -324,6 +324,114 @@ struct ConsumeMicroUSD: Equatable, Comparable, Sendable {
     }
 }
 
+struct ConsumePricedExposureEstimate: Equatable, Sendable {
+    let amount: ConsumeMicroUSD
+    let promptTokenUpperBound: Int64
+    let completionTokenUpperBound: Int64
+    let rateCardKey: String
+}
+
+enum ConsumePricedExposureEstimator {
+    static func estimate(
+        bodyByteCount: Int,
+        request: JSONValue,
+        match: ConsumeTrustedRateCardMatch,
+        projection: RateCardProjection
+    ) throws -> ConsumePricedExposureEstimate {
+        guard bodyByteCount >= 0,
+              let promptTokens = Int64(exactly: bodyByteCount),
+              let completionTokens = explicitOutputTokenBound(from: request) else {
+            throw ConsumeBudgetError(code: "local_pricing_unavailable")
+        }
+        return try estimate(
+            promptTokenUpperBound: promptTokens,
+            completionTokenUpperBound: completionTokens,
+            match: match,
+            projection: projection
+        )
+    }
+
+    static func estimate(
+        promptTokenUpperBound promptTokens: Int64,
+        completionTokenUpperBound completionTokens: Int64,
+        match: ConsumeTrustedRateCardMatch,
+        projection: RateCardProjection
+    ) throws -> ConsumePricedExposureEstimate {
+        guard promptTokens >= 0, completionTokens > 0 else {
+            throw ConsumeBudgetError(code: "local_pricing_unavailable")
+        }
+        let row = match.row
+        let prompt = try componentMicroUSD(
+            tokens: promptTokens,
+            ratePerMtok: row.promptRatePerMtok,
+            globalMultiplierPPM: row.globalMultiplierPPM,
+            usdPerMillionCredits: projection.usdPerMillionCredits
+        )
+        let completion = try componentMicroUSD(
+            tokens: completionTokens,
+            ratePerMtok: row.completionRatePerMtok,
+            globalMultiplierPPM: row.globalMultiplierPPM,
+            usdPerMillionCredits: projection.usdPerMillionCredits
+        )
+        let amount = try prompt + completion
+        guard amount > .zero else {
+            throw ConsumeBudgetError(code: "local_pricing_unavailable")
+        }
+        return ConsumePricedExposureEstimate(
+            amount: amount,
+            promptTokenUpperBound: promptTokens,
+            completionTokenUpperBound: completionTokens,
+            rateCardKey: match.rateCardKey
+        )
+    }
+
+    private static func explicitOutputTokenBound(from request: JSONValue) -> Int64? {
+        request.objectPositiveInt64("max_tokens")
+    }
+
+    private static func componentMicroUSD(
+        tokens: Int64,
+        ratePerMtok: Int64,
+        globalMultiplierPPM: Int64,
+        usdPerMillionCredits: Double
+    ) throws -> ConsumeMicroUSD {
+        guard tokens >= 0,
+              ratePerMtok >= 0,
+              globalMultiplierPPM >= 0,
+              usdPerMillionCredits.isFinite,
+              usdPerMillionCredits >= 0 else {
+            throw ConsumeBudgetError(code: "local_pricing_unavailable")
+        }
+        if tokens == 0 || ratePerMtok == 0 || globalMultiplierPPM == 0 || usdPerMillionCredits == 0 {
+            return .zero
+        }
+        guard let creditsDecimal = decimalUSDPerMillionCredits(usdPerMillionCredits) else {
+            throw ConsumeBudgetError(code: "local_pricing_unavailable")
+        }
+        let numerator = Decimal(tokens)
+            * Decimal(ratePerMtok)
+            * Decimal(globalMultiplierPPM)
+            * creditsDecimal
+        var quotient = numerator / Decimal(1_000_000_000_000 as Int64)
+        var rounded = Decimal()
+        NSDecimalRound(&rounded, &quotient, 0, .up)
+        let number = NSDecimalNumber(decimal: rounded)
+        guard number != NSDecimalNumber.notANumber,
+              number.compare(NSDecimalNumber(value: Int64.max)) != .orderedDescending,
+              number.compare(NSDecimalNumber.zero) != .orderedAscending else {
+            throw ConsumeBudgetError(code: "local_pricing_unavailable")
+        }
+        return ConsumeMicroUSD(rawValue: number.int64Value)
+    }
+
+    private static func decimalUSDPerMillionCredits(_ value: Double) -> Decimal? {
+        guard value == 1.0 else {
+            return nil
+        }
+        return Decimal(1)
+    }
+}
+
 enum ConsumeBudgetMode: Equatable, Sendable {
     case unconfigured
     case budget(ConsumeMicroUSD)
@@ -765,6 +873,41 @@ final class ConsumeBudgetLedger: @unchecked Sendable {
             reason: "upstream_proxy_not_implemented"
         )
         return .held(remaining)
+    }
+
+    func reserveAndHoldPricedEstimate(
+        runID: String,
+        budget: ConsumeMicroUSD,
+        estimate: ConsumeMicroUSD,
+        maxRequest: ConsumeMicroUSD?
+    ) throws -> ConsumeBudgetAdmissionResult {
+        lock.lock()
+        defer { lock.unlock() }
+        try requireHealthyUnlocked()
+        guard estimate > .zero else {
+            return .requestCapExceeded
+        }
+        if let maxRequest, estimate > maxRequest {
+            return .requestCapExceeded
+        }
+        let summary = try summaryUnlocked()
+        let committed = try summary.committedExposure()
+        let remaining = budget - committed
+        guard estimate <= remaining else {
+            return .budgetExceeded
+        }
+        let reservationID = try reserveUnlocked(
+            runID: runID,
+            amount: estimate,
+            reason: "priced_proxy_deferred"
+        )
+        try holdUnlocked(
+            runID: runID,
+            reservationID: reservationID,
+            amount: estimate,
+            reason: "upstream_proxy_not_implemented"
+        )
+        return .held(estimate)
     }
 
     func markHeldReservationsForRestart(excludingRunID: String) throws {
@@ -2619,7 +2762,12 @@ final class ConsumeLocalHandler: ChannelInboundHandler, @unchecked Sendable {
                 writeLocalError(context: context, status: .badRequest, code: "local_model_not_allowed")
                 return
             }
-            writeLocalChatAdmissionFailure(model: model, context: context)
+            writeLocalChatAdmissionFailure(
+                model: model,
+                request: parsed,
+                bodyByteCount: requestBody.count,
+                context: context
+            )
         }
     }
 
@@ -2835,7 +2983,7 @@ final class ConsumeLocalHandler: ChannelInboundHandler, @unchecked Sendable {
         return parsed
     }
 
-    private func writeLocalChatAdmissionFailure(model: String, context: ChannelHandlerContext) {
+    private func writeLocalChatAdmissionFailure(model: String, request: JSONValue, bodyByteCount: Int, context: ChannelHandlerContext) {
         let trustedPricing = runtime.trustedPricing.revalidated(now: runtime.now())
         let pricingMatch = trustedPricing.match(model: model)
         let trustedPricingWarnings = trustedPricing.warningCodes(match: pricingMatch)
@@ -2864,46 +3012,86 @@ final class ConsumeLocalHandler: ChannelInboundHandler, @unchecked Sendable {
                 code: "local_upstream_unavailable",
                 extraHeaders: warningHeaders(runtime.budget.localWarningTokens + trustedPricingWarnings)
             )
-        case .budget:
-            if pricingAdmitsCurrentRequest {
+        case .budget(let budget):
+            if pricingAdmitsCurrentRequest,
+               let pricingMatch,
+               case .available(let rateCard) = trustedPricing {
+                let estimate: ConsumePricedExposureEstimate
+                do {
+                    estimate = try ConsumePricedExposureEstimator.estimate(
+                        bodyByteCount: bodyByteCount,
+                        request: request,
+                        match: pricingMatch,
+                        projection: rateCard.projection
+                    )
+                } catch {
+                    if !runtime.budget.allowUnpriced {
+                        writeLocalError(context: context, status: .serviceUnavailable, code: "local_pricing_unavailable")
+                        return
+                    }
+                    return writeLocalUnpricedBudgetAdmission(budget: budget, context: context)
+                }
+                guard let ledger = runtime.budget.ledger else {
+                    writeLocalError(context: context, status: .serviceUnavailable, code: "local_budget_ledger_unavailable")
+                    return
+                }
+                do {
+                    switch try ledger.reserveAndHoldPricedEstimate(
+                        runID: runtime.launchID,
+                        budget: budget,
+                        estimate: estimate.amount,
+                        maxRequest: runtime.budget.maxRequestMicroUSD
+                    ) {
+                    case .budgetExceeded:
+                        writeLocalError(context: context, status: HTTPResponseStatus(statusCode: 402), code: "local_budget_exceeded")
+                    case .requestCapExceeded:
+                        writeLocalError(context: context, status: HTTPResponseStatus(statusCode: 402), code: "local_request_cap_exceeded")
+                    case .held:
+                        writeLocalError(
+                            context: context,
+                            status: .serviceUnavailable,
+                            code: "local_upstream_unavailable",
+                            extraHeaders: warningHeaders(runtime.budget.localWarningTokens + trustedPricingWarnings)
+                        )
+                    }
+                    return
+                } catch {
+                    writeLocalError(context: context, status: .serviceUnavailable, code: "local_budget_ledger_unavailable")
+                    return
+                }
+            } else if !runtime.budget.allowUnpriced {
+                writeLocalError(context: context, status: .serviceUnavailable, code: "local_pricing_unavailable")
+                return
+            }
+            writeLocalUnpricedBudgetAdmission(budget: budget, context: context)
+        }
+    }
+
+    private func writeLocalUnpricedBudgetAdmission(budget: ConsumeMicroUSD, context: ChannelHandlerContext) {
+        do {
+            guard let ledger = runtime.budget.ledger else {
+                writeLocalError(context: context, status: .serviceUnavailable, code: "local_budget_ledger_unavailable")
+                return
+            }
+            switch try ledger.reserveAndHoldUnpricedRemaining(
+                runID: runtime.launchID,
+                budget: budget,
+                maxRequest: runtime.budget.maxRequestMicroUSD
+            ) {
+            case .budgetExceeded:
+                writeLocalError(context: context, status: HTTPResponseStatus(statusCode: 402), code: "local_budget_exceeded")
+            case .requestCapExceeded:
+                writeLocalError(context: context, status: HTTPResponseStatus(statusCode: 402), code: "local_request_cap_exceeded")
+            case .held:
                 writeLocalError(
                     context: context,
                     status: .serviceUnavailable,
                     code: "local_upstream_unavailable",
-                    extraHeaders: warningHeaders(runtime.budget.localWarningTokens + trustedPricingWarnings)
+                    extraHeaders: warningHeaders(runtime.budget.localWarningTokens)
                 )
-                return
             }
-            guard runtime.budget.allowUnpriced else {
-                writeLocalError(context: context, status: .serviceUnavailable, code: "local_pricing_unavailable")
-                return
-            }
-            do {
-                guard let ledger = runtime.budget.ledger,
-                      case .budget(let budget) = runtime.budget.mode else {
-                    writeLocalError(context: context, status: .serviceUnavailable, code: "local_budget_ledger_unavailable")
-                    return
-                }
-                switch try ledger.reserveAndHoldUnpricedRemaining(
-                    runID: runtime.launchID,
-                    budget: budget,
-                    maxRequest: runtime.budget.maxRequestMicroUSD
-                ) {
-                case .budgetExceeded:
-                    writeLocalError(context: context, status: HTTPResponseStatus(statusCode: 402), code: "local_budget_exceeded")
-                case .requestCapExceeded:
-                    writeLocalError(context: context, status: HTTPResponseStatus(statusCode: 402), code: "local_request_cap_exceeded")
-                case .held:
-                    writeLocalError(
-                        context: context,
-                        status: .serviceUnavailable,
-                        code: "local_upstream_unavailable",
-                        extraHeaders: warningHeaders(runtime.budget.localWarningTokens)
-                    )
-                }
-            } catch {
-                writeLocalError(context: context, status: .serviceUnavailable, code: "local_budget_ledger_unavailable")
-            }
+        } catch {
+            writeLocalError(context: context, status: .serviceUnavailable, code: "local_budget_ledger_unavailable")
         }
     }
 
@@ -3078,6 +3266,15 @@ private extension JSONValue {
             return nil
         }
         return value
+    }
+
+    func objectPositiveInt64(_ key: String) -> Int64? {
+        guard case .object(let object) = self,
+              case .int(let value)? = object[key],
+              value > 0 else {
+            return nil
+        }
+        return Int64(value)
     }
 }
 

--- a/phase3-binary/Tests/macprovider-cliTests/ConsumeCommandTests.swift
+++ b/phase3-binary/Tests/macprovider-cliTests/ConsumeCommandTests.swift
@@ -2,6 +2,7 @@ import ArgumentParser
 import Darwin
 import Dispatch
 import Foundation
+import MacProviderCore
 import NIOCore
 import NIOEmbedded
 import NIOHTTP1
@@ -985,12 +986,12 @@ final class ConsumeCommandTests: XCTestCase {
             ledger: nil,
             ledgerPathClass: nil
         )
-        var currentDate = ISO8601DateFormatter.autotuneInternet.date(from: "2026-09-01T00:00:01Z")!
+        let clock = LockedTestDate(ISO8601DateFormatter.autotuneInternet.date(from: "2026-09-01T00:00:01Z")!)
         let runtime = consumeRuntime(
             token: token,
             budget: budget,
             trustedPricing: trustedPricing,
-            now: { currentDate }
+            now: { clock.now }
         )
         var headers = HTTPHeaders()
         headers.add(name: "Authorization", value: "Bearer \(token.value)")
@@ -1000,7 +1001,7 @@ final class ConsumeCommandTests: XCTestCase {
             head: HTTPRequestHead(version: .http1_1, method: .POST, uri: "/v1/chat/completions", headers: headers),
             body: Data(#"{"model":"llama-test","messages":[]}"#.utf8)
         )
-        currentDate = ISO8601DateFormatter.autotuneInternet.date(from: "2026-08-10T00:00:00Z")!
+        clock.now = ISO8601DateFormatter.autotuneInternet.date(from: "2026-08-10T00:00:00Z")!
         let rolledBackResponse = try response(
             from: runtime,
             head: HTTPRequestHead(version: .http1_1, method: .POST, uri: "/v1/chat/completions", headers: headers),
@@ -1072,6 +1073,350 @@ final class ConsumeCommandTests: XCTestCase {
 
         XCTAssertEqual(status["pricing_trust_state"] as? String, "trusted")
         XCTAssertEqual(status["pricing_warning_codes"] as? [String], ["stale_pricing"])
+    }
+
+    func testPhase3CPricedEstimateUsesGrossRatesAndRoundsUp() throws {
+        let rateCard = phase3CTrustedRateCard(
+            promptRatePerMtok: 2_000_000,
+            promptCacheHitRatePerMtok: 1,
+            completionRatePerMtok: 4_000_000,
+            providerShareBPS: 1,
+            globalMultiplierPPM: 500_000,
+            usdPerMillionCredits: 1.0
+        )
+        let match = try XCTUnwrap(rateCard.match(model: "llama-test"))
+
+        let estimate = try ConsumePricedExposureEstimator.estimate(
+            promptTokenUpperBound: 3,
+            completionTokenUpperBound: 5,
+            match: match,
+            projection: rateCard.projection
+        )
+
+        XCTAssertEqual(estimate.amount.rawValue, 13)
+        XCTAssertEqual(estimate.rateCardKey, "llama-test")
+
+        let tinyRateCard = phase3CTrustedRateCard(
+            promptRatePerMtok: 1,
+            completionRatePerMtok: 0,
+            usdPerMillionCredits: 1.0
+        )
+        let tinyMatch = try XCTUnwrap(tinyRateCard.match(model: "llama-test"))
+        let rounded = try ConsumePricedExposureEstimator.estimate(
+            promptTokenUpperBound: 1,
+            completionTokenUpperBound: 1,
+            match: tinyMatch,
+            projection: tinyRateCard.projection
+        )
+        XCTAssertEqual(rounded.amount.rawValue, 1)
+    }
+
+    func testPhase3CBudgetedTrustedPricingReservesPricedEstimateBeforeProxyDeferred() throws {
+        let token = try ConsumeLocalToken.generate()
+        let home = try makeTemporaryDirectory()
+        let ledgerURL = home.appendingPathComponent("budget.jsonl")
+        let ledger = try ConsumeBudgetLedger.open(ledgerPath: ledgerURL.path, homeDirectory: home, startupDirectory: home)
+        let trustedRateCard = phase3CTrustedRateCard(
+            promptRatePerMtok: 1_000_000,
+            completionRatePerMtok: 2_000_000,
+            usdPerMillionCredits: 1.0
+        )
+        let budget = ConsumeBudgetConfig(
+            mode: .budget(ConsumeMicroUSD(rawValue: 100_000_000)),
+            maxRequestMicroUSD: nil,
+            allowUnpriced: false,
+            ledger: ledger,
+            ledgerPathClass: ledger.pathClass
+        )
+        let runtime = consumeRuntime(
+            token: token,
+            budget: budget,
+            trustedPricing: .available(trustedRateCard),
+            now: { ConsumeCommandTests.phase3CTestNow }
+        )
+        var headers = HTTPHeaders()
+        headers.add(name: "Authorization", value: "Bearer \(token.value)")
+        let body = #"{"model":"llama-test","messages":[],"max_tokens":10}"#
+        let expected = try ConsumePricedExposureEstimator.estimate(
+            bodyByteCount: Data(body.utf8).count,
+            request: StrictJSONParser.parse(body),
+            match: XCTUnwrap(trustedRateCard.match(model: "llama-test")),
+            projection: trustedRateCard.projection
+        )
+
+        let response = try response(
+            from: runtime,
+            head: HTTPRequestHead(version: .http1_1, method: .POST, uri: "/v1/chat/completions", headers: headers),
+            body: Data(body.utf8)
+        )
+
+        XCTAssertEqual(response.status, .serviceUnavailable)
+        XCTAssertEqual(try localError(from: response.body)["code"] as? String, "local_upstream_unavailable")
+        XCTAssertNil(response.headers.first(name: "x-macprovider-warning"))
+        let summary = try ledger.summary()
+        XCTAssertEqual(summary.reserved.rawValue, 0)
+        XCTAssertEqual(summary.held.rawValue, expected.amount.rawValue)
+        XCTAssertEqual(summary.heldReservationCount, 1)
+        XCTAssertEqual(runtime.statusPayload()["budget_remaining_micro_usd"] as? String, "\(100_000_000 - expected.amount.rawValue)")
+    }
+
+    func testPhase3CPricedEstimateCapRejectsBeforeLedgerAppend() throws {
+        let token = try ConsumeLocalToken.generate()
+        let home = try makeTemporaryDirectory()
+        let ledgerURL = home.appendingPathComponent("budget.jsonl")
+        let ledger = try ConsumeBudgetLedger.open(ledgerPath: ledgerURL.path, homeDirectory: home, startupDirectory: home)
+        let trustedRateCard = phase3CTrustedRateCard(
+            promptRatePerMtok: 1_000_000,
+            completionRatePerMtok: 2_000_000,
+            usdPerMillionCredits: 1.0
+        )
+        let body = #"{"model":"llama-test","messages":[],"max_tokens":10}"#
+        let expected = try ConsumePricedExposureEstimator.estimate(
+            bodyByteCount: Data(body.utf8).count,
+            request: StrictJSONParser.parse(body),
+            match: XCTUnwrap(trustedRateCard.match(model: "llama-test")),
+            projection: trustedRateCard.projection
+        )
+        let budget = ConsumeBudgetConfig(
+            mode: .budget(ConsumeMicroUSD(rawValue: 100_000_000)),
+            maxRequestMicroUSD: ConsumeMicroUSD(rawValue: expected.amount.rawValue - 1),
+            allowUnpriced: false,
+            ledger: ledger,
+            ledgerPathClass: ledger.pathClass
+        )
+        let runtime = consumeRuntime(
+            token: token,
+            budget: budget,
+            trustedPricing: .available(trustedRateCard),
+            now: { ConsumeCommandTests.phase3CTestNow }
+        )
+        var headers = HTTPHeaders()
+        headers.add(name: "Authorization", value: "Bearer \(token.value)")
+
+        let response = try response(
+            from: runtime,
+            head: HTTPRequestHead(version: .http1_1, method: .POST, uri: "/v1/chat/completions", headers: headers),
+            body: Data(body.utf8)
+        )
+
+        XCTAssertEqual(response.status.code, 402)
+        XCTAssertEqual(try localError(from: response.body)["code"] as? String, "local_request_cap_exceeded")
+        let summary = try ledger.summary()
+        XCTAssertEqual(summary.reserved.rawValue, 0)
+        XCTAssertEqual(summary.held.rawValue, 0)
+    }
+
+    func testPhase3CDefaultPricingTierDoesNotReservePricedEstimate() throws {
+        let token = try ConsumeLocalToken.generate()
+        let home = try makeTemporaryDirectory()
+        let ledgerURL = home.appendingPathComponent("budget.jsonl")
+        let ledger = try ConsumeBudgetLedger.open(ledgerPath: ledgerURL.path, homeDirectory: home, startupDirectory: home)
+        let trustedRateCard = phase3CTrustedRateCard(
+            promptRatePerMtok: 1_000_000,
+            completionRatePerMtok: 2_000_000,
+            usdPerMillionCredits: 1.0,
+            includeModelRow: false
+        )
+        let budget = ConsumeBudgetConfig(
+            mode: .budget(ConsumeMicroUSD(rawValue: 100_000_000)),
+            maxRequestMicroUSD: nil,
+            allowUnpriced: false,
+            ledger: ledger,
+            ledgerPathClass: ledger.pathClass
+        )
+        let runtime = consumeRuntime(
+            token: token,
+            budget: budget,
+            trustedPricing: .available(trustedRateCard),
+            now: { ConsumeCommandTests.phase3CTestNow }
+        )
+        var headers = HTTPHeaders()
+        headers.add(name: "Authorization", value: "Bearer \(token.value)")
+
+        let response = try response(
+            from: runtime,
+            head: HTTPRequestHead(version: .http1_1, method: .POST, uri: "/v1/chat/completions", headers: headers),
+            body: Data(#"{"model":"llama-test","messages":[],"max_tokens":10}"#.utf8)
+        )
+
+        XCTAssertEqual(response.status, .serviceUnavailable)
+        XCTAssertEqual(try localError(from: response.body)["code"] as? String, "local_pricing_unavailable")
+        XCTAssertEqual(try ledger.summary().held.rawValue, 0)
+    }
+
+    func testPhase3COversizedOutputBoundFailsClosedBeforeLedgerAppend() throws {
+        let token = try ConsumeLocalToken.generate()
+        let home = try makeTemporaryDirectory()
+        let ledgerURL = home.appendingPathComponent("budget.jsonl")
+        let ledger = try ConsumeBudgetLedger.open(ledgerPath: ledgerURL.path, homeDirectory: home, startupDirectory: home)
+        let trustedRateCard = phase3CTrustedRateCard(
+            promptRatePerMtok: 1_000_000,
+            completionRatePerMtok: 2_000_000,
+            usdPerMillionCredits: 1.0
+        )
+        let budget = ConsumeBudgetConfig(
+            mode: .budget(ConsumeMicroUSD(rawValue: 100_000_000)),
+            maxRequestMicroUSD: nil,
+            allowUnpriced: false,
+            ledger: ledger,
+            ledgerPathClass: ledger.pathClass
+        )
+        let runtime = consumeRuntime(
+            token: token,
+            budget: budget,
+            trustedPricing: .available(trustedRateCard),
+            now: { ConsumeCommandTests.phase3CTestNow }
+        )
+        var headers = HTTPHeaders()
+        headers.add(name: "Authorization", value: "Bearer \(token.value)")
+
+        let response = try response(
+            from: runtime,
+            head: HTTPRequestHead(version: .http1_1, method: .POST, uri: "/v1/chat/completions", headers: headers),
+            body: Data(#"{"model":"llama-test","messages":[],"max_tokens":9223372036854775808}"#.utf8)
+        )
+
+        XCTAssertEqual(response.status, .serviceUnavailable)
+        XCTAssertEqual(try localError(from: response.body)["code"] as? String, "local_pricing_unavailable")
+        XCTAssertEqual(try ledger.summary().held.rawValue, 0)
+    }
+
+    func testPhase3CMaxCompletionTokensAloneFailsClosedBeforeLedgerAppend() throws {
+        let token = try ConsumeLocalToken.generate()
+        let home = try makeTemporaryDirectory()
+        let ledgerURL = home.appendingPathComponent("budget.jsonl")
+        let ledger = try ConsumeBudgetLedger.open(ledgerPath: ledgerURL.path, homeDirectory: home, startupDirectory: home)
+        let trustedRateCard = phase3CTrustedRateCard(
+            promptRatePerMtok: 1_000_000,
+            completionRatePerMtok: 2_000_000,
+            usdPerMillionCredits: 1.0
+        )
+        let budget = ConsumeBudgetConfig(
+            mode: .budget(ConsumeMicroUSD(rawValue: 100_000_000)),
+            maxRequestMicroUSD: nil,
+            allowUnpriced: false,
+            ledger: ledger,
+            ledgerPathClass: ledger.pathClass
+        )
+        let runtime = consumeRuntime(
+            token: token,
+            budget: budget,
+            trustedPricing: .available(trustedRateCard),
+            now: { ConsumeCommandTests.phase3CTestNow }
+        )
+        var headers = HTTPHeaders()
+        headers.add(name: "Authorization", value: "Bearer \(token.value)")
+
+        let response = try response(
+            from: runtime,
+            head: HTTPRequestHead(version: .http1_1, method: .POST, uri: "/v1/chat/completions", headers: headers),
+            body: Data(#"{"model":"llama-test","messages":[],"max_completion_tokens":1}"#.utf8)
+        )
+
+        XCTAssertEqual(response.status, .serviceUnavailable)
+        XCTAssertEqual(try localError(from: response.body)["code"] as? String, "local_pricing_unavailable")
+        XCTAssertEqual(try ledger.summary().held.rawValue, 0)
+    }
+
+    func testPhase3CNonUnitCreditConversionFailsClosedBeforeLedgerAppend() throws {
+        let token = try ConsumeLocalToken.generate()
+        let home = try makeTemporaryDirectory()
+        let ledgerURL = home.appendingPathComponent("budget.jsonl")
+        let ledger = try ConsumeBudgetLedger.open(ledgerPath: ledgerURL.path, homeDirectory: home, startupDirectory: home)
+        let trustedRateCard = phase3CTrustedRateCard(
+            promptRatePerMtok: 1_000_000,
+            completionRatePerMtok: 2_000_000,
+            usdPerMillionCredits: 1.5
+        )
+        let budget = ConsumeBudgetConfig(
+            mode: .budget(ConsumeMicroUSD(rawValue: 100_000_000)),
+            maxRequestMicroUSD: nil,
+            allowUnpriced: false,
+            ledger: ledger,
+            ledgerPathClass: ledger.pathClass
+        )
+        let runtime = consumeRuntime(
+            token: token,
+            budget: budget,
+            trustedPricing: .available(trustedRateCard),
+            now: { ConsumeCommandTests.phase3CTestNow }
+        )
+        var headers = HTTPHeaders()
+        headers.add(name: "Authorization", value: "Bearer \(token.value)")
+
+        let response = try response(
+            from: runtime,
+            head: HTTPRequestHead(version: .http1_1, method: .POST, uri: "/v1/chat/completions", headers: headers),
+            body: Data(#"{"model":"llama-test","messages":[],"max_tokens":10}"#.utf8)
+        )
+
+        XCTAssertEqual(response.status, .serviceUnavailable)
+        XCTAssertEqual(try localError(from: response.body)["code"] as? String, "local_pricing_unavailable")
+        XCTAssertEqual(try ledger.summary().held.rawValue, 0)
+    }
+
+    func testPhase3CMissingOutputBoundFailsClosedOrFallsBackToUnpricedOverride() throws {
+        let token = try ConsumeLocalToken.generate()
+        let home = try makeTemporaryDirectory()
+        let ledgerURL = home.appendingPathComponent("budget.jsonl")
+        let trustedRateCard = phase3CTrustedRateCard(
+            promptRatePerMtok: 1_000_000,
+            completionRatePerMtok: 2_000_000,
+            usdPerMillionCredits: 1.0
+        )
+        var headers = HTTPHeaders()
+        headers.add(name: "Authorization", value: "Bearer \(token.value)")
+        let body = #"{"model":"llama-test","messages":[]}"#
+
+        do {
+            let ledger = try ConsumeBudgetLedger.open(ledgerPath: ledgerURL.path, homeDirectory: home, startupDirectory: home)
+            let budget = ConsumeBudgetConfig(
+                mode: .budget(ConsumeMicroUSD(rawValue: 1_000_000)),
+                maxRequestMicroUSD: nil,
+                allowUnpriced: false,
+                ledger: ledger,
+                ledgerPathClass: ledger.pathClass
+            )
+            let runtime = consumeRuntime(
+                token: token,
+                budget: budget,
+                trustedPricing: .available(trustedRateCard),
+                now: { ConsumeCommandTests.phase3CTestNow }
+            )
+            let response = try response(
+                from: runtime,
+                head: HTTPRequestHead(version: .http1_1, method: .POST, uri: "/v1/chat/completions", headers: headers),
+                body: Data(body.utf8)
+            )
+            XCTAssertEqual(response.status, .serviceUnavailable)
+            XCTAssertEqual(try localError(from: response.body)["code"] as? String, "local_pricing_unavailable")
+            XCTAssertEqual(try ledger.summary().held.rawValue, 0)
+        }
+
+        let fallbackLedgerURL = home.appendingPathComponent("fallback-budget.jsonl")
+        let fallbackLedger = try ConsumeBudgetLedger.open(ledgerPath: fallbackLedgerURL.path, homeDirectory: home, startupDirectory: home)
+        let fallbackBudget = ConsumeBudgetConfig(
+            mode: .budget(ConsumeMicroUSD(rawValue: 1_000_000)),
+            maxRequestMicroUSD: nil,
+            allowUnpriced: true,
+            ledger: fallbackLedger,
+            ledgerPathClass: fallbackLedger.pathClass
+        )
+        let fallbackRuntime = consumeRuntime(
+            token: token,
+            budget: fallbackBudget,
+            trustedPricing: .available(trustedRateCard),
+            now: { ConsumeCommandTests.phase3CTestNow }
+        )
+        let fallbackResponse = try response(
+            from: fallbackRuntime,
+            head: HTTPRequestHead(version: .http1_1, method: .POST, uri: "/v1/chat/completions", headers: headers),
+            body: Data(body.utf8)
+        )
+        XCTAssertEqual(fallbackResponse.status, .serviceUnavailable)
+        XCTAssertEqual(try localError(from: fallbackResponse.body)["code"] as? String, "local_upstream_unavailable")
+        XCTAssertEqual(fallbackResponse.headers.first(name: "x-macprovider-warning"), "unpriced_override")
+        XCTAssertEqual(try fallbackLedger.summary().held.rawValue, 1_000_000)
     }
 
     func testPhase3NoBudgetStatusUsesNullBudgetAmounts() throws {
@@ -1704,6 +2049,28 @@ final class ConsumeCommandTests: XCTestCase {
         let error: Error?
     }
 
+    private final class LockedTestDate: @unchecked Sendable {
+        private let lock = NSLock()
+        private var value: Date
+
+        init(_ value: Date) {
+            self.value = value
+        }
+
+        var now: Date {
+            get {
+                lock.lock()
+                defer { lock.unlock() }
+                return value
+            }
+            set {
+                lock.lock()
+                value = newValue
+                lock.unlock()
+            }
+        }
+    }
+
     private func captureStatusOutput(_ body: () async throws -> Void) async -> CapturedStatusOutput {
         var stderr = ""
         let restore = ConsumeEndpointStatus.replaceStderrSinkForTesting { stderr += $0 }
@@ -1772,6 +2139,8 @@ final class ConsumeCommandTests: XCTestCase {
         }
     }
 
+    private static let phase3CTestNow = ISO8601DateFormatter.autotuneInternet.date(from: "2026-08-23T00:00:00Z")!
+
     private func consumeRuntime(
         token: ConsumeLocalToken,
         credentialStatus: ConsumeCredentialStatus = .missing,
@@ -1819,6 +2188,52 @@ final class ConsumeCommandTests: XCTestCase {
             policyVersion: "consume-test-policy",
             generatedAt: generatedDate,
             usdPerMillionCredits: 1.0,
+            rows: rows
+        )
+        projection.version = projection.projectionHash
+        return ConsumeTrustedRateCard(
+            version: projection.version,
+            policyVersion: projection.policyVersion,
+            generatedAt: generatedDate,
+            signerKeyID: "consume-test-key",
+            projection: projection,
+            stale: false
+        )
+    }
+
+    private func phase3CTrustedRateCard(
+        promptRatePerMtok: Int64,
+        promptCacheHitRatePerMtok: Int64? = nil,
+        completionRatePerMtok: Int64,
+        providerShareBPS: Int64 = 9_000,
+        globalMultiplierPPM: Int64 = 1_000_000,
+        usdPerMillionCredits: Double,
+        includeModelRow: Bool = true
+    ) -> ConsumeTrustedRateCard {
+        let generatedDate = ISO8601DateFormatter.autotuneInternet.date(from: "2026-08-20T00:00:00Z")!
+        var rows: [String: RateCardProjection.Row] = [
+            "default": RateCardProjection.Row(
+                promptRatePerMtok: promptRatePerMtok,
+                promptCacheHitRatePerMtok: promptCacheHitRatePerMtok,
+                completionRatePerMtok: completionRatePerMtok,
+                providerShareBPS: providerShareBPS,
+                globalMultiplierPPM: globalMultiplierPPM
+            ),
+        ]
+        if includeModelRow {
+            rows["llama-test"] = RateCardProjection.Row(
+                promptRatePerMtok: promptRatePerMtok,
+                promptCacheHitRatePerMtok: promptCacheHitRatePerMtok,
+                completionRatePerMtok: completionRatePerMtok,
+                providerShareBPS: providerShareBPS,
+                globalMultiplierPPM: globalMultiplierPPM
+            )
+        }
+        var projection = RateCardProjection(
+            version: "",
+            policyVersion: "consume-test-policy",
+            generatedAt: generatedDate,
+            usdPerMillionCredits: usdPerMillionCredits,
             rows: rows
         )
         projection.version = projection.projectionHash


### PR DESCRIPTION
## Summary

Implements SPEC-045 Phase 3C priced local admission primitives for the local consumer endpoint:

- computes conservative gross buyer-side micro-USD exposure for trusted exact/normalized rate-card matches;
- reserves and immediately holds the priced estimate in the Phase 3A ledger before returning the current deferred proxy response;
- fails closed for default-tier pricing, missing gateway-enforced output bounds, non-unit credit conversion, overflow/oversized bounds, and `max_completion_tokens`-only requests unless `--allow-unpriced` applies.

## Validation

- `swift test --filter ConsumeCommandTests/testPhase3C --skip-update`
- `swift test --filter Consume --skip-update`
- `swift build --target macprovider-cli --skip-update`
- `git diff --check origin/main...HEAD`
- Codex audit lanes: code review 0 C/H/M, security review 0 C/H/M, architecture review 0 C/H/M

SPEC-GOVERNANCE-DECLARATION-BEGIN
{
  "schema_version": "spec-pr-governance-v1",
  "behavior_change": "yes",
  "contract_change": "none",
  "specs": ["SPEC-045"],
  "requirements": ["SPEC-045-R004", "SPEC-045-R005", "SPEC-045-R008"],
  "authority_domains": ["local-consumer-endpoint"],
  "arbitration": ["DECISION_REQUIRED"],
  "tests": [
    "swift test --filter ConsumeCommandTests/testPhase3C --skip-update",
    "swift test --filter Consume --skip-update",
    "swift build --target macprovider-cli --skip-update",
    "git diff --check origin/main...HEAD",
    "Codex audit lanes: code/security/architecture 0 C/H/M"
  ],
  "journeys": ["not-required"],
  "issue": "https://github.com/Augustas11/macprovider/issues/927"
}
SPEC-GOVERNANCE-DECLARATION-END