### PR TITLE
Clarify Malibu trust review copy

### DIFF
--- a/phase3-binary/app/Sources/Malibu/Agent/AgentSnapshot.swift
+++ b/phase3-binary/app/Sources/Malibu/Agent/AgentSnapshot.swift
@@ -715,7 +715,7 @@ enum AgentSnapshotPresenter {
         }
         let tier = s.trustTier.rawValue.capitalized
         if hasDemotionCooldown(s) {
-            return "Trust: \(tier) · requalification cooldown active"
+            return "Trust: \(tier) · Trust review in progress"
         }
         if s.trustTier == .trusted {
             return "Trust: Trusted"
@@ -728,7 +728,7 @@ enum AgentSnapshotPresenter {
 
     private static func trustCriteriaAction(_ s: AgentSnapshot) -> String? {
         if hasDemotionCooldown(s) {
-            return "Re-qualify for Trusted to clear the cooldown."
+            return "Keep Malibu online; withdrawals unlock automatically when Trusted."
         }
         guard let met = s.trustCriteriaMet,
               let required = s.trustCriteriaRequired,
@@ -1624,7 +1624,7 @@ enum AgentSnapshotPresenter {
         } else if holdReasons.contains("per_wallet_daily_cap") {
             nextAction = "The wallet cap resets at the next UTC day."
         } else if holdReasons.contains("demotion_cooldown") {
-            nextAction = "Re-qualify for Trusted to clear the cooldown."
+            nextAction = "Keep Malibu online; withdrawals unlock automatically when Trusted."
         } else {
             nextAction = "Review the hold reason above before withdrawing."
         }
@@ -1635,7 +1635,7 @@ enum AgentSnapshotPresenter {
         guard s.malibuProjectionFresh else { return "MALIBU trust telemetry not published yet" }
         let tier = s.trustTier.rawValue.capitalized
         if hasDemotionCooldown(s) {
-            return "\(tier) — requalification cooldown active"
+            return "\(tier) — Trust review in progress"
         }
         if s.trustTier == .trusted {
             return "Trusted"
@@ -1954,7 +1954,7 @@ enum AgentSnapshotPresenter {
         case "per_wallet_daily_cap":
             return "the wallet's daily limit has been reached"
         case "demotion_cooldown":
-            return "a Trust cooldown is active"
+            return "Trust verification is in progress"
         default:
             return "payout eligibility is still being verified"
         }
@@ -2034,7 +2034,7 @@ enum AgentSnapshotPresenter {
         case "held_provisional_trust_tier":
             return "MALIBU is locked until Trusted"
         case "held_demotion_cooldown":
-            return "MALIBU is locked during Trust requalification"
+            return "MALIBU is locked until Trusted"
         case "withdrawable_balance_available":
             return "MALIBU is available to withdraw"
         case "withdrawable_no_balance":
@@ -2085,7 +2085,7 @@ enum AgentSnapshotPresenter {
         case "held_provisional_trust_tier":
             return "Trust verification is incomplete"
         case "held_demotion_cooldown":
-            return "Trust requalification is in progress"
+            return "Trust verification is in progress"
         case "missing_wallet_binding":
             return "wallet binding is missing"
         case "insufficient_verified_receipts":
@@ -2115,7 +2115,7 @@ enum AgentSnapshotPresenter {
         case "held_provisional_trust_tier":
             return "Complete the remaining trust criteria to unlock withdrawals."
         case "held_demotion_cooldown":
-            return "Re-qualify for Trusted to clear the cooldown."
+            return "Keep Malibu online; withdrawals unlock automatically when Trusted."
         case "missing_wallet_binding":
             return "Add a payout wallet."
         case "insufficient_verified_receipts":

--- a/phase3-binary/app/Tests/MalibuTests/AgentSnapshotPresenterTests.swift
+++ b/phase3-binary/app/Tests/MalibuTests/AgentSnapshotPresenterTests.swift
@@ -1154,6 +1154,18 @@ final class AgentSnapshotPresenterTests: XCTestCase {
             AgentSnapshotPresenter.malibuHoldLine(snapshot),
             "MALIBU status: provider daily limit reached Next: The provider cap resets at the next UTC day."
         )
+
+        snapshot.trustTier = .provisional
+        snapshot.malibuRewardEligibility = MalibuRewardEligibility(
+            earningState: "held",
+            withdrawalState: "held",
+            primaryReason: "held_demotion_cooldown",
+            reasons: ["held_demotion_cooldown"]
+        )
+        XCTAssertEqual(
+            AgentSnapshotPresenter.malibuHoldLine(snapshot),
+            "MALIBU status: Trust verification is in progress Next: Keep Malibu online; withdrawals unlock automatically when Trusted."
+        )
     }
 
     func testRewardEligibilityV1OverridesLegacyMalibuPresentation() {

--- a/phase3-binary/app/Tests/MalibuTests/DashboardViewTests.swift
+++ b/phase3-binary/app/Tests/MalibuTests/DashboardViewTests.swift
@@ -314,9 +314,9 @@ final class DashboardViewTests: XCTestCase {
         provisional.trustCriteriaMet = 2
         provisional.trustCriteriaRequired = 2
         let cooldownHealth = AgentSnapshotPresenter.miningHealth(provisional)
-        XCTAssertEqual(cooldownHealth.trustSummary, "Trust: Provisional · requalification cooldown active")
-        XCTAssertEqual(cooldownHealth.nextAction, "Re-qualify for Trusted to clear the cooldown.")
-        XCTAssertEqual(AgentSnapshotPresenter.trustLine(provisional), "Provisional — requalification cooldown active")
+        XCTAssertEqual(cooldownHealth.trustSummary, "Trust: Provisional · Trust review in progress")
+        XCTAssertEqual(cooldownHealth.nextAction, "Keep Malibu online; withdrawals unlock automatically when Trusted.")
+        XCTAssertEqual(AgentSnapshotPresenter.trustLine(provisional), "Provisional — Trust review in progress")
 
         var trustedWithHistoricalHold = provisional
         trustedWithHistoricalHold.trustTier = .trusted


### PR DESCRIPTION
## Summary
- Replace non-actionable Malibu "requalification cooldown" copy with automatic trust-review language.
- Keep provider guidance to "Keep Malibu online" while withdrawal authority remains backend Trusted status.
- Add/update tests for dashboard and reward eligibility copy.

## Verification
- [x] `xcodebuild test -project phase3-binary/app/Malibu.xcodeproj -scheme Malibu -destination platform=macOS -only-testing:MalibuTests/AgentSnapshotPresenterTests -only-testing:MalibuTests/DashboardViewTests`
- [x] `git diff --check origin/main...HEAD`
- [x] Code, security, and architecture review lanes: 0 findings

SPEC-GOVERNANCE-DECLARATION-BEGIN
{
  "schema_version": "spec-pr-governance-v1",
  "behavior_change": "yes",
  "contract_change": "none",
  "specs": ["SPEC-021"],
  "requirements": ["SPEC-021-R007", "SPEC-021-R009"],
  "authority_domains": ["malibu-emission-ledger", "malibu-epoch-disposition-state"],
  "arbitration": ["UNKNOWN"],
  "tests": [
    "xcodebuild test -project phase3-binary/app/Malibu.xcodeproj -scheme Malibu -destination platform=macOS -only-testing:MalibuTests/AgentSnapshotPresenterTests -only-testing:MalibuTests/DashboardViewTests",
    "git diff --check origin/main...HEAD",
    "code/security/architecture review lanes"
  ],
  "journeys": ["not-required"]
}
SPEC-GOVERNANCE-DECLARATION-END
