### PR TITLE
Implement SPEC-043 creator admin for Trusted Pools

### DIFF
--- a/phase4-coordinator/cmd/coordinator/main.go
+++ b/phase4-coordinator/cmd/coordinator/main.go
@@ -923,13 +923,33 @@ func main() {
 	providerMux := http.NewServeMux()
 	providerMux.Handle("/", wsServer.Handler())
 	providerMux.Handle("/internal/", buyerServer.InternalHandler())
+	var trustPoolAdminReloader trustpool.CreatorAdminConfigReloader
 	if cfg.TrustedPools.Enabled && trustPoolStore != nil && trustPoolRegistry != nil {
-		providerMux.Handle("/admin/trust-pools/", trustpool.NewAdminHandler(trustpool.AdminDeps{
-			Store:       trustPoolStore,
-			Registry:    trustPoolRegistry,
-			OperatorKey: cfg.Auth.OperatorKey,
-		}))
+		creatorAdminCredentials, err := trustPoolCreatorAdminCredentials(cfg.TrustedPools.CreatorAdminCredentials)
+		if err != nil {
+			logger.Fatal().Err(err).Msg("trusted pools creator admin credential config invalid")
+		}
+		trustPoolAdminHandler := trustpool.NewAdminHandler(trustpool.AdminDeps{
+			Store:                            trustPoolStore,
+			Registry:                         trustPoolRegistry,
+			OperatorKey:                      cfg.Auth.OperatorKey,
+			CreatorAdminCredentials:          creatorAdminCredentials,
+			CreatorAdminProviderIDs:          cfg.TrustedPools.CreatorAdminProviderIDs,
+			CreatorAdminProviderDelegatedIDs: cfg.TrustedPools.CreatorAdminProviderDelegatedIDs,
+			CreatorAdminBuyerAccountIDs:      cfg.TrustedPools.CreatorAdminBuyerAccountIDs,
+			CreatorProviderAdmitted: func(providerID string) bool {
+				return creatorProviderServingCapable(registry, providerID)
+			},
+		})
+		if reloader, ok := trustPoolAdminHandler.(trustpool.CreatorAdminConfigReloader); ok {
+			trustPoolAdminReloader = reloader
+		}
+		providerMux.Handle("/admin/trust-pools/", trustPoolAdminHandler)
 		logger.Info().Msg("trusted pools operator admin route mounted at /admin/trust-pools/")
+		providerMux.Handle("/creator/trust-pools/", trustPoolAdminHandler)
+		logger.Info().
+			Int("trusted_pools_creator_admin_credentials", len(creatorAdminCredentials)).
+			Msg("trusted pools creator admin route mounted at /creator/trust-pools/")
 	}
 	// Phase 3: MicroMDM command webhook for DeviceAttestation ingest.
 	// Point MicroMDM `-command-webhook-url` here. Auth is loopback-only
@@ -1248,7 +1268,7 @@ func main() {
 		select {
 		case sig := <-signals:
 			if sig == syscall.SIGHUP {
-				reloadCoordinatorConfig(*configPath, cfg.Tier2, logger, wsServer, buyerServer, autotuneCatalog, autotuneEvidenceStore, billingStore)
+				reloadCoordinatorConfig(*configPath, *configOverlay, cfg.Tier2, logger, wsServer, buyerServer, autotuneCatalog, autotuneEvidenceStore, trustPoolAdminReloader, billingStore)
 				continue
 			}
 			timeout := 30 * time.Second
@@ -2321,6 +2341,41 @@ func newHTTPServer(addr string, handler http.Handler) *http.Server {
 	}
 }
 
+func trustPoolCreatorAdminCredentials(configured []config.TrustedPoolsCreatorAdminCredentialConfig) ([]trustpool.CreatorAdminCredential, error) {
+	credentials := make([]trustpool.CreatorAdminCredential, 0, len(configured))
+	for i, credential := range configured {
+		notBefore, err := time.Parse(time.RFC3339Nano, strings.TrimSpace(credential.NotBeforeUTC))
+		if err != nil {
+			return nil, fmt.Errorf("trusted_pools.creator_admin_credentials[%d].not_before_utc: %w", i, err)
+		}
+		expiresAt, err := time.Parse(time.RFC3339Nano, strings.TrimSpace(credential.ExpiresAtUTC))
+		if err != nil {
+			return nil, fmt.Errorf("trusted_pools.creator_admin_credentials[%d].expires_at_utc: %w", i, err)
+		}
+		credentials = append(credentials, trustpool.CreatorAdminCredential{
+			CreatorAccountID: strings.TrimSpace(credential.CreatorAccountID),
+			CredentialID:     strings.TrimSpace(credential.CredentialID),
+			Token:            strings.TrimSpace(credential.Token),
+			NotBeforeUTC:     notBefore.UTC(),
+			ExpiresAtUTC:     expiresAt.UTC(),
+			Status:           strings.TrimSpace(credential.Status),
+		})
+	}
+	return credentials, nil
+}
+
+func creatorProviderServingCapable(registry *pool.Registry, providerID string) bool {
+	if registry == nil || providerID == "" {
+		return false
+	}
+	for _, provider := range registry.Snapshot() {
+		if provider.ProviderID == providerID {
+			return provider.ServingCapable()
+		}
+	}
+	return false
+}
+
 func loadTrustedPools(ctx context.Context, db *sql.DB, cfg config.TrustedPoolsConfig, logger zerolog.Logger) (*trustpool.Store, *trustpool.Registry, bool, error) {
 	store, err := trustpool.NewStore(db, trustpool.WithProductionActivationGate(trustpool.ProductionActivationGate{
 		AllowedLaunchEnvironments: cfg.ProductionActivation.AllowedLaunchEnvironments,
@@ -2602,16 +2657,16 @@ func walletMutationGuardHandler() http.Handler {
 }
 
 func reloadTier2Config(configPath string, startupTier2 config.Tier2Config, logger zerolog.Logger, wsServer *providerws.Server, buyerServer *buyer.Server, autotuneCatalog *autotune.Catalog, billingStores ...*billing.Store) {
-	reloadCoordinatorConfig(configPath, startupTier2, logger, wsServer, buyerServer, autotuneCatalog, nil, billingStores...)
+	reloadCoordinatorConfig(configPath, "", startupTier2, logger, wsServer, buyerServer, autotuneCatalog, nil, nil, billingStores...)
 }
 
-func reloadCoordinatorConfig(configPath string, startupTier2 config.Tier2Config, logger zerolog.Logger, wsServer *providerws.Server, buyerServer *buyer.Server, autotuneCatalog *autotune.Catalog, autotuneEvidenceStore autotune.EvidenceStore, billingStores ...*billing.Store) {
+func reloadCoordinatorConfig(configPath, configOverlay string, startupTier2 config.Tier2Config, logger zerolog.Logger, wsServer *providerws.Server, buyerServer *buyer.Server, autotuneCatalog *autotune.Catalog, autotuneEvidenceStore autotune.EvidenceStore, trustPoolAdminReloader trustpool.CreatorAdminConfigReloader, billingStores ...*billing.Store) {
 	// SPEC-016 v0.1.23 §6.5: the general SIGHUP reload must not parse,
 	// env-resolve, or validate payout.security.*, and a payout.* key
 	// edited on disk must not reject a tier2/billing reload. Payout
 	// tuning has its own dedicated SIGHUP listener
 	// (startPayoutSIGHUPListener); this path never applies payout fields.
-	cfg, err := config.LoadForSIGHUPReload(configPath)
+	cfg, err := config.LoadForSIGHUPReloadWithOverlay(configPath, configOverlay)
 	if err != nil {
 		logger.Error().Err(err).Msg("tier2 config reload rejected")
 		return
@@ -2624,6 +2679,14 @@ func reloadCoordinatorConfig(configPath string, startupTier2 config.Tier2Config,
 	if cfg.ProofOfWeights.RequireAutotuneHelloGate && (autotuneCatalog == nil || autotuneEvidenceStore == nil) {
 		logger.Error().Msg("proof_of_weights config reload rejected: autotune hello gate dependencies are not wired")
 		return
+	}
+	var creatorAdminCredentials []trustpool.CreatorAdminCredential
+	if trustPoolAdminReloader != nil {
+		creatorAdminCredentials, err = trustPoolCreatorAdminCredentials(cfg.TrustedPools.CreatorAdminCredentials)
+		if err != nil {
+			logger.Error().Err(err).Msg("trusted pools creator admin config reload rejected")
+			return
+		}
 	}
 	if tier2StartupFieldsChangedWithLogger(startupTier2, cfg.Tier2, logger) {
 		logger.Error().Msg("tier2 config reload rejected: startup-only tier2 fields require restart")
@@ -2714,6 +2777,15 @@ func reloadCoordinatorConfig(configPath string, startupTier2 config.Tier2Config,
 			Int("sticky_entries_invalidated", invalidated).
 			Str("event", "spec004_fr_sr_5_class_reload").
 			Msg("routing.model_classes reload: shape changed; sticky entries invalidated")
+	}
+	if trustPoolAdminReloader != nil {
+		trustPoolAdminReloader.SetCreatorAdminConfig(creatorAdminCredentials, cfg.TrustedPools.CreatorAdminProviderIDs, cfg.TrustedPools.CreatorAdminProviderDelegatedIDs, cfg.TrustedPools.CreatorAdminBuyerAccountIDs)
+		logger.Info().
+			Int("trusted_pools_creator_admin_credentials", len(creatorAdminCredentials)).
+			Int("trusted_pools_creator_provider_allowlist_creators", len(cfg.TrustedPools.CreatorAdminProviderIDs)).
+			Int("trusted_pools_creator_provider_delegation_creators", len(cfg.TrustedPools.CreatorAdminProviderDelegatedIDs)).
+			Int("trusted_pools_creator_buyer_allowlist_creators", len(cfg.TrustedPools.CreatorAdminBuyerAccountIDs)).
+			Msg("trusted pools creator admin config reloaded")
 	}
 }
 

--- a/phase4-coordinator/cmd/coordinator/main_test.go
+++ b/phase4-coordinator/cmd/coordinator/main_test.go
@@ -85,6 +85,40 @@ VALUES (?, ?, ?, ?, ?)`,
 	}
 }
 
+func TestCreatorProviderServingCapableRequiresServingAdmission(t *testing.T) {
+	registry := pool.NewRegistry(nil)
+	registry.Register(&pool.Provider{
+		ProviderID:     "provider-present-only",
+		AssignedID:     "session-self-minted",
+		ModelID:        "model-a",
+		State:          pool.StateReady,
+		SlotsFree:      1,
+		SlotsTotal:     1,
+		MaxConcurrency: 1,
+		AuthState:      pool.AuthSelfMinted,
+	}, nil)
+	if creatorProviderServingCapable(registry, "provider-present-only") {
+		t.Fatal("present AuthSelfMinted provider passed creator global-admission gate")
+	}
+
+	registry.Register(&pool.Provider{
+		ProviderID:     "provider-serving",
+		AssignedID:     "session-serving",
+		ModelID:        "model-a",
+		State:          pool.StateBusy,
+		SlotsFree:      0,
+		SlotsTotal:     1,
+		MaxConcurrency: 1,
+		AuthState:      pool.AuthSelfMintedVerified,
+	}, nil)
+	if !creatorProviderServingCapable(registry, "provider-serving") {
+		t.Fatal("busy but serving-capable provider failed creator global-admission gate")
+	}
+	if creatorProviderServingCapable(registry, "missing-provider") {
+		t.Fatal("missing provider passed creator global-admission gate")
+	}
+}
+
 func TestWithReferralValidationMountsOnlyValidationRoute(t *testing.T) {
 	base := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(http.StatusNoContent) })
 	disabled := withReferralValidation(base, nil)
@@ -741,7 +775,7 @@ func TestReloadCoordinatorConfigHotTogglesProofOfWeightsGate(t *testing.T) {
 		"bob":   "bob-secret-0123456789abcdef012345678901",
 	}
 	var logs bytes.Buffer
-	reloadCoordinatorConfig(writeReloadConfig(t, next), startup.Tier2, zerolog.New(&logs), wsServer, buyerServer, autotuneCatalog, reloadStubAutotuneEvidence{})
+	reloadCoordinatorConfig(writeReloadConfig(t, next), "", startup.Tier2, zerolog.New(&logs), wsServer, buyerServer, autotuneCatalog, reloadStubAutotuneEvidence{}, nil)
 	provider, ok := registry.Resolve("provider-a", "session-a")
 	if !ok {
 		t.Fatal("provider missing after proof_of_weights enable reload")
@@ -756,7 +790,7 @@ func TestReloadCoordinatorConfigHotTogglesProofOfWeightsGate(t *testing.T) {
 	next.ProofOfWeights.RequireAutotuneHelloGate = false
 	next.ProofOfWeights.TelemetryDrift.Enabled = false
 	logs.Reset()
-	reloadCoordinatorConfig(writeReloadConfig(t, next), startup.Tier2, zerolog.New(&logs), wsServer, buyerServer, autotuneCatalog, reloadStubAutotuneEvidence{})
+	reloadCoordinatorConfig(writeReloadConfig(t, next), "", startup.Tier2, zerolog.New(&logs), wsServer, buyerServer, autotuneCatalog, reloadStubAutotuneEvidence{}, nil)
 	provider, ok = registry.Resolve("provider-a", "session-a")
 	if !ok {
 		t.Fatal("provider missing after proof_of_weights disable reload")
@@ -1147,6 +1181,68 @@ func TestReloadTier2LogsMissingAlgorithmInvalidation(t *testing.T) {
 		!strings.Contains(rawLog, `"decision":"exclude"`) {
 		t.Fatalf("reload audit log missing invalid event: %s", rawLog)
 	}
+}
+
+func TestReloadCoordinatorConfigReloadsTrustedPoolsCreatorAdminConfig(t *testing.T) {
+	defer tier2.ResetForTest()
+	startup, _, wsServer, buyerServer := reloadTestServers(config.Default())
+	next := startup
+	next.Coordinator.RequireGatewayContext = true
+	next.TrustedPools.Enabled = true
+	next.TrustedPools.CreatorAdminCredentials = []config.TrustedPoolsCreatorAdminCredentialConfig{{
+		CreatorAccountID: "creator-a",
+		CredentialID:     "creator-a-cred-v2",
+		Token:            "creator-token-v2-0123456789abcdef",
+		NotBeforeUTC:     time.Now().UTC().Add(-time.Hour).Format(time.RFC3339Nano),
+		ExpiresAtUTC:     time.Now().UTC().Add(time.Hour).Format(time.RFC3339Nano),
+		Status:           trustpool.CreatorAdminCredentialStatusEnabled,
+	}}
+	next.TrustedPools.CreatorAdminProviderIDs = map[string][]string{"creator-a": {"provider-b"}}
+	next.TrustedPools.CreatorAdminProviderDelegatedIDs = map[string][]string{"creator-a": {"provider-b"}}
+	next.TrustedPools.CreatorAdminBuyerAccountIDs = map[string][]string{"creator-a": {"acct-b"}}
+	reloader := &reloadTrustPoolCreatorAdminConfigRecorder{}
+
+	basePath := writeReloadConfig(t, startup)
+	overlayPath := writeReloadConfig(t, next)
+	reloadCoordinatorConfig(basePath, overlayPath, startup.Tier2, zerolog.Nop(), wsServer, buyerServer, nil, nil, reloader)
+
+	if len(reloader.credentials) != 1 {
+		t.Fatalf("credentials len=%d, want 1", len(reloader.credentials))
+	}
+	if got := reloader.credentials[0]; got.CreatorAccountID != "creator-a" || got.CredentialID != "creator-a-cred-v2" || got.Token != "creator-token-v2-0123456789abcdef" {
+		t.Fatalf("reloaded credential = %+v", got)
+	}
+	if got := reloader.providerIDs["creator-a"]; len(got) != 1 || got[0] != "provider-b" {
+		t.Fatalf("provider allowlist = %#v, want provider-b", reloader.providerIDs)
+	}
+	if got := reloader.providerDelegatedIDs["creator-a"]; len(got) != 1 || got[0] != "provider-b" {
+		t.Fatalf("provider delegation projection = %#v, want provider-b", reloader.providerDelegatedIDs)
+	}
+	if got := reloader.buyerAccountIDs["creator-a"]; len(got) != 1 || got[0] != "acct-b" {
+		t.Fatalf("buyer allowlist = %#v, want acct-b", reloader.buyerAccountIDs)
+	}
+}
+
+type reloadTrustPoolCreatorAdminConfigRecorder struct {
+	credentials          []trustpool.CreatorAdminCredential
+	providerIDs          map[string][]string
+	providerDelegatedIDs map[string][]string
+	buyerAccountIDs      map[string][]string
+}
+
+func (r *reloadTrustPoolCreatorAdminConfigRecorder) SetCreatorAdminConfig(credentials []trustpool.CreatorAdminCredential, providerIDs, providerDelegatedIDs, buyerAccountIDs map[string][]string) {
+	r.credentials = append([]trustpool.CreatorAdminCredential(nil), credentials...)
+	r.providerIDs = cloneReloadStringSliceMap(providerIDs)
+	r.providerDelegatedIDs = cloneReloadStringSliceMap(providerDelegatedIDs)
+	r.buyerAccountIDs = cloneReloadStringSliceMap(buyerAccountIDs)
+}
+
+func cloneReloadStringSliceMap(in map[string][]string) map[string][]string {
+	out := make(map[string][]string, len(in))
+	for key, values := range in {
+		out[key] = append([]string(nil), values...)
+	}
+	return out
 }
 
 func reloadTestServers(cfg config.Config) (config.Config, *pool.Registry, *providerws.Server, *buyer.Server) {

--- a/phase4-coordinator/internal/buyer/server.go
+++ b/phase4-coordinator/internal/buyer/server.go
@@ -1056,6 +1056,14 @@ func (s *Server) handleInternalRouting(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusUnauthorized, "unauthorized", "Internal routing metadata requires coordinator authorization")
 		return
 	}
+	pools := map[string]any{
+		"enabled": s.trustPools != nil,
+	}
+	if s.trustPools != nil {
+		accountPools, generation := s.trustPools.BuyerAuthorizations()
+		pools["account_pools"] = accountPools
+		pools["buyer_authorization_generation"] = generation
+	}
 	w.Header().Set("Content-Type", "application/json")
 	_ = json.NewEncoder(w).Encode(map[string]any{
 		"sticky": map[string]any{
@@ -1073,9 +1081,7 @@ func (s *Server) handleInternalRouting(w http.ResponseWriter, r *http.Request) {
 		// pool_id) fails the gateway closed instead of silently routing pool
 		// traffic from the global snapshot. trustPools is the pool-feature
 		// handle (WithPoolMembership): nil = feature off = advertise false.
-		"pools": map[string]any{
-			"enabled": s.trustPools != nil,
-		},
+		"pools": pools,
 		"tier2": s.internalTier2Metadata(),
 	})
 }

--- a/phase4-coordinator/internal/buyer/spec042_pools_advertisement_test.go
+++ b/phase4-coordinator/internal/buyer/spec042_pools_advertisement_test.go
@@ -63,3 +63,58 @@ func TestInternalRoutingAdvertisesPoolCapability(t *testing.T) {
 		}
 	})
 }
+
+func TestInternalRoutingAdvertisesBuyerAuthorizationProjection(t *testing.T) {
+	registry := trustpool.NewRegistry()
+	if err := registry.LoadRouteableSnapshotsAtRevision(7, []trustpool.RouteableSnapshot{{
+		PoolID:         "abcdefghijklmnopqrstuv",
+		BuyerAccounts:  []string{"acct-a", "acct-b"},
+		SettlementMode: "observe",
+		Routeable:      true,
+		Generation:     7,
+	}, {
+		PoolID:         "ABCDEFGHIJKLMNOPQRSTUV",
+		BuyerAccounts:  []string{"acct-a"},
+		SettlementMode: "observe",
+		Routeable:      false,
+		Generation:     8,
+	}}); err != nil {
+		t.Fatalf("LoadRouteableSnapshotsAtRevision: %v", err)
+	}
+	server := buyer.NewServer(
+		pool.NewRegistry(nil),
+		zerolog.Nop(),
+		time.Unix(1716768000, 0),
+		buyer.WithGatewayServiceToken("operator-key"),
+		buyer.WithPoolMembership(registry),
+	)
+	req := httptest.NewRequest(http.MethodGet, "/internal/routing", nil)
+	req.Header.Set("Authorization", "Bearer operator-key")
+	rr := httptest.NewRecorder()
+	server.InternalHandler().ServeHTTP(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s", rr.Code, rr.Body.String())
+	}
+	var got struct {
+		Pools struct {
+			Enabled                      bool                `json:"enabled"`
+			AccountPools                 map[string][]string `json:"account_pools"`
+			BuyerAuthorizationGeneration uint64              `json:"buyer_authorization_generation"`
+		} `json:"pools"`
+	}
+	if err := json.Unmarshal(rr.Body.Bytes(), &got); err != nil {
+		t.Fatalf("json: %v body=%s", err, rr.Body.String())
+	}
+	if !got.Pools.Enabled {
+		t.Fatal("pools.enabled=false, want true")
+	}
+	if got.Pools.BuyerAuthorizationGeneration != 7 {
+		t.Fatalf("buyer_authorization_generation=%d, want registry revision 7", got.Pools.BuyerAuthorizationGeneration)
+	}
+	if len(got.Pools.AccountPools["acct-a"]) != 2 || got.Pools.AccountPools["acct-a"][0] != "ABCDEFGHIJKLMNOPQRSTUV" || got.Pools.AccountPools["acct-a"][1] != "abcdefghijklmnopqrstuv" {
+		t.Fatalf("acct-a pools=%v, want sorted two-pool projection", got.Pools.AccountPools["acct-a"])
+	}
+	if len(got.Pools.AccountPools["acct-b"]) != 1 || got.Pools.AccountPools["acct-b"][0] != "abcdefghijklmnopqrstuv" {
+		t.Fatalf("acct-b pools=%v, want one-pool projection", got.Pools.AccountPools["acct-b"])
+	}
+}

--- a/phase4-coordinator/internal/config/config.go
+++ b/phase4-coordinator/internal/config/config.go
@@ -14,12 +14,12 @@ import (
 	"strings"
 	"time"
 
+	"github.com/augstar/macprovider-coordinator/internal/providerid"
 	"github.com/augstar/macprovider-coordinator/internal/stats/hardwareverify"
 	"github.com/augstar/macprovider-coordinator/internal/versionfloor"
 	"gopkg.in/yaml.v3"
 )
 
-var providerIDPattern = regexp.MustCompile(`^[a-zA-Z0-9_.-]{1,64}$`)
 var lowerHex64Pattern = regexp.MustCompile(`^[0-9a-f]{64}$`)
 
 const (
@@ -43,10 +43,7 @@ var compatibilitySetIDPattern = regexp.MustCompile(`^[A-Za-z0-9_.-]{1,64}/[A-Za-
 // initial/proof, admission IssueToken, MintAdmissionTokenAndPairOT) MUST
 // funnel through this helper to keep that invariant.
 func ValidateProviderID(s string) error {
-	if !providerIDPattern.MatchString(s) {
-		return fmt.Errorf("invalid provider_id %q", s)
-	}
-	return nil
+	return providerid.Validate(s)
 }
 
 // ValidateCompatibilitySetID applies the signed release-manifest identifier
@@ -1030,15 +1027,28 @@ type StorageConfig struct {
 // with that reconstructed registry; reconstruction failure disables pool support
 // while preserving global routing.
 type TrustedPoolsConfig struct {
-	Enabled              bool                                   `yaml:"enabled"`
-	RefreshIntervalS     int                                    `yaml:"refresh_interval_s"`
-	ProductionActivation TrustedPoolsProductionActivationConfig `yaml:"production_activation"`
+	Enabled                          bool                                       `yaml:"enabled"`
+	RefreshIntervalS                 int                                        `yaml:"refresh_interval_s"`
+	ProductionActivation             TrustedPoolsProductionActivationConfig     `yaml:"production_activation"`
+	CreatorAdminCredentials          []TrustedPoolsCreatorAdminCredentialConfig `yaml:"creator_admin_credentials"`
+	CreatorAdminProviderIDs          map[string][]string                        `yaml:"creator_admin_provider_ids"`
+	CreatorAdminProviderDelegatedIDs map[string][]string                        `yaml:"creator_admin_provider_delegated_ids"`
+	CreatorAdminBuyerAccountIDs      map[string][]string                        `yaml:"creator_admin_buyer_account_ids"`
 }
 
 type TrustedPoolsProductionActivationConfig struct {
 	AllowedLaunchEnvironments []string `yaml:"allowed_launch_environments"`
 	EvidenceSHA256            string   `yaml:"evidence_sha256"`
 	RootCustodyHashes         []string `yaml:"root_custody_hashes"`
+}
+
+type TrustedPoolsCreatorAdminCredentialConfig struct {
+	CreatorAccountID string `yaml:"creator_account_id"`
+	CredentialID     string `yaml:"credential_id"`
+	Token            string `yaml:"token"`
+	NotBeforeUTC     string `yaml:"not_before_utc"`
+	ExpiresAtUTC     string `yaml:"expires_at_utc"`
+	Status           string `yaml:"status"`
 }
 
 type LoggingConfig struct {
@@ -1351,8 +1361,12 @@ func Default() Config {
 			AuditLogRetentionDays:   90,
 		},
 		TrustedPools: TrustedPoolsConfig{
-			Enabled:          false,
-			RefreshIntervalS: 30,
+			Enabled:                          false,
+			RefreshIntervalS:                 30,
+			CreatorAdminCredentials:          []TrustedPoolsCreatorAdminCredentialConfig{},
+			CreatorAdminProviderIDs:          map[string][]string{},
+			CreatorAdminProviderDelegatedIDs: map[string][]string{},
+			CreatorAdminBuyerAccountIDs:      map[string][]string{},
 			ProductionActivation: TrustedPoolsProductionActivationConfig{
 				AllowedLaunchEnvironments: []string{},
 				RootCustodyHashes:         []string{},
@@ -1634,9 +1648,44 @@ func LoadPayoutTuningOnly(basePath, overlayPath string) (PayoutTuningConfig, err
 // the payout runtime consumes config only via its startup snapshot
 // plus the §6.5 tuning-only SIGHUP listener.
 func LoadForSIGHUPReload(path string) (Config, error) {
+	return LoadForSIGHUPReloadWithOverlay(path, "")
+}
+
+func LoadForSIGHUPReloadWithOverlay(basePath, overlayPath string) (Config, error) {
+	doc, err := readConfigDocumentWithoutPayout(basePath, "base")
+	if err != nil {
+		return Config{}, err
+	}
+	cfg := Default()
+	if len(doc.Content) > 0 {
+		if err := doc.Decode(&cfg); err != nil {
+			return Config{}, fmt.Errorf("base config %s: %w", basePath, err)
+		}
+	}
+	if strings.TrimSpace(overlayPath) != "" {
+		overlayDoc, err := readConfigDocumentWithoutPayout(overlayPath, "overlay")
+		if err != nil {
+			return Config{}, err
+		}
+		if len(overlayDoc.Content) > 0 {
+			if err := overlayDoc.Decode(&cfg); err != nil {
+				return Config{}, fmt.Errorf("overlay config %s: %w", overlayPath, err)
+			}
+		}
+	}
+	// Belt-and-braces: the payout namespace stays at defaults regardless
+	// of what either document contained.
+	cfg.Payout = Default().Payout
+	if err := finalizeLoadedConfig(&cfg); err != nil {
+		return Config{}, err
+	}
+	return cfg, nil
+}
+
+func readConfigDocumentWithoutPayout(path, label string) (yaml.Node, error) {
 	b, err := os.ReadFile(path)
 	if err != nil {
-		return Config{}, fmt.Errorf("base config %s: %w", path, err)
+		return yaml.Node{}, fmt.Errorf("%s config %s: %w", label, path, err)
 	}
 	// Merge-audit r2 (convergent code+architect HIGH): strip the payout
 	// subtree BEFORE typed decode. Resetting cfg.Payout after a typed
@@ -1654,7 +1703,7 @@ func LoadForSIGHUPReload(path string) (Config, error) {
 	// other scalar byte-identical to what Load would see.
 	var doc yaml.Node
 	if err := yaml.Unmarshal(b, &doc); err != nil {
-		return Config{}, fmt.Errorf("base config %s: %w", path, err)
+		return yaml.Node{}, fmt.Errorf("%s config %s: %w", label, path, err)
 	}
 	if len(doc.Content) > 0 && doc.Content[0].Kind == yaml.MappingNode {
 		m := doc.Content[0]
@@ -1670,19 +1719,7 @@ func LoadForSIGHUPReload(path string) (Config, error) {
 		}
 		m.Content = kept
 	}
-	cfg := Default()
-	if len(doc.Content) > 0 {
-		if err := doc.Decode(&cfg); err != nil {
-			return Config{}, fmt.Errorf("base config %s: %w", path, err)
-		}
-	}
-	// Belt-and-braces: the payout namespace stays at defaults regardless
-	// of what the document contained.
-	cfg.Payout = Default().Payout
-	if err := finalizeLoadedConfig(&cfg); err != nil {
-		return Config{}, err
-	}
-	return cfg, nil
+	return doc, nil
 }
 
 func unmarshalYAMLFile(path string, cfg *Config) error {
@@ -1705,6 +1742,11 @@ func finalizeLoadedConfig(cfg *Config) error {
 	}
 	for name, key := range cfg.Auth.OperatorKeys {
 		if err := validateOperatorSecretStrength("auth.operator_keys."+name, key); err != nil {
+			return err
+		}
+	}
+	for i, credential := range cfg.TrustedPools.CreatorAdminCredentials {
+		if err := validateOperatorSecretStrength(fmt.Sprintf("trusted_pools.creator_admin_credentials[%d].token", i), credential.Token); err != nil {
 			return err
 		}
 	}
@@ -1739,6 +1781,13 @@ func (c *Config) resolveEnv() error {
 			return err
 		}
 		c.Auth.OperatorKeys[name] = v
+	}
+	for i := range c.TrustedPools.CreatorAdminCredentials {
+		v, err := resolveEnvValue(fmt.Sprintf("trusted_pools.creator_admin_credentials[%d].token", i), c.TrustedPools.CreatorAdminCredentials[i].Token)
+		if err != nil {
+			return err
+		}
+		c.TrustedPools.CreatorAdminCredentials[i].Token = v
 	}
 	for keyID, raw := range c.Referrals.HMACKeys {
 		v, err := resolveEnvValue("referrals.hmac_keys."+keyID, raw)
@@ -2120,6 +2169,18 @@ func (c Config) Validate() error {
 		return fmt.Errorf("trusted_pools.refresh_interval_s must be in [1,60] when trusted_pools.enabled=true")
 	}
 	if err := validateTrustedPoolsProductionActivation(c.TrustedPools); err != nil {
+		return err
+	}
+	if err := validateTrustedPoolsCreatorAdminCredentials(c.TrustedPools, c.Auth); err != nil {
+		return err
+	}
+	if err := validateTrustedPoolsCreatorAdminProviderIDs(c.TrustedPools); err != nil {
+		return err
+	}
+	if err := validateTrustedPoolsCreatorAdminProviderDelegatedIDs(c.TrustedPools); err != nil {
+		return err
+	}
+	if err := validateTrustedPoolsCreatorAdminBuyerAccountIDs(c.TrustedPools); err != nil {
 		return err
 	}
 	if err := c.validateCompatibilitySet(); err != nil {
@@ -2597,6 +2658,240 @@ func validateTrustedPoolsProductionActivation(c TrustedPoolsConfig) error {
 		seenCustody[value] = true
 	}
 	return nil
+}
+
+func validateTrustedPoolsCreatorAdminCredentials(c TrustedPoolsConfig, auth AuthConfig) error {
+	if len(c.CreatorAdminCredentials) == 0 {
+		return nil
+	}
+	if !c.Enabled {
+		return fmt.Errorf("trusted_pools.creator_admin_credentials requires trusted_pools.enabled=true")
+	}
+	reserved := map[string]string{}
+	if token := strings.TrimSpace(auth.OperatorKey); token != "" {
+		reserved[token] = "auth.operator_key"
+	}
+	if token := strings.TrimSpace(auth.GatewayServiceToken); token != "" {
+		reserved[token] = "auth.gateway_service_token"
+	}
+	for name, token := range auth.OperatorKeys {
+		token = strings.TrimSpace(token)
+		if token != "" {
+			reserved[token] = "auth.operator_keys." + name
+		}
+	}
+	seenTokens := make(map[string]string, len(c.CreatorAdminCredentials))
+	seenCredentials := make(map[string]bool, len(c.CreatorAdminCredentials))
+	for i, credential := range c.CreatorAdminCredentials {
+		field := fmt.Sprintf("trusted_pools.creator_admin_credentials[%d]", i)
+		rawCreatorID := credential.CreatorAccountID
+		creatorID := strings.TrimSpace(credential.CreatorAccountID)
+		rawCredentialID := credential.CredentialID
+		credentialID := strings.TrimSpace(credential.CredentialID)
+		token := strings.TrimSpace(credential.Token)
+		status := strings.TrimSpace(credential.Status)
+		if creatorID == "" {
+			return fmt.Errorf("%s.creator_account_id must be non-empty", field)
+		}
+		if rawCreatorID != creatorID {
+			return fmt.Errorf("%s.creator_account_id must be canonical", field)
+		}
+		if strings.Contains(creatorID, "/") {
+			return fmt.Errorf("%s.creator_account_id contains invalid creator id %q", field, creatorID)
+		}
+		if credentialID == "" {
+			return fmt.Errorf("%s.credential_id must be non-empty", field)
+		}
+		if rawCredentialID != credentialID {
+			return fmt.Errorf("%s.credential_id must be canonical", field)
+		}
+		if strings.Contains(credentialID, "/") {
+			return fmt.Errorf("%s.credential_id contains invalid credential id %q", field, credentialID)
+		}
+		key := creatorID + "/" + credentialID
+		if seenCredentials[key] {
+			return fmt.Errorf("%s duplicates creator credential %s", field, key)
+		}
+		seenCredentials[key] = true
+		if token == "" {
+			return fmt.Errorf("%s.token must be non-empty", field)
+		}
+		if reservedField, ok := reserved[token]; ok {
+			return fmt.Errorf("%s.token must differ from %s", field, reservedField)
+		}
+		if previous, ok := seenTokens[token]; ok {
+			return fmt.Errorf("%s.token must not reuse secret from %s", field, previous)
+		}
+		seenTokens[token] = field
+		notBefore, err := time.Parse(time.RFC3339Nano, strings.TrimSpace(credential.NotBeforeUTC))
+		if err != nil {
+			return fmt.Errorf("%s.not_before_utc must be RFC3339: %w", field, err)
+		}
+		expiresAt, err := time.Parse(time.RFC3339Nano, strings.TrimSpace(credential.ExpiresAtUTC))
+		if err != nil {
+			return fmt.Errorf("%s.expires_at_utc must be RFC3339: %w", field, err)
+		}
+		if !expiresAt.After(notBefore) {
+			return fmt.Errorf("%s.expires_at_utc must be after not_before_utc", field)
+		}
+		switch status {
+		case "enabled", "disabled":
+		default:
+			return fmt.Errorf("%s.status must be enabled or disabled", field)
+		}
+	}
+	return nil
+}
+
+func validateTrustedPoolsCreatorAdminProviderIDs(c TrustedPoolsConfig) error {
+	creatorIDs := trustedPoolsCreatorCredentialIDs(c)
+	if len(c.CreatorAdminProviderIDs) == 0 && len(creatorIDs) == 0 {
+		return nil
+	}
+	if !c.Enabled {
+		return fmt.Errorf("trusted_pools.creator_admin_provider_ids requires trusted_pools.enabled=true")
+	}
+	for creatorID := range creatorIDs {
+		if _, ok := c.CreatorAdminProviderIDs[creatorID]; !ok {
+			return fmt.Errorf("trusted_pools.creator_admin_provider_ids.%s must be configured for every trusted_pools.creator_admin_credentials entry", creatorID)
+		}
+	}
+	for creatorID, providerIDs := range c.CreatorAdminProviderIDs {
+		rawCreatorID := creatorID
+		creatorID = strings.TrimSpace(creatorID)
+		if creatorID == "" {
+			return fmt.Errorf("trusted_pools.creator_admin_provider_ids contains an empty creator id")
+		}
+		if rawCreatorID != creatorID {
+			return fmt.Errorf("trusted_pools.creator_admin_provider_ids contains non-canonical creator id %q", rawCreatorID)
+		}
+		if strings.Contains(creatorID, "/") {
+			return fmt.Errorf("trusted_pools.creator_admin_provider_ids contains invalid creator id %q", creatorID)
+		}
+		if _, ok := creatorIDs[creatorID]; !ok {
+			return fmt.Errorf("trusted_pools.creator_admin_provider_ids.%s requires matching trusted_pools.creator_admin_credentials entry", creatorID)
+		}
+		seen := make(map[string]bool, len(providerIDs))
+		for _, providerID := range providerIDs {
+			rawProviderID := providerID
+			providerID = strings.TrimSpace(providerID)
+			if rawProviderID != providerID {
+				return fmt.Errorf("trusted_pools.creator_admin_provider_ids.%s contains non-canonical provider_id %q", creatorID, rawProviderID)
+			}
+			if err := ValidateProviderID(providerID); err != nil {
+				return fmt.Errorf("trusted_pools.creator_admin_provider_ids.%s contains invalid provider_id %q", creatorID, providerID)
+			}
+			if seen[providerID] {
+				return fmt.Errorf("trusted_pools.creator_admin_provider_ids.%s must contain unique provider ids", creatorID)
+			}
+			seen[providerID] = true
+		}
+	}
+	return nil
+}
+
+func validateTrustedPoolsCreatorAdminProviderDelegatedIDs(c TrustedPoolsConfig) error {
+	creatorIDs := trustedPoolsCreatorCredentialIDs(c)
+	if len(c.CreatorAdminProviderDelegatedIDs) == 0 && len(creatorIDs) == 0 {
+		return nil
+	}
+	if !c.Enabled {
+		return fmt.Errorf("trusted_pools.creator_admin_provider_delegated_ids requires trusted_pools.enabled=true")
+	}
+	for creatorID := range creatorIDs {
+		if _, ok := c.CreatorAdminProviderDelegatedIDs[creatorID]; !ok {
+			return fmt.Errorf("trusted_pools.creator_admin_provider_delegated_ids.%s must be configured for every trusted_pools.creator_admin_credentials entry", creatorID)
+		}
+	}
+	for creatorID, providerIDs := range c.CreatorAdminProviderDelegatedIDs {
+		rawCreatorID := creatorID
+		creatorID = strings.TrimSpace(creatorID)
+		if creatorID == "" {
+			return fmt.Errorf("trusted_pools.creator_admin_provider_delegated_ids contains an empty creator id")
+		}
+		if rawCreatorID != creatorID {
+			return fmt.Errorf("trusted_pools.creator_admin_provider_delegated_ids contains non-canonical creator id %q", rawCreatorID)
+		}
+		if strings.Contains(creatorID, "/") {
+			return fmt.Errorf("trusted_pools.creator_admin_provider_delegated_ids contains invalid creator id %q", creatorID)
+		}
+		if _, ok := creatorIDs[creatorID]; !ok {
+			return fmt.Errorf("trusted_pools.creator_admin_provider_delegated_ids.%s requires matching trusted_pools.creator_admin_credentials entry", creatorID)
+		}
+		seen := make(map[string]bool, len(providerIDs))
+		for _, providerID := range providerIDs {
+			rawProviderID := providerID
+			providerID = strings.TrimSpace(providerID)
+			if rawProviderID != providerID {
+				return fmt.Errorf("trusted_pools.creator_admin_provider_delegated_ids.%s contains non-canonical provider_id %q", creatorID, rawProviderID)
+			}
+			if err := ValidateProviderID(providerID); err != nil {
+				return fmt.Errorf("trusted_pools.creator_admin_provider_delegated_ids.%s contains invalid provider_id %q", creatorID, providerID)
+			}
+			if seen[providerID] {
+				return fmt.Errorf("trusted_pools.creator_admin_provider_delegated_ids.%s must contain unique provider ids", creatorID)
+			}
+			seen[providerID] = true
+		}
+	}
+	return nil
+}
+
+func validateTrustedPoolsCreatorAdminBuyerAccountIDs(c TrustedPoolsConfig) error {
+	creatorIDs := trustedPoolsCreatorCredentialIDs(c)
+	if len(c.CreatorAdminBuyerAccountIDs) == 0 && len(creatorIDs) == 0 {
+		return nil
+	}
+	if !c.Enabled {
+		return fmt.Errorf("trusted_pools.creator_admin_buyer_account_ids requires trusted_pools.enabled=true")
+	}
+	for creatorID := range creatorIDs {
+		if _, ok := c.CreatorAdminBuyerAccountIDs[creatorID]; !ok {
+			return fmt.Errorf("trusted_pools.creator_admin_buyer_account_ids.%s must be configured for every trusted_pools.creator_admin_credentials entry", creatorID)
+		}
+	}
+	for creatorID, buyerAccountIDs := range c.CreatorAdminBuyerAccountIDs {
+		rawCreatorID := creatorID
+		creatorID = strings.TrimSpace(creatorID)
+		if creatorID == "" {
+			return fmt.Errorf("trusted_pools.creator_admin_buyer_account_ids contains an empty creator id")
+		}
+		if rawCreatorID != creatorID {
+			return fmt.Errorf("trusted_pools.creator_admin_buyer_account_ids contains non-canonical creator id %q", rawCreatorID)
+		}
+		if strings.Contains(creatorID, "/") {
+			return fmt.Errorf("trusted_pools.creator_admin_buyer_account_ids contains invalid creator id %q", creatorID)
+		}
+		if _, ok := creatorIDs[creatorID]; !ok {
+			return fmt.Errorf("trusted_pools.creator_admin_buyer_account_ids.%s requires matching trusted_pools.creator_admin_credentials entry", creatorID)
+		}
+		seen := make(map[string]bool, len(buyerAccountIDs))
+		for _, buyerAccountID := range buyerAccountIDs {
+			rawBuyerAccountID := buyerAccountID
+			buyerAccountID = strings.TrimSpace(buyerAccountID)
+			if buyerAccountID == "" {
+				return fmt.Errorf("trusted_pools.creator_admin_buyer_account_ids.%s contains an empty buyer account id", creatorID)
+			}
+			if rawBuyerAccountID != buyerAccountID {
+				return fmt.Errorf("trusted_pools.creator_admin_buyer_account_ids.%s contains non-canonical buyer account id %q", creatorID, rawBuyerAccountID)
+			}
+			if seen[buyerAccountID] {
+				return fmt.Errorf("trusted_pools.creator_admin_buyer_account_ids.%s must contain unique buyer account ids", creatorID)
+			}
+			seen[buyerAccountID] = true
+		}
+	}
+	return nil
+}
+
+func trustedPoolsCreatorCredentialIDs(c TrustedPoolsConfig) map[string]bool {
+	ids := make(map[string]bool, len(c.CreatorAdminCredentials))
+	for _, credential := range c.CreatorAdminCredentials {
+		if id := strings.TrimSpace(credential.CreatorAccountID); id != "" {
+			ids[id] = true
+		}
+	}
+	return ids
 }
 
 func (c Config) validateCompatibilitySet() error {

--- a/phase4-coordinator/internal/config/config_test.go
+++ b/phase4-coordinator/internal/config/config_test.go
@@ -672,6 +672,396 @@ func TestTrustedPoolsEnabledRequiresBoundedRefreshInterval(t *testing.T) {
 	}
 }
 
+func TestTrustedPoolsCreatorAdminCredentialsRequireEnabledTrustedPools(t *testing.T) {
+	cfg := validTestConfig()
+	cfg.TrustedPools.CreatorAdminCredentials = []TrustedPoolsCreatorAdminCredentialConfig{trustedPoolsCreatorCredentialConfig("creator-a", "creator-a-cred", "creator-token-a")}
+	if err := cfg.Validate(); err == nil || !strings.Contains(err.Error(), "creator_admin_credentials requires trusted_pools.enabled=true") {
+		t.Fatalf("Validate err=%v, want creator admin credential enablement rejection", err)
+	}
+
+	cfg.TrustedPools.Enabled = true
+	cfg.Coordinator.RequireGatewayContext = true
+	cfg.TrustedPools.CreatorAdminProviderIDs = map[string][]string{"creator-a": {"provider-a"}}
+	cfg.TrustedPools.CreatorAdminProviderDelegatedIDs = map[string][]string{"creator-a": {"provider-a"}}
+	cfg.TrustedPools.CreatorAdminBuyerAccountIDs = map[string][]string{"creator-a": {"acct-a"}}
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("creator admin credentials with trusted pools enabled should validate: %v", err)
+	}
+}
+
+func TestTrustedPoolsCreatorAdminCredentialsRejectInvalidCredential(t *testing.T) {
+	tests := []struct {
+		name  string
+		build func(*Config)
+		want  string
+	}{
+		{
+			name: "operator key",
+			build: func(cfg *Config) {
+				cfg.TrustedPools.CreatorAdminCredentials = []TrustedPoolsCreatorAdminCredentialConfig{trustedPoolsCreatorCredentialConfig("creator-a", "creator-a-cred", " operator-key ")}
+			},
+			want: "auth.operator_key",
+		},
+		{
+			name: "gateway service token",
+			build: func(cfg *Config) {
+				cfg.TrustedPools.CreatorAdminCredentials = []TrustedPoolsCreatorAdminCredentialConfig{trustedPoolsCreatorCredentialConfig("creator-a", "creator-a-cred", "gateway-service-token")}
+			},
+			want: "auth.gateway_service_token",
+		},
+		{
+			name: "named operator key",
+			build: func(cfg *Config) {
+				cfg.Auth.OperatorKeys = map[string]string{"alice": "named-operator-secret"}
+				cfg.TrustedPools.CreatorAdminCredentials = []TrustedPoolsCreatorAdminCredentialConfig{trustedPoolsCreatorCredentialConfig("creator-a", "creator-a-cred", "named-operator-secret")}
+			},
+			want: "auth.operator_keys.alice",
+		},
+		{
+			name: "duplicate creator credential token",
+			build: func(cfg *Config) {
+				cfg.TrustedPools.CreatorAdminCredentials = []TrustedPoolsCreatorAdminCredentialConfig{
+					trustedPoolsCreatorCredentialConfig("creator-a", "creator-a-cred", "shared-creator-token"),
+					trustedPoolsCreatorCredentialConfig("creator-b", "creator-b-cred", "shared-creator-token"),
+				}
+				cfg.TrustedPools.CreatorAdminProviderIDs["creator-b"] = []string{"provider-b"}
+				cfg.TrustedPools.CreatorAdminProviderDelegatedIDs["creator-b"] = []string{"provider-b"}
+				cfg.TrustedPools.CreatorAdminBuyerAccountIDs["creator-b"] = []string{"acct-b"}
+			},
+			want: "must not reuse secret",
+		},
+		{
+			name: "slash creator id",
+			build: func(cfg *Config) {
+				cfg.TrustedPools.CreatorAdminCredentials = []TrustedPoolsCreatorAdminCredentialConfig{trustedPoolsCreatorCredentialConfig("creator/a", "creator-a-cred", "creator-token-a")}
+			},
+			want: "invalid creator id",
+		},
+		{
+			name: "non-canonical creator id",
+			build: func(cfg *Config) {
+				cfg.TrustedPools.CreatorAdminCredentials = []TrustedPoolsCreatorAdminCredentialConfig{trustedPoolsCreatorCredentialConfig(" creator-a ", "creator-a-cred", "creator-token-a")}
+			},
+			want: "creator_account_id must be canonical",
+		},
+		{
+			name: "slash credential id",
+			build: func(cfg *Config) {
+				cfg.TrustedPools.CreatorAdminCredentials = []TrustedPoolsCreatorAdminCredentialConfig{trustedPoolsCreatorCredentialConfig("creator-a", "credential/a", "creator-token-a")}
+			},
+			want: "invalid credential id",
+		},
+		{
+			name: "expires before not before",
+			build: func(cfg *Config) {
+				credential := trustedPoolsCreatorCredentialConfig("creator-a", "creator-a-cred", "creator-token-a")
+				credential.ExpiresAtUTC = "2026-01-01T00:00:00Z"
+				credential.NotBeforeUTC = "2026-01-02T00:00:00Z"
+				cfg.TrustedPools.CreatorAdminCredentials = []TrustedPoolsCreatorAdminCredentialConfig{credential}
+			},
+			want: "expires_at_utc must be after not_before_utc",
+		},
+		{
+			name: "invalid status",
+			build: func(cfg *Config) {
+				credential := trustedPoolsCreatorCredentialConfig("creator-a", "creator-a-cred", "creator-token-a")
+				credential.Status = "pending"
+				cfg.TrustedPools.CreatorAdminCredentials = []TrustedPoolsCreatorAdminCredentialConfig{credential}
+			},
+			want: "status must be enabled or disabled",
+		},
+	}
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := validTestConfig()
+			cfg.TrustedPools.Enabled = true
+			cfg.Coordinator.RequireGatewayContext = true
+			cfg.TrustedPools.CreatorAdminCredentials = []TrustedPoolsCreatorAdminCredentialConfig{trustedPoolsCreatorCredentialConfig("creator-a", "creator-a-cred", "creator-token-a")}
+			cfg.TrustedPools.CreatorAdminProviderIDs = map[string][]string{"creator-a": {"provider-a"}}
+			cfg.TrustedPools.CreatorAdminProviderDelegatedIDs = map[string][]string{"creator-a": {"provider-a"}}
+			cfg.TrustedPools.CreatorAdminBuyerAccountIDs = map[string][]string{"creator-a": {"acct-a"}}
+			tc.build(&cfg)
+			if err := cfg.Validate(); err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("Validate err=%v, want substring %q", err, tc.want)
+			}
+		})
+	}
+}
+
+func TestLoadRejectsWeakTrustedPoolsCreatorAdminCredentialToken(t *testing.T) {
+	yaml := `
+auth:
+  operator_key: 0123456789abcdefABCDEFghijklmnop
+  gateway_service_token: fedcba9876543210PONMLKJIHGFEDCBA
+coordinator:
+  require_gateway_context: true
+trusted_pools:
+  enabled: true
+  creator_admin_credentials:
+    - creator_account_id: creator-a
+      credential_id: creator-a-cred
+      token: changeme
+      not_before_utc: 2026-01-01T00:00:00Z
+      expires_at_utc: 2027-01-01T00:00:00Z
+      status: enabled
+  creator_admin_provider_ids:
+    creator-a: [provider-a]
+  creator_admin_provider_delegated_ids:
+    creator-a: [provider-a]
+  creator_admin_buyer_account_ids:
+    creator-a: [acct-a]
+`
+	_, err := loadConfigFromYAML(t, yaml)
+	if err == nil || !strings.Contains(err.Error(), "trusted_pools.creator_admin_credentials[0].token") || !strings.Contains(err.Error(), "placeholder_denied") {
+		t.Fatalf("Load error=%v, want weak creator credential token rejection", err)
+	}
+}
+
+func TestTrustedPoolsCreatorAdminProviderIDsValidateCreatorAndProviders(t *testing.T) {
+	tests := []struct {
+		name  string
+		build func(*Config)
+		want  string
+	}{
+		{
+			name: "credential without provider allowlist",
+			build: func(cfg *Config) {
+				cfg.TrustedPools.CreatorAdminProviderIDs = map[string][]string{}
+			},
+			want: "must be configured for every trusted_pools.creator_admin_credentials entry",
+		},
+		{
+			name: "disabled trusted pools",
+			build: func(cfg *Config) {
+				cfg.TrustedPools.Enabled = false
+				cfg.TrustedPools.CreatorAdminCredentials = nil
+				cfg.TrustedPools.CreatorAdminProviderIDs = map[string][]string{"creator-a": {"provider-a"}}
+				cfg.TrustedPools.CreatorAdminBuyerAccountIDs = nil
+			},
+			want: "creator_admin_provider_ids requires trusted_pools.enabled=true",
+		},
+		{
+			name: "missing creator credential",
+			build: func(cfg *Config) {
+				cfg.TrustedPools.CreatorAdminCredentials = nil
+				cfg.TrustedPools.CreatorAdminProviderIDs = map[string][]string{"creator-b": {"provider-a"}}
+				cfg.TrustedPools.CreatorAdminBuyerAccountIDs = nil
+			},
+			want: "requires matching trusted_pools.creator_admin_credentials entry",
+		},
+		{
+			name: "non-canonical provider-map creator id",
+			build: func(cfg *Config) {
+				cfg.TrustedPools.CreatorAdminProviderIDs = map[string][]string{
+					"creator-a":   {"provider-a"},
+					" creator-a ": {"provider-b"},
+				}
+			},
+			want: "non-canonical creator id",
+		},
+		{
+			name: "invalid provider id",
+			build: func(cfg *Config) {
+				cfg.TrustedPools.CreatorAdminProviderIDs = map[string][]string{"creator-a": {"bad/provider"}}
+			},
+			want: "invalid provider_id",
+		},
+		{
+			name: "non-canonical provider id",
+			build: func(cfg *Config) {
+				cfg.TrustedPools.CreatorAdminProviderIDs = map[string][]string{"creator-a": {" provider-a "}}
+			},
+			want: "non-canonical provider_id",
+		},
+		{
+			name: "duplicate provider id",
+			build: func(cfg *Config) {
+				cfg.TrustedPools.CreatorAdminProviderIDs = map[string][]string{"creator-a": {"provider-a", "provider-a"}}
+			},
+			want: "unique provider ids",
+		},
+	}
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := validTestConfig()
+			cfg.TrustedPools.Enabled = true
+			cfg.Coordinator.RequireGatewayContext = true
+			cfg.TrustedPools.CreatorAdminCredentials = []TrustedPoolsCreatorAdminCredentialConfig{trustedPoolsCreatorCredentialConfig("creator-a", "creator-a-cred", "creator-token-a")}
+			cfg.TrustedPools.CreatorAdminProviderIDs = map[string][]string{"creator-a": {"provider-a"}}
+			cfg.TrustedPools.CreatorAdminProviderDelegatedIDs = map[string][]string{"creator-a": {"provider-a"}}
+			cfg.TrustedPools.CreatorAdminBuyerAccountIDs = map[string][]string{"creator-a": {"acct-a"}}
+			tc.build(&cfg)
+			if err := cfg.Validate(); err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("Validate err=%v, want substring %q", err, tc.want)
+			}
+		})
+	}
+}
+
+func TestTrustedPoolsCreatorAdminProviderDelegatedIDsValidateCreatorAndProviders(t *testing.T) {
+	tests := []struct {
+		name  string
+		build func(*Config)
+		want  string
+	}{
+		{
+			name: "credential without provider delegation projection",
+			build: func(cfg *Config) {
+				cfg.TrustedPools.CreatorAdminProviderDelegatedIDs = map[string][]string{}
+			},
+			want: "must be configured for every trusted_pools.creator_admin_credentials entry",
+		},
+		{
+			name: "disabled trusted pools",
+			build: func(cfg *Config) {
+				cfg.TrustedPools.Enabled = false
+				cfg.TrustedPools.CreatorAdminCredentials = nil
+				cfg.TrustedPools.CreatorAdminProviderIDs = nil
+				cfg.TrustedPools.CreatorAdminProviderDelegatedIDs = map[string][]string{"creator-a": {"provider-a"}}
+				cfg.TrustedPools.CreatorAdminBuyerAccountIDs = nil
+			},
+			want: "creator_admin_provider_delegated_ids requires trusted_pools.enabled=true",
+		},
+		{
+			name: "missing creator credential",
+			build: func(cfg *Config) {
+				cfg.TrustedPools.CreatorAdminCredentials = nil
+				cfg.TrustedPools.CreatorAdminProviderIDs = nil
+				cfg.TrustedPools.CreatorAdminProviderDelegatedIDs = map[string][]string{"creator-b": {"provider-a"}}
+				cfg.TrustedPools.CreatorAdminBuyerAccountIDs = nil
+			},
+			want: "requires matching trusted_pools.creator_admin_credentials entry",
+		},
+		{
+			name: "invalid provider id",
+			build: func(cfg *Config) {
+				cfg.TrustedPools.CreatorAdminProviderDelegatedIDs = map[string][]string{"creator-a": {"bad/provider"}}
+			},
+			want: "invalid provider_id",
+		},
+		{
+			name: "non-canonical provider id",
+			build: func(cfg *Config) {
+				cfg.TrustedPools.CreatorAdminProviderDelegatedIDs = map[string][]string{"creator-a": {" provider-a "}}
+			},
+			want: "non-canonical provider_id",
+		},
+		{
+			name: "duplicate provider id",
+			build: func(cfg *Config) {
+				cfg.TrustedPools.CreatorAdminProviderDelegatedIDs = map[string][]string{"creator-a": {"provider-a", "provider-a"}}
+			},
+			want: "unique provider ids",
+		},
+	}
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := validTestConfig()
+			cfg.TrustedPools.Enabled = true
+			cfg.Coordinator.RequireGatewayContext = true
+			cfg.TrustedPools.CreatorAdminCredentials = []TrustedPoolsCreatorAdminCredentialConfig{trustedPoolsCreatorCredentialConfig("creator-a", "creator-a-cred", "creator-token-a")}
+			cfg.TrustedPools.CreatorAdminProviderIDs = map[string][]string{"creator-a": {"provider-a"}}
+			cfg.TrustedPools.CreatorAdminProviderDelegatedIDs = map[string][]string{"creator-a": {"provider-a"}}
+			cfg.TrustedPools.CreatorAdminBuyerAccountIDs = map[string][]string{"creator-a": {"acct-a"}}
+			tc.build(&cfg)
+			if err := cfg.Validate(); err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("Validate err=%v, want substring %q", err, tc.want)
+			}
+		})
+	}
+}
+
+func TestTrustedPoolsCreatorAdminBuyerAccountIDsValidateCreatorAndBuyers(t *testing.T) {
+	tests := []struct {
+		name  string
+		build func(*Config)
+		want  string
+	}{
+		{
+			name: "credential without buyer allowlist",
+			build: func(cfg *Config) {
+				cfg.TrustedPools.CreatorAdminBuyerAccountIDs = map[string][]string{}
+			},
+			want: "must be configured for every trusted_pools.creator_admin_credentials entry",
+		},
+		{
+			name: "disabled trusted pools",
+			build: func(cfg *Config) {
+				cfg.TrustedPools.Enabled = false
+				cfg.TrustedPools.CreatorAdminCredentials = nil
+				cfg.TrustedPools.CreatorAdminProviderIDs = nil
+				cfg.TrustedPools.CreatorAdminProviderDelegatedIDs = nil
+				cfg.TrustedPools.CreatorAdminBuyerAccountIDs = map[string][]string{"creator-a": {"acct-a"}}
+			},
+			want: "creator_admin_buyer_account_ids requires trusted_pools.enabled=true",
+		},
+		{
+			name: "missing creator credential",
+			build: func(cfg *Config) {
+				cfg.TrustedPools.CreatorAdminCredentials = nil
+				cfg.TrustedPools.CreatorAdminProviderIDs = nil
+				cfg.TrustedPools.CreatorAdminProviderDelegatedIDs = nil
+				cfg.TrustedPools.CreatorAdminBuyerAccountIDs = map[string][]string{"creator-b": {"acct-a"}}
+			},
+			want: "requires matching trusted_pools.creator_admin_credentials entry",
+		},
+		{
+			name: "non-canonical buyer-map creator id",
+			build: func(cfg *Config) {
+				cfg.TrustedPools.CreatorAdminBuyerAccountIDs = map[string][]string{
+					"creator-a":   {"acct-a"},
+					" creator-a ": {"acct-b"},
+				}
+			},
+			want: "non-canonical creator id",
+		},
+		{
+			name: "empty buyer account id",
+			build: func(cfg *Config) {
+				cfg.TrustedPools.CreatorAdminBuyerAccountIDs = map[string][]string{"creator-a": {""}}
+			},
+			want: "empty buyer account id",
+		},
+		{
+			name: "duplicate buyer account id",
+			build: func(cfg *Config) {
+				cfg.TrustedPools.CreatorAdminBuyerAccountIDs = map[string][]string{"creator-a": {"acct-a", "acct-a"}}
+			},
+			want: "unique buyer account ids",
+		},
+	}
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := validTestConfig()
+			cfg.TrustedPools.Enabled = true
+			cfg.Coordinator.RequireGatewayContext = true
+			cfg.TrustedPools.CreatorAdminCredentials = []TrustedPoolsCreatorAdminCredentialConfig{trustedPoolsCreatorCredentialConfig("creator-a", "creator-a-cred", "creator-token-a")}
+			cfg.TrustedPools.CreatorAdminProviderIDs = map[string][]string{"creator-a": {"provider-a"}}
+			cfg.TrustedPools.CreatorAdminProviderDelegatedIDs = map[string][]string{"creator-a": {"provider-a"}}
+			cfg.TrustedPools.CreatorAdminBuyerAccountIDs = map[string][]string{"creator-a": {"acct-a"}}
+			tc.build(&cfg)
+			if err := cfg.Validate(); err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("Validate err=%v, want substring %q", err, tc.want)
+			}
+		})
+	}
+}
+
+func trustedPoolsCreatorCredentialConfig(creatorID, credentialID, token string) TrustedPoolsCreatorAdminCredentialConfig {
+	return TrustedPoolsCreatorAdminCredentialConfig{
+		CreatorAccountID: creatorID,
+		CredentialID:     credentialID,
+		Token:            token,
+		NotBeforeUTC:     "2026-01-01T00:00:00Z",
+		ExpiresAtUTC:     "2027-01-01T00:00:00Z",
+		Status:           "enabled",
+	}
+}
+
 func TestTrustedPoolsProductionActivationRequiresCompleteExplicitGate(t *testing.T) {
 	digest := strings.Repeat("a", 64)
 	tests := []struct {

--- a/phase4-coordinator/internal/providerid/providerid.go
+++ b/phase4-coordinator/internal/providerid/providerid.go
@@ -1,0 +1,19 @@
+package providerid
+
+import (
+	"fmt"
+	"regexp"
+)
+
+var pattern = regexp.MustCompile(`^[a-zA-Z0-9_.-]{1,64}$`)
+
+// Validate is the canonical ProviderID grammar. The "/" delimiter is reserved
+// by pool.Provider.SortKey (ProviderID + "/" + AssignedID), so provider IDs
+// must stay delimiter-free across config, admission, and durable trustpool
+// events.
+func Validate(s string) error {
+	if !pattern.MatchString(s) {
+		return fmt.Errorf("invalid provider_id %q", s)
+	}
+	return nil
+}

--- a/phase4-coordinator/internal/trustpool/admin_handler.go
+++ b/phase4-coordinator/internal/trustpool/admin_handler.go
@@ -22,27 +22,100 @@ import (
 const AdminSchemaVersion = "macprovider.trustpool-admin.v1"
 const maxAdminEventBodyBytes = 64 * 1024
 
+var (
+	errCreatorBoundary         = errors.New("trustpool: creator boundary mismatch")
+	errCreatorProviderBoundary = errors.New("trustpool: creator provider boundary mismatch")
+	errCreatorBuyerBoundary    = errors.New("trustpool: creator buyer boundary mismatch")
+	errCreatorInvalidEvent     = errors.New("trustpool: invalid creator event")
+)
+
+const CreatorAdminCredentialStatusEnabled = "enabled"
+
+type CreatorAdminCredential struct {
+	CreatorAccountID string
+	CredentialID     string
+	Token            string
+	NotBeforeUTC     time.Time
+	ExpiresAtUTC     time.Time
+	Status           string
+}
+
+type creatorPrincipal struct {
+	CreatorID    string
+	CredentialID string
+}
+
+type CreatorAdminConfigReloader interface {
+	SetCreatorAdminConfig(credentials []CreatorAdminCredential, providerIDs, providerDelegatedIDs, buyerAccountIDs map[string][]string)
+}
+
 // AdminDeps wires the default-off SPEC-043 operator control surface. The
 // handler accepts durable pool events only after replay-checking the whole
 // history, then refreshes the live registry pointer held by the buyer server.
 type AdminDeps struct {
-	Store       *Store
-	Registry    *Registry
-	OperatorKey string
+	Store                            *Store
+	Registry                         *Registry
+	OperatorKey                      string
+	CreatorAdminCredentials          []CreatorAdminCredential
+	CreatorAdminProviderIDs          map[string][]string
+	CreatorAdminProviderDelegatedIDs map[string][]string
+	CreatorAdminBuyerAccountIDs      map[string][]string
+	CreatorProviderAdmitted          func(providerID string) bool
 }
 
 func NewAdminHandler(deps AdminDeps) http.Handler {
-	return &adminHandler{deps: deps}
+	h := &adminHandler{deps: deps}
+	h.setCreatorAdminConfig(deps.CreatorAdminCredentials, deps.CreatorAdminProviderIDs, deps.CreatorAdminProviderDelegatedIDs, deps.CreatorAdminBuyerAccountIDs, false)
+	return h
 }
 
 type adminHandler struct {
-	deps AdminDeps
-	mu   sync.Mutex
+	deps            AdminDeps
+	mu              sync.Mutex
+	creatorConfigMu sync.RWMutex
+}
+
+func (h *adminHandler) SetCreatorAdminConfig(credentials []CreatorAdminCredential, providerIDs, providerDelegatedIDs, buyerAccountIDs map[string][]string) {
+	h.setCreatorAdminConfig(credentials, providerIDs, providerDelegatedIDs, buyerAccountIDs, true)
+}
+
+func (h *adminHandler) setCreatorAdminConfig(credentials []CreatorAdminCredential, providerIDs, providerDelegatedIDs, buyerAccountIDs map[string][]string, liveReload bool) {
+	if h == nil {
+		return
+	}
+	h.creatorConfigMu.Lock()
+	defer h.creatorConfigMu.Unlock()
+	h.deps.CreatorAdminCredentials = append([]CreatorAdminCredential(nil), credentials...)
+	h.deps.CreatorAdminProviderIDs = cloneStringSliceMap(providerIDs)
+	h.deps.CreatorAdminProviderDelegatedIDs = cloneStringSliceMap(providerDelegatedIDs)
+	h.deps.CreatorAdminBuyerAccountIDs = cloneStringSliceMap(buyerAccountIDs)
+	if h.deps.Registry != nil {
+		if liveReload {
+			h.deps.Registry.SetCreatorAdminCeilings(providerIDs, providerDelegatedIDs, buyerAccountIDs)
+		} else {
+			h.deps.Registry.InitCreatorAdminCeilings(providerIDs, providerDelegatedIDs, buyerAccountIDs)
+		}
+	}
+}
+
+func cloneStringSliceMap(in map[string][]string) map[string][]string {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make(map[string][]string, len(in))
+	for key, values := range in {
+		out[key] = append([]string(nil), values...)
+	}
+	return out
 }
 
 func (h *adminHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	if h.deps.Store == nil {
 		writeAdminJSON(w, http.StatusServiceUnavailable, map[string]any{"error": map[string]string{"code": "unavailable"}})
+		return
+	}
+	if strings.HasPrefix(r.URL.Path, "/creator/trust-pools/") {
+		h.serveCreatorHTTP(w, r)
 		return
 	}
 	if strings.HasPrefix(r.URL.Path, "/admin/trust-pools/pools/") && strings.HasSuffix(r.URL.Path, "/signed-lifecycle") {
@@ -83,6 +156,148 @@ func (h *adminHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	default:
 		writeAdminJSON(w, http.StatusNotFound, map[string]any{"error": map[string]string{"code": "not_found"}})
 	}
+}
+
+func (h *adminHandler) serveCreatorHTTP(w http.ResponseWriter, r *http.Request) {
+	principal, ok := h.creatorFromBearer(r)
+	if !ok {
+		writeAdminJSON(w, http.StatusUnauthorized, map[string]any{"error": map[string]string{"code": "unauthorized"}})
+		return
+	}
+	switch {
+	case r.URL.Path == "/creator/trust-pools/me":
+		h.handleCreatorMe(w, r, principal.CreatorID)
+	case r.URL.Path == "/creator/trust-pools/events":
+		h.handleCreatorAppendEvent(w, r, principal)
+	case r.URL.Path == "/creator/trust-pools/root-registration-nonces":
+		h.handleCreatorIssueRootRegistrationNonce(w, r, principal)
+	case r.URL.Path == "/creator/trust-pools/pools":
+		h.handleCreatorListPools(w, r, principal.CreatorID)
+	case strings.HasPrefix(r.URL.Path, "/creator/trust-pools/pools/") && creatorOperatorOnlyPoolRoute(r.URL.Path):
+		writeAdminJSON(w, http.StatusNotFound, map[string]any{"error": map[string]string{"code": "not_found"}})
+	case strings.HasPrefix(r.URL.Path, "/creator/trust-pools/pools/") && strings.HasSuffix(r.URL.Path, "/lifecycle"):
+		h.handleCreatorRestrictiveLifecycle(w, r, principal)
+	case strings.HasPrefix(r.URL.Path, "/creator/trust-pools/pools/") && strings.HasSuffix(r.URL.Path, "/audit"):
+		h.handleCreatorPoolAudit(w, r, principal.CreatorID)
+	case strings.HasPrefix(r.URL.Path, "/creator/trust-pools/pools/") && strings.HasSuffix(r.URL.Path, "/health"):
+		h.handleCreatorPoolHealth(w, r, principal.CreatorID)
+	case strings.HasPrefix(r.URL.Path, "/creator/trust-pools/pools/") && strings.HasSuffix(r.URL.Path, "/distribution"):
+		h.handleCreatorPoolDistribution(w, r, principal.CreatorID)
+	case strings.HasPrefix(r.URL.Path, "/creator/trust-pools/pools/"):
+		h.handleCreatorGetPool(w, r, principal.CreatorID)
+	default:
+		writeAdminJSON(w, http.StatusNotFound, map[string]any{"error": map[string]string{"code": "not_found"}})
+	}
+}
+
+func (h *adminHandler) creatorFromBearer(r *http.Request) (creatorPrincipal, bool) {
+	if h == nil {
+		return creatorPrincipal{}, false
+	}
+	h.creatorConfigMu.RLock()
+	credentials := append([]CreatorAdminCredential(nil), h.deps.CreatorAdminCredentials...)
+	h.creatorConfigMu.RUnlock()
+	if len(credentials) == 0 {
+		return creatorPrincipal{}, false
+	}
+	sort.Slice(credentials, func(i, j int) bool {
+		if credentials[i].CreatorAccountID == credentials[j].CreatorAccountID {
+			return credentials[i].CredentialID < credentials[j].CredentialID
+		}
+		return credentials[i].CreatorAccountID < credentials[j].CreatorAccountID
+	})
+	now := time.Now().UTC()
+	for _, credential := range credentials {
+		if !auth.BearerTokenMatchesHeader(r.Header, credential.Token) {
+			continue
+		}
+		creatorID := strings.TrimSpace(credential.CreatorAccountID)
+		credentialID := strings.TrimSpace(credential.CredentialID)
+		if creatorID == "" || credentialID == "" {
+			return creatorPrincipal{}, false
+		}
+		if strings.TrimSpace(credential.Status) != CreatorAdminCredentialStatusEnabled {
+			return creatorPrincipal{}, false
+		}
+		if credential.NotBeforeUTC.IsZero() || credential.ExpiresAtUTC.IsZero() {
+			return creatorPrincipal{}, false
+		}
+		if now.Before(credential.NotBeforeUTC.UTC()) || !now.Before(credential.ExpiresAtUTC.UTC()) {
+			return creatorPrincipal{}, false
+		}
+		return creatorPrincipal{CreatorID: creatorID, CredentialID: credentialID}, true
+	}
+	return creatorPrincipal{}, false
+}
+
+func (h *adminHandler) creatorProviderAdmitAllowed(creatorID, providerID string) bool {
+	if h == nil || creatorID == "" || providerID == "" {
+		return false
+	}
+	h.creatorConfigMu.RLock()
+	allowedProviderIDs := append([]string(nil), h.deps.CreatorAdminProviderIDs[creatorID]...)
+	h.creatorConfigMu.RUnlock()
+	for _, allowedProviderID := range allowedProviderIDs {
+		if strings.TrimSpace(allowedProviderID) == providerID {
+			return true
+		}
+	}
+	return false
+}
+
+func (h *adminHandler) creatorProviderCurrentlyAdmitted(providerID string) bool {
+	if h == nil || h.deps.CreatorProviderAdmitted == nil || providerID == "" {
+		return false
+	}
+	return h.deps.CreatorProviderAdmitted(providerID)
+}
+
+func (h *adminHandler) creatorProviderDelegated(creatorID, providerID string) bool {
+	if h == nil || creatorID == "" || providerID == "" {
+		return false
+	}
+	h.creatorConfigMu.RLock()
+	delegatedProviderIDs := append([]string(nil), h.deps.CreatorAdminProviderDelegatedIDs[creatorID]...)
+	h.creatorConfigMu.RUnlock()
+	for _, delegatedProviderID := range delegatedProviderIDs {
+		if strings.TrimSpace(delegatedProviderID) == providerID {
+			return true
+		}
+	}
+	return false
+}
+
+func (h *adminHandler) creatorBuyerAccountAllowed(creatorID, buyerAccountID string) bool {
+	if h == nil || creatorID == "" || buyerAccountID == "" {
+		return false
+	}
+	h.creatorConfigMu.RLock()
+	allowedBuyerAccountIDs := append([]string(nil), h.deps.CreatorAdminBuyerAccountIDs[creatorID]...)
+	h.creatorConfigMu.RUnlock()
+	for _, allowedBuyerAccountID := range allowedBuyerAccountIDs {
+		if strings.TrimSpace(allowedBuyerAccountID) == buyerAccountID {
+			return true
+		}
+	}
+	return false
+}
+
+func (h *adminHandler) handleCreatorMe(w http.ResponseWriter, r *http.Request, creatorID string) {
+	if r.Method != http.MethodGet {
+		w.Header().Set("Allow", http.MethodGet)
+		writeAdminJSON(w, http.StatusMethodNotAllowed, map[string]any{"error": map[string]string{"code": "method_not_allowed"}})
+		return
+	}
+	approval, ok, err := h.deps.Store.CreatorApproval(r.Context(), creatorID)
+	if err != nil {
+		h.writeLookupError(w, "creator_lookup_failed", err)
+		return
+	}
+	if !ok {
+		writeAdminJSON(w, http.StatusNotFound, map[string]any{"error": map[string]string{"code": "not_found"}})
+		return
+	}
+	writeAdminJSON(w, http.StatusOK, map[string]any{"creator": approval})
 }
 
 func (h *adminHandler) handleUpsertCreator(w http.ResponseWriter, r *http.Request) {
@@ -213,6 +428,151 @@ func (h *adminHandler) handleAppendEvent(w http.ResponseWriter, r *http.Request)
 	state, committed, _, err := h.deps.Store.AppendValidatedEvent(r.Context(), e)
 	if err != nil {
 		h.writeMutationError(w, err)
+		return
+	}
+	if !h.refreshRegistryIfAhead(w, state) {
+		return
+	}
+	writeAdminJSON(w, http.StatusAccepted, map[string]any{
+		"event": committed,
+		"pool":  adminPoolResponse(state.Pools[committed.PoolID], state.RouteGateCheckedAt),
+	})
+}
+
+func (h *adminHandler) handleCreatorIssueRootRegistrationNonce(w http.ResponseWriter, r *http.Request, principal creatorPrincipal) {
+	if r.Method != http.MethodPost {
+		w.Header().Set("Allow", http.MethodPost)
+		writeAdminJSON(w, http.StatusMethodNotAllowed, map[string]any{"error": map[string]string{"code": "method_not_allowed"}})
+		return
+	}
+	var issue RootRegistrationNonceIssue
+	dec := json.NewDecoder(http.MaxBytesReader(w, r.Body, maxAdminEventBodyBytes))
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(&issue); err != nil {
+		writeAdminJSON(w, http.StatusBadRequest, map[string]any{"error": map[string]string{"code": "invalid_json"}})
+		return
+	}
+	var trailing struct{}
+	if err := dec.Decode(&trailing); err != io.EOF {
+		writeAdminJSON(w, http.StatusBadRequest, map[string]any{"error": map[string]string{"code": "invalid_json"}})
+		return
+	}
+	if bodyCreator := strings.TrimSpace(issue.CreatorAccountID); bodyCreator != "" && bodyCreator != principal.CreatorID {
+		writeAdminJSON(w, http.StatusForbidden, map[string]any{"error": map[string]string{"code": "creator_mismatch"}})
+		return
+	}
+	if bodyCredentialID := strings.TrimSpace(issue.CreatorCredentialID); bodyCredentialID != "" && bodyCredentialID != principal.CredentialID {
+		writeAdminJSON(w, http.StatusForbidden, map[string]any{"error": map[string]string{"code": "creator_mismatch"}})
+		return
+	}
+	operationID, err := resolveOperationID(strings.TrimSpace(issue.OperationID), r.Header)
+	if err != nil {
+		h.writeMutationError(w, err)
+		return
+	}
+	issue.OperationID = operationID
+	issue.CreatorAccountID = principal.CreatorID
+	issue.CreatorCredentialID = principal.CredentialID
+	record, err := h.deps.Store.IssueRootRegistrationNonce(r.Context(), issue)
+	if err != nil {
+		h.writeMutationError(w, err)
+		return
+	}
+	writeAdminJSON(w, http.StatusCreated, map[string]any{"root_registration_nonce": record})
+}
+
+func (h *adminHandler) handleCreatorAppendEvent(w http.ResponseWriter, r *http.Request, principal creatorPrincipal) {
+	if r.Method != http.MethodPost {
+		w.Header().Set("Allow", http.MethodPost)
+		writeAdminJSON(w, http.StatusMethodNotAllowed, map[string]any{"error": map[string]string{"code": "method_not_allowed"}})
+		return
+	}
+	var e DurableEvent
+	dec := json.NewDecoder(http.MaxBytesReader(w, r.Body, maxAdminEventBodyBytes))
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(&e); err != nil {
+		writeAdminJSON(w, http.StatusBadRequest, map[string]any{"error": map[string]string{"code": "invalid_json"}})
+		return
+	}
+	var trailing struct{}
+	if err := dec.Decode(&trailing); err != io.EOF {
+		writeAdminJSON(w, http.StatusBadRequest, map[string]any{"error": map[string]string{"code": "invalid_json"}})
+		return
+	}
+	var err error
+	e, err = normalizeCreatorEvent(r, e, principal)
+	if err != nil {
+		h.writeRequestMutationError(w, err)
+		return
+	}
+	if err := creatorEventAllowed(e); err != nil {
+		h.writeRequestMutationError(w, err)
+		return
+	}
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	existing, ok, err := h.deps.Store.ExistingEvent(r.Context(), e.OperationID)
+	if err != nil {
+		h.writeMutationError(w, err)
+		return
+	}
+	state, err := h.deps.Store.Reconstruct(r.Context())
+	if err != nil {
+		h.writeReconstructError(w, err)
+		return
+	}
+	if ok {
+		if e.TimestampUTC.IsZero() {
+			e.TimestampUTC = existing.TimestampUTC.UTC()
+		}
+		if !creatorOwnsEventPool(state, existing, principal.CreatorID) {
+			writeAdminJSON(w, http.StatusNotFound, map[string]any{"error": map[string]string{"code": "not_found"}})
+			return
+		}
+		if !sameDurableEvent(existing, e) {
+			h.writeRequestMutationError(w, ErrConflictingOperationID)
+			return
+		}
+		if !h.refreshRegistryIfAhead(w, state) {
+			return
+		}
+		writeAdminJSON(w, http.StatusAccepted, map[string]any{
+			"event": existing,
+			"pool":  adminPoolResponse(state.Pools[existing.PoolID], state.RouteGateCheckedAt),
+		})
+		return
+	}
+	if !creatorOwnsEventPool(state, e, principal.CreatorID) {
+		writeAdminJSON(w, http.StatusNotFound, map[string]any{"error": map[string]string{"code": "not_found"}})
+		return
+	}
+	if err := creatorEventValidForCurrentState(state, e); err != nil {
+		h.writeRequestMutationError(w, err)
+		return
+	}
+	if !creatorApprovalValidForMutation(state, e, principal.CreatorID, time.Now().UTC()) {
+		h.writeRequestMutationError(w, ErrCreatorApprovalGate)
+		return
+	}
+	if e.EventType == EventMemberAdmitted {
+		if !h.creatorProviderAdmitAllowed(principal.CreatorID, e.ProviderID) || !h.creatorProviderDelegated(principal.CreatorID, e.ProviderID) || !h.creatorProviderCurrentlyAdmitted(e.ProviderID) {
+			h.writeRequestMutationError(w, errCreatorProviderBoundary)
+			return
+		}
+	}
+	if e.EventType == EventBuyerAuthorized || e.EventType == EventBuyerAuthorizationRm {
+		if !h.creatorBuyerAccountAllowed(principal.CreatorID, e.BuyerAccountID) {
+			h.writeRequestMutationError(w, errCreatorBuyerBoundary)
+			return
+		}
+	}
+	if err := h.requireDeliveryDrained(e); err != nil {
+		h.writeRequestMutationError(w, err)
+		return
+	}
+	state, committed, _, err := h.deps.Store.AppendValidatedEvent(r.Context(), e)
+	if err != nil {
+		h.writeRequestMutationError(w, err)
 		return
 	}
 	if !h.refreshRegistryIfAhead(w, state) {
@@ -529,6 +889,116 @@ func (h *adminHandler) handleRestrictiveLifecycle(w http.ResponseWriter, r *http
 	})
 }
 
+func (h *adminHandler) handleCreatorRestrictiveLifecycle(w http.ResponseWriter, r *http.Request, principal creatorPrincipal) {
+	if r.Method != http.MethodPost {
+		w.Header().Set("Allow", http.MethodPost)
+		writeAdminJSON(w, http.StatusMethodNotAllowed, map[string]any{"error": map[string]string{"code": "method_not_allowed"}})
+		return
+	}
+	poolID := poolIDFromSuffixedCreatorPath(r.URL.Path, "/lifecycle")
+	if poolID == "" {
+		writeAdminJSON(w, http.StatusNotFound, map[string]any{"error": map[string]string{"code": "not_found"}})
+		return
+	}
+	var body restrictiveLifecycleRequest
+	dec := json.NewDecoder(http.MaxBytesReader(w, r.Body, maxAdminEventBodyBytes))
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(&body); err != nil {
+		writeAdminJSON(w, http.StatusBadRequest, map[string]any{"error": map[string]string{"code": "invalid_json"}})
+		return
+	}
+	var trailing struct{}
+	if err := dec.Decode(&trailing); err != io.EOF {
+		writeAdminJSON(w, http.StatusBadRequest, map[string]any{"error": map[string]string{"code": "invalid_json"}})
+		return
+	}
+	operationID, err := resolveOperationID(strings.TrimSpace(body.OperationID), r.Header)
+	if err != nil {
+		h.writeMutationError(w, err)
+		return
+	}
+	lifecycle := strings.TrimSpace(body.Lifecycle)
+	switch lifecycle {
+	case LifecyclePaused, LifecycleDraining, LifecycleRetired:
+	case LifecycleActive:
+		h.writeMutationError(w, ErrActivationRequiresPromotion)
+		return
+	default:
+		writeAdminJSON(w, http.StatusBadRequest, map[string]any{"error": map[string]string{"code": "invalid_event"}})
+		return
+	}
+	e := DurableEvent{
+		OperationID:         operationID,
+		TimestampUTC:        body.TimestampUTC,
+		EventType:           EventLifecycleChanged,
+		PoolID:              poolID,
+		CreatorCredentialID: principal.CredentialID,
+		Lifecycle:           lifecycle,
+		Reason:              strings.TrimSpace(body.Reason),
+	}
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	existing, ok, err := h.deps.Store.ExistingEvent(r.Context(), e.OperationID)
+	if err != nil {
+		h.writeMutationError(w, err)
+		return
+	}
+	state, err := h.deps.Store.Reconstruct(r.Context())
+	if err != nil {
+		h.writeReconstructError(w, err)
+		return
+	}
+	if ok {
+		if e.TimestampUTC.IsZero() {
+			e.TimestampUTC = existing.TimestampUTC.UTC()
+		}
+		if !creatorOwnsPool(state, existing.PoolID, principal.CreatorID) {
+			writeAdminJSON(w, http.StatusNotFound, map[string]any{"error": map[string]string{"code": "not_found"}})
+			return
+		}
+		if !sameDurableEvent(existing, e) {
+			h.writeRequestMutationError(w, ErrConflictingOperationID)
+			return
+		}
+		if !h.refreshRegistryIfAhead(w, state) {
+			return
+		}
+		writeAdminJSON(w, http.StatusAccepted, map[string]any{
+			"event": existing,
+			"pool":  adminPoolResponse(state.Pools[existing.PoolID], state.RouteGateCheckedAt),
+		})
+		return
+	}
+	if !creatorOwnsPool(state, poolID, principal.CreatorID) {
+		writeAdminJSON(w, http.StatusNotFound, map[string]any{"error": map[string]string{"code": "not_found"}})
+		return
+	}
+	if err := creatorEventValidForCurrentState(state, e); err != nil {
+		h.writeRequestMutationError(w, err)
+		return
+	}
+	if !creatorApprovalValidForMutation(state, e, principal.CreatorID, time.Now().UTC()) {
+		h.writeRequestMutationError(w, ErrCreatorApprovalGate)
+		return
+	}
+	if err := h.requireDeliveryDrained(e); err != nil {
+		h.writeRequestMutationError(w, err)
+		return
+	}
+	state, committed, _, err := h.deps.Store.AppendValidatedEvent(r.Context(), e)
+	if err != nil {
+		h.writeRequestMutationError(w, err)
+		return
+	}
+	if !h.refreshRegistryIfAhead(w, state) {
+		return
+	}
+	writeAdminJSON(w, http.StatusAccepted, map[string]any{
+		"event": committed,
+		"pool":  adminPoolResponse(state.Pools[committed.PoolID], state.RouteGateCheckedAt),
+	})
+}
+
 func (h *adminHandler) handlePublicAnnouncementApproval(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
 		w.Header().Set("Allow", http.MethodPost)
@@ -754,6 +1224,7 @@ type adminRootRegistrationNonceAudit struct {
 	OperationID            string `json:"operation_id,omitempty"`
 	NonceSHA256            string `json:"nonce_sha256"`
 	CreatorAccountID       string `json:"creator_account_id"`
+	CreatorCredentialID    string `json:"creator_credential_id,omitempty"`
 	ApprovalRecordID       string `json:"approval_record_id"`
 	CurrentApprovalVersion string `json:"current_approval_version"`
 	LaunchEnvironment      string `json:"launch_environment"`
@@ -769,7 +1240,7 @@ func (h *adminHandler) rootRegistrationNonceAuditRecords(ctx context.Context, po
 		return nil, nil
 	}
 	rows, err := h.deps.Store.db.QueryContext(ctx, `
-SELECT operation_id, nonce, creator_account_id, approval_record_id, current_approval_version,
+SELECT operation_id, nonce, creator_account_id, creator_credential_id, approval_record_id, current_approval_version,
        launch_environment, purpose, expires_at_utc, issued_at_utc, consumed_operation_id, consumed_at_utc
 FROM trustpool_root_registration_nonces
 WHERE creator_account_id = ? AND approval_record_id = ?
@@ -781,12 +1252,13 @@ ORDER BY issued_at_utc`, pool.CreatorAccountID, pool.ApprovalRecordID)
 	out := make([]adminRootRegistrationNonceAudit, 0)
 	for rows.Next() {
 		var record adminRootRegistrationNonceAudit
-		var operationID, consumedOperationID, consumedAt sql.NullString
+		var operationID, creatorCredentialID, consumedOperationID, consumedAt sql.NullString
 		var nonce string
 		if err := rows.Scan(
 			&operationID,
 			&nonce,
 			&record.CreatorAccountID,
+			&creatorCredentialID,
 			&record.ApprovalRecordID,
 			&record.CurrentApprovalVersion,
 			&record.LaunchEnvironment,
@@ -803,6 +1275,9 @@ ORDER BY issued_at_utc`, pool.CreatorAccountID, pool.ApprovalRecordID)
 		}
 		if operationID.Valid {
 			record.OperationID = operationID.String
+		}
+		if creatorCredentialID.Valid {
+			record.CreatorCredentialID = creatorCredentialID.String
 		}
 		digest := sha256.Sum256([]byte(nonce))
 		record.NonceSHA256 = hex.EncodeToString(digest[:])
@@ -868,11 +1343,179 @@ func (h *adminHandler) handlePoolDistribution(w http.ResponseWriter, r *http.Req
 	writeAdminJSON(w, http.StatusOK, map[string]any{"distribution_package": buildAdminDistributionPackage(pool, state)})
 }
 
+func (h *adminHandler) handleCreatorListPools(w http.ResponseWriter, r *http.Request, creatorID string) {
+	if r.Method != http.MethodGet {
+		w.Header().Set("Allow", http.MethodGet)
+		writeAdminJSON(w, http.StatusMethodNotAllowed, map[string]any{"error": map[string]string{"code": "method_not_allowed"}})
+		return
+	}
+	state, err := h.deps.Store.Reconstruct(r.Context())
+	if err != nil {
+		h.writeReconstructError(w, err)
+		return
+	}
+	ids := make([]string, 0, len(state.Pools))
+	for id, pool := range state.Pools {
+		if pool != nil && pool.CreatorAccountID == creatorID {
+			ids = append(ids, id)
+		}
+	}
+	sort.Strings(ids)
+	pools := make([]adminPoolState, 0, len(ids))
+	for _, id := range ids {
+		pools = append(pools, adminPoolResponse(state.Pools[id], state.RouteGateCheckedAt))
+	}
+	writeAdminJSON(w, http.StatusOK, map[string]any{"pools": pools})
+}
+
+func (h *adminHandler) handleCreatorGetPool(w http.ResponseWriter, r *http.Request, creatorID string) {
+	if r.Method != http.MethodGet {
+		w.Header().Set("Allow", http.MethodGet)
+		writeAdminJSON(w, http.StatusMethodNotAllowed, map[string]any{"error": map[string]string{"code": "method_not_allowed"}})
+		return
+	}
+	poolID := strings.TrimSpace(strings.TrimPrefix(r.URL.Path, "/creator/trust-pools/pools/"))
+	if poolID == "" || strings.Contains(poolID, "/") {
+		writeAdminJSON(w, http.StatusNotFound, map[string]any{"error": map[string]string{"code": "not_found"}})
+		return
+	}
+	state, err := h.deps.Store.Reconstruct(r.Context())
+	if err != nil {
+		h.writeReconstructError(w, err)
+		return
+	}
+	pool := state.Pools[poolID]
+	if pool == nil || pool.CreatorAccountID != creatorID {
+		writeAdminJSON(w, http.StatusNotFound, map[string]any{"error": map[string]string{"code": "not_found"}})
+		return
+	}
+	writeAdminJSON(w, http.StatusOK, map[string]any{"pool": adminPoolResponse(pool, state.RouteGateCheckedAt)})
+}
+
+func (h *adminHandler) handleCreatorPoolAudit(w http.ResponseWriter, r *http.Request, creatorID string) {
+	if r.Method != http.MethodGet {
+		w.Header().Set("Allow", http.MethodGet)
+		writeAdminJSON(w, http.StatusMethodNotAllowed, map[string]any{"error": map[string]string{"code": "method_not_allowed"}})
+		return
+	}
+	poolID := poolIDFromSuffixedCreatorPath(r.URL.Path, "/audit")
+	if poolID == "" {
+		writeAdminJSON(w, http.StatusNotFound, map[string]any{"error": map[string]string{"code": "not_found"}})
+		return
+	}
+	state, err := h.deps.Store.Reconstruct(r.Context())
+	if err != nil {
+		h.writeReconstructError(w, err)
+		return
+	}
+	pool := state.Pools[poolID]
+	if pool == nil || pool.CreatorAccountID != creatorID {
+		writeAdminJSON(w, http.StatusNotFound, map[string]any{"error": map[string]string{"code": "not_found"}})
+		return
+	}
+	events, err := h.deps.Store.Events(r.Context())
+	if err != nil {
+		h.writeLookupError(w, "audit_lookup_failed", err)
+		return
+	}
+	filtered := make([]DurableEvent, 0)
+	rootRegistrationOps := make(map[string]bool)
+	for _, e := range events {
+		if e.PoolID == poolID {
+			filtered = append(filtered, e)
+			if e.EventType == EventRootIssuerRegistered && e.OperationID != "" {
+				rootRegistrationOps[e.OperationID] = true
+			}
+		}
+	}
+	nonceAudit, err := h.rootRegistrationNonceAuditRecords(r.Context(), pool, rootRegistrationOps)
+	if err != nil {
+		h.writeLookupError(w, "audit_lookup_failed", err)
+		return
+	}
+	var creatorApproval any
+	if approval, ok := state.CreatorApprovals[pool.CreatorAccountID]; ok {
+		creatorApproval = approval
+	}
+	writeAdminJSON(w, http.StatusOK, map[string]any{
+		"pool_id":                   poolID,
+		"creator_approval":          creatorApproval,
+		"root_registration_nonces":  nonceAudit,
+		"events":                    filtered,
+		"nonce_material_disclosure": "nonce digests are exported here; consumed nonce material may still appear inside root-registration durable events for replay compatibility",
+	})
+}
+
+func (h *adminHandler) handleCreatorPoolHealth(w http.ResponseWriter, r *http.Request, creatorID string) {
+	if r.Method != http.MethodGet {
+		w.Header().Set("Allow", http.MethodGet)
+		writeAdminJSON(w, http.StatusMethodNotAllowed, map[string]any{"error": map[string]string{"code": "method_not_allowed"}})
+		return
+	}
+	poolID := poolIDFromSuffixedCreatorPath(r.URL.Path, "/health")
+	if poolID == "" {
+		writeAdminJSON(w, http.StatusNotFound, map[string]any{"error": map[string]string{"code": "not_found"}})
+		return
+	}
+	state, err := h.deps.Store.Reconstruct(r.Context())
+	if err != nil {
+		h.writeReconstructError(w, err)
+		return
+	}
+	pool := state.Pools[poolID]
+	if pool == nil || pool.CreatorAccountID != creatorID {
+		writeAdminJSON(w, http.StatusNotFound, map[string]any{"error": map[string]string{"code": "not_found"}})
+		return
+	}
+	writeAdminJSON(w, http.StatusOK, map[string]any{
+		"pool_id":       poolID,
+		"health_events": adminHealthEvents(pool, state.RouteGateCheckedAt),
+	})
+}
+
+func (h *adminHandler) handleCreatorPoolDistribution(w http.ResponseWriter, r *http.Request, creatorID string) {
+	if r.Method != http.MethodGet {
+		w.Header().Set("Allow", http.MethodGet)
+		writeAdminJSON(w, http.StatusMethodNotAllowed, map[string]any{"error": map[string]string{"code": "method_not_allowed"}})
+		return
+	}
+	poolID := poolIDFromSuffixedCreatorPath(r.URL.Path, "/distribution")
+	if poolID == "" {
+		writeAdminJSON(w, http.StatusNotFound, map[string]any{"error": map[string]string{"code": "not_found"}})
+		return
+	}
+	state, err := h.deps.Store.Reconstruct(r.Context())
+	if err != nil {
+		h.writeReconstructError(w, err)
+		return
+	}
+	pool := state.Pools[poolID]
+	if pool == nil || pool.CreatorAccountID != creatorID {
+		writeAdminJSON(w, http.StatusNotFound, map[string]any{"error": map[string]string{"code": "not_found"}})
+		return
+	}
+	writeAdminJSON(w, http.StatusOK, map[string]any{"distribution_package": buildAdminDistributionPackage(pool, state)})
+}
+
 func (h *adminHandler) writeMutationError(w http.ResponseWriter, err error) {
 	h.disableRegistryOnMalformed(err)
+	h.writeMutationErrorResponse(w, err)
+}
+
+func (h *adminHandler) writeRequestMutationError(w http.ResponseWriter, err error) {
+	h.writeMutationErrorResponse(w, err)
+}
+
+func (h *adminHandler) writeMutationErrorResponse(w http.ResponseWriter, err error) {
 	switch {
 	case errors.Is(err, ErrConflictingOperationID):
 		writeAdminJSON(w, http.StatusConflict, map[string]any{"error": map[string]string{"code": "operation_conflict"}})
+	case errors.Is(err, errCreatorBoundary):
+		writeAdminJSON(w, http.StatusForbidden, map[string]any{"error": map[string]string{"code": "creator_mismatch"}})
+	case errors.Is(err, errCreatorProviderBoundary):
+		writeAdminJSON(w, http.StatusForbidden, map[string]any{"error": map[string]string{"code": "provider_not_authorized"}})
+	case errors.Is(err, errCreatorBuyerBoundary):
+		writeAdminJSON(w, http.StatusForbidden, map[string]any{"error": map[string]string{"code": "buyer_not_authorized"}})
 	case errors.Is(err, ErrActivationRequiresPromotion):
 		writeAdminJSON(w, http.StatusConflict, map[string]any{"error": map[string]string{"code": "activation_requires_promotion"}})
 	case errors.Is(err, ErrPromotionPreconditionFailed):
@@ -890,6 +1533,8 @@ func (h *adminHandler) writeMutationError(w http.ResponseWriter, err error) {
 		writeAdminJSON(w, http.StatusConflict, map[string]any{"error": map[string]string{"code": "public_announcement_gate_failed"}})
 	case errors.Is(err, ErrDeliveryDrainPending):
 		writeAdminJSON(w, http.StatusConflict, map[string]any{"error": map[string]string{"code": "delivery_drain_pending"}})
+	case errors.Is(err, errCreatorInvalidEvent):
+		writeAdminJSON(w, http.StatusBadRequest, map[string]any{"error": map[string]string{"code": "invalid_event"}})
 	case errors.Is(err, ErrProhibitedPromiseClaim):
 		writeAdminJSON(w, http.StatusBadRequest, map[string]any{"error": map[string]string{"code": "prohibited_promise_claim"}})
 	case errors.Is(err, ErrMalformedDurableEvent):
@@ -955,6 +1600,7 @@ func normalizeAdminEvent(r *http.Request, e DurableEvent) (DurableEvent, error) 
 	e.EventType = strings.TrimSpace(e.EventType)
 	e.PoolID = strings.TrimSpace(e.PoolID)
 	e.CreatorAccountID = strings.TrimSpace(e.CreatorAccountID)
+	e.CreatorCredentialID = strings.TrimSpace(e.CreatorCredentialID)
 	e.ApprovalRecordID = strings.TrimSpace(e.ApprovalRecordID)
 	e.ProviderID = strings.TrimSpace(e.ProviderID)
 	e.BuyerAccountID = strings.TrimSpace(e.BuyerAccountID)
@@ -985,8 +1631,171 @@ func normalizeAdminEvent(r *http.Request, e DurableEvent) (DurableEvent, error) 
 	return e, nil
 }
 
+func normalizeCreatorEvent(r *http.Request, e DurableEvent, principal creatorPrincipal) (DurableEvent, error) {
+	bodyCreatorID := strings.TrimSpace(e.CreatorAccountID)
+	bodyCredentialID := strings.TrimSpace(e.CreatorCredentialID)
+	e, err := normalizeAdminEvent(r, e)
+	if err != nil {
+		return DurableEvent{}, err
+	}
+	if bodyCredentialID != "" && bodyCredentialID != principal.CredentialID {
+		return DurableEvent{}, errCreatorBoundary
+	}
+	e.CreatorCredentialID = principal.CredentialID
+	switch e.EventType {
+	case EventPoolCreated, EventRootIssuerRegistered:
+		if bodyCreatorID != "" && bodyCreatorID != principal.CreatorID {
+			return DurableEvent{}, errCreatorBoundary
+		}
+		e.CreatorAccountID = principal.CreatorID
+	default:
+		if bodyCreatorID != "" && bodyCreatorID != principal.CreatorID {
+			return DurableEvent{}, errCreatorBoundary
+		}
+		e.CreatorAccountID = ""
+	}
+	return e, nil
+}
+
+func creatorEventAllowed(e DurableEvent) error {
+	if hasSignedControlProof(e) {
+		return ErrSignedControlProofPath
+	}
+	switch e.EventType {
+	case EventPoolCreated, EventRootIssuerRegistered, EventManifestAccepted, EventMemberAdmitted, EventMemberRevoked, EventBuyerAuthorized, EventBuyerAuthorizationRm:
+		return nil
+	case EventLifecycleChanged:
+		if e.Lifecycle == LifecycleActive {
+			return ErrActivationRequiresPromotion
+		}
+		switch e.Lifecycle {
+		case LifecyclePaused, LifecycleDraining, LifecycleRetired:
+			return nil
+		default:
+			return ErrMalformedDurableEvent
+		}
+	default:
+		return ErrMalformedDurableEvent
+	}
+}
+
+func creatorOperatorOnlyPoolRoute(path string) bool {
+	for _, suffix := range []string{"/promote", "/public-announcement", "/reviewed-distribution-artifact", "/signed-lifecycle"} {
+		if strings.HasSuffix(path, suffix) {
+			return true
+		}
+	}
+	return false
+}
+
+func creatorOwnsEventPool(state *ReconstructedState, e DurableEvent, creatorID string) bool {
+	if state == nil {
+		return false
+	}
+	if e.EventType == EventPoolCreated {
+		existing := state.Pools[e.PoolID]
+		return existing == nil || existing.CreatorAccountID == creatorID
+	}
+	return creatorOwnsPool(state, e.PoolID, creatorID)
+}
+
+func creatorOwnsPool(state *ReconstructedState, poolID, creatorID string) bool {
+	if state == nil {
+		return false
+	}
+	pool := state.Pools[poolID]
+	return pool != nil && pool.CreatorAccountID == creatorID
+}
+
+func creatorEventValidForCurrentState(state *ReconstructedState, e DurableEvent) error {
+	if err := ValidateCanonicalPoolID(e.PoolID); err != nil {
+		return errCreatorInvalidEvent
+	}
+	if state == nil {
+		return errCreatorInvalidEvent
+	}
+	pool := state.Pools[e.PoolID]
+	switch e.EventType {
+	case EventPoolCreated:
+		if !creatorPoolCreatedBindsIdentity(e) {
+			return errCreatorInvalidEvent
+		}
+		if pool != nil {
+			return errCreatorInvalidEvent
+		}
+	case EventRootIssuerRegistered:
+		if pool == nil || pool.RootIssuer != nil {
+			return errCreatorInvalidEvent
+		}
+	case EventManifestAccepted:
+		if pool == nil || pool.RootIssuer == nil {
+			return errCreatorInvalidEvent
+		}
+	case EventMemberAdmitted, EventMemberRevoked, EventBuyerAuthorized, EventBuyerAuthorizationRm, EventLifecycleChanged:
+		if pool == nil {
+			return errCreatorInvalidEvent
+		}
+	}
+	return nil
+}
+
+func creatorPoolCreatedBindsIdentity(e DurableEvent) bool {
+	raw, err := canonicalBase64(e.ManifestSnapshot)
+	if err != nil {
+		return false
+	}
+	snapshot, err := poolmanifest.ParseManifestSnapshot(raw)
+	if err != nil {
+		return false
+	}
+	poolID, err := snapshot.IdentityCore.PoolID()
+	if err != nil {
+		return false
+	}
+	return poolID == e.PoolID
+}
+
+func creatorApprovalValidForMutation(state *ReconstructedState, e DurableEvent, creatorID string, now time.Time) bool {
+	if state == nil || state.CreatorApprovals == nil || creatorID == "" {
+		return false
+	}
+	approval, ok := state.CreatorApprovals[creatorID]
+	if !ok {
+		return false
+	}
+	approvalID := e.ApprovalRecordID
+	version := e.CurrentApprovalVersion
+	environment := e.LaunchEnvironment
+	if e.EventType != EventPoolCreated && e.EventType != EventRootIssuerRegistered {
+		pool := state.Pools[e.PoolID]
+		if pool == nil || pool.CreatorAccountID != creatorID {
+			return false
+		}
+		approvalID = pool.ApprovalRecordID
+		if pool.RootIssuer != nil {
+			version = pool.RootIssuer.CurrentApprovalVersion
+			environment = pool.RootIssuer.LaunchEnvironment
+		}
+	}
+	if version == "" {
+		version = approval.CurrentApprovalVersion
+	}
+	if environment == "" {
+		environment = approval.AllowedLaunchEnvironment
+	}
+	return approval.ValidFor(approvalID, version, environment, now)
+}
+
 func poolIDFromSuffixedAdminPath(path, suffix string) string {
-	poolID := strings.TrimSpace(strings.TrimPrefix(strings.TrimSuffix(path, suffix), "/admin/trust-pools/pools/"))
+	return poolIDFromSuffixedPath(path, "/admin/trust-pools/pools/", suffix)
+}
+
+func poolIDFromSuffixedCreatorPath(path, suffix string) string {
+	return poolIDFromSuffixedPath(path, "/creator/trust-pools/pools/", suffix)
+}
+
+func poolIDFromSuffixedPath(path, prefix, suffix string) string {
+	poolID := strings.TrimSpace(strings.TrimPrefix(strings.TrimSuffix(path, suffix), prefix))
 	if poolID == "" || strings.Contains(poolID, "/") {
 		return ""
 	}

--- a/phase4-coordinator/internal/trustpool/admin_handler_test.go
+++ b/phase4-coordinator/internal/trustpool/admin_handler_test.go
@@ -83,6 +83,34 @@ func TestAdminHandler_AppendsCandidateEventsAndRejectsActivation(t *testing.T) {
 	}, "op-active-after-promote", http.StatusConflict)
 }
 
+func TestAdminHandler_RejectsMalformedMemberProviderID(t *testing.T) {
+	t.Parallel()
+	store, err := trustpool.NewStore(openTrustPoolDB(t))
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+	handler := trustpool.NewAdminHandler(trustpool.AdminDeps{
+		Store:       store,
+		Registry:    trustpool.NewRegistry(),
+		OperatorKey: "operator-secret",
+	})
+	root := newRootFixture(t)
+	approveCreator(t, store, "creator-a", "approval-v1", "approval-version-1", "candidate", time.Now().Add(24*time.Hour), trustpool.CreatorStatusEnabled)
+	postAdminEvent(t, handler, "operator-secret", trustpool.DurableEvent{
+		EventType:        trustpool.EventPoolCreated,
+		PoolID:           root.poolID,
+		CreatorAccountID: "creator-a",
+		ApprovalRecordID: "approval-v1",
+	}, "op-create", http.StatusAccepted)
+	postAdminEvent(t, handler, "operator-secret", signedRootRegistrationForIssue(t, "op-root", testAdminTS(1), root.poolID, "creator-a", "approval-v1", issueRootNonce(t, store, "creator-a", "approval-v1", testAdminTS(3600)), root), "op-root", http.StatusAccepted)
+	postAdminEvent(t, handler, "operator-secret", signedManifest(t, "op-manifest", testAdminTS(2), root.poolID, 1, root), "op-manifest", http.StatusAccepted)
+	postAdminEvent(t, handler, "operator-secret", trustpool.DurableEvent{
+		EventType:  trustpool.EventMemberAdmitted,
+		PoolID:     root.poolID,
+		ProviderID: "bad/provider",
+	}, "op-bad-provider", http.StatusBadRequest)
+}
+
 func TestAdminHandler_MalformedDurableStateClearsRouteableRegistry(t *testing.T) {
 	t.Parallel()
 	db := openTrustPoolDB(t)
@@ -546,7 +574,8 @@ func TestAdminHandler_SignedRevokeImmediateRevokesProviderAndBumpsGeneration(t *
 		t.Fatalf("pre-revoke snapshot = %+v, want routeable provider-a", before)
 	}
 
-	rec := postAdminSignedLifecycleWithTarget(t, routeable.store, handler, "", root, "op-revoke-immediate", poolmanifest.EmergencyLifecycleRevokeImmediate, "provider-a", "provider compromise", false, http.StatusAccepted)
+	revokeBody := signedLifecycleRequestBodyWithTarget(t, routeable.store, root, "op-revoke-immediate", poolmanifest.EmergencyLifecycleRevokeImmediate, "provider-a", "provider compromise", false)
+	rec := postAdminSignedLifecycleBody(t, handler, "", root.poolID, revokeBody, "", http.StatusAccepted)
 	var body struct {
 		Event struct {
 			EventType         string `json:"event_type"`
@@ -576,7 +605,7 @@ func TestAdminHandler_SignedRevokeImmediateRevokesProviderAndBumpsGeneration(t *
 		t.Fatalf("post-revoke snapshot = %+v buyer_auth=%v, want advanced fail-closed snapshot with buyer auth retained", after, registry.BuyerAuthorized(root.poolID, "acct-allowed"))
 	}
 
-	postAdminSignedLifecycleWithTarget(t, routeable.store, handler, "", root, "op-revoke-immediate", poolmanifest.EmergencyLifecycleRevokeImmediate, "provider-a", "provider compromise", false, http.StatusAccepted)
+	postAdminSignedLifecycleBody(t, handler, "", root.poolID, revokeBody, "", http.StatusAccepted)
 	retry := registry.Snapshot(root.poolID)
 	if retry.Generation != after.Generation || retry.Routeable || len(retry.Members) != 0 {
 		t.Fatalf("idempotent signed revoke retry snapshot = %+v, want unchanged generation %d", retry, after.Generation)
@@ -1414,6 +1443,494 @@ func TestAdminHandler_RejectsUnauthorized(t *testing.T) {
 	assertAdminSchemaVersion(t, rec)
 }
 
+func TestAdminHandler_CreatorSurfaceAllowsOwnedCandidateLaunch(t *testing.T) {
+	t.Parallel()
+	store, err := trustpool.NewStore(openTrustPoolDB(t))
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+	registry := trustpool.NewRegistry()
+	handler := trustpool.NewAdminHandler(trustpool.AdminDeps{
+		Store:                            store,
+		Registry:                         registry,
+		OperatorKey:                      "operator-secret",
+		CreatorAdminCredentials:          creatorCredentials("creator-a", "creator-a-cred", "creator-token-a"),
+		CreatorAdminProviderIDs:          map[string][]string{"creator-a": {"provider-a"}},
+		CreatorAdminProviderDelegatedIDs: map[string][]string{"creator-a": {"provider-a"}},
+		CreatorAdminBuyerAccountIDs:      map[string][]string{"creator-a": {"acct-allowed"}},
+		CreatorProviderAdmitted:          admittedProviderIDs("provider-a"),
+	})
+	root := newRootFixture(t)
+	approveCreator(t, store, "creator-a", "approval-v1", "approval-version-1", "candidate", time.Now().Add(24*time.Hour), trustpool.CreatorStatusEnabled)
+
+	postCreatorEvent(t, handler, "creator-token-a", creatorPoolCreatedEvent(t, root, "approval-v1"), "op-create", http.StatusAccepted)
+	existing, ok, err := store.ExistingEvent(t.Context(), "op-create")
+	if err != nil {
+		t.Fatalf("ExistingEvent: %v", err)
+	}
+	if !ok || existing.CreatorCredentialID != "creator-a-cred" {
+		t.Fatalf("stored create credential=%q ok=%v, want creator-a-cred", existing.CreatorCredentialID, ok)
+	}
+	nonce := postCreatorRootRegistrationNonce(t, handler, "creator-token-a", trustpool.RootRegistrationNonceIssue{
+		OperationID:            "op-nonce",
+		ApprovalRecordID:       "approval-v1",
+		CurrentApprovalVersion: "approval-version-1",
+		LaunchEnvironment:      "candidate",
+		ExpiresAtUTC:           testAdminTS(3600),
+	}, http.StatusCreated)
+	if nonce.CreatorCredentialID != "creator-a-cred" {
+		t.Fatalf("nonce creator credential id = %q, want creator-a-cred", nonce.CreatorCredentialID)
+	}
+	postCreatorEvent(t, handler, "creator-token-a", signedRootRegistrationForIssue(t, "op-root", testAdminTS(1), root.poolID, "creator-a", "approval-v1", nonce, root), "op-root", http.StatusAccepted)
+	postCreatorEvent(t, handler, "creator-token-a", signedManifest(t, "op-manifest", testAdminTS(2), root.poolID, 1, root), "op-manifest", http.StatusAccepted)
+	postCreatorEvent(t, handler, "creator-token-a", trustpool.DurableEvent{
+		EventType:  trustpool.EventMemberAdmitted,
+		PoolID:     root.poolID,
+		ProviderID: "provider-a",
+	}, "op-member", http.StatusAccepted)
+	postCreatorEvent(t, handler, "creator-token-a", trustpool.DurableEvent{
+		EventType:      trustpool.EventBuyerAuthorized,
+		PoolID:         root.poolID,
+		BuyerAccountID: "acct-allowed",
+	}, "op-buyer", http.StatusAccepted)
+
+	state, err := store.Reconstruct(t.Context())
+	if err != nil {
+		t.Fatalf("Reconstruct: %v", err)
+	}
+	pool := state.Pools[root.poolID]
+	if pool == nil || pool.CreatorAccountID != "creator-a" || !pool.Members["provider-a"] || !pool.BuyerAccounts["acct-allowed"] {
+		t.Fatalf("pool state = %+v, want creator-owned member and buyer authorization", pool)
+	}
+	if snap := registry.Snapshot(root.poolID); !snap.Exists || snap.Routeable || snap.Generation != 6 {
+		t.Fatalf("candidate registry snapshot = %+v, want non-routeable generation 6", snap)
+	}
+	if !registry.BuyerAuthorized(root.poolID, "acct-allowed") {
+		t.Fatal("acct-allowed should be authorized on the creator-owned candidate pool")
+	}
+
+	rec := getCreator(t, handler, "creator-token-a", "/creator/trust-pools/pools", http.StatusOK)
+	if !strings.Contains(rec.Body.String(), root.poolID) {
+		t.Fatalf("creator pool list body=%s missing owned pool", rec.Body.String())
+	}
+	getCreator(t, handler, "creator-token-a", "/creator/trust-pools/pools/"+root.poolID, http.StatusOK)
+	getCreator(t, handler, "creator-token-a", "/creator/trust-pools/pools/"+root.poolID+"/health", http.StatusOK)
+	getCreator(t, handler, "creator-token-a", "/creator/trust-pools/pools/"+root.poolID+"/distribution", http.StatusOK)
+	getCreator(t, handler, "creator-token-a", "/creator/trust-pools/pools/"+root.poolID+"/audit", http.StatusOK)
+}
+
+func TestAdminHandler_CreatorSurfaceReloadRevokesCredentialAndCeilings(t *testing.T) {
+	t.Parallel()
+	store, err := trustpool.NewStore(openTrustPoolDB(t))
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+	handler := trustpool.NewAdminHandler(trustpool.AdminDeps{
+		Store:                            store,
+		Registry:                         trustpool.NewRegistry(),
+		OperatorKey:                      "operator-secret",
+		CreatorAdminCredentials:          creatorCredentials("creator-a", "creator-a-cred", "creator-token-a"),
+		CreatorAdminProviderIDs:          map[string][]string{"creator-a": {"provider-a"}},
+		CreatorAdminProviderDelegatedIDs: map[string][]string{"creator-a": {"provider-a"}},
+		CreatorAdminBuyerAccountIDs:      map[string][]string{"creator-a": {"acct-a"}},
+		CreatorProviderAdmitted:          admittedProviderIDs("provider-a"),
+	})
+	getCreator(t, handler, "creator-token-a", "/creator/trust-pools/pools", http.StatusOK)
+
+	reloader, ok := handler.(trustpool.CreatorAdminConfigReloader)
+	if !ok {
+		t.Fatal("admin handler does not implement creator admin config reloader")
+	}
+	reloader.SetCreatorAdminConfig(nil, nil, nil, nil)
+	getCreator(t, handler, "creator-token-a", "/creator/trust-pools/pools", http.StatusUnauthorized)
+
+	reloader.SetCreatorAdminConfig(
+		creatorCredentials("creator-a", "creator-a-cred-v2", "creator-token-b"),
+		map[string][]string{"creator-a": {"provider-b"}},
+		map[string][]string{"creator-a": {"provider-b"}},
+		map[string][]string{"creator-a": {"acct-b"}},
+	)
+	getCreator(t, handler, "creator-token-a", "/creator/trust-pools/pools", http.StatusUnauthorized)
+	getCreator(t, handler, "creator-token-b", "/creator/trust-pools/pools", http.StatusOK)
+}
+
+func TestAdminHandler_CreatorSurfaceRejectsCrossCreatorAndOperatorOnlyActions(t *testing.T) {
+	t.Parallel()
+	store, err := trustpool.NewStore(openTrustPoolDB(t))
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+	handler := trustpool.NewAdminHandler(trustpool.AdminDeps{
+		Store:                   store,
+		Registry:                trustpool.NewRegistry(),
+		OperatorKey:             "operator-secret",
+		CreatorAdminCredentials: append(creatorCredentials("creator-a", "creator-a-cred", "creator-token-a"), creatorCredentials("creator-b", "creator-b-cred", "creator-token-b")...),
+		CreatorAdminProviderIDs: map[string][]string{
+			"creator-a": {"provider-a"},
+			"creator-b": {"provider-b"},
+		},
+		CreatorAdminProviderDelegatedIDs: map[string][]string{
+			"creator-a": {"provider-a"},
+			"creator-b": {"provider-b"},
+		},
+		CreatorAdminBuyerAccountIDs: map[string][]string{
+			"creator-a": {"acct-a"},
+			"creator-b": {"acct-b"},
+		},
+		CreatorProviderAdmitted: admittedProviderIDs("provider-a", "provider-b"),
+	})
+	rootA := newRootFixture(t)
+	rootB := newRootFixture(t)
+	approveCreator(t, store, "creator-a", "approval-a", "approval-version-1", "candidate", time.Now().Add(24*time.Hour), trustpool.CreatorStatusEnabled)
+	approveCreator(t, store, "creator-b", "approval-b", "approval-version-1", "candidate", time.Now().Add(24*time.Hour), trustpool.CreatorStatusEnabled)
+	postCreatorEvent(t, handler, "creator-token-a", creatorPoolCreatedEvent(t, rootA, "approval-a"), "op-create-a", http.StatusAccepted)
+	postCreatorEvent(t, handler, "creator-token-b", creatorPoolCreatedEvent(t, rootB, "approval-b"), "op-create-b", http.StatusAccepted)
+
+	postCreatorEvent(t, handler, "creator-token-a", creatorPoolCreatedEvent(t, rootB, "approval-b"), "op-create-b", http.StatusNotFound)
+	postCreatorEvent(t, handler, "creator-token-a", trustpool.DurableEvent{
+		EventType:  trustpool.EventMemberAdmitted,
+		PoolID:     rootB.poolID,
+		ProviderID: "provider-b",
+	}, "op-member-b", http.StatusNotFound)
+	postCreatorEvent(t, handler, "creator-token-a", trustpool.DurableEvent{
+		EventType:  trustpool.EventMemberAdmitted,
+		PoolID:     rootA.poolID,
+		ProviderID: "provider-z",
+	}, "op-member-z", http.StatusForbidden)
+	getCreator(t, handler, "creator-token-a", "/creator/trust-pools/pools/"+rootB.poolID, http.StatusNotFound)
+	rec := getCreator(t, handler, "creator-token-a", "/creator/trust-pools/pools", http.StatusOK)
+	if strings.Contains(rec.Body.String(), rootB.poolID) {
+		t.Fatalf("creator-a pool list body=%s included creator-b pool", rec.Body.String())
+	}
+
+	postCreatorEvent(t, handler, "creator-token-a", trustpool.DurableEvent{
+		EventType:        trustpool.EventPoolCreated,
+		PoolID:           "pool-c",
+		CreatorAccountID: "creator-b",
+		ApprovalRecordID: "approval-a",
+	}, "op-create-mismatch", http.StatusForbidden)
+	postCreatorEvent(t, handler, "creator-token-a", trustpool.DurableEvent{
+		EventType: trustpool.EventLifecycleChanged,
+		PoolID:    rootA.poolID,
+		Lifecycle: trustpool.LifecycleActive,
+	}, "op-active", http.StatusConflict)
+	postCreatorLifecycle(t, handler, "creator-token-a", rootA.poolID, "op-active-2", trustpool.LifecycleActive, "creator cannot activate", http.StatusConflict)
+
+	for _, path := range []string{
+		"/creator/trust-pools/creators",
+		"/creator/trust-pools/pools/" + rootA.poolID + "/promote",
+		"/creator/trust-pools/pools/" + rootA.poolID + "/public-announcement",
+		"/creator/trust-pools/pools/" + rootA.poolID + "/reviewed-distribution-artifact",
+		"/creator/trust-pools/pools/" + rootA.poolID + "/signed-lifecycle",
+	} {
+		req := httptest.NewRequest(http.MethodPost, path, bytes.NewReader([]byte(`{}`)))
+		req.Header.Set("Authorization", "Bearer creator-token-a")
+		rec := httptest.NewRecorder()
+		handler.ServeHTTP(rec, req)
+		if rec.Code != http.StatusNotFound {
+			t.Fatalf("POST %s status=%d body=%s, want 404", path, rec.Code, rec.Body.String())
+		}
+		assertAdminSchemaVersion(t, rec)
+	}
+}
+
+func TestAdminHandler_CreatorSurfaceIdempotencyAndPolicyGuards(t *testing.T) {
+	t.Parallel()
+	providerIDs := map[string][]string{"creator-a": {"provider-a"}}
+	store, err := trustpool.NewStore(openTrustPoolDB(t))
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+	registry := trustpool.NewRegistry()
+	handler := trustpool.NewAdminHandler(trustpool.AdminDeps{
+		Store:                            store,
+		Registry:                         registry,
+		OperatorKey:                      "operator-secret",
+		CreatorAdminCredentials:          creatorCredentials("creator-a", "creator-a-cred", "creator-token-a"),
+		CreatorAdminProviderIDs:          providerIDs,
+		CreatorAdminProviderDelegatedIDs: map[string][]string{"creator-a": {"provider-a"}},
+		CreatorAdminBuyerAccountIDs:      map[string][]string{"creator-a": {"acct-allowed"}},
+		CreatorProviderAdmitted:          admittedProviderIDs("provider-a"),
+	})
+	reloader, ok := handler.(trustpool.CreatorAdminConfigReloader)
+	if !ok {
+		t.Fatal("admin handler does not implement creator admin config reloader")
+	}
+	root := newRootFixture(t)
+	approveCreator(t, store, "creator-a", "approval-v1", "approval-version-1", "candidate", time.Now().Add(24*time.Hour), trustpool.CreatorStatusEnabled)
+
+	create := creatorPoolCreatedEvent(t, root, "approval-v1")
+	postCreatorEvent(t, handler, "creator-token-a", create, "op-create", http.StatusAccepted)
+	postCreatorEvent(t, handler, "creator-token-a", create, "op-create", http.StatusAccepted)
+
+	nonce := postCreatorRootRegistrationNonce(t, handler, "creator-token-a", trustpool.RootRegistrationNonceIssue{
+		OperationID:            "op-nonce",
+		ApprovalRecordID:       "approval-v1",
+		CurrentApprovalVersion: "approval-version-1",
+		LaunchEnvironment:      "candidate",
+		ExpiresAtUTC:           testAdminTS(3600),
+	}, http.StatusCreated)
+	postCreatorEvent(t, handler, "creator-token-a", signedRootRegistrationForIssue(t, "op-root", testAdminTS(1), root.poolID, "creator-a", "approval-v1", nonce, root), "op-root", http.StatusAccepted)
+	postCreatorEvent(t, handler, "creator-token-a", signedManifest(t, "op-manifest", testAdminTS(2), root.poolID, 1, root), "op-manifest", http.StatusAccepted)
+
+	admit := trustpool.DurableEvent{
+		EventType:  trustpool.EventMemberAdmitted,
+		PoolID:     root.poolID,
+		ProviderID: "provider-a",
+	}
+	postCreatorEvent(t, handler, "creator-token-a", admit, "op-member", http.StatusAccepted)
+	reloader.SetCreatorAdminConfig(
+		creatorCredentials("creator-a", "creator-a-cred", "creator-token-a"),
+		map[string][]string{"creator-a": {}},
+		map[string][]string{"creator-a": {"provider-a"}},
+		map[string][]string{"creator-a": {"acct-allowed"}},
+	)
+	postCreatorEvent(t, handler, "creator-token-a", admit, "op-member", http.StatusAccepted)
+	postCreatorEvent(t, handler, "creator-token-a", trustpool.DurableEvent{
+		EventType:  trustpool.EventMemberAdmitted,
+		PoolID:     root.poolID,
+		ProviderID: "provider-a",
+	}, "op-member-again", http.StatusForbidden)
+	reloader.SetCreatorAdminConfig(
+		creatorCredentials("creator-a", "creator-a-cred", "creator-token-a"),
+		map[string][]string{"creator-a": {"provider-a"}},
+		map[string][]string{"creator-a": {"provider-a"}},
+		map[string][]string{"creator-a": {"acct-allowed"}},
+	)
+
+	postCreatorEvent(t, handler, "creator-token-a", trustpool.DurableEvent{
+		EventType:      trustpool.EventBuyerAuthorized,
+		PoolID:         root.poolID,
+		BuyerAccountID: "acct-allowed",
+	}, "op-buyer", http.StatusAccepted)
+	postCreatorEvent(t, handler, "creator-token-a", trustpool.DurableEvent{
+		EventType:      trustpool.EventBuyerAuthorized,
+		PoolID:         root.poolID,
+		BuyerAccountID: "acct-other",
+	}, "op-buyer-other", http.StatusForbidden)
+	postAdminPromote(t, handler, "operator-secret", root.poolID, "op-promote", http.StatusAccepted)
+	activeSnap := registry.Snapshot(root.poolID)
+	if !activeSnap.Routeable || !activeSnap.Members["provider-a"] || !registry.BuyerAuthorized(root.poolID, "acct-allowed") {
+		t.Fatalf("active registry snapshot = %+v buyer_authorized=%v, want routeable provider and buyer", activeSnap, registry.BuyerAuthorized(root.poolID, "acct-allowed"))
+	}
+	activeGeneration := activeSnap.Generation
+	reloader.SetCreatorAdminConfig(
+		creatorCredentials("creator-a", "creator-a-cred", "creator-token-a"),
+		map[string][]string{"creator-a": {}},
+		map[string][]string{"creator-a": {"provider-a"}},
+		map[string][]string{"creator-a": {"acct-allowed"}},
+	)
+	if snap := registry.Snapshot(root.poolID); snap.Members["provider-a"] || snap.Generation == activeGeneration {
+		t.Fatalf("provider ceiling snapshot = %+v, want provider removed and generation bumped from %d", snap, activeGeneration)
+	}
+	if _, ok := registry.BeginPoolDeliveryAtGeneration(root.poolID, activeGeneration); ok {
+		t.Fatal("BeginPoolDeliveryAtGeneration accepted stale pre-ceiling generation")
+	}
+	reloader.SetCreatorAdminConfig(
+		creatorCredentials("creator-a", "creator-a-cred", "creator-token-a"),
+		map[string][]string{"creator-a": {"provider-a"}},
+		map[string][]string{"creator-a": {"provider-a"}},
+		map[string][]string{"creator-a": {}},
+	)
+	if registry.BuyerAuthorized(root.poolID, "acct-allowed") {
+		t.Fatal("buyer ceiling removal left stale buyer authorization live")
+	}
+	if _, authorized := registry.AuthorizeAndSnapshot(root.poolID, "acct-allowed"); authorized {
+		t.Fatal("AuthorizeAndSnapshot accepted buyer removed by creator ceiling")
+	}
+	reloader.SetCreatorAdminConfig(nil, nil, nil, nil)
+	if snap := registry.Snapshot(root.poolID); snap.Members["provider-a"] {
+		t.Fatalf("credential removal snapshot = %+v, want provider denied by retained empty ceiling", snap)
+	}
+	if registry.BuyerAuthorized(root.poolID, "acct-allowed") {
+		t.Fatal("credential removal cleared ceiling and left stale buyer authorization live")
+	}
+	reloader.SetCreatorAdminConfig(
+		creatorCredentials("creator-a", "creator-a-cred", "creator-token-a"),
+		map[string][]string{"creator-a": {"provider-a"}},
+		map[string][]string{"creator-a": {"provider-a"}},
+		map[string][]string{"creator-a": {"acct-allowed"}},
+	)
+	postCreatorLifecycle(t, handler, "creator-token-a", root.poolID, "op-pause", trustpool.LifecyclePaused, "pause for maintenance", http.StatusAccepted)
+	postCreatorLifecycle(t, handler, "creator-token-a", root.poolID, "op-pause", trustpool.LifecyclePaused, "pause for maintenance", http.StatusAccepted)
+
+	approveCreator(t, store, "creator-a", "approval-v2", "approval-version-2", "candidate", time.Now().Add(24*time.Hour), trustpool.CreatorStatusSuspended)
+	postCreatorEvent(t, handler, "creator-token-a", trustpool.DurableEvent{
+		EventType:  trustpool.EventMemberRevoked,
+		PoolID:     root.poolID,
+		ProviderID: "provider-a",
+	}, "op-revoke-suspended", http.StatusConflict)
+	postCreatorEvent(t, handler, "creator-token-a", trustpool.DurableEvent{
+		EventType:      trustpool.EventBuyerAuthorizationRm,
+		PoolID:         root.poolID,
+		BuyerAccountID: "acct-allowed",
+	}, "op-buyer-rm-suspended", http.StatusConflict)
+	postCreatorLifecycle(t, handler, "creator-token-a", root.poolID, "op-retire-suspended", trustpool.LifecycleRetired, "retire while suspended", http.StatusConflict)
+
+	state, err := store.Reconstruct(t.Context())
+	if err != nil {
+		t.Fatalf("Reconstruct: %v", err)
+	}
+	pool := state.Pools[root.poolID]
+	if pool == nil || !pool.Members["provider-a"] || !pool.BuyerAccounts["acct-allowed"] || pool.Lifecycle != trustpool.LifecyclePaused {
+		t.Fatalf("pool after guarded mutations = %+v, want provider/buyer retained and paused", pool)
+	}
+}
+
+func TestAdminHandler_CreatorSurfaceRejectsBadEventsWithoutDisablingRegistry(t *testing.T) {
+	t.Parallel()
+	store, err := trustpool.NewStore(openTrustPoolDB(t))
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+	registry := trustpool.NewRegistry()
+	handler := trustpool.NewAdminHandler(trustpool.AdminDeps{
+		Store:                            store,
+		Registry:                         registry,
+		OperatorKey:                      "operator-secret",
+		CreatorAdminCredentials:          creatorCredentials("creator-a", "creator-a-cred", "creator-token-a"),
+		CreatorAdminProviderIDs:          map[string][]string{"creator-a": {"provider-a"}},
+		CreatorAdminProviderDelegatedIDs: map[string][]string{"creator-a": {"provider-a"}},
+		CreatorAdminBuyerAccountIDs:      map[string][]string{"creator-a": {"acct-allowed"}},
+		CreatorProviderAdmitted:          admittedProviderIDs("provider-a"),
+	})
+	root := newRootFixture(t)
+	approveCreator(t, store, "creator-a", "approval-v1", "approval-version-1", "candidate", time.Now().Add(24*time.Hour), trustpool.CreatorStatusEnabled)
+	create := creatorPoolCreatedEvent(t, root, "approval-v1")
+	postCreatorEvent(t, handler, "creator-token-a", create, "op-create", http.StatusAccepted)
+	if snap := registry.Snapshot(root.poolID); !snap.Exists {
+		t.Fatalf("registry snapshot before bad event = %+v, want existing pool", snap)
+	}
+
+	postCreatorEvent(t, handler, "creator-token-a", create, "op-duplicate-create", http.StatusBadRequest)
+	postCreatorEvent(t, handler, "creator-token-a", trustpool.DurableEvent{
+		EventType:        trustpool.EventPoolCreated,
+		PoolID:           "pool.with.dot",
+		ApprovalRecordID: "approval-v1",
+	}, "op-bad-pool-id", http.StatusBadRequest)
+	if snap := registry.Snapshot(root.poolID); !snap.Exists {
+		t.Fatalf("registry snapshot after rejected creator event = %+v, want still present", snap)
+	}
+}
+
+func TestAdminHandler_CreatorSurfaceRejectsAllowlistedUnadmittedProvider(t *testing.T) {
+	t.Parallel()
+	store, err := trustpool.NewStore(openTrustPoolDB(t))
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+	handler := trustpool.NewAdminHandler(trustpool.AdminDeps{
+		Store:                            store,
+		Registry:                         trustpool.NewRegistry(),
+		OperatorKey:                      "operator-secret",
+		CreatorAdminCredentials:          creatorCredentials("creator-a", "creator-a-cred", "creator-token-a"),
+		CreatorAdminProviderIDs:          map[string][]string{"creator-a": {"provider-a"}},
+		CreatorAdminProviderDelegatedIDs: map[string][]string{"creator-a": {"provider-a"}},
+		CreatorAdminBuyerAccountIDs:      map[string][]string{"creator-a": {"acct-allowed"}},
+		CreatorProviderAdmitted:          admittedProviderIDs(),
+	})
+	root := newRootFixture(t)
+	approveCreator(t, store, "creator-a", "approval-v1", "approval-version-1", "candidate", time.Now().Add(24*time.Hour), trustpool.CreatorStatusEnabled)
+	postCreatorEvent(t, handler, "creator-token-a", creatorPoolCreatedEvent(t, root, "approval-v1"), "op-create", http.StatusAccepted)
+	postCreatorEvent(t, handler, "creator-token-a", trustpool.DurableEvent{
+		EventType:  trustpool.EventMemberAdmitted,
+		PoolID:     root.poolID,
+		ProviderID: "provider-a",
+	}, "op-member-unadmitted", http.StatusForbidden)
+	state, err := store.Reconstruct(t.Context())
+	if err != nil {
+		t.Fatalf("Reconstruct: %v", err)
+	}
+	if pool := state.Pools[root.poolID]; pool == nil || pool.Members["provider-a"] {
+		t.Fatalf("pool after unadmitted provider admit = %+v, want provider not admitted", pool)
+	}
+}
+
+func TestAdminHandler_CreatorSurfaceRejectsUndelegatedProvider(t *testing.T) {
+	t.Parallel()
+	store, err := trustpool.NewStore(openTrustPoolDB(t))
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+	handler := trustpool.NewAdminHandler(trustpool.AdminDeps{
+		Store:                            store,
+		Registry:                         trustpool.NewRegistry(),
+		OperatorKey:                      "operator-secret",
+		CreatorAdminCredentials:          creatorCredentials("creator-a", "creator-a-cred", "creator-token-a"),
+		CreatorAdminProviderIDs:          map[string][]string{"creator-a": {"provider-a"}},
+		CreatorAdminProviderDelegatedIDs: map[string][]string{"creator-a": {}},
+		CreatorAdminBuyerAccountIDs:      map[string][]string{"creator-a": {"acct-allowed"}},
+		CreatorProviderAdmitted:          admittedProviderIDs("provider-a"),
+	})
+	root := newRootFixture(t)
+	approveCreator(t, store, "creator-a", "approval-v1", "approval-version-1", "candidate", time.Now().Add(24*time.Hour), trustpool.CreatorStatusEnabled)
+	postCreatorEvent(t, handler, "creator-token-a", creatorPoolCreatedEvent(t, root, "approval-v1"), "op-create", http.StatusAccepted)
+	postCreatorEvent(t, handler, "creator-token-a", trustpool.DurableEvent{
+		EventType:  trustpool.EventMemberAdmitted,
+		PoolID:     root.poolID,
+		ProviderID: "provider-a",
+	}, "op-member-undelegated", http.StatusForbidden)
+	state, err := store.Reconstruct(t.Context())
+	if err != nil {
+		t.Fatalf("Reconstruct: %v", err)
+	}
+	if pool := state.Pools[root.poolID]; pool == nil || pool.Members["provider-a"] {
+		t.Fatalf("pool after undelegated provider admit = %+v, want provider not admitted", pool)
+	}
+}
+
+func TestAdminHandler_CreatorSurfaceRejectsUnauthorized(t *testing.T) {
+	t.Parallel()
+	store, err := trustpool.NewStore(openTrustPoolDB(t))
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+	handler := trustpool.NewAdminHandler(trustpool.AdminDeps{
+		Store:                            store,
+		Registry:                         trustpool.NewRegistry(),
+		OperatorKey:                      "operator-secret",
+		CreatorAdminCredentials:          creatorCredentials("creator-a", "creator-a-cred", "creator-token-a"),
+		CreatorAdminProviderIDs:          map[string][]string{"creator-a": {"provider-a"}},
+		CreatorAdminProviderDelegatedIDs: map[string][]string{"creator-a": {"provider-a"}},
+		CreatorAdminBuyerAccountIDs:      map[string][]string{"creator-a": {"acct-allowed"}},
+		CreatorProviderAdmitted:          admittedProviderIDs("provider-a"),
+	})
+	req := httptest.NewRequest(http.MethodGet, "/creator/trust-pools/pools", nil)
+	req.Header.Set("Authorization", "Bearer wrong")
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("status = %d body=%s, want 401", rec.Code, rec.Body.String())
+	}
+	assertAdminSchemaVersion(t, rec)
+}
+
+func TestAdminHandler_CreatorSurfaceRejectsExpiredCredential(t *testing.T) {
+	t.Parallel()
+	store, err := trustpool.NewStore(openTrustPoolDB(t))
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+	handler := trustpool.NewAdminHandler(trustpool.AdminDeps{
+		Store:                            store,
+		Registry:                         trustpool.NewRegistry(),
+		OperatorKey:                      "operator-secret",
+		CreatorAdminCredentials:          expiredCreatorCredentials("creator-a", "creator-a-cred", "creator-token-a"),
+		CreatorAdminProviderIDs:          map[string][]string{"creator-a": {"provider-a"}},
+		CreatorAdminProviderDelegatedIDs: map[string][]string{"creator-a": {"provider-a"}},
+		CreatorAdminBuyerAccountIDs:      map[string][]string{"creator-a": {"acct-allowed"}},
+		CreatorProviderAdmitted:          admittedProviderIDs("provider-a"),
+	})
+	req := httptest.NewRequest(http.MethodGet, "/creator/trust-pools/pools", nil)
+	req.Header.Set("Authorization", "Bearer creator-token-a")
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("status = %d body=%s, want 401", rec.Code, rec.Body.String())
+	}
+	assertAdminSchemaVersion(t, rec)
+}
+
 func TestAdminHandler_ReplayChecksBeforeAppend(t *testing.T) {
 	t.Parallel()
 	store, err := trustpool.NewStore(openTrustPoolDB(t))
@@ -1552,6 +2069,126 @@ func postAdminRootRegistrationNonce(t *testing.T, h http.Handler, operatorKey st
 		t.Fatalf("POST root registration nonce status=%d body=%s, want %d", rec.Code, rec.Body.String(), want)
 	}
 	assertAdminSchemaVersion(t, rec)
+}
+
+func postCreatorEvent(t *testing.T, h http.Handler, creatorToken string, e trustpool.DurableEvent, operationID string, want int) *httptest.ResponseRecorder {
+	t.Helper()
+	body, err := json.Marshal(e)
+	if err != nil {
+		t.Fatalf("marshal creator event: %v", err)
+	}
+	req := httptest.NewRequest(http.MethodPost, "/creator/trust-pools/events", bytes.NewReader(body))
+	req.Header.Set("Authorization", "Bearer "+creatorToken)
+	req.Header.Set("Idempotency-Key", operationID)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	if rec.Code != want {
+		t.Fatalf("POST creator event %s status=%d body=%s, want %d", operationID, rec.Code, rec.Body.String(), want)
+	}
+	assertAdminSchemaVersion(t, rec)
+	return rec
+}
+
+func postCreatorRootRegistrationNonce(t *testing.T, h http.Handler, creatorToken string, issue trustpool.RootRegistrationNonceIssue, want int) trustpool.RootRegistrationNonceRecord {
+	t.Helper()
+	body, err := json.Marshal(issue)
+	if err != nil {
+		t.Fatalf("marshal creator root registration nonce issue: %v", err)
+	}
+	req := httptest.NewRequest(http.MethodPost, "/creator/trust-pools/root-registration-nonces", bytes.NewReader(body))
+	req.Header.Set("Authorization", "Bearer "+creatorToken)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	if rec.Code != want {
+		t.Fatalf("POST creator root registration nonce status=%d body=%s, want %d", rec.Code, rec.Body.String(), want)
+	}
+	assertAdminSchemaVersion(t, rec)
+	var decoded struct {
+		RootRegistrationNonce trustpool.RootRegistrationNonceRecord `json:"root_registration_nonce"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &decoded); err != nil {
+		t.Fatalf("decode creator root registration nonce: %v", err)
+	}
+	return decoded.RootRegistrationNonce
+}
+
+func postCreatorLifecycle(t *testing.T, h http.Handler, creatorToken, poolID, operationID, lifecycle, reason string, want int) *httptest.ResponseRecorder {
+	t.Helper()
+	body, err := json.Marshal(map[string]string{
+		"lifecycle": lifecycle,
+		"reason":    reason,
+	})
+	if err != nil {
+		t.Fatalf("marshal creator lifecycle request: %v", err)
+	}
+	req := httptest.NewRequest(http.MethodPost, "/creator/trust-pools/pools/"+poolID+"/lifecycle", bytes.NewReader(body))
+	req.Header.Set("Authorization", "Bearer "+creatorToken)
+	req.Header.Set("Idempotency-Key", operationID)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	if rec.Code != want {
+		t.Fatalf("POST creator lifecycle %s/%s status=%d body=%s, want %d", operationID, lifecycle, rec.Code, rec.Body.String(), want)
+	}
+	assertAdminSchemaVersion(t, rec)
+	return rec
+}
+
+func getCreator(t *testing.T, h http.Handler, creatorToken, path string, want int) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodGet, path, nil)
+	req.Header.Set("Authorization", "Bearer "+creatorToken)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	if rec.Code != want {
+		t.Fatalf("GET creator %s status=%d body=%s, want %d", path, rec.Code, rec.Body.String(), want)
+	}
+	assertAdminSchemaVersion(t, rec)
+	return rec
+}
+
+func admittedProviderIDs(ids ...string) func(string) bool {
+	allowed := make(map[string]bool, len(ids))
+	for _, id := range ids {
+		allowed[id] = true
+	}
+	return func(providerID string) bool {
+		return allowed[providerID]
+	}
+}
+
+func creatorCredentials(creatorID, credentialID, token string) []trustpool.CreatorAdminCredential {
+	now := time.Now().UTC()
+	return []trustpool.CreatorAdminCredential{{
+		CreatorAccountID: creatorID,
+		CredentialID:     credentialID,
+		Token:            token,
+		NotBeforeUTC:     now.Add(-time.Hour),
+		ExpiresAtUTC:     now.Add(24 * time.Hour),
+		Status:           trustpool.CreatorAdminCredentialStatusEnabled,
+	}}
+}
+
+func expiredCreatorCredentials(creatorID, credentialID, token string) []trustpool.CreatorAdminCredential {
+	now := time.Now().UTC()
+	return []trustpool.CreatorAdminCredential{{
+		CreatorAccountID: creatorID,
+		CredentialID:     credentialID,
+		Token:            token,
+		NotBeforeUTC:     now.Add(-2 * time.Hour),
+		ExpiresAtUTC:     now.Add(-time.Hour),
+		Status:           trustpool.CreatorAdminCredentialStatusEnabled,
+	}}
+}
+
+func creatorPoolCreatedEvent(t *testing.T, root rootFixture, approvalID string) trustpool.DurableEvent {
+	t.Helper()
+	snapshot, _ := manifestSnapshotWithPolicyCoreMutation(t, 1, root, nil)
+	return trustpool.DurableEvent{
+		EventType:        trustpool.EventPoolCreated,
+		PoolID:           root.poolID,
+		ApprovalRecordID: approvalID,
+		ManifestSnapshot: snapshot,
+	}
 }
 
 func postAdminPublicAnnouncement(t *testing.T, h http.Handler, operatorKey, poolID string, approval trustpool.PublicAnnouncementApproval, want int) *httptest.ResponseRecorder {

--- a/phase4-coordinator/internal/trustpool/durable_store.go
+++ b/phase4-coordinator/internal/trustpool/durable_store.go
@@ -13,6 +13,7 @@ import (
 	"time"
 	"unicode/utf8"
 
+	"github.com/augstar/macprovider-coordinator/internal/providerid"
 	"github.com/augstar/macprovider-coordinator/internal/sqliteutil"
 	"github.com/augstar/macprovider-coordinator/internal/versionfloor"
 )
@@ -62,6 +63,35 @@ func (e PromotionPreconditionError) Error() string {
 	return ErrPromotionPreconditionFailed.Error() + ": " + e.Reason
 }
 
+// ValidatePoolID keeps coordinator-created durable pools on the same selector
+// shape the gateway accepts at dispatch time. SPEC-042-R001 derives pool_id as
+// base64url(SHA256(identity core)[0:16]); length remains relaxed while older
+// opaque IDs exist, but punctuation, slash, whitespace, and non-ASCII are not
+// valid launch IDs.
+func ValidatePoolID(poolID string) error {
+	if poolID == "" {
+		return fmt.Errorf("pool_id is required")
+	}
+	for i := 0; i < len(poolID); i++ {
+		b := poolID[i]
+		if (b >= 'A' && b <= 'Z') || (b >= 'a' && b <= 'z') || (b >= '0' && b <= '9') || b == '-' || b == '_' {
+			continue
+		}
+		return fmt.Errorf("pool_id %q must be base64url (A-Za-z0-9-_)", poolID)
+	}
+	return nil
+}
+
+func ValidateCanonicalPoolID(poolID string) error {
+	if err := ValidatePoolID(poolID); err != nil {
+		return err
+	}
+	if len(poolID) != 22 {
+		return fmt.Errorf("pool_id %q must be 22 chars: base64url(SHA256(identity core)[0:16])", poolID)
+	}
+	return nil
+}
+
 func (e PromotionPreconditionError) Is(target error) bool {
 	return target == ErrPromotionPreconditionFailed
 }
@@ -73,23 +103,24 @@ func (e PromotionPreconditionError) Is(target error) bool {
 // the append-only event ledger so suspension can affect routeability without
 // appending a pool event.
 type DurableEvent struct {
-	OperationID        string    `json:"operation_id"`
-	TimestampUTC       time.Time `json:"timestamp_utc"`
-	EventType          string    `json:"event_type"`
-	PoolID             string    `json:"pool_id"`
-	CreatorAccountID   string    `json:"creator_account_id,omitempty"`
-	ApprovalRecordID   string    `json:"approval_record_id,omitempty"`
-	ProviderID         string    `json:"provider_id,omitempty"`
-	BuyerAccountID     string    `json:"buyer_account_id,omitempty"`
-	Lifecycle          string    `json:"lifecycle,omitempty"`
-	Reason             string    `json:"reason,omitempty"`
-	MinBinaryVersion   string    `json:"min_binary_version,omitempty"`
-	ManifestVersion    uint64    `json:"manifest_version,omitempty"`
-	ManifestCoreDigest string    `json:"manifest_core_digest,omitempty"`
-	ManifestSignature  string    `json:"manifest_signature,omitempty"`
-	ManifestSnapshot   string    `json:"manifest_snapshot,omitempty"`
-	SignedControl      string    `json:"signed_control,omitempty"`
-	ControlSignatures  string    `json:"control_signatures,omitempty"`
+	OperationID         string    `json:"operation_id"`
+	TimestampUTC        time.Time `json:"timestamp_utc"`
+	EventType           string    `json:"event_type"`
+	PoolID              string    `json:"pool_id"`
+	CreatorAccountID    string    `json:"creator_account_id,omitempty"`
+	CreatorCredentialID string    `json:"creator_credential_id,omitempty"`
+	ApprovalRecordID    string    `json:"approval_record_id,omitempty"`
+	ProviderID          string    `json:"provider_id,omitempty"`
+	BuyerAccountID      string    `json:"buyer_account_id,omitempty"`
+	Lifecycle           string    `json:"lifecycle,omitempty"`
+	Reason              string    `json:"reason,omitempty"`
+	MinBinaryVersion    string    `json:"min_binary_version,omitempty"`
+	ManifestVersion     uint64    `json:"manifest_version,omitempty"`
+	ManifestCoreDigest  string    `json:"manifest_core_digest,omitempty"`
+	ManifestSignature   string    `json:"manifest_signature,omitempty"`
+	ManifestSnapshot    string    `json:"manifest_snapshot,omitempty"`
+	SignedControl       string    `json:"signed_control,omitempty"`
+	ControlSignatures   string    `json:"control_signatures,omitempty"`
 
 	CurrentApprovalVersion             string `json:"current_approval_version,omitempty"`
 	RootIssuerKeyID                    string `json:"root_issuer_key_id,omitempty"`
@@ -303,12 +334,13 @@ CREATE TABLE IF NOT EXISTS trustpool_events (
 CREATE INDEX IF NOT EXISTS idx_trustpool_events_pool_id ON trustpool_events(pool_id, id);
 CREATE INDEX IF NOT EXISTS idx_trustpool_events_creator ON trustpool_events(creator_account_id, id);
 CREATE INDEX IF NOT EXISTS idx_trustpool_events_event_type ON trustpool_events(event_type, id);
-	CREATE TABLE IF NOT EXISTS trustpool_root_registration_nonces (
-	    nonce TEXT PRIMARY KEY,
-	    operation_id TEXT,
-	    creator_account_id TEXT NOT NULL,
-	    approval_record_id TEXT NOT NULL,
-	    current_approval_version TEXT NOT NULL,
+CREATE TABLE IF NOT EXISTS trustpool_root_registration_nonces (
+    nonce TEXT PRIMARY KEY,
+    operation_id TEXT,
+    creator_account_id TEXT NOT NULL,
+    creator_credential_id TEXT,
+    approval_record_id TEXT NOT NULL,
+    current_approval_version TEXT NOT NULL,
     launch_environment TEXT NOT NULL,
     purpose TEXT NOT NULL,
     expires_at_utc TEXT NOT NULL,
@@ -420,6 +452,9 @@ CREATE TABLE IF NOT EXISTS trustpool_creator_approvals (
 		return err
 	}
 	if err := s.ensureColumn(ctx, "trustpool_root_registration_nonces", "operation_id", "TEXT"); err != nil {
+		return err
+	}
+	if err := s.ensureColumn(ctx, "trustpool_root_registration_nonces", "creator_credential_id", "TEXT"); err != nil {
 		return err
 	}
 	if err := s.ensureColumn(ctx, "trustpool_events", "approval_record_id", "TEXT"); err != nil {
@@ -540,6 +575,7 @@ CREATE INDEX IF NOT EXISTS idx_trustpool_manifest_acceptances_operation ON trust
 type RootRegistrationNonceIssue struct {
 	OperationID            string    `json:"operation_id"`
 	CreatorAccountID       string    `json:"creator_account_id"`
+	CreatorCredentialID    string    `json:"creator_credential_id,omitempty"`
 	ApprovalRecordID       string    `json:"approval_record_id"`
 	CurrentApprovalVersion string    `json:"current_approval_version"`
 	LaunchEnvironment      string    `json:"launch_environment"`
@@ -551,6 +587,7 @@ type RootRegistrationNonceRecord struct {
 	Nonce                  string    `json:"nonce"`
 	OperationID            string    `json:"operation_id"`
 	CreatorAccountID       string    `json:"creator_account_id"`
+	CreatorCredentialID    string    `json:"creator_credential_id,omitempty"`
 	ApprovalRecordID       string    `json:"approval_record_id"`
 	CurrentApprovalVersion string    `json:"current_approval_version"`
 	LaunchEnvironment      string    `json:"launch_environment"`
@@ -1271,6 +1308,7 @@ func (s *Store) IssueRootRegistrationNonce(ctx context.Context, issue RootRegist
 	}
 	issue.OperationID = strings.TrimSpace(issue.OperationID)
 	issue.CreatorAccountID = strings.TrimSpace(issue.CreatorAccountID)
+	issue.CreatorCredentialID = strings.TrimSpace(issue.CreatorCredentialID)
 	issue.ApprovalRecordID = strings.TrimSpace(issue.ApprovalRecordID)
 	issue.CurrentApprovalVersion = strings.TrimSpace(issue.CurrentApprovalVersion)
 	issue.LaunchEnvironment = strings.TrimSpace(issue.LaunchEnvironment)
@@ -1284,24 +1322,7 @@ func (s *Store) IssueRootRegistrationNonce(ctx context.Context, issue RootRegist
 	}
 	now := time.Now().UTC()
 	expires := issue.ExpiresAtUTC.UTC()
-	if !now.Before(expires) {
-		return RootRegistrationNonceRecord{}, ErrRootRegistrationNonce
-	}
-	var nonceBytes [32]byte
-	if _, err := rand.Read(nonceBytes[:]); err != nil {
-		return RootRegistrationNonceRecord{}, err
-	}
-	record := RootRegistrationNonceRecord{
-		Nonce:                  base64.RawURLEncoding.EncodeToString(nonceBytes[:]),
-		OperationID:            issue.OperationID,
-		CreatorAccountID:       issue.CreatorAccountID,
-		ApprovalRecordID:       issue.ApprovalRecordID,
-		CurrentApprovalVersion: issue.CurrentApprovalVersion,
-		LaunchEnvironment:      issue.LaunchEnvironment,
-		Purpose:                issue.Purpose,
-		ExpiresAtUTC:           expires,
-		IssuedAtUTC:            now,
-	}
+	var record RootRegistrationNonceRecord
 	err := sqliteutil.Transact(ctx, s.db, func(ctx context.Context, conn *sql.Conn) error {
 		if err := verifyManifestAcceptanceStateFromQueryer(ctx, conn); err != nil {
 			return err
@@ -1317,6 +1338,9 @@ func (s *Store) IssueRootRegistrationNonce(ctx context.Context, issue RootRegist
 			}
 			return ErrConflictingOperationID
 		}
+		if !now.Before(expires) {
+			return ErrRootRegistrationNonce
+		}
 		if used, err := operationIDExists(ctx, conn, issue.OperationID); err != nil {
 			return err
 		} else if used {
@@ -1329,14 +1353,31 @@ func (s *Store) IssueRootRegistrationNonce(ctx context.Context, issue RootRegist
 		if !ok || !approval.ValidFor(issue.ApprovalRecordID, issue.CurrentApprovalVersion, issue.LaunchEnvironment, now) {
 			return ErrCreatorApprovalGate
 		}
+		var nonceBytes [32]byte
+		if _, err := rand.Read(nonceBytes[:]); err != nil {
+			return err
+		}
+		record = RootRegistrationNonceRecord{
+			Nonce:                  base64.RawURLEncoding.EncodeToString(nonceBytes[:]),
+			OperationID:            issue.OperationID,
+			CreatorAccountID:       issue.CreatorAccountID,
+			CreatorCredentialID:    issue.CreatorCredentialID,
+			ApprovalRecordID:       issue.ApprovalRecordID,
+			CurrentApprovalVersion: issue.CurrentApprovalVersion,
+			LaunchEnvironment:      issue.LaunchEnvironment,
+			Purpose:                issue.Purpose,
+			ExpiresAtUTC:           expires,
+			IssuedAtUTC:            now,
+		}
 		_, err = conn.ExecContext(ctx, `
 	INSERT INTO trustpool_root_registration_nonces (
-	    nonce, operation_id, creator_account_id, approval_record_id, current_approval_version,
+	    nonce, operation_id, creator_account_id, creator_credential_id, approval_record_id, current_approval_version,
 	    launch_environment, purpose, expires_at_utc, issued_at_utc
-	) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+	) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 			record.Nonce,
 			record.OperationID,
 			record.CreatorAccountID,
+			nullString(record.CreatorCredentialID),
 			record.ApprovalRecordID,
 			record.CurrentApprovalVersion,
 			record.LaunchEnvironment,
@@ -1371,15 +1412,17 @@ func rootRegistrationNonceByOperationID(ctx context.Context, q rootNonceQueryer,
 		return RootRegistrationNonceRecord{}, false, nil
 	}
 	var record RootRegistrationNonceRecord
+	var credentialID sql.NullString
 	var expiresRaw, issuedRaw string
 	err := q.QueryRowContext(ctx, `
-SELECT nonce, operation_id, creator_account_id, approval_record_id, current_approval_version,
+SELECT nonce, operation_id, creator_account_id, creator_credential_id, approval_record_id, current_approval_version,
        launch_environment, purpose, expires_at_utc, issued_at_utc
 FROM trustpool_root_registration_nonces
 WHERE operation_id = ?`, strings.TrimSpace(operationID)).Scan(
 		&record.Nonce,
 		&record.OperationID,
 		&record.CreatorAccountID,
+		&credentialID,
 		&record.ApprovalRecordID,
 		&record.CurrentApprovalVersion,
 		&record.LaunchEnvironment,
@@ -1401,6 +1444,9 @@ WHERE operation_id = ?`, strings.TrimSpace(operationID)).Scan(
 	if err != nil {
 		return RootRegistrationNonceRecord{}, false, ErrRootRegistrationNonce
 	}
+	if credentialID.Valid {
+		record.CreatorCredentialID = credentialID.String
+	}
 	record.ExpiresAtUTC = expiresAt.UTC()
 	record.IssuedAtUTC = issuedAt.UTC()
 	return record, true, nil
@@ -1409,6 +1455,7 @@ WHERE operation_id = ?`, strings.TrimSpace(operationID)).Scan(
 func rootRegistrationNonceMatchesIssue(record RootRegistrationNonceRecord, issue RootRegistrationNonceIssue) bool {
 	return record.OperationID == strings.TrimSpace(issue.OperationID) &&
 		record.CreatorAccountID == strings.TrimSpace(issue.CreatorAccountID) &&
+		record.CreatorCredentialID == strings.TrimSpace(issue.CreatorCredentialID) &&
 		record.ApprovalRecordID == strings.TrimSpace(issue.ApprovalRecordID) &&
 		record.CurrentApprovalVersion == strings.TrimSpace(issue.CurrentApprovalVersion) &&
 		record.LaunchEnvironment == strings.TrimSpace(issue.LaunchEnvironment) &&
@@ -1857,10 +1904,10 @@ func (s *Store) PromotePool(ctx context.Context, e DurableEvent) (*Reconstructed
 
 func consumeRootRegistrationNonce(ctx context.Context, conn *sql.Conn, e DurableEvent, acceptedAt time.Time) error {
 	var creatorAccountID, approvalRecordID, currentApprovalVersion, launchEnvironment, purpose, expiresRaw string
-	var consumedOperationID sql.NullString
+	var creatorCredentialID, consumedOperationID sql.NullString
 	err := conn.QueryRowContext(ctx, `
 SELECT creator_account_id, approval_record_id, current_approval_version, launch_environment,
-       purpose, expires_at_utc, consumed_operation_id
+       purpose, expires_at_utc, creator_credential_id, consumed_operation_id
 FROM trustpool_root_registration_nonces
 WHERE nonce = ?`, e.RootRegistrationNonce).Scan(
 		&creatorAccountID,
@@ -1869,6 +1916,7 @@ WHERE nonce = ?`, e.RootRegistrationNonce).Scan(
 		&launchEnvironment,
 		&purpose,
 		&expiresRaw,
+		&creatorCredentialID,
 		&consumedOperationID,
 	)
 	if errors.Is(err, sql.ErrNoRows) {
@@ -1882,6 +1930,7 @@ WHERE nonce = ?`, e.RootRegistrationNonce).Scan(
 		return ErrRootRegistrationNonce
 	}
 	if creatorAccountID != e.CreatorAccountID ||
+		(creatorCredentialID.Valid && creatorCredentialID.String != "" && creatorCredentialID.String != e.CreatorCredentialID) ||
 		approvalRecordID != e.ApprovalRecordID ||
 		currentApprovalVersion != e.CurrentApprovalVersion ||
 		launchEnvironment != e.LaunchEnvironment ||
@@ -2925,6 +2974,7 @@ func (s *ReconstructedState) RouteableSnapshots() []RouteableSnapshot {
 		sort.Strings(buyers)
 		out = append(out, RouteableSnapshot{
 			PoolID:            p.PoolID,
+			CreatorAccountID:  p.CreatorAccountID,
 			Members:           members,
 			Revoked:           revoked,
 			BuyerAccounts:     buyers,
@@ -2991,8 +3041,8 @@ func validateEvent(e DurableEvent) error {
 	if e.TimestampUTC.IsZero() {
 		return fmt.Errorf("timestamp_utc is required")
 	}
-	if e.PoolID == "" {
-		return fmt.Errorf("pool_id is required")
+	if err := ValidatePoolID(e.PoolID); err != nil {
+		return err
 	}
 	if err := ValidatePromiseClaimsText(e.PoolID); err != nil {
 		return err
@@ -3064,6 +3114,9 @@ func validateEvent(e DurableEvent) error {
 	case EventMemberAdmitted, EventMemberRevoked:
 		if e.ProviderID == "" {
 			return fmt.Errorf("%s requires provider_id", e.EventType)
+		}
+		if err := providerid.Validate(e.ProviderID); err != nil {
+			return err
 		}
 	case EventBuyerAuthorized, EventBuyerAuthorizationRm:
 		if e.BuyerAccountID == "" {

--- a/phase4-coordinator/internal/trustpool/durable_store_test.go
+++ b/phase4-coordinator/internal/trustpool/durable_store_test.go
@@ -249,6 +249,37 @@ func TestDurableStore_PromotePoolRejectsPausedPoolWhenPreflightRegresses(t *test
 	}
 }
 
+func TestDurableStore_RejectsMalformedMemberProviderID(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	store, err := trustpool.NewStore(openTrustPoolDB(t))
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+	ts := time.Unix(1800000610, 0).UTC()
+	root := newRootFixture(t)
+	appendTrustPoolEvents(t, ctx, store,
+		ev("op-create", ts, trustpool.EventPoolCreated, root.poolID, func(e *trustpool.DurableEvent) {
+			e.CreatorAccountID = "creator-a"
+			e.ApprovalRecordID = "approval-v1"
+		}),
+		signedRootRegistrationForIssue(t, "op-root", ts.Add(time.Second), root.poolID, "creator-a", "approval-v1", issueRootNonce(t, store, "creator-a", "approval-v1", ts.Add(time.Hour)), root),
+		signedManifest(t, "op-manifest", ts.Add(2*time.Second), root.poolID, 1, root),
+	)
+
+	for _, eventType := range []string{trustpool.EventMemberAdmitted, trustpool.EventMemberRevoked} {
+		eventType := eventType
+		t.Run(eventType, func(t *testing.T) {
+			_, _, _, err := store.AppendValidatedEvent(ctx, ev("op-"+eventType, ts.Add(3*time.Second), eventType, root.poolID, func(e *trustpool.DurableEvent) {
+				e.ProviderID = "bad/provider"
+			}))
+			if err == nil || !strings.Contains(err.Error(), `invalid provider_id "bad/provider"`) {
+				t.Fatalf("AppendValidatedEvent err=%v, want invalid provider_id", err)
+			}
+		})
+	}
+}
+
 func TestDurableStore_PersistsManifestAcceptanceProjection(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
@@ -982,8 +1013,26 @@ func TestDurableStore_RootRegistrationNonceIssuedConsumedAndServerTimed(t *testi
 		t.Fatalf("unissued nonce err=%v, want ErrRootRegistrationNonce", err)
 	}
 
-	nonce := issueRootNonce(t, store, "creator-a", "approval-v1", ts.Add(time.Hour))
+	nonce, err := store.IssueRootRegistrationNonce(ctx, trustpool.RootRegistrationNonceIssue{
+		OperationID:            "op-nonce",
+		CreatorAccountID:       "creator-a",
+		CreatorCredentialID:    "creator-a-cred",
+		ApprovalRecordID:       "approval-v1",
+		CurrentApprovalVersion: "approval-version-1",
+		LaunchEnvironment:      "candidate",
+		Purpose:                trustpool.RootRegistrationPurposeDefault,
+		ExpiresAtUTC:           ts.Add(time.Hour),
+	})
+	if err != nil {
+		t.Fatalf("IssueRootRegistrationNonce: %v", err)
+	}
+	mismatchedCredential := signedRootRegistrationForIssue(t, "op-root-credential-mismatch", ts.Add(1500*time.Millisecond), root.poolID, "creator-a", "approval-v1", nonce, root)
+	mismatchedCredential.CreatorCredentialID = "creator-a-cred-v2"
+	if _, _, _, err := store.AppendValidatedEvent(ctx, mismatchedCredential); !errors.Is(err, trustpool.ErrRootRegistrationNonce) {
+		t.Fatalf("credential-mismatched nonce err=%v, want ErrRootRegistrationNonce", err)
+	}
 	accepted := signedRootRegistrationForIssue(t, "op-root", ts.Add(2*time.Second), root.poolID, "creator-a", "approval-v1", nonce, root)
+	accepted.CreatorCredentialID = "creator-a-cred"
 	if _, _, _, err := store.AppendValidatedEvent(ctx, accepted); err != nil {
 		t.Fatalf("AppendValidatedEvent root: %v", err)
 	}
@@ -1032,11 +1081,12 @@ func TestDurableStore_RootRegistrationNonceIssueIsIdempotent(t *testing.T) {
 	issue := trustpool.RootRegistrationNonceIssue{
 		OperationID:            "op-nonce",
 		CreatorAccountID:       "creator-a",
+		CreatorCredentialID:    "creator-a-cred",
 		ApprovalRecordID:       "approval-v1",
 		CurrentApprovalVersion: "approval-version-1",
 		LaunchEnvironment:      "candidate",
 		Purpose:                trustpool.RootRegistrationPurposeDefault,
-		ExpiresAtUTC:           time.Now().Add(time.Hour).UTC().Truncate(time.Nanosecond),
+		ExpiresAtUTC:           time.Now().Add(250 * time.Millisecond).UTC().Truncate(time.Nanosecond),
 	}
 	first, err := store.IssueRootRegistrationNonce(ctx, issue)
 	if err != nil {
@@ -1046,8 +1096,26 @@ func TestDurableStore_RootRegistrationNonceIssueIsIdempotent(t *testing.T) {
 	if err != nil {
 		t.Fatalf("IssueRootRegistrationNonce retry: %v", err)
 	}
-	if second.Nonce != first.Nonce || !second.IssuedAtUTC.Equal(first.IssuedAtUTC) || second.OperationID != "op-nonce" {
+	if second.Nonce != first.Nonce || !second.IssuedAtUTC.Equal(first.IssuedAtUTC) || second.OperationID != "op-nonce" || second.CreatorCredentialID != "creator-a-cred" {
 		t.Fatalf("retry record = %+v, want original %+v", second, first)
+	}
+	time.Sleep(time.Until(issue.ExpiresAtUTC.Add(time.Millisecond)))
+	expiredRetry, err := store.IssueRootRegistrationNonce(ctx, issue)
+	if err != nil {
+		t.Fatalf("IssueRootRegistrationNonce expired retry: %v", err)
+	}
+	if expiredRetry.Nonce != first.Nonce || !expiredRetry.IssuedAtUTC.Equal(first.IssuedAtUTC) {
+		t.Fatalf("expired retry record = %+v, want original %+v", expiredRetry, first)
+	}
+	newExpired := issue
+	newExpired.OperationID = "op-nonce-new-expired"
+	if _, err := store.IssueRootRegistrationNonce(ctx, newExpired); !errors.Is(err, trustpool.ErrRootRegistrationNonce) {
+		t.Fatalf("new expired nonce issue err=%v, want ErrRootRegistrationNonce", err)
+	}
+	conflictingCredential := issue
+	conflictingCredential.CreatorCredentialID = "creator-a-cred-v2"
+	if _, err := store.IssueRootRegistrationNonce(ctx, conflictingCredential); !errors.Is(err, trustpool.ErrConflictingOperationID) {
+		t.Fatalf("conflicting credential nonce issue err=%v, want ErrConflictingOperationID", err)
 	}
 	conflict := issue
 	conflict.LaunchEnvironment = "production"

--- a/phase4-coordinator/internal/trustpool/refresher_test.go
+++ b/phase4-coordinator/internal/trustpool/refresher_test.go
@@ -20,7 +20,7 @@ func TestRefreshRegistryClosesExpiredCreatorGateAtSameRevision(t *testing.T) {
 	}
 	registry := trustpool.NewRegistry()
 	root := newRootFixture(t)
-	graceEndsAt := time.Now().Add(2 * time.Second).UTC()
+	graceEndsAt := time.Now().Add(30 * time.Second).UTC()
 	approveCreator(t, store, "creator-a", "approval-v1", "approval-version-1", "candidate", graceEndsAt, trustpool.CreatorStatusEnabled)
 	events := []trustpool.DurableEvent{
 		ev("op-create", testAdminTS(0), trustpool.EventPoolCreated, root.poolID, func(e *trustpool.DurableEvent) {
@@ -62,7 +62,7 @@ func TestRefreshRegistryClosesExpiredCreatorGateAtSameRevision(t *testing.T) {
 	}
 	initialGeneration := snap.Generation
 
-	time.Sleep(time.Until(graceEndsAt) + 50*time.Millisecond)
+	approveCreator(t, store, "creator-a", "approval-v1", "approval-version-1", "candidate", time.Now().Add(-time.Second), trustpool.CreatorStatusEnabled)
 	expired, err := trustpool.RefreshRegistry(ctx, store, registry)
 	if err != nil {
 		t.Fatalf("expired RefreshRegistry: %v", err)

--- a/phase4-coordinator/internal/trustpool/registry.go
+++ b/phase4-coordinator/internal/trustpool/registry.go
@@ -27,12 +27,18 @@ import (
 type Registry struct {
 	mu                 sync.RWMutex
 	pools              map[string]*poolState
+	providerCeilings   map[string]map[string]struct{}
+	delegatedCeilings  map[string]map[string]struct{}
+	buyerCeilings      map[string]map[string]struct{}
+	ceilingConfigured  bool
+	ceilingGeneration  uint64
 	revision           uint64
 	revocationWatchers map[string]map[chan struct{}]struct{}
 	activeDeliveries   map[string]uint64
 }
 
 type poolState struct {
+	creatorAccountID string
 	// members is the set of provider identities admitted to the pool
 	// (SPEC-042 R003). revoked is the durable per-pool identity blocklist:
 	// a revoked identity stays out even if re-added to members by mistake,
@@ -96,6 +102,7 @@ type Snapshot struct {
 // routing gate fails closed while preserving the pool's generation fence.
 type RouteableSnapshot struct {
 	PoolID            string
+	CreatorAccountID  string
 	Members           []string
 	Revoked           []string
 	BuyerAccounts     []string
@@ -124,6 +131,49 @@ func (r *Registry) ensure(poolID string) *poolState {
 		r.pools[poolID] = ps
 	}
 	return ps
+}
+
+// InitCreatorAdminCeilings seeds creator-owned allowlists during startup before
+// any request can hold a generation fence. Runtime reloads must use
+// SetCreatorAdminCeilings so tightening the first ceiling invalidates stale
+// pre-reload reservations.
+func (r *Registry) InitCreatorAdminCeilings(providerIDs, delegatedProviderIDs, buyerAccountIDs map[string][]string) {
+	r.setCreatorAdminCeilings(providerIDs, delegatedProviderIDs, buyerAccountIDs, false)
+}
+
+// SetCreatorAdminCeilings installs the current creator-owned allowlists as a
+// live routing ceiling. Durable pool events can grant membership/authorization,
+// but a configured creator ceiling must still include the provider or buyer at
+// route time; removing an id from config therefore cuts stale access without
+// waiting for a compensating durable event.
+func (r *Registry) SetCreatorAdminCeilings(providerIDs, delegatedProviderIDs, buyerAccountIDs map[string][]string) {
+	r.setCreatorAdminCeilings(providerIDs, delegatedProviderIDs, buyerAccountIDs, true)
+}
+
+func (r *Registry) setCreatorAdminCeilings(providerIDs, delegatedProviderIDs, buyerAccountIDs map[string][]string, bumpOnChange bool) {
+	if r == nil {
+		return
+	}
+	nextProviders := normalizeCreatorCeilings(providerIDs)
+	nextDelegatedProviders := normalizeCreatorCeilings(delegatedProviderIDs)
+	nextBuyers := normalizeCreatorCeilings(buyerAccountIDs)
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.ceilingConfigured {
+		nextProviders = preserveRemovedCreatorCeilingsAsDenyAll(r.providerCeilings, nextProviders)
+		nextDelegatedProviders = preserveRemovedCreatorCeilingsAsDenyAll(r.delegatedCeilings, nextDelegatedProviders)
+		nextBuyers = preserveRemovedCreatorCeilingsAsDenyAll(r.buyerCeilings, nextBuyers)
+	}
+	if creatorCeilingsEqual(r.providerCeilings, nextProviders) && creatorCeilingsEqual(r.delegatedCeilings, nextDelegatedProviders) && creatorCeilingsEqual(r.buyerCeilings, nextBuyers) {
+		return
+	}
+	r.providerCeilings = nextProviders
+	r.delegatedCeilings = nextDelegatedProviders
+	r.buyerCeilings = nextBuyers
+	r.ceilingConfigured = true
+	if bumpOnChange {
+		r.ceilingGeneration++
+	}
 }
 
 // AddPool registers a pool with no members (seed helper).
@@ -351,6 +401,7 @@ func (r *Registry) LoadRouteableSnapshot(s RouteableSnapshot) error {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	r.pools[s.PoolID] = &poolState{
+		creatorAccountID:  s.CreatorAccountID,
 		members:           members,
 		revoked:           revoked,
 		buyers:            buyers,
@@ -450,7 +501,7 @@ func (r *Registry) BeginPoolDeliveryAtGeneration(poolID string, generation uint6
 	r.mu.Lock()
 	ps := r.pools[poolID]
 	now := time.Now().UTC()
-	if ps == nil || !ps.routeableAt(now) || ps.generationAt(now) != generation {
+	if ps == nil || !ps.routeableAt(now) || ps.generationAt(now)+r.ceilingGeneration != generation {
 		r.mu.Unlock()
 		return func() {}, false
 	}
@@ -540,6 +591,7 @@ func (r *Registry) loadRouteableSnapshots(revision uint64, snapshots []Routeable
 			buyers[id] = struct{}{}
 		}
 		next[s.PoolID] = &poolState{
+			creatorAccountID:  s.CreatorAccountID,
 			members:           members,
 			revoked:           revoked,
 			buyers:            buyers,
@@ -644,6 +696,7 @@ func poolStatesEqual(a, b *poolState) bool {
 		return a == b
 	}
 	return a.routeable == b.routeable &&
+		a.creatorAccountID == b.creatorAccountID &&
 		a.minBinaryVersion == b.minBinaryVersion &&
 		stringSlicesEqual(a.modelAllowlist, b.modelAllowlist) &&
 		a.settlementMode == b.settlementMode &&
@@ -726,6 +779,12 @@ func (r *Registry) RouteableSnapshots() []RouteableSnapshot {
 			if _, revoked := ps.revoked[id]; revoked {
 				continue
 			}
+			if !r.providerAllowedByCreatorCeilingLocked(ps.creatorAccountID, id) {
+				continue
+			}
+			if !r.providerDelegatedByCreatorCeilingLocked(ps.creatorAccountID, id) {
+				continue
+			}
 			members = append(members, id)
 		}
 		revoked := make([]string, 0, len(ps.revoked))
@@ -734,6 +793,9 @@ func (r *Registry) RouteableSnapshots() []RouteableSnapshot {
 		}
 		buyers := make([]string, 0, len(ps.buyers))
 		for id := range ps.buyers {
+			if !r.buyerAllowedByCreatorCeilingLocked(ps.creatorAccountID, id) {
+				continue
+			}
 			buyers = append(buyers, id)
 		}
 		sort.Strings(members)
@@ -741,6 +803,7 @@ func (r *Registry) RouteableSnapshots() []RouteableSnapshot {
 		sort.Strings(buyers)
 		out = append(out, RouteableSnapshot{
 			PoolID:            poolID,
+			CreatorAccountID:  ps.creatorAccountID,
 			Members:           members,
 			Revoked:           revoked,
 			BuyerAccounts:     buyers,
@@ -754,6 +817,31 @@ func (r *Registry) RouteableSnapshots() []RouteableSnapshot {
 		})
 	}
 	return out
+}
+
+// BuyerAuthorizations returns a deterministic account -> pool_id projection for
+// gateway-side pool-scope checks. It is intentionally pool-opaque: the gateway
+// gets only credential scope, then the coordinator still enforces routeability,
+// membership, generation, and freshness on dispatch.
+func (r *Registry) BuyerAuthorizations() (map[string][]string, uint64) {
+	if r == nil {
+		return nil, 0
+	}
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	accounts := make(map[string][]string)
+	for poolID, ps := range r.pools {
+		for accountID := range ps.buyers {
+			if !r.buyerAllowedByCreatorCeilingLocked(ps.creatorAccountID, accountID) {
+				continue
+			}
+			accounts[accountID] = append(accounts[accountID], poolID)
+		}
+	}
+	for accountID := range accounts {
+		sort.Strings(accounts[accountID])
+	}
+	return accounts, r.revision + r.ceilingGeneration
 }
 
 // Snapshot returns a consistent read of the pool's non-revoked members, its
@@ -774,6 +862,12 @@ func (r *Registry) Snapshot(poolID string) Snapshot {
 		if _, revoked := ps.revoked[id]; revoked {
 			continue
 		}
+		if !r.providerAllowedByCreatorCeilingLocked(ps.creatorAccountID, id) {
+			continue
+		}
+		if !r.providerDelegatedByCreatorCeilingLocked(ps.creatorAccountID, id) {
+			continue
+		}
 		members[id] = true
 	}
 	return Snapshot{
@@ -784,7 +878,7 @@ func (r *Registry) Snapshot(poolID string) Snapshot {
 		ModelAllowlist:    cloneStringSlice(ps.modelAllowlist),
 		SettlementMode:    routeablePoolSettlementMode(ps.settlementMode),
 		Routeable:         ps.routeableAt(now),
-		Generation:        ps.generationAt(now),
+		Generation:        ps.generationAt(now) + r.ceilingGeneration,
 		Revision:          r.revision,
 		RouteableUntilUTC: ps.routeableUntilUTC,
 		RouteableExpired:  routeableExpired,
@@ -812,9 +906,18 @@ func (r *Registry) AuthorizeAndSnapshot(poolID, buyerAccountID string) (Snapshot
 		if _, revoked := ps.revoked[id]; revoked {
 			continue
 		}
+		if !r.providerAllowedByCreatorCeilingLocked(ps.creatorAccountID, id) {
+			continue
+		}
+		if !r.providerDelegatedByCreatorCeilingLocked(ps.creatorAccountID, id) {
+			continue
+		}
 		members[id] = true
 	}
 	_, authorized := ps.buyers[buyerAccountID]
+	if authorized && !r.buyerAllowedByCreatorCeilingLocked(ps.creatorAccountID, buyerAccountID) {
+		authorized = false
+	}
 	return Snapshot{
 		PoolID:            poolID,
 		Exists:            true,
@@ -823,7 +926,7 @@ func (r *Registry) AuthorizeAndSnapshot(poolID, buyerAccountID string) (Snapshot
 		ModelAllowlist:    cloneStringSlice(ps.modelAllowlist),
 		SettlementMode:    routeablePoolSettlementMode(ps.settlementMode),
 		Routeable:         ps.routeableAt(now),
-		Generation:        ps.generationAt(now),
+		Generation:        ps.generationAt(now) + r.ceilingGeneration,
 		Revision:          r.revision,
 		RouteableUntilUTC: ps.routeableUntilUTC,
 		RouteableExpired:  routeableExpired,
@@ -844,6 +947,9 @@ func (r *Registry) BuyerAuthorized(poolID, buyerAccountID string) bool {
 		return false
 	}
 	_, ok := ps.buyers[buyerAccountID]
+	if ok && !r.buyerAllowedByCreatorCeilingLocked(ps.creatorAccountID, buyerAccountID) {
+		return false
+	}
 	return ok
 }
 
@@ -852,7 +958,7 @@ func (r *Registry) Generation(poolID string) uint64 {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
 	if ps := r.pools[poolID]; ps != nil {
-		return ps.generationAt(time.Now().UTC())
+		return ps.generationAt(time.Now().UTC()) + r.ceilingGeneration
 	}
 	return 0
 }
@@ -879,4 +985,79 @@ func (ps *poolState) generationAt(now time.Time) uint64 {
 		return ps.generation + 1
 	}
 	return ps.generation
+}
+
+func normalizeCreatorCeilings(in map[string][]string) map[string]map[string]struct{} {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make(map[string]map[string]struct{}, len(in))
+	for creatorID, ids := range in {
+		creatorID = strings.TrimSpace(creatorID)
+		if creatorID == "" {
+			continue
+		}
+		set := make(map[string]struct{}, len(ids))
+		for _, id := range ids {
+			id = strings.TrimSpace(id)
+			if id == "" {
+				continue
+			}
+			set[id] = struct{}{}
+		}
+		out[creatorID] = set
+	}
+	return out
+}
+
+func creatorCeilingsEqual(a, b map[string]map[string]struct{}) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for creatorID, aset := range a {
+		bset := b[creatorID]
+		if !stringSetsEqual(aset, bset) {
+			return false
+		}
+	}
+	return true
+}
+
+func preserveRemovedCreatorCeilingsAsDenyAll(previous, next map[string]map[string]struct{}) map[string]map[string]struct{} {
+	if len(previous) == 0 {
+		return next
+	}
+	if next == nil {
+		next = make(map[string]map[string]struct{}, len(previous))
+	}
+	for creatorID := range previous {
+		if _, ok := next[creatorID]; !ok {
+			next[creatorID] = map[string]struct{}{}
+		}
+	}
+	return next
+}
+
+func (r *Registry) providerAllowedByCreatorCeilingLocked(creatorID, providerID string) bool {
+	return allowedByCreatorCeilingLocked(r.providerCeilings, creatorID, providerID)
+}
+
+func (r *Registry) providerDelegatedByCreatorCeilingLocked(creatorID, providerID string) bool {
+	return allowedByCreatorCeilingLocked(r.delegatedCeilings, creatorID, providerID)
+}
+
+func (r *Registry) buyerAllowedByCreatorCeilingLocked(creatorID, buyerAccountID string) bool {
+	return allowedByCreatorCeilingLocked(r.buyerCeilings, creatorID, buyerAccountID)
+}
+
+func allowedByCreatorCeilingLocked(ceilings map[string]map[string]struct{}, creatorID, id string) bool {
+	if len(ceilings) == 0 || creatorID == "" {
+		return true
+	}
+	allowed, configured := ceilings[creatorID]
+	if !configured {
+		return true
+	}
+	_, ok := allowed[id]
+	return ok
 }

--- a/phase4-coordinator/internal/trustpool/registry_test.go
+++ b/phase4-coordinator/internal/trustpool/registry_test.go
@@ -212,6 +212,81 @@ func TestBeginPoolDeliveryAtGenerationRequiresRouteableCurrentGeneration(t *test
 	}
 }
 
+func TestCreatorAdminCeilingFirstRuntimeInstallBumpsGeneration(t *testing.T) {
+	t.Parallel()
+	r := trustpool.NewRegistry()
+	if err := r.LoadRouteableSnapshotsAtRevision(1, []trustpool.RouteableSnapshot{{
+		PoolID:           "P",
+		CreatorAccountID: "creator-a",
+		Members:          []string{"provider-a"},
+		BuyerAccounts:    []string{"acct-a"},
+		SettlementMode:   "observe",
+		Routeable:        true,
+		Generation:       7,
+	}}); err != nil {
+		t.Fatalf("LoadRouteableSnapshotsAtRevision: %v", err)
+	}
+	staleGeneration := r.Snapshot("P").Generation
+	if staleGeneration != 7 {
+		t.Fatalf("initial generation=%d, want durable generation 7", staleGeneration)
+	}
+	r.SetCreatorAdminCeilings(
+		map[string][]string{"creator-a": {}},
+		map[string][]string{"creator-a": {"provider-a"}},
+		map[string][]string{"creator-a": {"acct-a"}},
+	)
+	snap := r.Snapshot("P")
+	if snap.Members["provider-a"] || snap.Generation <= staleGeneration {
+		t.Fatalf("post-ceiling snapshot=%+v, want provider removed and generation > %d", snap, staleGeneration)
+	}
+	if _, ok := r.BeginPoolDeliveryAtGeneration("P", staleGeneration); ok {
+		t.Fatal("BeginPoolDeliveryAtGeneration accepted generation captured before first runtime ceiling install")
+	}
+}
+
+func TestCreatorAdminDelegationCeilingRevocationBumpsGeneration(t *testing.T) {
+	t.Parallel()
+	r := trustpool.NewRegistry()
+	if err := r.LoadRouteableSnapshotsAtRevision(1, []trustpool.RouteableSnapshot{{
+		PoolID:           "P",
+		CreatorAccountID: "creator-a",
+		Members:          []string{"provider-a"},
+		BuyerAccounts:    []string{"acct-a"},
+		SettlementMode:   "observe",
+		Routeable:        true,
+		Generation:       7,
+	}}); err != nil {
+		t.Fatalf("LoadRouteableSnapshotsAtRevision: %v", err)
+	}
+	r.InitCreatorAdminCeilings(
+		map[string][]string{"creator-a": {"provider-a"}},
+		map[string][]string{"creator-a": {"provider-a"}},
+		map[string][]string{"creator-a": {"acct-a"}},
+	)
+	staleGeneration := r.Snapshot("P").Generation
+	if staleGeneration != 7 {
+		t.Fatalf("initial generation=%d, want durable generation 7", staleGeneration)
+	}
+
+	r.SetCreatorAdminCeilings(
+		map[string][]string{"creator-a": {"provider-a"}},
+		map[string][]string{"creator-a": {}},
+		map[string][]string{"creator-a": {"acct-a"}},
+	)
+
+	snap := r.Snapshot("P")
+	if snap.Members["provider-a"] || snap.Generation <= staleGeneration {
+		t.Fatalf("post-delegation-revocation snapshot=%+v, want provider removed and generation > %d", snap, staleGeneration)
+	}
+	authSnap, authorized := r.AuthorizeAndSnapshot("P", "acct-a")
+	if !authorized || authSnap.Members["provider-a"] || authSnap.Generation <= staleGeneration {
+		t.Fatalf("AuthorizeAndSnapshot=(%+v,%v), want buyer still authorized, provider removed, generation > %d", authSnap, authorized, staleGeneration)
+	}
+	if _, ok := r.BeginPoolDeliveryAtGeneration("P", staleGeneration); ok {
+		t.Fatal("BeginPoolDeliveryAtGeneration accepted generation captured before delegated-provider revocation")
+	}
+}
+
 func TestBeginPoolDeliveryAtGenerationRejectsExpiredRouteableSnapshot(t *testing.T) {
 	t.Parallel()
 	r := trustpool.NewRegistry()

--- a/phase5-gateway/internal/config/config.go
+++ b/phase5-gateway/internal/config/config.go
@@ -277,21 +277,26 @@ type FeaturesConfig struct {
 }
 
 // TrustedPoolsConfig is the SPEC-042 Layer 2 gateway feature. Default-off.
-// AccountPools binds the authorized-pool ceiling to a buyer credential at
+// AccountPools binds a static authorized-pool ceiling to a buyer credential at
 // account granularity (a key belongs to exactly one account, so this is a
 // safe superset-free binding until per-key pool scopes land). A request may
-// select only a pool present in its account's list; an account absent from
-// the map authorizes no pool (fail-closed).
+// select only a pool present in its account's static list unless
+// CoordinatorAuthorizes is enabled. CoordinatorAuthorizes is the explicit
+// SPEC-043 creator self-service mode where the gateway refreshes the
+// coordinator's service-token-protected buyer authorization projection,
+// evaluates that map locally, and the coordinator still enforces durable buyer
+// authorization at dispatch.
 type TrustedPoolsConfig struct {
-	Enabled      bool                `yaml:"enabled"`
-	AccountPools map[string][]string `yaml:"account_pools"`
+	Enabled               bool                `yaml:"enabled"`
+	CoordinatorAuthorizes bool                `yaml:"coordinator_authorizes"`
+	AccountPools          map[string][]string `yaml:"account_pools"`
 }
 
-// Authorizes reports whether accountID is configured to select poolID.
-// Fail-closed: empty inputs and accounts absent from account_pools authorize
-// nothing. This is a pure map lookup with no coordinator interaction, so it
-// runs before any capability roundtrip and cannot become an existence oracle
-// (SPEC-042-R010).
+// Authorizes reports whether static account_pools config allows accountID to
+// select poolID. Fail-closed: empty inputs and accounts absent from
+// account_pools authorize nothing. This is a pure map lookup with no
+// coordinator interaction, so static mode runs before any capability roundtrip
+// and cannot become an existence oracle (SPEC-042-R010).
 func (t TrustedPoolsConfig) Authorizes(accountID, poolID string) bool {
 	if accountID == "" || poolID == "" {
 		return false
@@ -898,12 +903,12 @@ func validateWalletSessionsConfig(c Config) error {
 
 // validateTrustedPoolsConfig enforces SPEC-042 gateway config hygiene. When
 // disabled (default) any account_pools content is inert and not validated.
-// When enabled, every account id and pool id MUST be non-empty and every pool
-// id MUST be safe to carry in the coordinator-bound X-MacProvider-Pool header
-// (1-128 bytes, no C0/DEL/C1 control bytes) — an id the coordinator's opaque
-// header sanitizer would reject decodes to empty there and would be routed as
-// GLOBAL, a silent pool->global spill (SPEC-042-R002 forbids that), so it is
-// rejected at config load instead.
+// When enabled with static account_pools, every account id and pool id MUST be
+// non-empty and every pool id MUST be safe to carry in the coordinator-bound
+// X-MacProvider-Pool header (1-128 bytes, no C0/DEL/C1 control bytes) — an id
+// the coordinator's opaque header sanitizer would reject decodes to empty there
+// and would be routed as GLOBAL, a silent pool->global spill (SPEC-042-R002
+// forbids that), so it is rejected at config load instead.
 func validateTrustedPoolsConfig(c Config) error {
 	tp := c.Features.TrustedPools
 	if !tp.Enabled {
@@ -920,22 +925,19 @@ func validateTrustedPoolsConfig(c Config) error {
 			if !PoolIDHeaderSafe(poolID) {
 				return fmt.Errorf("features.trusted_pools.account_pools[%q] pool id %q is not a valid header value (1-128 bytes, no control characters)", accountID, poolID)
 			}
-			if !poolIDBase64URLShape(poolID) {
-				return fmt.Errorf("features.trusted_pools.account_pools[%q] pool id %q must be base64url (A-Za-z0-9-_); SPEC-042-R001 derives pool_id as base64url(SHA256(...))", accountID, poolID)
+			if !PoolIDBase64URLShape(poolID) || !PoolIDCanonicalShape(poolID) {
+				return fmt.Errorf("features.trusted_pools.account_pools[%q] pool id %q must be 22-char base64url(SHA256(identity core)[0:16])", accountID, poolID)
 			}
 		}
 	}
 	return nil
 }
 
-// poolIDBase64URLShape rejects pool ids outside the base64url alphabet
+// PoolIDBase64URLShape rejects pool ids outside the base64url alphabet
 // (A-Za-z0-9-_). SPEC-042-R001 derives pool_id as base64url(SHA256(identity
 // core)[0:16]); a value with spaces, punctuation, or non-ASCII cannot be a
-// canonical pool_id even though it may be header-safe. Length is NOT pinned to
-// 22 chars yet because the R001 derivation is not implemented and ids are
-// currently opaque operator strings; tighten to the exact decoded length when
-// derivation lands.
-func poolIDBase64URLShape(v string) bool {
+// canonical pool_id even though it may be header-safe.
+func PoolIDBase64URLShape(v string) bool {
 	if v == "" {
 		return false
 	}
@@ -947,6 +949,12 @@ func poolIDBase64URLShape(v string) bool {
 		return false
 	}
 	return true
+}
+
+// PoolIDCanonicalShape pins the encoded length of
+// base64url(SHA256(identity core)[0:16]) without padding.
+func PoolIDCanonicalShape(v string) bool {
+	return len(v) == 22
 }
 
 // PoolIDHeaderSafe mirrors the coordinator's sanitizeOpaqueHeader byte rules

--- a/phase5-gateway/internal/config/trusted_pools_test.go
+++ b/phase5-gateway/internal/config/trusted_pools_test.go
@@ -2,25 +2,31 @@ package config
 
 import "testing"
 
+const (
+	testPoolA = "abcdefghijklmnopqrstuv"
+	testPoolB = "ABCDEFGHIJKLMNOPQRSTUV"
+	testPoolC = "0123456789abcdefghijkl"
+)
+
 func TestTrustedPoolsAuthorizes(t *testing.T) {
 	tp := TrustedPoolsConfig{
 		Enabled: true,
 		AccountPools: map[string][]string{
-			"acct_a": {"poolone", "pooltwo"},
-			"acct_b": {"poolthree"},
+			"acct_a": {testPoolA, testPoolB},
+			"acct_b": {testPoolC},
 		},
 	}
 	cases := []struct {
 		account, pool string
 		want          bool
 	}{
-		{"acct_a", "poolone", true},
-		{"acct_a", "pooltwo", true},
-		{"acct_a", "poolthree", false}, // not in acct_a's list (no cross-account)
-		{"acct_b", "poolthree", true},
-		{"acct_b", "poolone", false},
-		{"acct_unknown", "poolone", false}, // account absent -> fail closed
-		{"", "poolone", false},             // empty account
+		{"acct_a", testPoolA, true},
+		{"acct_a", testPoolB, true},
+		{"acct_a", testPoolC, false}, // not in acct_a's list (no cross-account)
+		{"acct_b", testPoolC, true},
+		{"acct_b", testPoolA, false},
+		{"acct_unknown", testPoolA, false}, // account absent -> fail closed
+		{"", testPoolA, false},             // empty account
 		{"acct_a", "", false},              // empty pool
 	}
 	for _, tc := range cases {
@@ -29,8 +35,26 @@ func TestTrustedPoolsAuthorizes(t *testing.T) {
 		}
 	}
 	// A nil-map config authorizes nothing.
-	if (TrustedPoolsConfig{Enabled: true}).Authorizes("acct_a", "poolone") {
+	if (TrustedPoolsConfig{Enabled: true}).Authorizes("acct_a", testPoolA) {
 		t.Error("nil AccountPools authorized a pool; want fail-closed")
+	}
+	if (TrustedPoolsConfig{Enabled: true, CoordinatorAuthorizes: true}).Authorizes("acct_a", testPoolA) {
+		t.Error("static Authorizes used coordinator_authorizes without account_pools scope")
+	}
+	if !(TrustedPoolsConfig{Enabled: true, CoordinatorAuthorizes: true, AccountPools: map[string][]string{"acct_a": {testPoolA}}}).Authorizes("acct_a", testPoolA) {
+		t.Error("static Authorizes rejected locally scoped account/pool pair")
+	}
+	if (TrustedPoolsConfig{Enabled: true, CoordinatorAuthorizes: true}).Authorizes("acct_a", "pool.one") {
+		t.Error("static Authorizes accepted a non-canonical pool id")
+	}
+	if (TrustedPoolsConfig{Enabled: true, CoordinatorAuthorizes: true}).Authorizes("acct_a", "poolone") {
+		t.Error("static Authorizes accepted a short non-derived pool id")
+	}
+	if (TrustedPoolsConfig{Enabled: true, CoordinatorAuthorizes: true}).Authorizes("", testPoolA) {
+		t.Error("static Authorizes accepted an empty account")
+	}
+	if (TrustedPoolsConfig{Enabled: true, CoordinatorAuthorizes: true}).Authorizes("acct_a", "") {
+		t.Error("static Authorizes accepted an empty pool")
 	}
 }
 
@@ -52,16 +76,23 @@ func TestValidateTrustedPoolsConfig(t *testing.T) {
 
 	t.Run("enabled accepts base64url ids", func(t *testing.T) {
 		cfg := base(TrustedPoolsConfig{Enabled: true, AccountPools: map[string][]string{
-			"acct_a": {"AbC-123_xyz"},
+			"acct_a": {testPoolA},
 		}})
 		if err := validateTrustedPoolsConfig(cfg); err != nil {
 			t.Fatalf("valid config rejected: %v", err)
 		}
 	})
 
+	t.Run("coordinator authorizes may boot with empty static map fail closed", func(t *testing.T) {
+		cfg := base(TrustedPoolsConfig{Enabled: true, CoordinatorAuthorizes: true})
+		if err := validateTrustedPoolsConfig(cfg); err != nil {
+			t.Fatalf("coordinator-authorized config rejected: %v", err)
+		}
+	})
+
 	t.Run("enabled rejects empty account id", func(t *testing.T) {
 		cfg := base(TrustedPoolsConfig{Enabled: true, AccountPools: map[string][]string{
-			"  ": {"poolone"},
+			"  ": {testPoolA},
 		}})
 		if err := validateTrustedPoolsConfig(cfg); err == nil {
 			t.Fatal("empty account id accepted")
@@ -102,10 +133,19 @@ func TestValidateTrustedPoolsConfig(t *testing.T) {
 			}
 		}
 	})
+
+	t.Run("enabled rejects base64url but short pool id", func(t *testing.T) {
+		cfg := base(TrustedPoolsConfig{Enabled: true, AccountPools: map[string][]string{
+			"acct_a": {"poolone"},
+		}})
+		if err := validateTrustedPoolsConfig(cfg); err == nil {
+			t.Fatal("short non-derived pool id accepted")
+		}
+	})
 }
 
 func TestPoolIDHeaderSafe(t *testing.T) {
-	if !PoolIDHeaderSafe("AbC-123_xyz") {
+	if !PoolIDHeaderSafe(testPoolA) {
 		t.Error("base64url id rejected")
 	}
 	if PoolIDHeaderSafe("") {

--- a/phase5-gateway/internal/router/disclosure.go
+++ b/phase5-gateway/internal/router/disclosure.go
@@ -158,9 +158,7 @@ type coordinatorRoutingMetadata struct {
 	// Pools is the SPEC-042-R010 positive pool-capability advertisement. An
 	// old coordinator omits it entirely, decoding to the zero value
 	// (Enabled=false) so the gateway fails pool dispatch closed.
-	Pools struct {
-		Enabled bool `json:"enabled"`
-	} `json:"pools"`
+	Pools coordinatorPoolsMetadata `json:"pools"`
 	Tier2 struct {
 		Phase     any `json:"phase"`
 		ModelHash struct {
@@ -171,6 +169,24 @@ type coordinatorRoutingMetadata struct {
 		Attestation      coordinatorAttestationMetadata      `json:"attestation"`
 		BehavioralSafety coordinatorBehavioralSafetyMetadata `json:"behavioral_safety"`
 	} `json:"tier2"`
+}
+
+type coordinatorPoolsMetadata struct {
+	Enabled                      bool                `json:"enabled"`
+	AccountPools                 map[string][]string `json:"account_pools"`
+	BuyerAuthorizationGeneration uint64              `json:"buyer_authorization_generation"`
+}
+
+func (m coordinatorPoolsMetadata) Authorizes(accountID, poolID string) bool {
+	if accountID == "" || poolID == "" {
+		return false
+	}
+	for _, p := range m.AccountPools[accountID] {
+		if p == poolID {
+			return true
+		}
+	}
+	return false
 }
 
 type coordinatorEncryptedLegMetadata struct {

--- a/phase5-gateway/internal/router/pool_selection.go
+++ b/phase5-gateway/internal/router/pool_selection.go
@@ -69,10 +69,13 @@ var (
 //   - (poolID, nil)    an authorized, capability-satisfied pool to emit;
 //   - ("", selErr)     a typed rejection.
 //
-// Ordering is load-bearing (see the design doc decision table): the credential
-// authorization check (rows 0-4) is pure and local, so an unauthorized caller
-// is rejected BEFORE any coordinator capability roundtrip (row 5) and its
-// latency cannot reveal whether the named pool exists (SPEC-042-R010).
+// Ordering is load-bearing (see the design doc decision table): static
+// account_pools mode rejects unauthorized callers BEFORE any coordinator
+// capability roundtrip (row 5), so latency cannot reveal whether the named pool
+// exists (SPEC-042-R010). SPEC-043 creator self-service deployments may opt
+// into coordinator_authorizes: the gateway refreshes the coordinator's internal
+// account->pool authorization projection, evaluates the selected pool locally
+// from that projection, and only then emits the internal authority header.
 func (s *Server) resolvePoolSelection(ctx context.Context, headers http.Header, accountID string, poolSelectionAllowed bool) (string, *poolSelectionError) {
 	tp := s.cfg.Features.TrustedPools
 
@@ -122,40 +125,41 @@ func (s *Server) resolvePoolSelection(ctx context.Context, headers http.Header, 
 		return "", errPoolUnavailable
 	}
 
-	// Row 4: credential authorization. Pure map lookup, no coordinator call.
-	// An account absent from the config, or a pool outside its authorized set,
-	// is denied with the generic non-disclosing code. The narrow-only
-	// invariant is structural: the selector can only pick a pool already in
-	// the ceiling, never widen it.
-	if !tp.Authorizes(accountID, selector) {
-		return "", errPoolUnavailable
-	}
-
 	// Defense-in-depth: never emit a header value the coordinator's opaque
 	// sanitizer would drop to empty (which it would then route as GLOBAL — a
 	// silent pool->global spill). Config validation already rejects such ids
 	// when the feature is enabled; this guards programmatically-built configs
 	// that bypass Validate().
-	if !config.PoolIDHeaderSafe(selector) {
+	if !config.PoolIDHeaderSafe(selector) || !config.PoolIDBase64URLShape(selector) || !config.PoolIDCanonicalShape(selector) {
 		return "", errPoolUnavailable
 	}
 
-	// Row 5: positive pool-capability negotiation. Refuse unless the assigned
-	// coordinator advertises pool support; an old coordinator omits the block
-	// (decoding to Enabled=false) and would otherwise route pool traffic from
-	// the global snapshot (SPEC-042-R010). This uses the FRESH fetch, not the
-	// 5s-cached sticky-hint metadata: a stale cached "true" would let pool
-	// dispatch continue for up to the TTL after a coordinator rollback/disable
-	// (trustPools==nil), and the rolled-back coordinator would ignore the
-	// header and route globally — a pool->global spill the positive handshake
-	// exists to prevent. A fresh check per pool-required dispatch shrinks that
-	// window to the in-request TOCTOU that no gateway-side check can remove;
-	// the coordinator's own member-only routing is the second line when it is
-	// pool-aware. Pool traffic is opt-in, so the extra roundtrip is acceptable.
-	if md, ok := s.coordinatorRoutingMetadataFresh(ctx); !ok || !md.Pools.Enabled {
+	// Row 4: credential authorization. Static mode is a pure local config lookup:
+	// an account absent from the config, or a pool outside its authorized set, is
+	// denied with the generic non-disclosing code before any coordinator
+	// capability call. Coordinator-authorized mode refreshes the service-token
+	// protected /internal/routing projection, then performs an equivalent local
+	// map lookup against creator-authored buyer scopes. The request-specific
+	// selector is never sent to the coordinator for authorization lookup.
+	if !tp.CoordinatorAuthorizes {
+		if !tp.Authorizes(accountID, selector) {
+			return "", errPoolUnavailable
+		}
+		if md, ok := s.coordinatorRoutingMetadataFresh(ctx); !ok || !md.Pools.Enabled {
+			return "", errPoolUnavailable
+		}
+		return selector, nil
+	}
+	md, ok := s.coordinatorRoutingMetadataFresh(ctx)
+	if !ok || !md.Pools.Enabled {
+		return "", errPoolUnavailable
+	}
+	if !tp.Authorizes(accountID, selector) && !md.Pools.Authorizes(accountID, selector) {
 		return "", errPoolUnavailable
 	}
 
-	// Row 6: authorized and capability-satisfied.
+	// Row 5: authorized and capability-satisfied. The fresh positive
+	// pool-capability negotiation happened above in both modes; an old coordinator
+	// omits pools.enabled and fails closed before this return.
 	return selector, nil
 }

--- a/phase5-gateway/internal/router/pool_selection_test.go
+++ b/phase5-gateway/internal/router/pool_selection_test.go
@@ -13,6 +13,7 @@ import (
 const poolChatOK = `{"id":"chatcmpl_1","object":"chat.completion","usage":{"prompt_tokens":3,"completion_tokens":4,"total_tokens":7},"choices":[{"index":0,"message":{"role":"assistant","content":"ok"},"finish_reason":"stop"}]}`
 
 const poolChatBody = `{"model":"llama","max_tokens":20,"messages":[{"role":"user","content":"hi"}]}`
+const testPoolID = "abcdefghijklmnopqrstuv"
 
 // poolCoordCapture records what the fake coordinator saw so a test can assert
 // whether the chat leg was dispatched, whether the capability endpoint was
@@ -27,7 +28,7 @@ type poolCoordCapture struct {
 // newPoolHarness wires a gateway over a fake coordinator. routingBody is the
 // JSON returned by /internal/routing (use "" for an old coordinator that has no
 // /internal/routing — it 404s). The TrustedPools feature is enabled with
-// acct_pool authorized for "poolone" unless mutate overrides it.
+// acct_pool authorized for testPoolID unless mutate overrides it.
 func newPoolHarness(t *testing.T, routingBody string, mutate func(*config.Config)) (http.Handler, *poolCoordCapture, string) {
 	t.Helper()
 	cap := &poolCoordCapture{}
@@ -56,7 +57,7 @@ func newPoolHarness(t *testing.T, routingBody string, mutate func(*config.Config
 		cfg.Coordinator.OperatorURL = "http://operator.test"
 		cfg.Features.TrustedPools = config.TrustedPoolsConfig{
 			Enabled:      true,
-			AccountPools: map[string][]string{"acct_pool": {"poolone"}},
+			AccountPools: map[string][]string{"acct_pool": {testPoolID}},
 		}
 		if mutate != nil {
 			mutate(cfg)
@@ -77,12 +78,83 @@ func selectHeader(pool string) map[string]string {
 // X-MacProvider-Pool set to the selected pool_id (SPEC-042-R002).
 func TestPoolSelection_AuthorizedAndCapable_EmitsHeader(t *testing.T) {
 	h, cap, key := newPoolHarness(t, `{"pools":{"enabled":true}}`, nil)
-	resp := postChat(t, h, key, poolChatBody, selectHeader("poolone"))
+	resp := postChat(t, h, key, poolChatBody, selectHeader(testPoolID))
 	if resp.Code != http.StatusOK {
 		t.Fatalf("status=%d body=%s", resp.Code, resp.Body.String())
 	}
-	if !cap.sawPool || cap.poolHeader != "poolone" {
-		t.Fatalf("forwarded pool header = %q (seen=%v), want poolone", cap.poolHeader, cap.sawPool)
+	if !cap.sawPool || cap.poolHeader != testPoolID {
+		t.Fatalf("forwarded pool header = %q (seen=%v), want %s", cap.poolHeader, cap.sawPool, testPoolID)
+	}
+}
+
+func TestPoolSelection_CoordinatorAuthorizesRejectsMissingGatewayScope(t *testing.T) {
+	h, cap, key := newPoolHarness(t, `{"pools":{"enabled":true}}`, func(cfg *config.Config) {
+		cfg.Features.TrustedPools.CoordinatorAuthorizes = true
+		cfg.Features.TrustedPools.AccountPools = map[string][]string{"acct_pool": {"pool.one"}}
+	})
+	resp := postChat(t, h, key, poolChatBody, selectHeader(testPoolID))
+	if resp.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status=%d body=%s, want 503", resp.Code, resp.Body.String())
+	}
+	if cap.sawPool || cap.chatHits != 0 {
+		t.Fatalf("coordinator-authorized missing-scope request forwarded=%v chatHits=%d, want no chat dispatch", cap.sawPool, cap.chatHits)
+	}
+	if cap.routingHits != 1 {
+		t.Fatalf("routingHits=%d, want refreshed coordinator authorization projection", cap.routingHits)
+	}
+}
+
+func TestPoolSelection_CoordinatorAuthorizes_EmitsHeaderWithStaticAccountPool(t *testing.T) {
+	h, cap, key := newPoolHarness(t, `{"pools":{"enabled":true}}`, func(cfg *config.Config) {
+		cfg.Features.TrustedPools.CoordinatorAuthorizes = true
+	})
+	resp := postChat(t, h, key, poolChatBody, selectHeader(testPoolID))
+	if resp.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s", resp.Code, resp.Body.String())
+	}
+	if !cap.sawPool || cap.poolHeader != testPoolID {
+		t.Fatalf("forwarded pool header = %q (seen=%v), want %s", cap.poolHeader, cap.sawPool, testPoolID)
+	}
+	if cap.routingHits != 1 {
+		t.Fatalf("routingHits=%d, want fresh capability check before coordinator-authorized pool dispatch", cap.routingHits)
+	}
+}
+
+func TestPoolSelection_CoordinatorAuthorizes_EmitsHeaderWithCoordinatorBuyerScope(t *testing.T) {
+	h, cap, key := newPoolHarness(t, `{"pools":{"enabled":true,"account_pools":{"acct_pool":["abcdefghijklmnopqrstuv"]},"buyer_authorization_generation":7}}`, func(cfg *config.Config) {
+		cfg.Features.TrustedPools.CoordinatorAuthorizes = true
+		cfg.Features.TrustedPools.AccountPools = nil
+	})
+	resp := postChat(t, h, key, poolChatBody, selectHeader(testPoolID))
+	if resp.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s", resp.Code, resp.Body.String())
+	}
+	if !cap.sawPool || cap.poolHeader != testPoolID {
+		t.Fatalf("forwarded pool header = %q (seen=%v), want %s", cap.poolHeader, cap.sawPool, testPoolID)
+	}
+	if cap.routingHits != 1 {
+		t.Fatalf("routingHits=%d, want refreshed coordinator authorization projection", cap.routingHits)
+	}
+}
+
+func TestPoolSelection_CoordinatorAuthorizesRejectsNonCanonicalPoolIDBeforeDispatch(t *testing.T) {
+	h, cap, key := newPoolHarness(t, `{"pools":{"enabled":true}}`, func(cfg *config.Config) {
+		cfg.Features.TrustedPools.CoordinatorAuthorizes = true
+		cfg.Features.TrustedPools.AccountPools = nil
+	})
+	resp := postChat(t, h, key, poolChatBody, selectHeader("pool.one"))
+	if resp.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status=%d body=%s, want 503", resp.Code, resp.Body.String())
+	}
+	assertErrorCode(t, resp.Body.String(), "pool_unavailable")
+	if cap.chatHits != 0 {
+		t.Fatalf("chat dispatched for non-canonical pool id (chatHits=%d)", cap.chatHits)
+	}
+	if cap.sawPool {
+		t.Fatalf("non-canonical pool request emitted pool header %q; want none", cap.poolHeader)
+	}
+	if cap.routingHits != 0 {
+		t.Fatalf("routingHits=%d, want non-canonical pool rejected before metadata refresh", cap.routingHits)
 	}
 }
 
@@ -93,7 +165,7 @@ func TestPoolSelection_AuthorizedAndCapable_EmitsHeader(t *testing.T) {
 func TestPoolSelection_CapabilityCheckedFreshEachRequest(t *testing.T) {
 	h, cap, key := newPoolHarness(t, `{"pools":{"enabled":true}}`, nil)
 	for i := 0; i < 2; i++ {
-		resp := postChat(t, h, key, poolChatBody, selectHeader("poolone"))
+		resp := postChat(t, h, key, poolChatBody, selectHeader(testPoolID))
 		if resp.Code != http.StatusOK {
 			t.Fatalf("request %d status=%d body=%s", i, resp.Code, resp.Body.String())
 		}
@@ -140,7 +212,7 @@ func TestPoolSelection_FeatureOffPoolNamed_FailsClosed(t *testing.T) {
 	h, cap, key := newPoolHarness(t, `{"pools":{"enabled":true}}`, func(cfg *config.Config) {
 		cfg.Features.TrustedPools.Enabled = false
 	})
-	resp := postChat(t, h, key, poolChatBody, selectHeader("poolone"))
+	resp := postChat(t, h, key, poolChatBody, selectHeader(testPoolID))
 	if resp.Code != http.StatusServiceUnavailable {
 		t.Fatalf("status=%d body=%s, want 503", resp.Code, resp.Body.String())
 	}
@@ -172,7 +244,7 @@ func TestPoolSelection_Unauthorized_FailsClosedWithoutCapabilityFetch(t *testing
 // (no pool->global spill under version skew). Chat NOT dispatched.
 func TestPoolSelection_CoordinatorDeclinesCapability_FailsClosed(t *testing.T) {
 	h, cap, key := newPoolHarness(t, `{"pools":{"enabled":false}}`, nil)
-	resp := postChat(t, h, key, poolChatBody, selectHeader("poolone"))
+	resp := postChat(t, h, key, poolChatBody, selectHeader(testPoolID))
 	if resp.Code != http.StatusServiceUnavailable {
 		t.Fatalf("status=%d body=%s, want 503", resp.Code, resp.Body.String())
 	}
@@ -185,7 +257,7 @@ func TestPoolSelection_CoordinatorDeclinesCapability_FailsClosed(t *testing.T) {
 // Old coordinator that omits the pools advertisement entirely -> fail closed.
 func TestPoolSelection_OldCoordinatorNoAdvertisement_FailsClosed(t *testing.T) {
 	h, cap, key := newPoolHarness(t, `{"sticky":{"enabled":false,"ttl_seconds":1800}}`, nil)
-	resp := postChat(t, h, key, poolChatBody, selectHeader("poolone"))
+	resp := postChat(t, h, key, poolChatBody, selectHeader(testPoolID))
 	if resp.Code != http.StatusServiceUnavailable {
 		t.Fatalf("status=%d body=%s, want 503", resp.Code, resp.Body.String())
 	}
@@ -203,7 +275,7 @@ func TestPoolSelection_ConflictingSources_Invalid(t *testing.T) {
 	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader(poolChatBody))
 	req.Header.Set("Authorization", "Bearer "+key)
 	req.Header.Set("Content-Type", "application/json")
-	req.Header.Add("X-MacProvider-Pool-Select", "poolone")
+	req.Header.Add("X-MacProvider-Pool-Select", testPoolID)
 	req.Header.Add("X-MacProvider-Pool-Select", "poolother")
 	resp := httptest.NewRecorder()
 	h.ServeHTTP(resp, req)
@@ -231,14 +303,14 @@ func TestPoolSelection_IdlessDedupeSeparatesPoolFromGlobal(t *testing.T) {
 		t.Fatalf("global status=%d body=%s", r1.Code, r1.Body.String())
 	}
 	// Second: identical body, now pool-selected, within the dedupe window.
-	r2 := postChat(t, h, key, poolChatBody, selectHeader("poolone"))
+	r2 := postChat(t, h, key, poolChatBody, selectHeader(testPoolID))
 	if r2.Code != http.StatusOK {
 		t.Fatalf("pool status=%d body=%s", r2.Code, r2.Body.String())
 	}
 	if cap.chatHits != 2 {
 		t.Fatalf("chatHits=%d, want 2 — the pool request replayed the global attempt via id-less dedupe", cap.chatHits)
 	}
-	if !cap.sawPool || cap.poolHeader != "poolone" {
+	if !cap.sawPool || cap.poolHeader != testPoolID {
 		t.Fatalf("pool request did not dispatch with X-MacProvider-Pool (dedupe replay masked it): seen=%v hdr=%q", cap.sawPool, cap.poolHeader)
 	}
 }
@@ -273,14 +345,14 @@ func TestPoolSelection_DemoCannotSelectPool(t *testing.T) {
 		// Even with the demo account explicitly authorized, row-0 must reject.
 		cfg.Features.TrustedPools = config.TrustedPoolsConfig{
 			Enabled:      true,
-			AccountPools: map[string][]string{"demo:1.2.3.4": {"poolone"}},
+			AccountPools: map[string][]string{"demo:1.2.3.4": {testPoolID}},
 		}
 	}, WithHTTPClient(client))
 	demo := issueDemoToken(t, h, "1.2.3.4")
 	resp := postChat(t, h, "", poolChatBody, map[string]string{
 		"X-Demo-Token":              demo,
 		"X-Real-IP":                 "1.2.3.4",
-		"X-MacProvider-Pool-Select": "poolone",
+		"X-MacProvider-Pool-Select": testPoolID,
 	})
 	if resp.Code != http.StatusServiceUnavailable {
 		t.Fatalf("demo pool selection status=%d body=%s, want 503", resp.Code, resp.Body.String())
@@ -336,7 +408,7 @@ func TestPoolSelection_WalletSessionCannotSelectPool(t *testing.T) {
 		cfg.Auth.WalletSessions.MetadataRequestsPerMinute = 100
 		cfg.Features.TrustedPools = config.TrustedPoolsConfig{
 			Enabled:      true,
-			AccountPools: map[string][]string{accountID: {"poolone"}},
+			AccountPools: map[string][]string{accountID: {testPoolID}},
 		}
 	}, WithHTTPClient(client))
 	apiKey := createAccountAndKey(t, store, cfg, accountID)
@@ -346,7 +418,7 @@ func TestPoolSelection_WalletSessionCannotSelectPool(t *testing.T) {
 		"018f7b7b-7c35-4cf0-8d4e-3f0ab1c2f929", []byte(poolChatBody))
 	// The selector header is NOT part of the wallet signed profile — appending
 	// it after signing is exactly the attack the row-0 gate blocks.
-	req.Header.Set("X-MacProvider-Pool-Select", "poolone")
+	req.Header.Set("X-MacProvider-Pool-Select", testPoolID)
 	resp := httptest.NewRecorder()
 	h.ServeHTTP(resp, req)
 

--- a/specs/CONFORMANCE.json
+++ b/specs/CONFORMANCE.json
@@ -6037,7 +6037,7 @@
         "phase4-coordinator/internal/trustpool/durable_store.go:func validateEvent",
         "phase4-coordinator/internal/trustpool/durable_store.go:func (s *Store) UpsertReviewedDistributionArtifact",
         "phase4-coordinator/internal/trustpool/durable_store.go:func (s *Store) UpsertPublicAnnouncementApproval",
-        "phase4-coordinator/internal/trustpool/admin_handler.go:func (h *adminHandler) writeMutationError",
+        "phase4-coordinator/internal/trustpool/admin_handler.go:func (h *adminHandler) writeMutationError(",
         "phase4-coordinator/internal/trustpool/admin_handler.go:func (h *adminHandler) handleReviewedDistributionArtifact",
         "phase4-coordinator/internal/trustpool/admin_handler.go:func (h *adminHandler) handlePublicAnnouncementApproval",
         "phase4-coordinator/internal/trustpool/status.go:func BuildStatusDocumentWithLiveProviders",


### PR DESCRIPTION
## Summary
- add the SPEC-043 creator admin API for owned Trusted Pool creation, nonce issuance, candidate/restrictive mutations, buyer authorization, and owned read surfaces
- require provider ceiling + operator delegation + serving-capable global admission for creator member admission, and enforce provider/buyer/delegation ceilings at route time with generation invalidation
- project coordinator buyer authorizations to the gateway for coordinator_authorizes mode while preserving canonical selector validation and static-mode fail-closed behavior

## Validation
- go test ./cmd/coordinator ./internal/config ./internal/trustpool ./internal/buyer -count=1
- go test ./internal/config ./internal/router -count=1
- go test -race ./internal/trustpool -count=1
- go test -race ./internal/config ./cmd/coordinator -count=1
- go test -race ./internal/router -run TestPoolSelection_ -count=1
- go vet ./cmd/coordinator ./internal/config ./internal/trustpool ./internal/buyer
- go vet ./internal/config ./internal/router
- python3 scripts/check_spec_governance.py --base-ref origin/main
- 3-lane final review: code 0 C/H/M, architecture 0 C/H/M, security verifier 0 C/H/M

## Notes
- Full gateway router race package was not used as a gate because it hung; targeted pool-selection race passed.

Closes #1053

SPEC-GOVERNANCE-DECLARATION-BEGIN
{
  "schema_version": "spec-pr-governance-v1",
  "behavior_change": "yes",
  "contract_change": "yes",
  "specs": ["SPEC-042", "SPEC-043"],
  "requirements": ["SPEC-042-R010", "SPEC-043-R002", "SPEC-043-R004", "SPEC-043-R005", "SPEC-043-R006", "SPEC-043-R007", "SPEC-043-R008", "SPEC-043-R009"],
  "authority_domains": ["pool-control-plane", "trusted-pool-creator-onboarding"],
  "arbitration": ["DECISION_REQUIRED"],
  "tests": ["go test ./cmd/coordinator ./internal/config ./internal/trustpool ./internal/buyer -count=1", "go test ./internal/config ./internal/router -count=1", "go test -race ./internal/trustpool -count=1", "go test -race ./internal/config ./cmd/coordinator -count=1", "go test -race ./internal/router -run TestPoolSelection_ -count=1", "go vet ./cmd/coordinator ./internal/config ./internal/trustpool ./internal/buyer", "go vet ./internal/config ./internal/router", "python3 scripts/check_spec_governance.py --base-ref origin/main"],
  "journeys": ["JOURNEY-TRUSTED-POOL-CREATOR-MVP"],
  "issue": "https://github.com/Augustas11/macprovider/issues/1053"
}
SPEC-GOVERNANCE-DECLARATION-END