### PR TITLE
Implement SPEC-045 Phase 3G buffered SSE foundation

### DIFF
--- a/phase3-binary/Sources/macprovider-cli/ConsumeCommand.swift
+++ b/phase3-binary/Sources/macprovider-cli/ConsumeCommand.swift
@@ -641,6 +641,7 @@ struct ConsumeUpstreamRequest: Sendable {
     let endpoint: String
     let bearerToken: String
     let body: Data
+    let streaming: Bool
 }
 
 struct ConsumeUpstreamResponse: Sendable {
@@ -869,7 +870,8 @@ final class ConsumePinnedUpstreamClient: ConsumeUpstreamClient, @unchecked Senda
             host: host,
             port: portValue,
             bearerToken: upstreamRequest.bearerToken,
-            body: upstreamRequest.body
+            body: upstreamRequest.body,
+            streaming: upstreamRequest.streaming
         )
         do {
             try await send(
@@ -1246,7 +1248,7 @@ final class ConsumePinnedUpstreamClient: ConsumeUpstreamClient, @unchecked Senda
         }
     }
 
-    private static func httpRequestBytes(host: String, port: Int, bearerToken: String, body: Data) -> Data {
+    private static func httpRequestBytes(host: String, port: Int, bearerToken: String, body: Data, streaming: Bool) -> Data {
         let hostHeader = host.contains(":") && !host.hasPrefix("[") ? "[\(host)]" : host
         let authority = port == 443 ? hostHeader : "\(hostHeader):\(port)"
         var request = Data()
@@ -1254,7 +1256,7 @@ final class ConsumePinnedUpstreamClient: ConsumeUpstreamClient, @unchecked Senda
         request.append(Data("Host: \(authority)\r\n".utf8))
         request.append(Data("Authorization: Bearer \(bearerToken)\r\n".utf8))
         request.append(Data("Content-Type: application/json\r\n".utf8))
-        request.append(Data("Accept: application/json\r\n".utf8))
+        request.append(Data("Accept: \(streaming ? "text/event-stream" : "application/json")\r\n".utf8))
         request.append(Data("Accept-Encoding: identity\r\n".utf8))
         request.append(Data("Connection: close\r\n".utf8))
         request.append(Data("Content-Length: \(body.count)\r\n\r\n".utf8))
@@ -3278,8 +3280,14 @@ struct ConsumeEndpointRuntime: Sendable {
         requestCounter.releaseBodyBytes(count)
     }
 
-    func reserveUpstreamExchange(responseSpoolBytes: Int) -> ConsumeEndpointResourceReservation? {
-        requestCounter.reserveUpstreamExchange(responseSpoolBytes: responseSpoolBytes)
+    func reserveUpstreamExchange(
+        responseSpoolBytes: Int,
+        openStreamingResponse: Bool = false
+    ) -> ConsumeEndpointResourceReservation? {
+        requestCounter.reserveUpstreamExchange(
+            responseSpoolBytes: responseSpoolBytes,
+            openStreamingResponse: openStreamingResponse
+        )
     }
 
     func releaseUpstreamExchange(_ reservation: ConsumeEndpointResourceReservation) {
@@ -3405,6 +3413,7 @@ struct ConsumeEndpointResourceReservation: Sendable {
     let responseSpoolBytes: Int
     let upstreamWorkerTasks: Int
     let upstreamSocketDescriptors: Int
+    let openStreamingResponses: Int
 }
 
 struct ConsumeEndpointResourceSnapshot: Sendable {
@@ -3501,28 +3510,36 @@ final class ConsumeEndpointRequestCounter: @unchecked Sendable {
         lock.unlock()
     }
 
-    func reserveUpstreamExchange(responseSpoolBytes count: Int) -> ConsumeEndpointResourceReservation? {
+    func reserveUpstreamExchange(
+        responseSpoolBytes count: Int,
+        openStreamingResponse: Bool = false
+    ) -> ConsumeEndpointResourceReservation? {
         lock.lock()
         defer { lock.unlock() }
+        let streamingSlots = openStreamingResponse ? 1 : 0
         guard count >= 0,
               responseSpoolBytes <= maxResponseSpoolBytes - count,
+              openStreamingResponses <= maxOpenStreamingResponses - streamingSlots,
               upstreamWorkerTasks < maxUpstreamWorkerTasks,
               upstreamSocketDescriptors < maxUpstreamSocketDescriptors else {
             return nil
         }
         responseSpoolBytes += count
+        openStreamingResponses += streamingSlots
         upstreamWorkerTasks += 1
         upstreamSocketDescriptors += 1
         return ConsumeEndpointResourceReservation(
             responseSpoolBytes: count,
             upstreamWorkerTasks: 1,
-            upstreamSocketDescriptors: 1
+            upstreamSocketDescriptors: 1,
+            openStreamingResponses: streamingSlots
         )
     }
 
     func releaseUpstreamExchange(_ reservation: ConsumeEndpointResourceReservation) {
         lock.lock()
         responseSpoolBytes = max(0, responseSpoolBytes - max(0, reservation.responseSpoolBytes))
+        openStreamingResponses = max(0, openStreamingResponses - max(0, reservation.openStreamingResponses))
         upstreamWorkerTasks = max(0, upstreamWorkerTasks - max(0, reservation.upstreamWorkerTasks))
         upstreamSocketDescriptors = max(0, upstreamSocketDescriptors - max(0, reservation.upstreamSocketDescriptors))
         lock.unlock()
@@ -4181,10 +4198,7 @@ final class ConsumeLocalHandler: ChannelInboundHandler, @unchecked Sendable {
     }
 
     private func writeLocalChatAdmissionFailure(model: String, request: JSONValue, bodyByteCount: Int, context: ChannelHandlerContext) {
-        guard request.objectBool("stream") != true else {
-            writeLocalError(context: context, status: .serviceUnavailable, code: "local_pricing_unavailable")
-            return
-        }
+        let isStreaming = request.objectBool("stream") == true
         let trustedPricing = runtime.trustedPricing.revalidated(now: runtime.now())
         let pricingMatch = trustedPricing.match(model: model)
         let trustedPricingWarnings = trustedPricing.warningCodes(match: pricingMatch)
@@ -4231,7 +4245,7 @@ final class ConsumeLocalHandler: ChannelInboundHandler, @unchecked Sendable {
             }
             let headers = warningHeaders(runtime.budget.localWarningTokens + trustedPricingWarnings)
             let contextBox = ConsumeNIOContextBox(context)
-            resolveUpstreamEndpoint(context: context, extraHeaders: headers) { [weak self] endpoint in
+            resolveUpstreamEndpoint(streaming: isStreaming, context: context, extraHeaders: headers) { [weak self] endpoint in
                 guard let self else { return false }
                 guard !self.channelInactiveWhileUpstreamPending else { return false }
                 guard !self.runtime.pricingAdmissionGate.isEstimateExceeded() else {
@@ -4292,6 +4306,7 @@ final class ConsumeLocalHandler: ChannelInboundHandler, @unchecked Sendable {
                         case .reserved(let reservationID, let reservedAmount):
                             self.forwardUpstreamWithLedgerSettlement(
                                 body: self.requestBody,
+                                streaming: isStreaming,
                                 context: contextBox.context,
                                 endpoint: endpoint,
                                 bearerToken: bearerToken,
@@ -4312,6 +4327,7 @@ final class ConsumeLocalHandler: ChannelInboundHandler, @unchecked Sendable {
                 }
                 self.forwardUpstreamWithoutLedger(
                     body: self.requestBody,
+                    streaming: isStreaming,
                     context: contextBox.context,
                     endpoint: endpoint,
                     bearerToken: bearerToken,
@@ -4379,7 +4395,7 @@ final class ConsumeLocalHandler: ChannelInboundHandler, @unchecked Sendable {
                 }
                 let headers = warningHeaders(runtime.budget.localWarningTokens + trustedPricingWarnings)
                 let contextBox = ConsumeNIOContextBox(context)
-                resolveUpstreamEndpoint(context: context, extraHeaders: headers) { [weak self] endpoint in
+                resolveUpstreamEndpoint(streaming: isStreaming, context: context, extraHeaders: headers) { [weak self] endpoint in
                     guard let self else { return false }
                     guard !self.channelInactiveWhileUpstreamPending else { return false }
                     guard !self.runtime.pricingAdmissionGate.isEstimateExceeded() else {
@@ -4461,6 +4477,7 @@ final class ConsumeLocalHandler: ChannelInboundHandler, @unchecked Sendable {
                         case .reserved(let reservationID, let reservedAmount):
                             self.forwardUpstreamWithLedgerSettlement(
                                 body: self.requestBody,
+                                streaming: isStreaming,
                                 context: contextBox.context,
                                 endpoint: endpoint,
                                 bearerToken: bearerToken,
@@ -4490,6 +4507,7 @@ final class ConsumeLocalHandler: ChannelInboundHandler, @unchecked Sendable {
 
     private func forwardUpstreamWithoutLedger(
         body: Data,
+        streaming: Bool,
         context: ChannelHandlerContext,
         endpoint: String,
         bearerToken: String,
@@ -4499,7 +4517,8 @@ final class ConsumeLocalHandler: ChannelInboundHandler, @unchecked Sendable {
             origin: runtime.upstreamOrigin,
             endpoint: endpoint,
             bearerToken: bearerToken,
-            body: body
+            body: body,
+            streaming: streaming
         )
         let contextBox = ConsumeNIOContextBox(context)
         upstreamForwardIsPending = true
@@ -4515,7 +4534,7 @@ final class ConsumeLocalHandler: ChannelInboundHandler, @unchecked Sendable {
             switch result {
             case .success(let response):
                 do {
-                    let localResponse = try Self.responseForLocalDelivery(response)
+                    let localResponse = try Self.responseForLocalDelivery(response, streaming: streaming)
                     self.writeUpstreamResponse(localResponse, context: contextBox.context, extraHeaders: extraHeaders)
                 } catch {
                     self.writeLocalError(
@@ -4541,6 +4560,7 @@ final class ConsumeLocalHandler: ChannelInboundHandler, @unchecked Sendable {
 
     private func forwardUpstreamWithLedgerSettlement(
         body: Data,
+        streaming: Bool,
         context: ChannelHandlerContext,
         endpoint: String,
         bearerToken: String,
@@ -4556,7 +4576,8 @@ final class ConsumeLocalHandler: ChannelInboundHandler, @unchecked Sendable {
             origin: runtime.upstreamOrigin,
             endpoint: endpoint,
             bearerToken: bearerToken,
-            body: body
+            body: body,
+            streaming: streaming
         )
         let contextBox = ConsumeNIOContextBox(context)
         upstreamForwardIsPending = true
@@ -4573,9 +4594,10 @@ final class ConsumeLocalHandler: ChannelInboundHandler, @unchecked Sendable {
             case .success(let response):
                 let localResponse: ConsumeUpstreamResponse
                 do {
-                    localResponse = try Self.responseForLocalDelivery(response)
+                    localResponse = try Self.responseForLocalDelivery(response, streaming: streaming)
                     let settlement = try self.settlementAmount(
                         response: localResponse,
+                        streaming: streaming,
                         fallbackEstimate: estimate.amount,
                         pricingMatch: pricingMatch,
                         projection: projection
@@ -4677,12 +4699,13 @@ final class ConsumeLocalHandler: ChannelInboundHandler, @unchecked Sendable {
     }
 
     private func resolveUpstreamEndpoint(
+        streaming: Bool,
         context: ChannelHandlerContext,
         extraHeaders: [(String, String)],
         onSuccess: @escaping @Sendable (String) -> Bool
     ) {
         let contextBox = ConsumeNIOContextBox(context)
-        guard reserveUpstreamResources(context: contextBox.context, extraHeaders: extraHeaders) else { return }
+        guard reserveUpstreamResources(streaming: streaming, context: contextBox.context, extraHeaders: extraHeaders) else { return }
         upstreamForwardIsPending = true
         upstreamForwardWasDispatched = false
         channelInactiveWhileUpstreamPending = false
@@ -4717,12 +4740,14 @@ final class ConsumeLocalHandler: ChannelInboundHandler, @unchecked Sendable {
     }
 
     private func reserveUpstreamResources(
+        streaming: Bool,
         context: ChannelHandlerContext,
         extraHeaders: [(String, String)]
     ) -> Bool {
         guard upstreamResourceReservation == nil,
               let reservation = runtime.reserveUpstreamExchange(
-                responseSpoolBytes: ConsumeLocalLimits.nonStreamingResponseSpoolBytes
+                responseSpoolBytes: streaming ? 0 : ConsumeLocalLimits.nonStreamingResponseSpoolBytes,
+                openStreamingResponse: streaming
               ) else {
             writeLocalError(
                 context: context,
@@ -4763,13 +4788,24 @@ final class ConsumeLocalHandler: ChannelInboundHandler, @unchecked Sendable {
 
     private func settlementAmount(
         response: ConsumeUpstreamResponse,
+        streaming: Bool,
         fallbackEstimate: ConsumeMicroUSD,
         pricingMatch: ConsumeTrustedRateCardMatch,
         projection: RateCardProjection
     ) throws -> (amount: ConsumeMicroUSD, reason: String) {
-        guard let text = String(data: response.body, encoding: .utf8),
-              case .object(let root) = try? StrictJSONParser.parse(text),
-              case .object(let usage)? = root["usage"],
+        let usage: [String: JSONValue]?
+        if streaming, response.statusCode >= 200, response.statusCode < 300 {
+            usage = try Self.lastSSEUsageObject(response.body)
+        } else if streaming {
+            usage = nil
+        } else if let text = String(data: response.body, encoding: .utf8),
+                  case .object(let root) = try? StrictJSONParser.parse(text),
+                  case .object(let parsedUsage)? = root["usage"] {
+            usage = parsedUsage
+        } else {
+            usage = nil
+        }
+        guard let usage,
               case .int(let promptTokens)? = usage["prompt_tokens"],
               case .int(let completionTokens)? = usage["completion_tokens"] else {
             return (fallbackEstimate, "settled_to_admission_estimate")
@@ -4785,7 +4821,14 @@ final class ConsumeLocalHandler: ChannelInboundHandler, @unchecked Sendable {
         return (amount, "settled_to_upstream_usage")
     }
 
-    private static func responseForLocalDelivery(_ response: ConsumeUpstreamResponse) throws -> ConsumeUpstreamResponse {
+    private static func responseForLocalDelivery(_ response: ConsumeUpstreamResponse, streaming: Bool) throws -> ConsumeUpstreamResponse {
+        if streaming, response.statusCode >= 200, response.statusCode < 300 {
+            return try streamingResponseForLocalDelivery(response)
+        }
+        return try nonStreamingResponseForLocalDelivery(response)
+    }
+
+    private static func nonStreamingResponseForLocalDelivery(_ response: ConsumeUpstreamResponse) throws -> ConsumeUpstreamResponse {
         switch try upstreamResponseContentCoding(response.headers) {
         case .identity:
             return ConsumeUpstreamResponse(
@@ -4807,6 +4850,99 @@ final class ConsumeLocalHandler: ChannelInboundHandler, @unchecked Sendable {
                 body: decodedBody
             )
         }
+    }
+
+    private static func streamingResponseForLocalDelivery(_ response: ConsumeUpstreamResponse) throws -> ConsumeUpstreamResponse {
+        guard try upstreamResponseContentCoding(response.headers) == .identity,
+              upstreamResponseIsEventStream(response.headers) else {
+            throw ConsumeUpstreamForwardError.dispatchedUnavailable
+        }
+        _ = try lastSSEUsageObject(response.body)
+        return ConsumeUpstreamResponse(
+            statusCode: response.statusCode,
+            headers: response.headers.filter { name, _ in
+                name.caseInsensitiveCompare("content-encoding") != .orderedSame &&
+                    name.caseInsensitiveCompare("content-length") != .orderedSame
+            },
+            body: response.body
+        )
+    }
+
+    private static func upstreamResponseIsEventStream(_ headers: [(String, String)]) -> Bool {
+        let values = headers
+            .filter { name, _ in name.caseInsensitiveCompare("content-type") == .orderedSame }
+            .map { _, value in trimHTTPOptionalWhitespace(value[...]).lowercased() }
+        guard values.count == 1,
+              let value = values.first else {
+            return false
+        }
+        let mediaType = value.split(separator: ";", maxSplits: 1, omittingEmptySubsequences: false).first ?? ""
+        return trimHTTPOptionalWhitespace(mediaType[...]) == "text/event-stream"
+    }
+
+    private static func lastSSEUsageObject(_ body: Data) throws -> [String: JSONValue]? {
+        guard let text = String(data: body, encoding: .utf8) else {
+            throw ConsumeUpstreamForwardError.dispatchedUnavailable
+        }
+        var dataLines: [String] = []
+        var sawDone = false
+        var lastUsage: [String: JSONValue]?
+
+        func finishEvent() throws {
+            guard !dataLines.isEmpty else { return }
+            let payload = dataLines.joined(separator: "\n")
+            dataLines.removeAll(keepingCapacity: true)
+            if payload == "[DONE]" {
+                guard !sawDone else {
+                    throw ConsumeUpstreamForwardError.dispatchedUnavailable
+                }
+                sawDone = true
+                return
+            }
+            guard !sawDone else {
+                throw ConsumeUpstreamForwardError.dispatchedUnavailable
+            }
+            guard case .object(let root) = try? StrictJSONParser.parse(payload) else {
+                throw ConsumeUpstreamForwardError.dispatchedUnavailable
+            }
+            if case .object(let usage)? = root["usage"] {
+                lastUsage = usage
+            }
+        }
+
+        for rawLine in text.split(separator: "\n", omittingEmptySubsequences: false) {
+            let line = rawLine.last == "\r" ? rawLine.dropLast() : rawLine[...]
+            if line.isEmpty {
+                try finishEvent()
+                continue
+            }
+            guard !sawDone else {
+                throw ConsumeUpstreamForwardError.dispatchedUnavailable
+            }
+            if line.hasPrefix(":") {
+                continue
+            }
+            if line == "data" {
+                dataLines.append("")
+                continue
+            }
+            if line.hasPrefix("data:") {
+                var value = line.dropFirst(5)
+                if value.first == " " {
+                    value = value.dropFirst()
+                }
+                dataLines.append(String(value))
+                continue
+            }
+            guard line.contains(":") else {
+                throw ConsumeUpstreamForwardError.dispatchedUnavailable
+            }
+        }
+        try finishEvent()
+        guard sawDone else {
+            throw ConsumeUpstreamForwardError.dispatchedUnavailable
+        }
+        return lastUsage
     }
 
     private static func upstreamResponseContentCoding(_ headers: [(String, String)]) throws -> ConsumeUpstreamResponseContentCoding {

--- a/phase3-binary/Tests/macprovider-cliTests/ConsumeCommandTests.swift
+++ b/phase3-binary/Tests/macprovider-cliTests/ConsumeCommandTests.swift
@@ -780,6 +780,14 @@ final class ConsumeCommandTests: XCTestCase {
         XCTAssertEqual(streamingCounter.resourceSnapshot().openStreamingResponses, 1)
         streamingCounter.endStreamingResponse()
         XCTAssertEqual(streamingCounter.resourceSnapshot().openStreamingResponses, 0)
+        let streamingReservation = try XCTUnwrap(streamingCounter.reserveUpstreamExchange(
+            responseSpoolBytes: 0,
+            openStreamingResponse: true
+        ))
+        XCTAssertFalse(streamingCounter.reserveUpstreamExchange(responseSpoolBytes: 0, openStreamingResponse: true) != nil)
+        XCTAssertEqual(streamingCounter.resourceSnapshot().openStreamingResponses, 1)
+        streamingCounter.releaseUpstreamExchange(streamingReservation)
+        XCTAssertEqual(streamingCounter.resourceSnapshot().openStreamingResponses, 0)
     }
 
     func testPhase2PostHeaderIdleTimeoutReleasesActiveCapacity() throws {
@@ -2552,6 +2560,588 @@ final class ConsumeCommandTests: XCTestCase {
         XCTAssertEqual(summary.estimateExceeded.rawValue, 0)
     }
 
+    func testPhase3GStreamingResponseRelaysAfterDoneAndSettlesUsage() throws {
+        let token = try ConsumeLocalToken.generate()
+        let home = try makeTemporaryDirectory()
+        let ledgerURL = home.appendingPathComponent("budget.jsonl")
+        let ledger = try ConsumeBudgetLedger.open(ledgerPath: ledgerURL.path, homeDirectory: home, startupDirectory: home)
+        let trustedRateCard = phase3CTrustedRateCard(
+            promptRatePerMtok: 1_000_000,
+            completionRatePerMtok: 2_000_000,
+            usdPerMillionCredits: 1.0
+        )
+        let budget = ConsumeBudgetConfig(
+            mode: .budget(ConsumeMicroUSD(rawValue: 100_000_000)),
+            maxRequestMicroUSD: nil,
+            allowUnpriced: false,
+            ledger: ledger,
+            ledgerPathClass: ledger.pathClass
+        )
+        let recorder = ConsumeUpstreamRequestRecorder()
+        let sseBody = """
+        data: {"id":"chunk-1","choices":[{"delta":{"content":"hello"}}]}
+
+        data: {"id":"chunk-2","choices":[],"usage":{"prompt_tokens":1,"completion_tokens":2,"total_tokens":3}}
+
+        data: [DONE]
+
+        """
+        let upstreamClient = ConsumeStubUpstreamClient { request, eventLoop in
+            recorder.append(request)
+            return eventLoop.makeSucceededFuture(ConsumeUpstreamResponse(
+                statusCode: 200,
+                headers: [
+                    ("content-type", "text/event-stream; charset=utf-8"),
+                    ("content-length", "999999"),
+                    ("x-request-id", "stream-request-id"),
+                ],
+                body: Data(sseBody.utf8)
+            ))
+        }
+        let runtime = consumeRuntime(
+            token: token,
+            credentialStatus: .environmentLoaded,
+            credentialCustody: consumeCredentialCustody("buyer-token"),
+            budget: budget,
+            trustedPricing: .available(trustedRateCard),
+            upstreamClient: upstreamClient,
+            now: { ConsumeCommandTests.phase3CTestNow }
+        )
+        var headers = HTTPHeaders()
+        headers.add(name: "Authorization", value: "Bearer \(token.value)")
+        let body = #"{"model":"llama-test","messages":[],"max_tokens":10,"stream":true}"#
+        let expectedSettlement = try ConsumePricedExposureEstimator.actualUsageSettlement(
+            promptTokens: 1,
+            completionTokens: 2,
+            match: XCTUnwrap(trustedRateCard.match(model: "llama-test")),
+            projection: trustedRateCard.projection
+        )
+
+        let response = try response(
+            from: runtime,
+            head: HTTPRequestHead(version: .http1_1, method: .POST, uri: "/v1/chat/completions", headers: headers),
+            body: Data(body.utf8)
+        )
+
+        XCTAssertEqual(response.status, .ok)
+        XCTAssertEqual(response.body, sseBody)
+        XCTAssertEqual(response.headers.first(name: "content-type"), "text/event-stream; charset=utf-8")
+        XCTAssertEqual(response.headers.first(name: "content-length"), "\(Data(sseBody.utf8).count)")
+        XCTAssertNil(response.headers.first(name: "content-encoding"))
+        XCTAssertEqual(response.headers.first(name: "x-request-id"), "stream-request-id")
+        let forwarded = try XCTUnwrap(recorder.snapshot().first)
+        XCTAssertTrue(forwarded.streaming)
+        XCTAssertEqual(forwarded.body, Data(body.utf8))
+        let summary = try ledger.summary()
+        XCTAssertEqual(summary.reserved.rawValue, 0)
+        XCTAssertEqual(summary.held.rawValue, 0)
+        XCTAssertEqual(summary.settled.rawValue, expectedSettlement.rawValue)
+        XCTAssertEqual(summary.estimateExceeded.rawValue, 0)
+        let resourceSnapshot = runtime.requestCounter.resourceSnapshot()
+        XCTAssertEqual(resourceSnapshot.openStreamingResponses, 0)
+        XCTAssertEqual(resourceSnapshot.responseSpoolBytes, 0)
+    }
+
+    func testPhase3GNoBudgetExplicitLedgerRecordsAndSettlesStreamingAuditRows() throws {
+        let token = try ConsumeLocalToken.generate()
+        let home = try makeTemporaryDirectory()
+        let ledgerURL = home.appendingPathComponent("no-budget.jsonl")
+        let ledger = try ConsumeBudgetLedger.open(ledgerPath: ledgerURL.path, homeDirectory: home, startupDirectory: home)
+        let trustedRateCard = phase3CTrustedRateCard(
+            promptRatePerMtok: 1_000_000,
+            completionRatePerMtok: 2_000_000,
+            usdPerMillionCredits: 1.0
+        )
+        let budget = ConsumeBudgetConfig(
+            mode: .noBudget,
+            maxRequestMicroUSD: nil,
+            allowUnpriced: false,
+            ledger: ledger,
+            ledgerPathClass: ledger.pathClass
+        )
+        let recorder = ConsumeUpstreamRequestRecorder()
+        let sseBody = """
+        data: {"choices":[],"usage":{"prompt_tokens":1,"completion_tokens":2}}
+
+        data: [DONE]
+
+        """
+        let upstreamClient = ConsumeStubUpstreamClient { request, eventLoop in
+            recorder.append(request)
+            return eventLoop.makeSucceededFuture(ConsumeUpstreamResponse(
+                statusCode: 200,
+                headers: [
+                    ("content-type", "text/event-stream"),
+                    ("x-macprovider-warning", "upstream_notice"),
+                ],
+                body: Data(sseBody.utf8)
+            ))
+        }
+        let runtime = consumeRuntime(
+            token: token,
+            credentialStatus: .environmentLoaded,
+            credentialCustody: consumeCredentialCustody("buyer-token"),
+            budget: budget,
+            trustedPricing: .available(trustedRateCard),
+            upstreamClient: upstreamClient,
+            now: { ConsumeCommandTests.phase3CTestNow }
+        )
+        var headers = HTTPHeaders()
+        headers.add(name: "Authorization", value: "Bearer \(token.value)")
+        let body = #"{"model":"llama-test","messages":[],"max_tokens":10,"stream":true}"#
+        let expectedSettlement = try ConsumePricedExposureEstimator.actualUsageSettlement(
+            promptTokens: 1,
+            completionTokens: 2,
+            match: XCTUnwrap(trustedRateCard.match(model: "llama-test")),
+            projection: trustedRateCard.projection
+        )
+
+        let response = try response(
+            from: runtime,
+            head: HTTPRequestHead(version: .http1_1, method: .POST, uri: "/v1/chat/completions", headers: headers),
+            body: Data(body.utf8)
+        )
+
+        XCTAssertEqual(response.status, .ok)
+        XCTAssertEqual(response.body, sseBody)
+        XCTAssertEqual(response.headers.first(name: "x-macprovider-warning"), "upstream_notice,no_budget")
+        XCTAssertTrue(try XCTUnwrap(recorder.snapshot().first).streaming)
+        let summary = try ledger.summary()
+        XCTAssertEqual(summary.reserved.rawValue, 0)
+        XCTAssertEqual(summary.held.rawValue, 0)
+        XCTAssertEqual(summary.settled.rawValue, expectedSettlement.rawValue)
+    }
+
+    func testPhase3GStreamingSlotSaturationRejectsBeforeResolverLedgerAndForwarding() throws {
+        let token = try ConsumeLocalToken.generate()
+        let home = try makeTemporaryDirectory()
+        let ledgerURL = home.appendingPathComponent("budget.jsonl")
+        let ledger = try ConsumeBudgetLedger.open(ledgerPath: ledgerURL.path, homeDirectory: home, startupDirectory: home)
+        let trustedRateCard = phase3CTrustedRateCard(
+            promptRatePerMtok: 1_000_000,
+            completionRatePerMtok: 2_000_000,
+            usdPerMillionCredits: 1.0
+        )
+        let budget = ConsumeBudgetConfig(
+            mode: .budget(ConsumeMicroUSD(rawValue: 100_000_000)),
+            maxRequestMicroUSD: nil,
+            allowUnpriced: false,
+            ledger: ledger,
+            ledgerPathClass: ledger.pathClass
+        )
+        let resolverCalls = ConsumeInvocationCounter()
+        let forwardCalls = ConsumeInvocationCounter()
+        let upstreamClient = ConsumeStubUpstreamClient(
+            resolver: { _, eventLoop in
+                resolverCalls.increment()
+                return eventLoop.makeSucceededFuture("8.8.8.8")
+            },
+            handler: { _, eventLoop in
+                forwardCalls.increment()
+                return eventLoop.makeFailedFuture(ConsumeUpstreamForwardError.dispatchedUnavailable)
+            }
+        )
+        let counter = ConsumeEndpointRequestCounter(maxOpenStreamingResponses: 0)
+        let runtime = consumeRuntime(
+            token: token,
+            credentialStatus: .environmentLoaded,
+            credentialCustody: consumeCredentialCustody("buyer-token"),
+            budget: budget,
+            trustedPricing: .available(trustedRateCard),
+            upstreamClient: upstreamClient,
+            now: { ConsumeCommandTests.phase3CTestNow },
+            requestCounter: counter
+        )
+        var headers = HTTPHeaders()
+        headers.add(name: "Authorization", value: "Bearer \(token.value)")
+
+        let response = try response(
+            from: runtime,
+            head: HTTPRequestHead(version: .http1_1, method: .POST, uri: "/v1/chat/completions", headers: headers),
+            body: Data(#"{"model":"llama-test","messages":[],"max_tokens":10,"stream":true}"#.utf8)
+        )
+
+        XCTAssertEqual(response.status, .serviceUnavailable)
+        XCTAssertEqual(try localError(from: response.body)["code"] as? String, "local_endpoint_busy")
+        XCTAssertFalse(try localForwardedFlag(from: response.body))
+        XCTAssertEqual(resolverCalls.snapshot(), 0)
+        XCTAssertEqual(forwardCalls.snapshot(), 0)
+        XCTAssertEqual(try ledger.summary(), .empty)
+        let resourceSnapshot = counter.resourceSnapshot()
+        XCTAssertEqual(resourceSnapshot.openStreamingResponses, 0)
+        XCTAssertEqual(resourceSnapshot.responseSpoolBytes, 0)
+    }
+
+    func testPhase3GStreamingMissingDoneFailsBeforeLocalSuccessAndSettlesEstimate() throws {
+        let token = try ConsumeLocalToken.generate()
+        let home = try makeTemporaryDirectory()
+        let ledgerURL = home.appendingPathComponent("budget.jsonl")
+        let ledger = try ConsumeBudgetLedger.open(ledgerPath: ledgerURL.path, homeDirectory: home, startupDirectory: home)
+        let trustedRateCard = phase3CTrustedRateCard(
+            promptRatePerMtok: 1_000_000,
+            completionRatePerMtok: 2_000_000,
+            usdPerMillionCredits: 1.0
+        )
+        let budget = ConsumeBudgetConfig(
+            mode: .budget(ConsumeMicroUSD(rawValue: 100_000_000)),
+            maxRequestMicroUSD: nil,
+            allowUnpriced: false,
+            ledger: ledger,
+            ledgerPathClass: ledger.pathClass
+        )
+        let sseBody = """
+        data: {"choices":[],"usage":{"prompt_tokens":10,"completion_tokens":10}}
+
+        """
+        let upstreamClient = ConsumeStubUpstreamClient { _, eventLoop in
+            eventLoop.makeSucceededFuture(ConsumeUpstreamResponse(
+                statusCode: 200,
+                headers: [("content-type", "text/event-stream")],
+                body: Data(sseBody.utf8)
+            ))
+        }
+        let runtime = consumeRuntime(
+            token: token,
+            credentialStatus: .environmentLoaded,
+            credentialCustody: consumeCredentialCustody("buyer-token"),
+            budget: budget,
+            trustedPricing: .available(trustedRateCard),
+            upstreamClient: upstreamClient,
+            now: { ConsumeCommandTests.phase3CTestNow }
+        )
+        var headers = HTTPHeaders()
+        headers.add(name: "Authorization", value: "Bearer \(token.value)")
+        let body = #"{"model":"llama-test","messages":[],"max_tokens":10,"stream":true}"#
+        let expected = try ConsumePricedExposureEstimator.estimate(
+            bodyByteCount: Data(body.utf8).count,
+            request: StrictJSONParser.parse(body),
+            match: XCTUnwrap(trustedRateCard.match(model: "llama-test")),
+            projection: trustedRateCard.projection
+        )
+
+        let response = try response(
+            from: runtime,
+            head: HTTPRequestHead(version: .http1_1, method: .POST, uri: "/v1/chat/completions", headers: headers),
+            body: Data(body.utf8)
+        )
+
+        XCTAssertEqual(response.status, HTTPResponseStatus(statusCode: 502))
+        XCTAssertEqual(try localError(from: response.body)["code"] as? String, "local_upstream_unavailable")
+        XCTAssertTrue(try localForwardedFlag(from: response.body))
+        let summary = try ledger.summary()
+        XCTAssertEqual(summary.reserved.rawValue, 0)
+        XCTAssertEqual(summary.held.rawValue, 0)
+        XCTAssertEqual(summary.settled.rawValue, expected.amount.rawValue)
+    }
+
+    func testPhase3GCompressedStreamingResponseFailsBeforeLocalSuccessAndSettlesEstimate() throws {
+        let token = try ConsumeLocalToken.generate()
+        let home = try makeTemporaryDirectory()
+        let ledgerURL = home.appendingPathComponent("budget.jsonl")
+        let ledger = try ConsumeBudgetLedger.open(ledgerPath: ledgerURL.path, homeDirectory: home, startupDirectory: home)
+        let trustedRateCard = phase3CTrustedRateCard(
+            promptRatePerMtok: 1_000_000,
+            completionRatePerMtok: 2_000_000,
+            usdPerMillionCredits: 1.0
+        )
+        let budget = ConsumeBudgetConfig(
+            mode: .budget(ConsumeMicroUSD(rawValue: 100_000_000)),
+            maxRequestMicroUSD: nil,
+            allowUnpriced: false,
+            ledger: ledger,
+            ledgerPathClass: ledger.pathClass
+        )
+        let sseBody = "data: [DONE]\n\n"
+        let upstreamClient = ConsumeStubUpstreamClient { _, eventLoop in
+            eventLoop.makeSucceededFuture(ConsumeUpstreamResponse(
+                statusCode: 200,
+                headers: [
+                    ("content-type", "text/event-stream"),
+                    ("content-encoding", "gzip"),
+                ],
+                body: try! self.gzipData(Data(sseBody.utf8))
+            ))
+        }
+        let runtime = consumeRuntime(
+            token: token,
+            credentialStatus: .environmentLoaded,
+            credentialCustody: consumeCredentialCustody("buyer-token"),
+            budget: budget,
+            trustedPricing: .available(trustedRateCard),
+            upstreamClient: upstreamClient,
+            now: { ConsumeCommandTests.phase3CTestNow }
+        )
+        var headers = HTTPHeaders()
+        headers.add(name: "Authorization", value: "Bearer \(token.value)")
+        let body = #"{"model":"llama-test","messages":[],"max_tokens":10,"stream":true}"#
+        let expected = try ConsumePricedExposureEstimator.estimate(
+            bodyByteCount: Data(body.utf8).count,
+            request: StrictJSONParser.parse(body),
+            match: XCTUnwrap(trustedRateCard.match(model: "llama-test")),
+            projection: trustedRateCard.projection
+        )
+
+        let response = try response(
+            from: runtime,
+            head: HTTPRequestHead(version: .http1_1, method: .POST, uri: "/v1/chat/completions", headers: headers),
+            body: Data(body.utf8)
+        )
+
+        XCTAssertEqual(response.status, HTTPResponseStatus(statusCode: 502))
+        XCTAssertEqual(try localError(from: response.body)["code"] as? String, "local_upstream_unavailable")
+        XCTAssertTrue(try localForwardedFlag(from: response.body))
+        let summary = try ledger.summary()
+        XCTAssertEqual(summary.reserved.rawValue, 0)
+        XCTAssertEqual(summary.held.rawValue, 0)
+        XCTAssertEqual(summary.settled.rawValue, expected.amount.rawValue)
+    }
+
+    func testPhase3GWrongStreamingContentTypeFailsBeforeLocalSuccessAndSettlesEstimate() throws {
+        let token = try ConsumeLocalToken.generate()
+        let home = try makeTemporaryDirectory()
+        let ledgerURL = home.appendingPathComponent("budget.jsonl")
+        let ledger = try ConsumeBudgetLedger.open(ledgerPath: ledgerURL.path, homeDirectory: home, startupDirectory: home)
+        let trustedRateCard = phase3CTrustedRateCard(
+            promptRatePerMtok: 1_000_000,
+            completionRatePerMtok: 2_000_000,
+            usdPerMillionCredits: 1.0
+        )
+        let budget = ConsumeBudgetConfig(
+            mode: .budget(ConsumeMicroUSD(rawValue: 100_000_000)),
+            maxRequestMicroUSD: nil,
+            allowUnpriced: false,
+            ledger: ledger,
+            ledgerPathClass: ledger.pathClass
+        )
+        let upstreamClient = ConsumeStubUpstreamClient { _, eventLoop in
+            eventLoop.makeSucceededFuture(ConsumeUpstreamResponse(
+                statusCode: 200,
+                headers: [("content-type", "application/json")],
+                body: Data("data: [DONE]\n\n".utf8)
+            ))
+        }
+        let runtime = consumeRuntime(
+            token: token,
+            credentialStatus: .environmentLoaded,
+            credentialCustody: consumeCredentialCustody("buyer-token"),
+            budget: budget,
+            trustedPricing: .available(trustedRateCard),
+            upstreamClient: upstreamClient,
+            now: { ConsumeCommandTests.phase3CTestNow }
+        )
+        var headers = HTTPHeaders()
+        headers.add(name: "Authorization", value: "Bearer \(token.value)")
+        let body = #"{"model":"llama-test","messages":[],"max_tokens":10,"stream":true}"#
+        let expected = try ConsumePricedExposureEstimator.estimate(
+            bodyByteCount: Data(body.utf8).count,
+            request: StrictJSONParser.parse(body),
+            match: XCTUnwrap(trustedRateCard.match(model: "llama-test")),
+            projection: trustedRateCard.projection
+        )
+
+        let response = try response(
+            from: runtime,
+            head: HTTPRequestHead(version: .http1_1, method: .POST, uri: "/v1/chat/completions", headers: headers),
+            body: Data(body.utf8)
+        )
+
+        XCTAssertEqual(response.status, HTTPResponseStatus(statusCode: 502))
+        XCTAssertEqual(try localError(from: response.body)["code"] as? String, "local_upstream_unavailable")
+        XCTAssertTrue(try localForwardedFlag(from: response.body))
+        let summary = try ledger.summary()
+        XCTAssertEqual(summary.reserved.rawValue, 0)
+        XCTAssertEqual(summary.held.rawValue, 0)
+        XCTAssertEqual(summary.settled.rawValue, expected.amount.rawValue)
+    }
+
+    func testPhase3GMalformedStreamingEventFailsBeforeLocalSuccessAndSettlesEstimate() throws {
+        let token = try ConsumeLocalToken.generate()
+        let home = try makeTemporaryDirectory()
+        let ledgerURL = home.appendingPathComponent("budget.jsonl")
+        let ledger = try ConsumeBudgetLedger.open(ledgerPath: ledgerURL.path, homeDirectory: home, startupDirectory: home)
+        let trustedRateCard = phase3CTrustedRateCard(
+            promptRatePerMtok: 1_000_000,
+            completionRatePerMtok: 2_000_000,
+            usdPerMillionCredits: 1.0
+        )
+        let budget = ConsumeBudgetConfig(
+            mode: .budget(ConsumeMicroUSD(rawValue: 100_000_000)),
+            maxRequestMicroUSD: nil,
+            allowUnpriced: false,
+            ledger: ledger,
+            ledgerPathClass: ledger.pathClass
+        )
+        let sseBody = """
+        data: not json
+
+        data: [DONE]
+
+        """
+        let upstreamClient = ConsumeStubUpstreamClient { _, eventLoop in
+            eventLoop.makeSucceededFuture(ConsumeUpstreamResponse(
+                statusCode: 200,
+                headers: [("content-type", "text/event-stream")],
+                body: Data(sseBody.utf8)
+            ))
+        }
+        let runtime = consumeRuntime(
+            token: token,
+            credentialStatus: .environmentLoaded,
+            credentialCustody: consumeCredentialCustody("buyer-token"),
+            budget: budget,
+            trustedPricing: .available(trustedRateCard),
+            upstreamClient: upstreamClient,
+            now: { ConsumeCommandTests.phase3CTestNow }
+        )
+        var headers = HTTPHeaders()
+        headers.add(name: "Authorization", value: "Bearer \(token.value)")
+        let body = #"{"model":"llama-test","messages":[],"max_tokens":10,"stream":true}"#
+        let expected = try ConsumePricedExposureEstimator.estimate(
+            bodyByteCount: Data(body.utf8).count,
+            request: StrictJSONParser.parse(body),
+            match: XCTUnwrap(trustedRateCard.match(model: "llama-test")),
+            projection: trustedRateCard.projection
+        )
+
+        let response = try response(
+            from: runtime,
+            head: HTTPRequestHead(version: .http1_1, method: .POST, uri: "/v1/chat/completions", headers: headers),
+            body: Data(body.utf8)
+        )
+
+        XCTAssertEqual(response.status, HTTPResponseStatus(statusCode: 502))
+        XCTAssertEqual(try localError(from: response.body)["code"] as? String, "local_upstream_unavailable")
+        XCTAssertTrue(try localForwardedFlag(from: response.body))
+        let summary = try ledger.summary()
+        XCTAssertEqual(summary.reserved.rawValue, 0)
+        XCTAssertEqual(summary.held.rawValue, 0)
+        XCTAssertEqual(summary.settled.rawValue, expected.amount.rawValue)
+    }
+
+    func testPhase3GStreamingPostDoneEventFailsBeforeLocalSuccessAndSettlesEstimate() throws {
+        let token = try ConsumeLocalToken.generate()
+        let home = try makeTemporaryDirectory()
+        let ledgerURL = home.appendingPathComponent("budget.jsonl")
+        let ledger = try ConsumeBudgetLedger.open(ledgerPath: ledgerURL.path, homeDirectory: home, startupDirectory: home)
+        let trustedRateCard = phase3CTrustedRateCard(
+            promptRatePerMtok: 1_000_000,
+            completionRatePerMtok: 2_000_000,
+            usdPerMillionCredits: 1.0
+        )
+        let budget = ConsumeBudgetConfig(
+            mode: .budget(ConsumeMicroUSD(rawValue: 100_000_000)),
+            maxRequestMicroUSD: nil,
+            allowUnpriced: false,
+            ledger: ledger,
+            ledgerPathClass: ledger.pathClass
+        )
+        let sseBody = """
+        data: {"choices":[],"usage":{"prompt_tokens":1,"completion_tokens":1}}
+
+        data: [DONE]
+
+        event: keepalive
+
+        """
+        let upstreamClient = ConsumeStubUpstreamClient { _, eventLoop in
+            eventLoop.makeSucceededFuture(ConsumeUpstreamResponse(
+                statusCode: 200,
+                headers: [("content-type", "text/event-stream")],
+                body: Data(sseBody.utf8)
+            ))
+        }
+        let runtime = consumeRuntime(
+            token: token,
+            credentialStatus: .environmentLoaded,
+            credentialCustody: consumeCredentialCustody("buyer-token"),
+            budget: budget,
+            trustedPricing: .available(trustedRateCard),
+            upstreamClient: upstreamClient,
+            now: { ConsumeCommandTests.phase3CTestNow }
+        )
+        var headers = HTTPHeaders()
+        headers.add(name: "Authorization", value: "Bearer \(token.value)")
+        let body = #"{"model":"llama-test","messages":[],"max_tokens":10,"stream":true}"#
+        let expected = try ConsumePricedExposureEstimator.estimate(
+            bodyByteCount: Data(body.utf8).count,
+            request: StrictJSONParser.parse(body),
+            match: XCTUnwrap(trustedRateCard.match(model: "llama-test")),
+            projection: trustedRateCard.projection
+        )
+
+        let response = try response(
+            from: runtime,
+            head: HTTPRequestHead(version: .http1_1, method: .POST, uri: "/v1/chat/completions", headers: headers),
+            body: Data(body.utf8)
+        )
+
+        XCTAssertEqual(response.status, HTTPResponseStatus(statusCode: 502))
+        XCTAssertEqual(try localError(from: response.body)["code"] as? String, "local_upstream_unavailable")
+        XCTAssertTrue(try localForwardedFlag(from: response.body))
+        let summary = try ledger.summary()
+        XCTAssertEqual(summary.reserved.rawValue, 0)
+        XCTAssertEqual(summary.held.rawValue, 0)
+        XCTAssertEqual(summary.settled.rawValue, expected.amount.rawValue)
+    }
+
+    func testPhase3GStreamingLedgerWriteFailureKeepsForwardedProvenance() throws {
+        let token = try ConsumeLocalToken.generate()
+        let home = try makeTemporaryDirectory()
+        let ledgerURL = home.appendingPathComponent("budget.jsonl")
+        let ledger = try ConsumeBudgetLedger.open(ledgerPath: ledgerURL.path, homeDirectory: home, startupDirectory: home)
+        let trustedRateCard = phase3CTrustedRateCard(
+            promptRatePerMtok: 1_000_000,
+            completionRatePerMtok: 2_000_000,
+            usdPerMillionCredits: 1.0
+        )
+        let budget = ConsumeBudgetConfig(
+            mode: .budget(ConsumeMicroUSD(rawValue: 100_000_000)),
+            maxRequestMicroUSD: nil,
+            allowUnpriced: false,
+            ledger: ledger,
+            ledgerPathClass: ledger.pathClass
+        )
+        let sseBody = """
+        data: {"choices":[],"usage":{"prompt_tokens":1,"completion_tokens":1}}
+
+        data: [DONE]
+
+        """
+        let upstreamClient = ConsumeStubUpstreamClient { _, eventLoop in
+            try! FileManager.default.removeItem(at: ledgerURL)
+            try! Data().write(to: ledgerURL)
+            chmod(ledgerURL.path, 0o600)
+            return eventLoop.makeSucceededFuture(ConsumeUpstreamResponse(
+                statusCode: 200,
+                headers: [("content-type", "text/event-stream")],
+                body: Data(sseBody.utf8)
+            ))
+        }
+        let runtime = consumeRuntime(
+            token: token,
+            credentialStatus: .environmentLoaded,
+            credentialCustody: consumeCredentialCustody("buyer-token"),
+            budget: budget,
+            trustedPricing: .available(trustedRateCard),
+            upstreamClient: upstreamClient,
+            now: { ConsumeCommandTests.phase3CTestNow }
+        )
+        var headers = HTTPHeaders()
+        headers.add(name: "Authorization", value: "Bearer \(token.value)")
+        let body = #"{"model":"llama-test","messages":[],"max_tokens":10,"stream":true}"#
+
+        let response = try response(
+            from: runtime,
+            head: HTTPRequestHead(version: .http1_1, method: .POST, uri: "/v1/chat/completions", headers: headers),
+            body: Data(body.utf8)
+        )
+
+        XCTAssertEqual(response.status, .serviceUnavailable)
+        XCTAssertEqual(try localError(from: response.body)["code"] as? String, "local_budget_ledger_unavailable")
+        XCTAssertTrue(try localForwardedFlag(from: response.body))
+        XCTAssertNil(response.headers.first(name: "content-encoding"))
+    }
+
     func testPhase3DCloseDelimitedUpstreamParserWaitsForEOF() throws {
         let partial = Data("HTTP/1.1 200 OK\r\nContent-Type: application/json\r\n\r\n".utf8)
         XCTAssertNil(try ConsumePinnedUpstreamClient.parseCompleteHTTPResponseForTesting(
@@ -2916,7 +3506,7 @@ final class ConsumeCommandTests: XCTestCase {
         XCTAssertEqual(runtime.statusPayload()["pricing_warning_codes"] as? [String], [])
     }
 
-    func testPhase3DStreamingRequestFailsClosedBeforeLedgerAppend() throws {
+    func testPhase3GStreamingRequestRequiresEventStreamUpstreamBeforeLocalSuccess() throws {
         let token = try ConsumeLocalToken.generate()
         let home = try makeTemporaryDirectory()
         let ledgerURL = home.appendingPathComponent("budget.jsonl")
@@ -2949,17 +3539,97 @@ final class ConsumeCommandTests: XCTestCase {
         )
         var headers = HTTPHeaders()
         headers.add(name: "Authorization", value: "Bearer \(token.value)")
+        let body = #"{"model":"llama-test","messages":[],"max_tokens":10,"stream":true}"#
+        let expected = try ConsumePricedExposureEstimator.estimate(
+            bodyByteCount: Data(body.utf8).count,
+            request: StrictJSONParser.parse(body),
+            match: XCTUnwrap(trustedRateCard.match(model: "llama-test")),
+            projection: trustedRateCard.projection
+        )
 
         let response = try response(
             from: runtime,
             head: HTTPRequestHead(version: .http1_1, method: .POST, uri: "/v1/chat/completions", headers: headers),
-            body: Data(#"{"model":"llama-test","messages":[],"max_tokens":10,"stream":true}"#.utf8)
+            body: Data(body.utf8)
         )
 
-        XCTAssertEqual(response.status, HTTPResponseStatus.serviceUnavailable)
-        XCTAssertEqual(try localError(from: response.body)["code"] as? String, "local_pricing_unavailable")
-        XCTAssertEqual(recorder.snapshot().count, 0)
-        XCTAssertEqual(try ledger.summary(), .empty)
+        XCTAssertEqual(response.status, HTTPResponseStatus(statusCode: 502))
+        XCTAssertEqual(try localError(from: response.body)["code"] as? String, "local_upstream_unavailable")
+        XCTAssertTrue(try localForwardedFlag(from: response.body))
+        let forwarded = try XCTUnwrap(recorder.snapshot().first)
+        XCTAssertTrue(forwarded.streaming)
+        let summary = try ledger.summary()
+        XCTAssertEqual(summary.reserved.rawValue, 0)
+        XCTAssertEqual(summary.held.rawValue, 0)
+        XCTAssertEqual(summary.settled.rawValue, expected.amount.rawValue)
+    }
+
+    func testPhase3GStreamingUpstreamErrorResponseIsPreservedAndSettlesEstimate() throws {
+        let token = try ConsumeLocalToken.generate()
+        let home = try makeTemporaryDirectory()
+        let ledgerURL = home.appendingPathComponent("budget.jsonl")
+        let ledger = try ConsumeBudgetLedger.open(ledgerPath: ledgerURL.path, homeDirectory: home, startupDirectory: home)
+        let trustedRateCard = phase3CTrustedRateCard(
+            promptRatePerMtok: 1_000_000,
+            completionRatePerMtok: 2_000_000,
+            usdPerMillionCredits: 1.0
+        )
+        let budget = ConsumeBudgetConfig(
+            mode: .budget(ConsumeMicroUSD(rawValue: 100_000_000)),
+            maxRequestMicroUSD: nil,
+            allowUnpriced: false,
+            ledger: ledger,
+            ledgerPathClass: ledger.pathClass
+        )
+        let recorder = ConsumeUpstreamRequestRecorder()
+        let upstreamBody = #"{"error":{"message":"rate limited","type":"rate_limit_error","param":null,"code":"rate_limit_exceeded"},"usage":{"prompt_tokens":1,"completion_tokens":1}}"#
+        let upstreamClient = ConsumeStubUpstreamClient { request, eventLoop in
+            recorder.append(request)
+            return eventLoop.makeSucceededFuture(ConsumeUpstreamResponse(
+                statusCode: 429,
+                headers: [
+                    ("content-type", "application/json"),
+                    ("retry-after", "3"),
+                    ("x-request-id", "stream-error-request-id"),
+                ],
+                body: Data(upstreamBody.utf8)
+            ))
+        }
+        let runtime = consumeRuntime(
+            token: token,
+            credentialStatus: .environmentLoaded,
+            credentialCustody: consumeCredentialCustody("buyer-token"),
+            budget: budget,
+            trustedPricing: .available(trustedRateCard),
+            upstreamClient: upstreamClient,
+            now: { ConsumeCommandTests.phase3CTestNow }
+        )
+        var headers = HTTPHeaders()
+        headers.add(name: "Authorization", value: "Bearer \(token.value)")
+        let body = #"{"model":"llama-test","messages":[],"max_tokens":10,"stream":true}"#
+        let expected = try ConsumePricedExposureEstimator.estimate(
+            bodyByteCount: Data(body.utf8).count,
+            request: StrictJSONParser.parse(body),
+            match: XCTUnwrap(trustedRateCard.match(model: "llama-test")),
+            projection: trustedRateCard.projection
+        )
+
+        let response = try response(
+            from: runtime,
+            head: HTTPRequestHead(version: .http1_1, method: .POST, uri: "/v1/chat/completions", headers: headers),
+            body: Data(body.utf8)
+        )
+
+        XCTAssertEqual(response.status, HTTPResponseStatus(statusCode: 429))
+        XCTAssertEqual(response.body, upstreamBody)
+        XCTAssertEqual(response.headers.first(name: "content-type"), "application/json")
+        XCTAssertEqual(response.headers.first(name: "retry-after"), "3")
+        XCTAssertEqual(response.headers.first(name: "x-request-id"), "stream-error-request-id")
+        XCTAssertTrue(try XCTUnwrap(recorder.snapshot().first).streaming)
+        let summary = try ledger.summary()
+        XCTAssertEqual(summary.reserved.rawValue, 0)
+        XCTAssertEqual(summary.held.rawValue, 0)
+        XCTAssertEqual(summary.settled.rawValue, expected.amount.rawValue)
     }
 
     func testPhase3CPricedEstimateCapRejectsBeforeLedgerAppend() throws {

--- a/specs/design/spec-045/BUILD_SPEC_045_LOCAL_CONSUMER_ENDPOINT_IMPL.md
+++ b/specs/design/spec-045/BUILD_SPEC_045_LOCAL_CONSUMER_ENDPOINT_IMPL.md
@@ -22,7 +22,9 @@ Ship `macprovider-cli consume` as a local development adapter: a macOS loopback-
    - aggregate response-spool, upstream worker-task, upstream socket/file-descriptor, and streaming-response slot admission.
 7. `BUILD_SPEC_045_PHASE_3F_COMPRESSED_RESPONSE.md`
    - compressed non-streaming upstream response decode-to-identity, decoded response caps, and settlement from decoded usage.
-8. `BUILD_SPEC_045_PHASE_4_CONFORMANCE_JOURNEY.md`
+8. `BUILD_SPEC_045_PHASE_3G_BUFFERED_SSE_FOUNDATION.md`
+   - bounded buffered SSE upstream response relay, terminal `[DONE]` validation, and settlement from terminal stream usage evidence.
+9. `BUILD_SPEC_045_PHASE_4_CONFORMANCE_JOURNEY.md`
    - required automated coverage, fake-gateway integration harness, staging/production signed journey, and promotion evidence.
 
 ## Required sequencing
@@ -34,6 +36,7 @@ Ship `macprovider-cli consume` as a local development adapter: a macOS loopback-
 - Phase 3D may land without streaming/SSE forwarding, aggregate response-spool/socket admission, compressed non-streaming decode-to-identity, or mutable upstream invalid-credential state; those remain required before Phase 4 can claim conformance.
 - Phase 3E may land without streaming/SSE forwarding, compressed non-streaming decode-to-identity, or mutable upstream invalid-credential state; those remain required before Phase 4 can claim conformance.
 - Phase 3F may land without streaming/SSE forwarding, mutable upstream invalid-credential state, or fake/real conformance journeys; those remain required before Phase 4 can claim conformance.
+- Phase 3G may land without live incremental SSE flushing, disconnect cancellation, mutable upstream invalid-credential state, or fake/real conformance journeys; those remain required before Phase 4 can claim conformance.
 - Phase 4 must not claim production readiness until Phases 1-3 are implemented and the signed real-gateway journey exists.
 
 ## Non-goals

--- a/specs/design/spec-045/BUILD_SPEC_045_PHASE_3G_BUFFERED_SSE_FOUNDATION.md
+++ b/specs/design/spec-045/BUILD_SPEC_045_PHASE_3G_BUFFERED_SSE_FOUNDATION.md
@@ -1,0 +1,99 @@
+# BUILD_SPEC_045_PHASE_3G_BUFFERED_SSE_FOUNDATION
+
+Implement the first bounded SSE-compatible forwarding foundation for SPEC-045
+local consumer endpoint mode after compressed non-streaming response handling
+exists. This slice owns accepting `stream: true` chat-completions requests
+through the existing admission, resource, credential, and ledger gates, then
+relaying a complete bounded `text/event-stream` upstream response after terminal
+stream validation.
+
+This is a build slice, not a production-conformance declaration. Live
+incremental flush, client-disconnect upstream cancellation, mutable
+invalid-credential state, and fake/real gateway journeys remain later work.
+
+## Target Result
+
+Allowed, trusted-priced streaming chat-completions requests are no longer
+rejected solely because `stream: true` is present. They reserve an open
+streaming-response slot plus upstream worker/socket resources, request
+`text/event-stream` from the upstream gateway, require an identity
+`text/event-stream` response, validate a terminal `data: [DONE]` frame before
+local success, settle ledger exposure from the last parseable stream usage
+object before `[DONE]`, and return the bounded SSE bytes to the local client.
+
+## Required Implementation Shape
+
+1. Keep the existing admission order:
+   - local auth, request validation, model allowlist, pricing revalidation,
+     request cap, ledger preview/reservation, credential lookup, resolver, and
+     upstream dispatch order must remain equivalent to non-streaming requests;
+   - missing credentials must still reject before ledger mutation;
+   - local budget/cap failures must still win over missing credentials.
+
+2. Reserve streaming resources atomically:
+   - accepted streaming upstream exchanges reserve one upstream worker task,
+     one upstream socket/file-descriptor slot, and one open streaming-response
+     slot;
+   - streaming requests do not reserve non-streaming response-spool bytes;
+   - saturated streaming slots fail locally as `503 local_endpoint_busy` before
+     resolver, credential lookup, ledger mutation, or upstream forwarding;
+   - release the streaming reservation on every terminal success/failure path.
+
+3. Request and normalize SSE responses:
+   - upstream streaming requests use implementation-owned
+     `Accept: text/event-stream`;
+   - successful local streaming responses must have `Content-Type:
+     text/event-stream`, and the SSE success contract applies only to
+     successful upstream statuses;
+   - non-2xx upstream error responses for streaming requests are preserved
+     through the existing R007 response-header allowlist instead of being
+     reclassified as invalid SSE;
+   - compressed, ambiguous, malformed, post-terminal, missing-terminal, or
+     oversized successful SSE responses fail closed after dispatch as
+     `502 local_upstream_unavailable` with `forwarded_upstream: true`;
+   - strip upstream `Content-Length`, reject upstream `Content-Encoding`
+     unless absent or exactly `identity`, and preserve only the existing
+     allowlisted response headers.
+
+4. Settle after terminal stream evidence:
+   - parse complete SSE frames from the bounded upstream body;
+   - require a terminal `data: [DONE]` event before local success;
+   - settle from the most recent parseable JSON `usage` object before `[DONE]`
+     when usage is priceable;
+   - otherwise settle to the admission estimate;
+   - on terminal validation failure after reservation, settle to the admission
+     estimate before returning the local upstream failure.
+
+## Acceptance Tests
+
+- trusted budgeted `stream: true` requests forward and settle from SSE usage
+  only after `[DONE]`;
+- local streaming success returns `text/event-stream`, preserves event order,
+  strips upstream `Content-Length`, and reports a local decoded length;
+- no-budget ledger mode records and settles streaming audit rows;
+- streaming slot saturation rejects before resolver, credential lookup, ledger
+  mutation, or upstream forwarding;
+- missing `[DONE]`, compressed SSE, wrong content type, malformed event data,
+  or post-`[DONE]` events fail as forwarded upstream failures and settle to the
+  admission estimate;
+- non-2xx upstream JSON error responses for streaming requests preserve the
+  upstream status/body/allowlisted headers and settle to the admission estimate;
+- post-dispatch streaming ledger-write failures keep
+  `forwarded_upstream: true`.
+
+## Follow-Up Slices
+
+- live incremental SSE flushing, event-line/event-frame limits, idle stream
+  deadlines, disconnect cancellation, and conservative disconnect settlement;
+- mutable credential state that marks invalid or expired upstream buyer
+  credentials while preserving the initiating client's upstream auth failure;
+- fake-gateway and real-gateway conformance journeys.
+
+## Non-Goals
+
+- Do not implement live incremental local flushing in this slice.
+- Do not implement request compression or compressed SSE decoding.
+- Do not add new OpenAI-compatible endpoint paths.
+- Do not change gateway billing, coordinator settlement, provider payout, or
+  receipt semantics.
+- Do not claim SPEC-045 production readiness from this slice alone.


### PR DESCRIPTION
## Summary

Implements SPEC-045 Phase 3G buffered SSE foundation for the local consumer endpoint:

- forwards `stream: true` chat completions through the existing admission, credential, resource, and ledger gates;
- reserves streaming-response capacity atomically without consuming non-streaming response-spool bytes;
- validates successful buffered SSE responses before local success, requiring identity `text/event-stream` and terminal `data: [DONE]`;
- preserves non-2xx upstream JSON errors for streaming requests while settling conservatively to the admission estimate;
- settles successful streams from the last priceable SSE `usage` event before `[DONE]`.

## Validation

- `swift test --filter ConsumeCommandTests/testPhase3G --skip-update` - 11 tests passed
- `swift test --filter ConsumeCommandTests --skip-update` - 103 tests passed
- `swift build --target macprovider-cli --skip-update`
- `git diff --check`
- `jq empty specs/AUTHORITY.json && jq empty specs/CONFORMANCE.json`
- `python3 scripts/gen_spec_index.py --check && python3 scripts/gen_spec_index.py --lint`
- `python3 scripts/check_spec_governance.py --base-ref origin/main`
- `python3 -m unittest scripts.tests.test_spec_governance scripts.tests.test_spec_pr_declaration` - 59 tests passed

## Audit

- Code review lane: 0 C/H/M, no LOW/INFO on `/tmp/spec045-phase3g-full-v4.diff` (`bb730b80641b03a0182e3013ec0a0b58262af3d11dbf57046a0285565630db53`)
- Security review lane: 0 C/H/M, no LOW/INFO on `/tmp/spec045-phase3g-full-v4.diff` (`bb730b80641b03a0182e3013ec0a0b58262af3d11dbf57046a0285565630db53`)
- Architecture review lane: 0 C/H/M on `/tmp/spec045-phase3g-full-v4.diff` (`bb730b80641b03a0182e3013ec0a0b58262af3d11dbf57046a0285565630db53`); follow-up live streaming work remains documented

SPEC-GOVERNANCE-DECLARATION-BEGIN
{
  "schema_version": "spec-pr-governance-v1",
  "behavior_change": "yes",
  "contract_change": "none",
  "specs": ["SPEC-045"],
  "requirements": ["SPEC-045-R002", "SPEC-045-R003", "SPEC-045-R004", "SPEC-045-R005", "SPEC-045-R007", "SPEC-045-R008"],
  "authority_domains": ["local-consumer-endpoint"],
  "arbitration": ["CODE_BUG"],
  "tests": [
    "swift test --filter ConsumeCommandTests/testPhase3G --skip-update",
    "swift test --filter ConsumeCommandTests --skip-update",
    "swift build --target macprovider-cli --skip-update",
    "git diff --check",
    "python3 scripts/gen_spec_index.py --check && python3 scripts/gen_spec_index.py --lint",
    "python3 scripts/check_spec_governance.py --base-ref origin/main",
    "python3 -m unittest scripts.tests.test_spec_governance scripts.tests.test_spec_pr_declaration"
  ],
  "journeys": ["not-required"],
  "issue": "https://github.com/Augustas11/macprovider/issues/927"
}
SPEC-GOVERNANCE-DECLARATION-END
