### PR TITLE
Move settlement receipt audit writes off the hot path

### DIFF
--- a/ops/pearl-updater/macprovider-pearl-update
+++ b/ops/pearl-updater/macprovider-pearl-update
@@ -2220,6 +2220,10 @@ class Updater:
             raise UpdateError(f"{description} must be a normalized absolute path")
         return path
 
+    @staticmethod
+    def _coordinator_audit_database_path(coordinator_database: Path) -> Path:
+        return coordinator_database.parent / "coordinator-audit.db"
+
     def capture_database_paths(self) -> None:
         if self.gateway_db is not None:
             paths = (
@@ -2227,6 +2231,10 @@ class Updater:
                 if self.databases and self.databases[0] == self.gateway_db
                 else (self.gateway_db, *self.databases)
             )
+            if len(paths) >= 2:
+                coordinator_audit_database = self._coordinator_audit_database_path(paths[1])
+                if coordinator_audit_database not in paths:
+                    paths = (paths[0], paths[1], coordinator_audit_database, *paths[2:])
             config_hashes = dict(self.runtime_config_hashes)
         else:
             runtime = self.coordinator_runtime_state or self.coordinator_runtime()
@@ -2250,11 +2258,12 @@ class Updater:
             stats_unit_inputs, stats_database = self.stats_mirror_runtime()
             gateway_database = self._database_path(gateway, "gateway storage.db_path")
             coordinator_database = self._database_path(storage, "coordinator storage.db_path")
+            coordinator_audit_database = self._coordinator_audit_database_path(coordinator_database)
             if gateway_database == coordinator_database:
                 raise UpdateError("gateway and coordinator database paths must be distinct")
             if stats_database == gateway_database:
                 raise UpdateError("stats billing mirror cannot read the gateway database")
-            resolved = [gateway_database, coordinator_database]
+            resolved = [gateway_database, coordinator_database, coordinator_audit_database]
             if stats_database != coordinator_database:
                 resolved.append(stats_database)
             payout = effective.get(("malibu_emission", "sqlite_payout_db_path"))

--- a/ops/pearl-updater/test_pearl_updater.py
+++ b/ops/pearl-updater/test_pearl_updater.py
@@ -4916,6 +4916,7 @@ class PearlUpdaterTests(unittest.TestCase):
             (
                 Path("/srv/macprovider/gateway.sqlite"),
                 Path("/srv/macprovider/coordinator.sqlite"),
+                Path("/srv/macprovider/coordinator-audit.db"),
                 Path("/srv/macprovider/stats.sqlite"),
                 Path("/srv/macprovider/payout.sqlite"),
             ),
@@ -4957,7 +4958,11 @@ class PearlUpdaterTests(unittest.TestCase):
 
         self.assertEqual(
             self.updater.databases,
-            (Path("/srv/macprovider/gateway.sqlite"), coordinator_database),
+            (
+                Path("/srv/macprovider/gateway.sqlite"),
+                coordinator_database,
+                Path("/srv/macprovider/coordinator-audit.db"),
+            ),
         )
         self.assertEqual(self.updater.gateway_db, Path("/srv/macprovider/gateway.sqlite"))
         self.assertEqual(
@@ -4996,6 +5001,28 @@ class PearlUpdaterTests(unittest.TestCase):
         self.assertEqual(self.updater.databases, captured_paths)
         self.assertEqual(self.updater.runtime_config_hashes, captured_hashes)
 
+    def test_gateway_cannot_share_derived_coordinator_audit_database(self):
+        install = self.updater.install_root
+        install.mkdir(parents=True)
+        coordinator = install / "coordinator.yaml"
+        gateway = install / "gateway.yaml"
+        stats_fragment = self.root / "stats.service"
+        stats_dropin = self.root / "gate.conf"
+        coordinator.write_text("storage:\n  db_path: /srv/macprovider/coordinator.sqlite\n")
+        gateway.write_text("storage:\n  db_path: /srv/macprovider/coordinator-audit.db\n")
+        stats_fragment.write_text("[Service]\nExecStart=/bin/true\n")
+        stats_dropin.write_text(updater_module.TRANSACTION_GATE_DROPIN_TEXT)
+        self.updater.gateway_db = None
+        self.updater.databases = ()
+        self.updater.coordinator_runtime_state = updater_module.CoordinatorRuntime(coordinator, None, {})
+        self.updater.gateway_config_path = mock.Mock(return_value=gateway)
+        self.updater.stats_mirror_runtime = mock.Mock(
+            return_value=((stats_fragment, stats_dropin), Path("/srv/macprovider/stats.sqlite"))
+        )
+
+        with self.assertRaisesRegex(updater_module.UpdateError, "distinct absolute"):
+            self.updater.capture_database_paths()
+
     def test_capture_database_paths_accepts_journal_restored_state(self):
         gateway = Path("/srv/macprovider/gateway.sqlite")
         coordinator = Path("/srv/macprovider/coordinator.sqlite")
@@ -5008,7 +5035,10 @@ class PearlUpdaterTests(unittest.TestCase):
         self.updater.capture_database_paths()
 
         self.assertEqual(self.updater.gateway_db, gateway)
-        self.assertEqual(self.updater.databases, (gateway, coordinator))
+        self.assertEqual(
+            self.updater.databases,
+            (gateway, coordinator, Path("/srv/macprovider/coordinator-audit.db")),
+        )
         self.assertEqual(self.updater.runtime_config_hashes, {config: config_hash})
 
     def test_stats_mirror_cannot_share_gateway_database(self):

--- a/phase4-coordinator/cmd/coordinator/main.go
+++ b/phase4-coordinator/cmd/coordinator/main.go
@@ -242,6 +242,12 @@ func main() {
 		os.Exit(1)
 	}
 	defer auditStore.Close()
+	settlementReceiptAuditStore, err := audit.OpenSettlementReceiptStore(audit.DefaultDBPath(cfg.Storage.DBPath))
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "settlement receipt audit storage: %v\n", err)
+		os.Exit(1)
+	}
+	defer settlementReceiptAuditStore.Close()
 	admissionStore, err := providerws.NewSQLiteAdmissionStore(reqLogStore.DB())
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "admission storage: %v\n", err)
@@ -1264,8 +1270,10 @@ func main() {
 	startSettlementStartupScan(context.Background(), billingStore, cfg.Settlement, time.Now().UTC(), logger)
 	billingStore.StartNightlyReconcile(shutdownCtx, cfg.Settlement)
 	billingStore.StartWeeklySettlement(shutdownCtx, cfg.Settlement)
+	flushSettlementReceiptAuditOutbox := startSettlementReceiptAuditOutboxDrainer(shutdownCtx, billingStore, settlementReceiptAuditStore, cfg.Storage.AuditLogRetentionDays, metricsHandle, logger)
 	startRequestLogRetentionPruner(shutdownCtx, reqLogStore, cfg.Storage.RequestLogRetentionDays, cfg.Storage.RequestLogPruneOnStartup, logger)
 	startAuditLogRetentionPruner(shutdownCtx, auditStore, cfg.Storage.AuditLogRetentionDays, cfg.Storage.AuditLogPruneOnStartup, logger)
+	startAuditLogRetentionPruner(shutdownCtx, settlementReceiptAuditStore, cfg.Storage.AuditLogRetentionDays, cfg.Storage.AuditLogPruneOnStartup, logger)
 	startProviderConnectionEventPruner(shutdownCtx, connectionEventStore, logger)
 	startAdmissionRetentionPruner(shutdownCtx, wsServer.Admission(), cfg.Admission.ProvisionalRetentionDays, logger)
 	startGitHubAuthStatePruner(shutdownCtx, tokenStore, logger)
@@ -1338,6 +1346,9 @@ func main() {
 			case <-ctx.Done():
 				logger.Warn().Msg("receipt rotation audit drain timed out at shutdown")
 			}
+			outboxFlushCtx, outboxFlushCancel := context.WithTimeout(context.Background(), 5*time.Second)
+			flushSettlementReceiptAuditOutbox(outboxFlushCtx)
+			outboxFlushCancel()
 			logger.Info().Msg("coordinator shutdown complete")
 			return
 		case err := <-errs:
@@ -1407,6 +1418,18 @@ type requestLogPruner interface {
 
 type settlementStartupScanner interface {
 	StartStartupScan(context.Context, config.SettlementConfig, time.Time) error
+}
+
+type settlementReceiptAuditOutboxDrainer interface {
+	DrainSettlementReceiptAuditOutbox(context.Context, billing.SettlementReceiptAuditSink, int) (int, error)
+	PruneSettlementReceiptAuditOutbox(context.Context, time.Time, int) (int64, error)
+	SettlementReceiptAuditOutboxStats(context.Context) (billing.SettlementReceiptAuditOutboxStats, error)
+}
+
+type settlementReceiptAuditOutboxObserver interface {
+	ObserveSettlementReceiptAuditOutbox(int64, time.Duration)
+	IncSettlementReceiptAuditOutboxDrain(string)
+	AddSettlementReceiptAuditOutboxRows(string, int64)
 }
 
 const (
@@ -1498,6 +1521,105 @@ func startSettlementStartupScan(ctx context.Context, scanner settlementStartupSc
 	if err := scanner.StartStartupScan(ctx, settlement, now); err != nil {
 		logger.Warn().Err(err).Msg("billing startup scan failed")
 	}
+}
+
+func startSettlementReceiptAuditOutboxDrainer(ctx context.Context, store settlementReceiptAuditOutboxDrainer, sink billing.SettlementReceiptAuditSink, retentionDays int, observer settlementReceiptAuditOutboxObserver, logger zerolog.Logger) func(context.Context) {
+	if store == nil || sink == nil {
+		return func(context.Context) {}
+	}
+	const (
+		batchLimit    = 100
+		pruneLimit    = 500
+		drainInterval = 30 * time.Second
+		drainTimeout  = 5 * time.Second
+		statsTimeout  = time.Second
+	)
+	observeStats := func(runCtx context.Context) {
+		statsCtx, cancel := context.WithTimeout(runCtx, statsTimeout)
+		defer cancel()
+		stats, err := store.SettlementReceiptAuditOutboxStats(statsCtx)
+		if err != nil {
+			logger.Warn().Err(err).Msg("settlement receipt audit outbox stats failed")
+			return
+		}
+		var oldestAge time.Duration
+		if stats.HasOldestPendingCreated {
+			oldestAge = time.Since(stats.OldestPendingCreatedAt)
+			if oldestAge < 0 {
+				oldestAge = 0
+			}
+		}
+		if observer != nil {
+			observer.ObserveSettlementReceiptAuditOutbox(stats.PendingRows, oldestAge)
+		}
+	}
+	drain := func(runCtx context.Context) (int, error) {
+		drainCtx, cancel := context.WithTimeout(runCtx, drainTimeout)
+		defer cancel()
+		drained, err := store.DrainSettlementReceiptAuditOutbox(drainCtx, sink, batchLimit)
+		outcome := "success"
+		if err != nil {
+			outcome = "error"
+			logger.Warn().Err(err).Msg("settlement receipt audit outbox drain failed")
+		}
+		if observer != nil {
+			observer.IncSettlementReceiptAuditOutboxDrain(outcome)
+			observer.AddSettlementReceiptAuditOutboxRows("drained", int64(drained))
+		}
+		if drained > 0 {
+			logger.Info().Int("drained_rows", drained).Msg("settlement receipt audit outbox drained rows")
+		}
+		if retentionDays > 0 {
+			cutoff := time.Now().UTC().AddDate(0, 0, -retentionDays)
+			pruneCtx, cancel := context.WithTimeout(runCtx, drainTimeout)
+			defer cancel()
+			pruned, err := store.PruneSettlementReceiptAuditOutbox(pruneCtx, cutoff, pruneLimit)
+			if err != nil {
+				logger.Warn().Err(err).Msg("settlement receipt audit outbox prune failed")
+			} else if pruned > 0 {
+				logger.Info().Int64("pruned_rows", pruned).Msg("settlement receipt audit outbox pruned rows")
+			}
+			if observer != nil {
+				observer.AddSettlementReceiptAuditOutboxRows("pruned", pruned)
+			}
+		}
+		observeStats(runCtx)
+		return drained, err
+	}
+	flushOne := func(runCtx context.Context) {
+		if runCtx == nil {
+			runCtx = context.Background()
+		}
+		_, _ = drain(runCtx)
+	}
+	flushAll := func(runCtx context.Context) {
+		if runCtx == nil {
+			runCtx = context.Background()
+		}
+		for {
+			if runCtx.Err() != nil {
+				return
+			}
+			drained, err := drain(runCtx)
+			if drained == 0 || (err == nil && drained < batchLimit) {
+				return
+			}
+		}
+	}
+	flushOne(ctx)
+	go func() {
+		ticker := time.NewTicker(drainInterval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				flushOne(ctx)
+			}
+		}
+	}()
+	return flushAll
 }
 
 // mustParseTrustedProxies parses cfg.Proxy.TrustedProxies into the

--- a/phase4-coordinator/cmd/coordinator/main_test.go
+++ b/phase4-coordinator/cmd/coordinator/main_test.go
@@ -7,6 +7,7 @@ import (
 	"database/sql"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -19,6 +20,7 @@ import (
 
 	"github.com/augstar/macprovider-coordinator/internal/auth"
 	"github.com/augstar/macprovider-coordinator/internal/autotune"
+	"github.com/augstar/macprovider-coordinator/internal/billing"
 	"github.com/augstar/macprovider-coordinator/internal/buyer"
 	"github.com/augstar/macprovider-coordinator/internal/config"
 	"github.com/augstar/macprovider-coordinator/internal/pool"
@@ -283,6 +285,78 @@ func TestMoneySQLiteActivityMiddlewareMarksRequests(t *testing.T) {
 	}
 }
 
+func TestSettlementReceiptAuditOutboxDrainerPrunesAfterDrainError(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	store := &settlementReceiptAuditOutboxDrainerStub{
+		drained:      1,
+		drainErr:     errors.New("poison outbox row"),
+		drainCalled:  make(chan struct{}, 2),
+		pruneCalled:  make(chan struct{}, 2),
+		statsPending: 1,
+	}
+	observer := &settlementReceiptAuditOutboxObserverStub{
+		drainOutcomes: make(chan string, 2),
+		rowOps:        make(chan string, 4),
+	}
+
+	startSettlementReceiptAuditOutboxDrainer(ctx, store, settlementReceiptAuditSinkStub{}, 90, observer, zerolog.Nop())
+
+	assertSignal(t, store.drainCalled, "audit outbox drain")
+	assertSignal(t, store.pruneCalled, "audit outbox prune")
+	assertStringSignal(t, observer.drainOutcomes, "error", "audit outbox drain outcome")
+	assertStringSignal(t, observer.rowOps, "drained", "audit outbox drained row metric")
+}
+
+func TestSettlementReceiptAuditOutboxShutdownFlushDrains(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	store := &settlementReceiptAuditOutboxDrainerStub{
+		drainedBatches: []int{0, 100, 100, 50},
+		drainCalled:    make(chan struct{}, 4),
+		pruneCalled:    make(chan struct{}, 2),
+	}
+
+	flush := startSettlementReceiptAuditOutboxDrainer(ctx, store, settlementReceiptAuditSinkStub{}, 0, nil, zerolog.Nop())
+	assertSignal(t, store.drainCalled, "initial audit outbox drain")
+
+	shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), time.Second)
+	defer shutdownCancel()
+	flush(shutdownCtx)
+	assertSignal(t, store.drainCalled, "shutdown audit outbox drain")
+	assertSignal(t, store.drainCalled, "shutdown audit outbox second batch")
+	assertSignal(t, store.drainCalled, "shutdown audit outbox final batch")
+	assertNoSignal(t, store.drainCalled, "shutdown audit outbox extra batch")
+}
+
+func TestSettlementReceiptAuditOutboxShutdownFlushContinuesAfterPartialError(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	store := &settlementReceiptAuditOutboxDrainerStub{
+		drainedBatches: []int{0, 99, 99, 2, 0},
+		drainErrs: []error{
+			nil,
+			errors.New("poison outbox row"),
+			errors.New("poison outbox row"),
+			nil,
+			errors.New("only poison rows remain"),
+		},
+		drainCalled: make(chan struct{}, 5),
+		pruneCalled: make(chan struct{}, 5),
+	}
+
+	flush := startSettlementReceiptAuditOutboxDrainer(ctx, store, settlementReceiptAuditSinkStub{}, 0, nil, zerolog.Nop())
+	assertSignal(t, store.drainCalled, "initial audit outbox drain")
+
+	shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), time.Second)
+	defer shutdownCancel()
+	flush(shutdownCtx)
+	assertSignal(t, store.drainCalled, "shutdown audit outbox first partial batch")
+	assertSignal(t, store.drainCalled, "shutdown audit outbox second partial batch")
+	assertSignal(t, store.drainCalled, "shutdown audit outbox final successful batch")
+	assertNoSignal(t, store.drainCalled, "shutdown audit outbox poison-only spin")
+}
+
 type startupScanStub struct {
 	called chan config.SettlementConfig
 }
@@ -327,6 +401,101 @@ type fixedIdleTracker struct {
 
 func (t fixedIdleTracker) IdleFor(time.Time) time.Duration {
 	return t.idleFor
+}
+
+type settlementReceiptAuditOutboxDrainerStub struct {
+	drained        int
+	drainedBatches []int
+	drainErrs      []error
+	drainErr       error
+	pruned         int64
+	drainCalled    chan struct{}
+	pruneCalled    chan struct{}
+	statsPending   int64
+}
+
+func (s *settlementReceiptAuditOutboxDrainerStub) DrainSettlementReceiptAuditOutbox(context.Context, billing.SettlementReceiptAuditSink, int) (int, error) {
+	s.drainCalled <- struct{}{}
+	err := s.drainErr
+	if len(s.drainErrs) > 0 {
+		err = s.drainErrs[0]
+		s.drainErrs = s.drainErrs[1:]
+	}
+	if len(s.drainedBatches) > 0 {
+		drained := s.drainedBatches[0]
+		s.drainedBatches = s.drainedBatches[1:]
+		return drained, err
+	}
+	return s.drained, err
+}
+
+func (s *settlementReceiptAuditOutboxDrainerStub) PruneSettlementReceiptAuditOutbox(context.Context, time.Time, int) (int64, error) {
+	s.pruneCalled <- struct{}{}
+	return s.pruned, nil
+}
+
+func (s *settlementReceiptAuditOutboxDrainerStub) SettlementReceiptAuditOutboxStats(context.Context) (billing.SettlementReceiptAuditOutboxStats, error) {
+	stats := billing.SettlementReceiptAuditOutboxStats{PendingRows: s.statsPending}
+	if s.statsPending > 0 {
+		stats.OldestPendingCreatedAt = time.Now().Add(-time.Minute)
+		stats.HasOldestPendingCreated = true
+	}
+	return stats, nil
+}
+
+type settlementReceiptAuditSinkStub struct{}
+
+func (settlementReceiptAuditSinkStub) InsertSettlementReceiptOutbox(context.Context, time.Time, string, string, string, int64) (bool, error) {
+	return true, nil
+}
+
+type settlementReceiptAuditOutboxObserverStub struct {
+	drainOutcomes chan string
+	rowOps        chan string
+}
+
+func (s *settlementReceiptAuditOutboxObserverStub) ObserveSettlementReceiptAuditOutbox(int64, time.Duration) {
+}
+
+func (s *settlementReceiptAuditOutboxObserverStub) IncSettlementReceiptAuditOutboxDrain(outcome string) {
+	s.drainOutcomes <- outcome
+}
+
+func (s *settlementReceiptAuditOutboxObserverStub) AddSettlementReceiptAuditOutboxRows(operation string, rows int64) {
+	if rows <= 0 {
+		return
+	}
+	s.rowOps <- operation
+}
+
+func assertSignal(t *testing.T, ch <-chan struct{}, name string) {
+	t.Helper()
+	select {
+	case <-ch:
+	case <-time.After(time.Second):
+		t.Fatalf("%s did not run", name)
+	}
+}
+
+func assertStringSignal(t *testing.T, ch <-chan string, want, name string) {
+	t.Helper()
+	select {
+	case got := <-ch:
+		if got != want {
+			t.Fatalf("%s=%q want %q", name, got, want)
+		}
+	case <-time.After(time.Second):
+		t.Fatalf("%s did not run", name)
+	}
+}
+
+func assertNoSignal(t *testing.T, ch <-chan struct{}, name string) {
+	t.Helper()
+	select {
+	case <-ch:
+		t.Fatalf("%s unexpectedly ran", name)
+	case <-time.After(100 * time.Millisecond):
+	}
 }
 
 func assertNoImmediatePrune(t *testing.T, called <-chan time.Time, name string) {

--- a/phase4-coordinator/internal/audit/store.go
+++ b/phase4-coordinator/internal/audit/store.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/augstar/macprovider-coordinator/internal/pool"
@@ -17,20 +18,35 @@ import (
 var errStoreClosed = errors.New("audit store is closed")
 
 type Store struct {
-	db *sql.DB
+	db                             *sql.DB
+	settlementReceiptOutboxEnabled bool
+}
+
+// DefaultDBPath returns the sibling audit DB path next to the primary
+// coordinator money DB.
+func DefaultDBPath(storageDBPath string) string {
+	dir := filepath.Dir(strings.TrimSpace(storageDBPath))
+	if dir == "" || dir == "." {
+		return "coordinator-audit.db"
+	}
+	return filepath.Join(dir, "coordinator-audit.db")
 }
 
 func OpenStore(dbPath string) (*Store, error) {
-	return openStore(dbPath, false)
+	return openStore(dbPath, false, false)
+}
+
+func OpenSettlementReceiptStore(dbPath string) (*Store, error) {
+	return openStore(dbPath, false, true)
 }
 
 // OpenStoreWithManualWALCheckpoint opens an audit store for a SQLite DB whose
 // physical file has an explicit external WAL checkpoint owner.
 func OpenStoreWithManualWALCheckpoint(dbPath string) (*Store, error) {
-	return openStore(dbPath, true)
+	return openStore(dbPath, true, false)
 }
 
-func openStore(dbPath string, manualWALCheckpoint bool) (*Store, error) {
+func openStore(dbPath string, manualWALCheckpoint bool, settlementReceiptOutboxEnabled bool) (*Store, error) {
 	if dbPath == "" {
 		return nil, fmt.Errorf("db path is required")
 	}
@@ -53,7 +69,7 @@ func openStore(dbPath string, manualWALCheckpoint bool) (*Store, error) {
 	// latent SQLITE_BUSY source on the coordinator money path.
 	db.SetMaxOpenConns(1)
 	db.SetMaxIdleConns(1)
-	s := &Store{db: db}
+	s := &Store{db: db, settlementReceiptOutboxEnabled: settlementReceiptOutboxEnabled}
 	ctx := context.Background()
 	if _, err := s.db.ExecContext(ctx, `PRAGMA journal_mode=WAL`); err != nil {
 		_ = db.Close()
@@ -109,6 +125,25 @@ CREATE INDEX IF NOT EXISTS idx_audit_log_ts_utc ON audit_log(ts_utc);
 CREATE INDEX IF NOT EXISTS idx_audit_log_provider_id ON audit_log(provider_id);
 CREATE INDEX IF NOT EXISTS idx_audit_log_event_type ON audit_log(event_type);
 `)
+	if err != nil {
+		return err
+	}
+	if !s.settlementReceiptOutboxEnabled {
+		return nil
+	}
+	exists, err := s.columnExists(ctx, "audit_log", "settlement_receipt_audit_outbox_id")
+	if err != nil {
+		return err
+	}
+	if !exists {
+		if _, err := s.db.ExecContext(ctx, `ALTER TABLE audit_log ADD COLUMN settlement_receipt_audit_outbox_id INTEGER NULL`); err != nil {
+			return err
+		}
+	}
+	_, err = s.db.ExecContext(ctx, `
+CREATE UNIQUE INDEX IF NOT EXISTS idx_audit_log_settlement_receipt_outbox
+    ON audit_log(settlement_receipt_audit_outbox_id)
+    WHERE settlement_receipt_audit_outbox_id IS NOT NULL`)
 	return err
 }
 
@@ -133,6 +168,88 @@ INSERT INTO audit_log (
 		payloadJSON,
 	)
 	return err
+}
+
+func (s *Store) InsertSettlementReceiptOutbox(ctx context.Context, ts time.Time, eventType, providerID, payloadJSON string, outboxID int64) (bool, error) {
+	if s == nil || s.db == nil {
+		return false, errStoreClosed
+	}
+	if outboxID <= 0 {
+		return false, fmt.Errorf("settlement receipt audit outbox id is required")
+	}
+	var provider sql.NullString
+	if providerID != "" {
+		provider = sql.NullString{String: providerID, Valid: true}
+	}
+	res, err := s.db.ExecContext(ctx, `
+INSERT OR IGNORE INTO audit_log (
+    ts_utc,
+    event_type,
+    provider_id,
+    settlement_receipt_audit_outbox_id,
+    payload_json
+) VALUES (?, ?, ?, ?, ?)`,
+		ts.UTC().Format(time.RFC3339Nano),
+		eventType,
+		provider,
+		outboxID,
+		payloadJSON,
+	)
+	if err != nil {
+		return false, err
+	}
+	n, err := res.RowsAffected()
+	if err != nil {
+		return false, err
+	}
+	if n > 0 {
+		return true, nil
+	}
+	tsUTC := ts.UTC().Format(time.RFC3339Nano)
+	var gotTS, gotEventType, gotPayload string
+	var gotProvider sql.NullString
+	if err := s.db.QueryRowContext(ctx, `
+SELECT ts_utc, event_type, provider_id, payload_json
+FROM audit_log
+WHERE settlement_receipt_audit_outbox_id = ?`, outboxID).Scan(&gotTS, &gotEventType, &gotProvider, &gotPayload); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return false, fmt.Errorf("settlement receipt audit outbox id %d was ignored but no existing audit row was found", outboxID)
+		}
+		return false, err
+	}
+	if gotTS != tsUTC ||
+		gotEventType != eventType ||
+		gotProvider.Valid != provider.Valid ||
+		(gotProvider.Valid && gotProvider.String != provider.String) ||
+		gotPayload != payloadJSON {
+		return false, fmt.Errorf("settlement receipt audit outbox id %d already exists with different audit event", outboxID)
+	}
+	return false, nil
+}
+
+func (s *Store) columnExists(ctx context.Context, table, column string) (bool, error) {
+	rows, err := s.db.QueryContext(ctx, "PRAGMA table_info("+table+")")
+	if err != nil {
+		return false, err
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var cid int
+		var name, typ string
+		var notNull int
+		var defaultValue sql.NullString
+		var pk int
+		if err := rows.Scan(&cid, &name, &typ, &notNull, &defaultValue, &pk); err != nil {
+			return false, err
+		}
+		if name == column {
+			return true, nil
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return false, err
+	}
+	return false, nil
 }
 
 // pruneBatchSize bounds a single retention DELETE to keep the write lock

--- a/phase4-coordinator/internal/audit/store_test.go
+++ b/phase4-coordinator/internal/audit/store_test.go
@@ -11,6 +11,15 @@ import (
 	"github.com/augstar/macprovider-coordinator/internal/pool"
 )
 
+func TestDefaultDBPathReturnsSiblingAuditDB(t *testing.T) {
+	if got, want := DefaultDBPath(filepath.Join("var", "lib", "macprovider", "coordinator.db")), filepath.Join("var", "lib", "macprovider", "coordinator-audit.db"); got != want {
+		t.Fatalf("DefaultDBPath=%q want %q", got, want)
+	}
+	if got := DefaultDBPath("coordinator.db"); got != "coordinator-audit.db" {
+		t.Fatalf("DefaultDBPath local=%q want coordinator-audit.db", got)
+	}
+}
+
 func TestOpenStoreCreatesAuditLogSchema(t *testing.T) {
 	store := openTestStore(t)
 	defer store.Close()
@@ -47,6 +56,15 @@ WHERE type IN ('table', 'index') AND name IN (
 		if !seen[name] {
 			t.Fatalf("missing schema object %q; got %#v", name, seen)
 		}
+	}
+}
+
+func TestOpenStoreDoesNotMigrateSettlementReceiptOutboxID(t *testing.T) {
+	store := openTestStore(t)
+	defer store.Close()
+
+	if ok, err := store.columnExists(context.Background(), "audit_log", "settlement_receipt_audit_outbox_id"); err != nil || ok {
+		t.Fatalf("settlement receipt outbox column exists=%v err=%v, want absent for legacy audit store", ok, err)
 	}
 }
 
@@ -98,6 +116,163 @@ FROM audit_log`).Scan(&gotTS, &gotEventType, &gotProviderID, &gotPayload); err !
 	}
 	if gotTS != ts.Format(time.RFC3339Nano) || gotEventType != "custom_event" || gotProviderID != "provider-a" || gotPayload != payload {
 		t.Fatalf("row = (%q, %q, %q, %q)", gotTS, gotEventType, gotProviderID, gotPayload)
+	}
+}
+
+func TestInsertSettlementReceiptOutboxIsIdempotent(t *testing.T) {
+	store := openSettlementReceiptTestStore(t)
+	defer store.Close()
+	ctx := context.Background()
+	ts := time.Date(2026, 6, 7, 14, 23, 9, 123000000, time.UTC)
+	payload := `{"event":"one"}`
+
+	inserted, err := store.InsertSettlementReceiptOutbox(ctx, ts, "settlement_receipt_verdict", "provider-a", payload, 42)
+	if err != nil {
+		t.Fatalf("first insert: %v", err)
+	}
+	if !inserted {
+		t.Fatal("first insert inserted=false want true")
+	}
+	inserted, err = store.InsertSettlementReceiptOutbox(ctx, ts, "settlement_receipt_verdict", "provider-a", payload, 42)
+	if err != nil {
+		t.Fatalf("second insert: %v", err)
+	}
+	if inserted {
+		t.Fatal("second insert inserted=true want false")
+	}
+
+	var count int
+	var gotTS, gotPayload string
+	if err := store.DB().QueryRowContext(ctx, `
+SELECT COUNT(*), MIN(ts_utc), MIN(payload_json)
+FROM audit_log
+WHERE settlement_receipt_audit_outbox_id = 42`).Scan(&count, &gotTS, &gotPayload); err != nil {
+		t.Fatal(err)
+	}
+	if count != 1 || gotTS != ts.Format(time.RFC3339Nano) || gotPayload != `{"event":"one"}` {
+		t.Fatalf("row count/ts/payload = %d/%s/%s", count, gotTS, gotPayload)
+	}
+}
+
+func TestInsertSettlementReceiptOutboxRefusesMismatchedDuplicate(t *testing.T) {
+	tests := []struct {
+		name      string
+		ts        time.Time
+		eventType string
+		provider  string
+		payload   string
+	}{
+		{
+			name:      "timestamp",
+			ts:        time.Date(2026, 6, 7, 15, 23, 9, 123000000, time.UTC),
+			eventType: "settlement_receipt_verdict",
+			provider:  "provider-a",
+			payload:   `{"event":"one"}`,
+		},
+		{
+			name:      "event type",
+			ts:        time.Date(2026, 6, 7, 14, 23, 9, 123000000, time.UTC),
+			eventType: "settlement_receipt_replayed",
+			provider:  "provider-a",
+			payload:   `{"event":"one"}`,
+		},
+		{
+			name:      "provider",
+			ts:        time.Date(2026, 6, 7, 14, 23, 9, 123000000, time.UTC),
+			eventType: "settlement_receipt_verdict",
+			provider:  "provider-b",
+			payload:   `{"event":"one"}`,
+		},
+		{
+			name:      "payload",
+			ts:        time.Date(2026, 6, 7, 14, 23, 9, 123000000, time.UTC),
+			eventType: "settlement_receipt_verdict",
+			provider:  "provider-a",
+			payload:   `{"event":"two"}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			store := openSettlementReceiptTestStore(t)
+			defer store.Close()
+			ctx := context.Background()
+			originalTS := time.Date(2026, 6, 7, 14, 23, 9, 123000000, time.UTC)
+			originalPayload := `{"event":"one"}`
+
+			inserted, err := store.InsertSettlementReceiptOutbox(ctx, originalTS, "settlement_receipt_verdict", "provider-a", originalPayload, 42)
+			if err != nil {
+				t.Fatalf("first insert: %v", err)
+			}
+			if !inserted {
+				t.Fatal("first insert inserted=false want true")
+			}
+
+			inserted, err = store.InsertSettlementReceiptOutbox(ctx, tt.ts, tt.eventType, tt.provider, tt.payload, 42)
+			if err == nil {
+				t.Fatal("mismatched duplicate err=nil want error")
+			}
+			if inserted {
+				t.Fatal("mismatched duplicate inserted=true want false")
+			}
+			assertErrorContains(t, err, "already exists with different audit event")
+
+			var count int
+			var gotTS, gotEventType, gotProvider, gotPayload string
+			if err := store.DB().QueryRowContext(ctx, `
+SELECT COUNT(*), MIN(ts_utc), MIN(event_type), MIN(provider_id), MIN(payload_json)
+FROM audit_log
+WHERE settlement_receipt_audit_outbox_id = 42`).Scan(&count, &gotTS, &gotEventType, &gotProvider, &gotPayload); err != nil {
+				t.Fatal(err)
+			}
+			if count != 1 || gotTS != originalTS.Format(time.RFC3339Nano) || gotEventType != "settlement_receipt_verdict" || gotProvider != "provider-a" || gotPayload != originalPayload {
+				t.Fatalf("row count/ts/event/provider/payload = %d/%s/%s/%s/%s", count, gotTS, gotEventType, gotProvider, gotPayload)
+			}
+		})
+	}
+}
+
+func TestOpenStoreMigratesLegacyAuditLogForSettlementReceiptOutboxID(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "coordinator.db")
+	db, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.Exec(`
+CREATE TABLE audit_log (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    ts_utc TEXT NOT NULL,
+    event_type TEXT NOT NULL,
+    provider_id TEXT,
+    payload_json TEXT NOT NULL
+);
+INSERT INTO audit_log(ts_utc, event_type, provider_id, payload_json)
+VALUES('2026-06-07T14:23:09Z', 'legacy', 'provider-a', '{}');`); err != nil {
+		_ = db.Close()
+		t.Fatal(err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	store, err := OpenSettlementReceiptStore(dbPath)
+	if err != nil {
+		t.Fatalf("OpenStore legacy schema: %v", err)
+	}
+	defer store.Close()
+
+	if ok, err := store.columnExists(context.Background(), "audit_log", "settlement_receipt_audit_outbox_id"); err != nil || !ok {
+		t.Fatalf("settlement_receipt_audit_outbox_id exists=%v err=%v", ok, err)
+	}
+	var indexCount int
+	if err := store.DB().QueryRowContext(context.Background(), `
+SELECT COUNT(*)
+FROM sqlite_schema
+WHERE type='index' AND name='idx_audit_log_settlement_receipt_outbox'`).Scan(&indexCount); err != nil {
+		t.Fatal(err)
+	}
+	if indexCount != 1 {
+		t.Fatalf("unique outbox index count=%d want 1", indexCount)
 	}
 }
 
@@ -350,6 +525,15 @@ func openTestStore(t *testing.T) *Store {
 	store, err := OpenStore(t.TempDir() + "/coordinator.db")
 	if err != nil {
 		t.Fatalf("open store: %v", err)
+	}
+	return store
+}
+
+func openSettlementReceiptTestStore(t *testing.T) *Store {
+	t.Helper()
+	store, err := OpenSettlementReceiptStore(t.TempDir() + "/coordinator-audit.db")
+	if err != nil {
+		t.Fatalf("open settlement receipt store: %v", err)
 	}
 	return store
 }

--- a/phase4-coordinator/internal/billing/settlement_receipts.go
+++ b/phase4-coordinator/internal/billing/settlement_receipts.go
@@ -237,7 +237,7 @@ func (s *Store) applySettlementReceiptVerdict(ctx context.Context, id Settlement
 			if err := hydrateSettlementReceiptRouteAuditFieldsConn(ctx, conn, &existing); err != nil {
 				return err
 			}
-			if err := insertSettlementReceiptVerdictAuditConn(ctx, conn, existing, nil, receivedAtUnixMS); err != nil {
+			if err := insertSettlementReceiptVerdictAuditConn(ctx, conn, existing, receivedAtUnixMS); err != nil {
 				return err
 			}
 			outcome = existing
@@ -264,6 +264,10 @@ func (s *Store) applySettlementReceiptVerdict(ctx context.Context, id Settlement
 		} else if err := insertSettlementReceiptStateConn(ctx, conn, persisted); err != nil {
 			return err
 		}
+		verdictID, err := settlementReceiptVerdictIDConn(ctx, conn, id)
+		if err != nil {
+			return err
+		}
 		if reason, err := syncVerifiedReceiptLedgerCreditForAttemptTx(ctx, conn, state.RequestID, state.AttemptN, state.ProviderID); err != nil {
 			return err
 		} else if reason != "" {
@@ -276,11 +280,12 @@ func (s *Store) applySettlementReceiptVerdict(ctx context.Context, id Settlement
 			}
 		}
 		if receiptPresent {
-			if err := insertSettlementReceiptIngestedAuditConn(ctx, conn, state); err != nil {
+			_, err := enqueueSettlementReceiptAuditOutboxConn(ctx, conn, verdictID, settlementReceiptEventIngested, state, receivedAtUnixMS)
+			if err != nil {
 				return err
 			}
 		}
-		if err := insertSettlementReceiptVerdictAuditConn(ctx, conn, state, &result.Checks, receivedAtUnixMS); err != nil {
+		if err := insertSettlementReceiptVerdictAuditConn(ctx, conn, state, receivedAtUnixMS); err != nil {
 			return err
 		}
 		outcome = state
@@ -1041,33 +1046,316 @@ WHERE account_scope_hash = ? AND request_id = ? AND attempt_n = ? AND provider_i
 	return state, true, nil
 }
 
-func insertSettlementReceiptIngestedAuditConn(ctx context.Context, conn *sql.Conn, state SettlementReceiptState) error {
-	payload, err := settlementReceiptAuditPayload(state, nil, false, 0)
+func settlementReceiptVerdictIDConn(ctx context.Context, conn *sql.Conn, id SettlementReceiptIdentity) (int64, error) {
+	var verdictID int64
+	if err := conn.QueryRowContext(ctx, `
+SELECT id
+FROM settlement_receipt_verdicts
+WHERE account_scope_hash = ? AND request_id = ? AND attempt_n = ? AND provider_id = ?`,
+		redactedAccountScopeHash(id.AccountScope), id.RequestID, id.AttemptN, id.ProviderID,
+	).Scan(&verdictID); err != nil {
+		return 0, err
+	}
+	return verdictID, nil
+}
+
+func enqueueSettlementReceiptAuditOutboxConn(ctx context.Context, conn *sql.Conn, verdictID int64, eventType string, state SettlementReceiptState, attemptedReceivedAtUnixMS int64) (int64, error) {
+	if attemptedReceivedAtUnixMS == 0 {
+		attemptedReceivedAtUnixMS = state.ReceivedAtUnixMS
+	}
+	checksJSON, err := json.Marshal(state.Checks)
+	if err != nil {
+		return 0, err
+	}
+	result, err := conn.ExecContext(ctx, `
+INSERT INTO settlement_receipt_audit_outbox (
+    settlement_receipt_verdict_id, event_type, account_scope_hash,
+    request_id, attempt_n, provider_id, attempted_received_at_unix_ms,
+    idempotency_status, receipt_present, receipt_version, receipt_result,
+    settlement_outcome, reason, closed, terminal_state,
+    terminal_state_ts_unix_ms, pending_deadline_unix_ms, received_at_unix_ms,
+    route_snapshot_digest, route_snapshot_policy_version, route_snapshot_mode,
+    paid_entrypoint, provider_session_id, provider_generation_id,
+    spec008_hash_status, provider_reported_model_hash, provider_receipt_key_fingerprint,
+    catalog_id, catalog_body_digest, expected_catalog_model_hash,
+    model_id, model_hash, receipt_profile, buyer_debit_outcome,
+    provider_settlement_outcome, payout_exclusion_outcome, prompt_hash, output_hash,
+    usage_digest, receipt_tuple_canonical_sha256, checks_json, created_at_utc
+) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		verdictID, eventType, redactedAccountScopeHash(state.AccountScope),
+		state.RequestID, state.AttemptN, state.ProviderID, attemptedReceivedAtUnixMS,
+		state.IdempotencyStatus, boolInt(state.ReceiptPresent), nullString(state.ReceiptVersion),
+		state.ReceiptResult, state.SettlementOutcome, state.Reason, boolInt(state.Closed),
+		state.TerminalState, state.TerminalStateTSUnixMS, state.PendingDeadlineUnixMS,
+		state.ReceivedAtUnixMS, state.RouteSnapshotDigest, state.RouteSnapshotPolicyVersion,
+		state.RouteSnapshotMode, state.PaidEntrypoint, nullString(state.ProviderSessionID),
+		nullString(state.ProviderGenerationID), state.Spec008HashStatus,
+		state.ProviderReportedModelHash, state.ProviderReceiptKeyFingerprint,
+		state.CatalogID, state.CatalogBodyDigest, state.ExpectedCatalogModelHash,
+		state.ModelID, state.ModelHash, state.ReceiptProfile, state.BuyerDebitOutcome,
+		state.ProviderSettlementOutcome, state.PayoutExclusionOutcome, state.PromptHash,
+		nullString(state.OutputHash), nullString(state.UsageDigest),
+		nullString(state.ReceiptTupleCanonicalSHA256), string(checksJSON),
+		time.Now().UTC().Format(time.RFC3339Nano),
+	)
+	if err != nil {
+		return 0, err
+	}
+	return result.LastInsertId()
+}
+
+// SettlementReceiptAuditSink is the external audit writer used by the
+// settlement receipt audit outbox. The money DB stores compact outbox rows;
+// the sink owns the fat audit payload destination.
+type SettlementReceiptAuditSink interface {
+	InsertSettlementReceiptOutbox(context.Context, time.Time, string, string, string, int64) (bool, error)
+}
+
+// SettlementReceiptAuditOutboxStats is the low-cardinality health surface for
+// the compact money-DB audit outbox.
+type SettlementReceiptAuditOutboxStats struct {
+	PendingRows             int64
+	OldestPendingCreatedAt  time.Time
+	HasOldestPendingCreated bool
+}
+
+func insertSettlementReceiptVerdictAuditConn(ctx context.Context, conn *sql.Conn, state SettlementReceiptState, attemptedReceivedAtUnixMS int64) error {
+	verdictID, err := settlementReceiptVerdictIDConn(ctx, conn, state.SettlementReceiptIdentity)
 	if err != nil {
 		return err
 	}
-	_, err = conn.ExecContext(ctx, `
-INSERT INTO audit_log (ts_utc, event_type, provider_id, payload_json)
-VALUES (?, ?, ?, ?)`,
-		time.Now().UTC().Format(time.RFC3339Nano), settlementReceiptEventIngested, state.ProviderID, payload)
+	_, err = enqueueSettlementReceiptAuditOutboxConn(ctx, conn, verdictID, settlementReceiptEventVerdict, state, attemptedReceivedAtUnixMS)
 	return err
 }
 
-func insertSettlementReceiptVerdictAuditConn(ctx context.Context, conn *sql.Conn, state SettlementReceiptState, checks *SettlementVerificationChecks, attemptedReceivedAtUnixMS int64) error {
-	payload, err := settlementReceiptAuditPayload(state, checks, true, attemptedReceivedAtUnixMS)
-	if err != nil {
-		return err
+// DrainSettlementReceiptAuditOutbox drains pending settlement receipt audit
+// events after the hot receipt transaction commits. It is safe to call at
+// startup or from a background loop.
+func (s *Store) DrainSettlementReceiptAuditOutbox(ctx context.Context, sink SettlementReceiptAuditSink, limit int) (int, error) {
+	if sink == nil {
+		return 0, fmt.Errorf("settlement receipt audit sink is required")
 	}
-	_, err = conn.ExecContext(ctx, `
-INSERT INTO audit_log (ts_utc, event_type, provider_id, payload_json)
-VALUES (?, ?, ?, ?)`,
-		time.Now().UTC().Format(time.RFC3339Nano), settlementReceiptEventVerdict, state.ProviderID, payload)
-	return err
+	if limit <= 0 {
+		limit = 100
+	}
+	rows, err := s.db.QueryContext(ctx, `
+SELECT id
+FROM settlement_receipt_audit_outbox
+WHERE drained_at_utc IS NULL
+ORDER BY id
+LIMIT ?`, limit)
+	if err != nil {
+		return 0, err
+	}
+	ids := []int64{}
+	for rows.Next() {
+		var id int64
+		if err := rows.Scan(&id); err != nil {
+			_ = rows.Close()
+			return 0, err
+		}
+		ids = append(ids, id)
+	}
+	if err := rows.Err(); err != nil {
+		_ = rows.Close()
+		return 0, err
+	}
+	if err := rows.Close(); err != nil {
+		return 0, err
+	}
+	return s.drainSettlementReceiptAuditOutboxIDs(ctx, sink, ids)
+}
+
+func (s *Store) SettlementReceiptAuditOutboxStats(ctx context.Context) (SettlementReceiptAuditOutboxStats, error) {
+	var stats SettlementReceiptAuditOutboxStats
+	var oldest sql.NullString
+	err := s.db.QueryRowContext(ctx, `
+SELECT COUNT(*), MIN(created_at_utc)
+FROM settlement_receipt_audit_outbox
+WHERE drained_at_utc IS NULL`).Scan(&stats.PendingRows, &oldest)
+	if err != nil {
+		return stats, err
+	}
+	if oldest.Valid && oldest.String != "" {
+		createdAt, err := time.Parse(time.RFC3339Nano, oldest.String)
+		if err != nil {
+			return stats, fmt.Errorf("parse settlement receipt audit outbox oldest pending created_at_utc: %w", err)
+		}
+		stats.OldestPendingCreatedAt = createdAt
+		stats.HasOldestPendingCreated = true
+	}
+	return stats, nil
+}
+
+func (s *Store) drainSettlementReceiptAuditOutboxIDs(ctx context.Context, sink SettlementReceiptAuditSink, ids []int64) (int, error) {
+	drained := 0
+	var firstErr error
+	for _, id := range ids {
+		ok, err := s.drainSettlementReceiptAuditOutboxID(ctx, sink, id)
+		if err != nil {
+			if firstErr == nil {
+				firstErr = err
+			}
+			continue
+		}
+		if ok {
+			drained++
+		}
+	}
+	return drained, firstErr
+}
+
+func (s *Store) PruneSettlementReceiptAuditOutbox(ctx context.Context, cutoff time.Time, limit int) (int64, error) {
+	if limit <= 0 {
+		limit = 500
+	}
+	res, err := s.db.ExecContext(ctx, `
+DELETE FROM settlement_receipt_audit_outbox
+ WHERE id IN (
+       SELECT id
+         FROM settlement_receipt_audit_outbox
+        WHERE drained_at_utc IS NOT NULL
+          AND julianday(drained_at_utc) < julianday(?)
+     ORDER BY id
+        LIMIT ?
+ )`,
+		cutoff.UTC().Format(time.RFC3339Nano), limit)
+	if err != nil {
+		return 0, err
+	}
+	return res.RowsAffected()
+}
+
+func (s *Store) drainSettlementReceiptAuditOutboxID(ctx context.Context, sink SettlementReceiptAuditSink, outboxID int64) (bool, error) {
+	eventType, accountScopeHash, state, attemptedReceivedAtUnixMS, eventTime, found, err := s.loadSettlementReceiptAuditOutbox(ctx, outboxID)
+	if err != nil || !found {
+		return false, err
+	}
+	verdict := eventType == settlementReceiptEventVerdict
+	var checks *SettlementVerificationChecks
+	if verdict {
+		checks = &state.Checks
+	}
+	payload, err := settlementReceiptAuditPayloadForAccountHash(accountScopeHash, state, checks, verdict, attemptedReceivedAtUnixMS, outboxID)
+	if err != nil {
+		return false, err
+	}
+	if _, err := sink.InsertSettlementReceiptOutbox(ctx, eventTime, eventType, state.ProviderID, payload, outboxID); err != nil {
+		return false, err
+	}
+	return s.markSettlementReceiptAuditOutboxDrained(ctx, outboxID)
+}
+
+func (s *Store) loadSettlementReceiptAuditOutbox(ctx context.Context, outboxID int64) (string, string, SettlementReceiptState, int64, time.Time, bool, error) {
+	var eventType, accountScopeHash string
+	var state SettlementReceiptState
+	var attemptedReceivedAtUnixMS int64
+	var eventTime time.Time
+	found := false
+	err := sqliteutil.Transact(ctx, s.db, func(ctx context.Context, conn *sql.Conn) error {
+		var err error
+		eventType, accountScopeHash, state, attemptedReceivedAtUnixMS, eventTime, found, err = loadSettlementReceiptAuditOutboxConn(ctx, conn, outboxID)
+		return err
+	})
+	return eventType, accountScopeHash, state, attemptedReceivedAtUnixMS, eventTime, found, err
+}
+
+func (s *Store) markSettlementReceiptAuditOutboxDrained(ctx context.Context, outboxID int64) (bool, error) {
+	drained := false
+	err := sqliteutil.Transact(ctx, s.db, func(ctx context.Context, conn *sql.Conn) error {
+		res, err := conn.ExecContext(ctx, `
+UPDATE settlement_receipt_audit_outbox
+   SET drained_at_utc = ?
+ WHERE id = ? AND drained_at_utc IS NULL`,
+			time.Now().UTC().Format(time.RFC3339Nano), outboxID)
+		if err != nil {
+			return err
+		}
+		n, err := res.RowsAffected()
+		if err != nil {
+			return err
+		}
+		drained = n > 0
+		return nil
+	})
+	return drained, err
+}
+
+func loadSettlementReceiptAuditOutboxConn(ctx context.Context, conn *sql.Conn, outboxID int64) (string, string, SettlementReceiptState, int64, time.Time, bool, error) {
+	var state SettlementReceiptState
+	var eventType, accountScopeHash, checksJSON, createdAtUTC string
+	var attemptedReceivedAtUnixMS int64
+	var receiptPresent, closed int
+	var receiptVersion, outputHash, usageDigest, tupleDigest, providerSession, providerGeneration sql.NullString
+	err := conn.QueryRowContext(ctx, `
+SELECT event_type, account_scope_hash, attempted_received_at_unix_ms,
+       request_id, attempt_n, provider_id, idempotency_status,
+       receipt_present, receipt_version, receipt_result, settlement_outcome,
+       reason, closed, terminal_state, terminal_state_ts_unix_ms,
+       pending_deadline_unix_ms, received_at_unix_ms, route_snapshot_digest,
+       route_snapshot_policy_version, route_snapshot_mode, paid_entrypoint,
+       provider_session_id, provider_generation_id, spec008_hash_status,
+       provider_reported_model_hash, provider_receipt_key_fingerprint,
+       catalog_id, catalog_body_digest, expected_catalog_model_hash,
+       model_id, model_hash, receipt_profile, buyer_debit_outcome,
+       provider_settlement_outcome, payout_exclusion_outcome, prompt_hash,
+       output_hash, usage_digest, receipt_tuple_canonical_sha256, checks_json,
+       created_at_utc
+  FROM settlement_receipt_audit_outbox o
+ WHERE o.id = ? AND o.drained_at_utc IS NULL`, outboxID).Scan(
+		&eventType, &accountScopeHash, &attemptedReceivedAtUnixMS,
+		&state.RequestID, &state.AttemptN, &state.ProviderID, &state.IdempotencyStatus,
+		&receiptPresent,
+		&receiptVersion, &state.ReceiptResult, &state.SettlementOutcome,
+		&state.Reason, &closed, &state.TerminalState,
+		&state.TerminalStateTSUnixMS, &state.PendingDeadlineUnixMS,
+		&state.ReceivedAtUnixMS, &state.RouteSnapshotDigest,
+		&state.RouteSnapshotPolicyVersion, &state.RouteSnapshotMode,
+		&state.PaidEntrypoint, &providerSession, &providerGeneration,
+		&state.Spec008HashStatus,
+		&state.ProviderReportedModelHash, &state.ProviderReceiptKeyFingerprint,
+		&state.CatalogID, &state.CatalogBodyDigest,
+		&state.ExpectedCatalogModelHash, &state.ModelID, &state.ModelHash,
+		&state.ReceiptProfile, &state.BuyerDebitOutcome,
+		&state.ProviderSettlementOutcome, &state.PayoutExclusionOutcome,
+		&state.PromptHash, &outputHash, &usageDigest,
+		&tupleDigest, &checksJSON, &createdAtUTC,
+	)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return "", "", SettlementReceiptState{}, 0, time.Time{}, false, nil
+		}
+		return "", "", SettlementReceiptState{}, 0, time.Time{}, false, err
+	}
+	eventTime, err := time.Parse(time.RFC3339Nano, createdAtUTC)
+	if err != nil {
+		return "", "", SettlementReceiptState{}, 0, time.Time{}, false, fmt.Errorf("parse settlement receipt audit outbox created_at_utc: %w", err)
+	}
+	state.ReceiptPresent = receiptPresent == 1
+	state.Closed = closed == 1
+	state.ReceiptVersion = receiptVersion.String
+	state.OutputHash = outputHash.String
+	state.UsageDigest = usageDigest.String
+	state.ReceiptTupleCanonicalSHA256 = tupleDigest.String
+	if providerSession.Valid {
+		state.ProviderSessionID = providerSession.String
+	}
+	if providerGeneration.Valid {
+		state.ProviderGenerationID = providerGeneration.String
+	}
+	if err := json.Unmarshal([]byte(checksJSON), &state.Checks); err != nil {
+		return "", "", SettlementReceiptState{}, 0, time.Time{}, false, fmt.Errorf("decode settlement receipt checks: %w", err)
+	}
+	return eventType, accountScopeHash, state, attemptedReceivedAtUnixMS, eventTime, true, nil
 }
 
 func settlementReceiptAuditPayload(state SettlementReceiptState, checks *SettlementVerificationChecks, verdict bool, attemptedReceivedAtUnixMS int64) (string, error) {
+	return settlementReceiptAuditPayloadForAccountHash(redactedAccountScopeHash(state.AccountScope), state, checks, verdict, attemptedReceivedAtUnixMS, 0)
+}
+
+func settlementReceiptAuditPayloadForAccountHash(accountScopeHash string, state SettlementReceiptState, checks *SettlementVerificationChecks, verdict bool, attemptedReceivedAtUnixMS int64, outboxID int64) (string, error) {
 	payload := map[string]any{
-		"account_scope_hash":               redactedAccountScopeHash(state.AccountScope),
+		"account_scope_hash":               accountScopeHash,
 		"request_id":                       state.RequestID,
 		"attempt_id":                       settlementReceiptAttemptID(state),
 		"attempt_n":                        state.AttemptN,
@@ -1091,6 +1379,9 @@ func settlementReceiptAuditPayload(state SettlementReceiptState, checks *Settlem
 		"output_hash":                      state.OutputHash,
 		"usage_digest":                     state.UsageDigest,
 		"received_at_unix_ms":              state.ReceivedAtUnixMS,
+	}
+	if outboxID > 0 {
+		payload["settlement_receipt_audit_outbox_id"] = outboxID
 	}
 	if state.ProviderSessionID != "" {
 		payload["provider_session_id"] = state.ProviderSessionID

--- a/phase4-coordinator/internal/billing/settlement_receipts_test.go
+++ b/phase4-coordinator/internal/billing/settlement_receipts_test.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"strings"
 	"testing"
 	"time"
@@ -57,15 +58,171 @@ func TestIngestSettlementReceiptPersistsVerifiedStateAndRedactedAudit(t *testing
 	if got := scalar(t, store.db, `SELECT COUNT(*) FROM ledger_payout_ready`); got != 0 {
 		t.Fatalf("ledger_payout_ready rows=%d want 0", got)
 	}
+	if got := scalar(t, store.db, `SELECT COUNT(*) FROM settlement_receipt_audit_outbox WHERE drained_at_utc IS NULL`); got != 2 {
+		t.Fatalf("pending audit outbox rows=%d want 2 before background drain", got)
+	}
+	var firstOutboxID int64
+	var firstOutboxCreatedAt string
+	if err := store.db.QueryRow(`
+SELECT id, created_at_utc
+FROM settlement_receipt_audit_outbox
+WHERE event_type='settlement_receipt_verdict'
+ORDER BY id ASC
+LIMIT 1`).Scan(&firstOutboxID, &firstOutboxCreatedAt); err != nil {
+		t.Fatal(err)
+	}
+	drainSettlementReceiptAuditOutboxToBillingAuditLog(t, store, 2)
 	if got := scalar(t, store.db, `SELECT COUNT(*) FROM audit_log WHERE event_type='settlement_receipt_ingested'`); got != 1 {
 		t.Fatalf("ingested audit rows=%d want 1", got)
 	}
 	if got := scalar(t, store.db, `SELECT COUNT(*) FROM audit_log WHERE event_type='settlement_receipt_verdict'`); got != 1 {
 		t.Fatalf("verdict audit rows=%d want 1", got)
 	}
+	var auditTS string
+	if err := store.db.QueryRow(`
+SELECT ts_utc
+FROM audit_log
+WHERE settlement_receipt_audit_outbox_id = ?`, firstOutboxID).Scan(&auditTS); err != nil {
+		t.Fatal(err)
+	}
+	if auditTS != firstOutboxCreatedAt {
+		t.Fatalf("audit ts_utc=%s want outbox created_at_utc %s", auditTS, firstOutboxCreatedAt)
+	}
 	assertSettlementReceiptVerdictAuditContract(t, store.db, state)
 	assertSettlementReceiptAuditRedacted(t, store.db, input.Header, fixtures.ProviderReceiptPubkeyB64)
 	assertSettlementReceiptVerdictSchemaRedacted(t, store.db)
+}
+
+func TestSettlementReceiptAuditOutboxSurvivesPostCommitDrainFailure(t *testing.T) {
+	fixtures := loadSettlementVerifierFixtures(t)
+	pubkey := decodeSettlementVerifierPubkey(t, fixtures.ProviderReceiptPubkeyB64)
+	tuple := firstSettlementTupleWithNegativeVariant(t, fixtures, "normal_done")
+	input := settlementVerifierInputFromFixture(t, fixtures, tuple, pubkey)
+	_, store := newRequestAndBillingStores(t)
+	seedSettlementReceiptEvidence(t, store, input)
+	setSettlementReceiptNow(store, input.ReceiptReceivedUnixMS)
+
+	state, err := store.IngestSettlementReceipt(context.Background(), SettlementReceiptIngestionInput{
+		SettlementReceiptIdentity: SettlementReceiptIdentity{
+			AccountScope: input.AccountScope,
+			RequestID:    input.RequestID,
+			AttemptN:     input.AttemptN,
+			ProviderID:   input.ProviderID,
+		},
+		Header:                input.Header,
+		ProviderReceiptPubkey: pubkey,
+		receiptReceivedUnixMS: input.ReceiptReceivedUnixMS,
+	})
+	if err != nil {
+		t.Fatalf("post-commit audit drain failure must not fail receipt ingestion: %v", err)
+	}
+	if state.SettlementOutcome != SettlementOutcomeVerified || state.ReceiptResult != SettlementReceiptResultValid || !state.Closed {
+		t.Fatalf("state=%#v, want committed terminal verified state", state)
+	}
+	if got := scalar(t, store.db, `SELECT COUNT(*) FROM settlement_receipt_verdicts WHERE settlement_outcome='verified' AND closed=1`); got != 1 {
+		t.Fatalf("verified verdict rows=%d want 1", got)
+	}
+	if got := scalar(t, store.db, `SELECT COUNT(*) FROM settlement_receipt_audit_outbox WHERE drained_at_utc IS NULL`); got != 2 {
+		t.Fatalf("pending outbox rows=%d want 2", got)
+	}
+
+	drainSettlementReceiptAuditOutboxToBillingAuditLog(t, store, 2)
+	if got := scalar(t, store.db, `SELECT COUNT(*) FROM settlement_receipt_audit_outbox WHERE drained_at_utc IS NULL`); got != 0 {
+		t.Fatalf("pending outbox rows after drain=%d want 0", got)
+	}
+	if got := scalar(t, store.db, `SELECT COUNT(*) FROM audit_log WHERE event_type='settlement_receipt_ingested'`); got != 1 {
+		t.Fatalf("ingested audit rows=%d want 1", got)
+	}
+	if got := scalar(t, store.db, `SELECT COUNT(*) FROM audit_log WHERE event_type='settlement_receipt_verdict'`); got != 1 {
+		t.Fatalf("verdict audit rows=%d want 1", got)
+	}
+	if _, err := store.db.Exec(`UPDATE settlement_receipt_audit_outbox SET drained_at_utc = NULL`); err != nil {
+		t.Fatal(err)
+	}
+	drained, err := store.DrainSettlementReceiptAuditOutbox(context.Background(), settlementReceiptTestAuditSink{db: store.db}, 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if drained != 2 {
+		t.Fatalf("retry drain rows=%d want 2 marked after idempotent sink replay", drained)
+	}
+	if got := scalar(t, store.db, `SELECT COUNT(*) FROM audit_log WHERE event_type='settlement_receipt_ingested'`); got != 1 {
+		t.Fatalf("ingested audit rows after replay=%d want 1", got)
+	}
+	if got := scalar(t, store.db, `SELECT COUNT(*) FROM audit_log WHERE event_type='settlement_receipt_verdict'`); got != 1 {
+		t.Fatalf("verdict audit rows after replay=%d want 1", got)
+	}
+	drained, err = store.DrainSettlementReceiptAuditOutbox(context.Background(), settlementReceiptTestAuditSink{db: store.db}, 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if drained != 0 {
+		t.Fatalf("second drain rows=%d want 0", drained)
+	}
+	assertSettlementReceiptVerdictAuditContract(t, store.db, state)
+	assertSettlementReceiptAuditRedacted(t, store.db, input.Header, fixtures.ProviderReceiptPubkeyB64)
+}
+
+func TestSettlementReceiptAuditOutboxContinuesAfterFailureAndPrunesDrainedRows(t *testing.T) {
+	fixtures := loadSettlementVerifierFixtures(t)
+	pubkey := decodeSettlementVerifierPubkey(t, fixtures.ProviderReceiptPubkeyB64)
+	tuple := firstSettlementTupleWithNegativeVariant(t, fixtures, "normal_done")
+	input := settlementVerifierInputFromFixture(t, fixtures, tuple, pubkey)
+	_, store := newRequestAndBillingStores(t)
+	createSettlementReceiptAuditLog(t, store.db)
+	seedSettlementReceiptEvidence(t, store, input)
+	setSettlementReceiptNow(store, input.ReceiptReceivedUnixMS)
+	if _, err := store.IngestSettlementReceipt(context.Background(), SettlementReceiptIngestionInput{
+		SettlementReceiptIdentity: SettlementReceiptIdentity{
+			AccountScope: input.AccountScope,
+			RequestID:    input.RequestID,
+			AttemptN:     input.AttemptN,
+			ProviderID:   input.ProviderID,
+		},
+		Header:                input.Header,
+		ProviderReceiptPubkey: pubkey,
+		receiptReceivedUnixMS: input.ReceiptReceivedUnixMS,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	var failOutboxID, healthyOutboxID int64
+	if err := store.db.QueryRow(`
+SELECT MIN(id), MAX(id)
+FROM settlement_receipt_audit_outbox
+WHERE drained_at_utc IS NULL`).Scan(&failOutboxID, &healthyOutboxID); err != nil {
+		t.Fatal(err)
+	}
+
+	drained, err := store.DrainSettlementReceiptAuditOutbox(context.Background(), failingSettlementReceiptAuditSink{
+		failOutboxID: failOutboxID,
+		next:         settlementReceiptTestAuditSink{db: store.db},
+	}, 10)
+	if err == nil {
+		t.Fatal("drain err=nil want first row failure")
+	}
+	if drained != 1 {
+		t.Fatalf("drained rows=%d want healthy row drained despite first-row failure", drained)
+	}
+	if got := scalar(t, store.db, `SELECT COUNT(*) FROM settlement_receipt_audit_outbox WHERE id = ? AND drained_at_utc IS NULL`, failOutboxID); got != 1 {
+		t.Fatalf("failed row pending count=%d want 1", got)
+	}
+	if got := scalar(t, store.db, `SELECT COUNT(*) FROM settlement_receipt_audit_outbox WHERE id = ? AND drained_at_utc IS NOT NULL`, healthyOutboxID); got != 1 {
+		t.Fatalf("healthy row drained count=%d want 1", got)
+	}
+
+	if _, err := store.db.Exec(`UPDATE settlement_receipt_audit_outbox SET drained_at_utc = ? WHERE id = ?`, time.Now().UTC().AddDate(0, 0, -10).Format(time.RFC3339Nano), healthyOutboxID); err != nil {
+		t.Fatal(err)
+	}
+	pruned, err := store.PruneSettlementReceiptAuditOutbox(context.Background(), time.Now().UTC().AddDate(0, 0, -7), 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if pruned != 1 {
+		t.Fatalf("pruned rows=%d want 1", pruned)
+	}
+	if got := scalar(t, store.db, `SELECT COUNT(*) FROM settlement_receipt_audit_outbox`); got != 1 {
+		t.Fatalf("remaining outbox rows=%d want only failed pending row", got)
+	}
 }
 
 func TestSyncVerifiedReceiptLedgerCreditUpdatesPromptSplitColumns(t *testing.T) {
@@ -214,10 +371,11 @@ func TestSettlementReceiptPendingCanCloseWithValidReceiptBeforeDeadline(t *testi
 		ProviderID:   input.ProviderID,
 	}
 	deadline := input.TerminalStateTSUnixMS + input.RouteSnapshot.PendingDeadlineSeconds*1000
-	if _, err := store.RecordMissingSettlementReceipt(context.Background(), SettlementReceiptMissingInput{
+	pending, err := store.RecordMissingSettlementReceipt(context.Background(), SettlementReceiptMissingInput{
 		SettlementReceiptIdentity: id,
 		NowUnixMS:                 deadline - 100,
-	}); err != nil {
+	})
+	if err != nil {
 		t.Fatal(err)
 	}
 	verified, err := store.IngestSettlementReceipt(context.Background(), SettlementReceiptIngestionInput{
@@ -234,6 +392,46 @@ func TestSettlementReceiptPendingCanCloseWithValidReceiptBeforeDeadline(t *testi
 	}
 	if got := scalar(t, store.db, `SELECT COUNT(*) FROM settlement_receipt_verdicts WHERE settlement_outcome='verified' AND idempotency_status='terminal_after_pending'`); got != 1 {
 		t.Fatalf("terminal_after_pending rows=%d want 1", got)
+	}
+	mutatedPromptHash := strings.Repeat("f", 64)
+	if _, err := store.db.Exec(`
+UPDATE settlement_receipt_verdicts
+   SET route_snapshot_policy_version = 'mutated-policy',
+       paid_entrypoint = 'mutated-entrypoint',
+       model_id = 'mutated-model',
+       prompt_hash = ?
+ WHERE account_scope_hash = ? AND request_id = ? AND attempt_n = ? AND provider_id = ?`,
+		mutatedPromptHash, redactedAccountScopeHash(id.AccountScope), id.RequestID, id.AttemptN, id.ProviderID); err != nil {
+		t.Fatal(err)
+	}
+	drainSettlementReceiptAuditOutboxToBillingAuditLog(t, store, 3)
+	payloads := settlementReceiptVerdictPayloads(t, store.db)
+	if len(payloads) != 2 {
+		t.Fatalf("settlement_receipt_verdict audit payloads=%d want 2", len(payloads))
+	}
+	if got := payloads[0]["settlement_outcome"]; got != SettlementOutcomePending {
+		t.Fatalf("first verdict settlement_outcome=%v want pending", got)
+	}
+	if got := payloads[0]["idempotency_status"]; got != settlementReceiptIDPending {
+		t.Fatalf("first verdict idempotency_status=%v want pending", got)
+	}
+	if got := payloads[0]["route_snapshot_policy_version"]; got != pending.RouteSnapshotPolicyVersion {
+		t.Fatalf("first verdict route_snapshot_policy_version=%v want %s", got, pending.RouteSnapshotPolicyVersion)
+	}
+	if got := payloads[0]["paid_entrypoint"]; got != pending.PaidEntrypoint {
+		t.Fatalf("first verdict paid_entrypoint=%v want %s", got, pending.PaidEntrypoint)
+	}
+	if got := payloads[0]["model_id"]; got != pending.ModelID {
+		t.Fatalf("first verdict model_id=%v want %s", got, pending.ModelID)
+	}
+	if got := payloads[0]["prompt_hash"]; got != pending.PromptHash {
+		t.Fatalf("first verdict prompt_hash=%v want %s", got, pending.PromptHash)
+	}
+	if got := payloads[1]["settlement_outcome"]; got != SettlementOutcomeVerified {
+		t.Fatalf("second verdict settlement_outcome=%v want verified", got)
+	}
+	if got := payloads[1]["idempotency_status"]; got != settlementReceiptIDTerminalAfterPending {
+		t.Fatalf("second verdict idempotency_status=%v want terminal_after_pending", got)
 	}
 }
 
@@ -561,6 +759,7 @@ func TestSettlementReceiptResubmissionCannotChangeClosedOutcome(t *testing.T) {
 	if second.SettlementOutcome != SettlementOutcomeVerified || second.Reason != "verified_settlement" || second.IdempotencyStatus != settlementReceiptIDTerminalNoop {
 		t.Fatalf("second state=%#v, want original verified terminal no-op", second)
 	}
+	drainSettlementReceiptAuditOutboxToBillingAuditLog(t, store, 3)
 	payload := latestSettlementReceiptVerdictPayload(t, store.db)
 	if payload["idempotency_status"] != settlementReceiptIDTerminalNoop ||
 		payload["settlement_outcome"] != SettlementOutcomeVerified ||
@@ -651,6 +850,7 @@ WHERE account_scope_hash = ? AND request_id = ? AND attempt_n = ? AND provider_i
 		t.Fatalf("persisted hashes model=%s output=%s usage=%s, want coordinator evidence %s/%s/%s",
 			modelHash, outputHash, usageDigest, input.RouteSnapshot.ProviderReportedModelHash, input.OutputHash, wantUsageHash)
 	}
+	drainSettlementReceiptAuditOutboxToBillingAuditLog(t, store, 2)
 	payload := latestSettlementReceiptVerdictPayload(t, store.db)
 	for key, want := range map[string]string{
 		"model_hash":                   input.RouteSnapshot.ProviderReportedModelHash,
@@ -749,11 +949,58 @@ CREATE TABLE IF NOT EXISTS audit_log (
     ts_utc TEXT NOT NULL,
     event_type TEXT NOT NULL,
     provider_id TEXT,
+    settlement_receipt_audit_outbox_id INTEGER NULL,
     payload_json TEXT NOT NULL
 );
 CREATE INDEX IF NOT EXISTS idx_audit_log_event_type ON audit_log(event_type);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_audit_log_settlement_receipt_outbox
+    ON audit_log(settlement_receipt_audit_outbox_id)
+    WHERE settlement_receipt_audit_outbox_id IS NOT NULL;
 `); err != nil {
 		t.Fatal(err)
+	}
+}
+
+type settlementReceiptTestAuditSink struct {
+	db *sql.DB
+}
+
+func (s settlementReceiptTestAuditSink) InsertSettlementReceiptOutbox(ctx context.Context, ts time.Time, eventType, providerID, payloadJSON string, outboxID int64) (bool, error) {
+	res, err := s.db.ExecContext(ctx, `
+INSERT OR IGNORE INTO audit_log (ts_utc, event_type, provider_id, settlement_receipt_audit_outbox_id, payload_json)
+VALUES (?, ?, ?, ?, ?)`,
+		ts.UTC().Format(time.RFC3339Nano), eventType, providerID, outboxID, payloadJSON)
+	if err != nil {
+		return false, err
+	}
+	n, err := res.RowsAffected()
+	if err != nil {
+		return false, err
+	}
+	return n > 0, nil
+}
+
+type failingSettlementReceiptAuditSink struct {
+	failOutboxID int64
+	next         settlementReceiptTestAuditSink
+}
+
+func (s failingSettlementReceiptAuditSink) InsertSettlementReceiptOutbox(ctx context.Context, ts time.Time, eventType, providerID, payloadJSON string, outboxID int64) (bool, error) {
+	if outboxID == s.failOutboxID {
+		return false, errors.New("forced outbox sink failure")
+	}
+	return s.next.InsertSettlementReceiptOutbox(ctx, ts, eventType, providerID, payloadJSON, outboxID)
+}
+
+func drainSettlementReceiptAuditOutboxToBillingAuditLog(t *testing.T, store *Store, want int) {
+	t.Helper()
+	createSettlementReceiptAuditLog(t, store.db)
+	drained, err := store.DrainSettlementReceiptAuditOutbox(context.Background(), settlementReceiptTestAuditSink{db: store.db}, 100)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if drained != want {
+		t.Fatalf("drained rows=%d want %d", drained, want)
 	}
 }
 
@@ -911,6 +1158,35 @@ LIMIT 1`).Scan(&raw); err != nil {
 		t.Fatal(err)
 	}
 	return payload
+}
+
+func settlementReceiptVerdictPayloads(t *testing.T, db *sql.DB) []map[string]any {
+	t.Helper()
+	rows, err := db.Query(`
+SELECT payload_json
+FROM audit_log
+WHERE event_type='settlement_receipt_verdict'
+ORDER BY id ASC`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer rows.Close()
+	var payloads []map[string]any
+	for rows.Next() {
+		var raw string
+		if err := rows.Scan(&raw); err != nil {
+			t.Fatal(err)
+		}
+		var payload map[string]any
+		if err := json.Unmarshal([]byte(raw), &payload); err != nil {
+			t.Fatal(err)
+		}
+		payloads = append(payloads, payload)
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatal(err)
+	}
+	return payloads
 }
 
 func assertSettlementReceiptVerdictAuditContract(t *testing.T, db *sql.DB, state SettlementReceiptState) {

--- a/phase4-coordinator/internal/billing/store.go
+++ b/phase4-coordinator/internal/billing/store.go
@@ -367,6 +367,56 @@ CREATE INDEX IF NOT EXISTS idx_srv_provider_recent ON settlement_receipt_verdict
 CREATE INDEX IF NOT EXISTS idx_srv_provider_failed_recent ON settlement_receipt_verdicts(provider_id, received_at_unix_ms DESC, id DESC)
     WHERE closed=1 AND settlement_outcome='quarantined';
 
+CREATE TABLE IF NOT EXISTS settlement_receipt_audit_outbox (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    settlement_receipt_verdict_id INTEGER NOT NULL REFERENCES settlement_receipt_verdicts(id),
+    event_type TEXT NOT NULL CHECK(event_type IN ('settlement_receipt_ingested','settlement_receipt_verdict')),
+    account_scope_hash TEXT NOT NULL CHECK(length(account_scope_hash) = 64 AND account_scope_hash NOT GLOB '*[^0-9a-f]*'),
+    request_id TEXT NOT NULL,
+    attempt_n INTEGER NOT NULL CHECK(attempt_n >= 0),
+    provider_id TEXT NOT NULL,
+    attempted_received_at_unix_ms INTEGER NOT NULL CHECK(attempted_received_at_unix_ms > 0),
+    idempotency_status TEXT NOT NULL CHECK(idempotency_status IN ('pending','pending_updated','first_terminal','terminal_after_pending','terminal_noop')),
+    receipt_present INTEGER NOT NULL DEFAULT 0 CHECK(receipt_present IN (0,1)),
+    receipt_version TEXT NULL,
+    receipt_result TEXT NOT NULL DEFAULT 'inconclusive' CHECK(receipt_result IN ('valid','invalid','inconclusive')),
+    settlement_outcome TEXT NOT NULL DEFAULT 'pending' CHECK(settlement_outcome IN ('pending','verified','quarantined','zero_settled')),
+    reason TEXT NOT NULL DEFAULT '',
+    closed INTEGER NOT NULL DEFAULT 0 CHECK(closed IN (0,1)),
+    terminal_state TEXT NOT NULL DEFAULT '',
+    terminal_state_ts_unix_ms INTEGER NOT NULL DEFAULT 0,
+    pending_deadline_unix_ms INTEGER NOT NULL DEFAULT 0,
+    received_at_unix_ms INTEGER NOT NULL DEFAULT 1 CHECK(received_at_unix_ms > 0),
+    route_snapshot_digest TEXT NOT NULL DEFAULT '',
+    route_snapshot_policy_version TEXT NOT NULL DEFAULT '',
+    route_snapshot_mode TEXT NOT NULL DEFAULT '',
+    paid_entrypoint TEXT NOT NULL DEFAULT '',
+    provider_session_id TEXT NULL,
+    provider_generation_id TEXT NULL,
+    spec008_hash_status TEXT NOT NULL DEFAULT '',
+    provider_reported_model_hash TEXT NOT NULL DEFAULT '',
+    provider_receipt_key_fingerprint TEXT NOT NULL DEFAULT '',
+    catalog_id TEXT NOT NULL DEFAULT '',
+    catalog_body_digest TEXT NOT NULL DEFAULT '',
+    expected_catalog_model_hash TEXT NOT NULL DEFAULT '',
+    model_id TEXT NOT NULL DEFAULT '',
+    model_hash TEXT NOT NULL DEFAULT '',
+    receipt_profile TEXT NOT NULL DEFAULT '',
+    buyer_debit_outcome TEXT NOT NULL DEFAULT '',
+    provider_settlement_outcome TEXT NOT NULL DEFAULT '',
+    payout_exclusion_outcome TEXT NOT NULL DEFAULT '',
+    prompt_hash TEXT NOT NULL DEFAULT '',
+    output_hash TEXT NULL CHECK(output_hash IS NULL OR (length(output_hash) = 64 AND output_hash NOT GLOB '*[^0-9a-f]*')),
+    usage_digest TEXT NULL CHECK(usage_digest IS NULL OR (length(usage_digest) = 64 AND usage_digest NOT GLOB '*[^0-9a-f]*')),
+    receipt_tuple_canonical_sha256 TEXT NULL CHECK(receipt_tuple_canonical_sha256 IS NULL OR (length(receipt_tuple_canonical_sha256) = 64 AND receipt_tuple_canonical_sha256 NOT GLOB '*[^0-9a-f]*')),
+    checks_json TEXT NOT NULL DEFAULT '{}',
+    created_at_utc TEXT NOT NULL,
+    drained_at_utc TEXT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_srao_pending ON settlement_receipt_audit_outbox(drained_at_utc, id)
+    WHERE drained_at_utc IS NULL;
+CREATE INDEX IF NOT EXISTS idx_srao_verdict ON settlement_receipt_audit_outbox(settlement_receipt_verdict_id, id);
+
 -- SPEC-005 v0.5 (issue #253) — MIG-005-011
 -- ledger_quarantine_resolutions records operator-issued quarantine
 -- decisions. v0.5 widens the enum to force-credit and keeps history:
@@ -405,6 +455,9 @@ CREATE INDEX IF NOT EXISTS idx_lqr_request_latest ON ledger_quarantine_resolutio
 	if err := s.ensureSettlementRouteSnapshotComputeIntegrityColumns(ctx); err != nil {
 		return err
 	}
+	if err := s.ensureSettlementReceiptAuditOutboxSnapshotColumns(ctx); err != nil {
+		return err
+	}
 	if err := s.normalizeBillingTimeTextColumns(ctx); err != nil {
 		return err
 	}
@@ -432,6 +485,60 @@ func (s *Store) ensureSettlementRouteSnapshotComputeIntegrityColumns(ctx context
 	}
 	for _, col := range add {
 		exists, err := s.columnExists(ctx, "settlement_route_snapshots", col.name)
+		if err != nil {
+			return err
+		}
+		if exists {
+			continue
+		}
+		if _, err := s.db.ExecContext(ctx, col.sql); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (s *Store) ensureSettlementReceiptAuditOutboxSnapshotColumns(ctx context.Context) error {
+	add := []struct {
+		name string
+		sql  string
+	}{
+		{"receipt_present", `ALTER TABLE settlement_receipt_audit_outbox ADD COLUMN receipt_present INTEGER NOT NULL DEFAULT 0 CHECK(receipt_present IN (0,1))`},
+		{"receipt_version", `ALTER TABLE settlement_receipt_audit_outbox ADD COLUMN receipt_version TEXT NULL`},
+		{"receipt_result", `ALTER TABLE settlement_receipt_audit_outbox ADD COLUMN receipt_result TEXT NOT NULL DEFAULT 'inconclusive' CHECK(receipt_result IN ('valid','invalid','inconclusive'))`},
+		{"settlement_outcome", `ALTER TABLE settlement_receipt_audit_outbox ADD COLUMN settlement_outcome TEXT NOT NULL DEFAULT 'pending' CHECK(settlement_outcome IN ('pending','verified','quarantined','zero_settled'))`},
+		{"reason", `ALTER TABLE settlement_receipt_audit_outbox ADD COLUMN reason TEXT NOT NULL DEFAULT ''`},
+		{"closed", `ALTER TABLE settlement_receipt_audit_outbox ADD COLUMN closed INTEGER NOT NULL DEFAULT 0 CHECK(closed IN (0,1))`},
+		{"terminal_state", `ALTER TABLE settlement_receipt_audit_outbox ADD COLUMN terminal_state TEXT NOT NULL DEFAULT ''`},
+		{"terminal_state_ts_unix_ms", `ALTER TABLE settlement_receipt_audit_outbox ADD COLUMN terminal_state_ts_unix_ms INTEGER NOT NULL DEFAULT 0`},
+		{"pending_deadline_unix_ms", `ALTER TABLE settlement_receipt_audit_outbox ADD COLUMN pending_deadline_unix_ms INTEGER NOT NULL DEFAULT 0`},
+		{"received_at_unix_ms", `ALTER TABLE settlement_receipt_audit_outbox ADD COLUMN received_at_unix_ms INTEGER NOT NULL DEFAULT 1 CHECK(received_at_unix_ms > 0)`},
+		{"route_snapshot_digest", `ALTER TABLE settlement_receipt_audit_outbox ADD COLUMN route_snapshot_digest TEXT NOT NULL DEFAULT ''`},
+		{"route_snapshot_policy_version", `ALTER TABLE settlement_receipt_audit_outbox ADD COLUMN route_snapshot_policy_version TEXT NOT NULL DEFAULT ''`},
+		{"route_snapshot_mode", `ALTER TABLE settlement_receipt_audit_outbox ADD COLUMN route_snapshot_mode TEXT NOT NULL DEFAULT ''`},
+		{"paid_entrypoint", `ALTER TABLE settlement_receipt_audit_outbox ADD COLUMN paid_entrypoint TEXT NOT NULL DEFAULT ''`},
+		{"provider_session_id", `ALTER TABLE settlement_receipt_audit_outbox ADD COLUMN provider_session_id TEXT NULL`},
+		{"provider_generation_id", `ALTER TABLE settlement_receipt_audit_outbox ADD COLUMN provider_generation_id TEXT NULL`},
+		{"spec008_hash_status", `ALTER TABLE settlement_receipt_audit_outbox ADD COLUMN spec008_hash_status TEXT NOT NULL DEFAULT ''`},
+		{"provider_reported_model_hash", `ALTER TABLE settlement_receipt_audit_outbox ADD COLUMN provider_reported_model_hash TEXT NOT NULL DEFAULT ''`},
+		{"provider_receipt_key_fingerprint", `ALTER TABLE settlement_receipt_audit_outbox ADD COLUMN provider_receipt_key_fingerprint TEXT NOT NULL DEFAULT ''`},
+		{"catalog_id", `ALTER TABLE settlement_receipt_audit_outbox ADD COLUMN catalog_id TEXT NOT NULL DEFAULT ''`},
+		{"catalog_body_digest", `ALTER TABLE settlement_receipt_audit_outbox ADD COLUMN catalog_body_digest TEXT NOT NULL DEFAULT ''`},
+		{"expected_catalog_model_hash", `ALTER TABLE settlement_receipt_audit_outbox ADD COLUMN expected_catalog_model_hash TEXT NOT NULL DEFAULT ''`},
+		{"model_id", `ALTER TABLE settlement_receipt_audit_outbox ADD COLUMN model_id TEXT NOT NULL DEFAULT ''`},
+		{"model_hash", `ALTER TABLE settlement_receipt_audit_outbox ADD COLUMN model_hash TEXT NOT NULL DEFAULT ''`},
+		{"receipt_profile", `ALTER TABLE settlement_receipt_audit_outbox ADD COLUMN receipt_profile TEXT NOT NULL DEFAULT ''`},
+		{"buyer_debit_outcome", `ALTER TABLE settlement_receipt_audit_outbox ADD COLUMN buyer_debit_outcome TEXT NOT NULL DEFAULT ''`},
+		{"provider_settlement_outcome", `ALTER TABLE settlement_receipt_audit_outbox ADD COLUMN provider_settlement_outcome TEXT NOT NULL DEFAULT ''`},
+		{"payout_exclusion_outcome", `ALTER TABLE settlement_receipt_audit_outbox ADD COLUMN payout_exclusion_outcome TEXT NOT NULL DEFAULT ''`},
+		{"prompt_hash", `ALTER TABLE settlement_receipt_audit_outbox ADD COLUMN prompt_hash TEXT NOT NULL DEFAULT ''`},
+		{"output_hash", `ALTER TABLE settlement_receipt_audit_outbox ADD COLUMN output_hash TEXT NULL CHECK(output_hash IS NULL OR (length(output_hash) = 64 AND output_hash NOT GLOB '*[^0-9a-f]*'))`},
+		{"usage_digest", `ALTER TABLE settlement_receipt_audit_outbox ADD COLUMN usage_digest TEXT NULL CHECK(usage_digest IS NULL OR (length(usage_digest) = 64 AND usage_digest NOT GLOB '*[^0-9a-f]*'))`},
+		{"receipt_tuple_canonical_sha256", `ALTER TABLE settlement_receipt_audit_outbox ADD COLUMN receipt_tuple_canonical_sha256 TEXT NULL CHECK(receipt_tuple_canonical_sha256 IS NULL OR (length(receipt_tuple_canonical_sha256) = 64 AND receipt_tuple_canonical_sha256 NOT GLOB '*[^0-9a-f]*'))`},
+		{"checks_json", `ALTER TABLE settlement_receipt_audit_outbox ADD COLUMN checks_json TEXT NOT NULL DEFAULT '{}'`},
+	}
+	for _, col := range add {
+		exists, err := s.columnExists(ctx, "settlement_receipt_audit_outbox", col.name)
 		if err != nil {
 			return err
 		}

--- a/phase4-coordinator/internal/stats/metrics/metrics.go
+++ b/phase4-coordinator/internal/stats/metrics/metrics.go
@@ -8,6 +8,10 @@
 //	stats_rollup_errors_total{component}                       — Counter
 //	stats_rate_limit_exceeded_total{tier,endpoint}             — Counter
 //	stats_idle_prewarm_event_total{event,reason}                — Counter
+//	settlement_receipt_audit_outbox_pending_rows                — Gauge
+//	settlement_receipt_audit_outbox_oldest_pending_age_seconds  — Gauge
+//	settlement_receipt_audit_outbox_drain_total{outcome}        — Counter
+//	settlement_receipt_audit_outbox_rows_total{operation}       — Counter
 //
 // Label hygiene (SECURITY M5 — Step 4.C SECURITY lane category A):
 //
@@ -45,6 +49,12 @@
 //     idle-prewarm protocol allowlist. Non-skip events use
 //     reason="none" so the label set stays closed and low-cardinality.
 //
+//   - `settlement_receipt_audit_outbox_drain_total{outcome}` uses closed
+//     outcome values "success" / "error".
+//
+//   - `settlement_receipt_audit_outbox_rows_total{operation}` uses closed
+//     operation values "drained" / "pruned".
+//
 // No label takes an operator- or attacker-controllable string directly.
 // A `Reset` method exists for test isolation.
 package metrics
@@ -61,25 +71,29 @@ import (
 // case; production code passes prometheus.DefaultRegisterer (or
 // a coordinator-owned named registry).
 type Metrics struct {
-	RequestTotal                 *prometheus.CounterVec
-	PartnerKeyRequestTotal       *prometheus.CounterVec
-	RollupLagSeconds             *prometheus.GaugeVec
-	RollupErrorsTotal            *prometheus.CounterVec
-	RollupPanicTotal             *prometheus.CounterVec
-	RateLimitExceededTotal       *prometheus.CounterVec
-	RegisterRateLimitHits        *prometheus.CounterVec
-	RegisterSource               *prometheus.CounterVec
-	RegisterHardwareErrors       prometheus.Counter
-	IdlePrewarmEventTotal        *prometheus.CounterVec
-	ModelHashMismatchTotal       prometheus.Counter
-	CredentialBootstrapTotal     *prometheus.CounterVec
-	ReferralEventTotal           *prometheus.CounterVec
-	ProviderConnectionEventTotal *prometheus.CounterVec
-	MoneySQLiteConnectionWait    *prometheus.HistogramVec
-	MoneySQLiteTransaction       *prometheus.HistogramVec
-	MoneySQLiteWrite             *prometheus.HistogramVec
-	MoneySQLiteWALCheckpoint     *prometheus.GaugeVec
-	MoneySQLiteWALCheckpointTime *prometheus.HistogramVec
+	RequestTotal                                        *prometheus.CounterVec
+	PartnerKeyRequestTotal                              *prometheus.CounterVec
+	RollupLagSeconds                                    *prometheus.GaugeVec
+	RollupErrorsTotal                                   *prometheus.CounterVec
+	RollupPanicTotal                                    *prometheus.CounterVec
+	RateLimitExceededTotal                              *prometheus.CounterVec
+	RegisterRateLimitHits                               *prometheus.CounterVec
+	RegisterSource                                      *prometheus.CounterVec
+	RegisterHardwareErrors                              prometheus.Counter
+	IdlePrewarmEventTotal                               *prometheus.CounterVec
+	ModelHashMismatchTotal                              prometheus.Counter
+	CredentialBootstrapTotal                            *prometheus.CounterVec
+	ReferralEventTotal                                  *prometheus.CounterVec
+	ProviderConnectionEventTotal                        *prometheus.CounterVec
+	MoneySQLiteConnectionWait                           *prometheus.HistogramVec
+	MoneySQLiteTransaction                              *prometheus.HistogramVec
+	MoneySQLiteWrite                                    *prometheus.HistogramVec
+	MoneySQLiteWALCheckpoint                            *prometheus.GaugeVec
+	MoneySQLiteWALCheckpointTime                        *prometheus.HistogramVec
+	SettlementReceiptAuditOutboxPendingRows             prometheus.Gauge
+	SettlementReceiptAuditOutboxOldestPendingAgeSeconds prometheus.Gauge
+	SettlementReceiptAuditOutboxDrainTotal              *prometheus.CounterVec
+	SettlementReceiptAuditOutboxRowsTotal               *prometheus.CounterVec
 	// CapacityOverClaimTotal is the issue-#764 over-claim tripwire. It is
 	// PERMANENT by construction: a prometheus counter never decreases and is
 	// never reset for the process lifetime, and the coordinator increments it
@@ -237,6 +251,32 @@ func New(reg prometheus.Registerer) *Metrics {
 				Buckets: prometheus.ExponentialBuckets(0.001, 2, 16),
 			},
 			[]string{"component", "outcome"},
+		),
+		SettlementReceiptAuditOutboxPendingRows: f.NewGauge(
+			prometheus.GaugeOpts{
+				Name: "settlement_receipt_audit_outbox_pending_rows",
+				Help: "Latest count of undrained settlement receipt audit outbox rows.",
+			},
+		),
+		SettlementReceiptAuditOutboxOldestPendingAgeSeconds: f.NewGauge(
+			prometheus.GaugeOpts{
+				Name: "settlement_receipt_audit_outbox_oldest_pending_age_seconds",
+				Help: "Age in seconds of the oldest undrained settlement receipt audit outbox row, or zero when none are pending.",
+			},
+		),
+		SettlementReceiptAuditOutboxDrainTotal: f.NewCounterVec(
+			prometheus.CounterOpts{
+				Name: "settlement_receipt_audit_outbox_drain_total",
+				Help: "Count of settlement receipt audit outbox drain attempts by closed-set outcome.",
+			},
+			[]string{"outcome"},
+		),
+		SettlementReceiptAuditOutboxRowsTotal: f.NewCounterVec(
+			prometheus.CounterOpts{
+				Name: "settlement_receipt_audit_outbox_rows_total",
+				Help: "Count of settlement receipt audit outbox rows processed by closed-set operation.",
+			},
+			[]string{"operation"},
 		),
 	}
 }
@@ -401,6 +441,45 @@ func (m *Metrics) ObserveSQLiteWALCheckpointDuration(component, outcome string, 
 	m.MoneySQLiteWALCheckpointTime.WithLabelValues(component, outcome).Observe(duration.Seconds())
 }
 
+func (m *Metrics) SetSettlementReceiptAuditOutboxPendingRows(rows int64) {
+	if m == nil || m.SettlementReceiptAuditOutboxPendingRows == nil {
+		return
+	}
+	if rows < 0 {
+		rows = 0
+	}
+	m.SettlementReceiptAuditOutboxPendingRows.Set(float64(rows))
+}
+
+func (m *Metrics) SetSettlementReceiptAuditOutboxOldestPendingAge(age time.Duration) {
+	if m == nil || m.SettlementReceiptAuditOutboxOldestPendingAgeSeconds == nil {
+		return
+	}
+	if age < 0 {
+		age = 0
+	}
+	m.SettlementReceiptAuditOutboxOldestPendingAgeSeconds.Set(age.Seconds())
+}
+
+func (m *Metrics) ObserveSettlementReceiptAuditOutbox(pendingRows int64, oldestPendingAge time.Duration) {
+	m.SetSettlementReceiptAuditOutboxPendingRows(pendingRows)
+	m.SetSettlementReceiptAuditOutboxOldestPendingAge(oldestPendingAge)
+}
+
+func (m *Metrics) IncSettlementReceiptAuditOutboxDrain(outcome string) {
+	if m == nil || m.SettlementReceiptAuditOutboxDrainTotal == nil || !allowSettlementReceiptAuditOutboxDrainOutcome(outcome) {
+		return
+	}
+	m.SettlementReceiptAuditOutboxDrainTotal.WithLabelValues(outcome).Inc()
+}
+
+func (m *Metrics) AddSettlementReceiptAuditOutboxRows(operation string, rows int64) {
+	if m == nil || m.SettlementReceiptAuditOutboxRowsTotal == nil || !allowSettlementReceiptAuditOutboxRowsOperation(operation) || rows <= 0 {
+		return
+	}
+	m.SettlementReceiptAuditOutboxRowsTotal.WithLabelValues(operation).Add(float64(rows))
+}
+
 func allowMoneySQLiteComponent(component string) bool {
 	switch component {
 	case "billing_hot_path", "request_log_identity", "billing_reload_config", "route_snapshot", "wal_checkpoint":
@@ -431,6 +510,24 @@ func allowMoneySQLiteOutcome(outcome string) bool {
 func allowMoneySQLitePageClass(pageClass string) bool {
 	switch pageClass {
 	case "busy", "log", "checkpointed":
+		return true
+	default:
+		return false
+	}
+}
+
+func allowSettlementReceiptAuditOutboxDrainOutcome(outcome string) bool {
+	switch outcome {
+	case "success", "error":
+		return true
+	default:
+		return false
+	}
+}
+
+func allowSettlementReceiptAuditOutboxRowsOperation(operation string) bool {
+	switch operation {
+	case "drained", "pruned":
 		return true
 	default:
 		return false

--- a/phase4-coordinator/internal/stats/metrics/metrics_test.go
+++ b/phase4-coordinator/internal/stats/metrics/metrics_test.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
 )
 
 var (
@@ -61,6 +62,10 @@ var (
 	}
 	allowMoneySQLitePageClassLabel = map[string]bool{
 		"busy": true, "log": true, "checkpointed": true,
+	}
+	allowSettlementReceiptAuditOutboxOutcome   = map[string]bool{"success": true, "error": true}
+	allowSettlementReceiptAuditOutboxOperation = map[string]bool{
+		"drained": true, "pruned": true,
 	}
 	allowReferralOutcome = map[string]bool{
 		"disabled": true, "busy": true, "rate_limited": true,
@@ -124,6 +129,16 @@ func TestLabelHygiene(t *testing.T) {
 	m.ObserveSQLiteWALCheckpointDuration("wal_checkpoint", "success", time.Millisecond)
 	m.ObserveSQLiteWALCheckpointDuration("raw-attacker-value", "success", time.Millisecond)
 	m.ObserveSQLiteWALCheckpointDuration("wal_checkpoint", "raw-attacker-value", time.Millisecond)
+	m.SetSettlementReceiptAuditOutboxPendingRows(12)
+	m.SetSettlementReceiptAuditOutboxOldestPendingAge(3 * time.Second)
+	for outcome := range allowSettlementReceiptAuditOutboxOutcome {
+		m.IncSettlementReceiptAuditOutboxDrain(outcome)
+	}
+	m.IncSettlementReceiptAuditOutboxDrain("raw-attacker-value")
+	for operation := range allowSettlementReceiptAuditOutboxOperation {
+		m.AddSettlementReceiptAuditOutboxRows(operation, 2)
+	}
+	m.AddSettlementReceiptAuditOutboxRows("raw-attacker-value", 2)
 
 	families, err := reg.Gather()
 	if err != nil {
@@ -200,12 +215,20 @@ func TestLabelHygiene(t *testing.T) {
 						if !allowMoneySQLiteOutcomeLabel[val] {
 							t.Errorf("metric %s outcome=%q not in money SQLite allowed set", mf.GetName(), val)
 						}
+					} else if mf.GetName() == "settlement_receipt_audit_outbox_drain_total" {
+						if !allowSettlementReceiptAuditOutboxOutcome[val] {
+							t.Errorf("metric %s outcome=%q not in settlement receipt audit outbox allowed set", mf.GetName(), val)
+						}
 					} else if !allowCredentialBootstrapOutcome[val] {
 						t.Errorf("metric %s outcome=%q not in allowed set", mf.GetName(), val)
 					}
 				case "operation":
-					if !allowMoneySQLiteOperationLabel[val] {
-						t.Errorf("metric %s operation=%q not in allowed set", mf.GetName(), val)
+					if mf.GetName() == "settlement_receipt_audit_outbox_rows_total" {
+						if !allowSettlementReceiptAuditOutboxOperation[val] {
+							t.Errorf("metric %s operation=%q not in settlement receipt audit outbox allowed set", mf.GetName(), val)
+						}
+					} else if !allowMoneySQLiteOperationLabel[val] {
+						t.Errorf("metric %s operation=%q not in money SQLite allowed set", mf.GetName(), val)
 					}
 				case "page_class":
 					if !allowMoneySQLitePageClassLabel[val] {
@@ -214,6 +237,41 @@ func TestLabelHygiene(t *testing.T) {
 				}
 			}
 		}
+	}
+}
+
+func TestSettlementReceiptAuditOutboxHelpers(t *testing.T) {
+	reg := prometheus.NewRegistry()
+	m := New(reg)
+
+	m.SetSettlementReceiptAuditOutboxPendingRows(-1)
+	m.SetSettlementReceiptAuditOutboxOldestPendingAge(-time.Second)
+	m.IncSettlementReceiptAuditOutboxDrain("success")
+	m.IncSettlementReceiptAuditOutboxDrain("error")
+	m.IncSettlementReceiptAuditOutboxDrain("raw-attacker-value")
+	m.AddSettlementReceiptAuditOutboxRows("drained", 3)
+	m.AddSettlementReceiptAuditOutboxRows("pruned", 4)
+	m.AddSettlementReceiptAuditOutboxRows("drained", 0)
+	m.AddSettlementReceiptAuditOutboxRows("pruned", -1)
+	m.AddSettlementReceiptAuditOutboxRows("raw-attacker-value", 5)
+
+	families, err := reg.Gather()
+	if err != nil {
+		t.Fatalf("gather: %v", err)
+	}
+
+	assertMetricValue(t, families, "settlement_receipt_audit_outbox_pending_rows", nil, 0)
+	assertMetricValue(t, families, "settlement_receipt_audit_outbox_oldest_pending_age_seconds", nil, 0)
+	assertMetricValue(t, families, "settlement_receipt_audit_outbox_drain_total", map[string]string{"outcome": "success"}, 1)
+	assertMetricValue(t, families, "settlement_receipt_audit_outbox_drain_total", map[string]string{"outcome": "error"}, 1)
+	assertMetricValue(t, families, "settlement_receipt_audit_outbox_rows_total", map[string]string{"operation": "drained"}, 3)
+	assertMetricValue(t, families, "settlement_receipt_audit_outbox_rows_total", map[string]string{"operation": "pruned"}, 4)
+
+	if metricExists(families, "settlement_receipt_audit_outbox_drain_total", map[string]string{"outcome": "raw-attacker-value"}) {
+		t.Fatal("invalid settlement receipt audit outbox drain outcome created a metric series")
+	}
+	if metricExists(families, "settlement_receipt_audit_outbox_rows_total", map[string]string{"operation": "raw-attacker-value"}) {
+		t.Fatal("invalid settlement receipt audit outbox rows operation created a metric series")
 	}
 }
 
@@ -244,4 +302,65 @@ func containsCaseFold(haystack, needle string) bool {
 		}
 	}
 	return false
+}
+
+func assertMetricValue(t *testing.T, families []*dto.MetricFamily, name string, labels map[string]string, want float64) {
+	t.Helper()
+	for _, mf := range families {
+		if mf.GetName() != name {
+			continue
+		}
+		for _, mt := range mf.GetMetric() {
+			if !metricLabelsMatch(mt, labels) {
+				continue
+			}
+			var got float64
+			switch {
+			case mt.GetGauge() != nil:
+				got = mt.GetGauge().GetValue()
+			case mt.GetCounter() != nil:
+				got = mt.GetCounter().GetValue()
+			default:
+				t.Fatalf("metric %s has unsupported type", name)
+			}
+			if got != want {
+				t.Fatalf("metric %s%v = %v, want %v", name, labels, got, want)
+			}
+			return
+		}
+	}
+	t.Fatalf("metric %s%v not found", name, labels)
+}
+
+func metricExists(families []*dto.MetricFamily, name string, labels map[string]string) bool {
+	for _, mf := range families {
+		if mf.GetName() != name {
+			continue
+		}
+		for _, mt := range mf.GetMetric() {
+			if metricLabelsMatch(mt, labels) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func metricLabelsMatch(metric *dto.Metric, labels map[string]string) bool {
+	if len(labels) == 0 {
+		return len(metric.GetLabel()) == 0
+	}
+	for wantName, wantValue := range labels {
+		found := false
+		for _, lp := range metric.GetLabel() {
+			if lp.GetName() == wantName && lp.GetValue() == wantValue {
+				found = true
+				break
+			}
+		}
+		if !found {
+			return false
+		}
+	}
+	return true
 }

--- a/specs/CONFORMANCE.json
+++ b/specs/CONFORMANCE.json
@@ -4160,7 +4160,7 @@
     {
       "requirement_id": "SPEC-015-R001",
       "spec_id": "SPEC-015",
-      "state": "conformant",
+      "state": "pending",
       "implementation": [
         "phase3-binary/Sources/macprovider-cli/ReceiptBuilder.swift:buildSettlement",
         "phase4-coordinator/internal/billing/settlement_receipts.go:IngestSettlementReceipt",
@@ -4189,7 +4189,12 @@
           "expires_at": "2026-09-16"
         }
       ],
-      "gap": null
+      "gap": {
+        "verdict": "CODE_BUG",
+        "owner": "@Augustas11",
+        "issue": "https://github.com/Augustas11/macprovider/issues/1197",
+        "rationale": "Issue #1197 moves settlement receipt audit payload writes out of the hot coordinator transaction. Previous signed buyer-paid-path evidence remains historical, but mapped selector fragments changed and require a fresh protected signed buyer-paid-path promotion from main after this implementation lands."
+      }
     },
     {
       "requirement_id": "SPEC-015-R002",
@@ -4368,7 +4373,7 @@
     {
       "requirement_id": "SPEC-022-R004",
       "spec_id": "SPEC-022",
-      "state": "conformant",
+      "state": "pending",
       "implementation": [
         "phase4-coordinator/internal/billing/settlement_receipts.go:IngestSettlementReceipt",
         "phase4-coordinator/internal/billing/settlement_verifier.go:VerifySettlementReceipt"
@@ -4395,7 +4400,12 @@
           "expires_at": "2026-09-16"
         }
       ],
-      "gap": null
+      "gap": {
+        "verdict": "CODE_BUG",
+        "owner": "@Augustas11",
+        "issue": "https://github.com/Augustas11/macprovider/issues/1197",
+        "rationale": "Issue #1197 changes the settlement receipt ingestion hot path while preserving verified receipt semantics. Previous signed buyer-paid-path evidence remains historical, but mapped selector fragments changed and require a fresh protected signed buyer-paid-path promotion from main after this implementation lands."
+      }
     },
     {
       "requirement_id": "SPEC-022-R005",
@@ -4592,7 +4602,7 @@
     {
       "requirement_id": "SPEC-022-R011",
       "spec_id": "SPEC-022",
-      "state": "conformant",
+      "state": "pending",
       "implementation": [
         "phase4-coordinator/internal/billing/settlement_receipts.go:insertSettlementReceiptVerdictAuditConn"
       ],
@@ -4617,7 +4627,12 @@
           "expires_at": "2026-09-17"
         }
       ],
-      "gap": null
+      "gap": {
+        "verdict": "CODE_BUG",
+        "owner": "@Augustas11",
+        "issue": "https://github.com/Augustas11/macprovider/issues/1197",
+        "rationale": "Issue #1197 moves settlement audit payload persistence to an outbox drain. Previous signed buyer-enforce evidence remains historical, but mapped selector fragments changed and require a fresh protected signed buyer-enforce promotion from main after this implementation lands."
+      }
     },
     {
       "requirement_id": "SPEC-016-R001",

--- a/specs/README.md
+++ b/specs/README.md
@@ -23,14 +23,14 @@ it can no longer drift. Do not hand-edit the table; edit each spec's
 | SPEC-012 | Coordinator Demand-Pull Model Swap and Buyer Cold-Model Visibility | 0.3 | draft | pending | pending corpus migration | [SPEC-012-coordinator-demand-pull.md](SPEC-012-coordinator-demand-pull.md) |
 | SPEC-013 | `macprovider-cli autotune` subcommand | 0.3.1 | normative | pending | pending corpus migration | [SPEC-013-cli-autotune.md](SPEC-013-cli-autotune.md) |
 | SPEC-014 | Provider Portal (seller-facing web surface) | 0.10 | draft | pending | pending: 2 | [SPEC-014-provider-portal.md](SPEC-014-provider-portal.md) |
-| SPEC-015 | Verifiable inference receipts | 0.4.6 | normative | complete | conformant: 1, pending: 4 | [SPEC-015-receipts.md](SPEC-015-receipts.md) |
+| SPEC-015 | Verifiable inference receipts | 0.4.6 | normative | complete | pending: 5 | [SPEC-015-receipts.md](SPEC-015-receipts.md) |
 | SPEC-016 | Provider payout pipeline (USDC on Base) | 0.1.26 | draft | pending | conformant: 1, pending: 10 | [SPEC-016-payout-pipeline.md](SPEC-016-payout-pipeline.md) |
 | SPEC-017 | Network Stats API | 0.2.0 | normative | pending | pending: 1 | [SPEC-017-network-stats-api.md](SPEC-017-network-stats-api.md) |
 | SPEC-018 | Agentic tool calling (provider-side response synthesis) | 0.2.7 | normative | pending | conformant: 1, pending: 1 | [SPEC-018-agentic-tool-calling.md](SPEC-018-agentic-tool-calling.md) |
 | SPEC-019 | Structured output (`response_format: json_schema`) | 0.2.5 | normative | pending | pending corpus migration | [SPEC-019-structured-output.md](SPEC-019-structured-output.md) |
 | SPEC-020 | Provider autoupdate | v0.1.12 | normative | pending | pending: 4 | [SPEC-020-provider-autoupdate.md](SPEC-020-provider-autoupdate.md) |
 | SPEC-021 | MALIBU rewards emission ledger | 0.4.0 | draft | complete | pending: 10 | [SPEC-021-malibu-emission-ledger.md](SPEC-021-malibu-emission-ledger.md) |
-| SPEC-022 | Verified model settlement | v0.1.7 | draft | complete | conformant: 11 | [SPEC-022-verified-model-settlement.md](SPEC-022-verified-model-settlement.md) |
+| SPEC-022 | Verified model settlement | v0.1.7 | draft | complete | conformant: 9, pending: 2 | [SPEC-022-verified-model-settlement.md](SPEC-022-verified-model-settlement.md) |
 | SPEC-023 | Installer-Integrated Autotune Recommend | v0.9.3 | normative | pending | conformant: 2 | [SPEC-023-installer-autotune-recommend.md](SPEC-023-installer-autotune-recommend.md) |
 | SPEC-024 | Prefix-cache billing and provider-local cache isolation | 0.2.1 | normative | pending | pending corpus migration | [SPEC-024-prefix-cache-billing.md](SPEC-024-prefix-cache-billing.md) |
 | SPEC-025 | Native Mac App (signed `.dmg` + menu bar wrapper) | v0.23 | draft | pending | pending corpus migration | [SPEC-025-native-mac-app.md](SPEC-025-native-mac-app.md) |

--- a/test/integration/buyer_enforce_journey_test.go
+++ b/test/integration/buyer_enforce_journey_test.go
@@ -254,9 +254,10 @@ func waitForMissingReceiptDeadlineQuarantine(t *testing.T, s *scenario, wantCoun
 
 func (s *scenario) readSettlementVerdictAudits() []string {
 	s.t.Helper()
-	db, err := sql.Open("sqlite", s.coordinatorDB)
+	auditDB := filepath.Join(filepath.Dir(s.coordinatorDB), "coordinator-audit.db")
+	db, err := sql.Open("sqlite", auditDB)
 	if err != nil {
-		s.t.Fatalf("open coord db: %v", err)
+		s.t.Fatalf("open settlement receipt audit db: %v", err)
 	}
 	defer db.Close()
 	rows, err := db.Query(`SELECT payload_json FROM audit_log WHERE event_type = 'settlement_receipt_verdict' ORDER BY id ASC`)


### PR DESCRIPTION
## Summary

#1197 settlement-audit-outbox slice. This moves settlement receipt audit payload writes out of the hot receipt transaction by writing compact outbox rows in the money DB, then draining full audit payloads into sibling `coordinator-audit.db` after commit.

Rollback/archive lifecycle coverage is included: the Pearl updater captures/restores `coordinator-audit.db` with the existing database snapshot manifest, including restored legacy journal state.

## Conformance posture

This PR changes selector fragments that were previously covered by signed buyer paid-path/enforce evidence. The old signed evidence is preserved as historical evidence, but the affected requirement rows are conservatively marked `pending` with a #1197 gap until protected signed promotion can run from `main` after merge:

- `SPEC-015-R001`
- `SPEC-022-R004`
- `SPEC-022-R011`

Required post-merge step: run the protected signed buyer-paid-path and buyer-enforce promotion workflows against the merged source SHA, then land the generated promotion artifacts to restore conformant status.

## Verification

- `env GOCACHE=/private/tmp/macprovider-go-build go test ./cmd/coordinator ./internal/audit ./internal/billing ./internal/stats/metrics -count=1` in `phase4-coordinator`
- `env GOCACHE=/private/tmp/macprovider-go-build go test ./... -count=1` in `phase4-coordinator`
- `env GOCACHE=/private/tmp/macprovider-go-build go test -race -count=1 -timeout 5m ./...` in `test/integration`
- `python3 -m unittest ops.pearl-updater.test_pearl_updater`
- `python3 scripts/check_spec_governance.py --base-ref origin/main`
- `python3 scripts/gen_spec_index.py --check`
- `git diff --check origin/main..HEAD`

Note: an earlier parallel integration run failed during gateway seed setup while the full coordinator package suite was also running; rerunning the same integration command alone passed.

SPEC-GOVERNANCE-DECLARATION-BEGIN
{
  "schema_version": "spec-pr-governance-v1",
  "issue": "https://github.com/Augustas11/macprovider/issues/1197",
  "behavior_change": "yes",
  "contract_change": "yes",
  "specs": ["SPEC-015", "SPEC-022"],
  "requirements": ["SPEC-015-R001", "SPEC-022-R004", "SPEC-022-R011"],
  "authority_domains": ["billing-settlement-formula", "inference-receipts", "verified-model-settlement"],
  "arbitration": ["CODE_BUG"],
  "tests": [
    "env GOCACHE=/private/tmp/macprovider-go-build go test ./cmd/coordinator ./internal/audit ./internal/billing ./internal/stats/metrics -count=1 in phase4-coordinator",
    "env GOCACHE=/private/tmp/macprovider-go-build go test ./... -count=1 in phase4-coordinator",
    "env GOCACHE=/private/tmp/macprovider-go-build go test -race -count=1 -timeout 5m ./... in test/integration",
    "python3 -m unittest ops.pearl-updater.test_pearl_updater",
    "python3 scripts/check_spec_governance.py --base-ref origin/main",
    "python3 scripts/gen_spec_index.py --check"
  ],
  "journeys": ["JOURNEY-BUYER-PAID-PATH", "JOURNEY-BUYER-ENFORCE"]
}
SPEC-GOVERNANCE-DECLARATION-END
