### PR TITLE
Keep creator-MVP signed-evidence artifact names under GitHub's 256-character limit

### DIFF
--- a/.github/workflows/build-signed-trusted-pool-creator-mvp-journey.yml
+++ b/.github/workflows/build-signed-trusted-pool-creator-mvp-journey.yml
@@ -204,7 +204,7 @@ jobs:
       - name: Upload signed evidence artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
-          name: signed-trusted-pool-creator-mvp-journey-evidence-${{ steps.request.outputs.source_sha }}-${{ steps.request.outputs.requirement_slug }}
+          name: signed-trusted-pool-creator-mvp-journey-evidence-${{ steps.request.outputs.short_sha }}
           path: ${{ runner.temp }}/signed-trusted-pool-creator-mvp-journey-evidence/
           if-no-files-found: error
           include-hidden-files: false

--- a/scripts/test-signed-trusted-pool-creator-mvp-journey-workflow.sh
+++ b/scripts/test-signed-trusted-pool-creator-mvp-journey-workflow.sh
@@ -55,13 +55,19 @@ required_workflow = [
     "scripts/check_spec_governance.py --base-ref origin/main",
     "actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a",
     "retention-days: 1",
-    "signed-trusted-pool-creator-mvp-journey-evidence-${{ steps.request.outputs.source_sha }}-${{ steps.request.outputs.requirement_slug }}",
+    "signed-trusted-pool-creator-mvp-journey-evidence-${{ steps.request.outputs.short_sha }}",
     "macprovider.signed-trusted-pool-creator-mvp-journey-evidence.v1",
     "JOURNEY-TRUSTED-POOL-CREATOR-MVP",
 ]
 for value in required_workflow:
     if value not in workflow:
         raise SystemExit(f"workflow contract is missing: {value}")
+
+upload_name = "signed-trusted-pool-creator-mvp-journey-evidence-" + ("a" * 12)
+if len(upload_name) > 256:
+    raise SystemExit("GitHub Actions artifact names must stay within 256 characters")
+if "steps.request.outputs.requirement_slug }}" in workflow.split("name: signed-trusted-pool-creator-mvp-journey-evidence-", 1)[-1].split("\n", 1)[0]:
+    raise SystemExit("GitHub Actions artifact name must not include the full SPEC-043 requirement slug")
 
 if "\n  push:" in workflow or "\n  pull_request:" in workflow:
     raise SystemExit("workflow must be manual dispatch only")


### PR DESCRIPTION
## Summary
- The protected signer already signed Gate A evidence, then failed on `upload-artifact` because the artifact name with all 12 SPEC-043 IDs exceeded 256 characters.
- Name the GitHub Actions artifact by the 12-character source SHA so the signed envelope can be exported. This does not promote SPEC-043.

## Test plan
- [x] `bash scripts/test-signed-trusted-pool-creator-mvp-journey-workflow.sh`
- [ ] After merge, re-dispatch `.github/workflows/build-signed-trusted-pool-creator-mvp-journey.yml` from `main` with the same Gate A inputs as #1173.

SPEC-GOVERNANCE-DECLARATION-BEGIN
{
  "schema_version": "spec-pr-governance-v1",
  "behavior_change": "yes",
  "contract_change": "none",
  "specs": ["SPEC-043"],
  "requirements": ["SPEC-043-R012"],
  "authority_domains": ["trusted-pool-creator-onboarding"],
  "arbitration": ["DECISION_REQUIRED"],
  "tests": ["scripts/test-signed-trusted-pool-creator-mvp-journey-workflow.sh"],
  "journeys": ["JOURNEY-TRUSTED-POOL-CREATOR-MVP"],
  "issue": "https://github.com/Augustas11/macprovider/issues/1160"
}
SPEC-GOVERNANCE-DECLARATION-END

Made with [Cursor](https://cursor.com)