### PR TITLE
Keep Codex worktrees out of the home directory

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -88,15 +88,16 @@ command and result.
 ## Git Workflow
 
 Never do write-heavy work in canonical `/Users/augstar/macprovider-poc` unless
-the user explicitly says to use that checkout. Start from a fresh sibling
-worktree:
+the user explicitly says to use that checkout. Start from a fresh worktree under
+the hidden local worktree root so Finder does not fill with task directories:
 
 ```bash
 git status -sb
 git worktree list
 git fetch origin
-git worktree add ../macprovider-<topic> -b <scope>/<topic> origin/main
-cd ../macprovider-<topic>
+mkdir -p /Users/augstar/.codex/worktrees/macprovider
+git worktree add /Users/augstar/.codex/worktrees/macprovider/<topic> -b codex/<topic> origin/main
+cd /Users/augstar/.codex/worktrees/macprovider/<topic>
 ```
 
 Use one branch per task. Before pushing or opening a PR, verify
@@ -114,7 +115,16 @@ After any PR squash-merge or direct docs push, sync canonical main:
 git -C /Users/augstar/macprovider-poc fetch origin
 git -C /Users/augstar/macprovider-poc checkout main
 git -C /Users/augstar/macprovider-poc reset --hard origin/main
+git -C /Users/augstar/macprovider-poc worktree prune
+git -C /Users/augstar/macprovider-poc branch --merged origin/main
 ```
+
+Do not leave completed task worktrees behind. After a PR has merged or a task is
+abandoned, run `scripts/prune-merged-worktrees.sh` from the canonical checkout,
+inspect the dry-run, then run `scripts/prune-merged-worktrees.sh --apply` only
+for clean worktrees reported as merged into or patch-equivalent to `origin/main`.
+If a PR is still open, either keep the worktree intentionally and say so, or
+remove it only after confirming there is no unpushed work needed locally.
 
 Do not force-push `main`, admin-merge, bypass branch protection, or merge with
 red required checks unless the user gives explicit written approval for that

--- a/scripts/check_spec_pr_declaration.py
+++ b/scripts/check_spec_pr_declaration.py
@@ -55,6 +55,7 @@ GOVERNANCE_ONLY_PATHS = (
     "scripts/check_spec_governance.py",
     "scripts/check_spec_pr_declaration.py",
     "scripts/gen_spec_index.py",
+    "scripts/prune-merged-worktrees.sh",
     "scripts/tests/",
     "specs/",
 )

--- a/scripts/prune-merged-worktrees.sh
+++ b/scripts/prune-merged-worktrees.sh
@@ -1,0 +1,196 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE'
+Usage: scripts/prune-merged-worktrees.sh [--apply] [--base REF] [--strict] [--delete-branches]
+
+Dry-run by default. Removes only registered, clean MacProvider task worktrees
+whose HEAD is already contained in REF, or patch-equivalent to REF unless
+--strict is used.
+
+Options:
+  --apply            Actually remove eligible worktrees. Without this, print what would happen.
+  --base REF         Compare against REF. Default: origin/main.
+  --strict           Require HEAD to be an ancestor of REF; do not accept patch equivalence.
+  --delete-branches  After removing a worktree, run safe `git branch -d` for its local branch.
+  -h, --help         Show this help.
+USAGE
+}
+
+apply=false
+base=origin/main
+allow_patch_equivalent=true
+delete_branches=false
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --apply)
+      apply=true
+      ;;
+    --base)
+      [[ $# -ge 2 ]] || { echo "missing value for --base" >&2; exit 2; }
+      base="$2"
+      shift
+      ;;
+    --strict)
+      allow_patch_equivalent=false
+      ;;
+    --delete-branches)
+      delete_branches=true
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "unknown argument: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+  shift
+done
+
+repo_root="$(git rev-parse --show-toplevel)"
+canonical_root="/Users/augstar/macprovider-poc"
+git rev-parse --verify --quiet "$base" >/dev/null || {
+  echo "base ref does not exist: $base" >&2
+  exit 2
+}
+
+is_managed_task_path() {
+  local path="$1"
+  case "$path" in
+    /Users/augstar/macprovider-*|/private/tmp/macprovider-*|/Users/augstar/.codex/worktrees/macprovider/*)
+      return 0
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+}
+
+short_branch_name() {
+  local ref="$1"
+  if [[ "$ref" == refs/heads/* ]]; then
+    printf '%s\n' "${ref#refs/heads/}"
+  else
+    printf '%s\n' ""
+  fi
+}
+
+worktree_size() {
+  du -sh "$1" 2>/dev/null | awk '{print $1}'
+}
+
+worktree_kib() {
+  du -sk "$1" 2>/dev/null | awk '{print $1}'
+}
+
+has_clean_status() {
+  [[ -z "$(git -C "$1" status --porcelain=v1)" ]]
+}
+
+is_patch_equivalent() {
+  local head="$1"
+  local cherry
+  cherry="$(git cherry "$base" "$head")"
+  [[ -n "$cherry" ]] && ! grep -q '^+' <<<"$cherry"
+}
+
+eligible_reason() {
+  local head="$1"
+  if git merge-base --is-ancestor "$head" "$base"; then
+    printf '%s\n' "ancestor-of-$base"
+    return 0
+  fi
+  if [[ "$allow_patch_equivalent" == true ]] && is_patch_equivalent "$head"; then
+    printf '%s\n' "patch-equivalent-to-$base"
+    return 0
+  fi
+  return 1
+}
+
+removed=0
+skipped=0
+eligible_kib=0
+path=""
+head=""
+branch_ref=""
+
+process_worktree() {
+  [[ -n "$path" ]] || return 0
+
+  local reason size kib branch_name
+  branch_name="$(short_branch_name "$branch_ref")"
+  size="$(worktree_size "$path")"
+  kib="$(worktree_kib "$path")"
+
+  if [[ "$path" == "$repo_root" || "$path" == "$canonical_root" || "$branch_name" == "main" ]]; then
+    printf 'skip canonical\t%s\n' "$path"
+    skipped=$((skipped + 1))
+    return 0
+  fi
+
+  if ! is_managed_task_path "$path"; then
+    printf 'skip outside-managed-roots\t%s\n' "$path"
+    skipped=$((skipped + 1))
+    return 0
+  fi
+
+  if ! has_clean_status "$path"; then
+    printf 'skip dirty\t%s\t%s\t%s\n' "${size:-?}" "${branch_name:-detached}" "$path"
+    skipped=$((skipped + 1))
+    return 0
+  fi
+
+  if ! reason="$(eligible_reason "$head")"; then
+    printf 'skip unmerged\t%s\t%s\t%s\n' "${size:-?}" "${branch_name:-detached}" "$path"
+    skipped=$((skipped + 1))
+    return 0
+  fi
+
+  if [[ "$apply" == true ]]; then
+    printf 'remove %s\t%s\t%s\t%s\n' "$reason" "${size:-?}" "${branch_name:-detached}" "$path"
+    git worktree remove "$path"
+    if [[ "$delete_branches" == true && -n "$branch_name" ]]; then
+      git branch -d "$branch_name" || true
+    fi
+  else
+    printf 'would-remove %s\t%s\t%s\t%s\n' "$reason" "${size:-?}" "${branch_name:-detached}" "$path"
+  fi
+  removed=$((removed + 1))
+  if [[ "$kib" =~ ^[0-9]+$ ]]; then
+    eligible_kib=$((eligible_kib + kib))
+  fi
+}
+
+while IFS= read -r line || [[ -n "$line" ]]; do
+  if [[ -z "$line" ]]; then
+    process_worktree
+    path=""
+    head=""
+    branch_ref=""
+    continue
+  fi
+
+  case "$line" in
+    worktree\ *)
+      path="${line#worktree }"
+      ;;
+    HEAD\ *)
+      head="${line#HEAD }"
+      ;;
+    branch\ *)
+      branch_ref="${line#branch }"
+      ;;
+  esac
+done < <(git worktree list --porcelain)
+process_worktree
+
+if [[ "$apply" == true ]]; then
+  git worktree prune
+fi
+
+printf 'summary eligible=%d skipped=%d eligible_gib=%.1f mode=%s base=%s\n' "$removed" "$skipped" "$(awk -v kib="$eligible_kib" 'BEGIN { printf "%.1f", kib / 1024 / 1024 }')" "$([[ "$apply" == true ]] && echo apply || echo dry-run)" "$base"


### PR DESCRIPTION
## Summary

- route MacProvider Codex worktrees into a hidden local root instead of the home directory
- add a dry-run cleanup helper for merged or patch-equivalent task worktrees
- classify the helper as agent-governance-only for PR declaration checks

## Tests

- `bash -n scripts/prune-merged-worktrees.sh`
- `git diff --check`
- `scripts/prune-merged-worktrees.sh` dry-run
- `scripts/prune-merged-worktrees.sh --strict` dry-run
- `python3 scripts/check_spec_pr_declaration.py --event /private/tmp/pr-event-worktree-hygiene.json --base origin/main --head HEAD`

SPEC-GOVERNANCE-DECLARATION-BEGIN
{"schema_version":"spec-pr-governance-v1","behavior_change":"none","contract_change":"none","specs":[],"requirements":[],"authority_domains":[],"arbitration":[],"tests":["bash -n scripts/prune-merged-worktrees.sh","git diff --check","scripts/prune-merged-worktrees.sh dry-run","scripts/prune-merged-worktrees.sh --strict dry-run","python3 scripts/check_spec_pr_declaration.py --event /private/tmp/pr-event-worktree-hygiene.json --base origin/main --head HEAD"],"journeys":["not-required"]}
SPEC-GOVERNANCE-DECLARATION-END
