### PR TITLE
Relieve coordinator SQLite checkpoint pressure

### DIFF
--- a/phase4-coordinator/cmd/coordinator/main.go
+++ b/phase4-coordinator/cmd/coordinator/main.go
@@ -16,6 +16,7 @@ import (
 	"reflect"
 	"strconv"
 	"strings"
+	"sync/atomic"
 	"syscall"
 	"time"
 
@@ -37,6 +38,7 @@ import (
 	"github.com/augstar/macprovider-coordinator/internal/referralapi"
 	"github.com/augstar/macprovider-coordinator/internal/requestlog"
 	"github.com/augstar/macprovider-coordinator/internal/rewards"
+	"github.com/augstar/macprovider-coordinator/internal/sqliteutil"
 	"github.com/augstar/macprovider-coordinator/internal/stats"
 	statshardware "github.com/augstar/macprovider-coordinator/internal/stats/hardware"
 	statsmetrics "github.com/augstar/macprovider-coordinator/internal/stats/metrics"
@@ -193,18 +195,26 @@ func main() {
 	metricsHandle := statsmetrics.New(metricsRegistry)
 	registry := pool.NewRegistry(cfg.Providers)
 	startedAt := time.Now().UTC()
-	tokenStore, err := auth.OpenStore(cfg.Storage.DBPath)
+	tokenStore, err := auth.OpenStoreWithManualWALCheckpoint(cfg.Storage.DBPath)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "storage: %v\n", err)
 		os.Exit(1)
 	}
 	defer tokenStore.Close()
-	reqLogStore, err := requestlog.OpenStore(cfg.Storage.DBPath)
+	reqLogStore, err := requestlog.OpenStoreWithManualWALCheckpoint(cfg.Storage.DBPath)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "requestlog: %v\n", err)
 		os.Exit(1)
 	}
 	defer reqLogStore.Close()
+	moneyCheckpointDB, err := sql.Open("sqlite", sqliteutil.WithManualWALCheckpointPragmas(cfg.Storage.DBPath))
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "money sqlite checkpoint: %v\n", err)
+		os.Exit(1)
+	}
+	moneyCheckpointDB.SetMaxOpenConns(1)
+	moneyCheckpointDB.SetMaxIdleConns(1)
+	defer moneyCheckpointDB.Close()
 	payoutReadDB, closePayoutReadDB, err := configuredPayoutReadDB(cfg, reqLogStore)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "payout read db: %v\n", err)
@@ -226,7 +236,7 @@ func main() {
 		fmt.Fprintf(os.Stderr, "canary sanction storage: %v\n", err)
 		os.Exit(1)
 	}
-	auditStore, err := audit.OpenStore(cfg.Storage.DBPath)
+	auditStore, err := audit.OpenStoreWithManualWALCheckpoint(cfg.Storage.DBPath)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "audit log storage: %v\n", err)
 		os.Exit(1)
@@ -252,6 +262,7 @@ func main() {
 		fmt.Fprintf(os.Stderr, "billing: %v\n", err)
 		os.Exit(1)
 	}
+	billingStore.SetSQLiteMetrics(metricsHandle)
 	// R4 fix (CODE-M2): set the route-layer flag atomic BEFORE the
 	// startup snapshot so the snapshot's canonical hash captures the
 	// initial flag state (SPEC-005 v0.4 §11.6.4 / §13.2). The
@@ -340,6 +351,8 @@ func main() {
 	}()
 	shutdownCtx, stopBackground := context.WithCancel(context.Background())
 	defer stopBackground()
+	moneySQLiteActivity := newMoneySQLiteActivity(time.Now())
+	startMoneySQLiteWALCheckpointer(shutdownCtx, moneyCheckpointDB, metricsHandle, logger, moneySQLiteActivity)
 	// SPEC-017 v0.1.8 Step 2 — rollup runner. Reads OLTP source
 	// tables via `statsPools.Rollup`, writes the seven
 	// stats_* + stats_components_health + stats_rewards_populated
@@ -831,7 +844,7 @@ func main() {
 	} else if liveMDA != nil {
 		liveMDAService = liveMDA
 		liveMDAService.SetTokenValidator(tokenStore)
-		if mdaStore, err := mdm.OpenMDAStore(cfg.Storage.DBPath); err != nil {
+		if mdaStore, err := mdm.OpenMDAStoreWithManualWALCheckpoint(cfg.Storage.DBPath); err != nil {
 			logger.Error().Err(err).Msg("live MDA durable store open failed; continuing with in-memory only")
 		} else {
 			liveMDAService.SetMDAStore(mdaStore)
@@ -1242,18 +1255,17 @@ func main() {
 			Msg("provider referral status endpoint mounted; mutation routes remain feature-gated")
 	}
 	buyerHandler = withReferralAdvocacy(buyerHandler, referralStatus, referralChallenge, referralVerify)
+	buyerHandler = withMoneySQLiteActivity(buyerHandler, moneySQLiteActivity)
 
 	providerHTTP := newHTTPServer(providerAddr, providerMux)
 	buyerHTTP := newHTTPServer(buyerAddr, buyerHandler)
 	errs := make(chan error, 2)
 
-	if err := billingStore.StartStartupScan(context.Background(), cfg.Settlement, time.Now().UTC()); err != nil {
-		logger.Warn().Err(err).Msg("billing startup scan failed")
-	}
+	startSettlementStartupScan(context.Background(), billingStore, cfg.Settlement, time.Now().UTC(), logger)
 	billingStore.StartNightlyReconcile(shutdownCtx, cfg.Settlement)
 	billingStore.StartWeeklySettlement(shutdownCtx, cfg.Settlement)
-	startRequestLogRetentionPruner(shutdownCtx, reqLogStore, cfg.Storage.RequestLogRetentionDays, logger)
-	startAuditLogRetentionPruner(shutdownCtx, auditStore, cfg.Storage.AuditLogRetentionDays, logger)
+	startRequestLogRetentionPruner(shutdownCtx, reqLogStore, cfg.Storage.RequestLogRetentionDays, cfg.Storage.RequestLogPruneOnStartup, logger)
+	startAuditLogRetentionPruner(shutdownCtx, auditStore, cfg.Storage.AuditLogRetentionDays, cfg.Storage.AuditLogPruneOnStartup, logger)
 	startProviderConnectionEventPruner(shutdownCtx, connectionEventStore, logger)
 	startAdmissionRetentionPruner(shutdownCtx, wsServer.Admission(), cfg.Admission.ProvisionalRetentionDays, logger)
 	startGitHubAuthStatePruner(shutdownCtx, tokenStore, logger)
@@ -1393,6 +1405,101 @@ type requestLogPruner interface {
 	PruneBefore(context.Context, time.Time) (int64, error)
 }
 
+type settlementStartupScanner interface {
+	StartStartupScan(context.Context, config.SettlementConfig, time.Time) error
+}
+
+const (
+	moneySQLiteCheckpointIdleInterval = 30 * time.Second
+	moneySQLiteCheckpointTimeout      = time.Second
+)
+
+type moneySQLiteActivity struct {
+	lastUnixNano atomic.Int64
+}
+
+func newMoneySQLiteActivity(now time.Time) *moneySQLiteActivity {
+	a := &moneySQLiteActivity{}
+	a.Mark(now)
+	return a
+}
+
+func (a *moneySQLiteActivity) Mark(now time.Time) {
+	if a == nil {
+		return
+	}
+	a.lastUnixNano.Store(now.UnixNano())
+}
+
+func (a *moneySQLiteActivity) IdleFor(now time.Time) time.Duration {
+	if a == nil {
+		return 0
+	}
+	last := a.lastUnixNano.Load()
+	if last <= 0 {
+		return 0
+	}
+	return now.Sub(time.Unix(0, last))
+}
+
+func withMoneySQLiteActivity(next http.Handler, activity *moneySQLiteActivity) http.Handler {
+	if next == nil || activity == nil {
+		return next
+	}
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		activity.Mark(time.Now())
+		next.ServeHTTP(w, r)
+	})
+}
+
+type moneySQLiteIdleTracker interface {
+	IdleFor(time.Time) time.Duration
+}
+
+func startMoneySQLiteWALCheckpointer(ctx context.Context, db *sql.DB, observer sqliteutil.WALObserver, logger zerolog.Logger, idle moneySQLiteIdleTracker) {
+	startMoneySQLiteWALCheckpointerWithConfig(ctx, db, observer, logger, idle, moneySQLiteCheckpointIdleInterval, moneySQLiteCheckpointTimeout)
+}
+
+func startMoneySQLiteWALCheckpointerWithConfig(ctx context.Context, db *sql.DB, observer sqliteutil.WALObserver, logger zerolog.Logger, idle moneySQLiteIdleTracker, idleInterval, checkpointTimeout time.Duration) {
+	if db == nil {
+		return
+	}
+	if idleInterval <= 0 || checkpointTimeout <= 0 {
+		return
+	}
+	run := func() {
+		checkpointCtx, cancel := context.WithTimeout(ctx, checkpointTimeout)
+		defer cancel()
+		if err := sqliteutil.RunWALCheckpoint(checkpointCtx, db, "wal_checkpoint", observer); err != nil {
+			logger.Warn().Err(err).Msg("money sqlite WAL checkpoint failed")
+		}
+	}
+	go func() {
+		ticker := time.NewTicker(idleInterval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				if idle != nil && idle.IdleFor(time.Now()) < idleInterval {
+					continue
+				}
+				run()
+			}
+		}
+	}()
+}
+
+func startSettlementStartupScan(ctx context.Context, scanner settlementStartupScanner, settlement config.SettlementConfig, now time.Time, logger zerolog.Logger) {
+	if scanner == nil {
+		return
+	}
+	if err := scanner.StartStartupScan(ctx, settlement, now); err != nil {
+		logger.Warn().Err(err).Msg("billing startup scan failed")
+	}
+}
+
 // mustParseTrustedProxies parses cfg.Proxy.TrustedProxies into the
 // netip.Prefix slice the buyer Server's rate-limit keying expects.
 // Validate() at config.Load already rejected malformed CIDRs and
@@ -1430,7 +1537,7 @@ func setupCanarySanctionStore(ctx context.Context, cfg config.Config, db *sql.DB
 	return store, nil
 }
 
-func startRequestLogRetentionPruner(ctx context.Context, store requestLogPruner, retentionDays int, logger zerolog.Logger) {
+func startRequestLogRetentionPruner(ctx context.Context, store requestLogPruner, retentionDays int, pruneOnStartup bool, logger zerolog.Logger) {
 	if store == nil || retentionDays <= 0 {
 		return
 	}
@@ -1445,7 +1552,11 @@ func startRequestLogRetentionPruner(ctx context.Context, store requestLogPruner,
 			logger.Info().Int64("deleted_rows", deleted).Time("cutoff", cutoff).Msg("request_log retention pruned rows")
 		}
 	}
-	prune()
+	if pruneOnStartup {
+		prune()
+	} else {
+		logger.Info().Int("retention_days", retentionDays).Msg("request_log startup retention prune skipped; scheduled pruner armed")
+	}
 	go func() {
 		ticker := time.NewTicker(24 * time.Hour)
 		defer ticker.Stop()
@@ -1678,7 +1789,7 @@ func startSocialVerificationPromotionReconciler(
 	}()
 }
 
-func startAuditLogRetentionPruner(ctx context.Context, store requestLogPruner, retentionDays int, logger zerolog.Logger) {
+func startAuditLogRetentionPruner(ctx context.Context, store requestLogPruner, retentionDays int, pruneOnStartup bool, logger zerolog.Logger) {
 	if store == nil || retentionDays <= 0 {
 		return
 	}
@@ -1693,7 +1804,11 @@ func startAuditLogRetentionPruner(ctx context.Context, store requestLogPruner, r
 			logger.Info().Int64("deleted_rows", deleted).Time("cutoff", cutoff).Msg("audit_log retention pruned rows")
 		}
 	}
-	prune()
+	if pruneOnStartup {
+		prune()
+	} else {
+		logger.Info().Int("retention_days", retentionDays).Msg("audit_log startup retention prune skipped; scheduled pruner armed")
+	}
 	go func() {
 		ticker := time.NewTicker(24 * time.Hour)
 		defer ticker.Stop()

--- a/phase4-coordinator/cmd/coordinator/main_test.go
+++ b/phase4-coordinator/cmd/coordinator/main_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"crypto/ed25519"
+	"database/sql"
 	"encoding/base64"
 	"encoding/json"
 	"net"
@@ -22,6 +23,7 @@ import (
 	"github.com/augstar/macprovider-coordinator/internal/config"
 	"github.com/augstar/macprovider-coordinator/internal/pool"
 	"github.com/augstar/macprovider-coordinator/internal/requestlog"
+	"github.com/augstar/macprovider-coordinator/internal/sqliteutil"
 	statsmetrics "github.com/augstar/macprovider-coordinator/internal/stats/metrics"
 	"github.com/augstar/macprovider-coordinator/internal/tier2"
 	"github.com/augstar/macprovider-coordinator/internal/trustpool"
@@ -155,6 +157,196 @@ func TestAppTrackReferralMintReconcilerRunsAfterEnforcementRollback(t *testing.T
 	case <-called:
 	case <-time.After(time.Second):
 		t.Fatal("referral mint reconciler did not run with enforcement disabled")
+	}
+}
+
+func TestSettlementStartupScanRunsRecoveryWhenSettlementJobDisabled(t *testing.T) {
+	ctx := context.Background()
+	scanner := &startupScanStub{called: make(chan config.SettlementConfig, 1)}
+	settlement := config.Default().Settlement
+	settlement.JobEnabled = false
+
+	select {
+	case <-scanner.called:
+		t.Fatal("startup scan stub channel should start empty")
+	default:
+	}
+	startSettlementStartupScan(ctx, scanner, settlement, time.Unix(100, 0).UTC(), zerolog.Nop())
+	select {
+	case got := <-scanner.called:
+		if got.JobEnabled {
+			t.Fatal("startup recovery should receive disabled settlement config without enabling settlement jobs")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("startup recovery did not run when settlement.job_enabled=false")
+	}
+}
+
+func TestRetentionPrunersCanDeferStartupDelete(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	requestPruner := &retentionPrunerStub{called: make(chan time.Time, 1)}
+	startRequestLogRetentionPruner(ctx, requestPruner, 90, false, zerolog.Nop())
+	assertNoImmediatePrune(t, requestPruner.called, "request_log")
+
+	auditPruner := &retentionPrunerStub{called: make(chan time.Time, 1)}
+	startAuditLogRetentionPruner(ctx, auditPruner, 90, false, zerolog.Nop())
+	assertNoImmediatePrune(t, auditPruner.called, "audit_log")
+}
+
+func TestRetentionPrunersDefaultToStartupDelete(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	requestPruner := &retentionPrunerStub{called: make(chan time.Time, 1)}
+	startRequestLogRetentionPruner(ctx, requestPruner, 90, true, zerolog.Nop())
+	assertImmediatePrune(t, requestPruner.called, "request_log")
+
+	auditPruner := &retentionPrunerStub{called: make(chan time.Time, 1)}
+	startAuditLogRetentionPruner(ctx, auditPruner, 90, true, zerolog.Nop())
+	assertImmediatePrune(t, auditPruner.called, "audit_log")
+}
+
+func TestMoneySQLiteWALCheckpointerWaitsForIdle(t *testing.T) {
+	db, err := sql.Open("sqlite", sqliteutil.WithPragmas(filepath.Join(t.TempDir(), "checkpoint.db")))
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	if _, err := db.Exec(`CREATE TABLE t (id INTEGER PRIMARY KEY, v TEXT)`); err != nil {
+		t.Fatalf("create table: %v", err)
+	}
+	if _, err := db.Exec(`INSERT INTO t (v) VALUES ('a')`); err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	observer := &walObserverStub{called: make(chan string, 3)}
+	startMoneySQLiteWALCheckpointerWithConfig(ctx, db, observer, zerolog.Nop(), fixedIdleTracker{idleFor: 0}, 10*time.Millisecond, time.Second)
+
+	select {
+	case pageClass := <-observer.called:
+		t.Fatalf("checkpoint ran while buyer activity was not idle: %s", pageClass)
+	case <-time.After(50 * time.Millisecond):
+	}
+}
+
+func TestMoneySQLiteWALCheckpointerRunsAfterIdle(t *testing.T) {
+	db, err := sql.Open("sqlite", sqliteutil.WithPragmas(filepath.Join(t.TempDir(), "checkpoint.db")))
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	if _, err := db.Exec(`CREATE TABLE t (id INTEGER PRIMARY KEY, v TEXT)`); err != nil {
+		t.Fatalf("create table: %v", err)
+	}
+	if _, err := db.Exec(`INSERT INTO t (v) VALUES ('a')`); err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	observer := &walObserverStub{called: make(chan string, 3), durations: make(chan struct{}, 1)}
+	startMoneySQLiteWALCheckpointerWithConfig(ctx, db, observer, zerolog.Nop(), fixedIdleTracker{idleFor: time.Hour}, 10*time.Millisecond, time.Second)
+
+	seen := map[string]bool{}
+	deadline := time.After(time.Second)
+	for len(seen) < 3 {
+		select {
+		case pageClass := <-observer.called:
+			seen[pageClass] = true
+		case <-deadline:
+			t.Fatalf("checkpoint observations=%v, want busy/log/checkpointed", seen)
+		}
+	}
+	for _, pageClass := range []string{"busy", "log", "checkpointed"} {
+		if !seen[pageClass] {
+			t.Fatalf("missing checkpoint page class %q in %v", pageClass, seen)
+		}
+	}
+	select {
+	case <-observer.durations:
+	case <-time.After(time.Second):
+		t.Fatal("missing checkpoint duration observation")
+	}
+}
+
+func TestMoneySQLiteActivityMiddlewareMarksRequests(t *testing.T) {
+	activity := newMoneySQLiteActivity(time.Unix(100, 0))
+	handler := withMoneySQLiteActivity(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}), activity)
+	req := httptest.NewRequest(http.MethodGet, "/v1/chat/completions", nil)
+	handler.ServeHTTP(httptest.NewRecorder(), req)
+	if idle := activity.IdleFor(time.Now().Add(100 * time.Millisecond)); idle > time.Second {
+		t.Fatalf("activity idle=%s, want recent request mark", idle)
+	}
+}
+
+type startupScanStub struct {
+	called chan config.SettlementConfig
+}
+
+func (s *startupScanStub) StartStartupScan(_ context.Context, settlement config.SettlementConfig, _ time.Time) error {
+	s.called <- settlement
+	return nil
+}
+
+type retentionPrunerStub struct {
+	called chan time.Time
+}
+
+func (s *retentionPrunerStub) PruneBefore(_ context.Context, cutoff time.Time) (int64, error) {
+	s.called <- cutoff
+	return 1, nil
+}
+
+type walObserverStub struct {
+	called    chan string
+	durations chan struct{}
+}
+
+func (s *walObserverStub) ObserveSQLiteWALCheckpoint(component, pageClass, outcome string, _ int64) {
+	if component == "wal_checkpoint" && outcome == "success" {
+		s.called <- pageClass
+	}
+}
+
+func (s *walObserverStub) ObserveSQLiteWALCheckpointDuration(component, outcome string, _ time.Duration) {
+	if component == "wal_checkpoint" && outcome == "success" && s.durations != nil {
+		select {
+		case s.durations <- struct{}{}:
+		default:
+		}
+	}
+}
+
+type fixedIdleTracker struct {
+	idleFor time.Duration
+}
+
+func (t fixedIdleTracker) IdleFor(time.Time) time.Duration {
+	return t.idleFor
+}
+
+func assertNoImmediatePrune(t *testing.T, called <-chan time.Time, name string) {
+	t.Helper()
+	select {
+	case <-called:
+		t.Fatalf("%s pruner ran immediately despite startup deferral", name)
+	case <-time.After(100 * time.Millisecond):
+	}
+}
+
+func assertImmediatePrune(t *testing.T, called <-chan time.Time, name string) {
+	t.Helper()
+	select {
+	case cutoff := <-called:
+		if cutoff.IsZero() {
+			t.Fatalf("%s pruner received zero cutoff", name)
+		}
+	case <-time.After(time.Second):
+		t.Fatalf("%s pruner did not run immediately with startup prune enabled", name)
 	}
 }
 

--- a/phase4-coordinator/dist/coordinator.yaml
+++ b/phase4-coordinator/dist/coordinator.yaml
@@ -205,6 +205,10 @@ storage:
   db_path: "/var/lib/macprovider/coordinator.db"
   snapshot_interval_s: 300
   request_log_retention_days: 90
+  # Defaults are true for backward compatibility. Set false to defer DELETE
+  # retention work to the scheduled pruner tick during buyer traffic relief.
+  request_log_prune_on_startup: true
+  audit_log_prune_on_startup: true
 
 logging:
   level: "info"

--- a/phase4-coordinator/dist/coordinator.yaml.example
+++ b/phase4-coordinator/dist/coordinator.yaml.example
@@ -151,6 +151,10 @@ storage:
   db_path: "/var/lib/macprovider/coordinator.db"
   snapshot_interval_s: 300
   request_log_retention_days: 90
+  # Defaults are true for backward compatibility. Set false to defer DELETE
+  # retention work to the scheduled pruner tick during buyer traffic relief.
+  request_log_prune_on_startup: true
+  audit_log_prune_on_startup: true
 
 trusted_pools:
   enabled: false

--- a/phase4-coordinator/internal/audit/store.go
+++ b/phase4-coordinator/internal/audit/store.go
@@ -21,6 +21,16 @@ type Store struct {
 }
 
 func OpenStore(dbPath string) (*Store, error) {
+	return openStore(dbPath, false)
+}
+
+// OpenStoreWithManualWALCheckpoint opens an audit store for a SQLite DB whose
+// physical file has an explicit external WAL checkpoint owner.
+func OpenStoreWithManualWALCheckpoint(dbPath string) (*Store, error) {
+	return openStore(dbPath, true)
+}
+
+func openStore(dbPath string, manualWALCheckpoint bool) (*Store, error) {
 	if dbPath == "" {
 		return nil, fmt.Errorf("db path is required")
 	}
@@ -29,7 +39,11 @@ func OpenStore(dbPath string) (*Store, error) {
 			return nil, err
 		}
 	}
-	db, err := sql.Open("sqlite", sqliteutil.WithPragmas(dbPath))
+	dsn := sqliteutil.WithPragmas(dbPath)
+	if manualWALCheckpoint {
+		dsn = sqliteutil.WithManualWALCheckpointPragmas(dbPath)
+	}
+	db, err := sql.Open("sqlite", dsn)
 	if err != nil {
 		return nil, err
 	}

--- a/phase4-coordinator/internal/audit/store_test.go
+++ b/phase4-coordinator/internal/audit/store_test.go
@@ -3,6 +3,7 @@ package audit
 import (
 	"context"
 	"database/sql"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -46,6 +47,35 @@ WHERE type IN ('table', 'index') AND name IN (
 		if !seen[name] {
 			t.Fatalf("missing schema object %q; got %#v", name, seen)
 		}
+	}
+}
+
+func TestOpenStoreKeepsSQLiteAutocheckpointOwnerDefault(t *testing.T) {
+	store := openTestStore(t)
+	defer store.Close()
+
+	var got int
+	if err := store.DB().QueryRowContext(context.Background(), `PRAGMA wal_autocheckpoint`).Scan(&got); err != nil {
+		t.Fatalf("PRAGMA wal_autocheckpoint: %v", err)
+	}
+	if got == 0 {
+		t.Fatal("audit store disabled wal_autocheckpoint without an explicit checkpoint owner")
+	}
+}
+
+func TestOpenStoreWithManualWALCheckpointDisablesAutocheckpoint(t *testing.T) {
+	store, err := OpenStoreWithManualWALCheckpoint(filepath.Join(t.TempDir(), "coordinator.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+
+	var got int
+	if err := store.DB().QueryRowContext(context.Background(), `PRAGMA wal_autocheckpoint`).Scan(&got); err != nil {
+		t.Fatalf("PRAGMA wal_autocheckpoint: %v", err)
+	}
+	if got != 0 {
+		t.Fatalf("wal_autocheckpoint=%d want 0", got)
 	}
 }
 

--- a/phase4-coordinator/internal/auth/tokens.go
+++ b/phase4-coordinator/internal/auth/tokens.go
@@ -250,6 +250,14 @@ func GatewayInternalBearerMatches(headers http.Header, serviceToken string) Inte
 }
 
 func OpenStore(path string) (*Store, error) {
+	return openStore(path, false)
+}
+
+func OpenStoreWithManualWALCheckpoint(path string) (*Store, error) {
+	return openStore(path, true)
+}
+
+func openStore(path string, manualWALCheckpoint bool) (*Store, error) {
 	if path == "" {
 		return nil, fmt.Errorf("db path is required")
 	}
@@ -258,7 +266,11 @@ func OpenStore(path string) (*Store, error) {
 			return nil, err
 		}
 	}
-	db, err := sql.Open("sqlite", sqliteutil.WithPragmas(path))
+	dsn := sqliteutil.WithPragmas(path)
+	if manualWALCheckpoint {
+		dsn = sqliteutil.WithManualWALCheckpointPragmas(path)
+	}
+	db, err := sql.Open("sqlite", dsn)
 	if err != nil {
 		return nil, err
 	}

--- a/phase4-coordinator/internal/auth/tokens_test.go
+++ b/phase4-coordinator/internal/auth/tokens_test.go
@@ -60,6 +60,38 @@ func TestValidateTokenReadOnlyAuthenticatesWithoutRefreshingUsage(t *testing.T) 
 	}
 }
 
+func TestOpenStoreWithManualWALCheckpointDisablesAutocheckpoint(t *testing.T) {
+	store, err := auth.OpenStoreWithManualWALCheckpoint(filepath.Join(t.TempDir(), "coordinator.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+
+	var got int
+	if err := store.DB().QueryRowContext(context.Background(), `PRAGMA wal_autocheckpoint`).Scan(&got); err != nil {
+		t.Fatalf("PRAGMA wal_autocheckpoint: %v", err)
+	}
+	if got != 0 {
+		t.Fatalf("wal_autocheckpoint=%d want 0", got)
+	}
+}
+
+func TestOpenStoreKeepsSQLiteAutocheckpointOwnerDefault(t *testing.T) {
+	store, err := auth.OpenStore(filepath.Join(t.TempDir(), "coordinator.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+
+	var got int
+	if err := store.DB().QueryRowContext(context.Background(), `PRAGMA wal_autocheckpoint`).Scan(&got); err != nil {
+		t.Fatalf("PRAGMA wal_autocheckpoint: %v", err)
+	}
+	if got == 0 {
+		t.Fatal("auth store disabled wal_autocheckpoint without an explicit checkpoint owner")
+	}
+}
+
 func TestOpenStoreUpgradesPreRecoverySocialTablesAdditively(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "coordinator.db")
 	db, err := sql.Open("sqlite", path)

--- a/phase4-coordinator/internal/billing/hotpath.go
+++ b/phase4-coordinator/internal/billing/hotpath.go
@@ -65,7 +65,7 @@ func (s *Store) writeHotPath(ctx context.Context, reqLogStore *requestlog.Store,
 	if account != nil {
 		reqRow.AccountID = account.ID()
 	}
-	return sqliteutil.Transact(ctx, s.db, func(ctx context.Context, conn *sql.Conn) error {
+	return sqliteutil.TransactObserved(ctx, s.db, "billing_hot_path", s.sqliteMetric, func(ctx context.Context, conn *sql.Conn) error {
 		if err := reqLogStore.InsertExec(ctx, conn, reqRow); err != nil {
 			return err
 		}
@@ -310,7 +310,7 @@ func (s *Store) writeRequestLogWithIdentity(ctx context.Context, reqLogStore *re
 	if account != nil {
 		reqRow.AccountID = account.ID()
 	}
-	return sqliteutil.Transact(ctx, s.db, func(ctx context.Context, conn *sql.Conn) error {
+	return sqliteutil.TransactObserved(ctx, s.db, "request_log_identity", s.sqliteMetric, func(ctx context.Context, conn *sql.Conn) error {
 		if err := reqLogStore.InsertExec(ctx, conn, reqRow); err != nil {
 			return err
 		}

--- a/phase4-coordinator/internal/billing/route_snapshot.go
+++ b/phase4-coordinator/internal/billing/route_snapshot.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"regexp"
 	"strings"
+	"time"
 
 	"github.com/augstar/macprovider-coordinator/internal/modelidentity"
 )
@@ -215,7 +216,16 @@ func (s *Store) InsertRouteSnapshot(ctx context.Context, snapshot RouteSnapshot)
 	if err != nil {
 		return "", err
 	}
-	_, err = s.db.ExecContext(ctx, `
+	connWaitStarted := time.Now()
+	conn, err := s.db.Conn(ctx)
+	s.observeSQLiteConnectionWait("route_snapshot", err, time.Since(connWaitStarted))
+	if err != nil {
+		return "", err
+	}
+	defer conn.Close()
+
+	started := time.Now()
+	_, err = conn.ExecContext(ctx, `
 INSERT INTO settlement_route_snapshots (
     account_scope, request_id, attempt_n, provider_id,
     provider_session_id, provider_generation_id, pool_id, paid_entrypoint,
@@ -254,10 +264,33 @@ INSERT INTO settlement_route_snapshots (
 		digest, string(rendered),
 		string(canonical),
 	)
+	s.observeSQLiteWrite("route_snapshot", "route_snapshot_insert", err, time.Since(started))
 	if err != nil {
 		return "", err
 	}
 	return digest, nil
+}
+
+func (s *Store) observeSQLiteConnectionWait(component string, err error, duration time.Duration) {
+	if s == nil || s.sqliteMetric == nil {
+		return
+	}
+	outcome := "success"
+	if err != nil {
+		outcome = "error"
+	}
+	s.sqliteMetric.ObserveSQLiteConnectionWait(component, outcome, duration)
+}
+
+func (s *Store) observeSQLiteWrite(component, operation string, err error, duration time.Duration) {
+	if s == nil || s.sqliteMetric == nil {
+		return
+	}
+	outcome := "success"
+	if err != nil {
+		outcome = "error"
+	}
+	s.sqliteMetric.ObserveSQLiteWriteDuration(component, operation, outcome, duration)
 }
 
 func nullableString(v *string) any {

--- a/phase4-coordinator/internal/billing/snapshot.go
+++ b/phase4-coordinator/internal/billing/snapshot.go
@@ -157,7 +157,7 @@ func (s *Store) ReloadBillingConfigV05(ctx context.Context, cfg RewardsConfig, f
 	}
 
 	var snapshotID int64
-	if err := sqliteutil.Transact(ctx, s.db, func(ctx context.Context, conn *sql.Conn) error {
+	if err := sqliteutil.TransactObserved(ctx, s.db, "billing_reload_config", s.sqliteMetric, func(ctx context.Context, conn *sql.Conn) error {
 		res, err := conn.ExecContext(ctx, `
 INSERT INTO ledger_config_snapshots (
     effective_at_utc, config_hash, provider_share_bps, global_multiplier_ppm,

--- a/phase4-coordinator/internal/billing/store.go
+++ b/phase4-coordinator/internal/billing/store.go
@@ -23,6 +23,7 @@ type SettlementConfig = config.SettlementConfig
 type Store struct {
 	db           *sql.DB
 	now          func() time.Time
+	sqliteMetric SQLiteMetrics
 	settlementMu sync.RWMutex
 	settlement   SettlementConfig
 	// SPEC-005 v0.4 §13.2 — billing.quarantine_resolution_force_void_enabled
@@ -39,6 +40,12 @@ type Store struct {
 	forceCreditHoldSeconds atomic.Int64
 }
 
+type SQLiteMetrics interface {
+	ObserveSQLiteConnectionWait(component, outcome string, duration time.Duration)
+	ObserveSQLiteTransactionDuration(component, outcome string, duration time.Duration)
+	ObserveSQLiteWriteDuration(component, operation, outcome string, duration time.Duration)
+}
+
 const defaultForceCreditSettlementHoldSeconds int64 = 24 * 60 * 60
 
 func NewStore(db *sql.DB) (*Store, error) {
@@ -51,6 +58,13 @@ func NewStore(db *sql.DB) (*Store, error) {
 		return nil, err
 	}
 	return s, nil
+}
+
+func (s *Store) SetSQLiteMetrics(metrics SQLiteMetrics) {
+	if s == nil {
+		return
+	}
+	s.sqliteMetric = metrics
 }
 
 func (s *Store) migrate(ctx context.Context) error {

--- a/phase4-coordinator/internal/config/config.go
+++ b/phase4-coordinator/internal/config/config.go
@@ -1012,9 +1012,11 @@ type GitHubOAuthConfig struct {
 }
 
 type StorageConfig struct {
-	DBPath                  string `yaml:"db_path"`
-	SnapshotIntervalS       int    `yaml:"snapshot_interval_s"`
-	RequestLogRetentionDays int    `yaml:"request_log_retention_days"`
+	DBPath                   string `yaml:"db_path"`
+	SnapshotIntervalS        int    `yaml:"snapshot_interval_s"`
+	RequestLogRetentionDays  int    `yaml:"request_log_retention_days"`
+	RequestLogPruneOnStartup bool   `yaml:"request_log_prune_on_startup"`
+	AuditLogPruneOnStartup   bool   `yaml:"audit_log_prune_on_startup"`
 	// SPEC-002 v1.3.5 §7.10.1 R-7.10.2 — retention for the
 	// operator_model_swap audit_log table (and any future audit event
 	// types). Default 90 days mirrors request_log_retention_days.
@@ -1372,10 +1374,12 @@ func Default() Config {
 			ResponseTimeAnomalyMinMS:       10000,
 		},
 		Storage: StorageConfig{
-			DBPath:                  "coordinator.db",
-			SnapshotIntervalS:       300,
-			RequestLogRetentionDays: 90,
-			AuditLogRetentionDays:   90,
+			DBPath:                   "coordinator.db",
+			SnapshotIntervalS:        300,
+			RequestLogRetentionDays:  90,
+			RequestLogPruneOnStartup: true,
+			AuditLogPruneOnStartup:   true,
+			AuditLogRetentionDays:    90,
 		},
 		TrustedPools: TrustedPoolsConfig{
 			Enabled:                          false,

--- a/phase4-coordinator/internal/config/config_test.go
+++ b/phase4-coordinator/internal/config/config_test.go
@@ -640,6 +640,24 @@ func TestSpec005BillingDefaultsAndValidation(t *testing.T) {
 	}
 }
 
+func TestStorageStartupPruneDefaultsAndUnmarshal(t *testing.T) {
+	cfg := Default()
+	if !cfg.Storage.RequestLogPruneOnStartup {
+		t.Fatal("request_log_prune_on_startup default=false want true")
+	}
+	if !cfg.Storage.AuditLogPruneOnStartup {
+		t.Fatal("audit_log_prune_on_startup default=false want true")
+	}
+
+	storage := Default().Storage
+	if err := yaml.Unmarshal([]byte("request_log_prune_on_startup: false\naudit_log_prune_on_startup: false\n"), &storage); err != nil {
+		t.Fatalf("unmarshal storage startup prune knobs: %v", err)
+	}
+	if storage.RequestLogPruneOnStartup || storage.AuditLogPruneOnStartup {
+		t.Fatalf("explicit storage startup prune false not honored: %+v", storage)
+	}
+}
+
 func TestTrustedPoolsEnabledRequiresGatewayContext(t *testing.T) {
 	cfg := validTestConfig()
 	cfg.TrustedPools.Enabled = true

--- a/phase4-coordinator/internal/mdm/device_binding_test.go
+++ b/phase4-coordinator/internal/mdm/device_binding_test.go
@@ -37,6 +37,38 @@ func TestDeviceBindingStoreExclusiveClaim(t *testing.T) {
 	}
 }
 
+func TestOpenMDAStoreWithManualWALCheckpointDisablesAutocheckpoint(t *testing.T) {
+	store, err := OpenMDAStoreWithManualWALCheckpoint(filepath.Join(t.TempDir(), "coordinator.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+
+	var got int
+	if err := store.db.QueryRowContext(context.Background(), `PRAGMA wal_autocheckpoint`).Scan(&got); err != nil {
+		t.Fatalf("PRAGMA wal_autocheckpoint: %v", err)
+	}
+	if got != 0 {
+		t.Fatalf("wal_autocheckpoint=%d want 0", got)
+	}
+}
+
+func TestOpenMDAStoreKeepsSQLiteAutocheckpointOwnerDefault(t *testing.T) {
+	store, err := OpenMDAStore(filepath.Join(t.TempDir(), "coordinator.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+
+	var got int
+	if err := store.db.QueryRowContext(context.Background(), `PRAGMA wal_autocheckpoint`).Scan(&got); err != nil {
+		t.Fatalf("PRAGMA wal_autocheckpoint: %v", err)
+	}
+	if got == 0 {
+		t.Fatal("MDA store disabled wal_autocheckpoint without an explicit checkpoint owner")
+	}
+}
+
 func TestClaimDeviceRejectsEnrolledUnboundForTokenPath(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		_ = json.NewEncoder(w).Encode(listDevicesResponse{
@@ -364,7 +396,7 @@ func TestDurableMDAProofSurvivesNewService(t *testing.T) {
 		cfg: cfg, mdmCfg: config.Tier2MDMConfig{MDARefreshIntervalHours: 168},
 		pool: reg1, log: zerolog.Nop(), now: func() time.Time { return now },
 		bindings: NewDeviceBindingStore(),
-		ledger: make(map[string]enqueueLedgerEntry),
+		ledger:   make(map[string]enqueueLedgerEntry),
 	}
 	svc1.SetMDAStore(store)
 	_ = svc1.bindings.Claim("p-dur", "C02DURABLE1")
@@ -384,7 +416,7 @@ func TestDurableMDAProofSurvivesNewService(t *testing.T) {
 		cfg: cfg, mdmCfg: config.Tier2MDMConfig{MDARefreshIntervalHours: 168},
 		pool: reg2, log: zerolog.Nop(), now: func() time.Time { return now },
 		bindings: NewDeviceBindingStore(),
-		ledger: make(map[string]enqueueLedgerEntry),
+		ledger:   make(map[string]enqueueLedgerEntry),
 	}
 	svc2.SetMDAStore(store)
 	if !svc2.AttachCachedMDAProof("p-dur", "s2") {
@@ -406,7 +438,7 @@ func TestDurableMDAProofSurvivesNewService(t *testing.T) {
 		cfg: cfg, mdmCfg: config.Tier2MDMConfig{MDARefreshIntervalHours: 168},
 		pool: reg3, log: zerolog.Nop(), now: func() time.Time { return later },
 		bindings: NewDeviceBindingStore(),
-		ledger: make(map[string]enqueueLedgerEntry),
+		ledger:   make(map[string]enqueueLedgerEntry),
 	}
 	svc3.SetMDAStore(store)
 	if svc3.AttachCachedMDAProof("p-dur", "s3") {
@@ -532,7 +564,7 @@ func TestDurableDeviceBindingSurvivesNewService(t *testing.T) {
 
 	svc2 := &LiveMDAService{
 		client: client2, pool: reg, bindings: NewDeviceBindingStore(), log: zerolog.Nop(),
-		now: func() time.Time { return now },
+		now:     func() time.Time { return now },
 		pending: make(map[string]pendingMDARequest), ledger: make(map[string]enqueueLedgerEntry),
 		mdmCfg: config.Tier2MDMConfig{MDARefreshIntervalHours: 168},
 	}
@@ -601,7 +633,7 @@ func TestDurablePendingSurvivesNewServiceWebhook(t *testing.T) {
 	svc2.SetMDAStore(store)
 
 	body, _ := json.Marshal(map[string]interface{}{
-		"udid": "UDID-PEND",
+		"udid":         "UDID-PEND",
 		"command_uuid": "cmd-durable-1",
 		"payload": map[string]interface{}{
 			"DeviceAttestation": []interface{}{
@@ -1016,4 +1048,3 @@ func TestClaimDeviceClearsHardwareOnSerialRebind(t *testing.T) {
 		t.Fatal("R7-M1: stale A webhook must not SetMDAProof")
 	}
 }
-

--- a/phase4-coordinator/internal/mdm/mda_store.go
+++ b/phase4-coordinator/internal/mdm/mda_store.go
@@ -64,6 +64,14 @@ type MDAStore struct {
 
 // OpenMDAStore opens (or creates) MDA tables on the coordinator storage DB.
 func OpenMDAStore(path string) (*MDAStore, error) {
+	return openMDAStore(path, false)
+}
+
+func OpenMDAStoreWithManualWALCheckpoint(path string) (*MDAStore, error) {
+	return openMDAStore(path, true)
+}
+
+func openMDAStore(path string, manualWALCheckpoint bool) (*MDAStore, error) {
 	path = strings.TrimSpace(path)
 	if path == "" {
 		return nil, fmt.Errorf("mda store: db path is required")
@@ -73,7 +81,11 @@ func OpenMDAStore(path string) (*MDAStore, error) {
 			return nil, err
 		}
 	}
-	db, err := sql.Open("sqlite", sqliteutil.WithPragmas(path))
+	dsn := sqliteutil.WithPragmas(path)
+	if manualWALCheckpoint {
+		dsn = sqliteutil.WithManualWALCheckpointPragmas(path)
+	}
+	db, err := sql.Open("sqlite", dsn)
 	if err != nil {
 		return nil, err
 	}

--- a/phase4-coordinator/internal/requestlog/store.go
+++ b/phase4-coordinator/internal/requestlog/store.go
@@ -127,6 +127,14 @@ func OpenStoreReadOnly(dbPath string) (*Store, error) {
 }
 
 func OpenStore(dbPath string) (*Store, error) {
+	return openStore(dbPath, false)
+}
+
+func OpenStoreWithManualWALCheckpoint(dbPath string) (*Store, error) {
+	return openStore(dbPath, true)
+}
+
+func openStore(dbPath string, manualWALCheckpoint bool) (*Store, error) {
 	if dbPath == "" {
 		return nil, fmt.Errorf("db path is required")
 	}
@@ -135,7 +143,11 @@ func OpenStore(dbPath string) (*Store, error) {
 			return nil, err
 		}
 	}
-	db, err := sql.Open("sqlite", sqliteutil.WithPragmas(dbPath))
+	dsn := sqliteutil.WithPragmas(dbPath)
+	if manualWALCheckpoint {
+		dsn = sqliteutil.WithManualWALCheckpointPragmas(dbPath)
+	}
+	db, err := sql.Open("sqlite", dsn)
 	if err != nil {
 		return nil, err
 	}

--- a/phase4-coordinator/internal/requestlog/store_test.go
+++ b/phase4-coordinator/internal/requestlog/store_test.go
@@ -445,8 +445,24 @@ VALUES ('idem-legacy', 'hash-a', 'req-legacy', ?)`,
 	}
 }
 
-func TestOpenStoreAppliesSQLitePragmasViaDSN(t *testing.T) {
+func TestOpenStoreKeepsSQLiteAutocheckpointOwnerDefault(t *testing.T) {
 	store := openTestStore(t)
+	defer store.Close()
+
+	var got int
+	if err := store.db.QueryRowContext(context.Background(), `PRAGMA wal_autocheckpoint`).Scan(&got); err != nil {
+		t.Fatalf("PRAGMA wal_autocheckpoint: %v", err)
+	}
+	if got == 0 {
+		t.Fatal("request log store disabled wal_autocheckpoint without an explicit checkpoint owner")
+	}
+}
+
+func TestOpenStoreWithManualWALCheckpointAppliesSQLitePragmasViaDSN(t *testing.T) {
+	store, err := OpenStoreWithManualWALCheckpoint(filepath.Join(t.TempDir(), "coordinator.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
 	defer store.Close()
 	ctx := context.Background()
 	for _, tc := range []struct {
@@ -455,6 +471,7 @@ func TestOpenStoreAppliesSQLitePragmasViaDSN(t *testing.T) {
 	}{
 		{query: `PRAGMA busy_timeout`, want: 5000},
 		{query: `PRAGMA foreign_keys`, want: 1},
+		{query: `PRAGMA wal_autocheckpoint`, want: 0},
 	} {
 		var got int
 		if err := store.db.QueryRowContext(ctx, tc.query).Scan(&got); err != nil {

--- a/phase4-coordinator/internal/sqliteutil/dsn.go
+++ b/phase4-coordinator/internal/sqliteutil/dsn.go
@@ -8,9 +8,9 @@ import (
 // WithPragmas builds a modernc.org/sqlite DSN with the project's standard
 // pragma set (busy_timeout, foreign_keys, WAL, synchronous=FULL).
 //
-// ARCH-5: this helper is byte-identical to phase5-gateway/internal/storage/
-// sqlite/dsn.go::sqliteDSN. The duplication is intentional — coordinator and
-// gateway are deployed as independent Go modules, and introducing a shared
+// ARCH-5: this helper deliberately mirrors the gateway SQLite DSN shape while
+// remaining coordinator-owned. The duplication is intentional — coordinator
+// and gateway are deployed as independent Go modules, and introducing a shared
 // library would re-couple them on every DSN tweak. See audits/2026-06-10/
 // REPO_AUDIT.md (ARCH-5) for the conscious-debt reasoning.
 //
@@ -38,6 +38,19 @@ func WithPragmas(path string) string {
 		separator = "&"
 	}
 	return path + separator + values.Encode()
+}
+
+// WithManualWALCheckpointPragmas disables SQLite's autocheckpoint for a DB
+// handle whose owner starts an explicit off-hot-path checkpoint loop.
+func WithManualWALCheckpointPragmas(path string) string {
+	base := WithPragmas(path)
+	values := url.Values{}
+	values.Add("_pragma", "wal_autocheckpoint(0)")
+	separator := "?"
+	if strings.Contains(base, "?") {
+		separator = "&"
+	}
+	return base + separator + values.Encode()
 }
 
 // ReadOnlyDSN builds a strictly read-only modernc.org/sqlite DSN.

--- a/phase4-coordinator/internal/sqliteutil/transact.go
+++ b/phase4-coordinator/internal/sqliteutil/transact.go
@@ -3,7 +3,16 @@ package sqliteutil
 import (
 	"context"
 	"database/sql"
+	"time"
 )
+
+// Observer receives closed-set SQLite timing observations from money-path
+// stores. Implementations must keep labels bounded; component values are
+// call-site constants, and outcome is "success" or "error".
+type Observer interface {
+	ObserveSQLiteConnectionWait(component, outcome string, duration time.Duration)
+	ObserveSQLiteTransactionDuration(component, outcome string, duration time.Duration)
+}
 
 // Transact reserves a single *sql.Conn from db, issues BEGIN IMMEDIATE to
 // take the SQLite write lock deterministically, invokes fn with the
@@ -34,11 +43,29 @@ import (
 // see phase4-coordinator/internal/sqliteutil/transact_test.go for the
 // invariant coverage.
 func Transact(ctx context.Context, db *sql.DB, fn func(context.Context, *sql.Conn) error) (err error) {
+	return TransactObserved(ctx, db, "", nil, fn)
+}
+
+// TransactObserved is Transact with optional timing observation for the
+// sql.DB connection wait and full BEGIN IMMEDIATE..COMMIT/ROLLBACK duration.
+func TransactObserved(ctx context.Context, db *sql.DB, component string, observer Observer, fn func(context.Context, *sql.Conn) error) (err error) {
+	connWaitStarted := time.Now()
 	conn, cerr := db.Conn(ctx)
+	observeConnectionWait(observer, component, cerr, time.Since(connWaitStarted))
 	if cerr != nil {
 		return cerr
 	}
 	defer conn.Close()
+
+	txStarted := time.Now()
+	txErr := true
+	defer func() {
+		if err == nil && !txErr {
+			observeTransactionDuration(observer, component, nil, time.Since(txStarted))
+			return
+		}
+		observeTransactionDuration(observer, component, err, time.Since(txStarted))
+	}()
 
 	if _, err := conn.ExecContext(ctx, `BEGIN IMMEDIATE`); err != nil {
 		return err
@@ -58,5 +85,27 @@ func Transact(ctx context.Context, db *sql.DB, fn func(context.Context, *sql.Con
 		return err
 	}
 	committed = true
+	txErr = false
 	return nil
+}
+
+func observeConnectionWait(observer Observer, component string, err error, duration time.Duration) {
+	if observer == nil || component == "" {
+		return
+	}
+	observer.ObserveSQLiteConnectionWait(component, sqliteOutcome(err), duration)
+}
+
+func observeTransactionDuration(observer Observer, component string, err error, duration time.Duration) {
+	if observer == nil || component == "" {
+		return
+	}
+	observer.ObserveSQLiteTransactionDuration(component, sqliteOutcome(err), duration)
+}
+
+func sqliteOutcome(err error) string {
+	if err != nil {
+		return "error"
+	}
+	return "success"
 }

--- a/phase4-coordinator/internal/sqliteutil/transact_test.go
+++ b/phase4-coordinator/internal/sqliteutil/transact_test.go
@@ -4,10 +4,38 @@ import (
 	"context"
 	"database/sql"
 	"errors"
+	"os"
 	"testing"
+	"time"
 
 	_ "modernc.org/sqlite"
 )
+
+type observedEvent struct {
+	kind      string
+	component string
+	outcome   string
+}
+
+type testObserver struct {
+	events []observedEvent
+}
+
+func (o *testObserver) ObserveSQLiteConnectionWait(component, outcome string, _ time.Duration) {
+	o.events = append(o.events, observedEvent{kind: "conn", component: component, outcome: outcome})
+}
+
+func (o *testObserver) ObserveSQLiteTransactionDuration(component, outcome string, _ time.Duration) {
+	o.events = append(o.events, observedEvent{kind: "tx", component: component, outcome: outcome})
+}
+
+func (o *testObserver) ObserveSQLiteWALCheckpoint(component, pageClass, outcome string, _ int64) {
+	o.events = append(o.events, observedEvent{kind: "wal:" + pageClass, component: component, outcome: outcome})
+}
+
+func (o *testObserver) ObserveSQLiteWALCheckpointDuration(component, outcome string, _ time.Duration) {
+	o.events = append(o.events, observedEvent{kind: "wal_duration", component: component, outcome: outcome})
+}
 
 func openTestDB(t *testing.T) *sql.DB {
 	t.Helper()
@@ -112,4 +140,67 @@ func TestTransactBeginError(t *testing.T) {
 	if err == nil {
 		t.Fatal("Transact returned nil on closed db, want error")
 	}
+}
+
+func TestTransactObservedEmitsConnectionWaitAndTransactionOutcome(t *testing.T) {
+	db := openTestDB(t)
+	observer := &testObserver{}
+
+	err := TransactObserved(context.Background(), db, "billing_hot_path", observer, func(ctx context.Context, conn *sql.Conn) error {
+		_, err := conn.ExecContext(ctx, `INSERT INTO t (v) VALUES ('a')`)
+		return err
+	})
+	if err != nil {
+		t.Fatalf("TransactObserved success path returned err: %v", err)
+	}
+
+	sentinel := errors.New("callback rejected")
+	err = TransactObserved(context.Background(), db, "billing_hot_path", observer, func(context.Context, *sql.Conn) error {
+		return sentinel
+	})
+	if !errors.Is(err, sentinel) {
+		t.Fatalf("TransactObserved returned %v, want sentinel", err)
+	}
+
+	assertObserved(t, observer.events, observedEvent{kind: "conn", component: "billing_hot_path", outcome: "success"})
+	assertObserved(t, observer.events, observedEvent{kind: "tx", component: "billing_hot_path", outcome: "success"})
+	assertObserved(t, observer.events, observedEvent{kind: "tx", component: "billing_hot_path", outcome: "error"})
+}
+
+func TestRunWALCheckpointEmitsPageClasses(t *testing.T) {
+	dbPath := t.TempDir() + "/checkpoint.db"
+	db, err := sql.Open("sqlite", WithManualWALCheckpointPragmas(dbPath))
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	if _, err := db.Exec(`CREATE TABLE t (id INTEGER PRIMARY KEY, v TEXT)`); err != nil {
+		t.Fatalf("create table: %v", err)
+	}
+	if _, err := db.Exec(`INSERT INTO t (v) VALUES ('a')`); err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+
+	observer := &testObserver{}
+	if err := RunWALCheckpoint(context.Background(), db, "wal_checkpoint", observer); err != nil {
+		t.Fatalf("RunWALCheckpoint returned err: %v", err)
+	}
+
+	assertObserved(t, observer.events, observedEvent{kind: "wal:busy", component: "wal_checkpoint", outcome: "success"})
+	assertObserved(t, observer.events, observedEvent{kind: "wal:log", component: "wal_checkpoint", outcome: "success"})
+	assertObserved(t, observer.events, observedEvent{kind: "wal:checkpointed", component: "wal_checkpoint", outcome: "success"})
+	assertObserved(t, observer.events, observedEvent{kind: "wal_duration", component: "wal_checkpoint", outcome: "success"})
+	if info, err := os.Stat(dbPath + "-wal"); err == nil && info.Size() != 0 {
+		t.Fatalf("WAL size after TRUNCATE checkpoint=%d want 0", info.Size())
+	}
+}
+
+func assertObserved(t *testing.T, events []observedEvent, want observedEvent) {
+	t.Helper()
+	for _, got := range events {
+		if got == want {
+			return
+		}
+	}
+	t.Fatalf("missing observation %+v in %+v", want, events)
 }

--- a/phase4-coordinator/internal/sqliteutil/wal.go
+++ b/phase4-coordinator/internal/sqliteutil/wal.go
@@ -1,0 +1,43 @@
+package sqliteutil
+
+import (
+	"context"
+	"database/sql"
+	"time"
+)
+
+// WALObserver receives closed-set WAL checkpoint page observations.
+type WALObserver interface {
+	ObserveSQLiteWALCheckpoint(component, pageClass, outcome string, pages int64)
+	ObserveSQLiteWALCheckpointDuration(component, outcome string, duration time.Duration)
+}
+
+// RunWALCheckpoint runs a bounded TRUNCATE checkpoint on the supplied SQLite
+// handle and observes the busy/log/checkpointed page counts. Callers should
+// provide an off-hot-path *sql.DB so disabling wal_autocheckpoint does not
+// move checkpoint work onto request or billing pools.
+func RunWALCheckpoint(ctx context.Context, db *sql.DB, component string, observer WALObserver) error {
+	var busy, logPages, checkpointedPages int64
+	started := time.Now()
+	err := db.QueryRowContext(ctx, `PRAGMA wal_checkpoint(TRUNCATE)`).Scan(&busy, &logPages, &checkpointedPages)
+	outcome := sqliteOutcome(err)
+	observeWALCheckpointDuration(observer, component, outcome, time.Since(started))
+	observeWALCheckpoint(observer, component, "busy", outcome, busy)
+	observeWALCheckpoint(observer, component, "log", outcome, logPages)
+	observeWALCheckpoint(observer, component, "checkpointed", outcome, checkpointedPages)
+	return err
+}
+
+func observeWALCheckpoint(observer WALObserver, component, pageClass, outcome string, pages int64) {
+	if observer == nil || component == "" {
+		return
+	}
+	observer.ObserveSQLiteWALCheckpoint(component, pageClass, outcome, pages)
+}
+
+func observeWALCheckpointDuration(observer WALObserver, component, outcome string, duration time.Duration) {
+	if observer == nil || component == "" {
+		return
+	}
+	observer.ObserveSQLiteWALCheckpointDuration(component, outcome, duration)
+}

--- a/phase4-coordinator/internal/stats/metrics/metrics.go
+++ b/phase4-coordinator/internal/stats/metrics/metrics.go
@@ -50,6 +50,8 @@
 package metrics
 
 import (
+	"time"
+
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 )
@@ -73,6 +75,11 @@ type Metrics struct {
 	CredentialBootstrapTotal     *prometheus.CounterVec
 	ReferralEventTotal           *prometheus.CounterVec
 	ProviderConnectionEventTotal *prometheus.CounterVec
+	MoneySQLiteConnectionWait    *prometheus.HistogramVec
+	MoneySQLiteTransaction       *prometheus.HistogramVec
+	MoneySQLiteWrite             *prometheus.HistogramVec
+	MoneySQLiteWALCheckpoint     *prometheus.GaugeVec
+	MoneySQLiteWALCheckpointTime *prometheus.HistogramVec
 	// CapacityOverClaimTotal is the issue-#764 over-claim tripwire. It is
 	// PERMANENT by construction: a prometheus counter never decreases and is
 	// never reset for the process lifetime, and the coordinator increments it
@@ -191,6 +198,45 @@ func New(reg prometheus.Registerer) *Metrics {
 				Help: "Count of durable provider connection lifecycle events by closed-set kind, outcome, and failure_reason.",
 			},
 			[]string{"kind", "outcome", "failure_reason"},
+		),
+		MoneySQLiteConnectionWait: f.NewHistogramVec(
+			prometheus.HistogramOpts{
+				Name:    "money_sqlite_connection_wait_seconds",
+				Help:    "sql.DB connection wait time for coordinator money-path SQLite operations.",
+				Buckets: prometheus.ExponentialBuckets(0.0005, 2, 16),
+			},
+			[]string{"component", "outcome"},
+		),
+		MoneySQLiteTransaction: f.NewHistogramVec(
+			prometheus.HistogramOpts{
+				Name:    "money_sqlite_transaction_duration_seconds",
+				Help:    "BEGIN IMMEDIATE to COMMIT/ROLLBACK duration for coordinator money-path SQLite transactions.",
+				Buckets: prometheus.ExponentialBuckets(0.001, 2, 16),
+			},
+			[]string{"component", "outcome"},
+		),
+		MoneySQLiteWrite: f.NewHistogramVec(
+			prometheus.HistogramOpts{
+				Name:    "money_sqlite_write_duration_seconds",
+				Help:    "Duration of single-statement coordinator money-path SQLite writes that do not use the shared transaction helper.",
+				Buckets: prometheus.ExponentialBuckets(0.001, 2, 16),
+			},
+			[]string{"component", "operation", "outcome"},
+		),
+		MoneySQLiteWALCheckpoint: f.NewGaugeVec(
+			prometheus.GaugeOpts{
+				Name: "money_sqlite_wal_checkpoint_pages",
+				Help: "Latest off-hot-path SQLite WAL checkpoint page counts by component, page class, and outcome.",
+			},
+			[]string{"component", "page_class", "outcome"},
+		),
+		MoneySQLiteWALCheckpointTime: f.NewHistogramVec(
+			prometheus.HistogramOpts{
+				Name:    "money_sqlite_wal_checkpoint_duration_seconds",
+				Help:    "Duration of off-hot-path coordinator money SQLite WAL checkpoints.",
+				Buckets: prometheus.ExponentialBuckets(0.001, 2, 16),
+			},
+			[]string{"component", "outcome"},
 		),
 	}
 }
@@ -318,4 +364,75 @@ func (m *Metrics) IncProviderConnectionEvent(kind, outcome, failureReason string
 		failureReason = "other"
 	}
 	m.ProviderConnectionEventTotal.WithLabelValues(kind, outcome, failureReason).Inc()
+}
+
+func (m *Metrics) ObserveSQLiteConnectionWait(component, outcome string, duration time.Duration) {
+	if m == nil || m.MoneySQLiteConnectionWait == nil || !allowMoneySQLiteComponent(component) || !allowMoneySQLiteOutcome(outcome) {
+		return
+	}
+	m.MoneySQLiteConnectionWait.WithLabelValues(component, outcome).Observe(duration.Seconds())
+}
+
+func (m *Metrics) ObserveSQLiteTransactionDuration(component, outcome string, duration time.Duration) {
+	if m == nil || m.MoneySQLiteTransaction == nil || !allowMoneySQLiteComponent(component) || !allowMoneySQLiteOutcome(outcome) {
+		return
+	}
+	m.MoneySQLiteTransaction.WithLabelValues(component, outcome).Observe(duration.Seconds())
+}
+
+func (m *Metrics) ObserveSQLiteWriteDuration(component, operation, outcome string, duration time.Duration) {
+	if m == nil || m.MoneySQLiteWrite == nil || !allowMoneySQLiteComponent(component) || !allowMoneySQLiteOperation(operation) || !allowMoneySQLiteOutcome(outcome) {
+		return
+	}
+	m.MoneySQLiteWrite.WithLabelValues(component, operation, outcome).Observe(duration.Seconds())
+}
+
+func (m *Metrics) ObserveSQLiteWALCheckpoint(component, pageClass, outcome string, pages int64) {
+	if m == nil || m.MoneySQLiteWALCheckpoint == nil || !allowMoneySQLiteComponent(component) || !allowMoneySQLitePageClass(pageClass) || !allowMoneySQLiteOutcome(outcome) {
+		return
+	}
+	m.MoneySQLiteWALCheckpoint.WithLabelValues(component, pageClass, outcome).Set(float64(pages))
+}
+
+func (m *Metrics) ObserveSQLiteWALCheckpointDuration(component, outcome string, duration time.Duration) {
+	if m == nil || m.MoneySQLiteWALCheckpointTime == nil || !allowMoneySQLiteComponent(component) || !allowMoneySQLiteOutcome(outcome) {
+		return
+	}
+	m.MoneySQLiteWALCheckpointTime.WithLabelValues(component, outcome).Observe(duration.Seconds())
+}
+
+func allowMoneySQLiteComponent(component string) bool {
+	switch component {
+	case "billing_hot_path", "request_log_identity", "billing_reload_config", "route_snapshot", "wal_checkpoint":
+		return true
+	default:
+		return false
+	}
+}
+
+func allowMoneySQLiteOperation(operation string) bool {
+	switch operation {
+	case "route_snapshot_insert":
+		return true
+	default:
+		return false
+	}
+}
+
+func allowMoneySQLiteOutcome(outcome string) bool {
+	switch outcome {
+	case "success", "error":
+		return true
+	default:
+		return false
+	}
+}
+
+func allowMoneySQLitePageClass(pageClass string) bool {
+	switch pageClass {
+	case "busy", "log", "checkpointed":
+		return true
+	default:
+		return false
+	}
 }

--- a/phase4-coordinator/internal/stats/metrics/metrics_test.go
+++ b/phase4-coordinator/internal/stats/metrics/metrics_test.go
@@ -17,7 +17,9 @@ package metrics
 import (
 	"regexp"
 	"strconv"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
 )
@@ -47,6 +49,18 @@ var (
 		"minted": true, "recovered": true, "rejected_v1": true,
 		"rejected_identity": true, "rejected_used": true, "rejected_expired": true,
 		"rejected_rate": true, "rejected_outstanding": true, "store_error": true,
+	}
+	allowMoneySQLiteComponentLabel = map[string]bool{
+		"billing_hot_path": true, "request_log_identity": true,
+		"billing_reload_config": true, "route_snapshot": true,
+		"wal_checkpoint": true,
+	}
+	allowMoneySQLiteOutcomeLabel   = map[string]bool{"success": true, "error": true}
+	allowMoneySQLiteOperationLabel = map[string]bool{
+		"route_snapshot_insert": true,
+	}
+	allowMoneySQLitePageClassLabel = map[string]bool{
+		"busy": true, "log": true, "checkpointed": true,
 	}
 	allowReferralOutcome = map[string]bool{
 		"disabled": true, "busy": true, "rate_limited": true,
@@ -99,6 +113,17 @@ func TestLabelHygiene(t *testing.T) {
 	}
 	m.IncReferralEvent("validate", "raw-attacker-value")
 	m.IncReferralEvent("raw-attacker-value", "valid")
+	m.ObserveSQLiteConnectionWait("billing_hot_path", "success", time.Millisecond)
+	m.ObserveSQLiteConnectionWait("raw-attacker-value", "success", time.Millisecond)
+	m.ObserveSQLiteConnectionWait("billing_hot_path", "raw-attacker-value", time.Millisecond)
+	m.ObserveSQLiteTransactionDuration("request_log_identity", "error", time.Millisecond)
+	m.ObserveSQLiteWriteDuration("route_snapshot", "route_snapshot_insert", "success", time.Millisecond)
+	m.ObserveSQLiteWriteDuration("route_snapshot", "raw-attacker-value", "success", time.Millisecond)
+	m.ObserveSQLiteWALCheckpoint("wal_checkpoint", "log", "success", 7)
+	m.ObserveSQLiteWALCheckpoint("wal_checkpoint", "raw-attacker-value", "success", 7)
+	m.ObserveSQLiteWALCheckpointDuration("wal_checkpoint", "success", time.Millisecond)
+	m.ObserveSQLiteWALCheckpointDuration("raw-attacker-value", "success", time.Millisecond)
+	m.ObserveSQLiteWALCheckpointDuration("wal_checkpoint", "raw-attacker-value", time.Millisecond)
 
 	families, err := reg.Gather()
 	if err != nil {
@@ -131,8 +156,8 @@ func TestLabelHygiene(t *testing.T) {
 						t.Errorf("metric %s endpoint=%q not in allowed set", mf.GetName(), val)
 					}
 				case "component":
-					if !allowComp[val] {
-						t.Errorf("metric %s component=%q not in §9.5 allowed set", mf.GetName(), val)
+					if !allowComp[val] && !allowMoneySQLiteComponentLabel[val] {
+						t.Errorf("metric %s component=%q not in allowed set", mf.GetName(), val)
 					}
 				case "partner_key_id":
 					// Must parse as a non-negative integer.
@@ -171,8 +196,20 @@ func TestLabelHygiene(t *testing.T) {
 						if !allowReferralOutcome[val] {
 							t.Errorf("metric %s outcome=%q not in referral allowed set", mf.GetName(), val)
 						}
+					} else if strings.HasPrefix(mf.GetName(), "money_sqlite_") {
+						if !allowMoneySQLiteOutcomeLabel[val] {
+							t.Errorf("metric %s outcome=%q not in money SQLite allowed set", mf.GetName(), val)
+						}
 					} else if !allowCredentialBootstrapOutcome[val] {
 						t.Errorf("metric %s outcome=%q not in allowed set", mf.GetName(), val)
+					}
+				case "operation":
+					if !allowMoneySQLiteOperationLabel[val] {
+						t.Errorf("metric %s operation=%q not in allowed set", mf.GetName(), val)
+					}
+				case "page_class":
+					if !allowMoneySQLitePageClassLabel[val] {
+						t.Errorf("metric %s page_class=%q not in allowed set", mf.GetName(), val)
 					}
 				}
 			}


### PR DESCRIPTION
## Summary

Second stacked slice for #1197, based on #1210.

- moves coordinator money-path SQLite handles to explicit WAL checkpoint ownership
- keeps standalone CLI/default store opens on SQLite autocheckpoint unless a checkpoint owner is explicitly started
- runs idle-gated `PRAGMA wal_checkpoint(TRUNCATE)` off the buyer path
- adds closed-label metrics for SQLite connection wait, transaction/write duration, WAL checkpoint pages, and checkpoint duration
- defers optional startup retention deletes while preserving crash-recovery startup scan even when settlement jobs are disabled
- keeps settlement receipt audit outbox and operator restore/archive tooling out of this PR

## Verification

- `cd phase4-coordinator && go test ./cmd/coordinator ./internal/auth ./internal/mdm ./internal/audit ./internal/requestlog ./internal/sqliteutil ./internal/stats/metrics ./internal/billing ./internal/config -count=1`
- `cd phase4-coordinator && go test ./... -count=1`
- `cd test/integration && go test -race -count=1 -timeout 5m ./...`
- `python3 scripts/check_spec_governance.py --base-ref origin/codex/1197-gateway-retry`
- `python3 scripts/check_spec_pr_declaration.py --event /private/tmp/1197-pr2-event.json --base origin/codex/1197-gateway-retry --head HEAD`
- `git diff --check origin/codex/1197-gateway-retry`

## Stack

- #1210: gateway retry amplification reduction
- this PR: coordinator SQLite pressure relief
- next: settlement receipt audit outbox
- next: operator incident-response tooling

SPEC-GOVERNANCE-DECLARATION-BEGIN
{
  "schema_version": "spec-pr-governance-v1",
  "issue": "https://github.com/Augustas11/macprovider/issues/1197",
  "behavior_change": "yes",
  "contract_change": "none",
  "specs": ["SPEC-005", "SPEC-022"],
  "requirements": ["SPEC-005-R002", "SPEC-022-R001"],
  "authority_domains": ["billing-settlement-formula", "verified-model-settlement"],
  "arbitration": ["CODE_BUG"],
  "tests": [
    "phase4-coordinator/internal/audit",
    "phase4-coordinator/internal/auth",
    "phase4-coordinator/internal/mdm",
    "phase4-coordinator/internal/sqliteutil",
    "phase4-coordinator/internal/requestlog",
    "phase4-coordinator/internal/billing",
    "phase4-coordinator/internal/config",
    "phase4-coordinator/internal/stats/metrics",
    "phase4-coordinator/cmd/coordinator"
  ],
  "journeys": ["not-required"]
}
SPEC-GOVERNANCE-DECLARATION-END
