### PR TITLE
Guard Pearl rollout on request-log index readiness

### DIFF
--- a/ops/pearl-updater/macprovider-pearl-update
+++ b/ops/pearl-updater/macprovider-pearl-update
@@ -77,6 +77,12 @@ AUXILIARY_UNITS = (
     "stats-billing-mirror.timer",
     "stats-billing-mirror.service",
 )
+REQUIRED_REQUEST_LOG_INDEX_KEYS = frozenset(
+    {
+        "external_request_id",
+        "account_external_request_id",
+    }
+)
 COORDINATOR_ASSET = "coordinator-linux-amd64"
 COORDINATOR_CLI_ASSET = "coordinator-cli-linux-amd64"
 GATEWAY_ASSET = "gateway-linux-amd64"
@@ -2210,6 +2216,183 @@ class Updater:
             if candidate is not None:
                 value = candidate
         return value
+
+    @staticmethod
+    def _coordinator_command_environment(runtime: CoordinatorRuntime) -> dict[str, str]:
+        environment = {
+            "HOME": "/nonexistent",
+            "LANG": "C",
+            "LC_ALL": "C",
+            "PATH": "/usr/bin:/bin",
+            "TMPDIR": "/tmp",
+        }
+        environment.update(runtime.environment)
+        return environment
+
+    def _coordinator_migrate_indexes_argv(self, *, check: bool) -> list[str]:
+        runtime = self.coordinator_runtime_state or self.coordinator_runtime()
+        argv = [
+            str(self.install_root / "coordinator"),
+            "migrate-indexes",
+            "--config",
+            str(runtime.base_config),
+        ]
+        if runtime.overlay_config is not None:
+            argv.extend(["--config-overlay", str(runtime.overlay_config)])
+        if check:
+            argv.extend(["--check", "--format", "json"])
+        return argv
+
+    def _coordinator_request_log_index_status(self) -> dict[str, Any]:
+        runtime = self.coordinator_runtime_state or self.coordinator_runtime()
+        result = self.run_command(
+            self._coordinator_migrate_indexes_argv(check=True),
+            check=False,
+            timeout=120,
+            env=self._coordinator_command_environment(runtime),
+        )
+        if result.returncode != 0:
+            raise UpdateError("coordinator migrate-indexes --check failed; output suppressed")
+        if len(result.stdout.encode("utf-8")) > MAX_CANDIDATE_OUTPUT_BYTES:
+            raise UpdateError("coordinator migrate-indexes --check output exceeds updater safety limit")
+        try:
+            status = json.loads(result.stdout)
+        except ValueError as exc:
+            raise UpdateError("coordinator migrate-indexes --check returned invalid JSON") from exc
+        if not isinstance(status, dict):
+            raise UpdateError("coordinator migrate-indexes --check returned non-object JSON")
+        migration_state = status.get("migration_state")
+        keys = status.get("keys")
+        if migration_state not in ("legacy", "unindexed", "indexed"):
+            raise UpdateError("coordinator migrate-indexes --check returned an unknown migration_state")
+        if not isinstance(keys, list) or not keys:
+            raise UpdateError("coordinator migrate-indexes --check returned no migration keys")
+        seen: set[str] = set()
+        expected_aggregate = "indexed"
+        for key in keys:
+            if not isinstance(key, dict) or not isinstance(key.get("key"), str) or not key["key"]:
+                raise UpdateError("coordinator migrate-indexes --check returned an invalid migration key")
+            name = key["key"]
+            if name in seen:
+                raise UpdateError("coordinator migrate-indexes --check returned duplicate migration keys")
+            seen.add(name)
+            key_state = key.get("state")
+            if key_state not in ("legacy", "unindexed", "indexed"):
+                raise UpdateError("coordinator migrate-indexes --check returned an unknown key state")
+            index_present = key.get("index_present")
+            if index_present is not None and not isinstance(index_present, bool):
+                raise UpdateError("coordinator migrate-indexes --check returned an invalid index_present value")
+            columns_present = key.get("columns_present")
+            if columns_present is not None and not isinstance(columns_present, bool):
+                raise UpdateError("coordinator migrate-indexes --check returned an invalid columns_present value")
+            if key_state == "legacy":
+                if columns_present is True or index_present is True:
+                    raise UpdateError("coordinator migrate-indexes --check returned inconsistent legacy key state")
+                expected_aggregate = "legacy"
+            elif key_state == "unindexed":
+                if columns_present is False or index_present is True:
+                    raise UpdateError("coordinator migrate-indexes --check returned inconsistent unindexed key state")
+                if expected_aggregate != "legacy":
+                    expected_aggregate = "unindexed"
+            elif key_state == "indexed" and (columns_present is not True or index_present is not True):
+                raise UpdateError("coordinator migrate-indexes --check returned inconsistent indexed key state")
+        missing_keys = sorted(REQUIRED_REQUEST_LOG_INDEX_KEYS - seen)
+        if missing_keys:
+            raise UpdateError(
+                f"coordinator migrate-indexes --check omitted required migration key: {missing_keys[0]}"
+            )
+        if migration_state != expected_aggregate:
+            raise UpdateError("coordinator migrate-indexes --check returned inconsistent migration_state")
+        return status
+
+    @staticmethod
+    def _migration_key_states(status: dict[str, Any]) -> dict[str, str]:
+        states: dict[str, str] = {}
+        for key in status["keys"]:
+            name = str(key["key"])
+            state = key.get("state")
+            states[name] = state if isinstance(state, str) else "unknown"
+        return states
+
+    def ensure_coordinator_request_log_indexes(self) -> None:
+        before = self._coordinator_request_log_index_status()
+        before_state = str(before["migration_state"])
+        before_keys = self._migration_key_states(before)
+        if before_state == "indexed":
+            self.audit(
+                "coordinator_request_log_indexes",
+                "success",
+                action="check",
+                migration_state=before_state,
+                key_states=before_keys,
+            )
+            return
+
+        runtime = self.coordinator_runtime_state or self.coordinator_runtime()
+        result = self.run_command(
+            self._coordinator_migrate_indexes_argv(check=False),
+            check=False,
+            timeout=31 * 60,
+            env=self._coordinator_command_environment(runtime),
+        )
+        if result.returncode != 0:
+            self.audit(
+                "coordinator_request_log_indexes",
+                "failed",
+                action="migrate",
+                previous_migration_state=before_state,
+                key_states=before_keys,
+            )
+            raise UpdateError("coordinator migrate-indexes failed; output suppressed")
+
+        after = self._coordinator_request_log_index_status()
+        after_state = str(after["migration_state"])
+        after_keys = self._migration_key_states(after)
+        if after_state != "indexed":
+            self.audit(
+                "coordinator_request_log_indexes",
+                "failed",
+                action="verify",
+                previous_migration_state=before_state,
+                migration_state=after_state,
+                key_states=after_keys,
+            )
+            raise UpdateError("coordinator request_log indexes are still not indexed after migrate-indexes")
+        self.audit(
+            "coordinator_request_log_indexes",
+            "success",
+            action="migrate",
+            previous_migration_state=before_state,
+            migration_state=after_state,
+            key_states=after_keys,
+        )
+
+    def require_coordinator_request_log_indexes_for_current_release(self) -> None:
+        status = self._coordinator_request_log_index_status()
+        migration_state = str(status["migration_state"])
+        key_states = self._migration_key_states(status)
+        if migration_state != "indexed":
+            self.audit(
+                "coordinator_request_log_indexes",
+                "failed",
+                action="already_current_check",
+                migration_state=migration_state,
+                key_states=key_states,
+            )
+            raise UpdateError(
+                "already-current Pearl release cannot skip rollout until coordinator request_log indexes are indexed"
+            )
+        self.audit(
+            "coordinator_request_log_indexes",
+            "success",
+            action="already_current_check",
+            migration_state=migration_state,
+            key_states=key_states,
+        )
+
+    def skip_already_current_release(self, release: Release, current: SemVer) -> None:
+        self.require_coordinator_request_log_indexes_for_current_release()
+        self.audit("rollout_skipped", "already_current", candidate=release.tag, current=str(current))
 
     @staticmethod
     def _database_path(value: str, description: str) -> Path:
@@ -5164,6 +5347,7 @@ class Updater:
         self.wait_for("coordinator health/version", self.config.service_health_timeout_s, lambda: self.local_coordinator_ready(release, False))
         if release.catalog is not None:
             self.assert_effective_tier2_catalog_path()
+        self.ensure_coordinator_request_log_indexes()
         self.systemctl("start", "macprovider-gateway.service")
         self.wait_for(
             "gateway systemd active state",
@@ -6259,7 +6443,7 @@ def main(argv: list[str]) -> int:
         if args.plan:
             return 0
         if decision == "already_current":
-            updater.audit("rollout_skipped", "already_current", candidate=release.tag, current=str(current))
+            updater.skip_already_current_release(release, current)
             return 0
         updater.apply(release, current)
         return 0

--- a/ops/pearl-updater/test_pearl_updater.py
+++ b/ops/pearl-updater/test_pearl_updater.py
@@ -1728,7 +1728,8 @@ class PearlUpdaterTests(unittest.TestCase):
 
     def test_restart_order_and_external_canary_final_gate(self):
         release = self.verify()
-        self.updater.systemctl = mock.Mock()
+        order = []
+        self.updater.systemctl = mock.Mock(side_effect=lambda _action, unit: order.append(f"systemctl:{unit}"))
         self.updater.run_canary_gate = mock.Mock()
         self.updater.service_active = mock.Mock(return_value=True)
         self.updater.local_coordinator_ready = mock.Mock(return_value=True)
@@ -1741,8 +1742,9 @@ class PearlUpdaterTests(unittest.TestCase):
         self.updater.verify_exact_catalog_admission = mock.Mock()
         self.updater.verify_exact_provider_canary = mock.Mock()
         self.updater.verify_buyer_canary_rollout_posture = mock.Mock()
-        self.updater.verify_live_runtime_binding = mock.Mock()
-        self.updater.restore_auxiliary_services = mock.Mock()
+        self.updater.ensure_coordinator_request_log_indexes = mock.Mock(side_effect=lambda: order.append("index-guard"))
+        self.updater.verify_live_runtime_binding = mock.Mock(side_effect=lambda _release: order.append("live-binding"))
+        self.updater.restore_auxiliary_services = mock.Mock(side_effect=lambda: order.append("restore-auxiliary"))
         self.updater.restore_auxiliary_timers = mock.Mock()
         self.updater._restore_canary_timer = mock.Mock()
         self.updater.wait_for = lambda _description, _timeout, check: self.assertTrue(check())
@@ -1755,6 +1757,9 @@ class PearlUpdaterTests(unittest.TestCase):
                 mock.call("start", "macprovider-gateway.service"),
             ],
         )
+        self.assertLess(order.index("index-guard"), order.index("systemctl:macprovider-gateway.service"))
+        self.assertLess(order.index("index-guard"), order.index("live-binding"))
+        self.assertLess(order.index("index-guard"), order.index("restore-auxiliary"))
         self.updater.prove_serving_recovery.assert_called_once_with(
             self.updater.release_identity(release)
         )
@@ -1775,6 +1780,7 @@ class PearlUpdaterTests(unittest.TestCase):
         self.updater.assert_effective_tier2_catalog_path = mock.Mock(
             side_effect=updater_module.UpdateError("effective tier2.catalog_path is not the release-bound current catalog path")
         )
+        self.updater.ensure_coordinator_request_log_indexes = mock.Mock()
         self.updater.wait_for = lambda _description, _timeout, check: self.assertTrue(check())
 
         with self.assertRaisesRegex(updater_module.UpdateError, "effective tier2.catalog_path"):
@@ -1786,6 +1792,511 @@ class PearlUpdaterTests(unittest.TestCase):
             [mock.call("start", "macprovider-coordinator.service")],
         )
         self.updater.local_gateway_ready.assert_not_called()
+        self.updater.ensure_coordinator_request_log_indexes.assert_not_called()
+
+    def test_rollout_migrates_indexes_before_gateway_and_traffic_restore(self):
+        release = self.verify()
+        self.updater.systemctl = mock.Mock()
+        self.updater.service_active = mock.Mock(return_value=True)
+        self.updater.local_coordinator_ready = mock.Mock(return_value=True)
+        self.updater.local_gateway_ready = mock.Mock(return_value=True)
+        self.updater.assert_effective_tier2_catalog_path = mock.Mock()
+        self.updater.ensure_coordinator_request_log_indexes = mock.Mock(
+            side_effect=updater_module.UpdateError("index guard failed")
+        )
+        self.updater.verify_live_runtime_binding = mock.Mock()
+        self.updater.restore_auxiliary_services = mock.Mock()
+        self.updater.prove_serving_recovery = mock.Mock()
+        self.updater.wait_for = lambda _description, _timeout, check: self.assertTrue(check())
+
+        with self.assertRaisesRegex(updater_module.UpdateError, "index guard failed"):
+            self.updater.verify_rollout(release)
+
+        self.updater.ensure_coordinator_request_log_indexes.assert_called_once_with()
+        self.assertEqual(
+            self.updater.systemctl.call_args_list,
+            [mock.call("start", "macprovider-coordinator.service")],
+        )
+        self.updater.local_gateway_ready.assert_not_called()
+        self.updater.verify_live_runtime_binding.assert_not_called()
+        self.updater.restore_auxiliary_services.assert_not_called()
+        self.updater.prove_serving_recovery.assert_not_called()
+
+    def test_migrate_indexes_uses_live_base_overlay_and_referenced_environment(self):
+        install = self.updater.install_root
+        install.mkdir(parents=True)
+        base = install / "coordinator.yaml"
+        overlay = self.root / "coordinator.overlay.yaml"
+        base.write_text("storage:\n  db_path: /srv/macprovider/base.sqlite\n")
+        overlay.write_text("storage:\n  db_path: /srv/macprovider/pearl.sqlite\n")
+        self.updater.coordinator_runtime_state = updater_module.CoordinatorRuntime(
+            base,
+            overlay,
+            {"TOKEN": "sentinel-secret"},
+        )
+        self.updater.audit = mock.Mock()
+        calls = []
+
+        def fake_run(argv, *, check=True, timeout, env=None, input_text=None):
+            calls.append({"argv": list(argv), "timeout": timeout, "env": dict(env or {})})
+            if "--check" in argv:
+                check_count = sum(1 for call in calls if "--check" in call["argv"])
+                state = "unindexed" if check_count == 1 else "indexed"
+                return subprocess.CompletedProcess(
+                    argv,
+                    0,
+                    stdout=json.dumps(
+                            {
+                                "migration_state": state,
+                                "keys": [
+                                    {
+                                        "key": "external_request_id",
+                                        "state": state,
+                                        "columns_present": True,
+                                        "index_present": state == "indexed",
+                                    },
+                                    {
+                                        "key": "account_external_request_id",
+                                        "state": state,
+                                        "columns_present": True,
+                                        "index_present": state == "indexed",
+                                    },
+                                ],
+                            }
+                    ),
+                    stderr="",
+                )
+            return subprocess.CompletedProcess(argv, 0, stdout="migrate-indexes ok\n", stderr="")
+
+        self.updater.run_command = mock.Mock(side_effect=fake_run)
+
+        self.updater.ensure_coordinator_request_log_indexes()
+
+        self.assertEqual(len(calls), 3)
+        self.assertIn("--config-overlay", calls[0]["argv"])
+        self.assertEqual(calls[0]["argv"][calls[0]["argv"].index("--config") + 1], str(base))
+        self.assertEqual(calls[0]["argv"][calls[0]["argv"].index("--config-overlay") + 1], str(overlay))
+        for call in calls:
+            self.assertEqual(call["env"]["TOKEN"], "sentinel-secret")
+            self.assertEqual(call["env"]["HOME"], "/nonexistent")
+        self.updater.audit.assert_called_with(
+            "coordinator_request_log_indexes",
+            "success",
+            action="migrate",
+            previous_migration_state="unindexed",
+            migration_state="indexed",
+            key_states={
+                "external_request_id": "indexed",
+                "account_external_request_id": "indexed",
+            },
+        )
+
+    def test_migrate_indexes_check_failure_suppresses_command_output(self):
+        self.updater.coordinator_runtime_state = updater_module.CoordinatorRuntime(
+            self.root / "coordinator.yaml",
+            None,
+            {"TOKEN": "sentinel-secret"},
+        )
+        self.updater.run_command = mock.Mock(
+            return_value=subprocess.CompletedProcess(
+                ["coordinator"],
+                1,
+                stdout="sentinel-secret in stdout",
+                stderr="sentinel-secret in stderr",
+            )
+        )
+
+        with self.assertRaisesRegex(updater_module.UpdateError, "output suppressed") as raised:
+            self.updater.ensure_coordinator_request_log_indexes()
+
+        self.assertNotIn("sentinel-secret", str(raised.exception))
+        self.updater.run_command.assert_called_once()
+
+    def test_migrate_indexes_mutation_failure_suppresses_command_output(self):
+        self.updater.coordinator_runtime_state = updater_module.CoordinatorRuntime(
+            self.root / "coordinator.yaml",
+            None,
+            {"TOKEN": "sentinel-secret"},
+        )
+        self.updater.audit = mock.Mock()
+        unindexed = json.dumps(
+            {
+                "migration_state": "unindexed",
+                "keys": [
+                    {
+                        "key": "external_request_id",
+                        "state": "unindexed",
+                        "columns_present": True,
+                        "index_present": False,
+                    },
+                    {
+                        "key": "account_external_request_id",
+                        "state": "unindexed",
+                        "columns_present": True,
+                        "index_present": False,
+                    },
+                ],
+            }
+        )
+        self.updater.run_command = mock.Mock(
+            side_effect=[
+                subprocess.CompletedProcess(["coordinator"], 0, stdout=unindexed, stderr=""),
+                subprocess.CompletedProcess(
+                    ["coordinator"],
+                    1,
+                    stdout="sentinel-secret in stdout",
+                    stderr="sentinel-secret in stderr",
+                ),
+            ]
+        )
+
+        with self.assertRaisesRegex(updater_module.UpdateError, "output suppressed") as raised:
+            self.updater.ensure_coordinator_request_log_indexes()
+
+        self.assertNotIn("sentinel-secret", str(raised.exception))
+        self.assertEqual(self.updater.run_command.call_count, 2)
+        self.updater.audit.assert_called_once_with(
+            "coordinator_request_log_indexes",
+            "failed",
+            action="migrate",
+            previous_migration_state="unindexed",
+            key_states={
+                "external_request_id": "unindexed",
+                "account_external_request_id": "unindexed",
+            },
+        )
+
+    def test_migrate_indexes_status_rejects_inconsistent_json(self):
+        self.updater.coordinator_runtime_state = updater_module.CoordinatorRuntime(
+            self.root / "coordinator.yaml",
+            None,
+            {},
+        )
+        self.updater.run_command = mock.Mock(
+            return_value=subprocess.CompletedProcess(
+                ["coordinator"],
+                0,
+                stdout=json.dumps(
+                    {
+                            "migration_state": "indexed",
+                            "keys": [
+                                {
+                                    "key": "external_request_id",
+                                    "state": "unindexed",
+                                    "columns_present": True,
+                                    "index_present": False,
+                                },
+                                {
+                                    "key": "account_external_request_id",
+                                    "state": "indexed",
+                                    "columns_present": True,
+                                    "index_present": True,
+                                }
+                            ],
+                        }
+                ),
+                stderr="",
+            )
+        )
+
+        with self.assertRaisesRegex(updater_module.UpdateError, "inconsistent migration_state"):
+            self.updater.ensure_coordinator_request_log_indexes()
+
+        self.updater.run_command.assert_called_once()
+
+    def test_migrate_indexes_status_rejects_inconsistent_index_marker(self):
+        self.updater.coordinator_runtime_state = updater_module.CoordinatorRuntime(
+            self.root / "coordinator.yaml",
+            None,
+            {},
+        )
+        self.updater.run_command = mock.Mock(
+            return_value=subprocess.CompletedProcess(
+                ["coordinator"],
+                0,
+                stdout=json.dumps(
+                    {
+                        "migration_state": "indexed",
+                        "keys": [
+                            {
+                                "key": "external_request_id",
+                                "state": "indexed",
+                                "columns_present": True,
+                                "index_present": False,
+                            },
+                            {
+                                "key": "account_external_request_id",
+                                "state": "indexed",
+                                "columns_present": True,
+                                "index_present": True,
+                            }
+                        ],
+                    }
+                ),
+                stderr="",
+            )
+        )
+
+        with self.assertRaisesRegex(updater_module.UpdateError, "inconsistent indexed key state"):
+            self.updater.ensure_coordinator_request_log_indexes()
+
+        self.updater.run_command.assert_called_once()
+
+    def test_migrate_indexes_status_rejects_missing_index_marker_for_indexed_key(self):
+        self.updater.coordinator_runtime_state = updater_module.CoordinatorRuntime(
+            self.root / "coordinator.yaml",
+            None,
+            {},
+        )
+        self.updater.run_command = mock.Mock(
+            return_value=subprocess.CompletedProcess(
+                ["coordinator"],
+                0,
+                stdout=json.dumps(
+                    {
+                        "migration_state": "indexed",
+                        "keys": [
+                            {
+                                "key": "external_request_id",
+                                "state": "indexed",
+                                "columns_present": True,
+                            },
+                            {
+                                "key": "account_external_request_id",
+                                "state": "indexed",
+                                "columns_present": True,
+                                "index_present": True,
+                            }
+                        ],
+                    }
+                ),
+                stderr="",
+            )
+        )
+
+        with self.assertRaisesRegex(updater_module.UpdateError, "inconsistent indexed key state"):
+            self.updater.ensure_coordinator_request_log_indexes()
+
+        self.updater.run_command.assert_called_once()
+
+    def test_migrate_indexes_status_rejects_inconsistent_columns_marker(self):
+        self.updater.coordinator_runtime_state = updater_module.CoordinatorRuntime(
+            self.root / "coordinator.yaml",
+            None,
+            {},
+        )
+        self.updater.run_command = mock.Mock(
+            return_value=subprocess.CompletedProcess(
+                ["coordinator"],
+                0,
+                stdout=json.dumps(
+                    {
+                        "migration_state": "indexed",
+                        "keys": [
+                            {
+                                "key": "external_request_id",
+                                "state": "indexed",
+                                "columns_present": False,
+                                "index_present": True,
+                            },
+                            {
+                                "key": "account_external_request_id",
+                                "state": "indexed",
+                                "columns_present": True,
+                                "index_present": True,
+                            }
+                        ],
+                    }
+                ),
+                stderr="",
+            )
+        )
+
+        with self.assertRaisesRegex(updater_module.UpdateError, "inconsistent indexed key state"):
+            self.updater.ensure_coordinator_request_log_indexes()
+
+        self.updater.run_command.assert_called_once()
+
+    def test_migrate_indexes_status_rejects_unindexed_with_index_marker(self):
+        self.updater.coordinator_runtime_state = updater_module.CoordinatorRuntime(
+            self.root / "coordinator.yaml",
+            None,
+            {},
+        )
+        self.updater.run_command = mock.Mock(
+            return_value=subprocess.CompletedProcess(
+                ["coordinator"],
+                0,
+                stdout=json.dumps(
+                    {
+                        "migration_state": "unindexed",
+                        "keys": [
+                            {
+                                "key": "external_request_id",
+                                "state": "unindexed",
+                                "columns_present": True,
+                                "index_present": True,
+                            },
+                            {
+                                "key": "account_external_request_id",
+                                "state": "unindexed",
+                                "columns_present": True,
+                                "index_present": False,
+                            }
+                        ],
+                    }
+                ),
+                stderr="",
+            )
+        )
+
+        with self.assertRaisesRegex(updater_module.UpdateError, "inconsistent unindexed key state"):
+            self.updater.ensure_coordinator_request_log_indexes()
+
+        self.updater.run_command.assert_called_once()
+
+    def test_migrate_indexes_status_requires_current_mandatory_keys(self):
+        self.updater.coordinator_runtime_state = updater_module.CoordinatorRuntime(
+            self.root / "coordinator.yaml",
+            None,
+            {},
+        )
+        self.updater.run_command = mock.Mock(
+            return_value=subprocess.CompletedProcess(
+                ["coordinator"],
+                0,
+                stdout=json.dumps(
+                    {
+                        "migration_state": "indexed",
+                        "keys": [
+                            {
+                                "key": "external_request_id",
+                                "state": "indexed",
+                                "columns_present": True,
+                                "index_present": True,
+                            }
+                        ],
+                    }
+                ),
+                stderr="",
+            )
+        )
+
+        with self.assertRaisesRegex(updater_module.UpdateError, "omitted required migration key"):
+            self.updater.ensure_coordinator_request_log_indexes()
+
+        self.updater.run_command.assert_called_once()
+
+    def test_migrate_indexes_status_rejects_unknown_only_keys(self):
+        self.updater.coordinator_runtime_state = updater_module.CoordinatorRuntime(
+            self.root / "coordinator.yaml",
+            None,
+            {},
+        )
+        self.updater.run_command = mock.Mock(
+            return_value=subprocess.CompletedProcess(
+                ["coordinator"],
+                0,
+                stdout=json.dumps(
+                    {
+                            "migration_state": "indexed",
+                            "keys": [
+                                {
+                                    "key": "future_only",
+                                    "state": "indexed",
+                                    "columns_present": True,
+                                    "index_present": True,
+                                }
+                            ],
+                        }
+                ),
+                stderr="",
+            )
+        )
+
+        with self.assertRaisesRegex(updater_module.UpdateError, "omitted required migration key"):
+            self.updater.ensure_coordinator_request_log_indexes()
+
+        self.updater.run_command.assert_called_once()
+
+    def test_already_current_skip_requires_indexed_request_log_keys(self):
+        release = self.verify()
+        self.updater.audit = mock.Mock()
+        self.updater._coordinator_request_log_index_status = mock.Mock(
+            return_value={
+                "migration_state": "indexed",
+                "keys": [
+                    {
+                        "key": "external_request_id",
+                        "state": "indexed",
+                        "index_present": True,
+                    },
+                    {
+                        "key": "account_external_request_id",
+                        "state": "indexed",
+                        "index_present": True,
+                    },
+                ],
+            }
+        )
+
+        self.updater.skip_already_current_release(release, updater_module.SemVer.parse("1.8.27"))
+
+        self.updater.audit.assert_has_calls(
+            [
+                mock.call(
+                    "coordinator_request_log_indexes",
+                    "success",
+                    action="already_current_check",
+                    migration_state="indexed",
+                    key_states={
+                        "external_request_id": "indexed",
+                        "account_external_request_id": "indexed",
+                    },
+                ),
+                mock.call(
+                    "rollout_skipped",
+                    "already_current",
+                    candidate=release.tag,
+                    current="1.8.27",
+                ),
+            ]
+        )
+
+    def test_already_current_skip_fails_closed_when_indexes_are_unindexed(self):
+        release = self.verify()
+        self.updater.audit = mock.Mock()
+        self.updater._coordinator_request_log_index_status = mock.Mock(
+            return_value={
+                "migration_state": "unindexed",
+                "keys": [
+                    {
+                        "key": "external_request_id",
+                        "state": "indexed",
+                        "index_present": True,
+                    },
+                    {
+                        "key": "account_external_request_id",
+                        "state": "unindexed",
+                        "index_present": False,
+                    },
+                ],
+            }
+        )
+
+        with self.assertRaisesRegex(updater_module.UpdateError, "cannot skip rollout"):
+            self.updater.skip_already_current_release(release, updater_module.SemVer.parse("1.8.27"))
+
+        self.updater.audit.assert_called_once_with(
+            "coordinator_request_log_indexes",
+            "failed",
+            action="already_current_check",
+            migration_state="unindexed",
+            key_states={
+                "external_request_id": "indexed",
+                "account_external_request_id": "unindexed",
+            },
+        )
 
     def test_bridge_rollout_requires_capacity_and_safe_active_deadline(self):
         deadline = (
@@ -5806,6 +6317,7 @@ class PearlUpdaterTests(unittest.TestCase):
         self.updater.verify_provider_admission_rollout_policy = mock.Mock()
         self.updater.verify_exact_catalog_admission = mock.Mock()
         self.updater.verify_buyer_canary_rollout_posture = mock.Mock()
+        self.updater.ensure_coordinator_request_log_indexes = mock.Mock()
         self.updater.verify_live_runtime_binding = mock.Mock()
         self.updater.restore_auxiliary_timers = mock.Mock()
         self.updater._restore_canary_timer = mock.Mock()

--- a/phase4-coordinator/cmd/coordinator/main.go
+++ b/phase4-coordinator/cmd/coordinator/main.go
@@ -117,7 +117,7 @@ func main() {
 			fmt.Fprintln(os.Stderr, "  coordinator --version           (print build version)")
 			fmt.Fprintln(os.Stderr, "  coordinator partner-keys <issue|revoke|list> [flags]")
 			fmt.Fprintln(os.Stderr, "  coordinator visibility revert --id <pid> --reason TEXT")
-			fmt.Fprintln(os.Stderr, "  coordinator migrate-indexes --config <path>  (one-shot operator migration)")
+			fmt.Fprintln(os.Stderr, "  coordinator migrate-indexes --config <path> [--config-overlay <path>]  (one-shot operator migration)")
 			fmt.Fprintln(os.Stderr, "  coordinator backfill-attempt-n --config <path>  (one-shot attempt_n backfill)")
 			fmt.Fprintln(os.Stderr, "  coordinator stats-migrate [--admin-dsn DSN] [--check]  (SPEC-017 stats/rewards migrations)")
 			os.Exit(2)

--- a/phase4-coordinator/cmd/coordinator/migrate_indexes.go
+++ b/phase4-coordinator/cmd/coordinator/migrate_indexes.go
@@ -2,7 +2,7 @@ package main
 
 // SPEC-002 v1.4.2 R-2 / ISS-188 operator-runbook subcommand:
 //
-//	coordinator migrate-indexes --config <path>
+//	coordinator migrate-indexes --config <path> [--config-overlay <path>]
 //
 // One-shot CREATE INDEX for request_log.external_request_id (and any
 // future ensureIndex DDL). Intentionally NOT invoked from the daemon
@@ -32,6 +32,7 @@ func runMigrateIndexesIO(args []string, stdout, stderr io.Writer) int {
 	fs := flag.NewFlagSet("migrate-indexes", flag.ContinueOnError)
 	fs.SetOutput(stderr)
 	configPath := fs.String("config", "coordinator.yaml", "path to coordinator YAML config")
+	configOverlay := fs.String("config-overlay", "", "optional coordinator YAML config overlay")
 	timeout := fs.Duration("timeout", 30*time.Minute, "max time the index build may run")
 	// SPEC-002 v1.5.1 R-2 / issue #197: --check reports per-key
 	// migration state without mutating the schema. Intended for
@@ -52,7 +53,7 @@ func runMigrateIndexesIO(args []string, stdout, stderr io.Writer) int {
 			return 2
 		}
 	}
-	cfg, err := config.Load(*configPath)
+	cfg, err := config.LoadWithOverlay(*configPath, *configOverlay)
 	if err != nil {
 		fmt.Fprintf(stderr, "config: %v\n", err)
 		return 1

--- a/phase4-coordinator/cmd/coordinator/migrate_indexes_test.go
+++ b/phase4-coordinator/cmd/coordinator/migrate_indexes_test.go
@@ -170,3 +170,51 @@ func TestMigrateIndexesCheckRejectsBogusFormatBeforeOpen(t *testing.T) {
 		t.Errorf("bogus --format triggered schema migration before format validation")
 	}
 }
+
+func TestMigrateIndexesCheckHonorsConfigOverlay(t *testing.T) {
+	dir := t.TempDir()
+	baseDBPath := filepath.Join(dir, "base.db")
+	overlayDBPath := filepath.Join(dir, "overlay.db")
+	configPath := filepath.Join(dir, "coordinator.yaml")
+	overlayPath := filepath.Join(dir, "coordinator.overlay.yaml")
+
+	db, err := sql.Open("sqlite", overlayDBPath)
+	if err != nil {
+		t.Fatalf("open seed db: %v", err)
+	}
+	if _, err := db.ExecContext(context.Background(), `CREATE TABLE request_log (
+		id INTEGER PRIMARY KEY AUTOINCREMENT,
+		ts_utc TEXT NOT NULL,
+		request_id TEXT NOT NULL,
+		model TEXT NOT NULL
+	)`); err != nil {
+		t.Fatalf("seed legacy schema: %v", err)
+	}
+	_ = db.Close()
+
+	if err := os.WriteFile(configPath, []byte("auth:\n  operator_key: 0123456789abcdefABCDEFghijklmnop\n  gateway_service_token: fedcba9876543210PONMLKJIHGFEDCBA\nstorage:\n  db_path: "+baseDBPath+"\n"), 0o644); err != nil {
+		t.Fatalf("write base config: %v", err)
+	}
+	if err := os.WriteFile(overlayPath, []byte("storage:\n  db_path: "+overlayDBPath+"\n"), 0o644); err != nil {
+		t.Fatalf("write overlay config: %v", err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	rc := runMigrateIndexesIO([]string{"--config", configPath, "--config-overlay", overlayPath, "--check", "--format", "json"}, &stdout, &stderr)
+	if rc != 0 {
+		t.Fatalf("rc=%d stderr=%s", rc, stderr.String())
+	}
+
+	var got struct {
+		MigrationState string `json:"migration_state"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &got); err != nil {
+		t.Fatalf("decode json: %v\nstdout=%s", err, stdout.String())
+	}
+	if got.MigrationState != "legacy" {
+		t.Fatalf("migration_state=%q, want legacy from overlay DB: stdout=%s", got.MigrationState, stdout.String())
+	}
+	if _, err := os.Stat(baseDBPath); !os.IsNotExist(err) {
+		t.Fatalf("base db was touched despite overlay storage.db_path: stat err=%v", err)
+	}
+}


### PR DESCRIPTION
## Summary
- make Pearl rollout verify coordinator request_log index readiness before gateway start and traffic restoration
- run `coordinator migrate-indexes` with the live base config plus overlay when indexes are absent, then re-check before continuing
- make already-current no-op deploys fail closed unless both current request_log index keys are already indexed
- add `--config-overlay` support to `coordinator migrate-indexes` so the deploy guard checks the same SQLite DB Pearl actually uses

## Validation
- `python3 ops/pearl-updater/test_pearl_updater.py` (201 tests, 1 skipped)
- `go test ./cmd/coordinator`
- `make test-coordinator`
- `make test-dist`
- final review lanes: code 0 CRITICAL/HIGH/MEDIUM, architecture 0 CRITICAL/HIGH/MEDIUM, security 0 CRITICAL/HIGH/MEDIUM

## Operational Notes
This is the guard for the post-#1212 Pearl blocker: the missing request_log reconciliation index must be checked or repaired before buyer traffic returns. The PR intentionally does not auto-migrate in the already-current path because traffic may already be live there; it fails closed and requires an actual rollout window.

Refs #1197

SPEC-GOVERNANCE-DECLARATION-BEGIN
{
  "schema_version": "spec-pr-governance-v1",
  "behavior_change": "yes",
  "contract_change": "none",
  "issue": "https://github.com/Augustas11/macprovider/issues/1197",
  "specs": ["SPEC-002", "SPEC-005", "SPEC-006"],
  "requirements": ["SPEC-002-R001", "SPEC-005-R005", "SPEC-006-R003"],
  "authority_domains": ["coordinator-admission-routing", "billing-settlement-formula", "buyer-api-error-contract"],
  "arbitration": ["CODE_BUG"],
  "tests": [
    "python3 ops/pearl-updater/test_pearl_updater.py",
    "go test ./cmd/coordinator",
    "make test-coordinator",
    "make test-dist"
  ],
  "journeys": ["not-required"]
}
SPEC-GOVERNANCE-DECLARATION-END
