### PR TITLE
Fix SPEC-042 signer redaction schema

### DIFF
--- a/scripts/build-trusted-pool-layer2-journey-result.py
+++ b/scripts/build-trusted-pool-layer2-journey-result.py
@@ -76,6 +76,11 @@ FORBIDDEN_OVERCLAIM_PATTERNS = (
     re.compile(r"(?i)\bprovider[- ]?operator[- ]?blind(ness)?\b"),
     re.compile(r"(?i)\boperator[- ]?blind(ness)?\b"),
 )
+SIGNED_REDACTION_FIELDS = (
+    "secrets_redacted",
+    "operator_identity_redacted",
+    "local_account_names_redacted",
+)
 
 
 def die(message: str) -> None:
@@ -338,6 +343,19 @@ def require_candidate_identity(value: Any) -> dict[str, Any]:
     return deepcopy(identity)
 
 
+def require_signed_redaction(value: Any) -> dict[str, bool]:
+    redaction = require_object(value, "redaction")
+    for field, redacted in sorted(redaction.items()):
+        if field.endswith("_redacted") and redacted is not True:
+            die(f"redaction.{field} must be true")
+    signed_redaction: dict[str, bool] = {}
+    for field in SIGNED_REDACTION_FIELDS:
+        if redaction.get(field) is not True:
+            die(f"redaction.{field} must be true")
+        signed_redaction[field] = True
+    return signed_redaction
+
+
 def build_payload(root: Path, source: str, *, source_sha: str, evidence_sha: str, requirement_ids: str | None) -> dict[str, Any]:
     require_string(source_sha, COMMIT_RE, "--source-sha")
     require_string(evidence_sha, COMMIT_RE, "--evidence-sha")
@@ -385,10 +403,7 @@ def build_payload(root: Path, source: str, *, source_sha: str, evidence_sha: str
     if "summary" in result:
         reject_forbidden_overclaim_text(require_string(result.get("summary"), None, "result.summary"), "result.summary")
     steps = require_steps(evidence.get("steps"))
-    redaction = deepcopy(require_object(evidence.get("redaction"), "redaction"))
-    for field in ("secrets_redacted", "operator_identity_redacted", "local_account_names_redacted"):
-        if redaction.get(field) is not True:
-            die(f"redaction.{field} must be true")
+    redaction = require_signed_redaction(evidence.get("redaction"))
     observations = require_observations(evidence.get("observations"))
     candidate_identity = require_candidate_identity(evidence.get("candidate_identity"))
     artifact_sha = hashlib.sha256(evidence_bytes).hexdigest()

--- a/scripts/tests/test_trusted_pool_layer2_journey_result.py
+++ b/scripts/tests/test_trusted_pool_layer2_journey_result.py
@@ -342,6 +342,51 @@ class TrustedPoolLayer2JourneyResultTests(unittest.TestCase):
             with self.assertRaises(SystemExit, msg=text):
                 builder.reject_forbidden_overclaim_text(text, "text")
 
+    def test_builder_normalizes_rich_source_redaction_for_signed_payload(self) -> None:
+        builder = load_builder()
+        rich_redaction = {
+            "secrets_redacted": True,
+            "operator_identity_redacted": True,
+            "local_account_names_redacted": True,
+            "artifact_id": "redacted-trusted-pool-layer2",
+            "bearer_tokens_redacted": True,
+            "buyer_credential_redacted": True,
+            "local_endpoint_redacted": True,
+            "provider_identity_redacted": True,
+            "raw_prompt_output_redacted": True,
+            "redaction_reviewed_by_human": True,
+        }
+        self.assertEqual(
+            {
+                "secrets_redacted": True,
+                "operator_identity_redacted": True,
+                "local_account_names_redacted": True,
+            },
+            builder.require_signed_redaction(rich_redaction),
+        )
+
+    def test_builder_rejects_missing_required_signed_redaction(self) -> None:
+        builder = load_builder()
+        redaction = {
+            "secrets_redacted": True,
+            "operator_identity_redacted": True,
+            "local_account_names_redacted": False,
+            "artifact_id": "redacted-trusted-pool-layer2",
+        }
+        with self.assertRaises(SystemExit):
+            builder.require_signed_redaction(redaction)
+
+    def test_builder_rejects_false_rich_source_redaction_flag(self) -> None:
+        builder = load_builder()
+        redaction = {
+            "secrets_redacted": True,
+            "operator_identity_redacted": True,
+            "local_account_names_redacted": True,
+            "buyer_credential_redacted": False,
+        }
+        with self.assertRaises(SystemExit):
+            builder.require_signed_redaction(redaction)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

Fixes the SPEC-042 Trusted Pool Layer 2 protected signer failure by normalizing rich source evidence redaction into the canonical signed journey-result `redaction` shape.

The builder now rejects any source redaction flag ending in `_redacted` unless it is exactly `true`, then emits only the three canonical signed redaction fields expected by the shared signed evidence validator.

## Validation

- `python3 -m unittest scripts.tests.test_trusted_pool_layer2_journey_result`
- `scripts/test-signed-trusted-pool-layer2-journey-workflow.sh`
- exact builder smoke for `journeys/evidence/trusted-pool-layer2-20260824T011501Z.redacted.json`
- `python3 scripts/check_spec_governance.py`
- `python3 scripts/gen_spec_index.py --check`
- `git diff --check`
- `python3 -m py_compile scripts/build-trusted-pool-layer2-journey-result.py scripts/tests/test_trusted_pool_layer2_journey_result.py`
- 3 audit lanes on final diff: code/security/architecture = 0 C/H/M

Not tested: protected GitHub signer rerun with the production-release signing secret; that must be rerun from `main` after this PR merges.

SPEC-GOVERNANCE-DECLARATION-BEGIN
{
  "schema_version": "spec-pr-governance-v1",
  "behavior_change": "yes",
  "contract_change": "none",
  "specs": ["SPEC-042"],
  "requirements": ["SPEC-042-R002", "SPEC-042-R005", "SPEC-042-R006", "SPEC-042-R010"],
  "authority_domains": ["pool-control-plane"],
  "arbitration": ["CODE_BUG"],
  "tests": [
    "python3 -m unittest scripts.tests.test_trusted_pool_layer2_journey_result",
    "scripts/test-signed-trusted-pool-layer2-journey-workflow.sh",
    "python3 scripts/check_spec_governance.py",
    "python3 scripts/gen_spec_index.py --check",
    "git diff --check"
  ],
  "journeys": ["JOURNEY-TRUSTED-POOL-LAYER2-MVP"],
  "issue": "https://github.com/Augustas11/macprovider/issues/1053"
}
SPEC-GOVERNANCE-DECLARATION-END
