### PR TITLE
AutoUpdater: honor the <discovery> cooldown so head-expiry retries back off (#1235)

### DIFF
--- a/phase3-binary/Sources/macprovider-cli/AutoUpdater.swift
+++ b/phase3-binary/Sources/macprovider-cli/AutoUpdater.swift
@@ -330,6 +330,10 @@ struct AutoUpdater: Sendable {
                 return
             }
             try markerStore.ensureTrustedRoot()
+            if let activeCooldown = markerStore.activeCooldown(target: "<discovery>") {
+                await record(updateID: updateID, target: "<discovery>", source: .githubPoll, phase: .cooldown, outcome: .skipped, reason: "cooldown_\(activeCooldown.failureClass.rawValue)_until_\(ISO8601DateFormatter.autoupdate.string(from: activeCooldown.until))", attempt: activeCooldown.attempt)
+                return
+            }
             let update = SelfUpdate(currentVersion: currentVersion, releasesAPIURL: releasesAPIURL, session: session)
             let head: SignedReleaseDiscoveryHead
             do {

--- a/phase3-binary/Tests/macprovider-cliTests/AutoUpdateTests.swift
+++ b/phase3-binary/Tests/macprovider-cliTests/AutoUpdateTests.swift
@@ -2190,6 +2190,75 @@ final class AutoUpdateTests: XCTestCase {
         XCTAssertEqual(fenceObservedOwnedLock.value, 1)
     }
 
+    func testDiscoveryHonorsDiscoveryCooldownWithoutPollingNetwork() async throws {
+        // Regression for the discovery-head cooldown that was written by
+        // `fail(... target: "<discovery>" ...)` on discovery_head_expired /
+        // replay / equivocation but never consulted before the next poll,
+        // so head-expiry failures retried every cycle with no backoff
+        // (observed x139/x157 on live nodes). The discovery path must check
+        // the "<discovery>" sentinel cooldown up front, the same way the
+        // concrete-target cooldown is checked once a valid head resolves.
+        let fixture = try TempHome()
+        let store = AutoUpdateMarkerStore(homeDirectory: fixture.url)
+        try store.ensureTrustedRoot()
+        store.recordCooldown(target: "<discovery>", failureClass: .discoveryHeadExpired)
+
+        DiscoveryCooldownGuardMockURLProtocol.requestCount = 0
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.protocolClasses = [DiscoveryCooldownGuardMockURLProtocol.self]
+        let session = URLSession(configuration: configuration)
+
+        await AutoUpdateEventStore.shared.clear()
+        SessionAutoupdateGate.shared.resetForTest()
+        defer { SessionAutoupdateGate.shared.resetForTest() }
+
+        let status = ProviderStatus(
+            modelID: "mlx-community/Test-Model",
+            modelLoaded: true,
+            capacity: ProviderCapacity(maxContextOverride: nil, maxConcurrencyOverride: nil)
+        )
+        let updater = AutoUpdater(
+            config: .defaults(configPath: fixture.url.appendingPathComponent("config.yaml").path),
+            currentVersion: "1.6.0",
+            providerStatus: status,
+            releasesAPIURL: "https://example.invalid/releases",
+            markerStore: store,
+            session: session,
+            trustProvider: {
+                AutoUpdateTrustState(
+                    v2Accepted: true,
+                    tier: "pinned",
+                    encryptedLegValid: true,
+                    attestationRequired: false,
+                    attestationSatisfied: true,
+                    tokenConfigured: true,
+                    tokenValidated: true,
+                    bearerlessDuplicate: false,
+                    connected: true
+                )
+            },
+            drain: { _ in true },
+            sendReady: {},
+            restartLaunchd: {},
+            fenceReloadJobs: {},
+            currentBinaryURL: { nil },
+            rollbackObserverAvailable: { true },
+            launchdProviderAvailable: { true }
+        )
+
+        await updater.handleSignedReleaseDiscovery()
+
+        XCTAssertEqual(DiscoveryCooldownGuardMockURLProtocol.requestCount, 0)
+        let event = await AutoUpdateEventStore.shared.lastWireObject()
+        XCTAssertEqual(event?["source"] as? String, AutoUpdateSource.githubPoll.rawValue)
+        XCTAssertEqual(event?["phase"] as? String, AutoUpdatePhase.cooldown.rawValue)
+        XCTAssertEqual(event?["outcome"] as? String, AutoUpdateOutcome.skipped.rawValue)
+        XCTAssertEqual(event?["target_version"] as? String, "<discovery>")
+        XCTAssertTrue(
+            (event?["reason"] as? String)?.hasPrefix("cooldown_\(AutoUpdateFailureClass.discoveryHeadExpired.rawValue)_until_") ?? false
+        )
+    }
+
     func testTrustLossRollbackAndCleanupRemainUnderMutationLock() throws {
         let fixture = try TempHome()
         let store = AutoUpdateMarkerStore(homeDirectory: fixture.url)
@@ -3529,6 +3598,22 @@ private final class AutoUpdateCounter: @unchecked Sendable {
         value += 1
         return value
     }
+}
+
+/// Fails every request but records that one was attempted, so tests can
+/// assert a cooldown-skip path never reaches the network.
+private final class DiscoveryCooldownGuardMockURLProtocol: URLProtocol {
+    nonisolated(unsafe) static var requestCount = 0
+
+    override class func canInit(with request: URLRequest) -> Bool { true }
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+
+    override func startLoading() {
+        DiscoveryCooldownGuardMockURLProtocol.requestCount += 1
+        client?.urlProtocol(self, didFailWithError: URLError(.fileDoesNotExist))
+    }
+
+    override func stopLoading() {}
 }
 
 private final class AutoUpdateMockURLProtocol: URLProtocol {


### PR DESCRIPTION
## Summary

Fixes a real bug in the client autoupdater's signed-recovery poll: it records a
cooldown under the sentinel target `"<discovery>"` on discovery-head failures
(expired / replay / equivocation) but **never read it**, so head-expiry retries
were ungoverned — live nodes logged hundreds of `discovery_head_expired` attempts
(×139 / ×157 observed in #1235).

`handleSignedReleaseDiscovery()` now checks the `"<discovery>"` cooldown at the
start of the poll and skips early if active, mirroring the existing
concrete-target cooldown-skip. Expiry is handled by `activeCooldown` (filters
`until <= now`), so re-discovery resumes on the next poll after the backoff
window — no permanent block. The backoff write/escalation logic is unchanged;
this only makes the write actually gate subsequent polls.

## Testing

- `cd phase3-binary && swift test --filter AutoUpdateTests` — 84 passed, 0 failures
  (83 pre-existing + new `testDiscoveryHonorsDiscoveryCooldownWithoutPollingNetwork`,
  which asserts no network request is made while the `<discovery>` cooldown is
  active and verifies the emitted skip event shape).
- `swift build` — clean.

## Audit

3-lane codex (code / security / architecture): 0 Critical / 0 High / 0 Medium,
1 LOW (carried). Recommendation: APPROVE.

Part of #1235 (client retry hygiene).

SPEC-GOVERNANCE-DECLARATION-BEGIN
{
  "schema_version": "spec-pr-governance-v1",
  "issue": "https://github.com/Augustas11/macprovider/issues/1235",
  "behavior_change": "yes",
  "contract_change": "none",
  "specs": ["SPEC-020"],
  "requirements": ["SPEC-020-R001"],
  "authority_domains": ["provider-autoupdate"],
  "arbitration": ["CODE_BUG"],
  "tests": [
    "cd phase3-binary && swift test --filter AutoUpdateTests"
  ],
  "journeys": ["not-required"]
}
SPEC-GOVERNANCE-DECLARATION-END

🤖 Generated with [Claude Code](https://claude.com/claude-code)
