### PR TITLE
Bound local endpoint resource admission before dispatch

### DIFF
--- a/phase3-binary/Sources/macprovider-cli/ConsumeCommand.swift
+++ b/phase3-binary/Sources/macprovider-cli/ConsumeCommand.swift
@@ -3271,7 +3271,16 @@ struct ConsumeEndpointRuntime: Sendable {
         requestCounter.releaseBodyBytes(count)
     }
 
+    func reserveUpstreamExchange(responseSpoolBytes: Int) -> ConsumeEndpointResourceReservation? {
+        requestCounter.reserveUpstreamExchange(responseSpoolBytes: responseSpoolBytes)
+    }
+
+    func releaseUpstreamExchange(_ reservation: ConsumeEndpointResourceReservation) {
+        requestCounter.releaseUpstreamExchange(reservation)
+    }
+
     func statusPayload() -> [String: Any] {
+        let resourceSnapshot = requestCounter.resourceSnapshot()
         var payload: [String: Any] = [
             "schema_version": "local_consumer_endpoint.status.v1",
             "process_launch_id": launchID,
@@ -3282,6 +3291,11 @@ struct ConsumeEndpointRuntime: Sendable {
             "model_allowlist": modelAllowlist,
             "local_auth_state": "required",
             "active_request_count": requestCounter.current(),
+            "buffered_request_body_bytes": resourceSnapshot.bufferedBodyBytes,
+            "response_spool_bytes": resourceSnapshot.responseSpoolBytes,
+            "upstream_worker_task_count": resourceSnapshot.upstreamWorkerTasks,
+            "upstream_socket_descriptor_count": resourceSnapshot.upstreamSocketDescriptors,
+            "open_streaming_response_count": resourceSnapshot.openStreamingResponses,
             "last_successful_upstream_contact_at": NSNull(),
             "error_ring": [],
         ]
@@ -3379,23 +3393,53 @@ struct ConsumeValidatedRequest {
     let endpoint: ConsumeLocalEndpoint
 }
 
+struct ConsumeEndpointResourceReservation: Sendable {
+    let responseSpoolBytes: Int
+    let upstreamWorkerTasks: Int
+    let upstreamSocketDescriptors: Int
+}
+
+struct ConsumeEndpointResourceSnapshot: Sendable {
+    let bufferedBodyBytes: Int
+    let responseSpoolBytes: Int
+    let upstreamWorkerTasks: Int
+    let upstreamSocketDescriptors: Int
+    let openStreamingResponses: Int
+}
+
 final class ConsumeEndpointRequestCounter: @unchecked Sendable {
     private let lock = NSLock()
     private let maxIncompleteConnections: Int
     private let maxActiveRequests: Int
     private let maxBufferedBodyBytes: Int
+    private let maxResponseSpoolBytes: Int
+    private let maxOpenStreamingResponses: Int
+    private let maxUpstreamWorkerTasks: Int
+    private let maxUpstreamSocketDescriptors: Int
     private var incompleteConnections = 0
     private var value = 0
     private var bufferedBodyBytes = 0
+    private var responseSpoolBytes = 0
+    private var openStreamingResponses = 0
+    private var upstreamWorkerTasks = 0
+    private var upstreamSocketDescriptors = 0
 
     init(
         maxIncompleteConnections: Int = 16,
         maxActiveRequests: Int = 32,
-        maxBufferedBodyBytes: Int = 8 * 1024 * 1024
+        maxBufferedBodyBytes: Int = 8 * 1024 * 1024,
+        maxResponseSpoolBytes: Int = 8 * 1024 * 1024,
+        maxOpenStreamingResponses: Int = 16,
+        maxUpstreamWorkerTasks: Int = 32,
+        maxUpstreamSocketDescriptors: Int = 32
     ) {
         self.maxIncompleteConnections = maxIncompleteConnections
         self.maxActiveRequests = maxActiveRequests
         self.maxBufferedBodyBytes = maxBufferedBodyBytes
+        self.maxResponseSpoolBytes = maxResponseSpoolBytes
+        self.maxOpenStreamingResponses = maxOpenStreamingResponses
+        self.maxUpstreamWorkerTasks = maxUpstreamWorkerTasks
+        self.maxUpstreamSocketDescriptors = maxUpstreamSocketDescriptors
     }
 
     func beginIncompleteConnection() -> Bool {
@@ -3449,10 +3493,63 @@ final class ConsumeEndpointRequestCounter: @unchecked Sendable {
         lock.unlock()
     }
 
+    func reserveUpstreamExchange(responseSpoolBytes count: Int) -> ConsumeEndpointResourceReservation? {
+        lock.lock()
+        defer { lock.unlock() }
+        guard count >= 0,
+              responseSpoolBytes <= maxResponseSpoolBytes - count,
+              upstreamWorkerTasks < maxUpstreamWorkerTasks,
+              upstreamSocketDescriptors < maxUpstreamSocketDescriptors else {
+            return nil
+        }
+        responseSpoolBytes += count
+        upstreamWorkerTasks += 1
+        upstreamSocketDescriptors += 1
+        return ConsumeEndpointResourceReservation(
+            responseSpoolBytes: count,
+            upstreamWorkerTasks: 1,
+            upstreamSocketDescriptors: 1
+        )
+    }
+
+    func releaseUpstreamExchange(_ reservation: ConsumeEndpointResourceReservation) {
+        lock.lock()
+        responseSpoolBytes = max(0, responseSpoolBytes - max(0, reservation.responseSpoolBytes))
+        upstreamWorkerTasks = max(0, upstreamWorkerTasks - max(0, reservation.upstreamWorkerTasks))
+        upstreamSocketDescriptors = max(0, upstreamSocketDescriptors - max(0, reservation.upstreamSocketDescriptors))
+        lock.unlock()
+    }
+
+    func beginStreamingResponse() -> Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        guard openStreamingResponses < maxOpenStreamingResponses else { return false }
+        openStreamingResponses += 1
+        return true
+    }
+
+    func endStreamingResponse() {
+        lock.lock()
+        openStreamingResponses = max(0, openStreamingResponses - 1)
+        lock.unlock()
+    }
+
     func current() -> Int {
         lock.lock()
         defer { lock.unlock() }
         return value
+    }
+
+    func resourceSnapshot() -> ConsumeEndpointResourceSnapshot {
+        lock.lock()
+        defer { lock.unlock() }
+        return ConsumeEndpointResourceSnapshot(
+            bufferedBodyBytes: bufferedBodyBytes,
+            responseSpoolBytes: responseSpoolBytes,
+            upstreamWorkerTasks: upstreamWorkerTasks,
+            upstreamSocketDescriptors: upstreamSocketDescriptors,
+            openStreamingResponses: openStreamingResponses
+        )
     }
 }
 
@@ -3662,7 +3759,9 @@ final class ConsumeLocalHandler: ChannelInboundHandler, @unchecked Sendable {
     private var connectionIsIncompletePreAuth = false
     private var requestIsActive = false
     private var reservedBodyBytes = 0
+    private var upstreamResourceReservation: ConsumeEndpointResourceReservation?
     private var upstreamForwardIsPending = false
+    private var upstreamForwardWasDispatched = false
     private var channelInactiveWhileUpstreamPending = false
     private var responseStarted = false
     private var headerDeadlineTask: Scheduled<Void>?
@@ -3747,6 +3846,10 @@ final class ConsumeLocalHandler: ChannelInboundHandler, @unchecked Sendable {
         }
         if upstreamForwardIsPending {
             channelInactiveWhileUpstreamPending = true
+            if !upstreamForwardWasDispatched {
+                releaseUpstreamResourcesIfNeeded()
+                endRequestIfNeeded()
+            }
         }
         if !upstreamForwardIsPending {
             endRequestIfNeeded()
@@ -4392,10 +4495,13 @@ final class ConsumeLocalHandler: ChannelInboundHandler, @unchecked Sendable {
         )
         let contextBox = ConsumeNIOContextBox(context)
         upstreamForwardIsPending = true
+        upstreamForwardWasDispatched = true
         runtime.upstreamClient.forwardChatCompletions(request: request, on: context.eventLoop).whenComplete { [weak self] result in
             guard let self else { return }
             defer {
+                self.releaseUpstreamResourcesIfNeeded()
                 self.upstreamForwardIsPending = false
+                self.upstreamForwardWasDispatched = false
                 self.endRequestIfNeeded()
             }
             switch result {
@@ -4435,10 +4541,13 @@ final class ConsumeLocalHandler: ChannelInboundHandler, @unchecked Sendable {
         )
         let contextBox = ConsumeNIOContextBox(context)
         upstreamForwardIsPending = true
+        upstreamForwardWasDispatched = true
         runtime.upstreamClient.forwardChatCompletions(request: request, on: context.eventLoop).whenComplete { [weak self] result in
             guard let self else { return }
             defer {
+                self.releaseUpstreamResourcesIfNeeded()
                 self.upstreamForwardIsPending = false
+                self.upstreamForwardWasDispatched = false
                 self.endRequestIfNeeded()
             }
             switch result {
@@ -4513,7 +4622,9 @@ final class ConsumeLocalHandler: ChannelInboundHandler, @unchecked Sendable {
         onSuccess: @escaping @Sendable (String) -> Bool
     ) {
         let contextBox = ConsumeNIOContextBox(context)
+        guard reserveUpstreamResources(context: contextBox.context, extraHeaders: extraHeaders) else { return }
         upstreamForwardIsPending = true
+        upstreamForwardWasDispatched = false
         channelInactiveWhileUpstreamPending = false
         runtime.upstreamClient.resolveChatCompletionsEndpoint(origin: runtime.upstreamOrigin, on: context.eventLoop).whenComplete { [weak self] result in
             guard let self else { return }
@@ -4522,10 +4633,16 @@ final class ConsumeLocalHandler: ChannelInboundHandler, @unchecked Sendable {
             case .success(let endpoint):
                 self.upstreamForwardIsPending = false
                 if !onSuccess(endpoint) {
+                    self.upstreamForwardWasDispatched = false
+                    self.releaseUpstreamResourcesIfNeeded()
                     self.endRequestIfNeeded()
                 }
             case .failure(let error):
-                defer { self.endRequestIfNeeded() }
+                defer {
+                    self.releaseUpstreamResourcesIfNeeded()
+                    self.upstreamForwardWasDispatched = false
+                    self.endRequestIfNeeded()
+                }
                 self.upstreamForwardIsPending = false
                 let failure = Self.classifyUpstreamFailure(error)
                 self.writeLocalError(
@@ -4537,6 +4654,30 @@ final class ConsumeLocalHandler: ChannelInboundHandler, @unchecked Sendable {
                 )
             }
         }
+    }
+
+    private func reserveUpstreamResources(
+        context: ChannelHandlerContext,
+        extraHeaders: [(String, String)]
+    ) -> Bool {
+        guard upstreamResourceReservation == nil,
+              let reservation = runtime.reserveUpstreamExchange(responseSpoolBytes: ConsumeLocalLimits.bodyBytes) else {
+            writeLocalError(
+                context: context,
+                status: .serviceUnavailable,
+                code: "local_endpoint_busy",
+                extraHeaders: extraHeaders
+            )
+            return false
+        }
+        upstreamResourceReservation = reservation
+        return true
+    }
+
+    private func releaseUpstreamResourcesIfNeeded() {
+        guard let reservation = upstreamResourceReservation else { return }
+        upstreamResourceReservation = nil
+        runtime.releaseUpstreamExchange(reservation)
     }
 
     private static func classifyUpstreamFailure(_ error: Error) -> ConsumeUpstreamFailureClassification {

--- a/phase3-binary/Tests/macprovider-cliTests/ConsumeCommandTests.swift
+++ b/phase3-binary/Tests/macprovider-cliTests/ConsumeCommandTests.swift
@@ -55,6 +55,23 @@ private final class ConsumeUpstreamRequestRecorder: @unchecked Sendable {
     }
 }
 
+private final class ConsumeInvocationCounter: @unchecked Sendable {
+    private let lock = NSLock()
+    private var value = 0
+
+    func increment() {
+        lock.lock()
+        value += 1
+        lock.unlock()
+    }
+
+    func snapshot() -> Int {
+        lock.lock()
+        defer { lock.unlock() }
+        return value
+    }
+}
+
 private final class ConsumeUpstreamPromiseBox: @unchecked Sendable {
     private let lock = NSLock()
     private var promise: EventLoopPromise<ConsumeUpstreamResponse>?
@@ -743,6 +760,25 @@ final class ConsumeCommandTests: XCTestCase {
         XCTAssertFalse(counter.reserveBodyBytes(1))
         counter.releaseBodyBytes(2)
         XCTAssertTrue(counter.reserveBodyBytes(1))
+        counter.releaseBodyBytes(1)
+
+        let resourceReservation = try XCTUnwrap(counter.reserveUpstreamExchange(responseSpoolBytes: ConsumeLocalLimits.bodyBytes))
+        var snapshot = counter.resourceSnapshot()
+        XCTAssertEqual(snapshot.responseSpoolBytes, ConsumeLocalLimits.bodyBytes)
+        XCTAssertEqual(snapshot.upstreamWorkerTasks, 1)
+        XCTAssertEqual(snapshot.upstreamSocketDescriptors, 1)
+        counter.releaseUpstreamExchange(resourceReservation)
+        snapshot = counter.resourceSnapshot()
+        XCTAssertEqual(snapshot.responseSpoolBytes, 0)
+        XCTAssertEqual(snapshot.upstreamWorkerTasks, 0)
+        XCTAssertEqual(snapshot.upstreamSocketDescriptors, 0)
+
+        let streamingCounter = ConsumeEndpointRequestCounter(maxOpenStreamingResponses: 1)
+        XCTAssertTrue(streamingCounter.beginStreamingResponse())
+        XCTAssertFalse(streamingCounter.beginStreamingResponse())
+        XCTAssertEqual(streamingCounter.resourceSnapshot().openStreamingResponses, 1)
+        streamingCounter.endStreamingResponse()
+        XCTAssertEqual(streamingCounter.resourceSnapshot().openStreamingResponses, 0)
     }
 
     func testPhase2PostHeaderIdleTimeoutReleasesActiveCapacity() throws {
@@ -1255,6 +1291,7 @@ final class ConsumeCommandTests: XCTestCase {
             ledgerPathClass: ledger.pathClass
         )
         let recorder = ConsumeUpstreamRequestRecorder()
+        let counter = ConsumeEndpointRequestCounter()
         let upstreamClient = ConsumeStubUpstreamClient { request, eventLoop in
             recorder.append(request)
             return eventLoop.makeFailedFuture(ConsumeUpstreamForwardError.dispatchedUnavailable)
@@ -1265,6 +1302,8 @@ final class ConsumeCommandTests: XCTestCase {
             trustedPricing: .available(trustedRateCard),
             upstreamClient: upstreamClient,
             now: { ConsumeCommandTests.phase3CTestNow }
+            ,
+            requestCounter: counter
         )
         var headers = HTTPHeaders()
         headers.add(name: "Authorization", value: "Bearer \(token.value)")
@@ -1351,6 +1390,7 @@ final class ConsumeCommandTests: XCTestCase {
             ledgerPathClass: ledger.pathClass
         )
         let recorder = ConsumeUpstreamRequestRecorder()
+        let counter = ConsumeEndpointRequestCounter()
         let upstreamClient = ConsumeStubUpstreamClient { request, eventLoop in
             recorder.append(request)
             return eventLoop.makeFailedFuture(ConsumeUpstreamForwardError.dispatchedUnavailable)
@@ -1362,7 +1402,8 @@ final class ConsumeCommandTests: XCTestCase {
             budget: budget,
             trustedPricing: .available(trustedRateCard),
             upstreamClient: upstreamClient,
-            now: { ConsumeCommandTests.phase3CTestNow }
+            now: { ConsumeCommandTests.phase3CTestNow },
+            requestCounter: counter
         )
         var headers = HTTPHeaders()
         headers.add(name: "Authorization", value: "Bearer \(token.value)")
@@ -1388,6 +1429,10 @@ final class ConsumeCommandTests: XCTestCase {
         XCTAssertEqual(summary.reserved.rawValue, 0)
         XCTAssertEqual(summary.held.rawValue, expected.amount.rawValue)
         XCTAssertEqual(summary.heldReservationCount, 1)
+        let resourceSnapshot = counter.resourceSnapshot()
+        XCTAssertEqual(resourceSnapshot.responseSpoolBytes, 0)
+        XCTAssertEqual(resourceSnapshot.upstreamWorkerTasks, 0)
+        XCTAssertEqual(resourceSnapshot.upstreamSocketDescriptors, 0)
     }
 
     func testPhase3DPreDispatchTransportFailureSettlesReservationToZero() throws {
@@ -1408,6 +1453,7 @@ final class ConsumeCommandTests: XCTestCase {
             ledgerPathClass: ledger.pathClass
         )
         let recorder = ConsumeUpstreamRequestRecorder()
+        let counter = ConsumeEndpointRequestCounter()
         let upstreamClient = ConsumeStubUpstreamClient { request, eventLoop in
             recorder.append(request)
             return eventLoop.makeFailedFuture(ConsumeUpstreamForwardError.preDispatchUnavailable)
@@ -1419,7 +1465,8 @@ final class ConsumeCommandTests: XCTestCase {
             budget: budget,
             trustedPricing: .available(trustedRateCard),
             upstreamClient: upstreamClient,
-            now: { ConsumeCommandTests.phase3CTestNow }
+            now: { ConsumeCommandTests.phase3CTestNow },
+            requestCounter: counter
         )
         var headers = HTTPHeaders()
         headers.add(name: "Authorization", value: "Bearer \(token.value)")
@@ -1439,6 +1486,10 @@ final class ConsumeCommandTests: XCTestCase {
         XCTAssertEqual(summary.held.rawValue, 0)
         XCTAssertEqual(summary.settled.rawValue, 0)
         XCTAssertEqual(summary.heldReservationCount, 0)
+        let resourceSnapshot = counter.resourceSnapshot()
+        XCTAssertEqual(resourceSnapshot.responseSpoolBytes, 0)
+        XCTAssertEqual(resourceSnapshot.upstreamWorkerTasks, 0)
+        XCTAssertEqual(resourceSnapshot.upstreamSocketDescriptors, 0)
     }
 
     func testPhase3DSendFailureIsPreDispatch() throws {
@@ -1468,6 +1519,7 @@ final class ConsumeCommandTests: XCTestCase {
             ledgerPathClass: ledger.pathClass
         )
         let recorder = ConsumeUpstreamRequestRecorder()
+        let counter = ConsumeEndpointRequestCounter()
         let upstreamClient = ConsumeStubUpstreamClient(
             resolver: { _, eventLoop in
                 eventLoop.makeFailedFuture(ConsumeUpstreamForwardError.preDispatchUnavailable)
@@ -1484,7 +1536,8 @@ final class ConsumeCommandTests: XCTestCase {
             budget: budget,
             trustedPricing: .available(trustedRateCard),
             upstreamClient: upstreamClient,
-            now: { ConsumeCommandTests.phase3CTestNow }
+            now: { ConsumeCommandTests.phase3CTestNow },
+            requestCounter: counter
         )
         var headers = HTTPHeaders()
         headers.add(name: "Authorization", value: "Bearer \(token.value)")
@@ -1504,6 +1557,163 @@ final class ConsumeCommandTests: XCTestCase {
         XCTAssertEqual(summary.held.rawValue, 0)
         XCTAssertEqual(summary.settled.rawValue, 0)
         XCTAssertEqual(summary.heldReservationCount, 0)
+        let resourceSnapshot = counter.resourceSnapshot()
+        XCTAssertEqual(resourceSnapshot.responseSpoolBytes, 0)
+        XCTAssertEqual(resourceSnapshot.upstreamWorkerTasks, 0)
+        XCTAssertEqual(resourceSnapshot.upstreamSocketDescriptors, 0)
+    }
+
+    func testPhase3EAggregateUpstreamResourceLimitsRejectBeforeResolverLedgerAndForwarding() throws {
+        let token = try ConsumeLocalToken.generate()
+        let trustedRateCard = phase3CTrustedRateCard(
+            promptRatePerMtok: 1_000_000,
+            completionRatePerMtok: 2_000_000,
+            usdPerMillionCredits: 1.0
+        )
+        let cases: [(name: String, counter: ConsumeEndpointRequestCounter)] = [
+            ("worker", ConsumeEndpointRequestCounter(maxUpstreamWorkerTasks: 0)),
+            ("socket", ConsumeEndpointRequestCounter(maxUpstreamSocketDescriptors: 0)),
+            ("spool", ConsumeEndpointRequestCounter(maxResponseSpoolBytes: ConsumeLocalLimits.bodyBytes - 1)),
+        ]
+        var headers = HTTPHeaders()
+        headers.add(name: "Authorization", value: "Bearer \(token.value)")
+        let body = Data(#"{"model":"llama-test","messages":[],"max_tokens":10}"#.utf8)
+
+        for testCase in cases {
+            let home = try makeTemporaryDirectory()
+            let ledgerURL = home.appendingPathComponent("budget-\(testCase.name).jsonl")
+            let ledger = try ConsumeBudgetLedger.open(ledgerPath: ledgerURL.path, homeDirectory: home, startupDirectory: home)
+            let budget = ConsumeBudgetConfig(
+                mode: .budget(ConsumeMicroUSD(rawValue: 100_000_000)),
+                maxRequestMicroUSD: nil,
+                allowUnpriced: false,
+                ledger: ledger,
+                ledgerPathClass: ledger.pathClass
+            )
+            let resolverCalls = ConsumeInvocationCounter()
+            let recorder = ConsumeUpstreamRequestRecorder()
+            let upstreamClient = ConsumeStubUpstreamClient(
+                resolver: { _, eventLoop in
+                    resolverCalls.increment()
+                    return eventLoop.makeSucceededFuture("8.8.8.8")
+                },
+                handler: { request, eventLoop in
+                    recorder.append(request)
+                    return eventLoop.makeFailedFuture(ConsumeUpstreamForwardError.dispatchedUnavailable)
+                }
+            )
+            let runtime = consumeRuntime(
+                token: token,
+                budget: budget,
+                trustedPricing: .available(trustedRateCard),
+                upstreamClient: upstreamClient,
+                now: { ConsumeCommandTests.phase3CTestNow },
+                requestCounter: testCase.counter
+            )
+
+            let response = try response(
+                from: runtime,
+                head: HTTPRequestHead(version: .http1_1, method: .POST, uri: "/v1/chat/completions", headers: headers),
+                body: body
+            )
+
+            XCTAssertEqual(response.status, .serviceUnavailable, testCase.name)
+            XCTAssertEqual(try localError(from: response.body)["code"] as? String, "local_endpoint_busy", testCase.name)
+            XCTAssertFalse(try localForwardedFlag(from: response.body), testCase.name)
+            XCTAssertEqual(resolverCalls.snapshot(), 0, testCase.name)
+            XCTAssertEqual(recorder.snapshot().count, 0, testCase.name)
+            let summary = try ledger.summary()
+            XCTAssertEqual(summary.reserved.rawValue, 0, testCase.name)
+            XCTAssertEqual(summary.held.rawValue, 0, testCase.name)
+            XCTAssertEqual(summary.settled.rawValue, 0, testCase.name)
+            XCTAssertEqual(summary.heldReservationCount, 0, testCase.name)
+        }
+    }
+
+    func testPhase3EUpstreamResourceReservationsAreHeldWhileForwardingAndReleasedAfterSuccess() throws {
+        let token = try ConsumeLocalToken.generate()
+        let trustedRateCard = phase3CTrustedRateCard(
+            promptRatePerMtok: 1_000_000,
+            completionRatePerMtok: 2_000_000,
+            usdPerMillionCredits: 1.0
+        )
+        let budget = ConsumeBudgetConfig(
+            mode: .noBudget,
+            maxRequestMicroUSD: nil,
+            allowUnpriced: false,
+            ledger: nil,
+            ledgerPathClass: nil
+        )
+        let counter = ConsumeEndpointRequestCounter(
+            maxResponseSpoolBytes: ConsumeLocalLimits.bodyBytes,
+            maxUpstreamWorkerTasks: 1,
+            maxUpstreamSocketDescriptors: 1
+        )
+        let pendingPromise = ConsumeUpstreamPromiseBox()
+        let recorder = ConsumeUpstreamRequestRecorder()
+        let upstreamClient = ConsumeStubUpstreamClient { request, eventLoop in
+            recorder.append(request)
+            let promise = eventLoop.makePromise(of: ConsumeUpstreamResponse.self)
+            pendingPromise.set(promise)
+            return promise.futureResult
+        }
+        let runtime = consumeRuntime(
+            token: token,
+            credentialStatus: .environmentLoaded,
+            credentialCustody: consumeCredentialCustody("buyer-token"),
+            budget: budget,
+            trustedPricing: .available(trustedRateCard),
+            upstreamClient: upstreamClient,
+            now: { ConsumeCommandTests.phase3CTestNow },
+            requestCounter: counter
+        )
+        var headers = HTTPHeaders()
+        headers.add(name: "Authorization", value: "Bearer \(token.value)")
+        let body = Data(#"{"model":"llama-test","messages":[],"max_tokens":10}"#.utf8)
+
+        let firstChannel = EmbeddedChannel()
+        try firstChannel.pipeline.addHandler(ConsumeLocalHandler(runtime: runtime)).wait()
+        try firstChannel.writeInbound(HTTPServerRequestPart.head(
+            HTTPRequestHead(version: .http1_1, method: .POST, uri: "/v1/chat/completions", headers: headers)
+        ))
+        var firstBuffer = firstChannel.allocator.buffer(capacity: body.count)
+        firstBuffer.writeBytes(body)
+        try firstChannel.writeInbound(HTTPServerRequestPart.body(firstBuffer))
+        try firstChannel.writeInbound(HTTPServerRequestPart.end(nil))
+        firstChannel.embeddedEventLoop.run()
+
+        XCTAssertEqual(recorder.snapshot().count, 1)
+        var snapshot = counter.resourceSnapshot()
+        XCTAssertEqual(snapshot.responseSpoolBytes, ConsumeLocalLimits.bodyBytes)
+        XCTAssertEqual(snapshot.upstreamWorkerTasks, 1)
+        XCTAssertEqual(snapshot.upstreamSocketDescriptors, 1)
+        let status = runtime.statusPayload()
+        XCTAssertEqual(status["response_spool_bytes"] as? Int, ConsumeLocalLimits.bodyBytes)
+        XCTAssertEqual(status["upstream_worker_task_count"] as? Int, 1)
+        XCTAssertEqual(status["upstream_socket_descriptor_count"] as? Int, 1)
+
+        let saturated = try response(
+            from: runtime,
+            head: HTTPRequestHead(version: .http1_1, method: .POST, uri: "/v1/chat/completions", headers: headers),
+            body: body
+        )
+        XCTAssertEqual(saturated.status, .serviceUnavailable)
+        XCTAssertEqual(try localError(from: saturated.body)["code"] as? String, "local_endpoint_busy")
+        XCTAssertFalse(try localForwardedFlag(from: saturated.body))
+        XCTAssertEqual(recorder.snapshot().count, 1)
+
+        pendingPromise.succeed(ConsumeUpstreamResponse(
+            statusCode: 200,
+            headers: [("content-type", "application/json")],
+            body: Data(#"{"usage":{"prompt_tokens":1,"completion_tokens":1}}"#.utf8)
+        ))
+        firstChannel.embeddedEventLoop.run()
+        let forwarded = try drainResponse(from: firstChannel)
+        XCTAssertEqual(forwarded.status, .ok)
+        snapshot = counter.resourceSnapshot()
+        XCTAssertEqual(snapshot.responseSpoolBytes, 0)
+        XCTAssertEqual(snapshot.upstreamWorkerTasks, 0)
+        XCTAssertEqual(snapshot.upstreamSocketDescriptors, 0)
     }
 
     func testPhase3DForwardingKeepsActiveCapacityUntilUpstreamCompletes() throws {
@@ -1592,6 +1802,11 @@ final class ConsumeCommandTests: XCTestCase {
         )
         let endpointPromise = ConsumeEndpointPromiseBox()
         let recorder = ConsumeUpstreamRequestRecorder()
+        let counter = ConsumeEndpointRequestCounter(
+            maxResponseSpoolBytes: ConsumeLocalLimits.bodyBytes,
+            maxUpstreamWorkerTasks: 1,
+            maxUpstreamSocketDescriptors: 1
+        )
         let upstreamClient = ConsumeStubUpstreamClient(
             resolver: { _, eventLoop in
                 let promise = eventLoop.makePromise(of: String.self)
@@ -1608,7 +1823,8 @@ final class ConsumeCommandTests: XCTestCase {
             budget: budget,
             trustedPricing: .available(trustedRateCard),
             upstreamClient: upstreamClient,
-            now: { ConsumeCommandTests.phase3CTestNow }
+            now: { ConsumeCommandTests.phase3CTestNow },
+            requestCounter: counter
         )
         let channel = EmbeddedChannel()
         try channel.pipeline.addHandler(ConsumeLocalHandler(runtime: runtime)).wait()
@@ -1625,13 +1841,28 @@ final class ConsumeCommandTests: XCTestCase {
         try channel.writeInbound(HTTPServerRequestPart.end(nil))
         channel.embeddedEventLoop.run()
         XCTAssertEqual(runtime.statusPayload()["active_request_count"] as? Int, 1)
+        var resourceSnapshot = counter.resourceSnapshot()
+        XCTAssertEqual(resourceSnapshot.responseSpoolBytes, ConsumeLocalLimits.bodyBytes)
+        XCTAssertEqual(resourceSnapshot.upstreamWorkerTasks, 1)
+        XCTAssertEqual(resourceSnapshot.upstreamSocketDescriptors, 1)
 
         try channel.close().wait()
+        channel.embeddedEventLoop.run()
+        XCTAssertEqual(runtime.statusPayload()["active_request_count"] as? Int, 0)
+        resourceSnapshot = counter.resourceSnapshot()
+        XCTAssertEqual(resourceSnapshot.responseSpoolBytes, 0)
+        XCTAssertEqual(resourceSnapshot.upstreamWorkerTasks, 0)
+        XCTAssertEqual(resourceSnapshot.upstreamSocketDescriptors, 0)
+
         endpointPromise.succeed("8.8.8.8")
         channel.embeddedEventLoop.run()
 
         XCTAssertEqual(runtime.statusPayload()["active_request_count"] as? Int, 0)
         XCTAssertEqual(recorder.snapshot().count, 0)
+        resourceSnapshot = counter.resourceSnapshot()
+        XCTAssertEqual(resourceSnapshot.responseSpoolBytes, 0)
+        XCTAssertEqual(resourceSnapshot.upstreamWorkerTasks, 0)
+        XCTAssertEqual(resourceSnapshot.upstreamSocketDescriptors, 0)
         let summary = try ledger.summary()
         XCTAssertEqual(summary.reserved.rawValue, 0)
         XCTAssertEqual(summary.held.rawValue, 0)

--- a/specs/design/spec-045/BUILD_SPEC_045_LOCAL_CONSUMER_ENDPOINT_IMPL.md
+++ b/specs/design/spec-045/BUILD_SPEC_045_LOCAL_CONSUMER_ENDPOINT_IMPL.md
@@ -18,7 +18,9 @@ Ship `macprovider-cli consume` as a local development adapter: a macOS loopback-
    - trusted pricing, conservative estimate math, chargeable proxy admission, settlement, `estimate_exceeded`, and restart/shutdown behavior.
 5. `BUILD_SPEC_045_PHASE_3D_UPSTREAM_FORWARDING_SETTLEMENT.md`
    - non-streaming upstream forwarding, pinned dispatch, durable reservation settlement, failure provenance, and Phase 3D transport hardening.
-6. `BUILD_SPEC_045_PHASE_4_CONFORMANCE_JOURNEY.md`
+6. `BUILD_SPEC_045_PHASE_3E_RESOURCE_ACCOUNTING.md`
+   - aggregate response-spool, upstream worker-task, upstream socket/file-descriptor, and streaming-response slot admission.
+7. `BUILD_SPEC_045_PHASE_4_CONFORMANCE_JOURNEY.md`
    - required automated coverage, fake-gateway integration harness, staging/production signed journey, and promotion evidence.
 
 ## Required sequencing
@@ -28,6 +30,7 @@ Ship `macprovider-cli consume` as a local development adapter: a macOS loopback-
 - Phase 3A must not forward chargeable requests; it only establishes fail-closed local budget-ledger foundations.
 - Phase 3 must not forward chargeable requests until durable reservation append and conservative pricing admission are implemented.
 - Phase 3D may land without streaming/SSE forwarding, aggregate response-spool/socket admission, compressed non-streaming decode-to-identity, or mutable upstream invalid-credential state; those remain required before Phase 4 can claim conformance.
+- Phase 3E may land without streaming/SSE forwarding, compressed non-streaming decode-to-identity, or mutable upstream invalid-credential state; those remain required before Phase 4 can claim conformance.
 - Phase 4 must not claim production readiness until Phases 1-3 are implemented and the signed real-gateway journey exists.
 
 ## Non-goals

--- a/specs/design/spec-045/BUILD_SPEC_045_PHASE_3E_RESOURCE_ACCOUNTING.md
+++ b/specs/design/spec-045/BUILD_SPEC_045_PHASE_3E_RESOURCE_ACCOUNTING.md
@@ -1,0 +1,96 @@
+# BUILD_SPEC_045_PHASE_3E_RESOURCE_ACCOUNTING
+
+Implement aggregate local endpoint resource admission for SPEC-045 after the
+first non-streaming upstream forwarding path exists. This slice owns bounded
+accounting primitives for upstream response spooling, upstream worker tasks,
+upstream socket/file-descriptor reservations, and streaming-response slots.
+
+This is a build slice, not a production-conformance declaration. Streaming
+forwarding, compressed decode-to-identity, mutable invalid-credential state,
+and fake/real gateway journeys remain later work.
+
+## Target Result
+
+Chargeable local endpoint requests that would exceed aggregate local endpoint
+resource capacity fail locally as `local_endpoint_busy` before upstream
+resolution, upstream credential use, durable ledger reservation, or upstream
+forwarding. Accepted non-streaming upstream exchanges hold conservative
+resource reservations until the upstream outcome is complete and the local
+request can release active capacity.
+
+## Required Implementation Shape
+
+1. Extend the existing local endpoint request counter instead of adding a
+   second resource subsystem:
+   - keep the existing incomplete-connection, active-request, and buffered
+     request-body limits;
+   - add aggregate reservations for non-streaming response-spool bytes,
+     upstream worker tasks, upstream socket/file-descriptor slots, and open
+     streaming-response slots;
+   - make each aggregate reservation and release lock-protected and monotonic
+     under underflow.
+
+2. Gate upstream non-streaming dispatch with one atomic reservation:
+   - reserve one upstream worker task;
+   - reserve one upstream socket/file-descriptor slot;
+   - reserve the conservative non-streaming response-spool budget before
+     upstream resolution;
+   - reject as `503 local_endpoint_busy` with `forwarded_upstream: false` if
+     any required aggregate resource is saturated;
+   - perform this rejection before credential lookup, ledger mutation, DNS
+     resolution, or upstream forwarding.
+
+3. Hold and release resources deterministically:
+   - hold the reservation across upstream endpoint resolution, ledger
+     reservation, upstream forwarding, settlement, and local terminal response
+     preparation;
+   - release on resolver failure, local disconnect before forwarding, local
+     admission rejection after resolver success, pre-dispatch upstream failure,
+     post-dispatch upstream failure, and successful upstream response handling;
+   - keep active-request capacity tied to the same pending upstream lifecycle
+     established in Phase 3D.
+
+4. Expose bounded diagnostic counts in local status:
+   - report current buffered request-body bytes;
+   - report current non-streaming response-spool bytes;
+   - report current upstream worker-task count;
+   - report current upstream socket/file-descriptor count;
+   - report current open streaming-response count.
+
+5. Add streaming-response slot primitives without enabling streaming
+   forwarding:
+   - `stream: true` remains fail-closed before ledger append in this slice;
+   - the streaming slot counter exists for the later streaming implementation
+     and must reject over-capacity reservations in unit coverage.
+
+## Acceptance Tests
+
+- saturated upstream worker-task capacity rejects a chargeable request as
+  `local_endpoint_busy` before resolver, credential lookup, ledger mutation, or
+  forwarding;
+- saturated upstream socket/file-descriptor capacity rejects before resolver
+  and forwarding;
+- saturated non-streaming response-spool capacity rejects before resolver and
+  forwarding;
+- an accepted upstream exchange holds aggregate resources while pending and
+  releases them after success or failure;
+- resource status counts reflect held and released reservations;
+- streaming-response slot primitives reject saturation even though streaming
+  forwarding remains disabled.
+
+## Follow-Up Slices
+
+- streaming/SSE forwarding, event bounds, disconnect handling, and SSE
+  settlement evidence after `[DONE]`;
+- compressed non-streaming decode/cap/identity forwarding;
+- mutable credential state that marks invalid or expired upstream buyer
+  credentials while preserving the initiating client's upstream auth failure;
+- fake-gateway and real-gateway conformance journeys.
+
+## Non-Goals
+
+- Do not add OS-wide process file-descriptor scanning.
+- Do not implement streaming/SSE forwarding.
+- Do not change gateway billing, coordinator settlement, provider payout, or
+  receipt semantics.
+- Do not claim SPEC-045 production readiness from this slice alone.


### PR DESCRIPTION
## Summary

- add SPEC-045 Phase 3E build spec for aggregate local endpoint resource accounting
- reserve response-spool, worker-task, and socket-descriptor capacity before upstream resolver/credential/ledger/forwarding side effects
- expose resource diagnostic counts in status and add regressions for saturation, success release, failure release, and resolver-pending disconnect release

## Validation

- `swift test --filter ConsumeCommandTests --skip-update`
- `swift build --target macprovider-cli --skip-update`
- `git diff --check`
- `python3 scripts/gen_spec_index.py --check`
- `python3 scripts/gen_spec_index.py --lint`
- `python3 scripts/check_spec_governance.py --base-ref origin/main`
- `python3 -m unittest scripts.tests.test_spec_governance scripts.tests.test_spec_pr_declaration`
- `jq empty specs/AUTHORITY.json && jq empty specs/CONFORMANCE.json`
- 3-lane Codex audit over `/tmp/spec045-phase3e-full.diff`: code CLEAR 0 C/H/M, security CLEAR 0 C/H/M, architecture CLEAR 0 C/H/M

## Deferred

- streaming/SSE forwarding and composite streaming reservations
- compressed non-streaming decode-to-identity
- mutable invalid/expired credential state
- real/fake conformance journeys

SPEC-GOVERNANCE-DECLARATION-BEGIN
{
  "schema_version": "spec-pr-governance-v1",
  "behavior_change": "yes",
  "contract_change": "none",
  "specs": ["SPEC-045"],
  "requirements": ["SPEC-045-R002", "SPEC-045-R006", "SPEC-045-R007", "SPEC-045-R008"],
  "authority_domains": ["local-consumer-endpoint"],
  "arbitration": ["DECISION_REQUIRED"],
  "tests": [
    "phase3-binary/Tests/macprovider-cliTests/ConsumeCommandTests.swift:testPhase2EnforcesLocalResourceCapsBeforeBuffering",
    "phase3-binary/Tests/macprovider-cliTests/ConsumeCommandTests.swift:testPhase3EAggregateUpstreamResourceLimitsRejectBeforeResolverLedgerAndForwarding",
    "phase3-binary/Tests/macprovider-cliTests/ConsumeCommandTests.swift:testPhase3EUpstreamResourceReservationsAreHeldWhileForwardingAndReleasedAfterSuccess",
    "phase3-binary/Tests/macprovider-cliTests/ConsumeCommandTests.swift:testPhase3DResolverSuccessAfterDisconnectReleasesCapacityWithoutReservation",
    "phase3-binary/Tests/macprovider-cliTests/ConsumeCommandTests.swift:testPhase3DResolverFailureStopsBeforeReservationAndForwarding",
    "phase3-binary/Tests/macprovider-cliTests/ConsumeCommandTests.swift:testPhase3DPreDispatchTransportFailureSettlesReservationToZero",
    "phase3-binary/Tests/macprovider-cliTests/ConsumeCommandTests.swift:testPhase3DDispatchedTransportFailureHoldsReservation"
  ],
  "journeys": ["not-required"],
  "issue": "https://github.com/Augustas11/macprovider/issues/927"
}
SPEC-GOVERNANCE-DECLARATION-END
