### PR TITLE
Repair 1212 conformance promotion ledger

### DIFF
--- a/specs/CONFORMANCE.json
+++ b/specs/CONFORMANCE.json
@@ -4175,20 +4175,7 @@
       "journeys": [
         "JOURNEY-BUYER-PAID-PATH"
       ],
-      "evidence": [
-        {
-          "artifact": "commit:5ed5d7190bd878fe3623fff9a5684e71eddfb8f1",
-          "source": null,
-          "captured_at": "2026-08-17",
-          "expires_at": "2026-09-16"
-        },
-        {
-          "artifact": "sha256:77b9de93bbbdc7a853e1196379769bb25d93c0bd1d683c1ca62a80038237d389",
-          "source": "journeys/evidence/buyer-paid-path-20260817T045519Z.spec-005-r001-spec-005-r002-spec-006-r001-spec-006-r002-spec-006-r003-spec-015-r001-spec-022-r001-spec-022-r002-spec-022-r003-spec-022-r004-spec-022-r005-spec-022-r010.journey-result.signed.json",
-          "captured_at": "2026-08-17",
-          "expires_at": "2026-09-16"
-        }
-      ],
+      "evidence": [],
       "gap": {
         "verdict": "CODE_BUG",
         "owner": "@Augustas11",
@@ -4386,20 +4373,7 @@
       "journeys": [
         "JOURNEY-BUYER-PAID-PATH"
       ],
-      "evidence": [
-        {
-          "artifact": "commit:5ed5d7190bd878fe3623fff9a5684e71eddfb8f1",
-          "source": null,
-          "captured_at": "2026-08-17",
-          "expires_at": "2026-09-16"
-        },
-        {
-          "artifact": "sha256:77b9de93bbbdc7a853e1196379769bb25d93c0bd1d683c1ca62a80038237d389",
-          "source": "journeys/evidence/buyer-paid-path-20260817T045519Z.spec-005-r001-spec-005-r002-spec-006-r001-spec-006-r002-spec-006-r003-spec-015-r001-spec-022-r001-spec-022-r002-spec-022-r003-spec-022-r004-spec-022-r005-spec-022-r010.journey-result.signed.json",
-          "captured_at": "2026-08-17",
-          "expires_at": "2026-09-16"
-        }
-      ],
+      "evidence": [],
       "gap": {
         "verdict": "CODE_BUG",
         "owner": "@Augustas11",
@@ -4613,20 +4587,7 @@
       "journeys": [
         "JOURNEY-BUYER-ENFORCE"
       ],
-      "evidence": [
-        {
-          "artifact": "commit:caa6ae4aec712c5d6353a3d307aab551911bea65",
-          "source": null,
-          "captured_at": "2026-08-18",
-          "expires_at": "2026-09-17"
-        },
-        {
-          "artifact": "sha256:5ede794fefc03470f1e3e5c0c401e95c8b9842c2c4aa0ac0fb7fcefd0ee39e14",
-          "source": "journeys/evidence/buyer-enforce-20260818T065941Z.spec-022-r007-spec-022-r008-spec-022-r009-spec-022-r011.journey-result.signed.json",
-          "captured_at": "2026-08-18",
-          "expires_at": "2026-09-17"
-        }
-      ],
+      "evidence": [],
       "gap": {
         "verdict": "CODE_BUG",
         "owner": "@Augustas11",


### PR DESCRIPTION
Clear stale historical evidence entries from three pending #1212 conformance rows so the protected signed promotion workflows can insert fresh evidence bound to the #1212 source SHA.

SPEC-GOVERNANCE-DECLARATION-BEGIN
{
  "schema_version": "spec-pr-governance-v1",
  "behavior_change": "none",
  "contract_change": "yes",
  "specs": ["SPEC-015", "SPEC-022"],
  "requirements": ["SPEC-015-R001", "SPEC-022-R004", "SPEC-022-R011"],
  "authority_domains": ["inference-receipts", "verified-model-settlement"],
  "arbitration": ["CODE_BUG"],
  "tests": [
    "python3 -m json.tool specs/CONFORMANCE.json",
    "python3 scripts/check_spec_governance.py --base-ref origin/main",
    "python3 scripts/preflight-signed-journey-promotion.py --source-sha ea5cd0a8c70e8838264a57b6958c0ecb2af78d83 --requirement-ids SPEC-015-R001,SPEC-022-R004 --journey-id JOURNEY-BUYER-PAID-PATH",
    "python3 scripts/preflight-signed-journey-promotion.py --source-sha ea5cd0a8c70e8838264a57b6958c0ecb2af78d83 --requirement-ids SPEC-022-R011 --journey-id JOURNEY-BUYER-ENFORCE",
    "git diff --check"
  ],
  "journeys": ["JOURNEY-BUYER-PAID-PATH", "JOURNEY-BUYER-ENFORCE"],
  "issue": "https://github.com/Augustas11/macprovider/issues/1197"
}
SPEC-GOVERNANCE-DECLARATION-END
