### PR TITLE
Reduce empty-pool gateway retry amplification

### DIFF
--- a/phase5-gateway/gateway.yaml.example
+++ b/phase5-gateway/gateway.yaml.example
@@ -144,11 +144,17 @@ timeouts:
   streaming_idle_ms: 10000
 
 retry_503:
-  # Retries coordinator 503 no_provider_available AND transient 502 provider
-  # transport failures (provider_disconnected / provider_error / provider_failed).
+  # Shared retry loop for transient coordinator admission failures. Keep this
+  # enabled so transient 502 provider transport failures
+  # (provider_disconnected / provider_error / provider_failed) can recover.
   # Does NOT retry null-usage provider errors, tier-2 policy rejects, or
   # post-inference structured-output 502s (malformed_json_response, etc.).
   enabled: true
+  # Capacity-empty coordinator 503s (no_provider_available or an empty 503)
+  # are excluded by default to avoid multiplying requests while the provider
+  # pool is genuinely empty. Enable only when operators want the gateway to
+  # smooth short, momentary capacity races.
+  retry_no_provider_available: false
   max_attempts: 3
   backoff_base_ms: 100
   backoff_max_ms: 500

--- a/phase5-gateway/internal/config/config.go
+++ b/phase5-gateway/internal/config/config.go
@@ -259,10 +259,11 @@ type RoutingConfig struct {
 }
 
 type Retry503Config struct {
-	Enabled       bool `yaml:"enabled"`
-	MaxAttempts   int  `yaml:"max_attempts"`
-	BackoffBaseMs int  `yaml:"backoff_base_ms"`
-	BackoffMaxMs  int  `yaml:"backoff_max_ms"`
+	Enabled                  bool `yaml:"enabled"`
+	RetryNoProviderAvailable bool `yaml:"retry_no_provider_available"`
+	MaxAttempts              int  `yaml:"max_attempts"`
+	BackoffBaseMs            int  `yaml:"backoff_base_ms"`
+	BackoffMaxMs             int  `yaml:"backoff_max_ms"`
 }
 
 type ExplorerConfig struct {
@@ -463,7 +464,7 @@ func Default() Config {
 		},
 		CORS:     CORSConfig{AllowedOrigins: []string{"https://console.malibu.tech", "https://malibu.tech"}},
 		Routing:  RoutingConfig{StickyEnabled: false, StickyTTLS: 1800},
-		Retry503: Retry503Config{Enabled: true, MaxAttempts: 3, BackoffBaseMs: 100, BackoffMaxMs: 500},
+		Retry503: Retry503Config{Enabled: true, RetryNoProviderAvailable: false, MaxAttempts: 3, BackoffBaseMs: 100, BackoffMaxMs: 500},
 		Explorer: ExplorerConfig{Enabled: false},
 		Features: FeaturesConfig{ResponsesAPIEnabled: false, AnthropicMessagesEnabled: false, RelayBlindRequests: RelayBlindRequestsConfig{
 			Enabled:                    false,

--- a/phase5-gateway/internal/config/config_test.go
+++ b/phase5-gateway/internal/config/config_test.go
@@ -27,6 +27,16 @@ func TestAccountAdmissionDefaults(t *testing.T) {
 	}
 }
 
+func TestRetry503DefaultsKeepNoProviderRetryOff(t *testing.T) {
+	cfg := Default()
+	if !cfg.Retry503.Enabled {
+		t.Fatal("Retry503.Enabled=false want true so transient provider 502 retries stay supported")
+	}
+	if cfg.Retry503.RetryNoProviderAvailable {
+		t.Fatal("Retry503.RetryNoProviderAvailable=true want false to avoid retry storms against empty capacity")
+	}
+}
+
 func TestWalletSessionsDefaultOffDoesNotRequireSecrets(t *testing.T) {
 	cfg := validTestConfig()
 	cfg.Auth.WalletSessions = WalletSessionsConfig{}

--- a/phase5-gateway/internal/router/chat_proxy.go
+++ b/phase5-gateway/internal/router/chat_proxy.go
@@ -791,7 +791,7 @@ func (s *Server) doCoordinatorChatWithRetry(upCtx context.Context, r *http.Reque
 			resp.Body = io.NopCloser(bytes.NewReader(body))
 		}
 		resp.ContentLength = int64(len(body))
-		if readErr != nil || !isCoordinatorChatRetryEligible(resp.StatusCode, body) {
+		if readErr != nil || !isCoordinatorChatRetryEligible(resp.StatusCode, body, s.cfg.Retry503) {
 			return resp, false, priorProviderDispatch, nil
 		}
 		if attempt == maxAttempts {
@@ -2081,12 +2081,13 @@ func coordinatorTier2PolicyError(status int, body []byte) bool {
 }
 
 // isCoordinatorChatRetryEligible returns true when the coordinator response
-// indicates the request MAY succeed on a retry — momentarily unavailable pool
-// (503) or transient provider transport failure (502). It intentionally does
-// NOT retry null-usage provider errors, tier2 policy errors, or post-inference
-// structured-output failures that already ran billing.
-func isCoordinatorChatRetryEligible(status int, body []byte) bool {
-	if isCoordNoProviderAvailable503(status, body) {
+// indicates the request MAY succeed on a retry. Transient provider transport
+// failures (502) use the shared retry loop whenever retry_503.enabled is on;
+// coordinator capacity-empty 503s are additionally gated by
+// retry_503.retry_no_provider_available so operators can avoid amplifying an
+// empty provider pool.
+func isCoordinatorChatRetryEligible(status int, body []byte, cfg config.Retry503Config) bool {
+	if cfg.RetryNoProviderAvailable && isCoordNoProviderAvailable503(status, body) {
 		return true
 	}
 	return isCoordTransientProvider502(status, body)

--- a/phase5-gateway/internal/router/chat_proxy_retry_test.go
+++ b/phase5-gateway/internal/router/chat_proxy_retry_test.go
@@ -433,6 +433,30 @@ func TestGatewayCoord503RetryDisabledKeepsSingleDispatch(t *testing.T) {
 	assertRetryLogCounts(t, logs.String(), 0, 0, 0)
 }
 
+func TestGatewayCoord503NoProviderRetryDefaultOffKeepsSingleDispatch(t *testing.T) {
+	logs := captureRetryLogs(t)
+	var calls int
+	client := &http.Client{Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+		calls++
+		return responseWithBody(http.StatusServiceUnavailable, http.Header{"Content-Type": []string{"application/json"}}, noProviderBody()), nil
+	})}
+	h, store, _, cfg := newRetryHarness(t, client, func(cfg *config.Config) {
+		cfg.Retry503.RetryNoProviderAvailable = false
+	})
+	fullKey := createAccountAndKey(t, store, cfg, "acct_retry_no_provider_default_off")
+
+	resp := postChat(t, h, fullKey, chatBody(false), nil)
+
+	if resp.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status=%d body=%s", resp.Code, resp.Body.String())
+	}
+	if calls != 1 {
+		t.Fatalf("coordinator calls=%d want 1", calls)
+	}
+	assertErrorCode(t, resp.Body.String(), "no_provider_available")
+	assertRetryLogCounts(t, logs.String(), 0, 0, 0)
+}
+
 func TestGatewayCoord503RetryAttemptsRespectRequestRateLimit(t *testing.T) {
 	var calls int
 	client := &http.Client{Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
@@ -666,6 +690,24 @@ func TestGatewayRetry503ConfigValidationViaLoad(t *testing.T) {
 	}
 }
 
+func TestGatewayRetry503ConfigLoadPinsNoProviderRetryDefaultAndOverride(t *testing.T) {
+	withoutKey, err := config.Load(writeRetryConfig(t, "enabled: true\n  max_attempts: 3\n  backoff_base_ms: 100\n  backoff_max_ms: 500"))
+	if err != nil {
+		t.Fatalf("Load without retry_no_provider_available: %v", err)
+	}
+	if withoutKey.Retry503.RetryNoProviderAvailable {
+		t.Fatal("Load without retry_no_provider_available defaulted true, want false")
+	}
+
+	withKey, err := config.Load(writeRetryConfig(t, "enabled: true\n  retry_no_provider_available: true\n  max_attempts: 3\n  backoff_base_ms: 100\n  backoff_max_ms: 500"))
+	if err != nil {
+		t.Fatalf("Load with retry_no_provider_available: %v", err)
+	}
+	if !withKey.Retry503.RetryNoProviderAvailable {
+		t.Fatal("Load retry_no_provider_available=true decoded false")
+	}
+}
+
 // TestGatewayRetriedProvider502ThenRouteSnapshotFailedDoesNotRefund pins the
 // item-18 security fix (verified-realizable NEW-to-diff undercharge). When the
 // gateway retries a provider-dispatched provider_failed 502 (which the
@@ -794,6 +836,7 @@ func newRetryHarness(t *testing.T, client *http.Client, mutate func(*config.Conf
 	t.Helper()
 	return newTestHarnessConfig(t, fakeOAuth{}, func(cfg *config.Config) {
 		cfg.Coordinator.BuyerURL = "http://coordinator.test"
+		cfg.Retry503.RetryNoProviderAvailable = true
 		cfg.Retry503.BackoffBaseMs = 10
 		cfg.Retry503.BackoffMaxMs = 10
 		if mutate != nil {

--- a/phase5-gateway/internal/router/request_deadlines_test.go
+++ b/phase5-gateway/internal/router/request_deadlines_test.go
@@ -331,6 +331,7 @@ func TestStructuredTimeoutDuringRetryBackoff(t *testing.T) {
 	h, store, dbPath, cfg := newTestHarnessConfig(t, fakeOAuth{}, func(cfg *config.Config) {
 		cfg.Coordinator.BuyerURL = "http://coordinator.test"
 		cfg.Retry503.Enabled = true
+		cfg.Retry503.RetryNoProviderAvailable = true
 		cfg.Retry503.MaxAttempts = 3
 		// Backoff (3s) straddles the 1s admission budget: the phase expires
 		// while the retry loop sleeps, exercising the stale-resp return path.


### PR DESCRIPTION
## Summary

Stack part 1 for issue #1197.

- Make empty-pool `503 no_provider_available` retries opt-in with `retry_503.retry_no_provider_available`.
- Keep transient provider `502` retry behavior enabled.
- Pin default/config/env behavior and retry dispatch tests.

This is the lowest-risk, fastest relief slice: it reduces buyer-path retry amplification without touching coordinator money-path writes.

## Verification

- `go test ./internal/config ./internal/router -count=1` in `phase5-gateway` - passed.
- `git diff --check origin/main..HEAD` - passed.

## Stack

- Part 1: gateway retry amplification reduction - this PR.
- Part 2: coordinator SQLite pressure relief.
- Part 3: settlement receipt audit outbox.
- Part 4: fail-closed SQLite relief/archive/restore tooling.

SPEC-GOVERNANCE-DECLARATION-BEGIN
{
  "schema_version": "spec-pr-governance-v1",
  "issue": "https://github.com/Augustas11/macprovider/issues/1197",
  "behavior_change": "yes",
  "contract_change": "none",
  "specs": [
    "SPEC-022"
  ],
  "requirements": [
    "SPEC-022-R005"
  ],
  "authority_domains": [
    "buyer-api-error-contract",
    "verified-model-settlement"
  ],
  "arbitration": [
    "CODE_BUG"
  ],
  "tests": [
    "go test ./internal/config ./internal/router -count=1",
    "git diff --check origin/main..HEAD"
  ],
  "journeys": [
    "JOURNEY-BUYER-PAID-PATH"
  ]
}
SPEC-GOVERNANCE-DECLARATION-END
