### PR TITLE
Keep verified model weights in an app-owned durable store

### DIFF
--- a/phase3-binary/Sources/MacProviderCore/Config.swift
+++ b/phase3-binary/Sources/MacProviderCore/Config.swift
@@ -37,6 +37,7 @@ public struct AppConfig: Equatable, Sendable {
     public var modelCatalogSHA256: String?
     public var modelCatalogVersion: String?
     public var modelCatalogHash: String?
+    public var modelArtifactRoot: String?
     public var coordinatorURL: String?
     public var providerID: String?
     public var endpointURL: String?
@@ -145,6 +146,7 @@ public struct AppConfig: Equatable, Sendable {
             modelCatalogSHA256: nil,
             modelCatalogVersion: nil,
             modelCatalogHash: nil,
+            modelArtifactRoot: nil,
             coordinatorURL: nil,
             providerID: nil,
             endpointURL: nil,
@@ -443,6 +445,7 @@ public enum ConfigLoader {
         try assign(&config.modelCatalogSHA256, from: dict, key: "model_catalog_sha256", expected: "string")
         try assign(&config.modelCatalogVersion, from: dict, key: "model_catalog_version", expected: "string")
         try assign(&config.modelCatalogHash, from: dict, key: "model_catalog_hash", expected: "string")
+        try assign(&config.modelArtifactRoot, from: dict, key: "model_artifact_root", expected: "string")
         try assign(&config.coordinatorURL, from: dict, key: "coordinator_url", expected: "string")
         try assign(&config.providerID, from: dict, key: "provider_id", expected: "string")
         try assign(&config.endpointURL, from: dict, key: "endpoint_url", expected: "string")
@@ -517,6 +520,7 @@ public enum ConfigLoader {
         try assign(&config.autoUpdateEnabled, from: environment, env: "MACPROVIDER_AUTO_UPDATE_ENABLED", expected: "boolean")
         try assign(&config.autoupdateEnabled, from: environment, env: "MACPROVIDER_AUTOUPDATE", expected: "boolean")
         try assign(&config.autoUpdateAcceptProvisional, from: environment, env: "MACPROVIDER_AUTO_UPDATE_ACCEPT_PROVISIONAL", expected: "boolean")
+        try assign(&config.modelArtifactRoot, from: environment, env: "MACPROVIDER_MODEL_ARTIFACT_ROOT", expected: "string")
         try assign(&config.logLevel, from: environment, env: "MACPROVIDER_LOG_LEVEL", expected: "valid log level")
         try assign(&config.logFormat, from: environment, env: "MACPROVIDER_LOG_FORMAT", expected: "json or text")
         try assign(&config.logFile, from: environment, env: "MACPROVIDER_LOG_FILE", expected: "string")

--- a/phase3-binary/Sources/macprovider-cli/AutotuneCommand.swift
+++ b/phase3-binary/Sources/macprovider-cli/AutotuneCommand.swift
@@ -909,6 +909,7 @@ struct AutotuneCommand: AsyncParsableCommand {
             buyerTTFTCeilingMS: buyerTTFTCeilingMS
         )
         let outcomes = try await AutotuneRecommendationBenchmarker(
+            artifactResolver: CachedModelArtifactResolver.forConfig(resolvedConfig),
             runnerFactory: { try CandidateProviderRunner() }
         ).benchmarks(
             request: request,
@@ -1100,16 +1101,18 @@ struct AutotuneCommand: AsyncParsableCommand {
                 buyerTTFTCeilingMS: buyerTTFTCeilingMS
             )
             let outcomes: BenchmarkOutcomes
+            let artifactResolver = CachedModelArtifactResolver.forConfig(resolvedConfig)
             if installedOnly {
                 outcomes = try Self.installedOnlyBenchmarkOutcomes(
                     request: request,
                     candidateModelIDs: candidateModelFilter,
                     catalogSHA: catalogSHA,
-                    artifactResolver: CachedModelArtifactResolver()
+                    artifactResolver: artifactResolver
                 )
             } else {
                 try emitEvent("progress", phase: "benchmarking")
                 outcomes = try await AutotuneRecommendationBenchmarker(
+                    artifactResolver: artifactResolver,
                     runnerFactory: { try CandidateProviderRunner() }
                 ).benchmarks(
                     request: request,
@@ -1258,7 +1261,9 @@ struct AutotuneCommand: AsyncParsableCommand {
         guard let requestedModelIDs = try recommendCandidateModelFilter(), !requestedModelIDs.isEmpty else {
             throw ValidationError("--prefetch requires an explicit --candidate-models allowlist")
         }
-        let outcome = try await AutotuneRecommendationBenchmarker().prefetchArtifacts(
+        let outcome = try await AutotuneRecommendationBenchmarker(
+            artifactResolver: CachedModelArtifactResolver.forConfig(resolvedConfig)
+        ).prefetchArtifacts(
             candidateCatalog: catalog.value,
             hardware: hardware,
             candidateModelIDs: requestedModelIDs

--- a/phase3-binary/Sources/macprovider-cli/AutotuneRecommend.swift
+++ b/phase3-binary/Sources/macprovider-cli/AutotuneRecommend.swift
@@ -3357,7 +3357,39 @@ final class HFAssetRedirectGuard: NSObject, URLSessionTaskDelegate {
 
 struct CachedModelArtifactResolver {
     var hubRoot: URL = defaultHubRoot
+    var durableRoot: URL
     var downloader: HuggingFaceSnapshotDownloader = HuggingFaceSnapshotDownloader()
+
+    var durableStore: DurableModelArtifactStore {
+        DurableModelArtifactStore(root: durableRoot)
+    }
+
+    init(
+        hubRoot: URL = defaultHubRoot,
+        durableRoot: URL? = nil,
+        downloader: HuggingFaceSnapshotDownloader = HuggingFaceSnapshotDownloader()
+    ) {
+        self.hubRoot = hubRoot
+        self.downloader = downloader
+        if let durableRoot {
+            self.durableRoot = durableRoot.standardizedFileURL
+        } else if hubRoot.standardizedFileURL.path == Self.defaultHubRoot.standardizedFileURL.path {
+            self.durableRoot = DurableModelArtifactStore.defaultRoot
+        } else {
+            self.durableRoot = hubRoot
+                .appendingPathComponent("macprovider-durable-models", isDirectory: true)
+                .standardizedFileURL
+        }
+    }
+
+    /// Overlay `model_artifact_root` from yaml/env the same way serve preflight does.
+    static func forConfig(_ config: AppConfig?) -> CachedModelArtifactResolver {
+        var resolver = CachedModelArtifactResolver()
+        if let root = config?.modelArtifactRoot, root.hasPrefix("/") {
+            resolver.durableRoot = URL(fileURLWithPath: root, isDirectory: true).standardizedFileURL
+        }
+        return resolver
+    }
 
     static var defaultHubRoot: URL {
         if let hfHome = ProcessInfo.processInfo.environment["HF_HOME"], !hfHome.isEmpty {
@@ -3455,13 +3487,31 @@ struct CachedModelArtifactResolver {
     }
 
     func verifiedExistingArtifact(for row: CandidateCatalog.Row) throws -> VerifiedModelArtifact {
-        guard let revision = row.modelRevision else {
+        guard let revision = row.modelRevision, let expected = row.modelSHA256 else {
             throw AutotuneRecommendError.invalidArtifact("missing revision/hash")
         }
-        return try verifiedExistingArtifact(
-            for: row,
-            at: snapshotURL(modelID: row.modelID, revision: revision)
+        let durable = try durableStore.artifactURL(
+            modelID: row.modelID,
+            revision: revision,
+            sha256: expected
         )
+        var durableStat = stat()
+        if lstat(durable.path, &durableStat) == 0, (durableStat.st_mode & S_IFMT) == S_IFDIR {
+            _ = try durableStore.validatedContainedDirectory(durable.path)
+            do {
+                return try verifiedExistingArtifact(for: row, at: durable)
+            } catch let error as AutotuneRecommendError {
+                guard case .invalidArtifact = error else { throw error }
+                // Stale durable bytes for a republished catalog hash: fall
+                // through to Hugging Face staging and overwrite on adopt.
+            }
+        }
+        let staging = snapshotURL(modelID: row.modelID, revision: revision)
+        var st = stat()
+        if lstat(staging.path, &st) == 0, (st.st_mode & S_IFMT) == S_IFDIR {
+            return try verifiedExistingArtifact(for: row, at: staging)
+        }
+        return try verifiedExistingArtifact(for: row, at: durable)
     }
 
     func verifiedExistingArtifact(
@@ -3483,11 +3533,26 @@ struct CachedModelArtifactResolver {
                 "hash mismatch \(row.modelID)@\(revision) expected=\(expected) actual=\(inspection.sha256)"
             )
         }
+        if durableStore.contains(snapshot.path) {
+            return VerifiedModelArtifact(
+                modelArgument: URL(fileURLWithPath: snapshot.path).standardizedFileURL.path,
+                sha256: inspection.sha256,
+                configJSONData: inspection.configJSONData,
+                configSHA256: inspection.configSHA256
+            )
+        }
+        let durable = try durableStore.adoptVerifiedStaging(
+            staging: snapshot,
+            modelID: row.modelID,
+            revision: revision,
+            sha256: inspection.sha256
+        )
+        let durableInspection = try ModelArtifactVerifier.inspectCanonicalArtifact(directory: durable)
         return VerifiedModelArtifact(
-            modelArgument: snapshot.path,
-            sha256: inspection.sha256,
-            configJSONData: inspection.configJSONData,
-            configSHA256: inspection.configSHA256
+            modelArgument: durable.path,
+            sha256: durableInspection.sha256,
+            configJSONData: durableInspection.configJSONData,
+            configSHA256: durableInspection.configSHA256
         )
     }
 

--- a/phase3-binary/Sources/macprovider-cli/DurableModelArtifactStore.swift
+++ b/phase3-binary/Sources/macprovider-cli/DurableModelArtifactStore.swift
@@ -1,0 +1,268 @@
+import Foundation
+
+/// Provider-owned model weight store. Hugging Face cache is staging only.
+struct DurableModelArtifactStore {
+    var root: URL
+    var fileManager: FileManager = .default
+
+    static let cacheBackedWarning =
+        "model_artifact_cache_backed: active artifact is under Hugging Face cache; serving now uses the durable store copy"
+
+    static var defaultRoot: URL {
+        if let override = ProcessInfo.processInfo.environment["MACPROVIDER_MODEL_ARTIFACT_ROOT"],
+           !override.isEmpty,
+           override.hasPrefix("/")
+        {
+            return URL(fileURLWithPath: override, isDirectory: true).standardizedFileURL
+        }
+        return FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent("Library/Application Support/macprovider/models", isDirectory: true)
+            .standardizedFileURL
+    }
+
+    static func isHuggingFaceCachePath(_ path: String) -> Bool {
+        let standardized = URL(fileURLWithPath: path).standardizedFileURL.path
+        if standardized.contains("/.cache/huggingface/") {
+            return true
+        }
+        if let hfHome = ProcessInfo.processInfo.environment["HF_HOME"], !hfHome.isEmpty {
+            let hub = URL(fileURLWithPath: hfHome).appendingPathComponent("hub", isDirectory: true)
+                .standardizedFileURL.path
+            if standardized == hub || standardized.hasPrefix(hub + "/") {
+                return true
+            }
+        }
+        return false
+    }
+
+    func artifactURL(modelID: String, revision: String, sha256: String) throws -> URL {
+        let escapedID = try Self.escapedComponent(modelID, label: "model id")
+        let escapedRevision = try Self.escapedComponent(revision, label: "revision")
+        guard sha256.range(of: #"^[0-9a-f]{64}$"#, options: .regularExpression) != nil else {
+            throw AutotuneRecommendError.invalidArtifact("durable artifact hash must be 64 lowercase hex characters")
+        }
+        return root
+            .appendingPathComponent(escapedID, isDirectory: true)
+            .appendingPathComponent(escapedRevision, isDirectory: true)
+            .appendingPathComponent(sha256, isDirectory: true)
+            .standardizedFileURL
+    }
+
+    func contains(_ path: String) -> Bool {
+        (try? validatedContainedDirectory(path)) != nil
+    }
+
+    func validatedContainedDirectory(_ path: String) throws -> URL {
+        let standardized = URL(fileURLWithPath: path).standardizedFileURL
+        try validateNoSymlinkAncestors(of: standardized, requireComplete: true)
+        return standardized
+    }
+
+    func isModelMaterialized(modelID: String) -> Bool {
+        guard let escapedID = try? Self.escapedComponent(modelID, label: "model id") else {
+            return false
+        }
+        let modelRoot = root.appendingPathComponent(escapedID, isDirectory: true)
+        guard let enumerator = fileManager.enumerator(
+            at: modelRoot,
+            includingPropertiesForKeys: [.isRegularFileKey],
+            options: [.skipsHiddenFiles]
+        ) else {
+            return false
+        }
+        for case let url as URL in enumerator {
+            var isDirectory: ObjCBool = false
+            if fileManager.fileExists(atPath: url.path, isDirectory: &isDirectory),
+               !isDirectory.boolValue
+            {
+                return true
+            }
+        }
+        return false
+    }
+
+    /// Copy a verified regular-file snapshot into the durable store.
+    func adoptVerifiedStaging(
+        staging: URL,
+        modelID: String,
+        revision: String,
+        sha256: String
+    ) throws -> URL {
+        let destination = try artifactURL(modelID: modelID, revision: revision, sha256: sha256)
+        try ensureRoot()
+        try validateNoSymlinkAncestors(
+            of: destination,
+            requireComplete: fileManager.fileExists(atPath: destination.path)
+        )
+        if fileManager.fileExists(atPath: destination.path) {
+            let existing: String?
+            do {
+                existing = try ModelArtifactVerifier.canonicalArtifactHash(directory: destination)
+            } catch {
+                existing = nil
+            }
+            if existing != sha256 {
+                try fileManager.removeItem(at: destination)
+                try copyRegularTree(from: staging, to: destination)
+            }
+        } else {
+            try copyRegularTree(from: staging, to: destination)
+        }
+        let actual = try ModelArtifactVerifier.canonicalArtifactHash(directory: destination)
+        guard actual == sha256 else {
+            throw AutotuneRecommendError.invalidArtifact(
+                "durable artifact hash mismatch expected=\(sha256) actual=\(actual)"
+            )
+        }
+        return destination
+    }
+
+    /// Remove inactive durable artifacts. Never deletes `keeping`.
+    func gcInactive(keeping: Set<String>) throws {
+        let rootPath = root.standardizedFileURL.path
+        guard fileManager.fileExists(atPath: rootPath) else { return }
+        let kept = Set(keeping.map { URL(fileURLWithPath: $0).standardizedFileURL.path })
+        try gcDirectory(root, keeping: kept)
+    }
+
+    private func gcDirectory(_ directory: URL, keeping: Set<String>) throws {
+        let entries = try fileManager.contentsOfDirectory(
+            at: directory,
+            includingPropertiesForKeys: [.isDirectoryKey],
+            options: [.skipsHiddenFiles]
+        )
+        for entry in entries {
+            if entry.lastPathComponent.hasPrefix(".tmp-") {
+                try? fileManager.removeItem(at: entry)
+                continue
+            }
+            var st = stat()
+            guard lstat(entry.path, &st) == 0 else { continue }
+            if (st.st_mode & S_IFMT) == S_IFLNK {
+                let path = entry.standardizedFileURL.path
+                if !keeping.contains(path) {
+                    try fileManager.removeItem(at: entry)
+                }
+                continue
+            }
+            guard (st.st_mode & S_IFMT) == S_IFDIR else { continue }
+            let path = entry.standardizedFileURL.path
+            if keeping.contains(path) {
+                continue
+            }
+            if keeping.contains(where: { $0.hasPrefix(path + "/") }) {
+                try gcDirectory(entry, keeping: keeping)
+                continue
+            }
+            try fileManager.removeItem(at: entry)
+        }
+    }
+
+    private func ensureRoot() throws {
+        try fileManager.createDirectory(at: root, withIntermediateDirectories: true)
+        var st = stat()
+        guard lstat(root.path, &st) == 0, (st.st_mode & S_IFMT) == S_IFDIR else {
+            throw AutotuneRecommendError.invalidArtifact("durable artifact root is not a directory")
+        }
+        try FileManager.default.setAttributes(
+            [.posixPermissions: NSNumber(value: Int16(0o700))],
+            ofItemAtPath: root.path
+        )
+    }
+
+    private func validateNoSymlinkAncestors(of url: URL, requireComplete: Bool) throws {
+        let rootURL = root.standardizedFileURL
+        var rootStat = stat()
+        if lstat(rootURL.path, &rootStat) == 0, (rootStat.st_mode & S_IFMT) == S_IFLNK {
+            throw AutotuneRecommendError.invalidArtifact("durable artifact root must not be a symlink")
+        }
+        let rootPath = rootURL.path
+        let targetPath = url.standardizedFileURL.path
+        guard targetPath == rootPath || targetPath.hasPrefix(rootPath + "/") else {
+            throw AutotuneRecommendError.invalidArtifact("durable path escapes artifact root")
+        }
+        var current = rootURL
+        let relative = targetPath.dropFirst(rootPath.count).split(separator: "/").map(String.init)
+        for component in relative where !component.isEmpty {
+            current.appendPathComponent(component)
+            var st = stat()
+            if lstat(current.path, &st) != 0 {
+                if requireComplete {
+                    throw AutotuneRecommendError.invalidArtifact("durable path is missing")
+                }
+                return
+            }
+            if (st.st_mode & S_IFMT) == S_IFLNK {
+                throw AutotuneRecommendError.invalidArtifact("symlink in durable path")
+            }
+        }
+    }
+
+    private func copyRegularTree(from source: URL, to destination: URL) throws {
+        let destPath = destination.standardizedFileURL.path
+        try validateNoSymlinkAncestors(of: destination.deletingLastPathComponent(), requireComplete: false)
+        let rootPath = root.standardizedFileURL.path
+        guard destPath == rootPath || destPath.hasPrefix(rootPath + "/") else {
+            throw AutotuneRecommendError.invalidArtifact("durable destination escapes artifact root")
+        }
+        let staging = destination.deletingLastPathComponent()
+            .appendingPathComponent(".tmp-\(UUID().uuidString)", isDirectory: true)
+        try fileManager.createDirectory(at: staging, withIntermediateDirectories: true)
+        do {
+            let inspection = try ModelArtifactVerifier.inspectCanonicalArtifact(directory: source)
+            _ = inspection
+            guard let enumerator = fileManager.enumerator(
+                at: source,
+                includingPropertiesForKeys: [.isRegularFileKey, .isDirectoryKey],
+                options: []
+            ) else {
+                throw AutotuneRecommendError.invalidArtifact("cannot enumerate staging artifact")
+            }
+            let basePath = source.resolvingSymlinksInPath().path
+            for case let url as URL in enumerator {
+                var statbuf = stat()
+                guard lstat(url.path, &statbuf) == 0 else {
+                    throw AutotuneRecommendError.invalidArtifact("lstat during durable copy")
+                }
+                if (statbuf.st_mode & S_IFMT) == S_IFLNK {
+                    throw AutotuneRecommendError.invalidArtifact("symlink in staging artifact")
+                }
+                if (statbuf.st_mode & S_IFMT) == S_IFDIR {
+                    continue
+                }
+                guard (statbuf.st_mode & S_IFMT) == S_IFREG else {
+                    throw AutotuneRecommendError.invalidArtifact("non-regular file in staging artifact")
+                }
+                let path = url.resolvingSymlinksInPath().path
+                guard path.hasPrefix(basePath + "/") else {
+                    throw AutotuneRecommendError.invalidArtifact("path escape during durable copy")
+                }
+                let rel = String(path.dropFirst(basePath.count + 1))
+                let target = staging.appendingPathComponent(rel)
+                try fileManager.createDirectory(at: target.deletingLastPathComponent(), withIntermediateDirectories: true)
+                try fileManager.copyItem(at: url, to: target)
+            }
+            try? fileManager.removeItem(at: destination)
+            try fileManager.moveItem(at: staging, to: destination)
+        } catch {
+            try? fileManager.removeItem(at: staging)
+            throw error
+        }
+    }
+
+    private static func escapedComponent(_ value: String, label: String) throws -> String {
+        let escaped = value
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .replacingOccurrences(of: "/", with: "--")
+        guard !escaped.isEmpty,
+              !escaped.contains("\0"),
+              !escaped.contains("/"),
+              escaped != ".",
+              escaped != "..",
+              !escaped.contains("..")
+        else {
+            throw AutotuneRecommendError.invalidArtifact("unsafe durable \(label)")
+        }
+        return escaped
+    }
+}

--- a/phase3-binary/Sources/macprovider-cli/MacProviderCLI.swift
+++ b/phase3-binary/Sources/macprovider-cli/MacProviderCLI.swift
@@ -727,11 +727,16 @@ struct ServeCommand: AsyncParsableCommand {
     }
 
     static func runModelArtifactPreflight(
-        _ resolved: AppConfig,
+        _ resolved: inout AppConfig,
         joiningCoordinator: Bool = true,
         staticInputs: AutotuneStaticInputs = AutotuneStaticInputs(),
-        artifactResolver: CachedModelArtifactResolver = CachedModelArtifactResolver()
+        artifactResolver: CachedModelArtifactResolver = CachedModelArtifactResolver(),
+        persistConfigMigration: Bool = false
     ) async throws -> CatalogRuntimeTrust? {
+        var artifactResolver = artifactResolver
+        if let root = resolved.modelArtifactRoot, root.hasPrefix("/") {
+            artifactResolver.durableRoot = URL(fileURLWithPath: root, isDirectory: true).standardizedFileURL
+        }
         guard let expected = resolved.modelArtifactSHA256 else {
             if resolved.modelArtifactPath != nil {
                 FileHandle.standardError.write(Data("model_artifact_path requires model_artifact_sha256 for a verified local snapshot\n".utf8))
@@ -756,40 +761,139 @@ struct ServeCommand: AsyncParsableCommand {
             FileHandle.standardError.write(Data("model_artifact_sha256 requires model_artifact_path to be a verified local snapshot path\n".utf8))
             throw ExitCode(2)
         }
+        let configuredPath = URL(fileURLWithPath: artifactPath).standardizedFileURL.path
+        let loadPath: String
+        let persistFrom: String?
         let actual: String
         do {
-            actual = try ModelArtifactVerifier.canonicalArtifactHash(directory: URL(fileURLWithPath: artifactPath))
+            let resolvedLoad = try resolveVerifiedLoadPath(
+                configuredPath: configuredPath,
+                expectedSHA256: expected,
+                resolved: resolved,
+                artifactResolver: artifactResolver
+            )
+            loadPath = resolvedLoad.path
+            persistFrom = resolvedLoad.persistFrom
+            actual = try ModelArtifactVerifier.canonicalArtifactHash(directory: URL(fileURLWithPath: loadPath))
             guard actual == expected else {
-                FileHandle.standardError.write(Data("model artifact hash mismatch for \(artifactPath)\n".utf8))
+                FileHandle.standardError.write(Data("model artifact hash mismatch for \(loadPath)\n".utf8))
                 throw ExitCode(2)
             }
         } catch let exit as ExitCode {
             throw exit
         } catch {
-            FileHandle.standardError.write(Data("model artifact verification failed for \(artifactPath): \(error)\n".utf8))
+            FileHandle.standardError.write(Data("model artifact verification failed for \(configuredPath): \(error)\n".utf8))
             throw ExitCode(2)
         }
+        resolved.modelArtifactPath = loadPath
         if resolved.donorMode || joiningCoordinator {
             return try await runModelCatalogPreflight(
-                resolved,
-                modelPath: artifactPath,
+                &resolved,
+                modelPath: loadPath,
                 actualArtifactSHA256: actual,
                 requireRecommendable: !resolved.donorMode,
                 staticInputs: staticInputs,
-                artifactResolver: artifactResolver
+                artifactResolver: artifactResolver,
+                persistConfigMigration: persistConfigMigration,
+                persistFrom: persistFrom
             )
         }
         return nil
     }
 
+    private static func isExistingDirectory(_ path: String) -> Bool {
+        var info = stat()
+        return lstat(path, &info) == 0 && (info.st_mode & S_IFMT) == S_IFDIR
+    }
+
+    private static func requireContainedDurablePathIfOwned(
+        _ path: String,
+        artifactResolver: CachedModelArtifactResolver
+    ) throws {
+        let standardized = URL(fileURLWithPath: path).standardizedFileURL.path
+        let root = artifactResolver.durableRoot.standardizedFileURL.path
+        guard standardized == root || standardized.hasPrefix(root + "/") else {
+            return
+        }
+        do {
+            _ = try artifactResolver.durableStore.validatedContainedDirectory(path)
+        } catch {
+            FileHandle.standardError.write(Data(
+                "[error] Configured durable model artifact failed containment: \(error.localizedDescription)\n".utf8
+            ))
+            throw ExitCode(2)
+        }
+    }
+
+    private static func resolveVerifiedLoadPath(
+        configuredPath: String,
+        expectedSHA256: String,
+        resolved: AppConfig,
+        artifactResolver: CachedModelArtifactResolver
+    ) throws -> (path: String, persistFrom: String?) {
+        if isExistingDirectory(configuredPath) {
+            try requireContainedDurablePathIfOwned(configuredPath, artifactResolver: artifactResolver)
+            let actual = try ModelArtifactVerifier.canonicalArtifactHash(
+                directory: URL(fileURLWithPath: configuredPath)
+            )
+            guard actual == expectedSHA256 else {
+                FileHandle.standardError.write(Data("model artifact hash mismatch for \(configuredPath)\n".utf8))
+                throw ExitCode(2)
+            }
+            return (configuredPath, nil)
+        }
+        guard let modelID = resolved.modelCatalogModelID, !modelID.isEmpty,
+              let revision = resolved.modelCatalogRevision, !revision.isEmpty
+        else {
+            FileHandle.standardError.write(
+                Data("model artifact verification failed for \(configuredPath): missing pinned snapshot\n".utf8)
+            )
+            throw ExitCode(2)
+        }
+        let durablePath: String
+        do {
+            durablePath = try artifactResolver.durableStore.artifactURL(
+                modelID: modelID,
+                revision: revision,
+                sha256: expectedSHA256
+            ).standardizedFileURL.path
+        } catch {
+            FileHandle.standardError.write(Data("model durable artifact path is invalid: \(error)\n".utf8))
+            throw ExitCode(2)
+        }
+        guard isExistingDirectory(durablePath) else {
+            FileHandle.standardError.write(
+                Data("model artifact verification failed for \(configuredPath): missing pinned snapshot\n".utf8)
+            )
+            throw ExitCode(2)
+        }
+        try requireContainedDurablePathIfOwned(durablePath, artifactResolver: artifactResolver)
+        let actual = try ModelArtifactVerifier.canonicalArtifactHash(
+            directory: URL(fileURLWithPath: durablePath)
+        )
+        guard actual == expectedSHA256 else {
+            FileHandle.standardError.write(Data("model artifact hash mismatch for \(durablePath)\n".utf8))
+            throw ExitCode(2)
+        }
+        if DurableModelArtifactStore.isHuggingFaceCachePath(configuredPath) {
+            FileHandle.standardError.write(
+                Data("\(DurableModelArtifactStore.cacheBackedWarning)\n".utf8)
+            )
+        }
+        return (durablePath, configuredPath)
+    }
+
     private static func runModelCatalogPreflight(
-        _ resolved: AppConfig,
+        _ resolved: inout AppConfig,
         modelPath: String,
         actualArtifactSHA256: String,
         requireRecommendable: Bool,
         staticInputs: AutotuneStaticInputs,
-        artifactResolver: CachedModelArtifactResolver
+        artifactResolver: CachedModelArtifactResolver,
+        persistConfigMigration: Bool,
+        persistFrom: String?
     ) async throws -> CatalogRuntimeTrust {
+        let actual = actualArtifactSHA256
         guard let key = resolved.modelCatalogKey,
               let modelID = resolved.modelCatalogModelID,
               let revision = resolved.modelCatalogRevision,
@@ -842,8 +946,92 @@ struct ServeCommand: AsyncParsableCommand {
             .standardizedFileURL
             .path
         let configuredSnapshot = URL(fileURLWithPath: modelPath).standardizedFileURL.path
-        guard configuredSnapshot == expectedSnapshot else {
-            FileHandle.standardError.write(Data("model must be the catalog-pinned Hugging Face snapshot path\n".utf8))
+        let durableURL: URL
+        do {
+            durableURL = try artifactResolver.durableStore.artifactURL(
+                modelID: modelID,
+                revision: revision,
+                sha256: actual
+            )
+        } catch {
+            FileHandle.standardError.write(Data("model durable artifact path is invalid: \(error)\n".utf8))
+            throw ExitCode(2)
+        }
+        let durablePath = durableURL.standardizedFileURL.path
+        var pendingPersistFrom = persistFrom
+        if configuredSnapshot == durablePath {
+            try requireContainedDurablePathIfOwned(configuredSnapshot, artifactResolver: artifactResolver)
+            resolved.modelArtifactPath = durablePath
+        } else if configuredSnapshot == expectedSnapshot {
+            FileHandle.standardError.write(
+                Data("\(DurableModelArtifactStore.cacheBackedWarning)\n".utf8)
+            )
+            do {
+                let adopted = try artifactResolver.durableStore.adoptVerifiedStaging(
+                    staging: URL(fileURLWithPath: configuredSnapshot),
+                    modelID: modelID,
+                    revision: revision,
+                    sha256: actual
+                )
+                guard adopted.standardizedFileURL.path == durablePath else {
+                    FileHandle.standardError.write(Data("durable artifact migration landed outside the expected store path\n".utf8))
+                    throw ExitCode(2)
+                }
+                resolved.modelArtifactPath = durablePath
+                pendingPersistFrom = configuredSnapshot
+            } catch let exit as ExitCode {
+                throw exit
+            } catch {
+                FileHandle.standardError.write(
+                    Data("cache-backed model artifact could not be migrated to the durable store: \(error)\n".utf8)
+                )
+                throw ExitCode(2)
+            }
+        } else if artifactResolver.durableStore.contains(configuredSnapshot) {
+            let durableHash: String
+            do {
+                durableHash = try ModelArtifactVerifier.canonicalArtifactHash(
+                    directory: URL(fileURLWithPath: configuredSnapshot)
+                )
+            } catch {
+                FileHandle.standardError.write(Data("model artifact verification failed for \(configuredSnapshot): \(error)\n".utf8))
+                throw ExitCode(2)
+            }
+            guard durableHash == actual else {
+                FileHandle.standardError.write(Data("model artifact hash mismatch for \(configuredSnapshot)\n".utf8))
+                throw ExitCode(2)
+            }
+            if configuredSnapshot != durablePath {
+                do {
+                    let adopted = try artifactResolver.durableStore.adoptVerifiedStaging(
+                        staging: URL(fileURLWithPath: configuredSnapshot),
+                        modelID: modelID,
+                        revision: revision,
+                        sha256: actual
+                    )
+                    guard adopted.standardizedFileURL.path == durablePath else {
+                        FileHandle.standardError.write(Data("durable artifact migration landed outside the expected store path\n".utf8))
+                        throw ExitCode(2)
+                    }
+                } catch {
+                    FileHandle.standardError.write(
+                        Data("non-canonical durable artifact could not be moved to the catalog identity path: \(error)\n".utf8)
+                    )
+                    throw ExitCode(2)
+                }
+                pendingPersistFrom = configuredSnapshot
+            }
+            resolved.modelArtifactPath = durablePath
+        } else if DurableModelArtifactStore.isHuggingFaceCachePath(configuredSnapshot) {
+            FileHandle.standardError.write(
+                Data(
+                    "model_artifact_missing_from_cache: \(configuredSnapshot) is a Hugging Face cache path that is not the catalog-pinned snapshot; re-run autotune --recommend --apply\n"
+                        .utf8
+                )
+            )
+            throw ExitCode(2)
+        } else {
+            FileHandle.standardError.write(Data("model must be a durable provider artifact or the catalog-pinned Hugging Face snapshot path\n".utf8))
             throw ExitCode(2)
         }
 
@@ -899,6 +1087,17 @@ struct ServeCommand: AsyncParsableCommand {
         } else {
             state = "live_verified"
         }
+        if persistConfigMigration,
+           let from = pendingPersistFrom,
+           let to = resolved.modelArtifactPath,
+           from != to
+        {
+            try persistMigratedArtifactPath(
+                configPath: resolved.configPath,
+                from: from,
+                to: to
+            )
+        }
         return CatalogRuntimeTrust(
             state: state,
             releaseID: catalog.value.version,
@@ -909,6 +1108,107 @@ struct ServeCommand: AsyncParsableCommand {
             rowIdentity: catalog.value.rowIdentity(for: key),
             modelSHA256: row.modelSHA256
         )
+    }
+
+    static func persistMigratedArtifactPath(configPath: String, from oldPath: String, to newPath: String) throws {
+        let expanded: String
+        if configPath.hasPrefix("~/") {
+            expanded = FileManager.default.homeDirectoryForCurrentUser
+                .appendingPathComponent(String(configPath.dropFirst(2))).path
+        } else {
+            expanded = configPath
+        }
+        guard expanded.hasPrefix("/"), FileManager.default.fileExists(atPath: expanded) else {
+            return
+        }
+        try ProviderConfigMutationLock.withExclusiveLock(configPath: expanded) {
+            try persistMigratedArtifactPathLocked(
+                expanded: expanded,
+                from: oldPath,
+                to: newPath
+            )
+        }
+    }
+
+    private static func persistMigratedArtifactPathLocked(
+        expanded: String,
+        from oldPath: String,
+        to newPath: String
+    ) throws {
+        guard FileManager.default.fileExists(atPath: expanded) else {
+            return
+        }
+        var info = stat()
+        guard lstat(expanded, &info) == 0, (info.st_mode & S_IFMT) == S_IFREG else {
+            return
+        }
+        let original = try String(contentsOfFile: expanded, encoding: .utf8)
+        let oldLiterals = Set([oldPath, yamlPathLiteral(oldPath)])
+        let replacement = "model_artifact_path: \(yamlPathLiteral(newPath))"
+        var replaced = false
+        let updated = original.split(separator: "\n", omittingEmptySubsequences: false).map { line -> String in
+            guard !replaced else { return String(line) }
+            let raw = String(line)
+            guard raw.first?.isWhitespace != true else { return raw }
+            let candidate = raw.hasSuffix("\r") ? String(raw.dropLast()) : raw
+            for literal in oldLiterals where candidate == "model_artifact_path: \(literal)" {
+                replaced = true
+                return replacement
+            }
+            return raw
+        }.joined(separator: "\n")
+        guard replaced, updated != original else {
+            return
+        }
+        let backup = expanded + ".pre-durable-artifact.bak"
+        var bakInfo = stat()
+        if lstat(backup, &bakInfo) == 0 {
+            guard (bakInfo.st_mode & S_IFMT) == S_IFREG else {
+                return
+            }
+            try FileManager.default.removeItem(atPath: backup)
+        }
+        let backupMode = mode_t((info.st_mode & 0o777) & ~0o077)
+        try writeExclusiveRegularFile(
+            path: backup,
+            contents: original,
+            mode: backupMode == 0 ? 0o600 : backupMode
+        )
+        try updated.write(toFile: expanded, atomically: true, encoding: .utf8)
+        try FileManager.default.setAttributes(
+            [.posixPermissions: NSNumber(value: info.st_mode & 0o777)],
+            ofItemAtPath: expanded
+        )
+    }
+
+    private static func writeExclusiveRegularFile(path: String, contents: String, mode: mode_t) throws {
+        let fd = open(path, O_WRONLY | O_CREAT | O_EXCL | O_CLOEXEC | O_NOFOLLOW, mode)
+        guard fd >= 0 else {
+            throw POSIXError(POSIXErrorCode(rawValue: errno) ?? .EIO)
+        }
+        defer { close(fd) }
+        _ = fchmod(fd, mode)
+        let bytes = Array(contents.utf8)
+        let written = bytes.withUnsafeBytes { raw in
+            write(fd, raw.baseAddress, raw.count)
+        }
+        guard written == bytes.count else {
+            throw POSIXError(POSIXErrorCode(rawValue: errno) ?? .EIO)
+        }
+    }
+
+    private static func yamlPathLiteral(_ value: String) -> String {
+        let plain = value.utf8.allSatisfy { byte in
+            (0x61...0x7A).contains(byte)
+                || (0x41...0x5A).contains(byte)
+                || (0x30...0x39).contains(byte)
+                || [0x2D, 0x5F, 0x2E, 0x2F].contains(byte)
+        }
+        guard !value.isEmpty, plain else {
+            let data = try? JSONEncoder().encode(value)
+            return data.map { String(decoding: $0, as: UTF8.self) } ?? "\"\""
+        }
+        return value
     }
 
     static func makeCoordinatorClient(
@@ -1348,8 +1648,13 @@ struct ServeCommand: AsyncParsableCommand {
             let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
             return trimmed.isEmpty ? nil : trimmed
         }
+        var targetResolver = CachedModelArtifactResolver()
+        if let root = resolved.modelArtifactRoot, root.hasPrefix("/") {
+            targetResolver.durableRoot = URL(fileURLWithPath: root, isDirectory: true).standardizedFileURL
+        }
         let targetAuthorities = Self.localRuntimeTargetAuthorities(
-            supportedModels: resolved.supportedModels
+            supportedModels: resolved.supportedModels,
+            artifactResolver: targetResolver
         )
         let authorizedSwitchModelIDs = Self.localRuntimeTargetModelIDs(
             supportedModels: resolved.supportedModels,
@@ -2385,10 +2690,11 @@ struct ServeCommand: AsyncParsableCommand {
             let catalogTrust: CatalogRuntimeTrust?
             do {
                 catalogTrust = try await Self.runModelArtifactPreflight(
-                    resolved,
+                    &resolved,
                     joiningCoordinator: joiningCoordinator,
                     staticInputs: staticInputs,
-                    artifactResolver: artifactResolver
+                    artifactResolver: artifactResolver,
+                    persistConfigMigration: true
                 )
             } catch where joiningCoordinator || resolved.donorMode {
                 throw ServeCatalogPreflightError(underlying: error)
@@ -2555,10 +2861,10 @@ struct SelfTestCommand: AsyncParsableCommand {
     }
 
     func run() async throws {
-        let resolved = try ConfigLoader.load(
+        var resolved = try ConfigLoader.load(
             cli: CLIOverrides(model: model, configPath: config)
         )
-        _ = try await ServeCommand.runModelArtifactPreflight(resolved, joiningCoordinator: false)
+        _ = try await ServeCommand.runModelArtifactPreflight(&resolved, joiningCoordinator: false)
         let runtime = try await ModelRuntime(
             modelID: resolved.model,
             modelLoadPath: Self.modelLoadPath(for: resolved),

--- a/phase3-binary/Sources/macprovider-cli/ModelsSubcommand.swift
+++ b/phase3-binary/Sources/macprovider-cli/ModelsSubcommand.swift
@@ -69,7 +69,8 @@ struct ModelsListCommand: AsyncParsableCommand {
                     supportedModels: models,
                     source: "control_socket",
                     warmSwapAvailable: true,
-                    authorizedModelIDs: Set(authorizedModelIDs.map(modelIDKey))
+                    authorizedModelIDs: Set(authorizedModelIDs.map(modelIDKey)),
+                    artifactResolver: CachedModelArtifactResolver.forConfig(resolved)
                 )
             } else {
                 printModelsTable(currentModelID: status.currentModelID, supportedModels: models)
@@ -81,7 +82,8 @@ struct ModelsListCommand: AsyncParsableCommand {
                     currentModelID: nil,
                     supportedModels: models,
                     source: "config_fallback",
-                    warmSwapAvailable: false
+                    warmSwapAvailable: false,
+                    artifactResolver: CachedModelArtifactResolver.forConfig(resolved)
                 )
             } else {
                 print("serve not running; warm-swap disabled")
@@ -422,7 +424,7 @@ struct ModelsAdoptRecommendationCommand: AsyncParsableCommand {
             try fail("blocked_warning", exitCode: 2)
         }
         do {
-            try await Self.validateSignedAuthority(recommendation)
+            try await Self.validateSignedAuthority(recommendation, configPath: config)
         } catch {
             try fail("signed_authority_invalid", exitCode: 2)
         }
@@ -968,7 +970,10 @@ extension ModelsAdoptRecommendationCommand {
         !value.isEmpty && value.utf8.allSatisfy { $0 >= 0x20 && $0 != 0x7F }
     }
 
-    fileprivate static func validateSignedAuthority(_ recommendation: ParsedRecommendationAdoption) async throws {
+    fileprivate static func validateSignedAuthority(
+        _ recommendation: ParsedRecommendationAdoption,
+        configPath: String? = nil
+    ) async throws {
         #if DEBUG
         if ProcessInfo.processInfo.environment["XCTestConfigurationFilePath"] != nil
             || ProcessInfo.processInfo.processName.lowercased().contains("xctest") {
@@ -1002,11 +1007,20 @@ extension ModelsAdoptRecommendationCommand {
               BandwidthTier.derive(chip: currentHardware.chip).satisfies(minimum: row.minBandwidthTier) else {
             throw ValidationError("recommendation hardware or binary identity is stale")
         }
-        let artifact = try CachedModelArtifactResolver().verifiedExistingArtifact(for: row)
-        guard URL(fileURLWithPath: artifact.modelArgument).standardizedFileURL
-                == URL(fileURLWithPath: recommendation.core.modelArtifactPath ?? "").standardizedFileURL,
-              artifact.sha256 == recommendation.core.modelArtifactSHA256 else {
+        let resolvedConfig = try? ConfigLoader.load(cli: CLIOverrides(configPath: configPath))
+        let artifact = try CachedModelArtifactResolver.forConfig(resolvedConfig).verifiedExistingArtifact(for: row)
+        guard artifact.sha256 == recommendation.core.modelArtifactSHA256 else {
             throw ValidationError("recommendation artifact authority does not match the signed snapshot")
+        }
+        if let recordedPath = recommendation.core.modelArtifactPath {
+            let recorded = URL(fileURLWithPath: recordedPath).standardizedFileURL
+            let loaded = URL(fileURLWithPath: artifact.modelArgument).standardizedFileURL
+            if recorded != loaded, FileManager.default.fileExists(atPath: recorded.path) {
+                let recordedHash = try ModelArtifactVerifier.canonicalArtifactHash(directory: recorded)
+                guard recordedHash == artifact.sha256 else {
+                    throw ValidationError("recommendation artifact authority does not match the signed snapshot")
+                }
+            }
         }
         try validateSignedContextAuthority(recommendation: recommendation, row: row, artifact: artifact)
     }
@@ -1596,7 +1610,8 @@ private func emitJSONList(
     supportedModels: [String],
     source: String,
     warmSwapAvailable: Bool,
-    authorizedModelIDs: Set<String>? = nil
+    authorizedModelIDs: Set<String>? = nil,
+    artifactResolver: CachedModelArtifactResolver = CachedModelArtifactResolver()
 ) async throws {
     do {
         let document = try await makeModelsListWire(
@@ -1604,7 +1619,8 @@ private func emitJSONList(
             supportedModels: supportedModels,
             source: source,
             warmSwapAvailable: warmSwapAvailable,
-            authorizedModelIDs: authorizedModelIDs
+            authorizedModelIDs: authorizedModelIDs,
+            artifactResolver: artifactResolver
         )
         try ModelSwitchingWireCodec.printJSON(document)
     } catch {
@@ -1622,7 +1638,8 @@ private func makeModelsListWire(
     supportedModels: [String],
     source: String,
     warmSwapAvailable: Bool,
-    authorizedModelIDs: Set<String>? = nil
+    authorizedModelIDs: Set<String>? = nil,
+    artifactResolver: CachedModelArtifactResolver = CachedModelArtifactResolver()
 ) async throws -> ModelsListWire {
     var effectiveModels = supportedModels
     if let currentModelID {
@@ -1651,7 +1668,7 @@ private func makeModelsListWire(
             // not make Malibu advertise a target the runtime cannot switch to.
             weightsPresent = warmSwapAvailable && authorizedModelIDs.contains(modelIDKey(modelID))
         } else {
-            weightsPresent = exactLocalArtifactPresent(modelID: modelID)
+            weightsPresent = exactLocalArtifactPresent(modelID: modelID, artifactResolver: artifactResolver)
         }
         rows.append(ModelsListWire.Row(
             modelID: modelID,
@@ -1673,7 +1690,10 @@ private func makeModelsListWire(
     )
 }
 
-private func exactLocalArtifactPresent(modelID: String) -> Bool {
+private func exactLocalArtifactPresent(
+    modelID: String,
+    artifactResolver: CachedModelArtifactResolver
+) -> Bool {
     // A plain directory is insufficient evidence: the runtime requires the
     // signed catalog revision and canonical artifact hash. Unknown rows stay
     // false so Malibu cannot promote an idle partial/stale cache to Ready.
@@ -1687,5 +1707,5 @@ private func exactLocalArtifactPresent(modelID: String) -> Bool {
           row.modelSHA256 != nil else {
         return false
     }
-    return (try? CachedModelArtifactResolver().verifiedExistingArtifact(for: row)) != nil
+    return (try? artifactResolver.verifiedExistingArtifact(for: row)) != nil
 }

--- a/phase3-binary/Sources/macprovider-cli/ProviderPreWarmer.swift
+++ b/phase3-binary/Sources/macprovider-cli/ProviderPreWarmer.swift
@@ -17,18 +17,26 @@ enum PreWarmResult: Equatable {
 
 struct HuggingFaceCacheChecker {
     private let cacheRoot: URL
+    private let durableRoot: URL
     private let fileManager: FileManager
 
     init(
         cacheRoot: URL = FileManager.default.homeDirectoryForCurrentUser
             .appendingPathComponent(".cache/huggingface/hub", isDirectory: true),
+        durableRoot: URL = DurableModelArtifactStore.defaultRoot,
         fileManager: FileManager = .default
     ) {
         self.cacheRoot = cacheRoot
+        self.durableRoot = durableRoot
         self.fileManager = fileManager
     }
 
     func isModelCached(modelID: String) -> Bool {
+        if DurableModelArtifactStore(root: durableRoot, fileManager: fileManager)
+            .isModelMaterialized(modelID: modelID)
+        {
+            return true
+        }
         guard let repoDirectory = repositoryDirectory(for: modelID) else {
             return false
         }

--- a/phase3-binary/Tests/macprovider-cliTests/AutotuneRecommendTests.swift
+++ b/phase3-binary/Tests/macprovider-cliTests/AutotuneRecommendTests.swift
@@ -1,6 +1,7 @@
 import CryptoKit
 import Darwin
 import Foundation
+import MacProviderCore
 import XCTest
 @testable import macprovider_cli
 
@@ -2460,13 +2461,71 @@ final class AutotuneRecommendTests: XCTestCase {
         )
 
         let verified = try CachedModelArtifactResolver(hubRoot: hub).verifiedExistingArtifact(for: row)
+        let durable = try CachedModelArtifactResolver(hubRoot: hub).durableStore.artifactURL(
+            modelID: row.modelID,
+            revision: revision,
+            sha256: expected
+        )
 
         XCTAssertEqual(verified.sha256, expected)
-        XCTAssertEqual(verified.modelArgument, snapshot.path)
+        XCTAssertEqual(verified.modelArgument, durable.path)
+        XCTAssertTrue(FileManager.default.fileExists(atPath: durable.path))
+        XCTAssertTrue(FileManager.default.fileExists(atPath: snapshot.path))
+
+        try FileManager.default.removeItem(at: snapshot)
+        let afterCacheDelete = try CachedModelArtifactResolver(hubRoot: hub).verifiedExistingArtifact(for: row)
+        XCTAssertEqual(afterCacheDelete.modelArgument, durable.path)
 
         var mismatch = row
         mismatch.modelSHA256 = String(repeating: "0", count: 64)
         XCTAssertThrowsError(try CachedModelArtifactResolver(hubRoot: hub).verifiedExistingArtifact(for: mismatch))
+    }
+
+    func testResolverForConfigOverlaysYAMLRootAndAdoptsThere() throws {
+        let hub = try tempDir()
+        let customRoot = try tempDir()
+        let revision = String(repeating: "a", count: 40)
+        let snapshot = hub
+            .appendingPathComponent("models--namespace--model", isDirectory: true)
+            .appendingPathComponent("snapshots", isDirectory: true)
+            .appendingPathComponent(revision, isDirectory: true)
+        try FileManager.default.createDirectory(at: snapshot, withIntermediateDirectories: true)
+        try Data("weights".utf8).write(to: snapshot.appendingPathComponent("weights.bin"))
+        let expected = try ModelArtifactVerifier.canonicalArtifactHash(directory: snapshot)
+        let row = CandidateCatalog.Row(
+            modelID: "namespace/model",
+            modelRevision: revision,
+            modelSHA256: expected,
+            minRAMGB: 1,
+            minBandwidthTier: .c,
+            benchGate: CandidateCatalog.BenchGate(minSustainedTPS: 1, max4KTTFTMS: 1_000),
+            runtimeStatus: "recommendable",
+            notes: nil
+        )
+        var config = AppConfig.defaults()
+        config.modelArtifactRoot = customRoot.path
+        var resolver = CachedModelArtifactResolver.forConfig(config)
+        resolver.hubRoot = hub
+        let verified = try resolver.verifiedExistingArtifact(for: row)
+        let expectedDurable = try DurableModelArtifactStore(root: customRoot).artifactURL(
+            modelID: row.modelID,
+            revision: revision,
+            sha256: expected
+        )
+        XCTAssertEqual(verified.modelArgument, expectedDurable.path)
+        XCTAssertTrue(FileManager.default.fileExists(atPath: expectedDurable.path))
+        let defaultResolver = CachedModelArtifactResolver(hubRoot: hub)
+        XCTAssertNotEqual(
+            defaultResolver.durableRoot.standardizedFileURL.path,
+            customRoot.standardizedFileURL.path
+        )
+        XCTAssertFalse(
+            FileManager.default.fileExists(
+                atPath: defaultResolver.durableRoot
+                    .appendingPathComponent("namespace--model", isDirectory: true)
+                    .path
+            )
+        )
     }
 
     func testPrefetchVerifiesOnlyExplicitSignedArtifactWithoutStartingBenchmarkRuntime() async throws {
@@ -2497,7 +2556,12 @@ final class AutotuneRecommendTests: XCTestCase {
 
         XCTAssertEqual(outcome.matchedModelIDs, [row.modelID])
         XCTAssertEqual(outcome.prefetchedModelIDs, [row.modelID])
-        XCTAssertEqual(outcome.artifacts.map(\.path), [snapshot.path])
+        let durable = try resolver.durableStore.artifactURL(
+            modelID: row.modelID,
+            revision: revision,
+            sha256: try XCTUnwrap(request.candidateCatalog.rows[modelKey]?.modelSHA256)
+        )
+        XCTAssertEqual(outcome.artifacts.map(\.path), [durable.path])
         XCTAssertTrue(outcome.diagnostics.isEmpty)
     }
 
@@ -2714,7 +2778,11 @@ final class AutotuneRecommendTests: XCTestCase {
         let verified = try await CachedModelArtifactResolver(hubRoot: hub, downloader: downloader)
             .verifiedArtifact(for: row)
 
-        XCTAssertEqual(verified.modelArgument, snapshot.path)
+        XCTAssertEqual(verified.modelArgument, try resolver.durableStore.artifactURL(
+            modelID: row.modelID,
+            revision: revision,
+            sha256: expected
+        ).path)
         XCTAssertEqual(verified.sha256, expected)
         XCTAssertEqual(try String(contentsOf: snapshot.appendingPathComponent("weights.bin")), "fresh")
     }
@@ -2796,7 +2864,12 @@ final class AutotuneRecommendTests: XCTestCase {
         try FileManager.default.createDirectory(at: goodSnapshot, withIntermediateDirectories: true)
         try Data("weights".utf8).write(to: goodSnapshot.appendingPathComponent("weights.bin"))
         request.candidateCatalog.rows[goodKey]?.modelSHA256 = try ModelArtifactVerifier.canonicalArtifactHash(directory: goodSnapshot)
-        let goodArtifactPath = goodSnapshot.path
+        let goodArtifactPath = try durableArtifactPath(
+            hubRoot: hub,
+            modelID: goodRow.modelID,
+            revision: goodRevision,
+            sha256: try XCTUnwrap(request.candidateCatalog.rows[goodKey]?.modelSHA256)
+        )
 
         let prober = RecordingStage1Prober(results: [
             goodArtifactPath: .feasible(medianTPS: 88, p95TTFTMS: 900)
@@ -2857,7 +2930,12 @@ final class AutotuneRecommendTests: XCTestCase {
         try FileManager.default.createDirectory(at: snapshot, withIntermediateDirectories: true)
         try Data("weights".utf8).write(to: snapshot.appendingPathComponent("weights.bin"))
         request.candidateCatalog.rows[goodKey]?.modelSHA256 = try ModelArtifactVerifier.canonicalArtifactHash(directory: snapshot)
-        let artifactPath = snapshot.path
+        let artifactPath = try durableArtifactPath(
+            hubRoot: hub,
+            modelID: goodRow.modelID,
+            revision: revision,
+            sha256: try XCTUnwrap(request.candidateCatalog.rows[goodKey]?.modelSHA256)
+        )
 
         let prober = RecordingStage1Prober(results: [
             artifactPath: .feasible(medianTPS: 88, p95TTFTMS: 900)
@@ -2933,8 +3011,14 @@ final class AutotuneRecommendTests: XCTestCase {
         try Data("weights".utf8).write(to: snapshot.appendingPathComponent("weights.bin"))
         request.candidateCatalog.rows[modelKey]?.modelSHA256 = try ModelArtifactVerifier.canonicalArtifactHash(directory: snapshot)
         request.benchmarks = [:]
+        let durablePath = try durableArtifactPath(
+            hubRoot: hub,
+            modelID: row.modelID,
+            revision: revision,
+            sha256: try XCTUnwrap(request.candidateCatalog.rows[modelKey]?.modelSHA256)
+        )
         let prober = RecordingStage1Prober(results: [
-            snapshot.path: .feasible(medianTPS: 12, p95TTFTMS: 900),
+            durablePath: .feasible(medianTPS: 12, p95TTFTMS: 900),
         ])
         let benchmarker = AutotuneRecommendationBenchmarker(
             artifactResolver: resolver,
@@ -2952,7 +3036,7 @@ final class AutotuneRecommendTests: XCTestCase {
         )
 
         XCTAssertNotNil(outcomes.benchmarks[modelKey])
-        XCTAssertEqual(prober.probedModels, [snapshot.path])
+        XCTAssertEqual(prober.probedModels, [durablePath])
     }
 
     func testProbeSafetyAssessmentFailsClosedOnUnavailableTelemetry() {
@@ -3697,8 +3781,14 @@ final class AutotuneRecommendTests: XCTestCase {
         try Data("weights".utf8).write(to: snapshot.appendingPathComponent("weights.bin"))
         request.candidateCatalog.rows[modelKey]?.modelSHA256 = try ModelArtifactVerifier.canonicalArtifactHash(directory: snapshot)
         request.benchmarks = [:]
+        let durablePath = try durableArtifactPath(
+            hubRoot: hub,
+            modelID: row.modelID,
+            revision: revision,
+            sha256: try XCTUnwrap(request.candidateCatalog.rows[modelKey]?.modelSHA256)
+        )
         let prober = RecordingStage1Prober(results: [
-            snapshot.path: .infeasible(reason: "probe request failed: The request timed out.", nErr: 3),
+            durablePath: .infeasible(reason: "probe request failed: The request timed out.", nErr: 3),
         ])
         let benchmarker = AutotuneRecommendationBenchmarker(
             artifactResolver: resolver,
@@ -3734,11 +3824,17 @@ final class AutotuneRecommendTests: XCTestCase {
         try Data("weights".utf8).write(to: snapshot.appendingPathComponent("weights.bin"))
         request.candidateCatalog.rows[modelKey]?.modelSHA256 = try ModelArtifactVerifier.canonicalArtifactHash(directory: snapshot)
         request.benchmarks = [:]
+        let durablePath = try durableArtifactPath(
+            hubRoot: hub,
+            modelID: row.modelID,
+            revision: revision,
+            sha256: try XCTUnwrap(request.candidateCatalog.rows[modelKey]?.modelSHA256)
+        )
         let benchmarker = AutotuneRecommendationBenchmarker(
             artifactResolver: resolver,
             runnerFactory: { try CandidateProviderRunner(providerBinaryPath: "/bin/true") },
             prober: RecordingStage1Prober(results: [
-                snapshot.path: .feasible(medianTPS: 0, p95TTFTMS: .infinity),
+                durablePath: .feasible(medianTPS: 0, p95TTFTMS: .infinity),
             ]),
             safetySampler: StaticProbeSafetySampler()
         )
@@ -3768,11 +3864,17 @@ final class AutotuneRecommendTests: XCTestCase {
         try Data("weights".utf8).write(to: snapshot.appendingPathComponent("weights.bin"))
         request.candidateCatalog.rows[modelKey]?.modelSHA256 = try ModelArtifactVerifier.canonicalArtifactHash(directory: snapshot)
         request.benchmarks = [:]
+        let durablePath = try durableArtifactPath(
+            hubRoot: hub,
+            modelID: row.modelID,
+            revision: revision,
+            sha256: try XCTUnwrap(request.candidateCatalog.rows[modelKey]?.modelSHA256)
+        )
         let benchmarker = AutotuneRecommendationBenchmarker(
             artifactResolver: resolver,
             runnerFactory: { try CandidateProviderRunner(providerBinaryPath: "/bin/true") },
             prober: RecordingStage1Prober(results: [
-                snapshot.path: .feasible(medianTPS: 42, p95TTFTMS: .infinity),
+                durablePath: .feasible(medianTPS: 42, p95TTFTMS: .infinity),
             ]),
             safetySampler: StaticProbeSafetySampler()
         )
@@ -3805,19 +3907,26 @@ final class AutotuneRecommendTests: XCTestCase {
         let artifactSHA = try ModelArtifactVerifier.canonicalArtifactHash(directory: snapshot)
         request.candidateCatalog.rows[modelKey]?.modelSHA256 = artifactSHA
         request.benchmarks = [:]
+        _ = try resolver.verifiedExistingArtifact(for: try XCTUnwrap(request.candidateCatalog.rows[modelKey]))
+        let durablePath = try durableArtifactPath(
+            hubRoot: hub,
+            modelID: row.modelID,
+            revision: revision,
+            sha256: artifactSHA
+        )
         let prefetched = PrefetchedModelArtifact(
             modelKey: modelKey,
             modelID: row.modelID,
             modelRevision: revision,
             candidateRowIdentity: try XCTUnwrap(request.candidateCatalog.rowIdentity(for: modelKey)),
-            path: snapshot.path,
+            path: durablePath,
             sha256: artifactSHA
         )
         let benchmarker = AutotuneRecommendationBenchmarker(
             artifactResolver: resolver,
             runnerFactory: { try CandidateProviderRunner(providerBinaryPath: "/bin/true") },
             prober: RecordingStage1Prober(results: [
-                snapshot.path: .feasible(medianTPS: .nan, p95TTFTMS: 900),
+                durablePath: .feasible(medianTPS: .nan, p95TTFTMS: 900),
             ]),
             safetySampler: StaticProbeSafetySampler()
         )
@@ -3854,12 +3963,19 @@ final class AutotuneRecommendTests: XCTestCase {
         let artifactSHA = try ModelArtifactVerifier.canonicalArtifactHash(directory: snapshot)
         request.candidateCatalog.rows[modelKey]?.modelSHA256 = artifactSHA
         request.benchmarks = [:]
+        _ = try resolver.verifiedExistingArtifact(for: try XCTUnwrap(request.candidateCatalog.rows[modelKey]))
+        let durablePath = try durableArtifactPath(
+            hubRoot: hub,
+            modelID: row.modelID,
+            revision: revision,
+            sha256: artifactSHA
+        )
         let prefetched = PrefetchedModelArtifact(
             modelKey: modelKey,
             modelID: row.modelID,
             modelRevision: revision,
             candidateRowIdentity: try XCTUnwrap(request.candidateCatalog.rowIdentity(for: modelKey)),
-            path: snapshot.path,
+            path: durablePath,
             sha256: artifactSHA
         )
         let readinessFailure = "provider readiness timeout before Stage 1 probe: Could not connect to the server"
@@ -3867,7 +3983,7 @@ final class AutotuneRecommendTests: XCTestCase {
             artifactResolver: resolver,
             runnerFactory: { try CandidateProviderRunner(providerBinaryPath: "/bin/true") },
             prober: RecordingStage1Prober(results: [
-                snapshot.path: .infeasible(reason: readinessFailure, nErr: 1),
+                durablePath: .infeasible(reason: readinessFailure, nErr: 1),
             ]),
             safetySampler: StaticProbeSafetySampler()
         )
@@ -4508,6 +4624,19 @@ final class AutotuneRecommendTests: XCTestCase {
         return object["key_id"] as? String == keyID &&
             object["alg"] as? String == "ed25519" &&
             Data(base64Encoded: object["signature"] as? String ?? "") != nil
+    }
+
+    private func durableArtifactPath(
+        hubRoot: URL,
+        modelID: String,
+        revision: String,
+        sha256: String
+    ) throws -> String {
+        try CachedModelArtifactResolver(hubRoot: hubRoot).durableStore.artifactURL(
+            modelID: modelID,
+            revision: revision,
+            sha256: sha256
+        ).path
     }
 
     private func tempDir() throws -> URL {

--- a/phase3-binary/Tests/macprovider-cliTests/DurableModelArtifactStoreTests.swift
+++ b/phase3-binary/Tests/macprovider-cliTests/DurableModelArtifactStoreTests.swift
@@ -1,0 +1,195 @@
+import Darwin
+import Foundation
+import XCTest
+@testable import macprovider_cli
+
+final class DurableModelArtifactStoreTests: XCTestCase {
+    func testAdoptCopiesRegularFilesAndRejectsSymlinks() throws {
+        let root = try tempDir()
+        let store = DurableModelArtifactStore(root: root)
+        let staging = try tempDir()
+        try Data("weights".utf8).write(to: staging.appendingPathComponent("weights.bin"))
+        try Data("{}".utf8).write(to: staging.appendingPathComponent("config.json"))
+        let sha = try ModelArtifactVerifier.canonicalArtifactHash(directory: staging)
+        let revision = String(repeating: "a", count: 40)
+
+        let adopted = try store.adoptVerifiedStaging(
+            staging: staging,
+            modelID: "namespace/model",
+            revision: revision,
+            sha256: sha
+        )
+        XCTAssertTrue(store.contains(adopted.path))
+        XCTAssertEqual(try ModelArtifactVerifier.canonicalArtifactHash(directory: adopted), sha)
+        XCTAssertEqual(
+            try String(contentsOf: adopted.appendingPathComponent("weights.bin")),
+            "weights"
+        )
+
+        let linked = try tempDir()
+        try Data("weights".utf8).write(to: linked.appendingPathComponent("weights.bin"))
+        XCTAssertEqual(symlink("weights.bin", linked.appendingPathComponent("link.bin").path), 0)
+        XCTAssertThrowsError(
+            try store.adoptVerifiedStaging(
+                staging: linked,
+                modelID: "namespace/symlink",
+                revision: revision,
+                sha256: sha
+            )
+        )
+    }
+
+    func testGCKeepsActiveArtifactAndRemovesSiblings() throws {
+        let root = try tempDir()
+        let store = DurableModelArtifactStore(root: root)
+        let first = try tempDir()
+        try Data("one".utf8).write(to: first.appendingPathComponent("weights.bin"))
+        let firstSHA = try ModelArtifactVerifier.canonicalArtifactHash(directory: first)
+        let second = try tempDir()
+        try Data("two".utf8).write(to: second.appendingPathComponent("weights.bin"))
+        let secondSHA = try ModelArtifactVerifier.canonicalArtifactHash(directory: second)
+        let revision = String(repeating: "b", count: 40)
+
+        let kept = try store.adoptVerifiedStaging(
+            staging: first,
+            modelID: "namespace/model",
+            revision: revision,
+            sha256: firstSHA
+        )
+        let stale = try store.adoptVerifiedStaging(
+            staging: second,
+            modelID: "namespace/other",
+            revision: revision,
+            sha256: secondSHA
+        )
+        XCTAssertTrue(FileManager.default.fileExists(atPath: kept.path))
+        XCTAssertTrue(FileManager.default.fileExists(atPath: stale.path))
+
+        try store.gcInactive(keeping: [kept.path])
+        XCTAssertTrue(FileManager.default.fileExists(atPath: kept.path))
+        XCTAssertFalse(FileManager.default.fileExists(atPath: stale.path))
+    }
+
+    func testEscapedComponentRejectsPathTraversal() {
+        let store = DurableModelArtifactStore(root: URL(fileURLWithPath: "/tmp"))
+        XCTAssertThrowsError(
+            try store.artifactURL(
+                modelID: "foo/../bar",
+                revision: String(repeating: "c", count: 40),
+                sha256: String(repeating: "a", count: 64)
+            )
+        )
+    }
+
+    func testDetectsHuggingFaceCachePaths() {
+        XCTAssertTrue(
+            DurableModelArtifactStore.isHuggingFaceCachePath(
+                "/Users/tester/.cache/huggingface/hub/models--x--y/snapshots/abc"
+            )
+        )
+        XCTAssertFalse(
+            DurableModelArtifactStore.isHuggingFaceCachePath(
+                "/Users/tester/Library/Application Support/macprovider/models/x/abc"
+            )
+        )
+    }
+
+    func testIsModelMaterializedAfterAdopt() throws {
+        let root = try tempDir()
+        let store = DurableModelArtifactStore(root: root)
+        let staging = try tempDir()
+        try Data("weights".utf8).write(to: staging.appendingPathComponent("weights.bin"))
+        let sha = try ModelArtifactVerifier.canonicalArtifactHash(directory: staging)
+        XCTAssertFalse(store.isModelMaterialized(modelID: "namespace/model"))
+        _ = try store.adoptVerifiedStaging(
+            staging: staging,
+            modelID: "namespace/model",
+            revision: String(repeating: "d", count: 40),
+            sha256: sha
+        )
+        XCTAssertTrue(store.isModelMaterialized(modelID: "namespace/model"))
+        XCTAssertFalse(store.isModelMaterialized(modelID: "namespace/other"))
+    }
+
+    func testAdoptRepairsCorruptDurableDestinationFromHealthyStaging() throws {
+        let root = try tempDir()
+        let store = DurableModelArtifactStore(root: root)
+        let staging = try tempDir()
+        try Data("healthy".utf8).write(to: staging.appendingPathComponent("weights.bin"))
+        let sha = try ModelArtifactVerifier.canonicalArtifactHash(directory: staging)
+        let revision = String(repeating: "e", count: 40)
+        let destination = try store.artifactURL(
+            modelID: "namespace/model",
+            revision: revision,
+            sha256: sha
+        )
+        try FileManager.default.createDirectory(at: destination, withIntermediateDirectories: true)
+        XCTAssertEqual(symlink("missing.bin", destination.appendingPathComponent("broken.bin").path), 0)
+
+        let adopted = try store.adoptVerifiedStaging(
+            staging: staging,
+            modelID: "namespace/model",
+            revision: revision,
+            sha256: sha
+        )
+        XCTAssertEqual(adopted.path, destination.path)
+        XCTAssertEqual(try ModelArtifactVerifier.canonicalArtifactHash(directory: adopted), sha)
+        XCTAssertEqual(try String(contentsOf: adopted.appendingPathComponent("weights.bin")), "healthy")
+    }
+
+    func testContainsRejectsSymlinkInDurablePath() throws {
+        let root = try tempDir()
+        let store = DurableModelArtifactStore(root: root)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        let outside = try tempDir()
+        try Data("escaped".utf8).write(to: outside.appendingPathComponent("weights.bin"))
+        let link = root.appendingPathComponent("escape-link")
+        XCTAssertEqual(symlink(outside.path, link.path), 0)
+        XCTAssertFalse(store.contains(link.path))
+        XCTAssertFalse(store.contains(link.appendingPathComponent("weights.bin").path))
+    }
+
+    func testAdoptRejectsExistingDestinationReachedThroughSymlinkAncestor() throws {
+        let root = try tempDir()
+        let store = DurableModelArtifactStore(root: root)
+        let staging = try tempDir()
+        try Data("weights".utf8).write(to: staging.appendingPathComponent("weights.bin"))
+        let sha = try ModelArtifactVerifier.canonicalArtifactHash(directory: staging)
+        let revision = String(repeating: "f", count: 40)
+        let destination = try store.artifactURL(
+            modelID: "namespace/model",
+            revision: revision,
+            sha256: sha
+        )
+        let modelDir = destination.deletingLastPathComponent().deletingLastPathComponent()
+        let outside = try tempDir()
+        let escaped = outside.appendingPathComponent(modelDir.lastPathComponent, isDirectory: true)
+        try FileManager.default.createDirectory(at: destination, withIntermediateDirectories: true)
+        try Data("weights".utf8).write(to: destination.appendingPathComponent("weights.bin"))
+        try FileManager.default.moveItem(at: modelDir, to: escaped)
+        XCTAssertEqual(symlink(escaped.path, modelDir.path), 0)
+        XCTAssertTrue(FileManager.default.fileExists(atPath: destination.path))
+
+        XCTAssertThrowsError(
+            try store.adoptVerifiedStaging(
+                staging: staging,
+                modelID: "namespace/model",
+                revision: revision,
+                sha256: sha
+            )
+        ) { error in
+            XCTAssertTrue(String(describing: error).contains("symlink"), "\(error)")
+        }
+        XCTAssertThrowsError(try store.validatedContainedDirectory(destination.path))
+    }
+
+    private func tempDir() throws -> URL {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("DurableModelArtifactStoreTests-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        addTeardownBlock {
+            try? FileManager.default.removeItem(at: root)
+        }
+        return root
+    }
+}

--- a/phase3-binary/Tests/macprovider-cliTests/ProviderPreWarmerTests.swift
+++ b/phase3-binary/Tests/macprovider-cliTests/ProviderPreWarmerTests.swift
@@ -13,7 +13,10 @@ final class ProviderPreWarmerTests: XCTestCase {
             filename: "model.safetensors"
         )
 
-        let checker = HuggingFaceCacheChecker(cacheRoot: cacheRoot)
+        let checker = HuggingFaceCacheChecker(
+            cacheRoot: cacheRoot,
+            durableRoot: cacheRoot.appendingPathComponent("empty-durable", isDirectory: true)
+        )
         XCTAssertTrue(checker.isModelCached(modelID: "mlx-community/Llama-3.2-1B-Instruct-4bit"))
         XCTAssertFalse(checker.isModelCached(modelID: "mlx-community/OtherModel-4bit"))
     }
@@ -25,8 +28,30 @@ final class ProviderPreWarmerTests: XCTestCase {
             .appendingPathComponent("snapshots/empty-revision", isDirectory: true)
         try FileManager.default.createDirectory(at: snapshot, withIntermediateDirectories: true)
 
-        let checker = HuggingFaceCacheChecker(cacheRoot: cacheRoot)
+        let checker = HuggingFaceCacheChecker(
+            cacheRoot: cacheRoot,
+            durableRoot: cacheRoot.appendingPathComponent("empty-durable", isDirectory: true)
+        )
         XCTAssertFalse(checker.isModelCached(modelID: "mlx-community/EmptyModel"))
+    }
+
+    func testHuggingFaceCacheCheckerTreatsDurableStoreAsCached() throws {
+        let cacheRoot = try temporaryDirectory(name: "hf-durable-only")
+        let durableRoot = try temporaryDirectory(name: "durable-only")
+        let revision = String(repeating: "a", count: 40)
+        let weights = try temporaryDirectory(name: "durable-weights")
+        try Data("durable".utf8).write(to: weights.appendingPathComponent("weights.bin"))
+        let sha = try ModelArtifactVerifier.canonicalArtifactHash(directory: weights)
+        _ = try DurableModelArtifactStore(root: durableRoot).adoptVerifiedStaging(
+            staging: weights,
+            modelID: "mlx-community/DurableOnly-4bit",
+            revision: revision,
+            sha256: sha
+        )
+
+        let checker = HuggingFaceCacheChecker(cacheRoot: cacheRoot, durableRoot: durableRoot)
+        XCTAssertTrue(checker.isModelCached(modelID: "mlx-community/DurableOnly-4bit"))
+        XCTAssertFalse(checker.isModelCached(modelID: "mlx-community/OtherModel-4bit"))
     }
 
     func testPreWarmerHappyPathReturnsAlreadyCachedAndStopsProvider() async throws {

--- a/phase3-binary/Tests/macprovider-cliTests/ServeCommandTests.swift
+++ b/phase3-binary/Tests/macprovider-cliTests/ServeCommandTests.swift
@@ -1,4 +1,5 @@
 import ArgumentParser
+import Darwin
 import Foundation
 import MacProviderCore
 import XCTest
@@ -870,7 +871,7 @@ final class ServeCommandTests: XCTestCase {
         config.modelArtifactPath = snapshot.path
         config.modelArtifactSHA256 = expected
 
-        try await ServeCommand.runModelArtifactPreflight(config, joiningCoordinator: false)
+        try await ServeCommand.runModelArtifactPreflight(&config, joiningCoordinator: false)
     }
 
     func testSelfTestUsesVerifiedArtifactPathForRuntimeLoad() {
@@ -890,7 +891,7 @@ final class ServeCommandTests: XCTestCase {
         config.modelArtifactSHA256 = expected
 
         do {
-            try await ServeCommand.runModelArtifactPreflight(config, joiningCoordinator: true)
+            try await ServeCommand.runModelArtifactPreflight(&config, joiningCoordinator: true)
             XCTFail("coordinator-joining paid mode must require catalog provenance")
         } catch {
             // expected
@@ -902,7 +903,7 @@ final class ServeCommandTests: XCTestCase {
         config.model = "test-public-model"
 
         do {
-            try await ServeCommand.runModelArtifactPreflight(config, joiningCoordinator: true)
+            try await ServeCommand.runModelArtifactPreflight(&config, joiningCoordinator: true)
             XCTFail("coordinator-joining paid mode must require a verified artifact hash")
         } catch {
             // expected
@@ -915,7 +916,7 @@ final class ServeCommandTests: XCTestCase {
         config.model = "/tmp/arbitrary-model"
 
         do {
-            try await ServeCommand.runModelArtifactPreflight(config)
+            try await ServeCommand.runModelArtifactPreflight(&config)
             XCTFail("donor mode must require an artifact hash")
         } catch {
             // expected
@@ -932,7 +933,7 @@ final class ServeCommandTests: XCTestCase {
         config.modelArtifactSHA256 = expected
 
         do {
-            try await ServeCommand.runModelArtifactPreflight(config)
+            try await ServeCommand.runModelArtifactPreflight(&config)
             XCTFail("donor mode must require catalog provenance")
         } catch {
             // expected
@@ -1019,7 +1020,7 @@ final class ServeCommandTests: XCTestCase {
         config.modelCatalogHash = String(repeating: "a", count: 64)
 
         try await ServeCommand.runModelArtifactPreflight(
-            config,
+            &config,
             joiningCoordinator: true,
             staticInputs: staticInputs,
             artifactResolver: resolver
@@ -1098,6 +1099,211 @@ final class ServeCommandTests: XCTestCase {
         }
     }
 
+    func testCoordinatorJoinMigratesCacheBackedSnapshotToDurableStore() async throws {
+        let fixture = try await makeCatalogBoundFixture()
+        var config = fixture.config
+        try await ServeCommand.runModelArtifactPreflight(
+            &config,
+            joiningCoordinator: true,
+            staticInputs: fixture.staticInputs,
+            artifactResolver: fixture.resolver
+        )
+        XCTAssertEqual(config.modelArtifactPath, fixture.durablePath)
+        XCTAssertTrue(FileManager.default.fileExists(atPath: fixture.durablePath))
+        XCTAssertTrue(FileManager.default.fileExists(atPath: fixture.snapshot.path))
+    }
+
+    func testCoordinatorJoinServesDurableStoreAfterHuggingFaceCacheDeleted() async throws {
+        let fixture = try await makeCatalogBoundFixture()
+        var config = fixture.config
+        try await ServeCommand.runModelArtifactPreflight(
+            &config,
+            joiningCoordinator: true,
+            staticInputs: fixture.staticInputs,
+            artifactResolver: fixture.resolver
+        )
+        try FileManager.default.removeItem(at: fixture.snapshot)
+        config.modelArtifactPath = fixture.snapshot.path
+        try await ServeCommand.runModelArtifactPreflight(
+            &config,
+            joiningCoordinator: true,
+            staticInputs: fixture.staticInputs,
+            artifactResolver: fixture.resolver
+        )
+        XCTAssertEqual(config.modelArtifactPath, fixture.durablePath)
+        XCTAssertTrue(FileManager.default.fileExists(atPath: fixture.durablePath))
+        XCTAssertFalse(FileManager.default.fileExists(atPath: fixture.snapshot.path))
+    }
+
+    func testCoordinatorJoinPersistsMigratedDurablePathWithoutTouchingHomeConfig() async throws {
+        let fixture = try await makeCatalogBoundFixture()
+        let yaml = try tempDir().appendingPathComponent("config.yaml")
+        try """
+        model: \(fixture.config.model ?? "")
+        model_artifact_path: \(fixture.snapshot.path)
+        model_artifact_sha256: \(fixture.config.modelArtifactSHA256 ?? "")
+        """.write(to: yaml, atomically: true, encoding: .utf8)
+        var config = fixture.config
+        config.configPath = yaml.path
+        try await ServeCommand.runModelArtifactPreflight(
+            &config,
+            joiningCoordinator: true,
+            staticInputs: fixture.staticInputs,
+            artifactResolver: fixture.resolver,
+            persistConfigMigration: true
+        )
+        let post = try String(contentsOf: yaml, encoding: .utf8)
+        XCTAssertTrue(post.contains(fixture.durablePath), post)
+        XCTAssertFalse(post.contains("model_artifact_path: \(fixture.snapshot.path)\n"), post)
+        XCTAssertTrue(FileManager.default.fileExists(atPath: yaml.path + ".pre-durable-artifact.bak"))
+        XCTAssertEqual(config.modelArtifactPath, fixture.durablePath)
+    }
+
+    func testCoordinatorJoinRewritesNonCanonicalDurablePathToCatalogIdentity() async throws {
+        let fixture = try await makeCatalogBoundFixture()
+        var config = fixture.config
+        try await ServeCommand.runModelArtifactPreflight(
+            &config,
+            joiningCoordinator: true,
+            staticInputs: fixture.staticInputs,
+            artifactResolver: fixture.resolver
+        )
+        let alias = fixture.resolver.durableRoot
+            .appendingPathComponent("wrong--identity", isDirectory: true)
+            .appendingPathComponent(String(repeating: "1", count: 40), isDirectory: true)
+            .appendingPathComponent(try XCTUnwrap(config.modelArtifactSHA256), isDirectory: true)
+        try FileManager.default.createDirectory(at: alias.deletingLastPathComponent(), withIntermediateDirectories: true)
+        try FileManager.default.copyItem(at: URL(fileURLWithPath: fixture.durablePath), to: alias)
+        config.modelArtifactPath = alias.path
+        try await ServeCommand.runModelArtifactPreflight(
+            &config,
+            joiningCoordinator: true,
+            staticInputs: fixture.staticInputs,
+            artifactResolver: fixture.resolver
+        )
+        XCTAssertEqual(config.modelArtifactPath, fixture.durablePath)
+    }
+
+    func testCoordinatorJoinRejectsExactDurableIdentityReachedThroughSymlinkAncestor() async throws {
+        let fixture = try await makeCatalogBoundFixture()
+        var config = fixture.config
+        try await ServeCommand.runModelArtifactPreflight(
+            &config,
+            joiningCoordinator: true,
+            staticInputs: fixture.staticInputs,
+            artifactResolver: fixture.resolver
+        )
+        let identity = URL(fileURLWithPath: fixture.durablePath)
+        let modelDir = identity.deletingLastPathComponent().deletingLastPathComponent()
+        let outside = try tempDir()
+        let escaped = outside.appendingPathComponent(modelDir.lastPathComponent, isDirectory: true)
+        try FileManager.default.moveItem(at: modelDir, to: escaped)
+        try FileManager.default.createSymbolicLink(at: modelDir, withDestinationURL: escaped)
+        config.modelArtifactPath = fixture.durablePath
+        do {
+            try await ServeCommand.runModelArtifactPreflight(
+                &config,
+                joiningCoordinator: true,
+                staticInputs: fixture.staticInputs,
+                artifactResolver: fixture.resolver
+            )
+            XCTFail("symlink-escaped durable identity path must fail closed")
+        } catch is ExitCode {
+            // expected
+        }
+    }
+
+    func testCoordinatorJoinPersistIgnoresIndentedNestedArtifactPath() async throws {
+        let fixture = try await makeCatalogBoundFixture()
+        let yaml = try tempDir().appendingPathComponent("config.yaml")
+        try """
+        model: \(fixture.config.model ?? "")
+        model_artifact_path: \(fixture.snapshot.path)
+        model_artifact_sha256: \(fixture.config.modelArtifactSHA256 ?? "")
+        nested:
+          model_artifact_path: \(fixture.snapshot.path)
+        """.write(to: yaml, atomically: true, encoding: .utf8)
+        var config = fixture.config
+        config.configPath = yaml.path
+        try await ServeCommand.runModelArtifactPreflight(
+            &config,
+            joiningCoordinator: true,
+            staticInputs: fixture.staticInputs,
+            artifactResolver: fixture.resolver,
+            persistConfigMigration: true
+        )
+        let post = try String(contentsOf: yaml, encoding: .utf8)
+        XCTAssertTrue(post.contains("model_artifact_path: \(fixture.durablePath)"), post)
+        XCTAssertTrue(post.contains("  model_artifact_path: \(fixture.snapshot.path)"), post)
+        XCTAssertEqual(config.modelArtifactPath, fixture.durablePath)
+    }
+
+    func testPersistMigratedArtifactPathBackupIsOwnerOnly() throws {
+        let yaml = try tempDir().appendingPathComponent("config.yaml")
+        try """
+        model_artifact_path: /old/snapshot
+        provider_token: secret-token
+        """.write(to: yaml, atomically: true, encoding: .utf8)
+        try FileManager.default.setAttributes([.posixPermissions: 0o600], ofItemAtPath: yaml.path)
+        try ServeCommand.persistMigratedArtifactPath(
+            configPath: yaml.path,
+            from: "/old/snapshot",
+            to: "/new/durable"
+        )
+        let backup = yaml.path + ".pre-durable-artifact.bak"
+        let backupMode = try FileManager.default.attributesOfItem(atPath: backup)[.posixPermissions] as? NSNumber
+        XCTAssertEqual((backupMode?.intValue ?? 0) & 0o077, 0)
+        let configMode = try FileManager.default.attributesOfItem(atPath: yaml.path)[.posixPermissions] as? NSNumber
+        XCTAssertEqual((configMode?.intValue ?? 0) & 0o777, 0o600)
+        XCTAssertTrue(try String(contentsOf: yaml, encoding: .utf8).contains("model_artifact_path: /new/durable"))
+        XCTAssertTrue(try String(contentsOf: URL(fileURLWithPath: backup), encoding: .utf8).contains("model_artifact_path: /old/snapshot"))
+    }
+
+    func testPersistMigratedArtifactPathWaitsForSharedProviderConfigMutationLock() throws {
+        let yaml = try tempDir().appendingPathComponent("config.yaml")
+        try "model_artifact_path: /old/snapshot\n".write(to: yaml, atomically: true, encoding: .utf8)
+        let lockURL = yaml.deletingLastPathComponent().appendingPathComponent(".config.yaml.lock")
+        let lockFD = open(lockURL.path, O_CREAT | O_RDWR | O_NOFOLLOW, 0o600)
+        XCTAssertGreaterThanOrEqual(lockFD, 0)
+        guard lockFD >= 0 else { return }
+        XCTAssertEqual(flock(lockFD, LOCK_EX), 0)
+
+        let started = DispatchSemaphore(value: 0)
+        let finished = DispatchSemaphore(value: 0)
+        DispatchQueue.global().async {
+            started.signal()
+            try? ServeCommand.persistMigratedArtifactPath(
+                configPath: yaml.path,
+                from: "/old/snapshot",
+                to: "/new/durable"
+            )
+            finished.signal()
+        }
+
+        XCTAssertEqual(started.wait(timeout: .now() + 1), .success)
+        XCTAssertEqual(
+            finished.wait(timeout: .now() + 0.15),
+            .timedOut,
+            "artifact-path persist must wait for the shared provider config mutation lock"
+        )
+        XCTAssertEqual(flock(lockFD, LOCK_UN), 0)
+        _ = close(lockFD)
+        XCTAssertEqual(finished.wait(timeout: .now() + 5), .success)
+        XCTAssertTrue(try String(contentsOf: yaml, encoding: .utf8).contains("model_artifact_path: /new/durable"))
+    }
+
+    func testPersistMigratedArtifactPathSkipsWhenTopLevelPathAlreadyChanged() throws {
+        let yaml = try tempDir().appendingPathComponent("config.yaml")
+        try "model_artifact_path: /other/snapshot\n".write(to: yaml, atomically: true, encoding: .utf8)
+        try ServeCommand.persistMigratedArtifactPath(
+            configPath: yaml.path,
+            from: "/old/snapshot",
+            to: "/new/durable"
+        )
+        XCTAssertEqual(try String(contentsOf: yaml, encoding: .utf8), "model_artifact_path: /other/snapshot\n")
+        XCTAssertFalse(FileManager.default.fileExists(atPath: yaml.path + ".pre-durable-artifact.bak"))
+    }
+
     private func assertCatalogBoundSnapshotPreflight(runtimeStatus: String, donorMode: Bool) async throws {
         try await assertCatalogBoundSnapshotPreflight(
             runtimeStatus: runtimeStatus,
@@ -1172,10 +1378,82 @@ final class ServeCommandTests: XCTestCase {
         config.modelCatalogHash = AutotuneStaticInputs.candidateCatalogSHA256(bytes: catalogBytes)
 
         try await ServeCommand.runModelArtifactPreflight(
-            config,
+            &config,
             joiningCoordinator: true,
             staticInputs: staticInputs,
             artifactResolver: resolver
+        )
+    }
+
+    private struct CatalogBoundFixture {
+        var config: AppConfig
+        var resolver: CachedModelArtifactResolver
+        var snapshot: URL
+        var durablePath: String
+        var staticInputs: AutotuneStaticInputs
+    }
+
+    private func makeCatalogBoundFixture() async throws -> CatalogBoundFixture {
+        let hub = try tempDir()
+        let resolver = CachedModelArtifactResolver(hubRoot: hub)
+        let key = "test-model"
+        let modelID = "test/model"
+        let revision = String(repeating: "1", count: 40)
+        let snapshot = resolver.snapshotURL(modelID: modelID, revision: revision)
+        try FileManager.default.createDirectory(at: snapshot, withIntermediateDirectories: true)
+        try Data("weights".utf8).write(to: snapshot.appendingPathComponent("model.safetensors"))
+        try Data("{}".utf8).write(to: snapshot.appendingPathComponent("config.json"))
+        let artifactSHA = try ModelArtifactVerifier.canonicalArtifactHash(directory: snapshot)
+        let catalogJSON = """
+        {"version":"test-catalog","generated_at":"2026-07-29T08:45:00Z","source":"operator_curated_autotune_candidate_catalog","policy_version":"autotune-policy-v1","rows":{"\(key)":{"model_id":"\(modelID)","model_revision":"\(revision)","model_sha256":"\(artifactSHA)","min_ram_gb":1,"min_bandwidth_tier":"C","bench_gate":{"min_sustained_tps":1,"max_4k_ttft_ms":1000,"provenance":{"source":"legacy_unverified","notes":"test fixture"}},"runtime_status":"recommendable"}}}
+        """
+        let rateCardJSON = Self.validRateCardJSON(keys: [key])
+        let demandRankJSON = Self.validDemandRankJSON(keys: [key], version: "test-catalog")
+        let catalogBytes = Data(catalogJSON.utf8)
+        let rateCardBytes = Data(rateCardJSON.utf8)
+        let demandRankBytes = Data(demandRankJSON.utf8)
+        let staticInputs = AutotuneStaticInputs(
+            fetch: { url in
+                switch url.path {
+                case "/v1/rate-card":
+                    return rateCardBytes
+                case "/v1/autotune-candidates":
+                    return catalogBytes
+                case "/v1/demand-rank":
+                    return demandRankBytes
+                default:
+                    break
+                }
+                if url.path.hasSuffix(".sig") {
+                    let signature = Data(repeating: 0, count: 64).base64EncodedString()
+                    return Data("{\"key_id\":\"streamvc-autotune-static-v4\",\"alg\":\"ed25519\",\"signature\":\"\(signature)\"}".utf8)
+                }
+                return catalogBytes
+            },
+            verifySignature: { _, _ in true },
+            now: { ISO8601DateFormatter.autotuneInternet.date(from: "2026-07-29T08:45:00Z")! }
+        )
+        var config = AppConfig.defaults()
+        config.model = key
+        config.modelArtifactPath = snapshot.path
+        config.modelArtifactSHA256 = artifactSHA
+        config.modelCatalogKey = key
+        config.modelCatalogModelID = modelID
+        config.modelCatalogRevision = revision
+        config.modelCatalogSHA256 = artifactSHA
+        config.modelCatalogVersion = "test-catalog"
+        config.modelCatalogHash = AutotuneStaticInputs.candidateCatalogSHA256(bytes: catalogBytes)
+        let durablePath = try resolver.durableStore.artifactURL(
+            modelID: modelID,
+            revision: revision,
+            sha256: artifactSHA
+        ).path
+        return CatalogBoundFixture(
+            config: config,
+            resolver: resolver,
+            snapshot: snapshot,
+            durablePath: durablePath,
+            staticInputs: staticInputs
         )
     }
 
@@ -1240,7 +1518,7 @@ final class ServeCommandTests: XCTestCase {
         config.modelArtifactSHA256 = String(repeating: "b", count: 64)
 
         do {
-            try await ServeCommand.runModelArtifactPreflight(config)
+            try await ServeCommand.runModelArtifactPreflight(&config)
             XCTFail("artifact mismatch must fail")
         } catch {
             // expected
@@ -1253,7 +1531,7 @@ final class ServeCommandTests: XCTestCase {
         config.modelArtifactSHA256 = String(repeating: "a", count: 64)
 
         do {
-            try await ServeCommand.runModelArtifactPreflight(config)
+            try await ServeCommand.runModelArtifactPreflight(&config)
             XCTFail("artifact hash must require a local path")
         } catch {
             // expected
@@ -1267,7 +1545,7 @@ final class ServeCommandTests: XCTestCase {
         config.modelArtifactPath = snapshot.path
 
         do {
-            try await ServeCommand.runModelArtifactPreflight(config, joiningCoordinator: false)
+            try await ServeCommand.runModelArtifactPreflight(&config, joiningCoordinator: false)
             XCTFail("artifact path must require a verification hash")
         } catch {
             // expected

--- a/phase3-binary/Tests/macprovider-cliTests/ServingKnobsConfigTests.swift
+++ b/phase3-binary/Tests/macprovider-cliTests/ServingKnobsConfigTests.swift
@@ -28,6 +28,25 @@ final class ServingKnobsConfigTests: XCTestCase {
         XCTAssertFalse(config.enableReceipts)
         XCTAssertFalse(config.pagedKV.enabled)
         XCTAssertFalse(config.pagedKV.effectiveEnabled)
+        XCTAssertNil(config.modelArtifactRoot)
+    }
+
+    func testModelArtifactRootYAMLAndEnvironment() throws {
+        let yaml = try ConfigLoader.load(
+            cli: CLIOverrides(),
+            environment: [:],
+            fileExists: { _ in true },
+            readFile: { _ in "model_artifact_root: /tmp/macprovider-models\n" }
+        )
+        XCTAssertEqual(yaml.modelArtifactRoot, "/tmp/macprovider-models")
+
+        let env = try ConfigLoader.load(
+            cli: CLIOverrides(),
+            environment: ["MACPROVIDER_MODEL_ARTIFACT_ROOT": "/tmp/env-models"],
+            fileExists: { _ in true },
+            readFile: { _ in "model_artifact_root: /tmp/macprovider-models\n" }
+        )
+        XCTAssertEqual(env.modelArtifactRoot, "/tmp/env-models")
     }
 
     func testEnableReceiptsCLIOverridesEnvironmentOverridesYAML() throws {

--- a/phase3-binary/Tests/macprovider-cliTests/UninstallCommandTests.swift
+++ b/phase3-binary/Tests/macprovider-cliTests/UninstallCommandTests.swift
@@ -307,6 +307,9 @@ final class UninstallCommandTests: XCTestCase {
         try Data("lease".utf8).write(to: lifecycle.appendingPathComponent("lease-v1.json"))
         try Data("manifest".utf8).write(to: root.appendingPathComponent("install_manifest.json"))
         try Data("hidden".utf8).write(to: root.appendingPathComponent(".residue"))
+        let models = root.appendingPathComponent("models", isDirectory: true)
+        try FileManager.default.createDirectory(at: models, withIntermediateDirectories: true)
+        try Data("weights".utf8).write(to: models.appendingPathComponent("weights.bin"))
 
         var warnings: [String] = []
         UninstallCommand.cleanupApplicationSupportPreservingLifecycleState(


### PR DESCRIPTION
## Summary
- Keep catalog-bound model weights in `~/Library/Application Support/macprovider/models` (or `MACPROVIDER_MODEL_ARTIFACT_ROOT` / `model_artifact_root`) so paid serve survives Hugging Face cache cleanup (#1123).
- Serve preflight migrates cache-backed snapshots onto the catalog identity path after signed-row admission, then persists `model_artifact_path` under the shared provider config lock.
- Autotune recommend/prefetch/apply and `models list`/`adopt` honor the same durable root overlay; durable paths reject symlink ancestors and owner-only backups preserve config mode.

## Test plan
- [x] `swift test --filter DurableModelArtifactStoreTests`
- [x] `swift test --filter testCoordinatorJoin`
- [x] `swift test --filter testPersistMigratedArtifactPath`
- [x] `swift test --filter testResolverForConfigOverlaysYAMLRootAndAdoptsThere`

SPEC-GOVERNANCE-DECLARATION-BEGIN
{
  "schema_version": "spec-pr-governance-v1",
  "behavior_change": "yes",
  "contract_change": "none",
  "specs": ["SPEC-023"],
  "requirements": ["SPEC-023-R002"],
  "authority_domains": ["installer-autotune-policy"],
  "arbitration": ["CODE_BUG"],
  "tests": [
    "phase3-binary/Tests/macprovider-cliTests/DurableModelArtifactStoreTests.swift::testAdoptCopiesRegularFilesAndRejectsSymlinks",
    "phase3-binary/Tests/macprovider-cliTests/ServeCommandTests.swift::testCoordinatorJoinServesDurableStoreAfterHuggingFaceCacheDeleted",
    "phase3-binary/Tests/macprovider-cliTests/AutotuneRecommendTests.swift::testResolverForConfigOverlaysYAMLRootAndAdoptsThere"
  ],
  "journeys": ["not-required"],
  "issue": "https://github.com/Augustas11/macprovider/issues/1123"
}
SPEC-GOVERNANCE-DECLARATION-END

Made with [Cursor](https://cursor.com)