### PR TITLE
Allow reviewed OpenSSL formula digest

### DIFF
--- a/scripts/install-sealed-release-openssl.sh
+++ b/scripts/install-sealed-release-openssl.sh
@@ -11,6 +11,7 @@ readonly expected_bottle_sha256="5477285c4ebec45713873ae4002affece39e427c5f1b655
 # GitHub macos-15-intel runners currently expose either reviewed Homebrew
 # formula text digest for this same OpenSSL 3.6.3 sequoia bottle.
 readonly -a expected_formula_sha256s=(
+  "e15cca35502166eb7a93940f3fe489e490b09a7b9e07ba3145d7ec1471bcd8d1"
   "773b90da6562a4018e1b5033b01432500002c4636cdfd35acf68d1a4b457590c"
   "00e19cdcb1b7d99058a8a15f316e5dce2e4b5cd2afee14b272e7f5448624801d"
 )

--- a/scripts/test-release-security-posture.sh
+++ b/scripts/test-release-security-posture.sh
@@ -912,6 +912,7 @@ def validate_sealed_openssl_installer(candidate):
         'readonly expected_bottle_tag="sequoia"',
         'readonly expected_bottle_sha256="5477285c4ebec45713873ae4002affece39e427c5f1b655c6a3df49c6b90f924"',
         'readonly -a expected_formula_sha256s=(',
+        '"e15cca35502166eb7a93940f3fe489e490b09a7b9e07ba3145d7ec1471bcd8d1"',
         '"773b90da6562a4018e1b5033b01432500002c4636cdfd35acf68d1a4b457590c"',
         '"00e19cdcb1b7d99058a8a15f316e5dce2e4b5cd2afee14b272e7f5448624801d"',
         "actual_formula_sha256 not in expected_formula_sha256s",
@@ -968,6 +969,14 @@ for description, mutation in (
         ),
     ),
     (
+        "reviewed current formula digest removal",
+        sealed_openssl_installer.replace(
+            '  "e15cca35502166eb7a93940f3fe489e490b09a7b9e07ba3145d7ec1471bcd8d1"\n',
+            "",
+            1,
+        ),
+    ),
+    (
         "reviewed legacy formula digest removal",
         sealed_openssl_installer.replace(
             '  "773b90da6562a4018e1b5033b01432500002c4636cdfd35acf68d1a4b457590c"\n',
@@ -976,7 +985,7 @@ for description, mutation in (
         ),
     ),
     (
-        "reviewed current formula digest removal",
+        "reviewed alternate formula digest removal",
         sealed_openssl_installer.replace(
             '  "00e19cdcb1b7d99058a8a15f316e5dce2e4b5cd2afee14b272e7f5448624801d"\n',
             "",


### PR DESCRIPTION
## Summary

- Add the newly observed Homebrew `openssl@3` formula text digest from the protected macos-15-intel runner.
- Keep the pinned OpenSSL 3.6.3 sequoia bottle version, rebuild, SHA-256, cellar, receipt, and sealed-file checks unchanged.
- Extend the release security posture regression test so removing the new digest is still detected.

SPEC-GOVERNANCE-DECLARATION-BEGIN
{
  "schema_version": "spec-pr-governance-v1",
  "behavior_change": "yes",
  "contract_change": "none",
  "specs": [
    "SPEC-020"
  ],
  "requirements": [
    "SPEC-020-R002"
  ],
  "authority_domains": [
    "provider-autoupdate"
  ],
  "arbitration": [
    "UNKNOWN"
  ],
  "tests": [
    "bash scripts/test-release-security-posture.sh",
    "git diff --check origin/main..HEAD",
    "python3 scripts/check_spec_governance.py --base-ref origin/main"
  ],
  "journeys": [
    "not-required"
  ]
}
SPEC-GOVERNANCE-DECLARATION-END

## Tests

- `bash scripts/test-release-security-posture.sh`
- `git diff --check origin/main..HEAD`
- `python3 scripts/check_spec_governance.py --base-ref origin/main`
