### PR TITLE
Fix SPEC-023 serve context capacity binding

### DIFF
--- a/phase3-binary/Sources/macprovider-cli/AutotuneCommand.swift
+++ b/phase3-binary/Sources/macprovider-cli/AutotuneCommand.swift
@@ -1189,6 +1189,8 @@ struct AutotuneCommand: AsyncParsableCommand {
                     thermalThrottleDetected: false,
                     artifactSHA256: artifact.sha256,
                     modelArtifactPath: artifact.modelArgument,
+                    modelConfigJSONData: artifact.configJSONData,
+                    modelConfigSHA256: artifact.configSHA256,
                     benchmarkID: "installed-only-\(modelKey)",
                     generatedAt: request.generatedAt,
                     candidateCatalogSHA256: catalogSHA,
@@ -1316,7 +1318,12 @@ struct AutotuneCommand: AsyncParsableCommand {
             knobs: WinningKnobs(
                 kvBits: nil,
                 maxBatch: hardware.recommendedMaxBatch,
-                maxContext: Self.spec023RecommendationProbeContext
+                maxContext: hardware.recommendedMaxContext(
+                    modelID: selectedRow.modelID,
+                    verifiedConfigJSONData: selectedBenchmark.modelConfigJSONData,
+                    verifiedConfigSHA256: selectedBenchmark.modelConfigSHA256,
+                    catalogMinRAMGB: selectedRow.minRAMGB
+                )
             ),
             tpsMedian: selected.tokensPerSecond,
             ttftP95MS: 0,

--- a/phase3-binary/Sources/macprovider-cli/AutotuneRecommend.swift
+++ b/phase3-binary/Sources/macprovider-cli/AutotuneRecommend.swift
@@ -167,6 +167,27 @@ struct AutotuneRecommendHardware: Equatable {
 }
 
 extension AutotuneRecommendHardware {
+    var recommendedMaxContext: Int {
+        ProviderCapacity.defaultContextTokens(forPhysicalMemoryGB: memoryGB)
+    }
+
+    func recommendedMaxContext(
+        modelID: String,
+        verifiedConfigJSONData: Data?,
+        verifiedConfigSHA256: String?,
+        catalogMinRAMGB: Int
+    ) -> Int {
+        let hardwareCap = recommendedMaxContext
+        let modelCap = AutotuneModelContextCap.safeMaxContextTokens(
+            hardwareMemoryGB: memoryGB,
+            catalogMinRAMGB: catalogMinRAMGB,
+            modelID: modelID,
+            verifiedConfigJSONData: verifiedConfigJSONData,
+            verifiedConfigSHA256: verifiedConfigSHA256
+        )
+        return min(hardwareCap, modelCap)
+    }
+
     var recommendedMaxBatch: Int {
         let normalizedChip = chip.lowercased()
         if normalizedChip.contains("ultra") {
@@ -182,6 +203,232 @@ extension AutotuneRecommendHardware {
             return 2
         }
         return 1
+    }
+}
+
+enum AutotuneModelContextCap {
+    static let failClosedMaxContext = 4_000
+
+    private static let minimumAcceptedContext = 4_000
+    private static let maximumAcceptedContext = 1_000_000
+    private static let bytesPerKVElement = 2
+    private static let memorySafetyFractionNumerator = 3
+    private static let memorySafetyFractionDenominator = 4
+    private static let bytesPerGB: UInt64 = 1_073_741_824
+
+    private static let configFieldPaths: [[String]] = [
+        ["max_position_embeddings"],
+        ["max_sequence_length"],
+        ["max_seq_len"],
+        ["seq_length"],
+        ["n_ctx"],
+        ["context_length"],
+        ["text_config", "max_position_embeddings"],
+        ["text_config", "max_sequence_length"],
+        ["text_config", "max_seq_len"],
+        ["text_config", "seq_length"],
+        ["text_config", "n_ctx"],
+        ["text_config", "context_length"]
+    ]
+
+    static func declaredMaxContextTokens(modelID: String, verifiedConfigJSONData: Data?) -> Int? {
+        if let verifiedConfigJSONData,
+           let value = declaredMaxContextTokens(configData: verifiedConfigJSONData)
+        {
+            return value
+        }
+        return knownDeclaredMaxContextTokens(modelID: modelID)
+    }
+
+    static func safeMaxContextTokens(
+        hardwareMemoryGB: Int,
+        catalogMinRAMGB: Int,
+        modelID: String,
+        verifiedConfigJSONData: Data?,
+        verifiedConfigSHA256: String?
+    ) -> Int {
+        let architecturalCap = declaredMaxContextTokens(
+            modelID: modelID,
+            verifiedConfigJSONData: verifiedConfigJSONData
+        ) ?? failClosedMaxContext
+        guard let verifiedConfigJSONData,
+              let verifiedConfigSHA256,
+              Data(SHA256.hash(data: verifiedConfigJSONData)).hexLower == verifiedConfigSHA256,
+              let memoryCap = memorySafeContextTokens(
+                configData: verifiedConfigJSONData,
+                hardwareMemoryGB: hardwareMemoryGB,
+                catalogMinRAMGB: catalogMinRAMGB
+              )
+        else {
+            return min(architecturalCap, failClosedMaxContext)
+        }
+        return min(architecturalCap, memoryCap)
+    }
+
+    static func declaredMaxContextTokens(configData: Data) -> Int? {
+        guard let root = strictConfigRoot(configData) else {
+            return nil
+        }
+
+        for path in configFieldPaths {
+            if let value = intValue(in: root, path: path), let saneValue = saneContext(value) {
+                return saneValue
+            }
+        }
+        return nil
+    }
+
+    static func memorySafeContextTokens(configData: Data, hardwareMemoryGB: Int, catalogMinRAMGB: Int) -> Int? {
+        guard let root = strictConfigRoot(configData),
+              let bytesPerToken = kvCacheBytesPerToken(in: root)
+        else {
+            return nil
+        }
+
+        let reservedGB = max(catalogMinRAMGB, 1) + AutotuneRecommendEngine.safetyMarginGB
+        let spareGB = max(0, hardwareMemoryGB - reservedGB)
+        let usableKVBytes = UInt64(spareGB) * bytesPerGB * UInt64(memorySafetyFractionNumerator)
+            / UInt64(memorySafetyFractionDenominator)
+        let additionalTokens = Int(min(
+            UInt64(maximumAcceptedContext - failClosedMaxContext),
+            usableKVBytes / UInt64(bytesPerToken)
+        ))
+        return saneContext(failClosedMaxContext + additionalTokens)
+    }
+
+    private static func strictConfigRoot(_ configData: Data) -> [String: Any]? {
+        guard (try? AutotuneStrictJSON.rejectDuplicateKeys(configData)) != nil,
+              let root = try? JSONSerialization.jsonObject(with: configData) as? [String: Any]
+        else {
+            return nil
+        }
+        return root
+    }
+
+    private static func intValue(in object: [String: Any], path: [String]) -> Int? {
+        var current: Any = object
+        for key in path {
+            guard let dictionary = current as? [String: Any],
+                  let next = dictionary[key]
+            else {
+                return nil
+            }
+            current = next
+        }
+        if type(of: current) == Bool.self {
+            return nil
+        }
+        if let number = current as? NSNumber,
+           CFGetTypeID(number) == CFBooleanGetTypeID() {
+            return nil
+        }
+        if let value = current as? Int {
+            return value
+        }
+        if let value = current as? Double,
+           value.isFinite,
+           value.rounded(.towardZero) == value,
+           let exact = Int(exactly: value) {
+            return exact
+        }
+        if let value = current as? String {
+            return Int(value)
+        }
+        return nil
+    }
+
+    private static func kvCacheBytesPerToken(in root: [String: Any]) -> Int? {
+        guard let layers = firstInt(in: root, paths: [
+            ["num_hidden_layers"],
+            ["n_layer"],
+            ["num_layers"],
+            ["text_config", "num_hidden_layers"],
+            ["text_config", "n_layer"],
+            ["text_config", "num_layers"]
+        ]),
+            let hiddenSize = firstInt(in: root, paths: [
+                ["hidden_size"],
+                ["n_embd"],
+                ["d_model"],
+                ["text_config", "hidden_size"],
+                ["text_config", "n_embd"],
+                ["text_config", "d_model"]
+            ]),
+            let attentionHeads = firstInt(in: root, paths: [
+                ["num_attention_heads"],
+                ["n_head"],
+                ["text_config", "num_attention_heads"],
+                ["text_config", "n_head"]
+            ])
+        else {
+            return nil
+        }
+        let kvHeads = firstInt(in: root, paths: [
+            ["num_key_value_heads"],
+            ["n_kv_head"],
+            ["text_config", "num_key_value_heads"],
+            ["text_config", "n_kv_head"]
+        ]) ?? attentionHeads
+        let headDim = firstInt(in: root, paths: [
+            ["head_dim"],
+            ["text_config", "head_dim"]
+        ]) ?? (hiddenSize / attentionHeads)
+
+        guard layers > 0, hiddenSize > 0, attentionHeads > 0, kvHeads > 0, headDim > 0,
+              hiddenSize % attentionHeads == 0
+        else {
+            return nil
+        }
+        guard let bytes = checkedProduct([
+            UInt64(layers),
+            UInt64(kvHeads),
+            UInt64(headDim),
+            2,
+            UInt64(bytesPerKVElement)
+        ])
+        else {
+            return nil
+        }
+        guard bytes > 0, bytes <= UInt64(Int.max) else {
+            return nil
+        }
+        return Int(bytes)
+    }
+
+    private static func checkedProduct(_ values: [UInt64]) -> UInt64? {
+        var product: UInt64 = 1
+        for value in values {
+            let multiplied = product.multipliedReportingOverflow(by: value)
+            guard multiplied.overflow == false else {
+                return nil
+            }
+            product = multiplied.partialValue
+        }
+        return product
+    }
+
+    private static func firstInt(in root: [String: Any], paths: [[String]]) -> Int? {
+        for path in paths {
+            if let value = intValue(in: root, path: path), value > 0 {
+                return value
+            }
+        }
+        return nil
+    }
+
+    private static func saneContext(_ value: Int) -> Int? {
+        guard value >= minimumAcceptedContext, value <= maximumAcceptedContext else {
+            return nil
+        }
+        return value
+    }
+
+    private static func knownDeclaredMaxContextTokens(modelID: String) -> Int? {
+        let normalized = modelID.lowercased()
+        if normalized.contains("qwen2.5-coder-32b") {
+            return 32_768
+        }
+        return nil
     }
 }
 
@@ -1645,6 +1892,8 @@ struct CandidateBenchmark: Equatable {
     var thermalThrottleDetected: Bool
     var artifactSHA256: String
     var modelArtifactPath: String
+    var modelConfigJSONData: Data? = nil
+    var modelConfigSHA256: String? = nil
     var benchmarkID: String?
     var generatedAt: Date
     var candidateCatalogSHA256: String
@@ -2748,6 +2997,8 @@ struct RecommendationFreshnessChecker {
 struct VerifiedModelArtifact {
     var modelArgument: String
     var sha256: String
+    var configJSONData: Data?
+    var configSHA256: String?
 }
 
 /// macOS kernel memory-pressure verdict, read in-process from
@@ -3226,13 +3477,18 @@ struct CachedModelArtifactResolver {
         else {
             throw AutotuneRecommendError.invalidArtifact("missing pinned snapshot \(row.modelID)@\(revision)")
         }
-        let actual = try ModelArtifactVerifier.canonicalArtifactHash(directory: snapshot)
-        guard actual == expected else {
+        let inspection = try ModelArtifactVerifier.inspectCanonicalArtifact(directory: snapshot)
+        guard inspection.sha256 == expected else {
             throw AutotuneRecommendError.invalidArtifact(
-                "hash mismatch \(row.modelID)@\(revision) expected=\(expected) actual=\(actual)"
+                "hash mismatch \(row.modelID)@\(revision) expected=\(expected) actual=\(inspection.sha256)"
             )
         }
-        return VerifiedModelArtifact(modelArgument: snapshot.path, sha256: actual)
+        return VerifiedModelArtifact(
+            modelArgument: snapshot.path,
+            sha256: inspection.sha256,
+            configJSONData: inspection.configJSONData,
+            configSHA256: inspection.configSHA256
+        )
     }
 
     func snapshotURL(modelID: String, revision: String) -> URL {
@@ -3566,6 +3822,8 @@ struct AutotuneRecommendationBenchmarker {
                         thermalThrottleDetected: safety.thermalThrottleDetected,
                         artifactSHA256: artifact.sha256,
                         modelArtifactPath: artifact.modelArgument,
+                        modelConfigJSONData: artifact.configJSONData,
+                        modelConfigSHA256: artifact.configSHA256,
                         benchmarkID: "spec-023-\(modelKey)-\(Int(generatedAt.timeIntervalSince1970))",
                         generatedAt: generatedAt,
                         candidateCatalogSHA256: request.candidateCatalogSHA256,
@@ -3701,7 +3959,17 @@ struct AutotuneRecommendationBenchmarker {
 }
 
 enum ModelArtifactVerifier {
+    struct CanonicalArtifactInspection {
+        var sha256: String
+        var configJSONData: Data?
+        var configSHA256: String?
+    }
+
     static func canonicalArtifactHash(directory: URL) throws -> String {
+        try inspectCanonicalArtifact(directory: directory).sha256
+    }
+
+    static func inspectCanonicalArtifact(directory: URL) throws -> CanonicalArtifactInspection {
         let fm = FileManager.default
         var root = stat()
         guard lstat(directory.path, &root) == 0,
@@ -3714,6 +3982,8 @@ enum ModelArtifactVerifier {
         }
         let basePath = directory.resolvingSymlinksInPath().path
         var entries: [(path: String, size: UInt64, sha: String)] = []
+        var configJSONData: Data?
+        var configSHA256: String?
         for case let url as URL in enumerator {
             let path = url.resolvingSymlinksInPath().path
             guard path.hasPrefix(basePath + "/") else {
@@ -3740,12 +4010,21 @@ enum ModelArtifactVerifier {
                 throw AutotuneRecommendError.invalidArtifact("hardlink \(rel)")
             }
             let data = try Data(contentsOf: url)
-            entries.append((rel, UInt64(data.count), Data(SHA256.hash(data: data)).hexLower))
+            let fileSHA256 = Data(SHA256.hash(data: data)).hexLower
+            if rel == "config.json" {
+                configJSONData = data
+                configSHA256 = fileSHA256
+            }
+            entries.append((rel, UInt64(data.count), fileSHA256))
         }
         let manifest = entries.sorted { $0.path < $1.path }
             .map { "\($0.path)\n\($0.size)\n\($0.sha)\n" }
             .joined()
-        return Data(SHA256.hash(data: Data(manifest.utf8))).hexLower
+        return CanonicalArtifactInspection(
+            sha256: Data(SHA256.hash(data: Data(manifest.utf8))).hexLower,
+            configJSONData: configJSONData,
+            configSHA256: configSHA256
+        )
     }
 }
 

--- a/phase3-binary/Sources/macprovider-cli/ModelsSubcommand.swift
+++ b/phase3-binary/Sources/macprovider-cli/ModelsSubcommand.swift
@@ -805,7 +805,7 @@ private func loadModelsConfig(
     )
 }
 
-private struct ParsedRecommendationAdoption {
+struct ParsedRecommendationAdoption {
     let targetModelID: String
     let core: RecommendationCore
     let donorMode: Bool
@@ -829,6 +829,7 @@ extension ModelsAdoptRecommendationCommand {
         } else {
             data = try Data(contentsOf: URL(fileURLWithPath: ConfigLoader.expandTilde(pathOrStdin)))
         }
+        try AutotuneStrictJSON.rejectDuplicateKeys(data)
         guard let root = try JSONSerialization.jsonObject(with: data) as? [String: Any],
               root["schema_version"] as? String == "autotune_recommend.v1",
               let generatedAt = root["generated_at"] as? String,
@@ -842,7 +843,7 @@ extension ModelsAdoptRecommendationCommand {
               let candidateCatalogVersion = inputs["candidate_catalog_version"] as? String,
               let hardware = root["hardware"] as? [String: Any],
               let hardwareChip = hardware["chip"] as? String,
-              let hardwareMemoryGB = hardware["memory_gb"] as? Int,
+              let hardwareMemoryGB = strictRecommendationInt(hardware["memory_gb"]),
               let hardwareBinaryVersion = hardware["binary_version"] as? String,
               let serveConfig = root["serve_config"] as? [String: Any],
               let warnings = root["warnings"] as? [String],
@@ -887,9 +888,9 @@ extension ModelsAdoptRecommendationCommand {
               !catalogVersion.isEmpty,
               let catalogHash = serveConfig["model_catalog_hash"] as? String,
               isLowerHex(catalogHash, count: 64),
-              let maxContext = serveConfig["max_context_override"] as? Int,
+              let maxContext = strictRecommendationInt(serveConfig["max_context_override"]),
               maxContext > 0,
-              let maxBatch = serveConfig["max_concurrency_override"] as? Int,
+              let maxBatch = strictRecommendationInt(serveConfig["max_concurrency_override"]),
               maxBatch > 0,
               let donorMode = serveConfig["donor_mode"] as? Bool
         else {
@@ -899,7 +900,8 @@ extension ModelsAdoptRecommendationCommand {
             .allSatisfy(isSafeConfigString) else {
             throw ValidationError("serve_config contains unsafe strings")
         }
-        if let value = serveConfig["kv_bits"], !(value is NSNull), !(value is Int) {
+        if let value = serveConfig["kv_bits"], !(value is NSNull),
+           strictRecommendationInt(value) == nil {
             throw ValidationError("serve_config.kv_bits is invalid")
         }
         for key in ["draft_model", "draft_model_artifact_sha256"] {
@@ -907,7 +909,7 @@ extension ModelsAdoptRecommendationCommand {
                 throw ValidationError("serve_config.\(key) is invalid")
             }
         }
-        let kvBits = serveConfig["kv_bits"] as? Int
+        let kvBits = strictRecommendationInt(serveConfig["kv_bits"])
         let core = RecommendationCore(
             model: recommendedModel,
             targetContext: maxContext,
@@ -939,6 +941,27 @@ extension ModelsAdoptRecommendationCommand {
             hardwareMemoryGB: hardwareMemoryGB,
             hardwareBinaryVersion: hardwareBinaryVersion
         )
+    }
+
+    private static func strictRecommendationInt(_ value: Any?) -> Int? {
+        guard let value, !(value is NSNull) else { return nil }
+        if type(of: value) == Bool.self {
+            return nil
+        }
+        if let number = value as? NSNumber,
+           CFGetTypeID(number) == CFBooleanGetTypeID() {
+            return nil
+        }
+        if let intValue = value as? Int {
+            return intValue
+        }
+        if let doubleValue = value as? Double,
+           doubleValue.isFinite,
+           doubleValue.rounded(.towardZero) == doubleValue,
+           let exact = Int(exactly: doubleValue) {
+            return exact
+        }
+        return nil
     }
 
     private static func isSafeConfigString(_ value: String) -> Bool {
@@ -984,6 +1007,33 @@ extension ModelsAdoptRecommendationCommand {
                 == URL(fileURLWithPath: recommendation.core.modelArtifactPath ?? "").standardizedFileURL,
               artifact.sha256 == recommendation.core.modelArtifactSHA256 else {
             throw ValidationError("recommendation artifact authority does not match the signed snapshot")
+        }
+        try validateSignedContextAuthority(recommendation: recommendation, row: row, artifact: artifact)
+    }
+
+    static func validateSignedContextAuthority(
+        recommendation: ParsedRecommendationAdoption,
+        row: CandidateCatalog.Row,
+        artifact: VerifiedModelArtifact
+    ) throws {
+        let hardware = AutotuneRecommendHardware(
+            machine: nil,
+            chip: recommendation.hardwareChip,
+            memoryGB: recommendation.hardwareMemoryGB,
+            bandwidthTier: BandwidthTier.derive(chip: recommendation.hardwareChip),
+            osVersion: "",
+            binaryVersion: recommendation.hardwareBinaryVersion,
+            diversificationID: "",
+            hardwareIdentityHash: ""
+        )
+        let expectedMaxContext = hardware.recommendedMaxContext(
+            modelID: row.modelID,
+            verifiedConfigJSONData: artifact.configJSONData,
+            verifiedConfigSHA256: artifact.configSHA256,
+            catalogMinRAMGB: row.minRAMGB
+        )
+        guard recommendation.core.knobs.maxContext == expectedMaxContext else {
+            throw ValidationError("recommendation context authority does not match the verified model config")
         }
     }
 

--- a/phase3-binary/Tests/macprovider-cliTests/AutotuneRecommendTests.swift
+++ b/phase3-binary/Tests/macprovider-cliTests/AutotuneRecommendTests.swift
@@ -439,13 +439,304 @@ final class AutotuneRecommendTests: XCTestCase {
         XCTAssertEqual(explanation["confidence"] as? String, "catalog_estimate")
     }
 
+    func testRecommendApplyServeConfigKeepsProbeContextAtSafetyMarginBoundary() throws {
+        var request = try makeRequest()
+        request.hardware = Self.hardware(chip: "Apple M5", memoryGB: 32, bandwidthTier: .c)
+        let result = AutotuneRecommendEngine().recommend(request)
+        let selected = try XCTUnwrap(result.selectedCandidate)
+        var benchmark = try XCTUnwrap(request.benchmarks[selected.catalogKey])
+        let row = try XCTUnwrap(request.candidateCatalog.rows[selected.catalogKey])
+        let snapshot = try tempDir()
+        Self.bindContextConfig(Self.contextConfigJSON(maxContext: 262_144), to: &benchmark)
+        benchmark.modelArtifactPath = snapshot.path
+        let configData = try XCTUnwrap(benchmark.modelConfigJSONData)
+        XCTAssertEqual(AutotuneModelContextCap.declaredMaxContextTokens(configData: configData), 262_144)
+        XCTAssertEqual(
+            AutotuneModelContextCap.memorySafeContextTokens(
+                configData: configData,
+                hardwareMemoryGB: request.hardware.memoryGB,
+                catalogMinRAMGB: row.minRAMGB
+            ),
+            AutotuneModelContextCap.failClosedMaxContext
+        )
+
+        let core = AutotuneCommand.recommendationCoreForConfig(
+            selected: selected,
+            selectedBenchmark: benchmark,
+            selectedRow: row,
+            catalogVersion: request.candidateCatalog.version,
+            catalogHash: request.candidateCatalogSHA256,
+            hardware: request.hardware
+        )
+        let root = try XCTUnwrap(JSONSerialization.jsonObject(with: Data(result.jsonString(serveConfig: core).utf8)) as? [String: Any])
+        let serveConfig = try XCTUnwrap(root["serve_config"] as? [String: Any])
+
+        XCTAssertEqual(core.targetContext, AutotuneCommand.spec023RecommendationProbeContext)
+        XCTAssertEqual(row.minRAMGB, request.hardware.memoryGB - AutotuneRecommendEngine.safetyMarginGB)
+        XCTAssertEqual(core.knobs.maxContext, AutotuneModelContextCap.failClosedMaxContext)
+        XCTAssertEqual(serveConfig["max_context_override"] as? Int, AutotuneModelContextCap.failClosedMaxContext)
+    }
+
+    func testRecommendApplyServeConfigRaisesQwenEightBContextOnThirtyTwoGBMac() throws {
+        var request = try makeRequest(modelKey: "qwen3-8b")
+        request.hardware = Self.hardware(chip: "Apple M5", memoryGB: 32, bandwidthTier: .c)
+        let result = AutotuneRecommendEngine().recommend(request)
+        let selected = try XCTUnwrap(result.selectedCandidate)
+        var benchmark = try XCTUnwrap(request.benchmarks[selected.catalogKey])
+        let row = try XCTUnwrap(request.candidateCatalog.rows[selected.catalogKey])
+        let snapshot = try tempDir()
+        Self.bindContextConfig(Self.contextConfigJSON(maxContext: 262_144), to: &benchmark)
+        benchmark.modelArtifactPath = snapshot.path
+
+        let core = AutotuneCommand.recommendationCoreForConfig(
+            selected: selected,
+            selectedBenchmark: benchmark,
+            selectedRow: row,
+            catalogVersion: request.candidateCatalog.version,
+            catalogHash: request.candidateCatalogSHA256,
+            hardware: request.hardware
+        )
+        let root = try XCTUnwrap(JSONSerialization.jsonObject(with: Data(result.jsonString(serveConfig: core).utf8)) as? [String: Any])
+        let serveConfig = try XCTUnwrap(root["serve_config"] as? [String: Any])
+
+        XCTAssertEqual(result.recommendedModel, "qwen3-8b")
+        XCTAssertEqual(row.minRAMGB, 12)
+        XCTAssertEqual(request.hardware.memoryGB - row.minRAMGB - AutotuneRecommendEngine.safetyMarginGB, 16)
+        XCTAssertEqual(core.targetContext, AutotuneCommand.spec023RecommendationProbeContext)
+        XCTAssertEqual(core.knobs.maxContext, 120_000)
+        XCTAssertEqual(serveConfig["max_context_override"] as? Int, 120_000)
+    }
+
+    func testRecommendApplyServeConfigClampsServeContextToModelConfig() throws {
+        var request = try makeRequest()
+        request.hardware = Self.hardware(chip: "Apple M4 Ultra", memoryGB: 256, bandwidthTier: .s)
+        let result = AutotuneRecommendEngine().recommend(request)
+        let selected = try XCTUnwrap(result.selectedCandidate)
+        var benchmark = try XCTUnwrap(request.benchmarks[selected.catalogKey])
+        let row = try XCTUnwrap(request.candidateCatalog.rows[selected.catalogKey])
+        let snapshot = try tempDir()
+        Self.bindContextConfig(Self.contextConfigJSON(maxContext: 32_768), to: &benchmark)
+        benchmark.modelArtifactPath = snapshot.path
+
+        let core = AutotuneCommand.recommendationCoreForConfig(
+            selected: selected,
+            selectedBenchmark: benchmark,
+            selectedRow: row,
+            catalogVersion: request.candidateCatalog.version,
+            catalogHash: request.candidateCatalogSHA256,
+            hardware: request.hardware
+        )
+        let root = try XCTUnwrap(JSONSerialization.jsonObject(with: Data(result.jsonString(serveConfig: core).utf8)) as? [String: Any])
+        let serveConfig = try XCTUnwrap(root["serve_config"] as? [String: Any])
+
+        XCTAssertEqual(core.targetContext, AutotuneCommand.spec023RecommendationProbeContext)
+        XCTAssertEqual(core.knobs.maxContext, 32_768)
+        XCTAssertEqual(serveConfig["max_context_override"] as? Int, 32_768)
+    }
+
+    func testRecommendApplyServeConfigFailsClosedForKnownModelWhenConfigMissing() throws {
+        let hardware = Self.hardware(chip: "Apple M3 Ultra", memoryGB: 512, bandwidthTier: .s)
+
+        XCTAssertEqual(
+            hardware.recommendedMaxContext(
+                modelID: "mlx-community/Qwen2.5-Coder-32B-Instruct-4bit",
+                verifiedConfigJSONData: nil,
+                verifiedConfigSHA256: nil,
+                catalogMinRAMGB: 48
+            ),
+            AutotuneModelContextCap.failClosedMaxContext
+        )
+    }
+
+    func testModelContextParserRejectsOutOfRangeDoubleWithoutTrapping() throws {
+        XCTAssertNil(
+            AutotuneModelContextCap.declaredMaxContextTokens(
+                configData: Data(#"{"max_position_embeddings":1e100}"#.utf8)
+            )
+        )
+    }
+
+    func testRecommendApplyServeConfigFailsClosedForOverflowingKVGeometry() throws {
+        let configData = Data(Self.contextConfigJSON(
+            maxContext: 262_144,
+            hiddenSize: 1_000_000_000,
+            attentionHeads: 1,
+            kvHeads: 1_000_000_000,
+            layers: 1_000_000_000
+        ).utf8)
+        let hardware = Self.hardware(chip: "Apple M4 Ultra", memoryGB: 512, bandwidthTier: .s)
+
+        XCTAssertEqual(
+            hardware.recommendedMaxContext(
+                modelID: "mlx-community/overflowing-geometry-4bit",
+                verifiedConfigJSONData: configData,
+                verifiedConfigSHA256: Self.sha256Hex(configData),
+                catalogMinRAMGB: 1
+            ),
+            AutotuneModelContextCap.failClosedMaxContext
+        )
+    }
+
+    func testRecommendApplyServeConfigFailsClosedForBooleanKVGeometry() throws {
+        let configData = Data(#"""
+        {
+          "max_position_embeddings": 262144,
+          "hidden_size": true,
+          "num_attention_heads": true,
+          "num_key_value_heads": true,
+          "num_hidden_layers": true
+        }
+        """#.utf8)
+        let hardware = Self.hardware(chip: "Apple M4 Ultra", memoryGB: 512, bandwidthTier: .s)
+
+        XCTAssertEqual(
+            hardware.recommendedMaxContext(
+                modelID: "mlx-community/boolean-geometry-4bit",
+                verifiedConfigJSONData: configData,
+                verifiedConfigSHA256: Self.sha256Hex(configData),
+                catalogMinRAMGB: 1
+            ),
+            AutotuneModelContextCap.failClosedMaxContext
+        )
+    }
+
+    func testRecommendApplyServeConfigFailsClosedForDuplicateTopLevelConfigKeys() throws {
+        let configData = Data(#"""
+        {
+          "max_position_embeddings": 32768,
+          "max_position_embeddings": 262144,
+          "hidden_size": 128,
+          "num_attention_heads": 4,
+          "num_key_value_heads": 1,
+          "num_hidden_layers": 1
+        }
+        """#.utf8)
+        let hardware = Self.hardware(chip: "Apple M4 Ultra", memoryGB: 512, bandwidthTier: .s)
+
+        XCTAssertNil(AutotuneModelContextCap.declaredMaxContextTokens(configData: configData))
+        XCTAssertEqual(
+            hardware.recommendedMaxContext(
+                modelID: "mlx-community/duplicate-top-level-config-4bit",
+                verifiedConfigJSONData: configData,
+                verifiedConfigSHA256: Self.sha256Hex(configData),
+                catalogMinRAMGB: 1
+            ),
+            AutotuneModelContextCap.failClosedMaxContext
+        )
+    }
+
+    func testRecommendApplyServeConfigFailsClosedForDuplicateNestedConfigKeys() throws {
+        let configData = Data(#"""
+        {
+          "max_position_embeddings": 262144,
+          "hidden_size": 128,
+          "num_attention_heads": 4,
+          "num_key_value_heads": 1,
+          "text_config": {
+            "num_hidden_layers": 1,
+            "num_hidden_layers": 2
+          }
+        }
+        """#.utf8)
+        let hardware = Self.hardware(chip: "Apple M4 Ultra", memoryGB: 512, bandwidthTier: .s)
+
+        XCTAssertNil(
+            AutotuneModelContextCap.memorySafeContextTokens(
+                configData: configData,
+                hardwareMemoryGB: hardware.memoryGB,
+                catalogMinRAMGB: 1
+            )
+        )
+        XCTAssertEqual(
+            hardware.recommendedMaxContext(
+                modelID: "mlx-community/duplicate-nested-config-4bit",
+                verifiedConfigJSONData: configData,
+                verifiedConfigSHA256: Self.sha256Hex(configData),
+                catalogMinRAMGB: 1
+            ),
+            AutotuneModelContextCap.failClosedMaxContext
+        )
+    }
+
+    func testRecommendApplyServeConfigUsesVerifiedConfigBytesNotMutableArtifactPath() throws {
+        var request = try makeRequest()
+        request.hardware = Self.hardware(chip: "Apple M4 Ultra", memoryGB: 256, bandwidthTier: .s)
+        let result = AutotuneRecommendEngine().recommend(request)
+        let selected = try XCTUnwrap(result.selectedCandidate)
+        var benchmark = try XCTUnwrap(request.benchmarks[selected.catalogKey])
+        let row = try XCTUnwrap(request.candidateCatalog.rows[selected.catalogKey])
+        let snapshot = try tempDir()
+        try Data(Self.contextConfigJSON(maxContext: 262_144).utf8)
+            .write(to: snapshot.appendingPathComponent("config.json"))
+        Self.bindContextConfig(Self.contextConfigJSON(maxContext: 32_768), to: &benchmark)
+        benchmark.modelArtifactPath = snapshot.path
+
+        let core = AutotuneCommand.recommendationCoreForConfig(
+            selected: selected,
+            selectedBenchmark: benchmark,
+            selectedRow: row,
+            catalogVersion: request.candidateCatalog.version,
+            catalogHash: request.candidateCatalogSHA256,
+            hardware: request.hardware
+        )
+
+        XCTAssertEqual(core.knobs.maxContext, 32_768)
+    }
+
+    func testRecommendApplyServeConfigFailsClosedWithoutModelContextEvidence() throws {
+        let hardware = Self.hardware(chip: "Apple M4 Ultra", memoryGB: 256, bandwidthTier: .s)
+
+        XCTAssertEqual(
+            hardware.recommendedMaxContext(
+                modelID: "mlx-community/unknown-context-model-4bit",
+                verifiedConfigJSONData: nil,
+                verifiedConfigSHA256: nil,
+                catalogMinRAMGB: 1
+            ),
+            AutotuneModelContextCap.failClosedMaxContext
+        )
+    }
+
+    func testRecommendApplyServeConfigDerivesMemorySafeContextFromKVGeometry() throws {
+        var request = try makeRequest()
+        request.hardware = Self.hardware(chip: "Apple M5", memoryGB: 36, bandwidthTier: .c)
+        let result = AutotuneRecommendEngine().recommend(request)
+        let selected = try XCTUnwrap(result.selectedCandidate)
+        var benchmark = try XCTUnwrap(request.benchmarks[selected.catalogKey])
+        let row = try XCTUnwrap(request.candidateCatalog.rows[selected.catalogKey])
+        let snapshot = try tempDir()
+        Self.bindContextConfig(Self.contextConfigJSON(
+            maxContext: 262_144,
+            hiddenSize: 2_048,
+            attentionHeads: 16,
+            kvHeads: 4,
+            layers: 48
+        ), to: &benchmark)
+        benchmark.modelArtifactPath = snapshot.path
+
+        let core = AutotuneCommand.recommendationCoreForConfig(
+            selected: selected,
+            selectedBenchmark: benchmark,
+            selectedRow: row,
+            catalogVersion: request.candidateCatalog.version,
+            catalogHash: request.candidateCatalogSHA256,
+            hardware: request.hardware
+        )
+
+        XCTAssertEqual(row.minRAMGB, 28)
+        XCTAssertEqual(core.knobs.maxContext, 36_768)
+    }
+
     func testRecommendApplyServeConfigUsesHardwareDerivedMaxBatch() throws {
         var request = try makeRequest()
         request.hardware = Self.hardware(chip: "Apple M4 Max", memoryGB: 64, bandwidthTier: .a)
         let result = AutotuneRecommendEngine().recommend(request)
         let selected = try XCTUnwrap(result.selectedCandidate)
-        let benchmark = try XCTUnwrap(request.benchmarks[selected.catalogKey])
+        var benchmark = try XCTUnwrap(request.benchmarks[selected.catalogKey])
         let row = try XCTUnwrap(request.candidateCatalog.rows[selected.catalogKey])
+        let snapshot = try tempDir()
+        Self.bindContextConfig(Self.contextConfigJSON(maxContext: 262_144), to: &benchmark)
+        benchmark.modelArtifactPath = snapshot.path
 
         let core = AutotuneCommand.recommendationCoreForConfig(
             selected: selected,
@@ -459,7 +750,9 @@ final class AutotuneRecommendTests: XCTestCase {
         let serveConfig = try XCTUnwrap(root["serve_config"] as? [String: Any])
 
         XCTAssertEqual(core.knobs.maxBatch, 2)
+        XCTAssertEqual(core.knobs.maxContext, 200_000)
         XCTAssertEqual(serveConfig["max_concurrency_override"] as? Int, 2)
+        XCTAssertEqual(serveConfig["max_context_override"] as? Int, 200_000)
     }
 
     func testAllRowsFailingEligibilityEmitsNoEligibleWarning() throws {
@@ -3890,6 +4183,34 @@ final class AutotuneRecommendTests: XCTestCase {
       }
     }
     """
+
+    private static func contextConfigJSON(
+        maxContext: Int,
+        hiddenSize: Int = 128,
+        attentionHeads: Int = 4,
+        kvHeads: Int = 1,
+        layers: Int = 1
+    ) -> String {
+        """
+        {
+          "max_position_embeddings": \(maxContext),
+          "hidden_size": \(hiddenSize),
+          "num_attention_heads": \(attentionHeads),
+          "num_key_value_heads": \(kvHeads),
+          "num_hidden_layers": \(layers)
+        }
+        """
+    }
+
+    private static func bindContextConfig(_ json: String, to benchmark: inout CandidateBenchmark) {
+        let data = Data(json.utf8)
+        benchmark.modelConfigJSONData = data
+        benchmark.modelConfigSHA256 = sha256Hex(data)
+    }
+
+    private static func sha256Hex(_ data: Data) -> String {
+        Data(SHA256.hash(data: data)).map { String(format: "%02x", $0) }.joined()
+    }
 
     private static func policyIdentityCatalogJSON() -> String {
         """

--- a/phase3-binary/Tests/macprovider-cliTests/ModelsSubcommandTests.swift
+++ b/phase3-binary/Tests/macprovider-cliTests/ModelsSubcommandTests.swift
@@ -309,6 +309,50 @@ final class ModelsSubcommandTests: XCTestCase {
         XCTAssertTrue(post.contains("coordinator_endpoint: https://coordinator.example\n"))
     }
 
+    func testAdoptRecommendationContextAuthorityRejectsInflatedContext() throws {
+        let fixture = try AdoptionFixture(current: "old-model", target: "new-model")
+        let inspection = try ModelArtifactVerifier.inspectCanonicalArtifact(directory: fixture.artifact)
+        let artifact = VerifiedModelArtifact(
+            modelArgument: fixture.artifact.path,
+            sha256: fixture.artifactSHA256,
+            configJSONData: inspection.configJSONData,
+            configSHA256: inspection.configSHA256
+        )
+        let row = CandidateCatalog.Row(
+            modelID: fixture.targetModelID,
+            modelRevision: String(repeating: "1", count: 40),
+            modelSHA256: fixture.artifactSHA256,
+            minRAMGB: 1,
+            minBandwidthTier: .c,
+            benchGate: CandidateCatalog.BenchGate(minSustainedTPS: 1, max4KTTFTMS: 1_000),
+            runtimeStatus: "recommendable",
+            notes: nil
+        )
+        let valid = Self.parsedAdoption(
+            fixture: fixture,
+            maxContext: 32_768,
+            hardwareMemoryGB: 64
+        )
+        XCTAssertNoThrow(try ModelsAdoptRecommendationCommand.validateSignedContextAuthority(
+            recommendation: valid,
+            row: row,
+            artifact: artifact
+        ))
+
+        let inflated = Self.parsedAdoption(
+            fixture: fixture,
+            maxContext: 200_000,
+            hardwareMemoryGB: 64
+        )
+        XCTAssertThrowsError(try ModelsAdoptRecommendationCommand.validateSignedContextAuthority(
+            recommendation: inflated,
+            row: row,
+            artifact: artifact
+        )) { error in
+            XCTAssertTrue(String(describing: error).contains("context authority"))
+        }
+    }
+
     func testAdoptRecommendationRollsBackOwnedConfigWhenSwitchFails() async throws {
         let socketPath = try makeSocketPath()
         let fixture = try AdoptionFixture(current: "old-model", target: "new-model")
@@ -364,6 +408,59 @@ final class ModelsSubcommandTests: XCTestCase {
         XCTAssertEqual(terminal.type, "failed")
         XCTAssertEqual(terminal.reason, "invalid_recommendation")
         XCTAssertTrue(try String(contentsOf: fixture.config).contains("model: old-model\n"))
+    }
+
+    func testAdoptRecommendationRejectsDuplicateKeysWithoutMutation() async throws {
+        let fixture = try AdoptionFixture(current: "old-model", target: "new-model")
+        let duplicate = try String(contentsOf: fixture.recommendation).replacingOccurrences(
+            of: #""warnings": [],"#,
+            with: #""warnings": ["blocking"], "warnings": [],"#
+        )
+        try Data(duplicate.utf8).write(to: fixture.recommendation)
+        let command = try ModelsAdoptRecommendationCommand.parse([
+            "--json",
+            "--config", fixture.config.path,
+            "--recommendation-json", fixture.recommendation.path,
+            "--ctl-socket-path", try makeSocketPath().path,
+        ])
+
+        let capture = await captureOutput { try await command.run() }
+
+        XCTAssertEqual(capture.error as? ExitCode, ExitCode(2))
+        let terminal = try XCTUnwrap(decodeAdoptionEvents(capture.stdout).last)
+        XCTAssertEqual(terminal.type, "failed")
+        XCTAssertEqual(terminal.reason, "invalid_recommendation")
+        XCTAssertTrue(try String(contentsOf: fixture.config).contains("model: old-model\n"))
+    }
+
+    func testAdoptRecommendationRejectsBooleanMaxConcurrencyWithoutMutation() async throws {
+        let fixture = try AdoptionFixture(current: "old-model", target: "new-model")
+        try mutateRecommendationFixture(fixture) {
+            $0.replacingOccurrences(of: #""max_concurrency_override": 1"#, with: #""max_concurrency_override": true"#)
+        }
+
+        try await assertAdoptionRejectsInvalidRecommendation(fixture)
+    }
+
+    func testAdoptRecommendationRejectsBooleanKVBitsWithoutMutation() async throws {
+        let fixture = try AdoptionFixture(current: "old-model", target: "new-model")
+        try mutateRecommendationFixture(fixture) {
+            $0.replacingOccurrences(
+                of: #""max_concurrency_override": 1"#,
+                with: #""kv_bits": true, "max_concurrency_override": 1"#
+            )
+        }
+
+        try await assertAdoptionRejectsInvalidRecommendation(fixture)
+    }
+
+    func testAdoptRecommendationRejectsBooleanMaxContextWithoutMutation() async throws {
+        let fixture = try AdoptionFixture(current: "old-model", target: "new-model")
+        try mutateRecommendationFixture(fixture) {
+            $0.replacingOccurrences(of: #""max_context_override": 4000"#, with: #""max_context_override": true"#)
+        }
+
+        try await assertAdoptionRejectsInvalidRecommendation(fixture)
     }
 
     func testAdoptRecommendationRejectsStaleRecommendationWithoutMutation() async throws {
@@ -827,6 +924,72 @@ final class ModelsSubcommandTests: XCTestCase {
             return try JSONDecoder().decode(ModelAdoptionEventWire.self, from: data)
         }
     }
+
+    private func mutateRecommendationFixture(
+        _ fixture: AdoptionFixture,
+        _ mutate: (String) -> String
+    ) throws {
+        let original = try String(contentsOf: fixture.recommendation)
+        try Data(mutate(original).utf8).write(to: fixture.recommendation)
+    }
+
+    private func assertAdoptionRejectsInvalidRecommendation(
+        _ fixture: AdoptionFixture,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) async throws {
+        let command = try ModelsAdoptRecommendationCommand.parse([
+            "--json",
+            "--config", fixture.config.path,
+            "--recommendation-json", fixture.recommendation.path,
+            "--ctl-socket-path", try makeSocketPath().path,
+        ])
+
+        let capture = await captureOutput { try await command.run() }
+
+        XCTAssertEqual(capture.error as? ExitCode, ExitCode(2), file: file, line: line)
+        let terminal = try XCTUnwrap(decodeAdoptionEvents(capture.stdout).last, file: file, line: line)
+        XCTAssertEqual(terminal.type, "failed", file: file, line: line)
+        XCTAssertEqual(terminal.reason, "invalid_recommendation", file: file, line: line)
+        XCTAssertTrue(try String(contentsOf: fixture.config).contains("model: old-model\n"), file: file, line: line)
+    }
+
+    private static func parsedAdoption(
+        fixture: AdoptionFixture,
+        maxContext: Int,
+        hardwareMemoryGB: Int
+    ) -> ParsedRecommendationAdoption {
+        ParsedRecommendationAdoption(
+            targetModelID: fixture.targetModelID,
+            core: RecommendationCore(
+                model: fixture.targetModelID,
+                targetContext: maxContext,
+                knobs: WinningKnobs(kvBits: nil, maxBatch: 1, maxContext: maxContext),
+                tpsMedian: 0,
+                ttftP95MS: 0,
+                replicates: 0,
+                modelArtifactPath: fixture.artifact.path,
+                modelArtifactSHA256: fixture.artifactSHA256,
+                modelCatalogKey: "test-key",
+                modelCatalogModelID: fixture.targetModelID,
+                modelCatalogRevision: String(repeating: "1", count: 40),
+                modelCatalogSHA256: fixture.artifactSHA256,
+                modelCatalogVersion: "test-catalog",
+                modelCatalogHash: String(repeating: "2", count: 64)
+            ),
+            donorMode: false,
+            draftModel: nil,
+            draftModelArtifactSHA256: nil,
+            warnings: [],
+            recommendationSHA256: String(repeating: "3", count: 64),
+            rateCardVersion: "test-catalog",
+            demandRankVersion: "test-catalog",
+            candidateCatalogVersion: "test-catalog",
+            hardwareChip: "Apple M4 Max",
+            hardwareMemoryGB: hardwareMemoryGB,
+            hardwareBinaryVersion: "1.8.90"
+        )
+    }
 }
 
 private enum ModelsSubcommandTestError: Error {
@@ -860,6 +1023,15 @@ private struct AdoptionFixture {
         try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
         artifact = dir.appendingPathComponent("artifact", isDirectory: true)
         try FileManager.default.createDirectory(at: artifact, withIntermediateDirectories: true)
+        try Data("""
+        {
+          "max_position_embeddings": 32768,
+          "hidden_size": 128,
+          "num_attention_heads": 4,
+          "num_key_value_heads": 1,
+          "num_hidden_layers": 1
+        }
+        """.utf8).write(to: artifact.appendingPathComponent("config.json"))
         try Data("weights".utf8).write(to: artifact.appendingPathComponent("model.safetensors"))
         artifactSHA256 = try ModelArtifactVerifier.canonicalArtifactHash(directory: artifact)
         targetModelID = target


### PR DESCRIPTION
## Summary

- Keep SPEC-023 recommendation probes at 4k while deriving apply-ready `serve_config.max_context_override` from verified provider/model capacity evidence.
- Bind context expansion to verified `config.json` bytes captured from the canonical artifact hash path, matching config SHA, KV geometry, and post-safety-margin memory headroom.
- Harden `models adopt-recommendation` so tampered recommendation JSON cannot smuggle duplicate keys or boolean numeric fields into applied config.

Closes #1164.

## Validation

- `swift test --filter AutotuneRecommendTests`
- `swift test --filter ModelsSubcommandTests`
- `swift test --filter ConfigApplierTests`
- `swift test --filter RecommendationEmitterTests`
- `swift test --filter AutotuneCommandTests`
- `swift build`
- `git diff --check origin/main`
- Full `swift test` attempted; local environment fails at `StageForwardParityTests` because MLX cannot load the default metallib.
- Final code, security, and architecture review gates: 0 CRITICAL / 0 HIGH / 0 MEDIUM.

SPEC-GOVERNANCE-DECLARATION-BEGIN
{
  "schema_version": "spec-pr-governance-v1",
  "behavior_change": "yes",
  "contract_change": "none",
  "issue": "https://github.com/Augustas11/macprovider/issues/1164",
  "specs": ["SPEC-023"],
  "requirements": ["SPEC-023-R001", "SPEC-023-R002"],
  "authority_domains": ["installer-autotune-policy"],
  "arbitration": ["CODE_BUG"],
  "tests": [
    "swift test --filter AutotuneRecommendTests",
    "swift test --filter ModelsSubcommandTests",
    "swift test --filter ConfigApplierTests",
    "swift test --filter RecommendationEmitterTests",
    "swift test --filter AutotuneCommandTests",
    "swift build",
    "git diff --check origin/main"
  ],
  "journeys": ["not-required"]
}
SPEC-GOVERNANCE-DECLARATION-END
