### PR TITLE
Advertise v1.8.105 provider release

### DIFF
--- a/phase4-coordinator/coordinator.yaml.example
+++ b/phase4-coordinator/coordinator.yaml.example
@@ -188,7 +188,7 @@ autotune:
 # legacy cohort (DECISION_CRITERIA Entry 161). `required_binary_version` is a
 # hard admission floor, not an autoupdate target, and is unaffected by the gate.
 coordinator_advertised_version:
-  latest_binary_version: "1.8.102"
+  latest_binary_version: "1.8.105"
   required_binary_version: ""
 
 auth:

--- a/phase4-coordinator/dist/coordinator.yaml
+++ b/phase4-coordinator/dist/coordinator.yaml
@@ -378,5 +378,5 @@ providers:
 # reconnecting and tells its operator to upgrade, and one without it
 # reconnect-loops.
 coordinator_advertised_version:
-  latest_binary_version: "1.8.102"
+  latest_binary_version: "1.8.105"
   required_binary_version: "1.8.33"

--- a/phase4-coordinator/dist/coordinator.yaml.example
+++ b/phase4-coordinator/dist/coordinator.yaml.example
@@ -418,7 +418,7 @@ malibu_emission:
 # routing. Keys match model_id case-insensitively; values must be bare
 # numeric versions or the coordinator refuses to start.
 coordinator_advertised_version:
-  latest_binary_version: "1.8.102"
+  latest_binary_version: "1.8.105"
   # required_binary_version: "1.7.0"
   # per_model_required_binary_version:
   #   "mlx-community/Qwen3-Coder-30B-A3B-Instruct-4bit": "1.8.60"


### PR DESCRIPTION
## Summary

- advertise published provider CLI `1.8.105` from the coordinator config templates
- keep the hard provider admission floor unchanged at `1.8.33`
- unblock the live rollout verifier so append-only signed release discovery can be published for `v1.8.105`

## Verification

- `bash scripts/test-coordinator-advertised-version.sh v1.8.105`
- `bash scripts/test-coordinator-advertised-version-test.sh`
- `go test ./internal/config ./internal/ws` from `phase4-coordinator/`
- `python3 -m unittest ops.pearl.config.test_pearl_config_reconcile`

SPEC-GOVERNANCE-DECLARATION-BEGIN
{
  "schema_version": "spec-pr-governance-v1",
  "behavior_change": "yes",
  "contract_change": "none",
  "specs": ["SPEC-020"],
  "requirements": ["SPEC-020-R001"],
  "authority_domains": ["provider-autoupdate"],
  "arbitration": ["CODE_BUG"],
  "tests": [
    "bash scripts/test-coordinator-advertised-version.sh v1.8.105",
    "bash scripts/test-coordinator-advertised-version-test.sh",
    "go test ./internal/config ./internal/ws",
    "python3 -m unittest ops.pearl.config.test_pearl_config_reconcile"
  ],
  "journeys": ["not-required"],
  "issue": "https://github.com/Augustas11/macprovider/issues/1164"
}
SPEC-GOVERNANCE-DECLARATION-END
