### PR TITLE
Build SPEC-045 Phase 3H live SSE emission

### DIFF
--- a/phase3-binary/Sources/macprovider-cli/ConsumeCommand.swift
+++ b/phase3-binary/Sources/macprovider-cli/ConsumeCommand.swift
@@ -650,6 +650,11 @@ struct ConsumeUpstreamResponse: Sendable {
     let body: Data
 }
 
+private struct ConsumeSSEValidationResult: Sendable {
+    let eventBlocks: [Data]
+    let lastUsage: [String: JSONValue]?
+}
+
 enum ConsumeUpstreamForwardError: Error {
     case preDispatchUnavailable
     case dispatchedUnavailable
@@ -722,8 +727,10 @@ final class ConsumePinnedUpstreamClient: ConsumeUpstreamClient, @unchecked Senda
         func schedule(nanoseconds: UInt64, _ block: @escaping @Sendable () -> Void) {
             let work = DispatchWorkItem(block: block)
             lock.lock()
+            let previous = task
             task = work
             lock.unlock()
+            previous?.cancel()
             DispatchQueue.global(qos: .utility).asyncAfter(
                 deadline: .now() + .nanoseconds(Int(nanoseconds)),
                 execute: work
@@ -989,6 +996,10 @@ final class ConsumePinnedUpstreamClient: ConsumeUpstreamClient, @unchecked Senda
                     }
                     if let data, !data.isEmpty {
                         state.received.append(data)
+                        deadline.schedule(nanoseconds: timeoutNanoseconds) {
+                            connection.cancel()
+                            finish(.failure(ConsumeUpstreamForwardError.dispatchedUnavailable))
+                        }
                     }
                     if let headerRange = state.received.range(of: headerTerminator) {
                         let bodyStart = headerRange.upperBound
@@ -3386,6 +3397,9 @@ enum ConsumeLocalLimits {
     static let headerBytes = 64 * 1024
     static let bodyBytes = 1 * 1024 * 1024
     static let nonStreamingResponseSpoolBytes = bodyBytes * 2
+    static let sseEventLineBytes = 64 * 1024
+    static let sseEventFrameBytes = 256 * 1024
+    static let sseEventBlocks = 4096
     static let headerReadTimeout: TimeAmount = .seconds(5)
     static let requestReadTimeout: TimeAmount = .seconds(15)
     static let bodyIdleTimeout: TimeAmount = .seconds(5)
@@ -4533,9 +4547,17 @@ final class ConsumeLocalHandler: ChannelInboundHandler, @unchecked Sendable {
             }
             switch result {
             case .success(let response):
+                guard !self.shouldSuppressLateStreamingWrite(streaming: streaming) else {
+                    return
+                }
                 do {
                     let localResponse = try Self.responseForLocalDelivery(response, streaming: streaming)
-                    self.writeUpstreamResponse(localResponse, context: contextBox.context, extraHeaders: extraHeaders)
+                    self.writeUpstreamResponse(
+                        localResponse,
+                        streaming: streaming,
+                        context: contextBox.context,
+                        extraHeaders: extraHeaders
+                    )
                 } catch {
                     self.writeLocalError(
                         context: contextBox.context,
@@ -4547,6 +4569,9 @@ final class ConsumeLocalHandler: ChannelInboundHandler, @unchecked Sendable {
                 }
             case .failure(let error):
                 let failure = Self.classifyUpstreamFailure(error)
+                guard !self.shouldSuppressLateStreamingWrite(streaming: streaming) else {
+                    return
+                }
                 self.writeLocalError(
                     context: contextBox.context,
                     status: failure.status,
@@ -4592,6 +4617,15 @@ final class ConsumeLocalHandler: ChannelInboundHandler, @unchecked Sendable {
             }
             switch result {
             case .success(let response):
+                if self.shouldSuppressLateStreamingWrite(streaming: streaming) {
+                    self.settleDisconnectedStreamingReservation(
+                        ledger: ledger,
+                        reservationID: reservationID,
+                        reservedAmount: reservedAmount,
+                        estimate: estimate.amount
+                    )
+                    return
+                }
                 let localResponse: ConsumeUpstreamResponse
                 do {
                     localResponse = try Self.responseForLocalDelivery(response, streaming: streaming)
@@ -4657,11 +4691,24 @@ final class ConsumeLocalHandler: ChannelInboundHandler, @unchecked Sendable {
                     )
                     return
                 }
-                self.writeUpstreamResponse(localResponse, context: contextBox.context, extraHeaders: extraHeaders)
+                self.writeUpstreamResponse(
+                    localResponse,
+                    streaming: streaming,
+                    context: contextBox.context,
+                    extraHeaders: extraHeaders
+                )
             case .failure(let error):
                 let failure = Self.classifyUpstreamFailure(error)
                 do {
-                    if failure.forwardedUpstream {
+                    if self.shouldSuppressLateStreamingWrite(streaming: streaming) {
+                        self.settleDisconnectedStreamingReservation(
+                            ledger: ledger,
+                            reservationID: reservationID,
+                            reservedAmount: reservedAmount,
+                            estimate: estimate.amount
+                        )
+                        return
+                    } else if failure.forwardedUpstream {
                         try ledger.hold(
                             runID: self.runtime.launchID,
                             reservationID: reservationID,
@@ -4678,6 +4725,9 @@ final class ConsumeLocalHandler: ChannelInboundHandler, @unchecked Sendable {
                         )
                     }
                 } catch {
+                    guard !self.shouldSuppressLateStreamingWrite(streaming: streaming) else {
+                        return
+                    }
                     self.writeLocalError(
                         context: contextBox.context,
                         status: .serviceUnavailable,
@@ -4685,6 +4735,9 @@ final class ConsumeLocalHandler: ChannelInboundHandler, @unchecked Sendable {
                         forwardedUpstream: failure.forwardedUpstream,
                         extraHeaders: extraHeaders
                     )
+                    return
+                }
+                guard !self.shouldSuppressLateStreamingWrite(streaming: streaming) else {
                     return
                 }
                 self.writeLocalError(
@@ -4728,6 +4781,9 @@ final class ConsumeLocalHandler: ChannelInboundHandler, @unchecked Sendable {
                 }
                 self.upstreamForwardIsPending = false
                 let failure = Self.classifyUpstreamFailure(error)
+                guard !self.shouldSuppressLateStreamingWrite(streaming: streaming) else {
+                    return
+                }
                 self.writeLocalError(
                     context: contextBox.context,
                     status: failure.status,
@@ -4765,6 +4821,31 @@ final class ConsumeLocalHandler: ChannelInboundHandler, @unchecked Sendable {
         guard let reservation = upstreamResourceReservation else { return }
         upstreamResourceReservation = nil
         runtime.releaseUpstreamExchange(reservation)
+    }
+
+    private func shouldSuppressLateStreamingWrite(streaming: Bool) -> Bool {
+        streaming && channelInactiveWhileUpstreamPending
+    }
+
+    private func settleDisconnectedStreamingReservation(
+        ledger: ConsumeBudgetLedger,
+        reservationID: String,
+        reservedAmount: ConsumeMicroUSD,
+        estimate: ConsumeMicroUSD
+    ) {
+        do {
+            try ledger.settle(
+                runID: runtime.launchID,
+                reservationID: reservationID,
+                reservedAmount: reservedAmount,
+                settledAmount: estimate,
+                reason: "settled_to_admission_estimate"
+            )
+        } catch {
+            // The ledger marks itself unavailable on append/identity failure.
+            // With the local channel already closed, the safe recovery state is
+            // to suppress local writes and let subsequent admission fail closed.
+        }
     }
 
     private static func classifyUpstreamFailure(_ error: Error) -> ConsumeUpstreamFailureClassification {
@@ -4857,7 +4938,7 @@ final class ConsumeLocalHandler: ChannelInboundHandler, @unchecked Sendable {
               upstreamResponseIsEventStream(response.headers) else {
             throw ConsumeUpstreamForwardError.dispatchedUnavailable
         }
-        _ = try lastSSEUsageObject(response.body)
+        _ = try validatedSSEStream(response.body)
         return ConsumeUpstreamResponse(
             statusCode: response.statusCode,
             headers: response.headers.filter { name, _ in
@@ -4881,17 +4962,39 @@ final class ConsumeLocalHandler: ChannelInboundHandler, @unchecked Sendable {
     }
 
     private static func lastSSEUsageObject(_ body: Data) throws -> [String: JSONValue]? {
+        try validatedSSEStream(body).lastUsage
+    }
+
+    private static func validatedSSEStream(_ body: Data) throws -> ConsumeSSEValidationResult {
         guard let text = String(data: body, encoding: .utf8) else {
             throw ConsumeUpstreamForwardError.dispatchedUnavailable
         }
         var dataLines: [String] = []
+        var eventLines: [String] = []
+        var eventFrameBytes = 0
+        var eventBlocks: [Data] = []
         var sawDone = false
         var lastUsage: [String: JSONValue]?
 
         func finishEvent() throws {
+            defer {
+                dataLines.removeAll(keepingCapacity: true)
+                eventLines.removeAll(keepingCapacity: true)
+                eventFrameBytes = 0
+            }
+            if !eventLines.isEmpty {
+                let block = eventLines.joined(separator: "\n") + "\n\n"
+                guard let blockData = block.data(using: .utf8),
+                      blockData.count <= ConsumeLocalLimits.sseEventFrameBytes else {
+                    throw ConsumeUpstreamForwardError.dispatchedUnavailable
+                }
+                guard eventBlocks.count < ConsumeLocalLimits.sseEventBlocks else {
+                    throw ConsumeUpstreamForwardError.dispatchedUnavailable
+                }
+                eventBlocks.append(blockData)
+            }
             guard !dataLines.isEmpty else { return }
             let payload = dataLines.joined(separator: "\n")
-            dataLines.removeAll(keepingCapacity: true)
             if payload == "[DONE]" {
                 guard !sawDone else {
                     throw ConsumeUpstreamForwardError.dispatchedUnavailable
@@ -4912,6 +5015,9 @@ final class ConsumeLocalHandler: ChannelInboundHandler, @unchecked Sendable {
 
         for rawLine in text.split(separator: "\n", omittingEmptySubsequences: false) {
             let line = rawLine.last == "\r" ? rawLine.dropLast() : rawLine[...]
+            guard line.utf8.count <= ConsumeLocalLimits.sseEventLineBytes else {
+                throw ConsumeUpstreamForwardError.dispatchedUnavailable
+            }
             if line.isEmpty {
                 try finishEvent()
                 continue
@@ -4919,6 +5025,11 @@ final class ConsumeLocalHandler: ChannelInboundHandler, @unchecked Sendable {
             guard !sawDone else {
                 throw ConsumeUpstreamForwardError.dispatchedUnavailable
             }
+            eventFrameBytes += line.utf8.count + 1
+            guard eventFrameBytes <= ConsumeLocalLimits.sseEventFrameBytes else {
+                throw ConsumeUpstreamForwardError.dispatchedUnavailable
+            }
+            eventLines.append(String(line))
             if line.hasPrefix(":") {
                 continue
             }
@@ -4942,7 +5053,7 @@ final class ConsumeLocalHandler: ChannelInboundHandler, @unchecked Sendable {
         guard sawDone else {
             throw ConsumeUpstreamForwardError.dispatchedUnavailable
         }
-        return lastUsage
+        return ConsumeSSEValidationResult(eventBlocks: eventBlocks, lastUsage: lastUsage)
     }
 
     private static func upstreamResponseContentCoding(_ headers: [(String, String)]) throws -> ConsumeUpstreamResponseContentCoding {
@@ -5182,6 +5293,7 @@ final class ConsumeLocalHandler: ChannelInboundHandler, @unchecked Sendable {
 
     private func writeUpstreamResponse(
         _ response: ConsumeUpstreamResponse,
+        streaming: Bool,
         context: ChannelHandlerContext,
         extraHeaders: [(String, String)]
     ) {
@@ -5193,7 +5305,6 @@ final class ConsumeLocalHandler: ChannelInboundHandler, @unchecked Sendable {
             }
             headers.add(name: name, value: value)
         }
-        headers.replaceOrAdd(name: "content-length", value: "\(response.body.count)")
         headers.replaceOrAdd(name: "connection", value: "close")
         for (name, value) in extraHeaders {
             if name.caseInsensitiveCompare("x-macprovider-warning") == .orderedSame,
@@ -5204,11 +5315,34 @@ final class ConsumeLocalHandler: ChannelInboundHandler, @unchecked Sendable {
                 headers.replaceOrAdd(name: name, value: value)
             }
         }
+        let streamingBlocks: [Data]?
+        if streaming,
+           response.statusCode >= 200,
+           response.statusCode < 300,
+           Self.upstreamResponseIsEventStream(response.headers),
+           let parsed = try? Self.validatedSSEStream(response.body) {
+            streamingBlocks = parsed.eventBlocks
+        } else {
+            streamingBlocks = nil
+        }
+        if streamingBlocks == nil {
+            headers.replaceOrAdd(name: "content-length", value: "\(response.body.count)")
+        }
         let status = HTTPResponseStatus(statusCode: response.statusCode)
         let head = HTTPResponseHead(version: .http1_1, status: status, headers: headers)
         responseStarted = true
-        context.write(wrapOutboundOut(.head(head)), promise: nil)
-        if !response.body.isEmpty {
+        if let streamingBlocks {
+            context.writeAndFlush(wrapOutboundOut(.head(head)), promise: nil)
+            for block in streamingBlocks {
+                guard !block.isEmpty else { continue }
+                var buffer = context.channel.allocator.buffer(capacity: block.count)
+                buffer.writeBytes(block)
+                context.writeAndFlush(wrapOutboundOut(.body(.byteBuffer(buffer))), promise: nil)
+            }
+        } else {
+            context.write(wrapOutboundOut(.head(head)), promise: nil)
+        }
+        if streamingBlocks == nil, !response.body.isEmpty {
             var buffer = context.channel.allocator.buffer(capacity: response.body.count)
             buffer.writeBytes(response.body)
             context.write(wrapOutboundOut(.body(.byteBuffer(buffer))), promise: nil)

--- a/phase3-binary/Tests/macprovider-cliTests/ConsumeCommandTests.swift
+++ b/phase3-binary/Tests/macprovider-cliTests/ConsumeCommandTests.swift
@@ -89,6 +89,13 @@ private final class ConsumeUpstreamPromiseBox: @unchecked Sendable {
         lock.unlock()
         current?.succeed(response)
     }
+
+    func fail(_ error: Error) {
+        lock.lock()
+        let current = promise
+        lock.unlock()
+        current?.fail(error)
+    }
 }
 
 private final class ConsumeEndpointPromiseBox: @unchecked Sendable {
@@ -106,6 +113,13 @@ private final class ConsumeEndpointPromiseBox: @unchecked Sendable {
         let current = promise
         lock.unlock()
         current?.succeed(endpoint)
+    }
+
+    func fail(_ error: Error) {
+        lock.lock()
+        let current = promise
+        lock.unlock()
+        current?.fail(error)
     }
 }
 
@@ -2617,18 +2631,23 @@ final class ConsumeCommandTests: XCTestCase {
             projection: trustedRateCard.projection
         )
 
-        let response = try response(
+        let response = try responseWithBodyChunks(
             from: runtime,
             head: HTTPRequestHead(version: .http1_1, method: .POST, uri: "/v1/chat/completions", headers: headers),
             body: Data(body.utf8)
         )
 
         XCTAssertEqual(response.status, .ok)
-        XCTAssertEqual(response.body, sseBody)
+        XCTAssertEqual(response.body, response.bodyChunks.joined())
         XCTAssertEqual(response.headers.first(name: "content-type"), "text/event-stream; charset=utf-8")
-        XCTAssertEqual(response.headers.first(name: "content-length"), "\(Data(sseBody.utf8).count)")
+        XCTAssertNil(response.headers.first(name: "content-length"))
         XCTAssertNil(response.headers.first(name: "content-encoding"))
         XCTAssertEqual(response.headers.first(name: "x-request-id"), "stream-request-id")
+        XCTAssertEqual(response.bodyChunks, [
+            #"data: {"id":"chunk-1","choices":[{"delta":{"content":"hello"}}]}"# + "\n\n",
+            #"data: {"id":"chunk-2","choices":[],"usage":{"prompt_tokens":1,"completion_tokens":2,"total_tokens":3}}"# + "\n\n",
+            "data: [DONE]\n\n",
+        ])
         let forwarded = try XCTUnwrap(recorder.snapshot().first)
         XCTAssertTrue(forwarded.streaming)
         XCTAssertEqual(forwarded.body, Data(body.utf8))
@@ -2640,6 +2659,465 @@ final class ConsumeCommandTests: XCTestCase {
         let resourceSnapshot = runtime.requestCounter.resourceSnapshot()
         XCTAssertEqual(resourceSnapshot.openStreamingResponses, 0)
         XCTAssertEqual(resourceSnapshot.responseSpoolBytes, 0)
+    }
+
+    func testPhase3HStreamingOversizedEventLineFailsBeforeLocalSuccessAndSettlesEstimate() throws {
+        let token = try ConsumeLocalToken.generate()
+        let home = try makeTemporaryDirectory()
+        let ledgerURL = home.appendingPathComponent("budget.jsonl")
+        let ledger = try ConsumeBudgetLedger.open(ledgerPath: ledgerURL.path, homeDirectory: home, startupDirectory: home)
+        let trustedRateCard = phase3CTrustedRateCard(
+            promptRatePerMtok: 1_000_000,
+            completionRatePerMtok: 2_000_000,
+            usdPerMillionCredits: 1.0
+        )
+        let budget = ConsumeBudgetConfig(
+            mode: .budget(ConsumeMicroUSD(rawValue: 100_000_000)),
+            maxRequestMicroUSD: nil,
+            allowUnpriced: false,
+            ledger: ledger,
+            ledgerPathClass: ledger.pathClass
+        )
+        let sseBody = "data: \(String(repeating: "x", count: ConsumeLocalLimits.sseEventLineBytes + 1))\n\ndata: [DONE]\n\n"
+        let upstreamClient = ConsumeStubUpstreamClient { _, eventLoop in
+            eventLoop.makeSucceededFuture(ConsumeUpstreamResponse(
+                statusCode: 200,
+                headers: [("content-type", "text/event-stream")],
+                body: Data(sseBody.utf8)
+            ))
+        }
+        let runtime = consumeRuntime(
+            token: token,
+            credentialStatus: .environmentLoaded,
+            credentialCustody: consumeCredentialCustody("buyer-token"),
+            budget: budget,
+            trustedPricing: .available(trustedRateCard),
+            upstreamClient: upstreamClient,
+            now: { ConsumeCommandTests.phase3CTestNow }
+        )
+        var headers = HTTPHeaders()
+        headers.add(name: "Authorization", value: "Bearer \(token.value)")
+        let body = #"{"model":"llama-test","messages":[],"max_tokens":10,"stream":true}"#
+        let expected = try ConsumePricedExposureEstimator.estimate(
+            bodyByteCount: Data(body.utf8).count,
+            request: StrictJSONParser.parse(body),
+            match: XCTUnwrap(trustedRateCard.match(model: "llama-test")),
+            projection: trustedRateCard.projection
+        )
+
+        let response = try response(
+            from: runtime,
+            head: HTTPRequestHead(version: .http1_1, method: .POST, uri: "/v1/chat/completions", headers: headers),
+            body: Data(body.utf8)
+        )
+
+        XCTAssertEqual(response.status, HTTPResponseStatus(statusCode: 502))
+        XCTAssertEqual(try localError(from: response.body)["code"] as? String, "local_upstream_unavailable")
+        XCTAssertTrue(try localForwardedFlag(from: response.body))
+        let summary = try ledger.summary()
+        XCTAssertEqual(summary.reserved.rawValue, 0)
+        XCTAssertEqual(summary.held.rawValue, 0)
+        XCTAssertEqual(summary.settled.rawValue, expected.amount.rawValue)
+    }
+
+    func testPhase3HStreamingOversizedEventFrameFailsBeforeLocalSuccessAndSettlesEstimate() throws {
+        let token = try ConsumeLocalToken.generate()
+        let home = try makeTemporaryDirectory()
+        let ledgerURL = home.appendingPathComponent("budget.jsonl")
+        let ledger = try ConsumeBudgetLedger.open(ledgerPath: ledgerURL.path, homeDirectory: home, startupDirectory: home)
+        let trustedRateCard = phase3CTrustedRateCard(
+            promptRatePerMtok: 1_000_000,
+            completionRatePerMtok: 2_000_000,
+            usdPerMillionCredits: 1.0
+        )
+        let budget = ConsumeBudgetConfig(
+            mode: .budget(ConsumeMicroUSD(rawValue: 100_000_000)),
+            maxRequestMicroUSD: nil,
+            allowUnpriced: false,
+            ledger: ledger,
+            ledgerPathClass: ledger.pathClass
+        )
+        let eventLine = "data: \(String(repeating: "x", count: 1024))\n"
+        let sseBody = String(repeating: eventLine, count: (ConsumeLocalLimits.sseEventFrameBytes / eventLine.utf8.count) + 2) + "\n"
+        let upstreamClient = ConsumeStubUpstreamClient { _, eventLoop in
+            eventLoop.makeSucceededFuture(ConsumeUpstreamResponse(
+                statusCode: 200,
+                headers: [("content-type", "text/event-stream")],
+                body: Data(sseBody.utf8)
+            ))
+        }
+        let runtime = consumeRuntime(
+            token: token,
+            credentialStatus: .environmentLoaded,
+            credentialCustody: consumeCredentialCustody("buyer-token"),
+            budget: budget,
+            trustedPricing: .available(trustedRateCard),
+            upstreamClient: upstreamClient,
+            now: { ConsumeCommandTests.phase3CTestNow }
+        )
+        var headers = HTTPHeaders()
+        headers.add(name: "Authorization", value: "Bearer \(token.value)")
+        let body = #"{"model":"llama-test","messages":[],"max_tokens":10,"stream":true}"#
+        let expected = try ConsumePricedExposureEstimator.estimate(
+            bodyByteCount: Data(body.utf8).count,
+            request: StrictJSONParser.parse(body),
+            match: XCTUnwrap(trustedRateCard.match(model: "llama-test")),
+            projection: trustedRateCard.projection
+        )
+
+        let response = try response(
+            from: runtime,
+            head: HTTPRequestHead(version: .http1_1, method: .POST, uri: "/v1/chat/completions", headers: headers),
+            body: Data(body.utf8)
+        )
+
+        XCTAssertEqual(response.status, HTTPResponseStatus(statusCode: 502))
+        XCTAssertEqual(try localError(from: response.body)["code"] as? String, "local_upstream_unavailable")
+        XCTAssertTrue(try localForwardedFlag(from: response.body))
+        let summary = try ledger.summary()
+        XCTAssertEqual(summary.reserved.rawValue, 0)
+        XCTAssertEqual(summary.held.rawValue, 0)
+        XCTAssertEqual(summary.settled.rawValue, expected.amount.rawValue)
+    }
+
+    func testPhase3HStreamingTooManyEventBlocksFailsBeforeLocalSuccessAndSettlesEstimate() throws {
+        let token = try ConsumeLocalToken.generate()
+        let home = try makeTemporaryDirectory()
+        let ledgerURL = home.appendingPathComponent("budget.jsonl")
+        let ledger = try ConsumeBudgetLedger.open(ledgerPath: ledgerURL.path, homeDirectory: home, startupDirectory: home)
+        let trustedRateCard = phase3CTrustedRateCard(
+            promptRatePerMtok: 1_000_000,
+            completionRatePerMtok: 2_000_000,
+            usdPerMillionCredits: 1.0
+        )
+        let budget = ConsumeBudgetConfig(
+            mode: .budget(ConsumeMicroUSD(rawValue: 100_000_000)),
+            maxRequestMicroUSD: nil,
+            allowUnpriced: false,
+            ledger: ledger,
+            ledgerPathClass: ledger.pathClass
+        )
+        let sseBody = String(repeating: ":\n\n", count: ConsumeLocalLimits.sseEventBlocks + 1) + "data: [DONE]\n\n"
+        let upstreamClient = ConsumeStubUpstreamClient { _, eventLoop in
+            eventLoop.makeSucceededFuture(ConsumeUpstreamResponse(
+                statusCode: 200,
+                headers: [("content-type", "text/event-stream")],
+                body: Data(sseBody.utf8)
+            ))
+        }
+        let runtime = consumeRuntime(
+            token: token,
+            credentialStatus: .environmentLoaded,
+            credentialCustody: consumeCredentialCustody("buyer-token"),
+            budget: budget,
+            trustedPricing: .available(trustedRateCard),
+            upstreamClient: upstreamClient,
+            now: { ConsumeCommandTests.phase3CTestNow }
+        )
+        var headers = HTTPHeaders()
+        headers.add(name: "Authorization", value: "Bearer \(token.value)")
+        let body = #"{"model":"llama-test","messages":[],"max_tokens":10,"stream":true}"#
+        let expected = try ConsumePricedExposureEstimator.estimate(
+            bodyByteCount: Data(body.utf8).count,
+            request: StrictJSONParser.parse(body),
+            match: XCTUnwrap(trustedRateCard.match(model: "llama-test")),
+            projection: trustedRateCard.projection
+        )
+
+        let response = try response(
+            from: runtime,
+            head: HTTPRequestHead(version: .http1_1, method: .POST, uri: "/v1/chat/completions", headers: headers),
+            body: Data(body.utf8)
+        )
+
+        XCTAssertEqual(response.status, HTTPResponseStatus(statusCode: 502))
+        XCTAssertEqual(try localError(from: response.body)["code"] as? String, "local_upstream_unavailable")
+        XCTAssertTrue(try localForwardedFlag(from: response.body))
+        let summary = try ledger.summary()
+        XCTAssertEqual(summary.reserved.rawValue, 0)
+        XCTAssertEqual(summary.held.rawValue, 0)
+        XCTAssertEqual(summary.settled.rawValue, expected.amount.rawValue)
+    }
+
+    func testPhase3HStreamingDisconnectSettlesEstimateAndReleasesResources() throws {
+        let token = try ConsumeLocalToken.generate()
+        let home = try makeTemporaryDirectory()
+        let ledgerURL = home.appendingPathComponent("budget.jsonl")
+        let ledger = try ConsumeBudgetLedger.open(ledgerPath: ledgerURL.path, homeDirectory: home, startupDirectory: home)
+        let trustedRateCard = phase3CTrustedRateCard(
+            promptRatePerMtok: 1_000_000,
+            completionRatePerMtok: 2_000_000,
+            usdPerMillionCredits: 1.0
+        )
+        let budget = ConsumeBudgetConfig(
+            mode: .budget(ConsumeMicroUSD(rawValue: 100_000_000)),
+            maxRequestMicroUSD: nil,
+            allowUnpriced: false,
+            ledger: ledger,
+            ledgerPathClass: ledger.pathClass
+        )
+        let pendingPromise = ConsumeUpstreamPromiseBox()
+        let upstreamClient = ConsumeStubUpstreamClient { _, eventLoop in
+            let promise = eventLoop.makePromise(of: ConsumeUpstreamResponse.self)
+            pendingPromise.set(promise)
+            return promise.futureResult
+        }
+        let runtime = consumeRuntime(
+            token: token,
+            credentialStatus: .environmentLoaded,
+            credentialCustody: consumeCredentialCustody("buyer-token"),
+            budget: budget,
+            trustedPricing: .available(trustedRateCard),
+            upstreamClient: upstreamClient,
+            now: { ConsumeCommandTests.phase3CTestNow }
+        )
+        var headers = HTTPHeaders()
+        headers.add(name: "Authorization", value: "Bearer \(token.value)")
+        let body = #"{"model":"llama-test","messages":[],"max_tokens":10,"stream":true}"#
+        let expected = try ConsumePricedExposureEstimator.estimate(
+            bodyByteCount: Data(body.utf8).count,
+            request: StrictJSONParser.parse(body),
+            match: XCTUnwrap(trustedRateCard.match(model: "llama-test")),
+            projection: trustedRateCard.projection
+        )
+        let channel = EmbeddedChannel()
+        try channel.pipeline.addHandler(ConsumeLocalHandler(runtime: runtime)).wait()
+        try channel.writeInbound(HTTPServerRequestPart.head(
+            HTTPRequestHead(version: .http1_1, method: .POST, uri: "/v1/chat/completions", headers: headers)
+        ))
+        var requestBuffer = channel.allocator.buffer(capacity: Data(body.utf8).count)
+        requestBuffer.writeBytes(Data(body.utf8))
+        try channel.writeInbound(HTTPServerRequestPart.body(requestBuffer))
+        try channel.writeInbound(HTTPServerRequestPart.end(nil))
+        channel.embeddedEventLoop.run()
+        XCTAssertEqual(runtime.requestCounter.resourceSnapshot().openStreamingResponses, 1)
+
+        try channel.close().wait()
+        pendingPromise.succeed(ConsumeUpstreamResponse(
+            statusCode: 200,
+            headers: [("content-type", "text/event-stream")],
+            body: Data("data: {\"usage\":{\"prompt_tokens\":1,\"completion_tokens\":2}}\n\ndata: [DONE]\n\n".utf8)
+        ))
+        channel.embeddedEventLoop.run()
+
+        XCTAssertNil(try channel.readOutbound(as: HTTPServerResponsePart.self))
+        let summary = try ledger.summary()
+        XCTAssertEqual(summary.reserved.rawValue, 0)
+        XCTAssertEqual(summary.held.rawValue, 0)
+        XCTAssertEqual(summary.settled.rawValue, expected.amount.rawValue)
+        let snapshot = runtime.requestCounter.resourceSnapshot()
+        XCTAssertEqual(snapshot.openStreamingResponses, 0)
+        XCTAssertEqual(snapshot.upstreamWorkerTasks, 0)
+        XCTAssertEqual(snapshot.upstreamSocketDescriptors, 0)
+    }
+
+    func testPhase3HStreamingDisconnectSuppressesLateUpstreamFailureResponse() throws {
+        let token = try ConsumeLocalToken.generate()
+        let home = try makeTemporaryDirectory()
+        let ledgerURL = home.appendingPathComponent("budget.jsonl")
+        let ledger = try ConsumeBudgetLedger.open(ledgerPath: ledgerURL.path, homeDirectory: home, startupDirectory: home)
+        let trustedRateCard = phase3CTrustedRateCard(
+            promptRatePerMtok: 1_000_000,
+            completionRatePerMtok: 2_000_000,
+            usdPerMillionCredits: 1.0
+        )
+        let budget = ConsumeBudgetConfig(
+            mode: .budget(ConsumeMicroUSD(rawValue: 100_000_000)),
+            maxRequestMicroUSD: nil,
+            allowUnpriced: false,
+            ledger: ledger,
+            ledgerPathClass: ledger.pathClass
+        )
+        let pendingPromise = ConsumeUpstreamPromiseBox()
+        let upstreamClient = ConsumeStubUpstreamClient { _, eventLoop in
+            let promise = eventLoop.makePromise(of: ConsumeUpstreamResponse.self)
+            pendingPromise.set(promise)
+            return promise.futureResult
+        }
+        let runtime = consumeRuntime(
+            token: token,
+            credentialStatus: .environmentLoaded,
+            credentialCustody: consumeCredentialCustody("buyer-token"),
+            budget: budget,
+            trustedPricing: .available(trustedRateCard),
+            upstreamClient: upstreamClient,
+            now: { ConsumeCommandTests.phase3CTestNow }
+        )
+        var headers = HTTPHeaders()
+        headers.add(name: "Authorization", value: "Bearer \(token.value)")
+        let body = #"{"model":"llama-test","messages":[],"max_tokens":10,"stream":true}"#
+        let expected = try ConsumePricedExposureEstimator.estimate(
+            bodyByteCount: Data(body.utf8).count,
+            request: StrictJSONParser.parse(body),
+            match: XCTUnwrap(trustedRateCard.match(model: "llama-test")),
+            projection: trustedRateCard.projection
+        )
+        let channel = EmbeddedChannel()
+        try channel.pipeline.addHandler(ConsumeLocalHandler(runtime: runtime)).wait()
+        try channel.writeInbound(HTTPServerRequestPart.head(
+            HTTPRequestHead(version: .http1_1, method: .POST, uri: "/v1/chat/completions", headers: headers)
+        ))
+        var requestBuffer = channel.allocator.buffer(capacity: Data(body.utf8).count)
+        requestBuffer.writeBytes(Data(body.utf8))
+        try channel.writeInbound(HTTPServerRequestPart.body(requestBuffer))
+        try channel.writeInbound(HTTPServerRequestPart.end(nil))
+        channel.embeddedEventLoop.run()
+        XCTAssertEqual(runtime.requestCounter.resourceSnapshot().openStreamingResponses, 1)
+
+        try channel.close().wait()
+        pendingPromise.fail(ConsumeUpstreamForwardError.dispatchedUnavailable)
+        channel.embeddedEventLoop.run()
+
+        XCTAssertNil(try channel.readOutbound(as: HTTPServerResponsePart.self))
+        let summary = try ledger.summary()
+        XCTAssertEqual(summary.reserved.rawValue, 0)
+        XCTAssertEqual(summary.held.rawValue, 0)
+        XCTAssertEqual(summary.settled.rawValue, expected.amount.rawValue)
+        let snapshot = runtime.requestCounter.resourceSnapshot()
+        XCTAssertEqual(snapshot.openStreamingResponses, 0)
+        XCTAssertEqual(snapshot.upstreamWorkerTasks, 0)
+        XCTAssertEqual(snapshot.upstreamSocketDescriptors, 0)
+    }
+
+    func testPhase3HStreamingDisconnectSettlementFailureMarksLedgerUnavailable() throws {
+        for terminalResult in ["success", "failure"] {
+            let token = try ConsumeLocalToken.generate()
+            let home = try makeTemporaryDirectory()
+            let ledgerURL = home.appendingPathComponent("budget-\(terminalResult).jsonl")
+            let ledger = try ConsumeBudgetLedger.open(ledgerPath: ledgerURL.path, homeDirectory: home, startupDirectory: home)
+            let trustedRateCard = phase3CTrustedRateCard(
+                promptRatePerMtok: 1_000_000,
+                completionRatePerMtok: 2_000_000,
+                usdPerMillionCredits: 1.0
+            )
+            let budget = ConsumeBudgetConfig(
+                mode: .budget(ConsumeMicroUSD(rawValue: 100_000_000)),
+                maxRequestMicroUSD: nil,
+                allowUnpriced: false,
+                ledger: ledger,
+                ledgerPathClass: ledger.pathClass
+            )
+            let pendingPromise = ConsumeUpstreamPromiseBox()
+            let upstreamClient = ConsumeStubUpstreamClient { _, eventLoop in
+                let promise = eventLoop.makePromise(of: ConsumeUpstreamResponse.self)
+                pendingPromise.set(promise)
+                return promise.futureResult
+            }
+            let runtime = consumeRuntime(
+                token: token,
+                credentialStatus: .environmentLoaded,
+                credentialCustody: consumeCredentialCustody("buyer-token"),
+                budget: budget,
+                trustedPricing: .available(trustedRateCard),
+                upstreamClient: upstreamClient,
+                now: { ConsumeCommandTests.phase3CTestNow }
+            )
+            var headers = HTTPHeaders()
+            headers.add(name: "Authorization", value: "Bearer \(token.value)")
+            let body = #"{"model":"llama-test","messages":[],"max_tokens":10,"stream":true}"#
+            let channel = EmbeddedChannel()
+            try channel.pipeline.addHandler(ConsumeLocalHandler(runtime: runtime)).wait()
+            try channel.writeInbound(HTTPServerRequestPart.head(
+                HTTPRequestHead(version: .http1_1, method: .POST, uri: "/v1/chat/completions", headers: headers)
+            ))
+            var requestBuffer = channel.allocator.buffer(capacity: Data(body.utf8).count)
+            requestBuffer.writeBytes(Data(body.utf8))
+            try channel.writeInbound(HTTPServerRequestPart.body(requestBuffer))
+            try channel.writeInbound(HTTPServerRequestPart.end(nil))
+            channel.embeddedEventLoop.run()
+            XCTAssertEqual(runtime.requestCounter.resourceSnapshot().openStreamingResponses, 1, terminalResult)
+
+            try channel.close().wait()
+            try replacePinnedLedgerFile(ledgerURL)
+            if terminalResult == "success" {
+                pendingPromise.succeed(ConsumeUpstreamResponse(
+                    statusCode: 200,
+                    headers: [("content-type", "text/event-stream")],
+                    body: Data("data: {\"usage\":{\"prompt_tokens\":1,\"completion_tokens\":2}}\n\ndata: [DONE]\n\n".utf8)
+                ))
+            } else {
+                pendingPromise.fail(ConsumeUpstreamForwardError.dispatchedUnavailable)
+            }
+            channel.embeddedEventLoop.run()
+
+            XCTAssertNil(try channel.readOutbound(as: HTTPServerResponsePart.self), terminalResult)
+            let status = runtime.statusPayload()
+            XCTAssertEqual(status["budget_ledger_state"] as? String, "unavailable", terminalResult)
+            XCTAssertEqual(status["pricing_trust_state"] as? String, "unavailable", terminalResult)
+            let snapshot = runtime.requestCounter.resourceSnapshot()
+            XCTAssertEqual(snapshot.openStreamingResponses, 0, terminalResult)
+            XCTAssertEqual(snapshot.upstreamWorkerTasks, 0, terminalResult)
+            XCTAssertEqual(snapshot.upstreamSocketDescriptors, 0, terminalResult)
+
+            let nextResponse = try response(
+                from: runtime,
+                head: HTTPRequestHead(version: .http1_1, method: .POST, uri: "/v1/chat/completions", headers: headers),
+                body: Data(body.utf8)
+            )
+            XCTAssertEqual(nextResponse.status, .serviceUnavailable, terminalResult)
+            XCTAssertEqual(try localError(from: nextResponse.body)["code"] as? String, "local_budget_ledger_unavailable", terminalResult)
+            XCTAssertFalse(try localForwardedFlag(from: nextResponse.body), terminalResult)
+        }
+    }
+
+    func testPhase3HStreamingDisconnectSuppressesLateResolverFailureResponse() throws {
+        let token = try ConsumeLocalToken.generate()
+        let trustedRateCard = phase3CTrustedRateCard(
+            promptRatePerMtok: 1_000_000,
+            completionRatePerMtok: 2_000_000,
+            usdPerMillionCredits: 1.0
+        )
+        let budget = ConsumeBudgetConfig(
+            mode: .noBudget,
+            maxRequestMicroUSD: nil,
+            allowUnpriced: false,
+            ledger: nil,
+            ledgerPathClass: nil
+        )
+        let endpointPromise = ConsumeEndpointPromiseBox()
+        let upstreamClient = ConsumeStubUpstreamClient(
+            resolver: { _, eventLoop in
+                let promise = eventLoop.makePromise(of: String.self)
+                endpointPromise.set(promise)
+                return promise.futureResult
+            },
+            handler: { _, eventLoop in
+                eventLoop.makeFailedFuture(ConsumeUpstreamForwardError.dispatchedUnavailable)
+            }
+        )
+        let runtime = consumeRuntime(
+            token: token,
+            credentialStatus: .environmentLoaded,
+            credentialCustody: consumeCredentialCustody("buyer-token"),
+            budget: budget,
+            trustedPricing: .available(trustedRateCard),
+            upstreamClient: upstreamClient,
+            now: { ConsumeCommandTests.phase3CTestNow }
+        )
+        var headers = HTTPHeaders()
+        headers.add(name: "Authorization", value: "Bearer \(token.value)")
+        let body = #"{"model":"llama-test","messages":[],"max_tokens":10,"stream":true}"#
+        let channel = EmbeddedChannel()
+        try channel.pipeline.addHandler(ConsumeLocalHandler(runtime: runtime)).wait()
+        try channel.writeInbound(HTTPServerRequestPart.head(
+            HTTPRequestHead(version: .http1_1, method: .POST, uri: "/v1/chat/completions", headers: headers)
+        ))
+        var requestBuffer = channel.allocator.buffer(capacity: Data(body.utf8).count)
+        requestBuffer.writeBytes(Data(body.utf8))
+        try channel.writeInbound(HTTPServerRequestPart.body(requestBuffer))
+        try channel.writeInbound(HTTPServerRequestPart.end(nil))
+        channel.embeddedEventLoop.run()
+        XCTAssertEqual(runtime.requestCounter.resourceSnapshot().openStreamingResponses, 1)
+
+        try channel.close().wait()
+        endpointPromise.fail(ConsumeUpstreamForwardError.preDispatchUnavailable)
+        channel.embeddedEventLoop.run()
+
+        XCTAssertNil(try channel.readOutbound(as: HTTPServerResponsePart.self))
+        let snapshot = runtime.requestCounter.resourceSnapshot()
+        XCTAssertEqual(snapshot.openStreamingResponses, 0)
+        XCTAssertEqual(snapshot.upstreamWorkerTasks, 0)
+        XCTAssertEqual(snapshot.upstreamSocketDescriptors, 0)
     }
 
     func testPhase3GNoBudgetExplicitLedgerRecordsAndSettlesStreamingAuditRows() throws {
@@ -2696,15 +3174,20 @@ final class ConsumeCommandTests: XCTestCase {
             projection: trustedRateCard.projection
         )
 
-        let response = try response(
+        let response = try responseWithBodyChunks(
             from: runtime,
             head: HTTPRequestHead(version: .http1_1, method: .POST, uri: "/v1/chat/completions", headers: headers),
             body: Data(body.utf8)
         )
 
         XCTAssertEqual(response.status, .ok)
-        XCTAssertEqual(response.body, sseBody)
+        XCTAssertEqual(response.body, response.bodyChunks.joined())
+        XCTAssertNil(response.headers.first(name: "content-length"))
         XCTAssertEqual(response.headers.first(name: "x-macprovider-warning"), "upstream_notice,no_budget")
+        XCTAssertEqual(response.bodyChunks, [
+            #"data: {"choices":[],"usage":{"prompt_tokens":1,"completion_tokens":2}}"# + "\n\n",
+            "data: [DONE]\n\n",
+        ])
         XCTAssertTrue(try XCTUnwrap(recorder.snapshot().first).streaming)
         let summary = try ledger.summary()
         XCTAssertEqual(summary.reserved.rawValue, 0)
@@ -4594,6 +5077,12 @@ final class ConsumeCommandTests: XCTestCase {
         chmod(url.path, 0o600)
     }
 
+    private func replacePinnedLedgerFile(_ url: URL) throws {
+        try FileManager.default.removeItem(at: url)
+        try Data().write(to: url)
+        chmod(url.path, 0o600)
+    }
+
     private func makeTemporaryDirectory() throws -> URL {
         let base = URL(fileURLWithPath: FileManager.default.currentDirectoryPath, isDirectory: true)
             .appendingPathComponent(".build/mp-consume-tests", isDirectory: true)
@@ -4852,10 +5341,20 @@ final class ConsumeCommandTests: XCTestCase {
         head: HTTPRequestHead,
         body requestBody: Data = Data()
     ) throws -> (status: HTTPResponseStatus, headers: HTTPHeaders, body: String) {
+        let response = try responseWithBodyChunks(from: runtime, head: head, body: requestBody)
+        return (response.status, response.headers, response.body)
+    }
+
+    private func responseWithBodyChunks(
+        from runtime: ConsumeEndpointRuntime,
+        head: HTTPRequestHead,
+        body requestBody: Data = Data()
+    ) throws -> (status: HTTPResponseStatus, headers: HTTPHeaders, body: String, bodyChunks: [String]) {
         let channel = EmbeddedChannel()
         try channel.pipeline.addHandler(ConsumeLocalHandler(runtime: runtime)).wait()
         var responseHead: HTTPResponseHead?
         var responseBody = Data()
+        var bodyChunks: [String] = []
 
         try channel.writeInbound(HTTPServerRequestPart.head(head))
         if !requestBody.isEmpty {
@@ -4873,20 +5372,21 @@ final class ConsumeCommandTests: XCTestCase {
             case .body(.byteBuffer(var buffer)):
                 if let bytes = buffer.readBytes(length: buffer.readableBytes) {
                     responseBody.append(contentsOf: bytes)
+                    bodyChunks.append(String(decoding: bytes, as: UTF8.self))
                 }
             case .end:
                 guard let responseHead else {
                     XCTFail("response head was not emitted")
-                    return (.internalServerError, HTTPHeaders(), "")
+                    return (.internalServerError, HTTPHeaders(), "", [])
                 }
-                return (responseHead.status, responseHead.headers, String(decoding: responseBody, as: UTF8.self))
+                return (responseHead.status, responseHead.headers, String(decoding: responseBody, as: UTF8.self), bodyChunks)
             default:
                 break
             }
         }
 
         XCTFail("response end was not emitted")
-        return (.internalServerError, HTTPHeaders(), String(decoding: responseBody, as: UTF8.self))
+        return (.internalServerError, HTTPHeaders(), String(decoding: responseBody, as: UTF8.self), bodyChunks)
     }
 
     private func drainResponse(from channel: EmbeddedChannel) throws -> (status: HTTPResponseStatus, headers: HTTPHeaders, body: String) {

--- a/specs/design/spec-045/BUILD_SPEC_045_LOCAL_CONSUMER_ENDPOINT_IMPL.md
+++ b/specs/design/spec-045/BUILD_SPEC_045_LOCAL_CONSUMER_ENDPOINT_IMPL.md
@@ -24,7 +24,9 @@ Ship `macprovider-cli consume` as a local development adapter: a macOS loopback-
    - compressed non-streaming upstream response decode-to-identity, decoded response caps, and settlement from decoded usage.
 8. `BUILD_SPEC_045_PHASE_3G_BUFFERED_SSE_FOUNDATION.md`
    - bounded buffered SSE upstream response relay, terminal `[DONE]` validation, and settlement from terminal stream usage evidence.
-9. `BUILD_SPEC_045_PHASE_4_CONFORMANCE_JOURNEY.md`
+9. `BUILD_SPEC_045_PHASE_3H_LIVE_SSE_EMISSION.md`
+   - local live SSE emission, event-line/event-frame bounds, idle read deadline refresh, and conservative local-disconnect settlement.
+10. `BUILD_SPEC_045_PHASE_4_CONFORMANCE_JOURNEY.md`
    - required automated coverage, fake-gateway integration harness, staging/production signed journey, and promotion evidence.
 
 ## Required sequencing
@@ -37,6 +39,7 @@ Ship `macprovider-cli consume` as a local development adapter: a macOS loopback-
 - Phase 3E may land without streaming/SSE forwarding, compressed non-streaming decode-to-identity, or mutable upstream invalid-credential state; those remain required before Phase 4 can claim conformance.
 - Phase 3F may land without streaming/SSE forwarding, mutable upstream invalid-credential state, or fake/real conformance journeys; those remain required before Phase 4 can claim conformance.
 - Phase 3G may land without live incremental SSE flushing, disconnect cancellation, mutable upstream invalid-credential state, or fake/real conformance journeys; those remain required before Phase 4 can claim conformance.
+- Phase 3H may land without fully incremental upstream socket relay, mutable upstream invalid-credential state, or fake/real conformance journeys; those remain required before Phase 4 can claim conformance.
 - Phase 4 must not claim production readiness until Phases 1-3 are implemented and the signed real-gateway journey exists.
 
 ## Non-goals

--- a/specs/design/spec-045/BUILD_SPEC_045_PHASE_3H_LIVE_SSE_EMISSION.md
+++ b/specs/design/spec-045/BUILD_SPEC_045_PHASE_3H_LIVE_SSE_EMISSION.md
@@ -1,0 +1,100 @@
+# BUILD_SPEC_045_PHASE_3H_LIVE_SSE_EMISSION
+
+Implement the next streaming slice after the Phase 3G buffered SSE foundation.
+This slice owns local live SSE emission semantics, SSE event-line and event-frame
+bounds, upstream idle-read deadline refresh, and conservative local-disconnect
+settlement. It does not replace the bounded upstream response parser with a
+fully incremental upstream transport API.
+
+## Target Result
+
+Successful trusted streaming chat-completions requests still pass the existing
+admission, resource, credential, forwarding, validation, and ledger gates, but
+the local response is emitted as an SSE stream: no `Content-Length`, response
+headers are flushed before event bodies, and each validated SSE event is written
+as its own flushed body part. Oversized SSE lines or events fail before local
+success. If the local client disconnects while a streaming upstream exchange is
+pending, local delivery is skipped, upstream work is abandoned when the current
+transport can observe completion, and any ledger reservation settles
+conservatively to the admission estimate.
+
+## Required Implementation Shape
+
+1. Preserve Phase 3G admission and validation:
+   - do not weaken local auth, model allowlist, pricing, ledger, credential,
+     resolver, resource, content-type, content-encoding, terminal `[DONE]`, or
+     post-`[DONE]` validation;
+   - non-2xx streaming upstream responses remain preserved as upstream error
+     responses, not reclassified as malformed SSE;
+   - streaming validation failures still return local upstream failures before
+     any local success response is started.
+
+2. Add bounded SSE parser metadata:
+   - enforce a maximum SSE line byte count;
+   - enforce a maximum SSE event frame byte count across all lines in one
+     event;
+   - enforce a maximum emitted event-block count so tiny-event floods cannot
+     create unbounded flush churn within the response body byte cap;
+   - keep terminal `[DONE]`, duplicate-DONE, missing-DONE, post-DONE, and JSON
+     event-data validation unchanged;
+   - return validated event blocks for local emission without reserializing
+     JSON payloads.
+
+3. Emit successful SSE responses as live local streams:
+   - strip upstream `Content-Length` and `Content-Encoding`;
+   - do not synthesize `Content-Length` for successful local SSE;
+   - flush the response head before event bodies;
+   - write each validated SSE event block as a separate flushed response body;
+   - close the local connection only after the terminal event and response end.
+
+4. Refresh upstream idle read deadline:
+   - treat upstream receive progress as activity;
+   - refresh the read deadline after every non-empty upstream receive chunk so
+     slow but progressing streams are not failed by a single absolute read
+     timer.
+
+5. Handle local disconnect conservatively:
+   - if the local channel closes while a streaming upstream exchange is pending,
+     mark the request disconnected;
+   - do not write a late local success or local error response to the closed
+     channel;
+   - for ledger-backed streaming reservations, settle to the admission estimate
+     rather than trusting partial or late stream usage evidence;
+   - if that terminal ledger append fails after disconnect, treat the ledger as
+     unavailable so subsequent ledger-backed admission fails closed rather than
+     continuing with an apparently live reservation;
+   - release all upstream worker/socket/streaming-slot reservations and active
+     request accounting after the upstream future reaches a terminal state.
+
+## Acceptance Tests
+
+- successful streaming responses omit `Content-Length`, preserve event order,
+  and expose multiple body chunks matching validated SSE event blocks;
+- oversized SSE event lines fail as forwarded upstream failures and settle to
+  the admission estimate;
+- oversized SSE event frames fail as forwarded upstream failures and settle to
+  the admission estimate;
+- too many tiny SSE event blocks fail as forwarded upstream failures and settle
+  to the admission estimate;
+- local disconnect during a pending streaming upstream exchange causes
+  conservative estimate settlement and releases streaming resources without
+  emitting a late local response.
+- local disconnect plus terminal ledger append failure marks the ledger
+  unavailable, releases streaming resources, suppresses late local output, and
+  causes the next ledger-backed request to fail closed.
+
+## Follow-Up Slices
+
+- fully incremental upstream socket-to-local relay with upstream cancellation
+  handles;
+- mutable credential state that marks invalid or expired upstream buyer
+  credentials while preserving the initiating client's upstream auth failure;
+- fake-gateway and real-gateway conformance journeys.
+
+## Non-Goals
+
+- Do not implement request compression or compressed SSE decoding.
+- Do not add new OpenAI-compatible endpoint paths.
+- Do not change gateway billing, coordinator settlement, provider payout, or
+  receipt semantics.
+- Do not claim SPEC-045 production readiness from this slice alone.


### PR DESCRIPTION
## Summary

- add BUILD_SPEC_045_PHASE_3H_LIVE_SSE_EMISSION for the local live-SSE emission slice
- emit successful local streaming responses without Content-Length and flush validated SSE event blocks individually
- add SSE line/frame/event-block bounds, upstream idle-read refresh, and conservative disconnect handling with ledger-unavailable fail-closed recovery

## Validation

- `git diff --check`
- `swift test --filter ConsumeCommandTests --skip-update` (110 tests)
- `swift build --target macprovider-cli --skip-update`
- `jq empty specs/AUTHORITY.json && jq empty specs/CONFORMANCE.json`
- `python3 scripts/gen_spec_index.py --check`
- `python3 scripts/gen_spec_index.py --lint`
- `python3 scripts/check_spec_governance.py --base-ref origin/main`
- `python3 -m unittest scripts.tests.test_spec_governance scripts.tests.test_spec_pr_declaration` (59 tests)
- 3-lane Codex audit round 3: code/security/architecture all 0 C/H/M

SPEC-GOVERNANCE-DECLARATION-BEGIN
{
  "schema_version": "spec-pr-governance-v1",
  "behavior_change": "yes",
  "contract_change": "none",
  "specs": ["SPEC-045"],
  "requirements": [
    "SPEC-045-R001",
    "SPEC-045-R002",
    "SPEC-045-R003",
    "SPEC-045-R004",
    "SPEC-045-R005",
    "SPEC-045-R006",
    "SPEC-045-R007",
    "SPEC-045-R008"
  ],
  "authority_domains": ["local-consumer-endpoint"],
  "arbitration": ["CODE_BUG"],
  "tests": [
    "swift test --filter ConsumeCommandTests --skip-update",
    "swift build --target macprovider-cli --skip-update",
    "python3 scripts/check_spec_governance.py --base-ref origin/main"
  ],
  "journeys": ["not-required"],
  "issue": "https://github.com/Augustas11/macprovider/issues/927"
}
SPEC-GOVERNANCE-DECLARATION-END
