### PR TITLE
Capture real SPEC-045 local endpoint evidence

### DIFF
--- a/journeys/evidence/local-consumer-endpoint-20260824T060103Z.redacted.json
+++ b/journeys/evidence/local-consumer-endpoint-20260824T060103Z.redacted.json
@@ -1,0 +1,227 @@
+{
+  "schema_version": "macprovider.local-consumer-endpoint-evidence.v1",
+  "journey_id": "JOURNEY-LOCAL-CONSUMER-ENDPOINT",
+  "requirement_ids": [
+    "SPEC-045-R001",
+    "SPEC-045-R002",
+    "SPEC-045-R003",
+    "SPEC-045-R004",
+    "SPEC-045-R005",
+    "SPEC-045-R006",
+    "SPEC-045-R007",
+    "SPEC-045-R008"
+  ],
+  "repository": {
+    "name": "Augustas11/macprovider",
+    "commit": "dc63ecec59593235593b3de003e567e007ddcdc8"
+  },
+  "captured_at": "2026-08-24T06:13:13Z",
+  "expires_at": "2027-08-24",
+  "operator": {
+    "role": "release-operator",
+    "identity_fingerprint": "2e5a2503810a6b75d51919075dd43175eafdc4ea5dacf20c604a8668d5d79b60"
+  },
+  "environment": {
+    "class": "staging-or-production-local-consumer-endpoint",
+    "hardware_profile": "local-macos-redacted",
+    "candidate": "commit:dc63ecec59593235593b3de003e567e007ddcdc8"
+  },
+  "result": {
+    "status": "pass"
+  },
+  "steps": [
+    {
+      "id": "step-01-capture-local-endpoint",
+      "status": "pass",
+      "artifacts": [
+        "redacted-local-consumer-endpoint"
+      ],
+      "support_artifacts": [
+        "cli_binary",
+        "ledger_capture",
+        "log_capture",
+        "rate_card_capture",
+        "status_capture"
+      ]
+    },
+    {
+      "id": "step-02-openai-sdk-local-client",
+      "status": "pass",
+      "artifacts": [
+        "redacted-local-consumer-endpoint"
+      ],
+      "support_artifacts": [
+        "cli_binary",
+        "ledger_capture",
+        "log_capture",
+        "rate_card_capture",
+        "status_capture"
+      ]
+    },
+    {
+      "id": "step-03-permitted-chat-completion",
+      "status": "pass",
+      "artifacts": [
+        "redacted-local-consumer-endpoint"
+      ],
+      "support_artifacts": [
+        "cli_binary",
+        "ledger_capture",
+        "log_capture",
+        "rate_card_capture",
+        "status_capture"
+      ]
+    },
+    {
+      "id": "step-04-over-budget-denial",
+      "status": "pass",
+      "artifacts": [
+        "redacted-local-consumer-endpoint"
+      ],
+      "support_artifacts": [
+        "cli_binary",
+        "ledger_capture",
+        "log_capture",
+        "rate_card_capture",
+        "status_capture"
+      ]
+    },
+    {
+      "id": "step-05-restart-held-reservation",
+      "status": "pass",
+      "artifacts": [
+        "redacted-local-consumer-endpoint"
+      ],
+      "support_artifacts": [
+        "cli_binary",
+        "ledger_capture",
+        "log_capture",
+        "rate_card_capture",
+        "status_capture"
+      ]
+    },
+    {
+      "id": "step-06-recovery-release-held-reservation",
+      "status": "pass",
+      "artifacts": [
+        "redacted-local-consumer-endpoint"
+      ],
+      "support_artifacts": [
+        "cli_binary",
+        "ledger_capture",
+        "log_capture",
+        "rate_card_capture",
+        "status_capture"
+      ]
+    },
+    {
+      "id": "step-07-redaction-status-logs",
+      "status": "pass",
+      "artifacts": [
+        "redacted-local-consumer-endpoint"
+      ],
+      "support_artifacts": [
+        "cli_binary",
+        "ledger_capture",
+        "log_capture",
+        "rate_card_capture",
+        "status_capture"
+      ]
+    },
+    {
+      "id": "step-08-restore-local-state",
+      "status": "pass",
+      "artifacts": [
+        "redacted-local-consumer-endpoint"
+      ],
+      "support_artifacts": [
+        "cli_binary",
+        "ledger_capture",
+        "log_capture",
+        "rate_card_capture",
+        "status_capture"
+      ]
+    }
+  ],
+  "redaction": {
+    "local_account_names_redacted": true,
+    "operator_identity_redacted": true,
+    "secrets_redacted": true
+  },
+  "observations": {
+    "bearer_tokens_redacted": true,
+    "generated_local_token_used_as_api_key": true,
+    "held_reservation_survived_restart": true,
+    "local_base_url_configured": true,
+    "openai_sdk_used": true,
+    "over_budget_denial_observed": true,
+    "permitted_chat_completion_observed": true,
+    "raw_prompt_output_redacted": true,
+    "recovery_release_observed": true,
+    "redacted_artifacts_reviewed": true,
+    "staging_or_production_gateway": true,
+    "fake_gateway_used": false,
+    "local_token_logged": false,
+    "raw_completion_logged": false,
+    "raw_prompt_logged": false,
+    "upstream_credential_logged": false
+  },
+  "candidate_identity": {
+    "buyer_credential_fingerprint": "c7b9bf95d1388c019fe79d12fcfaa7a999adf833d467d5036b7c1baad9872733",
+    "cli_binary_sha256": "3959f11814b3a1fa2ae9fbf5717a1be497bdcdc535ae9376176bef7e4a1b7e14",
+    "cli_version": "1.8.104",
+    "gateway_kind": "production",
+    "ledger_sha256": "1cc54d17e294ce5c26aaf87dcf074a69ef0189ab53344c80ab6173baed65efa1",
+    "local_endpoint_base_url_sha256": "9d7a1b946b33f681ceeadb541d350a5b806dec27a91c1f4f964edf0fcb338cfa",
+    "local_token_fingerprint": "10c381ea3055b68eec3bc7971c5775b7aed8ed9a5e617b2c2d00a8432dd0c159",
+    "log_capture_sha256": "9d11ebf3ec36b42e08158b621b42184847db0d638e2a5b9eaf233d1ab34a2d4b",
+    "model_id": "mlx-community/Qwen3-8B-4bit",
+    "rate_card_sha256": "dff447006f51a81ba233d45d383a3e0d377e007f48f488404308415a6b4692c5",
+    "sdk_name": "openai-python",
+    "sdk_version": "3.3.1",
+    "status_capture_sha256": "cf7d215a13730b7ead2e014e7d2112be4181eae8bdddbe4dfff08db68db81d31",
+    "upstream_gateway_origin_sha256": "05ec143545d842afe0609f2659c59812840dcfeba47e869dea17ff2121686dbe"
+  },
+  "support_artifacts": {
+    "cli_binary": {
+      "role": "cli-binary",
+      "sha256": "3959f11814b3a1fa2ae9fbf5717a1be497bdcdc535ae9376176bef7e4a1b7e14",
+      "bytes": 59629952
+    },
+    "ledger_capture": {
+      "role": "redacted-ledger-capture",
+      "sha256": "1cc54d17e294ce5c26aaf87dcf074a69ef0189ab53344c80ab6173baed65efa1",
+      "bytes": 3198
+    },
+    "log_capture": {
+      "role": "redacted-log-capture",
+      "sha256": "9d11ebf3ec36b42e08158b621b42184847db0d638e2a5b9eaf233d1ab34a2d4b",
+      "bytes": 196
+    },
+    "rate_card_capture": {
+      "role": "redacted-rate-card-capture",
+      "sha256": "dff447006f51a81ba233d45d383a3e0d377e007f48f488404308415a6b4692c5",
+      "bytes": 382
+    },
+    "status_capture": {
+      "role": "redacted-status-capture",
+      "sha256": "cf7d215a13730b7ead2e014e7d2112be4181eae8bdddbe4dfff08db68db81d31",
+      "bytes": 1272
+    }
+  },
+  "review": {
+    "reviewed_at": "2026-08-24T06:12:04Z",
+    "reviewer_role": "release-operator",
+    "support_artifacts_reviewed": [
+      "cli_binary",
+      "ledger_capture",
+      "log_capture",
+      "rate_card_capture",
+      "status_capture"
+    ],
+    "real_gateway_basis": "staging-or-production-gateway",
+    "sdk_client_basis": "openai-sdk-local-token-api-key",
+    "redaction_basis": "redacted-support-artifacts-reviewed"
+  },
+  "run_id": "local-consumer-endpoint-20260824T060103Z"
+}

--- a/scripts/build-local-consumer-endpoint-journey-result.py
+++ b/scripts/build-local-consumer-endpoint-journey-result.py
@@ -48,6 +48,7 @@ CANDIDATE_IDENTITY_VERSION_RE = re.compile(r"^v?[0-9]+[.][0-9]+[.][0-9]+(?:-(?:t
 CANDIDATE_IDENTITY_MODEL_ID_RE = re.compile(
     r"^(?:"
     r"model-test|"
+    r"mlx-community/(?:Llama-3[.]2-3B-Instruct-4bit|Qwen3-8B-4bit)|"
     r"gpt-[0-9]+(?:[-.](?:mini|nano|turbo|preview|latest|instruct|realtime|audio|search|chat|transcribe|tts|[0-9]{4}(?:-[0-9]{2}(?:-[0-9]{2})?)?)){0,6}|"
     r"o[1-9](?:[-.](?:mini|pro|preview|latest|reasoning|[0-9]{4}(?:-[0-9]{2}(?:-[0-9]{2})?)?)){0,6}"
     r")$"

--- a/scripts/capture-local-consumer-endpoint-evidence.py
+++ b/scripts/capture-local-consumer-endpoint-evidence.py
@@ -184,6 +184,7 @@ CANDIDATE_IDENTITY_VERSION_RE = re.compile(r"^v?[0-9]+[.][0-9]+[.][0-9]+(?:-(?:t
 CANDIDATE_IDENTITY_MODEL_ID_RE = re.compile(
     r"^(?:"
     r"model-test|"
+    r"mlx-community/(?:Llama-3[.]2-3B-Instruct-4bit|Qwen3-8B-4bit)|"
     r"gpt-[0-9]+(?:[-.](?:mini|nano|turbo|preview|latest|instruct|realtime|audio|search|chat|transcribe|tts|[0-9]{4}(?:-[0-9]{2}(?:-[0-9]{2})?)?)){0,6}|"
     r"o[1-9](?:[-.](?:mini|pro|preview|latest|reasoning|[0-9]{4}(?:-[0-9]{2}(?:-[0-9]{2})?)?)){0,6}"
     r")$"

--- a/scripts/check_spec_governance.py
+++ b/scripts/check_spec_governance.py
@@ -179,6 +179,7 @@ LOCAL_CONSUMER_ENDPOINT_CANDIDATE_IDENTITY_VERSION_RE = re.compile(r"^v?[0-9]+[.
 LOCAL_CONSUMER_ENDPOINT_CANDIDATE_IDENTITY_MODEL_ID_RE = re.compile(
     r"^(?:"
     r"model-test|"
+    r"mlx-community/(?:Llama-3[.]2-3B-Instruct-4bit|Qwen3-8B-4bit)|"
     r"gpt-[0-9]+(?:[-.](?:mini|nano|turbo|preview|latest|instruct|realtime|audio|search|chat|transcribe|tts|[0-9]{4}(?:-[0-9]{2}(?:-[0-9]{2})?)?)){0,6}|"
     r"o[1-9](?:[-.](?:mini|pro|preview|latest|reasoning|[0-9]{4}(?:-[0-9]{2}(?:-[0-9]{2})?)?)){0,6}"
     r")$"

--- a/scripts/tests/test_local_consumer_endpoint_evidence_capture.py
+++ b/scripts/tests/test_local_consumer_endpoint_evidence_capture.py
@@ -183,7 +183,7 @@ def base_argv(root: Path, commit: str, files: dict[str, Path], output: str) -> l
         "--gateway-kind",
         "production",
         "--model-id",
-        "model-test",
+        "mlx-community/Llama-3.2-3B-Instruct-4bit",
         "--sdk-name",
         "openai-python",
         "--sdk-version",
@@ -233,6 +233,7 @@ class LocalConsumerEndpointEvidenceCaptureTests(unittest.TestCase):
             self.assertNotIn("summary", evidence["result"])
             self.assertEqual(sorted(LOCAL_CONSUMER_ENDPOINT_EVIDENCE_REQUIREMENT_IDS), evidence["requirement_ids"])
             self.assertEqual("production", evidence["candidate_identity"]["gateway_kind"])
+            self.assertEqual("mlx-community/Llama-3.2-3B-Instruct-4bit", evidence["candidate_identity"]["model_id"])
             self.assertEqual(
                 sorted(["cli_binary", "ledger_capture", "log_capture", "rate_card_capture", "status_capture"]),
                 sorted(evidence["support_artifacts"]),
@@ -734,6 +735,19 @@ class LocalConsumerEndpointEvidenceCaptureTests(unittest.TestCase):
             argv[argv.index("--candidate") + 1] = "Summarize confidential merger plans"
             with self.assertRaises(SystemExit):
                 capture.main(argv)
+            for name, model_id in {
+                "unknown_namespace": "private-org/Llama-3.2-3B-Instruct-4bit",
+                "nested_namespace": "mlx-community/private/Llama-3.2-3B-Instruct-4bit",
+                "urlish_model": "mlx-community/Llama-3.2-3B-Instruct-4bit?token=redacted",
+                "operator_local_model": "mlx-community/augstar-MacBook-Pro",
+                "secret_phrase_model": "mlx-community/secret-production-token-1234567890",
+                "prompt_phrase_model": "mlx-community/Summarize-confidential-merger-plans",
+                "completion_phrase_model": "mlx-community/raw-completion-text",
+            }.items():
+                argv = base_argv(root, commit, files, f"journeys/evidence/local-consumer-endpoint-model-{name}.redacted.json")
+                argv[argv.index("--model-id") + 1] = model_id
+                with self.assertRaises(SystemExit, msg=name):
+                    capture.main(argv)
             argv = base_argv(root, commit, files, "journeys/evidence/local-consumer-endpoint-operator-local.redacted.json")
             argv[argv.index("--operator-role") + 1] = "augstar@MacBook-Pro.local"
             with self.assertRaises(SystemExit):

--- a/scripts/tests/test_local_consumer_endpoint_journey_result.py
+++ b/scripts/tests/test_local_consumer_endpoint_journey_result.py
@@ -83,7 +83,7 @@ def valid_signed(*, requirement_ids=None, extra_requirement=None, **overrides):
             "local_endpoint_base_url_sha256": FINGERPRINT,
             "local_token_fingerprint": FINGERPRINT,
             "log_capture_sha256": FINGERPRINT,
-            "model_id": "model-test",
+            "model_id": "mlx-community/Llama-3.2-3B-Instruct-4bit",
             "rate_card_sha256": FINGERPRINT,
             "sdk_name": "openai-python",
             "sdk_version": "2.0.0",
@@ -339,6 +339,35 @@ class LocalConsumerEndpointJourneyResultTests(unittest.TestCase):
                     root=root,
                 )
                 self.assertTrue(any(field in error and ("secret-like" in error or "commit:<signed.repository.commit>" in error) for error in result.errors), field)
+
+    def test_governance_rejects_malformed_mlx_model_ids_when_source_matches_signed(self) -> None:
+        for name, model_id in {
+            "unknown_namespace": "private-org/Llama-3.2-3B-Instruct-4bit",
+            "nested_namespace": "mlx-community/private/Llama-3.2-3B-Instruct-4bit",
+            "urlish_model": "mlx-community/Llama-3.2-3B-Instruct-4bit?token=redacted",
+            "operator_local_model": "mlx-community/augstar-MacBook-Pro",
+            "secret_phrase_model": "mlx-community/secret-production-token-1234567890",
+            "prompt_phrase_model": "mlx-community/Summarize-confidential-merger-plans",
+            "completion_phrase_model": "mlx-community/raw-completion-text",
+        }.items():
+            with tempfile.TemporaryDirectory() as directory:
+                root = Path(directory).resolve()
+                signed = complete_signed_payload()
+                signed["candidate_identity"]["model_id"] = model_id
+                source = "journeys/evidence/local-consumer-endpoint-staging.redacted.json"
+                write_redacted_source(root, signed, source)
+                result = ValidationResult()
+                _validate_local_consumer_endpoint_journey_result(
+                    signed,
+                    "SPEC-045-R008",
+                    [LOCAL_CONSUMER_ENDPOINT_JOURNEY_ID],
+                    signed["artifacts"],
+                    signed["steps"],
+                    "evidence[0]",
+                    result,
+                    root=root,
+                )
+                self.assertTrue(any("candidate_identity.model_id" in error for error in result.errors), name)
 
     def test_governance_rejects_operator_local_candidate_identity_metadata_when_source_matches_signed(self) -> None:
         cases = {
@@ -736,6 +765,22 @@ class LocalConsumerEndpointJourneyResultTests(unittest.TestCase):
         identity["upstream_gateway_origin_sha256"] = NON_ALLOWLISTED_GATEWAY_ORIGIN_SHA256
         with self.assertRaises(SystemExit):
             builder.require_candidate_identity(identity)
+
+    def test_builder_rejects_malformed_mlx_model_ids(self) -> None:
+        builder = load_builder()
+        for name, model_id in {
+            "unknown_namespace": "private-org/Llama-3.2-3B-Instruct-4bit",
+            "nested_namespace": "mlx-community/private/Llama-3.2-3B-Instruct-4bit",
+            "urlish_model": "mlx-community/Llama-3.2-3B-Instruct-4bit?token=redacted",
+            "operator_local_model": "mlx-community/augstar-MacBook-Pro",
+            "secret_phrase_model": "mlx-community/secret-production-token-1234567890",
+            "prompt_phrase_model": "mlx-community/Summarize-confidential-merger-plans",
+            "completion_phrase_model": "mlx-community/raw-completion-text",
+        }.items():
+            identity = valid_signed()["candidate_identity"]
+            identity["model_id"] = model_id
+            with self.assertRaises(SystemExit, msg=name):
+                builder.require_candidate_identity(identity)
 
     def test_builder_rejects_operator_local_candidate_identity_metadata(self) -> None:
         builder = load_builder()


### PR DESCRIPTION
## Summary
- Capture the first real redacted SPEC-045 local-consumer endpoint evidence source from a production gateway run.
- Tighten the evidence capture, journey-result builder, and governance validators to admit only the known production MLX model IDs required by the captured run.
- Add focused regression coverage for accepted/rejected local model identity formats.

## Validation
- `python3 -m unittest scripts.tests.test_local_consumer_endpoint_evidence_capture scripts.tests.test_local_consumer_endpoint_journey_result` (35 tests)
- `python3 scripts/check_spec_governance.py --base-ref origin/main`
- `python3 scripts/build-local-consumer-endpoint-journey-result.py --output /tmp/macprovider-spec045-phase4d-result/local-consumer-endpoint-20260824T060103Z.unsigned.journey-result.json --source-sha dc63ecec59593235593b3de003e567e007ddcdc8 --evidence-sha 1aa0f155d1ac211d6ed29d2db89951ee5ce8990a journeys/evidence/local-consumer-endpoint-20260824T060103Z.redacted.json`
- Native Codex 3-lane audit: code, security, architecture; 0 Critical/High/Medium findings remaining. LOW carried: Qwen has regex parity but not a dedicated positive fixture.

SPEC-GOVERNANCE-DECLARATION-BEGIN
{
  "schema_version": "spec-pr-governance-v1",
  "issue": "https://github.com/Augustas11/macprovider/issues/927",
  "behavior_change": "yes",
  "contract_change": "none",
  "specs": ["SPEC-045"],
  "requirements": [
    "SPEC-045-R001",
    "SPEC-045-R002",
    "SPEC-045-R003",
    "SPEC-045-R004",
    "SPEC-045-R005",
    "SPEC-045-R006",
    "SPEC-045-R007",
    "SPEC-045-R008"
  ],
  "authority_domains": ["local-consumer-endpoint"],
  "arbitration": ["DECISION_REQUIRED"],
  "tests": [
    "python3 -m unittest scripts.tests.test_local_consumer_endpoint_evidence_capture scripts.tests.test_local_consumer_endpoint_journey_result",
    "python3 scripts/check_spec_governance.py --base-ref origin/main",
    "python3 scripts/build-local-consumer-endpoint-journey-result.py --output /tmp/macprovider-spec045-phase4d-result/local-consumer-endpoint-20260824T060103Z.unsigned.journey-result.json --source-sha dc63ecec59593235593b3de003e567e007ddcdc8 --evidence-sha 1aa0f155d1ac211d6ed29d2db89951ee5ce8990a journeys/evidence/local-consumer-endpoint-20260824T060103Z.redacted.json"
  ],
  "journeys": ["local-consumer-endpoint-20260824T060103Z"]
}
SPEC-GOVERNANCE-DECLARATION-END
