### PR TITLE
Implement SPEC-045 Phase 3F compressed responses

### DIFF
--- a/phase3-binary/Sources/macprovider-cli/ConsumeCommand.swift
+++ b/phase3-binary/Sources/macprovider-cli/ConsumeCommand.swift
@@ -7,6 +7,7 @@ import Network
 import Security
 @preconcurrency import NIO
 @preconcurrency import NIOHTTP1
+import zlib
 
 struct ConsumeCommand: AsyncParsableCommand {
     static let configuration = CommandConfiguration(
@@ -653,6 +654,11 @@ enum ConsumeUpstreamForwardError: Error {
     case dispatchedUnavailable
 }
 
+private enum ConsumeUpstreamResponseContentCoding {
+    case identity
+    case gzip
+}
+
 struct ConsumeUpstreamTimeouts: Sendable {
     let connectNanoseconds: UInt64
     let sendNanoseconds: UInt64
@@ -1072,8 +1078,8 @@ final class ConsumePinnedUpstreamClient: ConsumeUpstreamClient, @unchecked Senda
             guard !line.isEmpty, let colon = line.firstIndex(of: ":") else {
                 throw ConsumeUpstreamForwardError.dispatchedUnavailable
             }
-            let name = String(line[..<colon]).trimmingCharacters(in: .whitespacesAndNewlines)
-            let value = String(line[line.index(after: colon)...]).trimmingCharacters(in: .whitespacesAndNewlines)
+            let name = trimHTTPOptionalWhitespace(line[..<colon])
+            let value = trimHTTPOptionalWhitespace(line[line.index(after: colon)...])
             guard validHTTPHeaderName(name),
                   validHTTPHeaderValue(value) else {
                 throw ConsumeUpstreamForwardError.dispatchedUnavailable
@@ -1142,12 +1148,26 @@ final class ConsumePinnedUpstreamClient: ConsumeUpstreamClient, @unchecked Senda
         return true
     }
 
+    private static func trimHTTPOptionalWhitespace(_ value: Substring) -> String {
+        var start = value.startIndex
+        var end = value.endIndex
+        while start < end, value[start] == " " || value[start] == "\t" {
+            start = value.index(after: start)
+        }
+        while start < end {
+            let previous = value.index(before: end)
+            guard value[previous] == " " || value[previous] == "\t" else { break }
+            end = previous
+        }
+        return String(value[start..<end])
+    }
+
     private static func chunkedTransferEncoding(_ headers: [(String, String)]) throws -> Bool {
         let tokens = headers
             .filter { name, _ in name.caseInsensitiveCompare("transfer-encoding") == .orderedSame }
             .flatMap { _, value in
                 value.split(separator: ",", omittingEmptySubsequences: false)
-                    .map { $0.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() }
+                    .map { trimHTTPOptionalWhitespace($0).lowercased() }
             }
         guard tokens.allSatisfy({ !$0.isEmpty }) else {
             throw ConsumeUpstreamForwardError.dispatchedUnavailable
@@ -1158,23 +1178,10 @@ final class ConsumePinnedUpstreamClient: ConsumeUpstreamClient, @unchecked Senda
         return !tokens.isEmpty
     }
 
-    private static func upstreamResponseContentEncodingIsIdentity(_ headers: [(String, String)]) -> Bool {
-        for (name, value) in headers where name.caseInsensitiveCompare("content-encoding") == .orderedSame {
-            let tokens = value
-                .split(separator: ",")
-                .map { $0.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() }
-                .filter { !$0.isEmpty }
-            guard !tokens.isEmpty, tokens.allSatisfy({ $0 == "identity" }) else {
-                return false
-            }
-        }
-        return true
-    }
-
     private static func contentLength(_ headers: [(String, String)]) throws -> Int? {
         let values = headers.compactMap { name, value -> String? in
             guard name.caseInsensitiveCompare("content-length") == .orderedSame else { return nil }
-            return value.trimmingCharacters(in: .whitespacesAndNewlines)
+            return trimHTTPOptionalWhitespace(value[...])
         }
         guard values.count <= 1 else {
             throw ConsumeUpstreamForwardError.dispatchedUnavailable
@@ -1202,7 +1209,7 @@ final class ConsumePinnedUpstreamClient: ConsumeUpstreamClient, @unchecked Senda
                 throw ConsumeUpstreamForwardError.dispatchedUnavailable
             }
             let sizeText = lineText.split(separator: ";", maxSplits: 1, omittingEmptySubsequences: false).first ?? ""
-            guard let chunkSize = Int(sizeText.trimmingCharacters(in: .whitespacesAndNewlines), radix: 16),
+            guard let chunkSize = Int(trimHTTPOptionalWhitespace(sizeText[...]), radix: 16),
                   chunkSize >= 0 else {
                 throw ConsumeUpstreamForwardError.dispatchedUnavailable
             }
@@ -3370,6 +3377,7 @@ enum ConsumeLocalLimits {
     static let headerCount = 96
     static let headerBytes = 64 * 1024
     static let bodyBytes = 1 * 1024 * 1024
+    static let nonStreamingResponseSpoolBytes = bodyBytes * 2
     static let headerReadTimeout: TimeAmount = .seconds(5)
     static let requestReadTimeout: TimeAmount = .seconds(15)
     static let bodyIdleTimeout: TimeAmount = .seconds(5)
@@ -4506,7 +4514,18 @@ final class ConsumeLocalHandler: ChannelInboundHandler, @unchecked Sendable {
             }
             switch result {
             case .success(let response):
-                self.writeUpstreamResponse(response, context: contextBox.context, extraHeaders: extraHeaders)
+                do {
+                    let localResponse = try Self.responseForLocalDelivery(response)
+                    self.writeUpstreamResponse(localResponse, context: contextBox.context, extraHeaders: extraHeaders)
+                } catch {
+                    self.writeLocalError(
+                        context: contextBox.context,
+                        status: HTTPResponseStatus(statusCode: 502),
+                        code: "local_upstream_unavailable",
+                        forwardedUpstream: true,
+                        extraHeaders: extraHeaders
+                    )
+                }
             case .failure(let error):
                 let failure = Self.classifyUpstreamFailure(error)
                 self.writeLocalError(
@@ -4552,9 +4571,11 @@ final class ConsumeLocalHandler: ChannelInboundHandler, @unchecked Sendable {
             }
             switch result {
             case .success(let response):
+                let localResponse: ConsumeUpstreamResponse
                 do {
+                    localResponse = try Self.responseForLocalDelivery(response)
                     let settlement = try self.settlementAmount(
-                        response: response,
+                        response: localResponse,
                         fallbackEstimate: estimate.amount,
                         pricingMatch: pricingMatch,
                         projection: projection
@@ -4577,11 +4598,44 @@ final class ConsumeLocalHandler: ChannelInboundHandler, @unchecked Sendable {
                             reason: settlement.reason
                         )
                     }
+                } catch ConsumeUpstreamForwardError.dispatchedUnavailable {
+                    do {
+                        try ledger.settle(
+                            runID: self.runtime.launchID,
+                            reservationID: reservationID,
+                            reservedAmount: reservedAmount,
+                            settledAmount: estimate.amount,
+                            reason: "settled_to_admission_estimate"
+                        )
+                    } catch {
+                        self.writeLocalError(
+                            context: contextBox.context,
+                            status: .serviceUnavailable,
+                            code: "local_budget_ledger_unavailable",
+                            forwardedUpstream: true,
+                            extraHeaders: extraHeaders
+                        )
+                        return
+                    }
+                    self.writeLocalError(
+                        context: contextBox.context,
+                        status: HTTPResponseStatus(statusCode: 502),
+                        code: "local_upstream_unavailable",
+                        forwardedUpstream: true,
+                        extraHeaders: extraHeaders
+                    )
+                    return
                 } catch {
-                    self.writeLocalError(context: contextBox.context, status: .serviceUnavailable, code: "local_budget_ledger_unavailable")
+                    self.writeLocalError(
+                        context: contextBox.context,
+                        status: .serviceUnavailable,
+                        code: "local_budget_ledger_unavailable",
+                        forwardedUpstream: true,
+                        extraHeaders: extraHeaders
+                    )
                     return
                 }
-                self.writeUpstreamResponse(response, context: contextBox.context, extraHeaders: extraHeaders)
+                self.writeUpstreamResponse(localResponse, context: contextBox.context, extraHeaders: extraHeaders)
             case .failure(let error):
                 let failure = Self.classifyUpstreamFailure(error)
                 do {
@@ -4602,7 +4656,13 @@ final class ConsumeLocalHandler: ChannelInboundHandler, @unchecked Sendable {
                         )
                     }
                 } catch {
-                    self.writeLocalError(context: contextBox.context, status: .serviceUnavailable, code: "local_budget_ledger_unavailable")
+                    self.writeLocalError(
+                        context: contextBox.context,
+                        status: .serviceUnavailable,
+                        code: "local_budget_ledger_unavailable",
+                        forwardedUpstream: failure.forwardedUpstream,
+                        extraHeaders: extraHeaders
+                    )
                     return
                 }
                 self.writeLocalError(
@@ -4661,7 +4721,9 @@ final class ConsumeLocalHandler: ChannelInboundHandler, @unchecked Sendable {
         extraHeaders: [(String, String)]
     ) -> Bool {
         guard upstreamResourceReservation == nil,
-              let reservation = runtime.reserveUpstreamExchange(responseSpoolBytes: ConsumeLocalLimits.bodyBytes) else {
+              let reservation = runtime.reserveUpstreamExchange(
+                responseSpoolBytes: ConsumeLocalLimits.nonStreamingResponseSpoolBytes
+              ) else {
             writeLocalError(
                 context: context,
                 status: .serviceUnavailable,
@@ -4705,9 +4767,6 @@ final class ConsumeLocalHandler: ChannelInboundHandler, @unchecked Sendable {
         pricingMatch: ConsumeTrustedRateCardMatch,
         projection: RateCardProjection
     ) throws -> (amount: ConsumeMicroUSD, reason: String) {
-        guard Self.upstreamResponseContentEncodingIsIdentity(response.headers) else {
-            return (fallbackEstimate, "settled_to_admission_estimate")
-        }
         guard let text = String(data: response.body, encoding: .utf8),
               case .object(let root) = try? StrictJSONParser.parse(text),
               case .object(let usage)? = root["usage"],
@@ -4724,6 +4783,119 @@ final class ConsumeLocalHandler: ChannelInboundHandler, @unchecked Sendable {
             return (fallbackEstimate, "settled_to_admission_estimate")
         }
         return (amount, "settled_to_upstream_usage")
+    }
+
+    private static func responseForLocalDelivery(_ response: ConsumeUpstreamResponse) throws -> ConsumeUpstreamResponse {
+        switch try upstreamResponseContentCoding(response.headers) {
+        case .identity:
+            return ConsumeUpstreamResponse(
+                statusCode: response.statusCode,
+                headers: response.headers.filter { name, _ in
+                    name.caseInsensitiveCompare("content-encoding") != .orderedSame &&
+                        name.caseInsensitiveCompare("content-length") != .orderedSame
+                },
+                body: response.body
+            )
+        case .gzip:
+            let decodedBody = try gunzip(response.body, maxDecodedBytes: ConsumeLocalLimits.bodyBytes)
+            return ConsumeUpstreamResponse(
+                statusCode: response.statusCode,
+                headers: response.headers.filter { name, _ in
+                    name.caseInsensitiveCompare("content-encoding") != .orderedSame &&
+                        name.caseInsensitiveCompare("content-length") != .orderedSame
+                },
+                body: decodedBody
+            )
+        }
+    }
+
+    private static func upstreamResponseContentCoding(_ headers: [(String, String)]) throws -> ConsumeUpstreamResponseContentCoding {
+        let tokens = headers
+            .filter { name, _ in name.caseInsensitiveCompare("content-encoding") == .orderedSame }
+            .flatMap { _, value in
+                value.split(separator: ",", omittingEmptySubsequences: false)
+                    .map { trimHTTPOptionalWhitespace($0).lowercased() }
+            }
+        guard tokens.allSatisfy({ !$0.isEmpty }) else {
+            throw ConsumeUpstreamForwardError.dispatchedUnavailable
+        }
+        if tokens.isEmpty || tokens == ["identity"] {
+            return .identity
+        }
+        if tokens == ["gzip"] {
+            return .gzip
+        }
+        throw ConsumeUpstreamForwardError.dispatchedUnavailable
+    }
+
+    private static func trimHTTPOptionalWhitespace(_ value: Substring) -> String {
+        var start = value.startIndex
+        var end = value.endIndex
+        while start < end, value[start] == " " || value[start] == "\t" {
+            start = value.index(after: start)
+        }
+        while start < end {
+            let previous = value.index(before: end)
+            guard value[previous] == " " || value[previous] == "\t" else { break }
+            end = previous
+        }
+        return String(value[start..<end])
+    }
+
+    private static func gunzip(_ body: Data, maxDecodedBytes: Int) throws -> Data {
+        guard body.count <= Int(UInt32.max), maxDecodedBytes >= 0 else {
+            throw ConsumeUpstreamForwardError.dispatchedUnavailable
+        }
+        var stream = z_stream()
+        let initStatus = inflateInit2_(
+            &stream,
+            16 + MAX_WBITS,
+            ZLIB_VERSION,
+            Int32(MemoryLayout<z_stream>.size)
+        )
+        guard initStatus == Z_OK else {
+            throw ConsumeUpstreamForwardError.dispatchedUnavailable
+        }
+        defer { inflateEnd(&stream) }
+
+        return try body.withUnsafeBytes { input in
+            stream.next_in = UnsafeMutablePointer<Bytef>(
+                mutating: input.bindMemory(to: Bytef.self).baseAddress
+            )
+            stream.avail_in = uInt(body.count)
+            var output = Data()
+            let chunkSize = 32 * 1024
+
+            while true {
+                var buffer = [UInt8](repeating: 0, count: chunkSize)
+                let status = buffer.withUnsafeMutableBytes { rawBuffer -> Int32 in
+                    stream.next_out = rawBuffer.bindMemory(to: Bytef.self).baseAddress
+                    stream.avail_out = uInt(chunkSize)
+                    return inflate(&stream, Z_NO_FLUSH)
+                }
+                let produced = chunkSize - Int(stream.avail_out)
+                if produced > 0 {
+                    guard output.count + produced <= maxDecodedBytes else {
+                        throw ConsumeUpstreamForwardError.dispatchedUnavailable
+                    }
+                    output.append(contentsOf: buffer.prefix(produced))
+                }
+
+                switch status {
+                case Z_STREAM_END:
+                    guard stream.avail_in == 0 else {
+                        throw ConsumeUpstreamForwardError.dispatchedUnavailable
+                    }
+                    return output
+                case Z_OK:
+                    guard produced > 0 || stream.avail_in > 0 else {
+                        throw ConsumeUpstreamForwardError.dispatchedUnavailable
+                    }
+                default:
+                    throw ConsumeUpstreamForwardError.dispatchedUnavailable
+                }
+            }
+        }
     }
 
     private func writeLocalUnpricedBudgetAdmission(budget: ConsumeMicroUSD, context: ChannelHandlerContext) {
@@ -4877,16 +5049,6 @@ final class ConsumeLocalHandler: ChannelInboundHandler, @unchecked Sendable {
         context: ChannelHandlerContext,
         extraHeaders: [(String, String)]
     ) {
-        guard Self.upstreamResponseContentEncodingIsIdentity(response.headers) else {
-            writeLocalError(
-                context: context,
-                status: HTTPResponseStatus(statusCode: 502),
-                code: "local_upstream_unavailable",
-                forwardedUpstream: true,
-                extraHeaders: extraHeaders
-            )
-            return
-        }
         var headers = HTTPHeaders()
         for (name, value) in response.headers {
             let normalized = name.lowercased()
@@ -4917,19 +5079,6 @@ final class ConsumeLocalHandler: ChannelInboundHandler, @unchecked Sendable {
         }
         context.writeAndFlush(wrapOutboundOut(.end(nil)), promise: nil)
         context.close(promise: nil)
-    }
-
-    private static func upstreamResponseContentEncodingIsIdentity(_ headers: [(String, String)]) -> Bool {
-        for (name, value) in headers where name.caseInsensitiveCompare("content-encoding") == .orderedSame {
-            let tokens = value
-                .split(separator: ",")
-                .map { $0.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() }
-                .filter { !$0.isEmpty }
-            guard !tokens.isEmpty, tokens.allSatisfy({ $0 == "identity" }) else {
-                return false
-            }
-        }
-        return true
     }
 
     private static func allowedUpstreamResponseHeader(_ normalizedName: String) -> Bool {

--- a/phase3-binary/Tests/macprovider-cliTests/ConsumeCommandTests.swift
+++ b/phase3-binary/Tests/macprovider-cliTests/ConsumeCommandTests.swift
@@ -7,6 +7,7 @@ import NIOCore
 import NIOEmbedded
 import NIOHTTP1
 import XCTest
+import zlib
 @testable import macprovider_cli
 
 private final class ConsumeStubUpstreamClient: ConsumeUpstreamClient, @unchecked Sendable {
@@ -1573,7 +1574,7 @@ final class ConsumeCommandTests: XCTestCase {
         let cases: [(name: String, counter: ConsumeEndpointRequestCounter)] = [
             ("worker", ConsumeEndpointRequestCounter(maxUpstreamWorkerTasks: 0)),
             ("socket", ConsumeEndpointRequestCounter(maxUpstreamSocketDescriptors: 0)),
-            ("spool", ConsumeEndpointRequestCounter(maxResponseSpoolBytes: ConsumeLocalLimits.bodyBytes - 1)),
+            ("spool", ConsumeEndpointRequestCounter(maxResponseSpoolBytes: ConsumeLocalLimits.nonStreamingResponseSpoolBytes - 1)),
         ]
         var headers = HTTPHeaders()
         headers.add(name: "Authorization", value: "Bearer \(token.value)")
@@ -1645,7 +1646,7 @@ final class ConsumeCommandTests: XCTestCase {
             ledgerPathClass: nil
         )
         let counter = ConsumeEndpointRequestCounter(
-            maxResponseSpoolBytes: ConsumeLocalLimits.bodyBytes,
+            maxResponseSpoolBytes: ConsumeLocalLimits.nonStreamingResponseSpoolBytes,
             maxUpstreamWorkerTasks: 1,
             maxUpstreamSocketDescriptors: 1
         )
@@ -1684,11 +1685,11 @@ final class ConsumeCommandTests: XCTestCase {
 
         XCTAssertEqual(recorder.snapshot().count, 1)
         var snapshot = counter.resourceSnapshot()
-        XCTAssertEqual(snapshot.responseSpoolBytes, ConsumeLocalLimits.bodyBytes)
+        XCTAssertEqual(snapshot.responseSpoolBytes, ConsumeLocalLimits.nonStreamingResponseSpoolBytes)
         XCTAssertEqual(snapshot.upstreamWorkerTasks, 1)
         XCTAssertEqual(snapshot.upstreamSocketDescriptors, 1)
         let status = runtime.statusPayload()
-        XCTAssertEqual(status["response_spool_bytes"] as? Int, ConsumeLocalLimits.bodyBytes)
+        XCTAssertEqual(status["response_spool_bytes"] as? Int, ConsumeLocalLimits.nonStreamingResponseSpoolBytes)
         XCTAssertEqual(status["upstream_worker_task_count"] as? Int, 1)
         XCTAssertEqual(status["upstream_socket_descriptor_count"] as? Int, 1)
 
@@ -1803,7 +1804,7 @@ final class ConsumeCommandTests: XCTestCase {
         let endpointPromise = ConsumeEndpointPromiseBox()
         let recorder = ConsumeUpstreamRequestRecorder()
         let counter = ConsumeEndpointRequestCounter(
-            maxResponseSpoolBytes: ConsumeLocalLimits.bodyBytes,
+            maxResponseSpoolBytes: ConsumeLocalLimits.nonStreamingResponseSpoolBytes,
             maxUpstreamWorkerTasks: 1,
             maxUpstreamSocketDescriptors: 1
         )
@@ -1842,7 +1843,7 @@ final class ConsumeCommandTests: XCTestCase {
         channel.embeddedEventLoop.run()
         XCTAssertEqual(runtime.statusPayload()["active_request_count"] as? Int, 1)
         var resourceSnapshot = counter.resourceSnapshot()
-        XCTAssertEqual(resourceSnapshot.responseSpoolBytes, ConsumeLocalLimits.bodyBytes)
+        XCTAssertEqual(resourceSnapshot.responseSpoolBytes, ConsumeLocalLimits.nonStreamingResponseSpoolBytes)
         XCTAssertEqual(resourceSnapshot.upstreamWorkerTasks, 1)
         XCTAssertEqual(resourceSnapshot.upstreamSocketDescriptors, 1)
 
@@ -2006,7 +2007,75 @@ final class ConsumeCommandTests: XCTestCase {
         XCTAssertEqual(try ledger.summary(), .empty)
     }
 
-    func testPhase3DCompressedUpstreamResponseFailsBeforeLocalSuccess() throws {
+    func testPhase3FCompressedUpstreamResponseDecodesBeforeSettlementAndLocalSuccess() throws {
+        let token = try ConsumeLocalToken.generate()
+        let home = try makeTemporaryDirectory()
+        let ledgerURL = home.appendingPathComponent("budget.jsonl")
+        let ledger = try ConsumeBudgetLedger.open(ledgerPath: ledgerURL.path, homeDirectory: home, startupDirectory: home)
+        let trustedRateCard = phase3CTrustedRateCard(
+            promptRatePerMtok: 1_000_000,
+            completionRatePerMtok: 2_000_000,
+            usdPerMillionCredits: 1.0
+        )
+        let budget = ConsumeBudgetConfig(
+            mode: .budget(ConsumeMicroUSD(rawValue: 100_000_000)),
+            maxRequestMicroUSD: nil,
+            allowUnpriced: false,
+            ledger: ledger,
+            ledgerPathClass: ledger.pathClass
+        )
+        let decodedBody = Data(#"{"usage":{"prompt_tokens":1,"completion_tokens":1}}"#.utf8)
+        let compressedBody = try gzipData(decodedBody)
+        let upstreamClient = ConsumeStubUpstreamClient { _, eventLoop in
+            eventLoop.makeSucceededFuture(ConsumeUpstreamResponse(
+                statusCode: 200,
+                headers: [
+                    ("content-type", "application/json"),
+                    ("content-encoding", "gzip"),
+                    ("content-length", "999999"),
+                    ("x-request-id", "upstream-request-id"),
+                ],
+                body: compressedBody
+            ))
+        }
+        let runtime = consumeRuntime(
+            token: token,
+            credentialStatus: .environmentLoaded,
+            credentialCustody: consumeCredentialCustody("buyer-token"),
+            budget: budget,
+            trustedPricing: .available(trustedRateCard),
+            upstreamClient: upstreamClient,
+            now: { ConsumeCommandTests.phase3CTestNow }
+        )
+        var headers = HTTPHeaders()
+        headers.add(name: "Authorization", value: "Bearer \(token.value)")
+        let body = #"{"model":"llama-test","messages":[],"max_tokens":10}"#
+        let expectedSettlement = try ConsumePricedExposureEstimator.actualUsageSettlement(
+            promptTokens: 1,
+            completionTokens: 1,
+            match: XCTUnwrap(trustedRateCard.match(model: "llama-test")),
+            projection: trustedRateCard.projection
+        )
+
+        let response = try response(
+            from: runtime,
+            head: HTTPRequestHead(version: .http1_1, method: .POST, uri: "/v1/chat/completions", headers: headers),
+            body: Data(body.utf8)
+        )
+
+        XCTAssertEqual(response.status, .ok)
+        XCTAssertEqual(response.body, String(decoding: decodedBody, as: UTF8.self))
+        XCTAssertNil(response.headers.first(name: "content-encoding"))
+        XCTAssertEqual(response.headers.first(name: "content-length"), "\(decodedBody.count)")
+        XCTAssertEqual(response.headers.first(name: "x-request-id"), "upstream-request-id")
+        let summary = try ledger.summary()
+        XCTAssertEqual(summary.reserved.rawValue, 0)
+        XCTAssertEqual(summary.held.rawValue, 0)
+        XCTAssertEqual(summary.settled.rawValue, expectedSettlement.rawValue)
+        XCTAssertEqual(summary.estimateExceeded.rawValue, 0)
+    }
+
+    func testPhase3FInvalidCompressedUpstreamResponseFailsBeforeLocalSuccessAndSettlesEstimate() throws {
         let token = try ConsumeLocalToken.generate()
         let home = try makeTemporaryDirectory()
         let ledgerURL = home.appendingPathComponent("budget.jsonl")
@@ -2030,7 +2099,421 @@ final class ConsumeCommandTests: XCTestCase {
                     ("content-type", "application/json"),
                     ("content-encoding", "gzip"),
                 ],
-                body: Data(#"{"usage":{"prompt_tokens":1000,"completion_tokens":1000}}"#.utf8)
+                body: Data("not-gzip".utf8)
+            ))
+        }
+        let runtime = consumeRuntime(
+            token: token,
+            credentialStatus: .environmentLoaded,
+            credentialCustody: consumeCredentialCustody("buyer-token"),
+            budget: budget,
+            trustedPricing: .available(trustedRateCard),
+            upstreamClient: upstreamClient,
+            now: { ConsumeCommandTests.phase3CTestNow }
+        )
+        var headers = HTTPHeaders()
+        headers.add(name: "Authorization", value: "Bearer \(token.value)")
+        let body = #"{"model":"llama-test","messages":[],"max_tokens":10}"#
+        let expected = try ConsumePricedExposureEstimator.estimate(
+            bodyByteCount: Data(body.utf8).count,
+            request: StrictJSONParser.parse(body),
+            match: XCTUnwrap(trustedRateCard.match(model: "llama-test")),
+            projection: trustedRateCard.projection
+        )
+
+        let response = try response(
+            from: runtime,
+            head: HTTPRequestHead(version: .http1_1, method: .POST, uri: "/v1/chat/completions", headers: headers),
+            body: Data(body.utf8)
+        )
+
+        XCTAssertEqual(response.status, HTTPResponseStatus(statusCode: 502))
+        XCTAssertEqual(try localError(from: response.body)["code"] as? String, "local_upstream_unavailable")
+        XCTAssertTrue(try localForwardedFlag(from: response.body))
+        XCTAssertNil(response.headers.first(name: "content-encoding"))
+        let summary = try ledger.summary()
+        XCTAssertEqual(summary.reserved.rawValue, 0)
+        XCTAssertEqual(summary.held.rawValue, 0)
+        XCTAssertEqual(summary.settled.rawValue, expected.amount.rawValue)
+        XCTAssertEqual(summary.estimateExceeded.rawValue, 0)
+    }
+
+    func testPhase3FInvalidCompressedUpstreamResponseWithLedgerWriteFailureKeepsForwardedProvenance() throws {
+        let token = try ConsumeLocalToken.generate()
+        let home = try makeTemporaryDirectory()
+        let ledgerURL = home.appendingPathComponent("budget.jsonl")
+        let ledger = try ConsumeBudgetLedger.open(ledgerPath: ledgerURL.path, homeDirectory: home, startupDirectory: home)
+        let trustedRateCard = phase3CTrustedRateCard(
+            promptRatePerMtok: 1_000_000,
+            completionRatePerMtok: 2_000_000,
+            usdPerMillionCredits: 1.0
+        )
+        let budget = ConsumeBudgetConfig(
+            mode: .budget(ConsumeMicroUSD(rawValue: 100_000_000)),
+            maxRequestMicroUSD: nil,
+            allowUnpriced: false,
+            ledger: ledger,
+            ledgerPathClass: ledger.pathClass
+        )
+        let upstreamClient = ConsumeStubUpstreamClient { _, eventLoop in
+            try! FileManager.default.removeItem(at: ledgerURL)
+            try! Data().write(to: ledgerURL)
+            chmod(ledgerURL.path, 0o600)
+            return eventLoop.makeSucceededFuture(ConsumeUpstreamResponse(
+                statusCode: 200,
+                headers: [
+                    ("content-type", "application/json"),
+                    ("content-encoding", "gzip"),
+                ],
+                body: Data("not-gzip".utf8)
+            ))
+        }
+        let runtime = consumeRuntime(
+            token: token,
+            credentialStatus: .environmentLoaded,
+            credentialCustody: consumeCredentialCustody("buyer-token"),
+            budget: budget,
+            trustedPricing: .available(trustedRateCard),
+            upstreamClient: upstreamClient,
+            now: { ConsumeCommandTests.phase3CTestNow }
+        )
+        var headers = HTTPHeaders()
+        headers.add(name: "Authorization", value: "Bearer \(token.value)")
+        let body = Data(#"{"model":"llama-test","messages":[],"max_tokens":10}"#.utf8)
+
+        let response = try response(
+            from: runtime,
+            head: HTTPRequestHead(version: .http1_1, method: .POST, uri: "/v1/chat/completions", headers: headers),
+            body: body
+        )
+
+        XCTAssertEqual(response.status, .serviceUnavailable)
+        XCTAssertEqual(try localError(from: response.body)["code"] as? String, "local_budget_ledger_unavailable")
+        XCTAssertTrue(try localForwardedFlag(from: response.body))
+        XCTAssertNil(response.headers.first(name: "content-encoding"))
+    }
+
+    func testPhase3FDecodedUpstreamResponseWithLedgerWriteFailureKeepsForwardedProvenance() throws {
+        let token = try ConsumeLocalToken.generate()
+        let home = try makeTemporaryDirectory()
+        let ledgerURL = home.appendingPathComponent("budget.jsonl")
+        let ledger = try ConsumeBudgetLedger.open(ledgerPath: ledgerURL.path, homeDirectory: home, startupDirectory: home)
+        let trustedRateCard = phase3CTrustedRateCard(
+            promptRatePerMtok: 1_000_000,
+            completionRatePerMtok: 2_000_000,
+            usdPerMillionCredits: 1.0
+        )
+        let budget = ConsumeBudgetConfig(
+            mode: .budget(ConsumeMicroUSD(rawValue: 100_000_000)),
+            maxRequestMicroUSD: nil,
+            allowUnpriced: false,
+            ledger: ledger,
+            ledgerPathClass: ledger.pathClass
+        )
+        let decodedBody = Data(#"{"usage":{"prompt_tokens":1,"completion_tokens":1}}"#.utf8)
+        let compressedBody = try gzipData(decodedBody)
+        let upstreamClient = ConsumeStubUpstreamClient { _, eventLoop in
+            try! FileManager.default.removeItem(at: ledgerURL)
+            try! Data().write(to: ledgerURL)
+            chmod(ledgerURL.path, 0o600)
+            return eventLoop.makeSucceededFuture(ConsumeUpstreamResponse(
+                statusCode: 200,
+                headers: [
+                    ("content-type", "application/json"),
+                    ("content-encoding", "gzip"),
+                ],
+                body: compressedBody
+            ))
+        }
+        let runtime = consumeRuntime(
+            token: token,
+            credentialStatus: .environmentLoaded,
+            credentialCustody: consumeCredentialCustody("buyer-token"),
+            budget: budget,
+            trustedPricing: .available(trustedRateCard),
+            upstreamClient: upstreamClient,
+            now: { ConsumeCommandTests.phase3CTestNow }
+        )
+        var headers = HTTPHeaders()
+        headers.add(name: "Authorization", value: "Bearer \(token.value)")
+        let body = Data(#"{"model":"llama-test","messages":[],"max_tokens":10}"#.utf8)
+
+        let response = try response(
+            from: runtime,
+            head: HTTPRequestHead(version: .http1_1, method: .POST, uri: "/v1/chat/completions", headers: headers),
+            body: body
+        )
+
+        XCTAssertEqual(response.status, .serviceUnavailable)
+        XCTAssertEqual(try localError(from: response.body)["code"] as? String, "local_budget_ledger_unavailable")
+        XCTAssertTrue(try localForwardedFlag(from: response.body))
+        XCTAssertNil(response.headers.first(name: "content-encoding"))
+    }
+
+    func testPhase3FDispatchedUpstreamFailureWithLedgerWriteFailureKeepsForwardedProvenance() throws {
+        let token = try ConsumeLocalToken.generate()
+        let home = try makeTemporaryDirectory()
+        let ledgerURL = home.appendingPathComponent("budget.jsonl")
+        let ledger = try ConsumeBudgetLedger.open(ledgerPath: ledgerURL.path, homeDirectory: home, startupDirectory: home)
+        let trustedRateCard = phase3CTrustedRateCard(
+            promptRatePerMtok: 1_000_000,
+            completionRatePerMtok: 2_000_000,
+            usdPerMillionCredits: 1.0
+        )
+        let budget = ConsumeBudgetConfig(
+            mode: .budget(ConsumeMicroUSD(rawValue: 100_000_000)),
+            maxRequestMicroUSD: nil,
+            allowUnpriced: false,
+            ledger: ledger,
+            ledgerPathClass: ledger.pathClass
+        )
+        let upstreamClient = ConsumeStubUpstreamClient { _, eventLoop in
+            try! FileManager.default.removeItem(at: ledgerURL)
+            try! Data().write(to: ledgerURL)
+            chmod(ledgerURL.path, 0o600)
+            return eventLoop.makeFailedFuture(ConsumeUpstreamForwardError.dispatchedUnavailable)
+        }
+        let runtime = consumeRuntime(
+            token: token,
+            credentialStatus: .environmentLoaded,
+            credentialCustody: consumeCredentialCustody("buyer-token"),
+            budget: budget,
+            trustedPricing: .available(trustedRateCard),
+            upstreamClient: upstreamClient,
+            now: { ConsumeCommandTests.phase3CTestNow }
+        )
+        var headers = HTTPHeaders()
+        headers.add(name: "Authorization", value: "Bearer \(token.value)")
+        let body = Data(#"{"model":"llama-test","messages":[],"max_tokens":10}"#.utf8)
+
+        let response = try response(
+            from: runtime,
+            head: HTTPRequestHead(version: .http1_1, method: .POST, uri: "/v1/chat/completions", headers: headers),
+            body: body
+        )
+
+        XCTAssertEqual(response.status, .serviceUnavailable)
+        XCTAssertEqual(try localError(from: response.body)["code"] as? String, "local_budget_ledger_unavailable")
+        XCTAssertTrue(try localForwardedFlag(from: response.body))
+    }
+
+    func testPhase3FAmbiguousCompressedUpstreamResponseFailsClosedAndSettlesEstimate() throws {
+        let token = try ConsumeLocalToken.generate()
+        let home = try makeTemporaryDirectory()
+        let ledgerURL = home.appendingPathComponent("budget.jsonl")
+        let ledger = try ConsumeBudgetLedger.open(ledgerPath: ledgerURL.path, homeDirectory: home, startupDirectory: home)
+        let trustedRateCard = phase3CTrustedRateCard(
+            promptRatePerMtok: 1_000_000,
+            completionRatePerMtok: 2_000_000,
+            usdPerMillionCredits: 1.0
+        )
+        let budget = ConsumeBudgetConfig(
+            mode: .budget(ConsumeMicroUSD(rawValue: 100_000_000)),
+            maxRequestMicroUSD: nil,
+            allowUnpriced: false,
+            ledger: ledger,
+            ledgerPathClass: ledger.pathClass
+        )
+        let upstreamClient = ConsumeStubUpstreamClient { _, eventLoop in
+            eventLoop.makeSucceededFuture(ConsumeUpstreamResponse(
+                statusCode: 200,
+                headers: [
+                    ("content-type", "application/json"),
+                    ("content-encoding", "gzip, identity"),
+                ],
+                body: Data()
+            ))
+        }
+        let runtime = consumeRuntime(
+            token: token,
+            credentialStatus: .environmentLoaded,
+            credentialCustody: consumeCredentialCustody("buyer-token"),
+            budget: budget,
+            trustedPricing: .available(trustedRateCard),
+            upstreamClient: upstreamClient,
+            now: { ConsumeCommandTests.phase3CTestNow }
+        )
+        var headers = HTTPHeaders()
+        headers.add(name: "Authorization", value: "Bearer \(token.value)")
+        let body = #"{"model":"llama-test","messages":[],"max_tokens":10}"#
+        let expected = try ConsumePricedExposureEstimator.estimate(
+            bodyByteCount: Data(body.utf8).count,
+            request: StrictJSONParser.parse(body),
+            match: XCTUnwrap(trustedRateCard.match(model: "llama-test")),
+            projection: trustedRateCard.projection
+        )
+
+        let response = try response(
+            from: runtime,
+            head: HTTPRequestHead(version: .http1_1, method: .POST, uri: "/v1/chat/completions", headers: headers),
+            body: Data(body.utf8)
+        )
+
+        XCTAssertEqual(response.status, HTTPResponseStatus(statusCode: 502))
+        XCTAssertEqual(try localError(from: response.body)["code"] as? String, "local_upstream_unavailable")
+        XCTAssertTrue(try localForwardedFlag(from: response.body))
+        XCTAssertNil(response.headers.first(name: "content-encoding"))
+        let summary = try ledger.summary()
+        XCTAssertEqual(summary.reserved.rawValue, 0)
+        XCTAssertEqual(summary.held.rawValue, 0)
+        XCTAssertEqual(summary.settled.rawValue, expected.amount.rawValue)
+        XCTAssertEqual(summary.estimateExceeded.rawValue, 0)
+    }
+
+    func testPhase3FNonHTTPWhitespaceCompressedUpstreamResponseFailsClosedAndSettlesEstimate() throws {
+        let token = try ConsumeLocalToken.generate()
+        let home = try makeTemporaryDirectory()
+        let ledgerURL = home.appendingPathComponent("budget.jsonl")
+        let ledger = try ConsumeBudgetLedger.open(ledgerPath: ledgerURL.path, homeDirectory: home, startupDirectory: home)
+        let trustedRateCard = phase3CTrustedRateCard(
+            promptRatePerMtok: 1_000_000,
+            completionRatePerMtok: 2_000_000,
+            usdPerMillionCredits: 1.0
+        )
+        let budget = ConsumeBudgetConfig(
+            mode: .budget(ConsumeMicroUSD(rawValue: 100_000_000)),
+            maxRequestMicroUSD: nil,
+            allowUnpriced: false,
+            ledger: ledger,
+            ledgerPathClass: ledger.pathClass
+        )
+        let upstreamClient = ConsumeStubUpstreamClient { _, eventLoop in
+            eventLoop.makeSucceededFuture(ConsumeUpstreamResponse(
+                statusCode: 200,
+                headers: [
+                    ("content-type", "application/json"),
+                    ("content-encoding", "\u{00a0}gzip"),
+                ],
+                body: Data()
+            ))
+        }
+        let runtime = consumeRuntime(
+            token: token,
+            credentialStatus: .environmentLoaded,
+            credentialCustody: consumeCredentialCustody("buyer-token"),
+            budget: budget,
+            trustedPricing: .available(trustedRateCard),
+            upstreamClient: upstreamClient,
+            now: { ConsumeCommandTests.phase3CTestNow }
+        )
+        var headers = HTTPHeaders()
+        headers.add(name: "Authorization", value: "Bearer \(token.value)")
+        let body = #"{"model":"llama-test","messages":[],"max_tokens":10}"#
+        let expected = try ConsumePricedExposureEstimator.estimate(
+            bodyByteCount: Data(body.utf8).count,
+            request: StrictJSONParser.parse(body),
+            match: XCTUnwrap(trustedRateCard.match(model: "llama-test")),
+            projection: trustedRateCard.projection
+        )
+
+        let response = try response(
+            from: runtime,
+            head: HTTPRequestHead(version: .http1_1, method: .POST, uri: "/v1/chat/completions", headers: headers),
+            body: Data(body.utf8)
+        )
+
+        XCTAssertEqual(response.status, HTTPResponseStatus(statusCode: 502))
+        XCTAssertEqual(try localError(from: response.body)["code"] as? String, "local_upstream_unavailable")
+        XCTAssertTrue(try localForwardedFlag(from: response.body))
+        XCTAssertNil(response.headers.first(name: "content-encoding"))
+        let summary = try ledger.summary()
+        XCTAssertEqual(summary.reserved.rawValue, 0)
+        XCTAssertEqual(summary.held.rawValue, 0)
+        XCTAssertEqual(summary.settled.rawValue, expected.amount.rawValue)
+        XCTAssertEqual(summary.estimateExceeded.rawValue, 0)
+    }
+
+    func testPhase3FDuplicateIdentityUpstreamResponseFailsClosedAndSettlesEstimate() throws {
+        let token = try ConsumeLocalToken.generate()
+        let home = try makeTemporaryDirectory()
+        let ledgerURL = home.appendingPathComponent("budget.jsonl")
+        let ledger = try ConsumeBudgetLedger.open(ledgerPath: ledgerURL.path, homeDirectory: home, startupDirectory: home)
+        let trustedRateCard = phase3CTrustedRateCard(
+            promptRatePerMtok: 1_000_000,
+            completionRatePerMtok: 2_000_000,
+            usdPerMillionCredits: 1.0
+        )
+        let budget = ConsumeBudgetConfig(
+            mode: .budget(ConsumeMicroUSD(rawValue: 100_000_000)),
+            maxRequestMicroUSD: nil,
+            allowUnpriced: false,
+            ledger: ledger,
+            ledgerPathClass: ledger.pathClass
+        )
+        let upstreamClient = ConsumeStubUpstreamClient { _, eventLoop in
+            eventLoop.makeSucceededFuture(ConsumeUpstreamResponse(
+                statusCode: 200,
+                headers: [
+                    ("content-type", "application/json"),
+                    ("content-encoding", "identity"),
+                    ("content-encoding", "identity"),
+                ],
+                body: Data(#"{"usage":{"prompt_tokens":1,"completion_tokens":1}}"#.utf8)
+            ))
+        }
+        let runtime = consumeRuntime(
+            token: token,
+            credentialStatus: .environmentLoaded,
+            credentialCustody: consumeCredentialCustody("buyer-token"),
+            budget: budget,
+            trustedPricing: .available(trustedRateCard),
+            upstreamClient: upstreamClient,
+            now: { ConsumeCommandTests.phase3CTestNow }
+        )
+        var headers = HTTPHeaders()
+        headers.add(name: "Authorization", value: "Bearer \(token.value)")
+        let body = #"{"model":"llama-test","messages":[],"max_tokens":10}"#
+        let expected = try ConsumePricedExposureEstimator.estimate(
+            bodyByteCount: Data(body.utf8).count,
+            request: StrictJSONParser.parse(body),
+            match: XCTUnwrap(trustedRateCard.match(model: "llama-test")),
+            projection: trustedRateCard.projection
+        )
+
+        let response = try response(
+            from: runtime,
+            head: HTTPRequestHead(version: .http1_1, method: .POST, uri: "/v1/chat/completions", headers: headers),
+            body: Data(body.utf8)
+        )
+
+        XCTAssertEqual(response.status, HTTPResponseStatus(statusCode: 502))
+        XCTAssertEqual(try localError(from: response.body)["code"] as? String, "local_upstream_unavailable")
+        XCTAssertTrue(try localForwardedFlag(from: response.body))
+        XCTAssertNil(response.headers.first(name: "content-encoding"))
+        let summary = try ledger.summary()
+        XCTAssertEqual(summary.reserved.rawValue, 0)
+        XCTAssertEqual(summary.held.rawValue, 0)
+        XCTAssertEqual(summary.settled.rawValue, expected.amount.rawValue)
+        XCTAssertEqual(summary.estimateExceeded.rawValue, 0)
+    }
+
+    func testPhase3FOversizedCompressedUpstreamResponseFailsBeforeLocalSuccessAndSettlesEstimate() throws {
+        let token = try ConsumeLocalToken.generate()
+        let home = try makeTemporaryDirectory()
+        let ledgerURL = home.appendingPathComponent("budget.jsonl")
+        let ledger = try ConsumeBudgetLedger.open(ledgerPath: ledgerURL.path, homeDirectory: home, startupDirectory: home)
+        let trustedRateCard = phase3CTrustedRateCard(
+            promptRatePerMtok: 1_000_000,
+            completionRatePerMtok: 2_000_000,
+            usdPerMillionCredits: 1.0
+        )
+        let budget = ConsumeBudgetConfig(
+            mode: .budget(ConsumeMicroUSD(rawValue: 100_000_000)),
+            maxRequestMicroUSD: nil,
+            allowUnpriced: false,
+            ledger: ledger,
+            ledgerPathClass: ledger.pathClass
+        )
+        let oversizedBody = Data(repeating: UInt8(ascii: "x"), count: ConsumeLocalLimits.bodyBytes + 1)
+        let compressedBody = try gzipData(oversizedBody)
+        let upstreamClient = ConsumeStubUpstreamClient { _, eventLoop in
+            eventLoop.makeSucceededFuture(ConsumeUpstreamResponse(
+                statusCode: 200,
+                headers: [
+                    ("content-type", "application/json"),
+                    ("content-encoding", "gzip"),
+                ],
+                body: compressedBody
             ))
         }
         let runtime = consumeRuntime(
@@ -2108,6 +2591,7 @@ final class ConsumeCommandTests: XCTestCase {
             "X-Request-Id: ok\nInjected: yes",
             "X-Request-Id: ok\rInjected: yes",
             "X-Request-Id: ok\u{7f}",
+            "Content-Encoding:\u{0b}gzip",
             "Bad Header: value",
         ] {
             XCTAssertThrowsError(try ConsumePinnedUpstreamClient.parseCompleteHTTPResponseForTesting(
@@ -3374,6 +3858,53 @@ final class ConsumeCommandTests: XCTestCase {
     private func localForwardedFlag(from body: String) throws -> Bool {
         let macprovider = try XCTUnwrap(localError(from: body)["macprovider"] as? [String: Any])
         return try XCTUnwrap(macprovider["forwarded_upstream"] as? Bool)
+    }
+
+    private func gzipData(_ data: Data) throws -> Data {
+        guard data.count <= Int(UInt32.max) else {
+            throw NSError(domain: "ConsumeCommandTests.gzip", code: -1)
+        }
+        var stream = z_stream()
+        let initStatus = deflateInit2_(
+            &stream,
+            Z_DEFAULT_COMPRESSION,
+            Z_DEFLATED,
+            16 + MAX_WBITS,
+            8,
+            Z_DEFAULT_STRATEGY,
+            ZLIB_VERSION,
+            Int32(MemoryLayout<z_stream>.size)
+        )
+        guard initStatus == Z_OK else {
+            throw NSError(domain: "ConsumeCommandTests.gzip", code: Int(initStatus))
+        }
+        defer { deflateEnd(&stream) }
+
+        return try data.withUnsafeBytes { input in
+            stream.next_in = UnsafeMutablePointer<Bytef>(
+                mutating: input.bindMemory(to: Bytef.self).baseAddress
+            )
+            stream.avail_in = uInt(data.count)
+            var output = Data()
+            let chunkSize = 32 * 1024
+            var status: Int32 = Z_OK
+            repeat {
+                var buffer = [UInt8](repeating: 0, count: chunkSize)
+                status = buffer.withUnsafeMutableBytes { rawBuffer -> Int32 in
+                    stream.next_out = rawBuffer.bindMemory(to: Bytef.self).baseAddress
+                    stream.avail_out = uInt(chunkSize)
+                    return deflate(&stream, Z_FINISH)
+                }
+                let produced = chunkSize - Int(stream.avail_out)
+                if produced > 0 {
+                    output.append(contentsOf: buffer.prefix(produced))
+                }
+                guard status == Z_OK || status == Z_STREAM_END else {
+                    throw NSError(domain: "ConsumeCommandTests.gzip", code: Int(status))
+                }
+            } while status != Z_STREAM_END
+            return output
+        }
     }
 
     private func writeCredential(_ value: String, under directory: URL, name: String) throws -> URL {

--- a/specs/design/spec-045/BUILD_SPEC_045_LOCAL_CONSUMER_ENDPOINT_IMPL.md
+++ b/specs/design/spec-045/BUILD_SPEC_045_LOCAL_CONSUMER_ENDPOINT_IMPL.md
@@ -20,7 +20,9 @@ Ship `macprovider-cli consume` as a local development adapter: a macOS loopback-
    - non-streaming upstream forwarding, pinned dispatch, durable reservation settlement, failure provenance, and Phase 3D transport hardening.
 6. `BUILD_SPEC_045_PHASE_3E_RESOURCE_ACCOUNTING.md`
    - aggregate response-spool, upstream worker-task, upstream socket/file-descriptor, and streaming-response slot admission.
-7. `BUILD_SPEC_045_PHASE_4_CONFORMANCE_JOURNEY.md`
+7. `BUILD_SPEC_045_PHASE_3F_COMPRESSED_RESPONSE.md`
+   - compressed non-streaming upstream response decode-to-identity, decoded response caps, and settlement from decoded usage.
+8. `BUILD_SPEC_045_PHASE_4_CONFORMANCE_JOURNEY.md`
    - required automated coverage, fake-gateway integration harness, staging/production signed journey, and promotion evidence.
 
 ## Required sequencing
@@ -31,6 +33,7 @@ Ship `macprovider-cli consume` as a local development adapter: a macOS loopback-
 - Phase 3 must not forward chargeable requests until durable reservation append and conservative pricing admission are implemented.
 - Phase 3D may land without streaming/SSE forwarding, aggregate response-spool/socket admission, compressed non-streaming decode-to-identity, or mutable upstream invalid-credential state; those remain required before Phase 4 can claim conformance.
 - Phase 3E may land without streaming/SSE forwarding, compressed non-streaming decode-to-identity, or mutable upstream invalid-credential state; those remain required before Phase 4 can claim conformance.
+- Phase 3F may land without streaming/SSE forwarding, mutable upstream invalid-credential state, or fake/real conformance journeys; those remain required before Phase 4 can claim conformance.
 - Phase 4 must not claim production readiness until Phases 1-3 are implemented and the signed real-gateway journey exists.
 
 ## Non-goals

--- a/specs/design/spec-045/BUILD_SPEC_045_PHASE_3F_COMPRESSED_RESPONSE.md
+++ b/specs/design/spec-045/BUILD_SPEC_045_PHASE_3F_COMPRESSED_RESPONSE.md
@@ -1,0 +1,83 @@
+# BUILD_SPEC_045_PHASE_3F_COMPRESSED_RESPONSE
+
+Implement compressed non-streaming upstream response normalization for the
+SPEC-045 local consumer endpoint after aggregate resource admission exists.
+This slice owns gzip response decoding before local delivery and before budget
+settlement.
+
+This is a build slice, not a production-conformance declaration. Streaming
+forwarding, mutable invalid-credential state, and fake/real gateway journeys
+remain later work.
+
+## Target Result
+
+For non-streaming chargeable upstream responses, the local endpoint accepts an
+upstream `Content-Encoding: gzip` response, decodes it under the existing local
+response body cap, strips compression metadata, settles ledger usage from the
+decoded JSON body when possible, and returns an identity response to the local
+client. Unsupported, ambiguous, malformed, or oversized response codings fail
+closed after upstream dispatch as `502 local_upstream_unavailable` with
+`forwarded_upstream: true`.
+
+## Required Implementation Shape
+
+1. Normalize upstream responses before settlement and local delivery:
+   - parse all upstream `Content-Encoding` header values as comma-separated
+     tokens;
+   - no content coding and explicit `identity`-only coding are identity;
+   - exactly one `gzip` coding is supported;
+   - blank, duplicated, stacked, mixed, or unsupported codings are rejected.
+
+2. Decode gzip responses with bounded output:
+   - use a real gzip decoder, not ad hoc header stripping;
+   - cap decoded bytes at `ConsumeLocalLimits.bodyBytes`;
+   - reject malformed gzip data, trailing compressed junk, zlib failures, and
+     decoded output larger than the cap as dispatched upstream failures.
+   - reserve aggregate non-streaming response-spool capacity for the
+     compression-capable peak where encoded and decoded bodies can coexist.
+
+3. Preserve local response safety:
+   - remove upstream `Content-Encoding` and upstream `Content-Length` from the
+     normalized response;
+   - let the existing local response writer set the decoded `Content-Length`;
+   - continue to forward only the existing allowed upstream response headers;
+   - do not add streaming response support in this slice.
+
+4. Settle from decoded usage:
+   - compute actual usage settlement from the decoded upstream JSON body when
+     usage is parseable;
+   - retain the existing admission-estimate fallback when decoded usage is
+     absent, unparsable, or out of settlement bounds;
+   - on compressed response normalization failure after ledger reservation,
+     settle to the admission estimate before returning the local upstream
+     failure.
+
+## Acceptance Tests
+
+- gzip upstream response bodies decode to identity before local success;
+- local success strips `Content-Encoding`, rewrites `Content-Length` to the
+  decoded byte count, and preserves allowed response headers;
+- ledger settlement uses decoded upstream usage when present;
+- malformed gzip upstream responses fail as `502 local_upstream_unavailable`
+  with `forwarded_upstream: true` and settle to the admission estimate;
+- gzip responses whose decoded body exceeds `ConsumeLocalLimits.bodyBytes`
+  fail before local success and settle to the admission estimate;
+- unsupported or ambiguous response codings remain fail-closed.
+
+## Follow-Up Slices
+
+- streaming/SSE forwarding, event bounds, disconnect handling, and SSE
+  settlement evidence after `[DONE]`;
+- mutable credential state that marks invalid or expired upstream buyer
+  credentials while preserving the initiating client's upstream auth failure;
+- fake-gateway and real-gateway conformance journeys.
+
+## Non-Goals
+
+- Do not implement request compression; local request `Content-Encoding`
+  remains rejected.
+- Do not implement Brotli, deflate, zstd, stacked encodings, or transparent
+  streaming decompression.
+- Do not change gateway billing, coordinator settlement, provider payout, or
+  receipt semantics.
+- Do not claim SPEC-045 production readiness from this slice alone.


### PR DESCRIPTION
## Summary
- add SPEC-045 Phase 3F build slice for compressed non-streaming upstream responses
- decode supported gzip upstream responses before budget settlement and local delivery
- reject ambiguous, malformed, duplicate, mixed, unsupported, or oversized codings as forwarded upstream failures while preserving ledger/provenance safety
- reserve aggregate non-streaming response spool for encoded+decoded coexistence

## Validation
- `swift test --filter ConsumeCommandTests/testPhase3F --skip-update` (9 tests)
- `swift test --filter ConsumeCommandTests --skip-update` (93 tests)
- `swift build --target macprovider-cli --skip-update`
- `git diff --check`
- `jq empty specs/AUTHORITY.json && jq empty specs/CONFORMANCE.json`
- `python3 scripts/gen_spec_index.py --check && python3 scripts/gen_spec_index.py --lint`
- `python3 scripts/check_spec_governance.py --base-ref origin/main`
- `python3 -m unittest scripts.tests.test_spec_governance scripts.tests.test_spec_pr_declaration`
- 3-lane Codex audit on `/tmp/spec045-phase3f-full.diff` SHA-256 `1ed1d4b42cc2c579b67dc58601beda50d35fb43bfc637636d6b681a9bd71dcfb`: code/security/architecture all 0 C/H/M

## Audit Notes
- Carried LOW: upstream response field names with OWS before `:` are still normalized rather than rejected.
- Carried LOW: add direct trailing-gzip-junk and concatenated-member regression tests; implementation already rejects trailing inflate input.

SPEC-GOVERNANCE-DECLARATION-BEGIN
{
  "schema_version": "spec-pr-governance-v1",
  "issue": "https://github.com/Augustas11/macprovider/issues/927",
  "behavior_change": "yes",
  "contract_change": "none",
  "specs": ["SPEC-045"],
  "requirements": ["SPEC-045-R005", "SPEC-045-R007", "SPEC-045-R008"],
  "authority_domains": ["local-consumer-endpoint"],
  "arbitration": ["DECISION_REQUIRED"],
  "tests": [
    "swift test --filter ConsumeCommandTests/testPhase3F --skip-update",
    "swift test --filter ConsumeCommandTests --skip-update",
    "swift build --target macprovider-cli --skip-update",
    "git diff --check",
    "python3 scripts/check_spec_governance.py --base-ref origin/main"
  ],
  "journeys": ["not-required: build slice before Phase 4 fake/real gateway conformance journeys"]
}
SPEC-GOVERNANCE-DECLARATION-END
