### PR TITLE
fix: unblock signed headless smoke acceptance upgrade

### DIFF
--- a/phase3-binary/Sources/macprovider-cli/CoordinatorClient.swift
+++ b/phase3-binary/Sources/macprovider-cli/CoordinatorClient.swift
@@ -146,7 +146,7 @@ actor CoordinatorClient {
     typealias InstalledCompatibilityManifest = @Sendable (URL, String) -> CompatibilitySetManifest?
     typealias ReloadHelperFence = @Sendable () throws -> Void
 
-    static let binaryVersion = "1.8.107"
+    static let binaryVersion = "1.8.108"
     private static let keepaliveDebugEnabled = ProcessInfo.processInfo.environment["MACPROVIDER_KEEPALIVE_DEBUG"] == "1"
 
     private let coordinatorURL: URL

--- a/phase3-binary/dist/install.sh
+++ b/phase3-binary/dist/install.sh
@@ -12449,17 +12449,35 @@ validate_acceptance_upgrade_target() {
       || die 7 "could not create installed compatibility preflight error capture"
     if installed_preflight="$("$installed_binary" release-payload-preflight 2>"$installed_preflight_error_file")"; then
       rm -f "$installed_preflight_error_file"
-      installed_version="$(python3 - "$installed_preflight" <<'PY'
+      installed_version="$(python3 - "$installed_preflight" "$GITHUB_REPO" <<'PY'
 import json
 import re
 import sys
 
-value = json.loads(sys.argv[1])
+def reject_duplicate_keys(pairs):
+    value = {}
+    for key, item in pairs:
+        if key in value:
+            raise ValueError(f"duplicate key: {key}")
+        value[key] = item
+    return value
+
+value = json.loads(sys.argv[1], object_pairs_hook=reject_duplicate_keys)
 version = value.get("version")
+compatibility_set_id = value.get("compatibility_set_id")
+identity_match = None
+if isinstance(compatibility_set_id, str):
+    identity_match = re.fullmatch(
+        re.escape(sys.argv[2])
+        + r":v([0-9]+\.[0-9]+\.[0-9]+)@[0-9a-f]{40}",
+        compatibility_set_id,
+    )
 if set(value) != {"compatibility_set_id", "status", "version"} \
         or value.get("status") != "valid" \
         or not isinstance(version, str) \
-        or not re.fullmatch(r"[0-9]+\.[0-9]+\.[0-9]+", version):
+        or not re.fullmatch(r"[0-9]+\.[0-9]+\.[0-9]+", version) \
+        or identity_match is None \
+        or identity_match.group(1) != version:
     raise SystemExit(1)
 print(version)
 PY
@@ -12477,8 +12495,10 @@ PY
       # common comparison below still requires the signed candidate to be
       # strictly newer, and staged candidate signature/identity validation is
       # unchanged and occurs before any live cutover.
-      [ "$target" = "v1.8.108" ] \
-        || die 7 "legacy headless smoke compatibility fallback is limited to acceptance target v1.8.108"
+      if [ "$target" != "v1.8.108" ]; then
+        rm -f "$installed_preflight_error_file"
+        die 7 "legacy headless smoke compatibility fallback is limited to acceptance target v1.8.108"
+      fi
       python3 - "$installed_preflight_error_file" "$installed_preflight_status" <<'PY' \
         || {
 import sys

--- a/phase3-binary/dist/install.sh
+++ b/phase3-binary/dist/install.sh
@@ -31,7 +31,7 @@ unset MACPROVIDER_BUNDLED_APP
 GITHUB_REPO="${MACPROVIDER_GITHUB_REPO:-Augustas11/macprovider}"
 MACPROVIDER_MIN_SUPPORTED_VERSION="v1.7.11"
 MACPROVIDER_MIN_EMERGENCY_VERSION="v1.8.30"
-MACPROVIDER_MIN_HEADLESS_VERSION="v1.8.107"
+MACPROVIDER_MIN_HEADLESS_VERSION="v1.8.108"
 COORDINATOR_URL_DEFAULT="wss://coordinator.malibu.tech/ws/provider"
 COORDINATOR_BASE_DEFAULT="https://coordinator.malibu.tech"
 INSTALL_DIR="${MACPROVIDER_INSTALL_DIR:-$HOME/macprovider}"
@@ -12409,6 +12409,32 @@ installed_provider_binary_path() {
   fi
 }
 
+installed_provider_binary_version() {
+  local installed_binary="$1"
+  local version_file installed_version
+  version_file="$(mktemp "${TMPDIR:-/tmp}/macprovider-installed-version.XXXXXX")" \
+    || return 1
+  if ! "$installed_binary" --version >"$version_file" 2>/dev/null; then
+    rm -f "$version_file"
+    return 1
+  fi
+  installed_version="$(python3 - "$version_file" <<'PY'
+import re
+import sys
+
+data = open(sys.argv[1], "rb").read()
+if not re.fullmatch(rb"v?[0-9]+\.[0-9]+\.[0-9]+(?:\r?\n)?", data):
+    raise SystemExit(1)
+print(data.decode("ascii").rstrip("\r\n"))
+PY
+  )" || {
+    rm -f "$version_file"
+    return 1
+  }
+  rm -f "$version_file"
+  printf '%s\n' "$installed_version"
+}
+
 validate_acceptance_upgrade_target() {
   target="$1"
   [ -n "${MACPROVIDER_ACCEPTANCE_ASSET_DIR:-}" ] || return 0
@@ -12419,9 +12445,11 @@ validate_acceptance_upgrade_target() {
   [ "${EMERGENCY_ROLLBACK:-0}" = "1" ] && return 0
   installed_manifest="$INSTALL_DIR/compatibility-set.json"
   if [ -f "$installed_manifest" ]; then
-    installed_preflight="$("$installed_binary" release-payload-preflight 2>/dev/null)" \
-      || die 7 "installed compatibility set failed preflight before acceptance upgrade"
-    installed_version="$(python3 - "$installed_preflight" <<'PY'
+    installed_preflight_error_file="$(mktemp "${TMPDIR:-/tmp}/macprovider-installed-preflight.XXXXXX")" \
+      || die 7 "could not create installed compatibility preflight error capture"
+    if installed_preflight="$("$installed_binary" release-payload-preflight 2>"$installed_preflight_error_file")"; then
+      rm -f "$installed_preflight_error_file"
+      installed_version="$(python3 - "$installed_preflight" <<'PY'
 import json
 import re
 import sys
@@ -12435,10 +12463,51 @@ if set(value) != {"compatibility_set_id", "status", "version"} \
     raise SystemExit(1)
 print(version)
 PY
-    )" || die 7 "installed compatibility set returned invalid preflight identity"
-    installed_tag="v$installed_version"
+      )" || die 7 "installed compatibility set returned invalid preflight identity"
+      installed_tag="v$installed_version"
+    else
+      installed_preflight_status="$?"
+      # Some pre-release headless smoke CLIs expose release-payload-preflight
+      # but fail inside that command because their legacy credentials parser
+      # rejects the modern --config argument. Acceptance upgrades may recover
+      # only from that exact exit/status shape and only for the one-shot
+      # v1.8.105 -> v1.8.108 acceptance bridge tracked by issue #1201. Remove
+      # this branch after that signed acceptance release has drained the smoke
+      # fleet. The
+      # common comparison below still requires the signed candidate to be
+      # strictly newer, and staged candidate signature/identity validation is
+      # unchanged and occurs before any live cutover.
+      [ "$target" = "v1.8.108" ] \
+        || die 7 "legacy headless smoke compatibility fallback is limited to acceptance target v1.8.108"
+      python3 - "$installed_preflight_error_file" "$installed_preflight_status" <<'PY' \
+        || {
+import sys
+
+expected = (
+    b"Error: Unknown option '--config'\n"
+    b"Usage: macprovider-cli credentials <subcommand>\n"
+    b"  See 'macprovider-cli credentials --help' for more information.\n"
+)
+if sys.argv[2] != "2" or open(sys.argv[1], "rb").read() != expected:
+    raise SystemExit(1)
+PY
+        rm -f "$installed_preflight_error_file"
+        die 7 "installed compatibility preflight failed outside the legacy headless smoke signature"
+      }
+      rm -f "$installed_preflight_error_file"
+      installed_version="$(installed_provider_binary_version "$installed_binary")" \
+        || die 7 "installed provider CLI version fallback failed before acceptance upgrade"
+      case "$installed_version" in
+        v*) installed_tag="$installed_version" ;;
+        *) installed_tag="v$installed_version" ;;
+      esac
+      [ "$installed_tag" = "v1.8.105" ] \
+        || die 7 "legacy headless smoke compatibility fallback requires incumbent v1.8.105"
+      log "Installed compatibility preflight failed; using bounded legacy incumbent version check for acceptance upgrade."
+    fi
   else
-    installed_version="$("$installed_binary" --version 2>/dev/null | tr -d '\r\n')"
+    installed_version="$(installed_provider_binary_version "$installed_binary")" \
+      || die 7 "installed provider CLI returned an invalid version"
     case "$installed_version" in
       v*) installed_tag="$installed_version" ;;
       *) installed_tag="v$installed_version" ;;

--- a/phase3-binary/dist/install.sh
+++ b/phase3-binary/dist/install.sh
@@ -12495,6 +12495,10 @@ PY
       # common comparison below still requires the signed candidate to be
       # strictly newer, and staged candidate signature/identity validation is
       # unchanged and occurs before any live cutover.
+      if [ "${HEADLESS:-0}" != "1" ]; then
+        rm -f "$installed_preflight_error_file"
+        die 7 "legacy headless smoke compatibility fallback requires headless mode"
+      fi
       if [ "$target" != "v1.8.108" ]; then
         rm -f "$installed_preflight_error_file"
         die 7 "legacy headless smoke compatibility fallback is limited to acceptance target v1.8.108"
@@ -12552,7 +12556,11 @@ validate_acceptance_provider_component_target() {
     *) provider_target_tag="v$provider_target" ;;
   esac
   validate_macprovider_version_tag "$provider_target_tag"
-  installed_version="$("$installed_binary" --version 2>/dev/null | tr -d '\r\n')" \
+  if [ "${HEADLESS:-0}" = "1" ] \
+      && ! version_at_least "$provider_target_tag" "$MACPROVIDER_MIN_HEADLESS_VERSION"; then
+    die 7 "headless mode requires macprovider-cli $MACPROVIDER_MIN_HEADLESS_VERSION or newer; acceptance provider component $provider_target_tag does not support SSH-only protected-file fleet installation"
+  fi
+  installed_version="$(installed_provider_binary_version "$installed_binary")" \
     || die 7 "installed provider CLI version preflight failed before acceptance upgrade"
   case "$installed_version" in
     v*) installed_tag="$installed_version" ;;
@@ -12568,7 +12576,7 @@ validate_acceptance_provider_component_target() {
 validate_staged_acceptance_provider_component() {
   local provider_target="$1"
   local staged_provider_version
-  staged_provider_version="$("$staging_dir/macprovider-cli" --version 2>/dev/null | tr -d '\r\n')" \
+  staged_provider_version="$(installed_provider_binary_version "$staging_dir/macprovider-cli")" \
     || die 5 "staged acceptance provider CLI version preflight failed"
   case "$staged_provider_version" in
     v*) staged_provider_version="${staged_provider_version#v}" ;;

--- a/phase3-binary/dist/test/install_headless_fleet.test.sh
+++ b/phase3-binary/dist/test/install_headless_fleet.test.sh
@@ -241,22 +241,22 @@ FUNCTION_PATH="$TMP/functions.sh" SYSTEM_DIR="$TMP/system" USERS_DIR="$TMP/users
   source "$FUNCTION_PATH"
 
   MACPROVIDER_MIN_SUPPORTED_VERSION=v1.7.11
-  MACPROVIDER_MIN_HEADLESS_VERSION=v1.8.107
+  MACPROVIDER_MIN_HEADLESS_VERSION=v1.8.108
   HEADLESS=1
   if (validate_headless_release_tag v1.8.105); then
     echo "headless mode unexpectedly accepted a pre-headless release tag" >&2
     exit 1
   fi
-  validate_headless_release_tag v1.8.107
+  validate_headless_release_tag v1.8.108
   if (validate_headless_acceptance_source); then
     echo "headless mode unexpectedly accepted missing acceptance provenance" >&2
     exit 1
   fi
-  if (BUNDLED_APP=/Applications/Malibu.app MACPROVIDER_ACCEPTANCE_ASSET_DIR=/tmp/a MACPROVIDER_VERSION=v1.8.107 MACPROVIDER_ACCEPTANCE_COMMIT=0123456789012345678901234567890123456789 MACPROVIDER_ACCEPTANCE_CONTROL_COMMIT=abcdefabcdefabcdefabcdefabcdefabcdefabcd MACPROVIDER_ACCEPTANCE_RUN_ID=1 MACPROVIDER_ACCEPTANCE_RUN_ATTEMPT=1 validate_headless_acceptance_source); then
+  if (BUNDLED_APP=/Applications/Malibu.app MACPROVIDER_ACCEPTANCE_ASSET_DIR=/tmp/a MACPROVIDER_VERSION=v1.8.108 MACPROVIDER_ACCEPTANCE_COMMIT=0123456789012345678901234567890123456789 MACPROVIDER_ACCEPTANCE_CONTROL_COMMIT=abcdefabcdefabcdefabcdefabcdefabcdefabcd MACPROVIDER_ACCEPTANCE_RUN_ID=1 MACPROVIDER_ACCEPTANCE_RUN_ATTEMPT=1 validate_headless_acceptance_source); then
     echo "headless mode unexpectedly accepted MACPROVIDER_BUNDLED_APP" >&2
     exit 1
   fi
-  MACPROVIDER_ACCEPTANCE_ASSET_DIR=/tmp/a MACPROVIDER_VERSION=v1.8.107 MACPROVIDER_ACCEPTANCE_COMMIT=0123456789012345678901234567890123456789 MACPROVIDER_ACCEPTANCE_CONTROL_COMMIT=abcdefabcdefabcdefabcdefabcdefabcdefabcd MACPROVIDER_ACCEPTANCE_RUN_ID=1 MACPROVIDER_ACCEPTANCE_RUN_ATTEMPT=1 validate_headless_acceptance_source
+  MACPROVIDER_ACCEPTANCE_ASSET_DIR=/tmp/a MACPROVIDER_VERSION=v1.8.108 MACPROVIDER_ACCEPTANCE_COMMIT=0123456789012345678901234567890123456789 MACPROVIDER_ACCEPTANCE_CONTROL_COMMIT=abcdefabcdefabcdefabcdefabcdefabcdefabcd MACPROVIDER_ACCEPTANCE_RUN_ID=1 MACPROVIDER_ACCEPTANCE_RUN_ATTEMPT=1 validate_headless_acceptance_source
   HEADLESS=0
   validate_headless_release_tag v1.8.105
 

--- a/scripts/test-install-version-pin.sh
+++ b/scripts/test-install-version-pin.sh
@@ -775,6 +775,10 @@ MOCK_LEGACY_VERSION="1.8.105"
 export MOCK_LEGACY_VERSION
 rc=0
 ( validate_acceptance_upgrade_target v1.8.108 ) >/dev/null 2>&1 || rc=$?
+report "case21b2-non-headless-legacy-smoke-rejected" 7 "$rc"
+HEADLESS=1
+rc=0
+( validate_acceptance_upgrade_target v1.8.108 ) >/dev/null 2>&1 || rc=$?
 report "case21b2-legacy-smoke-older-version-accepted" 0 "$rc"
 MOCK_LEGACY_VERSION="1.8.104"
 rc=0
@@ -813,6 +817,7 @@ rc=0
 ( validate_acceptance_upgrade_target v1.8.108 ) >/dev/null 2>&1 || rc=$?
 report "case21b2-altered-preflight-error-rejected" 7 "$rc"
 unset MOCK_LEGACY_PREFLIGHT_VARIANT
+unset HEADLESS
 unset MOCK_LEGACY_VERSION
 rm -f "$INSTALL_DIR/compatibility-set.json"
 
@@ -830,6 +835,44 @@ report "case21c-newer-provider-component-accepted" 0 "$rc"
 rc=0
 ( validate_acceptance_provider_component_target 1.8.39 ) >/dev/null 2>&1 || rc=$?
 report "case21c-provider-component-downgrade-rejected" 7 "$rc"
+# Headless SSH support follows the signed provider CLI component, not only the
+# compatibility-set release tag, because private sets may pin components.
+HEADLESS=1
+MACPROVIDER_MIN_HEADLESS_VERSION=v1.8.108
+rc=0
+( validate_acceptance_provider_component_target 1.8.107 ) >/dev/null 2>&1 || rc=$?
+report "case21c-headless-provider-component-below-floor-rejected" 7 "$rc"
+rc=0
+( validate_acceptance_provider_component_target 1.8.108 ) >/dev/null 2>&1 || rc=$?
+report "case21c-headless-provider-component-at-floor-accepted" 0 "$rc"
+unset HEADLESS MACPROVIDER_MIN_HEADLESS_VERSION
+cat > "$REAL_INSTALLED_BINARY" <<'SCRIPT'
+#!/usr/bin/env bash
+case "${1:-}" in
+  --version)
+    printf '1.8.4\n0\n'
+    ;;
+  *)
+    exit 2
+    ;;
+esac
+SCRIPT
+chmod +x "$REAL_INSTALLED_BINARY"
+rc=0
+( validate_acceptance_provider_component_target 1.8.41 ) >/dev/null 2>&1 || rc=$?
+report "case21c-installed-component-multiline-version-rejected" 7 "$rc"
+cat > "$REAL_INSTALLED_BINARY" <<'SCRIPT'
+#!/usr/bin/env bash
+case "${1:-}" in
+  --version)
+    printf '1.8.40\n'
+    ;;
+  *)
+    exit 2
+    ;;
+esac
+SCRIPT
+chmod +x "$REAL_INSTALLED_BINARY"
 EMERGENCY_ROLLBACK=1
 rc=0
 ( validate_acceptance_provider_component_target 1.8.39 ) >/dev/null 2>&1 || rc=$?
@@ -853,6 +896,14 @@ report "case21d-staged-provider-matches-signed-component" 0 "$rc"
 rc=0
 ( validate_staged_acceptance_provider_component 1.8.41 ) >/dev/null 2>&1 || rc=$?
 report "case21d-staged-provider-mismatch-rejected" 5 "$rc"
+cat > "$staging_dir/macprovider-cli" <<'SCRIPT'
+#!/usr/bin/env bash
+printf '1.8.4\n0\n'
+SCRIPT
+chmod +x "$staging_dir/macprovider-cli"
+rc=0
+( validate_staged_acceptance_provider_component 1.8.40 ) >/dev/null 2>&1 || rc=$?
+report "case21d-staged-provider-multiline-version-rejected" 5 "$rc"
 rm -rf "$staging_dir"
 
 ################################################################

--- a/scripts/test-install-version-pin.sh
+++ b/scripts/test-install-version-pin.sh
@@ -693,6 +693,97 @@ report "case21b-newer-set-release-accepted" 0 "$rc"
 rc=0
 ( validate_acceptance_upgrade_target v1.8.41 ) >/dev/null 2>&1 || rc=$?
 report "case21b-equal-set-release-rejected" 7 "$rc"
+
+cat > "$REAL_INSTALLED_BINARY" <<'SCRIPT'
+#!/usr/bin/env bash
+case "${1:-}" in
+  --version)
+    printf '1.8.40\n'
+    ;;
+  release-payload-preflight)
+    printf '{"status":"valid","version":"1.8.40"}\n'
+    ;;
+  *)
+    exit 2
+    ;;
+esac
+SCRIPT
+chmod +x "$REAL_INSTALLED_BINARY"
+rc=0
+( validate_acceptance_upgrade_target v1.8.108 ) >/dev/null 2>&1 || rc=$?
+report "case21b-malformed-successful-preflight-rejected" 7 "$rc"
+
+################################################################
+# Case 21b2 — a legacy headless smoke incumbent whose compatibility
+# preflight fails may fall back to its bounded semantic version, but
+# only a strictly newer signed acceptance candidate is accepted.
+################################################################
+cat > "$REAL_INSTALLED_BINARY" <<'SCRIPT'
+#!/usr/bin/env bash
+case "${1:-}" in
+  --version)
+    printf '%s\n' "${MOCK_LEGACY_VERSION:-1.8.40}"
+    ;;
+  release-payload-preflight)
+    if [ "${MOCK_LEGACY_PREFLIGHT_VARIANT:-exact}" = "altered" ]; then
+      printf "Error: Unknown option '--config'\n" >&2
+      printf 'Usage: macprovider-cli credentials <subcommand>\n' >&2
+    else
+      printf "Error: Unknown option '--config'\n" >&2
+      printf 'Usage: macprovider-cli credentials <subcommand>\n' >&2
+      printf "  See 'macprovider-cli credentials --help' for more information.\n" >&2
+    fi
+    exit "${MOCK_LEGACY_PREFLIGHT_EXIT:-2}"
+    ;;
+  *)
+    exit 2
+    ;;
+esac
+SCRIPT
+chmod +x "$REAL_INSTALLED_BINARY"
+MOCK_LEGACY_VERSION="1.8.105"
+export MOCK_LEGACY_VERSION
+rc=0
+( validate_acceptance_upgrade_target v1.8.108 ) >/dev/null 2>&1 || rc=$?
+report "case21b2-legacy-smoke-older-version-accepted" 0 "$rc"
+MOCK_LEGACY_VERSION="1.8.104"
+rc=0
+( validate_acceptance_upgrade_target v1.8.108 ) >/dev/null 2>&1 || rc=$?
+report "case21b2-unrelated-older-incumbent-rejected" 7 "$rc"
+MOCK_LEGACY_VERSION="1.8.105"
+rc=0
+( validate_acceptance_upgrade_target v1.8.109 ) >/dev/null 2>&1 || rc=$?
+report "case21b2-later-acceptance-target-rejected" 7 "$rc"
+MOCK_LEGACY_VERSION="1.8.108"
+rc=0
+( validate_acceptance_upgrade_target v1.8.108 ) >/dev/null 2>&1 || rc=$?
+report "case21b2-legacy-smoke-equal-version-rejected" 7 "$rc"
+MOCK_LEGACY_VERSION="1.8.109"
+rc=0
+( validate_acceptance_upgrade_target v1.8.108 ) >/dev/null 2>&1 || rc=$?
+report "case21b2-legacy-smoke-newer-version-rejected" 7 "$rc"
+MOCK_LEGACY_VERSION="not-a-version"
+rc=0
+( validate_acceptance_upgrade_target v1.8.108 ) >/dev/null 2>&1 || rc=$?
+report "case21b2-legacy-smoke-malformed-version-rejected" 7 "$rc"
+MOCK_LEGACY_VERSION="1.8."$'\n'"105"
+rc=0
+( validate_acceptance_upgrade_target v1.8.108 ) >/dev/null 2>&1 || rc=$?
+report "case21b2-legacy-smoke-multiline-version-rejected" 7 "$rc"
+MOCK_LEGACY_VERSION="1.8.105"
+MOCK_LEGACY_PREFLIGHT_EXIT="99"
+export MOCK_LEGACY_PREFLIGHT_EXIT
+rc=0
+( validate_acceptance_upgrade_target v1.8.108 ) >/dev/null 2>&1 || rc=$?
+report "case21b2-arbitrary-preflight-failure-rejected" 7 "$rc"
+unset MOCK_LEGACY_PREFLIGHT_EXIT
+MOCK_LEGACY_PREFLIGHT_VARIANT="altered"
+export MOCK_LEGACY_PREFLIGHT_VARIANT
+rc=0
+( validate_acceptance_upgrade_target v1.8.108 ) >/dev/null 2>&1 || rc=$?
+report "case21b2-altered-preflight-error-rejected" 7 "$rc"
+unset MOCK_LEGACY_PREFLIGHT_VARIANT
+unset MOCK_LEGACY_VERSION
 rm -f "$INSTALL_DIR/compatibility-set.json"
 
 ################################################################

--- a/scripts/test-install-version-pin.sh
+++ b/scripts/test-install-version-pin.sh
@@ -713,6 +713,36 @@ rc=0
 ( validate_acceptance_upgrade_target v1.8.108 ) >/dev/null 2>&1 || rc=$?
 report "case21b-malformed-successful-preflight-rejected" 7 "$rc"
 
+cat > "$REAL_INSTALLED_BINARY" <<'SCRIPT'
+#!/usr/bin/env bash
+case "${1:-}" in
+  --version)
+    printf '1.8.40\n'
+    ;;
+  release-payload-preflight)
+    printf '%s\n' "$MOCK_SUCCESSFUL_PREFLIGHT_JSON"
+    ;;
+  *)
+    exit 2
+    ;;
+esac
+SCRIPT
+chmod +x "$REAL_INSTALLED_BINARY"
+MOCK_SUCCESSFUL_PREFLIGHT_JSON='{"compatibility_set_id":null,"status":"valid","version":"1.8.40"}'
+export MOCK_SUCCESSFUL_PREFLIGHT_JSON
+rc=0
+( validate_acceptance_upgrade_target v1.8.108 ) >/dev/null 2>&1 || rc=$?
+report "case21b-null-preflight-identity-rejected" 7 "$rc"
+MOCK_SUCCESSFUL_PREFLIGHT_JSON='{"compatibility_set_id":"Augustas11/macprovider:v1.8.40@aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","status":"invalid","status":"valid","version":"1.8.40"}'
+rc=0
+( validate_acceptance_upgrade_target v1.8.108 ) >/dev/null 2>&1 || rc=$?
+report "case21b-duplicate-preflight-key-rejected" 7 "$rc"
+MOCK_SUCCESSFUL_PREFLIGHT_JSON='{"compatibility_set_id":"Augustas11/macprovider:v1.8.39@aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","status":"valid","version":"1.8.40"}'
+rc=0
+( validate_acceptance_upgrade_target v1.8.108 ) >/dev/null 2>&1 || rc=$?
+report "case21b-mismatched-preflight-identity-version-rejected" 7 "$rc"
+unset MOCK_SUCCESSFUL_PREFLIGHT_JSON
+
 ################################################################
 # Case 21b2 — a legacy headless smoke incumbent whose compatibility
 # preflight fails may fall back to its bounded semantic version, but


### PR DESCRIPTION
## Summary
- carry Erik's headless smoke acceptance upgrade fix onto current main
- constrain the legacy v1.8.105 bridge to HEADLESS=1 and target v1.8.108
- enforce the headless floor against the signed provider CLI component and reject malformed multiline version output

## Verification
- bash scripts/test-install-version-pin.sh
- bash phase3-binary/dist/test/install_headless_fleet.test.sh
- bash scripts/test-compatibility-artifact-index.sh
- bash scripts/test-coordinator-advertised-version-test.sh
- bash -n phase3-binary/dist/install.sh
- bash -n scripts/test-install-version-pin.sh
- bash -n phase3-binary/dist/test/install_headless_fleet.test.sh
- git diff --check origin/main..HEAD
- 3-lane auditors: code review, security, architecture all 0 Critical/High/Medium

## Handoff
Supersedes #1213 because Erik's fork branch has maintainer edits disabled and cannot be updated from this repo.

SPEC-GOVERNANCE-DECLARATION-BEGIN
{
  "schema_version": "spec-pr-governance-v1",
  "behavior_change": "yes",
  "contract_change": "none",
  "issue": "https://github.com/Augustas11/macprovider/issues/1201",
  "specs": [
    "SPEC-020",
    "SPEC-025",
    "SPEC-026"
  ],
  "requirements": [
    "SPEC-020-R002",
    "SPEC-020-R003"
  ],
  "authority_domains": [
    "provider-autoupdate",
    "native-app-lifecycle",
    "browserless-onboarding"
  ],
  "arbitration": [
    "CODE_BUG"
  ],
  "tests": [
    "bash scripts/test-install-version-pin.sh",
    "bash phase3-binary/dist/test/install_headless_fleet.test.sh",
    "bash scripts/test-compatibility-artifact-index.sh",
    "bash scripts/test-coordinator-advertised-version-test.sh"
  ],
  "journeys": [
    "not-required"
  ]
}
SPEC-GOVERNANCE-DECLARATION-END
