### PR TITLE
Batch SPEC-045 signed promotion validation

### DIFF
--- a/.github/workflows/promote-signed-local-consumer-endpoint-journey.yml
+++ b/.github/workflows/promote-signed-local-consumer-endpoint-journey.yml
@@ -132,25 +132,10 @@ jobs:
           REQUIREMENT_IDS: ${{ steps.request.outputs.requirement_ids }}
         run: |
           set -euo pipefail
-          python3 - "$REQUIREMENT_IDS" "$ENVELOPE" <<'PY'
-          import subprocess
-          import sys
-
-          requirement_ids = [item for item in sys.argv[1].split(",") if item]
-          envelope = sys.argv[2]
-          for requirement_id in requirement_ids:
-              subprocess.run(
-                  [
-                      "python3",
-                      "scripts/promote-signed-journey-result.py",
-                      "--base-ref",
-                      "origin/main",
-                      requirement_id,
-                      envelope,
-                  ],
-                  check=True,
-              )
-          PY
+          python3 scripts/promote-signed-journey-result.py \
+            --base-ref origin/main \
+            --requirement-ids "$REQUIREMENT_IDS" \
+            "$ENVELOPE"
 
       - name: Verify promoted ledger and committed artifact set
         shell: bash

--- a/scripts/check_spec_governance.py
+++ b/scripts/check_spec_governance.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 import argparse
 import ast
 import base64
+import functools
 import hashlib
 import json
 import os
@@ -2930,6 +2931,7 @@ def _extract_python_mapping_fragment(text: str, selector: str) -> str | None:
     return fragments[0]
 
 
+@functools.lru_cache(maxsize=4096)
 def _selector_identifier(selector: str) -> str | None:
     stripped = selector.strip()
     for pattern in (
@@ -3164,6 +3166,7 @@ def _extract_mapping_fragment(text: str, selector: str, relative: str) -> str | 
     return _extract_text_anchor_fragment(text, selector)
 
 
+@functools.lru_cache(maxsize=4096)
 def _mapping_selector_resolves(text: str, selector: str, relative: str) -> str | None:
     return _extract_mapping_fragment(text, selector, relative)
 
@@ -3191,8 +3194,8 @@ def _commit_mapping_selector_matches_current(root: Path, commit: str, mapping: s
         current = current_path.read_text(encoding="utf-8")
     except (OSError, UnicodeDecodeError):
         return False
-    committed_fragment = _extract_mapping_fragment(committed, selector, relative)
-    current_fragment = _extract_mapping_fragment(current, selector, relative)
+    committed_fragment = _mapping_selector_resolves(committed, selector, relative)
+    current_fragment = _mapping_selector_resolves(current, selector, relative)
     return committed_fragment is not None and committed_fragment == current_fragment
 
 

--- a/scripts/promote-signed-journey-result.py
+++ b/scripts/promote-signed-journey-result.py
@@ -131,20 +131,7 @@ def upsert_evidence(existing: list[Any], record: dict[str, Any]) -> list[Any]:
     ] + [record]
 
 
-def promote(
-    root: Path,
-    requirement_id: str,
-    evidence_source: str,
-    *,
-    base_ref: str,
-    trusted_public_key_sha256: str = JOURNEY_RESULT_PUBLIC_KEY_SHA256,
-    openssl_bin: str | None = None,
-) -> None:
-    try:
-        trusted_openssl = resolve_trusted_openssl(openssl_bin)
-    except ValueError as exc:
-        die(str(exc))
-    evidence_source = require_relative_evidence_source(evidence_source)
+def load_conformance(root: Path) -> dict[str, Any]:
     conformance_path = root / "specs" / "CONFORMANCE.json"
     load_result = ValidationResult()
     conformance = _load_json(conformance_path, load_result)
@@ -157,12 +144,27 @@ def promote(
     requirements = conformance.get("requirements")
     if not isinstance(requirements, list):
         die("specs/CONFORMANCE.json requirements must be an array")
+    return conformance
 
+
+def promote_requirement_in_memory(
+    root: Path,
+    conformance: dict[str, Any],
+    requirement_id: str,
+    evidence_source: str,
+    *,
+    commit: str,
+    captured_at: str,
+    expires_at: str,
+    journey_id: str,
+    trusted_public_key_sha256: str,
+    trusted_openssl: str,
+) -> str:
+    requirements = conformance.get("requirements")
     matches = [item for item in requirements if isinstance(item, dict) and item.get("requirement_id") == requirement_id]
     if len(matches) != 1:
         die(f"requirement must exist exactly once: {requirement_id}")
     requirement = matches[0]
-    commit, captured_at, expires_at, journey_id = require_signed_metadata(root, evidence_source)
     if journey_id == TRUSTED_POOL_LAYER2_JOURNEY_ID:
         die(f"{TRUSTED_POOL_LAYER2_JOURNEY_ID} is evidence-only and cannot promote full SPEC-042 requirement rows")
     require_valid_signed_result(root, requirement, evidence_source, commit, trusted_public_key_sha256, trusted_openssl)
@@ -197,6 +199,43 @@ def promote(
 
     requirement.clear()
     requirement.update(updated)
+    return digest
+
+
+def promote_many(
+    root: Path,
+    requirement_ids: list[str],
+    evidence_source: str,
+    *,
+    base_ref: str,
+    trusted_public_key_sha256: str = JOURNEY_RESULT_PUBLIC_KEY_SHA256,
+    openssl_bin: str | None = None,
+) -> None:
+    if not requirement_ids:
+        die("at least one requirement ID is required")
+    try:
+        trusted_openssl = resolve_trusted_openssl(openssl_bin)
+    except ValueError as exc:
+        die(str(exc))
+    evidence_source = require_relative_evidence_source(evidence_source)
+    conformance_path = root / "specs" / "CONFORMANCE.json"
+    conformance = load_conformance(root)
+    commit, captured_at, expires_at, journey_id = require_signed_metadata(root, evidence_source)
+    promoted: list[tuple[str, str]] = []
+    for requirement_id in requirement_ids:
+        digest = promote_requirement_in_memory(
+            root,
+            conformance,
+            requirement_id,
+            evidence_source,
+            commit=commit,
+            captured_at=captured_at,
+            expires_at=expires_at,
+            journey_id=journey_id,
+            trusted_public_key_sha256=trusted_public_key_sha256,
+            trusted_openssl=trusted_openssl,
+        )
+        promoted.append((requirement_id, digest))
     result = validate_repository(root, base_ref, trusted_public_key_sha256, conformance_override=conformance, openssl_bin=trusted_openssl)
     if result.errors:
         for error in result.errors:
@@ -204,19 +243,50 @@ def promote(
         die("ledger promotion rejected")
 
     write_json_atomically(conformance_path, conformance)
-    print(f"promote-signed-journey-result: promoted {requirement_id} with sha256:{digest}")
+    for requirement_id, digest in promoted:
+        print(f"promote-signed-journey-result: promoted {requirement_id} with sha256:{digest}")
+
+
+def promote(
+    root: Path,
+    requirement_id: str,
+    evidence_source: str,
+    *,
+    base_ref: str,
+    trusted_public_key_sha256: str = JOURNEY_RESULT_PUBLIC_KEY_SHA256,
+    openssl_bin: str | None = None,
+) -> None:
+    promote_many(
+        root,
+        [requirement_id],
+        evidence_source,
+        base_ref=base_ref,
+        trusted_public_key_sha256=trusted_public_key_sha256,
+        openssl_bin=openssl_bin,
+    )
 
 
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("requirement_id")
-    parser.add_argument("evidence_source", help="signed journey-result path under journeys/evidence/")
+    parser.add_argument("--requirement-ids", default=None, help="comma-separated requirement IDs to promote in one validation pass")
+    parser.add_argument("requirement_id_or_evidence_source")
+    parser.add_argument("evidence_source", nargs="?", help="signed journey-result path under journeys/evidence/")
     parser.add_argument("--root", default=".", help="repository root")
     parser.add_argument("--base-ref", required=True, help="trusted base ref for governance validation")
     parser.add_argument("--openssl-bin", default=None, help="absolute path to trusted OpenSSL")
     args = parser.parse_args(argv)
 
-    promote(Path(args.root).resolve(), args.requirement_id, args.evidence_source, base_ref=args.base_ref, openssl_bin=args.openssl_bin)
+    if args.requirement_ids is None:
+        if args.evidence_source is None:
+            parser.error("evidence_source is required")
+        requirement_ids = [args.requirement_id_or_evidence_source]
+        evidence_source = args.evidence_source
+    else:
+        if args.evidence_source is not None:
+            parser.error("--requirement-ids expects a single evidence_source positional")
+        requirement_ids = [item for item in args.requirement_ids.split(",") if item]
+        evidence_source = args.requirement_id_or_evidence_source
+    promote_many(Path(args.root).resolve(), requirement_ids, evidence_source, base_ref=args.base_ref, openssl_bin=args.openssl_bin)
     return 0
 
 

--- a/scripts/test-signed-local-consumer-endpoint-journey-workflow.sh
+++ b/scripts/test-signed-local-consumer-endpoint-journey-workflow.sh
@@ -51,6 +51,7 @@ required_workflow = [
     "MACPROVIDER_ACCEPTANCE_SIGNING_KEY_PEM: ${{ secrets.MACPROVIDER_ACCEPTANCE_SIGNING_KEY_PEM }}",
     "scripts/sign-journey-result.py",
     "scripts/promote-signed-journey-result.py",
+    '--requirement-ids "$REQUIREMENT_IDS"',
     "scripts/check_spec_governance.py --base-ref origin/main",
     "actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a",
     "retention-days: 1",
@@ -111,12 +112,16 @@ if len(step_by_name) != len(step_names):
 preflight_name = "Preflight selector freshness before signing"
 posture_name = "Verify protected environment and repository posture"
 sign_name = "Sign journey-result payload"
-for required_step_name in (preflight_name, posture_name, sign_name):
+promote_name = "Promote only after signed validation"
+for required_step_name in (preflight_name, posture_name, sign_name, promote_name):
     if required_step_name not in step_by_name:
         raise SystemExit(f"workflow step is missing: {required_step_name}")
 preflight_step = "\n".join(step_by_name[preflight_name]["lines"])
 posture_step = "\n".join(step_by_name[posture_name]["lines"])
 sign_step = "\n".join(step_by_name[sign_name]["lines"])
+promote_step = "\n".join(step_by_name[promote_name]["lines"])
+if "for requirement_id in requirement_ids:" in promote_step:
+    raise SystemExit("workflow must batch requirement promotion into one governance validation pass")
 if step_names.index(preflight_name) > step_names.index(sign_name):
     raise SystemExit("preflight step must execute before the signing step")
 if "MACPROVIDER_ACCEPTANCE_SIGNING_KEY_PEM" in preflight_step:

--- a/scripts/tests/test_journey_result_tools.py
+++ b/scripts/tests/test_journey_result_tools.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import hashlib
+import copy
 import contextlib
 import io
 import json
@@ -237,6 +238,79 @@ class JourneyResultToolsTests(unittest.TestCase):
                 },
                 requirement["evidence"],
             )
+            self.assertEqual([], validate_repository(root, trusted_journey_result_public_key_sha256=trusted_hash).errors)
+
+    def test_promoter_batches_requirements_into_one_ledger_write(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            write_repository(root, base_repository())
+            commit = subprocess.check_output(["git", "rev-parse", "HEAD"], cwd=root, text=True).strip()
+            private_key = generate_acceptance_key(root)
+            trusted_hash = hashlib.sha256((root / "security" / "acceptance-candidate-signing-public.pem").read_bytes()).hexdigest()
+            conformance_path = root / "specs" / "CONFORMANCE.json"
+            conformance = json.loads(conformance_path.read_text(encoding="utf-8"))
+            first = conformance["requirements"][0]
+            first["journeys"] = ["JOURNEY-BOOT"]
+            second = copy.deepcopy(first)
+            second["requirement_id"] = "SPEC-001-R002"
+            conformance["requirements"].append(second)
+            conformance_path.write_text(json.dumps(conformance, indent=2) + "\n", encoding="utf-8")
+            payload_path = root / "journey-payload.json"
+            requirement_ids = ["SPEC-001-R001", "SPEC-001-R002"]
+            envelope = signed_journey_envelope(commit, requirement_ids=requirement_ids, signatures=[])
+            payload_path.write_text(json.dumps(envelope["signed"], indent=2) + "\n", encoding="utf-8")
+            evidence_path = root / "journeys" / "evidence" / "signed-result.json"
+            env = os.environ.copy()
+            env["MACPROVIDER_ACCEPTANCE_SIGNING_KEY_PEM"] = private_key
+            openssl = shutil.which("openssl")
+            if openssl is None:
+                raise unittest.SkipTest("openssl is required")
+            subprocess.run(
+                [
+                    sys.executable,
+                    str(SIGNER),
+                    "--root",
+                    str(root),
+                    "--input",
+                    str(payload_path),
+                    "--output",
+                    "journeys/evidence/signed-result.json",
+                    "--verified-at",
+                    "2026-01-01T00:00:01Z",
+                    "--openssl-bin",
+                    openssl,
+                ],
+                env=env,
+                check=True,
+                stdout=subprocess.DEVNULL,
+            )
+
+            promoter = load_promoter_module()
+            with contextlib.redirect_stdout(io.StringIO()):
+                promoter.promote_many(
+                    root,
+                    requirement_ids,
+                    "journeys/evidence/signed-result.json",
+                    base_ref="HEAD",
+                    trusted_public_key_sha256=trusted_hash,
+                )
+
+            conformance = json.loads(conformance_path.read_text(encoding="utf-8"))
+            rows = {item["requirement_id"]: item for item in conformance["requirements"]}
+            digest = hashlib.sha256(evidence_path.read_bytes()).hexdigest()
+            for requirement_id in requirement_ids:
+                requirement = rows[requirement_id]
+                self.assertEqual("conformant", requirement["state"])
+                self.assertIsNone(requirement["gap"])
+                self.assertIn(
+                    {
+                        "artifact": f"sha256:{digest}",
+                        "source": "journeys/evidence/signed-result.json",
+                        "captured_at": "2026-01-01",
+                        "expires_at": "2027-01-01",
+                    },
+                    requirement["evidence"],
+                )
             self.assertEqual([], validate_repository(root, trusted_journey_result_public_key_sha256=trusted_hash).errors)
 
     def test_promoter_restores_ledger_when_gate_rejects(self) -> None:


### PR DESCRIPTION
## Summary

- Batch signed journey-result promotion so a multi-requirement SPEC-045 envelope runs one governance validation after all in-memory row updates.
- Cache selector-fragment extraction within a governance process to avoid repeating identical expensive scans.
- Lock the protected SPEC-045 signer workflow to use `--requirement-ids` instead of a per-requirement subprocess loop.

## Validation

- `python3 -m unittest scripts.tests.test_journey_result_tools scripts.tests.test_spec_governance` -> 62 tests OK
- `bash scripts/test-signed-local-consumer-endpoint-journey-workflow.sh` -> OK
- `python3 scripts/check_spec_governance.py --base-ref origin/main` -> passed, real 51.17s / 51.22s observed
- `git diff --check` -> OK
- Native Codex audits: code/security/architecture all 0 C/H/M findings

SPEC-GOVERNANCE-DECLARATION-BEGIN
{
  "schema_version": "spec-pr-governance-v1",
  "behavior_change": "yes",
  "contract_change": "yes",
  "specs": ["SPEC-045"],
  "requirements": [
    "SPEC-045-R001",
    "SPEC-045-R002",
    "SPEC-045-R003",
    "SPEC-045-R004",
    "SPEC-045-R005",
    "SPEC-045-R006",
    "SPEC-045-R007",
    "SPEC-045-R008"
  ],
  "authority_domains": ["local-consumer-endpoint"],
  "arbitration": ["DECISION_REQUIRED"],
  "tests": [
    "scripts.tests.test_journey_result_tools",
    "scripts.tests.test_spec_governance",
    "scripts/test-signed-local-consumer-endpoint-journey-workflow.sh",
    "scripts/check_spec_governance.py --base-ref origin/main"
  ],
  "journeys": ["JOURNEY-LOCAL-CONSUMER-ENDPOINT"]
}
SPEC-GOVERNANCE-DECLARATION-END
